### PR TITLE
REPL: Handle message from `complete_methods!` when max methods is hit

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -1097,6 +1097,9 @@ function complete_keyword_argument(partial::String, last_idx::Int, context_modul
     last_word = partial[wordrange] # the word to complete
     kwargs = Set{String}()
     for m in methods
+        # if MAX_METHOD_COMPLETIONS is hit a single TextCompletion is return by complete_methods! with an explanation
+        # which can be ignored here
+        m isa TextCompletion && continue
         m::MethodCompletion
         possible_kwargs = Base.kwarg_decl(m.method)
         current_kwarg_candidates = String[]


### PR DESCRIPTION
It appears https://github.com/JuliaLang/julia/pull/56963 wasn't a proper fix (although curiously it did appear to work https://github.com/JuliaLang/julia/pull/56963#issuecomment-2572338231)

Reported on 1.11.3 https://discourse.julialang.org/t/sympy-makes-repl-to-stuck/124814/11
```
julia> using SymPy
Precompiling SymPy...
  19 dependencies successfully precompiled in 11 seconds. 33 already precompiled.

julia> sympy.apart(33/4)
8.25000000000000

julia> @syms n
(n,)

julia> ex = 1/(n*(n+3))
    1    
─────────
n⋅(n + 3)

julia> sympy.apart(e┌ Error: Error in the keymap
│   exception =
│    TypeError: in typeassert, expected REPL.REPLCompletions.MethodCompletion, got a value of type REPL.REPLCompletions.TextCompletion
│    Stacktrace:
│      [1] complete_keyword_argument
│        @ ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/REPLCompletions.jl:1040
│      [2] completions(string::String, pos::Int64, context_module::Module, shift::Bool, hint::Bool)
│        @ REPL.REPLCompletions ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/REPLCompletions.jl:1379
│      [3] complete_line(c::REPL.REPLCompletionProvider, s::REPL.LineEdit.PromptState, mod::Module; hint::Bool)
│        @ REPL ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/REPL.jl:637
│      [4] #complete_line#14
│        @ ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/LineEdit.jl:428
│      [5] complete_line
│        @ ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/LineEdit.jl:427
│      [6] complete_line
│        @ ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/LineEdit.jl:369
│      [7] edit_tab (repeats 2 times)
│        @ ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/LineEdit.jl:2419
│      [8] #118
│        @ ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/LineEdit.jl:2465
│      [9] #invokelatest#2
│        @ ./essentials.jl:1055 [inlined]
│     [10] invokelatest
│        @ ./essentials.jl:1052 [inlined]
│     [11] #30
│        @ ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/LineEdit.jl:1711
│     [12] macro expansion
│        @ ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/LineEdit.jl:2861 [inlined]
│     [13] macro expansion
│        @ ./lock.jl:273 [inlined]
│     [14] #282
│        @ ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/LineEdit.jl:2851
└ @ REPL.LineEdit ~/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/LineEdit.jl:2863
```