### PR TITLE
Fix generate_precompile statement grouping & avoid defining new func

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -136,60 +136,58 @@ for match = Base._methods(+, (Int, Int), -1, Base.get_world_counter())
     m = match.method
     delete!(push!(Set{Method}(), m), m)
     copy(Core.Compiler.retrieve_code_info(Core.Compiler.specialize_method(match), typemax(UInt)))
-
-    empty!(Set())
-    push!(push!(Set{Union{GlobalRef,Symbol}}(), :two), GlobalRef(Base, :two))
-    (setindex!(Dict{String,Base.PkgId}(), Base.PkgId(Base), "file.jl"))["file.jl"]
-    (setindex!(Dict{Symbol,Vector{Int}}(), [1], :two))[:two]
-    (setindex!(Dict{Base.PkgId,String}(), "file.jl", Base.PkgId(Base)))[Base.PkgId(Base)]
-    (setindex!(Dict{Union{GlobalRef,Symbol}, Vector{Int}}(), [1], :two))[:two]
-    (setindex!(IdDict{Type, Union{Missing, Vector{Tuple{LineNumberNode, Expr}}}}(), missing, Int))[Int]
-    Dict{Symbol, Union{Nothing, Bool, Symbol}}(:one => false)[:one]
-    Dict(Base => [:(1+1)])[Base]
-    Dict(:one => [1])[:one]
-    Dict("abc" => Set())["abc"]
-    pushfirst!([], sum)
-    get(Base.pkgorigins, Base.PkgId(Base), nothing)
-    sort!([1,2,3])
-    unique!([1,2,3])
-    cumsum([1,2,3])
-    append!(Int[], BitSet())
-    isempty(BitSet())
-    delete!(BitSet([1,2]), 3)
-    deleteat!(Int32[1,2,3], [1,3])
-    deleteat!(Any[1,2,3], [1,3])
-    Core.svec(1, 2) == Core.svec(3, 4)
-    any(t->t[1].line > 1, [(LineNumberNode(2,:none), :(1+1))])
-
-    # Code loading uses this
-    sortperm(mtime.(readdir(".")), rev=true)
-    # JLLWrappers uses these
-    Dict{Base.UUID,Set{String}}()[Base.UUID("692b3bcd-3c85-4b1f-b108-f13ce0eb3210")] = Set{String}()
-    get!(Set{String}, Dict{Base.UUID,Set{String}}(), Base.UUID("692b3bcd-3c85-4b1f-b108-f13ce0eb3210"))
-    eachindex(IndexLinear(), Expr[])
-    push!(Expr[], Expr(:return, false))
-    vcat(String[], String[])
-    k, v = (:hello => nothing)
-    Base.print_time_imports_report(Base)
-    Base.print_time_imports_report_init(Base)
-
-    # Preferences uses these
-    get(Dict{String,Any}(), "missing", nothing)
-    delete!(Dict{String,Any}(), "missing")
-    for (k, v) in Dict{String,Any}()
-        println(k)
-    end
-
-    # interactive startup uses this
-    write(IOBuffer(), "")
-
-    # Not critical, but helps hide unrelated compilation from @time when using --trace-compile.
-    f55729() = Base.Experimental.@force_compile
-    @time @eval f55729()
-    @time @eval f55729()
-
     break   # only actually need to do this once
 end
+empty!(Set())
+push!(push!(Set{Union{GlobalRef,Symbol}}(), :two), GlobalRef(Base, :two))
+(setindex!(Dict{String,Base.PkgId}(), Base.PkgId(Base), "file.jl"))["file.jl"]
+(setindex!(Dict{Symbol,Vector{Int}}(), [1], :two))[:two]
+(setindex!(Dict{Base.PkgId,String}(), "file.jl", Base.PkgId(Base)))[Base.PkgId(Base)]
+(setindex!(Dict{Union{GlobalRef,Symbol}, Vector{Int}}(), [1], :two))[:two]
+(setindex!(IdDict{Type, Union{Missing, Vector{Tuple{LineNumberNode, Expr}}}}(), missing, Int))[Int]
+Dict{Symbol, Union{Nothing, Bool, Symbol}}(:one => false)[:one]
+Dict(Base => [:(1+1)])[Base]
+Dict(:one => [1])[:one]
+Dict("abc" => Set())["abc"]
+pushfirst!([], sum)
+get(Base.pkgorigins, Base.PkgId(Base), nothing)
+sort!([1,2,3])
+unique!([1,2,3])
+cumsum([1,2,3])
+append!(Int[], BitSet())
+isempty(BitSet())
+delete!(BitSet([1,2]), 3)
+deleteat!(Int32[1,2,3], [1,3])
+deleteat!(Any[1,2,3], [1,3])
+Core.svec(1, 2) == Core.svec(3, 4)
+any(t->t[1].line > 1, [(LineNumberNode(2,:none), :(1+1))])
+
+# Code loading uses this
+sortperm(mtime.(readdir(".")), rev=true)
+# JLLWrappers uses these
+Dict{Base.UUID,Set{String}}()[Base.UUID("692b3bcd-3c85-4b1f-b108-f13ce0eb3210")] = Set{String}()
+get!(Set{String}, Dict{Base.UUID,Set{String}}(), Base.UUID("692b3bcd-3c85-4b1f-b108-f13ce0eb3210"))
+eachindex(IndexLinear(), Expr[])
+push!(Expr[], Expr(:return, false))
+vcat(String[], String[])
+k, v = (:hello => nothing)
+Base.print_time_imports_report(Base)
+Base.print_time_imports_report_init(Base)
+
+# Preferences uses these
+get(Dict{String,Any}(), "missing", nothing)
+delete!(Dict{String,Any}(), "missing")
+for (k, v) in Dict{String,Any}()
+    println(k)
+end
+
+# interactive startup uses this
+write(IOBuffer(), "")
+
+# Not critical, but helps hide unrelated compilation from @time when using --trace-compile.
+f55729() = Base.Experimental.@force_compile
+@time @eval f55729()
+@time @eval f55729()
 """
 
 julia_exepath() = joinpath(Sys.BINDIR, Base.julia_exename())

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -184,10 +184,8 @@ end
 # interactive startup uses this
 write(IOBuffer(), "")
 
-# Not critical, but helps hide unrelated compilation from @time when using --trace-compile.
-f55729() = Base.Experimental.@force_compile
-@time @eval f55729()
-@time @eval f55729()
+# precompile @time report generation and printing
+@time @eval Base.Experimental.@force_compile
 """
 
 julia_exepath() = joinpath(Sys.BINDIR, Base.julia_exename())


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/pull/56227#discussion_r1810900522

Also, I don't think these are supposed to be inside the for loop which is specific to `match` (which only runs once anyway).

