### PR TITLE
Logging: test multithreaded logging

### DIFF
--- a/stdlib/Logging/test/threads_exec.jl
+++ b/stdlib/Logging/test/threads_exec.jl
@@ -1,0 +1,14 @@
+using Logging
+
+function test_threads_exec(n)
+    Threads.@threads for i in 1:n
+        x = rand()
+        @debug "iteration" i x Threads.threadid()
+        @info "iteration" i x Threads.threadid()
+        @warn "iteration" i x Threads.threadid()
+        @error "iteration" i x Threads.threadid()
+    end
+end
+
+n = parse(Int, ARGS[1])
+test_threads_exec(n)


### PR DESCRIPTION
Investigating https://github.com/JuliaLang/julia/issues/57376

With and without the redirect there's no crash locally.
Ideally it'd be good to test logging to the console but I don't think we can do that without noisy logs on the console..

- Tests for no crashes due to memory corruption
- Tests that no tearing occurs in log prints