### PR TITLE
Allow printing task backtraces via profiling peek mechanism

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -601,6 +601,11 @@ function profile_printing_listener()
             profile = @something(profile, require(PkgId(UUID("9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"), "Profile")))
 
             invokelatest(profile.peek_report[])
+            if Base.get_bool_env("JULIA_PROFILE_PEEK_TASK_BACKTRACES", true) === true
+                print(stderr, "Printing Julia task backtraces...\n")
+                flush(stderr)
+                ccall(:jl_print_task_backtraces, Cvoid, ())
+            end
             if Base.get_bool_env("JULIA_PROFILE_PEEK_HEAP_SNAPSHOT", false) === true
                 println(stderr, "Saving heap snapshot...")
                 fname = invokelatest(profile.take_heap_snapshot)

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -445,7 +445,12 @@ Enable debug logging for a file or module, see [`Logging`](@ref man-logging) for
 
 ### [`JULIA_PROFILE_PEEK_HEAP_SNAPSHOT`](@id JULIA_PROFILE_PEEK_HEAP_SNAPSHOT)
 
-Enable collecting of a heap snapshot during execution via the profiling peek mechanism.
+Enable collecting of a heap snapshot during execution via the profiling peek mechanism. Set to `1` to enable.
+See [Triggered During Execution](@ref).
+
+### [`JULIA_PROFILE_PEEK_TASK_BACKTRACES`](@id JULIA_PROFILE_PEEK_TASK_BACKTRACES)
+
+Disable printing of task backtraces via the profiling peek mechanism. Set to `0` to disable.
 See [Triggered During Execution](@ref).
 
 ### [`JULIA_TIMING_SUBSYSTEMS`](@id JULIA_TIMING_SUBSYSTEMS)

--- a/stdlib/Profile/docs/src/index.md
+++ b/stdlib/Profile/docs/src/index.md
@@ -34,6 +34,9 @@ First, a single stack trace at the instant that the signal was thrown is shown, 
 followed by the profile report at the next yield point, which may be at task completion for code without yield points
 e.g. tight loops.
 
+In addition to the profile, all task backtraces will be printed, unless the environment variable
+[`JULIA_PROFILE_PEEK_TASK_BACKTRACES`](@ref JULIA_PROFILE_PEEK_TASK_BACKTRACES) is set to `0`.
+
 Optionally set environment variable [`JULIA_PROFILE_PEEK_HEAP_SNAPSHOT`](@ref JULIA_PROFILE_PEEK_HEAP_SNAPSHOT) to `1` to also automatically collect a
 [heap snapshot](@ref Heap-Snapshots).
 


### PR DESCRIPTION
This would be useful e.g. for debugging stuck tests run via `ReTestItems.jl` (which uses multiple Julia processes to run the tests)