### PR TITLE
jitlayers: use std::make_tuple instead of tuple constructor

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -662,7 +662,7 @@ static void jl_emit_codeinst_to_jit(
     int waiting = jl_analyze_workqueue(codeinst, params);
     if (waiting) {
         auto release = std::move(params.tsctx_lock); // unlock again before moving from it
-        incompletemodules.insert(std::pair(codeinst, std::tuple(std::move(params), waiting)));
+        incompletemodules.insert(std::pair(codeinst, std::make_tuple(std::move(params), waiting)));
     }
     else {
         finish_params(result_m.getModuleUnlocked(), params);


### PR DESCRIPTION
this should be safer for the type deduction and fixes a build error for macos on Yggdrasil (https://github.com/JuliaPackaging/Yggdrasil/pull/9660):

```
src/jitlayers.cpp:665:54: error: no viable constructor or deduction guide for deduction of template arguments of 'tuple'
  665 |         incompletemodules.insert(std::pair(codeinst, std::tuple(std::move(params), waiting)));
```
The Yggdrasil environment is a bit special with a rather new clang (version 17) but an old macos sdk and I don't know exactly in which circumstances this triggers. But I think `std::make_tuple` should be more reliable when the tuple types are not specified.

cc: @fingolfin 