### PR TITLE
fix a forgotten rename `readuntil`  -> `copyuntil`

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1028,7 +1028,7 @@ function readavailable(this::LibuvStream)
     return bytes
 end
 
-function readuntil(x::LibuvStream, c::UInt8; keep::Bool=false)
+function copyuntil(out::IO, x::LibuvStream, c::UInt8; keep::Bool=false)
     iolock_begin()
     buf = x.buffer
     @assert buf.seekable == false
@@ -1058,9 +1058,9 @@ function readuntil(x::LibuvStream, c::UInt8; keep::Bool=false)
             end
         end
     end
-    bytes = readuntil(buf, c, keep=keep)
+    copyuntil(out, buf, c; keep)
     iolock_end()
-    return bytes
+    return out
 end
 
 uv_write(s::LibuvStream, p::Vector{UInt8}) = GC.@preserve p uv_write(s, pointer(p), UInt(sizeof(p)))


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/56352, with the repro in that issue:

```
Master:
  1.114874 seconds (13.01 M allocations: 539.592 MiB, 3.80% gc time)

After:
   0.369492 seconds (12.99 M allocations: 485.031 MiB, 10.73% gc time)

1.10:
    0.341114 seconds (8.36 M allocations: 454.242 MiB, 2.69% gc time)
```