### PR TITLE
fix `IRShow.show` of the standard library `Compiler`

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -169,15 +169,7 @@ include("reflection_interface.jl")
 
 if isdefined(Base, :IRShow)
     @eval module IRShow
-        import ..Compiler
-        using Core.IR
-        using ..Base
-        import .Compiler: IRCode, CFG, scan_ssa_use!,
-            isexpr, compute_basic_blocks, block_for_inst, IncrementalCompact,
-            Effects, ALWAYS_TRUE, ALWAYS_FALSE, DebugInfoStream, getdebugidx,
-            VarState, InvalidIRError, argextype, widenconst, singleton_type,
-            sptypes_from_meth_instance, EMPTY_SPTYPES, InferenceState,
-            NativeInterpreter, CachedMethodTable, LimitedAccuracy, Timings
+        using ..Compiler: Compiler
         # During bootstrap, Base will later include this into its own "IRShow module"
         Compiler.include(IRShow, "ssair/show.jl")
     end

--- a/base/show.jl
+++ b/base/show.jl
@@ -2822,23 +2822,14 @@ function show(io::IO, vm::Core.TypeofVararg)
 end
 
 module IRShow
-    import ..Compiler
-    using Core.IR
-    import ..Base
-    import .Compiler: IRCode, CFG, scan_ssa_use!,
-        isexpr, compute_basic_blocks, block_for_inst, IncrementalCompact,
-        Effects, ALWAYS_TRUE, ALWAYS_FALSE, DebugInfoStream, getdebugidx,
-        VarState, InvalidIRError, argextype, widenconst, singleton_type,
-        sptypes_from_meth_instance, EMPTY_SPTYPES, InferenceState,
-        NativeInterpreter, CachedMethodTable, LimitedAccuracy, Timings
-
+    using ..Compiler: Compiler
     Base.include(IRShow, Base.strcat(Base.BUILDROOT, "../usr/share/julia/Compiler/src/ssair/show.jl"))
 
     const __debuginfo = Dict{Symbol, Any}(
         # :full => src -> statementidx_lineinfo_printer(src), # and add variable slot information
         :source => src -> statementidx_lineinfo_printer(src),
         # :oneliner => src -> statementidx_lineinfo_printer(PartialLineInfoPrinter, src),
-        :none => src -> Base.IRShow.lineinfo_disabled,
+        :none => src -> lineinfo_disabled,
         )
     const default_debuginfo = Ref{Symbol}(:none)
     debuginfo(sym) = sym === :default ? default_debuginfo[] : sym


### PR DESCRIPTION
Previously, definitions of overloaded `Base.show` and `IRShow.show` were mixed, causing `show` to not function properly for `Compiler` as a standard library. This commit fixes that issue and also includes some minor cleanups.