### PR TITLE
interpreter: pop GC frames when leaving multiple `:enter` blocks

### DIFF
--- a/test/scopedvalues.jl
+++ b/test/scopedvalues.jl
@@ -182,3 +182,16 @@ end
     @test Core.current_scope() === nothing
 end
 nothrow_scope()
+
+# https://github.com/JuliaLang/julia/issues/56062
+@testset "issue #56062" begin
+    ts = Int[]
+    try
+        @with begin
+            return
+        end
+    catch err
+    finally
+        push!(ts, 2)
+    end
+end


### PR DESCRIPTION
Resolves https://github.com/JuliaLang/julia/issues/56062