### PR TITLE
`sincos` for non-float symmetric matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -969,7 +969,8 @@ for (hermtype, wrapper) in [(:Symmetric, :Symmetric), (:SymTridiagonal, :Symmetr
         function sincos(A::$hermtype{<:Real})
             n = checksquare(A)
             F = eigen(A)
-            S, C = Diagonal(similar(A, (n,))), Diagonal(similar(A, (n,)))
+            T = float(eltype(F.values))
+            S, C = Diagonal(similar(A, T, (n,))), Diagonal(similar(A, T, (n,)))
             for i in 1:n
                 S.diag[i], C.diag[i] = sincos(F.values[i])
             end
@@ -980,7 +981,8 @@ end
 function sincos(A::Hermitian{<:Complex})
     n = checksquare(A)
     F = eigen(A)
-    S, C = Diagonal(similar(A, (n,))), Diagonal(similar(A, (n,)))
+    T = float(eltype(F.values))
+    S, C = Diagonal(similar(A, T, (n,))), Diagonal(similar(A, T, (n,)))
     for i in 1:n
         S.diag[i], C.diag[i] = sincos(F.values[i])
     end

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -1167,4 +1167,15 @@ end
     @test a*H == H
 end
 
+@testset "trigonometric funtions for Integer matrices" begin
+    A = diagm(0=>1:4, 1=>1:3, -1=>1:3)
+    for B in (Symmetric(A), Symmetric(complex.(A)))
+        SC = @inferred(sincos(B))
+        @test SC[1] ≈ sin(B)
+        @test SC[2] ≈ cos(B)
+        @test cos(A) ≈ real(exp(im*A))
+        @test sin(A) ≈ imag(exp(im*A))
+    end
+end
+
 end # module TestSymmetric

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -1167,7 +1167,7 @@ end
     @test a*H == H
 end
 
-@testset "trigonometric funtions for Integer matrices" begin
+@testset "trigonometric functions for Integer matrices" begin
     A = diagm(0=>1:4, 1=>1:3, -1=>1:3)
     for B in (Symmetric(A), Symmetric(complex.(A)))
         SC = @inferred(sincos(B))


### PR DESCRIPTION
Ensures that the `eltype` of the array to which the result of `sincos` is a floating-point one, even if the argument doesn't have a floating-point `eltype`.

After this, the following works:
```julia
julia> A = diagm(0=>1:3)
3×3 Matrix{Int64}:
 1  0  0
 0  2  0
 0  0  3

julia> sincos(A)
([0.8414709848078965 0.0 0.0; 0.0 0.9092974268256817 0.0; 0.0 0.0 0.1411200080598672], [0.5403023058681398 0.0 0.0; 0.0 -0.4161468365471424 0.0; 0.0 0.0 -0.9899924966004454])
```