### PR TITLE
fix dispatch constraint on arg on rationalize for AbstractIrrational

### DIFF
--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -110,7 +110,7 @@ end
 <=(x::AbstractFloat, y::AbstractIrrational) = x < y
 
 # Irrational vs Rational
-@assume_effects :total function rationalize(::Type{T}, x::AbstractIrrational; tol::Real=0) where T
+@assume_effects :total function rationalize(::Type{T}, x::AbstractIrrational; tol::Real=0) where {T <: Integer}
     return rationalize(T, big(x), tol=tol)
 end
 @assume_effects :total function lessrational(rx::Rational{<:Integer}, x::AbstractIrrational)


### PR DESCRIPTION
The type is the type parameter of `Rational`, so it should be `<:Integer`. All the other `rationalize` methods have the `<:Integer` constraint for that argument.