### PR TITLE
inference: don't allow `SSAValue`s in assignment lhs

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -3648,7 +3648,7 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState, nextr
                         changes = StateUpdate(lhs, VarState(rt, false))
                     elseif isa(lhs, GlobalRef)
                         handle_global_assignment!(interp, frame, lhs, rt)
-                    elseif !isa(lhs, SSAValue)
+                    else
                         merge_effects!(interp, frame, EFFECTS_UNKNOWN)
                     end
                 end


### PR DESCRIPTION
In `InferenceState` the lhs of a `:=` expression should only contain `GlobalRef` or `SlotNumber` and no other IR elements. Currently when `SSAValue` appears in `lhs`, the invalid assignment effect is somehow ignored, but this is incorrect anyway, so this commit removes that check. Since `SSAValue` should not appear in `lhs` in the first place, this is not a significant change though.