### PR TITLE
`Integer`s in the type domain

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -257,6 +257,8 @@ using .Iterators: Flatten, Filter, product  # for generators
 using .Iterators: Stateful    # compat (was formerly used in reinterpretarray.jl)
 include("namedtuple.jl")
 
+include("typedomainintegers.jl")
+
 # For OS specific stuff
 # We need to strcat things here, before strings are really defined
 function strcat(x::String, y::String)

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -257,8 +257,6 @@ using .Iterators: Flatten, Filter, product  # for generators
 using .Iterators: Stateful    # compat (was formerly used in reinterpretarray.jl)
 include("namedtuple.jl")
 
-include("typedomainintegers.jl")
-
 # For OS specific stuff
 # We need to strcat things here, before strings are really defined
 function strcat(x::String, y::String)
@@ -307,6 +305,7 @@ end
 # numeric operations
 include("hashing.jl")
 include("rounding.jl")
+include("typedomainintegers.jl")
 include("div.jl")
 include("rawbigints.jl")
 include("float.jl")

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -305,7 +305,7 @@ end
 # numeric operations
 include("hashing.jl")
 include("rounding.jl")
-include("typedomainintegers.jl")
+include("typedomainintegers.jl"); using .TypeDomainIntegers
 include("div.jl")
 include("rawbigints.jl")
 include("float.jl")

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -522,6 +522,8 @@ include("irrationals.jl")
 include("mathconstants.jl")
 using .MathConstants: ℯ, π, pi
 
+include("typedomainintegers_irrationals.jl")
+
 # Stack frames and traces
 include("stacktraces.jl")
 using .StackTraces

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -613,7 +613,7 @@ julia> cispi(0.25 + 1im)
 """
 function cispi end
 cispi(theta::Real) = Complex(reverse(sincospi(theta))...)
-function cispi(n::TypeDomainInteger)
+function cispi(@nospecialize n::TypeDomainInteger)
     o = one(TypeDomainInteger)
     if iseven(n)
         o

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -86,7 +86,7 @@ julia> imag(1 + 3im)
 """
 imag(z::Complex) = z.im
 real(x::Real) = x
-imag(x::Real) = zero(x)
+imag(@nospecialize x::Real) = zero(NonnegativeInteger)
 
 """
     reim(z)

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -613,6 +613,14 @@ julia> cispi(0.25 + 1im)
 """
 function cispi end
 cispi(theta::Real) = Complex(reverse(sincospi(theta))...)
+function cispi(n::TypeDomainInteger)
+    o = one(TypeDomainInteger)
+    if iseven(n)
+        o
+    else
+        -o
+    end
+end
 
 function cispi(z::Complex)
     v = exp(-(pi*imag(z)))

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -580,6 +580,17 @@ end
 /(x::BigInt, y::Union{ClongMax,CulongMax}) = float(x)/y
 /(x::Union{ClongMax,CulongMax}, y::BigInt) = x/float(y)
 
+for func ∈ (:+, :-, :*, :(==), :isequal)
+    @eval begin
+        function Base.$func((@nospecialize l::BigInt), (@nospecialize r::TypeDomainInteger))
+            TypeDomainIntegers.BaseHelpers.apply_n_t($func, l, r)
+        end
+        function Base.$func((@nospecialize l::TypeDomainInteger), (@nospecialize r::BigInt))
+            TypeDomainIntegers.BaseHelpers.apply_t_n($func, l, r)
+        end
+    end
+end
+
 # unary ops
 (-)(x::BigInt) = MPZ.neg(x)
 (~)(x::BigInt) = MPZ.com(x)

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -13,6 +13,8 @@ import .Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor, 
              sign, hastypemax, isodd, iseven, digits!, hash, hash_integer, top_set_bit,
              clamp
 
+using ..TypeDomainIntegers
+
 if Clong == Int32
     const ClongMax = Union{Int8, Int16, Int32}
     const CulongMax = Union{UInt8, UInt16, UInt32}
@@ -389,6 +391,18 @@ function (::Type{T})(x::BigInt) where T<:Base.BitSigned
     end
 end
 
+function convert(::Type{NonnegativeInteger}, x::BigInt)
+    TypeDomainIntegers.Conversion.tdnn_from_x(x)
+end
+function convert(::Type{TypeDomainInteger}, x::BigInt)
+    TypeDomainIntegers.Conversion.tdi_from_x(x)
+end
+function NonnegativeInteger(x::BigInt)
+    TypeDomainIntegers.Conversion.tdnn_from_x(x)
+end
+function TypeDomainInteger(x::BigInt)
+    TypeDomainIntegers.Conversion.tdi_from_x(x)
+end
 
 Float64(n::BigInt, ::RoundingMode{:ToZero}) = MPZ.get_d(n)
 

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -580,7 +580,7 @@ end
 /(x::BigInt, y::Union{ClongMax,CulongMax}) = float(x)/y
 /(x::Union{ClongMax,CulongMax}, y::BigInt) = x/float(y)
 
-for func ∈ (:+, :-, :*, :(==), :isequal)
+for func ∈ (:+, :-, :*, :(==))
     @eval begin
         function Base.$func((@nospecialize l::BigInt), (@nospecialize r::TypeDomainInteger))
             TypeDomainIntegers.BaseHelpers.apply_n_t($func, l, r)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -299,6 +299,7 @@ end
 
 # ^ for any x supporting *
 to_power_type(x) = convert(Base._return_type(*, Tuple{typeof(x), typeof(x)}), x)
+to_power_type(@nospecialize x::TypeDomainInteger) = x
 @noinline throw_domerr_powbysq(::Any, p) = throw(DomainError(p, LazyString(
     "Cannot raise an integer x to a negative power ", p, ".",
     "\nConvert input to float.")))

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -1159,6 +1159,19 @@ function factorial(n::Integer)
     return f
 end
 
+function factorial(@nospecialize n::Union{
+        typeof(NonnegativeInteger(0)),
+        typeof(NonnegativeInteger(1)),
+        typeof(NonnegativeInteger(2)),
+})
+    two = NonnegativeInteger(2)
+    if n === two
+        two
+    else
+        one(NonnegativeInteger)
+    end
+end
+
 """
     binomial(n::Integer, k::Integer)
 

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -1110,6 +1110,20 @@ function isqrt(x::Union{Int64,UInt64,Int128,UInt128})
     s*s > x ? s-1 : s
 end
 
+function isqrt(@nospecialize n::Union{
+    typeof(NonnegativeInteger(0)),
+    typeof(NonnegativeInteger(1)),
+    typeof(NonnegativeInteger(2)),
+    typeof(NonnegativeInteger(3)),
+})
+    z = zero(NonnegativeInteger)
+    if n isa PositiveIntegerUpperBound
+        natural_successor(z)
+    else
+        z
+    end
+end
+
 """
     factorial(n::Integer)
 

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -109,7 +109,7 @@ end
 <=(x::AbstractIrrational, y::AbstractFloat) = x < y
 <=(x::AbstractFloat, y::AbstractIrrational) = x < y
 
-for func ∈ (:+, :-, :*, :(==), :isequal)
+for func ∈ (:+, :-, :*, :(==))
     @eval begin
         function Base.$func((@nospecialize l::Irrational), (@nospecialize r::TypeDomainInteger))
             TypeDomainIntegers.BaseHelpers.apply_n_t($func, l, r)

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -151,13 +151,20 @@ hash(x::Irrational, h::UInt) = 3*objectid(x) - h
 
 widen(::Type{T}) where {T<:Irrational} = T
 
-zero(::AbstractIrrational) = false
-zero(::Type{<:AbstractIrrational}) = false
+zero(::AbstractIrrational) = zero(TypeDomainInteger)
+zero(::Type{<:AbstractIrrational}) = zero(TypeDomainInteger)
 
-one(::AbstractIrrational) = true
-one(::Type{<:AbstractIrrational}) = true
+one(::AbstractIrrational) = one(TypeDomainInteger)
+one(::Type{<:AbstractIrrational}) = one(TypeDomainInteger)
 
-sign(x::AbstractIrrational) = ifelse(x < zero(x), -1.0, 1.0)
+function sign(x::AbstractIrrational)
+    o = one(TypeDomainInteger)
+    if signbit(x)
+        -o
+    else
+        o
+    end
+end
 
 -(x::AbstractIrrational) = -Float64(x)
 for op in Symbol[:+, :-, :*, :/, :^]

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -109,6 +109,17 @@ end
 <=(x::AbstractIrrational, y::AbstractFloat) = x < y
 <=(x::AbstractFloat, y::AbstractIrrational) = x < y
 
+for func ∈ (:+, :-, :*, :(==), :isequal)
+    @eval begin
+        function Base.$func((@nospecialize l::Irrational), (@nospecialize r::TypeDomainInteger))
+            TypeDomainIntegers.BaseHelpers.apply_n_t($func, l, r)
+        end
+        function Base.$func((@nospecialize l::TypeDomainInteger), (@nospecialize r::Irrational))
+            TypeDomainIntegers.BaseHelpers.apply_t_n($func, l, r)
+        end
+    end
+end
+
 # Irrational vs Rational
 @assume_effects :total function rationalize(::Type{T}, x::AbstractIrrational; tol::Real=0) where T
     return rationalize(T, big(x), tol=tol)

--- a/base/math.jl
+++ b/base/math.jl
@@ -1628,6 +1628,31 @@ function expm1(n::typeof(NonnegativeInteger(0)))
     n
 end
 
+function sinh(n::typeof(NonnegativeInteger(0)))
+    n
+end
+function cosh(n::typeof(NonnegativeInteger(0)))
+    natural_successor(n)
+end
+function tanh(n::typeof(NonnegativeInteger(0)))
+    n
+end
+function sech(n::typeof(NonnegativeInteger(0)))
+    natural_successor(n)
+end
+function asinh(n::typeof(NonnegativeInteger(0)))
+    n
+end
+function acosh(n::typeof(NonnegativeInteger(1)))
+    natural_predecessor(n)
+end
+function atanh(n::typeof(NonnegativeInteger(0)))
+    n
+end
+function asech(n::typeof(NonnegativeInteger(1)))
+    natural_predecessor(n)
+end
+
 function log2(@nospecialize n::Union{typeof(NonnegativeInteger(1)),typeof(NonnegativeInteger(2))})
     natural_predecessor(n)
 end

--- a/base/math.jl
+++ b/base/math.jl
@@ -681,6 +681,16 @@ Return the fourth root of `x` by applying `sqrt` twice successively.
 """
 fourthroot(x::Number) = sqrt(sqrt(x))
 
+function sqrt(@nospecialize n::Union{typeof(NonnegativeInteger(0)),typeof(NonnegativeInteger(1))})
+    n
+end
+function cbrt(@nospecialize n::Union{typeof(NonnegativeInteger(0)),typeof(NonnegativeInteger(1))})
+    n
+end
+function fourthroot(@nospecialize n::Union{typeof(NonnegativeInteger(0)),typeof(NonnegativeInteger(1))})
+    n
+end
+
 """
     hypot(x, y)
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -29,6 +29,8 @@ using Core.Intrinsics: sqrt_llvm
 
 using .Base: IEEEFloat
 
+using ..TypeDomainIntegers
+
 @noinline function throw_complex_domainerror(f::Symbol, x)
     throw(DomainError(x,
         LazyString(f," was called with a negative real argument but will only return a complex result if called with a complex argument. Try ", f,"(Complex(x)).")))

--- a/base/math.jl
+++ b/base/math.jl
@@ -1615,6 +1615,19 @@ exp2(x::AbstractFloat) = 2^x
 exp10(x::AbstractFloat) = 10^x
 fourthroot(::Missing) = missing
 
+function exp2(@nospecialize n::Union{
+    typeof(NonnegativeInteger(0)),
+    typeof(NonnegativeInteger(1)),
+})
+    natural_successor(n)
+end
+function exp10(n::typeof(NonnegativeInteger(0)))
+    natural_successor(n)
+end
+function expm1(n::typeof(NonnegativeInteger(0)))
+    n
+end
+
 function log2(@nospecialize n::Union{typeof(NonnegativeInteger(1)),typeof(NonnegativeInteger(2))})
     natural_predecessor(n)
 end

--- a/base/math.jl
+++ b/base/math.jl
@@ -835,6 +835,8 @@ function _hypot(x::NTuple{N,<:IEEEFloat}) where {N}
     return scale * sqrt(mapreduce(y -> abs2(y * invscale), add_fast, x))
 end
 
+hypot(x::TypeDomainInteger) = abs(x)
+
 atan(y::Real, x::Real) = atan(promote(float(y),float(x))...)
 atan(y::T, x::T) where {T<:AbstractFloat} = Base.no_op_err("atan", T)
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -264,6 +264,13 @@ deg2rad(z::Real) = deg2rad(float(z))
 rad2deg(z::Number) = (z/pi)*180
 deg2rad(z::Number) = (z*pi)/180
 
+function deg2rad(@nospecialize z::typeof(zero(TypeDomainInteger)))
+    z
+end
+function rad2deg(@nospecialize z::typeof(zero(TypeDomainInteger)))
+    z
+end
+
 log(b::T, x::T) where {T<:Number} = log(x)/log(b)
 
 """

--- a/base/math.jl
+++ b/base/math.jl
@@ -1615,4 +1615,17 @@ exp2(x::AbstractFloat) = 2^x
 exp10(x::AbstractFloat) = 10^x
 fourthroot(::Missing) = missing
 
+function log2(@nospecialize n::Union{typeof(NonnegativeInteger(1)),typeof(NonnegativeInteger(2))})
+    natural_predecessor(n)
+end
+function log10(@nospecialize n::typeof(NonnegativeInteger(1)))
+    zero(NonnegativeInteger)
+end
+function log(@nospecialize n::typeof(NonnegativeInteger(1)))
+    zero(NonnegativeInteger)
+end
+function log1p(@nospecialize n::typeof(NonnegativeInteger(0)))
+    zero(NonnegativeInteger)
+end
+
 end # module

--- a/base/math.jl
+++ b/base/math.jl
@@ -1666,4 +1666,23 @@ function log1p(@nospecialize n::typeof(NonnegativeInteger(0)))
     zero(NonnegativeInteger)
 end
 
+function sind(n::typeof(NonnegativeInteger(0)))
+    n
+end
+function asind(n::typeof(NonnegativeInteger(0)))
+    n
+end
+function cosd(n::typeof(NonnegativeInteger(0)))
+    natural_successor(n)
+end
+function acosd(n::typeof(NonnegativeInteger(1)))
+    natural_predecessor(n)
+end
+function secd(n::typeof(NonnegativeInteger(0)))
+    natural_successor(n)
+end
+function asecd(n::typeof(NonnegativeInteger(1)))
+    natural_predecessor(n)
+end
+
 end # module

--- a/base/mathconstants.jl
+++ b/base/mathconstants.jl
@@ -8,6 +8,8 @@ See [`π`](@ref), [`ℯ`](@ref), [`γ`](@ref), [`φ`](@ref) and [`catalan`](@ref
 """
 module MathConstants
 
+using ..TypeDomainIntegers
+
 export π, pi, ℯ, e, γ, eulergamma, catalan, φ, golden
 
 Base.@irrational π        pi
@@ -120,13 +122,13 @@ for T in (AbstractIrrational, Rational, Integer, Number, Complex)
 end
 Base.literal_pow(::typeof(^), ::Irrational{:ℯ}, ::Val{p}) where {p} = exp(p)
 
-Base.log(::Irrational{:ℯ}) = 1 # use 1 to correctly promote expressions like log(x)/log(ℯ)
+Base.log(::Irrational{:ℯ}) = one(TypeDomainInteger)
 Base.log(::Irrational{:ℯ}, x::Number) = log(x)
 
-Base.sin(::Irrational{:π}) = 0.0
-Base.cos(::Irrational{:π}) = -1.0
-Base.sincos(::Irrational{:π}) = (0.0, -1.0)
-Base.tan(::Irrational{:π}) = 0.0
+Base.sin(::Irrational{:π}) = zero(TypeDomainInteger)
+Base.cos(::Irrational{:π}) = -one(TypeDomainInteger)
+Base.sincos(::Irrational{:π}) = (zero(TypeDomainInteger), -one(TypeDomainInteger))
+Base.tan(::Irrational{:π}) = zero(TypeDomainInteger)
 Base.cot(::Irrational{:π}) = -1/0
 
 end # module

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -967,6 +967,17 @@ cmp(x::CdoubleMax, y::BigFloat) = -cmp(y,x)
 <=(x::BigFloat, y::CdoubleMax) = !isnan(x) && !isnan(y) && cmp(x,y) <= 0
 <=(x::CdoubleMax, y::BigFloat) = !isnan(x) && !isnan(y) && cmp(y,x) >= 0
 
+for func ∈ (:+, :-, :*, :(==), :isequal)
+    @eval begin
+        function Base.$func((@nospecialize l::BigFloat), (@nospecialize r::TypeDomainInteger))
+            TypeDomainIntegers.BaseHelpers.apply_n_t($func, l, r)
+        end
+        function Base.$func((@nospecialize l::TypeDomainInteger), (@nospecialize r::BigFloat))
+            TypeDomainIntegers.BaseHelpers.apply_t_n($func, l, r)
+        end
+    end
+end
+
 # Note: this inlines the implementation of `mpfr_signbit` to avoid a
 # `ccall`.
 signbit(x::BigFloat) = signbit(x.sign)

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -22,7 +22,7 @@ import
         RawBigIntRoundingIncrementHelper, truncated, RawBigInt
 
 
-using .Base.Libc
+using .Base.Libc, ..TypeDomainIntegers
 import ..Rounding:
     rounding_raw, setrounding_raw, rounds_to_nearest, rounds_away_from_zero,
     tie_breaker_is_to_even, correct_rounding_requires_increment
@@ -401,6 +401,22 @@ function Bool(x::BigFloat)
     iszero(x) && return false
     isone(x) && return true
     throw(InexactError(:Bool, Bool, x))
+end
+function convert(::Type{NonnegativeInteger}, x::BigFloat)
+    isinteger(x) || throw(InexactError(:NonnegativeInteger, NonnegativeInteger, x))
+    TypeDomainIntegers.Conversion.tdnn_from_x(x)
+end
+function convert(::Type{TypeDomainInteger}, x::BigFloat)
+    isinteger(x) || throw(InexactError(:TypeDomainInteger, TypeDomainInteger, x))
+    TypeDomainIntegers.Conversion.tdi_from_x(x)
+end
+function NonnegativeInteger(x::BigFloat)
+    isinteger(x) || throw(InexactError(:NonnegativeInteger, NonnegativeInteger, x))
+    TypeDomainIntegers.Conversion.tdnn_from_x(x)
+end
+function TypeDomainInteger(x::BigFloat)
+    isinteger(x) || throw(InexactError(:TypeDomainInteger, TypeDomainInteger, x))
+    TypeDomainIntegers.Conversion.tdi_from_x(x)
 end
 function BigInt(x::BigFloat)
     isinteger(x) || throw(InexactError(:BigInt, BigInt, x))

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -967,7 +967,7 @@ cmp(x::CdoubleMax, y::BigFloat) = -cmp(y,x)
 <=(x::BigFloat, y::CdoubleMax) = !isnan(x) && !isnan(y) && cmp(x,y) <= 0
 <=(x::CdoubleMax, y::BigFloat) = !isnan(x) && !isnan(y) && cmp(y,x) >= 0
 
-for func ∈ (:+, :-, :*, :(==), :isequal)
+for func ∈ (:+, :-, :*, :(==))
     @eval begin
         function Base.$func((@nospecialize l::BigFloat), (@nospecialize r::TypeDomainInteger))
             TypeDomainIntegers.BaseHelpers.apply_n_t($func, l, r)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -310,7 +310,7 @@ julia> denominator(4)
 1
 ```
 """
-denominator(x::Integer) = one(x)
+denominator(@nospecialize x::Integer) = one(TypeDomainInteger)
 denominator(x::Rational) = x.den
 
 sign(x::Rational) = oftype(x, sign(x.num))

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1176,6 +1176,22 @@ for (finv, f, finvh, fh, finvd, fd, fn) in ((:sec, :cos, :sech, :cosh, :secd, :c
     end
 end
 
+function sinc(@nospecialize n::TypeDomainInteger)
+    z = zero(TypeDomainInteger)
+    if iszero(n)
+        natural_successor(z)
+    else
+        z
+    end
+end
+function cosc(@nospecialize n::Union{
+    typeof(TypeDomainInteger(-1)),
+    typeof(TypeDomainInteger( 0)),
+    typeof(TypeDomainInteger( 1)),
+})
+    -n
+end
+
 for (tfa, tfainv, hfa, hfainv, fn) in ((:asec, :acos, :asech, :acosh, "secant"),
                                        (:acsc, :asin, :acsch, :asinh, "cosecant"),
                                        (:acot, :atan, :acoth, :atanh, "cotangent"))

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -931,10 +931,18 @@ function tanpi(_x::T) where T<:IEEEFloat
     return float(T)(si / co)
 end
 
-sinpi(x::Integer) = x >= 0 ? zero(float(x)) : -zero(float(x))
+function cospi(n::TypeDomainInteger)
+    o = one(NonnegativeInteger)
+    if iseven(n)
+        o
+    else
+        -o
+    end
+end
+
+sinpi(x::Integer) = zero(NonnegativeInteger)
 cospi(x::Integer) = isodd(x) ? -one(float(x)) : one(float(x))
-tanpi(x::Integer) = x >= 0 ? (isodd(x) ? -zero(float(x)) : zero(float(x))) :
-                             (isodd(x) ? zero(float(x)) : -zero(float(x)))
+tanpi(x::Integer) = zero(NonnegativeInteger)
 sincospi(x::Integer) = (sinpi(x), cospi(x))
 sinpi(x::AbstractFloat) = sin(pi*x)
 cospi(x::AbstractFloat) = cos(pi*x)

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -347,7 +347,7 @@ baremodule TypeDomainIntegers
             end
         end
         const PAll = PrimitiveTypes.TypesAll
-        for type ∈ PrimitiveTypes.types_all
+        for type ∈ (AbstractFloat, PrimitiveTypes.types_all...)
             @eval begin
                 function Base.convert(::Type{$type}, @nospecialize n::TypeDomainInteger)
                     tdi_to_x($type, n)

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -257,7 +257,7 @@ baremodule TypeDomainIntegers
             end
         end
         const TypeDomainIntegerType = Union{Type{TypeDomainInteger},Type{NonnegativeInteger}}
-        function Base.convert(::Type{Bool}, @nospecialize o::ZeroOrOne)
+        function Base.convert(::Type{Bool}, @nospecialize o::TypeDomainInteger)
             to_bool(o)
         end
         function Base.convert((@nospecialize unused::TypeDomainIntegerType), n::Bool)
@@ -287,7 +287,7 @@ baremodule TypeDomainIntegers
         function TypeDomainInteger(n::Union{Bool,I})
             convert(TypeDomainInteger, n)
         end
-        function Bool(@nospecialize n::ZeroOrOne)
+        function Bool(@nospecialize n::TypeDomainInteger)
             to_bool(n)
         end
         function I(@nospecialize n::TypeDomainInteger)

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -64,6 +64,9 @@ baremodule TypeDomainIntegers
         export NegativeInteger, TypeDomainInteger, negated
         struct NegativeInteger{X<:PositiveInteger} <: Integer
             x::X
+            global function new_negative_integer(x::X) where {X<:PositiveInteger}
+                new{X}(x)
+            end
         end
         const TypeDomainInteger = Union{NonnegativeInteger,NegativeInteger}
         function negated(@nospecialize n::TypeDomainInteger)
@@ -72,7 +75,7 @@ baremodule TypeDomainIntegers
             else
                 n = n::NonnegativeInteger
                 if n isa PositiveIntegerUpperBound
-                    NegativeInteger(n)
+                    new_negative_integer(n)
                 else
                     n
                 end

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -386,19 +386,22 @@ baremodule TypeDomainIntegers
     baremodule BaseHelpers
         using ..Basic, ..LazyMinus
         using Base: convert, <, +, -, *, ==, !, @nospecialize
+        function interoperable(@nospecialize n::TypeDomainInteger)
+            convert(Int, n)
+        end
         function apply_n_t(func, (@nospecialize l::Number), @nospecialize r::TypeDomainInteger)
-            i = convert(Int, r)
+            i = interoperable(r)
             func(l, i)
         end
         function apply_t_n(func, (@nospecialize l::TypeDomainInteger), @nospecialize r::Number)
-            i = convert(Int, l)
+            i = interoperable(l)
             func(i, r)
         end
         function apply_n_t(::typeof(+), (@nospecialize l::Number), @nospecialize r::TypeDomainInteger)
             if r isa NegativeInteger
                 let pos = negated(r), posm1 = natural_predecessor(pos)
                     if posm1 isa PositiveIntegerUpperBound
-                        l - convert(Int, pos)
+                        l - interoperable(pos)
                     else
                         l - true
                     end
@@ -408,7 +411,7 @@ baremodule TypeDomainIntegers
                 if r isa PositiveIntegerUpperBound
                     let p = natural_predecessor(r)
                         if p isa PositiveIntegerUpperBound
-                            l + convert(Int, r)
+                            l + interoperable(r)
                         else
                             l + true
                         end
@@ -427,13 +430,13 @@ baremodule TypeDomainIntegers
         end
         function apply_t_n(::typeof(-), (@nospecialize l::TypeDomainInteger), @nospecialize r::Number)
             if l isa NegativeInteger
-                convert(Int, l) - r
+                interoperable(l) - r
             else
                 l = l::NonnegativeInteger
                 if l isa PositiveIntegerUpperBound
                     let p = natural_predecessor(l)
                         if p isa PositiveIntegerUpperBound
-                            convert(Int, l) - r
+                            interoperable(l) - r
                         else
                             true - r
                         end
@@ -447,7 +450,7 @@ baremodule TypeDomainIntegers
             if r isa NegativeInteger
                 let pos = negated(r), posm1 = natural_predecessor(pos)
                     if posm1 isa PositiveIntegerUpperBound
-                        l * convert(Int, r)
+                        l * interoperable(r)
                     else
                         -l
                     end
@@ -457,7 +460,7 @@ baremodule TypeDomainIntegers
                 if r isa PositiveIntegerUpperBound
                     let p = natural_predecessor(r)
                         if p isa PositiveIntegerUpperBound
-                            l * convert(Int, r)
+                            l * interoperable(r)
                         else
                             l
                         end
@@ -471,7 +474,7 @@ baremodule TypeDomainIntegers
             if l isa NegativeInteger
                 let pos = negated(l), posm1 = natural_predecessor(pos)
                     if posm1 isa PositiveIntegerUpperBound
-                        convert(Int, l) * r
+                        interoperable(l) * r
                     else
                         -r
                     end
@@ -481,7 +484,7 @@ baremodule TypeDomainIntegers
                 if l isa PositiveIntegerUpperBound
                     let p = natural_predecessor(l)
                         if p isa PositiveIntegerUpperBound
-                            convert(Int, l) * r
+                            interoperable(l) * r
                         else
                             r
                         end

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -541,6 +541,12 @@ baremodule TypeDomainIntegers
                 end
             end
         end
+        function Base.inv(@nospecialize n::Union{
+            typeof(TypeDomainInteger(-1)),
+            typeof(TypeDomainInteger( 1)),
+        })
+            n
+        end
     end
 
     baremodule BaseHelpers

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -453,7 +453,7 @@ baremodule TypeDomainIntegers
 
     baremodule BaseHelpers
         using ..Basic, ..LazyMinus, ..Interoperability
-        using Base: convert, <, +, -, *, ==, !, @nospecialize
+        using Base: convert, isequal, <, +, -, *, ==, !, @nospecialize
         export apply_n_t, apply_t_n
         function apply_n_t(::typeof(+), (@nospecialize l::Number), @nospecialize r::TypeDomainInteger)
             if r isa NegativeInteger
@@ -551,6 +551,30 @@ baremodule TypeDomainIntegers
                     zero()
                 end
             end
+        end
+        function apply_n_t(
+            func::Union{typeof(isequal),typeof(==)},
+            (@nospecialize l::Number),
+            (@nospecialize r::TypeDomainInteger),
+        )
+            if r isa NegativeInteger
+                func(l, interoperable(r))
+            else
+                r = r::NonnegativeInteger
+                if r isa PositiveIntegerUpperBound
+                    func(l, interoperable(r))
+                else
+                    iszero(l)
+                end
+            end
+        end
+        function apply_t_n(
+            func::Union{typeof(isequal),typeof(==)},
+            (@nospecialize l::TypeDomainInteger),
+            (@nospecialize r::Number),
+        )
+            # equality is commutative
+            apply_n_t(func, r, l)
         end
     end
 

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -1,0 +1,574 @@
+baremodule TypeDomainNaturalNumbers
+    baremodule Basic
+        using Base: @nospecialize
+        export
+            natural_successor, natural_predecessor,
+            NonnegativeInteger, PositiveInteger, PositiveIntegerUpperBound,
+            with_refined_type, zero
+        baremodule RecursiveStep
+            using Base: @nospecialize
+            export recursive_step
+            function recursive_step(@nospecialize t::Type)
+                Union{Nothing,t}
+            end
+        end
+        baremodule UpperBounds
+            using ..RecursiveStep
+            abstract type A{P <: recursive_step(Any)} end
+            abstract type B{P <: recursive_step(A)} <: A{P} end
+        end
+        const NonnegativeIntegerUpperBound = UpperBounds.B
+        using .RecursiveStep
+        struct NonnegativeIntegerImpl{
+            Predecessor<:recursive_step(NonnegativeIntegerUpperBound),
+        } <: NonnegativeIntegerUpperBound{Predecessor}
+            predecessor::Predecessor
+            function stricter(t::UnionAll)
+                t{P} where {P <: recursive_step(t)}
+            end
+            global const NonnegativeIntegerImplTighter = stricter(NonnegativeIntegerImpl)
+            global const NonnegativeInteger = stricter(NonnegativeIntegerImplTighter)
+            global const PositiveInteger = let t = NonnegativeIntegerImplTighter
+                t{P} where {P <: t}
+            end
+            global const PositiveIntegerUpperBound = let t = UpperBounds.A
+                t{P} where {P <: t}
+            end
+            global function new_nonnegative_integer(p::P) where {P<:recursive_step(NonnegativeInteger)}
+                t_p = P::DataType
+                r = new{t_p}(p)
+                with_refined_type(r)
+            end
+        end
+        function with_refined_type(@nospecialize r::NonnegativeInteger)
+            r
+        end
+        function natural_successor(o::NonnegativeInteger)
+            new_nonnegative_integer(o)::PositiveInteger
+        end
+        function natural_predecessor(o::PositiveInteger)
+            r = o.predecessor
+            with_refined_type(r)
+        end
+        function zero()
+            new_nonnegative_integer(nothing)
+        end
+    end
+
+    baremodule LazyMinus
+        using ..Basic
+        using Base: @nospecialize
+        export NegativeInteger, TypeDomainInteger, negated
+        struct NegativeInteger{X<:PositiveInteger}
+            x::X
+        end
+        const TypeDomainInteger = Union{NonnegativeInteger,NegativeInteger}
+        function negated(@nospecialize n::TypeDomainInteger)
+            if n isa NegativeInteger
+                n.x
+            else
+                n = n::NonnegativeInteger
+                if n isa PositiveIntegerUpperBound
+                    NegativeInteger(n)
+                else
+                    n
+                end
+            end
+        end
+    end
+
+    baremodule RecursiveAlgorithms
+        using ..Basic, ..LazyMinus
+        using Base: !, +, -, <, @assume_effects, @inline, @nospecialize
+        export subtracted, added, to_int, from_int, is_even, multiplied, is_less
+        @assume_effects :foldable function is_less((@nospecialize l::NonnegativeInteger), @nospecialize r::NonnegativeInteger)
+            if r isa PositiveIntegerUpperBound
+                if l isa PositiveIntegerUpperBound
+                    let pl = natural_predecessor(l), pr = natural_predecessor(r), res = @inline is_less(pl, pr)
+                        res::Bool
+                    end
+                else
+                    true
+                end
+            else
+                false
+            end
+        end
+        @assume_effects :foldable function subtracted((@nospecialize l::NonnegativeInteger), @nospecialize r::NonnegativeInteger)
+            l_pos = l isa PositiveIntegerUpperBound
+            if r isa PositiveIntegerUpperBound
+                if l_pos
+                    let a = natural_predecessor(l), b = natural_predecessor(r), ret = @inline subtracted(a, b)
+                        ret::TypeDomainInteger
+                    end
+                else
+                    negated(r)
+                end
+            else
+                if l_pos
+                    l::PositiveInteger
+                else
+                    zero()
+                end
+            end
+        end
+        @assume_effects :foldable function added((@nospecialize l::NonnegativeInteger), @nospecialize r::NonnegativeInteger)
+            ret = if r isa PositiveIntegerUpperBound
+                let a = natural_successor(l), b = natural_predecessor(r)
+                    @inline added(a, b)
+                end
+            else
+                l
+            end
+            with_refined_type(ret)
+        end
+        @assume_effects :foldable function to_int(@nospecialize o::NonnegativeInteger)
+            if o isa PositiveIntegerUpperBound
+                let p = natural_predecessor(o), t = @inline to_int(p)
+                    t::Int + 1
+                end
+            else
+                0
+            end::Int
+        end
+        struct ConvertNaturalToNegativeException <: Exception end
+        @assume_effects :foldable function from_int(n::Int)
+            if n < 0
+                throw(ConvertNaturalToNegativeException())
+            end
+            ret = if n === 0
+                zero()
+            else
+                let v = n - 1, p = @inline from_int(v)
+                    p = with_refined_type(p)
+                    natural_successor(p)
+                end
+            end
+            with_refined_type(ret)
+        end
+        @assume_effects :foldable function is_even(@nospecialize o::NonnegativeInteger)
+            if o isa PositiveIntegerUpperBound
+                let p = natural_predecessor(o)
+                    if p isa PositiveIntegerUpperBound
+                        let s = natural_predecessor(p), r = @inline is_even(s)
+                            r::Bool
+                        end
+                    else
+                        false
+                    end
+                end
+            else
+                true
+            end
+        end
+        @assume_effects :foldable function multiplied((@nospecialize l::NonnegativeInteger), @nospecialize r::NonnegativeInteger)
+            if r isa PositiveIntegerUpperBound
+                let p = natural_predecessor(r), x = @inline multiplied(l, p)
+                    added(x, l)
+                end
+            else
+                zero()
+            end
+        end
+    end
+
+    baremodule BaseOverloads
+        using ..Basic, ..RecursiveAlgorithms, ..LazyMinus
+        using Base: Base, convert, <, +, -, *, ==, isequal, isless, !, @nospecialize
+        function Base.zero(@nospecialize unused::Type{<:TypeDomainInteger})
+            zero()
+        end
+        function Base.zero(@nospecialize unused::TypeDomainInteger)
+            zero()
+        end
+        function Base.iszero(@nospecialize n::TypeDomainInteger)
+            if n isa NegativeInteger
+                false
+            else
+                n = with_refined_type(n)
+                if n isa PositiveIntegerUpperBound
+                    false
+                else
+                    true
+                end
+            end
+        end
+        const ZeroOrOne = Union{typeof(zero()),typeof(natural_successor(zero()))}
+        function to_bool(@nospecialize n::ZeroOrOne)
+            if n isa PositiveIntegerUpperBound
+                true
+            else
+                false
+            end
+        end
+        function from_bool(b::Bool)
+            z = zero()
+            if b
+                natural_successor(z)
+            else
+                z
+            end
+        end
+        const TypeDomainIntegerType = Union{Type{TypeDomainInteger},Type{NonnegativeInteger}}
+        function Base.convert(::Type{Bool}, @nospecialize o::ZeroOrOne)
+            to_bool(o)
+        end
+        function Base.convert((@nospecialize unused::TypeDomainIntegerType), n::Bool)
+            from_bool(n)
+        end
+        function Base.convert(::Type{Int}, @nospecialize o::TypeDomainInteger)
+            if o isa NegativeInteger
+                -to_int(negated(o))
+            else
+                o = o::NonnegativeInteger
+                to_int(o)
+            end
+        end
+        function Base.convert(::Type{NonnegativeInteger}, n::Int)
+            from_int(n)
+        end
+        function Base.convert(::Type{TypeDomainInteger}, n::Int)
+            if n < 0
+                negated(from_int(-n))
+            else
+                from_int(n)
+            end
+        end
+        function NonnegativeInteger(n::Union{Bool,Int})
+            convert(NonnegativeInteger, n)
+        end
+        function TypeDomainInteger(n::Union{Bool,Int})
+            convert(TypeDomainInteger, n)
+        end
+        function Bool(@nospecialize n::ZeroOrOne)
+            to_bool(n)
+        end
+        function Int(@nospecialize n::TypeDomainInteger)
+            convert(Int, n)
+        end
+        function Base.:(-)((@nospecialize l::TypeDomainInteger), @nospecialize r::TypeDomainInteger)
+            n = negated(r)
+            l + n
+        end
+        function Base.:(+)((@nospecialize l::TypeDomainInteger), @nospecialize r::TypeDomainInteger)
+            l_neg = l isa NegativeInteger
+            if r isa NegativeInteger
+                if l_neg
+                    l = l::NegativeInteger
+                    let a = negated(l)::PositiveInteger, b = negated(r)::PositiveInteger, s = added(a, b)
+                        negated(s)
+                    end
+                else
+                    l = l::NonnegativeInteger
+                    let b = negated(r)::PositiveInteger
+                        subtracted(l, b)
+                    end
+                end
+            else
+                r = r::NonnegativeInteger
+                if l_neg
+                    l = l::NegativeInteger
+                    let a = negated(l)::PositiveInteger
+                        subtracted(r, a)
+                    end
+                else
+                    l = l::NonnegativeInteger
+                    added(l, r)
+                end
+            end
+        end
+        function Base.propertynames(
+            (@nospecialize unused::Union{Basic.NonnegativeIntegerImpl,NegativeInteger}),
+            ::Bool = false,
+        )
+            ()
+        end
+        function Base.iseven(@nospecialize o::TypeDomainInteger)
+            if o isa NegativeInteger
+                is_even(negated(o))
+            else
+                o = o::NonnegativeInteger
+                is_even(o)
+            end
+        end
+        function Base.isodd(@nospecialize o::TypeDomainInteger)
+            !Base.iseven(o)
+        end
+        function Base.:(==)((@nospecialize l::TypeDomainInteger), @nospecialize r::TypeDomainInteger)
+            l === r
+        end
+        function Base.isequal((@nospecialize l::TypeDomainInteger), @nospecialize r::TypeDomainInteger)
+            l === r
+        end
+        function Base.:(<)((@nospecialize l::TypeDomainInteger), @nospecialize r::TypeDomainInteger)
+            l_neg = l isa NegativeInteger
+            if r isa NegativeInteger
+                if l_neg
+                    l = l::NegativeInteger
+                    let a = negated(l)::PositiveInteger, b = negated(r)::PositiveInteger
+                        is_less(b, a)
+                    end
+                else
+                    false
+                end
+            else
+                r = r::NonnegativeInteger
+                if l_neg
+                    true
+                else
+                    l = l::NonnegativeInteger
+                    is_less(l, r)
+                end
+            end
+        end
+        function Base.isless((@nospecialize l::TypeDomainInteger), @nospecialize r::TypeDomainInteger)
+            l < r
+        end
+        function Base.:(==)((@nospecialize l::TypeDomainInteger), @nospecialize r::Number)
+            i = convert(Int, l)
+            i == r
+        end
+        function Base.isequal((@nospecialize l::TypeDomainInteger), @nospecialize r::Number)
+            i = convert(Int, l)
+            isequal(i, r)
+        end
+        function Base.:(<)((@nospecialize l::TypeDomainInteger), @nospecialize r::Real)
+            i = convert(Int, l)
+            i < r
+        end
+        function Base.isless((@nospecialize l::TypeDomainInteger), @nospecialize r::Real)
+            i = convert(Int, l)
+            isless(i, r)
+        end
+        function Base.:(==)((@nospecialize l::Number), @nospecialize r::TypeDomainInteger)
+            i = convert(Int, r)
+            l == i
+        end
+        function Base.isequal((@nospecialize l::Number), @nospecialize r::TypeDomainInteger)
+            i = convert(Int, r)
+            isequal(l, i)
+        end
+        function Base.:(<)((@nospecialize l::Real), @nospecialize r::TypeDomainInteger)
+            i = convert(Int, r)
+            l < i
+        end
+        function Base.isless((@nospecialize l::Real), @nospecialize r::TypeDomainInteger)
+            i = convert(Int, r)
+            isless(l, i)
+        end
+        function Base.one(@nospecialize unused::Type{<:TypeDomainInteger})
+            natural_successor(zero())
+        end
+        function Base.one(@nospecialize unused::TypeDomainInteger)
+            natural_successor(zero())
+        end
+        function Base.isone(@nospecialize n::TypeDomainInteger)
+            if n isa NegativeInteger
+                false
+            else
+                n = n::NonnegativeInteger
+                if n isa PositiveIntegerUpperBound
+                    let p = natural_predecessor(n)
+                        if p isa PositiveIntegerUpperBound
+                            false
+                        else
+                            true
+                        end
+                    end
+                else
+                    false
+                end
+            end
+        end
+        function Base.:(*)((@nospecialize l::TypeDomainInteger), @nospecialize r::TypeDomainInteger)
+            l_neg = l isa NegativeInteger
+            if r isa NegativeInteger
+                if l_neg
+                    l = l::NegativeInteger
+                    let a = negated(l)::PositiveInteger, b = negated(r)::PositiveInteger
+                        multiplied(a, b)::PositiveInteger
+                    end
+                else
+                    l = l::NonnegativeInteger
+                    let b = negated(r)::PositiveInteger, m = multiplied(l, b)
+                        negated(m)
+                    end
+                end
+            else
+                r = r::NonnegativeInteger
+                if l_neg
+                    l = l::NegativeInteger
+                    let a = negated(l)::PositiveInteger, m = multiplied(a, r)
+                        negated(m)
+                    end
+                else
+                    l = l::NonnegativeInteger
+                    multiplied(l, r)
+                end
+            end
+        end
+        function Base.:(+)((@nospecialize l::Number), @nospecialize r::TypeDomainInteger)
+            if r isa NegativeInteger
+                let pos = negated(r), posm1 = natural_predecessor(pos)
+                    if posm1 isa PositiveIntegerUpperBound
+                        l - convert(Int, pos)
+                    else
+                        l - true
+                    end
+                end
+            else
+                r = r::NonnegativeInteger
+                if r isa PositiveIntegerUpperBound
+                    let p = natural_predecessor(r)
+                        if p isa PositiveIntegerUpperBound
+                            l + convert(Int, r)
+                        else
+                            l + true
+                        end
+                    end
+                else
+                    l
+                end
+            end
+        end
+        function Base.:(+)((@nospecialize l::TypeDomainInteger), @nospecialize r::Number)
+            # addition is commutative
+            r + l
+        end
+        function Base.:(-)((@nospecialize l::Number), @nospecialize r::TypeDomainInteger)
+            l + negated(r)
+        end
+        function Base.:(-)((@nospecialize l::TypeDomainInteger), @nospecialize r::Number)
+            if l isa NegativeInteger
+                convert(Int, l) - r
+            else
+                l = l::NonnegativeInteger
+                if l isa PositiveIntegerUpperBound
+                    let p = natural_predecessor(l)
+                        if p isa PositiveIntegerUpperBound
+                            convert(Int, l) - r
+                        else
+                            true - r
+                        end
+                    end
+                else
+                    -r
+                end
+            end
+        end
+        function Base.:(*)((@nospecialize l::Number), @nospecialize r::TypeDomainInteger)
+            if r isa NegativeInteger
+                let pos = negated(r), posm1 = natural_predecessor(pos)
+                    if posm1 isa PositiveIntegerUpperBound
+                        l * convert(Int, r)
+                    else
+                        -l
+                    end
+                end
+            else
+                r = r::NonnegativeInteger
+                if r isa PositiveIntegerUpperBound
+                    let p = natural_predecessor(r)
+                        if p isa PositiveIntegerUpperBound
+                            l * convert(Int, r)
+                        else
+                            l
+                        end
+                    end
+                else
+                    zero()
+                end
+            end
+        end
+        function Base.:(*)((@nospecialize l::TypeDomainInteger), @nospecialize r::Number)
+            if l isa NegativeInteger
+                let pos = negated(l), posm1 = natural_predecessor(pos)
+                    if posm1 isa PositiveIntegerUpperBound
+                        convert(Int, l) * r
+                    else
+                        -r
+                    end
+                end
+            else
+                l = l::NonnegativeInteger
+                if l isa PositiveIntegerUpperBound
+                    let p = natural_predecessor(l)
+                        if p isa PositiveIntegerUpperBound
+                            convert(Int, l) * r
+                        else
+                            r
+                        end
+                    end
+                else
+                    zero()
+                end
+            end
+        end
+        function Base.:(-)(@nospecialize n::TypeDomainInteger)
+            negated(n)
+        end
+    end
+
+    export
+        natural_successor, natural_predecessor, NonnegativeInteger, PositiveInteger,
+        PositiveIntegerUpperBound, NegativeInteger, TypeDomainInteger
+
+    """
+        natural_successor(::NonnegativeInteger)
+
+    Return the successor of a natural number.
+    """
+    const natural_successor = Basic.natural_successor
+
+    """
+        natural_predecessor(::PositiveInteger)
+
+    Return the predecessor of a nonzero natural number.
+    """
+    const natural_predecessor = Basic.natural_predecessor
+
+    """
+        NonnegativeInteger
+
+    Nonnegative integers in the type domain.
+
+    The implementation is basically the unary numeral system. Especially inspired by
+    the Peano axioms/Zermelo construction of the natural numbers.
+    """
+    const NonnegativeInteger = Basic.NonnegativeInteger
+
+    """
+        PositiveInteger
+
+    Positive integers in the type domain. Subtypes [`NonnegativeInteger`](@ref).
+    """
+    const PositiveInteger = Basic.PositiveInteger
+
+    """
+        PositiveIntegerUpperBound
+
+    Positive integers in the type domain. Supertypes [`PositiveInteger`](@ref).
+    """
+    const PositiveIntegerUpperBound = Basic.PositiveIntegerUpperBound
+
+    """
+        ConvertNaturalToNegativeException
+
+    Thrown when a conversion of a negative integer to a natural number is attempted.
+    """
+    const ConvertNaturalToNegativeException = RecursiveAlgorithms.ConvertNaturalToNegativeException
+
+    """
+        NegativeInteger
+
+    Negative integers in the type domain.
+    """
+    const NegativeInteger = LazyMinus.NegativeInteger
+
+    """
+        TypeDomainInteger
+
+    Integers in the type domain.
+    """
+    const TypeDomainInteger = LazyMinus.TypeDomainInteger
+end

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -488,7 +488,7 @@ baremodule TypeDomainIntegers
         function apply_n_t(::typeof(+), (@nospecialize l::Number), @nospecialize r::TypeDomainInteger)
             if r isa NegativeInteger
                 let pos = negated(r)::PositiveInteger
-                    l - tdi_to_int(pos)
+                    l + -tdi_to_int(pos)
                 end
             else
                 r = r::NonnegativeInteger

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -82,9 +82,19 @@ baremodule TypeDomainIntegers
 
     baremodule Interoperability
         using ..Basic, ..LazyMinus
-        using Base: checked_add, @nospecialize
+        using Base: checked_add, map, @nospecialize
         export interoperable, incremented, decremented, I, int_minus_one, int_zero, int_plus_one
         const I = Int8
+        const other_types = (
+            Int16, Int32, Int64, Int128,
+            UInt8, UInt16, UInt32, UInt64, UInt128,
+            Float16, Float32, Float64,
+        )
+        const OtherTypes = Union{other_types...,}
+        const OtherTypesType = let f = x -> Type{x}
+            t = map(f, other_types)
+            Union{t...,}
+        end
         const int_minus_one = I(-1)
         const int_zero = I(0)
         const int_plus_one = I(1)
@@ -399,6 +409,30 @@ baremodule TypeDomainIntegers
         end
         function Base.:(-)(@nospecialize n::TypeDomainInteger)
             negated(n)
+        end
+        function Base.convert((@nospecialize t::Interoperability.OtherTypesType), @nospecialize n::TypeDomainInteger)
+            i = interoperable(n)
+            convert(t, i)
+        end
+        function Base.convert(::Type{NonnegativeInteger}, x::Interoperability.OtherTypes)
+            i = I(x)::I
+            convert(NonnegativeInteger, i)
+        end
+        function Base.convert(::Type{TypeDomainInteger}, x::Interoperability.OtherTypes)
+            i = I(x)::I
+            convert(TypeDomainInteger, i)
+        end
+        function (t::Interoperability.OtherTypesType)(@nospecialize n::TypeDomainInteger)
+            i = interoperable(n)
+            t(i)
+        end
+        function NonnegativeInteger(x::Interoperability.OtherTypes)
+            i = I(x)::I
+            NonnegativeInteger(i)
+        end
+        function TypeDomainInteger(x::Interoperability.OtherTypes)
+            i = I(x)::I
+            TypeDomainInteger(i)
         end
     end
 

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -58,7 +58,7 @@ baremodule TypeDomainIntegers
     baremodule LazyMinus
         using ..Basic
         using Base: @nospecialize
-        export NegativeInteger, TypeDomainInteger, negated
+        export NegativeInteger, TypeDomainInteger, negated, absolute_value_of
         struct NegativeInteger{X<:PositiveInteger} <: Integer
             x::X
             global function new_negative_integer(x::X) where {X<:PositiveInteger}
@@ -76,6 +76,13 @@ baremodule TypeDomainIntegers
                 else
                     n
                 end
+            end
+        end
+        function absolute_value_of(@nospecialize n::TypeDomainInteger)
+            if n isa NegativeInteger
+                n.x
+            else
+                n::NonnegativeInteger
             end
         end
     end
@@ -478,6 +485,9 @@ baremodule TypeDomainIntegers
         end
         function Base.:(-)(@nospecialize n::TypeDomainInteger)
             negated(n)
+        end
+        function Base.abs(@nospecialize n::TypeDomainInteger)
+            absolute_value_of(n)
         end
     end
 

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -483,7 +483,7 @@ baremodule TypeDomainIntegers
 
     baremodule BaseHelpers
         using ..Basic, ..LazyMinus, ..Conversion
-        using Base: convert, isequal, <, +, -, *, ==, !, @nospecialize
+        using Base: convert, isequal, iszero, <, +, -, *, ==, !, @nospecialize
         export apply_n_t, apply_t_n
         function apply_n_t(::typeof(+), (@nospecialize l::Number), @nospecialize r::TypeDomainInteger)
             if r isa NegativeInteger

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -1,4 +1,4 @@
-baremodule TypeDomainNaturalNumbers
+baremodule TypeDomainIntegers
     baremodule Basic
         using Base: @nospecialize
         export

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -289,7 +289,7 @@ baremodule TypeDomainIntegers
     baremodule BaseOverloadsPromotion
         using ..Basic, ..RecursiveAlgorithms, ..LazyMinus, ..PrimitiveTypes
         using ..Basic: UpperBounds
-        using Base: Base, @nospecialize, @eval
+        using Base: Base, ==, @nospecialize, @eval
         struct UnexpectedException <: Exception end
         const ZeroOrOne = Union{typeof(zero()),typeof(natural_successor(zero()))}
         for type ∈ PrimitiveTypes.types_all
@@ -306,6 +306,21 @@ baremodule TypeDomainIntegers
                     Int16  # presumably wide enough for any type domain integer
                 end
                 Base.promote_type(t, $type)
+            end
+        end
+        function Base.promote_rule(
+            (@nospecialize l::Type{<:TypeDomainInteger}),
+            (@nospecialize r::Type{<:TypeDomainInteger}),
+        )
+            if (l <: Union{}) || (r <: Union{})
+                throw(UnexpectedException())
+            end
+            if l == r
+                l
+            elseif (l <: ZeroOrOne) && (r <: ZeroOrOne)
+                Bool
+            else
+                Int16  # presumably wide enough for any type domain integer
             end
         end
     end

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -225,7 +225,7 @@ baremodule TypeDomainIntegers
         using ..RecursiveAlgorithms: ConvertNaturalToNegativeException
         export
             tdnn_to_int, tdi_to_int, tdnn_from_int, tdi_from_int,
-            tdnn_to_x,   tdi_to_x,   tdnn_from_x,   tdi_from_x
+                         tdi_to_x,   tdnn_from_x,   tdi_from_x
         function tdnn_to_int(@nospecialize n::NonnegativeInteger)
             if n isa PositiveIntegerUpperBound
                 let p = natural_predecessor(n)
@@ -263,10 +263,6 @@ baremodule TypeDomainIntegers
             else
                 n
             end
-        end
-        function tdnn_to_x(x::TNumber, @nospecialize n::NonnegativeInteger)
-            i = tdnn_to_int(n)
-            x(i)
         end
         function tdi_to_x(x::TNumber, @nospecialize n::TypeDomainInteger)
             i = tdi_to_int(n)

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -264,6 +264,17 @@ baremodule TypeDomainIntegers
                 n
             end
         end
+        function tdnn_from_int(i::Bool)
+            z = zero()
+            if i
+                natural_successor(z)
+            else
+                z
+            end
+        end
+        function tdi_from_int(i::Bool)
+            tdnn_from_int(i)
+        end
         function tdi_to_x(x::TNumber, @nospecialize n::TypeDomainInteger)
             i = tdi_to_int(n)
             x(i)

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 baremodule TypeDomainIntegers
     baremodule Basic
         using Base: @nospecialize

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -553,6 +553,10 @@ baremodule TypeDomainIntegers
         function Base.widen(@nospecialize t::Type{<:TypeDomainInteger})
             t
         end
+        function Base.show(io::Base.IO, n::TypeDomainInteger)
+            i = tdi_to_int(n)
+            Base.show(io, Int(i))
+        end
     end
 
     baremodule BaseHelpers

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -485,16 +485,15 @@ baremodule TypeDomainIntegers
         using ..Basic, ..LazyMinus, ..Conversion
         using Base: convert, isequal, <, +, -, *, ==, !, @nospecialize
         export apply_n_t, apply_t_n
-        const interoperable = tdi_to_int
         function apply_n_t(::typeof(+), (@nospecialize l::Number), @nospecialize r::TypeDomainInteger)
             if r isa NegativeInteger
                 let pos = negated(r)::PositiveInteger
-                    l - interoperable(pos)
+                    l - tdi_to_int(pos)
                 end
             else
                 r = r::NonnegativeInteger
                 if r isa PositiveIntegerUpperBound
-                    l + interoperable(r)
+                    l + tdi_to_int(r)
                 else
                     l
                 end
@@ -509,11 +508,11 @@ baremodule TypeDomainIntegers
         end
         function apply_t_n(::typeof(-), (@nospecialize l::TypeDomainInteger), @nospecialize r::Number)
             if l isa NegativeInteger
-                interoperable(l) - r
+                tdi_to_int(l) - r
             else
                 l = l::NonnegativeInteger
                 if l isa PositiveIntegerUpperBound
-                    interoperable(l) - r
+                    tdi_to_int(l) - r
                 else
                     -r
                 end
@@ -523,7 +522,7 @@ baremodule TypeDomainIntegers
             if r isa NegativeInteger
                 let pos = negated(r), posm1 = natural_predecessor(pos)
                     if posm1 isa PositiveIntegerUpperBound
-                        l * interoperable(r)
+                        l * tdi_to_int(r)
                     else
                         -l
                     end
@@ -533,7 +532,7 @@ baremodule TypeDomainIntegers
                 if r isa PositiveIntegerUpperBound
                     let p = natural_predecessor(r)
                         if p isa PositiveIntegerUpperBound
-                            l * interoperable(r)
+                            l * tdi_to_int(r)
                         else
                             l
                         end
@@ -547,7 +546,7 @@ baremodule TypeDomainIntegers
             if l isa NegativeInteger
                 let pos = negated(l), posm1 = natural_predecessor(pos)
                     if posm1 isa PositiveIntegerUpperBound
-                        interoperable(l) * r
+                        tdi_to_int(l) * r
                     else
                         -r
                     end
@@ -557,7 +556,7 @@ baremodule TypeDomainIntegers
                 if l isa PositiveIntegerUpperBound
                     let p = natural_predecessor(l)
                         if p isa PositiveIntegerUpperBound
-                            interoperable(l) * r
+                            tdi_to_int(l) * r
                         else
                             r
                         end
@@ -573,11 +572,11 @@ baremodule TypeDomainIntegers
             (@nospecialize r::TypeDomainInteger),
         )
             if r isa NegativeInteger
-                func(l, interoperable(r))
+                func(l, tdi_to_int(r))
             else
                 r = r::NonnegativeInteger
                 if r isa PositiveIntegerUpperBound
-                    func(l, interoperable(r))
+                    func(l, tdi_to_int(r))
                 else
                     iszero(l)
                 end

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -488,23 +488,13 @@ baremodule TypeDomainIntegers
         const interoperable = tdi_to_int
         function apply_n_t(::typeof(+), (@nospecialize l::Number), @nospecialize r::TypeDomainInteger)
             if r isa NegativeInteger
-                let pos = negated(r), posm1 = natural_predecessor(pos)
-                    if posm1 isa PositiveIntegerUpperBound
-                        l - interoperable(pos)
-                    else
-                        l - true
-                    end
+                let pos = negated(r)::PositiveInteger
+                    l - interoperable(pos)
                 end
             else
                 r = r::NonnegativeInteger
                 if r isa PositiveIntegerUpperBound
-                    let p = natural_predecessor(r)
-                        if p isa PositiveIntegerUpperBound
-                            l + interoperable(r)
-                        else
-                            l + true
-                        end
-                    end
+                    l + interoperable(r)
                 else
                     l
                 end
@@ -523,13 +513,7 @@ baremodule TypeDomainIntegers
             else
                 l = l::NonnegativeInteger
                 if l isa PositiveIntegerUpperBound
-                    let p = natural_predecessor(l)
-                        if p isa PositiveIntegerUpperBound
-                            interoperable(l) - r
-                        else
-                            true - r
-                        end
-                    end
+                    interoperable(l) - r
                 else
                     -r
                 end

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -16,7 +16,8 @@ baremodule TypeDomainIntegers
         end
         baremodule UpperBounds
             using ..RecursiveStep
-            abstract type A{P <: recursive_step(Any)} end
+            const s = Integer
+            abstract type A{P <: recursive_step(s)} <: s    end
             abstract type B{P <: recursive_step(A)} <: A{P} end
         end
         const NonnegativeIntegerUpperBound = UpperBounds.B
@@ -61,7 +62,7 @@ baremodule TypeDomainIntegers
         using ..Basic
         using Base: @nospecialize
         export NegativeInteger, TypeDomainInteger, negated
-        struct NegativeInteger{X<:PositiveInteger}
+        struct NegativeInteger{X<:PositiveInteger} <: Integer
             x::X
         end
         const TypeDomainInteger = Union{NonnegativeInteger,NegativeInteger}

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -339,7 +339,7 @@ baremodule TypeDomainIntegers
 
     baremodule BaseOverloads
         using ..Basic, ..RecursiveAlgorithms, ..LazyMinus, ..PrimitiveTypes, ..Conversion
-        using Base: Base, convert, RoundingMode, <, +, -, *, ==, isequal, isless, !, @nospecialize, @eval
+        using Base: Base, convert, RoundingMode, <, +, -, *, isless, !, @nospecialize, @eval
         function Base.zero(@nospecialize unused::Type{<:TypeDomainInteger})
             zero()
         end
@@ -435,12 +435,6 @@ baremodule TypeDomainIntegers
         end
         function Base.isodd(@nospecialize o::TypeDomainInteger)
             !Base.iseven(o)
-        end
-        function Base.:(==)((@nospecialize l::TypeDomainInteger), @nospecialize r::TypeDomainInteger)
-            l === r
-        end
-        function Base.isequal((@nospecialize l::TypeDomainInteger), @nospecialize r::TypeDomainInteger)
-            l === r
         end
         function Base.:(<)((@nospecialize l::TypeDomainInteger), @nospecialize r::TypeDomainInteger)
             l_neg = l isa NegativeInteger
@@ -671,9 +665,9 @@ baremodule TypeDomainIntegers
     end
 
     baremodule BaseOverloadsBinaryOperations
-        using Base: Base, isequal, +, -, *, ==, @nospecialize, @eval
+        using Base: Base, +, -, *, ==, @nospecialize, @eval
         using ..Basic, ..LazyMinus, ..PrimitiveTypes, ..BaseHelpers
-        for type ∈ PrimitiveTypes.types_all, func ∈ (:+, :-, :*, :(==), :isequal)
+        for type ∈ PrimitiveTypes.types_all, func ∈ (:+, :-, :*, :(==))
             @eval begin
                 function Base.$func((@nospecialize l::$type), (@nospecialize r::TypeDomainInteger))
                     apply_n_t($func, l, r)

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -526,6 +526,21 @@ baremodule TypeDomainIntegers
         function Base.signbit(@nospecialize n::TypeDomainInteger)
             n isa NegativeInteger
         end
+        function Base.sign(@nospecialize n::TypeDomainInteger)
+            zer = zero()
+            plus = natural_successor(zer)
+            minus = negated(plus)
+            if n isa NegativeInteger
+                minus
+            else
+                n = n::NonnegativeInteger
+                if n isa PositiveIntegerUpperBound
+                    plus
+                else
+                    zer
+                end
+            end
+        end
     end
 
     baremodule BaseHelpers

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -6,7 +6,7 @@ baremodule TypeDomainIntegers
         export
             natural_successor, natural_predecessor,
             NonnegativeInteger, PositiveInteger, PositiveIntegerUpperBound,
-            with_refined_type, zero
+            zero
         baremodule RecursiveStep
             using Base: @nospecialize
             export recursive_step
@@ -40,18 +40,15 @@ baremodule TypeDomainIntegers
             global function new_nonnegative_integer(p::P) where {P<:recursive_step(NonnegativeInteger)}
                 t_p = P::DataType
                 r = new{t_p}(p)
-                with_refined_type(r)
+                r::NonnegativeInteger
             end
-        end
-        function with_refined_type(@nospecialize r::NonnegativeInteger)
-            r
         end
         function natural_successor(o::NonnegativeInteger)
             new_nonnegative_integer(o)::PositiveInteger
         end
         function natural_predecessor(o::PositiveInteger)
             r = o.predecessor
-            with_refined_type(r)
+            r::NonnegativeInteger
         end
         function zero()
             new_nonnegative_integer(nothing)
@@ -126,7 +123,7 @@ baremodule TypeDomainIntegers
             else
                 l
             end
-            with_refined_type(ret)
+            ret::NonnegativeInteger
         end
         @assume_effects :foldable function to_int(@nospecialize o::NonnegativeInteger)
             if o isa PositiveIntegerUpperBound
@@ -146,11 +143,11 @@ baremodule TypeDomainIntegers
                 zero()
             else
                 let v = n - 1, p = @inline from_int(v)
-                    p = with_refined_type(p)
+                    p = p::NonnegativeInteger
                     natural_successor(p)
                 end
             end
-            with_refined_type(ret)
+            ret::NonnegativeInteger
         end
         @assume_effects :foldable function is_even(@nospecialize o::NonnegativeInteger)
             if o isa PositiveIntegerUpperBound
@@ -191,7 +188,7 @@ baremodule TypeDomainIntegers
             if n isa NegativeInteger
                 false
             else
-                n = with_refined_type(n)
+                n = n::NonnegativeInteger
                 if n isa PositiveIntegerUpperBound
                     false
                 else

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -454,6 +454,7 @@ baremodule TypeDomainIntegers
     baremodule BaseHelpers
         using ..Basic, ..LazyMinus, ..Interoperability
         using Base: convert, <, +, -, *, ==, !, @nospecialize
+        export apply_n_t, apply_t_n
         function apply_n_t(func, (@nospecialize l::Number), @nospecialize r::TypeDomainInteger)
             i = interoperable(r)
             func(l, i)

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -547,6 +547,12 @@ baremodule TypeDomainIntegers
         })
             n
         end
+        function Base.widen(@nospecialize n::TypeDomainInteger)
+            n
+        end
+        function Base.widen(@nospecialize t::Type{<:TypeDomainInteger})
+            t
+        end
     end
 
     baremodule BaseHelpers

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -99,7 +99,22 @@ baremodule TypeDomainIntegers
         const int_zero = I(0)
         const int_plus_one = I(1)
         function interoperable(@nospecialize n::TypeDomainInteger)
-            I(n)
+            if n isa NegativeInteger
+                I(n)
+            else
+                n = n::NonnegativeInteger
+                if n isa PositiveIntegerUpperBound
+                    let p = natural_predecessor(n)
+                        if p isa PositiveIntegerUpperBound
+                            I(n)
+                        else
+                            true
+                        end
+                    end
+                else
+                    false
+                end
+            end
         end
         function incremented(n::I)
             checked_add(n, int_plus_one)::I

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -455,14 +455,6 @@ baremodule TypeDomainIntegers
         using ..Basic, ..LazyMinus, ..Interoperability
         using Base: convert, <, +, -, *, ==, !, @nospecialize
         export apply_n_t, apply_t_n
-        function apply_n_t(func, (@nospecialize l::Number), @nospecialize r::TypeDomainInteger)
-            i = interoperable(r)
-            func(l, i)
-        end
-        function apply_t_n(func, (@nospecialize l::TypeDomainInteger), @nospecialize r::Number)
-            i = interoperable(l)
-            func(i, r)
-        end
         function apply_n_t(::typeof(+), (@nospecialize l::Number), @nospecialize r::TypeDomainInteger)
             if r isa NegativeInteger
                 let pos = negated(r), posm1 = natural_predecessor(pos)

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -592,6 +592,21 @@ baremodule TypeDomainIntegers
         end
     end
 
+    baremodule BaseOverloadsBinaryOperations
+        using Base: Base, isequal, +, -, *, ==, @nospecialize, @eval
+        using ..Basic, ..LazyMinus, ..PrimitiveTypes, ..BaseHelpers
+        for type ∈ PrimitiveTypes.types_all, func ∈ (:+, :-, :*, :(==), :isequal)
+            @eval begin
+                function Base.$func((@nospecialize l::$type), (@nospecialize r::TypeDomainInteger))
+                    apply_n_t($func, l, r)
+                end
+                function Base.$func((@nospecialize l::TypeDomainInteger), (@nospecialize r::$type))
+                    apply_t_n($func, l, r)
+                end
+            end
+        end
+    end
+
     export
         natural_successor, natural_predecessor, NonnegativeInteger, PositiveInteger,
         PositiveIntegerUpperBound, NegativeInteger, TypeDomainInteger

--- a/base/typedomainintegers.jl
+++ b/base/typedomainintegers.jl
@@ -523,6 +523,9 @@ baremodule TypeDomainIntegers
         function Base.abs(@nospecialize n::TypeDomainInteger)
             absolute_value_of(n)
         end
+        function Base.signbit(@nospecialize n::TypeDomainInteger)
+            n isa NegativeInteger
+        end
     end
 
     baremodule BaseHelpers

--- a/base/typedomainintegers_irrationals.jl
+++ b/base/typedomainintegers_irrationals.jl
@@ -1,0 +1,75 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+function angle(@nospecialize n::TypeDomainInteger)
+    if n isa NegativeInteger
+        π
+    else
+        zero(TypeDomainInteger)
+    end
+end
+
+function exp(@nospecialize n::Union{
+    typeof(NonnegativeInteger(0)),
+    typeof(NonnegativeInteger(1)),
+})
+    if n isa PositiveIntegerUpperBound
+        ℯ
+    else
+        NonnegativeInteger(1)
+    end
+end
+
+const ZeroOrPi = Union{
+    typeof(NonnegativeInteger(0)),
+    typeof(π),
+}
+
+function sin(@nospecialize x::ZeroOrPi)
+    NonnegativeInteger(0)
+end
+function tan(@nospecialize x::ZeroOrPi)
+    NonnegativeInteger(0)
+end
+function cos(@nospecialize x::ZeroOrPi)
+    o = one(NonnegativeInteger)
+    if iszero(x)
+        o
+    else
+        -o
+    end
+end
+function Math.sec(@nospecialize x::ZeroOrPi)
+    o = one(NonnegativeInteger)
+    if iszero(x)
+        o
+    else
+        -o
+    end
+end
+
+function asin(x::typeof(NonnegativeInteger(0)))
+    x
+end
+function atan(x::typeof(NonnegativeInteger(0)))
+    x
+end
+function acos(@nospecialize x::Union{
+    typeof(TypeDomainInteger(-1)),
+    typeof(TypeDomainInteger( 1)),
+})
+    if x isa NegativeInteger
+        π
+    else
+        zero(NonnegativeInteger)
+    end
+end
+function Math.asec(@nospecialize x::Union{
+    typeof(TypeDomainInteger(-1)),
+    typeof(TypeDomainInteger( 1)),
+})
+    if x isa NegativeInteger
+        π
+    else
+        zero(NonnegativeInteger)
+    end
+end

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -290,12 +290,13 @@ are included, including those not visible in the current module.
 See also [`supertype`](@ref), [`supertypes`](@ref), [`methodswith`](@ref).
 
 # Examples
-```jldoctest
-julia> subtypes(Integer)
-3-element Vector{Any}:
- Bool
- Signed
- Unsigned
+```julia
+julia> subtypes(Real)
+4-element Vector{Any}:
+ AbstractFloat
+ AbstractIrrational
+ Integer
+ Rational
 ```
 """
 subtypes(x::Type) = _subtypes_in!(Base.loaded_modules_array(), x)

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -16,7 +16,7 @@ const TESTNAMES = [
         "operators", "ordering", "path", "ccall", "parse", "loading", "gmp",
         "sorting", "spawn", "backtrace", "exceptions",
         "file", "read", "version", "namedtuple",
-        "mpfr", "broadcast", "complex",
+        "mpfr", "broadcast", "complex", "typedomainintegers",
         "floatapprox", "stdlib", "reflection", "regex", "float16",
         "combinatorics", "sysinfo", "env", "rounding", "ranges", "mod2pi",
         "euler", "show", "client", "terminfo",

--- a/test/math.jl
+++ b/test/math.jl
@@ -83,11 +83,11 @@ end
     @test repr(Any[pi ℯ; ℯ pi]) == "Any[π ℯ; ℯ π]"
     @test string(pi) == "π"
 
-    @test sin(π) == sind(180) === sinpi(1) === sinpi(1//1) == tan(π) == 0
-    @test tan(π) == tand(180) === tanpi(1) === tanpi(1//1) === -0.0
-    @test cos(π) == cosd(180) === cospi(1) === cospi(1//1) == sec(π) == -1
+    @test sin(π) == sind(180) == sinpi(1) == sinpi(1//1) == tan(π) == 0
+    @test tan(π) == tand(180) == tanpi(1) == tanpi(1//1) == -0.0
+    @test cos(π) == cosd(180) == cospi(1) == cospi(1//1) == sec(π) == -1
     @test csc(π) == 1/0 && cot(π) == -1/0
-    @test sincos(π) === sincospi(1) == (0, -1)
+    @test sincos(π) == sincospi(1) == (0, -1)
 end
 
 @testset "frexp,ldexp,significand,exponent" begin
@@ -572,16 +572,16 @@ end
 
 @testset "Integer and Inf args for sinpi/cospi/tanpi/sinc/cosc" begin
     for (sinpi, cospi) in ((sinpi, cospi), (x->sincospi(x)[1], x->sincospi(x)[2]))
-        @test sinpi(1) === 0.0
-        @test sinpi(-1) === -0.0
+        @test sinpi(1) == 0.0
+        @test sinpi(-1) == -0.0
         @test cospi(1) == -1
         @test cospi(2) == 1
     end
 
-    @test tanpi(1) === -0.0
-    @test tanpi(-1) === 0.0
-    @test tanpi(2) === 0.0
-    @test tanpi(-2) === -0.0
+    @test tanpi(1) == -0.0
+    @test tanpi(-1) == 0.0
+    @test tanpi(2) == 0.0
+    @test tanpi(-2) == -0.0
     @test sinc(1) == 0
     @test sinc(complex(1,0)) == 0
     @test sinc(0) == 1
@@ -878,7 +878,7 @@ end
     @test exp10(5) ≈ exp10(5.0)
     @test exp10(50//10) ≈ exp10(5.0)
     @test log10(exp10(ℯ)) ≈ ℯ
-    @test log(ℯ) === 1
+    @test log(ℯ) == 1
     @test exp2(Float16(2.0)) ≈ exp2(2.0)
     @test exp2(Float16(1.0)) === Float16(exp2(1.0))
     @test exp10(Float16(1.0)) === Float16(exp10(1.0))

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -524,8 +524,8 @@ end
     @test isa(sign(2//3), Rational{Int})
     @test isa(2//3 + 2//3im, Complex{Rational{Int}})
     @test isa(sign(2//3 + 2//3im), ComplexF64)
-    @test sign(pi) === 1.0
-    @test sign(pi) === -sign(-pi)
+    @test sign(pi) == 1.0
+    @test sign(pi) == -sign(-pi)
     @test sign(one(UInt)) == 1
     @test sign(zero(UInt)) == 0
 
@@ -1115,10 +1115,10 @@ end
 
 @testset "Irrational zero and one" begin
     for i in (π, ℯ, γ, catalan)
-        @test one(i) === true
-        @test zero(i) === false
-        @test one(typeof(i)) === true
-        @test zero(typeof(i)) === false
+        @test one(i) == true
+        @test zero(i) == false
+        @test one(typeof(i)) == true
+        @test zero(typeof(i)) == false
     end
 end
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1119,6 +1119,9 @@ end
         @test zero(i) == false
         @test one(typeof(i)) == true
         @test zero(typeof(i)) == false
+        @testset "JuliaLang/julia/issues/37977" begin
+            @test i === one(i)*i
+        end
     end
 end
 

--- a/test/typedomainintegers.jl
+++ b/test/typedomainintegers.jl
@@ -238,22 +238,22 @@ const max_tested_number = 7
             end
         end
     end
-    # @testset "some identities" begin
-    #     z = @inferred zero(NonnegativeInteger)
-    #     o = @inferred natural_successor(z)
-    #     for c ∈ (π, ℯ, 7, 0x7, 7.0, true)
-    #         @test (z + c) === c === (c + z) === (c - z) === (o * c) === (c * o)
-    #     end
-    # end
-    # @testset "heterogeneous `+` `-` `*`" begin
-    #     for i ∈ -max_tested_number:max_tested_number
-    #         n = convert(TypeDomainInteger, i)
-    #         for x ∈ (((-1):5)..., ((-3):0.1:3)...)
-    #             for op ∈ (+, -, *)
-    #                 @test op(n, x) == op(i, x)
-    #                 @test op(x, n) == op(x, i)
-    #             end
-    #         end
-    #     end
-    # end
+    @testset "some identities" begin
+        z = @inferred zero(NonnegativeInteger)
+        o = @inferred natural_successor(z)
+        for c ∈ (π, ℯ, 7, 0x7, 7.0, true)
+            @test (z + c) === c === (c + z) === (c - z) === (o * c) === (c * o)
+        end
+    end
+    @testset "heterogeneous `+` `-` `*`" begin
+        for i ∈ -max_tested_number:max_tested_number
+            n = convert(TypeDomainInteger, i)
+            for x ∈ (((-1):5)..., ((-3):0.1:3)...)
+                for op ∈ (+, -, *)
+                    @test op(n, x) == op(i, x)
+                    @test op(x, n) == op(x, i)
+                end
+            end
+        end
+    end
 end

--- a/test/typedomainintegers.jl
+++ b/test/typedomainintegers.jl
@@ -1,0 +1,259 @@
+using Base.TypeDomainIntegers
+using Test
+
+const max_tested_number = 7
+
+@testset "TypeDomainNaturalNumbers.jl" begin
+    @testset "subtyping" begin
+        @test PositiveInteger <: NonnegativeInteger <: TypeDomainInteger <: Integer
+        @test NegativeInteger <: TypeDomainInteger
+        @test !(NonnegativeInteger <: PositiveInteger)
+        @test PositiveInteger <: PositiveIntegerUpperBound
+        @test !(NonnegativeInteger <: PositiveIntegerUpperBound)
+        @test PositiveInteger == typeintersect(NonnegativeInteger,PositiveIntegerUpperBound)
+    end
+    @testset "zero" begin
+        n = @inferred zero(NonnegativeInteger)
+        @test @inferred iszero(n)
+        @test n isa NonnegativeInteger
+        @test !(n isa PositiveInteger)
+        @test Base.issingletontype(typeof(n))
+    end
+    @testset "positive integers" begin
+        n = @inferred zero(NonnegativeInteger)
+        for _ ∈ 1:max_tested_number
+            n = @inferred natural_successor(n)
+            @test !(@inferred iszero(n))
+            @test n isa NonnegativeInteger
+            @test n isa PositiveInteger
+            @test n isa PositiveIntegerUpperBound
+        end
+    end
+    @testset "successor, predecessor" begin
+        m = @inferred zero(NonnegativeInteger)
+        @test_throws MethodError natural_predecessor(m)
+        n = @inferred natural_successor(m)
+        for _ ∈ 1:max_tested_number
+            @test m === @inferred natural_predecessor(n)
+            @test n === @inferred natural_successor(m)
+        end
+    end
+    @testset "conversion to/from `Bool`" begin
+        z = @inferred zero(NonnegativeInteger)
+        o = @inferred natural_successor(z)
+        t = @inferred natural_successor(o)
+        @test z === convert(NonnegativeInteger, false)
+        @test o === convert(NonnegativeInteger, true)
+        @test false === @inferred convert(Bool, z)
+        @test  true === @inferred convert(Bool, o)
+        @test_throws MethodError  convert(Bool, t)
+    end
+    @testset "conversion to/from `Int`" begin
+        for i ∈ 0:max_tested_number
+            @test i === convert(Int, convert(NonnegativeInteger, i))
+            @test convert(NonnegativeInteger, i) isa NonnegativeInteger
+        end
+        @testset "negative" begin
+            for i ∈ -5:-1
+                @test_throws Exception convert(NonnegativeInteger, i)
+            end
+        end
+    end
+    @testset "identity conversion" begin
+        for i ∈ -max_tested_number:max_tested_number
+            n = convert(TypeDomainInteger, i)
+            @test n === @inferred convert(TypeDomainInteger, n)
+        end
+        for i ∈ 0:max_tested_number
+            n = convert(NonnegativeInteger, i)
+            @test n === @inferred convert(NonnegativeInteger, n)
+        end
+    end
+    @testset "constructors" begin
+        @testset "`Bool`" begin
+            for i ∈ 0:1
+                b = Bool(i)
+                n = convert(NonnegativeInteger, i)
+                @test b === @inferred Bool(n)
+                @test n === NonnegativeInteger(b)
+            end
+            @testset "failure" begin
+                t = convert(NonnegativeInteger, 2)
+                @test_throws MethodError Bool(t)
+            end
+        end
+        @testset "`Int`" begin
+            for i ∈ 0:max_tested_number
+                n = convert(NonnegativeInteger, i)
+                @test i === @inferred Int(n)
+                @test n === NonnegativeInteger(i)
+            end
+            for i ∈ -max_tested_number:max_tested_number
+                n = convert(TypeDomainInteger, i)
+                @test i === @inferred Int(n)
+                @test n === TypeDomainInteger(i)
+            end
+        end
+    end
+    @testset "instance zero" begin
+        for i ∈ 0:max_tested_number
+            @test zero(NonnegativeInteger) === zero(convert(NonnegativeInteger, i))
+        end
+        for i ∈ -max_tested_number:max_tested_number
+            @test zero(TypeDomainInteger) === zero(convert(TypeDomainInteger, i))
+        end
+    end
+    @testset "properties" begin
+        for i ∈ -max_tested_number:max_tested_number
+            n = convert(TypeDomainInteger, i)
+            @test () === @inferred propertynames(n)
+            @test () === @inferred propertynames(n, false)
+        end
+    end
+    @testset "`iseven`, `isodd`" begin
+        for i ∈ -max_tested_number:max_tested_number
+            n = convert(TypeDomainInteger, i)
+            @test iseven(n) === iseven(i)
+            @test isodd(n) === isodd(i)
+        end
+    end
+    @testset "comparisons" begin
+        @testset "between type domain integers" begin
+            for a ∈ -max_tested_number:max_tested_number
+                l = convert(TypeDomainInteger, a)
+                for b ∈ -max_tested_number:max_tested_number
+                    r = convert(TypeDomainInteger, b)
+                    for op ∈ (==, <, isequal, isless)
+                        @test op(l, r) isa Bool
+                        @test op(l, r) == op(a, b)
+                    end
+                end
+            end
+        end
+        # @testset "between a type domain integer and a `Number`" begin
+        #     z = @inferred zero(NonnegativeInteger)
+        #     o = @inferred natural_successor(z)
+        #     t = @inferred natural_successor(o)
+        #     for i ∈ -max_tested_number:max_tested_number
+        #         lesser_numbers = (
+        #             prevfloat(Float64(i)), prevfloat(Float32(i)), prevfloat(Float16(i)),
+        #             i - true, Float64(i) - true, Float32(i) - true, Float16(i) - true,
+        #             -Inf16, -Inf32, -Inf64,
+        #         )
+        #         greater_numbers = (
+        #             nextfloat(Float64(i)), nextfloat(Float32(i)), nextfloat(Float16(i)),
+        #             i + true, Float64(i) + true, Float32(i) + true, Float16(i) + true,
+        #             Inf16, Inf32, Inf64,
+        #         )
+        #         unequal_numbers = (lesser_numbers..., greater_numbers...)
+        #         n = convert(TypeDomainInteger, i)
+        #         @testset "`==`, `isequal`" begin
+        #             for op ∈ (==, isequal)
+        #                 for x ∈ (i, Float64(i), Float32(i), Float16(i))
+        #                     @test op(n, x)
+        #                     @test op(x, n)
+        #                 end
+        #                 for x ∈ unequal_numbers
+        #                     @test !op(n, x)
+        #                     @test !op(x, n)
+        #                 end
+        #             end
+        #             @testset "`missing`" begin
+        #                 @test ismissing(n == missing)
+        #                 @test ismissing(missing == n)
+        #                 @test !isequal(n, missing)
+        #                 @test !isequal(missing, n)
+        #             end
+        #         end
+        #         @testset "`<`, `isless`" begin
+        #             for op ∈ (<, isless)
+        #                 for x ∈ (i, Float64(i), Float32(i), Float16(i))
+        #                     @test !op(n, x)
+        #                     @test !op(x, n)
+        #                 end
+        #                 for x ∈ greater_numbers
+        #                     @test op(n, x)
+        #                     @test !op(x, n)
+        #                 end
+        #                 for x ∈ lesser_numbers
+        #                     @test !op(n, x)
+        #                     @test op(x, n)
+        #                 end
+        #             end
+        #             @testset "`missing`" begin
+        #                 @test ismissing(n < missing)
+        #                 @test ismissing(missing < n)
+        #                 @test isless(n, missing)
+        #                 @test !isless(missing, n)
+        #             end
+        #         end
+        #     end
+        # end
+    end
+    @testset "addition and subtraction" begin
+        @testset "identity" begin
+            id = zero(NonnegativeInteger)
+            for i ∈ -max_tested_number:max_tested_number
+                n = convert(TypeDomainInteger, i)
+                @test (@inferred (n + id)) === (id + n) === (n - id) === n
+                @test (@inferred (n - n)) === id
+            end
+        end
+        @testset "special cases" begin
+            z = zero(NonnegativeInteger)
+            o = @inferred natural_successor(z)
+            t = @inferred natural_successor(o)
+            @test -o === (z - o)
+            @test -t === (z - t)
+            @test -o === (o - t)
+            @test t === @inferred (o + o)
+            @test o === @inferred (t - o)
+        end
+        @testset "systematic" begin
+            for a ∈ -max_tested_number:max_tested_number
+                l = convert(TypeDomainInteger, a)
+                for b ∈ -max_tested_number:max_tested_number
+                    r = convert(TypeDomainInteger, b)
+                    @test convert(Int, l + r) === (a + b)
+                end
+            end
+        end
+    end
+    @testset "multiplication" begin
+        z = zero(NonnegativeInteger)
+        o = @inferred natural_successor(z)
+        t = @inferred natural_successor(o)
+        @testset "`one`, `isone`" begin
+            @test o === one(TypeDomainInteger) === one(NonnegativeInteger) === one(z) === one(o) === one(t)
+            @test !isone(z)
+            @test isone(o)
+            @test !isone(t)
+        end
+        for a ∈ -max_tested_number:max_tested_number
+            l = convert(TypeDomainInteger, a)
+            @test l === (l * o) === (o * l)
+            for b ∈ -max_tested_number:max_tested_number
+                r = convert(TypeDomainInteger, b)
+                @test convert(Int, l * r) === (a * b)
+            end
+        end
+    end
+    # @testset "some identities" begin
+    #     z = @inferred zero(NonnegativeInteger)
+    #     o = @inferred natural_successor(z)
+    #     for c ∈ (π, ℯ, 7, 0x7, 7.0, true)
+    #         @test (z + c) === c === (c + z) === (c - z) === (o * c) === (c * o)
+    #     end
+    # end
+    # @testset "heterogeneous `+` `-` `*`" begin
+    #     for i ∈ -max_tested_number:max_tested_number
+    #         n = convert(TypeDomainInteger, i)
+    #         for x ∈ (((-1):5)..., ((-3):0.1:3)...)
+    #             for op ∈ (+, -, *)
+    #                 @test op(n, x) == op(i, x)
+    #                 @test op(x, n) == op(x, i)
+    #             end
+    #         end
+    #     end
+    # end
+end

--- a/test/typedomainintegers.jl
+++ b/test/typedomainintegers.jl
@@ -46,7 +46,7 @@ const max_tested_number = 7
         @test o === convert(NonnegativeInteger, true)
         @test false === @inferred convert(Bool, z)
         @test  true === @inferred convert(Bool, o)
-        @test_throws MethodError  convert(Bool, t)
+        @test_throws InexactError convert(Bool, t)
     end
     @testset "conversion to/from `Int`" begin
         for i ∈ 0:max_tested_number
@@ -79,7 +79,7 @@ const max_tested_number = 7
             end
             @testset "failure" begin
                 t = convert(NonnegativeInteger, 2)
-                @test_throws MethodError Bool(t)
+                @test_throws InexactError Bool(t)
             end
         end
         @testset "`Int`" begin

--- a/test/typedomainintegers.jl
+++ b/test/typedomainintegers.jl
@@ -130,65 +130,65 @@ const max_tested_number = 7
                 end
             end
         end
-        # @testset "between a type domain integer and a `Number`" begin
-        #     z = @inferred zero(NonnegativeInteger)
-        #     o = @inferred natural_successor(z)
-        #     t = @inferred natural_successor(o)
-        #     for i ∈ -max_tested_number:max_tested_number
-        #         lesser_numbers = (
-        #             prevfloat(Float64(i)), prevfloat(Float32(i)), prevfloat(Float16(i)),
-        #             i - true, Float64(i) - true, Float32(i) - true, Float16(i) - true,
-        #             -Inf16, -Inf32, -Inf64,
-        #         )
-        #         greater_numbers = (
-        #             nextfloat(Float64(i)), nextfloat(Float32(i)), nextfloat(Float16(i)),
-        #             i + true, Float64(i) + true, Float32(i) + true, Float16(i) + true,
-        #             Inf16, Inf32, Inf64,
-        #         )
-        #         unequal_numbers = (lesser_numbers..., greater_numbers...)
-        #         n = convert(TypeDomainInteger, i)
-        #         @testset "`==`, `isequal`" begin
-        #             for op ∈ (==, isequal)
-        #                 for x ∈ (i, Float64(i), Float32(i), Float16(i))
-        #                     @test op(n, x)
-        #                     @test op(x, n)
-        #                 end
-        #                 for x ∈ unequal_numbers
-        #                     @test !op(n, x)
-        #                     @test !op(x, n)
-        #                 end
-        #             end
-        #             @testset "`missing`" begin
-        #                 @test ismissing(n == missing)
-        #                 @test ismissing(missing == n)
-        #                 @test !isequal(n, missing)
-        #                 @test !isequal(missing, n)
-        #             end
-        #         end
-        #         @testset "`<`, `isless`" begin
-        #             for op ∈ (<, isless)
-        #                 for x ∈ (i, Float64(i), Float32(i), Float16(i))
-        #                     @test !op(n, x)
-        #                     @test !op(x, n)
-        #                 end
-        #                 for x ∈ greater_numbers
-        #                     @test op(n, x)
-        #                     @test !op(x, n)
-        #                 end
-        #                 for x ∈ lesser_numbers
-        #                     @test !op(n, x)
-        #                     @test op(x, n)
-        #                 end
-        #             end
-        #             @testset "`missing`" begin
-        #                 @test ismissing(n < missing)
-        #                 @test ismissing(missing < n)
-        #                 @test isless(n, missing)
-        #                 @test !isless(missing, n)
-        #             end
-        #         end
-        #     end
-        # end
+        @testset "between a type domain integer and a `Number`" begin
+            z = @inferred zero(NonnegativeInteger)
+            o = @inferred natural_successor(z)
+            t = @inferred natural_successor(o)
+            for i ∈ -max_tested_number:max_tested_number
+                lesser_numbers = (
+                    prevfloat(Float64(i)), prevfloat(Float32(i)), prevfloat(Float16(i)),
+                    i - true, Float64(i) - true, Float32(i) - true, Float16(i) - true,
+                    -Inf16, -Inf32, -Inf64,
+                )
+                greater_numbers = (
+                    nextfloat(Float64(i)), nextfloat(Float32(i)), nextfloat(Float16(i)),
+                    i + true, Float64(i) + true, Float32(i) + true, Float16(i) + true,
+                    Inf16, Inf32, Inf64,
+                )
+                unequal_numbers = (lesser_numbers..., greater_numbers...)
+                n = convert(TypeDomainInteger, i)
+                @testset "`==`, `isequal`" begin
+                    for op ∈ (==, isequal)
+                        for x ∈ (i, Float64(i), Float32(i), Float16(i))
+                            @test op(n, x)
+                            @test op(x, n)
+                        end
+                        for x ∈ unequal_numbers
+                            @test !op(n, x)
+                            @test !op(x, n)
+                        end
+                    end
+                    @testset "`missing`" begin
+                        @test ismissing(n == missing)
+                        @test ismissing(missing == n)
+                        @test !isequal(n, missing)
+                        @test !isequal(missing, n)
+                    end
+                end
+                @testset "`<`, `isless`" begin
+                    for op ∈ (<, isless)
+                        for x ∈ (i, Float64(i), Float32(i), Float16(i))
+                            @test !op(n, x)
+                            @test !op(x, n)
+                        end
+                        for x ∈ greater_numbers
+                            @test op(n, x)
+                            @test !op(x, n)
+                        end
+                        for x ∈ lesser_numbers
+                            @test !op(n, x)
+                            @test op(x, n)
+                        end
+                    end
+                    @testset "`missing`" begin
+                        @test ismissing(n < missing)
+                        @test ismissing(missing < n)
+                        @test isless(n, missing)
+                        @test !isless(missing, n)
+                    end
+                end
+            end
+        end
     end
     @testset "addition and subtraction" begin
         @testset "identity" begin


### PR DESCRIPTION
Introduce `TypeDomainInteger`, a subtype of `Integer` in the type domain. That is, each value is of singleton type.

These type domain integers are then applied to many places in `Base` (yet other applications are also possible).

To be clear, this should go into `Base`, as opposed to a user package, because:

* the invalidations when defining a new `Integer` subtype are horrid
* it should be utilized from within `Base`, e.g., it fixes the bug below for irrationals

Fixes #37977

Updates #34003

Closes  #44538