### PR TITLE
Make `Base.donotdelete` public

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@ New library functions
 
 * `ispositive(::Real)` and `isnegative(::Real)` are provided for performance and convenience ([#53677]).
 * Exporting function `fieldindex` to get the index of a struct's field ([#58119]).
+* `Base.donotdelete` is now public. It prevents deadcode elemination of its arguments ([#55774]).
 
 New library features
 --------------------

--- a/base/public.jl
+++ b/base/public.jl
@@ -125,4 +125,5 @@ public
     notnothing,
     runtests,
     text_colors,
-    depwarn
+    depwarn,
+    donotdelete


### PR DESCRIPTION
I rely on `Base.donotdelete` in [Chairmarks.jl](https://chairmarks.lilithhafner.com) and I'd like it to be public. I imagine that other benchmarking tools also rely on it. It's been around since 1.8 (see also: #55773) and I think we should commit to keeping it functional for the rest of 1.x.