### PR TITLE
Revert "add fenv cache to task struct (#51288)"

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -20,7 +20,6 @@
 #include "libsupport.h"
 #include <stdint.h>
 #include <string.h>
-#include <fenv.h>
 
 #include "htable.h"
 #include "arraylist.h"
@@ -2314,9 +2313,6 @@ typedef struct _jl_task_t {
     _Atomic(uint64_t) finished_at;
 
 // hidden state:
-    // cached floating point environment
-    // only updated at task switch
-    fenv_t fenv;
 
     // id of owning thread - does not need to be defined until the task runs
     _Atomic(int16_t) tid;

--- a/src/task.c
+++ b/src/task.c
@@ -541,7 +541,6 @@ JL_NO_ASAN static void ctx_switch(jl_task_t *lastt)
     jl_set_pgcstack(&t->gcstack);
     jl_signal_fence();
     lastt->ptls = NULL;
-    fegetenv(&lastt->fenv);
 #ifdef MIGRATE_TASKS
     ptls->previous_task = lastt;
 #endif
@@ -734,7 +733,6 @@ JL_DLLEXPORT void jl_switch(void) JL_NOTSAFEPOINT_LEAVE JL_NOTSAFEPOINT_ENTER
            0 == ptls->finalizers_inhibited);
     ptls->finalizers_inhibited = finalizers_inhibited;
     jl_timing_block_task_enter(ct, ptls, blk); (void)blk;
-    fesetenv(&ct->fenv);
 
     sig_atomic_t other_defer_signal = ptls->defer_signal;
     ptls->defer_signal = defer_signal;
@@ -1147,7 +1145,6 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion
     t->excstack = NULL;
     t->ctx.started = 0;
     t->priority = 0;
-    fegetenv(&t->fenv);
     jl_atomic_store_relaxed(&t->tid, -1);
     t->threadpoolid = ct->threadpoolid;
     t->ptls = NULL;
@@ -1254,7 +1251,6 @@ CFI_NORETURN
     if (!pt->sticky && !pt->ctx.copy_stack)
         jl_atomic_store_release(&pt->tid, -1);
 #endif
-    fesetenv(&ct->fenv);
 
     ct->ctx.started = 1;
     if (ct->metrics_enabled) {


### PR DESCRIPTION
This reverts commit 12aa9dea03a8a6bbe2891d3ca6ce34a21ec84734.

un-fixes #51277 

Alternatively, we could add a flag for whether the state is non-default so we know whether `fesetenv` is necessary, if this behavior is considered desireable.
