### PR TITLE
Fix eltype of flatten of tuple with non-2 length

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -11,7 +11,8 @@ const Base = parentmodule(@__MODULE__)
 using .Base:
     @inline, Pair, Pairs, AbstractDict, IndexLinear, IndexStyle, AbstractVector, Vector,
     SizeUnknown, HasLength, HasShape, IsInfinite, EltypeUnknown, HasEltype, OneTo,
-    @propagate_inbounds, @isdefined, @boundscheck, @inbounds, Generator, IdDict,
+    @propagate_inbounds, @isdefined, @boundscheck, @inbounds, @_foldable_meta,
+    Generator, IdDict,
     AbstractRange, AbstractUnitRange, UnitRange, LinearIndices, TupleOrBottom,
     (:), |, +, -, *, !==, !, ==, !=, <=, <, >, >=, =>, missing,
     any, _counttuple, eachindex, ntuple, zero, prod, reduce, in, firstindex, lastindex,
@@ -1205,9 +1206,8 @@ eltype(::Type{Flatten{I}}) where {I} = eltype(eltype(I))
 
 # For tuples, we statically know the element type of each index, so we can compute
 # this at compile time.
-Base.@assume_effects :foldable function eltype(
-    ::Type{Flatten{I}}
-) where {I<:Union{Tuple,NamedTuple}}
+function eltype(::Type{Flatten{I}}) where {I<:Union{Tuple,NamedTuple}}
+    @_foldable_meta
     T = Union{}
     for i in fieldtypes(I)
         T = Base.promote_typejoin(T, eltype(i))

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1216,7 +1216,6 @@ function eltype(::Type{Flatten{I}}) where {I<:Union{Tuple,NamedTuple}}
     T
 end
 
-promote_typejoin(map(eltype, fieldtypes(I))...)
 eltype(::Type{Flatten{Tuple{}}}) = eltype(Tuple{})
 IteratorEltype(::Type{Flatten{I}}) where {I} = _flatteneltype(I, IteratorEltype(I))
 IteratorEltype(::Type{Flatten{Tuple{}}}) = IteratorEltype(Tuple{})

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -16,7 +16,7 @@ using .Base:
     (:), |, +, -, *, !==, !, ==, !=, <=, <, >, >=, =>, missing,
     any, _counttuple, eachindex, ntuple, zero, prod, reduce, in, firstindex, lastindex,
     tail, fieldtypes, min, max, minimum, zero, oneunit, promote, promote_shape, LazyString,
-    tuple_type_head, tuple_type_tail
+    tuple_type_tail
 using Core: @doc
 
 using .Base:
@@ -1212,8 +1212,8 @@ function eltype(::Type{Flatten{I}}) where {I<:NamedTuple{<:Any, T}} where T
     _flatten_eltype(Union{}, T)
 end
 
-function _flatten_eltype(T::Type, I::Type{<:Tuple})
-    T2 = promote_typejoin(T, eltype(tuple_type_head(I)))
+function _flatten_eltype(T::Type, I::Type{<:Tuple{E, Vararg{Any}}}) where E
+    T2 = promote_typejoin(T, eltype(E))
     T2 === Any && return Any
     _flatten_eltype(T2, tuple_type_tail(I))
 end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -518,6 +518,11 @@ end
 @test eltype(flatten((Int[], Nothing[], Int[]))) == Union{Int, Nothing}
 @test eltype(flatten((String[],))) == String
 @test eltype(flatten((Int[], UInt[], Int8[],))) == Integer
+@test eltype(flatten((; a = Int[], b = Nothing[], c = Int[]))) == Union{Int, Nothing}
+@test eltype(flatten((; a = String[],))) == String
+@test eltype(flatten((; a = Int[], b = UInt[], c = Int8[],))) == Integer
+@test eltype(flatten(())) == Union{}
+@test eltype(flatten((;))) == Union{}
 @test length(flatten(zip(1:3, 4:6))) == 6
 @test length(flatten(1:6)) == 6
 @test collect(flatten(Any[])) == Any[]

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -515,6 +515,9 @@ end
 @test eltype(flatten(UnitRange{Int8}[1:2, 3:4])) == Int8
 @test eltype(flatten(([1, 2], [3.0, 4.0]))) == Real
 @test eltype(flatten((a = [1, 2], b = Int8[3, 4]))) == Signed
+@test eltype(flatten((Int[], Nothing[], Int[]))) == Union{Int, Nothing}
+@test eltype(flatten((String[],))) == String
+@test eltype(flatten((Int[], UInt[], Int8[],))) == Integer
 @test length(flatten(zip(1:3, 4:6))) == 6
 @test length(flatten(1:6)) == 6
 @test collect(flatten(Any[])) == Any[]


### PR DESCRIPTION
In 4c076c80af, eltype of flatten of tuple was improved by computing a refined eltype at compile time. However, this implementation only worked for length-2 tuples, and errored for all others.
Generalize this to all tuples.

Closes #56783