### PR TITLE
Make `OncePerX` subtype `Function`

### DIFF
--- a/base/lock.jl
+++ b/base/lock.jl
@@ -693,7 +693,7 @@ julia> procstate === fetch(@async global_state())
 true
 ```
 """
-mutable struct OncePerProcess{T, F}
+mutable struct OncePerProcess{T, F} <: Function
     value::Union{Nothing,T}
     @atomic state::UInt8 # 0=initial, 1=hasrun, 2=error
     @atomic allow_compile_time::Bool
@@ -801,7 +801,7 @@ julia> threadvec === thread_state[Threads.threadid()]
 true
 ```
 """
-mutable struct OncePerThread{T, F}
+mutable struct OncePerThread{T, F} <: Function
     @atomic xs::AtomicMemory{T} # values
     @atomic ss::AtomicMemory{UInt8} # states: 0=initial, 1=hasrun, 2=error, 3==concurrent
     const initializer::F
@@ -926,7 +926,7 @@ Making lazy task value...done.
 false
 ```
 """
-mutable struct OncePerTask{T, F}
+mutable struct OncePerTask{T, F} <: Function
     const initializer::F
 
     OncePerTask{T}(initializer::F) where {T, F} = new{T,F}(initializer)


### PR DESCRIPTION
These are essentially functions, and by subtyping `Function`, it allows them to be passed into functions that accept a function as an argument without having to update code on the package side.

For example, the [macOS version getters](https://github.com/JuliaGPU/Metal.jl/blob/a1c0b8f267ce8b8ee8ebc07dab359e76e0437d77/src/version.jl#L18C1-L41C4) are defined as OncePerProcess constants for 1.12+, without this PR, code that accepts a function where the `macos_version` is passed in would break.

Should be backported to 1.12.