### PR TITLE
improved `eltype` for `flatten` with tuple argument

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -30,7 +30,7 @@ end
 import .Base:
     first, last,
     isempty, length, size, axes, ndims,
-    eltype, IteratorSize, IteratorEltype, promote_type,
+    eltype, IteratorSize, IteratorEltype, promote_typejoin,
     haskey, keys, values, pairs,
     getindex, setindex!, get, iterate,
     popfirst!, isdone, peek, intersect
@@ -1213,7 +1213,7 @@ julia> [(x,y) for x in 0:1 for y in 'a':'c']  # collects generators involving It
 flatten(itr) = Flatten(itr)
 
 eltype(::Type{Flatten{I}}) where {I} = eltype(eltype(I))
-eltype(::Type{Flatten{I}}) where {I<:Tuple} = promote_type(map(eltype, fieldtypes(I))...)
+eltype(::Type{Flatten{I}}) where {I<:Union{Tuple,NamedTuple}} = promote_typejoin(map(eltype, fieldtypes(I))...)
 eltype(::Type{Flatten{Tuple{}}}) = eltype(Tuple{})
 IteratorEltype(::Type{Flatten{I}}) where {I} = _flatteneltype(I, IteratorEltype(I))
 IteratorEltype(::Type{Flatten{Tuple{}}}) = IteratorEltype(Tuple{})

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -30,7 +30,7 @@ end
 import .Base:
     first, last,
     isempty, length, size, axes, ndims,
-    eltype, IteratorSize, IteratorEltype,
+    eltype, IteratorSize, IteratorEltype, promote_type,
     haskey, keys, values, pairs,
     getindex, setindex!, get, iterate,
     popfirst!, isdone, peek, intersect
@@ -1213,6 +1213,7 @@ julia> [(x,y) for x in 0:1 for y in 'a':'c']  # collects generators involving It
 flatten(itr) = Flatten(itr)
 
 eltype(::Type{Flatten{I}}) where {I} = eltype(eltype(I))
+eltype(::Type{Flatten{I}}) where {I<:Tuple} = promote_type(map(eltype, fieldtypes(I))...)
 eltype(::Type{Flatten{Tuple{}}}) = eltype(Tuple{})
 IteratorEltype(::Type{Flatten{I}}) where {I} = _flatteneltype(I, IteratorEltype(I))
 IteratorEltype(::Type{Flatten{Tuple{}}}) = IteratorEltype(Tuple{})

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -513,6 +513,7 @@ end
 @test collect(flatten(Any[flatten(Any[1:2, 6:5]), flatten(Any[6:7, 8:9])])) == Any[1,2,6,7,8,9]
 @test collect(flatten(Any[2:1])) == Any[]
 @test eltype(flatten(UnitRange{Int8}[1:2, 3:4])) == Int8
+@test eltype(flatten((Int16[1, 2], Int32[3, 4]))) == Int32
 @test length(flatten(zip(1:3, 4:6))) == 6
 @test length(flatten(1:6)) == 6
 @test collect(flatten(Any[])) == Any[]

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -513,7 +513,8 @@ end
 @test collect(flatten(Any[flatten(Any[1:2, 6:5]), flatten(Any[6:7, 8:9])])) == Any[1,2,6,7,8,9]
 @test collect(flatten(Any[2:1])) == Any[]
 @test eltype(flatten(UnitRange{Int8}[1:2, 3:4])) == Int8
-@test eltype(flatten((Int16[1, 2], Int32[3, 4]))) == Int32
+@test eltype(flatten(([1, 2], [3.0, 4.0]))) == Real
+@test eltype(flatten((a = [1, 2], b = Int8[3, 4]))) == Signed
 @test length(flatten(zip(1:3, 4:6))) == 6
 @test length(flatten(1:6)) == 6
 @test collect(flatten(Any[])) == Any[]


### PR DESCRIPTION
We have always had
```
julia> t = (Int16[1,2], Int32[3,4]); eltype(Iterators.flatten(t))
Any
```
With this PR, the result is `Signed` (`promote_typejoin` applied to the element types of the tuple elements).

The same applies to `NamedTuple`:
```
julia> nt = (a = [1,2], b = (3,4)); eltype(Iterators.flatten(nt))
Any     # old
Int64   # new
```