### PR TITLE
OpenBLAS: Use dynamic architecture support on AArch64.

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1002,16 +1002,14 @@ endif
 # If we are running on ARM, set certain options automatically
 ifneq (,$(findstring arm,$(ARCH)))
 JCFLAGS += -fsigned-char
-USE_BLAS64:=0
 OPENBLAS_DYNAMIC_ARCH:=0
 OPENBLAS_TARGET_ARCH:=ARMV7
+BINARY:=32
 endif
 
 # If we are running on aarch64 (e.g. ARMv8 or ARM64), set certain options automatically
 ifneq (,$(findstring aarch64,$(ARCH)))
-OPENBLAS_DYNAMIC_ARCH:=0
 OPENBLAS_TARGET_ARCH:=ARMV8
-USE_BLAS64:=1
 BINARY:=64
 endif
 

--- a/deps/openblas.mk
+++ b/deps/openblas.mk
@@ -31,6 +31,7 @@ endif
 endif
 
 # 64-bit BLAS interface
+$(error USE_BLAS64: $(USE_BLAS64))
 ifeq ($(USE_BLAS64), 1)
 OPENBLAS_BUILD_OPTS += INTERFACE64=1 SYMBOLSUFFIX="$(OPENBLAS_SYMBOLSUFFIX)" LIBPREFIX="libopenblas$(OPENBLAS_LIBNAMESUFFIX)"
 ifeq ($(OS), Darwin)


### PR DESCRIPTION
We already do so on Yggdrasil, so this just makes both source and binary builds behave similarly.

Closes https://github.com/JuliaLang/julia/issues/56075