### PR TITLE
cfunction: fix segfault when jl_type_infer doesn't run

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7483,7 +7483,8 @@ static Function *gen_cfun_wrapper(
     if (lam) {
         // TODO: this isn't ideal to be unconditionally calling type inference from here
         codeinst = jl_type_infer(lam, world, SOURCE_MODE_NOT_REQUIRED);
-        astrt = codeinst->rettype;
+        if (codeinst)
+            astrt = codeinst->rettype;
         if (astrt != (jl_value_t*)jl_bottom_type &&
             jl_type_intersection(astrt, declrt) == jl_bottom_type) {
             // Do not warn if the function never returns since it is


### PR DESCRIPTION
[Multivectors](https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_date/2025-01/05/Multivectors.primary.log) tried to recurse here too much though a generated function generator ending up back in inference, leading to a segfault here.