### PR TITLE
juliac: add `invokelatest_gr` override to juliac-buildscript.jl

### DIFF
--- a/contrib/juliac-buildscript.jl
+++ b/contrib/juliac-buildscript.jl
@@ -38,6 +38,14 @@ end
     @inline function invokelatest(f::F, args...; kwargs...) where F
         return f(args...; kwargs...)
     end
+    @inline function invokelatest_gr(gr::GlobalRef, @nospecialize args...; kwargs...)
+        @inline
+        kwargs = merge(NamedTuple(), kwargs)
+        if isempty(kwargs)
+            return apply_gr(gr, args...)
+        end
+        return apply_gr_kw(kwargs, gr, args...)
+    end
     function sprint(f::F, args::Vararg{Any,N}; context=nothing, sizehint::Integer=0) where {F<:Function,N}
         s = IOBuffer(sizehint=sizehint)
         if context isa Tuple


### PR DESCRIPTION
This extends the existing `invokelatest` hack to treat the current world as the latest world for globalref lookups.

Since this came up, @Keno can you confirm that any world-age-affecting operations on bindings still require `eval()`?
Are there any imports / assignments / etc. that might bump the world age by changing a binding?