### PR TITLE
Add `invokelatest` barrier to `string(...)` in `@assert`

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -232,12 +232,12 @@ macro assert(ex, msgs...)
         msg = msg # pass-through
     elseif !isempty(msgs) && (isa(msg, Expr) || isa(msg, Symbol))
         # message is an expression needing evaluating
-        msg = :(Main.Base.string($(esc(msg))))
+        msg = :(Main.Base.invokelatest(Main.Base.string, $(esc(msg))))
     elseif isdefined(Main, :Base) && isdefined(Main.Base, :string) && applicable(Main.Base.string, msg)
         msg = Main.Base.string(msg)
     else
         # string() might not be defined during bootstrap
-        msg = :(_assert_tostring($(Expr(:quote,msg))))
+        msg = :(Main.Base.invokelatest(_assert_tostring, $(Expr(:quote,msg))))
     end
     return :($(esc(ex)) ? $(nothing) : throw(AssertionError($msg)))
 end


### PR DESCRIPTION
This change protects `@assert` from invalidations to `Base.string(...)` by adding an `invokelatest` barrier.

A common source of invalidations right now is `print(io, join(args...))`. The problem is:
1. Inference concludes that `join(::Any...)` returns `Union{String,AnnotatedString}`
2. The `print` call is union-split to `String` and `AnnotatedString`
3. This code is now invalidated when StyledStrings defines `print(io, ::AnnotatedString)`

The invalidation chain for `@assert` is similar: ` @assert 1 == 1` calls into `string(::Expr)` which calls into `print(io, join(args::Any...))`. Unfortunately that leads to the invalidation of almost all `@assert`s without an explicit error message

Similar to https://github.com/JuliaLang/julia/pull/55583#issuecomment-2308969806