### PR TITLE
bpart: Start tracking backedges for bindings

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -67,7 +67,7 @@ using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospeciali
     partition_restriction, quoted, rename_unionall, rewrap_unionall, specialize_method,
     structdiff, tls_world_age, unconstrain_vararg_length, unionlen, uniontype_layout,
     uniontypes, unsafe_convert, unwrap_unionall, unwrapva, vect, widen_diagonal,
-    _uncompressed_ir
+    _uncompressed_ir, maybe_add_binding_backedge!
 using Base.Order
 
 import Base: ==, _topmod, append!, convert, copy, copy!, findall, first, get, get!,

--- a/Compiler/src/bootstrap.jl
+++ b/Compiler/src/bootstrap.jl
@@ -91,6 +91,6 @@ function activate!(; reflection=true, codegen=false)
         Base.REFLECTION_COMPILER[] = Compiler
     end
     if codegen
-        activate_codegen!()
+        bootstrap!()
     end
 end

--- a/Compiler/src/ssair/verify.jl
+++ b/Compiler/src/ssair/verify.jl
@@ -67,7 +67,10 @@ function check_op(ir::IRCode, domtree::DomTree, @nospecialize(op), use_bb::Int, 
             imported_binding = partition_restriction(bpart)::Core.Binding
             bpart = lookup_binding_partition(min_world(ir.valid_worlds), imported_binding)
         end
-        if !is_defined_const_binding(binding_kind(bpart)) || (bpart.max_world < max_world(ir.valid_worlds))
+        if (!is_defined_const_binding(binding_kind(bpart)) || (bpart.max_world < max_world(ir.valid_worlds))) &&
+                (op.mod !== Core) && (op.mod !== Base)
+            # Core and Base are excluded because the frontend uses them for intrinsics, etc.
+            # TODO: Decide which way to go with these.
             @verify_error "Unbound or partitioned GlobalRef not allowed in value position"
             raise_error()
         end

--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -489,10 +489,12 @@ Represents access to a global through runtime reflection, rather than as a manif
 perform such accesses.
 """
 struct GlobalAccessInfo <: CallInfo
+    b::Core.Binding
     bpart::Core.BindingPartition
 end
-GlobalAccessInfo(::Nothing) = NoCallInfo()
-add_edges_impl(edges::Vector{Any}, info::GlobalAccessInfo) =
-    push!(edges, info.bpart)
+GlobalAccessInfo(::Core.Binding, ::Nothing) = NoCallInfo()
+function add_edges_impl(edges::Vector{Any}, info::GlobalAccessInfo)
+    push!(edges, info.b)
+end
 
 @specialize

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -544,8 +544,9 @@ function store_backedges(caller::CodeInstance, edges::SimpleVector)
             # ignore `Method`-edges (from e.g. failed `abstract_call_method`)
             i += 1
             continue
-        elseif isa(item, Core.BindingPartition)
+        elseif isa(item, Core.Binding)
             i += 1
+            maybe_add_binding_backedge!(item, caller)
             continue
         end
         if isa(item, CodeInstance)

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -134,7 +134,7 @@ let code = Any[
         Expr(:boundscheck),
         Compiler.GotoIfNot(SSAValue(1), 6),
         # block 2
-        Expr(:call, GlobalRef(Base, :size), Compiler.Argument(3)),
+        Expr(:call, size, Compiler.Argument(3)),
         Compiler.ReturnNode(),
         # block 3
         Core.PhiNode(),

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -31,6 +31,10 @@ let os = ccall(:jl_get_UNAME, Any, ())
     end
 end
 
+# subarrays
+include("subarray.jl")
+include("views.jl")
+
 # numeric operations
 include("hashing.jl")
 include("rounding.jl")

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -231,8 +231,6 @@ include("indices.jl")
 include("genericmemory.jl")
 include("array.jl")
 include("abstractarray.jl")
-include("subarray.jl")
-include("views.jl")
 include("baseext.jl")
 
 include("c.jl")

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -20,7 +20,7 @@ using .Base:
 using Core: @doc
 
 using .Base:
-    cld, fld, SubArray, view, resize!, IndexCartesian
+    cld, fld, resize!, IndexCartesian
 using .Base.Checked: checked_mul
 
 import .Base:
@@ -1327,7 +1327,7 @@ eltype(::Type{PartitionIterator{T}}) where {T} = Vector{eltype(T)}
 # Arrays use a generic `view`-of-a-`vec`, so we cannot exactly predict what we'll get back
 eltype(::Type{PartitionIterator{T}}) where {T<:AbstractArray} = AbstractVector{eltype(T)}
 # But for some common implementations in Base we know the answer exactly
-eltype(::Type{PartitionIterator{T}}) where {T<:Vector} = SubArray{eltype(T), 1, T, Tuple{UnitRange{Int}}, true}
+eltype(::Type{PartitionIterator{T}}) where {T<:Vector} = Base.SubArray{eltype(T), 1, T, Tuple{UnitRange{Int}}, true}
 
 IteratorEltype(::Type{PartitionIterator{T}}) where {T} = IteratorEltype(T)
 IteratorEltype(::Type{PartitionIterator{T}}) where {T<:AbstractArray} = EltypeUnknown()
@@ -1353,7 +1353,7 @@ end
 function iterate(itr::PartitionIterator{<:AbstractArray}, state = firstindex(itr.c))
     state > lastindex(itr.c) && return nothing
     r = min(state + itr.n - 1, lastindex(itr.c))
-    return @inbounds view(itr.c, state:r), r + 1
+    return @inbounds Base.view(itr.c, state:r), r + 1
 end
 
 struct IterationCutShort; end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1293,7 +1293,9 @@ function _include_from_serialized(pkg::PkgId, path::String, ocachepath::Union{No
 
         edges = sv[3]::Vector{Any}
         ext_edges = sv[4]::Union{Nothing,Vector{Any}}
-        StaticData.insert_backedges(edges, ext_edges)
+        extext_methods = sv[5]::Vector{Any}
+        internal_methods = sv[6]::Vector{Any}
+        StaticData.insert_backedges(edges, ext_edges, extext_methods, internal_methods)
 
         restored = register_restored_modules(sv, pkg, path)
 

--- a/src/init.c
+++ b/src/init.c
@@ -910,6 +910,7 @@ static NOINLINE void _finish_julia_init(JL_IMAGE_SEARCH rel, jl_ptls_t ptls, jl_
         jl_n_threads_per_pool[JL_THREADPOOL_ID_INTERACTIVE] = 0;
         jl_n_threads_per_pool[JL_THREADPOOL_ID_DEFAULT] = 1;
     } else {
+        jl_current_task->world_age = jl_atomic_load_acquire(&jl_world_counter);
         post_image_load_hooks();
     }
     jl_start_threads();

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3271,12 +3271,13 @@ void jl_init_types(void) JL_GC_DISABLED
 
     jl_binding_type =
         jl_new_datatype(jl_symbol("Binding"), core, jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(4, "globalref", "value", "partitions", "flags"),
-                        jl_svec(4, jl_any_type/*jl_globalref_type*/, jl_any_type, jl_binding_partition_type, jl_uint8_type),
+                        jl_perm_symsvec(5, "globalref", "value", "partitions", "backedges", "flags"),
+                        jl_svec(5, jl_any_type/*jl_globalref_type*/, jl_any_type, jl_binding_partition_type,
+                                   jl_any_type, jl_uint8_type),
                         jl_emptysvec, 0, 1, 0);
-    const static uint32_t binding_atomicfields[] = { 0x0005 }; // Set fields 1, 3 as atomic
+    const static uint32_t binding_atomicfields[] = { 0x0005 }; // Set fields 2, 3 as atomic
     jl_binding_type->name->atomicfields = binding_atomicfields;
-    const static uint32_t binding_constfields[] = { 0x0002 }; // Set fields 2 as constant
+    const static uint32_t binding_constfields[] = { 0x0001 }; // Set fields 1 as constant
     jl_binding_type->name->constfields = binding_constfields;
 
     jl_globalref_type =
@@ -3856,6 +3857,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_code_instance_type->types, 15, jl_voidpointer_type);
     jl_svecset(jl_code_instance_type->types, 16, jl_voidpointer_type);
     jl_svecset(jl_binding_type->types, 0, jl_globalref_type);
+    jl_svecset(jl_binding_type->types, 3, jl_array_any_type);
     jl_svecset(jl_binding_partition_type->types, 3, jl_binding_partition_type);
 
     jl_compute_field_offsets(jl_datatype_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -696,6 +696,7 @@ typedef struct _jl_binding_t {
     jl_globalref_t *globalref;  // cached GlobalRef for this binding
     _Atomic(jl_value_t*) value;
     _Atomic(jl_binding_partition_t*) partitions;
+    jl_array_t *backedges;
     uint8_t did_print_backdate_admonition:1;
     uint8_t exportp:1; // `public foo` sets `publicp`, `export foo` sets both `publicp` and `exportp`
     uint8_t publicp:1; // exportp without publicp is not allowed.

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -719,8 +719,9 @@ jl_value_t *jl_code_or_ci_for_interpreter(jl_method_instance_t *lam JL_PROPAGATE
 int jl_code_requires_compiler(jl_code_info_t *src, int include_force_compile);
 jl_code_info_t *jl_new_code_info_from_ir(jl_expr_t *ast);
 JL_DLLEXPORT jl_code_info_t *jl_new_code_info_uninit(void);
-JL_DLLEXPORT void jl_resolve_definition_effects_in_ir(jl_array_t *stmts, jl_module_t *m, jl_svec_t *sparam_vals,
-                                                      int binding_effects);
+JL_DLLEXPORT void jl_resolve_definition_effects_in_ir(jl_array_t *stmts, jl_module_t *m, jl_svec_t *sparam_vals, jl_value_t *binding_edge,
+                                           int binding_effects);
+JL_DLLEXPORT void jl_maybe_add_binding_backedge(jl_globalref_t *gr, jl_module_t *defining_module, jl_value_t *edge);
 
 int get_next_edge(jl_array_t *list, int i, jl_value_t** invokesig, jl_code_instance_t **caller) JL_NOTSAFEPOINT;
 int set_next_edge(jl_array_t *list, int i, jl_value_t *invokesig, jl_code_instance_t *caller);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1675,16 +1675,24 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
             write_uint(f, decode_restriction_kind(pku));
 #endif
             size_t max_world = jl_atomic_load_relaxed(&bpart->max_world);
-            if (max_world == ~(size_t)0) {
-                // Still valid. Will be considered primordial after re-load.
-                // We could consider updating min_world to the loaded world, but
-                // there doesn't appear to be much point.
-                write_uint(f, 0);
-                write_uint(f, max_world);
+            if (s->incremental) {
+                if (max_world == ~(size_t)0) {
+                    // Still valid. Will be considered to be defined in jl_require_world
+                    // after reload, which is the first world before new code runs.
+                    // We use this as a quick check to determine whether a binding was
+                    // invalidated. If a binding was first defined in or before
+                    // jl_require_world, then we can assume that all precompile processes
+                    // will have seen it consistently.
+                    write_uint(f, jl_require_world);
+                    write_uint(f, max_world);
+                } else {
+                    // The world will not be reachable after loading
+                    write_uint(f, 1);
+                    write_uint(f, 0);
+                }
             } else {
-                // The world will not be reachable after loading
-                write_uint(f, 1);
-                write_uint(f, 0);
+                write_uint(f, bpart->min_world);
+                write_uint(f, max_world);
             }
             write_pointerfield(s, (jl_value_t*)jl_atomic_load_relaxed(&bpart->next));
 #ifdef _P64
@@ -4140,7 +4148,7 @@ static jl_value_t *jl_restore_package_image_from_stream(void* pkgimage_handle, i
                                                    extext_methods, method_roots_list, cachesizes_sv);
             }
             else {
-                restored = (jl_value_t*)jl_svec(4, restored, init_order, edges, ext_edges);
+                restored = (jl_value_t*)jl_svec(6, restored, init_order, edges, ext_edges, extext_methods, internal_methods);
             }
         }
     }

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -1097,7 +1097,7 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval_flex(jl_module_t *JL_NONNULL m, jl_val
             jl_get_module_compile(m) != JL_OPTIONS_COMPILE_MIN)) {
         // use codegen
         mfunc = jl_method_instance_for_thunk(thk, m);
-        jl_resolve_definition_effects_in_ir((jl_array_t*)thk->code, m, NULL, 0);
+        jl_resolve_definition_effects_in_ir((jl_array_t*)thk->code, m, NULL, NULL, 0);
         // Don't infer blocks containing e.g. method definitions, since it's probably not worthwhile.
         size_t world = jl_atomic_load_acquire(&jl_world_counter);
         ct->world_age = world;
@@ -1110,8 +1110,9 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval_flex(jl_module_t *JL_NONNULL m, jl_val
     else {
         // use interpreter
         assert(thk);
-        if (has_opaque)
-            jl_resolve_definition_effects_in_ir((jl_array_t*)thk->code, m, NULL, 0);
+        if (has_opaque) {
+            jl_resolve_definition_effects_in_ir((jl_array_t*)thk->code, m, NULL, NULL, 0);
+        }
         size_t world = jl_atomic_load_acquire(&jl_world_counter);
         ct->world_age = world;
         result = jl_interpret_toplevel_thunk(m, thk);

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -726,6 +726,7 @@ function resolve_toplevel_symbols!(src::Core.CodeInfo, mod::Module)
         #=jl_array_t *stmts=# src.code::Any,
         #=jl_module_t *m=# mod::Any,
         #=jl_svec_t *sparam_vals=# Core.svec()::Any,
+        #=jl_value_t *binding_edge=# C_NULL::Ptr{Cvoid},
         #=int binding_effects=# 0::Int)::Cvoid
     return src
 end

--- a/test/rebinding.jl
+++ b/test/rebinding.jl
@@ -2,7 +2,6 @@
 
 module Rebinding
     using Test
-
     make_foo() = Foo(1)
 
     @test Base.binding_kind(@__MODULE__, :Foo) == Base.BINDING_KIND_GUARD
@@ -41,10 +40,73 @@ module Rebinding
     Base.delete_binding(@__MODULE__, :delete_me)
     @test_throws UndefVarError f_return_delete_me()
 
+    # + foreign module
+    module NotTheDefinitionModule
+        const delete_me_other = 2
+    end
+    @eval f_return_delete_me_foreign_module() = $(GlobalRef(NotTheDefinitionModule, :delete_me_other))
+    @test f_return_delete_me_foreign_module() == 2
+    Base.delete_binding(NotTheDefinitionModule, :delete_me_other)
+    @test_throws UndefVarError f_return_delete_me_foreign_module()
+
     ## + via indirect access
-    const delete_me = 2
+    const delete_me = 3
     f_return_delete_me_indirect() = getglobal(@__MODULE__, :delete_me)
-    @test f_return_delete_me_indirect() == 2
+    @test f_return_delete_me_indirect() == 3
     Base.delete_binding(@__MODULE__, :delete_me)
     @test_throws UndefVarError f_return_delete_me_indirect()
+end
+
+module RebindingPrecompile
+    using Test
+    include("precompile_utils.jl")
+
+    precompile_test_harness("rebinding precompile") do load_path
+        # Test that the system doesn't accidentally forget to revalidate a method without backedges
+        write(joinpath(load_path, "LotsOfBindingsToDelete.jl"),
+              """
+              module LotsOfBindingsToDelete
+                const delete_me_1 = 1
+                const delete_me_2 = 2
+                const delete_me_3 = 3
+                const delete_me_4 = 4
+              end
+              """)
+        Base.compilecache(Base.PkgId("LotsOfBindingsToDelete"))
+        write(joinpath(load_path, "UseTheBindings.jl"),
+              """
+              module UseTheBindings
+                using LotsOfBindingsToDelete
+                @eval f_use_bindings1() = \$(GlobalRef(LotsOfBindingsToDelete, :delete_me_1))
+                @eval f_use_bindings2() = \$(GlobalRef(LotsOfBindingsToDelete, :delete_me_2))
+                f_use_bindings3() = LotsOfBindingsToDelete.delete_me_3
+                f_use_bindings4() = LotsOfBindingsToDelete.delete_me_4
+                # Code Instances for each of these
+                @assert (f_use_bindings1(), f_use_bindings2(), f_use_bindings3(), f_use_bindings4()) ==
+                    (1, 2, 3, 4)
+              end
+              """)
+        Base.compilecache(Base.PkgId("UseTheBindings"))
+        @eval using LotsOfBindingsToDelete
+        # Delete some bindings before loading the dependent package
+        Base.delete_binding(LotsOfBindingsToDelete, :delete_me_1)
+        Base.delete_binding(LotsOfBindingsToDelete, :delete_me_3)
+        # Load the dependent package
+        @eval using UseTheBindings
+        invokelatest() do
+            @test_throws UndefVarError UseTheBindings.f_use_bindings1()
+            @test UseTheBindings.f_use_bindings2() == 2
+            @test_throws UndefVarError UseTheBindings.f_use_bindings3()
+            @test UseTheBindings.f_use_bindings4() == 4
+            # Delete remaining bindings
+            Base.delete_binding(LotsOfBindingsToDelete, :delete_me_2)
+            Base.delete_binding(LotsOfBindingsToDelete, :delete_me_4)
+            invokelatest() do
+                @test_throws UndefVarError UseTheBindings.f_use_bindings2()
+                @test_throws UndefVarError UseTheBindings.f_use_bindings4()
+            end
+        end
+    end
+
+    finish_precompile_test!()
 end


### PR DESCRIPTION
This PR adds limited backedge support for Bindings. There are two classes of bindings that get backedges:

1. Cross-module `GlobalRef` bindings (new in this PR)
2. Any globals accesses through intrinsics (i.e. those with forward edges from #57009)

This is a time/space trade-off for invalidation. As a result of the first category, invalidating a binding now only needs to scan all the methods defined in the same module as the binding. At the same time, it is anticipated that most binding references are to bindings in the same module, keeping the list of bindings that need explicit (back)edges small.