### PR TITLE
fix inexact conversion of `Rational` to `Integer` exception type

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -147,9 +147,9 @@ end
 Rational(x::Rational) = x
 
 Bool(x::Rational) = x==0 ? false : x==1 ? true :
-    throw(InexactError(:Bool, Bool, x)) # to resolve ambiguity
+    throw(InexactError(:convert, Bool, x)) # to resolve ambiguity
 (::Type{T})(x::Rational) where {T<:Integer} = (isinteger(x) ? convert(T, x.num)::T :
-    throw(InexactError(nameof(T), T, x)))
+    throw(InexactError(:convert, T, x)))
 
 AbstractFloat(x::Rational) = (float(x.num)/float(x.den))::AbstractFloat
 function (::Type{T})(x::Rational{S}) where T<:AbstractFloat where S

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -779,6 +779,12 @@ end
     @test_throws InexactError Rational{Integer}(Int8(-1), UInt8(1))
 end
 
+struct Issue55756A <: Integer end
+struct Issue55756B <: Integer end
+@testset "inexact conversion to `Integer`, issue #55756" begin
+    @test_throws InexactError Union{Issue55756A,Issue55756B}(1//2)
+end
+
 @testset "issue #41489" begin
     @test Core.Compiler.return_type(+, NTuple{2, Rational}) == Rational
     @test Core.Compiler.return_type(-, NTuple{2, Rational}) == Rational


### PR DESCRIPTION
Fixes #55756