### PR TITLE
perform inference using optimizer-derived type information

### DIFF
--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -825,6 +825,7 @@ mutable struct IRInterpretationState
     callstack #::Vector{AbsIntState}
     frameid::Int
     parentid::Int
+    new_call_inferred::Bool
 
     function IRInterpretationState(interp::AbstractInterpreter,
         spec_info::SpecInfo, ir::IRCode, mi::MethodInstance, argtypes::Vector{Any},
@@ -850,7 +851,7 @@ mutable struct IRInterpretationState
         edges = Any[]
         callstack = AbsIntState[]
         return new(spec_info, ir, mi, WorldWithRange(world, valid_worlds), curridx, argtypes_refined, ir.sptypes, tpdum,
-                ssa_refined, lazyreachability, tasks, edges, callstack, 0, 0)
+                ssa_refined, lazyreachability, tasks, edges, callstack, 0, 0, #=new_call_inferred=#false)
     end
 end
 

--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -143,16 +143,48 @@ struct InliningState{Interp<:AbstractInterpreter}
     edges::Vector{Any}
     world::UInt
     interp::Interp
+    opt_cache::IdDict{MethodInstance,CodeInstance}
 end
-function InliningState(sv::InferenceState, interp::AbstractInterpreter)
-    return InliningState(sv.edges, frame_world(sv), interp)
+function InliningState(sv::InferenceState, interp::AbstractInterpreter,
+                       opt_cache::IdDict{MethodInstance,CodeInstance}=IdDict{MethodInstance,CodeInstance}())
+    return InliningState(sv.edges, frame_world(sv), interp, opt_cache)
 end
-function InliningState(interp::AbstractInterpreter)
-    return InliningState(Any[], get_inference_world(interp), interp)
+function InliningState(interp::AbstractInterpreter,
+                       opt_cache::IdDict{MethodInstance,CodeInstance}=IdDict{MethodInstance,CodeInstance}())
+    return InliningState(Any[], get_inference_world(interp), interp, opt_cache)
+end
+
+struct OptimizerCache{CodeCache}
+    wvc::WorldView{CodeCache}
+    owner
+    opt_cache::IdDict{MethodInstance,CodeInstance}
+    function OptimizerCache(
+        wvc::WorldView{CodeCache},
+        owner,
+        opt_cache::IdDict{MethodInstance,CodeInstance}) where CodeCache
+        @nospecialize owner
+        new{CodeCache}(wvc, owner, opt_cache)
+    end
+end
+function get((; wvc, owner, opt_cache)::OptimizerCache, mi::MethodInstance, default)
+    if haskey(opt_cache, mi)
+        codeinst = opt_cache[mi]
+        if (codeinst.min_world ≤ wvc.worlds.min_world &&
+            wvc.worlds.max_world ≤ codeinst.max_world &&
+            codeinst.owner === owner)
+            @assert isdefined(codeinst, :inferred) && codeinst.inferred === nothing
+            return codeinst
+        end
+    end
+    return get(wvc, mi, default)
 end
 
 # get `code_cache(::AbstractInterpreter)` from `state::InliningState`
-code_cache(state::InliningState) = WorldView(code_cache(state.interp), state.world)
+function code_cache(state::InliningState)
+    cache = WorldView(code_cache(state.interp), state.world)
+    owner = cache_owner(state.interp)
+    return OptimizerCache(cache, owner, state.opt_cache)
+end
 
 mutable struct OptimizationState{Interp<:AbstractInterpreter}
     linfo::MethodInstance
@@ -168,13 +200,15 @@ mutable struct OptimizationState{Interp<:AbstractInterpreter}
     bb_vartables::Vector{Union{Nothing,VarTable}}
     insert_coverage::Bool
 end
-function OptimizationState(sv::InferenceState, interp::AbstractInterpreter)
-    inlining = InliningState(sv, interp)
+function OptimizationState(sv::InferenceState, interp::AbstractInterpreter,
+                           opt_cache::IdDict{MethodInstance,CodeInstance}=IdDict{MethodInstance,CodeInstance}())
+    inlining = InliningState(sv, interp, opt_cache)
     return OptimizationState(sv.linfo, sv.src, nothing, sv.stmt_info, sv.mod,
                              sv.sptypes, sv.slottypes, inlining, sv.cfg,
                              sv.unreachable, sv.bb_vartables, sv.insert_coverage)
 end
-function OptimizationState(mi::MethodInstance, src::CodeInfo, interp::AbstractInterpreter)
+function OptimizationState(mi::MethodInstance, src::CodeInfo, interp::AbstractInterpreter,
+                           opt_cache::IdDict{MethodInstance,CodeInstance}=IdDict{MethodInstance,CodeInstance}())
     # prepare src for running optimization passes if it isn't already
     nssavalues = src.ssavaluetypes
     if nssavalues isa Int
@@ -194,7 +228,7 @@ function OptimizationState(mi::MethodInstance, src::CodeInfo, interp::AbstractIn
     mod = isa(def, Method) ? def.module : def
     # Allow using the global MI cache, but don't track edges.
     # This method is mostly used for unit testing the optimizer
-    inlining = InliningState(interp)
+    inlining = InliningState(interp, opt_cache)
     cfg = compute_basic_blocks(src.code)
     unreachable = BitSet()
     bb_vartables = Union{VarTable,Nothing}[]

--- a/Compiler/src/ssair/EscapeAnalysis.jl
+++ b/Compiler/src/ssair/EscapeAnalysis.jl
@@ -24,10 +24,10 @@ using Base:       # Base definitions
     isempty, length, max, min, missing, println, push!, pushfirst!,
     !, !==, &, *, +, -, :, <, <<, >, |, ∈, ∉, ∩, ∪, ≠, ≤, ≥, ⊆
 using ..Compiler: # Compiler specific definitions
-    AbstractLattice, Compiler, IRCode, IR_FLAG_NOTHROW,
+    @show, AbstractLattice, Compiler, IRCode, IR_FLAG_NOTHROW,
     argextype, fieldcount_noerror, has_flag, intrinsic_nothrow, is_meta_expr_head,
     is_identity_free_argtype, isexpr, setfield!_nothrow, singleton_type, try_compute_field,
-    try_compute_fieldidx, widenconst
+    try_compute_fieldidx, widenconst, ⊑
 
 function include(x::String)
     if !isdefined(Base, :end_base_include)

--- a/Compiler/src/ssair/ir.jl
+++ b/Compiler/src/ssair/ir.jl
@@ -1709,7 +1709,8 @@ function reprocess_phi_node!(𝕃ₒ::AbstractLattice, compact::IncrementalCompa
 
     # There's only one predecessor left - just replace it
     v = phi.values[1]
-    if !⊑(𝕃ₒ, compact[compact.ssa_rename[old_idx]][:type], argextype(v, compact))
+    ⋤ = strictneqpartialorder(𝕃ₒ)
+    if argextype(v, compact) ⋤ compact[compact.ssa_rename[old_idx]][:type]
         v = Refined(v)
     end
     compact.ssa_rename[old_idx] = v

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -106,6 +106,7 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState)
     #@assert last(result.valid_worlds) <= get_world_counter() || isempty(caller.edges)
     if isdefined(result, :ci)
         ci = result.ci
+        mi = result.linfo
         # if we aren't cached, we don't need this edge
         # but our caller might, so let's just make it anyways
         if last(result.valid_worlds) >= get_world_counter()
@@ -132,7 +133,7 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState)
                 end
                 di = inferred_result.debuginfo
                 uncompressed = inferred_result
-                inferred_result = maybe_compress_codeinfo(interp, result.linfo, inferred_result)
+                inferred_result = maybe_compress_codeinfo(interp, mi, inferred_result)
                 result.is_src_volatile = false
             elseif ci.owner === nothing
                 # The global cache can only handle objects that codegen understands
@@ -140,7 +141,7 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState)
             end
         end
         if !@isdefined di
-            di = DebugInfo(result.linfo)
+            di = DebugInfo(mi)
         end
         min_world, max_world = first(result.valid_worlds), last(result.valid_worlds)
         ipo_effects = encode_effects(result.ipo_effects)
@@ -149,6 +150,9 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState)
             UInt32, Any, Any, Any),
             ci, inferred_result, rettype, exctype, rettype_const, const_flags, min_world, max_world,
             ipo_effects, result.analysis_results, di, edges)
+        if is_cached(caller) # CACHE_MODE_GLOBAL
+            cache_result!(interp, mi, ci)
+        end
         engine_reject(interp, ci)
         if !discard_src && isdefined(interp, :codegen) && uncompressed isa CodeInfo
             # record that the caller could use this result to generate code when required, if desired, to avoid repeating n^2 work
@@ -157,7 +161,6 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState)
                 # This is necessary to get decent bootstrapping performance
                 # when compiling the compiler to inject everything eagerly
                 # where codegen can start finding and using it right away
-                mi = result.linfo
                 if mi.def isa Method && isa_compileable_sig(mi)
                     ccall(:jl_add_codeinst_to_jit, Cvoid, (Any, Any), ci, uncompressed)
                 end
@@ -165,6 +168,10 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState)
         end
     end
     return nothing
+end
+
+function cache_result!(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInstance)
+    code_cache(interp)[mi] = ci
 end
 
 function finish!(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInstance, src::CodeInfo)
@@ -200,11 +207,13 @@ function finish!(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInstan
 end
 
 function finish_nocycle(::AbstractInterpreter, frame::InferenceState)
-    finishinfer!(frame, frame.interp)
+    opt_cache = IdDict{MethodInstance,CodeInstance}()
+    finishinfer!(frame, frame.interp, opt_cache)
     opt = frame.result.src
     if opt isa OptimizationState # implies `may_optimize(caller.interp) === true`
         optimize(frame.interp, opt, frame.result)
     end
+    empty!(opt_cache)
     finish!(frame.interp, frame)
     if frame.cycleid != 0
         frames = frame.callstack::Vector{AbsIntState}
@@ -227,10 +236,11 @@ function finish_cycle(::AbstractInterpreter, frames::Vector{AbsIntState}, cyclei
         cycle_valid_worlds = intersect(cycle_valid_worlds, caller.world.valid_worlds)
         cycle_valid_effects = merge_effects(cycle_valid_effects, caller.ipo_effects)
     end
+    opt_cache = IdDict{MethodInstance,CodeInstance}()
     for frameid = cycleid:length(frames)
         caller = frames[frameid]::InferenceState
         adjust_cycle_frame!(caller, cycle_valid_worlds, cycle_valid_effects)
-        finishinfer!(caller, caller.interp)
+        finishinfer!(caller, caller.interp, opt_cache)
     end
     for frameid = cycleid:length(frames)
         caller = frames[frameid]::InferenceState
@@ -239,6 +249,7 @@ function finish_cycle(::AbstractInterpreter, frames::Vector{AbsIntState}, cyclei
             optimize(caller.interp, opt, caller.result)
         end
     end
+    empty!(opt_cache)
     for frameid = cycleid:length(frames)
         caller = frames[frameid]::InferenceState
         finish!(caller.interp, caller)
@@ -283,22 +294,6 @@ function maybe_compress_codeinfo(interp::AbstractInterpreter, mi::MethodInstance
     else
         return nothing
     end
-end
-
-function cache_result!(interp::AbstractInterpreter, result::InferenceResult, ci::CodeInstance)
-    @assert isdefined(ci, :inferred)
-    # check if the existing linfo metadata is also sufficient to describe the current inference result
-    # to decide if it is worth caching this right now
-    mi = result.linfo
-    cache = WorldView(code_cache(interp), result.valid_worlds)
-    if haskey(cache, mi)
-        ci = cache[mi]
-        # n.b.: accurate edge representation might cause the CodeInstance for this to be constructed later
-        @assert isdefined(ci, :inferred)
-        return false
-    end
-    code_cache(interp)[mi] = ci
-    return true
 end
 
 function cycle_fix_limited(@nospecialize(typ), sv::InferenceState)
@@ -428,7 +423,8 @@ const empty_edges = Core.svec()
 
 # inference completed on `me`
 # update the MethodInstance
-function finishinfer!(me::InferenceState, interp::AbstractInterpreter)
+function finishinfer!(me::InferenceState, interp::AbstractInterpreter,
+                      opt_cache::IdDict{MethodInstance, CodeInstance})
     # prepare to run optimization passes on fulltree
     @assert isempty(me.ip)
     # inspect whether our inference had a limited result accuracy,
@@ -481,7 +477,7 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter)
                 # disable optimization if we've already obtained very accurate result
                 !result_is_constabi(interp, result)
         if doopt
-            result.src = OptimizationState(me, interp)
+            result.src = OptimizationState(me, interp, opt_cache)
         else
             result.src = me.src # for reflection etc.
         end
@@ -502,9 +498,11 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter)
             ci, rettype, exctype, rettype_const, const_flags, min_world, max_world,
             encode_effects(result.ipo_effects), result.analysis_results, di, edges)
         if is_cached(me) # CACHE_MODE_GLOBAL
-            cached_result = cache_result!(me.interp, result, ci)
-            if !cached_result
+            already_cached = is_already_cached(me.interp, result, ci)
+            if already_cached
                 me.cache_mode = CACHE_MODE_VOLATILE
+            else
+                opt_cache[result.linfo] = ci
             end
         end
     end
@@ -549,6 +547,19 @@ end
         const_flags = 0x0
     end
     return ResultForCache(rettype, exctype, rettype_const, const_flags)
+end
+
+function is_already_cached(interp::AbstractInterpreter, result::InferenceResult, ci::CodeInstance)
+    # check if the existing linfo metadata is also sufficient to describe the current inference result
+    # to decide if it is worth caching this right now
+    mi = result.linfo
+    cache = WorldView(code_cache(interp), result.valid_worlds)
+    if haskey(cache, mi)
+        # n.b.: accurate edge representation might cause the CodeInstance for this to be constructed later
+        @assert isdefined(cache[mi], :inferred)
+        return true
+    end
+    return false
 end
 
 # record the backedges

--- a/Compiler/src/types.jl
+++ b/Compiler/src/types.jl
@@ -1,5 +1,4 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
-#
 
 const WorkThunk = Any
 # #@eval struct WorkThunk

--- a/src/gf.c
+++ b/src/gf.c
@@ -650,7 +650,9 @@ JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
 
 JL_DLLEXPORT void jl_update_codeinst(
         jl_code_instance_t *codeinst, jl_value_t *inferred,
-        int32_t const_flags, size_t min_world, size_t max_world,
+        jl_value_t *rettype, jl_value_t *exctype,
+        jl_value_t *rettype_const, int32_t const_flags,
+        size_t min_world, size_t max_world,
         uint32_t effects, jl_value_t *analysis_results,
         jl_debuginfo_t *di, jl_svec_t *edges /* , int absolute_max*/)
 {
@@ -663,6 +665,14 @@ JL_DLLEXPORT void jl_update_codeinst(
     jl_gc_wb(codeinst, di);
     jl_atomic_store_relaxed(&codeinst->edges, edges);
     jl_gc_wb(codeinst, edges);
+    codeinst->rettype = rettype;
+    jl_gc_wb(codeinst, rettype);
+    codeinst->exctype = exctype;
+    jl_gc_wb(codeinst, exctype);
+    if ((const_flags & 2) != 0) {
+        codeinst->rettype_const = rettype_const;
+        jl_gc_wb(codeinst, rettype_const);
+    }
     if ((const_flags & 1) != 0) {
         assert(codeinst->rettype_const);
         jl_atomic_store_release(&codeinst->invoke, jl_fptr_const_return);
@@ -676,8 +686,8 @@ JL_DLLEXPORT void jl_update_codeinst(
 JL_DLLEXPORT void jl_fill_codeinst(
         jl_code_instance_t *codeinst,
         jl_value_t *rettype, jl_value_t *exctype,
-        jl_value_t *inferred_const,
-        int32_t const_flags, size_t min_world, size_t max_world,
+        jl_value_t *rettype_const, int32_t const_flags,
+        size_t min_world, size_t max_world,
         uint32_t effects, jl_value_t *analysis_results,
         jl_debuginfo_t *di, jl_svec_t *edges /* , int absolute_max*/)
 {
@@ -688,8 +698,8 @@ JL_DLLEXPORT void jl_fill_codeinst(
     codeinst->exctype = exctype;
     jl_gc_wb(codeinst, exctype);
     if ((const_flags & 2) != 0) {
-        codeinst->rettype_const = inferred_const;
-        jl_gc_wb(codeinst, inferred_const);
+        codeinst->rettype_const = rettype_const;
+        jl_gc_wb(codeinst, rettype_const);
     }
     jl_atomic_store_relaxed(&codeinst->edges, edges);
     jl_gc_wb(codeinst, edges);

--- a/test/compileall.jl
+++ b/test/compileall.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 # This test builds a full system image, so it can take a little while.
 # We make it a separate test target here, so that it can run in parallel
 # with the rest of the tests.


### PR DESCRIPTION
In certain cases, the optimizer can introduce new type information. This is particularly evident in SROA, where load forwarding can reveal type information that was not visible during abstract interpretation. In such cases, re-running abstract interpretation using this new type information can be highly valuable, however, currently, this only occurs when semi-concrete interpretation happens to be triggered.

This commit introduces a new "post-optimization inference" phase at the end of the optimizer pipeline. When the optimizer derives new type information, this phase performs IR abstract interpretation to further optimize the IR.

Such cases are especially common in patterns involving captured
variables, as discussed in JuliaLang/julia#15276. By combining the
"post-optimization inference" implemented in this commit with EA-based
load forwarding, it is anticipated that the issue described in
JuliaLang/julia#15276 can largely be resolved.

---

@nanosoldier `runbenchmarks("inference", vs=":master")`
