### PR TITLE
Update jloptions.c - error message

### DIFF
--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -656,7 +656,7 @@ restart_switch:
                         nthreadsi = strtol(&endptr[1], &endptri, 10);
                         // Allow 0 for interactive
                         if (errno != 0 || endptri == &endptr[1] || *endptri != 0 || nthreadsi < 0 || nthreadsi >= INT16_MAX)
-                            jl_errorf("julia: -t,--threads=<n>,<m>; m must be an integer ≥ 0");
+                            jl_errorf("julia: -t,--threads=<n>,<m>; m must be an integer >= 0");
                         if (nthreadsi == 0)
                             jl_options.nthreadpools = 1;
                     }


### PR DESCRIPTION
Update to >= to be consistent with similar error messages and avoid scrambled character in the terminal which don't support this type of characters