### PR TITLE
`getproperty(::Type,f::Symbol)`: type assert when `f === :parameters`

### DIFF
--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -46,7 +46,15 @@ macro _boundscheck() Expr(:boundscheck) end
 # with ambiguities by defining a few common and critical operations
 # (and these don't need the extra convert code)
 getproperty(x::Module, f::Symbol) = (@inline; getglobal(x, f))
-getproperty(x::Type, f::Symbol) = (@inline; getfield(x, f))
+function getproperty(x::Type, f::Symbol)
+    @inline
+    if f === :parameters
+        # Ensure `type.parameters` has perfect type inference even when `type` is
+        # not completely determined at compile time.
+        x = x::DataType
+    end
+    getfield(x, f)
+end
 setproperty!(x::Type, f::Symbol, v) = error("setfield! fields of Types should not be changed")
 setproperty!(x::Array, f::Symbol, v) = error("setfield! fields of Array should not be changed")
 getproperty(x::Tuple, f::Int) = (@inline; getfield(x, f))

--- a/test/core.jl
+++ b/test/core.jl
@@ -827,6 +827,12 @@ function issue23618(a::AbstractVector)
 end
 @test Base.infer_return_type(issue23618, (Vector{Int},)) == Vector{Set{Int}}
 
+@testset "type inference for getting the `parameters` field of a type" begin
+    let f(x) = x.parameters
+        @test Base.infer_return_type(f, Tuple{DataType}) === Base.infer_return_type(f, Tuple{Type})
+    end
+end
+
 # ? syntax
 @test (true ? 1 : false ? 2 : 3) == 1
 


### PR DESCRIPTION
It is common to access the `parameters` field of a `DataType` using `getproperties`. However, when the first argument is not inferred as `DataType`, the return type infers as `Any`, instead of as `Core.SimpleVector`. I believe this causes much type instability and invalidation.

The proper fix would probably be to introduce a getter function, something like `_get_datatype_parameters(x::DataType) = x.parameters`, then use the getter instead of directly using `getproperties`. For `Compiler`, we may have to introduce a getter anyway, as `Compiler.getproperty === Core.getfield`, but outside of the compiler this seems like a good enough hacky fix.