### PR TITLE
doc: fix docstring for `Dates.format`

### DIFF
--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -713,7 +713,7 @@ except that it does not truncate values longer than the width.
 When creating a `format` you can use any non-code characters as a separator. For example to
 generate the string "1996-01-15T00:00:00" you could use `format`: "yyyy-mm-ddTHH:MM:SS".
 Note that if you need to use a code character as a literal you can use the escape character
-backslash. The string "1996y01m" can be produced with the format "yyyy\\ymm\\m".
+backslash. The string "1996y01m" can be produced with the format raw"yyyy\\ymm\\m".
 """
 function format(dt::TimeType, f::AbstractString; locale::Locale=ENGLISH)
     format(dt, DateFormat(f, locale))


### PR DESCRIPTION
Close #35286

Current docstring:
```
julia> using Dates

help?> Dates.format

...

  as a literal you can use the escape character backslash. The string
  "1996y01m" can be produced with the format "yyyy\ymm\m".

julia>
```

```jl
julia> using Dates

julia> "yyyy\ymm\m"
ERROR: ParseError:
# Error @ REPL[36]:1:6
"yyyy\ymm\m"
#    └┘ ── invalid escape sequence
Stacktrace:
 [1] top-level scope
   @ REPL:1

julia> Dates.format(Dates.now(), raw"yyyy\ymm\m")
"2024y11m"

julia> Dates.format(Dates.now(), "yyyy\\ymm\\m")  # Another way
"2024y11m"
```
