### PR TITLE
RFC: Add `RelocPath` type for userdefined relocatable paths

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3540,7 +3540,7 @@ function resolve_depot(inc::AbstractString)
 end
 
 """
-    RelocPath(path::AbstractString)
+    Base.RelocPath(path::AbstractString)
 
 A type to represent a relocatable path.
 
@@ -3554,7 +3554,7 @@ julia> path1 = joinpath(mktempdir(), "foo"); touch(path1); # set up a file calle
 
 julia> pushfirst!(DEPOT_PATH, dirname(path1));
 
-julia> relocpath = RelocPath(path1);
+julia> relocpath = Base.RelocPath(path1);
 
 julia> String(relocpath) == path1
 true

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3496,14 +3496,22 @@ function CacheHeaderIncludes(dep_tuple::Tuple{Module, String, UInt64, UInt32, Fl
     return CacheHeaderIncludes(PkgId(dep_tuple[1]), dep_tuple[2:end]..., String[])
 end
 
-function replace_depot_path(path::AbstractString, depots::Vector{String}=normalize_depots_for_relocation())
+function replace_depot_path_impl(path::AbstractString, depots::Vector{String}=normalize_depots_for_relocation())
+    the_depot = nothing
+    reloc_path = path
     for depot in depots
         if startswith(path, string(depot, Filesystem.pathsep())) || path == depot
-            path = replace(path, depot => "@depot"; count=1)
+            reloc_path = replace(path, depot => "@depot"; count=1)
+            the_depot = depot
             break
         end
     end
-    return path
+    return the_depot, reloc_path
+end
+
+function replace_depot_path(path::AbstractString, depots::Vector{String}=normalize_depots_for_relocation())
+    _, reloc_path = replace_depot_path_impl(path, depots)
+    return reloc_path
 end
 
 function normalize_depots_for_relocation()

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3575,7 +3575,6 @@ struct RelocPath
     function RelocPath(path::AbstractString)
         depot, _ = replace_depot_path_impl(path)
         if isnothing(depot)
-            @show DEPOT_PATH
             error("Failed to locate $(path) in any of DEPOT_PATH.")
         end
         subpath = replace(path, depot => ""; count=1)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3544,13 +3544,17 @@ function resolve_depot(inc::AbstractString)
 end
 
 """
-    Base.RelocPath(path::AbstractString)
+    Base.RelocPath(path::AbstractString; track_content::Bool=true)
 
 A type to represent a relocatable path.
 
 Requires `path` to be located within one of `DEPOT_PATH` upon construction.
 
 An error is thrown if relocation fails.
+
+If `track_content=true` the content hash of `path` is stored and later used to distinguish
+different versions of `path` appearing in multiple depots. If `path` refers to a directory,
+then the content hash is based on the string list of the directory's entries.
 
 # Example
 ```jldoctest

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3594,18 +3594,16 @@ struct RelocPath
     end
 end
 
-function String(r::RelocPath; verify_content::Bool=true)
-    if verify_content && isnothing(r.checksum)
-        error("Can't verify content for RelocPath(; track_content=false).")
-    end
+function String(r::RelocPath)
     for d in DEPOT_PATH
         if isdirpath(d)
             d = dirname(d)
         end
         path = string(d, r.subpath)
         if ispath(path)
-            !verify_content && return path
-            _include_dependency_hash(path) == r.checksum && return path
+            if isnothing(r.checksum) || _include_dependency_hash(path) == r.checksum
+                return path
+            end
         end
     end
     error("Failed to relocate @depot$(r.subpath) in any of DEPOT_PATH.")

--- a/base/public.jl
+++ b/base/public.jl
@@ -54,6 +54,7 @@ public
     load_path,
     active_project,
     active_manifest,
+    RelocPath,
 
 # Reflection and introspection
     get_extension,

--- a/test/Makefile
+++ b/test/Makefile
@@ -51,6 +51,7 @@ relocatedepot:
 	@cp -R $(SRCDIR)/RelocationTestPkg2 $(SRCDIR)/relocatedepot
 	@cp -R $(SRCDIR)/RelocationTestPkg3 $(SRCDIR)/relocatedepot
 	@cp -R $(SRCDIR)/RelocationTestPkg4 $(SRCDIR)/relocatedepot
+	@cp -R $(SRCDIR)/RelocationTestPkg5 $(SRCDIR)/relocatedepot
 	@cd $(SRCDIR) && \
 	$(call PRINT_JULIA, $(call spawn,RELOCATEDEPOT="" $(JULIA_EXECUTABLE)) $(TEST_JULIA_OPTIONS) ./runtests.jl $(TEST_SCRIPT_OPTIONS) $@)
 
@@ -64,6 +65,7 @@ revise-relocatedepot: revise-% :
 	@cp -R $(SRCDIR)/RelocationTestPkg2 $(SRCDIR)/relocatedepot
 	@cp -R $(SRCDIR)/RelocationTestPkg3 $(SRCDIR)/relocatedepot
 	@cp -R $(SRCDIR)/RelocationTestPkg4 $(SRCDIR)/relocatedepot
+	@cp -R $(SRCDIR)/RelocationTestPkg5 $(SRCDIR)/relocatedepot
 	@cd $(SRCDIR) && \
 	$(call PRINT_JULIA, $(call spawn,RELOCATEDEPOT="" $(JULIA_EXECUTABLE)) $(TEST_JULIA_OPTIONS) ./runtests.jl $(TEST_SCRIPT_OPTIONS) --revise $*)
 

--- a/test/RelocationTestPkg1/src/RelocationTestPkg1.jl
+++ b/test/RelocationTestPkg1/src/RelocationTestPkg1.jl
@@ -1,5 +1,7 @@
 module RelocationTestPkg1
 
+const relocpath = Base.RelocPath(@__DIR__)
+
 greet() = print("Hello World!")
 
 end # module RelocationTestPkg1

--- a/test/RelocationTestPkg1/src/RelocationTestPkg1.jl
+++ b/test/RelocationTestPkg1/src/RelocationTestPkg1.jl
@@ -1,7 +1,5 @@
 module RelocationTestPkg1
 
-const relocpath = Base.RelocPath(@__DIR__)
-
 greet() = print("Hello World!")
 
 end # module RelocationTestPkg1

--- a/test/RelocationTestPkg5/Project.toml
+++ b/test/RelocationTestPkg5/Project.toml
@@ -1,0 +1,4 @@
+name = "RelocationTestPkg5"
+uuid = "4c39e1d3-80fc-478e-8fc9-3bafa33dd728"
+authors = ["Florian Atteneder <florian.atteneder@gmail.com>"]
+version = "0.1.0"

--- a/test/RelocationTestPkg5/src/RelocationTestPkg5.jl
+++ b/test/RelocationTestPkg5/src/RelocationTestPkg5.jl
@@ -1,0 +1,12 @@
+module RelocationTestPkg5
+
+const dir  = normpath(joinpath(@__DIR__, "..", "..", "TestPkg"))
+const file = joinpath(dir, "Project.toml")
+const dir_tracked      = Base.RelocPath(dir;  track_content=true)
+const dir_not_tracked  = Base.RelocPath(dir;  track_content=false)
+const file_tracked     = Base.RelocPath(file; track_content=true)
+const file_not_tracked = Base.RelocPath(file; track_content=false)
+
+greet() = print("Hello World!")
+
+end # module RelocationTestPkg5

--- a/test/relocatedepot.jl
+++ b/test/relocatedepot.jl
@@ -21,7 +21,7 @@ function test_harness(@nospecialize(fn); empty_load_path=true, empty_depot_path=
 end
 
 # We test relocation with these dummy pkgs:
-# - RelocationTestPkg1 - pkg with no include_dependency
+# - RelocationTestPkg1 - pkg with no include_dependency, also contains a RelocPath()
 # - RelocationTestPkg2 - pkg with include_dependency tracked by `mtime`
 # - RelocationTestPkg3 - pkg with include_dependency tracked by content
 # - RelocationTestPkg4 - pkg with no dependencies; will be compiled such that the pkgimage is
@@ -264,11 +264,18 @@ else
         pkgname = "RelocationTestPkg1"
         test_harness() do
             push!(LOAD_PATH, joinpath(@__DIR__, "relocatedepot"))
-            push!(DEPOT_PATH, joinpath(@__DIR__, "relocatedepot")) # required to find src files
             push!(DEPOT_PATH, joinpath(@__DIR__, "relocatedepot", "julia")) # contains cache file
+            push!(DEPOT_PATH, joinpath(@__DIR__, "relocatedepot")) # required to find src files
             pkg = Base.identify_package(pkgname)
             @test Base.isprecompiled(pkg) == true
             @test Base.isrelocatable(pkg) == true
+            pkg = Base.require(pkg)
+            @test String(pkg.relocpath) == joinpath(pkgdir(pkg), "src")
+            pop!(DEPOT_PATH)
+            @test_throws(
+                ErrorException("Failed to relocate @depot/RelocationTestPkg1/src in any of DEPOT_PATH."),
+                String(pkg.relocpath)
+            )
         end
     end
 

--- a/test/relocatedepot.jl
+++ b/test/relocatedepot.jl
@@ -189,10 +189,10 @@ if !test_relocated_depot
             file = joinpath(dir, "Project.toml")
             @test p.dir  == dir
             @test p.file == file
-            @test String(p.dir_tracked, verify_content=true)       == dir
-            @test String(p.dir_not_tracked, verify_content=false)  == dir
-            @test String(p.file_tracked, verify_content=true)      == file
-            @test String(p.file_not_tracked, verify_content=false) == file
+            @test String(p.dir_tracked)      == dir
+            @test String(p.dir_not_tracked)  == dir
+            @test String(p.file_tracked)     == file
+            @test String(p.file_not_tracked) == file
         end
     end
 
@@ -228,63 +228,37 @@ if !test_relocated_depot
 
                 @test_throws(
                     ErrorException("Failed to relocate @depot$(foo_tracked.subpath) in any of DEPOT_PATH."),
-                    String(foo_tracked, verify_content=true)
+                    String(foo_tracked)
                 )
-                @test String(new_foo_tracked, verify_content=true) == foo
-                @test String(foo_tracked, verify_content=false) == foo
-                @test_throws(
-                    str -> occursin("Can't verify content for RelocPath(; track_content=false)", str),
-                    String(foo_not_tracked, verify_content=true)
-                )
-                @test String(foo_not_tracked, verify_content=false) == foo
+                @test String(new_foo_tracked) == foo
+                @test String(foo_not_tracked) == foo
 
                 @test_throws(
                     ErrorException("Failed to relocate @depot$(bar_tracked.subpath) in any of DEPOT_PATH."),
-                    String(bar_tracked, verify_content=true)
+                    String(bar_tracked)
                 )
-                @test String(new_bar_tracked, verify_content=true) == bar
-                @test String(bar_tracked, verify_content=false) == bar
-                @test_throws(
-                    ErrorException("Can't verify content for RelocPath(; track_content=false)."),
-                    String(bar_not_tracked, verify_content=true)
-                )
-                @test String(bar_not_tracked, verify_content=false) == bar
+                @test String(new_bar_tracked) == bar
+                @test String(bar_not_tracked) == bar
 
                 foo_tracked = new_foo_tracked
                 bar_tracked = new_bar_tracked
                 empty!(DEPOT_PATH)
                 @test_throws(
                     ErrorException("Failed to relocate @depot$(foo_tracked.subpath) in any of DEPOT_PATH."),
-                    String(foo_tracked, verify_content=true)
+                    String(foo_tracked)
                 )
                 @test_throws(
-                    ErrorException("Failed to relocate @depot$(foo_tracked.subpath) in any of DEPOT_PATH."),
-                    String(foo_tracked, verify_content=false)
-                )
-                @test_throws(
-                    ErrorException("Can't verify content for RelocPath(; track_content=false)."),
-                    String(foo_not_tracked, verify_content=true)
-                )
-                @test_throws(
-                    ErrorException("Failed to relocate @depot$(foo_tracked.subpath) in any of DEPOT_PATH."),
-                    String(foo_not_tracked, verify_content=false)
+                    ErrorException("Failed to relocate @depot$(foo_not_tracked.subpath) in any of DEPOT_PATH."),
+                    String(foo_not_tracked)
                 )
 
                 @test_throws(
                     ErrorException("Failed to relocate @depot$(bar_tracked.subpath) in any of DEPOT_PATH."),
-                    String(bar_tracked, verify_content=true)
+                    String(bar_tracked)
                 )
                 @test_throws(
-                    ErrorException("Failed to relocate @depot$(bar_tracked.subpath) in any of DEPOT_PATH."),
-                    String(bar_tracked, verify_content=false)
-                )
-                @test_throws(
-                    ErrorException("Can't verify content for RelocPath(; track_content=false)."),
-                    String(bar_not_tracked, verify_content=true)
-                )
-                @test_throws(
-                    ErrorException("Failed to relocate @depot$(bar_tracked.subpath) in any of DEPOT_PATH."),
-                    String(bar_not_tracked, verify_content=false)
+                    ErrorException("Failed to relocate @depot$(bar_not_tracked.subpath) in any of DEPOT_PATH."),
+                    String(bar_not_tracked)
                 )
             end
         end
@@ -454,34 +428,26 @@ else
             @test p.file == file
             @test_throws(
                 ErrorException("Failed to relocate @depot$(p.dir_tracked.subpath) in any of DEPOT_PATH."),
-                String(p.dir_tracked, verify_content=true)
-            )
-            @test_throws(
-                ErrorException("Failed to relocate @depot$(p.dir_tracked.subpath) in any of DEPOT_PATH."),
-                String(p.dir_tracked, verify_content=false)
+                String(p.dir_tracked)
             )
             @test_throws(
                 ErrorException("Failed to relocate @depot$(p.dir_not_tracked.subpath) in any of DEPOT_PATH."),
-                String(p.dir_not_tracked, verify_content=false)
+                String(p.dir_not_tracked)
             )
             @test_throws(
                 ErrorException("Failed to relocate @depot$(p.file_tracked.subpath) in any of DEPOT_PATH."),
-                String(p.file_tracked, verify_content=true)
-            )
-            @test_throws(
-                ErrorException("Failed to relocate @depot$(p.file_tracked.subpath) in any of DEPOT_PATH."),
-                String(p.file_tracked, verify_content=false)
+                String(p.file_tracked)
             )
             @test_throws(
                 ErrorException("Failed to relocate @depot$(p.file_not_tracked.subpath) in any of DEPOT_PATH."),
-                String(p.file_not_tracked, verify_content=false)
+                String(p.file_not_tracked)
             )
 
             push!(DEPOT_PATH, @__DIR__)
-            @test String(p.dir_tracked, verify_content=true)       == dir
-            @test String(p.dir_not_tracked, verify_content=false)  == dir
-            @test String(p.file_tracked, verify_content=true)      == file
-            @test String(p.file_not_tracked, verify_content=false) == file
+            @test String(p.dir_tracked)      == dir
+            @test String(p.dir_not_tracked)  == dir
+            @test String(p.file_tracked)     == file
+            @test String(p.file_not_tracked) == file
         end
     end
 


### PR DESCRIPTION
`RelocPath(path)` works by splitting `path` as `depot/subpath` based on `DEPOT_PATH` during construction.

When using `RelocPath` one explicitly opts into relocation, so it throws when `path` cannot be split.

A relocated path can be queried with `String(r::RelocPath)`, which also throws on failure.

---

Fixes #54430
Alternative to #55146