### PR TITLE
feat(markdown): support both en dash and em dash in Markdown parsing

### DIFF
--- a/stdlib/Markdown/src/Common/inline.jl
+++ b/stdlib/Markdown/src/Common/inline.jl
@@ -166,7 +166,10 @@ function linebreak(stream::IO, md::MD)
 end
 
 @trigger '-' ->
-function en_dash(stream::IO, md::MD)
+function en_or_em_dash(stream::IO, md::MD)
+    if startswith(stream, "---")
+        return "—"
+    end
     if startswith(stream, "--")
         return "–"
     end

--- a/stdlib/Markdown/src/GitHub/GitHub.jl
+++ b/stdlib/Markdown/src/GitHub/GitHub.jl
@@ -60,5 +60,5 @@ end
 @flavor github [list, indentcode, blockquote, admonition, footnote, fencedcode, hashheader,
                 github_table, github_paragraph,
 
-                linebreak, escapes, en_dash, inline_code, asterisk_bold,
+                linebreak, escapes, en_or_em_dash, inline_code, asterisk_bold,
                 underscore_bold, asterisk_italic, underscore_italic, image, footnote_link, link, autolink]

--- a/stdlib/Markdown/src/Julia/Julia.jl
+++ b/stdlib/Markdown/src/Julia/Julia.jl
@@ -10,5 +10,5 @@ include("interp.jl")
 @flavor julia [blocktex, blockinterp, hashheader, list, indentcode, fencedcode,
                blockquote, admonition, footnote, github_table, horizontalrule, setextheader, paragraph,
 
-               linebreak, escapes, tex, interp, en_dash, inline_code,
+               linebreak, escapes, tex, interp, en_or_em_dash, inline_code,
                asterisk_bold, underscore_bold, asterisk_italic, underscore_italic, image, footnote_link, link, autolink]

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1267,6 +1267,27 @@ end
     @test sprint(show, MIME("text/plain"), s) == "  Misc:\n  - line\n   break"
 end
 
+@testset "pullrequest #57664: en_or_em_dash" begin
+    # Test that two hyphens (--) is parsed as en dash (–)
+    # and three hyphens (---) is parsed as em dash (—)
+    hyphen_text = md"foo - bar"
+    en_dash_text = md"foo -- bar"
+    em_dash_text = md"foo --- bar"
+
+    @test sprint(show, "text/markdown", hyphen_text) == "foo - bar\n"
+    @test sprint(show, "text/markdown", en_dash_text) == "foo – bar\n"
+    @test sprint(show, "text/markdown", em_dash_text) == "foo — bar\n"
+
+    # Test that parsing works for hyphen-minus (-), en dash (–) and em dash (—)
+    hyphen_text = md"foo - bar"
+    en_dash_text = md"foo – bar"
+    em_dash_text = md"foo — bar"
+
+    @test hyphen_text |> Markdown.plain == "foo - bar\n"
+    @test en_dash_text |> Markdown.plain == "foo – bar\n"
+    @test em_dash_text |> Markdown.plain == "foo — bar\n"
+end
+
 @testset "pullrequest #41552: a code block has \\end{verbatim}" begin
     s1 = md"""
          ```tex


### PR DESCRIPTION
This PR adds support for em dash in Markdown parsing.

