### PR TITLE
improve pcre.jl code a bit

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -91,6 +91,12 @@ include("osutils.jl")
 include("io.jl")
 include("iobuffer.jl")
 
+# Concurrency (part 1)
+include("linked_list.jl")
+include("condition.jl")
+include("threads.jl")
+include("lock.jl")
+
 # strings & printing
 include("intfuncs.jl")
 include("strings/strings.jl")
@@ -116,12 +122,6 @@ include("missing.jl")
 
 # version
 include("version.jl")
-
-# Concurrency (part 1)
-include("linked_list.jl")
-include("condition.jl")
-include("threads.jl")
-include("lock.jl")
 
 # system & environment
 include("sysinfo.jl")

--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -24,19 +24,19 @@ function create_match_context()
     return ctx
 end
 
-THREAD_MATCH_CONTEXTS::Vector{Ptr{Cvoid}} = [C_NULL]
+global THREAD_MATCH_CONTEXTS::Vector{Ptr{Cvoid}} = [C_NULL]
 
-PCRE_COMPILE_LOCK = nothing
+global PCRE_COMPILE_LOCK::Threads.SpinLock
 
 _tid() = Int(ccall(:jl_threadid, Int16, ())) + 1
-_mth() = Int(Core.Intrinsics.atomic_pointerref(cglobal(:jl_n_threads, Cint), :acquire))
+_mth() = Threads.maxthreadid()
 
 function get_local_match_context()
     tid = _tid()
     ctxs = THREAD_MATCH_CONTEXTS
     if length(ctxs) < tid
         # slow path to allocate it
-        l = PCRE_COMPILE_LOCK::Threads.SpinLock
+        l = PCRE_COMPILE_LOCK
         lock(l)
         try
             ctxs = THREAD_MATCH_CONTEXTS

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -69,11 +69,11 @@ Regex(pattern::AbstractString) = Regex(pattern, DEFAULT_COMPILER_OPTS, DEFAULT_M
 
 function compile(regex::Regex)
     if regex.regex == C_NULL
-        if PCRE.PCRE_COMPILE_LOCK === nothing
+        if !isdefinedglobal(PCRE, :PCRE_COMPILE_LOCK)
             regex.regex = PCRE.compile(regex.pattern, regex.compile_options)
             PCRE.jit_compile(regex.regex)
         else
-            l = PCRE.PCRE_COMPILE_LOCK::Threads.SpinLock
+            l = PCRE.PCRE_COMPILE_LOCK
             lock(l)
             try
                 if regex.regex == C_NULL


### PR DESCRIPTION
- `PCRE._mth()` now uses `Base._maxthreadid` instead of manual inlining of `Threads.maxthreadid()`
- `PCRE_COMPILE_LOCK` is now typed global