### PR TITLE
cconvert(Ref{BigFloat}, x) should return BigFloatData

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -214,6 +214,8 @@ end
 Base.unsafe_convert(::Type{Ref{BigFloat}}, x::Ptr{BigFloat}) = error("not compatible with mpfr")
 Base.unsafe_convert(::Type{Ref{BigFloat}}, x::Ref{BigFloat}) = error("not compatible with mpfr")
 Base.cconvert(::Type{Ref{BigFloat}}, x::BigFloat) = x.d # BigFloatData is the Ref type for BigFloat
+Base.cconvert(::Type{Ref{BigFloat}}, x::Number) = convert(BigFloat, x).d # avoid default conversion to Ref(BigFloat(x))
+Base.cconvert(::Type{Ref{BigFloat}}, x::Ref{BigFloat}) = x[].d
 function Base.unsafe_convert(::Type{Ref{BigFloat}}, x::BigFloatData)
     d = getfield(x, :d)
     p = Base.unsafe_convert(Ptr{Limb}, d)

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -1097,3 +1097,10 @@ end
         end
     end
 end
+
+# BigFloatData is the Ref type for BigFloat in ccall:
+@testset "cconvert(Ref{BigFloat}, x)" begin
+    for x in (1.0, big"1.0", Ref(big"1.0"))
+        @test Base.cconvert(Ref{BigFloat}, x) isa Base.MPFR.BigFloatData
+    end
+end


### PR DESCRIPTION
#55906 changed `cconvert(Ref{BigFloat}, x::BigFloat)` to return `x.d`, but neglected to do so for other types of `x`, where it still returns a `Ref{BigFloat}` and hence is now returning the wrong type for `ccall`.

Not only does this break backwards compatibility (https://github.com/JuliaMath/SpecialFunctions.jl/issues/485), but it also seems simply wrong: the *whole* job of `cconvert` is to convert objects to the correct type for use with `ccall`.  This PR does so (at least for `Number` and `Ref{BigFloat}`).