### PR TITLE
Support scope_id for link-local IPv6 (rfc4007)

### DIFF
--- a/stdlib/Sockets/src/IPAddr.jl
+++ b/stdlib/Sockets/src/IPAddr.jl
@@ -293,6 +293,7 @@ end
 struct InetAddr{T<:IPAddr}
     host::T
     port::UInt16
+    scope_id::UInt32
 end
 
 """
@@ -306,7 +307,7 @@ julia> Sockets.InetAddr(ip"127.0.0.1", 8000)
 Sockets.InetAddr{IPv4}(ip"127.0.0.1", 8000)
 ```
 """
-InetAddr(ip::IPAddr, port) = InetAddr{typeof(ip)}(ip, port)
+InetAddr(ip::IPAddr, port, scope_id=UInt32(0)) = InetAddr{typeof(ip)}(ip, port, scope_id)
 
 """
     InetAddr(str::AbstractString, port) -> InetAddr
@@ -323,11 +324,15 @@ julia> Sockets.InetAddr("127.0.0.1", 8000)
 Sockets.InetAddr{IPv4}(ip"127.0.0.1", 8000)
 ```
 """
-InetAddr(str::AbstractString, port) = InetAddr(parse(IPAddr, str), port)
+InetAddr(str::AbstractString, port, scope_id=UInt32(0)) = InetAddr(parse(IPAddr, str), port, scope_id)
 
 function show(io::IO, addr::InetAddr)
     show(io, typeof(addr))
     print(io, "(")
     show(io, addr.host)
-    print(io, ", ", Int(addr.port), ")")
+    print(io, ", ", Int(addr.port))
+    if addr.scope_id != 0
+        print(io, ", ", Int(addr.scope_id))
+    end
+    print(io, ")")
 end

--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -201,8 +201,8 @@ function getnameinfo(address::Union{IPv4, IPv6})
     status = UV_EINVAL
     host_in = Ref(hton(address.host))
     iolock_begin()
-    status = ccall(:jl_getnameinfo, Int32, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt16, Cint, Ptr{Cvoid}, Cint),
-                   eventloop(), req, host_in, port, flags, uvcb, address isa IPv6)
+    status = ccall(:jl_getnameinfo, Int32, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt16, UInt32, Cint, Ptr{Cvoid}, Cint),
+                   eventloop(), req, host_in, 0, port, flags, uvcb, address isa IPv6)
     if status < 0
         Libc.free(req)
         if status == UV_EINVAL


### PR DESCRIPTION
IPv6 has a notion of link-local addresses (see https://www.rfc-editor.org/rfc/rfc4007),
I found https://labs.ripe.net/author/philip_homburg/whats-the-deal-with-ipv6-link-local-addresses/ 
helpful for further explanation.

Python uses `(host, port, flowinfo, scope_id)` with `flowinfo` and `scope_id` being optional.
The concrete scenario I was running into was receiving a broadcast packet and not being able
to connect to the sender since it was using link-local addresses.

