### PR TITLE
Update stable release tag to 1.11.1 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ and then use the command prompt to change into the resulting julia directory. By
 Julia. However, most users should use the [most recent stable version](https://github.com/JuliaLang/julia/releases)
 of Julia. You can get this version by running:
 
-    git checkout v1.10.5
+    git checkout v1.11.1
 
 To build the `julia` executable, run `make` from within the julia directory.
 


### PR DESCRIPTION
This still points to 1.10 and should be updated.