### PR TITLE
display "(empty range)" in case of empty ranges

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -16,7 +16,7 @@ function show(io::IO, ::MIME"text/plain", r::UnitRange)
     show(io, first(r))
     print(io, ':')
     show(io, last(r))
-    if !get(io, :compact, false) && isempty(r)
+    if !(get(io, :compact, false)::Bool) && isempty(r)
         print(io, " (empty range)")
     end
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -14,7 +14,7 @@ show(io::IO, ::MIME"text/plain", r::AbstractRange) = show(io, r) # always use th
 
 function show(io::IO, ::MIME"text/plain", r::UnitRange)
     print(io, repr(first(r)), ':', repr(last(r)))
-    if isempty(r)
+    if !get(io, :compact, false) && isempty(r)
         print(io, " (empty range)")
     end
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -13,7 +13,9 @@ end
 show(io::IO, ::MIME"text/plain", r::AbstractRange) = show(io, r) # always use the compact form for printing ranges
 
 function show(io::IO, ::MIME"text/plain", r::UnitRange)
-    print(io, repr(first(r)), ':', repr(last(r)))
+    show(io, first(r))
+    print(io, ':')
+    show(io, last(r))
     if !get(io, :compact, false) && isempty(r)
         print(io, " (empty range)")
     end

--- a/base/show.jl
+++ b/base/show.jl
@@ -12,6 +12,13 @@ end
 
 show(io::IO, ::MIME"text/plain", r::AbstractRange) = show(io, r) # always use the compact form for printing ranges
 
+function show(io::IO, ::MIME"text/plain", r::UnitRange)
+    print(io, repr(first(r)), ':', repr(last(r)))
+    if isempty(r)
+        print(io, " (empty range)")
+    end
+end
+
 function show(io::IO, ::MIME"text/plain", r::LinRange)
     isempty(r) && return show(io, r)
     # show for LinRange, e.g.

--- a/base/show.jl
+++ b/base/show.jl
@@ -13,9 +13,7 @@ end
 show(io::IO, ::MIME"text/plain", r::AbstractRange) = show(io, r) # always use the compact form for printing ranges
 
 function show(io::IO, ::MIME"text/plain", r::UnitRange)
-    show(io, first(r))
-    print(io, ':')
-    show(io, last(r))
+    show(io, r)
     if !(get(io, :compact, false)::Bool) && isempty(r)
         print(io, " (empty range)")
     end

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -336,13 +336,13 @@ julia> searchsorted([1, 2, 4, 5, 5, 7], 5) # multiple matches
 4:5
 
 julia> searchsorted([1, 2, 4, 5, 5, 7], 3) # no match, insert in the middle
-3:2
+3:2 (empty range)
 
 julia> searchsorted([1, 2, 4, 5, 5, 7], 9) # no match, insert at end
-7:6
+7:6 (empty range)
 
 julia> searchsorted([1, 2, 4, 5, 5, 7], 0) # no match, insert at start
-1:0
+1:0 (empty range)
 
 julia> searchsorted([1=>"one", 2=>"two", 2=>"two", 4=>"four"], 2=>"two", by=first) # compare the keys of the pairs
 2:3


### PR DESCRIPTION
As mentioned in #40331, empty ranges could be confusing. This pr adds a message "(empty range)" incase if the range is empty. 
So for the example given in the issue
```sh
julia> a = 1:3
1:3

julia> b = 5:6
5:6

julia> intersect(a,b)  # old behaviour
5:4

julia> intersect(a,b)  # new behaviour
5:4 (empty range)
```