### PR TITLE
Implement support for set of constants in absint

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -62,7 +62,8 @@ struct MethodMatches
     valid_worlds::WorldRange
 end
 any_ambig(result::MethodLookupResult) = result.ambig
-any_ambig(info::MethodMatchInfo) = any_ambig(info.results)
+any_ambig(query::MethodLookupQuery) = any_ambig(query.results)
+any_ambig(info::MethodMatchInfo) = any_ambig(info.query)
 any_ambig(m::MethodMatches) = any_ambig(m.info)
 fully_covering(info::MethodMatchInfo) = info.fullmatch
 fully_covering(m::MethodMatches) = fully_covering(m.info)
@@ -78,7 +79,7 @@ any_ambig(m::UnionSplitMethodMatches) = any_ambig(m.info)
 fully_covering(info::UnionSplitInfo) = all(fully_covering, info.split)
 fully_covering(m::UnionSplitMethodMatches) = fully_covering(m.info)
 
-nmatches(info::MethodMatchInfo) = length(info.results)
+nmatches(info::MethodMatchInfo) = length(info.query.results)
 function nmatches(info::UnionSplitInfo)
     n = 0
     for mminfo in info.split
@@ -379,7 +380,7 @@ function find_union_split_method_matches(interp::AbstractInterpreter, argtypes::
         end
         valid_worlds = intersect(valid_worlds, thismatches.valid_worlds)
         thisfullmatch = any(match::MethodMatch->match.fully_covers, thismatches)
-        thisinfo = MethodMatchInfo(thismatches, mt, sig_n, thisfullmatch)
+        thisinfo = MethodMatchInfo(MethodLookupQuery(thismatches, arg_n, sig_n), mt, thisfullmatch)
         push!(infos, thisinfo)
         for idx = 1:length(thismatches)
             push!(applicable, MethodMatchTarget(thismatches[idx], thisinfo.edges, idx))
@@ -404,7 +405,7 @@ function find_simple_method_matches(interp::AbstractInterpreter, @nospecialize(a
         return FailedMethodMatch("Too many methods matched")
     end
     fullmatch = any(match::MethodMatch->match.fully_covers, matches)
-    info = MethodMatchInfo(matches, mt, atype, fullmatch)
+    info = MethodMatchInfo(MethodLookupQuery(matches, Any[], atype), mt, fullmatch)
     applicable = MethodMatchTarget[MethodMatchTarget(matches[idx], info.edges, idx) for idx = 1:length(matches)]
     return MethodMatches(applicable, info, matches.valid_worlds)
 end

--- a/Compiler/src/abstractlattice.jl
+++ b/Compiler/src/abstractlattice.jl
@@ -15,11 +15,11 @@ is_valid_lattice_norec(::JLTypeLattice, @nospecialize(elem)) = isa(elem, Type)
 """
     struct ConstsLattice <: AbstractLattice
 
-A lattice extending `JLTypeLattice` and adjoining `Const` and `PartialTypeVar`.
+A lattice extending `JLTypeLattice` and adjoining `Const`, `ConstSet`, `PartialTypeVar`.
 """
 struct ConstsLattice <: AbstractLattice; end
 widenlattice(::ConstsLattice) = JLTypeLattice()
-is_valid_lattice_norec(::ConstsLattice, @nospecialize(elem)) = isa(elem, Const) || isa(elem, PartialTypeVar)
+is_valid_lattice_norec(::ConstsLattice, @nospecialize(elem)) = isa(elem, Const) || isa(elem, PartialTypeVar) || isa(elem, ConstSet)
 
 """
     struct PartialsLattice{𝕃<:AbstractLattice} <: AbstractLattice

--- a/Compiler/src/methodtable.jl
+++ b/Compiler/src/methodtable.jl
@@ -15,6 +15,11 @@ function iterate(result::MethodLookupResult, args...)
     return (match::MethodMatch, state)
 end
 getindex(result::MethodLookupResult, idx::Int) = getindex(result.matches, idx)::MethodMatch
+struct MethodLookupQuery
+    results::MethodLookupResult
+    argtypes::Vector{Any}
+    atype
+end
 
 abstract type MethodTableView end
 

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -1557,7 +1557,7 @@ function handle_modifyop!_call!(ir::IRCode, idx::Int, stmt::Expr, info::ModifyOp
     info isa ConstCallInfo && (info = info.call)
     info isa MethodMatchInfo || return nothing
     length(info.edges) == length(info.results) == 1 || return nothing
-    match = info.results[1]::MethodMatch
+    match = info.query.results[1]::MethodMatch
     match.fully_covers || return nothing
     edge = info.edges[1]
     edge === nothing && return nothing

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -560,6 +560,9 @@ function ir_inline_unionsplit!(compact::IncrementalCompact, idx::Int, argexprs::
                 end
             else
                 argtypes = case.argtypes
+                if isempty(argtypes) # TODO: Fix the case where this is Any[]
+                    continue
+                end
                 for i = 1:nparams
                     argex = argexprs[i]
                     tT, sT = argtypes[i], argextype(argex, compact)

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -29,7 +29,8 @@ end
 struct ConstantCase
     val::Any
     edge::CodeInstance
-    ConstantCase(@nospecialize(val), edge::CodeInstance) = new(val, edge)
+    argtypes::Vector{Any}
+    ConstantCase(@nospecialize(val), edge::CodeInstance, argtypes::Vector{Any}) = new(val, edge, argtypes)
 end
 
 struct SomeCase
@@ -539,20 +540,42 @@ function ir_inline_unionsplit!(compact::IncrementalCompact, idx::Int, argexprs::
         nparams = fieldcount(atype)
         @assert nparams == fieldcount(mtype)
         if !(i == ncases && fully_covered && handled_all_cases)
-            for i = 1:nparams
-                aft, mft = fieldtype(atype, i), fieldtype(mtype, i)
-                # If this is always true, we don't need to check for it
-                aft <: mft && continue
-                # Generate isa check
-                isa_expr = Expr(:call, isa, argexprs[i], mft)
-                isa_type = isa_tfunc(optimizer_lattice(interp), argextype(argexprs[i], compact), Const(mft))
-                ssa = insert_node_here!(compact, NewInstruction(isa_expr, isa_type, line))
-                if cond === true
-                    cond = ssa
-                else
-                    and_expr = Expr(:call, and_int, cond, ssa)
-                    and_type = and_int_tfunc(optimizer_lattice(interp), argextype(cond, compact), isa_type)
-                    cond = insert_node_here!(compact, NewInstruction(and_expr, and_type, line))
+            if !isa(case, ConstantCase)
+                for i = 1:nparams
+                    aft, mft = fieldtype(atype, i), fieldtype(mtype, i)
+                    # If this is always true, we don't need to check for it
+                    aft <: mft && continue
+
+                    # Generate isa check
+                    isa_expr = Expr(:call, isa, argexprs[i], mft)
+                    isa_type = isa_tfunc(optimizer_lattice(interp), argextype(argexprs[i], compact), Const(mft))
+                    ssa = insert_node_here!(compact, NewInstruction(isa_expr, isa_type, line))
+                    if cond === true
+                        cond = ssa
+                    else
+                        and_expr = Expr(:call, and_int, cond, ssa)
+                        and_type = and_int_tfunc(optimizer_lattice(interp), argextype(cond, compact), isa_type)
+                        cond = insert_node_here!(compact, NewInstruction(and_expr, and_type, line))
+                    end
+                end
+            else
+                argtypes = case.argtypes
+                for i = 1:nparams
+                    argex = argexprs[i]
+                    tT, sT = argtypes[i], argextype(argex, compact)
+                    if isa(tT, Const) && isa(sT, ConstSet)
+                        # Generate egal check
+                        egal_expr = Expr(:call, ===, argex, tT)
+                        egal_type = egal_tfunc(optimizer_lattice(interp), argextype(argexprs[i], compact), tT)
+                        ssa = insert_node_here!(compact, NewInstruction(egal_expr, egal_type, line))
+                        if cond === true
+                            cond = ssa
+                        else
+                            and_expr = Expr(:call, and_int, cond, ssa)
+                            and_type = and_int_tfunc(optimizer_lattice(interp), argextype(cond, compact), egal_type)
+                            cond = insert_node_here!(compact, NewInstruction(and_expr, and_type, line))
+                        end
+                    end
                 end
             end
             insert_node_here!(compact, NewInstruction(GotoIfNot(cond, next_cond_bb), Any, line))
@@ -809,7 +832,7 @@ end
     if code isa CodeInstance
         if use_const_api(code)
             # in this case function can be inlined to a constant
-            return ConstantCase(quoted(code.rettype_const), code)
+            return ConstantCase(quoted(code.rettype_const), code, Any[]) # TODO: argtypes
         end
         return code
     end
@@ -822,7 +845,7 @@ end
         res = inf_result.result
         if isa(res, Const) && is_inlineable_constant(res.val)
             # use constant calling convention
-            return ConstantCase(quoted(res.val), inf_result.ci_as_edge)
+            return ConstantCase(quoted(res.val), inf_result.ci_as_edge, inf_result.argtypes)
         end
     end
     return InferredResult(inf_result.src, effects, inf_result.ci_as_edge)
@@ -1160,7 +1183,7 @@ function handle_invoke_call!(todo::Vector{Pair{Int,Any}},
     end
     result = info.result
     if isa(result, ConcreteResult)
-        item = concrete_result_item(result, info, state)
+        item = concrete_result_item(result, info, state, sig.argtypes)
     elseif isa(result, SemiConcreteResult)
         item = semiconcrete_result_item(result, info, flag, state)
     else
@@ -1292,11 +1315,11 @@ function process_simple!(todo::Vector{Pair{Int,Any}}, ir::IRCode, idx::Int, flag
 end
 
 function handle_any_const_result!(cases::Vector{InliningCase},
-    @nospecialize(result), match::MethodMatch, argtypes::Vector{Any},
+    @nospecialize(result), match::MethodMatch, match_argtypes::Vector{Any}, argtypes::Vector{Any},
     @nospecialize(info::CallInfo), flag::UInt32, state::InliningState;
     allow_typevars::Bool)
     if isa(result, ConcreteResult)
-        return handle_concrete_result!(cases, result, match, info, state)
+        return handle_concrete_result!(cases, result, match, match_argtypes, info, state)
     elseif isa(result, SemiConcreteResult)
         return handle_semi_concrete_result!(cases, result, match, info, flag, state)
     elseif isa(result, ConstPropResult)
@@ -1337,7 +1360,6 @@ function compute_inlining_cases(@nospecialize(info::CallInfo), flag::UInt32, sig
     local all_result_count = 0
     local joint_effects = EFFECTS_TOTAL
     for i = 1:nunion
-        # Base.@show info
         query = getsplit(info, i)
         meth = query.results
         if meth.ambig
@@ -1366,7 +1388,7 @@ function compute_inlining_cases(@nospecialize(info::CallInfo), flag::UInt32, sig
                 handled_all_cases = false
             else
                 handled_all_cases &= handle_any_const_result!(cases,
-                    result, match, argtypes, info, flag, state; allow_typevars=false)
+                    result, match, query.argtypes, argtypes, info, flag, state; allow_typevars=false)
             end
         end
         fully_covered &= split_fully_covered
@@ -1383,7 +1405,7 @@ function compute_inlining_cases(@nospecialize(info::CallInfo), flag::UInt32, sig
             match = query.results[j]
             result = getresult(info, k)
             handled_all_cases &= handle_any_const_result!(cases,
-                result, match, argtypes, info, flag, state; allow_typevars=true)
+                result, match, query.argtypes, argtypes, info, flag, state; allow_typevars=true)
         end
         if !fully_covered
             # We will emit an inline MethodError in this case, but that info already came inference, so we must already have the uncovered edge for it
@@ -1466,8 +1488,8 @@ function handle_semi_concrete_result!(cases::Vector{InliningCase}, result::SemiC
 end
 
 function handle_concrete_result!(cases::Vector{InliningCase}, result::ConcreteResult,
-    match::MethodMatch, @nospecialize(info::CallInfo), state::InliningState)
-    case = concrete_result_item(result, info, state)
+    match::MethodMatch, argtypes::Vector{Any}, @nospecialize(info::CallInfo), state::InliningState)
+    case = concrete_result_item(result, info, state, argtypes)
     case === nothing && return false
     push!(cases, InliningCase(match.spec_types, case))
     return true
@@ -1476,13 +1498,13 @@ end
 may_inline_concrete_result(result::ConcreteResult) =
     isdefined(result, :result) && is_inlineable_constant(result.result)
 
-function concrete_result_item(result::ConcreteResult, @nospecialize(info::CallInfo), state::InliningState)
+function concrete_result_item(result::ConcreteResult, @nospecialize(info::CallInfo), state::InliningState, argtypes::Vector{Any})
     if !may_inline_concrete_result(result)
         et = InliningEdgeTracker(state)
         return compileable_specialization(result.edge, result.effects, et, info, state)
     end
     @assert result.effects === EFFECTS_TOTAL
-    return ConstantCase(quoted(result.result), result.edge)
+    return ConstantCase(quoted(result.result), result.edge, argtypes)
 end
 
 function handle_cases!(todo::Vector{Pair{Int,Any}}, ir::IRCode, idx::Int, stmt::Expr,
@@ -1514,7 +1536,7 @@ function handle_opaque_closure_call!(todo::Vector{Pair{Int,Any}},
         validate_sparams(mi.sparam_vals) || return nothing
         item = resolve_todo(mi, result.result, info, flag, state)
     elseif isa(result, ConcreteResult)
-        item = concrete_result_item(result, info, state)
+        item = concrete_result_item(result, info, state, Any[]) # TODO argtypes for ConstSplit
     elseif isa(result, SemiConcreteResult)
         item = item = semiconcrete_result_item(result, info, flag, state)
     else

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -1337,7 +1337,9 @@ function compute_inlining_cases(@nospecialize(info::CallInfo), flag::UInt32, sig
     local all_result_count = 0
     local joint_effects = EFFECTS_TOTAL
     for i = 1:nunion
-        meth = getsplit(info, i)
+        # Base.@show info
+        query = getsplit(info, i)
+        meth = query.results
         if meth.ambig
             # Too many applicable methods
             # Or there is a (partial?) ambiguity
@@ -1377,7 +1379,8 @@ function compute_inlining_cases(@nospecialize(info::CallInfo), flag::UInt32, sig
             # we handled everything except one match with unmatched sparams,
             # so try to handle it by bypassing validate_sparams
             (i, j, k) = revisit_idx
-            match = getsplit(info, i)[j]
+            query = getsplit(info, i)
+            match = query.results[j]
             result = getresult(info, k)
             handled_all_cases &= handle_any_const_result!(cases,
                 result, match, argtypes, info, flag, state; allow_typevars=true)

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -3087,7 +3087,7 @@ function _hasmethod_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, sv
     if match === nothing
         rt = Const(false)
         vresults = MethodLookupResult(Any[], valid_worlds, true)
-        vinfo = MethodMatchInfo(vresults, mt, types, false) # XXX: this should actually be an info with invoke-type edge
+        vinfo = MethodMatchInfo(MethodLookupQuery(vresults, argtype_by_index(argtypes, typeidx), types), mt, false) # XXX: this should actually be an info with invoke-type edge
     else
         rt = Const(true)
         vinfo = InvokeCallInfo(nothing, match, nothing, types)

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1167,10 +1167,13 @@ end
             r = _getfield_tfunc_const(sv, name)
             r !== nothing && return r
         end
-        typ =  _getfield_tfunc(widenlattice(𝕃), widenconst(s00), name, setfield)
+        typ = _getfield_tfunc(widenlattice(𝕃), widenconst(s00), name, setfield)
+	s00 = widenconst(s00)
+        if !isconcretetype(s00)
+            return typ
+	end
         vals = Any[]
-        
-        for n in fieldnames(widenconst(s00))
+        for n in fieldnames(s00)
             r = _getfield_tfunc_const(sv, Const(n))
             if r === nothing
                 return typ

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -4,9 +4,9 @@
 # structs/constants #
 #####################
 
-# N.B.: Const/PartialStruct/InterConditional are defined in Core, to allow them to be used
+# N.B.: Const/ConstSet/PartialStruct/InterConditional are defined in Core, to allow them to be used
 # inside the global code cache.
-import Core: Const, InterConditional, PartialStruct
+import Core: Const, InterConditional, PartialStruct, ConstSet
 
 """
     cnd::Conditional
@@ -498,6 +498,8 @@ end
     if isa(a, Const)
         if isa(b, Const)
             return a.val === b.val
+        elseif isa(b, ConstSet)
+            return any(_b -> a == _b, b.vals)
         end
         # TODO: `b` could potentially be a `PartialTypeVar` here, in which case we might be
         # able to return `true` in more cases; in the meantime, just returning this is the
@@ -506,11 +508,25 @@ end
     elseif isa(b, Const)
         if issingletontype(a)
             return a.instance === b.val
+        # elseif isa(a, ConstSet)
+        #     return any(_a -> b == _a, a.vals)
         end
         return false
     elseif isa(a, PartialTypeVar)
         return b === TypeVar || a === b
     elseif isa(b, PartialTypeVar)
+        return false
+    elseif isa(a, ConstSet)
+        if isa(b, ConstSet)
+            for _a in a.vals
+                if !any(_a -> b == _a, a.vals)
+                    return false
+                end
+            end
+            return true
+        end
+        return false
+    elseif isa(b, ConstSet)
         return false
     end
     return ⊑(widenlattice(lattice), a, b)
@@ -677,6 +693,7 @@ Widens extended lattice element `x` to native `Type` representation.
 widenconst(::AnyConditional) = Bool
 widenconst(a::AnyMustAlias) = widenconst(widenmustalias(a))
 widenconst(c::Const) = (v = c.val; isa(v, Type) ? Type{v} : typeof(v))
+widenconst(c::ConstSet) = c.typ
 widenconst(::PartialTypeVar) = TypeVar
 widenconst(t::Core.PartialStruct) = t.typ
 widenconst(t::PartialOpaque) = t.typ
@@ -752,4 +769,36 @@ function Core.PartialStruct(::AbstractLattice, @nospecialize(typ), fields::Vecto
         assert_nested_slotwrapper(fields[i])
     end
     return Core._PartialStruct(typ, fields)
+end
+
+function Core.ConstSet(lattice::AbstractLattice,
+                       @nospecialize(a::Union{Core.Const, Core.ConstSet}),
+                       @nospecialize(b::Union{Core.Const, Core.ConstSet}))
+    if a isa Core.ConstSet
+        vals = copy(a.vals)
+        typa = a.typ
+        if b isa Core.ConstSet
+            append!(vals, b.vals)
+            typb = b
+        elseif b isa Core.Const
+            push!(vals, b)
+            typb = widenconst(b)
+        end
+    elseif b isa Core.ConstSet
+        vals = copy(b.vals)
+        typb = b.typ
+        if a isa Core.Const
+            push!(vals, a)
+            typa = widenconst(a)
+        end
+    elseif a isa Core.Const && b isa Core.Const
+        vals = Any[a, b]
+        typa = widenconst(a)
+        typb = widenconst(b)
+    end
+
+    # Need to define compiler version
+    # unique!(vals)
+    # vals = collect(IdSet(vals))
+    return Core._ConstSet(tmerge(lattice, typa, typb), vals)
 end

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -645,6 +645,24 @@ end
             return Bottom
         end
         return v
+    elseif isa(v, ConstSet)
+        typ = tmeet(widenlattice(lattice), widenconst(v), t)
+        if typ === Bottom
+            return Bottom
+        end
+        vals = Any[]
+        for c in v.vals
+            c′ = tmeet(lattice, c, t)
+            if c′ !== Bottom
+                push!(vals, c′)
+            end
+        end
+        if isempty(vals)
+            return Bottom
+        elseif length(vals) == 1
+            return vals[1]
+        end
+        return Core._ConstSet(typ, vals)
     end
     tmeet(widenlattice(lattice), widenconst(v), t)
 end
@@ -797,8 +815,10 @@ function Core.ConstSet(lattice::AbstractLattice,
         typb = widenconst(b)
     end
 
-    # Need to define compiler version
-    # unique!(vals)
-    # vals = collect(IdSet(vals))
+    set = IdSet()
+    for v in vals
+        push!(set, v)
+    end
+    vals = collect(set)
     return Core._ConstSet(tmerge(lattice, typa, typb), vals)
 end

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -595,6 +595,11 @@ end
     if isa(a, PartialTypeVar) || isa(b, PartialTypeVar)
         return false
     end
+    if isa(a, ConstSet) || isa(b, ConstSet)
+        # N.B. Assumes a === b checked above
+        # TODO: ConstSet with different order
+        return false
+    end
     return is_lattice_equal(widenlattice(lattice), a, b)
 end
 

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -667,7 +667,7 @@ end
         elseif length(vals) == 1
             return vals[1]
         end
-        return Core._ConstSet(typ, vals)
+        return Core.ConstSet(typ, vals)
     end
     tmeet(widenlattice(lattice), widenconst(v), t)
 end
@@ -794,6 +794,15 @@ function Core.PartialStruct(::AbstractLattice, @nospecialize(typ), fields::Vecto
     return Core._PartialStruct(typ, fields)
 end
 
+function Core.ConstSet(@nospecialize(typ), vals::Vector{Any})
+    set = IdSet()
+    for v in vals
+        push!(set, v)
+    end
+    vals = collect(set)
+    return Core._ConstSet(typ, vals)
+end
+    
 function Core.ConstSet(lattice::AbstractLattice,
                        @nospecialize(a::Union{Core.Const, Core.ConstSet}),
                        @nospecialize(b::Union{Core.Const, Core.ConstSet}))
@@ -820,10 +829,5 @@ function Core.ConstSet(lattice::AbstractLattice,
         typb = widenconst(b)
     end
 
-    set = IdSet()
-    for v in vals
-        push!(set, v)
-    end
-    vals = collect(set)
-    return Core._ConstSet(tmerge(lattice, typa, typb), vals)
+    return Core.ConstSet(tmerge(lattice, typa, typb), vals)
 end

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -695,6 +695,7 @@ end
     if acp && bcp
         typea === typeb && return typea
 
+        # Uncomment to activate ConstSet formation
         # if !isa(typea, PartialTypeVar) && !isa(typeb, PartialTypeVar)
         #     return ConstSet(lattice, typea, typeb)
         # end

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -690,10 +690,14 @@ end
 end
 
 @nospecializeinfer function tmerge(lattice::ConstsLattice, @nospecialize(typea), @nospecialize(typeb))
-    acp = isa(typea, Const) || isa(typea, PartialTypeVar)
-    bcp = isa(typeb, Const) || isa(typeb, PartialTypeVar)
+    acp = isa(typea, Const) || isa(typea, PartialTypeVar) || isa(typea, ConstSet)
+    bcp = isa(typeb, Const) || isa(typeb, PartialTypeVar) || isa(typeb, ConstSet)
     if acp && bcp
         typea === typeb && return typea
+
+        # if !isa(typea, PartialTypeVar) && !isa(typeb, PartialTypeVar)
+        #     return ConstSet(lattice, typea, typeb)
+        # end
     end
     wl = widenlattice(lattice)
     acp && (typea = widenlattice(wl, typea))

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -696,9 +696,9 @@ end
         typea === typeb && return typea
 
         # Uncomment to activate ConstSet formation
-        # if !isa(typea, PartialTypeVar) && !isa(typeb, PartialTypeVar)
-        #     return ConstSet(lattice, typea, typeb)
-        # end
+        if !isa(typea, PartialTypeVar) && !isa(typeb, PartialTypeVar)
+            return ConstSet(lattice, typea, typeb)
+        end
     end
     wl = widenlattice(lattice)
     acp && (typea = widenlattice(wl, typea))

--- a/Compiler/src/types.jl
+++ b/Compiler/src/types.jl
@@ -479,14 +479,14 @@ function add_edges!(edges::Vector{Any}, info::CallInfo)
     nothing
 end
 nsplit(info::CallInfo) = nsplit_impl(info)::Union{Nothing,Int}
-getsplit(info::CallInfo, idx::Int) = getsplit_impl(info, idx)::MethodLookupResult
+getsplit(info::CallInfo, idx::Int) = getsplit_impl(info, idx)::MethodLookupQuery
 getresult(info::CallInfo, idx::Int) = getresult_impl(info, idx)#=::Union{Nothing,ConstResult}=#
 
 add_edges_impl(::Vector{Any}, ::CallInfo) = error("""
     All `CallInfo` is required to implement `add_edges_impl(::Vector{Any}, ::CallInfo)`""")
 nsplit_impl(::CallInfo) = nothing
 getsplit_impl(::CallInfo, ::Int) = error("""
-    A `info::CallInfo` that implements `nsplit_impl(info::CallInfo) -> Int` must implement `getsplit_impl(info::CallInfo, idx::Int) -> MethodLookupResult`
+    A `info::CallInfo` that implements `nsplit_impl(info::CallInfo) -> Int` must implement `getsplit_impl(info::CallInfo, idx::Int) -> MethodLookupQuery`
     in order to correctly opt in to inlining""")
 getresult_impl(::CallInfo, ::Int) = nothing
 

--- a/Compiler/src/typeutils.jl
+++ b/Compiler/src/typeutils.jl
@@ -235,14 +235,18 @@ function unionsplitcost(𝕃::AbstractLattice, argtypes::Union{SimpleVector,Vect
     nu = 1
     max = 2
     for ti in argtypes
-        if has_extended_unionsplit(𝕃) && !isvarargtype(ti)
-            ti = widenconst(ti)
-        end
+        nti = 1
         if isa(ti, ConstSet)
-            ti = widenconst(ti)
+            nti = length(ti.vals)
+        else
+            if has_extended_unionsplit(𝕃) && !isvarargtype(ti)
+                ti = widenconst(ti)
+            end
+            if isa(ti, Union)
+                nti = unionlen(ti)
+            end
         end
-        if isa(ti, Union)
-            nti = unionlen(ti)
+        if nti > 1
             if nti > max
                 max, nti = nti, max
             end
@@ -280,9 +284,9 @@ function _switchtupleunion(𝕃::AbstractLattice, t::Vector{Any}, i::Int, tunion
                 _switchtupleunion(𝕃, t, i - 1, tunion, origt)
             end
             t[i] = origti
-        elseif isa(ti, ConstSet) && isa(widenconst(ti), Union)
-            for ty in uniontypes(widenconst(ti))
-                t[i] = tmeet(𝕃, ti, ty)
+        elseif isa(ti, ConstSet) # && isa(widenconst(ti), Union)
+            for ty in ti.vals # uniontypes(widenconst(ti))
+                t[i] = ty #tmeet(𝕃, ti, ty)
                 _switchtupleunion(𝕃, t, i - 1, tunion, origt)
             end
             t[i] = origti

--- a/Compiler/src/typeutils.jl
+++ b/Compiler/src/typeutils.jl
@@ -238,6 +238,9 @@ function unionsplitcost(𝕃::AbstractLattice, argtypes::Union{SimpleVector,Vect
         if has_extended_unionsplit(𝕃) && !isvarargtype(ti)
             ti = widenconst(ti)
         end
+        if isa(ti, ConstSet)
+            ti = widenconst(ti)
+        end
         if isa(ti, Union)
             nti = unionlen(ti)
             if nti > max
@@ -274,6 +277,12 @@ function _switchtupleunion(𝕃::AbstractLattice, t::Vector{Any}, i::Int, tunion
         if isa(ti, Union)
             for ty in uniontypes(ti)
                 t[i] = ty
+                _switchtupleunion(𝕃, t, i - 1, tunion, origt)
+            end
+            t[i] = origti
+        elseif isa(ti, ConstSet) && isa(widenconst(ti), Union)
+            for ty in uniontypes(widenconst(ti))
+                t[i] = tmeet(𝕃, ti, ty)
                 _switchtupleunion(𝕃, t, i - 1, tunion, origt)
             end
             t[i] = origti

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -542,6 +542,7 @@ eval(Core, quote
     UpsilonNode(@nospecialize(val)) = $(Expr(:new, :UpsilonNode, :val))
     UpsilonNode() = $(Expr(:new, :UpsilonNode))
     Const(@nospecialize(v)) = $(Expr(:new, :Const, :v))
+    _ConstSet(@nospecialize(typ), values::Array{Any, 1}) = $(Expr(:new, :ConstSet, :typ, :values))
     _PartialStruct(@nospecialize(typ), fields::Array{Any, 1}) = $(Expr(:new, :PartialStruct, :typ, :fields))
     PartialOpaque(@nospecialize(typ), @nospecialize(env), parent::MethodInstance, source) = $(Expr(:new, :PartialOpaque, :typ, :env, :parent, :source))
     InterConditional(slot::Int, @nospecialize(thentype), @nospecialize(elsetype)) = $(Expr(:new, :InterConditional, :slot, :thentype, :elsetype))

--- a/base/coreir.jl
+++ b/base/coreir.jl
@@ -12,6 +12,15 @@ The type representing a constant value.
 Core.Const
 
 """
+    struct ConstSet
+        vals::Vector{Any}
+    end
+
+The type representing a set of constant values
+"""
+Core.ConstSet
+
+"""
     struct PartialStruct
         typ
         fields::Vector{Any} # elements are other type lattice members

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2586,6 +2586,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("SlotNumber", (jl_value_t*)jl_slotnumber_type);
     add_builtin("Argument", (jl_value_t*)jl_argument_type);
     add_builtin("Const", (jl_value_t*)jl_const_type);
+    add_builtin("ConstSet", (jl_value_t*)jl_constset_type);
     add_builtin("PartialStruct", (jl_value_t*)jl_partial_struct_type);
     add_builtin("PartialOpaque", (jl_value_t*)jl_partial_opaque_type);
     add_builtin("InterConditional", (jl_value_t*)jl_interconditional_type);

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -33,6 +33,7 @@
     XX(jl_code_info_type) \
     XX(jl_code_instance_type) \
     XX(jl_const_type) \
+    XX(jl_constset_type) \
     XX(jl_core_module) \
     XX(jl_datatype_type) \
     XX(jl_debuginfo_type) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3692,6 +3692,11 @@ void jl_init_types(void) JL_GC_DISABLED
                                        jl_svec1(jl_any_type),
                                        jl_emptysvec, 0, 0, 1);
 
+    jl_constset_type = jl_new_datatype(jl_symbol("ConstSet"), core, jl_any_type, jl_emptysvec,
+                                       jl_perm_symsvec(2, "typ", "vals"),
+                                       jl_svec2(jl_any_type, jl_array_any_type),
+                                       jl_emptysvec, 0, 0, 2);
+
     jl_partial_struct_type = jl_new_datatype(jl_symbol("PartialStruct"), core, jl_any_type, jl_emptysvec,
                                        jl_perm_symsvec(2, "typ", "fields"),
                                        jl_svec2(jl_any_type, jl_array_any_type),

--- a/src/julia.h
+++ b/src/julia.h
@@ -940,6 +940,7 @@ extern JL_DLLIMPORT jl_datatype_t *jl_ssavalue_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_slotnumber_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_argument_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_const_type JL_GLOBALLY_ROOTED;
+extern JL_DLLIMPORT jl_datatype_t *jl_constset_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_partial_struct_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_partial_opaque_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_interconditional_type JL_GLOBALLY_ROOTED;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -102,7 +102,7 @@ extern "C" {
 // TODO: put WeakRefs on the weak_refs list during deserialization
 // TODO: handle finalizers
 
-#define NUM_TAGS    196
+#define NUM_TAGS    197
 
 // An array of references that need to be restored from the sysimg
 // This is a manually constructed dual of the gvars array, which would be produced by codegen for Julia code, for C.
@@ -141,6 +141,7 @@ jl_value_t **const*const get_tags(void) {
         INSERT_TAG(jl_argument_type);
         INSERT_TAG(jl_returnnode_type);
         INSERT_TAG(jl_const_type);
+        INSERT_TAG(jl_constset_type);
         INSERT_TAG(jl_partial_struct_type);
         INSERT_TAG(jl_partial_opaque_type);
         INSERT_TAG(jl_interconditional_type);


### PR DESCRIPTION
Putting up a very rough draft for feedback.

Currently a function like:

```julia
julia> function f(cond)
          x = if cond
             1
          else
             2
          end
          x = x*x
       end
f (generic function with 1 method)
```

loses precision since we can't represent `Union{Const(1), Const(2)}` and then perform union-splitting on it.

```julia
julia> @code_typed optimize=false f(true)
CodeInfo(
1 ─      Core.NewvarNode(:(x))::Any
└──      goto #3 if not cond
2 ─      (@_4 = 1)::Core.Const(1)
└──      goto #4
3 ─      (@_4 = 2)::Core.Const(2)
4 ┄      (x = @_4)::Int64
│   %7 = (x * x)::Int64
│        (x = %7)::Int64
└──      return %7
) => Int64
```

In #55118 I was considering adding a `preferred_vector_width(Float64) -> Union{Const(2), Const(4), Const(8)}` and then have codegen refine that to a concrete integer depending on the actual target. (That might not be the best way of implementing that, but I can't even experiment with that right now).

In the abstract interpretation literature doing a Set of Const is a common extension, but similar to `Union` we would need to be craeful to not grow the `set` to big.  

Since modifying `Union` to support groups of non-type lattice element seemed more complicated, I am trying adding a new `ConstSet` lattice element.
