### PR TITLE
For loop instead of while in generic `copyto!`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1012,14 +1012,19 @@ function copyto!(dest::AbstractArray, dstart::Integer, src, sstart::Integer, n::
         end
         y = iterate(src, y[2])
     end
-    i = Int(dstart)
-    while i <= dmax && y !== nothing
-        val, st = y
-        @inbounds dest[i] = val
-        y = iterate(src, st)
-        i += 1
+    if y === nothing
+        throw(ArgumentError(LazyString(
+            "source has fewer elements than required, ",
+            "expected at least ",sstart," got ", sstart-1)))
     end
-    i <= dmax && throw(BoundsError(dest, i))
+    val, st = y
+    i = Int(dstart)
+    @inbounds dest[i] = val
+    for val in Iterators.take(Iterators.rest(src, st), n-1)
+        i += 1
+        @inbounds dest[i] = val
+    end
+    i < dmax && throw(BoundsError(dest, i))
     return dest
 end
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2172,3 +2172,13 @@ end
     @test one(Mat([1 2; 3 4])) == Mat([1 0; 0 1])
     @test one(Mat([1 2; 3 4])) isa Mat
 end
+
+@testset "copyto! with non-AbstractArray src" begin
+    A = zeros(4)
+    x = (i for i in axes(A,1))
+    copyto!(A, 1, x, 1, length(A))
+    @test A == axes(A,1)
+    A .= 0
+    copyto!(A, 1, x, 1)
+    @test A == axes(A,1)
+end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2179,6 +2179,10 @@ end
     copyto!(A, 1, x, 1, length(A))
     @test A == axes(A,1)
     A .= 0
+    copyto!(A, 1, x, 1, 2)
+    @test A[1:2] == first(x,2)
+    @test iszero(A[3:end])
+    A .= 0
     copyto!(A, 1, x, 1)
     @test A == axes(A,1)
 end


### PR DESCRIPTION
This appears to improve performance.
```julia
julia> A = zeros(100_000);

julia> x = (i for i in axes(A,1));

julia> @btime copyto!($A, 1, $x, 1, length($A));
  64.162 μs (0 allocations: 0 bytes) # nightly v"1.12.0-DEV.1593"
  52.532 μs (0 allocations: 0 bytes) # this PR
```