### PR TITLE
Apple: fix bus error on smaller readonly file in unix

### DIFF
--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -213,9 +213,7 @@ function mmap(io::IO,
     szfile = convert(Csize_t, len + offset)
     requestedSizeLarger = false
     if !(io isa Mmap.Anonymous)
-        @static if !Sys.isapple()
-            requestedSizeLarger = szfile > filesize(io)
-        end
+        requestedSizeLarger = szfile > filesize(io)
     end
     # platform-specific mmapping
     @static if Sys.isunix()
@@ -230,9 +228,6 @@ function mmap(io::IO,
             else
                 throw(ArgumentError("unable to increase file size to $szfile due to read-only permissions"))
             end
-        end
-        @static if Sys.isapple()
-            iswrite && grow && grow!(io, offset, len)
         end
         # mmap the file
         ptr = ccall(:jl_mmap, Ptr{Cvoid}, (Ptr{Cvoid}, Csize_t, Cint, Cint, RawFD, Int64),


### PR DESCRIPTION
Enables the fix for #28245 in #44354 for Apple now that the Julia bug is fixed by #55641.

Closes #28245