### PR TITLE
fix world_age_at_entry in codegen

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1712,18 +1712,12 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         return ghostValue(ctx, jl_nothing_type);
     }
     else if (is_libjulia_func(jl_get_tls_world_age)) {
-        bool toplevel = !(ctx.linfo && jl_is_method(ctx.linfo->def.method));
-        if (!toplevel) { // top level code does not see a stable world age during execution
-            ++CCALL_STAT(jl_get_tls_world_age);
-            assert(lrt == ctx.types().T_size);
-            assert(!isVa && !llvmcall && nccallargs == 0);
-            JL_GC_POP();
-            Instruction *world_age = cast<Instruction>(ctx.world_age_at_entry);
-            setName(ctx.emission_context, world_age, "task_world_age");
-            jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
-            ai.decorateInst(world_age);
-            return mark_or_box_ccall_result(ctx, world_age, retboxed, rt, unionall, static_rt);
-        }
+        ++CCALL_STAT(jl_get_tls_world_age);
+        assert(lrt == ctx.types().T_size);
+        assert(!isVa && !llvmcall && nccallargs == 0);
+        JL_GC_POP();
+        Value *world_age = get_tls_world_age(ctx);
+        return mark_or_box_ccall_result(ctx, world_age, retboxed, rt, unionall, static_rt);
     }
     else if (is_libjulia_func(jl_get_world_counter)) {
         ++CCALL_STAT(jl_get_world_counter);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -1050,10 +1050,7 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval_flex(jl_module_t *JL_NONNULL m, jl_val
         // use codegen
         mfunc = jl_method_instance_for_thunk(thk, m);
         jl_resolve_globals_in_ir((jl_array_t*)thk->code, m, NULL, 0);
-        // Don't infer blocks containing e.g. method definitions, since it's probably not
-        // worthwhile and also unsound (see #24316).
-        // TODO: This is still not correct since an `eval` can happen elsewhere, but it
-        // helps in common cases.
+        // Don't infer blocks containing e.g. method definitions, since it's probably not worthwhile.
         size_t world = jl_atomic_load_acquire(&jl_world_counter);
         ct->world_age = world;
         if (!has_defs && jl_get_module_infer(m) != 0) {


### PR DESCRIPTION
The world is set (and reset) by the caller in toplevel code, so it should not be changed here as that makes the inference beforehand invalid (undermining the point of doing #56509 without any benefit). Also avoid allocating world_age_at_entry for every function, when it is almost never needed.