### PR TITLE
Always add the frame-pointer=all attribute

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -83,20 +83,6 @@
 
 using namespace llvm;
 
-static bool jl_fpo_disabled(const Triple &TT) {
-#ifdef JL_DISABLE_FPO
-    return true;
-#endif
-#ifdef _COMPILER_MSAN_ENABLED_
-    // MSAN doesn't support FPO
-    return true;
-#endif
-    if (TT.isOSLinux() || TT.isOSWindows() || TT.isOSFreeBSD() || TT.isOSOpenBSD()) {
-        return true;
-    }
-    return false;
-}
-
 static bool jl_floattemp_var_needed(const Triple &TT) {
 #ifdef JL_NEED_FLOATTEMP_VAR
     return true;
@@ -2969,8 +2955,7 @@ void jl_init_function(Function *F, const Triple &TT)
     if (TT.isOSWindows() && TT.getArch() == Triple::x86_64) {
         attr.addUWTableAttr(llvm::UWTableKind::Default); // force NeedsWinEH
     }
-    if (jl_fpo_disabled(TT))
-        attr.addAttribute("frame-pointer", "all");
+    attr.addAttribute("frame-pointer", "all");
     if (!TT.isOSWindows()) {
 #if !defined(_COMPILER_ASAN_ENABLED_)
         // ASAN won't like us accessing undefined memory causing spurious issues,


### PR DESCRIPTION
At some point LLVM on MacOS started doing frame pointer optimization by default. We should ask for a frame pointer on every function, on all platforms.

Prior to this change, on `1.11.3+0.aarch64.apple.darwin14`:
```
julia> @code_native ((x,y) -> Core.Intrinsics.add_float(x,y))(1.0,2.0)
	.section	__TEXT,__text,regular,pure_instructions
	.build_version macos, 15, 0
	.globl	"_julia_#1_678"                 ; -- Begin function julia_#1_678
	.p2align	2
"_julia_#1_678":                        ; @"julia_#1_678"
; Function Signature: var"#1"(Float64, Float64)
; ┌ @ REPL[1]:1 within `#1`
; %bb.0:                                ; %top
; │ @ REPL[1] within `#1`
	;DEBUG_VALUE: #1:x <- $d0
	;DEBUG_VALUE: #1:x <- $d0
	;DEBUG_VALUE: #1:y <- $d1
	;DEBUG_VALUE: #1:y <- $d1
; │ @ REPL[1]:1 within `#1`
	fadd	d0, d0, d1
	ret
; └
                                        ; -- End function
	.section	__DATA,__const
	.p2align	3, 0x0                          ; @"+Core.Float64#680"
"l_+Core.Float64#680":
	.quad	"l_+Core.Float64#680.jit"

.set "l_+Core.Float64#680.jit", 5490712608
.subsections_via_symbols
```

Prior to this change, on `1.11.3+0.aarch64.linux.gnu`:
```
julia> @code_native ((x,y) -> Core.Intrinsics.add_float(x,y))(1.0,2.0)
	.text
	.file	"#1"
	.globl	"julia_#1_656"                  // -- Begin function julia_#1_656
	.p2align	2
	.type	"julia_#1_656",@function
"julia_#1_656":                         // @"julia_#1_656"
; Function Signature: var"#1"(Float64, Float64)
; ┌ @ REPL[1]:1 within `#1`
// %bb.0:                               // %top
; │ @ REPL[1] within `#1`
	//DEBUG_VALUE: #1:x <- $d0
	//DEBUG_VALUE: #1:x <- $d0
	//DEBUG_VALUE: #1:y <- $d1
	//DEBUG_VALUE: #1:y <- $d1
	stp	x29, x30, [sp, #-16]!           // 16-byte Folded Spill
	mov	x29, sp
; │ @ REPL[1]:1 within `#1`
	fadd	d0, d0, d1
	ldp	x29, x30, [sp], #16             // 16-byte Folded Reload
	ret
.Lfunc_end0:
	.size	"julia_#1_656", .Lfunc_end0-"julia_#1_656"
; └
                                        // -- End function
	.type	".L+Core.Float64#658",@object   // @"+Core.Float64#658"
	.section	.rodata,"a",@progbits
	.p2align	3, 0x0
".L+Core.Float64#658":
	.xword	".L+Core.Float64#658.jit"
	.size	".L+Core.Float64#658", 8

.set ".L+Core.Float64#658.jit", 278205186835760
	.size	".L+Core.Float64#658.jit", 8
	.section	".note.GNU-stack","",@progbits
```
