### PR TITLE
Fix evalpoly for no coefficients case

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -91,7 +91,7 @@ julia> evalpoly(2, (1, 2, 3))
 17
 ```
 """
-function evalpoly(x, p::Tuple)
+function evalpoly(x, p::Tuple{Any, Vararg})
     if @generated
         N = length(p.parameters::Core.SimpleVector)
         ex = :(p[end])
@@ -119,7 +119,7 @@ function _evalpoly(x, p)
     ex
 end
 
-function evalpoly(z::Complex, p::Tuple)
+function evalpoly(z::Complex, p::Tuple{Any, Any, Vararg})
     if @generated
         N = length(p.parameters)
         a = :(p[end])
@@ -145,9 +145,9 @@ function evalpoly(z::Complex, p::Tuple)
     end
 end
 
-evalpoly(z::Complex, p::Tuple{}) = zero(z)
-
 evalpoly(z::Complex, p::Tuple{<:Any}) = p[1]
+
+evalpoly(z::Complex, p::Tuple{}) = zero(z)
 
 evalpoly(z::Complex, p::AbstractVector) = _evalpoly(z, p)
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -104,11 +104,14 @@ function evalpoly(x, p::Tuple)
     end
 end
 
+evalpoly(x, p::Tuple{}) = zero(x)
+
 evalpoly(x, p::AbstractVector) = _evalpoly(x, p)
 
 function _evalpoly(x, p)
     Base.require_one_based_indexing(p)
     N = length(p)
+    N == 0 && return zero(x)
     ex = p[end]
     for i in N-1:-1:1
         ex = muladd(x, ex, p[i])
@@ -141,15 +144,18 @@ function evalpoly(z::Complex, p::Tuple)
         _evalpoly(z, p)
     end
 end
-evalpoly(z::Complex, p::Tuple{<:Any}) = p[1]
 
+evalpoly(z::Complex, p::Tuple{}) = zero(z)
+
+evalpoly(z::Complex, p::Tuple{<:Any}) = p[1]
 
 evalpoly(z::Complex, p::AbstractVector) = _evalpoly(z, p)
 
 function _evalpoly(z::Complex, p)
     Base.require_one_based_indexing(p)
-    length(p) == 1 && return p[1]
     N = length(p)
+    N == 0 && return zero(z)
+    N == 1 && return p[1]
     a = p[end]
     b = p[end-1]
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -724,6 +724,14 @@ end
     @test evalpoly(1+im, [2,]) == 2
 end
 
+@testset "evalpoly no coefficients" begin
+    for x in (1,1.0,1.0+1.0im)
+        for p in ((),[])
+            @test evalpoly(x,p) == zero(x)
+        end
+    end
+end
+
 @testset "cis" begin
     for z in (1.234, 1.234 + 5.678im)
         @test cis(z) ≈ exp(im*z)


### PR DESCRIPTION
This resolves #56699 

I went with the route of returning `zero(x)` for `evalpoly(x,p)` instead of an error.
This is because according to me a naive implementation of `evalpoly` would use a counter initialized to zero and loop over the coefficients and would thereby return zero in case of no coefficients. 

Please let me know if I have made a mistake in this pull request as this is my first PR. 