### PR TITLE
Add right arrow and end as completion keys

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -823,25 +823,14 @@ function edit_move_right(buf::IOBuffer)
     end
     return false
 end
+
+edit_move_right(s::PromptState) = edit_move_right(s.input_buffer) ? refresh_line(s) : false
+
 function edit_move_right(m::MIState)
     s = state(m)
-    buf = s.input_buffer
-    if edit_move_right(s.input_buffer)
-        refresh_line(s)
-        return true
-    else
-        completions, partial, should_complete = complete_line(s.p.complete, s, m.active_module)
-        if should_complete && eof(buf) && length(completions) == 1 && length(partial) > 1
-            # Replace word by completion
-            prev_pos = position(s)
-            push_undo(s)
-            edit_splice!(s, (prev_pos - sizeof(partial)) => prev_pos, completions[1].completion)
-            refresh_line(state(s))
-            return true
-        else
-            return false
-        end
-    end
+    changed = edit_move_right(s.input_buffer)
+    refresh_line(s)
+    return changed
 end
 
 function edit_move_word_right(s::PromptState)


### PR DESCRIPTION
This PR extends the feature added in #54983 by allowing it to work when there is more than one completion (allowing you to _always_ accept the autosuggestion) and adds `End` as another completion key.
This PR also centralizes the places where completions are managed, rather than in #54983 which split them up.
As in #54983, these two keys only accept completions when there is an autosuggestion presented (the gray text after what you have already typed). Pressing these keys repeatedly won't show a list of completions,
which matches the behavior of similar tools from other environments. These keys are the defaults for other autosuggestions tools I have used like [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions)
and [fish shell](https://fishshell.com/). For users of zsh and fish, this is a more natural setup.
