### PR TITLE
threading deadlock: change jl_fptr_wait_for_compiled to actually compile code

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -677,7 +677,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_method_inferred(
         jl_method_instance_t *mi JL_PROPAGATES_ROOT, jl_value_t *rettype,
         size_t min_world, size_t max_world, jl_debuginfo_t *di, jl_svec_t *edges);
 JL_DLLEXPORT jl_method_instance_t *jl_get_unspecialized(jl_method_t *def JL_PROPAGATES_ROOT);
-JL_DLLEXPORT void jl_read_codeinst_invoke(jl_code_instance_t *ci, uint8_t *specsigflags, jl_callptr_t *invoke, void **specptr, int waitcompile) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_read_codeinst_invoke(jl_code_instance_t *ci, uint8_t *specsigflags, jl_callptr_t *invoke, void **specptr, int waitcompile);
 JL_DLLEXPORT jl_method_instance_t *jl_method_match_to_mi(jl_method_match_t *match, size_t world, size_t min_valid, size_t max_valid, int mt_cache);
 
 JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst_uninit(jl_method_instance_t *mi, jl_value_t *owner);


### PR DESCRIPTION
The jl_fptr_wait_for_compiled state merely means it could compile that code, but in many circumstances, it will not actually compile that code until a long delay: when either all edges are satisfied or it is demanded to run immediately. The previous logic did not handle that possibility leading to deadlocks (possible even on one thread).

A high rate of failure was shown on running the following CI test:

    $ ./julia -t 20 -q <<EOF
    for i = 1:1000
    i % 10 == 0 && @show i
    (@eval function _atthreads_greedy_dynamic_schedule()
        inc = Threads.Atomic{Int}(0)
        Threads.@threads :greedy for _ = 1:Threads.threadpoolsize()
            Threads.@threads :dynamic for _ = 1:Threads.threadpoolsize()
                Threads.atomic_add!(inc, 1)
            end
        end
        return inc[]
    end)() == Threads.threadpoolsize() * Threads.threadpoolsize()
    end
    EOF