### PR TITLE
Make write(IO, Char) actually return the amount of printed bytes instead of the attempted written bytes.

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -864,11 +864,10 @@ end
 
 function write(io::IO, c::Char)
     u = bswap(reinterpret(UInt32, c))
-    n = 1
+    n = 0
     while true
-        write(io, u % UInt8)
+        n += write(io, u % UInt8)
         (u >>= 8) == 0 && return n
-        n += 1
     end
 end
 # write(io, ::AbstractChar) is not defined: implementations

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -399,3 +399,9 @@ end
     io = IOBuffer(data)
     @test read(io) == data
 end
+
+@testset "Writing Char to full buffer" begin
+    io = IOBuffer(;maxsize=1)
+    write(io, 'a')
+    @test write(io, 'a') == 0
+end


### PR DESCRIPTION
This might break some tests but I want to see which