### PR TITLE
Construct proper URIs for paths when run on WSL in tests

### DIFF
--- a/test/path.jl
+++ b/test/path.jl
@@ -312,7 +312,14 @@
     end
 
     @testset "uripath" begin
-        host = if Sys.iswindows() "" else gethostname() end
+        host = if Sys.iswindows()
+            ""
+        elseif ispath("/proc/sys/fs/binfmt_misc/WSLInterop")
+            distro = get(ENV, "WSL_DISTRO_NAME", "") # See <https://patrickwu.space/wslconf/>
+            "wsl%24/$distro" # See <https://github.com/microsoft/terminal/pull/14993> and <https://learn.microsoft.com/en-us/windows/wsl/filesystems>
+        else
+            gethostname()
+        end
         sysdrive, uridrive = if Sys.iswindows() "C:\\", "C:/" else "/", "" end
         @test Base.Filesystem.uripath("$(sysdrive)some$(sep)file.txt") == "file://$host/$(uridrive)some/file.txt"
         @test Base.Filesystem.uripath("$(sysdrive)another$(sep)$(sep)folder$(sep)file.md") == "file://$host/$(uridrive)another/folder/file.md"


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/55454 produces the correct URIs when run on WSL, but the tests don't use the same logic and so they fail on WSL at the moment. This fixes the tests on WSL.

CC @tecosaur