### PR TITLE
[docs] Add RISC-V page to table of content

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -248,6 +248,7 @@ DevDocs = [
         "devdocs/build/windows.md",
         "devdocs/build/freebsd.md",
         "devdocs/build/arm.md",
+        "devdocs/build/riscv.md",
         "devdocs/build/distributing.md",
     ]
 ]


### PR DESCRIPTION
This was missed in #56105.