### PR TITLE
Make jl_static_show_func_sig more robust

### DIFF
--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1403,6 +1403,7 @@ size_t jl_static_show_func_sig_(JL_STREAM *s, jl_value_t *type, jl_static_show_c
         return n;
     }
     if ((jl_nparams(ftype) == 0 || ftype == ((jl_datatype_t*)ftype)->name->wrapper) &&
+            ((jl_datatype_t*)ftype)->name->mt &&
             ((jl_datatype_t*)ftype)->name->mt != jl_type_type_mt &&
             ((jl_datatype_t*)ftype)->name->mt != jl_nonfunction_mt) {
         n += jl_static_show_symbol(s, ((jl_datatype_t*)ftype)->name->mt->name);


### PR DESCRIPTION
Fixes a crash in existing compiler tests when build with debug symbols. More generally, this function is used for C-side debugging so should be robust to unexpected data. (In this particular case the signature in question was a plain `Tuple{Any}` from the opaque closure test).