### PR TITLE
Type `Base.is_interactive` as `Bool`

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -30,14 +30,14 @@ exit() = exit(0)
 
 const roottask = current_task()
 
-is_interactive = false
+is_interactive::Bool = false
 
 """
     isinteractive() -> Bool
 
 Determine whether Julia is running an interactive session.
 """
-isinteractive() = (is_interactive::Bool)
+isinteractive() = is_interactive
 
 ## package depots (registries, packages, environments) ##
 


### PR DESCRIPTION
Before, typing `Base.is_interactive = 7` would cause weird internal REPL failures down the line. Now, it throws an InexactError and has no impact.