### PR TITLE
fix `help?> StructType.field` command

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -666,7 +666,7 @@ function fielddoc(binding::Binding, field::Symbol)
         if multidoc !== nothing
             structdoc = get(multidoc.docs, Union{}, nothing)
             if structdoc !== nothing
-                fieldsdoc = get(structdoc.data, :field, nothing)
+                fieldsdoc = get(structdoc.data, :fields, nothing)
                 if fieldsdoc !== nothing
                     fielddoc = get(fieldsdoc, field)
                     if fielddoc !== nothing

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -662,13 +662,17 @@ function fielddoc(binding::Binding, field::Symbol)
     for mod in modules
         dict = meta(mod; autoinit=false)
         isnothing(dict) && continue
-        if haskey(dict, binding)
-            multidoc = dict[binding]
-            if haskey(multidoc.docs, Union{})
-                fields = multidoc.docs[Union{}].data[:fields]
-                if haskey(fields, field)
-                    doc = fields[field]
-                    return isa(doc, Markdown.MD) ? doc : Markdown.parse(doc)
+        multidoc = get(dict, binding, nothing)
+        if multidoc !== nothing
+            structdoc = get(multidoc.docs, Union{}, nothing)
+            if structdoc !== nothing
+                fieldsdoc = get(structdoc.data, :field, nothing)
+                if fieldsdoc !== nothing
+                    fielddoc = get(fieldsdoc, field)
+                    if fielddoc !== nothing
+                        return isa(fielddoc, Markdown.MD) ?
+                            fielddoc : Markdown.parse(fielddoc)
+                    end
                 end
             end
         end

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -668,7 +668,7 @@ function fielddoc(binding::Binding, field::Symbol)
             if structdoc !== nothing
                 fieldsdoc = get(structdoc.data, :fields, nothing)
                 if fieldsdoc !== nothing
-                    fielddoc = get(fieldsdoc, field)
+                    fielddoc = get(fieldsdoc, field, nothing)
                     if fielddoc !== nothing
                         return isa(fielddoc, Markdown.MD) ?
                             fielddoc : Markdown.parse(fielddoc)

--- a/stdlib/REPL/test/docview.jl
+++ b/stdlib/REPL/test/docview.jl
@@ -92,6 +92,9 @@ end
     @test endswith(get_help_standard("StructWithOneField.not_a_field"), "StructWithOneField` has field `field1`.\n")
     @test endswith(get_help_standard("StructWithTwoFields.not_a_field"), "StructWithTwoFields` has fields `field1`, and `field2`.\n")
     @test endswith(get_help_standard("StructWithThreeFields.not_a_field"), "StructWithThreeFields` has fields `field1`, `field2`, and `field3`.\n")
+
+    # Shouldn't error if the struct doesn't have any field documentations at all.
+    @test endswith(get_help_standard("Int.not_a_field"), "`$Int` has no fields.\n")
 end
 
 module InternalWarningsTests


### PR DESCRIPTION
`help?> StructType.field` currently errors when `StructType` doesn't have any field documentation at all. This commit adds a proper guard against such cases.