### PR TITLE
Fix uninitialized variable warning

### DIFF
--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2219,7 +2219,7 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
                 SmallVector<OperandBundleDef,2> bundles;
                 CI->getOperandBundlesAsDefs(bundles);
                 bool gc_transition = false;
-                Value *ptls;
+                Value *ptls = nullptr;
                 for (auto &bundle: bundles)
                     if (bundle.getTag() == "gc-transition") {
                         gc_transition = true;


### PR DESCRIPTION
```julia
In member function 'llvm::Value* llvm::IRBuilderBase::CreateConstInBoundsGEP1_32(llvm::Type*, llvm::Value*, unsigned int, const llvm::Twine&)',
    inlined from 'bool LateLowerGCFrame::CleanupIR(llvm::Function&, State*, bool*)' at /home/topolarity/repos/julia/src/llvm-late-gc-lowering.cpp:2238:73:
/home/topolarity/repos/julia/usr/include/llvm/IR/IRBuilder.h:1898:33: warning: 'ptls' may be used uninitialized [-Wmaybe-uninitialized]
 1898 |     if (auto *V = Folder.FoldGEP(Ty, Ptr, Idx, GEPNoWrapFlags::inBounds()))
      |                   ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/topolarity/repos/julia/src/llvm-late-gc-lowering.cpp: In member function 'bool LateLowerGCFrame::CleanupIR(llvm::Function&, State*, bool*)':
/home/topolarity/repos/julia/src/llvm-late-gc-lowering.cpp:2222:24: note: 'ptls' was declared here
 2222 |                 Value *ptls;
      |                        ^~~~
```

Not much point doing `assert(ptls != NULL)` if we haven't initialized it to NULL in the first place.