### PR TITLE
fix: Base.GMP.MPZ.invert yielding return code instead of return value

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -174,8 +174,8 @@ end
 
 invert!(x::BigInt, a::BigInt, b::BigInt) =
     ccall((:__gmpz_invert, libgmp), Cint, (mpz_t, mpz_t, mpz_t), x, a, b)
-invert(a::BigInt, b::BigInt) = invert!(BigInt(), a, b)
 invert!(x::BigInt, b::BigInt) = invert!(x, x, b)
+invert(a::BigInt, b::BigInt) = (ret=BigInt(); invert!(ret, a, b); ret)
 
 for op in (:add_ui, :sub_ui, :mul_ui, :mul_2exp, :fdiv_q_2exp, :pow_ui, :bin_ui)
     op! = Symbol(op, :!)

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -468,6 +468,34 @@ end
     end
 end
 
+@testset "modular invert" begin
+    # test invert is correct and does not mutate
+    a = BigInt(3)
+    b = BigInt(7)
+    i = BigInt(5)
+    @test Base.GMP.MPZ.invert(a, b) == i
+    @test a == BigInt(3)
+    @test b == BigInt(7)
+
+    # test in place invert does mutate first argument
+    a = BigInt(3)
+    b = BigInt(7)
+    i = BigInt(5)
+    i_inplace = BigInt(3)
+    Base.GMP.MPZ.invert!(i_inplace, b)
+    @test i_inplace == i
+
+    # test in place invert does mutate only first argument
+    a = BigInt(3)
+    b = BigInt(7)
+    i = BigInt(5)
+    i_inplace = BigInt(0)
+    Base.GMP.MPZ.invert!(i_inplace, a, b)
+    @test i_inplace == i
+    @test a == BigInt(3)
+    @test b == BigInt(7)
+end
+
 @testset "math ops returning BigFloat" begin
     # operations that when applied to Int64 give Float64, should give BigFloat
     @test typeof(exp(a)) == BigFloat


### PR DESCRIPTION
Hey,

I hope I followed all guidelines for contributing, this is my first contribution. 

There is a bug in `Base.GMP.MPZ.invert` it returns GMP return code, instead of the actual value. This PR fixes it. I am not sure if it could be implemented better, but from my testing you cannot get away without a deepcopy.

Before:
```
julia> Base.GMP.MPZ.invert(big"3", big"7")
1
```

After:
```
julia> Base.GMP.MPZ.invert(big"3", big"7")
5
```