### PR TITLE
effects: pack bits better

### DIFF
--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -17,37 +17,41 @@ const SLOT_USEDUNDEF    = 32 # slot has uses that might raise UndefVarError
 
 const IR_FLAG_NULL        = zero(UInt32)
 # This statement is marked as @inbounds by user.
-# Ff replaced by inlining, any contained boundschecks may be removed.
+# If replaced by inlining, any contained boundschecks may be removed.
 const IR_FLAG_INBOUNDS    = one(UInt32) << 0
 # This statement is marked as @inline by user
 const IR_FLAG_INLINE      = one(UInt32) << 1
 # This statement is marked as @noinline by user
 const IR_FLAG_NOINLINE    = one(UInt32) << 2
+# This statement is proven :consistent
+const IR_FLAG_CONSISTENT  = one(UInt32) << 3
+# This statement is proven :effect_free
+const IR_FLAG_EFFECT_FREE = one(UInt32) << 4
+# This statement is proven :nothrow
+const IR_FLAG_NOTHROW     = one(UInt32) << 5
+# This statement is proven :terminates_globally
+const IR_FLAG_TERMINATES  = one(UInt32) << 6
+#const IR_FLAG_TERMINATES_LOCALLY = one(UInt32) << 7
+#const IR_FLAG_NOTASKSTATE = one(UInt32) << 8
+#const IR_FLAG_INACCESSIBLEMEM = one(UInt32) << 9
+const IR_FLAG_NOUB        = one(UInt32) << 10
+#const IR_FLAG_NOUBINIB   = one(UInt32) << 11
+#const IR_FLAG_CONSISTENTOVERLAY = one(UInt32) << 12
+# This statement is :nortcall
+const IR_FLAG_NORTCALL = one(UInt32) << 13
 # An optimization pass has updated this statement in a way that may
 # have exposed information that inference did not see. Re-running
 # inference on this statement may be profitable.
-const IR_FLAG_REFINED     = one(UInt32) << 3
-# This statement is proven :consistent
-const IR_FLAG_CONSISTENT  = one(UInt32) << 4
-# This statement is proven :effect_free
-const IR_FLAG_EFFECT_FREE = one(UInt32) << 5
-# This statement is proven :nothrow
-const IR_FLAG_NOTHROW     = one(UInt32) << 6
-# This statement is proven :terminates
-const IR_FLAG_TERMINATES  = one(UInt32) << 7
-# This statement is proven :noub
-const IR_FLAG_NOUB        = one(UInt32) << 8
-# TODO: Both of these should eventually go away once
-# This statement is :effect_free == EFFECT_FREE_IF_INACCESSIBLEMEMONLY
-const IR_FLAG_EFIIMO      = one(UInt32) << 9
-# This statement is :inaccessiblememonly == INACCESSIBLEMEM_OR_ARGMEMONLY
-const IR_FLAG_INACCESSIBLEMEM_OR_ARGMEM = one(UInt32) << 10
-# This statement is :nortcall
-const IR_FLAG_NORTCALL    = one(UInt32) << 11
+const IR_FLAG_REFINED     = one(UInt32) << 16
 # This statement has no users and may be deleted if flags get refined to IR_FLAGS_REMOVABLE
-const IR_FLAG_UNUSED      = one(UInt32) << 12
+const IR_FLAG_UNUSED      = one(UInt32) << 17
+# TODO: Both of these next two should eventually go away once
+# This statement is :effect_free == EFFECT_FREE_IF_INACCESSIBLEMEMONLY
+const IR_FLAG_EFIIMO      = one(UInt32) << 18
+# This statement is :inaccessiblememonly == INACCESSIBLEMEM_OR_ARGMEMONLY
+const IR_FLAG_INACCESSIBLEMEM_OR_ARGMEM = one(UInt32) << 19
 
-const NUM_IR_FLAGS = 13 # sync with julia.h
+const NUM_IR_FLAGS = 3 # sync with julia.h
 
 const IR_FLAGS_EFFECTS =
     IR_FLAG_CONSISTENT | IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW |
@@ -815,6 +819,7 @@ function scan_non_dataflow_flags!(inst::Instruction, sv::PostOptAnalysisState)
             sv.nortcall = false
         end
     end
+    nothing
 end
 
 function scan_inconsistency!(inst::Instruction, sv::PostOptAnalysisState)

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -413,6 +413,7 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter)
     ipo_effects = result.ipo_effects = me.ipo_effects = adjust_effects(me)
     result.exc_result = me.exc_bestguess = refine_exception_type(me.exc_bestguess, ipo_effects)
     me.src.rettype = widenconst(ignorelimited(bestguess))
+    me.src.ssaflags = me.ssaflags
     me.src.min_world = first(me.world.valid_worlds)
     me.src.max_world = last(me.world.valid_worlds)
     istoplevel = !(me.linfo.def isa Method)
@@ -936,7 +937,7 @@ function codeinfo_for_const(interp::AbstractInterpreter, mi::MethodInstance, @no
     tree.slotflags = fill(0x00, nargs)
     tree.ssavaluetypes = 1
     tree.debuginfo = DebugInfo(mi)
-    tree.ssaflags = UInt32[0]
+    tree.ssaflags = [IR_FLAG_NULL]
     tree.rettype = Core.Typeof(val)
     tree.edges = Core.svec()
     set_inlineable!(tree, true)

--- a/src/julia.h
+++ b/src/julia.h
@@ -279,7 +279,7 @@ typedef union __jl_purity_overrides_t {
 } _jl_purity_overrides_t;
 
 #define NUM_EFFECTS_OVERRIDES 11
-#define NUM_IR_FLAGS 13
+#define NUM_IR_FLAGS 3
 
 // This type describes a single function body
 typedef struct _jl_code_info_t {
@@ -292,15 +292,8 @@ typedef struct _jl_code_info_t {
         // 1 << 0 = inbounds region
         // 1 << 1 = callsite inline region
         // 1 << 2 = callsite noinline region
-        // 1 << 3 = refined statement
-        // 1 << 4 = :consistent
-        // 1 << 5 = :effect_free
-        // 1 << 6 = :nothrow
-        // 1 << 7 = :terminates
-        // 1 << 8 = :noub
-        // 1 << 9 = :effect_free_if_inaccessiblememonly
-        // 1 << 10 = :inaccessiblemem_or_argmemonly
-        // 1 << 11-19 = callsite effects overrides
+        // 1 << 3-14 = purity
+        // 1 << 16+ = reserved for inference
     // miscellaneous data:
     jl_array_t *slotnames; // names of local variables
     jl_array_t *slotflags;  // local var bit flags


### PR DESCRIPTION
There is no reason to preserve duplicates of the bits for the value before and after inference, and many of the numbers in the comments had gotten incorrect. Now we are able to pack all 16 bits of currently defined bitflags into 20 bits, instead of 25 bits (although either case still rounds up to 32).

There was also no reason for InferenceState to be mutating of CodeInfo during execution, so remove that mutation.