### PR TITLE
Correct nothrow modeling of `get_binding_type`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -2501,7 +2501,7 @@ function builtin_effects(𝕃::AbstractLattice, @nospecialize(f::Builtin), argty
     elseif f === Core.get_binding_type
         length(argtypes) == 2 || return EFFECTS_THROWS
         # Modeled more precisely in abstract_eval_get_binding_type
-        return Effects(EFFECTS_TOTAL; effect_free=ALWAYS_FALSE)
+        return Effects(EFFECTS_TOTAL; effect_free=ALWAYS_FALSE, nothrow=get_binding_type_nothrow(𝕃, argtypes[1], argtypes[2]))
     elseif f === compilerbarrier
         length(argtypes) == 2 || return Effects(EFFECTS_THROWS; consistent=ALWAYS_FALSE)
         setting = argtypes[1]


### PR DESCRIPTION
As pointed out in https://github.com/JuliaLang/julia/pull/56299#discussion_r1826509185, although the bug predates that PR.