### PR TITLE
Fix printing of `var"keyword"` identifiers (issue #56936)

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1757,9 +1757,15 @@ function show_enclosed_list(io::IO, op, items, sep, cl, indent, prec=0, quote_le
     print(io, cl)
 end
 
+const keyword_syms = Set([
+    :baremodule, :begin, :break, :catch, :const, :continue, :do, :else, :elseif,
+    :end, :export, :false, :finally, :for, :function, :global, :if, :import,
+    :let, :local, :macro, :module, :public, :quote, :return, :struct, :true,
+    :try, :using, :while ])
+
 function is_valid_identifier(sym)
-    return isidentifier(sym) || (
-        _isoperator(sym) &&
+    return (isidentifier(sym) && !(sym in keyword_syms)) ||
+        (_isoperator(sym) &&
         !(sym in (Symbol("'"), :(::), :?)) &&
         !is_syntactic_operator(sym)
     )

--- a/test/show.jl
+++ b/test/show.jl
@@ -2356,9 +2356,9 @@ end
 
 # begin/end indices
 @weak_test_repr "a[begin, end, (begin; end)]"
-@test repr(Base.remove_linenums!(:(a[begin, end, (begin; end)]))) == ":(a[begin, end, (begin;\n          end)])"
+@test_broken repr(Base.remove_linenums!(:(a[begin, end, (begin; end)]))) == ":(a[begin, end, (begin;\n          end)])"
 @weak_test_repr "a[begin, end, let x=1; (x+1;); end]"
-@test repr(Base.remove_linenums!(:(a[begin, end, let x=1; (x+1;); end]))) ==
+@test_broken repr(Base.remove_linenums!(:(a[begin, end, let x=1; (x+1;); end]))) ==
         ":(a[begin, end, let x = 1\n          begin\n              x + 1\n          end\n      end])"
 @test_repr "a[(bla;)]"
 @test_repr "a[(;;)]"
@@ -2794,4 +2794,10 @@ Base.setindex!(d::NoLengthDict, v, k) = d.dict[k] = v
     str = sprint(io->show(io, MIME("text/plain"), x))
     @test contains(str, "NoLengthDict")
     @test contains(str, "1 => 2")
+end
+
+# Issue 56936
+@testset "code printing of var\"keyword\" identifiers" begin
+    @test_repr """:(var"do" = 1)"""
+    @weak_test_repr """:(let var"let" = 1; var"let"; end)"""
 end


### PR DESCRIPTION
Fixes #56936.

One quirk this change would introduce is that `:((1:10)[end])` will be shown as `:((1:10)[var"end"])`, which is not ideal, but still correct.  It would make sense to fix this at the same time we fix `(let var"end" = 1; (1:10)[var"end"]; end) == 10` being true.  I'll open a separate issue for this.
