### PR TITLE
Fixing the //(x::Number, y::Complex) one liner to accomodate silent overflows and division by zero/infinity

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -98,9 +98,26 @@ function //(x::Rational, y::Rational)
 end
 
 //(x::Complex, y::Real) = complex(real(x)//y, imag(x)//y)
-//(x::Number, y::Complex) = x*conj(y)//abs2(y)
-
-
+function //(x::Number, y::Complex)
+    if((x//abs2(y))==0//1 || (x//abs2(y))==1//0)
+        return (x//abs2(y))
+    end
+    return (x//abs2(y))*conj(y)
+end
+function //(x::Number, y::Complex{<:Integer})
+    if isinf(real(y)) || isinf(imag(y))
+        return 0//1
+    end
+    real_y = real(y)
+    imag_y = imag(y)
+    denom = Int32(abs(real_y))^2 + Int32(abs(imag_y))^2
+    if denom == 0//1
+        return 1//0
+    end
+    real_part = x * real_y // denom
+    imag_part = -x * imag_y // denom
+    return real_part + imag_part * im
+end
 //(X::AbstractArray, y::Number) = X .// y
 
 function show(io::IO, x::Rational)

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -18,7 +18,12 @@ using Test
     @test -1//0 == -1//0
     @test -7//0 == -1//0
     @test  (-1//2) // (-2//5) == 5//4
-
+    @testset "Complex//Number Overflow" begin
+        for y ∈ (1 // 0, -1 // 0)
+            @test (7 // complex(y)) == (7 // y)
+        end
+        @test Int8(8) // Int8(100)im == 0//1 - 2//25*im
+    end
     @test_throws OverflowError -(0x01//0x0f)
     @test_throws OverflowError -(typemin(Int)//1)
     @test_throws OverflowError (typemax(Int)//3) + 1


### PR DESCRIPTION
Fixes #53435 Fixes #56245. I have added conditions for division by zero and infinite handling in the case of complex numbers and overflow handling in the case of integer-based complex numbers. Further, I have added a few tests for the same :)