### PR TITLE
loading: clean up more concurrency issues

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -657,8 +657,8 @@ function __init__()
     init_active_project()
     append!(empty!(_sysimage_modules), keys(loaded_modules))
     empty!(loaded_precompiles) # If we load a packageimage when building the image this might not be empty
-    for (mod, key) in module_keys
-        push!(get!(Vector{Module}, loaded_precompiles, key), mod)
+    for mod in loaded_modules_order
+        push!(get!(Vector{Module}, loaded_precompiles, PkgId(mod)), mod)
     end
     if haskey(ENV, "JULIA_MAX_NUM_PRECOMPILE_FILES")
         MAX_NUM_PRECOMPILE_FILES[] = parse(Int, ENV["JULIA_MAX_NUM_PRECOMPILE_FILES"])

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -35,8 +35,8 @@ precompile(Base.unsafe_string, (Ptr{UInt8},))
 precompile(Base.unsafe_string, (Ptr{Int8},))
 
 # loading.jl
-precompile(Base.__require_prelocked, (Base.PkgId, Nothing))
-precompile(Base._require, (Base.PkgId, Nothing))
+precompile(Base.__require, (Module, Symbol))
+precompile(Base.__require, (Base.PkgId,))
 precompile(Base.indexed_iterate, (Pair{Symbol, Union{Nothing, String}}, Int))
 precompile(Base.indexed_iterate, (Pair{Symbol, Union{Nothing, String}}, Int, Int))
 precompile(Tuple{typeof(Base.Threads.atomic_add!), Base.Threads.Atomic{Int}, Int})

--- a/stdlib/REPL/src/Pkg_beforeload.jl
+++ b/stdlib/REPL/src/Pkg_beforeload.jl
@@ -1,17 +1,7 @@
 ## Pkg stuff needed before Pkg has loaded
 
 const Pkg_pkgid = Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg")
-
-function load_pkg()
-    REPLExt = Base.require_stdlib(Pkg_pkgid, "REPLExt")
-    @lock Base.require_lock begin
-        # require_stdlib does not guarantee that the `__init__` of the package is done when loading is done async
-        # but we need to wait for the repl mode to be set up
-        lock = get(Base.package_locks, Base.PkgId(REPLExt), nothing)
-        lock !== nothing && wait(lock[2])
-    end
-    return REPLExt
-end
+load_pkg() = Base.require_stdlib(Pkg_pkgid, "REPLExt")
 
 ## Below here copied/tweaked from Pkg Types.jl so that the dummy Pkg prompt
 # can populate the env correctly before Pkg loads


### PR DESCRIPTION
Guarantee that `__init__` runs before `using` returns. Could be slightly breaking for people that do crazy things inside `__init__`, but just don't do that. Since extensions then probably load after `__init__` (or at least, run their `__init__` after), this is a partial step towards changing things so that extensions are guaranteed to load if using all of their triggers before the corresponding `using` returns

Fixes #55556

~~Currently blocked on fixing a Pkg bug: https://github.com/JuliaLang/Pkg.jl/pull/4057~~