### PR TITLE
Fix C compiler warning when using pre-C11 compiler

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -66,7 +66,6 @@
 
 typedef struct _jl_taggedvalue_t jl_taggedvalue_t;
 typedef struct _jl_tls_states_t *jl_ptls_t;
-typedef struct _jl_genericmemory_t jl_genericmemory_t;
 
 #ifdef JL_LIBRARY_EXPORTS
 #include "uv.h"
@@ -163,7 +162,7 @@ typedef struct {
     // jl_value_t *data[];
 } jl_svec_t;
 
-JL_EXTENSION struct _jl_genericmemory_t {
+JL_EXTENSION typedef struct _jl_genericmemory_t {
     JL_DATA_TYPE
     size_t length;
     void *ptr;
@@ -179,7 +178,7 @@ JL_EXTENSION struct _jl_genericmemory_t {
     // size_t padding[1];
     // T inl[];
 #endif
-};
+} jl_genericmemory_t;
 
 JL_EXTENSION typedef struct {
     JL_DATA_TYPE

--- a/src/julia.h
+++ b/src/julia.h
@@ -163,7 +163,7 @@ typedef struct {
     // jl_value_t *data[];
 } jl_svec_t;
 
-JL_EXTENSION typedef struct _jl_genericmemory_t {
+JL_EXTENSION struct _jl_genericmemory_t {
     JL_DATA_TYPE
     size_t length;
     void *ptr;
@@ -179,7 +179,7 @@ JL_EXTENSION typedef struct _jl_genericmemory_t {
     // size_t padding[1];
     // T inl[];
 #endif
-} jl_genericmemory_t;
+};
 
 JL_EXTENSION typedef struct {
     JL_DATA_TYPE


### PR DESCRIPTION
e.g. when embedding Julia into another project:

    warning: redefinition of typedef 'jl_genericmemory_t' is a C11 feature