### PR TITLE
Install correct libgcc_s on darwin

### DIFF
--- a/deps/csl.mk
+++ b/deps/csl.mk
@@ -75,12 +75,24 @@ else
 $(eval $(call copy_csl,$(call versioned_libname,libgcc_s_seh,1)))
 endif
 else
-ifeq ($(APPLE_ARCH),arm64)
+ifeq ($(OS),Darwin)
+# On macOS, libgcc_s has soversion 1.1 always on aarch64 and only for GCC 12+
+# (-> libgfortran 5) on x86_64
+ifeq ($(ARCH),aarch64)
+$(eval $(call copy_csl,$(call versioned_libname,libgcc_s,1.1)))
+else
+ifeq ($(LIBGFORTRAN_VERSION),5)
 $(eval $(call copy_csl,$(call versioned_libname,libgcc_s,1.1)))
 else
 $(eval $(call copy_csl,$(call versioned_libname,libgcc_s,1)))
 endif
 endif
+else
+# Other targets just use libgcc_s.1
+$(eval $(call copy_csl,$(call versioned_libname,libgcc_s,1)))
+endif
+endif
+
 # winpthread is only Windows, pthread is only others
 ifeq ($(OS),WINNT)
 $(eval $(call copy_csl,$(call versioned_libname,libwinpthread,1)))


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/48056

We could simplify the logic a lot if we assume that modern Julia is always built against GCC ≥ 12. Would that be a fair assumption.