### PR TITLE
inference: Don't try to infer optimized opaque_closure

### DIFF
--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -352,7 +352,7 @@ allow the optimizer to rewrite the return type parameter of the `OpaqueClosure` 
 struct OpaqueClosureCreateInfo <: CallInfo
     unspec::CallMeta
     function OpaqueClosureCreateInfo(unspec::CallMeta)
-        @assert isa(unspec.info, OpaqueClosureCallInfo)
+        @assert isa(unspec.info, Union{OpaqueClosureCallInfo, NoCallInfo})
         return new(unspec)
     end
 end


### PR DESCRIPTION
We don't have frontend syntax for it, but there is a use case for having `:new_opaque_closure` take an OC constructed from an optimized OpaqueClosure (and just replacing the capture environment). In this case, there is nothing inference can do to introspect into the opaque closure, so it just needs to bail out early.