### PR TITLE
use LQ for "wide A" \ b, not QR

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1209,8 +1209,11 @@ function (\)(A::AbstractMatrix, B::AbstractVecOrMat)
             return UpperTriangular(A) \ B
         end
         return lu(A) \ B
+    elseif m > n # (overdetermined) use pivoted QR
+        return qr(A, ColumnNorm()) \ B
+    else # m < n (underdetermined) use LQ = pivoted QR of A'
+        return qr(A', ColumnNorm())' \ B
     end
-    return qr(A, ColumnNorm()) \ B
 end
 
 (\)(a::AbstractVector, b::AbstractArray) = pinv(a) * b


### PR DESCRIPTION
As discussed in #34350, for a "wide" ("underdetermined") system of equations, `A \ b` seems to be more efficient if computed by "LQ" factorization, i.e. QR factorization of the transpose `A'`.  (More than 2x faster on my machine for a 100×1000 matrix.)

* It still computes the minimum-norm solution as before, and should still be robust to ill-conditioned A (it doesn't square the condition number, and uses row-pivoting = column pivoting of the transpose).  Using the LQ factorization to compute the minimum-norm solution is described in the [LAPACK manual on LQ](https://www.netlib.org/lapack/lug/node41.html), is straightforward and is already implemented.  
* The old solution uses pivoted QR of A (not its transpose) followed by ["complete orthogonal factorization"](https://www.netlib.org/lapack/lug/node43.html) of R.  The latter step seems to pay a big performance price.
* Although we have `lq(A)`, it does not currently support row-pivoting, so I use `qr(A', ColumnNorm())'` instead, which is logically equivalent.

Hopefully this is already covered by the existing tests?