### PR TITLE
pkgimage.mk: Avoid using environment variable as Makefile variable.

### DIFF
--- a/pkgimage.mk
+++ b/pkgimage.mk
@@ -4,9 +4,10 @@ JULIAHOME := $(SRCDIR)
 include $(JULIAHOME)/Make.inc
 include $(JULIAHOME)/stdlib/stdlib.mk
 
+DEPOTDIR := $(build_prefix)/share/julia
 
 # set some influential environment variables
-export JULIA_DEPOT_PATH := $(shell echo $(call cygpath_w,$(build_prefix)/share/julia))
+export JULIA_DEPOT_PATH := $(shell echo $(call cygpath_w,$(DEPOTDIR)))
 export JULIA_LOAD_PATH := @stdlib$(PATHSEP)$(shell echo $(call cygpath_w,$(JULIAHOME)/stdlib))
 unexport JULIA_PROJECT :=
 unexport JULIA_BINDIR :=
@@ -18,13 +19,13 @@ release: $(BUILDDIR)/stdlib/release.image
 debug: $(BUILDDIR)/stdlib/debug.image
 all: release debug
 
-$(JULIA_DEPOT_PATH)/compiled:
+$(DEPOTDIR)/compiled:
 	mkdir -p $@
 
 print-depot-path:
 	@$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --startup-file=no -e '@show Base.DEPOT_PATH')
 
-$(BUILDDIR)/stdlib/%.image: $(JULIAHOME)/stdlib/Project.toml $(JULIAHOME)/stdlib/Manifest.toml $(INDEPENDENT_STDLIBS_SRCS) $(JULIA_DEPOT_PATH)/compiled
+$(BUILDDIR)/stdlib/%.image: $(JULIAHOME)/stdlib/Project.toml $(JULIAHOME)/stdlib/Manifest.toml $(INDEPENDENT_STDLIBS_SRCS) $(DEPOTDIR)/compiled
 	@$(call PRINT_JULIA, JULIA_CPU_TARGET="$(JULIA_CPU_TARGET)" $(call spawn,$(JULIA_EXECUTABLE)) --startup-file=no -e \
 		'Base.Precompilation.precompilepkgs(configs=[``=>Base.CacheFlags(debug_level=2, opt_level=3), ``=>Base.CacheFlags(check_bounds=1, debug_level=2, opt_level=3)])')
 	touch $@
@@ -33,5 +34,5 @@ $(BUILDDIR)/stdlib/release.image: $(build_private_libdir)/sys.$(SHLIB_EXT)
 $(BUILDDIR)/stdlib/debug.image: $(build_private_libdir)/sys-debug.$(SHLIB_EXT)
 
 clean:
-	rm -rf $(JULIA_DEPOT_PATH)/compiled
+	rm -rf $(DEPOTDIR)/compiled
 	rm -f $(BUILDDIR)/stdlib/*.image


### PR DESCRIPTION
Fixes error when compiling with Wine:
julia/pkgimage.mk:21: *** target pattern contains no '%'.  Stop.
make: *** [Makefile:126: stdlibs-cache-release] Error 2