### PR TITLE
fix `exp(weirdNaN)`

### DIFF
--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -216,6 +216,7 @@ end
     small_part =  muladd(jU, expm1b_kernel(base, r), jL) + jU
 
     if !(abs(x) <= SUBNORM_EXP(base, T))
+        isnan(x) && return x
         x >= MAX_EXP(base, T) && return Inf
         x <= MIN_EXP(base, T) && return 0.0
         if k <= -53
@@ -243,6 +244,7 @@ end
     hi, lo = Base.canonicalize2(1.0, kern)
     small_part = fma(jU, hi, muladd(jU, (lo+xlo), very_small))
     if !(abs(x) <= SUBNORM_EXP(base, T))
+        isnan(x) && return x
         x >= MAX_EXP(base, T) && return Inf
         x <= MIN_EXP(base, T) && return 0.0
         if k <= -53

--- a/test/math.jl
+++ b/test/math.jl
@@ -382,6 +382,10 @@ end
     end
 end
 
+@testset "https://github.com/JuliaLang/julia/issues/56782" begin
+    @test isnan(exp(reinterpret(Float64, 0x7ffbb14880000000)))
+end
+
 @testset "test abstractarray trig functions" begin
     TAA = rand(2,2)
     TAA = (TAA + TAA')/2.


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/56782
Fix `exp(reinterpret(Float64, 0x7ffbb14880000000))` returning non-NaN value. This should have minimal performance impact since it's already in the fallback branch.