### PR TITLE
use `@main` for juliac executable entry point

### DIFF
--- a/contrib/juliac-buildscript.jl
+++ b/contrib/juliac-buildscript.jl
@@ -1,9 +1,5 @@
 # Script to run in the process that generates juliac's object file output
 
-inputfile = ARGS[1]
-output_type = ARGS[2]
-add_ccallables = ARGS[3] == "true"
-
 # Run the verifier in the current world (before modifications), so that error
 # messages and types print in their usual way.
 Core.Compiler._verify_trim_world_age[] = Base.get_world_counter()
@@ -189,13 +185,37 @@ end
 
 import Base.Experimental.entrypoint
 
-let mod = Base.include(Base.__toplevel__, inputfile)
-    if !isa(mod, Module)
-        mod = Main
-    end
+# for use as C main if needed
+function _main(argc::Cint, argv::Ptr{Ptr{Cchar}})::Cint
+    args = ccall(:jl_set_ARGS, Any, (Cint, Ptr{Ptr{Cchar}}), argc, argv)::Vector{String}
+    return Main.main(args)
+end
+
+let mod = Base.include(Main, ARGS[1])
     Core.@latestworld
-    if output_type == "--output-exe" && isdefined(mod, :main) && !add_ccallables
-        entrypoint(mod.main, ())
+    if ARGS[2] == "--output-exe"
+        have_cmain = false
+        if isdefined(Main, :main)
+            for m in methods(Main.main)
+                if isdefined(m, :ccallable)
+                    # TODO: possibly check signature and return type
+                    have_cmain = true
+                    break
+                end
+            end
+        end
+        if !have_cmain
+            if Base.should_use_main_entrypoint()
+                if hasmethod(Main.main, Tuple{Vector{String}})
+                    entrypoint(_main, (Cint, Ptr{Ptr{Cchar}}))
+                    Base._ccallable("main", Cint, Tuple{typeof(_main), Cint, Ptr{Ptr{Cchar}}})
+                else
+                    error("`@main` must accept a `Vector{String}` argument.")
+                end
+            else
+                error("To generate an executable a `@main` function must be defined.")
+            end
+        end
     end
     #entrypoint(join, (Base.GenericIOBuffer{Memory{UInt8}}, Array{Base.SubString{String}, 1}, String))
     #entrypoint(join, (Base.GenericIOBuffer{Memory{UInt8}}, Array{String, 1}, Char))
@@ -204,7 +224,7 @@ let mod = Base.include(Base.__toplevel__, inputfile)
     entrypoint(Base.wait_forever, ())
     entrypoint(Base.trypoptask, (Base.StickyWorkqueue,))
     entrypoint(Base.checktaskempty, ())
-    if add_ccallables
+    if ARGS[3] == "true"
         ccall(:jl_add_ccallable_entrypoints, Cvoid, ())
     end
 end

--- a/src/gf.c
+++ b/src/gf.c
@@ -4642,8 +4642,6 @@ JL_DLLEXPORT void jl_extern_c(jl_value_t *name, jl_value_t *declrt, jl_tupletype
         jl_error("@ccallable: function object must be a singleton");
 
     // compute / validate return type
-    if (!jl_is_concrete_type(declrt) || jl_is_kind(declrt))
-        jl_error("@ccallable: return type must be concrete and correspond to a C type");
     if (!jl_type_mappable_to_c(declrt))
         jl_error("@ccallable: return type doesn't correspond to a C type");
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -2579,7 +2579,7 @@ uint64_t parse_heap_size_hint(const char *optarg, const char *option_name);
 
 // Set julia-level ARGS array according to the arguments provided in
 // argc/argv
-JL_DLLEXPORT void jl_set_ARGS(int argc, char **argv);
+JL_DLLEXPORT jl_value_t *jl_set_ARGS(int argc, char **argv);
 
 JL_DLLEXPORT int jl_generating_output(void) JL_NOTSAFEPOINT;
 

--- a/test/trimming/basic_jll.jl
+++ b/test/trimming/basic_jll.jl
@@ -1,14 +1,10 @@
-module MyApp
-
 using Libdl
 using Zstd_jll
 
-Base.@ccallable function main()::Cint
+function @main(args::Vector{String})::Cint
     println(Core.stdout, "Julia! Hello, world!")
     fptr = dlsym(Zstd_jll.libzstd_handle, :ZSTD_versionString)
     println(Core.stdout, unsafe_string(ccall(fptr, Cstring, ())))
     println(Core.stdout, unsafe_string(ccall((:ZSTD_versionString, libzstd), Cstring, ())))
     return 0
-end
-
 end

--- a/test/trimming/hello.jl
+++ b/test/trimming/hello.jl
@@ -1,13 +1,10 @@
-module MyApp
-
 world::String = "world!"
 const str = OncePerProcess{String}() do
     return "Hello, " * world
 end
 
-Base.@ccallable function main()::Cint
+function @main(args::Vector{String})::Cint
     println(Core.stdout, str())
+    foreach(x->println(Core.stdout, x), args)
     return 0
-end
-
 end

--- a/test/trimming/trimming.jl
+++ b/test/trimming/trimming.jl
@@ -6,7 +6,7 @@ bindir = dirname(ARGS[1])
 let exe_suffix = splitext(Base.julia_exename())[2]
 
     hello_exe = joinpath(bindir, "hello" * exe_suffix)
-    @test readchomp(`$hello_exe`) == "Hello, world!"
+    @test readchomp(`$hello_exe arg1 arg2`) == "Hello, world!\n$hello_exe\narg1\narg2"
     @test filesize(hello_exe) < 2_000_000
 
     basic_jll_exe = joinpath(bindir, "basic_jll" * exe_suffix)


### PR DESCRIPTION
juliac clearly should use the at-main mechanism for executables. That also allows us to call julia_init from C main instead of using `__attribute__((constructor))`. I also added support for passing in the command line arguments (kind of useful!)

I changed `Core.ARGS` from a `Vector{Any}` to a `Vector{String}`. I don't know why we didn't do that years ago. Surely this is ok?

~~The biggest problem is looking up julia `main` from C main. For now I put in a hack to keep the binding around, but it's not very satisfying. Maybe we should insert a `ccallable` with some known name like `juliac_exe_main`? Any other ideas on how to handle this? Edit: done.~~
