### PR TITLE
Specialize indexing a CartesianIndices with a CartesianIndex StepRangeLen

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -403,7 +403,7 @@ module IteratorsMD
         getindex(iter, C.indices...)
     end
     @inline Base.getindex(iter::CartesianIndices{0}, ::CartesianIndices{0}) = iter
-    @inline function Base.getindex(iter::CartesianIndices{N}, r::StepRangeLen{CartesianIndex{N},CartesianIndex{N},CartesianIndex{N},<:Integer}) where {N}
+    @inline function Base.getindex(iter::CartesianIndices{N}, r::AbstractRange{CartesianIndex{N}}) where {N}
         @boundscheck checkbounds(iter, r)
         start = first(iter) + CartesianIndex((Tuple(first(r)) .- first.(axes(iter))) .* Tuple(step(iter)))
         stepsz = CartesianIndex(Tuple(step(iter)) .* Tuple(step(r)))

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -405,7 +405,7 @@ module IteratorsMD
     @inline Base.getindex(iter::CartesianIndices{0}, ::CartesianIndices{0}) = iter
     @inline function Base.getindex(iter::CartesianIndices{N}, r::StepRangeLen{CartesianIndex{N},CartesianIndex{N},CartesianIndex{N},<:Integer}) where {N}
         @boundscheck checkbounds(iter, r)
-        start = first(iter) + first(r) - CartesianIndex(first.(axes(iter)))
+        start = first(iter) + CartesianIndex((Tuple(first(r)) .- first.(axes(iter))) .* Tuple(step(iter)))
         stepsz = CartesianIndex(Tuple(step(iter)) .* Tuple(step(r)))
         StepRangeLen(start, stepsz, length(r))
     end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -285,6 +285,34 @@ end
     end
 end
 
+@testset "Indexing CartesianIndices as an nD range" begin
+    for (m, n) in [(4, 6), (4, 4), (6,4)]
+        C = CartesianIndices((m, n))
+        for k in -7:7
+            dlen = length = max(0, k <= 0 ? min(m+k, n) : min(m, n-k))
+            dind = StepRangeLen(CartesianIndex(1+max(0,-k),1+max(0,k)), CartesianIndex(1,1), dlen)
+            @test C[dind] === dind
+            @test C[dind[1:2:end]] === dind[1:2:end]
+        end
+    end
+    for C in [CartesianIndices((20:4:100,)),
+                CartesianIndices((20:-4:-100,)),
+                CartesianIndices((20:100,)),
+                CartesianIndices((Base.IdentityUnitRange(20:100),))]
+        r = StepRangeLen(CartesianIndex(firstindex(C)+1), CartesianIndex(3), 4)
+        @test C[r] == C[collect(r)]
+    end
+    C = CartesianIndices((3:8, 3:8, 3:8))
+    r = StepRangeLen(CartesianIndex(1,1,1), CartesianIndex(1,1,1), 6)
+    @test C[r] == StepRangeLen(CartesianIndex(3,3,3), CartesianIndex(1,1,1), 6)
+    r = StepRangeLen(CartesianIndex(1,1,1), CartesianIndex(1,0,0), 6)
+    @test C[r] == StepRangeLen(CartesianIndex(3,3,3), CartesianIndex(1,0,0), 6)
+
+    C = CartesianIndices((3:8, 3:8, Base.IdentityUnitRange(3:8)))
+    r = StepRangeLen(CartesianIndex(1,1,3), CartesianIndex(1,1,1), 6)
+    @test C[r] == StepRangeLen(CartesianIndex(3,3,3), CartesianIndex(1,1,1), 6)
+end
+
 @testset "LinearIndices" begin
     @testset "constructors" begin
         for oinds in [


### PR DESCRIPTION
Since a `CartesianIndices` may be seen as an nD range, indexing it with a range in a specific direction would return a range. This is the nD equivalent of indexing a 1D range with another range, which returns a range as the result.
For example,
```julia
julia> C = CartesianIndices((3, 3))
CartesianIndices((3, 3))

julia> collect(C)
3×3 Matrix{CartesianIndex{2}}:
 CartesianIndex(1, 1)  CartesianIndex(1, 2)  CartesianIndex(1, 3)
 CartesianIndex(2, 1)  CartesianIndex(2, 2)  CartesianIndex(2, 3)
 CartesianIndex(3, 1)  CartesianIndex(3, 2)  CartesianIndex(3, 3)

julia> using LinearAlgebra

julia> r = diagind(C, IndexCartesian())
StepRangeLen(CartesianIndex(1, 1), CartesianIndex(1, 1), 3)

julia> C[r] # returns a materialized range
3-element Vector{CartesianIndex{2}}:
 CartesianIndex(1, 1)
 CartesianIndex(2, 2)
 CartesianIndex(3, 3)
```
After this PR,
```julia
julia> C[r] # returns the range without materializing it
StepRangeLen(CartesianIndex(1, 1), CartesianIndex(1, 1), 3)

julia> C[r] |> collect
3-element Vector{CartesianIndex{2}}:
 CartesianIndex(1, 1)
 CartesianIndex(2, 2)
 CartesianIndex(3, 3)
```
Such operations might find utility in sparse matrix constructions, when one needs a range of indices to populate. See e.g., https://github.com/JuliaSparse/SparseArrays.jl/pull/600