### PR TITLE
Runtime intrinsics: fix fpext and fptrunc behaviour on Float16/BFloat16

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -2455,7 +2455,7 @@ const _SPECIAL_BUILTINS = Any[
 ]
 
 # Types compatible with fpext/fptrunc
-const _FLOAT_TYPES = Any[Core.BFloat16, Float16, Float32, Float64]
+const CORE_FLOAT_TYPES = Union{Core.BFloat16, Float16, Float32, Float64}
 
 function isdefined_effects(𝕃::AbstractLattice, argtypes::Vector{Any})
     # consistent if the first arg is immutable
@@ -2873,11 +2873,11 @@ function intrinsic_exct(𝕃::AbstractLattice, f::IntrinsicFunction, argtypes::V
 
         # fpext and fptrunc have further restrictions on the allowed types.
         if f === Intrinsics.fpext &&
-            !(ty in _FLOAT_TYPES && xty in _FLOAT_TYPES && Core.sizeof(ty) > Core.sizeof(xty))
+            !(ty <: CORE_FLOAT_TYPES && xty <: CORE_FLOAT_TYPES && Core.sizeof(ty) > Core.sizeof(xty))
             return ErrorException
         end
         if f === Intrinsics.fptrunc &&
-            !(ty in _FLOAT_TYPES && xty in _FLOAT_TYPES && Core.sizeof(ty) < Core.sizeof(xty))
+            !(ty <: CORE_FLOAT_TYPES && xty <: CORE_FLOAT_TYPES && Core.sizeof(ty) < Core.sizeof(xty))
             return ErrorException
         end
 

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -2454,6 +2454,9 @@ const _SPECIAL_BUILTINS = Any[
     Core._apply_iterate,
 ]
 
+# Types compatible with fpext/fptrunc
+const _FLOAT_TYPES = Any[Core.BFloat16, Float16, Float32, Float64]
+
 function isdefined_effects(𝕃::AbstractLattice, argtypes::Vector{Any})
     # consistent if the first arg is immutable
     na = length(argtypes)
@@ -2867,6 +2870,17 @@ function intrinsic_exct(𝕃::AbstractLattice, f::IntrinsicFunction, argtypes::V
         if !(isprimitivetype(ty) && isprimitivetype(xty))
             return ErrorException
         end
+
+        # fpext and fptrunc have further restrictions on the allowed types.
+        if f === Intrinsics.fpext &&
+            !(ty in _FLOAT_TYPES && xty in _FLOAT_TYPES && Core.sizeof(ty) > Core.sizeof(xty))
+            return ErrorException
+        end
+        if f === Intrinsics.fptrunc &&
+            !(ty in _FLOAT_TYPES && xty in _FLOAT_TYPES && Core.sizeof(ty) < Core.sizeof(xty))
+            return ErrorException
+        end
+
         return Union{}
     end
 

--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -1384,3 +1384,14 @@ end |> Compiler.is_nothrow
 @test Base.infer_effects() do
     @ccall unsafecall()::Cvoid
 end == Compiler.EFFECTS_UNKNOWN
+
+# fpext
+@test Compiler.intrinsic_nothrow(Core.Intrinsics.fpext, Any[Type{Float32}, Float16])
+@test Compiler.intrinsic_nothrow(Core.Intrinsics.fpext, Any[Type{Float64}, Float16])
+@test Compiler.intrinsic_nothrow(Core.Intrinsics.fpext, Any[Type{Float64}, Float32])
+@test !Compiler.intrinsic_nothrow(Core.Intrinsics.fpext, Any[Type{Float16}, Float16])
+@test !Compiler.intrinsic_nothrow(Core.Intrinsics.fpext, Any[Type{Float16}, Float32])
+@test !Compiler.intrinsic_nothrow(Core.Intrinsics.fpext, Any[Type{Float32}, Float32])
+@test !Compiler.intrinsic_nothrow(Core.Intrinsics.fpext, Any[Type{Float32}, Float64])
+@test !Compiler.intrinsic_nothrow(Core.Intrinsics.fpext, Any[Type{Int32}, Float16])
+@test !Compiler.intrinsic_nothrow(Core.Intrinsics.fpext, Any[Type{Float32}, Int16])

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -761,33 +761,25 @@ static inline void name(unsigned osize, jl_value_t *ty, void *pa, void *pr) JL_N
     OP(ty, (c_type*)pr, a); \
 }
 
-#define un_fintrinsic_half(OP, name) \
-static inline void name(unsigned osize, jl_value_t *ty, void *pa, void *pr) JL_NOTSAFEPOINT \
-{ \
-    uint16_t a = *(uint16_t*)pa; \
-    float A = half_to_float(a); \
-    if (osize == 16) { \
-        float R; \
-        OP(ty, &R, A); \
-        *(uint16_t*)pr = float_to_half(R); \
-    } else { \
-        OP(ty, (uint16_t*)pr, A); \
-    } \
-}
+#define un_fintrinsic_half(OP, name)                                            \
+    static inline void name(unsigned osize, jl_value_t *ty, void *pa, void *pr) \
+        JL_NOTSAFEPOINT                                                         \
+    {                                                                           \
+        uint16_t a = *(uint16_t *)pa;                                           \
+        float R, A = half_to_float(a);                                          \
+        OP(ty, &R, A);                                                          \
+        *(uint16_t *)pr = float_to_half(R);                                     \
+    }
 
-#define un_fintrinsic_bfloat(OP, name) \
-static inline void name(unsigned osize, jl_value_t *ty, void *pa, void *pr) JL_NOTSAFEPOINT \
-{ \
-    uint16_t a = *(uint16_t*)pa; \
-    float A = bfloat_to_float(a); \
-    if (osize == 16) { \
-        float R; \
-        OP(ty, &R, A); \
-        *(uint16_t*)pr = float_to_bfloat(R); \
-    } else { \
-        OP(ty, (uint16_t*)pr, A); \
-    } \
-}
+#define un_fintrinsic_bfloat(OP, name)                                          \
+    static inline void name(unsigned osize, jl_value_t *ty, void *pa, void *pr) \
+        JL_NOTSAFEPOINT                                                         \
+    {                                                                           \
+        uint16_t a = *(uint16_t *)pa;                                           \
+        float R, A = bfloat_to_float(a);                                        \
+        OP(ty, &R, A);                                                          \
+        *(uint16_t *)pr = float_to_bfloat(R);                                   \
+    }
 
 // float or integer inputs
 // OP::Function macro(inputa, inputb)
@@ -1629,32 +1621,85 @@ cvt_iintrinsic(LLVMUItoFP, uitofp)
 cvt_iintrinsic(LLVMFPtoSI, fptosi)
 cvt_iintrinsic(LLVMFPtoUI, fptoui)
 
-#define fptrunc(tr, pr, a) \
-        if (!(osize < 8 * sizeof(a))) \
-            jl_error("fptrunc: output bitsize must be < input bitsize"); \
-        else if (osize == 16) { \
-            if ((jl_datatype_t*)tr == jl_float16_type) \
-                *(uint16_t*)pr = float_to_half(a); \
-            else /*if ((jl_datatype_t*)tr == jl_bfloat16_type)*/ \
-                *(uint16_t*)pr = float_to_bfloat(a); \
-        } \
-        else if (osize == 32) \
-            *(float*)pr = a; \
-        else if (osize == 64) \
-            *(double*)pr = a; \
-        else \
-            jl_error("fptrunc: runtime floating point intrinsics are not implemented for bit sizes other than 16, 32 and 64");
-#define fpext(tr, pr, a) \
-        if (!(osize >= 8 * sizeof(a))) \
-            jl_error("fpext: output bitsize must be >= input bitsize"); \
-        if (osize == 32) \
-            *(float*)pr = a; \
-        else if (osize == 64) \
-            *(double*)pr = a; \
-        else \
-            jl_error("fpext: runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64");
-un_fintrinsic_withtype(fptrunc,fptrunc)
-un_fintrinsic_withtype(fpext,fpext)
+#define fintrinsic_read_float16(p)   half_to_float(*(uint16_t *)p)
+#define fintrinsic_read_bfloat16(p)  bfloat_to_float(*(uint16_t *)p)
+#define fintrinsic_read_float32(p)   *(float *)p
+#define fintrinsic_read_float64(p)   *(double *)p
+
+#define fintrinsic_write_float16(p, x)  *(uint16_t *)p = float_to_half(x)
+#define fintrinsic_write_bfloat16(p, x) *(uint16_t *)p = float_to_bfloat(x)
+#define fintrinsic_write_float32(p, x)  *(float *)p = x
+#define fintrinsic_write_float64(p, x)  *(double *)p = x
+
+/*
+ * aty: Type of value argument (input)
+ * pa:  Pointer to value argument data
+ * ty:  Type argument (output)
+ * pr:  Pointer to result data
+ */
+
+static inline void fptrunc(jl_datatype_t *aty, void *pa, jl_datatype_t *ty, void *pr)
+{
+    unsigned isize = jl_datatype_size(aty), osize = jl_datatype_size(ty);
+    if (!(osize < isize)) {
+        jl_error("fptrunc: output bitsize must be < input bitsize");
+        return;
+    }
+
+#define fptrunc_convert(in, out)                                \
+    else if (aty == jl_##in##_type && ty == jl_##out##_type)    \
+        fintrinsic_write_##out(pr, fintrinsic_read_##in(pa))
+
+    if (0)
+        ;
+    fptrunc_convert(float32, float16);
+    fptrunc_convert(float64, float16);
+    fptrunc_convert(float32, bfloat16);
+    fptrunc_convert(float64, bfloat16);
+    fptrunc_convert(float64, float32);
+    else
+        jl_error("fptrunc: runtime floating point intrinsics are not implemented for bit sizes other than 16, 32 and 64");
+#undef fptrunc_convert
+}
+
+static inline void fpext(jl_datatype_t *aty, void *pa, jl_datatype_t *ty, void *pr)
+{
+    unsigned isize = jl_datatype_size(aty), osize = jl_datatype_size(ty);
+    if (!(osize >= isize)) {
+        jl_error("fpext: output bitsize must be >= input bitsize");
+        return;
+    }
+
+#define fpext_convert(in, out)                                  \
+    else if (aty == jl_##in##_type && ty == jl_##out##_type)    \
+        fintrinsic_write_##out(pr, fintrinsic_read_##in(pa))
+
+    if (0)
+        ;
+
+    fpext_convert(float16, float16);
+    fpext_convert(float16, bfloat16);
+    fpext_convert(float16, float32);
+    fpext_convert(float16, float64);
+
+    fpext_convert(bfloat16, float16);
+    fpext_convert(bfloat16, bfloat16);
+    fpext_convert(bfloat16, float32);
+    fpext_convert(bfloat16, float64);
+
+    fpext_convert(float32, float32);
+    fpext_convert(float32, float64);
+
+    fpext_convert(float64, float64);
+
+    else
+        jl_error("fptrunc: runtime floating point intrinsics are not implemented for bit sizes other than 16, 32 and 64");
+#undef fpext_convert
+}
+
+cvt_iintrinsic(fptrunc, fptrunc)
+cvt_iintrinsic(fpext, fpext)
+
 
 // checked arithmetic
 /**

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1665,8 +1665,8 @@ static inline void fptrunc(jl_datatype_t *aty, void *pa, jl_datatype_t *ty, void
 static inline void fpext(jl_datatype_t *aty, void *pa, jl_datatype_t *ty, void *pr)
 {
     unsigned isize = jl_datatype_size(aty), osize = jl_datatype_size(ty);
-    if (!(osize >= isize)) {
-        jl_error("fpext: output bitsize must be >= input bitsize");
+    if (!(osize > isize)) {
+        jl_error("fpext: output bitsize must be > input bitsize");
         return;
     }
 
@@ -1676,22 +1676,11 @@ static inline void fpext(jl_datatype_t *aty, void *pa, jl_datatype_t *ty, void *
 
     if (0)
         ;
-
-    fpext_convert(float16, float16);
-    fpext_convert(float16, bfloat16);
     fpext_convert(float16, float32);
     fpext_convert(float16, float64);
-
-    fpext_convert(bfloat16, float16);
-    fpext_convert(bfloat16, bfloat16);
     fpext_convert(bfloat16, float32);
     fpext_convert(bfloat16, float64);
-
-    fpext_convert(float32, float32);
     fpext_convert(float32, float64);
-
-    fpext_convert(float64, float64);
-
     else
         jl_error("fptrunc: runtime floating point intrinsics are not implemented for bit sizes other than 16, 32 and 64");
 #undef fpext_convert

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -290,7 +290,7 @@ function f32(sign, exp, sig)
     return reinterpret(Float32, UInt32(x))
 end
 function f64(sign, exp, sig)
-    x = (sign&1)<<31 | (exp&((1<<11)-1))<<52 | sig&((1<<52)-1)
+    x = Int64(sign&1)<<31 | Int64(exp&((1<<11)-1))<<52 | sig&((Int64(1)<<52)-1)
     return reinterpret(Float64, UInt64(x))
 end
 
@@ -327,10 +327,10 @@ end
     @test_intrinsic_pred Core.Intrinsics.fptrunc Float16 NaN isnan
     # Quiet NaN
     @test_intrinsic_pred Core.Intrinsics.fptrunc Float16 f32(0, 0xff, 1<<22 | 1<<13) isnan
-    @test_intrinsic_pred Core.Intrinsics.fptrunc Float16 f64(0, 0x7ff, 1<<51 | 1<<42) isnan
+    @test_intrinsic_pred Core.Intrinsics.fptrunc Float16 f64(0, 0x7ff, Int64(1)<<51 | Int64(1)<<42) isnan
     # Signalling NaN that can be propagated to Float16
     @test_intrinsic_pred Core.Intrinsics.fptrunc Float16 f32(0, 0xff, 1<<13) isnan
-    @test_intrinsic_pred Core.Intrinsics.fptrunc Float16 f64(0, 0x7ff, 1<<42) isnan
+    @test_intrinsic_pred Core.Intrinsics.fptrunc Float16 f64(0, 0x7ff, Int64(1)<<42) isnan
     # Signalling NaN that cannot be propagated to Float16
     @test_intrinsic_pred Core.Intrinsics.fptrunc Float16 f32(0, 0xff, 1) isnan
     @test_intrinsic_pred Core.Intrinsics.fptrunc Float16 f64(0, 0x7ff, 1) isnan

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -19,9 +19,8 @@ truncbool(u) = reinterpret(UInt8, reinterpret(Bool, u))
     @test Core.Intrinsics.add_int(1, 1) == 2
     @test Core.Intrinsics.sub_int(1, 1) == 0
 
-    @test_throws ErrorException("fpext: output bitsize must be >= input bitsize")    Core.Intrinsics.fpext(Float32, 1.0)
-    @test_throws ErrorException("fpext: output bitsize must be >= input bitsize")    Core.Intrinsics.fpext(Float32, 1.0)
-    @test_throws ErrorException("fpext: output bitsize must be >= input bitsize")    Core.Intrinsics.fpext(Int32, 0x0000_0000_0000_0000)
+    @test_throws ErrorException("fpext: output bitsize must be > input bitsize")    Core.Intrinsics.fpext(Float32, 1.0)
+    @test_throws ErrorException("fpext: output bitsize must be > input bitsize")    Core.Intrinsics.fpext(Float32, 1.0)
 
     @test_throws ErrorException("fptrunc: output bitsize must be < input bitsize")  Core.Intrinsics.fptrunc(Int32, 0x0000_0000)
     @test_throws ErrorException("fptrunc: output bitsize must be < input bitsize")  Core.Intrinsics.fptrunc(Int64, 0x0000_0000)
@@ -167,7 +166,6 @@ end
     # unary
     @test_intrinsic Core.Intrinsics.abs_float Float64(-3.3) Float64(3.3)
     @test_intrinsic Core.Intrinsics.neg_float Float64(3.3) Float64(-3.3)
-    @test_intrinsic Core.Intrinsics.fpext Float64 Float64(3.3) Float64(3.3)
 
     # binary
     @test_intrinsic Core.Intrinsics.add_float Float64(3.3) Float64(2) Float64(5.3)
@@ -200,7 +198,6 @@ end
     # unary
     @test_intrinsic Core.Intrinsics.abs_float Float32(-3.3) Float32(3.3)
     @test_intrinsic Core.Intrinsics.neg_float Float32(3.3) Float32(-3.3)
-    @test_intrinsic Core.Intrinsics.fpext Float32 Float32(3.3) Float32(3.3)
     @test_intrinsic Core.Intrinsics.fpext Float64 Float32(3.3) 3.299999952316284
     @test_intrinsic Core.Intrinsics.fptrunc Float32 Float64(3.3) Float32(3.3)
 
@@ -236,7 +233,6 @@ end
     @test_intrinsic Core.Intrinsics.abs_float Float16(-3.3) Float16(3.3)
     @test_intrinsic Core.Intrinsics.neg_float Float16(3.3) Float16(-3.3)
     # See <https://github.com/JuliaLang/julia/issues/57130>
-    @test_intrinsic Core.Intrinsics.fpext Float16 Float16(3.3) Float16(3.3)
     @test_intrinsic Core.Intrinsics.fpext Float32 Float16(3.3) 3.3007812f0
     @test_intrinsic Core.Intrinsics.fpext Float64 Float16(3.3) 3.30078125
     @test_intrinsic Core.Intrinsics.fptrunc Float16 Float32(3.3) Float16(3.3)

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -18,9 +18,25 @@ truncbool(u) = reinterpret(UInt8, reinterpret(Bool, u))
 @testset "runtime intrinsics" begin
     @test Core.Intrinsics.add_int(1, 1) == 2
     @test Core.Intrinsics.sub_int(1, 1) == 0
+
+    @test_throws ErrorException("fpext: output bitsize must be >= input bitsize")    Core.Intrinsics.fpext(Float32, 1.0)
+    @test_throws ErrorException("fpext: output bitsize must be >= input bitsize")    Core.Intrinsics.fpext(Float32, 1.0)
     @test_throws ErrorException("fpext: output bitsize must be >= input bitsize")    Core.Intrinsics.fpext(Int32, 0x0000_0000_0000_0000)
+
     @test_throws ErrorException("fptrunc: output bitsize must be < input bitsize")  Core.Intrinsics.fptrunc(Int32, 0x0000_0000)
     @test_throws ErrorException("fptrunc: output bitsize must be < input bitsize")  Core.Intrinsics.fptrunc(Int64, 0x0000_0000)
+    @test_throws ErrorException("fptrunc: output bitsize must be < input bitsize")  Core.Intrinsics.fptrunc(Float16, Float16(1.0))
+    @test_throws ErrorException("fptrunc: output bitsize must be < input bitsize")  Core.Intrinsics.fptrunc(Core.BFloat16, Float16(1.0))
+    @test_throws ErrorException("fptrunc: output bitsize must be < input bitsize")  Core.Intrinsics.fptrunc(Float32, Float16(1.0))
+    @test_throws ErrorException("fptrunc: output bitsize must be < input bitsize")  Core.Intrinsics.fptrunc(Float32, 1.0f0)
+    @test_throws ErrorException("fptrunc: output bitsize must be < input bitsize")  Core.Intrinsics.fptrunc(Float64, 1.0)
+
+    let bf16_1 = Core.Intrinsics.bitcast(Core.BFloat16, 0x3f80)
+        @test_throws ErrorException("fptrunc: output bitsize must be < input bitsize")  Core.Intrinsics.fptrunc(Core.BFloat16, bf16_1)
+        @test_throws ErrorException("fptrunc: output bitsize must be < input bitsize")  Core.Intrinsics.fptrunc(Float16, bf16_1)
+        @test_throws ErrorException("fptrunc: output bitsize must be < input bitsize")  Core.Intrinsics.fptrunc(Float32, bf16_1)
+    end
+
     @test_throws ErrorException("ZExt: output bitsize must be > input bitsize")     Core.Intrinsics.zext_int(Int8, 0x00)
     @test_throws ErrorException("SExt: output bitsize must be > input bitsize")     Core.Intrinsics.sext_int(Int8, 0x00)
     @test_throws ErrorException("ZExt: output bitsize must be > input bitsize")     Core.Intrinsics.zext_int(Int8, 0x0000)
@@ -220,8 +236,7 @@ end
     @test_intrinsic Core.Intrinsics.abs_float Float16(-3.3) Float16(3.3)
     @test_intrinsic Core.Intrinsics.neg_float Float16(3.3) Float16(-3.3)
     # See <https://github.com/JuliaLang/julia/issues/57130>
-    #broken @test_intrinsic Core.Intrinsics.fpext Float16 Float16(3.3) Float16(3.3)
-    @test_broken Core.Intrinsics.fpext(Float16, Float16(3.3)) === Float16(3.3)
+    @test_intrinsic Core.Intrinsics.fpext Float16 Float16(3.3) Float16(3.3)
     @test_intrinsic Core.Intrinsics.fpext Float32 Float16(3.3) 3.3007812f0
     @test_intrinsic Core.Intrinsics.fpext Float64 Float16(3.3) 3.30078125
     @test_intrinsic Core.Intrinsics.fptrunc Float16 Float32(3.3) Float16(3.3)


### PR DESCRIPTION
This makes two changes `fpext` and `fptrunc` to match the behaviour specified in their error strings:
-`fpext` works when converting from Float16 => Float16,
-`fptrunc` is prevented from truncating Float16 => Float16

Both are re-written to make it explicit what conversions are possible, and how they are done.

Closes #57130.