### PR TITLE
use PrecompileTools mechanics to compile REPL

### DIFF
--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -188,24 +188,25 @@ let
         end
     end
 
-    Core.Compiler.Timings.reset_timings()
-    Core.Compiler.__set_measure_typeinf(true)
-    try
-        repl_workload()
-    finally
-        Core.Compiler.__set_measure_typeinf(false)
-        Core.Compiler.Timings.close_current_timer()
-    end
-    roots = Core.Compiler.Timings._timings[1].children
-    for child in roots
-        precompile(child.mi_info.mi.specTypes)
-        check_edges(child)
+    if Base.generating_output() && Base.JLOptions().use_pkgimages != 0
+        Core.Compiler.Timings.reset_timings()
+        Core.Compiler.__set_measure_typeinf(true)
+        try
+            repl_workload()
+        finally
+            Core.Compiler.__set_measure_typeinf(false)
+            Core.Compiler.Timings.close_current_timer()
+        end
+        roots = Core.Compiler.Timings._timings[1].children
+        for child in roots
+            precompile(child.mi_info.mi.specTypes)
+            check_edges(child)
+        end
+        precompile(Tuple{typeof(Base.setindex!), Base.Dict{Any, Any}, Any, Int})
+        precompile(Tuple{typeof(Base.delete!), Base.Set{Any}, String})
+        precompile(Tuple{typeof(Base.:(==)), Char, String})
+        precompile(Tuple{typeof(Base.reseteof), Base.TTY})
     end
 end
-
-precompile(Tuple{typeof(Base.setindex!), Base.Dict{Any, Any}, Any, Int})
-precompile(Tuple{typeof(Base.delete!), Base.Set{Any}, String})
-precompile(Tuple{typeof(Base.:(==)), Char, String})
-precompile(Tuple{typeof(Base.reseteof), Base.TTY})
 
 end # Precompile


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/55778

Based on discussion here https://github.com/JuliaLang/julia/issues/55778#issuecomment-2352428043

With this `?reinterpret` feels instant, with only these precompiles at the start.
![Screenshot 2024-09-16 at 9 49 39 AM](https://github.com/user-attachments/assets/20dc016d-c6f7-4870-acd7-0e795dcf541b)

