### PR TITLE
allow the Compiler.jl stdlib to be installed on older version of Julia

### DIFF
--- a/Compiler/Project.toml
+++ b/Compiler/Project.toml
@@ -1,3 +1,3 @@
 name = "Compiler"
 uuid = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
-version = "0.0.1"
+version = "0.0.2"

--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -180,12 +180,12 @@ include("optimize.jl")
 include("bootstrap.jl")
 include("reflection_interface.jl")
 
-if isdefined(Base, :end_base_include)
-    @eval module IRShow
-        using ..Compiler: Compiler
-        # During bootstrap, Base will later include this into its own "IRShow module"
-        Compiler.include(IRShow, "ssair/show.jl")
-    end
+module IRShow end
+if !isdefined(Base, :end_base_include)
+    # During bootstrap, skip including this file and defer it to base/show.jl to include later
+else
+    # When this module is loaded as the standard library, include this file as usual
+    include(IRShow, "ssair/show.jl")
 end
 
 end # baremodule Compiler

--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -1,15 +1,28 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+if isdefined(Base, :end_base_include) && !isdefined(Base, :Compiler)
+
+# Define a dummy `Compiler` module to make it installable even on Julia versions where
+# Compiler.jl is not available as a standard library.
+@eval module Compiler
+    function __init__()
+        println("""
+        The `Compiler` standard library is not available for this version of Julia.
+        Use Julia version `v"1.12.0-DEV.1581"` or later.
+        """)
+    end
+end
+
 # When generating an incremental precompile file, we first check whether we
 # already have a copy of this *exact* code in the system image. If so, we
 # simply generates a pkgimage that has the dependency edges we recorded in
 # the system image and simply returns that copy of the compiler. If not,
 # we proceed to load/precompile this as an ordinary package.
-if isdefined(Base, :generating_output) && Base.generating_output(true) &&
+elseif (isdefined(Base, :generating_output) && Base.generating_output(true) &&
         Base.samefile(joinpath(Sys.BINDIR, Base.DATAROOTDIR, Base._compiler_require_dependencies[1][2]), @eval @__FILE__) &&
         !Base.any_includes_stale(
             map(Base.compiler_chi, Base._compiler_require_dependencies),
-            "sysimg", nothing)
+            "sysimg", nothing))
 
     Base.prepare_compiler_stub_image!()
     append!(Base._require_dependencies, map(Base.expand_compiler_path, Base._compiler_require_dependencies))

--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -180,7 +180,7 @@ include("optimize.jl")
 include("bootstrap.jl")
 include("reflection_interface.jl")
 
-if isdefined(Base, :IRShow)
+if isdefined(Base, :end_base_include)
     @eval module IRShow
         using ..Compiler: Compiler
         # During bootstrap, Base will later include this into its own "IRShow module"

--- a/Compiler/src/ssair/show.jl
+++ b/Compiler/src/ssair/show.jl
@@ -1,7 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-# This file is not loaded into `Core.Compiler` but rather loaded into the context of
-# `Base.IRShow` and thus does not participate in bootstrapping.
+# This file does not participate in bootstrapping, but is included in the system image by
+# being loaded from `base/show.jl`. Compiler.jl as the standard library will simply include
+# this file in the context of `Compiler.IRShow`.
 
 using Base, Core.IR
 

--- a/Compiler/src/ssair/show.jl
+++ b/Compiler/src/ssair/show.jl
@@ -1135,3 +1135,12 @@ function Base.show(io::IO, tinf::Timings.Timing)
 end
 
 @specialize
+
+const __debuginfo = Dict{Symbol, Any}(
+    # :full => src -> statementidx_lineinfo_printer(src), # and add variable slot information
+    :source => src -> statementidx_lineinfo_printer(src),
+    # :oneliner => src -> statementidx_lineinfo_printer(PartialLineInfoPrinter, src),
+    :none => src -> lineinfo_disabled,
+    )
+const default_debuginfo = Ref{Symbol}(:none)
+debuginfo(sym) = sym === :default ? default_debuginfo[] : sym

--- a/base/show.jl
+++ b/base/show.jl
@@ -2821,10 +2821,8 @@ function show(io::IO, vm::Core.TypeofVararg)
     end
 end
 
-module IRShow
-    using ..Compiler: Compiler
-    Base.include(IRShow, Base.strcat(Base.BUILDROOT, "../usr/share/julia/Compiler/src/ssair/show.jl"))
-end
+Compiler.include(Compiler.IRShow, "ssair/show.jl") # define `show` for the compiler types
+const IRShow = Compiler.IRShow # an alias for compatibility
 
 function show(io::IO, src::CodeInfo; debuginfo::Symbol=:source)
     # Fix slot names and types in function body

--- a/base/show.jl
+++ b/base/show.jl
@@ -2824,15 +2824,6 @@ end
 module IRShow
     using ..Compiler: Compiler
     Base.include(IRShow, Base.strcat(Base.BUILDROOT, "../usr/share/julia/Compiler/src/ssair/show.jl"))
-
-    const __debuginfo = Dict{Symbol, Any}(
-        # :full => src -> statementidx_lineinfo_printer(src), # and add variable slot information
-        :source => src -> statementidx_lineinfo_printer(src),
-        # :oneliner => src -> statementidx_lineinfo_printer(PartialLineInfoPrinter, src),
-        :none => src -> lineinfo_disabled,
-        )
-    const default_debuginfo = Ref{Symbol}(:none)
-    debuginfo(sym) = sym === :default ? default_debuginfo[] : sym
 end
 
 function show(io::IO, src::CodeInfo; debuginfo::Symbol=:source)


### PR DESCRIPTION
Since JuliaLang/julia#56409, Compiler.jl as a standard library has become available. However, for Julia versions prior to this change, even though the stdlib can be installed via Pkg.jl, the precompilation fails due to code compatibility issues. Consequently, when an external package that uses the Compiler stdlib adds Compiler.jl to its Project.toml, the package would stop working on older Julia versions.

To address this, this commit adopts the same approach as JET.jl. Specifically, on older Julia versions, a dummy `Compiler` module is defined, allowing dependent packages to switch between using the Compiler.jl stdlib or the previous `Core.Compiler`. While this is a somewhat hacky solution, it should resolve the issue for now.