### PR TITLE
Logging: Improve threadsafety

### DIFF
--- a/base/logging/ConsoleLogger.jl
+++ b/base/logging/ConsoleLogger.jl
@@ -27,30 +27,29 @@ Message formatting can be controlled by setting keyword arguments:
 """
 struct ConsoleLogger <: AbstractLogger
     stream::IO
-    stream_lock::ReentrantLock
+    lock::ReentrantLock
     min_level::LogLevel
     meta_formatter
     show_limited::Bool
     right_justify::Int
     message_limits::Dict{Any,Int}
-    message_limits_lock::ReentrantLock
 end
 function ConsoleLogger(stream::IO, min_level=Info;
                        meta_formatter=default_metafmt, show_limited=true,
                        right_justify=0)
     ConsoleLogger(stream, ReentrantLock(), min_level, meta_formatter,
-                  show_limited, right_justify, Dict{Any,Int}(), ReentrantLock())
+                  show_limited, right_justify, Dict{Any,Int}())
 end
 function ConsoleLogger(min_level=Info;
                        meta_formatter=default_metafmt, show_limited=true,
                        right_justify=0)
     ConsoleLogger(closed_stream, ReentrantLock(), min_level, meta_formatter,
-                  show_limited, right_justify, Dict{Any,Int}(), ReentrantLock())
+                  show_limited, right_justify, Dict{Any,Int}())
 end
 
 
 shouldlog(logger::ConsoleLogger, level, _module, group, id) =
-    @lock logger.message_limits_lock get(logger.message_limits, id, 1) > 0
+    @lock logger.lock get(logger.message_limits, id, 1) > 0
 
 min_enabled_level(logger::ConsoleLogger) = logger.min_level
 
@@ -114,7 +113,7 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
     hasmaxlog = haskey(kwargs, :maxlog) ? 1 : 0
     maxlog = get(kwargs, :maxlog, nothing)
     if maxlog isa Core.BuiltinInts
-        @lock logger.message_limits_lock begin
+        @lock logger.lock begin
             remaining = get!(logger.message_limits, id, Int(maxlog)::Int)
             remaining == 0 && return
             logger.message_limits[id] = remaining - 1
@@ -192,6 +191,6 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
     end
 
     b = take!(buf)
-    @lock logger.stream_lock write(stream, b)
+    @lock logger.lock write(stream, b)
     nothing
 end

--- a/base/logging/ConsoleLogger.jl
+++ b/base/logging/ConsoleLogger.jl
@@ -116,8 +116,8 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
     if maxlog isa Core.BuiltinInts
         @lock logger.message_limits_lock begin
             remaining = get!(logger.message_limits, id, Int(maxlog)::Int)
+            remaining == 0 && return
             logger.message_limits[id] = remaining - 1
-            remaining > 0 || return
         end
     end
 

--- a/base/logging/ConsoleLogger.jl
+++ b/base/logging/ConsoleLogger.jl
@@ -9,6 +9,9 @@ interactive work with the Julia REPL.
 
 Log levels less than `min_level` are filtered out.
 
+This Logger is thread-safe, with locks for both orchestration of message
+limits i.e. `maxlog`, and writes to the stream.
+
 Message formatting can be controlled by setting keyword arguments:
 
 * `meta_formatter` is a function which takes the log event metadata
@@ -24,29 +27,30 @@ Message formatting can be controlled by setting keyword arguments:
 """
 struct ConsoleLogger <: AbstractLogger
     stream::IO
+    stream_lock::ReentrantLock
     min_level::LogLevel
     meta_formatter
     show_limited::Bool
     right_justify::Int
     message_limits::Dict{Any,Int}
-    lock::ReentrantLock
+    message_limits_lock::ReentrantLock
 end
 function ConsoleLogger(stream::IO, min_level=Info;
                        meta_formatter=default_metafmt, show_limited=true,
                        right_justify=0)
-    ConsoleLogger(stream, min_level, meta_formatter,
+    ConsoleLogger(stream, ReentrantLock(), min_level, meta_formatter,
                   show_limited, right_justify, Dict{Any,Int}(), ReentrantLock())
 end
 function ConsoleLogger(min_level=Info;
                        meta_formatter=default_metafmt, show_limited=true,
                        right_justify=0)
-    ConsoleLogger(closed_stream, min_level, meta_formatter,
+    ConsoleLogger(closed_stream, ReentrantLock(), min_level, meta_formatter,
                   show_limited, right_justify, Dict{Any,Int}(), ReentrantLock())
 end
 
 
 shouldlog(logger::ConsoleLogger, level, _module, group, id) =
-    @lock logger.lock get(logger.message_limits, id, 1) > 0
+    @lock logger.message_limits_lock get(logger.message_limits, id, 1) > 0
 
 min_enabled_level(logger::ConsoleLogger) = logger.min_level
 
@@ -110,7 +114,7 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
     hasmaxlog = haskey(kwargs, :maxlog) ? 1 : 0
     maxlog = get(kwargs, :maxlog, nothing)
     if maxlog isa Core.BuiltinInts
-        @lock logger.lock begin
+        @lock logger.message_limits_lock begin
             remaining = get!(logger.message_limits, id, Int(maxlog)::Int)
             logger.message_limits[id] = remaining - 1
             remaining > 0 || return
@@ -188,6 +192,6 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
     end
 
     b = take!(buf)
-    @lock logger.lock write(stream, b)
+    @lock logger.stream_lock write(stream, b)
     nothing
 end

--- a/base/logging/ConsoleLogger.jl
+++ b/base/logging/ConsoleLogger.jl
@@ -27,7 +27,7 @@ Message formatting can be controlled by setting keyword arguments:
 """
 struct ConsoleLogger <: AbstractLogger
     stream::IO
-    lock::ReentrantLock
+    lock::ReentrantLock # do not log within this lock
     min_level::LogLevel
     meta_formatter
     show_limited::Bool

--- a/base/logging/logging.jl
+++ b/base/logging/logging.jl
@@ -172,6 +172,7 @@ Alias for [`LogLevel(1_000_001)`](@ref LogLevel).
 const AboveMaxLevel = LogLevel( 1000001)
 
 # Global log limiting mechanism for super fast but inflexible global log limiting.
+# Atomic ensures that the value is always consistent across threads.
 const _min_enabled_level = Threads.Atomic{Int32}(Debug)
 
 function show(io::IO, level::LogLevel)

--- a/base/logging/logging.jl
+++ b/base/logging/logging.jl
@@ -543,7 +543,8 @@ with_logstate(f::Function, logstate) = @with(CURRENT_LOGSTATE => logstate, f())
 
 Disable all log messages at log levels equal to or less than `level`.  This is
 a *global* setting, intended to make debug logging extremely cheap when
-disabled.
+disabled. Note that this cannot be used to enable logging that is currently disabled
+by other mechanisms.
 
 # Examples
 ```julia

--- a/base/logging/logging.jl
+++ b/base/logging/logging.jl
@@ -132,6 +132,7 @@ isless(a::LogLevel, b::LogLevel) = isless(a.level, b.level)
 +(level::LogLevel, inc::Integer) = LogLevel(level.level+inc)
 -(level::LogLevel, inc::Integer) = LogLevel(level.level-inc)
 convert(::Type{LogLevel}, level::Integer) = LogLevel(level)
+convert(::Type{Int32}, level::LogLevel) = level.level
 
 """
     BelowMinLevel
@@ -171,7 +172,7 @@ Alias for [`LogLevel(1_000_001)`](@ref LogLevel).
 const AboveMaxLevel = LogLevel( 1000001)
 
 # Global log limiting mechanism for super fast but inflexible global log limiting.
-const _min_enabled_level = Ref{LogLevel}(Debug)
+const _min_enabled_level = Threads.Atomic{Int32}(Debug)
 
 function show(io::IO, level::LogLevel)
     if     level == BelowMinLevel  print(io, "BelowMinLevel")
@@ -394,7 +395,7 @@ function logmsg_code(_module, file, line, level, message, exs...)
             level = $level
             # simplify std_level code emitted, if we know it is one of our global constants
             std_level = $(level isa Symbol ? :level : :(level isa $LogLevel ? level : convert($LogLevel, level)::$LogLevel))
-            if std_level >= $(_min_enabled_level)[]
+            if std_level.level >= $(_min_enabled_level)[]
                 group = $(log_data._group)
                 _module = $(log_data._module)
                 logger = $(current_logger_for_env)(std_level, group, _module)

--- a/base/logging/logging.jl
+++ b/base/logging/logging.jl
@@ -693,8 +693,8 @@ function handle_message(logger::SimpleLogger, level::LogLevel, message, _module,
     if maxlog isa Core.BuiltinInts
         @lock logger.message_limits_lock begin
             remaining = get!(logger.message_limits, id, Int(maxlog)::Int)
+            remaining == 0 && return
             logger.message_limits[id] = remaining - 1
-            remaining > 0 || return
         end
     end
     buf = IOBuffer()

--- a/stdlib/Logging/test/threads_exec.jl
+++ b/stdlib/Logging/test/threads_exec.jl
@@ -1,0 +1,13 @@
+using Logging
+
+function test_threads_exec(n)
+    Threads.@threads for i in 1:n
+        @debug "iteration" maxlog=1 _id=Symbol("$(i)_debug") i Threads.threadid()
+        @info "iteration" maxlog=1 _id=Symbol("$(i)_info") i Threads.threadid()
+        @warn "iteration" maxlog=1 _id=Symbol("$(i)_warn") i Threads.threadid()
+        @error "iteration" maxlog=1 _id=Symbol("$(i)_error") i Threads.threadid()
+    end
+end
+
+n = parse(Int, ARGS[1])
+test_threads_exec(n)

--- a/stdlib/Test/src/logging.jl
+++ b/stdlib/Test/src/logging.jl
@@ -107,8 +107,8 @@ function Logging.handle_message(logger::TestLogger, level, msg, _module,
         if maxlog isa Core.BuiltinInts
             @lock logger.lock begin
                 remaining = get!(logger.message_limits, id, Int(maxlog)::Int)
+                remaining == 0 && return
                 logger.message_limits[id] = remaining - 1
-                remaining > 0 || return
             end
         end
     end


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/57376
Closes https://github.com/JuliaLang/julia/issues/34037

- Adds a lock in `SimpleLogger` and `ConsoleLogger` for use on maxlog tracking and stream writes to improve threadsafety.
Closely similar to https://github.com/JuliaLang/julia/pull/54497 by @NHDaly 

- Turns the internal `_min_enabled_level` into a `Threads.Atomic`. There are [some direct interactions](https://juliahub.com/ui/Search?type=code&q=_min_enabled_level&w=true) to this internal in the ecosystem, but they should still work
```
julia> Base.CoreLogging._min_enabled_level[] = Logging.Info+1
LogLevel(1)
```

- Brings tests over from https://github.com/JuliaLang/julia/pull/57448

Performance seems highly similar:

### Master
```
julia> @time for i in 1:10000
          @info "foo" maxlog=10000000
       end
[ Info: foo
...
  0.481446 seconds (1.33 M allocations: 89.226 MiB, 0.49% gc time)
```

### This PR
```
  0.477235 seconds (1.31 M allocations: 79.002 MiB, 1.77% gc time)
```