### PR TITLE
better error message for rpad/lpad with zero-width padding

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -479,7 +479,7 @@ function lpad(
     l = Int(textwidth(p))::Int
     if l == 0
         throw(ArgumentError("$(repr(p)) has zero textwidth" * (ncodeunits(p) != 1 ? "" :
-            "; maybe you want pad^max(0, ncodeunits(str) - npad) * str to pad by codeunits" *
+            "; maybe you want pad^max(0, npad - ncodeunits(str)) * str to pad by codeunits" *
             (s isa AbstractString && codeunit(s) != UInt8 ? "?" : " (bytes)?"))))
     end
     q, r = divrem(m, l)
@@ -516,7 +516,7 @@ function rpad(
     l = Int(textwidth(p))::Int
     if l == 0
         throw(ArgumentError("$(repr(p)) has zero textwidth" * (ncodeunits(p) != 1 ? "" :
-            "; maybe you want str * pad^max(0, ncodeunits(str) - npad) to pad by codeunits" *
+            "; maybe you want str * pad^max(0, npad - ncodeunits(str)) to pad by codeunits" *
             (s isa AbstractString && codeunit(s) != UInt8 ? "?" : " (bytes)?"))))
     end
     q, r = divrem(m, l)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -478,7 +478,7 @@ function lpad(
     m ≤ 0 && return stringfn(s)
     l = Int(textwidth(p))::Int
     if l == 0
-        throw(ArgumentError("$(repr(p)) has zero width" * (ncodeunits(p) != 1 ? "" :
+        throw(ArgumentError("$(repr(p)) has zero textwidth" * (ncodeunits(p) != 1 ? "" :
             "; maybe you want pad^max(0, ncodeunits(str) - npad) * str to pad by codeunits" *
             (s isa AbstractString && codeunit(s) != UInt8 ? "?" : " (bytes)?"))))
     end
@@ -515,7 +515,7 @@ function rpad(
     m ≤ 0 && return stringfn(s)
     l = Int(textwidth(p))::Int
     if l == 0
-        throw(ArgumentError("$(repr(p)) has zero width" * (ncodeunits(p) != 1 ? "" :
+        throw(ArgumentError("$(repr(p)) has zero textwidth" * (ncodeunits(p) != 1 ? "" :
             "; maybe you want str * pad^max(0, ncodeunits(str) - npad) to pad by codeunits" *
             (s isa AbstractString && codeunit(s) != UInt8 ? "?" : " (bytes)?"))))
     end

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -476,7 +476,12 @@ function lpad(
     n = Int(n)::Int
     m = signed(n) - Int(textwidth(s))::Int
     m ≤ 0 && return stringfn(s)
-    l = textwidth(p)
+    l = Int(textwidth(p))::Int
+    if l == 0
+        throw(ArgumentError("$(repr(p)) has zero width" * (ncodeunits(p) != 1 ? "" :
+            "; maybe you want pad^max(0, ncodeunits(str) - npad) * str to pad by codeunits" *
+            (s isa AbstractString && codeunit(s) != UInt8 ? "?" : " (bytes)?"))))
+    end
     q, r = divrem(m, l)
     r == 0 ? stringfn(p^q, s) : stringfn(p^q, first(p, r), s)
 end
@@ -508,7 +513,12 @@ function rpad(
     n = Int(n)::Int
     m = signed(n) - Int(textwidth(s))::Int
     m ≤ 0 && return stringfn(s)
-    l = textwidth(p)
+    l = Int(textwidth(p))::Int
+    if l == 0
+        throw(ArgumentError("$(repr(p)) has zero width" * (ncodeunits(p) != 1 ? "" :
+            "; maybe you want str * pad^max(0, ncodeunits(str) - npad) to pad by codeunits" *
+            (s isa AbstractString && codeunit(s) != UInt8 ? "?" : " (bytes)?"))))
+    end
     q, r = divrem(m, l)
     r == 0 ? stringfn(s, p^q) : stringfn(s, p^q, first(p, r))
 end

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -66,7 +66,10 @@ end
     @test lpad("⟨k|H₁|k⟩", 12) |> textwidth == 12
     @test rpad("⟨k|H₁|k⟩", 12) |> textwidth == 12
     for pad in (rpad, lpad), p in ('\0', "\0", "\0\0", "\u302")
-        @test_throws ArgumentError pad("foo", 10, p)
+        @test_throws "has zero textwidth" pad("foo", 10, p)
+        if ncodeunits(p) == 1
+            @test_throws r".*has zero textwidth.*maybe you want.*bytes.*" pad("foo", 10, p)
+        end
     end
 end
 

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -66,9 +66,10 @@ end
     @test lpad("⟨k|H₁|k⟩", 12) |> textwidth == 12
     @test rpad("⟨k|H₁|k⟩", 12) |> textwidth == 12
     for pad in (rpad, lpad), p in ('\0', "\0", "\0\0", "\u302")
-        @test_throws "has zero textwidth" pad("foo", 10, p)
         if ncodeunits(p) == 1
             @test_throws r".*has zero textwidth.*maybe you want.*bytes.*" pad("foo", 10, p)
+        else
+            @test_throws r".*has zero textwidth$" pad("foo", 10, p)
         end
     end
 end

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -65,6 +65,9 @@ end
     @test rpad("⟨k|H₁|k̃⟩", 12) |> textwidth == 12
     @test lpad("⟨k|H₁|k⟩", 12) |> textwidth == 12
     @test rpad("⟨k|H₁|k⟩", 12) |> textwidth == 12
+    for pad in (rpad, lpad), p in ('\0', "\0", "\0\0", "\u302")
+        @test_throws ArgumentError pad("foo", 10, p)
+    end
 end
 
 @testset "string truncation (ltruncate, rtruncate, ctruncate)" begin


### PR DESCRIPTION
Closes #45339 — throw a more informative `ArgumentError` message from `rpad` and `lpad` if a zero-`textwidth` padding is passed (not a `DivideError`).

If the padding character has `ncodeunits == 1`, suggests that maybe they want `str * pad^max(0, npad - ncodeunits(str))` instead.