### PR TITLE
Add hint for UndefVarError string macro errors

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -185,6 +185,14 @@ function showerror(io::IO, ex::UndefVarError)
     end
     Experimental.show_error_hints(io, ex)
 end
+function _UndefVarError_str_macro_hint(io::IO, ex::UndefVarError)
+    var = ex.var
+    m = match(r"@([a-zA-Z_][a-zA-Z0-9_]*)_str\b", string(var))
+    if m !== nothing && length(m.captures) == 1
+        print(io, "\nSuggestion: You may be using the string macro form `", m.captures[1], "\"\"`, for which the expected `$(var)` macro is not defined.")
+    end
+end
+Base.Experimental.register_error_hint(_UndefVarError_str_macro_hint, UndefVarError)
 
 function showerror(io::IO, ex::InexactError)
     print(io, "InexactError: ", ex.func, '(')


### PR DESCRIPTION
Master
```
julia> foo""
ERROR: LoadError: UndefVarError: `@foo_str` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
in expression starting at REPL[1]:1
```

This PR
```
julia> foo""
ERROR: LoadError: UndefVarError: `@foo_str` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
Suggestion: You may be using the string macro form `foo""`, for which the expected `@foo_str` macro is not defined.
in expression starting at REPL[3]:1
```

todo:
- [ ] Tests
- [ ] Handle cmd macros too 
```
julia> foo``
ERROR: LoadError: UndefVarError: `@foo_cmd` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
in expression starting at REPL[4]:1
```