### PR TITLE
dict docs: document that ordering of keys/values/pairs match iterate

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -88,8 +88,8 @@ Return an iterator over all keys in a dictionary.
 When the keys are stored internally in a hash table,
 as is the case for `Dict`,
 the order in which they are returned may vary.
-But `keys(a)` and `values(a)` both iterate `a` and
-return the elements in the same order.
+But `keys(a)`, `values(a)` and `pairs(a)` all iterate `a`
+and return the elements in the same order.
 
 # Examples
 ```jldoctest
@@ -114,8 +114,8 @@ Return an iterator over all values in a collection.
 When the values are stored internally in a hash table,
 as is the case for `Dict`,
 the order in which they are returned may vary.
-But `keys(a)` and `values(a)` both iterate `a` and
-return the elements in the same order.
+But `keys(a)`, `values(a)` and `pairs(a)` all iterate `a`
+and return the elements in the same order.
 
 # Examples
 ```jldoctest
@@ -138,6 +138,10 @@ values(a::AbstractDict) = ValueIterator(a)
 Return an iterator over `key => value` pairs for any
 collection that maps a set of keys to a set of values.
 This includes arrays, where the keys are the array indices.
+When the entries are stored internally in a hash table,
+as is the case for `Dict`, the order in which they are returned may vary.
+But `keys(a)`, `values(a)` and `pairs(a)` all iterate `a`
+and return the elements in the same order.
 
 # Examples
 ```jldoctest

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -787,6 +787,20 @@ end
           [v for (k, v) in d] == [d[x[1]] for (i, x) in enumerate(d)]
 end
 
+@testset "consistency of iteration order" begin
+    d = Dict(randn() => randn() for _ = 1:100)
+    @test [k for (k,v) = d] ==
+        [k for k = keys(d)] ==
+        [k for (k,v) = pairs(d)] ==
+        collect(keys(d))
+    @test [v for (k,v) = d] ==
+        [v for v = values(d)] ==
+        [v for (k,v) = pairs(d)] ==
+        [d[k] for k = keys(d)] ==
+        collect(values(d))
+    @test [k => v for (k,v) = d] == collect(d) == collect(pairs(d))
+end
+
 @testset "generators, similar" begin
     d = Dict(:a=>"a")
     # TODO: restore when 0.7 deprecation is removed

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -787,7 +787,7 @@ end
           [v for (k, v) in d] == [d[x[1]] for (i, x) in enumerate(d)]
 end
 
-@testset "consistency of iteration order" begin
+@testset "consistency of dict iteration order (issue #56841)" begin
     d = Dict(randn() => randn() for _ = 1:100)
     @test [k for (k,v) = d] ==
         [k for k = keys(d)] ==

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -789,10 +789,8 @@ end
 
 @testset "consistency of dict iteration order (issue #56841)" begin
     dict = Dict(randn() => randn() for _ = 1:100)
-    foreach(zip(dict, keys(dict), values(dict), pairs(dict))) do (d, k, v, p)
-        @test d == p
-        @test first(d) == first(p) == k
-        @test last(d) == last(p) == v
+    @test all(zip(dict, keys(dict), values(dict), pairs(dict))) do (d, k, v, p)
+        d == p && first(d) == first(p) == k && last(d) == last(p) == v
     end
 end
 

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -788,17 +788,12 @@ end
 end
 
 @testset "consistency of dict iteration order (issue #56841)" begin
-    d = Dict(randn() => randn() for _ = 1:100)
-    @test [k for (k,v) = d] ==
-        [k for k = keys(d)] ==
-        [k for (k,v) = pairs(d)] ==
-        collect(keys(d))
-    @test [v for (k,v) = d] ==
-        [v for v = values(d)] ==
-        [v for (k,v) = pairs(d)] ==
-        [d[k] for k = keys(d)] ==
-        collect(values(d))
-    @test [k => v for (k,v) = d] == collect(d) == collect(pairs(d))
+    dict = Dict(randn() => randn() for _ = 1:100)
+    foreach(zip(dict, keys(dict), values(dict), pairs(dict))) do (d, k, v, p)
+        @test d == p
+        @test first(d) == first(p) == k
+        @test last(d) == last(p) == v
+    end
 end
 
 @testset "generators, similar" begin


### PR DESCRIPTION
Fix #56841.

Currently the documentation states that keys(dict) and values(dict) iterate in the same order. But it is not stated whether this is the same order as that used by pairs(dict), or when looping, for (k,v) in dict.

This PR makes this guarantee explicit.