### PR TITLE
Some misc compiler-related code cleanup

### DIFF
--- a/Compiler/src/ssair/ir.jl
+++ b/Compiler/src/ssair/ir.jl
@@ -482,6 +482,7 @@ function block_for_inst(ir::IRCode, inst::Int)
     end
     block_for_inst(ir.cfg, inst)
 end
+block_for_inst(ir::IRCode, ssa::SSAValue) = block_for_inst(ir, ssa.id)
 
 function getindex(ir::IRCode, s::SSAValue)
     id = s.id

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -39,29 +39,35 @@ isexpr(@nospecialize(ex), head::Symbol) = isa(ex, Expr) && ex.head === head
 isexpr(@nospecialize(ex), head::Symbol, n::Int) = isa(ex, Expr) && ex.head === head && length(ex.args) == n
 
 copy(e::Expr) = exprarray(e.head, copy_exprargs(e.args))
+function copy(x::PhiNode)
+    values = x.values
+    nvalues = length(values)
+    new_values = Vector{Any}(undef, nvalues)
+    @inbounds for i = 1:nvalues
+        isassigned(values, i) || continue
+        new_values[i] = copy_exprs(values[i])
+    end
+    return PhiNode(copy(x.edges), new_values)
+end
+function copy(x::PhiCNode)
+    values = x.values
+    nvalues = length(values)
+    new_values = Vector{Any}(undef, nvalues)
+    @inbounds for i = 1:nvalues
+        isassigned(values, i) || continue
+        new_values[i] = copy_exprs(values[i])
+    end
+    return PhiCNode(new_values)
+end
 
 # copy parts of an AST that the compiler mutates
 function copy_exprs(@nospecialize(x))
     if isa(x, Expr)
         return copy(x)
     elseif isa(x, PhiNode)
-        values = x.values
-        nvalues = length(values)
-        new_values = Vector{Any}(undef, nvalues)
-        @inbounds for i = 1:nvalues
-            isassigned(values, i) || continue
-            new_values[i] = copy_exprs(values[i])
-        end
-        return PhiNode(copy(x.edges), new_values)
+        return copy(x)
     elseif isa(x, PhiCNode)
-        values = x.values
-        nvalues = length(values)
-        new_values = Vector{Any}(undef, nvalues)
-        @inbounds for i = 1:nvalues
-            isassigned(values, i) || continue
-            new_values[i] = copy_exprs(values[i])
-        end
-        return PhiCNode(new_values)
+        return copy(x)
     end
     return x
 end


### PR DESCRIPTION
I'm cleaning up some downstream packages following the compiler split and these were commonly found in compat code. One is the `Base.copy` method for Phi(C)Node, which we had an implementation for, just not wired up to `copy`. The other is `block_for_inst` with an SSAValue, which exists for IncremetalCompact, but not IRCode, so add the latter for consistency.