### PR TITLE
Profile: fix Compiler short path

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -529,9 +529,11 @@ function flatten(data::Vector, lidict::LineInfoDict)
 end
 
 const SRC_DIR = normpath(joinpath(Sys.BUILD_ROOT_PATH, "src"))
+const COMPILER_DIR = "././../usr/share/julia/Compiler/"
 
 # Take a file-system path and try to form a concise representation of it
 # based on the package ecosystem
+# filenamecache is a dict of spath -> (fullpath or "" if !isfile, modulename, shortpath)
 function short_path(spath::Symbol, filenamecache::Dict{Symbol, Tuple{String,String,String}})
     return get!(filenamecache, spath) do
         path = Base.fixup_stdlib_path(string(spath))
@@ -544,6 +546,10 @@ function short_path(spath::Symbol, filenamecache::Dict{Symbol, Tuple{String,Stri
         elseif startswith(path_norm, lib_dir)
             remainder = only(split(path_norm, lib_dir, keepempty=false))
             return (isfile(path_norm) ? path_norm : ""), "@julialib", remainder
+        elseif startswith(path, COMPILER_DIR)
+            remainder = only(split(path, COMPILER_DIR, keepempty=false))
+            possible_compiler_path = normpath(joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "Compiler", remainder))
+            return (isfile(possible_compiler_path) ? possible_compiler_path : ""), "@Compiler", remainder
         elseif isabspath(path)
             if ispath(path)
                 # try to replace the file-system prefix with a short "@Module" one,


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/56504

@Keno I'm not sure this is the best/most robust way to do this.. I couldn't figure out where the relative source paths Compiler were relative to.

![Screenshot 2024-11-09 at 5 07 40 PM](https://github.com/user-attachments/assets/c5eb6485-eed0-45b1-8183-eaea92790d93)
