### PR TITLE
[GHA] Explicitly install Julia for whitespace workflow

### DIFF
--- a/.github/workflows/Whitespace.yml
+++ b/.github/workflows/Whitespace.yml
@@ -18,6 +18,9 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           persist-credentials: false
+      - uses: julia-actions/setup-julia@9b79636afcfb07ab02c256cede01fe2db6ba808c # v2.6.0
+        with:
+          version: '1'
       - name: Check whitespace
         run: |
           contrib/check-whitespace.jl


### PR DESCRIPTION
So far we relied on the fact that Julia comes in the default Ubuntu images on GitHub Actions runners, but this may change in the future (although there's apparently no plan in this direction for the time being).  To make the workflow more future-proof, we now explicitly install Julia using a dedicated workflow.