### PR TITLE
Improve printing of several arguments

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -137,7 +137,6 @@ function print_to_string(xs...)
         return ""
     end
     siz = sum(_str_sizehint, xs; init = 0)
-    # specialized for performance reasons
     s = IOBuffer(sizehint=siz)
     print(s, xs...)
     String(_unsafe_take!(s))

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -42,9 +42,7 @@ end
 function print(io::IO, xs...)
     lock(io)
     try
-        foreach(xs) do x
-            print(io, x)
-        end
+        foreach(Fix1(print, io), xs)
     finally
         unlock(io)
     end
@@ -134,20 +132,14 @@ function _str_sizehint(x)
     end
 end
 
-function _str_sizehints(xs...)
-    mapreduce(_str_sizehint, +, xs; init = 0)
-end
-
 function print_to_string(xs...)
     if isempty(xs)
         return ""
     end
-    siz = _str_sizehints(xs...)
+    siz = sum(_str_sizehint, xs; init = 0)
     # specialized for performance reasons
     s = IOBuffer(sizehint=siz)
-    foreach(xs) do x
-        print(s, x)
-    end
+    print(s, xs...)
     String(_unsafe_take!(s))
 end
 
@@ -155,13 +147,11 @@ function string_with_env(env, xs...)
     if isempty(xs)
         return ""
     end
-    siz = _str_sizehints(xs...)
+    siz = sum(_str_sizehint, xs; init = 0)
     # specialized for performance reasons
     s = IOBuffer(sizehint=siz)
     env_io = IOContext(s, env)
-    foreach(xs) do x
-        print(env_io, x)
-    end
+    print(env_io, xs...)
     String(_unsafe_take!(s))
 end
 

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -147,7 +147,6 @@ function string_with_env(env, xs...)
         return ""
     end
     siz = sum(_str_sizehint, xs; init = 0)
-    # specialized for performance reasons
     s = IOBuffer(sizehint=siz)
     env_io = IOContext(s, env)
     print(env_io, xs...)

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -134,14 +134,15 @@ function _str_sizehint(x)
     end
 end
 
+function _str_sizehints(xs...)
+    mapreduce(_str_sizehint, +, xs; init = 0)
+end
+
 function print_to_string(xs...)
     if isempty(xs)
         return ""
     end
-    siz::Int = 0
-    for x in xs
-        siz += _str_sizehint(x)
-    end
+    siz = _str_sizehints(xs...)
     # specialized for performance reasons
     s = IOBuffer(sizehint=siz)
     foreach(xs) do x
@@ -154,10 +155,7 @@ function string_with_env(env, xs...)
     if isempty(xs)
         return ""
     end
-    siz::Int = 0
-    for x in xs
-        siz += _str_sizehint(x)
-    end
+    siz = _str_sizehints(xs...)
     # specialized for performance reasons
     s = IOBuffer(sizehint=siz)
     env_io = IOContext(s, env)

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -42,7 +42,7 @@ end
 function print(io::IO, xs...)
     lock(io)
     try
-        for x in xs
+        foreach(xs) do x
             print(io, x)
         end
     finally
@@ -144,7 +144,7 @@ function print_to_string(xs...)
     end
     # specialized for performance reasons
     s = IOBuffer(sizehint=siz)
-    for x in xs
+    foreach(xs) do x
         print(s, x)
     end
     String(_unsafe_take!(s))
@@ -161,7 +161,7 @@ function string_with_env(env, xs...)
     # specialized for performance reasons
     s = IOBuffer(sizehint=siz)
     env_io = IOContext(s, env)
-    for x in xs
+    foreach(xs) do x
         print(env_io, x)
     end
     String(_unsafe_take!(s))


### PR DESCRIPTION
Following a discussion on [Discourse](https://discourse.julialang.org/t/string-optimisation-in-julia/119301/10?u=gdalle), this PR tries to improve `print` (and variants) for more than one argument.
The idea is that `for` is type-unstable over the tuple `args`, while `foreach` unrolls. I have no idea how to properly evaluate the potential performance gains though.