### PR TITLE
[CI] Add GitHub Actions workflow to check stdlib/Manifest.toml

### DIFF
--- a/.github/workflows/CheckStdlibManifest.yml
+++ b/.github/workflows/CheckStdlibManifest.yml
@@ -6,6 +6,7 @@ on:
       - 'stdlib/*.version'
       - 'stdlib/*/Project.toml'
 
+# We intentionally don't give any elevated permissions to the GITHUB_TOKEN:
 permissions: {}
 
 jobs:

--- a/.github/workflows/CheckStdlibManifest.yml
+++ b/.github/workflows/CheckStdlibManifest.yml
@@ -1,0 +1,33 @@
+name: Stdlib Manifest is up-to-date
+
+on:
+  pull_request:
+    paths:
+      - 'stdlib/**'
+
+permissions: {}
+
+jobs:
+  check_stdlib_manifest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: julia-actions/setup-julia@5c9647d97b78a5debe5164e9eec09d653d29bd71 # v2.6.1
+        with:
+          version: 'nightly'
+      - uses: julia-actions/cache@824243901fb567ccb490b0d0e2483ccecde46834 # v2.0.5
+      - name: 'Update stdlib manifest'
+        shell: julia --project=stdlib --color=yes {0}
+        run: |
+          using Pkg
+          Pkg.Registry.add("General")
+          Pkg.resolve()
+      - name: 'Summary'
+        run: |
+          if ! git diff-index --quiet HEAD -- stdlib/Manifest.toml; then
+              echo "stdlib/Manifest.toml is not up-to-date"
+              echo "Update it with the command"
+              echo "    ./julia --project=stdlib -e 'using Pkg; Pkg.resolve()'"
+              exit 1
+          fi

--- a/.github/workflows/CheckStdlibManifest.yml
+++ b/.github/workflows/CheckStdlibManifest.yml
@@ -3,7 +3,8 @@ name: Stdlib Manifest is up-to-date
 on:
   pull_request:
     paths:
-      - 'stdlib/**'
+      - 'stdlib/*.version'
+      - 'stdlib/*/Project.toml'
 
 permissions: {}
 

--- a/.github/workflows/CheckStdlibManifest.yml
+++ b/.github/workflows/CheckStdlibManifest.yml
@@ -14,6 +14,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: julia-actions/setup-julia@5c9647d97b78a5debe5164e9eec09d653d29bd71 # v2.6.1
         with:
           version: 'nightly'


### PR DESCRIPTION
Fix https://github.com/JuliaCI/julia-buildkite/issues/417.

I first tried with a workflow to automatically open a PR to update the manifest, via workflow dispatch and/or schedule, but it's complicated to do it with limited permissions: `peter-evans/create-pull-request` allows [creating PRs from forks](https://github.com/peter-evans/create-pull-request/blob/67ccf781d68cd99b580ae25a5c18a1cc84ffff1f/docs/concepts-guidelines.md#push-pull-request-branches-to-a-fork), but that's finicky because it requires a PAT which can push to the fork and for the workflow dispatch we'd need to keep the list of committers in sync across different organisations (GitHub doesn't allow creating forks within the same org, even with different name), and also schedule would be useless because for a seldom used repo that'd go stale very quickly.

Adding a check in PRs is probably the easiest option with least permissions required.  This needs #56972 to be merged first.