### PR TITLE
Make no-body `function` declaration implicitly `global`

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1181,7 +1181,9 @@
     (cond ((and (length= e 2) (or (symbol? name) (globalref? name)))
            (if (not (valid-name? name))
                (error (string "invalid function name \"" name "\"")))
-           `(method ,name))
+           (if (globalref? name)
+             `(block (global ,name) (method ,name))
+             `(block (global-if-global ,name) (method ,name))))
           ((not (pair? name))  e)
           ((eq? (car name) 'call)
            (let* ((raw-typevars (or where '()))
@@ -3127,6 +3129,10 @@
            (if (eq? (var-kind (cadr e) scope) 'local)
                (if (length= e 2) (null) `(= ,@(cdr e)))
                `(const ,@(cdr e))))
+        ((eq? (car e) 'global-if-global)
+           (if (eq? (var-kind (cadr e) scope) 'local)
+               '(null)
+               `(global ,@(cdr e))))
         ((memq (car e) '(local local-def))
          (check-valid-name (cadr e))
          ;; remove local decls
@@ -3759,7 +3765,7 @@ f(x) = yt(x)
   (Set '(quote top core lineinfo line inert local-def unnecessary copyast
          meta inbounds boundscheck loopinfo decl aliasscope popaliasscope
          thunk with-static-parameters toplevel-only
-         global globalref assign-const-if-global isglobal thismodule
+         global globalref global-if-global assign-const-if-global isglobal thismodule
          const atomic null true false ssavalue isdefined toplevel module lambda
          error gc_preserve_begin gc_preserve_end import using export public inline noinline purity)))
 

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -4110,3 +4110,11 @@ end
 # Issue #56904 - lambda linearized twice
 @test (let; try 3; finally try 1; f(() -> x); catch x; end; end; x = 7; end) === 7
 @test (let; try 3; finally try 4; finally try 1; f(() -> x); catch x; end; end; end; x = 7; end) === 7
+
+# Issue #57546 - explicit function declaration should create new global
+module FuncDecl57546
+    using Test
+    @test_nowarn @eval function Any end
+    @test isa(Any, Function)
+    @test isempty(methods(Any))
+end


### PR DESCRIPTION
These were the intended semantics of #57311 (and matches what it used to do in 1.11). Note however that this differs from the body-ful form, which now always tries to extend. Fixes #57546.

Note that this implementation is slightly inefficient since it goes through a binding replacement.
However, there's a change coming down the line which optimizes these replacements.
I do think it should eventually be refactored to just create the binding directly, but that's a little bit
of a larger change.