### PR TITLE
add option to dump backtrace of stop-the-world straggler

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -62,6 +62,7 @@ struct JLOptions
     trace_compile_timing::Int8
     trim::Int8
     task_metrics::Int8
+    timeout_for_safepoint_straggler_s::Int16
 end
 
 # This runs early in the sysimage != is not defined yet

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -66,6 +66,7 @@ typedef struct {
     int8_t trace_compile_timing;
     int8_t trim;
     int8_t task_metrics;
+    int16_t timeout_for_safepoint_straggler_s;
 } jl_options_t;
 
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -215,6 +215,8 @@ typedef struct {
     size_t bt_size;
     int tid;
 } jl_record_backtrace_result_t;
+JL_DLLEXPORT JL_DLLEXPORT size_t jl_try_record_thread_backtrace(jl_ptls_t ptls2, struct _jl_bt_element_t *bt_data,
+                                                                size_t max_bt_size) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_record_backtrace_result_t jl_record_backtrace(jl_task_t *t, struct _jl_bt_element_t *bt_data,
                                                               size_t max_bt_size, int all_tasks_profiler) JL_NOTSAFEPOINT;
 extern volatile struct _jl_bt_element_t *profile_bt_data_prof;

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1238,3 +1238,9 @@ end
         @test parse(UInt64,read(`$exename --heap-size-hint=$str -E "Base.JLOptions().heap_size_hint"`, String)) == val
     end
 end
+
+@testset "--timeout-for-safepoint-straggler" begin
+    exename = `$(Base.julia_cmd())`
+    timeout = 120
+    @test parse(Int,read(`$exename --timeout-for-safepoint-straggler=$timeout -E "Base.JLOptions().timeout_for_safepoint_straggler_s"`, String)) == timeout
+end


### PR DESCRIPTION
This is still a work in progress, but it should help determine what a straggler thread was doing during the stop-the-world phase and why it failed to reach a safepoint in a timely manner.

We've encountered long TTSP issues in production, and this tool should provide a valuable means to accurately diagnose them.