### PR TITLE
doc: MathConstants: add admonitions noting unknown rationality

### DIFF
--- a/base/mathconstants.jl
+++ b/base/mathconstants.jl
@@ -88,6 +88,10 @@ true
 
 Euler's constant.
 
+!!! note
+    Even though `MathConstants.γ isa Irrational`, it is not actually known
+    whether Euler's constant is rational.
+
 # Examples
 ```jldoctest
 julia> Base.MathConstants.eulergamma
@@ -122,6 +126,10 @@ true
     catalan
 
 Catalan's constant.
+
+!!! note
+    Even though `MathConstants.catalan isa Irrational`, it is not actually known
+    whether Catalan's constant is rational.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Some of the `Irrational` constants are not known to be irrational, so it'd be good to note that in the doc string of each such constant to avoid being misleading.