### PR TITLE
Fix debug build against non-debug LLVM

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -1115,7 +1115,7 @@ static SmallVector<Partition, 32> partitionModule(Module &M, unsigned threads) {
 
     bool verified = verify_partitioning(partitions, M, fvars, gvars);
     if (!verified)
-        M.dump();
+        llvm_dump(&M);
     assert(verified && "Partitioning failed to partition globals correctly");
     (void) verified;
 


### PR DESCRIPTION
The ::dump functions are conditionally defined in LLVM. We have a helper to work around this, so use it.