### PR TITLE
Add some loading / LazyArtifacts precompiles to the sysimage

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -42,6 +42,13 @@ precompile(Base.indexed_iterate, (Pair{Symbol, Union{Nothing, String}}, Int, Int
 precompile(Tuple{typeof(Base.Threads.atomic_add!), Base.Threads.Atomic{Int}, Int})
 precompile(Tuple{typeof(Base.Threads.atomic_sub!), Base.Threads.Atomic{Int}, Int})
 
+# LazyArtifacts (but more generally helpful)
+precompile(Tuple{Type{Base.Val{x} where x}, Module})
+precompile(Tuple{Type{NamedTuple{(:honor_overrides,), T} where T<:Tuple}, Tuple{Bool}})
+precompile(Tuple{typeof(Base.unique!), Array{String, 1}})
+precompile(Tuple{typeof(Base.invokelatest), Any})
+precompile(Tuple{typeof(Base.vcat), Array{String, 1}, Array{String, 1}})
+
 # Pkg loading
 precompile(Tuple{typeof(Base.Filesystem.normpath), String, String, Vararg{String}})
 precompile(Tuple{typeof(Base.append!), Array{String, 1}, Array{String, 1}})


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/55725

These help LazyArtifacts mainly but seem beneficial for the sysimage.

## master
```
% julia +nightly --start=no -e "using InteractiveUtils; @time @time_imports using MicroMamba"
      0.7 ms  Printf
     16.2 ms  Dates
      0.4 ms  Scratch
      0.7 ms  TOML
               ┌ 0.0 ms NetworkOptions.__init__()
      1.5 ms  NetworkOptions
               ┌ 0.9 ms MbedTLS_jll.__init__()
      3.3 ms  MbedTLS_jll
               ┌ 0.6 ms LibSSH2_jll.__init__()
      2.5 ms  LibSSH2_jll
               ┌ 1.1 ms LibGit2_jll.__init__()
      3.3 ms  LibGit2_jll
      8.5 ms  LibGit2
      6.3 ms  ArgTools
               ┌ 0.7 ms nghttp2_jll.__init__()
      2.4 ms  nghttp2_jll
               ┌ 0.7 ms LibCURL_jll.__init__()
      2.7 ms  LibCURL_jll
               ┌ 0.0 ms MozillaCACerts_jll.__init__()
      2.0 ms  MozillaCACerts_jll
               ┌ 0.0 ms LibCURL.__init__()
      1.1 ms  LibCURL
               ┌ 3.4 ms Downloads.Curl.__init__()
     18.7 ms  Downloads
      0.8 ms  Tar
               ┌ 0.1 ms p7zip_jll.__init__()
      2.8 ms  p7zip_jll
      0.3 ms  UUIDs
      0.2 ms  Logging
               ┌ 0.0 ms Pkg.__init__()
    180.1 ms  Pkg
      0.4 ms  LazyArtifacts
      7.7 ms  Preferences
      0.4 ms  JLLWrappers
               ┌ 128.4 ms micromamba_jll.__init__() 99.80% compilation time (9% recompilation)
    209.4 ms  micromamba_jll 99.54% compilation time (23% recompilation)
      0.5 ms  MicroMamba
  0.514519 seconds (1.26 M allocations: 73.194 MiB, 13.64% gc time, 41.43% compilation time: 25% of which was recompilation)
```

## master with https://github.com/JuliaPackaging/LazyArtifacts.jl/pull/1
```
% ./julia --start=no --trace-compile=stderr --trace-compile-timing -e "using InteractiveUtils; @time @time_imports using MicroMamba"
      0.5 ms  Printf
     15.0 ms  Dates
      0.3 ms  Scratch
     10.0 ms  LazyArtifacts
      1.0 ms  TOML
      7.2 ms  Preferences
      0.5 ms  JLLWrappers
               ┌ 545.2 ms micromamba_jll.__init__() 99.93% compilation time (88% recompilation)
    545.7 ms  micromamba_jll 99.84% compilation time (88% recompilation)
      0.4 ms  MicroMamba
  0.586889 seconds (763.19 k allocations: 40.931 MiB, 5.56% gc time, 92.84% compilation time: 88% of which was recompilation)
```

## https://github.com/JuliaLang/julia/pull/55739 with https://github.com/JuliaPackaging/LazyArtifacts.jl/pull/1
```
% ./julia --start=no -e "using InteractiveUtils; @time @time_imports using MicroMamba"
      0.7 ms  Printf
     21.5 ms  Dates
      0.5 ms  Scratch
     14.9 ms  LazyArtifacts
      0.9 ms  TOML
      8.7 ms  Preferences
      0.5 ms  JLLWrappers
               ┌ 44.7 ms micromamba_jll.__init__() 99.60% compilation time (3% recompilation)
     45.3 ms  micromamba_jll 98.17% compilation time (3% recompilation)
      0.4 ms  MicroMamba
  0.129260 seconds (177.54 k allocations: 9.573 MiB, 34.42% compilation time: 3% of which was recompilation)
```

## This PR with https://github.com/JuliaLang/julia/pull/55739 and https://github.com/JuliaPackaging/LazyArtifacts.jl/pull/1
```
% ./julia --start=no -e "using InteractiveUtils; @time @time_imports using MicroMamba"
      0.5 ms  Printf
     18.9 ms  Dates
      0.3 ms  Scratch
     11.9 ms  LazyArtifacts
      0.6 ms  TOML
      7.6 ms  Preferences
      0.8 ms  JLLWrappers
               ┌ 0.1 ms micromamba_jll.__init__()
      0.8 ms  micromamba_jll
      0.4 ms  MicroMamba
  0.054467 seconds (67.72 k allocations: 3.673 MiB)
```
 


