### PR TITLE
Scheduler: Use the root task as a scheduler task

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -1203,6 +1203,12 @@ function wait()
     return result
 end
 
+function wait_forever()
+    while true
+        wait()
+    end
+end
+
 if Sys.iswindows()
     pause() = ccall(:Sleep, stdcall, Cvoid, (UInt32,), 0xffffffff)
 else


### PR DESCRIPTION
A Julia thread runs Julia's scheduler in the context of the switching task. If no task is found to switch to, the thread will sleep while holding onto the (possibly completed) task, preventing the task from being garbage collected. This recent [Discourse post](https://discourse.julialang.org/t/weird-behaviour-of-gc-with-multithreaded-array-access/125433) illustrates precisely this problem.

A solution to this would be for an idle Julia thread to switch to a "scheduler" task, thereby freeing the old task.

Other than thread 1, the root task that is created for every Julia-started (non-GC) thread essentially ends immediately -- we call `jl_finish_task` at the end of `jl_threadfun`.

This PR uses root tasks (on all but thread 1) as scheduler tasks. This solves the problem for all but thread 1. We could do the same for thread 1 also, but it would require special-casing as we cannot use thread 1's root task for this purpose.