### PR TITLE
`AnnotatedString`: add concrete type asserts to `isvalid`, `ncodeunits`

### DIFF
--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -147,11 +147,11 @@ promote_rule(::Type{<:AnnotatedString}, ::Type{<:AbstractString}) = AnnotatedStr
 
 ## AbstractString interface ##
 
-ncodeunits(s::AnnotatedString) = ncodeunits(s.string)
+ncodeunits(s::AnnotatedString) = ncodeunits(s.string)::Int
 codeunits(s::AnnotatedString) = codeunits(s.string)
 codeunit(s::AnnotatedString) = codeunit(s.string)
 codeunit(s::AnnotatedString, i::Integer) = codeunit(s.string, i)
-isvalid(s::AnnotatedString, i::Integer) = isvalid(s.string, i)
+isvalid(s::AnnotatedString, i::Integer) = isvalid(s.string, i)::Bool
 @propagate_inbounds iterate(s::AnnotatedString, i::Integer=firstindex(s)) =
     if i <= lastindex(s.string); (s[i], nextind(s, i)) end
 eltype(::Type{<:AnnotatedString{S}}) where {S} = AnnotatedChar{eltype(S)}

--- a/test/strings/annotated.jl
+++ b/test/strings/annotated.jl
@@ -74,6 +74,9 @@
 
     a = Base.AnnotatedString("hello", [(1:5, :label, 1)])
     @test first(a) == Base.AnnotatedChar('h', [(:label, 1)])
+
+    @test Bool === Base.infer_return_type(isvalid, Tuple{Base.AnnotatedString, Vararg})
+    @test Int === Base.infer_return_type(ncodeunits, Tuple{Base.AnnotatedString})
 end
 
 @testset "AnnotatedChar" begin


### PR DESCRIPTION
The type assertions are valid according to the doc strings of these two functions in the case of `AbstractString`.

Should prevent some invalidation on loading user code.

Fixes #57606