### PR TITLE
precompilepkgs: make the circular dep warning clearer and more informative

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -365,9 +365,9 @@ const Config = Pair{Cmd, Base.CacheFlags}
 const PkgConfig = Tuple{PkgId,Config}
 
 # name or parent → ext
-function full_name(ext_to_parent::Dict{PkgId, String}, pkg::PkgId, arrowspace::Bool=true)
+function full_name(ext_to_parent::Dict{PkgId, String}, pkg::PkgId)
     if haskey(ext_to_parent, pkg)
-        return string(ext_to_parent[pkg], arrowspace ? " → " : "→", pkg.name)
+        return string(ext_to_parent[pkg], " → ", pkg.name)
     else
         return pkg.name
     end
@@ -621,7 +621,7 @@ function _precompilepkgs(pkgs::Vector{String},
     end
     if !isempty(circular_deps)
         deps_list = join((full_name(ext_to_parent, pkg) for pkg in circular_deps), "\n  ")
-        cycles_names = join((join((full_name(ext_to_parent, pkg, false) for pkg in cycle), " → ") * " ↩" for cycle in cycles), "\n  ")
+	cycles_names = join((join((full_name(ext_to_parent, pkg) for pkg in cycle), " → ") * " ↩" for cycle in cycles), "\n  ")
         @warn """
         Circular dependency detected. Precompilation will be skipped for:
           $deps_list

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -649,12 +649,13 @@ function _precompilepkgs(pkgs::Vector{String},
             cycles_names *= cycle_str
         end
         plural1 = length(cycles) > 1 ? "these cycles" : "this cycle"
-        plural2 = length(cycles) > 1 ? "cycles" : "cycle"
+        plural2 = length(outer_deps) > 1 ? "have" : "has"
+        plural3 = length(cycles) > 1 ? "cycles" : "cycle"
         msg = """Circular dependency detected.
         Precompilation will be skipped for dependencies all in $plural1:
         $cycles_names"""
         if !isempty(outer_deps)
-            msg *= "Precompilation will also be skipped for the following, which have depdenencies in the $plural2:\n"
+            msg *= "Precompilation will also be skipped for the following, which $plural2 depdenencies in the $plural3:\n"
             msg *= join(("  " * full_name(exts, pkg) for pkg in outer_deps), "\n")
         end
         @warn msg

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -601,7 +601,12 @@ function _precompilepkgs(pkgs::Vector{String},
         end
     end
     if !isempty(circular_deps)
-        @warn """Circular dependency detected. Precompilation will be skipped for:\n  $(join(string.(circular_deps), "\n  "))"""
+        deps_list = ""
+        for pkg in circular_deps
+            name = haskey(exts, pkg) ? string(exts[pkg], " → ", pkg.name) : pkg.name
+            deps_list *= "  $name\n"
+        end
+        @warn """Circular dependency detected. Precompilation will be skipped for:\n$deps_list"""
     end
     @debug "precompile: circular dep check done"
 

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -652,10 +652,10 @@ function _precompilepkgs(pkgs::Vector{String},
         plural2 = length(outer_deps) > 1 ? "have" : "has"
         plural3 = length(cycles) > 1 ? "cycles" : "cycle"
         msg = """Circular dependency detected.
-        Precompilation will be skipped for dependencies all in $plural1:
+        Precompilation will be skipped for dependencies in $plural1:
         $cycles_names"""
         if !isempty(outer_deps)
-            msg *= "Precompilation will also be skipped for the following, which $plural2 depdenencies in the $plural3:\n"
+            msg *= "Precompilation will also be skipped for the following, which depend on the above $plural3:\n"
             msg *= join(("  " * full_name(exts, pkg) for pkg in outer_deps), "\n")
         end
         @warn msg

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -365,9 +365,9 @@ const Config = Pair{Cmd, Base.CacheFlags}
 const PkgConfig = Tuple{PkgId,Config}
 
 # name or parent → ext
-function full_name(ext_to_parent::Dict{PkgId, PkgId}, pkg::PkgId)
+function full_name(ext_to_parent::Dict{PkgId, String}, pkg::PkgId, arrowspace::Bool=true)
     if haskey(ext_to_parent, pkg)
-        return string(ext_to_parent[pkg].name, " → ", pkg.name)
+        return string(ext_to_parent[pkg], arrowspace ? " → " : "→", pkg.name)
     else
         return pkg.name
     end
@@ -621,7 +621,7 @@ function _precompilepkgs(pkgs::Vector{String},
     end
     if !isempty(circular_deps)
         deps_list = join((full_name(ext_to_parent, pkg) for pkg in circular_deps), "\n  ")
-        cycles_names = join((join((full_name(ext_to_parent, pkg) for pkg in cycle), " → ") * " ↩" for cycle in cycles), "\n  ")
+        cycles_names = join((join((full_name(ext_to_parent, pkg, false) for pkg in cycle), " → ") * " ↩" for cycle in cycles), "\n  ")
         @warn """
         Circular dependency detected. Precompilation will be skipped for:
           $deps_list

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -655,7 +655,7 @@ function _precompilepkgs(pkgs::Vector{String},
     circular_deps = Base.PkgId[]
     for pkg in keys(direct_deps)
         @assert isempty(stack)
-	if scan_pkg!(pkg, direct_deps)
+        if scan_pkg!(pkg, direct_deps)
             push!(circular_deps, pkg)
             for pkg_config in keys(was_processed)
                 # notify all to allow skipping

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -381,7 +381,9 @@ function excluded_circular_deps_explanation(io::IOContext{IO}, ext_to_parent::Di
         cycle_str = ""
         for (i, pkg) in enumerate(cycle)
             j = max(0, i - 1)
-            if i == 1
+            if length(cycle) == 1
+                line = " ─ "
+            elseif i == 1
                 line = " ┌ "
             elseif i < length(cycle)
                 line = " │ " * " " ^j


### PR DESCRIPTION
Was e.g.
```
┌ Warning: Circular dependency detected. Precompilation will be skipped for:
│   Base.PkgId(Base.UUID("eb0c05c4-6780-5852-a67e-5d31d2970b9a"), "ArrayInterfaceTrackerExt")
│   Base.PkgId(Base.UUID("f517fe37-dbe3-4b94-8317-1923a5111588"), "Polyester")
│   Base.PkgId(Base.UUID("0d7ed370-da01-4f52-bd93-41d350b8b718"), "StaticArrayInterface")
│   Base.PkgId(Base.UUID("6a4ca0a5-0e36-4168-a932-d9be78d558f1"), "AcceleratedKernels")
│   Base.PkgId(Base.UUID("244f68ed-b92b-5712-87ae-6c617c41e16a"), "NNlibAMDGPUExt")
│   Base.PkgId(Base.UUID("06b0261c-7a9b-5753-9bdf-fd6840237b4a"), "StaticArrayInterfaceStaticArraysExt")
│   Base.PkgId(Base.UUID("21141c5a-9bdb-4563-92ae-f87d6854732e"), "AMDGPU")
│   Base.PkgId(Base.UUID("9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"), "Tracker")
└ @ Base.Precompilation precompilation.jl:511
```
Now
![Screenshot 2024-11-21 at 11 20 50 PM](https://github.com/user-attachments/assets/6939d834-90c3-4d87-baa9-cf6a4931ca03)

Thanks to @topolarity figuring out proper cycles tracking.