### PR TITLE
codegen: cleanup gcstack call frames somewhat earlier

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -2162,12 +2162,12 @@ jl_cgval_t function_sig_t::emit_a_ccall(
         }
     }
 
-    // Potentially we could drop `jl_roots(gc_uses)` in the presence of `gc-transition(gc_uses)`
+    // Potentially we could add gc_uses to `gc-transition`, instead of emitting them separately as jl_roots
     SmallVector<OperandBundleDef, 2> bundles;
     if (!gc_uses.empty())
         bundles.push_back(OperandBundleDef("jl_roots", gc_uses));
     if (gc_safe)
-        bundles.push_back(OperandBundleDef("gc-transition", ArrayRef<Value*> {}));
+        bundles.push_back(OperandBundleDef("gc-transition", get_current_ptls(ctx)));
     // the actual call
     CallInst *ret = ctx.builder.CreateCall(functype, llvmf,
             argvals,

--- a/src/llvm-gc-interface-passes.h
+++ b/src/llvm-gc-interface-passes.h
@@ -328,7 +328,7 @@ public:
     bool runOnFunction(Function &F, bool *CFGModified = nullptr);
 
 private:
-    CallInst *pgcstack;
+    Value *pgcstack;
     Function *smallAllocFunc;
 
     void MaybeNoteDef(State &S, BBState &BBS, Value *Def, const ArrayRef<int> &SafepointsSoFar,
@@ -388,7 +388,7 @@ private:
     Function *smallAllocFunc;
     Function *bigAllocFunc;
     Function *allocTypedFunc;
-    Instruction *pgcstack;
+    Value *pgcstack;
     Type *T_size;
 
     // Lowers a `julia.new_gc_frame` intrinsic.
@@ -411,8 +411,9 @@ private:
 
     // Lowers a `julia.safepoint` intrinsic.
     void lowerSafepoint(CallInst *target, Function &F);
+
     // Check if the pass should be run
-    bool shouldRunFinalGC(Function &F);
+    bool shouldRunFinalGC();
 };
 
 #endif // LLVM_GC_PASSES_H

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -72,25 +72,9 @@ void JuliaPassContext::initAll(Module &M)
     T_prjlvalue = JuliaType::get_prjlvalue_ty(ctx);
 }
 
-llvm::CallInst *JuliaPassContext::getPGCstack(llvm::Function &F) const
+llvm::Value *JuliaPassContext::getPGCstack(llvm::Function &F) const
 {
-    if (!pgcstack_getter && !adoptthread_func)
-        return nullptr;
-    for (auto &I : F.getEntryBlock()) {
-        if (CallInst *callInst = dyn_cast<CallInst>(&I)) {
-            Value *callee = callInst->getCalledOperand();
-            if ((pgcstack_getter && callee == pgcstack_getter) ||
-                (adoptthread_func && callee == adoptthread_func)) {
-                return callInst;
-            }
-        }
-    }
-    return nullptr;
-}
-
-llvm::CallInst *JuliaPassContext::getOrAddPGCstack(llvm::Function &F)
-{
-    if (pgcstack_getter || adoptthread_func)
+    if (pgcstack_getter || adoptthread_func) {
         for (auto &I : F.getEntryBlock()) {
             if (CallInst *callInst = dyn_cast<CallInst>(&I)) {
                 Value *callee = callInst->getCalledOperand();
@@ -100,13 +84,14 @@ llvm::CallInst *JuliaPassContext::getOrAddPGCstack(llvm::Function &F)
                 }
             }
         }
-    IRBuilder<> builder(&F.getEntryBlock().front());
-    if (pgcstack_getter)
-        return builder.CreateCall(pgcstack_getter);
-    auto FT = FunctionType::get(PointerType::get(F.getContext(), 0), false);
-    auto F2 = Function::Create(FT, Function::ExternalLinkage, "julia.get_pgcstack", F.getParent());
-    pgcstack_getter = F2;
-    return builder.CreateCall( F2);
+    }
+    if (F.getCallingConv() == CallingConv::Swift) {
+        for (auto &arg : F.args()) {
+            if (arg.hasSwiftSelfAttr())
+                return &arg;
+        }
+    }
+    return nullptr;
 }
 
 llvm::Function *JuliaPassContext::getOrNull(

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -85,12 +85,10 @@ struct JuliaPassContext {
 
     // Gets a call to the `julia.get_pgcstack' intrinsic in the entry
     // point of the given function, if there exists such a call.
+    // Otherwise, gets a swiftself argument, if there exists such an argument.
     // Otherwise, `nullptr` is returned.
-    llvm::CallInst *getPGCstack(llvm::Function &F) const;
-    // Gets a call to the `julia.get_pgcstack' intrinsic in the entry
-    // point of the given function, if there exists such a call.
-    // Otherwise, creates a new call to the intrinsic
-    llvm::CallInst *getOrAddPGCstack(llvm::Function &F);
+    llvm::Value *getPGCstack(llvm::Function &F) const;
+
     // Gets the intrinsic or well-known function that conforms to
     // the given description if it exists in the module. If not,
     // `nullptr` is returned.

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -322,13 +322,13 @@ bool LowerPTLS::run(bool *CFGModified)
             need_init = false;
         }
 
-        for (auto it = pgcstack_getter->user_begin(); it != pgcstack_getter->user_end();) {
+        for (auto it = pgcstack_getter->user_begin(); it != pgcstack_getter->user_end(); ) {
             auto call = cast<CallInst>(*it);
             ++it;
             auto f = call->getCaller();
             Value *pgcstack = NULL;
-            for (Function::arg_iterator arg = f->arg_begin(); arg != f->arg_end();++arg) {
-                if (arg->hasSwiftSelfAttr()){
+            for (Function::arg_iterator arg = f->arg_begin(); arg != f->arg_end(); ++arg) {
+                if (arg->hasSwiftSelfAttr()) {
                     pgcstack = &*arg;
                     break;
                 }


### PR DESCRIPTION
Slightly reduces the amount of work these optimization passes need to do later, in most typical cases, and avoids putting an unknown call at the top of all of our functions, which can inhibit some optimizations of otherwise trivial functions.

Fixes #57400