### PR TITLE
Profile: add helper method for printing profile report to file

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -217,7 +217,7 @@ const META_OFFSET_THREADID = 5
 
 """
     print([io::IO = stdout,] [data::Vector = fetch()], [lidict::Union{LineInfoDict, LineInfoFlatDict} = getdict(data)]; kwargs...)
-    print(path::String [data::Vector = fetch()], [lidict::Union{LineInfoDict, LineInfoFlatDict} = getdict(data)]; kwargs...)
+    print(path::String, [cols::Int = 1000], [data::Vector = fetch()], [lidict::Union{LineInfoDict, LineInfoFlatDict} = getdict(data)]; kwargs...)
 
 Prints profiling results to `io` (by default, `stdout`). If you do not
 supply a `data` vector, the internal buffer of accumulated backtraces
@@ -358,9 +358,9 @@ function print(io::IO,
     return
 end
 
-function print(path::String, args...; kwargs...)
+function print(path::String, cols::Int = 1000, args...; kwargs...)
     open(path, "w") do io
-        ioc = IOContext(io, :displaysize=>(100000,100000))
+        ioc = IOContext(io, :displaysize=>(1000,cols))
         print(ioc, args...; kwargs...)
     end
 end

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -217,6 +217,7 @@ const META_OFFSET_THREADID = 5
 
 """
     print([io::IO = stdout,] [data::Vector = fetch()], [lidict::Union{LineInfoDict, LineInfoFlatDict} = getdict(data)]; kwargs...)
+    print(path::String [data::Vector = fetch()], [lidict::Union{LineInfoDict, LineInfoFlatDict} = getdict(data)]; kwargs...)
 
 Prints profiling results to `io` (by default, `stdout`). If you do not
 supply a `data` vector, the internal buffer of accumulated backtraces
@@ -355,6 +356,13 @@ function print(io::IO,
         any_nosamples && warning_empty(summary = true)
     end
     return
+end
+
+function print(path::String, args...; kwargs...)
+    open(path, "w") do io
+        ioc = IOContext(io, :displaysize=>(100000,100000))
+        print(ioc, args...; kwargs...)
+    end
 end
 
 """

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -95,6 +95,9 @@ for options in ((format=:tree, C=true),
     Profile.print(iobuf; options...)
     str = String(take!(iobuf))
     @test !isempty(str)
+    file, _ = mktemp()
+    Profile.print(file; options...)
+    @test filesize(file) > 0
 end
 
 @testset "Profile.print() groupby options" begin


### PR DESCRIPTION
The IOContext part is isn't obvious, because otherwise the IO is assumed to be 80 chars wide, which makes for bad reports.