### PR TITLE
codegen: fix bits compare for UnionAll

### DIFF
--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -999,3 +999,8 @@ for (T, StructName) in ((Int128, :Issue55558), (UInt128, :UIssue55558))
         @test sizeof($(StructName)) == 48 broken=broken_i128
     end
 end
+
+@noinline Base.@nospecializeinfer f55768(@nospecialize z::UnionAll) = z === Vector
+@test f55768(Vector)
+@test f55768(Vector{T} where T)
+@test !f55768(Vector{S} where S)


### PR DESCRIPTION
Fixes #55768 in two parts: one is making the type computation in emit_bits_compare agree with the parent function and two is not using the optimized egal code for UnionAll kinds, which is different from how the egal code itself works for kinds.