### PR TITLE
inference: (slightly) improve type stability of capturing closures

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -335,7 +335,7 @@ end
 
 const REFLECTION_COMPILER = RefValue{Union{Nothing, Module}}(nothing)
 
-function invoke_in_typeinf_world(args...)
+function invoke_in_typeinf_world(@nospecialize args...)
     vargs = Any[args...]
     return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Any}, Cint), vargs, length(vargs))
 end


### PR DESCRIPTION
As an idea to improve type stability for capturing closures, such as in JuliaLang/julia#31909, I tried this idea of propagating the closure object as a `PartialStruct` whose `fields` include captured variables of which types are (partially) known. By performing const-prop on this `closure::PartialStruct`, we can achieve a certain level of type stability.
Specifically, I made some modifications to `abstract_eval_new` to allow creating `PartialStruct` even for `:new` objects that are `!isconcretedispatch` (since `PartialStruct` can now represent abstract elements). I also adjusted `const_prop_argument_heuristic` to perform aggressive constant propagation using such `closure::PartialStruct`.

As a result, the following code now achieves type stability:
```julia
julia> Base.infer_return_type((Bool,Int,)) do b, y
           x = b ? 1 : missing
           inner = y -> x + y
           return inner(y)
       end
Any                   # master
Union{Missing, Int64} # this commit
```

However, this alone was not enough to fully resolve JuliaLang/julia#31909. The call graph of `map` is extremely complex, and simply applying constant propagation everywhere does not achieve the type safety requested in the issue.

Nevertheless this commit alone would still improve type stability for some cases, so I will go ahead and submit it as a PR.

---

@nanosoldier `runbenchmarks("inference", vs=":master")`