### PR TITLE
Always disallow assignments to constants

### DIFF
--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -3969,8 +3969,13 @@ end
 
 # Test trying to define a constant and then trying to assign to the same value
 module AssignConstValueTest
+    using Test
     const x = 1
-    x = 1
+    @test_throws ErrorException @eval x = 1
+    @test_throws ErrorException @eval begin
+        @Base.Experimental.force_compile
+        global x = 1
+    end
 end
 @test isconst(AssignConstValueTest, :x)
 


### PR DESCRIPTION
We have historically allowed the following without warning or error:

```
const x = 1
x = 1
```

As well as
```
const x = 1
x = 2
```
with a UB warning.

In 1.12, we made the second case error, as part of the general binding partition changes, but did not touch the first case, because it did not have the warning.

I think this made a reasonable amount of sense, because we essentially treated constants as special kinds of mutable globals (to which assignment happened to be UB).

However, in the 1.12+ design, constants and globals are quite sepearate beasts, and I think it makes sense to extend the error to the egal case also, even if it is technically more breaking.

In fact, I already thought that's what I did when I implemented the new effect model for global assignment, causing #57566. I can't think of a legitimate reason to keep this special case. For those who want to do binding replacement, the `const` keyword is mandatory, so the assignment is now literally always a semantic no-op or an error.

Fixes #57566.