### PR TITLE
handle stack with abstract eltype

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2962,6 +2962,12 @@ _typed_stack(dims::Integer, ::Type{T}, ::Type{S}, A) where {T,S} =
     _typed_stack(dims, T, S, IteratorSize(S), A)
 _typed_stack(dims::Integer, ::Type{T}, ::Type{S}, ::HasLength, A) where {T,S} =
     _typed_stack(dims, T, S, HasShape{1}(), A)
+
+function _typed_stack(dims::Integer, ::Type{T}, ::Type{S}, ::HasLength, A) where {T,S<:AbstractArray}
+    N = ndims(first(A))
+    _typed_stack(dims, T, S, HasShape{N}(), A)
+end
+
 function _typed_stack(dims::Integer, ::Type{T}, ::Type{S}, ::HasShape{N}, A) where {T,S,N}
     if dims == N+1
         _typed_stack(:, T, S, A, (_vec_axis(A),))

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1834,6 +1834,9 @@ end
     @test_throws ArgumentError stack(())
     @test_throws ArgumentError stack([])
     @test_throws ArgumentError stack(x for x in 1:3 if false)
+
+    # issue #56771
+    @test size(stack(AbstractArray[ones(1,2) for _=1:3]; dims=2)) == (1, 3, 2)
 end
 
 @testset "tests from PR 31644" begin


### PR DESCRIPTION
fixes #56771 

probably not perfectly universally robust, but I bet this catches 95%+ of encountered instances.