### PR TITLE
move null check in `unsafe_convert` of RefValue

### DIFF
--- a/base/refvalue.jl
+++ b/base/refvalue.jl
@@ -46,9 +46,9 @@ function unsafe_convert(P::Union{Type{Ptr{T}},Type{Ptr{Cvoid}}}, b::RefValue{T})
         # Instead, explicitly load the pointer from the `RefValue`,
         # which also ensures this returns same pointer as the one rooted in the `RefValue` object.
         p = atomic_pointerref(Ptr{Ptr{Cvoid}}(pointer_from_objref(b)), :monotonic)
-    end
-    if p == C_NULL
-        throw(UndefRefError())
+        if p == C_NULL
+            throw(UndefRefError())
+        end
     end
     return p
 end


### PR DESCRIPTION
LLVM can optimize out this check but our optimizer can't, so this leads to smaller IR in most cases.