### PR TITLE
provide access to @kwdef default values

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -633,7 +633,7 @@ macro kwdef(expr)
     return quote
         $(esc(:($Base.@__doc__ $expr)))
         $kwdefs
-        $(esc(:(Base.kwdef_defaults)))(::Type{$(esc(S))}) = (;$(filter(p -> isexpr(p, :kw), parameters)...))
+        $(esc(:($Base.kwdef_defaults)))(::Type{$(esc(S))}) = (;$(filter(p -> isexpr(p, :kw), parameters)...))
     end
 end
 

--- a/base/util.jl
+++ b/base/util.jl
@@ -542,6 +542,8 @@ _crc32c(x::UInt16, crc::UInt32=0x00000000) =
 _crc32c(x::UInt8, crc::UInt32=0x00000000) =
     ccall(:jl_crc32c, UInt32, (UInt32, Ref{UInt8}, Csize_t), crc, x, 1)
 
+function kwdef_defaults end
+
 """
     @kwdef typedef
 
@@ -603,6 +605,7 @@ macro kwdef(expr)
     if !isempty(parameters)
         T_no_esc = Meta.unescape(T)
         if T_no_esc isa Symbol
+            S = T
             sig = Expr(:call, esc(T), Expr(:parameters, parameters...))
             body = Expr(:block, __source__, Expr(:call, esc(T), fieldnames...))
             kwdefs = Expr(:function, sig, body)
@@ -630,6 +633,7 @@ macro kwdef(expr)
     return quote
         $(esc(:($Base.@__doc__ $expr)))
         $kwdefs
+        $(esc(:(Base.kwdef_defaults)))(::Type{$(esc(S))}) = (;$(filter(p -> isexpr(p, :kw), parameters)...))
     end
 end
 


### PR DESCRIPTION
As of now, there's no way to access default field values passed to @kwdef, aside from parsing the constructor signature (https://discourse.julialang.org/t/how-to-get-default-values-of-a-functions-kwargs/66158/2).

This PR adds `Base.kwdef_defaults(::Type) = (default fieldvals)` for all structs defined with `@kwdef`. This function can either be made public immediately, or remain internal for some time.

Fixes https://github.com/JuliaLang/julia/issues/50876. Useful in various cases, for example in pretty-printing: knowing the defaults makes it possible for user show() methods to omit fields with default values.

That's what `@kwdef` now expands to:
```julia
julia> @macroexpand @kwdef struct S
               a = 1
               b::Int = 2
               c
       end
quote
    #= REPL[22]:51 =#
    begin
        $(Expr(:meta, :doc))
        struct S
            #= REPL[25]:2 =#
            a
            #= REPL[25]:3 =#
            b::Int
            #= REPL[25]:4 =#
            c
        end
    end
    #= REPL[22]:52 =#
    function S(; a = 1, b = 2, c)
        #= REPL[25]:1 =#
        S(a, b, c)
    end
    #= REPL[22]:53 =#
    Base.kwdef_defaults(::Base.Type{S}) = begin
            #= REPL[22]:53 =#
            (; a = 1, b = 2)
        end
end
```