### PR TITLE
Inline `wrap` in triangular `generic_matmatmul`

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -622,6 +622,16 @@ Base.@constprop :aggressive function wrap(A::AbstractVecOrMat, tA::AbstractChar)
     return B::AbstractVecOrMat
 end
 
+struct StaticChar{C} <: AbstractChar end
+StaticChar(x::AbstractChar) = StaticChar{x}()
+Base.Char(::StaticChar{C}) where {C} = Char(C)
+Base.codepoint(::StaticChar{C}) where {C} = Base.codepoint(C)
+StaticChar{C}(x::UInt32) where {C} = Char(x) == Char(C) ? StaticChar{C}() : throw(ArgumentError(lazy"invalid argument $x"))
+
+wrap(A::AbstractVecOrMat, ::StaticChar{'N'}) = A
+wrap(A::AbstractVecOrMat, ::StaticChar{'T'}) = transpose(A)
+wrap(A::AbstractVecOrMat, ::StaticChar{'C'}) = adjoint(A)
+
 _unwrap(A::AbstractVecOrMat) = A
 
 ## convenience methods

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -622,16 +622,6 @@ Base.@constprop :aggressive function wrap(A::AbstractVecOrMat, tA::AbstractChar)
     return B::AbstractVecOrMat
 end
 
-struct StaticChar{C} <: AbstractChar end
-StaticChar(x::AbstractChar) = StaticChar{x}()
-Base.Char(::StaticChar{C}) where {C} = Char(C)
-Base.codepoint(::StaticChar{C}) where {C} = Base.codepoint(C)
-StaticChar{C}(x::UInt32) where {C} = Char(x) == Char(C) ? StaticChar{C}() : throw(ArgumentError(lazy"invalid argument $x"))
-
-wrap(A::AbstractVecOrMat, ::StaticChar{'N'}) = A
-wrap(A::AbstractVecOrMat, ::StaticChar{'T'}) = transpose(A)
-wrap(A::AbstractVecOrMat, ::StaticChar{'C'}) = adjoint(A)
-
 _unwrap(A::AbstractVecOrMat) = A
 
 ## convenience methods

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -523,6 +523,8 @@ Base.@constprop :aggressive function _symm_hemm_generic!(C, tA, tB, A, B, alpha,
     _generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), alpha, beta)
 end
 
+generic_matmatmul!(C, A, B, alpha, beta) = generic_matmatmul!(C, wrapper_char(A), wrapper_char(B), A, B, alpha, beta)
+
 # legacy method
 Base.@constprop :aggressive generic_matmatmul!(C::StridedMatrix{T}, tA, tB, A::StridedVecOrMat{T}, B::StridedVecOrMat{T},
         _add::MulAddMul = MulAddMul()) where {T<:BlasFloat} =
@@ -969,7 +971,7 @@ end
 # aggressive const prop makes mixed eltype mul!(C, A, B) invoke _generic_matmatmul! directly
 # legacy method
 Base.@constprop :aggressive generic_matmatmul!(C::AbstractVecOrMat, tA, tB, A::AbstractVecOrMat, B::AbstractVecOrMat, _add::MulAddMul = MulAddMul()) =
-    _generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), _add.alpha, _add.beta)
+    generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
 Base.@constprop :aggressive generic_matmatmul!(C::AbstractVecOrMat, tA, tB, A::AbstractVecOrMat, B::AbstractVecOrMat, alpha::Number, beta::Number) =
     _generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), alpha, beta)
 

--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -120,6 +120,11 @@ _mul!(C::AbstractMatrix, A::AbstractTriangular, B::BandedMatrix, alpha::Number, 
 _mul!(C::AbstractMatrix, A::BandedMatrix, B::AbstractTriangular, alpha::Number, beta::Number) =
     @stable_muladdmul _mul!(C, A, B, MulAddMul(alpha, beta))
 
+generic_matmatmul!(C::StridedMatrix, A::HermOrSym{<:Any, <:StridedMatrix}, B::UpperOrLowerTriangular{<:Any, <:StridedMatrix}, alpha, beta) =
+    _generic_matmatmul!(C, A, B, alpha, beta)
+generic_matmatmul!(C::StridedMatrix, A::UpperOrLowerTriangular{<:Any, <:StridedMatrix}, B::HermOrSym{<:Any, <:StridedMatrix}, alpha, beta) =
+    _generic_matmatmul!(C, A, B, alpha, beta)
+
 function *(H::UpperHessenberg, B::Bidiagonal)
     T = promote_op(matprod, eltype(H), eltype(B))
     A = mul!(similar(H, T, size(H)), H, B)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -1078,10 +1078,17 @@ for (TA, TB) in ((:AbstractTriangular, :AbstractMatrix),
         if isone(alpha) && iszero(beta)
             return _trimul!(C, A, B)
         else
-            return generic_matmatmul!(C, StaticChar('N'), StaticChar('N'), A, B, alpha, beta)
+            return generic_matmatmul!(C, A, B, alpha, beta)
         end
     end
 end
+generic_matmatmul!(C::StridedMatrix, A::StridedMatrix, B::UpperOrLowerTriangular{<:Any, <:StridedMatrix}, alpha, beta) =
+    _generic_matmatmul!(C, A, B, alpha, beta)
+generic_matmatmul!(C::StridedMatrix, A::UpperOrLowerTriangular{<:Any, <:StridedMatrix}, B::StridedMatrix, alpha, beta) =
+    _generic_matmatmul!(C, A, B, alpha, beta)
+generic_matmatmul!(C::StridedMatrix, A::UpperOrLowerTriangular{<:Any, <:StridedMatrix},
+        B::UpperOrLowerTriangular{<:Any, <:StridedMatrix}, alpha, beta) =
+    _generic_matmatmul!(C, A, B, alpha, beta)
 
 ldiv!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = _ldiv!(C, A, B)
 # generic fallback for AbstractTriangular, directs to 2-arg [l/r]div!

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -1078,7 +1078,7 @@ for (TA, TB) in ((:AbstractTriangular, :AbstractMatrix),
         if isone(alpha) && iszero(beta)
             return _trimul!(C, A, B)
         else
-            return _generic_matmatmul!(C, A, B, alpha, beta)
+            return generic_matmatmul!(C, StaticChar('N'), StaticChar('N'), A, B, alpha, beta)
         end
     end
 end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -1078,7 +1078,7 @@ for (TA, TB) in ((:AbstractTriangular, :AbstractMatrix),
         if isone(alpha) && iszero(beta)
             return _trimul!(C, A, B)
         else
-            return generic_matmatmul!(C, 'N', 'N', A, B, alpha, beta)
+            return _generic_matmatmul!(C, A, B, alpha, beta)
         end
     end
 end


### PR DESCRIPTION
Currently, `generic_matmatmul!` wraps the argument matrices and calls `_generic_matmatmul!`:
https://github.com/JuliaLang/julia/blob/db6e95e20095cc41307dd6b80aa66320e98cb64b/stdlib/LinearAlgebra/src/matmul.jl#L973-L974
This PR avoids the constant-propagation latency in `wrap` by forwarding some common combination of matrix types directly to `_generic_matmatmul!`. This uses the fact that `wrap(A, 'N') === A`.
```julia
julia> using LinearAlgebra

julia> U = UpperTriangular(rand(Int,2,2)); S = Symmetric(rand(Int,2,2));

julia> @time U * S;
  0.250291 seconds (1.09 M allocations: 57.887 MiB, 10.13% gc time, 99.98% compilation time) # nightly v"1.12.0-DEV.1523"
  0.139498 seconds (242.99 k allocations: 12.425 MiB, 17.48% gc time, 99.96% compilation time) # this PR

```