### PR TITLE
Define parent and parentindices for Array

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -165,6 +165,13 @@ function vect(X::T...) where T
     return vec
 end
 
+parent(A::Array) = A.ref.mem
+
+function parentindices(A::Array)
+    offset = div(A.ref.ptr_or_offset - A.ref.mem.ptr, elsize(A))
+    (offset + 1:offset + length(A),)
+end
+
 """
     vect(X...)
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3286,3 +3286,18 @@ end
     ref = memoryref(mem, 2)
     @test parent(ref) === mem
 end
+
+@testset "Parent" begin
+    x = ["abc", "def", "ghi"]
+    mem = parent(x)
+    @test mem isa Memory{String}
+    start_index = 0
+    for i in eachindex(mem)
+        if isassigned(mem, i)
+            start_index = i
+            break
+        end
+    end
+    @test !iszero(start_index)
+    @test parentindices(x) == (start_index:start_index+2,)
+end


### PR DESCRIPTION
The parent of an Array is the underlying Memory, and the parentindices are the indices of that Memory that corresponds to the Array.

Closes #56238