### PR TITLE
REPL: use `@async` to run repl keymap etc. not `@spawn :interactive`

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2927,7 +2927,7 @@ keymap_data(ms::MIState, m::ModalInterface) = keymap_data(state(ms), mode(ms))
 
 function prompt!(term::TextTerminal, prompt::ModalInterface, s::MIState = init_state(term, prompt))
     Base.reseteof(term)
-    t1 = Threads.@spawn :interactive while true
+    t1 = @async while true
         wait(s.async_channel)
         status = @lock s.line_modify_lock begin
             fcn = take!(s.async_channel)
@@ -2942,7 +2942,7 @@ function prompt!(term::TextTerminal, prompt::ModalInterface, s::MIState = init_s
         old_state = mode(s)
         # spawn this because the main repl task is sticky (due to use of @async and _wait2)
         # and we want to not block typing when the repl task thread is busy
-        t2 = Threads.@spawn :interactive while true
+        t2 = @async while true
             eof(term) || peek(term) # wait before locking but don't consume
             @lock s.line_modify_lock begin
                 s.n_keys_pressed += 1


### PR DESCRIPTION
The execution of regular user input happens outside of this scope, but if the user pastes in multiple prompts then those prompts are executed within these tasks.

On a system with no interactive pool, but a > 1 default one, `@spawn :interactive` has free reign to schedule onto any `:default` thread. (Perhaps it shouldn't and just spawn onto 1??)

Some user code doesn't like being run on threads other than the main thread, like GLFW, so weird errors can happen when code is pasted in that doesn't happen otherwise, so this reverts these back to `@async`.

The main task is already sticky for many reasons, so I don't think this is a loss.