### PR TITLE
CI: Add a list of test failures at top of buildkite page via `buildkite-agent annotate`

### DIFF
--- a/stdlib/Dates/test/accessors.jl
+++ b/stdlib/Dates/test/accessors.jl
@@ -5,6 +5,7 @@ module AccessorsTest
 using Dates
 using Test
 
+@test false
 @testset "yearmonthday/yearmonth/monthday" begin
     # yearmonthday is the opposite of totaldays
     # taking Rata Die Day # and returning proleptic Gregorian date

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -4,6 +4,8 @@ using Test, Markdown, StyledStrings
 import Markdown: MD, Paragraph, Header, Italic, Bold, LineBreak, insert_hlines, plain, term, html, rst, Table, Code, LaTeX, Footnote
 import Base: show
 
+@test error("dummy error")
+
 # Basics
 # Equality is checked by making sure the HTML output is
 # the same – the structure itself may be different.

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2411,7 +2411,7 @@ function show_result_as_buildkite_annotation(io::IO, result::Result)
 
     msg = """
     <details>
-    <summary><code>$firstline</code> $label</summary>
+    <summary><code>$firstline</code></summary>
 
     ```term
     $str_color
@@ -2421,7 +2421,7 @@ function show_result_as_buildkite_annotation(io::IO, result::Result)
     """
 
     try
-        run(`buildkite-agent annotate --style $type --context "julia-test-failures" --append "$msg"`)
+        run(`buildkite-agent annotate --style $type --job $job_id --context "$(label)-$(job_id)" --append "$msg"`)
     catch e
         @error "Error adding buildkite annotation" e
     end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2406,7 +2406,12 @@ function show_result_as_buildkite_annotation(io::IO, result::Result)
     str_nocolor = sprint(show, result; context=IOContext(io, :color => false))
     firstline = split(str_nocolor, '\n')[1]
     pathsep = Sys.iswindows() ? '\\' : '/'
-    firstline = replace(firstline, string(Sys.STDLIB, pathsep) => "")
+    firstline = replace(firstline,
+            string(Sys.STDLIB, pathsep) => "",
+            string(normpath(Sys.BUILD_ROOT_PATH), pathsep) => "", # HACK?
+            string(dirname(Sys.BINDIR), pathsep) => "" # HACK?
+            )
+
     str_color = sprint(show, result; context=io)
 
     msg = """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,7 +78,7 @@ limited_worker_rss && move_to_node1("Distributed")
 
 # Move LinearAlgebra and Pkg tests to the front, because they take a while, so we might
 # as well get them all started early.
-for prependme in ["LinearAlgebra", "Pkg"]
+for prependme in ["LinearAlgebra", "Pkg", "Dates", "Markdown"]
     prependme_test_ids = findall(x->occursin(prependme, x), tests)
     prependme_tests = tests[prependme_test_ids]
     deleteat!(tests, prependme_test_ids)


### PR DESCRIPTION
Floats test failures and errors to the top of the buildkite page using https://buildkite.com/docs/agent/v3/cli-annotate

See https://buildkite.com/julialang/julia-master/builds/45414

Todo:
- [ ] Revert the dummy failures
- [ ] Fix false positives from Test's own tests
- [ ] Shorten non-stdlib and paths too
- [ ] Don't send failures from ignored groups
- [ ] Move out of Test? But need to figure out how to initialize it any time Test is loaded within a buildkite job
- [ ] Find a way to link to the line in the job logs?? I don't think it's possible.