### PR TITLE
don't taint `:terminates` because of the loop in `afoldl`

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -593,6 +593,7 @@ const ⊽ = nor
 # method count limit in inference
 afoldl(op, a) = a
 function afoldl(op, a, bs...)
+    @_terminates_locally_meta
     l = length(bs)
     i =  0; y = a;            l == i && return y
     #@nexprs 31 i -> (y = op(y, bs[i]); l == i && return y)

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -350,6 +350,7 @@ end
 end
 
 @test [Base.afoldl(+, 1:i...) for i = 1:40] == [i * (i + 1) ÷ 2 for i = 1:40]
+@test Core.Compiler.is_terminates(Base.infer_effects(Base.afoldl, Tuple{typeof(+), Vararg{Int, 100}}))
 
 @testset "Returns" begin
     @test @inferred(Returns(1)()   ) === 1


### PR DESCRIPTION
The iteration count is always finite.