### PR TITLE
Throw an error when `@threads` captures a boxed variable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -92,6 +92,9 @@ Multi-threading changes
   every subsequent time afterwards. There are also `OncePerThread{T}` and `OncePerTask{T}` types for
   similar usage with threads or tasks. ([#55793])
 
+* `Threads.@threads` no longer allows the provided closure to contain boxed variable references, as
+these create silent, surprising race conditions.
+
 Build system changes
 --------------------
 

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -232,7 +232,11 @@ function throw_if_boxed_captures(f)
         # has a kwarg method, so the Boxed variables are hidden at least one layer
         # down.
         if fieldtype(T, i) <: Function
-            throw_if_boxed_captures(getfield(f, i))
+            f_inner = getfield(f, i)
+            if f !== f_inner
+                # don't recurse into self!
+                throw_if_boxed_captures(getfield(f, i))
+            end
         end
     end
 end


### PR DESCRIPTION
This is my proposal to close https://github.com/JuliaLang/julia/issues/14948

Any time `Threads.@threads` constructs a closure that contains a `Core.Box`, that should be a clear sign of a race condition, since the order at which that `Box` is read from or written to is undefined. This is a really easy, surprising, and hidden footgun for users to run into. 

I suspect that a large chunk of existing cases out in the wild have not been caught because in many cases, the bugs caused by this have a low probability of being seen (though exist nonetheless). 

Basically, all I'm doing here is walking through the fieldtypes of the closure produced by `@threads` and if that closure has a `Core.Box` in it, we throw an error that suggests what went wrong and how it can potentially be fixed. This is a pretty aggressive approach to the problem in #14948, but I think it's a serious enough problem that it's warranted. 