### PR TITLE
Add a developer documentation section to the `LinearAlgebra` docs

### DIFF
--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -891,6 +891,12 @@ LinearAlgebra.LAPACK.trsyl!
 LinearAlgebra.LAPACK.hseqr!
 ```
 
+## Developer Documentation
+
+```@docs
+LinearAlgebra.matprod_dest
+```
+
 ```@meta
 DocTestSetup = nothing
 ```


### PR DESCRIPTION
Functions that are meant for package developers may go here, instead of the main section that is primarily for users.