### PR TITLE
Skip or loosen two `errorshow` tests on 32-bit Windows

### DIFF
--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -794,6 +794,7 @@ backtrace()
     is_windows_32_bit = Sys.iswindows() && (Sys.WORD_SIZE == 32)
     if is_windows_32_bit
         # These tests are currently broken (intermittently/non-determistically) on 32-bit Windows.
+        # https://github.com/JuliaLang/julia/issues/55900
         # Instead of skipping them entirely, we skip one, and we loosen the other.
 
         # Broken test: @test occursin("the above 2 lines are repeated 5000 more times", output[7])

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -791,8 +791,21 @@ backtrace()
     @test occursin("g28442", output[3])
     @test lstrip(output[5])[1:3] == "[2]"
     @test occursin("f28442", output[5])
-    @test occursin("the above 2 lines are repeated 5000 more times", output[7])
-    @test lstrip(output[8])[1:7] == "[10003]"
+    is_windows_32_bit = Sys.iswindows() && (Sys.WORD_SIZE == 32)
+    if is_windows_32_bit
+        # These tests are currently broken (intermittently/non-determistically) on 32-bit Windows.
+        # Instead of skipping them entirely, we skip one, and we loosen the other.
+
+        # Broken test: @test occursin("the above 2 lines are repeated 5000 more times", output[7])
+        @test occursin("the above 2 lines are repeated ", output[7])
+        @test occursin(" more times", output[7])
+
+        # Broken test: @test lstrip(output[8])[1:7] == "[10003]"
+        @test_broken false
+    else
+        @test occursin("the above 2 lines are repeated 5000 more times", output[7])
+        @test lstrip(output[8])[1:7] == "[10003]"
+    end
 end
 
 @testset "Line number correction" begin


### PR DESCRIPTION
Ref #55900.