### PR TITLE
Walk to imports in `isconst(::GlobalRef)`

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1370,8 +1370,7 @@ JL_DLLEXPORT int jl_globalref_is_const(jl_globalref_t *gr)
     if (!b)
         b = jl_get_module_binding(gr->mod, gr->name, 1);
     jl_binding_partition_t *bpart = jl_get_binding_partition(b, jl_current_task->world_age);
-    if (!bpart)
-        return 0;
+    jl_walk_binding_inplace(&b, &bpart, jl_current_task->world_age);
     return jl_bkind_is_some_constant(jl_binding_kind(bpart));
 }
 

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -110,6 +110,7 @@ not_const = 1
 @test isconst(@__MODULE__, :a_const) == true
 @test isconst(Base, :pi) == true
 @test isconst(@__MODULE__, :pi) == true
+@test isconst(GlobalRef(@__MODULE__, :pi)) == true
 @test isconst(@__MODULE__, :not_const) == false
 @test isconst(@__MODULE__, :is_not_defined) == false
 


### PR DESCRIPTION
This restores 1.11 behavior. However, I find this function a bit problematic, since it is asking whether the binding is `constant` in a particular sense, but not whether it is `const` (in the sense of having been declared with the keyword or equivalent), so the shortening is confusing. However, we don't need to address that now. Fixes #57475.