### PR TITLE
Some usability follow-ups and fixes for the world macro

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1258,8 +1258,8 @@ arbitrary code in fixed worlds. `world` may be `UnitRange`, in which case the ma
 will error unless the binding is valid and has the same value across the entire world
 range.
 
-The `@world` macro is primarily used in the priniting of bindings that are no longer available
-in the current world.
+The `@world` macro is primarily used in the printing of bindings that are no longer
+available in the current world.
 
 ## Example
 ```

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1283,9 +1283,12 @@ julia> fold
 """
 macro world(sym, world)
     if isa(sym, Symbol)
-        return :($(_resolve_in_world)($world, $(QuoteNode(GlobalRef(__module__, sym)))))
+        return :($(_resolve_in_world)($(esc(world)), $(QuoteNode(GlobalRef(__module__, sym)))))
     elseif isa(sym, GlobalRef)
-        return :($(_resolve_in_world)($world, $(QuoteNode(sym))))
+        return :($(_resolve_in_world)($(esc(world)), $(QuoteNode(sym))))
+    elseif isa(sym, Expr) && sym.head === :(.) &&
+            length(sym.args) == 2 && isa(sym.args[2], QuoteNode) && isa(sym.args[2].value, Symbol)
+        return :($(_resolve_in_world)($(esc(world)), $(GlobalRef)($(esc(sym.args[1])), $(sym.args[2]))))
     else
         error("`@world` requires a symbol or GlobalRef")
     end

--- a/base/range.jl
+++ b/base/range.jl
@@ -1685,9 +1685,9 @@ end
 # The rest of this is defined in essentials.jl, but UnitRange is not available
 function _resolve_in_world(worlds::UnitRange, gr::GlobalRef)
     # Validate that this binding's reference covers the entire world range
-    bpart = lookup_binding_partition(first(worlds), gr)
-    if bpart.max_world < last(world)
+    bpart = lookup_binding_partition(UInt(first(worlds)), gr)
+    if bpart.max_world < last(worlds)
         error("Binding does not cover the full world range")
     end
-    _resolve_in_world(last(world), gr)
+    _resolve_in_world(UInt(last(worlds)), gr)
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -1061,6 +1061,8 @@ function show_type_name(io::IO, tn::Core.TypeName)
     sym = (globfunc ? globname : tn.name)::Symbol
     globfunc && print(io, "typeof(")
     quo = false
+    world = check_world_bounded(tn)
+    world !== nothing && print(io, "@world(")
     if !(get(io, :compact, false)::Bool)
         # Print module prefix unless type is visible from module passed to
         # IOContext If :module is not set, default to Main.
@@ -1078,8 +1080,6 @@ function show_type_name(io::IO, tn::Core.TypeName)
             end
         end
     end
-    world = check_world_bounded(tn)
-    world !== nothing && print(io, "@world(")
     show_sym(io, sym)
     world !== nothing && print(io, ", ", world, ")")
     quo      && print(io, ")")
@@ -3358,4 +3358,63 @@ end
 
 function show(io::IO, ::MIME"text/plain", oc::Core.OpaqueClosure{A, R}) where {A, R}
     show(io, oc)
+end
+
+# printing bindings and partitions
+function print_partition(io::IO, partition::Core.BindingPartition)
+    print(io, partition.min_world)
+    print(io, ":")
+    max_world = @atomic partition.max_world
+    if max_world == typemax(UInt)
+        print(io, '∞')
+    else
+        print(io, max_world)
+    end
+    print(io, " - ")
+    kind = binding_kind(partition)
+    if is_some_const_binding(kind)
+        print(io, "constant binding to ")
+        print(io, partition_restriction(partition))
+    elseif kind == BINDING_KIND_GUARD
+        print(io, "undefined binding - guard entry")
+    elseif kind == BINDING_KIND_FAILED
+        print(io, "ambiguous binding - guard entry")
+    elseif kind == BINDING_KIND_DECLARED
+        print(io, "undefined, but declared using `global` - guard entry")
+    elseif kind == BINDING_KIND_IMPLICIT
+        print(io, "implicit `using` from ")
+        print(io, partition_restriction(partition))
+    elseif kind == BINDING_KIND_EXPLICIT
+        print(io, "explicit `using` from ")
+        print(io, partition_restriction(partition))
+    elseif kind == BINDING_KIND_IMPORTED
+        print(io, "explicit `import` from ")
+        print(io, partition_restriction(partition))
+    else
+        @assert kind == BINDING_KIND_GLOBAL
+        print(io, "global variable with type ")
+        print(io, partition_restriction(partition))
+    end
+end
+
+function show(io::IO, ::MIME"text/plain", partition::Core.BindingPartition)
+    print(io, "BindingPartition ")
+    print_partition(io, partition)
+end
+
+function show(io::IO, ::MIME"text/plain", bnd::Core.Binding)
+    print(io, "Binding ")
+    print(io, bnd.globalref)
+    if !isdefined(bnd, :partitions)
+        print(io, "No partitions")
+    else
+        partition = @atomic bnd.partitions
+        while true
+            println(io)
+            print(io, "   ")
+            print_partition(io, partition)
+            isdefined(partition, :next) || break
+            partition = @atomic partition.next
+        end
+    end
 end

--- a/test/rebinding.jl
+++ b/test/rebinding.jl
@@ -7,6 +7,7 @@ module Rebinding
     struct Foo
         x::Int
     end
+    const defined_world_age = Base.tls_world_age()
     x = Foo(1)
 
     @test Base.binding_kind(@__MODULE__, :Foo) == Base.BINDING_KIND_CONST
@@ -15,4 +16,9 @@ module Rebinding
 
     @test Base.binding_kind(@__MODULE__, :Foo) == Base.BINDING_KIND_GUARD
     @test contains(repr(x), "@world")
+
+    # Tests for @world syntax
+    @test Base.@world(Foo, defined_world_age) == typeof(x)
+    @test Base.@world(Rebinding.Foo, defined_world_age) == typeof(x)
+    @test Base.@world((@__MODULE__).Foo, defined_world_age) == typeof(x)
 end


### PR DESCRIPTION
1. Allow fully qualified module names: `@world(Foo.Bar.baz, 1)`
2. Correct the printing order of the world macro and module qualifier
3. Add pretty printing for Binding(Partition). Example of the test:

```
julia> GlobalRef(Rebinding, :Foo).binding
Binding Main.Rebinding.Foo
   27497:∞ - undefined binding - guard entry
   0:27496 - constant binding to @world(Main.Rebinding.Foo, 0:27496)

```