### PR TITLE
`Base.summarysize` for `Memory` with `Union`

### DIFF
--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -149,13 +149,8 @@ function (ss::SummarySize)(obj::GenericMemory)
     datakey = unsafe_convert(Ptr{Cvoid}, obj)
     if !haskey(ss.seen, datakey)
         ss.seen[datakey] = true
-        dsize = sizeof(obj)
+        size += sizeof(obj)
         T = eltype(obj)
-        if isbitsunion(T)
-            # add 1 union selector byte for each element
-            dsize += length(obj)
-        end
-        size += dsize
         if !isempty(obj) && T !== Symbol && (!Base.allocatedinline(T) || (T isa DataType && !Base.datatype_pointerfree(T)))
             push!(ss.frontier_x, obj)
             push!(ss.frontier_i, 1)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -619,6 +619,11 @@ let z = Z53061[Z53061(S53061(rand(), (rand(),rand())), 0) for _ in 1:10^4]
     @test abs(summarysize(z) - 640000)/640000 <= 0.01 broken = Sys.WORD_SIZE == 32 && Sys.islinux()
 end
 
+# issue #57506
+let len = 100, m1 = Memory{UInt8}(1:len), m2 = Memory{Union{Nothing,UInt8}}(1:len)
+    @test summarysize(m2) == summarysize(m1) + len
+end
+
 ## test conversion from UTF-8 to UTF-16 (for Windows APIs)
 
 # empty arrays


### PR DESCRIPTION
Fixes the double accounting of the union byte array in `Base.summarysize` as described in #57506.

If this is the correct fix, can it be backported to 1.11?

Fix #57506