### PR TITLE
[backports-release-1.11] Allow ext → ext dependency if triggers are a strict superset

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,10 @@ Language changes
   omit the default user depot ([#51448]).
 * Precompilation cache files are now relocatable and their validity is now verified through
   a content hash of their source files instead of their `mtime` ([#49866]).
+* Extensions may now depend on other extensions, if their triggers include all of the triggers
+  of any extension they wish to depend upon (+ at least one other trigger). In contrast to prior
+  versions, ext-to-ext dependencies that don't meet this requirement are now blocked during pre-
+  compilation to prevent extension cycles [#55557].
 
 Compiler/Runtime improvements
 -----------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,10 +37,10 @@ Language changes
   omit the default user depot ([#51448]).
 * Precompilation cache files are now relocatable and their validity is now verified through
   a content hash of their source files instead of their `mtime` ([#49866]).
-* Extensions may now depend on other extensions, if their triggers include all of the triggers
-  of any extension they wish to depend upon (+ at least one other trigger). In contrast to prior
-  versions, ext-to-ext dependencies that don't meet this requirement are now blocked during pre-
-  compilation to prevent extension cycles [#55557].
+* Extensions may now depend on other extensions, if their triggers include all triggers of any
+  extension they wish to depend upon (+ at least one other trigger). Ext-to-ext dependencies
+  that don't meet this requirement are now blocked from using `Base.get_extension` during pre-
+  compilation, to prevent extension cycles [#55557].
 
 Compiler/Runtime improvements
 -----------------------------

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2543,7 +2543,17 @@ function _require(pkg::PkgId, env=nothing)
                 # double-check the search now that we have lock
                 m = _require_search_from_serialized(pkg, path, UInt128(0), true)
                 m isa Module && return m
-                return compilecache(pkg, path; reasons)
+                triggers = get(EXT_PRIMED, pkg, nothing)
+                loadable_exts = nothing
+                if triggers !== nothing # extension
+                    loadable_exts = PkgId[]
+                    for (ext′, triggers′) in EXT_PRIMED
+                        if triggers′ ⊊ triggers
+                            push!(loadable_exts, ext′)
+                        end
+                    end
+                end
+                return compilecache(pkg, path; reasons, loadable_exts)
             end
             loaded isa Module && return loaded
             if isnothing(loaded) # maybe_cachefile_lock returns nothing if it had to wait for another process

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -826,15 +826,11 @@ function _precompilepkgs(pkgs::Vector{String},
                                 Base.with_logger(Base.NullLogger()) do
                                     # The false here means we ignore loaded modules, so precompile for a fresh session
                                     keep_loaded_modules = false
-                                    if haskey(exts, pkg)
-                                        # any extension in our direct dependencies is one we have a right to load
-                                        loadable_exts = filter((dep)->haskey(exts, dep), depsmap[pkg])
-                                        Base.compilecache(pkg, sourcepath, std_pipe, std_pipe, keep_loaded_modules;
-                                                          flags, cacheflags, loadable_exts)
-                                    else
-                                        Base.compilecache(pkg, sourcepath, std_pipe, std_pipe, keep_loaded_modules;
-                                                          flags, cacheflags)
-                                    end
+                                    # for extensions, any extension in our direct dependencies is one we have a right to load
+                                    # for packages, we may load any extension (all possible triggers are accounted for above)
+                                    loadable_exts = haskey(exts, pkg) ? filter((dep)->haskey(exts, dep), depsmap[pkg]) : nothing
+                                    Base.compilecache(pkg, sourcepath, std_pipe, std_pipe, keep_loaded_modules;
+                                                      flags, cacheflags, loadable_exts)
                                 end
                             end
                             if ret isa Base.PrecompilableError

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -419,6 +419,7 @@ function _precompilepkgs(pkgs::Vector{String},
         return name
     end
 
+    triggers = Dict{Base.PkgId,Vector{Base.PkgId}}()
     for (dep, deps) in env.deps
         pkg = Base.PkgId(dep, env.names[dep])
         Base.in_sysimage(pkg) && continue
@@ -427,25 +428,22 @@ function _precompilepkgs(pkgs::Vector{String},
         # add any extensions
         pkg_exts = Dict{Base.PkgId, Vector{Base.PkgId}}()
         for (ext_name, extdep_uuids) in env.extensions[dep]
-            ext_deps = Base.PkgId[]
-            push!(ext_deps, pkg) # depends on parent package
+            ext_uuid = Base.uuid5(pkg.uuid, ext_name)
+            ext = Base.PkgId(ext_uuid, ext_name)
+            triggers[ext] = Base.PkgId[pkg] # depends on parent package
             all_extdeps_available = true
             for extdep_uuid in extdep_uuids
                 extdep_name = env.names[extdep_uuid]
                 if extdep_uuid in keys(env.deps)
-                    push!(ext_deps, Base.PkgId(extdep_uuid, extdep_name))
+                    push!(triggers[ext], Base.PkgId(extdep_uuid, extdep_name))
                 else
                     all_extdeps_available = false
                     break
                 end
             end
             all_extdeps_available || continue
-            ext_uuid = Base.uuid5(pkg.uuid, ext_name)
-            ext = Base.PkgId(ext_uuid, ext_name)
-            filter!(!Base.in_sysimage, ext_deps)
-            depsmap[ext] = ext_deps
             exts[ext] = pkg.name
-            pkg_exts[ext] = ext_deps
+            pkg_exts[ext] = depsmap[ext] = filter(!Base.in_sysimage, triggers[ext])
         end
         if !isempty(pkg_exts)
             pkg_exts_map[pkg] = collect(keys(pkg_exts))
@@ -461,6 +459,16 @@ function _precompilepkgs(pkgs::Vector{String},
     append!(direct_deps, keys(filter(d->last(d) in keys(env.project_deps), exts)))
 
     @debug "precompile: deps collected"
+
+    # An extension effectively depends on another extension if it has a strict superset of its triggers
+    for ext_a in keys(exts)
+        for ext_b in keys(exts)
+            if triggers[ext_a] ⊋ triggers[ext_b]
+                push!(depsmap[ext_a], ext_b)
+            end
+        end
+    end
+
     # this loop must be run after the full depsmap has been populated
     for (pkg, pkg_exts) in pkg_exts_map
         # find any packages that depend on the extension(s)'s deps and replace those deps in their deps list with the extension(s),
@@ -817,7 +825,16 @@ function _precompilepkgs(pkgs::Vector{String},
                             t = @elapsed ret = precompile_pkgs_maybe_cachefile_lock(io, print_lock, fancyprint, pkg_config, pkgspidlocked, hascolor) do
                                 Base.with_logger(Base.NullLogger()) do
                                     # The false here means we ignore loaded modules, so precompile for a fresh session
-                                    Base.compilecache(pkg, sourcepath, std_pipe, std_pipe, false; flags, cacheflags, isext = haskey(exts, pkg))
+                                    keep_loaded_modules = false
+                                    if haskey(exts, pkg)
+                                        # any extension in our direct dependencies is one we have a right to load
+                                        loadable_exts = filter((dep)->haskey(exts, dep), depsmap[pkg])
+                                        Base.compilecache(pkg, sourcepath, std_pipe, std_pipe, keep_loaded_modules;
+                                                          flags, cacheflags, loadable_exts)
+                                    else
+                                        Base.compilecache(pkg, sourcepath, std_pipe, std_pipe, keep_loaded_modules;
+                                                          flags, cacheflags)
+                                    end
                                 end
                             end
                             if ret isa Base.PrecompilableError

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1158,6 +1158,74 @@ end
         cmd = addenv(cmd, "JULIA_LOAD_PATH" => proj)
         @test occursin("Hello Cycles!", String(read(cmd)))
 
+        # Extension-to-extension dependencies
+
+        mktempdir() do depot # Parallel pre-compilation
+            code = """
+            Base.disable_parallel_precompile = false
+            using ExtToExtDependency
+            Base.get_extension(ExtToExtDependency, :ExtA) isa Module || error("expected extension to load")
+            Base.get_extension(ExtToExtDependency, :ExtAB) isa Module || error("expected extension to load")
+            ExtToExtDependency.greet()
+            """
+            proj = joinpath(@__DIR__, "project", "Extensions", "ExtToExtDependency")
+            cmd =  `$(Base.julia_cmd()) --startup-file=no -e $code`
+            cmd = addenv(cmd,
+                "JULIA_LOAD_PATH" => proj,
+                "JULIA_DEPOT_PATH" => depot * Base.Filesystem.pathsep(),
+            )
+            @test occursin("Hello ext-to-ext!", String(read(cmd)))
+        end
+        mktempdir() do depot # Serial pre-compilation
+            code = """
+            Base.disable_parallel_precompile = true
+            using ExtToExtDependency
+            Base.get_extension(ExtToExtDependency, :ExtA) isa Module || error("expected extension to load")
+            Base.get_extension(ExtToExtDependency, :ExtAB) isa Module || error("expected extension to load")
+            ExtToExtDependency.greet()
+            """
+            proj = joinpath(@__DIR__, "project", "Extensions", "ExtToExtDependency")
+            cmd =  `$(Base.julia_cmd()) --startup-file=no -e $code`
+            cmd = addenv(cmd,
+                "JULIA_LOAD_PATH" => proj,
+                "JULIA_DEPOT_PATH" => depot * Base.Filesystem.pathsep(),
+            )
+            @test occursin("Hello ext-to-ext!", String(read(cmd)))
+        end
+
+        mktempdir() do depot # Parallel pre-compilation
+            code = """
+            Base.disable_parallel_precompile = false
+            using CrossPackageExtToExtDependency
+            Base.get_extension(CrossPackageExtToExtDependency.CyclicExtensions, :ExtA) isa Module || error("expected extension to load")
+            Base.get_extension(CrossPackageExtToExtDependency, :ExtAB) isa Module || error("expected extension to load")
+            CrossPackageExtToExtDependency.greet()
+            """
+            proj = joinpath(@__DIR__, "project", "Extensions", "CrossPackageExtToExtDependency")
+            cmd =  `$(Base.julia_cmd()) --startup-file=no -e $code`
+            cmd = addenv(cmd,
+                "JULIA_LOAD_PATH" => proj,
+                "JULIA_DEPOT_PATH" => depot * Base.Filesystem.pathsep(),
+            )
+            @test occursin("Hello x-package ext-to-ext!", String(read(cmd)))
+        end
+        mktempdir() do depot # Serial pre-compilation
+            code = """
+            Base.disable_parallel_precompile = true
+            using CrossPackageExtToExtDependency
+            Base.get_extension(CrossPackageExtToExtDependency.CyclicExtensions, :ExtA) isa Module || error("expected extension to load")
+            Base.get_extension(CrossPackageExtToExtDependency, :ExtAB) isa Module || error("expected extension to load")
+            CrossPackageExtToExtDependency.greet()
+            """
+            proj = joinpath(@__DIR__, "project", "Extensions", "CrossPackageExtToExtDependency")
+            cmd =  `$(Base.julia_cmd()) --startup-file=no -e $code`
+            cmd = addenv(cmd,
+                "JULIA_LOAD_PATH" => proj,
+                "JULIA_DEPOT_PATH" => depot * Base.Filesystem.pathsep(),
+            )
+            @test occursin("Hello x-package ext-to-ext!", String(read(cmd)))
+        end
+
     finally
         try
             rm(depot_path, force=true, recursive=true)

--- a/test/project/Extensions/CrossPackageExtToExtDependency/Manifest.toml
+++ b/test/project/Extensions/CrossPackageExtToExtDependency/Manifest.toml
@@ -1,18 +1,24 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.4"
+julia_version = "1.11.1"
 manifest_format = "2.0"
-project_hash = "ec25ff8df3a5e2212a173c3de2c7d716cc47cd36"
+project_hash = "dc35c2cf8c6b82fb5b9624c9713c2df34ca30499"
+
+[[deps.CyclicExtensions]]
+deps = ["ExtDep"]
+path = "../CyclicExtensions"
+uuid = "17d4f0df-b55c-4714-ac4b-55fa23f7355c"
+version = "0.1.0"
+weakdeps = ["SomePackage"]
+
+    [deps.CyclicExtensions.extensions]
+    ExtA = ["SomePackage"]
+    ExtB = ["SomePackage"]
 
 [[deps.ExtDep]]
-deps = ["SomePackage", "SomeOtherPackage"]
+deps = ["SomeOtherPackage", "SomePackage"]
 path = "../ExtDep.jl"
 uuid = "fa069be4-f60b-4d4c-8b95-f8008775090c"
-version = "0.1.0"
-
-[[deps.ExtDep2]]
-path = "../ExtDep2"
-uuid = "55982ee5-2ad5-4c40-8cfe-5e9e1b01500d"
 version = "0.1.0"
 
 [[deps.SomeOtherPackage]]

--- a/test/project/Extensions/CrossPackageExtToExtDependency/Project.toml
+++ b/test/project/Extensions/CrossPackageExtToExtDependency/Project.toml
@@ -1,0 +1,12 @@
+name = "CrossPackageExtToExtDependency"
+uuid = "30f07f2e-c47e-40db-93a2-cbc4d1b301cc"
+version = "0.1.0"
+
+[deps]
+CyclicExtensions = "17d4f0df-b55c-4714-ac4b-55fa23f7355c"
+
+[weakdeps]
+SomePackage = "678608ae-7bb3-42c7-98b1-82102067a3d8"
+
+[extensions]
+ExtAB = ["CyclicExtensions", "SomePackage"]

--- a/test/project/Extensions/CrossPackageExtToExtDependency/ext/ExtAB.jl
+++ b/test/project/Extensions/CrossPackageExtToExtDependency/ext/ExtAB.jl
@@ -1,0 +1,12 @@
+module ExtAB
+
+using CrossPackageExtToExtDependency
+using SomePackage
+using CyclicExtensions
+
+const ExtA = Base.get_extension(CyclicExtensions, :ExtA)
+if !(ExtA isa Module)
+    error("expected extension to load")
+end
+
+end

--- a/test/project/Extensions/CrossPackageExtToExtDependency/src/CrossPackageExtToExtDependency.jl
+++ b/test/project/Extensions/CrossPackageExtToExtDependency/src/CrossPackageExtToExtDependency.jl
@@ -1,0 +1,7 @@
+module CrossPackageExtToExtDependency
+
+using CyclicExtensions
+
+greet() = print("Hello x-package ext-to-ext!")
+
+end # module CrossPackageExtToTextDependency

--- a/test/project/Extensions/EnvWithDeps/Manifest.toml
+++ b/test/project/Extensions/EnvWithDeps/Manifest.toml
@@ -5,7 +5,7 @@ manifest_format = "2.0"
 project_hash = "ec25ff8df3a5e2212a173c3de2c7d716cc47cd36"
 
 [[deps.ExtDep]]
-deps = ["SomePackage"]
+deps = ["SomePackage", "SomeOtherPackage"]
 path = "../ExtDep.jl"
 uuid = "fa069be4-f60b-4d4c-8b95-f8008775090c"
 version = "0.1.0"
@@ -13,6 +13,11 @@ version = "0.1.0"
 [[deps.ExtDep2]]
 path = "../ExtDep2"
 uuid = "55982ee5-2ad5-4c40-8cfe-5e9e1b01500d"
+version = "0.1.0"
+
+[[deps.SomeOtherPackage]]
+path = "../SomeOtherPackage"
+uuid = "178f68a2-4498-45ee-a775-452b36359b63"
 version = "0.1.0"
 
 [[deps.SomePackage]]

--- a/test/project/Extensions/EnvWithHasExtensions/Manifest.toml
+++ b/test/project/Extensions/EnvWithHasExtensions/Manifest.toml
@@ -5,7 +5,7 @@ manifest_format = "2.0"
 project_hash = "a4c480cfa7da9610333d5c42623bf746bd286c5f"
 
 [[deps.ExtDep]]
-deps = ["SomePackage"]
+deps = ["SomePackage", "SomeOtherPackage"]
 path = "../ExtDep.jl"
 uuid = "fa069be4-f60b-4d4c-8b95-f8008775090c"
 version = "0.1.0"
@@ -24,6 +24,11 @@ version = "0.1.0"
     ExtDep = "fa069be4-f60b-4d4c-8b95-f8008775090c"
     ExtDep2 = "55982ee5-2ad5-4c40-8cfe-5e9e1b01500d"
     LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[deps.SomeOtherPackage]]
+path = "../SomeOtherPackage"
+uuid = "178f68a2-4498-45ee-a775-452b36359b63"
+version = "0.1.0"
 
 [[deps.SomePackage]]
 path = "../SomePackage"

--- a/test/project/Extensions/EnvWithHasExtensionsv2/Manifest.toml
+++ b/test/project/Extensions/EnvWithHasExtensionsv2/Manifest.toml
@@ -5,7 +5,7 @@ manifest_format = "2.0"
 project_hash = "caa716752e6dff3d77c3de929ebbb5d2024d04ef"
 
 [[deps.ExtDep]]
-deps = ["SomePackage"]
+deps = ["SomePackage", "SomeOtherPackage"]
 path = "../ExtDep.jl"
 uuid = "fa069be4-f60b-4d4c-8b95-f8008775090c"
 version = "0.1.0"
@@ -18,6 +18,11 @@ weakdeps = ["ExtDep"]
 
     [deps.HasExtensions.extensions]
     Extension2 = "ExtDep"
+
+[[deps.SomeOtherPackage]]
+path = "../SomeOtherPackage"
+uuid = "178f68a2-4498-45ee-a775-452b36359b63"
+version = "0.1.0"
 
 [[deps.SomePackage]]
 path = "../SomePackage"

--- a/test/project/Extensions/ExtDep.jl/Project.toml
+++ b/test/project/Extensions/ExtDep.jl/Project.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 
 [deps]
 SomePackage = "678608ae-7bb3-42c7-98b1-82102067a3d8"
+SomeOtherPackage = "178f68a2-4498-45ee-a775-452b36359b63"

--- a/test/project/Extensions/ExtDep.jl/src/ExtDep.jl
+++ b/test/project/Extensions/ExtDep.jl/src/ExtDep.jl
@@ -2,6 +2,7 @@ module ExtDep
 
 # loading this package makes the check for loading extensions trigger
 # which tests #47921
+using SomeOtherPackage
 using SomePackage
 
 struct ExtDepStruct end

--- a/test/project/Extensions/ExtToExtDependency/Manifest.toml
+++ b/test/project/Extensions/ExtToExtDependency/Manifest.toml
@@ -1,18 +1,13 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.4"
+julia_version = "1.11.1"
 manifest_format = "2.0"
-project_hash = "ec25ff8df3a5e2212a173c3de2c7d716cc47cd36"
+project_hash = "90b427e837c654fabb1434527ea698dabad46d29"
 
 [[deps.ExtDep]]
-deps = ["SomePackage", "SomeOtherPackage"]
+deps = ["SomeOtherPackage", "SomePackage"]
 path = "../ExtDep.jl"
 uuid = "fa069be4-f60b-4d4c-8b95-f8008775090c"
-version = "0.1.0"
-
-[[deps.ExtDep2]]
-path = "../ExtDep2"
-uuid = "55982ee5-2ad5-4c40-8cfe-5e9e1b01500d"
 version = "0.1.0"
 
 [[deps.SomeOtherPackage]]

--- a/test/project/Extensions/ExtToExtDependency/Project.toml
+++ b/test/project/Extensions/ExtToExtDependency/Project.toml
@@ -1,0 +1,14 @@
+name = "ExtToExtDependency"
+uuid = "594ddb71-72fb-4cfe-9471-775d48a5b70b"
+version = "0.1.0"
+
+[deps]
+ExtDep = "fa069be4-f60b-4d4c-8b95-f8008775090c"
+
+[weakdeps]
+SomeOtherPackage = "178f68a2-4498-45ee-a775-452b36359b63"
+SomePackage = "678608ae-7bb3-42c7-98b1-82102067a3d8"
+
+[extensions]
+ExtA = ["SomePackage"]
+ExtAB = ["SomePackage", "SomeOtherPackage"]

--- a/test/project/Extensions/ExtToExtDependency/ext/ExtA.jl
+++ b/test/project/Extensions/ExtToExtDependency/ext/ExtA.jl
@@ -1,0 +1,6 @@
+module ExtA
+
+using ExtToExtDependency
+using SomePackage
+
+end

--- a/test/project/Extensions/ExtToExtDependency/ext/ExtAB.jl
+++ b/test/project/Extensions/ExtToExtDependency/ext/ExtAB.jl
@@ -1,0 +1,12 @@
+module ExtAB
+
+using ExtToExtDependency
+using SomePackage
+using SomeOtherPackage
+
+const ExtA = Base.get_extension(ExtToExtDependency, :ExtA)
+if !(ExtA isa Module)
+    error("expected extension to load")
+end
+
+end

--- a/test/project/Extensions/ExtToExtDependency/src/ExtToExtDependency.jl
+++ b/test/project/Extensions/ExtToExtDependency/src/ExtToExtDependency.jl
@@ -1,0 +1,7 @@
+module ExtToExtDependency
+
+using ExtDep
+
+greet() = print("Hello ext-to-ext!")
+
+end # module ExtToExtDependency

--- a/test/project/Extensions/HasDepWithExtensions.jl/Manifest.toml
+++ b/test/project/Extensions/HasDepWithExtensions.jl/Manifest.toml
@@ -5,7 +5,7 @@ manifest_format = "2.0"
 project_hash = "4e196b07f2ee7adc48ac9d528d42b3cf3737c7a0"
 
 [[deps.ExtDep]]
-deps = ["SomePackage"]
+deps = ["SomePackage", "SomeOtherPackage"]
 path = "../ExtDep.jl"
 uuid = "fa069be4-f60b-4d4c-8b95-f8008775090c"
 version = "0.1.0"
@@ -36,6 +36,11 @@ version = "0.1.0"
     ExtDep = "fa069be4-f60b-4d4c-8b95-f8008775090c"
     ExtDep2 = "55982ee5-2ad5-4c40-8cfe-5e9e1b01500d"
     LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[deps.SomeOtherPackage]]
+path = "../SomeOtherPackage"
+uuid = "178f68a2-4498-45ee-a775-452b36359b63"
+version = "0.1.0"
 
 [[deps.SomePackage]]
 path = "../SomePackage"

--- a/test/project/Extensions/SomeOtherPackage/Project.toml
+++ b/test/project/Extensions/SomeOtherPackage/Project.toml
@@ -1,0 +1,4 @@
+name = "SomeOtherPackage"
+uuid = "178f68a2-4498-45ee-a775-452b36359b63"
+authors = ["Cody Tapscott <topolarity@tapscott.me>"]
+version = "0.1.0"

--- a/test/project/Extensions/SomeOtherPackage/src/SomeOtherPackage.jl
+++ b/test/project/Extensions/SomeOtherPackage/src/SomeOtherPackage.jl
@@ -1,0 +1,5 @@
+module SomeOtherPackage
+
+greet() = print("Hello World!")
+
+end # module SomeOtherPackage


### PR DESCRIPTION
This is an effort at a proper workaround (feature?) to resolve https://github.com/JuliaLang/julia/issues/56204.

For example:
```toml
[extensions]
PlottingExt = "Plots"
StatisticsPlottingExt = ["Plots", "Statistics"]
```

Here `StatisticsPlottingExt` is allowed to depend on `PlottingExt` This provides a way to declare `ext → ext` dependencies while still avoiding any extension cycles. The same trick can also be used to make an extension in one package depend on an extension provided in another.

We'll also need to land JuliaLang/julia#49891, so that we guarantee these load in the right order.