### PR TITLE
Add missing `copy!(::AbstractMatrix, ::UniformScaling)` method

### DIFF
--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -411,7 +411,7 @@ Copies a [`UniformScaling`](@ref) onto a matrix.
 !!! compat "Julia 1.12"
     This method is available as of Julia 1.12.
 """
-copy!(A::AbstractMatrix, J::UniformScaling) = copyto!(A, J)
+Base.copy!(A::AbstractMatrix, J::UniformScaling) = copyto!(A, J)
 
 function cond(J::UniformScaling{T}) where T
     onereal = inv(one(real(J.λ)))

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -403,6 +403,16 @@ function copyto!(A::Tridiagonal, J::UniformScaling)
     return A
 end
 
+"""
+    copy!(dest::AbstractMatrix, src::UniformScaling)
+
+Copies a [`UniformScaling`](@ref) onto a matrix.
+
+!!! compat "Julia 1.12"
+    This method is available as of Julia 1.12.
+"""
+copy!(A, J::UniformScaling) = copyto!(A, J)
+
 function cond(J::UniformScaling{T}) where T
     onereal = inv(one(real(J.λ)))
     return J.λ ≠ zero(T) ? onereal : oftype(onereal, Inf)

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -411,7 +411,7 @@ Copies a [`UniformScaling`](@ref) onto a matrix.
 !!! compat "Julia 1.12"
     This method is available as of Julia 1.12.
 """
-copy!(A, J::UniformScaling) = copyto!(A, J)
+copy!(A::AbstractMatrix, J::UniformScaling) = copyto!(A, J)
 
 function cond(J::UniformScaling{T}) where T
     onereal = inv(one(real(J.λ)))

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -226,6 +226,13 @@ let
         @test copyto!(B, J) == [λ zero(λ)]
     end
 
+    @testset "copy!" begin
+        A = Matrix{Int}(undef, (3,3))
+        @test copy!(A, I) == one(A)
+        B = Matrix{ComplexF64}(undef, (1,2))
+        @test copy!(B, J) == [λ zero(λ)]
+    end
+
     @testset "binary ops with vectors" begin
         v = complex.(randn(3), randn(3))
         # As shown in #20423@GitHub, vector acts like x1 matrix when participating in linear algebra


### PR DESCRIPTION
Hi everyone! First PR to Julia here.

It was noticed in [a Slack thread yesterday](https://julialang.slack.com/archives/C6A044SQH/p1727850230110489) that `copy!(A, I)` doesn't work, but `copyto!(A, I)` does. This PR adds the missing method for `copy!(::AbstractMatrix, ::UniformScaling)`, which simply defers to `copyto!`, and corresponding tests.

I'm not sure what the best practice for contributing `compat` strings is. In this case I added a `compat` notice for Julia 1.12, but please feel free to change this.