### PR TITLE
fix #52986, regression in `@doc` of macro without REPL loaded

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -577,6 +577,10 @@ function _doc(binding::Binding, sig::Type = Union{})
             for msig in multidoc.order
                 sig <: msig && return multidoc.docs[msig]
             end
+            # if no matching signatures, return first
+            if !isempty(multidoc.docs)
+                return first(values(multidoc.docs))
+            end
         end
     end
     return nothing

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -4,6 +4,7 @@ import Base.Docs: meta, @var, DocStr, parsedoc
 
 # check that @doc can work before REPL is loaded
 @test !startswith(read(`$(Base.julia_cmd()) -E '@doc sin'`, String), "nothing")
+@test !startswith(read(`$(Base.julia_cmd()) -E '@doc @time'`, String), "nothing")
 
 using Markdown
 using REPL


### PR DESCRIPTION
fix #52986