### PR TITLE
GC: report times spent in each step of sweeping

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -24,6 +24,9 @@ struct GC_Num
     mark_time       ::Int64
     stack_pool_sweep_time ::Int64
     total_sweep_time  ::Int64
+    total_sweep_page_walk_time              ::Int64
+    total_sweep_madvise_time                ::Int64
+    total_sweep_free_mallocd_memory_time    ::Int64
     total_mark_time   ::Int64
     total_stack_pool_sweep_time::Int64
     last_full_sweep ::Int64

--- a/src/gc-interface.h
+++ b/src/gc-interface.h
@@ -46,6 +46,9 @@ typedef struct {
     uint64_t mark_time;
     uint64_t stack_pool_sweep_time;
     uint64_t total_sweep_time;
+    uint64_t    total_sweep_page_walk_time;
+    uint64_t    total_sweep_madvise_time;
+    uint64_t    total_sweep_free_mallocd_memory_time;
     uint64_t total_mark_time;
     uint64_t total_stack_pool_sweep_time;
     uint64_t last_full_sweep;


### PR DESCRIPTION
We've been using this patch for a while (e.g., https://github.com/RelationalAI/julia/pull/176), and it has proven valuable for identifying the most expensive part of sweeping in a customer workload. Specifically, it highlighted that the madvise stage was the bottleneck. These metrics allowed us to effectively determine whether concurrent page sweeping would be beneficial.