### PR TITLE
fix evalpoly type instability and 0-length case

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -160,7 +160,7 @@ function _evalpoly(z::Complex, p)
     for i in N-2:-1:1
         ai = a
         a = muladd(r, ai, b)
-        @inbounds b = muladd(-s, ai, p[i])
+        b = muladd(-s, ai, @inbounds p[i])
     end
     ai = a
     muladd(ai, z, b)

--- a/base/math.jl
+++ b/base/math.jl
@@ -113,7 +113,7 @@ function _evalpoly(x, p)
     @inbounds p0 = N == 0 ? reduce_empty_iter(+, p) : p[N]
     s = oftype(one(x) * p0, p0)
     for i in N-1:-1:1
-        @inbounds s = muladd(x, s, p[i])
+        s = muladd(x, s, @inbounds p[i])
     end
     return s
 end

--- a/base/math.jl
+++ b/base/math.jl
@@ -110,7 +110,7 @@ evalpoly(x, p::AbstractVector) = _evalpoly(x, p)
 function _evalpoly(x, p)
     Base.require_one_based_indexing(p)
     N = length(p)
-    @inbounds p0 = N == 0 ? reduce_empty_iter(+, p) : p[N]
+    p0 = iszero(N) ? reduce_empty_iter(+, p) : @inbounds p[N]
     s = oftype(one(x) * p0, p0)
     for i in N-1:-1:1
         s = muladd(x, s, @inbounds p[i])

--- a/base/math.jl
+++ b/base/math.jl
@@ -94,7 +94,7 @@ julia> evalpoly(2, (1, 2, 3))
 function evalpoly(x, p::Tuple)
     if @generated
         N = length(p.parameters::Core.SimpleVector)
-        ex = :(p[end])
+        ex = :(oftype(one(x) * p[end], p[end]))
         for i in N-1:-1:1
             ex = :(muladd(x, $ex, p[$i]))
         end

--- a/base/math.jl
+++ b/base/math.jl
@@ -112,7 +112,6 @@ function _evalpoly(x, p)
     N = length(p)
     @inbounds p0 = N == 0 ? reduce_empty_iter(+, p) : p[N]
     s = oftype(one(x) * p0, p0)
-    N <= 1 && return s
     for i in N-1:-1:1
         @inbounds s = muladd(x, s, p[i])
     end

--- a/base/math.jl
+++ b/base/math.jl
@@ -148,7 +148,7 @@ end
 function _evalpoly(z::Complex, p)
     Base.require_one_based_indexing(p)
     N = length(p)
-    @inbounds p0 = N == 0 ? reduce_empty_iter(+, p) : p[N]
+    p0 = iszero(N) ? reduce_empty_iter(+, p) : @inbounds p[N]
     N <= 1 && return oftype(one(z) * p0, p0)
     a = p0
     @inbounds b = p[N-1]

--- a/base/math.jl
+++ b/base/math.jl
@@ -118,7 +118,8 @@ function _evalpoly(x, p)
     return s
 end
 
-function evalpoly(z::Complex, p::Tuple)
+# Goertzel-like algorithm from Knuth, TAOCP vol. 2, section 4.6.4:
+function evalpoly(z::Complex, p::Tuple{Any, Any, Vararg})
     if @generated
         N = length(p.parameters)
         a = :(p[end])
@@ -143,10 +144,6 @@ function evalpoly(z::Complex, p::Tuple)
         _evalpoly(z, p)
     end
 end
-evalpoly(z::Complex, p::Tuple{<:Any}) = p[1]
-evalpoly(z::Complex, ::Tuple{}) = zero(one(z)) # dimensionless zero, i.e. 0 * z^0
-
-evalpoly(z::Complex, p::AbstractVector) = _evalpoly(z, p)
 
 function _evalpoly(z::Complex, p)
     Base.require_one_based_indexing(p)

--- a/test/math.jl
+++ b/test/math.jl
@@ -716,6 +716,8 @@ end
         @test evalpoly(x, [p1, p2, p3]) == evpm
     end
     @test evalpoly(1.0f0, ()) === 0.0f0 # issue #56699
+    @test @inferred(evalpoly(1.0f0, Int[])) === 0.0f0 # issue #56699
+    @test_throws MethodError evalpoly(1.0f0, [])
     @test @inferred(evalpoly(1.0f0, [2])) === 2.0f0 # type-stability
 end
 
@@ -729,6 +731,8 @@ end
     @test evalpoly(1+im, (2,)) == 2
     @test evalpoly(1+im, [2,]) == 2
     @test evalpoly(1.0f0+im, ()) === 0.0f0+0im # issue #56699
+    @test @inferred(evalpoly(1.0f0+im, Int[])) === 0.0f0+0im # issue #56699
+    @test_throws MethodError evalpoly(1.0f0, [])
     @test @inferred(evalpoly(1.0f0+im, [2])) === 2.0f0+0im # type-stability
 end
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -707,6 +707,10 @@ end
     c = 3
     @test @evalpoly(c, a0, a1) == 7
     @test @evalpoly(1, 2) == 2
+
+    isdefined(Main, :Furlongs) || @eval Main include("testhelpers/Furlongs.jl")
+    using .Main.Furlongs
+    @test @evalpoly(Furlong(2)) === evalpoly(Furlong(2), ()) === evalpoly(Furlong(2), Int[]) === 0
 end
 
 @testset "evalpoly real" begin

--- a/test/math.jl
+++ b/test/math.jl
@@ -723,6 +723,9 @@ end
     @test @inferred(evalpoly(1.0f0, Int[])) === 0.0f0 # issue #56699
     @test_throws MethodError evalpoly(1.0f0, [])
     @test @inferred(evalpoly(1.0f0, [2])) === 2.0f0 # type-stability
+
+    # different @generated branches should return same type:
+    @test evalpoly(3.0, (1,)) === Base.Math._evalpoly(3.0, (1,)) === 1.0
 end
 
 @testset "evalpoly complex" begin
@@ -738,6 +741,10 @@ end
     @test @inferred(evalpoly(1.0f0+im, Int[])) === 0.0f0+0im # issue #56699
     @test_throws MethodError evalpoly(1.0f0, [])
     @test @inferred(evalpoly(1.0f0+im, [2])) === 2.0f0+0im # type-stability
+
+    # different @generated branches should return same type:
+    @test evalpoly(3.0+0im, (1,)) === Base.Math._evalpoly(3.0+0im, (1,)) === 1.0+0im
+    @test evalpoly(3.0+0im, (1,2)) === Base.Math._evalpoly(3.0+0im, (1,2)) === 7.0+0im
 end
 
 @testset "cis" begin

--- a/test/math.jl
+++ b/test/math.jl
@@ -715,6 +715,8 @@ end
         @test evalpoly(x, (p1, p2, p3)) == evpm
         @test evalpoly(x, [p1, p2, p3]) == evpm
     end
+    @test evalpoly(1.0f0, ()) === 0.0f0 # issue #56699
+    @test @inferred(evalpoly(1.0f0, [2])) === 2.0f0 # type-stability
 end
 
 @testset "evalpoly complex" begin
@@ -726,6 +728,8 @@ end
     end
     @test evalpoly(1+im, (2,)) == 2
     @test evalpoly(1+im, [2,]) == 2
+    @test evalpoly(1.0f0+im, ()) === 0.0f0+0im # issue #56699
+    @test @inferred(evalpoly(1.0f0+im, [2])) === 2.0f0+0im # type-stability
 end
 
 @testset "cis" begin


### PR DESCRIPTION
A few fixes/improvements to the `evalpoly` function:

1. Fixes #56699: returns zero for an empty tuple or array of coefficients
2. Fixes a type-instability in `evalpoly(x, ::Vector)`
3. Adds a missing `@inbounds` annotation
4. Trivial: Renames a local variable `ex` that was-copy-pasted from the macro version (where `ex` referred to an expression) but makes no sense here for the numeric sum.
5. Removes some extraneous methods (by tightening a method signature, as suggested by @nsajko) — should still dispatch to the same implementations as before.

Probably should be backported.