### PR TITLE
Remove jldoctest setup for permutedims

### DIFF
--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -143,7 +143,7 @@ julia> permutedims(X)
  [5 6; 7 8]  [13 14; 15 16]
 
 julia> transpose(X)
-2×2 transpose(::Matrix{Matrix{Int64}}) with eltype Transpose{Int64, Matrix{Int64}}:
+2×2 transpose(::Matrix{Matrix{Int64}}) with eltype LinearAlgebra.Transpose{Int64, Matrix{Int64}}:
  [1 3; 2 4]  [9 11; 10 12]
  [5 7; 6 8]  [13 15; 14 16]
 ```
@@ -240,7 +240,7 @@ julia> p == r
 true
 
 julia> typeof(r)
-Transpose{Int64, Vector{Int64}}
+LinearAlgebra.Transpose{Int64, Vector{Int64}}
 
 julia> p[1] = 5; r[2] = 6; # mutating p or r also changes v
 
@@ -264,7 +264,7 @@ julia> permutedims(V)
  [1 2; 3 4]  [5 6; 7 8]
 
 julia> transpose(V)
-1×2 transpose(::Vector{Matrix{Int64}}) with eltype Transpose{Int64, Matrix{Int64}}:
+1×2 transpose(::Vector{Matrix{Int64}}) with eltype LinearAlgebra.Transpose{Int64, Matrix{Int64}}:
  [1 3; 2 4]  [5 7; 6 8]
 ```
 """

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -123,7 +123,7 @@ julia> permutedims(A)
 ```
 And `permutedims` produces results that differ from `transpose`
 for matrices whose elements are themselves numeric matrices:
-```jldoctest; setup = :(using LinearAlgebra)
+```jldoctest
 julia> a = [1 2; 3 4];
 
 julia> b = [5 6; 7 8];
@@ -220,7 +220,7 @@ For vectors of numbers, `permutedims(v)` works much like `transpose(v)`
 except that the return type differs (it uses [`reshape`](@ref)
 rather than a `LinearAlgebra.Transpose` view, though both
 share memory with the original array `v`):
-```jldoctest; setup = :(using LinearAlgebra)
+```jldoctest
 julia> v = [1, 2, 3, 4]
 4-element Vector{Int64}:
  1
@@ -253,7 +253,7 @@ julia> v # shares memory with both p and r
 ```
 However, `permutedims` produces results that differ from `transpose`
 for vectors whose elements are themselves numeric matrices:
-```jldoctest; setup = :(using LinearAlgebra)
+```jldoctest
 julia> V = [[[1 2; 3 4]]; [[5 6; 7 8]]]
 2-element Vector{Matrix{Int64}}:
  [1 2; 3 4]


### PR DESCRIPTION
`setup = :(using LinearAlgebra)` break the docs in REPL, also we don't need `using LinearAlgebra` in the doctest(`transpose` already in Base)

![image](https://github.com/user-attachments/assets/7e53b33c-8d6e-401d-8aba-01b08bca828c)