### PR TITLE
libgit2: Always use the bundled PCRE library.

### DIFF
--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -42,6 +42,10 @@ ifneq (,$(findstring $(OS),Linux FreeBSD OpenBSD))
 LIBGIT2_OPTS += -DUSE_HTTPS="mbedTLS" -DUSE_SHA1="CollisionDetection" -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
 endif
 
+# use the bundled distribution of libpcre. we should consider linking against the
+# pcre2 library we're building anyway, but this is currently how Yggdrasil does it.
+LIBGIT2_OPTS += -DREGEX_BACKEND="builtin"
+
 LIBGIT2_SRC_PATH := $(SRCCACHE)/$(LIBGIT2_SRC_DIR)
 
 $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: $(LIBGIT2_SRC_PATH)/source-extracted


### PR DESCRIPTION
This is how Yggdrasil builds the library. Well, not explicitly, but there's no other PCRE in the Yggdrasil sysroot for libgit2 to discover, so it ends up using the bundled one.

We could instead use the copy of PCRE2 that we build anyway, but that isn't simply a matter of setting `REGEX_BACKEND` to `pcre2`, it also requires setting `-L` and `-I` to point into the build directory with something a la:

```make
CFLAGS += -I$(build_includedir)
LDFLAGS += -L$(build_libdir)
```

I'm not sure how kosher that is? So let's just do the quick fix for now.