### PR TITLE
try adding more unwind info to builds fix profiling

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -496,11 +496,12 @@ endif
 endif
 
 JCFLAGS_COMMON    := -std=gnu11 -pipe $(fPIC) -fno-strict-aliasing -D_FILE_OFFSET_BITS=64 -Wformat -Wformat-security
+JCFLAGS_COMMON    := $(JCFLAGS_COMMON) -funwind-tables -fasynchronous-unwind-tables -femit-dwarf-unwind=always
 JCFLAGS_CLANG     := $(JCFLAGS_COMMON)
 JCFLAGS_GCC       := $(JCFLAGS_COMMON) -fno-gnu-unique
 
 # These flags are needed to generate decent debug info
-JCPPFLAGS_COMMON  := -fasynchronous-unwind-tables
+JCPPFLAGS_COMMON  := -funwind-tables -fasynchronous-unwind-tables -femit-dwarf-unwind=always
 JCPPFLAGS_CLANG   := $(JCPPFLAGS_COMMON) -mllvm -enable-tail-merge=0
 JCPPFLAGS_GCC     := $(JCPPFLAGS_COMMON) -fno-tree-tail-merge
 


### PR DESCRIPTION
Mainly opening as a place to collect attempts to improve profiling sampling (on MacOS, but maybe more generally)

I have no idea how repeatable these are but as an example, profiling some printing stuff and showing with `ProfileView.view(C=true)`

## master
![Screenshot 2024-09-26 at 10 52 58 PM](https://github.com/user-attachments/assets/7540f9ef-8564-48ef-beeb-70162d87e170)


## this PR
with 
```
USE_BINARYBUILDER_LIBUNWIND := 0
USE_BINARYBUILDER_OPENBLAS := 0
USE_BINARYBUILDER_OBJCONV := 0
```

![Screenshot 2024-09-27 at 1 57 59 PM](https://github.com/user-attachments/assets/77694814-b119-44e5-a158-f61eb444eb84)
