### PR TITLE
Take safepoint lock before going to sleep in the scheduler.

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1129,7 +1129,7 @@ void jl_safepoint_end_gc(void);
 // The caller should set it **BEFORE** calling this function.
 void jl_safepoint_wait_gc(void) JL_NOTSAFEPOINT;
 void jl_safepoint_wait_thread_resume(void) JL_NOTSAFEPOINT;
-
+int8_t jl_safepoint_take_sleep_lock(jl_ptls_t ptls) JL_NOTSAFEPOINT_ENTER;
 // Set pending sigint and enable the mechanisms to deliver the sigint.
 void jl_safepoint_enable_sigint(void);
 // If the safepoint is enabled to deliver sigint, disable it

--- a/src/safepoint.c
+++ b/src/safepoint.c
@@ -282,7 +282,11 @@ int8_t jl_safepoint_take_sleep_lock(jl_ptls_t ptls)
     int8_t gc_state = jl_gc_safe_enter(ptls);
     uv_mutex_lock(&ptls->sleep_lock);
     if (jl_atomic_load_relaxed(&ptls->suspend_count)) {
-        // defer this broadcast until we determine whether uv_cond_wait is really going to be needed
+        // This dance with the locks is because we are not allowed to hold both these locks at the same time
+        // This avoids a situation where  jl_safepoint_suspend_thread loads our GC state and sees GC_UNSAFE
+        // But we are in the process of becoming GC_SAFE, and also trigger the old safepoint, this causes us
+        // to go sleep in scheduler and the suspender thread to go to sleep in safepoint_cond_begin meaning we hang
+        // To avoid this we do the broadcast below to force it to observe the new gc_state
         uv_mutex_unlock(&ptls->sleep_lock);
         uv_mutex_lock(&safepoint_lock);
         uv_cond_broadcast(&safepoint_cond_begin);

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -499,8 +499,7 @@ JL_DLLEXPORT jl_task_t *jl_task_get_next(jl_value_t *trypoptask, jl_value_t *q, 
 
                 // the other threads will just wait for an individual wake signal to resume
                 JULIA_DEBUG_SLEEPWAKE( ptls->sleep_enter = cycleclock() );
-                int8_t gc_state = jl_gc_safe_enter(ptls);
-                uv_mutex_lock(&ptls->sleep_lock);
+                int8_t gc_state = jl_safepoint_take_sleep_lock(ptls); // This puts the thread in GC_SAFE and takes the sleep lock
                 while (may_sleep(ptls)) {
                     if (ptls->tid == 0) {
                         task = wait_empty;


### PR DESCRIPTION
This avoids a deadlock during exit. Between a thread going to sleep and the thread exiting.