### PR TITLE
precompile: don't waste memory on useless inferred code

### DIFF
--- a/Compiler/src/effects.jl
+++ b/Compiler/src/effects.jl
@@ -335,6 +335,7 @@ is_inaccessiblemem_or_argmemonly(effects::Effects) = effects.inaccessiblememonly
 
 is_consistent_overlay(effects::Effects) = effects.nonoverlayed === CONSISTENT_OVERLAY
 
+# (sync this with codegen.cpp and staticdata.c effects_foldable functions)
 function encode_effects(e::Effects)
     return ((e.consistent          % UInt32) << 0)  |
            ((e.effect_free         % UInt32) << 3)  |

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -10182,10 +10182,10 @@ jl_llvm_functions_t jl_emit_codeinst(
             else if (jl_is_method(def) && // don't delete toplevel code
                         def->source != NULL && // don't delete code from optimized opaque closures that can't be reconstructed
                         inferred != jl_nothing && // and there is something to delete (test this before calling jl_ir_inlining_cost)
-                        !effects_foldable(jl_atomic_load_relaxed(&codeinst->ipo_purity_bits)) && // don't delete code we may want for irinterp
-                        ((jl_ir_inlining_cost(inferred) == UINT16_MAX) || // don't delete inlineable code
-                        jl_atomic_load_relaxed(&codeinst->invoke) == jl_fptr_const_return_addr) && // unless it is constant
-                        !(params.imaging_mode || jl_options.incremental)) { // don't delete code when generating a precompile file
+                        ((!effects_foldable(jl_atomic_load_relaxed(&codeinst->ipo_purity_bits)) && // don't delete code we may want for irinterp
+                          (jl_ir_inlining_cost(inferred) == UINT16_MAX) && // don't delete inlineable code
+                          !jl_generating_output()) || // don't delete code when generating a precompile file, trading memory in the short term for avoiding likely duplicating inference work for aotcompile
+                         jl_atomic_load_relaxed(&codeinst->invoke) == jl_fptr_const_return_addr)) { // unless it is constant (although this shouldn't have had code in the first place)
                 // Never end up in a situation where the codeinst has no invoke, but also no source, so we never fall
                 // through the cracks of SOURCE_MODE_ABI.
                 jl_callptr_t expected = NULL;


### PR DESCRIPTION
We never have a reason to reference this data again since we already have native code generated for it, so it is simply wasting memory and download space.

$ du -sh {old,new}/usr/share/julia/compiled
256M old
227M new