### PR TITLE
Thread wakeup: replace serial wakeup with tree wakeup

### DIFF
--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -219,6 +219,7 @@ typedef struct _jl_tls_states_t {
     // some hidden state (usually just because we don't have the type's size declaration)
 #ifdef JL_LIBRARY_EXPORTS
     uv_mutex_t sleep_lock;
+    int wake_next;
     uv_cond_t wake_signal;
 #endif
 } jl_tls_states_t;


### PR DESCRIPTION
This is still WIP.

Every time a task is scheduled (and in numerous other situations), we would like to ensure that at least one thread is awake to run the task. Currently, we wake _all_ threads, via a serial loop in `wakeup_thread()`. This scales poorly and is inefficient. https://github.com/JuliaLang/julia/pull/56475 reworks this with a "spinner" thread approach. This PR tries a different approach: continue to wake up all threads, but via a tree wakeup rather than serially.