### PR TITLE
`Base`: `power_by_squaring`: don't require `one`

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -336,7 +336,7 @@ end
 
 # ^ for any x supporting *
 function to_power_type(x::Number)
-    T = promote_type(typeof(x), typeof(one(x)), typeof(x*x))
+    T = promote_type(typeof(x), typeof(x*x))
     convert(T, x)
 end
 to_power_type(x) = oftype(x*x, x)

--- a/test/math.jl
+++ b/test/math.jl
@@ -1,5 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+include("testhelpers/EvenIntegers.jl")
+using .EvenIntegers
+
 using Random
 using LinearAlgebra
 using Base.Experimental: @force_compile
@@ -1537,6 +1540,12 @@ end
         for y ∈ 0:2
             @test all((t -> ===(t...)), zip(x^y, p[y + 1]))
         end
+    end
+
+    @testset "rng exponentiation, issue #57590" begin
+        @test EvenInteger(16) === @inferred EvenInteger(2)^4
+        @test EvenInteger(16) === @inferred EvenInteger(2)^Int(4)  # avoid `literal_pow`
+        @test EvenInteger(16) === @inferred EvenInteger(2)^EvenInteger(4)
     end
 end
 

--- a/test/testhelpers/EvenIntegers.jl
+++ b/test/testhelpers/EvenIntegers.jl
@@ -1,0 +1,87 @@
+"""
+The even integers, an example of set with an additive identity and closed under
+addition and multiplication, but lacking a multiplicative identity, a
+[*rng*](https://en.wikipedia.org/wiki/Rng_(algebra)).
+"""
+module EvenIntegers
+    export EvenInteger
+
+    struct EvenInteger{T <: Integer} <: Integer
+        x::T
+        function EvenInteger(x::Integer)
+            if isodd(x)
+                throw(ArgumentError("can't convert odd integer to even integer"))
+            end
+            new{typeof(x)}(x)
+        end
+    end
+    function EvenInteger(x::EvenInteger)
+        x
+    end
+    function EvenInteger{T}(x::EvenInteger{T}) where {T <: Integer}
+        x
+    end
+    function EvenInteger{T}(x::T) where {T <: Integer}
+        EvenInteger(x)
+    end
+    function EvenInteger{T}(x::Integer) where {T <: Integer}
+        throw(ArgumentError("not implemented"))
+    end
+    function Base.Int(n::EvenInteger)
+        Int(n.x)
+    end
+    function Base.iseven(::EvenInteger)
+        true
+    end
+    function Base.isodd(::EvenInteger)
+        false
+    end
+    function Base.iszero(n::EvenInteger)
+        iszero(n.x)
+    end
+    function Base.isone(::EvenInteger)
+        false
+    end
+    function Base.zero(n::EvenInteger)
+        EvenInteger(zero(n.x))
+    end
+    function Base.zero(::Type{EvenInteger{T}}) where {T <: Integer}
+        EvenInteger(zero(T))
+    end
+    function Base.:(==)(l::EvenInteger, r::EvenInteger)
+        l.x == r.x
+    end
+    function Base.:(<)(l::EvenInteger, r::EvenInteger)
+        l.x < r.x
+    end
+    function Base.promote_rule(::Type{EvenInteger{L}}, ::Type{EvenInteger{R}}) where {L <: Integer, R <: Integer}
+        EvenInteger{promote_type(L, R)}
+    end
+    function Base.promote_rule(::Type{EvenInteger{L}}, ::Type{R}) where {L <: Integer, R <: Integer}
+        promote_type(L, R)
+    end
+    function Base.:(+)(l::EvenInteger, r::EvenInteger)
+        EvenInteger(l.x + r.x)
+    end
+    function Base.:(*)(l::EvenInteger, r::EvenInteger)
+        EvenInteger(l.x * r.x)
+    end
+    function Base.:(-)(n::EvenInteger)
+        EvenInteger(-n.x)
+    end
+    function Base.:(-)(l::EvenInteger, r::EvenInteger)
+        l + (-r)
+    end
+    function right_shift(l::EvenInteger, r::Integer)
+        l.x >> r
+    end
+    function Base.:(>>)(l::EvenInteger, r::Integer)
+        right_shift(l, r)
+    end
+    function Base.:(>>)(l::EvenInteger, r::Int)  # resolve dispatch ambiguity
+        right_shift(l, r)
+    end
+    function Base.trailing_zeros(n::EvenInteger)
+        trailing_zeros(n.x)
+    end
+end


### PR DESCRIPTION
* Follows up on/partially reverts #55634
* Reopens #53504, perhaps it's OK to require some types to implement their own `^` for good performance
* Fixes #57390, a regression