### PR TITLE
Remove `jl_init__threading` and `jl_init_with_image__threading`

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -247,8 +247,6 @@
     XX(jl_init_options) \
     XX(jl_init_restored_module) \
     XX(jl_init_with_image) \
-    XX(jl_init_with_image__threading) \
-    XX(jl_init__threading) \
     XX(jl_install_sigint_handler) \
     XX(jl_instantiate_type_in_env) \
     XX(jl_instantiate_unionall) \

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -119,19 +119,6 @@ JL_DLLEXPORT void jl_init(void)
     free(libbindir);
 }
 
-// HACK: remove this for Julia 1.8 (see <https://github.com/JuliaLang/julia/issues/40730>)
-JL_DLLEXPORT void jl_init__threading(void)
-{
-    jl_init();
-}
-
-// HACK: remove this for Julia 1.8 (see <https://github.com/JuliaLang/julia/issues/40730>)
-JL_DLLEXPORT void jl_init_with_image__threading(const char *julia_bindir,
-                                     const char *image_relative_path)
-{
-    jl_init_with_image(julia_bindir, image_relative_path);
-}
-
 static void _jl_exception_clear(jl_task_t *ct) JL_NOTSAFEPOINT
 {
     ct->ptls->previous_exception = NULL;


### PR DESCRIPTION
These were supposed to be removed in Julia 1.8 apparently (#40730)