### PR TITLE
Check for conflicting `@ccallable` name before JIT registration

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2349,7 +2349,6 @@ static void jl_compile_extern(jl_method_t *m, void *sysimg_handle) JL_GC_DISABLE
     int success = jl_compile_extern_c(NULL, NULL, sysimg_handle, jl_svecref(sv, 0), jl_svecref(sv, 1));
     if (!success)
         jl_safe_printf("WARNING: @ccallable was already defined for this method name\n"); // enjoy a very bad time
-    assert(success || !sysimg_handle);
 }
 
 


### PR DESCRIPTION
Fixes #54878. For pkgimages with conflicting `@ccallable` definitions:

```console
$ cat Foo/src/Foo.jl
module Foo
Base.@ccallable function foo()::Cint
    return 0
end
end
$ cat Bar/src/Bar.jl
module Bar
Base.@ccallable function foo()::Cint
    return 0
end
end
```

This turns the existing segfault into a warning, as on 1.9:
```julia
julia> using Foo, Bar
WARNING: @ccallable was already defined for this method name
```