### PR TITLE
adds libmsvcrt from mingw-64 to the build directory

### DIFF
--- a/deps/csl.mk
+++ b/deps/csl.mk
@@ -125,6 +125,11 @@ install-csl:
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/$(GCC_VERSION)/libmsvcrt.a $(build_private_libdir)/
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/$(GCC_VERSION)/libssp.dll.a $(build_private_libdir)/
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/$(GCC_VERSION)/libssp.dll.a $(build_libdir)/
+ifeq ($(ARCH),x86_64)
+	-cp -a /mingw64/lib/libmsvcrt.a  $(build_private_libdir)/
+else
+	-cp -a /mingw32/i686-w64-mingw32/lib/libmsvcrt.a  $(build_private_libdir)/
+endif # ifeq ($(ARCH),x86_64)
 endif
 endif
 ifeq ($(OS),WINNT)

--- a/deps/csl.mk
+++ b/deps/csl.mk
@@ -125,11 +125,7 @@ install-csl:
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/$(GCC_VERSION)/libmsvcrt.a $(build_private_libdir)/
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/$(GCC_VERSION)/libssp.dll.a $(build_private_libdir)/
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/$(GCC_VERSION)/libssp.dll.a $(build_libdir)/
-ifeq ($(ARCH),x86_64)
-	-cp -a /mingw64/lib/libmsvcrt.a  $(build_private_libdir)/
-else
-	-cp -a /mingw32/i686-w64-mingw32/lib/libmsvcrt.a  $(build_private_libdir)/
-endif # ifeq ($(ARCH),x86_64)
+	-cp -a $(MINGW_PREFIX)/lib/libmsvcrt.a  $(build_private_libdir)/
 endif
 endif
 ifeq ($(OS),WINNT)


### PR DESCRIPTION
### The Problem: Build fails on Windows when using Msys/MinGW

Build was failing on windows 11 with MINGW64 using [these instructions](https://docs.julialang.org/en/v1.13-dev/devdocs/build/windows/#Compiling-with-MinGW/MSYS2) with the following error (See #57397). This is perhaps because of C runtime version mismatches (see #56840). 

```
Output ────── 450.762215 seconds
    LINK usr/lib/julia/sys.dll
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../lib/dllcrt2.o: in function `_CRT_INIT':
C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtdll.c:100:(.text+0x15d): undefined reference to `_initterm_e'
collect2.exe: error: ld returned 1 exit status
make[1]: *** [sysimage.mk:18: /c/Users/kajin/Documents/julia/usr/lib/julia/sys.dll] Error 1
make: *** [Makefile:120: julia-sysimg-release] Error 2

```

### The fix

Copy the `libmsvcrt.a` provided by `mingw` in the right spot in the julia build directory. 

**this PR fixes it**
based on this patch: 

https://github.com/Zentrik/llvm_julia_tester/blob/d8bfc7590bbcb3a9bc5c9eedbfe11bf65eddd91c/julia-patches/ffba662dd275d1bdd5a5935f4d3cc372b5235d07

Fix #56840, fix #57397.