### PR TITLE
Add a new macro `@outline`, and use it in `@assert`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -98,6 +98,7 @@ New library functions
 * `insertdims(array; dims)` allows to insert singleton dimensions into an array which is the inverse operation to `dropdims`. ([#45793])
 * The new `Fix` type is a generalization of `Fix1/Fix2` for fixing a single argument ([#54653]).
 * `Sys.detectwsl()` allows to testing if Julia is running inside WSL at runtime. ([#57069])
+* `@outline expr` moves `expr` out to a separate, noinlined function -- a common performance optimization for error-throwing parts of code. ([#57122])
 
 New library features
 --------------------

--- a/base/error.jl
+++ b/base/error.jl
@@ -235,14 +235,14 @@ macro assert(ex, msgs...)
         # message is an expression needing evaluating
         # N.B. To reduce the risk of invalidation caused by the complex callstack involved
         # with `string`, use `inferencebarrier` here to hide this `string` from the compiler.
-        msg = :(Main.Base.inferencebarrier(Main.Base.string)($(esc(msg))))
+        msg = :($Main.Base.inferencebarrier($Main.Base.string)($(msg)))
     elseif isdefined(Main, :Base) && isdefined(Main.Base, :string) && applicable(Main.Base.string, msg)
         msg = Main.Base.string(msg)
     else
         # string() might not be defined during bootstrap
-        msg = :(Main.Base.inferencebarrier(_assert_tostring)($(Expr(:quote,msg))))
+        msg = :($Main.Base.inferencebarrier($_assert_tostring)($(Expr(:quote,msg))))
     end
-    return :($(esc(ex)) ? $(nothing) : throw(AssertionError($msg)))
+    return esc(:($(ex) ? $(nothing) : $Base.@outline($throw($AssertionError($msg)))))
 end
 
 # this may be overridden in contexts where `string(::Expr)` doesn't work

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1067,6 +1067,7 @@ export
     @simd,
     @inline,
     @noinline,
+    @outline,
     @nospecialize,
     @specialize,
     @polly,

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -377,7 +377,7 @@ sometimes harm the compiler's ability to optimize.
 # Examples
 ```julia
 function getindex(container, index)
-    if index < 1 || index > length(container)
+    if index ∉ eachindex(container)
         # Outline this throw, since constructing a BoundsError requires boxing
         # the arguments, which produces a lot of code.
         @outline throw(BoundsError(container, index))

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -365,12 +365,12 @@ scenarios. The expr is extracted into an outlined function, which is marked `@no
 
 Outlining an expr can be used to make a function smaller, e.g. by outlining an unlikely
 branch, which could help with runtime performance by improving instruction cache locality,
-and could help with compilation performance since 2 smaller functions can sometimes compile
+and could help with compilation performance since two smaller functions can sometimes compile
 faster than one larger function. Finally, outlining can be useful for type-stability, by
 outlining a type unstable block within a hot loop, where the outlined function could be type
 stable.
 
-A common use case is to @outline the code that throws exceptions, since this should be a
+A common use case is to `@outline` the code that throws exceptions, since this should be a
 rare case, but it can introduce a lot of complexity to the generated code, which can
 sometimes harm the compiler's ability to optimize.
 


### PR DESCRIPTION
Adds a new macro `@outline`, and uses it in `@assert`.

This implements the simplest suggestion in https://github.com/JuliaLang/julia/issues/29688.
It would still be excellent if the compiler would automatically perform this optimization for any `throw()` statement, but it sounds like introducing automatic outlining for such cases would be a difficult implementation task in the Compiler.

And in either case, even if we had such an optimization, there may be cases where a human will want to perform this optimization themselves for a number of reasons, including code-size reduction, improving type stability, outlining rare branches, etc, and having this in a macro is a nice way to automate it, and make this optimization more accessible. 😊 

----------

Example macro usage:
```julia
  @boundscheck if !(i > 1 && i <= length(x))
      @outline throw(BoundsError(x, i))
  end
```

This commit applies this new macro `@outline` to `@assert`, producing essentially:
```julia
# @assert x == y
x == y ? nothing : @outline(throw(AssertionError("x == y"))
```
or in a more complete example:
```julia
julia> @macroexpand @assert x != x "x == x: $x"
:(if x != x
      nothing
  else
      #= REPL[3]:36 =#
      var"#17#outline"(x) = begin
              $(Expr(:meta, :noinline))
              #= REPL[3]:36 =#
              (throw)((AssertionError)(((Main).Base.inferencebarrier((Main).Base.string))("x == x: $(x)")))
          end
      #= REPL[3]:38 =#
      var"#17#outline"(x)
  end)
```

This can improve performance for fast code that uses assertions. For example, take this definition of `getindex` for `WithoutMissingVector`:
https://github.com/JuliaLang/julia/blob/5058dbad0462f0142f0a18be0a9aa1d62c76d2d0/base/sort.jl#L597-L601

Before:
```julia
julia> @btime Base.Sort.WithoutMissingVector($(Any[1]))[$1]
  3.041 ns (0 allocations: 0 bytes)
1
```
After:
```julia
julia> @btime Base.Sort.WithoutMissingVector($(Any[1]))[$1]
  2.250 ns (0 allocations: 0 bytes)
1
```

The number of instructions in that function according to `@code_native` (on an aarch64 M2 MacBook) reduced from ~90 to ~40.