### PR TITLE
strings: type assert in the generic `nextind`, `prevind` methods

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -512,9 +512,9 @@ function prevind(s::AbstractString, i::Int, n::Int)
     @boundscheck 0 < i ≤ z || throw(BoundsError(s, i))
     n == 0 && return thisind(s, i) == i ? i : string_index_err(s, i)
     while n > 0 && 1 < i
-        @inbounds n -= isvalid(s, i -= 1)
+        @inbounds n -= isvalid(s, i -= 1)::Bool
     end
-    return i - n::Int
+    return i - n
 end
 
 """
@@ -571,9 +571,9 @@ function nextind(s::AbstractString, i::Int, n::Int)
     @boundscheck 0 ≤ i ≤ z || throw(BoundsError(s, i))
     n == 0 && return thisind(s, i) == i ? i : string_index_err(s, i)
     while n > 0 && i < z
-        @inbounds n -= isvalid(s, i += 1)
+        @inbounds n -= isvalid(s, i += 1)::Bool
     end
-    return i + n::Int
+    return i + n
 end
 
 ## string index iteration type ##

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -508,9 +508,9 @@ prevind(s::AbstractString, i::Int)                 = prevind(s, i, 1)
 
 function prevind(s::AbstractString, i::Int, n::Int)
     n < 0 && throw(ArgumentError("n cannot be negative: $n"))
-    z = ncodeunits(s) + 1
+    z = ncodeunits(s)::Int + 1
     @boundscheck 0 < i ≤ z || throw(BoundsError(s, i))
-    n == 0 && return thisind(s, i) == i ? i : string_index_err(s, i)
+    n == 0 && return thisind(s, i)::Int == i ? i : string_index_err(s, i)
     while n > 0 && 1 < i
         @inbounds n -= isvalid(s, i -= 1)::Bool
     end
@@ -567,9 +567,9 @@ nextind(s::AbstractString, i::Int)                 = nextind(s, i, 1)
 
 function nextind(s::AbstractString, i::Int, n::Int)
     n < 0 && throw(ArgumentError("n cannot be negative: $n"))
-    z = ncodeunits(s)
+    z = ncodeunits(s)::Int
     @boundscheck 0 ≤ i ≤ z || throw(BoundsError(s, i))
-    n == 0 && return thisind(s, i) == i ? i : string_index_err(s, i)
+    n == 0 && return thisind(s, i)::Int == i ? i : string_index_err(s, i)
     while n > 0 && i < z
         @inbounds n -= isvalid(s, i += 1)::Bool
     end

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -514,7 +514,7 @@ function prevind(s::AbstractString, i::Int, n::Int)
     while n > 0 && 1 < i
         @inbounds n -= isvalid(s, i -= 1)
     end
-    return i::Int - n::Int
+    return i - n::Int
 end
 
 """
@@ -573,7 +573,7 @@ function nextind(s::AbstractString, i::Int, n::Int)
     while n > 0 && i < z
         @inbounds n -= isvalid(s, i += 1)
     end
-    return i::Int + n::Int
+    return i + n::Int
 end
 
 ## string index iteration type ##

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -514,7 +514,7 @@ function prevind(s::AbstractString, i::Int, n::Int)
     while n > 0 && 1 < i
         @inbounds n -= isvalid(s, i -= 1)
     end
-    return i - n
+    return (i - n)::Int
 end
 
 """
@@ -573,7 +573,7 @@ function nextind(s::AbstractString, i::Int, n::Int)
     while n > 0 && i < z
         @inbounds n -= isvalid(s, i += 1)
     end
-    return i + n
+    return (i + n)::Int
 end
 
 ## string index iteration type ##

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -514,7 +514,7 @@ function prevind(s::AbstractString, i::Int, n::Int)
     while n > 0 && 1 < i
         @inbounds n -= isvalid(s, i -= 1)
     end
-    return (i - n)::Int
+    return i::Int - n::Int
 end
 
 """
@@ -573,7 +573,7 @@ function nextind(s::AbstractString, i::Int, n::Int)
     while n > 0 && i < z
         @inbounds n -= isvalid(s, i += 1)
     end
-    return (i + n)::Int
+    return i::Int + n::Int
 end
 
 ## string index iteration type ##

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -877,6 +877,11 @@ end
             end
         end
     end
+
+    @testset "return type infers to `Int`" begin
+        @test Int === Base.infer_return_type(prevind, Tuple{AbstractString, Vararg})
+        @test Int === Base.infer_return_type(nextind, Tuple{AbstractString, Vararg})
+    end
 end
 
 @testset "first and last" begin


### PR DESCRIPTION
The type assertions are valid according to the doc strings of these functions in the case of `AbstractString`.

Should prevent some invalidation on loading user code.

Fixes #57605