### PR TITLE
bpart: Rename partition flags, turn binding flags atomic

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -49,8 +49,8 @@ using Core: ABIOverride, Builtin, CodeInstance, IntrinsicFunction, MethodInstanc
 
 using Base
 using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospecializeinfer,
-    BINDING_KIND_GLOBAL, BINDING_KIND_UNDEF_CONST, BINDING_KIND_BACKDATED_CONST, BINDING_KIND_DECLARED,
-    BINDING_FLAG_DEPWARN,
+    PARTITION_KIND_GLOBAL, PARTITION_KIND_UNDEF_CONST, PARTITION_KIND_BACKDATED_CONST, PARTITION_KIND_DECLARED,
+    PARTITION_FLAG_DEPWARN,
     Base, BitVector, Bottom, Callable, DataTypeFieldDesc,
     EffectsOverride, Filter, Generator, IteratorSize, JLOptions, NUM_EFFECTS_OVERRIDES,
     OneTo, Ordering, RefValue, SizeUnknown, _NAMEDTUPLE_NAME,

--- a/base/invalidation.jl
+++ b/base/invalidation.jl
@@ -140,7 +140,7 @@ function invalidate_code_for_globalref!(b::Core.Binding, invalidated_bpart::Core
             end
         end
     end
-    if (invalidated_bpart.kind & BINDING_FLAG_EXPORTED != 0) || (new_bpart !== nothing && (new_bpart.kind & BINDING_FLAG_EXPORTED != 0))
+    if (invalidated_bpart.kind & PARTITION_FLAG_EXPORTED != 0) || (new_bpart !== nothing && (new_bpart.kind & PARTITION_FLAG_EXPORTED != 0))
         # This binding was exported - we need to check all modules that `using` us to see if they
         # have a binding that is affected by this change.
         usings_backedges = ccall(:jl_get_module_usings_backedges, Any, (Any,), gr.mod)
@@ -151,7 +151,7 @@ function invalidate_code_for_globalref!(b::Core.Binding, invalidated_bpart::Core
                 isdefined(user_binding, :partitions) || continue
                 latest_bpart = user_binding.partitions
                 latest_bpart.max_world == typemax(UInt) || continue
-                binding_kind(latest_bpart) in (BINDING_KIND_IMPLICIT, BINDING_KIND_FAILED, BINDING_KIND_GUARD) || continue
+                binding_kind(latest_bpart) in (PARTITION_KIND_IMPLICIT, PARTITION_KIND_FAILED, PARTITION_KIND_GUARD) || continue
                 @atomic :release latest_bpart.max_world = new_max_world
                 invalidate_code_for_globalref!(convert(Core.Binding, user_binding), latest_bpart, nothing, new_max_world)
             end

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -197,29 +197,29 @@ function _fieldnames(@nospecialize t)
 end
 
 # N.B.: Needs to be synced with julia.h
-const BINDING_KIND_CONST        = 0x0
-const BINDING_KIND_CONST_IMPORT = 0x1
-const BINDING_KIND_GLOBAL       = 0x2
-const BINDING_KIND_IMPLICIT     = 0x3
-const BINDING_KIND_EXPLICIT     = 0x4
-const BINDING_KIND_IMPORTED     = 0x5
-const BINDING_KIND_FAILED       = 0x6
-const BINDING_KIND_DECLARED     = 0x7
-const BINDING_KIND_GUARD        = 0x8
-const BINDING_KIND_UNDEF_CONST  = 0x9
-const BINDING_KIND_BACKDATED_CONST = 0xa
+const PARTITION_KIND_CONST        = 0x0
+const PARTITION_KIND_CONST_IMPORT = 0x1
+const PARTITION_KIND_GLOBAL       = 0x2
+const PARTITION_KIND_IMPLICIT     = 0x3
+const PARTITION_KIND_EXPLICIT     = 0x4
+const PARTITION_KIND_IMPORTED     = 0x5
+const PARTITION_KIND_FAILED       = 0x6
+const PARTITION_KIND_DECLARED     = 0x7
+const PARTITION_KIND_GUARD        = 0x8
+const PARTITION_KIND_UNDEF_CONST  = 0x9
+const PARTITION_KIND_BACKDATED_CONST = 0xa
 
-const BINDING_FLAG_EXPORTED     = 0x10
-const BINDING_FLAG_DEPRECATED   = 0x20
-const BINDING_FLAG_DEPWARN      = 0x40
+const PARTITION_FLAG_EXPORTED     = 0x10
+const PARTITION_FLAG_DEPRECATED   = 0x20
+const PARTITION_FLAG_DEPWARN      = 0x40
 
-const BINDING_KIND_MASK         = 0x0f
-const BINDING_FLAG_MASK         = 0xf0
+const PARTITION_MASK_KIND         = 0x0f
+const PARTITION_MASK_FLAG         = 0xf0
 
-is_defined_const_binding(kind::UInt8) = (kind == BINDING_KIND_CONST || kind == BINDING_KIND_CONST_IMPORT || kind == BINDING_KIND_BACKDATED_CONST)
-is_some_const_binding(kind::UInt8) = (is_defined_const_binding(kind) || kind == BINDING_KIND_UNDEF_CONST)
-is_some_imported(kind::UInt8) = (kind == BINDING_KIND_IMPLICIT || kind == BINDING_KIND_EXPLICIT || kind == BINDING_KIND_IMPORTED)
-is_some_guard(kind::UInt8) = (kind == BINDING_KIND_GUARD || kind == BINDING_KIND_FAILED || kind == BINDING_KIND_UNDEF_CONST)
+is_defined_const_binding(kind::UInt8) = (kind == PARTITION_KIND_CONST || kind == PARTITION_KIND_CONST_IMPORT || kind == PARTITION_KIND_BACKDATED_CONST)
+is_some_const_binding(kind::UInt8) = (is_defined_const_binding(kind) || kind == PARTITION_KIND_UNDEF_CONST)
+is_some_imported(kind::UInt8) = (kind == PARTITION_KIND_IMPLICIT || kind == PARTITION_KIND_EXPLICIT || kind == PARTITION_KIND_IMPORTED)
+is_some_guard(kind::UInt8) = (kind == PARTITION_KIND_GUARD || kind == PARTITION_KIND_FAILED || kind == PARTITION_KIND_UNDEF_CONST)
 
 function lookup_binding_partition(world::UInt, b::Core.Binding)
     ccall(:jl_get_binding_partition, Ref{Core.BindingPartition}, (Any, UInt), b, world)

--- a/base/show.jl
+++ b/base/show.jl
@@ -3377,17 +3377,17 @@ function print_partition(io::IO, partition::Core.BindingPartition)
     else
         print(io, max_world)
     end
-    if (partition.kind & BINDING_FLAG_MASK) != 0
+    if (partition.kind & PARTITION_MASK_FLAG) != 0
         first = false
         print(io, " [")
-        if (partition.kind & BINDING_FLAG_EXPORTED) != 0
+        if (partition.kind & PARTITION_FLAG_EXPORTED) != 0
             print(io, "exported")
         end
-        if (partition.kind & BINDING_FLAG_DEPRECATED) != 0
+        if (partition.kind & PARTITION_FLAG_DEPRECATED) != 0
             first ? (first = false) : print(io, ",")
             print(io, "deprecated")
         end
-        if (partition.kind & BINDING_FLAG_DEPWARN) != 0
+        if (partition.kind & PARTITION_FLAG_DEPWARN) != 0
             first ? (first = false) : print(io, ",")
             print(io, "depwarn")
         end
@@ -3395,31 +3395,31 @@ function print_partition(io::IO, partition::Core.BindingPartition)
     end
     print(io, " - ")
     kind = binding_kind(partition)
-    if kind == BINDING_KIND_BACKDATED_CONST
+    if kind == PARTITION_KIND_BACKDATED_CONST
         print(io, "backdated constant binding to ")
         print(io, partition_restriction(partition))
     elseif is_defined_const_binding(kind)
         print(io, "constant binding to ")
         print(io, partition_restriction(partition))
-    elseif kind == BINDING_KIND_UNDEF_CONST
+    elseif kind == PARTITION_KIND_UNDEF_CONST
         print(io, "undefined const binding")
-    elseif kind == BINDING_KIND_GUARD
+    elseif kind == PARTITION_KIND_GUARD
         print(io, "undefined binding - guard entry")
-    elseif kind == BINDING_KIND_FAILED
+    elseif kind == PARTITION_KIND_FAILED
         print(io, "ambiguous binding - guard entry")
-    elseif kind == BINDING_KIND_DECLARED
+    elseif kind == PARTITION_KIND_DECLARED
         print(io, "weak global binding declared using `global` (implicit type Any)")
-    elseif kind == BINDING_KIND_IMPLICIT
+    elseif kind == PARTITION_KIND_IMPLICIT
         print(io, "implicit `using` from ")
         print(io, partition_restriction(partition).globalref)
-    elseif kind == BINDING_KIND_EXPLICIT
+    elseif kind == PARTITION_KIND_EXPLICIT
         print(io, "explicit `using` from ")
         print(io, partition_restriction(partition).globalref)
-    elseif kind == BINDING_KIND_IMPORTED
+    elseif kind == PARTITION_KIND_IMPORTED
         print(io, "explicit `import` from ")
         print(io, partition_restriction(partition).globalref)
     else
-        @assert kind == BINDING_KIND_GLOBAL
+        @assert kind == PARTITION_KIND_GLOBAL
         print(io, "global variable with type ")
         print(io, partition_restriction(partition))
     end

--- a/src/ast.c
+++ b/src/ast.c
@@ -178,7 +178,7 @@ static value_t fl_defined_julia_global(fl_context_t *fl_ctx, value_t *args, uint
     jl_sym_t *var = scmsym_to_julia(fl_ctx, args[0]);
     jl_binding_t *b = jl_get_module_binding(ctx->module, var, 0);
     jl_binding_partition_t *bpart = jl_get_binding_partition(b, jl_current_task->world_age);
-    return (bpart != NULL && jl_binding_kind(bpart) == BINDING_KIND_GLOBAL) ? fl_ctx->T : fl_ctx->F;
+    return (bpart != NULL && jl_binding_kind(bpart) == PARTITION_KIND_GLOBAL) ? fl_ctx->T : fl_ctx->F;
 }
 
 // Used to generate a unique suffix for a given symbol (e.g. variable or type name)

--- a/src/gf.c
+++ b/src/gf.c
@@ -3816,7 +3816,7 @@ jl_function_t *jl_new_generic_function_with_supertype(jl_sym_t *name, jl_module_
     JL_GC_PUSH1(&ftype);
     ftype->name->mt->name = name;
     jl_gc_wb(ftype->name->mt, name);
-    jl_declare_constant_val3(NULL, module, tname, (jl_value_t*)ftype, BINDING_KIND_CONST, new_world);
+    jl_declare_constant_val3(NULL, module, tname, (jl_value_t*)ftype, PARTITION_KIND_CONST, new_world);
     jl_value_t *f = jl_new_struct(ftype);
     ftype->instance = f;
     jl_gc_wb(ftype, f);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -937,23 +937,23 @@ jl_method_t *jl_make_opaque_closure_method(jl_module_t *module, jl_value_t *name
 JL_DLLEXPORT int jl_is_valid_oc_argtype(jl_tupletype_t *argt, jl_method_t *source);
 
 STATIC_INLINE int jl_bkind_is_some_import(enum jl_partition_kind kind) JL_NOTSAFEPOINT {
-    return kind == BINDING_KIND_IMPLICIT || kind == BINDING_KIND_EXPLICIT || kind == BINDING_KIND_IMPORTED;
+    return kind == PARTITION_KIND_IMPLICIT || kind == PARTITION_KIND_EXPLICIT || kind == PARTITION_KIND_IMPORTED;
 }
 
 STATIC_INLINE int jl_bkind_is_some_guard(enum jl_partition_kind kind) JL_NOTSAFEPOINT {
-    return kind == BINDING_KIND_FAILED || kind == BINDING_KIND_GUARD;
+    return kind == PARTITION_KIND_FAILED || kind == PARTITION_KIND_GUARD;
 }
 
 STATIC_INLINE int jl_bkind_is_some_implicit(enum jl_partition_kind kind) JL_NOTSAFEPOINT {
-    return kind == BINDING_KIND_IMPLICIT || jl_bkind_is_some_guard(kind);
+    return kind == PARTITION_KIND_IMPLICIT || jl_bkind_is_some_guard(kind);
 }
 
 STATIC_INLINE int jl_bkind_is_some_constant(enum jl_partition_kind kind) JL_NOTSAFEPOINT {
-    return kind == BINDING_KIND_CONST || kind == BINDING_KIND_CONST_IMPORT || kind == BINDING_KIND_UNDEF_CONST || kind == BINDING_KIND_BACKDATED_CONST;
+    return kind == PARTITION_KIND_CONST || kind == PARTITION_KIND_CONST_IMPORT || kind == PARTITION_KIND_UNDEF_CONST || kind == PARTITION_KIND_BACKDATED_CONST;
 }
 
 STATIC_INLINE int jl_bkind_is_defined_constant(enum jl_partition_kind kind) JL_NOTSAFEPOINT {
-    return kind == BINDING_KIND_CONST || kind == BINDING_KIND_CONST_IMPORT || kind == BINDING_KIND_BACKDATED_CONST;
+    return kind == PARTITION_KIND_CONST || kind == PARTITION_KIND_CONST_IMPORT || kind == PARTITION_KIND_BACKDATED_CONST;
 }
 
 JL_DLLEXPORT jl_binding_partition_t *jl_get_binding_partition(jl_binding_t *b JL_PROPAGATES_ROOT, size_t world) JL_GLOBALLY_ROOTED;
@@ -996,12 +996,12 @@ STATIC_INLINE void jl_walk_binding_inplace_depwarn(jl_binding_t **bnd, jl_bindin
         enum jl_partition_kind kind = jl_binding_kind(*bpart);
         if (!jl_bkind_is_some_import(kind)) {
             if (!passed_explicit && depwarn)
-                *depwarn |= (*bpart)->kind & BINDING_FLAG_DEPWARN;
+                *depwarn |= (*bpart)->kind & PARTITION_FLAG_DEPWARN;
             return;
         }
         if (!passed_explicit && depwarn)
-            *depwarn |= (*bpart)->kind & BINDING_FLAG_DEPWARN;
-        if (kind != BINDING_KIND_IMPLICIT)
+            *depwarn |= (*bpart)->kind & PARTITION_FLAG_DEPWARN;
+        if (kind != PARTITION_KIND_IMPLICIT)
             passed_explicit = 1;
         *bnd = (jl_binding_t*)(*bpart)->restriction;
         *bpart = jl_get_binding_partition(*bnd, world);
@@ -1016,12 +1016,12 @@ STATIC_INLINE void jl_walk_binding_inplace_all(jl_binding_t **bnd, jl_binding_pa
         enum jl_partition_kind kind = jl_binding_kind(*bpart);
         if (!jl_bkind_is_some_import(kind)) {
             if (!passed_explicit && depwarn)
-                *depwarn |= (*bpart)->kind & BINDING_FLAG_DEPWARN;
+                *depwarn |= (*bpart)->kind & PARTITION_FLAG_DEPWARN;
             return;
         }
         if (!passed_explicit && depwarn)
-            *depwarn |= (*bpart)->kind & BINDING_FLAG_DEPWARN;
-        if (kind != BINDING_KIND_IMPLICIT)
+            *depwarn |= (*bpart)->kind & PARTITION_FLAG_DEPWARN;
+        if (kind != PARTITION_KIND_IMPLICIT)
             passed_explicit = 1;
         *bnd = (jl_binding_t*)(*bpart)->restriction;
         *bpart = jl_get_binding_partition_all(*bnd, min_world, max_world);
@@ -1040,12 +1040,12 @@ STATIC_INLINE void jl_walk_binding_inplace_worlds(jl_binding_t **bnd, jl_binding
         enum jl_partition_kind kind = jl_binding_kind(*bpart);
         if (!jl_bkind_is_some_import(kind)) {
             if (!passed_explicit && depwarn)
-                *depwarn |= (*bpart)->kind & BINDING_FLAG_DEPWARN;
+                *depwarn |= (*bpart)->kind & PARTITION_FLAG_DEPWARN;
             return;
         }
         if (!passed_explicit && depwarn)
-            *depwarn |= (*bpart)->kind & BINDING_FLAG_DEPWARN;
-        if (kind != BINDING_KIND_IMPLICIT)
+            *depwarn |= (*bpart)->kind & PARTITION_FLAG_DEPWARN;
+        if (kind != PARTITION_KIND_IMPLICIT)
             passed_explicit = 1;
         *bnd = (jl_binding_t*)(*bpart)->restriction;
         *bpart = jl_get_binding_partition(*bnd, world);

--- a/src/method.c
+++ b/src/method.c
@@ -1069,7 +1069,7 @@ JL_DLLEXPORT jl_value_t *jl_declare_const_gf(jl_module_t *mod, jl_sym_t *name)
     jl_binding_partition_t *bpart = jl_get_binding_partition(b, new_world);
     jl_value_t *gf = NULL;
     enum jl_partition_kind kind = jl_binding_kind(bpart);
-    if (!jl_bkind_is_some_guard(kind) && kind != BINDING_KIND_DECLARED && kind != BINDING_KIND_IMPLICIT) {
+    if (!jl_bkind_is_some_guard(kind) && kind != PARTITION_KIND_DECLARED && kind != PARTITION_KIND_IMPLICIT) {
         jl_walk_binding_inplace(&b, &bpart, new_world);
         if (jl_bkind_is_some_constant(jl_binding_kind(bpart))) {
             gf = bpart->restriction;
@@ -1084,7 +1084,7 @@ JL_DLLEXPORT jl_value_t *jl_declare_const_gf(jl_module_t *mod, jl_sym_t *name)
     // From this point on (if we didn't error), we're committed to raising the world age,
     // because we've used it to declare the type name.
     jl_atomic_store_release(&jl_world_counter, new_world);
-    jl_declare_constant_val3(b, mod, name, gf, BINDING_KIND_CONST, new_world);
+    jl_declare_constant_val3(b, mod, name, gf, PARTITION_KIND_CONST, new_world);
     JL_GC_PROMISE_ROOTED(gf);
     JL_UNLOCK(&world_counter_lock);
     return gf;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3607,10 +3607,10 @@ static int jl_validate_binding_partition(jl_binding_t *b, jl_binding_partition_t
     if (jl_atomic_load_relaxed(&bpart->max_world) != ~(size_t)0)
         return 1;
     size_t raw_kind = bpart->kind;
-    enum jl_partition_kind kind = (enum jl_partition_kind)(raw_kind & BINDING_KIND_MASK);
+    enum jl_partition_kind kind = (enum jl_partition_kind)(raw_kind & PARTITION_MASK_KIND);
     if (!unchanged_implicit && jl_bkind_is_some_implicit(kind)) {
         jl_check_new_binding_implicit(bpart, b, NULL, jl_atomic_load_relaxed(&jl_world_counter));
-        bpart->kind |= (raw_kind & BINDING_FLAG_MASK);
+        bpart->kind |= (raw_kind & PARTITION_MASK_FLAG);
         if (bpart->min_world > jl_require_world)
             goto invalidated;
     }
@@ -3625,7 +3625,7 @@ static int jl_validate_binding_partition(jl_binding_t *b, jl_binding_partition_t
     if (latest_imported_bpart->min_world <= bpart->min_world) {
 add_backedge:
         // Imported binding is still valid
-        if ((kind == BINDING_KIND_EXPLICIT || kind == BINDING_KIND_IMPORTED) &&
+        if ((kind == PARTITION_KIND_EXPLICIT || kind == PARTITION_KIND_IMPORTED) &&
                 external_blob_index((jl_value_t*)imported_binding) != mod_idx) {
             jl_add_binding_backedge(imported_binding, (jl_value_t*)b);
         }
@@ -3650,7 +3650,7 @@ invalidated:
             jl_validate_binding_partition(bedge, jl_atomic_load_relaxed(&bedge->partitions), mod_idx, 0, 0);
         }
     }
-    if (bpart->kind & BINDING_FLAG_EXPORTED) {
+    if (bpart->kind & PARTITION_FLAG_EXPORTED) {
         jl_module_t *mod = b->globalref->mod;
         jl_sym_t *name = b->globalref->name;
         JL_LOCK(&mod->lock);

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -35,14 +35,14 @@ function UndefVarError_hint(io::IO, ex::UndefVarError)
         if scope isa Module
             bpart = Base.lookup_binding_partition(ex.world, GlobalRef(scope, var))
             kind = Base.binding_kind(bpart)
-            if kind === Base.BINDING_KIND_GLOBAL || kind === Base.BINDING_KIND_UNDEF_CONST || kind == Base.BINDING_KIND_DECLARED
+            if kind === Base.PARTITION_KIND_GLOBAL || kind === Base.PARTITION_KIND_UNDEF_CONST || kind == Base.PARTITION_KIND_DECLARED
                 print(io, "\nSuggestion: add an appropriate import or assignment. This global was declared but not assigned.")
-            elseif kind === Base.BINDING_KIND_FAILED
+            elseif kind === Base.PARTITION_KIND_FAILED
                 print(io, "\nHint: It looks like two or more modules export different ",
                 "bindings with this name, resulting in ambiguity. Try explicitly ",
                 "importing it from a particular module, or qualifying the name ",
                 "with the module it should come from.")
-            elseif kind === Base.BINDING_KIND_GUARD
+            elseif kind === Base.PARTITION_KIND_GUARD
                 print(io, "\nSuggestion: check for spelling errors or missing imports.")
             elseif Base.is_some_imported(kind)
                 print(io, "\nSuggestion: this global was defined as `$(Base.partition_restriction(bpart).globalref)` but not assigned a value.")

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -648,7 +648,7 @@ function CC.abstract_eval_globalref(interp::REPLInterpreter, g::GlobalRef, baile
             return CC.RTEffects(Const(CC.partition_restriction(partition)), Union{}, CC.EFFECTS_TOTAL)
         else
             b = convert(Core.Binding, g)
-            if CC.binding_kind(partition) == CC.BINDING_KIND_GLOBAL && isdefined(b, :value)
+            if CC.binding_kind(partition) == CC.PARTITION_KIND_GLOBAL && isdefined(b, :value)
                 return CC.RTEffects(Const(b.value), Union{}, CC.EFFECTS_TOTAL)
             end
         end

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -313,7 +313,7 @@ function summarize(binding::Binding, sig)
         println(io, "No documentation found.\n")
         quot = any(isspace, sprint(print, binding)) ? "'" : ""
         bpart = Base.lookup_binding_partition(Base.tls_world_age(), convert(Core.Binding, GlobalRef(binding.mod, binding.var)))
-        if Base.binding_kind(bpart) === Base.BINDING_KIND_GUARD
+        if Base.binding_kind(bpart) === Base.PARTITION_KIND_GUARD
             println(io, "Binding ", quot, "`", binding, "`", quot, " does not exist.")
         else
             println(io, "Binding ", quot, "`", binding, "`", quot, " exists, but has not been assigned a value.")

--- a/test/rebinding.jl
+++ b/test/rebinding.jl
@@ -4,24 +4,24 @@ module Rebinding
     using Test
     make_foo() = Foo(1)
 
-    @test Base.binding_kind(@__MODULE__, :Foo) == Base.BINDING_KIND_GUARD
+    @test Base.binding_kind(@__MODULE__, :Foo) == Base.PARTITION_KIND_GUARD
     struct Foo
         x::Int
     end
     const defined_world_age = Base.tls_world_age()
     x = Foo(1)
 
-    @test Base.binding_kind(@__MODULE__, :Foo) == Base.BINDING_KIND_CONST
+    @test Base.binding_kind(@__MODULE__, :Foo) == Base.PARTITION_KIND_CONST
     @test !contains(repr(x), "@world")
     Base.delete_binding(@__MODULE__, :Foo)
 
-    @test Base.binding_kind(@__MODULE__, :Foo) == Base.BINDING_KIND_GUARD
+    @test Base.binding_kind(@__MODULE__, :Foo) == Base.PARTITION_KIND_GUARD
     @test contains(repr(x), "@world")
 
     # Test that it still works if Foo is redefined to a non-type
     const Foo = 1
 
-    @test Base.binding_kind(@__MODULE__, :Foo) == Base.BINDING_KIND_CONST
+    @test Base.binding_kind(@__MODULE__, :Foo) == Base.PARTITION_KIND_CONST
     @test contains(repr(x), "@world")
     Base.delete_binding(@__MODULE__, :Foo)
 


### PR DESCRIPTION
This renames the partition flags to start with PARTITION_ and turns the Binding flags into a bitfield that can be accessed atomically in preparation for adding further flags.