### PR TITLE
Fast bounds-check for CartesianIndex ranges

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -754,11 +754,8 @@ checkindex(::Type{Bool}, inds::IdentityUnitRange, i::Real) = checkindex(Bool, in
 checkindex(::Type{Bool}, inds::OneTo{T}, i::T) where {T<:BitInteger} = unsigned(i - one(i)) < unsigned(last(inds))
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Colon) = true
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Slice) = true
-_checkindex_range(::Type{Bool}, inds, i::AbstractRange) =
+checkindex(::Type{Bool}, inds::AbstractUnitRange, i::AbstractRange) =
     isempty(i) | (checkindex(Bool, inds, first(i)) & checkindex(Bool, inds, last(i)))
-checkindex(::Type{Bool}, inds::AbstractUnitRange, i::AbstractRange) = _checkindex_range(Bool, inds, i)
-# generic fallback method for unusual range indices, e.g. CartesianIndex ranges
-checkindex(::Type{Bool}, inds, i::AbstractRange) = _checkindex_range(Bool, inds, i)
 # range like indices with cheap `extrema`
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i::LinearIndices) =
     isempty(i) | (checkindex(Bool, inds, first(i)) & checkindex(Bool, inds, last(i)))

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -754,8 +754,11 @@ checkindex(::Type{Bool}, inds::IdentityUnitRange, i::Real) = checkindex(Bool, in
 checkindex(::Type{Bool}, inds::OneTo{T}, i::T) where {T<:BitInteger} = unsigned(i - one(i)) < unsigned(last(inds))
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Colon) = true
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Slice) = true
-checkindex(::Type{Bool}, inds::AbstractUnitRange, i::AbstractRange) =
+_checkindex_range(::Type{Bool}, inds, i::AbstractRange) =
     isempty(i) | (checkindex(Bool, inds, first(i)) & checkindex(Bool, inds, last(i)))
+checkindex(::Type{Bool}, inds::AbstractUnitRange, i::AbstractRange) = _checkindex_range(Bool, inds, i)
+# generic fallback method for unusual range indices, e.g. CartesianIndex ranges
+checkindex(::Type{Bool}, inds, i::AbstractRange) = _checkindex_range(Bool, inds, i)
 # range like indices with cheap `extrema`
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i::LinearIndices) =
     isempty(i) | (checkindex(Bool, inds, first(i)) & checkindex(Bool, inds, last(i)))

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -730,6 +730,8 @@ end
 end
 @inline checkindex(::Type{Bool}, inds::Tuple, I::CartesianIndex) =
     checkbounds_indices(Bool, inds, I.I)
+@inline checkindex(::Type{Bool}, inds::Tuple, i::AbstractRange{<:CartesianIndex}) =
+    isempty(i) | (checkindex(Bool, inds, first(i)) & checkindex(Bool, inds, last(i)))
 
 # Indexing into Array with mixtures of Integers and CartesianIndices is
 # extremely performance-sensitive. While the abstract fallbacks support this,

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -1354,4 +1354,9 @@ end
     end
 end
 
+@testset "bounds-check with CartesianIndex ranges" begin
+    D = Diagonal(1:typemax(Int))
+    @test checkbounds(Bool, D, diagind(D, IndexCartesian()))
+end
+
 end # module TestDiagonal


### PR DESCRIPTION
`StepRangeLen{<:CartesianIndex}` indices have been supported since v1.11, but bounds-checking for such indices currently falls back to iterating over the entire range. This PR adds a quick `checkindex` for such ranges.

The performance improvement as a consequence:
```julia
julia> D = Diagonal(1:10_000);

julia> @btime checkbounds($D, diagind($D, IndexCartesian()));
  6.697 μs (0 allocations: 0 bytes) # nightly, O(n)
  4.044 ns (0 allocations: 0 bytes) # This PR, O(1)
```