### PR TITLE
remove debug print call in `process_sysimg_args!`

### DIFF
--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -276,7 +276,6 @@ baremodule BuildSettings end
 function process_sysimg_args!()
     let i = 2 # skip file name
         while i <= length(Core.ARGS)
-            Core.println(Core.ARGS[i])
             if Core.ARGS[i] == "--buildsettings"
                 include(BuildSettings, ARGS[i+1])
             elseif Core.ARGS[i] == "--buildroot"


### PR DESCRIPTION
I assume leaving this in was not intentional?