### PR TITLE
Ensure that String(::Memory) returns only a String, not any owner

### DIFF
--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -197,7 +197,7 @@ JL_DLLEXPORT jl_value_t *jl_genericmemory_to_string(jl_genericmemory_t *m, size_
     if (how != 0) {
         jl_value_t *o = jl_genericmemory_data_owner_field(m);
         jl_genericmemory_data_owner_field(m) = NULL;
-        if (how == 3 &&
+        if (how == 3 && jl_is_string(o) &&
              ((mlength + sizeof(void*) + 1 <= GC_MAX_SZCLASS) == (len + sizeof(void*) + 1 <= GC_MAX_SZCLASS))) {
             if (jl_string_data(o)[len] != '\0')
                 jl_string_data(o)[len] = '\0';


### PR DESCRIPTION
Fixes #56435