### PR TITLE
Fix some corner cases of `isapprox` with unsigned integers

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -232,7 +232,9 @@ function isapprox(x::Integer, y::Integer;
     if norm === abs && atol < 1 && rtol == 0
         return x == y
     else
-        return norm(x - y) <= max(atol, rtol*max(norm(x), norm(y)))
+        # We need to take the difference `max` - `min` when comparing unsigned integers.
+        _x, _y = x < y ? (x, y) : (y, x)
+        return norm(_y - _x) <= max(atol, rtol*max(norm(_x), norm(_y)))
     end
 end
 

--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -257,6 +257,28 @@ end
     end
 end
 
+@testset "isapprox and unsigned integers" begin
+    for T in Base.BitUnsigned_types
+        # The order of the operands for difference between unsigned integers is
+        # very important, test both combinations.
+        @test isapprox(T(42), T(42); rtol=T(0), atol=0.5)
+        @test !isapprox(T(0), T(1); rtol=T(0), atol=0.5)
+        @test !isapprox(T(1), T(0); rtol=T(0), atol=0.5)
+        @test isapprox(T(1), T(3); atol=T(2))
+        @test isapprox(T(4), T(2); atol=T(2))
+        @test isapprox(T(5), T(7); atol=typemax(T))
+        @test isapprox(T(8), T(6); atol=typemax(T))
+        @test isapprox(T(1), T(2); rtol=1)
+        @test isapprox(T(6), T(3); rtol=1)
+        @test !isapprox(typemin(T), typemax(T))
+        @test !isapprox(typemax(T), typemin(T))
+        @test !isapprox(typemin(T), typemax(T); atol=typemax(T)-T(1))
+        @test !isapprox(typemax(T), typemin(T); atol=typemax(T)-T(1))
+        @test isapprox(typemin(T), typemax(T); atol=typemax(T))
+        @test isapprox(typemax(T), typemin(T); atol=typemax(T))
+    end
+end
+
 @testset "Conversion from floating point to unsigned integer near extremes (#51063)" begin
     @test_throws InexactError UInt32(4.2949673f9)
     @test_throws InexactError UInt64(1.8446744f19)

--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -259,17 +259,24 @@ end
 
 @testset "isapprox and unsigned integers" begin
     for T in Base.BitUnsigned_types
+        # Test also combinations of different integer types
+        W = widen(T)
         # The order of the operands for difference between unsigned integers is
         # very important, test both combinations.
         @test isapprox(T(42), T(42); rtol=T(0), atol=0.5)
+        @test isapprox(T(42), W(42); rtol=T(0), atol=0.5)
         @test !isapprox(T(0), T(1); rtol=T(0), atol=0.5)
         @test !isapprox(T(1), T(0); rtol=T(0), atol=0.5)
         @test isapprox(T(1), T(3); atol=T(2))
         @test isapprox(T(4), T(2); atol=T(2))
+        @test isapprox(T(1), W(3); atol=T(2))
+        @test isapprox(T(4), W(2); atol=T(2))
         @test isapprox(T(5), T(7); atol=typemax(T))
         @test isapprox(T(8), T(6); atol=typemax(T))
         @test isapprox(T(1), T(2); rtol=1)
         @test isapprox(T(6), T(3); rtol=1)
+        @test isapprox(T(1), W(2); rtol=1)
+        @test isapprox(T(6), W(3); rtol=1)
         @test !isapprox(typemin(T), typemax(T))
         @test !isapprox(typemax(T), typemin(T))
         @test !isapprox(typemin(T), typemax(T); atol=typemax(T)-T(1))


### PR DESCRIPTION
Since the order of the operands when doing the difference between two unsigned integers is particularly important, always make sure we do the difference between the larger number and the smaller one.  This addresses some of the corner cases described in #50380 and #55814, but it doesn't fully solve them as the remaining issues with the signed integers (for which there are already tests marked as broken) need a different treatment.