### PR TITLE
[1.11.x] Revert "yet more atomics & cache-line fixes on work-stealing queue (#53424)"

### DIFF
--- a/src/work-stealing-queue.h
+++ b/src/work-stealing-queue.h
@@ -3,8 +3,6 @@
 #ifndef WORK_STEALING_QUEUE_H
 #define WORK_STEALING_QUEUE_H
 
-#include <stdalign.h>
-
 #include "julia_atomics.h"
 #include "assert.h"
 
@@ -37,10 +35,10 @@ static inline ws_array_t *create_ws_array(size_t capacity, int32_t eltsz) JL_NOT
 }
 
 typedef struct {
-    // align to JL_CACHE_BYTE_ALIGNMENT
-    alignas(JL_CACHE_BYTE_ALIGNMENT) _Atomic(int64_t) top;
-    alignas(JL_CACHE_BYTE_ALIGNMENT) _Atomic(int64_t) bottom;
-    alignas(JL_CACHE_BYTE_ALIGNMENT) _Atomic(ws_array_t *) array;
+    _Atomic(int64_t) top;
+    char _padding[JL_CACHE_BYTE_ALIGNMENT - sizeof(_Atomic(int64_t))];
+    _Atomic(int64_t) bottom; // put on a separate cache line. conservatively estimate cache line size as 128 bytes
+    _Atomic(ws_array_t *) array;
 } ws_queue_t;
 
 static inline ws_array_t *ws_queue_push(ws_queue_t *q, void *elt, int32_t eltsz) JL_NOTSAFEPOINT


### PR DESCRIPTION
@gbaraldi @vchuravy @vtjnash @d-netto once again, latest release branch is broken. Does nobody care?

Results in reliable `julia` segfault immediately upon startup. I don't know what is going on or why it is crashing or what is wrong, but this is very reproducible and bisection result is reliable.

Notably, does not seem to be happening in `master`.

See the following issue for more details:
Fixes https://github.com/JuliaLang/julia/issues/54560

This reverts commit 53180e48ad973e5fa479327fb22ff2e1e5dba284.

This is a respin of https://github.com/JuliaLang/julia/pull/56342