### PR TITLE
inference: fix the ptrfree field check

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1266,18 +1266,6 @@ end
     return rewrap_unionall(R, s00)
 end
 
-# checks if a field of this type is guaranteed to be defined to a value
-# and that access to an uninitialized field will cause an `UndefRefError` or return zero
-# - is_undefref_fieldtype(String) === true
-# - is_undefref_fieldtype(Integer) === true
-# - is_undefref_fieldtype(Any) === true
-# - is_undefref_fieldtype(Int) === false
-# - is_undefref_fieldtype(Union{Int32,Int64}) === false
-# - is_undefref_fieldtype(T) === false
-function is_undefref_fieldtype(@nospecialize ftyp)
-    return !has_free_typevars(ftyp) && !allocatedinline(ftyp)
-end
-
 @nospecs function setfield!_tfunc(𝕃::AbstractLattice, o, f, v, order)
     if !isvarargtype(order)
         hasintersect(widenconst(order), Symbol) || return Bottom

--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -266,6 +266,9 @@ end |> Compiler.is_consistent
 @test Base.infer_effects() do
     Maybe{String}()[]
 end |> Compiler.is_consistent
+@test Base.infer_effects() do
+    Maybe{Some{Base.RefValue{Int}}}()
+end |> Compiler.is_consistent
 let f() = Maybe{String}()[]
     @test Base.return_types() do
         f() # this call should be concrete evaluated


### PR DESCRIPTION
The previous implementation using `is_undefref_field` was flawed. We can now implement a more robust check with `DataTypeFieldDesc`.