### PR TITLE
support passing a specific Method to invoke

### DIFF
--- a/Compiler/src/abstractlattice.jl
+++ b/Compiler/src/abstractlattice.jl
@@ -229,7 +229,7 @@ end
     if isa(t, Const)
         # don't consider mutable values useful constants
         val = t.val
-        return isa(val, Symbol) || isa(val, Type) || !ismutable(val)
+        return isa(val, Symbol) || isa(val, Type) || isa(val, Method) || !ismutable(val)
     end
     isa(t, PartialTypeVar) && return false # this isn't forwardable
     return is_const_prop_profitable_arg(widenlattice(𝕃), t)

--- a/Compiler/src/utilities.jl
+++ b/Compiler/src/utilities.jl
@@ -54,8 +54,8 @@ function count_const_size(@nospecialize(x), count_self::Bool = true)
         # No definite size
         (isa(x, GenericMemory) || isa(x, String) || isa(x, SimpleVector)) &&
             return MAX_INLINE_CONST_SIZE + 1
-        if isa(x, Module)
-            # We allow modules, because we already assume they are externally
+        if isa(x, Module) || isa(x, Method)
+            # We allow modules and methods, because we already assume they are externally
             # rooted, so we count their contents as 0 size.
             return sizeof(Ptr{Cvoid})
         end

--- a/NEWS.md
+++ b/NEWS.md
@@ -119,7 +119,7 @@ New library features
 * `Base.require_one_based_indexing` and `Base.has_offset_axes` are now public ([#56196])
 * New `ltruncate`, `rtruncate` and `ctruncate` functions for truncating strings to text width, accounting for char widths ([#55351])
 * `isless` (and thus `cmp`, sorting, etc.) is now supported for zero-dimensional `AbstractArray`s ([#55772])
-* `invoke` now supports passing a Method instead of a type signature making this interface somewhat more flexible for certain uncommon use cases ([#TBD]).
+* `invoke` now supports passing a Method instead of a type signature making this interface somewhat more flexible for certain uncommon use cases ([#56692]).
 
 Standard library changes
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -119,6 +119,7 @@ New library features
 * `Base.require_one_based_indexing` and `Base.has_offset_axes` are now public ([#56196])
 * New `ltruncate`, `rtruncate` and `ctruncate` functions for truncating strings to text width, accounting for char widths ([#55351])
 * `isless` (and thus `cmp`, sorting, etc.) is now supported for zero-dimensional `AbstractArray`s ([#55772])
+* `invoke` now supports passing a Method instead of a type signature making this interface somewhat more flexible for certain uncommon use cases ([#TBD]).
 
 Standard library changes
 ------------------------

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2030,20 +2030,31 @@ applicable
 
 """
     invoke(f, argtypes::Type, args...; kwargs...)
+    invoke(f, argtypes::Method, args...; kwargs...)
 
 Invoke a method for the given generic function `f` matching the specified types `argtypes` on the
 specified arguments `args` and passing the keyword arguments `kwargs`. The arguments `args` must
 conform with the specified types in `argtypes`, i.e. conversion is not automatically performed.
 This method allows invoking a method other than the most specific matching method, which is useful
 when the behavior of a more general definition is explicitly needed (often as part of the
-implementation of a more specific method of the same function).
+implementation of a more specific method of the same function). However, because this means
+the runtime must do more work, `invoke` is generally also slower--sometimes significantly
+so--than doing normal dispatch with a regular call.
 
-Be careful when using `invoke` for functions that you don't write.  What definition is used
+Be careful when using `invoke` for functions that you don't write. What definition is used
 for given `argtypes` is an implementation detail unless the function is explicitly states
 that calling with certain `argtypes` is a part of public API.  For example, the change
 between `f1` and `f2` in the example below is usually considered compatible because the
 change is invisible by the caller with a normal (non-`invoke`) call.  However, the change is
 visible if you use `invoke`.
+
+# Passing a `Method` instead of a signature
+The `argtypes` argument may be a `Method`, in which case the ordinary method table lookup is
+bypassed entirely and the given method is invoked directly. Needing this feature is uncommon.
+Note in particular that the specified `Method` may be entirely unreachable from ordinary dispatch
+(or ordinary invoke), e.g. because it was replaced or fully covered by more specific methods.
+If the method is part of the ordinary method table, this call behaves similar
+to `invoke(f, method.sig, args...)`.
 
 # Examples
 ```jldoctest

--- a/test/core.jl
+++ b/test/core.jl
@@ -8352,3 +8352,10 @@ macro define_call(sym)
 end
 @test eval(Expr(:toplevel, :(@define_call(f_macro_defined1)))) == 1
 @test @define_call(f_macro_defined2) == 1
+
+let m = which(+, (Int, Int))
+    @eval f56692(i) = invoke(+, $m, i, 4)
+    global g56692() = f56692(5) == 9 ? "true" : false
+end
+@test @inferred(f56692(3)) == 7
+@test @inferred(g56692()) == "true"


### PR DESCRIPTION
The main purpose of this is integrating with external compilers using overlay method tables, where the Method might need to come from a source other than regular dispatch. Note that this is generally much less well optimized at runtime than generic dispatch, so this shouldn't be treated as expecting to give a performance boost in any dynamic cases.

Trivial examples:

    julia> let m = which(+, (Int, Int))
           @eval f(i, j) = invoke(+, $m, i, j)
           end
    julia> f(2,2)
    4

    julia> let m = which(Core.kwcall, (@NamedTuple{base::Int}, typeof(string), Int))
           @eval f(i, base) = @noinline invoke(string, $m, i; base)
           end
    julia> f(20,16)
    "14"