### PR TITLE
Optimizer: Update SROA def-uses after DCE

### DIFF
--- a/Compiler/src/ssair/passes.jl
+++ b/Compiler/src/ssair/passes.jl
@@ -1511,6 +1511,10 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
             used_ssas[x.id] -= 1
         end
         ir = complete(compact)
+        # remove any use that has been optimized away by the DCE
+        for (intermediaries, defuse) in values(defuses)
+            filter!(x -> ir[SSAValue(x.idx)][:stmt] !== nothing, defuse.uses)
+        end
         sroa_mutables!(ir, defuses, used_ssas, lazydomtree, inlining)
         return ir
     else

--- a/Compiler/test/irpasses.jl
+++ b/Compiler/test/irpasses.jl
@@ -2034,15 +2034,11 @@ end
 # https://github.com/JuliaLang/julia/issues/57141
 # don't eliminate `setfield!` when the field is to be used
 let src = code_typed1(()) do
-        f = function ()
-            ref = Ref{Any}()
-            ref[] = 0
-            @assert isdefined(ref, :x)
-            inner() = ref[] + 1
-            (inner(), ref[])
-        end
-        first(f())
+        ref = Ref{Any}()
+        ref[] = 0
+        @assert isdefined(ref, :x)
+        inner() = ref[] + 1
+        (inner(), ref[])
     end
-    ex = src.code[2]
     @test count(iscall((src, setfield!)), src.code) == 1
 end

--- a/Compiler/test/irpasses.jl
+++ b/Compiler/test/irpasses.jl
@@ -2044,5 +2044,5 @@ let src = code_typed1(()) do
         first(f())
     end
     ex = src.code[2]
-    @test isexpr(ex, :call) && argextype(ex.args[1], src) === Const(setfield!)
+    @test count(iscall((src, setfield!)), src.code) == 1
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/57141.

Given the function

```julia
julia> function _f()
           ref = Ref{Any}()
           ref[] = 3
           @assert isdefined(ref, :x)
           inner = Returns(ref)
           x = inner()
           (x, ref[])
       end
_f (generic function with 1 method)

julia> f() = first(_f())
f (generic function with 1 method)
```

Here is before:
```julia
julia> @code_typed f()
CodeInfo(
1 ─ %1 = %new(Base.RefValue{Any})::Base.RefValue{Any}
└──      goto #3
2 ─      unreachable
3 ─      return %1
) => Base.RefValue{Any}
```

Here is after this PR:
```julia
julia> @code_typed f()
CodeInfo(
1 ─ %1 = %new(Base.RefValue{Any})::Base.RefValue{Any}
│          builtin Base.setfield!(%1, :x, 3)::Int64
│   %3 =   builtin Main.isdefined(%1, :x)::Bool
└──      goto #3 if not %3
2 ─      goto #4
3 ─ %6 =    invoke Base.AssertionError("isdefined(ref, :x)"::String)::AssertionError
│          builtin Base.throw(%6)::Union{}
└──      unreachable
4 ─      return %1
) => Base.RefValue{Any}
```

The elimination of `setfield!` was due to a use still being recorded for `ref[]` in the def-use data while DCE eliminated this `getindex` call (by virtue of not using the second tuple element in the result).