### PR TITLE
Specialize common reductions for ranges with `init` specified

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -1425,13 +1425,6 @@ function sum(r::AbstractRange{<:Real})
                                      : (step(r) * l) * ((l-1)>>1))
 end
 
-# common reductions with init specified
-for (fred, f) in [(maximum, max), (minimum, min), (sum, add_sum)]
-    @eval function _foldl_impl(op::typeof(BottomRF($f)), init, r::AbstractRange)
-        isempty(r) ? init : op(init, $fred(r))
-    end
-end
-
 function _in_range(x, r::AbstractRange)
     isempty(r) && return false
     f, l = first(r), last(r)

--- a/base/range.jl
+++ b/base/range.jl
@@ -1425,6 +1425,13 @@ function sum(r::AbstractRange{<:Real})
                                      : (step(r) * l) * ((l-1)>>1))
 end
 
+# common reductions with init specified
+for (fred, f) in [(maximum, max), (minimum, min), (sum, add_sum)]
+    @eval function _foldl_impl(op::typeof(BottomRF($f)), init, r::AbstractRange)
+        isempty(r) ? init : op(init, $fred(r))
+    end
+end
+
 function _in_range(x, r::AbstractRange)
     isempty(r) && return false
     f, l = first(r), last(r)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -61,6 +61,13 @@ function _foldl_impl(op, init, itr::Union{Tuple,NamedTuple})
     @invoke _foldl_impl(op, init, itr::Any)
 end
 
+# common reductions for ranges with init specified
+for (fred, f) in ((maximum, max), (minimum, min), (sum, add_sum))
+    @eval function _foldl_impl(op::typeof(BottomRF($f)), init, r::AbstractRange)
+        isempty(r) ? init : op(init, $fred(r))
+    end
+end
+
 struct _InitialValue end
 
 """
@@ -1155,3 +1162,4 @@ function _simple_count(::typeof(identity), x::Array{Bool}, init::T=0) where {T}
     end
     return n
 end
+

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -61,13 +61,6 @@ function _foldl_impl(op, init, itr::Union{Tuple,NamedTuple})
     @invoke _foldl_impl(op, init, itr::Any)
 end
 
-# common reductions for ranges with init specified
-for (fred, f) in ((maximum, max), (minimum, min), (sum, add_sum))
-    @eval function _foldl_impl(op::typeof(BottomRF($f)), init, r::AbstractRange)
-        isempty(r) ? init : op(init, $fred(r))
-    end
-end
-
 struct _InitialValue end
 
 """
@@ -1161,4 +1154,11 @@ function _simple_count(::typeof(identity), x::Array{Bool}, init::T=0) where {T}
         n = (n + x[i]) % T
     end
     return n
+end
+
+# A few common reductions for ranges with init specified
+for (fred, f) in ((maximum, max), (minimum, min), (sum, add_sum))
+    @eval function _foldl_impl(op::typeof(BottomRF($f)), init, r::AbstractRange)
+        isempty(r) ? init : op(init, $fred(r))
+    end
 end

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -1162,4 +1162,3 @@ function _simple_count(::typeof(identity), x::Array{Bool}, init::T=0) where {T}
     end
     return n
 end
-

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1554,8 +1554,8 @@ end
             (range(10, stop=20, length=5), 1, 5),
             (range(10.3, step=-2, length=7), 7, 1),
            ]
-        @test minimum(r) === r[imin]
-        @test maximum(r) === r[imax]
+        @test minimum(r) === minimum(r, init=typemax(eltype(r))) === r[imin]
+        @test maximum(r) === maximum(r, init=typemin(eltype(r))) === r[imax]
         @test imin === argmin(r)
         @test imax === argmax(r)
         @test extrema(r) === (r[imin], r[imax])


### PR DESCRIPTION
The idea is that since ranges have `O(1)` reductions such as `minimum`, `maximum` and `sum` defined, we may reuse the implementations in the corresponding reductions with `init` specified, instead of hitting slow fallback implementations.

for example, after this,
```julia
julia> @btime maximum($(Ref(1:10000))[], init=typemin(Int))
  2.344 ns (0 allocations: 0 bytes)
10000
```
whereas, on master, this is `O(N)` as it loops over each element.

The specific use case is to avoid hitting slow fallbacks  in a change like https://github.com/JuliaLinearAlgebra/BlockBandedMatrices.jl/pull/218/files.