### PR TITLE
Fix printing of `AbstractDict`s with unknown length

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -152,7 +152,7 @@ function show(io::IO, ::MIME"text/plain", iter::Union{KeySet,ValueIterator})
 end
 
 function show(io::IO, ::MIME"text/plain", t::AbstractDict{K,V}) where {K,V}
-    isempty(t) && return show(io, t)
+    (isempty(t) || !haslength(t)) && return show(io, t)
     # show more descriptively, with one line per key/value pair
     recur_io = IOContext(io, :SHOWN_SET => t)
     limit = get(io, :limit, false)::Bool

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -995,7 +995,7 @@ function dict_identifier_key(str::String, tag::Symbol, context_module::Module=Ma
     isa(objt, Core.Const) || return (nothing, nothing, nothing)
     obj = objt.val
     isa(obj, AbstractDict) || return (nothing, nothing, nothing)
-    length(obj)::Int < 1_000_000 || return (nothing, nothing, nothing)
+    (Base.haslength(obj) && length(obj)::Int < 1_000_000) || return (nothing, nothing, nothing)
     begin_of_key = something(findnext(!isspace, str, nextind(str, end_of_identifier) + 1), # +1 for [
                              lastindex(str)+1)
     return (obj, str[begin_of_key:end], begin_of_key)

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -68,6 +68,16 @@ let ex = quote
         Base.keys(d::CustomDict) = collect(keys(d.mydict))
         Base.length(d::CustomDict) = length(d.mydict)
 
+        # Support AbstractDict with unknown length, #55931
+        struct NoLengthDict{K,V} <: AbstractDict{K,V}
+            dict::Dict{K,V}
+            NoLengthDict{K,V}() where {K,V} = new(Dict{K,V}())
+        end
+        Base.iterate(d::NoLengthDict, s...) = iterate(d.dict, s...)
+        Base.IteratorSize(::Type{<:NoLengthDict}) = Base.SizeUnknown()
+        Base.eltype(::Type{NoLengthDict{K,V}}) where {K,V} = Pair{K,V}
+        Base.setindex!(d::NoLengthDict, v, k) = d.dict[k] = v
+
         test(x::T, y::T) where {T<:Real} = pass
         test(x::Real, y::Real) = pass
         test(x::AbstractArray{T}, y) where {T<:Real} = pass
@@ -151,6 +161,7 @@ let ex = quote
         test_repl_comp_dict = CompletionFoo.test_dict
         test_repl_comp_customdict = CompletionFoo.test_customdict
         test_dict_ℂ = Dict(1=>2)
+        test_dict_no_length = CompletionFoo.NoLengthDict{Int,Int}()
     end
     ex.head = :toplevel
     Core.eval(Main, ex)
@@ -1486,8 +1497,21 @@ test_dict_completion("CompletionFoo.test_customdict")
 test_dict_completion("test_repl_comp_dict")
 test_dict_completion("test_repl_comp_customdict")
 
-# Issue #23004: this should not throw:
-@test REPLCompletions.dict_identifier_key("test_dict_ℂ[\\", :other) isa Tuple
+struct NoLengthDict{K,V} <: AbstractDict{K,V}
+    dict::Dict{K,V}
+    NoLengthDict{K,V}() where {K,V} = new(Dict{K,V}())
+end
+Base.iterate(d::NoLengthDict, s...) = iterate(d.dict, s...)
+Base.IteratorSize(::Type{<:NoLengthDict}) = Base.SizeUnknown()
+Base.eltype(::Type{NoLengthDict{K,V}}) where {K,V} = Pair{K,V}
+Base.setindex!(d::NoLengthDict, v, k) = d.dict[k] = v
+
+@testset "dict_identifier_key" begin
+    # Issue #23004: this should not throw:
+    @test REPLCompletions.dict_identifier_key("test_dict_ℂ[\\", :other) isa Tuple
+    # Issue #55931: neither should this:
+    @test REPLCompletions.dict_identifier_key("test_dict_no_length[", :other) isa NTuple{3,Nothing}
+end
 
 @testset "completion of string/cmd macros (#22577)" begin
     c, r, res = test_complete("ra")

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1497,15 +1497,6 @@ test_dict_completion("CompletionFoo.test_customdict")
 test_dict_completion("test_repl_comp_dict")
 test_dict_completion("test_repl_comp_customdict")
 
-struct NoLengthDict{K,V} <: AbstractDict{K,V}
-    dict::Dict{K,V}
-    NoLengthDict{K,V}() where {K,V} = new(Dict{K,V}())
-end
-Base.iterate(d::NoLengthDict, s...) = iterate(d.dict, s...)
-Base.IteratorSize(::Type{<:NoLengthDict}) = Base.SizeUnknown()
-Base.eltype(::Type{NoLengthDict{K,V}}) where {K,V} = Pair{K,V}
-Base.setindex!(d::NoLengthDict, v, k) = d.dict[k] = v
-
 @testset "dict_identifier_key" begin
     # Issue #23004: this should not throw:
     @test REPLCompletions.dict_identifier_key("test_dict_ℂ[\\", :other) isa Tuple

--- a/test/show.jl
+++ b/test/show.jl
@@ -2787,5 +2787,5 @@ Base.setindex!(d::NoLengthDict, v, k) = d.dict[k] = v
 @testset "show AbstractDict with unknown length" begin
     x = NoLengthDict{Int,Int}()
     x[1] = 2
-    @test sprint((io, x) -> show(io, MIME("text/plain"), x), x) == "NoLengthDict(1 => 2)"
+    @test endswith(sprint((io, x) -> show(io, MIME("text/plain"), x), x), "NoLengthDict(1 => 2)")
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -2787,5 +2787,7 @@ Base.setindex!(d::NoLengthDict, v, k) = d.dict[k] = v
 @testset "show AbstractDict with unknown length" begin
     x = NoLengthDict{Int,Int}()
     x[1] = 2
-    @test endswith(sprint((io, x) -> show(io, MIME("text/plain"), x), x), "NoLengthDict(1 => 2)")
+    str = sprint(io->show(io, MIME("text/plain"), x))
+    @test contains(str, "NoLengthDict")
+    @test contains(str, "1 => 2")
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -2773,3 +2773,19 @@ end
     do_expr1 = :(foo() do; bar(); end)
     @test !contains(sprint(show, do_expr1), " \n")
 end
+
+struct NoLengthDict{K,V} <: AbstractDict{K,V}
+    dict::Dict{K,V}
+    NoLengthDict{K,V}() where {K,V} = new(Dict{K,V}())
+end
+Base.iterate(d::NoLengthDict, s...) = iterate(d.dict, s...)
+Base.IteratorSize(::Type{<:NoLengthDict}) = Base.SizeUnknown()
+Base.eltype(::Type{NoLengthDict{K,V}}) where {K,V} = Pair{K,V}
+Base.setindex!(d::NoLengthDict, v, k) = d.dict[k] = v
+
+# Issue 55931
+@testset "show AbstractDict with unknown length" begin
+    x = NoLengthDict{Int,Int}()
+    x[1] = 2
+    @test sprint((io, x) -> show(io, MIME("text/plain"), x), x) == "NoLengthDict(1 => 2)"
+end


### PR DESCRIPTION
Also fix interacting with them at the REPL.

Fixes #55931