### PR TITLE
Remove arraylist_t from external native code APIs.

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1951,13 +1951,15 @@ JL_DLLIMPORT void *jl_create_native(jl_array_t *methods, LLVMOrcThreadSafeModule
 JL_DLLIMPORT void jl_dump_native(void *native_code,
         const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *asm_fname,
         ios_t *z, ios_t *s, jl_emission_params_t *params);
-JL_DLLIMPORT void jl_get_llvm_gvs(void *native_code, arraylist_t *gvs);
-JL_DLLIMPORT void jl_get_llvm_external_fns(void *native_code, arraylist_t *gvs);
+JL_DLLIMPORT void jl_get_llvm_gvs(void *native_code, size_t *num_els, void **gvs);
+JL_DLLIMPORT void jl_get_llvm_external_fns(void *native_code, size_t *num_els,
+                                           jl_code_instance_t *gvs);
 JL_DLLIMPORT void jl_get_function_id(void *native_code, jl_code_instance_t *ncode,
         int32_t *func_idx, int32_t *specfunc_idx);
 JL_DLLIMPORT void jl_register_fptrs(uint64_t image_base, const struct _jl_image_fptrs_t *fptrs,
                                     jl_method_instance_t **linfos, size_t n);
-JL_DLLIMPORT void jl_get_llvm_mis(void *native_code, arraylist_t* MIs);
+JL_DLLIMPORT void jl_get_llvm_mis(void *native_code, size_t *num_els,
+                                  jl_method_instance_t *MIs);
 JL_DLLIMPORT void jl_init_codegen(void);
 JL_DLLIMPORT void jl_teardown_codegen(void) JL_NOTSAFEPOINT;
 JL_DLLIMPORT int jl_getFunctionInfo(jl_frame_t **frames, uintptr_t pointer, int skipC, int noInline) JL_NOTSAFEPOINT;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2896,10 +2896,20 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
 
     int en = jl_gc_enable(0);
     if (native_functions) {
-        jl_get_llvm_gvs(native_functions, &gvars);
-        jl_get_llvm_external_fns(native_functions, &external_fns);
-        if (jl_options.trim)
-            jl_get_llvm_mis(native_functions, &MIs);
+        size_t num_gvars, num_external_fns;
+        jl_get_llvm_gvs(native_functions, &num_gvars, NULL);
+        arraylist_grow(&gvars, num_gvars);
+        jl_get_llvm_gvs(native_functions, &num_gvars, gvars.items);
+        jl_get_llvm_external_fns(native_functions, &num_external_fns, NULL);
+        arraylist_grow(&external_fns, num_external_fns);
+        jl_get_llvm_external_fns(native_functions, &num_external_fns,
+                                 (jl_code_instance_t *)external_fns.items);
+        if (jl_options.trim) {
+            size_t num_mis;
+            jl_get_llvm_mis(native_functions, &num_mis, NULL);
+            arraylist_grow(&MIs, num_mis);
+            jl_get_llvm_mis(native_functions, &num_mis, (jl_method_instance_t *)MIs.items);
+        }
     }
     if (jl_options.trim) {
         jl_rebuild_methtables(&MIs, &new_methtables);


### PR DESCRIPTION
GPUCompiler.jl used to rely on calls to the `lookup` function (mapping MIs to CIs) to keep track of MIs used during compilation, which Enzyme.jl then uses for... whatever it does. After https://github.com/JuliaLang/julia/pull/54899, the IR already contains CIs, resulting in this not being reliable anymore, as the `lookup` callback isn't invoked for every CI anymore.

I noticed that we already had accessor functions for fetching the list of MIs involved in a native compilation, `jl_get_llvm_mis`, however these functions currently use `arraylist_t` objects that are not usable to external consumers like GPUCompiler.jl. This PR switches those APIs over to a more traditional C style, passing pointers to the number of elements and the underlying data.

I guess it may be better for Enzyme.jl to consume CIs instead of MIs so that we don't need to maintain this mapping, but I focussed first on making the existing logic work again, and generalizing the current APIs doesn't seem to have much of a drawback.