### PR TITLE
Add reference to time_ns in time

### DIFF
--- a/base/libc.jl
+++ b/base/libc.jl
@@ -288,6 +288,8 @@ time(tm::TmStruct) = Float64(ccall(:mktime, Int, (Ref{TmStruct},), tm))
     time() -> Float64
 
 Get the system time in seconds since the epoch, with fairly high (typically, microsecond) resolution.
+
+See also [`time_ns`](@ref).
 """
 time() = ccall(:jl_clock_now, Float64, ())
 


### PR DESCRIPTION
I couldn't find `time_ns` when I was looking for it, nice to make clear the "monotonic" clock is also available in Base.