### PR TITLE
Add dispatch routines for `ldiv!` with transposed LU and transposed or Hermitian/Symmetric `B`

### DIFF
--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -521,6 +521,14 @@ function ldiv!(adjA::AdjointFactorization{<:Any,<:LU}, B::AbstractVecOrMat)
     _apply_inverse_ipiv_rows!(A, B)
 end
 
+# To enable rdiv! via ldiv!
+ldiv!(A::TransposeFactorization{T,<:LU{T,<:StridedMatrix}}, B::Transpose{T,<:StridedVecOrMat{T}}) where {T<:Union{BlasFloat,BlasComplex}} =
+    LAPACK.getrs!('T', A.parent.factors, A.parent.ipiv, copy(B))
+ldiv!(A::TransposeFactorization{T,<:LU{T,<:StridedMatrix}}, B::Transpose{T,<:Hermitian{T,<:StridedMatrix}}) where {T<:BlasComplex} =
+    LAPACK.getrs!('T', A.parent.factors, A.parent.ipiv, Matrix(B))
+ldiv!(A::TransposeFactorization{T,<:LU{T,<:StridedMatrix}}, B::Symmetric{T,<:StridedMatrix}) where {T<:BlasFloat} =
+    LAPACK.getrs!('T', A.parent.factors, A.parent.ipiv, Matrix(B))
+
 (\)(A::AdjointFactorization{T,<:LU{T,<:StridedMatrix}}, B::Adjoint{T,<:StridedVecOrMat{T}}) where {T<:BlasComplex} =
     LAPACK.getrs!('C', A.parent.factors, A.parent.ipiv, copy(B))
 (\)(A::TransposeFactorization{T,<:LU{T,<:StridedMatrix}}, B::Transpose{T,<:StridedVecOrMat{T}}) where {T<:BlasFloat} =

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -499,4 +499,12 @@ end
     end
 end
 
+@testset "lu!/rdiv! via lu/ldiv! (#55422)" begin
+    id(A,T) = T(Matrix{eltype(A)}(I, size(A)...))
+    A = randn(1000,1000);
+    @test inv(A) ≈ ldiv!(lu(A), id(A,Matrix)) ≈ rdiv!(id(A,Matrix), lu(A)) ≈ rdiv!(id(A,Symmetric), lu(A))
+    A = complex.(randn(1000,1000),randn(1000,1000));
+    @test inv(A) ≈ ldiv!(lu(A), id(A,Matrix)) ≈ rdiv!(id(A,Matrix), lu(A)) ≈ rdiv!(id(A,Hermitian), lu(A))
+end
+
 end # module TestLU


### PR DESCRIPTION
## Introduction

This PR is a possible fix for the issue JuliaLang/LinearAlgebra.jl#1085, where it is observed that, with LU factorisation, `rdiv!` is much slower than `ldiv!`, see the issue for details and analysis.

This PR adds four new dispatch routines (methods) for `ldiv!` with LU: for `Adjoint`, `Transpose`, `Hermitian`, and `Symmetric`.

## Test Suite
```julia
using LinearAlgebra, BenchmarkTools
id(A,T) = T(Matrix{eltype(A)}(I, size(A)...))

A = randn(1000,1000);

@btime inv($A);
@btime ldiv!(lu(A), $(id(A,Matrix)));
@btime rdiv!($(id(A,Matrix)), lu(A));
@btime rdiv!($(id(A,Symmetric)), lu(A));

inv(A) ≈ ldiv!(lu(A), id(A,Matrix)) ≈ rdiv!(id(A,Matrix), lu(A)) ≈ rdiv!(id(A,Symmetric), lu(A))

A = complex.(randn(1000,1000),randn(1000,1000));

@btime inv($A);
@btime ldiv!(lu(A), $(id(A,Matrix)));
@btime rdiv!($(id(A,Matrix)), lu(A));
@btime rdiv!($(id(A,Hermitian)), lu(A));

inv(A) ≈ ldiv!(lu(A), id(A,Matrix)) ≈ rdiv!(id(A,Matrix), lu(A)) ≈ rdiv!(id(A,Hermitian), lu(A))
```

## Test Results
See https://github.com/JuliaLang/julia/pull/55760#issuecomment-2346746421

