### PR TITLE
inference: add missing modeling for `swapglobal!`

### DIFF
--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -6097,3 +6097,22 @@ global setglobal!_must_throw::Int = 42
 @test Base.infer_return_type((String,)) do x
     setglobal!(@__MODULE__, :setglobal!_must_throw, x)
 end === Union{}
+
+global swapglobal!_xxx::Int = 42
+@test Base.infer_return_type((Int,)) do x
+    swapglobal!(@__MODULE__, :swapglobal!_xxx, x)
+end === Int
+@test Base.infer_return_type((String,)) do x
+    swapglobal!(@__MODULE__, :swapglobal!_xxx, x)
+end === Union{}
+
+global swapglobal!_must_throw
+@newinterp SwapGlobalInterp
+let CC = Base.Compiler
+    CC.InferenceParams(::SwapGlobalInterp) = CC.InferenceParams(; assume_bindings_static=true)
+end
+function func_swapglobal!_must_throw(x)
+    swapglobal!(@__MODULE__, :swapglobal!_must_throw, x)
+end
+@test Base.infer_return_type(func_swapglobal!_must_throw, (Int,); interp=SwapGlobalInterp()) === Union{}
+@test !Base.Compiler.is_effect_free(Base.infer_effects(func_swapglobal!_must_throw, (Int,); interp=SwapGlobalInterp()) )


### PR DESCRIPTION
This was missed from JuliaLang/julia#56299.