### PR TITLE
broadcast: align `ndims` implementation with intent behind code (#56999)

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -274,9 +274,14 @@ Base.@propagate_inbounds function Base.iterate(bc::Broadcasted, s)
 end
 
 Base.IteratorSize(::Type{T}) where {T<:Broadcasted} = Base.HasShape{ndims(T)}()
-Base.ndims(BC::Type{<:Broadcasted{<:Any,Nothing}}) = _maxndims(fieldtype(BC, :args))
-Base.ndims(::Type{<:Broadcasted{<:AbstractArrayStyle{N},Nothing}}) where {N<:Integer} = N
+Base.ndims(BC::Type{<:Broadcasted{<:Any,Nothing}}) = _maxndims_broadcasted(BC)
+# the `AbstractArrayStyle` type parameter is required to be either equal to `Any` or be an `Int` value
+Base.ndims(BC::Type{<:Broadcasted{<:AbstractArrayStyle{Any},Nothing}}) = _maxndims_broadcasted(BC)
+Base.ndims(::Type{<:Broadcasted{<:AbstractArrayStyle{N},Nothing}}) where {N} = N::Int
 
+function _maxndims_broadcasted(BC::Type{<:Broadcasted})
+    _maxndims(fieldtype(BC, :args))
+end
 _maxndims(T::Type{<:Tuple}) = reduce(max, (ntuple(n -> _ndims(fieldtype(T, n)), Base._counttuple(T))))
 _maxndims(::Type{<:Tuple{T}}) where {T} = ndims(T)
 _maxndims(::Type{<:Tuple{T}}) where {T<:Tuple} = _ndims(T)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -882,6 +882,8 @@ let
 
     @test @inferred(Base.IteratorSize(Broadcast.broadcasted(+, (1,2,3), a1, zeros(3,3,3)))) === Base.HasShape{3}()
 
+    @test @inferred(Base.IteratorSize(Base.broadcasted(randn))) === Base.HasShape{0}()
+
     # inference on nested
     bc = Base.broadcasted(+, AD1(randn(3)), AD1(randn(3)))
     bc_nest = Base.broadcasted(+, bc , bc)


### PR DESCRIPTION
Backport of PR #56999 to v1.10.

The `N<:Integer` constraint was nonsensical, given that `(N === Any) || (N isa Int)`. N5N3 noticed this back in 2022:
https://github.com/JuliaLang/julia/pull/44061#discussion_r883261337

Follow up on #44061. Also xref #45477.

(cherry picked from commit d3964b600a5e596bd47cf04b3da4a1e78d4aecaf)