### PR TITLE
REPL completions: Enter import mode only when cursor beyond "import"

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -944,7 +944,7 @@ function get_import_mode(s::String, pos::Int)
     # ^\s*(?:@\w+\s*(?:\(\s*)?)?
 
     # Do not enter import mode unless cursor beyond import keyword
-    beyond_kw(m) = pos >= m.offsets[1] + length(m[1])
+    beyond_kw(m) = pos >= m.offsets[1] + sizeof(m[1])
 
     # match simple cases like `using |` and `import  |`
     mod_import_match_simple = match(r"^\s*(?:@\w+\s*(?:\(\s*)?)?\b(using|import)\s*$", s)

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -180,6 +180,8 @@ end
 
 test_complete(s) = map_completion_text(@inferred(completions(s, lastindex(s))))
 test_scomplete(s) =  map_completion_text(@inferred(shell_completions(s, lastindex(s))))
+# | is reserved in test_complete_pos
+test_complete_pos(s) = map_completion_text(@inferred(completions(replace(s, '|' => ""), findfirst('|', s)-1)))
 test_complete_context(s, m=@__MODULE__; shift::Bool=true) =
     map_completion_text(@inferred(completions(s,lastindex(s), m, shift)))
 test_complete_foo(s) = test_complete_context(s, Main.CompletionFoo)
@@ -2483,4 +2485,10 @@ end
 let (c, r, res) = test_complete_context("global xxx::Number = Base.", Main)
     @test res
     @test "pi" ∈ c
+end
+
+# #57473
+let (c, r) = test_complete_pos("@tim| using Date")
+    @test "@time" in c
+    @test r == 1:4
 end

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -2492,3 +2492,17 @@ let (c, r) = test_complete_pos("@tim| using Date")
     @test "@time" in c
     @test r == 1:4
 end
+
+# #56389
+let s = "begin\n  using Linear"
+    c, r = test_complete(s)
+    @test "LinearAlgebra" in c
+    @test r == 15:20
+    @test s[r] == "Linear"
+end
+let s = "using .CompletionFoo: bar, type_"
+    c, r = test_complete(s)
+    @test "type_test" in c
+    @test r == 28:32
+    @test s[r] == "type_"
+end


### PR DESCRIPTION
Adds a position argument to `get_import_mode`.

Fixes #55842