### PR TITLE
Fix codegen not handling invoke exprs with Codeinstances  iwith jl_fptr_sparam_addr invoke types.

### DIFF
--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -1027,3 +1027,12 @@ for a in ((@noinline Ref{Int}(2)),
         @test ex === a
     end
 end
+
+# Make sure that code that has unbound sparams works
+#https://github.com/JuliaLang/julia/issues/56739
+
+f56739(a) where {T} = a
+
+@test f56739(1) == 1
+g56739(x) = @noinline f56739(x)
+@test g56739(1) == 1


### PR DESCRIPTION
fixes https://github.com/JuliaLang/julia/issues/56739
I didn't succeed in making a test for this. The sole trigger seems to be 
```julia
using HMMGradients
T = Float32
A = T[0.0 1.0 0.0; 0.0 0.5 0.5; 1.0 0.0 0.0]
t2tr = Dict{Int,Vector{Int}}[Dict(1 => [2]),]
t2IJ= HMMGradients.t2tr2t2IJ(t2tr)

Nt = length(t2tr)+1
Ns = size(A,1)
y = rand(T,Nt,Ns)

c = rand(Float32, Nt)
beta = backward(Nt,A,c,t2IJ,y)
gamma = posterior(Nt,t2IJ,A,y)
```
in @oscardssmith memorynew PR

One other option is to have the builtin handle receiving a CI. That might make the code cleaner and does handle the case where we receive a dynamic CI (is that even a thing)
