### PR TITLE
Generalize signature of `checkbounds(A, I...)`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -693,8 +693,12 @@ end
     checkbounds(A, I...)
 
 Throw an error if the specified indices `I` are not in bounds for the given array `A`.
+
+!!! note
+    Custom types wishing to opt into bounds-checking should define
+    `checkbounds(::Type{Bool}, A::CustomType, I...)` instead of this method.
 """
-function checkbounds(A::AbstractArray, I...)
+function checkbounds(A, I...)
     @inline
     checkbounds(Bool, A, I...) || throw_boundserror(A, I)
     nothing


### PR DESCRIPTION
This method checks if indices are within bounds, and throws an error if they aren't. Custom types such as `Broadcasted`, therefore, would only need to implement the bounds-checking logic, and may leave the error-throwing bit to `Base`. They may do this by specializing `checkbounds(Bool, A::MyType, I...)` instead of `checkbounds(A, I...)`, and the fallback implementation of the latter would handle processing the result.