### PR TITLE
Add try/catch around handle_message() to catch errors during logging.

### DIFF
--- a/base/logging/logging.jl
+++ b/base/logging/logging.jl
@@ -420,12 +420,13 @@ function logmsg_code(_module, file, line, level, message, exs...)
     end
 end
 
-@noinline function handle_message_nothrow(logger, level, msg, _module, group, id, file,
-                                          line, args...; kwargs...)
+@noinline function handle_message_nothrow(logger, level, msg, _module, group, id, file, line; kwargs...)
+    @nospecialize
     try
         @invokelatest handle_message(
-            logger, level, msg, _module, group, id, file, line, args...;
+            logger, level, msg, _module, group, id, file, line;
             kwargs...)
+
     catch err
         @invokelatest logging_error(logger, level, _module, group, id, file, line, err, true)
     end

--- a/base/logging/logging.jl
+++ b/base/logging/logging.jl
@@ -409,7 +409,7 @@ function logmsg_code(_module, file, line, level, message, exs...)
                         end
                         line = $(log_data._line)
                         local msg, kwargs
-                        $(logrecord) && invokelatest($handle_message,
+                        $(logrecord) && $handle_message_nothrow(
                             logger, level, msg, _module, group, id, file, line;
                             kwargs...)
                     end
@@ -417,6 +417,17 @@ function logmsg_code(_module, file, line, level, message, exs...)
             end
             nothing
         end
+    end
+end
+
+@noinline function handle_message_nothrow(logger, level, msg, _module, group, id, file,
+                                          line, args...; kwargs...)
+    try
+        @invokelatest handle_message(
+            logger, level, msg, _module, group, id, file, line, args...;
+            kwargs...)
+    catch err
+        @invokelatest logging_error(logger, level, _module, group, id, file, line, err, true)
     end
 end
 

--- a/test/corelogging.jl
+++ b/test/corelogging.jl
@@ -115,18 +115,17 @@ end
     end
 end
 @testset "Log message handle_message exception handling" begin
-    # Exceptions in log handling (printing) of msg are caught by default
+    # Exceptions in log handling (printing) of msg are caught by default.
     struct Foo end
     Base.show(::IO, ::Foo) = 1 ÷ 0
 
-    @test_warn r"Error: Exception while generating log record in module Main at.*DivideError: integer division error" @info Foo()
+    # We cannot use `@test_logs` here, since test_logs does not actually _print_ the message
+    # (i.e. it does not invoke handle_message). To test exception handling during printing,
+    # we have to use `@test_warn` to see what was printed.
+    @test_warn r"Error: Exception while generating log record in module .*DivideError: integer division error"s @info Foo()
 
     # Exceptions in log handling (printing) of attributes are caught by default
-    out = capture_stderr() do
-        @info "foo" x=Foo()
-    end
-    @test occursin("Error: Exception while generating log record in module Main at", out)
-    @test occursin("DivideError: integer division error", out)
+    @test_warn r"Error: Exception while generating log record in module .*DivideError: integer division error"s @info "foo" x=Foo()
 end
 
 @testset "Special keywords" begin

--- a/test/corelogging.jl
+++ b/test/corelogging.jl
@@ -113,6 +113,13 @@ end
         @test_logs (Info,"the msg") logmsg()
         @test only(collect_test_logs(logmsg)[1]).kwargs[:x] === "the y"
     end
+
+    # Exceptions in log handling (printing) of msg are caught by default
+    struct Foo end
+    Base.show(::IO, ::Foo) = 1 ÷ 0
+    @test_logs (Error, Test.Ignored(), Test.Ignored(), :logevent_error) catch_exceptions=true @info Foo()
+    # Exceptions in log handling (printing) of attributes are caught by default
+    @test_logs (Error, Test.Ignored(), Test.Ignored(), :logevent_error) catch_exceptions=true @info "foo" x=Foo()
 end
 
 @testset "Special keywords" begin

--- a/test/corelogging.jl
+++ b/test/corelogging.jl
@@ -115,26 +115,11 @@ end
     end
 end
 @testset "Log message handle_message exception handling" begin
-    function capture_stderr(func)
-        fname = tempname()
-        f = open(fname, "w")
-        redirect_stderr(f) do
-            func()
-        end
-        close(f)
-        buf = read(fname)
-        rm(fname)
-        String(buf)
-    end
-
     # Exceptions in log handling (printing) of msg are caught by default
     struct Foo end
     Base.show(::IO, ::Foo) = 1 ÷ 0
-    out = capture_stderr() do
-        @info Foo()
-    end
-    @test occursin("Error: Exception while generating log record in module Main at", out)
-    @test occursin("DivideError: integer division error", out)
+
+    @test_warn r"Error: Exception while generating log record in module Main at.*DivideError: integer division error" @info Foo()
 
     # Exceptions in log handling (printing) of attributes are caught by default
     out = capture_stderr() do


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/56889.

Before this PR, an exception thrown while constructing the objects to log (the `msg`) would be caught and logged. However, an exception thrown while _printing_ the msg to an IO would _not_ be caught, and can abort the program. This breaks the promise that enabling verbose debug logging shouldn't introduce new crashes.

After this PR, an exception thrown during handle_message is caught and logged, just like an exception during `msg` construction:

```julia
julia> struct Foo end

julia> Base.show(::IO, ::Foo) = error("oh no")

julia> begin
           # Unexpectedly, the execption thrown while printing `Foo()` escapes
           @info Foo()
           # So we never reach this line! :'(
           println("~~~~~ ALL DONE ~~~~~~~~")
       end
┌ Error: Exception while generating log record in module Main at REPL[10]:3
│   exception =
│    oh no
│    Stacktrace:
│      [1] error(s::String)
│        @ Base ./error.jl:44
│      [2] show(::IOBuffer, ::Foo)
│        @ Main ./REPL[9]:1
...
│     [30] repl_main
│        @ ./client.jl:593 [inlined]
│     [31] _start()
│        @ Base ./client.jl:568
└ @ Main REPL[10]:3
~~~~~ ALL DONE ~~~~~~~~
```

This PR respects the change made in https://github.com/JuliaLang/julia/pull/36600 to keep the codegen as small as possible, by putting the new try/catch into a no-inlined function, so that we don't have to introduce a new try/catch in the macro-generated code body.