### PR TITLE
Introduce non moving allocation

### DIFF
--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -540,6 +540,11 @@ JL_DLLEXPORT jl_value_t *(jl_gc_alloc)(jl_ptls_t ptls, size_t sz, void *ty)
     return jl_gc_alloc_(ptls, sz, ty);
 }
 
+JL_DLLEXPORT jl_value_t *(jl_gc_alloc_nonmoving)(jl_ptls_t ptls, size_t sz, void *ty)
+{
+    return jl_gc_alloc_nonmoving_(ptls, sz, ty);
+}
+
 JL_DLLEXPORT void *jl_malloc(size_t sz)
 {
     return jl_gc_counted_malloc(sz);

--- a/src/gc-interface.h
+++ b/src/gc-interface.h
@@ -148,6 +148,9 @@ JL_DLLEXPORT uint64_t jl_gc_total_hrtime(void);
 // **must** also set the type of the returning object to be `ty`. The type `ty` may also be used to record
 // an allocation of that type in the allocation profiler.
 struct _jl_value_t *jl_gc_alloc_(struct _jl_tls_states_t * ptls, size_t sz, void *ty);
+// Similar to jl_gc_alloc_, except that the GC needs to make sure the object allocated from this function will
+// not be moved by the GC.
+struct _jl_value_t *jl_gc_alloc_nonmoving_(struct _jl_tls_states_t * ptls, size_t sz, void *ty);
 // Allocates small objects and increments Julia allocation counterst. Size of the object
 // header must be included in the object size. The (possibly unused in some implementations)
 // offset to the arena in which we're allocating is passed in the second parameter, and the

--- a/src/gc-mmtk.c
+++ b/src/gc-mmtk.c
@@ -963,6 +963,13 @@ inline jl_value_t *jl_gc_alloc_(jl_ptls_t ptls, size_t sz, void *ty)
     return v;
 }
 
+inline jl_value_t *jl_gc_alloc_nonmoving_(jl_ptls_t ptls, size_t sz, void *ty)
+{
+    // TODO: Currently we just alloc the object, as we only support a non-moving GC
+    // We should pin the object if we start support a moving GC, or use a non-moving allocator.
+    return jl_gc_alloc_(ptls, sz, ty);
+}
+
 // allocation wrappers that track allocation and let collection run
 JL_DLLEXPORT void *jl_gc_counted_malloc(size_t sz)
 {

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -806,6 +806,12 @@ inline jl_value_t *jl_gc_alloc_(jl_ptls_t ptls, size_t sz, void *ty)
     return v;
 }
 
+inline jl_value_t *jl_gc_alloc_nonmoving_(jl_ptls_t ptls, size_t sz, void *ty)
+{
+    // Just use the normal allocation, as the GC won't move objects anyway.
+    return jl_gc_alloc_(ptls, sz, ty);
+}
+
 int jl_gc_classify_pools(size_t sz, int *osize)
 {
     if (sz > GC_MAX_SZCLASS)

--- a/src/julia.h
+++ b/src/julia.h
@@ -77,6 +77,17 @@ typedef struct _jl_tls_states_t *jl_ptls_t;
 // the common fields are hidden before the pointer, but the following macro is
 // used to indicate which types below are subtypes of jl_value_t
 #define JL_DATA_TYPE
+// Objects of a type that is JL_NON_MOVING should be allocated with
+// jl_gc_alloc_non_moving so they will never be moved by GC.
+// These types may be marked as non moving:
+// 1. Types that are used by the GC when they scan an object such as jl_datatype_t
+//    and jl_typename_t. Those types should never be moved by the GC.
+// 2. Types that are frequently referenced and frequently pinned. If a type
+//    is likely to be pinned, we could just allocate them as non-moving.
+// Having a separate allocation function for non moving types is beneficial,
+// as those objects of non-moving types can be allocated into a different space,
+// rather than being pinned and cause worse heap fragmentation.
+#define JL_NON_MOVING
 typedef struct _jl_value_t jl_value_t;
 #include "julia_threads.h"
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -560,12 +560,17 @@ static_assert(ARRAY_CACHE_ALIGN_THRESHOLD > GC_MAX_SZCLASS, "");
  * safepoints will be caught by the GC analyzer.
  */
 JL_DLLEXPORT jl_value_t *jl_gc_alloc(jl_ptls_t ptls, size_t sz, void *ty);
+JL_DLLEXPORT jl_value_t *jl_gc_alloc_nonmoving(jl_ptls_t ptls, size_t sz, void *ty);
 // On GCC, only inline when sz is constant
 #ifdef __GNUC__
 #  define jl_gc_alloc(ptls, sz, ty)  \
     (__builtin_constant_p(sz) ?      \
      jl_gc_alloc_(ptls, sz, ty) :    \
      (jl_gc_alloc)(ptls, sz, ty))
+#  define jl_gc_alloc_nonmoving(ptls, sz, ty)  \
+    (__builtin_constant_p(sz) ?      \
+     jl_gc_alloc_nonmoving_(ptls, sz, ty) :    \
+     (jl_gc_alloc_nonmoving)(ptls, sz, ty))
 #else
 #  define jl_gc_alloc(ptls, sz, ty) jl_gc_alloc_(ptls, sz, ty)
 #endif


### PR DESCRIPTION
This PR introduces a non moving allocation function. Having a separate allocation function for non moving types is benefitial, as those objects of non-moving types can be allocated into a different space, rather than being pinned in place among movable objects and cause worse heap fragmentation.

These types will be allocated as non moving:
1. Types that are used by the GC when they scan an object such as `jl_datatype_t`  and `jl_typename_t`. Those types should never be moved by the GC (otherwise it greatly complicates the GC implementation with little benefits).
2. Types that are frequently referenced and frequently pinned. If a type is likely to be pinned, we could just allocate them as non-moving. Small-number, long-live and pervasively referenced types are good candidates, such as `jl_module_t`.

This PR itself does not allocate any object as non-moving. It just introduces the mechanism.