### PR TITLE
Fix trampoline warning on x86 as well

### DIFF
--- a/cli/trampolines/trampolines_x86_64.S
+++ b/cli/trampolines/trampolines_x86_64.S
@@ -6,9 +6,9 @@
 #define XX(name) \
 DEBUGINFO(name); \
 .global CNAME(name); \
+CNAME(name)##:; \
 .cfi_startproc; \
 SEH_START1(name); \
-CNAME(name)##:; \
 SEH_START2(); \
     CET_START(); \
     mov CNAMEADDR(name)(%rip),%r11; \


### PR DESCRIPTION
Fix https://github.com/JuliaLang/julia/pull/54634 on x86 as well.