### PR TITLE
lowering: split `finally` blocks for exceptional control-flow

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -4854,10 +4854,14 @@ f(x) = yt(x)
                  ;; separate trycatch and tryfinally blocks earlier.
                  (mark-label catch)
                  (if finally
-                     (begin (enter-finally-block catchcode #f) ;; enter block via exception
+                     (begin (set! finally-handler last-finally-handler)
+                            (set! catch-token-stack (cons handler-token catch-token-stack))
+                            (compile (caddr e) break-labels #f #f) ;; enter block via exception
+                            (emit '(call (top rethrow)))
+                            (emit-return tail '(null)) ; unreachable
+                            (set! catch-token-stack (cdr catch-token-stack))
                             (mark-label endl) ;; non-exceptional control flow enters here
-                            (set! finally-handler last-finally-handler)
-                            (compile (caddr e) break-labels #f #f)
+                            (compile (renumber-assigned-ssavalues (caddr e)) break-labels #f #f)
                             ;; emit actions to be taken at exit of finally
                             ;; block, depending on the tag variable `finally`
                             (let loop ((actions (caddr my-finally-handler)))

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -241,6 +241,18 @@ end
         end
     end)()
     @test length(Base.current_exceptions()) == 0
+
+    (()-> begin
+        while true
+            try
+                error("foo")
+            finally
+                break
+            end
+        end
+        @test length(Base.current_exceptions()) == 0
+    end)()
+    @test length(Base.current_exceptions()) == 0
 end
 
 @testset "Deep exception stacks" begin


### PR DESCRIPTION
This change duplicates `finally` blocks in lowered IR, so that they can have a static nesting depth in the `try-catch` hierarchy.

Previously, `finally` control-flow looked like this:

```
error   non-error
    \   /
     \ /
      |
    finally block
      |
     / \
    /   \
 error   non-error
```

This kind of flow is a problem, because in a couple places the compiler assumes that it can actually "color" the CFG such that there is a static nesting depth at each BasicBlock (i.e. each BasicBlock can be labeled w/ a unique enclosing `try` / `catch` scope). The above `finally` pattern violates that assumption.

In an upcoming PR, I want to extend the lifetimes of our Event Handlers (`jl_handler_t`) until the end of a `catch` block (rather than the start) which noticeably breaks `llvm-lower-handlers.cpp`. (@keno was very clear about this assumption in the comments for that pass.)

Behaviorally this was _mostly_ benign, except for some mis-handling of an erroring entry that turns into a non-erroring exit:
```julia
function foo()
    try
        error("foo")
    finally
        return nothing
    end
end

function bar()
    if foo() === nothing
        # ...
    end
    # do things
    error("baz")
end
```
which spits out internal compiler stack traces (oops!):
```
julia> bar()
ERROR: baz
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] bar()
   @ Main ./REPL[2]:6
 [3] top-level scope
   @ REPL[3]:1

caused by: foo
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] foo()
    @ Main ./REPL[1]:3
  [3]
    @ Core.Compiler ./compiler/abstractinterpretation.jl:909
  [4]
    @ Core.Compiler ./compiler/abstractinterpretation.jl:794
  [5]
    @ Core.Compiler ./compiler/abstractinterpretation.jl:788
  [6]
    @ Core.Compiler ./compiler/abstractinterpretation.jl:103
# ... <snip>
 [21] typeinf_ext_toplevel(mi::Core.MethodInstance, world::UInt64)
    @ Core.Compiler ./compiler/typeinfer.jl:1078
 [22] top-level scope
    @ REPL[3]:1
```

That could be fixed by banning `break` and `return` within `finally` blocks or making the lowering more complicated, but this PR instead splits the `finally` block into an erroring and non-erroring path so that we can attach the `catch` handler appropriately.
