### PR TITLE
add recompile comment in --trace-compile in terminal color mode too

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -2560,8 +2560,15 @@ static void record_precompile_statement(jl_method_instance_t *mi, double compila
     if (!jl_has_free_typevars(mi->specTypes)) {
         if (is_recompile && s_precompile == JL_STDERR && jl_options.color != JL_OPTIONS_COLOR_OFF)
             jl_printf(s_precompile, "\e[33m");
-        if (force_trace_compile || jl_options.trace_compile_timing)
-            jl_printf(s_precompile, "#= %6.1f ms =# ", compilation_time / 1e6);
+        if (force_trace_compile || jl_options.trace_compile_timing) {
+            jl_printf(s_precompile, "#= %6.1f ms", compilation_time / 1e6);
+            if (is_recompile) {
+                jl_printf(s_precompile, "*=# ");
+            }
+            else {
+                jl_printf(s_precompile, " =# ");
+            }
+        }
         jl_printf(s_precompile, "precompile(");
         jl_static_show(s_precompile, mi->specTypes);
         jl_printf(s_precompile, ")");

--- a/src/gf.c
+++ b/src/gf.c
@@ -2565,8 +2565,12 @@ static void record_precompile_statement(jl_method_instance_t *mi, double compila
         jl_printf(s_precompile, "precompile(");
         jl_static_show(s_precompile, mi->specTypes);
         jl_printf(s_precompile, ")");
-        if (is_recompile)
-            jl_printf(s_precompile, " # recompile\e[0m");
+        if (is_recompile) {
+            jl_printf(s_precompile, " # recompile");
+            if (s_precompile == JL_STDERR && jl_options.color != JL_OPTIONS_COLOR_OFF) {
+                jl_printf(s_precompile, "\e[0m");
+            }
+        }
         jl_printf(s_precompile, "\n");
         if (s_precompile != JL_STDERR)
             ios_flush(&f_precompile);

--- a/src/gf.c
+++ b/src/gf.c
@@ -2560,15 +2560,8 @@ static void record_precompile_statement(jl_method_instance_t *mi, double compila
     if (!jl_has_free_typevars(mi->specTypes)) {
         if (is_recompile && s_precompile == JL_STDERR && jl_options.color != JL_OPTIONS_COLOR_OFF)
             jl_printf(s_precompile, "\e[33m");
-        if (force_trace_compile || jl_options.trace_compile_timing) {
-            jl_printf(s_precompile, "#= %6.1f ms", compilation_time / 1e6);
-            if (is_recompile) {
-                jl_printf(s_precompile, "*=# ");
-            }
-            else {
-                jl_printf(s_precompile, " =# ");
-            }
-        }
+        if (force_trace_compile || jl_options.trace_compile_timing)
+            jl_printf(s_precompile, "#= %6.1f ms =# ", compilation_time / 1e6);
         jl_printf(s_precompile, "precompile(");
         jl_static_show(s_precompile, mi->specTypes);
         jl_printf(s_precompile, ")");

--- a/src/gf.c
+++ b/src/gf.c
@@ -2565,14 +2565,8 @@ static void record_precompile_statement(jl_method_instance_t *mi, double compila
         jl_printf(s_precompile, "precompile(");
         jl_static_show(s_precompile, mi->specTypes);
         jl_printf(s_precompile, ")");
-        if (is_recompile) {
-            if (s_precompile == JL_STDERR && jl_options.color != JL_OPTIONS_COLOR_OFF) {
-                jl_printf(s_precompile, "\e[0m");
-            }
-            else {
-                jl_printf(s_precompile, " # recompile");
-            }
-        }
+        if (is_recompile)
+            jl_printf(s_precompile, " # recompile\e[0m");
         jl_printf(s_precompile, "\n");
         if (s_precompile != JL_STDERR)
             ios_flush(&f_precompile);


### PR DESCRIPTION
Update: Just adds the comment in color terminal mode too

---

I didn't think adding the `# recompile` text to the end in the repl was a good idea as it increases likelihood of text wrapping.
And the color should be sufficient for local review, but when people copy from a color terminal we lose the recompile info.

So this just adds a zero-length change indicator, for people to look out for.