### PR TITLE
use the correct path to include Compiler.jl in release builds

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -87,14 +87,14 @@ eval(m, x) = Core.eval(m, x)
 function include(x::String)
     if !isdefined(Base, :end_base_include)
         # During bootstrap, all includes are relative to `base/`
-        x = Base.strcat(Base.strcat(Base.BUILDROOT, "../usr/share/julia/Compiler/src/"), x)
+        x = Base.strcat(Base.strcat(Base.DATAROOT, "julia/Compiler/src/"), x)
     end
     Base.include(Compiler, x)
 end
 
 function include(mod::Module, x::String)
     if !isdefined(Base, :end_base_include)
-        x = Base.strcat(Base.strcat(Base.BUILDROOT, "../usr/share/julia/Compiler/src/"), x)
+        x = Base.strcat(Base.strcat(Base.DATAROOT, "julia/Compiler/src/"), x)
     end
     Base.include(mod, x)
 end

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -266,26 +266,25 @@ function strcat(x::String, y::String)
     return out
 end
 
-function file_exists(path::String)::Bool
-    result = ccall(:access, Cint, (Cstring, Cint), path, 0 #=F_OK=#)
-    return result == 0  # If result is 0, the file exists
-end
-
-global BUILDROOT::String = ""
+BUILDROOT::String = ""
+DATAROOT::String = ""
 
 baremodule BuildSettings end
 
 function process_sysimg_args!()
-    let i = 1
-        global BUILDROOT
+    let i = 2 # skip file name
         while i <= length(Core.ARGS)
+            Core.println(Core.ARGS[i])
             if Core.ARGS[i] == "--buildsettings"
                 include(BuildSettings, ARGS[i+1])
-                i += 1
+            elseif Core.ARGS[i] == "--buildroot"
+                global BUILDROOT = Core.ARGS[i+1]
+            elseif Core.ARGS[i] == "--dataroot"
+                global DATAROOT = Core.ARGS[i+1]
             else
-                BUILDROOT = Core.ARGS[i]
+                error(strcat("invalid sysimage argument: ", Core.ARGS[i]))
             end
-            i += 1
+            i += 2
         end
     end
 end
@@ -293,11 +292,8 @@ process_sysimg_args!()
 
 function isready end
 
-if file_exists(strcat(BUILDROOT, "../usr/share/julia/Compiler/src/Compiler.jl"))
-    include(strcat(BUILDROOT, "../usr/share/julia/Compiler/src/Compiler.jl"))
-else
-    include(strcat(BUILDROOT, "../share/julia/Compiler/src/Compiler.jl"))
-end
+include(strcat(DATAROOT, "julia/Compiler/src/Compiler.jl"))
+
 
 const _return_type = Compiler.return_type
 

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -266,6 +266,21 @@ function strcat(x::String, y::String)
     return out
 end
 
+function file_exists(filename::String)
+    file = ccall(
+        (:fopen, "libc"),
+        Ptr{Cvoid},
+        (Ptr{UInt8}, Ptr{UInt8}),
+        filename, "r"
+    )
+    if file != C_NULL
+        ccall((:fclose, "libc"), Cint, (Ptr{Cvoid},), file)
+        return true
+    else
+        return false
+    end
+end
+
 global BUILDROOT::String = ""
 
 baremodule BuildSettings end
@@ -288,7 +303,11 @@ process_sysimg_args!()
 
 function isready end
 
-include(strcat(BUILDROOT, "../usr/share/julia/Compiler/src/Compiler.jl"))
+if file_exists(strcat(BUILDROOT, "../usr/share/julia/Compiler/src/Compiler.jl"))
+    include(strcat(BUILDROOT, "../usr/share/julia/Compiler/src/Compiler.jl"))
+else
+    include(strcat(BUILDROOT, "../share/julia/Compiler/src/Compiler.jl"))
+end
 
 const _return_type = Compiler.return_type
 

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -266,19 +266,9 @@ function strcat(x::String, y::String)
     return out
 end
 
-function file_exists(filename::String)
-    file = ccall(
-        (:fopen, "libc"),
-        Ptr{Cvoid},
-        (Ptr{UInt8}, Ptr{UInt8}),
-        filename, "r"
-    )
-    if file != C_NULL
-        ccall((:fclose, "libc"), Cint, (Ptr{Cvoid},), file)
-        return true
-    else
-        return false
-    end
+function file_exists(path::String)::Bool
+    result = ccall(:access, Cint, (Cstring, Cint), path, 0 #=F_OK=#)
+    return result == 0  # If result is 0, the file exists
 end
 
 global BUILDROOT::String = ""

--- a/sysimage.mk
+++ b/sysimage.mk
@@ -61,18 +61,19 @@ BASE_SRCS := $(sort $(shell find $(JULIAHOME)/base -name \*.jl -and -not -name s
                     $(shell find $(BUILDROOT)/base -name \*.jl  -and -not -name sysimg.jl))
 STDLIB_SRCS := $(JULIAHOME)/base/sysimg.jl $(SYSIMG_STDLIBS_SRCS)
 RELBUILDROOT := $(call rel_path,$(JULIAHOME)/base,$(BUILDROOT)/base)/ # <-- make sure this always has a trailing slash
+RELDATADIR := $(call rel_path,$(JULIAHOME)/base,$(build_datarootdir))/ # <-- make sure this always has a trailing slash
 
 $(build_private_libdir)/basecompiler.ji: $(COMPILER_SRCS)
 	@$(call PRINT_JULIA, cd $(JULIAHOME)/base && \
 	$(call spawn,$(JULIA_EXECUTABLE)) -C "$(JULIA_CPU_TARGET)" $(HEAPLIM) --output-ji $(call cygpath_w,$@).tmp \
-		--startup-file=no --warn-overwrite=yes -g$(BOOTSTRAP_DEBUG_LEVEL) -O1 Base_compiler.jl $(RELBUILDROOT))
+		--startup-file=no --warn-overwrite=yes -g$(BOOTSTRAP_DEBUG_LEVEL) -O1 Base_compiler.jl --buildroot $(RELBUILDROOT) --dataroot $(RELDATADIR))
 	@mv $@.tmp $@
 
 $(build_private_libdir)/sys.ji: $(build_private_libdir)/basecompiler.ji $(JULIAHOME)/VERSION $(BASE_SRCS) $(STDLIB_SRCS)
 	@$(call PRINT_JULIA, cd $(JULIAHOME)/base && \
 	if ! JULIA_BINDIR=$(call cygpath_w,$(build_bindir)) WINEPATH="$(call cygpath_w,$(build_bindir));$$WINEPATH" \
 			$(call spawn, $(JULIA_EXECUTABLE)) -g1 -O1 -C "$(JULIA_CPU_TARGET)" $(HEAPLIM) --output-ji $(call cygpath_w,$@).tmp $(JULIA_SYSIMG_BUILD_FLAGS) \
-			--startup-file=no --warn-overwrite=yes --sysimage $(call cygpath_w,$<) sysimg.jl $(RELBUILDROOT); then \
+			--startup-file=no --warn-overwrite=yes --sysimage $(call cygpath_w,$<) sysimg.jl --buildroot $(RELBUILDROOT) --dataroot $(RELDATADIR); then \
 		echo '*** This error might be fixed by running `make clean`. If the error persists$(COMMA) try `make cleanall`. ***'; \
 		false; \
 	fi )


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/56409 broke PackageCompiler (or other use cases where you want to compile a new core compiler from a release build) since it hardcoded the relative path `../usr/` from Base to the `shared` directory but this is not true in releases where it is at `..`. 

The workaround here is ugly but I couldn't come up with anything better to compute that relative path based only on `BUILDROOT`. Maybe it can work as a nerd snipe for someone to improve it.