### PR TITLE
Reduce duplication in triangular indexing methods

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -208,45 +208,33 @@ function full!(A::UnitUpperTriangular)
     B
 end
 
-Base.isassigned(A::UnitLowerTriangular, i::Int, j::Int) =
-    i > j ? isassigned(A.data, i, j) : true
-Base.isassigned(A::LowerTriangular, i::Int, j::Int) =
-    i >= j ? isassigned(A.data, i, j) : true
-Base.isassigned(A::UnitUpperTriangular, i::Int, j::Int) =
-    i < j ? isassigned(A.data, i, j) : true
-Base.isassigned(A::UpperTriangular, i::Int, j::Int) =
-    i <= j ? isassigned(A.data, i, j) : true
+_isforwardedindex(U::UpperTriangular, row::Integer, col::Integer) = row <= col
+_isforwardedindex(U::LowerTriangular, row::Integer, col::Integer) = row >= col
+_isforwardedindex(U::UnitUpperTriangular, row::Integer, col::Integer) = row < col
+_isforwardedindex(U::UnitLowerTriangular, row::Integer, col::Integer) = row > col
 
-Base.isstored(A::UnitLowerTriangular, i::Int, j::Int) =
-    i > j ? Base.isstored(A.data, i, j) : false
-Base.isstored(A::LowerTriangular, i::Int, j::Int) =
-    i >= j ? Base.isstored(A.data, i, j) : false
-Base.isstored(A::UnitUpperTriangular, i::Int, j::Int) =
-    i < j ? Base.isstored(A.data, i, j) : false
-Base.isstored(A::UpperTriangular, i::Int, j::Int) =
-    i <= j ? Base.isstored(A.data, i, j) : false
+Base.isassigned(A::UpperOrLowerTriangular, i::Int, j::Int) =
+    _isforwardedindex(A, i, j) ? isassigned(A.data, i, j) : true
 
-@propagate_inbounds getindex(A::UnitLowerTriangular{T}, i::Int, j::Int) where {T} =
-    i > j ? A.data[i,j] : ifelse(i == j, oneunit(T), zero(T))
-@propagate_inbounds getindex(A::LowerTriangular, i::Int, j::Int) =
-    i >= j ? A.data[i,j] : _zero(A.data,j,i)
-@propagate_inbounds getindex(A::UnitUpperTriangular{T}, i::Int, j::Int) where {T} =
-    i < j ? A.data[i,j] : ifelse(i == j, oneunit(T), zero(T))
-@propagate_inbounds getindex(A::UpperTriangular, i::Int, j::Int) =
-    i <= j ? A.data[i,j] : _zero(A.data,j,i)
+Base.isstored(A::UpperOrLowerTriangular, i::Int, j::Int) =
+    _isforwardedindex(A, i, j) ? Base.isstored(A.data, i, j) : false
+
+@propagate_inbounds getindex(A::Union{UnitLowerTriangular{T}, UnitUpperTriangular{T}}, i::Int, j::Int) where {T} =
+    _isforwardedindex(A, i, j) ? A.data[i,j] : ifelse(i == j, oneunit(T), zero(T))
+@propagate_inbounds getindex(A::Union{LowerTriangular, UpperTriangular}, i::Int, j::Int) =
+    _isforwardedindex(A, i, j) ? A.data[i,j] : _zero(A.data,j,i)
+
+_isforwardedindex(U::UpperTriangular, b::BandIndex) = b.band >= 0
+_isforwardedindex(U::LowerTriangular, b::BandIndex) = b.band <= 0
+_isforwardedindex(U::UnitUpperTriangular, b::BandIndex) = b.band > 0
+_isforwardedindex(U::UnitLowerTriangular, b::BandIndex) = b.band < 0
 
 # these specialized getindex methods enable constant-propagation of the band
-Base.@constprop :aggressive @propagate_inbounds function getindex(A::UnitLowerTriangular{T}, b::BandIndex) where {T}
-    b.band < 0 ? A.data[b] : ifelse(b.band == 0, oneunit(T), zero(T))
+Base.@constprop :aggressive @propagate_inbounds function getindex(A::Union{UnitLowerTriangular{T}, UnitUpperTriangular{T}}, b::BandIndex) where {T}
+    _isforwardedindex(A, b) ? A.data[b] : ifelse(b.band == 0, oneunit(T), zero(T))
 end
-Base.@constprop :aggressive @propagate_inbounds function getindex(A::LowerTriangular, b::BandIndex)
-    b.band <= 0 ? A.data[b] : _zero(A.data, b)
-end
-Base.@constprop :aggressive @propagate_inbounds function getindex(A::UnitUpperTriangular{T}, b::BandIndex) where {T}
-    b.band > 0 ? A.data[b] : ifelse(b.band == 0, oneunit(T), zero(T))
-end
-Base.@constprop :aggressive @propagate_inbounds function getindex(A::UpperTriangular, b::BandIndex)
-    b.band >= 0 ? A.data[b] : _zero(A.data, b)
+Base.@constprop :aggressive @propagate_inbounds function getindex(A::Union{LowerTriangular, UpperTriangular}, b::BandIndex)
+    _isforwardedindex(A, b) ? A.data[b] : _zero(A.data, b)
 end
 
 _zero_triangular_half_str(::Type{<:UpperOrUnitUpperTriangular}) = "lower"


### PR DESCRIPTION
This uses an orthogonal design to reduce code duplication in the indexing methods for triangular matrices.