### PR TITLE
Allow freezing of `Core.MethodTables`

### DIFF
--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1195,9 +1195,22 @@ end
     freeze!(mt::Core.MethodTable)
 
 Disallow adding or modifying methods of `mt`.
+
+See also [`unfreeze!(mt)`](@ref unfreeze!).
 """
 function freeze!(mt::Core.MethodTable)
-    ccall(:jl_method_table_seal, Cvoid, (Any,), mt)
+    ccall(:jl_method_table_set_frozen, Cvoid, (Any,Cint), mt, 1)
+end
+
+"""
+    unfreeze!(mt::Core.MethodTable)
+
+Allow adding or modifying methods of `mt`.
+
+See also [`freeze!(mt)`](@ref freeze!).
+"""
+function unfreeze!(mt::Core.MethodTable)
+    ccall(:jl_method_table_set_frozen, Cvoid, (Any,Cint), mt, 0)
 end
 
 function get_methodtable(m::Method)

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -976,7 +976,7 @@ function morespecific!(m::Method)
     # check that all Methods in this table are morespecific than m
     # so we might avoid disabling a table that might get used for more than just subsets of m
     all(m2 -> m === m2 || morespecific(m2, m), MethodList(mt)) || error("unsupported Method to disable")
-    setfield!(mt, nfields(mt), 0x1)
+    setfield!(mt, :frozen, 0x1, :monotonic)
 end
 
 """

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1189,7 +1189,11 @@ Disallow adding or modifying methods of `mt`.
 
 See also [`unfreeze!(mt)`](@ref unfreeze!).
 """
-function freeze!(mt::Core.MethodTable)
+function morespecific!(m::Method)
+    mt = get_methodtable(m)
+    # check that all Methods in this table are morespecific than m
+    # so we might avoid disabling a table that might get used for more than just subsets of m
+    all(m2 -> m === m2 || morespecific(m2, m), MethodList(mt)) || error("unsupported Method to disable")
     setfield!(mt, nfields(mt), 0x1)
 end
 

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1199,7 +1199,6 @@ Disallow adding or modifyng methods of `mt`.
 function seal_methodtable(m::Core.MethodTable)
     ccall(:jl_method_table_seal, Cvoid, (Any,), m)
 end
-seal_methodtable(m::Nothing) = nothing
 
 function get_methodtable(m::Method)
     mt = ccall(:jl_method_get_table, Any, (Any,), m)

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1190,7 +1190,7 @@ Disallow adding or modifying methods of `mt`.
 See also [`unfreeze!(mt)`](@ref unfreeze!).
 """
 function freeze!(mt::Core.MethodTable)
-    ccall(:jl_method_table_set_frozen, Cvoid, (Any, Cint), mt, 1)
+    setfield!(mt, nfields(mt), 0x1)
 end
 
 function get_methodtable(m::Method)

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1192,12 +1192,12 @@ function delete_method(m::Method)
 end
 
 """
-    seal_methodtable(m::Core.MethodTable)
+    freeze!(mt::Core.MethodTable)
 
 Disallow adding or modifying methods of `mt`.
 """
-function seal_methodtable(m::Core.MethodTable)
-    ccall(:jl_method_table_seal, Cvoid, (Any,), m)
+function freeze!(mt::Core.MethodTable)
+    ccall(:jl_method_table_seal, Cvoid, (Any,), mt)
 end
 
 function get_methodtable(m::Method)

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1183,15 +1183,6 @@ function signature_type(@nospecialize(f), @nospecialize(argtypes))
 end
 
 """
-    delete_method(m::Method)
-
-Make method `m` uncallable and force recompilation of any methods that use(d) it.
-"""
-function delete_method(m::Method)
-    ccall(:jl_method_table_disable, Cvoid, (Any, Any), get_methodtable(m), m)
-end
-
-"""
     freeze!(mt::Core.MethodTable)
 
 Disallow adding or modifying methods of `mt`.
@@ -1200,17 +1191,6 @@ See also [`unfreeze!(mt)`](@ref unfreeze!).
 """
 function freeze!(mt::Core.MethodTable)
     ccall(:jl_method_table_set_frozen, Cvoid, (Any, Cint), mt, 1)
-end
-
-"""
-    unfreeze!(mt::Core.MethodTable)
-
-Allow adding or modifying methods of `mt`.
-
-See also [`freeze!(mt)`](@ref freeze!).
-"""
-function unfreeze!(mt::Core.MethodTable)
-    ccall(:jl_method_table_set_frozen, Cvoid, (Any, Cint), mt, 0)
 end
 
 function get_methodtable(m::Method)

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1182,6 +1182,25 @@ function signature_type(@nospecialize(f), @nospecialize(argtypes))
     return rewrap_unionall(Tuple{ft, u.parameters...}, argtypes)
 end
 
+"""
+    delete_method(m::Method)
+
+Make method `m` uncallable and force recompilation of any methods that use(d) it.
+"""
+function delete_method(m::Method)
+    ccall(:jl_method_table_disable, Cvoid, (Any, Any), get_methodtable(m), m)
+end
+
+"""
+    seal_methodtable(m::Core.MethodTable)
+
+Disallow adding or modifyng methods of `mt`.
+"""
+function seal_methodtable(m::Core.MethodTable)
+    ccall(:jl_method_table_seal, Cvoid, (Any,), m)
+end
+seal_methodtable(m::Nothing) = nothing
+
 function get_methodtable(m::Method)
     mt = ccall(:jl_method_get_table, Any, (Any,), m)
     if mt === nothing

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1194,7 +1194,7 @@ end
 """
     seal_methodtable(m::Core.MethodTable)
 
-Disallow adding or modifyng methods of `mt`.
+Disallow adding or modifying methods of `mt`.
 """
 function seal_methodtable(m::Core.MethodTable)
     ccall(:jl_method_table_seal, Cvoid, (Any,), m)

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1199,7 +1199,7 @@ Disallow adding or modifying methods of `mt`.
 See also [`unfreeze!(mt)`](@ref unfreeze!).
 """
 function freeze!(mt::Core.MethodTable)
-    ccall(:jl_method_table_set_frozen, Cvoid, (Any,Cint), mt, 1)
+    ccall(:jl_method_table_set_frozen, Cvoid, (Any, Cint), mt, 1)
 end
 
 """
@@ -1210,7 +1210,7 @@ Allow adding or modifying methods of `mt`.
 See also [`freeze!(mt)`](@ref freeze!).
 """
 function unfreeze!(mt::Core.MethodTable)
-    ccall(:jl_method_table_set_frozen, Cvoid, (Any,Cint), mt, 0)
+    ccall(:jl_method_table_set_frozen, Cvoid, (Any, Cint), mt, 0)
 end
 
 function get_methodtable(m::Method)

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -54,7 +54,7 @@ JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *mo
     mt->backedges = NULL;
     JL_MUTEX_INIT(&mt->writelock, "methodtable->writelock");
     mt->offs = 0;
-    mt->frozen = 0;
+    jl_atomic_store_relaxed(&mt->frozen, 0);
     return mt;
 }
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -331,7 +331,7 @@ jl_datatype_t *jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_a
             (jl_value_t*)mi, 1, ~(size_t)0);
     jl_typemap_insert(&mt->cache, (jl_value_t*)mt, newentry, 0);
 
-    mt->frozen = 1;
+    jl_atomic_store_relaxed(&mt->frozen, 1);
     JL_GC_POP();
     return dt;
 }
@@ -772,7 +772,7 @@ static int reset_mt_caches(jl_methtable_t *mt, void *env)
 {
     // removes all method caches
     // this might not be entirely safe (GC or MT), thus we only do it very early in bootstrapping
-    if (!mt->frozen) { // make sure not to reset frozen functions
+    if (!jl_atomic_load_relaxed(&mt->frozen)) { // make sure not to reset frozen functions
         jl_atomic_store_release(&mt->leafcache, (jl_genericmemory_t*)jl_an_empty_memory_any);
         jl_atomic_store_release(&mt->cache, jl_nothing);
     }

--- a/src/gf.c
+++ b/src/gf.c
@@ -2030,13 +2030,7 @@ JL_DLLEXPORT void jl_method_table_disable(jl_methtable_t *mt, jl_method_t *metho
 
 JL_DLLEXPORT void jl_method_table_set_frozen(jl_methtable_t *mt, int val)
 {
-    JL_LOCK(&world_counter_lock);
-    JL_LOCK(&mt->writelock);
-    size_t world = jl_atomic_load_relaxed(&jl_world_counter);
     mt->frozen = val;
-    jl_atomic_store_release(&jl_world_counter, world + 1);
-    JL_UNLOCK(&mt->writelock);
-    JL_UNLOCK(&world_counter_lock);
 }
 
 static int jl_type_intersection2(jl_value_t *t1, jl_value_t *t2, jl_value_t **isect JL_REQUIRE_ROOTED_SLOT, jl_value_t **isect2 JL_REQUIRE_ROOTED_SLOT)

--- a/src/gf.c
+++ b/src/gf.c
@@ -2028,12 +2028,12 @@ JL_DLLEXPORT void jl_method_table_disable(jl_methtable_t *mt, jl_method_t *metho
     JL_UNLOCK(&world_counter_lock);
 }
 
-JL_DLLEXPORT void jl_method_table_seal(jl_methtable_t *mt)
+JL_DLLEXPORT void jl_method_table_set_frozen(jl_methtable_t *mt, int val)
 {
     JL_LOCK(&world_counter_lock);
     JL_LOCK(&mt->writelock);
     size_t world = jl_atomic_load_relaxed(&jl_world_counter);
-    mt->frozen = 1;
+    mt->frozen = val;
     jl_atomic_store_release(&jl_world_counter, world + 1);
     JL_UNLOCK(&mt->writelock);
     JL_UNLOCK(&world_counter_lock);

--- a/src/gf.c
+++ b/src/gf.c
@@ -2028,11 +2028,6 @@ JL_DLLEXPORT void jl_method_table_disable(jl_methtable_t *mt, jl_method_t *metho
     JL_UNLOCK(&world_counter_lock);
 }
 
-JL_DLLEXPORT void jl_method_table_set_frozen(jl_methtable_t *mt, int val)
-{
-    mt->frozen = val;
-}
-
 static int jl_type_intersection2(jl_value_t *t1, jl_value_t *t2, jl_value_t **isect JL_REQUIRE_ROOTED_SLOT, jl_value_t **isect2 JL_REQUIRE_ROOTED_SLOT)
 {
     *isect2 = NULL;

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -305,7 +305,7 @@
     XX(jl_method_instance_add_backedge) \
     XX(jl_method_table_add_backedge) \
     XX(jl_method_table_disable) \
-    XX(jl_method_table_seal) \
+    XX(jl_method_table_set_frozen) \
     XX(jl_method_table_for) \
     XX(jl_method_table_insert) \
     XX(jl_methtable_lookup) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -305,7 +305,6 @@
     XX(jl_method_instance_add_backedge) \
     XX(jl_method_table_add_backedge) \
     XX(jl_method_table_disable) \
-    XX(jl_method_table_set_frozen) \
     XX(jl_method_table_for) \
     XX(jl_method_table_insert) \
     XX(jl_methtable_lookup) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -305,6 +305,7 @@
     XX(jl_method_instance_add_backedge) \
     XX(jl_method_table_add_backedge) \
     XX(jl_method_table_disable) \
+    XX(jl_method_table_seal) \
     XX(jl_method_table_for) \
     XX(jl_method_table_insert) \
     XX(jl_methtable_lookup) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3038,9 +3038,9 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_methtable_type->name->names = jl_perm_symsvec(11, "name", "defs",
                                                      "leafcache", "cache", "max_args",
                                                      "module", "backedges",
-                                                     "", "", "offs", "");
+                                                     "", "", "offs", "frozen");
     const static uint32_t methtable_constfields[1] = { 0x00000020 }; // (1<<5);
-    const static uint32_t methtable_atomicfields[1] = { 0x0000001e }; // (1<<1)|(1<<2)|(1<<3)|(1<<4);
+    const static uint32_t methtable_atomicfields[1] = { 0x00000041e }; // (1<<1)|(1<<2)|(1<<3)|(1<<4)|(1<<10);
     jl_methtable_type->name->constfields = methtable_constfields;
     jl_methtable_type->name->atomicfields = methtable_atomicfields;
     jl_precompute_memoized_dt(jl_methtable_type, 1);

--- a/src/julia.h
+++ b/src/julia.h
@@ -791,7 +791,7 @@ typedef struct _jl_methtable_t {
     jl_array_t *backedges; // (sig, caller::MethodInstance) pairs
     jl_mutex_t writelock;
     uint8_t offs;  // 0, or 1 to skip splitting typemap on first (function) argument
-    uint8_t frozen; // whether this accepts adding new methods
+    _Atomic(uint8_t) frozen; // whether this accepts adding new methods
 } jl_methtable_t;
 
 typedef struct {

--- a/src/method.c
+++ b/src/method.c
@@ -1227,7 +1227,7 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
     if ((jl_value_t*)mt == jl_nothing)
         jl_error("Method dispatch is unimplemented currently for this method signature");
     if (mt->frozen)
-        jl_error("cannot add methods to or modify methods of a sealed function");
+        jl_error("cannot add methods to or modify methods of a frozen function");
 
     assert(jl_is_linenode(functionloc));
     jl_sym_t *file = (jl_sym_t*)jl_linenode_file(functionloc);

--- a/src/method.c
+++ b/src/method.c
@@ -1236,6 +1236,7 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
     int32_t line = jl_linenode_line(functionloc);
 
     // TODO: derive our debug name from the syntax instead of the type
+    assert(mt != NULL);
     jl_methtable_t *kwmt = mt == jl_kwcall_mt ? jl_kwmethod_table_for(argtype) : mt;
     // if we have a kwcall, try to derive the name from the callee argument method table
     name = (kwmt ? kwmt : mt)->name;

--- a/src/method.c
+++ b/src/method.c
@@ -1226,7 +1226,7 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
         mt = jl_method_table_for(argtype);
     if ((jl_value_t*)mt == jl_nothing)
         jl_error("Method dispatch is unimplemented currently for this method signature");
-    if (mt->frozen)
+    if (jl_atomic_load_acquire(&mt->frozen))
         jl_error("cannot add methods to or modify methods of a frozen function");
 
     assert(jl_is_linenode(functionloc));

--- a/src/method.c
+++ b/src/method.c
@@ -1227,7 +1227,7 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
     if ((jl_value_t*)mt == jl_nothing)
         jl_error("Method dispatch is unimplemented currently for this method signature");
     if (mt->frozen)
-        jl_error("cannot add methods to a builtin function");
+        jl_error("cannot add methods to or modify methods of a sealed function");
 
     assert(jl_is_linenode(functionloc));
     jl_sym_t *file = (jl_sym_t*)jl_linenode_file(functionloc);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -975,7 +975,7 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
             }
             else if (jl_typetagis(v, jl_typename_type)) {
                 jl_typename_t *tn = (jl_typename_t*)v;
-                if (tn->mt != NULL && !tn->mt->frozen) {
+                if (tn->mt != NULL && !jl_atomic_load_relaxed(&tn->mt->frozen)) {
                     jl_methtable_t * new_methtable = (jl_methtable_t *)ptrhash_get(&new_methtables, tn->mt);
                     if (new_methtable != HT_NOTFOUND)
                         record_field_change((jl_value_t **)&tn->mt, (jl_value_t*)new_methtable);

--- a/test/core.jl
+++ b/test/core.jl
@@ -35,7 +35,7 @@ for (T, c) in (
         (Core.CodeInstance, [:next, :min_world, :max_world, :inferred, :debuginfo, :ipo_purity_bits, :invoke, :specptr, :specsigflags, :precompile]),
         (Core.Method, [:primary_world, :deleted_world]),
         (Core.MethodInstance, [:cache, :flags]),
-        (Core.MethodTable, [:defs, :leafcache, :cache, :max_args]),
+        (Core.MethodTable, [:defs, :leafcache, :cache, :max_args, :frozen]),
         (Core.TypeMapEntry, [:next, :min_world, :max_world]),
         (Core.TypeMapLevel, [:arg1, :targ, :name1, :tname, :list, :any]),
         (Core.TypeName, [:cache, :linearcache]),

--- a/test/core.jl
+++ b/test/core.jl
@@ -2650,7 +2650,7 @@ for f in (:Any, :Function, :(Core.Builtin), :(Union{Nothing, Type}), :(Union{typ
     @test_throws ErrorException("Method dispatch is unimplemented currently for this method signature") @eval (::$f)() = 1
 end
 for f in (:(Core.getfield), :((::typeof(Core.getfield))), :((::Core.IntrinsicFunction)))
-    @test_throws ErrorException("cannot add methods to a builtin function") @eval $f() = 1
+    @test_throws ErrorException("cannot add methods to or modify methods of a frozen function") @eval $f() = 1
 end
 
 # issue #33370

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1301,8 +1301,12 @@ end
 
 # sealing
 f_sealed(x::Int64) = x+1
-Base.seal_methodtable(Base.methods(f_sealed).mt)
+Base.freeze!(Base.methods(f_sealed).mt)
 @test_throws(
     ErrorException("cannot add methods to or modify methods of a frozen function"),
     @eval f_sealed(x::Float64) = x+2
 )
+Base.unfreeze!(Base.methods(f_sealed).mt)
+f_sealed(x::Float64) = x + 2
+@test f_sealed(1) == 2
+@test f_sealed(1.0) == 2.0

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1303,6 +1303,6 @@ end
 f_sealed(x::Int64) = x+1
 Base.seal_methodtable(Base.methods(f_sealed).mt)
 @test_throws(
-    ErrorException("cannot add methods to or modify methods of a sealed function"),
+    ErrorException("cannot add methods to or modify methods of a frozen function"),
     @eval f_sealed(x::Float64) = x+2
 )

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1299,14 +1299,14 @@ end
 
 @test methods(Union{}) == Any[m.method for m in Base._methods_by_ftype(Tuple{Core.TypeofBottom, Vararg}, 1, Base.get_world_counter())] # issue #55187
 
-# sealing
-f_sealed(x::Int64) = x+1
-Base.freeze!(Base.methods(f_sealed).mt)
+# freezing Core.MethodTable
+f_frozen(x::Int) = x+1
+Base.freeze!(Base.methods(f_frozen).mt)
 @test_throws(
     ErrorException("cannot add methods to or modify methods of a frozen function"),
-    @eval f_sealed(x::Float64) = x+2
+    @eval f_frozen(x::Float64) = x+2
 )
-Base.unfreeze!(Base.methods(f_sealed).mt)
-f_sealed(x::Float64) = x + 2
-@test f_sealed(1) == 2
-@test f_sealed(1.0) == 2.0
+Base.unfreeze!(Base.methods(f_frozen).mt)
+f_frozen(x::Float64) = x+2
+@test f_frozen(1) == 2
+@test f_frozen(1.0) == 3.0

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1306,7 +1306,3 @@ Base.freeze!(Base.methods(f_frozen).mt)
     ErrorException("cannot add methods to or modify methods of a frozen function"),
     @eval f_frozen(x::Float64) = x+2
 )
-Base.unfreeze!(Base.methods(f_frozen).mt)
-f_frozen(x::Float64) = x+2
-@test f_frozen(1) == 2
-@test f_frozen(1.0) == 3.0

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1299,10 +1299,10 @@ end
 
 @test methods(Union{}) == Any[m.method for m in Base._methods_by_ftype(Tuple{Core.TypeofBottom, Vararg}, 1, Base.get_world_counter())] # issue #55187
 
-# freezing Core.MethodTable
-f_frozen(x::Int) = x+1
-Base.freeze!(Base.methods(f_frozen).mt)
+# disallow adding new methods
+f_sealed(x::Int) = x+1
+Base.morespecific!(which(f_frozen, (Int,)))
 @test_throws(
     ErrorException("cannot add methods to or modify methods of a frozen function"),
-    @eval f_frozen(x::Float64) = x+2
+    @eval f_sealed(x::Float64) = x+2
 )

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1298,3 +1298,11 @@ end
 @test Base.infer_return_type(code_lowered, (Any,Any)) == Vector{Core.CodeInfo}
 
 @test methods(Union{}) == Any[m.method for m in Base._methods_by_ftype(Tuple{Core.TypeofBottom, Vararg}, 1, Base.get_world_counter())] # issue #55187
+
+# sealing
+f_sealed(x::Int64) = x+1
+Base.seal_methodtable(Base.methods(f_sealed).mt)
+@test_throws(
+    ErrorException("cannot add methods to or modify methods of a sealed function"),
+    @eval f_sealed(x::Float64) = x+2
+)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1301,7 +1301,12 @@ end
 
 # disallow adding new methods
 f_sealed(x::Int) = x+1
-Base.morespecific!(which(f_frozen, (Int,)))
+f_sealed(x::Integer) = x+2
+@test_throws(
+    ErrorException("unsupported Method to disable"),
+    Base.morespecific!(which(f_sealed, (Int,)))
+)
+Base.morespecific!(which(f_sealed, (Integer,)))
 @test_throws(
     ErrorException("cannot add methods to or modify methods of a frozen function"),
     @eval f_sealed(x::Float64) = x+2


### PR DESCRIPTION
Implements the idea from https://github.com/JuliaLang/julia/issues/54138#issuecomment-2067174572.

A follow-up PR would apply it to some relevant functions in Base.