### PR TITLE
Support native `fma` on riscv64

### DIFF
--- a/src/llvm-cpufeatures.cpp
+++ b/src/llvm-cpufeatures.cpp
@@ -71,8 +71,16 @@ static bool have_fma(Function &intr, Function &caller, const Triple &TT) JL_NOTS
             if (Feature == "+fma" || Feature == "+fma4")
                 return typ == "f32" || typ == "f64";
         } else if (TT.isRISCV64()) {
-            if (Feature == "+zfh" || Feature == "+f" || Feature == "+d")
-                return typ == "f16" || typ == "f32" || typ == "f64";
+            // Don't return early if we find a known extension but it doesn't
+            // support the current type (e.g. f64 with Zfh or f16 with D)
+            if (Feature == "+zfh" && (typ == "f16" || typ == "f32"))
+                // Zfh implies F: https://github.com/riscv/riscv-isa-manual/blob/9799e5b43fa6780e58ec440774b0194debbca52b/src/zfh.adoc
+                return true;
+            else if (Feature == "+d" && (typ == "f32" || typ == "f64"))
+                // D implies F: https://github.com/riscv/riscv-isa-manual/blob/9799e5b43fa6780e58ec440774b0194debbca52b/src/d-st-ext.adoc
+                return true;
+            if (Feature == "+f" && typ == "f32")
+                return true;
         }
 
     return false;

--- a/src/llvm-cpufeatures.cpp
+++ b/src/llvm-cpufeatures.cpp
@@ -73,11 +73,9 @@ static bool have_fma(Function &intr, Function &caller, const Triple &TT) JL_NOTS
         } else if (TT.isRISCV64()) {
             // Don't return early if we find a known extension but it doesn't
             // support the current type (e.g. f64 with Zfh or f16 with D)
-            if (Feature == "+zfh" && (typ == "f16" || typ == "f32"))
-                // Zfh implies F: https://github.com/riscv/riscv-isa-manual/blob/9799e5b43fa6780e58ec440774b0194debbca52b/src/zfh.adoc
+            if (Feature == "+zfh" && typ == "f16")
                 return true;
-            else if (Feature == "+d" && (typ == "f32" || typ == "f64"))
-                // D implies F: https://github.com/riscv/riscv-isa-manual/blob/9799e5b43fa6780e58ec440774b0194debbca52b/src/d-st-ext.adoc
+            else if (Feature == "+d" && typ == "f64")
                 return true;
             if (Feature == "+f" && typ == "f32")
                 return true;

--- a/src/llvm-cpufeatures.cpp
+++ b/src/llvm-cpufeatures.cpp
@@ -62,15 +62,18 @@ static bool have_fma(Function &intr, Function &caller, const Triple &TT) JL_NOTS
     SmallVector<StringRef, 128> Features;
     FS.split(Features, ',');
     for (StringRef Feature : Features)
-    if (TT.isARM()) {
-      if (Feature == "+vfp4")
-        return typ == "f32" || typ == "f64";
-      else if (Feature == "+vfp4sp")
-        return typ == "f32";
-    } else if (TT.isX86()) {
-      if (Feature == "+fma" || Feature == "+fma4")
-        return typ == "f32" || typ == "f64";
-    }
+        if (TT.isARM()) {
+            if (Feature == "+vfp4")
+                return typ == "f32" || typ == "f64";
+            else if (Feature == "+vfp4sp")
+                return typ == "f32";
+        } else if (TT.isX86()) {
+            if (Feature == "+fma" || Feature == "+fma4")
+                return typ == "f32" || typ == "f64";
+        } else if (TT.isRISCV64()) {
+            if (Feature == "+zfh" || Feature == "+f" || Feature == "+d")
+                return typ == "f16" || typ == "f32" || typ == "f64";
+        }
 
     return false;
 }


### PR DESCRIPTION
This is an attempt to support native `fma` on riscv64, but I'm quite confused because with this PR I get at the same time
```julia-repl
julia> Core.Intrinsics.have_fma(Float64)
false

julia> code_llvm(fma, NTuple{3,Float64}; debuginfo=:none)
```
```llvm
; Function Signature: fma(Float64, Float64, Float64)
define double @julia_fma_1141(double %"x::Float64", double %"y::Float64", double %"z::Float64") #0 {
common.ret:
    #dbg_value(double %"x::Float64", !2, !DIExpression(), !16)
    #dbg_value(double %"y::Float64", !14, !DIExpression(), !16)
    #dbg_value(double %"z::Float64", !15, !DIExpression(), !16)
  %0 = call double @llvm.fma.f64(double %"x::Float64", double %"y::Float64", double %"z::Float64")
  ret double %0
}
```
`Core.Intrinsics.have_fma` claims native FMA instructions aren't available, but `fma` now uses `@llvm.fma.f64` instead of going through the emulated path, as it does on `master`:
```julia-repl
julia> code_llvm(fma, NTuple{3,Float64}; debuginfo=:none)
```
```llvm
; Function Signature: fma(Float64, Float64, Float64)
define double @julia_fma_1023(double %"x::Float64", double %"y::Float64", double %"z::Float64") #0 {
common.ret:
    #dbg_value(double %"x::Float64", !3, !DIExpression(), !17)
    #dbg_value(double %"y::Float64", !15, !DIExpression(), !17)
    #dbg_value(double %"z::Float64", !16, !DIExpression(), !17)
  %0 = call double @j_fma_emulated_1026(double %"x::Float64", double %"y::Float64", double %"z::Float64")
  ret double %0
}
```
@gbaraldi any idea of what's going on?