### PR TITLE
Reset mtime of BOLTed files to prevent make rebuilding targets

### DIFF
--- a/contrib/bolt/Makefile
+++ b/contrib/bolt/Makefile
@@ -79,22 +79,21 @@ copy_originals: stage1
 
 # I don't think there's any particular reason to have -no-huge-pages here, perhaps slightly more accurate profile data
 # as the final build uses -no-huge-pages
+# We reset the mtime of the files to prevent make from rebuilding targets depending on them.
 bolt_instrument: copy_originals
 	for file in $(FILES_TO_OPTIMIZE); do \
 		abs_file=$(STAGE1_BUILD)/usr/lib/$$file; \
+		old_time=$$(stat -c %Y $$abs_file); \
 		$(LLVM_BOLT) "$$abs_file.original" -o $$abs_file --instrument --instrumentation-file-append-pid --instrumentation-file="$(PROFILE_DIR)/$$file-prof" -no-huge-pages; \
 		mkdir -p $$(dirname "$(PROFILE_DIR)/$$file-prof"); \
+		touch -d "@$$old_time" $$abs_file; \
 		printf "\n"; \
 	done && \
 	touch $@
 	@echo $(AFTER_INSTRUMENT_MESSAGE)
 
-# We don't want to rebuild julia-src as then we lose the bolt instrumentation
-# So we have to manually build the sysimage and package image
 finish_stage1: stage1
-	$(MAKE) -C $(STAGE1_BUILD) julia-base-cache && \
-	$(MAKE) -C $(STAGE1_BUILD) -f sysimage.mk sysimg-release && \
-	$(MAKE) -C $(STAGE1_BUILD) -f pkgimage.mk release
+	$(MAKE) -C $(STAGE1_BUILD)
 
 merge_data: bolt_instrument
 	for file in $(FILES_TO_OPTIMIZE); do \
@@ -108,10 +107,13 @@ merge_data: bolt_instrument
 # It tries to reuse old text segments to reduce binary size
 # BOLT doesn't fully support computed gotos https://github.com/llvm/llvm-project/issues/89117, so we cannot use --use-old-text on libjulia-internal
 # That flag saves less than 1 MiB for libjulia-internal so oh well.
+# We reset the mtime of the files to prevent make from rebuilding targets depending on them.
 bolt: merge_data
 	for file in $(FILES_TO_OPTIMIZE); do \
         abs_file=$(STAGE1_BUILD)/usr/lib/$$file; \
+		old_time=$$(stat -c %Y $$abs_file); \
 		$(LLVM_BOLT) "$$abs_file.original" -data "$(PROFILE_DIR)/$$file-prof.merged.fdata" -o $$abs_file $(BOLT_ARGS) $$(if [ "$$file" != $(shell readlink $(STAGE1_BUILD)/usr/lib/libjulia-internal.so) ]; then echo "--use-old-text -split-strategy=cdsplit"; fi); \
+		touch -d "@$$old_time" $$abs_file; \
     done && \
     touch $@
 

--- a/contrib/pgo-lto-bolt/Makefile
+++ b/contrib/pgo-lto-bolt/Makefile
@@ -123,25 +123,24 @@ copy_originals: stage2
 
 # I don't think there's any particular reason to have -no-huge-pages here, perhaps slightly more accurate profile data
 # as the final build uses -no-huge-pages
+# We reset the mtime of the files to prevent make from rebuilding targets depending on them.
 bolt_instrument: copy_originals
 	for file in $(FILES_TO_OPTIMIZE); do \
 		abs_file=$(STAGE2_BUILD)/usr/lib/$$file; \
+		old_time=$$(stat -c %Y $$abs_file); \
 		$(LLVM_BOLT) "$$abs_file.original" -o $$abs_file --instrument --instrumentation-file-append-pid --instrumentation-file="$(BOLT_PROFILE_DIR)/$$file-prof" -no-huge-pages; \
 		mkdir -p $$(dirname "$(BOLT_PROFILE_DIR)/$$file-prof"); \
+		touch -d "@$$old_time" $$abs_file; \
 		printf "\n"; \
 	done && \
 	touch $@
 	@echo $(AFTER_INSTRUMENT_MESSAGE)
 
-# We don't want to rebuild julia-src as then we lose the bolt instrumentation
-# So we have to manually build the sysimage and package image
 finish_stage2: PGO_CFLAGS:=-fprofile-use=$(PGO_PROFILE_FILE)
 finish_stage2: PGO_CXXFLAGS:=-fprofile-use=$(PGO_PROFILE_FILE)
 finish_stage2: PGO_LDFLAGS:=-flto=thin -fprofile-use=$(PGO_PROFILE_FILE) -Wl,--icf=safe
 finish_stage2: stage2
-	$(MAKE) -C $(STAGE2_BUILD) $(TOOLCHAIN_FLAGS) julia-base-cache && \
-	$(MAKE) -C $(STAGE2_BUILD) $(TOOLCHAIN_FLAGS) -f sysimage.mk sysimg-release && \
-	$(MAKE) -C $(STAGE2_BUILD) $(TOOLCHAIN_FLAGS) -f pkgimage.mk release
+	$(MAKE) -C $(STAGE2_BUILD) $(TOOLCHAIN_FLAGS)
 
 merge_data: bolt_instrument
 	for file in $(FILES_TO_OPTIMIZE); do \
@@ -155,10 +154,13 @@ merge_data: bolt_instrument
 # It tries to reuse old text segments to reduce binary size
 # BOLT doesn't fully support computed gotos https://github.com/llvm/llvm-project/issues/89117, so we cannot use --use-old-text on libjulia-internal
 # That flag saves less than 1 MiB for libjulia-internal so oh well.
+# We reset the mtime of the files to prevent make from rebuilding targets depending on them.
 bolt: merge_data
 	for file in $(FILES_TO_OPTIMIZE); do \
         abs_file=$(STAGE2_BUILD)/usr/lib/$$file; \
+		old_time=$$(stat -c %Y $$abs_file); \
 		$(LLVM_BOLT) "$$abs_file.original" -data "$(BOLT_PROFILE_DIR)/$$file-prof.merged.fdata" -o $$abs_file $(BOLT_ARGS) $$(if [ "$$file" != $(shell readlink $(STAGE2_BUILD)/usr/lib/libjulia-internal.so) ]; then echo "--use-old-text -split-strategy=cdsplit"; fi); \
+		touch -d "@$$old_time" $$abs_file; \
     done && \
     touch $@
 


### PR DESCRIPTION
This simplifies the `finish_stage` rule.