### PR TITLE
remove superfluous global keywords in scope docs

### DIFF
--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -589,7 +589,7 @@ julia> Fs = Vector{Any}(undef, 2); i = 1;
 
 julia> while i <= 2
            Fs[i] = ()->i
-           global i += 1
+           i += 1
        end
 
 julia> Fs[1]()
@@ -610,7 +610,7 @@ julia> while i <= 2
            let i = i
                Fs[i] = ()->i
            end
-           global i += 1
+           i += 1
        end
 
 julia> Fs[1]()


### PR DESCRIPTION
These `global` keywords seem like a remnant from when soft/hard scope worked differently.
I find the tutorial clearer without them.