### PR TITLE
Fix string handling in jlchecksum

### DIFF
--- a/deps/tools/jlchecksum
+++ b/deps/tools/jlchecksum
@@ -63,7 +63,7 @@ find_checksum()
         fi
     done
     if [ ! -f "$DEPSDIR/checksums/$BASENAME/$CHECKSUM_TYPE" ]; then
-        if [ ${TAGGED_RELEASE_BANNER:-} ]; then
+        if [ "${TAGGED_RELEASE_BANNER:-}" ]; then
             echo "WARNING: $CHECKSUM_TYPE checksum for $BASENAME not found in deps/checksums/, failing release build." >&2
             exit 3
         fi


### PR DESCRIPTION
A `TAGGED_RELEASE_BANNER` with spaces such as `Official https://julialang.org release` produces the error `/cache/build/builder-amdci4-5/julialang/julia-master/deps/tools/jlchecksum: 66: [: Official: unexpected operator`.