### PR TITLE
More testsets, fix commented out test, add Array{UInt8} conversion test

### DIFF
--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -343,9 +343,7 @@ end
     @test_throws StringIndexError get(utf8_str, 2, 'X')
 end
 
-#=
-# issue #7764
-let
+@testset "issue #7764" begin
     srep = repeat("Σβ",2)
     s="Σβ"
     ss=SubString(s,1,lastindex(s))
@@ -358,16 +356,15 @@ let
     @test iterate(srep, 7) == ('β',9)
 
     @test srep[7] == 'β'
-    @test_throws BoundsError srep[8]
+    @test_throws StringIndexError srep[8]
 end
-=#
 
 # This caused JuliaLang/JSON.jl#82
 @test first('\x00':'\x7f') === '\x00'
 @test last('\x00':'\x7f') === '\x7f'
 
-# make sure substrings do not accept code unit if it is not start of codepoint
-let s = "x\u0302"
+@testset "make sure substrings do not accept code unit if it is not start of codepoint" begin
+    s = "x\u0302"
     @test s[1:2] == s
     @test_throws BoundsError s[0:3]
     @test_throws BoundsError s[1:4]
@@ -1076,8 +1073,8 @@ let s = "∀x∃y", u = codeunits(s)
     @test Base.elsize(u) == Base.elsize(typeof(u)) == 1
 end
 
-# issue #24388
-let v = unsafe_wrap(Vector{UInt8}, "abc")
+@testset "issue #24388" begin
+    v = unsafe_wrap(Vector{UInt8}, "abc")
     s = String(v)
     @test_throws BoundsError v[1]
     push!(v, UInt8('x'))
@@ -1093,8 +1090,8 @@ let v = [0x40,0x41,0x42]
     @test String(view(v, 2:3)) == "AB"
 end
 
-# issue #54369
-let v = Base.StringMemory(3)
+@testset "issue #54369" begin
+    v = Base.StringMemory(3)
     v .= [0x41,0x42,0x43]
     s = String(v)
     @test s == "ABC"
@@ -1116,8 +1113,8 @@ let rng = MersenneTwister(1), strs = ["∀εa∀aε"*String(rand(rng, UInt8, 100
     end
 end
 
-# conversion of SubString to the same type, issue #25525
-let x = SubString("ab", 1, 1)
+@testset "conversion of SubString to the same type, issue #25525" begin
+    x = SubString("ab", 1, 1)
     y = convert(SubString{String}, x)
     @test y === x
     chop("ab") === chop.(["ab"])[1]
@@ -1168,6 +1165,9 @@ end
     @test_throws MethodError checkbounds(Bool, "abc", [1.0, 2.0])
 
     apple_uint8 = Vector{UInt8}("Apple")
+    @test apple_uint8 == [0x41, 0x70, 0x70, 0x6c, 0x65]
+
+    apple_uint8 = Array{UInt8}("Apple")
     @test apple_uint8 == [0x41, 0x70, 0x70, 0x6c, 0x65]
 
     Base.String(::tstStringType) = "Test"


### PR DESCRIPTION
Moved some `let...end` blocks into `@testset begin ... end` format. Added a test for converting a string to `Array{UInt8}`. Restored a commented out testset.