### PR TITLE
Add exit code to `Base.compilecache` error message

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3288,7 +3288,7 @@ function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, in
     if p.exitcode == 125
         return PrecompilableError()
     else
-        error("Failed to precompile $(repr("text/plain", pkg)) to $(repr(tmppath)).")
+        error("Failed to precompile $(repr("text/plain", pkg)) to $(repr(tmppath)) (exit code $(p.exitcode)).")
     end
 end
 


### PR DESCRIPTION
Minor tweak to the error message: embed the exit code of the Julia child process that failed to compile the package.