### PR TITLE
Add `--trace-eval` and `Base.TRACE_EVAL` for showing each top level eval

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@ Command-line option changes
 * The option `--sysimage-native-code=no` has been deprecated.
 * The `JULIA_CPU_TARGET` environment variable now supports a `sysimage` keyword to match (or extend) the CPU target used to build the current system image ([#58970]).
 * The `--code-coverage=all` option now automatically throws away sysimage caches so that code coverage can be accurately measured on methods within the sysimage. It is thrown away after startup (and after startup.jl), before any user code is executed ([#59234])
+* New `--trace-eval` command-line option to show expressions being evaluated during top-level evaluation. Supports `--trace-eval=loc` or just `--trace-eval` (show location only), `--trace-eval=full` (show full expressions), and `--trace-eval=no` (disable tracing). Also adds `Base.TRACE_EVAL` global control that takes priority over the command-line option and can be set to `:no`, `:loc`, `:full`, or `nothing` (to use command-line setting). ([#57137])
 
 Multi-threading changes
 -----------------------

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2324,6 +2324,37 @@ const toplevel_load = Ref(true)
 const _require_world_age = Ref{UInt}(typemax(UInt))
 
 """
+    Base.TRACE_EVAL
+
+Global control for expression tracing during top-level evaluation. This setting takes priority
+over the `--trace-eval` command-line option.
+
+Set to:
+- `nothing` - use the command-line `--trace-eval` setting (default)
+- `:no` - disable expression tracing
+- `:loc` - show only location information during evaluation
+- `:full` - show full expressions being evaluated
+
+# Examples
+```julia
+# Enable full expression tracing
+Base.TRACE_EVAL = :full
+
+# Show only locations
+Base.TRACE_EVAL = :loc
+
+# Disable tracing (overrides command-line setting)
+Base.TRACE_EVAL = :no
+
+# Reset to use command-line setting
+Base.TRACE_EVAL = nothing
+```
+
+See also: [Command-line Interface](@ref cli) for the `--trace-eval` option.
+"""
+TRACE_EVAL::Union{Symbol,Nothing} = nothing
+
+"""
     require(into::Module, module::Symbol)
 
 This function is part of the implementation of [`using`](@ref) / [`import`](@ref), if a module is not
@@ -2862,6 +2893,28 @@ function include_string(mapexpr::Function, mod::Module, code::AbstractString,
             # Wrap things to be eval'd in a :toplevel expr to carry line
             # information as part of the expr.
             line_and_ex.args[2] = ex
+            # Check global TRACE_EVAL first, fall back to command line option
+            trace_eval_setting = TRACE_EVAL
+            trace_eval = if trace_eval_setting !== nothing
+                # Convert symbol to integer value
+                setting = trace_eval_setting
+                if setting === :no
+                    0
+                elseif setting === :loc
+                    1
+                elseif setting === :full
+                    2
+                else
+                    error("Invalid TRACE_EVAL value: $(setting). Must be :no, :loc, or :full")
+                end
+            else
+                JLOptions().trace_eval
+            end
+            if trace_eval == 2 # show everything
+                println(stderr, "eval: ", line_and_ex)
+            elseif trace_eval == 1 # show top location only
+                println(stderr, "eval: ", line_and_ex.args[1])
+            end
             result = Core.eval(mod, line_and_ex)
         end
         return result

--- a/base/options.jl
+++ b/base/options.jl
@@ -64,6 +64,7 @@ struct JLOptions
     heap_target_increment::UInt64
     trace_compile_timing::Int8
     trim::Int8
+    trace_eval::Int8
     task_metrics::Int8
     timeout_for_safepoint_straggler_s::Int16
     gc_sweep_always_full::Int8

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -295,6 +295,13 @@ If --trace-compile is enabled show how long each took to compile in ms
 Print precompile statements for methods dispatched during execution or save to stderr or a path.
 
 .TP
+--trace-eval[={no*|loc|full}]
+Show top-level expressions being evaluated. `loc` shows location info only,
+`full` shows full expressions (omitting setting is equivalent to `loc`).
+Only shows the outermost expression being evaluated, not internal function calls.
+Can be controlled programmatically via Base.TRACE_EVAL.
+
+.TP
 --task-metrics={yes|no*}
 Enable the collection of per-task metrics.
 

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -379,6 +379,7 @@ Base.@elapsed
 Base.@allocated
 Base.@allocations
 Base.@lock_conflicts
+Base.TRACE_EVAL
 Base.EnvDict
 Base.ENV
 Base.Sys.STDLIB

--- a/doc/src/manual/command-line-interface.md
+++ b/doc/src/manual/command-line-interface.md
@@ -219,6 +219,7 @@ The following is a complete list of command-line switches available when launchi
 |`--trace-compile={stderr\|name}`       |Print precompile statements for methods compiled during execution or save to stderr or a path. Methods that were recompiled are printed in yellow or with a trailing comment if color is not supported|
 |`--trace-compile-timing`               |If `--trace-compile` is enabled show how long each took to compile in ms|
 |`--trace-dispatch={stderr\|name}`      |Print precompile statements for methods dispatched during execution or save to stderr or a path.|
+|`--trace-eval[={no*\|loc\|full}]`      |Show top-level expressions being evaluated. `loc` shows location info only, `full` shows full expressions (omitting setting is equivalent to `loc`). Only shows the outermost expression being evaluated, not internal function calls. See also [`Base.TRACE_EVAL`](@ref).|
 |`--image-codegen`                      |Force generate code in imaging mode|
 |`--permalloc-pkgimg={yes\|no*}`        |Copy the data section of package images into memory|
 |`--trim={no*\|safe\|unsafe\|unsafe-warn}` |Build a sysimage including only code provably reachable from methods marked by calling `entrypoint`. The three non-default options differ in how they handle dynamic call sites. In safe mode, such sites result in compile-time errors. In unsafe mode, such sites are allowed but the resulting binary might be missing needed code and can throw runtime errors. With unsafe-warn, such sites will trigger warnings at compile-time and might error at runtime.|

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1544,6 +1544,36 @@ Note the `--startup-file=no` which helps isolate the test from packages you may 
 More analysis of the reasons for recompilation can be achieved with the
 [`SnoopCompile`](https://github.com/timholy/SnoopCompile.jl) package.
 
+### Tracing expression evaluation
+
+If you need to understand what code is being evaluated during test or script execution,
+you can use the `--trace-eval` command-line option or the [`Base.TRACE_EVAL`](@ref) global control to trace the outermost expressions being evaluated (top-level statements). Note this does not individually report the contents of function calls or code blocks:
+
+```bash
+# Show only location information during evaluation
+julia --trace-eval=loc script.jl
+
+# Show full expressions being evaluated
+julia --trace-eval=full script.jl
+```
+
+You can also control this programmatically:
+
+```julia
+# Enable full expression tracing
+Base.TRACE_EVAL = :full
+
+# Show only locations
+Base.TRACE_EVAL = :loc
+
+# Disable tracing
+Base.TRACE_EVAL = :no
+
+# Reset to use command-line setting
+Base.TRACE_EVAL = nothing
+```
+
+
 ### Reducing precompilation time
 
 If package precompilation is taking a long time, one option is to set the following internal and then precompile.

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -157,6 +157,7 @@ JL_DLLEXPORT void jl_init_options(void)
                         0, // heap-target-increment
                         0, // trace_compile_timing
                         JL_TRIM_NO, // trim
+                        0, // trace-eval
                         0, // task_metrics
                         -1, // timeout_for_safepoint_straggler_s
                         0, // gc_sweep_always_full
@@ -344,6 +345,7 @@ static const char opts_hidden[]  =
     "                                               With unsafe-warn warnings will be printed for\n"
     "                                               dynamic call sites that might lead to such errors.\n"
     "                                               In safe mode compile-time errors are given instead.\n"
+    " --trace-eval={loc|full|no*}                   Show the expression being evaluated before eval.\n"
     " --hard-heap-limit=<size>[<unit>]              Set a hard limit on the heap size: if we ever\n"
     "                                               go above this limit, we will abort. The value\n"
     "                                               may be specified as a number of bytes,\n"
@@ -410,6 +412,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_gc_threads,
            opt_permalloc_pkgimg,
            opt_trim,
+           opt_trace_eval,
            opt_experimental_features,
            opt_compress_sysimage,
     };
@@ -484,6 +487,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "gc-sweep-always-full", no_argument, 0, opt_gc_sweep_always_full },
         { "trim",  optional_argument, 0, opt_trim },
         { "compress-sysimage", required_argument, 0, opt_compress_sysimage },
+        { "trace-eval",       optional_argument, 0, opt_trace_eval },
         { 0, 0, 0, 0 }
     };
 
@@ -1057,6 +1061,16 @@ restart_switch:
                 jl_options.trim = JL_TRIM_UNSAFE_WARN;
             else
                 jl_errorf("julia: invalid argument to --trim={safe|no|unsafe|unsafe-warn} (%s)", optarg);
+            break;
+        case opt_trace_eval:
+            if (optarg == NULL || !strcmp(optarg,"loc"))
+                jl_options.trace_eval = 1;
+            else if (!strcmp(optarg,"full"))
+                jl_options.trace_eval = 2;
+            else if (!strcmp(optarg,"no"))
+                jl_options.trace_eval = 0;
+            else
+                jl_errorf("julia: invalid argument to --trace-eval={yes|no} (%s)", optarg);
             break;
         case opt_task_metrics:
             if (!strcmp(optarg, "no"))

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -68,6 +68,7 @@ typedef struct {
     uint64_t heap_target_increment;
     int8_t trace_compile_timing;
     int8_t trim;
+    int8_t trace_eval;
     int8_t task_metrics;
     int16_t timeout_for_safepoint_straggler_s;
     int8_t gc_sweep_always_full;


### PR DESCRIPTION
For debugging purposes makes it possible to see where top level eval is at during a running script or test suite, for debugging slow execution/hangs. Especially on remote machines that are harder to send a `SIGUSR1/SIGINFO` to.

For instance, the default `loc(ation)` mode on a test suite:

```
julia> import Pkg

julia> Pkg.test("TOML", julia_args=["--trace-eval"])
     Testing TOML
      Status `/private/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_Lj6sZ4/Project.toml`
...
     Testing Running tests...
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:3 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:4 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:6 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:8 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:18 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/readme.jl:4 =#
Test Summary: | Pass  Broken  Total  Time
README        |  197       4    201  2.9s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:19 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:4 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:5 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:6 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:8 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:9 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:10 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:13 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:21 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:33 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:20 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:3 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:5 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:6 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:8 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:10 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:22 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:37 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:48 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/empty-file.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/example.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/implicit-and-explicit-after.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/implicit-and-explicit-before.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/implicit-groups.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/newline-crlf.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/newline-lf.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/spec-example-1-compact.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/spec-example-1.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/array.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/bool.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/empty.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/hetergeneous.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/mixed-int-array.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/mixed-int-float.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/mixed-int-string.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/mixed-string-table.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/nested-double.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/nested-inline-table.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/nested.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/nospaces.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/string-quote-comma-2.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/string-quote-comma.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/string-with-comma.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/strings.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/table-array-string-backslash.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/bool/bool.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/comment/at-eof.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/comment/at-eof2.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/comment/everywhere.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/comment/noeol.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/comment/tricky.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/datetime/datetime.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/datetime/local-date.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/datetime/local-time.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/datetime/local.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/datetime/milliseconds.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/datetime/timezone.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/float/exponent.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/float/float.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/float/inf-and-nan.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/float/long.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/float/underscore.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/float/zero.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/array.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/bool.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/empty.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/end-in-bool.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/inline-table.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/key-dotted.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/multiline.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/nest.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/integer/integer.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/integer/literals.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/integer/long.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/integer/underscore.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/integer/zero.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/alphanum.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/case-sensitive.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/dotted.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/empty.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/equals-nospace.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/escapes.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/numeric-dotted.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/numeric.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/quoted-dots.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/space.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/special-chars.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/special-word.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/double-quote-escape.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/empty.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/escape-esc.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/escape-tricky.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/escaped-escape.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/escapes.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/multiline-escaped-crlf.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/multiline-quotes.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/multiline.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/nl.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/raw-multiline.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/raw.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/simple.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/unicode-escape.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/unicode-literal.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/with-pound.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/array-implicit.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/array-many.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/array-nest.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/array-one.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/array-table-array.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/empty.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/keyword.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/names.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/no-eol.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/sub-empty.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/whitespace.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/with-literal-string.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/with-pound.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/with-single-quotes.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_MZ4E97/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/without-super.jl:1 =#
Test Summary: | Pass  Broken  Total  Time
valid         |   91      10    101  2.1s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:89 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:97 =#
Test Summary: | Pass  Broken  Total  Time
invalid       |  194      30    224  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:21 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:3 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:4 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:5 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:8 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:10 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:22 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:34 =#
Test Summary: | Pass  Broken  Total  Time
Numbers       |   52       1     53  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:102 =#
Test Summary: | Pass  Total  Time
Booleans      |    8      8  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:114 =#
Test Summary: | Pass  Total  Time
Datetime      |   15     15  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:134 =#
Test Summary: | Pass  Total  Time
Time          |    3      3  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:143 =#
Test Summary: | Pass  Total  Time
String        |    1      1  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:172 =#
Test Summary: | Pass  Total  Time
Array         |    4      4  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:22 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/invalids.jl:3 =#
Test Summary: | Pass  Total  Time
errors        |    5      5  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:23 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/error_printing.jl:3 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/error_printing.jl:4 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/error_printing.jl:8 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/error_printing.jl:10 =#
Test Summary:  | Pass  Total  Time
error printing |    3      3  0.1s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:24 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:3 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:4 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:6 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:13 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:20 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:23 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:25 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:32 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:37 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:45 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:48 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:52 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:54 =#
Test Summary:    | Pass  Total  Time
empty dict print |    1      1  0.1s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:64 =#
Test Summary:      | Pass  Total  Time
special characters |    2      2  0.1s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:75 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:80 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:83 =#
Test Summary:                | Pass  Total  Time
vec with dicts and non-dicts |    4      4  0.3s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:118 =#
Test Summary:     | Pass  Total  Time
unsigned integers |    1      1  0.0s
Test Summary:     | Pass  Total  Time
unsigned integers |    1      1  0.0s
Test Summary:     | Pass  Total  Time
unsigned integers |    1      1  0.0s
Test Summary:     | Pass  Total  Time
unsigned integers |    1      1  0.0s
Test Summary:     | Pass  Total  Time
unsigned integers |    1      1  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:131 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:136 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:142 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:143 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:145 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:147 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:148 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:150 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:164 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:165 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:170 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:171 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:172 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:180 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:187 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:188 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:189 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:191 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:202 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:203 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:204 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:215 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:216 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:220 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:221 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:222 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:223 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:227 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:234 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:25 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/parse.jl:3 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/parse.jl:4 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/parse.jl:6 =#
Test Summary:                     | Pass  Total  Time
TOML.(try)parse(file) entrypoints |   29     29  0.1s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:27 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:29 =#
Test Summary: | Pass  Total  Time
Docstrings    |    1      1  0.0s
     Testing TOML tests passed
```

And with this and the new `JULIA_TEST_VERBOSE` https://github.com/JuliaLang/julia/pull/59295
```
% JULIA_TEST_VERBOSE=true ./julia --start=no -q
julia> import Pkg

julia> Pkg.test("TOML", julia_args=["--trace-eval"])
     Testing TOML
      Status `/private/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_nV08UL/Project.toml`
...
     Testing Running tests...
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:3 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:4 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:6 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:8 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:18 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/readme.jl:4 =#
Starting testset: README
  Starting testset: Example
  Finished testset: Example (0.4s)
  Starting testset: Comment
  Finished testset: Comment (0.0s)
  Starting testset: Key/Value Pair
  Finished testset: Key/Value Pair (0.0s)
  Starting testset: Keys
  Finished testset: Keys (0.2s)
  Starting testset: String
  Finished testset: String (0.0s)
  Starting testset: Integer
  Finished testset: Integer (0.0s)
  Starting testset: Float
  Finished testset: Float (0.0s)
  Starting testset: Boolean
    Starting testset: Offset Date-Time
    Finished testset: Offset Date-Time (0.5s)
    Starting testset: Local Date-Time
    Finished testset: Local Date-Time (0.0s)
    Starting testset: Local Date
    Finished testset: Local Date (0.1s)
    Starting testset: Local Time
    Finished testset: Local Time (0.0s)
  Finished testset: Boolean (0.7s)
  Starting testset: Array
  Finished testset: Array (0.2s)
  Starting testset: Table
  Finished testset: Table (0.9s)
  Starting testset: Inline table
    Starting testset: Array of Tables
    Finished testset: Array of Tables (0.4s)
  Finished testset: Inline table (0.4s)
Finished testset: README (2.8s)
Test Summary:        | Pass  Broken  Total  Time
README               |  197       4    201  2.8s
  Example            |    7              7  0.4s
  Comment            |    2              2  0.0s
  Key/Value Pair     |    4              4  0.0s
  Keys               |   25             25  0.2s
  String             |   19       2     21  0.0s
  Integer            |   47             47  0.0s
  Float              |   22             22  0.0s
  Boolean            |   19       2     21  0.7s
    Offset Date-Time |    8       2     10  0.5s
    Local Date-Time  |    3              3  0.0s
    Local Date       |    2              2  0.1s
    Local Time       |    3              3  0.0s
  Array              |   11             11  0.2s
  Table              |   20             20  0.9s
  Inline table       |   21             21  0.4s
    Array of Tables  |   14             14  0.4s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:19 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:4 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:5 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:6 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:8 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:9 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:10 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:13 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:21 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/utils/utils.jl:33 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:20 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:3 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:5 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:6 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:8 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:10 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:22 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:37 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:48 =#
Starting testset: valid
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/empty-file.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/example.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/implicit-and-explicit-after.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/implicit-and-explicit-before.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/implicit-groups.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/newline-crlf.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/newline-lf.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/spec-example-1-compact.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/spec-example-1.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/array.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/bool.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/empty.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/hetergeneous.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/mixed-int-array.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/mixed-int-float.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/mixed-int-string.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/mixed-string-table.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/nested-double.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/nested-inline-table.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/nested.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/nospaces.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/string-quote-comma-2.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/string-quote-comma.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/string-with-comma.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/strings.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/array/table-array-string-backslash.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/bool/bool.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/comment/at-eof.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/comment/at-eof2.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/comment/everywhere.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/comment/noeol.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/comment/tricky.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/datetime/datetime.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/datetime/local-date.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/datetime/local-time.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/datetime/local.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/datetime/milliseconds.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/datetime/timezone.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/float/exponent.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/float/float.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/float/inf-and-nan.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/float/long.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/float/underscore.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/float/zero.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/array.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/bool.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/empty.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/end-in-bool.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/inline-table.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/key-dotted.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/multiline.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/inline-table/nest.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/integer/integer.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/integer/literals.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/integer/long.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/integer/underscore.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/integer/zero.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/alphanum.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/case-sensitive.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/dotted.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/empty.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/equals-nospace.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/escapes.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/numeric-dotted.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/numeric.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/quoted-dots.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/space.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/special-chars.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/key/special-word.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/double-quote-escape.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/empty.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/escape-esc.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/escape-tricky.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/escaped-escape.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/escapes.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/multiline-escaped-crlf.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/multiline-quotes.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/multiline.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/nl.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/raw-multiline.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/raw.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/simple.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/unicode-escape.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/unicode-literal.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/string/with-pound.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/array-implicit.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/array-many.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/array-nest.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/array-one.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/array-table-array.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/empty.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/keyword.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/names.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/no-eol.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/sub-empty.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/whitespace.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/with-literal-string.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/with-pound.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/with-single-quotes.jl:1 =#
eval: #= /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCDn9S/testfiles/toml-test-julia-1.2.0/testfiles/valid/table/without-super.jl:1 =#
Finished testset: valid (2.0s)
Test Summary: | Pass  Broken  Total  Time
valid         |   91      10    101  2.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:89 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/toml_test.jl:97 =#
Starting testset: invalid
Finished testset: invalid (0.0s)
Test Summary: | Pass  Broken  Total  Time
invalid       |  194      30    224  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:21 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:3 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:4 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:5 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:8 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:10 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:22 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:34 =#
Starting testset: Numbers
Finished testset: Numbers (0.0s)
Test Summary: | Pass  Broken  Total  Time
Numbers       |   52       1     53  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:102 =#
Starting testset: Booleans
Finished testset: Booleans (0.0s)
Test Summary: | Pass  Total  Time
Booleans      |    8      8  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:114 =#
Starting testset: Datetime
Finished testset: Datetime (0.0s)
Test Summary: | Pass  Total  Time
Datetime      |   15     15  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:134 =#
Starting testset: Time
Finished testset: Time (0.0s)
Test Summary: | Pass  Total  Time
Time          |    3      3  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:143 =#
Starting testset: String
Finished testset: String (0.0s)
Test Summary: | Pass  Total  Time
String        |    1      1  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/values.jl:172 =#
Starting testset: Array
Finished testset: Array (0.0s)
Test Summary: | Pass  Total  Time
Array         |    4      4  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:22 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/invalids.jl:3 =#
Starting testset: errors
Finished testset: errors (0.0s)
Test Summary: | Pass  Total  Time
errors        |    5      5  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:23 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/error_printing.jl:3 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/error_printing.jl:4 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/error_printing.jl:8 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/error_printing.jl:10 =#
Starting testset: error printing
Finished testset: error printing (0.1s)
Test Summary:  | Pass  Total  Time
error printing |    3      3  0.1s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:24 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:3 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:4 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:6 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:13 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:20 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:23 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:25 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:32 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:37 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:45 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:48 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:52 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:54 =#
Starting testset: empty dict print
Finished testset: empty dict print (0.1s)
Test Summary:    | Pass  Total  Time
empty dict print |    1      1  0.1s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:64 =#
Starting testset: special characters
Finished testset: special characters (0.1s)
Test Summary:      | Pass  Total  Time
special characters |    2      2  0.1s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:75 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:80 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:83 =#
Starting testset: vec with dicts and non-dicts
Finished testset: vec with dicts and non-dicts (0.3s)
Test Summary:                | Pass  Total  Time
vec with dicts and non-dicts |    4      4  0.3s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:118 =#
Starting testset: unsigned integers
Finished testset: unsigned integers (0.0s)
Test Summary:     | Pass  Total  Time
unsigned integers |    1      1  0.0s
Starting testset: unsigned integers
Finished testset: unsigned integers (0.0s)
Test Summary:     | Pass  Total  Time
unsigned integers |    1      1  0.0s
Starting testset: unsigned integers
Finished testset: unsigned integers (0.0s)
Test Summary:     | Pass  Total  Time
unsigned integers |    1      1  0.0s
Starting testset: unsigned integers
Finished testset: unsigned integers (0.0s)
Test Summary:     | Pass  Total  Time
unsigned integers |    1      1  0.0s
Starting testset: unsigned integers
Finished testset: unsigned integers (0.0s)
Test Summary:     | Pass  Total  Time
unsigned integers |    1      1  0.0s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:131 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:136 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:142 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:143 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:145 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:147 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:148 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:150 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:164 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:165 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:170 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:171 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:172 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:180 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:187 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:188 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:189 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:191 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:202 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:203 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:204 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:215 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:216 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:220 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:221 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:222 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:223 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:227 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/print.jl:234 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:25 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/parse.jl:3 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/parse.jl:4 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/parse.jl:6 =#
Starting testset: TOML.(try)parse(file) entrypoints
Finished testset: TOML.(try)parse(file) entrypoints (0.1s)
Test Summary:                     | Pass  Total  Time
TOML.(try)parse(file) entrypoints |   29     29  0.1s
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:27 =#
eval: #= /Users/ian/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/TOML/test/runtests.jl:29 =#
Starting testset: Docstrings
Finished testset: Docstrings (0.0s)
Test Summary: | Pass  Total  Time
Docstrings    |    1      1  0.0s
     Testing TOML tests passed
```
