### PR TITLE
avoid overflow on functionality to print backtrace of safepoint straggler

### DIFF
--- a/src/safepoint.c
+++ b/src/safepoint.c
@@ -157,7 +157,7 @@ void jl_gc_wait_for_the_world(jl_ptls_t* gc_all_tls_states, int gc_n_threads)
                     uv_mutex_unlock(&safepoint_lock);
                 }
                 else {
-                    const int64_t timeout = jl_options.timeout_for_safepoint_straggler_s * 1000000000; // convert to nanoseconds
+                    const int64_t timeout = jl_options.timeout_for_safepoint_straggler_s * 1000000000LL; // convert to nanoseconds
                     int ret = 0;
                     uv_mutex_lock(&safepoint_lock);
                     if (!jl_atomic_load_relaxed(&ptls2->gc_state)) {

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1630,25 +1630,27 @@ end
     program = "
         function main()
             t = Threads.@spawn begin
-                ccall(:uv_sleep, Cvoid, (Cuint,), 5000)
+                ccall(:uv_sleep, Cvoid, (Cuint,), 20_000)
             end
             # Force a GC
-            ccall(:uv_sleep, Cvoid, (Cuint,), 1000)
+            ccall(:uv_sleep, Cvoid, (Cuint,), 1_000)
             GC.gc()
             wait(t)
         end
         main()
     "
-    tmp_output_filename = tempname()
-    tmp_output_file = open(tmp_output_filename, "w")
-    if isnothing(tmp_output_file)
-        error("Failed to open file $tmp_output_filename")
+    for timeout in ("1", "4", "16")
+        tmp_output_filename = tempname()
+        tmp_output_file = open(tmp_output_filename, "w")
+        if isnothing(tmp_output_file)
+            error("Failed to open file $tmp_output_filename")
+        end
+        run(pipeline(`$(Base.julia_cmd()) --threads=4 --timeout-for-safepoint-straggler=$(timeout) -e $program`, stderr=tmp_output_file))
+        # Check whether we printed the straggler's backtrace
+        @test !isempty(read(tmp_output_filename, String))
+        close(tmp_output_file)
+        rm(tmp_output_filename)
     end
-    run(pipeline(`$(Base.julia_cmd()) --threads=4 --timeout-for-safepoint-straggler=1 -e $program`, stderr=tmp_output_file))
-    # Check whether we printed the straggler's backtrace
-    @test !isempty(read(tmp_output_filename, String))
-    close(tmp_output_file)
-    rm(tmp_output_filename)
 end
 
 end # main testset


### PR DESCRIPTION
In the line of C code:

```C
const int64_t timeout = jl_options.timeout_for_safepoint_straggler_s * 1000000000;
```

`jl_options.timeout_for_safepoint_straggler_s` is an `int16_t` and `1000000000` is an `int32_t`.

The result of `jl_options.timeout_for_safepoint_straggler_s * 1000000000` will be an `int32_t` which may not be large enough to hold the value of `jl_options.timeout_for_safepoint_straggler_s` after converting to nanoseconds, leading to overflow.