### PR TITLE
Add option to use `@spawn :samepool` for using the same threadpool as the caller

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,7 +24,7 @@ New language features
   - wall-time for the task (`Base.Experimental.task_wall_time_ns`).
 - Support for Unicode 16 ([#56925]).
 - `Threads.@spawn` now takes a `:same` argument to specify the same threadpool as the caller.
-  `Threads.@spawn :same foo()` which is shorthand for `Threads.@spawn Threads.threadpool() foo()` ([#])
+  `Threads.@spawn :same foo()` which is shorthand for `Threads.@spawn Threads.threadpool() foo()` ([#57109])
 
 Language changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,8 @@ New language features
   - actual running time for the task (`Base.Experimental.task_running_time_ns`), and
   - wall-time for the task (`Base.Experimental.task_wall_time_ns`).
 - Support for Unicode 16 ([#56925]).
+- `Threads.@spawn` now takes a `:same` argument to specify the same threadpool as the caller.
+  `Threads.@spawn :same foo()` which is shorthand for `Threads.@spawn Threads.threadpool() foo()` ([#])
 
 Language changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,8 +23,8 @@ New language features
   - actual running time for the task (`Base.Experimental.task_running_time_ns`), and
   - wall-time for the task (`Base.Experimental.task_wall_time_ns`).
 - Support for Unicode 16 ([#56925]).
-- `Threads.@spawn` now takes a `:same` argument to specify the same threadpool as the caller.
-  `Threads.@spawn :same foo()` which is shorthand for `Threads.@spawn Threads.threadpool() foo()` ([#57109])
+- `Threads.@spawn` now takes a `:samepool` argument to specify the same threadpool as the caller.
+  `Threads.@spawn :samepool foo()` which is shorthand for `Threads.@spawn Threads.threadpool() foo()` ([#57109])
 
 Language changes
 ----------------

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -440,10 +440,11 @@ function _spawn_set_thrpool(t::Task, tp::Symbol)
 end
 
 """
-    Threads.@spawn [:default|:interactive] expr
+    Threads.@spawn [:default|:interactive|:same] expr
 
 Create a [`Task`](@ref) and [`schedule`](@ref) it to run on any available
-thread in the specified threadpool (`:default` if unspecified). The task is
+thread in the specified threadpool: `:default`, `:interactive`, or `:same`
+to use the same as the caller. `:default` is used if unspecified. The task is
 allocated to a thread once one becomes available. To wait for the task to
 finish, call [`wait`](@ref) on the result of this macro, or call
 [`fetch`](@ref) to wait and then obtain its return value.
@@ -468,6 +469,9 @@ the variable's value in the current task.
 !!! compat "Julia 1.9"
     A threadpool may be specified as of Julia 1.9.
 
+!!! compat "Julia 1.12"
+    The same threadpool may be specified as of Julia 1.12.
+
 # Examples
 ```julia-repl
 julia> t() = println("Hello from ", Threads.threadid());
@@ -486,7 +490,7 @@ macro spawn(args...)
         ttype, ex = args
         if ttype isa QuoteNode
             ttype = ttype.value
-            if ttype !== :interactive && ttype !== :default
+            if !in(ttype, (:interactive, :default, :same))
                 throw(ArgumentError(LazyString("unsupported threadpool in @spawn: ", ttype)))
             end
             tp = QuoteNode(ttype)
@@ -507,7 +511,11 @@ macro spawn(args...)
         let $(letargs...)
             local task = Task($thunk)
             task.sticky = false
-            _spawn_set_thrpool(task, $(esc(tp)))
+            local tp = $(esc(tp))
+            if tp == :same
+                tp = Threads.threadpool()
+            end
+            _spawn_set_thrpool(task, tp)
             if $(Expr(:islocal, var))
                 put!($var, task)
             end

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -440,10 +440,10 @@ function _spawn_set_thrpool(t::Task, tp::Symbol)
 end
 
 """
-    Threads.@spawn [:default|:interactive|:same] expr
+    Threads.@spawn [:default|:interactive|:samepool] expr
 
 Create a [`Task`](@ref) and [`schedule`](@ref) it to run on any available
-thread in the specified threadpool: `:default`, `:interactive`, or `:same`
+thread in the specified threadpool: `:default`, `:interactive`, or `:samepool`
 to use the same as the caller. `:default` is used if unspecified. The task is
 allocated to a thread once one becomes available. To wait for the task to
 finish, call [`wait`](@ref) on the result of this macro, or call
@@ -490,7 +490,7 @@ macro spawn(args...)
         ttype, ex = args
         if ttype isa QuoteNode
             ttype = ttype.value
-            if !in(ttype, (:interactive, :default, :same))
+            if !in(ttype, (:interactive, :default, :samepool))
                 throw(ArgumentError(LazyString("unsupported threadpool in @spawn: ", ttype)))
             end
             tp = QuoteNode(ttype)
@@ -512,7 +512,7 @@ macro spawn(args...)
             local task = Task($thunk)
             task.sticky = false
             local tp = $(esc(tp))
-            if tp == :same
+            if tp == :samepool
                 tp = Threads.threadpool()
             end
             _spawn_set_thrpool(task, tp)

--- a/test/threadpool_use.jl
+++ b/test/threadpool_use.jl
@@ -9,14 +9,14 @@ using Base.Threads
 @test fetch(Threads.@spawn Threads.threadpool()) === :default
 @test fetch(Threads.@spawn :default Threads.threadpool()) === :default
 @test fetch(Threads.@spawn :interactive Threads.threadpool()) === :interactive
-@test fetch(Threads.@spawn :same Threads.threadpool()) === Threads.threadpool()
+@test fetch(Threads.@spawn :samepool Threads.threadpool()) === Threads.threadpool()
 @sync for tp in [:interactive, :default]
     Threads.@spawn tp begin
-        @test fetch(Threads.@spawn :same Threads.threadpool()) === Threads.threadpool()
+        @test fetch(Threads.@spawn :samepool Threads.threadpool()) === Threads.threadpool()
     end
 end
 wait(Threads.@spawn :interactive begin
-    @test fetch(Threads.@spawn :same Threads.threadpool()) === Threads.threadpool()
+    @test fetch(Threads.@spawn :samepool Threads.threadpool()) === Threads.threadpool()
 end)
 tp = :default
 @test fetch(Threads.@spawn tp Threads.threadpool()) === :default

--- a/test/threadpool_use.jl
+++ b/test/threadpool_use.jl
@@ -9,6 +9,15 @@ using Base.Threads
 @test fetch(Threads.@spawn Threads.threadpool()) === :default
 @test fetch(Threads.@spawn :default Threads.threadpool()) === :default
 @test fetch(Threads.@spawn :interactive Threads.threadpool()) === :interactive
+@test fetch(Threads.@spawn :same Threads.threadpool()) === Threads.threadpool()
+@sync for tp in [:interactive, :default]
+    Threads.@spawn tp begin
+        @test fetch(Threads.@spawn :same Threads.threadpool()) === Threads.threadpool()
+    end
+end
+wait(Threads.@spawn :interactive begin
+    @test fetch(Threads.@spawn :same Threads.threadpool()) === Threads.threadpool()
+end)
 tp = :default
 @test fetch(Threads.@spawn tp Threads.threadpool()) === :default
 tp = :interactive


### PR DESCRIPTION
Adds `Threads.@spawn :samepool foo()` as shorthand for `Threads.@spawn Threads.threadpool() foo()` to make it easier to stick within the same threadpool.

[ConcurrentUtilities.jl](https://github.com/JuliaServices/ConcurrentUtilities.jl/blob/5fced8291da84bd081cb2e27d2e16f5bc8081f38/src/ConcurrentUtilities.jl#L7-L13) already demonstrates this is desired functionality.

One common use for this is replacing `@async` with `@spawn` when there's an interactive thread, given that the main task runs on thread 1, so a bare `@spawn` will change threadpool to `:default`, perhaps unexpectedly.