### PR TITLE
Remove trailing comma in 0-dim `reshape` summary

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -3259,7 +3259,9 @@ showindices(io) = nothing
 function showarg(io::IO, r::ReshapedArray, toplevel)
     print(io, "reshape(")
     showarg(io, parent(r), false)
-    print(io, ", ", join(r.dims, ", "))
+    if !isempty(r.dims)
+        print(io, ", ", join(r.dims, ", "))
+    end
     print(io, ')')
     toplevel && print(io, " with eltype ", eltype(r))
     return nothing

--- a/test/show.jl
+++ b/test/show.jl
@@ -1861,6 +1861,8 @@ end
     B = @view ones(2)[r]
     Base.showarg(io, B, false)
     @test String(take!(io)) == "view(::Vector{Float64}, $(repr(r)))"
+
+    @test Base.showarg(io, reshape(1:1), false) == "reshape(::UnitRange{Int64})"
 end
 
 @testset "Methods" begin

--- a/test/show.jl
+++ b/test/show.jl
@@ -1862,7 +1862,8 @@ end
     Base.showarg(io, B, false)
     @test String(take!(io)) == "view(::Vector{Float64}, $(repr(r)))"
 
-    @test Base.showarg(io, reshape(1:1), false) == "reshape(::UnitRange{Int64})"
+    Base.showarg(io, reshape(UnitRange{Int64}(1,1)), false)
+    @test String(take!(io)) == "reshape(::UnitRange{Int64})"
 end
 
 @testset "Methods" begin


### PR DESCRIPTION
Currently, there is an extra comma in displaying the summary for a 0-dim `ReshapedArray`: 
```julia
julia> reshape(1:1)
0-dimensional reshape(::UnitRange{Int64}, ) with eltype Int64:
1
```
This PR only prints the comma if `dims` isn't empty, so that we now obtain
```julia
julia> reshape(1:1)
0-dimensional reshape(::UnitRange{Int64}) with eltype Int64:
1
```