### PR TITLE
Miscellaneous `Meta.partially_inline!` fixes

### DIFF
--- a/base/meta.jl
+++ b/base/meta.jl
@@ -362,6 +362,19 @@ function _partially_inline!(@nospecialize(x), slot_replacements::Vector{Any},
         x.edges .+= slot_offset
         return x
     end
+    if isa(x, Core.UpsilonNode)
+        if !isdefined(x, :val)
+            return x
+        end
+        return Core.UpsilonNode(
+            _partially_inline!(x.val, slot_replacements, type_signature, static_param_values,
+                               slot_offset, statement_offset, boundscheck),
+        )
+    end
+    if isa(x, Core.PhiCNode)
+        _partially_inline!(x.values, slot_replacements, type_signature, static_param_values,
+                           slot_offset, statement_offset, boundscheck)
+    end
     if isa(x, Core.ReturnNode)
        # Unreachable doesn't have val defined
        if !isdefined(x, :val)
@@ -381,6 +394,9 @@ function _partially_inline!(@nospecialize(x), slot_replacements::Vector{Any},
         )
     end
     if isa(x, Core.EnterNode)
+        if x.catch_dest == 0
+            return x
+        end
         return Core.EnterNode(x, x.catch_dest + statement_offset)
     end
     if isa(x, Expr)


### PR DESCRIPTION
This fixes up a couple of conspicuous problems I noticed when reviewing #56787

I'm unsure we should have accepted this pass in Base to begin with... It should at least be re-written to error on unexpected IR elements (instead of performing an invalid transform silently), but the real problem is that this pass is out-of-pipeline and so it doesn't run on most user code and we have much worse coverage compared to passes in the main Compiler.