### PR TITLE
Generic `Tuple` conversion method from `CartesianIndices`

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -329,7 +329,7 @@ module IteratorsMD
     promote_rule(::Type{CartesianIndices{N,R1}}, ::Type{CartesianIndices{N,R2}}) where {N,R1,R2} =
         CartesianIndices{N,Base.indices_promote_type(R1,R2)}
 
-    convert(::Type{T}, R::CartesianIndices) where {T<:Tuple{Vararg{AbstractRange}}} = convert(T, R.indices)
+    convert(::Type{T}, R::CartesianIndices) where {T<:Tuple{Vararg{OrdinalRange}}} = convert(T, R.indices)
 
     convert(::Type{CartesianIndices{N,R}}, inds::CartesianIndices{N}) where {N,R} =
         CartesianIndices(convert(R, inds.indices))::CartesianIndices{N,R}

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -329,25 +329,7 @@ module IteratorsMD
     promote_rule(::Type{CartesianIndices{N,R1}}, ::Type{CartesianIndices{N,R2}}) where {N,R1,R2} =
         CartesianIndices{N,Base.indices_promote_type(R1,R2)}
 
-    convert(::Type{Tuple{}}, R::CartesianIndices{0}) = ()
-    for RT in (OrdinalRange{Int, Int}, StepRange{Int, Int}, AbstractUnitRange{Int})
-        @eval convert(::Type{NTuple{N,$RT}}, R::CartesianIndices{N}) where {N} =
-            map(x->convert($RT, x), R.indices)
-    end
-    convert(::Type{NTuple{N,AbstractUnitRange}}, R::CartesianIndices{N}) where {N} =
-        convert(NTuple{N,AbstractUnitRange{Int}}, R)
-    convert(::Type{NTuple{N,UnitRange{Int}}}, R::CartesianIndices{N}) where {N} =
-        UnitRange{Int}.(convert(NTuple{N,AbstractUnitRange}, R))
-    convert(::Type{NTuple{N,UnitRange}}, R::CartesianIndices{N}) where {N} =
-        UnitRange.(convert(NTuple{N,AbstractUnitRange}, R))
-    convert(::Type{Tuple{Vararg{AbstractUnitRange{Int}}}}, R::CartesianIndices{N}) where {N} =
-        convert(NTuple{N,AbstractUnitRange{Int}}, R)
-    convert(::Type{Tuple{Vararg{AbstractUnitRange}}}, R::CartesianIndices) =
-        convert(Tuple{Vararg{AbstractUnitRange{Int}}}, R)
-    convert(::Type{Tuple{Vararg{UnitRange{Int}}}}, R::CartesianIndices{N}) where {N} =
-        convert(NTuple{N,UnitRange{Int}}, R)
-    convert(::Type{Tuple{Vararg{UnitRange}}}, R::CartesianIndices) =
-        convert(Tuple{Vararg{UnitRange{Int}}}, R)
+    convert(::Type{T}, R::CartesianIndices) where {T<:Tuple{Vararg{AbstractRange}}} = convert(T, R.indices)
 
     convert(::Type{CartesianIndices{N,R}}, inds::CartesianIndices{N}) where {N,R} =
         CartesianIndices(convert(R, inds.indices))::CartesianIndices{N,R}

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -574,7 +574,7 @@ end
     @test t3 == (1, 2, 0)
 end
 
-@test "Tuple conversions from CartesianIndices" begin
+@testset "Tuple conversions from CartesianIndices" begin
     @test convert(Tuple{}, CartesianIndices(())) === ()
     @testset for t in ((1:4,), (1:4, 3:5))
         st = map(x -> convert(StepRange, x), t)

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -573,3 +573,27 @@ end
     end
     @test t3 == (1, 2, 0)
 end
+
+@test "Tuple conversions from CartesianIndices" begin
+    @test convert(Tuple{}, CartesianIndices(())) === ()
+    @testset for t in ((1:4,), (1:4, 3:5))
+        st = map(x -> convert(StepRange, x), t)
+        C = CartesianIndices(t)
+        @test convert(NTuple{length(t),UnitRange{Int}}, C) == t
+        @test convert(NTuple{length(t),AbstractUnitRange{Int}}, C) == t
+        @test convert(NTuple{length(t),UnitRange}, C) == t
+        @test convert(NTuple{length(t),AbstractUnitRange}, C) == t
+        @test convert(Tuple{Vararg{UnitRange{Int}}}, C) == t
+        @test convert(Tuple{Vararg{AbstractUnitRange{Int}}}, C) == t
+        @test convert(Tuple{Vararg{UnitRange}}, C) == t
+        @test convert(Tuple{Vararg{AbstractUnitRange}}, C) == t
+        @test convert(NTuple{length(t),StepRange{Int,Int}}, C) == st
+        @test convert(NTuple{length(t),OrdinalRange{Int,Int}}, C) == t
+    end
+    @testset for t in ((3:2:5,), (1:1:4, 3:5), (1:1:4, 3:1:5))
+        st = map(x -> convert(StepRange, x), t)
+        C = CartesianIndices(t)
+        @test convert(NTuple{length(t),StepRange{Int,Int}}, C) == st
+        @test convert(NTuple{length(t),OrdinalRange{Int,Int}}, C) == t
+    end
+end


### PR DESCRIPTION
The methods to convert a `CartesianIndices` to a `Tuple` of ranges do the same thing: convert the enclosed ranges. We may therefore merge the multiple methods into a generic one that forwards the conversion to the indices. The behavior should remain identical in general, except missing method errors would be from the `Tuple` conversion rather than from the `CartesianIndices` object. Generalizing the signature here also ensures that we don't accidentally miss out on conversions, such as
```julia
julia> convert(Tuple{Vararg{StepRange{Int,Int}}}, CartesianIndices((1:4, 1:4)))
(1:1:4, 1:1:4)
```
This errors currently, as the corresponding `convert` isn't defined.

Overall, this PR reduces the number of `convert` methods necessary, and makes the code simpler (and easier) to read.

Since the method signature is now broader, it enables calls like
```julia
julia> convert(Tuple{UnitRange{Float64}}, CartesianIndices((1:4,)))
(1.0:4.0,)
```
I'm unsure if this is desirable, but it probably doesn't hurt either.