### PR TITLE
inference: avoid creating `PartialStruct` that never exists at runtime

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -2156,7 +2156,11 @@ function form_partially_defined_struct(𝕃ᵢ::AbstractLattice, @nospecialize(o
     if fields[fldidx] === Union{}
         return nothing # `Union{}` field never transitions to be defined
     end
-    undefs = partialstruct_init_undefs(objt, fldcnt)
+    undefs = partialstruct_init_undefs(objt, fields)
+    if undefs === nothing
+        # this object never exists at runtime, avoid creating unprofitable `PartialStruct`
+        return nothing
+    end
     undefs[fldidx] = false
     return PartialStruct(𝕃ᵢ, objt0, undefs, fields)
 end

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1995,7 +1995,7 @@ function tuple_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any})
     typ = Tuple{params...}
     # replace a singleton type with its equivalent Const object
     issingletontype(typ) && return Const(typ.instance)
-    return anyinfo ? PartialStruct(𝕃, typ, partialstruct_init_undefs(typ, argtypes), argtypes) : typ
+    return anyinfo ? PartialStruct(𝕃, typ, partialstruct_init_undefs(typ, argtypes)::Vector, argtypes) : typ
 end
 
 @nospecs function memorynew_tfunc(𝕃::AbstractLattice, memtype, memlen)

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -755,7 +755,9 @@ end
 
 # Legacy constructor
 function Core.PartialStruct(𝕃::AbstractLattice, @nospecialize(typ), fields::Vector{Any})
-    return PartialStruct(𝕃, typ, partialstruct_init_undefs(typ, fields), fields)
+    undefs = partialstruct_init_undefs(typ, fields)
+    undefs === nothing && error("This object never exists at runtime")
+    return PartialStruct(𝕃, typ, undefs, fields)
 end
 
 function Core.PartialStruct(::AbstractLattice, @nospecialize(typ), undefs::Vector{Union{Nothing,Bool}}, fields::Vector{Any})

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -6382,4 +6382,15 @@ g57292(xs::String...) = getfield(("abc",), 1, :not_atomic, xs...)
 @test Base.infer_return_type(f57292) == String
 @test Base.infer_return_type(g57292) == String
 
+mutable struct Issue57673{C<:Union{Int,Float64}}
+    c::C
+    d
+    Issue57673(c::C, d) where C = new{C}(c, d)
+    Issue57673(c::C) where C = new{C}(c)
+end
+@test Base.infer_return_type((Issue57673,)) do a::Issue57673{<:String}
+    setfield!(a, :d, nothing)
+    a
+end === Union{} # `setfield!` tfunc should be able to figure out this object is runtime invalid
+
 end # module inference


### PR DESCRIPTION
Specifically, when `form_partially_defined_struct` tries to create a `PartialStruct`, this commit adds extra checks to prevent creating it if it doesn't exist at runtime.
While it would be better to avoid propagating these runtime-invalid object types altogether, that would require a major overhaul of the dispatch system. As a fix within the current dispatch system, this commit is proposed.

- closes JuliaLang/julia#57673