### PR TITLE
Avoid conversions to `Float64` in non-literal powers of `Float16`

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -1276,14 +1276,14 @@ end
     return ifelse(isfinite(x) & isfinite(err), muladd(x, y, err), x*y)
 end
 
-function ^(x::Float32, n::Integer)
-    n == -2 && return (i=inv(x); i*i)
-    n == 3 && return x*x*x #keep compatibility with literal_pow
-    n < 0 && return Float32(Base.power_by_squaring(inv(Float64(x)),-n))
-    Float32(Base.power_by_squaring(Float64(x),n))
+for (T, WT) in ((Float16, Float32), (Float32, Float64))
+    @eval function ^(x::$T, n::Integer)
+        n == -2 && return (i=inv(x); i*i)
+        n == 3 && return x*x*x #keep compatibility with literal_pow
+        n < 0 && return $T(Base.power_by_squaring(inv($WT(x)),-n))
+        $T(Base.power_by_squaring($WT(x),n))
+    end
 end
-@inline ^(x::Float16, y::Integer) = Float16(Float32(x) ^ y)
-@inline literal_pow(::typeof(^), x::Float16, ::Val{p}) where {p} = Float16(literal_pow(^,Float32(x),Val(p)))
 
 ## rem2pi-related calculations ##
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -1276,13 +1276,11 @@ end
     return ifelse(isfinite(x) & isfinite(err), muladd(x, y, err), x*y)
 end
 
-for (T, WT) in ((Float16, Float32), (Float32, Float64))
-    @eval function ^(x::$T, n::Integer)
-        n == -2 && return (i=inv(x); i*i)
-        n == 3 && return x*x*x #keep compatibility with literal_pow
-        n < 0 && return $T(Base.power_by_squaring(inv($WT(x)),-n))
-        $T(Base.power_by_squaring($WT(x),n))
-    end
+function ^(x::Union{Float16,Float32}, n::Integer)
+    n == -2 && return (i=inv(x); i*i)
+    n == 3 && return x*x*x #keep compatibility with literal_pow
+    n < 0 && return oftype(x, Base.power_by_squaring(inv(widen(x)),-n))
+    oftype(x, Base.power_by_squaring(widen(x),n))
 end
 
 ## rem2pi-related calculations ##


### PR DESCRIPTION
Follow up to #55929: this PR avoids conversions `Float16` -> `Float64` in non-literal powers.  For the cases of exponents 3 and -2 also the conversion to `Float32` is avoided entirely.  Example on Apple Silicon: before PR:
```
julia> code_llvm((Float16,); debuginfo=:none) do b b ^ (1 + 2) end
; Function Signature: var"#8"(Float16, Int64)
define half @"julia_#8_397"(half %"b::Float16", i64 signext %"e::Int64") #0 {
top:
  %0 = fpext half %"b::Float16" to float
  %1 = fmul float %0, %0
  %2 = fmul float %1, %0
  %3 = fptrunc float %2 to half
  ret half %3
}

julia> @benchmark b ^ e setup=(b=randn(Float16); e=3)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  2.709 ns … 27.959 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.833 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.864 ns ±  0.437 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

       ▇  █  ▃  ▅  ▂  ▁  ▂                                   ▁
  ▃▁█▁▁█▁▁█▁▁█▁▁█▁▁█▁▁█▁▁█▁▁█▁█▁▁█▁▁▇▁▁▇▁▁▆▁▁▅▁▁▅▁▁▁▁▁▅▁▁█▁▆ █
  2.71 ns      Histogram: log(frequency) by time     3.54 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
after PR:
```
julia> code_llvm((Float16,); debuginfo=:none) do b b ^ (1 + 2) end
; Function Signature: var"#11"(Float16, Int64)
define half @"julia_#11_1956"(half %"b::Float16", i64 signext %"e::Int64") #0 {
top:
  %0 = fmul half %"b::Float16", %"b::Float16"
  %1 = fmul half %0, %"b::Float16"
  ret half %1
}

julia> @benchmark b ^ e setup=(b=randn(Float16); e=3)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  2.375 ns … 30.958 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.500 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.525 ns ±  0.349 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

        ▄   █  ▃   ▄  ▂                                      ▁
  ▄▁▁▆▁▁█▁▁▁█▁▁█▁▁▁█▁▁█▁▁█▁▁▁█▁▁▆▁▁▁▇▁▁▆▁▁▆▁▁▁▆▁▁▅▁▁▁▄▁▁▄▁▁▆ █
  2.38 ns      Histogram: log(frequency) by time     3.08 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```