### PR TITLE
Make `LinearAlgebra.haszero` public

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -150,6 +150,8 @@ Standard library changes
   Custom array types may specialize this function to return an appropriate result ([#55252]).
 * The matrix multiplication `A * B` calls `matprod_dest(A, B, T::Type)` to generate the destination.
   This function is now public ([#55537]).
+* The function `haszero(T::Type)` is used to check if a type `T` has a unique zero element defined as `zero(T)`.
+  This is now public.
 
 #### Logging
 

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -895,6 +895,7 @@ LinearAlgebra.LAPACK.hseqr!
 
 ```@docs
 LinearAlgebra.matprod_dest
+LinearAlgebra.haszero
 ```
 
 ```@meta

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -169,6 +169,7 @@ export
 public AbstractTriangular,
         Givens,
         checksquare,
+        haszero,
         hermitian,
         hermitian_type,
         isbanded,

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -108,6 +108,21 @@ norm2(x::Union{Array{T},StridedVector{T}}) where {T<:BlasFloat} =
     length(x) < NRM2_CUTOFF ? generic_norm2(x) : BLAS.nrm2(x)
 
 # Conservative assessment of types that have zero(T) defined for themselves
+"""
+    haszero(T::Type)
+
+Return whether a type `T` has a unique zero element defined using `zero(T)`.
+If a type `M` specializes `zero(M)`, it may also choose to add the method
+```julia
+haszero(::Type{M}) where {M} = true
+```
+By default, `haszero` is assumed to be `false`, in which case the zero elements
+are deduced from values rather than the type.
+
+!!! note
+    `haszero` is a conservative check that is used to dispatch to
+    optimized paths. Extending it is optional, but encouraged.
+"""
 haszero(::Type) = false
 haszero(::Type{T}) where {T<:Number} = isconcretetype(T)
 haszero(::Type{Union{Missing,T}}) where {T<:Number} = haszero(T)

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -112,10 +112,7 @@ norm2(x::Union{Array{T},StridedVector{T}}) where {T<:BlasFloat} =
     haszero(T::Type)
 
 Return whether a type `T` has a unique zero element defined using `zero(T)`.
-If a type `M` specializes `zero(M)`, it may also choose to add the method
-```julia
-haszero(::Type{M}) where {M} = true
-```
+If a type `M` specializes `zero(M)`, it may also choose to set `haszero(M)` to `true`.
 By default, `haszero` is assumed to be `false`, in which case the zero elements
 are deduced from values rather than the type.
 


### PR DESCRIPTION
The trait `haszero` is used to check if a type `T` has a unique zero defined using `zero(T)`. This lets us dispatch to optimized paths without losing generality. This PR makes the function public so that this may be extended by packages (such as `StaticArrays`).