### PR TITLE
Revert "Make the memory GEP an inbounds GEP since the bounds check has happened somewhere else"

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -4280,8 +4280,9 @@ static jl_cgval_t emit_memoryref(jl_codectx_t &ctx, const jl_cgval_t &ref, jl_cg
             ovflw = ctx.builder.CreateICmpUGE(ctx.builder.CreateAdd(offset, mlen), ctx.builder.CreateNUWAdd(mlen, mlen));
         }
 #endif
+        //Is this change fine
         boffset = ctx.builder.CreateMul(offset, elsz);
-        newdata = ctx.builder.CreateInBoundsGEP(getInt8Ty(ctx.builder.getContext()), data, boffset);
+        newdata = ctx.builder.CreateGEP(getInt8Ty(ctx.builder.getContext()), data, boffset);
         (void)boffset; // LLVM is very bad at handling GEP with types different from the load
         if (bc) {
             BasicBlock *failBB, *endBB;


### PR DESCRIPTION
Reverts JuliaLang/julia#55107

This PR adds UB to julia by creating out of bounds GEPs when we will fail the bounds check. LLVM is then able to assume that this never happens. 

We can maybe split the Memoryref of the load with the one from the bounds check to make this change more legal