### PR TITLE
Remove zero arg methods of `+` and `*` from linalg tests

### DIFF
--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -1139,8 +1139,8 @@ end
     Base.zero(::Thing)       = Thing(0.)
     Base.one(::Type{Thing})  = Thing(1.)
     Base.one(::Thing)        = Thing(1.)
-    Base.:+(t::Thing...)     = +(getfield.(t, :data)...)
-    Base.:*(t::Thing...)     = *(getfield.(t, :data)...)
+    Base.:+(t1::Thing, t::Thing...) = +(getfield.((t1, t...), :data)...)
+    Base.:*(t1::Thing, t::Thing...) = *(getfield.((t1, t...), :data)...)
 
     M = Float64[1 2; 3 4]
     A = Thing.(M)


### PR DESCRIPTION
There are tests elsewhere that i) make sure there is no zero-arg methods of these functions and ii) tests that e.g. `+()` throws a `MethodError`. Without this patch there are test errors whenever the same test process runs both of these tests.

Fix #56190, fix #56136.