### PR TITLE
Markdown: support `parse(::AbstractString)`

### DIFF
--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -56,7 +56,8 @@ const MARKDOWN_FACES = [
 
 __init__() = foreach(addface!, MARKDOWN_FACES)
 
-parse(markdown::AbstractString; flavor = julia) = parse(IOBuffer(markdown), flavor = flavor)
+parse(markdown::String; flavor = julia) = parse(IOBuffer(markdown), flavor = flavor)
+parse(markdown::AbstractString; flavor = julia) = parse(String(markdown), flavor = flavor)
 parse_file(file::AbstractString; flavor = julia) = parse(read(file, String), flavor = flavor)
 
 function mdexpr(s, flavor = :julia)

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1308,3 +1308,7 @@ end
     # https://github.com/JuliaLang/julia/issues/37757
     @test insert_hlines(nothing) === nothing
 end
+
+@testset "Lazy Strings" begin
+    @test Markdown.parse(lazy"foo") == Markdown.parse("foo")
+end


### PR DESCRIPTION
`Markdown.parse` is documented to accept `AbstractString` but it was implemented by calling `IOBuffer` on the string argument.  `IOBuffer`, however, is documented only for `String` arguments.

This commit changes the current `parse(::AbstractString)` to `parse(::String)` and implements `parse(::AbstractString)` by converting the argument to `String`.

Now, even `LazyString`s can be parsed to Markdown representation.

Fixes #55732