### PR TITLE
make: define `basecompiler.ji` target

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -86,13 +86,7 @@ function include(mod::Module, x::String)
     Base.include(mod, x)
 end
 
-
 macro _boundscheck() Expr(:boundscheck) end
-
-# These types are used by reflection.jl and expr.jl too, so declare them here.
-# Note that `@assume_effects` is available only after loading namedtuple.jl.
-abstract type MethodTableView end
-abstract type AbstractInterpreter end
 
 function return_type end
 function is_return_type(Core.@nospecialize(f))
@@ -189,6 +183,6 @@ if isdefined(Base, :IRShow)
     end
 end
 
-end
+end # baremodule Compiler
 
-end
+end # if isdefined(Base, :generating_output) && ...

--- a/Compiler/src/cicache.jl
+++ b/Compiler/src/cicache.jl
@@ -77,9 +77,3 @@ function setindex!(wvc::WorldView{InternalCodeCache}, ci::CodeInstance, mi::Meth
     setindex!(wvc.cache, ci, mi)
     return wvc
 end
-
-function code_cache(interp::AbstractInterpreter)
-    cache = InternalCodeCache(cache_owner(interp))
-    worlds = WorldRange(get_inference_world(interp))
-    return WorldView(cache, worlds)
-end

--- a/Compiler/src/methodtable.jl
+++ b/Compiler/src/methodtable.jl
@@ -16,6 +16,8 @@ function iterate(result::MethodLookupResult, args...)
 end
 getindex(result::MethodLookupResult, idx::Int) = getindex(result.matches, idx)::MethodMatch
 
+abstract type MethodTableView end
+
 """
     struct InternalMethodTable <: MethodTableView
 

--- a/Compiler/src/types.jl
+++ b/Compiler/src/types.jl
@@ -24,7 +24,7 @@ the following methods to satisfy the `AbstractInterpreter` API requirement:
 - `get_inference_cache(interp::NewInterpreter)` - return the local inference cache
 - `cache_owner(interp::NewInterpreter)` - return the owner of any new cache entries
 """
-:(AbstractInterpreter)
+abstract type AbstractInterpreter end
 
 abstract type AbstractLattice end
 
@@ -464,6 +464,12 @@ infer_compilation_signature(::NativeInterpreter) = true
 typeinf_lattice(::AbstractInterpreter) = InferenceLattice(BaseInferenceLattice.instance)
 ipo_lattice(::AbstractInterpreter) = InferenceLattice(IPOResultLattice.instance)
 optimizer_lattice(::AbstractInterpreter) = SimpleInferenceLattice.instance
+
+function code_cache(interp::AbstractInterpreter)
+  cache = InternalCodeCache(cache_owner(interp))
+  worlds = WorldRange(get_inference_world(interp))
+  return WorldView(cache, worlds)
+end
 
 get_escape_cache(interp::AbstractInterpreter) = GetNativeEscapeCache(interp)
 

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 baremodule Base
+
 using Core.Intrinsics, Core.IR
 
 # to start, we're going to use a very simple definition of `include`
@@ -128,7 +129,6 @@ function setpropertyonce!(x::Module, f::Symbol, desired, success_order::Symbol=:
     return Core.setglobalonce!(x, f, val, success_order, fail_order)
 end
 
-
 convert(::Type{Any}, Core.@nospecialize x) = x
 convert(::Type{T}, x::T) where {T} = x
 include("coreio.jl")
@@ -254,7 +254,6 @@ using .Order
 
 include("coreir.jl")
 
-
 # For OS specific stuff
 # We need to strcat things here, before strings are really defined
 function strcat(x::String, y::String)
@@ -267,10 +266,9 @@ function strcat(x::String, y::String)
     return out
 end
 
-BUILDROOT::String = ""
+global BUILDROOT::String = ""
 
-baremodule BuildSettings
-end
+baremodule BuildSettings end
 
 function process_sysimg_args!()
     let i = 1
@@ -299,4 +297,5 @@ include("flparse.jl")
 Core._setparser!(fl_parse)
 
 # Further definition of Base will happen in Base.jl if loaded.
-end
+
+end # baremodule Base

--- a/sysimage.mk
+++ b/sysimage.mk
@@ -6,6 +6,7 @@ include $(JULIAHOME)/stdlib/stdlib.mk
 
 default: sysimg-$(JULIA_BUILD_MODE) # contains either "debug" or "release"
 all: sysimg-release sysimg-debug
+basecompiler-ji: $(build_private_libdir)/basecompiler.ji
 sysimg-ji: $(build_private_libdir)/sys.ji
 sysimg-bc: $(build_private_libdir)/sys-bc.a
 sysimg-release: $(build_private_libdir)/sys.$(SHLIB_EXT)

--- a/test/compiler/contextual.jl
+++ b/test/compiler/contextual.jl
@@ -11,7 +11,7 @@ module MiniCassette
     # fancy features, but sufficient to exercise this code path in the compiler.
 
     using Core.IR
-    using Core.Compiler: retrieve_code_info, quoted, signature_type, anymap
+    using Core.Compiler: retrieve_code_info, quoted, anymap
     using Base.Meta: isexpr
 
     export Ctx, overdub


### PR DESCRIPTION
For easier experimentation with just the bootstrap process.

Additionally, as a follow-up to JuliaLang/julia#56409, this commit also includes some minor cosmetic changes.