### PR TITLE
Print results of `runtests` with `printstyled`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -438,9 +438,9 @@ cd(@__DIR__) do
     # o_ts.verbose = true # set to true to show all timings when successful
     Test.print_test_results(o_ts, 1)
     if !o_ts.anynonpass
-        println("    \033[32;1mSUCCESS\033[0m")
+        printstyled("    SUCCESS\n"; bold=true, color=:green)
     else
-        println("    \033[31;1mFAILURE\033[0m\n")
+        printstyled("    FAILURE\n\n"; bold=true, color=:red)
         skipped > 0 &&
             println("$skipped test", skipped > 1 ? "s were" : " was", " skipped due to failure.")
         println("The global RNG seed was 0x$(string(seed, base = 16)).\n")


### PR DESCRIPTION
This ensures escape characters are used only if `stdout` can accept them.