### PR TITLE
Try fixing color in windows on buildkite

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -392,6 +392,11 @@ function __init__()
         JuliaSyntax.enable_in_core!()
     end
 
+    printstyled("this should be green\n", color=:green)
+    printstyled(stdout, "this should be green\n", color=:green)
+    printstyled(stderr, "this should be green\n", color=:green)
+    @show stdout get(stdout, :color, nothing)
+
     CoreLogging.global_logger(CoreLogging.ConsoleLogger())
     nothing
 end

--- a/base/terminfo.jl
+++ b/base/terminfo.jl
@@ -356,6 +356,7 @@ function ttyhastruecolor()
         (haskey(current_terminfo, :setrgbf) && haskey(current_terminfo, :setrgbb)) ||
         @static if Sys.isunix() get(current_terminfo, :colors, 0) > 256 else false end ||
         @static if Sys.iswindows()
+            @info "ttyhastruecolor" Sys.windows_version() haskey(ENV, "WT_SESSION")
             Sys.windows_version() ≥ v"10.0.14931" || # See <https://devblogs.microsoft.com/commandline/24-bit-color-in-the-windows-console/>
             haskey(ENV, "WT_SESSION") # In case windows version was inaccurate. Windows Terminal supports truecolor.
         else
@@ -374,6 +375,7 @@ function ttyhastruecolor()
 end
 
 function get_have_color()
+    println("get_have_color")
     global have_color
     have_color === nothing && (have_color = ttyhascolor())
     return have_color::Bool

--- a/base/terminfo.jl
+++ b/base/terminfo.jl
@@ -355,7 +355,12 @@ function ttyhastruecolor()
         get(current_terminfo, :RGB, false) || get(current_terminfo, :Tc, false) ||
         (haskey(current_terminfo, :setrgbf) && haskey(current_terminfo, :setrgbb)) ||
         @static if Sys.isunix() get(current_terminfo, :colors, 0) > 256 else false end ||
-        (Sys.iswindows() && Sys.windows_version() ≥ v"10.0.14931") || # See <https://devblogs.microsoft.com/commandline/24-bit-color-in-the-windows-console/>
+        @static if Sys.iswindows()
+            Sys.windows_version() ≥ v"10.0.14931" || # See <https://devblogs.microsoft.com/commandline/24-bit-color-in-the-windows-console/>
+            haskey(ENV, "WT_SESSION") # In case windows version was inaccurate. Windows Terminal supports truecolor.
+        else
+            false
+        end ||
         something(tryparse(Int, get(ENV, "VTE_VERSION", "")), 0) >= 3600 || # Per GNOME bug #685759 <https://bugzilla.gnome.org/show_bug.cgi?id=685759>
         haskey(ENV, "XTERM_VERSION") ||
         get(ENV, "TERMINAL_PROGRAM", "") == "iTerm.app" || # Why does Apple need to be special?


### PR DESCRIPTION
Trying to fix why buildkite logs don't have color (without just forcing color on) https://buildkite.com/julialang/julia-release-1-dot-10/builds/466#01948d7b-e3eb-4a8f-a1f0-47eea2264646