### PR TITLE
remove fence that GC change made unnecessary

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -4463,8 +4463,6 @@ static void emit_memory_zeroinit_and_stores(jl_codectx_t &ctx, jl_datatype_t *ty
     auto len_store = ctx.builder.CreateAlignedStore(nel, len_field, Align(sizeof(void*)));
     auto aliasinfo = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_memorylen);
     aliasinfo.decorateInst(len_store);
-    //This avoids the length store from being deleted which is illegal
-    ctx.builder.CreateFence(AtomicOrdering::Release, SyncScope::SingleThread);
     // zeroinit pointers and unions
     if (zi) {
         Value *memory_ptr = ctx.builder.CreateStructGEP(ctx.types().T_jlgenericmemory, decay_alloc, 1);


### PR DESCRIPTION
@gbaraldi and I think that this fence can probably be removed now that https://github.com/JuliaLang/julia/pull/55223 is merged. This should slightly expand the set of cases where the Memory is removable.