### PR TITLE
Don't throw an error in raw! if the stream is closed

### DIFF
--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -1160,6 +1160,8 @@ JL_DLLEXPORT uv_handle_type jl_uv_handle_type(uv_handle_t *handle)
 
 JL_DLLEXPORT int jl_tty_set_mode(uv_tty_t *handle, int mode)
 {
+    if (!handle)
+        return UV__EOF;
     if (handle->type != UV_TTY) return 0;
     uv_tty_mode_t mode_enum = UV_TTY_MODE_NORMAL;
     if (mode)

--- a/stdlib/REPL/src/Terminals.jl
+++ b/stdlib/REPL/src/Terminals.jl
@@ -122,19 +122,17 @@ cmove_col(t::UnixTerminal, n) = (write(t.out_stream, '\r'); n > 1 && cmove_right
 
 if Sys.iswindows()
     function raw!(t::TTYTerminal,raw::Bool)
-        check_open(t.in_stream)
         if Base.ispty(t.in_stream)
             run((raw ? `stty raw -echo onlcr -ocrnl opost` : `stty sane`),
                 t.in_stream, t.out_stream, t.err_stream)
             true
         else
-            ccall(:jl_tty_set_mode, Int32, (Ptr{Cvoid},Int32), t.in_stream.handle::Ptr{Cvoid}, raw) != -1
+            ccall(:jl_tty_set_mode, Int32, (Ptr{Cvoid},Int32), t.in_stream.handle::Ptr{Cvoid}, raw) == 0
         end
     end
 else
     function raw!(t::TTYTerminal, raw::Bool)
-        check_open(t.in_stream)
-        ccall(:jl_tty_set_mode, Int32, (Ptr{Cvoid},Int32), t.in_stream.handle::Ptr{Cvoid}, raw) != -1
+        ccall(:jl_tty_set_mode, Int32, (Ptr{Cvoid},Int32), t.in_stream.handle::Ptr{Cvoid}, raw) == 0
     end
 end
 


### PR DESCRIPTION
This was added in #12568 to protect against a segfault after `close(stdin)`. However, the API is not great, because the stdin closing is an asynchronous event, so there isn't really any way to use this API without inccurring an error. Further, it already returns an error code of whether or not the action suceeded, and it's bad practice to have two ways for an operation to fail. Remove the error check and handle a closed stream gracefully returning an EOF error. In all users in Base, this EOF error is ignored, but we will gracefully check for EOF later and shut down the REPL, which is the desired behavior.

Fixes https://github.com/timholy/Revise.jl/issues/859