### PR TITLE
fix reporting of precompile configs on CI

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -800,8 +800,8 @@ function precompilepkgs(pkgs::Vector{String}=String[];
                             name *= color_string(" $(config_str)", :light_black)
                         end
                         lock(print_lock) do
-                            if !fancyprint && target === nothing && isempty(pkg_queue)
-                                printpkgstyle(io, :Precompiling, "packages...")
+                            if !fancyprint && isempty(pkg_queue)
+                                printpkgstyle(io, :Precompiling, something(target, "packages..."))
                             end
                         end
                         push!(pkg_queue, pkg_config)


### PR DESCRIPTION
Currently the header doesn't print for `Pkg.test` with coverage on

```
  [8dfed614] Test v1.11.0
   1077.2 ms  ✓ RequiredInterfaces
  1 dependency successfully precompiled in 1 seconds. 8 already precompiled.
```