### PR TITLE
reword eachslice docs to allow other slices objects

### DIFF
--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -77,7 +77,7 @@ end
 """
     eachslice(A::AbstractArray; dims, drop=true)
 
-Create a sliced object, usually [`Slices`](@ref), that is an array of slices over dimensions 
+Create a sliced object, usually [`Slices`](@ref), that is an array of slices over dimensions
 `dims` of `A`, returning views that select all the data from the other dimensions in `A`.
 `dims` can either be an integer or a tuple of integers.
 

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -77,13 +77,13 @@ end
 """
     eachslice(A::AbstractArray; dims, drop=true)
 
-Create a [`Slices`](@ref) object that is an array of slices over dimensions `dims` of `A`, returning
-views that select all the data from the other dimensions in `A`. `dims` can either be an
-integer or a tuple of integers.
+Create a sliced object, usually [`Slices`](@ref), that is an array of slices over dimensions 
+`dims` of `A`, returning views that select all the data from the other dimensions in `A`.
+`dims` can either be an integer or a tuple of integers.
 
-If `drop = true` (the default), the outer `Slices` will drop the inner dimensions, and
+If `drop = true` (the default), the outer slices will drop the inner dimensions, and
 the ordering of the dimensions will match those in `dims`. If `drop = false`, then the
-`Slices` will have the same dimensionality as the underlying array, with inner
+slices object will have the same dimensionality as the underlying array, with inner
 dimensions having size 1.
 
 See [`stack`](@ref)`(slices; dims)` for the inverse of `eachslice(A; dims::Integer)`.


### PR DESCRIPTION
The wording of `eachslice` is overly strict in enforcing a `Slices`  return type, instead of allowing other objects with similar behavior but e.g. potentially additional behaviors. The existence of `AbstractSlices` suggests this was actually intended at some stage but did not make it into the docs. 

AxisKeys.jl already returns something else and it seems not to cause any problems, but it would be good to be able to do this without breaking the documented contract of the method.

Closes #57206