### PR TITLE
effects: fix `Base.@_noub_meta`

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -337,7 +337,8 @@ macro _noub_meta()
         #=:inaccessiblememonly=#false,
         #=:noub=#true,
         #=:noub_if_noinbounds=#false,
-        #=:consistent_overlay=#false))
+        #=:consistent_overlay=#false,
+        #=:nortcall=#false))
 end
 # can be used in place of `@assume_effects :notaskstate` (supposed to be used for bootstrapping)
 macro _notaskstate_meta()

--- a/src/method.c
+++ b/src/method.c
@@ -491,6 +491,8 @@ jl_code_info_t *jl_new_code_info_from_ir(jl_expr_t *ir)
                         if (consistent_overlay) li->purity.overrides.ipo_consistent_overlay = consistent_overlay;
                         int8_t nortcall = jl_unbox_bool(jl_exprarg(ma, 10));
                         if (nortcall) li->purity.overrides.ipo_nortcall = nortcall;
+                    } else {
+                        assert(jl_expr_nargs(ma) == 0);
                     }
                 }
                 else

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -810,7 +810,12 @@ end
 #        @test !Core.Compiler.is_nothrow(effects)
 #    end
 #end
-#
+
+@test Core.Compiler.is_noub(Base.infer_effects(Base._growbeg!, (Vector{Int}, Int)))
+@test Core.Compiler.is_noub(Base.infer_effects(Base._growbeg!, (Vector{Any}, Int)))
+@test Core.Compiler.is_noub(Base.infer_effects(Base._growend!, (Vector{Int}, Int)))
+@test Core.Compiler.is_noub(Base.infer_effects(Base._growend!, (Vector{Any}, Int)))
+
 # tuple indexing
 # --------------
 


### PR DESCRIPTION
This had the incorrect number of arguments to `Expr(:purity, ...)` causing it to be silently ignored.