### PR TITLE
Remove unused variable from `endswith`

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -100,7 +100,6 @@ Base.startswith(io::IO, prefix::AbstractString) = startswith(io, String(prefix))
 
 function endswith(a::Union{String, SubString{String}},
                   b::Union{String, SubString{String}})
-    cub = ncodeunits(b)
     astart = ncodeunits(a) - ncodeunits(b) + 1
     if astart < 1
         false


### PR DESCRIPTION
This is a trivial code cleanup suggestion. The `cub` variable was unused in `endswith(::Union{String, SubString{String}}, ::Union{String, SubString{String}})`.

I ran the tests with `make test`, there were some failures but they did not appear to be related to the change.