### PR TITLE
Automatically enable JITPROFILING with ITTAPI

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -10435,7 +10435,9 @@ extern "C" void jl_init_llvm(void)
         }
     } else {
 #ifdef USE_ITTAPI
-        jl_using_intel_jitevents = __itt_get_collection_state() == __itt_collection_init_successful;
+        __itt_collection_state state = __itt_get_collection_state();
+        jl_using_intel_jitevents = state == __itt_collection_init_successful ||
+                                   state == __itt_collection_collector_exists;
 #endif
     }
 #endif

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -81,6 +81,10 @@
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/Linker/Linker.h>
 
+#ifdef USE_ITTAPI
+#include "ittapi/ittnotify.h"
+#endif
+
 using namespace llvm;
 
 static bool jl_fpo_disabled(const Triple &TT) {
@@ -10425,8 +10429,14 @@ extern "C" void jl_init_llvm(void)
     const char *jit_profiling = getenv("ENABLE_JITPROFILING");
 
 #if defined(JL_USE_INTEL_JITEVENTS)
-    if (jit_profiling && atoi(jit_profiling)) {
-        jl_using_intel_jitevents = 1;
+    if (jit_profiling) {
+        if (atoi(jit_profiling)) {
+            jl_using_intel_jitevents = 1;
+        }
+    } else {
+#ifdef USE_ITTAPI
+        jl_using_intel_jitevents = __itt_get_collection_state() == __itt_collection_init_successful;
+#endif
     }
 #endif
 


### PR DESCRIPTION
This helps when profiling remotely since VTunes doesn't support
setting environment variables on remote systems.

Will still respect `ENABLE_JITPROFILING=0`.
