### PR TITLE
export `maxthreadid` from `Threads`

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 export threadid, nthreads, @threads, @spawn,
-       threadpool, nthreadpools
+       threadpool, nthreadpools, maxthreadid
 
 public Condition, threadpoolsize, ngcthreads
 


### PR DESCRIPTION
`maxthreadid` is in the documentation and is referred to by other public docstrings so it should at least itself be public. Looking at what else is being exported I think this has the same "weight".