### PR TITLE
Add missing type asserts when taking the queue out of the task struct

### DIFF
--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -660,7 +660,7 @@ function wait_with_timeout(c::GenericCondition; first::Bool=false, timeout::Real
             # don't do anything here.
             if !waiter_left[] && ct.queue === c.waitq
                 dosched = true
-                Base.list_deletefirst!(c.waitq::IntrusiveLinkedList{Task}, ct)
+                Base.list_deletefirst!(c.waitq, ct)
             end
             unlock(c.lock)
             # send the waiting task a timeout

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -658,7 +658,7 @@ function wait_with_timeout(c::GenericCondition; first::Bool=false, timeout::Real
             # Confirm that the waiting task is still in the wait queue and remove it. If
             # the task is not in the wait queue, it must have been notified already so we
             # don't do anything here.
-            if !waiter_left[] && ct.queue == c.waitq
+            if !waiter_left[] && ct.queue === c.waitq
                 dosched = true
                 Base.list_deletefirst!(c.waitq::IntrusiveLinkedList{Task}, ct)
             end

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -660,7 +660,7 @@ function wait_with_timeout(c::GenericCondition; first::Bool=false, timeout::Real
             # don't do anything here.
             if !waiter_left[] && ct.queue == c.waitq
                 dosched = true
-                Base.list_deletefirst!(c.waitq, ct)
+                Base.list_deletefirst!(c.waitq::IntrusiveLinkedList{Task}, ct)
             end
             unlock(c.lock)
             # send the waiting task a timeout

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -252,7 +252,7 @@ function wait_no_relock(c::GenericCondition)
     try
         return wait()
     catch
-        ct.queue === nothing || list_deletefirst!(ct.queue, ct)
+        ct.queue === nothing || list_deletefirst!(ct.queue::IntrusiveLinkedList{Task}, ct)
         rethrow()
     end
 end

--- a/base/task.jl
+++ b/base/task.jl
@@ -495,7 +495,7 @@ function _wait_multiple(waiting_tasks, throwexc=false, all=false, failfast=false
         for i in findall(remaining_mask)
             waiter = waiter_tasks[i]
             donenotify = tasks[i].donenotify::ThreadSynchronizer
-            @lock donenotify Base.list_deletefirst!(donenotify.waitq::IntrusiveLinkedList{Task}, waiter)
+            @lock donenotify Base.list_deletefirst!(donenotify.waitq, waiter)
         end
         done_tasks = tasks[done_mask]
         if throwexc && exception

--- a/base/task.jl
+++ b/base/task.jl
@@ -1158,7 +1158,7 @@ function ensure_rescheduled(othertask::Task)
     # if the current task was queued,
     # also need to return it to the runnable state
     # before throwing an error
-    list_deletefirst!(W::IntrusiveLinkedList{Task}, ct)
+    list_deletefirst!(W, ct)
     nothing
 end
 

--- a/base/task.jl
+++ b/base/task.jl
@@ -495,7 +495,7 @@ function _wait_multiple(waiting_tasks, throwexc=false, all=false, failfast=false
         for i in findall(remaining_mask)
             waiter = waiter_tasks[i]
             donenotify = tasks[i].donenotify::ThreadSynchronizer
-            @lock donenotify Base.list_deletefirst!(donenotify.waitq, waiter)
+            @lock donenotify Base.list_deletefirst!(donenotify.waitq::IntrusiveLinkedList{Task}, waiter)
         end
         done_tasks = tasks[done_mask]
         if throwexc && exception
@@ -1158,7 +1158,7 @@ function ensure_rescheduled(othertask::Task)
     # if the current task was queued,
     # also need to return it to the runnable state
     # before throwing an error
-    list_deletefirst!(W, ct)
+    list_deletefirst!(W::IntrusiveLinkedList{Task}, ct)
     nothing
 end
 

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -32,7 +32,7 @@ function kill_timer(delay)
         # **DON'T COPY ME.**
         # The correct way to handle timeouts is to close the handle:
         # e.g. `close(stdout_read); close(stdin_write)`
-        test_task.queue === nothing || Base.list_deletefirst!(test_task.queue, test_task)
+        test_task.queue === nothing || Base.list_deletefirst!(test_task.queue::IntrusiveLinkedList{Task}, test_task)
         schedule(test_task, "hard kill repl test"; error=true)
         print(stderr, "WARNING: attempting hard kill of repl test after exceeding timeout\n")
     end


### PR DESCRIPTION
This was causing some dynamic dispatches (caught by the juliac test)