### PR TITLE
InteractiveUtils: add `@trace_compile` and `@trace_dispatch`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -178,6 +178,9 @@ Standard library changes
 
 #### InteractiveUtils
 
+* New macro `@trace_compile` for running an expression and show which methods are compiled, with timing
+  i.e. with `--trace-compile=stderr --trace-compile-timing` enabled for that call only. ([#55915])
+
 Deprecated or removed
 ---------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -178,8 +178,9 @@ Standard library changes
 
 #### InteractiveUtils
 
-* New macro `@trace_compile` for running an expression and show which methods are compiled, with timing
-  i.e. with `--trace-compile=stderr --trace-compile-timing` enabled for that call only. ([#55915])
+* New macros `@trace_compile` and `@trace_dispatch` for running an expression with
+  `--trace-compile=stderr --trace-compile-timing` and `--trace-dispatch=stderr` respectively enabled.
+  ([#55915])
 
 Deprecated or removed
 ---------------------

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1486,11 +1486,11 @@ from the manifest, then revert the change with `pkg> undo`.
 
 If loading time is dominated by slow `__init__()` methods having compilation, one verbose way to identify what is being
 compiled is to use the julia args `--trace-compile=stderr --trace-compile-timing` which will report a [`precompile`](@ref)
-statement each time a method is compiled, along with how long compilation took. For instance, the full setup would be:
+statement each time a method is compiled, along with how long compilation took. The InteractiveUtils macro
+[`@trace_compile`](@ref) provides a way to enable those args for a specific call. So a call for a complete report report would look like:
 
 ```
-$ julia --startup-file=no --trace-compile=stderr --trace-compile-timing
-julia> @time @time_imports using CustomPackage
+julia> @time @time_imports @trace_compile using CustomPackage
 ...
 ```
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -2513,12 +2513,32 @@ jl_code_instance_t *jl_method_inferred_with_abi(jl_method_instance_t *mi JL_PROP
 
 jl_mutex_t precomp_statement_out_lock;
 
+_Atomic(uint8_t) jl_force_trace_compile_timing_enabled = 0;
+
+/**
+ * @brief Enable force trace compile to stderr with timing.
+ */
+JL_DLLEXPORT void jl_force_trace_compile_timing_enable(void)
+{
+    // Increment the flag to allow reentrant callers to `@trace_compile`.
+    jl_atomic_fetch_add(&jl_force_trace_compile_timing_enabled, 1);
+}
+/**
+ * @brief Disable force trace compile to stderr with timing.
+ */
+JL_DLLEXPORT void jl_force_trace_compile_timing_disable(void)
+{
+    // Increment the flag to allow reentrant callers to `@trace_compile`.
+    jl_atomic_fetch_add(&jl_force_trace_compile_timing_enabled, -1);
+}
+
 static void record_precompile_statement(jl_method_instance_t *mi, double compilation_time, int is_recompile)
 {
     static ios_t f_precompile;
     static JL_STREAM* s_precompile = NULL;
     jl_method_t *def = mi->def.method;
-    if (jl_options.trace_compile == NULL)
+    uint8_t force_trace_compile = jl_atomic_load_relaxed(&jl_force_trace_compile_timing_enabled);
+    if (force_trace_compile == 0 && jl_options.trace_compile == NULL)
         return;
     if (!jl_is_method(def))
         return;
@@ -2528,7 +2548,7 @@ static void record_precompile_statement(jl_method_instance_t *mi, double compila
     JL_LOCK(&precomp_statement_out_lock);
     if (s_precompile == NULL) {
         const char *t = jl_options.trace_compile;
-        if (!strncmp(t, "stderr", 6)) {
+        if (force_trace_compile || !strncmp(t, "stderr", 6)) {
             s_precompile = JL_STDERR;
         }
         else {
@@ -2540,7 +2560,7 @@ static void record_precompile_statement(jl_method_instance_t *mi, double compila
     if (!jl_has_free_typevars(mi->specTypes)) {
         if (is_recompile && s_precompile == JL_STDERR && jl_options.color != JL_OPTIONS_COLOR_OFF)
             jl_printf(s_precompile, "\e[33m");
-        if (jl_options.trace_compile_timing)
+        if (force_trace_compile || jl_options.trace_compile_timing)
             jl_printf(s_precompile, "#= %6.1f ms =# ", compilation_time / 1e6);
         jl_printf(s_precompile, "precompile(");
         jl_static_show(s_precompile, mi->specTypes);

--- a/src/gf.c
+++ b/src/gf.c
@@ -2582,6 +2582,25 @@ static void record_precompile_statement(jl_method_instance_t *mi, double compila
 
 jl_mutex_t dispatch_statement_out_lock;
 
+_Atomic(uint8_t) jl_force_trace_dispatch_enabled = 0;
+
+/**
+ * @brief Enable force trace dispatch to stderr.
+ */
+JL_DLLEXPORT void jl_force_trace_dispatch_enable(void)
+{
+    // Increment the flag to allow reentrant callers to `@trace_dispatch`.
+    jl_atomic_fetch_add(&jl_force_trace_dispatch_enabled, 1);
+}
+/**
+ * @brief Disable force trace dispatch to stderr.
+ */
+JL_DLLEXPORT void jl_force_trace_dispatch_disable(void)
+{
+    // Increment the flag to allow reentrant callers to `@trace_dispatch`.
+    jl_atomic_fetch_add(&jl_force_trace_dispatch_enabled, -1);
+}
+
 static void record_dispatch_statement(jl_method_instance_t *mi)
 {
     static ios_t f_dispatch;
@@ -2590,10 +2609,11 @@ static void record_dispatch_statement(jl_method_instance_t *mi)
     if (!jl_is_method(def))
         return;
 
+    uint8_t force_trace_dispatch = jl_atomic_load_relaxed(&jl_force_trace_dispatch_enabled);
     JL_LOCK(&dispatch_statement_out_lock);
     if (s_dispatch == NULL) {
         const char *t = jl_options.trace_dispatch;
-        if (!strncmp(t, "stderr", 6)) {
+        if (force_trace_dispatch || !strncmp(t, "stderr", 6)) {
             s_dispatch = JL_STDERR;
         }
         else {
@@ -3413,7 +3433,8 @@ have_entry:
             // unreachable
         }
         // mfunc is about to be dispatched
-        if (jl_options.trace_dispatch != NULL) {
+        uint8_t force_trace_dispatch = jl_atomic_load_relaxed(&jl_force_trace_dispatch_enabled);
+        if (force_trace_dispatch || jl_options.trace_dispatch != NULL) {
             uint8_t miflags = jl_atomic_load_relaxed(&mfunc->flags);
             uint8_t was_dispatched = miflags & JL_MI_FLAGS_MASK_DISPATCHED;
             if (!was_dispatched) {
@@ -3544,7 +3565,8 @@ jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value
             jl_gc_sync_total_bytes(last_alloc); // discard allocation count from compilation
     }
     JL_GC_PROMISE_ROOTED(mfunc);
-    if (jl_options.trace_dispatch != NULL) {
+    uint8_t force_trace_dispatch = jl_atomic_load_relaxed(&jl_force_trace_dispatch_enabled);
+    if (force_trace_dispatch || jl_options.trace_dispatch != NULL) {
         uint8_t miflags = jl_atomic_load_relaxed(&mfunc->flags);
         uint8_t was_dispatched = miflags & JL_MI_FLAGS_MASK_DISPATCHED;
         if (!was_dispatched) {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1171,6 +1171,9 @@ JL_DLLEXPORT jl_code_instance_t *jl_cache_uninferred(jl_method_instance_t *mi, j
 JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst_for_uninferred(jl_method_instance_t *mi, jl_code_info_t *src);
 JL_DLLEXPORT extern jl_value_t *(*const jl_rettype_inferred_addr)(jl_method_instance_t *mi JL_PROPAGATES_ROOT, size_t min_world, size_t max_world) JL_NOTSAFEPOINT;
 
+JL_DLLEXPORT void jl_force_trace_compile_timing_enable(void);
+JL_DLLEXPORT void jl_force_trace_compile_timing_disable(void);
+
 uint32_t jl_module_next_counter(jl_module_t *m) JL_NOTSAFEPOINT;
 jl_tupletype_t *arg_type_tuple(jl_value_t *arg1, jl_value_t **args, size_t nargs);
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1174,6 +1174,9 @@ JL_DLLEXPORT extern jl_value_t *(*const jl_rettype_inferred_addr)(jl_method_inst
 JL_DLLEXPORT void jl_force_trace_compile_timing_enable(void);
 JL_DLLEXPORT void jl_force_trace_compile_timing_disable(void);
 
+JL_DLLEXPORT void jl_force_trace_dispatch_enable(void);
+JL_DLLEXPORT void jl_force_trace_dispatch_disable(void);
+
 uint32_t jl_module_next_counter(jl_module_t *m) JL_NOTSAFEPOINT;
 jl_tupletype_t *arg_type_tuple(jl_value_t *arg1, jl_value_t **args, size_t nargs);
 

--- a/stdlib/InteractiveUtils/docs/src/index.md
+++ b/stdlib/InteractiveUtils/docs/src/index.md
@@ -33,5 +33,6 @@ InteractiveUtils.@code_llvm
 InteractiveUtils.code_native
 InteractiveUtils.@code_native
 InteractiveUtils.@time_imports
+InteractiveUtils.@trace_compile
 InteractiveUtils.clipboard
 ```

--- a/stdlib/InteractiveUtils/docs/src/index.md
+++ b/stdlib/InteractiveUtils/docs/src/index.md
@@ -34,5 +34,6 @@ InteractiveUtils.code_native
 InteractiveUtils.@code_native
 InteractiveUtils.@time_imports
 InteractiveUtils.@trace_compile
+InteractiveUtils.@trace_dispatch
 InteractiveUtils.clipboard
 ```

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -11,7 +11,7 @@ Base.Experimental.@optlevel 1
 
 export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, varinfo,
     versioninfo, subtypes, supertypes, @which, @edit, @less, @functionloc, @code_warntype,
-    @code_typed, @code_lowered, @code_llvm, @code_native, @time_imports, clipboard
+    @code_typed, @code_lowered, @code_llvm, @code_native, @time_imports, clipboard, @trace_compile
 
 import Base.Docs.apropos
 

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -11,7 +11,7 @@ Base.Experimental.@optlevel 1
 
 export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, varinfo,
     versioninfo, subtypes, supertypes, @which, @edit, @less, @functionloc, @code_warntype,
-    @code_typed, @code_lowered, @code_llvm, @code_native, @time_imports, clipboard, @trace_compile
+    @code_typed, @code_lowered, @code_llvm, @code_native, @time_imports, clipboard, @trace_compile, @trace_dispatch
 
 import Base.Docs.apropos
 

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -256,6 +256,17 @@ macro time_imports(ex)
     end
 end
 
+macro trace_compile(ex)
+    quote
+        try
+            ccall(:jl_force_trace_compile_timing_enable, Cvoid, ())
+            $(esc(ex))
+        finally
+            ccall(:jl_force_trace_compile_timing_disable, Cvoid, ())
+        end
+    end
+end
+
 """
     @functionloc
 
@@ -409,3 +420,24 @@ julia> @time_imports using CSV
 
 """
 :@time_imports
+
+"""
+    @trace_compile
+
+A macro to execute an expression and show any methods that were compiled (or recompiled in yellow),
+like the julia args `--trace-compile=stderr --trace-compile-timing` but specifically for a call.
+
+```julia-repl
+julia> @trace_compile rand(2,2) * rand(2,2)
+#=   39.1 ms =# precompile(Tuple{typeof(Base.rand), Int64, Int64})
+#=  102.0 ms =# precompile(Tuple{typeof(Base.:(*)), Array{Float64, 2}, Array{Float64, 2}})
+2×2 Matrix{Float64}:
+ 0.421704  0.864841
+ 0.211262  0.444366
+```
+
+!!! compat "Julia 1.12"
+    This macro requires at least Julia 1.12
+
+"""
+:@trace_compile

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -267,6 +267,17 @@ macro trace_compile(ex)
     end
 end
 
+macro trace_dispatch(ex)
+    quote
+        try
+            ccall(:jl_force_trace_dispatch_enable, Cvoid, ())
+            $(esc(ex))
+        finally
+            ccall(:jl_force_trace_dispatch_disable, Cvoid, ())
+        end
+    end
+end
+
 """
     @functionloc
 
@@ -441,3 +452,15 @@ julia> @trace_compile rand(2,2) * rand(2,2)
 
 """
 :@trace_compile
+
+"""
+    @trace_dispatch
+
+A macro to execute an expression and report methods that were compiled via dynamic dispatch,
+like the julia arg `--trace-dispatch=stderr` but specifically for a call.
+
+!!! compat "Julia 1.12"
+    This macro requires at least Julia 1.12
+
+"""
+:@trace_dispatch


### PR DESCRIPTION
Sometimes you just want to see what's compiling in a live session rather than restart into a dedicated session with trace-compile on.

```
julia> @trace_compile rand(2,2) * rand(2,2)
#=   39.1 ms =# precompile(Tuple{typeof(Base.rand), Int64, Int64})
#=  102.0 ms =# precompile(Tuple{typeof(Base.:(*)), Array{Float64, 2}, Array{Float64, 2}})
2×2 Matrix{Float64}:
 0.421704  0.864841
 0.211262  0.444366

```

Another benefit is being able to use it in conjunction with `@time` and `@time_imports`
```
 @time @time_imports @trace_compile using Foo
```

I think it also makes sense to add `@trace_dispatch` after https://github.com/JuliaLang/julia/pull/55848 is merged.

