### PR TITLE
Properly mark `Meta.parse` as public

### DIFF
--- a/base/meta.jl
+++ b/base/meta.jl
@@ -12,6 +12,7 @@ export quot,
        isunaryoperator,
        isbinaryoperator,
        ispostfixoperator,
+       parse,
        replace_sourceloc!,
        show_sexpr,
        @dump

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -12,10 +12,11 @@ export quot,
        isunaryoperator,
        isbinaryoperator,
        ispostfixoperator,
-       parse,
        replace_sourceloc!,
        show_sexpr,
        @dump
+
+public parse
 
 using Base: isidentifier, isoperator, isunaryoperator, isbinaryoperator, ispostfixoperator
 import Base: isexpr


### PR DESCRIPTION
This is to remove the warning that the symbol is internal when checking the docstring for `Meta.parse` since it’s in the documentation.