### PR TITLE
REPL: make UndefVarError aware of imported modules

### DIFF
--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -321,7 +321,7 @@ function show_error_hints(io, ex, args...)
             @invokelatest handler(io, ex, args...)
         catch err
             tn = typeof(handler).name
-            @error "Hint-handler $handler for $(typeof(ex)) in $(tn.module) caused an error"
+            @error "Hint-handler $handler for $(typeof(ex)) in $(tn.module) caused an error" err
         end
     end
 end

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -319,9 +319,9 @@ function show_error_hints(io, ex, args...)
     for handler in hinters
         try
             @invokelatest handler(io, ex, args...)
-        catch err
+        catch
             tn = typeof(handler).name
-            @error "Hint-handler $handler for $(typeof(ex)) in $(tn.module) caused an error" err
+            @error "Hint-handler $handler for $(typeof(ex)) in $(tn.module) caused an error" exception=current_exceptions()
         end
     end
 end

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -74,7 +74,18 @@ end
 function _UndefVarError_warnfor(io::IO, m::Module, var::Symbol)
     Base.isbindingresolved(m, var) || return false
     (Base.isexported(m, var) || Base.ispublic(m, var)) || return false
-    print(io, "\nHint: a global variable of this name also exists in $m.")
+    active_mod = Base.active_module()
+    mod_imported = in(Symbol(m), names(active_mod, imported=true))
+    if !mod_imported && Symbol(m) == var
+        print(io, "\nHint: $m is loaded but not imported in the active module `$(active_mod)`.")
+    else
+        print(io, "\nHint: a global variable of this name also exists in $m")
+        if mod_imported
+            print(io, ".")
+        else
+            print(io, ", which is loaded but not imported in the active module `$(active_mod)`.")
+        end
+    end
     return true
 end
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -75,15 +75,14 @@ function _UndefVarError_warnfor(io::IO, m::Module, var::Symbol)
     Base.isbindingresolved(m, var) || return false
     (Base.isexported(m, var) || Base.ispublic(m, var)) || return false
     active_mod = Base.active_module()
-    mod_imported = isdefined(active_mod, Symbol(m))
-    if !mod_imported && Symbol(m) == var
-        print(io, "\nHint: $m is loaded but not imported in the active module `$(active_mod)`.")
+    print(io, "\nHint: ")
+    if isdefined(active_mod, Symbol(m))
+        print(io, "a global variable of this name also exists in $m.")
     else
-        print(io, "\nHint: a global variable of this name also exists in $m")
-        if mod_imported
-            print(io, ".")
+        if Symbol(m) == var
+            print(io, "$m is loaded but not imported in the active module $active_mod.")
         else
-            print(io, ", which is loaded but not imported in the active module `$(active_mod)`.")
+            print(io, "a global variable of this name may be made accessible by importing $m in the current active module $active_mod")
         end
     end
     return true

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -75,7 +75,7 @@ function _UndefVarError_warnfor(io::IO, m::Module, var::Symbol)
     Base.isbindingresolved(m, var) || return false
     (Base.isexported(m, var) || Base.ispublic(m, var)) || return false
     active_mod = Base.active_module()
-    mod_imported = in(Symbol(m), names(active_mod, imported=true))
+    mod_imported = isdefined(active_mod, Symbol(m))
     if !mod_imported && Symbol(m) == var
         print(io, "\nHint: $m is loaded but not imported in the active module `$(active_mod)`.")
     else


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/55914

```
(@v1.12) pkg>

julia> Pkg
ERROR: UndefVarError: `Pkg` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
Hint: Pkg is loaded but not imported in the active module `Main`.

julia> activate
ERROR: UndefVarError: `activate` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
Hint: a global variable of this name also exists in Pkg, which is loaded but not imported in the active module `Main`.

julia> import Pkg

julia> activate
ERROR: UndefVarError: `activate` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
Hint: a global variable of this name also exists in Pkg.

```