### PR TITLE
Revert "Some small follow-ups to stackless compiler"

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2681,7 +2681,7 @@ function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo, sv::Infere
     end
     si = StmtInfo(!unused)
     call = abstract_call(interp, arginfo, si, sv)::Future
-    Future{Any}(call, interp, sv) do call, interp, sv
+    Future{Nothing}(call, interp, sv) do call, interp, sv
         # this only is needed for the side-effect, sequenced before any task tries to consume the return value,
         # which this will do even without returning this Future
         sv.stmt_info[sv.currpc] = call.info
@@ -2833,7 +2833,7 @@ function abstract_eval_new_opaque_closure(interp::AbstractInterpreter, e::Expr, 
                 pushfirst!(argtypes, rt.env)
                 callinfo = abstract_call_opaque_closure(interp, rt,
                     ArgInfo(nothing, argtypes), StmtInfo(true), sv, #=check=#false)::Future
-                Future{Any}(callinfo, interp, sv) do callinfo, interp, sv
+                Future{Nothing}(callinfo, interp, sv) do callinfo, interp, sv
                     sv.stmt_info[sv.currpc] = OpaqueClosureCreateInfo(callinfo)
                     nothing
                 end
@@ -3775,7 +3775,6 @@ function typeinf(interp::AbstractInterpreter, frame::InferenceState)
     takeprev = 0
     while takenext >= frame.frameid
         callee = takenext == 0 ? frame : callstack[takenext]::InferenceState
-        interp = callee.interp
         if !isempty(callstack)
             if length(callstack) - frame.frameid >= minwarn
                 topmethod = callstack[1].linfo

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -1128,35 +1128,24 @@ end
 """
     Future{T}
 
-Assign-once delayed return value for a value of type `T`, similar to RefValue{T}.
-Can be constructed in one of three ways:
+Delayed return value for a value of type `T`, similar to RefValue{T}, but
+explicitly represents completed as a `Bool` rather than as `isdefined`.
+Set once with `f[] = v` and accessed with `f[]` afterwards.
 
-1. With an immediate as `Future{T}(val)`
-2. As an assign-once storage location with `Future{T}()`. Assigned (once) using `f[] = val`.
-3. As a delayed computation with `Future{T}(callback, dep, interp, sv)` to have
-   `sv` arrange to call the `callback` with the result of `dep` when it is ready.
-
-Use `isready` to check if the value is ready, and `getindex` to get the value.
+Can also be constructed with the `completed` flag value and a closure to
+produce `x`, as well as the additional arguments to avoid always capturing the
+same couple of values.
 """
 struct Future{T}
     later::Union{Nothing,RefValue{T}}
     now::Union{Nothing,T}
-    function Future{T}() where {T}
-        later = RefValue{T}()
-        @assert !isassigned(later) "Future{T}() is not allowed for inlinealloc T"
-        new{T}(later, nothing)
-    end
+    Future{T}() where {T} = new{T}(RefValue{T}(), nothing)
     Future{T}(x) where {T} = new{T}(nothing, x)
     Future(x::T) where {T} = new{T}(nothing, x)
 end
-isready(f::Future) = f.later === nothing || isassigned(f.later)
+isready(f::Future) = f.later === nothing
 getindex(f::Future{T}) where {T} = (later = f.later; later === nothing ? f.now::T : later[])
-function setindex!(f::Future, v)
-    later = something(f.later)
-    @assert !isassigned(later)
-    later[] = v
-    return f
-end
+setindex!(f::Future, v) = something(f.later)[] = v
 convert(::Type{Future{T}}, x) where {T} = Future{T}(x) # support return type conversion
 convert(::Type{Future{T}}, x::Future) where {T} = x::Future{T}
 function Future{T}(f, immediate::Bool, interp::AbstractInterpreter, sv::AbsIntState) where {T}
@@ -1187,6 +1176,7 @@ function Future{T}(f, prev::Future{S}, interp::AbstractInterpreter, sv::AbsIntSt
     end
 end
 
+
 """
     doworkloop(args...)
 
@@ -1199,16 +1189,12 @@ Each task will be run repeatedly when returning `false`, until it returns `true`
 function doworkloop(interp::AbstractInterpreter, sv::AbsIntState)
     tasks = sv.tasks
     prev = length(tasks)
-    prevcallstack = length(sv.callstack)
     prev == 0 && return false
     task = pop!(tasks)
     completed = task(interp, sv)
     tasks = sv.tasks # allow dropping gc root over the previous call
     completed isa Bool || throw(TypeError(:return, "", Bool, task)) # print the task on failure as part of the error message, instead of just "@ workloop:line"
-    if !completed
-        @assert (length(tasks) >= prev || length(sv.callstack) > prevcallstack) "Task did not complete, but also did not create any child tasks"
-        push!(tasks, task)
-    end
+    completed || push!(tasks, task)
     # efficient post-order visitor: items pushed are executed in reverse post order such
     # that later items are executed before earlier ones, but are fully executed
     # (including any dependencies scheduled by them) before going on to the next item

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -52,7 +52,7 @@ end
 function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo, irsv::IRInterpretationState)
     si = StmtInfo(true) # TODO better job here?
     call = abstract_call(interp, arginfo, si, irsv)::Future
-    Future{Any}(call, interp, irsv) do call, interp, irsv
+    Future{Nothing}(call, interp, irsv) do call, interp, irsv
         irsv.ir.stmts[irsv.curridx][:info] = call.info
         nothing
     end


### PR DESCRIPTION
Reverts JuliaLang/julia#55972. This appears to cause a 5-10% regression in performance.