### PR TITLE
Reland " Avoid materializing arrays in bidiag matmul #55450"

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -673,7 +673,9 @@ matprod_dest(A::Diagonal, B::Diagonal, TS) = _matprod_dest_diag(B, TS)
 _matprod_dest_diag(A, TS) = similar(A, TS)
 function _matprod_dest_diag(A::SymTridiagonal, TS)
     n = size(A, 1)
-    Tridiagonal(similar(A, TS, n-1), similar(A, TS, n), similar(A, TS, n-1))
+    ev = similar(A, TS, max(0, n-1))
+    dv = similar(A, TS, n)
+    Tridiagonal(ev, dv, similar(ev))
 end
 
 # Special handling for adj/trans vec

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -665,7 +665,7 @@ function __bibimul!(C, A, B::Bidiagonal, _add)
                 Bj₊1j₊1 = Bd[j+1]
                 Bj₊1j₊2 = Bu[j+1]
                 C[j, j-1] += _add(Ajj₋1*Bj₋1j₋1)
-                C[j, j  ] += _add(Ajj₋1*Bj₋1j   + Ajj*Bjj       + Ajj₊1*Bj₊1j)
+                C[j, j  ] += _add(Ajj₋1*Bj₋1j   + Ajj*Bjj)
                 C[j, j+1] += _add(Ajj  *Bjj₊1   + Ajj₊1*Bj₊1j₊1)
                 C[j, j+2] += _add(Ajj₊1*Bj₊1j₊2)
             end
@@ -705,9 +705,6 @@ function __bibimul!(C, A::Bidiagonal, B, _add)
             for j in 3:n-2
                 Ajj     = Ad[j]
                 Ajj₊1   = Au[j]
-                Bj₋1j₋2 = Bl[j-2]
-                Bj₋1j₋1 = Bd[j-1]
-                Bj₋1j   = Bu[j-1]
                 Bjj₋1   = Bl[j-1]
                 Bjj     = Bd[j]
                 Bjj₊1   = Bu[j]
@@ -733,9 +730,6 @@ function __bibimul!(C, A::Bidiagonal, B, _add)
                 Bjj₋1   = Bl[j-1]
                 Bjj     = Bd[j]
                 Bjj₊1   = Bu[j]
-                Bj₊1j   = Bl[j]
-                Bj₊1j₊1 = Bd[j+1]
-                Bj₊1j₊2 = Bu[j+1]
                 C[j,j-2]  += _add( Ajj₋1*Bj₋1j₋2)
                 C[j, j-1] += _add(Ajj₋1*Bj₋1j₋1 + Ajj*Bjj₋1)
                 C[j, j  ] += _add(Ajj₋1*Bj₋1j   + Ajj*Bjj)
@@ -756,8 +750,6 @@ function __bibimul!(C, A::Bidiagonal, B::Bidiagonal, _add)
             for j in 3:n-2
                 Ajj     = Ad[j]
                 Ajj₊1   = Au[j]
-                Bj₋1j₋1 = Bd[j-1]
-                Bj₋1j   = Bu[j-1]
                 Bjj     = Bd[j]
                 Bjj₊1   = Bu[j]
                 Bj₊1j₊1 = Bd[j+1]
@@ -776,8 +768,6 @@ function __bibimul!(C, A::Bidiagonal, B::Bidiagonal, _add)
             for j in 3:n-2
                 Ajj     = Ad[j]
                 Ajj₊1   = Au[j]
-                Bj₋1j₋2 = Bl[j-2]
-                Bj₋1j₋1 = Bd[j-1]
                 Bjj₋1   = Bl[j-1]
                 Bjj     = Bd[j]
                 Bj₊1j   = Bl[j]
@@ -800,8 +790,6 @@ function __bibimul!(C, A::Bidiagonal, B::Bidiagonal, _add)
                 Bj₋1j   = Bu[j-1]
                 Bjj     = Bd[j]
                 Bjj₊1   = Bu[j]
-                Bj₊1j₊1 = Bd[j+1]
-                Bj₊1j₊2 = Bu[j+1]
                 C[j, j-1] += _add(Ajj₋1*Bj₋1j₋1)
                 C[j, j  ] += _add(Ajj₋1*Bj₋1j   + Ajj*Bjj)
                 C[j, j+1] += _add(Ajj  *Bjj₊1)
@@ -820,8 +808,6 @@ function __bibimul!(C, A::Bidiagonal, B::Bidiagonal, _add)
                 Bj₋1j₋1 = Bd[j-1]
                 Bjj₋1   = Bl[j-1]
                 Bjj     = Bd[j]
-                Bj₊1j   = Bl[j]
-                Bj₊1j₊1 = Bd[j+1]
                 C[j,j-2]  += _add( Ajj₋1*Bj₋1j₋2)
                 C[j, j-1] += _add(Ajj₋1*Bj₋1j₋1 + Ajj*Bjj₋1)
                 C[j, j  ] += _add(Ajj*Bjj)

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -817,17 +817,17 @@ function _mul!(C::AbstractMatrix, A::AbstractMatrix, B::Bidiagonal, _add::MulAdd
     (iszero(m) || iszero(n)) && return C
     iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
     @inbounds if B.uplo == 'U'
+        for j in n:-1:2, i in 1:m
+            _modify!(_add, A[i,j] * B.dv[j] + A[i,j-1] * B.ev[j-1], C, (i, j))
+        end
         for i in 1:m
-            for j in n:-1:2
-                _modify!(_add, A[i,j] * B.dv[j] + A[i,j-1] * B.ev[j-1], C, (i, j))
-            end
             _modify!(_add, A[i,1] * B.dv[1], C, (i, 1))
         end
     else # uplo == 'L'
+        for j in 1:n-1, i in 1:m
+            _modify!(_add, A[i,j] * B.dv[j] + A[i,j+1] * B.ev[j], C, (i, j))
+        end
         for i in 1:m
-            for j in 1:n-1
-                _modify!(_add, A[i,j] * B.dv[j] + A[i,j+1] * B.ev[j], C, (i, j))
-            end
             _modify!(_add, A[i,n] * B.dv[n], C, (i, n))
         end
     end

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -557,7 +557,8 @@ end
 # function to get the internally stored vectors for Bidiagonal and [Sym]Tridiagonal
 # to avoid allocations in _mul! below (#24324, #24578)
 _diag(A::Tridiagonal, k) = k == -1 ? A.dl : k == 0 ? A.d : A.du
-_diag(A::SymTridiagonal, k) = k == 0 ? A.dv : A.ev
+_diag(A::SymTridiagonal{<:Number}, k) = k == 0 ? A.dv : A.ev
+_diag(A::SymTridiagonal, k) = k == 0 ? view(A, diagind(A, IndexStyle(A))) : view(A, diagind(A, 1, IndexStyle(A)))
 function _diag(A::Bidiagonal, k)
     if k == 0
         return A.dv

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -762,9 +762,9 @@ end
 function _mul_bitrisym!(C::AbstractVecOrMat, A::Bidiagonal, B::AbstractVecOrMat, _add::MulAddMul)
     nA = size(A,1)
     nB = size(B,2)
-    d = B.dv
+    d = A.dv
     if A.uplo == 'U'
-        u = B.ev
+        u = A.ev
         @inbounds begin
             for j = 1:nB
                 b₀, b₊ = B[1, j], B[2, j]
@@ -777,7 +777,7 @@ function _mul_bitrisym!(C::AbstractVecOrMat, A::Bidiagonal, B::AbstractVecOrMat,
             end
         end
     else
-        l = B.ev
+        l = A.ev
         @inbounds begin
             for j = 1:nB
                 b₀, b₊ = B[1, j], B[2, j]

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -576,8 +576,13 @@ function _bibimul!(C, A, B, _add)
     require_one_based_indexing(C)
     check_A_mul_B!_sizes(size(C), size(A), size(B))
     n = size(A,1)
-    iszero(n) && return C
-    n <= 3 && return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
+    if n <= 3
+        # naive multiplication
+        for I in CartesianIndices(C)
+            _modify!(_add, sum(A[I[1], k] * B[k, I[2]] for k in axes(A,2)), C, I)
+        end
+        return C
+    end
     # We use `_rmul_or_fill!` instead of `_modify!` here since using
     # `_modify!` in the following loop will not update the
     # off-diagonal elements for non-zero beta.
@@ -744,7 +749,14 @@ function _mul!(C::AbstractVecOrMat, A::BiTriSym, B::AbstractVecOrMat, _add::MulA
     nB = size(B,2)
     (iszero(nA) || iszero(nB)) && return C
     iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
-    nA <= 3 && return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
+    if nA <= 3
+        # naive multiplication
+        for I in CartesianIndices(C)
+            col = Base.tail(Tuple(I))
+            _modify!(_add, sum(A[I[1], k] * B[k, col...] for k in axes(A,2)), C, I)
+        end
+        return C
+    end
     l = _diag(A, -1)
     d = _diag(A, 0)
     u = _diag(A, 1)
@@ -767,10 +779,10 @@ function _mul!(C::AbstractMatrix, A::AbstractMatrix, B::TriSym, _add::MulAddMul)
     check_A_mul_B!_sizes(size(C), size(A), size(B))
     n = size(A,1)
     m = size(B,2)
-    (iszero(m) || iszero(n)) && return C
-    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
-    if n <= 3 || m <= 1
-        return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
+    (iszero(_add.alpha) || iszero(m)) && return _rmul_or_fill!(C, _add.beta)
+    if m == 1
+        B11 = B[1,1]
+        return mul!(C, A, B11, _add.alpha, _add.beta)
     end
     Bl = _diag(B, -1)
     Bd = _diag(B, 0)
@@ -804,9 +816,6 @@ function _mul!(C::AbstractMatrix, A::AbstractMatrix, B::Bidiagonal, _add::MulAdd
     m, n = size(A)
     (iszero(m) || iszero(n)) && return C
     iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
-    if size(A, 1) <= 3 || size(B, 2) <= 1
-        return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
-    end
     @inbounds if B.uplo == 'U'
         for i in 1:m
             for j in n:-1:2
@@ -833,8 +842,12 @@ function _dibimul!(C, A, B, _add)
     require_one_based_indexing(C)
     check_A_mul_B!_sizes(size(C), size(A), size(B))
     n = size(A,1)
-    iszero(n) && return C
-    n <= 3 && return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
+    if n <= 3
+        for I in CartesianIndices(C)
+            _modify!(_add, A.diag[I[1]] * B[I[1], I[2]], C, I)
+        end
+        return C
+    end
     _rmul_or_fill!(C, _add.beta)  # see the same use above
     iszero(_add.alpha) && return C
     Ad = A.diag

--- a/stdlib/LinearAlgebra/test/addmul.jl
+++ b/stdlib/LinearAlgebra/test/addmul.jl
@@ -220,4 +220,23 @@ end
     end
 end
 
+@testset "issue #55727" begin
+    C = zeros(1,1)
+    @testset "$(nameof(typeof(A)))" for A in Any[Diagonal([NaN]),
+                Bidiagonal([NaN], Float64[], :U),
+                SymTridiagonal([NaN], Float64[]),
+                Tridiagonal(Float64[], [NaN], Float64[]),
+                ]
+        @testset "$(nameof(typeof(B)))" for B in Any[SymTridiagonal([1.0], Float64[]),
+                    Tridiagonal(Float64[], [1.0], Float64[]),
+                    Bidiagonal([1.0], Float64[], :U),
+                    Bidiagonal([1.0], Float64[], :L),
+                    ]
+            C .= 0
+            @test mul!(C, A, B, 0.0, false)[] === 0.0
+            @test mul!(C, B, A, 0.0, false)[] === 0.0
+        end
+    end
+end
+
 end  # module

--- a/stdlib/LinearAlgebra/test/addmul.jl
+++ b/stdlib/LinearAlgebra/test/addmul.jl
@@ -224,13 +224,16 @@ end
     C = zeros(1,1)
     @testset "$(nameof(typeof(A)))" for A in Any[Diagonal([NaN]),
                 Bidiagonal([NaN], Float64[], :U),
+                Bidiagonal([NaN], Float64[], :L),
                 SymTridiagonal([NaN], Float64[]),
                 Tridiagonal(Float64[], [NaN], Float64[]),
                 ]
-        @testset "$(nameof(typeof(B)))" for B in Any[SymTridiagonal([1.0], Float64[]),
-                    Tridiagonal(Float64[], [1.0], Float64[]),
+        @testset "$(nameof(typeof(B)))" for B in Any[
+                    Diagonal([1.0]),
                     Bidiagonal([1.0], Float64[], :U),
                     Bidiagonal([1.0], Float64[], :L),
+                    SymTridiagonal([1.0], Float64[]),
+                    Tridiagonal(Float64[], [1.0], Float64[]),
                     ]
             C .= 0
             @test mul!(C, A, B, 0.0, false)[] === 0.0

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -1062,7 +1062,7 @@ end
             @test B * B ≈ M * M
             @test mul!(similar(B, size(B)), B, B) ≈ M * M
 
-            for m in 1:6
+            for m in 0:6
                 AL = rand(m,n)
                 AR = rand(n,m)
                 @test AL * B ≈ AL * M

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -1058,9 +1058,11 @@ end
 
             @test B * v ≈ M * v
             @test mul!(similar(v), B, v) ≈ M * v
+            @test mul!(ones(size(v)), B, v, 2, 3) ≈ M * v * 2 .+ 3
 
             @test B * B ≈ M * M
             @test mul!(similar(B, size(B)), B, B) ≈ M * M
+            @test mul!(ones(size(B)), B, B, 2, 4) ≈ M * M * 2 .+ 4
 
             for m in 0:6
                 AL = rand(m,n)
@@ -1069,6 +1071,8 @@ end
                 @test B * AR ≈ M * AR
                 @test mul!(similar(AL), AL, B) ≈ AL * M
                 @test mul!(similar(AR), B, AR) ≈ M * AR
+                @test mul!(ones(size(AL)), AL, B, 2, 4) ≈ AL * M * 2 .+ 4
+                @test mul!(ones(size(AR)), B, AR, 2, 4) ≈ M * AR * 2 .+ 4
             end
 
             @test B * D ≈ M * D
@@ -1077,7 +1081,19 @@ end
             @test mul!(similar(B), B, D) ≈ M * D
             @test mul!(similar(B, size(B)), D, B) ≈ D * M
             @test mul!(similar(B, size(B)), B, D) ≈ M * D
+            @test mul!(ones(size(B)), D, B, 2, 4) ≈ D * M * 2 .+ 4
+            @test mul!(ones(size(B)), B, D, 2, 4) ≈ M * D * 2 .+ 4
         end
+        BL = Bidiagonal(rand(n), rand(max(0, n-1)), :L)
+        ML = Matrix(BL)
+        BU = Bidiagonal(rand(n), rand(max(0, n-1)), :U)
+        MU = Matrix(BU)
+        T = Tridiagonal(zeros(max(0, n-1)), zeros(n), zeros(max(0, n-1)))
+        @test mul!(T, BL, BU) ≈ ML * MU
+        @test mul!(T, BU, BL) ≈ MU * ML
+        T = Tridiagonal(ones(max(0, n-1)), ones(n), ones(max(0, n-1)))
+        @test mul!(copy(T), BL, BU, 2, 3) ≈ ML * MU * 2 + T * 3
+        @test mul!(copy(T), BU, BL, 2, 3) ≈ MU * ML * 2 + T * 3
     end
 end
 

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -1048,4 +1048,37 @@ end
     @test mul!(similar(D), B, D) == mul!(similar(D), D, B) == B * D
 end
 
+@testset "mul for small matrices" begin
+    @testset for n in 0:4
+        D = Diagonal(rand(n))
+        v = rand(n)
+        @testset for uplo in (:L, :U)
+            B = Bidiagonal(rand(n), rand(max(n-1,0)), uplo)
+            M = Matrix(B)
+
+            @test B * v ≈ M * v
+            @test mul!(similar(v), B, v) ≈ M * v
+
+            @test B * B ≈ M * M
+            @test mul!(similar(B, size(B)), B, B) ≈ M * M
+
+            for m in 1:6
+                AL = rand(m,n)
+                AR = rand(n,m)
+                @test AL * B ≈ AL * M
+                @test B * AR ≈ M * AR
+                @test mul!(similar(AL), AL, B) ≈ AL * M
+                @test mul!(similar(AR), B, AR) ≈ M * AR
+            end
+
+            @test B * D ≈ M * D
+            @test D * B ≈ D * M
+            @test mul!(similar(B), B, D) ≈ M * D
+            @test mul!(similar(B), B, D) ≈ M * D
+            @test mul!(similar(B, size(B)), D, B) ≈ D * M
+            @test mul!(similar(B, size(B)), B, D) ≈ M * D
+        end
+    end
+end
+
 end # module TestBidiagonal

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -1049,7 +1049,7 @@ end
 end
 
 @testset "mul for small matrices" begin
-    @testset for n in 0:4
+    @testset for n in 0:6
         D = Diagonal(rand(n))
         v = rand(n)
         @testset for uplo in (:L, :U)
@@ -1094,6 +1094,24 @@ end
         T = Tridiagonal(ones(max(0, n-1)), ones(n), ones(max(0, n-1)))
         @test mul!(copy(T), BL, BU, 2, 3) ≈ ML * MU * 2 + T * 3
         @test mul!(copy(T), BU, BL, 2, 3) ≈ MU * ML * 2 + T * 3
+    end
+
+    n = 4
+    arr = SizedArrays.SizedArray{(2,2)}(reshape([1:4;],2,2))
+    for B in (
+            Bidiagonal(fill(arr,n), fill(arr,n-1), :L),
+            Bidiagonal(fill(arr,n), fill(arr,n-1), :U),
+            )
+        @test B * B ≈ Matrix(B) * Matrix(B)
+        BL = Bidiagonal(fill(arr,n), fill(arr,n-1), :L)
+        BU = Bidiagonal(fill(arr,n), fill(arr,n-1), :U)
+        @test BL * B ≈ Matrix(BL) * Matrix(B)
+        @test BU * B ≈ Matrix(BU) * Matrix(B)
+        @test B * BL ≈ Matrix(B) * Matrix(BL)
+        @test B * BU ≈ Matrix(B) * Matrix(BU)
+        D = Diagonal(fill(arr,n))
+        @test D * B ≈ Matrix(D) * Matrix(B)
+        @test B * D ≈ Matrix(B) * Matrix(D)
     end
 end
 

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -971,7 +971,7 @@ end
 end
 
 @testset "mul for small matrices" begin
-    @testset for n in 0:4
+    @testset for n in 0:6
         for T in (
                 Tridiagonal(rand(max(n-1,0)), rand(n), rand(max(n-1,0))),
                 SymTridiagonal(rand(n), rand(max(n-1,0))),
@@ -1020,6 +1020,24 @@ end
                 @test mul!(ones(size(T)), T, B, 2, 4) ≈ M * B * 2 .+ 4
             end
         end
+    end
+
+    n = 4
+    arr = SizedArrays.SizedArray{(2,2)}(reshape([1:4;],2,2))
+    for T in (
+            SymTridiagonal(fill(arr,n), fill(arr,n-1)),
+            Tridiagonal(fill(arr,n-1), fill(arr,n), fill(arr,n-1)),
+            )
+        @test T * T ≈ Matrix(T) * Matrix(T)
+        BL = Bidiagonal(fill(arr,n), fill(arr,n-1), :L)
+        BU = Bidiagonal(fill(arr,n), fill(arr,n-1), :U)
+        @test BL * T ≈ Matrix(BL) * Matrix(T)
+        @test BU * T ≈ Matrix(BU) * Matrix(T)
+        @test T * BL ≈ Matrix(T) * Matrix(BL)
+        @test T * BU ≈ Matrix(T) * Matrix(BU)
+        D = Diagonal(fill(arr,n))
+        @test D * T ≈ Matrix(D) * Matrix(T)
+        @test T * D ≈ Matrix(T) * Matrix(D)
     end
 end
 

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -970,4 +970,48 @@ end
     @test sprint(show, S) == "SymTridiagonal($(repr(diag(S))), $(repr(diag(S,1))))"
 end
 
+@testset "mul for small matrices" begin
+    @testset for n in 0:4
+        for T in (
+                Tridiagonal(rand(max(n-1,0)), rand(n), rand(max(n-1,0))),
+                SymTridiagonal(rand(n), rand(max(n-1,0))),
+                )
+            M = Matrix(T)
+            @test T * T ≈ M * M
+            @test mul!(similar(T, size(T)), T, T) ≈ M * M
+
+            for m in 0:6
+                AR = rand(n,m)
+                AL = rand(m,n)
+                @test AL * T ≈ AL * M
+                @test T * AR ≈ M * AR
+                @test mul!(similar(AL), AL, T) ≈ AL * M
+                @test mul!(similar(AR), T, AR) ≈ M * AR
+            end
+
+            v = rand(n)
+            @test T * v ≈ M * v
+            @test mul!(similar(v), T, v) ≈ M * v
+
+            D = Diagonal(rand(n))
+            @test T * D ≈ M * D
+            @test D * T ≈ D * M
+            @test mul!(Tridiagonal(similar(T)), D, T) ≈ D * M
+            @test mul!(Tridiagonal(similar(T)), T, D) ≈ M * D
+            @test mul!(similar(T, size(T)), D, T) ≈ D * M
+            @test mul!(similar(T, size(T)), T, D) ≈ M * D
+
+            B = Bidiagonal(rand(n), rand(max(0, n-1)), :U)
+            @test T * B ≈ M * B
+            @test B * T ≈ B * M
+            if n <= 2
+                @test mul!(Tridiagonal(similar(T)), B, T) ≈ B * M
+                @test mul!(Tridiagonal(similar(T)), T, B) ≈ M * B
+                @test mul!(similar(T, size(T)), B, T) ≈ B * M
+                @test mul!(similar(T, size(T)), T, B) ≈ M * B
+            end
+        end
+    end
+end
+
 end # module TestTridiagonal

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -979,6 +979,7 @@ end
             M = Matrix(T)
             @test T * T ≈ M * M
             @test mul!(similar(T, size(T)), T, T) ≈ M * M
+            @test mul!(ones(size(T)), T, T, 2, 4) ≈ M * M * 2 .+ 4
 
             for m in 0:6
                 AR = rand(n,m)
@@ -987,6 +988,8 @@ end
                 @test T * AR ≈ M * AR
                 @test mul!(similar(AL), AL, T) ≈ AL * M
                 @test mul!(similar(AR), T, AR) ≈ M * AR
+                @test mul!(ones(size(AL)), AL, T, 2, 4) ≈ AL * M * 2 .+ 4
+                @test mul!(ones(size(AR)), T, AR, 2, 4) ≈ M * AR * 2 .+ 4
             end
 
             v = rand(n)
@@ -1000,15 +1003,21 @@ end
             @test mul!(Tridiagonal(similar(T)), T, D) ≈ M * D
             @test mul!(similar(T, size(T)), D, T) ≈ D * M
             @test mul!(similar(T, size(T)), T, D) ≈ M * D
+            @test mul!(ones(size(T)), D, T, 2, 4) ≈ D * M * 2 .+ 4
+            @test mul!(ones(size(T)), T, D, 2, 4) ≈ M * D * 2 .+ 4
 
-            B = Bidiagonal(rand(n), rand(max(0, n-1)), :U)
-            @test T * B ≈ M * B
-            @test B * T ≈ B * M
-            if n <= 2
-                @test mul!(Tridiagonal(similar(T)), B, T) ≈ B * M
-                @test mul!(Tridiagonal(similar(T)), T, B) ≈ M * B
+            for uplo in (:U, :L)
+                B = Bidiagonal(rand(n), rand(max(0, n-1)), uplo)
+                @test T * B ≈ M * B
+                @test B * T ≈ B * M
+                if n <= 2
+                    @test mul!(Tridiagonal(similar(T)), B, T) ≈ B * M
+                    @test mul!(Tridiagonal(similar(T)), T, B) ≈ M * B
+                end
                 @test mul!(similar(T, size(T)), B, T) ≈ B * M
                 @test mul!(similar(T, size(T)), T, B) ≈ M * B
+                @test mul!(ones(size(T)), B, T, 2, 4) ≈ B * M * 2 .+ 4
+                @test mul!(ones(size(T)), T, B, 2, 4) ≈ M * B * 2 .+ 4
             end
         end
     end


### PR DESCRIPTION
This relands JuliaLang/julia#55450 and adds tests for the failing case noted in https://github.com/JuliaLang/LinearAlgebra.jl/issues/1091. The `addmul` tests that were failing earlier pass with this change. 

The issue in the earlier PR was that we were not exiting quickly for `iszero(alpha)` in `_bibimul!` for small matrices, and were computing the result as `C .= A * B * alpha + C * beta`. The problem with this is that if `A * B` contains `NaN`s, this propagates to `C` even if `alpha === 0.0`. This is fixed now, and the result is only computed if `!iszero(alpha)`.