### PR TITLE
REPL: precompile in its own module because Main is closed. Add check for unexpected errors.

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -758,11 +758,11 @@ setmodifiers!(c::REPLCompletionProvider, m::LineEdit.Modifiers) = c.modifiers = 
 Set `mod` as the default contextual module in the REPL,
 both for evaluating expressions and printing them.
 """
-function activate(mod::Module=Main)
+function activate(mod::Module=Main; interactive_utils::Bool=true)
     mistate = (Base.active_repl::LineEditREPL).mistate
     mistate === nothing && return nothing
     mistate.active_module = mod
-    Base.load_InteractiveUtils(mod)
+    interactive_utils && Base.load_InteractiveUtils(mod)
     return nothing
 end
 

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -38,9 +38,8 @@ let
     DOWN_ARROW = "\e[B"
 
     repl_script = """
-    module ThrowAway; import REPL; end
     import REPL
-    REPL.activate(ThrowAway; interactive_utils=false) # Main is closed so we can't evaluate in it
+    REPL.activate(REPL.Precompile; interactive_utils=false) # Main is closed so we can't evaluate in it
     2+2
     print("")
     printstyled("a", "b")
@@ -63,7 +62,7 @@ let
     [][1]
     Base.Iterators.minimum
     cd("complete_path\t\t$CTRL_C
-    REPL.activate(parentmodule(ThrowAway); interactive_utils=false)
+    REPL.activate(; interactive_utils=false)
     println("done")
     """
 

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -38,7 +38,7 @@ let
     DOWN_ARROW = "\e[B"
 
     repl_script = """
-    module ThrowAway end
+    module ThrowAway; import REPL; end
     import REPL
     REPL.activate(ThrowAway; interactive_utils=false) # Main is closed so we can't evaluate in it
     2+2
@@ -63,6 +63,7 @@ let
     [][1]
     Base.Iterators.minimum
     cd("complete_path\t\t$CTRL_C
+    REPL.activate(parentmodule(ThrowAway); interactive_utils=false)
     println("done")
     """
 

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -25,6 +25,9 @@ let
     DOWN_ARROW = "\e[B"
 
     repl_script = """
+    module ThrowAway end
+    import REPL
+    REPL.activate(ThrowAway; interactive_utils=false) # Main is closed so we can't evaluate in it
     2+2
     print("")
     printstyled("a", "b")

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -14,6 +14,19 @@ finally
 end
 
 let
+    # these are intentionally triggered
+    allowed_errors = [
+        "BoundsError: attempt to access 0-element Vector{Any} at index [1]",
+        "MethodError: no method matching f(::$Int, ::$Int)",
+        "Padding of type", # reinterpret docstring has ERROR examples
+    ]
+    function check_errors(out)
+        str = String(out)
+        if occursin("ERROR:", str) && !any(occursin(e, str) for e in allowed_errors)
+            @error "Unexpected error (Review REPL precompilation with debug_output on):\n$str"
+            exit(1)
+        end
+    end
     ## Debugging options
     # View the code sent to the repl by setting this to `stdout`
     debug_output = devnull # or stdout
@@ -116,10 +129,10 @@ let
             end
             schedule(repltask)
             # wait for the definitive prompt before start writing to the TTY
-            readuntil(output_copy, JULIA_PROMPT)
+            check_errors(readuntil(output_copy, JULIA_PROMPT))
             write(debug_output, "\n#### REPL STARTED ####\n")
             sleep(0.1)
-            readavailable(output_copy)
+            check_errors(readavailable(output_copy))
             # Input our script
             precompile_lines = split(repl_script::String, '\n'; keepempty=false)
             curr = 0
@@ -127,16 +140,16 @@ let
                 sleep(0.1)
                 curr += 1
                 # consume any other output
-                bytesavailable(output_copy) > 0 && readavailable(output_copy)
+                bytesavailable(output_copy) > 0 && check_errors(readavailable(output_copy))
                 # push our input
                 write(debug_output, "\n#### inputting statement: ####\n$(repr(l))\n####\n")
                 # If the line ends with a CTRL_C, don't write an extra newline, which would
                 # cause a second empty prompt. Our code below expects one new prompt per
                 # input line and can race out of sync with the unexpected second line.
                 endswith(l, CTRL_C) ? write(ptm, l) : write(ptm, l, "\n")
-                readuntil(output_copy, "\n")
+                check_errors(readuntil(output_copy, "\n"))
                 # wait for the next prompt-like to appear
-                readuntil(output_copy, "\n")
+                check_errors(readuntil(output_copy, "\n"))
                 strbuf = ""
                 while !eof(output_copy)
                     strbuf *= String(readavailable(output_copy))
@@ -146,6 +159,7 @@ let
                     occursin(HELP_PROMPT, strbuf) && break
                     sleep(0.1)
                 end
+                check_errors(strbuf)
             end
             write(debug_output, "\n#### COMPLETED - Closing REPL ####\n")
             write(ptm, "$CTRL_D")


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/55753
Also adds a check for unintended errors, given the REPL output is hidden.