### PR TITLE
staticdata: Close data race after backedge insertion

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -4265,6 +4265,34 @@ JL_DLLEXPORT jl_value_t *jl_restore_package_image_from_file(const char *fname, j
     return mod;
 }
 
+JL_DLLEXPORT void _jl_promote_ci_to_current(jl_code_instance_t *ci, size_t validated_world) JL_NOTSAFEPOINT
+{
+    if (jl_atomic_load_relaxed(&ci->max_world) != validated_world)
+        return;
+    jl_atomic_store_relaxed(&ci->max_world, (size_t)-1);
+    jl_svec_t *edges = jl_atomic_load_relaxed(&ci->edges);
+    for (size_t i = 0; i < jl_svec_len(edges); i++) {
+        jl_value_t *edge = jl_svecref(edges, i);
+        if (!jl_is_code_instance(edge))
+            continue;
+        _jl_promote_ci_to_current(ci, validated_world);
+    }
+}
+
+JL_DLLEXPORT void jl_promote_ci_to_current(jl_code_instance_t *ci, size_t validated_world)
+{
+    size_t current_world = jl_atomic_load_relaxed(&jl_world_counter);
+    // No need to acquire the lock if we've been invalidated anyway
+    if (current_world > validated_world)
+        return;
+    JL_LOCK(&world_counter_lock);
+    current_world = jl_atomic_load_relaxed(&jl_world_counter);
+    if (current_world == validated_world) {
+        _jl_promote_ci_to_current(ci, validated_world);
+    }
+    JL_UNLOCK(&world_counter_lock);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -4269,7 +4269,7 @@ JL_DLLEXPORT void _jl_promote_ci_to_current(jl_code_instance_t *ci, size_t valid
 {
     if (jl_atomic_load_relaxed(&ci->max_world) != validated_world)
         return;
-    jl_atomic_store_relaxed(&ci->max_world, (size_t)-1);
+    jl_atomic_store_relaxed(&ci->max_world, ~(size_t)0);
     jl_svec_t *edges = jl_atomic_load_relaxed(&ci->edges);
     for (size_t i = 0; i < jl_svec_len(edges); i++) {
         jl_value_t *edge = jl_svecref(edges, i);


### PR DESCRIPTION
Addresses review comment in https://github.com/JuliaLang/julia/pull/57212#discussion_r1937694448. The key is that the hand-off of responsibility for verification between the loading code and the ordinary backedge mechanism happens under the world counter lock to ensure synchronization.