### PR TITLE
expose metric to report reasons why full GCs were triggered

### DIFF
--- a/src/gc-stock.h
+++ b/src/gc-stock.h
@@ -505,6 +505,20 @@ FORCE_INLINE void gc_big_object_link(bigval_t *sentinel_node, bigval_t *node) JL
     sentinel_node->next = node;
 }
 
+// Must be kept in sync with `base/timing.jl`
+#define FULL_SWEEP_REASON_SWEEP_ALWAYS_FULL (0)
+#define FULL_SWEEP_REASON_FORCED_FULL_SWEEP (1)
+#define FULL_SWEEP_REASON_USER_MAX_EXCEEDED (2)
+#define FULL_SWEEP_REASON_LARGE_PROMOTION_RATE (3)
+#define FULL_SWEEP_NUM_REASONS (4)
+
+extern JL_DLLEXPORT uint64_t jl_full_sweep_reasons[FULL_SWEEP_NUM_REASONS];
+STATIC_INLINE void gc_count_full_sweep_reason(int reason) JL_NOTSAFEPOINT
+{
+    assert(reason >= 0 && reason < FULL_SWEEP_NUM_REASONS);
+    jl_full_sweep_reasons[reason]++;
+}
+
 extern uv_mutex_t gc_perm_lock;
 extern uv_mutex_t gc_threads_lock;
 extern uv_cond_t gc_threads_cond;

--- a/test/gc.jl
+++ b/test/gc.jl
@@ -49,6 +49,13 @@ function issue_54275_test()
     @test !live_bytes_has_grown_too_much
 end
 
+function full_sweep_reasons_test()
+    GC.gc()
+    reasons = Base.full_sweep_reasons()
+    @test reasons[:FULL_SWEEP_REASON_FORCED_FULL_SWEEP] >= 1
+    @test keys(reasons) == Set(Base.FULL_SWEEP_REASONS)
+end
+
 # !!! note:
 #     Since we run our tests on 32bit OS as well we confine ourselves
 #     to parameters that allocate about 512MB of objects. Max RSS is lower
@@ -71,6 +78,10 @@ end
 
 @testset "Base.GC docstrings" begin
     @test isempty(Docs.undocumented_names(GC))
+end
+
+@testset "Full GC reasons" begin
+    full_sweep_reasons_test()
 end
 
 #testset doesn't work here because this needs to run in top level


### PR DESCRIPTION
Additional GC observability tool.

This will help us to diagnose why some of our servers are triggering so many full GCs in certain circumstances.