### PR TITLE
Put `jl_gc_new_weakref` in a header file again

### DIFF
--- a/src/gc-common.h
+++ b/src/gc-common.h
@@ -192,6 +192,6 @@ extern int gc_logging_enabled;
 // Allocates a new weak-reference, assigns its value and increments Julia allocation
 // counters. If thread-local allocators are used, then this function should allocate in the
 // thread-local allocator of the current thread.
-JL_DLLEXPORT struct _jl_weakref_t *jl_gc_new_weakref(struct _jl_value_t *value);
+JL_DLLEXPORT jl_weakref_t *jl_gc_new_weakref(jl_value_t *value);
 
 #endif // JL_GC_COMMON_H

--- a/src/gc-common.h
+++ b/src/gc-common.h
@@ -185,4 +185,13 @@ extern jl_ptls_t* gc_all_tls_states;
 
 extern int gc_logging_enabled;
 
+// =========================================================================== //
+// Misc
+// =========================================================================== //
+
+// Allocates a new weak-reference, assigns its value and increments Julia allocation
+// counters. If thread-local allocators are used, then this function should allocate in the
+// thread-local allocator of the current thread.
+JL_DLLEXPORT struct _jl_weakref_t *jl_gc_new_weakref(struct _jl_value_t *value);
+
 #endif // JL_GC_COMMON_H


### PR DESCRIPTION
The gcext implementation in [gap](https://github.com/gap-system/gap/)/[GAP.jl](https://github.com/oscar-system/GAP.jl) uses `jl_gc_new_weakref`. Since https://github.com/JuliaLang/julia/pull/55608 got merged, this symbol is no longer mentioned in any header file, and thus the compilation of gap fails. This PR puts it back into a header file, but now in `gc-common.h` (instead of `gc-interface.h`), since https://github.com/JuliaLang/julia/pull/55608 moved the implementation to `gc-common.c`.

We are aware of the alternative function `jl_gc_new_weakref_th` (that still is in a header after https://github.com/JuliaLang/julia/pull/55608). However, it was not present in any header file before https://github.com/JuliaLang/julia/pull/55256, even though it was already marked as `JL_DLLEXPORT` well before that.

In short, without this PR we are not able to adapt the code to a way that works both with julia 1.11 and nightly.

@fingolfin I get locally still the same error as we can observe in CI. I suppose that this needs a rebuild of `libjulia` with this PR here included to work, right? 

ping @d-netto @gbaraldi