### PR TITLE
trimming: improve output on failure

### DIFF
--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -327,12 +327,15 @@ function verify_typeinf_trim(io::IO, codeinfos::Vector{Any}, onlywarn::Bool)
     end
 
     let severity = 0
-        if counts[2] > 0
-            print("Trim verify finished with ", counts[2], counts[2] == 1 ? " warning.\n\n" : " warnings.\n\n")
+        if counts[1] > 0 || counts[2] > 0
+            print("Trim verify finished with ")
+            print(counts[1], counts[1] == 1 ? " error" : " errors")
+            print(", ")
+            print(counts[2], counts[2] == 1 ? " warning" : " warnings")
+            print(".\n")
             severity = 2
         end
         if counts[1] > 0
-            print("Trim verify finished with ", counts[1], counts[1] == 1 ? " error.\n\n" : " errors.\n\n")
             severity = 1
         end
         # messages classified as errors are fatal, warnings are not

--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -339,7 +339,7 @@ function verify_typeinf_trim(io::IO, codeinfos::Vector{Any}, onlywarn::Bool)
             severity = 1
         end
         # messages classified as errors are fatal, warnings are not
-        0 < severity <= 1 && !onlywarn && error("verify_typeinf_trim failed")
+        0 < severity <= 1 && !onlywarn && throw(Core.TrimFailure())
     end
     nothing
 end

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -475,6 +475,7 @@ struct ABIOverride
 end
 
 struct PrecompilableError <: Exception end
+struct TrimFailure <: Exception end
 
 String(s::String) = s  # no constructor yet
 

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -2,6 +2,7 @@
 
 // Pointers that are exposed through the public libjulia
 #define JL_EXPORTED_DATA_POINTERS(XX) \
+    XX(jl_abioverride_type) \
     XX(jl_abstractarray_type) \
     XX(jl_abstractstring_type) \
     XX(jl_addrspace_type) \
@@ -65,6 +66,8 @@
     XX(jl_interrupt_exception) \
     XX(jl_intrinsic_type) \
     XX(jl_kwcall_func) \
+    XX(jl_libdl_module) \
+    XX(jl_libdl_dlopen_func) \
     XX(jl_lineinfonode_type) \
     XX(jl_linenumbernode_type) \
     XX(jl_llvmpointer_type) \
@@ -108,6 +111,7 @@
     XX(jl_pinode_type) \
     XX(jl_pointer_type) \
     XX(jl_pointer_typename) \
+    XX(jl_precompilable_error) \
     XX(jl_quotenode_type) \
     XX(jl_readonlymemory_exception) \
     XX(jl_ref_type) \
@@ -116,12 +120,12 @@
     XX(jl_simplevector_type) \
     XX(jl_slotnumber_type) \
     XX(jl_ssavalue_type) \
-    XX(jl_abioverride_type) \
     XX(jl_stackovf_exception) \
     XX(jl_string_type) \
     XX(jl_symbol_type) \
     XX(jl_task_type) \
     XX(jl_top_module) \
+    XX(jl_trimfailure_type) \
     XX(jl_true) \
     XX(jl_tuple_typename) \
     XX(jl_tvar_type) \
@@ -149,9 +153,6 @@
     XX(jl_voidpointer_type) \
     XX(jl_void_type) \
     XX(jl_weakref_type) \
-    XX(jl_libdl_module) \
-    XX(jl_libdl_dlopen_func) \
-    XX(jl_precompilable_error) \
 
 // Data symbols that are defined inside the public libjulia
 #define JL_EXPORTED_DATA_SYMBOLS(XX) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3934,27 +3934,30 @@ void post_boot_hooks(void)
     jl_int32_type->super = jl_signed_type;
     jl_int64_type->super = jl_signed_type;
 
-    jl_errorexception_type = (jl_datatype_t*)core("ErrorException");
-    jl_stackovf_exception  = jl_new_struct_uninit((jl_datatype_t*)core("StackOverflowError"));
-    jl_diverror_exception  = jl_new_struct_uninit((jl_datatype_t*)core("DivideError"));
-    jl_undefref_exception  = jl_new_struct_uninit((jl_datatype_t*)core("UndefRefError"));
-    jl_undefvarerror_type  = (jl_datatype_t*)core("UndefVarError");
-    jl_fielderror_type     = (jl_datatype_t*)core("FieldError");
-    jl_atomicerror_type    = (jl_datatype_t*)core("ConcurrencyViolationError");
-    jl_interrupt_exception = jl_new_struct_uninit((jl_datatype_t*)core("InterruptException"));
-    jl_boundserror_type    = (jl_datatype_t*)core("BoundsError");
-    jl_memory_exception    = jl_new_struct_uninit((jl_datatype_t*)core("OutOfMemoryError"));
+    jl_stackovf_exception       = jl_new_struct_uninit((jl_datatype_t*)core("StackOverflowError"));
+    jl_diverror_exception       = jl_new_struct_uninit((jl_datatype_t*)core("DivideError"));
+    jl_undefref_exception       = jl_new_struct_uninit((jl_datatype_t*)core("UndefRefError"));
+    jl_interrupt_exception      = jl_new_struct_uninit((jl_datatype_t*)core("InterruptException"));
+    jl_memory_exception         = jl_new_struct_uninit((jl_datatype_t*)core("OutOfMemoryError"));
     jl_readonlymemory_exception = jl_new_struct_uninit((jl_datatype_t*)core("ReadOnlyMemoryError"));
-    jl_typeerror_type      = (jl_datatype_t*)core("TypeError");
-    jl_argumenterror_type  = (jl_datatype_t*)core("ArgumentError");
-    jl_methoderror_type    = (jl_datatype_t*)core("MethodError");
-    jl_loaderror_type      = (jl_datatype_t*)core("LoadError");
-    jl_initerror_type      = (jl_datatype_t*)core("InitError");
+    jl_precompilable_error      = jl_new_struct_uninit((jl_datatype_t*)core("PrecompilableError"));
+
+    jl_errorexception_type   = (jl_datatype_t*)core("ErrorException");
+    jl_undefvarerror_type    = (jl_datatype_t*)core("UndefVarError");
+    jl_fielderror_type       = (jl_datatype_t*)core("FieldError");
+    jl_atomicerror_type      = (jl_datatype_t*)core("ConcurrencyViolationError");
+    jl_boundserror_type      = (jl_datatype_t*)core("BoundsError");
+    jl_typeerror_type        = (jl_datatype_t*)core("TypeError");
+    jl_argumenterror_type    = (jl_datatype_t*)core("ArgumentError");
+    jl_methoderror_type      = (jl_datatype_t*)core("MethodError");
+    jl_loaderror_type        = (jl_datatype_t*)core("LoadError");
+    jl_initerror_type        = (jl_datatype_t*)core("InitError");
     jl_missingcodeerror_type = (jl_datatype_t*)core("MissingCodeError");
-    jl_precompilable_error = jl_new_struct_uninit((jl_datatype_t*)core("PrecompilableError"));
-    jl_pair_type           = core("Pair");
-    jl_kwcall_func         = core("kwcall");
-    jl_kwcall_mt           = ((jl_datatype_t*)jl_typeof(jl_kwcall_func))->name->mt;
+    jl_trimfailure_type      = (jl_datatype_t*)core("TrimFailure");
+
+    jl_pair_type             = core("Pair");
+    jl_kwcall_func           = core("kwcall");
+    jl_kwcall_mt             = ((jl_datatype_t*)jl_typeof(jl_kwcall_func))->name->mt;
     jl_atomic_store_relaxed(&jl_kwcall_mt->max_args, 0);
 
     jl_weakref_type = (jl_datatype_t*)core("WeakRef");

--- a/src/julia.h
+++ b/src/julia.h
@@ -1012,6 +1012,7 @@ extern JL_DLLIMPORT jl_datatype_t *jl_undefvarerror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_fielderror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_atomicerror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_missingcodeerror_type JL_GLOBALLY_ROOTED;
+extern JL_DLLIMPORT jl_datatype_t *jl_trimfailure_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_lineinfonode_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_abioverride_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_value_t *jl_stackovf_exception JL_GLOBALLY_ROOTED;

--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -382,7 +382,14 @@ static void *jl_precompile_trimmed(size_t world)
             jl_array_ptr_1d_push(m, ccallable);
     }
 
-    void *native_code = jl_create_native(m, NULL, jl_options.trim, 0, world);
+    void *native_code = NULL;
+    JL_TRY {
+        native_code = jl_create_native(m, NULL, jl_options.trim, 0, world);
+    } JL_CATCH {
+        // The verification check (presumably) failed. The error message should
+        // already have been printed, so just give up here (w/o a stack trace).
+        exit(1);
+    }
     JL_GC_POP();
     return native_code;
 }

--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -386,8 +386,12 @@ static void *jl_precompile_trimmed(size_t world)
     JL_TRY {
         native_code = jl_create_native(m, NULL, jl_options.trim, 0, world);
     } JL_CATCH {
-        // The verification check (presumably) failed. The error message should
-        // already have been printed, so just give up here (w/o a stack trace).
+        jl_value_t *exc = jl_current_exception(jl_current_task);
+        if (!jl_isa(exc, (jl_value_t*)jl_trimfailure_type))
+            jl_rethrow(); // unexpected exception, expose the stacktrace
+
+        // The verification check failed. The error message should already have
+        // been printed, so give up here and exit (w/o a stack trace).
         exit(1);
     }
     JL_GC_POP();

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -102,7 +102,7 @@ extern "C" {
 // TODO: put WeakRefs on the weak_refs list during deserialization
 // TODO: handle finalizers
 
-#define NUM_TAGS    196
+#define NUM_TAGS    197
 
 // An array of references that need to be restored from the sysimg
 // This is a manually constructed dual of the gvars array, which would be produced by codegen for Julia code, for C.
@@ -250,6 +250,7 @@ jl_value_t **const*const get_tags(void) {
         INSERT_TAG(jl_atomicerror_type);
         INSERT_TAG(jl_missingcodeerror_type);
         INSERT_TAG(jl_precompilable_error);
+        INSERT_TAG(jl_trimfailure_type);
 
         // other special values
         INSERT_TAG(jl_emptysvec);


### PR DESCRIPTION
Remove the unnecessary stack trace and print the error/warning summary on a single line.

Before:
```console
...
Trim verify finished with 1 warning.

Trim verify finished with 57 errors.

fatal: error thrown and no exception handler available.
ErrorException("verify_typeinf_trim failed")
error at ./error.jl:44
verify_typeinf_trim at ./../usr/share/julia/Compiler/src/verifytrim.jl:341
unknown function (ip: 0x7314d73ccaaa) at (unknown file)
jl_apply at /home/user/jc/jh-juliac-mwe/julia/src/julia.h:2320 [inlined]
jl_f__call_latest at /home/user/jc/jh-juliac-mwe/julia/src/builtins.c:883
#invokelatest#1 at ./essentials.jl:1090 [inlined]
invokelatest at ./essentials.jl:1086 [inlined]
verify_typeinf_trim at ./../usr/share/julia/Compiler/src/typeinfer.jl:1371 [inlined]
typeinf_ext_toplevel at ./../usr/share/julia/Compiler/src/typeinfer.jl:1365
jfptr_typeinf_ext_toplevel_124479 at /home/user/jc/jh-juliac-mwe/julia/usr/lib/julia/sys.so (unknown line)
jl_apply at /home/user/jc/jh-juliac-mwe/julia/src/julia.h:2320 [inlined]
jl_create_native_impl at /home/user/jc/jh-juliac-mwe/julia/src/aotcompile.cpp:667
jl_precompile_trimmed at /home/user/jc/jh-juliac-mwe/julia/src/precompile_utils.c:385 [inlined]
ijl_create_system_image at /home/user/jc/jh-juliac-mwe/julia/src/staticdata.c:3419
ijl_write_compiler_output at /home/user/jc/jh-juliac-mwe/julia/src/precompile.c:155
ijl_atexit_hook at /home/user/jc/jh-juliac-mwe/julia/src/init.c:278
jl_repl_entrypoint at /home/user/jc/jh-juliac-mwe/julia/src/jlapi.c:1125
main at /home/user/jc/jh-juliac-mwe/julia/cli/loader_exe.c:58
unknown function (ip: 0x7314e1029d8f) at /lib/x86_64-linux-gnu/libc.so.6
__libc_start_main at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
_start at /home/user/jc/jh-juliac-mwe/julia/usr/bin/julia (unknown line)

Failed to compile ./test/trimming/hello.jl
```

After:
```console
...
Trim verify finished with 57 errors, 1 warning.

Failed to compile ./test/trimming/hello.jl
```