### PR TITLE
Allow indexing `UniformScaling` with `CartesianIndex{2}`

### DIFF
--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -86,6 +86,7 @@ julia> (0.7*I)(3)
 eltype(::Type{UniformScaling{T}}) where {T} = T
 ndims(J::UniformScaling) = 2
 Base.has_offset_axes(::UniformScaling) = false
+getindex(J::UniformScaling, ind::CartesianIndex{2}) = J[Tuple(ind)...]
 getindex(J::UniformScaling, i::Integer,j::Integer) = ifelse(i==j,J.λ,zero(J.λ))
 
 getindex(J::UniformScaling, n::Integer, m::AbstractVector{<:Integer}) = getindex(J, m, n)

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -28,8 +28,8 @@ Random.seed!(1234543)
 end
 
 @testset "getindex" begin
-    @test I[1,1] == 1
-    @test I[1,2] == 0
+    @test I[1,1] == I[CartesianIndex(1,1)] == 1
+    @test I[1,2] == I[CartesianIndex(1,2)] == 0
 
     J = I(15)
     for (a, b) in [


### PR DESCRIPTION
Since indexing with two `Integer`s is defined, we might as well define indexing with a `CartesianIndex`. This makes certain loops convenient where the index is obtained using `eachindex`.