### PR TITLE
define `Core.Closure` and make compiler-generated closures subtype of it

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2531,6 +2531,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("IntrinsicFunction", (jl_value_t*)jl_intrinsic_type);
     add_builtin("Function", (jl_value_t*)jl_function_type);
     add_builtin("Builtin", (jl_value_t*)jl_builtin_type);
+    add_builtin("Closure", (jl_value_t*)jl_closure_type);
     add_builtin("MethodInstance", (jl_value_t*)jl_method_instance_type);
     add_builtin("CodeInfo", (jl_value_t*)jl_code_info_type);
     add_builtin("LLVMPtr", (jl_value_t*)jl_llvmpointer_type);

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -845,7 +845,8 @@ JL_DLLEXPORT jl_datatype_t *jl_new_datatype(
     }
     else {
         tn = jl_new_typename_in((jl_sym_t*)name, module, abstract, mutabl);
-        if (super == jl_function_type || super == jl_builtin_type || is_anonfn_typename(jl_symbol_name(name))) {
+        if (super == jl_function_type || super == jl_builtin_type ||
+            super == jl_closure_type || is_anonfn_typename(jl_symbol_name(name))) {
             // Callable objects (including compiler-generated closures) get independent method tables
             // as an optimization
             tn->mt = jl_new_method_table(name, module);

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1602,7 +1602,7 @@ void jl_init_serializer(void)
                      jl_pointer_type, jl_abstractarray_type, jl_nothing_type,
                      jl_vararg_type,
                      jl_densearray_type, jl_function_type, jl_typename_type,
-                     jl_builtin_type, jl_task_type, jl_uniontype_type,
+                     jl_builtin_type, jl_closure_type, jl_task_type, jl_uniontype_type,
                      jl_array_any_type, jl_intrinsic_type,
                      jl_methtable_type, jl_typemap_level_type,
                      jl_voidpointer_type, jl_newvarnode_type, jl_abstractstring_type,

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -29,6 +29,7 @@
     XX(jl_bottom_type) \
     XX(jl_boundserror_type) \
     XX(jl_builtin_type) \
+    XX(jl_closure_type) \
     XX(jl_char_type) \
     XX(jl_code_info_type) \
     XX(jl_code_instance_type) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3248,8 +3248,10 @@ void jl_init_types(void) JL_GC_DISABLED
 
     jl_function_type = jl_new_abstracttype((jl_value_t*)jl_symbol("Function"), core, jl_any_type, jl_emptysvec);
     jl_builtin_type  = jl_new_abstracttype((jl_value_t*)jl_symbol("Builtin"), core, jl_function_type, jl_emptysvec);
+    jl_closure_type = jl_new_abstracttype((jl_value_t*)jl_symbol("Closure"), core, jl_function_type, jl_emptysvec);
     jl_function_type->name->mt = NULL; // subtypes of Function have independent method tables
     jl_builtin_type->name->mt = NULL;  // so they don't share the Any type table
+    jl_closure_type->name->mt = NULL;
 
     jl_svec_t *tv;
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -4232,8 +4232,8 @@ f(x) = yt(x)
                                               (filter ssavalue? fieldtypes)))
                                 (fieldnames (append closure-param-names (filter (lambda (v) (not (is-var-boxed? v lam))) capt-vars))))
                            (if (null? para)
-                               (type-for-closure type-name capt-vars '(core Function))
-                               (type-for-closure-parameterized type-name para fieldnames capt-vars fieldtypes '(core Function)))))
+                               (type-for-closure type-name capt-vars '(core Closure))
+                               (type-for-closure-parameterized type-name para fieldnames capt-vars fieldtypes '(core Closure)))))
                         (mk-method ;; expression to make the method
                          (if short '()
                              (let* ((iskw ;; TODO jb/functions need more robust version of this

--- a/src/julia.h
+++ b/src/julia.h
@@ -907,6 +907,7 @@ extern JL_DLLIMPORT jl_unionall_t *jl_anytuple_type_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_vararg_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_function_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_builtin_type JL_GLOBALLY_ROOTED;
+extern JL_DLLIMPORT jl_datatype_t *jl_closure_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_unionall_t *jl_opaque_closure_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_typename_t *jl_opaque_closure_typename JL_GLOBALLY_ROOTED;
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -101,7 +101,7 @@ extern "C" {
 // TODO: put WeakRefs on the weak_refs list during deserialization
 // TODO: handle finalizers
 
-#define NUM_TAGS    195
+#define NUM_TAGS    196
 
 // An array of references that need to be restored from the sysimg
 // This is a manually constructed dual of the gvars array, which would be produced by codegen for Julia code, for C.
@@ -162,6 +162,7 @@ jl_value_t **const*const get_tags(void) {
         INSERT_TAG(jl_unionall_type);
         INSERT_TAG(jl_typename_type);
         INSERT_TAG(jl_builtin_type);
+        INSERT_TAG(jl_closure_type);
         INSERT_TAG(jl_code_info_type);
         INSERT_TAG(jl_opaque_closure_type);
         INSERT_TAG(jl_task_type);

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -561,7 +561,7 @@ function should_send_whole_type(s, t::DataType)
         name = tn.mt.name
         mod = tn.module
         isanonfunction = mod === Main && # only Main
-            t.super === Function && # only Functions
+            t.super === Core.Closure && # only Functions
             unsafe_load(unsafe_convert(Ptr{UInt8}, tn.name)) == UInt8('#') && # hidden type
             (!isdefined(mod, name) || t != typeof(getglobal(mod, name))) # XXX: 95% accurate test for this being an inner function
             # TODO: more accurate test? (tn.name !== "#" name)

--- a/test/core.jl
+++ b/test/core.jl
@@ -8398,3 +8398,13 @@ f_call_me() = invoke(f_invoke_me, f_invoke_me_ci)
 f_invalidate_me() = 2
 @test_throws ErrorException invoke(f_invoke_me, f_invoke_me_ci)
 @test_throws ErrorException f_call_me()
+
+function genenerate_closure(argtypes::Vector{Any})
+    local argtypesi
+    @inline function closure()
+        argtypesi = @noinline copy(argtypes)
+        return length(argtypesi)
+    end
+    return closure
+end
+@test genenerate_closure(Any[]) isa Core.Closure


### PR DESCRIPTION
Performance issues related to code containing closures are frequently discussed (e.g., JuliaLang/julia#15276, JuliaLang/julia#56561). Several approaches can be considered to address this problem, one of which involves re-inferring code containing closures (JuliaLang/julia#56687). To implement this idea, it is necessary to determine whether a given piece of code includes a closure. However, there is currently no explicit mechanism for making this determination (although there are some code that checks whether the function name contains `"#"` for this purpose, but this is an ad hoc solution).

To address this, this commit lays the foundation for future optimizations targeting closures by defining closure functions as a subtype of the new type `Core.Closure <: Function`. This change allows the optimizer to apply targeted optimizations to code containing calls to functions that are subtype of `Core.Closure`.