### PR TITLE
Add `promote_rule` methods instead of `promote_type`

### DIFF
--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -331,9 +331,11 @@ promote_rule(::Type{Bottom}, ::Type{Bottom}, slurp...) = Bottom # not strictly n
 promote_rule(::Type{Bottom}, ::Type{T}, slurp...) where {T} = T
 promote_rule(::Type{T}, ::Type{Bottom}, slurp...) where {T} = T
 
+# if both the arguments are identical, or if both the orderings in promote_rule
+# are defined to return identical results, we may return the result directly
 promote_result(::Type{T},::Type{T},::Type{T},::Type{T}) where {T} = T
-# If only one promote_rule is defined, use the definition directly
 promote_result(::Type,::Type,::Type{T},::Type{T}) where {T} = T
+# If only one promote_rule is defined, use the definition directly
 promote_result(::Type,::Type,::Type{T},::Type{Bottom}) where {T} = T
 promote_result(::Type,::Type,::Type{Bottom},::Type{T}) where {T} = T
 # if multiple promote_rules are defined, try to promote the results

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -307,8 +307,7 @@ function promote_type(::Type{T}, ::Type{S}) where {T,S}
     # Try promote_rule in both orders. Typically only one is defined,
     # and there is a fallback returning Bottom below, so the common case is
     #   promote_type(T, S) =>
-    #   promote_result(T, S, result, Bottom) =>
-    #   typejoin(result, Bottom) => result
+    #   promote_result(T, S, result, Bottom) => result
     promote_result(T, S, promote_rule(T,S), promote_rule(S,T))
 end
 

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -321,6 +321,7 @@ it for new types as appropriate.
 """
 function promote_rule end
 
+# add a level of indirection to avoid method ambiguities
 promote_rule(T::Type, S::Type) = _promote_rule(T, S)
 _promote_rule(::Type, ::Type) = Bottom
 _promote_rule(::Type{T}, ::Type{T}) where {T} = T
@@ -340,7 +341,7 @@ promote_result(::Type,::Type,::Type{Bottom},::Type{T}) where {T} = T
 promote_result(::Type,::Type,::Type{T},::Type{S}) where {T,S} = (@inline; promote_type(T,S))
 # avoid recursion if the types don't change under promote_rule, and throw an informative error instead
 function _throw_promote_type_fail(A::Type, B::Type)
-    throw(ArgumentError(LazyString("promote_type(", A, ", ", B, ") failed as conflicting `promote_rule`s were ",
+    throw(ArgumentError(LazyString("`promote_type(", A, ", ", B, ")` failed as conflicting `promote_rule`s were ",
     "detected with either argument being a possible result.")))
 end
 promote_result(::Type{T},::Type{S},::Type{T},::Type{S}) where {T,S} = _throw_promote_type_fail(T, S)

--- a/test/core.jl
+++ b/test/core.jl
@@ -8390,10 +8390,18 @@ f_invalidate_me() = 2
 @test_throws ErrorException invoke(f_invoke_me, f_invoke_me_ci)
 @test_throws ErrorException f_call_me()
 
-@testset "error with conflicting promote_rules" begin
+@testset "promote_rule and promote_result overloads" begin
     struct PromoteA end
     struct PromoteB end
-    Base.promote_rule(::Type{PromoteA}, ::Type{PromoteB}) = PromoteA
-    Base.promote_rule(::Type{PromoteB}, ::Type{PromoteA}) = PromoteB
-    @test_throws ArgumentError promote_type(PromoteA, PromoteB)
+
+    @testset "error with conflicting promote_rules" begin
+        Base.promote_rule(::Type{PromoteA}, ::Type{PromoteB}) = PromoteA
+        Base.promote_rule(::Type{PromoteB}, ::Type{PromoteA}) = PromoteB
+        @test_throws ArgumentError promote_type(PromoteA, PromoteB)
+    end
+
+    @testset "promote_rule overload for identical types" begin
+        Base.promote_rule(::Type{PromoteA}, ::Type{PromoteA}) = PromoteB
+        @test promote_type(PromoteA, PromoteA) == PromoteB
+    end
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -8389,3 +8389,11 @@ f_call_me() = invoke(f_invoke_me, f_invoke_me_ci)
 f_invalidate_me() = 2
 @test_throws ErrorException invoke(f_invoke_me, f_invoke_me_ci)
 @test_throws ErrorException f_call_me()
+
+@testset "error with conflicting promote_rules" begin
+    struct PromoteA end
+    struct PromoteB end
+    Base.promote_rule(::Type{PromoteA}, ::Type{PromoteB}) = PromoteA
+    Base.promote_rule(::Type{PromoteB}, ::Type{PromoteA}) = PromoteB
+    @test_throws ArgumentError promote_type(PromoteA, PromoteB)
+end


### PR DESCRIPTION
In this PR, we move some `promote_type` methods to `promote_rule`, so that packages that wish to override this behavior only need to define the appropriate `promote_rule` method. E.g., currently, if one wishes to define `promote_type(T, T)` to return something other than `T`, they would need to specialize `promote_type`. With this PR, they may specialize `promote_rule` instead, which seems to be what the promotion documentation asks for.

This is inspired by the specific example in https://github.com/JuliaLang/julia/issues/54138.
cc @nsajko

Note that this PR changes
```julia
julia> struct A end

julia> promote_rule(A, A)
Union{}
```
to
```julia
julia> promote_rule(A, A)
A
```
Previously, this was being handled directly by `promote_type`.

Some of the methods added to `promote_result` also lead to an informative error in conflicting cases:
```julia
julia> struct A end

julia> struct B end

julia> Base.promote_rule(::Type{A}, ::Type{B}) = A

julia> Base.promote_rule(::Type{B}, ::Type{A}) = B

julia> promote_type(A, B)
ERROR: ArgumentError: promote_type(A, B) failed as conflicting `promote_rule`s were detected with either argument being a possible result.
Stacktrace:
 [1] _throw_promote_type_fail(A::Type, B::Type)
   @ Base ./promotion.jl:343
 [2] promote_result(::Type{A}, ::Type{B}, ::Type{A}, ::Type{B})
   @ Base ./promotion.jl:346
 [3] promote_type(::Type{A}, ::Type{B})
   @ Base ./promotion.jl:312
 [4] top-level scope
   @ REPL[5]:1
```
Currently, this leads to a stack-overflow, as `promote_result` calls `promote_type` internally, creating a cycle.