### PR TITLE
Avoid promotion in `muladd` involving unitful `Furlong`

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -342,7 +342,7 @@ end
 *(x::Real, z::Complex) = Complex(x * real(z), x * imag(z))
 *(z::Complex, x::Real) = Complex(x * real(z), x * imag(z))
 
-muladd(x::Real, z::Complex, y::Number) = muladd(z, x, y)
+muladd(x::Real, z::Complex, y::Union{Real,Complex}) = muladd(z, x, y)
 muladd(z::Complex, x::Real, y::Real) = Complex(muladd(real(z),x,y), imag(z)*x)
 muladd(z::Complex, x::Real, w::Complex) =
     Complex(muladd(real(z),x,real(w)), muladd(imag(z),x,imag(w)))

--- a/test/testhelpers/Furlongs.jl
+++ b/test/testhelpers/Furlongs.jl
@@ -100,5 +100,8 @@ for op in (:rem, :mod)
 end
 Base.sqrt(x::Furlong) = _div(sqrt(x.val), x, Val(2))
 Base.muladd(x::Furlong, y::Furlong, z::Furlong) = x*y + z
+Base.muladd(x::Furlong, y::Number, z::Number) = x*y + z
+Base.muladd(x::Number, y::Furlong, z::Number) = x*y + z
+Base.muladd(x::Number, y::Number, z::Furlong) = x*y + z
 
 end

--- a/test/testhelpers/Furlongs.jl
+++ b/test/testhelpers/Furlongs.jl
@@ -101,7 +101,10 @@ end
 Base.sqrt(x::Furlong) = _div(sqrt(x.val), x, Val(2))
 Base.muladd(x::Furlong, y::Furlong, z::Furlong) = x*y + z
 Base.muladd(x::Furlong, y::Number, z::Number) = x*y + z
+Base.muladd(x::Furlong, y::Furlong, z::Number) = x*y + z
 Base.muladd(x::Number, y::Furlong, z::Number) = x*y + z
 Base.muladd(x::Number, y::Number, z::Furlong) = x*y + z
+Base.muladd(x::Number, y::Furlong, z::Furlong) = x*y + z
+Base.muladd(x::Furlong, y::Number, z::Furlong) = x*y + z
 
 end


### PR DESCRIPTION
In unitful `muladd`, we don't want to enforce type promotion as we have it in `muladd(::Number, ::Number, ::Number)`.

Needed for https://github.com/JuliaLang/LinearAlgebra.jl/pull/1155.