### PR TITLE
binaryplatforms.jl: Remove unnecessary backslash in regex

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -751,7 +751,7 @@ function Base.parse(::Type{Platform}, triplet::String; validate_strict::Bool = f
         end
         os_version = nothing
         if os == "macos"
-            os_version = extract_os_version("macos", r".*darwin([\d\.]+)"sa)
+            os_version = extract_os_version("macos", r".*darwin([\d.]+)"sa)
         end
         if os == "freebsd"
             os_version = extract_os_version("freebsd", r".*freebsd([\d.]+)"sa)


### PR DESCRIPTION
This regex and two very similar ones a few lines below use different "quoting styles", which confused me when reading, suspecting an error. There is no error.

This PR changes `\.` to `.` inside a regex character class. Both have the same meaning. Avoiding the backslash is the simpler way.