### PR TITLE
`Base`: `append!`, `resize!`: convert length to `Int` before passing it on

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1348,7 +1348,7 @@ function append! end
 
 function append!(a::Vector{T}, items::Union{AbstractVector{<:T},Tuple}) where T
     items isa Tuple && (items = map(x -> convert(T, x), items))
-    n = length(items)
+    n = Int(length(items))::Int
     _growend!(a, n)
     copyto!(a, length(a)-n+1, items, firstindex(items), n)
     return a

--- a/base/array.jl
+++ b/base/array.jl
@@ -1472,10 +1472,8 @@ julia> a[1:6]
  1
 ```
 """
-function resize!(a::Vector, nl::Integer)
-    resize!(a, Int(nl)::Int)
-end
-function resize!(a::Vector, nl::Int)
+function resize!(a::Vector, nl_::Integer)
+    nl = Int(nl_)::Int
     l = length(a)
     if nl > l
         _growend!(a, nl-l)

--- a/base/array.jl
+++ b/base/array.jl
@@ -1473,6 +1473,9 @@ julia> a[1:6]
 ```
 """
 function resize!(a::Vector, nl::Integer)
+    resize!(a, Int(nl)::Int)
+end
+function resize!(a::Vector, nl::Int)
     l = length(a)
     if nl > l
         _growend!(a, nl-l)


### PR DESCRIPTION
Reduces the number of invalidations from 512 to 505 on running this code:

```julia
struct I <: Integer end
Base.Int(::I) = 7
```