### PR TITLE
Compiler: fix unsoundness of getfield_tfunc on Tuple Types

### DIFF
--- a/Compiler/src/typeutils.jl
+++ b/Compiler/src/typeutils.jl
@@ -36,14 +36,8 @@ function isTypeDataType(@nospecialize t)
     isType(t) && return false
     # Could be Union{} at runtime
     t === Core.TypeofBottom && return false
-    if t.name === Tuple.name
-        # If we have a Union parameter, could have been redistributed at runtime,
-        # e.g. `Tuple{Union{Int, Float64}, Int}` is a DataType, but
-        # `Union{Tuple{Int, Int}, Tuple{Float64, Int}}` is typeequal to it and
-        # is not.
-        return all(isTypeDataType, t.parameters)
-    end
-    return true
+    # Return true if `t` is not covariant
+    return t.name !== Tuple.name
 end
 
 has_extended_info(@nospecialize x) = (!isa(x, Type) && !isvarargtype(x)) || isType(x)

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -1769,6 +1769,7 @@ let getfield_tfunc(@nospecialize xs...) =
         Compiler.getfield_tfunc(Compiler.fallback_lattice, xs...)
     @test getfield_tfunc(Type, Core.Const(:parameters)) !== Union{}
     @test !isa(getfield_tfunc(Type{Tuple{Union{Int, Float64}, Int}}, Core.Const(:name)), Core.Const)
+    @test !isa(getfield_tfunc(Type{Tuple{Any}}, Core.Const(:name)), Core.Const)
 end
 @test fully_eliminated(Base.ismutable, Tuple{Base.RefValue})
 


### PR DESCRIPTION
This was noted in the original review of that PR by the PR author, but was for some reason not fixed at that time: https://github.com/JuliaLang/julia/pull/46693#discussion_r968785997