### PR TITLE
Do not call `rand` during sysimage precompilation

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -183,10 +183,11 @@ for match = Base._methods(+, (Int, Int), -1, Base.get_world_counter())
     # interactive startup uses this
     write(IOBuffer(), "")
 
-    # not critical, but helps hide unrelated compilation from @time when using --trace-compile
-    foo() = rand(2,2) * rand(2,2)
-    @time foo()
-    @time foo()
+    # Not critical, but helps hide unrelated compilation from @time when using --trace-compile.
+    # Do not call `rand` which can cause bad caching on some platforms: #56177.
+    f55729() = ones(2, 2) * ones(2, 2)
+    @time f55729()
+    @time f55729()
 
     break   # only actually need to do this once
 end

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -184,10 +184,9 @@ for match = Base._methods(+, (Int, Int), -1, Base.get_world_counter())
     write(IOBuffer(), "")
 
     # Not critical, but helps hide unrelated compilation from @time when using --trace-compile.
-    # Do not call `rand` which can cause bad caching on some platforms: #56177.
-    f55729() = ones(2, 2) * ones(2, 2)
-    @time f55729()
-    @time f55729()
+    f55729() = Base.Experimental.@force_compile
+    @time @eval f55729()
+    @time @eval f55729()
 
     break   # only actually need to do this once
 end


### PR DESCRIPTION
This change by itself doesn't do anything significant on `master`, but when backported to the v1.11 branch it'll address #56177.  However it'd be great if someone could tell _why_ this fixes that issue, because it looks very unrelated.