### PR TITLE
Informative error in promotion with conflicting `promote_rule`s

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -8480,8 +8480,8 @@ end
     @testset "error with conflicting promote_rules" begin
         Base.promote_rule(::Type{PromoteA}, ::Type{PromoteB}) = PromoteA
         Base.promote_rule(::Type{PromoteB}, ::Type{PromoteA}) = PromoteB
-        @test_throws "promote_type(PromoteA, PromoteB) failed" promote_type(PromoteA, PromoteB)
-        @test_throws "promote_type(PromoteB, PromoteA) failed" promote_type(PromoteB, PromoteA)
+        @test_throws ArgumentError promote_type(PromoteA, PromoteB)
+        @test_throws ArgumentError promote_type(PromoteB, PromoteA)
     end
     @testset "unambiguous cases" begin
         @test promote_type(PromoteA, PromoteA) == PromoteA


### PR DESCRIPTION
This is the non-controversial change from https://github.com/JuliaLang/julia/pull/56779 that improves the error message in type promotion.

On master, promotion with conflicting `promote_rule` definitions leads to a stack overflow:
```julia
julia> struct PromoteB end

julia> struct PromoteA end

julia> Base.promote_rule(::Type{PromoteA}, ::Type{PromoteB}) = PromoteA

julia> Base.promote_rule(::Type{PromoteB}, ::Type{PromoteA}) = PromoteB

julia> promote_type(PromoteA, PromoteB)
Warning: detected a stack overflow; program state may be corrupted, so further execution might be unreliable.
ERROR: StackOverflowError:
Stacktrace:
      [1] promote_result(::Type, ::Type, ::Type{PromoteA}, ::Type{PromoteB})
        @ Base ./promotion.jl:337
      [2] promote_type
        @ ./promotion.jl:317 [inlined]--- the above 2 lines are repeated 79982 more times ---
```
In this PR, this is changed to an `ArgumentError`:
```julia
julia> promote_type(PromoteA, PromoteB)
ERROR: ArgumentError: promote_type(PromoteA, PromoteB) failed, as conflicting promote_rule definitions were detected with both PromoteA and PromoteB being possible results.
```
