### PR TITLE
inference: use `ssa_def_slot` for `typeassert` refinement

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -2656,7 +2656,7 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
         if sv isa InferenceState && f === typeassert
             # perform very limited back-propagation of invariants after this type assertion
             if rt !== Bottom && isa(fargs, Vector{Any})
-                farg2 = fargs[2]
+                farg2 = ssa_def_slot(fargs[2], sv)
                 if farg2 isa SlotNumber
                     refinements = SlotRefinement(farg2, rt)
                 end

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -4103,6 +4103,17 @@ end == [Union{Some{Float64}, Some{Int}, Some{UInt8}}]
         end
         return a
     end == Union{Int32,Int64}
+
+    @test Base.infer_return_type((Vector{Any},)) do args
+        codeinst = first(args)
+        if codeinst isa Core.MethodInstance
+            mi = codeinst
+        else
+            codeinst::Core.CodeInstance
+            mi = codeinst.def
+        end
+        return mi
+    end == Core.MethodInstance
 end
 
 callsig_backprop_basic(::Int) = nothing


### PR DESCRIPTION
Allows type refinement in the following kind of case:
```julia
julia> @test Base.infer_return_type((Vector{Any},)) do args
           codeinst = first(args)
           if codeinst isa Core.MethodInstance
               mi = codeinst
           else
               codeinst::Core.CodeInstance
               mi = codeinst.def
           end
           return mi
       end == Core.MethodInstance
Test Passed
```