### PR TITLE
add the ability to specify the external name of a ccallable

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1371,8 +1371,7 @@ function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim_m
                 end
                 # additionally enqueue the ccallable entrypoint / adapter, which implicitly
                 # invokes the above ci
-                push!(codeinfos, rt)
-                push!(codeinfos, sig)
+                push!(codeinfos, item)
             end
         end
         while !isempty(tocompile)

--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -256,7 +256,7 @@ function get_verify_typeinf_trim(codeinfos::Vector{Any})
     caches = IdDict{MethodInstance,CodeInstance}()
     errors = ErrorList()
     parents = ParentMap()
-    for i = 1:2:length(codeinfos)
+    for i = 1:length(codeinfos)
         item = codeinfos[i]
         if item isa CodeInstance
             push!(inspected, item)
@@ -268,14 +268,14 @@ function get_verify_typeinf_trim(codeinfos::Vector{Any})
             end
         end
     end
-    for i = 1:2:length(codeinfos)
+    for i = 1:length(codeinfos)
         item = codeinfos[i]
         if item isa CodeInstance
             src = codeinfos[i + 1]::CodeInfo
             verify_codeinstance!(item, src, inspected, caches, parents, errors)
-        else
-            rt = item::Type
-            sig = codeinfos[i + 1]::Type
+        elseif item isa SimpleVector
+            rt = item[1]::Type
+            sig = item[2]::Type
             ptr = ccall(:jl_get_specialization1,
                         #= MethodInstance =# Ptr{Cvoid}, (Any, Csize_t, Cint),
                         sig, this_world, #= mt_cache =# 0)

--- a/Compiler/test/verifytrim.jl
+++ b/Compiler/test/verifytrim.jl
@@ -44,8 +44,8 @@ let infos = typeinf_ext_toplevel(Any[Core.svec(Base.SecretBuffer, Tuple{Type{Bas
 
             $""", repr)
 
-    resize!(infos, 2)
-    @test infos[1] isa Type && infos[2] isa Type
+    resize!(infos, 1)
+    @test infos[1] isa Core.SimpleVector && infos[1][1] isa Type && infos[1][2] isa Type
     errors, parents = get_verify_typeinf_trim(infos)
     desc = only(errors)
     @test !desc.first

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -784,9 +784,12 @@ void *jl_emit_native_impl(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvm
                 compiled_functions[codeinst] = {std::move(result_m), std::move(decls)};
         }
         else {
-            jl_value_t *sig = jl_array_ptr_ref(codeinfos, ++i);
-            assert(jl_is_type(item) && jl_is_type(sig));
-            jl_generate_ccallable(clone.getModuleUnlocked(), nullptr, item, sig, params);
+            assert(jl_is_simplevector(item));
+            jl_value_t *rt = jl_svecref(item, 0);
+            jl_value_t *sig = jl_svecref(item, 1);
+            jl_value_t *nameval = jl_svec_len(item) == 2 ? jl_nothing : jl_svecref(item, 2);
+            assert(jl_is_type(rt) && jl_is_type(sig));
+            jl_generate_ccallable(clone.getModuleUnlocked(), nullptr, nameval, rt, sig, params);
         }
     }
     // finally, make sure all referenced methods get fixed up, particularly if the user declined to compile them

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -789,7 +789,7 @@ void *jl_emit_native_impl(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvm
             jl_value_t *sig = jl_svecref(item, 1);
             jl_value_t *nameval = jl_svec_len(item) == 2 ? jl_nothing : jl_svecref(item, 2);
             assert(jl_is_type(rt) && jl_is_type(sig));
-            jl_generate_ccallable(clone.getModuleUnlocked(), nullptr, nameval, rt, sig, params);
+            jl_generate_ccallable(clone.getModuleUnlocked(), nameval, rt, sig, params);
         }
     }
     // finally, make sure all referenced methods get fixed up, particularly if the user declined to compile them

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -70,7 +70,7 @@ JL_DLLEXPORT uint32_t jl_get_LLVM_VERSION_fallback(void)
     return 0;
 }
 
-JL_DLLEXPORT int jl_compile_extern_c_fallback(LLVMOrcThreadSafeModuleRef llvmmod, void *params, void *sysimg, jl_value_t *declrt, jl_value_t *sigt)
+JL_DLLEXPORT int jl_compile_extern_c_fallback(LLVMOrcThreadSafeModuleRef llvmmod, void *params, void *sysimg, jl_value_t *name, jl_value_t *declrt, jl_value_t *sigt)
 {
     // Assume we were able to register the ccallable with the JIT. The
     // fact that we didn't is not observable since we cannot compile

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7709,14 +7709,14 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
 
 // do codegen to create a C-callable alias/wrapper, or if sysimg_handle is set,
 // restore one from a loaded system image.
-const char *jl_generate_ccallable(Module *llvmmod, void *sysimg_handle, jl_value_t *declrt, jl_value_t *sigt, jl_codegen_params_t &params)
+const char *jl_generate_ccallable(Module *llvmmod, void *sysimg_handle, jl_value_t *nameval, jl_value_t *declrt, jl_value_t *sigt, jl_codegen_params_t &params)
 {
     ++GeneratedCCallables;
     jl_datatype_t *ft = (jl_datatype_t*)jl_tparam0(sigt);
     assert(jl_is_datatype(ft));
     jl_value_t *ff = ft->instance;
     assert(ff);
-    const char *name = jl_symbol_name(ft->name->mt->name);
+    const char *name = !jl_is_string(nameval) ? jl_symbol_name(ft->name->mt->name) : jl_string_data(nameval);
     jl_value_t *crt = declrt;
     if (jl_is_abstract_ref_type(declrt)) {
         declrt = jl_tparam0(declrt);

--- a/src/gf.c
+++ b/src/gf.c
@@ -4596,7 +4596,7 @@ JL_DLLEXPORT void jl_typeinf_timing_end(uint64_t start, int is_recompile)
 }
 
 // declare a C-callable entry point; called during code loading from the toplevel
-JL_DLLEXPORT void jl_extern_c(jl_value_t *declrt, jl_tupletype_t *sigt)
+JL_DLLEXPORT void jl_extern_c(jl_value_t *name, jl_value_t *declrt, jl_tupletype_t *sigt)
 {
     // validate arguments. try to do as many checks as possible here to avoid
     // throwing errors later during codegen.
@@ -4627,7 +4627,10 @@ JL_DLLEXPORT void jl_extern_c(jl_value_t *declrt, jl_tupletype_t *sigt)
     if (!jl_is_method(meth))
         jl_error("@ccallable: could not find requested method");
     JL_GC_PUSH1(&meth);
-    meth->ccallable = jl_svec2(declrt, (jl_value_t*)sigt);
+    if (name == jl_nothing)
+        meth->ccallable = jl_svec2(declrt, (jl_value_t*)sigt);
+    else
+        meth->ccallable = jl_svec3(declrt, (jl_value_t*)sigt, name);
     jl_gc_wb(meth, meth->ccallable);
     JL_GC_POP();
 }

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -284,7 +284,7 @@ struct jl_codegen_params_t {
     ~jl_codegen_params_t() JL_NOTSAFEPOINT JL_NOTSAFEPOINT_LEAVE = default;
 };
 
-const char *jl_generate_ccallable(Module *llvmmod, void *sysimg_handle, jl_value_t *declrt, jl_value_t *sigt, jl_codegen_params_t &params);
+const char *jl_generate_ccallable(Module *llvmmod, void *sysimg_handle, jl_value_t *nameval, jl_value_t *declrt, jl_value_t *sigt, jl_codegen_params_t &params);
 
 jl_llvm_functions_t jl_emit_code(
         orc::ThreadSafeModule &M,

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -284,7 +284,7 @@ struct jl_codegen_params_t {
     ~jl_codegen_params_t() JL_NOTSAFEPOINT JL_NOTSAFEPOINT_LEAVE = default;
 };
 
-const char *jl_generate_ccallable(Module *llvmmod, void *sysimg_handle, jl_value_t *nameval, jl_value_t *declrt, jl_value_t *sigt, jl_codegen_params_t &params);
+const char *jl_generate_ccallable(Module *llvmmod, jl_value_t *nameval, jl_value_t *declrt, jl_value_t *sigt, jl_codegen_params_t &params);
 
 jl_llvm_functions_t jl_emit_code(
         orc::ThreadSafeModule &M,

--- a/src/julia.h
+++ b/src/julia.h
@@ -1920,6 +1920,7 @@ JL_DLLEXPORT jl_method_instance_t *jl_new_method_instance_uninit(void);
 JL_DLLEXPORT jl_svec_t *jl_svec(size_t n, ...) JL_MAYBE_UNROOTED;
 JL_DLLEXPORT jl_svec_t *jl_svec1(void *a);
 JL_DLLEXPORT jl_svec_t *jl_svec2(void *a, void *b);
+JL_DLLEXPORT jl_svec_t *jl_svec3(void *a, void *b, void *c);
 JL_DLLEXPORT jl_svec_t *jl_alloc_svec(size_t n);
 JL_DLLEXPORT jl_svec_t *jl_alloc_svec_uninit(size_t n);
 JL_DLLEXPORT jl_svec_t *jl_svec_copy(jl_svec_t *a);

--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -271,7 +271,7 @@ static void *jl_precompile_(jl_array_t *m, int external_linkage)
         }
         else {
             assert(jl_is_simplevector(item));
-            assert(jl_svec_len(item) == 2);
+            assert(jl_svec_len(item) == 2 || jl_svec_len(item) == 3);
             jl_array_ptr_1d_push(m2, item);
         }
     }

--- a/src/simplevector.c
+++ b/src/simplevector.c
@@ -56,6 +56,19 @@ JL_DLLEXPORT jl_svec_t *jl_svec2(void *a, void *b)
     return v;
 }
 
+JL_DLLEXPORT jl_svec_t *jl_svec3(void *a, void *b, void *c)
+{
+    jl_task_t *ct = jl_current_task;
+    jl_svec_t *v = (jl_svec_t*)jl_gc_alloc(ct->ptls, sizeof(void*) * 4,
+                                           jl_simplevector_type);
+    jl_set_typetagof(v, jl_simplevector_tag, 0);
+    jl_svec_set_len_unsafe(v, 3);
+    jl_svec_data(v)[0] = (jl_value_t*)a;
+    jl_svec_data(v)[1] = (jl_value_t*)b;
+    jl_svec_data(v)[2] = (jl_value_t*)c;
+    return v;
+}
+
 JL_DLLEXPORT jl_svec_t *jl_alloc_svec_uninit(size_t n)
 {
     jl_task_t *ct = jl_current_task;

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -259,6 +259,7 @@ precompile_test_harness(false) do dir
 
               # check that @ccallable works from precompiled modules
               Base.@ccallable Cint f35014(x::Cint) = x+Cint(1)
+              Base.@ccallable "f35014_other" f35014_2(x::Cint)::Cint = x+Cint(1)
 
               # check that Tasks work from serialized state
               ch1 = Channel(x -> nothing)
@@ -399,6 +400,8 @@ precompile_test_harness(false) do dir
             let foo_ptr = Libdl.dlopen(ocachefile::String, RTLD_NOLOAD)
                 f35014_ptr = Libdl.dlsym(foo_ptr, :f35014)
                 @test ccall(f35014_ptr, Int32, (Int32,), 3) == 4
+                f35014_other_ptr = Libdl.dlsym(foo_ptr, :f35014_other)
+                @test ccall(f35014_other_ptr, Int32, (Int32,), 3) == 4
             end
         else
             ocachefile = nothing


### PR DESCRIPTION
This will allow exporting julia `main` as something else so a separate native `main` can be written to handle initialization. I'm sure it will have lots of other uses too though.