### PR TITLE
Add precompile signatures to Markdown to reduce latency. 

### DIFF
--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -124,7 +124,23 @@ catdoc(md::MD...) = MD(md...)
 
 if Base.generating_output()
     # workload to reduce latency
-    md"**Here is some markdown**..."
+    md"""
+    # H1
+    ## H2
+    ### H3
+    **bold text**
+    *italicized text*
+    > blockquote
+    1. First item
+    2. Second item
+    3. Third item
+    - First item
+    - Second item
+    - Third item
+    `code`
+    Horizontal Rule
+    ---
+    """
 end
 
 end

--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -123,7 +123,8 @@ import Base.Docs: catdoc
 catdoc(md::MD...) = MD(md...)
 
 if Base.generating_output()
-    md""  # workload to trigger precompile
+    # (representive) workload to trigger precompile; from Pkg.REPLMode.gen_help()
+    md"**Welcome to the Pkg REPL-mode** .."
 end
 
 end

--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -123,7 +123,7 @@ import Base.Docs: catdoc
 catdoc(md::MD...) = MD(md...)
 
 if Base.generating_output()
-    # (representive) workload to trigger precompile; from Pkg.REPLMode.gen_help()
+    # (representative) workload to trigger precompile; from Pkg.REPLMode.gen_help()
     md"**Welcome to the Pkg REPL-mode** .."
 end
 

--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -122,4 +122,26 @@ import Base.Docs: catdoc
 
 catdoc(md::MD...) = MD(md...)
 
+
+precompile(Tuple{typeof(Markdown.mdexpr), String})
+precompile(Tuple{typeof(Markdown.hashheader), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
+precompile(Tuple{typeof(Markdown.list), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
+precompile(Tuple{typeof(Markdown.fencedcode), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
+precompile(Tuple{typeof(Markdown.blockquote), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
+precompile(Tuple{typeof(Markdown.admonition), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
+precompile(Tuple{typeof(Markdown.blocktex), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
+precompile(Tuple{typeof(Markdown.blockinterp), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
+precompile(Tuple{typeof(Markdown.indentcode), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
+precompile(Tuple{typeof(Markdown.footnote), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
+
+#=  145.1 ms =# precompile(Tuple{typeof(Markdown.github_table), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
+
+precompile(Tuple{typeof(Markdown.horizontalrule), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
+precompile(Tuple{typeof(Markdown.setextheader), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
+precompile(Tuple{typeof(Markdown.paragraph), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
+
+precompile(Tuple{typeof(Markdown.toexpr), Markdown.Paragraph})
+precompile(Tuple{typeof(Markdown.toexpr), Array{Any, 1}})
+precompile(Tuple{typeof(Markdown.toexpr), String})
+
 end

--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -123,7 +123,7 @@ import Base.Docs: catdoc
 catdoc(md::MD...) = MD(md...)
 
 if Base.generating_output()
-    dummy = md""  # workload to trigger precompile
+    md""  # workload to trigger precompile
 end
 
 end

--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -123,8 +123,8 @@ import Base.Docs: catdoc
 catdoc(md::MD...) = MD(md...)
 
 if Base.generating_output()
-    # (representative) workload to trigger precompile; from Pkg.REPLMode.gen_help()
-    md"**Welcome to the Pkg REPL-mode** .."
+    # workload to reduce latency
+    md"**Here is some markdown**..."
 end
 
 end

--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -122,26 +122,8 @@ import Base.Docs: catdoc
 
 catdoc(md::MD...) = MD(md...)
 
-
-precompile(Tuple{typeof(Markdown.mdexpr), String})
-precompile(Tuple{typeof(Markdown.hashheader), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
-precompile(Tuple{typeof(Markdown.list), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
-precompile(Tuple{typeof(Markdown.fencedcode), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
-precompile(Tuple{typeof(Markdown.blockquote), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
-precompile(Tuple{typeof(Markdown.admonition), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
-precompile(Tuple{typeof(Markdown.blocktex), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
-precompile(Tuple{typeof(Markdown.blockinterp), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
-precompile(Tuple{typeof(Markdown.indentcode), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
-precompile(Tuple{typeof(Markdown.footnote), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
-
-#=  145.1 ms =# precompile(Tuple{typeof(Markdown.github_table), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
-
-precompile(Tuple{typeof(Markdown.horizontalrule), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
-precompile(Tuple{typeof(Markdown.setextheader), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
-precompile(Tuple{typeof(Markdown.paragraph), Base.GenericIOBuffer{Memory{UInt8}}, Markdown.MD})
-
-precompile(Tuple{typeof(Markdown.toexpr), Markdown.Paragraph})
-precompile(Tuple{typeof(Markdown.toexpr), Array{Any, 1}})
-precompile(Tuple{typeof(Markdown.toexpr), String})
+if Base.generating_output()
+    dummy = md""  # workload to trigger precompile
+end
 
 end


### PR DESCRIPTION
Fixes #55706 that is seemingly a 4472x regression, not just 16x (was my first guess, based on CondaPkg, also fixes or greatly mitigates https://github.com/JuliaPy/CondaPkg.jl/issues/145), and large part of 3x regression for PythonCall.