### PR TITLE
`StepRange` constructor with an `OrdinalRange` argument

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -1326,8 +1326,8 @@ promote_rule(a::Type{StepRange{T1a,T1b}}, ::Type{UR}) where {T1a,T1b,UR<:Abstrac
     promote_rule(a, StepRange{eltype(UR), eltype(UR)})
 StepRange{T1,T2}(r::AbstractRange) where {T1,T2} =
     StepRange{T1,T2}(convert(T1, first(r)), convert(T2, step(r)), convert(T1, last(r)))
-StepRange(r::AbstractUnitRange{T}) where {T} =
-    StepRange{T,T}(first(r), step(r), last(r))
+StepRange(r::OrdinalRange{T,S}) where {T,S} =
+    StepRange{T,S}(first(r), step(r), last(r))
 (StepRange{T1,T2} where T1)(r::AbstractRange) where {T2} = StepRange{eltype(r),T2}(r)
 StepRange(r::StepRangeLen) = StepRange{eltype(r)}(r)
 StepRange{T}(r::StepRangeLen{<:Any,<:Any,S}) where {T,S} = StepRange{T,S}(r)

--- a/base/range.jl
+++ b/base/range.jl
@@ -1321,13 +1321,15 @@ function promote_rule(::Type{StepRange{T1a,T1b}}, ::Type{StepRange{T2a,T2b}}) wh
     el_same(promote_type(T1a, T2a), StepRange{T1a,Tb}, StepRange{T2a,Tb})
 end
 StepRange{T1,T2}(r::StepRange{T1,T2}) where {T1,T2} = r
+StepRange{T}(r::StepRange{T}) where {T} = r
+StepRange(r::StepRange) = r
 
 promote_rule(a::Type{StepRange{T1a,T1b}}, ::Type{UR}) where {T1a,T1b,UR<:AbstractUnitRange} =
     promote_rule(a, StepRange{eltype(UR), eltype(UR)})
 StepRange{T1,T2}(r::AbstractRange) where {T1,T2} =
     StepRange{T1,T2}(convert(T1, first(r)), convert(T2, step(r)), convert(T1, last(r)))
-StepRange(r::OrdinalRange{T,S}) where {T,S} =
-    StepRange{T,S}(first(r), step(r), last(r))
+StepRange(r::OrdinalRange{T,S}) where {T,S} = StepRange{T,S}(first(r), step(r), last(r))
+StepRange{T}(r::OrdinalRange{<:Any,S}) where {T,S} = StepRange{T,S}(first(r), step(r), last(r))
 (StepRange{T1,T2} where T1)(r::AbstractRange) where {T2} = StepRange{eltype(r),T2}(r)
 StepRange(r::StepRangeLen) = StepRange{eltype(r)}(r)
 StepRange{T}(r::StepRangeLen{<:Any,<:Any,S}) where {T,S} = StepRange{T,S}(r)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1299,6 +1299,8 @@ end
     @test convert(StepRange, 0:5) === 0:1:5
     @test convert(StepRange{Int128,Int128}, 0.:5) === Int128(0):Int128(1):Int128(5)
 
+    @test StepRange(1:1:4) === 1:1:4
+
     @test_throws ArgumentError StepRange(1.1,1,5.1)
 
     @test promote(0f0:inv(3f0):1f0, 0.:2.:5.) === (0:1/3:1, 0.:2.:5.)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1300,7 +1300,7 @@ end
     @test convert(StepRange{Int128,Int128}, 0.:5) === Int128(0):Int128(1):Int128(5)
 
     @test StepRange(1:1:4) === 1:1:4
-    @test StepRange{Int32}(1:1:4) === StepRange{Int32,Int64}(1,1,4)
+    @test StepRange{Int32}(1:1:4) === StepRange{Int32,Int}(1,1,4)
 
     struct MyStepRange57718{T,S} <: OrdinalRange{T,S}
         r :: StepRange{T,S}
@@ -1311,7 +1311,7 @@ end
     Base.length(mr::MyStepRange57718) = length(mr.r)
 
     @test StepRange(MyStepRange57718(1:1:4)) === 1:1:4
-    @test StepRange{Int32}(MyStepRange57718(1:1:4)) === StepRange{Int32,Int64}(1,1,4)
+    @test StepRange{Int32}(MyStepRange57718(1:1:4)) === StepRange{Int32,Int}(1,1,4)
 
     @test_throws ArgumentError StepRange(1.1,1,5.1)
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1300,6 +1300,18 @@ end
     @test convert(StepRange{Int128,Int128}, 0.:5) === Int128(0):Int128(1):Int128(5)
 
     @test StepRange(1:1:4) === 1:1:4
+    @test StepRange{Int32}(1:1:4) === StepRange{Int32,Int64}(1,1,4)
+
+    struct MyStepRange57718{T,S} <: OrdinalRange{T,S}
+        r :: StepRange{T,S}
+    end
+    Base.first(mr::MyStepRange57718) = first(mr.r)
+    Base.last(mr::MyStepRange57718) = last(mr.r)
+    Base.step(mr::MyStepRange57718) = step(mr.r)
+    Base.length(mr::MyStepRange57718) = length(mr.r)
+
+    @test StepRange(MyStepRange57718(1:1:4)) === 1:1:4
+    @test StepRange{Int32}(MyStepRange57718(1:1:4)) === StepRange{Int32,Int64}(1,1,4)
 
     @test_throws ArgumentError StepRange(1.1,1,5.1)
 


### PR DESCRIPTION
The `StepRange` constructor currently doesn't convert from a `StepRange`, but similar calls work with other range types such as `StepRangeLen` and `UnitRange`.
```julia
julia> StepRange(2:1:4)
ERROR: MethodError: no method matching StepRange(::StepRange{Int64, Int64})
The type `StepRange` exists, but no method is defined for this combination of argument types when trying to construct it.
```
After this PR, it works:
```julia
julia> StepRange(2:1:4)
2:1:4
```