### PR TITLE
Prevent pre-compilation package from triggering its own extensions

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1220,6 +1220,40 @@ end
             @test occursin("Hello x-package ext-to-ext!", String(read(cmd)))
         end
 
+        # Extensions for "parent" dependencies
+        # (i.e. an `ExtAB`  where A depends on / loads B, but B provides the extension)
+
+        mktempdir() do depot # Parallel pre-compilation
+            code = """
+            Base.disable_parallel_precompile = false
+            using Parent
+            Base.get_extension(getfield(Parent, :DepWithParentExt), :ParentExt) isa Module || error("expected extension to load")
+            Parent.greet()
+            """
+            proj = joinpath(@__DIR__, "project", "Extensions", "Parent.jl")
+            cmd =  `$(Base.julia_cmd()) --startup-file=no -e $code`
+            cmd = addenv(cmd,
+                "JULIA_LOAD_PATH" => proj,
+                "JULIA_DEPOT_PATH" => depot * Base.Filesystem.pathsep(),
+            )
+            @test occursin("Hello parent!", String(read(cmd)))
+        end
+        mktempdir() do depot # Serial pre-compilation
+            code = """
+            Base.disable_parallel_precompile = true
+            using Parent
+            Base.get_extension(getfield(Parent, :DepWithParentExt), :ParentExt) isa Module || error("expected extension to load")
+            Parent.greet()
+            """
+            proj = joinpath(@__DIR__, "project", "Extensions", "Parent.jl")
+            cmd =  `$(Base.julia_cmd()) --startup-file=no -e $code`
+            cmd = addenv(cmd,
+                "JULIA_LOAD_PATH" => proj,
+                "JULIA_DEPOT_PATH" => depot * Base.Filesystem.pathsep(),
+            )
+            @test occursin("Hello parent!", String(read(cmd)))
+        end
+
     finally
         try
             rm(depot_path, force=true, recursive=true)

--- a/test/project/Extensions/DepWithParentExt.jl/Project.toml
+++ b/test/project/Extensions/DepWithParentExt.jl/Project.toml
@@ -1,0 +1,9 @@
+name = "DepWithParentExt"
+uuid = "8a35c396-5ffc-40d2-b7ec-e8ed2248da32"
+version = "0.1.0"
+
+[weakdeps]
+Parent = "58cecb9c-f68a-426e-b92a-89d456ae7acc"
+
+[extensions]
+ParentExt = "Parent"

--- a/test/project/Extensions/DepWithParentExt.jl/ext/ParentExt.jl
+++ b/test/project/Extensions/DepWithParentExt.jl/ext/ParentExt.jl
@@ -1,0 +1,6 @@
+module ParentExt
+
+using Parent
+using DepWithParentExt
+
+end

--- a/test/project/Extensions/DepWithParentExt.jl/src/DepWithParentExt.jl
+++ b/test/project/Extensions/DepWithParentExt.jl/src/DepWithParentExt.jl
@@ -1,0 +1,5 @@
+module DepWithParentExt
+
+greet() = print("Hello dep w/ ext for parent dep!")
+
+end # module DepWithParentExt

--- a/test/project/Extensions/Parent.jl/Manifest.toml
+++ b/test/project/Extensions/Parent.jl/Manifest.toml
@@ -1,0 +1,20 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.0-DEV"
+manifest_format = "2.0"
+project_hash = "b6ac643184d62cc94427c9aa665ff1fb63d66038"
+
+[[deps.DepWithParentExt]]
+path = "../DepWithParentExt.jl"
+uuid = "8a35c396-5ffc-40d2-b7ec-e8ed2248da32"
+version = "0.1.0"
+weakdeps = ["Parent"]
+
+    [deps.DepWithParentExt.extensions]
+    ParentExt = "Parent"
+
+[[deps.Parent]]
+deps = ["DepWithParentExt"]
+path = "."
+uuid = "58cecb9c-f68a-426e-b92a-89d456ae7acc"
+version = "0.1.0"

--- a/test/project/Extensions/Parent.jl/Project.toml
+++ b/test/project/Extensions/Parent.jl/Project.toml
@@ -1,0 +1,7 @@
+name = "Parent"
+uuid = "58cecb9c-f68a-426e-b92a-89d456ae7acc"
+version = "0.1.0"
+authors = ["Cody Tapscott <topolarity@tapscott.me>"]
+
+[deps]
+DepWithParentExt = "8a35c396-5ffc-40d2-b7ec-e8ed2248da32"

--- a/test/project/Extensions/Parent.jl/src/Parent.jl
+++ b/test/project/Extensions/Parent.jl/src/Parent.jl
@@ -1,0 +1,7 @@
+module Parent
+
+using DepWithParentExt
+
+greet() = print("Hello parent!")
+
+end # module Parent


### PR DESCRIPTION
It is possible for an extension `ExtAB` to be loadable by one of its triggers, e.g. if `A` loads `B`. However, this loading is not supposed to happen during pre-compilation of `A`.

Getting this wrong means disagreeing with the scheduled pre-compile jobs (`A` is not scheduled to depend on or generate a cache file for `ExtAB` but accidentally attempts both) and leads to confusing errors about missing cache files.

We used to cover up this bad behavior w/ an erroneous cycle warning (fixed by #55910), but now we need to be sure this works.
