### PR TITLE
Use `Base.process_status(p)` instead of `p.exitcode` in error message

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3288,7 +3288,7 @@ function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, in
     if p.exitcode == 125
         return PrecompilableError()
     else
-        error("Failed to precompile $(repr("text/plain", pkg)) to $(repr(tmppath)) (exit code $(p.exitcode)).")
+        error("Failed to precompile $(repr("text/plain", pkg)) to $(repr(tmppath)) ($(Base.process_status(p))).")
     end
 end
 


### PR DESCRIPTION
Fixup https://github.com/JuliaLang/julia/pull/57455