### PR TITLE
Extend `Base.rationalize` instead of defining new function `Base.MathConstants.rationalize`

### DIFF
--- a/base/mathconstants.jl
+++ b/base/mathconstants.jl
@@ -29,7 +29,7 @@ end
 Base.@assume_effects :foldable function (::Type{T})(x::_KnownIrrational, r::RoundingMode) where {T<:Union{Float32,Float64}}
     Base._irrational_to_float(T, x, r)
 end
-Base.@assume_effects :foldable function rationalize(::Type{T}, x::_KnownIrrational; tol::Real=0) where {T<:Integer}
+Base.@assume_effects :foldable function Base.rationalize(::Type{T}, x::_KnownIrrational; tol::Real=0) where {T<:Integer}
     Base._rationalize_irrational(T, x, tol)
 end
 Base.@assume_effects :foldable function Base.lessrational(rx::Rational, x::_KnownIrrational)


### PR DESCRIPTION
#55886 accidentally created a new function `Base.MathConstants.rationalize` instead of extending `Base.rationalize`, which is the reason why `Base.rationalize(Int, π)` isn’t constant-folded in Julia 1.10 and 1.11:
```
julia> @btime rationalize(Int,π);
  1.837 ns (0 allocations: 0 bytes)      # v1.9: constant-folded
  88.416 μs (412 allocations: 15.00 KiB) # v1.10: not constant-folded
```
This PR fixes that. It should probably be backported to 1.10 and 1.11.