### PR TITLE
inference: fixes and improvements for exct modeling of `invoke`/OC calls

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2181,6 +2181,9 @@ function abstract_invoke(interp::AbstractInterpreter, arginfo::ArgInfo, si::Stmt
     rt = from_interprocedural!(interp, rt, sv, arginfo, sig)
     info = InvokeCallInfo(match, const_result)
     edge !== nothing && add_invoke_backedge!(sv, lookupsig, edge)
+    if !match.fully_covers
+        effects = Effects(effects; nothrow=false)
+    end
     return CallMeta(rt, Any, effects, info)
 end
 

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2339,7 +2339,7 @@ function abstract_call_opaque_closure(interp::AbstractInterpreter,
     ocargsig′ = unwrap_unionall(ocargsig)
     ocargsig′ isa DataType || return CallMeta(Any, Any, Effects(), NoCallInfo())
     ocsig = rewrap_unionall(Tuple{Tuple, ocargsig′.parameters...}, ocargsig)
-    hasintersect(sig, ocsig) || return CallMeta(Union{}, TypeError, EFFECTS_THROWS, NoCallInfo())
+    hasintersect(sig, ocsig) || return CallMeta(Union{}, Union{MethodError,TypeError}, EFFECTS_THROWS, NoCallInfo())
     ocmethod = closure.source::Method
     result = abstract_call_method(interp, ocmethod, sig, Core.svec(), false, si, sv)
     (; rt, edge, effects, volatile_inf_result) = result

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -6109,3 +6109,13 @@ oc_exct_2() = Base.Experimental.@opaque Tuple{Number}->Number (x) -> '1'
 @test Base.infer_exception_type((Int,)) do x
     oc_exct_2()(x)
 end == TypeError
+
+# nothrow modeling for `invoke` calls
+f_invoke_nothrow(::Number) = :number
+f_invoke_nothrow(::Int) = :int
+@test Base.infer_effects((Int,)) do x
+    @invoke f_invoke_nothrow(x::Number)
+end |> Core.Compiler.is_nothrow
+@test Base.infer_effects((Union{Nothing,Int},)) do x
+    @invoke f_invoke_nothrow(x::Number)
+end |> !Core.Compiler.is_nothrow

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -6078,9 +6078,7 @@ gcondvarargs(a, x...) = return fcondvarargs(a, x...) ? isa(a, Int64) : !isa(a, I
 @test Core.Compiler.return_type(gcondvarargs, Tuple{Vararg{Any}}) === Bool
 
 # JuliaLang/julia#55627: argtypes check in `abstract_call_opaque_closure`
-issue55627_some_method(x) = 2x
-issue55627_make_oc() = Base.Experimental.@opaque (x::Int)->issue55627_some_method(x)
-
+issue55627_make_oc() = Base.Experimental.@opaque (x::Int) -> 2x
 @test Base.infer_return_type() do
     f = issue55627_make_oc()
     return f(1), f()
@@ -6099,9 +6097,7 @@ end >: MethodError
 end >: TypeError
 
 # `exct` modeling for opaque closure
-oc_exct_1() = Base.Experimental.@opaque function (x)
-        return x < 0 ? throw(x) : x
-    end
+oc_exct_1() = Base.Experimental.@opaque (x) -> x < 0 ? throw(x) : x
 @test Base.infer_exception_type((Int,)) do x
     oc_exct_1()(x)
 end == Int
@@ -6116,6 +6112,28 @@ f_invoke_nothrow(::Int) = :int
 @test Base.infer_effects((Int,)) do x
     @invoke f_invoke_nothrow(x::Number)
 end |> Core.Compiler.is_nothrow
+@test Base.infer_effects((Char,)) do x
+    @invoke f_invoke_nothrow(x::Number)
+end |> !Core.Compiler.is_nothrow
 @test Base.infer_effects((Union{Nothing,Int},)) do x
     @invoke f_invoke_nothrow(x::Number)
 end |> !Core.Compiler.is_nothrow
+
+# `exct` modeling for `invoke` calls
+f_invoke_exct(x::Number) = x < 0 ? throw(x) : x
+f_invoke_exct(x::Int) = x
+@test Base.infer_exception_type((Int,)) do x
+    @invoke f_invoke_exct(x::Number)
+end == Int
+@test Base.infer_exception_type() do
+    @invoke f_invoke_exct(42::Number)
+end == Union{}
+@test Base.infer_exception_type((Union{Nothing,Int},)) do x
+    @invoke f_invoke_exct(x::Number)
+end == Union{Int,TypeError}
+@test Base.infer_exception_type((Int,)) do x
+    invoke(f_invoke_exct, Number, x)
+end == TypeError
+@test Base.infer_exception_type((Char,)) do x
+    invoke(f_invoke_exct, Tuple{Number}, x)
+end == TypeError

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -6089,3 +6089,11 @@ end == Union{}
     f = issue55627_make_oc()
     return f(1), f(xs...)
 end == Tuple{Int,Int}
+@test Base.infer_exception_type() do
+    f = issue55627_make_oc()
+    return f(1), f()
+end >: MethodError
+@test Base.infer_exception_type() do
+    f = issue55627_make_oc()
+    return f(1), f('1')
+end >: TypeError

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -6097,3 +6097,15 @@ end >: MethodError
     f = issue55627_make_oc()
     return f(1), f('1')
 end >: TypeError
+
+# `exct` modeling for opaque closure
+oc_exct_1() = Base.Experimental.@opaque function (x)
+        return x < 0 ? throw(x) : x
+    end
+@test Base.infer_exception_type((Int,)) do x
+    oc_exct_1()(x)
+end == Int
+oc_exct_2() = Base.Experimental.@opaque Tuple{Number}->Number (x) -> '1'
+@test Base.infer_exception_type((Int,)) do x
+    oc_exct_2()(x)
+end == TypeError


### PR DESCRIPTION
- fix exct for mismatched opaque closure call: bfeaa277e3c9ed28c642f1fa209e2038367a1811 (following up #55672 )
- improve exct modeling for opaque closure calls: 7a65218b0b1796b2bd722204f5f03ed661267607
- fix `nothrow` modeling for `invoke` calls: 6916bc1bf3e3aa049484e7f3af7c38e2458527e9
- improve `exct` modeling for `invoke` calls: 7b2d5d966fb9f3081e0ca6b2259c086bf84bfab4