### PR TITLE
trimming: Restore JLL support

### DIFF
--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -163,7 +163,7 @@ macro max_methods(n::Int, fdef::Expr)
 end
 
 """
-    Experimental.@compiler_options optimize={0,1,2,3} compile={yes,no,all,min} infer={yes,no} max_methods={default,1,2,3,4}
+    Experimental.@compiler_options optimize={0,1,2,3} compile={yes,no,all,min} infer={true,false} max_methods={default,1,2,3,4}
 
 Set compiler options for code in the enclosing module. Options correspond directly to
 command-line options with the same name, where applicable. The following options

--- a/contrib/juliac-buildscript.jl
+++ b/contrib/juliac-buildscript.jl
@@ -33,9 +33,6 @@ end
     JuliaSyntax.enable_in_core!() = nothing
     init_active_project() = ACTIVE_PROJECT[] = nothing
     set_active_project(projfile::Union{AbstractString,Nothing}) = ACTIVE_PROJECT[] = projfile
-    init_depot_path() = nothing
-    init_load_path() = nothing
-    init_active_project() = nothing
     disable_library_threading() = nothing
     start_profile_listener() = nothing
     invokelatest_trimmed(f, args...; kwargs...) = f(args...; kwargs...)

--- a/test/trimming/Makefile
+++ b/test/trimming/Makefile
@@ -30,7 +30,7 @@ LDFLAGS_ADD = -lm $(shell $(JULIA_CONFIG) --ldflags --ldlibs) -ljulia-internal
 
 #=============================================================================
 
-release: hello$(EXE)
+release: hello$(EXE) basic_jll$(EXE)
 
 hello.o: $(SRCDIR)/hello.jl $(BUILDSCRIPT)
 	$(JULIA) -t 1 -J $(BIN)/../lib/julia/sys.so --startup-file=no --history-file=no --output-o $@ --output-incremental=no --strip-ir --strip-metadata --experimental --trim $(BUILDSCRIPT) $(SRCDIR)/hello.jl --output-exe true
@@ -38,14 +38,21 @@ hello.o: $(SRCDIR)/hello.jl $(BUILDSCRIPT)
 init.o: $(SRCDIR)/init.c
 	$(CC) -c -o $@ $< $(CPPFLAGS_ADD) $(CPPFLAGS) $(CFLAGS_ADD) $(CFLAGS)
 
+basic_jll.o: $(SRCDIR)/basic_jll.jl $(BUILDSCRIPT)
+	$(JULIA) -t 1 -J $(BIN)/../lib/julia/sys.so --startup-file=no --history-file=no --project=$(SRCDIR) -e "using Pkg; Pkg.instantiate()"
+	$(JULIA) -t 1 -J $(BIN)/../lib/julia/sys.so --startup-file=no --history-file=no --project=$(SRCDIR) --output-o $@ --output-incremental=no --strip-ir --strip-metadata --experimental --trim $(BUILDSCRIPT) $(SRCDIR)/basic_jll.jl --output-exe true
+
 hello$(EXE): hello.o init.o
 	$(CC) -o $@ $(WHOLE_ARCHIVE) hello.o $(NO_WHOLE_ARCHIVE) init.o $(CPPFLAGS_ADD) $(CPPFLAGS) $(CFLAGS_ADD) $(CFLAGS) $(LDFLAGS_ADD) $(LDFLAGS)
 
-check: hello$(EXE)
+basic_jll$(EXE): basic_jll.o init.o
+	$(CC) -o $@ $(WHOLE_ARCHIVE) basic_jll.o $(NO_WHOLE_ARCHIVE) init.o $(CPPFLAGS_ADD) $(CPPFLAGS) $(CFLAGS_ADD) $(CFLAGS) $(LDFLAGS_ADD) $(LDFLAGS)
+
+check: hello$(EXE) basic_jll$(EXE)
 	$(JULIA) --depwarn=error $(SRCDIR)/../runtests.jl $(SRCDIR)/trimming
 
 clean:
-	-rm -f hello$(EXE) init.o hello.o
+	-rm -f hello$(EXE) basic_jll$(EXE) init.o hello.o basic_jll.o
 
 .PHONY: release clean check
 

--- a/test/trimming/Project.toml
+++ b/test/trimming/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+Zstd_jll = "3161d3a3-bdf6-5164-811a-617609db77b4"

--- a/test/trimming/basic_jll.jl
+++ b/test/trimming/basic_jll.jl
@@ -1,0 +1,14 @@
+module MyApp
+
+using Libdl
+using Zstd_jll
+
+Base.@ccallable function main()::Cint
+    println(Core.stdout, "Julia! Hello, world!")
+    fptr = dlsym(Zstd_jll.libzstd_handle, :ZSTD_versionString)
+    println(Core.stdout, unsafe_string(ccall(fptr, Cstring, ())))
+    println(Core.stdout, unsafe_string(ccall((:ZSTD_versionString, libzstd), Cstring, ())))
+    return 0
+end
+
+end

--- a/test/trimming/trimming.jl
+++ b/test/trimming/trimming.jl
@@ -1,7 +1,15 @@
 using Test
 
-exe_path = joinpath(@__DIR__, "hello"*splitext(Base.julia_exename())[2])
+let exe_suffix = splitext(Base.julia_exename())[2]
 
-@test readchomp(`$exe_path`) == "Hello, world!"
+    hello_exe = joinpath(@__DIR__, "hello" * exe_suffix)
+    @test readchomp(`$hello_exe`) == "Hello, world!"
+    @test filesize(hello_exe) < filesize(unsafe_string(Base.JLOptions().image_file))/10
 
-@test filesize(exe_path) < filesize(unsafe_string(Base.JLOptions().image_file))/10
+    basic_jll_exe = joinpath(@__DIR__, "basic_jll" * exe_suffix)
+    lines = split(readchomp(`$basic_jll_exe`), "\n")
+    @test lines[1] == "Julia! Hello, world!"
+    @test lines[2] == lines[3]
+    @test Base.VersionNumber(lines[2]) ≥ v"1.5.7"
+    @test filesize(basic_jll_exe) < filesize(unsafe_string(Base.JLOptions().image_file))/10
+end


### PR DESCRIPTION
Add an extra indirection to our printing code for `@assert` so that that inferrability is restored after the override. Also partially revert d77c24f009b93577bcf254908e639c9f149f2e4e which, deleted init code important for JLL's

~This still requires that we bypass this inference-disabling code in JLLWrappers.jl:~
```julia
if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@compiler_options"))
    @eval Base.Experimental.@compiler_options compile=min optimize=0 infer=false
end
```