### PR TITLE
bpart: Allow inference/codegen to merge multiple partitions

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -2383,8 +2383,8 @@ function abstract_eval_getglobal(interp::AbstractInterpreter, sv::AbsIntState, s
         M, s = M.val, s.val
         if M isa Module && s isa Symbol
             gr = GlobalRef(M, s)
-            (ret, bpart) = abstract_eval_globalref(interp, gr, saw_latestworld, sv)
-            return CallMeta(ret, bpart === nothing ? NoCallInfo() : GlobalAccessInfo(convert(Core.Binding, gr), bpart))
+            ret = abstract_eval_globalref(interp, gr, saw_latestworld, sv)
+            return CallMeta(ret, GlobalAccessInfo(convert(Core.Binding, gr)))
         end
         return CallMeta(Union{}, TypeError, EFFECTS_THROWS, NoCallInfo())
     elseif !hasintersect(widenconst(M), Module) || !hasintersect(widenconst(s), Symbol)
@@ -2427,18 +2427,23 @@ end
         if !isa(M, Module) || !isa(s, Symbol)
             return CallMeta(Union{}, TypeError, EFFECTS_THROWS, NoCallInfo())
         end
-        partition = abstract_eval_binding_partition!(interp, GlobalRef(M, s), sv)
-
-        if is_some_guard(binding_kind(partition))
-            # We do not currently assume an invalidation for guard -> defined transitions
-            # rt = Const(nothing)
-            rt = Type
-        elseif is_some_const_binding(binding_kind(partition))
-            rt = Const(Any)
-        else
-            rt = Const(partition_restriction(partition))
+        gr = GlobalRef(M, s)
+        (valid_worlds, rt) = scan_leaf_partitions(interp, gr, sv.world) do interp, _, partition
+            local rt
+            kind = binding_kind(partition)
+            if is_some_guard(kind) || kind == BINDING_KIND_DECLARED
+                # We do not currently assume an invalidation for guard -> defined transitions
+                # rt = Const(nothing)
+                rt = Type
+            elseif is_some_const_binding(kind)
+                rt = Const(Any)
+            else
+                rt = Const(partition_restriction(partition))
+            end
+            rt
         end
-        return CallMeta(rt, Union{}, EFFECTS_TOTAL, NoCallInfo())
+        update_valid_age!(sv, valid_worlds)
+        return CallMeta(rt, Union{}, EFFECTS_TOTAL, GlobalAccessInfo(convert(Core.Binding, gr)))
     elseif !hasintersect(widenconst(M), Module) || !hasintersect(widenconst(s), Symbol)
         return CallMeta(Union{}, TypeError, EFFECTS_THROWS, NoCallInfo())
     elseif M ⊑ Module && s ⊑ Symbol
@@ -2463,8 +2468,8 @@ function abstract_eval_setglobal!(interp::AbstractInterpreter, sv::AbsIntState, 
         M, s = M.val, s.val
         if M isa Module && s isa Symbol
             gr = GlobalRef(M, s)
-            (rt, exct), partition = global_assignment_rt_exct(interp, sv, saw_latestworld, gr, v)
-            return CallMeta(rt, exct, Effects(setglobal!_effects, nothrow=exct===Bottom), GlobalAccessInfo(convert(Core.Binding, gr), partition))
+            (rt, exct) = global_assignment_rt_exct(interp, sv, saw_latestworld, gr, v)
+            return CallMeta(rt, exct, Effects(setglobal!_effects, nothrow=exct===Bottom), GlobalAccessInfo(convert(Core.Binding, gr)))
         end
         return CallMeta(Union{}, TypeError, EFFECTS_THROWS, NoCallInfo())
     end
@@ -2544,6 +2549,7 @@ function abstract_eval_setglobalonce!(interp::AbstractInterpreter, sv::AbsIntSta
     end
 end
 
+
 function abstract_eval_replaceglobal!(interp::AbstractInterpreter, sv::AbsIntState, saw_latestworld::Bool, argtypes::Vector{Any})
     if length(argtypes) in (5, 6, 7)
         (M, s, x, v) = argtypes[2], argtypes[3], argtypes[4], argtypes[5]
@@ -2553,14 +2559,19 @@ function abstract_eval_replaceglobal!(interp::AbstractInterpreter, sv::AbsIntSta
             M isa Module || return CallMeta(Union{}, TypeError, EFFECTS_THROWS, NoCallInfo())
             s isa Symbol || return CallMeta(Union{}, TypeError, EFFECTS_THROWS, NoCallInfo())
             gr = GlobalRef(M, s)
-            partition = abstract_eval_binding_partition!(interp, gr, sv)
-            rte = abstract_eval_partition_load(interp, partition)
-            if binding_kind(partition) == BINDING_KIND_GLOBAL
-                T = partition_restriction(partition)
+            (valid_worlds, (rte, T)) = scan_leaf_partitions(interp, gr, sv.world) do interp, _, partition
+                partition_T = nothing
+                partition_rte = abstract_eval_partition_load(interp, partition)
+                if binding_kind(partition) == BINDING_KIND_GLOBAL
+                    partition_T = partition_restriction(partition)
+                end
+                partition_exct = Union{partition_rte.exct, global_assignment_binding_rt_exct(interp, partition, v)[2]}
+                partition_rte = RTEffects(partition_rte.rt, partition_exct, partition_rte.effects)
+                Pair{RTEffects, Any}(partition_rte, partition_T)
             end
-            exct = Union{rte.exct, global_assignment_binding_rt_exct(interp, partition, v)[2]}
-            effects = merge_effects(rte.effects, Effects(setglobal!_effects, nothrow=exct===Bottom))
-            sg = CallMeta(Any, exct, effects, GlobalAccessInfo(convert(Core.Binding, gr), partition))
+            update_valid_age!(sv, valid_worlds)
+            effects = merge_effects(rte.effects, Effects(setglobal!_effects, nothrow=rte.exct===Bottom))
+            sg = CallMeta(Any, rte.exct, effects, GlobalAccessInfo(convert(Core.Binding, gr)))
         else
             sg = abstract_eval_setglobal!(interp, sv, saw_latestworld, M, s, v)
         end
@@ -2943,7 +2954,7 @@ function abstract_eval_special_value(interp::AbstractInterpreter, @nospecialize(
         end
     elseif isa(e, GlobalRef)
         # No need for an edge since an explicit GlobalRef will be picked up by the source scan
-        return abstract_eval_globalref(interp, e, sstate.saw_latestworld, sv)[1]
+        return abstract_eval_globalref(interp, e, sstate.saw_latestworld, sv)
     end
     if isa(e, QuoteNode)
         e = e.value
@@ -3228,25 +3239,29 @@ function abstract_eval_isdefinedglobal(interp::AbstractInterpreter, mod::Module,
 
     effects = EFFECTS_TOTAL
     gr = GlobalRef(mod, sym)
-    partition = lookup_binding_partition!(interp, gr, sv)
-    if allow_import !== true && is_some_imported(binding_kind(partition))
-        if allow_import === false
-            rt = Const(false)
-        else
-            effects = Effects(generic_isdefinedglobal_effects, nothrow=true)
-        end
-    else
-        partition = walk_binding_partition!(interp, partition, sv)
-        rte = abstract_eval_partition_load(interp, partition)
-        if rte.exct == Union{}
-            rt = Const(true)
-        elseif rte.rt === Union{} && rte.exct === UndefVarError
-            rt = Const(false)
-        else
-            effects = Effects(generic_isdefinedglobal_effects, nothrow=true)
+    if allow_import !== true
+        gr = GlobalRef(mod, sym)
+        partition = lookup_binding_partition!(interp, gr, sv)
+        if allow_import !== true && is_some_imported(binding_kind(partition))
+            if allow_import === false
+                rt = Const(false)
+            else
+                effects = Effects(generic_isdefinedglobal_effects, nothrow=true)
+            end
+            @goto done
         end
     end
-    return CallMeta(RTEffects(rt, Union{}, effects), GlobalAccessInfo(convert(Core.Binding, gr), partition))
+
+    (valid_worlds, rte) = abstract_load_all_consistent_leaf_partitions(interp, gr, sv.world)
+    if rte.exct == Union{}
+        rt = Const(true)
+    elseif rte.rt === Union{} && rte.exct === UndefVarError
+        rt = Const(false)
+    else
+        effects = Effects(generic_isdefinedglobal_effects, nothrow=true)
+    end
+@label done
+    return CallMeta(RTEffects(rt, Union{}, effects), GlobalAccessInfo(convert(Core.Binding, gr)))
 end
 
 function abstract_eval_isdefinedglobal(interp::AbstractInterpreter, @nospecialize(M), @nospecialize(s), @nospecialize(allow_import_arg), @nospecialize(order_arg), saw_latestworld::Bool, sv::AbsIntState)
@@ -3463,50 +3478,47 @@ world_range(compact::IncrementalCompact) = world_range(compact.ir)
 function abstract_eval_globalref_type(g::GlobalRef, src::Union{CodeInfo, IRCode, IncrementalCompact})
     worlds = world_range(src)
     partition = lookup_binding_partition(min_world(worlds), g)
-    partition.max_world < max_world(worlds) && return Any
-    while is_some_imported(binding_kind(partition))
-        imported_binding = partition_restriction(partition)::Core.Binding
-        partition = lookup_binding_partition(min_world(worlds), imported_binding)
-        partition.max_world < max_world(worlds) && return Any
-    end
-    kind = binding_kind(partition)
-    if is_some_guard(kind)
-        # return Union{}
+
+    (valid_worlds, rte) = abstract_load_all_consistent_leaf_partitions(nothing, g, WorldWithRange(min_world(worlds), worlds))
+    if min_world(valid_worlds) > min_world(worlds) || max_world(valid_worlds) < max_world(worlds)
         return Any
     end
-    if is_some_const_binding(kind)
-        return Const(partition_restriction(partition))
-    end
-    return kind == BINDING_KIND_DECLARED ? Any : partition_restriction(partition)
+
+    return rte.rt
 end
 
-function lookup_binding_partition!(interp::AbstractInterpreter, g::GlobalRef, sv::AbsIntState)
+function lookup_binding_partition!(interp::AbstractInterpreter, g::Union{GlobalRef, Core.Binding}, sv::AbsIntState)
     partition = lookup_binding_partition(get_inference_world(interp), g)
     update_valid_age!(sv, WorldRange(partition.min_world, partition.max_world))
     partition
 end
 
-function walk_binding_partition!(interp::AbstractInterpreter, partition::Core.BindingPartition, sv::AbsIntState)
+function walk_binding_partition(imported_binding::Core.Binding, partition::Core.BindingPartition, world::UInt)
+    valid_worlds = WorldRange(partition.min_world, partition.max_world)
     while is_some_imported(binding_kind(partition))
         imported_binding = partition_restriction(partition)::Core.Binding
-        partition = lookup_binding_partition(get_inference_world(interp), imported_binding)
-        update_valid_age!(sv, WorldRange(partition.min_world, partition.max_world))
+        partition = lookup_binding_partition(world, imported_binding)
+        valid_worlds = intersect(valid_worlds, WorldRange(partition.min_world, partition.max_world))
     end
-    return partition
+    return Pair{WorldRange, Pair{Core.Binding, Core.BindingPartition}}(valid_worlds, imported_binding=>partition)
 end
 
 function abstract_eval_binding_partition!(interp::AbstractInterpreter, g::GlobalRef, sv::AbsIntState)
-    partition = lookup_binding_partition!(interp, g, sv)
-    partition = walk_binding_partition!(interp, partition, sv)
+    b = convert(Core.Binding, g)
+    partition = lookup_binding_partition!(interp, b, sv)
+    valid_worlds, (_, partition) = walk_binding_partition(b, partition, get_inference_world(interp))
+    update_valid_age!(sv, valid_worlds)
     return partition
 end
 
-function abstract_eval_partition_load(interp::AbstractInterpreter, partition::Core.BindingPartition)
+abstract_eval_partition_load(interp::Union{AbstractInterpreter, Nothing}, ::Core.Binding, partition::Core.BindingPartition) =
+    abstract_eval_partition_load(interp, partition)
+function abstract_eval_partition_load(interp::Union{AbstractInterpreter, Nothing}, partition::Core.BindingPartition)
     kind = binding_kind(partition)
     isdepwarn = (partition.kind & BINDING_FLAG_DEPWARN) != 0
     local_getglobal_effects = Effects(generic_getglobal_effects, effect_free=isdepwarn ? ALWAYS_FALSE : ALWAYS_TRUE)
     if is_some_guard(kind) || kind == BINDING_KIND_UNDEF_CONST
-        if InferenceParams(interp).assume_bindings_static
+        if interp !== nothing && InferenceParams(interp).assume_bindings_static
             return RTEffects(Union{}, UndefVarError, EFFECTS_THROWS)
         else
             # We do not currently assume an invalidation for guard -> defined transitions
@@ -3528,6 +3540,10 @@ function abstract_eval_partition_load(interp::AbstractInterpreter, partition::Co
     end
 
     if kind == BINDING_KIND_DECLARED
+        # Could be replaced by a backdated const which has an effect, so we can't assume it won't.
+        # Besides, we would prefer not to merge the world range for this into the world range for
+        # _GLOBAL, because that would pessimize codegen.
+        local_getglobal_effects = Effects(local_getglobal_effects, effect_free=ALWAYS_FALSE)
         rt = Any
     else
         rt = partition_restriction(partition)
@@ -3535,39 +3551,88 @@ function abstract_eval_partition_load(interp::AbstractInterpreter, partition::Co
     return RTEffects(rt, UndefVarError, local_getglobal_effects)
 end
 
-function abstract_eval_globalref(interp::AbstractInterpreter, g::GlobalRef, saw_latestworld::Bool, sv::AbsIntState)
-    if saw_latestworld
-        return Pair{RTEffects, Union{Nothing, Core.BindingPartition}}(RTEffects(Any, Any, generic_getglobal_effects), nothing)
+function scan_specified_partitions(query::Function, walk_binding_partition::Function, interp, g::GlobalRef, wwr::WorldWithRange)
+    local total_validity, rte, binding_partition
+    binding = convert(Core.Binding, g)
+    lookup_world = max_world(wwr.valid_worlds)
+    while true
+        # Partitions are ordered newest-to-oldest so start at the top
+        binding_partition = @isdefined(binding_partition) ?
+            lookup_binding_partition(lookup_world, binding, binding_partition) :
+            lookup_binding_partition(lookup_world, binding)
+        while lookup_world >= binding_partition.min_world && (!@isdefined(total_validity) || min_world(total_validity) > min_world(wwr.valid_worlds))
+            partition_validity, (leaf_binding, leaf_partition) = walk_binding_partition(binding, binding_partition, lookup_world)
+            @assert lookup_world in partition_validity
+            this_rte = query(interp, leaf_binding, leaf_partition)
+            if @isdefined(rte)
+                if this_rte === rte
+                    total_validity = union(total_validity, partition_validity)
+                    lookup_world = min_world(total_validity) - 1
+                    continue
+                end
+                if min_world(total_validity) <= wwr.this
+                    @goto out
+                end
+            end
+            total_validity = partition_validity
+            lookup_world = min_world(total_validity) - 1
+            rte = this_rte
+        end
+        min_world(total_validity) > min_world(wwr.valid_worlds) || break
     end
-    partition = abstract_eval_binding_partition!(interp, g, sv)
-    ret = abstract_eval_partition_load(interp, partition)
-    if ret.rt !== Union{} && ret.exct === UndefVarError && InferenceParams(interp).assume_bindings_static
-        b = convert(Core.Binding, g)
-        if isdefined(b, :value)
+@label out
+    return Pair{WorldRange, typeof(rte)}(total_validity, rte)
+end
+
+scan_leaf_partitions(query::Function, interp, g::GlobalRef, wwr::WorldWithRange) =
+    scan_specified_partitions(query, walk_binding_partition, interp, g, wwr)
+
+scan_partitions(query::Function, interp, g::GlobalRef, wwr::WorldWithRange) =
+    scan_specified_partitions(query,
+        (b::Core.Binding, bpart::Core.BindingPartition, world::UInt)->
+            Pair{WorldRange, Pair{Core.Binding, Core.BindingPartition}}(WorldRange(bpart.min_world, bpart.max_world), b=>bpart),
+        interp, g, wwr)
+
+abstract_load_all_consistent_leaf_partitions(interp, g::GlobalRef, wwr::WorldWithRange) =
+    scan_leaf_partitions(abstract_eval_partition_load, interp, g, wwr)
+
+function abstract_eval_globalref(interp, g::GlobalRef, saw_latestworld::Bool, sv::AbsIntState)
+    if saw_latestworld
+        return RTEffects(Any, Any, generic_getglobal_effects)
+    end
+    (valid_worlds, (ret, binding_if_global)) = scan_leaf_partitions(interp, g, sv.world) do interp, binding, partition
+        # For inference purposes, we don't particularly care which global binding we end up loading, we only
+        # care about its type. However, we would still like to terminate the world range for the particular
+        # binding we end up reaching such that codegen can emit a simpler pointer load.
+        Pair{RTEffects, Union{Nothing, Core.Binding}}(
+            abstract_eval_partition_load(interp, partition),
+            binding_kind(partition) in (BINDING_KIND_GLOBAL, BINDING_KIND_DECLARED) ? binding : nothing)
+    end
+    update_valid_age!(sv, valid_worlds)
+    if ret.rt !== Union{} && ret.exct === UndefVarError && binding_if_global !== nothing && InferenceParams(interp).assume_bindings_static
+        if isdefined(binding_if_global, :value)
             ret = RTEffects(ret.rt, Union{}, Effects(generic_getglobal_effects, nothrow=true))
         end
         # We do not assume in general that assigned global bindings remain assigned.
         # The existence of pkgimages allows them to revert in practice.
     end
-    return Pair{RTEffects, Union{Nothing, Core.BindingPartition}}(ret, partition)
+    return ret
 end
 
 function global_assignment_rt_exct(interp::AbstractInterpreter, sv::AbsIntState, saw_latestworld::Bool, g::GlobalRef, @nospecialize(newty))
     if saw_latestworld
-        return Pair{Pair{Any,Any}, Union{Core.BindingPartition, Nothing}}(
-            Pair{Any,Any}(newty, Union{ErrorException, TypeError}), nothing)
+        return Pair{Any,Any}(newty, Union{ErrorException, TypeError})
     end
-    partition = abstract_eval_binding_partition!(interp, g, sv)
-    return Pair{Pair{Any,Any}, Union{Core.BindingPartition, Nothing}}(
-        global_assignment_binding_rt_exct(interp, partition, newty),
-        partition)
+    (valid_worlds, ret) = scan_partitions((interp, _, partition)->global_assignment_binding_rt_exct(interp, partition, newty), interp, g, sv.world)
+    update_valid_age!(sv, valid_worlds)
+    return ret
 end
 
 function global_assignment_binding_rt_exct(interp::AbstractInterpreter, partition::Core.BindingPartition, @nospecialize(newty))
     kind = binding_kind(partition)
     if is_some_guard(kind)
         return Pair{Any,Any}(newty, ErrorException)
-    elseif is_some_const_binding(kind)
+    elseif is_some_const_binding(kind) || is_some_imported(kind)
         return Pair{Any,Any}(Bottom, ErrorException)
     end
     ty = kind == BINDING_KIND_DECLARED ? Any : partition_restriction(partition)

--- a/Compiler/src/cicache.jl
+++ b/Compiler/src/cicache.jl
@@ -40,6 +40,14 @@ function intersect(a::WorldRange, b::WorldRange)
     return ret
 end
 
+function union(a::WorldRange, b::WorldRange)
+    if b.min_world < a.min_world
+        (b, a) = (a, b)
+    end
+    @assert a.max_world >= b.min_world - 1
+    return WorldRange(a.min_world, b.max_world)
+end
+
 """
     struct WorldView
 

--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -490,9 +490,7 @@ perform such accesses.
 """
 struct GlobalAccessInfo <: CallInfo
     b::Core.Binding
-    bpart::Core.BindingPartition
 end
-GlobalAccessInfo(::Core.Binding, ::Nothing) = NoCallInfo()
 function add_edges_impl(edges::Vector{Any}, info::GlobalAccessInfo)
     push!(edges, info.b)
 end

--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -400,6 +400,17 @@ let effects = Base.infer_effects(setglobal!_nothrow_undefinedyet2)
 end
 @test_throws TypeError setglobal!_nothrow_undefinedyet2()
 
+module ExportMutableGlobal
+    global mutable_global_for_setglobal_test::Int = 0
+    export mutable_global_for_setglobal_test
+end
+using .ExportMutableGlobal: mutable_global_for_setglobal_test
+f_assign_imported() = global mutable_global_for_setglobal_test = 42
+let effects = Base.infer_effects(f_assign_imported)
+    @test !Compiler.is_nothrow(effects)
+end
+@test_throws ErrorException f_assign_imported()
+
 # Nothrow for setfield!
 mutable struct SetfieldNothrow
     x::Int

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -21,7 +21,6 @@ include(strcat(BUILDROOT, "version_git.jl")) # include($BUILDROOT/base/version_g
 
 # Initialize DL_LOAD_PATH as early as possible.  We are defining things here in
 # a slightly more verbose fashion than usual, because we're running so early.
-const DL_LOAD_PATH = String[]
 let os = ccall(:jl_get_UNAME, Any, ())
     if os === :Darwin || os === :Apple
         if Base.DARWIN_FRAMEWORK

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -277,6 +277,7 @@ end
 
 BUILDROOT::String = ""
 DATAROOT::String = ""
+const DL_LOAD_PATH = String[]
 
 baremodule BuildSettings end
 

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -225,6 +225,10 @@ function lookup_binding_partition(world::UInt, b::Core.Binding)
     ccall(:jl_get_binding_partition, Ref{Core.BindingPartition}, (Any, UInt), b, world)
 end
 
+function lookup_binding_partition(world::UInt, b::Core.Binding, previous_partition::Core.BindingPartition)
+    ccall(:jl_get_binding_partition_with_hint, Ref{Core.BindingPartition}, (Any, Any, UInt), b, previous_partition, world)
+end
+
 function convert(::Type{Core.Binding}, gr::Core.GlobalRef)
     if isdefined(gr, :binding)
         return gr.binding

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2929,14 +2929,13 @@ static jl_value_t *static_eval(jl_codectx_t &ctx, jl_value_t *ex)
 {
     if (jl_is_symbol(ex)) {
         jl_sym_t *sym = (jl_sym_t*)ex;
-        jl_binding_t *bnd = jl_get_module_binding(ctx.module, sym, 0);
-        jl_binding_partition_t *bpart = jl_get_binding_partition_all(bnd, ctx.min_world, ctx.max_world);
+        jl_binding_t *bnd = jl_get_module_binding(ctx.module, sym, 1);
         int possibly_deprecated = 0;
-        jl_walk_binding_inplace_all(&bnd, &bpart, &possibly_deprecated, ctx.min_world, ctx.max_world);
-        if (bpart && jl_bkind_is_some_constant(jl_binding_kind(bpart))) {
+        jl_value_t *cval = jl_get_binding_leaf_partitions_value_if_const(bnd, &possibly_deprecated, ctx.min_world, ctx.max_world);
+        if (cval) {
             if (possibly_deprecated)
                 emit_depwarn_check(ctx, bnd);
-            return bpart->restriction;
+            return cval;
         }
         return NULL;
     }
@@ -2958,13 +2957,9 @@ static jl_value_t *static_eval(jl_codectx_t &ctx, jl_value_t *ex)
     jl_sym_t *s = NULL;
     if (jl_is_globalref(ex)) {
         s = jl_globalref_name(ex);
-        jl_binding_t *bnd = jl_get_module_binding(jl_globalref_mod(ex), s, 0);
-        jl_binding_partition_t *bpart = jl_get_binding_partition_all(bnd, ctx.min_world, ctx.max_world);
+        jl_binding_t *bnd = jl_get_module_binding(jl_globalref_mod(ex), s, 1);
         int possibly_deprecated = 0;
-        jl_walk_binding_inplace_all(&bnd, &bpart, &possibly_deprecated, ctx.min_world, ctx.max_world);
-        jl_value_t *v = NULL;
-        if (bpart && jl_bkind_is_some_constant(jl_binding_kind(bpart)))
-            v = bpart->restriction;
+        jl_value_t *v = jl_get_binding_leaf_partitions_value_if_const(bnd, &possibly_deprecated, ctx.min_world, ctx.max_world);
         if (v) {
             if (possibly_deprecated)
                 emit_depwarn_check(ctx, bnd);
@@ -2986,13 +2981,9 @@ static jl_value_t *static_eval(jl_codectx_t &ctx, jl_value_t *ex)
                     // Assumes that the module is rooted somewhere.
                     s = (jl_sym_t*)static_eval(ctx, jl_exprarg(e, 2));
                     if (s && jl_is_symbol(s)) {
-                        jl_binding_t *bnd = jl_get_module_binding(m, s, 0);
-                        jl_binding_partition_t *bpart = jl_get_binding_partition_all(bnd, ctx.min_world, ctx.max_world);
+                        jl_binding_t *bnd = jl_get_module_binding(m, s, 1);
                         int possibly_deprecated = 0;
-                        jl_walk_binding_inplace_all(&bnd, &bpart, &possibly_deprecated, ctx.min_world, ctx.max_world);
-                        jl_value_t *v = NULL;
-                        if (bpart && jl_bkind_is_some_constant(jl_binding_kind(bpart)))
-                            v = bpart->restriction;
+                        jl_value_t *v = jl_get_binding_leaf_partitions_value_if_const(bnd, &possibly_deprecated, ctx.min_world, ctx.max_world);
                         if (v) {
                             if (possibly_deprecated)
                                 emit_depwarn_check(ctx, bnd);
@@ -3236,48 +3227,32 @@ static jl_cgval_t emit_globalref_runtime(jl_codectx_t &ctx, jl_binding_t *bnd, j
 static jl_cgval_t emit_globalref(jl_codectx_t &ctx, jl_module_t *mod, jl_sym_t *name, AtomicOrdering order)
 {
     jl_binding_t *bnd = jl_get_module_binding(mod, name, 1);
-    assert(bnd);
-    jl_binding_partition_t *bpart = jl_get_binding_partition_all(bnd, ctx.min_world, ctx.max_world);
-    if (!bpart) {
+    struct restriction_kind_pair rkp = { NULL, NULL, BINDING_KIND_GUARD, 0 };
+    if (!jl_get_binding_leaf_partitions_restriction_kind(bnd, &rkp, ctx.min_world, ctx.max_world)) {
         return emit_globalref_runtime(ctx, bnd, mod, name);
     }
-    int possibly_deprecated = 0;
-    int saw_explicit = 0;
-    while (bpart) {
-        if (!saw_explicit && (bpart->kind & BINDING_FLAG_DEPWARN))
-            possibly_deprecated = 1;
-        enum jl_partition_kind kind = jl_binding_kind(bpart);
-        if (!jl_bkind_is_some_import(kind))
-            break;
-        if (kind != BINDING_KIND_IMPLICIT)
-            saw_explicit = 1;
-        bnd = (jl_binding_t*)bpart->restriction;
-        bpart = jl_get_binding_partition_all(bnd, ctx.min_world, ctx.max_world);
-    }
-    Value *bp = NULL;
-    if (bpart) {
-        enum jl_partition_kind kind = jl_binding_kind(bpart);
-        if (jl_bkind_is_some_constant(kind) && kind != BINDING_KIND_BACKDATED_CONST) {
-            if (possibly_deprecated) {
-                bp = julia_binding_gv(ctx, bnd);
-                ctx.builder.CreateCall(prepare_call(jldepcheck_func), { bp });
-            }
-            jl_value_t *constval = bpart->restriction;
-            if (!constval) {
-                undef_var_error_ifnot(ctx, ConstantInt::get(getInt1Ty(ctx.builder.getContext()), 0), name, (jl_value_t*)mod);
-                return jl_cgval_t();
-            }
-            return mark_julia_const(ctx, constval);
+    if (jl_bkind_is_some_constant(rkp.kind) && rkp.kind != BINDING_KIND_BACKDATED_CONST) {
+        if (rkp.maybe_depwarn) {
+            Value *bp = julia_binding_gv(ctx, bnd);
+            ctx.builder.CreateCall(prepare_call(jldepcheck_func), { bp });
         }
+        jl_value_t *constval = rkp.restriction;
+        if (!constval) {
+            undef_var_error_ifnot(ctx, ConstantInt::get(getInt1Ty(ctx.builder.getContext()), 0), name, (jl_value_t*)mod);
+            return jl_cgval_t();
+        }
+        return mark_julia_const(ctx, constval);
     }
-    if (!bpart || jl_binding_kind(bpart) != BINDING_KIND_GLOBAL) {
+    if (rkp.kind != BINDING_KIND_GLOBAL) {
         return emit_globalref_runtime(ctx, bnd, mod, name);
     }
-    bp = julia_binding_gv(ctx, bnd);
-    if (possibly_deprecated) {
+    Value *bp = julia_binding_gv(ctx, bnd);
+    if (rkp.maybe_depwarn) {
         ctx.builder.CreateCall(prepare_call(jldepcheck_func), { bp });
     }
-    jl_value_t *ty = bpart->restriction;
+    if (bnd != rkp.binding_if_global)
+        bp = julia_binding_gv(ctx, rkp.binding_if_global);
+    jl_value_t *ty = rkp.restriction;
     Value *bpval = julia_binding_pvalue(ctx, bp);
     if (ty == nullptr)
         ty = (jl_value_t*)jl_any_type;
@@ -3845,27 +3820,27 @@ static jl_cgval_t emit_isdefinedglobal(jl_codectx_t &ctx, jl_module_t *modu, jl_
 {
     Value *isnull = NULL;
     jl_binding_t *bnd = allow_import ? jl_get_binding(modu, name) : jl_get_module_binding(modu, name, 0);
-    jl_binding_partition_t *bpart = jl_get_binding_partition_all(bnd, ctx.min_world, ctx.max_world);
-    enum jl_partition_kind kind = bpart ? jl_binding_kind(bpart) : BINDING_KIND_GUARD;
-    if (kind == BINDING_KIND_GLOBAL || jl_bkind_is_some_constant(kind)) {
-        if (jl_get_binding_value_if_const(bnd))
-            return mark_julia_const(ctx, jl_true);
-        Value *bp = julia_binding_gv(ctx, bnd);
-        bp = julia_binding_pvalue(ctx, bp);
-        LoadInst *v = ctx.builder.CreateAlignedLoad(ctx.types().T_prjlvalue, bp, Align(sizeof(void*)));
-        jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_binding);
-        ai.decorateInst(v);
-        v->setOrdering(get_llvm_atomic_order(order));
-        isnull = ctx.builder.CreateICmpNE(v, Constant::getNullValue(ctx.types().T_prjlvalue));
+    struct restriction_kind_pair rkp = { NULL, NULL, BINDING_KIND_GUARD, 0 };
+    if (allow_import && jl_get_binding_leaf_partitions_restriction_kind(bnd, &rkp, ctx.min_world, ctx.max_world)) {
+        if (jl_bkind_is_some_constant(rkp.kind))
+            return mark_julia_const(ctx, rkp.restriction);
+        if (rkp.kind == BINDING_KIND_GLOBAL) {
+            Value *bp = julia_binding_gv(ctx, rkp.binding_if_global);
+            bp = julia_binding_pvalue(ctx, bp);
+            LoadInst *v = ctx.builder.CreateAlignedLoad(ctx.types().T_prjlvalue, bp, Align(sizeof(void*)));
+            jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_binding);
+            ai.decorateInst(v);
+            v->setOrdering(get_llvm_atomic_order(order));
+            isnull = ctx.builder.CreateICmpNE(v, Constant::getNullValue(ctx.types().T_prjlvalue));
+            return mark_julia_type(ctx, isnull, false, jl_bool_type);
+        }
     }
-    else {
-        Value *v = ctx.builder.CreateCall(prepare_call(jlboundp_func), {
-                literal_pointer_val(ctx, (jl_value_t*)modu),
-                literal_pointer_val(ctx, (jl_value_t*)name),
-                ConstantInt::get(getInt32Ty(ctx.builder.getContext()), allow_import)
-            });
-        isnull = ctx.builder.CreateICmpNE(v, ConstantInt::get(getInt32Ty(ctx.builder.getContext()), 0));
-    }
+    Value *v = ctx.builder.CreateCall(prepare_call(jlboundp_func), {
+            literal_pointer_val(ctx, (jl_value_t*)modu),
+            literal_pointer_val(ctx, (jl_value_t*)name),
+            ConstantInt::get(getInt32Ty(ctx.builder.getContext()), allow_import)
+        });
+    isnull = ctx.builder.CreateICmpNE(v, ConstantInt::get(getInt32Ty(ctx.builder.getContext()), 0));
     return mark_julia_type(ctx, isnull, false, jl_bool_type);
 }
 

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -318,9 +318,9 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
       While these exist as OS concepts on Darwin, we want to use them on other platforms
       such as Windows, so we emulate them here.
     */
-    if (!abspath && !is_atpath && jl_base_module != NULL) {
+    if (!abspath && !is_atpath && jl_base_module != NULL && jl_typeinf_world != 1) {
         jl_binding_t *b = jl_get_module_binding(jl_base_module, jl_symbol("DL_LOAD_PATH"), 0);
-        jl_array_t *DL_LOAD_PATH = (jl_array_t*)(b ? jl_get_binding_value(b) : NULL);
+        jl_array_t *DL_LOAD_PATH = (jl_array_t*)(b ? jl_get_binding_value_in_world(b, jl_typeinf_world) : NULL);
         if (DL_LOAD_PATH != NULL) {
             size_t j;
             for (j = 0; j < jl_array_nrows(DL_LOAD_PATH); j++) {

--- a/src/julia.h
+++ b/src/julia.h
@@ -1907,6 +1907,7 @@ JL_DLLEXPORT jl_sym_t *jl_gensym(void);
 JL_DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, size_t len);
 JL_DLLEXPORT jl_sym_t *jl_get_root_symbol(void);
 JL_DLLEXPORT jl_value_t *jl_get_binding_value(jl_binding_t *b JL_PROPAGATES_ROOT);
+JL_DLLEXPORT jl_value_t *jl_get_binding_value_in_world(jl_binding_t *b JL_PROPAGATES_ROOT, size_t world);
 JL_DLLEXPORT jl_value_t *jl_get_binding_value_if_const(jl_binding_t *b JL_PROPAGATES_ROOT);
 JL_DLLEXPORT jl_value_t *jl_get_binding_value_if_resolved(jl_binding_t *b JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_get_binding_value_if_resolved_and_const(jl_binding_t *b JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -957,7 +957,17 @@ STATIC_INLINE int jl_bkind_is_defined_constant(enum jl_partition_kind kind) JL_N
 }
 
 JL_DLLEXPORT jl_binding_partition_t *jl_get_binding_partition(jl_binding_t *b JL_PROPAGATES_ROOT, size_t world) JL_GLOBALLY_ROOTED;
+JL_DLLEXPORT jl_binding_partition_t *jl_get_binding_partition_with_hint(jl_binding_t *b JL_PROPAGATES_ROOT, jl_binding_partition_t *previous_part, size_t world) JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT jl_binding_partition_t *jl_get_binding_partition_all(jl_binding_t *b JL_PROPAGATES_ROOT, size_t min_world, size_t max_world) JL_GLOBALLY_ROOTED;
+
+struct restriction_kind_pair {
+    jl_binding_t *binding_if_global;
+    jl_value_t *restriction;
+    enum jl_partition_kind kind;
+    int maybe_depwarn;
+};
+JL_DLLEXPORT int jl_get_binding_leaf_partitions_restriction_kind(jl_binding_t *b JL_PROPAGATES_ROOT, struct restriction_kind_pair *rkp, size_t min_world, size_t max_world) JL_GLOBALLY_ROOTED;
+JL_DLLEXPORT jl_value_t *jl_get_binding_leaf_partitions_value_if_const(jl_binding_t *b JL_PROPAGATES_ROOT, int *maybe_depwarn, size_t min_world, size_t max_world);
 
 EXTERN_INLINE_DECLARE uint8_t jl_bpart_get_kind(jl_binding_partition_t *bpart) JL_NOTSAFEPOINT {
     return (uint8_t)(bpart->kind & 0xf);
@@ -966,6 +976,7 @@ EXTERN_INLINE_DECLARE uint8_t jl_bpart_get_kind(jl_binding_partition_t *bpart) J
 STATIC_INLINE void jl_walk_binding_inplace(jl_binding_t **bnd, jl_binding_partition_t **bpart JL_PROPAGATES_ROOT, size_t world) JL_NOTSAFEPOINT;
 STATIC_INLINE void jl_walk_binding_inplace_depwarn(jl_binding_t **bnd, jl_binding_partition_t **bpart, size_t world, int *depwarn) JL_NOTSAFEPOINT;
 STATIC_INLINE void jl_walk_binding_inplace_all(jl_binding_t **bnd, jl_binding_partition_t **bpart JL_PROPAGATES_ROOT, int *depwarn, size_t min_world, size_t max_world) JL_NOTSAFEPOINT;
+STATIC_INLINE void jl_walk_binding_inplace_worlds(jl_binding_t **bnd, jl_binding_partition_t **bpart, size_t *min_world, size_t *max_world, int *depwarn, size_t world) JL_NOTSAFEPOINT;
 
 #ifndef __clang_analyzer__
 STATIC_INLINE void jl_walk_binding_inplace(jl_binding_t **bnd, jl_binding_partition_t **bpart, size_t world) JL_NOTSAFEPOINT
@@ -1014,6 +1025,30 @@ STATIC_INLINE void jl_walk_binding_inplace_all(jl_binding_t **bnd, jl_binding_pa
             passed_explicit = 1;
         *bnd = (jl_binding_t*)(*bpart)->restriction;
         *bpart = jl_get_binding_partition_all(*bnd, min_world, max_world);
+    }
+}
+
+STATIC_INLINE void jl_walk_binding_inplace_worlds(jl_binding_t **bnd, jl_binding_partition_t **bpart, size_t *min_world, size_t *max_world, int *depwarn, size_t world) JL_NOTSAFEPOINT
+{
+    int passed_explicit = 0;
+    while (*bpart) {
+        if (*min_world < (*bpart)->min_world)
+            *min_world = (*bpart)->min_world;
+        size_t bpart_max_world = jl_atomic_load_relaxed(&(*bpart)->max_world);
+        if (*max_world > bpart_max_world)
+            *max_world = bpart_max_world;
+        enum jl_partition_kind kind = jl_binding_kind(*bpart);
+        if (!jl_bkind_is_some_import(kind)) {
+            if (!passed_explicit && depwarn)
+                *depwarn |= (*bpart)->kind & BINDING_FLAG_DEPWARN;
+            return;
+        }
+        if (!passed_explicit && depwarn)
+            *depwarn |= (*bpart)->kind & BINDING_FLAG_DEPWARN;
+        if (kind != BINDING_KIND_IMPLICIT)
+            passed_explicit = 1;
+        *bnd = (jl_binding_t*)(*bpart)->restriction;
+        *bpart = jl_get_binding_partition(*bnd, world);
     }
 }
 #endif

--- a/src/module.c
+++ b/src/module.c
@@ -165,13 +165,9 @@ void jl_check_new_binding_implicit(
     return;
 }
 
-STATIC_INLINE jl_binding_partition_t *jl_get_binding_partition_(jl_binding_t *b JL_PROPAGATES_ROOT, size_t world, modstack_t *st) JL_GLOBALLY_ROOTED
+STATIC_INLINE jl_binding_partition_t *jl_get_binding_partition_(jl_binding_t *b JL_PROPAGATES_ROOT, jl_value_t *parent, _Atomic(jl_binding_partition_t *)*insert, size_t world, modstack_t *st) JL_GLOBALLY_ROOTED
 {
-    if (!b)
-        return NULL;
     assert(jl_is_binding(b));
-    jl_value_t *parent = (jl_value_t*)b;
-    _Atomic(jl_binding_partition_t *)*insert = &b->partitions;
     jl_binding_partition_t *bpart = jl_atomic_load_relaxed(insert);
     size_t max_world = (size_t)-1;
     jl_binding_partition_t *new_bpart = NULL;
@@ -202,12 +198,22 @@ STATIC_INLINE jl_binding_partition_t *jl_get_binding_partition_(jl_binding_t *b 
 }
 
 jl_binding_partition_t *jl_get_binding_partition(jl_binding_t *b, size_t world) {
+    if (!b)
+        return NULL;
     // Duplicate the code for the entry frame for branch prediction
-    return jl_get_binding_partition_(b, world, NULL);
+    return jl_get_binding_partition_(b, (jl_value_t*)b, &b->partitions, world, NULL);
+}
+
+jl_binding_partition_t *jl_get_binding_partition_with_hint(jl_binding_t *b, jl_binding_partition_t *prev, size_t world) JL_GLOBALLY_ROOTED {
+    // Helper for getting a binding partition for an older world after we've already looked up the partition for a newer world
+    assert(b);
+    assert(prev->min_world > world);
+    return jl_get_binding_partition_(b, (jl_value_t*)prev, &prev->next, world, NULL);
 }
 
 jl_binding_partition_t *jl_get_binding_partition2(jl_binding_t *b JL_PROPAGATES_ROOT, size_t world, modstack_t *st) JL_GLOBALLY_ROOTED {
-    return jl_get_binding_partition_(b, world, st);
+    assert(b);
+    return jl_get_binding_partition_(b, (jl_value_t*)b, &b->partitions, world, st);
 }
 
 jl_binding_partition_t *jl_get_binding_partition_all(jl_binding_t *b, size_t min_world, size_t max_world) {
@@ -219,6 +225,53 @@ jl_binding_partition_t *jl_get_binding_partition_all(jl_binding_t *b, size_t min
     if (jl_atomic_load_relaxed(&bpart->max_world) < max_world)
         return NULL;
     return bpart;
+}
+
+JL_DLLEXPORT int jl_get_binding_leaf_partitions_restriction_kind(jl_binding_t *b JL_PROPAGATES_ROOT, struct restriction_kind_pair *rkp, size_t min_world, size_t max_world) {
+    if (!b)
+        return 0;
+
+    int first = 1;
+    size_t validated_min_world = max_world == ~(size_t)0 ? ~(size_t)0 : max_world + 1;
+    jl_binding_partition_t *bpart = NULL;
+    int maybe_depwarn = 0;
+    while (validated_min_world > min_world) {
+        bpart = bpart ? jl_get_binding_partition_with_hint(b, bpart, validated_min_world - 1) :
+                        jl_get_binding_partition(b, validated_min_world - 1);
+        while (validated_min_world > min_world && validated_min_world > bpart->min_world) {
+            jl_binding_t *curb = b;
+            jl_binding_partition_t *curbpart = bpart;
+            size_t cur_min_world = bpart->min_world;
+            size_t cur_max_world = validated_min_world - 1;
+            jl_walk_binding_inplace_worlds(&curb, &curbpart, &cur_min_world, &cur_max_world, &maybe_depwarn, cur_max_world);
+            if (first == 1) {
+                rkp->kind = jl_binding_kind(curbpart);
+                rkp->restriction = curbpart->restriction;
+                if (rkp->kind == BINDING_KIND_GLOBAL || rkp->kind == BINDING_KIND_DECLARED)
+                    rkp->binding_if_global = curb;
+                first = 0;
+            } else {
+                if (jl_binding_kind(curbpart) != rkp->kind || curbpart->restriction != rkp->restriction)
+                    return 0;
+                if ((rkp->kind == BINDING_KIND_GLOBAL || rkp->kind == BINDING_KIND_DECLARED) && rkp->binding_if_global != curb)
+                    return 0;
+            }
+            validated_min_world = cur_min_world;
+        }
+    }
+    rkp->maybe_depwarn = maybe_depwarn;
+    return 1;
+}
+
+JL_DLLEXPORT jl_value_t *jl_get_binding_leaf_partitions_value_if_const(jl_binding_t *b JL_PROPAGATES_ROOT, int *maybe_depwarn, size_t min_world, size_t max_world) {
+    struct restriction_kind_pair rkp = { NULL, NULL, BINDING_KIND_GUARD, 0 };
+    if (!jl_get_binding_leaf_partitions_restriction_kind(b, &rkp, min_world, max_world))
+        return NULL;
+    if (jl_bkind_is_some_constant(rkp.kind) && rkp.kind != BINDING_KIND_BACKDATED_CONST) {
+        *maybe_depwarn = rkp.maybe_depwarn;
+        return rkp.restriction;
+    }
+    return NULL;
 }
 
 JL_DLLEXPORT jl_module_t *jl_new_module__(jl_sym_t *name, jl_module_t *parent)
@@ -604,8 +657,13 @@ static inline void check_backdated_binding(jl_binding_t *b, enum jl_partition_ki
 
 JL_DLLEXPORT jl_value_t *jl_get_binding_value(jl_binding_t *b)
 {
-    jl_binding_partition_t *bpart = jl_get_binding_partition(b, jl_current_task->world_age);
-    jl_walk_binding_inplace(&b, &bpart, jl_current_task->world_age);
+    return jl_get_binding_value_in_world(b, jl_current_task->world_age);
+}
+
+JL_DLLEXPORT jl_value_t *jl_get_binding_value_in_world(jl_binding_t *b, size_t world)
+{
+    jl_binding_partition_t *bpart = jl_get_binding_partition(b, world);
+    jl_walk_binding_inplace(&b, &bpart, world);
     enum jl_partition_kind kind = jl_binding_kind(bpart);
     if (jl_bkind_is_some_guard(kind))
         return NULL;

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -642,20 +642,17 @@ end
 function CC.abstract_eval_globalref(interp::REPLInterpreter, g::GlobalRef, bailed::Bool,
                                     sv::CC.InferenceState)
     # Ignore saw_latestworld
-    partition = CC.abstract_eval_binding_partition!(interp, g, sv)
     if (interp.limit_aggressive_inference ? is_repl_frame(sv) : is_call_graph_uncached(sv))
+        partition = CC.abstract_eval_binding_partition!(interp, g, sv)
         if CC.is_defined_const_binding(CC.binding_kind(partition))
-            return Pair{CC.RTEffects, Union{Nothing, Core.BindingPartition}}(
-                CC.RTEffects(Const(CC.partition_restriction(partition)), Union{}, CC.EFFECTS_TOTAL), partition)
+            return CC.RTEffects(Const(CC.partition_restriction(partition)), Union{}, CC.EFFECTS_TOTAL)
         else
             b = convert(Core.Binding, g)
             if CC.binding_kind(partition) == CC.BINDING_KIND_GLOBAL && isdefined(b, :value)
-                return Pair{CC.RTEffects, Union{Nothing, Core.BindingPartition}}(
-                    CC.RTEffects(Const(b.value), Union{}, CC.EFFECTS_TOTAL), partition)
+                return CC.RTEffects(Const(b.value), Union{}, CC.EFFECTS_TOTAL)
             end
         end
-        return Pair{CC.RTEffects, Union{Nothing, Core.BindingPartition}}(
-            CC.RTEffects(Union{}, UndefVarError, CC.EFFECTS_THROWS), partition)
+        return CC.RTEffects(Union{}, UndefVarError, CC.EFFECTS_THROWS)
     end
     return @invoke CC.abstract_eval_globalref(interp::CC.AbstractInterpreter, g::GlobalRef, bailed::Bool,
                                               sv::CC.InferenceState)


### PR DESCRIPTION
When inference and codegen queries the partitions of a binding, they often only care about a subset of the information in the partition. At the moment, we always truncate world ranges to the most precise partition that contains the relevant query. However, we can instead expand the world range to cover all partitions that are equivalent for the given query. To give a concrete example, both inference and codegen never care about the exported flag in a binding partition, so we should not unnecessarily truncate a world range just because an export was introduced.

Further, this commit lays the ground work to stop invalidating code for these same kinds of transitions, although the actual logic to do that will come in a separate PR.