### PR TITLE
add Order.rev() for reverse sorting

### DIFF
--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -174,4 +174,19 @@ if ccall(:jl_ver_major, Int32, ()) < 2
     ordtype(o::Ordering,        vs::AbstractArray) = eltype(vs)
 end
 
+"""    rev(val)
+
+A wrapper that reverses the order of `isless` comparisons. Useful when sorting by several keys, some forward, some reverse.
+
+# Examples
+```julia
+sort(..., by=x -> (x.a, rev(x.b), rev(x.c)))
+```
+"""
+struct rev{T}
+    val::T
+end
+
+Base.isless(a::rev, b::rev) = isless(b.val, a.val)
+
 end

--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -180,7 +180,7 @@ A wrapper that reverses the order of `isless` comparisons. Useful when sorting b
 
 # Examples
 ```julia
-sort(..., by=x -> (x.a, rev(x.b), rev(x.c)))
+sort(..., by=x -> (x.a, Order.rev(x.b), Order.rev(x.c)))
 ```
 """
 struct rev{T}


### PR DESCRIPTION
_**upd:** available in `DataManipulation.jl` in the meantime_

---

Sorting with `by=x -> (x[1], x[2])` sorts by `x[1]` and then (for `x[1]` duplicates) by `x[2]`.

Then, `sort(X; by)` sorts in the ascending order of `x[1]` and `x[2]`, `sort(X; by, rev=true)` sorts in the descending order of both.

But there's no way to sort in ascending order of `x[1]` and then descending order of `x[2]`. This PR makes it possible, with `by=x -> (x[1], Order.rev(x[2])`.

What do you think of this interface? I imagine this `Order.rev` function being public, but not exported.