### PR TITLE
run UV on separate thread by default

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -552,6 +552,7 @@ function _start()
     append!(ARGS, Core.ARGS)
     # clear any postoutput hooks that were saved in the sysimage
     empty!(Base.postoutput_hooks)
+    Base.Experimental.make_io_thread()
     local ret = 0
     try
         repl_was_requested = exec_options(JLOptions())


### PR DESCRIPTION
This capability was added in https://github.com/JuliaLang/julia/pull/55529, but not used by default which seems silly since there are lots of issues like https://github.com/JuliaLang/julia/issues/43952 where this is needed to fix bugs. I'm not sure that this is the right place to add this (rather than in julia_init.c) but putting this up as a trial balloon.