### PR TITLE
Add edge kind for access to non-explicit partitioned bindings

### DIFF
--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -481,4 +481,18 @@ end
 add_edges_impl(edges::Vector{Any}, info::VirtualMethodMatchInfo) =
     _add_edges_impl(edges, info.info, #=mi_edge=#true)
 
+"""
+    info::GlobalAccessInfo <: CallInfo
+
+Represents access to a global through runtime reflection, rather than as a manifest
+`GlobalRef` in the source code. Used for builtins (getglobal/setglobal/etc.) that
+perform such accesses.
+"""
+struct GlobalAccessInfo <: CallInfo
+    bpart::Core.BindingPartition
+end
+GlobalAccessInfo(::Nothing) = NoCallInfo()
+add_edges_impl(edges::Vector{Any}, info::GlobalAccessInfo) =
+    push!(edges, info.bpart)
+
 @specialize

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -544,6 +544,9 @@ function store_backedges(caller::CodeInstance, edges::SimpleVector)
             # ignore `Method`-edges (from e.g. failed `abstract_call_method`)
             i += 1
             continue
+        elseif isa(item, Core.BindingPartition)
+            i += 1
+            continue
         end
         if isa(item, CodeInstance)
             item = item.def

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -878,6 +878,10 @@ static int jl_verify_method(jl_code_instance_t *codeinst, size_t *minworld, size
             size_t min_valid2;
             size_t max_valid2;
             assert(!jl_is_method(edge)); // `Method`-edge isn't allowed for the optimized one-edge format
+            if (jl_is_binding_partition(edge)) {
+                j += 1;
+                continue;
+            }
             if (jl_is_code_instance(edge))
                 edge = (jl_value_t*)jl_get_ci_mi((jl_code_instance_t*)edge);
             if (jl_is_method_instance(edge)) {
@@ -1048,6 +1052,10 @@ static void jl_insert_backedges(jl_array_t *edges, jl_array_t *ext_ci_list)
                             continue;
                         }
                         else if (jl_is_method(edge)) {
+                            j += 1;
+                            continue;
+                        }
+                        else if (jl_is_binding_partition(edge)) {
                             j += 1;
                             continue;
                         }

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -646,9 +646,11 @@ function CC.abstract_eval_globalref(interp::REPLInterpreter, g::GlobalRef, baile
                                     sv::CC.InferenceState)
     if (interp.limit_aggressive_inference ? is_repl_frame(sv) : is_call_graph_uncached(sv))
         if isdefined_globalref(g)
-            return CC.RTEffects(Const(ccall(:jl_get_globalref_value, Any, (Any,), g)), Union{}, CC.EFFECTS_TOTAL)
+            return Pair{CC.RTEffects, Union{Nothing, Core.BindingPartition}}(
+                CC.RTEffects(Const(ccall(:jl_get_globalref_value, Any, (Any,), g)), Union{}, CC.EFFECTS_TOTAL), nothing)
         end
-        return CC.RTEffects(Union{}, UndefVarError, CC.EFFECTS_THROWS)
+        return Pair{CC.RTEffects, Union{Nothing, Core.BindingPartition}}(
+            CC.RTEffects(Union{}, UndefVarError, CC.EFFECTS_THROWS), nothing)
     end
     return @invoke CC.abstract_eval_globalref(interp::CC.AbstractInterpreter, g::GlobalRef, bailed::Bool,
                                               sv::CC.InferenceState)

--- a/sysimage.mk
+++ b/sysimage.mk
@@ -43,6 +43,7 @@ COMPILER_SRCS := $(addprefix $(JULIAHOME)/, \
 		base/int.jl \
 		base/indices.jl \
 		base/iterators.jl \
+		base/invalidation.jl \
 		base/namedtuple.jl \
 		base/number.jl \
 		base/operators.jl \

--- a/test/rebinding.jl
+++ b/test/rebinding.jl
@@ -31,7 +31,7 @@ module Rebinding
 
     # Tests for @world syntax
     @test Base.@world(Foo, defined_world_age) == typeof(x)
-    @test Base.@world(Rebinding.Foo, defined_world_age) == typeof(x)
+    nameof(@__MODULE__) === :Rebinding && @test Base.@world(Rebinding.Foo, defined_world_age) == typeof(x)
     @test Base.@world((@__MODULE__).Foo, defined_world_age) == typeof(x)
 
     # Test invalidation (const -> undefined)
@@ -40,4 +40,11 @@ module Rebinding
     @test f_return_delete_me() == 1
     Base.delete_binding(@__MODULE__, :delete_me)
     @test_throws UndefVarError f_return_delete_me()
+
+    ## + via indirect access
+    const delete_me = 2
+    f_return_delete_me_indirect() = getglobal(@__MODULE__, :delete_me)
+    @test f_return_delete_me_indirect() == 2
+    Base.delete_binding(@__MODULE__, :delete_me)
+    @test_throws UndefVarError f_return_delete_me_indirect()
 end


### PR DESCRIPTION
Our binding partion invalidation code scans the original source for any GlobalRefs that need to be invalidated. However, this is not the only source of access to binding partitions. Various intrinsics (in particular the `*global` ones) also operate on bindings. Since these are not manifest in the source, we instead use the existing `edges` mechanism to give them forward edges.

This PR only includes the basic info type, and validation in the replacement case. There's a bit more work to do there, but I'm waiting on #56499 for that part, precompilation in particular.