### PR TITLE
Fix compilation warning on aarch64-linux

### DIFF
--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -992,7 +992,13 @@ int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT
     #endif
 #elif defined(_OS_LINUX_) && defined(__GLIBC__)
     __jmp_buf *_ctx = &mctx->__jmpbuf;
+    #if defined(_CPU_AARCH64_)
+    // Only on aarch64-linux libunwind uses a different struct than system's one:
+    // <https://github.com/libunwind/libunwind/blob/e63e024b72d35d4404018fde1a546fde976da5c5/include/libunwind-aarch64.h#L193-L205>.
+    struct unw_sigcontext *mc = &c->uc_mcontext;
+    #else
     mcontext_t *mc = &c->uc_mcontext;
+    #endif
     #if defined(_CPU_X86_)
     // https://github.com/bminor/glibc/blame/master/sysdeps/i386/__longjmp.S
     // https://github.com/bminor/glibc/blame/master/sysdeps/i386/jmpbuf-offsets.h


### PR DESCRIPTION
This fixes the warning:
```
/cache/build/default-aws-aarch64-ci-1-3/julialang/julia-master/src/stackwalk.c: In function 'jl_simulate_longjmp':
/cache/build/default-aws-aarch64-ci-1-3/julialang/julia-master/src/stackwalk.c:995:22: warning: initialization of 'mcontext_t *' {aka 'struct sigcontext *'} from incompatible pointer type 'struct unw_sigcontext *' [-Wincompatible-pointer-types]
  995 |     mcontext_t *mc = &c->uc_mcontext;
      |                      ^
```

This is the last remaining warning during compilation on aarch64-linux.