### PR TITLE
widen `join(::Any...)` return type to `AbstractString`

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -370,7 +370,7 @@ function _join_preserve_annotations(iterator, args...)
         # a plain `String` from `io`.
         if isconcretetype(et) || !isempty(io.annotations)
             seekstart(io)
-            read(io, AnnotatedString{String})
+            Core.compilerbarrier(:type, read(io, AnnotatedString{String}))::AbstractString
         else
             String(take!(io.io))
         end


### PR DESCRIPTION
@JeffBezanson and @vtjnash have mentioned that we might want to generalize `join / *` to be more like our binary operators over numbers. In particular, that would mean dynamically choosing a result AbstractString that can "faithfully" encode the concatenation of all provided sub-strings.

That means significantly weakening the result type for `join(...)` from `::Union{String,AnnotatedString}` to `::AbstractString`. This PR takes that inference hit early, without changing how `join` actually works.

This also happens to resolve some of the invalidation problems with StyledStrings.

We'll need more fixes though, because https://github.com/JuliaLang/julia/pull/56005/ unfortunately means that StyledStrings invalidates _itself_ (and its dependencies) when `require_stdlib` gets involved