### PR TITLE
Clarify `div` docstring for floating-point input

### DIFF
--- a/base/div.jl
+++ b/base/div.jl
@@ -43,6 +43,21 @@ julia> div(4, 3, RoundFromZero)
 julia> div(-4, 3, RoundFromZero)
 -2
 ```
+Because `div(x, y)` implements strictly correct truncated rounding based on the true
+value of floating-point numbers, unintuitive situations can arise. For example:
+```jldoctest
+julia> div(6.0, 0.1)
+59.0
+julia> 6.0 / 0.1
+60.0
+julia> 6.0 / big(0.1)
+59.99999999999999666933092612453056361837965690217069245739573412231113406246995
+```
+What is happening here is that the true value of the floating-point number written
+as `0.1` is slightly larger than the numerical value 1/10 while `6.0` represents
+the number 6 precisely. Therefore the true value of `6.0 / 0.1` is slightly less
+than 60. When doing division, this is rounded to precisely `60.0`, but
+`div(6.0, 0.1, RoundToZero)` always truncates the true value, so the result is `59.0`.
 """
 div(x, y, r::RoundingMode)
 


### PR DESCRIPTION
Closes #55837

This is a variant of the warning found in the `fld` docstring clarifying floating-point behaviour.