### PR TITLE
Make isbitstypes use memmove instead of the runtime function in copyto!

### DIFF
--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -119,7 +119,7 @@ function unsafe_copyto!(dest::MemoryRef{T}, src::MemoryRef{T}, n) where {T}
     n == 0 && return dest
     @boundscheck memoryref(dest, n), memoryref(src, n)
     if isbitstype(T)
-        memmove(pointer(dest), pointer(src), aligned_sizeof(T) * n)
+        GC.@preserve dest src memmove(pointer(dest), pointer(src), aligned_sizeof(T) * n)
     else
         ccall(:jl_genericmemory_copyto, Cvoid, (Any, Ptr{Cvoid}, Any, Ptr{Cvoid}, Int), dest.mem, dest.ptr_or_offset, src.mem, src.ptr_or_offset, Int(n))
     end

--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -118,7 +118,11 @@ function unsafe_copyto!(dest::MemoryRef{T}, src::MemoryRef{T}, n) where {T}
     @_terminates_globally_notaskstate_meta
     n == 0 && return dest
     @boundscheck memoryref(dest, n), memoryref(src, n)
-    ccall(:jl_genericmemory_copyto, Cvoid, (Any, Ptr{Cvoid}, Any, Ptr{Cvoid}, Int), dest.mem, dest.ptr_or_offset, src.mem, src.ptr_or_offset, Int(n))
+    if isbitstype(T)
+        memmove(pointer(dest), pointer(src), aligned_sizeof(T) * n)
+    else
+        ccall(:jl_genericmemory_copyto, Cvoid, (Any, Ptr{Cvoid}, Any, Ptr{Cvoid}, Int), dest.mem, dest.ptr_or_offset, src.mem, src.ptr_or_offset, Int(n))
+    end
     return dest
 end
 


### PR DESCRIPTION
This might help llvm understand whats going on. Also enzyme really wants this to look like this to trace through it better.

We probably want to backport this. (this is also very likely faster)