### PR TITLE
Clarifying ispunct behavior difference between Julia and C in documentation

### DIFF
--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -532,8 +532,8 @@ iscntrl(c::AbstractChar) = c <= '\x1f' || '\x7f' <= c <= '\u9f'
     ispunct(c::AbstractChar) -> Bool
 
 Tests whether a character belongs to the Unicode general category Punctuation, i.e. a
-character whose category code begins with 'P'.
-
+character whose category code begins with 'P'.\n
+*Note*: This behavior is different from the ispunct function in C which checks for printable characters that are not alphanumeric or whitespace, based on the ASCII.
 # Examples
 ```jldoctest
 julia> ispunct('α')

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -532,11 +532,16 @@ iscntrl(c::AbstractChar) = c <= '\x1f' || '\x7f' <= c <= '\u9f'
     ispunct(c::AbstractChar) -> Bool
 
 Tests whether a character belongs to the Unicode general category Punctuation, i.e. a
-character whose category code begins with 'P'.\n
-*Note*: This behavior is different from the ispunct function in C which checks for printable characters that are not alphanumeric or whitespace, based on the ASCII.
+character whose category code begins with 'P'.
+
+!!! note
+    This behavior is different from the `ispunct` function in C.
 # Examples
 ```jldoctest
 julia> ispunct('α')
+false
+
+julia> ispunct('=')
 false
 
 julia> ispunct('/')

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -536,6 +536,7 @@ character whose category code begins with 'P'.
 
 !!! note
     This behavior is different from the `ispunct` function in C.
+
 # Examples
 ```jldoctest
 julia> ispunct('α')


### PR DESCRIPTION
Fixes #56680. This PR updates the documentation for the ispunct function in Julia to explicitly note its differing behavior from the similarly named function in C.