### PR TITLE
fix precompile(::MethodInstance) ccall signature

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -4191,7 +4191,7 @@ end
 
 # Variants that work for `invoke`d calls for which the signature may not be sufficient
 precompile(mi::Core.MethodInstance, world::UInt=get_world_counter()) =
-    (ccall(:jl_compile_method_instance, Cvoid, (Any, Any, UInt), mi, C_NULL, world); return true)
+    (ccall(:jl_compile_method_instance, Cvoid, (Any, Ptr{Cvoid}, UInt), mi, C_NULL, world); return true)
 
 """
     precompile(f, argtypes::Tuple{Vararg{Any}}, m::Method)


### PR DESCRIPTION
Prevents calling this method from triggering undefined behavior in C