### PR TITLE
Adding `JL_DATA_TYPE` annotation to `_jl_globalref_t`

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -718,6 +718,7 @@ typedef struct _jl_module_t {
 } jl_module_t;
 
 struct _jl_globalref_t {
+    JL_DATA_TYPE
     jl_module_t *mod;
     jl_sym_t *name;
     jl_binding_t *binding;


### PR DESCRIPTION
`_jl_globalref_t` seems to be allocated in the heap, and there is an object `jl_globalref_type` which indicates that it is in fact, a data type, thus it should be annotated with `JL_DATA_TYPE`??