### PR TITLE
Make a failed extension load throw an error during pre-compilation

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1585,12 +1585,13 @@ function run_extension_callbacks(extid::ExtensionId)
         true
     catch
         # Try to continue loading if loading an extension errors
-        errs = current_exceptions()
-        @error "Error during loading of extension $(extid.id.name) of $(extid.parentid.name), \
-                use `Base.retry_load_extensions()` to retry." exception=errs
         if JLOptions().incremental != 0
             # during incremental precompilation, this should be fail-fast
-            throw(PrecompilableError())
+            rethrow()
+        else
+            errs = current_exceptions()
+            @error "Error during loading of extension $(extid.id.name) of $(extid.parentid.name), \
+                use `Base.retry_load_extensions()` to retry." exception=errs
         end
         false
     finally

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1588,6 +1588,10 @@ function run_extension_callbacks(extid::ExtensionId)
         errs = current_exceptions()
         @error "Error during loading of extension $(extid.id.name) of $(extid.parentid.name), \
                 use `Base.retry_load_extensions()` to retry." exception=errs
+        if JLOptions().incremental != 0
+            # during incremental precompilation, this should be fail-fast
+            throw(PrecompilableError())
+        end
         false
     finally
         global loading_extension = false


### PR DESCRIPTION
Without this change the tests added in https://github.com/JuliaLang/julia/pull/56666 pass (even w/o that PR applied), because the failure to load `ExtAB` is just ignored.

I think we should tighten that up (w/o a backport, so that we don't break folks depending on this). The stab I've taken here might be the wrong approach since I'm not sure how it interacts with any locks, etc., but I wanted to get the ball rolling.