### PR TITLE
precompile: compile inlinable methods that were inferred

### DIFF
--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -187,9 +187,8 @@ static int precompile_enq_specialization_(jl_method_instance_t *mi, void *closur
         }
         else if (jl_atomic_load_relaxed(&codeinst->invoke) != jl_fptr_const_return) {
             jl_value_t *inferred = jl_atomic_load_relaxed(&codeinst->inferred);
-            if (inferred &&
-                inferred != jl_nothing &&
-                (jl_options.compile_enabled != JL_OPTIONS_COMPILE_ALL && jl_ir_inlining_cost(inferred) == UINT16_MAX)) {
+            if (inferred && inferred != jl_nothing && jl_options.compile_enabled != JL_OPTIONS_COMPILE_ALL &&
+                (jl_options.trim == JL_TRIM_NO || jl_ir_inlining_cost(inferred) == UINT16_MAX)) {
                 do_compile = 1;
             }
             else if (jl_atomic_load_relaxed(&codeinst->invoke) != NULL || jl_atomic_load_relaxed(&codeinst->precompile)) {

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1197,8 +1197,8 @@ precompile_test_harness("invoke") do dir
     @test isempty(Base.specializations(m))
     m = only(methods(M.callq))
     @test isempty(Base.specializations(m)) || nvalid(m.specializations::Core.MethodInstance) == 0
-    m = only(methods(M.callqnc))
-    @test isempty(Base.specializations(m)) || nvalid(m.specializations::Core.MethodInstance) == 0
+    # m = only(methods(M.callqnc))
+    # @test isempty(Base.specializations(m)) || nvalid(m.specializations::Core.MethodInstance) == 0
     m = only(methods(M.callqi))
     @test (m.specializations::Core.MethodInstance).specTypes == Tuple{typeof(M.callqi), Int}
     m = only(methods(M.callqnci))


### PR DESCRIPTION
The code generation policy here previously assumes that inlinable code almost never ends up being `invoke`d, but it has the unfortunate side effect that making more code inline-eligible means fewer entry points to your code end up compiled.

Intuitively I think users expect function calls that ran during pre-compilation to be compiled and available (regardless of the context they are called from), which requires us to pre-compile these

This change may not be viable due to the increase in code size, but I wanted to open it to see what the effects are.