### PR TITLE
docs: include `summarize`d information in the extended documentation mode

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -708,10 +708,13 @@ using Core: CodeInfo, MethodInstance, CodeInstance, GotoNode, GotoIfNot, ReturnN
 end # module IR
 
 # docsystem basics
+function _ensure_doc_expr(@nospecialize(x), mod::Module, __source__::LineNumberNode)
+    isa(x, Expr) && x.head === :escape && return x
+    return Expr(:escape, Expr(:var"hygienic-scope", x, mod, __source__))
+end
 macro doc(x...)
     docex = atdoc(__source__, __module__, x...)
-    isa(docex, Expr) && docex.head === :escape && return docex
-    return Expr(:escape, Expr(:var"hygienic-scope", docex, typeof(atdoc).name.module, __source__))
+    return _ensure_doc_expr(docex, typeof(atdoc).name.module, __source__)
 end
 macro __doc__(x)
     return Expr(:escape, Expr(:block, Expr(:meta, :doc), x))

--- a/stdlib/REPL/test/docview.jl
+++ b/stdlib/REPL/test/docview.jl
@@ -146,7 +146,7 @@ module InternalWarningsTests
         @test docstring("A.B") == "No docstring or readme file found for public module `$(@__MODULE__).A.B`.\n\n# Public names\n\n`e`\n"
         @test startswith(docstring("A.B.c"), prefix(["A.B.c"]))
         @test startswith(docstring("A.B.d"), prefix(["A.B.d"]))
-        @test docstring("A.B.e") == "e is 6\n"
+        @test occursin("e is 6\n", docstring("A.B.e"))
         @test startswith(docstring("A.B2"), prefix(["A.B2"]))
         @test startswith(docstring("A.B2.C"), prefix(["A.B2", "A.B2.C"]))
         @test startswith(docstring("A.B2.C.d"), prefix(["A.B2", "A.B2.C", "A.B2.C.d"]))

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1346,31 +1346,35 @@ end
 
 let dt1 = striptrimdocs(_repl(:(dynamic_test(1.0))))
     @test dt1 isa Expr
-    @test dt1.args[1] isa Expr
-    @test dt1.args[1].head === :call
-    @test dt1.args[1].args[1] === Base.Docs.doc
-    @test dt1.args[1].args[3] == :(Union{Tuple{typeof(1.0)}})
+    arg1 = dt1.args[1]
+    @test arg1 isa Expr
+    @test arg1.head === :call
+    @test arg1.args[1] === Base.Docs.doc
+    @test arg1.args[4] == :(Union{Tuple{typeof(1.0)}})
 end
 let dt2 = striptrimdocs(_repl(:(dynamic_test(::String))))
     @test dt2 isa Expr
-    @test dt2.args[1] isa Expr
-    @test dt2.args[1].head === :call
-    @test dt2.args[1].args[1] === Base.Docs.doc
-    @test dt2.args[1].args[3] == :(Union{Tuple{String}})
+    arg1 = dt2.args[1]
+    @test arg1 isa Expr
+    @test arg1.head === :call
+    @test arg1.args[1] === Base.Docs.doc
+    @test arg1.args[4] == :(Union{Tuple{String}})
 end
 let dt3 = striptrimdocs(_repl(:(dynamic_test(a))))
     @test dt3 isa Expr
-    @test dt3.args[1] isa Expr
-    @test dt3.args[1].head === :call
-    @test dt3.args[1].args[1] === Base.Docs.doc
-    @test dt3.args[1].args[3].args[2].head === :curly # can't test equality due to line numbers
+    arg1 = dt3.args[1]
+    @test arg1 isa Expr
+    @test arg1.head === :call
+    @test arg1.args[1] === Base.Docs.doc
+    @test arg1.args[4].args[2].head === :curly # can't test equality due to line numbers
 end
 let dt4 = striptrimdocs(_repl(:(dynamic_test(1.0,u=2.0))))
     @test dt4 isa Expr
-    @test dt4.args[1] isa Expr
-    @test dt4.args[1].head === :call
-    @test dt4.args[1].args[1] === Base.Docs.doc
-    @test dt4.args[1].args[3] == :(Union{Tuple{typeof(1.0)}})
+    arg1 = dt4.args[1]
+    @test arg1 isa Expr
+    @test arg1.head === :call
+    @test arg1.args[1] === Base.Docs.doc
+    @test arg1.args[4] == :(Union{Tuple{typeof(1.0)}})
 end
 
 # Equality testing


### PR DESCRIPTION
When a binding does not have documentation, we return the result of `summarize(::Binding)` as fallback documentation. While this summary itself is often quite useful, it is not displayed when the binding does have documentation, e.g. `help?> Base.Compiler.InferenceResult`:
```julia
help?> Base.Compiler.InferenceResult
  ...

  result::InferenceResult

  A type that represents the result of running type inference on a chunk of code. There are two constructor available:

    •  InferenceResult(mi::MethodInstance, [𝕃::AbstractLattice]) for regular inference, without extended lattice information included in result.argtypes.
    •  InferenceResult(mi::MethodInstance, argtypes::Vector{Any}, overridden_by_const::BitVector) for constant inference, with extended lattice information included in
       result.argtypes.
```
I believe allowing summary information to be included someway could be useful, so this commit modifies the behavior in extended documentation mode to include the result of `summarize` at the end of the documentation. Now ``help?> ?Base.Compiler.InferenceResult`` would look like:
```julia
help?> ?Base.Compiler.InferenceResult
  ... # the same contents as what rendered in the regular documentation mode

  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  Extended information found for private binding Compiler.InferenceResult.

  Summary
  ≡≡≡≡≡≡≡

  mutable struct Compiler.InferenceResult

  Fields
  ≡≡≡≡≡≡

  linfo               :: Core.MethodInstance
  argtypes            :: Vector{Any}
  overridden_by_const :: Union{Nothing, BitVector}
  result              :: Any
  exc_result          :: Any
  src                 :: Any
  valid_worlds        :: Compiler.WorldRange
  ipo_effects         :: Compiler.Effects
  effects             :: Compiler.Effects
  analysis_results    :: Compiler.AnalysisResults
  is_src_volatile     :: Bool
  ci                  :: Core.CodeInstance
  ci_as_edge          :: Core.CodeInstance
```

Note that it only changes the behavior of the extended documentation mode within REPL, and the existing behavior of `@doc` outside of REPL doesn't change at all.

Additionally, this commit refactors the internal implementation of the help mode in REPL.jl to improve extensibility for future enhancements.