### PR TITLE
inference: add missing tfuncs to the `xxxglobal` builtins

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -2469,8 +2469,6 @@ function getfield_effects(𝕃::AbstractLattice, argtypes::Vector{Any}, @nospeci
     return Effects(EFFECTS_TOTAL; consistent, nothrow, inaccessiblememonly, noub)
 end
 
-
-
 """
     builtin_effects(𝕃::AbstractLattice, f::Builtin, argtypes::Vector{Any}, rt) -> Effects
 
@@ -3064,6 +3062,14 @@ end
     ⊑ = partialorder(𝕃)
     return M ⊑ Module && s ⊑ Symbol
 end
+
+add_tfunc(getglobal, 2, 3, @nospecs((𝕃::AbstractLattice, args...)->Any), 1)
+add_tfunc(setglobal!, 3, 4, @nospecs((𝕃::AbstractLattice, args...)->Any), 3)
+add_tfunc(swapglobal!, 3, 4, @nospecs((𝕃::AbstractLattice, args...)->Any), 3)
+add_tfunc(modifyglobal!, 4, 5, @nospecs((𝕃::AbstractLattice, args...)->Any), 3)
+add_tfunc(replaceglobal!, 4, 6, @nospecs((𝕃::AbstractLattice, args...)->Any), 3)
+add_tfunc(setglobalonce!, 3, 5, @nospecs((𝕃::AbstractLattice, args...)->Bool), 3)
+add_tfunc(Core.get_binding_type, 2, 2, @nospecs((𝕃::AbstractLattice, args...)->Type), 0)
 
 # foreigncall
 # ===========


### PR DESCRIPTION
These builtins are now special-cased within `abstract_call_known` after JuliaLang/julia#56299, making them unnecessary for basic inference. As a result, their tfuncs have been removed in the PR. However the algorithm for calculating inlining costs still looks up these tfuncs, so they need to be recovered. Additionally, the `generate_builtins.jl` script in JuliaInterpreter also uses these tfuncs, so it would be worthwhile to register even simple placeholder tfuncs for now.

@nanosoldier `runbenchmarks("inference", vs=":master")`