### PR TITLE
drop llvm 16 support

### DIFF
--- a/doc/src/devdocs/build/build.md
+++ b/doc/src/devdocs/build/build.md
@@ -249,7 +249,7 @@ The most complicated dependency is LLVM, for which we require additional patches
 For packaging Julia with LLVM, we recommend either:
  - bundling a Julia-only LLVM library inside the Julia package, or
  - adding the patches to the LLVM package of the distribution.
-   * A complete list of patches is available in on [Github](https://github.com/JuliaLang/llvm-project) see the `julia-release/15.x` branch.
+   * A complete list of patches is available in on [Github](https://github.com/JuliaLang/llvm-project) see the `julia-release/18.x` branch.
    * The only Julia-specific patch is the lib renaming (`llvm7-symver-jlprefix.patch`), which should _not_ be applied to a system LLVM.
    * The remaining patches are all upstream bug fixes, and have been contributed into upstream LLVM.
 

--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -475,7 +475,6 @@ void LLVMTrunc(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *otys, integerP
     memcpy(pr, pa, onumbytes);
 }
 
-#if JL_LLVM_VERSION >= 170000
 extern "C" JL_DLLEXPORT
 unsigned countr_zero_8(uint8_t Val) {
     return countr_zero(Val);
@@ -495,27 +494,6 @@ extern "C" JL_DLLEXPORT
 unsigned countr_zero_64(uint64_t Val) {
     return countr_zero(Val);
 }
-#else
-extern "C" JL_DLLEXPORT
-unsigned countTrailingZeros_8(uint8_t Val) {
-    return countTrailingZeros(Val);
-}
-
-extern "C" JL_DLLEXPORT
-unsigned countTrailingZeros_16(uint16_t Val) {
-    return countTrailingZeros(Val);
-}
-
-extern "C" JL_DLLEXPORT
-unsigned countTrailingZeros_32(uint32_t Val) {
-    return countTrailingZeros(Val);
-}
-
-extern "C" JL_DLLEXPORT
-unsigned countTrailingZeros_64(uint64_t Val) {
-    return countTrailingZeros(Val);
-}
-#endif
 
 extern "C" JL_DLLEXPORT
 void jl_LLVMSMod(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
@@ -545,7 +523,6 @@ void jl_LLVMFlipSign(unsigned numbits, integerPart *pa, integerPart *pb, integer
         memcpy(pr, pa, numbytes);
 }
 
-#if JL_LLVM_VERSION >= 170000
 extern "C" JL_DLLEXPORT
 unsigned LLVMPopcount(unsigned numbits, integerPart *pa) {
     CREATE(a)
@@ -575,34 +552,3 @@ unsigned LLVMCountl_zero(unsigned numbits, integerPart *pa) {
     CREATE(a)
     return a.countl_zero();
 }
-#else
-extern "C" JL_DLLEXPORT
-unsigned LLVMCountPopulation(unsigned numbits, integerPart *pa) {
-    CREATE(a)
-    return a.countPopulation();
-}
-
-extern "C" JL_DLLEXPORT
-unsigned LLVMCountTrailingOnes(unsigned numbits, integerPart *pa) {
-    CREATE(a)
-    return a.countTrailingOnes();
-}
-
-extern "C" JL_DLLEXPORT
-unsigned LLVMCountTrailingZeros(unsigned numbits, integerPart *pa) {
-    CREATE(a)
-    return a.countTrailingZeros();
-}
-
-extern "C" JL_DLLEXPORT
-unsigned LLVMCountLeadingOnes(unsigned numbits, integerPart *pa) {
-    CREATE(a)
-    return a.countLeadingOnes();
-}
-
-extern "C" JL_DLLEXPORT
-unsigned LLVMCountLeadingZeros(unsigned numbits, integerPart *pa) {
-    CREATE(a)
-    return a.countLeadingZeros();
-}
-#endif

--- a/src/APInt-C.h
+++ b/src/APInt-C.h
@@ -54,19 +54,11 @@ JL_DLLEXPORT int LLVMDiv_uov(unsigned numbits, integerPart *pa, integerPart *pb,
 JL_DLLEXPORT int LLVMRem_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
 JL_DLLEXPORT int LLVMRem_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
 
-#if JL_LLVM_VERSION >= 170000
 JL_DLLEXPORT unsigned LLVMPopcount(unsigned numbits, integerPart *pa);
 JL_DLLEXPORT unsigned LLVMCountr_one(unsigned numbits, integerPart *pa);
 JL_DLLEXPORT unsigned LLVMCountr_zero(unsigned numbits, integerPart *pa);
 JL_DLLEXPORT unsigned LLVMCountl_one(unsigned numbits, integerPart *pa);
 JL_DLLEXPORT unsigned LLVMCountl_zero(unsigned numbits, integerPart *pa);
-#else
-JL_DLLEXPORT unsigned LLVMCountPopulation(unsigned numbits, integerPart *pa);
-JL_DLLEXPORT unsigned LLVMCountTrailingOnes(unsigned numbits, integerPart *pa);
-JL_DLLEXPORT unsigned LLVMCountTrailingZeros(unsigned numbits, integerPart *pa);
-JL_DLLEXPORT unsigned LLVMCountLeadingOnes(unsigned numbits, integerPart *pa);
-JL_DLLEXPORT unsigned LLVMCountLeadingZeros(unsigned numbits, integerPart *pa);
-#endif
 
 JL_DLLEXPORT void LLVMFPtoSI(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr);
 JL_DLLEXPORT void LLVMFPtoUI(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr);
@@ -82,17 +74,10 @@ JL_DLLEXPORT int LLVMFPtoUI_exact(jl_datatype_t *ty, integerPart *pa, jl_datatyp
 JL_DLLEXPORT void jl_LLVMSMod(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
 JL_DLLEXPORT void jl_LLVMFlipSign(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
 
-#if JL_LLVM_VERSION >= 170000
 JL_DLLEXPORT unsigned countr_zero_8(uint8_t Val);
 JL_DLLEXPORT unsigned countr_zero_16(uint16_t Val);
 JL_DLLEXPORT unsigned countr_zero_32(uint32_t Val);
 JL_DLLEXPORT unsigned countr_zero_64(uint64_t Val);
-#else
-JL_DLLEXPORT unsigned countTrailingZeros_8(uint8_t Val);
-JL_DLLEXPORT unsigned countTrailingZeros_16(uint16_t Val);
-JL_DLLEXPORT unsigned countTrailingZeros_32(uint32_t Val);
-JL_DLLEXPORT unsigned countTrailingZeros_64(uint64_t Val);
-#endif
 
 //uint8_t getSwappedBytes_8(uint8_t Value); // no-op
 //uint16_t getSwappedBytes_16(uint16_t Value);

--- a/src/Makefile
+++ b/src/Makefile
@@ -77,11 +77,7 @@ else
 # JULIACODEGEN != LLVM
 endif
 
-RT_LLVM_LIBS := support
-
-ifeq ($(shell test $(LLVM_VER_MAJ) -ge 16 && echo true),true)
-RT_LLVM_LIBS += targetparser
-endif
+RT_LLVM_LIBS := support targetparser
 
 ifeq ($(OS),WINNT)
 SRCS += win32_ucontext

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -264,9 +264,6 @@ static GlobalVariable *emit_plt_thunk(
     SmallVector<Value*, 16> args;
     for (auto &arg : plt->args())
         args.push_back(&arg);
-    #if JL_LLVM_VERSION < 170000
-    assert(cast<PointerType>(ptr->getType())->isOpaqueOrPointeeTypeMatches(functype));
-    #endif
     CallInst *ret = irbuilder.CreateCall(
         functype,
         ptr, ArrayRef<Value*>(args));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -23,11 +23,7 @@
 #include <llvm/CodeGen/TargetSubtargetInfo.h>
 #include <llvm/MC/TargetRegistry.h>
 #include <llvm/Target/TargetOptions.h>
-#if JL_LLVM_VERSION >= 170000
 #include <llvm/TargetParser/Host.h>
-#else
-#include <llvm/ADT/Host.h>
-#endif
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Object/SymbolSize.h>
 
@@ -637,11 +633,7 @@ static AttributeList get_func_attrs(LLVMContext &C)
 static AttributeList get_donotdelete_func_attrs(LLVMContext &C)
 {
     AttrBuilder FnAttrs(C);
-#if JL_LLVM_VERSION >= 160000
     FnAttrs.addMemoryAttr(MemoryEffects::inaccessibleMemOnly());
-#else
-    FnAttrs.addAttribute(Attribute::InaccessibleMemOnly);
-#endif
     FnAttrs.addAttribute(Attribute::WillReturn);
     FnAttrs.addAttribute(Attribute::NoUnwind);
     return AttributeList::get(C,
@@ -671,11 +663,7 @@ static AttributeList get_attrs_box_float(LLVMContext &C, unsigned nbytes)
     auto FnAttrs = AttrBuilder(C);
     FnAttrs.addAttribute(Attribute::WillReturn);
     FnAttrs.addAttribute(Attribute::NoUnwind);
-#if JL_LLVM_VERSION >= 160000
     FnAttrs.addMemoryAttr(MemoryEffects::inaccessibleMemOnly());
-#else
-    FnAttrs.addAttribute(Attribute::InaccessibleMemOnly);
-#endif
     auto RetAttrs = AttrBuilder(C);
     RetAttrs.addAttribute(Attribute::NonNull);
     RetAttrs.addDereferenceableAttr(nbytes);
@@ -691,11 +679,7 @@ static AttributeList get_attrs_box_sext(LLVMContext &C, unsigned nbytes)
     auto FnAttrs = AttrBuilder(C);
     FnAttrs.addAttribute(Attribute::WillReturn);
     FnAttrs.addAttribute(Attribute::NoUnwind);
-#if JL_LLVM_VERSION >= 160000
     FnAttrs.addMemoryAttr(MemoryEffects::inaccessibleMemOnly());
-#else
-    FnAttrs.addAttribute(Attribute::InaccessibleMemOnly);
-#endif
     auto RetAttrs = AttrBuilder(C);
     RetAttrs.addAttribute(Attribute::NonNull);
     RetAttrs.addAttribute(Attribute::getWithDereferenceableBytes(C, nbytes));
@@ -712,11 +696,7 @@ static AttributeList get_attrs_box_zext(LLVMContext &C, unsigned nbytes)
     auto FnAttrs = AttrBuilder(C);
     FnAttrs.addAttribute(Attribute::WillReturn);
     FnAttrs.addAttribute(Attribute::NoUnwind);
-#if JL_LLVM_VERSION >= 160000
     FnAttrs.addMemoryAttr(MemoryEffects::inaccessibleMemOnly());
-#else
-    FnAttrs.addAttribute(Attribute::InaccessibleMemOnly);
-#endif
     auto RetAttrs = AttrBuilder(C);
     RetAttrs.addAttribute(Attribute::NonNull);
     RetAttrs.addDereferenceableAttr(nbytes);
@@ -1141,12 +1121,7 @@ static const auto jlegalx_func = new JuliaFunction<TypeFnContextAndSizeT>{
         return FunctionType::get(getInt32Ty(C), {T, T, T_size}, false); },
     [](LLVMContext &C) {
         AttrBuilder FnAttrs(C);
-#if JL_LLVM_VERSION >= 160000
         FnAttrs.addMemoryAttr(MemoryEffects::inaccessibleOrArgMemOnly());
-#else
-        FnAttrs.addAttribute(Attribute::ReadOnly);
-        FnAttrs.addAttribute(Attribute::ArgMemOnly);
-#endif
         FnAttrs.addAttribute(Attribute::NoUnwind);
         return AttributeList::get(C,
                 AttributeSet::get(C, FnAttrs),
@@ -1166,9 +1141,7 @@ static const auto jl_alloc_obj_func = new JuliaFunction<TypeFnContextAndSizeT>{
         auto FnAttrs = AttrBuilder(C);
         FnAttrs.addAllocSizeAttr(1, None); // returns %1 bytes
         FnAttrs.addAllocKindAttr(AllocFnKind::Alloc);
-#if JL_LLVM_VERSION >= 160000
         FnAttrs.addMemoryAttr(MemoryEffects::argMemOnly(ModRefInfo::Ref) | MemoryEffects::inaccessibleMemOnly(ModRefInfo::ModRef));
-#endif
         FnAttrs.addAttribute(Attribute::WillReturn);
         FnAttrs.addAttribute(Attribute::NoUnwind);
         auto RetAttrs = AttrBuilder(C);
@@ -1204,11 +1177,7 @@ static const auto jl_typeof_func = new JuliaFunction<>{
     },
     [](LLVMContext &C) {
         AttrBuilder FnAttrs(C);
-#if JL_LLVM_VERSION >= 160000
         FnAttrs.addMemoryAttr(MemoryEffects::none());
-#else
-        FnAttrs.addAttribute(Attribute::ReadNone);
-#endif
         FnAttrs.addAttribute(Attribute::NoUnwind);
         FnAttrs.addAttribute(Attribute::NoRecurse);
         return AttributeList::get(C,
@@ -1223,11 +1192,7 @@ static const auto jl_write_barrier_func = new JuliaFunction<>{
             {JuliaType::get_prjlvalue_ty(C)}, true); },
     [](LLVMContext &C) {
         AttrBuilder FnAttrs(C);
-#if JL_LLVM_VERSION >= 160000
         FnAttrs.addMemoryAttr(MemoryEffects::inaccessibleMemOnly());
-#else
-        FnAttrs.addAttribute(Attribute::InaccessibleMemOnly);
-#endif
         FnAttrs.addAttribute(Attribute::NoUnwind);
         FnAttrs.addAttribute(Attribute::NoRecurse);
         return AttributeList::get(C,
@@ -1300,12 +1265,7 @@ static const auto memcmp_func = new JuliaFunction<TypeFnContextAndSizeT>{
             {getPointerTy(C), getPointerTy(C), T_size}, false); },
     [](LLVMContext &C) {
         AttrBuilder FnAttrs(C);
-#if JL_LLVM_VERSION >= 160000
         FnAttrs.addMemoryAttr(MemoryEffects::argMemOnly(ModRefInfo::Ref));
-#else
-        FnAttrs.addAttribute(Attribute::ArgMemOnly);
-        FnAttrs.addAttribute(Attribute::ReadOnly);
-#endif
         FnAttrs.addAttribute(Attribute::NoUnwind);
         return AttributeList::get(C,
             AttributeSet::get(C, FnAttrs),
@@ -1355,11 +1315,7 @@ static const auto jlfieldindex_func = new JuliaFunction<>{
     },
     [](LLVMContext &C) {
         AttrBuilder FnAttrs(C);
-#if JL_LLVM_VERSION >= 160000
         FnAttrs.addMemoryAttr(MemoryEffects::readOnly());
-#else
-        FnAttrs.addAttribute(Attribute::ReadOnly);
-#endif
         FnAttrs.addAttribute(Attribute::NoUnwind);
         FnAttrs.addAttribute(Attribute::WillReturn);
         return AttributeList::get(C,
@@ -1425,9 +1381,7 @@ static const auto jl_allocgenericmemory = new JuliaFunction<TypeFnContextAndSize
         [](LLVMContext &C) {
             AttrBuilder FnAttrs(C);
             AttrBuilder RetAttrs(C);
-#if JL_LLVM_VERSION >= 160000
             FnAttrs.addMemoryAttr(MemoryEffects::inaccessibleMemOnly(ModRefInfo::ModRef) | MemoryEffects::argMemOnly(ModRefInfo::Ref));
-#endif
             FnAttrs.addAttribute(Attribute::WillReturn);
             RetAttrs.addAlignmentAttr(Align(16));
             RetAttrs.addAttribute(Attribute::NonNull);
@@ -1505,11 +1459,7 @@ static const auto pointer_from_objref_func = new JuliaFunction<>{
             {PointerType::get(JuliaType::get_jlvalue_ty(C), AddressSpace::Derived)}, false); },
     [](LLVMContext &C) {
         AttrBuilder FnAttrs(C);
-#if JL_LLVM_VERSION >= 160000
         FnAttrs.addMemoryAttr(MemoryEffects::none());
-#else
-        FnAttrs.addAttribute(Attribute::ReadNone);
-#endif
         FnAttrs.addAttribute(Attribute::NoUnwind);
         return AttributeList::get(C,
             AttributeSet::get(C, FnAttrs),
@@ -1532,11 +1482,7 @@ static const auto gc_loaded_func = new JuliaFunction<>{
         FnAttrs.addAttribute(Attribute::Speculatable);
         FnAttrs.addAttribute(Attribute::WillReturn);
         FnAttrs.addAttribute(Attribute::NoRecurse);
-#if JL_LLVM_VERSION >= 160000
         FnAttrs.addMemoryAttr(MemoryEffects::none());
-#else
-        FnAttrs.addAttribute(Attribute::ReadNone);
-#endif
         AttrBuilder RetAttrs(C);
         RetAttrs.addAttribute(Attribute::NonNull);
         RetAttrs.addAttribute(Attribute::NoUndef);
@@ -2440,11 +2386,7 @@ static Value *emit_inttoptr(jl_codectx_t &ctx, Value *v, Type *ty)
         auto ptr = I->getOperand(0);
         if (ty->getPointerAddressSpace() == ptr->getType()->getPointerAddressSpace())
             return ptr;
-        #if JL_LLVM_VERSION >= 170000
         else
-        #else
-        else if (cast<PointerType>(ty)->hasSameElementTypeAs(cast<PointerType>(ptr->getType())))
-        #endif
             return ctx.builder.CreateAddrSpaceCast(ptr, ty);
     }
     ++EmittedIntToPtrs;
@@ -10343,10 +10285,6 @@ char jl_using_perf_jitevents = 0;
 
 int jl_is_timing_passes = 0;
 
-#if JL_LLVM_VERSION < 170000
-int jl_opaque_ptrs_set = 0;
-#endif
-
 extern "C" void jl_init_llvm(void)
 {
     jl_page_size = jl_getpagesize();
@@ -10365,12 +10303,8 @@ extern "C" void jl_init_llvm(void)
     initializeAnalysis(Registry);
     initializeTransformUtils(Registry);
     initializeInstCombine(Registry);
-#if JL_LLVM_VERSION >= 160000
-    // TODO
-#else
-    initializeAggressiveInstCombine(Registry);
-    initializeInstrumentation(Registry);
-#endif
+    // TODO: initializeAggressiveInstCombine(Registry);
+    // TODO: initializeInstrumentation(Registry);
     initializeTarget(Registry);
 #ifdef USE_POLLY
     polly::initializePollyPasses(Registry);
@@ -10395,17 +10329,6 @@ extern "C" void jl_init_llvm(void)
     clopt = llvmopts.lookup("combiner-store-merge-dependence-limit");
     if (clopt && clopt->getNumOccurrences() == 0)
         cl::ProvidePositionalOption(clopt, "4", 1);
-
-    #if JL_LLVM_VERSION < 170000
-    // we want the opaque-pointers to be opt-in, per LLVMContext, for this release
-    // so change the default value back to pre-14.x, without changing the NumOccurrences flag for it
-    clopt = llvmopts.lookup("opaque-pointers");
-    if (clopt && clopt->getNumOccurrences() == 0) {
-        clopt->addOccurrence(1, clopt->ArgStr, "false", true);
-    } else {
-        jl_opaque_ptrs_set = 1;
-    }
-    #endif
 
     clopt = llvmopts.lookup("time-passes");
     if (clopt && clopt->getNumOccurrences() > 0)

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -58,11 +58,7 @@
 #include "llvm-version.h"
 
 // for outputting disassembly
-#if JL_LLVM_VERSION >= 170000
 #include <llvm/TargetParser/Triple.h>
-#else
-#include <llvm/ADT/Triple.h>
-#endif
 #include <llvm/AsmParser/Parser.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/BinaryFormat/COFF.h>
@@ -505,7 +501,7 @@ jl_value_t *jl_dump_function_ir_impl(jl_llvmf_dump_t *dump, char strip_ir_metada
         auto TSM = std::unique_ptr<orc::ThreadSafeModule>(unwrap(dump->TSM));
         //If TSM is not passed in, then the context MUST be locked externally.
         //RAII will release the lock
-        Optional<orc::ThreadSafeContext::Lock> lock;
+        std::optional<orc::ThreadSafeContext::Lock> lock;
         if (TSM) {
             lock.emplace(TSM->getContext().getLock());
         }
@@ -1107,11 +1103,7 @@ static void jl_dump_asm_internal(
                             const MCOperand &OpI = Inst.getOperand(Op);
                             if (OpI.isImm()) {
                                 int64_t imm = OpI.getImm();
-                                #if JL_LLVM_VERSION >= 170000
                                 if (opinfo.operands()[Op].OperandType == MCOI::OPERAND_PCREL)
-                                #else
-                                if (opinfo.OpInfo[Op].OperandType == MCOI::OPERAND_PCREL)
-                                #endif
                                     imm += Fptr + Index;
                                 const char *name = DisInfo.lookupSymbolName(imm);
                                 if (name)

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -37,11 +37,7 @@
 #include <llvm/CodeGen/TargetSubtargetInfo.h>
 #include <llvm/MC/TargetRegistry.h>
 #include <llvm/Target/TargetOptions.h>
-#if JL_LLVM_VERSION >= 170000
 #include <llvm/TargetParser/Host.h>
-#else
-#include <llvm/Support/Host.h>
-#endif
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Object/SymbolSize.h>
 
@@ -1103,22 +1099,13 @@ public:
         return Error::success();
     }
 
-#if JL_LLVM_VERSION >= 160000
     Error notifyRemovingResources(JITDylib &JD, orc::ResourceKey K) override
-#else
-    Error notifyRemovingResources(orc::ResourceKey K) override
-#endif
     {
         return Error::success();
     }
 
-#if JL_LLVM_VERSION >= 160000
     void notifyTransferringResources(JITDylib &JD, orc::ResourceKey DstKey,
                                      orc::ResourceKey SrcKey) override {}
-#else
-    void notifyTransferringResources(orc::ResourceKey DstKey,
-                                     orc::ResourceKey SrcKey) override {}
-#endif
 
     void modifyPassConfig(MaterializationResponsibility &MR, jitlink::LinkGraph &,
                           jitlink::PassConfiguration &PassConfig) override
@@ -1168,21 +1155,12 @@ public:
     Error notifyFailed(orc::MaterializationResponsibility &MR) override {
         return Error::success();
     }
-#if JL_LLVM_VERSION >= 160000
     Error notifyRemovingResources(JITDylib &JD, orc::ResourceKey K) override
-#else
-    Error notifyRemovingResources(orc::ResourceKey K) override
-#endif
     {
         return Error::success();
     }
-#if JL_LLVM_VERSION >= 160000
     void notifyTransferringResources(JITDylib &JD, orc::ResourceKey DstKey,
                                      orc::ResourceKey SrcKey) override {}
-#else
-    void notifyTransferringResources(orc::ResourceKey DstKey,
-                                     orc::ResourceKey SrcKey) override {}
-#endif
 
     void modifyPassConfig(orc::MaterializationResponsibility &,
                           jitlink::LinkGraph &,
@@ -1199,11 +1177,7 @@ public:
                 for (auto block : section.blocks()) {
                     secsize += block->getSize();
                 }
-#if JL_LLVM_VERSION >= 160000
                 if ((section.getMemProt() & orc::MemProt::Exec) == orc::MemProt::None) {
-#else
-                if ((section.getMemProt() & jitlink::MemProt::Exec) == jitlink::MemProt::None) {
-#endif
                     data_size += secsize;
                 } else {
                     code_size += secsize;
@@ -1235,11 +1209,7 @@ public:
 // TODO: Port our memory management optimisations to JITLink instead of using the
 // default InProcessMemoryManager.
 std::unique_ptr<jitlink::JITLinkMemoryManager> createJITLinkMemoryManager() JL_NOTSAFEPOINT {
-#if JL_LLVM_VERSION < 160000
-    return cantFail(orc::MapperJITLinkMemoryManager::CreateWithMapper<orc::InProcessMemoryMapper>());
-#else
     return cantFail(orc::MapperJITLinkMemoryManager::CreateWithMapper<orc::InProcessMemoryMapper>(/*Reservation Granularity*/ 16 * 1024 * 1024));
-#endif
 }
 
 #ifdef _COMPILER_CLANG_
@@ -1288,21 +1258,11 @@ public:
                                      bool IsReadOnly) override {
         return MemMgr->allocateDataSection(Size, Alignment, SectionID, SectionName, IsReadOnly);
     }
-#if JL_LLVM_VERSION >= 160000
     virtual void reserveAllocationSpace(uintptr_t CodeSize, Align CodeAlign,
                                         uintptr_t RODataSize, Align RODataAlign,
                                         uintptr_t RWDataSize, Align RWDataAlign) override {
         return MemMgr->reserveAllocationSpace(CodeSize, CodeAlign, RODataSize, RODataAlign, RWDataSize, RWDataAlign);
     }
-#else
-    virtual void reserveAllocationSpace(uintptr_t CodeSize, uint32_t CodeAlign,
-                                        uintptr_t RODataSize,
-                                        uint32_t RODataAlign,
-                                        uintptr_t RWDataSize,
-                                        uint32_t RWDataAlign) override {
-        return MemMgr->reserveAllocationSpace(CodeSize, CodeAlign, RODataSize, RODataAlign, RWDataSize, RWDataAlign);
-    }
-#endif
     virtual bool needsToReserveAllocationSpace() override {
         return MemMgr->needsToReserveAllocationSpace();
     }
@@ -1415,7 +1375,7 @@ namespace {
             FeaturesStr = Features.getString();
         }
         // Allocate a target...
-        Optional<CodeModel::Model> codemodel =
+        std::optional<CodeModel::Model> codemodel =
 #ifdef _P64
             // Make sure we are using the large code model on 64bit
             // Let LLVM pick a default suitable for jitting on 32bit
@@ -1830,11 +1790,6 @@ struct JuliaOJIT::DLSymOptimizer {
                     if (named) {
                         auto T = GV.getValueType();
                         assert(T->isPointerTy());
-                        #if JL_LLVM_VERSION < 170000
-                        if (!T->isOpaquePointerTy()) {
-                            T = T->getNonOpaquePointerElementType();
-                        }
-                        #endif
                         init = GlobalAlias::create(T, 0, GlobalValue::PrivateLinkage, GV.getName() + ".jit", init, &M);
                     }
                     GV.setInitializer(init);
@@ -1885,11 +1840,6 @@ struct JuliaOJIT::DLSymOptimizer {
                         if (named) {
                             auto T = CI->getType();
                             assert(T->isPointerTy());
-                            #if JL_LLVM_VERSION < 170000
-                            if (!T->isOpaquePointerTy()) {
-                                T = T->getNonOpaquePointerElementType();
-                            }
-                            #endif
                             init = GlobalAlias::create(T, 0, GlobalValue::PrivateLinkage, CI->getName() + ".jit", init, &M);
                         }
                         // DCE and SimplifyCFG will kill the branching structure around
@@ -1932,19 +1882,6 @@ void fixupTM(TargetMachine &TM) {
             TM.setFastISel(false);
     }
 }
-
-#if JL_LLVM_VERSION < 170000
-extern int jl_opaque_ptrs_set;
-void SetOpaquePointer(LLVMContext &ctx) {
-    if (jl_opaque_ptrs_set)
-        return;
-#ifndef JL_LLVM_OPAQUE_POINTERS
-    ctx.setOpaquePointers(false);
-#else
-    ctx.setOpaquePointers(true);
-#endif
-}
-#endif
 
 llvm::DataLayout jl_create_datalayout(TargetMachine &TM) {
     // Mark our address spaces as non-integral
@@ -2053,7 +1990,7 @@ JuliaOJIT::JuliaOJIT()
 
     orc::SymbolAliasMap jl_crt = {
         // Float16 conversion routines
-#if defined(_CPU_X86_64_) && defined(_OS_DARWIN_) && JL_LLVM_VERSION >= 160000
+#if defined(_CPU_X86_64_) && defined(_OS_DARWIN_)
         // LLVM 16 reverted to soft-float ABI for passing half on x86_64 Darwin
         // https://github.com/llvm/llvm-project/commit/2bcf51c7f82ca7752d1bba390a2e0cb5fdd05ca9
         { mangle("__gnu_h2f_ieee"), { mangle("julia_half_to_float"),  JITSymbolFlags::Exported } },
@@ -2087,7 +2024,6 @@ JuliaOJIT::JuliaOJIT()
 
 #ifdef MSAN_EMUTLS_WORKAROUND
     orc::SymbolMap msan_crt;
-    #if JL_LLVM_VERSION >= 170000
     msan_crt[mangle("__emutls_get_address")] = {ExecutorAddr::fromPtr(msan_workaround::getTLSAddress), JITSymbolFlags::Exported};
     msan_crt[mangle("__emutls_v.__msan_param_tls")] = {ExecutorAddr::fromPtr(
         reinterpret_cast<void *>(static_cast<uintptr_t>(msan_workaround::MSanTLS::param))), JITSymbolFlags::Exported};
@@ -2105,25 +2041,6 @@ JuliaOJIT::JuliaOJIT()
         reinterpret_cast<void *>(static_cast<uintptr_t>(msan_workaround::MSanTLS::va_arg_overflow_size))), JITSymbolFlags::Exported};
     msan_crt[mangle("__emutls_v.__msan_origin_tls")] = {ExecutorAddr::fromPtr(
         reinterpret_cast<void *>(static_cast<uintptr_t>(msan_workaround::MSanTLS::origin))), JITSymbolFlags::Exported};
-    #else
-    msan_crt[mangle("__emutls_get_address")] = JITEvaluatedSymbol::fromPointer(msan_workaround::getTLSAddress, JITSymbolFlags::Exported);
-    msan_crt[mangle("__emutls_v.__msan_param_tls")] = JITEvaluatedSymbol::fromPointer(
-        reinterpret_cast<void *>(static_cast<uintptr_t>(msan_workaround::MSanTLS::param)), JITSymbolFlags::Exported);
-    msan_crt[mangle("__emutls_v.__msan_param_origin_tls")] = JITEvaluatedSymbol::fromPointer(
-        reinterpret_cast<void *>(static_cast<uintptr_t>(msan_workaround::MSanTLS::param_origin)), JITSymbolFlags::Exported);
-    msan_crt[mangle("__emutls_v.__msan_retval_tls")] = JITEvaluatedSymbol::fromPointer(
-        reinterpret_cast<void *>(static_cast<uintptr_t>(msan_workaround::MSanTLS::retval)), JITSymbolFlags::Exported);
-    msan_crt[mangle("__emutls_v.__msan_retval_origin_tls")] = JITEvaluatedSymbol::fromPointer(
-        reinterpret_cast<void *>(static_cast<uintptr_t>(msan_workaround::MSanTLS::retval_origin)), JITSymbolFlags::Exported);
-    msan_crt[mangle("__emutls_v.__msan_va_arg_tls")] = JITEvaluatedSymbol::fromPointer(
-        reinterpret_cast<void *>(static_cast<uintptr_t>(msan_workaround::MSanTLS::va_arg)), JITSymbolFlags::Exported);
-    msan_crt[mangle("__emutls_v.__msan_va_arg_origin_tls")] = JITEvaluatedSymbol::fromPointer(
-        reinterpret_cast<void *>(static_cast<uintptr_t>(msan_workaround::MSanTLS::va_arg_origin)), JITSymbolFlags::Exported);
-    msan_crt[mangle("__emutls_v.__msan_va_arg_overflow_size_tls")] = JITEvaluatedSymbol::fromPointer(
-        reinterpret_cast<void *>(static_cast<uintptr_t>(msan_workaround::MSanTLS::va_arg_overflow_size)), JITSymbolFlags::Exported);
-    msan_crt[mangle("__emutls_v.__msan_origin_tls")] = JITEvaluatedSymbol::fromPointer(
-        reinterpret_cast<void *>(static_cast<uintptr_t>(msan_workaround::MSanTLS::origin)), JITSymbolFlags::Exported);
-    #endif
     cantFail(GlobalJD.define(orc::absoluteSymbols(msan_crt)));
 #endif
 #if JL_LLVM_VERSION < 190000
@@ -2133,11 +2050,7 @@ JuliaOJIT::JuliaOJIT()
     // hopefully fixed upstream by e7698a13e319a9919af04d3d693a6f6ea7168a44
     static int64_t jl___asan_globals_registered;
     orc::SymbolMap asan_crt;
-    #if JL_LLVM_VERSION >= 170000
     asan_crt[mangle("___asan_globals_registered")] = {ExecutorAddr::fromPtr(&jl___asan_globals_registered), JITSymbolFlags::Common | JITSymbolFlags::Exported};
-    #else
-    asan_crt[mangle("___asan_globals_registered")] = JITEvaluatedSymbol::fromPointer(&jl___asan_globals_registered, JITSymbolFlags::Common | JITSymbolFlags::Exported);
-    #endif
     cantFail(JD.define(orc::absoluteSymbols(asan_crt)));
 #endif
 #endif
@@ -2148,9 +2061,6 @@ JuliaOJIT::~JuliaOJIT() = default;
 ThreadSafeContext JuliaOJIT::makeContext()
 {
     auto ctx = std::make_unique<LLVMContext>();
-    #if JL_LLVM_VERSION < 170000
-    SetOpaquePointer(*ctx);
-    #endif
     return orc::ThreadSafeContext(std::move(ctx));
 }
 
@@ -2162,11 +2072,7 @@ orc::SymbolStringPtr JuliaOJIT::mangle(StringRef Name)
 
 void JuliaOJIT::addGlobalMapping(StringRef Name, uint64_t Addr)
 {
-    #if JL_LLVM_VERSION >= 170000
     cantFail(JD.define(orc::absoluteSymbols({{mangle(Name), {ExecutorAddr::fromPtr((void*)Addr), JITSymbolFlags::Exported}}})));
-    #else
-    cantFail(JD.define(orc::absoluteSymbols({{mangle(Name), JITEvaluatedSymbol::fromPointer((void*)Addr)}})));
-    #endif
 }
 
 void JuliaOJIT::addModule(orc::ThreadSafeModule TSM)
@@ -2245,7 +2151,6 @@ SmallVector<uint64_t> JuliaOJIT::findSymbols(ArrayRef<StringRef> Names)
     return Addrs;
 }
 
-#if JL_LLVM_VERSION >= 170000
 Expected<ExecutorSymbolDef> JuliaOJIT::findSymbol(StringRef Name, bool ExportedSymbolsOnly)
 {
     orc::JITDylib* SearchOrders[3] = {&JD, &GlobalJD, &ExternalJD};
@@ -2286,50 +2191,6 @@ uint64_t JuliaOJIT::getFunctionAddress(StringRef Name)
     }
     return addr->getAddress().getValue();
 }
-#else
-JL_JITSymbol JuliaOJIT::findSymbol(StringRef Name, bool ExportedSymbolsOnly)
-{
-    orc::JITDylib* SearchOrders[3] = {&JD, &GlobalJD, &ExternalJD};
-    ArrayRef<orc::JITDylib*> SearchOrder = ArrayRef<orc::JITDylib*>(&SearchOrders[0], ExportedSymbolsOnly ? 3 : 1);
-    auto Sym = ES.lookup(SearchOrder, Name);
-    if (Sym)
-        return *Sym;
-    return Sym.takeError();
-}
-
-JL_JITSymbol JuliaOJIT::findUnmangledSymbol(StringRef Name)
-{
-    return findSymbol(getMangledName(Name), true);
-}
-
-Expected<JL_JITSymbol> JuliaOJIT::findExternalJDSymbol(StringRef Name, bool ExternalJDOnly)
-{
-    orc::JITDylib* SearchOrders[3] = {&ExternalJD, &GlobalJD, &JD};
-    ArrayRef<orc::JITDylib*> SearchOrder = ArrayRef<orc::JITDylib*>(&SearchOrders[0], ExternalJDOnly ? 1 : 3);
-    auto Sym = ES.lookup(SearchOrder, getMangledName(Name));
-    return Sym;
-}
-
-uint64_t JuliaOJIT::getGlobalValueAddress(StringRef Name)
-{
-    auto addr = findSymbol(getMangledName(Name), false);
-    if (!addr) {
-        consumeError(addr.takeError());
-        return 0;
-    }
-    return cantFail(addr).getAddress();
-}
-
-uint64_t JuliaOJIT::getFunctionAddress(StringRef Name)
-{
-    auto addr = findSymbol(getMangledName(Name), false);
-    if (!addr) {
-        consumeError(addr.takeError());
-        return 0;
-    }
-    return cantFail(addr).getAddress();
-}
-#endif
 
 StringRef JuliaOJIT::getFunctionAtAddress(uint64_t Addr, jl_callptr_t invoke, jl_code_instance_t *codeinst)
 {
@@ -2361,13 +2222,8 @@ StringRef JuliaOJIT::getFunctionAtAddress(uint64_t Addr, jl_callptr_t invoke, jl
 }
 
 #ifdef JL_USE_JITLINK
-#if JL_LLVM_VERSION >= 170000
 #define addAbsoluteToMap(map,name) \
     (map[mangle(#name)] = {ExecutorAddr::fromPtr(&name), JITSymbolFlags::Exported | JITSymbolFlags::Callable}, orc::ExecutorAddr::fromPtr(&name))
-#else
-#define addAbsoluteToMap(map,name) \
-    (map[mangle(#name)] = JITEvaluatedSymbol::fromPointer(&name, JITSymbolFlags::Exported | JITSymbolFlags::Callable), orc::ExecutorAddr::fromPtr(&name))
-#endif
 
 void JuliaOJIT::enableJITDebuggingSupport()
 {
@@ -2552,11 +2408,7 @@ void jl_merge_module(orc::ThreadSafeModule &destTSM, orc::ThreadSafeModule srcTS
                 }
                 // Reparent the global variable:
                 SG.removeFromParent();
-                #if JL_LLVM_VERSION >= 170000
                 dest.insertGlobalVariable(&SG);
-                #else
-                dest.getGlobalList().push_back(&SG);
-                #endif
                 // Comdat is owned by the Module
                 SG.setComdat(nullptr);
             }
@@ -2603,11 +2455,7 @@ void jl_merge_module(orc::ThreadSafeModule &destTSM, orc::ThreadSafeModule srcTS
                     }
                 }
                 SG.removeFromParent();
-                #if JL_LLVM_VERSION >= 170000
                 dest.insertAlias(&SG);
-                #else
-                dest.getAliasList().push_back(&SG);
-                #endif
             }
 
             // metadata nodes need to be explicitly merged not just copied

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -363,14 +363,6 @@ private:
 };
 using MaxAlignedAlloc = MaxAlignedAllocImpl<>;
 
-#if JL_LLVM_VERSION < 170000
-typedef JITSymbol JL_JITSymbol;
-// The type that is similar to SymbolInfo on LLVM 4.0 is actually
-// `JITEvaluatedSymbol`. However, we only use this type when a JITSymbol
-// is expected.
-typedef JITSymbol JL_SymbolInfo;
-#endif
-
 using CompilerResultT = Expected<std::unique_ptr<llvm::MemoryBuffer>>;
 using OptimizerResultT = Expected<orc::ThreadSafeModule>;
 using SharedBytesT = StringSet<MaxAlignedAllocImpl<sizeof(StringSet<>::MapEntryTy)>>;
@@ -472,7 +464,7 @@ public:
             }
             private:
             ResourcePool &pool;
-            Optional<ResourceT> resource;
+            std::optional<ResourceT> resource;
         };
 
         OwningResource operator*() JL_NOTSAFEPOINT {
@@ -558,16 +550,10 @@ public:
     orc::ExecutionSession &getExecutionSession() JL_NOTSAFEPOINT { return ES; }
     orc::JITDylib &getExternalJITDylib() JL_NOTSAFEPOINT { return ExternalJD; }
 
-    #if JL_LLVM_VERSION >= 170000
     Expected<llvm::orc::ExecutorSymbolDef> findSymbol(StringRef Name, bool ExportedSymbolsOnly) JL_NOTSAFEPOINT;
     Expected<llvm::orc::ExecutorSymbolDef> findUnmangledSymbol(StringRef Name) JL_NOTSAFEPOINT;
     Expected<llvm::orc::ExecutorSymbolDef> findExternalJDSymbol(StringRef Name, bool ExternalJDOnly) JL_NOTSAFEPOINT;
     SmallVector<uint64_t> findSymbols(ArrayRef<StringRef> Names) JL_NOTSAFEPOINT;
-    #else
-    JITEvaluatedSymbol findSymbol(StringRef Name, bool ExportedSymbolsOnly) JL_NOTSAFEPOINT;
-    JITEvaluatedSymbol findUnmangledSymbol(StringRef Name) JL_NOTSAFEPOINT;
-    Expected<JITEvaluatedSymbol> findExternalJDSymbol(StringRef Name, bool ExternalJDOnly) JL_NOTSAFEPOINT;
-    #endif
     uint64_t getGlobalValueAddress(StringRef Name) JL_NOTSAFEPOINT;
     uint64_t getFunctionAddress(StringRef Name) JL_NOTSAFEPOINT;
     StringRef getFunctionAtAddress(uint64_t Addr, jl_callptr_t invoke, jl_code_instance_t *codeinst) JL_NOTSAFEPOINT;
@@ -659,10 +645,6 @@ Module &jl_codegen_params_t::shared_module() JL_NOTSAFEPOINT {
     return *_shared_module;
 }
 void fixupTM(TargetMachine &TM) JL_NOTSAFEPOINT;
-
-#if JL_LLVM_VERSION < 170000
-void SetOpaquePointer(LLVMContext &ctx) JL_NOTSAFEPOINT;
-#endif
 
 void optimizeDLSyms(Module &M);
 

--- a/src/llvm-cpufeatures.cpp
+++ b/src/llvm-cpufeatures.cpp
@@ -37,7 +37,7 @@ STATISTIC(LoweredWithoutFMA, "Number of have_fma's that were lowered to false");
 extern JuliaOJIT *jl_ExecutionEngine;
 
 // whether this platform unconditionally (i.e. without needing multiversioning) supports FMA
-Optional<bool> always_have_fma(Function &intr, const Triple &TT) JL_NOTSAFEPOINT {
+std::optional<bool> always_have_fma(Function &intr, const Triple &TT) JL_NOTSAFEPOINT {
     if (TT.isAArch64()) {
         auto intr_name = intr.getName();
         auto typ = intr_name.substr(strlen("julia.cpu.have_fma."));

--- a/src/llvm-julia-licm.cpp
+++ b/src/llvm-julia-licm.cpp
@@ -342,11 +342,7 @@ struct JuliaLICM : public JuliaPassContext {
             }
         }
         if (changed && SE) {
-#if JL_LLVM_VERSION >= 160000
             SE->forgetLoopDispositions();
-#else
-            SE->forgetLoopDispositions(L);
-#endif
         }
 #ifdef JL_VERIFY_PASSES
         assert(!verifyLLVMIR(*L));

--- a/src/llvm-lower-handlers.cpp
+++ b/src/llvm-lower-handlers.cpp
@@ -8,11 +8,7 @@
 
 #include <llvm/ADT/DepthFirstIterator.h>
 #include <llvm/ADT/Statistic.h>
-#if JL_LLVM_VERSION >= 170000
 #include <llvm/TargetParser/Triple.h>
-#else
-#include <llvm/ADT/Triple.h>
-#endif
 #include <llvm/Analysis/CFG.h>
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Constants.h>

--- a/src/llvm-multiversioning.cpp
+++ b/src/llvm-multiversioning.cpp
@@ -15,11 +15,7 @@
 #include <llvm/ADT/SmallString.h>
 #include <llvm/ADT/BitVector.h>
 #include <llvm/ADT/Statistic.h>
-#if JL_LLVM_VERSION >= 170000
 #include <llvm/TargetParser/Triple.h>
-#else
-#include <llvm/ADT/Triple.h>
-#endif
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
@@ -51,7 +47,7 @@
 
 using namespace llvm;
 
-extern Optional<bool> always_have_fma(Function&, const Triple &TT);
+extern std::optional<bool> always_have_fma(Function&, const Triple &TT);
 
 namespace {
 constexpr uint32_t clone_mask =
@@ -185,7 +181,7 @@ struct TargetSpec {
     }
 };
 
-static Optional<SmallVector<TargetSpec, 0>> get_target_specs(Module &M) {
+static std::optional<SmallVector<TargetSpec, 0>> get_target_specs(Module &M) {
     auto md = M.getModuleFlag("julia.mv.specs");
     if (!md)
         return None;

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -129,9 +129,7 @@ namespace jl_intrinsics {
     static Function *addGCAllocAttributes(Function *target)
     {
         auto FnAttrs = AttrBuilder(target->getContext());
-#if JL_LLVM_VERSION >= 160000
         FnAttrs.addMemoryAttr(MemoryEffects::argMemOnly(ModRefInfo::Ref) | MemoryEffects::inaccessibleMemOnly(ModRefInfo::ModRef));
-#endif
         FnAttrs.addAllocKindAttr(AllocFnKind::Alloc);
         FnAttrs.addAttribute(Attribute::WillReturn);
         FnAttrs.addAttribute(Attribute::NoUnwind);
@@ -228,11 +226,7 @@ namespace jl_intrinsics {
                     false),
                 Function::ExternalLinkage,
                 QUEUE_GC_ROOT_NAME);
-#if JL_LLVM_VERSION >= 160000
             intrinsic->setMemoryEffects(MemoryEffects::inaccessibleOrArgMemOnly());
-#else
-            intrinsic->addFnAttr(Attribute::InaccessibleMemOrArgMemOnly);
-#endif
             return intrinsic;
         });
 
@@ -248,11 +242,7 @@ namespace jl_intrinsics {
                     false),
                 Function::ExternalLinkage,
                 SAFEPOINT_NAME);
-#if JL_LLVM_VERSION >= 160000
             intrinsic->setMemoryEffects(MemoryEffects::inaccessibleOrArgMemOnly());
-#else
-            intrinsic->addFnAttr(Attribute::InaccessibleMemOrArgMemOnly);
-#endif
             return intrinsic;
         });
 }
@@ -309,11 +299,7 @@ namespace jl_well_known {
                     false),
                 Function::ExternalLinkage,
                 GC_QUEUE_ROOT_NAME);
-#if JL_LLVM_VERSION >= 160000
             func->setMemoryEffects(MemoryEffects::inaccessibleOrArgMemOnly());
-#else
-            func->addFnAttr(Attribute::InaccessibleMemOrArgMemOnly);
-#endif
             return func;
         });
 

--- a/src/llvm-propagate-addrspaces.cpp
+++ b/src/llvm-propagate-addrspaces.cpp
@@ -163,22 +163,14 @@ Value *PropagateJuliaAddrspacesVisitor::LiftPointer(Module *M, Value *V, Instruc
             Instruction *InstV = cast<Instruction>(V);
             Instruction *NewV = InstV->clone();
             ToInsert.push_back(std::make_pair(NewV, InstV));
-            #if JL_LLVM_VERSION >= 170000
             Type *NewRetTy = PointerType::get(InstV->getType(), allocaAddressSpace);
-            #else
-            Type *NewRetTy = PointerType::getWithSamePointeeType(cast<PointerType>(InstV->getType()), allocaAddressSpace);
-            #endif
             NewV->mutateType(NewRetTy);
             LiftingMap[InstV] = NewV;
             ToRevisit.push_back(NewV);
         }
     }
     auto CollapseCastsAndLift = [&](Value *CurrentV, Instruction *InsertPt) -> Value * {
-        #if JL_LLVM_VERSION >= 170000
         PointerType *TargetType = PointerType::get(CurrentV->getType(), allocaAddressSpace);
-        #else
-        PointerType *TargetType = PointerType::getWithSamePointeeType(cast<PointerType>(CurrentV->getType()), allocaAddressSpace);
-        #endif
         while (!LiftingMap.count(CurrentV)) {
             if (isa<BitCastInst>(CurrentV))
                 CurrentV = cast<BitCastInst>(CurrentV)->getOperand(0);
@@ -192,17 +184,7 @@ Value *PropagateJuliaAddrspacesVisitor::LiftPointer(Module *M, Value *V, Instruc
         }
         if (LiftingMap.count(CurrentV))
             CurrentV = LiftingMap[CurrentV];
-        #if JL_LLVM_VERSION >= 170000
         assert(CurrentV->getType() == TargetType);
-        #else
-        if (CurrentV->getType() != TargetType) {
-            // Shouldn't get here when using opaque pointers, so the new BitCastInst is fine
-            assert(CurrentV->getContext().supportsTypedPointers());
-            auto *BCI = new BitCastInst(CurrentV, TargetType);
-            ToInsert.push_back(std::make_pair(BCI, InsertPt));
-            CurrentV = BCI;
-        }
-        #endif
         return CurrentV;
     };
 

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -9,11 +9,7 @@
 #include <llvm-c/Types.h>
 
 #include <llvm/Pass.h>
-#if JL_LLVM_VERSION >= 170000
 #include <llvm/TargetParser/Triple.h>
-#else
-#include <llvm/ADT/Triple.h>
-#endif
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
@@ -67,11 +63,7 @@ private:
 
 void LowerPTLS::set_pgcstack_attrs(CallInst *pgcstack) const
 {
-#if JL_LLVM_VERSION >= 160000
     pgcstack->addFnAttr(Attribute::getWithMemoryEffects(pgcstack->getContext(), MemoryEffects::none()));
-#else
-    addFnAttr(pgcstack, Attribute::ReadNone);
-#endif
     addFnAttr(pgcstack, Attribute::NoUnwind);
 }
 

--- a/src/llvm-simdloop.cpp
+++ b/src/llvm-simdloop.cpp
@@ -297,11 +297,7 @@ static bool processLoop(Loop &L, OptimizationRemarkEmitter &ORE, ScalarEvolution
         }
 
         if (SE)
-#if JL_LLVM_VERSION >= 160000
             SE->forgetLoopDispositions();
-#else
-            SE->forgetLoopDispositions(&L);
-#endif
     }
 
 #ifdef JL_VERIFY_PASSES

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -10,12 +10,8 @@
 #define JL_LLVM_VERSION (LLVM_VERSION_MAJOR * 10000 + LLVM_VERSION_MINOR * 100 \
                         + LLVM_VERSION_PATCH)
 
-#if JL_LLVM_VERSION < 150000
-    #error Only LLVM versions >= 15.0.0 are supported by Julia
-#endif
-
-#if JL_LLVM_VERSION >= 160000
-    #define JL_LLVM_OPAQUE_POINTERS 1
+#if JL_LLVM_VERSION < 170000
+    #error Only LLVM versions >= 17.0.0 are supported by Julia
 #endif
 
 #if JL_LLVM_VERSION < 19000 && defined(_CPU_RISCV64_)

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -7,11 +7,7 @@
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringMap.h>
-#if JL_LLVM_VERSION >= 170000
 #include <llvm/TargetParser/Host.h>
-#else
-#include <llvm/Support/Host.h>
-#endif
 #include <llvm/Support/MathExtras.h>
 #include <llvm/Support/raw_ostream.h>
 
@@ -162,11 +158,7 @@ struct FeatureList {
     {
         int cnt = 0;
         for (size_t i = 0; i < n; i++)
-            #if JL_LLVM_VERSION >= 170000
             cnt += llvm::popcount(eles[i]);
-            #else
-            cnt += llvm::countPopulation(eles[i]);
-            #endif
         return cnt;
     }
     inline bool empty() const

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -4,11 +4,7 @@
 #include <map>
 #include <string>
 #include <llvm/ADT/StringMap.h>
-#if JL_LLVM_VERSION >= 170000
 #include <llvm/TargetParser/Host.h>
-#else
-#include <llvm/Support/Host.h>
-#endif
 #include <llvm/Support/raw_ostream.h>
 
 #include "julia.h"

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1574,7 +1574,6 @@ bi_iintrinsic_cnvtb_fast(LLVMAShr, ashr_op, ashr_int, , 1)
 //un_iintrinsic_fast(LLVMByteSwap, bswap_op, bswap_int, u)
 un_iintrinsic_slow(LLVMByteSwap, bswap_int, u)
 //#define ctpop_op(a) __builtin_ctpop(a)
-#if JL_LLVM_VERSION >= 170000
 //uu_iintrinsic_fast(LLVMPopcount, ctpop_op, ctpop_int, u)
 uu_iintrinsic_slow(LLVMPopcount, ctpop_int, u)
 //#define ctlz_op(a) __builtin_ctlz(a)
@@ -1583,16 +1582,6 @@ uu_iintrinsic_slow(LLVMCountl_zero, ctlz_int, u)
 //#define cttz_op(a) __builtin_cttz(a)
 //uu_iintrinsic_fast(LLVMCountr_zero, cttz_op, cttz_int, u)
 uu_iintrinsic_slow(LLVMCountr_zero, cttz_int, u)
-#else
-//uu_iintrinsic_fast(LLVMCountPopulation, ctpop_op, ctpop_int, u)
-uu_iintrinsic_slow(LLVMCountPopulation, ctpop_int, u)
-//#define ctlz_op(a) __builtin_ctlz(a)
-//uu_iintrinsic_fast(LLVMCountLeadingZeros, ctlz_op, ctlz_int, u)
-uu_iintrinsic_slow(LLVMCountLeadingZeros, ctlz_int, u)
-//#define cttz_op(a) __builtin_cttz(a)
-//uu_iintrinsic_fast(LLVMCountTrailingZeros, cttz_op, cttz_int, u)
-uu_iintrinsic_slow(LLVMCountTrailingZeros, cttz_int, u)
-#endif
 #define not_op(a) ~a
 un_iintrinsic_fast(LLVMFlipAllBits, not_op, not_int, u)
 

--- a/src/support/win32-clang-ABI-bug/optional
+++ b/src/support/win32-clang-ABI-bug/optional
@@ -57,7 +57,6 @@ namespace optional_detail {
 //
 // The move constructible / assignable conditions emulate the remaining behavior
 // of std::is_trivially_copyable.
-#if JL_LLVM_VERSION >= 170000
 template <typename T,
           bool = (std::is_trivially_copy_constructible<T>::value &&
                   std::is_trivially_copy_assignable<T>::value &&
@@ -65,15 +64,6 @@ template <typename T,
                    !std::is_move_constructible<T>::value) &&
                   (std::is_trivially_move_assignable<T>::value ||
                    !std::is_move_assignable<T>::value))>
-#else
-template <typename T,
-          bool = (llvm::is_trivially_copy_constructible<T>::value &&
-                  std::is_trivially_copy_assignable<T>::value &&
-                  (llvm::is_trivially_move_constructible<T>::value ||
-                   !std::is_move_constructible<T>::value) &&
-                  (std::is_trivially_move_assignable<T>::value ||
-                   !std::is_move_assignable<T>::value))>
-#endif
 class OptionalStorage {
   union {
     char empty;


### PR DESCRIPTION
Now that we use LLVM 18, and almost have LLVM 19 support, do cleanup to remove LLVM 15/16 support.