### PR TITLE
Don't try to allocate new binding partitions from static show

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -1848,6 +1848,7 @@ JL_DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, size_t len);
 JL_DLLEXPORT jl_sym_t *jl_get_root_symbol(void);
 JL_DLLEXPORT jl_value_t *jl_get_binding_value(jl_binding_t *b JL_PROPAGATES_ROOT);
 JL_DLLEXPORT jl_value_t *jl_get_binding_value_if_const(jl_binding_t *b JL_PROPAGATES_ROOT);
+JL_DLLEXPORT jl_value_t *jl_get_binding_value_if_resolved_and_const(jl_binding_t *b JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_declare_const_gf(jl_binding_t *b, jl_module_t *mod, jl_sym_t *name);
 JL_DLLEXPORT jl_method_t *jl_method_def(jl_svec_t *argdata, jl_methtable_t *mt, jl_code_info_t *f, jl_module_t *module);
 JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo, size_t world, jl_code_instance_t **cache);

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -661,7 +661,7 @@ static int is_globname_binding(jl_value_t *v, jl_datatype_t *dv) JL_NOTSAFEPOINT
     jl_sym_t *globname = dv->name->mt != NULL ? dv->name->mt->name : NULL;
     if (globname && dv->name->module) {
         jl_binding_t *b = jl_get_module_binding(dv->name->module, globname, 0);
-        jl_value_t *bv = jl_get_binding_value_if_const(b);
+        jl_value_t *bv = jl_get_binding_value_if_resolved_and_const(b);
         // The `||` makes this function work for both function instances and function types.
         if (bv && (bv == v || jl_typeof(bv) == v))
             return 1;


### PR DESCRIPTION
In particular static show is used inside the GC for profiling, which showed up as a segfault on CI, e.g. in
https://buildkite.com/julialang/julia-master/builds/41407#0192b628-47f3-49f9-a081-cd2708eb6121.

GC check didn't catch it because that file is explicitly exempt: https://github.com/JuliaLang/julia/blob/master/src/Makefile#L504