### PR TITLE
lock: Specialize `OncePerX` more aggressively

### DIFF
--- a/test/trimming/hello.jl
+++ b/test/trimming/hello.jl
@@ -1,6 +1,13 @@
 module MyApp
+
+world::String = "world!"
+const str = OncePerProcess{String}() do
+    return "Hello, " * world
+end
+
 Base.@ccallable function main()::Cint
-    println(Core.stdout, "Hello, world!")
+    println(Core.stdout, str())
     return 0
 end
+
 end


### PR DESCRIPTION
Accidental regression from https://github.com/JuliaLang/julia/pull/57289. Due to the different specialization rules for `Function` types, the `@noinline` bodies were inferring very poorly treating `once` as a `Function` instead of the much more specific `OncePerX{T,F}`.

Adds a trimming test case so that we don't regress again.