### PR TITLE
better handle unknown expression heads in deparse

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -253,6 +253,7 @@
            ((const)        (string "const " (deparse (cadr e))))
            ((top)          (deparse (cadr e)))
            ((core)         (string "Core." (deparse (cadr e))))
+           ((thismodule)   (string "@__MODULE__()"))
            ((globalref)    (string (deparse (cadr e)) "." (deparse-colon-dot (caddr e))))
            ((ssavalue)     (string "SSAValue(" (cadr e) ")"))
            ((line)         (if (length= e 2)
@@ -265,8 +266,10 @@
                                 '(#\= #\:))))
                 (string ":" (deparse (cadr e)))
                 (string ":(" (deparse (cadr e)) ")")))
+           ((escape)
+            (string "$(esc(" (deparse `(quote ,(cadr e))) ")"))
            (else
-            (string e))))))
+            (string "$(Expr(" (string.join (map (lambda (x) (deparse `(quote ,x))) e) ", ") ")"))))))
 
 ;; custom gensyms
 

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -3985,3 +3985,19 @@ begin
   end
 end
 @test f45494() === (0,)
+
+# issue #55788
+@test_throws r"""
+    \$\(Expr\(:foo, :\(\$\(esc\(:\(begin
+        SSAValue\(\d+\) = 1
+        begin
+            \$\(Expr\(:newvar, :x\)
+            nothing
+            begin
+                nothing
+                x = SSAValue\(\d+\)
+            end
+            const @__MODULE__\(\).x
+            SSAValue\(\d+\)
+        end
+    end\)\)\)\)""" eval(Expr(:foo, esc(:(const x=1))))


### PR DESCRIPTION
Now prints unknown expression heads recursively too, similar to
`show(::Expr)` instead of just dumping s-exprs. Also adds nicer
printing for `(escape ...)` and `(thismodule)`.

ref #55788
