### PR TITLE
Don't pass lSystem to the linker since macos always links it

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -25,8 +25,6 @@ else ifeq ($(OS),FreeBSD)
 LOADER_LDFLAGS += -Wl,--no-as-needed -ldl -lpthread -rdynamic -lc -Wl,--as-needed
 else ifeq ($(OS),OpenBSD)
 LOADER_LDFLAGS += -Wl,--no-as-needed -lpthread -rdynamic -lc -Wl,--as-needed
-else ifeq ($(OS),Darwin)
-LOADER_LDFLAGS += -lSystem
 endif
 
 # Build list of dependent libraries that must be opened


### PR DESCRIPTION
This stops it complaing about duplicated libs. 

For libunwind there isn't much we can do because it's part of lsystem and we also need out own.