### PR TITLE
[Random] Fix typo in `_bits2float` for `Float32`

### DIFF
--- a/stdlib/Random/src/XoshiroSimd.jl
+++ b/stdlib/Random/src/XoshiroSimd.jl
@@ -46,7 +46,7 @@ simdThreshold(::Type{Bool}) = 640
     ui = (x>>>32) % UInt32
     li = x % UInt32
     u = _uint2float(ui, Float32)
-    l = _uint2float(ui, Float32)
+    l = _uint2float(li, Float32)
     (UInt64(reinterpret(UInt32, u)) << 32) | UInt64(reinterpret(UInt32, l))
 end
 @inline function _bits2float(x::UInt64, ::Type{Float16})


### PR DESCRIPTION
Fix #57336.  I don't know what a good test for this would be (besides testing exact values or `allunique(rand(T, 4))`?), suggestions welcome.