### PR TITLE
Buildkite Test Engine: fix JSON comma separate bug

### DIFF
--- a/test/buildkitetestjson.jl
+++ b/test/buildkitetestjson.jl
@@ -31,10 +31,10 @@ json_repr(io::IO, val::Integer; indent::Int=0) = print(io, val)
 json_repr(io::IO, val::Float64; indent::Int=0) = print(io, val)
 function json_repr(io::IO, val::AbstractVector; indent::Int=0)
     print(io, '[')
-    for elt in val
+    for i in eachindex(val)
         print(io, '\n', ' '^(indent + 2))
-        json_repr(io, elt; indent=indent+2)
-        elt === last(val) || print(io, ',')
+        json_repr(io, val[i]; indent=indent+2)
+        i == length(val) || print(io, ',')
     end
     print(io, '\n', ' '^indent, ']')
 end

--- a/test/buildkitetestjson.jl
+++ b/test/buildkitetestjson.jl
@@ -34,7 +34,7 @@ function json_repr(io::IO, val::AbstractVector; indent::Int=0)
     for i in eachindex(val)
         print(io, '\n', ' '^(indent + 2))
         json_repr(io, val[i]; indent=indent+2)
-        i == length(val) || print(io, ',')
+        i == lastindex(val) || print(io, ',')
     end
     print(io, '\n', ' '^indent, ']')
 end


### PR DESCRIPTION
This pull request fixes a missing-comma-separator bug in the [Bootleg JSON writer](https://github.com/JuliaLang/julia/blob/7eb5cb89fb938a1dc67efa3861b25562767a7bbe/test/buildkitetestjson.jl#L13) 🏴‍☠️ which is responsible for producing JSON test results for [Buildkite Test Engine](https://buildkite.com/platform/test-engine/).

There was a bug when serializing to JSON array (from `AbstractVector`) where elements that were [`===` / “egal”](https://docs.julialang.org/en/v1/base/base/#Core.:===) to the final element would not have a comma separator placed after them, producing invalid JSON. I stumbled upon this because I work at Buildkite; I've previously [contributed a fix for a different issue in `test/buildkitetestjson.jl](https://github.com/JuliaLang/julia/pull/53706).

Specifically, this bug occurred when the last item of `expanded` or `backtrace` within `failure_expanded` was an empty string, because `elt === last(val)` was `"" === ""` was `true`, so e.g. `["hello", "", "world", ""]` would serialize to:

```json
[
  "hello",
  ""
  "world",
  ""
]
```

Note this was _not_ happening when the last element was a **non**-empty string; the strings come from `split(string, '\n')` which returns a singleton empty string for zero-width splits, but separate strings for non-empty splits:

```
julia> [[x, objectid(x)] for x in split("\n", '\n')]
2-element Vector{Vector{Any}}:
 ["", 0x37373e5ed3d3af9c]
 ["", 0x37373e5ed3d3af9c]

julia> [[x, objectid(x)] for x in split("hello\nhello", '\n')]
2-element Vector{Vector{Any}}:
 ["hello", 0x8096d78ab9fd726c]
 ["hello", 0x2bec5d6f24b3bdf5]
```

This patch changes the “is final item” check to be index-based, rather than identity-based.

I've tested it by adding a synthetic failure to an existing test:

```julia
@test throw(ErrorException("testing Buildkite JSON\n\ncomma after blank lines\n\nwhen last line is blank\n"))
```

And then observed the `test/results_1.json` before and after this patch:

```diff
       "expanded": [
         "testing Buildkite JSON",
-        ""
+        "",
         "comma after blank lines",
-        ""
+        "",
         "when last line is blank",
         ""
       ]
```

Related:
- https://github.com/JuliaLang/julia/pull/53706
- cc: @tecosaur for past context
