### PR TITLE
codegen: manually restore `ct->scope` when no exception handler is emitted

### DIFF
--- a/test/scopedvalues.jl
+++ b/test/scopedvalues.jl
@@ -175,3 +175,10 @@ const inlineable_const_sv = ScopedValue(1)
 @test fully_eliminated(; retval=(inlineable_const_sv => 1)) do
     inlineable_const_sv => 1
 end
+
+# Handle nothrow scope bodies correctly (#56609)
+@eval function nothrow_scope()
+    $(Expr(:tryfinally, :(), nothing, 1))
+    @test Core.current_scope() === nothing
+end
+nothrow_scope()


### PR DESCRIPTION
This fixes a bug introduced by #55907, which was neglecting that it's possible for `EnterNode` to have no `catch` destination and still have a scope.

This can especially happen if the compiler has decided that the body is `nothrow` and chooses to optimize away the `catch` destination, but also #55907 intended to make the scope-only form of `:enter` legal (and not need an exception handler) even if the body is _not_ `nothrow`.

This fixes all that up to restore the scope correctly on the happy path.

~~Needs tests - will add those soon~~