### PR TITLE
Small ABIOverride follow up and add basic test

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -65,7 +65,8 @@ using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospeciali
     kwerr, lookup_binding_partition, may_invoke_generator, methods, midpoint, moduleroot,
     partition_restriction, quoted, rename_unionall, rewrap_unionall, specialize_method,
     structdiff, tls_world_age, unconstrain_vararg_length, unionlen, uniontype_layout,
-    uniontypes, unsafe_convert, unwrap_unionall, unwrapva, vect, widen_diagonal
+    uniontypes, unsafe_convert, unwrap_unionall, unwrapva, vect, widen_diagonal,
+    _uncompressed_ir
 using Base.Order
 
 import Base: ==, _topmod, append!, convert, copy, copy!, findall, first, get, get!,

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1092,9 +1092,6 @@ function ci_meets_requirement(code::CodeInstance, source_mode::UInt8)
     return false
 end
 
-_uncompressed_ir(codeinst::CodeInstance, s::String) =
-    ccall(:jl_uncompress_ir, Ref{CodeInfo}, (Any, Any, Any), codeinst.def.def::Method, codeinst, s)
-
 # compute (and cache) an inferred AST and return type
 function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance, source_mode::UInt8)
     start_time = ccall(:jl_typeinf_timing_begin, UInt64, ())

--- a/Compiler/test/abioverride.jl
+++ b/Compiler/test/abioverride.jl
@@ -1,0 +1,52 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+using Base.Meta
+include("irutils.jl")
+
+# In this test, we will manually construct a CodeInstance that specializes the `myplus`
+# method on a constant for the second argument and test various, interfaces surrounding
+# CodeInstances with ABI overrides.
+myplus(x::Int, y::Int) = x + y
+
+struct SecondArgConstOverride
+    arg2::Int
+end
+
+world = Base.tls_world_age()
+mi = Base.specialize_method(only(Base._methods_by_ftype(Tuple{typeof(myplus), Int, Int}, -1, world)))
+interp = Compiler.NativeInterpreter(world)
+ci = Compiler.typeinf_ext(interp, mi, Compiler.SOURCE_MODE_FORCE_SOURCE)
+
+function is_known_call(@nospecialize(x), @nospecialize(func), src::Core.CodeInfo)
+    isexpr(x, :call) || return false
+    ft = Compiler.argextype(x.args[1], src, Compiler.VarState[])
+    return Compiler.singleton_type(ft) === func
+end
+
+# Construct a CodeInstance with an ABI override
+new_ci = let new_source = copy(Base.uncompressed_ir(ci))
+    ## Sanity check
+    @assert length(new_source.code) == 2
+    add = new_source.code[1]
+    @assert is_known_call(add, Core.Intrinsics.add_int, new_source) && add.args[3] == Core.Argument(3)
+
+    ## Replace x + y by x + 1
+    add.args[3] = 1
+
+    ## Remove the argument
+    resize!(new_source.slotnames, 2)
+    resize!(new_source.slotflags, 2)
+
+    # Construct the CodeInstance
+    new_ci = Core.CodeInstance(Core.ABIOverride(Tuple{typeof(myplus), Int}, mi),
+        SecondArgConstOverride(1), ci.rettype, ci.exctype, nothing, new_source,
+        Int32(0), ci.min_world, ci.max_world, ci.ipo_purity_bits, nothing, ci.relocatability, ci.debuginfo, ci.edges)
+
+    # Poke the CI into the global cache
+    ccall(:jl_mi_cache_insert, Cvoid, (Any, Any), mi, new_ci)
+
+    new_ci
+end
+
+@test contains(repr(new_ci), "ABI Overridden")
+@test invoke(myplus, new_ci, 10) == 11

--- a/Compiler/test/testgroups
+++ b/Compiler/test/testgroups
@@ -15,3 +15,4 @@ ssair
 tarjan
 validation
 special_loading
+abioverride

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -131,12 +131,13 @@ isempty(mt::Core.MethodTable) = (mt.defs === nothing)
 uncompressed_ir(m::Method) = isdefined(m, :source) ? _uncompressed_ir(m) :
                              isdefined(m, :generator) ? error("Method is @generated; try `code_lowered` instead.") :
                              error("Code for this Method is not available.")
-function _uncompressed_ir(m::Method)
-    s = m.source
-    if s isa String
-        s = ccall(:jl_uncompress_ir, Ref{CodeInfo}, (Any, Ptr{Cvoid}, Any), m, C_NULL, s)
-    end
-    return s::CodeInfo
+
+function uncompressed_ir(ci::CodeInstance)
+    inferred = ci.inferred
+    isa(inferred, CodeInfo) && return inferred
+    isa(inferred, String) && return _uncompressed_ir(ci, inferred)
+    inferred === nothing && error("Inferred code was deleted.")
+    error(string("Unknown inferred code type ", typeof(inferred)))
 end
 
 # for backwards compat

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1391,6 +1391,17 @@ end
 hasgenerator(m::Method) = isdefined(m, :generator)
 hasgenerator(m::Core.MethodInstance) = hasgenerator(m.def::Method)
 
+function _uncompressed_ir(m::Method)
+    s = m.source
+    if s isa String
+        s = ccall(:jl_uncompress_ir, Ref{CodeInfo}, (Any, Ptr{Cvoid}, Any), m, C_NULL, s)
+    end
+    return s::CodeInfo
+end
+
+_uncompressed_ir(codeinst::CodeInstance, s::String) =
+    ccall(:jl_uncompress_ir, Ref{CodeInfo}, (Any, Any, Any), codeinst.def.def::Method, codeinst, s)
+
 """
     Base.generating_output([incremental::Bool])::Bool
 


### PR DESCRIPTION
Just a basic `invoke` test for now. There's various other code paths that should also be tested with ABI overwrites, but this gives us the basic framework and more tests can be added as needed.