### PR TITLE
staticdata: Fix typo in recursive edge revalidation

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -4390,7 +4390,7 @@ JL_DLLEXPORT void _jl_promote_ci_to_current(jl_code_instance_t *ci, size_t valid
         jl_value_t *edge = jl_svecref(edges, i);
         if (!jl_is_code_instance(edge))
             continue;
-        _jl_promote_ci_to_current(ci, validated_world);
+        _jl_promote_ci_to_current((jl_code_instance_t *)edge, validated_world);
     }
 }
 

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2307,6 +2307,7 @@ precompile_test_harness("llvmcall validation") do load_path
     @eval using LLVMCall
     invokelatest() do
         @test LLVMCall.do_llvmcall2() == UInt32(0)
+        @test first(methods(LLVMCall.do_llvmcall)).specializations.cache.max_world === typemax(UInt)
     end
 end
 


### PR DESCRIPTION
Addresses mystery #3 in #57381 (and extends the test from that issue).