### PR TITLE
Don't error when initializing LibGit2 with CA roots path

### DIFF
--- a/stdlib/LibGit2/test/bad_ca_roots.jl
+++ b/stdlib/LibGit2/test/bad_ca_roots.jl
@@ -12,20 +12,24 @@ const CAN_SET_CA_ROOTS_PATH = !Sys.isapple() && !Sys.iswindows()
 # Given this is a sub-processed test file, not using @testsets avoids
 # leaking the report print into the Base test runner report
 begin # empty CA roots file
-    # these fail for different reasons on different platforms:
-    # - on Apple & Windows you cannot set the CA roots path location
-    # - on Linux & FreeBSD you you can but these are invalid files
+    # different behavior on different platforms:
+    # - on Apple & Windows you cannot set the CA roots path location; don't error
+    # - on Linux & FreeBSD you can but these are invalid files
+
     ENV["JULIA_SSL_CA_ROOTS_PATH"] = "/dev/null"
-    @test_throws LibGit2.GitError LibGit2.ensure_initialized()
-    ENV["JULIA_SSL_CA_ROOTS_PATH"] = tempname()
-    @test_throws LibGit2.GitError LibGit2.ensure_initialized()
-    # test that it still fails if called a second time
-    @test_throws LibGit2.GitError LibGit2.ensure_initialized()
-    if !CAN_SET_CA_ROOTS_PATH
-        # test that this doesn't work on macOS & Windows
-        ENV["JULIA_SSL_CA_ROOTS_PATH"] = NetworkOptions.bundled_ca_roots()
+    if CAN_SET_CA_ROOTS_PATH
         @test_throws LibGit2.GitError LibGit2.ensure_initialized()
-        delete!(ENV, "JULIA_SSL_CA_ROOTS_PATH")
+    else
+        @test LibGit2.ensure_initialized() === nothing
+    end
+
+    ENV["JULIA_SSL_CA_ROOTS_PATH"] = tempname()
+    if CAN_SET_CA_ROOTS_PATH
+        @test_throws LibGit2.GitError LibGit2.ensure_initialized()
+        # test that it still fails if called a second time
+        @test_throws LibGit2.GitError LibGit2.ensure_initialized()
+    else
+        @test LibGit2.ensure_initialized() === nothing
         @test LibGit2.ensure_initialized() === nothing
     end
 end


### PR DESCRIPTION
When SSL_CERT_FILE or SSL_CERT_DIR is set, it is [impossible to set this location](https://github.com/libgit2/libgit2/blob/4dcdb64c6844d76776745cdc25071a72c1af84d6/src/libgit2/settings.c#L206-L222) in LibGit2_jll on Apple and Windows because [it isn't built with support for that](https://github.com/JuliaPackaging/Yggdrasil/blob/7123a60a68102ba6cd953e13a4e45845dc37fd82/L/LibGit2/build_tarballs.jl#L67). Until now we've errored out with a message telling users to set JULIA_SSL_CA_ROOTS_PATH to an empty string, which is a somewhat problematic workaround because the Windows environment variables UI doesn't allow empty values, and [setting it to an empty string from PowerShell unsets it](https://discourse.julialang.org/t/how-to-fix-ssl-cert-issues-in-pkg/115495/7?u=visr). This PR changes the behavior to allow this expected error.

Variables like SSL_CERT_FILE are for instance [set by the Conda OpenSSL package on environment activation](https://github.com/conda-forge/openssl-feedstock/blob/83b5e2a793bc95d19e6cc2d9d28068f1a6ff6b79/recipe/activate-win.ps1) used by e.g. Python, ensuring many people cannot use Pkg operations that use LibGit2, like `dev Example`, `add Example#master`. See more user reports [on Discourse](https://discourse.julialang.org/search?q=JULIA_SSL_CA_ROOTS_PATH).

Together with https://github.com/JuliaLang/NetworkOptions.jl/pull/37 this should improve the experience of users trying out Julia from a Conda environment. This should also be fine to backport.