### PR TITLE
prevent unnecessary compilation while defining `Base.TOML.ValidSigs`

### DIFF
--- a/base/toml_parser.jl
+++ b/base/toml_parser.jl
@@ -770,7 +770,7 @@ isvalid_hex(c::Char) = isdigit(c) || ('a' <= c <= 'f') || ('A' <= c <= 'F')
 isvalid_oct(c::Char) = '0' <= c <= '7'
 isvalid_binary(c::Char) = '0' <= c <= '1'
 
-const ValidSigs = Union{typeof.([isvalid_hex, isvalid_oct, isvalid_binary, isdigit])...}
+const ValidSigs = Union{typeof(isvalid_hex), typeof(isvalid_oct), typeof(isvalid_binary), typeof(isdigit)}
 # This function eats things accepted by `f` but also allows eating `_` in between
 # digits. Returns if it ate at lest one character and if it ate an underscore
 function accept_batch_underscore(l::Parser, f::ValidSigs, fail_if_underscore=true)::Err{Tuple{Bool, Bool}}


### PR DESCRIPTION
Decreases the invalidation count on running the following code from 219 to 191:

```julia
struct I <: Integer end
Base.Int(::I) = 7
```