### PR TITLE
remove unused Base.GMP.MPZ.import! and test Base.GMP.MPZ.export!

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -264,8 +264,6 @@ end
 
 limbs_write!(x::BigInt, a) = ccall((:__gmpz_limbs_write, libgmp), Ptr{Limb}, (mpz_t, Clong), x, a)
 limbs_finish!(x::BigInt, a) = ccall((:__gmpz_limbs_finish, libgmp), Cvoid, (mpz_t, Clong), x, a)
-import!(x::BigInt, a, b, c, d, e, f) = ccall((:__gmpz_import, libgmp), Cvoid,
-    (mpz_t, Csize_t, Cint, Csize_t, Cint, Csize_t, Ptr{Cvoid}), x, a, b, c, d, e, f)
 
 setbit!(x, a) = (ccall((:__gmpz_setbit, libgmp), Cvoid, (mpz_t, bitcnt_t), x, a); x)
 tstbit(a::BigInt, b) = ccall((:__gmpz_tstbit, libgmp), Cint, (mpz_t, bitcnt_t), a, b) % Bool


### PR DESCRIPTION
rename Base.GMP.MPZ.export! "dynamic" variable from `a` to `x`, since it is more in line with comment on L141 in base/gmp.jl
https://github.com/JuliaLang/julia/blob/cab11bbd2d5452f523ef277bfee2affec4e3c9f5/base/gmp.jl#L141-L146

add tests, that numbers and vectors can be exported and imported correctly and composed import and export is identity