### PR TITLE
Fix the implementation of `closewrite(::AbstractPipe)`

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -444,10 +444,9 @@ end
 function pipe_reader end
 function pipe_writer end
 
-for f in (:flush, :iswritable)
+for f in (:flush, :closewrite, :iswritable)
     @eval $(f)(io::AbstractPipe) = $(f)(pipe_writer(io)::IO)
 end
-closewrite(io::AbstractPipe) = close(pipe_writer(io)::IO)
 write(io::AbstractPipe, byte::UInt8) = write(pipe_writer(io)::IO, byte)
 write(to::IO, from::AbstractPipe) = write(to, pipe_reader(from))
 unsafe_write(io::AbstractPipe, p::Ptr{UInt8}, nb::UInt) = unsafe_write(pipe_writer(io)::IO, p, nb)::Union{Int,UInt}

--- a/base/io.jl
+++ b/base/io.jl
@@ -444,9 +444,10 @@ end
 function pipe_reader end
 function pipe_writer end
 
-for f in (:flush, :closewrite, :iswritable)
+for f in (:flush, :iswritable)
     @eval $(f)(io::AbstractPipe) = $(f)(pipe_writer(io)::IO)
 end
+closewrite(io::AbstractPipe) = close(pipe_writer(io)::IO)
 write(io::AbstractPipe, byte::UInt8) = write(pipe_writer(io)::IO, byte)
 write(to::IO, from::AbstractPipe) = write(to, pipe_reader(from))
 unsafe_write(io::AbstractPipe, p::Ptr{UInt8}, nb::UInt) = unsafe_write(pipe_writer(io)::IO, p, nb)::Union{Int,UInt}

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -804,6 +804,7 @@ show(io::IO, stream::Pipe) = print(io,
     uv_status_string(stream.out), ", ",
     bytesavailable(stream), " bytes waiting)")
 
+closewrite(pipe::Pipe) = close(pipe.in)
 
 ## Functions for PipeEndpoint and PipeServer ##
 

--- a/test/read.jl
+++ b/test/read.jl
@@ -678,7 +678,12 @@ let p = Pipe()
     @test data_read[1:nread] == data[2:nread+1]
     @test read(p.out, 49) == data[end-48:end]
     wait(t)
+
+    closewrite(p)
+    @test !isopen(p.in)
+    @test isopen(p.out)
     close(p)
+    @test !isopen(p.out)
 end
 
 @testset "issue #27412" for itr in [eachline(IOBuffer("a")), readeach(IOBuffer("a"), Char)]


### PR DESCRIPTION
Previously this would just call `closewrite(p.in)`, which would throw an exception since `closewrite` isn't supported for the libuv stream underlying `PipeEndpoint`.

This fixes the example in the `Pipe` docstring: https://docs.julialang.org/en/v1/base/io-network/#Base.Pipe