### PR TITLE
[build] Enable Intel JIT events only on x86_64

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -486,11 +486,15 @@ endif
 # Set to 1 to enable profiling with perf
 ifeq ("$(OS)", "Linux")
 USE_PERF_JITEVENTS ?= 1
+ifeq ($(ARCH),x86_64)
 USE_INTEL_JITEVENTS ?= 1
-else
+else # ARCH x86_64
+USE_INTEL_JITEVENTS ?= 0
+endif # ARCH x86_64
+else # OS Linux
 USE_PERF_JITEVENTS ?= 0
 USE_INTEL_JITEVENTS ?= 0
-endif
+endif # OS Linux
 
 JULIACODEGEN := LLVM
 


### PR DESCRIPTION
Currently we are enabling it for all Linux systems, but [Intel VTune supports only x86_64](https://www.intel.com/content/www/us/en/developer/articles/system-requirements/vtune-profiler-system-requirements.html) and building LLVM with ITTAPI support is problematic on some platforms (e.g. riscv64, ref: https://github.com/JuliaPackaging/Yggdrasil/pull/10204).