### PR TITLE
remove type piracy from `==` defined in `Compiler`

### DIFF
--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -191,11 +191,6 @@ struct NotFound end
 
 const NOT_FOUND = NotFound()
 
-const CompilerTypes = Union{Const, Conditional, MustAlias, NotFound, PartialStruct}
-==(x::CompilerTypes, y::CompilerTypes) = x === y
-==(x::Type, y::CompilerTypes) = false
-==(x::CompilerTypes, y::Type) = false
-
 #################
 # lattice logic #
 #################

--- a/base/coreir.jl
+++ b/base/coreir.jl
@@ -45,8 +45,7 @@ Core.PartialStruct
 
 Similar to `Conditional`, but conveys inter-procedural constraints imposed on call arguments.
 This is separate from `Conditional` to catch logic errors: the lattice element name is `InterConditional`
-while processing a call, then `Conditional` everywhere else. Thus `InterConditional` does not appear in
-`CompilerTypes`—these type's usages are disjoint—though we define the lattice for `InterConditional`.
+while processing a call, then `Conditional` everywhere else.
 """
 Core.InterConditional
 


### PR DESCRIPTION
`Compiler.:(==)` is now identical to `Base.:(==)`, so the following `==` methods defined in typelattice.jl are considered type piracy: https://github.com/JuliaLang/julia/blob/1edc6f1b7752ed67059020ba7ce174dffa225954/Compiler/src/typelattice.jl#L194-L197

In fact, loading `Compiler` as a standard library with this code can sometimes result in errors like the following:
```julia
julia> using Compiler

julia> Int == Core.Const(1)
ERROR: MethodError: ==(::Type{Int64}, ::Core.Const) is ambiguous.
...
```

Since these `==` definitions no longer seem necessary, this commit simply removes them to resolve the issue.

@nanosoldier `runbenchmarks("inference", vs=":master")`