### PR TITLE
doc: `baremodule`: more accurate `include` example

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -187,7 +187,8 @@ baremodule Mod
 using Base
 
 eval(x) = Core.eval(Mod, x)
-include(p) = Base.include(Mod, p)
+include(p::AbstractString) = Base.include(Mod, p)
+include(f::Function, p::AbstractString) = Base.include(f, Mod, p)
 
 ...
 


### PR DESCRIPTION
In the example code:
* show the two-argument method, too
* show the dispatch constraint on the path argument of `include`, xref #55466