### PR TITLE
bpart: Check whether the replaced binding is a type before assuming

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1051,10 +1051,13 @@ function check_world_bounded(tn::Core.TypeName)
     isdefined(bnd, :partitions) || return nothing
     partition = @atomic bnd.partitions
     while true
-        if is_defined_const_binding(binding_kind(partition)) && partition_restriction(partition) <: tn.wrapper
-            max_world = @atomic partition.max_world
-            max_world == typemax(UInt) && return nothing
-            return Int(partition.min_world):Int(max_world)
+        if is_defined_const_binding(binding_kind(partition))
+            cval = partition_restriction(partition)
+            if isa(cval, Type) && cval <: tn.wrapper
+                max_world = @atomic partition.max_world
+                max_world == typemax(UInt) && return nothing
+                return Int(partition.min_world):Int(max_world)
+            end
         end
         isdefined(partition, :next) || return nothing
         partition = @atomic partition.next

--- a/test/rebinding.jl
+++ b/test/rebinding.jl
@@ -18,6 +18,13 @@ module Rebinding
     @test Base.binding_kind(@__MODULE__, :Foo) == Base.BINDING_KIND_GUARD
     @test contains(repr(x), "@world")
 
+    # Test that it still works if Foo is redefined to a non-type
+    const Foo = 1
+
+    @test Base.binding_kind(@__MODULE__, :Foo) == Base.BINDING_KIND_CONST
+    @test contains(repr(x), "@world")
+    Base.delete_binding(@__MODULE__, :Foo)
+
     struct Foo
         x::Int
     end


### PR DESCRIPTION
Somebody may replace the type with an int. Fixes #57515.