### PR TITLE
`Base`: add a `lerpi` method for `String` that just throws

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -977,6 +977,11 @@ function lerpi(j::Integer, d::Integer, a::T, b::T) where T
     return T((1-t)*a + t*b)
 end
 
+# help avoid some unnecessary work for the compiler when compiling type unstable code
+@nospecializeinfer function lerpi((@nospecialize j::Integer), (@nospecialize d::Integer), ::String, ::String)
+    throw(ArgumentError("can't interpolate between strings"))
+end
+
 # non-scalar indexing
 
 getindex(r::AbstractRange, ::Colon) = copy(r)

--- a/base/range.jl
+++ b/base/range.jl
@@ -978,7 +978,8 @@ function lerpi(j::Integer, d::Integer, a::T, b::T) where T
 end
 
 # help avoid some unnecessary work for the compiler when compiling type unstable code
-@nospecializeinfer function lerpi((@nospecialize j::Integer), (@nospecialize d::Integer), ::String, ::String)
+function lerpi((@nospecialize j::Integer), (@nospecialize d::Integer), ::String, ::String)
+    @_nospecializeinfer_meta
     throw(ArgumentError("can't interpolate between strings"))
 end
 


### PR DESCRIPTION
I know this seems stupid, but it should hopefully help the compiler realize compiling `*(::Union{Regex, AbstractChar, AbstractString}, ::String)` is not necessary, and thus prevent some invalidation in user code.