### PR TITLE
Add summary printing for GenericMemoryRef

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -3196,6 +3196,14 @@ function array_summary(io::IO, a, inds)
     print(io, " with indices ", inds2string(inds))
 end
 
+## `summary` for GenericMemoryRef
+function summary(io::IO, mref::GenericMemoryRef)
+    offset = Core.memoryrefoffset(mref)
+    len_after_offset = length(mref.mem) - offset + 1
+    print(io, len_after_offset, "-element ")
+    showarg(io, mref, true)
+end
+
 ## `summary` for Function
 summary(io::IO, f::Function) = show(io, MIME"text/plain"(), f)
 


### PR DESCRIPTION
Fixes #57184

```julia-repl
julia> x = Memory{Int}([1,2,3,4])
# master
julia> copyto!(x, 2, x, 4, 6)
ERROR: BoundsError: attempt to access MemoryRef{Int64} at index [6]
julia> summary(memoryref(x, 2))
"MemoryRef{Int64}"

# this pr
julia> copyto!(x, 2, x, 4, 2)
ERROR: BoundsError: attempt to access 1-elements MemoryRef{Int64} at index [2]
julia> summary(memoryref(x, 2))
"3-elements MemoryRef{Int64}"
```