### PR TITLE
Add explicit imports for types and fix bugs

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -72,7 +72,7 @@ using Base.Order
 
 import Base: ==, _topmod, append!, convert, copy, copy!, findall, first, get, get!,
     getindex, haskey, in, isempty, isready, iterate, iterate, last, length, max_world,
-    min_world, popfirst!, push!, resize!, setindex!, size
+    min_world, popfirst!, push!, resize!, setindex!, size, intersect
 
 const getproperty = Core.getfield
 const setproperty! = Core.setfield!

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -224,6 +224,7 @@ function cld end
 function fld end
 
 # Lazy strings
+import Core: String
 include("strings/lazy.jl")
 
 # array structures

--- a/base/bool.jl
+++ b/base/bool.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+import Core: Bool
+
 # promote Bool to any other numeric type
 promote_rule(::Type{Bool}, ::Type{T}) where {T<:Number} = T
 

--- a/base/char.jl
+++ b/base/char.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+import Core: AbstractChar, Char
+
 """
 The `AbstractChar` type is the supertype of all character implementations
 in Julia. A character represents a Unicode code point, and can be converted

--- a/base/coreir.jl
+++ b/base/coreir.jl
@@ -49,5 +49,5 @@ while processing a call, then `Conditional` everywhere else.
 """
 Core.InterConditional
 
-InterConditional(var::SlotNumber, @nospecialize(thentype), @nospecialize(elsetype)) =
+Core.InterConditional(var::SlotNumber, @nospecialize(thentype), @nospecialize(elsetype)) =
     InterConditional(slot_id(var), thentype, elsetype)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -353,6 +353,7 @@ end
 @deprecate one(i::CartesianIndex)                    oneunit(i)
 @deprecate one(I::Type{CartesianIndex{N}}) where {N} oneunit(I)
 
+import .MPFR: BigFloat
 @deprecate BigFloat(x, prec::Int)                               BigFloat(x; precision=prec)
 @deprecate BigFloat(x, prec::Int, rounding::RoundingMode)       BigFloat(x, rounding; precision=prec)
 @deprecate BigFloat(x::Real, prec::Int)                         BigFloat(x; precision=prec)

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -137,11 +137,11 @@ export File,
        S_IROTH, S_IWOTH, S_IXOTH, S_IRWXO
 
 import .Base:
-    IOError, _UVError, _sizeof_uv_fs, check_open, close, eof, eventloop, fd, isopen,
-    bytesavailable, position, read, read!, readavailable, seek, seekend, show,
+    IOError, _UVError, _sizeof_uv_fs, check_open, close, closewrite, eof, eventloop, fd, isopen,
+    bytesavailable, position, read, read!, readbytes!, readavailable, seek, seekend, show,
     skip, stat, unsafe_read, unsafe_write, write, transcode, uv_error,
     setup_stdio, rawhandle, OS_HANDLE, INVALID_OS_HANDLE, windowserror, filesize,
-    isexecutable, isreadable, iswritable, MutableDenseArrayType
+    isexecutable, isreadable, iswritable, MutableDenseArrayType, truncate
 
 import .Base.RefValue
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -2,6 +2,9 @@
 
 const IEEEFloat = Union{Float16, Float32, Float64}
 
+import Core: Float16, Float32, Float64, AbstractFloat
+import Core: Int8, Int16, Int32, Int64, Int128, UInt8, UInt16, UInt32, UInt64, UInt128
+
 ## floating point traits ##
 
 """

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -13,6 +13,8 @@ import .Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor, 
              sign, hastypemax, isodd, iseven, digits!, hash, hash_integer, top_set_bit,
              clamp, unsafe_takestring
 
+import Core: Signed, Float16, Float32, Float64
+
 if Clong == Int32
     const ClongMax = Union{Int8, Int16, Int32}
     const CulongMax = Union{UInt8, UInt16, UInt32}

--- a/base/hamt.jl
+++ b/base/hamt.jl
@@ -239,11 +239,11 @@ or grows the HAMT by inserting a new trie instead.
     end
 end
 
-length(::Leaf) = 1
-length(trie::HAMT) = sum((length(trie.data[i]) for i in eachindex(trie.data)), init=0)
+Base.length(::Leaf) = 1
+Base.length(trie::HAMT) = sum((length(trie.data[i]) for i in eachindex(trie.data)), init=0)
 
-isempty(::Leaf) = false
-function isempty(trie::HAMT)
+Base.isempty(::Leaf) = false
+function Base.isempty(trie::HAMT)
     if islevel_empty(trie)
         return true
     end
@@ -251,7 +251,7 @@ function isempty(trie::HAMT)
 end
 
 # DFS
-function iterate(trie::HAMT, state=nothing)
+function Base.iterate(trie::HAMT, state=nothing)
     if state === nothing
         state = (;parent=nothing, trie, i=1)
     end

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -20,12 +20,15 @@ import
         sinpi, cospi, sincospi, tanpi, sind, cosd, tand, asind, acosd, atand,
         uinttype, exponent_max, exponent_min, ieee754_representation, significand_mask
 
+import .Core: AbstractFloat
+import .Base: Rational, Float16, Float32, Float64, Bool
+
 using .Base.Libc
 import ..Rounding: Rounding,
     rounding_raw, setrounding_raw, rounds_to_nearest, rounds_away_from_zero,
     tie_breaker_is_to_even, correct_rounding_requires_increment
 
-import ..GMP: ClongMax, CulongMax, CdoubleMax, Limb, libgmp
+import ..GMP: ClongMax, CulongMax, CdoubleMax, Limb, libgmp, BigInt
 
 import ..FastMath.sincos_fast
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -4,10 +4,12 @@
 module IteratorsMD
     import .Base: eltype, length, size, first, last, in, getindex, setindex!,
                   min, max, zero, oneunit, isless, eachindex,
-                  convert, show, iterate, promote_rule, to_indices, copy
+                  convert, show, iterate, promote_rule, to_indices, copy,
+                  isassigned
 
     import .Base: +, -, *, (:)
     import .Base: simd_outer_range, simd_inner_length, simd_index, setindex
+    import Core: Tuple
     using .Base: to_index, fill_to_length, tail, safe_tail
     using .Base: IndexLinear, IndexCartesian, AbstractCartesianIndex,
         ReshapedArray, ReshapedArrayLF, OneTo, Fix1

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+import Core: NamedTuple
+
 """
     NamedTuple
 

--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+import Core: Ref
+
 """
     Ref{T}
 

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+import Core: Symbol
+
 """
 The `AbstractString` type is the supertype of all string implementations in
 Julia. Strings are encodings of sequences of [Unicode](https://unicode.org/)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+import Core: Tuple
+
 # Document NTuple here where we have everything needed for the doc system
 """
     NTuple{N, T}


### PR DESCRIPTION
I was playing with strengthening the semantics around #57290. However, the particular change I was trying turned out too breaking (I may try a weaker version of it). Still, there were a number of good changes found in two categories:

1. We should explicitly import types when defining constructors. This has been allowed for a long time, but we may want to consider removing it, especially given the new binding semantics which make it more confusing as in #57290.

2. There were a couple of places where I don't think it was intended for generic functions in question not to extend Base.