### PR TITLE
Specialize newindex for StructuredMatrix broadcasting

### DIFF
--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -199,6 +199,8 @@ function Broadcast.newindex(A::StructuredMatrix, b::BandIndex)
     # and we apply newindex to both the axes at once to obtain the result
     size(A,1) > 1 ? b : BandIndex(0, 1)
 end
+# Simplify newindex computation for square StructuredMatrix types
+Broadcast.newindex(D::StructuredMatrix, I::CartesianIndex{2}) = size(D) == (1,1) ? CartesianIndex(1,1) : I
 
 function copyto!(dest::Diagonal, bc::Broadcasted{<:StructuredMatrixStyle})
     isvalidstructbc(dest, bc) || return copyto!(dest, convert(Broadcasted{Nothing}, bc))

--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -199,7 +199,7 @@ function Broadcast.newindex(A::StructuredMatrix, b::BandIndex)
     # and we apply newindex to both the axes at once to obtain the result
     size(A,1) > 1 ? b : BandIndex(0, 1)
 end
-# Simplify newindex computation for square StructuredMatrix types
+# All structured matrices are square, and therefore they only broadcast out if they are size (1, 1)
 Broadcast.newindex(D::StructuredMatrix, I::CartesianIndex{2}) = size(D) == (1,1) ? CartesianIndex(1,1) : I
 
 function copyto!(dest::Diagonal, bc::Broadcasted{<:StructuredMatrixStyle})


### PR DESCRIPTION
This provides most of the benefits seen in https://github.com/JuliaLang/julia/pull/55604. The simpler implementation appears to help with branch-prediction in inferring the zero elements of the structured matrices.
The improved performance as a consequence:
```julia
julia> using LinearAlgebra

julia> U = UpperTriangular(rand(3000,3000)); D = Diagonal(rand(size(U,1)));

julia> @btime $U .+ $D;
  23.405 ms (3 allocations: 68.66 MiB) # nightly
  15.266 ms (3 allocations: 68.66 MiB) # This PR
```
