### PR TITLE
[REPL] raise default implicit `show` limit to 1MiB

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -484,7 +484,7 @@ function repl_backend_loop(backend::REPLBackend, get_module::Function)
     return nothing
 end
 
-SHOW_MAXIMUM_BYTES::Int = 20480
+SHOW_MAXIMUM_BYTES::Int = 1_048_576
 
 # Limit printing during REPL display
 mutable struct LimitIO{IO_t <: IO} <: IO


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/53959#issuecomment-2426946640

I would like to understand more where these issues are coming from; it would be easy to exempt some types from Base or Core with
```julia
REPL.show_limited(io::IO, mime::MIME, x::SomeType) = show(io, mime, x)
```
but I'm not sure which are causing problems in practice.

But meanwhile I think raising the limit makes sense.