### PR TITLE
add a `firstindex(::Array)` method

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -906,12 +906,6 @@ iterate(A::Array, i=1) = (@inline; (i - 1)%UInt < length(A)%UInt ? (@inbounds A[
 # but this constant folds even when `typeof(a)` is not concretely inferred.
 firstindex(@nospecialize a::Array) = 1
 
-## Indexing: lastindex ##
-
-# Functionality-wise this is redundant with respect to the method for `AbstractArray`,
-# but the return type infers perfectly here even when `typeof(a)` is not concretely inferred.
-lastindex(a::Array) = length(a)
-
 ## Indexing: getindex ##
 
 """

--- a/base/array.jl
+++ b/base/array.jl
@@ -900,6 +900,12 @@ end
 
 iterate(A::Array, i=1) = (@inline; (i - 1)%UInt < length(A)%UInt ? (@inbounds A[i], i + 1) : nothing)
 
+## Indexing: firstindex ##
+
+# Functionality-wise this is redundant with respect to the method for `AbstractArray`,
+# but this constant folds even when `typeof(a)` is not concretely inferred.
+firstindex(@nospecialize a::Array) = 1
+
 ## Indexing: getindex ##
 
 """

--- a/base/array.jl
+++ b/base/array.jl
@@ -906,6 +906,12 @@ iterate(A::Array, i=1) = (@inline; (i - 1)%UInt < length(A)%UInt ? (@inbounds A[
 # but this constant folds even when `typeof(a)` is not concretely inferred.
 firstindex(@nospecialize a::Array) = 1
 
+## Indexing: lastindex ##
+
+# Functionality-wise this is redundant with respect to the method for `AbstractArray`,
+# but the return type infers perfectly here even when `typeof(a)` is not concretely inferred.
+lastindex(a::Array) = length(a)
+
 ## Indexing: getindex ##
 
 """

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2137,6 +2137,11 @@ end
     end
 end
 
+@testset "inference for `firstindex(::Array)`" begin
+    @test Int === Base.infer_return_type(firstindex, Tuple{Array})
+    @test Core.Compiler.is_foldable(Base.infer_effects(firstindex, Tuple{Array}))
+end
+
 @testset "zero for arbitrary axes" begin
     r = SizedArrays.SOneTo(2)
     s = Base.OneTo(2)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2142,10 +2142,6 @@ end
     @test Core.Compiler.is_foldable(Base.infer_effects(firstindex, Tuple{Array}))
 end
 
-@testset "inference for `lastindex(::Array)`" begin
-    @test Int === Base.infer_return_type(lastindex, Tuple{Array})
-end
-
 @testset "zero for arbitrary axes" begin
     r = SizedArrays.SOneTo(2)
     s = Base.OneTo(2)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2142,6 +2142,10 @@ end
     @test Core.Compiler.is_foldable(Base.infer_effects(firstindex, Tuple{Array}))
 end
 
+@testset "inference for `lastindex(::Array)`" begin
+    @test Int === Base.infer_return_type(lastindex, Tuple{Array})
+end
+
 @testset "zero for arbitrary axes" begin
     r = SizedArrays.SOneTo(2)
     s = Base.OneTo(2)


### PR DESCRIPTION
`firstindex(::Array)` should now constant fold even when the type of the argument is not concretely inferred. Should prevent some invalidation on loading user code.