### PR TITLE
Add `Base.@acquire` for non-closure version of `Base.acquire(f, s::Base.Semaphore)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ Julia v1.13 Release Notes
 New language features
 ---------------------
 
+  - New `Base.@acquire` macro for a non-closure version of `Base.acquire(f, s::Base.Semaphore)`, like `@lock`. ([#56845])
+
 Language changes
 ----------------
 

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -562,6 +562,36 @@ function acquire(f, s::Semaphore)
 end
 
 """
+    Base.@acquire s::Semaphore expr
+
+Macro version of `Base.acquire(f, s::Semaphore)` but with `expr` instead of `f` function.
+Expands to:
+```julia
+Base.acquire(s)
+try
+    expr
+finally
+    Base.release(s)
+end
+```
+This is similar to using [`acquire`](@ref) with a `do` block, but avoids creating a closure.
+
+!!! compat "Julia 1.13"
+    `Base.@acquire` was added in Julia 1.13
+"""
+macro acquire(s, expr)
+    quote
+        local temp = $(esc(s))
+        Base.acquire(temp)
+        try
+            $(esc(expr))
+        finally
+            Base.release(temp)
+        end
+    end
+end
+
+"""
     release(s::Semaphore)
 
 Return one permit to the pool,

--- a/base/public.jl
+++ b/base/public.jl
@@ -27,6 +27,7 @@ public
 # Semaphores
     Semaphore,
     acquire,
+    @acquire,
     release,
 
 # arrays

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -237,6 +237,24 @@ end
     @test all(<=(sem_size), history)
     @test all(>=(0), history)
     @test history[end] == 0
+
+    # macro form
+    clock = Threads.Atomic{Int}(1)
+    occupied = Threads.Atomic{Int}(0)
+    history = fill!(Vector{Int}(undef, 2n), -1)
+    @sync for _ in 1:n
+        @async begin
+            @test Base.@acquire s begin
+                history[Threads.atomic_add!(clock, 1)] = Threads.atomic_add!(occupied, 1) + 1
+                sleep(rand(0:0.01:0.1))
+                history[Threads.atomic_add!(clock, 1)] = Threads.atomic_sub!(occupied, 1) - 1
+                return :resultvalue
+            end === :resultvalue
+        end
+    end
+    @test all(<=(sem_size), history)
+    @test all(>=(0), history)
+    @test history[end] == 0
 end
 
 # task switching


### PR DESCRIPTION
Given `@lock` exists, this would make sense.