### PR TITLE
Scaling `mul!` for generic `AbstractArray`s

### DIFF
--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -131,53 +131,54 @@ end
 
 
 @testset "array and subarray" begin
-    aa = reshape([1.:6;], (2,3))
-    for a in (aa, view(aa, 1:2, 1:2))
-        am, an = size(a)
-        @testset "Scaling with rmul! and lmul" begin
-            @test rmul!(copy(a), 5.) == a*5
-            @test lmul!(5., copy(a)) == a*5
-            b = randn(2048)
-            subB = view(b, :, :)
-            @test rmul!(copy(b), 5.) == b*5
-            @test rmul!(copy(subB), 5.) == subB*5
-            @test lmul!(Diagonal([1.; 2.]), copy(a)) == a.*[1; 2]
-            @test lmul!(Diagonal([1; 2]), copy(a)) == a.*[1; 2]
-            @test rmul!(copy(a), Diagonal(1.:an)) == a.*Vector(1:an)'
-            @test rmul!(copy(a), Diagonal(1:an)) == a.*Vector(1:an)'
-            @test_throws DimensionMismatch lmul!(Diagonal(Vector{Float64}(undef,am+1)), a)
-            @test_throws DimensionMismatch rmul!(a, Diagonal(Vector{Float64}(undef,an+1)))
-        end
+    for aa in (reshape([1.:6;], (2,3)), fill(float.(rand(Int8,2,2)), 2,3))
+        for a in (aa, view(aa, 1:2, 1:2))
+            am, an = size(a)
+            @testset "Scaling with rmul! and lmul" begin
+                @test rmul!(copy(a), 5.) == a*5
+                @test lmul!(5., copy(a)) == a*5
+                b = randn(2048)
+                subB = view(b, :, :)
+                @test rmul!(copy(b), 5.) == b*5
+                @test rmul!(copy(subB), 5.) == subB*5
+                @test lmul!(Diagonal([1.; 2.]), copy(a)) == a.*[1; 2]
+                @test lmul!(Diagonal([1; 2]), copy(a)) == a.*[1; 2]
+                @test rmul!(copy(a), Diagonal(1.:an)) == a.*Vector(1:an)'
+                @test rmul!(copy(a), Diagonal(1:an)) == a.*Vector(1:an)'
+                @test_throws DimensionMismatch lmul!(Diagonal(Vector{Float64}(undef,am+1)), a)
+                @test_throws DimensionMismatch rmul!(a, Diagonal(Vector{Float64}(undef,an+1)))
+            end
 
-        @testset "Scaling with rdiv! and ldiv!" begin
-            @test rdiv!(copy(a), 5.) == a/5
-            @test ldiv!(5., copy(a)) == a/5
-            @test ldiv!(zero(a), 5., copy(a)) == a/5
-        end
+            @testset "Scaling with rdiv! and ldiv!" begin
+                @test rdiv!(copy(a), 5.) == a/5
+                @test ldiv!(5., copy(a)) == a/5
+                @test ldiv!(zero(a), 5., copy(a)) == a/5
+            end
 
-        @testset "Scaling with 3-argument mul!" begin
-            @test mul!(similar(a), 5., a) == a*5
-            @test mul!(similar(a), a, 5.) == a*5
-            @test mul!(similar(a), Diagonal([1.; 2.]), a) == a.*[1; 2]
-            @test mul!(similar(a), Diagonal([1; 2]), a)   == a.*[1; 2]
-            @test_throws DimensionMismatch mul!(similar(a), Diagonal(Vector{Float64}(undef, am+1)), a)
-            @test_throws DimensionMismatch mul!(Matrix{Float64}(undef, 3, 2), a, Diagonal(Vector{Float64}(undef, an+1)))
-            @test_throws DimensionMismatch mul!(similar(a), a, Diagonal(Vector{Float64}(undef, an+1)))
-            @test mul!(similar(a), a, Diagonal(1.:an)) == a.*Vector(1:an)'
-            @test mul!(similar(a), a, Diagonal(1:an))  == a.*Vector(1:an)'
-        end
+            @testset "Scaling with 3-argument mul!" begin
+                @test mul!(similar(a), 5., a) == a*5
+                @test mul!(similar(a), a, 5.) == a*5
+                @test mul!(similar(a), Diagonal([1.; 2.]), a) == a.*[1; 2]
+                @test mul!(similar(a), Diagonal([1; 2]), a)   == a.*[1; 2]
+                @test_throws DimensionMismatch mul!(similar(a), Diagonal(Vector{Float64}(undef, am+1)), a)
+                @test_throws DimensionMismatch mul!(Matrix{Float64}(undef, 3, 2), a, Diagonal(Vector{Float64}(undef, an+1)))
+                @test_throws DimensionMismatch mul!(similar(a), a, Diagonal(Vector{Float64}(undef, an+1)))
+                @test mul!(similar(a), a, Diagonal(1.:an)) == a.*Vector(1:an)'
+                @test mul!(similar(a), a, Diagonal(1:an))  == a.*Vector(1:an)'
+            end
 
-        @testset "Scaling with 5-argument mul!" begin
-            @test mul!(copy(a), 5., a, 10, 100) == a*150
-            @test mul!(copy(a), a, 5., 10, 100) == a*150
-            @test mul!(vec(copy(a)), 5., a, 10, 100) == vec(a*150)
-            @test mul!(vec(copy(a)), a, 5., 10, 100) == vec(a*150)
-            @test_throws DimensionMismatch mul!([vec(copy(a)); 0], 5., a, 10, 100)
-            @test_throws DimensionMismatch mul!([vec(copy(a)); 0], a, 5., 10, 100)
-            @test mul!(copy(a), Diagonal([1.; 2.]), a, 10, 100) == 10a.*[1; 2] .+ 100a
-            @test mul!(copy(a), Diagonal([1; 2]), a, 10, 100)   == 10a.*[1; 2] .+ 100a
-            @test mul!(copy(a), a, Diagonal(1.:an), 10, 100) == 10a.*Vector(1:an)' .+ 100a
-            @test mul!(copy(a), a, Diagonal(1:an), 10, 100)  == 10a.*Vector(1:an)' .+ 100a
+            @testset "Scaling with 5-argument mul!" begin
+                @test mul!(copy(a), 5., a, 10, 100) == a*150
+                @test mul!(copy(a), a, 5., 10, 100) == a*150
+                @test mul!(vec(copy(a)), 5., a, 10, 100) == vec(a*150)
+                @test mul!(vec(copy(a)), a, 5., 10, 100) == vec(a*150)
+                @test_throws DimensionMismatch mul!([vec(copy(a)); 0], 5., a, 10, 100)
+                @test_throws DimensionMismatch mul!([vec(copy(a)); 0], a, 5., 10, 100)
+                @test mul!(copy(a), Diagonal([1.; 2.]), a, 10, 100) == 10a.*[1; 2] .+ 100a
+                @test mul!(copy(a), Diagonal([1; 2]), a, 10, 100)   == 10a.*[1; 2] .+ 100a
+                @test mul!(copy(a), a, Diagonal(1.:an), 10, 100) == 10a.*Vector(1:an)' .+ 100a
+                @test mul!(copy(a), a, Diagonal(1:an), 10, 100)  == 10a.*Vector(1:an)' .+ 100a
+            end
         end
     end
 end


### PR DESCRIPTION
This improves performance in the scaling `mul!` for `StridedArray`s by using loops instead of broadcasting.
```julia
julia> using LinearAlgebra

julia> A = zeros(200,200); C = similar(A);

julia> @btime mul!($C, $A, 1, 2, 2);
  19.180 μs (0 allocations: 0 bytes) # nightly v"1.12.0-DEV.1479"
  11.361 μs (0 allocations: 0 bytes) # This PR
```
The latency is reduced as well for the same reason.
```julia
julia> using LinearAlgebra

julia> A = zeros(2,2); C = similar(A);

julia> @time mul!(C, A, 1, 2, 2);
  0.203034 seconds (522.94 k allocations: 27.011 MiB, 14.95% gc time, 99.97% compilation time) # nightly
  0.034713 seconds (59.16 k allocations: 2.962 MiB, 99.91% compilation time) # This PR
```
Thirdly, I've replaced the `.*ₛ` calls by explicit branches. This fixes the following:
```julia
julia> A = [zeros(2), zeros(2)]; C = similar(A);

julia> mul!(C, A, 1)
ERROR: MethodError: no method matching +(::Vector{Float64}, ::Bool)
```
After this,
```julia
julia> mul!(C, A, 1)
2-element Vector{Vector{Float64}}:
 [0.0, 0.0]
 [0.0, 0.0]
```
Also, I've added `@stable_muladdmul` annotations to the `generic_mul!` call, but moved it within the loop to narrow its scope. This doesn't increase the latency, while making the call type-stable.

```julia
julia> D = Diagonal(1:2); C = similar(D);

julia> @time mul!(C, D, 1, 2, 2);
  0.248385 seconds (898.18 k allocations: 47.027 MiB, 12.30% gc time, 99.96% compilation time) # nightly
  0.249940 seconds (919.80 k allocations: 49.128 MiB, 11.36% gc time, 99.99% compilation time) # This PR
```