### PR TITLE
clarify that time_ns is monotonic

### DIFF
--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -159,7 +159,7 @@ end
     time_ns() -> UInt64
 
 Get the time in nanoseconds relative to some machine-specific arbitrary time in the past
-(which may change if the system is suspended or rebooted).
+(which may change if the system is rebooted or suspended).
 The primary use is for measuring the elapsed time during program execution.  The return value is guaranteed to
 be monotonic and is unaffected by clock drift or changes to local calendar time.
 

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -158,8 +158,11 @@ end
 """
     time_ns() -> UInt64
 
-Get the time in nanoseconds relative to some arbitrary time in the past. The primary use is for measuring the elapsed time
-between two moments in time.
+Get the time in nanoseconds relative to some arbitrary time in the past (which may change if the system is rebooted).
+The primary use is for measuring the elapsed time during program execution.  The return value is guaranteed to
+be monotonic and is unaffected by clock drift or changes to local calendar time.
+
+(Although the returned time is always in nanoseconds, the timing resolution is platform-dependent.)
 """
 time_ns() = ccall(:jl_hrtime, UInt64, ())
 

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -160,7 +160,7 @@ end
 
 Get the time in nanoseconds relative to some machine-specific arbitrary time in the past
 (which may change if the system is rebooted or suspended).
-The primary use is for measuring the elapsed time during program execution.  The return value is guaranteed to
+The primary use is for measuring elapsed times during program execution.  The return value is guaranteed to
 be monotonic and is unaffected by clock drift or changes to local calendar time.
 
 (Although the returned time is always in nanoseconds, the timing resolution is platform-dependent.)

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -159,7 +159,7 @@ end
     time_ns() -> UInt64
 
 Get the time in nanoseconds relative to some machine-specific arbitrary time in the past.
-The primary use is for measuring elapsed times during program execution.  The return value is guaranteed to
+The primary use is for measuring elapsed times during program execution. The return value is guaranteed to
 be monotonic (mod 2⁶⁴) while the system is running, and is unaffected by clock drift or changes to local calendar time,
 but it may change arbitrarily across system reboots or suspensions.
 

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -160,7 +160,7 @@ end
 
 Get the time in nanoseconds relative to some machine-specific arbitrary time in the past.
 The primary use is for measuring elapsed times during program execution.  The return value is guaranteed to
-be monotonic while the system is running, and is unaffected by clock drift or changes to local calendar time,
+be monotonic (mod 2⁶⁴) while the system is running, and is unaffected by clock drift or changes to local calendar time,
 but it may change arbitrarily across system reboots or suspensions.
 
 (Although the returned time is always in nanoseconds, the timing resolution is platform-dependent.)

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -158,10 +158,10 @@ end
 """
     time_ns() -> UInt64
 
-Get the time in nanoseconds relative to some machine-specific arbitrary time in the past
-(which may change if the system is rebooted or suspended).
+Get the time in nanoseconds relative to some machine-specific arbitrary time in the past.
 The primary use is for measuring elapsed times during program execution.  The return value is guaranteed to
-be monotonic and is unaffected by clock drift or changes to local calendar time.
+be monotonic while the system is running, and is unaffected by clock drift or changes to local calendar time,
+but it may change arbitrarily across system reboots or suspensions.
 
 (Although the returned time is always in nanoseconds, the timing resolution is platform-dependent.)
 """

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -158,7 +158,8 @@ end
 """
     time_ns() -> UInt64
 
-Get the time in nanoseconds relative to some arbitrary time in the past (which may change if the system is rebooted).
+Get the time in nanoseconds relative to some machine-specific arbitrary time in the past
+(which may change if the system is suspended or rebooted).
 The primary use is for measuring the elapsed time during program execution.  The return value is guaranteed to
 be monotonic and is unaffected by clock drift or changes to local calendar time.
 


### PR DESCRIPTION
Since `time_ns()` is based on [`uv_hrtime`](https://docs.libuv.org/en/v1.x/misc.html#c.uv_hrtime), the docs should note that it is guaranteed to be monotonic (see also #2464 and [this discourse thread](https://discourse.julialang.org/t/how-to-access-the-monotonic-steady-clock/125078/)).   This PR also notes that you can't compare times across machines or reboots, and that the timing resolution is system-dependent.

On Unix systems, it calls [`clock_gettime(CLOCK_MONOTONIC, &t)`](https://github.com/libuv/libuv/blob/0f31978c303b76798ff2b72e9498e5520722ef8a/src/unix/posix-hrtime.c#L32) and the [GNU libc manual](https://www.gnu.org/software/libc/manual/html_node/Getting-the-Time.html) notes that the reference time "may change if the system is rebooted or suspended."   On Windows, it calls [`QueryPerformanceCounter`](https://github.com/libuv/libuv/blob/0f31978c303b76798ff2b72e9498e5520722ef8a/src/win/util.c#L471).

(This docstring was last discussed in #54696.)

Also, I changed

> The primary use is for measuring the elapsed time *between two moments in time.*

To "The primary use is for measuring elapsed times *during program execution*" (emphasis added), since you don't want to use this to compare arbitrary "moments", e.g. from different runs of a program (that may span a system reboot).