### PR TITLE
array: inline `convert` where possible

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -984,6 +984,7 @@ Dict{String, Int64} with 2 entries:
 function setindex! end
 
 function setindex!(A::Array{T}, x, i::Int) where {T}
+    @_propagate_inbounds_meta
     @inline
     x = x isa T ? x : convert(T, x)::T
     return _setindex!(A, x, i)
@@ -995,6 +996,7 @@ function _setindex!(A::Array{T}, x::T, i::Int) where {T}
     return A
 end
 function setindex!(A::Array{T}, x, i1::Int, i2::Int, I::Int...) where {T}
+    @_propagate_inbounds_meta
     @inline
     x = x isa T ? x : convert(T, x)::T
     return _setindex!(A, x, i1, i2, I...)

--- a/base/array.jl
+++ b/base/array.jl
@@ -324,9 +324,13 @@ copyto!(dest::Array{T}, src::Array{T}) where {T} = copyto!(dest, 1, src, 1, leng
 # N.B: The generic definition in multidimensional.jl covers, this, this is just here
 # for bootstrapping purposes.
 function fill!(dest::Array{T}, x) where T
-    xT = x isa T ? x : convert(T, x)::T
+    @inline
+    x = x isa T ? x : convert(T, x)::T
+    return _fill!(dest, x)
+end
+function _fill!(dest::Array{T}, x::T) where T
     for i in eachindex(dest)
-        @inbounds dest[i] = xT
+        @inbounds dest[i] = x
     end
     return dest
 end
@@ -1262,10 +1266,16 @@ See also [`pushfirst!`](@ref).
 function push! end
 
 function push!(a::Vector{T}, item) where T
+    @inline
     # convert first so we don't grow the array if the assignment won't work
-    itemT = item isa T ? item : convert(T, item)::T
+    # and also to avoid a dynamic dynamic dispatch in the common case that
+    # `item` is poorly-typed and `a` is well-typed
+    item = item isa T ? item : convert(T, item)::T
+    return _push!(a, item)
+end
+function _push!(a::Vector{T}, item::T) where T
     _growend!(a, 1)
-    @_safeindex a[length(a)] = itemT
+    @_safeindex a[length(a)] = item
     return a
 end
 
@@ -1659,7 +1669,11 @@ julia> pushfirst!([1, 2, 3, 4], 5, 6)
 ```
 """
 function pushfirst!(a::Vector{T}, item) where T
+    @inline
     item = item isa T ? item : convert(T, item)::T
+    return _pushfirst!(a, item)
+end
+function _pushfirst!(a::Vector{T}, item::T) where T
     _growbeg!(a, 1)
     @_safeindex a[1] = item
     return a
@@ -1745,12 +1759,17 @@ julia> insert!(Any[1:6;], 3, "here")
 ```
 """
 function insert!(a::Array{T,1}, i::Integer, item) where T
+    @inline
+    @_noub_meta
+    item = item isa T ? item : convert(T, item)::T
+    return _insert!(a, i, item)
+end
+function _insert!(a::Array{T,1}, i::Integer, item::T) where T
     @_noub_meta
     # Throw convert error before changing the shape of the array
-    _item = item isa T ? item : convert(T, item)::T
     _growat!(a, i, 1)
     # :noub, because _growat! already did bound check
-    @inbounds a[i] = _item
+    @inbounds a[i] = item
     return a
 end
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -984,12 +984,22 @@ Dict{String, Int64} with 2 entries:
 function setindex! end
 
 function setindex!(A::Array{T}, x, i::Int) where {T}
+    @inline
+    x = x isa T ? x : convert(T, x)::T
+    return _setindex!(A, x, i)
+end
+function _setindex!(A::Array{T}, x::T, i::Int) where {T}
     @_noub_if_noinbounds_meta
     @boundscheck (i - 1)%UInt < length(A)%UInt || throw_boundserror(A, (i,))
-    memoryrefset!(memoryrefnew(A.ref, i, false), x isa T ? x : convert(T,x)::T, :not_atomic, false)
+    memoryrefset!(memoryrefnew(A.ref, i, false), x, :not_atomic, false)
     return A
 end
 function setindex!(A::Array{T}, x, i1::Int, i2::Int, I::Int...) where {T}
+    @inline
+    x = x isa T ? x : convert(T, x)::T
+    return _setindex!(A, x, i1, i2, I...)
+end
+function _setindex!(A::Array{T}, x, i1::Int, i2::Int, I::Int...) where {T}
     @inline
     @_noub_if_noinbounds_meta
     @boundscheck checkbounds(A, i1, i2, I...) # generally _to_linear_index requires bounds checking
@@ -1760,7 +1770,6 @@ julia> insert!(Any[1:6;], 3, "here")
 """
 function insert!(a::Array{T,1}, i::Integer, item) where T
     @inline
-    @_noub_meta
     item = item isa T ? item : convert(T, item)::T
     return _insert!(a, i, item)
 end

--- a/base/array.jl
+++ b/base/array.jl
@@ -985,7 +985,6 @@ function setindex! end
 
 function setindex!(A::Array{T}, x, i::Int) where {T}
     @_propagate_inbounds_meta
-    @inline
     x = x isa T ? x : convert(T, x)::T
     return _setindex!(A, x, i)
 end
@@ -997,7 +996,6 @@ function _setindex!(A::Array{T}, x::T, i::Int) where {T}
 end
 function setindex!(A::Array{T}, x, i1::Int, i2::Int, I::Int...) where {T}
     @_propagate_inbounds_meta
-    @inline
     x = x isa T ? x : convert(T, x)::T
     return _setindex!(A, x, i1, i2, I...)
 end
@@ -1771,7 +1769,7 @@ julia> insert!(Any[1:6;], 3, "here")
 ```
 """
 function insert!(a::Array{T,1}, i::Integer, item) where T
-    @inline
+    @_propagate_inbounds_meta
     item = item isa T ? item : convert(T, item)::T
     return _insert!(a, i, item)
 end

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -179,10 +179,11 @@ nextind(@nospecialize(t::NamedTuple), i::Integer) = Int(i)+1
 
 convert(::Type{NT}, nt::NT) where {names, NT<:NamedTuple{names}} = nt
 convert(::Type{NT}, nt::NT) where {names, T<:Tuple, NT<:NamedTuple{names,T}} = nt
-convert(::Type{NT}, t::Tuple) where {NT<:NamedTuple} = NT(t)
+convert(::Type{NT}, t::Tuple) where {NT<:NamedTuple} = (@inline NT(t))::NT
 
 function convert(::Type{NamedTuple{names,T}}, nt::NamedTuple{names}) where {names,T<:Tuple}
-    NamedTuple{names,T}(T(nt))::NamedTuple{names,T}
+    NT = NamedTuple{names,T}
+    (@inline NT(nt))::NT
 end
 
 function convert(::Type{NT}, nt::NamedTuple{names}) where {names, NT<:NamedTuple{names}}

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -1224,8 +1224,8 @@ end
 # high level tests
 @test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(getindex, (Vector{Int},Int)))
 @test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(getindex, (Vector{Any},Int)))
-@test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(setindex!, (Vector{Int},Int,Int)))
-@test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(setindex!, (Vector{Any},Any,Int)))
+@test Core.Compiler.is_noub(Base.infer_effects(setindex!, (Vector{Int},Int,Int)))
+@test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(Base._setindex!, (Vector{Any},Any,Int)))
 @test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(isassigned, (Vector{Int},Int)))
 @test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(isassigned, (Vector{Any},Int)))
 @test Base.infer_effects((Vector{Int},Int)) do xs, i

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -1224,7 +1224,7 @@ end
 # high level tests
 @test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(getindex, (Vector{Int},Int)))
 @test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(getindex, (Vector{Any},Int)))
-@test Core.Compiler.is_noub(Base.infer_effects(setindex!, (Vector{Int},Int,Int)))
+@test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(setindex!, (Vector{Int},Int,Int)))
 @test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(Base._setindex!, (Vector{Any},Any,Int)))
 @test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(isassigned, (Vector{Int},Int)))
 @test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(isassigned, (Vector{Any},Int)))


### PR DESCRIPTION
This improves a common scenario, where someone wants to `push!` a poorly-typed object onto a well-typed Vector.

For example:
```julia
const NT = @NamedTuple{x::Int,y::Any}
foo(v::Vector{NT}, x::Int, @nospecialize(y)) = push!(v, (; x, y))
```

The `(; x, y)` is slightly poorly-typed here. It could have any type for its `.y` field before it is converted inside the `push!` to a NamedTuple with `y::Any`

Without this PR, the dispatch for this `push!` cannot be inferred:
```julia
julia> code_typed(foo, (Vector{NT}, Int, Any))[1]
 CodeInfo(
1 ─ ...
│   %4 = %new(%3, x, y)::NamedTuple{(:x, :y), <:Tuple{Int64, Any}}
│   %5 = Main.push!(v, %4)::Vector{@NamedTuple{x::Int64, y}}
└──      return %5
) => Vector{@NamedTuple{x::Int64, y}}
```

With this PR, the above dynamic call is fully statically resolved and inlined (and therefore `--trim` compatible)