### PR TITLE
Allow function negation `-f` to work like `!f`

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1154,6 +1154,29 @@ julia> filter(!isletter, str)
 !(f::ComposedFunction{typeof(!)}) = f.inner #allows !!f === f
 
 """
+    -f::Function
+
+When the argument of `-` is a function, it returns `(-) ∘ f`.
+
+See also [`!`](@ref) for boolean negation, and [`∘`](@ref).
+
+# Examples
+```jldoctest
+julia> map(-abs2, Tuple(-2:2))
+(-4, -1, 0, -1, -4)
+
+julia> sum(-log10, [1 0.1; 0.01 0.001]; dims=1)
+1×2 Matrix{Float64}:
+ 2.0  4.0
+```
+
+!!! compat "Julia 1.12"
+    This method requires at least Julia 1.12.
+"""
+-(f::Function) = (-) ∘ f
+-(f::ComposedFunction{typeof(-)}) = f.inner #allows -(-f) === f
+
+"""
     Fix{N}(f, x)
 
 A type representing a partially-applied version of a function `f`, with the argument


### PR DESCRIPTION
We have `!f === (!)∘f` to negate any boolean function. Was there ever discussion of making `-f === (-)∘f` too? Both are small conveniences to avoid defining `x -> op(x)`. This one would allow for example:

```julia
julia> A = reshape(1:16,4,4);

julia> eigvals(A; sortby=-real)  # does not accept rev=true
4-element Vector{ComplexF64}:
     36.209372712298546 + 0.0im
 -4.146487327145629e-17 + 1.9341169324764503e-16im
 -4.146487327145629e-17 - 1.9341169324764503e-16im
     -2.209372712298546 + 0.0im

julia> sum(-log, A; dims=1)  # -sum allocates twice
1×4 Matrix{Float64}:
 -3.17805  -7.42655  -9.38261  -10.6846
```

This will not change the fact that `-f.(xs)` means `-(f.(xs))`, when usually fused `@. -f(xs)` would be better. (Unless you write `(-f).(xs)` by hand.)

Needs tests obviously, but RFC? 
