### PR TITLE
Change some hardcoded loop ranges to axes in dense linalg functions

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -18,14 +18,14 @@ function isone(A::AbstractMatrix)
     m, n = size(A)
     m != n && return false # only square matrices can satisfy x == one(x)
     if sizeof(A) < ISONE_CUTOFF
-        _isone_triacheck(A, m)
+        _isone_triacheck(A)
     else
-        _isone_cachefriendly(A, m)
+        _isone_cachefriendly(A)
     end
 end
 
-@inline function _isone_triacheck(A::AbstractMatrix, m::Int)
-    @inbounds for i in 1:m, j in i:m
+@inline function _isone_triacheck(A::AbstractMatrix)
+    @inbounds for i in axes(A,2), j in axes(A,1)
         if i == j
             isone(A[i,i]) || return false
         else
@@ -36,8 +36,8 @@ end
 end
 
 # Inner loop over rows to be friendly to the CPU cache
-@inline function _isone_cachefriendly(A::AbstractMatrix, m::Int)
-    @inbounds for i in 1:m, j in 1:m
+@inline function _isone_cachefriendly(A::AbstractMatrix)
+    @inbounds for i in axes(A,2), j in axes(A,1)
         if i == j
             isone(A[i,i]) || return false
         else
@@ -198,7 +198,7 @@ function fillband!(A::AbstractMatrix{T}, x, l, u) where T
     require_one_based_indexing(A)
     m, n = size(A)
     xT = convert(T, x)
-    for j in 1:n
+    for j in axes(A,2)
         for i in max(1,j-u):min(m,j-l)
             @inbounds A[i, j] = xT
         end
@@ -553,7 +553,7 @@ function (^)(A::AbstractMatrix{T}, p::Real) where T
     if isdiag(A)
         TT = promote_op(^, T, typeof(p))
         retmat = copymutable_oftype(A, TT)
-        for i in 1:n
+        for i in axes(retmat,1)
             retmat[i, i] = retmat[i, i] ^ p
         end
         return retmat
@@ -792,10 +792,10 @@ end
 
 ## Swap rows i and j and columns i and j in X
 function rcswap!(i::Integer, j::Integer, X::AbstractMatrix{<:Number})
-    for k = 1:size(X,1)
+    for k = axes(X,1)
         X[k,i], X[k,j] = X[k,j], X[k,i]
     end
-    for k = 1:size(X,2)
+    for k = axes(X,2)
         X[i,k], X[j,k] = X[j,k], X[i,k]
     end
 end


### PR DESCRIPTION
These should be safer in general, and are also easier to reason about.