### PR TITLE
fix a huge part of invalidation on defining a new `Integer` subtype

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -503,7 +503,7 @@ getindex(s::String, r::AbstractUnitRange{<:Integer}) = s[Int(first(r)):Int(last(
     end
     j = nextind(s, j) - 1
     n = j - i + 1
-    ss = _string_n(n)
+    ss = _string_n(n::Int)
     GC.@preserve s ss unsafe_copyto!(pointer(ss), pointer(s, i), n)
     return ss
 end


### PR DESCRIPTION
I have no idea why this helps, it really seems like Julia should be able to infer the type of `n` as `Int` on its own. Perhaps something to do with the `print`-related callers of `getindex` taking `Vararg` args?

MWE:

```julia
using SnoopCompileCore
length(@snoop_invalidations begin
    struct I <: Integer end
    Csize_t
    Csize_t(::I) = Csize_t(0)
end)
```

It returns `5806` before this change and `46` after the change.