### PR TITLE
Delete unnecessary methods in OffsetArrays.jl

### DIFF
--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -571,17 +571,6 @@ Base.reshape(A::OffsetArray, inds::Tuple{Colon}) = _reshape_nov(A, inds)
 # This is a stopgap solution
 Base.permutedims(v::OffsetVector) = reshape(v, (1, axes(v, 1)))
 
-Base.fill(v, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
-    fill!(similar(Array{typeof(v)}, inds), v)
-Base.zeros(::Type{T}, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {T, N} =
-    fill!(similar(Array{T}, inds), zero(T))
-Base.ones(::Type{T}, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {T, N} =
-    fill!(similar(Array{T}, inds), one(T))
-Base.trues(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
-    fill!(similar(BitArray, inds), true)
-Base.falses(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
-    fill!(similar(BitArray, inds), false)
-
 Base.zero(A::OffsetArray) = parent_call(zero, A)
 Base.fill!(A::OffsetArray, x) = parent_call(Ap -> fill!(Ap, x), A)
 


### PR DESCRIPTION
These are all defined elsewhere in Base:
```julia
WARNING: Method definition fill(Any, Tuple{Vararg{Union{Integer, Base.AbstractUnitRange{T} where T}, N}}) where {N} in module Base at array.jl:542 overwritten in module OffsetArrays at /opt/hostedtoolcache/julia/nightly/x64/share/julia/test/testhelpers/OffsetArrays.jl:574.
WARNING: Method definition zeros(Type{T}, Tuple{Vararg{Union{Integer, Base.AbstractUnitRange{T} where T}, N}}) where {T, N} in module Base at array.jl:603 overwritten in module OffsetArrays at /opt/hostedtoolcache/julia/nightly/x64/share/julia/test/testhelpers/OffsetArrays.jl:576.
WARNING: Method definition ones(Type{T}, Tuple{Vararg{Union{Integer, Base.AbstractUnitRange{T} where T}, N}}) where {T, N} in module Base at array.jl:603 overwritten in module OffsetArrays at /opt/hostedtoolcache/julia/nightly/x64/share/julia/test/testhelpers/OffsetArrays.jl:578.
WARNING: Method definition trues(Tuple{Vararg{Union{Integer, Base.AbstractUnitRange{T} where T}, N}}) where {N} in module Base at bitarray.jl:426 overwritten in module OffsetArrays at /opt/hostedtoolcache/julia/nightly/x64/share/julia/test/testhelpers/OffsetArrays.jl:580.
WARNING: Method definition falses(Tuple{Vararg{Union{Integer, Base.AbstractUnitRange{T} where T}, N}}) where {N} in module Base at bitarray.jl:407 overwritten in module OffsetArrays at /opt/hostedtoolcache/julia/nightly/x64/share/julia/test/testhelpers/OffsetArrays.jl:582.
```

(similar to #56414)