### PR TITLE
Implementing a string method that works for iterators and generators

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -100,7 +100,6 @@ Base.startswith(io::IO, prefix::AbstractString) = startswith(io, String(prefix))
 
 function endswith(a::Union{String, SubString{String}},
                   b::Union{String, SubString{String}})
-    cub = ncodeunits(b)
     astart = ncodeunits(a) - ncodeunits(b) + 1
     if astart < 1
         false


### PR DESCRIPTION
fixes #57072 , allowing queries like 
`String(Iterators.map(c->c+1, "Hello, world"))`
to work. also adds tests for the same :)