### PR TITLE
fix "Right arrow autocompletes at line end" implementation

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2260,7 +2260,7 @@ function complete_line(s::SearchState, repeats, mod::Module; hint::Bool=false)
     if length(completions) == 1
         prev_pos = position(s)
         push_undo(s)
-        edit_splice!(s, (prev_pos - sizeof(partial)) => prev_pos, completions[1])
+        edit_splice!(s, (prev_pos - sizeof(partial)) => prev_pos, completions[1].completion)
         return true
     end
     return false

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -835,7 +835,7 @@ function edit_move_right(m::MIState)
             # Replace word by completion
             prev_pos = position(s)
             push_undo(s)
-            edit_splice!(s, (prev_pos - sizeof(partial)) => prev_pos, completions[1])
+            edit_splice!(s, (prev_pos - sizeof(partial)) => prev_pos, completions[1].completion)
             refresh_line(state(s))
             return true
         else


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/56864. The feature in https://github.com/JuliaLang/julia/pull/54983 never worked I think?

Ref https://github.com/JuliaLang/julia/blob/99fd5d9a92190e826bc462d5739e7be948a3bf44/stdlib/REPL/src/LineEdit.jl#L504

