### PR TITLE
Fix fetching parent in symmetric algebra

### DIFF
--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -307,7 +307,9 @@ function applytri(f, A::HermOrSym, B::HermOrSym)
         f(uppertriangular(_conjugation(A)(A.data)), uppertriangular(B.data))
     end
 end
-parentof_applytri(f, args...) = applytri(parent ∘ f, args...)
+_parent_tri(U::UpperOrLowerTriangular) = parent(U)
+_parent_tri(U) = U
+parentof_applytri(f, args...) = _parent_tri(applytri(f, args...))
 
 isdiag(A::HermOrSym) = applytri(isdiag, A)
 

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -1160,4 +1160,11 @@ end
     @test symT-s == Array(symT) - Array(s)
 end
 
+@testset "issue #56283" begin
+    a = 1.0
+    D = Diagonal(randn(10))
+    H = Hermitian(D*D')
+    @test a*H == H
+end
+
 end # module TestSymmetric


### PR DESCRIPTION
We only need the `parent` of the result if it is a triangular matrix. For other structurally triangular matrices, such as `Diagonal`s, we may use these directly in the `Hermitian` constructor.

The operation proceeds as (assuming `H isa Hermitian` with `H.uplo == 'U'`):
```julia
function +(H::Hermitian, H::Hermitian)
    U = uppertriangular(parent(H))
    Ures = U + U
    data = Ures isa UpperTriangular ? parent(Ures) : Ures # this PR
    Hermitian(data, :U)
end
```
This accounts for the fact that `Ures` may not be an `UpperTriangular`, as `uppertriangular` might be specialized by the parent. In such cases we should not extract the parent. Currently, only `Diagonal` specializes `uppertriangular`, so this issue only exists for a `Hermitian` or a `Symmetric` that wraps a `Diagonal`.

Fixes https://github.com/JuliaLang/julia/issues/56283 