### PR TITLE
Don't delete inferred code from external interpreters

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -939,7 +939,7 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
                     record_field_change((jl_value_t**)&ci->inferred, jl_nothing);
                 }
                 else if (native_functions && // don't delete any code if making a ji file
-                         (ci->owner != jl_nothing) && // don't delete code for external interpreters
+                         (ci->owner == jl_nothing) && // don't delete code for external interpreters
                          !effects_foldable(jl_atomic_load_relaxed(&ci->ipo_purity_bits)) && // don't delete code we may want for irinterp
                          jl_ir_inlining_cost(inferred) == UINT16_MAX) { // don't delete inlineable code
                     // delete the code now: if we thought it was worth keeping, it would have been converted to object code

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -939,6 +939,7 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
                     record_field_change((jl_value_t**)&ci->inferred, jl_nothing);
                 }
                 else if (native_functions && // don't delete any code if making a ji file
+                         (ci->owner != jl_nothing) && // don't delete code for external interpreters
                          !effects_foldable(jl_atomic_load_relaxed(&ci->ipo_purity_bits)) && // don't delete code we may want for irinterp
                          jl_ir_inlining_cost(inferred) == UINT16_MAX) { // don't delete inlineable code
                     // delete the code now: if we thought it was worth keeping, it would have been converted to object code


### PR DESCRIPTION
We were deleting code from external abstract interpreters since https://github.com/JuliaLang/julia/commit/bdf8219ee80557ea6035b421b00d91b1174234f2.
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/2637. Not sure how to write tests for this :( 