### PR TITLE
Faster println()

### DIFF
--- a/base/coreio.jl
+++ b/base/coreio.jl
@@ -1,8 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 print(xs...)   = print(stdout, xs...)
-println(xs...) = println(stdout, xs...)
-println(io::IO) = print(io, "\n")  # One less allocation than with '\n'
+println(xs...) = print(stdout, xs..., '\n')  # 2-3 fewer allocations, this way, not calling println 
+println(io::IO) = print(io, "\n")  # One less allocation than with '\n', though ok above
 
 function show end
 function repr end

--- a/base/coreio.jl
+++ b/base/coreio.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 print(xs...)   = print(stdout, xs...)
-println(xs...) = print(stdout, xs..., '\n')  # 2-3 fewer allocations, this way, not calling println 
+println(xs...) = print(stdout, xs..., '\n')  # 2-3 fewer allocations, this way, not calling println
 println(io::IO) = print(io, "\n")  # One less allocation than with '\n', though ok above
 
 function show end

--- a/base/coreio.jl
+++ b/base/coreio.jl
@@ -1,7 +1,13 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+# These forms do not require a stack, unlike splatting:
+print(x) = print(stdout, x)
+print(x1, x2) = print(stdout, x1, x2)
+println(x) = print(stdout, x, "\n")
+println(x1, x2) = print(stdout, x1, x2, "\n")
+
 print(xs...)   = print(stdout, xs...)
-println(xs...) = print(stdout, xs..., '\n')  # 2-3 fewer allocations, this way, not calling println
+println(xs...) = print(stdout, xs..., "\n")  # 2-3 fewer allocations, this way, not calling println
 println(io::IO) = print(io, "\n")  # One less allocation than with '\n', though ok above
 
 function show end

--- a/base/coreio.jl
+++ b/base/coreio.jl
@@ -2,7 +2,7 @@
 
 print(xs...)   = print(stdout, xs...)
 println(xs...) = println(stdout, xs...)
-println(io::IO) = print(io, '\n')
+println(io::IO) = print(io, "\n")  # One less allocation than with '\n'
 
 function show end
 function repr end

--- a/base/coreio.jl
+++ b/base/coreio.jl
@@ -1,14 +1,13 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-# These forms do not require a stack, unlike splatting:
 print(x) = print(stdout, x)
 print(x1, x2) = print(stdout, x1, x2)
 println(x) = print(stdout, x, "\n")
 println(x1, x2) = print(stdout, x1, x2, "\n")
 
 print(xs...)   = print(stdout, xs...)
-println(xs...) = print(stdout, xs..., "\n")  # 2-3 fewer allocations, this way, not calling println
-println(io::IO) = print(io, "\n")  # One less allocation than with '\n', though ok above
+println(xs...) = print(stdout, xs..., "\n")  # fewer allocations than `println(stdout, xs...)`
+println(io::IO) = print(io, "\n")
 
 function show end
 function repr end


### PR DESCRIPTION
Would be nice to backport to 1.11.2 since common enough.