### PR TITLE
Remove obsolete comment

### DIFF
--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -14,8 +14,6 @@ extern "C" {
 // this flag controls when data actually moves out to the underlying I/O
 // channel. memory streams are a special case of this where the data
 // never moves out.
-
-//make it compatible with UV Handles
 typedef enum { bm_none=1000, bm_line, bm_block, bm_mem } bufmode_t;
 typedef enum { bst_none, bst_rd, bst_wr } bufstate_t;
 


### PR DESCRIPTION
The `bufmode_t` enum was added to `src/support/ios.h` in d316c93ab3cca456b4cd37f5859ff472550ea2d3 by Jeff Bezanson with the comment

```c
// this flag controls when data actually moves out to the underlying I/O
// channel. memory streams are a special case of this where the data
// never moves out.
typedef enum { bm_none, bm_line, bm_block, bm_mem } bufmode_t;
```

In 30aed865b713a546d2d2eb44b88b43aa1c27e1ed Keno Fischer added a new comment and modified the enum:

```diff
 // this flag controls when data actually moves out to the underlying I/O
 // channel. memory streams are a special case of this where the data
 // never moves out.
-typedef enum { bm_none, bm_line, bm_block, bm_mem } bufmode_t;
+
+//make it compatible with UV Handles
+typedef enum { bm_none=UV_HANDLE_TYPE_MAX+1, bm_line, bm_block, bm_mem } bufmode_t;
```

In c12aca890a8ae387d11db0b54351f8b61305c00b Jameson Nash removed `uv.h` and updated the enum definition to no longer use `UV_HANDLE_TYPE_MAX`:

```diff
-typedef enum { bm_none=UV_HANDLE_TYPE_MAX+1, bm_line, bm_block, bm_mem } bufmode_t;
+typedef enum { bm_none=1000, bm_line, bm_block, bm_mem } bufmode_t;
```

This last change made the comment by Keno Fischer seemingly obsolete, yet the comment remains. This pull request simply removes the two lines remaining from Keno Fischer's commit. Perhaps it is better to update the comment to explain why `bm_none` now has the value `1000` but I did not dig deep enough into the changes to figure out if this value is significant in some way that should be documented.