### PR TITLE
task: reuse stack immediately when Task dies and switches to new Task

### DIFF
--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -146,7 +146,8 @@ JL_DLLEXPORT void jl_free_stack(void *stkbuf, size_t bufsz)
 void jl_release_task_stack(jl_ptls_t ptls, jl_task_t *task)
 {
     // avoid adding an original thread stack to the free list
-    if (task == ptls->root_task && !task->ctx.copy_stack)
+    assert(!task->ctx.copy_stack);
+    if (task == ptls->root_task)
         return;
     void *stkbuf = task->ctx.stkbuf;
     size_t bufsz = task->ctx.bufsz;

--- a/src/task.c
+++ b/src/task.c
@@ -449,7 +449,7 @@ JL_NO_ASAN static void ctx_switch(jl_task_t *lastt)
     int killed = jl_atomic_load_relaxed(&lastt->_state) != JL_TASK_STATE_RUNNABLE;
     if (!t->ctx.started && !t->ctx.copy_stack && t->ctx.stkbuf == NULL) {
         // need to allocate the stack
-        void *stkbuf = killed && !lastt->ctx.copy_stack && lastt != ptls->root_task && lastt->ctx.bufsz >= t->ctx.bufsz && t->ctx.bufsz <= lastt->ctx.bufsz * 1.5 ? lastt->ctx.stkbuf : NULL;
+        void *stkbuf = killed && !lastt->ctx.copy_stack && lastt != ptls->root_task && t->ctx.bufsz <= lastt->ctx.bufsz && lastt->ctx.bufsz <= t->ctx.bufsz * 1.5 ? lastt->ctx.stkbuf : NULL;
         if (stkbuf) {
             // Directly reuse our current stkbuf for the new task if possible (about the
             // right size and using the right allocator).


### PR DESCRIPTION
Previously we forced it to ping-pong between two stacks, always wasting a little bit of memory (8MB * nthreads) and losing out a bit on possibly warmer caches.