### PR TITLE
Fix devcontainer definition

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,0 @@
-FROM julia:latest
-
-RUN apt-get update && apt-get install -y build-essential libatomic1 python gfortran perl wget m4 cmake pkg-config git

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,12 @@
 {
-    "extensions": [
-      "julialang.language-julia",
-      "ms-vscode.cpptools"
-    ],
-  
-    "dockerFile": "Dockerfile"
+  "image": "docker.io/library/julia:latest",
+  "customizations": {
+      "vscode": {
+        "extensions": [
+          "julialang.language-julia",
+          "ms-vscode.cpptools"
+        ]
+     }
+  },
+  "onCreateCommand": "apt-get update && apt-get install -y build-essential libatomic1 python3 gfortran perl wget m4 cmake pkg-config git"
 }


### PR DESCRIPTION
Starting with  the Julia v1.9 container, `python` has no installation candidate. 

At the same time, modernize `devcontainer.json` and remove the need for a Dockerfile.