### PR TITLE
Fix "Various fixes to byte / bytearray search" 

### DIFF
--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -178,7 +178,7 @@ function findall(
     i = firstindex(s)
     while true
         i = _search(s, byte, i)
-        iszero(i) && return result
+        isnothing(i) && return result
         i += 1
         index = i - ncu
         # If the char is invalid, it's possible that its first byte is


### PR DESCRIPTION
Fixes the conflict between #54593 and #54579
`_search` returns `nothing` instead of zero as a sentinal in #54579
