### PR TITLE
Highlight circular references

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -443,7 +443,7 @@ function show_circular(io::IOContext, @nospecialize(x))
     for (k, v) in io.dict
         if k === :SHOWN_SET
             if v === x
-                print(io, "#= circular reference @-$d =#")
+                printstyled(io, "#= circular reference @-$d =#"; color = :yellow)
                 return true
             end
             d += 1

--- a/test/show.jl
+++ b/test/show.jl
@@ -1275,6 +1275,7 @@ let x = [], y = [], z = Base.ImmutableDict(x => y)
     push!(y, x)
     push!(y, z)
     @test replstr(x) == "1-element Vector{Any}:\n Any[Any[#= circular reference @-2 =#], Base.ImmutableDict{Vector{Any}, Vector{Any}}([#= circular reference @-3 =#] => [#= circular reference @-2 =#])]"
+    @test replstr(x, :color => true) == "1-element Vector{Any}:\n Any[Any[\e[33m#= circular reference @-2 =#\e[39m], Base.ImmutableDict{Vector{Any}, Vector{Any}}([\e[33m#= circular reference @-3 =#\e[39m] => [\e[33m#= circular reference @-2 =#\e[39m])]"
     @test repr(z) == "Base.ImmutableDict{Vector{Any}, Vector{Any}}([Any[Any[#= circular reference @-2 =#], Base.ImmutableDict{Vector{Any}, Vector{Any}}(#= circular reference @-3 =#)]] => [Any[Any[#= circular reference @-2 =#]], Base.ImmutableDict{Vector{Any}, Vector{Any}}(#= circular reference @-2 =#)])"
     @test sprint(dump, x) == """
         Array{Any}((1,))


### PR DESCRIPTION
The text `"#= circular reference @-$d =#"` is printed yellow. Adds a test with the context `:color => true`.

A [straw poll on Slack](https://julialang.slack.com/archives/C67910KEH/p1732394439260099) suggests this is an improvement, with ~~16~~ ~~18~~ 23 in favor (including myself) and ~~6~~ 8 opposed as of the time of writing.

### Before

![before](https://github.com/user-attachments/assets/5d8944a1-727c-4c20-a6ec-4ac157795a5a)

### After

![after](https://github.com/user-attachments/assets/171ae3bf-0bc1-46b3-9f72-3a63dae7e712)
