### PR TITLE
`copytrito!` for triangular matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -2069,17 +2069,16 @@ function copytrito!(B::AbstractMatrix, A::AbstractMatrix, uplo::AbstractChar)
     require_one_based_indexing(A, B)
     BLAS.chkuplo(uplo)
     m,n = size(A)
-    m1,n1 = size(B)
     A = Base.unalias(B, A)
     if uplo == 'U'
-        LAPACK.lacpy_size_check((m1, n1), (n < m ? n : m, n))
+        LAPACK.lacpy_size_check(size(B), (n < m ? n : m, n))
         for j in axes(A,2), i in axes(A,1)[begin : min(j,end)]
             # extract the parents for UpperTriangular matrices
             Bv, Av = _uppertridata(B), _uppertridata(A)
             @inbounds Bv[i,j] = Av[i,j]
         end
     else # uplo == 'L'
-        LAPACK.lacpy_size_check((m1, n1), (m, m < n ? m : n))
+        LAPACK.lacpy_size_check(size(B), (m, m < n ? m : n))
         for j in axes(A,2), i in axes(A,1)[j:end]
             # extract the parents for LowerTriangular matrices
             Bv, Av = _lowertridata(B), _lowertridata(A)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -2074,14 +2074,14 @@ function copytrito!(B::AbstractMatrix, A::AbstractMatrix, uplo::AbstractChar)
         LAPACK.lacpy_size_check(size(B), (n < m ? n : m, n))
         for j in axes(A,2), i in axes(A,1)[begin : min(j,end)]
             # extract the parents for UpperTriangular matrices
-            Bv, Av = _uppertridata(B), _uppertridata(A)
+            Bv, Av = uppertridata(B), uppertridata(A)
             @inbounds Bv[i,j] = Av[i,j]
         end
     else # uplo == 'L'
         LAPACK.lacpy_size_check(size(B), (m, m < n ? m : n))
         for j in axes(A,2), i in axes(A,1)[j:end]
             # extract the parents for LowerTriangular matrices
-            Bv, Av = _lowertridata(B), _lowertridata(A)
+            Bv, Av = lowertridata(B), lowertridata(A)
             @inbounds Bv[i,j] = Av[i,j]
         end
     end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -2074,12 +2074,16 @@ function copytrito!(B::AbstractMatrix, A::AbstractMatrix, uplo::AbstractChar)
     if uplo == 'U'
         LAPACK.lacpy_size_check((m1, n1), (n < m ? n : m, n))
         for j in axes(A,2), i in axes(A,1)[begin : min(j,end)]
-            @inbounds B[i,j] = A[i,j]
+            # extract the parents for UpperTriangular matrices
+            Bv, Av = _uppertridata(B), _uppertridata(A)
+            @inbounds Bv[i,j] = Av[i,j]
         end
     else # uplo == 'L'
         LAPACK.lacpy_size_check((m1, n1), (m, m < n ? m : n))
         for j in axes(A,2), i in axes(A,1)[j:end]
-            @inbounds B[i,j] = A[i,j]
+            # extract the parents for LowerTriangular matrices
+            Bv, Av = _lowertridata(B), _lowertridata(A)
+            @inbounds Bv[i,j] = Av[i,j]
         end
     end
     return B

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -633,28 +633,26 @@ end
     return dest
 end
 
-function copytrito!(B::UpperTriangular, A::UpperTriangular, uplo::AbstractChar)
-    if uplo == 'U'
-        copytrito!(B.data, A.data, 'U')
+function copytrito_triangular!(Bdata, Adata, uplo, uplomatch, sz)
+    if uplomatch
+        copytrito!(Bdata, Adata, uplo)
     else
         BLAS.chkuplo(uplo)
-        m,n = size(A)
-        LAPACK.lacpy_size_check(size(B), (m, m < n ? m : n))
+        LAPACK.lacpy_size_check(size(Bdata), sz)
         # only the diagonal is copied in this case
-        copyto!(diagview(B.data), diagview(A.data))
+        copyto!(diagview(Bdata), diagview(Adata))
     end
+    return Bdata
+end
+
+function copytrito!(B::UpperTriangular, A::UpperTriangular, uplo::AbstractChar)
+    m,n = size(A)
+    copytrito_triangular!(B.data, A.data, uplo, uplo == 'U', (m, m < n ? m : n))
     return B
 end
 function copytrito!(B::LowerTriangular, A::LowerTriangular, uplo::AbstractChar)
-    if uplo == 'L'
-        copytrito!(B.data, A.data, 'L')
-    else
-        BLAS.chkuplo(uplo)
-        m,n = size(A)
-        LAPACK.lacpy_size_check(size(B), (n < m ? n : m, n))
-        # only the diagonal is copied in this case
-        copyto!(diagview(B.data), diagview(A.data))
-    end
+    m,n = size(A)
+    copytrito_triangular!(B.data, A.data, uplo, uplo == 'L', (n < m ? n : m, n))
     return B
 end
 

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -658,10 +658,12 @@ function copytrito!(B::LowerTriangular, A::LowerTriangular, uplo::AbstractChar)
     return B
 end
 
-_uppertridata(A) = A
-_lowertridata(A) = A
-_uppertridata(A::UpperTriangular) = parent(A)
-_lowertridata(A::LowerTriangular) = parent(A)
+uppertridata(A) = A
+lowertridata(A) = A
+# we restrict these specializations only to strided matrices to avoid cases where an UpperTriangular type
+# doesn't share its indexing with the parent
+uppertridata(A::UpperTriangular{<:Any, <:StridedMatrix}) = parent(A)
+lowertridata(A::LowerTriangular{<:Any, <:StridedMatrix}) = parent(A)
 
 @inline _rscale_add!(A::AbstractTriangular, B::AbstractTriangular, C::Number, alpha::Number, beta::Number) =
     @stable_muladdmul _triscale!(A, B, C, MulAddMul(alpha, beta))

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -143,7 +143,6 @@ const UpperOrUnitUpperTriangular{T,S} = Union{UpperTriangular{T,S}, UnitUpperTri
 const LowerOrUnitLowerTriangular{T,S} = Union{LowerTriangular{T,S}, UnitLowerTriangular{T,S}}
 const UpperOrLowerTriangular{T,S} = Union{UpperOrUnitUpperTriangular{T,S}, LowerOrUnitLowerTriangular{T,S}}
 const UnitUpperOrUnitLowerTriangular{T,S} = Union{UnitUpperTriangular{T,S}, UnitLowerTriangular{T,S}}
-const UpperTriangularOrLowerTriangular{T,S} = Union{UpperTriangular{T,S}, LowerTriangular{T,S}}
 
 uppertriangular(M) = UpperTriangular(M)
 lowertriangular(M) = LowerTriangular(M)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -641,6 +641,8 @@ function copytrito!(B::UpperTriangular, A::UpperTriangular, uplo::AbstractChar)
         BLAS.chkuplo(uplo)
         m,n = size(A)
         LAPACK.lacpy_size_check(size(B), (m, m < n ? m : n))
+        # only the diagonal is copied in this case
+        copyto!(diagview(B.data), diagview(A.data))
     end
     return B
 end
@@ -651,6 +653,8 @@ function copytrito!(B::LowerTriangular, A::LowerTriangular, uplo::AbstractChar)
         BLAS.chkuplo(uplo)
         m,n = size(A)
         LAPACK.lacpy_size_check(size(B), (n < m ? n : m, n))
+        # only the diagonal is copied in this case
+        copyto!(diagview(B.data), diagview(A.data))
     end
     return B
 end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -143,6 +143,7 @@ const UpperOrUnitUpperTriangular{T,S} = Union{UpperTriangular{T,S}, UnitUpperTri
 const LowerOrUnitLowerTriangular{T,S} = Union{LowerTriangular{T,S}, UnitLowerTriangular{T,S}}
 const UpperOrLowerTriangular{T,S} = Union{UpperOrUnitUpperTriangular{T,S}, LowerOrUnitLowerTriangular{T,S}}
 const UnitUpperOrUnitLowerTriangular{T,S} = Union{UnitUpperTriangular{T,S}, UnitLowerTriangular{T,S}}
+const UpperTriangularOrLowerTriangular{T,S} = Union{UpperTriangular{T,S}, LowerTriangular{T,S}}
 
 uppertriangular(M) = UpperTriangular(M)
 lowertriangular(M) = LowerTriangular(M)
@@ -631,6 +632,19 @@ end
         end
     end
     return dest
+end
+
+function copytrito!(B::UpperTriangular, A::UpperTriangular, uplo::AbstractChar)
+    if uplo == 'U'
+        copytrito!(B.data, A.data, 'U')
+    end
+    return B
+end
+function copytrito!(B::LowerTriangular, A::LowerTriangular, uplo::AbstractChar)
+    if uplo == 'L'
+        copytrito!(B.data, A.data, 'L')
+    end
+    return B
 end
 
 @inline _rscale_add!(A::AbstractTriangular, B::AbstractTriangular, C::Number, alpha::Number, beta::Number) =

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -637,12 +637,20 @@ end
 function copytrito!(B::UpperTriangular, A::UpperTriangular, uplo::AbstractChar)
     if uplo == 'U'
         copytrito!(B.data, A.data, 'U')
+    else
+        BLAS.chkuplo(uplo)
+        m,n = size(A)
+        LAPACK.lacpy_size_check(size(B), (m, m < n ? m : n))
     end
     return B
 end
 function copytrito!(B::LowerTriangular, A::LowerTriangular, uplo::AbstractChar)
     if uplo == 'L'
         copytrito!(B.data, A.data, 'L')
+    else
+        BLAS.chkuplo(uplo)
+        m,n = size(A)
+        LAPACK.lacpy_size_check(size(B), (n < m ? n : m, n))
     end
     return B
 end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -633,7 +633,7 @@ end
     return dest
 end
 
-function copytrito_triangular!(Bdata, Adata, uplo, uplomatch, sz)
+Base.@constprop :aggressive function copytrito_triangular!(Bdata, Adata, uplo, uplomatch, sz)
     if uplomatch
         copytrito!(Bdata, Adata, uplo)
     else

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -647,6 +647,11 @@ function copytrito!(B::LowerTriangular, A::LowerTriangular, uplo::AbstractChar)
     return B
 end
 
+_uppertridata(A) = A
+_lowertridata(A) = A
+_uppertridata(A::UpperTriangular) = parent(A)
+_lowertridata(A::LowerTriangular) = parent(A)
+
 @inline _rscale_add!(A::AbstractTriangular, B::AbstractTriangular, C::Number, alpha::Number, beta::Number) =
     @stable_muladdmul _triscale!(A, B, C, MulAddMul(alpha, beta))
 @inline _lscale_add!(A::AbstractTriangular, B::Number, C::AbstractTriangular, alpha::Number, beta::Number) =

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -1405,6 +1405,8 @@ end
         M[1+!isupper, 1+isupper] = 4
         uplo, loup = U isa UpperTriangular ? ('U', 'L') : ('L', 'U' )
         @test copytrito!(similar(U), U, uplo) == U
+        @test copytrito!(zero(M), U, uplo) == U
+        @test copytrito!(similar(U), Array(U), uplo) == U
         @test copytrito!(zero(U), U, loup) == zero(U)
         Ubig = T(similar(M, (3,3)))
         copytrito!(Ubig, U, uplo)

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -1407,7 +1407,9 @@ end
         @test copytrito!(similar(U), U, uplo) == U
         @test copytrito!(zero(M), U, uplo) == U
         @test copytrito!(similar(U), Array(U), uplo) == U
-        @test copytrito!(zero(U), U, loup) == zero(U)
+        @test copytrito!(zero(U), U, loup) == Diagonal(U)
+        @test copytrito!(similar(U), MyTriangular(U), uplo) == U
+        @test copytrito!(zero(M), MyTriangular(U), uplo) == U
         Ubig = T(similar(M, (3,3)))
         copytrito!(Ubig, U, uplo)
         @test Ubig[axes(U)...] == U

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -1396,4 +1396,20 @@ end
     @test exp(log(M)) ≈ M
 end
 
+@testset "copytrito!" begin
+    for T in (UpperTriangular, LowerTriangular)
+        M = Matrix{BigFloat}(undef, 2, 2)
+        M[1,1] = M[2,2] = 3
+        U = T(M)
+        isupper = U isa UpperTriangular
+        M[1+!isupper, 1+isupper] = 4
+        uplo, loup = U isa UpperTriangular ? ('U', 'L') : ('L', 'U' )
+        @test copytrito!(similar(U), U, uplo) == U
+        @test copytrito!(zero(U), U, loup) == zero(U)
+        Ubig = T(similar(M, (3,3)))
+        copytrito!(Ubig, U, uplo)
+        @test Ubig[axes(U)...] == U
+    end
+end
+
 end # module TestTriangular


### PR DESCRIPTION
This does two things:

1. Forward `copytrito!` for triangular matrices to the parent in case the specified `uplo` corresponds to the stored part. This works because these matrices share their elements with the parents for the stored part.
2. Make `copytrito!` only copy the diagonal if the `uplo` corresponds to the non-stored part.

This makes `copytrito!` involving a triangular matrix equivalent to that involving its parent if the filled part is copied, and O(N) otherwise.

Examples of improvements in performance:
```julia
julia> using LinearAlgebra

julia> A1 = UpperTriangular(rand(400,400));

julia> A2 = similar(A1);

julia> @btime copytrito!($A2, $A1, 'U');
  70.753 μs (0 allocations: 0 bytes) # nightly v"1.12.0-DEV.1657"
  26.143 μs (0 allocations: 0 bytes) # this PR

julia> @btime copytrito!(parent($A2), $A1, 'U');
  56.025 μs (0 allocations: 0 bytes) # nightly
  26.633 μs (0 allocations: 0 bytes) # this PR
```