### PR TITLE
Handle `waitpid` race condition when `SIGCHLD` is set to `SIG_IGN`

### DIFF
--- a/test/embedding/Makefile
+++ b/test/embedding/Makefile
@@ -21,6 +21,7 @@ EXE := $(suffix $(abspath $(JULIA)))
 
 # get compiler and linker flags. (see: `contrib/julia-config.jl`)
 JULIA_CONFIG := $(JULIA) -e 'include(joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "julia-config.jl"))' --
+JULIA_LIBDIR := $(shell $(JULIA) -e 'println(joinpath(Sys.BINDIR, "..", "lib"))' --)
 CPPFLAGS_ADD :=
 CFLAGS_ADD = $(shell $(JULIA_CONFIG) --cflags)
 LDFLAGS_ADD = -lm $(shell $(JULIA_CONFIG) --ldflags --ldlibs)
@@ -29,14 +30,20 @@ DEBUGFLAGS += -g
 
 #=============================================================================
 
-release: $(BIN)/embedding$(EXE)
-debug:   $(BIN)/embedding-debug$(EXE)
+release: $(BIN)/embedding$(EXE) $(BIN)/libdl-embedding$(EXE)
+debug:   $(BIN)/embedding-debug$(EXE) $(BIN)/libdl-embedding$(EXE)
 
 $(BIN)/embedding$(EXE): $(SRCDIR)/embedding.c
 	$(CC) $^ -o $@ $(CPPFLAGS_ADD) $(CPPFLAGS) $(CFLAGS_ADD) $(CFLAGS) $(LDFLAGS_ADD) $(LDFLAGS)
 
 $(BIN)/embedding-debug$(EXE): $(SRCDIR)/embedding.c
 	$(CC) $^ -o $@ $(CPPFLAGS_ADD) $(CPPFLAGS) $(CFLAGS_ADD) $(CFLAGS) $(LDFLAGS_ADD) $(LDFLAGS) $(DEBUGFLAGS)
+
+$(BIN)/libdl-embedding$(EXE): $(SRCDIR)/libdl_embedding.c
+	$(CC) $^ -o $@ $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -ldl -DLIBJULIA_PATH=\"$(JULIA_LIBDIR)/libjulia.so\"
+
+$(BIN)/libdl-embedding-debug$(EXE): $(SRCDIR)/libdl_embedding.c
+	$(CC) $^ -o $@ $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(DEBUGFLAGS) -ldl -DLIBJULIA_PATH=\"$(JULIA_LIBDIR)/libjulia.so\"
 
 ifneq ($(abspath $(BIN)),$(abspath $(SRCDIR)))
 # for demonstration purposes, our demo code is also installed
@@ -45,7 +52,8 @@ $(BIN)/LocalModule.jl: $(SRCDIR)/LocalModule.jl
 	cp $< $@
 endif
 
-check: $(BIN)/embedding$(EXE) $(BIN)/LocalModule.jl
+check: $(BIN)/embedding$(EXE) $(BIN)/libdl-embedding$(EXE) $(BIN)/LocalModule.jl
+	$(BIN)/libdl-embedding$(EXE) # run w/o error
 	$(JULIA) --depwarn=error $(SRCDIR)/embedding-test.jl $<
 	@echo SUCCESS
 

--- a/test/embedding/libdl_embedding.c
+++ b/test/embedding/libdl_embedding.c
@@ -1,0 +1,12 @@
+#include <dlfcn.h>
+#include <stdio.h>
+#include <signal.h>
+
+int main(int argc, char *argv[])
+{
+    // This test doesn't do much yet, except check
+    // https://github.com/JuliaLang/julia/issues/57240
+    signal(SIGCHLD, SIG_IGN);
+    void *handle = dlopen(LIBJULIA_PATH, RTLD_LAZY);
+    return 0;
+}


### PR DESCRIPTION
The `fork()` we do here relies on `SIGCHLD` to make sure that we don't race against the child.

This is easy to see in an embedding application that dynamically links `libjulia`:
```c
int main(int argc, char *argv[])
{
    signal(SIGCHLD, SIG_IGN);
    void *handle = dlopen("path/to/libjulia.so", RTLD_LAZY);
    return 0;
}
```

Without this change, this fails with an error message:
```
Error during libstdcxxprobe in parent process:
waitpid: No child processes
```

Resolves #57240