### PR TITLE
[build] Fix value of `CMAKE_C{,XX}_ARG` when `CC_ARG` doesn't have args

### DIFF
--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -36,8 +36,8 @@ CMAKE_COMMON += -DCMAKE_C_COMPILER_LAUNCHER=ccache
 CMAKE_COMMON += -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 CMAKE_CC := "$$(which $(shell echo $(CC_ARG) | cut -d' ' -f1))"
 CMAKE_CXX := "$$(which $(shell echo $(CXX_ARG) | cut -d' ' -f1))"
-CMAKE_CC_ARG := $(shell echo $(CC_ARG) | cut -d' ' -f2-)
-CMAKE_CXX_ARG := $(shell echo $(CXX_ARG) | cut -d' ' -f2-)
+CMAKE_CC_ARG := $(shell echo $(CC_ARG) | cut -s -d' ' -f2-)
+CMAKE_CXX_ARG := $(shell echo $(CXX_ARG) | cut -s -d' ' -f2-)
 else
 CMAKE_CC := "$$(which $(CC_BASE))"
 CMAKE_CXX := "$$(which $(CXX_BASE))"


### PR DESCRIPTION
The problem was that `cut` by default prints the entire line if the delimiter doesn't appear, unless the option `-s` is used, which means that if `CC_ARG` contains only `gcc` then `CMAKE_CC_ARG` also contains `gcc` instead of being empty.

Before the PR:
```console
$ make -C deps/ print-CC_ARG print-CMAKE_CC_ARG print-CMAKE_COMMON USECCACHE=1
make: Entering directory '/home/mose/repo/julia/deps'
CC_ARG=gcc
CMAKE_CC_ARG=gcc
CMAKE_COMMON=-DCMAKE_INSTALL_PREFIX:PATH=/home/mose/repo/julia/usr -DCMAKE_PREFIX_PATH=/home/mose/repo/julia/usr -DLIB_INSTALL_DIR=/home/mose/repo/julia/usr/lib -DCMAKE_INSTALL_LIBDIR=/home/mose/repo/julia/usr/lib -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER="$(which gcc)" -DCMAKE_C_COMPILER_ARG1="gcc " -DCMAKE_CXX_COMPILER="$(which g++)" -DCMAKE_CXX_COMPILER_ARG1="g++ " -DCMAKE_LINKER="$(which ld)" -DCMAKE_AR="$(which ar)" -DCMAKE_RANLIB="$(which ranlib)"
make: Leaving directory '/home/mose/repo/julia/deps'
```
After the PR
```console
$ make -C deps/ print-CC_ARG print-CMAKE_CC_ARG print-CMAKE_COMMON USECCACHE=1
make: Entering directory '/home/mose/repo/julia/deps'
CC_ARG=gcc
CMAKE_CC_ARG=
CMAKE_COMMON=-DCMAKE_INSTALL_PREFIX:PATH=/home/mose/repo/julia/usr -DCMAKE_PREFIX_PATH=/home/mose/repo/julia/usr -DLIB_INSTALL_DIR=/home/mose/repo/julia/usr/lib -DCMAKE_INSTALL_LIBDIR=/home/mose/repo/julia/usr/lib -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER="$(which gcc)" -DCMAKE_CXX_COMPILER="$(which g++)" -DCMAKE_LINKER="$(which ld)" -DCMAKE_AR="$(which ar)" -DCMAKE_RANLIB="$(which ranlib)"
make: Leaving directory '/home/mose/repo/julia/deps'
```
as intended.

What I don't understand is why we use `CMAKE_C_COMPILER_ARG1` in the first place, which is an [undocumented hack](https://gitlab.kitware.com/cmake/cmake/-/issues/23358#note_1163817).