### PR TITLE
inference: don't add backdge when `applicable` inferred to return `Bool`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -3008,14 +3008,16 @@ function abstract_applicable(interp::AbstractInterpreter, argtypes::Vector{Any},
         else
             rt = Const(true) # has applicable matches
         end
-        for i in 1:napplicable
-            match = applicable[i]::MethodMatch
-            edge = specialize_method(match)::MethodInstance
-            add_backedge!(sv, edge)
+        if rt !== Bool
+            for i in 1:napplicable
+                match = applicable[i]::MethodMatch
+                edge = specialize_method(match)
+                add_backedge!(sv, edge)
+            end
+            # also need an edge to the method table in case something gets
+            # added that did not intersect with any existing method
+            add_uncovered_edges!(sv, matches, atype)
         end
-        # also need an edge to the method table in case something gets
-        # added that did not intersect with any existing method
-        add_uncovered_edges!(sv, matches, atype)
     end
     return Future(CallMeta(rt, Union{}, EFFECTS_TOTAL, NoCallInfo()))
 end


### PR DESCRIPTION
~~Even if the return value of `applicable(f, args...)` is initially inferred as `Const(true)`, when a new method is added to `f` then it may cause new method match ambiguities, requiring the call to return return `false` at the next invocation. To handle such cases, it is necessary to always add a method table backedge in the inference of `applicable`.~~

Also just as a minor backedge reduction optimization, this commit avoids adding backedges when `applicable` is inferred to return `::Bool`.