### PR TITLE
separate module context for Compiler.jl tests

### DIFF
--- a/Compiler/test/AbstractInterpreter.jl
+++ b/Compiler/test/AbstractInterpreter.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module test_AbstractInterpreter
+
 using Test
 
 include("irutils.jl")
@@ -534,3 +536,5 @@ let interp = DebugInterp()
     end
     @test found
 end
+
+end # module test_AbstractInterpreter

--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -2,6 +2,8 @@
 
 # tests for codegen and optimizations
 
+module test_codegen
+
 using Random
 using InteractiveUtils
 using Libdl
@@ -1027,3 +1029,5 @@ for a in ((@noinline Ref{Int}(2)),
         @test ex === a
     end
 end
+
+end # test_codegen

--- a/Compiler/test/compact.jl
+++ b/Compiler/test/compact.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module test_compact
+
 using Test
 
 include("irutils.jl")
@@ -55,3 +57,5 @@ end
     verify_ir(new_ir)
     @test length(new_ir.cfg.blocks) == 1
 end
+
+end # module test_compact

--- a/Compiler/test/contextual.jl
+++ b/Compiler/test/contextual.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module test_contextual
+
 # N.B.: This file is also run from interpreter.jl, so needs to be standalone-executable
 using Test
 include("setup_Compiler.jl")
@@ -124,3 +126,5 @@ f() = 2
 foo(i) = i+bar(Val(1))
 
 @test @inferred(overdub(Ctx(), foo, 1)) == 43
+
+end # module test_contextual

--- a/Compiler/test/datastructures.jl
+++ b/Compiler/test/datastructures.jl
@@ -1,5 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module test_datastructures
+
+using Test
+
 include("setup_Compiler.jl")
 
 @testset "CachedMethodTable" begin
@@ -113,3 +117,5 @@ end
         end
     end
 end
+
+end # module test_datastructures

--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module test_effects
+
 using Test
 include("irutils.jl")
 
@@ -1384,3 +1386,5 @@ end |> Compiler.is_nothrow
 @test Base.infer_effects() do
     @ccall unsafecall()::Cvoid
 end == Compiler.EFFECTS_UNKNOWN
+
+end # module test_effects

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module test_inference
+
 using Test
 
 include("irutils.jl")
@@ -6126,3 +6128,5 @@ function func_swapglobal!_must_throw(x)
 end
 @test Base.infer_return_type(func_swapglobal!_must_throw, (Int,); interp=SwapGlobalInterp()) === Union{}
 @test !Compiler.is_effect_free(Base.infer_effects(func_swapglobal!_must_throw, (Int,); interp=SwapGlobalInterp()) )
+
+end # test_inference

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module test_inline
+
 using Test
 using Base.Meta
 using Core: ReturnNode
@@ -2309,3 +2311,5 @@ g_noinline_invoke(x) = f_noinline_invoke(x)
 let src = code_typed1(g_noinline_invoke, (Union{Symbol,Nothing},))
     @test !any(@nospecialize(x)->isa(x,GlobalRef), src.code)
 end
+
+end # module test_inline

--- a/Compiler/test/invalidation.jl
+++ b/Compiler/test/invalidation.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module test_invalidation
+
 # setup
 # -----
 
@@ -283,3 +285,5 @@ begin take!(GLOBAL_BUFFER)
     @test isnothing(pr48932_caller_inlined(42))
     @test "42" == String(take!(GLOBAL_BUFFER))
 end
+
+end # module test_invalidation

--- a/Compiler/test/irpasses.jl
+++ b/Compiler/test/irpasses.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module test_irpasses
+
 using Test
 using Base.Meta
 using Core.IR
@@ -1996,3 +1998,5 @@ let code = Any[
     ir = Compiler.domsort_ssa!(ir, domtree)
     Compiler.verify_ir(ir)
 end
+
+end # module test_irpasses

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module test_ssair
+
 include("irutils.jl")
 
 using Test
@@ -818,3 +820,5 @@ let cl = Int32[32, 1, 1, 1000, 240, 230]
     cl2 = ccall(:jl_uncompress_codelocs, Any, (Any, Int), str, 2)
     @test cl == cl2
 end
+
+end # module test_ssair

--- a/Compiler/test/tarjan.jl
+++ b/Compiler/test/tarjan.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module test_tarjan
+
 using Test
 
 include("irutils.jl")
@@ -167,3 +169,5 @@ end
     test_reachability(100, 150; all_checks=false)
     test_reachability(100, 1000; all_checks=false)
 end
+
+end # module test_tarjan

--- a/Compiler/test/validation.jl
+++ b/Compiler/test/validation.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module test_validation
+
 using Test, Core.IR
 
 include("setup_Compiler.jl")
@@ -139,3 +141,5 @@ end
     @test count(e.kind === Compiler.SLOTNAMES_NARGS_MISMATCH for e in errors) == 1
     @test count(e.kind === Compiler.SIGNATURE_NARGS_MISMATCH for e in errors) == 1
 end
+
+end # module test_validation


### PR DESCRIPTION
xref: <https://github.com/JuliaLang/julia/pull/56632#pullrequestreview-2451230479>

This also allows us to execute each file standalone, which might be useful for debugging.