### PR TITLE
generated: Switch resolution module back to what it was before

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -1694,6 +1694,6 @@ function (g::Core.GeneratedFunctionStub)(world::UInt, source::Method, @nospecial
                          Expr(:meta, :pop_loc))))
     spnames = g.spnames
     return generated_body_to_codeinfo(spnames === Core.svec() ? lam : Expr(Symbol("with-static-parameters"), lam, spnames...),
-        typename(typeof(g.gen)).module,
+        source.module,
         source.isva)
 end


### PR DESCRIPTION
This addresses post-commit review https://github.com/JuliaLang/julia/pull/57230#discussion_r1939750418. This change was left-over from before I decided to also change the type of the `source` argument (at which point `source.module` was unavailable in the function). This module was supposed to be the same, but it turns out that both the julia tests and several packages use this code manually and use different modules for the two places. Use the same one we used before (which is probably more correct anyway) to fix #57417