### PR TITLE
Specialize `isbanded` for `StridedMatrix`

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1460,9 +1460,7 @@ julia> LinearAlgebra.isbanded(b, -1, 0)
 true
 ```
 """
-function isbanded(A::AbstractMatrix, kl::Integer, ku::Integer)
-    _isbanded(A, kl, ku)
-end
+isbanded(A::AbstractMatrix, kl::Integer, ku::Integer) = _isbanded(A, kl, ku)
 _isbanded(A::AbstractMatrix, kl::Integer, ku::Integer) = istriu(A, kl) && istril(A, ku)
 # Performance optimization for StridedMatrix by better utilizing cache locality
 # The istriu and istril loops are merged

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1487,7 +1487,7 @@ function _isbanded_impl(A, kl, ku)
     The fourth is mainly relevant for wide matrices, where there is a block to the right
     beyond ku, where the elements should all be zero. The reason we separate this from the
     third group is that we may loop over all the rows using A[:, col] instead of A[rowrange, col],
-    which is usally faster.
+    which is usually faster.
     =#
 
     last_col_nonzeroblocks = size(A,1) + ku # fully zero rectangular block beyond this column

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1436,7 +1436,7 @@ function istril(A::AbstractMatrix, k::Integer = 0)
     require_one_based_indexing(A)
     # Split the column range into two parts for wide matrices,
     # as iterating over a slice is faster than over a UnitRange view.
-    # The second loop is over the block beyond the ku-th superdiagonal,
+    # The second loop is over the block beyond the k-th superdiagonal,
     # which should be zero for a banded matrix
     col_cutoff = size(A,1) + max(k,0)
     for j in max(firstindex(A,2), k + 2):min(lastindex(A,2), col_cutoff)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1501,29 +1501,21 @@ function _isbanded_impl(A, kl, ku)
 
     for col in intersect(axes(A,2), colrange_onlybottomrows) # only loop over the bottom rows
         botrowinds = max(firstindex(A,1), col-kl+1):lastindex(A,1)
-        if !isempty(botrowinds)
-            bottomrows = @view A[botrowinds, col]
-            _iszero(bottomrows) || return false
-        end
+        bottomrows = @view A[botrowinds, col]
+        _iszero(bottomrows) || return false
     end
     for col in intersect(axes(A,2), colrange_topbottomrows)
         toprowinds = firstindex(A,1):min(col-ku-1, lastindex(A,1))
-        if !isempty(toprowinds)
-            toprows = @view A[toprowinds, col]
-            _iszero(toprows) || return false
-        end
+        toprows = @view A[toprowinds, col]
+        _iszero(toprows) || return false
         botrowinds = max(firstindex(A,1), col-kl+1):lastindex(A,1)
-        if !isempty(botrowinds)
-            bottomrows = @view A[botrowinds, col]
-            _iszero(bottomrows) || return false
-        end
+        bottomrows = @view A[botrowinds, col]
+        _iszero(bottomrows) || return false
     end
     for col in intersect(axes(A,2), colrange_onlytoprows_nonzero)
         toprowinds = firstindex(A,1):min(col-ku-1, lastindex(A,1))
-        if !isempty(toprowinds)
-            toprows = @view A[toprowinds, col]
-            _iszero(toprows) || return false
-        end
+        toprows = @view A[toprowinds, col]
+        _iszero(toprows) || return false
     end
     for col in intersect(axes(A,2), colrange_zero_block)
         _iszero(@view A[:, col]) || return false

--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -75,8 +75,10 @@ imag(H::UpperHessenberg) = UpperHessenberg(triu!(imag(H.data),-1))
 
 Base.@constprop :aggressive function istriu(A::UpperHessenberg, k::Integer=0)
     k <= -1 && return true
-    return _istriu(parent(A), k)
+    return _istriu(A, k)
 end
+# additional indirection to dispatch to optimized method for banded parents (defined in special.jl)
+_istriu(A::UpperHessenberg, k) = _isbanded_impl(parent(A), k, size(A,2)-1)
 
 function Matrix{T}(H::UpperHessenberg) where T
     m,n = size(H)

--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -75,7 +75,7 @@ imag(H::UpperHessenberg) = UpperHessenberg(triu!(imag(H.data),-1))
 
 Base.@constprop :aggressive function istriu(A::UpperHessenberg, k::Integer=0)
     k <= -1 && return true
-    return _istriu(A, k)
+    return _istriu(parent(A), k)
 end
 
 function Matrix{T}(H::UpperHessenberg) where T

--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -78,7 +78,15 @@ Base.@constprop :aggressive function istriu(A::UpperHessenberg, k::Integer=0)
     return _istriu(A, k)
 end
 # additional indirection to dispatch to optimized method for banded parents (defined in special.jl)
-_istriu(A::UpperHessenberg, k) = _isbanded_impl(parent(A), k, size(A,2)-1)
+@inline function _istriu(A::UpperHessenberg, k)
+    P = parent(A)
+    m = size(A, 1)
+    for j in firstindex(P,2):min(m + k - 1, lastindex(P,2))
+        Prows = @view P[max(begin, j - k + 1):min(j+1,end), j]
+        _iszero(Prows) || return false
+    end
+    return true
+end
 
 function Matrix{T}(H::UpperHessenberg) where T
     m,n = size(H)

--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -592,3 +592,4 @@ end
 # istriu/istril for triangular wrappers of structured matrices
 _istril(A::LowerTriangular{<:Any, <:BandedMatrix}, k) = istril(parent(A), k)
 _istriu(A::UpperTriangular{<:Any, <:BandedMatrix}, k) = istriu(parent(A), k)
+_istriu(A::UpperHessenberg{<:Any, <:BandedMatrix}, k) = istriu(parent(A), k)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -349,14 +349,29 @@ Base.@constprop :aggressive function istril(A::LowerTriangular, k::Integer=0)
     return _istril(A, k)
 end
 # additional indirection to dispatch to optimized method for banded parents (defined in special.jl)
-_istril(A::LowerTriangular, k) = _isbanded_impl(parent(A), -size(A,1)+1, k)
+@inline function _istril(A::LowerTriangular, k)
+    P = parent(A)
+    for j in max(firstindex(P,2), k + 2):lastindex(P,2)
+        Pzero = @view P[max(j, begin):min(j - k - 1, end), j]
+        _iszero(Pzero) || return false
+    end
+    return true
+end
 
 Base.@constprop :aggressive function istriu(A::UpperTriangular, k::Integer=0)
     k <= 0 && return true
     return _istriu(A, k)
 end
 # additional indirection to dispatch to optimized method for banded parents (defined in special.jl)
-_istriu(A::UpperTriangular, k) = _isbanded_impl(parent(A), k, size(A,2)-1)
+@inline function _istriu(A::UpperTriangular, k)
+    P = parent(A)
+    m = size(A, 1)
+    for j in firstindex(P,2):min(m + k - 1, lastindex(P,2))
+        Pzero = @view P[max(begin, j - k + 1):min(j, end), j]
+        _iszero(Pzero) || return false
+    end
+    return true
+end
 
 istril(A::Adjoint, k::Integer=0) = istriu(A.parent, -k)
 istril(A::Transpose, k::Integer=0) = istriu(A.parent, -k)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -346,27 +346,14 @@ istril(A::UnitLowerTriangular, k::Integer=0) = k >= 0
 istriu(A::UnitUpperTriangular, k::Integer=0) = k <= 0
 Base.@constprop :aggressive function istril(A::LowerTriangular, k::Integer=0)
     k >= 0 && return true
-    return _istril(A, k)
+    return _istril(parent(A), k)
 end
-@inline function _istril(A::LowerTriangular, k)
-    P = parent(A)
-    for j in max(firstindex(P,2), k + 2):lastindex(P,2)
-        all(iszero, @view(P[j:min(j - k - 1, end), j])) || return false
-    end
-    return true
-end
+
 Base.@constprop :aggressive function istriu(A::UpperTriangular, k::Integer=0)
     k <= 0 && return true
-    return _istriu(A, k)
+    return _istriu(parent(A), k)
 end
-@inline function _istriu(A::UpperTriangular, k)
-    P = parent(A)
-    m = size(A, 1)
-    for j in firstindex(P,2):min(m + k - 1, lastindex(P,2))
-        all(iszero, @view(P[max(begin, j - k + 1):j, j])) || return false
-    end
-    return true
-end
+
 istril(A::Adjoint, k::Integer=0) = istriu(A.parent, -k)
 istril(A::Transpose, k::Integer=0) = istriu(A.parent, -k)
 istriu(A::Adjoint, k::Integer=0) = istril(A.parent, -k)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -346,13 +346,17 @@ istril(A::UnitLowerTriangular, k::Integer=0) = k >= 0
 istriu(A::UnitUpperTriangular, k::Integer=0) = k <= 0
 Base.@constprop :aggressive function istril(A::LowerTriangular, k::Integer=0)
     k >= 0 && return true
-    return _istril(parent(A), k)
+    return _istril(A, k)
 end
+# additional indirection to dispatch to optimized method for banded parents (defined in special.jl)
+_istril(A::LowerTriangular, k) = _isbanded_impl(parent(A), -size(A,1)+1, k)
 
 Base.@constprop :aggressive function istriu(A::UpperTriangular, k::Integer=0)
     k <= 0 && return true
-    return _istriu(parent(A), k)
+    return _istriu(A, k)
 end
+# additional indirection to dispatch to optimized method for banded parents (defined in special.jl)
+_istriu(A::UpperTriangular, k) = _isbanded_impl(parent(A), k, size(A,2)-1)
 
 istril(A::Adjoint, k::Integer=0) = istriu(A.parent, -k)
 istril(A::Transpose, k::Integer=0) = istriu(A.parent, -k)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -352,8 +352,7 @@ end
 @inline function _istril(A::LowerTriangular, k)
     P = parent(A)
     for j in max(firstindex(P,2), k + 2):lastindex(P,2)
-        Pzero = @view P[max(j, begin):min(j - k - 1, end), j]
-        _iszero(Pzero) || return false
+        _iszero(@view P[max(j, begin):min(j - k - 1, end), j]) || return false
     end
     return true
 end
@@ -367,8 +366,7 @@ end
     P = parent(A)
     m = size(A, 1)
     for j in firstindex(P,2):min(m + k - 1, lastindex(P,2))
-        Pzero = @view P[max(begin, j - k + 1):min(j, end), j]
-        _iszero(Pzero) || return false
+        _iszero(@view P[max(begin, j - k + 1):min(j, end), j]) || return false
     end
     return true
 end

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -603,12 +603,16 @@ end
     end
 end
 
-@testset "isbanded with rectangular matrices" begin
-    for A in (zeros(2,5), zeros(5,2))
+@testset "isbanded/istril/istriu with rectangular matrices" begin
+    @testset "$(size(A))" for A in (zeros(2,5), zeros(5,2))
         A[diagind(A)] .= 1
         G = GenericArray(A)
-        for (kl,ku) in Iterators.product(-6:6, -6:6)
-            @test isbanded(A, kl, ku) == isbanded(G, kl, ku)
+        @testset for (kl,ku) in Iterators.product(-6:6, -6:6)
+            @test isbanded(A, kl, ku) == isbanded(G, kl, ku) == (0 in (kl:ku))
+        end
+        @testset for k in -6:6
+            @test istriu(A,k) == istriu(G,k) == (k <= 0)
+            @test istril(A,k) == istril(G,k) == (k >= 0)
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -530,24 +530,37 @@ end
         @test !istriu(pentadiag)
         @test istriu(pentadiag, -2)
         @test !istriu(tridiag)
+        @test istriu(tridiag) == istriu(tridiagG) == istriu(Tridiag)
         @test istriu(tridiag, -1)
+        @test istriu(tridiag, -1) == istriu(tridiagG, -1) == istriu(Tridiag, -1)
         @test istriu(ubidiag)
         @test istriu(ubidiag) == istriu(ubidiagG) == istriu(uBidiag)
         @test !istriu(ubidiag, 1)
+        @test istriu(ubidiag, 1) == istriu(ubidiagG, 1) == istriu(uBidiag, 1)
         @test !istriu(lbidiag)
+        @test istriu(lbidiag) == istriu(lbidiagG) == istriu(lBidiag)
         @test istriu(lbidiag, -1)
+        @test istriu(lbidiag, -1) == istriu(lbidiagG, -1) == istriu(lBidiag, -1)
         @test istriu(adiag)
+        @test istriu(adiag) == istriu(adiagG) == istriu(aDiag)
     end
     @testset "istril" begin
         @test !istril(pentadiag)
         @test istril(pentadiag, 2)
         @test !istril(tridiag)
+        @test istril(tridiag) == istril(tridiagG) == istril(Tridiag)
         @test istril(tridiag, 1)
+        @test istril(tridiag, 1) == istril(tridiagG, 1) == istril(Tridiag, 1)
         @test !istril(ubidiag)
+        @test istril(ubidiag) == istril(ubidiagG) == istril(ubidiagG)
         @test istril(ubidiag, 1)
+        @test istril(ubidiag, 1) == istril(ubidiagG, 1) == istril(uBidiag, 1)
         @test istril(lbidiag)
+        @test istril(lbidiag) == istril(lbidiagG) == istril(lBidiag)
         @test !istril(lbidiag, -1)
+        @test istril(lbidiag, -1) == istril(lbidiagG, -1) == istril(lBidiag, -1)
         @test istril(adiag)
+        @test istril(adiag) == istril(adiagG) == istril(aDiag)
     end
     @testset "isbanded" begin
         @test isbanded(pentadiag, -2, 2)
@@ -580,9 +593,13 @@ end
     end
     @testset "isdiag" begin
         @test !isdiag(tridiag)
+        @test isdiag(tridiag) == isdiag(tridiagG) == isdiag(Tridiag)
         @test !isdiag(ubidiag)
+        @test isdiag(ubidiag) == isdiag(ubidiagG) == isdiag(uBidiag)
         @test !isdiag(lbidiag)
+        @test isdiag(lbidiag) == isdiag(lbidiagG) == isdiag(lBidiag)
         @test isdiag(adiag)
+        @test isdiag(adiag) ==isdiag(adiagG) == isdiag(aDiag)
     end
 end
 

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -605,14 +605,17 @@ end
 
 @testset "isbanded/istril/istriu with rectangular matrices" begin
     @testset "$(size(A))" for A in (zeros(2,5), zeros(5,2))
-        A[diagind(A)] .= 1
-        G = GenericArray(A)
-        @testset for (kl,ku) in Iterators.product(-6:6, -6:6)
-            @test isbanded(A, kl, ku) == isbanded(G, kl, ku) == (0 in (kl:ku))
-        end
-        @testset for k in -6:6
-            @test istriu(A,k) == istriu(G,k) == (k <= 0)
-            @test istril(A,k) == istril(G,k) == (k >= 0)
+        @testset for m in -1:1
+            A .= 0
+            A[diagind(A, m)] .= 1
+            G = GenericArray(A)
+            @testset for (kl,ku) in Iterators.product(-6:6, -6:6)
+                @test isbanded(A, kl, ku) == isbanded(G, kl, ku) == (m in (kl:ku))
+            end
+            @testset for k in -6:6
+                @test istriu(A,k) == istriu(G,k) == (k <= m)
+                @test istril(A,k) == istril(G,k) == (k >= m)
+            end
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -604,17 +604,17 @@ end
 end
 
 @testset "isbanded/istril/istriu with rectangular matrices" begin
-    @testset "$(size(A))" for A in (zeros(2,5), zeros(5,2))
-        @testset for m in -1:1
+    @testset "$(size(A))" for A in [zeros(0,4), zeros(2,5), zeros(5,2), zeros(4,0)]
+        @testset for m in -(size(A,1)-1):(size(A,2)-1)
             A .= 0
             A[diagind(A, m)] .= 1
             G = GenericArray(A)
             @testset for (kl,ku) in Iterators.product(-6:6, -6:6)
-                @test isbanded(A, kl, ku) == isbanded(G, kl, ku) == (m in (kl:ku))
+                @test isbanded(A, kl, ku) == isbanded(G, kl, ku) == isempty(A) || (m in (kl:ku))
             end
             @testset for k in -6:6
-                @test istriu(A,k) == istriu(G,k) == (k <= m)
-                @test istril(A,k) == istril(G,k) == (k >= m)
+                @test istriu(A,k) == istriu(G,k) == isempty(A) || (k <= m)
+                @test istril(A,k) == istril(G,k) == isempty(A) || (k >= m)
             end
         end
     end

--- a/stdlib/LinearAlgebra/test/hessenberg.jl
+++ b/stdlib/LinearAlgebra/test/hessenberg.jl
@@ -279,4 +279,29 @@ end
     @test H.H == D
 end
 
+@testset "istriu/istril forwards to parent" begin
+    @testset "$(nameof(typeof(M)))" for M in [Tridiagonal(rand(n-1), rand(n), rand(n-1)),
+                Tridiagonal(zeros(n-1), zeros(n), zeros(n-1)),
+                Diagonal(randn(n)),
+                Diagonal(zeros(n)),
+                ]
+        U = UpperHessenberg(M)
+        A = Array(U)
+        for k in -n:n
+            @test istriu(U, k) == istriu(A, k)
+            @test istril(U, k) == istril(A, k)
+        end
+    end
+    z = zeros(n,n)
+    P = Matrix{BigFloat}(undef, n, n)
+    copytrito!(P, z, 'U')
+    P[diagind(P,-1)] .= 0
+    U = UpperHessenberg(P)
+    A = Array(U)
+    @testset for k in -n:n
+        @test istriu(U, k) == istriu(A, k)
+        @test istril(U, k) == istril(A, k)
+    end
+end
+
 end # module TestHessenberg

--- a/stdlib/LinearAlgebra/test/hessenberg.jl
+++ b/stdlib/LinearAlgebra/test/hessenberg.jl
@@ -280,6 +280,7 @@ end
 end
 
 @testset "istriu/istril forwards to parent" begin
+    n = 10
     @testset "$(nameof(typeof(M)))" for M in [Tridiagonal(rand(n-1), rand(n), rand(n-1)),
                 Tridiagonal(zeros(n-1), zeros(n), zeros(n-1)),
                 Diagonal(randn(n)),


### PR DESCRIPTION
This improves performance, as the loops in `istriu` and `istril` may be fused to improve cache-locality.
This also changes the quick-return behavior, and only returns after the check over all the upper or lower bands for a column is complete.

```julia
julia> using LinearAlgebra

julia> A = zeros(2, 10_000);

julia> @btime isdiag($A);
  32.682 μs (0 allocations: 0 bytes) # nightly v"1.12.0-DEV.1593"
  9.481 μs (0 allocations: 0 bytes) # this PR

julia> A = zeros(10_000, 2);

julia> @btime isdiag($A);
  10.288 μs (0 allocations: 0 bytes)  # nightly 
  2.579 μs (0 allocations: 0 bytes) # this PR

julia> A = zeros(100, 100);

julia> @btime isdiag($A);
  6.616 μs (0 allocations: 0 bytes) # nightly
  3.075 μs (0 allocations: 0 bytes) # this PR

julia> A = diagm(0=>1:100);  A[3,4] = 1;

julia> @btime isdiag($A);
  2.759 μs (0 allocations: 0 bytes) # nightly
  85.371 ns (0 allocations: 0 bytes) # this PR
```

A similar change is added to `istriu`/`istril` as well, so that
```julia
julia> A = zeros(2, 10_000);

julia> @btime istriu($A); # trivial
  7.358 ns (0 allocations: 0 bytes) # nightly
  13.779 ns (0 allocations: 0 bytes) # this PR

julia> @btime istril($A);
  33.464 μs (0 allocations: 0 bytes) # nightly
  9.476 μs (0 allocations: 0 bytes) # this PR

julia> A = zeros(10_000, 2);

julia> @btime istriu($A);
  10.020 μs (0 allocations: 0 bytes) # nightly
  2.620 μs (0 allocations: 0 bytes) # this PR

julia> @btime istril($A); # trivial
  6.793 ns (0 allocations: 0 bytes) # nightly
  14.473 ns (0 allocations: 0 bytes) # this PR

julia> A = zeros(100, 100);

julia> @btime istriu($A);
  3.435 μs (0 allocations: 0 bytes) # nightly
  1.637 μs (0 allocations: 0 bytes) # this PR

julia> @btime istril($A);
  3.353 μs (0 allocations: 0 bytes) # nightly
  1.661 μs (0 allocations: 0 bytes) # this PR
```