### PR TITLE
Fix documentation of `jl_gc_collect`

### DIFF
--- a/doc/src/manual/embedding.md
+++ b/doc/src/manual/embedding.md
@@ -449,12 +449,14 @@ jl_gc_wb(jl_array_owner(some_array), some_value);
 
 There are some functions to control the GC. In normal use cases, these should not be necessary.
 
-| Function             | Description                                  |
-|:-------------------- |:-------------------------------------------- |
-| `jl_gc_collect()`    | Force a GC run                               |
-| `jl_gc_enable(0)`    | Disable the GC, return previous state as int |
-| `jl_gc_enable(1)`    | Enable the GC,  return previous state as int |
-| `jl_gc_is_enabled()` | Return current state as int                  |
+| Function                           | Description                                                         |
+| :--------------------------------- | :------------------------------------------------------------------ |
+| `jl_gc_collect(JL_GC_FULL)`        | Force a GC run on all objects                                       |
+| `jl_gc_collect(JL_GC_INCREMENTAL)` | Force a GC run only on young objects                                |
+| `jl_gc_collect(JL_GC_AUTO)`        | Force a GC run, automatically choosing between full and incremental |
+| `jl_gc_enable(0)`                  | Disable the GC, return previous state as int                        |
+| `jl_gc_enable(1)`                  | Enable the GC, return previous state as int                         |
+| `jl_gc_is_enabled()`               | Return current state as int                                         |
 
 ## Working with Arrays
 

--- a/src/gc-interface.h
+++ b/src/gc-interface.h
@@ -97,9 +97,7 @@ JL_DLLEXPORT int jl_gc_is_enabled(void);
 // Sets a soft limit to Julia's heap.
 JL_DLLEXPORT void jl_gc_set_max_memory(uint64_t max_mem);
 // Runs a GC cycle. This function's parameter determines whether we're running an
-// incremental, full, or automatic (i.e. heuristic driven) collection. Returns whether we
-// should run a collection cycle again (e.g. a full mark right after a full sweep to ensure
-// we do a full heap traversal).
+// incremental, full, or automatic (i.e. heuristic driven) collection.
 JL_DLLEXPORT void jl_gc_collect(jl_gc_collection_t collection);
 // Returns whether the thread with `tid` is a collector thread
 JL_DLLEXPORT int gc_is_collector_thread(int tid) JL_NOTSAFEPOINT;


### PR DESCRIPTION
Fix documentation of `jl_gc_collect`:
- wrong signature of `jl_gc_collect` in embedding docs
- docstring referring to values returned by `void` function