### PR TITLE
minor followup to #57009, improve typing of `GlobalAccessInfo`

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -2476,7 +2476,8 @@ function abstract_eval_setglobal!(interp::AbstractInterpreter, sv::AbsIntState, 
         M, s = M.val, s.val
         if M isa Module && s isa Symbol
             (rt, exct), partition = global_assignment_rt_exct(interp, sv, saw_latestworld, GlobalRef(M, s), v)
-            return CallMeta(rt, exct, Effects(setglobal!_effects, nothrow=exct===Bottom), GlobalAccessInfo(partition))
+            return CallMeta(rt, exct, Effects(setglobal!_effects, nothrow=exct===Bottom),
+                partition === nothing ? NoCallInfo() : GlobalAccessInfo(partition))
         end
         return CallMeta(Union{}, TypeError, EFFECTS_THROWS, NoCallInfo())
     end

--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -491,7 +491,6 @@ perform such accesses.
 struct GlobalAccessInfo <: CallInfo
     bpart::Core.BindingPartition
 end
-GlobalAccessInfo(::Nothing) = NoCallInfo()
 add_edges_impl(edges::Vector{Any}, info::GlobalAccessInfo) =
     push!(edges, info.bpart)
 


### PR DESCRIPTION
`bpart`s there are all known to be `Core.BindingPartition` and never be `nothing`.