### PR TITLE
Documentation for `MemoryRef`

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2849,6 +2849,10 @@ Construct a `GenericMemoryRef` from a memory object and an offset index (1-based
 can also be negative. This always returns an inbounds object, and will throw an
 error if that is not possible (because the index would result in a shift
 out-of-bounds of the underlying memory).
+
+# See also
+- [`Core.memoryrefoffset`](@ref) – Retrieves the offset of a `MemoryRef` within its parent memory.
+- [`length(::GenericMemoryRef)`](@ref) – Gets the total number of elements in a `MemoryRef`.
 """
 memoryref(::Union{GenericMemory,GenericMemoryRef}, ::Integer)
 


### PR DESCRIPTION
Adds documentation for #57184 with a "see also" hint for `length `and `memoryrefoffset` :)