### PR TITLE
inference: don't allocate `TryCatchFrame` for `compute_trycatch(::IRCode)`

### DIFF
--- a/Compiler/src/ssair/slot2ssa.jl
+++ b/Compiler/src/ssair/slot2ssa.jl
@@ -801,9 +801,11 @@ function construct_ssa!(ci::CodeInfo, ir::IRCode, sv::OptimizationState,
                         has_pinode[id] = false
                         enter_idx = idx
                         while (handler = gethandler(handler_info, enter_idx)) !== nothing
-                            (; enter_idx) = handler
-                            leave_block = block_for_inst(cfg, (code[enter_idx]::EnterNode).catch_dest)
-                            cidx = findfirst((; slot)::NewPhiCNode2->slot_id(slot)==id, new_phic_nodes[leave_block])
+                            enter_idx = get_enter_idx(handler)
+                            enter_node = code[enter_idx]::EnterNode
+                            leave_block = block_for_inst(cfg, enter_node.catch_dest)
+                            cidx = findfirst((; slot)::NewPhiCNode2->slot_id(slot)==id,
+                                new_phic_nodes[leave_block])
                             if cidx !== nothing
                                 node = thisdef ? UpsilonNode(thisval) : UpsilonNode()
                                 if incoming_vals[id] === UNDEF_TOKEN

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -4436,7 +4436,7 @@ let x = Tuple{Int,Any}[
         #=20=# (0, Core.ReturnNode(Core.SlotNumber(3)))
     ]
     (;handler_at, handlers) = Compiler.compute_trycatch(last.(x))
-    @test map(x->x[1] == 0 ? 0 : handlers[x[1]].enter_idx, handler_at) == first.(x)
+    @test map(x->x[1] == 0 ? 0 : Compiler.get_enter_idx(handlers[x[1]]), handler_at) == first.(x)
 end
 
 @test only(Base.return_types((Bool,)) do y


### PR DESCRIPTION
`TryCatchFrame` is only required for the abstract interpretation and is not necessary in `compute_trycatch` within slot2ssa.jl.

@nanosoldier `runbenchmarks("inference", vs=":master")`