### PR TITLE
Add dims check to triangular mul

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -548,7 +548,6 @@ for (T, UT) in ((:UpperTriangular, :UnitUpperTriangular), (:LowerTriangular, :Un
 end
 @inline function _copyto!(A::UpperOrUnitUpperTriangular, B::UnitUpperTriangular)
     @boundscheck checkbounds(A, axes(B)...)
-    n = size(B,1)
     B2 = Base.unalias(A, B)
     Ap = parent(A)
     B2p = parent(B2)
@@ -564,7 +563,6 @@ end
 end
 @inline function _copyto!(A::LowerOrUnitLowerTriangular, B::UnitLowerTriangular)
     @boundscheck checkbounds(A, axes(B)...)
-    n = size(B,1)
     B2 = Base.unalias(A, B)
     Ap = parent(A)
     B2p = parent(B2)
@@ -608,10 +606,10 @@ end
     @boundscheck checkbounds(dest, axes(U)...)
     isunit = U isa UnitUpperTriangular
     for col in axes(dest,2)
-        for row in 1:col-isunit
+        for row in firstindex(dest,1):col-isunit
             @inbounds dest[row,col] = U.data[row,col]
         end
-        for row in col+!isunit:size(U,1)
+        for row in col+!isunit:lastindex(dest,1)
             @inbounds dest[row,col] = U[row,col]
         end
     end
@@ -621,10 +619,10 @@ end
     @boundscheck checkbounds(dest, axes(L)...)
     isunit = L isa UnitLowerTriangular
     for col in axes(dest,2)
-        for row in 1:col-!isunit
+        for row in firstindex(dest,1):col-!isunit
             @inbounds dest[row,col] = L[row,col]
         end
-        for row in col+isunit:size(L,1)
+        for row in col+isunit:lastindex(dest,1)
             @inbounds dest[row,col] = L.data[row,col]
         end
     end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -350,8 +350,7 @@ Base.@constprop :aggressive function istril(A::LowerTriangular, k::Integer=0)
 end
 @inline function _istril(A::LowerTriangular, k)
     P = parent(A)
-    m = size(A, 1)
-    for j in max(1, k + 2):lastindex(P,2)
+    for j in max(firstindex(P,2), k + 2):lastindex(P,2)
         all(iszero, @view(P[j:min(j - k - 1, end), j])) || return false
     end
     return true
@@ -363,7 +362,7 @@ end
 @inline function _istriu(A::UpperTriangular, k)
     P = parent(A)
     m = size(A, 1)
-    for j in firstindex(P,2):min(m, m + k - 1)
+    for j in firstindex(P,2):min(m + k - 1, lastindex(P,2))
         all(iszero, @view(P[max(begin, j - k + 1):j, j])) || return false
     end
     return true


### PR DESCRIPTION
This adds a dimension check to triangular matrix multiplication methods. While such checks already exist in the individual branches (occasionally within `BLAS` methods), having these earlier would permit certain optimizations, as we are assured that the axes are compatible. This potentially duplicates the checks, but this is unlikely to be a concern given how cheap the checks are.

I've also reused the `check_A_mul_B!_sizes` function that is defined in `bidiag.jl`, instead of hard-coding the checks.

Further, I've replaced some hard-coded loop ranges by the corresponding `axes` and `first/lastindex` calls. These are identical under the 1-based indexing assumption, but the `axes` variants are easier to read and reason about.