### PR TITLE
2-arg `show` for `Symmetric`/`Hermitian` and triangular

### DIFF
--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -1051,3 +1051,9 @@ function Base.replace_in_print_matrix(A::HermOrSym,i::Integer,j::Integer,s::Abst
     inds = A.uplo == 'U' ? ijminmax : reverse(ijminmax)
     Base.replace_in_print_matrix(parent(A), inds..., s)
 end
+
+function Base.show(io::IO, S::HermOrSym)
+    print(io, string(nameof(typeof(S))), "(")
+    @invoke show(io::IO, S::AbstractMatrix)
+    print(io, ")")
+end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2986,3 +2986,10 @@ end
 # Cube roots of real-valued triangular matrices
 cbrt(A::UpperTriangular{T}) where {T<:Real} = UpperTriangular(_cbrt_quasi_triu!(Matrix{T}(A)))
 cbrt(A::LowerTriangular{T}) where {T<:Real} = LowerTriangular(_cbrt_quasi_triu!(Matrix{T}(A'))')
+
+# show
+function Base.show(io::IO, S::UpperOrLowerTriangular)
+    print(io, string(nameof(typeof(S))), "(")
+    @invoke show(io::IO, S::AbstractMatrix)
+    print(io, ")")
+end

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -1160,4 +1160,12 @@ end
     @test symT-s == Array(symT) - Array(s)
 end
 
+@testset "show" begin
+    A = rand(2,2)
+    H = Hermitian(A)
+    S = Symmetric(A)
+    @test sprint(show, H) == "Hermitian([$(H[1,1]) $(H[1,2]); $(H[2,1]) $(H[2,2])])"
+    @test sprint(show, S) == "Symmetric([$(S[1,1]) $(S[1,2]); $(S[2,1]) $(S[2,2])])"
+end
+
 end # module TestSymmetric

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -851,8 +851,10 @@ end
 
     # don't access non-structural elements while displaying
     M = Matrix{BigFloat}(undef, 2, 2)
-    @test sprint(show, UpperTriangular(M)) == "BigFloat[#undef #undef; 0.0 #undef]"
-    @test sprint(show, LowerTriangular(M)) == "BigFloat[#undef 0.0; #undef #undef]"
+    @test sprint(show, UpperTriangular(M)) == "UpperTriangular(BigFloat[#undef #undef; 0.0 #undef])"
+    @test sprint(show, LowerTriangular(M)) == "LowerTriangular(BigFloat[#undef 0.0; #undef #undef])"
+    @test sprint(show, UnitUpperTriangular(M)) == "UnitUpperTriangular(BigFloat[1.0 #undef; 0.0 1.0])"
+    @test sprint(show, UnitLowerTriangular(M)) == "UnitLowerTriangular(BigFloat[1.0 0.0; #undef 1.0])"
 end
 
 @testset "adjoint/transpose triangular/vector multiplication" begin


### PR DESCRIPTION
After this,
```julia
julia> A = rand(2,2);

julia> H = Hermitian(A)
2×2 Hermitian{Float64, Matrix{Float64}}:
 0.889108  0.264298
 0.264298  0.234985

julia> println(H)
Hermitian([0.8891078167175059 0.26429820656950753; 0.26429820656950753 0.23498548977257172])

julia> S = Symmetric(A)
2×2 Symmetric{Float64, Matrix{Float64}}:
 0.889108  0.264298
 0.264298  0.234985

julia> println(S)
Symmetric([0.8891078167175059 0.26429820656950753; 0.26429820656950753 0.23498548977257172])

julia> U = UpperTriangular(A)
2×2 UpperTriangular{Float64, Matrix{Float64}}:
 0.889108  0.264298
  ⋅        0.234985

julia> println(U)
UpperTriangular([0.8891078167175059 0.26429820656950753; 0.0 0.23498548977257172])

julia> U = UnitUpperTriangular(A)
2×2 UnitUpperTriangular{Float64, Matrix{Float64}}:
 1.0  0.264298
  ⋅   1.0

julia> println(U)
UnitUpperTriangular([1.0 0.26429820656950753; 0.0 1.0])

julia> L = LowerTriangular(A)
2×2 LowerTriangular{Float64, Matrix{Float64}}:
 0.889108   ⋅ 
 0.2504    0.234985

julia> println(L)
LowerTriangular([0.8891078167175059 0.0; 0.2503997651590879 0.23498548977257172])

julia> L = UnitLowerTriangular(A)
2×2 UnitLowerTriangular{Float64, Matrix{Float64}}:
 1.0      ⋅ 
 0.2504  1.0

julia> println(L)
UnitLowerTriangular([1.0 0.0; 0.2503997651590879 1.0])
```
The displayed form is now a valid constructor, and may be copy-pasted to reconstruct the object.