### PR TITLE
Fix `unsafe_read` for `IOBuffer` with non dense data

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -184,12 +184,31 @@ end
 function unsafe_read(from::GenericIOBuffer, p::Ptr{UInt8}, nb::UInt)
     from.readable || _throw_not_readable()
     avail = bytesavailable(from)
-    adv = min(avail, nb)
-    GC.@preserve from unsafe_copyto!(p, pointer(from.data, from.ptr), adv)
+    adv = UInt(min(avail, nb))
+    unsafe_read!(p, from.data, from.ptr, adv)
     from.ptr += adv
     if nb > avail
         throw(EOFError())
     end
+    nothing
+end
+
+function unsafe_read!(dest::Ptr{UInt8}, src::AbstractVector{UInt8}, so::Integer, nbytes::UInt)
+    dest_array = unsafe_wrap(Array, dest, nbytes)
+    copyto!(dest_array, 1, src, so, nbytes)
+    nothing
+end
+
+# Note: Currently, CodeUnits <: DenseVector, which makes this union redundant w.r.t
+# DenseArrayType{UInt8}, but this is a bug, and may be removed in future versions
+# of Julia. See #54002
+const DenseBytes = Union{
+    <:DenseArrayType{UInt8},
+    CodeUnits{UInt8, <:Union{String, SubString{String}}},
+}
+
+function unsafe_read!(dest::Ptr{UInt8}, src::DenseBytes, so::Integer, nbytes::UInt)
+    GC.@preserve src unsafe_copyto!(dest, pointer(src, so), nbytes)
     nothing
 end
 

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -193,7 +193,7 @@ function unsafe_read(from::GenericIOBuffer, p::Ptr{UInt8}, nb::UInt)
     nothing
 end
 
-function unsafe_read!(dest::Ptr{UInt8}, src::{UInt8}, so::Integer, nbytes::UInt)
+function unsafe_read!(dest::Ptr{UInt8}, src::AbstractVector{UInt8}, so::Integer, nbytes::UInt)
     for i in 1:nbytes
         unsafe_store!(dest, @inbounds(src[so+i-1]), i)
     end

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -193,10 +193,10 @@ function unsafe_read(from::GenericIOBuffer, p::Ptr{UInt8}, nb::UInt)
     nothing
 end
 
-function unsafe_read!(dest::Ptr{UInt8}, src::AbstractVector{UInt8}, so::Integer, nbytes::UInt)
-    dest_array = unsafe_wrap(Array, dest, nbytes)
-    copyto!(dest_array, 1, src, so, nbytes)
-    nothing
+function unsafe_read!(dest::Ptr{UInt8}, src::{UInt8}, so::Integer, nbytes::UInt)
+    for i in 1:nbytes
+        unsafe_store!(dest, @inbounds(src[so+i-1]), i)
+    end
 end
 
 # Note: Currently, CodeUnits <: DenseVector, which makes this union redundant w.r.t

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -184,7 +184,7 @@ end
 function unsafe_read(from::GenericIOBuffer, p::Ptr{UInt8}, nb::UInt)
     from.readable || _throw_not_readable()
     avail = bytesavailable(from)
-    adv = UInt(min(avail, nb))
+    adv = min(avail, nb)
     unsafe_read!(p, from.data, from.ptr, adv)
     from.ptr += adv
     if nb > avail

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -61,14 +61,6 @@ function findnext(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:AbstractChar}
     end
 end
 
-# Note: Currently, CodeUnits <: DenseVector, which makes this union redundant w.r.t
-# DenseArrayType{UInt8}, but this is a bug, and may be removed in future versions
-# of Julia. See #54002
-const DenseBytes = Union{
-    <:DenseArrayType{UInt8},
-    CodeUnits{UInt8, <:Union{String, SubString{String}}},
-}
-
 function findfirst(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:Union{UInt8, Int8}}, a::Union{DenseInt8, DenseUInt8})
     findnext(pred, a, firstindex(a))
 end

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -389,3 +389,13 @@ end
     b = pushfirst!([0x02], 0x01)
     @test take!(IOBuffer(b)) == [0x01, 0x02]
 end
+
+@testset "#54636 reading from non-dense vectors" begin
+    data = 0x00:0xFF
+    io = IOBuffer(data)
+    @test read(io) == data
+
+    data = @view(collect(0x00:0x0f)[begin:2:end])
+    io = IOBuffer(data)
+    @test read(io) == data
+end


### PR DESCRIPTION
Fixes one part of #54636 

It was only safe to use the following if `from.data` was a dense vector of bytes.
```julia
GC.@preserve from unsafe_copyto!(p, pointer(from.data, from.ptr), adv)
```

This PR adds a fallback suggested by @matthias314 in https://discourse.julialang.org/t/copying-bytes-from-abstractvector-to-ptr/119408/7