### PR TITLE
Only strip invariant.load from special pointers

### DIFF
--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1979,7 +1979,7 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
             // strip all constant alias information, as it might depend on the gc having
             // preserved a gc root, which stops being true after this pass (#32215)
             // similar to RewriteStatepointsForGC::stripNonValidData, but less aggressive
-            if (auto *LI = dyn_cast<Load>(I)){
+            if (auto *LI = dyn_cast<LoadInst>(I)){
                 if (isSpecialPtr(LI->getPointerOperand()->getType()) && LI->getMetadata(LLVMContext::MD_invariant_load))
                     LI->setMetadata(LLVMContext::MD_invariant_load, NULL);
             }

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1979,8 +1979,10 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
             // strip all constant alias information, as it might depend on the gc having
             // preserved a gc root, which stops being true after this pass (#32215)
             // similar to RewriteStatepointsForGC::stripNonValidData, but less aggressive
-            if (I->getMetadata(LLVMContext::MD_invariant_load))
-                I->setMetadata(LLVMContext::MD_invariant_load, NULL);
+            if (auto *LI = dyn_cast<Load>(I)){
+                if (isSpecialPtr(LI->getPointerOperand()->getType()) && LI->getMetadata(LLVMContext::MD_invariant_load))
+                    LI->setMetadata(LLVMContext::MD_invariant_load, NULL);
+            }
             if (MDNode *TBAA = I->getMetadata(LLVMContext::MD_tbaa)) {
                 if (TBAA->getNumOperands() == 4 && isTBAA(TBAA, {"jtbaa_const", "jtbaa_memoryptr", "jtbaa_memorylen", "tbaa_memoryown"})) {
                     MDNode *MutableTBAA = createMutableTBAAAccessTag(TBAA);

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -90,6 +90,22 @@ top:
     ret void
 }
 
+; Confirm that `invariant.load` on other loads survive
+define void @gc_keep_invariant(float addrspace(1)* %0) {
+top:
+; CHECK-LABEL: @gc_drop_aliasing
+    %pgcstack = call {}*** @julia.get_pgcstack()
+    %1 = bitcast {}*** %pgcstack to {}**
+    %current_task = getelementptr inbounds {}*, {}** %0, i64 -12
+
+; CHECK: %current_task = getelementptr inbounds ptr, ptr %0, i64 -12
+; CHECK-NEXT: [[ptls_field:%.*]] = getelementptr inbounds i8, ptr %current_task,
+; CHECK-NEXT: [[ptls_load:%.*]] = load ptr, ptr [[ptls_field]], align 8, !tbaa !0
+    %2 = load float, float addrspace(1)* %0, align 4, !invariant.load
+; CHECK-NEXT: = load float, float addrspace(1)* %0, align 4, !invariant.load
+    ret void
+}
+
 define i32 @callee_root({} addrspace(10)* %v0, {} addrspace(10)* %v1) {
 top:
 ; CHECK-LABEL: @callee_root

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -93,7 +93,7 @@ top:
 ; Confirm that `invariant.load` on other loads survive
 define void @gc_keep_invariant(float addrspace(1)* %0) {
 top:
-; CHECK-LABEL: @gc_drop_aliasing
+; CHECK-LABEL: @gc_keep_invariant
     %pgcstack = call {}*** @julia.get_pgcstack()
     %1 = bitcast {}*** %pgcstack to {}**
     %current_task = getelementptr inbounds {}*, {}** %0, i64 -12

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -96,13 +96,11 @@ top:
 ; CHECK-LABEL: @gc_keep_invariant
     %pgcstack = call {}*** @julia.get_pgcstack()
     %1 = bitcast {}*** %pgcstack to {}**
-    %current_task = getelementptr inbounds {}*, {}** %0, i64 -12
+    %current_task = getelementptr inbounds {}*, {}** %1, i64 -12
 
-; CHECK: %current_task = getelementptr inbounds ptr, ptr %0, i64 -12
-; CHECK-NEXT: [[ptls_field:%.*]] = getelementptr inbounds i8, ptr %current_task,
-; CHECK-NEXT: [[ptls_load:%.*]] = load ptr, ptr [[ptls_field]], align 8, !tbaa !0
-    %2 = load float, float addrspace(1)* %0, align 4, !invariant.load
-; CHECK-NEXT: = load float, float addrspace(1)* %0, align 4, !invariant.load
+; CHECK: %current_task = getelementptr inbounds ptr, ptr %1, i64 -12
+    %2 = load float, ptr addrspace(1) %0, align 4, !invariant.load !1
+; CHECK-NEXT: %2 = load float, ptr addrspace(1) %0, align 4, !invariant.load
     ret void
 }
 


### PR DESCRIPTION
Other backends (in this case NVPTX) require that `invariant.load`
metadata is maintained to generate non-coherent loads.

Currently, we unconditionally strip that metadata from all loads,
since our other uses of it may have become invalid.

x-ref: https://github.com/llvm/llvm-project/pull/112834 https://github.com/JuliaGPU/CUDA.jl/issues/2531
