### PR TITLE
improve getproperty(Pairs) warnings

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -432,7 +432,13 @@ const All16{T,N} = Tuple{T,T,T,T,T,T,T,T,
 
 # the plan is to eventually overload getproperty to access entries of the dict
 @noinline function getproperty(x::Pairs, s::Symbol)
-    depwarn("use values(kwargs) and keys(kwargs) instead of kwargs.data and kwargs.itr", :getproperty, force=true)
+    if s == :data
+        depwarn("use values(kwargs) instead of kwargs.data", :getproperty, force=true)
+    elseif s == :itr
+        depwarn("use keys(kwargs) instead of kwargs.itr", :getproperty, force=true)
+    else
+        depwarn("use NamedTuple(kwargs).$s instead of kwargs.$s", :getproperty, force=true)
+    end
     return getfield(x, s)
 end
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -432,13 +432,8 @@ const All16{T,N} = Tuple{T,T,T,T,T,T,T,T,
 
 # the plan is to eventually overload getproperty to access entries of the dict
 @noinline function getproperty(x::Pairs, s::Symbol)
-    if s == :data
-        depwarn("use values(kwargs) instead of kwargs.data", :getproperty, force=true)
-    elseif s == :itr
-        depwarn("use keys(kwargs) instead of kwargs.itr", :getproperty, force=true)
-    else
-        depwarn("use NamedTuple(kwargs).$s instead of kwargs.$s", :getproperty, force=true)
-    end
+    s == :data && depwarn("use values(kwargs) instead of kwargs.data", :getproperty, force=true)
+    s == :itr && depwarn("use keys(kwargs) instead of kwargs.itr", :getproperty, force=true)
     return getfield(x, s)
 end
 


### PR DESCRIPTION
Currently, the warning can be quite confusing:
```julia
julia> f(;kwargs...) = kwargs.a
f (generic function with 1 method)

julia> f(a=1)
┌ Warning: use values(kwargs) and keys(kwargs) instead of kwargs.data and kwargs.itr
│   caller = f(; kwargs::Base.Pairs{Symbol, Int64, Tuple{Symbol}, @NamedTuple{a::Int64}}) at REPL[1]:1
└ @ Main ./REPL[1]:1
ERROR: type Pairs has no field a
```
After this PR:
```julia
julia> f(a=1)
┌ Warning: use NamedTuple(kwargs).a instead of kwargs.a
│   caller = f(; kwargs::Base.Pairs{Symbol, Int64, Tuple{Symbol}, @NamedTuple{a::Int64}}) at REPL[9]:1
└ @ Main ./REPL[9]:1
ERROR: type Pairs has no field a
```