### PR TITLE
`Base`: bootstrap: eliminate `Array`-specific `length` methods

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -312,7 +312,7 @@ julia> length([1 2; 3 4])
 4
 ```
 """
-length(t::AbstractArray) = (@inline; prod(size(t)))
+length(t::AbstractArray)
 
 # `eachindex` is mostly an optimization of `keys`
 eachindex(itrs...) = keys(itrs...)

--- a/base/array.jl
+++ b/base/array.jl
@@ -191,7 +191,6 @@ function size(a::Array, d::Int)
     sz = getfield(a, :size)
     return d > length(sz) ? 1 : getfield(sz, d, false) # @inbounds
 end
-size(a::Array) = getfield(a, :size)
 
 asize_from(a::Array, n) = n > ndims(a) ? () : (size(a,n), asize_from(a, n+1)...)
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -7,10 +7,8 @@ const Callable = Union{Function,Type}
 const Bottom = Union{}
 
 # Define minimal array interface here to help code used in macros:
-length(a::Array{T, 0}) where {T} = 1
-length(a::Array{T, 1}) where {T} = getfield(a, :size)[1]
-length(a::Array{T, 2}) where {T} = (sz = getfield(a, :size); sz[1] * sz[2])
-# other sizes are handled by generic prod definition for AbstractArray
+size(a::Array) = getfield(a, :size)
+length(t::AbstractArray) = (@inline; prod(size(t)))
 length(a::GenericMemory) = getfield(a, :length)
 throw_boundserror(A, I) = (@noinline; throw(BoundsError(A, I)))
 


### PR DESCRIPTION
Three methods of `length` are deleted.

Made possible by moving the following methods to earlier within the bootstrapping:
* `size(a::Array)`
* `length(t::AbstractArray)`

Improves abstract return type inference of `f(x::Array) = length(a)`, presumably because the method count is now low enough for the world-splitting optimization to kick in.