### PR TITLE
Initial support for RISC-V

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -938,8 +938,12 @@ endif
 
 #If nothing is set default to native unless we are cross-compiling
 ifeq ($(MARCH)$(MCPU)$(MTUNE)$(JULIA_CPU_TARGET)$(XC_HOST),)
-ifeq ($(ARCH),aarch64) #ARM recommends only setting MCPU for AArch64
+ifeq ($(ARCH),aarch64)
+# ARM recommends only setting MCPU for AArch64
 MCPU=native
+else ifneq (,$(findstring riscv64,$(ARCH)))
+# RISC-V doesn't have a native option
+$(error Building for RISC-V requires a specific MARCH to be set))
 else
 MARCH=native
 MTUNE=native
@@ -995,6 +999,9 @@ endif
 ifneq (,$(findstring arm,$(ARCH)))
 DIST_ARCH:=arm
 endif
+ifneq (,$(findstring riscv64,$(ARCH)))
+DIST_ARCH:=riscv64
+endif
 
 JULIA_BINARYDIST_FILENAME := julia-$(JULIA_COMMIT)-$(DIST_OS)$(DIST_ARCH)
 endif
@@ -1018,7 +1025,11 @@ ifneq ($(MARCH),)
 CC += -march=$(MARCH)
 CXX += -march=$(MARCH)
 FC += -march=$(MARCH)
+# On RISC-V, don't forward the MARCH ISA string to JULIA_CPU_TARGET,
+# as it's always incompatible with LLVM's CPU target name parser.
+ifeq (,$(findstring riscv64,$(ARCH)))
 JULIA_CPU_TARGET ?= $(MARCH)
+endif
 endif
 
 # Set MCPU-specific flags

--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -597,7 +597,7 @@ const arch_mapping = Dict(
     "armv7l" => "arm(v7l)?", # if we just see `arm-linux-gnueabihf`, we assume it's `armv7l`
     "armv6l" => "armv6l",
     "powerpc64le" => "p(ower)?pc64le",
-    "riscv64" => "riscv64",
+    "riscv64" => "(rv64|riscv64)",
 )
 # Keep this in sync with `CPUID.ISAs_by_family`
 # These are the CPUID side of the microarchitectures targeted by GCC flags in BinaryBuilder.jl
@@ -630,6 +630,9 @@ const arch_march_isa_mapping = let
             "armv8_2_crypto" => get_set("aarch64", "armv8.2-a+crypto"),
             "a64fx" => get_set("aarch64", "a64fx"),
             "apple_m1" => get_set("aarch64", "apple_m1"),
+        ],
+        "riscv64" => [
+            "riscv64" => get_set("riscv64", "riscv64")
         ],
         "powerpc64le" => [
             "power8" => get_set("powerpc64le", "power8"),

--- a/base/cpuid.jl
+++ b/base/cpuid.jl
@@ -61,6 +61,9 @@ const ISAs_by_family = Dict(
         "a64fx" => ISA(Set((JL_AArch64_v8_2a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_sha2, JL_AArch64_ccpp, JL_AArch64_complxnum, JL_AArch64_fullfp16, JL_AArch64_sve))),
         "apple_m1" => ISA(Set((JL_AArch64_v8_5a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_aes, JL_AArch64_sha2, JL_AArch64_sha3, JL_AArch64_ccpp, JL_AArch64_complxnum, JL_AArch64_fp16fml, JL_AArch64_fullfp16, JL_AArch64_dotprod, JL_AArch64_rcpc, JL_AArch64_altnzcv))),
     ],
+    "riscv64" => [
+        "riscv64" => ISA(Set{UInt32}()),
+    ],
     "powerpc64le" => [
         # We have no way to test powerpc64le features yet, so we're only going to declare the lowest ISA:
         "power8" => ISA(Set{UInt32}()),

--- a/cli/trampolines/trampolines_riscv64.S
+++ b/cli/trampolines/trampolines_riscv64.S
@@ -1,0 +1,20 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include "common.h"
+#include "../../src/jl_exported_funcs.inc"
+
+#define SEP ;
+
+#define XX(name) \
+.global CNAME(name) SEP \
+.cfi_startproc SEP \
+.p2align    2 SEP \
+ CNAME(name)##: SEP \
+    auipc t3, %pcrel_hi(CNAMEADDR(name)) SEP \
+    ld t3, %pcrel_lo(CNAME(name))(t3) SEP \
+    jr t3 SEP \
+.cfi_endproc SEP \
+
+JL_RUNTIME_EXPORTED_FUNCS(XX)
+JL_CODEGEN_EXPORTED_FUNCS(XX)
+#undef XX

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -202,12 +202,15 @@ if Artifacts !== nothing
     using Artifacts, Base.BinaryPlatforms, Libdl
     artifacts_toml = abspath(joinpath(Sys.STDLIB, "Artifacts", "test", "Artifacts.toml"))
     artifact_hash("HelloWorldC", artifacts_toml)
-    oldpwd = pwd(); cd(dirname(artifacts_toml))
-    macroexpand(Main, :(@artifact_str("HelloWorldC")))
-    cd(oldpwd)
     artifacts = Artifacts.load_artifacts_toml(artifacts_toml)
     platforms = [Artifacts.unpack_platform(e, "HelloWorldC", artifacts_toml) for e in artifacts["HelloWorldC"]]
     best_platform = select_platform(Dict(p => triplet(p) for p in platforms))
+    if best_platform !== nothing
+      # @artifact errors for unsupported platforms
+      oldpwd = pwd(); cd(dirname(artifacts_toml))
+      macroexpand(Main, :(@artifact_str("HelloWorldC")))
+      cd(oldpwd)
+    end
     dlopen("libjulia$(Base.isdebugbuild() ? "-debug" : "")", RTLD_LAZY | RTLD_DEEPBIND)
     """
 end

--- a/contrib/normalize_triplet.py
+++ b/contrib/normalize_triplet.py
@@ -14,6 +14,7 @@ arch_mapping = {
     'i686': "i\\d86",
     'aarch64': "(arm|aarch)64",
     'armv7l': "arm(v7l)?",
+    'riscv64': "(rv64|riscv64)",
     'powerpc64le': "p(ower)?pc64le",
 }
 platform_mapping = {

--- a/doc/src/devdocs/build/build.md
+++ b/doc/src/devdocs/build/build.md
@@ -148,6 +148,7 @@ Notes for various operating systems:
 Notes for various architectures:
 
 * [ARM](https://github.com/JuliaLang/julia/blob/master/doc/src/devdocs/build/arm.md)
+* [RISC-V](https://github.com/JuliaLang/julia/blob/master/doc/src/devdocs/build/riscv.md)
 
 ## Required Build Tools and External Libraries
 

--- a/doc/src/devdocs/build/riscv.md
+++ b/doc/src/devdocs/build/riscv.md
@@ -1,0 +1,103 @@
+# RISC-V (Linux)
+
+Julia has experimental support for 64-bit RISC-V (RV64) processors running
+Linux. This file provides general guidelines for compilation, in addition to
+instructions for specific devices.
+
+A list of [known issues](https://github.com/JuliaLang/julia/labels/system:riscv)
+for RISC-V is available. If you encounter difficulties, please create an issue
+including the output from `cat /proc/cpuinfo`.
+
+
+## Compiling Julia
+
+For now, Julia will need to be compiled entirely from source, i.e., including
+all of its dependencies. This can be accomplished with the following
+`Make.user`:
+
+```make
+USE_BINARYBUILDER := 0
+```
+
+Additionally, it is required to indicate what architecture, and optionally which
+CPU to build for. This can be done by setting the `MARCH` and `MCPU` variables
+in `Make.user`
+
+The `MARCH` variable needs to be set to a RISC-V ISA string, which can be found by
+looking at the documentation of your device, or by inspecting `/proc/cpuinfo`. Only
+use flags that your compiler supports, e.g., run `gcc -march=help` to see a list of
+supported flags. A common value is `rv64gc`, which is a good starting point.
+
+The `MCPU` variable is optional, and can be used to further optimize the
+generated code for a specific CPU. If you are unsure, it is recommended to leave
+it unset. You can find a list of supported values by running `gcc --target-help`.
+
+For example, if you are using a StarFive VisionFive2, which contains a JH7110
+processor based on the SiFive U74, you can set these flags as follows:
+
+```make
+MARCH := rv64gc_zba_zbb
+MCPU := sifive-u74
+```
+
+If you prefer a portable build, you could use:
+
+```make
+MARCH := rv64gc
+
+# also set JULIA_CPU_TARGET to the expanded form of rv64gc
+# (it normally copies the value of MCPU, which we don't set)
+JULIA_CPU_TARGET := generic-rv64,i,m,a,f,d,zicsr,zifencei,c
+```
+
+### Cross-compilation
+
+A native build on a RISC-V device may take a very long time, so it's also
+possible to cross-compile Julia on a faster machine.
+
+First, get a hold of a RISC-V cross-compilation toolchain that provides
+support for C, C++ and Fortran. This can be done by checking-out the
+[riscv-gnu-toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain)
+repository and building it as follows:
+
+```sh
+sudo mkdir /opt/riscv && sudo chown $USER /opt/riscv
+./configure --prefix=/opt/riscv --with-languages=c,c++,fortran
+make linux -j$(nproc)
+```
+
+Then, install the QEMU user-mode emulator for RISC-V, along with `binfmt`
+support to enable execution of RISC-V binaries on the host machine. The
+exact steps depend on your distribution, e.g., on Arch Linux it involves
+installing the `qemu-user-static` and `qemu-user-static-binfmt` packages.
+Note that to actually execute RISC-V binaries, QEMU will need to be able to
+find the RISC-V system root, which can be achieved by setting the
+`QEMU_LD_PREFIX` environment variable to the path of the root filesystem.
+
+Finally, compile Julia with the following `Make.user` variables (in addition to
+the ones from the previous section):
+
+```make
+XC_HOST=riscv64-unknown-linux-gnu
+OS=Linux
+export QEMU_LD_PREFIX=/opt/riscv/sysroot
+```
+
+Note that you will have to execute `make` with `PATH` set to include the
+cross-compilation toolchain, e.g., by running:
+
+```sh
+PATH=/opt/riscv/bin:$PATH make -j$(nproc)
+```
+
+Because of the RISC-V sysroot we use being very barren, you may need to
+add additional libraries that the Julia build system currently expects
+to be available system-wide. For example, the build currently relies on
+a system-provided `libz`, so you may need to copy this library from the
+Julia build into the system root:
+
+```sh
+make -C deps install-zlib
+cp -v usr/lib/libz.*   /opt/riscv/sysroot/usr/lib
+cp -v usr/include/z*.h /opt/riscv/sysroot/usr/include
+```

--- a/src/abi_riscv.cpp
+++ b/src/abi_riscv.cpp
@@ -1,0 +1,315 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+//===----------------------------------------------------------------------===//
+//
+// The ABI implementation used for RISC-V targets.
+//
+//===----------------------------------------------------------------------===//
+//
+// The Procedure Call Standard can be found here:
+// https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-cc.adoc
+//
+// This code is based on:
+// - The Rust implementation:
+//    https://github.com/rust-lang/rust/blob/master/compiler/rustc_target/src/abi/call/riscv.rs
+// - The LLVM RISC-V backend:
+//   https://github.com/llvm/llvm-project/blob/78533528cf5ed04ac78722afff7c9f2f91aa8359/llvm/lib/Target/RISCV/RISCVISelLowering.cpp#L10865
+//
+//===----------------------------------------------------------------------===//
+
+
+struct ABI_RiscvLayout : AbiLayout {
+
+static const size_t XLen = 8;
+static const size_t FLen = 8;
+static const int NumArgGPRs = 8;
+static const int NumArgFPRs = 8;
+
+// available register num is needed to determine if fp pair or int-fp pair in a struct should be unpacked
+// WARN: with this, use_sret must only be called once before the next
+// needPassByRef call, otherwise avail_gprs is wrong
+int avail_gprs, avail_fprs;
+
+// preferred type is determined in the same time of use_sret & needPassByRef
+// cache it here to avoid computing it again in preferred_llvm_type
+Type *cached_llvmtype = NULL;
+
+ABI_RiscvLayout() : avail_gprs(NumArgGPRs), avail_fprs(NumArgFPRs) {}
+
+enum RegPassKind { UNKNOWN = 0, INTEGER = 1, FLOAT = 2 };
+
+struct ElementType {
+    RegPassKind type;
+    jl_datatype_t *dt;
+    ElementType() : type(RegPassKind::UNKNOWN), dt(NULL) {};
+};
+
+bool is_floattype(jl_datatype_t *dt) const
+{
+    return dt == jl_float16_type || dt == jl_float32_type || dt == jl_float64_type;
+}
+
+Type *get_llvm_fptype(jl_datatype_t *dt, LLVMContext &ctx) const
+{
+    assert(is_floattype(dt));
+    switch (jl_datatype_size(dt)) {
+    case 2: return Type::getHalfTy(ctx);
+    case 4: return Type::getFloatTy(ctx);
+    case 8: return Type::getDoubleTy(ctx);
+    case 16: return Type::getFP128Ty(ctx);
+    default: assert(0 && "abi_riscv: unsupported floating point type"); return NULL;
+    }
+}
+
+// for primitive types that can be passed as integer
+// includes integer, bittypes, pointer
+Type *get_llvm_inttype(jl_datatype_t *dt, LLVMContext &ctx) const
+{
+    assert(jl_is_primitivetype(dt));
+    // XXX: without Zfh, Float16 is passed in integer registers
+    if (dt == jl_float16_type)
+        return Type::getInt32Ty(ctx);
+    assert(!is_floattype(dt));
+    if (dt == jl_bool_type)
+        return getInt8Ty(ctx);
+    if (dt == jl_int32_type)
+        return getInt32Ty(ctx);
+    if (dt == jl_int64_type)
+        return getInt64Ty(ctx);
+    int nb = jl_datatype_size(dt);
+    return Type::getIntNTy(ctx, nb * 8);
+}
+
+bool should_use_fp_conv(jl_datatype_t *dt, ElementType &ele1, ElementType &ele2) const
+{
+    if (jl_is_primitivetype(dt)) {
+        size_t dsz = jl_datatype_size(dt);
+        if (dsz > FLen) {
+            return false;
+        }
+        if (is_floattype(dt)) {
+            if (ele1.type == RegPassKind::UNKNOWN) {
+                ele1.type = RegPassKind::FLOAT;
+                ele1.dt = dt;
+            }
+            else if (ele2.type == RegPassKind::UNKNOWN) {
+                ele2.type = RegPassKind::FLOAT;
+                ele2.dt = dt;
+            }
+            else {
+                // 3 elements not eligible, must be a pair
+                return false;
+            }
+        }
+        // integer or pointer type or bitstypes
+        else {
+            if (ele1.type == RegPassKind::UNKNOWN) {
+                ele1.type = RegPassKind::INTEGER;
+                ele1.dt = dt;
+            }
+            else if (ele1.type == RegPassKind::INTEGER) {
+                // two integers not eligible
+                return false;
+            }
+            // ele1.type == RegPassKind::FLOAT
+            else {
+                if (ele2.type == RegPassKind::UNKNOWN) {
+                    ele2.type = RegPassKind::INTEGER;
+                    ele2.dt = dt;
+                }
+                else {
+                    // 3 elements not eligible, must be a pair
+                    return false;
+                }
+            }
+        }
+    }
+    else { // aggregates
+        while (size_t nfields = jl_datatype_nfields(dt)) {
+            size_t i;
+            size_t fieldsz;
+            for (i = 0; i < nfields; i++) {
+                if ((fieldsz = jl_field_size(dt, i))) {
+                    break;
+                }
+            }
+            assert(i < nfields);
+            // If there's only one non zero sized member, try again on this member
+            if (fieldsz == jl_datatype_size(dt)) {
+                dt = (jl_datatype_t *)jl_field_type(dt, i);
+                if (!jl_is_datatype(dt)) // could be inline union #46787
+                    return false;
+                continue;
+            }
+            for (; i < nfields; i++) {
+                size_t fieldsz = jl_field_size(dt, i);
+                if (fieldsz == 0)
+                    continue;
+                jl_datatype_t *fieldtype = (jl_datatype_t *)jl_field_type(dt, i);
+                if (!jl_is_datatype(dt)) // could be inline union
+                    return false;
+                // This needs to be done after the zero size member check
+                if (ele2.type != RegPassKind::UNKNOWN) {
+                    // we already have a pair and can't accept more elements
+                    return false;
+                }
+                if (!should_use_fp_conv(fieldtype, ele1, ele2)) {
+                    return false;
+                }
+            }
+            break;
+        }
+    }
+    // Tuple{Int,} can reach here as well, but doesn't really hurt
+    return true;
+}
+
+Type *get_llvm_inttype_byxlen(size_t xlen, LLVMContext &ctx) const
+{
+    if (xlen == 8) {
+        return getInt64Ty(ctx);
+    }
+    else if (xlen == 4) {
+        return getInt32Ty(ctx);
+    }
+    else {
+        assert(0 && "abi_riscv: unsupported xlen");
+        return NULL;
+    }
+}
+
+Type *classify_arg(jl_datatype_t *ty, int &avail_gprs, int &avail_fprs, bool &onstack,
+                   LLVMContext &ctx) const
+{
+    onstack = false;
+    if (ty == jl_nothing_type) {
+        return NULL;
+    }
+    ElementType ele1, ele2;
+    if (should_use_fp_conv(ty, ele1, ele2)) {
+        if (ele1.type == RegPassKind::FLOAT) {
+            if (ele2.type == RegPassKind::FLOAT) {
+                if (avail_fprs >= 2) {
+                    avail_fprs -= 2;
+                    SmallVector<Type *, 2> eles;
+                    eles.push_back(get_llvm_fptype(ele1.dt, ctx));
+                    eles.push_back(get_llvm_fptype(ele2.dt, ctx));
+                    return StructType::get(ctx, eles);
+                }
+            }
+            else if (ele2.type == RegPassKind::INTEGER) {
+                if (avail_fprs >= 1 && avail_gprs >= 1) {
+                    avail_fprs -= 1;
+                    avail_gprs -= 1;
+                    SmallVector<Type *, 2> eles;
+                    eles.push_back(get_llvm_fptype(ele1.dt, ctx));
+                    eles.push_back(get_llvm_inttype(ele2.dt, ctx));
+                    return StructType::get(ctx, eles);
+                }
+            }
+            else {
+                // A struct containing just one floating-point real is passed
+                // as though it were a standalone floating-point real.
+                if (avail_fprs >= 1) {
+                    avail_fprs -= 1;
+                    return get_llvm_fptype(ele1.dt, ctx);
+                }
+            }
+        }
+        else if (ele1.type == RegPassKind::INTEGER) {
+            if (ele2.type == RegPassKind::FLOAT) {
+                if (avail_fprs >= 1 && avail_gprs >= 1) {
+                    avail_fprs -= 1;
+                    avail_gprs -= 1;
+                    return StructType::get(get_llvm_inttype(ele1.dt, ctx),
+                                           get_llvm_fptype(ele2.dt, ctx));
+                }
+            }
+        }
+    }
+    size_t dsz = jl_datatype_size(ty);
+    if (dsz > 2 * XLen) {
+        if (!jl_is_primitivetype(ty)) {
+            onstack = true;
+        }
+        // else let llvm backend handle scalars
+        if (avail_gprs >= 1) {
+            avail_gprs -= 1;
+        }
+        return NULL;
+    }
+
+    if (dsz > XLen) {
+        size_t alignment = jl_datatype_align(ty);
+        bool align_regs = alignment > XLen;
+        if (avail_gprs >= 2) {
+            avail_gprs -= 2;
+        }
+        // should we handle variadic as well?
+        // Variadic arguments with 2×XLEN-bit alignment and size at most 2×XLEN
+        // bits are passed in an aligned register pair
+        else {
+            avail_gprs = 0;
+        }
+
+        if (!jl_is_primitivetype(ty)) {
+            // Aggregates or scalars passed on the stack are aligned to the
+            // greater of the type alignment and XLen bits, but never more than
+            // the stack alignment.
+            if (align_regs) {
+                if (alignment == 16) {
+                    return Type::getInt128Ty(ctx);
+                }
+                else {
+                    return Type::getInt64Ty(ctx);
+                }
+            }
+            else {
+                return ArrayType::get(get_llvm_inttype_byxlen(XLen, ctx), 2);
+            }
+        }
+        // let llvm backend handle scalars
+        return NULL;
+    }
+
+    //else dsz <= XLen
+    if (avail_gprs >= 1) {
+        avail_gprs -= 1;
+    }
+    if (!jl_is_primitivetype(ty)) {
+        return get_llvm_inttype_byxlen(XLen, ctx);
+    }
+    return get_llvm_inttype(ty, ctx);
+}
+
+bool use_sret(jl_datatype_t *ty, LLVMContext &ctx) override
+{
+    bool onstack = false;
+    int gprs = 2;
+    int fprs = FLen ? 2 : 0;
+    this->cached_llvmtype = classify_arg(ty, gprs, fprs, onstack, ctx);
+    if (onstack) {
+        this->avail_gprs -= 1;
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+bool needPassByRef(jl_datatype_t *ty, AttrBuilder &ab, LLVMContext &ctx,
+                   Type *Ty) override
+{
+    bool onstack = false;
+    this->cached_llvmtype =
+        classify_arg(ty, this->avail_gprs, this->avail_fprs, onstack, ctx);
+    return onstack;
+}
+
+Type *preferred_llvm_type(jl_datatype_t *ty, bool isret,
+                          LLVMContext &ctx) const override
+{
+    return this->cached_llvmtype;
+}
+
+};

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -1664,7 +1664,8 @@ void jl_dump_native_impl(void *native_code,
     }
 
     CodeModel::Model CMModel = CodeModel::Small;
-    if (TheTriple.isPPC() || (TheTriple.isX86() && TheTriple.isArch64Bit() && TheTriple.isOSLinux())) {
+    if (TheTriple.isPPC() || TheTriple.isRISCV() ||
+        (TheTriple.isX86() && TheTriple.isArch64Bit() && TheTriple.isOSLinux())) {
         // On PPC the small model is limited to 16bit offsets. For very large images the small code model
         CMModel = CodeModel::Medium; //  isn't good enough on x86 so use Medium, it has no cost because only the image goes in .ldata
     }

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -367,6 +367,7 @@ static bool is_native_simd_type(jl_datatype_t *dt) {
 
 #include "abi_arm.cpp"
 #include "abi_aarch64.cpp"
+#include "abi_riscv.cpp"
 #include "abi_ppc64le.cpp"
 #include "abi_win32.cpp"
 #include "abi_win64.cpp"
@@ -391,6 +392,8 @@ static bool is_native_simd_type(jl_datatype_t *dt) {
   typedef ABI_ARMLayout DefaultAbiState;
 #elif defined _CPU_AARCH64_
   typedef ABI_AArch64Layout DefaultAbiState;
+#elif defined _CPU_RISCV64_
+  typedef ABI_RiscvLayout DefaultAbiState;
 #elif defined _CPU_PPC64_
   typedef ABI_PPC64leLayout DefaultAbiState;
 #else

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5368,7 +5368,7 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_clos
     }
     CallInst *call = ctx.builder.CreateCall(cft, TheCallee, argvals);
     call->setAttributes(returninfo.attrs);
-    if (gcstack_arg)
+    if (gcstack_arg && ctx.emission_context.use_swiftcc)
         call->setCallingConv(CallingConv::Swift);
 
     jl_cgval_t retval;
@@ -8186,7 +8186,8 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, Value 
 
     if (gcstack_arg){
         AttrBuilder param(ctx.builder.getContext());
-        param.addAttribute(Attribute::SwiftSelf);
+        if (ctx.emission_context.use_swiftcc)
+            param.addAttribute(Attribute::SwiftSelf);
         param.addAttribute(Attribute::NonNull);
         attrs.push_back(AttributeSet::get(ctx.builder.getContext(), param));
         fsig.push_back(PointerType::get(JuliaType::get_ppjlvalue_ty(ctx.builder.getContext()), 0));
@@ -8278,7 +8279,7 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, Value 
             fval = emit_inttoptr(ctx, fval, ftype->getPointerTo());
     }
     if (auto F = dyn_cast<Function>(fval)) {
-        if (gcstack_arg)
+        if (gcstack_arg && ctx.emission_context.use_swiftcc)
             F->setCallingConv(CallingConv::Swift);
         assert(F->arg_size() >= argnames.size());
         for (size_t i = 0; i < argnames.size(); i++) {

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -1058,6 +1058,8 @@ static void jl_dump_asm_internal(
                 if (insSize == 0) // skip illegible bytes
 #if defined(_CPU_PPC_) || defined(_CPU_PPC64_) || defined(_CPU_ARM_) || defined(_CPU_AARCH64_)
                     insSize = 4; // instructions are always 4 bytes
+#elif defined(_CPU_RISCV64_)
+                    insSize = 2; // instructions can be 2 bytes when compressed
 #else
                     insSize = 1; // attempt to slide 1 byte forward
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -105,8 +105,8 @@ JL_DLLIMPORT void __tsan_switch_to_fiber(void *fiber, unsigned flags);
 #ifndef _OS_WINDOWS_
     #if defined(_CPU_ARM_) || defined(_CPU_PPC_) || defined(_CPU_WASM_)
         #define MAX_ALIGN 8
-    #elif defined(_CPU_AARCH64_) || (JL_LLVM_VERSION >= 180000 && (defined(_CPU_X86_64_) || defined(_CPU_X86_)))
-    // int128 is 16 bytes aligned on aarch64 and on x86 with LLVM >= 18
+    #elif defined(_CPU_AARCH64_) || defined(_CPU_RISCV64_) || (JL_LLVM_VERSION >= 180000 && (defined(_CPU_X86_64_) || defined(_CPU_X86_)))
+    // int128 is 16 bytes aligned on aarch64 and riscv, and on x86 with LLVM >= 18
         #define MAX_ALIGN 16
     #elif defined(_P64)
     // Generically we assume MAX_ALIGN is sizeof(void*)
@@ -259,6 +259,11 @@ static inline uint64_t cycleclock(void) JL_NOTSAFEPOINT
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return (int64_t)(tv.tv_sec) * 1000000 + tv.tv_usec;
+#elif defined(_CPU_RISCV64_)
+    // taken from https://github.com/google/benchmark/blob/3b3de69400164013199ea448f051d94d7fc7d81f/src/cycleclock.h#L190
+    uint64_t ret;
+    __asm__ volatile("rdcycle %0" : "=r"(ret));
+    return ret;
 #elif defined(_CPU_PPC64_)
     // This returns a time-base, which is not always precisely a cycle-count.
     // https://reviews.llvm.org/D78084

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -56,7 +56,7 @@ typedef struct {
     !defined(JL_HAVE_ASM) && \
     !defined(JL_HAVE_UNW_CONTEXT)
 #if (defined(_CPU_X86_64_) || defined(_CPU_X86_) || defined(_CPU_AARCH64_) ||  \
-     defined(_CPU_ARM_) || defined(_CPU_PPC64_))
+     defined(_CPU_ARM_) || defined(_CPU_PPC64_) || defined(_CPU_RISCV64_))
 #define JL_HAVE_ASM
 #endif
 #if 0

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -117,6 +117,8 @@ Instruction *LowerPTLS::emit_pgcstack_tp(Value *offset, Instruction *insertBefor
             asm_str = "mrs $0, tpidr_el0";
         } else if (TargetTriple.isARM()) {
             asm_str = "mrc p15, 0, $0, c13, c0, 3";
+        } else if (TargetTriple.isRISCV()) {
+            asm_str = "mv $0, tp";
         } else if (TargetTriple.getArch() == Triple::x86_64) {
             asm_str = "movq %fs:0, $0";
         } else if (TargetTriple.getArch() == Triple::x86) {

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -18,6 +18,10 @@
     #define JL_LLVM_OPAQUE_POINTERS 1
 #endif
 
+#if JL_LLVM_VERSION < 19000 && defined(_CPU_RISCV64_)
+    #error Only LLVM versions >= 19.0.0 are supported by Julia on RISC-V
+#endif
+
 #ifdef __cplusplus
 #if defined(__GNUC__) && (__GNUC__ >= 9)
 // Added in GCC 9, this warning is annoying

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -256,7 +256,7 @@ JL_DLLEXPORT float julia_half_to_float(uint16_t param) {
 #if ((defined(__GNUC__) && __GNUC__ > 11) || \
      (defined(__clang__) && __clang_major__ > 14)) && \
     !defined(_CPU_PPC64_) && !defined(_CPU_PPC_) && \
-    !defined(_OS_WINDOWS_)
+    !defined(_OS_WINDOWS_) && !defined(_CPU_RISCV64_)
     #define FLOAT16_TYPE _Float16
     #define FLOAT16_TO_UINT16(x) (*(uint16_t*)&(x))
     #define FLOAT16_FROM_UINT16(x) (*(_Float16*)&(x))
@@ -355,7 +355,7 @@ float julia_bfloat_to_float(uint16_t param) {
 #if ((defined(__GNUC__) && __GNUC__ > 12) || \
      (defined(__clang__) && __clang_major__ > 16)) && \
     !defined(_CPU_PPC64_) && !defined(_CPU_PPC_) && \
-    !defined(_OS_WINDOWS_)
+    !defined(_OS_WINDOWS_) && !defined(_CPU_RISCV64_)
     #define BFLOAT16_TYPE __bf16
     #define BFLOAT16_TO_UINT16(x) (*(uint16_t*)&(x))
     #define BFLOAT16_FROM_UINT16(x) (*(__bf16*)&(x))

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -80,6 +80,9 @@ static inline uintptr_t jl_get_rsp_from_ctx(const void *_ctx)
 #elif defined(_OS_LINUX_) && defined(_CPU_ARM_)
     const ucontext_t *ctx = (const ucontext_t*)_ctx;
     return ctx->uc_mcontext.arm_sp;
+#elif defined(_OS_LINUX_) && (defined(_CPU_RISCV64_))
+    const ucontext_t *ctx = (const ucontext_t*)_ctx;
+    return ctx->uc_mcontext.__gregs[REG_SP];
 #elif defined(_OS_FREEBSD_) && defined(_CPU_X86_64_)
     const ucontext_t *ctx = (const ucontext_t*)_ctx;
     return ctx->uc_mcontext.mc_rsp;
@@ -175,6 +178,11 @@ JL_NO_ASAN static void jl_call_in_ctx(jl_ptls_t ptls, void (*fptr)(void), int si
     ctx->uc_mcontext.arm_sp = rsp;
     ctx->uc_mcontext.arm_lr = 0; // Clear link register
     ctx->uc_mcontext.arm_pc = target;
+#elif defined(_OS_LINUX_) && (defined(_CPU_RISCV64_))
+    ucontext_t *ctx = (ucontext_t*)_ctx;
+    ctx->uc_mcontext.__gregs[REG_SP] = rsp;
+    ctx->uc_mcontext.__gregs[REG_RA] = 0; // Clear return address address (ra)
+    ctx->uc_mcontext.__gregs[REG_PC] = (uintptr_t)fptr;
 #else
 #pragma message("julia: throw-in-context not supported on this platform")
     // TODO Add support for PowerPC(64)?

--- a/src/support/platform.h
+++ b/src/support/platform.h
@@ -27,6 +27,7 @@
  *          _CPU_X86_64_
  *          _CPU_AARCH64_
  *          _CPU_ARM_
+ *          _CPU_RISCV64_
  *          _CPU_WASM_
  */
 
@@ -106,6 +107,8 @@
 #define _CPU_AARCH64_
 #elif defined(__arm__) || defined(_M_ARM)
 #define _CPU_ARM_
+#elif defined(__riscv) && __riscv_xlen == 64
+#define _CPU_RISCV64_
 #elif defined(__PPC64__)
 #define _CPU_PPC64_
 #elif defined(_ARCH_PPC)

--- a/src/task.c
+++ b/src/task.c
@@ -1491,6 +1491,14 @@ CFI_NORETURN
                     // because all our addresses are word-aligned.
         " udf #0" // abort
         : : "r" (stk), "r"(fn) : "memory" );
+#elif defined(_CPU_RISCV64_)
+    asm volatile(
+        " mv sp, %0;\n"
+        " mv ra, zero;\n" // Clear return address register
+        " mv fp, zero;\n" // Clear frame pointer
+        " jr %1;\n" // call `fn` with fake stack frame
+        " ebreak" // abort
+        : : "r"(stk), "r"(fn) : "memory" );
 #elif defined(_CPU_PPC64_)
     // N.B.: There is two iterations of the PPC64 ABI.
     // v2 is current and used here. Make sure you have the

--- a/src/threading.c
+++ b/src/threading.c
@@ -18,7 +18,7 @@
 // For variant 1 JL_ELF_TLS_INIT_SIZE is the size of the thread control block (TCB)
 // For variant 2 JL_ELF_TLS_INIT_SIZE is 0
 #if defined(_OS_LINUX_) || defined(_OS_FREEBSD_)
-#  if defined(_CPU_X86_64_) || defined(_CPU_X86_)
+#  if defined(_CPU_X86_64_) || defined(_CPU_X86_) || defined(_CPU_RISCV64_)
 #    define JL_ELF_TLS_VARIANT 2
 #    define JL_ELF_TLS_INIT_SIZE 0
 #  elif defined(_CPU_AARCH64_)
@@ -638,6 +638,8 @@ static void jl_check_tls(void)
     asm("mrs %0, tpidr_el0" : "=r"(tp));
 #elif defined(__ARM_ARCH) && __ARM_ARCH >= 7
     asm("mrc p15, 0, %0, c13, c0, 3" : "=r"(tp));
+#elif defined(_CPU_RISCV64_)
+    asm("mv %0, tp" : "=r"(tp));
 #else
 #  error "Cannot emit thread pointer for this architecture."
 #endif


### PR DESCRIPTION
Rebase and extension of @alexfanqi's initial work on porting Julia to RISC-V. Requires LLVM 19.

Tested on a VisionFive2, built with:

```make
MARCH := rv64gc_zba_zbb
MCPU := sifive-u74

USE_BINARYBUILDER:=0

DEPS_GIT = llvm
override LLVM_VER=19.1.1
override LLVM_BRANCH=julia-release/19.x
override LLVM_SHA1=julia-release/19.x
```

In case anybody wants to test this out, I'll be uploading builds here: https://github.com/maleadt/julia/releases

```julia-repl
❯ ./julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.12.0-DEV.1374 (2024-10-14)
 _/ |\__'_|_|_|\__'_|  |  riscv/25092a3982* (fork: 1 commits, 0 days)
|__/                   |

julia> versioninfo(; verbose=true)
Julia Version 1.12.0-DEV.1374
Commit 25092a3982* (2024-10-14 09:57 UTC)
Platform Info:
  OS: Linux (riscv64-unknown-linux-gnu)
  uname: Linux 6.11.3-1-riscv64 #1 SMP Debian 6.11.3-1 (2024-10-10) riscv64 unknown
  CPU: unknown:
              speed         user         nice          sys         idle          irq
       #1  1500 MHz        922 s          0 s        265 s     160953 s          0 s
       #2  1500 MHz        457 s          0 s        280 s     161521 s          0 s
       #3  1500 MHz        452 s          0 s        270 s     160911 s          0 s
       #4  1500 MHz        638 s         15 s        301 s     161340 s          0 s
  Memory: 7.760246276855469 GB (7474.08203125 MB free)
  Uptime: 16260.13 sec
  Load Avg:  0.25  0.23  0.1
  WORD_SIZE: 64
  LLVM: libLLVM-19.1.1 (ORCJIT, sifive-u74)
Threads: 1 default, 0 interactive, 1 GC (on 4 virtual cores)
Environment:
  HOME = /home/tim
  PATH = /home/tim/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/games
  TERM = xterm-256color


julia> ccall(:jl_dump_host_cpu, Nothing, ())
CPU: sifive-u74
Features: +zbb,+d,+i,+f,+c,+a,+zba,+m,-zvbc,-zksed,-zvfhmin,-zbkc,-zkne,-zksh,-zfh,-zfhmin,-zknh,-v,-zihintpause,-zicboz,-zbs,-zvknha,-zvksed,-zfa,-ztso,-zbc,-zvknhb,-zihintntl,-zknd,-zvbb,-zbkx,-zkt,-zvkt,-zicond,-zvksh,-zvfh,-zvkg,-zvkb,-zbkb,-zvkned


julia> @code_native debuginfo=:none 1+2.
	.text
	.attribute	4, 16
	.attribute	5, "rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zifencei2p0_zmmul1p0_zba1p0_zbb1p0"
	.file	"+"
	.globl	"julia_+_3003"
	.p2align	1
	.type	"julia_+_3003",@function
"julia_+_3003":
	addi	sp, sp, -16
	sd	ra, 8(sp)
	sd	s0, 0(sp)
	addi	s0, sp, 16
	fcvt.d.l	fa5, a0
	ld	ra, 8(sp)
	ld	s0, 0(sp)
	fadd.d	fa0, fa5, fa0
	addi	sp, sp, 16
	ret
.Lfunc_end0:
	.size	"julia_+_3003", .Lfunc_end0-"julia_+_3003"

	.type	".L+Core.Float64#3005",@object
	.section	.data.rel.ro,"aw",@progbits
	.p2align	3, 0x0
".L+Core.Float64#3005":
	.quad	".L+Core.Float64#3005.jit"
	.size	".L+Core.Float64#3005", 8

.set ".L+Core.Float64#3005.jit", 272467692544
	.size	".L+Core.Float64#3005.jit", 8
	.section	".note.GNU-stack","",@progbits
```

Lots of bugs guaranteed, but with this we at least have a functional build and REPL for further development by whoever is interested 🙂 

Probably also requires Linux 6.4+, since the fallback processor detection used here relies on LLVM's `sys::getHostCPUFeatures`, which for RISC-V is implemented using hwprobe introduced in 6.4. We could probably add a fallback that parses `/proc/cpuinfo`, either by building a CPU database much like how we've done for AArch64, or by parsing the actual ISA string contained there. That would probably also be a good place to add support for profiles, which are supposedly the way forward to package RISC-V binaries. That can happen in follow-up PRs though.