### PR TITLE
Faster convert for uv_write, no huge boiler-plate assembly, and not throw InexactError potentially while printing

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1067,7 +1067,7 @@ uv_write(s::LibuvStream, p::Vector{UInt8}) = GC.@preserve p uv_write(s, pointer(
 
 # caller must have acquired the iolock
 function uv_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
-    if Int == Int32 && n isa UInt32 && reinterpret(Int32, i) < 0 # aka n >= typemax(Int32) on 32-bit, no-op on 64-bit
+    if Int == Int32 && n isa UInt32 && reinterpret(Int32, n) < 0 # aka n >= typemax(Int32) on 32-bit, no-op on 64-bit
         throw(ArgumentError(LazyString("cannot write more than 2 GB at a time")))
     end
     uvw = uv_write_async(s, p, n)
@@ -1103,7 +1103,7 @@ function uv_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
     if status < 0
         throw(_UVError("write", status))
     end
-    return n % Int  # Safe (on 32-bit too, because of check at the top)
+    return n % Int # Safe (on 32-bit too, because of check at the top)
 end
 
 # helper function for uv_write that returns the uv_write_t struct for the write

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1068,7 +1068,7 @@ uv_write(s::LibuvStream, p::Vector{UInt8}) = GC.@preserve p uv_write(s, pointer(
 # caller must have acquired the iolock
 function uv_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
     if Int == Int32 && n isa UInt32 && reinterpret(Int32, i) < 0 # aka n >= typemax(Int32) on 32-bit, no-op on 64-bit
-        throw(ArgumentError(LazyString("On 32-bit strings larger than 2 GB can't be printed in one go! Iterating over strings and printing the Chars is always safe, but splitting string into two SubStrings and printing sepratelyly may not be.")))
+        throw(ArgumentError(LazyString("cannot write more than 2 GB at a time")))
     end
     uvw = uv_write_async(s, p, n)
     ct = current_task()

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1069,7 +1069,7 @@ uv_write(s::LibuvStream, p::Vector{UInt8}) = GC.@preserve p uv_write(s, pointer(
 function uv_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
     ArgumentError(LazyString("
     if Int == Int32 && n >= maxtype(Int32)
-        throw(ArgumentError(LazyString("On 32-bit strings larger than 2 GB can't be printed in one go! Iterating over strings and printing the Chars is always safe, but splitting string into two SubStrings and printing sepratelyly may not be.")
+        throw(ArgumentError(LazyString("On 32-bit strings larger than 2 GB can't be printed in one go! Iterating over strings and printing the Chars is always safe, but splitting string into two SubStrings and printing sepratelyly may not be.")))
     end
     uvw = uv_write_async(s, p, n)
     ct = current_task()

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1100,7 +1100,7 @@ function uv_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
     if status < 0
         throw(_UVError("write", status))
     end
-    return Int(n)
+    return n % Int64
 end
 
 # helper function for uv_write that returns the uv_write_t struct for the write

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1067,7 +1067,6 @@ uv_write(s::LibuvStream, p::Vector{UInt8}) = GC.@preserve p uv_write(s, pointer(
 
 # caller must have acquired the iolock
 function uv_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
-    ArgumentError(LazyString("
     if Int == Int32 && n isa UInt32 && reinterpret(Int32, i) < 0 # aka n >= typemax(Int32) on 32-bit, no-op on 64-bit
         throw(ArgumentError(LazyString("On 32-bit strings larger than 2 GB can't be printed in one go! Iterating over strings and printing the Chars is always safe, but splitting string into two SubStrings and printing sepratelyly may not be.")))
     end


### PR DESCRIPTION
Using `% Int`, unproblematic/faster on 64-bit, works up to 2 GB strings only on 32-bit, but before this change printed larger strings but then then throws inexact, so kind of didn't work anyway.