### PR TITLE
optimizer: don't insert `:throw_undef_if_not` for defined slots

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -6051,7 +6051,7 @@ end |> Core.Compiler.is_nothrow
 end |> Core.Compiler.is_nothrow
 
 # refine `undef` information from `@isdefined` check
-@test Base.infer_effects((Bool,Int)) do c, x
+function isdefined_nothrow(c, x)
     local val
     if c
         val = x
@@ -6060,7 +6060,11 @@ end |> Core.Compiler.is_nothrow
         return val
     end
     return zero(Int)
-end |> Core.Compiler.is_nothrow
+end
+@test Core.Compiler.is_nothrow(Base.infer_effects(isdefined_nothrow, (Bool,Int)))
+@test !any(first(only(code_typed(isdefined_nothrow, (Bool,Int)))).code) do @nospecialize x
+    Meta.isexpr(x, :throw_undef_if_not)
+end
 
 # End to end test case for the partially initialized struct with `PartialStruct`
 @noinline broadcast_noescape1(a) = (broadcast(identity, a); nothing)


### PR DESCRIPTION
As an application of JuliaLang/julia#55545, this commit avoids the insertion of `:throw_undef_if_not` nodes when the defined-ness of a slot is guaranteed by abstract interpretation.

```julia
julia> function isdefined_nothrow(c, x)
           local val
           if c
               val = x
           end
           if @isdefined val
               return val
           end
           return zero(Int)
       end;

julia> @code_typed isdefined_nothrow(true, 42)
```
```diff
diff --git a/old b/new
index c4980a5c9c..3d1d6d30f0 100644
--- a/old
+++ b/new
@@ -4,7 +4,6 @@ CodeInfo(
 3 ┄ %3 = φ (#2 => x, #1 => #undef)::Int64
 │   %4 = φ (#2 => true, #1 => false)::Bool
 └──      goto #5 if not %4
-4 ─      $(Expr(:throw_undef_if_not, :val, :(%4)))::Any
-└──      return %3
+4 ─      return %3
 5 ─      return 0
 ) => Int64
```