### PR TITLE
fix `Vararg{T,T} where T` crashing `code_typed`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -547,7 +547,13 @@ function collect_slot_refinements(𝕃ᵢ::AbstractLattice, applicable::Vector{A
             sigt = Bottom
             for j = 1:length(applicable)
                 match = applicable[j]::MethodMatch
-                sigt = sigt ⊔ fieldtype(match.spec_types, i)
+                spect = fieldtype(match.spec_types, i)
+                if isType(spect)
+                    sigt = sigt ⊔ spect
+                else
+                    sigt = Any
+                    break
+                end
             end
             if sigt ⊏ argt # i.e. signature type is strictly more specific than the type of the argument slot
                 if slotrefinements === nothing

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -547,13 +547,8 @@ function collect_slot_refinements(𝕃ᵢ::AbstractLattice, applicable::Vector{A
             sigt = Bottom
             for j = 1:length(applicable)
                 match = applicable[j]::MethodMatch
-                spect = fieldtype(match.spec_types, i)
-                if isType(spect)
-                    sigt = sigt ⊔ spect
-                else
-                    sigt = Any
-                    break
-                end
+                valid_as_lattice(match.spec_types, true) || continue
+                sigt = sigt ⊔ fieldtype(match.spec_types, i)
             end
             if sigt ⊏ argt # i.e. signature type is strictly more specific than the type of the argument slot
                 if slotrefinements === nothing

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -6048,3 +6048,10 @@ t255751 = Array{Float32, 3}
 
 issue55882_nfields(x::Union{T,Nothing}) where T<:Number = nfields(x)
 @test Base.infer_return_type(issue55882_nfields) <: Int
+
+# issue #55916
+f55916(x) = 1
+f55916(::Vararg{T,T}) where {T} = "2"
+g55916(x) = f55916(x)
+# this shouldn't error
+@test only(code_typed(g55916, (Any,); optimize=false))[2] == Int


### PR DESCRIPTION
Not sure this is the right place to fix this error, perhaps
`match.spec_types` should always be a tuple of valid types?

fixes #55916
