### PR TITLE
lowering: Handle malformed `...` expressions

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -449,7 +449,7 @@
                   (check-dotop (cadr e))))))
   e)
 
-(define (vararg? x) (and (pair? x) (eq? (car x) '...)))
+(define (vararg? x) (and (pair? x) (eq? (car x) '...) (length= x 2)))
 (define (vararg-type-expr? x)
   (or (eq? x 'Vararg)
       (and (length> x 1)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2691,8 +2691,7 @@
                           (if (null? run) '()
                               (list `(call (core tuple) ,.(reverse run))))
                           (let ((x (car a)))
-                            (if (and (length= x 2)
-                                     (eq? (car x) '...))
+                            (if (vararg? x)
                                 (if (null? run)
                                     (list* (cadr x)
                                            (tuple-wrap (cdr a) '()))
@@ -2814,7 +2813,10 @@
    '.>>>=   lower-update-op
 
    '|...|
-   (lambda (e) (error "\"...\" expression outside call"))
+   (lambda (e)
+     (if (not (length= e 2))
+         (error "wrong number of expressions following \"...\""))
+     (error "\"...\" expression outside call"))
 
    '$
    (lambda (e) (error "\"$\" expression outside quote"))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -346,13 +346,7 @@ end
 @test Meta.lower(Main, Meta.parse("x...")) == Expr(:error, "\"...\" expression outside call")
 
 # issue #57153 - malformed "..." expr
-module M57153
-macro foo()
-    Expr(:(...), 1, 2, 3)
-end
-end
-@test Meta.lower(M57153, :(identity(@foo()))) ==
-    (Expr(:error, "wrong number of expressions following \"...\""))
+@test Meta.lower(@__MODULE__, :(identity($(Expr(:(...), 1, 2, 3)))) ==
 
 # issue #15830
 @test Meta.lower(Main, Meta.parse("foo(y = (global x)) = y")) == Expr(:error, "misplaced \"global\" declaration")

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -345,6 +345,15 @@ end
 # issue #15828
 @test Meta.lower(Main, Meta.parse("x...")) == Expr(:error, "\"...\" expression outside call")
 
+# issue #57153 - malformed "..." expr
+module M57153
+macro foo()
+    Expr(:(...), 1, 2, 3)
+end
+end
+@test Meta.lower(M57153, :(identity(@foo()))) ==
+    (Expr(:error, "wrong number of expressions following \"...\""))
+
 # issue #15830
 @test Meta.lower(Main, Meta.parse("foo(y = (global x)) = y")) == Expr(:error, "misplaced \"global\" declaration")
 

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -346,7 +346,8 @@ end
 @test Meta.lower(Main, Meta.parse("x...")) == Expr(:error, "\"...\" expression outside call")
 
 # issue #57153 - malformed "..." expr
-@test Meta.lower(@__MODULE__, :(identity($(Expr(:(...), 1, 2, 3)))) ==
+@test Meta.lower(@__MODULE__, :(identity($(Expr(:(...), 1, 2, 3))))) ==
+    (Expr(:error, "wrong number of expressions following \"...\""))
 
 # issue #15830
 @test Meta.lower(Main, Meta.parse("foo(y = (global x)) = y")) == Expr(:error, "misplaced \"global\" declaration")


### PR DESCRIPTION
Fixes #51572. The expander had a looser definition of a vararg than the recursive logic destructing the vararg, so a bad expression like `(call f (... x y))` could cause a stack overflow via indestructible mutant semi-vararg.

This change produces a saner error in this situation:
```
julia> macro foo(); Expr(:(...), 1, 2, 3); end; (@foo,)
ERROR: syntax: wrong number of expressions following "..." around REPL[1]:1
Stacktrace:
 [1] top-level scope
   @ REPL[1]:1
```
