### PR TITLE
Add `Timer` args to struct and add show method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -119,6 +119,7 @@ New library features
 certain compiler plugin workflows ([#56660]).
 * `sort` now supports `NTuple`s ([#54494])
 * `map!(f, A)` now stores the results in `A`, like `map!(f, A, A)`. or `A .= f.(A)` ([#40632]).
+* `Timer` now has readable `timeout` and `interval` properties, and a more descriptive show method ([#57081])
 
 Standard library changes
 ------------------------

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -622,6 +622,16 @@ let a = Ref(0)
     @test a[] == 1
 end
 
+@testset "Timer properties" begin
+    t = Timer(1.0, interval = 0.5)
+    @test t.timeout == 1.0
+    @test t.interval == 0.5
+    close(t)
+    @test !isopen(t)
+    @test t.timeout == 1.0
+    @test t.interval == 0.5
+end
+
 # trying to `schedule` a finished task
 let t = @async nothing
     wait(t)


### PR DESCRIPTION
Makes it possible to access & see the initial setup of a Timer.

This PR
```julia-repl
julia> t = Timer(1, interval=2)
Timer (open, timeout: 1, interval: 2) @0x000000010c35be50

julia> wait(Timer(t -> println("$(t.timeout) seconds have passed"), 2))
2 seconds have passed
```

Master
```julia-repl
julia> t = Timer(1, interval=2)
Timer(Ptr{Nothing}(0x0000600000b15800), Base.GenericCondition(Base.Threads.SpinLock(0)), true, false)

julia> dump(t)
Timer
  handle: Ptr{Nothing}(0x0000600000b15800)
  cond: Base.GenericCondition{Base.Threads.SpinLock}
    waitq: Base.IntrusiveLinkedList{Task}
      head: Nothing nothing
      tail: Nothing nothing
    lock: Base.Threads.SpinLock
      owned: Int64 0
  isopen: Bool true
  set: Bool true
```