### PR TITLE
Skip trailing comma in displaying a 1D `CartesianIndex`

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -91,7 +91,9 @@ module IteratorsMD
     flatten(I::Tuple{Any}) = Tuple(I[1])
     @inline flatten(I::Tuple) = (Tuple(I[1])..., flatten(tail(I))...)
     CartesianIndex(index::Tuple{Vararg{Union{Integer, CartesianIndex}}}) = CartesianIndex(index...)
-    show(io::IO, i::CartesianIndex) = (print(io, "CartesianIndex"); show(io, i.I))
+    show(io::IO, i::CartesianIndex) = (print(io, "CartesianIndex"); _showtuple_skiptrailingcomma(io, i.I))
+    _showtuple_skiptrailingcomma(io, t) = show(io, t)
+    _showtuple_skiptrailingcomma(io, t::Tuple{Any}) = print(io, "(", t[1], ")")
 
     # length
     length(::CartesianIndex{N}) where {N} = N

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -91,9 +91,11 @@ module IteratorsMD
     flatten(I::Tuple{Any}) = Tuple(I[1])
     @inline flatten(I::Tuple) = (Tuple(I[1])..., flatten(tail(I))...)
     CartesianIndex(index::Tuple{Vararg{Union{Integer, CartesianIndex}}}) = CartesianIndex(index...)
-    show(io::IO, i::CartesianIndex) = (print(io, "CartesianIndex"); _showtuple_skiptrailingcomma(io, i.I))
-    _showtuple_skiptrailingcomma(io, t) = show(io, t)
-    _showtuple_skiptrailingcomma(io, t::Tuple{Any}) = print(io, "(", t[1], ")")
+    function show(io::IO, i::CartesianIndex)
+        print(io, "CartesianIndex(")
+        join(io, i.I, ", ")
+        print(io, ")")
+    end
 
     # length
     length(::CartesianIndex{N}) where {N} = N

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -573,3 +573,12 @@ end
     end
     @test t3 == (1, 2, 0)
 end
+
+@testset "CartesianIndex show" begin
+    c = CartesianIndex()
+    @test sprint(show, c) == "CartesianIndex()"
+    c = CartesianIndex(3)
+    @test sprint(show, c) == "CartesianIndex(3)"
+    c = CartesianIndex(3, 3)
+    @test sprint(show, c) == "CartesianIndex(3, 3)"
+end


### PR DESCRIPTION
On nightly v"1.13.0-DEV.186",
```julia
julia> CartesianIndex(3)
CartesianIndex(3,)
```
This PR
```julia
julia> CartesianIndex(3)
CartesianIndex(3)
```
The trailing comma is removed in the displayed form.