### PR TITLE
Make GEP when loading the PTLS an inbounds one.

### DIFF
--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -128,7 +128,7 @@ Instruction *LowerPTLS::emit_pgcstack_tp(Value *offset, Instruction *insertBefor
             offset = ConstantInt::getSigned(T_size, jl_tls_offset);
         auto tp = InlineAsm::get(FunctionType::get(PointerType::get(builder.getContext(), 0), false), asm_str, "=r", false);
         tls = builder.CreateCall(tp, {}, "thread_ptr");
-        tls = builder.CreateGEP(Type::getInt8Ty(builder.getContext()), tls, {offset}, "tls_ppgcstack");
+        tls = builder.CreateInBoundsGEP(Type::getInt8Ty(builder.getContext()), tls, {offset}, "tls_ppgcstack");
     }
     return builder.CreateLoad(T_pppjlvalue, tls, "tls_pgcstack");
 }


### PR DESCRIPTION
Non inbounds GEPs should only be used when doing pointer arithmethic i.e Ptr or MemoryRef boundscheck.
Found when auditing non inbounds GEPs for https://github.com/JuliaLang/julia/pull/55681