### PR TITLE
Fix and test special loading support for Compiler

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -6,13 +6,13 @@
 # the system image and simply returns that copy of the compiler. If not,
 # we proceed to load/precompile this as an ordinary package.
 if isdefined(Base, :generating_output) && Base.generating_output(true) &&
-        Base.samefile(Base._compiler_require_dependencies[1][2], @eval @__FILE__) &&
+        Base.samefile(joinpath(Sys.BINDIR, Base.DATAROOTDIR, Base._compiler_require_dependencies[1][2]), @eval @__FILE__) &&
         !Base.any_includes_stale(
-            map(Base.CacheHeaderIncludes, Base._compiler_require_dependencies),
+            map(Base.compiler_chi, Base._compiler_require_dependencies),
             "sysimg", nothing)
 
     Base.prepare_compiler_stub_image!()
-    append!(Base._require_dependencies, Base._compiler_require_dependencies)
+    append!(Base._require_dependencies, map(Base.expand_compiler_path, Base._compiler_require_dependencies))
     # There isn't much point in precompiling native code - downstream users will
     # specialize their own versions of the compiler code and we don't activate
     # the compiler by default anyway, so let's save ourselves some disk space.

--- a/Compiler/test/CompilerLoadingTest/Manifest.toml
+++ b/Compiler/test/CompilerLoadingTest/Manifest.toml
@@ -1,0 +1,16 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.0-DEV"
+manifest_format = "2.0"
+project_hash = "10c2816629fed766649b89eb6670e7001df6ea18"
+
+[[deps.Compiler]]
+path = "../.."
+uuid = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
+version = "0.0.1"
+
+[[deps.CompilerLoadingTest]]
+deps = ["Compiler"]
+path = "."
+uuid = "95defb8a-f82d-44d7-b2c9-37d658f648c1"
+version = "0.0.0"

--- a/Compiler/test/CompilerLoadingTest/Project.toml
+++ b/Compiler/test/CompilerLoadingTest/Project.toml
@@ -1,0 +1,5 @@
+name = "CompilerLoadingTest"
+uuid = "95defb8a-f82d-44d7-b2c9-37d658f648c1"
+
+[deps]
+Compiler = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"

--- a/Compiler/test/CompilerLoadingTest/compiler_loading_test.jl
+++ b/Compiler/test/CompilerLoadingTest/compiler_loading_test.jl
@@ -1,0 +1,12 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+using Test, UUIDs
+
+# This file is loaded as part of special_loading.jl
+Base.compilecache(Base.PkgId(UUID(0x95defb8a_f82d_44d7_b2c9_37d658f648c1), "CompilerLoadingTest"))
+
+using CompilerLoadingTest
+@test Base.maybe_loaded_precompile(Base.PkgId(UUID(0x807dbc54_b67e_4c79_8afb_eafe4df6f2e1), "Compiler"), Base.module_build_id(Base.Compiler)) !== nothing
+
+using Compiler
+@test CompilerLoadingTest.Compiler === Compiler === Base.Compiler

--- a/Compiler/test/CompilerLoadingTest/src/CompilerLoadingTest.jl
+++ b/Compiler/test/CompilerLoadingTest/src/CompilerLoadingTest.jl
@@ -1,0 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module CompilerLoadingTest
+    using Compiler
+end

--- a/Compiler/test/irutils.jl
+++ b/Compiler/test/irutils.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 using Core.IR
 using Core.Compiler: IRCode, IncrementalCompact, singleton_type, VarState
 using Base.Meta: isexpr

--- a/Compiler/test/runtests.jl
+++ b/Compiler/test/runtests.jl
@@ -2,5 +2,6 @@
 using Test, Compiler
 
 for file in readlines(joinpath(@__DIR__, "testgroups"))
+    file == "special_loading" && continue # Only applicable to Base.Compiler
     include(file * ".jl")
 end

--- a/Compiler/test/special_loading.jl
+++ b/Compiler/test/special_loading.jl
@@ -1,0 +1,9 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+mktempdir() do dir
+    withenv("JULIA_DEPOT_PATH" => dir * (Sys.iswindows() ? ";" : ":"), "JULIA_LOAD_PATH" => nothing) do
+        cd(joinpath(@__DIR__, "CompilerLoadingTest")) do
+            @test success(pipeline(`$(Base.julia_cmd()[1]) --startup-file=no --project=. compiler_loading_test.jl`; stdout, stderr))
+        end
+    end
+end

--- a/Compiler/test/testgroups
+++ b/Compiler/test/testgroups
@@ -14,3 +14,4 @@ newinterp
 ssair
 tarjan
 validation
+special_loading

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -407,6 +407,13 @@ for i = 1:length(_included_files)
         _include_dependency!(_compiler_require_dependencies, true, mod, file, true, false)
     end
 end
+# Make relative to DATAROOTDIR to allow relocation
+let basedir = joinpath(Sys.BINDIR, DATAROOTDIR)
+for i = 1:length(_compiler_require_dependencies)
+    tup = _compiler_require_dependencies[i]
+    _compiler_require_dependencies[i] = (tup[1], relpath(tup[2], basedir), tup[3:end]...)
+end
+end
 @assert length(_compiler_require_dependencies) >= 15
 
 end

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3938,6 +3938,9 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image, jl
         size_t len = jl_array_nrows(*restored);
         assert(len > 0);
         jl_module_t *topmod = (jl_module_t*)jl_array_ptr_ref(*restored, len-1);
+        // Ordinarily set during deserialization, but our compiler stub image,
+        // just returns a reference to the sysimage version, so we set it here.
+        topmod->build_id.hi = checksum;
         assert(jl_is_module(topmod));
         arraylist_push(&jl_top_mods, (void*)topmod);
     }

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -505,13 +505,18 @@ static int64_t write_header(ios_t *s, uint8_t pkgimage)
     return checksumpos;
 }
 
+static int is_serialization_root_module(jl_module_t *mod) JL_NOTSAFEPOINT
+{
+    return mod->parent == jl_main_module || mod->parent == jl_base_module || mod->parent == mod;
+}
+
 // serialize information about the result of deserializing this file
 static void write_worklist_for_header(ios_t *s, jl_array_t *worklist)
 {
     int i, l = jl_array_nrows(worklist);
     for (i = 0; i < l; i++) {
         jl_module_t *workmod = (jl_module_t*)jl_array_ptr_ref(worklist, i);
-        if (workmod->parent == jl_main_module || workmod->parent == workmod) {
+        if (is_serialization_root_module(workmod)) {
             size_t l = strlen(jl_symbol_name(workmod->name));
             write_int32(s, l);
             ios_write(s, jl_symbol_name(workmod->name), l);
@@ -525,7 +530,7 @@ static void write_worklist_for_header(ios_t *s, jl_array_t *worklist)
 
 static void write_module_path(ios_t *s, jl_module_t *depmod) JL_NOTSAFEPOINT
 {
-    if (depmod->parent == jl_main_module || depmod->parent == depmod)
+    if (is_serialization_root_module(depmod))
         return;
     const char *mname = jl_symbol_name(depmod->name);
     size_t slen = strlen(mname);
@@ -603,13 +608,13 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
         write_float64(s, jl_unbox_float64(jl_fieldref(deptuple, 4)));  // mtime
         jl_module_t *depmod = (jl_module_t*)jl_fieldref(deptuple, 0);  // evaluating module
         jl_module_t *depmod_top = depmod;
-        while (depmod_top->parent != jl_main_module && depmod_top->parent != depmod_top)
+        while (!is_serialization_root_module(depmod_top))
             depmod_top = depmod_top->parent;
         unsigned provides = 0;
         size_t j, lj = jl_array_nrows(worklist);
         for (j = 0; j < lj; j++) {
             jl_module_t *workmod = (jl_module_t*)jl_array_ptr_ref(worklist, j);
-            if (workmod->parent == jl_main_module || workmod->parent == workmod) {
+            if (is_serialization_root_module(workmod)) {
                 ++provides;
                 if (workmod == depmod_top) {
                     write_int32(s, provides);


### PR DESCRIPTION
The new `Compiler` package has a special stub that bypasses compilig a separate copy if you have `dev`'ed the version that's already compiled into the sysimg. It wasn't quite working properly in the final version of that PR if a compiler so loaded was a dependency of another precompiled package. Fix that and add a test to make sure it doesn't regress.