### PR TITLE
only import REPL in runtests if we are actually going to use it

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,9 @@
 using Test
 using Distributed
 using Dates
-import REPL
+if !Sys.iswindows() && isa(stdin, Base.TTY)
+    import REPL
+end
 using Printf: @sprintf
 using Base: Experimental
 


### PR DESCRIPTION
External stdlibs that want to use this might not want to have to load REPL etc.

REPL is used in https://github.com/JuliaLang/julia/blob/4709b6c48e79f6226e6dbee1b49bf7e563058ff7/test/runtests.jl#L215.