### PR TITLE
optimizer: handle `EnterNode` with `catch_dest == 0`

### DIFF
--- a/Compiler/src/ssair/irinterp.jl
+++ b/Compiler/src/ssair/irinterp.jl
@@ -249,8 +249,10 @@ function process_terminator!(@nospecialize(stmt), bb::Int, bb_ip::BitSetBoundedM
         return backedge
     elseif isa(stmt, EnterNode)
         dest = stmt.catch_dest
-        @assert dest > bb
-        push!(bb_ip, dest)
+        if dest ≠ 0
+            @assert dest > bb
+            push!(bb_ip, dest)
+        end
         push!(bb_ip, bb+1)
         return false
     else

--- a/Compiler/src/ssair/passes.jl
+++ b/Compiler/src/ssair/passes.jl
@@ -2393,8 +2393,10 @@ function cfg_simplify!(ir::IRCode)
                     end
                 elseif isa(terminator, EnterNode)
                     catchbb = terminator.catch_dest
-                    if bb_rename_succ[catchbb] == 0
-                        push!(worklist, catchbb)
+                    if catchbb ≠ 0
+                        if bb_rename_succ[catchbb] == 0
+                            push!(worklist, catchbb)
+                        end
                     end
                 elseif isa(terminator, GotoNode) || isa(terminator, ReturnNode)
                     # No implicit fall through. Schedule from work list.


### PR DESCRIPTION
In some parts of the optimizer code, such as `cfg_simplify!` and irinterp, it is assumed that `EnterNode` always has `catch_dest ≠ 0`, but this assumption is incorrect. This commit fixes those cases.