### PR TITLE
doc: manual: give the Performance Tips a table of contents

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -3,6 +3,13 @@
 In the following sections, we briefly go through a few techniques that can help make your Julia
 code run as fast as possible.
 
+## [Table of contents](@id man-performance-tips-toc)
+
+```@contents
+Pages = ["performance-tips.md"]
+Depth = 3
+```
+
 ## General advice
 
 ### Performance critical code should be inside a function


### PR DESCRIPTION
The page is quite long, and now it also has a more intricate structure than before, IMO it deserves a TOC.