### PR TITLE
Convert from `StepRangeLen` to `StepRange`

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -1329,6 +1329,8 @@ StepRange{T1,T2}(r::AbstractRange) where {T1,T2} =
 StepRange(r::AbstractUnitRange{T}) where {T} =
     StepRange{T,T}(first(r), step(r), last(r))
 (StepRange{T1,T2} where T1)(r::AbstractRange) where {T2} = StepRange{eltype(r),T2}(r)
+StepRange(r::StepRangeLen) = StepRange{eltype(r)}(r)
+StepRange{T}(r::StepRangeLen{<:Any,<:Any,S}) where {T,S} = StepRange{T,S}(r)
 
 function promote_rule(::Type{StepRangeLen{T1,R1,S1,L1}},::Type{StepRangeLen{T2,R2,S2,L2}}) where {T1,T2,R1,R2,S1,S2,L1,L2}
     R, S, L = promote_type(R1, R2), promote_type(S1, S2), promote_type(L1, L2)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2786,3 +2786,20 @@ end
     @test promote(MyUnitRange(2:3), Base.OneTo(3)) == (2:3, 1:3)
     @test promote(MyUnitRange(UnitRange(3.0, 4.0)), Base.OneTo(3)) == (3.0:4.0, 1.0:3.0)
 end
+
+@testset "StepRange(::StepRangeLen)" begin
+    ind = StepRangeLen(2, -1, 2)
+    @test StepRange(ind) == ind
+    @test StepRange(ind) isa StepRange{eltype(ind), typeof(step(ind))}
+    @test StepRange{Int8}(ind) == ind
+    @test StepRange{Int8}(ind) isa StepRange{Int8}
+    @test StepRange{Int8,Int8}(ind) == ind
+    @test StepRange{Int8,Int8}(ind) isa StepRange{Int8,Int8}
+
+    r = StepRangeLen(3, 0, 4)
+    @test_throws "step cannot be zero" StepRange(r)
+
+    r = StepRangeLen(Date(2020,1,1), Day(1), 4)
+    @test StepRange(r) == r
+    @test StepRange(r) isa StepRange{Date,Day}
+end


### PR DESCRIPTION
Currently, one may convert from a `StepRangeLen` to a `StepRange` by using the fully parameterized constructor:
```julia
julia> r = StepRangeLen(3, 1, 4)
3:1:6

julia> StepRange{Int,Int}(r)
3:1:6
```
This PR adds a few other constructors that have fewer parameters specified. These parameters may be derived from the argument. After this PR, the following work:
```julia
julia> StepRange(r)
3:1:6

julia> StepRange{Int32}(r)
3:1:6

julia> StepRange{Int32}(r) |> typeof
StepRange{Int32, Int64}
```