### PR TITLE
Specialize `parentmodule` for `IntrinsicFunction`

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -2378,6 +2378,7 @@ Determine the module containing the (first) definition of a generic
 function.
 """
 parentmodule(f::Function) = parentmodule(typeof(f))
+parentmodule(f::Core.IntrinsicFunction) = Core.Intrinsics
 
 """
     parentmodule(f::Function, types) -> Module


### PR DESCRIPTION
Before:
```julia
julia> parentmodule(Base.add_float)
Core

julia> Core.add_float
ERROR: UndefVarError: `add_float` not defined in `Core`
Suggestion: check for spelling errors or missing imports.
Stacktrace:
 [1] getproperty(x::Module, f::Symbol)
   @ Base ./Base.jl:42
 [2] top-level scope
   @ REPL[92]:1
```
Now:
```julia
julia> parentmodule(Base.add_float) == Core.Intrinsics # (edited, originally contained a typo)
true

julia> Core.Intrinsics.add_float
add_float (intrinsic function 12)
```