### PR TITLE
[Compiler] new approach to verify --trim output

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -189,14 +189,19 @@ macro __SOURCE_FILE__()
     return QuoteNode(__source__.file::Symbol)
 end
 
-module IRShow end
+module IRShow end # relies on string and IO operations defined in Base
+baremodule TrimVerifier end # relies on IRShow, so define this afterwards
+
 function load_irshow!()
     if isdefined(Base, :end_base_include)
         # This code path is exclusively for Revise, which may want to re-run this
         # after bootstrap.
-        include(IRShow, Base.joinpath(Base.dirname(Base.String(@__SOURCE_FILE__)), "ssair/show.jl"))
+        Compilerdir = Base.dirname(Base.String(@__SOURCE_FILE__))
+        include(IRShow, Base.joinpath(Compilerdir, "ssair/show.jl"))
+        include(TrimVerifier, Base.joinpath(Compilerdir, "verifytrim.jl"))
     else
         include(IRShow, "ssair/show.jl")
+        include(TrimVerifier, "verifytrim.jl")
     end
 end
 if !isdefined(Base, :end_base_include)

--- a/Compiler/src/bootstrap.jl
+++ b/Compiler/src/bootstrap.jl
@@ -71,7 +71,7 @@ function bootstrap!()
                 end
             end
         end
-        codeinfos = typeinf_ext_toplevel(methods, [world], false)
+        codeinfos = typeinf_ext_toplevel(methods, [world], TRIM_NO)
         for i = 1:2:length(codeinfos)
             ci = codeinfos[i]::CodeInstance
             src = codeinfos[i + 1]::CodeInfo

--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -1,0 +1,344 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+import ..Compiler: verify_typeinf_trim
+
+using ..Compiler:
+     # operators
+     !, !=, !==, +, :, <, <=, ==, =>, >, >=, ∈, ∉,
+     # types
+     Array, Builtin, Callable, Cint, CodeInfo, CodeInstance, Csize_t, Exception,
+     GenericMemory, GlobalRef, IdDict, IdSet, IntrinsicFunction, Method, MethodInstance,
+     NamedTuple, Pair, PhiCNode, PhiNode, PiNode, QuoteNode, SSAValue, SimpleVector, String,
+     Tuple, VarState, Vector,
+     # functions
+     argextype, empty!, error, get, get_ci_mi, get_world_counter, getindex, getproperty,
+     hasintersect, haskey, in, isdispatchelem, isempty, isexpr, iterate, length, map!, max,
+     pop!, popfirst!, push!, pushfirst!, reinterpret, reverse!, reverse, setindex!,
+     setproperty!, similar, singleton_type, sptypes_from_meth_instance,
+     unsafe_pointer_to_objref, widenconst,
+     # misc
+     @nospecialize, C_NULL
+using ..IRShow: LineInfoNode, print, show, println, append_scopes!, IOContext, IO, normalize_method_name
+using ..Base: Base, sourceinfo_slotnames
+using ..Base.StackTraces: StackFrame
+
+## declarations ##
+
+struct CallMissing <: Exception
+    codeinst::CodeInstance
+    codeinfo::CodeInfo
+    sptypes::Vector{VarState}
+    stmtidx::Int
+    desc::String
+end
+
+struct CCallableMissing <: Exception
+    rt
+    sig
+    desc
+end
+
+const ParentMap = IdDict{CodeInstance,Tuple{CodeInstance,Int}}
+const ErrorList = Vector{Pair{Bool,Any}} # severity => exception
+
+const runtime_functions = Symbol[
+    # a denylist of any runtime functions which someone might ccall which can call jl_apply or access reflection state
+    # which might not be captured by the trim output
+    :jl_apply,
+]
+
+## code for pretty printing ##
+
+# wrap a statement in a typeassert for printing clarity, unless that info seems already obvious
+function mapssavaluetypes(codeinfo::CodeInfo, sptypes::Vector{VarState}, stmt)
+    @nospecialize stmt
+    newstmt = mapssavalues(codeinfo, sptypes, stmt)
+    typ = widenconst(argextype(stmt, codeinfo, sptypes))
+    if newstmt isa Expr
+        if newstmt.head ∈ (:quote, :inert)
+            return newstmt
+        end
+    elseif newstmt isa GlobalRef && isdispatchelem(typ)
+        return newstmt
+    elseif newstmt isa Union{Int, UInt8, UInt16, UInt32, UInt64, Float16, Float32, Float64, String, QuoteNode}
+        return newstmt
+    elseif newstmt isa Callable
+        return newstmt
+    end
+    return Expr(:(::), newstmt, typ)
+end
+
+# map the ssavalues in a (value-producing) statement to the expression they came from, summarizing some things to avoid excess printing
+function mapssavalues(codeinfo::CodeInfo, sptypes::Vector{VarState}, stmt)
+    @nospecialize stmt
+    if stmt isa SSAValue
+        return mapssavalues(codeinfo, sptypes, codeinfo.code[stmt.id])
+    elseif stmt isa PiNode
+        return mapssavalues(codeinfo, sptypes, stmt.val)
+    elseif stmt isa Expr
+        stmt.head ∈ (:quote, :inert) && return stmt
+        newstmt = Expr(stmt.head)
+        if stmt.head === :foreigncall
+            return Expr(:call, :ccall, mapssavalues(codeinfo, sptypes, stmt.args[1]))
+        elseif stmt.head ∉ (:new, :method, :toplevel, :thunk)
+            newstmt.args = map!(similar(stmt.args), stmt.args) do arg
+                @nospecialize arg
+                return mapssavaluetypes(codeinfo, sptypes, arg)
+            end
+            if newstmt.head === :invoke
+                # why is the fancy printing for this not in show_unquoted?
+                popfirst!(newstmt.args)
+                newstmt.head = :call
+            end
+        end
+        return newstmt
+    elseif stmt isa PhiNode
+        return PhiNode()
+    elseif stmt isa PhiCNode
+        return PhiNode()
+    end
+    return stmt
+end
+
+function verify_print_stmt(io::IOContext{IO}, codeinfo::CodeInfo, sptypes::Vector{VarState}, stmtidx::Int)
+    if codeinfo.slotnames !== nothing
+        io = IOContext(io, :SOURCE_SLOTNAMES => sourceinfo_slotnames(codeinfo))
+    end
+    print(io, mapssavaluetypes(codeinfo, sptypes, SSAValue(stmtidx)))
+end
+
+function verify_print_error(io::IOContext{IO}, desc::CallMissing, parents::ParentMap)
+    (; codeinst, codeinfo, sptypes, stmtidx, desc) = desc
+    frames = verify_create_stackframes(codeinst, stmtidx, parents)
+    print(io, desc, " from ")
+    verify_print_stmt(io, codeinfo, sptypes, stmtidx)
+    Base.show_backtrace(io, frames)
+    print(io, "\n\n")
+    nothing
+end
+
+function verify_print_error(io::IOContext{IO}, desc::CCallableMissing, parents::ParentMap)
+    print(io, desc.desc, " for ", desc.sig, " => ", desc.rt, "\n\n")
+    nothing
+end
+
+function verify_create_stackframes(codeinst::CodeInstance, stmtidx::Int, parents::ParentMap)
+    scopes = LineInfoNode[]
+    frames = StackFrame[]
+    parent = (codeinst, stmtidx)
+    while parent !== nothing
+        codeinst, stmtidx = parent
+        di = codeinst.debuginfo
+        append_scopes!(scopes, stmtidx, di, :var"unknown scope")
+        for i in reverse(1:length(scopes))
+            lno = scopes[i]
+            inlined = i != 1
+            def = lno.method
+            def isa Union{Method,Core.CodeInstance,MethodInstance} || (def = nothing)
+            sf = StackFrame(normalize_method_name(lno.method), lno.file, lno.line, def, false, inlined, 0)
+            push!(frames, sf)
+        end
+        empty!(scopes)
+        parent = get(parents, codeinst, nothing)
+    end
+    return frames
+end
+
+## code for analysis ##
+
+function may_dispatch(@nospecialize ftyp)
+    if ftyp <: IntrinsicFunction
+        return true
+    elseif ftyp <: Builtin
+        # other builtins (including the IntrinsicFunctions) are good
+        return Core._apply isa ftyp ||
+               Core._apply_iterate isa ftyp ||
+               Core._apply_pure isa ftyp ||
+               Core._call_in_world isa ftyp ||
+               Core._call_in_world_total isa ftyp ||
+               Core._call_latest isa ftyp ||
+               Core.invoke isa ftyp ||
+               Core.finalizer isa ftyp ||
+               Core.modifyfield! isa ftyp ||
+               Core.modifyglobal! isa ftyp ||
+               Core.memoryrefmodify! isa ftyp
+    else
+        return true
+    end
+end
+
+function verify_codeinstance!(codeinst::CodeInstance, codeinfo::CodeInfo, inspected::IdSet{CodeInstance}, caches::IdDict{MethodInstance,CodeInstance}, parents::ParentMap, errors::ErrorList)
+    mi = get_ci_mi(codeinst)
+    sptypes = sptypes_from_meth_instance(mi)
+    src = codeinfo.code
+    for i = 1:length(src)
+        stmt = src[i]
+        isexpr(stmt, :(=)) && (stmt = stmt.args[2])
+        error = ""
+        warn = false
+        if isexpr(stmt, :invoke) || isexpr(stmt, :invoke_modify)
+            error = "unresolved invoke"
+            edge = stmt.args[1]
+            if edge isa CodeInstance
+                haskey(parents, edge) || (parents[edge] = (codeinst, i))
+                edge in inspected && continue
+            end
+            # TODO: check for calls to Base.atexit?
+        elseif isexpr(stmt, :call)
+            error = "unresolved call"
+            farg = stmt.args[1]
+            ftyp = widenconst(argextype(farg, codeinfo, sptypes))
+            if ftyp <: IntrinsicFunction
+                #TODO: detect if f !== Core.Intrinsics.atomic_pointermodify (see statement_cost), otherwise error
+                continue
+            elseif ftyp <: Builtin
+                if !may_dispatch(ftyp)
+                    continue
+                end
+                if Core._apply_iterate isa ftyp
+                    if length(stmt.args) >= 3
+                        # args[1] is _apply_iterate object
+                        # args[2] is invoke object
+                        farg = stmt.args[3]
+                        ftyp = widenconst(argextype(farg, codeinfo, sptypes))
+                        if may_dispatch(ftyp)
+                            error = "unresolved call to function"
+                        else
+                            for i in 4:length(stmt.args)
+                                atyp = widenconst(argextype(stmt.args[i], codeinfo, sptypes))
+                                if !(atyp <: Union{SimpleVector, GenericMemory, Array, Tuple, NamedTuple})
+                                    error = "unresolved argument to call"
+                                    break
+                                end
+                            end
+                        end
+                    end
+                elseif Core.finalizer isa ftyp
+                    if length(stmt.args) == 3
+                        # TODO: check that calling `args[1](args[2])` is defined before warning
+                        error = "unresolved finalizer registered"
+                        warn = true
+                    end
+                else
+                    error = "unresolved call to builtin"
+                end
+            end
+            extyp = argextype(SSAValue(i), codeinfo, sptypes)
+            if extyp === Union{}
+                warn = true # downgrade must-throw calls to be only a warning
+            end
+        elseif isexpr(stmt, :cfunction)
+            error = "unresolved cfunction"
+            #TODO: parse the cfunction expression to check the target is defined
+            warn = true
+        elseif isexpr(stmt, :foreigncall)
+            foreigncall = stmt.args[1]
+            if foreigncall isa QuoteNode
+                if foreigncall.value in runtime_functions
+                    error = "disallowed ccall into a runtime function"
+                end
+            end
+        elseif isexpr(stmt, :new_opaque_closure)
+            error = "unresolved opaque closure"
+            # TODO: check that this opaque closure has a valid signature for possible codegen and code defined for it
+            warn = true
+        end
+        if !isempty(error)
+            push!(errors, warn => CallMissing(codeinst, codeinfo, sptypes, i, error))
+        end
+    end
+end
+
+## entry-point ##
+
+function get_verify_typeinf_trim(codeinfos::Vector{Any})
+    this_world = get_world_counter()
+    inspected = IdSet{CodeInstance}()
+    caches = IdDict{MethodInstance,CodeInstance}()
+    errors = ErrorList()
+    parents = ParentMap()
+    for i = 1:2:length(codeinfos)
+        item = codeinfos[i]
+        if item isa CodeInstance
+            push!(inspected, item)
+            if item.owner === nothing && item.min_world <= this_world <= item.max_world
+                mi = get_ci_mi(item)
+                if mi === item.def
+                    caches[mi] = item
+                end
+            end
+        end
+    end
+    for i = 1:2:length(codeinfos)
+        item = codeinfos[i]
+        if item isa CodeInstance
+            src = codeinfos[i + 1]::CodeInfo
+            verify_codeinstance!(item, src, inspected, caches, parents, errors)
+        else
+            rt = item::Type
+            sig = codeinfos[i + 1]::Type
+            ptr = ccall(:jl_get_specialization1,
+                        #= MethodInstance =# Ptr{Cvoid}, (Any, Csize_t, Cint),
+                        sig, this_world, #= mt_cache =# 0)
+            asrt = Any
+            valid = if ptr !== C_NULL
+                mi = unsafe_pointer_to_objref(ptr)::MethodInstance
+                ci = get(caches, mi, nothing)
+                if ci isa CodeInstance
+                    # TODO: should we find a way to indicate to the user that this gets called via ccallable?
+                    # parent[ci] = something
+                    asrt = ci.rettype
+                    ci in inspected
+                else
+                    false
+                end
+            else
+                false
+            end
+            if !valid
+                warn = false
+                push!(errors, warn => CCallableMissing(rt, sig, "unresolved ccallable"))
+            elseif !(asrt <: rt)
+                warn = hasintersect(asrt, rt)
+                push!(errors, warn => CCallableMissing(asrt, sig, "ccallable declared return type does not match inference"))
+            end
+        end
+    end
+    return (errors, parents)
+end
+
+# It is unclear if this file belongs in Compiler itself, or should instead be a codegen
+# driver / verifier implemented by juliac-buildscript.jl for the purpose of extensibility.
+# For now, it is part of Base.Compiler, but executed with invokelatest so that packages
+# could provide hooks to change, customize, or tweak its behavior and heuristics.
+Base.delete_method(Base.which(verify_typeinf_trim, (IO, Vector{Any}, Bool)),)
+function verify_typeinf_trim(io::IO, codeinfos::Vector{Any}, onlywarn::Bool)
+    errors, parents = get_verify_typeinf_trim(codeinfos)
+
+    # count up how many messages we printed, of each severity
+    counts = [0, 0] # errors, warnings
+    io = IOContext{IO}(io)
+    # print all errors afterwards, when the parents map is fully constructed
+    for desc in errors
+        warn, desc = desc
+        severity = warn ? 2 : 1
+        no = (counts[severity] += 1)
+        print(io, warn ? "Verifier warning #" : "Verifier error #", no, ": ")
+        # TODO: should we coalesce any of these stacktraces to minimize spew?
+        verify_print_error(io, desc, parents)
+    end
+
+    let severity = 0
+        if counts[2] > 0
+            print("Trim verify finished with ", counts[2], counts[2] == 1 ? " warning.\n\n" : " warnings.\n\n")
+            severity = 2
+        end
+        if counts[1] > 0
+            print("Trim verify finished with ", counts[1], counts[1] == 1 ? " error.\n\n" : " errors.\n\n")
+            severity = 1
+        end
+        # messages classified as errors are fatal, warnings are not
+        0 < severity <= 1 && !onlywarn && error("verify_typeinf_trim failed")
+    end
+    nothing
+end

--- a/Compiler/test/testgroups
+++ b/Compiler/test/testgroups
@@ -16,3 +16,4 @@ tarjan
 validation
 special_loading
 abioverride
+verifytrim

--- a/Compiler/test/verifytrim.jl
+++ b/Compiler/test/verifytrim.jl
@@ -1,0 +1,91 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+include("setup_Compiler.jl")
+
+# revise: Core.include(Compiler.TrimVerifier, joinpath(@__DIR__, "../src/verifytrim.jl"))
+
+using Test
+using .Compiler: typeinf_ext_toplevel, TrimVerifier, TRIM_SAFE, TRIM_UNSAFE
+using .TrimVerifier: get_verify_typeinf_trim, verify_print_error, CallMissing, CCallableMissing
+
+function sprint(f, args...)
+    return Base.sprint((io, f, args...) -> f(IOContext{IO}(io), args...), f, args...)
+end
+
+let infos = Any[]
+    errors, parents = get_verify_typeinf_trim(infos)
+    @test isempty(errors)
+    @test isempty(parents)
+end
+
+# use TRIM_UNSAFE to bypass verifier inside typeinf_ext_toplevel
+let infos = typeinf_ext_toplevel(Any[Core.svec(Base.SecretBuffer, Tuple{Type{Base.SecretBuffer}})], [Base.get_world_counter()], TRIM_UNSAFE)
+    @test_broken length(infos) > 4
+    errors, parents = get_verify_typeinf_trim(infos)
+    @test_broken isempty(errors) # missing cfunction
+    #resize!(infos, 4)
+    #errors, = get_verify_typeinf_trim(infos)
+
+    desc = only(errors)
+    @test desc.first
+    desc = desc.second
+    @test desc isa CallMissing
+    @test occursin("finalizer", desc.desc)
+    repr = sprint(verify_print_error, desc, parents)
+    @test occursin(
+        r"""^unresolved finalizer registered from \(Core.finalizer\)\(Base.final_shred!, %new\(\)::Base.SecretBuffer\)::Nothing
+            Stacktrace:
+             \[1\] finalizer\(f::typeof\(Base.final_shred!\), o::Base.SecretBuffer\)
+               @ Base gcutils.jl:(\d+) \[inlined\]
+             \[2\] Base.SecretBuffer\(; sizehint::Int\d\d\)
+               @ Base secretbuffer.jl:(\d+) \[inlined\]
+             \[3\] Base.SecretBuffer\(\)
+               @ Base secretbuffer.jl:(\d+)
+
+            $""", repr)
+
+    resize!(infos, 2)
+    @test infos[1] isa Type && infos[2] isa Type
+    errors, parents = get_verify_typeinf_trim(infos)
+    desc = only(errors)
+    @test !desc.first
+    desc = desc.second
+    @test desc isa CCallableMissing
+    @test desc.rt == Base.SecretBuffer
+    @test desc.sig == Tuple{Type{Base.SecretBuffer}}
+    @test occursin("unresolved ccallable", desc.desc)
+    repr = sprint(verify_print_error, desc, parents)
+    @test repr == "unresolved ccallable for Tuple{Type{Base.SecretBuffer}} => Base.SecretBuffer\n\n"
+end
+
+let infos = typeinf_ext_toplevel(Any[Core.svec(Float64, Tuple{typeof(+), Int32, Int64})], [Base.get_world_counter()], TRIM_UNSAFE)
+    errors, parents = get_verify_typeinf_trim(infos)
+    desc = only(errors)
+    @test !desc.first
+    desc = desc.second
+    @test desc isa CCallableMissing
+    @test desc.rt == Int64
+    @test desc.sig == Tuple{typeof(+), Int32, Int64}
+    @test occursin("ccallable declared return type", desc.desc)
+    repr = sprint(verify_print_error, desc, parents)
+    @test repr == "ccallable declared return type does not match inference for Tuple{typeof(+), Int32, Int64} => Int64\n\n"
+end
+
+let infos = typeinf_ext_toplevel(Any[Core.svec(Int64, Tuple{typeof(ifelse), Bool, Int64, UInt64})], [Base.get_world_counter()], TRIM_UNSAFE)
+    errors, parents = get_verify_typeinf_trim(infos)
+    desc = only(errors)
+    @test desc.first
+    desc = desc.second
+    @test desc isa CCallableMissing
+    @test occursin("ccallable declared return type", desc.desc)
+    repr = sprint(verify_print_error, desc, parents)
+    @test repr == "ccallable declared return type does not match inference for Tuple{typeof(ifelse), Bool, Int64, UInt64} => Union{Int64, UInt64}\n\n"
+end
+
+let infos = typeinf_ext_toplevel(Any[Core.svec(Union{Int64,UInt64}, Tuple{typeof(ifelse), Bool, Int64, UInt64})], [Base.get_world_counter()], TRIM_SAFE)
+    errors, parents = get_verify_typeinf_trim(infos)
+    @test isempty(errors)
+    infos = typeinf_ext_toplevel(Any[Core.svec(Real, Tuple{typeof(ifelse), Bool, Int64, UInt64})], [Base.get_world_counter()], TRIM_SAFE)
+    errors, parents = get_verify_typeinf_trim(infos)
+    @test isempty(errors)
+end

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -107,6 +107,9 @@ include("strings/strings.jl")
 include("regex.jl")
 include("parse.jl")
 include("shell.jl")
+const IRShow = Compiler.IRShow # an alias for compatibility
+include("stacktraces.jl")
+using .StackTraces
 include("show.jl")
 include("arrayshow.jl")
 include("methodshow.jl")
@@ -242,10 +245,6 @@ include("combinatorics.jl")
 include("irrationals.jl")
 include("mathconstants.jl")
 using .MathConstants: ℯ, π, pi
-
-# Stack frames and traces
-include("stacktraces.jl")
-using .StackTraces
 
 # experimental API's
 include("experimental.jl")

--- a/base/show.jl
+++ b/base/show.jl
@@ -2841,7 +2841,6 @@ function show(io::IO, vm::Core.TypeofVararg)
 end
 
 Compiler.load_irshow!()
-const IRShow = Compiler.IRShow # an alias for compatibility
 
 function show(io::IO, src::CodeInfo; debuginfo::Symbol=:source)
     # Fix slot names and types in function body

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -428,12 +428,6 @@ static void resolve_workqueue(jl_codegen_params_t &params, egal_set &method_root
                     preal_specsig = true;
                 }
             }
-            else if (params.params->trim) {
-                jl_safe_printf("warning: no code provided for function ");
-                jl_(codeinst->def);
-                if (params.params->trim)
-                    abort();
-            }
         }
         // patch up the prototype we emitted earlier
         Module *mod = proto.decl->getParent();
@@ -447,11 +441,6 @@ static void resolve_workqueue(jl_codegen_params_t &params, egal_set &method_root
             preal_decl = mod->getNamedValue(gf_thunk_name)->getName();
         }
         if (preal_decl.empty()) {
-            if (invokeName.empty() && params.params->trim) {
-                jl_safe_printf("warning: bailed out to invoke when compiling: ");
-                jl_(codeinst->def);
-                abort();
-            }
             pinvoke = emit_tojlinvoke(codeinst, invokeName, mod, params);
             if (!proto.specsig)
                 proto.decl->replaceAllUsesWith(pinvoke);
@@ -638,9 +627,9 @@ static void generate_cfunc_thunks(jl_codegen_params_t &params, jl_compiled_funct
 
 // takes the running content that has collected in the shadow module and dump it to disk
 // this builds the object file portion of the sysimage files for fast startup
-// `_external_linkage` create linkages between pkgimages.
+// `external_linkage` create linkages between pkgimages.
 extern "C" JL_DLLEXPORT_CODEGEN
-void *jl_create_native_impl(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmmod, int _trim, int _external_linkage, size_t world)
+void *jl_create_native_impl(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmmod, int trim, int external_linkage, size_t world)
 {
     JL_TIMING(INFERENCE, INFERENCE);
     auto ct = jl_current_task;
@@ -653,10 +642,9 @@ void *jl_create_native_impl(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvm
         compiler_start_time = jl_hrtime();
 
     jl_cgparams_t cgparams = jl_default_cgparams;
-    cgparams.trim = _trim ? 1 : 0;
     size_t compile_for[] = { jl_typeinf_world, world };
     int compiler_world = 1;
-    if (_trim || compile_for[0] == 0)
+    if (trim || compile_for[0] == 0)
         compiler_world = 0;
     jl_value_t **fargs;
     JL_GC_PUSHARGS(fargs, 4);
@@ -673,7 +661,7 @@ void *jl_create_native_impl(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvm
         fargs[2] = (jl_value_t*)worlds;
         jl_array_data(worlds, size_t)[0] = jl_typeinf_world;
         jl_array_data(worlds, size_t)[compiler_world] = world; // might overwrite previous
-        fargs[3] = _trim ? jl_true : jl_false;
+        fargs[3] = jl_box_long(trim);
         size_t last_age = ct->world_age;
         ct->world_age = jl_typeinf_world;
         codeinfos = (jl_array_t*)jl_apply(fargs, 4);
@@ -685,7 +673,7 @@ void *jl_create_native_impl(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvm
         jl_error("inference not available for generating compiled output");
     }
     fargs[0] = (jl_value_t*)codeinfos;
-    void *data = jl_emit_native(codeinfos, llvmmod, &cgparams, _external_linkage);
+    void *data = jl_emit_native(codeinfos, llvmmod, &cgparams, external_linkage);
 
     // move everything inside, now that we've merged everything
     // (before adding the exported headers)
@@ -729,7 +717,7 @@ void *jl_create_native_impl(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvm
 // also be used be extern consumers like GPUCompiler.jl to obtain a module containing
 // all reachable & inferrrable functions.
 extern "C" JL_DLLEXPORT_CODEGEN
-void *jl_emit_native_impl(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int _external_linkage)
+void *jl_emit_native_impl(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int external_linkage)
 {
     JL_TIMING(NATIVE_AOT, NATIVE_Create);
     ++CreateNativeCalls;
@@ -737,7 +725,6 @@ void *jl_emit_native_impl(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvm
     if (cgparams == NULL)
         cgparams = &jl_default_cgparams;
     jl_native_code_desc_t *data = new jl_native_code_desc_t;
-    jl_method_instance_t *mi = NULL;
     orc::ThreadSafeContext ctx;
     orc::ThreadSafeModule backing;
     if (!llvmmod) {
@@ -757,7 +744,7 @@ void *jl_emit_native_impl(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvm
         params.getContext().setDiscardValueNames(true);
     params.params = cgparams;
     assert(params.imaging_mode); // `_imaging_mode` controls if broken features like code-coverage are disabled
-    params.external_linkage = _external_linkage;
+    params.external_linkage = external_linkage;
     params.temporary_roots = jl_alloc_array_1d(jl_array_any_type, 0);
     JL_GC_PUSH3(&params.temporary_roots, &method_roots.list, &method_roots.keyset);
     jl_compiled_functions_t compiled_functions;
@@ -773,7 +760,7 @@ void *jl_emit_native_impl(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvm
             assert(jl_is_code_info(src));
             if (compiled_functions.count(codeinst))
                 continue; // skip any duplicates that accidentally made there way in here (or make this an error?)
-            if (_external_linkage) {
+            if (external_linkage) {
                 uint8_t specsigflags;
                 jl_callptr_t invoke;
                 void *fptr;
@@ -795,13 +782,6 @@ void *jl_emit_native_impl(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvm
             record_method_roots(method_roots, jl_get_ci_mi(codeinst));
             if (result_m)
                 compiled_functions[codeinst] = {std::move(result_m), std::move(decls)};
-            else if (params.params->trim) {
-                // if we're building a small image, we need to compile everything
-                // to ensure that we have all the information we need.
-                jl_safe_printf("codegen failed to compile code root ");
-                jl_(mi);
-                abort();
-            }
         }
         else {
             jl_value_t *sig = jl_array_ptr_ref(codeinfos, ++i);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2281,12 +2281,6 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             ret = emit_invoke(ctx, *modifyop, argv, 3, (jl_value_t*)jl_any_type);
         }
         else {
-            if (trim_may_error(ctx.params->trim)) {
-                // if we know the return type, we can assume the result is of that type
-                errs() << "ERROR: Dynamic call to setfield/modifyfield\n";
-                errs() << "In " << ctx.builder.getCurrentDebugLocation()->getFilename() << ":" << ctx.builder.getCurrentDebugLocation()->getLine() << "\n";
-                print_stacktrace(ctx, ctx.params->trim);
-            }
             Value *callval = emit_jlcall(ctx, jlapplygeneric_func, nullptr, argv, 3, julia_call);
             ret = mark_julia_type(ctx, callval, true, jl_any_type);
         }
@@ -4020,12 +4014,6 @@ static jl_cgval_t union_store(jl_codectx_t &ctx,
                 rhs = emit_invoke(ctx, *modifyop, argv, 3, (jl_value_t*)jl_any_type);
             }
             else {
-                if (trim_may_error(ctx.params->trim)) {
-                    // if we know the return type, we can assume the result is of that type
-                    errs() << "ERROR: Dynamic call to setfield/modifyfield\n";
-                    errs() << "In " << ctx.builder.getCurrentDebugLocation()->getFilename() << ":" << ctx.builder.getCurrentDebugLocation()->getLine() << "\n";
-                    print_stacktrace(ctx, ctx.params->trim);
-                }
                 Value *callval = emit_jlcall(ctx, jlapplygeneric_func, nullptr, argv, 3, julia_call);
                 rhs = mark_julia_type(ctx, callval, true, jl_any_type);
             }

--- a/src/init.c
+++ b/src/init.c
@@ -739,8 +739,7 @@ JL_DLLEXPORT jl_cgparams_t jl_default_cgparams = {
         /* debug_info_level */ 0, // later jl_options.debug_level,
         /* safepoint_on_entry */ 1,
         /* gcstack_arg */ 1,
-        /* use_jlplt*/ 1,
-        /* trim */ 0 };
+        /* use_jlplt*/ 1 };
 
 static void init_global_mutexes(void) {
     JL_MUTEX_INIT(&jl_modules_mutex, "jl_modules_mutex");

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -244,7 +244,6 @@ struct jl_codegen_params_t {
     std::map<jl_datatype_t*, DIType*> ditypes;
     std::map<jl_datatype_t*, Type*> llvmtypes;
     DenseMap<Constant*, GlobalVariable*> mergedConstants;
-    llvm::MapVector<jl_method_instance_t*, std::tuple<jl_method_instance_t*, CallFrames>> enqueuers;
     // Map from symbol name (in a certain library) to its GV in sysimg and the
     // DL handle address in the current session.
     StringMap<std::pair<GlobalVariable*,SymMapGV>> libMapGV;

--- a/src/julia.h
+++ b/src/julia.h
@@ -2668,7 +2668,6 @@ typedef struct {
     int gcstack_arg; // Pass the ptls value as an argument with swiftself
 
     int use_jlplt; // Whether to use the Julia PLT mechanism or emit symbols directly
-    int trim; // can we emit dynamic dispatches?
 } jl_cgparams_t;
 extern JL_DLLEXPORT int jl_default_debug_info_kind;
 extern JL_DLLEXPORT jl_cgparams_t jl_default_cgparams;

--- a/sysimage.mk
+++ b/sysimage.mk
@@ -57,10 +57,12 @@ COMPILER_SRCS := $(addprefix $(JULIAHOME)/, \
 		base/traits.jl \
 		base/refvalue.jl \
 		base/tuple.jl)
-COMPILER_SRCS += $(shell find $(JULIAHOME)/Compiler/src -name \*.jl)
+COMPILER_SRCS += $(shell find $(JULIAHOME)/Compiler/src -name \*.jl -and -not -name verifytrim.jl -and -not -name show.jl)
 # sort these to remove duplicates
 BASE_SRCS := $(sort $(shell find $(JULIAHOME)/base -name \*.jl -and -not -name sysimg.jl) \
-                    $(shell find $(BUILDROOT)/base -name \*.jl  -and -not -name sysimg.jl))
+                    $(shell find $(BUILDROOT)/base -name \*.jl  -and -not -name sysimg.jl)) \
+             $(JULIAHOME)/Compiler/src/ssair/show.jl \
+             $(JULIAHOME)/Compiler/src/verifytrim.jl
 STDLIB_SRCS := $(JULIAHOME)/base/sysimg.jl $(SYSIMG_STDLIBS_SRCS)
 RELBUILDROOT := $(call rel_path,$(JULIAHOME)/base,$(BUILDROOT)/base)/ # <-- make sure this always has a trailing slash
 RELDATADIR := $(call rel_path,$(JULIAHOME)/base,$(build_datarootdir))/ # <-- make sure this always has a trailing slash


### PR DESCRIPTION
Reimplement all of the trim verification support in Julia as a compiler analysis pass. Move all this verification code into the Compiler julia code, where we have much better utilities for pretty printing and better observability for analysis.

```
julia> using Profile

julia> infos = Base.Compiler.typeinf_ext_toplevel(Any[Core.svec(Int, Tuple{typeof(Profile.take_heap_snapshot)})], [Base.get_world_counter()], true);
Verifier error #1: ccallable declared return type does not match inference for Tuple{typeof(Profile.take_heap_snapshot)} => String

Verifier error #2: unresolved call to builtin from (Core._call_latest)(Base.CoreLogging.shouldlog, (Base.CoreLogging.current_logger_for_env)(Base.CoreLogging.Warn, :Profile, Profile::Module)::Base.CoreLogging.AbstractLogger, $(QuoteNode(Warn)), $(QuoteNode(Profile)), :Profile, Profile.Symbol(φ ()::String)::Symbol)::Any
Stacktrace:
 [1] invokelatest(::typeof(Base.CoreLogging.shouldlog), ::Base.CoreLogging.AbstractLogger, ::Base.CoreLogging.LogLevel, ::Module, ::Symbol, ::Symbol; kwargs::@Kwargs{})
   @ Base essentials.jl:1057 [inlined]
 [2] invokelatest(::typeof(Base.CoreLogging.shouldlog), ::Base.CoreLogging.AbstractLogger, ::Base.CoreLogging.LogLevel, ::Module, ::Symbol, ::Symbol)
   @ Base essentials.jl:1053 [inlined]
 [3] macro expansion
   @ logging/logging.jl:405 [inlined]
 [4] take_heap_snapshot(all_one::Bool; dir::Nothing, kwargs::@Kwargs{})
   @ Profile ~/julia/usr/share/julia/stdlib/v1.13/Profile/src/Profile.jl:1463
 [5] take_heap_snapshot(all_one::Bool)
   @ Profile ~/julia/usr/share/julia/stdlib/v1.13/Profile/src/Profile.jl:1454 [inlined]

Verifier error #3: unresolved call to builtin from (Core._call_latest)(Base.CoreLogging.logging_error, φ ()::Base.CoreLogging.AbstractLogger, $(QuoteNode(Warn)), $(QuoteNode(Profile)), :Profile, φ ()::Symbol, φ ()::String, 1463, $(Expr(:the_exception))::Any, true::Bool)::Any
Stacktrace:
 [1] invokelatest(::typeof(Base.CoreLogging.logging_error), ::Base.CoreLogging.AbstractLogger, ::Base.CoreLogging.LogLevel, ::Module, ::Symbol, ::Symbol, ::String, ::Int64, ::Any, ::Bool; kwargs::@Kwargs{})
   @ Base essentials.jl:1057 [inlined]
 [2] invokelatest(::typeof(Base.CoreLogging.logging_error), ::Base.CoreLogging.AbstractLogger, ::Base.CoreLogging.LogLevel, ::Module, ::Symbol, ::Symbol, ::String, ::Int64, ::Any, ::Bool)
   @ Base essentials.jl:1053 [inlined]
 [3] macro expansion
   @ logging/logging.jl:387 [inlined]
 [4] take_heap_snapshot(all_one::Bool; dir::Nothing, kwargs::@Kwargs{})
   @ Profile ~/julia/usr/share/julia/stdlib/v1.13/Profile/src/Profile.jl:1463
 [5] take_heap_snapshot(all_one::Bool)
   @ Profile ~/julia/usr/share/julia/stdlib/v1.13/Profile/src/Profile.jl:1454 [inlined]

Verifier error #4: unresolved call from (f::Function)(%new()::IOBuffer, Core.getfield(args::Tuple{String}, 1)::String)::Any
Stacktrace:
 [1] sprint(f::Function, args::String; context::Nothing, sizehint::Int64)
   @ Base strings/io.jl:117
 [2] repr(x::String; context::Nothing)                                                                                                                                                                                                                                                                                  @ Base strings/io.jl:286 [inlined]
 [3] unsafe_convert(::Type{Cstring}, s::String)
   @ Base strings/cstring.jl:85 [inlined]
 [4] rm(path::String; force::Bool, recursive::Bool, allow_delayed_delete::Bool)
   @ Base.Filesystem file.jl:320
 [5] take_heap_snapshot(all_one::Bool; dir::Nothing, kwargs::@Kwargs{})
   @ Profile ~/julia/usr/share/julia/stdlib/v1.13/Profile/src/Profile.jl:1461
 [6] take_heap_snapshot(all_one::Bool)
   @ Profile ~/julia/usr/share/julia/stdlib/v1.13/Profile/src/Profile.jl:1454 [inlined]

Verifier error #5: unresolved call to function from Core._apply_iterate(Base.iterate, Base.open, args::Tuple{String, Vararg{String}})::IOStream
Stacktrace:
 [1] open(::Profile.HeapSnapshot.var"#assemble_snapshot##0#assemble_snapshot##1"{String}, ::String, ::Vararg{String}; kwargs::@Kwargs{})
   @ Base io.jl:408
 [2] open(::Profile.HeapSnapshot.var"#assemble_snapshot##0#assemble_snapshot##1"{String}, ::String, ::String)
   @ Base io.jl:407 [inlined]
 [3] assemble_snapshot(in_prefix::String, out_file::String)
   @ Profile.HeapSnapshot ~/julia/usr/share/julia/stdlib/v1.13/Profile/src/heapsnapshot_reassemble.jl:81 [inlined]
 [4] take_heap_snapshot(filepath::String, all_one::Bool; redact_data::Bool, streaming::Bool)
   @ Profile ~/julia/usr/share/julia/stdlib/v1.13/Profile/src/Profile.jl:1416
 [5] take_heap_snapshot(filepath::String, all_one::Bool)
   @ Profile ~/julia/usr/share/julia/stdlib/v1.13/Profile/src/Profile.jl:1408 [inlined]
 [6] take_heap_snapshot(all_one::Bool; dir::Nothing, kwargs::@Kwargs{})
   @ Profile ~/julia/usr/share/julia/stdlib/v1.13/Profile/src/Profile.jl:1469
 [7] take_heap_snapshot(all_one::Bool)
   @ Profile ~/julia/usr/share/julia/stdlib/v1.13/Profile/src/Profile.jl:1454 [inlined]

...

Verifier error #65: unresolved call from Base.pairs(@_2::NamedTuple)::Base.Pairs{Symbol, _A, I, A} where {_A, I<:Tuple{Vararg{Symbol}}, A<:NamedTuple}
Stacktrace:
 [1] macro expansion
   @ logging/logging.jl:388 [inlined]
 [2] take_heap_snapshot(all_one::Bool; dir::Nothing, kwargs::@Kwargs{})
   @ Profile ~/julia/usr/share/julia/stdlib/v1.13/Profile/src/Profile.jl:1463
 [3] take_heap_snapshot(all_one::Bool)
   @ Profile ~/julia/usr/share/julia/stdlib/v1.13/Profile/src/Profile.jl:1454 [inlined]

Trim verify finished with 1 warning.

Trim verify finished with 65 errors.

ERROR: verify_typeinf_trim failed
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:44
 [2] verify_typeinf_trim(io::Base.TTY, codeinfos::Vector{Any})
   @ Base.Compiler.TrimVerifier ./../usr/share/julia/Compiler/src/verifytrim.jl:326
 [3] #invokelatest#1
   @ ./essentials.jl:1057 [inlined]
 [4] invokelatest
   @ ./essentials.jl:1053 [inlined]
 [5] verify_typeinf_trim
   @ ./../usr/share/julia/Compiler/src/typeinfer.jl:1364 [inlined]
 [6] typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt64}, trim::Bool)
   @ Compiler ./../usr/share/julia/Compiler/src/typeinfer.jl:1359
 [7] top-level scope
   @ REPL[2]:1
```

Or with the whole trimming support:
```
$ JULIA_DEBUG=loading time ~/julia/julia -g0 -t1 -J ~/julia/usr/lib/julia/sys.so  --startup-file=no --history-file=no --output-o main.a --output-incremental=no --strip-ir --strip-metadata --experimental --trim ~/julia/contrib/juliac-buildscript.jl ~+/main.jl --output-exe true
```