### PR TITLE
Read views of destination in adjoint * adjoint

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -955,7 +955,7 @@ Base.@constprop :aggressive generic_matmatmul!(C::AbstractVecOrMat, tA, tB, A::A
         ta = t(_add.alpha)
         for i in AxM
             mul!(tmp, pB, view(pA, :, i))
-            C[ci,:] .+= t.(ta .* tmp)
+            @views C[ci,:] .+= t.(ta .* tmp)
             ci += 1
         end
     else

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -825,7 +825,7 @@ end
 # NOTE: the generic version is also called as fallback for
 #       strides != 1 cases
 
-generic_matvecmul!(C::AbstractVector, tA, A::AbstractVecOrMat, B::AbstractVector, alpha::Number, beta::Number) =
+Base.@constprop :aggressive generic_matvecmul!(C::AbstractVector, tA, A::AbstractVecOrMat, B::AbstractVector, alpha::Number, beta::Number) =
     @stable_muladdmul generic_matvecmul!(C, tA, A, B, MulAddMul(alpha, beta))
 @inline function generic_matvecmul!(C::AbstractVector, tA, A::AbstractVecOrMat, B::AbstractVector,
                                     _add::MulAddMul = MulAddMul())


### PR DESCRIPTION
Also, add an aggressive constprop annotation to `generic_matvecmul!`.

Together, these improve performance:
```julia
julia> A = rand(Int,100,100);

julia> @btime $A' * $A';
  290.203 μs (405 allocations: 175.98 KiB) # v"1.12.0-DEV.1364"
  270.008 μs (5 allocations: 79.11 KiB) # This PR
```