### PR TITLE
Infer eltype from diag element in off-diag bands for structured matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -409,13 +409,7 @@ function diag(M::Bidiagonal{T}, n::Integer=0) where T
     elseif (n == 1 && M.uplo == 'U') ||  (n == -1 && M.uplo == 'L')
         return copyto!(similar(M.ev, length(M.ev)), M.ev)
     elseif -size(M,1) <= n <= size(M,1)
-        # We compute the element type as zero(M[1,1]) if !haszero(T)
-        # This only works as we limit n to abs(n) <= size(M,1), instead of allowing arbitrary values
-        # The limit ensures that n>0 is allowed only if M has at least one element
-        v = similar(M.dv, typeof(_zero(M, 1, 1)), size(M,1)-abs(n))
-        for i in eachindex(v)
-            v[i] = M[BandIndex(n,i)]
-        end
+        v = Base.collect_similar(M, (M[BandIndex(n,i)] for i in 1:size(M,1)-abs(n)))
         return v
     else
         throw(ArgumentError(LazyString(lazy"requested diagonal, $n, must be at least $(-size(M, 1)) ",

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -401,7 +401,7 @@ function triu!(M::Bidiagonal{T}, k::Integer=0) where T
     return M
 end
 
-function diag(M::Bidiagonal{T}, n::Integer=0) where T
+Base.@constprop :aggressive function diag(M::Bidiagonal{T}, n::Integer=0) where T
     # every branch call similar(..., ::Int) to make sure the
     # same vector type is returned independent of n
     if n == 0
@@ -409,8 +409,7 @@ function diag(M::Bidiagonal{T}, n::Integer=0) where T
     elseif (n == 1 && M.uplo == 'U') ||  (n == -1 && M.uplo == 'L')
         return copyto!(similar(M.ev, length(M.ev)), M.ev)
     elseif -size(M,1) <= n <= size(M,1)
-        v = Base.collect_similar(M, (M[BandIndex(n,i)] for i in 1:size(M,1)-abs(n)))
-        return v
+        return Base.collect_similar(M.dv, (M[BandIndex(n,i)] for i in 1:size(M,1)-abs(n)))
     else
         throw(ArgumentError(LazyString(lazy"requested diagonal, $n, must be at least $(-size(M, 1)) ",
             lazy"and at most $(size(M, 2)) for an $(size(M, 1))-by-$(size(M, 2)) matrix")))

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -409,7 +409,10 @@ function diag(M::Bidiagonal{T}, n::Integer=0) where T
     elseif (n == 1 && M.uplo == 'U') ||  (n == -1 && M.uplo == 'L')
         return copyto!(similar(M.ev, length(M.ev)), M.ev)
     elseif -size(M,1) <= n <= size(M,1)
-        v = similar(M.dv, size(M,1)-abs(n))
+        # We compute the element type as zero(M[1,1]) if !haszero(T)
+        # This only works as we limit n to abs(n) <= size(M,1), instead of allowing arbitrary values
+        # The limit ensures that n>0 is allowed only if M has at least one element
+        v = similar(M.dv, typeof(_zero(M, 1, 1)), size(M,1)-abs(n))
         for i in eachindex(v)
             v[i] = M[BandIndex(n,i)]
         end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -753,7 +753,10 @@ function diag(D::Diagonal{T}, k::Integer=0) where T
     if k == 0
         return copyto!(similar(D.diag, length(D.diag)), D.diag)
     elseif -size(D,1) <= k <= size(D,1)
-        v = similar(D.diag, size(D,1)-abs(k))
+        # We compute the element type as zero(D[1,1]) if !haszero(T)
+        # This only works as we limit k to abs(k) <= size(D,1), instead of allowing arbitrary values
+        # The limit ensures that k>0 is allowed only if D has at least one element
+        v = similar(D.diag, typeof(_zero(D, 1, 1)), size(D,1)-abs(k))
         for i in eachindex(v)
             v[i] = D[BandIndex(k, i)]
         end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -753,14 +753,7 @@ function diag(D::Diagonal{T}, k::Integer=0) where T
     if k == 0
         return copyto!(similar(D.diag, length(D.diag)), D.diag)
     elseif -size(D,1) <= k <= size(D,1)
-        # We compute the element type as zero(D[1,1]) if !haszero(T)
-        # This only works as we limit k to abs(k) <= size(D,1), instead of allowing arbitrary values
-        # The limit ensures that k>0 is allowed only if D has at least one element
-        v = similar(D.diag, typeof(_zero(D, 1, 1)), size(D,1)-abs(k))
-        for i in eachindex(v)
-            v[i] = D[BandIndex(k, i)]
-        end
-        return v
+        return Base.collect_similar(D.diag, (D[BandIndex(k,i)] for i in 1:size(D,1)-abs(k)))
     else
         throw(ArgumentError(LazyString(lazy"requested diagonal, $k, must be at least $(-size(D, 1)) ",
             lazy"and at most $(size(D, 2)) for an $(size(D, 1))-by-$(size(D, 2)) matrix")))

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -198,7 +198,10 @@ function diag(M::SymTridiagonal{T}, n::Integer=0) where T<:Number
     elseif absn == 1
         return copyto!(similar(M.ev, length(M.dv)-1), _evview(M))
     elseif absn <= size(M,1)
-        v = similar(M.dv, size(M,1)-absn)
+        # We compute the element type as zero(M[1,1]) if !haszero(T)
+        # This only works as we limit n to abs(n) <= size(M,1), instead of allowing arbitrary values
+        # The limit ensures that n>0 is allowed only if M has at least one element
+        v = similar(M.dv, typeof(_zero(M, 1, 1)), size(M,1)-absn)
         for i in eachindex(v)
             v[i] = M[BandIndex(n,i)]
         end
@@ -664,7 +667,10 @@ function diag(M::Tridiagonal{T}, n::Integer=0) where T
     elseif n == 1
         return copyto!(similar(M.du, length(M.du)), M.du)
     elseif abs(n) <= size(M,1)
-        v = similar(M.d, size(M,1)-abs(n))
+        # We compute the element type as zero(M[1,1]) if !haszero(T)
+        # This only works as we limit n to abs(n) <= size(M,1), instead of allowing arbitrary values
+        # The limit ensures that n>0 is allowed only if M has at least one element
+        v = similar(M.d, typeof(_zero(M, 1, 1)), size(M,1)-abs(n))
         for i in eachindex(v)
             v[i] = M[BandIndex(n,i)]
         end

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -198,14 +198,7 @@ function diag(M::SymTridiagonal{T}, n::Integer=0) where T<:Number
     elseif absn == 1
         return copyto!(similar(M.ev, length(M.dv)-1), _evview(M))
     elseif absn <= size(M,1)
-        # We compute the element type as zero(M[1,1]) if !haszero(T)
-        # This only works as we limit n to abs(n) <= size(M,1), instead of allowing arbitrary values
-        # The limit ensures that n>0 is allowed only if M has at least one element
-        v = similar(M.dv, typeof(_zero(M, 1, 1)), size(M,1)-absn)
-        for i in eachindex(v)
-            v[i] = M[BandIndex(n,i)]
-        end
-        return v
+        return Base.collect_similar(M.dv, (M[BandIndex(n,i)] for i in 1:size(M,1)-absn))
     else
         throw_diag_outofboundserror(n, size(M))
     end
@@ -667,14 +660,7 @@ function diag(M::Tridiagonal{T}, n::Integer=0) where T
     elseif n == 1
         return copyto!(similar(M.du, length(M.du)), M.du)
     elseif abs(n) <= size(M,1)
-        # We compute the element type as zero(M[1,1]) if !haszero(T)
-        # This only works as we limit n to abs(n) <= size(M,1), instead of allowing arbitrary values
-        # The limit ensures that n>0 is allowed only if M has at least one element
-        v = similar(M.d, typeof(_zero(M, 1, 1)), size(M,1)-abs(n))
-        for i in eachindex(v)
-            v[i] = M[BandIndex(n,i)]
-        end
-        return v
+        return Base.collect_similar(M.d, (M[BandIndex(n,i)] for i in 1:size(M,1)-abs(n)))
     else
         throw(ArgumentError(LazyString(lazy"requested diagonal, $n, must be at least $(-size(M, 1)) ",
             lazy"and at most $(size(M, 2)) for an $(size(M, 1))-by-$(size(M, 2)) matrix")))


### PR DESCRIPTION
This allows the zero `diag` bands for `StructuredMatrix`es to have a different `eltype` from the filled bands, which is useful when the `eltype` of the matrix does not have a `zero`. The implementation depends on the fact that currently we don't allow `diag` bands beyond the size of the matrix.
This permits use cases like
```julia
julia> using LinearAlgebra, Static

julia> D = Diagonal(fill(static(1), 4))
4×4 Diagonal{StaticInt{1}, Vector{StaticInt{1}}}:
 static(1)      ⋅          ⋅          ⋅    
     ⋅      static(1)      ⋅          ⋅    
     ⋅          ⋅      static(1)      ⋅    
     ⋅          ⋅          ⋅      static(1)

julia> diag(D,1)
3-element Vector{StaticInt{0}}:
 static(0)
 static(0)
 static(0)
```