### PR TITLE
Clarify mathematical definition of `lcm`

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -97,6 +97,9 @@ end
 Least common (positive) multiple (or zero if any argument is zero).
 The arguments may be integer and rational numbers.
 
+``a`` is a multiple of ``b`` if there exists an integer ``m`` such
+that ``a=mb``.
+
 !!! compat "Julia 1.4"
     Rational arguments require Julia 1.4 or later.
 


### PR DESCRIPTION
Some folks define `lcm(x::T,y::T)` as any `z::T` such that there exists `a::T, b::T` with `a*x==z` and `b*y==z` and for all `zʹ::T` such that there exist  `a::T, b::T` with `a*x==zʹ` and `b*y==zʹ`, there also exists `c::T` with `z*c==zʹ`. This is a reasonable definition, but not what we use. Notably, it makes `lcm(x::Rational, y::Rational) = z::Rational` true for all finite, nonzero `x`, `y`, and `z`.

The definition we use requires `a`, `b`, and `c` to all be _integers_, not rationals in the case of `lcm(x::Rational, y::Rational)`. This clarifies what we mean when we define `lcm(x::Rational, y::Rational)` and also how the generic function should be extended.

See [this thread](https://github.com/JuliaLang/julia/pull/56423#discussion_r1826999933) for more discussion

cc @oscardssmith 