### PR TITLE
Fix `make binary-dist` when using `USE_BINARYBUILDER_LLVM=0`

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -292,7 +292,9 @@ ifeq ($(OS),Darwin)
 # https://github.com/JuliaLang/julia/issues/29981
 LLVM_INSTALL += && ln -s libLLVM.dylib $2$$(build_shlibdir)/libLLVM-$$(LLVM_VER_SHORT).dylib
 endif
+ifeq ($(BUILD_LLD), 1)
 LLVM_INSTALL += && cp $2$$(build_shlibdir)/lld$$(EXE) $2$$(build_depsbindir)
+endif
 
 $(eval $(call staged-install, \
 	llvm,$$(LLVM_SRC_DIR)/build_$$(LLVM_BUILDTYPE), \

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -292,6 +292,7 @@ ifeq ($(OS),Darwin)
 # https://github.com/JuliaLang/julia/issues/29981
 LLVM_INSTALL += && ln -s libLLVM.dylib $2$$(build_shlibdir)/libLLVM-$$(LLVM_VER_SHORT).dylib
 endif
+LLVM_INSTALL += && cp $2$$(build_shlibdir)/lld$$(EXE) $2$$(build_depsbindir)
 
 $(eval $(call staged-install, \
 	llvm,$$(LLVM_SRC_DIR)/build_$$(LLVM_BUILDTYPE), \

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -293,7 +293,7 @@ ifeq ($(OS),Darwin)
 LLVM_INSTALL += && ln -s libLLVM.dylib $2$$(build_shlibdir)/libLLVM-$$(LLVM_VER_SHORT).dylib
 endif
 ifeq ($(BUILD_LLD), 1)
-LLVM_INSTALL += && cp $2$$(build_shlibdir)/lld$$(EXE) $2$$(build_depsbindir)
+LLVM_INSTALL += && cp $2$$(build_bindir)/lld$$(EXE) $2$$(build_depsbindir)
 endif
 
 $(eval $(call staged-install, \


### PR DESCRIPTION
`make binary-dist` expects lld to be in usr/tools but it ends up in usr/bin so I copied it into usr/tools. Should fix the scheduled source tests which currently fail at linking.

I think this is also broken with `USE_BINARYBUILDER_LLVM=0` and `BUILD_LLD=0`, maybe https://github.com/JuliaLang/julia/commit/ceaeb7b71bc76afaca2f3b80998164a47e30ce33 is the fix?