### PR TITLE
Fix and test searchsorted for arrays whose first index is `typemin(Int)`

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -206,7 +206,7 @@ function searchsortedlast(v::AbstractVector, x, lo::T, hi::T, o::Ordering)::keyt
     u = T(1)
     lo = lo - u
     hi = hi + u
-    @inbounds while lo < hi - u
+    @inbounds while lo != hi - u
         m = midpoint(lo, hi)
         if lt(o, x, v[m])
             hi = m
@@ -224,7 +224,7 @@ function searchsorted(v::AbstractVector, x, ilo::T, ihi::T, o::Ordering)::UnitRa
     u = T(1)
     lo = ilo - u
     hi = ihi + u
-    @inbounds while lo < hi - u
+    @inbounds while lo != hi - u
         m = midpoint(lo, hi)
         if lt(o, v[m], x)
             lo = m

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -585,6 +585,22 @@ end
     # Issue #56457
     o2 = OffsetArray([2,2,3], typemax(Int)-3);
     @test searchsorted(o2, 2) == firstindex(o2):firstindex(o2)+1
+
+    struct IdentityVector <: AbstractVector{Int}
+        lo::Int
+        hi::Int
+    end
+    function Base.getindex(s::IdentityVector, i::Int)
+        s.lo <= i <= s.hi || throw(BoundsError(s, i))
+        i
+    end
+    Base.axes(s::IdentityVector) = (s.lo:s.hi,)
+    Base.size(s::IdentityVector) = length.(axes(s))
+
+    o3 = IdentityVector(typemin(Int), typemin(Int)+5)
+    @test searchsortedfirst(o3, typemin(Int)+2) == typemin(Int)+2
+    @test searchsortedlast(o3, typemin(Int)+2) == typemin(Int)+2
+    @test searchsorted(o3, typemin(Int)+2) == typemin(Int)+2:typemin(Int)+2
 end
 
 function adaptive_sort_test(v; trusted=InsertionSort, kw...)

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -598,9 +598,9 @@ end
     Base.size(s::IdentityVector) = length.(axes(s))
 
     o3 = IdentityVector(typemin(Int), typemin(Int)+5)
-    @test searchsortedfirst(o3, typemin(Int)+2) == typemin(Int)+2
-    @test searchsortedlast(o3, typemin(Int)+2) == typemin(Int)+2
-    @test searchsorted(o3, typemin(Int)+2) == typemin(Int)+2:typemin(Int)+2
+    @test searchsortedfirst(o3, typemin(Int)+2) === typemin(Int)+2
+    @test searchsortedlast(o3, typemin(Int)+2) === typemin(Int)+2
+    @test searchsorted(o3, typemin(Int)+2) === typemin(Int)+2:typemin(Int)+2
 end
 
 function adaptive_sort_test(v; trusted=InsertionSort, kw...)


### PR DESCRIPTION
This fixes the issue reported in https://github.com/JuliaLang/julia/issues/56457#issuecomment-2457223264 which, combined with #56464 which fixed the issue in the OP, fixes #56457.

After this PR I am aware of no more reported bugs with these searchsorted* methods. (though the range methods do still have bugs).

`searchsortedfirst` was fine all along, but I added it to tests regardless.