### PR TITLE
Break dependency between loading and Core.Compiler

### DIFF
--- a/base/compiler/cicache.jl
+++ b/base/compiler/cicache.jl
@@ -13,11 +13,9 @@ end
 
 function setindex!(cache::InternalCodeCache, ci::CodeInstance, mi::MethodInstance)
     @assert ci.owner === cache.owner
-    if cache.owner === nothing
-        m = mi.def
-        if isa(m, Method) && m.module != Core
-            ccall(:jl_push_newly_inferred, Cvoid, (Any,), ci)
-        end
+    m = mi.def
+    if isa(m, Method) && m.module != Core
+        ccall(:jl_push_newly_inferred, Cvoid, (Any,), ci)
     end
     ccall(:jl_mi_cache_insert, Cvoid, (Any, Any), mi, ci)
     return cache

--- a/base/compiler/cicache.jl
+++ b/base/compiler/cicache.jl
@@ -13,6 +13,12 @@ end
 
 function setindex!(cache::InternalCodeCache, ci::CodeInstance, mi::MethodInstance)
     @assert ci.owner === cache.owner
+    if cache.owner === nothing
+        m = mi.def
+        if isa(m, Method) && m.module != Core
+            ccall(:jl_push_newly_inferred, Cvoid, (Any,), ci)
+        end
+    end
     ccall(:jl_mi_cache_insert, Cvoid, (Any, Any), mi, ci)
     return cache
 end

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -1,9 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-# Tracking of newly-inferred CodeInstances during precompilation
-const track_newly_inferred = RefValue{Bool}(false)
-const newly_inferred = CodeInstance[]
-
 """
 The module `Core.Compiler.Timings` provides a simple implementation of nested timers that
 can be used to measure the exclusive time spent inferring each method instance that is
@@ -264,12 +260,6 @@ function cache_result!(interp::AbstractInterpreter, result::InferenceResult)
 
     if cache_results
         code_cache(interp)[mi] = result.ci
-        if track_newly_inferred[]
-            m = mi.def
-            if isa(m, Method) && m.module != Core
-                ccall(:jl_push_newly_inferred, Cvoid, (Any,), result.ci)
-            end
-        end
     end
     return cache_results
 end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2863,6 +2863,9 @@ function load_path_setup_code(load_path::Bool=true)
     return code
 end
 
+# Const global for GC root
+const newly_inferred = CodeInstance[]
+
 # this is called in the external process that generates precompiled package files
 function include_package_for_output(pkg::PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String},
                                     concrete_deps::typeof(_concrete_dependencies), source::Union{Nothing,String})
@@ -2882,8 +2885,7 @@ function include_package_for_output(pkg::PkgId, input::String, depot_path::Vecto
         task_local_storage()[:SOURCE_PATH] = source
     end
 
-    ccall(:jl_set_newly_inferred, Cvoid, (Any,), Core.Compiler.newly_inferred)
-    Core.Compiler.track_newly_inferred.x = true
+    ccall(:jl_set_newly_inferred, Cvoid, (Any,), newly_inferred)
     try
         Base.include(Base.__toplevel__, input)
     catch ex
@@ -2891,10 +2893,15 @@ function include_package_for_output(pkg::PkgId, input::String, depot_path::Vecto
         @debug "Aborting `create_expr_cache'" exception=(ErrorException("Declaration of __precompile__(false) not allowed"), catch_backtrace())
         exit(125) # we define status = 125 means PrecompileableError
     finally
-        Core.Compiler.track_newly_inferred.x = false
+        ccall(:jl_set_newly_inferred, Cvoid, (Any,), nothing)
     end
     # check that the package defined the expected module so we can give a nice error message if not
     Base.check_package_module_loaded(pkg)
+
+    # Re-populate the runtime's newly-inferred array, which will be included
+    # in the output. We removed it above to avoid including any code we may
+    # have compiled for error handling and validation.
+    ccall(:jl_set_newly_inferred, Cvoid, (Any,), newly_inferred)
 end
 
 function check_package_module_loaded(pkg::PkgId)

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -91,12 +91,16 @@ extern jl_mutex_t world_counter_lock;
 // This gets called as the first step of Base.include_package_for_output
 JL_DLLEXPORT void jl_set_newly_inferred(jl_value_t* _newly_inferred)
 {
-    assert(_newly_inferred == NULL || jl_is_array(_newly_inferred));
+    assert(_newly_inferred == NULL || _newly_inferred == jl_nothing || jl_is_array(_newly_inferred));
+    if (_newly_inferred == jl_nothing)
+        _newly_inferred = NULL;
     newly_inferred = (jl_array_t*) _newly_inferred;
 }
 
 JL_DLLEXPORT void jl_push_newly_inferred(jl_value_t* ci)
 {
+    if (!newly_inferred)
+        return;
     JL_LOCK(&newly_inferred_mutex);
     size_t end = jl_array_nrows(newly_inferred);
     jl_array_grow_end(newly_inferred, 1);


### PR DESCRIPTION
This code was originally added in df81bf9a96c59f257a01307cd0ecf05035d8301f where Core.Compiler would keep an array of all the things it inferred, which could then be provieded to the runtime to be included in the package image. In 113efb6e0aa27879cb423ab323c0159911e4c5e7 keeping the array itself became a runtime service for locking considerations. As a result, the role of Core.Compiler here is a bit weird. It has the enable switch and the GC root, but all the actual state is being managed by the runtime.

It would be desirable to remove the Core.Compiler reference, so that loading.jl can function even if `Core.Compiler` does not exist (which is in theory supposed to be possible, even though we currently never run in such a configuration; that said, post trimming one might imagine useful instances of such a setup).

To do this, put the runtime fully in charge of managing this array. Core.Compiler will call the callback unconditionally for all newly inferred cis and the runtime can decide whether to save it or not.

Extracted from #56128