### PR TITLE
make `datatype_min_ninitialized` robust against non `DataType` input

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3708,7 +3708,7 @@ end
     if isa(rt, PartialStruct)
         fields = copy(rt.fields)
         anyrefine = !isvarargtype(rt.fields[end]) &&
-            length(rt.fields) > datatype_min_ninitialized(unwrap_unionall(rt.typ))
+            length(rt.fields) > datatype_min_ninitialized(rt.typ)
         𝕃 = typeinf_lattice(info.interp)
         ⊏ = strictpartialorder(𝕃)
         for i in 1:length(fields)

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -601,7 +601,7 @@ end
         end
         nflds == 0 && return nothing
         fields = Vector{Any}(undef, nflds)
-        anyrefine = nflds > datatype_min_ninitialized(unwrap_unionall(aty))
+        anyrefine = nflds > datatype_min_ninitialized(aty)
         for i = 1:nflds
             ai = getfield_tfunc(𝕃, typea, Const(i))
             bi = getfield_tfunc(𝕃, typeb, Const(i))

--- a/Compiler/src/typeutils.jl
+++ b/Compiler/src/typeutils.jl
@@ -64,7 +64,9 @@ end
 
 # Compute the minimum number of initialized fields for a particular datatype
 # (therefore also a lower bound on the number of fields)
-function datatype_min_ninitialized(t::DataType)
+function datatype_min_ninitialized(@nospecialize t0)
+    t = unwrap_unionall(t0)
+    t isa DataType || return 0
     isabstracttype(t) && return 0
     if t.name === _NAMEDTUPLE_NAME
         names, types = t.parameters[1], t.parameters[2]


### PR DESCRIPTION
By unwrapping the input type in `datatype_min_ninitialized`, and guard against non `DataType` input by returning the most conservative value `0` in such cases.

- fixes JuliaLang/julia#56997