### PR TITLE
Hide IRShow include from Revise

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -181,12 +181,26 @@ include("bootstrap.jl")
 include("reflection_interface.jl")
 include("opaque_closure.jl")
 
+macro __SOURCE_FILE__()
+    __source__.file === nothing && return nothing
+    return __source__.file::Symbol
+end
+
 module IRShow end
+function load_irshow!()
+    if isdefined(Base, :end_base_include)
+        # This code path is exclusively for Revise, which may want to re-run this
+        # after bootstrap.
+        include(IRShow, Base.joinpath(Base.dirname(Base.String(@__SOURCE_FILE__)), "ssair/show.jl"))
+    else
+        include(IRShow, "ssair/show.jl")
+    end
+end
 if !isdefined(Base, :end_base_include)
     # During bootstrap, skip including this file and defer it to base/show.jl to include later
 else
     # When this module is loaded as the standard library, include this file as usual
-    include(IRShow, "ssair/show.jl")
+    load_irshow!()
 end
 
 end # baremodule Compiler

--- a/base/show.jl
+++ b/base/show.jl
@@ -2821,7 +2821,7 @@ function show(io::IO, vm::Core.TypeofVararg)
     end
 end
 
-Compiler.include(Compiler.IRShow, "ssair/show.jl") # define `show` for the compiler types
+Compiler.load_irshow!()
 const IRShow = Compiler.IRShow # an alias for compatibility
 
 function show(io::IO, src::CodeInfo; debuginfo::Symbol=:source)


### PR DESCRIPTION
Revise in theory wants to re-evaluate this include, but it fails at doing so, because the include call no longer works after bootstrap. It happens to work right now on master, because the lowering of `Compiler.include` happens to hide the include call from Revise, but that's a Revise bug I'm about to fix. Address this by moving the include call into the package and using an absolute include if necessary.