### PR TITLE
inference: allow `PartialStruct` to represent strict undef field

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -69,7 +69,7 @@ using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospeciali
     structdiff, tls_world_age, unconstrain_vararg_length, unionlen, uniontype_layout,
     uniontypes, unsafe_convert, unwrap_unionall, unwrapva, vect, widen_diagonal,
     _uncompressed_ir, maybe_add_binding_backedge!, datatype_min_ninitialized,
-    partialstruct_undef_length, partialstruct_init_undef
+    partialstruct_init_undefs, fieldcount_noerror
 using Base.Order
 
 import Base: ==, _topmod, append!, convert, copy, copy!, findall, first, get, get!,
@@ -82,10 +82,6 @@ const swapproperty! = Core.swapfield!
 const modifyproperty! = Core.modifyfield!
 const replaceproperty! = Core.replacefield!
 const _DOCS_ALIASING_WARNING = ""
-
-function _getundef(p::PartialStruct)
-    Base.getproperty(p, :undef)
-end
 
 ccall(:jl_set_istopmod, Cvoid, (Any, Bool), Compiler, false)
 

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -514,7 +514,7 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter, cycleid::
             rettype_const = result_type.parameters[1]
             const_flags = 0x2
         elseif isa(result_type, PartialStruct)
-            rettype_const = (_getundef(result_type), result_type.fields)
+            rettype_const = (_getundefs(result_type), result_type.fields)
             const_flags = 0x2
         elseif isa(result_type, InterConditional)
             rettype_const = result_type
@@ -958,9 +958,9 @@ function cached_return_type(code::CodeInstance)
     rettype_const = code.rettype_const
     # the second subtyping/egal conditions are necessary to distinguish usual cases
     # from rare cases when `Const` wrapped those extended lattice type objects
-    if isa(rettype_const, Tuple{BitVector, Vector{Any}}) && !(Tuple{BitVector, Vector{Any}} <: rettype)
-        undef, fields = rettype_const
-        return PartialStruct(fallback_lattice, rettype, undef, fields)
+    if isa(rettype_const, Tuple{Vector{Union{Nothing,Bool}}, Vector{Any}}) && !(Tuple{Vector{Union{Nothing,Bool}}, Vector{Any}} <: rettype)
+        undefs, fields = rettype_const
+        return PartialStruct(fallback_lattice, rettype, undefs, fields)
     elseif isa(rettype_const, PartialOpaque) && rettype <: Core.OpaqueClosure
         return rettype_const
     elseif isa(rettype_const, InterConditional) && rettype !== InterConditional

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -318,15 +318,15 @@ end
         fields = vartyp.fields
         thenfields = thentype === Bottom ? nothing : copy(fields)
         elsefields = elsetype === Bottom ? nothing : copy(fields)
-        undef = copy(_getundef(vartyp))
+        undefs = copy(_getundefs(vartyp))
         if 1 ≤ fldidx ≤ length(fields)
             thenfields === nothing || (thenfields[fldidx] = thentype)
             elsefields === nothing || (elsefields[fldidx] = elsetype)
-            undef[fldidx] = false
+            undefs[fldidx] = false
         end
         return Conditional(slot,
-            thenfields === nothing ? Bottom : PartialStruct(fallback_lattice, vartyp.typ, undef, thenfields),
-            elsefields === nothing ? Bottom : PartialStruct(fallback_lattice, vartyp.typ, undef, elsefields))
+            thenfields === nothing ? Bottom : PartialStruct(fallback_lattice, vartyp.typ, undefs, thenfields),
+            elsefields === nothing ? Bottom : PartialStruct(fallback_lattice, vartyp.typ, undefs, elsefields))
     else
         vartyp_widened = widenconst(vartyp)
         thenfields = thentype === Bottom ? nothing : Any[]
@@ -424,21 +424,15 @@ end
     if isa(a, PartialStruct)
         if isa(b, PartialStruct)
             a.typ <: b.typ || return false
-            if length(a.fields) ≠ length(b.fields)
-                if !(isvarargtype(a.fields[end]) || isvarargtype(b.fields[end]))
-                    length(a.fields) ≥ length(b.fields) || return false
-                else
+            nflds = length(a.fields)
+            nflds == length(b.fields) || return false
+            for i in 1:nflds
+                if !(_getundefs(b)[i] === nothing || _getundefs(a)[i] === _getundefs(b)[i])
                     return false
                 end
-            end
-            na = length(a.fields)
-            nb = length(b.fields)
-            nmax = max(na, nb)
-            for i in 1:nmax
-                is_field_maybe_undef(a, i) ≤ is_field_maybe_undef(b, i) || return false
-                af = partialstruct_getfield(a, i)
-                bf = partialstruct_getfield(b, i)
-                if i == na || i == nb
+                af = a.fields[i]
+                bf = b.fields[i]
+                if i == nflds
                     if isvarargtype(af)
                         # If `af` is vararg, so must bf by the <: above
                         @assert isvarargtype(bf)
@@ -474,10 +468,13 @@ end
             nf = nfields(a.val)
             for i in 1:nf
                 if !isdefined(a.val, i)
-                    is_field_maybe_undef(b, i) || return false # conflicting defined-ness information
+                    _getundefs(b)[i] === false && return false # conflicting defined-ness information
                     continue # since ∀ T Union{} ⊑ T
                 end
                 i > length(b.fields) && break # `a` has more information than `b` that is partially initialized struct
+                if _getundefs(b)[i] === true
+                    return false # conflicting defined-ness information
+                end
                 bfᵢ = b.fields[i]
                 if i == nf
                     bfᵢ = unwrapva(bfᵢ)
@@ -548,7 +545,7 @@ end
     if isa(a, PartialStruct)
         isa(b, PartialStruct) || return false
         length(a.fields) == length(b.fields) || return false
-        _getundef(a) == _getundef(b) || return false
+        _getundefs(a) == _getundefs(b) || return false
         widenconst(a) == widenconst(b) || return false
         a.fields === b.fields && return true # fast path
         for i in 1:length(a.fields)
@@ -756,14 +753,18 @@ end
 # different instances of the compiler that may share the `Core.PartialStruct`
 # type.
 
-function Core.PartialStruct(𝕃::AbstractLattice, @nospecialize(typ), fields::Vector{Any}; all_defined::Bool = true)
-    undef = partialstruct_init_undef(typ, fields; all_defined)
-    return PartialStruct(𝕃, typ, undef, fields)
+# Legacy constructor
+function Core.PartialStruct(𝕃::AbstractLattice, @nospecialize(typ), fields::Vector{Any})
+    return PartialStruct(𝕃, typ, partialstruct_init_undefs(typ, fields), fields)
 end
 
-function Core.PartialStruct(::AbstractLattice, @nospecialize(typ), undef::BitVector, fields::Vector{Any})
+function Core.PartialStruct(::AbstractLattice, @nospecialize(typ), undefs::Vector{Union{Nothing,Bool}}, fields::Vector{Any})
     for i = 1:length(fields)
         assert_nested_slotwrapper(fields[i])
     end
-    return PartialStruct(typ, undef, fields)
+    return PartialStruct(typ, undefs, fields)
 end
+
+# a special getter for `PartialStruct` to achieve better type stability:
+# `(x::PartialStruct).undefs` will be lowered to `getfield(x, :undefs)::Any` otherwise
+_getundefs(p::PartialStruct) = Base.getproperty(p, :undefs)

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -325,65 +325,10 @@ function n_initialized(t::Const)
     nf = nfields(t.val)
     return something(findfirst(i::Int->!isdefined(t.val,i), 1:nf), nf+1)-1
 end
-
-is_field_maybe_undef(t::Const, i) = !isdefined(t.val, i)
-
 function n_initialized(pstruct::PartialStruct)
-    pstruct_undef = _getundef(pstruct)
-    i = findfirst(pstruct_undef)
-    nmin = datatype_min_ninitialized(pstruct.typ)
-    i === nothing && return max(length(pstruct_undef), nmin)
-    n = i::Int - 1
-    @assert n ≥ nmin
-    n
-end
-
-function is_field_maybe_undef(pstruct::PartialStruct, fi)
-    fi ≥ 1 || return true
-    pstruct_undef = _getundef(pstruct)
-    fi ≤ length(pstruct_undef) && return pstruct_undef[fi]
-    fi > datatype_min_ninitialized(pstruct.typ)
-end
-
-function partialstruct_getfield(pstruct::PartialStruct, fi::Integer)
-    @assert fi > 0
-    fi ≤ length(pstruct.fields) && return pstruct.fields[fi]
-    fieldtype(pstruct.typ, fi)
-end
-
-function refines_definedness_information(pstruct::PartialStruct)
-    pstruct_undef = _getundef(pstruct)
-    nflds = length(pstruct_undef)
-    something(findfirst(pstruct_undef), nflds + 1) - 1 > datatype_min_ninitialized(pstruct.typ)
-end
-
-function define_field(pstruct::PartialStruct, fi::Int)
-    if !is_field_maybe_undef(pstruct, fi)
-        # no new information to be gained
-        return nothing
-    end
-
-    new = expand_partialstruct(pstruct, fi)
-    if new === nothing
-        new = PartialStruct(fallback_lattice, pstruct.typ, copy(_getundef(pstruct)), copy(pstruct.fields))
-    end
-    _getundef(new)[fi] = false
-    return new
-end
-
-function expand_partialstruct(pstruct::PartialStruct, until::Int)
-    pstruct_undef = _getundef(pstruct)
-    n = length(pstruct_undef)
-    until ≤ n && return nothing
-
-    undef = partialstruct_init_undef(pstruct.typ, until; all_defined = false)
-    for i in 1:n
-        undef[i] &= pstruct_undef[i]
-    end
-    nf = length(pstruct.fields)
-    typ = pstruct.typ
-    fields = Any[i ≤ nf ? pstruct.fields[i] : fieldtype(typ, i) for i in 1:until]
-    return PartialStruct(fallback_lattice, typ, undef, fields)
+    undefs = _getundefs(pstruct)
+    nf = length(undefs)
+    return something(findfirst(i::Int->undefs[i]!==false, 1:nf), nf+1)-1
 end
 
 # A simplified type_more_complex query over the extended lattice
@@ -397,7 +342,7 @@ end
             @assert n_initialized(typea) ≤ n_initialized(typeb) "typeb ⊑ typea is assumed"
         elseif typeb isa PartialStruct
             @assert n_initialized(typea) ≤ n_initialized(typeb) &&
-                all(b < a for (a, b) in zip(_getundef(typea), _getundef(typeb))) "typeb ⊑ typea is assumed"
+                all(b === nothing || a === b for (a, b) in zip(_getundefs(typea), _getundefs(typeb))) "typeb ⊑ typea is assumed"
         else
             return false
         end
@@ -651,24 +596,21 @@ end
     if aty === bty && !isType(aty)
         if typea isa PartialStruct
             if typeb isa PartialStruct
-                nflds = min(length(typea.fields), length(typeb.fields))
-                nundef = nflds - (isvarargtype(typea.fields[end]) && isvarargtype(typeb.fields[end]))
+                nflds = length(typea.fields)
+                @assert nflds == length(typeb.fields)
             else
-                nflds = min(length(typea.fields), n_initialized(typeb::Const))
-                nundef = nflds
+                nflds = length(typea.fields)
             end
         elseif typeb isa PartialStruct
-            nflds = min(n_initialized(typea::Const), length(typeb.fields))
-            nundef = nflds
+            nflds = length(typeb.fields)
         else
-            nflds = min(n_initialized(typea::Const), n_initialized(typeb::Const))
-            nundef = nflds
+            nflds = fieldcount(aty)
         end
         nflds == 0 && return nothing
-        _undef = partialstruct_init_undef(aty, nundef; all_defined = false)
+        undefs = Union{Nothing,Bool}[nothing for _ in 1:nflds]
         fields = Vector{Any}(undef, nflds)
         fldmin = datatype_min_ninitialized(aty)
-        n_initialized_merged = min(n_initialized(typea::Union{Const, PartialStruct}), n_initialized(typeb::Union{Const, PartialStruct}))
+        n_initialized_merged = min(n_initialized(typea), n_initialized(typeb))
         anyrefine = n_initialized_merged > fldmin
         for i = 1:nflds
             ai = getfield_tfunc(𝕃, typea, Const(i))
@@ -701,16 +643,34 @@ end
                 end
             end
             fields[i] = tyi
-            if i ≤ nundef
-                _undef[i] = is_field_maybe_undef(typea, i) || is_field_maybe_undef(typeb, i)
+            if typea isa PartialStruct
+                aundefᵢ = _getundefs(typea)[i]
+                if typeb isa PartialStruct
+                    if aundefᵢ === _getundefs(typeb)[i]
+                        undefs[i] = aundefᵢ
+                    end
+                else
+                    if aundefᵢ === !isdefined(typeb.val, i)
+                        undefs[i] = aundefᵢ
+                    end
+                end
+            elseif typeb isa PartialStruct
+                bundefᵢ = _getundefs(typeb)[i]
+                if !isdefined(typea.val, i) === bundefᵢ
+                    undefs[i] = bundefᵢ
+                end
+            else
+                aundefᵢ = isdefined(typea.val, i)
+                if aundefᵢ === isdefined(typeb.val, i)
+                    undefs[i] = !aundefᵢ
+                end
             end
             if !anyrefine
                 anyrefine = has_nontrivial_extended_info(𝕃, tyi) || # extended information
-                            ⋤(𝕃, tyi, ft) || # just a type-level information, but more precise than the declared type
-                            !get(_undef, i, true) && i > fldmin # possibly uninitialized field is known to be initialized
+                            ⋤(𝕃, tyi, ft) # just a type-level information, but more precise than the declared type
             end
         end
-        anyrefine && return PartialStruct(𝕃, aty, _undef, fields)
+        anyrefine && return PartialStruct(𝕃, aty, undefs, fields)
     end
     return nothing
 end

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1146,6 +1146,32 @@ function fieldcount(@nospecialize t)
     return fcount
 end
 
+function fieldcount_noerror(@nospecialize t)
+    if t isa UnionAll || t isa Union
+        t = argument_datatype(t)
+        if t === nothing
+            return nothing
+        end
+    elseif t === Union{}
+        return 0
+    end
+    t isa DataType || return nothing
+    if t.name === _NAMEDTUPLE_NAME
+        names, types = t.parameters
+        if names isa Tuple
+            return length(names)
+        end
+        if types isa DataType && types <: Tuple
+            return fieldcount_noerror(types)
+        end
+        return nothing
+    elseif isabstracttype(t) || (t.name === Tuple.name && isvatuple(t))
+        return nothing
+    end
+    return isdefined(t, :types) ? length(t.types) : length(t.name.names)
+end
+
+
 """
     fieldtypes(T::Type)
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3693,7 +3693,7 @@ void jl_init_types(void) JL_GC_DISABLED
                                        jl_emptysvec, 0, 0, 1);
 
     jl_partial_struct_type = jl_new_datatype(jl_symbol("PartialStruct"), core, jl_any_type, jl_emptysvec,
-                                       jl_perm_symsvec(3, "typ", "undef", "fields"),
+                                       jl_perm_symsvec(3, "typ", "undefs", "fields"),
                                        jl_svec(3, jl_any_type, jl_any_type, jl_array_any_type),
                                        jl_emptysvec, 0, 0, 3);
 


### PR DESCRIPTION
This change allows `PartialStruct` to represent structs with strictly
uninitialized fields.

Now the previous `undef::BitVector` field is changed to
`undefs::Vector{Union{Nothing,Bool}}` to encode defined-ness information
of each field.

Also, this lets us fix the length of `typ::PartialStruct`'s `fields` to
always match the number of fields in `typ.typ`. Instead of the current
design where the length of `fields` changes depending on the number of
initialized fields, it seems simpler to have `PartialStruct`s
representing the same `typ` always have the same `fields` length.
So, I've included that refactoring as well.

- fixes the newly detected error in Oscar.jl