### PR TITLE
mergewith: add edge case example to docstring

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -392,9 +392,7 @@ Dict{String, Float64} with 3 entries:
 
 julia> ans == mergewith(+)(a, b)
 true
-```
 
-```jldoctest
 julia> mergewith(-, Dict(), Dict(:a=>1))  # Combining function only used if key is present in both
 Dict{Any, Any} with 1 entry:
   :a => 1

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -393,6 +393,12 @@ Dict{String, Float64} with 3 entries:
 julia> ans == mergewith(+)(a, b)
 true
 ```
+
+```jldoctest
+julia> mergewith(-, Dict(), Dict(:a=>1))  # Combining function only used if key is present in both
+Dict{Any, Any} with 1 entry:
+  :a => 1
+```
 """
 mergewith(combine, d::AbstractDict, others::AbstractDict...) =
     mergewith!(combine, _typeddict(d, others...), others...)


### PR DESCRIPTION
I ran into this edge case as a (developer, not code) bug. I though it should be documented, as the behaviour can be unexpected.