### PR TITLE
teach llvm-alloc-helpers about `gc_loaded`

### DIFF
--- a/src/llvm-alloc-helpers.cpp
+++ b/src/llvm-alloc-helpers.cpp
@@ -246,7 +246,8 @@ void jl_alloc::runEscapeAnalysis(llvm::CallInst *I, EscapeAnalysisRequiredArgs r
                 return true;
             }
             if (required.pass.gc_loaded_func == callee) {
-                required.use_info.addrescaped = true;
+                required.use_info.haspreserve = true;
+                required.use_info.hasload = true;
                 return true;
             }
             if (required.pass.typeof_func == callee) {

--- a/src/llvm-alloc-helpers.cpp
+++ b/src/llvm-alloc-helpers.cpp
@@ -245,6 +245,10 @@ void jl_alloc::runEscapeAnalysis(llvm::CallInst *I, EscapeAnalysisRequiredArgs r
                 required.use_info.addrescaped = true;
                 return true;
             }
+            if (required.pass.gc_loaded_func == callee) {
+                required.use_info.addrescaped = true;
+                return true;
+            }
             if (required.pass.typeof_func == callee) {
                 required.use_info.hastypeof = true;
                 assert(use->get() == I);


### PR DESCRIPTION
combined with https://github.com/JuliaLang/julia/pull/55913, the compiler is smart enough to fully remove
```
function f()
    m = Memory{Int}(undef, 3)
    @inbounds m[1] = 2
    @inbounds m[2] = 2
    @inbounds m[3] = 4
    @inbounds return m[1] + m[2] + m[3]
end
```