### PR TITLE
bpart: Also partition the export flag

### DIFF
--- a/base/invalidation.jl
+++ b/base/invalidation.jl
@@ -113,39 +113,36 @@ function invalidate_method_for_globalref!(gr::GlobalRef, method::Method, invalid
     end
 end
 
-const BINDING_FLAG_EXPORTP = 0x2
-
 function invalidate_code_for_globalref!(b::Core.Binding, invalidated_bpart::Core.BindingPartition, new_bpart::Union{Core.BindingPartition, Nothing}, new_max_world::UInt)
     gr = b.globalref
-    if is_some_guard(binding_kind(invalidated_bpart))
+    if !is_some_guard(binding_kind(invalidated_bpart))
         # TODO: We may want to invalidate for these anyway, since they have performance implications
-        return
-    end
-    foreach_module_mtable(gr.mod, new_max_world) do mt::Core.MethodTable
-        for method in MethodList(mt)
-            invalidate_method_for_globalref!(gr, method, invalidated_bpart, new_max_world)
+        foreach_module_mtable(gr.mod, new_max_world) do mt::Core.MethodTable
+            for method in MethodList(mt)
+                invalidate_method_for_globalref!(gr, method, invalidated_bpart, new_max_world)
+            end
+            return true
         end
-        return true
-    end
-    if isdefined(b, :backedges)
-        for edge in b.backedges
-            if isa(edge, CodeInstance)
-                ccall(:jl_invalidate_code_instance, Cvoid, (Any, UInt), edge, new_max_world)
-            elseif isa(edge, Core.Binding)
-                isdefined(edge, :partitions) || continue
-                latest_bpart = edge.partitions
-                latest_bpart.max_world == typemax(UInt) || continue
-                is_some_imported(binding_kind(latest_bpart)) || continue
-                partition_restriction(latest_bpart) === b || continue
-                invalidate_code_for_globalref!(edge, latest_bpart, nothing, new_max_world)
-            else
-                invalidate_method_for_globalref!(gr, edge::Method, invalidated_bpart, new_max_world)
+        if isdefined(b, :backedges)
+            for edge in b.backedges
+                if isa(edge, CodeInstance)
+                    ccall(:jl_invalidate_code_instance, Cvoid, (Any, UInt), edge, new_max_world)
+                elseif isa(edge, Core.Binding)
+                    isdefined(edge, :partitions) || continue
+                    latest_bpart = edge.partitions
+                    latest_bpart.max_world == typemax(UInt) || continue
+                    is_some_imported(binding_kind(latest_bpart)) || continue
+                    partition_restriction(latest_bpart) === b || continue
+                    invalidate_code_for_globalref!(edge, latest_bpart, nothing, new_max_world)
+                else
+                    invalidate_method_for_globalref!(gr, edge::Method, invalidated_bpart, new_max_world)
+                end
             end
         end
     end
-    if (b.flags & BINDING_FLAG_EXPORTP) != 0
+    if (invalidated_bpart.kind & BINDING_FLAG_EXPORTED != 0) || (new_bpart !== nothing && (new_bpart.kind & BINDING_FLAG_EXPORTED != 0))
         # This binding was exported - we need to check all modules that `using` us to see if they
-        # have an implicit binding to us.
+        # have a binding that is affected by this change.
         usings_backedges = ccall(:jl_get_module_usings_backedges, Any, (Any,), gr.mod)
         if usings_backedges !== nothing
             for user in usings_backedges::Vector{Any}
@@ -154,8 +151,8 @@ function invalidate_code_for_globalref!(b::Core.Binding, invalidated_bpart::Core
                 isdefined(user_binding, :partitions) || continue
                 latest_bpart = user_binding.partitions
                 latest_bpart.max_world == typemax(UInt) || continue
-                is_some_imported(binding_kind(latest_bpart)) || continue
-                partition_restriction(latest_bpart) === b || continue
+                binding_kind(latest_bpart) in (BINDING_KIND_IMPLICIT, BINDING_KIND_FAILED, BINDING_KIND_GUARD) || continue
+                @atomic :release latest_bpart.max_world = new_max_world
                 invalidate_code_for_globalref!(convert(Core.Binding, user_binding), latest_bpart, nothing, new_max_world)
             end
         end

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -209,6 +209,8 @@ const BINDING_KIND_GUARD        = 0x8
 const BINDING_KIND_UNDEF_CONST  = 0x9
 const BINDING_KIND_BACKDATED_CONST = 0xa
 
+const BINDING_FLAG_EXPORTED     = 0x10
+
 is_defined_const_binding(kind::UInt8) = (kind == BINDING_KIND_CONST || kind == BINDING_KIND_CONST_IMPORT || kind == BINDING_KIND_BACKDATED_CONST)
 is_some_const_binding(kind::UInt8) = (is_defined_const_binding(kind) || kind == BINDING_KIND_UNDEF_CONST)
 is_some_imported(kind::UInt8) = (kind == BINDING_KIND_IMPLICIT || kind == BINDING_KIND_EXPLICIT || kind == BINDING_KIND_IMPORTED)

--- a/base/show.jl
+++ b/base/show.jl
@@ -3374,6 +3374,9 @@ function print_partition(io::IO, partition::Core.BindingPartition)
     else
         print(io, max_world)
     end
+    if (partition.kind & BINDING_FLAG_EXPORTED) != 0
+        print(io, " [exported]")
+    end
     print(io, " - ")
     kind = binding_kind(partition)
     if kind == BINDING_KIND_BACKDATED_CONST

--- a/src/ast.c
+++ b/src/ast.c
@@ -178,7 +178,7 @@ static value_t fl_defined_julia_global(fl_context_t *fl_ctx, value_t *args, uint
     jl_sym_t *var = scmsym_to_julia(fl_ctx, args[0]);
     jl_binding_t *b = jl_get_module_binding(ctx->module, var, 0);
     jl_binding_partition_t *bpart = jl_get_binding_partition(b, jl_current_task->world_age);
-    return (bpart != NULL && bpart->kind == BINDING_KIND_GLOBAL) ? fl_ctx->T : fl_ctx->F;
+    return (bpart != NULL && jl_binding_kind(bpart) == BINDING_KIND_GLOBAL) ? fl_ctx->T : fl_ctx->F;
 }
 
 // Used to generate a unique suffix for a given symbol (e.g. variable or type name)

--- a/src/method.c
+++ b/src/method.c
@@ -1061,10 +1061,10 @@ JL_DLLEXPORT jl_value_t *jl_declare_const_gf(jl_module_t *mod, jl_sym_t *name)
     jl_binding_t *b = jl_get_binding_for_method_def(mod, name, new_world);
     jl_binding_partition_t *bpart = jl_get_binding_partition(b, new_world);
     jl_value_t *gf = NULL;
-    enum jl_partition_kind kind = bpart->kind;
+    enum jl_partition_kind kind = jl_binding_kind(bpart);
     if (!jl_bkind_is_some_guard(kind) && kind != BINDING_KIND_DECLARED && kind != BINDING_KIND_IMPLICIT) {
         jl_walk_binding_inplace(&b, &bpart, new_world);
-        if (jl_bkind_is_some_constant(bpart->kind)) {
+        if (jl_bkind_is_some_constant(jl_binding_kind(bpart))) {
             gf = bpart->restriction;
             JL_GC_PROMISE_ROOTED(gf);
             jl_check_gf(gf, b->globalref->name);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -307,7 +307,7 @@ void jl_declare_global(jl_module_t *m, jl_value_t *arg, jl_value_t *set_type, in
         global_type = (jl_value_t*)jl_any_type;
     while (1) {
         bpart = jl_get_binding_partition(b, new_world);
-        enum jl_partition_kind kind = bpart->kind;
+        enum jl_partition_kind kind = jl_binding_kind(bpart);
         if (kind != BINDING_KIND_GLOBAL) {
             if (jl_bkind_is_some_guard(kind) || kind == BINDING_KIND_DECLARED || kind == BINDING_KIND_IMPLICIT) {
                 if (kind == new_kind) {
@@ -317,7 +317,7 @@ void jl_declare_global(jl_module_t *m, jl_value_t *arg, jl_value_t *set_type, in
                 }
                 check_safe_newbinding(gm, gs);
                 if (bpart->min_world == new_world) {
-                    bpart->kind = new_kind;
+                    bpart->kind = new_kind | (bpart->kind & 0xf0);
                     bpart->restriction = global_type;
                     if (global_type)
                         jl_gc_wb(bpart, global_type);
@@ -655,11 +655,11 @@ static void import_module(jl_module_t *JL_NONNULL m, jl_module_t *import, jl_sym
     // TODO: this is a bit race-y with what error message we might print
     jl_binding_t *b = jl_get_module_binding(m, name, 1);
     jl_binding_partition_t *bpart = jl_get_binding_partition(b, jl_current_task->world_age);
-    enum jl_partition_kind kind = bpart->kind;
+    enum jl_partition_kind kind = jl_binding_kind(bpart);
     if (kind != BINDING_KIND_GUARD && kind != BINDING_KIND_FAILED && kind != BINDING_KIND_DECLARED && kind != BINDING_KIND_IMPLICIT) {
         // Unlike regular constant declaration, we allow this as long as we eventually end up at a constant.
          jl_walk_binding_inplace(&b, &bpart, jl_current_task->world_age);
-        if (bpart->kind == BINDING_KIND_CONST || bpart->kind == BINDING_KIND_BACKDATED_CONST || bpart->kind == BINDING_KIND_CONST_IMPORT) {
+        if (jl_binding_kind(bpart) == BINDING_KIND_CONST || jl_binding_kind(bpart) == BINDING_KIND_BACKDATED_CONST || jl_binding_kind(bpart) == BINDING_KIND_CONST_IMPORT) {
             // Already declared (e.g. on another thread) or imported.
             if (bpart->restriction == (jl_value_t*)import)
                 return;

--- a/test/rebinding.jl
+++ b/test/rebinding.jl
@@ -193,10 +193,31 @@ module RebindingPrecompile
             Core.eval(Export2, :(const import_me2 = 22))
         end
         invokelatest() do
-            # Currently broken
-            # @test_throws UndefVarError ImportTest.f_use_binding2()
+            @test_throws UndefVarError ImportTest.f_use_binding2()
         end
     end
 
     finish_precompile_test!()
+end
+
+module Regression
+    using Test
+
+    # Issue #57377
+    module GeoParams57377
+        module B
+            using ...GeoParams57377
+            export S
+            struct S end
+            module C
+                using ..GeoParams57377
+                h() = S()
+                x -> nothing
+            end
+        end
+
+        using .B
+        export S
+    end
+    @test GeoParams57377.B.C.h() == GeoParams57377.B.C.S()
 end


### PR DESCRIPTION
Whether or not a binding is exported affects the binding resolution of any downstream modules that `using` the module that defines the binding. As such, it needs to fully participate in the invalidation mechanism, so that code which references bindings whose resolution may have changed get properly invalidated.

To do this, move the `exportp` flag from Binding into a separate bitflag set that gets or'd into the BindingPartition `->kind` field. Note that we do not move `publicp` in the same way since it does not affect binding resolution.

There is currently no mechanism to un-export a binding, although the system is set up to support this in the future (and Revise may want it). That said, at such a time, we may need to revisit the above decision on `publicp`.

Lastly, I will note that this adds a fair number of additional invalidations. Most of these are unnecessary, as changing an export only affects the *downstream* users not the binding itself. I am planning to tackle this as part of a larger future PR that avoids invalidation when this is not required.

Fixes #57377