### PR TITLE
Profile.print: Shorten C paths too

### DIFF
--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -56,6 +56,8 @@ global STDLIB::String = "$BINDIR/../share/julia/stdlib/v$(VERSION.major).$(VERSI
 # In case STDLIB change after julia is built, the variable below can be used
 # to update cached method locations to updated ones.
 const BUILD_STDLIB_PATH = STDLIB
+# Similarly, this is the root of the julia repo directory that julia was built from
+const BUILD_ROOT_PATH = "$BINDIR/../.."
 
 # helper to avoid triggering precompile warnings
 

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -503,13 +503,22 @@ function flatten(data::Vector, lidict::LineInfoDict)
     return (newdata, newdict)
 end
 
+const SRC_DIR = normpath(joinpath(Sys.BUILD_ROOT_PATH, "src"))
+const LIB_DIR = normpath(joinpath(Sys.BUILD_ROOT_PATH, "usr", "lib"))
+
 # Take a file-system path and try to form a concise representation of it
 # based on the package ecosystem
 function short_path(spath::Symbol, filenamecache::Dict{Symbol, Tuple{String,String,String}})
     return get!(filenamecache, spath) do
         path = Base.fixup_stdlib_path(string(spath))
         possible_base_path = normpath(joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "base", path))
-        if isabspath(path)
+        if startswith(path, SRC_DIR)
+            remainder = only(split(path, SRC_DIR, keepempty=false))
+            return (isfile(path) ? path : ""), "@src", remainder
+        elseif startswith(path, LIB_DIR)
+            remainder = only(split(path, LIB_DIR, keepempty=false))
+            return (isfile(path) ? path : ""), "@lib", remainder
+        elseif isabspath(path)
             if ispath(path)
                 # try to replace the file-system prefix with a short "@Module" one,
                 # assuming that profile came from the current machine

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -504,20 +504,21 @@ function flatten(data::Vector, lidict::LineInfoDict)
 end
 
 const SRC_DIR = normpath(joinpath(Sys.BUILD_ROOT_PATH, "src"))
-const LIB_DIR = normpath(joinpath(Sys.BUILD_ROOT_PATH, "usr", "lib"))
 
 # Take a file-system path and try to form a concise representation of it
 # based on the package ecosystem
 function short_path(spath::Symbol, filenamecache::Dict{Symbol, Tuple{String,String,String}})
     return get!(filenamecache, spath) do
         path = Base.fixup_stdlib_path(string(spath))
+        path_norm = normpath(path)
         possible_base_path = normpath(joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "base", path))
-        if startswith(path, SRC_DIR)
-            remainder = only(split(path, SRC_DIR, keepempty=false))
-            return (isfile(path) ? path : ""), "@src", remainder
-        elseif startswith(path, LIB_DIR)
-            remainder = only(split(path, LIB_DIR, keepempty=false))
-            return (isfile(path) ? path : ""), "@lib", remainder
+        lib_dir = abspath(Sys.BINDIR, Base.LIBDIR)
+        if startswith(path_norm, SRC_DIR)
+            remainder = only(split(path_norm, SRC_DIR, keepempty=false))
+            return (isfile(path_norm) ? path_norm : ""), "@juliasrc", remainder
+        elseif startswith(path_norm, lib_dir)
+            remainder = only(split(path_norm, lib_dir, keepempty=false))
+            return (isfile(path_norm) ? path_norm : ""), "@julialib", remainder
         elseif isabspath(path)
             if ispath(path)
                 # try to replace the file-system prefix with a short "@Module" one,


### PR DESCRIPTION
Follow-on from https://github.com/JuliaLang/julia/pull/55335
Shortens C paths that reside in `src` and `usr/lib`.
If the files exist on the machine they are links, if not they aren't.

## This PR
![Screenshot 2024-09-04 at 10 19 22 AM](https://github.com/user-attachments/assets/d3dbfc4a-8848-47b4-a7e8-cd33f90c0efb)

## Master
![Screenshot 2024-09-03 at 10 11 49 PM](https://github.com/user-attachments/assets/3d93ac8e-53a7-4601-8d19-38be2a9b660f)

Also note how messy it is on an official build of 1.10.5 (and a whole load of dropped frames..)
![Screenshot 2024-09-03 at 10 23 22 PM](https://github.com/user-attachments/assets/f2b71dee-7b7c-4602-b670-a5ca2638a923)
