### PR TITLE
Clarify objectid doc

### DIFF
--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -832,7 +832,8 @@ isbits(@nospecialize x) = isbitstype(typeof(x))
 """
     objectid(x) -> UInt
 
-Get a hash value for `x` based on object identity.
+Get a hash value for `x` based on object identity. This value is not unique nor
+stable between Julia processes or versions.
 
 If `x === y` then `objectid(x) == objectid(y)`, and usually when `x !== y`, `objectid(x) != objectid(y)`.
 


### PR DESCRIPTION
Clarifies the `objectid` documentation based on the discussion in #57477.

Close #57477.
