### PR TITLE
Update svd.jl documentation

### DIFF
--- a/stdlib/LinearAlgebra/src/svd.jl
+++ b/stdlib/LinearAlgebra/src/svd.jl
@@ -151,7 +151,7 @@ number of singular values.
 
 `alg` specifies which algorithm and LAPACK method to use for SVD:
 - `alg = DivideAndConquer()` (default): Calls `LAPACK.gesdd!`.
-- `alg = QRIteration()`: Calls `LAPACK.gesvd!` (typically slower but more accurate) .
+- `alg = LinearAlgebra.QRIteration()`: Calls `LAPACK.gesvd!` (typically slower but more accurate) .
 
 !!! compat "Julia 1.3"
     The `alg` keyword argument requires Julia 1.3 or later.


### PR DESCRIPTION
QRIteration() is not exported, so I updated the svd.jl documentation section that suggests such a method exists for the `svd` function. Now it says to use `alg = LinearAlgebra.QRIteration()` instead of `alg = QRIteration()` which would produce an error before.