### PR TITLE
fixup! JuliaLang/julia#56028, fix up the type-level escapability check

### DIFF
--- a/base/compiler/ssair/EscapeAnalysis/EscapeAnalysis.jl
+++ b/base/compiler/ssair/EscapeAnalysis/EscapeAnalysis.jl
@@ -26,7 +26,7 @@ using ._TOP_MOD:     # Base definitions
 using Core.Compiler: # Core.Compiler specific definitions
     AbstractLattice, Bottom, IRCode, IR_FLAG_NOTHROW, InferenceResult, SimpleInferenceLattice,
     argextype, fieldcount_noerror, hasintersect, has_flag, intrinsic_nothrow,
-    is_meta_expr_head, is_mutation_free_argtype, isexpr, println, setfield!_nothrow,
+    is_meta_expr_head, is_identity_free_argtype, isexpr, println, setfield!_nothrow,
     singleton_type, try_compute_field, try_compute_fieldidx, widenconst, ⊑
 
 include(x) = _TOP_MOD.include(@__MODULE__, x)
@@ -861,7 +861,7 @@ function add_escape_change!(astate::AnalysisState, @nospecialize(x), xinfo::Esca
     xinfo === ⊥ && return nothing # performance optimization
     xidx = iridx(x, astate.estate)
     if xidx !== nothing
-        if force || !is_mutation_free_argtype(argextype(x, astate.ir))
+        if force || !is_identity_free_argtype(argextype(x, astate.ir))
             push!(astate.changes, EscapeChange(xidx, xinfo))
         end
     end
@@ -871,7 +871,7 @@ end
 function add_liveness_change!(astate::AnalysisState, @nospecialize(x), livepc::Int)
     xidx = iridx(x, astate.estate)
     if xidx !== nothing
-        if !is_mutation_free_argtype(argextype(x, astate.ir))
+        if !is_identity_free_argtype(argextype(x, astate.ir))
             push!(astate.changes, LivenessChange(xidx, livepc))
         end
     end
@@ -1077,7 +1077,10 @@ function escape_invoke!(astate::AnalysisState, pc::Int, args::Vector{Any})
             # to consider the possibility of aliasing between them and the return value.
             for argidx = first_idx:last_idx
                 arg = args[argidx]
-                if !is_mutation_free_argtype(argextype(arg, astate.ir))
+                if arg isa GlobalRef
+                    continue # :effect_free guarantees that nothings escapes to the global scope
+                end
+                if !is_identity_free_argtype(argextype(arg, astate.ir))
                     add_alias_change!(astate, ret, arg)
                 end
             end

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1731,8 +1731,11 @@ function sroa_mutables!(ir::IRCode, defuses::IdDict{Int,Tuple{SPCSet,SSADefUse}}
             if finalizer_useidx isa Int
                 nargs = length(ir.argtypes) # COMBAK this might need to be `Int(opt.src.nargs)`
                 estate = EscapeAnalysis.analyze_escapes(ir, nargs, 𝕃ₒ, get_escape_cache(inlining.interp))
+                # disable finalizer inlining when this allocation is aliased to somewhere,
+                # mostly likely to edges of `PhiNode`
+                hasaliases = EscapeAnalysis.getaliases(SSAValue(defidx), estate) !== nothing
                 einfo = estate[SSAValue(defidx)]
-                if EscapeAnalysis.has_no_escape(einfo)
+                if !hasaliases && EscapeAnalysis.has_no_escape(einfo)
                     already = BitSet(use.idx for use in defuse.uses)
                     for idx = einfo.Liveness
                         if idx ∉ already

--- a/test/compiler/EscapeAnalysis/EAUtils.jl
+++ b/test/compiler/EscapeAnalysis/EAUtils.jl
@@ -18,7 +18,7 @@ using Core:
     CodeInstance, MethodInstance, CodeInfo
 using .CC:
     InferenceResult, InferenceState, OptimizationState, IRCode
-using .EA: analyze_escapes, ArgEscapeCache, EscapeInfo, EscapeState
+using .EA: analyze_escapes, ArgEscapeCache, ArgEscapeInfo, EscapeInfo, EscapeState
 
 struct EAToken end
 
@@ -165,6 +165,42 @@ function Base.show(io::IO, x::EscapeInfo)
     else
         printstyled(io, name; color)
     end
+end
+
+function get_sym_color(x::ArgEscapeInfo)
+    escape_bits = x.escape_bits
+    if escape_bits == EA.ARG_ALL_ESCAPE
+        color, sym = :red, "X"
+    elseif escape_bits == 0x00
+        color, sym = :green, "✓"
+    else
+        color, sym = :bold, "*"
+        if !iszero(escape_bits & EA.ARG_RETURN_ESCAPE)
+            color, sym = :blue, "↑"
+        end
+        if !iszero(escape_bits & EA.ARG_THROWN_ESCAPE)
+            color = :yellow
+        end
+    end
+    return sym, color
+end
+
+function Base.show(io::IO, x::ArgEscapeInfo)
+    escape_bits = x.escape_bits
+    if escape_bits == EA.ARG_ALL_ESCAPE
+        color, sym = :red, "X"
+    elseif escape_bits == 0x00
+        color, sym = :green, "✓"
+    else
+        color, sym = :bold, "*"
+        if !iszero(escape_bits & EA.ARG_RETURN_ESCAPE)
+            color, sym = :blue, "↑"
+        end
+        if !iszero(escape_bits & EA.ARG_THROWN_ESCAPE)
+            color = :yellow
+        end
+    end
+    printstyled(io, "ArgEscapeInfo(", sym, ")"; color)
 end
 
 struct EscapeResult

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -2275,6 +2275,9 @@ function f_EA_finalizer(N::Int)
         Base.@assume_effects :nothrow @noinline println(devnull, "ptr = ", ptr)
     end
 end
+let src = code_typed1(foreign_alloc, (Type{Float64},Int,))
+    @test count(iscall((src, Core.finalizer)), src.code) == 1
+end
 let src = code_typed1(f_EA_finalizer, (Int,))
     @test count(iscall((src, Core.finalizer)), src.code) == 0
 end


### PR DESCRIPTION
In JuliaLang/julia#56028, the type-level escapability check was changed to use `is_mutation_free_argtype`, but this was a mistake because EA no longer runs for structs like
`mutable struct ForeignBuffer{T}; const ptr::Ptr{T}; end`. This commit changes it to use `is_identity_free_argtype` instead, which can be used to detect whether a type may contain any mutable allocations or not.