### PR TITLE
CI: Be noisy about cache being bad. Check hash of downloaded busybox executable

### DIFF
--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -53,7 +53,9 @@ function download_from_cache(desired_url::AbstractString)
 end
 
 if Sys.iswindows()
-    busybox = download_from_cache("https://frippery.org/files/busybox/busybox.exe")
+    # See https://frippery.org/files/busybox/
+    # latest as of 2024-09-20 18:08
+    busybox = download_from_cache("https://frippery.org/files/busybox/busybox-w32-FRP-5467-g9376eebd8.exe")
     busybox_hash_correct(busybox) || error("The busybox executable downloaded has an incorrect hash")
 
     havebb = try # use busybox-w32 on windows, if available

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -35,6 +35,7 @@ function _tryonce_download_from_cache(desired_url::AbstractString)
             return cache_output_filename
         end
     end
+    @warn "Could not download from cache at $cache_url, falling back to primary source at $desired_url"
     return Downloads.download(desired_url; timeout = 60)
 end
 
@@ -47,6 +48,9 @@ end
 
 if Sys.iswindows()
     busybox = download_from_cache("https://frippery.org/files/busybox/busybox.exe")
+    if filesize(busybox) < 500000 # busybox is 622094 bytes
+        @warn "The busybox executable is too small to be valid" busybox filesize(busybox) read(busybox, String)
+    end
     havebb = try # use busybox-w32 on windows, if available
         success(`$busybox`)
         true


### PR DESCRIPTION
https://cache.julialang.org/ was down, and busybox had started failing, probably because the upstream server started blocking our CI windows machine. So add some visible info to catch cache issues before it gets that far.

Also now checks the file hash before executing it.