### PR TITLE
make `choosetests` find the test files for devved stdlibs

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -708,7 +708,7 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS / 2),
     ENV2["JULIA_LOAD_PATH"] = string("@", pathsep, "@stdlib")
     ENV2["JULIA_TESTS"] = "true"
     delete!(ENV2, "JULIA_PROJECT")
-    project_flag = propagate_project ? "--project" : ""
+    project_flag = propagate_project ? `--project` : ``
     try
         run(setenv(`$(julia_cmd()) $project_flag $(joinpath(Sys.BINDIR,
             Base.DATAROOTDIR, "julia", "test", "runtests.jl")) $tests`, ENV2))

--- a/base/util.jl
+++ b/base/util.jl
@@ -707,7 +707,7 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS / 2),
     ENV2["JULIA_TESTS"] = "true"
     delete!(ENV2, "JULIA_PROJECT")
     try
-        run(setenv(`$(julia_cmd()) $(joinpath(Sys.BINDIR,
+        run(setenv(`$(julia_cmd()) --project=$(Base.active_project()) $(joinpath(Sys.BINDIR,
             Base.DATAROOTDIR, "julia", "test", "runtests.jl")) $tests`, ENV2))
         nothing
     catch

--- a/base/util.jl
+++ b/base/util.jl
@@ -678,7 +678,7 @@ end
 
 """
     Base.runtests(tests=["all"]; ncores=ceil(Int, Sys.CPU_THREADS / 2),
-                  exit_on_error=false, revise=false, [seed])
+                  exit_on_error=false, revise=false, propagate_project=true, [seed])
 
 Run the Julia unit tests listed in `tests`, which can be either a string or an array of
 strings, using `ncores` processors. If `exit_on_error` is `false`, when one test
@@ -686,12 +686,14 @@ fails, all remaining tests in other files will still be run; they are otherwise 
 when `exit_on_error == true`.
 If `revise` is `true`, the `Revise` package is used to load any modifications to `Base` or
 to the standard libraries before running the tests.
+If `propagate_project` is true the current project is propagated to the test environment.
 If a seed is provided via the keyword argument, it is used to seed the
 global RNG in the context where the tests are run; otherwise the seed is chosen randomly.
 """
 function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS / 2),
                   exit_on_error::Bool=false,
                   revise::Bool=false,
+                  propagate_project::Bool=false,
                   seed::Union{BitInteger,Nothing}=nothing)
     if isa(tests,AbstractString)
         tests = split(tests)
@@ -706,8 +708,9 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS / 2),
     ENV2["JULIA_LOAD_PATH"] = string("@", pathsep, "@stdlib")
     ENV2["JULIA_TESTS"] = "true"
     delete!(ENV2, "JULIA_PROJECT")
+    project_flag = propagate_project ? "--project" : ""
     try
-        run(setenv(`$(julia_cmd()) --project=$(Base.active_project()) $(joinpath(Sys.BINDIR,
+        run(setenv(`$(julia_cmd()) $project_flag $(joinpath(Sys.BINDIR,
             Base.DATAROOTDIR, "julia", "test", "runtests.jl")) $tests`, ENV2))
         nothing
     catch

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -48,10 +48,11 @@ const NETWORK_REQUIRED_LIST = vcat(INTERNET_REQUIRED_LIST, ["Sockets"])
 function test_path(test)
     t = split(test, '/')
     if t[1] in STDLIBS
+        pkgdir = abspath(Base.find_package(String(t[1])), "..", "..")
         if length(t) == 2
-            return joinpath(STDLIB_DIR, t[1], "test", t[2])
+            return joinpath(pkgdir, "test", t[2])
         else
-            return joinpath(STDLIB_DIR, t[1], "test", "runtests")
+            return joinpath(pkgdir, "test", "runtests")
         end
     elseif t[1] == "Compiler"
         testpath = length(t) >= 2 ? t[2:end] : ("runtests",)


### PR DESCRIPTION
I want to move out LinearAlgebra into its own repository but I still want to be able to run its tests in parallel. The easiest would be to be able to use `Base.runtests` but right now it hard codes the path to the stdlib folder. Instead, use the loading mechanism to look up where the stdlib of the active project actively resides.

cc @Keno since maybe this is useful for Compiler.jl as well (not sure if it runs anything in parallel right now).