### PR TITLE
unify `prod(::Tuple{Vararg{Int}})` with a single method

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -649,12 +649,15 @@ reverse(t::Tuple) = revargs(t...)
 
 ## specialized reduction ##
 
-prod(x::Tuple{}) = 1
-# This is consistent with the regular prod because there is no need for size promotion
-# if all elements in the tuple are of system size.
-# It is defined here separately in order to support bootstrap, because it's needed earlier
-# than the general prod definition is available.
-prod(x::Tuple{Int, Vararg{Int}}) = *(x...)
+# used in bootstrapping
+function prod(x::Tuple{Vararg{Int}})
+    @_terminates_locally_meta
+    r = 1
+    for y in x
+        r *= y
+    end
+    r
+end
 
 # a version of `in` esp. for NamedTuple, to make it pure, and not compiled for each tuple length
 function sym_in(x::Symbol, itr::Tuple{Vararg{Symbol}})


### PR DESCRIPTION
One less method.