### PR TITLE
Improve documentation of run(Cmd)

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -500,12 +500,16 @@ exiting with a non-zero status (when `wait` is true).
 The `args...` allow you to pass through file descriptors to the command, and are ordered
 like regular unix file descriptors (eg `stdin, stdout, stderr, FD(3), FD(4)...`).
 
-If `wait` is false, the process runs asynchronously. You can later wait for it and check
-its exit status by calling `success` on the returned process object.
+If `wait` is false, the process runs asynchronously. You can later [`wait`](@ref) for it
+and check its exit status by calling `success` on the returned process object. If the
+`command` spawns only a single process, a `Process` object is returned and the
+exit code can be retrieved via the `exitcode` field; see [`wait`](@ref) for more details.
 
 When `wait` is false, the process' I/O streams are directed to `devnull`.
 When `wait` is true, I/O streams are shared with the parent process.
 Use [`pipeline`](@ref) to control I/O redirection.
+
+See also: [`Cmd`](@ref).
 """
 function run(cmds::AbstractCmd, args...; wait::Bool = true)
     if wait


### PR DESCRIPTION
This PR aims to make it clearer to new users how `run`, `wait`, and `Process::exitcode` all
interact. This is a comment point of confusion for new users.

It's a bit awkward having `Process` be a sort-of-internal data type, but then expecting
users to use `Process::exitcode`. I think this PR at least makes the current situation
clearer, and design changes can be left alone for now.

Fix #57612.
