### PR TITLE
Make output type promotion for `LinearAlgebra.normalize` GPU friendly

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1973,9 +1973,9 @@ NaN
 normalize(a::AbstractArray, p::Real = 2) = _normalize(a, norm(a, p))
 
 @inline _normalize(a::AbstractArray{T}, nrm) where {T} = _normalize(promote_type(T, typeof(nrm)), a, nrm)
-Base.@constprop :aggressive @inline _normalize(a::AbstractArray{T}, nrm) where {S, T <: AbstractArray{S}} = _normalize(promote_op(/, T, typeof(nrm)), a, nrm)
+Base.@constprop :aggressive @inline _normalize(a::AbstractArray{T}, nrm) where {T <: AbstractArray} = _normalize(promote_op(/, T, typeof(nrm)), a, nrm)
 
-@inline function _normalize(T, a::AbstractArray, nrm)
+Base.@constprop :aggressive @inline function _normalize(T, a::AbstractArray, nrm)
     if !isempty(a)
         aa = copymutable_oftype(a, T)
         return __normalize!(aa, nrm)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1973,7 +1973,7 @@ NaN
 normalize(a::AbstractArray, p::Real = 2) = _normalize(a, norm(a, p))
 
 @inline _normalize(a::AbstractArray{T}, nrm) where {T} = _normalize(promote_type(T, typeof(nrm)), a, nrm)
-@inline _normalize(a::AbstractArray{T}, nrm) where {T <: AbstractArray} = _normalize(promote_op(/, T, typeof(nrm)), a, nrm)
+Base.@constprop :aggressive @inline _normalize(a::AbstractArray{T}, nrm) where {S, T <: AbstractArray{S}} = _normalize(promote_op(/, T, typeof(nrm)), a, nrm)
 
 @inline function _normalize(T, a::AbstractArray, nrm)
     if !isempty(a)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1972,11 +1972,11 @@ NaN
 """
 function normalize(a::AbstractArray, p::Real = 2)
     nrm = norm(a, p)
+    T = promote_type(eltype(a), typeof(nrm))
     if !isempty(a)
-        aa = copymutable_oftype(a, typeof(first(a)/nrm))
+        aa = copymutable_oftype(a, T)
         return __normalize!(aa, nrm)
     else
-        T = typeof(zero(eltype(a))/nrm)
         return T[]
     end
 end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -665,7 +665,7 @@ true
 ```
 """
 Base.@constprop :aggressive function norm(itr, p::Real=2)
-    isempty(itr) && return float(norm(zero(eltype(itr))))
+    isempty(itr) && return float(norm(zero(eltype(eltype(itr)))))
     v, s = iterate(itr)
     !isnothing(s) && !ismissing(v) && v == itr && throw(ArgumentError(
         "cannot evaluate norm recursively if the type of the initial element is identical to that of the container"))

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1972,7 +1972,6 @@ NaN
 """
 normalize(a::AbstractArray, p::Real = 2) = _normalize(a, norm(a, p))
 
-@inline _normalize(a::AbstractArray, nrm) = _normalize(promote_op(/, eltype(a), typeof(nrm)), a, nrm)
 @inline _normalize(a::AbstractArray{T}, nrm) where {T} = _normalize(promote_type(T, typeof(nrm)), a, nrm)
 @inline _normalize(a::AbstractArray{T}, nrm) where {T <: AbstractArray} = _normalize(promote_op(/, T, typeof(nrm)), a, nrm)
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1970,9 +1970,13 @@ julia> normalize(0, 1)
 NaN
 ```
 """
-function normalize(a::AbstractArray, p::Real = 2)
-    nrm = norm(a, p)
-    T = promote_type(eltype(a), typeof(nrm))
+normalize(a::AbstractArray, p::Real = 2) = _normalize(a, norm(a, p))
+
+@inline _normalize(a::AbstractArray, nrm) = _normalize(promote_op(/, eltype(a), typeof(nrm)), a, nrm)
+@inline _normalize(a::AbstractArray{T}, nrm) where {T} = _normalize(promote_type(T, typeof(nrm)), a, nrm)
+@inline _normalize(a::AbstractArray{T}, nrm) where {T <: AbstractArray} = _normalize(promote_op(/, T, typeof(nrm)), a, nrm)
+
+@inline function _normalize(T, a::AbstractArray, nrm)
     if !isempty(a)
         aa = copymutable_oftype(a, T)
         return __normalize!(aa, nrm)
@@ -1983,6 +1987,8 @@ end
 
 normalize(x) = x / norm(x)
 normalize(x, p::Real) = x / norm(x, p)
+
+
 
 """
     copytrito!(B, A, uplo) -> B

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -414,6 +414,8 @@ end
         @test size.(a) == size.(arr)
         @test axes.(a) == axes.(arr)
     end
+
+    @test typeof(normalize(Vector{Int64}[])) == Vector{Float64}
 end
 
 @testset "normalize for scalars" begin

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -401,7 +401,7 @@ end
         [ones(2), ones(1, 2)],
         [ones(Float16, 2, 3), ones(Int16, 2, 3)],
         [Dual.(randn(2,3), randn(2,3)), Dual.(randn(3,4), randn(3,4))],
-        [OffsetArray([-1,0], (-2,)), OffsetArray([-1;0;;], (-2,-2))]
+        [OffsetArray([-1 0], (-2,-2)), OffsetArray([-1 0], (-2,-2))]
     )
         a = normalize(arr)
         an = norm(arr)
@@ -410,12 +410,12 @@ end
         R = promote_type(T, S)
         @test eltype(a[1]) == R
         @test eltype(a[2]) == R
-        @test eltype(a) == Base.promote_typeof(a[1], a[2])
+        @test eltype(a) == Base.promote_op(/, eltype(a), typeof(an))
         @test size.(a) == size.(arr)
         @test axes.(a) == axes.(arr)
     end
 
-    @test typeof(normalize(Vector{Int64}[])) == Vector{Float64}
+    @test typeof(normalize(Vector{Int64}[])) == Vector{Vector{Float64}}
 end
 
 @testset "normalize for scalars" begin

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -395,6 +395,27 @@ end
     @test typeof(normalize([1 2 3; 4 5 6])) == Array{Float64,2}
 end
 
+@testset "normalize for nested arrays" begin
+    for arr in (
+        [ones(2, 1), ones(1, 2)],
+        [ones(2), ones(1, 2)],
+        [ones(Float16, 2, 3), ones(Int16, 2, 3)],
+        [Dual.(randn(2,3), randn(2,3)), Dual.(randn(3,4), randn(3,4))],
+        [OffsetArray([-1,0], (-2,)), OffsetArray([-1;0;;], (-2,-2))]
+    )
+        a = normalize(arr)
+        an = norm(arr)
+        T = promote_type(eltype(arr[1]), typeof(an))
+        S = promote_type(eltype(arr[2]), typeof(an))
+        R = promote_type(T, S)
+        @test eltype(a[1]) == R
+        @test eltype(a[2]) == R
+        @test eltype(a) == Base.promote_typeof(a[1], a[2])
+        @test size.(a) == size.(arr)
+        @test axes.(a) == axes.(arr)
+    end
+end
+
 @testset "normalize for scalars" begin
     @test normalize(8.0) == 1.0
     @test normalize(-3.0) == -1.0


### PR DESCRIPTION
Relying on the type of the first element of the array is brittle. It also prevents this function from being used in GPU code (scalar indexing).

I can't intuit why the code was so convoluted though - does it predate the type promotion framework? **EDIT: Apparently it was a workaround for array of array type promotion.**

AFAICT this passes relevant tests, though they seem sparse. I'll see what CI does.

**EDIT: Also fixes corner case where `norm` errors on empty array of arrays, and adds tests**