### PR TITLE
cfunction: reimplement, as originally planned, for reliable performance

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1266,6 +1266,7 @@ function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim::
     tocompile = Vector{CodeInstance}()
     codeinfos = []
     # first compute the ABIs of everything
+    latest = true # whether this_world == world_counter()
     for this_world in reverse(sort!(worlds))
         interp = NativeInterpreter(this_world)
         for i = 1:length(methods)
@@ -1278,18 +1279,18 @@ function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim::
                 # then we want to compile and emit this
                 if item.def.primary_world <= this_world <= item.def.deleted_world
                     ci = typeinf_ext(interp, item, SOURCE_MODE_NOT_REQUIRED)
-                    ci isa CodeInstance && !use_const_api(ci) && push!(tocompile, ci)
+                    ci isa CodeInstance && push!(tocompile, ci)
                 end
-            elseif item isa SimpleVector
+            elseif item isa SimpleVector && latest
                 (rt::Type, sig::Type) = item
                 # make a best-effort attempt to enqueue the relevant code for the ccallable
                 ptr = ccall(:jl_get_specialization1,
                             #= MethodInstance =# Ptr{Cvoid}, (Any, Csize_t, Cint),
                             sig, this_world, #= mt_cache =# 0)
                 if ptr !== C_NULL
-                    mi = unsafe_pointer_to_objref(ptr)
+                    mi = unsafe_pointer_to_objref(ptr)::MethodInstance
                     ci = typeinf_ext(interp, mi, SOURCE_MODE_NOT_REQUIRED)
-                    ci isa CodeInstance && !use_const_api(ci) && push!(tocompile, ci)
+                    ci isa CodeInstance && push!(tocompile, ci)
                 end
                 # additionally enqueue the ccallable entrypoint / adapter, which implicitly
                 # invokes the above ci
@@ -1305,7 +1306,7 @@ function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim::
             mi = get_ci_mi(callee)
             def = mi.def
             if use_const_api(callee)
-                src = codeinfo_for_const(interp, mi, code.rettype_const)
+                src = codeinfo_for_const(interp, mi, callee.rettype_const)
             elseif haskey(interp.codegen, callee)
                 src = interp.codegen[callee]
             elseif isa(def, Method) && ccall(:jl_get_module_infer, Cint, (Any,), def.module) == 0 && !trim
@@ -1327,6 +1328,7 @@ function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim::
                 println("warning: failed to get code for ", mi)
             end
         end
+        latest = false
     end
     return codeinfos
 end

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1970,6 +1970,8 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
     return retval;
 }
 
+static inline Constant *literal_static_pointer_val(const void *p, Type *T);
+
 jl_cgval_t function_sig_t::emit_a_ccall(
         jl_codectx_t &ctx,
         const native_sym_arg_t &symarg,

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -278,16 +278,16 @@ extern void _chkstk(void);
 
 // types
 struct jl_typecache_t {
-    Type *T_ptr;
+    PointerType *T_ptr;
     Type *T_size;
     Type *T_jlvalue;
-    Type *T_pjlvalue;
-    Type *T_prjlvalue;
-    Type *T_ppjlvalue;
-    Type *T_pprjlvalue;
+    PointerType *T_pjlvalue;
+    PointerType *T_prjlvalue;
+    PointerType *T_ppjlvalue;
+    PointerType *T_pprjlvalue;
     StructType *T_jlgenericmemory;
     StructType *T_jlarray;
-    Type *T_pjlarray;
+    PointerType *T_pjlarray;
     FunctionType *T_jlfunc;
     FunctionType *T_jlfuncparams;
 
@@ -990,20 +990,12 @@ static const auto jlapplygeneric_func = new JuliaFunction<>{
 static const auto jlinvoke_func = new JuliaFunction<>{
     XSTR(jl_invoke),
     get_func2_sig,
-    [](LLVMContext &C) { return AttributeList::get(C,
-            AttributeSet(),
-            Attributes(C, {Attribute::NonNull}),
-            {AttributeSet(),
-             Attributes(C, {Attribute::ReadOnly, Attribute::NoCapture})}); },
+    get_func_attrs,
 };
 static const auto jlinvokeoc_func = new JuliaFunction<>{
     XSTR(jl_invoke_oc),
     get_func2_sig,
-    [](LLVMContext &C) { return AttributeList::get(C,
-            AttributeSet(),
-            Attributes(C, {Attribute::NonNull}),
-            {AttributeSet(),
-             Attributes(C, {Attribute::ReadOnly, Attribute::NoCapture})}); },
+    get_func_attrs,
 };
 static const auto jlopaque_closure_call_func = new JuliaFunction<>{
     XSTR(jl_f_opaque_closure_call),
@@ -1396,6 +1388,14 @@ static const auto jlgetcfunctiontrampoline_func = new JuliaFunction<>{
             Attributes(C, {Attribute::NonNull}),
             None); },
 };
+static const auto jlgetabiconverter_func = new JuliaFunction<TypeFnContextAndSizeT>{
+    XSTR(jl_get_abi_converter),
+    [](LLVMContext &C, Type *T_size) {
+        Type *T_ptr = getPointerTy(C);
+        return FunctionType::get(T_ptr,
+            {T_ptr, T_ptr, T_ptr, T_ptr}, false); },
+    nullptr,
+};
 static const auto diff_gc_total_bytes_func = new JuliaFunction<>{
     XSTR(jl_gc_diff_total_bytes),
     [](LLVMContext &C) { return FunctionType::get(getInt64Ty(C), false); },
@@ -1461,7 +1461,6 @@ static const auto jlgetbuiltinfptr_func = new JuliaFunction<>{
             {JuliaType::get_prjlvalue_ty(C)}, false); },
     nullptr,
 };
-
 
 // placeholder functions
 static const auto gcroot_flush_func = new JuliaFunction<>{
@@ -2095,7 +2094,7 @@ jl_aliasinfo_t jl_aliasinfo_t::fromTBAA(jl_codectx_t &ctx, MDNode *tbaa) {
 }
 
 static Type *julia_type_to_llvm(jl_codectx_t &ctx, jl_value_t *jt, bool *isboxed = NULL);
-static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, Value *fval, StringRef name, jl_value_t *sig, jl_value_t *jlrettype, bool is_opaque_closure, bool gcstack_arg,
+static jl_returninfo_t get_specsig_function(jl_codegen_params_t &ctx, Module *M, Value *fval, StringRef name, jl_value_t *sig, jl_value_t *jlrettype, bool is_opaque_closure,
         ArrayRef<const char*> ArgNames=None, unsigned nreq=0);
 static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval = -1);
 static jl_cgval_t emit_checked_var(jl_codectx_t &ctx, Value *bp, jl_sym_t *name, jl_value_t *scope, bool isvol, MDNode *tbaa);
@@ -2107,14 +2106,14 @@ static Value *get_tls_world_age(jl_codectx_t &ctx);
 static Value *get_scope_field(jl_codectx_t &ctx);
 static Value *get_tls_world_age_field(jl_codectx_t &ctx);
 static void CreateTrap(IRBuilder<> &irbuilder, bool create_new_block = true);
-static CallInst *emit_jlcall(jl_codectx_t &ctx, FunctionCallee theFptr, Value *theF,
+static CallInst *emit_jlcall(jl_codectx_t &ctx, Value *theFptr, Value *theF,
                              ArrayRef<jl_cgval_t> args, size_t nargs, JuliaFunction<> *trampoline);
 static CallInst *emit_jlcall(jl_codectx_t &ctx, JuliaFunction<> *theFptr, Value *theF,
                              ArrayRef<jl_cgval_t> args, size_t nargs, JuliaFunction<> *trampoline);
 static Value *emit_f_is(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgval_t &arg2,
                         Value *nullcheck1 = nullptr, Value *nullcheck2 = nullptr);
 static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t nargs, ArrayRef<jl_cgval_t> argv, bool is_promotable=false);
-static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, ArrayRef<jl_cgval_t> argv, size_t nargs, jl_value_t *rt, Value *age_ok);
+static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, ArrayRef<jl_cgval_t> argv, size_t nargs, jl_value_t *rt);
 
 static Value *literal_pointer_val(jl_codectx_t &ctx, jl_value_t *p);
 static unsigned julia_alignment(jl_value_t *jt);
@@ -2914,7 +2913,7 @@ static jl_cgval_t convert_julia_type(jl_codectx_t &ctx, const jl_cgval_t &v, jl_
     return jl_cgval_t(v, typ, new_tindex);
 }
 
-std::unique_ptr<Module> jl_create_llvm_module(StringRef name, LLVMContext &context, const DataLayout &DL, const Triple &triple)
+std::unique_ptr<Module> jl_create_llvm_module(StringRef name, LLVMContext &context, const DataLayout &DL, const Triple &triple) JL_NOTSAFEPOINT
 {
     ++ModulesCreated;
     auto m = std::make_unique<Module>(name, context);
@@ -2941,14 +2940,16 @@ std::unique_ptr<Module> jl_create_llvm_module(StringRef name, LLVMContext &conte
     return m;
 }
 
-static void jl_name_jlfunc_args(jl_codegen_params_t &params, Function *F) {
+static void jl_name_jlfunc_args(jl_codegen_params_t &params, Function *F) JL_NOTSAFEPOINT
+{
     assert(F->arg_size() == 3);
     F->getArg(0)->setName("function::Core.Function");
     F->getArg(1)->setName("args::Any[]");
     F->getArg(2)->setName("nargs::UInt32");
 }
 
-static void jl_name_jlfuncparams_args(jl_codegen_params_t &params, Function *F) {
+static void jl_name_jlfuncparams_args(jl_codegen_params_t &params, Function *F) JL_NOTSAFEPOINT
+{
     assert(F->arg_size() == 4);
     F->getArg(0)->setName("function::Core.Function");
     F->getArg(1)->setName("args::Any[]");
@@ -2956,7 +2957,7 @@ static void jl_name_jlfuncparams_args(jl_codegen_params_t &params, Function *F) 
     F->getArg(3)->setName("sparams::Any");
 }
 
-void jl_init_function(Function *F, const Triple &TT)
+void jl_init_function(Function *F, const Triple &TT) JL_NOTSAFEPOINT
 {
     // set any attributes that *must* be set on all functions
     AttrBuilder attr(F->getContext());
@@ -3020,6 +3021,7 @@ static bool uses_specsig(jl_value_t *sig, bool needsparams, jl_value_t *rettype,
     bool allSingleton = true;
     for (size_t i = 0; i < jl_nparams(sig); i++) {
         jl_value_t *sigt = jl_tparam(sig, i);
+        // TODO: sigt = unwrap_va(sigt)
         bool issing = jl_is_datatype(sigt) && jl_is_datatype_singleton((jl_datatype_t*)sigt);
         allSingleton &= issing;
         if (!deserves_argbox(sigt) && !issing) {
@@ -5311,14 +5313,14 @@ isdefined_unknown_idx:
 }
 
 // Returns ctx.types().T_prjlvalue
-static CallInst *emit_jlcall(jl_codectx_t &ctx, FunctionCallee theFptr, Value *theF,
+static CallInst *emit_jlcall(jl_codectx_t &ctx, Value *theFptr, Value *theF,
                              ArrayRef<jl_cgval_t> argv, size_t nargs, JuliaFunction<> *trampoline)
 {
     ++EmittedJLCalls;
     Function *TheTrampoline = prepare_call(trampoline);
     // emit arguments
     SmallVector<Value*, 4> theArgs;
-    theArgs.push_back(theFptr.getCallee());
+    theArgs.push_back(theFptr);
     if (theF)
         theArgs.push_back(theF);
     for (size_t i = 0; i < nargs; i++) {
@@ -5485,12 +5487,11 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_clos
 }
 
 static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_closure, jl_value_t *specTypes, jl_value_t *jlretty, llvm::Value *callee, StringRef specFunctionObject, jl_code_instance_t *fromexternal,
-                                          ArrayRef<jl_cgval_t> argv, size_t nargs, jl_returninfo_t::CallingConv *cc, unsigned *nreturn_roots, jl_value_t *inferred_retty, Value *age_ok)
+                                          ArrayRef<jl_cgval_t> argv, size_t nargs, jl_returninfo_t::CallingConv *cc, unsigned *nreturn_roots, jl_value_t *inferred_retty)
 {
     ++EmittedSpecfunCalls;
     // emit specialized call site
-    bool gcstack_arg = JL_FEAT_TEST(ctx, gcstack_arg);
-    jl_returninfo_t returninfo = get_specsig_function(ctx, jl_Module, callee, specFunctionObject, specTypes, jlretty, is_opaque_closure, gcstack_arg);
+    jl_returninfo_t returninfo = get_specsig_function(ctx.emission_context, jl_Module, callee, specFunctionObject, specTypes, jlretty, is_opaque_closure);
     *cc = returninfo.cc;
     *nreturn_roots = returninfo.return_roots;
     if (fromexternal) {
@@ -5510,31 +5511,17 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_clos
         setName(ctx.emission_context, TheCallee, namep);
         returninfo.decl = FunctionCallee(returninfo.decl.getFunctionType(), TheCallee);
     }
-    if (age_ok) {
-        std::string funcName(specFunctionObject);
-        funcName += "_gfthunk";
-        Function *gf_thunk = Function::Create(returninfo.decl.getFunctionType(),
-                GlobalVariable::InternalLinkage, funcName, jl_Module);
-        jl_init_function(gf_thunk, ctx.emission_context.TargetTriple);
-        gf_thunk->setAttributes(AttributeList::get(gf_thunk->getContext(), {returninfo.attrs, gf_thunk->getAttributes()}));
-        // build a specsig -> jl_apply_generic converter thunk
-        // this builds a method that calls jl_apply_generic (as a closure over a singleton function pointer),
-        // but which has the signature of a specsig
-        emit_specsig_to_fptr1(gf_thunk, returninfo.cc, returninfo.return_roots, specTypes, jlretty, is_opaque_closure, nargs, ctx.emission_context,
-            prepare_call(jlapplygeneric_func));
-        returninfo.decl = FunctionCallee(returninfo.decl.getFunctionType(), ctx.builder.CreateSelect(age_ok, returninfo.decl.getCallee(), gf_thunk));
-    }
     jl_cgval_t retval = emit_call_specfun_other(ctx, is_opaque_closure, specTypes, jlretty, returninfo, argv, nargs);
     // see if inference has a different / better type for the call than the lambda
     return update_julia_type(ctx, retval, inferred_retty);
 }
 
 static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, jl_method_instance_t *mi, jl_value_t *jlretty, StringRef specFunctionObject, jl_code_instance_t *fromexternal,
-                                          ArrayRef<jl_cgval_t> argv, size_t nargs, jl_returninfo_t::CallingConv *cc, unsigned *return_roots, jl_value_t *inferred_retty, Value *age_ok)
+                                          ArrayRef<jl_cgval_t> argv, size_t nargs, jl_returninfo_t::CallingConv *cc, unsigned *return_roots, jl_value_t *inferred_retty)
 {
     bool is_opaque_closure = jl_is_method(mi->def.value) && mi->def.method->is_for_opaque_closure;
     return emit_call_specfun_other(ctx, is_opaque_closure, mi->specTypes, jlretty, NULL,
-        specFunctionObject, fromexternal, argv, nargs, cc, return_roots, inferred_retty, age_ok);
+        specFunctionObject, fromexternal, argv, nargs, cc, return_roots, inferred_retty);
 }
 
 static jl_value_t *get_ci_abi(jl_code_instance_t *ci)
@@ -5545,16 +5532,16 @@ static jl_value_t *get_ci_abi(jl_code_instance_t *ci)
 }
 
 static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, jl_code_instance_t *ci, StringRef specFunctionObject, jl_code_instance_t *fromexternal,
-    ArrayRef<jl_cgval_t> argv, size_t nargs, jl_returninfo_t::CallingConv *cc, unsigned *return_roots, jl_value_t *inferred_retty, Value *age_ok)
+    ArrayRef<jl_cgval_t> argv, size_t nargs, jl_returninfo_t::CallingConv *cc, unsigned *return_roots, jl_value_t *inferred_retty)
 {
     jl_method_instance_t *mi = jl_get_ci_mi(ci);
     bool is_opaque_closure = jl_is_method(mi->def.value) && mi->def.method->is_for_opaque_closure;
     return emit_call_specfun_other(ctx, is_opaque_closure, get_ci_abi(ci), ci->rettype, NULL,
-        specFunctionObject, fromexternal, argv, nargs, cc, return_roots, inferred_retty, age_ok);
+        specFunctionObject, fromexternal, argv, nargs, cc, return_roots, inferred_retty);
 }
 
 static jl_cgval_t emit_call_specfun_boxed(jl_codectx_t &ctx, jl_value_t *jlretty, StringRef specFunctionObject, jl_code_instance_t *fromexternal,
-                                          ArrayRef<jl_cgval_t> argv, size_t nargs, jl_value_t *inferred_retty, Value *age_ok)
+                                          ArrayRef<jl_cgval_t> argv, size_t nargs, jl_value_t *inferred_retty)
 {
     Value *theFptr;
     if (fromexternal) {
@@ -5577,9 +5564,7 @@ static jl_cgval_t emit_call_specfun_boxed(jl_codectx_t &ctx, jl_value_t *jlretty
         theFptr = jl_Module->getOrInsertFunction(specFunctionObject, ctx.types().T_jlfunc).getCallee();
         addRetAttr(cast<Function>(theFptr), Attribute::NonNull);
     }
-    if (age_ok)
-        theFptr = ctx.builder.CreateSelect(age_ok, theFptr, prepare_call(jlapplygeneric_func));
-    Value *ret = emit_jlcall(ctx, FunctionCallee(ctx.types().T_jlfunc, theFptr), nullptr, argv, nargs, julia_call);
+    Value *ret = emit_jlcall(ctx, theFptr, nullptr, argv, nargs, julia_call);
     return update_julia_type(ctx, mark_julia_type(ctx, ret, true, jlretty), inferred_retty);
 }
 
@@ -5597,10 +5582,10 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt)
         if (argv[i].typ == jl_bottom_type)
             return jl_cgval_t();
     }
-    return emit_invoke(ctx, lival, argv, nargs, rt, nullptr);
+    return emit_invoke(ctx, lival, argv, nargs, rt);
 }
 
-static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, ArrayRef<jl_cgval_t> argv, size_t nargs, jl_value_t *rt, Value *age_ok)
+static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, ArrayRef<jl_cgval_t> argv, size_t nargs, jl_value_t *rt)
 {
     ++EmittedInvokes;
     bool handled = false;
@@ -5633,7 +5618,7 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, ArrayR
                 unsigned return_roots = 0;
                 jl_returninfo_t::CallingConv cc = jl_returninfo_t::CallingConv::Boxed;
                 StringRef protoname = f->getName();
-                result = emit_call_specfun_other(ctx, mi, ctx.rettype, protoname, nullptr, argv, nargs, &cc, &return_roots, rt, age_ok);
+                result = emit_call_specfun_other(ctx, mi, ctx.rettype, protoname, nullptr, argv, nargs, &cc, &return_roots, rt);
             }
             handled = true;
         }
@@ -5699,9 +5684,9 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, ArrayR
                         jl_returninfo_t::CallingConv cc = jl_returninfo_t::CallingConv::Boxed;
                         unsigned return_roots = 0;
                         if (specsig)
-                            result = emit_call_specfun_other(ctx, codeinst, protoname, external ? codeinst : nullptr, argv, nargs, &cc, &return_roots, rt, age_ok);
+                            result = emit_call_specfun_other(ctx, codeinst, protoname, external ? codeinst : nullptr, argv, nargs, &cc, &return_roots, rt);
                         else
-                            result = emit_call_specfun_boxed(ctx, codeinst->rettype, protoname, external ? codeinst : nullptr, argv, nargs, rt, age_ok);
+                            result = emit_call_specfun_boxed(ctx, codeinst->rettype, protoname, external ? codeinst : nullptr, argv, nargs, rt);
                         if (need_to_emit) {
                             Function *trampoline_decl = cast<Function>(jl_Module->getNamedValue(protoname));
                             ctx.call_targets[codeinst] = {cc, return_roots, trampoline_decl, nullptr, specsig};
@@ -5726,8 +5711,8 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, ArrayR
                 print_stacktrace(ctx, ctx.params->trim);
             }
         }
-        Value *r = age_ok ? emit_jlcall(ctx, jlapplygeneric_func, nullptr, argv, nargs, julia_call) : emit_jlcall(ctx, jlinvoke_func, boxed(ctx, lival), argv, nargs, julia_call2);
-        result = mark_julia_type(ctx, r, true, age_ok ? (jl_value_t*)jl_any_type : rt);
+        Value *r = emit_jlcall(ctx, jlinvoke_func, boxed(ctx, lival), argv, nargs, julia_call2);
+        result = mark_julia_type(ctx, r, true, rt);
     }
     if (result.typ == jl_bottom_type) {
 #ifndef JL_NDEBUG
@@ -5818,9 +5803,10 @@ static jl_cgval_t emit_specsig_oc_call(jl_codectx_t &ctx, jl_value_t *oc_type, j
     jl_cgval_t &theArg = argv[0];
     jl_cgval_t closure_specptr = emit_getfield_knownidx(ctx, theArg, 4, (jl_datatype_t*)oc_type, jl_memory_order_notatomic);
     Value *specptr = emit_unbox(ctx, ctx.types().T_size, closure_specptr, (jl_value_t*)jl_long_type);
+    specptr = emit_inttoptr(ctx, specptr, ctx.types().T_ptr);
     JL_GC_PUSH1(&sigtype);
     jl_cgval_t r = emit_call_specfun_other(ctx, true, sigtype, oc_rett, specptr, "", NULL, argv, nargs,
-        &cc, &return_roots, oc_rett, nullptr);
+        &cc, &return_roots, oc_rett);
     JL_GC_POP();
     return r;
 }
@@ -5898,14 +5884,14 @@ static jl_cgval_t emit_call(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt, bo
                 return mark_julia_type(ctx, ret, true, rt);
             }
         }
-        FunctionCallee fptr;
+        Value *fptr;
         JuliaFunction<> *cc;
         if (f.typ == (jl_value_t*)jl_intrinsic_type) {
             fptr = prepare_call(jlintrinsic_func);
             cc = julia_call3;
         }
         else {
-            fptr = FunctionCallee(get_func_sig(ctx.builder.getContext()), ctx.builder.CreateCall(prepare_call(jlgetbuiltinfptr_func), {emit_typeof(ctx, f)}));
+            fptr = ctx.builder.CreateCall(prepare_call(jlgetbuiltinfptr_func), {emit_typeof(ctx, f)});
             cc = julia_call;
         }
         if (trim_may_error(ctx.params->trim)) {
@@ -6723,8 +6709,7 @@ static std::pair<Function*, Function*> get_oc_function(jl_codectx_t &ctx, jl_met
     bool is_opaque_closure = jl_is_method(mi->def.value) && mi->def.method->is_for_opaque_closure;
     assert(is_opaque_closure);
     if (specsig) {
-        bool gcstack_arg = JL_FEAT_TEST(ctx, gcstack_arg);
-        jl_returninfo_t returninfo = get_specsig_function(ctx, jl_Module, nullptr, protoname, mi->specTypes, rettype, is_opaque_closure, gcstack_arg);
+        jl_returninfo_t returninfo = get_specsig_function(ctx.emission_context, jl_Module, nullptr, protoname, mi->specTypes, rettype, is_opaque_closure);
         cc = returninfo.cc;
         return_roots = returninfo.return_roots;
         specF = cast<Function>(returninfo.decl.getCallee());
@@ -7192,7 +7177,7 @@ JL_GCC_IGNORE_STOP
 // --- generate function bodies ---
 
 // gc frame emission
-static void allocate_gc_frame(jl_codectx_t &ctx, BasicBlock *b0, bool or_new=false)
+static void allocate_gc_frame(jl_codectx_t &ctx, BasicBlock *b0, bool or_new=false) JL_NOTSAFEPOINT
 {
     // allocate a placeholder gc instruction
     // this will require the runtime, but it gets deleted later if unused
@@ -7244,12 +7229,34 @@ static Value *get_scope_field(jl_codectx_t &ctx)
     return emit_ptrgep(ctx, ct, offsetof(jl_task_t, scope), "scope");
 }
 
+static std::string get_function_name(bool specsig, bool needsparams, const char *unadorned_name, const Triple &TargetTriple)
+{
+    std::string _funcName;
+    raw_string_ostream funcName(_funcName);
+    // try to avoid conflicts in the global symbol table
+    if (specsig)
+        funcName << "julia_"; // api 5
+    else if (needsparams)
+        funcName << "japi3_";
+    else
+        funcName << "japi1_";
+    if (TargetTriple.isOSLinux()) {
+        if (unadorned_name[0] == '@')
+            unadorned_name++;
+    }
+    funcName << unadorned_name << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
+    return funcName.str();
+}
+
+static void gen_invoke_wrapper(jl_method_instance_t *lam, jl_value_t *abi, jl_value_t *jlretty, jl_value_t *declrt, jl_returninfo_t &f, unsigned nargs, int retarg, bool is_opaque_closure, StringRef funcName,
+        Module *M, jl_codegen_params_t &params);
+
 Function *get_or_emit_fptr1(StringRef preal_decl, Module *M)
 {
     return cast<Function>(M->getOrInsertFunction(preal_decl, get_func_sig(M->getContext()), get_func_attrs(M->getContext())).getCallee());
 }
 
-Function *emit_tojlinvoke(jl_code_instance_t *codeinst, StringRef theFptrName, Module *M, jl_codegen_params_t &params) JL_NOTSAFEPOINT
+Function *emit_tojlinvoke(jl_code_instance_t *codeinst, Value *theFunc, Module *M, jl_codegen_params_t &params) JL_NOTSAFEPOINT
 {
     ++EmittedToJLInvokes;
     jl_codectx_t ctx(M->getContext(), params, codeinst);
@@ -7265,14 +7272,11 @@ Function *emit_tojlinvoke(jl_code_instance_t *codeinst, StringRef theFptrName, M
     jl_name_jlfunc_args(params, f);
     //f->setAlwaysInline();
     ctx.f = f; // for jl_Module
-    BasicBlock *b0 = BasicBlock::Create(ctx.builder.getContext(), "top", f);
+    BasicBlock *b0 = BasicBlock::Create(M->getContext(), "top", f);
     ctx.builder.SetInsertPoint(b0);
-    Function *theFunc;
     Value *theFarg;
 
-    if (!theFptrName.empty()) {
-        theFunc = cast<Function>(
-            M->getOrInsertFunction(theFptrName, jlinvoke_func->_type(ctx.builder.getContext())).getCallee());
+    if (theFunc) {
         theFarg = literal_pointer_val(ctx, (jl_value_t*)codeinst);
     }
     else {
@@ -7283,10 +7287,18 @@ Function *emit_tojlinvoke(jl_code_instance_t *codeinst, StringRef theFptrName, M
     }
     theFarg = track_pjlvalue(ctx, theFarg);
     auto args = f->arg_begin();
-    CallInst *r = ctx.builder.CreateCall(theFunc, { &*args, &*++args, &*++args, theFarg });
-    r->setAttributes(theFunc->getAttributes());
+    CallInst *r = ctx.builder.CreateCall(FunctionCallee(jlinvoke_func->_type(M->getContext()), theFunc), { &*args, &*++args, &*++args, theFarg });
+    r->setAttributes(jlinvoke_func->_attrs(M->getContext()));
     ctx.builder.CreateRet(r);
     return f;
+}
+
+Function *emit_tojlinvoke(jl_code_instance_t *codeinst, StringRef theFptrName, Module *M, jl_codegen_params_t &params) JL_NOTSAFEPOINT
+{
+    Value *theFunc = nullptr;
+    if (!theFptrName.empty())
+        theFunc = M->getOrInsertFunction(theFptrName, jlinvoke_func->_type(M->getContext()), jlinvoke_func->_attrs(M->getContext())).getCallee();
+    return emit_tojlinvoke(codeinst, theFunc, M, params);
 }
 
 static jl_value_t *get_oc_type(jl_value_t *calltype, jl_value_t *rettype) JL_ALWAYS_LEAFTYPE
@@ -7299,12 +7311,16 @@ static jl_value_t *get_oc_type(jl_value_t *calltype, jl_value_t *rettype) JL_ALW
     return oc_type;
 }
 
-void emit_specsig_to_fptr1(
+static void emit_specsig_to_specsig(
         Function *gf_thunk, jl_returninfo_t::CallingConv cc, unsigned return_roots,
         jl_value_t *calltype, jl_value_t *rettype, bool is_for_opaque_closure,
         size_t nargs,
         jl_codegen_params_t &params,
-        Function *target)
+        Value *target,
+        jl_value_t *targetsig,
+        jl_value_t *targetrt,
+        jl_returninfo_t *targetspec,
+        jl_value_t *rettype_const)
 {
     ++EmittedCFuncInvalidates;
     jl_codectx_t ctx(gf_thunk->getParent()->getContext(), params, 0, 0);
@@ -7321,7 +7337,7 @@ void emit_specsig_to_fptr1(
         ++AI;
     if (return_roots)
         ++AI;
-    if (JL_FEAT_TEST(ctx,gcstack_arg)){
+    if (JL_FEAT_TEST(ctx,gcstack_arg)) {
         ++AI; // gcstack_arg
     }
     for (size_t i = 0; i < nargs; i++) {
@@ -7372,16 +7388,23 @@ void emit_specsig_to_fptr1(
         }
     }
     assert(AI == gf_thunk->arg_end());
-    Value *gf_ret = emit_jlcall(ctx, target, nullptr, myargs, nargs, julia_call);
-    jl_cgval_t gf_retbox = mark_julia_type(ctx, gf_ret, true, jl_any_type);
-    if (cc != jl_returninfo_t::Boxed) {
-        emit_typecheck(ctx, gf_retbox, rettype, "cfunction");
-        gf_retbox = update_julia_type(ctx, gf_retbox, rettype);
+    jl_cgval_t gf_retval;
+    if (target || targetspec) {
+        if (targetspec == nullptr)
+            gf_retval = mark_julia_type(ctx, emit_jlcall(ctx, target, nullptr, myargs, nargs, julia_call), true, targetrt);
+        else
+            gf_retval = emit_call_specfun_other(ctx, is_for_opaque_closure, targetsig, targetrt, *targetspec, myargs, nargs);
+    }
+    if (rettype_const)
+        gf_retval = mark_julia_const(ctx, rettype_const);
+    if (targetrt != rettype) {
+        emit_typecheck(ctx, gf_retval, rettype, "cfunction");
+        gf_retval = update_julia_type(ctx, gf_retval, rettype);
     }
 
     switch (cc) {
     case jl_returninfo_t::Boxed:
-        ctx.builder.CreateRet(gf_ret);
+        ctx.builder.CreateRet(boxed(ctx, gf_retval));
         break;
     case jl_returninfo_t::Register: {
         Type *gfrt = gf_thunk->getReturnType();
@@ -7389,7 +7412,7 @@ void emit_specsig_to_fptr1(
             ctx.builder.CreateRetVoid();
         }
         else {
-            ctx.builder.CreateRet(ctx.builder.CreateAlignedLoad(gfrt, gf_ret, Align(julia_alignment(rettype))));
+            ctx.builder.CreateRet(emit_unbox(ctx, gfrt, gf_retval, rettype));
         }
         break;
     }
@@ -7398,65 +7421,273 @@ void emit_specsig_to_fptr1(
         Align align(julia_alignment(rettype));
         if (return_roots) {
             Value *roots = gf_thunk->arg_begin() + 1; // root1 has type [n x {}*]*
-            split_value_into(ctx, gf_retbox, align, sret, align, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack), roots, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe));
+            split_value_into(ctx, gf_retval, align, sret, align, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack), roots, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe));
         }
         else {
-            emit_unbox_store(ctx, gf_retbox, sret, ctx.tbaa().tbaa_stack, align);
+            emit_unbox_store(ctx, gf_retval, sret, ctx.tbaa().tbaa_stack, align);
         }
         ctx.builder.CreateRetVoid();
         break;
     }
     case jl_returninfo_t::Union: {
+        Value *gf_ret = boxed(ctx, gf_retval); // TODO: this is not the most optimal way to emit this
         Type *retty = gf_thunk->getReturnType();
-        Value *gf_retval = UndefValue::get(retty);
-        Value *tindex = compute_box_tindex(ctx, emit_typeof(ctx, gf_retbox, false, true), (jl_value_t*)jl_any_type, rettype);
+        Value *retval = UndefValue::get(retty);
+        Value *tindex = compute_box_tindex(ctx, emit_typeof(ctx, gf_retval, false, true), (jl_value_t*)jl_any_type, rettype);
         tindex = ctx.builder.CreateOr(tindex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), UNION_BOX_MARKER));
-        gf_retval = ctx.builder.CreateInsertValue(gf_retval, gf_ret, 0);
-        gf_retval = ctx.builder.CreateInsertValue(gf_retval, tindex, 1);
-        ctx.builder.CreateRet(gf_retval);
+        retval = ctx.builder.CreateInsertValue(retval, gf_ret, 0);
+        retval = ctx.builder.CreateInsertValue(retval, tindex, 1);
+        ctx.builder.CreateRet(retval);
         break;
     }
     case jl_returninfo_t::Ghosts: {
-        Value *gf_retval = compute_tindex_unboxed(ctx, gf_retbox, rettype);
-        ctx.builder.CreateRet(gf_retval);
+        Value *retval = compute_tindex_unboxed(ctx, gf_retval, rettype);
+        ctx.builder.CreateRet(retval);
         break;
     }
     }
 }
 
+void emit_specsig_to_fptr1(
+        Function *gf_thunk, jl_returninfo_t::CallingConv cc, unsigned return_roots,
+        jl_value_t *calltype, jl_value_t *rettype, bool is_for_opaque_closure,
+        size_t nargs,
+        jl_codegen_params_t &params,
+        Function *target)
+{
+    emit_specsig_to_specsig(gf_thunk, cc, return_roots, calltype, rettype, is_for_opaque_closure, nargs, params, target, calltype, rettype, nullptr, nullptr);
+}
+
+static void emit_fptr1_wrapper(Module *M, StringRef gf_thunk_name, Value *target, jl_value_t *rettype_const, jl_value_t *declrt, jl_value_t *jlrettype, jl_codegen_params_t &params)
+{
+    Function *w = Function::Create(get_func_sig(M->getContext()), GlobalVariable::ExternalLinkage, gf_thunk_name, M);
+    jl_init_function(w, params.TargetTriple);
+    w->setAttributes(AttributeList::get(M->getContext(), {get_func_attrs(M->getContext()), w->getAttributes()}));
+    w->addFnAttr(Attribute::OptimizeNone);
+    w->addFnAttr(Attribute::NoInline);
+
+    jl_codectx_t ctx(M->getContext(), params, 0, 0);
+    ctx.f = w;
+    ctx.rettype = declrt;
+
+    BasicBlock *b0 = BasicBlock::Create(ctx.builder.getContext(), "top", w);
+    ctx.builder.SetInsertPoint(b0);
+    DebugLoc noDbg;
+    ctx.builder.SetCurrentDebugLocation(noDbg);
+    allocate_gc_frame(ctx, b0);
+
+    jl_cgval_t gf_retval;
+    if (target) {
+        FunctionCallee theFunc(w->getFunctionType(), target);
+        auto args = w->arg_begin();
+        CallInst *r = ctx.builder.CreateCall(theFunc, { &*args, &*++args, &*++args }); // cf emit_tojlinvoke
+        assert(++args == w->arg_end());
+        r->setAttributes(w->getAttributes());
+        gf_retval = mark_julia_type(ctx, r, true, jlrettype);
+    }
+    if (rettype_const)
+        gf_retval = mark_julia_const(ctx, rettype_const);
+    if (jlrettype != declrt)
+        emit_typecheck(ctx, gf_retval, declrt, "cfunction");
+    ctx.builder.CreateRet(boxed(ctx, gf_retval));
+}
+
+static void emit_specsig_to_specsig(
+        Module *M, StringRef gf_thunk_name,
+        jl_value_t *calltype, jl_value_t *rettype, bool is_for_opaque_closure,
+        size_t nargs,
+        jl_codegen_params_t &params,
+        Value *target,
+        jl_value_t *targetsig,
+        jl_value_t *targetrt,
+        jl_returninfo_t *targetspec,
+        jl_value_t *rettype_const)
+{
+    jl_returninfo_t returninfo = get_specsig_function(params, M, nullptr, gf_thunk_name, calltype, rettype, is_for_opaque_closure);
+    Function *gf_thunk = cast<Function>(returninfo.decl.getCallee());
+    jl_init_function(gf_thunk, params.TargetTriple);
+    gf_thunk->setAttributes(AttributeList::get(gf_thunk->getContext(), {returninfo.attrs, gf_thunk->getAttributes()}));
+    emit_specsig_to_specsig(gf_thunk, returninfo.cc, returninfo.return_roots, calltype, rettype, is_for_opaque_closure, nargs, params, target, targetsig, targetrt, targetspec, rettype_const);
+}
+
+std::string emit_abi_converter(Module *M, jl_codegen_params_t &params, jl_value_t *declrt, jl_value_t *sigt, size_t nargs, bool specsig, jl_code_instance_t *codeinst, Value *target, bool target_specsig)
+{
+    // this builds a method that calls a method with the same arguments but a different specsig
+    // build a specsig -> specsig converter thunk
+    // build a specsig -> arg1 converter thunk
+    // build a args1 -> specsig converter thunk (gen_invoke_wrapper)
+    // build a args1 -> args1 converter thunk (to add typeassert on result)
+    bool needsparams = false;
+    bool is_opaque_closure = false;
+    jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
+    std::string gf_thunk_name = get_function_name(specsig, needsparams, name_from_method_instance(mi), params.TargetTriple);
+    gf_thunk_name += "_gfthunk";
+    if (target_specsig) {
+        jl_value_t *abi = get_ci_abi(codeinst);
+        jl_returninfo_t targetspec = get_specsig_function(params, M, target, "", abi, codeinst->rettype, is_opaque_closure);
+        if (specsig)
+            emit_specsig_to_specsig(M, gf_thunk_name, sigt, declrt, is_opaque_closure, nargs, params,
+                    target, mi->specTypes, codeinst->rettype, &targetspec, nullptr);
+        else
+            gen_invoke_wrapper(mi, abi, codeinst->rettype, declrt, targetspec, nargs, -1, is_opaque_closure, gf_thunk_name, M, params);
+    }
+    else {
+        if (specsig)
+            emit_specsig_to_specsig(M, gf_thunk_name, sigt, declrt, is_opaque_closure, nargs, params,
+                    target, mi->specTypes, codeinst->rettype, nullptr, nullptr);
+        else
+            emit_fptr1_wrapper(M, gf_thunk_name, target, nullptr, declrt, codeinst->rettype, params);
+    }
+    return gf_thunk_name;
+}
+
+std::string emit_abi_dispatcher(Module *M, jl_codegen_params_t &params, jl_value_t *declrt, jl_value_t *sigt, size_t nargs, bool specsig, jl_code_instance_t *codeinst, Value *invoke)
+{
+    // this builds a method that calls a method with the same arguments but a different specsig
+    // build a specsig -> args1 (apply_generic) or invoke (emit_tojlinvoke) call
+    // build a args1 -> args1 call (emit_fptr1_wrapper)
+    // build a args1 -> invoke call (emit_tojlinvoke)
+    bool is_opaque_closure = false;
+    Value *target;
+    if (!codeinst)
+        target = prepare_call_in(M, jlapplygeneric_func);
+    else
+        target = emit_tojlinvoke(codeinst, invoke, M, params); // TODO: inline this call?
+    std::string gf_thunk_name;
+    if (codeinst)
+        raw_string_ostream(gf_thunk_name) << "jfptr_" << name_from_method_instance(jl_get_ci_mi(codeinst)) << "_";
+    else
+        raw_string_ostream(gf_thunk_name) << "j_";
+    raw_string_ostream(gf_thunk_name) << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1) << "_gfthunk";
+    if (specsig)
+        emit_specsig_to_specsig(M, gf_thunk_name, sigt, declrt, is_opaque_closure, nargs, params,
+                target, sigt, codeinst ? codeinst->rettype : (jl_value_t*)jl_any_type, nullptr, nullptr);
+    else
+        emit_fptr1_wrapper(M, gf_thunk_name, target, nullptr, declrt, codeinst ? codeinst->rettype : (jl_value_t*)jl_any_type, params);
+    return gf_thunk_name;
+}
+
+std::string emit_abi_constreturn(Module *M, jl_codegen_params_t &params, jl_value_t *declrt, jl_value_t *sigt, size_t nargs, bool specsig, jl_value_t *rettype_const)
+{
+    bool is_opaque_closure = false;
+    std::string gf_thunk_name;
+    raw_string_ostream(gf_thunk_name) << "jconst_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
+    if (specsig) {
+        emit_specsig_to_specsig(M, gf_thunk_name, sigt, declrt, is_opaque_closure, nargs, params,
+                nullptr, sigt, jl_typeof(rettype_const), nullptr, rettype_const);
+    }
+    else {
+        emit_fptr1_wrapper(M, gf_thunk_name, nullptr, rettype_const, declrt, jl_typeof(rettype_const), params);
+    }
+    return gf_thunk_name;
+}
+
+std::string emit_abi_constreturn(Module *M, jl_codegen_params_t &params, bool specsig, jl_code_instance_t *codeinst)
+{
+    jl_value_t *abi = get_ci_abi(codeinst);
+    return emit_abi_constreturn(M, params, codeinst->rettype, abi, specsig ? jl_nparams(abi) : 0, specsig, codeinst->rettype_const);
+}
+
+// release jl_world_counter
+// store theFptr
+// release last_world_v
+//
+// acquire last_world_v
+// read theFptr
+// acquire jl_world_counter
+// if (last_world_v != jl_world_counter)
+//   fptr = compute_new_fptr(&last_world_v)
+// return fptr()
+static jl_cgval_t emit_abi_call(jl_codectx_t &ctx, jl_value_t *declrt, jl_value_t *sigt, ArrayRef<jl_cgval_t> inputargs, size_t nargs, Value *world_age_field)
+{
+    jl_cgval_t retval;
+    if (sigt) {
+        jl_temporary_root(ctx, declrt);
+        jl_temporary_root(ctx, sigt);
+        assert(nargs == jl_nparams(sigt));
+        bool needsparams = false;
+        bool is_opaque_closure = false;
+        bool specsig = uses_specsig(sigt, needsparams, declrt, ctx.params->prefer_specsig);
+        PointerType *T_ptr = ctx.types().T_ptr;
+        Type *T_size = ctx.types().T_size;
+        Constant *Vnull = ConstantPointerNull::get(T_ptr);
+        Module *M = jl_Module;
+        GlobalVariable *theFptr = new GlobalVariable(*M, T_ptr, false,
+                GlobalVariable::PrivateLinkage,
+                Vnull);
+        GlobalVariable *last_world_p = new GlobalVariable(*M, T_size, false,
+                GlobalVariable::PrivateLinkage,
+                ConstantInt::get(T_size, 0));
+        ArrayType *T_cfuncdata = ArrayType::get(T_ptr, 6);
+        size_t flags = specsig;
+        GlobalVariable *cfuncdata = new GlobalVariable(*M, T_cfuncdata, false,
+                GlobalVariable::PrivateLinkage,
+                ConstantArray::get(T_cfuncdata, {
+                    Vnull,
+                    Vnull,
+                    Vnull,
+                    literal_pointer_val_slot(ctx.emission_context, M, declrt),
+                    literal_pointer_val_slot(ctx.emission_context, M, sigt),
+                    literal_static_pointer_val((void*)flags, T_ptr)}));
+        LoadInst *last_world_v = ctx.builder.CreateAlignedLoad(T_size, last_world_p, ctx.types().alignof_ptr);
+        last_world_v->setOrdering(AtomicOrdering::Acquire);
+        LoadInst *callee = ctx.builder.CreateAlignedLoad(T_ptr, theFptr, ctx.types().alignof_ptr);
+        callee->setOrdering(AtomicOrdering::Monotonic);
+        LoadInst *world_v = ctx.builder.CreateAlignedLoad(ctx.types().T_size,
+            prepare_global_in(M, jlgetworld_global), ctx.types().alignof_ptr);
+        world_v->setOrdering(AtomicOrdering::Acquire);
+        ctx.builder.CreateStore(world_v, world_age_field);
+        Value *age_not_ok = ctx.builder.CreateICmpNE(last_world_v, world_v);
+        Value *target = emit_guarded_test(ctx, age_not_ok, callee, [&] {
+                Function *getcaller = prepare_call(jlgetabiconverter_func);
+                CallInst *cw = ctx.builder.CreateCall(getcaller, {
+                        get_current_task(ctx),
+                        theFptr,
+                        last_world_p,
+                        cfuncdata});
+                cw->setAttributes(getcaller->getAttributes());
+                return cw;
+            });
+        ctx.emission_context.cfuncs.push_back({declrt, sigt, nargs, specsig, theFptr, cfuncdata});
+        if (specsig) {
+            // TODO: could we force this to guarantee passing a box for `f` here (since we
+            // know we had it here) and on the receiver end (emit_abi_converter /
+            // emit_abi_dispatcher), force it to know that it can simply use this pointer
+            // instead of re-boxing it if it needs to the boxed copy of it. This comes up
+            // very rarely since usually the ABI calls are concrete and match exactly and
+            // aren't closures, but sometimes there are cases like that because of
+            // `::Function` de-specialization heuristics, such as for the `Returns` callable
+            // given that it is `@nospecialize`.
+            jl_returninfo_t targetspec = get_specsig_function(ctx.emission_context, M, target, "", sigt, declrt, is_opaque_closure);
+            retval = emit_call_specfun_other(ctx, is_opaque_closure, sigt, declrt, targetspec, inputargs, nargs);
+        }
+        else {
+            retval = mark_julia_type(ctx, emit_jlcall(ctx, target, nullptr, inputargs, nargs, julia_call), true, declrt);
+        }
+    }
+    else {
+        // emit a dispatch
+        Value *ret = emit_jlcall(ctx, jlapplygeneric_func, NULL, inputargs, nargs, julia_call);
+        retval = mark_julia_type(ctx, ret, true, jl_any_type);
+        // inline a call to typeassert here
+        emit_typecheck(ctx, retval, declrt, "cfunction");
+        retval = update_julia_type(ctx, retval, declrt);
+    }
+    return retval;
+}
+
 static Function *gen_cfun_wrapper(
     Module *into, jl_codegen_params_t &params,
     const function_sig_t &sig, jl_value_t *ff, const char *aliasname,
-    jl_value_t *declrt, jl_method_instance_t *lam,
+    jl_value_t *declrt, jl_value_t *sigt,
     jl_unionall_t *unionall_env, jl_svec_t *sparam_vals, jl_array_t **closure_types)
 {
     ++GeneratedCFuncWrappers;
     // Generate a c-callable wrapper
     assert(into);
     size_t nargs = sig.nccallargs;
-    const char *name = "cfunction";
-    size_t world = jl_atomic_load_acquire(&jl_world_counter);
+    const char *name = aliasname ? aliasname : "cfunction";
     bool nest = (!ff || unionall_env);
-    jl_value_t *astrt = (jl_value_t*)jl_any_type;
-    if (aliasname)
-        name = aliasname;
-    else if (lam)
-        name = jl_symbol_name(lam->def.method->name);
-
-    jl_code_instance_t *codeinst = NULL;
-    if (lam) {
-        // TODO: this isn't ideal to be unconditionally calling type inference from here
-        codeinst = jl_type_infer(lam, world, SOURCE_MODE_NOT_REQUIRED);
-        if (codeinst)
-            astrt = codeinst->rettype;
-        if (astrt != (jl_value_t*)jl_bottom_type &&
-            jl_type_intersection(astrt, declrt) == jl_bottom_type) {
-            // Do not warn if the function never returns since it is
-            // occasionally required by the C API (typically error callbacks)
-            // even though we're likely to encounter memory errors in that case
-            jl_printf(JL_STDERR, "WARNING: cfunction: return type of %s does not match\n", name);
-        }
-    }
 
     std::string funcName;
     raw_string_ostream(funcName) << "jlcapi_" << name << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
@@ -7538,19 +7769,6 @@ static Function *gen_cfun_wrapper(
     jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
     ctx.world_age_at_entry = ai.decorateInst(
             ctx.builder.CreateAlignedLoad(ctx.types().T_size, world_age_field, ctx.types().alignof_ptr));
-    Value *world_v = ctx.builder.CreateAlignedLoad(ctx.types().T_size,
-        prepare_global_in(jl_Module, jlgetworld_global), ctx.types().alignof_ptr);
-    cast<LoadInst>(world_v)->setOrdering(AtomicOrdering::Acquire);
-
-    Value *age_ok = nullptr;
-    if (codeinst) {
-        LoadInst *lam_max = ctx.builder.CreateAlignedLoad(
-                ctx.types().T_size,
-                emit_ptrgep(ctx, literal_pointer_val(ctx, (jl_value_t*)codeinst), offsetof(jl_code_instance_t, max_world)),
-                ctx.types().alignof_ptr);
-        age_ok = ctx.builder.CreateICmpUGE(lam_max, world_v);
-    }
-    ctx.builder.CreateStore(world_v, world_age_field);
 
     // first emit code to record the arguments
     Function::arg_iterator AI = cw->arg_begin();
@@ -7705,30 +7923,8 @@ static Function *gen_cfun_wrapper(
     assert(AI == cw->arg_end());
 
     // Create the call
-    bool jlfunc_sret;
-    jl_cgval_t retval;
-    if (codeinst) {
-        retval = emit_invoke(ctx, mark_julia_const(ctx, (jl_value_t*)codeinst), inputargs, nargs + 1, astrt, age_ok);
-        jlfunc_sret = retval.V && isa<AllocaInst>(retval.V) && !retval.TIndex && retval.inline_roots.empty();
-        if (jlfunc_sret && sig.sret) {
-            // fuse the two sret together
-            assert(retval.ispointer());
-            AllocaInst *result = cast<AllocaInst>(retval.V);
-            retval.V = sretPtr;
-            result->replaceAllUsesWith(sretPtr);
-            result->eraseFromParent();
-        }
-    }
-    else {
-        // emit a dispatch
-        jlfunc_sret = false;
-        Value *ret = emit_jlcall(ctx, jlapplygeneric_func, NULL, inputargs, nargs + 1, julia_call);
-        retval = mark_julia_type(ctx, ret, true, astrt);
-    }
-
-    // inline a call to typeassert here, if required
-    emit_typecheck(ctx, retval, declrt, "cfunction");
-    retval = update_julia_type(ctx, retval, declrt);
+    jl_cgval_t retval = emit_abi_call(ctx, declrt, sigt, inputargs, nargs + 1, world_age_field);
+    bool jlfunc_sret = retval.V && isa<AllocaInst>(retval.V) && !retval.TIndex && retval.inline_roots.empty();
 
     // Prepare the return value
     Value *r;
@@ -7738,7 +7934,12 @@ static Function *gen_cfun_wrapper(
         r = boxed(ctx, retval);
     }
     else if (sig.sret && jlfunc_sret) {
-        // nothing to do
+        // fuse the two sret together
+        assert(retval.ispointer());
+        AllocaInst *result = cast<AllocaInst>(retval.V);
+        retval.V = sretPtr;
+        result->replaceAllUsesWith(sretPtr);
+        result->eraseFromParent();
         r = NULL;
     }
     else if (!type_is_ghost(sig.lrt)) {
@@ -7760,14 +7961,6 @@ static Function *gen_cfun_wrapper(
 
     ctx.builder.SetCurrentDebugLocation(noDbg);
     ctx.builder.ClearInsertionPoint();
-
-    if (aliasname) {
-        auto alias = GlobalAlias::create(cw->getValueType(), cw->getType()->getAddressSpace(),
-                            GlobalValue::ExternalLinkage, aliasname, cw, M);
-        if(ctx.emission_context.TargetTriple.isOSBinFormatCOFF()) {
-            alias->setDLLStorageClass(GlobalValue::DLLStorageClassTypes::DLLExportStorageClass);
-        }
-    }
 
     if (nest) {
         funcName += "make";
@@ -7795,6 +7988,26 @@ static Function *gen_cfun_wrapper(
     }
 
     return cw;
+}
+
+static const char *derive_sigt_name(jl_value_t *jargty)
+{
+    jl_datatype_t *dt = (jl_datatype_t*)jl_argument_datatype(jargty);
+    if ((jl_value_t*)dt == jl_nothing)
+        return NULL;
+    jl_sym_t *name = dt->name->name;
+    // if we have a kwcall, use that as the name anyways
+    jl_methtable_t *mt = dt->name->mt;
+    if (mt == jl_type_type_mt || mt == jl_nonfunction_mt || mt == NULL) {
+        // our value for `name` from MethodTable is not good, try to come up with something better
+        if (jl_is_type_type((jl_value_t*)dt)) {
+            dt = (jl_datatype_t*)jl_argument_datatype(jl_tparam0(dt));
+            if ((jl_value_t*)dt != jl_nothing) {
+                name = dt->name->name;
+            }
+        }
+    }
+    return jl_symbol_name(name);
 }
 
 // Get the LLVM Function* for the C-callable entry point for a certain function
@@ -7896,13 +8109,11 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
             return jl_cgval_t();
         }
     }
-    size_t world = jl_atomic_load_acquire(&jl_world_counter);
-    // try to look up this function for direct invoking
-    jl_method_instance_t *lam = sigt ? jl_get_specialization1((jl_tupletype_t*)sigt, world, 0) : NULL;
+    const char *name = derive_sigt_name(fexpr_rt.typ);
     Value *F = gen_cfun_wrapper(
             jl_Module, ctx.emission_context,
-            sig, fexpr_rt.constant, NULL,
-            declrt, lam,
+            sig, fexpr_rt.constant, name,
+            declrt, sigt,
             unionall_env, sparam_vals, &closure_types);
     bool outboxed;
     if (nest) {
@@ -7967,6 +8178,7 @@ const char *jl_generate_ccallable(Module *llvmmod, void *sysimg_handle, jl_value
 {
     ++GeneratedCCallables;
     jl_datatype_t *ft = (jl_datatype_t*)jl_tparam0(sigt);
+    assert(jl_is_datatype(ft));
     jl_value_t *ff = ft->instance;
     assert(ff);
     const char *name = jl_symbol_name(ft->name->mt->name);
@@ -7991,7 +8203,6 @@ const char *jl_generate_ccallable(Module *llvmmod, void *sysimg_handle, jl_value
         function_sig_t sig("cfunction", lcrt, crt, toboxed,
                            argtypes, NULL, false, CallingConv::C, false, &params);
         if (sig.err_msg.empty()) {
-            size_t world = jl_atomic_load_acquire(&jl_world_counter);
             if (sysimg_handle) {
                 // restore a ccallable from the system image
                 void *addr;
@@ -8004,9 +8215,13 @@ const char *jl_generate_ccallable(Module *llvmmod, void *sysimg_handle, jl_value
                 }
             }
             else {
-                jl_method_instance_t *lam = jl_get_specialization1((jl_tupletype_t*)sigt, world, 0);
                 //Safe b/c params holds context lock
-                gen_cfun_wrapper(llvmmod, params, sig, ff, name, declrt, lam, NULL, NULL, NULL);
+                Function *cw = gen_cfun_wrapper(llvmmod, params, sig, ff, name, declrt, sigt, NULL, NULL, NULL);
+                auto alias = GlobalAlias::create(cw->getValueType(), cw->getType()->getAddressSpace(),
+                                    GlobalValue::ExternalLinkage, name, cw, llvmmod);
+                if (params.TargetTriple.isOSBinFormatCOFF()) {
+                    alias->setDLLStorageClass(GlobalValue::DLLStorageClassTypes::DLLExportStorageClass);
+                }
             }
             JL_GC_POP();
             return name;
@@ -8018,7 +8233,7 @@ const char *jl_generate_ccallable(Module *llvmmod, void *sysimg_handle, jl_value
 
 // generate a julia-callable function that calls f (AKA lam)
 // if is_opaque_closure, then generate the OC invoke, rather than a real invoke
-static void gen_invoke_wrapper(jl_method_instance_t *lam, jl_value_t *abi, jl_value_t *jlretty, jl_returninfo_t &f, unsigned nargs, int retarg, bool is_opaque_closure, StringRef funcName,
+static void gen_invoke_wrapper(jl_method_instance_t *lam, jl_value_t *abi, jl_value_t *jlretty, jl_value_t *declrt, jl_returninfo_t &f, unsigned nargs, int retarg, bool is_opaque_closure, StringRef funcName,
         Module *M, jl_codegen_params_t &params)
 {
     ++GeneratedInvokeWrappers;
@@ -8069,6 +8284,10 @@ static void gen_invoke_wrapper(jl_method_instance_t *lam, jl_value_t *abi, jl_va
         argv[i] = mark_julia_type(ctx, theArg, true, ty);
     }
     jl_cgval_t retval = emit_call_specfun_other(ctx, is_opaque_closure, abi, jlretty, f, argv, nargs);
+    if (declrt != jlretty) {
+        emit_typecheck(ctx, retval, declrt, "cfunction");
+        retval = update_julia_type(ctx, retval, declrt);
+    }
     if (retarg != -1) {
         Value *theArg;
         if (retarg == 0)
@@ -8085,20 +8304,22 @@ static void gen_invoke_wrapper(jl_method_instance_t *lam, jl_value_t *abi, jl_va
         ctx.builder.CreateRet(boxed(ctx, retval));
 }
 
-static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, Value *fval, StringRef name, jl_value_t *sig, jl_value_t *jlrettype, bool is_opaque_closure, bool gcstack_arg,
+static jl_returninfo_t get_specsig_function(jl_codegen_params_t &params, Module *M, Value *fval, StringRef name, jl_value_t *sig, jl_value_t *jlrettype, bool is_opaque_closure,
         ArrayRef<const char*> ArgNames, unsigned nreq)
 {
+    bool gcstack_arg = params.params->gcstack_arg;
     jl_returninfo_t props = {};
     SmallVector<Type*,8> fsig;
     SmallVector<std::string,4> argnames;
     Type *rt = NULL;
     Type *srt = NULL;
+    Type *T_prjlvalue = PointerType::get(M->getContext(), AddressSpace::Tracked);
     if (jlrettype == (jl_value_t*)jl_bottom_type) {
-        rt = getVoidTy(ctx.builder.getContext());
+        rt = getVoidTy(M->getContext());
         props.cc = jl_returninfo_t::Register;
     }
     else if (jl_is_structtype(jlrettype) && jl_is_datatype_singleton((jl_datatype_t*)jlrettype)) {
-        rt = getVoidTy(ctx.builder.getContext());
+        rt = getVoidTy(M->getContext());
         props.cc = jl_returninfo_t::Register;
     }
     else if (jl_is_uniontype(jlrettype)) {
@@ -8106,25 +8327,25 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, Value 
         union_alloca_type((jl_uniontype_t*)jlrettype, allunbox, props.union_bytes, props.union_align, props.union_minalign);
         if (props.union_bytes) {
             props.cc = jl_returninfo_t::Union;
-            Type *AT = ArrayType::get(getInt8Ty(ctx.builder.getContext()), props.union_bytes);
+            Type *AT = ArrayType::get(getInt8Ty(M->getContext()), props.union_bytes);
             fsig.push_back(AT->getPointerTo());
             argnames.push_back("union_bytes_return");
-            Type *pair[] = { ctx.types().T_prjlvalue, getInt8Ty(ctx.builder.getContext()) };
-            rt = StructType::get(ctx.builder.getContext(), ArrayRef<Type*>(pair));
+            Type *pair[] = { T_prjlvalue, getInt8Ty(M->getContext()) };
+            rt = StructType::get(M->getContext(), ArrayRef<Type*>(pair));
         }
         else if (allunbox) {
             props.cc = jl_returninfo_t::Ghosts;
-            rt = getInt8Ty(ctx.builder.getContext());
+            rt = getInt8Ty(M->getContext());
         }
         else {
-            rt = ctx.types().T_prjlvalue;
+            rt = T_prjlvalue;
         }
     }
     else if (!deserves_retbox(jlrettype)) {
         bool retboxed;
-        rt = julia_type_to_llvm(ctx, jlrettype, &retboxed);
+        rt = _julia_type_to_llvm(&params, M->getContext(), jlrettype, &retboxed);
         assert(!retboxed);
-        if (rt != getVoidTy(ctx.builder.getContext()) && deserves_sret(jlrettype, rt)) {
+        if (rt != getVoidTy(M->getContext()) && deserves_sret(jlrettype, rt)) {
             auto tracked = CountTrackedPointers(rt, true);
             assert(!tracked.derived);
             if (tracked.count && !tracked.all) {
@@ -8139,53 +8360,53 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, Value 
             fsig.push_back(rt->getPointerTo(M->getDataLayout().getAllocaAddrSpace()));
             argnames.push_back("sret_return");
             srt = rt;
-            rt = getVoidTy(ctx.builder.getContext());
+            rt = getVoidTy(M->getContext());
         }
         else {
             props.cc = jl_returninfo_t::Register;
         }
     }
     else {
-        rt = ctx.types().T_prjlvalue;
+        rt = T_prjlvalue;
     }
 
     SmallVector<AttributeSet, 8> attrs; // function declaration attributes
     if (props.cc == jl_returninfo_t::SRet) {
         assert(srt);
-        AttrBuilder param(ctx.builder.getContext());
+        AttrBuilder param(M->getContext());
         param.addStructRetAttr(srt);
         param.addAttribute(Attribute::NoAlias);
         param.addAttribute(Attribute::NoCapture);
         param.addAttribute(Attribute::NoUndef);
-        attrs.push_back(AttributeSet::get(ctx.builder.getContext(), param));
+        attrs.push_back(AttributeSet::get(M->getContext(), param));
         assert(fsig.size() == 1);
     }
     if (props.cc == jl_returninfo_t::Union) {
-        AttrBuilder param(ctx.builder.getContext());
+        AttrBuilder param(M->getContext());
         param.addAttribute(Attribute::NoAlias);
         param.addAttribute(Attribute::NoCapture);
         param.addAttribute(Attribute::NoUndef);
-        attrs.push_back(AttributeSet::get(ctx.builder.getContext(), param));
+        attrs.push_back(AttributeSet::get(M->getContext(), param));
         assert(fsig.size() == 1);
     }
 
     if (props.return_roots) {
-        AttrBuilder param(ctx.builder.getContext());
+        AttrBuilder param(M->getContext());
         param.addAttribute(Attribute::NoAlias);
         param.addAttribute(Attribute::NoCapture);
         param.addAttribute(Attribute::NoUndef);
-        attrs.push_back(AttributeSet::get(ctx.builder.getContext(), param));
-        fsig.push_back(ctx.types().T_ptr);
+        attrs.push_back(AttributeSet::get(M->getContext(), param));
+        fsig.push_back(getPointerTy(M->getContext()));
         argnames.push_back("return_roots");
     }
 
-    if (gcstack_arg){
-        AttrBuilder param(ctx.builder.getContext());
-        if (ctx.emission_context.use_swiftcc)
+    if (gcstack_arg) {
+        AttrBuilder param(M->getContext());
+        if (params.use_swiftcc)
             param.addAttribute(Attribute::SwiftSelf);
         param.addAttribute(Attribute::NonNull);
-        attrs.push_back(AttributeSet::get(ctx.builder.getContext(), param));
-        fsig.push_back(PointerType::get(JuliaType::get_ppjlvalue_ty(ctx.builder.getContext()), 0));
+        attrs.push_back(AttributeSet::get(M->getContext(), param));
+        fsig.push_back(PointerType::get(M->getContext(), 0));
         argnames.push_back("pgcstack_arg");
     }
 
@@ -8198,16 +8419,16 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, Value 
             if (is_uniquerep_Type(jt))
                 continue;
             isboxed = deserves_argbox(jt);
-            et = isboxed ? ctx.types().T_prjlvalue : julia_type_to_llvm(ctx, jt);
+            et = isboxed ? T_prjlvalue : _julia_type_to_llvm(&params, M->getContext(), jt, nullptr);
             if (type_is_ghost(et))
                 continue;
         }
-        AttrBuilder param(ctx.builder.getContext());
+        AttrBuilder param(M->getContext());
         Type *ty = et;
         if (et == nullptr || et->isAggregateType()) { // aggregate types are passed by pointer
             param.addAttribute(Attribute::NoCapture);
             param.addAttribute(Attribute::ReadOnly);
-            ty = ctx.builder.getPtrTy(AddressSpace::Derived);
+            ty = PointerType::get(M->getContext(), AddressSpace::Derived);
         }
         else if (isboxed && jl_is_immutable_datatype(jt)) {
             param.addAttribute(Attribute::ReadOnly);
@@ -8217,7 +8438,7 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, Value 
             Attribute::AttrKind attr = issigned ? Attribute::SExt : Attribute::ZExt;
             param.addAttribute(attr);
         }
-        attrs.push_back(AttributeSet::get(ctx.builder.getContext(), param));
+        attrs.push_back(AttributeSet::get(M->getContext(), param));
         fsig.push_back(ty);
         size_t argno = i < nreq ? i : nreq;
         std::string genname;
@@ -8233,8 +8454,8 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, Value 
         if (et && et->isAggregateType()) {
             auto tracked = CountTrackedPointers(et);
             if (tracked.count && !tracked.all) {
-                attrs.push_back(AttributeSet::get(ctx.builder.getContext(), param));
-                fsig.push_back(ctx.builder.getPtrTy(M->getDataLayout().getAllocaAddrSpace()));
+                attrs.push_back(AttributeSet::get(M->getContext(), param));
+                fsig.push_back(PointerType::get(M->getContext(), M->getDataLayout().getAllocaAddrSpace()));
                 if (!genname.empty())
                     argnames.push_back((Twine(".roots.") + genname).str());
             }
@@ -8244,25 +8465,26 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, Value 
     AttributeSet FnAttrs;
     AttributeSet RetAttrs;
     if (jlrettype == (jl_value_t*)jl_bottom_type)
-        FnAttrs = FnAttrs.addAttribute(ctx.builder.getContext(), Attribute::NoReturn);
-    else if (rt == ctx.types().T_prjlvalue)
-        RetAttrs = RetAttrs.addAttribute(ctx.builder.getContext(), Attribute::NonNull);
-    AttributeList attributes = AttributeList::get(ctx.builder.getContext(), FnAttrs, RetAttrs, attrs);
+        FnAttrs = FnAttrs.addAttribute(M->getContext(), Attribute::NoReturn);
+    else if (rt == T_prjlvalue)
+        RetAttrs = RetAttrs.addAttribute(M->getContext(), Attribute::NonNull);
+    AttributeList attributes = AttributeList::get(M->getContext(), FnAttrs, RetAttrs, attrs);
 
     FunctionType *ftype = FunctionType::get(rt, fsig, false);
     if (fval == NULL) {
         Function *f = M ? cast_or_null<Function>(M->getNamedValue(name)) : NULL;
         if (f == NULL) {
             f = Function::Create(ftype, GlobalVariable::ExternalLinkage, name, M);
-            jl_init_function(f, ctx.emission_context.TargetTriple);
-            if (ctx.emission_context.params->debug_info_level >= 2) {
+            jl_init_function(f, params.TargetTriple);
+            if (params.params->debug_info_level >= 2) {
                 ios_t sigbuf;
                 ios_mem(&sigbuf, 0);
                 jl_static_show_func_sig((JL_STREAM*) &sigbuf, sig);
-                f->setAttributes(AttributeList::get(f->getContext(), {attributes.addFnAttribute(ctx.builder.getContext(),"julia.fsig", StringRef(sigbuf.buf, sigbuf.size)), f->getAttributes()}));
+                f->setAttributes(AttributeList::get(f->getContext(), {attributes.addFnAttribute(M->getContext(),"julia.fsig", StringRef(sigbuf.buf, sigbuf.size)), f->getAttributes()}));
                 ios_close(&sigbuf);
-            } else
+            } else {
                 f->setAttributes(AttributeList::get(f->getContext(), {attributes, f->getAttributes()}));
+            }
         }
         else {
             assert(f->getFunctionType() == ftype);
@@ -8270,11 +8492,10 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, Value 
         fval = f;
     }
     else {
-        if (fval->getType()->isIntegerTy())
-            fval = emit_inttoptr(ctx, fval, ftype->getPointerTo());
+        assert(fval->getType()->isPointerTy());
     }
     if (auto F = dyn_cast<Function>(fval)) {
-        if (gcstack_arg && ctx.emission_context.use_swiftcc)
+        if (gcstack_arg && params.use_swiftcc)
             F->setCallingConv(CallingConv::Swift);
         assert(F->arg_size() >= argnames.size());
         for (size_t i = 0; i < argnames.size(); i++) {
@@ -8319,25 +8540,6 @@ static jl_datatype_t *compute_va_type(jl_value_t *sig, size_t nreq)
     jl_value_t *typ = jl_apply_tuple_type(tupargs, 1);
     JL_GC_POP();
     return (jl_datatype_t*)typ;
-}
-
-static std::string get_function_name(bool specsig, bool needsparams, const char *unadorned_name, const Triple &TargetTriple)
-{
-    std::string _funcName;
-    raw_string_ostream funcName(_funcName);
-    // try to avoid conflicts in the global symbol table
-    if (specsig)
-        funcName << "julia_"; // api 5
-    else if (needsparams)
-        funcName << "japi3_";
-    else
-        funcName << "japi1_";
-    if (TargetTriple.isOSLinux()) {
-        if (unadorned_name[0] == '@')
-            unadorned_name++;
-    }
-    funcName << unadorned_name << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
-    return funcName.str();
 }
 
 // Compile to LLVM IR, using a specialized signature if applicable.
@@ -8555,8 +8757,8 @@ static jl_llvm_functions_t
                     ArgNames[i] = name;
             }
         }
-        returninfo = get_specsig_function(ctx, M, NULL, declarations.specFunctionObject, abi,
-                                          jlrettype, ctx.is_opaque_closure, JL_FEAT_TEST(ctx,gcstack_arg),
+        returninfo = get_specsig_function(params, M, NULL, declarations.specFunctionObject, abi,
+                                          jlrettype, ctx.is_opaque_closure,
                                           ArgNames, nreq);
         f = cast<Function>(returninfo.decl.getCallee());
         has_sret = (returninfo.cc == jl_returninfo_t::SRet || returninfo.cc == jl_returninfo_t::Union);
@@ -8590,7 +8792,7 @@ static jl_llvm_functions_t
         raw_string_ostream(wrapName) << "jfptr_" << ctx.name << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
         declarations.functionObject = wrapName;
         size_t nparams = jl_nparams(abi);
-        gen_invoke_wrapper(lam, abi, jlrettype, returninfo, nparams, retarg, ctx.is_opaque_closure, declarations.functionObject, M, ctx.emission_context);
+        gen_invoke_wrapper(lam, abi, jlrettype, jlrettype, returninfo, nparams, retarg, ctx.is_opaque_closure, declarations.functionObject, M, ctx.emission_context);
         // TODO: add attributes: maybe_mark_argument_dereferenceable(Arg, argType)
         // TODO: add attributes: dereferenceable<sizeof(void*) * nreq>
         // TODO: (if needsparams) add attributes: dereferenceable<sizeof(void*) * length(sp)>, readonly, nocapture
@@ -9958,6 +10160,39 @@ static jl_llvm_functions_t
 
 // --- entry point ---
 
+jl_llvm_functions_t jl_emit_codedecls(
+        orc::ThreadSafeModule &M,
+        jl_code_instance_t *codeinst,
+        jl_codegen_params_t &params)
+{
+    jl_llvm_functions_t decls = {};
+    jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
+    bool specsig, needsparams;
+    std::tie(specsig, needsparams) = uses_specsig(get_ci_abi(codeinst), mi, codeinst->rettype, params.params->prefer_specsig);
+    const char *name = name_from_method_instance(mi);
+    if (specsig)
+        raw_string_ostream(decls.functionObject) << "jfptr_" << name << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
+    else if (needsparams)
+        decls.functionObject = "jl_fptr_sparam";
+    else
+        decls.functionObject = "jl_fptr_args";
+    raw_string_ostream(decls.specFunctionObject) << (specsig ? "j_" : "j1_") << name << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
+    M.withModuleDo([&](Module &M) {
+            bool is_opaque_closure = jl_is_method(mi->def.value) && mi->def.method->is_for_opaque_closure;
+            if (specsig) {
+                get_specsig_function(params, &M, nullptr, decls.specFunctionObject, get_ci_abi(codeinst), codeinst->rettype, is_opaque_closure);
+            }
+            else {
+                Function *f = Function::Create(needsparams ? JuliaType::get_jlfuncparams_ty(M.getContext()) : JuliaType::get_jlfunc_ty(M.getContext()),
+                                     GlobalVariable::ExternalLinkage,
+                                     decls.specFunctionObject, M);
+                jl_init_function(f, params.TargetTriple);
+                f->setAttributes(AttributeList::get(M.getContext(), {get_func_attrs(M.getContext()), f->getAttributes()}));
+            }
+        });
+    return decls;
+}
+
 jl_llvm_functions_t jl_emit_code(
         orc::ThreadSafeModule &m,
         jl_method_instance_t *li,
@@ -10012,7 +10247,7 @@ static jl_llvm_functions_t jl_emit_oc_wrapper(orc::ThreadSafeModule &m, jl_codeg
         jl_codectx_t ctx(M->getContext(), params, 0, 0);
         ctx.name = M->getModuleIdentifier().data();
         std::string funcName = get_function_name(true, false, ctx.name, ctx.emission_context.TargetTriple);
-        jl_returninfo_t returninfo = get_specsig_function(ctx, M, NULL, funcName, mi->specTypes, rettype, true, JL_FEAT_TEST(ctx,gcstack_arg));
+        jl_returninfo_t returninfo = get_specsig_function(params, M, NULL, funcName, mi->specTypes, rettype, true);
         Function *gf_thunk = cast<Function>(returninfo.decl.getCallee());
         jl_init_function(gf_thunk, ctx.emission_context.TargetTriple);
         size_t nrealargs = jl_nparams(mi->specTypes);
@@ -10032,8 +10267,8 @@ jl_llvm_functions_t jl_emit_codeinst(
 {
     JL_TIMING(CODEGEN, CODEGEN_Codeinst);
     jl_timing_show_method_instance(jl_get_ci_mi(codeinst), JL_TIMING_DEFAULT_BLOCK);
+    jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
     if (!src) {
-        jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
         // Assert that this this is the generic method for opaque closure wrappers:
         // this signals to instead compile specptr such that it holds the specptr -> invoke wrapper
         // to satisfy the dispatching implementation requirements of jl_f_opaque_closure_call
@@ -10044,7 +10279,7 @@ jl_llvm_functions_t jl_emit_codeinst(
         return jl_llvm_functions_t(); // user error
     }
     //assert(jl_egal((jl_value_t*)jl_atomic_load_relaxed(&codeinst->debuginfo), (jl_value_t*)src->debuginfo) && "trying to generate code for a codeinst for an incompatible src");
-    jl_llvm_functions_t decls = jl_emit_code(m, jl_get_ci_mi(codeinst), src, get_ci_abi(codeinst), codeinst->rettype, params);
+    jl_llvm_functions_t decls = jl_emit_code(m, mi, src, get_ci_abi(codeinst), codeinst->rettype, params);
     return decls;
 }
 
@@ -10152,6 +10387,7 @@ static void init_jit_functions(void)
     add_named_global(jlunlockvalue_func, &jl_unlock_value);
     add_named_global(jllockfield_func, &jl_lock_field);
     add_named_global(jlunlockfield_func, &jl_unlock_field);
+    add_named_global(jlgetabiconverter_func, &jl_get_abi_converter);
 
 #ifdef _OS_WINDOWS_
 #if defined(_CPU_X86_64_)

--- a/src/gf.c
+++ b/src/gf.c
@@ -3165,6 +3165,7 @@ jl_method_instance_t *jl_normalize_to_compilable_mi(jl_method_instance_t *mi JL_
 JL_DLLEXPORT jl_method_instance_t *jl_method_match_to_mi(jl_method_match_t *match, size_t world, size_t min_valid, size_t max_valid, int mt_cache)
 {
     jl_method_t *m = match->method;
+    JL_GC_PROMISE_ROOTED(m);
     jl_svec_t *env = match->sparams;
     jl_tupletype_t *ti = match->spec_types;
     jl_method_instance_t *mi = NULL;
@@ -3200,7 +3201,7 @@ JL_DLLEXPORT jl_method_instance_t *jl_method_match_to_mi(jl_method_match_t *matc
 }
 
 // compile-time method lookup
-jl_method_instance_t *jl_get_specialization1(jl_tupletype_t *types JL_PROPAGATES_ROOT, size_t world, int mt_cache)
+jl_method_instance_t *jl_get_specialization1(jl_tupletype_t *types, size_t world, int mt_cache)
 {
     if (jl_has_free_typevars((jl_value_t*)types))
         return NULL; // don't poison the cache due to a malformed query

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -454,6 +454,7 @@ static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, jl_va
     Constant *c = x.constant ? julia_const_to_llvm(ctx, x.constant) : nullptr;
     if ((x.inline_roots.empty() && !x.ispointer()) || c != nullptr) { // already unboxed, but sometimes need conversion
         Value *unboxed = c ? c : x.V;
+        assert(unboxed); // clang-sa doesn't know that !x.ispointer() implies x.V does have a value
         return emit_unboxed_coercion(ctx, to, unboxed);
     }
 
@@ -461,6 +462,7 @@ static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, jl_va
     Value *p = x.constant ? literal_pointer_val(ctx, x.constant) : x.V;
 
     if (jt == (jl_value_t*)jl_bool_type || to->isIntegerTy(1)) {
+        assert(p && x.inline_roots.empty()); // clang-sa doesn't know that x.ispointer() implied these are true
         jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, x.tbaa);
         Instruction *unbox_load = ai.decorateInst(ctx.builder.CreateLoad(getInt8Ty(ctx.builder.getContext()), p));
         setName(ctx.emission_context, unbox_load, p->getName() + ".unbox");
@@ -486,6 +488,7 @@ static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, jl_va
         p = combined;
         ai = combined_ai;
     }
+    assert(p); // clang-sa doesn't know that x.ispointer() implied this is true
     Instruction *load = ctx.builder.CreateAlignedLoad(to, p, Align(alignment));
     setName(ctx.emission_context, load, p->getName() + ".unbox");
     return ai.decorateInst(load);

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -213,12 +213,83 @@ static void jl_optimize_roots(jl_codegen_params_t &params, jl_method_instance_t 
         JL_UNLOCK(&m->writelock);
 }
 
-void jl_jit_globals(std::map<void *, GlobalVariable*> &globals) JL_NOTSAFEPOINT
+static void finish_params(Module *M, jl_codegen_params_t &params, SmallVector<orc::ThreadSafeModule,0> &sharedmodules) JL_NOTSAFEPOINT
 {
-    for (auto &global : globals) {
-        jl_link_global(global.second, global.first);
+    if (params._shared_module) {
+        sharedmodules.push_back(orc::ThreadSafeModule(std::move(params._shared_module), params.tsctx));
+    }
+
+    // In imaging mode, we can't inline global variable initializers in order to preserve
+    // the fiction that we don't know what loads from the global will return. Thus, we
+    // need to emit a separate module for the globals before any functions are compiled,
+    // to ensure that the globals are defined when they are compiled.
+    if (jl_options.image_codegen) {
+        if (!params.global_targets.empty()) {
+            void **globalslots = new void*[params.global_targets.size()];
+            void **slot = globalslots;
+            for (auto &global : params.global_targets) {
+                auto GV = global.second;
+                *slot = global.first;
+                jl_ExecutionEngine->addGlobalMapping(GV->getName(), (uintptr_t)slot);
+                slot++;
+            }
+#ifdef __clang_analyzer__
+            static void **leaker = globalslots; // for the purpose of the analyzer, we need to expressly leak this variable or it thinks we forgot to free it
+#endif
+        }
+    }
+    else {
+        StringMap<void*> NewGlobals;
+        for (auto &global : params.global_targets) {
+            NewGlobals[global.second->getName()] = global.first;
+        }
+        for (auto &GV : M->globals()) {
+            auto InitValue = NewGlobals.find(GV.getName());
+            if (InitValue != NewGlobals.end()) {
+                jl_link_global(&GV, InitValue->second);
+            }
+        }
     }
 }
+
+extern "C" JL_DLLEXPORT_CODEGEN
+void *jl_jit_abi_converter_impl(jl_task_t *ct, void *unspecialized, jl_value_t *declrt, jl_value_t *sigt, size_t nargs, int specsig,
+                                jl_code_instance_t *codeinst, jl_callptr_t invoke, void *target, int target_specsig)
+{
+    if (codeinst == nullptr && unspecialized != nullptr)
+        return unspecialized;
+    orc::ThreadSafeModule result_m;
+    std::string gf_thunk_name;
+    {
+        jl_codegen_params_t params(std::make_unique<LLVMContext>(), jl_ExecutionEngine->getDataLayout(), jl_ExecutionEngine->getTargetTriple()); // Locks the context
+        params.getContext().setDiscardValueNames(true);
+        params.cache = true;
+        params.imaging_mode = 0;
+        result_m = jl_create_ts_module("gfthunk", params.tsctx, params.DL, params.TargetTriple);
+        Module *M = result_m.getModuleUnlocked();
+        if (target) {
+            Value *llvmtarget = literal_static_pointer_val((void*)target, PointerType::get(M->getContext(), 0));
+            gf_thunk_name = emit_abi_converter(M, params, declrt, sigt, nargs, specsig, codeinst, llvmtarget, target_specsig);
+        }
+        else if (invoke == jl_fptr_const_return_addr) {
+            gf_thunk_name = emit_abi_constreturn(M, params, declrt, sigt, nargs, specsig, codeinst->rettype_const);
+        }
+        else {
+            Value *llvminvoke = invoke ? literal_static_pointer_val((void*)invoke, PointerType::get(M->getContext(), 0)) : nullptr;
+            gf_thunk_name = emit_abi_dispatcher(M, params, declrt, sigt, nargs, specsig, codeinst, llvminvoke);
+        }
+        SmallVector<orc::ThreadSafeModule,0> sharedmodules;
+        finish_params(M, params, sharedmodules);
+        assert(sharedmodules.empty());
+    }
+    int8_t gc_state = jl_gc_safe_enter(ct->ptls);
+    jl_ExecutionEngine->addModule(std::move(result_m));
+    uintptr_t Addr = jl_ExecutionEngine->getFunctionAddress(gf_thunk_name);
+    jl_gc_safe_leave(ct->ptls, gc_state);
+    assert(Addr);
+    return (void*)Addr;
+}
+
 
   // lock for places where only single threaded behavior is implemented, so we need GC support
 static jl_mutex_t jitlock;
@@ -261,45 +332,6 @@ static DenseMap<jl_code_instance_t*, SmallVector<jl_code_instance_t*,0>> incompl
 //     However, this guarantee relies on Julia releasing all TSC locks before causing any materialization units to be dispatched
 //     as materialization may need to acquire TSC locks.
 
-
-static void finish_params(Module *M, jl_codegen_params_t &params) JL_NOTSAFEPOINT
-{
-    if (params._shared_module) {
-        sharedmodules.push_back(orc::ThreadSafeModule(std::move(params._shared_module), params.tsctx));
-    }
-
-    // In imaging mode, we can't inline global variable initializers in order to preserve
-    // the fiction that we don't know what loads from the global will return. Thus, we
-    // need to emit a separate module for the globals before any functions are compiled,
-    // to ensure that the globals are defined when they are compiled.
-    if (jl_options.image_codegen) {
-        if (!params.global_targets.empty()) {
-            void **globalslots = new void*[params.global_targets.size()];
-            void **slot = globalslots;
-            for (auto &global : params.global_targets) {
-                auto GV = global.second;
-                *slot = global.first;
-                jl_ExecutionEngine->addGlobalMapping(GV->getName(), (uintptr_t)slot);
-                slot++;
-            }
-#ifdef __clang_analyzer__
-            static void **leaker = globalslots; // for the purpose of the analyzer, we need to expressly leak this variable or it thinks we forgot to free it
-#endif
-        }
-    }
-    else {
-        StringMap<void*> NewGlobals;
-        for (auto &global : params.global_targets) {
-            NewGlobals[global.second->getName()] = global.first;
-        }
-        for (auto &GV : M->globals()) {
-            auto InitValue = NewGlobals.find(GV.getName());
-            if (InitValue != NewGlobals.end()) {
-                jl_link_global(&GV, InitValue->second);
-            }
-        }
-    }
-}
 
 static int jl_analyze_workqueue(jl_code_instance_t *callee, jl_codegen_params_t &params, bool forceall=false) JL_NOTSAFEPOINT_LEAVE JL_NOTSAFEPOINT_ENTER
 {
@@ -516,7 +548,7 @@ static void prepare_compile(jl_code_instance_t *codeinst) JL_NOTSAFEPOINT_LEAVE 
             waiting = jl_analyze_workqueue(codeinst, params, true); // may safepoint
             assert(!waiting); (void)waiting;
             Module *M = emittedmodules[codeinst].getModuleUnlocked();
-            finish_params(M, params);
+            finish_params(M, params, sharedmodules);
             incompletemodules.erase(it);
         }
         // and then indicate this should be compiled now
@@ -548,7 +580,7 @@ static void complete_emit(jl_code_instance_t *edge) JL_NOTSAFEPOINT_LEAVE JL_NOT
             int waiting = jl_analyze_workqueue(callee, params); // may safepoint
             assert(!waiting); (void)waiting;
             Module *M = emittedmodules[callee].getModuleUnlocked();
-            finish_params(M, params);
+            finish_params(M, params, sharedmodules);
             incompletemodules.erase(it);
         }
     }
@@ -764,7 +796,7 @@ void jl_emit_codeinst_to_jit_impl(
         incompletemodules.try_emplace(codeinst, std::move(params), waiting);
     }
     else {
-        finish_params(result_m.getModuleUnlocked(), params);
+        finish_params(result_m.getModuleUnlocked(), params, sharedmodules);
     }
     emittedmodules[codeinst] = std::move(result_m);
 }
@@ -832,7 +864,7 @@ int jl_compile_extern_c_impl(LLVMOrcThreadSafeModuleRef llvmmod, void *p, void *
                 }
                 jl_analyze_workqueue(nullptr, params, true);
                 assert(params.workqueue.empty());
-                finish_params(&M, params);
+                finish_params(&M, params, sharedmodules);
             }
         }
         pparams = nullptr;

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -547,6 +547,7 @@
     YY(jl_getUnwindInfo) \
     YY(jl_get_libllvm) \
     YY(jl_register_passbuilder_callbacks) \
+    YY(jl_jit_abi_converter) \
     YY(JLJITGetLLVMOrcExecutionSession) \
     YY(JLJITGetJuliaOJIT) \
     YY(JLJITGetExternalJITDylib) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1229,15 +1229,15 @@ _Atomic(jl_value_t*) *jl_table_peek_bp(jl_genericmemory_t *a, jl_value_t *key) J
 JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t*);
 
 JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *module);
-JL_DLLEXPORT jl_method_instance_t *jl_get_specialization1(jl_tupletype_t *types, size_t world, int mt_cache);
-jl_method_instance_t *jl_get_specialized(jl_method_t *m, jl_value_t *types, jl_svec_t *sp);
+JL_DLLEXPORT jl_method_instance_t *jl_get_specialization1(jl_tupletype_t *types JL_PROPAGATES_ROOT, size_t world, int mt_cache);
+jl_method_instance_t *jl_get_specialized(jl_method_t *m, jl_value_t *types, jl_svec_t *sp) JL_PROPAGATES_ROOT;
 JL_DLLEXPORT jl_value_t *jl_rettype_inferred(jl_value_t *owner, jl_method_instance_t *li JL_PROPAGATES_ROOT, size_t min_world, size_t max_world);
 JL_DLLEXPORT jl_value_t *jl_rettype_inferred_native(jl_method_instance_t *mi, size_t min_world, size_t max_world) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_code_instance_t *jl_method_compiled(jl_method_instance_t *mi JL_PROPAGATES_ROOT, size_t world) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_methtable_t *mt JL_PROPAGATES_ROOT, jl_value_t *type, size_t world);
 JL_DLLEXPORT jl_method_instance_t *jl_specializations_get_linfo(
     jl_method_t *m JL_PROPAGATES_ROOT, jl_value_t *type, jl_svec_t *sparams);
-jl_method_instance_t *jl_specializations_get_or_insert(jl_method_instance_t *mi_ins);
+jl_method_instance_t *jl_specializations_get_or_insert(jl_method_instance_t *mi_ins JL_PROPAGATES_ROOT);
 JL_DLLEXPORT void jl_method_instance_add_backedge(jl_method_instance_t *callee, jl_value_t *invokesig, jl_code_instance_t *caller);
 JL_DLLEXPORT void jl_method_table_add_backedge(jl_methtable_t *mt, jl_value_t *typ, jl_code_instance_t *caller);
 JL_DLLEXPORT void jl_mi_cache_insert(jl_method_instance_t *mi JL_ROOTING_ARGUMENT,
@@ -1557,6 +1557,9 @@ JL_DLLEXPORT jl_value_t *jl_get_cfunction_trampoline(
     jl_value_t *fobj, jl_datatype_t *result, htable_t *cache, jl_svec_t *fill,
     void *(*init_trampoline)(void *tramp, void **nval),
     jl_unionall_t *env, jl_value_t **vals);
+JL_DLLEXPORT void *jl_get_abi_converter(jl_task_t *ct, _Atomic(void*) *fptr, _Atomic(size_t) *last_world, void *data);
+JL_DLLIMPORT void *jl_jit_abi_converter(jl_task_t *ct, void *unspecialized, jl_value_t *declrt, jl_value_t *sigt, size_t nargs, int specsig,
+    jl_code_instance_t *codeinst, jl_callptr_t invoke, void *target, int target_specsig);
 
 
 // Special filenames used to refer to internal julia libraries

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -326,6 +326,136 @@ jl_value_t *jl_get_cfunction_trampoline(
 }
 JL_GCC_IGNORE_STOP
 
+struct cfuncdata_t {
+    jl_code_instance_t** plast_codeinst;
+    jl_code_instance_t* last_codeinst;
+    void *unspecialized;
+    jl_value_t *const *const declrt;
+    jl_value_t *const *const sigt;
+    size_t flags;
+};
+
+extern "C" JL_DLLEXPORT
+void *jl_jit_abi_converter_fallback(jl_task_t *ct, void *unspecialized, jl_value_t *declrt, jl_value_t *sigt, size_t nargs, int specsig,
+                                    jl_code_instance_t *codeinst, jl_callptr_t invoke, void *target, int target_specsig)
+{
+    if (unspecialized)
+        return unspecialized;
+    jl_errorf("cfunction not available in this build of Julia");
+}
+
+static const inline char *name_from_method_instance(jl_method_instance_t *li) JL_NOTSAFEPOINT
+{
+    return jl_is_method(li->def.method) ? jl_symbol_name(li->def.method->name) : "top-level scope";
+}
+
+static jl_mutex_t cfun_lock;
+// release jl_world_counter
+// store theFptr
+// release last_world_v
+//
+// acquire last_world_v
+// read theFptr
+// acquire jl_world_counter
+extern "C" JL_DLLEXPORT
+void *jl_get_abi_converter(jl_task_t *ct, _Atomic(void*) *fptr, _Atomic(size_t) *last_world, void *data)
+{
+    cfuncdata_t *cfuncdata = (cfuncdata_t*)data;
+    jl_value_t *sigt = *cfuncdata->sigt;
+    JL_GC_PROMISE_ROOTED(sigt);
+    jl_value_t *declrt = *cfuncdata->declrt;
+    JL_GC_PROMISE_ROOTED(declrt);
+    bool specsig = cfuncdata->flags & 1;
+    size_t nargs = jl_nparams(sigt);
+    jl_method_instance_t *mi;
+    jl_code_instance_t *codeinst;
+    size_t world;
+    // check first, while behind this lock, of the validity of the current contents of this cfunc thunk
+    JL_LOCK(&cfun_lock);
+    do {
+        size_t last_world_v = jl_atomic_load_relaxed(last_world);
+        void *f = jl_atomic_load_relaxed(fptr);
+        jl_code_instance_t *last_ci = cfuncdata->plast_codeinst ? *cfuncdata->plast_codeinst : nullptr;
+        world = jl_atomic_load_acquire(&jl_world_counter);
+        ct->world_age = world;
+        if (world == last_world_v) {
+            JL_UNLOCK(&cfun_lock);
+            return f;
+        }
+        mi = jl_get_specialization1((jl_tupletype_t*)sigt, world, 0);
+        if (f != nullptr) {
+            if (last_ci == nullptr) {
+                if (mi == nullptr) {
+                    jl_atomic_store_release(last_world, world);
+                    JL_UNLOCK(&cfun_lock);
+                    return f;
+                }
+            }
+            else {
+                if (jl_get_ci_mi(last_ci) == mi && jl_atomic_load_relaxed(&last_ci->max_world) >= world) { // same dispatch and source
+                    jl_atomic_store_release(last_world, world);
+                    JL_UNLOCK(&cfun_lock);
+                    return f;
+                }
+            }
+        }
+        JL_UNLOCK(&cfun_lock);
+        // next, try to figure out what the target should look like (outside of the lock since this is very slow)
+        codeinst = mi ? jl_type_infer(mi, world, SOURCE_MODE_ABI) : nullptr;
+        // relock for the remainder of the function
+        JL_LOCK(&cfun_lock);
+    } while (jl_atomic_load_acquire(&jl_world_counter) != world); // restart entirely, since jl_world_counter changed thus jl_get_specialization1 might have changed
+    // double-check if the values were set on another thread
+    size_t last_world_v = jl_atomic_load_relaxed(last_world);
+    void *f = jl_atomic_load_relaxed(fptr);
+    if (world == last_world_v) {
+        JL_UNLOCK(&cfun_lock);
+        return f; // another thread fixed this up while we were away
+    }
+    auto assign_fptr = [fptr, last_world, cfuncdata, world, codeinst](void *f) {
+        cfuncdata->plast_codeinst = &cfuncdata->last_codeinst;
+        cfuncdata->last_codeinst = codeinst;
+        jl_atomic_store_relaxed(fptr, f);
+        jl_atomic_store_release(last_world, world);
+        JL_UNLOCK(&cfun_lock);
+        return f;
+    };
+    jl_callptr_t invoke = nullptr;
+    if (codeinst != NULL) {
+        jl_value_t *astrt = codeinst->rettype;
+        if (astrt != (jl_value_t*)jl_bottom_type &&
+            jl_type_intersection(astrt, declrt) == jl_bottom_type) {
+            // Do not warn if the function never returns since it is
+            // occasionally required by the C API (typically error callbacks)
+            // even though we're likely to encounter memory errors in that case
+            jl_printf(JL_STDERR, "WARNING: cfunction: return type of %s does not match\n", name_from_method_instance(mi));
+        }
+        uint8_t specsigflags;
+        jl_read_codeinst_invoke(codeinst, &specsigflags, &invoke, &f, 1);
+        if (invoke != nullptr) {
+            if (invoke == jl_fptr_const_return_addr) {
+                return assign_fptr(jl_jit_abi_converter(ct, cfuncdata->unspecialized, declrt, sigt, nargs, specsig, codeinst, invoke, nullptr, false));
+            }
+            else if (invoke == jl_fptr_args_addr) {
+                assert(f);
+                if (!specsig && jl_subtype(astrt, declrt))
+                    return assign_fptr(f);
+                return assign_fptr(jl_jit_abi_converter(ct, cfuncdata->unspecialized, declrt, sigt, nargs, specsig, codeinst, invoke, f, false));
+            }
+            else if (specsigflags & 0b1) {
+                assert(f);
+                if (specsig && jl_egal(mi->specTypes, sigt) && jl_egal(declrt, astrt))
+                    return assign_fptr(f);
+                return assign_fptr(jl_jit_abi_converter(ct, cfuncdata->unspecialized, declrt, sigt, nargs, specsig, codeinst, invoke, f, true));
+            }
+        }
+    }
+    f = jl_jit_abi_converter(ct, cfuncdata->unspecialized, declrt, sigt, nargs, specsig, codeinst, invoke, nullptr, false);
+    if (codeinst == nullptr)
+        cfuncdata->unspecialized = f;
+    return assign_fptr(f);
+}
+
 void jl_init_runtime_ccall(void)
 {
     JL_MUTEX_INIT(&libmap_lock, "libmap_lock");

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1859,6 +1859,9 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
                                 else if (invokeptr_id == -4) {
                                     fptr_id = JL_API_OC_CALL;
                                 }
+                                else if (invokeptr_id == -5) {
+                                    abort();
+                                }
                                 else {
                                     assert(invokeptr_id > 0);
                                     ios_ensureroom(s->fptr_record, invokeptr_id * sizeof(void*));


### PR DESCRIPTION
This implements several sources of bugfixes and improvements:
 - direct edges are correctly represented
 - performance does not degrade when edges trigger
 - the JIT does not call `jl_infer_type` until actually required
 - constant return can handle invalidation and emitting efficient code

This generates the code for the exact signature specified by the user, instead of using `jl_infer_type` to compute a different signature which previously might cause unnecessary boxing and previously introduced unstable performance characteristics. This lets us defer generating the actual thunk required at runtime with the JIT when the required information is already available, and also to validate that information is still correct, and regenerate it when not correct anymore.