### PR TITLE
move time_imports and trace_* macros to Base but remain owned by InteractiveUtils

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -630,7 +630,7 @@ macro timed(ex)
 end
 
 # Exported, documented, and tested in InteractiveUtils
-# here so it's possible to time all imports, including InteractiveUtils and its deps
+# here so it's possible to time/trace all imports, including InteractiveUtils and its deps
 macro time_imports(ex)
     quote
         try
@@ -638,6 +638,28 @@ macro time_imports(ex)
             $(esc(ex))
         finally
             Base.Threads.atomic_sub!(Base.TIMING_IMPORTS, 1)
+        end
+    end
+end
+
+macro trace_compile(ex)
+    quote
+        try
+            ccall(:jl_force_trace_compile_timing_enable, Cvoid, ())
+            $(esc(ex))
+        finally
+            ccall(:jl_force_trace_compile_timing_disable, Cvoid, ())
+        end
+    end
+end
+
+macro trace_dispatch(ex)
+    quote
+        try
+            ccall(:jl_force_trace_dispatch_enable, Cvoid, ())
+            $(esc(ex))
+        finally
+            ccall(:jl_force_trace_dispatch_disable, Cvoid, ())
         end
     end
 end

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -628,3 +628,16 @@ macro timed(ex)
         )
     end
 end
+
+# Exported, documented, and tested in InteractiveUtils
+# here so it's possible to time all imports, including InteractiveUtils and its deps
+macro time_imports(ex)
+    quote
+        try
+            Base.Threads.atomic_add!(Base.TIMING_IMPORTS, 1)
+            $(esc(ex))
+        finally
+            Base.Threads.atomic_sub!(Base.TIMING_IMPORTS, 1)
+        end
+    end
+end

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -4,6 +4,10 @@
 
 import Base: typesof, insert!, replace_ref_begin_end!, infer_effects
 
+# defined in Base so it's possible to time all imports, including InteractiveUtils and its deps
+# via. `Base.@time_imports`
+import Base: @time_imports
+
 separate_kwargs(args...; kwargs...) = (args, values(kwargs))
 
 """
@@ -242,17 +246,6 @@ macro code_lowered(ex0...)
     quote
         local results = $thecall
         length(results) == 1 ? results[1] : results
-    end
-end
-
-macro time_imports(ex)
-    quote
-        try
-            Base.Threads.atomic_add!(Base.TIMING_IMPORTS, 1)
-            $(esc(ex))
-        finally
-            Base.Threads.atomic_sub!(Base.TIMING_IMPORTS, 1)
-        end
     end
 end
 

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -5,8 +5,8 @@
 import Base: typesof, insert!, replace_ref_begin_end!, infer_effects
 
 # defined in Base so it's possible to time all imports, including InteractiveUtils and its deps
-# via. `Base.@time_imports`
-import Base: @time_imports
+# via. `Base.@time_imports` etc.
+import Base: @time_imports, @trace_compile, @trace_dispatch
 
 separate_kwargs(args...; kwargs...) = (args, values(kwargs))
 
@@ -246,28 +246,6 @@ macro code_lowered(ex0...)
     quote
         local results = $thecall
         length(results) == 1 ? results[1] : results
-    end
-end
-
-macro trace_compile(ex)
-    quote
-        try
-            ccall(:jl_force_trace_compile_timing_enable, Cvoid, ())
-            $(esc(ex))
-        finally
-            ccall(:jl_force_trace_compile_timing_disable, Cvoid, ())
-        end
-    end
-end
-
-macro trace_dispatch(ex)
-    quote
-        try
-            ccall(:jl_force_trace_dispatch_enable, Cvoid, ())
-            $(esc(ex))
-        finally
-            ccall(:jl_force_trace_dispatch_disable, Cvoid, ())
-        end
     end
 end
 


### PR DESCRIPTION
This way all packages can be timed including InteractiveUtils and its deps (Base64, JuliaSyntaxHighlighting, Markdown, StyledStrings).

With this PR
```
% ./julia --start=no -e "@time Base.@time_imports using REPL"
     41.8 ms  StyledStrings
               ┌ 0.1 ms JuliaSyntaxHighlighting.__init__()
     14.2 ms  JuliaSyntaxHighlighting
      1.0 ms  Base64
               ┌ 0.0 ms Markdown.__init__()
      9.6 ms  Markdown
      2.2 ms  InteractiveUtils
      0.3 ms  Unicode
               ┌ 0.0 ms REPL.REPLCompletions.__init__()
               ├ 0.0 ms REPL.__init__()
     95.7 ms  REPL
  0.225907 seconds (290.95 k allocations: 16.761 MiB)
```

Otherwise
```
% ./julia --start=no -e "using InteractiveUtils; @time @time_imports using REPL"
      0.5 ms  Unicode
               ┌ 0.0 ms REPL.REPLCompletions.__init__()
               ├ 0.1 ms REPL.__init__()
    107.5 ms  REPL
  0.127016 seconds (164.18 k allocations: 9.199 MiB)
```

Also the `@trace_compile` and `@trace_dispatch` macros for the same reason.