### PR TITLE
Bugfix: String indexing in big_str macro

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -699,13 +699,14 @@ macro big_str(s)
     message = "invalid number format $s for BigInt or BigFloat"
     throw_error =  :(throw(ArgumentError($message)))
     if '_' in s
-        # remove _ in s[2:end-1]
-        bf = IOBuffer(maxsize=lastindex(s))
+        # remove _ in s[2:end-1].
+        # Do not allow '_' right before or after dot.
+        bf = IOBuffer(sizehint=ncodeunits(s))
         c = s[1]
         print(bf, c)
         is_prev_underscore = (c == '_')
         is_prev_dot = (c == '.')
-        for c in SubString(s, 2, lastindex(s)-1)
+        for c in SubString(s, nextind(s, 1), prevind(s, lastindex(s)))
             c != '_' && print(bf, c)
             c == '_' && is_prev_dot && return throw_error
             c == '.' && is_prev_underscore && return throw_error

--- a/test/int.jl
+++ b/test/int.jl
@@ -118,6 +118,10 @@ end
     @test big"1.0" == BigFloat(1.0)
     @test_throws ArgumentError big"1.0.3"
     @test_throws ArgumentError big"pi"
+
+    @test_throws ArgumentError big"_æ1"
+    @test_throws ArgumentError big"æ_1"
+    @test_throws ArgumentError big"_ææ"
 end
 
 @test round(UInt8, 123) == 123


### PR DESCRIPTION
Make sure that non-ASCII in the big string macro correctly throws an ArgumentError instead of a string indexing error.