### PR TITLE
Support `eltype`s without zero in `_rmul_or_fill!`

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -163,12 +163,8 @@ end
 
 @inline function _rmul_or_fill!(C::AbstractArray, beta::Number)
     if !isempty(C)
-        if iszero(beta)
-            if haszero(eltype(C))
-                fill!(C, zero(eltype(C)))
-            else
-                C .= zero.(C)
-            end
+        if iszero(beta) && haszero(eltype(C))
+            fill!(C, zero(eltype(C)))
         else
             rmul!(C, beta)
         end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -162,13 +162,16 @@ julia> C
 end
 
 @inline function _rmul_or_fill!(C::AbstractArray, beta::Number)
-    if isempty(C)
-        return C
-    end
-    if iszero(beta)
-        fill!(C, zero(eltype(C)))
-    else
-        rmul!(C, beta)
+    if !isempty(C)
+        if iszero(beta)
+            if haszero(eltype(C))
+                fill!(C, zero(eltype(C)))
+            else
+                C .= zero.(C)
+            end
+        else
+            rmul!(C, beta)
+        end
     end
     return C
 end

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -25,6 +25,12 @@ Random.seed!(123)
 
 n = 5 # should be odd
 
+@testset "_rmul_or_fill!" begin
+    D = Diagonal(fill(ones(2,2), 4))
+    LinearAlgebra._rmul_or_fill!(D, 0)
+    @test iszero(D)
+end
+
 @testset for elty in (Int, Rational{BigInt}, Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFloat})
     # In the long run, these tests should step through Strang's
     #  axiomatic definition of determinants.


### PR DESCRIPTION
This uses `rmul!` instead of `fill!(C, zero(eltype(C)))` if `eltype(C)` doesn't have a zero. This is useful for block matrices.
The following works after this:
```julia
julia> D = Diagonal(fill(ones(2,2), 2))
2×2 Diagonal{Matrix{Float64}, Vector{Matrix{Float64}}}:
 [1.0 1.0; 1.0 1.0]          ⋅         
         ⋅           [1.0 1.0; 1.0 1.0]

julia> LinearAlgebra._rmul_or_fill!(D, 0)
2×2 Diagonal{Matrix{Float64}, Vector{Matrix{Float64}}}:
 [0.0 0.0; 0.0 0.0]          ⋅         
         ⋅           [0.0 0.0; 0.0 0.0]
```