### PR TITLE
Call `pthread_attr_init` in `jl_init_stack_limits`

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -67,6 +67,7 @@ void jl_init_stack_limits(int ismaster, void **stack_lo, void **stack_hi)
 #  if defined(_OS_LINUX_) || defined(_OS_FREEBSD_)
         pthread_attr_t attr;
 #if defined(_OS_FREEBSD_)
+        pthread_attr_init(&attr);
         pthread_attr_get_np(pthread_self(), &attr);
 #else
         pthread_getattr_np(pthread_self(), &attr);


### PR DESCRIPTION
#55515 seems to have introduced segfaults on FreeBSD during the `atexit` and `ccall` tests. Prior to that PR, we had been calling `pthread_attr_init` in `jl_init_stack_limits` on FreeBSD. According to the [manual page](https://man.freebsd.org/cgi/man.cgi?query=pthread_attr_get_np&apropos=0&sektion=3&manpath=FreeBSD+13.2-RELEASE&arch=default&format=html) for `pthread_attr_get_np`, it is "HIGHLY RECOMMENDED" to use `pthread_attr_init` to allocate storage. Might as well put it back then, and hopefully it'll fix the segfaults.