### PR TITLE
move to a simpler versioning policy for the Compiler.jl stdlib

### DIFF
--- a/Compiler/Project.toml
+++ b/Compiler/Project.toml
@@ -1,6 +1,6 @@
 name = "Compiler"
 uuid = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
-version = "0.0.3"
+version = "0.0.0"
 
 [compat]
 julia = "1.10"

--- a/Compiler/README.md
+++ b/Compiler/README.md
@@ -1,0 +1,45 @@
+# The `Compiler` module
+
+This directory maintains the implementation of the Julia compiler.
+
+Through a bootstrapping process, it is bundled into the Julia runtime as `Base.Compiler`.
+
+You can also use this `Compiler` module as the `Compiler` standard library by following the steps below.
+
+## How to use
+
+To utilize this `Compiler.jl` standard library, you need to declare it as a dependency in
+your `Project.toml` as follows:
+> Project.toml
+```toml
+[deps]
+Compiler = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
+
+[compat]
+Compiler = "0"
+```
+
+With the setup above, [the special placeholder version (v0.0.0)](https://github.com/JuliaLang/BaseCompiler.jl)
+will be installed by default.[^1]
+
+[^1]: Currently, only version v0.0.0 is registered in the [General](https://github.com/JuliaRegistries/General) registry.
+
+If needed, you can switch to a custom implementation of the `Compiler` module by running
+```julia-repl
+pkg> dev /path/to/Compiler.jl # to use a local implementation
+```
+or
+```julia-repl
+pkg> add https://url/of/Compiler/branch # to use a remote implementation
+```
+This feature is particularly useful for developing or experimenting with alternative compiler implementations.
+
+> [!note]
+> The Compiler.jl standard library is available starting from Julia v1.10.
+> However, switching to a custom compiler implementation is supported only from
+> Julia v1.12 onwards.
+
+> [!warning]
+> When using a custom, non-`Base` version of `Compiler` implementation, it may be necessary
+> to run `InteractiveUtils.@activate Compiler` to ensure proper functionality of certain
+> reflection utilities.


### PR DESCRIPTION
# Update (May 06, 2025)

As a result of discussions, the versioning and management policy for the Compiler.jl stdlib ended up being slightly different from what was originally proposed. For details, please refer to [this comment](https://github.com/JuliaLang/julia/pull/57520#issuecomment-2811922086) and the newly added READMEs ([JuliaLang/julia/Compiler/README.md](https://github.com/JuliaLang/julia/blob/a8f3e4d0603692ac79700890d3e8d35e904e000e/Compiler/README.md) and [JuliaLang/BaseCompiler.jl/README.md](https://github.com/JuliaLang/BaseCompiler.jl)).

---

# Original OP
For external packages like Cthulhu that use the Compiler.jl stdlib, it's quite a hassle to manage all three types of compatibility: between the external package, the Julia runtime, and Compiler.jl.

I'm thinking instead of handling these compatibility issues by some complex version engineering for Compiler.jl, we should keep its use supplementary. External `AbstractInterpreter` packages should primarily use `Base.Compiler`, while managing compatibility with the Julia runtime and `Base.Compiler`. This would bring us back to the previous situation, but it seems better in terms of compatibility management.

On the other hand, using the Compiler.jl stdlib allows for easy switching of the `Compiler` implementation, which should be an optional benefit. This is especially useful when developing the `Compiler` itself, where it's common to do `pkg> dev /path/to/Compiler`. In such cases, the implementation of the Compiler.jl stdlib should be used instead of `Base.Compiler`.
As a mechanism to switch the `Compiler` implementation used by external `AbstractInterpreter` packages, using package extensions might be the simplest approach. As shown in
[this example PR](https://github.com/JuliaDebug/Cthulhu.jl/pull/619), we can switch the `Compiler` implementation when `using Compiler` is called[^1], and still precompile the usual code. However, to list Compiler.jl in `[extensions]`, it needs a version. To this end, I propose releasing Compiler.jl versions in line with the Julia runtime versions, following other Julia standard libraries. But we would only do minor version releases, not patch releases, which are harder to define. Specifically, we could release a corresponding version of Compiler.jl when a release branch is cut. After that, we wouldn't manage patch versions, and as long as `pkg> dev /path/to/Compiler` works, this simple versioning should suffice.
Alternatively, we could register a single version `1.0.0` of Compiler.jl with a dummy implementation, letting the external package determine if the implementation is real (developed) or dummy, but this seems more hacky than using package extensions.

[^1]: Also, I'm aware of another issue: when using the Compiler.jl
  stdlib, you need to run `InteractiveUtils.@activate Compiler` first,
  or else some reflection utilities won't work (for example,
  `Base._which(tt; method_table=Compiler.method_table(myinterp))`).
  I think this problem can be solved by adding
  `InteractiveUtils.@activate` in the `__init__` function of the package
  extension code, but I'm not sure if this is a safe solution. It might
  be better to set up a callback that only gets called when
  `InteractiveUtils.@activate` is executed?