### PR TITLE
Fix `contrib/juliac.jl`: enable `--experimental` option if `--trim` option is passed to juliac.jl

### DIFF
--- a/contrib/juliac.jl
+++ b/contrib/juliac.jl
@@ -79,7 +79,7 @@ open(initsrc_path, "w") do io
               """)
 end
 
-static_call_graph_arg() = isnothing(trim) ?  `` : `--trim=$(trim)`
+static_call_graph_arg() = isnothing(trim) ?  `` : `--experimental --trim=$(trim)`
 cmd = addenv(`$cmd --project=$(Base.active_project()) --output-o $img_path --output-incremental=no --strip-ir --strip-metadata $(static_call_graph_arg()) $(joinpath(@__DIR__,"juliac-buildscript.jl")) $absfile $output_type $add_ccallables`, "OPENBLAS_NUM_THREADS" => 1, "JULIA_NUM_THREADS" => 1)
 verbose && println("Running: $cmd")
 if !success(pipeline(cmd; stdout, stderr))


### PR DESCRIPTION
This PR fixes the `static_call_graph_arg` function in `contrib/juliac.jl`. If we use `--trim` option, we must use it with `--experimental` flag.

https://github.com/JuliaLang/julia/blob/522f496994d374afe4e38db31cbb6543cda144ef/src/jloptions.c#L989