### PR TITLE
Don't return null pointer when asking for the type of a declared global

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -782,9 +782,10 @@ JL_DLLEXPORT jl_value_t *jl_get_binding_type(jl_module_t *m, jl_sym_t *var)
     if (b == NULL)
         return jl_nothing;
     jl_walk_binding_inplace(&b, &bpart, jl_current_task->world_age);
-    if (jl_bkind_is_some_guard(jl_binding_kind(bpart)))
+    enum jl_partition_kind kind = jl_binding_kind(bpart);
+    if (jl_bkind_is_some_guard(kind) || kind == BINDING_KIND_DECLARED)
         return jl_nothing;
-    if (jl_bkind_is_some_constant(jl_binding_kind(bpart))) {
+    if (jl_bkind_is_some_constant(kind)) {
         // TODO: We would like to return the type of the constant, but
         // currently code relies on this returning any to bypass conversion
         // before an attempted assignment to a constant.

--- a/test/core.jl
+++ b/test/core.jl
@@ -8463,3 +8463,11 @@ function f57315()
     return 1
 end
 @test_throws UndefVarError(:flag_2, :local) f57315()
+
+# issue #57446
+module GlobalAssign57446
+    using Test
+    global theglobal
+    (@__MODULE__).theglobal = 1
+    @test theglobal == 1
+end


### PR DESCRIPTION
The `_DECLARED` partition kind used to be considered `guard`, but we now consider it equivalent to an Any-typed `_GLOBAL` (but with weaker redefinition properties). That said, its `->restriction` is NULL, so add it to the list of bindings that should return `nothing` here (and thus `Any` from the bulitin) to fix #57446.