### PR TITLE
Convert triangular inv test comparison to isapprox

### DIFF
--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -903,7 +903,7 @@ end
     function test_one_oneunit_triangular(a)
         b = Matrix(a)
         @test (@inferred a^1) == b^1
-        @test (@inferred a^-1) == b^-1
+        @test (@inferred a^-1) ≈ b^-1
         @test one(a) == one(b)
         @test one(a)*a == a
         @test a*one(a) == a


### PR DESCRIPTION
The failing test was noticed in https://github.com/JuliaLang/julia/pull/55607. The comparison will only hold approximately in general, as the inverses are computed differently.