### PR TITLE
Refactor IOBuffer code

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -24,8 +24,8 @@
 #   to make room for more data, without replacing or resizing data
 
 # Internal trait object used to access unsafe constructors.
-struct Unsafe end
-const unsafe = Unsafe()
+struct UnsafeMethod end
+const unsafe_method = UnsafeMethod()
 
 mutable struct GenericIOBuffer{T<:AbstractVector{UInt8}} <: IO
     # T should support: getindex, setindex!, length, copyto!, similar, and (optionally) resize!
@@ -68,7 +68,7 @@ mutable struct GenericIOBuffer{T<:AbstractVector{UInt8}} <: IO
 
     # Unsafe constructor which does not do any checking
     function GenericIOBuffer{T}(
-            ::Unsafe,
+            ::UnsafeMethod,
             data::T,
             readable::Bool,
             writable::Bool,
@@ -95,7 +95,7 @@ function GenericIOBuffer{T}(
     if mz < len
         throw(ArgumentError("maxsize must not be smaller than data length"))
     end
-    return GenericIOBuffer{T}(unsafe, data, readable, writable, seekable, append, mz)
+    return GenericIOBuffer{T}(unsafe_method, data, readable, writable, seekable, append, mz)
 end
 
 const IOBuffer = GenericIOBuffer{Memory{UInt8}}
@@ -226,7 +226,7 @@ function IOBuffer(;
     # A common usecase of IOBuffer is to incrementally construct strings. By using StringMemory
     # as the default storage, we can turn the result into a string without copying.
     data = fill!(StringMemory(size), 0)
-    buf = GenericIOBuffer{Memory{UInt8}}(unsafe, data, flags.read, flags.write, true, flags.append, mz)
+    buf = GenericIOBuffer{Memory{UInt8}}(unsafe_method, data, flags.read, flags.write, true, flags.append, mz)
     if flags.truncate
         buf.size = 0
     end

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -598,7 +598,7 @@ end
     existing_space = min(lastindex(io.data), io.maxsize) - (io.append ? io.size : io.ptr - 1)
     if existing_space < nshort % Int
         # Outline this function to make it more likely that ensureroom inlines itself
-        return ensureroom_slowpath(io, nshort)
+        return ensureroom_slowpath(io, nshort, existing_space)
     end
     return io
 end
@@ -613,9 +613,8 @@ end
 end
 
 # Here, we already know there is not enough room at the end of the io's data.
-@noinline function ensureroom_slowpath(io::GenericIOBuffer, nshort::UInt)
+@noinline function ensureroom_slowpath(io::GenericIOBuffer, nshort::UInt, available_bytes::Int)
     reclaimable_bytes = first(get_used_span(io)) - 1
-    available_bytes = min(lastindex(io.data), io.maxsize) - (io.append ? io.size : io.ptr - 1)
     # Avoid resizing and instead compact the buffer, only if we gain enough bytes from
     # doing so (at least 32 bytes and 1/8th of the data length). Also, if we would have
     # to resize anyway, there would be no point in compacting, so also check that.

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -775,7 +775,7 @@ function unsafe_write(to::GenericIOBuffer, p::Ptr{UInt8}, nb::UInt)
     append = to.append
     ptr = append ? size+1 : to.ptr
     data = to.data
-    to_write = min(nb % Int, min(Int(length(data))::Int, to.maxsize) - ptr + 1)
+    to_write = min(nb, (min(Int(length(data))::Int, to.maxsize) - ptr + 1) % UInt) % Int
     # Dispatch based on the type of data, to possibly allow using memcpy
     _unsafe_write(data, p, ptr, to_write % UInt)
     # Update to.size only if the ptr has advanced to higher than
@@ -850,8 +850,7 @@ readavailable(io::GenericIOBuffer) = read(io)
 read(io::GenericIOBuffer, nb::Integer) = read!(io, StringVector(min(nb, bytesavailable(io))))
 
 function occursin(delim::UInt8, buf::GenericIOBuffer)
-    ptr = buf.ptr
-    return in(delim, view(buf.data, ptr:ptr + bytesavailable(buf)-1))
+    return in(delim, view(buf.data, buf.ptr:buf.size))
 end
 
 function copyuntil(out::IO, io::GenericIOBuffer, delim::UInt8; keep::Bool=false)

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -93,7 +93,7 @@ mutable struct GenericIOBuffer{T<:AbstractVector{UInt8}} <: IO
             maxsize::Int,
         ) where T<:AbstractVector{UInt8}
         len = Int(length(data))::Int
-        return new(data, false, readable, writable, seekable, append, len, maxsize, 1, 0, -1)
+        return new{T}(data, false, readable, writable, seekable, append, len, maxsize, 1, 0, -1)
     end
 end
 
@@ -297,8 +297,8 @@ function copy(b::GenericIOBuffer{T}) where T
     else
         # When the buffer is just readable, they can share the same data, so we just make
         # a shallow copy of the IOBuffer struct.
-        # Use unsafe method because we want to allow b.maxsize to be larger than data, in case that
-        # is the case for `b`.
+        # Use internal constructor because we want to allow b.maxsize to be larger than data,
+        # in case that is the case for `b`.
         ret = _new_generic_iobuffer(T, b.data, b.readable, b.writable, b.seekable, b.append, b.maxsize)
         ret.offset = b.offset
         ret.ptr = b.ptr

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -578,9 +578,8 @@ function take!(io::GenericIOBuffer)
         nbytes = bytesavailable(io)
         data = read!(io, StringVector(nbytes))
     end
-    # TODO: Why do we not reinit here? The user has taken control of the buffer
-    # so it's not safe to hold onto it.
     if io.writable
+        io.reinit = true
         io.ptr = 1
         io.size = 0
     end

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -335,7 +335,7 @@ show(io::IO, b::GenericIOBuffer) = print(io, "IOBuffer(data=UInt8[...], ",
                                       "size=",     b.size - get_offset(b), ", ",
                                       "maxsize=",  b.maxsize == typemax(Int) ? "Inf" : b.maxsize, ", ",
                                       "ptr=",      b.ptr - get_offset(b), ", ",
-                                      "mark=",     position(b), ")")
+                                      "mark=",     b.mark, ")")
 
 @noinline function _throw_not_readable()
     # See https://github.com/JuliaLang/julia/issues/29688.

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -736,7 +736,7 @@ function take!(io::GenericIOBuffer)
         io.reinit = true
         io.ptr = 1
         io.size = 0
-        io.offset_or_compacted = -get_compacted(io)
+        io.offset_or_compacted = 0
     end
     return data
 end
@@ -769,7 +769,7 @@ function take!(io::IOBuffer)
         io.reinit = true
         io.ptr = 1
         io.size = 0
-        io.offset_or_compacted = -get_compacted(io)
+        io.offset_or_compacted = 0
     end
     return data
 end

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -743,25 +743,7 @@ function write(to::IO, from::GenericIOBuffer)
     # If they're the same buffer, we need to special case it since the buffer
     # is being mutated twice in the write call.
     if to === from
-        if from.append
-            # If from.append, we copy data to from.size + 1.
-            # Note that this ensureroom might switch the data buffer, or update
-            # the fields like from.size
-            ensureroom(from, available)
-            data = from.data
-            size = from.size
-            existing_space = lastindex(data) - min(from.maxsize, size)
-            to_write = min(existing_space, available)
-            iszero(to_write) && return 0
-            GC.@preserve from unsafe_copyto!(data, size + 1, data, from.ptr, to_write)
-            from.size = size + to_write
-            from.ptr += to_write
-            return to_write
-        else
-            # Else, we copy data to itself, meaning we don't need to copy the data at all.
-            from.ptr = from.size + 1
-            return available
-        end
+        throw(ArgumentError("Writing all content fron an IOBuffer into itself in invalid"))
     else
         written = GC.@preserve from unsafe_write(to, pointer(from.data, from.ptr), UInt(available))
         from.ptr += written

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -560,8 +560,7 @@ end
 
 # Here, we already know there is not enough room at the end of the io's data.
 @noinline function ensureroom_slowpath(io::GenericIOBuffer, nshort::UInt)
-    used_span = get_used_span(io)
-    reclaimable_bytes = first(used_span) - 1
+    reclaimable_bytes = first(get_used_span(io)) - 1
     available_bytes = min(lastindex(io.data), io.maxsize) - (io.append ? io.size : io.ptr - 1)
     # Avoid resizing and instead compact the buffer, only if we gain enough bytes from
     # doing so (at least 32 bytes and 1/8th of the data length). Also, if we would have
@@ -575,7 +574,7 @@ end
         return io
     end
 
-    desired_size = length(io.data) + Int(nshort)
+    desired_size = length(io.data) + Int(nshort) - available_bytes
     if desired_size > io.maxsize
         # If we can't fit all the requested data in the new buffer, we need to
         # fit as much as possible, so we must compact

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -10,20 +10,20 @@
 #   uuuuuuuuuuuuuXXXXXXXXXXXXX------.......
 #   |       |    |           |     |     |
 #   |       |    ptr         size  |     |
-#   1       mark                   |     lastindex(data)
+#   1       mark (zero-indexed)    |     lastindex(data)
 #                                  maxsize
 
 #            AFTER COMPACTION
-# Mark, ptr and size decreases by (mark - 1)
+# Mark, ptr and size decreases by `mark`
 
 #   uuuuuXXXXXXXXXXXXX--------------.......
-#   |    |           |             |      |
-#   |    ptr         size          |      lastindex(data)
-#   mark                           maxsize
+#  |     |           |             |      |
+#  |     ptr         size          |      lastindex(data)
+#  mark (zero-indexed)             maxsize
 
 # * The underlying array is always 1-indexed
 # * The IOBuffer has full control of the underlying array.
-# * Data in 1::mark-1, if mark > 0 can be deleted, shifting the whole thing to the left
+# * Data in 1:mark, if mark > -1 can be deleted, shifting the whole thing to the left
 #   to make room for more data, without replacing or resizing data
 
 mutable struct GenericIOBuffer{T<:AbstractVector{UInt8}} <: IO
@@ -56,9 +56,8 @@ mutable struct GenericIOBuffer{T<:AbstractVector{UInt8}} <: IO
     # This value is alwaus in 1 : size+1
     ptr::Int
 
-    # Data at the marked location or before for non-seekable buffers can be compacted.
-    # If this is -1, the mark is not set.
-    # The mark is zero-indexed.
+    # Data at the marked location or before for non-seekable buffers can be deleted.
+    # The mark is zero-indexed. If it is -1, the mark is not set.
     # The purpose of the mark is to reset the stream to a given position using reset.
     # This value is always == -1, or in 0:size-1
     mark::Int

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -460,8 +460,9 @@ function skip(io::GenericIOBuffer, n::Int)
         seek(io, seekto) # Does error checking
     else
         # Don't use seek in order to allow a non-seekable IO to still skip bytes.
-        # Handle overflow
-        io.ptr = min(io.size + 1, clamp(widen(io.ptr) + widen(n), Int))
+        # Handle overflow.
+        maxptr = io.size + 1
+        io.ptr = n > maxptr || io.ptr - n > maxptr ? maxptr : io.ptr + n
         io
     end
 end

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -631,6 +631,9 @@ function closewrite(io::GenericIOBuffer)
 end
 
 @noinline function close(io::GenericIOBuffer{T}) where T
+    if io.writable && !io.reinit
+        _resize!(io, 0)
+    end
     io.readable = false
     io.writable = false
     io.seekable = false
@@ -639,9 +642,6 @@ end
     io.ptr = 1
     io.mark = -1
     io.offset = 0
-    if io.writable && !io.reinit
-        io.data = _resize!(io, 0)
-    end
     nothing
 end
 

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -739,16 +739,16 @@ _unsafe_take!(io::IOBuffer) =
         io.size - io.offset)
 
 function write(to::IO, from::GenericIOBuffer)
-    available = bytesavailable(from)
-    # If they're the same buffer, we need to special case it since the buffer
-    # is being mutated twice in the write call.
+    # This would cause an infinite loop, as it should read until the end, but more
+    # data is being written into it continuously.
     if to === from
         throw(ArgumentError("Writing all content fron an IOBuffer into itself in invalid"))
     else
+        available = bytesavailable(from)
         written = GC.@preserve from unsafe_write(to, pointer(from.data, from.ptr), UInt(available))
-        from.ptr += written
+        from.ptr = from.size + 1
     end
-    return available
+    return written
 end
 
 function unsafe_write(to::GenericIOBuffer, p::Ptr{UInt8}, nb::UInt)

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -252,7 +252,7 @@ end
 
 function unsafe_read(from::GenericIOBuffer, p::Ptr{UInt8}, nb::UInt)
     from.readable || _throw_not_readable()
-    avail = bytesavailable(from)
+    avail = bytesavailable(from) % UInt
     adv = min(avail, nb)
     unsafe_read!(p, from.data, from.ptr, adv)
     from.ptr += adv
@@ -382,6 +382,8 @@ filesize(io::GenericIOBuffer) = (io.seekable ? io.size : bytesavailable(io))
 bytesavailable(io::GenericIOBuffer) = io.size - io.ptr + 1
 
 # Position is zero-indexed, but ptr is one-indexed, hence the -1
+# TODO: Document that position for an unseekable stream is invalid, or
+# make it error
 position(io::GenericIOBuffer) = io.ptr - 1
 
 function skip(io::GenericIOBuffer, n::Integer)
@@ -421,6 +423,7 @@ function seek(io::GenericIOBuffer, n::Int)
     return io
 end
 
+# TODO: Should check for seekable and error if not
 function seekend(io::GenericIOBuffer)
     io.ptr = io.size+1
     return io

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -225,8 +225,7 @@ function IOBuffer(;
     flags = open_flags(read=read, write=write, append=append, truncate=truncate)
     # A common usecase of IOBuffer is to incrementally construct strings. By using StringMemory
     # as the default storage, we can turn the result into a string without copying.
-    data = fill!(StringMemory(size), 0)
-    buf = GenericIOBuffer{Memory{UInt8}}(unsafe_method, data, flags.read, flags.write, true, flags.append, mz)
+    buf = GenericIOBuffer{Memory{UInt8}}(unsafe_method, StringMemory(size), flags.read, flags.write, true, flags.append, mz)
     if flags.truncate
         buf.size = 0
     end

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -751,7 +751,7 @@ end
 # e.g. wrap directly in an array without copying. Otherwise the logic is the same as
 # the generic method
 function take!(io::IOBuffer)
-    ismarked(io) && unmark(io)
+    io.mark = -1
     if io.seekable
         nbytes = filesize(io)
         if nbytes == 0 || io.reinit

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -8,17 +8,19 @@
 # a write operation happens.
 
 #   .....uuuuuuuuuuuuuXXXXXXXXXXXXX------------
-#   |   |       |    |           |            |    |
-#   |   offset  |    ptr         size         |    maxsize (≥ lastindex)
-#   1           mark (zero-indexed)           lastindex(data)
+#   |   |            |           |            |    |
+#   |   offset       ptr         size         |    maxsize (≥ lastindex)
+#   1                                         lastindex(data)
+
+# N.B: `mark` does not correspond to any index in the buffer, but is instead equal
+# to position (== io.offset + io.ptr - 1) at the time it is set.
 
 #            AFTER COMPACTION
-# Mark, ptr and size decreases by `mark`. Offset is zeroed.
 
 #   uuuuuXXXXXXXXXXXXX---------------------
 #  ||    |           |                    |    |
 #  |1    ptr         size                 |    maxsize (≥ lastindex)
-#  mark (zero-indexed)                    lastindex(data)
+#                                         lastindex(data)
 #  offset (set to zero)
 
 # * The underlying array is always 1-indexed
@@ -57,7 +59,6 @@ mutable struct GenericIOBuffer{T<:AbstractVector{UInt8}} <: IO
     # This value is always in 0 : lastindex(data)
     size::Int
 
-    # This is the maximum length that the buffer size can grow to.
     # This value is always in 0:typemax(Int).
     # We always have length(data) <= maxsize
     maxsize::Int

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -471,7 +471,6 @@ end
 # _resize! should reset offset before so.
 function _resize!(io::GenericIOBuffer, new_size::Int)
     old_data = io.data
-    @assert iszero(io.offset)
     if applicable(resize!, old_data, new_size)
         resize!(old_data, new_size)
     else
@@ -498,7 +497,6 @@ function truncate(io::GenericIOBuffer, n::Integer)
     n > io.maxsize && throw(ArgumentError("truncate failed, $(n) bytes is exceeds IOBuffer maxsize $(io.maxsize)"))
     n = Int(n)::Int
     if io.reinit
-        @assert iszero(io.offset)
         io.data = _similar_data(io, n)
         io.reinit = false
     elseif n > length(io.data) - io.offset
@@ -584,7 +582,6 @@ end
 end
 
 function zero_offset!(io::GenericIOBuffer)::Int
-    @assert io.writable
     offset = io.offset
     iszero(offset) && return 0
     size = io.size

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -84,7 +84,7 @@ mutable struct GenericIOBuffer{T<:AbstractVector{UInt8}} <: IO
     # If compacted: Value is in typemin(Int):0
     offset_or_compacted::Int
 
-    # The mark is -1 if offset, else the zero-indexed virtual position of ptr in the buffer.
+    # The mark is -1 if not set, else the zero-indexed virtual position of ptr in the buffer.
     # Due to compaction, this value does not correspond to any actual index in the buffer.
     # This value is in -1:typemax(Int)
     mark::Int

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -617,7 +617,7 @@ end
 function alloc_request(buffer::IOBuffer, recommended_size::UInt)
     ensureroom(buffer, recommended_size)
     ptr = buffer.append ? buffer.size + 1 : buffer.ptr
-    nb = min(length(buffer.data), buffer.maxsize) - ptr + 1
+    nb = min(length(buffer.data), buffer.maxsize + get_offset(buffer)) - ptr + 1
     return (Ptr{Cvoid}(pointer(buffer.data, ptr)), nb)
 end
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -615,7 +615,7 @@ end
 ## BUFFER ##
 ## Allocate space in buffer (for immediate use)
 function alloc_request(buffer::IOBuffer, recommended_size::UInt)
-    ensureroom(buffer, Int(recommended_size))
+    ensureroom(buffer, recommended_size)
     ptr = buffer.append ? buffer.size + 1 : buffer.ptr
     nb = min(length(buffer.data), buffer.maxsize) - ptr + 1
     return (Ptr{Cvoid}(pointer(buffer.data, ptr)), nb)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -990,7 +990,7 @@ function unsafe_read(s::LibuvStream, p::Ptr{UInt8}, nb::UInt)
     if bytesavailable(sbuf) >= nb
         unsafe_read(sbuf, p, nb)
     else
-        newbuf = _truncated_pipebuffer(a; maxsize=nb)
+        newbuf = _truncated_pipebuffer(unsafe_wrap(Array, p, nb); maxsize=nb)
         try
             s.buffer = newbuf
             write(newbuf, sbuf)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -943,8 +943,7 @@ function readbytes!(s::LibuvStream, a::Vector{UInt8}, nb::Int)
         nread = readbytes!(sbuf, a, nb)
     else
         initsize = length(a)
-        newbuf = PipeBuffer(a, maxsize=nb)
-        newbuf.size = get_offset(newbuf) # reset the write pointer to the beginning
+        newbuf = _truncated_pipebuffer(a; maxsize=nb)
         nread = try
             s.buffer = newbuf
             write(newbuf, sbuf)
@@ -991,8 +990,7 @@ function unsafe_read(s::LibuvStream, p::Ptr{UInt8}, nb::UInt)
     if bytesavailable(sbuf) >= nb
         unsafe_read(sbuf, p, nb)
     else
-        newbuf = PipeBuffer(unsafe_wrap(Array, p, nb), maxsize=Int(nb))
-        newbuf.size = get_offset(newbuf) # reset the write pointer to the beginning
+        newbuf = _truncated_pipebuffer(a; maxsize=nb)
         try
             s.buffer = newbuf
             write(newbuf, sbuf)
@@ -1600,8 +1598,7 @@ function readbytes!(s::BufferStream, a::Vector{UInt8}, nb::Int)
             nread = readbytes!(sbuf, a, nb)
         else
             initsize = length(a)
-            newbuf = PipeBuffer(a, maxsize=nb)
-            newbuf.size = get_offset(newbuf) # reset the write pointer to the beginning
+            newbuf = _truncated_pipebuffer(a; maxsize=nb)
             nread = try
                 s.buffer = newbuf
                 write(newbuf, sbuf)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -617,7 +617,7 @@ end
 function alloc_request(buffer::IOBuffer, recommended_size::UInt)
     ensureroom(buffer, Int(recommended_size))
     ptr = buffer.append ? buffer.size + 1 : buffer.ptr
-    nb = min(length(buffer.data)-buffer.offset, buffer.maxsize) + buffer.offset - ptr + 1
+    nb = min(length(buffer.data), buffer.maxsize) - ptr + 1
     return (Ptr{Cvoid}(pointer(buffer.data, ptr)), nb)
 end
 
@@ -944,7 +944,7 @@ function readbytes!(s::LibuvStream, a::Vector{UInt8}, nb::Int)
     else
         initsize = length(a)
         newbuf = PipeBuffer(a, maxsize=nb)
-        newbuf.size = newbuf.offset # reset the write pointer to the beginning
+        newbuf.size = 0 # reset the write pointer to the beginning
         nread = try
             s.buffer = newbuf
             write(newbuf, sbuf)
@@ -992,7 +992,7 @@ function unsafe_read(s::LibuvStream, p::Ptr{UInt8}, nb::UInt)
         unsafe_read(sbuf, p, nb)
     else
         newbuf = PipeBuffer(unsafe_wrap(Array, p, nb), maxsize=Int(nb))
-        newbuf.size = newbuf.offset # reset the write pointer to the beginning
+        newbuf.size = 0 # reset the write pointer to the beginning
         try
             s.buffer = newbuf
             write(newbuf, sbuf)
@@ -1601,7 +1601,7 @@ function readbytes!(s::BufferStream, a::Vector{UInt8}, nb::Int)
         else
             initsize = length(a)
             newbuf = PipeBuffer(a, maxsize=nb)
-            newbuf.size = newbuf.offset # reset the write pointer to the beginning
+            newbuf.size = 0 # reset the write pointer to the beginning
             nread = try
                 s.buffer = newbuf
                 write(newbuf, sbuf)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -990,7 +990,7 @@ function unsafe_read(s::LibuvStream, p::Ptr{UInt8}, nb::UInt)
     if bytesavailable(sbuf) >= nb
         unsafe_read(sbuf, p, nb)
     else
-        newbuf = _truncated_pipebuffer(unsafe_wrap(Array, p, nb); maxsize=nb)
+        newbuf = _truncated_pipebuffer(unsafe_wrap(Array, p, nb); maxsize=Int(nb))
         try
             s.buffer = newbuf
             write(newbuf, sbuf)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -944,7 +944,7 @@ function readbytes!(s::LibuvStream, a::Vector{UInt8}, nb::Int)
     else
         initsize = length(a)
         newbuf = PipeBuffer(a, maxsize=nb)
-        newbuf.size = newbuf.offset # reset the write pointer to the beginning
+        newbuf.size = get_offset(newbuf) # reset the write pointer to the beginning
         nread = try
             s.buffer = newbuf
             write(newbuf, sbuf)
@@ -992,7 +992,7 @@ function unsafe_read(s::LibuvStream, p::Ptr{UInt8}, nb::UInt)
         unsafe_read(sbuf, p, nb)
     else
         newbuf = PipeBuffer(unsafe_wrap(Array, p, nb), maxsize=Int(nb))
-        newbuf.size = newbuf.offset # reset the write pointer to the beginning
+        newbuf.size = get_offset(newbuf) # reset the write pointer to the beginning
         try
             s.buffer = newbuf
             write(newbuf, sbuf)
@@ -1601,7 +1601,7 @@ function readbytes!(s::BufferStream, a::Vector{UInt8}, nb::Int)
         else
             initsize = length(a)
             newbuf = PipeBuffer(a, maxsize=nb)
-            newbuf.size = newbuf.offset # reset the write pointer to the beginning
+            newbuf.size = get_offset(newbuf) # reset the write pointer to the beginning
             nread = try
                 s.buffer = newbuf
                 write(newbuf, sbuf)

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -243,33 +243,7 @@ end
 
 @testset "Write to self" begin
     buffer = IOBuffer()
-    write(buffer, "abcde")
-    write(buffer, buffer)
-    @test take!(buffer) == b"abcde"
-
-    buffer = IOBuffer()
-    write(buffer, "abcde")
-    seek(buffer, 2)
-    write(buffer, buffer)
-    @test take!(buffer) == b"abcde"
-
-    buffer = IOBuffer(;append=true)
-    write(buffer, "abcde")
-    seek(buffer, 2)
-    write(buffer, buffer)
-    @test take!(buffer) == b"abcdecde"
-
-    buffer = IOBuffer(;append=true)
-    write(buffer, "abcde")
-    read(buffer)
-    write(buffer, buffer)
-    @test take!(buffer) == b"abcde"
-
-    buffer = IOBuffer(;append=true, maxsize=7, sizehint=5)
-    write(buffer, "abcde")
-    seek(buffer, 2)
-    write(buffer, buffer)
-    @test take!(buffer) == b"abcdecd"
+    @test_throws ArgumentError write(buffer, buffer)
 end
 
 @testset "Read/write empty IOBuffer" begin
@@ -507,9 +481,6 @@ end
     truncate(io2, io2.size - 2)
     @test read(io2, String) == "goodnightmoonhelloworld"
     seek(io2, 0)
-    write(io2, io2)
-    @test read(io2, String) == ""
-    @test bufcontents(io2) == "goodnightmoonhelloworld"
 end
 
 # issue #11917

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -244,6 +244,13 @@ end
 @testset "Write to self" begin
     buffer = IOBuffer()
     @test_throws ArgumentError write(buffer, buffer)
+
+    # Write to another IOBuffer with limited size
+    to = IOBuffer(;maxsize=4)
+    from = IOBuffer(collect(b"abcdefghi"))
+    write(to, from)
+    @test String(take!(to)) == "abcd"
+    @test eof(from)
 end
 
 @testset "Read/write empty IOBuffer" begin

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -586,16 +586,16 @@ end
 
 @testset "Compacting" begin
     # Compacting works
-    buf = Base.GenericIOBuffer(UInt8[], true, true, false, true, 5)
+    buf = Base.GenericIOBuffer(UInt8[], true, true, false, true, 20)
     mark(buf)
-    write(buf, "Hello")
+    write(buf, "Hello"^5)
     reset(buf)
     unmark(buf)
     read(buf, UInt8)
     read(buf, UInt8)
     write(buf, "a!")
-    @test length(buf.data) == 5
-    @test take!(buf) == b"lloa!"
+    @test length(buf.data) == 20
+    @test String(take!(buf)) == "llo" * "Hello"^3 * "a!"
 
     # Compacting does not do anything when mark == 0
     buf = Base.GenericIOBuffer(UInt8[], true, true, false, true, 5)

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -25,7 +25,7 @@ new_unseekable_buffer() = Base.GenericIOBuffer(Memory{UInt8}(), true, true, fals
     # Test that you can't make an IOBuffer with a maxsize
     # smaller than the size you actually give it
     @test_throws ArgumentError IOBuffer([0x01, 0x02]; maxsize=1)
-    @test_throws ArgumentError IOBuffer("abcdefghij"; maxsize=8)
+    @test_throws ArgumentError IOBuffer(b"abcdefghij"; maxsize=8)
 end
 
 @testset "Basic reading" begin

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -11,7 +11,7 @@ bufcontents(io::Base.GenericIOBuffer) = unsafe_string(pointer(io.data), io.size)
 # it anyway.
 # I make a new method here such that if the implementation of Base.PipeBuffer
 # changes, these tests will still work.
-new_unseekable_buffer() = Base.GenericIOBuffer(Memory{UInt8}(), true, true, false, true, typemax(Int))
+new_unseekable_buffer() = Base.GenericIOBuffer(Memory{UInt8}(), true, true, false, true, typemax(Int), false)
 
 @testset "Basic tests" begin
     @test_throws ArgumentError IOBuffer(;maxsize=-1)
@@ -361,7 +361,7 @@ end
 @testset "Position of compactable buffer" begin
     # Set maxsize, because otherwise compaction it too hard to reason about,
     # and this test will be brittle
-    io = Base.GenericIOBuffer(Memory{UInt8}(), true, true, false, true, 100)
+    io = Base.GenericIOBuffer(Memory{UInt8}(), true, true, false, true, 100, false)
     write(io, "abcd")
     read(io, UInt16)
     @test position(io) == 2
@@ -608,7 +608,7 @@ end
 
 @testset "Compacting" begin
     # Compacting works
-    buf = Base.GenericIOBuffer(UInt8[], true, true, false, true, 20)
+    buf = Base.GenericIOBuffer(UInt8[], true, true, false, true, 20, false)
     mark(buf)
     write(buf, "Hello"^5)
     reset(buf)
@@ -620,7 +620,7 @@ end
     @test String(take!(buf)) == "llo" * "Hello"^3 * "a!"
 
     # Compacting does not do anything when mark == 0
-    buf = Base.GenericIOBuffer(UInt8[], true, true, false, true, 5)
+    buf = Base.GenericIOBuffer(UInt8[], true, true, false, true, 5, false)
     mark(buf)
     write(buf, "Hello")
     reset(buf)
@@ -641,7 +641,7 @@ end
 end
 
 @testset "peek(::GenericIOBuffer)" begin
-    io = Base.GenericIOBuffer(UInt8[], true, true, false, true, typemax(Int))
+    io = Base.GenericIOBuffer(UInt8[], true, true, false, true, typemax(Int), false)
     write(io, "こんにちは")
     @test peek(io) == 0xe3
     @test peek(io, Char) == 'こ'

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -202,6 +202,20 @@ end
     write(buf, "bcd")
     @test read(buf, UInt8) == 0x61
     @test take!(buf) == b"bcd"
+
+    # Compaction is reset after take!
+    buf = Base.GenericIOBuffer(Memory{UInt8}(), true, true, false, true, 100, false)
+    write(buf, rand(UInt8, 50))
+    read(buf, 40)
+    write(buf, rand(UInt8, 100))
+    mark(buf)
+    read(buf, 70)
+    @test position(buf) == 110
+    @test length(buf.data) <= 100
+    v = take!(buf)
+    write(buf, 0xf1)
+    @test position(buf) == 0
+    @test !ismarked(buf)
 end
 
 @testset "maxsize is preserved" begin

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -107,6 +107,37 @@ end
     @test isreadable(buf2)
     @test !iswritable(buf2)
     @test read(buf2) == 0x04:0x0d
+
+    # Test copying a non-seekable stream
+    buf = new_unseekable_buffer()
+    write(buf, "abcdef")
+    read(buf, UInt16)
+    mark(buf)
+    read(buf, UInt16)
+    buf2 = copy(buf)
+    @test read(buf2) == b"ef"
+    reset(buf2)
+    @test read(buf2) == b"cdef"
+
+    # Test copying seekable stream
+    buf = IOBuffer()
+    write(buf, "abcdef")
+    seekstart(buf)
+    read(buf)
+    mark(buf)
+    buf2 = copy(buf)
+    @test reset(buf2) == 6
+    seekstart(buf2)
+    @test read(buf2) == b"abcdef"
+
+    # Test copying a taken buffer
+    buf = IOBuffer()
+    write(buf, "abcdef")
+    take!(buf)
+    buf2 = copy(buf)
+    @test eof(buf2)
+    seekstart(buf2)
+    @test eof(buf2)
 end
 
 @testset "copyuntil" begin

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -88,11 +88,11 @@ end
 
     # Test copying with non-Memory backed GenericIOBuffer
     buf = IOBuffer(Test.GenericArray(collect(0x02:0x0d)), read=true)
-    @test_broken read(buf, UInt16)
+    @test read(buf, UInt16) == 0x0302
     buf2 = copy(buf)
     @test isreadable(buf2)
     @test !iswritable(buf2)
-    @test_broken read(buf2) == 0x04:0x0d
+    @test read(buf2) == 0x04:0x0d
 end
 
 @testset "copyuntil" begin

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -128,6 +128,15 @@ end
     @test take!(copy(b)) == b"abcdeabcabc\n"
     copyline(b, a; keep=false)
     @test take!(copy(b)) == b"abcdeabcabc\nac"
+
+    # Test a current bug in copyline
+    a = Base.SecretBuffer("abcde\r\n")
+    b = IOBuffer()
+    write(b, "xxxxxxxxxx")
+    seek(b, 2)
+    copyline(b, a; keep=false)
+    Base.shred!(a)
+    @test take!(b) == b"xxabcdexxx"
 end
 
 @testset "take!" begin

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -195,6 +195,19 @@ end
     v = pushfirst!([0x01], 0x02)
     io = IOBuffer(v; maxsize=2)
     @test read(io) == b"\x02\x01"
+
+    # Buffer will not write past maxsize, even if given a larger buffer
+    # And also even if the data is taken and replaced
+    v = sizehint!(UInt8[], 128)
+    io = IOBuffer(v; write=true, read=true, maxsize=12)
+    write(io, 0x01:0x0f)
+    seekstart(io)
+    @test read(io) == 0x01:0x0c
+    @test write(io, 0x01) == 0
+    @test write(io, "abc") == 0
+    @test take!(io).ref.mem === v.ref.mem
+    write(io, 0x01:0x0f)
+    @test take!(io) == 0x01:0x0c
 end
 
 @testset "Write to self" begin

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -21,6 +21,11 @@ new_unseekable_buffer() = Base.GenericIOBuffer(Memory{UInt8}(), true, true, fals
     v = UInt8[]
     buf = IOBuffer(v; sizehint=64, write=true)
     @test length(v.ref.mem) >= 64
+
+    # Test that you can't make an IOBuffer with a maxsize
+    # smaller than the size you actually give it
+    @test_throws ArgumentError IOBuffer([0x01, 0x02]; maxsize=1)
+    @test_throws ArgumentError IOBuffer("abcdefghij"; maxsize=8)
 end
 
 @testset "Basic reading" begin

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -7,7 +7,7 @@ ioslength(io::IOBuffer) = (io.seekable ? io.size : bytesavailable(io))
 bufcontents(io::Base.GenericIOBuffer) = unsafe_string(pointer(io.data), io.size)
 
 @testset "Basic tests" begin
-    @test_broken IOBuffer(;maxsize=-1)
+    @test_throws ArgumentError IOBuffer(;maxsize=-1)
     @test_throws ArgumentError IOBuffer([0x01]; maxsize=-1)
 
     # Test that sizehint actually will sizehint the vector,


### PR DESCRIPTION
I've been a little frustrated with the IOBuffer code. It contains a whole bunch of implicit invariants, and is poorly commented. It also has several bugs that ultimately stems from the code being unclear about its own assumptions.

This is a refactoring of IOBuffer. The primary goals are:
* Comment the code more heavily
* Test the code more thoroughly

The secondary goals are
* Fix a few outstanding bugs
* Add some minor performance improvements

This is a purely internal refactoring with be no change in behaviour of `IOBuffer`, except straight up bugfixes. However, note that previous code may have relied on buggy behaviour. Fixing bugs may therefore cause breakage.

## Current changes
### **BEHAVIOUR CHANGES**
* The following code used to not throw an error, but now does: `IOBuffer(b"abc"; maxsize=2)`. I consider this a bugfix. It should not be possible to construct an IOBuffer with a buffersize larger than `maxsize`.
* It used to be possible to write to indices higher than `maxindex`, which could trigger a bug causing data loss. The bug has been fixed, but as a result, some IOBuffers may reach full capacity faster (really: reach it at the correct point), changing writing behaviour. 

### Bugfixes
* Do not corrupt data on `copyline` on a non-appending buffer
* Respect `maxsize` even after `take!` (fix #57549)
* Fix bug when copying from an appending iobuffer to itself
* Fix bug where re-allocating the buffer may cause it to shrink, discarding data.
* Fix bug where `truncate` may throw a wrong BoundsError
* Fix a bug where truncating a buffer may not correctly removed mark at position that has been deleted
* Fix a bug where initializing an IOBuffer without an explicit buffer and with `truncate=false` makes it contain the full buffer
* Current behaviour for `reset` and `position` did not work for `PipeBuffer`. Fix that

### Changes to brittle code
* Removed some tests that explicitly tested internal code and internal behaviour. Some of that behaviour has changed.
* Changed some internal `PipeBuffer` behaviour, which did not respect writable IOBuffer's ownership of their buffer and therefore failed spuriously

### Performance improvements
* Writing to dense IOBuffer now uses memmove and is up to 10x faster for long writes.
* Minor optimisations (about ten percent) for writing to IOBuffers in general 

Closes #57549