### PR TITLE
[Random] Avoid conversion to `Float32` in `Float16` sampler

### DIFF
--- a/stdlib/Random/src/Xoshiro.jl
+++ b/stdlib/Random/src/Xoshiro.jl
@@ -294,7 +294,7 @@ rand(r::Union{TaskLocalRNG, Xoshiro}, ::SamplerTrivial{UInt52{UInt64}})    = ran
 rand(r::Union{TaskLocalRNG, Xoshiro}, ::SamplerTrivial{UInt104{UInt128}})  = rand(r, UInt104Raw())
 
 rand(r::Union{TaskLocalRNG, Xoshiro}, ::SamplerTrivial{CloseOpen01{Float16}}) =
-    Float16(Float32(rand(r, UInt16) >>> 5) * Float32(0x1.0p-11))
+    Float16(rand(r, UInt16) >>> 5) * Float16(0x1.0p-11)
 
 rand(r::Union{TaskLocalRNG, Xoshiro}, ::SamplerTrivial{CloseOpen01{Float32}}) =
     Float32(rand(r, UInt32) >>> 8) * Float32(0x1.0p-24)


### PR DESCRIPTION
Following a discussion I had today with @milankl about https://github.com/JuliaMath/BFloat16s.jl/pull/82, this is a marginally more efficient way to draw a `Float16` on hardware with native support for `Float16`.  The difference in terms of time is almost negligible, but on native `Float16` hardware we can avoid a conversion instruction.  For example, on Apple Silicon, on 441bcd05fe
```julia-repl
julia> code_llvm(rand, (Type{Float16},); debuginfo=:none)
```
```llvm
; Function Signature: rand(Type{Float16})
define half @julia_rand_8379() #0 {
top:
  ; ignore the common part...
  %sum.shift = lshr i64 %6, 53
  %14 = trunc i64 %sum.shift to i16
  %15 = uitofp i16 %14 to float
  %16 = fmul float %15, 0x3F40000000000000
  %17 = fptrunc float %16 to half
  ret half %17
}
```
with this PR:
```llvm
; Function Signature: rand(Type{Float16})
define half @julia_rand_935() #0 {
top:
  ; ignore the common part...
  %sum.shift = lshr i64 %6, 53
  %14 = trunc i64 %sum.shift to i16
  %15 = uitofp i16 %14 to half
  %16 = fmul half %15, 0xH1000
  ret half %16
}
```
Note that we can avoid the `fptrunc float to half` instruction.

The same is evident in the native (ARM) code

<details>
<summary>Native code</summary>

```julia-repl
julia> code_native(rand, (Type{Float16},); debuginfo=:none)
```
```asm
	.section	__TEXT,__text,regular,pure_instructions
	.build_version macos, 14, 0
	.globl	_julia_rand_8382                ; -- Begin function julia_rand_8382
	.p2align	2
_julia_rand_8382:                       ; @julia_rand_8382
; Function Signature: rand(Type{Float16})
; %bb.0:                                ; %top
	stp	x29, x30, [sp, #-16]!           ; 16-byte Folded Spill
	mov	x8, #32524                      ; =0x7f0c
	movk	x8, #174, lsl #16
	movk	x8, #1, lsl #32
	add	x0, x8, #36
	blr	x8
	ldp	x8, x9, [x0, #-56]
	ldp	x12, x10, [x0, #-40]
	add	x11, x10, x8
	ror	x11, x11, #41
	add	x11, x11, x8
	eor	x12, x12, x8
	eor	x10, x10, x9
	eor	x13, x12, x9
	eor	x8, x10, x8
	eor	x9, x12, x9, lsl #17
	ror	x10, x10, #19
	stp	x8, x13, [x0, #-56]
	stp	x9, x10, [x0, #-40]
	lsr	x8, x11, #53
	ucvtf	s0, w8, #11
	fcvt	h0, s0
	ldp	x29, x30, [sp], #16             ; 16-byte Folded Reload
	ret
                                        ; -- End function
	.section	__DATA,__const
	.p2align	3, 0x0                          ; @"+Core.Float16#8384"
"l_+Core.Float16#8384":
	.quad	"l_+Core.Float16#8384.jit"

.set "l_+Core.Float16#8384.jit", 4718995504
.subsections_via_symbols
```

This PR:
```julia-repl
julia> code_native(rand, (Type{Float16},); debuginfo=:none)
```
```asm
	.section	__TEXT,__text,regular,pure_instructions
	.build_version macos, 14, 0
	.globl	_julia_rand_938                 ; -- Begin function julia_rand_938
	.p2align	2
_julia_rand_938:                        ; @julia_rand_938
; Function Signature: rand(Type{Float16})
; %bb.0:                                ; %top
	stp	x29, x30, [sp, #-16]!           ; 16-byte Folded Spill
	mov	x8, #32524                      ; =0x7f0c
	movk	x8, #161, lsl #16
	movk	x8, #1, lsl #32
	add	x0, x8, #36
	blr	x8
	ldp	x8, x9, [x0, #-56]
	ldp	x10, x11, [x0, #-40]
	add	x12, x11, x8
	ror	x12, x12, #41
	add	x12, x12, x8
	eor	x10, x10, x8
	eor	x11, x11, x9
	eor	x13, x10, x9
	eor	x8, x11, x8
	eor	x9, x10, x9, lsl #17
	ror	x10, x11, #19
	stp	x8, x13, [x0, #-56]
	stp	x9, x10, [x0, #-40]
	lsr	x8, x12, #53
	ucvtf	h0, w8, #11
	ldp	x29, x30, [sp], #16             ; 16-byte Folded Reload
	ret
                                        ; -- End function
	.section	__DATA,__const
	.p2align	3, 0x0                          ; @"+Core.Float16#940"
"l_+Core.Float16#940":
	.quad	"l_+Core.Float16#940.jit"

.set "l_+Core.Float16#940.jit", 4718143536
.subsections_via_symbols
```

Note that in the second case the `ucvtf` is done only on the `h0` registry (native half precision), instead of `s0` (single precision) and we can avoid the extra `fcvt` instruction.

</details>

Most importantly, the statistical properties of the distribution is unchanged (same number of unique elements, 2048, and same distribution).