### PR TITLE
Fix regression of Pkg and more

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -81,6 +81,9 @@ precompile(Base.get_preferences, (Base.UUID,))
 precompile(Base.record_compiletime_preference, (Base.UUID, String))
 
 # miscellaneous
+precompile(Tuple{typeof(Base.setindex!), Base.EnvDict, Bool, String})
+precompile(Tuple{typeof(Base.first), Array{Any, 1}})
+precompile(Tuple{typeof(Base.print), Base.TTY, String})
 precompile(Tuple{typeof(Base.exit)})
 precompile(Tuple{typeof(Base.require), Base.PkgId})
 precompile(Tuple{typeof(Base.recursive_prefs_merge), Base.Dict{String, Any}})


### PR DESCRIPTION
Please add to 1.11 backport, because (Markdown and) Pkg are used by code, such as PythonCall (indirectly), not just interactively.

This is emitted for Pkg and Markdown:
precompile(Tuple{typeof(Base.setindex!), Base.EnvDict, Bool, String})

This one too for Pkg:
precompile(Tuple{typeof(Base.first), Array{Any, 1}})

I do not add to Pkg section, it and REPL one seem should not exist... from when they where in the sysimage? Those precompiles should still likely still be in, since useful for other code, might be moved into misc too.


This may not be strictly needed, I've (only?) seen this when exiting the REPL:
precompile(Tuple{typeof(Base.print), Base.TTY, String})

I didn't time any of these yet, a difference when in the sysimage, or how much larger it gets, e.g. for that last one.