### PR TITLE
Don't show keymap `@error` for hints

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -382,7 +382,13 @@ function check_for_hint(s::MIState)
         # Requires making space for them earlier in refresh_multi_line
         return clear_hint(st)
     end
-    completions, partial, should_complete = complete_line(st.p.complete, st, s.active_module; hint = true)::Tuple{Vector{String},String,Bool}
+
+    completions, partial, should_complete = try
+        complete_line(st.p.complete, st, s.active_module; hint = true)::Tuple{Vector{String},String,Bool}
+    catch e
+        @debug "error completing line for hint" e=e,catch_backtrace()
+        return clear_hint(st)
+    end
     isempty(completions) && return clear_hint(st)
     # Don't complete for single chars, given e.g. `x` completes to `xor`
     if length(partial) > 1 && should_complete

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -385,8 +385,8 @@ function check_for_hint(s::MIState)
 
     completions, partial, should_complete = try
         complete_line(st.p.complete, st, s.active_module; hint = true)::Tuple{Vector{String},String,Bool}
-    catch e
-        @debug "error completing line for hint" e=e,catch_backtrace()
+    catch
+        @debug "error completing line for hint" exception=current_exceptions()
         return clear_hint(st)
     end
     isempty(completions) && return clear_hint(st)


### PR DESCRIPTION
It's too disruptive to show errors for hints. The error will still be shown if tab is pressed.

Helps issues like https://github.com/JuliaLang/julia/issues/56037