### PR TITLE
Fix :noub inference for pointerset/pointerref, getfield with bounds checking disabled

### DIFF
--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -5915,25 +5915,25 @@ end == Val
 @test Base.infer_effects((Any,Any); optimize=false) do a, b
     getfield(PartiallyInitialized1(a, b), :b)
 end |> Compiler.is_nothrow
-@test Base.infer_effects((Any,Any,Symbol,); optimize=false) do a, b, f
+@test Base.infer_effects((Any,Any,Int,); optimize=false) do a, b, f
     getfield(PartiallyInitialized1(a, b), f, #=boundscheck=#false)
 end |> !Compiler.is_nothrow
 @test Base.infer_effects((Any,Any,Any); optimize=false) do a, b, c
     getfield(PartiallyInitialized1(a, b, c), :c)
 end |> Compiler.is_nothrow
-@test Base.infer_effects((Any,Any,Any,Symbol); optimize=false) do a, b, c, f
+@test Base.infer_effects((Any,Any,Any,Int); optimize=false) do a, b, c, f
     getfield(PartiallyInitialized1(a, b, c), f, #=boundscheck=#false)
 end |> Compiler.is_nothrow
 @test Base.infer_effects((Any,Any); optimize=false) do a, b
     getfield(PartiallyInitialized2(a, b), :b)
 end |> Compiler.is_nothrow
-@test Base.infer_effects((Any,Any,Symbol,); optimize=false) do a, b, f
+@test Base.infer_effects((Any,Any,Int,); optimize=false) do a, b, f
     getfield(PartiallyInitialized2(a, b), f, #=boundscheck=#false)
 end |> !Compiler.is_nothrow
 @test Base.infer_effects((Any,Any,Any); optimize=false) do a, b, c
     getfield(PartiallyInitialized2(a, b, c), :c)
 end |> Compiler.is_nothrow
-@test Base.infer_effects((Any,Any,Any,Symbol); optimize=false) do a, b, c, f
+@test Base.infer_effects((Any,Any,Any,Int); optimize=false) do a, b, c, f
     getfield(PartiallyInitialized2(a, b, c), f, #=boundscheck=#false)
 end |> Compiler.is_nothrow
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2435,14 +2435,19 @@ julia> Tuple(Real[1, 2, pi])  # takes a collection
 tuple
 
 """
-    getfield(value, name::Symbol, [order::Symbol])
-    getfield(value, i::Int, [order::Symbol])
+    getfield(value, name::Symbol, [boundscheck::Bool=true], [order::Symbol])
+    getfield(value, i::Int, [boundscheck::Bool=true], [order::Symbol])
 
-Extract a field from a composite `value` by name or position. Optionally, an
-ordering can be defined for the operation. If the field was declared `@atomic`,
-the specification is strongly recommended to be compatible with the stores to
-that location. Otherwise, if not declared as `@atomic`, this parameter must be
-`:not_atomic` if specified.
+Extract a field from a composite `value` by name or position.
+
+Optionally, an ordering can be defined for the operation.  If the field was
+declared `@atomic`, the specification is strongly recommended to be compatible
+with the stores to that location. Otherwise, if not declared as `@atomic`, this
+parameter must be `:not_atomic` if specified.
+
+The bounds check may be disabled, in which case the behavior of this function is
+undefined if `i` is out of bounds.
+
 See also [`getproperty`](@ref Base.getproperty) and [`fieldnames`](@ref).
 
 # Examples

--- a/base/docs/intrinsicsdocs.jl
+++ b/base/docs/intrinsicsdocs.jl
@@ -23,6 +23,15 @@ The `Core.Intrinsics` module holds the `Core.IntrinsicFunction` objects.
 Core.Intrinsics
 
 """
+    Core.memorynew(::Type{T} where T <: GenericMemory, n::Int)
+
+Construct an uninitialized [`GenericMemory`](@ref) of length `n`.
+
+See also [`Memory`](@ref Base.Memory).
+"""
+Core.memorynew
+
+"""
     Core.memoryrefnew(::GenericMemory)
     Core.memoryrefnew(::GenericMemoryRef, index::Int, [boundscheck::Bool])
 
@@ -128,6 +137,35 @@ a given value, only if it was previously not set.
 See also [`setpropertyonce!`](@ref Base.replaceproperty!) and [`Core.memoryrefset!`](@ref).
 """
 Core.memoryrefsetonce!
+
+
+"""
+    Core.Intrinsics.pointerref(p::Ptr{T}, i::Int, align::Int)
+
+Load a value of type `T` from the address of the `i`th element (1-indexed)
+starting at `p`. This is equivalent to the C expression `p[i-1]`.
+
+The alignment must be a power of two, or 0, indicating the default alignment
+for `T`. If `p[i-1]` is out of bounds, invalid, or is not aligned, the behavior
+is undefined. An alignment of 1 is always safe.
+
+See also [`unsafe_load`](@ref).
+"""
+Core.Intrinsics.pointerref
+
+"""
+    Core.Intrinsics.pointerset(p::Ptr{T}, x::T, i::Int, align::Int)
+
+Store a value of type `T` to the address of the `i`th element (1-indexed)
+starting at `p`.  This is equivalent to the C expression `p[i-1] = x`.
+
+The alignment must be a power of two, or `0`, indicating the default alignment
+for `T`. If `p[i-1]` is out of bounds, invalid, or is not aligned, the behavior
+is undefined. An alignment of 1 is always safe.
+
+See also [`unsafe_store!`](@ref).
+"""
+Core.Intrinsics.pointerset
 
 """
     Core.Intrinsics.atomic_pointerref(pointer::Ptr{T}, order::Symbol) --> T

--- a/doc/src/devdocs/builtins.md
+++ b/doc/src/devdocs/builtins.md
@@ -1,12 +1,25 @@
 # [Core.Builtins](@id lib-builtins)
 
-## Builtin Function APIs
+The following builtin functions are considered unstable, but provide the basic
+definitions for what defines the abilities and behaviors of a Julia
+program. They are typically accessed through a higher level generic API.
 
-The following Builtin function APIs are considered unstable, but provide the basic
-definitions for what defines the abilities and behaviors of a Julia program. They are
-typically accessed through a higher level generic API.
+## Raw access to memory
 
 ```@docs
+Core.Intrinsics.pointerref
+Core.Intrinsics.pointerset
+Core.Intrinsics.atomic_pointerref
+Core.Intrinsics.atomic_pointerset
+Core.Intrinsics.atomic_pointerswap
+Core.Intrinsics.atomic_pointermodify
+Core.Intrinsics.atomic_pointerreplace
+```
+
+## Managed memory
+
+```@docs
+Core.memorynew
 Core.memoryrefnew
 Core.memoryrefoffset
 Core.memoryrefget
@@ -16,12 +29,15 @@ Core.memoryrefswap!
 Core.memoryrefmodify!
 Core.memoryrefreplace!
 Core.memoryrefsetonce!
-Core.Intrinsics.atomic_pointerref
-Core.Intrinsics.atomic_pointerset
-Core.Intrinsics.atomic_pointerswap
-Core.Intrinsics.atomic_pointermodify
-Core.Intrinsics.atomic_pointerreplace
+```
+
+## Module bindings
+
 Core.get_binding_type
+
+## Other
+
+```@docs
 Core.IntrinsicFunction
 Core.Intrinsics
 Core.IR


### PR DESCRIPTION
- We now taint `:noub` for `pointerref` (and `pointerset`), fixing #56056
- Adds doc strings for `pointerset`, `pointerref`.
- Fixes the issue mentioned in https://github.com/JuliaLang/julia/issues/56056#issuecomment-2606702010, namely that `getfield` with bounds checking off didn't taint `:noub`.
  - Also taint `:nothrow` when bounds checking is off but the field name is a symbol, since we'll throw a `FieldError`.
    - This required updating some tests to use `Int` instead of `Symbol`.
  - Updates `getfield` to document the boundscheck argument.
- Categorizes functions documented in `builtins.md`