### PR TITLE
Reuse size-check function from `lacpy!` in `copytrito!`

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -2014,20 +2014,12 @@ function copytrito!(B::AbstractMatrix, A::AbstractMatrix, uplo::AbstractChar)
     m1,n1 = size(B)
     A = Base.unalias(B, A)
     if uplo == 'U'
-        if n < m
-            (m1 < n || n1 < n) && throw(DimensionMismatch(lazy"B of size ($m1,$n1) should have at least size ($n,$n)"))
-        else
-            (m1 < m || n1 < n) && throw(DimensionMismatch(lazy"B of size ($m1,$n1) should have at least size ($m,$n)"))
-        end
+        LAPACK.lacpy_size_check((m1, n1), (n < m ? n : m, n))
         for j in 1:n, i in 1:min(j,m)
             @inbounds B[i,j] = A[i,j]
         end
     else # uplo == 'L'
-        if m < n
-            (m1 < m || n1 < m) && throw(DimensionMismatch(lazy"B of size ($m1,$n1) should have at least size ($m,$m)"))
-        else
-            (m1 < m || n1 < n) && throw(DimensionMismatch(lazy"B of size ($m1,$n1) should have at least size ($m,$n)"))
-        end
+        LAPACK.lacpy_size_check((m1, n1), (m, m < n ? m : n))
         for j in 1:n, i in j:m
             @inbounds B[i,j] = A[i,j]
         end


### PR DESCRIPTION
Since there is a size-check function in `lacpy!` that does the same thing, we may reuse it instead of duplicating the check