### PR TITLE
Make threadpoolsize(), threadpooltids(), and ngcthreads() public

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -3,7 +3,7 @@
 export threadid, nthreads, @threads, @spawn,
        threadpool, nthreadpools
 
-public Condition
+public Condition, threadpoolsize, ngcthreads
 
 """
     Threads.threadid([t::Task]) -> Int


### PR DESCRIPTION
`threadpoolsize()` and `ngcthreads()` were already in the docs anyway, and `threadpooltids()` is useful for checking which threads belong to a pool.