### PR TITLE
fixes/cleanup for use-system-unwind make flags

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1096,15 +1096,12 @@ else ifneq ($(DISABLE_LIBUNWIND), 0)
 LIBUNWIND:=
 else
 LIBUNWIND:=-lunwind
-ifeq ($(USE_SYSTEM_LIBUNWIND), 1)
-ifneq ($(OS),Darwin)
-# Only for linux since we want to use not yet released libunwind features
-JCFLAGS+=-DSYSTEM_LIBUNWIND
-JCPPFLAGS+=-DSYSTEM_LIBUNWIND
-endif
-endif
 ifneq ($(findstring $(OS),Darwin OpenBSD),)
 JCPPFLAGS+=-DLLVMLIBUNWIND
+else ifeq ($(USE_SYSTEM_LIBUNWIND), 1)
+# Only for linux and freebsd since we want to use not yet released gnu libunwind features
+JCFLAGS+=-DSYSTEM_LIBUNWIND
+JCPPFLAGS+=-DSYSTEM_LIBUNWIND
 endif
 endif
 

--- a/Make.inc
+++ b/Make.inc
@@ -1095,20 +1095,16 @@ LIBUNWIND:=
 else ifneq ($(DISABLE_LIBUNWIND), 0)
 LIBUNWIND:=
 else
+LIBUNWIND:=-lunwind
 ifeq ($(USE_SYSTEM_LIBUNWIND), 1)
 ifneq ($(OS),Darwin)
-LIBUNWIND:=-lunwind
 # Only for linux since we want to use not yet released libunwind features
 JCFLAGS+=-DSYSTEM_LIBUNWIND
 JCPPFLAGS+=-DSYSTEM_LIBUNWIND
 endif
-else
-ifneq ($(findstring $(OS),Darwin OpenBSD),)
-LIBUNWIND:=-lunwind
-JCPPFLAGS+=-DLLVMLIBUNWIND
-else
-LIBUNWIND:=-lunwind
 endif
+ifneq ($(findstring $(OS),Darwin OpenBSD),)
+JCPPFLAGS+=-DLLVMLIBUNWIND
 endif
 endif
 


### PR DESCRIPTION
Assuming non-windows and libunwind not disabled:

The flag `-DLLVMLIBUNWIND` is currently set on macos only for `USE_SYSTEM_UNWIND=0` which seems wrong to me and causes build issues for macos on Yggdrasil in combination with the recent https://github.com/JuliaLang/julia/pull/55049 which should only affect gnu libunwind (`error: call to undeclared function 'unw_ensure_tls'`).
This flag is now set independently of the system-libunwind flag (on Darwin and OpenBSD as before).

`LIBUNWIND=-lunwind` is set for `USE_SYSTEM_UNWIND=0` || `USE_SYSTEM_UNWIND=1` && `OS != Darwin`.
I don't think the check for Darwin make sense and might be a leftover from using osxunwind a (long) while ago.
Changed that to always set `-lunwind` if enabled.

x-ref: https://github.com/JuliaPackaging/Yggdrasil/pull/9331