### PR TITLE
docs: fix-up world-age handling for META access

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -75,8 +75,8 @@ const META    = gensym(:meta)
 const METAType = IdDict{Any,Any}
 
 function meta(m::Module; autoinit::Bool=true)
-    if !isdefinedglobal(m, META)
-        return autoinit ? invokelatest(initmeta, m) : nothing
+    if !invokelatest(isdefinedglobal, m, META)
+        return autoinit ? initmeta(m) : nothing
     end
     # TODO: This `invokelatest` is not technically required, but because
     # of the automatic constant backdating is currently required to avoid
@@ -85,13 +85,13 @@ function meta(m::Module; autoinit::Bool=true)
 end
 
 function initmeta(m::Module)
-    if !isdefinedglobal(m, META)
+    if !invokelatest(isdefinedglobal, m, META)
         val = METAType()
         Core.eval(m, :(const $META = $val))
         push!(modules, m)
         return val
     end
-    return getglobal(m, META)
+    return invokelatest(getglobal, m, META)
 end
 
 function signature!(tv::Vector{Any}, expr::Expr)

--- a/test/testhelpers/OffsetDenseArrays.jl
+++ b/test/testhelpers/OffsetDenseArrays.jl
@@ -24,7 +24,7 @@ function Base.setindex(x::OffsetDenseArray, v, i::Integer)
     x.x[i - x.offset] = v
 end
 
-IndexStyle(::Type{<:OffsetDenseArray}) = Base.IndexLinear()
+Base.IndexStyle(::Type{<:OffsetDenseArray}) = Base.IndexLinear()
 Base.axes(x::OffsetDenseArray) = (x.offset + 1 : x.offset + length(x.x),)
 Base.keys(x::OffsetDenseArray) = only(axes(x))
 


### PR DESCRIPTION
This should be enough to get rid of the 3 lingering warnings in our main test suite.