### PR TITLE
backport 1.10: fix handling of unknown setting in `@constprop`, fix error message

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -388,13 +388,14 @@ macro constprop(setting)
 end
 
 function constprop_setting(@nospecialize setting)
+    s = setting
     isa(setting, QuoteNode) && (setting = setting.value)
     if setting === :aggressive
         return :aggressive_constprop
     elseif setting === :none
         return :no_constprop
     end
-    throw(ArgumentError(LazyString("@constprop "), setting, "not supported"))
+    throw(ArgumentError(LazyString("`Base.@constprop ", s, "` not supported")))
 end
 
 """

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1402,3 +1402,15 @@ end
     GC.gc(true); yield()
     @test in_fin[]
 end
+
+@testset "`@constprop`, `@assume_effects` handling of an unknown setting" begin
+    for x ∈ ("constprop", "assume_effects")
+        try
+            eval(Meta.parse("Base.@$x :unknown f() = 3"))
+            error("unexpectedly reached")
+        catch e
+            e::LoadError
+            @test e.error isa ArgumentError
+        end
+    end
+end


### PR DESCRIPTION
Backport of PR #56946 to v1.10.

Co-authored-by: Shuhei Kadowaki <40514306+aviatesk@users.noreply.github.com>
(cherry picked from commit a3f336fd713ff9723073f4543dd5b7c43cfb399e)