### PR TITLE
Fix logdet method for manually constructed Cholesky decompositions with negative entries.

### DIFF
--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -839,7 +839,7 @@ end
 function logdet(C::Cholesky)
     dd = zero(real(eltype(C)))
     @inbounds for i in 1:size(C.factors,1)
-        dd += log(real(C.factors[i,i]))
+        dd += log(abs(real(C.factors[i,i])))
     end
     dd + dd # instead of 2.0dd which can change the type
 end


### PR DESCRIPTION
## Context:
Cholesky decompositions constructed by the `cholesky` algorithm return matrices with positive elements along the diagonal. This is not a requirement of the Cholesky decomposition, but it is assumed by the method of `logdet` for the `Cholesky` type.

In the following example, a user-constructed Cholesky object `S` has a `DomainError` on `logdet`

```julia
using LinearAlgebra

U = [-0.9166852531274825 -0.8523978411697082; 0.0 -0.6124760294793627]
S = Cholesky{Float64, Matrix{Float64}}(U, 'U', 0)
M = det(S.L * S.U)
det(S)

log(det(S)) == logdet(M)
logdet(S) #DomainError 
```

## Implemented Fix:
By taking the absolute value of the diagonal elements, we don't change the determinant but do ensure that we can take logs. `logdet` now returns the correct value for `Cholesky` objects with negative diagonal entries.

## Alternative Fixes:
We could add a check to `Cholesky` to enforce non-negativity of the diagonal entries of `U`/`L`. I chose this method because it is more generic and easier to implement.