### PR TITLE
Default GDB Listener to on when running under RR

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -10417,6 +10417,8 @@ extern "C" void jl_init_llvm(void)
     // Register GDB event listener
 #if defined(JL_DEBUG_BUILD)
     jl_using_gdb_jitevents = true;
+#else
+    jl_using_gdb_jitevents = jl_running_under_rr(0);
 #endif
     const char *jit_gdb = getenv("ENABLE_GDBLISTENER");
     if (jit_gdb) {

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -183,6 +183,7 @@
     XX(jl_gc_sync_total_bytes) \
     XX(jl_gc_total_hrtime) \
     XX(jl_gdblookup) \
+    XX(jl_running_under_rr) \
     XX(jl_generating_output) \
     XX(jl_declare_const_gf) \
     XX(jl_gensym) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -192,7 +192,7 @@ void JL_UV_LOCK(void);
 extern _Atomic(unsigned) _threadedregion;
 extern _Atomic(uint16_t) io_loop_tid;
 
-int jl_running_under_rr(int recheck) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_running_under_rr(int recheck) JL_NOTSAFEPOINT;
 
 //--------------------------------------------------
 // timers

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -137,7 +137,7 @@ void jl_init_thread_scheduler(jl_ptls_t ptls) JL_NOTSAFEPOINT
     // since we are being initialized from foreign code, we could not necessarily have expected or predicted that to happen
 }
 
-int jl_running_under_rr(int recheck)
+JL_DLLEXPORT int jl_running_under_rr(int recheck)
 {
 #ifdef _OS_LINUX_
 #define RR_CALL_BASE 1000


### PR DESCRIPTION
We already default to on for the GDB event listener when running a debug build,
but it is likely (and beneficial) that the user will want the GDB listner, even on a release build
if they are recording Julia. Setting `ENABLE_GDBLISTENER=0` will still disable it.
