### PR TITLE
Forward istriu/istril for triangular to parent

### DIFF
--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -569,5 +569,5 @@ function cholesky(S::RealHermSymComplexHerm{<:Real,<:SymTridiagonal}, ::NoPivot 
 end
 
 # istriu/istril for triangular wrappers of structured matrices
-_istril(A::BandedMatrix, k, ::Val{'L'}) = istril(A, k)
-_istriu(A::BandedMatrix, k, ::Val{'U'}) = istriu(A, k)
+_istril(A::LowerTriangular{<:Any, <:BandedMatrix}, k) = istril(parent(A), k)
+_istriu(A::UpperTriangular{<:Any, <:BandedMatrix}, k) = istriu(parent(A), k)

--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -567,3 +567,7 @@ function cholesky(S::RealHermSymComplexHerm{<:Real,<:SymTridiagonal}, ::NoPivot 
     B = Bidiagonal{T}(diag(S, 0), diag(S, S.uplo == 'U' ? 1 : -1), sym_uplo(S.uplo))
     cholesky!(Hermitian(B, sym_uplo(S.uplo)), NoPivot(); check = check)
 end
+
+# istriu/istril for triangular wrappers of structured matrices
+_istril(A::BandedMatrix, k, ::Val{'L'}) = istril(A, k)
+_istriu(A::BandedMatrix, k, ::Val{'U'}) = istriu(A, k)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -332,11 +332,11 @@ end
 
 Base.@constprop :aggressive function istril(A::Union{LowerTriangular,UnitLowerTriangular}, k::Integer=0)
     k >= 0 && return true
-    return _istril(A, k)
+    return istril(parent(U), k)
 end
 Base.@constprop :aggressive function istriu(A::Union{UpperTriangular,UnitUpperTriangular}, k::Integer=0)
     k <= 0 && return true
-    return _istriu(A, k)
+    return istriu(parent(A), k)
 end
 istril(A::Adjoint, k::Integer=0) = istriu(A.parent, -k)
 istril(A::Transpose, k::Integer=0) = istriu(A.parent, -k)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -334,7 +334,7 @@ istril(A::UnitLowerTriangular, k::Integer=0) = k >= 0
 istriu(A::UnitUpperTriangular, k::Integer=0) = k <= 0
 Base.@constprop :aggressive function istril(A::LowerTriangular, k::Integer=0)
     k >= 0 && return true
-    _istril(A, k)
+    return _istril(A, k)
 end
 @inline function _istril(A::LowerTriangular, k)
     P = parent(A)
@@ -346,7 +346,7 @@ end
 end
 Base.@constprop :aggressive function istriu(A::UpperTriangular, k::Integer=0)
     k <= 0 && return true
-    _istriu(A, k)
+    return _istriu(A, k)
 end
 @inline function _istriu(A::UpperTriangular, k)
     P = parent(A)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -334,23 +334,25 @@ istril(A::UnitLowerTriangular, k::Integer=0) = k >= 0
 istriu(A::UnitUpperTriangular, k::Integer=0) = k <= 0
 Base.@constprop :aggressive function istril(A::LowerTriangular, k::Integer=0)
     k >= 0 && return true
-    _istril(parent(A), k, Val('L'))
+    _istril(A, k)
 end
-@inline function _istril(A, k, ::Val{'L'})
+@inline function _istril(A::LowerTriangular, k)
+    P = parent(A)
     m = size(A, 1)
     for j in max(1, k + 2):m
-        all(iszero, view(A, j:min(j - k - 1, m), j)) || return false
+        all(iszero, view(P, j:min(j - k - 1, m), j)) || return false
     end
     return true
 end
 Base.@constprop :aggressive function istriu(A::UpperTriangular, k::Integer=0)
     k <= 0 && return true
-    _istriu(parent(A), k, Val('U'))
+    _istriu(A, k)
 end
-@inline function _istriu(A, k, ::Val{'U'})
+@inline function _istriu(A::UpperTriangular, k)
+    P = parent(A)
     m = size(A, 1)
     for j in 1:min(m, m + k - 1)
-        all(iszero, view(A, max(1, j - k + 1):j, j)) || return false
+        all(iszero, view(P, max(1, j - k + 1):j, j)) || return false
     end
     return true
 end

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -1228,4 +1228,21 @@ end
     end
 end
 
+@testset "istriu/istril for structured parents" begin
+    for M in [Tridiagonal(rand(n-1), rand(n), rand(n-1)),
+                Tridiagonal(zeros(n-1), zeros(n), zeros(n-1)),
+                Diagonal(randn(n)),
+                Diagonal(zeros(n)),
+                ]
+        for TriT in (UpperTriangular, UnitUpperTriangular, LowerTriangular, UnitLowerTriangular)
+            U = TriT(M)
+            A = Array(U)
+            for k in -(n-1):n-1
+                @test istriu(U, k) == istriu(A, k)
+                @test istril(U, k) == istril(A, k)
+            end
+        end
+    end
+end
+
 end # module TestTriangular

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -1228,19 +1228,30 @@ end
     end
 end
 
-@testset "istriu/istril for structured parents" begin
-    for M in [Tridiagonal(rand(n-1), rand(n), rand(n-1)),
+@testset "istriu/istril forwards to parent" begin
+    @testset "$(nameof(typeof(M)))" for M in [Tridiagonal(rand(n-1), rand(n), rand(n-1)),
                 Tridiagonal(zeros(n-1), zeros(n), zeros(n-1)),
                 Diagonal(randn(n)),
                 Diagonal(zeros(n)),
                 ]
-        for TriT in (UpperTriangular, UnitUpperTriangular, LowerTriangular, UnitLowerTriangular)
+        @testset for TriT in (UpperTriangular, UnitUpperTriangular, LowerTriangular, UnitLowerTriangular)
             U = TriT(M)
             A = Array(U)
-            for k in -(n-1):n-1
+            for k in -n:n
                 @test istriu(U, k) == istriu(A, k)
                 @test istril(U, k) == istril(A, k)
             end
+        end
+    end
+    z = zeros(n,n)
+    @testset for TriT in (UpperTriangular, UnitUpperTriangular, LowerTriangular, UnitLowerTriangular)
+        P = Matrix{BigFloat}(undef, n, n)
+        copytrito!(P, z, TriT <: Union{UpperTriangular, UnitUpperTriangular} ? 'U' : 'L')
+        U = TriT(P)
+        A = Array(U)
+        @testset for k in -n:n
+            @test istriu(U, k) == istriu(A, k)
+            @test istril(U, k) == istril(A, k)
         end
     end
 end


### PR DESCRIPTION
Since an `AbstractTriangular` forwards `getindex` to its parent for the stored half, we may forward `istriu/istril` to the parent as well. This may let us access optimized methods for the parent.
E.g.:
```julia
julia> using LinearAlgebra

julia> U = UpperTriangular(Diagonal(zeros(1000)));

julia> @btime istriu($U,2);
  306.667 μs (0 allocations: 0 bytes) # nightly
  481.897 ns (0 allocations: 0 bytes) # This PR
```