### PR TITLE
Make `Pairs` public

### DIFF
--- a/base/public.jl
+++ b/base/public.jl
@@ -20,6 +20,7 @@ public
     Generator,
     ImmutableDict,
     OneTo,
+    Pairs,
     LogRange,
     UUID,
 


### PR DESCRIPTION
This is the type of slurped keyword args and IMO was already public in 1.10.