### PR TITLE
trimming: make sure to fail / warn on `Expr(:call, ...)`

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5908,6 +5908,7 @@ static jl_cgval_t emit_call(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt, bo
     if (ctx.params->trim != JL_TRIM_NO) {
         // TODO: Implement the last-minute call resolution that used to be here
         //       in inference instead.
+        failed_dispatch = 1;
     }
 
     if (failed_dispatch && trim_may_error(ctx.params->trim)) {


### PR DESCRIPTION
I adapted this code incorrectly in #56271.

This dispatch should not be treated as resolved just because arg0 is constant. With the previous code, that meant it was eligible for last-minute call resolution, but call-resolution in codegen is now forbidden so this needs to fail unilaterally.