### PR TITLE
Minor change to an example for clarity.

### DIFF
--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -1002,13 +1002,13 @@ there is a terse syntax form. In the function body, `p` will refer to the object
 called. A `Polynomial` can be used as follows:
 
 ```jldoctest polynomial
-julia> p = Polynomial([1,10,100])
+julia> poly = Polynomial([1,10,100])
 Polynomial{Int64}([1, 10, 100])
 
-julia> p(3)
+julia> poly(3)
 931
 
-julia> p()
+julia> poly()
 2551
 ```
 


### PR DESCRIPTION
This is a minor change, given the different syntax from usual methods/functions, using a different name for the example may make it clearer that there is nothing special about the name `p` used in the definition of the function.