### PR TITLE
Fix and test an overflow issue in `searchsorted`

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -231,8 +231,8 @@ function searchsorted(v::AbstractVector, x, ilo::T, ihi::T, o::Ordering)::UnitRa
         elseif lt(o, x, v[m])
             hi = m
         else
-            a = searchsortedfirst(v, x, max(lo,ilo), m, o)
-            b = searchsortedlast(v, x, m, min(hi,ihi), o)
+            a = searchsortedfirst(v, x, lo+u, m, o)
+            b = searchsortedlast(v, x, m, hi-u, o)
             return a : b
         end
     end

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -581,6 +581,10 @@ end
     @test searchsortedfirst(o, 1.5) == 0
     @test searchsortedlast(o, 0) == firstindex(o) - 1
     @test searchsortedlast(o, 1.5) == -1
+
+    # Issue #56457
+    o2 = OffsetArray([2,2,3], typemax(Int)-3);
+    @test searchsorted(o2, 2) == firstindex(o2):firstindex(o2)+1
 end
 
 function adaptive_sort_test(v; trusted=InsertionSort, kw...)

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -821,17 +821,6 @@ centered(A::AbstractArray, cp::Dims=center(A)) = OffsetArray(A, .-cp)
 
 centered(A::AbstractArray, i::CartesianIndex) = centered(A, Tuple(i))
 
-# we may pass the searchsorted* functions to the parent, and wrap the offset
-for f in [:searchsortedfirst, :searchsortedlast, :searchsorted]
-    _safe_f = Symbol("_safe_" * String(f))
-    @eval function $_safe_f(v::OffsetArray, x, ilo, ihi, o::Base.Ordering)
-        offset = firstindex(v) - firstindex(parent(v))
-        $f(parent(v), x, ilo - offset, ihi - offset, o) .+ offset
-    end
-    @eval Base.$f(v::OffsetVector, x, ilo::T, ihi::T, o::Base.Ordering) where T<:Integer =
-        $_safe_f(v, x, ilo, ihi, o)
-end
-
 ##
 # Deprecations
 ##


### PR DESCRIPTION
And remove `searchsorted` special cases for offset arrays in tests that had the impact of bypassing actually testing `searchsorted` behavior on offset arrays

```julia-repl
julia> using OffsetArrays

julia> struct MyOffsetVector{T,A<:AbstractVector{T}} <: AbstractVector{T}
           data :: A
       end

julia> Base.size(M::MyOffsetVector) = size(M.data)

julia> Base.axes(M::MyOffsetVector) = axes(M.data)

julia> Base.getindex(M::MyOffsetVector, i::Int) = M.data[i]

julia> soa = OffsetArray([2,2,3], typemax(Int)-3);

julia> v = MyOffsetVector(soa)
3-element MyOffsetVector{Int64, OffsetVector{Int64, Vector{Int64}}} with indices 9223372036854775805:9223372036854775807:
 2
 2
 3

julia> searchsorted(v, 2)
9223372036854775805:9223372036854775805 # before
9223372036854775805:9223372036854775806 # after
```

Fixes the specific bug reported in the OP of #56457, but not the separate but related bug in https://github.com/JuliaLang/julia/issues/56457#issuecomment-2457223264.

This also replaces min/max computation with increment decrement and shrinks the search bounds by 1 in some cases which could plausibly improve performance (though likely negligibly)