### PR TITLE
typeinfer: Enqueue CIs for `ccallable` entrypoints

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1284,7 +1284,7 @@ function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim::
                 # make a best-effort attempt to enqueue the relevant code for the ccallable
                 ptr = ccall(:jl_get_specialization1,
                             #= MethodInstance =# Ptr{Cvoid}, (Any, Csize_t, Cint),
-                            sig, get_world_counter(), #= mt_cache =# 0)
+                            sig, this_world, #= mt_cache =# 0)
                 if ptr !== C_NULL
                     mi = unsafe_pointer_to_objref(ptr)
                     ci = typeinf_ext(interp, mi, SOURCE_MODE_NOT_REQUIRED)

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1280,8 +1280,20 @@ function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim::
                     ci isa CodeInstance && !use_const_api(ci) && push!(tocompile, ci)
                 end
             elseif item isa SimpleVector
-                push!(codeinfos, item[1]::Type)
-                push!(codeinfos, item[2]::Type)
+                (rt::Type, sig::Type) = item
+                # make a best-effort attempt to enqueue the relevant code for the ccallable
+                ptr = ccall(:jl_get_specialization1,
+                            #= MethodInstance =# Ptr{Cvoid}, (Any, Csize_t, Cint),
+                            sig, get_world_counter(), #= mt_cache =# 0)
+                if ptr !== C_NULL
+                    mi = unsafe_pointer_to_objref(ptr)
+                    ci = typeinf_ext(interp, mi, SOURCE_MODE_NOT_REQUIRED)
+                    ci isa CodeInstance && !use_const_api(ci) && push!(tocompile, ci)
+                end
+                # additionally enqueue the ccallable entrypoint / adapter, which implicitly
+                # invokes the above ci
+                push!(codeinfos, rt)
+                push!(codeinfos, sig)
             end
         end
         while !isempty(tocompile)


### PR DESCRIPTION
This is another step in the long-term direction to have type-inference fully-explore the code graph we want to emit, largely side-stepping the vestigial `jl_type_infer` paths that we still have in type-inference for ccallable (and OpaqueClosure)

This is needed for `juliac`, since the trim checks in codegen check if code was enqueued in the workqueue as expected.