### PR TITLE
Disable serial precompilation. Add warning when loaded dep versions mismatch env.

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2687,6 +2687,7 @@ function __require_prelocked(pkg::PkgId, env)
                             A dependency is already loaded with a different version than the version specified in the active environment.
                             $(repr("text/plain", pkg)) will be loaded directly and not precompiled.
                             There may be unexpected issues due to the dependency version mismatch.
+                            Use `pkg> status --manifest` to review the mismatched dependency versions.
                             """
                     else
                         @warn "Skipping precompilation due to precompilable error. Importing $(repr("text/plain", pkg)) directly." exception=loaded

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2682,9 +2682,14 @@ function __require_prelocked(pkg::PkgId, env)
                 @goto load_from_cache # the new cachefile will have the newest mtime so will come first in the search
             elseif isa(loaded, Exception)
                 if precompilableerror(loaded)
-                    if !disable_serial_precompile
-                        verbosity = isinteractive() ? CoreLogging.Info : CoreLogging.Debug
-                        @logmsg verbosity "Skipping precompilation due to precompilable error. Importing $(repr("text/plain", pkg))." exception=loaded
+                    if haskey(reasons, "wrong dep version loaded") # TODO: this is a bit of a hack as the dict is more of a debug thing
+                        @warn """
+                            A dependency is already loaded with a different version than the version specified in the active environment.
+                            $(repr("text/plain", pkg)) will be loaded directly and not precompiled.
+                            There may be unexpected issues due to the dependency version mismatch.
+                            """
+                    else
+                        @warn "Skipping precompilation due to precompilable error. Importing $(repr("text/plain", pkg)) directly." exception=loaded
                     end
                 else
                     @warn "The call to compilecache failed to create a usable precompiled cache file for $(repr("text/plain", pkg))" exception=loaded


### PR DESCRIPTION
Helps with https://github.com/JuliaLang/julia/issues/56766

- Disables serial precompilation, so if `precompilepkgs` wasn't able to cover the package, just load it without precompilation.
- Warns the user if it's because wrong dep versions are loaded
- https://github.com/JuliaLang/Pkg.jl/pull/4109 adds loaded mismatch info to `pkg> status`

An example where the default env has OrderedCollections v1.6.3 but the target env has v1.7.0

## This PR + https://github.com/JuliaLang/Pkg.jl/pull/4109
![Screenshot 2024-12-06 at 3 25 20 PM](https://github.com/user-attachments/assets/3115fb45-4117-4ae9-8a00-8343881b2dd0)



## Master
Note the `[ Info: Precompiling Tables ...` at the end

![Screenshot 2024-12-06 at 3 28 41 PM](https://github.com/user-attachments/assets/a2f6be0e-bfa8-48bf-98cd-79d2a3fd772a)
