### PR TITLE
make `using Foo` in package `Foo` equivalent to `using .Foo`. 

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2383,6 +2383,10 @@ function __require(into::Module, mod::Symbol)
         error("`using/import $mod` outside of a Module detected. Importing a package outside of a module \
          is not allowed during package precompilation.")
     end
+    topmod = moduleroot(into)
+    if nameof(topmod) === mod
+        return topmod
+    end
     @lock require_lock begin
     LOADING_CACHE[] = LoadingCache()
     try

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2360,4 +2360,19 @@ precompile_test_harness("MainImportDisallow") do load_path
     end
 end
 
+precompile_test_harness("Package top-level load itself") do load_path
+    write(joinpath(load_path, "UsingSelf.jl"),
+        """
+        __precompile__(false)
+        module UsingSelf
+        using UsingSelf
+        x = 3
+        end
+          """)
+    @eval using UsingSelf
+    invokelatest() do
+        @test UsingSelf.x == 3
+    end
+end
+
 finish_precompile_test!()


### PR DESCRIPTION
This also applies to submodules where the package module is directly returned instead of doing a full environment lookup.

This allows e.g. packages that fail to precompile and load themselves to not load themselves circularly and more similarly matches the behavior of code being precompiled. It should also be better for performance since there is no need to start looking through environment files.

Should fix some PkgEval failures, for example:
https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/10f5d44_vs_aae2243/GeneralizedMonteCarlo.primary.log
or 
https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/10f5d44_vs_aae2243/YaoBase.primary.log.
