### PR TITLE
add merge() for tuples

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -349,6 +349,9 @@ function _front(v, t...)
     (v, _front(t...)...)
 end
 
+
+merge(a::Tuple, b::Tuple) = (b..., last(a, length(a) - length(b))...)
+
 ## mapping ##
 
 # 1 argument function


### PR DESCRIPTION
`merge()` makes sense for any indexed collection, while it's currently only defined for dicts and namedtuples.

Here, I define it for regular tuples, with the same semantics:
```julia
julia> merge((a=1, b=2, c=3), (a=4, b=5))
(a = 4, b = 5, c = 3)

julia> merge((1,2,3), (4,5))
(4, 5, 3)
```
Potentially, the `merge` docstring should also be generalized to say that it merges all collections in the same way – `merge(a, b)[i] == b[i]` for `i in keys(b)`, and `a[i]` for other `i`.

Will add tests and update docs if this addition is ok. Maybe also define for vectors?