### PR TITLE
Add option to make `verbose = true` apply recursively to nested test sets

### DIFF
--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -157,10 +157,10 @@ This can be used to allow for factorization of test sets, making it easier to ru
 test sets by running the associated functions instead.
 Note that in the case of functions, the test set will be given the name of the called function.
 In the event that a nested test set has no failures, as happened here, it will be hidden in the
-summary, unless the `verbose=true` option is passed:
+summary:
 
 ```jldoctest testfoo; filter = r"[0-9\.]+s"
-julia> @testset verbose = true "Foo Tests" begin
+julia> @testset "Foo Tests" begin
            @testset "Animals" begin
                @test foo("cat") == 9
                @test foo("dog") == foo("cat")
@@ -172,10 +172,6 @@ julia> @testset verbose = true "Foo Tests" begin
        end;
 Test Summary: | Pass  Total  Time
 Foo Tests     |    8      8  0.0s
-  Animals     |    2      2  0.0s
-  Arrays 1    |    2      2  0.0s
-  Arrays 2    |    2      2  0.0s
-  Arrays 3    |    2      2  0.0s
 ```
 
 If we do have a test failure, only the details for the failed test sets will be shown:
@@ -205,6 +201,66 @@ Foo Tests     |    3     1      4  0.0s
   Animals     |    2            2  0.0s
   Arrays      |    1     1      2  0.0s
 ERROR: Some tests did not pass: 3 passed, 1 failed, 0 errored, 0 broken.
+```
+
+You can use the `verbose` option to show results even for test sets that pass.
+`verbose=true` (or equivalently `verbose=1`) displays results only for the top level of
+nested sets:
+
+```julia-repl; filter = r"[0-9\.]+s"
+julia> @testset "Foo Tests" verbose = true begin
+           @testset "Animals" begin
+               @testset "Felines" begin
+                   @test foo("cat") == 9
+               end
+               @testset "Canines" begin
+                   @test foo("dog") == 9
+               end
+           end
+           @testset "Arrays" begin
+               @testset "zeros" begin
+                   @test foo(zeros(2)) == 4
+               end
+               @testset "fill" begin
+                   @test foo(fill(1.0, 4)) == 16
+               end
+           end
+       end;
+Test Summary: | Pass  Total  Time
+Foo Tests     |    4      4  0.0s
+  Animals     |    2      2  0.0s
+  Arrays      |    2      2  0.0s
+```
+
+whereas `verbose=2` will apply to all nested test sets:
+
+```julia-repl; filter = r"[0-9\.]+s"
+julia> @testset "Foo Tests" verbose = 2 begin
+           @testset "Animals" begin
+               @testset "Felines" begin
+                   @test foo("cat") == 9
+               end
+               @testset "Canines" begin
+                   @test foo("dog") == 9
+               end
+           end
+           @testset "Arrays" begin
+               @testset "zeros" begin
+                   @test foo(zeros(2)) == 4
+               end
+               @testset "fill" begin
+                   @test foo(fill(1.0, 4)) == 16
+               end
+           end
+       end;
+Test Summary: | Pass  Total  Time
+Foo Tests     |    4      4  0.0s
+  Animals     |    2      2  0.0s
+    Felines   |    1      1  0.0s
+    Canines   |    1      1  0.0s
+  Arrays      |    2      2  0.0s
+    zeros     |    1      1  0.0s
+    fill      |    1      1  0.0s
 ```
 
 ## Testing Log Statements

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1054,6 +1054,21 @@ end
 #-----------------------------------------------------------------------
 
 """
+    VerbosityLevel
+
+Different possible levels of verbosity for test output as reported by DefaultTestSet.
+
+Options are `only_failures`, `this_testset`, and `this_testset_and_children`.
+"""
+@enum VerbosityLevel only_failures=0 this_testset=1 this_testset_and_children=2
+
+# The established user interface for setting verbosity level is `verbose = true/false`,
+# hence the below conversion. Note that by virtue of being an Enum, we can also use the Ints
+# 0, 1, 2 to construct a `VerbosityLevel`.
+VerbosityLevel(x::Bool) = x ? this_testset : only_failures
+
+
+"""
     DefaultTestSet
 
 If using the DefaultTestSet, the test results will be recorded. If there
@@ -1065,7 +1080,7 @@ mutable struct DefaultTestSet <: AbstractTestSet
     results::Vector{Any}
     n_passed::Int
     anynonpass::Bool
-    verbose::Bool
+    verbose::VerbosityLevel
     showtiming::Bool
     time_start::Float64
     time_end::Union{Float64,Nothing}
@@ -1073,7 +1088,18 @@ mutable struct DefaultTestSet <: AbstractTestSet
     file::Union{String,Nothing}
     rng::Union{Nothing,AbstractRNG}
 end
-function DefaultTestSet(desc::AbstractString; verbose::Bool = false, showtiming::Bool = true, failfast::Union{Nothing,Bool} = nothing, source = nothing, rng = nothing)
+function DefaultTestSet(desc::AbstractString; verbose = nothing, showtiming::Bool = true, failfast::Union{Nothing,Bool} = nothing, source = nothing, rng = nothing)
+    if isnothing(verbose)
+        parent_ts = get_testset()
+        if parent_ts isa DefaultTestSet && (parent_ts.verbose == this_testset_and_children)
+            verbose = this_testset_and_children
+        else
+            verbose = only_failures
+        end
+    elseif !(verbose isa VerbosityLevel)
+        verbose = VerbosityLevel(verbose)
+    end
+
     if isnothing(failfast)
         # pass failfast state into child testsets
         parent_ts = get_testset()
@@ -1133,7 +1159,7 @@ Defaults to the empty tuple.
 """
 function results end
 
-print_verbose(ts::DefaultTestSet) = ts.verbose
+print_verbose(ts::DefaultTestSet) = ts.verbose > only_failures
 results(ts::DefaultTestSet) = ts.results
 
 # When a DefaultTestSet finishes, it records itself to its parent
@@ -1275,7 +1301,7 @@ function get_alignment(ts::DefaultTestSet, depth::Int)
     # The minimum width at this depth is
     ts_width = 2*depth + length(ts.description)
     # If not verbose and all passing, no need to look at children
-    !ts.verbose && !ts.anynonpass && return ts_width
+    (ts.verbose == only_failures) && !ts.anynonpass && return ts_width
     # Return the maximum of this width and the minimum width
     # for all children (if they exist)
     isempty(ts.results) && return ts_width


### PR DESCRIPTION
I wanted a feature where `verbose = true` would apply to nested test sets all the way down the nesting, so I made it. Any interest in having this as part of `DefaultTestSet`? I didn't discuss this with anyone before hand, so "we don't want this, please close" is a valid response.

I wasn't sure about the best interface. I went with `verbose = 2`, but happy to consider e.g. `verbose = :recursive`. Currently `verbose = 1` is equivalent to `verbose = true`.

I'm leaving this as a draft because it currently breaks the `DefaultTestSet` constructors: If someone uses the "full" inner constructor with a `Bool` for `verbose` it'll error. `DefaultTestSet` isn't exported, but I would still like to fix that. I'll pause here to get comments though before implementing the fix.