### PR TITLE
Don't leave trailing whitespace when printing do-block expr

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -2196,8 +2196,12 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
     elseif head === :do && nargs == 2
         iob = IOContext(io, beginsym=>false)
         show_unquoted(iob, args[1], indent, -1, quote_level)
-        print(io, " do ")
-        show_list(iob, (((args[2]::Expr).args[1])::Expr).args, ", ", 0, 0, quote_level)
+        print(io, " do")
+        do_args = (((args[2]::Expr).args[1])::Expr).args
+        if !isempty(do_args)
+            print(io, ' ')
+            show_list(iob, do_args, ", ", 0, 0, quote_level)
+        end
         for stmt in (((args[2]::Expr).args[2])::Expr).args
             print(io, '\n', " "^(indent + indent_width))
             show_unquoted(iob, stmt, indent + indent_width, -1, quote_level)

--- a/test/show.jl
+++ b/test/show.jl
@@ -2772,5 +2772,4 @@ end
 @testset "show(<do-block expr>) no trailing whitespace" begin
     do_expr1 = :(foo() do; bar(); end)
     @test !contains(sprint(show, do_expr1), " \n")
-    @test sprint(show, do_expr1) == "foo() do\n    bar()\nend"
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -2768,3 +2768,9 @@ let topmi = ccall(:jl_new_method_instance_uninit, Ref{Core.MethodInstance}, ());
     topmi.def = Main
     @test contains(repr(topmi), "Toplevel MethodInstance")
 end
+
+@testset "show(<do-block expr>) no trailing whitespace" begin
+    do_expr1 = :(foo() do; bar(); end)
+    @test !contains(sprint(show, do_expr1), " \n")
+    @test sprint(show, do_expr1) == "foo() do\n    bar()\nend"
+end


### PR DESCRIPTION
This is pretty niche, but... I was programmatically constructing code and writing it out to a file and it left trailing white-space which a linter (/ git pre-commit hook) complained about, so i had to add a second pass stripping white-space... i thought we could instead just change the printing to avoid leaving trailing white-space. 

Before, when printing a `do`-block, we'd print a white-space after `do` even if no arguments follow. Now we don't print that space. 