### PR TITLE
[deps] Fix build systems of curl and openssl

### DIFF
--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -1,6 +1,10 @@
 ## CURL ##
 include $(SRCDIR)/curl.version
 
+ifeq ($(USE_SYSTEM_OPENSSL), 0)
+$(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/openssl
+endif
+
 ifeq ($(USE_SYSTEM_LIBSSH2), 0)
 $(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/libssh2
 endif

--- a/deps/openssl.mk
+++ b/deps/openssl.mk
@@ -34,6 +34,8 @@ else ifeq ($(ARCH),ppc64le)
 OPENSSL_TARGET := linux-ppc64le
 else ifeq ($(ARCH),powerpc64le)
 OPENSSL_TARGET := linux-ppc64le
+else ifeq ($(ARCH),riscv64)
+OPENSSL_TARGET := linux64-riscv64
 endif
 else
 OPENSSL_TARGET := unknown


### PR DESCRIPTION
* Curl was missing a dependency on OpenSSL after #56708
* openssl is missing configuration target for riscv64