### PR TITLE
Avoid `stat`-ing stdlib path if it's unreadable

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3115,9 +3115,16 @@ end
 
         # now check if this file is fresh relative to its source files
         if !skip_timecheck
-            if !samefile(includes[1].filename, modpath) && !samefile(fixup_stdlib_path(includes[1].filename), modpath)
-                @debug "Rejecting cache file $cachefile because it is for file $(includes[1].filename) not file $modpath"
-                return true # cache file was compiled from a different path
+            if !samefile(includes[1].filename, modpath)
+                stdlib_path = fixup_stdlib_path(includes[1].filename)
+                # In certain cases the path rewritten by `fixup_stdlib_path` may
+                # point to an unreadable directory, make sure we can `stat` the
+                # file before comparing it with `modpath`.
+                isreadable = iszero(@ccall jl_fs_access(stdlib_path::Cstring, 0x04::Cint)::Cint)
+                if isreadable && !samefile(stdlib_path, modpath)
+                    @debug "Rejecting cache file $cachefile because it is for file $(includes[1].filename) not file $modpath"
+                    return true # cache file was compiled from a different path
+                end
             end
             for (modkey, req_modkey) in requires
                 # verify that `require(modkey, name(req_modkey))` ==> `req_modkey`

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3121,7 +3121,7 @@ end
                 # point to an unreadable directory, make sure we can `stat` the
                 # file before comparing it with `modpath`.
                 isreadable = iszero(@ccall jl_fs_access(stdlib_path::Cstring, 0x04::Cint)::Cint)
-                if isreadable && !samefile(stdlib_path, modpath)
+                if !(isreadable && samefile(stdlib_path, modpath))
                     @debug "Rejecting cache file $cachefile because it is for file $(includes[1].filename) not file $modpath"
                     return true # cache file was compiled from a different path
                 end


### PR DESCRIPTION
This seems to fix #55966 for me on v1.10:
```julia-repl
julia> run(`sudo mkdir -p $(abspath(Sys.BUILD_STDLIB_PATH))`);

julia> run(`sudo chmod go-x $(abspath(Sys.BUILD_STDLIB_PATH))`);

julia> using SuiteSparse
[ Info: Precompiling SuiteSparse [4607b0f0-06f3-5cda-b6b1-a6196a1729e9]

julia>
```

It's hard to make a proper test for this because it requires fiddling with the build directory, which for from-source builds is likely needed and you don't want to mess with it, and in general may require admin access.

I'll make a separate PR for `master`, as sketched in https://github.com/JuliaLang/julia/issues/55966#issuecomment-2389154120, I started from v1.10 because that's the only version where I can reliably reproduce the issue, and so test it locally easily.  Also, the code around these lines is changed in v1.11, so this would need a manual backport in any case.