### PR TITLE
fix: use `foreach` instead `for` in array `append!`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1356,7 +1356,7 @@ end
 
 append!(a::AbstractVector, iter) = _append!(a, IteratorSize(iter), iter)
 push!(a::AbstractVector, iter...) = append!(a, iter)
-append!(a::AbstractVector, iter...) = (for v in iter; append!(a, v); end; return a)
+append!(a::AbstractVector, iter...) = (foreach(v -> append!(a, v), iter); a)
 
 function _append!(a::AbstractVector, ::Union{HasLength,HasShape}, iter)
     n = Int(length(iter))::Int


### PR DESCRIPTION
fixes #55063 

Use `foreach` loop instead of `for` loop in array's `append!` due to it being type-stable.