### PR TITLE
contrib: include private libdir in `ldflags` on macOS

### DIFF
--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -67,9 +67,7 @@ function ldlibs(doframework)
         "julia"
     end
     if Sys.isunix()
-        return "-Wl,-rpath,$(shell_escape(libDir())) " *
-            (Sys.isapple() ? string() : "-Wl,-rpath,$(shell_escape(private_libDir())) ") *
-            "-l$libname"
+        return "-Wl,-rpath,$(shell_escape(libDir())) -Wl,-rpath,$(shell_escape(private_libDir())) -l$libname"
     else
         return "-l$libname -lopenlibm"
     end


### PR DESCRIPTION
The private libdir is used on macOS, so it needs to be included in our `ldflags`