### PR TITLE
gf: add `concrete_lim` parameter for addl. compilable method limit

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -135,6 +135,7 @@ using Core: ARGS, include
 using ..Compiler: >, getindex, length
 
 global MAX_METHODS::Int = 3
+global MAX_CONCRETE_METHODS::Int = 0
 
 if length(ARGS) > 2 && ARGS[2] === "--buildsettings"
     include(BuildSettings, ARGS[3])

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -1390,9 +1390,6 @@ function compute_inlining_cases(@nospecialize(info::CallInfo), flag::UInt32, sig
             handled_all_cases &= handle_any_const_result!(cases,
                 result, match, argtypes, info, flag, state; allow_typevars=true)
         end
-        if !fully_covered
-            # We will emit an inline MethodError in this case, but that info already came inference, so we must already have the uncovered edge for it
-        end
     elseif !isempty(cases)
         # if we've not seen all candidates, union split is valid only for dispatch tuples
         filter!(case::InliningCase->isdispatchtuple(case.sig), cases)

--- a/Compiler/src/types.jl
+++ b/Compiler/src/types.jl
@@ -158,6 +158,13 @@ Parameters that control abstract interpretation-based type inference operation.
   can have a more fine-grained control on this configuration with per-module or per-method
   annotation basis.
 ---
+- `inf_params.max_concrete_methods::Int = 0`\\
+  TODO: rewrite
+  Specifies an additional set of allowed matches for a call (on top of `max_methods`) for
+  "concrete" methods which have exactly one specialization signature, i.e. the signature they
+  were defined with is already fully-specialized, for example all argument types are concrete
+  or marked `@nospecialize`.
+---
 - `inf_params.max_union_splitting::Int = 4`\\
   Specifies the maximum number of union-tuples to swap or expand before computing the set of
   matching methods or conditional types.
@@ -194,6 +201,7 @@ Parameters that control abstract interpretation-based type inference operation.
 """
 struct InferenceParams
     max_methods::Int
+    max_concrete_methods::Int
     max_union_splitting::Int
     max_apply_union_enum::Int
     max_tuple_splat::Int
@@ -205,6 +213,7 @@ struct InferenceParams
 
     function InferenceParams(
         max_methods::Int,
+        max_concrete_methods::Int,
         max_union_splitting::Int,
         max_apply_union_enum::Int,
         max_tuple_splat::Int,
@@ -212,9 +221,11 @@ struct InferenceParams
         ipo_constant_propagation::Bool,
         aggressive_constant_propagation::Bool,
         assume_bindings_static::Bool,
-        ignore_recursion_hardlimit::Bool)
+        ignore_recursion_hardlimit::Bool,
+    )
         return new(
             max_methods,
+            max_concrete_methods,
             max_union_splitting,
             max_apply_union_enum,
             max_tuple_splat,
@@ -222,12 +233,14 @@ struct InferenceParams
             ipo_constant_propagation,
             aggressive_constant_propagation,
             assume_bindings_static,
-            ignore_recursion_hardlimit)
+            ignore_recursion_hardlimit,
+        )
     end
 end
 function InferenceParams(
     params::InferenceParams = InferenceParams( # default constructor
         #=max_methods::Int=# BuildSettings.MAX_METHODS,
+        #=max_concrete_methods::Int=# BuildSettings.MAX_CONCRETE_METHODS,
         #=max_union_splitting::Int=# 4,
         #=max_apply_union_enum::Int=# 8,
         #=max_tuple_splat::Int=# 32,
@@ -235,8 +248,10 @@ function InferenceParams(
         #=ipo_constant_propagation::Bool=# true,
         #=aggressive_constant_propagation::Bool=# false,
         #=assume_bindings_static::Bool=# false,
-        #=ignore_recursion_hardlimit::Bool=# false);
+        #=ignore_recursion_hardlimit::Bool=# false
+    );
     max_methods::Int = params.max_methods,
+    max_concrete_methods::Int = params.max_concrete_methods,
     max_union_splitting::Int = params.max_union_splitting,
     max_apply_union_enum::Int = params.max_apply_union_enum,
     max_tuple_splat::Int = params.max_tuple_splat,
@@ -244,9 +259,11 @@ function InferenceParams(
     ipo_constant_propagation::Bool = params.ipo_constant_propagation,
     aggressive_constant_propagation::Bool = params.aggressive_constant_propagation,
     assume_bindings_static::Bool = params.assume_bindings_static,
-    ignore_recursion_hardlimit::Bool = params.ignore_recursion_hardlimit)
+    ignore_recursion_hardlimit::Bool = params.ignore_recursion_hardlimit,
+)
     return InferenceParams(
         max_methods,
+        max_concrete_methods,
         max_union_splitting,
         max_apply_union_enum,
         max_tuple_splat,
@@ -254,7 +271,8 @@ function InferenceParams(
         ipo_constant_propagation,
         aggressive_constant_propagation,
         assume_bindings_static,
-        ignore_recursion_hardlimit)
+        ignore_recursion_hardlimit,
+    )
 end
 
 """

--- a/Compiler/test/EscapeAnalysis.jl
+++ b/Compiler/test/EscapeAnalysis.jl
@@ -1417,8 +1417,8 @@ end
             max = Ref{UInt}(typemax(UInt))
             has_ambig = Ref{Int32}(0)
             mt = ccall(:jl_matching_methods, Any,
-                (Any, Any, Cint, Cint, UInt, Ptr{UInt}, Ptr{UInt}, Ref{Int32}),
-                t, mt, lim, ambig, world, min, max, has_ambig)::Union{Array{Any,1}, Bool}
+                (Any, Any, Cint, Cint, Cint, UInt, Ptr{UInt}, Ptr{UInt}, Ref{Int32}),
+                t, mt, lim, #= concrete_lim =# 0, ambig, world, min, max, has_ambig)::Union{Array{Any,1}, Bool}
             return mt, has_ambig[]
         end
         for i in findall(isnew, result.ir.stmts.stmt)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1139,7 +1139,7 @@ function isambiguous(m1::Method, m2::Method; ambiguous_bottom::Bool=false)
         min = Ref{UInt}(typemin(UInt))
         max = Ref{UInt}(typemax(UInt))
         has_ambig = Ref{Int32}(0)
-        ms = collect(Core.MethodMatch, _methods_by_ftype(ti, nothing, -1, world, true, min, max, has_ambig)::Vector)
+        ms = collect(Core.MethodMatch, _methods_by_ftype(ti, nothing, -1, -1, world, true, min, max, has_ambig)::Vector)
         has_ambig[] == 0 && return false
         if !ambiguous_bottom
             filter!(ms) do m::Core.MethodMatch

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -895,7 +895,7 @@ JL_DLLEXPORT jl_method_instance_t *jl_method_lookup(jl_value_t **args, size_t na
 jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value_t **args, size_t nargs);
 jl_value_t *jl_gf_invoke(jl_value_t *types, jl_value_t *f, jl_value_t **args, size_t nargs);
 JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup_worlds(jl_value_t *types, jl_value_t *mt, size_t world, size_t *min_world, size_t *max_world);
-JL_DLLEXPORT jl_value_t *jl_matching_methods(jl_tupletype_t *types, jl_value_t *mt, int lim, int include_ambiguous,
+JL_DLLEXPORT jl_value_t *jl_matching_methods(jl_tupletype_t *types, jl_value_t *mt, int lim, int concrete_lim, int include_ambiguous,
                                              size_t world, size_t *min_valid, size_t *max_valid, int *ambig);
 JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup_worlds(jl_value_t *types, jl_value_t *mt, size_t world, size_t *min_world, size_t *max_world);
 

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -907,7 +907,7 @@ end
 function complete_methods!(out::Vector{Completion}, @nospecialize(funct), args_ex::Vector{Any}, kwargs_ex::Set{Symbol}, max_method_completions::Int, exact_nargs::Bool)
     # Input types and number of arguments
     t_in = Tuple{funct, args_ex...}
-    m = Base._methods_by_ftype(t_in, nothing, max_method_completions, Base.get_world_counter(),
+    m = Base._methods_by_ftype(t_in, nothing, max_method_completions, 0, Base.get_world_counter(),
         #=ambig=# true, Ref(typemin(UInt)), Ref(typemax(UInt)), Ptr{Int32}(C_NULL))
     if !isa(m, Vector)
         push!(out, TextCompletion(sprint(Base.show_signature_function, funct) * "( too many methods, use SHIFT-TAB to show )"))

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2140,7 +2140,7 @@ function detect_ambiguities(mods::Module...;
             is_in_mods(parentmodule(m), recursive, mods) || continue
             world = Base.get_world_counter()
             ambig = Ref{Int32}(0)
-            ms = Base._methods_by_ftype(m.sig, nothing, -1, world, true, Ref(typemin(UInt)), Ref(typemax(UInt)), ambig)::Vector
+            ms = Base._methods_by_ftype(m.sig, nothing, -1, -1, world, true, Ref(typemin(UInt)), Ref(typemax(UInt)), ambig)::Vector
             ambig[] == 0 && continue
             for match2 in ms
                 match2 = match2::Core.MethodMatch

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -297,25 +297,25 @@ for f in (Ambig8.f, Ambig8.g)
     @test_throws MethodError f(0)
     @test_throws MethodError f(pi)
     let ambig = Ref{Int32}(0)
-        ms = Base._methods_by_ftype(Tuple{typeof(f), Union{Int,AbstractIrrational}}, nothing, 10, Base.get_world_counter(), false, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+        ms = Base._methods_by_ftype(Tuple{typeof(f), Union{Int,AbstractIrrational}}, nothing, 10, 0, Base.get_world_counter(), false, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
         @test ms isa Vector
         @test length(ms) == 2
         @test ambig[] == 1
     end
     let ambig = Ref{Int32}(0)
-        ms = Base._methods_by_ftype(Tuple{typeof(f), Union{Int,AbstractIrrational}}, nothing, -1, Base.get_world_counter(), false, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+        ms = Base._methods_by_ftype(Tuple{typeof(f), Union{Int,AbstractIrrational}}, nothing, -1, 0, Base.get_world_counter(), false, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
         @test ms isa Vector
         @test length(ms) == 2
         @test ambig[] == 1
     end
     let ambig = Ref{Int32}(0)
-        ms = Base._methods_by_ftype(Tuple{typeof(f), Union{Int,AbstractIrrational}}, nothing, 10, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+        ms = Base._methods_by_ftype(Tuple{typeof(f), Union{Int,AbstractIrrational}}, nothing, 10, 0, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
         @test ms isa Vector
         @test length(ms) == 3
         @test ambig[] == 1
     end
     let ambig = Ref{Int32}(0)
-        ms = Base._methods_by_ftype(Tuple{typeof(f), Union{Int,AbstractIrrational}}, nothing, -1, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+        ms = Base._methods_by_ftype(Tuple{typeof(f), Union{Int,AbstractIrrational}}, nothing, -1, 0, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
         @test ms isa Vector
         @test length(ms) == 3
         @test ambig[] == 1
@@ -382,7 +382,7 @@ f35983(::Type, ::Type) = 2
 @test length(Base.methods(f35983, (Any, Any))) == 2
 @test first(Base.methods(f35983, (Any, Any))).sig == Tuple{typeof(f35983), Type, Type}
 let ambig = Ref{Int32}(0)
-    ms = Base._methods_by_ftype(Tuple{typeof(f35983), Type, Type}, nothing, -1, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+    ms = Base._methods_by_ftype(Tuple{typeof(f35983), Type, Type}, nothing, -1, 0, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
     @test ms isa Vector
     @test length(ms) == 1
     @test ambig[] == 0
@@ -391,7 +391,7 @@ f35983(::Type{Int16}, ::Any) = 3
 @test length(Base.methods_including_ambiguous(f35983, (Type, Type))) == 2
 @test length(Base.methods(f35983, (Type, Type))) == 1
 let ambig = Ref{Int32}(0)
-    ms = Base._methods_by_ftype(Tuple{typeof(f35983), Type, Type}, nothing, -1, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+    ms = Base._methods_by_ftype(Tuple{typeof(f35983), Type, Type}, nothing, -1, 0, Base.get_world_counter(), true, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
     @test ms isa Vector
     @test length(ms) == 2
     @test ambig[] == 1
@@ -399,7 +399,7 @@ end
 
 struct B38280 <: Real; val; end
 let ambig = Ref{Int32}(0)
-    ms = Base._methods_by_ftype(Tuple{Type{B38280}, Any}, nothing, 1, Base.get_world_counter(), false, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
+    ms = Base._methods_by_ftype(Tuple{Type{B38280}, Any}, nothing, 1, 0, Base.get_world_counter(), false, Ref{UInt}(typemin(UInt)), Ref{UInt}(typemax(UInt)), ambig)
     @test ms isa Vector
     @test length(ms) == 1
     @test ambig[] == 1
@@ -410,7 +410,7 @@ fnoambig(::Int,::Any) = 2
 fnoambig(::Any,::Int) = 3
 fnoambig(::Any,::Any) = 4
 let has_ambig = Ref(Int32(0))
-    ms = Base._methods_by_ftype(Tuple{typeof(fnoambig), Any, Any}, nothing, 4, Base.get_world_counter(), false, Ref(typemin(UInt)), Ref(typemax(UInt)), has_ambig)
+    ms = Base._methods_by_ftype(Tuple{typeof(fnoambig), Any, Any}, nothing, 4, 0, Base.get_world_counter(), false, Ref(typemin(UInt)), Ref(typemax(UInt)), has_ambig)
     @test ms isa Vector
     @test length(ms) == 4
     @test has_ambig[] == 0


### PR DESCRIPTION
The intention here is to distinguish between:
 - matched methods whose compilable specializations are in an `O(1):1` ratio with lowered source code, so that the methods explored via this query are bounded by a fixed-multiple of source code size.
 - unbounded-specializing methods, which may be in a many-to-one mapping from MethodInstance to literal source.

The analogy is that an "instance" of a function is a specialization, similar to how an "instance" of an abstract type is a concrete type. As you might expect, concrete / finite-unions can be split / explored more aggressively than unboundedly-abstract ones.

The first type of methods are called "concrete" in this PR, although that's open to review / feedback. A better name (which is correct for a wider set of reasonable predicates) might be "bounded- specialization functions" or "finitely-specializable functions".  The main goal is to explore these methods more aggressively in `inlining`, so the `union-split` limits can be relaxed for "sum-type"-like patterns.

Just a draft / hack to start discussion: The exact predicate still needs fixing and the implementation of `ml_sortmatches` needs to be adapted to apply concrete_lim properly. It also might be worth caching the "concrete-ness" query as a flag on the `Method` object itself.