### PR TITLE
Correction of lcm() for Array arguments

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -155,8 +155,8 @@ lcm(a::Real, b::Real, c::Real...) = lcm(a, lcm(b, c...))
 gcd(a::T, b::T) where T<:Real = throw(MethodError(gcd, (a,b)))
 lcm(a::T, b::T) where T<:Real = throw(MethodError(lcm, (a,b)))
 
-gcd(abc::AbstractArray{<:Real}) = reduce(gcd, abc; init=abc[1])
-lcm(abc::AbstractArray{<:Real}) = reduce(lcm, abc; init=abc[1])
+gcd(abc::AbstractArray{<:Real}) = reduce(gcd, abc)
+lcm(abc::AbstractArray{<:Real}) = reduce(lcm, abc)
 
 function gcd(abc::AbstractArray{<:Integer})
     a = zero(eltype(abc))

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -36,6 +36,9 @@ julia> gcd(1//3, 2)
 
 julia> gcd(0, 0, 10, 15)
 5
+
+julia> gcd([1//3; 2//3])
+1//3
 ```
 """
 function gcd(a::T, b::T) where T<:Integer
@@ -125,6 +128,9 @@ julia> lcm(1//3, 2)
 
 julia> lcm(1, 3, 5, 7)
 105
+
+julia> lcm([1//3; 2//3])
+2//3
 ```
 """
 function lcm(a::T, b::T) where T<:Integer
@@ -149,8 +155,8 @@ lcm(a::Real, b::Real, c::Real...) = lcm(a, lcm(b, c...))
 gcd(a::T, b::T) where T<:Real = throw(MethodError(gcd, (a,b)))
 lcm(a::T, b::T) where T<:Real = throw(MethodError(lcm, (a,b)))
 
-gcd(abc::AbstractArray{<:Real}) = reduce(gcd, abc; init=zero(eltype(abc)))
-lcm(abc::AbstractArray{<:Real}) = reduce(lcm, abc; init=one(eltype(abc)))
+gcd(abc::AbstractArray{<:Real}) = reduce(gcd, abc; init=abc[1])
+lcm(abc::AbstractArray{<:Real}) = reduce(lcm, abc; init=abc[1])
 
 function gcd(abc::AbstractArray{<:Integer})
     a = zero(eltype(abc))


### PR DESCRIPTION
This is a draft (1st PR attempt!) to try to correct the wrong implementation of the `lcm()` function with Array argument, cf. bug #55379.

The `init` argument in the `reduce()` function was incorrect. It is sufficient to ~~initialize with any value in the Array~~ remove the `init` argument.
I have also added examples in the doc string, but I don't know if I did it the right way (Array argument may need a separate entry). Also, I don't know yet how to write a test.

Fixes #55379
Fixes #56166