### PR TITLE
Replace unconditional store with cmpswap to avoid deadlocking in jl_fptr_wait_for_compiled_addr

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -10166,7 +10166,8 @@ jl_llvm_functions_t jl_emit_codeinst(
                         !(params.imaging_mode || jl_options.incremental)) { // don't delete code when generating a precompile file
                 // Never end up in a situation where the codeinst has no invoke, but also no source, so we never fall
                 // through the cracks of SOURCE_MODE_ABI.
-                jl_atomic_store_release(&codeinst->invoke, jl_fptr_wait_for_compiled_addr);
+                jl_callptr_t expected = NULL;
+                jl_atomic_cmpswap_relaxed(&codeinst->invoke, &expected, jl_fptr_wait_for_compiled_addr);
                 jl_atomic_store_release(&codeinst->inferred, jl_nothing);
             }
         }


### PR DESCRIPTION
That unconditional store could overwrite the actual compiled code in that pointer, so make it a cmpswap