### PR TITLE
Get rid of --lisp prompt

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -286,7 +286,6 @@
     XX(jl_is_unary_and_binary_operator) \
     XX(jl_is_unary_operator) \
     XX(jl_lazy_load_and_lookup) \
-    XX(jl_lisp_prompt) \
     XX(jl_load) \
     XX(jl_load_) \
     XX(jl_load_and_lookup) \

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -994,9 +994,6 @@ static void lock_low32(void)
     return;
 }
 
-// Actual definition in `ast.c`
-void jl_lisp_prompt(void);
-
 #ifdef _OS_LINUX_
 static void rr_detach_teleport(void) {
 #define RR_CALL_BASE 1000
@@ -1030,11 +1027,6 @@ JL_DLLEXPORT int jl_repl_entrypoint(int argc, char *argv[])
     lock_low32();
 
     libsupport_init();
-    int lisp_prompt = (argc >= 2 && strcmp((char*)argv[1],"--lisp") == 0);
-    if (lisp_prompt) {
-        memmove(&argv[1], &argv[2], (argc-2)*sizeof(void*));
-        argc--;
-    }
     char **new_argv = argv;
     jl_parse_opts(&argc, (char***)&new_argv);
 
@@ -1051,11 +1043,6 @@ JL_DLLEXPORT int jl_repl_entrypoint(int argc, char *argv[])
     }
 
     julia_init(jl_options.image_file_specified ? JL_IMAGE_CWD : JL_IMAGE_JULIA_HOME);
-    if (lisp_prompt) {
-        jl_current_task->world_age = jl_get_world_counter();
-        jl_lisp_prompt();
-        return 0;
-    }
     int ret = true_main(argc, (char**)new_argv);
     jl_atexit_hook(ret);
     return ret;

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1033,13 +1033,6 @@ let exename = Base.julia_cmd()
     @test errors_not_signals(`$exename --startup-file=false`)
 end
 
-# Make sure `julia --lisp` doesn't break
-run(pipeline(devnull, `$(joinpath(Sys.BINDIR, Base.julia_exename())) --lisp`, devnull))
-
-# Test that `julia [some other option] --lisp` is disallowed
-@test readchomperrors(`$(joinpath(Sys.BINDIR, Base.julia_exename())) -Cnative --lisp`) ==
-    (false, "", "ERROR: --lisp must be specified as the first argument")
-
 # --sysimage-native-code={yes|no}
 let exename = `$(Base.julia_cmd()) --startup-file=no`
     @test readchomp(`$exename --sysimage-native-code=yes -E


### PR DESCRIPTION
It shouldn't be exported (seems not needed, was always undocumented). I'll look into what more can go, but will be a separate PR likely.