### PR TITLE
Vectorise random vectors of `Float16`

### DIFF
--- a/stdlib/Random/src/XoshiroSimd.jl
+++ b/stdlib/Random/src/XoshiroSimd.jl
@@ -44,6 +44,13 @@ simdThreshold(::Type{Bool}) = 640
     l = Float32(li >>> 8) * Float32(0x1.0p-24)
     (UInt64(reinterpret(UInt32, u)) << 32) | UInt64(reinterpret(UInt32, l))
 end
+@inline function _bits2float(x::UInt64, ::Type{Float16})
+    ui = (x>>>16) % UInt16
+    li = x % UInt16
+    u = Float16(ui >>> 5) * Float16(0x1.0p-11)
+    l = Float16(li >>> 5) * Float16(0x1.0p-11)
+    (UInt64(reinterpret(UInt16, u)) << 16) | UInt64(reinterpret(UInt16, l))
+end
 
 # required operations. These could be written more concisely with `ntuple`, but the compiler
 # sometimes refuses to properly vectorize.
@@ -118,6 +125,18 @@ for N in [4,8,16]
         ret <$N x i64> %i
         """
         @eval @inline _bits2float(x::$VT, ::Type{Float32}) = llvmcall($code, $VT, Tuple{$VT}, x)
+
+        code = """
+        %as16 = bitcast <$N x i64> %0 to <$(4N) x i16>
+        %shiftamt = shufflevector <1 x i16> <i16 5>, <1 x i16> undef, <$(4N) x i32> zeroinitializer
+        %sh = lshr <$(4N) x i16> %as16, %shiftamt
+        %f = uitofp <$(4N) x i16> %sh to <$(4N) x half>
+        %scale = shufflevector <1 x half> <half 0x3f40000000000000>, <1 x half> undef, <$(4N) x i32> zeroinitializer
+        %m = fmul <$(4N) x half> %f, %scale
+        %i = bitcast <$(4N) x half> %m to <$N x i64>
+        ret <$N x i64> %i
+        """
+        @eval @inline _bits2float(x::$VT, ::Type{Float16}) = llvmcall($code, $VT, Tuple{$VT}, x)
     end
 end
 
@@ -137,7 +156,7 @@ end
 
 _id(x, T) = x
 
-@inline function xoshiro_bulk(rng::Union{TaskLocalRNG, Xoshiro}, dst::Ptr{UInt8}, len::Int, T::Union{Type{UInt8}, Type{Bool}, Type{Float32}, Type{Float64}}, ::Val{N}, f::F = _id) where {N, F}
+@inline function xoshiro_bulk(rng::Union{TaskLocalRNG, Xoshiro}, dst::Ptr{UInt8}, len::Int, T::Union{Type{UInt8}, Type{Bool}, Type{Float16}, Type{Float32}, Type{Float64}}, ::Val{N}, f::F = _id) where {N, F}
     if len >= simdThreshold(T)
         written = xoshiro_bulk_simd(rng, dst, len, T, Val(N), f)
         len -= written
@@ -265,13 +284,8 @@ end
 end
 
 
-function rand!(rng::Union{TaskLocalRNG, Xoshiro}, dst::Array{Float32}, ::SamplerTrivial{CloseOpen01{Float32}})
-    GC.@preserve dst xoshiro_bulk(rng, convert(Ptr{UInt8}, pointer(dst)), length(dst)*4, Float32, xoshiroWidth(), _bits2float)
-    dst
-end
-
-function rand!(rng::Union{TaskLocalRNG, Xoshiro}, dst::Array{Float64}, ::SamplerTrivial{CloseOpen01{Float64}})
-    GC.@preserve dst xoshiro_bulk(rng, convert(Ptr{UInt8}, pointer(dst)), length(dst)*8, Float64, xoshiroWidth(), _bits2float)
+function rand!(rng::Union{TaskLocalRNG, Xoshiro}, dst::Array{T}, ::SamplerTrivial{CloseOpen01{T}}) where {T<:Union{Float16,Float32,Float64}}
+    GC.@preserve dst xoshiro_bulk(rng, convert(Ptr{UInt8}, pointer(dst)), length(dst)*sizeof(T), T, xoshiroWidth(), _bits2float)
     dst
 end
 

--- a/stdlib/Random/src/XoshiroSimd.jl
+++ b/stdlib/Random/src/XoshiroSimd.jl
@@ -45,11 +45,15 @@ simdThreshold(::Type{Bool}) = 640
     (UInt64(reinterpret(UInt32, u)) << 32) | UInt64(reinterpret(UInt32, l))
 end
 @inline function _bits2float(x::UInt64, ::Type{Float16})
-    ui = (x>>>16) % UInt16
-    li = x % UInt16
-    u = Float16(ui >>> 5) * Float16(0x1.0p-11)
-    l = Float16(li >>> 5) * Float16(0x1.0p-11)
-    (UInt64(reinterpret(UInt16, u)) << 16) | UInt64(reinterpret(UInt16, l))
+    i1 = (x>>>48) % UInt16
+    i2 = (x>>>32) % UInt16
+    i3 = (x>>>16) % UInt16
+    i4 = x % UInt16
+    f1 = Float16(i1 >>> 5) * Float16(0x1.0p-11)
+    f2 = Float16(i2 >>> 5) * Float16(0x1.0p-11)
+    f3 = Float16(i3 >>> 5) * Float16(0x1.0p-11)
+    f4 = Float16(i4 >>> 5) * Float16(0x1.0p-11)
+    return (UInt64(reinterpret(UInt16, f1)) << 48) | (UInt64(reinterpret(UInt16, f2)) << 32) | (UInt64(reinterpret(UInt16, f3)) << 16) | UInt64(reinterpret(UInt16, f4))
 end
 
 # required operations. These could be written more concisely with `ntuple`, but the compiler


### PR DESCRIPTION
With this PR, `rand!(::Vector{Float16})` on Apple Silicon becomes about one order of magnitude faster:
```
julia> @btime rand!(v) setup=(v=Vector{Float16}(undef, 2 ^ 20));
  1.208 ms (0 allocations: 0 bytes) # before PR
  122.750 μs (0 allocations: 0 bytes) # after PR
```
and about 2x and 4x faster than vectors of `Float32` or `Float64` of the same size, when the operation is memory-bound, as you'd expect:
```
julia> @btime rand!(v) setup=(v=Vector{Float32}(undef, 2 ^ 20));
  375.125 μs (0 allocations: 0 bytes)

julia> @btime rand!(v) setup=(v=Vector{Float64}(undef, 2 ^ 20));
  763.667 μs (0 allocations: 0 bytes)
```

This sensibly improves performance also on hardware without native `Float16`, for example on zenver2 (AMD Ryzen 9 3950X) I get
```
julia> @btime rand!(v) setup=(v=Vector{Float16}(undef, 2 ^ 20));
  1.180 ms (0 allocations: 0 bytes) # before PR
  335.613 μs (0 allocations: 0 bytes) # after PR
```

<s>However I'm pretty sure I did something wrong because now `rand!(::Vector{Float16})` produces numbers larger than 1, so I need help to fix my mindless pattern matching adaptation 🙂 My assumption is that I got wrong the implementation of `_bits2float`, which I have little clue of what it's supposed to do exactly (besides converting a `UInt64` to a floating point number) being undocumented and sparsely commented.  CC @chethega who I believe originally introduced this code in #34852/#40546.  Also CC @rfourquet in case he can provide some help.</s>  ***Edit***: wait, I think I got it 👀