### PR TITLE
[docs] Fix rendering of warning admonition in llvm passes page

### DIFF
--- a/doc/src/devdocs/llvm-passes.md
+++ b/doc/src/devdocs/llvm-passes.md
@@ -98,7 +98,7 @@ This pass performs modifications to a module to create functions that are optimi
 
 !!! warning
 
-   Use of `llvmcall` with multiversioning is dangerous. `llvmcall` enables access to features not typically exposed by the Julia APIs, and are therefore usually not available on all architectures. If multiversioning is enabled and code generation is requested for a target architecture that does not support the feature required by an `llvmcall` expression, LLVM will probably error out, likely with an abort and the message `LLVM ERROR: Do not know how to split the result of this operator!`.
+    Use of `llvmcall` with multiversioning is dangerous. `llvmcall` enables access to features not typically exposed by the Julia APIs, and are therefore usually not available on all architectures. If multiversioning is enabled and code generation is requested for a target architecture that does not support the feature required by an `llvmcall` expression, LLVM will probably error out, likely with an abort and the message `LLVM ERROR: Do not know how to split the result of this operator!`.
 
 ### GCInvariantVerifier
 


### PR DESCRIPTION
Follow up to #56392: also the warning in https://docs.julialang.org/en/v1.11.1/devdocs/llvm-passes/#Multiversioning is rendered incorrectly because of a missing space.