### PR TITLE
some updates for trimming

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -824,6 +824,7 @@ static void jl_queue_module_for_serialization(jl_serializer_state *s, jl_module_
                      // ... or point to Base functions accessed by the runtime
                      (m == jl_base_module && (!strcmp(jl_symbol_name(b->globalref->name), "wait") ||
                                               !strcmp(jl_symbol_name(b->globalref->name), "task_done_hook"))))) {
+                    record_field_change((jl_value_t**)&b->backedges, NULL);
                     jl_queue_for_serialization(s, b);
                 }
             }


### PR DESCRIPTION
- add a nospecialize to throw_boundserror
- disable load path setup
- remove upstreamed change to utf8proc_map
- fix warning for accessing mod.main in the wrong world
- remove binding backedges when trimming