### PR TITLE
lowering: Fix captured vars shadowed by an inner global declaration

### DIFF
--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -136,12 +136,14 @@ inside of another local scope, the scope it creates is nested inside of all the
 local scopes that it appears within, which are all ultimately nested inside of
 the global scope of the module in which the code is evaluated. Variables in
 outer scopes are visible from any scope they contain — meaning that they can be
-read and written in inner scopes — unless there is a local variable with the
-same name that "shadows" the outer variable of the same name. This is true even
-if the outer local is declared after (in the sense of textually below) an inner
+read and written in inner scopes — unless there is a variable with the same name
+that "shadows" the outer variable of the same name. This is true even if the
+outer local is declared after (in the sense of textually below) an inner
 block. When we say that a variable "exists" in a given scope, this means that a
 variable by that name exists in any of the scopes that the current scope is
-nested inside of, including the current one.
+nested inside of, including the current one. If a variable's value is used in a
+local scope, but nothing with its name exists in this scope, it is assumed to be
+a global.
 
 Some programming languages require explicitly declaring new variables before
 using them. Explicit declaration works in Julia too: in any local scope, writing

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3317,11 +3317,11 @@
 (define (lambda-all-vars e)
   (append (lam:argnames e) (caddr e)))
 
-;; compute set of variables referenced in a lambda but not bound by it
+;; compute set of non-global variables referenced in a lambda but not bound by it
 (define (free-vars- e tab)
   (cond ((or (eq? e UNUSED) (underscore-symbol? e)) tab)
         ((symbol? e) (put! tab e #t))
-        ((and (pair? e) (eq? (car e) 'globalref)) tab)
+        ((and (pair? e) (memq (car e) '(global globalref))) tab)
         ((and (pair? e) (eq? (car e) 'break-block)) (free-vars- (caddr e) tab))
         ((and (pair? e) (eq? (car e) 'with-static-parameters)) (free-vars- (cadr e) tab))
         ((or (atom? e) (quoted? e)) tab)
@@ -3345,9 +3345,15 @@
               vi)
     tab))
 
+;; env:      list of vinfo (includes any closure #self#; should not include globals)
+;; captvars: list of vinfo
+;; sp:       list of symbol
+;; new-sp:   list of symbol (static params declared here)
+;; methsig:  `(call (core svec) ...)
+;; tab:      table of (name . var-info)
 (define (analyze-vars-lambda e env captvars sp new-sp methsig tab)
   (let* ((args (lam:args e))
-         (locl (caddr e))
+         (locl (lam:vinfo e))
          (allv (nconc (map arg-name args) locl))
          (fv   (let* ((fv (diff (free-vars (lam:body e)) allv))
                       ;; add variables referenced in declared types for free vars
@@ -3357,27 +3363,23 @@
                                             fv))))
                  (append (diff dv fv) fv)))
          (sig-fv (if methsig (free-vars methsig) '()))
-         (glo  (find-global-decls (lam:body e)))
          ;; make var-info records for vars introduced by this lambda
          (vi   (nconc
                 (map (lambda (decl) (make-var-info (decl-var decl)))
                      args)
                 (map make-var-info locl)))
-         (capt-sp (filter (lambda (v) (or (and (memq v fv) (not (memq v glo)) (not (memq v new-sp)))
+         (capt-sp (filter (lambda (v) (or (and (memq v fv) (not (memq v new-sp)))
                                           (memq v sig-fv)))
                           sp))
          ;; captured vars: vars from the environment that occur
          ;; in our set of free variables (fv).
          (cv    (append (filter (lambda (v) (and (memq (vinfo:name v) fv)
-                                                 (not (memq (vinfo:name v) new-sp))
-                                                 (not (memq (vinfo:name v) glo))))
+                                                 (not (memq (vinfo:name v) new-sp))))
                                 env)
                         (map make-var-info capt-sp)))
          (new-env (append vi
                           ;; new environment: add our vars
-                          (filter (lambda (v)
-                                    (and (not (memq (vinfo:name v) allv))
-                                         (not (memq (vinfo:name v) glo))))
+                          (filter (lambda (v) (not (memq (vinfo:name v) allv)))
                                   env))))
     (analyze-vars (lam:body e)
                   new-env
@@ -4003,7 +4005,7 @@ f(x) = yt(x)
        ((atom? e) e)
        (else
         (case (car e)
-          ((quote top core globalref thismodule lineinfo line break inert module toplevel null true false meta import using) e)
+          ((quote top core global globalref thismodule lineinfo line break inert module toplevel null true false meta import using) e)
           ((toplevel-only)
            ;; hack to avoid generating a (method x) expr for struct types
            (if (eq? (cadr e) 'struct)


### PR DESCRIPTION
## Bug

As discovered in #57547, lowering isn't resolving references to captured
variables when a global of the same name is declared in any scope in the
current function:

```
julia> let
            g = 1
            function f()
                let; global g = 2; end;
                return g    # g is not resolved
            end; f()
        end
ERROR: Found raw symbol in code returned from lowering. Expected all symbols to
have been resolved to GlobalRef or slots.
```

`resolve-scopes` correctly detects that we're returning the local, but
scope-blocks are removed in this pass.  As a result, `analyze-vars-lambda` finds
more globals than `resolve-scopes` did when calling `find-global-decls` (which
does not peek inside nested scopes) on `f`.  `analyze-vars-lambda` then
calculates the set of captured variables in `f` to be:

```
captvars = (current_env ∩ free_vars) - (new_staticparams ∪ wrong_globals)
```

so `g` in this case is never captured.

As one might expect from the diff, static parameters were affected too:
```
julia> let
           function f(x::T) where T
               function g(x)
                   let; global T = 1; end
                   x::T
               end
           end
       end
ERROR: Found raw symbol in code returned from lowering. Expected all symbols to
have been resolved to GlobalRef or slots.
```

This bug was introduced (revealed, maybe) in #57051---the whole resolution step
used to happen after lowering, so lowering passes disagreeing on scopes would be
less visible.

## Fix

Omit globals from the free variable list in `analyze-vars-lambda` in the first
place.  This way we don't need to call the scope-block-dependant
`find-global-decls`. 

After:
```
julia> let
            g = 1
            function f()
                let; global g = 2; end;
                return g
            end; f()
        end
1

julia> let
           function f(x::T) where T
               function g(x)
                   let; global T = 1; end
                   x::T
               end
           end
       end
(::var"#f#f##1") (generic function with 1 method)
```

Also in this PR:
- To handle our new ability to shadow a captured variable with a global, prevent
  tampering with globals in `cl-convert-`
- Update the manual slightly
