### PR TITLE
Implement logic for feature detection piggy backing on LLVM's feature detection

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -103,6 +103,7 @@
     XX(jl_dlopen) \
     XX(jl_dlsym) \
     XX(jl_dump_host_cpu) \
+    XX(jl_dump_host_cpu2)
     XX(jl_check_pkgimage_clones) \
     XX(jl_egal) \
     XX(jl_egal__bits) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -103,7 +103,7 @@
     XX(jl_dlopen) \
     XX(jl_dlsym) \
     XX(jl_dump_host_cpu) \
-    XX(jl_dump_host_cpu2)
+    XX(jl_dump_host_cpu2) \
     XX(jl_check_pkgimage_clones) \
     XX(jl_egal) \
     XX(jl_egal__bits) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -104,6 +104,7 @@
     XX(jl_dlsym) \
     XX(jl_dump_host_cpu) \
     XX(jl_dump_host_cpu2) \
+    XX(jl_dump_specific_cpu) \
     XX(jl_check_pkgimage_clones) \
     XX(jl_egal) \
     XX(jl_egal__bits) \

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -13,7 +13,11 @@
 #include <llvm/TargetParser/AArch64TargetParser.h>
 #include <llvm/TargetParser/X86TargetParser.h>
 #include <llvm/TargetParser/RISCVTargetParser.h>
+#if JL_LLVM_VERSION >= 190000
+#include <llvm/TargetParser/RISCVISAInfo.h>
+#else
 #include <llvm/Support/RISCVISAInfo.h>
+#endif
 #include <llvm/Support/MathExtras.h>
 #include <llvm/Support/raw_ostream.h>
 

--- a/src/processor.h
+++ b/src/processor.h
@@ -218,6 +218,7 @@ JL_DLLEXPORT jl_value_t *jl_cpu_has_fma(int bits);
 // Check if the CPU has native FMA instructions;
 // For debugging only
 JL_DLLEXPORT void jl_dump_host_cpu(void);
+JL_DLLEXPORT void jl_dump_host_cpu2(void);
 JL_DLLEXPORT jl_value_t* jl_check_pkgimage_clones(char* data);
 
 JL_DLLEXPORT int32_t jl_set_zero_subnormals(int8_t isZero);

--- a/src/processor.h
+++ b/src/processor.h
@@ -219,6 +219,7 @@ JL_DLLEXPORT jl_value_t *jl_cpu_has_fma(int bits);
 // For debugging only
 JL_DLLEXPORT void jl_dump_host_cpu(void);
 JL_DLLEXPORT void jl_dump_host_cpu2(void);
+JL_DLLEXPORT void jl_dump_specific_cpu(const char* triple, const char* cpu_name);
 JL_DLLEXPORT jl_value_t* jl_check_pkgimage_clones(char* data);
 
 JL_DLLEXPORT int32_t jl_set_zero_subnormals(int8_t isZero);


### PR DESCRIPTION
This doesn't switch or implement the new logic fully but I'm already opening for some comments if people have opinions.
The design is a bit more C++isy (this means removing c++ from the runtime is further away) and potentially less space efficient than the previous one (Not that it's very relevant).

The design switches to a clone targets logic that serializes a string like 
`cpu_name1;+feature1, +feature2; 0: cpu_name2; +feature3, +feature4; 0`
This gets rid of the nice bitset logic that we have but hopefully LLVM can replace most of it

- [x] CPU name based parsing
- [x] Target choosing logic (This matches by number of features currently, do we want something nicer?)
- [ ] Extra feature parsing (dependency detection)
- [ ] Cloning logic
- [ ] Adapt LLVM pass
- [ ] Extra targets (AMDGPU?)
- [ ] C api for LLVM.jl and relateds to use (just wrap jl_get_llvm_features)
- [ ] Delete old code
