### PR TITLE
Libdl: Store path contents as `Tuple` instead of `Vector`

### DIFF
--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -330,10 +330,9 @@ libfoo = LazyLibrary(LazyLibraryPath(prefix, "lib/libfoo.so.1.2.3"))
 ```
 """
 struct LazyLibraryPath
-    pieces::Vector
-    LazyLibraryPath(pieces::Vector) = new(pieces)
+    pieces::Tuple{Vararg{Any}}
+    LazyLibraryPath(pieces...) = new(pieces)
 end
-LazyLibraryPath(args...) = LazyLibraryPath(collect(args))
 Base.string(llp::LazyLibraryPath) = joinpath(String[string(p) for p in llp.pieces])
 Base.cconvert(::Type{Cstring}, llp::LazyLibraryPath) = Base.cconvert(Cstring, string(llp))
 # Define `print` so that we can wrap this in a `LazyString`


### PR DESCRIPTION
This makes `LazyLibraryPath` eligible for const-prop, which is important so that we can inline/infer `string(::LazyLibraryPath)` at compile-time if the argument is a (global) `const`.

Otherwise, this code is not infer-able without something like TypedCallable to make the interface requirements explicit.