### PR TITLE
Support vectorization of the gc.loaded intrinsics

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1541,7 +1541,7 @@ static const auto gc_loaded_v2_func = new JuliaFunction<>{
 
 static const auto gc_loaded_v4_func = new JuliaFunction<>{
     "julia.gc_loaded.v4",
-    [](LLVMContext &C) { return gc_loaded_vN_ft(C, 2); },
+    [](LLVMContext &C) { return gc_loaded_vN_ft(C, 4); },
     gc_loaded_v2_func->_attrs,
 };
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -564,6 +564,11 @@ public:
         : name(StringRef(cname, N-1)), _type(_type), _attrs(_attrs) {}
     JuliaFunction(StringRef cname, TypeFn_t _type, llvm::AttributeList (*_attrs)(llvm::LLVMContext &C))
         : name(cname), _type(_type), _attrs(_attrs) {}
+    template <size_t N>
+    JuliaFunction(const char (&cname)[N], TypeFn_t _type, llvm::AttributeList (*_attrs)(llvm::LLVMContext &C), std::initializer_list<JuliaFunction*> _variants)
+        : name(StringRef(cname, N-1)), _type(_type), _attrs(_attrs), variants(_variants) {}
+    JuliaFunction(StringRef cname, TypeFn_t _type, llvm::AttributeList (*_attrs)(llvm::LLVMContext &C), std::initializer_list<JuliaFunction*> _variants)
+        : name(cname), _type(_type), _attrs(_attrs), variants(_variants) {}
     JuliaFunction(char *cname, TypeFn_t _type, llvm::AttributeList (*_attrs)(llvm::LLVMContext &C)) = delete;
 
     llvm::StringRef name;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -44,6 +44,7 @@
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/MDBuilder.h>
 #include <llvm/Analysis/InstructionSimplify.h>
+#include <llvm/Transforms/Utils/ModuleUtils.h>
 
 // support
 #include <llvm/ADT/SmallBitVector.h>
@@ -568,6 +569,7 @@ public:
     llvm::StringRef name;
     TypeFn_t _type;
     llvm::AttributeList (*_attrs)(llvm::LLVMContext &C);
+    llvm::SmallVector<JuliaFunction*,4> variants;
 
     JuliaFunction(const JuliaFunction&) = delete;
     JuliaFunction(const JuliaFunction&&) = delete;
@@ -579,6 +581,11 @@ public:
                          name, m);
         if (_attrs)
             F->setAttributes(_attrs(m->getContext()));
+        for (auto *other : variants) {
+            auto *otherF = other->realize(m);
+            // add the freshly created function llvm.compiler.used
+            appendToCompilerUsed(*m, {otherF});
+        }
         return F;
     }
 };
@@ -1498,6 +1505,58 @@ static const auto pointer_from_objref_func = new JuliaFunction<>{
             Attributes(C, {Attribute::NonNull}),
             {}); },
 };
+
+FunctionType *gc_loaded_vN_ft(LLVMContext &C, int N) {
+    return FunctionType::get(
+        FixedVectorType::get(PointerType::get(JuliaType::get_prjlvalue_ty(C), AddressSpace::Loaded), N),
+        {
+            FixedVectorType::get(JuliaType::get_prjlvalue_ty(C), N),
+            FixedVectorType::get(PointerType::get(JuliaType::get_prjlvalue_ty(C), 0), N)
+        }, false);
+}
+
+// nonnull / nocapture / readnone don't apply to vectors of pointers
+static const auto gc_loaded_v2_func = new JuliaFunction<>{
+    "julia.gc_loaded.v2",
+    [](LLVMContext &C) { return gc_loaded_vN_ft(C, 2); },
+    [](LLVMContext &C) {
+        AttrBuilder FnAttrs(C);
+        FnAttrs.addAttribute(Attribute::NoSync);
+        FnAttrs.addAttribute(Attribute::NoUnwind);
+        FnAttrs.addAttribute(Attribute::Speculatable);
+        FnAttrs.addAttribute(Attribute::WillReturn);
+        FnAttrs.addAttribute(Attribute::NoRecurse);
+#if JL_LLVM_VERSION >= 160000
+        FnAttrs.addMemoryAttr(MemoryEffects::none());
+#else
+        FnAttrs.addAttribute(Attribute::ReadNone);
+#endif
+        AttrBuilder RetAttrs(C);
+        RetAttrs.addAttribute(Attribute::NoUndef);
+        return AttributeList::get(C, AttributeSet::get(C,FnAttrs), AttributeSet::get(C,RetAttrs),
+                { Attributes(C, {Attribute::NoUndef}),
+                  Attributes(C, {Attribute::NoUndef}) });
+                  },
+};
+
+static const auto gc_loaded_v4_func = new JuliaFunction<>{
+    "julia.gc_loaded.v4",
+    [](LLVMContext &C) { return gc_loaded_vN_ft(C, 2); },
+    gc_loaded_v2_func->_attrs,
+};
+
+static const auto gc_loaded_v8_func = new JuliaFunction<>{
+    "julia.gc_loaded.v8",
+    [](LLVMContext &C) { return gc_loaded_vN_ft(C, 8); },
+    gc_loaded_v2_func->_attrs,
+};
+
+static const auto gc_loaded_v16_func = new JuliaFunction<>{
+    "julia.gc_loaded.v16",
+    [](LLVMContext &C) { return gc_loaded_vN_ft(C, 16); },
+    gc_loaded_v2_func->_attrs,
+};
+
 static const auto gc_loaded_func = new JuliaFunction<>{
     "julia.gc_loaded",
     // # memory(none) nosync nounwind speculatable willreturn norecurse
@@ -1515,6 +1574,10 @@ static const auto gc_loaded_func = new JuliaFunction<>{
         FnAttrs.addAttribute(Attribute::WillReturn);
         FnAttrs.addAttribute(Attribute::NoRecurse);
         FnAttrs.addMemoryAttr(MemoryEffects::none());
+        // XXX: According to langref we should be able to specify:
+        // _ZGV_LLVM_Nxvv for vector length agnostic and even
+        // _ZGV_LLVM_Nxvv_julia.gc_loaded(_LLVM_Scalarize_julia.gc_loaded) but that seems to not have been implemented
+	    FnAttrs.addAttribute("vector-function-abi-variant", "_ZGV_LLVM_N2vv_julia.gc_loaded(julia.gc_loaded.v2),_ZGV_LLVM_N4vv_julia.gc_loaded(julia.gc_loaded.v4),_ZGV_LLVM_N8vv_julia.gc_loaded(julia.gc_loaded.v8),_ZGV_LLVM_N16vv_julia.gc_loaded(julia.gc_loaded.v16)");
         AttrBuilder RetAttrs(C);
         RetAttrs.addAttribute(Attribute::NonNull);
         RetAttrs.addAttribute(Attribute::NoUndef);
@@ -1522,6 +1585,7 @@ static const auto gc_loaded_func = new JuliaFunction<>{
                 { Attributes(C, {Attribute::NonNull, Attribute::NoUndef, Attribute::ReadNone}, {NoCaptureAttr(C)}),
                   Attributes(C, {Attribute::NonNull, Attribute::NoUndef, Attribute::ReadNone}) });
                   },
+    {gc_loaded_v2_func,gc_loaded_v4_func,gc_loaded_v8_func,gc_loaded_v16_func},
 };
 
 // julia.call represents a call with julia calling convention, it is used as

--- a/src/llvm-alloc-helpers.cpp
+++ b/src/llvm-alloc-helpers.cpp
@@ -250,7 +250,8 @@ void jl_alloc::runEscapeAnalysis(llvm::CallInst *I, EscapeAnalysisRequiredArgs r
                 required.use_info.addrescaped = true;
                 return true;
             }
-            if (required.pass.gc_loaded_func == callee) {
+            if (required.pass.gc_loaded_func == callee ||
+                callee->getName().starts_with("julia.gc_loaded")) {
                 // TODO add manual load->store forwarding
                 push_inst(inst);
                 return true;

--- a/src/llvm-alloc-opt.cpp
+++ b/src/llvm-alloc-opt.cpp
@@ -349,7 +349,8 @@ bool Optimizer::isSafepoint(Instruction *inst)
         // Known functions emitted in codegen that are not safepoints
         if (callee == pass.pointer_from_objref_func
             || callee == pass.gc_loaded_func
-            || callee->getName() == "memcmp") {
+            || callee->getName() == "memcmp"
+	    || callee->getName().starts_with("julia.gc_loaded")) {
             return false;
         }
     }

--- a/test/llvmpasses/vectorized_intrinsics.ll
+++ b/test/llvmpasses/vectorized_intrinsics.ll
@@ -1,0 +1,100 @@
+; This file is a part of Julia. License is MIT: https://julialang.org/license
+
+; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='loop-vectorize' -force-vector-width=2 -S %s | FileCheck %s --check-prefixes=CHECKV2
+; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='loop-vectorize' -force-vector-width=4 -S %s | FileCheck %s --check-prefixes=CHECKV4
+; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='loop-vectorize' -force-vector-width=8 -S %s | FileCheck %s --check-prefixes=CHECKV8
+; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='loop-vectorize' -force-vector-width=16 -S %s | FileCheck %s --check-prefixes=CHECKV16
+
+; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='loop-vectorize' -scalable-vectorization=on -force-target-supports-scalable-vectors=true -force-vector-width=2 -S %s | FileCheck %s --check-prefixes=CHECKSCAL
+
+source_filename = "vectorized_intrinsics.ll"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128-ni:10:11:12:13"
+target triple = "x86_64-unknown-linux-gnu"
+
+@jl_nothing = external constant ptr
+@llvm.compiler.used = appending global [4 x ptr] [ptr @julia.gc_loaded.v2, ptr @julia.gc_loaded.v4, ptr @julia.gc_loaded.v8, ptr @julia.gc_loaded.v16], section "llvm.metadata"
+
+define void @"julia_#5_1643"(ptr addrspace(11) nocapture noundef nonnull readonly align 8 dereferenceable(16) %"v::FixedSizeArray", ptr nocapture readonly %.roots.v) #0 {
+top:
+  %pgcstack = call ptr @julia.get_pgcstack()
+  %memoryref_mem = load ptr addrspace(10), ptr %.roots.v, align 8, !tbaa !3, !alias.scope !7, !noalias !10
+  %0 = getelementptr inbounds i8, ptr addrspace(11) %"v::FixedSizeArray", i64 8
+  %.unbox = load i64, ptr addrspace(11) %0, align 8, !tbaa !15, !invariant.load !17, !alias.scope !18, !noalias !19
+  %1 = icmp slt i64 %.unbox, 1
+  br i1 %1, label %L48, label %L13.preheader15
+
+L13.preheader15:                                  ; preds = %top
+  %2 = addrspacecast ptr addrspace(10) %memoryref_mem to ptr addrspace(11)
+  %memory_data_ptr = getelementptr inbounds { i64, ptr }, ptr addrspace(11) %2, i64 0, i32 1
+  br label %L30
+
+L30:                                              ; preds = %L30, %L13.preheader15
+  %value_phi3 = phi i64 [ %5, %L30 ], [ 1, %L13.preheader15 ]
+  %memoryref_data = load ptr, ptr addrspace(11) %memory_data_ptr, align 8, !tbaa !15, !invariant.load !17, !alias.scope !18, !noalias !19, !nonnull !17
+  %memoryref_offset = shl i64 %value_phi3, 3
+  %3 = call ptr addrspace(13) @julia.gc_loaded(ptr addrspace(10) %memoryref_mem, ptr %memoryref_data)
+  ; CHECKV2: call <2 x ptr addrspace(13)> @julia.gc_loaded.v2
+  ; CHECKV4: call <4 x ptr addrspace(13)> @julia.gc_loaded.v4
+  ; CHECKV8: call <8 x ptr addrspace(13)> @julia.gc_loaded.v8
+  ; CHECKV16: call <16 x ptr addrspace(13)> @julia.gc_loaded.v16
+  %4 = getelementptr i8, ptr addrspace(13) %3, i64 %memoryref_offset
+  %memoryref_data6 = getelementptr i8, ptr addrspace(13) %4, i64 -8
+  store i64 4607182418800017408, ptr addrspace(13) %memoryref_data6, align 8, !tbaa !20, !alias.scope !22, !noalias !23
+  %5 = add nuw i64 %value_phi3, 1
+  %6 = icmp ult i64 %value_phi3, %.unbox
+  br i1 %6, label %L30, label %L48.loopexit
+
+L48.loopexit:                                     ; preds = %L30
+  br label %L48
+
+L48:                                              ; preds = %L48.loopexit, %top
+  ret void
+}
+
+declare ptr @julia.get_pgcstack()
+
+; Function Attrs: norecurse nosync nounwind speculatable willreturn memory(none)
+declare noundef nonnull ptr addrspace(13) @julia.gc_loaded(ptr addrspace(10) nocapture noundef nonnull readnone, ptr noundef nonnull readnone) #1
+
+; Function Attrs: norecurse nosync nounwind speculatable willreturn memory(none)
+declare noundef <2 x ptr addrspace(13)> @julia.gc_loaded.v2(<2 x ptr addrspace(10)> noundef, <2 x ptr> noundef) #2
+
+; Function Attrs: norecurse nosync nounwind speculatable willreturn memory(none)
+declare noundef <4 x ptr addrspace(13)> @julia.gc_loaded.v4(<4 x ptr addrspace(10)> noundef, <4 x ptr> noundef) #2
+
+; Function Attrs: norecurse nosync nounwind speculatable willreturn memory(none)
+declare noundef <8 x ptr addrspace(13)> @julia.gc_loaded.v8(<8 x ptr addrspace(10)> noundef, <8 x ptr> noundef) #2
+
+; Function Attrs: norecurse nosync nounwind speculatable willreturn memory(none)
+declare noundef <16 x ptr addrspace(13)> @julia.gc_loaded.v16(<16 x ptr addrspace(10)> noundef, <16 x ptr> noundef) #2
+
+attributes #0 = { "frame-pointer"="all" "julia.fsig"="var\22#5\22(FixedSizeArrays.FixedSizeArray{Float64, 1, Memory{Float64}})" "probe-stack"="inline-asm" }
+attributes #1 = { norecurse nosync nounwind speculatable willreturn memory(none) "vector-function-abi-variant"="_ZGV_LLVM_N2vv_julia.gc_loaded(julia.gc_loaded.v2),_ZGV_LLVM_N4vv_julia.gc_loaded(julia.gc_loaded.v4),_ZGV_LLVM_N8vv_julia.gc_loaded(julia.gc_loaded.v8),_ZGV_LLVM_N16vv_julia.gc_loaded(julia.gc_loaded.v16)" }
+attributes #2 = { norecurse nosync nounwind speculatable willreturn memory(none) }
+
+!llvm.module.flags = !{!0, !1, !2}
+
+!0 = !{i32 2, !"Dwarf Version", i32 4}
+!1 = !{i32 2, !"Debug Info Version", i32 3}
+!2 = !{i32 2, !"julia.debug_level", i32 2}
+!3 = !{!4, !4, i64 0}
+!4 = !{!"jtbaa_gcframe", !5, i64 0}
+!5 = !{!"jtbaa", !6, i64 0}
+!6 = !{!"jtbaa"}
+!7 = !{!8}
+!8 = !{!"jnoalias_gcframe", !9}
+!9 = !{!"jnoalias"}
+!10 = !{!11, !12, !13, !14}
+!11 = !{!"jnoalias_stack", !9}
+!12 = !{!"jnoalias_data", !9}
+!13 = !{!"jnoalias_typemd", !9}
+!14 = !{!"jnoalias_const", !9}
+!15 = !{!16, !16, i64 0, i64 1}
+!16 = !{!"jtbaa_const", !5, i64 0}
+!17 = !{}
+!18 = !{!14}
+!19 = !{!8, !11, !12, !13}
+!20 = !{!21, !21, i64 0}
+!21 = !{!"jtbaa_data", !5, i64 0}
+!22 = !{!12}
+!23 = !{!8, !11, !13, !14}

--- a/test/llvmpasses/vectorized_intrinsics.ll
+++ b/test/llvmpasses/vectorized_intrinsics.ll
@@ -5,8 +5,6 @@
 ; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='loop-vectorize' -force-vector-width=8 -S %s | FileCheck %s --check-prefixes=CHECKV8
 ; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='loop-vectorize' -force-vector-width=16 -S %s | FileCheck %s --check-prefixes=CHECKV16
 
-; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='loop-vectorize' -scalable-vectorization=on -force-target-supports-scalable-vectors=true -force-vector-width=2 -S %s | FileCheck %s --check-prefixes=CHECKSCAL
-
 source_filename = "vectorized_intrinsics.ll"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128-ni:10:11:12:13"
 target triple = "x86_64-unknown-linux-gnu"
@@ -33,10 +31,10 @@ L30:                                              ; preds = %L30, %L13.preheader
   %memoryref_data = load ptr, ptr addrspace(11) %memory_data_ptr, align 8, !tbaa !15, !invariant.load !17, !alias.scope !18, !noalias !19, !nonnull !17
   %memoryref_offset = shl i64 %value_phi3, 3
   %3 = call ptr addrspace(13) @julia.gc_loaded(ptr addrspace(10) %memoryref_mem, ptr %memoryref_data)
-  ; CHECKV2: call <2 x ptr addrspace(13)> @julia.gc_loaded.v2
-  ; CHECKV4: call <4 x ptr addrspace(13)> @julia.gc_loaded.v4
-  ; CHECKV8: call <8 x ptr addrspace(13)> @julia.gc_loaded.v8
-  ; CHECKV16: call <16 x ptr addrspace(13)> @julia.gc_loaded.v16
+  ; CHECKV2: call <2 x ptr addrspace(13)> @julia.gc_loaded.v2(ptr addrspace(10) %memoryref_mem, <2 x ptr>
+  ; CHECKV4: call <4 x ptr addrspace(13)> @julia.gc_loaded.v4(ptr addrspace(10) %memoryref_mem, <4 x ptr>
+  ; CHECKV8: call <8 x ptr addrspace(13)> @julia.gc_loaded.v8(ptr addrspace(10) %memoryref_mem, <8 x ptr>
+  ; CHECKV16: call <16 x ptr addrspace(13)> @julia.gc_loaded.v16(ptr addrspace(10) %memoryref_mem, <16 x ptr>
   %4 = getelementptr i8, ptr addrspace(13) %3, i64 %memoryref_offset
   %memoryref_data6 = getelementptr i8, ptr addrspace(13) %4, i64 -8
   store i64 4607182418800017408, ptr addrspace(13) %memoryref_data6, align 8, !tbaa !20, !alias.scope !22, !noalias !23
@@ -57,19 +55,19 @@ declare ptr @julia.get_pgcstack()
 declare noundef nonnull ptr addrspace(13) @julia.gc_loaded(ptr addrspace(10) nocapture noundef nonnull readnone, ptr noundef nonnull readnone) #1
 
 ; Function Attrs: norecurse nosync nounwind speculatable willreturn memory(none)
-declare noundef <2 x ptr addrspace(13)> @julia.gc_loaded.v2(<2 x ptr addrspace(10)> noundef, <2 x ptr> noundef) #2
+declare noundef <2 x ptr addrspace(13)> @julia.gc_loaded.v2(ptr addrspace(10) nocapture noundef nonnull readnone, <2 x ptr> noundef) #2
 
 ; Function Attrs: norecurse nosync nounwind speculatable willreturn memory(none)
-declare noundef <4 x ptr addrspace(13)> @julia.gc_loaded.v4(<4 x ptr addrspace(10)> noundef, <4 x ptr> noundef) #2
+declare noundef <4 x ptr addrspace(13)> @julia.gc_loaded.v4(ptr addrspace(10) nocapture noundef nonnull readnone, <4 x ptr> noundef) #2
 
 ; Function Attrs: norecurse nosync nounwind speculatable willreturn memory(none)
-declare noundef <8 x ptr addrspace(13)> @julia.gc_loaded.v8(<8 x ptr addrspace(10)> noundef, <8 x ptr> noundef) #2
+declare noundef <8 x ptr addrspace(13)> @julia.gc_loaded.v8(ptr addrspace(10) nocapture noundef nonnull readnone, <8 x ptr> noundef) #2
 
 ; Function Attrs: norecurse nosync nounwind speculatable willreturn memory(none)
-declare noundef <16 x ptr addrspace(13)> @julia.gc_loaded.v16(<16 x ptr addrspace(10)> noundef, <16 x ptr> noundef) #2
+declare noundef <16 x ptr addrspace(13)> @julia.gc_loaded.v16(ptr addrspace(10) nocapture noundef nonnull readnone, <16 x ptr> noundef) #2
 
 attributes #0 = { "frame-pointer"="all" "julia.fsig"="var\22#5\22(FixedSizeArrays.FixedSizeArray{Float64, 1, Memory{Float64}})" "probe-stack"="inline-asm" }
-attributes #1 = { norecurse nosync nounwind speculatable willreturn memory(none) "vector-function-abi-variant"="_ZGV_LLVM_N2vv_julia.gc_loaded(julia.gc_loaded.v2),_ZGV_LLVM_N4vv_julia.gc_loaded(julia.gc_loaded.v4),_ZGV_LLVM_N8vv_julia.gc_loaded(julia.gc_loaded.v8),_ZGV_LLVM_N16vv_julia.gc_loaded(julia.gc_loaded.v16)" }
+attributes #1 = { norecurse nosync nounwind speculatable willreturn memory(none) "vector-function-abi-variant"="_ZGV_LLVM_N2uv_julia.gc_loaded(julia.gc_loaded.v2),_ZGV_LLVM_N4uv_julia.gc_loaded(julia.gc_loaded.v4),_ZGV_LLVM_N8uv_julia.gc_loaded(julia.gc_loaded.v8),_ZGV_LLVM_N16uv_julia.gc_loaded(julia.gc_loaded.v16)" }
 attributes #2 = { norecurse nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.module.flags = !{!0, !1, !2}


### PR DESCRIPTION
Motivated by https://github.com/JuliaLang/julia/issues/56145#issuecomment-2410433091 I was interested
in seeing if we could teach LLVM about vectorizing our intrinsics that will be removed before the final result
e.g. `@julia.gc_loaded`

This is an alternative to #51536 and uses the "vector-function-abi-variant" attribute.

This creates a lot of code-duplication so it might make sense to first do #52945

On nightly (54299d94158)

```llvm
; Function Signature: var"#2"(FixedSizeArrays.FixedSizeArray{Float64, 1, Memory{Float64}})
define void @"julia_#2_2050"(ptr nocapture noundef nonnull readonly align 8 dereferenceable(16) %"v::FixedSizeArray", ptr nocapture readonly %.roots.v) #0 {
top:
  %0 = getelementptr inbounds i8, ptr %"v::FixedSizeArray", i64 8
  %.unbox = load i64, ptr %0, align 8
  %1 = icmp slt i64 %.unbox, 1
  br i1 %1, label %L48, label %L13.preheader15

L13.preheader15:                                  ; preds = %top
  %memoryref_mem = load ptr, ptr %.roots.v, align 8
  %memory_data_ptr = getelementptr inbounds { i64, ptr }, ptr %memoryref_mem, i64 0, i32 1
  %memoryref_data.pre = load ptr, ptr %memory_data_ptr, align 8
  br label %L30

L30:                                              ; preds = %L30, %L13.preheader15
  %value_phi3 = phi i64 [ %3, %L30 ], [ 1, %L13.preheader15 ]
  %memoryref_offset = shl i64 %value_phi3, 3
  %2 = getelementptr i8, ptr %memoryref_data.pre, i64 %memoryref_offset
  %memoryref_data6 = getelementptr i8, ptr %2, i64 -8
  store i64 4607182418800017408, ptr %memoryref_data6, align 8
  %3 = add nuw i64 %value_phi3, 1
  %4 = icmp ult i64 %value_phi3, %.unbox
  br i1 %4, label %L30, label %L48

L48:                                              ; preds = %L30, %top
  ret void
}
```

On this PR:

```llvm
; Function Signature: var"#2"(FixedSizeArrays.FixedSizeArray{Float64, 1, Memory{Float64}})
define void @"julia_#2_2053"(ptr nocapture noundef nonnull readonly align 8 dereferenceable(16) %"v::FixedSizeArray", ptr nocapture readonly %.roots.v) #0 {
top:
  %0 = getelementptr inbounds i8, ptr %"v::FixedSizeArray", i64 8
  %.unbox = load i64, ptr %0, align 8
  %1 = icmp slt i64 %.unbox, 1
  br i1 %1, label %L48, label %L13.preheader15

L13.preheader15:                                  ; preds = %top
  %memoryref_mem = load ptr, ptr %.roots.v, align 8
  %memory_data_ptr = getelementptr inbounds { i64, ptr }, ptr %memoryref_mem, i64 0, i32 1
  %min.iters.check = icmp ult i64 %.unbox, 8
  %memoryref_data.pre.pre = load ptr, ptr %memory_data_ptr, align 8
  br i1 %min.iters.check, label %scalar.ph, label %vector.ph

vector.ph:                                        ; preds = %L13.preheader15
  %n.vec = and i64 %.unbox, 9223372036854775800
  %ind.end = or disjoint i64 %n.vec, 1
  br label %vector.body

vector.body:                                      ; preds = %vector.body, %vector.ph
  %index = phi i64 [ 0, %vector.ph ], [ %index.next, %vector.body ]
  %vec.ind = phi <8 x i64> [ <i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8>, %vector.ph ], [ %vec.ind.next, %vector.body ]
  %broadcast.splatinsert20 = insertelement <8 x ptr> poison, ptr %memoryref_data.pre.pre, i64 0
  %broadcast.splat21 = shufflevector <8 x ptr> %broadcast.splatinsert20, <8 x ptr> poison, <8 x i32> zeroinitializer
  %2 = shl <8 x i64> %vec.ind, <i64 3, i64 3, i64 3, i64 3, i64 3, i64 3, i64 3, i64 3>
  %3 = getelementptr i8, <8 x ptr> %broadcast.splat21, <8 x i64> %2
  %4 = getelementptr i8, <8 x ptr> %3, i64 -8
  call void @llvm.masked.scatter.v8i64.v8p0(<8 x i64> <i64 4607182418800017408, i64 4607182418800017408, i64 4607182418800017408, i64 4607182418800017408, i64 4607182418800017408, i64 4607182418800017408, i64 4607182418800017408, i64 4607182418800017408>, <8 x ptr> %4, i32 8, <8 x i1> <i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true>)
  %index.next = add nuw i64 %index, 8
  %vec.ind.next = add <8 x i64> %vec.ind, <i64 8, i64 8, i64 8, i64 8, i64 8, i64 8, i64 8, i64 8>
  %5 = icmp eq i64 %index.next, %n.vec
  br i1 %5, label %middle.block, label %vector.body

middle.block:                                     ; preds = %vector.body
  %cmp.n = icmp eq i64 %.unbox, %n.vec
  br i1 %cmp.n, label %L48, label %scalar.ph

scalar.ph:                                        ; preds = %middle.block, %L13.preheader15
  %bc.resume.val = phi i64 [ %ind.end, %middle.block ], [ 1, %L13.preheader15 ]
  br label %L30

L30:                                              ; preds = %L30, %scalar.ph
  %value_phi3 = phi i64 [ %7, %L30 ], [ %bc.resume.val, %scalar.ph ]
  %memoryref_offset = shl i64 %value_phi3, 3
  %6 = getelementptr i8, ptr %memoryref_data.pre.pre, i64 %memoryref_offset
  %memoryref_data6 = getelementptr i8, ptr %6, i64 -8
  store i64 4607182418800017408, ptr %memoryref_data6, align 8
  %7 = add nuw i64 %value_phi3, 1
  %8 = icmp ult i64 %value_phi3, %.unbox
  br i1 %8, label %L30, label %L48

L48:                                              ; preds = %L30, %middle.block, %top
  ret void
}
```

Not pretty, but at least the intrinsic no longer blocks vectorization.

Running with `JULIA_LLVM_ARGS="--debug-only=vfabi-demangler"`

```
VFABI: Adding mapping '_ZGV_LLVM_N2vv_julia.gc_loaded(julia.gc_loaded.v2)' for   %3 = call ptr addrspace(13) @julia.gc_loaded(ptr addrspace(10) %memoryref_mem, ptr %memoryref_data), !dbg !80
VFABI: Adding mapping '_ZGV_LLVM_N4vv_julia.gc_loaded(julia.gc_loaded.v4)' for   %3 = call ptr addrspace(13) @julia.gc_loaded(ptr addrspace(10) %memoryref_mem, ptr %memoryref_data), !dbg !80
VFABI: Adding mapping '_ZGV_LLVM_N8vv_julia.gc_loaded(julia.gc_loaded.v8)' for   %3 = call ptr addrspace(13) @julia.gc_loaded(ptr addrspace(10) %memoryref_mem, ptr %memoryref_data), !dbg !80
VFABI: Adding mapping '_ZGV_LLVM_N16vv_julia.gc_loaded(julia.gc_loaded.v16)' for   %3 = call ptr addrspace(13) @julia.gc_loaded(ptr addrspace(10) %memoryref_mem, ptr %memoryref_data), !dbg !80
```


and with `JULIA_LLVM_ARGS="--print-after=loop-vectorize --pass-remarks-analysis=loop-vectorize"`
```llvm
remark: abstractarray.jl:699:0: the cost-model indicates that interleaving is not beneficial
; *** IR Dump After LoopVectorizePass on julia_#5_1744 ***
define void @"julia_#5_1744"(ptr addrspace(11) nocapture noundef nonnull readonly align 8 dereferenceable(16) %"v::FixedSizeArray", ptr nocapture readonly %.roots.v) #0 !dbg !5 {
top:
  %pgcstack = call ptr @julia.get_pgcstack()
  %memoryref_mem = load ptr addrspace(10), ptr %.roots.v, align 8, !tbaa !24, !alias.scope !28, !noalias !31
  call void @llvm.dbg.declare(metadata ptr addrspace(11) %"v::FixedSizeArray", metadata !23, metadata !DIExpression()), !dbg !36
  %0 = getelementptr inbounds i8, ptr addrspace(11) %"v::FixedSizeArray", i64 8, !dbg !37
  %.unbox = load i64, ptr addrspace(11) %0, align 8, !dbg !51, !tbaa !62, !invariant.load !10, !alias.scope !64, !noalias !65
  %1 = icmp slt i64 %.unbox, 1, !dbg !51
  br i1 %1, label %L48, label %L13.preheader15, !dbg !36

L13.preheader15:                                  ; preds = %top
  %2 = addrspacecast ptr addrspace(10) %memoryref_mem to ptr addrspace(11)
  %memory_data_ptr = getelementptr inbounds { i64, ptr }, ptr addrspace(11) %2, i64 0, i32 1
  %min.iters.check = icmp ult i64 %.unbox, 8, !dbg !66
  br i1 %min.iters.check, label %scalar.ph, label %vector.ph, !dbg !66

vector.ph:                                        ; preds = %L13.preheader15
  %n.mod.vf = urem i64 %.unbox, 8, !dbg !66
  %n.vec = sub i64 %.unbox, %n.mod.vf, !dbg !66
  %ind.end = add i64 1, %n.vec, !dbg !66
  %broadcast.splatinsert = insertelement <8 x ptr addrspace(10)> poison, ptr addrspace(10) %memoryref_mem, i64 0, !dbg !66
  %broadcast.splat = shufflevector <8 x ptr addrspace(10)> %broadcast.splatinsert, <8 x ptr addrspace(10)> poison, <8 x i32> zeroinitializer, !dbg !66
  br label %vector.body, !dbg !66

vector.body:                                      ; preds = %vector.body, %vector.ph
  %index = phi i64 [ 0, %vector.ph ], [ %index.next, %vector.body ]
  %vec.ind = phi <8 x i64> [ <i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8>, %vector.ph ], [ %vec.ind.next, %vector.body ]
  %3 = load ptr, ptr addrspace(11) %memory_data_ptr, align 8, !dbg !71, !tbaa !62, !invariant.load !10, !alias.scope !64, !noalias !65, !nonnull !10
  %broadcast.splatinsert20 = insertelement <8 x ptr> poison, ptr %3, i64 0, !dbg !74
  %broadcast.splat21 = shufflevector <8 x ptr> %broadcast.splatinsert20, <8 x ptr> poison, <8 x i32> zeroinitializer, !dbg !74
  %4 = shl <8 x i64> %vec.ind, <i64 3, i64 3, i64 3, i64 3, i64 3, i64 3, i64 3, i64 3>, !dbg !74
  %5 = call <8 x ptr addrspace(13)> @julia.gc_loaded.v8(<8 x ptr addrspace(10)> %broadcast.splat, <8 x ptr> %broadcast.splat21), !dbg !66
  %6 = getelementptr i8, <8 x ptr addrspace(13)> %5, <8 x i64> %4, !dbg !66
  %7 = getelementptr i8, <8 x ptr addrspace(13)> %6, i64 -8, !dbg !66
  call void @llvm.masked.scatter.v8i64.v8p13(<8 x i64> <i64 4607182418800017408, i64 4607182418800017408, i64 4607182418800017408, i64 4607182418800017408, i64 4607182418800017408, i64 4607182418800017408, i64 4607182418800017408, i64 4607182418800017408>, <8 x ptr addrspace(13)> %7, i32 8, <8 x i1> <i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true>), !dbg !80, !tbaa !81, !alias.scope !83, !noalias !84
  %index.next = add nuw i64 %index, 8
  %vec.ind.next = add <8 x i64> %vec.ind, <i64 8, i64 8, i64 8, i64 8, i64 8, i64 8, i64 8, i64 8>
  %8 = icmp eq i64 %index.next, %n.vec
  br i1 %8, label %middle.block, label %vector.body, !llvm.loop !85

middle.block:                                     ; preds = %vector.body
  %cmp.n = icmp eq i64 %.unbox, %n.vec, !dbg !88
  br i1 %cmp.n, label %L48.loopexit, label %scalar.ph, !dbg !88

scalar.ph:                                        ; preds = %L13.preheader15, %middle.block
  %bc.resume.val = phi i64 [ %ind.end, %middle.block ], [ 1, %L13.preheader15 ]
  br label %L30, !dbg !66

L30:                                              ; preds = %L30, %scalar.ph
  %value_phi3 = phi i64 [ %11, %L30 ], [ %bc.resume.val, %scalar.ph ]
  %memoryref_data = load ptr, ptr addrspace(11) %memory_data_ptr, align 8, !dbg !71, !tbaa !62, !invariant.load !10, !alias.scope !64, !noalias !65, !nonnull !10
  %memoryref_offset = shl i64 %value_phi3, 3, !dbg !74
  %9 = call ptr addrspace(13) @julia.gc_loaded(ptr addrspace(10) %memoryref_mem, ptr %memoryref_data), !dbg !80
  %10 = getelementptr i8, ptr addrspace(13) %9, i64 %memoryref_offset, !dbg !80
  %memoryref_data6 = getelementptr i8, ptr addrspace(13) %10, i64 -8, !dbg !80
  store i64 4607182418800017408, ptr addrspace(13) %memoryref_data6, align 8, !dbg !80, !tbaa !81, !alias.scope !83, !noalias !84
  %11 = add nuw i64 %value_phi3, 1, !dbg !89
  %12 = icmp ult i64 %value_phi3, %.unbox, !dbg !88
  br i1 %12, label %L30, label %L48.loopexit, !dbg !88, !llvm.loop !90

L48.loopexit:                                     ; preds = %middle.block, %L30
  br label %L48, !dbg !88

L48:                                              ; preds = %L48.loopexit, %top
  ret void, !dbg !88
}
```
