### PR TITLE
Merge Compiler.isready and Base.isready

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -57,7 +57,7 @@ using Base: Ordering, vect, EffectsOverride, BitVector, @_gc_preserve_begin, @_g
 using Base.Order
 import Base: getindex, setindex!, length, iterate, push!, isempty, first, convert, ==,
     copy, popfirst!, in, haskey, resize!, copy!, append!, last, get!, size,
-    get, iterate, findall, min_world, max_world, _topmod
+    get, iterate, findall, min_world, max_world, _topmod, isready
 
 const getproperty = Core.getfield
 const setproperty! = Core.setfield!

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -286,6 +286,8 @@ function process_sysimg_args!()
 end
 process_sysimg_args!()
 
+function isready end
+
 include(strcat(BUILDROOT, "../usr/share/julia/Compiler/src/Compiler.jl"))
 
 const _return_type = Compiler.return_type


### PR DESCRIPTION
These didn't get merged when the Compiler moved out, because the Base function doesn't get defined until very late in the build process. However, they are semantically the same, so merge their method tables.