### PR TITLE
[Test] Improve regex matching expected test summaries

### DIFF
--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -870,7 +870,7 @@ let msg = read(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --co
             end
         end'`), stderr=devnull), String)
     @test occursin(r"""
-        Test Summary: \| Pass  Fail  Total  Time
+        Test Summary: \| Pass  Fail  Total +Time
         Foo Tests     \|    2     2      4  \s*\d*\.\ds
           Animals     \|    1     1      2  \s*\d*\.\ds
             Felines   \|    1            1  \s*\d*\.\ds
@@ -1253,7 +1253,7 @@ end
 
 @testset "verbose option" begin
     expected = r"""
-    Test Summary:             \| Pass  Total  Time
+    Test Summary:             \| Pass  Total +Time
     Parent                    \|    9      9  \s*\d*\.\ds
       Child 1                 \|    3      3  \s*\d*\.\ds
         Child 1\.1 \(long name\) \|    1      1  \s*\d*\.\ds
@@ -1324,7 +1324,7 @@ end
 @testset "failfast option" begin
     @testset "non failfast (default)" begin
         expected = r"""
-        Test Summary: \| Pass  Fail  Error  Total  Time
+        Test Summary: \| Pass  Fail  Error  Total +Time
         Foo           \|    1     2      1      4  \s*\d*\.\ds
           Bar         \|    1     1             2  \s*\d*\.\ds
         """
@@ -1350,7 +1350,7 @@ end
     end
     @testset "failfast" begin
         expected = r"""
-        Test Summary: \| Fail  Total  Time
+        Test Summary: \| Fail  Total +Time
         Foo           \|    1      1  \s*\d*\.\ds
         """
 
@@ -1375,7 +1375,7 @@ end
     end
     @testset "failfast passes to child testsets" begin
         expected = r"""
-        Test Summary: \| Fail  Total  Time
+        Test Summary: \| Fail  Total +Time
         Foo           \|    1      1  \s*\d*\.\ds
           1           \|    1      1  \s*\d*\.\ds
         """
@@ -1401,7 +1401,7 @@ end
     end
     @testset "failfast via env var" begin
         expected = r"""
-        Test Summary: \| Fail  Total  Time
+        Test Summary: \| Fail  Total +Time
         Foo           \|    1      1  \s*\d*\.\ds
         """
 
@@ -1712,7 +1712,7 @@ end
 
         # this tests both the `TestCounts` parts as well as the fallback `x`s
         expected = r"""
-                    Test Summary: \| Pass  Fail  Error  Broken  Total  Time
+                    Test Summary: \| Pass  Fail  Error  Broken  Total +Time
                     outer         \|    3     1      1       1      6  \s*\d*.\ds
                       a           \|    1                           1  \s*\d*.\ds
                       custom      \|    1     1      1       1      4  \s*\?s


### PR DESCRIPTION
Allow for more spaces between "Total" and "Time" columns, in case tests take occasionally longer than usual.

This would make the failed test in #57095 pass:
```julia-repl
julia> occursin(r"Test Summary: \| Pass  Fail  Total +Time
       Foo Tests     \|    2     2      4  \s*\d*\.\ds
         Animals     \|    1     1      2  \s*\d*\.\ds
           Felines   \|    1            1  \s*\d*\.\ds
           Canines   \|          1      1  \s*\d*\.\ds
         Arrays      \|    1     1      2  \s*\d*\.\ds
       ", "Canines: Test Failed at none:12\n  Expression: foo(\"dog\") == 11\n   Evaluated: 9 == 11\n\nStacktrace:\n [1] top-level scope\n   @ none:7\n [2] macro expansion\n   @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-x64-5.0/build/default-macmini-x64-5-0/julialang/julia-master/julia-cd027888a7/share/julia/stdlib/v1.12/Test/src/Test.jl:1764 [inlined]\n [3] macro expansion\n   @ none:8 [inlined]\n [4] macro expansion\n   @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-x64-5.0/build/default-macmini-x64-5-0/julialang/julia-master/julia-cd027888a7/share/julia/stdlib/v1.12/Test/src/Test.jl:1764 [inlined]\n [5] macro expansion\n   @ none:12 [inlined]\n [6] macro expansion\n   @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-x64-5.0/build/default-macmini-x64-5-0/julialang/julia-master/julia-cd027888a7/share/julia/stdlib/v1.12/Test/src/Test.jl:1764 [inlined]\n [7] macro expansion\n   @ none:12 [inlined]\n [8] macro expansion\n   @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-x64-5.0/build/default-macmini-x64-5-0/julialang/julia-master/julia-cd027888a7/share/julia/stdlib/v1.12/Test/src/Test.jl:679 [inlined]\nArrays: Test Failed at none:17\n  Expression: foo(fill(1.0, 4)) == 15\n   Evaluated: 16 == 15\n\nStacktrace:\n [1] top-level scope\n   @ none:7\n [2] macro expansion\n   @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-x64-5.0/build/default-macmini-x64-5-0/julialang/julia-master/julia-cd027888a7/share/julia/stdlib/v1.12/Test/src/Test.jl:1764 [inlined]\n [3] macro expansion\n   @ none:16 [inlined]\n [4] macro expansion\n   @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-x64-5.0/build/default-macmini-x64-5-0/julialang/julia-master/julia-cd027888a7/share/julia/stdlib/v1.12/Test/src/Test.jl:1764 [inlined]\n [5] macro expansion\n   @ none:17 [inlined]\n [6] macro expansion\n   @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-x64-5.0/build/default-macmini-x64-5-0/julialang/julia-master/julia-cd027888a7/share/julia/stdlib/v1.12/Test/src/Test.jl:679 [inlined]\nTest Summary: | Pass  Fail  Total   Time\nFoo Tests     |    2     2      4  10.2s\n  Animals     |    1     1      2  10.0s\n    Felines   |    1            1   0.0s\n    Canines   |          1      1  10.0s\n  Arrays      |    1     1      2   0.1s\nRNG of the outermost testset: Random.Xoshiro(0xe8d7b24b2f690da2, 0x354660fd679bcb5d, 0xb33a21adffe3f15b, 0x95b5454a71f564bf, 0x20c262b28365e7b9)\n")
true
```

Fix #57095.