### PR TITLE
typeinfer: Add `force_enable_inference` to override Module-level inference settings

### DIFF
--- a/Compiler/src/types.jl
+++ b/Compiler/src/types.jl
@@ -191,6 +191,10 @@ Parameters that control abstract interpretation-based type inference operation.
   it will `throw`). Defaults to `false` since this assumption does not hold in Julia's
   semantics for native code execution.
 ---
+- `inf_params.force_enable_inference::Bool = false`\\
+  If `true`, inference will be performed on functions regardless of whether it was disabled
+  at the module level via `Base.Experimental.@compiler_options`.
+---
 """
 struct InferenceParams
     max_methods::Int
@@ -202,6 +206,7 @@ struct InferenceParams
     aggressive_constant_propagation::Bool
     assume_bindings_static::Bool
     ignore_recursion_hardlimit::Bool
+    force_enable_inference::Bool
 
     function InferenceParams(
         max_methods::Int,
@@ -212,7 +217,9 @@ struct InferenceParams
         ipo_constant_propagation::Bool,
         aggressive_constant_propagation::Bool,
         assume_bindings_static::Bool,
-        ignore_recursion_hardlimit::Bool)
+        ignore_recursion_hardlimit::Bool,
+        force_enable_inference::Bool,
+    )
         return new(
             max_methods,
             max_union_splitting,
@@ -222,7 +229,9 @@ struct InferenceParams
             ipo_constant_propagation,
             aggressive_constant_propagation,
             assume_bindings_static,
-            ignore_recursion_hardlimit)
+            ignore_recursion_hardlimit,
+            force_enable_inference,
+        )
     end
 end
 function InferenceParams(
@@ -235,7 +244,9 @@ function InferenceParams(
         #=ipo_constant_propagation::Bool=# true,
         #=aggressive_constant_propagation::Bool=# false,
         #=assume_bindings_static::Bool=# false,
-        #=ignore_recursion_hardlimit::Bool=# false);
+        #=ignore_recursion_hardlimit::Bool=# false,
+        #=force_enable_inference::Bool=# false
+    );
     max_methods::Int = params.max_methods,
     max_union_splitting::Int = params.max_union_splitting,
     max_apply_union_enum::Int = params.max_apply_union_enum,
@@ -244,7 +255,9 @@ function InferenceParams(
     ipo_constant_propagation::Bool = params.ipo_constant_propagation,
     aggressive_constant_propagation::Bool = params.aggressive_constant_propagation,
     assume_bindings_static::Bool = params.assume_bindings_static,
-    ignore_recursion_hardlimit::Bool = params.ignore_recursion_hardlimit)
+    ignore_recursion_hardlimit::Bool = params.ignore_recursion_hardlimit,
+    force_enable_inference::Bool = params.force_enable_inference,
+)
     return InferenceParams(
         max_methods,
         max_union_splitting,
@@ -254,7 +267,9 @@ function InferenceParams(
         ipo_constant_propagation,
         aggressive_constant_propagation,
         assume_bindings_static,
-        ignore_recursion_hardlimit)
+        ignore_recursion_hardlimit,
+        force_enable_inference,
+    )
 end
 
 """


### PR DESCRIPTION
Allows `--trim` to infer all the way through `__init__()` in JLLWrappers.jl despite [the `@compiler_options` disabling inference](https://github.com/JuliaPackaging/JLLWrappers.jl/blob/ecaba50a4462209714f0979667c64c1bf28ee892/src/toplevel_generators.jl#L55)

Required for #57587. 