### PR TITLE
Fix misleading abstract type wording

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -119,6 +119,10 @@ abstract type Number end
 abstract type Real <: Number end
 ```
 [`Number`](@ref) has no supertype, whereas [`Real`](@ref) is an abstract subtype of `Number`.
+
+Note "abstract" is often used to refer to any non-concrete type, even if that type was not declared as `abstract type`.
+For example, `Union` would be called "abstract", even though it is not declared using `abstract type`, because it
+cannot be instantiated.
 """
 kw"abstract type", kw"abstract"
 


### PR DESCRIPTION
This PR fixes the places where a type was called abstract when it is actually non-concrete.
The goal is to consistently use "abstract" to refer to types declared `abstract type` and
refer to all other non-concrete types as such.

Fix #53118.