### PR TITLE
restrict `optimize_until` argument type correctly

### DIFF
--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -1025,7 +1025,7 @@ function run_passes_ipo_safe(
     optimize_until = nothing,  # run all passes by default
 )
     __stage__ = 0  # used by @pass
-    # NOTE: The pass name MUST be unique for `optimize_until::AbstractString` to work
+    # NOTE: The pass name MUST be unique for `optimize_until::String` to work
     @pass "convert"   ir = convert_to_ircode(ci, sv)
     @pass "slot2reg"  ir = slot2reg(ir, ci, sv)
     # TODO: Domsorting can produce an updated domtree - no need to recompute here

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -977,23 +977,23 @@ end
 
 """
     typeinf_ircode(interp::AbstractInterpreter, match::MethodMatch,
-                   optimize_until::Union{Integer,AbstractString,Nothing}) -> (ir::Union{IRCode,Nothing}, returntype::Type)
+                   optimize_until::Union{Int,String,Nothing}) -> (ir::Union{IRCode,Nothing}, returntype::Type)
     typeinf_ircode(interp::AbstractInterpreter,
                    method::Method, atype, sparams::SimpleVector,
-                   optimize_until::Union{Integer,AbstractString,Nothing}) -> (ir::Union{IRCode,Nothing}, returntype::Type)
+                   optimize_until::Union{Int,String,Nothing}) -> (ir::Union{IRCode,Nothing}, returntype::Type)
     typeinf_ircode(interp::AbstractInterpreter, mi::MethodInstance,
-                   optimize_until::Union{Integer,AbstractString,Nothing}) -> (ir::Union{IRCode,Nothing}, returntype::Type)
+                   optimize_until::Union{Int,String,Nothing}) -> (ir::Union{IRCode,Nothing}, returntype::Type)
 
 Infer a `method` and return an `IRCode` with inferred `returntype` on success.
 """
 typeinf_ircode(interp::AbstractInterpreter, match::MethodMatch,
-               optimize_until::Union{Integer,AbstractString,Nothing}) =
+               optimize_until::Union{Int,String,Nothing}) =
     typeinf_ircode(interp, specialize_method(match), optimize_until)
 typeinf_ircode(interp::AbstractInterpreter, method::Method, @nospecialize(atype), sparams::SimpleVector,
-               optimize_until::Union{Integer,AbstractString,Nothing}) =
+               optimize_until::Union{Int,String,Nothing}) =
     typeinf_ircode(interp, specialize_method(method, atype, sparams), optimize_until)
 function typeinf_ircode(interp::AbstractInterpreter, mi::MethodInstance,
-                        optimize_until::Union{Integer,AbstractString,Nothing})
+                        optimize_until::Union{Int,String,Nothing})
     frame = typeinf_frame(interp, mi, false)
     if frame === nothing
         return nothing, Any

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -463,7 +463,7 @@ internals.
   when looking up methods, use current world age if not specified.
 - `interp::Core.Compiler.AbstractInterpreter = Core.Compiler.NativeInterpreter(world)`:
   optional, controls the abstract interpreter to use, use the native interpreter if not specified.
-- `optimize_until::Union{Integer,AbstractString,Nothing} = nothing`: optional,
+- `optimize_until::Union{Int,String,Nothing} = nothing`: optional,
   controls the optimization passes to run.
   If it is a string, it specifies the name of the pass up to which the optimizer is run.
   If it is an integer, it specifies the number of passes to run.
@@ -507,7 +507,7 @@ function code_ircode_by_type(
     @nospecialize(tt::Type);
     world::UInt=get_world_counter(),
     interp=nothing,
-    optimize_until::Union{Integer,AbstractString,Nothing}=nothing,
+    optimize_until::Union{Int,String,Nothing}=nothing,
 )
     passed_interp = interp
     interp = passed_interp === nothing ? invoke_default_compiler(:_default_interp, world) : interp


### PR DESCRIPTION
The object types that `optimize_until` can accept are restricted by `matchpass`, so this restriction should also be reflected in functions like `typeinf_ircode` too.