### PR TITLE
Include `gc-common.h` in `julia.h`

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -72,6 +72,7 @@ typedef struct _jl_tls_states_t *jl_ptls_t;
 #include "uv.h"
 #endif
 #include "gc-interface.h"
+#include "gc-common.h"
 #include "julia_atomics.h"
 #include "julia_threads.h"
 #include "julia_assert.h"


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/pull/56319#issuecomment-2441460187.

I think this makes sense from a broader perspective, as `gc-common.h` contains pieces that were moved out of `gc-interface.h` and that libraries compiling against `julia.h` should still be able to use.

ping @gbaraldi @d-netto @fingolfin 