### PR TITLE
add require_lock call to maybe_loaded_precompile

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2397,11 +2397,12 @@ const module_keys = IdDict{Module,PkgId}() # the reverse of loaded_modules
 root_module_key(m::Module) = @lock require_lock module_keys[m]
 
 function maybe_loaded_precompile(key::PkgId, buildid::UInt128)
-    assert_havelock(require_lock)
+    @lock require_lock begin
     mods = get(loaded_precompiles, key, nothing)
     mods === nothing && return
     for mod in mods
         module_build_id(mod) == buildid && return mod
+    end
     end
 end
 


### PR DESCRIPTION
If we expect this to be a public API
(https://github.com/timholy/Revise.jl for some reason is trying to access this state), we should lock around it for consistency with the other similar functions.

Needed for https://github.com/timholy/Revise.jl/pull/856