### PR TITLE
Unwrap parent in triangular broadcast

### DIFF
--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -268,7 +268,7 @@ end
 _preprocess_broadcasted_offdiag(bc::Broadcast.Broadcasted) = Broadcast.broadcasted(bc.f, map(_preprocess_broadcasted_offdiag, bc.args)...)
 # Reduce terms like UpperTrianguar(Diagonal([1,2,3])) to 0 away from the diagonal
 _preprocess_broadcasted_offdiag(U::UpperOrLowerTriangular) = _preprocess_broadcasted_offdiag(parent(U))
-_preprocess_broadcasted_offdiag(D::BandedMatrix) = haszero(eltype(D)) ? zero(eltype(D)) : D
+_preprocess_broadcasted_offdiag(D::BandedMatrix) = haszero(eltype(D)) ? (size(D) == (1,1) ? D[1,1] : zero(eltype(D))) : D
 _preprocess_broadcasted_offdiag(x) = x
 function copyto!(dest::LowerTriangular, bc::Broadcasted{<:StructuredMatrixStyle})
     isvalidstructbc(dest, bc) || return copyto!(dest, convert(Broadcasted{Nothing}, bc))

--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -274,8 +274,6 @@ function copyto!(dest::LowerTriangular, bc::Broadcasted{<:StructuredMatrixStyle}
     isvalidstructbc(dest, bc) || return copyto!(dest, convert(Broadcasted{Nothing}, bc))
     axs = axes(dest)
     axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
-    # we process the Broadcasted object to extract the parents of LowerTriangular matrices
-    # this is because we only access the triangular half in the following section
     bc2 = _preprocess_broadcasted_offdiag(bc)
     for j in axs[2]
         @inbounds dest.data[j,j] = bc[BandIndex(0, j)]
@@ -293,8 +291,6 @@ function copyto!(dest::UpperTriangular, bc::Broadcasted{<:StructuredMatrixStyle}
     isvalidstructbc(dest, bc) || return copyto!(dest, convert(Broadcasted{Nothing}, bc))
     axs = axes(dest)
     axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
-    # we process the Broadcasted object to extract the parents of UpperTriangular matrices
-    # this is because we only access the triangular half in the following section
     bc2 = _preprocess_broadcasted_offdiag(bc)
     for j in axs[2]
         for i in 1:j-2

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -329,10 +329,11 @@ end
         @test D .+ Diag == M .+ Diag
         @test D .- Diag == M .- Diag
         @test Diag .- D == Diag .- M
-        Bidiag = Bidiagonal(diag(D), diag(D,1), :U)
-        @test D .+ Bidiag == M .+ Bidiag
-        @test D .- Bidiag == M .- Bidiag
-        @test Bidiag .- D == Bidiag .- M
+        # enable when diag(D, 1) works for block matrices
+        # Bidiag = Bidiagonal(diag(D), diag(D,1), :U)
+        # @test D .+ Bidiag == M .+ Bidiag
+        # @test D .- Bidiag == M .- Bidiag
+        # @test Bidiag .- D == Bidiag .- M
     end
     @testset "Diagonal" begin
         @testset "square" begin

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -324,6 +324,15 @@ end
         @test (x -> 1).(D) == ones(Int,size(D))
         @test all(==(2), ndims.(D))
         @test_throws MethodError size.(D)
+
+        Diag = Diagonal(diag(D))
+        @test D .+ Diag == M .+ Diag
+        @test D .- Diag == M .- Diag
+        @test Diag .- D == Diag .- M
+        Bidiag = Bidiagonal(diag(D), diag(D,1), :U)
+        @test D .+ Bidiag == M .+ Bidiag
+        @test D .- Bidiag == M .- Bidiag
+        @test Bidiag .- D == Bidiag .- M
     end
     @testset "Diagonal" begin
         @testset "square" begin
@@ -358,10 +367,12 @@ end
         B = Bidiagonal(fill(A,3), fill(A,2), :U)
         standardbroadcastingtests(B, Bidiagonal)
     end
-    @testset "UpperTriangular" begin
+    @testset "AbstractTriangular" begin
         A = [1 3; 2 4]
         U = UpperTriangular([(i+j)*A for i in 1:3, j in 1:3])
         standardbroadcastingtests(U, UpperTriangular)
+        L = LowerTriangular([(i+j)*A for i in 1:3, j in 1:3])
+        standardbroadcastingtests(L, LowerTriangular)
     end
 end
 


### PR DESCRIPTION
This replaces `AbstractTriangular` matrices by their parents in certain broadcast operations, where we only loop over the filled half. We also replace `Diagonal`/`Bidiagonal`/`Tridiaognal`/`SymTridiagonal` matrices by the corresponding zeros away from the bands. As a consequence, this removes branching in the indexing operations in the broadcast, which improves performance considerably.

```julia
julia> using LinearAlgebra

julia> U = UpperTriangular(rand(3000,3000)); D = Diagonal(rand(size(U,1)));

julia> @btime $U .+ $D;
  23.295 ms (3 allocations: 68.66 MiB) # nightly
  15.305 ms (3 allocations: 68.66 MiB) # This PR

julia> @btime parent($U) .+ $D; # dense matrix broadcast for reference
  26.637 ms (3 allocations: 68.66 MiB)
``` 
Also
```julia
julia> @btime UpperTriangular($D) .+ UpperTriangular($D);
  30.613 ms (3 allocations: 68.66 MiB) # nightly
  14.669 ms (3 allocations: 68.66 MiB) # This PR
```

Most of the performance gain comes from replacing the `Diagonal` by `zero(eltype(D))` in the broadcasting. It's a bit surprising that branch-prediction doesn't do this already. 