### PR TITLE
Add a separate GC stack for tracking GC preserved objects

### DIFF
--- a/src/gc-interface.h
+++ b/src/gc-interface.h
@@ -109,6 +109,13 @@ JL_DLLEXPORT const char* jl_gc_active_impl(void);
 // It still needs to be annotated with JL_DLLEXPORT since it is called from Rust by MMTk.
 JL_DLLEXPORT void jl_gc_sweep_stack_pools_and_mtarraylist_buffers(jl_ptls_t ptls) JL_NOTSAFEPOINT;
 
+// TODO: The preserve hook functions may be temporary. We should see the performance impact of the change.
+
+// Runtime hook for gc preserve begin. The GC needs to make sure that the preserved objects and its children stay alive and won't move.
+JL_DLLEXPORT void jl_gc_preserve_begin_hook(int n, ...) JL_NOTSAFEPOINT;
+// Runtime hook for gc preserve end. The GC needs to make sure that the preserved objects and its children stay alive and won't move.
+JL_DLLEXPORT void jl_gc_preserve_end_hook(void) JL_NOTSAFEPOINT;
+
 // ========================================================================= //
 // Metrics
 // ========================================================================= //

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -4080,6 +4080,16 @@ JL_DLLEXPORT const char* jl_gc_active_impl(void) {
     return "Built with stock GC";
 }
 
+JL_DLLEXPORT void jl_gc_preserve_begin_hook(int n, ...) JL_NOTSAFEPOINT
+{
+    jl_unreachable();
+}
+
+JL_DLLEXPORT void jl_gc_preserve_end_hook(void) JL_NOTSAFEPOINT
+{
+    jl_unreachable();
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -52,7 +52,14 @@ extern void JL_GC_ENABLEFRAME(interpreter_state*) JL_NOTSAFEPOINT;
 
 #else
 
+#ifdef MMTK_GC
+#define JL_GC_ENCODE_PUSHFRAME(n)  ((((size_t)(n))<<3)|2)
+// For roots that are not transitively pinned
+#define JL_GC_ENCODE_PUSHFRAME_NO_TPIN(n)  ((((size_t)(n))<<3)|6)
+#else
 #define JL_GC_ENCODE_PUSHFRAME(n)  ((((size_t)(n))<<2)|2)
+#define JL_GC_ENCODE_PUSHFRAME_NO_TPIN(n)  JL_GC_ENCODE_PUSHFRAME(n)
+#endif
 
 #define JL_GC_PUSHFRAME(frame,locals,n)                                             \
   JL_CPPALLOCA(frame, sizeof(*frame)+(((n)+3)*sizeof(jl_value_t*)));                \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -182,6 +182,8 @@
     XX(jl_gc_set_max_memory) \
     XX(jl_gc_sync_total_bytes) \
     XX(jl_gc_total_hrtime) \
+    XX(jl_gc_preserve_begin_hook) \
+    XX(jl_gc_preserve_end_hook) \
     XX(jl_gdblookup) \
     XX(jl_generating_output) \
     XX(jl_declare_const_gf) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -1048,8 +1048,41 @@ struct _jl_gcframe_t {
 
 #define jl_pgcstack (jl_current_task->gcstack)
 
+#ifndef MMTK_GC
 #define JL_GC_ENCODE_PUSHARGS(n)   (((size_t)(n))<<2)
 #define JL_GC_ENCODE_PUSH(n)       ((((size_t)(n))<<2)|1)
+#define JL_GC_DECODE_NROOTS(n)     (n >> 2)
+
+#define JL_GC_ENCODE_PUSHARGS_NO_TPIN(n)  JL_GC_ENCODE_PUSHARGS(n)
+#define JL_GC_ENCODE_PUSH_NO_TPIN(n)      JL_GC_ENCODE_PUSH(n)
+#else
+
+// We use an extra bit (100) in the nroots value from the frame to indicate that the roots
+// in the frame are/are not transitively pinning.
+// There are currently 3 macros that encode passing nroots to the gcframe
+// and they use the two lowest bits to encode information about what is in the frame (as below).
+// To support the distinction between transtively pinning roots and non transitively pinning roots
+// on the stack, we take another bit from nroots to encode information about whether or not to
+// transitively pin the roots in the frame.
+//
+// So the ones that transitively pin look like:
+// #define JL_GC_ENCODE_PUSHARGS(n)   (((size_t)(n))<<3)
+// #define JL_GC_ENCODE_PUSH(n)       ((((size_t)(n))<<3)|1)
+// #define JL_GC_ENCODE_PUSHFRAME(n)  ((((size_t)(n))<<3)|2)
+// and the ones that do not look like:
+// #define JL_GC_ENCODE_PUSHARGS_NO_TPIN(n)   (((size_t)(n))<<3|4)
+// #define JL_GC_ENCODE_PUSH_NO_TPIN(n)       ((((size_t)(n))<<3)|5)
+// #define JL_GC_ENCODE_PUSHFRAME_NO_TPIN(n)  ((((size_t)(n))<<3)|6)
+
+// these are transitively pinning
+#define JL_GC_ENCODE_PUSHARGS(n)   (((size_t)(n))<<3)
+#define JL_GC_ENCODE_PUSH(n)       ((((size_t)(n))<<3)|1)
+#define JL_GC_DECODE_NROOTS(n)     (n >> 3)
+
+// these only pin the root object itself
+#define JL_GC_ENCODE_PUSHARGS_NO_TPIN(n)   (((size_t)(n))<<3|4)
+#define JL_GC_ENCODE_PUSH_NO_TPIN(n)       ((((size_t)(n))<<3)|5)
+#endif
 
 #ifdef __clang_gcanalyzer__
 

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -274,6 +274,9 @@ typedef struct _jl_task_t {
     // uint48_t padding2_64;
     // saved gc stack top for context switches
     jl_gcframe_t *gcstack;
+    // GC stack of objects from gc preserve regions
+    // These must always be transitively pinned. Only used by MMTK.
+    jl_gcframe_t *gcpreserve_stack;
     size_t world_age;
     // quick lookup for current ptls
     jl_ptls_t ptls; // == jl_all_tls_states[tid]

--- a/src/llvm-gc-interface-passes.h
+++ b/src/llvm-gc-interface-passes.h
@@ -361,6 +361,7 @@ private:
     void PlaceGCFrameReset(State &S, unsigned R, unsigned MinColorRoot, ArrayRef<int> Colors, Value *GCFrame, Instruction *InsertBefore);
     void PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAssignedColors, State &S, std::map<Value *, std::pair<int, int>>);
     void CleanupWriteBarriers(Function &F, State *S, const SmallVector<CallInst*, 0> &WriteBarriers, bool *CFGModified);
+    void CleanupGCPreserve(Function &F, CallInst *CI, Value *callee, Type *T_size);
     bool CleanupIR(Function &F, State *S, bool *CFGModified);
     void NoteUseChain(State &S, BBState &BBS, User *TheUser);
     SmallVector<int, 1> GetPHIRefinements(PHINode *phi, State &S);
@@ -412,5 +413,13 @@ private:
     // Lowers a `julia.safepoint` intrinsic.
     void lowerSafepoint(CallInst *target, Function &F);
 };
+
+inline bool isSpecialPtr(Type *Ty) {
+    PointerType *PTy = dyn_cast<PointerType>(Ty);
+    if (!PTy)
+        return false;
+    unsigned AS = PTy->getAddressSpace();
+    return AddressSpace::FirstSpecial <= AS && AS <= AddressSpace::LastSpecial;
+}
 
 #endif // LLVM_GC_PASSES_H

--- a/src/llvm-late-gc-lowering-mmtk.cpp
+++ b/src/llvm-late-gc-lowering-mmtk.cpp
@@ -94,3 +94,49 @@ Value* LateLowerGCFrame::lowerGCAllocBytesLate(CallInst *target, Function &F)
     }
     return target;
 }
+
+void LateLowerGCFrame::CleanupGCPreserve(Function &F, CallInst *CI, Value *callee, Type *T_size) {
+    if (callee == gc_preserve_begin_func) {
+        // Initialize an IR builder.
+        IRBuilder<> builder(CI);
+
+        builder.SetCurrentDebugLocation(CI->getDebugLoc());
+        size_t nargs = 0;
+        State S2(F);
+
+        std::vector<Value*> args;
+        for (Use &U : CI->args()) {
+            Value *V = U;
+            if (isa<Constant>(V))
+                continue;
+            if (isa<PointerType>(V->getType())) {
+                if (isSpecialPtr(V->getType())) {
+                    int Num = Number(S2, V);
+                    if (Num >= 0) {
+                        nargs++;
+                        Value *Val = GetPtrForNumber(S2, Num, CI);
+                        args.push_back(Val);
+                    }
+                }
+            } else {
+                auto Nums = NumberAll(S2, V);
+                for (int Num : Nums) {
+                    if (Num < 0)
+                        continue;
+                    Value *Val = GetPtrForNumber(S2, Num, CI);
+                    args.push_back(Val);
+                    nargs++;
+                }
+            }
+        }
+        args.insert(args.begin(), ConstantInt::get(T_size, nargs));
+
+        ArrayRef<Value*> args_llvm = ArrayRef<Value*>(args);
+        builder.CreateCall(getOrDeclare(jl_well_known::GCPreserveBeginHook), args_llvm );
+    } else if (callee == gc_preserve_end_func) {
+        // Initialize an IR builder.
+        IRBuilder<> builder(CI);
+        builder.SetCurrentDebugLocation(CI->getDebugLoc());
+        builder.CreateCall(getOrDeclare(jl_well_known::GCPreserveEndHook), {});
+    }
+}

--- a/src/llvm-late-gc-lowering-stock.cpp
+++ b/src/llvm-late-gc-lowering-stock.cpp
@@ -7,3 +7,7 @@ Value* LateLowerGCFrame::lowerGCAllocBytesLate(CallInst *target, Function &F)
     // Do nothing for the stock GC
     return target;
 }
+
+void LateLowerGCFrame::CleanupGCPreserve(Function &F, CallInst *CI, Value *callee, Type *T_size) {
+    // Do nothing for the stock GC
+}

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -13,14 +13,6 @@ static bool isTrackedValue(Value *V) {
     return PT && PT->getAddressSpace() == AddressSpace::Tracked;
 }
 
-static bool isSpecialPtr(Type *Ty) {
-    PointerType *PTy = dyn_cast<PointerType>(Ty);
-    if (!PTy)
-        return false;
-    unsigned AS = PTy->getAddressSpace();
-    return AddressSpace::FirstSpecial <= AS && AS <= AddressSpace::LastSpecial;
-}
-
 // return how many Special pointers are in T (count > 0),
 // and if there is anything else in T (all == false)
 CountTrackedPointers::CountTrackedPointers(Type *T, bool ignore_loaded) {
@@ -2006,9 +1998,11 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
                 continue;
             }
             Value *callee = CI->getCalledOperand();
-            if (callee && (callee == gc_flush_func || callee == gc_preserve_begin_func
-                        || callee == gc_preserve_end_func)) {
+            if (callee && callee == gc_flush_func) {
                 /* No replacement */
+            } else if (callee && (callee == gc_preserve_begin_func
+                        || callee == gc_preserve_end_func)) {
+                CleanupGCPreserve(F, CI, callee, T_size);
             } else if (pointer_from_objref_func != nullptr && callee == pointer_from_objref_func) {
                 auto *obj = CI->getOperand(0);
                 auto *ASCI = new AddrSpaceCastInst(obj, CI->getType(), "", CI);

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -155,6 +155,12 @@ namespace jl_well_known {
 
     // `jl_gc_alloc_typed`: allocates bytes.
     extern const WellKnownFunctionDescription GCAllocTyped;
+
+    // `jl_gc_preserve_begin_hook`: called at the beginning of gc preserve regions, if required
+    extern const WellKnownFunctionDescription GCPreserveBeginHook;
+
+    // `jl_gc_preserve_end_hook`: called at the end of gc preserve regions, if required
+    extern const WellKnownFunctionDescription GCPreserveEndHook;
 }
 
 void setName(llvm::Value *V, const llvm::Twine &Name, int debug_info);

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -274,7 +274,7 @@ static void re_save_env(jl_stenv_t *e, jl_savedenv_t *se, int root)
         }
         else {
             roots = se->roots;
-            nroots = se->gcframe.nroots >> 2;
+            nroots = JL_GC_DECODE_NROOTS(se->gcframe.nroots);
         }
     }
     jl_varbinding_t *v = e->vars;
@@ -367,7 +367,7 @@ static void restore_env(jl_stenv_t *e, jl_savedenv_t *se, int root) JL_NOTSAFEPO
         }
         else {
             roots = se->roots;
-            nroots = se->gcframe.nroots >> 2;
+            nroots = JL_GC_DECODE_NROOTS(se->gcframe.nroots);
         }
     }
     jl_varbinding_t *v = e->vars;
@@ -4193,7 +4193,7 @@ static int merge_env(jl_stenv_t *e, jl_savedenv_t *me, jl_savedenv_t *se, int co
     else {
         saved = se->roots;
         merged = me->roots;
-        nroots = se->gcframe.nroots >> 2;
+        nroots = JL_GC_DECODE_NROOTS(se->gcframe.nroots);
     }
     assert(nroots == current_env_length(e) * 3);
     assert(nroots % 3 == 0);


### PR DESCRIPTION
This PR adds two things:
1.  a different shadow stack to record objects that are GC preserved. We need to be able to identify those objects, and they are different from the objects in the normal stack.
2. GC-specific hooks that are inserted for `GC.@preserve` regions, and related refactoring for code gen. Each GC can deal with the semantics of `GC.@preserve` based on its implementation.

There could be an alternative implementation for 1. Instead of having a different shadow stack, we just use an extra bit to encode whether the objects is from GC preserve, or from normal GC push. This would require changing the stock GC to handle the extra bit. But this is definitely viable.