### PR TITLE
Warn about negative size in array construction

### DIFF
--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -45,7 +45,7 @@ jl_genericmemory_t *_new_genericmemory_(jl_value_t *mtype, size_t nel, int8_t is
         prod += nel;
     }
     if (nel >= MAXINTVAL || prod >= (wideint_t) MAXINTVAL)
-        jl_exceptionf(jl_argumenterror_type, "invalid GenericMemory size: too large for system address width");
+        jl_exceptionf(jl_argumenterror_type, "invalid GenericMemory size: the number of elements is either negative or too large for system address width");
     size_t tot = (size_t)prod + LLT_ALIGN(sizeof(jl_genericmemory_t),JL_SMALL_BYTE_ALIGNMENT);
 
     int pooled = tot <= GC_MAX_SZCLASS;


### PR DESCRIPTION
After this,
```julia
julia> zeros(-1)
ERROR: ArgumentError: invalid GenericMemory size: the number of elements is either negative or too large for system address width
[...]
```
The error message is updated to warn about possible negative sizes when creating arrays.

Fixes https://github.com/JuliaLang/julia/issues/55446