### PR TITLE
Fix julia.h for use in MSVC

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -727,7 +727,15 @@ static const uint8_t PARTITION_FLAG_DEPRECATED     = 0x20;
 // where calling the function itself will provide a (better) deprecation warning/error.
 static const uint8_t PARTITION_FLAG_DEPWARN        = 0x40;
 
-typedef struct __attribute__((aligned(8))) _jl_binding_partition_t {
+#if defined(_COMPILER_MICROSOFT_)
+#define JL_ALIGNED_ATTR(alignment) \
+    __declspec(align(alignment))
+#else
+#define JL_ALIGNED_ATTR(alignment) \
+    __attribute__((aligned(alignment)))
+#endif
+
+typedef struct JL_ALIGNED_ATTR(8) _jl_binding_partition_t {
     JL_DATA_TYPE
     /* union {
      *   // For ->kind == PARTITION_KIND_GLOBAL


### PR DESCRIPTION
Since `__attribute__` is only valid for (mostly?) GCC and Clang, building libraries against Julia with MSVC is currently not working. This change should fix that.