### PR TITLE
Mention docstrings in the style guide

### DIFF
--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -23,7 +23,7 @@ environments provide a way to access documentation directly:
 `Docs.hasdoc(module, name)::Bool` tells whether a name has a docstring. `Docs.undocumented_names(module; all)`
 returns the undocumented names in a module.
 
-## Writing Documentation
+## [Writing Documentation](@id man-writing-documentation)
 
 Julia enables package developers and users to document functions, types and other objects easily
 via a built-in documentation system.

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -19,6 +19,11 @@ Julia's compiler works.
 It is also worth emphasizing that functions should take arguments, instead of operating directly
 on global variables (aside from constants like [`pi`](@ref)).
 
+## Write docstrings
+
+Comments describing an object should typically be written as [docstrings](man-writing-documentation) for improved editor and REPL accessability.
+Inline comments (`# comment`) and multiline comments (`#= comment =#`) are appropriate for information that is intended only for the reader of the code (as opposed to a user).
+
 ## Avoid writing overly-specific types
 
 Code should be as generic as possible. Instead of writing:

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -21,7 +21,7 @@ on global variables (aside from constants like [`pi`](@ref)).
 
 ## Write docstrings
 
-Comments describing an object should typically be written as [docstrings](man-writing-documentation) for editor and REPL accessability.
+Comments describing an object should typically be written as [docstrings](@ref man-writing-documentation) for editor and REPL accessability.
 Inline comments (`# comment`) and multiline comments (`#= comment =#`) are appropriate for information that is intended only for the reader of the code (as opposed to a user).
 
 ## Avoid writing overly-specific types

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -21,7 +21,7 @@ on global variables (aside from constants like [`pi`](@ref)).
 
 ## Write docstrings
 
-Comments describing an object should typically be written as [docstrings](man-writing-documentation) for improved editor and REPL accessability.
+Comments describing an object should typically be written as [docstrings](man-writing-documentation) for editor and REPL accessability.
 Inline comments (`# comment`) and multiline comments (`#= comment =#`) are appropriate for information that is intended only for the reader of the code (as opposed to a user).
 
 ## Avoid writing overly-specific types

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -21,7 +21,7 @@ on global variables (aside from constants like [`pi`](@ref)).
 
 ## Write docstrings
 
-Comments describing an object should typically be written as [docstrings](@ref man-writing-documentation) for editor and REPL accessability.
+Comments describing an object should typically be written as [docstrings](@ref man-writing-documentation) for editor and REPL accessibility.
 Inline comments (`# comment`) and multiline comments (`#= comment =#`) are appropriate for information that is intended only for the reader of the code (as opposed to a user).
 
 ## Avoid writing overly-specific types


### PR DESCRIPTION
Mention docstrings in the style guide and link to the section of the manual that gives more detail.