### PR TITLE
minor fix in enable/disable finalizers docstrings

### DIFF
--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -149,7 +149,7 @@ enable(on::Bool) = ccall(:jl_gc_enable, Int32, (Int32,), on) != 0
     GC.enable_finalizers(on::Bool)
 
 Increment or decrement the counter that controls the running of finalizers on
-the current Task. Finalizers will only run when the counter is at zero. (Set
+the current thread. Finalizers will only run when the counter is at zero. (Set
 `true` for enabling, `false` for disabling). They may still run concurrently on
 another Task or thread.
 """


### PR DESCRIPTION
Judging by the code from `jl_gc_disable_finalizers_internal` , these functions seem to change the ability to run finalizers on a per-thread (not per-task) basis.

```C
JL_DLLEXPORT void jl_gc_disable_finalizers_internal(void)
{
    jl_ptls_t ptls = jl_current_task->ptls;
    ptls->finalizers_inhibited++;
}
```