### PR TITLE
broadcast: align `ndims` implementation with intent behind code

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -281,20 +281,14 @@ end
 
 Base.IteratorSize(::Type{T}) where {T<:Broadcasted} = Base.HasShape{ndims(T)}()
 Base.ndims(BC::Type{<:Broadcasted{<:Any,Nothing}}) = _maxndims_broadcasted(BC)
-function Base.ndims(BC::Type{<:Broadcasted{<:AbstractArrayStyle{N},Nothing}}) where {N}
-    # `N` is the `AbstractArrayStyle` type parameter, so `N isa Union{Type,Int}`.
-    if (N isa Type) && (Any <: N)
-        # for `N isa Type`, `Any` is the only allowed value, indicating a wildcard
-        _maxndims_broadcasted(BC)
-    else
-        # for `N isa Int`, only nonnegative values are allowed, indicating the number of dimensions
-        let n = N::Int
-            if n < 0
-                throw(ArgumentError("dimension count must not be negative"))
-            end
-            n
-        end
+# the `AbstractArrayStyle` type parameter is required to be either equal to `Any` or be an `Int` value
+Base.ndims(BC::Type{<:Broadcasted{<:AbstractArrayStyle{Any},Nothing}}) = _maxndims_broadcasted(BC)
+function Base.ndims(::Type{<:Broadcasted{<:AbstractArrayStyle{N},Nothing}}) where {N}
+    n = N::Int
+    if n < 0
+        throw(ArgumentError("dimension count must not be negative"))
     end
+    n
 end
 
 function _maxndims_broadcasted(BC::Type{<:Broadcasted})

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -282,9 +282,12 @@ end
 Base.IteratorSize(::Type{T}) where {T<:Broadcasted} = Base.HasShape{ndims(T)}()
 Base.ndims(BC::Type{<:Broadcasted{<:Any,Nothing}}) = _maxndims_broadcasted(BC)
 function Base.ndims(BC::Type{<:Broadcasted{<:AbstractArrayStyle{N},Nothing}}) where {N}
+    # `N` is the `AbstractArrayStyle` type parameter, so `N isa Union{Type,Int}`.
     if (N isa Type) && (Any <: N)
+        # for `N isa Type`, `Any` is the only allowed value, indicating a wildcard
         _maxndims_broadcasted(BC)
     else
+        # for `N isa Int`, only nonnegative values are allowed, indicating the number of dimensions
         let n = N::Int
             NTuple{n}  # throw if negative
             n

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -289,7 +289,9 @@ function Base.ndims(BC::Type{<:Broadcasted{<:AbstractArrayStyle{N},Nothing}}) wh
     else
         # for `N isa Int`, only nonnegative values are allowed, indicating the number of dimensions
         let n = N::Int
-            NTuple{n}  # throw if negative
+            if n < 0
+                throw(ArgumentError("dimension count must not be negative"))
+            end
             n
         end
     end

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -283,13 +283,7 @@ Base.IteratorSize(::Type{T}) where {T<:Broadcasted} = Base.HasShape{ndims(T)}()
 Base.ndims(BC::Type{<:Broadcasted{<:Any,Nothing}}) = _maxndims_broadcasted(BC)
 # the `AbstractArrayStyle` type parameter is required to be either equal to `Any` or be an `Int` value
 Base.ndims(BC::Type{<:Broadcasted{<:AbstractArrayStyle{Any},Nothing}}) = _maxndims_broadcasted(BC)
-function Base.ndims(::Type{<:Broadcasted{<:AbstractArrayStyle{N},Nothing}}) where {N}
-    n = N::Int
-    if n < 0
-        throw(ArgumentError("dimension count must not be negative"))
-    end
-    n
-end
+Base.ndims(::Type{<:Broadcasted{<:AbstractArrayStyle{N},Nothing}}) where {N} = N::Int
 
 function _maxndims_broadcasted(BC::Type{<:Broadcasted})
     _maxndims(fieldtype(BC, :args))

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -930,6 +930,8 @@ let
 
     @test @inferred(Base.IteratorSize(Broadcast.broadcasted(+, (1,2,3), a1, zeros(3,3,3)))) === Base.HasShape{3}()
 
+    @test @inferred(Base.IteratorSize(Base.broadcasted(randn))) === Base.HasShape{0}()
+
     # inference on nested
     bc = Base.broadcasted(+, AD1(randn(3)), AD1(randn(3)))
     bc_nest = Base.broadcasted(+, bc , bc)


### PR DESCRIPTION
The `N<:Integer` constraint was nonsensical, given that `(N === Any) || (N isa Int)`. N5N3 noticed this back in 2022: https://github.com/JuliaLang/julia/pull/44061#discussion_r883261337

Follow up on #44061. Also xref #45477.