### PR TITLE
bootstrap: Handle unavailable `Base._return_type`

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1384,6 +1384,8 @@ verify_typeinf_trim(io::IO, codeinfos::Vector{Any}, onlywarn::Bool) = (msg = "--
 verify_typeinf_trim(codeinfos::Vector{Any}, onlywarn::Bool) = invokelatest(verify_typeinf_trim, stdout, codeinfos, onlywarn)
 
 function return_type(@nospecialize(f), t::DataType) # this method has a special tfunc
+    bootstrapping_compiler && return Any # unavailable during bootstrap
+
     world = tls_world_age()
     args = Any[_return_type, NativeInterpreter(world), Tuple{Core.Typeof(f), t.parameters...}]
     return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Any}, Cint), args, length(args))
@@ -1399,6 +1401,8 @@ function return_type(t::DataType)
 end
 
 function return_type(t::DataType, world::UInt)
+    bootstrapping_compiler && return Any # unavailable during bootstrap
+
     args = Any[_return_type, NativeInterpreter(world), t]
     return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Any}, Cint), args, length(args))
 end


### PR DESCRIPTION
Make sure not to `MethodError` if anyone tries to call `ntuple(...)` in Compiler