### PR TITLE
bpart: Ignore guard bindings for ambiguity purposes

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -65,6 +65,7 @@ void jl_check_new_binding_implicit(
 
     jl_binding_t *deprecated_impb = NULL;
     jl_binding_t *impb = NULL;
+    jl_binding_partition_t *impbpart = NULL;
 
     size_t min_world = new_bpart->min_world;
     size_t max_world = jl_atomic_load_relaxed(&new_bpart->max_world);
@@ -111,6 +112,14 @@ void jl_check_new_binding_implicit(
             if (impb) {
                 if (tempb->deprecated)
                     continue;
+                if (jl_binding_kind(tempbpart) == BINDING_KIND_GUARD &&
+                    jl_binding_kind(impbpart) != BINDING_KIND_GUARD)
+                    continue;
+                if (jl_binding_kind(impbpart) == BINDING_KIND_GUARD) {
+                    impb = tempb;
+                    impbpart = tempbpart;
+                    continue;
+                }
                 if (eq_bindings(tempbpart, impb, world))
                     continue;
                 // Binding is ambiguous
@@ -132,6 +141,7 @@ void jl_check_new_binding_implicit(
             }
             else {
                 impb = tempb;
+                impbpart = tempbpart;
             }
         }
     }

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -4088,3 +4088,17 @@ abstract type A57267{S, T} end
     B57267{S} = A57267{S, 1}
     const C57267 = B57267
 end
+
+# #57404 - Binding ambiguity resolution ignores guard bindings
+module Ambig57404
+    module A
+        export S
+    end
+    using .A
+    module B
+        const S = 1
+        export S
+    end
+    using .B
+end
+@test Ambig57404.S == 1


### PR DESCRIPTION
This makes non-guard bindings stronger than guard bindings for ambiguity purposes. Note that both of these are yet stronger than deprecated bindings, so if there's a "non-guard deprecated" binding and a "guard non-deprecated" binding, the latter will win and the access will be UndefVarError. I think this is the closest to the 1.11 behavior without relying on resolvedness.

Fixes #57404

This PR is against #57405 just because that PR touches the common interface, but is conceptually independent.