### PR TITLE
Make Compiler tests runnable as package

### DIFF
--- a/Compiler/Project.toml
+++ b/Compiler/Project.toml
@@ -4,3 +4,12 @@ version = "0.0.2"
 
 [compat]
 julia = "1.10"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[targets]
+test = ["Test", "InteractiveUtils", "Random", "Libdl"]

--- a/Compiler/test/EAUtils.jl
+++ b/Compiler/test/EAUtils.jl
@@ -2,7 +2,14 @@ module EAUtils
 
 export code_escapes, @code_escapes, __clear_cache!
 
-const CC = Core.Compiler
+if !@isdefined(Compiler)
+    if Base.identify_package("Compiler") === nothing
+        import Base.Compiler: Compiler
+    else
+        import Compiler
+    end
+end
+
 using ..EscapeAnalysis
 const EA = EscapeAnalysis
 
@@ -10,19 +17,19 @@ const EA = EscapeAnalysis
 # -------------------
 
 # imports
-import .CC:
+import .Compiler:
     AbstractInterpreter, NativeInterpreter, WorldView, WorldRange, InferenceParams,
     OptimizationParams, get_world_counter, get_inference_cache, ipo_dataflow_analysis!
 # usings
 using Core:
     CodeInstance, MethodInstance, CodeInfo
-using .CC:
+using .Compiler:
     InferenceResult, InferenceState, OptimizationState, IRCode
 using .EA: analyze_escapes, ArgEscapeCache, ArgEscapeInfo, EscapeInfo, EscapeState
 
 struct EAToken end
 
-# when working outside of Core.Compiler,
+# when working outside of CC,
 # cache entire escape state for later inspection and debugging
 struct EscapeCacheInfo
     argescapes::ArgEscapeCache
@@ -59,18 +66,18 @@ mutable struct EscapeAnalyzer <: AbstractInterpreter
     end
 end
 
-CC.InferenceParams(interp::EscapeAnalyzer) = interp.inf_params
-CC.OptimizationParams(interp::EscapeAnalyzer) = interp.opt_params
-CC.get_inference_world(interp::EscapeAnalyzer) = interp.world
-CC.get_inference_cache(interp::EscapeAnalyzer) = interp.inf_cache
-CC.cache_owner(::EscapeAnalyzer) = EAToken()
-CC.get_escape_cache(interp::EscapeAnalyzer) = GetEscapeCache(interp)
+Compiler.InferenceParams(interp::EscapeAnalyzer) = interp.inf_params
+Compiler.OptimizationParams(interp::EscapeAnalyzer) = interp.opt_params
+Compiler.get_inference_world(interp::EscapeAnalyzer) = interp.world
+Compiler.get_inference_cache(interp::EscapeAnalyzer) = interp.inf_cache
+Compiler.cache_owner(::EscapeAnalyzer) = EAToken()
+Compiler.get_escape_cache(interp::EscapeAnalyzer) = GetEscapeCache(interp)
 
-function CC.ipo_dataflow_analysis!(interp::EscapeAnalyzer, opt::OptimizationState,
+function Compiler.ipo_dataflow_analysis!(interp::EscapeAnalyzer, opt::OptimizationState,
                                    ir::IRCode, caller::InferenceResult)
     # run EA on all frames that have been optimized
     nargs = Int(opt.src.nargs)
-    𝕃ₒ = CC.optimizer_lattice(interp)
+    𝕃ₒ = Compiler.optimizer_lattice(interp)
     get_escape_cache = GetEscapeCache(interp)
     estate = try
         analyze_escapes(ir, nargs, 𝕃ₒ, get_escape_cache)
@@ -82,11 +89,11 @@ function CC.ipo_dataflow_analysis!(interp::EscapeAnalyzer, opt::OptimizationStat
     end
     if caller.linfo === interp.entry_mi
         # return back the result
-        interp.result = EscapeResultForEntry(CC.copy(ir), estate, caller.linfo)
+        interp.result = EscapeResultForEntry(Compiler.copy(ir), estate, caller.linfo)
     end
     record_escapes!(interp, caller, estate, ir)
 
-    @invoke CC.ipo_dataflow_analysis!(interp::AbstractInterpreter, opt::OptimizationState,
+    @invoke Compiler.ipo_dataflow_analysis!(interp::AbstractInterpreter, opt::OptimizationState,
                                       ir::IRCode, caller::InferenceResult)
 end
 
@@ -94,7 +101,7 @@ function record_escapes!(interp::EscapeAnalyzer,
     caller::InferenceResult, estate::EscapeState, ir::IRCode)
     argescapes = ArgEscapeCache(estate)
     ecacheinfo = EscapeCacheInfo(argescapes, estate, ir)
-    return CC.stack_analysis_result!(caller, ecacheinfo)
+    return Compiler.stack_analysis_result!(caller, ecacheinfo)
 end
 
 struct GetEscapeCache
@@ -113,19 +120,19 @@ struct FailedAnalysis
     get_escape_cache::GetEscapeCache
 end
 
-function CC.finish!(interp::EscapeAnalyzer, state::InferenceState; can_discard_trees::Bool=CC.may_discard_trees(interp))
-    ecacheinfo = CC.traverse_analysis_results(state.result) do @nospecialize result
+function Compiler.finish!(interp::EscapeAnalyzer, state::InferenceState; can_discard_trees::Bool=Compiler.may_discard_trees(interp))
+    ecacheinfo = Compiler.traverse_analysis_results(state.result) do @nospecialize result
         return result isa EscapeCacheInfo ? result : nothing
     end
     ecacheinfo isa EscapeCacheInfo && (interp.escape_cache.cache[state.linfo] = ecacheinfo)
-    return @invoke CC.finish!(interp::AbstractInterpreter, state::InferenceState; can_discard_trees)
+    return @invoke Compiler.finish!(interp::AbstractInterpreter, state::InferenceState; can_discard_trees)
 end
 
 # printing
 # --------
 
 using Core: Argument, SSAValue
-using .CC: widenconst, singleton_type
+using .Compiler: widenconst, singleton_type
 
 function get_name_color(x::EscapeInfo, symbol::Bool = false)
     getname(x) = string(nameof(x))
@@ -323,7 +330,7 @@ function code_escapes(@nospecialize(f), @nospecialize(types=Base.default_tt(f));
                       debuginfo::Symbol = :none)
     tt = Base.signature_type(f, types)
     match = Base._which(tt; world, raise=true)
-    mi = Core.Compiler.specialize_method(match)
+    mi = Compiler.specialize_method(match)
     return code_escapes(mi; world, debuginfo)
 end
 
@@ -331,7 +338,7 @@ function code_escapes(mi::MethodInstance;
                       world::UInt = get_world_counter(),
                       interp::EscapeAnalyzer=EscapeAnalyzer(world, GLOBAL_ESCAPE_CACHE; entry_mi=mi),
                       debuginfo::Symbol = :none)
-    frame = Core.Compiler.typeinf_frame(interp, mi, #=run_optimizer=#true)
+    frame = Compiler.typeinf_frame(interp, mi, #=run_optimizer=#true)
     isdefined(interp, :result) || error("optimization didn't happen: maybe everything has been constant folded?")
     slotnames = let src = frame.src
         src isa CodeInfo ? src.slotnames : nothing
@@ -357,7 +364,7 @@ Note that this version does not cache the analysis results.
 function code_escapes(ir::IRCode, nargs::Int;
                       world::UInt = get_world_counter(),
                       interp::AbstractInterpreter=EscapeAnalyzer(world, EscapeCache()))
-    estate = analyze_escapes(ir, nargs, CC.optimizer_lattice(interp), CC.get_escape_cache(interp))
+    estate = analyze_escapes(ir, nargs, Compiler.optimizer_lattice(interp), Compiler.get_escape_cache(interp))
     return EscapeResult(ir, estate) # return back the result
 end
 

--- a/Compiler/test/EscapeAnalysis.jl
+++ b/Compiler/test/EscapeAnalysis.jl
@@ -1,15 +1,10 @@
 module test_EA
 
-global use_core_compiler::Bool = true
+include("irutils.jl")
 
-if use_core_compiler
-    const EscapeAnalysis = Core.Compiler.EscapeAnalysis
-else
-    include(normpath(Sys.BINDIR, "..", "..", "Compiler", "src", "ssair", "EscapeAnalysis.jl"))
-end
+const EscapeAnalysis = Compiler.EscapeAnalysis
 
 include("EAUtils.jl")
-include("irutils.jl")
 
 using Test, .EscapeAnalysis, .EAUtils
 using .EscapeAnalysis: ignore_argescape

--- a/Compiler/test/compact.jl
+++ b/Compiler/test/compact.jl
@@ -1,4 +1,12 @@
-using Core.Compiler: IncrementalCompact, insert_node_here!, finish,
+if !@isdefined(Compiler)
+    if Base.identify_package("Compiler") === nothing
+        import Base.Compiler: Compiler
+    else
+        import Compiler
+    end
+end
+
+using .Compiler: IncrementalCompact, insert_node_here!, finish,
     NewInstruction, verify_ir, ReturnNode, SSAValue
 
 foo_test_function(i) = i == 1 ? 1 : 2
@@ -8,19 +16,19 @@ foo_test_function(i) = i == 1 ? 1 : 2
     compact = IncrementalCompact(ir)
 
     # set up first iterator
-    x = Core.Compiler.iterate(compact)
-    x = Core.Compiler.iterate(compact, x[2])
+    x = Compiler.iterate(compact)
+    x = Compiler.iterate(compact, x[2])
 
     # set up second iterator
-    x = Core.Compiler.iterate(compact)
+    x = Compiler.iterate(compact)
 
     # consume remainder
     while x !== nothing
-        x = Core.Compiler.iterate(compact, x[2])
+        x = Compiler.iterate(compact, x[2])
     end
 
     ir = finish(compact)
-    @test Core.Compiler.verify_ir(ir) === nothing
+    @test Compiler.verify_ir(ir) === nothing
 end
 
 # Test early finish of IncrementalCompact
@@ -40,7 +48,7 @@ end
 @testset "IncrementalCompact reverse affinity insert" begin
     ir = only(Base.code_ircode(foo_test_function, (Int,)))[1]
     compact = IncrementalCompact(ir)
-    @test !Core.Compiler.did_just_finish_bb(compact)
+    @test !Compiler.did_just_finish_bb(compact)
 
     insert_node_here!(compact, NewInstruction(ReturnNode(1), Union{}, ir[SSAValue(1)][:line]), true)
     new_ir = finish(compact)

--- a/Compiler/test/datastructures.jl
+++ b/Compiler/test/datastructures.jl
@@ -1,24 +1,32 @@
 using Test
 
+if !@isdefined(Compiler)
+    if Base.identify_package("Compiler") === nothing
+        import Base.Compiler: Compiler
+    else
+        import Compiler
+    end
+end
+
 @testset "CachedMethodTable" begin
     # cache result should be separated per `limit` and `sig`
     # https://github.com/JuliaLang/julia/pull/46799
-    interp = Core.Compiler.NativeInterpreter()
-    table = Core.Compiler.method_table(interp)
+    interp = Compiler.NativeInterpreter()
+    table = Compiler.method_table(interp)
     sig = Tuple{typeof(*), Any, Any}
-    result1 = Core.Compiler.findall(sig, table; limit=-1)
-    result2 = Core.Compiler.findall(sig, table; limit=Core.Compiler.InferenceParams().max_methods)
-    @test result1 !== nothing && !Core.Compiler.isempty(result1)
+    result1 = Compiler.findall(sig, table; limit=-1)
+    result2 = Compiler.findall(sig, table; limit=Compiler.InferenceParams().max_methods)
+    @test result1 !== nothing && !Compiler.isempty(result1)
     @test result2 === nothing
 end
 
 @testset "BitSetBoundedMinPrioritySet" begin
-    bsbmp = Core.Compiler.BitSetBoundedMinPrioritySet(5)
-    Core.Compiler.push!(bsbmp, 2)
-    Core.Compiler.push!(bsbmp, 2)
+    bsbmp = Compiler.BitSetBoundedMinPrioritySet(5)
+    Compiler.push!(bsbmp, 2)
+    Compiler.push!(bsbmp, 2)
     iterateok = true
     cnt = 0
-    @eval Core.Compiler for v in $bsbmp
+    @eval Compiler for v in $bsbmp
         if cnt == 0
             iterateok &= v == 2
         elseif cnt == 1
@@ -29,37 +37,37 @@ end
         cnt += 1
     end
     @test iterateok
-    @test Core.Compiler.popfirst!(bsbmp) == 2
-    Core.Compiler.push!(bsbmp, 1)
-    @test Core.Compiler.popfirst!(bsbmp) == 1
-    @test Core.Compiler.isempty(bsbmp)
+    @test Compiler.popfirst!(bsbmp) == 2
+    Compiler.push!(bsbmp, 1)
+    @test Compiler.popfirst!(bsbmp) == 1
+    @test Compiler.isempty(bsbmp)
 end
 
 @testset "basic heap functionality" begin
     v = [2,3,1]
-    @test Core.Compiler.heapify!(v, Core.Compiler.Forward) === v
-    @test Core.Compiler.heappop!(v, Core.Compiler.Forward) === 1
-    @test Core.Compiler.heappush!(v, 4, Core.Compiler.Forward) === v
-    @test Core.Compiler.heappop!(v, Core.Compiler.Forward) === 2
-    @test Core.Compiler.heappop!(v, Core.Compiler.Forward) === 3
-    @test Core.Compiler.heappop!(v, Core.Compiler.Forward) === 4
+    @test Compiler.heapify!(v, Compiler.Forward) === v
+    @test Compiler.heappop!(v, Compiler.Forward) === 1
+    @test Compiler.heappush!(v, 4, Compiler.Forward) === v
+    @test Compiler.heappop!(v, Compiler.Forward) === 2
+    @test Compiler.heappop!(v, Compiler.Forward) === 3
+    @test Compiler.heappop!(v, Compiler.Forward) === 4
 end
 
 @testset "randomized heap correctness tests" begin
-    order = Core.Compiler.By(x -> -x[2])
+    order = Compiler.By(x -> -x[2])
     for i in 1:6
         heap = Tuple{Int, Int}[(rand(1:i), rand(1:i)) for _ in 1:2i]
         mock = copy(heap)
-        @test Core.Compiler.heapify!(heap, order) === heap
+        @test Compiler.heapify!(heap, order) === heap
         sort!(mock, by=last)
 
         for _ in 1:6i
             if rand() < .5 && !isempty(heap)
                 # The first entries may differ because heaps are not stable
-                @test last(Core.Compiler.heappop!(heap, order)) === last(pop!(mock))
+                @test last(Compiler.heappop!(heap, order)) === last(pop!(mock))
             else
                 new = (rand(1:i), rand(1:i))
-                Core.Compiler.heappush!(heap, new, order)
+                Compiler.heappush!(heap, new, order)
                 push!(mock, new)
                 sort!(mock, by=last)
             end
@@ -68,29 +76,29 @@ end
 end
 
 @testset "searchsorted" begin
-    @test Core.Compiler.searchsorted([1, 1, 2, 2, 3, 3], 0) === Core.Compiler.UnitRange(1, 0)
-    @test Core.Compiler.searchsorted([1, 1, 2, 2, 3, 3], 1) === Core.Compiler.UnitRange(1, 2)
-    @test Core.Compiler.searchsorted([1, 1, 2, 2, 3, 3], 2) === Core.Compiler.UnitRange(3, 4)
-    @test Core.Compiler.searchsorted([1, 1, 2, 2, 3, 3], 4) === Core.Compiler.UnitRange(7, 6)
-    @test Core.Compiler.searchsorted([1, 1, 2, 2, 3, 3], 2.5; lt=<) === Core.Compiler.UnitRange(5, 4)
+    @test Compiler.searchsorted([1, 1, 2, 2, 3, 3], 0) === Compiler.UnitRange(1, 0)
+    @test Compiler.searchsorted([1, 1, 2, 2, 3, 3], 1) === Compiler.UnitRange(1, 2)
+    @test Compiler.searchsorted([1, 1, 2, 2, 3, 3], 2) === Compiler.UnitRange(3, 4)
+    @test Compiler.searchsorted([1, 1, 2, 2, 3, 3], 4) === Compiler.UnitRange(7, 6)
+    @test Compiler.searchsorted([1, 1, 2, 2, 3, 3], 2.5; lt=<) === Compiler.UnitRange(5, 4)
 
-    @test Core.Compiler.searchsorted(Core.Compiler.UnitRange(1, 3), 0) === Core.Compiler.UnitRange(1, 0)
-    @test Core.Compiler.searchsorted(Core.Compiler.UnitRange(1, 3), 1) === Core.Compiler.UnitRange(1, 1)
-    @test Core.Compiler.searchsorted(Core.Compiler.UnitRange(1, 3), 2) === Core.Compiler.UnitRange(2, 2)
-    @test Core.Compiler.searchsorted(Core.Compiler.UnitRange(1, 3), 4) === Core.Compiler.UnitRange(4, 3)
+    @test Compiler.searchsorted(Compiler.UnitRange(1, 3), 0) === Compiler.UnitRange(1, 0)
+    @test Compiler.searchsorted(Compiler.UnitRange(1, 3), 1) === Compiler.UnitRange(1, 1)
+    @test Compiler.searchsorted(Compiler.UnitRange(1, 3), 2) === Compiler.UnitRange(2, 2)
+    @test Compiler.searchsorted(Compiler.UnitRange(1, 3), 4) === Compiler.UnitRange(4, 3)
 
-    @test Core.Compiler.searchsorted([1:10;], 1, by=(x -> x >= 5)) === Core.Compiler.UnitRange(1, 4)
-    @test Core.Compiler.searchsorted([1:10;], 10, by=(x -> x >= 5)) === Core.Compiler.UnitRange(5, 10)
-    @test Core.Compiler.searchsorted([1:5; 1:5; 1:5], 1, 6, 10, Core.Compiler.Forward) === Core.Compiler.UnitRange(6, 6)
-    @test Core.Compiler.searchsorted(fill(1, 15), 1, 6, 10, Core.Compiler.Forward) === Core.Compiler.UnitRange(6, 10)
+    @test Compiler.searchsorted([1:10;], 1, by=(x -> x >= 5)) === Compiler.UnitRange(1, 4)
+    @test Compiler.searchsorted([1:10;], 10, by=(x -> x >= 5)) === Compiler.UnitRange(5, 10)
+    @test Compiler.searchsorted([1:5; 1:5; 1:5], 1, 6, 10, Compiler.Forward) === Compiler.UnitRange(6, 6)
+    @test Compiler.searchsorted(fill(1, 15), 1, 6, 10, Compiler.Forward) === Compiler.UnitRange(6, 10)
 
-    for (rg,I) in Any[(Core.Compiler.UnitRange(49, 57),   47:59),
-                      (Core.Compiler.StepRange(1, 2, 17), -1:19)]
-        rg_r = Core.Compiler.reverse(rg)
-        rgv, rgv_r = Core.Compiler.collect(rg), Core.Compiler.collect(rg_r)
+    for (rg,I) in Any[(Compiler.UnitRange(49, 57),   47:59),
+                      (Compiler.StepRange(1, 2, 17), -1:19)]
+        rg_r = Compiler.reverse(rg)
+        rgv, rgv_r = Compiler.collect(rg), Compiler.collect(rg_r)
         for i = I
-            @test Core.Compiler.searchsorted(rg,i) === Core.Compiler.searchsorted(rgv,i)
-            @test Core.Compiler.searchsorted(rg_r,i,rev=true) === Core.Compiler.searchsorted(rgv_r,i,rev=true)
+            @test Compiler.searchsorted(rg,i) === Compiler.searchsorted(rgv,i)
+            @test Compiler.searchsorted(rg_r,i,rev=true) === Compiler.searchsorted(rgv_r,i,rev=true)
         end
     end
 end
@@ -98,16 +106,16 @@ end
 @testset "basic sort" begin
     v = [3,1,2]
     @test v == [3,1,2]
-    @test Core.Compiler.sort!(v) === v == [1,2,3]
-    @test Core.Compiler.sort!(v, by = x -> -x) === v == [3,2,1]
-    @test Core.Compiler.sort!(v, by = x -> -x, < = >) === v == [1,2,3]
+    @test Compiler.sort!(v) === v == [1,2,3]
+    @test Compiler.sort!(v, by = x -> -x) === v == [3,2,1]
+    @test Compiler.sort!(v, by = x -> -x, < = >) === v == [1,2,3]
 end
 
 @testset "randomized sorting tests" begin
     for n in [0, 1, 3, 10, 30, 100, 300], k in [0, 30, 2n]
         v = rand(-1:k, n)
         for by in [identity, x -> -x, x -> x^2 + .1x], lt in [<, >]
-            @test sort(v; by, lt) == Core.Compiler.sort!(copy(v); by, < = lt)
+            @test sort(v; by, lt) == Compiler.sort!(copy(v); by, < = lt)
         end
     end
 end

--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -6,7 +6,7 @@ function f_apply_bail(f)
     f(()...)
     return nothing
 end
-@test !Core.Compiler.is_removable_if_unused(Base.infer_effects(f_apply_bail))
+@test !Compiler.is_removable_if_unused(Base.infer_effects(f_apply_bail))
 @test !fully_eliminated((Function,)) do f
     f_apply_bail(f)
     nothing
@@ -16,10 +16,10 @@ end
 # up the effects of the function being analyzed
 f_throws() = error()
 @noinline function return_type_unused(x)
-    Core.Compiler.return_type(f_throws, Tuple{})
+    Compiler.return_type(f_throws, Tuple{})
     return x+1
 end
-@test Core.Compiler.is_removable_if_unused(Base.infer_effects(return_type_unused, (Int,)))
+@test Compiler.is_removable_if_unused(Base.infer_effects(return_type_unused, (Int,)))
 @test fully_eliminated((Int,)) do x
     return_type_unused(x)
     return nothing
@@ -29,7 +29,7 @@ end
 ambig_effects_test(a::Int, b) = 1
 ambig_effects_test(a, b::Int) = 1
 ambig_effects_test(a, b) = 1
-@test !Core.Compiler.is_nothrow(Base.infer_effects(ambig_effects_test, (Int, Any)))
+@test !Compiler.is_nothrow(Base.infer_effects(ambig_effects_test, (Int, Any)))
 global ambig_unknown_type_global::Any = 1
 @noinline function conditionally_call_ambig(b::Bool, a)
     if b
@@ -46,7 +46,7 @@ end
 # appropriately
 struct FCallback; f::Union{Nothing, Function}; end
 f_invoke_callback(fc) = let f=fc.f; (f !== nothing && f(); nothing); end
-@test !Core.Compiler.is_removable_if_unused(Base.infer_effects(f_invoke_callback, (FCallback,)))
+@test !Compiler.is_removable_if_unused(Base.infer_effects(f_invoke_callback, (FCallback,)))
 @test !fully_eliminated((FCallback,)) do fc
     f_invoke_callback(fc)
     return nothing
@@ -79,7 +79,7 @@ Base.@assume_effects :terminates_globally function issue41694(x)
     end
     return res
 end
-@test Core.Compiler.is_foldable(Base.infer_effects(issue41694, (Int,)))
+@test Compiler.is_foldable(Base.infer_effects(issue41694, (Int,)))
 @test fully_eliminated() do
     issue41694(2)
 end
@@ -89,8 +89,8 @@ Base.@assume_effects :terminates_globally function recur_termination1(x)
     0 ≤ x < 20 || error("bad fact")
     return x * recur_termination1(x-1)
 end
-@test Core.Compiler.is_foldable(Base.infer_effects(recur_termination1, (Int,)))
-@test Core.Compiler.is_terminates(Base.infer_effects(recur_termination1, (Int,)))
+@test Compiler.is_foldable(Base.infer_effects(recur_termination1, (Int,)))
+@test Compiler.is_terminates(Base.infer_effects(recur_termination1, (Int,)))
 function recur_termination2()
     Base.@assume_effects :total !:terminates_globally
     recur_termination1(12)
@@ -104,10 +104,10 @@ Base.@assume_effects :terminates_globally function recur_termination21(x)
     return recur_termination22(x)
 end
 recur_termination22(x) = x * recur_termination21(x-1)
-@test Core.Compiler.is_foldable(Base.infer_effects(recur_termination21, (Int,)))
-@test Core.Compiler.is_foldable(Base.infer_effects(recur_termination22, (Int,)))
-@test Core.Compiler.is_terminates(Base.infer_effects(recur_termination21, (Int,)))
-@test Core.Compiler.is_terminates(Base.infer_effects(recur_termination22, (Int,)))
+@test Compiler.is_foldable(Base.infer_effects(recur_termination21, (Int,)))
+@test Compiler.is_foldable(Base.infer_effects(recur_termination22, (Int,)))
+@test Compiler.is_terminates(Base.infer_effects(recur_termination21, (Int,)))
+@test Compiler.is_terminates(Base.infer_effects(recur_termination22, (Int,)))
 function recur_termination2x()
     Base.@assume_effects :total !:terminates_globally
     recur_termination21(12) + recur_termination22(12)
@@ -133,61 +133,61 @@ end
 # control flow backedge should taint `terminates`
 @test Base.infer_effects((Int,)) do n
     for i = 1:n; end
-end |> !Core.Compiler.is_terminates
+end |> !Compiler.is_terminates
 
 # interprocedural-recursion should taint `terminates` **appropriately**
 function sumrecur(a, x)
     isempty(a) && return x
     return sumrecur(Base.tail(a), x + first(a))
 end
-@test Base.infer_effects(sumrecur, (Tuple{Int,Int,Int},Int)) |> Core.Compiler.is_terminates
-@test Base.infer_effects(sumrecur, (Tuple{Int,Int,Int,Vararg{Int}},Int)) |> !Core.Compiler.is_terminates
+@test Base.infer_effects(sumrecur, (Tuple{Int,Int,Int},Int)) |> Compiler.is_terminates
+@test Base.infer_effects(sumrecur, (Tuple{Int,Int,Int,Vararg{Int}},Int)) |> !Compiler.is_terminates
 
 # https://github.com/JuliaLang/julia/issues/45781
 @test Base.infer_effects((Float32,)) do a
     out1 = promote_type(Irrational{:π}, Bool)
     out2 = sin(a)
     out1, out2
-end |> Core.Compiler.is_terminates
+end |> Compiler.is_terminates
 
 # refine :consistent-cy effect inference using the return type information
 @test Base.infer_effects((Any,)) do x
     taint = Ref{Any}(x) # taints :consistent-cy, but will be adjusted
     throw(taint)
-end |> Core.Compiler.is_consistent
+end |> Compiler.is_consistent
 @test Base.infer_effects((Int,)) do x
     if x < 0
         taint = Ref(x) # taints :consistent-cy, but will be adjusted
         throw(DomainError(x, taint))
     end
     return nothing
-end |> Core.Compiler.is_consistent
+end |> Compiler.is_consistent
 @test Base.infer_effects((Int,)) do x
     if x < 0
         taint = Ref(x) # taints :consistent-cy, but will be adjusted
         throw(DomainError(x, taint))
     end
     return x == 0 ? nothing : x # should `Union` of isbitstype objects nicely
-end |> Core.Compiler.is_consistent
+end |> Compiler.is_consistent
 @test Base.infer_effects((Symbol,Any)) do s, x
     if s === :throw
         taint = Ref{Any}(":throw option given") # taints :consistent-cy, but will be adjusted
         throw(taint)
     end
     return s # should handle `Symbol` nicely
-end |> Core.Compiler.is_consistent
+end |> Compiler.is_consistent
 @test Base.infer_effects((Int,)) do x
     return Ref(x)
-end |> !Core.Compiler.is_consistent
+end |> !Compiler.is_consistent
 @test Base.infer_effects((Int,)) do x
     return x < 0 ? Ref(x) : nothing
-end |> !Core.Compiler.is_consistent
+end |> !Compiler.is_consistent
 @test Base.infer_effects((Int,)) do x
     if x < 0
         throw(DomainError(x, lazy"$x is negative"))
     end
     return nothing
-end |> Core.Compiler.is_foldable
+end |> Compiler.is_foldable
 
 # :the_exception expression should taint :consistent-cy
 global inconsistent_var::Int = 42
@@ -201,7 +201,7 @@ function catch_inconsistent()
         err
     end
 end
-@test !Core.Compiler.is_consistent(Base.infer_effects(catch_inconsistent))
+@test !Compiler.is_consistent(Base.infer_effects(catch_inconsistent))
 cache_inconsistent() = catch_inconsistent()
 function compare_inconsistent()
     a = cache_inconsistent()
@@ -221,7 +221,7 @@ function catch_inconsistent(x::T) where T
     end
     return v
 end
-@test !Core.Compiler.is_consistent(Base.infer_effects(catch_inconsistent, (Int,)))
+@test !Compiler.is_consistent(Base.infer_effects(catch_inconsistent, (Int,)))
 cache_inconsistent(x) = catch_inconsistent(x)
 function compare_inconsistent(x::T) where T
     x = one(T)
@@ -234,7 +234,7 @@ end
 @test !compare_inconsistent(3)
 
 # Effect modeling for Core.compilerbarrier
-@test Base.infer_effects(Base.inferencebarrier, Tuple{Any}) |> Core.Compiler.is_removable_if_unused
+@test Base.infer_effects(Base.inferencebarrier, Tuple{Any}) |> Compiler.is_removable_if_unused
 
 # effects modeling for allocation/access of uninitialized fields
 struct Maybe{T}
@@ -249,19 +249,19 @@ struct SyntacticallyDefined{T}
 end
 @test Base.infer_effects() do
     Maybe{Int}()
-end |> !Core.Compiler.is_consistent
+end |> !Compiler.is_consistent
 @test Base.infer_effects() do
     Maybe{Int}()[]
-end |> !Core.Compiler.is_consistent
+end |> !Compiler.is_consistent
 @test !fully_eliminated() do
     Maybe{Int}()[]
 end
 @test Base.infer_effects() do
     Maybe{String}()
-end |> Core.Compiler.is_consistent
+end |> Compiler.is_consistent
 @test Base.infer_effects() do
     Maybe{String}()[]
-end |> Core.Compiler.is_consistent
+end |> Compiler.is_consistent
 let f() = Maybe{String}()[]
     @test Base.return_types() do
         f() # this call should be concrete evaluated
@@ -269,16 +269,16 @@ let f() = Maybe{String}()[]
 end
 @test Base.infer_effects() do
     Ref{Int}()
-end |> !Core.Compiler.is_consistent
+end |> !Compiler.is_consistent
 @test Base.infer_effects() do
     Ref{Int}()[]
-end |> !Core.Compiler.is_consistent
+end |> !Compiler.is_consistent
 @test !fully_eliminated() do
     Ref{Int}()[]
 end
 @test Base.infer_effects() do
     Ref{String}()[]
-end |> Core.Compiler.is_consistent
+end |> Compiler.is_consistent
 let f() = Ref{String}()[]
     @test Base.return_types() do
         f() # this call should be concrete evaluated
@@ -286,7 +286,7 @@ let f() = Ref{String}()[]
 end
 @test Base.infer_effects((SyntacticallyDefined{Float64}, Symbol)) do w, s
     getfield(w, s)
-end |> Core.Compiler.is_foldable
+end |> Compiler.is_foldable
 
 # effects propagation for `Core.invoke` calls
 # https://github.com/JuliaLang/julia/issues/44763
@@ -307,7 +307,7 @@ function A1_inbounds()
     end
     return r
 end
-@test !Core.Compiler.is_consistent(Base.infer_effects(A1_inbounds))
+@test !Compiler.is_consistent(Base.infer_effects(A1_inbounds))
 
 # Test that purity doesn't try to accidentally run unreachable code due to
 # boundscheck elimination
@@ -317,7 +317,7 @@ function f_boundscheck_elim(n)
     # to run the `@inbounds getfield(sin, 1)` that `ntuple` generates.
     ntuple(x->(@inbounds ()[x]), n)
 end
-@test !Core.Compiler.is_noub(Base.infer_effects(f_boundscheck_elim, (Int,)))
+@test !Compiler.is_noub(Base.infer_effects(f_boundscheck_elim, (Int,)))
 @test Tuple{} <: only(Base.return_types(f_boundscheck_elim, (Int,)))
 
 # Test that purity modeling doesn't accidentally introduce new world age issues
@@ -343,36 +343,36 @@ function entry_to_be_invalidated(c)
 end
 @test Base.infer_effects((Char,)) do x
     entry_to_be_invalidated(x)
-end |> Core.Compiler.is_foldable
+end |> Compiler.is_foldable
 @test fully_eliminated(; retval=97) do
     entry_to_be_invalidated('a')
 end
 getcharid(c) = CONST_DICT[c] # now this is not eligible for concrete evaluation
 @test Base.infer_effects((Char,)) do x
     entry_to_be_invalidated(x)
-end |> !Core.Compiler.is_foldable
+end |> !Compiler.is_foldable
 @test !fully_eliminated() do
     entry_to_be_invalidated('a')
 end
 
-@test !Core.Compiler.builtin_nothrow(Core.Compiler.fallback_lattice, Core.get_binding_type, Any[Rational{Int}, Core.Const(:foo)], Any)
+@test !Compiler.builtin_nothrow(Compiler.fallback_lattice, Core.get_binding_type, Any[Rational{Int}, Core.Const(:foo)], Any)
 
 # effects modeling for assignment to globals
 global glob_assign_int::Int = 0
 f_glob_assign_int() = global glob_assign_int = 1
 let effects = Base.infer_effects(f_glob_assign_int, (); optimize=false)
-    @test Core.Compiler.is_consistent(effects)
-    @test !Core.Compiler.is_effect_free(effects)
-    @test Core.Compiler.is_nothrow(effects)
+    @test Compiler.is_consistent(effects)
+    @test !Compiler.is_effect_free(effects)
+    @test Compiler.is_nothrow(effects)
 end
 # effects modeling for for setglobal!
 global SETGLOBAL!_NOTHROW::Int = 0
 let effects = Base.infer_effects(; optimize=false) do
         setglobal!(@__MODULE__, :SETGLOBAL!_NOTHROW, 42)
     end
-    @test Core.Compiler.is_consistent(effects)
-    @test !Core.Compiler.is_effect_free(effects)
-    @test Core.Compiler.is_nothrow(effects)
+    @test Compiler.is_consistent(effects)
+    @test !Compiler.is_effect_free(effects)
+    @test Compiler.is_nothrow(effects)
 end
 
 # we should taint `nothrow` if the binding doesn't exist and isn't fixed yet,
@@ -383,23 +383,23 @@ setglobal!_nothrow_undefinedyet() = setglobal!(@__MODULE__, :UNDEFINEDYET, 42)
 let effects = Base.infer_effects() do
         global_assignment_undefinedyet()
     end
-    @test !Core.Compiler.is_nothrow(effects)
+    @test !Compiler.is_nothrow(effects)
 end
 let effects = Base.infer_effects() do
         setglobal!_nothrow_undefinedyet()
     end
-    @test !Core.Compiler.is_nothrow(effects)
+    @test !Compiler.is_nothrow(effects)
 end
 global UNDEFINEDYET::String = "0"
 let effects = Base.infer_effects() do
         global_assignment_undefinedyet()
     end
-    @test !Core.Compiler.is_nothrow(effects)
+    @test !Compiler.is_nothrow(effects)
 end
 let effects = Base.infer_effects() do
         setglobal!_nothrow_undefinedyet()
     end
-    @test !Core.Compiler.is_nothrow(effects)
+    @test !Compiler.is_nothrow(effects)
 end
 @test_throws Union{ErrorException,TypeError} setglobal!_nothrow_undefinedyet() # TODO: what kind of error should this be?
 
@@ -409,70 +409,70 @@ mutable struct SetfieldNothrow
 end
 f_setfield_nothrow() = SetfieldNothrow(0).x = 1
 let effects = Base.infer_effects(f_setfield_nothrow, ())
-    @test Core.Compiler.is_nothrow(effects)
-    @test Core.Compiler.is_effect_free(effects) # see EFFECT_FREE_IF_INACCESSIBLEMEMONLY
+    @test Compiler.is_nothrow(effects)
+    @test Compiler.is_effect_free(effects) # see EFFECT_FREE_IF_INACCESSIBLEMEMONLY
 end
 
 # even if 2-arg `getfield` may throw, it should be still `:consistent`
-@test Core.Compiler.is_consistent(Base.infer_effects(getfield, (NTuple{5, Float64}, Int)))
+@test Compiler.is_consistent(Base.infer_effects(getfield, (NTuple{5, Float64}, Int)))
 
 # SimpleVector allocation is consistent
-@test Core.Compiler.is_consistent(Base.infer_effects(Core.svec))
+@test Compiler.is_consistent(Base.infer_effects(Core.svec))
 @test Base.infer_effects() do
     Core.svec(nothing, 1, "foo")
-end |> Core.Compiler.is_consistent
+end |> Compiler.is_consistent
 
 # fastmath operations are in-`:consistent`
-@test !Core.Compiler.is_consistent(Base.infer_effects((a,b)->@fastmath(a+b), (Float64,Float64)))
+@test !Compiler.is_consistent(Base.infer_effects((a,b)->@fastmath(a+b), (Float64,Float64)))
 
 # issue 46122: @assume_effects for @ccall
 @test Base.infer_effects((Vector{Int},)) do a
     Base.@assume_effects :effect_free @ccall this_call_does_not_really_exist(a::Any)::Ptr{Int}
-end |> Core.Compiler.is_effect_free
+end |> Compiler.is_effect_free
 
 # `getfield_effects` handles access to union object nicely
-let 𝕃 = Core.Compiler.fallback_lattice
-    getfield_effects = Core.Compiler.getfield_effects
-    @test Core.Compiler.is_consistent(getfield_effects(𝕃, Any[Some{String}, Core.Const(:value)], String))
-    @test Core.Compiler.is_consistent(getfield_effects(𝕃, Any[Some{Symbol}, Core.Const(:value)], Symbol))
-    @test Core.Compiler.is_consistent(getfield_effects(𝕃, Any[Union{Some{Symbol},Some{String}}, Core.Const(:value)], Union{Symbol,String}))
+let 𝕃 = Compiler.fallback_lattice
+    getfield_effects = Compiler.getfield_effects
+    @test Compiler.is_consistent(getfield_effects(𝕃, Any[Some{String}, Core.Const(:value)], String))
+    @test Compiler.is_consistent(getfield_effects(𝕃, Any[Some{Symbol}, Core.Const(:value)], Symbol))
+    @test Compiler.is_consistent(getfield_effects(𝕃, Any[Union{Some{Symbol},Some{String}}, Core.Const(:value)], Union{Symbol,String}))
 end
 @test Base.infer_effects((Bool,)) do c
     obj = c ? Some{String}("foo") : Some{Symbol}(:bar)
     return getfield(obj, :value)
-end |> Core.Compiler.is_consistent
+end |> Compiler.is_consistent
 
 # getfield is nothrow when bounds checking is turned off
 @test Base.infer_effects((Tuple{Int,Int},Int)) do t, i
     getfield(t, i, false)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((Tuple{Int,Int},Symbol)) do t, i
     getfield(t, i, false)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((Tuple{Int,Int},String)) do t, i
     getfield(t, i, false) # invalid name type
-end |> !Core.Compiler.is_nothrow
+end |> !Compiler.is_nothrow
 
 @test Base.infer_effects((Some{Any},)) do some
     getfield(some, 1, :not_atomic)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((Some{Any},)) do some
     getfield(some, 1, :invalid_atomic_spec)
-end |> !Core.Compiler.is_nothrow
+end |> !Compiler.is_nothrow
 @test Base.infer_effects((Some{Any},Bool)) do some, boundscheck
     getfield(some, 1, boundscheck)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((Some{Any},Bool)) do some, boundscheck
     getfield(some, 1, :not_atomic, boundscheck)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((Some{Any},Bool)) do some, boundscheck
     getfield(some, 1, :invalid_atomic_spec, boundscheck)
-end |> !Core.Compiler.is_nothrow
+end |> !Compiler.is_nothrow
 @test Base.infer_effects((Some{Any},Any)) do some, boundscheck
     getfield(some, 1, :not_atomic, boundscheck)
-end |> !Core.Compiler.is_nothrow
+end |> !Compiler.is_nothrow
 
-@test Core.Compiler.is_consistent(Base.infer_effects(setindex!, (Base.RefValue{Int}, Int)))
+@test Compiler.is_consistent(Base.infer_effects(setindex!, (Base.RefValue{Int}, Int)))
 
 # :inaccessiblememonly effect
 const global constant_global::Int = 42
@@ -482,68 +482,68 @@ const global constant_mutable_global = Ref(0)
 const global constant_global_nonisbits = Some(:foo)
 @test Base.infer_effects() do
     constant_global
-end |> Core.Compiler.is_inaccessiblememonly
+end |> Compiler.is_inaccessiblememonly
 @test Base.infer_effects() do
     ConstantType
-end |> Core.Compiler.is_inaccessiblememonly
+end |> Compiler.is_inaccessiblememonly
 @test Base.infer_effects() do
     ConstantType{Any}()
-end |> Core.Compiler.is_inaccessiblememonly
+end |> Compiler.is_inaccessiblememonly
 @test Base.infer_effects() do
     constant_global_nonisbits
-end |> Core.Compiler.is_inaccessiblememonly
+end |> Compiler.is_inaccessiblememonly
 @test Base.infer_effects() do
     getglobal(@__MODULE__, :constant_global)
-end |> Core.Compiler.is_inaccessiblememonly
+end |> Compiler.is_inaccessiblememonly
 @test Base.infer_effects() do
     nonconstant_global
-end |> !Core.Compiler.is_inaccessiblememonly
+end |> !Compiler.is_inaccessiblememonly
 @test Base.infer_effects() do
     getglobal(@__MODULE__, :nonconstant_global)
-end |> !Core.Compiler.is_inaccessiblememonly
+end |> !Compiler.is_inaccessiblememonly
 @test Base.infer_effects((Symbol,)) do name
     getglobal(@__MODULE__, name)
-end |> !Core.Compiler.is_inaccessiblememonly
+end |> !Compiler.is_inaccessiblememonly
 @test Base.infer_effects((Int,)) do v
     global nonconstant_global = v
-end |> !Core.Compiler.is_inaccessiblememonly
+end |> !Compiler.is_inaccessiblememonly
 @test Base.infer_effects((Int,)) do v
     setglobal!(@__MODULE__, :nonconstant_global, v)
-end |> !Core.Compiler.is_inaccessiblememonly
+end |> !Compiler.is_inaccessiblememonly
 @test Base.infer_effects((Int,)) do v
     constant_mutable_global[] = v
-end |> !Core.Compiler.is_inaccessiblememonly
+end |> !Compiler.is_inaccessiblememonly
 module ConsistentModule
 const global constant_global::Int = 42
 const global ConstantType = Ref
 end # module
 @test Base.infer_effects() do
     ConsistentModule.constant_global
-end |> Core.Compiler.is_inaccessiblememonly
+end |> Compiler.is_inaccessiblememonly
 @test Base.infer_effects() do
     ConsistentModule.ConstantType
-end |> Core.Compiler.is_inaccessiblememonly
+end |> Compiler.is_inaccessiblememonly
 @test Base.infer_effects() do
     ConsistentModule.ConstantType{Any}()
-end |> Core.Compiler.is_inaccessiblememonly
+end |> Compiler.is_inaccessiblememonly
 @test Base.infer_effects() do
     getglobal(@__MODULE__, :ConsistentModule).constant_global
-end |> Core.Compiler.is_inaccessiblememonly
+end |> Compiler.is_inaccessiblememonly
 @test Base.infer_effects() do
     getglobal(@__MODULE__, :ConsistentModule).ConstantType
-end |> Core.Compiler.is_inaccessiblememonly
+end |> Compiler.is_inaccessiblememonly
 @test Base.infer_effects() do
     getglobal(@__MODULE__, :ConsistentModule).ConstantType{Any}()
-end |> Core.Compiler.is_inaccessiblememonly
+end |> Compiler.is_inaccessiblememonly
 @test Base.infer_effects((Module,)) do M
     M.constant_global
-end |> !Core.Compiler.is_inaccessiblememonly
+end |> !Compiler.is_inaccessiblememonly
 @test Base.infer_effects((Module,)) do M
     M.ConstantType
-end |> !Core.Compiler.is_inaccessiblememonly
+end |> !Compiler.is_inaccessiblememonly
 @test Base.infer_effects() do M
     M.ConstantType{Any}()
-end |> !Core.Compiler.is_inaccessiblememonly
+end |> !Compiler.is_inaccessiblememonly
 
 # the `:inaccessiblememonly` helper effect allows us to prove `:consistent`-cy of frames
 # including `getfield` / `isdefined` accessing to local mutable object
@@ -558,7 +558,7 @@ Base.isassigned(x::SafeRef) = true;
 function mutable_consistent(s)
     SafeRef(s)[]
 end
-@test Core.Compiler.is_inaccessiblememonly(Base.infer_effects(mutable_consistent, (Symbol,)))
+@test Compiler.is_inaccessiblememonly(Base.infer_effects(mutable_consistent, (Symbol,)))
 @test fully_eliminated(; retval=:foo) do
     mutable_consistent(:foo)
 end
@@ -566,7 +566,7 @@ end
 function nested_mutable_consistent(s)
     SafeRef(SafeRef(SafeRef(SafeRef(SafeRef(s)))))[][][][][]
 end
-@test Core.Compiler.is_inaccessiblememonly(Base.infer_effects(nested_mutable_consistent, (Symbol,)))
+@test Compiler.is_inaccessiblememonly(Base.infer_effects(nested_mutable_consistent, (Symbol,)))
 @test fully_eliminated(; retval=:foo) do
     nested_mutable_consistent(:foo)
 end
@@ -574,11 +574,11 @@ end
 const consistent_global = Some(:foo)
 @test Base.infer_effects() do
     consistent_global.value
-end |> Core.Compiler.is_consistent
+end |> Compiler.is_consistent
 const inconsistent_global = SafeRef(:foo)
 @test Base.infer_effects() do
     inconsistent_global[]
-end |> !Core.Compiler.is_consistent
+end |> !Compiler.is_consistent
 const inconsistent_condition_ref = Ref{Bool}(false)
 @test Base.infer_effects() do
     if inconsistent_condition_ref[]
@@ -586,11 +586,11 @@ const inconsistent_condition_ref = Ref{Bool}(false)
     else
         return 1
     end
-end |> !Core.Compiler.is_consistent
+end |> !Compiler.is_consistent
 
 # should handle va-method properly
 callgetfield1(xs...) = getfield(getfield(xs, 1), 1)
-@test !Core.Compiler.is_inaccessiblememonly(Base.infer_effects(callgetfield1, (Base.RefValue{Symbol},)))
+@test !Compiler.is_inaccessiblememonly(Base.infer_effects(callgetfield1, (Base.RefValue{Symbol},)))
 const GLOBAL_XS = Ref(:julia)
 global_getfield() = callgetfield1(GLOBAL_XS)
 @test let
@@ -623,9 +623,9 @@ end
 end
 for f = Any[removable_if_unused1, removable_if_unused2]
     effects = Base.infer_effects(f)
-    @test Core.Compiler.is_inaccessiblememonly(effects)
-    @test Core.Compiler.is_effect_free(effects)
-    @test Core.Compiler.is_removable_if_unused(effects)
+    @test Compiler.is_inaccessiblememonly(effects)
+    @test Compiler.is_effect_free(effects)
+    @test Compiler.is_removable_if_unused(effects)
     @test @eval fully_eliminated() do
         $f()
         nothing
@@ -637,9 +637,9 @@ end
     x
 end
 let effects = Base.infer_effects(removable_if_unused3, (Int,))
-    @test Core.Compiler.is_inaccessiblememonly(effects)
-    @test Core.Compiler.is_effect_free(effects)
-    @test Core.Compiler.is_removable_if_unused(effects)
+    @test Compiler.is_inaccessiblememonly(effects)
+    @test Compiler.is_effect_free(effects)
+    @test Compiler.is_removable_if_unused(effects)
 end
 @test fully_eliminated((Int,)) do v
     removable_if_unused3(v)
@@ -649,18 +649,18 @@ end
 @noinline function unremovable_if_unused1!(x)
     setref!(x, 42)
 end
-@test !Core.Compiler.is_removable_if_unused(Base.infer_effects(unremovable_if_unused1!, (typeof(global_ref),)))
-@test !Core.Compiler.is_removable_if_unused(Base.infer_effects(unremovable_if_unused1!, (Any,)))
+@test !Compiler.is_removable_if_unused(Base.infer_effects(unremovable_if_unused1!, (typeof(global_ref),)))
+@test !Compiler.is_removable_if_unused(Base.infer_effects(unremovable_if_unused1!, (Any,)))
 
 @noinline function unremovable_if_unused2!()
     setref!(global_ref, 42)
 end
-@test !Core.Compiler.is_removable_if_unused(Base.infer_effects(unremovable_if_unused2!))
+@test !Compiler.is_removable_if_unused(Base.infer_effects(unremovable_if_unused2!))
 
 @noinline function unremovable_if_unused3!()
     getfield(@__MODULE__, :global_ref)[] = nothing
 end
-@test !Core.Compiler.is_removable_if_unused(Base.infer_effects(unremovable_if_unused3!))
+@test !Compiler.is_removable_if_unused(Base.infer_effects(unremovable_if_unused3!))
 
 # array ops
 # =========
@@ -678,7 +678,7 @@ let good_dims = [1, 2, 3, 4, 10]
         dims = ntuple(i->dim, N)
         @test @eval Base.infer_effects() do
             construct_array(Int, $(dims...))
-        end |> Core.Compiler.is_removable_if_unused
+        end |> Compiler.is_removable_if_unused
         @test @eval fully_eliminated() do
             construct_array(Int, $(dims...))
             nothing
@@ -692,7 +692,7 @@ let bad_dims = [-1, typemax(Int)]
             dims = ntuple(i->dim, N)
             @test @eval Base.infer_effects() do
                 construct_array($T, $(dims...))
-            end |> !Core.Compiler.is_removable_if_unused
+            end |> !Compiler.is_removable_if_unused
             @test @eval !fully_eliminated() do
                 construct_array($T, $(dims...))
                 nothing
@@ -716,8 +716,8 @@ for safesig = Any[
         (Type{Any}, Any, Any)
     ]
     let effects = Base.infer_effects(getindex, safesig)
-        @test Core.Compiler.is_consistent_if_notreturned(effects)
-        @test Core.Compiler.is_removable_if_unused(effects)
+        @test Compiler.is_consistent_if_notreturned(effects)
+        @test Compiler.is_removable_if_unused(effects)
     end
 end
 for unsafesig = Any[
@@ -727,7 +727,7 @@ for unsafesig = Any[
         (Type{Number}, Any)
     ]
     let effects = Base.infer_effects(getindex, unsafesig)
-        @test !Core.Compiler.is_nothrow(effects)
+        @test !Compiler.is_nothrow(effects)
     end
 end
 # vect
@@ -737,53 +737,53 @@ for safesig = Any[
         (Int, Int)
     ]
     let effects = Base.infer_effects(Base.vect, safesig)
-        @test Core.Compiler.is_consistent_if_notreturned(effects)
-        @test Core.Compiler.is_removable_if_unused(effects)
+        @test Compiler.is_consistent_if_notreturned(effects)
+        @test Compiler.is_removable_if_unused(effects)
     end
 end
 
 # array getindex
 let tt = (MemoryRef{Any},Symbol,Bool)
     @testset let effects = Base.infer_effects(Core.memoryrefget, tt)
-        @test Core.Compiler.is_consistent_if_inaccessiblememonly(effects)
-        @test Core.Compiler.is_effect_free(effects)
-        @test !Core.Compiler.is_nothrow(effects)
-        @test Core.Compiler.is_terminates(effects)
+        @test Compiler.is_consistent_if_inaccessiblememonly(effects)
+        @test Compiler.is_effect_free(effects)
+        @test !Compiler.is_nothrow(effects)
+        @test Compiler.is_terminates(effects)
     end
 end
 
 # array setindex!
 let tt = (MemoryRef{Any},Any,Symbol,Bool)
     @testset let effects = Base.infer_effects(Core.memoryrefset!, tt)
-        @test Core.Compiler.is_consistent_if_inaccessiblememonly(effects)
-        @test Core.Compiler.is_effect_free_if_inaccessiblememonly(effects)
-        @test !Core.Compiler.is_nothrow(effects)
-        @test Core.Compiler.is_terminates(effects)
+        @test Compiler.is_consistent_if_inaccessiblememonly(effects)
+        @test Compiler.is_effect_free_if_inaccessiblememonly(effects)
+        @test !Compiler.is_nothrow(effects)
+        @test Compiler.is_terminates(effects)
     end
 end
 # nothrow for arrayset
 @test Base.infer_effects((MemoryRef{Int},Int)) do a, v
     Core.memoryrefset!(a, v, :not_atomic, true)
-end |> !Core.Compiler.is_nothrow
+end |> !Compiler.is_nothrow
 @test Base.infer_effects((MemoryRef{Int},Int)) do a, v
     a[] = v # may throw
-end |> !Core.Compiler.is_nothrow
+end |> !Compiler.is_nothrow
 # when bounds checking is turned off, it should be safe
 @test Base.infer_effects((MemoryRef{Int},Int)) do a, v
     Core.memoryrefset!(a, v, :not_atomic, false)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((MemoryRef{Number},Number)) do a, v
     Core.memoryrefset!(a, v, :not_atomic, false)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 
 # arraysize
 # ---------
 
 let effects = Base.infer_effects(size, (Array,Int))
-    @test Core.Compiler.is_consistent_if_inaccessiblememonly(effects)
-    @test Core.Compiler.is_effect_free(effects)
-    @test !Core.Compiler.is_nothrow(effects)
-    @test Core.Compiler.is_terminates(effects)
+    @test Compiler.is_consistent_if_inaccessiblememonly(effects)
+    @test Compiler.is_effect_free(effects)
+    @test !Compiler.is_nothrow(effects)
+    @test Compiler.is_terminates(effects)
 end
 # Test that arraysize has proper effect modeling
 @test fully_eliminated(M->(size(M, 2); nothing), (Matrix{Float64},))
@@ -792,10 +792,10 @@ end
 # --------
 
 let effects = Base.infer_effects(length, (Vector{Any},))
-    @test Core.Compiler.is_consistent_if_inaccessiblememonly(effects)
-    @test Core.Compiler.is_effect_free(effects)
-    @test Core.Compiler.is_nothrow(effects)
-    @test Core.Compiler.is_terminates(effects)
+    @test Compiler.is_consistent_if_inaccessiblememonly(effects)
+    @test Compiler.is_effect_free(effects)
+    @test Compiler.is_nothrow(effects)
+    @test Compiler.is_terminates(effects)
 end
 
 # resize
@@ -808,21 +808,21 @@ end
 #        Base._deleteend!,
 #    ]
 #    let effects = Base.infer_effects(op, (Vector, Int))
-#        @test Core.Compiler.is_effect_free_if_inaccessiblememonly(effects)
-#        @test Core.Compiler.is_terminates(effects)
-#        @test !Core.Compiler.is_nothrow(effects)
+#        @test Compiler.is_effect_free_if_inaccessiblememonly(effects)
+#        @test Compiler.is_terminates(effects)
+#        @test !Compiler.is_nothrow(effects)
 #    end
 #end
 
-@test Core.Compiler.is_noub(Base.infer_effects(Base._growbeg!, (Vector{Int}, Int)))
-@test Core.Compiler.is_noub(Base.infer_effects(Base._growbeg!, (Vector{Any}, Int)))
-@test Core.Compiler.is_noub(Base.infer_effects(Base._growend!, (Vector{Int}, Int)))
-@test Core.Compiler.is_noub(Base.infer_effects(Base._growend!, (Vector{Any}, Int)))
+@test Compiler.is_noub(Base.infer_effects(Base._growbeg!, (Vector{Int}, Int)))
+@test Compiler.is_noub(Base.infer_effects(Base._growbeg!, (Vector{Any}, Int)))
+@test Compiler.is_noub(Base.infer_effects(Base._growend!, (Vector{Int}, Int)))
+@test Compiler.is_noub(Base.infer_effects(Base._growend!, (Vector{Any}, Int)))
 
 # tuple indexing
 # --------------
 
-@test Core.Compiler.is_foldable(Base.infer_effects(iterate, Tuple{Tuple{Int, Int}, Int}))
+@test Compiler.is_foldable(Base.infer_effects(iterate, Tuple{Tuple{Int, Int}, Int}))
 
 # end to end
 # ----------
@@ -835,12 +835,12 @@ end
 #for T = Any[Int,Any], op! = Any[push!,pushfirst!], op = Any[length,size],
 #    xs = Any[(Int,), (Int,Int,)]
 #    let effects = Base.infer_effects(simple_vec_ops, (Type{T},typeof(op!),typeof(op),xs...))
-#        @test Core.Compiler.is_foldable(effects)
+#        @test Compiler.is_foldable(effects)
 #    end
 #end
 
 # Test that builtin_effects handles vararg correctly
-@test !Core.Compiler.is_nothrow(Core.Compiler.builtin_effects(Core.Compiler.fallback_lattice, Core.isdefined,
+@test !Compiler.is_nothrow(Compiler.builtin_effects(Compiler.fallback_lattice, Core.isdefined,
     Any[String, Vararg{Any}], Bool))
 
 # Test that :new can be eliminated even if an sparam is unknown
@@ -860,33 +860,33 @@ end
 # Effects for getfield of type instance
 @test Base.infer_effects(Tuple{Nothing}) do x
     WrapperOneField{typeof(x)}.instance
-end |> Core.Compiler.is_foldable_nothrow
+end |> Compiler.is_foldable_nothrow
 @test Base.infer_effects(Tuple{WrapperOneField{Float64}, Symbol}) do w, s
     getfield(w, s)
-end |> Core.Compiler.is_foldable
+end |> Compiler.is_foldable
 @test Base.infer_effects(Tuple{WrapperOneField{Symbol}, Symbol}) do w, s
     getfield(w, s)
-end |> Core.Compiler.is_foldable
+end |> Compiler.is_foldable
 
 # Flow-sensitive consistent for _typevar
 @test Base.infer_effects() do
     return WrapperOneField == (WrapperOneField{T} where T)
-end |> Core.Compiler.is_foldable_nothrow
+end |> Compiler.is_foldable_nothrow
 
 # Test that dead `@inbounds` does not taint consistency
 # https://github.com/JuliaLang/julia/issues/48243
 @test Base.infer_effects(Tuple{Int64}) do i
     false && @inbounds (1,2,3)[i]
     return 1
-end |> Core.Compiler.is_foldable_nothrow
+end |> Compiler.is_foldable_nothrow
 
 @test Base.infer_effects(Tuple{Int64}) do i
     @inbounds (1,2,3)[i]
-end |> !Core.Compiler.is_noub
+end |> !Compiler.is_noub
 
 @test Base.infer_effects(Tuple{Tuple{Int64}}) do x
     @inbounds x[1]
-end |> Core.Compiler.is_foldable_nothrow
+end |> Compiler.is_foldable_nothrow
 
 # Test that :new of non-concrete, but otherwise known type
 # does not taint consistency.
@@ -894,46 +894,46 @@ end |> Core.Compiler.is_foldable_nothrow
     x::T
     ImmutRef(x) = $(Expr(:new, :(ImmutRef{typeof(x)}), :x))
 end
-@test Core.Compiler.is_foldable(Base.infer_effects(ImmutRef, Tuple{Any}))
+@test Compiler.is_foldable(Base.infer_effects(ImmutRef, Tuple{Any}))
 
-@test Core.Compiler.is_foldable_nothrow(Base.infer_effects(typejoin, ()))
+@test Compiler.is_foldable_nothrow(Base.infer_effects(typejoin, ()))
 
 # nothrow-ness of subtyping operations
 # https://github.com/JuliaLang/julia/pull/48566
-@test !Core.Compiler.is_nothrow(Base.infer_effects((A,B)->A<:B, (Any,Any)))
-@test !Core.Compiler.is_nothrow(Base.infer_effects((A,B)->A>:B, (Any,Any)))
+@test !Compiler.is_nothrow(Base.infer_effects((A,B)->A<:B, (Any,Any)))
+@test !Compiler.is_nothrow(Base.infer_effects((A,B)->A>:B, (Any,Any)))
 
 # GotoIfNot should properly mark itself as throwing when given a non-Bool
 # https://github.com/JuliaLang/julia/pull/48583
 gotoifnot_throw_check_48583(x) = x ? x : 0
-@test !Core.Compiler.is_nothrow(Base.infer_effects(gotoifnot_throw_check_48583, (Missing,)))
-@test !Core.Compiler.is_nothrow(Base.infer_effects(gotoifnot_throw_check_48583, (Any,)))
-@test Core.Compiler.is_nothrow(Base.infer_effects(gotoifnot_throw_check_48583, (Bool,)))
+@test !Compiler.is_nothrow(Base.infer_effects(gotoifnot_throw_check_48583, (Missing,)))
+@test !Compiler.is_nothrow(Base.infer_effects(gotoifnot_throw_check_48583, (Any,)))
+@test Compiler.is_nothrow(Base.infer_effects(gotoifnot_throw_check_48583, (Bool,)))
 
 # unknown :static_parameter should taint :nothrow
 # https://github.com/JuliaLang/julia/issues/46771
 unknown_sparam_throw(::Union{Nothing, Type{T}}) where T = (T; nothing)
 unknown_sparam_nothrow1(x::Ref{T}) where T = (T; nothing)
 unknown_sparam_nothrow2(x::Ref{Ref{T}}) where T = (T; nothing)
-@test Core.Compiler.is_nothrow(Base.infer_effects(unknown_sparam_throw, (Type{Int},)))
-@test Core.Compiler.is_nothrow(Base.infer_effects(unknown_sparam_throw, (Type{<:Integer},)))
-@test !Core.Compiler.is_nothrow(Base.infer_effects(unknown_sparam_throw, (Type,)))
-@test !Core.Compiler.is_nothrow(Base.infer_effects(unknown_sparam_throw, (Nothing,)))
-@test !Core.Compiler.is_nothrow(Base.infer_effects(unknown_sparam_throw, (Union{Type{Int},Nothing},)))
-@test !Core.Compiler.is_nothrow(Base.infer_effects(unknown_sparam_throw, (Any,)))
-@test Core.Compiler.is_nothrow(Base.infer_effects(unknown_sparam_nothrow1, (Ref,)))
-@test Core.Compiler.is_nothrow(Base.infer_effects(unknown_sparam_nothrow2, (Ref{Ref{T}} where T,)))
+@test Compiler.is_nothrow(Base.infer_effects(unknown_sparam_throw, (Type{Int},)))
+@test Compiler.is_nothrow(Base.infer_effects(unknown_sparam_throw, (Type{<:Integer},)))
+@test !Compiler.is_nothrow(Base.infer_effects(unknown_sparam_throw, (Type,)))
+@test !Compiler.is_nothrow(Base.infer_effects(unknown_sparam_throw, (Nothing,)))
+@test !Compiler.is_nothrow(Base.infer_effects(unknown_sparam_throw, (Union{Type{Int},Nothing},)))
+@test !Compiler.is_nothrow(Base.infer_effects(unknown_sparam_throw, (Any,)))
+@test Compiler.is_nothrow(Base.infer_effects(unknown_sparam_nothrow1, (Ref,)))
+@test Compiler.is_nothrow(Base.infer_effects(unknown_sparam_nothrow2, (Ref{Ref{T}} where T,)))
 
 # purely abstract recursion should not taint :terminates
 # https://github.com/JuliaLang/julia/issues/48983
 abstractly_recursive1() = abstractly_recursive2()
 abstractly_recursive2() = (Base._return_type(abstractly_recursive1, Tuple{}); 1)
 abstractly_recursive3() = abstractly_recursive2()
-@test_broken Core.Compiler.is_terminates(Base.infer_effects(abstractly_recursive3, ()))
+@test_broken Compiler.is_terminates(Base.infer_effects(abstractly_recursive3, ()))
 actually_recursive1(x) = actually_recursive2(x)
 actually_recursive2(x) = (x <= 0) ? 1 : actually_recursive1(x - 1)
 actually_recursive3(x) = actually_recursive2(x)
-@test !Core.Compiler.is_terminates(Base.infer_effects(actually_recursive3, (Int,)))
+@test !Compiler.is_terminates(Base.infer_effects(actually_recursive3, (Int,)))
 
 # `isdefined` effects
 struct MaybeSome{T}
@@ -949,30 +949,30 @@ const defined_some = MaybeSome{String}("julia")
 let effects = Base.infer_effects() do
         isdefined(undefined_ref, :x)
     end
-    @test !Core.Compiler.is_consistent(effects)
-    @test Core.Compiler.is_nothrow(effects)
+    @test !Compiler.is_consistent(effects)
+    @test Compiler.is_nothrow(effects)
 end
 let effects = Base.infer_effects() do
         isdefined(defined_ref, :x)
     end
-    @test !Core.Compiler.is_consistent(effects)
-    @test Core.Compiler.is_nothrow(effects)
+    @test !Compiler.is_consistent(effects)
+    @test Compiler.is_nothrow(effects)
 end
 let effects = Base.infer_effects() do
         isdefined(undefined_some, :value)
     end
-    @test Core.Compiler.is_consistent(effects)
-    @test Core.Compiler.is_nothrow(effects)
+    @test Compiler.is_consistent(effects)
+    @test Compiler.is_nothrow(effects)
 end
 let effects = Base.infer_effects() do
         isdefined(defined_some, :value)
     end
-    @test Core.Compiler.is_consistent(effects)
-    @test Core.Compiler.is_nothrow(effects)
+    @test Compiler.is_consistent(effects)
+    @test Compiler.is_nothrow(effects)
 end
 # high-level interface test
 isassigned_effects(s) = isassigned(Ref(s))
-@test Core.Compiler.is_consistent(Base.infer_effects(isassigned_effects, (Symbol,)))
+@test Compiler.is_consistent(Base.infer_effects(isassigned_effects, (Symbol,)))
 @test fully_eliminated(; retval=true) do
     isassigned_effects(:foo)
 end
@@ -987,16 +987,16 @@ function optimize_throw_block_for_effects(x)
     return a
 end
 let effects = Base.infer_effects(optimize_throw_block_for_effects, (Int,))
-    @test Core.Compiler.is_consistent_if_notreturned(effects)
-    @test Core.Compiler.is_effect_free(effects)
-    @test !Core.Compiler.is_nothrow(effects)
-    @test Core.Compiler.is_terminates(effects)
+    @test Compiler.is_consistent_if_notreturned(effects)
+    @test Compiler.is_effect_free(effects)
+    @test !Compiler.is_nothrow(effects)
+    @test Compiler.is_terminates(effects)
 end
 
 # :isdefined effects
 @test @eval Base.infer_effects() do
     @isdefined($(gensym("some_undef_symbol")))
-end |> !Core.Compiler.is_consistent
+end |> !Compiler.is_consistent
 
 # Effects of Base.hasfield (#50198)
 hf50198(s) = hasfield(typeof((;x=1, y=2)), s)
@@ -1012,13 +1012,13 @@ g50311(x) = Val{f50311((1.0, x), "foo")}()
 const my_defined_var = 42
 @test Base.infer_effects() do
     getglobal(@__MODULE__, :my_defined_var, :monotonic)
-end |> Core.Compiler.is_foldable_nothrow
+end |> Compiler.is_foldable_nothrow
 @test Base.infer_effects() do
     getglobal(@__MODULE__, :my_defined_var, :foo)
-end |> !Core.Compiler.is_nothrow
+end |> !Compiler.is_nothrow
 @test Base.infer_effects() do
     getglobal(@__MODULE__, :my_defined_var, :foo, nothing)
-end |> !Core.Compiler.is_nothrow
+end |> !Compiler.is_nothrow
 
 # irinterp should refine `:nothrow` information only if profitable
 Base.@assume_effects :nothrow function irinterp_nothrow_override(x, y)
@@ -1031,14 +1031,14 @@ end
 @test Base.infer_effects((Float64,)) do y
     isinf(y) && return zero(y)
     irinterp_nothrow_override(true, y)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 
 # Effects for :compilerbarrier
 f1_compilerbarrier(b) = Base.compilerbarrier(:type, b)
 f2_compilerbarrier(b) = Base.compilerbarrier(:conditional, b)
 
-@test !Core.Compiler.is_consistent(Base.infer_effects(f1_compilerbarrier, (Bool,)))
-@test Core.Compiler.is_consistent(Base.infer_effects(f2_compilerbarrier, (Bool,)))
+@test !Compiler.is_consistent(Base.infer_effects(f1_compilerbarrier, (Bool,)))
+@test Compiler.is_consistent(Base.infer_effects(f2_compilerbarrier, (Bool,)))
 
 # Optimizer-refined effects
 function f1_optrefine(b)
@@ -1047,7 +1047,7 @@ function f1_optrefine(b)
     end
     return b
 end
-@test !Core.Compiler.is_consistent(Base.infer_effects(f1_optrefine, (Bool,)))
+@test !Compiler.is_consistent(Base.infer_effects(f1_optrefine, (Bool,)))
 
 function f2_optrefine()
     if Ref(false)[]
@@ -1055,15 +1055,15 @@ function f2_optrefine()
     end
     return true
 end
-@test !Core.Compiler.is_nothrow(Base.infer_effects(f2_optrefine; optimize=false))
-@test Core.Compiler.is_nothrow(Base.infer_effects(f2_optrefine))
+@test !Compiler.is_nothrow(Base.infer_effects(f2_optrefine; optimize=false))
+@test Compiler.is_nothrow(Base.infer_effects(f2_optrefine))
 
 function f3_optrefine(x)
     @fastmath sqrt(x)
     return x
 end
-@test !Core.Compiler.is_consistent(Base.infer_effects(f3_optrefine; optimize=false))
-@test Core.Compiler.is_consistent(Base.infer_effects(f3_optrefine, (Float64,)))
+@test !Compiler.is_consistent(Base.infer_effects(f3_optrefine; optimize=false))
+@test Compiler.is_consistent(Base.infer_effects(f3_optrefine, (Float64,)))
 
 # Check that :consistent is properly modeled for throwing statements
 const GLOBAL_MUTABLE_SWITCH = Ref{Bool}(false)
@@ -1076,7 +1076,7 @@ GLOBAL_MUTABLE_SWITCH[] = true
 # Check that flipping the switch doesn't accidentally change the return type
 @test (Base.return_types(check_switch2) |> only) === Nothing
 
-@test !Core.Compiler.is_consistent(Base.infer_effects(check_switch, (Base.RefValue{Bool},)))
+@test !Compiler.is_consistent(Base.infer_effects(check_switch, (Base.RefValue{Bool},)))
 
 # post-opt IPO analysis refinement of `:effect_free`-ness
 function post_opt_refine_effect_free(y, c=true)
@@ -1089,10 +1089,10 @@ function post_opt_refine_effect_free(y, c=true)
     end
     return r
 end
-@test Core.Compiler.is_effect_free(Base.infer_effects(post_opt_refine_effect_free, (Base.RefValue{Any},)))
+@test Compiler.is_effect_free(Base.infer_effects(post_opt_refine_effect_free, (Base.RefValue{Any},)))
 @test Base.infer_effects((Base.RefValue{Any},)) do y
     post_opt_refine_effect_free(y, true)
-end |> Core.Compiler.is_effect_free
+end |> Compiler.is_effect_free
 
 # Check EA-based refinement of :effect_free
 Base.@assume_effects :nothrow @noinline _noinline_set!(x) = (x[] = 1; nothing)
@@ -1132,22 +1132,22 @@ function set_arg_arr!(x)
 end
 
 # This is inferable by type analysis only since the arguments have no mutable memory
-@test Core.Compiler.is_effect_free_if_inaccessiblememonly(Base.infer_effects(_noinline_set!, (Base.RefValue{Int},)))
-@test Core.Compiler.is_effect_free_if_inaccessiblememonly(Base.infer_effects(_noinline_set!, (Vector{Int},)))
+@test Compiler.is_effect_free_if_inaccessiblememonly(Base.infer_effects(_noinline_set!, (Base.RefValue{Int},)))
+@test Compiler.is_effect_free_if_inaccessiblememonly(Base.infer_effects(_noinline_set!, (Vector{Int},)))
 for func in (set_ref_with_unused_arg_1, set_ref_with_unused_arg_2,
              set_arr_with_unused_arg_1, set_arr_with_unused_arg_2)
     effects = Base.infer_effects(func, (Nothing,))
-    @test Core.Compiler.is_inaccessiblememonly(effects)
-    @test Core.Compiler.is_effect_free(effects)
+    @test Compiler.is_inaccessiblememonly(effects)
+    @test Compiler.is_effect_free(effects)
 end
 
 # These need EA
-@test Core.Compiler.is_effect_free(Base.infer_effects(set_ref_with_unused_arg_1, (Base.RefValue{Int},)))
-@test Core.Compiler.is_effect_free(Base.infer_effects(set_ref_with_unused_arg_2, (Base.RefValue{Int},)))
-@test Core.Compiler.is_effect_free_if_inaccessiblememonly(Base.infer_effects(set_arg_ref!, (Base.RefValue{Int},)))
-@test_broken Core.Compiler.is_effect_free(Base.infer_effects(set_arr_with_unused_arg_1, (Vector{Int},)))
-@test_broken Core.Compiler.is_effect_free(Base.infer_effects(set_arr_with_unused_arg_2, (Vector{Int},)))
-@test_broken Core.Compiler.is_effect_free_if_inaccessiblememonly(Base.infer_effects(set_arg_arr!, (Vector{Int},)))
+@test Compiler.is_effect_free(Base.infer_effects(set_ref_with_unused_arg_1, (Base.RefValue{Int},)))
+@test Compiler.is_effect_free(Base.infer_effects(set_ref_with_unused_arg_2, (Base.RefValue{Int},)))
+@test Compiler.is_effect_free_if_inaccessiblememonly(Base.infer_effects(set_arg_ref!, (Base.RefValue{Int},)))
+@test_broken Compiler.is_effect_free(Base.infer_effects(set_arr_with_unused_arg_1, (Vector{Int},)))
+@test_broken Compiler.is_effect_free(Base.infer_effects(set_arr_with_unused_arg_2, (Vector{Int},)))
+@test_broken Compiler.is_effect_free_if_inaccessiblememonly(Base.infer_effects(set_arg_arr!, (Vector{Int},)))
 
 # EA-based refinement of :effect_free
 function f_EA_refine(ax, b)
@@ -1155,7 +1155,7 @@ function f_EA_refine(ax, b)
     @noinline bx[] = b
     return ax[] + b
 end
-@test Core.Compiler.is_effect_free(Base.infer_effects(f_EA_refine, (Base.RefValue{Int},Int)))
+@test Compiler.is_effect_free(Base.infer_effects(f_EA_refine, (Base.RefValue{Int},Int)))
 
 function issue51837(; openquotechar::Char, newlinechar::Char)
     ncodeunits(openquotechar) == 1 || throw(ArgumentError("`openquotechar` must be a single-byte character"))
@@ -1166,99 +1166,99 @@ function issue51837(; openquotechar::Char, newlinechar::Char)
 end
 @test Base.infer_effects() do openquotechar::Char, newlinechar::Char
     issue51837(; openquotechar, newlinechar)
-end |> !Core.Compiler.is_nothrow
+end |> !Compiler.is_nothrow
 @test_throws ArgumentError issue51837(; openquotechar='α', newlinechar='\n')
 
 # idempotency of effects derived by post-opt analysis
 callgetfield(x, f) = getfield(x, f, Base.@_boundscheck)
-@test Base.infer_effects(callgetfield, (Some{Any},Symbol)).noub === Core.Compiler.NOUB_IF_NOINBOUNDS
+@test Base.infer_effects(callgetfield, (Some{Any},Symbol)).noub === Compiler.NOUB_IF_NOINBOUNDS
 callgetfield1(x, f) = getfield(x, f, Base.@_boundscheck)
 callgetfield_simple(x, f) = callgetfield1(x, f)
 @test Base.infer_effects(callgetfield_simple, (Some{Any},Symbol)).noub ===
       Base.infer_effects(callgetfield_simple, (Some{Any},Symbol)).noub ===
-      Core.Compiler.ALWAYS_TRUE
+      Compiler.ALWAYS_TRUE
 callgetfield2(x, f) = getfield(x, f, Base.@_boundscheck)
 callgetfield_inbounds(x, f) = @inbounds callgetfield2(x, f)
 @test Base.infer_effects(callgetfield_inbounds, (Some{Any},Symbol)).noub ===
       Base.infer_effects(callgetfield_inbounds, (Some{Any},Symbol)).noub ===
-      Core.Compiler.ALWAYS_FALSE
+      Compiler.ALWAYS_FALSE
 
 # noub modeling for memory ops
 let (memoryrefnew, memoryrefget, memoryref_isassigned, memoryrefset!) =
         (Core.memoryrefnew, Core.memoryrefget, Core.memoryref_isassigned, Core.memoryrefset!)
     function builtin_effects(@nospecialize xs...)
-        interp = Core.Compiler.NativeInterpreter()
-        𝕃 = Core.Compiler.typeinf_lattice(interp)
-        rt = Core.Compiler.builtin_tfunction(interp, xs..., nothing)
-        return Core.Compiler.builtin_effects(𝕃, xs..., rt)
+        interp = Compiler.NativeInterpreter()
+        𝕃 = Compiler.typeinf_lattice(interp)
+        rt = Compiler.builtin_tfunction(interp, xs..., nothing)
+        return Compiler.builtin_effects(𝕃, xs..., rt)
     end
-    @test Core.Compiler.is_noub(builtin_effects(memoryrefnew, Any[Memory,]))
-    @test Core.Compiler.is_noub(builtin_effects(memoryrefnew, Any[MemoryRef,Int]))
-    @test Core.Compiler.is_noub(builtin_effects(memoryrefnew, Any[MemoryRef,Int,Core.Const(true)]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryrefnew, Any[MemoryRef,Int,Core.Const(false)]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryrefnew, Any[MemoryRef,Int,Bool]))
-    @test Core.Compiler.is_noub(builtin_effects(memoryrefnew, Any[MemoryRef,Int,Int]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryrefnew, Any[MemoryRef,Int,Vararg{Bool}]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryrefnew, Any[MemoryRef,Vararg{Any}]))
-    @test Core.Compiler.is_noub(builtin_effects(memoryrefget, Any[MemoryRef,Symbol,Core.Const(true)]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryrefget, Any[MemoryRef,Symbol,Core.Const(false)]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryrefget, Any[MemoryRef,Symbol,Bool]))
-    @test Core.Compiler.is_noub(builtin_effects(memoryrefget, Any[MemoryRef,Symbol,Int]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryrefget, Any[MemoryRef,Symbol,Vararg{Bool}]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryrefget, Any[MemoryRef,Vararg{Any}]))
-    @test Core.Compiler.is_noub(builtin_effects(memoryref_isassigned, Any[MemoryRef,Symbol,Core.Const(true)]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryref_isassigned, Any[MemoryRef,Symbol,Core.Const(false)]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryref_isassigned, Any[MemoryRef,Symbol,Bool]))
-    @test Core.Compiler.is_noub(builtin_effects(memoryref_isassigned, Any[MemoryRef,Symbol,Int]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryref_isassigned, Any[MemoryRef,Symbol,Vararg{Bool}]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryref_isassigned, Any[MemoryRef,Vararg{Any}]))
-    @test Core.Compiler.is_noub(builtin_effects(memoryrefset!, Any[MemoryRef,Any,Symbol,Core.Const(true)]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryrefset!, Any[MemoryRef,Any,Symbol,Core.Const(false)]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryrefset!, Any[MemoryRef,Any,Symbol,Bool]))
-    @test Core.Compiler.is_noub(builtin_effects(memoryrefset!, Any[MemoryRef,Any,Symbol,Int]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryrefset!, Any[MemoryRef,Any,Symbol,Vararg{Bool}]))
-    @test !Core.Compiler.is_noub(builtin_effects(memoryrefset!, Any[MemoryRef,Vararg{Any}]))
+    @test Compiler.is_noub(builtin_effects(memoryrefnew, Any[Memory,]))
+    @test Compiler.is_noub(builtin_effects(memoryrefnew, Any[MemoryRef,Int]))
+    @test Compiler.is_noub(builtin_effects(memoryrefnew, Any[MemoryRef,Int,Core.Const(true)]))
+    @test !Compiler.is_noub(builtin_effects(memoryrefnew, Any[MemoryRef,Int,Core.Const(false)]))
+    @test !Compiler.is_noub(builtin_effects(memoryrefnew, Any[MemoryRef,Int,Bool]))
+    @test Compiler.is_noub(builtin_effects(memoryrefnew, Any[MemoryRef,Int,Int]))
+    @test !Compiler.is_noub(builtin_effects(memoryrefnew, Any[MemoryRef,Int,Vararg{Bool}]))
+    @test !Compiler.is_noub(builtin_effects(memoryrefnew, Any[MemoryRef,Vararg{Any}]))
+    @test Compiler.is_noub(builtin_effects(memoryrefget, Any[MemoryRef,Symbol,Core.Const(true)]))
+    @test !Compiler.is_noub(builtin_effects(memoryrefget, Any[MemoryRef,Symbol,Core.Const(false)]))
+    @test !Compiler.is_noub(builtin_effects(memoryrefget, Any[MemoryRef,Symbol,Bool]))
+    @test Compiler.is_noub(builtin_effects(memoryrefget, Any[MemoryRef,Symbol,Int]))
+    @test !Compiler.is_noub(builtin_effects(memoryrefget, Any[MemoryRef,Symbol,Vararg{Bool}]))
+    @test !Compiler.is_noub(builtin_effects(memoryrefget, Any[MemoryRef,Vararg{Any}]))
+    @test Compiler.is_noub(builtin_effects(memoryref_isassigned, Any[MemoryRef,Symbol,Core.Const(true)]))
+    @test !Compiler.is_noub(builtin_effects(memoryref_isassigned, Any[MemoryRef,Symbol,Core.Const(false)]))
+    @test !Compiler.is_noub(builtin_effects(memoryref_isassigned, Any[MemoryRef,Symbol,Bool]))
+    @test Compiler.is_noub(builtin_effects(memoryref_isassigned, Any[MemoryRef,Symbol,Int]))
+    @test !Compiler.is_noub(builtin_effects(memoryref_isassigned, Any[MemoryRef,Symbol,Vararg{Bool}]))
+    @test !Compiler.is_noub(builtin_effects(memoryref_isassigned, Any[MemoryRef,Vararg{Any}]))
+    @test Compiler.is_noub(builtin_effects(memoryrefset!, Any[MemoryRef,Any,Symbol,Core.Const(true)]))
+    @test !Compiler.is_noub(builtin_effects(memoryrefset!, Any[MemoryRef,Any,Symbol,Core.Const(false)]))
+    @test !Compiler.is_noub(builtin_effects(memoryrefset!, Any[MemoryRef,Any,Symbol,Bool]))
+    @test Compiler.is_noub(builtin_effects(memoryrefset!, Any[MemoryRef,Any,Symbol,Int]))
+    @test !Compiler.is_noub(builtin_effects(memoryrefset!, Any[MemoryRef,Any,Symbol,Vararg{Bool}]))
+    @test !Compiler.is_noub(builtin_effects(memoryrefset!, Any[MemoryRef,Vararg{Any}]))
     # `:boundscheck` taint should be refined by post-opt analysis
     @test Base.infer_effects() do xs::Vector{Any}, i::Int
         memoryrefget(memoryrefnew(getfield(xs, :ref), i, Base.@_boundscheck), :not_atomic, Base.@_boundscheck)
-    end |> Core.Compiler.is_noub_if_noinbounds
+    end |> Compiler.is_noub_if_noinbounds
 end
 
 # high level tests
-@test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(getindex, (Vector{Int},Int)))
-@test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(getindex, (Vector{Any},Int)))
-@test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(setindex!, (Vector{Int},Int,Int)))
-@test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(Base._setindex!, (Vector{Any},Any,Int)))
-@test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(isassigned, (Vector{Int},Int)))
-@test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(isassigned, (Vector{Any},Int)))
+@test Compiler.is_noub_if_noinbounds(Base.infer_effects(getindex, (Vector{Int},Int)))
+@test Compiler.is_noub_if_noinbounds(Base.infer_effects(getindex, (Vector{Any},Int)))
+@test Compiler.is_noub_if_noinbounds(Base.infer_effects(setindex!, (Vector{Int},Int,Int)))
+@test Compiler.is_noub_if_noinbounds(Base.infer_effects(Base._setindex!, (Vector{Any},Any,Int)))
+@test Compiler.is_noub_if_noinbounds(Base.infer_effects(isassigned, (Vector{Int},Int)))
+@test Compiler.is_noub_if_noinbounds(Base.infer_effects(isassigned, (Vector{Any},Int)))
 @test Base.infer_effects((Vector{Int},Int)) do xs, i
     xs[i]
-end |> Core.Compiler.is_noub
+end |> Compiler.is_noub
 @test Base.infer_effects((Vector{Any},Int)) do xs, i
     xs[i]
-end |> Core.Compiler.is_noub
+end |> Compiler.is_noub
 @test Base.infer_effects((Vector{Int},Int,Int)) do xs, x, i
     xs[i] = x
-end |> Core.Compiler.is_noub
+end |> Compiler.is_noub
 @test Base.infer_effects((Vector{Any},Any,Int)) do xs, x, i
     xs[i] = x
-end |> Core.Compiler.is_noub
+end |> Compiler.is_noub
 @test Base.infer_effects((Vector{Int},Int)) do xs, i
     @inbounds xs[i]
-end |> !Core.Compiler.is_noub
+end |> !Compiler.is_noub
 @test Base.infer_effects((Vector{Any},Int)) do xs, i
     @inbounds xs[i]
-end |> !Core.Compiler.is_noub
+end |> !Compiler.is_noub
 Base.@propagate_inbounds getindex_propagate(xs, i) = xs[i]
 getindex_dont_propagate(xs, i) = xs[i]
-@test Core.Compiler.is_noub_if_noinbounds(Base.infer_effects(getindex_propagate, (Vector{Any},Int)))
-@test Core.Compiler.is_noub(Base.infer_effects(getindex_dont_propagate, (Vector{Any},Int)))
+@test Compiler.is_noub_if_noinbounds(Base.infer_effects(getindex_propagate, (Vector{Any},Int)))
+@test Compiler.is_noub(Base.infer_effects(getindex_dont_propagate, (Vector{Any},Int)))
 @test Base.infer_effects((Vector{Any},Int)) do xs, i
     @inbounds getindex_propagate(xs, i)
-end |> !Core.Compiler.is_noub
+end |> !Compiler.is_noub
 @test Base.infer_effects((Vector{Any},Int)) do xs, i
     @inbounds getindex_dont_propagate(xs, i)
-end |> Core.Compiler.is_noub
+end |> Compiler.is_noub
 
 # refine `:nothrow` when `exct` is known to be `Bottom`
 @test Base.infer_exception_type(getindex, (Vector{Int},Int)) == BoundsError
@@ -1270,14 +1270,14 @@ function getindex_nothrow(xs::Vector{Int}, i::Int)
         rethrow(err)
     end
 end
-@test Core.Compiler.is_nothrow(Base.infer_effects(getindex_nothrow, (Vector{Int}, Int)))
+@test Compiler.is_nothrow(Base.infer_effects(getindex_nothrow, (Vector{Int}, Int)))
 
 # callsite `@assume_effects` annotation
 let ast = code_lowered((Int,)) do x
         Base.@assume_effects :total identity(x)
     end |> only
     ssaflag = ast.ssaflags[findfirst(!iszero, ast.ssaflags)::Int]
-    override = Core.Compiler.decode_statement_effects_override(ssaflag)
+    override = Compiler.decode_statement_effects_override(ssaflag)
     # if this gets broken, check if this is synced with expr.jl
     @test override.consistent && override.effect_free && override.nothrow &&
           override.terminates_globally && !override.terminates_locally &&
@@ -1287,7 +1287,7 @@ end
 @test Base.infer_effects((Float64,)) do x
     isinf(x) && return 0.0
     return Base.@assume_effects :nothrow sin(x)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 let effects = Base.infer_effects((Vector{Float64},)) do xs
         isempty(xs) && return 0.0
         Base.@assume_effects :nothrow begin
@@ -1297,8 +1297,8 @@ let effects = Base.infer_effects((Vector{Float64},)) do xs
         end
     end
     # all nested overrides should be applied
-    @test Core.Compiler.is_nothrow(effects)
-    @test Core.Compiler.is_noub(effects)
+    @test Compiler.is_nothrow(effects)
+    @test Compiler.is_noub(effects)
 end
 @test Base.infer_effects((Int,)) do x
     res = 1
@@ -1308,20 +1308,20 @@ end
         x -= 1
     end
     return res
-end |> Core.Compiler.is_terminates
+end |> Compiler.is_terminates
 
 # https://github.com/JuliaLang/julia/issues/52531
 const a52531 = Core.Ref(1)
 @eval getref52531() = $(QuoteNode(a52531)).x
-@test !Core.Compiler.is_consistent(Base.infer_effects(getref52531))
+@test !Compiler.is_consistent(Base.infer_effects(getref52531))
 let
     global set_a52531!, get_a52531
     _a::Int             = -1
     set_a52531!(a::Int) = (_a = a; return get_a52531())
     get_a52531()        = _a
 end
-@test !Core.Compiler.is_consistent(Base.infer_effects(set_a52531!, (Int,)))
-@test !Core.Compiler.is_consistent(Base.infer_effects(get_a52531, ()))
+@test !Compiler.is_consistent(Base.infer_effects(set_a52531!, (Int,)))
+@test !Compiler.is_consistent(Base.infer_effects(get_a52531, ()))
 @test get_a52531() == -1
 @test set_a52531!(1) == 1
 @test get_a52531() == 1
@@ -1333,35 +1333,35 @@ let
     is_initialized52531()             = _is_initialized
 end
 top_52531(_) = (set_initialized52531!(true); nothing)
-@test !Core.Compiler.is_consistent(Base.infer_effects(is_initialized52531))
-@test !Core.Compiler.is_removable_if_unused(Base.infer_effects(set_initialized52531!, (Bool,)))
+@test !Compiler.is_consistent(Base.infer_effects(is_initialized52531))
+@test !Compiler.is_removable_if_unused(Base.infer_effects(set_initialized52531!, (Bool,)))
 @test !is_initialized52531()
 top_52531(0)
 @test is_initialized52531()
 
 const ref52843 = Ref{Int}()
 @eval func52843() = ($ref52843[] = 1; nothing)
-@test !Core.Compiler.is_foldable(Base.infer_effects(func52843))
+@test !Compiler.is_foldable(Base.infer_effects(func52843))
 let; Base.Experimental.@force_compile; func52843(); end
 @test ref52843[] == 1
 
-@test Core.Compiler.is_inaccessiblememonly(Base.infer_effects(identity∘identity, Tuple{Any}))
-@test Core.Compiler.is_inaccessiblememonly(Base.infer_effects(()->Vararg, Tuple{}))
+@test Compiler.is_inaccessiblememonly(Base.infer_effects(identity∘identity, Tuple{Any}))
+@test Compiler.is_inaccessiblememonly(Base.infer_effects(()->Vararg, Tuple{}))
 
 # pointerref nothrow for invalid pointer
-@test !Core.Compiler.intrinsic_nothrow(Core.Intrinsics.pointerref, Any[Type{Ptr{Vector{Int64}}}, Int, Int])
-@test !Core.Compiler.intrinsic_nothrow(Core.Intrinsics.pointerref, Any[Type{Ptr{T}} where T, Int, Int])
+@test !Compiler.intrinsic_nothrow(Core.Intrinsics.pointerref, Any[Type{Ptr{Vector{Int64}}}, Int, Int])
+@test !Compiler.intrinsic_nothrow(Core.Intrinsics.pointerref, Any[Type{Ptr{T}} where T, Int, Int])
 
 # post-opt :consistent-cy analysis correctness
 # https://github.com/JuliaLang/julia/issues/53508
-@test !Core.Compiler.is_consistent(Base.infer_effects(getindex, (UnitRange{Int},Int)))
-@test !Core.Compiler.is_consistent(Base.infer_effects(getindex, (Base.OneTo{Int},Int)))
+@test !Compiler.is_consistent(Base.infer_effects(getindex, (UnitRange{Int},Int)))
+@test !Compiler.is_consistent(Base.infer_effects(getindex, (Base.OneTo{Int},Int)))
 
 @noinline f53613() = @assert isdefined(@__MODULE__, :v53613)
 g53613() = f53613()
 h53613() = g53613()
-@test !Core.Compiler.is_consistent(Base.infer_effects(f53613))
-@test !Core.Compiler.is_consistent(Base.infer_effects(g53613))
+@test !Compiler.is_consistent(Base.infer_effects(f53613))
+@test !Compiler.is_consistent(Base.infer_effects(g53613))
 @test_throws AssertionError f53613()
 @test_throws AssertionError g53613()
 @test_throws AssertionError h53613()
@@ -1373,12 +1373,12 @@ global v53613 = nothing
 # tuple/svec effects
 @test Base.infer_effects((Vector{Any},)) do xs
     Core.tuple(xs...)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((Vector{Any},)) do xs
     Core.svec(xs...)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 
 # effects for unknown `:foreigncall`s
 @test Base.infer_effects() do
     @ccall unsafecall()::Cvoid
-end == Core.Compiler.EFFECTS_UNKNOWN
+end == Compiler.EFFECTS_UNKNOWN

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -5013,13 +5013,15 @@ g() = empty_nt_values(Base.inferencebarrier(Tuple{}))
 # is to test the case where inference limited a recursion, but then a forced constprop nevertheless managed
 # to terminate the call.
 @newinterp RecurseInterpreter
-function Compiler.const_prop_rettype_heuristic(interp::RecurseInterpreter, result::Compiler.MethodCallResult,
-                                            si::Compiler.StmtInfo, sv::Compiler.AbsIntState, force::Bool)
+function Compiler.const_prop_rettype_heuristic(
+    interp::RecurseInterpreter, result::Compiler.MethodCallResult,
+    si::Compiler.StmtInfo, sv::Compiler.AbsIntState, force::Bool)
     if result.rt isa Compiler.LimitedAccuracy
         return force # allow forced constprop to recurse into unresolved cycles
     end
-    return @invoke Compiler.const_prop_rettype_heuristic(interp::Compiler.AbstractInterpreter, result::Compiler.MethodCallResult,
-                                                    si::Compiler.StmtInfo, sv::Compiler.AbsIntState, force::Bool)
+    return @invoke Compiler.const_prop_rettype_heuristic(
+        interp::Compiler.AbstractInterpreter, result::Compiler.MethodCallResult,
+        si::Compiler.StmtInfo, sv::Compiler.AbsIntState, force::Bool)
 end
 Base.@constprop :aggressive type_level_recurse1(x...) = x[1] == 2 ? 1 : (length(x) > 100 ? x : type_level_recurse2(x[1] + 1, x..., x...))
 Base.@constprop :aggressive type_level_recurse2(x...) = type_level_recurse1(x...)
@@ -6091,9 +6093,7 @@ end === Union{}
 
 global swapglobal!_must_throw
 @newinterp SwapGlobalInterp
-let CC = Base.Compiler
-    CC.InferenceParams(::SwapGlobalInterp) = CC.InferenceParams(; assume_bindings_static=true)
-end
+Compiler.InferenceParams(::SwapGlobalInterp) = Compiler.InferenceParams(; assume_bindings_static=true)
 function func_swapglobal!_must_throw(x)
     swapglobal!(@__MODULE__, :swapglobal!_must_throw, x)
 end

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -1,13 +1,13 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-# tests for Core.Compiler correctness and precision
-import Core.Compiler: Const, Conditional, ⊑, ReturnNode, GotoIfNot
-isdispatchelem(@nospecialize x) = !isa(x, Type) || Core.Compiler.isdispatchelem(x)
+include("irutils.jl")
+
+# tests for Compiler correctness and precision
+import .Compiler: Const, Conditional, ⊑, ReturnNode, GotoIfNot
+isdispatchelem(@nospecialize x) = !isa(x, Type) || Compiler.isdispatchelem(x)
 
 using Random, Core.IR
 using InteractiveUtils
-
-include("irutils.jl")
 
 f39082(x::Vararg{T}) where {T <: Number} = x[1]
 let ast = only(code_typed(f39082, Tuple{Vararg{Rational}}))[1]
@@ -18,92 +18,92 @@ let ast = only(code_typed(f39082, Tuple{Rational, Vararg{Rational}}))[1]
 end
 
 # demonstrate some of the type-size limits
-@test Core.Compiler.limit_type_size(Ref{Complex{T} where T}, Ref, Ref, 100, 0) == Ref
-@test Core.Compiler.limit_type_size(Ref{Complex{T} where T}, Ref{Complex{T} where T}, Ref, 100, 0) == Ref{Complex{T} where T}
+@test Compiler.limit_type_size(Ref{Complex{T} where T}, Ref, Ref, 100, 0) == Ref
+@test Compiler.limit_type_size(Ref{Complex{T} where T}, Ref{Complex{T} where T}, Ref, 100, 0) == Ref{Complex{T} where T}
 
 let comparison = Tuple{X, X} where X<:Tuple
     sig = Tuple{X, X} where X<:comparison
     ref = Tuple{X, X} where X
-    @test Core.Compiler.limit_type_size(sig, comparison, comparison, 100, 100) == Tuple{Tuple, Tuple}
-    @test Core.Compiler.limit_type_size(sig, ref, comparison, 100, 100) == Tuple{Any, Any}
-    @test Core.Compiler.limit_type_size(Tuple{sig}, Tuple{ref}, comparison, 100, 100) == Tuple{Tuple{Any, Any}}
-    @test Core.Compiler.limit_type_size(ref, sig, Union{}, 100, 100) == ref
+    @test Compiler.limit_type_size(sig, comparison, comparison, 100, 100) == Tuple{Tuple, Tuple}
+    @test Compiler.limit_type_size(sig, ref, comparison, 100, 100) == Tuple{Any, Any}
+    @test Compiler.limit_type_size(Tuple{sig}, Tuple{ref}, comparison, 100, 100) == Tuple{Tuple{Any, Any}}
+    @test Compiler.limit_type_size(ref, sig, Union{}, 100, 100) == ref
 end
 
 let ref = Tuple{T, Val{T}} where T<:Val
     sig = Tuple{T, Val{T}} where T<:(Val{T} where T<:Val)
-    @test Core.Compiler.limit_type_size(sig, ref, Union{}, 100, 100) == Tuple{Val, Val}
-    @test Core.Compiler.limit_type_size(ref, sig, Union{}, 100, 100) == ref
+    @test Compiler.limit_type_size(sig, ref, Union{}, 100, 100) == Tuple{Val, Val}
+    @test Compiler.limit_type_size(ref, sig, Union{}, 100, 100) == ref
 end
 let ref = Tuple{T, Val{T}} where T<:(Val{T} where T<:(Val{T} where T<:(Val{T} where T<:Val)))
     sig = Tuple{T, Val{T}} where T<:(Val{T} where T<:(Val{T} where T<:(Val{T} where T<:(Val{T} where T<:Val))))
-    @test Core.Compiler.limit_type_size(sig, ref, Union{}, 100, 100) == Tuple{Val, Val}
-    @test Core.Compiler.limit_type_size(ref, sig, Union{}, 100, 100) == ref
+    @test Compiler.limit_type_size(sig, ref, Union{}, 100, 100) == Tuple{Val, Val}
+    @test Compiler.limit_type_size(ref, sig, Union{}, 100, 100) == ref
 end
 
 let t = Tuple{Ref{T},T,T} where T, c = Tuple{Ref, T, T} where T # #36407
-    @test t <: Core.Compiler.limit_type_size(t, c, Union{}, 1, 100)
+    @test t <: Compiler.limit_type_size(t, c, Union{}, 1, 100)
 end
 
 # obtain Vararg with 2 undefined fields
 let va = ccall(:jl_type_intersection_with_env, Any, (Any, Any), Tuple{Tuple}, Tuple{Tuple{Vararg{Any, N}}} where N)[2][1]
-    @test Core.Compiler.__limit_type_size(Tuple, va, Core.svec(va, Union{}), 2, 2) === Tuple
+    @test Compiler.__limit_type_size(Tuple, va, Core.svec(va, Union{}), 2, 2) === Tuple
 end
 
 mutable struct TS14009{T}; end
 let A = TS14009{TS14009{TS14009{TS14009{TS14009{T}}}}} where {T},
     B = Base.rewrap_unionall(TS14009{Base.unwrap_unionall(A)}, A)
 
-    @test Core.Compiler.Compiler.limit_type_size(B, A, A, 2, 2) == TS14009
+    @test Compiler.Compiler.limit_type_size(B, A, A, 2, 2) == TS14009
 end
 
 # issue #42835
-@test !Core.Compiler.type_more_complex(Int, Any, Core.svec(), 1, 1, 1)
-@test !Core.Compiler.type_more_complex(Int, Type{Int}, Core.svec(), 1, 1, 1)
-@test !Core.Compiler.type_more_complex(Type{Int}, Any, Core.svec(), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{Type{Int}}, Any, Core.svec(), 1, 1, 1)
-@test  Core.Compiler.limit_type_size(Type{Int}, Any, Union{}, 0, 0) == Type{Int}
-@test  Core.Compiler.type_more_complex(Type{Type{Int}}, Type{Int}, Core.svec(Type{Int}), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{Type{Int}}, Int, Core.svec(Type{Int}), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{Type{Int}}, Any, Core.svec(), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{Type{Type{Int}}}, Type{Type{Int}}, Core.svec(Type{Type{Int}}), 1, 1, 1)
+@test !Compiler.type_more_complex(Int, Any, Core.svec(), 1, 1, 1)
+@test !Compiler.type_more_complex(Int, Type{Int}, Core.svec(), 1, 1, 1)
+@test !Compiler.type_more_complex(Type{Int}, Any, Core.svec(), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{Type{Int}}, Any, Core.svec(), 1, 1, 1)
+@test  Compiler.limit_type_size(Type{Int}, Any, Union{}, 0, 0) == Type{Int}
+@test  Compiler.type_more_complex(Type{Type{Int}}, Type{Int}, Core.svec(Type{Int}), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{Type{Int}}, Int, Core.svec(Type{Int}), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{Type{Int}}, Any, Core.svec(), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{Type{Type{Int}}}, Type{Type{Int}}, Core.svec(Type{Type{Int}}), 1, 1, 1)
 
-@test  Core.Compiler.type_more_complex(ComplexF32, Any, Core.svec(), 1, 1, 1)
-@test !Core.Compiler.type_more_complex(ComplexF32, Any, Core.svec(Type{ComplexF32}), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(ComplexF32, Type{ComplexF32}, Core.svec(), 1, 1, 1)
-@test !Core.Compiler.type_more_complex(Type{ComplexF32}, Any, Core.svec(Type{Type{ComplexF32}}), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{ComplexF32}, Type{Type{ComplexF32}}, Core.svec(), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{ComplexF32}, ComplexF32, Core.svec(), 1, 1, 1)
-@test  Core.Compiler.limit_type_size(Type{ComplexF32}, ComplexF32, Union{}, 1, 1) == Type{<:Complex}
-@test  Core.Compiler.type_more_complex(Type{ComplexF32}, Any, Core.svec(), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{Type{ComplexF32}}, Type{ComplexF32}, Core.svec(Type{ComplexF32}), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{Type{ComplexF32}}, ComplexF32, Core.svec(ComplexF32), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{Type{Type{ComplexF32}}}, Type{Type{ComplexF32}}, Core.svec(Type{ComplexF32}), 1, 1, 1)
+@test  Compiler.type_more_complex(ComplexF32, Any, Core.svec(), 1, 1, 1)
+@test !Compiler.type_more_complex(ComplexF32, Any, Core.svec(Type{ComplexF32}), 1, 1, 1)
+@test  Compiler.type_more_complex(ComplexF32, Type{ComplexF32}, Core.svec(), 1, 1, 1)
+@test !Compiler.type_more_complex(Type{ComplexF32}, Any, Core.svec(Type{Type{ComplexF32}}), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{ComplexF32}, Type{Type{ComplexF32}}, Core.svec(), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{ComplexF32}, ComplexF32, Core.svec(), 1, 1, 1)
+@test  Compiler.limit_type_size(Type{ComplexF32}, ComplexF32, Union{}, 1, 1) == Type{<:Complex}
+@test  Compiler.type_more_complex(Type{ComplexF32}, Any, Core.svec(), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{Type{ComplexF32}}, Type{ComplexF32}, Core.svec(Type{ComplexF32}), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{Type{ComplexF32}}, ComplexF32, Core.svec(ComplexF32), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{Type{Type{ComplexF32}}}, Type{Type{ComplexF32}}, Core.svec(Type{ComplexF32}), 1, 1, 1)
 
 # n.b. Type{Type{Union{}} === Type{Core.TypeofBottom}
-@test !Core.Compiler.type_more_complex(Type{Union{}}, Any, Core.svec(), 1, 1, 1)
-@test !Core.Compiler.type_more_complex(Type{Type{Union{}}}, Any, Core.svec(), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{Type{Type{Union{}}}}, Any, Core.svec(), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{Type{Type{Union{}}}}, Type{Type{Union{}}}, Core.svec(Type{Type{Union{}}}), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{Type{Type{Type{Union{}}}}}, Type{Type{Type{Union{}}}}, Core.svec(Type{Type{Type{Union{}}}}), 1, 1, 1)
+@test !Compiler.type_more_complex(Type{Union{}}, Any, Core.svec(), 1, 1, 1)
+@test !Compiler.type_more_complex(Type{Type{Union{}}}, Any, Core.svec(), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{Type{Type{Union{}}}}, Any, Core.svec(), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{Type{Type{Union{}}}}, Type{Type{Union{}}}, Core.svec(Type{Type{Union{}}}), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{Type{Type{Type{Union{}}}}}, Type{Type{Type{Union{}}}}, Core.svec(Type{Type{Type{Union{}}}}), 1, 1, 1)
 
-@test !Core.Compiler.type_more_complex(Type{1}, Type{2}, Core.svec(), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{Union{Float32,Float64}}, Union{Float32,Float64}, Core.svec(Union{Float32,Float64}), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{Type{Union{Float32,Float64}}}, Union{Float32,Float64}, Core.svec(Union{Float32,Float64}), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{Type{Union{Float32,Float64}}}, Type{Union{Float32,Float64}}, Core.svec(Type{Union{Float32,Float64}}), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{<:Union{Float32,Float64}}, Type{Union{Float32,Float64}}, Core.svec(Union{Float32,Float64}), 1, 1, 1)
-@test  Core.Compiler.type_more_complex(Type{<:Union{Float32,Float64}}, Any, Core.svec(Union{Float32,Float64}), 1, 1, 1)
+@test !Compiler.type_more_complex(Type{1}, Type{2}, Core.svec(), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{Union{Float32,Float64}}, Union{Float32,Float64}, Core.svec(Union{Float32,Float64}), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{Type{Union{Float32,Float64}}}, Union{Float32,Float64}, Core.svec(Union{Float32,Float64}), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{Type{Union{Float32,Float64}}}, Type{Union{Float32,Float64}}, Core.svec(Type{Union{Float32,Float64}}), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{<:Union{Float32,Float64}}, Type{Union{Float32,Float64}}, Core.svec(Union{Float32,Float64}), 1, 1, 1)
+@test  Compiler.type_more_complex(Type{<:Union{Float32,Float64}}, Any, Core.svec(Union{Float32,Float64}), 1, 1, 1)
 
 # issue #49287
-@test !Core.Compiler.type_more_complex(Tuple{Vararg{Tuple{}}}, Tuple{Vararg{Tuple}}, Core.svec(), 0, 0, 0)
-@test  Core.Compiler.type_more_complex(Tuple{Vararg{Tuple}}, Tuple{Vararg{Tuple{}}}, Core.svec(), 0, 0, 0)
+@test !Compiler.type_more_complex(Tuple{Vararg{Tuple{}}}, Tuple{Vararg{Tuple}}, Core.svec(), 0, 0, 0)
+@test  Compiler.type_more_complex(Tuple{Vararg{Tuple}}, Tuple{Vararg{Tuple{}}}, Core.svec(), 0, 0, 0)
 
 # issue #51694
-@test Core.Compiler.type_more_complex(
+@test Compiler.type_more_complex(
        Base.Generator{Base.Iterators.Flatten{Array{Bool, 1}}, typeof(identity)},
        Base.Generator{Array{Bool, 1}, typeof(identity)},
        Core.svec(), 0, 0, 0)
-@test Core.Compiler.type_more_complex(
+@test Compiler.type_more_complex(
        Base.Generator{Base.Iterators.Flatten{Base.Generator{Array{Bool, 1}, typeof(identity)}}, typeof(identity)},
        Base.Generator{Array{Bool, 1}, typeof(identity)},
        Core.svec(), 0, 0, 0)
@@ -111,31 +111,31 @@ end
 let # 40336
     t = Type{Type{Type{Int}}}
     c = Type{Type{Int}}
-    r = Core.Compiler.limit_type_size(t, c, c, 100, 100)
+    r = Compiler.limit_type_size(t, c, c, 100, 100)
     @test t !== r && t <: r
 end
 
-@test Core.Compiler.limit_type_size(Type{Type{Type{Int}}}, Type, Union{}, 0, 0) == Type{<:Type}
-@test Core.Compiler.limit_type_size(Type{Type{Int}}, Type, Union{}, 0, 0) == Type{<:Type}
-@test Core.Compiler.limit_type_size(Type{Int}, Type, Union{}, 0, 0) == Type{Int}
-@test Core.Compiler.limit_type_size(Type{<:Int}, Type, Union{}, 0, 0) == Type{<:Int}
-@test Core.Compiler.limit_type_size(Type{ComplexF32}, ComplexF32, Union{}, 0, 0) == Type{<:Complex} # added nesting
-@test Core.Compiler.limit_type_size(Type{ComplexF32}, Type{ComplexF64}, Union{}, 0, 0) == Type{ComplexF32} # base matches
-@test Core.Compiler.limit_type_size(Type{ComplexF32}, Type, Union{}, 0, 0) == Type{<:Complex}
-@test_broken  Core.Compiler.limit_type_size(Type{<:ComplexF64}, Type, Union{}, 0, 0) == Type{<:Complex}
-@test Core.Compiler.limit_type_size(Type{<:ComplexF64}, Type, Union{}, 0, 0) == Type #50692
-@test Core.Compiler.limit_type_size(Type{Union{ComplexF32,ComplexF64}}, Type, Union{}, 0, 0) == Type
-@test_broken Core.Compiler.limit_type_size(Type{Union{ComplexF32,ComplexF64}}, Type, Union{}, 0, 0) == Type{<:Complex} #50692
-@test Core.Compiler.limit_type_size(Type{Union{Float32,Float64}}, Type, Union{}, 0, 0) == Type
-@test Core.Compiler.limit_type_size(Type{Union{Int,Type{Int}}}, Type{Type{Int}}, Union{}, 0, 0) == Type
-@test Core.Compiler.limit_type_size(Type{Union{Int,Type{Int}}}, Union{Type{Int},Type{Type{Int}}}, Union{}, 0, 0) == Type
-@test Core.Compiler.limit_type_size(Type{Union{Int,Type{Int}}}, Type{Union{Type{Int},Type{Type{Int}}}}, Union{}, 0, 0) == Type{Union{Int, Type{Int}}}
-@test Core.Compiler.limit_type_size(Type{Union{Int,Type{Int}}}, Type{Type{Int}}, Union{}, 0, 0) == Type
+@test Compiler.limit_type_size(Type{Type{Type{Int}}}, Type, Union{}, 0, 0) == Type{<:Type}
+@test Compiler.limit_type_size(Type{Type{Int}}, Type, Union{}, 0, 0) == Type{<:Type}
+@test Compiler.limit_type_size(Type{Int}, Type, Union{}, 0, 0) == Type{Int}
+@test Compiler.limit_type_size(Type{<:Int}, Type, Union{}, 0, 0) == Type{<:Int}
+@test Compiler.limit_type_size(Type{ComplexF32}, ComplexF32, Union{}, 0, 0) == Type{<:Complex} # added nesting
+@test Compiler.limit_type_size(Type{ComplexF32}, Type{ComplexF64}, Union{}, 0, 0) == Type{ComplexF32} # base matches
+@test Compiler.limit_type_size(Type{ComplexF32}, Type, Union{}, 0, 0) == Type{<:Complex}
+@test_broken  Compiler.limit_type_size(Type{<:ComplexF64}, Type, Union{}, 0, 0) == Type{<:Complex}
+@test Compiler.limit_type_size(Type{<:ComplexF64}, Type, Union{}, 0, 0) == Type #50692
+@test Compiler.limit_type_size(Type{Union{ComplexF32,ComplexF64}}, Type, Union{}, 0, 0) == Type
+@test_broken Compiler.limit_type_size(Type{Union{ComplexF32,ComplexF64}}, Type, Union{}, 0, 0) == Type{<:Complex} #50692
+@test Compiler.limit_type_size(Type{Union{Float32,Float64}}, Type, Union{}, 0, 0) == Type
+@test Compiler.limit_type_size(Type{Union{Int,Type{Int}}}, Type{Type{Int}}, Union{}, 0, 0) == Type
+@test Compiler.limit_type_size(Type{Union{Int,Type{Int}}}, Union{Type{Int},Type{Type{Int}}}, Union{}, 0, 0) == Type
+@test Compiler.limit_type_size(Type{Union{Int,Type{Int}}}, Type{Union{Type{Int},Type{Type{Int}}}}, Union{}, 0, 0) == Type{Union{Int, Type{Int}}}
+@test Compiler.limit_type_size(Type{Union{Int,Type{Int}}}, Type{Type{Int}}, Union{}, 0, 0) == Type
 
 
-@test Core.Compiler.limit_type_size(Type{Any}, Union{}, Union{}, 0, 0) ==
-      Core.Compiler.limit_type_size(Type{Any}, Any, Union{}, 0, 0) ==
-      Core.Compiler.limit_type_size(Type{Any}, Type, Union{}, 0, 0) ==
+@test Compiler.limit_type_size(Type{Any}, Union{}, Union{}, 0, 0) ==
+      Compiler.limit_type_size(Type{Any}, Any, Union{}, 0, 0) ==
+      Compiler.limit_type_size(Type{Any}, Type, Union{}, 0, 0) ==
       Type{Any}
 
 # issue #43296
@@ -159,32 +159,32 @@ Base.ndims(::Type{f}) where {f<:e43296} = ndims(supertype(f))
 Base.ndims(g::e43296) = ndims(typeof(g))
 @test only(Base.return_types(ndims, (h43296{Any, 0, Any, Int, Any},))) == Int
 
-@test Core.Compiler.unionlen(Union{}) == 1
-@test Core.Compiler.unionlen(Int8) == 1
-@test Core.Compiler.unionlen(Union{Int8, Int16}) == 2
-@test Core.Compiler.unionlen(Union{Int8, Int16, Int32, Int64}) == 4
-@test Core.Compiler.unionlen(Tuple{Union{Int8, Int16, Int32, Int64}}) == 1
-@test Core.Compiler.unionlen(Union{Int8, Int16, Int32, T} where T) == 1
+@test Compiler.unionlen(Union{}) == 1
+@test Compiler.unionlen(Int8) == 1
+@test Compiler.unionlen(Union{Int8, Int16}) == 2
+@test Compiler.unionlen(Union{Int8, Int16, Int32, Int64}) == 4
+@test Compiler.unionlen(Tuple{Union{Int8, Int16, Int32, Int64}}) == 1
+@test Compiler.unionlen(Union{Int8, Int16, Int32, T} where T) == 1
 
-@test Core.Compiler.unioncomplexity(Union{}) == 0
-@test Core.Compiler.unioncomplexity(Int8) == 0
-@test Core.Compiler.unioncomplexity(Val{Union{Int8, Int16, Int32, Int64}}) == 0
-@test Core.Compiler.unioncomplexity(Union{Int8, Int16}) == 1
-@test Core.Compiler.unioncomplexity(Union{Int8, Int16, Int32, Int64}) == 3
-@test Core.Compiler.unioncomplexity(Tuple{Union{Int8, Int16, Int32, Int64}}) == 3
-@test Core.Compiler.unioncomplexity(Union{Int8, Int16, Int32, T} where T) == 3
-@test Core.Compiler.unioncomplexity(Tuple{Val{T}, Union{Int8, Int16}, Int8} where T<:Union{Int8, Int16, Int32, Int64}) == 3
-@test Core.Compiler.unioncomplexity(Tuple{Vararg{Tuple{Union{Int8, Int16}}}}) == 2
-@test Core.Compiler.unioncomplexity(Tuple{Vararg{Symbol}}) == 1
-@test Core.Compiler.unioncomplexity(Tuple{Vararg{Union{Symbol, Tuple{Vararg{Symbol}}}}}) == 3
-@test Core.Compiler.unioncomplexity(Tuple{Vararg{Union{Symbol, Tuple{Vararg{Union{Symbol, Tuple{Vararg{Symbol}}}}}}}}) == 5
-@test Core.Compiler.unioncomplexity(Tuple{Vararg{Union{Symbol, Tuple{Vararg{Union{Symbol, Tuple{Vararg{Union{Symbol, Tuple{Vararg{Symbol}}}}}}}}}}}) == 7
+@test Compiler.unioncomplexity(Union{}) == 0
+@test Compiler.unioncomplexity(Int8) == 0
+@test Compiler.unioncomplexity(Val{Union{Int8, Int16, Int32, Int64}}) == 0
+@test Compiler.unioncomplexity(Union{Int8, Int16}) == 1
+@test Compiler.unioncomplexity(Union{Int8, Int16, Int32, Int64}) == 3
+@test Compiler.unioncomplexity(Tuple{Union{Int8, Int16, Int32, Int64}}) == 3
+@test Compiler.unioncomplexity(Union{Int8, Int16, Int32, T} where T) == 3
+@test Compiler.unioncomplexity(Tuple{Val{T}, Union{Int8, Int16}, Int8} where T<:Union{Int8, Int16, Int32, Int64}) == 3
+@test Compiler.unioncomplexity(Tuple{Vararg{Tuple{Union{Int8, Int16}}}}) == 2
+@test Compiler.unioncomplexity(Tuple{Vararg{Symbol}}) == 1
+@test Compiler.unioncomplexity(Tuple{Vararg{Union{Symbol, Tuple{Vararg{Symbol}}}}}) == 3
+@test Compiler.unioncomplexity(Tuple{Vararg{Union{Symbol, Tuple{Vararg{Union{Symbol, Tuple{Vararg{Symbol}}}}}}}}) == 5
+@test Compiler.unioncomplexity(Tuple{Vararg{Union{Symbol, Tuple{Vararg{Union{Symbol, Tuple{Vararg{Union{Symbol, Tuple{Vararg{Symbol}}}}}}}}}}}) == 7
 
 
 # PR 22120
 function tuplemerge_test(a, b, r, commutative=true)
-    @test r == Core.Compiler.tuplemerge(a, b)
-    @test r == Core.Compiler.tuplemerge(b, a) broken=!commutative
+    @test r == Compiler.tuplemerge(a, b)
+    @test r == Compiler.tuplemerge(b, a) broken=!commutative
 end
 tuplemerge_test(Tuple{Int}, Tuple{String}, Tuple{Union{Int, String}})
 tuplemerge_test(Tuple{Int}, Tuple{String, String}, Tuple)
@@ -213,39 +213,39 @@ tuplemerge_test(Tuple{ComplexF64, ComplexF64, ComplexF32}, Tuple{Vararg{Union{Co
     Tuple{Vararg{Complex}}, false)
 tuplemerge_test(Tuple{}, Tuple{Complex, Vararg{Union{ComplexF32, ComplexF64}}},
     Tuple{Vararg{Complex}})
-@test Core.Compiler.tmerge(Tuple{}, Union{Nothing, Tuple{ComplexF32, ComplexF32}}) ==
+@test Compiler.tmerge(Tuple{}, Union{Nothing, Tuple{ComplexF32, ComplexF32}}) ==
     Union{Nothing, Tuple{}, Tuple{ComplexF32, ComplexF32}}
-@test Core.Compiler.tmerge(Tuple{}, Union{Nothing, Tuple{ComplexF32}, Tuple{ComplexF32, ComplexF32}}) ==
+@test Compiler.tmerge(Tuple{}, Union{Nothing, Tuple{ComplexF32}, Tuple{ComplexF32, ComplexF32}}) ==
     Union{Nothing, Tuple{Vararg{ComplexF32}}}
-@test Core.Compiler.tmerge(Union{Nothing, Tuple{ComplexF32}}, Union{Nothing, Tuple{ComplexF32, ComplexF32}}) ==
+@test Compiler.tmerge(Union{Nothing, Tuple{ComplexF32}}, Union{Nothing, Tuple{ComplexF32, ComplexF32}}) ==
     Union{Nothing, Tuple{ComplexF32}, Tuple{ComplexF32, ComplexF32}}
-@test Core.Compiler.tmerge(Union{Nothing, Tuple{}, Tuple{ComplexF32}}, Union{Nothing, Tuple{ComplexF32, ComplexF32}}) ==
+@test Compiler.tmerge(Union{Nothing, Tuple{}, Tuple{ComplexF32}}, Union{Nothing, Tuple{ComplexF32, ComplexF32}}) ==
     Union{Nothing, Tuple{Vararg{ComplexF32}}}
-@test Core.Compiler.tmerge(Vector{Int}, Core.Compiler.tmerge(Vector{String}, Vector{Bool})) ==
+@test Compiler.tmerge(Vector{Int}, Compiler.tmerge(Vector{String}, Vector{Bool})) ==
     Union{Vector{Bool}, Vector{Int}, Vector{String}}
-@test Core.Compiler.tmerge(Vector{Int}, Core.Compiler.tmerge(Vector{String}, Union{Vector{Bool}, Vector{Symbol}})) == Vector
-@test Core.Compiler.tmerge(Base.BitIntegerType, Union{}) === Base.BitIntegerType
-@test Core.Compiler.tmerge(Union{}, Base.BitIntegerType) === Base.BitIntegerType
-@test Core.Compiler.tmerge(Core.Compiler.fallback_ipo_lattice, Core.Compiler.InterConditional(1, Int, Union{}), Core.Compiler.InterConditional(2, String, Union{})) === Core.Compiler.Const(true)
+@test Compiler.tmerge(Vector{Int}, Compiler.tmerge(Vector{String}, Union{Vector{Bool}, Vector{Symbol}})) == Vector
+@test Compiler.tmerge(Base.BitIntegerType, Union{}) === Base.BitIntegerType
+@test Compiler.tmerge(Union{}, Base.BitIntegerType) === Base.BitIntegerType
+@test Compiler.tmerge(Compiler.fallback_ipo_lattice, Compiler.InterConditional(1, Int, Union{}), Compiler.InterConditional(2, String, Union{})) === Compiler.Const(true)
 # test issue behind https://github.com/JuliaLang/julia/issues/50458
-@test Core.Compiler.tmerge(Nothing, Tuple{Base.BitInteger, Int}) == Union{Nothing, Tuple{Base.BitInteger, Int}}
-@test Core.Compiler.tmerge(Union{Nothing, Tuple{Int, Int}}, Tuple{Base.BitInteger, Int}) == Union{Nothing, Tuple{Any, Int}}
-@test Core.Compiler.tmerge(Nothing, Tuple{Union{Char, String, SubString{String}, Symbol}, Int}) == Union{Nothing, Tuple{Union{Char, String, SubString{String}, Symbol}, Int}}
-@test Core.Compiler.tmerge(Union{Nothing, Tuple{Char, Int}}, Tuple{Union{Char, String, SubString{String}, Symbol}, Int}) == Union{Nothing, Tuple{Union{Char, String, SubString{String}, Symbol}, Int}}
-@test Core.Compiler.tmerge(Nothing, Tuple{Integer, Int}) == Union{Nothing, Tuple{Integer, Int}}
-@test Core.Compiler.tmerge(Union{Nothing, Tuple{Int, Int}}, Tuple{Integer, Int}) == Union{Nothing, Tuple{Integer, Int}}
-@test Core.Compiler.tmerge(Union{Nothing, Int, AbstractVector{Int}}, Vector) == Union{Nothing, Int, AbstractVector}
-@test Core.Compiler.tmerge(Union{Nothing, Int, AbstractVector{Int}}, Matrix) == Union{Nothing, Int, AbstractArray}
-@test Core.Compiler.tmerge(Union{Nothing, Int, AbstractVector{Int}}, Matrix{Int}) == Union{Nothing, Int, AbstractArray{Int}}
-@test Core.Compiler.tmerge(Union{Nothing, Int, AbstractVector{Int}}, Array) == Union{Nothing, Int, AbstractArray}
-@test Core.Compiler.tmerge(Union{Nothing, Int, AbstractArray{Int}}, Vector) == Union{Nothing, Int, AbstractArray}
-@test Core.Compiler.tmerge(Union{Nothing, Int, AbstractVector}, Matrix{Int}) == Union{Nothing, Int, AbstractArray}
-@test Core.Compiler.tmerge(Union{Nothing, AbstractFloat}, Integer) == Union{Nothing, AbstractFloat, Integer}
-@test Core.Compiler.tmerge(AbstractVector, AbstractMatrix) == Union{AbstractVector, AbstractMatrix}
-@test Core.Compiler.tmerge(Union{AbstractVector, Nothing}, AbstractMatrix) == Union{Nothing, AbstractVector, AbstractMatrix}
-@test Core.Compiler.tmerge(Union{AbstractVector, Int}, AbstractMatrix) == Union{Int, AbstractVector, AbstractMatrix}
-@test Core.Compiler.tmerge(Union{AbstractVector, Integer}, AbstractMatrix) == Union{Integer, AbstractArray}
-@test Core.Compiler.tmerge(Union{AbstractVector, Nothing, Int}, AbstractMatrix) == Union{Nothing, Int, AbstractArray}
+@test Compiler.tmerge(Nothing, Tuple{Base.BitInteger, Int}) == Union{Nothing, Tuple{Base.BitInteger, Int}}
+@test Compiler.tmerge(Union{Nothing, Tuple{Int, Int}}, Tuple{Base.BitInteger, Int}) == Union{Nothing, Tuple{Any, Int}}
+@test Compiler.tmerge(Nothing, Tuple{Union{Char, String, SubString{String}, Symbol}, Int}) == Union{Nothing, Tuple{Union{Char, String, SubString{String}, Symbol}, Int}}
+@test Compiler.tmerge(Union{Nothing, Tuple{Char, Int}}, Tuple{Union{Char, String, SubString{String}, Symbol}, Int}) == Union{Nothing, Tuple{Union{Char, String, SubString{String}, Symbol}, Int}}
+@test Compiler.tmerge(Nothing, Tuple{Integer, Int}) == Union{Nothing, Tuple{Integer, Int}}
+@test Compiler.tmerge(Union{Nothing, Tuple{Int, Int}}, Tuple{Integer, Int}) == Union{Nothing, Tuple{Integer, Int}}
+@test Compiler.tmerge(Union{Nothing, Int, AbstractVector{Int}}, Vector) == Union{Nothing, Int, AbstractVector}
+@test Compiler.tmerge(Union{Nothing, Int, AbstractVector{Int}}, Matrix) == Union{Nothing, Int, AbstractArray}
+@test Compiler.tmerge(Union{Nothing, Int, AbstractVector{Int}}, Matrix{Int}) == Union{Nothing, Int, AbstractArray{Int}}
+@test Compiler.tmerge(Union{Nothing, Int, AbstractVector{Int}}, Array) == Union{Nothing, Int, AbstractArray}
+@test Compiler.tmerge(Union{Nothing, Int, AbstractArray{Int}}, Vector) == Union{Nothing, Int, AbstractArray}
+@test Compiler.tmerge(Union{Nothing, Int, AbstractVector}, Matrix{Int}) == Union{Nothing, Int, AbstractArray}
+@test Compiler.tmerge(Union{Nothing, AbstractFloat}, Integer) == Union{Nothing, AbstractFloat, Integer}
+@test Compiler.tmerge(AbstractVector, AbstractMatrix) == Union{AbstractVector, AbstractMatrix}
+@test Compiler.tmerge(Union{AbstractVector, Nothing}, AbstractMatrix) == Union{Nothing, AbstractVector, AbstractMatrix}
+@test Compiler.tmerge(Union{AbstractVector, Int}, AbstractMatrix) == Union{Int, AbstractVector, AbstractMatrix}
+@test Compiler.tmerge(Union{AbstractVector, Integer}, AbstractMatrix) == Union{Integer, AbstractArray}
+@test Compiler.tmerge(Union{AbstractVector, Nothing, Int}, AbstractMatrix) == Union{Nothing, Int, AbstractArray}
 
 # test that recursively more complicated types don't widen all the way to Any when there is a useful valid type upper bound
 # Specifically test with base types of a trivial type, a simple union, a complicated union, and a tuple.
@@ -253,7 +253,7 @@ for T in (Nothing, Base.BitInteger, Union{Int, Int32, Int16, Int8}, Tuple{Int, I
     Ta, Tb = T, T
     for i in 1:10
         Ta = Union{Tuple{Ta}, Nothing}
-        Tb = Core.Compiler.tmerge(Tuple{Tb}, Nothing)
+        Tb = Compiler.tmerge(Tuple{Tb}, Nothing)
         @test Ta <: Tb <: Union{Nothing, Tuple}
     end
 end
@@ -366,9 +366,9 @@ barTuple2() = fooTuple{tuple(:y)}()
 @test Base.return_types(barTuple1,Tuple{})[1] == Base.return_types(barTuple2,Tuple{})[1] == fooTuple{(:y,)}
 
 # issue #6050
-@test Core.Compiler.getfield_tfunc(Core.Compiler.fallback_lattice,
+@test Compiler.getfield_tfunc(Compiler.fallback_lattice,
           Dict{Int64,Tuple{UnitRange{Int64},UnitRange{Int64}}},
-          Core.Compiler.Const(:vals)) == Memory{Tuple{UnitRange{Int64},UnitRange{Int64}}}
+          Compiler.Const(:vals)) == Memory{Tuple{UnitRange{Int64},UnitRange{Int64}}}
 
 # assert robustness of `getfield_tfunc`
 struct GetfieldRobustness
@@ -647,7 +647,7 @@ f18450() = ifelse(true, Tuple{Vararg{Int}}, Tuple{Vararg})
 @test f18450() == Tuple{Vararg{Int}}
 
 # issue #18569
-@test !Core.Compiler.isconstType(Type{Tuple})
+@test !Compiler.isconstType(Type{Tuple})
 
 # issue #10880
 function cat10880(a, b)
@@ -778,9 +778,9 @@ end
 f_infer_abstract_fieldtype() = fieldtype(HasAbstractlyTypedField, :x)
 @test Base.return_types(f_infer_abstract_fieldtype, ()) == Any[Type{Union{Int,String}}]
 let fieldtype_tfunc(@nospecialize args...) =
-        Core.Compiler.fieldtype_tfunc(Core.Compiler.fallback_lattice, args...),
-    fieldtype_nothrow(@nospecialize(s0), @nospecialize(name)) = Core.Compiler.fieldtype_nothrow(
-        Core.Compiler.SimpleInferenceLattice.instance, s0, name)
+        Compiler.fieldtype_tfunc(Compiler.fallback_lattice, args...),
+    fieldtype_nothrow(@nospecialize(s0), @nospecialize(name)) = Compiler.fieldtype_nothrow(
+        Compiler.SimpleInferenceLattice.instance, s0, name)
     @test fieldtype_tfunc(Union{}, :x) == Union{}
     @test fieldtype_tfunc(Union{Type{Int32}, Int32}, Const(:x)) == Union{}
     @test fieldtype_tfunc(Union{Type{Base.RefValue{T}}, Type{Int32}} where {T<:Array}, Const(:x)) == Type{<:Array}
@@ -823,7 +823,7 @@ end
 
 # Issue 19641
 foo19641() = let a = 1.0
-    Core.Compiler.return_type(x -> x + a, Tuple{Float64})
+    Compiler.return_type(x -> x + a, Tuple{Float64})
 end
 @inferred foo19641()
 
@@ -977,15 +977,15 @@ test_no_apply(::Any) = true
 
 # issue #20033
 # check return_type_tfunc for calls where no method matches
-bcast_eltype_20033(f, A) = Core.Compiler.return_type(f, Tuple{eltype(A)})
+bcast_eltype_20033(f, A) = Compiler.return_type(f, Tuple{eltype(A)})
 err20033(x::Float64...) = prod(x)
 @test bcast_eltype_20033(err20033, [1]) === Union{}
 @test Base.return_types(bcast_eltype_20033, (typeof(err20033), Vector{Int},)) == Any[Type{Union{}}]
 # return_type on builtins
-@test Core.Compiler.return_type(tuple, Tuple{Int,Int8,Int}) === Tuple{Int,Int8,Int}
+@test Compiler.return_type(tuple, Tuple{Int,Int8,Int}) === Tuple{Int,Int8,Int}
 
 # issue #21088
-@test Core.Compiler.return_type(typeof, Tuple{Int}) == Type{Int}
+@test Compiler.return_type(typeof, Tuple{Int}) == Type{Int}
 
 # Inference of constant svecs
 @eval fsvecinf() = $(QuoteNode(Core.svec(Tuple{Int,Int}, Int)))[1]
@@ -1160,7 +1160,7 @@ end
 struct UnionIsdefinedA; x; end
 struct UnionIsdefinedB; x; end
 let isdefined_tfunc(@nospecialize xs...) =
-        Core.Compiler.isdefined_tfunc(Core.Compiler.fallback_lattice, xs...)
+        Compiler.isdefined_tfunc(Compiler.fallback_lattice, xs...)
     @test isdefined_tfunc(typeof(NamedTuple()), Const(0)) === Const(false)
     @test isdefined_tfunc(typeof(NamedTuple()), Const(1)) === Const(false)
     @test isdefined_tfunc(typeof((a=1,b=2)), Const(:a)) === Const(true)
@@ -1257,18 +1257,18 @@ function get_linfo(@nospecialize(f), @nospecialize(t))
     # get the MethodInstance for the method match
     match = Base._which(Base.signature_type(f, t))
     precompile(match.spec_types)
-    return Core.Compiler.specialize_method(match)
+    return Compiler.specialize_method(match)
 end
 
 function test_const_return(@nospecialize(f), @nospecialize(t), @nospecialize(val))
-    interp = Core.Compiler.NativeInterpreter()
-    linfo = Core.Compiler.getindex(Core.Compiler.code_cache(interp), get_linfo(f, t))
+    interp = Compiler.NativeInterpreter()
+    linfo = Compiler.getindex(Compiler.code_cache(interp), get_linfo(f, t))
     # If coverage is not enabled, make the check strict by requiring constant ABI
     # Otherwise, check the typed AST to make sure we return a constant.
     if Base.JLOptions().code_coverage == 0
-        @test Core.Compiler.invoke_api(linfo) == 2
+        @test Compiler.invoke_api(linfo) == 2
     end
-    if Core.Compiler.invoke_api(linfo) == 2
+    if Compiler.invoke_api(linfo) == 2
         @test linfo.rettype_const == val
         return
     end
@@ -1288,7 +1288,7 @@ function test_const_return(@nospecialize(f), @nospecialize(t), @nospecialize(val
             @test ret === val || (isa(ret, QuoteNode) && (ret::QuoteNode).value === val)
             continue
         elseif isa(ex, Expr)
-            if Core.Compiler.is_meta_expr_head(ex.head)
+            if Compiler.is_meta_expr_head(ex.head)
                 continue
             end
         end
@@ -1308,7 +1308,7 @@ function find_call(code::Core.CodeInfo, @nospecialize(func), narg)
                     farg = typeof(getfield(farg.mod, farg.name))
                 end
             elseif isa(farg, Core.SSAValue)
-                farg = Core.Compiler.widenconst(code.ssavaluetypes[farg.id])
+                farg = Compiler.widenconst(code.ssavaluetypes[farg.id])
             else
                 farg = typeof(farg)
             end
@@ -1355,7 +1355,7 @@ isdefined_f3(x) = isdefined(x, 3)
 @test find_call(only(code_typed(isdefined_f3, Tuple{Tuple{Vararg{Int}}}))[1], isdefined, 3)
 
 let isa_tfunc(@nospecialize xs...) =
-        Core.Compiler.isa_tfunc(Core.Compiler.fallback_lattice, xs...)
+        Compiler.isa_tfunc(Compiler.fallback_lattice, xs...)
     @test isa_tfunc(Array, Const(AbstractArray)) === Const(true)
     @test isa_tfunc(Array, Type{AbstractArray}) === Const(true)
     @test isa_tfunc(Array, Type{AbstractArray{Int}}) == Bool
@@ -1395,7 +1395,7 @@ let isa_tfunc(@nospecialize xs...) =
 end
 
 let subtype_tfunc(@nospecialize xs...) =
-        Core.Compiler.subtype_tfunc(Core.Compiler.fallback_lattice, xs...)
+        Compiler.subtype_tfunc(Compiler.fallback_lattice, xs...)
     @test subtype_tfunc(Type{<:Array}, Const(AbstractArray)) === Const(true)
     @test subtype_tfunc(Type{<:Array}, Type{AbstractArray}) === Const(true)
     @test subtype_tfunc(Type{<:Array}, Type{AbstractArray{Int}}) == Bool
@@ -1447,9 +1447,9 @@ end
 
 let egal_tfunc
     function egal_tfunc(a, b)
-        𝕃 = Core.Compiler.fallback_lattice
-        r = Core.Compiler.egal_tfunc(𝕃, a, b)
-        @test r === Core.Compiler.egal_tfunc(𝕃, b, a)
+        𝕃 = Compiler.fallback_lattice
+        r = Compiler.egal_tfunc(𝕃, a, b)
+        @test r === Compiler.egal_tfunc(𝕃, b, a)
         return r
     end
     @test egal_tfunc(Const(12345.12345), Const(12344.12345 + 1)) == Const(true)
@@ -1518,11 +1518,11 @@ egal_conditional_lattice3(x, y) = x === y + y ? "" : 1
 @test Base.return_types(egal_conditional_lattice3, (Int32, Int64)) == Any[Int]
 
 let nfields_tfunc(@nospecialize xs...) =
-        Core.Compiler.nfields_tfunc(Core.Compiler.fallback_lattice, xs...)
+        Compiler.nfields_tfunc(Compiler.fallback_lattice, xs...)
     sizeof_tfunc(@nospecialize xs...) =
-        Core.Compiler.sizeof_tfunc(Core.Compiler.fallback_lattice, xs...)
+        Compiler.sizeof_tfunc(Compiler.fallback_lattice, xs...)
     sizeof_nothrow(@nospecialize xs...) =
-        Core.Compiler.sizeof_nothrow(xs...)
+        Compiler.sizeof_nothrow(xs...)
     @test sizeof_tfunc(Const(Ptr)) === sizeof_tfunc(Union{Ptr, Int, Type{Ptr{Int8}}, Type{Int}}) === Const(Sys.WORD_SIZE ÷ 8)
     @test sizeof_tfunc(Type{Ptr}) === Const(sizeof(Ptr))
     @test sizeof_nothrow(Union{Ptr, Int, Type{Ptr{Int8}}, Type{Int}})
@@ -1563,7 +1563,7 @@ let nfields_tfunc(@nospecialize xs...) =
 end
 
 let typeof_tfunc(@nospecialize xs...) =
-        Core.Compiler.typeof_tfunc(Core.Compiler.fallback_lattice, xs...)
+        Compiler.typeof_tfunc(Compiler.fallback_lattice, xs...)
     @test typeof_tfunc(Tuple{Vararg{Int}}) == Type{Tuple{Vararg{Int,N}}} where N
     @test typeof_tfunc(Tuple{Any}) == Type{<:Tuple{Any}}
     @test typeof_tfunc(Type{Array}) === DataType
@@ -1577,13 +1577,13 @@ f_typeof_tfunc(x) = typeof(x)
 @test Base.return_types(f_typeof_tfunc, (Union{<:T, Int} where T<:Complex,)) == Any[Union{Type{Int}, Type{Complex{T}} where T<:Real}]
 
 # memoryref_tfunc, memoryrefget_tfunc, memoryrefset!_tfunc, memoryref_isassigned, memoryrefoffset_tfunc
-let memoryref_tfunc(@nospecialize xs...) = Core.Compiler.memoryref_tfunc(Core.Compiler.fallback_lattice, xs...)
-    memoryrefget_tfunc(@nospecialize xs...) = Core.Compiler.memoryrefget_tfunc(Core.Compiler.fallback_lattice, xs...)
-    memoryref_isassigned_tfunc(@nospecialize xs...) = Core.Compiler.memoryref_isassigned_tfunc(Core.Compiler.fallback_lattice, xs...)
-    memoryrefset!_tfunc(@nospecialize xs...) = Core.Compiler.memoryrefset!_tfunc(Core.Compiler.fallback_lattice, xs...)
-    memoryrefoffset_tfunc(@nospecialize xs...) = Core.Compiler.memoryrefoffset_tfunc(Core.Compiler.fallback_lattice, xs...)
-    interp = Core.Compiler.NativeInterpreter()
-    builtin_tfunction(@nospecialize xs...) = Core.Compiler.builtin_tfunction(interp, xs..., nothing)
+let memoryref_tfunc(@nospecialize xs...) = Compiler.memoryref_tfunc(Compiler.fallback_lattice, xs...)
+    memoryrefget_tfunc(@nospecialize xs...) = Compiler.memoryrefget_tfunc(Compiler.fallback_lattice, xs...)
+    memoryref_isassigned_tfunc(@nospecialize xs...) = Compiler.memoryref_isassigned_tfunc(Compiler.fallback_lattice, xs...)
+    memoryrefset!_tfunc(@nospecialize xs...) = Compiler.memoryrefset!_tfunc(Compiler.fallback_lattice, xs...)
+    memoryrefoffset_tfunc(@nospecialize xs...) = Compiler.memoryrefoffset_tfunc(Compiler.fallback_lattice, xs...)
+    interp = Compiler.NativeInterpreter()
+    builtin_tfunction(@nospecialize xs...) = Compiler.builtin_tfunction(interp, xs..., nothing)
     @test memoryref_tfunc(Memory{Int}) == MemoryRef{Int}
     @test memoryref_tfunc(Memory{Integer}) == MemoryRef{Integer}
     @test memoryref_tfunc(MemoryRef{Int}, Int) == MemoryRef{Int}
@@ -1645,8 +1645,8 @@ let memoryref_tfunc(@nospecialize xs...) = Core.Compiler.memoryref_tfunc(Core.Co
 end
 
 let tuple_tfunc(@nospecialize xs...) =
-        Core.Compiler.tuple_tfunc(Core.Compiler.fallback_lattice, Any[xs...])
-    @test Core.Compiler.widenconst(tuple_tfunc(Type{Int})) === Tuple{DataType}
+        Compiler.tuple_tfunc(Compiler.fallback_lattice, Any[xs...])
+    @test Compiler.widenconst(tuple_tfunc(Type{Int})) === Tuple{DataType}
     # https://github.com/JuliaLang/julia/issues/44705
     @test tuple_tfunc(Union{Type{Int32},Type{Int64}}) === Tuple{Type}
     @test tuple_tfunc(DataType) === Tuple{DataType}
@@ -1662,8 +1662,8 @@ g23024(TT::Tuple{DataType}) = f23024(TT[1], v23024)
 @test Base.return_types(g23024, (Tuple{DataType},)) == Any[Int]
 @test g23024((UInt8,)) === 2
 
-@test !Core.Compiler.isconstType(Type{typeof(Union{})}) # could be Core.TypeofBottom or Type{Union{}} at runtime
-@test !isa(Core.Compiler.getfield_tfunc(Core.Compiler.fallback_lattice, Type{Core.TypeofBottom}, Core.Compiler.Const(:name)), Core.Compiler.Const)
+@test !Compiler.isconstType(Type{typeof(Union{})}) # could be Core.TypeofBottom or Type{Union{}} at runtime
+@test !isa(Compiler.getfield_tfunc(Compiler.fallback_lattice, Type{Core.TypeofBottom}, Compiler.Const(:name)), Compiler.Const)
 @test Base.return_types(supertype, (Type{typeof(Union{})},)) == Any[Any]
 
 # issue #23685
@@ -1689,8 +1689,8 @@ gg13183(x::X...) where {X} = (_false13183 ? gg13183(x, x) : 0)
 # test the external OptimizationState constructor
 let linfo = get_linfo(Base.convert, Tuple{Type{Int64}, Int32}),
     world = UInt(23) # some small-numbered world that should be valid
-    interp = Core.Compiler.NativeInterpreter()
-    opt = Core.Compiler.OptimizationState(linfo, interp)
+    interp = Compiler.NativeInterpreter()
+    opt = Compiler.OptimizationState(linfo, interp)
     # make sure the state of the properties look reasonable
     @test opt.src !== linfo.def.source
     @test length(opt.src.slotflags) == linfo.def.nargs <= length(opt.src.slotnames)
@@ -1726,7 +1726,7 @@ mutable struct ARef{T}
     @atomic x::T
 end
 let getfield_tfunc(@nospecialize xs...) =
-        Core.Compiler.getfield_tfunc(Core.Compiler.fallback_lattice, xs...)
+        Compiler.getfield_tfunc(Compiler.fallback_lattice, xs...)
 
     # inference of `T.mutable`
     @test getfield_tfunc(Const(Int.name), Const(:flags)) == Const(0x4)
@@ -1762,7 +1762,7 @@ let getfield_tfunc(@nospecialize xs...) =
     @test getfield_tfunc(ARef{Int},Const(:x),Bool,Bool) === Union{}
 end
 
-import Core.Compiler: Const
+import .Compiler: Const
 mutable struct XY{X,Y}
     x::X
     y::Y
@@ -1774,7 +1774,7 @@ mutable struct ABCDconst
     const d::Union{Int,Nothing}
 end
 let setfield!_tfunc(@nospecialize xs...) =
-        Core.Compiler.setfield!_tfunc(Core.Compiler.fallback_lattice, xs...)
+        Compiler.setfield!_tfunc(Compiler.fallback_lattice, xs...)
     @test setfield!_tfunc(Base.RefValue{Int}, Const(:x), Int) === Int
     @test setfield!_tfunc(Base.RefValue{Int}, Const(:x), Int, Symbol) === Int
     @test setfield!_tfunc(Base.RefValue{Int}, Const(1), Int) === Int
@@ -1834,7 +1834,7 @@ let setfield!_tfunc(@nospecialize xs...) =
     @test setfield!_tfunc(ABCDconst, Const(4), Any) === Union{}
 end
 let setfield!_nothrow(@nospecialize xs...) =
-        Core.Compiler.setfield!_nothrow(Core.Compiler.SimpleInferenceLattice.instance, xs...)
+        Compiler.setfield!_nothrow(Compiler.SimpleInferenceLattice.instance, xs...)
     @test setfield!_nothrow(Base.RefValue{Int}, Const(:x), Int)
     @test setfield!_nothrow(Base.RefValue{Int}, Const(1), Int)
     @test setfield!_nothrow(Base.RefValue{Any}, Const(:x), Int)
@@ -2131,12 +2131,12 @@ end
 
     # handle edge case
     @test (@eval Module() begin
-        edgecase(_) = $(Core.Compiler.InterConditional(2, Int, Any))
+        edgecase(_) = $(Compiler.InterConditional(2, Int, Any))
         Base.return_types(edgecase, (Any,)) # create cache
         Base.return_types((Any,)) do x
             edgecase(x)
         end
-    end) == Any[Core.Compiler.InterConditional]
+    end) == Any[Compiler.InterConditional]
 
     # a tricky case: if constant inference derives `Const` while non-constant inference has
     # derived `InterConditional`, we should not discard that constant information
@@ -2235,7 +2235,7 @@ end
     end |> only == Int
     # the `fargs = nothing` edge case
     @test Base.return_types((Any,)) do a
-        Core.Compiler.return_type(invoke, Tuple{typeof(ispositive), Type{Tuple{Any}}, Any})
+        Compiler.return_type(invoke, Tuple{typeof(ispositive), Type{Tuple{Any}}, Any})
     end |> only == Type{Bool}
 
     # `InterConditional` handling: `abstract_call_opaque_closure`
@@ -2264,27 +2264,25 @@ mutable struct AliasableConstField{S,T}
     f2::T
 end
 
-import Core.Compiler:
+import .Compiler:
     InferenceLattice, MustAliasesLattice, InterMustAliasesLattice,
     BaseInferenceLattice, SimpleInferenceLattice, IPOResultLattice, typeinf_lattice, ipo_lattice, optimizer_lattice
 
 include("newinterp.jl")
 @newinterp MustAliasInterpreter
-let CC = Core.Compiler
-    CC.typeinf_lattice(::MustAliasInterpreter) = InferenceLattice(MustAliasesLattice(BaseInferenceLattice.instance))
-    CC.ipo_lattice(::MustAliasInterpreter) = InferenceLattice(InterMustAliasesLattice(IPOResultLattice.instance))
-    CC.optimizer_lattice(::MustAliasInterpreter) = SimpleInferenceLattice.instance
-end
+Compiler.typeinf_lattice(::MustAliasInterpreter) = InferenceLattice(MustAliasesLattice(BaseInferenceLattice.instance))
+Compiler.ipo_lattice(::MustAliasInterpreter) = InferenceLattice(InterMustAliasesLattice(IPOResultLattice.instance))
+Compiler.optimizer_lattice(::MustAliasInterpreter) = SimpleInferenceLattice.instance
 
 # lattice
 # -------
 
-import Core.Compiler: MustAlias, Const, PartialStruct, ⊑, tmerge
+import .Compiler: MustAlias, Const, PartialStruct, ⊑, tmerge
 let 𝕃ᵢ = InferenceLattice(MustAliasesLattice(BaseInferenceLattice.instance))
-    ⊑(@nospecialize(a), @nospecialize(b)) = Core.Compiler.:⊑(𝕃ᵢ, a, b)
-    tmerge(@nospecialize(a), @nospecialize(b)) = Core.Compiler.tmerge(𝕃ᵢ, a, b)
-    isa_tfunc(@nospecialize xs...) = Core.Compiler.isa_tfunc(𝕃ᵢ, xs...)
-    ifelse_tfunc(@nospecialize xs...) = Core.Compiler.ifelse_tfunc(𝕃ᵢ, xs...)
+    ⊑(@nospecialize(a), @nospecialize(b)) = Compiler.:⊑(𝕃ᵢ, a, b)
+    tmerge(@nospecialize(a), @nospecialize(b)) = Compiler.tmerge(𝕃ᵢ, a, b)
+    isa_tfunc(@nospecialize xs...) = Compiler.isa_tfunc(𝕃ᵢ, xs...)
+    ifelse_tfunc(@nospecialize xs...) = Compiler.ifelse_tfunc(𝕃ᵢ, xs...)
 
     @test (MustAlias(2, AliasableField{Any}, 1, Int) ⊑ Int)
     @test !(Int ⊑ MustAlias(2, AliasableField{Any}, 1, Int))
@@ -2553,11 +2551,11 @@ end |> only === Int
 end |> only === Some{Int}
 
 # handle the edge case
-@eval intermustalias_edgecase(_) = $(Core.Compiler.InterMustAlias(2, Some{Any}, 1, Int))
+@eval intermustalias_edgecase(_) = $(Compiler.InterMustAlias(2, Some{Any}, 1, Int))
 Base.return_types(intermustalias_edgecase, (Any,); interp=MustAliasInterpreter()) # create cache
 @test Base.return_types((Any,); interp=MustAliasInterpreter()) do x
     intermustalias_edgecase(x)
-end |> only === Core.Compiler.InterMustAlias
+end |> only === Compiler.InterMustAlias
 
 @test Base.infer_return_type((AliasableField,Integer,); interp=MustAliasInterpreter()) do a, x
     s = (;x)
@@ -2768,9 +2766,9 @@ end |> only === Int
 # `apply_type_tfunc` accuracy for constrained type construction
 # https://github.com/JuliaLang/julia/issues/47089
 import Core: Const
-import Core.Compiler: apply_type_tfunc
+import .Compiler: apply_type_tfunc
 struct Issue47089{A<:Number,B<:Number} end
-let 𝕃 = Core.Compiler.fallback_lattice
+let 𝕃 = Compiler.fallback_lattice
     A = Type{<:Integer}
     @test apply_type_tfunc(𝕃, Const(Issue47089), A, A) <: (Type{Issue47089{A,B}} where {A<:Integer, B<:Integer})
     @test apply_type_tfunc(𝕃, Const(Issue47089), Const(Int), Const(Int), Const(Int)) === Union{}
@@ -2789,7 +2787,7 @@ end
 @test only(Base.return_types(Base.afoldl, (typeof((m, n) -> () -> Returns(nothing)(m, n)), Function, Function, Vararg{Function}))) === Function
 
 let A = Tuple{A,B,C,D,E,F,G,H} where {A,B,C,D,E,F,G,H}
-    B = Core.Compiler.rename_unionall(A)
+    B = Compiler.rename_unionall(A)
     for i in 1:8
         @test A.var != B.var && (i == 1 ? A == B : A != B)
         A, B = A.body, B.body
@@ -3056,7 +3054,7 @@ let i
         end
     end
 end
-Core.Compiler.renumber_ir_elements!(code28279, ssachangemap, labelchangemap)
+Compiler.renumber_ir_elements!(code28279, ssachangemap, labelchangemap)
 @test length(code28279) === length(oldcode28279)
 offset = 1
 let i
@@ -3079,11 +3077,11 @@ end
 # issue #28356
 # unit test to make sure countunionsplit overflows gracefully
 # we don't care what number is returned as long as it's large
-@test Core.Compiler.unionsplitcost(Core.Compiler.JLTypeLattice(), Any[Union{Int32, Int64} for i=1:80]) > 100000
-@test Core.Compiler.unionsplitcost(Core.Compiler.JLTypeLattice(), Any[Union{Int8, Int16, Int32, Int64}]) == 2
-@test Core.Compiler.unionsplitcost(Core.Compiler.JLTypeLattice(), Any[Union{Int8, Int16, Int32, Int64}, Union{Int8, Int16, Int32, Int64}, Int8]) == 8
-@test Core.Compiler.unionsplitcost(Core.Compiler.JLTypeLattice(), Any[Union{Int8, Int16, Int32, Int64}, Union{Int8, Int16, Int32}, Int8]) == 6
-@test Core.Compiler.unionsplitcost(Core.Compiler.JLTypeLattice(), Any[Union{Int8, Int16, Int32}, Union{Int8, Int16, Int32, Int64}, Int8]) == 6
+@test Compiler.unionsplitcost(Compiler.JLTypeLattice(), Any[Union{Int32, Int64} for i=1:80]) > 100000
+@test Compiler.unionsplitcost(Compiler.JLTypeLattice(), Any[Union{Int8, Int16, Int32, Int64}]) == 2
+@test Compiler.unionsplitcost(Compiler.JLTypeLattice(), Any[Union{Int8, Int16, Int32, Int64}, Union{Int8, Int16, Int32, Int64}, Int8]) == 8
+@test Compiler.unionsplitcost(Compiler.JLTypeLattice(), Any[Union{Int8, Int16, Int32, Int64}, Union{Int8, Int16, Int32}, Int8]) == 6
+@test Compiler.unionsplitcost(Compiler.JLTypeLattice(), Any[Union{Int8, Int16, Int32}, Union{Int8, Int16, Int32, Int64}, Int8]) == 6
 
 # make sure compiler doesn't hang in union splitting
 
@@ -3326,8 +3324,8 @@ _rttf_test(::Int16) = 0
 _rttf_test(::Int32) = 0
 _rttf_test(::Int64) = 0
 _rttf_test(::Int128) = 0
-_call_rttf_test() = Core.Compiler.return_type(_rttf_test, Tuple{Any})
-@test Core.Compiler.return_type(_rttf_test, Tuple{Any}) === Int
+_call_rttf_test() = Compiler.return_type(_rttf_test, Tuple{Any})
+@test Compiler.return_type(_rttf_test, Tuple{Any}) === Int
 @test _call_rttf_test() === Int
 
 f_with_Type_arg(::Type{T}) where {T} = T
@@ -3375,7 +3373,7 @@ end
 @test @inferred(foo30783(2)) == Val(1)
 
 # PartialStruct tmerge
-using Core.Compiler: PartialStruct, tmerge, Const, ⊑
+using .Compiler: PartialStruct, tmerge, Const, ⊑
 struct FooPartial
     a::Int
     b::Int
@@ -3509,14 +3507,14 @@ const DenseIdx = Union{IntRange,Integer}
 @test @inferred(foo_26724((), 1:4, 1:5, 1:6)) === (4, 5, 6)
 
 # Non uniformity in expressions with PartialTypeVar
-@test Core.Compiler.:⊑(Core.Compiler.PartialTypeVar(TypeVar(:N), true, true), TypeVar)
+@test Compiler.:⊑(Compiler.PartialTypeVar(TypeVar(:N), true, true), TypeVar)
 let N = TypeVar(:N)
-    𝕃 = Core.Compiler.SimpleInferenceLattice.instance
-    argtypes = Any[Core.Compiler.Const(NTuple),
-        Core.Compiler.PartialTypeVar(N, true, true),
-        Core.Compiler.Const(Any)]
+    𝕃 = Compiler.SimpleInferenceLattice.instance
+    argtypes = Any[Compiler.Const(NTuple),
+        Compiler.PartialTypeVar(N, true, true),
+        Compiler.Const(Any)]
     rt = Type{Tuple{Vararg{Any,N}}}
-    @test Core.Compiler.apply_type_nothrow(𝕃, argtypes, rt)
+    @test Compiler.apply_type_nothrow(𝕃, argtypes, rt)
 end
 
 # issue #33768
@@ -3629,29 +3627,29 @@ end
 
 f() = _foldl_iter(step, (Missing[],), [0.0], 1)
 end
-@test Core.Compiler.typesubtract(Tuple{Union{Int,Char}}, Tuple{Char}, 0) == Tuple{Int}
-@test Core.Compiler.typesubtract(Tuple{Union{Int,Char}}, Tuple{Char}, 1) == Tuple{Int}
-@test Core.Compiler.typesubtract(Tuple{Union{Int,Char}}, Tuple{Char}, 2) == Tuple{Int}
-@test Core.Compiler.typesubtract(NTuple{3, Union{Int, Char}}, Tuple{Char, Any, Any}, 0) ==
+@test Compiler.typesubtract(Tuple{Union{Int,Char}}, Tuple{Char}, 0) == Tuple{Int}
+@test Compiler.typesubtract(Tuple{Union{Int,Char}}, Tuple{Char}, 1) == Tuple{Int}
+@test Compiler.typesubtract(Tuple{Union{Int,Char}}, Tuple{Char}, 2) == Tuple{Int}
+@test Compiler.typesubtract(NTuple{3, Union{Int, Char}}, Tuple{Char, Any, Any}, 0) ==
         Tuple{Int, Union{Char, Int}, Union{Char, Int}}
-@test Core.Compiler.typesubtract(NTuple{3, Union{Int, Char}}, Tuple{Char, Any, Any}, 10) ==
+@test Compiler.typesubtract(NTuple{3, Union{Int, Char}}, Tuple{Char, Any, Any}, 10) ==
         Union{Tuple{Int, Char, Char}, Tuple{Int, Char, Int}, Tuple{Int, Int, Char}, Tuple{Int, Int, Int}}
-@test Core.Compiler.typesubtract(NTuple{3, Union{Int, Char}}, NTuple{3, Char}, 0) ==
+@test Compiler.typesubtract(NTuple{3, Union{Int, Char}}, NTuple{3, Char}, 0) ==
         NTuple{3, Union{Int, Char}}
-@test Core.Compiler.typesubtract(NTuple{3, Union{Int, Char}}, NTuple{3, Char}, 10) ==
+@test Compiler.typesubtract(NTuple{3, Union{Int, Char}}, NTuple{3, Char}, 10) ==
         Union{Tuple{Char, Char, Int}, Tuple{Char, Int, Char}, Tuple{Char, Int, Int}, Tuple{Int, Char, Char},
               Tuple{Int, Char, Int}, Tuple{Int, Int, Char}, Tuple{Int, Int, Int}}
 # Test that these don't throw
-@test Core.Compiler.typesubtract(Tuple{Vararg{Int}}, Tuple{Vararg{Char}}, 0) == Tuple{Vararg{Int}}
-@test Core.Compiler.typesubtract(Tuple{Vararg{Int}}, Tuple{Vararg{Int}}, 0) == Union{}
-@test Core.Compiler.typesubtract(Tuple{String,Int}, Tuple{String,Vararg{Int}}, 0) == Union{}
-@test Core.Compiler.typesubtract(Tuple{String,Vararg{Int}}, Tuple{String,Int}, 0) == Tuple{String,Vararg{Int}}
-@test Core.Compiler.typesubtract(NTuple{3, Real}, NTuple{3, Char}, 0) == NTuple{3, Real}
-@test Core.Compiler.typesubtract(NTuple{3, Union{Real, Char}}, NTuple{2, Char}, 0) == NTuple{3, Union{Real, Char}}
+@test Compiler.typesubtract(Tuple{Vararg{Int}}, Tuple{Vararg{Char}}, 0) == Tuple{Vararg{Int}}
+@test Compiler.typesubtract(Tuple{Vararg{Int}}, Tuple{Vararg{Int}}, 0) == Union{}
+@test Compiler.typesubtract(Tuple{String,Int}, Tuple{String,Vararg{Int}}, 0) == Union{}
+@test Compiler.typesubtract(Tuple{String,Vararg{Int}}, Tuple{String,Int}, 0) == Tuple{String,Vararg{Int}}
+@test Compiler.typesubtract(NTuple{3, Real}, NTuple{3, Char}, 0) == NTuple{3, Real}
+@test Compiler.typesubtract(NTuple{3, Union{Real, Char}}, NTuple{2, Char}, 0) == NTuple{3, Union{Real, Char}}
 
-@test Core.Compiler.compatible_vatuple(Tuple{String,Vararg{Int}}, Tuple{String,Vararg{Int}})
-@test !Core.Compiler.compatible_vatuple(Tuple{String,Int}, Tuple{String,Vararg{Int}})
-@test !Core.Compiler.compatible_vatuple(Tuple{String,Vararg{Int}}, Tuple{String,Int})
+@test Compiler.compatible_vatuple(Tuple{String,Vararg{Int}}, Tuple{String,Vararg{Int}})
+@test !Compiler.compatible_vatuple(Tuple{String,Int}, Tuple{String,Vararg{Int}})
+@test !Compiler.compatible_vatuple(Tuple{String,Vararg{Int}}, Tuple{String,Int})
 
 @test Base.return_types(Issue35566.f) == [Val{:expected}]
 
@@ -3808,8 +3806,8 @@ f_generator_splat(t::Tuple) = tuple((identity(l) for l in t)...)
 
 # Issue #36710 - sizeof(::UnionAll) tfunc correctness
 @test (sizeof(Ptr),) == sizeof.((Ptr,)) == sizeof.((Ptr{Cvoid},))
-@test Core.Compiler.sizeof_tfunc(Core.Compiler.fallback_lattice, UnionAll) === Int
-@test !Core.Compiler.sizeof_nothrow(UnionAll)
+@test Compiler.sizeof_tfunc(Compiler.fallback_lattice, UnionAll) === Int
+@test !Compiler.sizeof_nothrow(UnionAll)
 
 @test only(Base.return_types(Core._expr)) === Expr
 @test only(Base.return_types(Core.svec, (Any,))) === Core.SimpleVector
@@ -3878,9 +3876,9 @@ f_apply_cglobal(args...) = cglobal(args...)
 @test only(Base.return_types(f_apply_cglobal, Tuple{Any, Type{Int}, Type{Int}, Vararg{Type{Int}}})) == Union{}
 
 # issue #37532
-@test Core.Compiler.intrinsic_nothrow(Core.bitcast, Any[Type{Ptr{Int}}, Int])
-@test Core.Compiler.intrinsic_nothrow(Core.bitcast, Any[Type{Ptr{T}} where T, Ptr])
-@test !Core.Compiler.intrinsic_nothrow(Core.bitcast, Any[Type{Ptr}, Ptr])
+@test Compiler.intrinsic_nothrow(Core.bitcast, Any[Type{Ptr{Int}}, Int])
+@test Compiler.intrinsic_nothrow(Core.bitcast, Any[Type{Ptr{T}} where T, Ptr])
+@test !Compiler.intrinsic_nothrow(Core.bitcast, Any[Type{Ptr}, Ptr])
 f37532(T, x) = (Core.bitcast(Ptr{T}, x); x)
 @test Base.return_types(f37532, Tuple{Any, Int}) == Any[Int]
 
@@ -3924,16 +3922,16 @@ Base.@constprop :aggressive @noinline f_constprop_aggressive_noinline(f, x) = (f
 Base.@constprop :none f_constprop_none(f, x) = (f(x); Val{x}())
 Base.@constprop :none @inline f_constprop_none_inline(f, x) = (f(x); Val{x}())
 
-@test !Core.Compiler.is_aggressive_constprop(only(methods(f_constprop_simple)))
-@test !Core.Compiler.is_no_constprop(only(methods(f_constprop_simple)))
-@test Core.Compiler.is_aggressive_constprop(only(methods(f_constprop_aggressive)))
-@test !Core.Compiler.is_no_constprop(only(methods(f_constprop_aggressive)))
-@test Core.Compiler.is_aggressive_constprop(only(methods(f_constprop_aggressive_noinline)))
-@test !Core.Compiler.is_no_constprop(only(methods(f_constprop_aggressive_noinline)))
-@test !Core.Compiler.is_aggressive_constprop(only(methods(f_constprop_none)))
-@test Core.Compiler.is_no_constprop(only(methods(f_constprop_none)))
-@test !Core.Compiler.is_aggressive_constprop(only(methods(f_constprop_none_inline)))
-@test Core.Compiler.is_no_constprop(only(methods(f_constprop_none_inline)))
+@test !Compiler.is_aggressive_constprop(only(methods(f_constprop_simple)))
+@test !Compiler.is_no_constprop(only(methods(f_constprop_simple)))
+@test Compiler.is_aggressive_constprop(only(methods(f_constprop_aggressive)))
+@test !Compiler.is_no_constprop(only(methods(f_constprop_aggressive)))
+@test Compiler.is_aggressive_constprop(only(methods(f_constprop_aggressive_noinline)))
+@test !Compiler.is_no_constprop(only(methods(f_constprop_aggressive_noinline)))
+@test !Compiler.is_aggressive_constprop(only(methods(f_constprop_none)))
+@test Compiler.is_no_constprop(only(methods(f_constprop_none)))
+@test !Compiler.is_aggressive_constprop(only(methods(f_constprop_none_inline)))
+@test Compiler.is_no_constprop(only(methods(f_constprop_none_inline)))
 
 # make sure that improvements to the compiler don't render the annotation effectless.
 @test Base.return_types((Function,)) do f
@@ -3989,12 +3987,12 @@ end
 @testset "switchtupleunion" begin
     # signature tuple
     let
-        tunion = Core.Compiler.switchtupleunion(Tuple{Union{Int32,Int64}, Nothing})
+        tunion = Compiler.switchtupleunion(Tuple{Union{Int32,Int64}, Nothing})
         @test Tuple{Int32, Nothing} in tunion
         @test Tuple{Int64, Nothing} in tunion
     end
     let
-        tunion = Core.Compiler.switchtupleunion(Tuple{Union{Int32,Int64}, Union{Float32,Float64}, Nothing})
+        tunion = Compiler.switchtupleunion(Tuple{Union{Int32,Int64}, Union{Float32,Float64}, Nothing})
         @test Tuple{Int32, Float32, Nothing} in tunion
         @test Tuple{Int32, Float64, Nothing} in tunion
         @test Tuple{Int64, Float32, Nothing} in tunion
@@ -4003,13 +4001,13 @@ end
 
     # argtypes
     let
-        tunion = Core.Compiler.switchtupleunion(Core.Compiler.ConstsLattice(), Any[Union{Int32,Int64}, Core.Const(nothing)])
+        tunion = Compiler.switchtupleunion(Compiler.ConstsLattice(), Any[Union{Int32,Int64}, Core.Const(nothing)])
         @test length(tunion) == 2
         @test Any[Int32, Core.Const(nothing)] in tunion
         @test Any[Int64, Core.Const(nothing)] in tunion
     end
     let
-        tunion = Core.Compiler.switchtupleunion(Core.Compiler.ConstsLattice(), Any[Union{Int32,Int64}, Union{Float32,Float64}, Core.Const(nothing)])
+        tunion = Compiler.switchtupleunion(Compiler.ConstsLattice(), Any[Union{Int32,Int64}, Union{Float32,Float64}, Core.Const(nothing)])
         @test length(tunion) == 4
         @test Any[Int32, Float32, Core.Const(nothing)] in tunion
         @test Any[Int32, Float64, Core.Const(nothing)] in tunion
@@ -4118,10 +4116,10 @@ callsig_backprop_bailout(::Val) = 2
 callsig_backprop_addinteger(a::Integer, b::Integer) = a + b # results in too many matching methods and triggers `bail_out_call`)
 @test Base.infer_return_type(callsig_backprop_addinteger) == Any
 let effects = Base.infer_effects(callsig_backprop_addinteger)
-    @test !Core.Compiler.is_consistent(effects)
-    @test !Core.Compiler.is_effect_free(effects)
-    @test !Core.Compiler.is_nothrow(effects)
-    @test !Core.Compiler.is_terminates(effects)
+    @test !Compiler.is_consistent(effects)
+    @test !Compiler.is_effect_free(effects)
+    @test !Compiler.is_nothrow(effects)
+    @test !Compiler.is_terminates(effects)
 end
 callsig_backprop_anti(::Any) = :any
 callsig_backprop_anti(::Int) = :int
@@ -4249,16 +4247,16 @@ end
 let # Test the presence of PhiNodes in lowered IR by taking the above function,
     # running it through SSA conversion and then putting it into an opaque
     # closure.
-    mi = Core.Compiler.specialize_method(first(methods(f_convert_me_to_ir)),
+    mi = Compiler.specialize_method(first(methods(f_convert_me_to_ir)),
         Tuple{Bool, Float64}, Core.svec())
     ci = Base.uncompressed_ast(mi.def)
     ci.slottypes = Any[ Any for i = 1:length(ci.slotflags) ]
     ci.ssavaluetypes = Any[Any for i = 1:ci.ssavaluetypes]
-    sv = Core.Compiler.OptimizationState(mi, Core.Compiler.NativeInterpreter())
-    ir = Core.Compiler.convert_to_ircode(ci, sv)
-    ir = Core.Compiler.slot2reg(ir, ci, sv)
-    ir = Core.Compiler.compact!(ir)
-    Core.Compiler.replace_code_newstyle!(ci, ir)
+    sv = Compiler.OptimizationState(mi, Compiler.NativeInterpreter())
+    ir = Compiler.convert_to_ircode(ci, sv)
+    ir = Compiler.slot2reg(ir, ci, sv)
+    ir = Compiler.compact!(ir)
+    Compiler.replace_code_newstyle!(ci, ir)
     ci.ssavaluetypes = length(ci.ssavaluetypes)
     @test any(x->isa(x, Core.PhiNode), ci.code)
     oc = @eval b->$(Expr(:new_opaque_closure, Tuple{Bool, Float64}, Any, Any, true,
@@ -4436,7 +4434,7 @@ let x = Tuple{Int,Any}[
         #=19=# (0, Expr(:pop_exception, Core.SSAValue(2)))
         #=20=# (0, Core.ReturnNode(Core.SlotNumber(3)))
     ]
-    (;handler_at, handlers) = Core.Compiler.compute_trycatch(last.(x))
+    (;handler_at, handlers) = Compiler.compute_trycatch(last.(x))
     @test map(x->x[1] == 0 ? 0 : handlers[x[1]].enter_idx, handler_at) == first.(x)
 end
 
@@ -4486,7 +4484,7 @@ let
                # Vararg
         #=va=# Bound, unbound,         # => Tuple{Integer,Integer} (invalid `TypeVar` widened beforehand)
         } where Bound<:Integer
-    argtypes = Core.Compiler.most_general_argtypes(method, specTypes)
+    argtypes = Compiler.most_general_argtypes(method, specTypes)
     popfirst!(argtypes)
     # N.B.: `argtypes` do not have va processing applied yet
     @test length(argtypes) == 12
@@ -4556,7 +4554,7 @@ end |> only == Tuple{Int,Int}
 end |> only == Int
 
 # form PartialStruct for mutables with `const` field
-import Core.Compiler: Const, ⊑
+import .Compiler: Const, ⊑
 mutable struct PartialMutable{S,T}
     const s::S
     t::T
@@ -4633,9 +4631,9 @@ end
 
 # issue #43784
 @testset "issue #43784" begin
-    ⊑ = Core.Compiler.partialorder(Core.Compiler.fallback_lattice)
-    ⊔ = Core.Compiler.join(Core.Compiler.fallback_lattice)
-    𝕃 = Core.Compiler.fallback_lattice
+    ⊑ = Compiler.partialorder(Compiler.fallback_lattice)
+    ⊔ = Compiler.join(Compiler.fallback_lattice)
+    𝕃 = Compiler.fallback_lattice
     Const, PartialStruct = Core.Const, Core.PartialStruct
     let init = Base.ImmutableDict{Any,Any}()
         a = Const(init)
@@ -4717,32 +4715,32 @@ end
         end |> only === Union{}
 
     a = Val{Union{}}
-    a = Core.Compiler.tmerge(Union{a, Val{a}}, a)
+    a = Compiler.tmerge(Union{a, Val{a}}, a)
     @test a == Union{Val{Union{}}, Val{Val{Union{}}}}
-    a = Core.Compiler.tmerge(Union{a, Val{a}}, a)
+    a = Compiler.tmerge(Union{a, Val{a}}, a)
     @test a == Union{Val{Union{}}, Val{Val{Union{}}}, Val{Union{Val{Union{}}, Val{Val{Union{}}}}}}
-    a = Core.Compiler.tmerge(Union{a, Val{a}}, a)
+    a = Compiler.tmerge(Union{a, Val{a}}, a)
     @test a == Val
 
     a = Val{Union{}}
-    a = Core.Compiler.tmerge(Core.Compiler.JLTypeLattice(), Val{<:a}, a)
+    a = Compiler.tmerge(Compiler.JLTypeLattice(), Val{<:a}, a)
     @test_broken a != Val{<:Val{Union{}}}
     @test_broken a == Val{<:Val} || a == Val
 
     a = Tuple{Vararg{Tuple{}}}
-    a = Core.Compiler.tmerge(Core.Compiler.JLTypeLattice(), Tuple{a}, a)
+    a = Compiler.tmerge(Compiler.JLTypeLattice(), Tuple{a}, a)
     @test a == Union{Tuple{Tuple{Vararg{Tuple{}}}}, Tuple{Vararg{Tuple{}}}}
-    a = Core.Compiler.tmerge(Core.Compiler.JLTypeLattice(), Tuple{a}, a)
+    a = Compiler.tmerge(Compiler.JLTypeLattice(), Tuple{a}, a)
     @test a == Tuple{Vararg{Union{Tuple{Tuple{Vararg{Tuple{}}}}, Tuple{Vararg{Tuple{}}}}}}
-    a = Core.Compiler.tmerge(Core.Compiler.JLTypeLattice(), Tuple{a}, a)
+    a = Compiler.tmerge(Compiler.JLTypeLattice(), Tuple{a}, a)
     @test a == Tuple
-    a = Core.Compiler.tmerge(Core.Compiler.JLTypeLattice(), Tuple{a}, a)
+    a = Compiler.tmerge(Compiler.JLTypeLattice(), Tuple{a}, a)
     @test a == Tuple
 end
 
-let ⊑ = Core.Compiler.partialorder(Core.Compiler.fallback_lattice)
-    ⊔ = Core.Compiler.join(Core.Compiler.fallback_lattice)
-    𝕃 = Core.Compiler.fallback_lattice
+let ⊑ = Compiler.partialorder(Compiler.fallback_lattice)
+    ⊔ = Compiler.join(Compiler.fallback_lattice)
+    𝕃 = Compiler.fallback_lattice
     Const, PartialStruct = Core.Const, Core.PartialStruct
 
     @test  (Const((1,2)) ⊑ PartialStruct(𝕃, Tuple{Int,Int}, Any[Const(1),Int]))
@@ -4789,18 +4787,18 @@ end
 # at top level.
 @test let
     Base.Experimental.@force_compile
-    Core.Compiler.return_type(+, NTuple{2, Rational})
+    Compiler.return_type(+, NTuple{2, Rational})
 end == Rational
 
 # vararg-tuple comparison within `Compiler.PartialStruct`
 # https://github.com/JuliaLang/julia/issues/44965
-let 𝕃ᵢ = Core.Compiler.fallback_lattice
-    t = Core.Compiler.tuple_tfunc(𝕃ᵢ, Any[Const(42), Vararg{Any}])
-    @test Core.Compiler.issimplertype(𝕃ᵢ, t, t)
+let 𝕃ᵢ = Compiler.fallback_lattice
+    t = Compiler.tuple_tfunc(𝕃ᵢ, Any[Const(42), Vararg{Any}])
+    @test Compiler.issimplertype(𝕃ᵢ, t, t)
 
-    t = Core.Compiler.tuple_tfunc(𝕃ᵢ, Any[Const(42), Vararg{Union{}}])
+    t = Compiler.tuple_tfunc(𝕃ᵢ, Any[Const(42), Vararg{Union{}}])
     @test t === Const((42,))
-    t = Core.Compiler.tuple_tfunc(𝕃ᵢ, Any[Const(42), Int, Vararg{Union{}}])
+    t = Compiler.tuple_tfunc(𝕃ᵢ, Any[Const(42), Int, Vararg{Union{}}])
     @test t.typ === Tuple{Int, Int}
     @test t.fields == Any[Const(42), Int]
 end
@@ -4900,7 +4898,7 @@ let src = code_typed1() do
 end
 
 # Test that Const ⊑ PartialStruct respects vararg
-@test Const((1,2)) ⊑ PartialStruct(Core.Compiler.fallback_lattice, Tuple{Vararg{Int}}, [Const(1), Vararg{Int}])
+@test Const((1,2)) ⊑ PartialStruct(Compiler.fallback_lattice, Tuple{Vararg{Int}}, [Const(1), Vararg{Int}])
 
 # Test that semi-concrete interpretation doesn't break on functions with while loops in them.
 Base.@assume_effects :consistent :effect_free :terminates_globally function pure_annotated_loop(x::Int, y::Int)
@@ -4926,7 +4924,7 @@ invoke_concretized1(a::Integer) = a > 0 ? "integer" : nothing
 # check if `invoke(invoke_concretized1, Tuple{Integer}, ::Int)` is foldable
 @test Base.infer_effects((Int,)) do a
     @invoke invoke_concretized1(a::Integer)
-end |> Core.Compiler.is_foldable
+end |> Compiler.is_foldable
 @test Base.return_types() do
     @invoke invoke_concretized1(42::Integer)
 end |> only === String
@@ -4936,7 +4934,7 @@ invoke_concretized2(a::Integer) = a > 0 ? :integer : nothing
 # check if `invoke(invoke_concretized2, Tuple{Integer}, ::Int)` is foldable
 @test Base.infer_effects((Int,)) do a
     @invoke invoke_concretized2(a::Integer)
-end |> Core.Compiler.is_foldable
+end |> Compiler.is_foldable
 @test let
     Base.Experimental.@force_compile
     @invoke invoke_concretized2(42::Integer)
@@ -5015,15 +5013,13 @@ g() = empty_nt_values(Base.inferencebarrier(Tuple{}))
 # is to test the case where inference limited a recursion, but then a forced constprop nevertheless managed
 # to terminate the call.
 @newinterp RecurseInterpreter
-let CC = Core.Compiler
-    function CC.const_prop_rettype_heuristic(interp::RecurseInterpreter, result::CC.MethodCallResult,
-                                             si::CC.StmtInfo, sv::CC.AbsIntState, force::Bool)
-        if result.rt isa CC.LimitedAccuracy
-            return force # allow forced constprop to recurse into unresolved cycles
-        end
-        return @invoke CC.const_prop_rettype_heuristic(interp::CC.AbstractInterpreter, result::CC.MethodCallResult,
-                                                       si::CC.StmtInfo, sv::CC.AbsIntState, force::Bool)
+function Compiler.const_prop_rettype_heuristic(interp::RecurseInterpreter, result::Compiler.MethodCallResult,
+                                            si::Compiler.StmtInfo, sv::Compiler.AbsIntState, force::Bool)
+    if result.rt isa Compiler.LimitedAccuracy
+        return force # allow forced constprop to recurse into unresolved cycles
     end
+    return @invoke Compiler.const_prop_rettype_heuristic(interp::Compiler.AbstractInterpreter, result::Compiler.MethodCallResult,
+                                                    si::Compiler.StmtInfo, sv::Compiler.AbsIntState, force::Bool)
 end
 Base.@constprop :aggressive type_level_recurse1(x...) = x[1] == 2 ? 1 : (length(x) > 100 ? x : type_level_recurse2(x[1] + 1, x..., x...))
 Base.@constprop :aggressive type_level_recurse2(x...) = type_level_recurse1(x...)
@@ -5035,23 +5031,10 @@ type_level_recurse_entry() = Val{type_level_recurse1(1)}()
 f_no_bail_effects_any(x::Any) = x
 f_no_bail_effects_any(x::NamedTuple{(:x,), Tuple{Any}}) = getfield(x, 1)
 g_no_bail_effects_any(x::Any) = f_no_bail_effects_any(x)
-@test Core.Compiler.is_foldable_nothrow(Base.infer_effects(g_no_bail_effects_any, Tuple{Any}))
+@test Compiler.is_foldable_nothrow(Base.infer_effects(g_no_bail_effects_any, Tuple{Any}))
 
 # issue #48374
 @test (() -> Union{<:Nothing})() == Nothing
-
-# :static_parameter accuracy
-unknown_sparam_throw(::Union{Nothing, Type{T}}) where T = @isdefined(T) ? T::Type : nothing
-unknown_sparam_nothrow1(x::Ref{T}) where T = @isdefined(T) ? T::Type : nothing
-unknown_sparam_nothrow2(x::Ref{Ref{T}}) where T = @isdefined(T) ? T::Type : nothing
-@test only(Base.return_types(unknown_sparam_throw, (Type{Int},))) == Type{Int}
-@test only(Base.return_types(unknown_sparam_throw, (Type{<:Integer},))) == Type{<:Integer}
-@test only(Base.return_types(unknown_sparam_throw, (Type,))) == Union{Nothing, Type}
-@test_broken only(Base.return_types(unknown_sparam_throw, (Nothing,))) === Nothing
-@test_broken only(Base.return_types(unknown_sparam_throw, (Union{Type{Int},Nothing},))) === Union{Nothing,Type{Int}}
-@test only(Base.return_types(unknown_sparam_throw, (Any,))) === Union{Nothing,Type}
-@test only(Base.return_types(unknown_sparam_nothrow1, (Ref,))) === Type
-@test only(Base.return_types(unknown_sparam_nothrow2, (Ref{Ref{T}} where T,))) === Type
 
 struct Issue49027{Ty<:Number}
     x::Ty
@@ -5200,9 +5183,9 @@ end |> only === Tuple{Int,Symbol}
     end
 end) == Type{Nothing}
 
-# Test that Core.Compiler.return_type inference works for the 1-arg version
+# Test that Compiler.return_type inference works for the 1-arg version
 @test Base.return_types() do
-    Core.Compiler.return_type(Tuple{typeof(+), Int, Int})
+    Compiler.return_type(Tuple{typeof(+), Int, Int})
 end |> only == Type{Int}
 
 # Test that NamedTuple abstract iteration works for PartialStruct/Const
@@ -5252,13 +5235,13 @@ let src = code_typed1((Bool,Base.RefValue{String}, Base.RefValue{Any},Int,)) do 
 end
 
 struct Issue49785{S, T<:S} end
-let 𝕃 = Core.Compiler.SimpleInferenceLattice.instance
-    argtypes = Any[Core.Compiler.Const(Issue49785),
+let 𝕃 = Compiler.SimpleInferenceLattice.instance
+    argtypes = Any[Compiler.Const(Issue49785),
         Union{Type{String},Type{Int}},
         Union{Type{String},Type{Int}}]
     rt = Type{Issue49785{<:Any, Int}}
     # the following should not throw
-    @test !Core.Compiler.apply_type_nothrow(𝕃, argtypes, rt)
+    @test !Compiler.apply_type_nothrow(𝕃, argtypes, rt)
     @test code_typed() do
         S = Union{Type{String},Type{Int}}[Int][1]
         map(T -> Issue49785{S,T}, (a = S,))
@@ -5715,7 +5698,7 @@ let x = 1, _Any = Any
 end
 
 # Issue #51927
-let 𝕃 = Core.Compiler.fallback_lattice
+let 𝕃 = Compiler.fallback_lattice
     @test apply_type_tfunc(𝕃, Const(Tuple{Vararg{Any,N}} where N), Int) == Type{NTuple{_A, Any}} where _A
 end
 
@@ -5738,7 +5721,7 @@ end
 @eval function has_tuin()
     $(Expr(:throw_undef_if_not, :x, false))
 end
-@test Core.Compiler.return_type(has_tuin, Tuple{}) === Union{}
+@test Compiler.return_type(has_tuin, Tuple{}) === Union{}
 @test_throws UndefVarError has_tuin()
 
 function gen_tuin_from_arg(world::UInt, source, _, _)
@@ -5793,7 +5776,7 @@ end
 
 # We want to make sure that both this returns `Tuple` and that
 # it doesn't infinite loop inside inference.
-@test Core.Compiler.return_type(gen_infinite_loop_ssa, Tuple{}) === Tuple
+@test Compiler.return_type(gen_infinite_loop_ssa, Tuple{}) === Tuple
 
 # inference local cache lookup with extended lattice elements that may be transformed
 # by `matching_cache_argtypes`
@@ -5829,7 +5812,7 @@ function foo54341(a, b, c, d, args...)
 end
 bar54341(args...) = foo54341(4, args...)
 
-@test Core.Compiler.return_type(bar54341, Tuple{Vararg{Int}}) === Int
+@test Compiler.return_type(bar54341, Tuple{Vararg{Int}}) === Int
 
 # `PartialStruct` for partially initialized structs:
 struct PartiallyInitialized1
@@ -5883,47 +5866,47 @@ end == Val
 # 2. getfield modeling for partial struct
 @test Base.infer_effects((Any,Any); optimize=false) do a, b
     getfield(PartiallyInitialized1(a, b), :b)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((Any,Any,Symbol,); optimize=false) do a, b, f
     getfield(PartiallyInitialized1(a, b), f, #=boundscheck=#false)
-end |> !Core.Compiler.is_nothrow
+end |> !Compiler.is_nothrow
 @test Base.infer_effects((Any,Any,Any); optimize=false) do a, b, c
     getfield(PartiallyInitialized1(a, b, c), :c)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((Any,Any,Any,Symbol); optimize=false) do a, b, c, f
     getfield(PartiallyInitialized1(a, b, c), f, #=boundscheck=#false)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((Any,Any); optimize=false) do a, b
     getfield(PartiallyInitialized2(a, b), :b)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((Any,Any,Symbol,); optimize=false) do a, b, f
     getfield(PartiallyInitialized2(a, b), f, #=boundscheck=#false)
-end |> !Core.Compiler.is_nothrow
+end |> !Compiler.is_nothrow
 @test Base.infer_effects((Any,Any,Any); optimize=false) do a, b, c
     getfield(PartiallyInitialized2(a, b, c), :c)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((Any,Any,Any,Symbol); optimize=false) do a, b, c, f
     getfield(PartiallyInitialized2(a, b, c), f, #=boundscheck=#false)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 
 # isdefined-Conditionals
 @test Base.infer_effects((Base.RefValue{Any},)) do x
     if isdefined(x, :x)
         return getfield(x, :x)
     end
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((Base.RefValue{Any},)) do x
     if isassigned(x)
         return x[]
     end
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((Any,Any); optimize=false) do a, c
     x = PartiallyInitialized2(a)
     x.c = c
     if isdefined(x, :c)
         return x.b
     end
-end |> !Core.Compiler.is_nothrow
+end |> !Compiler.is_nothrow
 @test Base.infer_effects((PartiallyInitialized2,); optimize=false) do x
     if isdefined(x, :b)
         if isdefined(x, :c)
@@ -5932,14 +5915,14 @@ end |> !Core.Compiler.is_nothrow
         return x.b
     end
     return nothing
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((Bool,Int,); optimize=false) do c, b
     x = c ? PartiallyInitialized1(true) : PartiallyInitialized1(true, b)
     if isdefined(x, :b)
         return Val(x.a), x.b
     end
     return nothing
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 
 # refine `undef` information from `@isdefined` check
 function isdefined_nothrow(c, x)
@@ -5952,7 +5935,7 @@ function isdefined_nothrow(c, x)
     end
     return zero(Int)
 end
-@test Core.Compiler.is_nothrow(Base.infer_effects(isdefined_nothrow, (Bool,Int)))
+@test Compiler.is_nothrow(Base.infer_effects(isdefined_nothrow, (Bool,Int)))
 @test !any(first(only(code_typed(isdefined_nothrow, (Bool,Int)))).code) do @nospecialize x
     Meta.isexpr(x, :throw_undef_if_not)
 end
@@ -5966,7 +5949,7 @@ end
 # InterConditional rt with Vararg argtypes
 fcondvarargs(a, b, c, d) = isa(d, Int64)
 gcondvarargs(a, x...) = return fcondvarargs(a, x...) ? isa(a, Int64) : !isa(a, Int64)
-@test Core.Compiler.return_type(gcondvarargs, Tuple{Vararg{Any}}) === Bool
+@test Compiler.return_type(gcondvarargs, Tuple{Vararg{Any}}) === Bool
 
 # JuliaLang/julia#55627: argtypes check in `abstract_call_opaque_closure`
 issue55627_make_oc() = Base.Experimental.@opaque (x::Int) -> 2x
@@ -6002,13 +5985,13 @@ f_invoke_nothrow(::Number) = :number
 f_invoke_nothrow(::Int) = :int
 @test Base.infer_effects((Int,)) do x
     @invoke f_invoke_nothrow(x::Number)
-end |> Core.Compiler.is_nothrow
+end |> Compiler.is_nothrow
 @test Base.infer_effects((Char,)) do x
     @invoke f_invoke_nothrow(x::Number)
-end |> !Core.Compiler.is_nothrow
+end |> !Compiler.is_nothrow
 @test Base.infer_effects((Union{Nothing,Int},)) do x
     @invoke f_invoke_nothrow(x::Number)
-end |> !Core.Compiler.is_nothrow
+end |> !Compiler.is_nothrow
 
 # `exct` modeling for `invoke` calls
 f_invoke_exct(x::Number) = x < 0 ? throw(x) : x
@@ -6042,7 +6025,7 @@ end
 
 t155751 = Union{AbstractArray{UInt8, 4}, Array{Float32, 4}, Grid55751{Float32, 3, _A} where _A}
 t255751 = Array{Float32, 3}
-@test Core.Compiler.tmerge_types_slow(t155751,t255751) == AbstractArray # shouldn't hang
+@test Compiler.tmerge_types_slow(t155751,t255751) == AbstractArray # shouldn't hang
 
 issue55882_nfields(x::Union{T,Nothing}) where T<:Number = nfields(x)
 @test Base.infer_return_type(issue55882_nfields) <: Int

--- a/Compiler/test/interpreter_exec.jl
+++ b/Compiler/test/interpreter_exec.jl
@@ -4,6 +4,14 @@
 using Test
 using Core.IR
 
+if !@isdefined(Compiler)
+    if Base.identify_package("Compiler") === nothing
+        import Base.Compiler: Compiler
+    else
+        import Compiler
+    end
+end
+
 # test that interpreter correctly handles PhiNodes (#29262)
 let m = Meta.@lower 1 + 1
     @assert Meta.isexpr(m, :thunk)
@@ -23,7 +31,7 @@ let m = Meta.@lower 1 + 1
     src.ssavaluetypes = nstmts
     src.ssaflags = fill(UInt8(0x00), nstmts)
     src.debuginfo = Core.DebugInfo(:none)
-    Core.Compiler.verify_ir(Core.Compiler.inflate_ir(src))
+    Compiler.verify_ir(Compiler.inflate_ir(src))
     global test29262 = true
     @test :a === @eval $m
     global test29262 = false
@@ -64,7 +72,7 @@ let m = Meta.@lower 1 + 1
     src.ssaflags = fill(UInt8(0x00), nstmts)
     src.debuginfo = Core.DebugInfo(:none)
     m.args[1] = copy(src)
-    Core.Compiler.verify_ir(Core.Compiler.inflate_ir(src))
+    Compiler.verify_ir(Compiler.inflate_ir(src))
     global test29262 = true
     @test (:b, :a, :c, :c) === @eval $m
     m.args[1] = copy(src)
@@ -103,7 +111,7 @@ let m = Meta.@lower 1 + 1
     src.ssavaluetypes = nstmts
     src.ssaflags = fill(UInt8(0x00), nstmts)
     src.debuginfo = Core.DebugInfo(:none)
-    Core.Compiler.verify_ir(Core.Compiler.inflate_ir(src))
+    Compiler.verify_ir(Compiler.inflate_ir(src))
     global test29262 = true
     @test :a === @eval $m
     global test29262 = false

--- a/Compiler/test/invalidation.jl
+++ b/Compiler/test/invalidation.jl
@@ -6,29 +6,28 @@
 include("irutils.jl")
 
 using Test
-const CC = Core.Compiler
 
 struct InvalidationTesterToken end
 
-struct InvalidationTester <: CC.AbstractInterpreter
+struct InvalidationTester <: Compiler.AbstractInterpreter
     world::UInt
-    inf_params::CC.InferenceParams
-    opt_params::CC.OptimizationParams
-    inf_cache::Vector{CC.InferenceResult}
+    inf_params::Compiler.InferenceParams
+    opt_params::Compiler.OptimizationParams
+    inf_cache::Vector{Compiler.InferenceResult}
     function InvalidationTester(;
                                 world::UInt = Base.get_world_counter(),
-                                inf_params::CC.InferenceParams = CC.InferenceParams(),
-                                opt_params::CC.OptimizationParams = CC.OptimizationParams(),
-                                inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[])
+                                inf_params::Compiler.InferenceParams = Compiler.InferenceParams(),
+                                opt_params::Compiler.OptimizationParams = Compiler.OptimizationParams(),
+                                inf_cache::Vector{Compiler.InferenceResult} = Compiler.InferenceResult[])
         return new(world, inf_params, opt_params, inf_cache)
     end
 end
 
-CC.InferenceParams(interp::InvalidationTester) = interp.inf_params
-CC.OptimizationParams(interp::InvalidationTester) = interp.opt_params
-CC.get_inference_world(interp::InvalidationTester) = interp.world
-CC.get_inference_cache(interp::InvalidationTester) = interp.inf_cache
-CC.cache_owner(::InvalidationTester) = InvalidationTesterToken()
+Compiler.InferenceParams(interp::InvalidationTester) = interp.inf_params
+Compiler.OptimizationParams(interp::InvalidationTester) = interp.opt_params
+Compiler.get_inference_world(interp::InvalidationTester) = interp.world
+Compiler.get_inference_cache(interp::InvalidationTester) = interp.inf_cache
+Compiler.cache_owner(::InvalidationTester) = InvalidationTesterToken()
 
 # basic functionality test
 # ------------------------
@@ -105,7 +104,7 @@ begin
     let rt = only(Base.return_types(pr48932_callee, (Any,)))
         @test rt === Any
         effects = Base.infer_effects(pr48932_callee, (Any,))
-        @test Core.Compiler.Effects(effects) == Core.Compiler.Effects()
+        @test Compiler.Effects(effects) == Compiler.Effects()
     end
 
     # run inference on both `pr48932_caller` and `pr48932_callee`
@@ -172,7 +171,7 @@ begin take!(GLOBAL_BUFFER)
     let rt = only(Base.return_types(pr48932_callee_inferable, (Any,)))
         @test rt === Int
         effects = Base.infer_effects(pr48932_callee_inferable, (Any,))
-        @test Core.Compiler.Effects(effects) == Core.Compiler.Effects()
+        @test Compiler.Effects(effects) == Compiler.Effects()
     end
 
     # run inference on both `pr48932_caller` and `pr48932_callee`:
@@ -234,7 +233,7 @@ begin take!(GLOBAL_BUFFER)
     let rt = only(Base.return_types(pr48932_callee_inlined, (Any,)))
         @test rt === Any
         effects = Base.infer_effects(pr48932_callee_inlined, (Any,))
-        @test Core.Compiler.Effects(effects) == Core.Compiler.Effects()
+        @test Compiler.Effects(effects) == Compiler.Effects()
     end
 
     # run inference on `pr48932_caller_inlined` and `pr48932_callee_inlined`

--- a/Compiler/test/irutils.jl
+++ b/Compiler/test/irutils.jl
@@ -1,11 +1,19 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+if !@isdefined(Compiler)
+    if Base.identify_package("Compiler") === nothing
+        import Base.Compiler: Compiler
+    else
+        import Compiler
+    end
+end
+
 using Core.IR
-using Core.Compiler: IRCode, IncrementalCompact, singleton_type, VarState
+using .Compiler: IRCode, IncrementalCompact, singleton_type, VarState
 using Base.Meta: isexpr
 using InteractiveUtils: gen_call_with_extracted_types_and_kwargs
 
-argextype(@nospecialize args...) = Core.Compiler.argextype(args..., VarState[])
+argextype(@nospecialize args...) = Compiler.argextype(args..., VarState[])
 code_typed1(args...; kwargs...) = first(only(code_typed(args...; kwargs...)))::CodeInfo
 macro code_typed1(ex0...)
     return gen_call_with_extracted_types_and_kwargs(__module__, :code_typed1, ex0)
@@ -91,11 +99,11 @@ let m = Meta.@lower 1 + 1
                                 kwargs...)
         src = make_codeinfo(code; slottypes, kwargs...)
         if slottypes !== nothing
-            ir = Core.Compiler.inflate_ir(src, slottypes)
+            ir = Compiler.inflate_ir(src, slottypes)
         else
-            ir = Core.Compiler.inflate_ir(src)
+            ir = Compiler.inflate_ir(src)
         end
-        verify && Core.Compiler.verify_ir(ir)
+        verify && Compiler.verify_ir(ir)
         return ir
     end
 end

--- a/Compiler/test/runtests.jl
+++ b/Compiler/test/runtests.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 using Test, Compiler
-using InteractiveUtils
+using InteractiveUtils: @activate
 @activate Compiler
 
 for file in readlines(joinpath(@__DIR__, "testgroups"))

--- a/Compiler/test/runtests.jl
+++ b/Compiler/test/runtests.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 using Test, Compiler
+using InteractiveUtils
+@activate Compiler
 
 for file in readlines(joinpath(@__DIR__, "testgroups"))
     file == "special_loading" && continue # Only applicable to Base.Compiler

--- a/Compiler/test/tarjan.jl
+++ b/Compiler/test/tarjan.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Core.Compiler: CFGReachability, DomTree, CFG, BasicBlock, StmtRange, dominates,
-                     bb_unreachable, kill_edge!
+include("irutils.jl")
 
-const CC = Core.Compiler
+using .Compiler: CFGReachability, DomTree, CFG, BasicBlock, StmtRange, dominates,
+                     bb_unreachable, kill_edge!
 
 function reachable(g::CFG, a::Int, b::Int; domtree=nothing)
     visited = BitVector(false for _ = 1:length(g.blocks))
@@ -83,7 +83,7 @@ function test_reachability(V, E; deletions = 2E ÷ 3, all_checks=false)
 
         if all_checks # checks for internal data structures - O(E^2)
 
-            # Nodes should be mutually reachable iff they are in the same SCC.
+            # Nodes should be mutually reachable iff they are in the same SCompiler.
             scc = reachability.scc
             reachable_nodes = BitSet(v for v = 1:V if !bb_unreachable(reachability, v))
             for i ∈ reachable_nodes
@@ -96,13 +96,13 @@ function test_reachability(V, E; deletions = 2E ÷ 3, all_checks=false)
             irreducible = reachability.irreducible
             for i ∈ reachable_nodes
                 in_nontrivial_scc = any(v != i && scc[v] == scc[i] for v = 1:V)
-                @test CC.getindex(irreducible, i) == in_nontrivial_scc
+                @test Compiler.getindex(irreducible, i) == in_nontrivial_scc
             end
         end
     end
 
     cfg = rand_cfg(V, E)
-    domtree = Core.Compiler.construct_domtree(cfg)
+    domtree = Compiler.construct_domtree(cfg)
     reachability = CFGReachability(cfg, domtree)
     check_reachability(reachability, cfg, domtree, all_checks)
 

--- a/Compiler/test/validation.jl
+++ b/Compiler/test/validation.jl
@@ -2,6 +2,14 @@
 
 using Test, Core.IR
 
+if !@isdefined(Compiler)
+    if Base.identify_package("Compiler") === nothing
+        import Base.Compiler: Compiler
+    else
+        import Compiler
+    end
+end
+
 function f22938(a, b, x...)
     nothing
     nothing
@@ -21,17 +29,17 @@ end
 msig = Tuple{typeof(f22938),Int,Int,Int,Int}
 world = Base.get_world_counter()
 match = only(Base._methods_by_ftype(msig, -1, world))
-mi = Core.Compiler.specialize_method(match)
-c0 = Core.Compiler.retrieve_code_info(mi, world)
+mi = Compiler.specialize_method(match)
+c0 = Compiler.retrieve_code_info(mi, world)
 
-@test isempty(Core.Compiler.validate_code(mi, c0))
+@test isempty(Compiler.validate_code(mi, c0))
 
 @testset "INVALID_EXPR_HEAD" begin
     c = copy(c0)
     c.code[1] = Expr(:invalid, 1)
-    errors = Core.Compiler.validate_code(c)
+    errors = Compiler.validate_code(c)
     @test length(errors) == 1
-    @test errors[1].kind === Core.Compiler.INVALID_EXPR_HEAD
+    @test errors[1].kind === Compiler.INVALID_EXPR_HEAD
 end
 
 @testset "INVALID_LVALUE" begin
@@ -39,9 +47,9 @@ end
     c.code[1] = Expr(:(=), GotoNode(1), 1)
     c.code[2] = Expr(:(=), :x, 1)
     c.code[3] = Expr(:(=), 3, 1)
-    errors = Core.Compiler.validate_code(c)
+    errors = Compiler.validate_code(c)
     @test length(errors) == 3
-    @test all(e.kind === Core.Compiler.INVALID_LVALUE for e in errors)
+    @test all(e.kind === Compiler.INVALID_LVALUE for e in errors)
 end
 
 @testset "INVALID_RVALUE" begin
@@ -52,9 +60,9 @@ end
     for h in (:line, :const, :meta)
         c.code[i+=1] = Expr(:(=), SlotNumber(2), Expr(h))
     end
-    errors = Core.Compiler.validate_code(c)
+    errors = Compiler.validate_code(c)
     @test length(errors) == 5
-    @test count(e.kind === Core.Compiler.INVALID_RVALUE for e in errors) == 5
+    @test count(e.kind === Compiler.INVALID_RVALUE for e in errors) == 5
 end
 
 @testset "INVALID_CALL_ARG" begin
@@ -66,74 +74,74 @@ end
     for h in (:line, :const, :meta)
         c.code[i+=1] = Expr(:call, GlobalRef(@__MODULE__,:f), Expr(h))
     end
-    errors = Core.Compiler.validate_code(c)
+    errors = Compiler.validate_code(c)
     @test length(errors) == 6
-    @test count(e.kind === Core.Compiler.INVALID_CALL_ARG for e in errors) == 6
+    @test count(e.kind === Compiler.INVALID_CALL_ARG for e in errors) == 6
 end
 
 @testset "EMPTY_SLOTNAMES" begin
     c = copy(c0)
     empty!(c.slotnames)
-    errors = Core.Compiler.validate_code(c)
+    errors = Compiler.validate_code(c)
     @test length(errors) == 2
-    @test any(e.kind === Core.Compiler.EMPTY_SLOTNAMES for e in errors)
-    @test any(e.kind === Core.Compiler.SLOTFLAGS_MISMATCH for e in errors)
+    @test any(e.kind === Compiler.EMPTY_SLOTNAMES for e in errors)
+    @test any(e.kind === Compiler.SLOTFLAGS_MISMATCH for e in errors)
 end
 
 @testset "SLOTFLAGS_MISMATCH" begin
     c = copy(c0)
     push!(c.slotflags, 0x00)
-    errors = Core.Compiler.validate_code(c)
+    errors = Compiler.validate_code(c)
     @test length(errors) == 1
-    @test errors[1].kind === Core.Compiler.SLOTFLAGS_MISMATCH
+    @test errors[1].kind === Compiler.SLOTFLAGS_MISMATCH
 end
 
 @testset "SSAVALUETYPES_MISMATCH" begin
     c = code_typed(f22938, (Int,Int,Int,Int))[1][1]
     empty!(c.ssavaluetypes)
-    errors = Core.Compiler.validate_code(c)
+    errors = Compiler.validate_code(c)
     @test length(errors) == 1
-    @test errors[1].kind === Core.Compiler.SSAVALUETYPES_MISMATCH
+    @test errors[1].kind === Compiler.SSAVALUETYPES_MISMATCH
 end
 
 @testset "SSAVALUETYPES_MISMATCH_UNINFERRED" begin
     c = copy(c0)
     c.ssavaluetypes -= 1
-    errors = Core.Compiler.validate_code(c)
+    errors = Compiler.validate_code(c)
     @test length(errors) == 1
-    @test errors[1].kind === Core.Compiler.SSAVALUETYPES_MISMATCH_UNINFERRED
+    @test errors[1].kind === Compiler.SSAVALUETYPES_MISMATCH_UNINFERRED
 end
 
 @testset "SSAFLAGS_MISMATCH" begin
     c = copy(c0)
     empty!(c.ssaflags)
-    errors = Core.Compiler.validate_code(c)
+    errors = Compiler.validate_code(c)
     @test length(errors) == 1
-    @test errors[1].kind === Core.Compiler.SSAFLAGS_MISMATCH
+    @test errors[1].kind === Compiler.SSAFLAGS_MISMATCH
 end
 
 @testset "SIGNATURE_NARGS_MISMATCH" begin
     old_sig = mi.def.sig
     mi.def.sig = Tuple{1,2}
-    errors = Core.Compiler.validate_code(mi, nothing)
+    errors = Compiler.validate_code(mi, nothing)
     mi.def.sig = old_sig
     @test length(errors) == 1
-    @test errors[1].kind === Core.Compiler.SIGNATURE_NARGS_MISMATCH
+    @test errors[1].kind === Compiler.SIGNATURE_NARGS_MISMATCH
 end
 
 @testset "NON_TOP_LEVEL_METHOD" begin
     c = copy(c0)
     c.code[1] = Expr(:method, :dummy)
-    errors = Core.Compiler.validate_code(c)
+    errors = Compiler.validate_code(c)
     @test length(errors) == 1
-    @test errors[1].kind === Core.Compiler.NON_TOP_LEVEL_METHOD
+    @test errors[1].kind === Compiler.NON_TOP_LEVEL_METHOD
 end
 
 @testset "SLOTNAMES_NARGS_MISMATCH" begin
     mi.def.nargs += 20
-    errors = Core.Compiler.validate_code(mi, c0)
+    errors = Compiler.validate_code(mi, c0)
     mi.def.nargs -= 20
     @test length(errors) == 2
-    @test count(e.kind === Core.Compiler.SLOTNAMES_NARGS_MISMATCH for e in errors) == 1
-    @test count(e.kind === Core.Compiler.SIGNATURE_NARGS_MISMATCH for e in errors) == 1
+    @test count(e.kind === Compiler.SLOTNAMES_NARGS_MISMATCH for e in errors) == 1
+    @test count(e.kind === Compiler.SIGNATURE_NARGS_MISMATCH for e in errors) == 1
 end

--- a/test/precompile_absint1.jl
+++ b/test/precompile_absint1.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Test
+import Base.Compiler: Compiler
 
 include("precompile_utils.jl")
 
@@ -15,6 +16,7 @@ precompile_test_harness() do load_path
         import SimpleModule: basic_caller, basic_callee
 
         module Custom
+            import Base.Compiler: Compiler
             include($newinterp_path)
             @newinterp PrecompileInterpreter
         end
@@ -36,7 +38,7 @@ precompile_test_harness() do load_path
 
     @eval let
         using TestAbsIntPrecompile1
-        cache_owner = Core.Compiler.cache_owner(
+        cache_owner = Compiler.cache_owner(
             TestAbsIntPrecompile1.Custom.PrecompileInterpreter())
         let m = only(methods(TestAbsIntPrecompile1.basic_callee))
             mi = only(Base.specializations(m))

--- a/test/precompile_absint2.jl
+++ b/test/precompile_absint2.jl
@@ -15,30 +15,30 @@ precompile_test_harness() do load_path
         import SimpleModule: basic_caller, basic_callee
 
         module Custom
-            const CC = Core.Compiler
+            import Base.Compiler: Compiler
             include($newinterp_path)
             @newinterp PrecompileInterpreter
             struct CustomData
                 inferred
                 CustomData(@nospecialize inferred) = new(inferred)
             end
-            function CC.transform_result_for_cache(interp::PrecompileInterpreter, result::CC.InferenceResult)
-                inferred_result = @invoke CC.transform_result_for_cache(
-                    interp::CC.AbstractInterpreter, result::CC.InferenceResult)
+            function Compiler.transform_result_for_cache(interp::PrecompileInterpreter, result::Compiler.InferenceResult)
+                inferred_result = @invoke Compiler.transform_result_for_cache(
+                    interp::Compiler.AbstractInterpreter, result::Compiler.InferenceResult)
                 return CustomData(inferred_result)
             end
-            function CC.src_inlining_policy(interp::PrecompileInterpreter, @nospecialize(src),
-                                            @nospecialize(info::CC.CallInfo), stmt_flag::UInt32)
+            function Compiler.src_inlining_policy(interp::PrecompileInterpreter, @nospecialize(src),
+                                            @nospecialize(info::Compiler.CallInfo), stmt_flag::UInt32)
                 if src isa CustomData
                     src = src.inferred
                 end
-                return @invoke CC.src_inlining_policy(interp::CC.AbstractInterpreter, src::Any,
-                                                      info::CC.CallInfo, stmt_flag::UInt32)
+                return @invoke Compiler.src_inlining_policy(interp::Compiler.AbstractInterpreter, src::Any,
+                                                      info::Compiler.CallInfo, stmt_flag::UInt32)
             end
-            CC.retrieve_ir_for_inlining(cached_result::Core.CodeInstance, src::CustomData) =
-                CC.retrieve_ir_for_inlining(cached_result, src.inferred)
-            CC.retrieve_ir_for_inlining(mi::Core.MethodInstance, src::CustomData, preserve_local_sources::Bool) =
-                CC.retrieve_ir_for_inlining(mi, src.inferred, preserve_local_sources)
+            Compiler.retrieve_ir_for_inlining(cached_result::Core.CodeInstance, src::CustomData) =
+                Compiler.retrieve_ir_for_inlining(cached_result, src.inferred)
+            Compiler.retrieve_ir_for_inlining(mi::Core.MethodInstance, src::CustomData, preserve_local_sources::Bool) =
+                Compiler.retrieve_ir_for_inlining(mi, src.inferred, preserve_local_sources)
         end
 
         Base.return_types((Float64,)) do x


### PR DESCRIPTION
Makes `test Compiler` work properly (as in use the Compiler package, not Base.Compiler) and pass tests, but still needs to be made parallel in a follow-on.