### PR TITLE
lowering: Only try to define the method once

### DIFF
--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -192,8 +192,6 @@ julia> nice(::Cat) = "nice 😸"
 ERROR: invalid method definition in Main: function NiceStuff.nice must be explicitly imported to be extended
 Stacktrace:
  [1] top-level scope
-   @ none:0
- [2] top-level scope
    @ none:1
 ```
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -4131,8 +4131,9 @@ f(x) = yt(x)
                                     `(toplevel-butfirst
                                       ;; wrap in toplevel-butfirst so it gets moved higher along with
                                       ;; closure type definitions
+                                      (unnecessary ,(cadr e))
                                       ,e
-                                      (thunk (lambda () (() () 0 ()) (block (return ,e))))))))
+                                      (latestworld)))))
                        ((null? cvs)
                         `(block
                           ,@sp-inits


### PR DESCRIPTION
Before:
```
:($(Expr(:thunk, CodeInfo(
1 ─       $(Expr(:thunk, CodeInfo(
1 ─     return $(Expr(:method, :(Main.f)))
)))
│         $(Expr(:method, :(Main.f)))
│   %3  = Main.f
│   %4  =   dynamic Core.Typeof(%3)
│   %5  =   builtin Core.svec(%4, Core.Any)
│   %6  =   builtin Core.svec()
│   %7  =   builtin Core.svec(%5, %6, $(QuoteNode(:(#= REPL[2]:1 =#))))
│         $(Expr(:method, :(Main.f), :(%7), CodeInfo(
1 ─     return 1
)))
│         $(Expr(:latestworld))
│   %10 = Main.f
└──       return %10
))))
```

After:
```
julia> @Meta.lower f(x)=1
:($(Expr(:thunk, CodeInfo(
1 ─       $(Expr(:method, :(Main.f)))
│         $(Expr(:latestworld))
│         Main.f
│         $(Expr(:latestworld))
│   %5  = Main.f
│   %6  =   dynamic Core.Typeof(%5)
│   %7  =   builtin Core.svec(%6, Core.Any)
│   %8  =   builtin Core.svec()
│   %9  =   builtin Core.svec(%7, %8, $(QuoteNode(:(#= REPL[1]:1 =#))))
│         $(Expr(:method, :(Main.f), :(%9), CodeInfo(
1 ─     return 1
)))
│         $(Expr(:latestworld))
│   %12 = Main.f
└──       return %12
))))
```

This doesn't really make a semantic difference, but if `f` is a type, we may now give a warning, so the prior definition would give the warning twice (https://github.com/JuliaLang/julia/pull/57311#issuecomment-2648045510). We may want to consider rate-limiting the warning independently, but for now at least give the correct number of warnings.