### PR TITLE
allow passing custom julia arguments in `runtests`

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -678,7 +678,7 @@ end
 
 """
     Base.runtests(tests=["all"]; ncores=ceil(Int, Sys.CPU_THREADS / 2),
-                  exit_on_error=false, revise=false, propagate_project=true, [seed])
+                  exit_on_error=false, revise=false, propagate_project=true, [seed], [julia_args::Cmd])
 
 Run the Julia unit tests listed in `tests`, which can be either a string or an array of
 strings, using `ncores` processors. If `exit_on_error` is `false`, when one test
@@ -689,12 +689,14 @@ to the standard libraries before running the tests.
 If `propagate_project` is true the current project is propagated to the test environment.
 If a seed is provided via the keyword argument, it is used to seed the
 global RNG in the context where the tests are run; otherwise the seed is chosen randomly.
+The argument `julia_args` can be used to pass custom julia arguments to the test process.
 """
 function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS / 2),
                   exit_on_error::Bool=false,
                   revise::Bool=false,
                   propagate_project::Bool=false,
-                  seed::Union{BitInteger,Nothing}=nothing)
+                  seed::Union{BitInteger,Nothing}=nothing,
+                  julia_args::Cmd=``)
     if isa(tests,AbstractString)
         tests = split(tests)
     end
@@ -710,7 +712,7 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS / 2),
     delete!(ENV2, "JULIA_PROJECT")
     project_flag = propagate_project ? `--project` : ``
     try
-        run(setenv(`$(julia_cmd()) $project_flag $(joinpath(Sys.BINDIR,
+        run(setenv(`$(julia_cmd()) $julia_args $project_flag $(joinpath(Sys.BINDIR,
             Base.DATAROOTDIR, "julia", "test", "runtests.jl")) $tests`, ENV2))
         nothing
     catch

--- a/base/util.jl
+++ b/base/util.jl
@@ -689,7 +689,7 @@ to the standard libraries before running the tests.
 If `propagate_project` is true the current project is propagated to the test environment.
 If a seed is provided via the keyword argument, it is used to seed the
 global RNG in the context where the tests are run; otherwise the seed is chosen randomly.
-The argument `julia_args` can be used to pass custom julia arguments to the test process.
+The argument `julia_args` can be used to pass custom `julia` command line flags to the test process.
 """
 function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS / 2),
                   exit_on_error::Bool=false,


### PR DESCRIPTION
The `propagate_project` kwarg can be removed after current users (LinearAlgebra.jl) switches to it.

This is to allow moving buildkite yaml logic into Julia where it is easier to write.