### PR TITLE
Compiler: avoid type instability in access to `PartialStruct` field

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -82,7 +82,7 @@ const modifyproperty! = Core.modifyfield!
 const replaceproperty! = Core.replacefield!
 const _DOCS_ALIASING_WARNING = ""
 
-function get_partialstruct_field_undef(p::PartialStruct)
+function _getundef(p::PartialStruct)
     Base.getproperty(p, :undef)
 end
 

--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -82,6 +82,10 @@ const modifyproperty! = Core.modifyfield!
 const replaceproperty! = Core.replacefield!
 const _DOCS_ALIASING_WARNING = ""
 
+function get_partialstruct_field_undef(p::PartialStruct)
+    Base.getproperty(p, :undef)
+end
+
 ccall(:jl_set_istopmod, Cvoid, (Any, Bool), Compiler, false)
 
 eval(x) = Core.eval(Compiler, x)

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -514,7 +514,7 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter, cycleid::
             rettype_const = result_type.parameters[1]
             const_flags = 0x2
         elseif isa(result_type, PartialStruct)
-            rettype_const = (get_partialstruct_field_undef(result_type), result_type.fields)
+            rettype_const = (_getundef(result_type), result_type.fields)
             const_flags = 0x2
         elseif isa(result_type, InterConditional)
             rettype_const = result_type

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -514,7 +514,7 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter, cycleid::
             rettype_const = result_type.parameters[1]
             const_flags = 0x2
         elseif isa(result_type, PartialStruct)
-            rettype_const = (result_type.undef, result_type.fields)
+            rettype_const = (get_partialstruct_field_undef(result_type), result_type.fields)
             const_flags = 0x2
         elseif isa(result_type, InterConditional)
             rettype_const = result_type

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -318,7 +318,7 @@ end
         fields = vartyp.fields
         thenfields = thentype === Bottom ? nothing : copy(fields)
         elsefields = elsetype === Bottom ? nothing : copy(fields)
-        undef = copy(vartyp.undef)
+        undef = copy(get_partialstruct_field_undef(vartyp))
         if 1 ≤ fldidx ≤ length(fields)
             thenfields === nothing || (thenfields[fldidx] = thentype)
             elsefields === nothing || (elsefields[fldidx] = elsetype)
@@ -548,7 +548,7 @@ end
     if isa(a, PartialStruct)
         isa(b, PartialStruct) || return false
         length(a.fields) == length(b.fields) || return false
-        a.undef == b.undef || return false
+        get_partialstruct_field_undef(a) == get_partialstruct_field_undef(b) || return false
         widenconst(a) == widenconst(b) || return false
         a.fields === b.fields && return true # fast path
         for i in 1:length(a.fields)

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -318,7 +318,7 @@ end
         fields = vartyp.fields
         thenfields = thentype === Bottom ? nothing : copy(fields)
         elsefields = elsetype === Bottom ? nothing : copy(fields)
-        undef = copy(get_partialstruct_field_undef(vartyp))
+        undef = copy(_getundef(vartyp))
         if 1 ≤ fldidx ≤ length(fields)
             thenfields === nothing || (thenfields[fldidx] = thentype)
             elsefields === nothing || (elsefields[fldidx] = elsetype)
@@ -548,7 +548,7 @@ end
     if isa(a, PartialStruct)
         isa(b, PartialStruct) || return false
         length(a.fields) == length(b.fields) || return false
-        get_partialstruct_field_undef(a) == get_partialstruct_field_undef(b) || return false
+        _getundef(a) == _getundef(b) || return false
         widenconst(a) == widenconst(b) || return false
         a.fields === b.fields && return true # fast path
         for i in 1:length(a.fields)

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -329,7 +329,7 @@ end
 is_field_maybe_undef(t::Const, i) = !isdefined(t.val, i)
 
 function n_initialized(pstruct::PartialStruct)
-    pstruct_undef = get_partialstruct_field_undef(pstruct)
+    pstruct_undef = _getundef(pstruct)
     i = findfirst(pstruct_undef)
     nmin = datatype_min_ninitialized(pstruct.typ)
     i === nothing && return max(length(pstruct_undef), nmin)
@@ -340,7 +340,7 @@ end
 
 function is_field_maybe_undef(pstruct::PartialStruct, fi)
     fi ≥ 1 || return true
-    pstruct_undef = get_partialstruct_field_undef(pstruct)
+    pstruct_undef = _getundef(pstruct)
     fi ≤ length(pstruct_undef) && return pstruct_undef[fi]
     fi > datatype_min_ninitialized(pstruct.typ)
 end
@@ -352,7 +352,7 @@ function partialstruct_getfield(pstruct::PartialStruct, fi::Integer)
 end
 
 function refines_definedness_information(pstruct::PartialStruct)
-    pstruct_undef = get_partialstruct_field_undef(pstruct)
+    pstruct_undef = _getundef(pstruct)
     nflds = length(pstruct_undef)
     something(findfirst(pstruct_undef), nflds + 1) - 1 > datatype_min_ninitialized(pstruct.typ)
 end
@@ -365,14 +365,14 @@ function define_field(pstruct::PartialStruct, fi::Int)
 
     new = expand_partialstruct(pstruct, fi)
     if new === nothing
-        new = PartialStruct(fallback_lattice, pstruct.typ, copy(get_partialstruct_field_undef(pstruct)), copy(pstruct.fields))
+        new = PartialStruct(fallback_lattice, pstruct.typ, copy(_getundef(pstruct)), copy(pstruct.fields))
     end
-    get_partialstruct_field_undef(new)[fi] = false
+    _getundef(new)[fi] = false
     return new
 end
 
 function expand_partialstruct(pstruct::PartialStruct, until::Int)
-    pstruct_undef = get_partialstruct_field_undef(pstruct)
+    pstruct_undef = _getundef(pstruct)
     n = length(pstruct_undef)
     until ≤ n && return nothing
 
@@ -397,7 +397,7 @@ end
             @assert n_initialized(typea) ≤ n_initialized(typeb) "typeb ⊑ typea is assumed"
         elseif typeb isa PartialStruct
             @assert n_initialized(typea) ≤ n_initialized(typeb) &&
-                all(b < a for (a, b) in zip(get_partialstruct_field_undef(typea), get_partialstruct_field_undef(typeb))) "typeb ⊑ typea is assumed"
+                all(b < a for (a, b) in zip(_getundef(typea), _getundef(typeb))) "typeb ⊑ typea is assumed"
         else
             return false
         end

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -329,9 +329,10 @@ end
 is_field_maybe_undef(t::Const, i) = !isdefined(t.val, i)
 
 function n_initialized(pstruct::PartialStruct)
-    i = findfirst(pstruct.undef)
+    pstruct_undef = get_partialstruct_field_undef(pstruct)
+    i = findfirst(pstruct_undef)
     nmin = datatype_min_ninitialized(pstruct.typ)
-    i === nothing && return max(length(pstruct.undef), nmin)
+    i === nothing && return max(length(pstruct_undef), nmin)
     n = i::Int - 1
     @assert n ≥ nmin
     n
@@ -339,7 +340,8 @@ end
 
 function is_field_maybe_undef(pstruct::PartialStruct, fi)
     fi ≥ 1 || return true
-    fi ≤ length(pstruct.undef) && return pstruct.undef[fi]
+    pstruct_undef = get_partialstruct_field_undef(pstruct)
+    fi ≤ length(pstruct_undef) && return pstruct_undef[fi]
     fi > datatype_min_ninitialized(pstruct.typ)
 end
 
@@ -350,8 +352,9 @@ function partialstruct_getfield(pstruct::PartialStruct, fi::Integer)
 end
 
 function refines_definedness_information(pstruct::PartialStruct)
-    nflds = length(pstruct.undef)
-    something(findfirst(pstruct.undef), nflds + 1) - 1 > datatype_min_ninitialized(pstruct.typ)
+    pstruct_undef = get_partialstruct_field_undef(pstruct)
+    nflds = length(pstruct_undef)
+    something(findfirst(pstruct_undef), nflds + 1) - 1 > datatype_min_ninitialized(pstruct.typ)
 end
 
 function define_field(pstruct::PartialStruct, fi::Int)
@@ -362,19 +365,20 @@ function define_field(pstruct::PartialStruct, fi::Int)
 
     new = expand_partialstruct(pstruct, fi)
     if new === nothing
-        new = PartialStruct(fallback_lattice, pstruct.typ, copy(pstruct.undef), copy(pstruct.fields))
+        new = PartialStruct(fallback_lattice, pstruct.typ, copy(get_partialstruct_field_undef(pstruct)), copy(pstruct.fields))
     end
-    new.undef[fi] = false
+    get_partialstruct_field_undef(new)[fi] = false
     return new
 end
 
 function expand_partialstruct(pstruct::PartialStruct, until::Int)
-    n = length(pstruct.undef)
+    pstruct_undef = get_partialstruct_field_undef(pstruct)
+    n = length(pstruct_undef)
     until ≤ n && return nothing
 
     undef = partialstruct_init_undef(pstruct.typ, until; all_defined = false)
     for i in 1:n
-        undef[i] &= pstruct.undef[i]
+        undef[i] &= pstruct_undef[i]
     end
     nf = length(pstruct.fields)
     typ = pstruct.typ
@@ -393,7 +397,7 @@ end
             @assert n_initialized(typea) ≤ n_initialized(typeb) "typeb ⊑ typea is assumed"
         elseif typeb isa PartialStruct
             @assert n_initialized(typea) ≤ n_initialized(typeb) &&
-                all(b < a for (a, b) in zip(typea.undef, typeb.undef)) "typeb ⊑ typea is assumed"
+                all(b < a for (a, b) in zip(get_partialstruct_field_undef(typea), get_partialstruct_field_undef(typeb))) "typeb ⊑ typea is assumed"
         else
             return false
         end


### PR DESCRIPTION
The `Base.getproperty` method for `PartialStruct` has a type assert to ensure type stable access of the field `undef`. However Compiler.jl has `Compiler.getproperty === Core.getfield`.

Introduce a getter for this field of `PartialStruct` into Compiler.jl and use it.

I guess this should improve compiler performance, and it should help avoid spurious invalidation.