### PR TITLE
Test startup with multithreads and no sysimage

### DIFF
--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1073,7 +1073,10 @@ run(pipeline(devnull, `$(joinpath(Sys.BINDIR, Base.julia_exename())) --lisp`, de
 let exename = `$(Base.julia_cmd()) --startup-file=no`
     @test readchomp(`$exename --sysimage-native-code=yes -E
         "Bool(Base.JLOptions().use_sysimage_native_code)"`) == "true"
-    @test readchomp(`$exename --sysimage-native-code=no -E
+    @showtime @test readchomp(`$exename --sysimage-native-code=no -E
+        "Bool(Base.JLOptions().use_sysimage_native_code)"`) == "false"
+    # test multithreaded startup with no sysimage
+    @showtime @test readchomp(`$exename --sysimage-native-code=no -t2,1 -E
         "Bool(Base.JLOptions().use_sysimage_native_code)"`) == "false"
 end
 


### PR DESCRIPTION
From https://github.com/JuliaLang/julia/pull/57087 it seems that startup when multithreaded with no sysimage fails on x86_64 linux, so test that on master.

The `@showtime`'s are just to see how long they take on CI. Will be dropped before merge.

---

MacOS x86 is slowest at ~4 minutes to run each of these, macOS aarch64 is fastest at 40s.

