### PR TITLE
Base.MPFR: avoid reading the global defaults unless necessary

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -238,7 +238,7 @@ Base.copyto!(fd::BigFloatData, limbs) = copyto!(getfield(fd, :d), offset_p_limbs
 
 include("rawbigfloats.jl")
 
-rounding_raw(::Type{BigFloat}) = something(Base.ScopedValues.get(CURRENT_ROUNDING_MODE), ROUNDING_MODE[])
+rounding_raw(::Type{BigFloat}) = @something(Base.ScopedValues.get(CURRENT_ROUNDING_MODE), ROUNDING_MODE[])
 setrounding_raw(::Type{BigFloat}, r::MPFRRoundingMode) = ROUNDING_MODE[]=r
 function setrounding_raw(f::Function, ::Type{BigFloat}, r::MPFRRoundingMode)
     Base.ScopedValues.@with(CURRENT_ROUNDING_MODE => r, f())
@@ -1039,7 +1039,7 @@ _convert_precision_from_base(precision::Integer, base::Integer) =
     base == 2 ? precision : ceil(Int, precision * log2(base))
 
 _precision_with_base_2(::Type{BigFloat}) =
-    Int(something(Base.ScopedValues.get(CURRENT_PRECISION), DEFAULT_PRECISION[])) # default precision of the type BigFloat itself
+    Int(@something(Base.ScopedValues.get(CURRENT_PRECISION), DEFAULT_PRECISION[])) # default precision of the type BigFloat itself
 
 """
     setprecision([T=BigFloat,] precision::Int; base=2)


### PR DESCRIPTION
Another follow-up to #51362.

Make sure the global default precision and rounding mode are only dereferenced when necessary (when there's no relevant scope, in the ScopedValues sense).

Currently this change doesn't result in performance improvements, presumably due to how costly the access to a `ScopedValue` currently is, but the idea is to avoid the cost of the dereference when possible.

Once ScopedValues are better optimized by the compiler, I guess this would also result in better effects in case it's known that a call is within a ScopedValues scope.