### PR TITLE
Capture/silence some noisy test warnings

### DIFF
--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -1031,7 +1031,7 @@ end
 # Make sure that code that has unbound sparams works
 #https://github.com/JuliaLang/julia/issues/56739
 
-f56739(a) where {T} = a
+@test_warn r"declares type variable T but does not use it" @eval f56739(a) where {T} = a
 
 @test f56739(1) == 1
 g56739(x) = @noinline f56739(x)

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -97,7 +97,7 @@ ambig(x::Union{Char, Int16}) = 's'
 
 # Automatic detection of ambiguities
 
-const allowed_undefineds = Set([])
+const allowed_undefineds = Set([GlobalRef(Base, :active_repl)])
 
 let Distributed = get(Base.loaded_modules,
                       Base.PkgId(Base.UUID("8ba89e20-285c-5b6f-9357-94700520ee1b"), "Distributed"),

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -298,7 +298,7 @@ end
 end |> only === Type{Int}
 
 if bc_opt == bc_default
-@testset "Array/Memory escape analysis" begin
+    # Array/Memory escape analysis
     function no_allocate(T::Type{<:Union{Memory, Vector}})
         v = T(undef, 2)
         v[1] = 2
@@ -308,8 +308,8 @@ if bc_opt == bc_default
     function test_alloc(::Type{T}; broken=false) where T
         @test (@allocated no_allocate(T)) == 0 broken=broken
     end
-    @testset "$T" for T in [Memory, Vector]
-        @testset "$ET" for ET in [Int, Float32, Union{Int, Float64}]
+    for T in [Memory, Vector]
+        for ET in [Int, Float32, Union{Int, Float64}]
             no_allocate(T{ET}) #compile
             # allocations aren't removed for Union eltypes which they theoretically could be eventually
             test_alloc(T{ET}, broken=(ET==Union{Int, Float64}))
@@ -344,7 +344,6 @@ if bc_opt == bc_default
     end
     no_alias_prove(1)
     @test_broken (@allocated no_alias_prove(5)) == 0
-end
 end
 
 end

--- a/test/channel_threadpool.jl
+++ b/test/channel_threadpool.jl
@@ -3,12 +3,10 @@
 using Test
 using Base.Threads
 
-@testset "Task threadpools" begin
-    c = Channel{Symbol}() do c; put!(c, threadpool(current_task())); end
-    @test take!(c) === threadpool(current_task())
-    c = Channel{Symbol}(spawn = true) do c; put!(c, threadpool(current_task())); end
-    @test take!(c) === :default
-    c = Channel{Symbol}(threadpool = :interactive) do c; put!(c, threadpool(current_task())); end
-    @test take!(c) === :interactive
-    @test_throws ArgumentError Channel{Symbol}(threadpool = :foo) do c; put!(c, :foo); end
-end
+c = Channel{Symbol}() do c; put!(c, threadpool(current_task())); end
+@test take!(c) === threadpool(current_task())
+c = Channel{Symbol}(spawn = true) do c; put!(c, threadpool(current_task())); end
+@test take!(c) === :default
+c = Channel{Symbol}(threadpool = :interactive) do c; put!(c, threadpool(current_task())); end
+@test take!(c) === :interactive
+@test_throws ArgumentError Channel{Symbol}(threadpool = :foo) do c; put!(c, :foo); end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -78,7 +78,7 @@ out = read(`$echocmd hello` & `$echocmd world`, String)
 @test occursin("hello", out)
 @test read(pipeline(`$echocmd hello` & `$echocmd world`, sortcmd), String) == "hello\nworld\n"
 
-@test (run(`$printfcmd "       \033[34m[stdio passthrough ok]\033[0m\n"`); true)
+@test_warn r"[stdio passthrough ok]" run(pipeline(`$printfcmd "       \033[34m[stdio passthrough ok]\033[0m\n"`, stdout=stderr, stderr=stderr))
 
 # Test for SIGPIPE being a failure condition
 @test_throws ProcessFailedException run(pipeline(yescmd, `head`, devnull))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -3971,11 +3971,12 @@ end
 
 # Module Replacement
 module ReplacementContainer
+    using Test
     module ReplaceMe
         const x = 1
     end
     const Old = ReplaceMe
-    module ReplaceMe
+    @test_warn r"WARNING: replacing module ReplaceMe" @eval module ReplaceMe
         const x = 2
     end
 end


### PR DESCRIPTION
Also https://github.com/JuliaLang/julia/pull/57110 removes 2 `@time` prints