### PR TITLE
update path to Compiler stdlib to a valid one similar to how it is done for other stdlibs

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -131,13 +131,17 @@ function fixup_stdlib_path(path::String)
     # The file defining Base.Sys gets included after this file is included so make sure
     # this function is valid even in this intermediary state
     if isdefined(@__MODULE__, :Sys)
-        BUILD_STDLIB_PATH = Sys.BUILD_STDLIB_PATH::String
-        STDLIB = Sys.STDLIB::String
-        if BUILD_STDLIB_PATH != STDLIB
+        if Sys.BUILD_STDLIB_PATH != Sys.STDLIB
             # BUILD_STDLIB_PATH gets defined in sysinfo.jl
             npath = normpath(path)
-            npath′ = replace(npath, normpath(BUILD_STDLIB_PATH) => normpath(STDLIB))
-            return npath == npath′ ? path : npath′
+            npath′ = replace(npath, normpath(Sys.BUILD_STDLIB_PATH) => normpath(Sys.STDLIB))
+            path = npath == npath′ ? path : npath′
+        end
+        if isdefined(@__MODULE__, :Core) && isdefined(Core, :Compiler)
+            compiler_folder = dirname(string(methods(Core.Compiler.eval)[1].file))
+            if dirname(path) == compiler_folder
+                return abspath(Sys.STDLIB, "..", "..", "Compiler", "src", basename(path))
+            end
         end
     end
     return path

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -138,7 +138,7 @@ function fixup_stdlib_path(path::String)
             path = npath == npath′ ? path : npath′
         end
         if isdefined(@__MODULE__, :Core) && isdefined(Core, :Compiler)
-            compiler_folder = dirname(string(methods(Core.Compiler.eval)[1].file))
+            compiler_folder = dirname(String(Base.moduleloc(Core.Compiler).file))
             if dirname(path) == compiler_folder
                 return abspath(Sys.STDLIB, "..", "..", "Compiler", "src", basename(path))
             end

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -658,6 +658,10 @@ file, ln = functionloc(versioninfo, Tuple{})
 @test isfile(pathof(InteractiveUtils))
 @test isdir(pkgdir(InteractiveUtils))
 
+# compiler stdlib path updating
+file, ln = functionloc(Core.Compiler.tmeet, Tuple{Int, Float64})
+@test isfile(file)
+
 @testset "buildbot path updating" begin
     file, ln = functionloc(versioninfo, Tuple{})
     @test isfile(file)


### PR DESCRIPTION
Fixes #56865. The Compiler "stdlib" resides in a different location so the current logic didn't handle updating it.

The 

```
compiler_folder = dirname(string(methods(Core.Compiler.eval)[1].file))
```

line to figure out the build path to the compiler feels very ugly. It is also something that is constant so doing it every time is wasteful...