### PR TITLE
Fix test report alignment

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1194,7 +1194,7 @@ function print_test_results(ts::AbstractTestSet, depth_pad=0)
     duration_width = max(textwidth("Time"), textwidth(tc.duration))
     # Calculate the alignment of the test result counts by
     # recursively walking the tree of test sets
-    align = max(get_alignment(ts, 0), textwidth("Test Summary:"))
+    align = max(get_alignment(ts, depth_pad), textwidth("Test Summary:"))
     # Print the outer test set header once
     printstyled(rpad("Test Summary:", align, " "), " |", " "; bold=true)
     if pass_width > 0


### PR DESCRIPTION
Fixes the bad alignment of the first column seen here

![Screenshot 2024-12-09 at 10 16 50 PM](https://github.com/user-attachments/assets/26fe7f3c-144b-4e1e-863c-08882bd273ea)

![image](https://github.com/user-attachments/assets/c589a5af-70b8-41de-83f8-65c3670dbd1c)