### PR TITLE
Don't report only-inferred methods as recompiles

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -2863,7 +2863,13 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
 
     // Everything from here on is considered (user facing) compile time
     uint64_t start = jl_typeinf_timing_begin();
-    int is_recompile = jl_atomic_load_relaxed(&mi->cache) != NULL;
+
+    // Is a recompile if there is cached code, and it was compiled (not only inferred) before
+    int is_recompile = 0;
+    jl_code_instance_t *codeinst_old = jl_atomic_load_relaxed(&mi->cache);
+    if ((codeinst_old != NULL) && (jl_atomic_load_relaxed(&codeinst_old->invoke) != NULL)) {
+        is_recompile = 1;
+    }
 
     // This codeinst hasn't been previously inferred do that now
     // jl_type_infer will internally do a cache lookup and jl_engine_reserve call


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/56155

If I run the test in https://github.com/JuliaLang/julia/issues/56155#issue-2585792789 the `--trace-compile` output contains no `# recompile` at all, but specifically not for `contractuser`.

And the test added here ensures that it is actually catching a true recompilation.