### PR TITLE
Use faster timeout on cmdlineargs test that relies on timeout

### DIFF
--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -799,7 +799,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     # --worker takes default / custom as argument (default/custom arguments
     # tested in test/parallel.jl)
     # shorten the worker timeout as this test relies on it timing out
-    withenv("JULIA_WORKER_TIMEOUT" => "5") do
+    withenv("JULIA_WORKER_TIMEOUT" => "10") do
         @test errors_not_signals(`$exename --worker=true`)
     end
 

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -798,7 +798,10 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
 
     # --worker takes default / custom as argument (default/custom arguments
     # tested in test/parallel.jl)
-    @test errors_not_signals(`$exename --worker=true`)
+    # shorten the worker timeout as this test relies on it timing out
+    withenv("JULIA_WORKER_TIMEOUT" => "5") do
+        @test errors_not_signals(`$exename --worker=true`)
+    end
 
     # --trace-compile
     let


### PR DESCRIPTION
Otherwise this test takes 1 minute doing nothing before the worker times out and satisfies the error throw.
i.e. locally
```
julia> run(`$(Base.julia_cmd()) --worker=true`)
julia_worker:9616#192.168.12.246
Master process (id 1) could not connect within 60.0 seconds.
exiting.
```
```
julia> withenv("JULIA_WORKER_TIMEOUT" => "5") do
       run(`$(Base.julia_cmd()) --worker=true`)
       end
julia_worker:9708#192.168.12.246
Master process (id 1) could not connect within 5.0 seconds.
exiting.
```