### PR TITLE
Remove warning from c when binding is ambiguous

### DIFF
--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -283,14 +283,14 @@ julia> module B
 B
 ```
 
-The statement `using .A, .B` works, but when you try to call `f`, you get a warning
+The statement `using .A, .B` works, but when you try to call `f`, you get an error with a hint
 
 ```jldoctest module_manual
 julia> using .A, .B
 
 julia> f
-WARNING: both B and A export "f"; uses of it in module Main must be qualified
 ERROR: UndefVarError: `f` not defined in `Main`
+Hint: It looks like two or more modules export different bindings with this name, resulting in ambiguity. Try explicitly importing it from a particular module, or qualifying the name with the module it should come from.
 ```
 
 Here, Julia cannot decide which `f` you are referring to, so you have to make a choice. The following solutions are commonly used:

--- a/src/module.c
+++ b/src/module.c
@@ -430,11 +430,6 @@ static jl_binding_t *using_resolve_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl
                     tempb = jl_get_module_binding(m, var, 1);
                     tempbpart = jl_get_binding_partition(tempb, jl_current_task->world_age);
                     jl_atomic_store_release(&tempbpart->restriction, encode_restriction(NULL, BINDING_KIND_FAILED));
-                    jl_printf(JL_STDERR,
-                              "WARNING: both %s and %s export \"%s\"; uses of it in module %s must be qualified\n",
-                              jl_symbol_name(owner->name),
-                              jl_symbol_name(imp->name), jl_symbol_name(var),
-                              jl_symbol_name(m->name));
                 }
                 return NULL;
             }


### PR DESCRIPTION
As pointed out in https://github.com/JuliaLang/julia/pull/55959#issuecomment-2405803080 this warning isn't necessary

So this becomes
```
julia> download
ERROR: UndefVarError: `download` not defined in `Main`
Hint: It looks like two or more modules export different bindings with this name, resulting in ambiguity. Try explicitly importing it from a particular module, or qualifying the name with the module it should come from.
Hint: a global variable of this name also exists in Base.
```