### PR TITLE
Mark `require_one_based_indexing` and `has_offset_axes` as public

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -110,6 +110,7 @@ New library features
   the uniquing checking ([#53474])
 * `RegexMatch` objects can now be used to construct `NamedTuple`s and `Dict`s ([#50988])
 * `Lockable` is now exported ([#54595])
+* `Base.require_one_based_indexing` and `Base.has_offset_axes` are now public ([#56196])
 * New `ltruncate`, `rtruncate` and `ctruncate` functions for truncating strings to text width, accounting for char widths ([#55351])
 
 Standard library changes

--- a/base/public.jl
+++ b/base/public.jl
@@ -28,6 +28,10 @@ public
     acquire,
     release,
 
+# arrays
+    has_offset_axes,
+    require_one_based_indexing,
+
 # collections
     IteratorEltype,
     IteratorSize,

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -115,7 +115,7 @@ Base.checkindex
 Base.elsize
 ```
 
-The following functions can be used to handle arrays with custom indices:
+While most code can be written in an index-agnostic manner (see, e.g., [`eachindex`](@ref)), it can sometimes be useful to explicitly check for offset axes:
 ```@docs
 Base.require_one_based_indexing
 Base.has_offset_axes

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -115,6 +115,12 @@ Base.checkindex
 Base.elsize
 ```
 
+The following functions can be used to handle arrays with custom indices:
+```@docs
+Base.require_one_based_indexing
+Base.has_offset_axes
+```
+
 ## Views (SubArrays and other view types)
 
 A “view” is a data structure that acts like an array (it is a subtype of `AbstractArray`), but the underlying data is actually


### PR DESCRIPTION
The discussion here mentions `require_one_based_indexing` being part of the public API: https://github.com/JuliaLang/julia/pull/43263

Both functions are also documented (albeit in the dev docs): 
* `require_one_based_indexing`: https://docs.julialang.org/en/v1/devdocs/offset-arrays/#man-custom-indices
* `has_offset_axes`: https://docs.julialang.org/en/v1/devdocs/offset-arrays/#For-objects-that-mimic-AbstractArray-but-are-not-subtypes

Towards https://github.com/JuliaLang/julia/issues/51335.