### PR TITLE
REPL: generate tab completion hints on a worker thread to not block typing

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1431,7 +1431,7 @@ function setup_interface(
                 end
             else
                 edit_insert(s, ';')
-                LineEdit.check_for_hint(s) && LineEdit.refresh_line(s)
+                LineEdit.check_show_hint(s)
             end
         end,
         '?' => function (s::MIState,o...)
@@ -1442,7 +1442,7 @@ function setup_interface(
                 end
             else
                 edit_insert(s, '?')
-                LineEdit.check_for_hint(s) && LineEdit.refresh_line(s)
+                LineEdit.check_show_hint(s)
             end
         end,
         ']' => function (s::MIState,o...)
@@ -1465,8 +1465,8 @@ function setup_interface(
                                         transition(s, mode) do
                                             LineEdit.state(s, mode).input_buffer = buf
                                         end
-                                        if !isempty(s) && @invokelatest(LineEdit.check_for_hint(s))
-                                            @invokelatest(LineEdit.refresh_line(s))
+                                        if !isempty(s)
+                                            @invokelatest(LineEdit.check_show_hint(s))
                                         end
                                         break
                                     end
@@ -1479,7 +1479,7 @@ function setup_interface(
                 Base.errormonitor(t_replswitch)
             else
                 edit_insert(s, ']')
-                LineEdit.check_for_hint(s) && LineEdit.refresh_line(s)
+                LineEdit.check_show_hint(s)
             end
         end,
 


### PR DESCRIPTION
Prevents slow tab completion hint generation from blocking typing.

Fixes https://github.com/JuliaLang/julia/issues/55434
Specifically the hinting part.

With julia now starting with an interactive thread by default, we can move the repl tab completion hint generation to a worker thread and enable the user to continue to type (on the repl task on the interactive thread) if generating the hint takes a long time. Showing old hints is cancelled if a new key has been pressed since.

Take this intentionally slowly compiling generated function, which needs to be generated to be introspected for completions. (thanks @MasonProtter for the example)
```julia
@generated function foo()
    sleep(5)
    (;apple=1, banana=2)
end
```

On master and 1.11 typing is blocked at `foo().` while the generated function compiles for 5s.

On this PR typing can continue and at any point the user can wait 5s for `apple` to be completed properly.

https://github.com/user-attachments/assets/0e306999-e760-4a46-a63d-fe982ff6a331

