### PR TITLE
fix rawbigints OOB issues

### DIFF
--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -1088,3 +1088,12 @@ end
         clear_flags()
     end
 end
+
+@testset "RawBigInt truncation OOB read" begin
+    @testset "T: $T" for T ∈ (UInt8, UInt16, UInt32, UInt64, UInt128)
+        v = Base.RawBigInt{T}("a"^sizeof(T), 1)
+        @testset "bit_count: $bit_count" for bit_count ∈ (0:10:80)
+            @test Base.truncated(UInt128, v, bit_count) isa Any
+        end
+    end
+end


### PR DESCRIPTION
Fixes issues introduced in #50691 and found in #55906:
* use `@inbounds` and `@boundscheck` macros in rawbigints, for catching OOB with `--check-bounds=yes`
* fix OOB in `truncate`

The fixes need backporting to v1.11, so this would ideally be merged before #55906.