### PR TITLE
[LinearAlgebra] Remove unreliable doctests

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -385,7 +385,7 @@ control over the factorization of `A`.
     these are already in a factorized form
 
 # Examples
-```jldoctest
+```julia-repl
 julia> A = [1 2.2 4; 3.1 0.2 3; 4 1 2];
 
 julia> X = [1; 2.5; 3];
@@ -426,7 +426,7 @@ control over the factorization of `A`.
     these are already in a factorized form
 
 # Examples
-```jldoctest
+```julia-repl
 julia> A = [1 2.2 4; 3.1 0.2 3; 4 1 2];
 
 julia> X = [1; 2.5; 3];

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -385,7 +385,7 @@ control over the factorization of `A`.
     these are already in a factorized form
 
 # Examples
-```julia-repl
+```jldoctest
 julia> A = [1 2.2 4; 3.1 0.2 3; 4 1 2];
 
 julia> X = [1; 2.5; 3];
@@ -394,17 +394,8 @@ julia> Y = zero(X);
 
 julia> ldiv!(Y, qr(A), X);
 
-julia> Y
-3-element Vector{Float64}:
-  0.7128099173553719
- -0.051652892561983674
-  0.10020661157024757
-
-julia> A\\X
-3-element Vector{Float64}:
-  0.7128099173553719
- -0.05165289256198333
-  0.10020661157024785
+julia> Y ≈ A\\X
+true
 ```
 """
 ldiv!(Y, A, B)
@@ -426,7 +417,7 @@ control over the factorization of `A`.
     these are already in a factorized form
 
 # Examples
-```julia-repl
+```jldoctest
 julia> A = [1 2.2 4; 3.1 0.2 3; 4 1 2];
 
 julia> X = [1; 2.5; 3];
@@ -435,17 +426,8 @@ julia> Y = copy(X);
 
 julia> ldiv!(qr(A), X);
 
-julia> X
-3-element Vector{Float64}:
-  0.7128099173553719
- -0.051652892561983674
-  0.10020661157024757
-
-julia> A\\Y
-3-element Vector{Float64}:
-  0.7128099173553719
- -0.05165289256198333
-  0.10020661157024785
+julia> X ≈ A\\Y
+true
 ```
 """
 ldiv!(A, B)

--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -446,7 +446,7 @@ This is useful because multiple shifted solves `(F + μ*I) \\ b`
 Iterating the decomposition produces the factors `F.Q, F.H, F.μ`.
 
 # Examples
-```jldoctest
+```julia-repl
 julia> A = [4. 9. 7.; 4. 4. 1.; 4. 3. 2.]
 3×3 Matrix{Float64}:
  4.0  9.0  7.0


### PR DESCRIPTION
The exact textual representation of the output of these doctests depend on the specific kernel used by the BLAS backend, and can vary between versions of OpenBLAS (as it did in JuliaLang/julia#41973), or between different CPUs, which makes these doctests unreliable.

Fix JuliaLang/LinearAlgebra.jl#1094.