### PR TITLE
Compiler: `abstract_apply`: declare type of two closure captures

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -1736,8 +1736,8 @@ function abstract_apply(interp::AbstractInterpreter, argtypes::Vector{Any}, si::
     retinfos = ApplyCallInfo[]
     retinfo = UnionSplitApplyCallInfo(retinfos)
     exctype = Union{}
-    ctypes´ = Vector{Any}[]
-    infos´ = Vector{MaybeAbstractIterationInfo}[]
+    ctypes´::Vector{Vector{Any}} = Vector{Any}[]
+    infos´::Vector{Vector{MaybeAbstractIterationInfo}} = Vector{MaybeAbstractIterationInfo}[]
     local ti, argtypesi
     local ctfuture::Future{AbstractIterationResult}
     local callfuture::Future{CallMeta}


### PR DESCRIPTION
These two local variables were, unlike some other ones, missing type declarations. The type declarations are helpful becase the variables get captured and assigned to in the closure `infercalls`, resulting in bad type inference without the type declarations.

I don't think there's any drawback to adding the type declarations:
* the declared type is concrete
* conversion shouldn't ever happen, as only values of the same type get assigned to these variables

This change decreases the number of invalidations on loading package TypeDomainNaturalNumbers v6.1.0 (without first loading the REPL) from 981 to 968. The comparison is on top of
eba2a337f914462b47a26fb30939155beab72ace.