### PR TITLE
Fix various issues with PGO+LTO makefile

### DIFF
--- a/contrib/pgo-lto/Makefile
+++ b/contrib/pgo-lto/Makefile
@@ -8,7 +8,6 @@ STAGE0_TOOLS:=$(STAGE0_BUILD)/usr/tools/
 
 PROFILE_DIR:=$(CURDIR)/profiles
 PROFILE_FILE:=$(PROFILE_DIR)/merged.prof
-PROFRAW_FILES:=$(wildcard $(PROFILE_DIR)/*.profraw)
 JULIA_ROOT:=$(CURDIR)/../..
 
 LLVM_CXXFILT:=$(STAGE0_TOOLS)llvm-cxxfilt
@@ -59,8 +58,8 @@ stage2: $(PROFILE_FILE) | $(STAGE2_BUILD)
 .DEFAULT: stage2
 	PATH=$(STAGE0_TOOLS):$$PATH $(STAGE2_FLAGS) $(MAKE) -C $(STAGE2_BUILD) USECLANG=1 USE_BINARYBUILDER_LLVM=0 $@
 
-$(PROFILE_FILE): stage1 $(PROFRAW_FILES)
-	$(LLVM_PROFDATA) merge -output=$@ $(PROFRAW_FILES)
+$(PROFILE_FILE): stage1
+	$(LLVM_PROFDATA) merge -output=$@ $(PROFILE_DIR)/*.profraw
 
 # show top 50 functions
 top: $(PROFILE_FILE)

--- a/contrib/pgo-lto/Makefile
+++ b/contrib/pgo-lto/Makefile
@@ -48,10 +48,12 @@ stage0: | $(STAGE0_BUILD)
 
 $(STAGE1_BUILD): stage0
 stage1: | $(STAGE1_BUILD)
+	@echo "--- Build Julia Stage 1 - with instrumentation"
 	PATH=$(STAGE0_TOOLS):$$PATH $(STAGE1_FLAGS) $(MAKE) -C $(STAGE1_BUILD) USECLANG=1 USE_BINARYBUILDER_LLVM=0 && touch $@
 	@echo $(AFTER_STAGE1_MESSAGE)
 
 stage2: $(PROFILE_FILE) | $(STAGE2_BUILD)
+	@echo "--- Build Julia Stage 2 - PGO + LTO optimised"
 	PATH=$(STAGE0_TOOLS):$$PATH $(STAGE2_FLAGS) $(MAKE) -C $(STAGE2_BUILD) USECLANG=1 USE_BINARYBUILDER_LLVM=0 && touch $@
 
 .DEFAULT: stage2

--- a/contrib/pgo-lto/Makefile
+++ b/contrib/pgo-lto/Makefile
@@ -59,7 +59,7 @@ stage2: $(PROFILE_FILE) | $(STAGE2_BUILD)
 	PATH=$(STAGE0_TOOLS):$$PATH $(STAGE2_FLAGS) $(MAKE) -C $(STAGE2_BUILD) USECLANG=1 USE_BINARYBUILDER_LLVM=0 $@
 
 $(PROFILE_FILE): stage1 $(wildcard $(PROFILE_DIR)/*.profraw)
-    $(LLVM_PROFDATA) merge -output=$@ $(PROFILE_DIR)/*.profraw
+	$(LLVM_PROFDATA) merge -output=$@ $(PROFILE_DIR)/*.profraw
 
 # show top 50 functions
 top: $(PROFILE_FILE)

--- a/contrib/pgo-lto/Makefile
+++ b/contrib/pgo-lto/Makefile
@@ -26,15 +26,14 @@ AFTER_STAGE1_MESSAGE:='You can now optionally collect more profiling data for us
 	Note that running extensive scripts may result in counter overflows, which can be detected by running $\
 	`make top`. Afterwards run `make stage2`.'
 
-TOOLCHAIN_FLAGS = $\
-	"CC=$(STAGE0_TOOLS)clang" $\
-	"CXX=$(STAGE0_TOOLS)clang++" $\
-	"LD=$(STAGE0_TOOLS)ld.lld" $\
-	"AR=$(STAGE0_TOOLS)llvm-ar" $\
-	"RANLIB=$(STAGE0_TOOLS)llvm-ranlib" $\
-	"CFLAGS+=$(PGO_CFLAGS)" $\
-	"CXXFLAGS+=$(PGO_CXXFLAGS)" $\
-	"LDFLAGS+=$(PGO_LDFLAGS)"
+STAGE1_FLAGS:=LDFLAGS="-fuse-ld=lld -flto=thin -Wl,--undefined-version -fprofile-generate=$(PROFILE_DIR)" $\
+			CFLAGS="-fprofile-generate=$(PROFILE_DIR) -Xclang -mllvm -Xclang -vp-counters-per-site=$(COUNTERS_PER_SITE)" $\
+			CXXFLAGS="-fprofile-generate=$(PROFILE_DIR) -Xclang -mllvm -Xclang -vp-counters-per-site=$(COUNTERS_PER_SITE)"
+STAGE2_FLAGS:=LDFLAGS="-fuse-ld=lld -flto=thin -Wl,--undefined-version -fprofile-use=$(PROFILE_FILE) -Wl,--icf=safe" $\
+			CFLAGS="-fprofile-use=$(PROFILE_FILE)" $\
+			CXXFLAGS="-fprofile-use=$(PROFILE_FILE)"
+
+all: stage2 # Default target as first in file
 
 $(STAGE0_BUILD) $(STAGE1_BUILD) $(STAGE2_BUILD):
 	$(MAKE) -C $(JULIA_ROOT) O=$@ configure
@@ -48,23 +47,15 @@ stage0: | $(STAGE0_BUILD)
 	touch $@
 
 $(STAGE1_BUILD): stage0
-stage1: PGO_CFLAGS:=-fprofile-generate=$(PROFILE_DIR) -Xclang -mllvm -Xclang -vp-counters-per-site=$(COUNTERS_PER_SITE)
-stage1: PGO_CXXFLAGS:=-fprofile-generate=$(PROFILE_DIR) -Xclang -mllvm -Xclang -vp-counters-per-site=$(COUNTERS_PER_SITE)
-stage1: PGO_LDFLAGS:=-fuse-ld=lld -flto=thin -fprofile-generate=$(PROFILE_DIR)
-stage1: export USE_BINARYBUILDER_LLVM=0
 stage1: | $(STAGE1_BUILD)
-	$(MAKE) -C $(STAGE1_BUILD) $(TOOLCHAIN_FLAGS) && touch $@
+	PATH=$(STAGE0_TOOLS):$$PATH $(STAGE1_FLAGS) $(MAKE) -C $(STAGE1_BUILD) USECLANG=1 USE_BINARYBUILDER_LLVM=0 && touch $@
 	@echo $(AFTER_STAGE1_MESSAGE)
 
-stage2: PGO_CFLAGS:=-fprofile-use=$(PROFILE_FILE)
-stage2: PGO_CXXFLAGS:=-fprofile-use=$(PROFILE_FILE)
-stage2: PGO_LDFLAGS:=-fuse-ld=lld -flto=thin -fprofile-use=$(PROFILE_FILE) -Wl,--icf=safe
-stage2: export USE_BINARYBUILDER_LLVM=0
 stage2: $(PROFILE_FILE) | $(STAGE2_BUILD)
-	$(MAKE) -C $(STAGE2_BUILD) $(TOOLCHAIN_FLAGS) && touch $@
+	PATH=$(STAGE0_TOOLS):$$PATH $(STAGE2_FLAGS) $(MAKE) -C $(STAGE2_BUILD) USECLANG=1 USE_BINARYBUILDER_LLVM=0 && touch $@
 
-install: stage2
-	$(MAKE) -C $(STAGE2_BUILD) USE_BINARYBUILDER_LLVM=0 install
+.DEFAULT: stage2
+	PATH=$(STAGE0_TOOLS):$$PATH $(STAGE2_FLAGS) $(MAKE) -C $(STAGE2_BUILD) USECLANG=1 USE_BINARYBUILDER_LLVM=0 $@
 
 $(PROFILE_FILE): stage1 $(PROFRAW_FILES)
 	$(LLVM_PROFDATA) merge -output=$@ $(PROFRAW_FILES)

--- a/contrib/pgo-lto/Makefile
+++ b/contrib/pgo-lto/Makefile
@@ -32,6 +32,8 @@ STAGE2_FLAGS:=LDFLAGS="-fuse-ld=lld -flto=thin -Wl,--undefined-version -fprofile
 			CFLAGS="-fprofile-use=$(PROFILE_FILE)" $\
 			CXXFLAGS="-fprofile-use=$(PROFILE_FILE)"
 
+COMMON_FLAGS:=USECLANG=1 USE_BINARYBUILDER_LLVM=0
+
 all: stage2 # Default target as first in file
 
 $(STAGE0_BUILD) $(STAGE1_BUILD) $(STAGE2_BUILD):
@@ -48,15 +50,15 @@ stage0: | $(STAGE0_BUILD)
 $(STAGE1_BUILD): stage0
 stage1: | $(STAGE1_BUILD)
 	@echo "--- Build Julia Stage 1 - with instrumentation"
-	PATH=$(STAGE0_TOOLS):$$PATH $(STAGE1_FLAGS) $(MAKE) -C $(STAGE1_BUILD) USECLANG=1 USE_BINARYBUILDER_LLVM=0 && touch $@
+	PATH=$(STAGE0_TOOLS):$$PATH $(STAGE1_FLAGS) $(MAKE) -C $(STAGE1_BUILD) $(COMMON_FLAGS) && touch $@
 	@echo $(AFTER_STAGE1_MESSAGE)
 
 stage2: $(PROFILE_FILE) | $(STAGE2_BUILD)
 	@echo "--- Build Julia Stage 2 - PGO + LTO optimised"
-	PATH=$(STAGE0_TOOLS):$$PATH $(STAGE2_FLAGS) $(MAKE) -C $(STAGE2_BUILD) USECLANG=1 USE_BINARYBUILDER_LLVM=0 && touch $@
+	PATH=$(STAGE0_TOOLS):$$PATH $(STAGE2_FLAGS) $(MAKE) -C $(STAGE2_BUILD) $(COMMON_FLAGS) && touch $@
 
 .DEFAULT: stage2
-	PATH=$(STAGE0_TOOLS):$$PATH $(STAGE2_FLAGS) $(MAKE) -C $(STAGE2_BUILD) USECLANG=1 USE_BINARYBUILDER_LLVM=0 $@
+	PATH=$(STAGE0_TOOLS):$$PATH $(STAGE2_FLAGS) $(MAKE) -C $(STAGE2_BUILD) $(COMMON_FLAGS) $@
 
 $(PROFILE_FILE): stage1 $(wildcard $(PROFILE_DIR)/*.profraw)
 	$(LLVM_PROFDATA) merge -output=$@ $(PROFILE_DIR)/*.profraw

--- a/contrib/pgo-lto/Makefile
+++ b/contrib/pgo-lto/Makefile
@@ -58,8 +58,8 @@ stage2: $(PROFILE_FILE) | $(STAGE2_BUILD)
 .DEFAULT: stage2
 	PATH=$(STAGE0_TOOLS):$$PATH $(STAGE2_FLAGS) $(MAKE) -C $(STAGE2_BUILD) USECLANG=1 USE_BINARYBUILDER_LLVM=0 $@
 
-$(PROFILE_FILE): stage1
-	$(LLVM_PROFDATA) merge -output=$@ $(PROFILE_DIR)/*.profraw
+$(PROFILE_FILE): stage1 $(wildcard $(PROFILE_DIR)/*.profraw)
+    $(LLVM_PROFDATA) merge -output=$@ $(PROFILE_DIR)/*.profraw
 
 # show top 50 functions
 top: $(PROFILE_FILE)


### PR DESCRIPTION
This fixes various issues with the PGO+LTO makefile
- `USECCACHE` doesn't work throwing an error at https://github.com/JuliaLang/julia/blob/eb5587dac02d1f6edf486a71b95149139cc5d9f7/Make.inc#L734 This is because setting `CC` and `CCX` by passing them as arguments to `make` prevents `Make.inc` from prepending these variables with `ccache` as `Make.inc` doesn't use override. To workaround this I instead set `USECLANG` and add the toolchain to the `PATH`.
- To deal with similar issues for the other make flags, I pass them as environment variables which can be edited in `Make.inc`.
- I add a way to build in one go by creating the `all` target, now you can just run `make` and a PGO+LTO build that profiles Julia's build will be generated.
- I workaround `PROFRAW_FILES` not being reevaluated after `stage1` builds, this caused the generation of `PROFILE_FILE` to run an outdated command if `stage1` was built and affected the profraw files. This is important when building in one go.
- I add a way to run rules like `binary-dist` which are not defined in this makefile with the correct toolchain which for example prevents `make binary-dist` from unnecessarily rebuilding `sys.ji`.
- Include `-Wl,--undefined-version` till https://github.com/JuliaLang/julia/issues/54533 gets fixed.

These changes need to be copied to the PGO+LTO+BOLT makefile and some to the BOLT makefile in a later pr.