### PR TITLE
Some small follow-ups to stackless compiler

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2681,7 +2681,7 @@ function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo, sv::Infere
     end
     si = StmtInfo(!unused)
     call = abstract_call(interp, arginfo, si, sv)::Future
-    Future{Nothing}(call, interp, sv) do call, interp, sv
+    Future{Any}(call, interp, sv) do call, interp, sv
         # this only is needed for the side-effect, sequenced before any task tries to consume the return value,
         # which this will do even without returning this Future
         sv.stmt_info[sv.currpc] = call.info
@@ -2833,7 +2833,7 @@ function abstract_eval_new_opaque_closure(interp::AbstractInterpreter, e::Expr, 
                 pushfirst!(argtypes, rt.env)
                 callinfo = abstract_call_opaque_closure(interp, rt,
                     ArgInfo(nothing, argtypes), StmtInfo(true), sv, #=check=#false)::Future
-                Future{Nothing}(callinfo, interp, sv) do callinfo, interp, sv
+                Future{Any}(callinfo, interp, sv) do callinfo, interp, sv
                     sv.stmt_info[sv.currpc] = OpaqueClosureCreateInfo(callinfo)
                     nothing
                 end
@@ -3774,6 +3774,7 @@ function typeinf(interp::AbstractInterpreter, frame::InferenceState)
     takeprev = 0
     while takenext >= frame.frameid
         callee = takenext == 0 ? frame : callstack[takenext]::InferenceState
+        interp = callee.interp
         if !isempty(callstack)
             if length(callstack) - frame.frameid >= minwarn
                 topmethod = callstack[1].linfo

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -52,7 +52,7 @@ end
 function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo, irsv::IRInterpretationState)
     si = StmtInfo(true) # TODO better job here?
     call = abstract_call(interp, arginfo, si, irsv)::Future
-    Future{Nothing}(call, interp, irsv) do call, interp, irsv
+    Future{Any}(call, interp, irsv) do call, interp, irsv
         irsv.ir.stmts[irsv.curridx][:info] = call.info
         nothing
     end


### PR DESCRIPTION
1. Adjust the docstring for `Future`, which had its design changed late in that PR and is now confusing.
2. Add additional assertions validating the API assumptions of the `Future` API. I found it too easy to accidentally misuse this and cause hard-to-debug failures. The biggest change is that `isready` accounts for delayed assignments again, which allows an additional invariant that incomplete tasks must always have other pending tasks, allowing for infinite loop detection in the scheduler.
3. A small fix to use the AbstractInterpreter that created the InferenceState for the callback. We haven't fully defined the semantics of mixed-interpreter inference stacks, but downstream packages were using is and this at least makes it mostly work again.