### PR TITLE
Refactoring codegen passes that lower write barrier and allocation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -76,9 +76,9 @@ ifeq ($(JULIACODEGEN),LLVM)
 GC_CODEGEN_SRCS := llvm-final-gc-lowering llvm-late-gc-lowering llvm-gc-invariant-verifier
 ifeq (${USE_THIRD_PARTY_GC},mmtk)
 FLAGS_COMMON += -I$(MMTK_API_INC)
-GC_CODEGEN_SRCS += llvm-late-gc-lowering-mmtk
+GC_CODEGEN_SRCS += llvm-final-gc-lowering-mmtk
 else
-GC_CODEGEN_SRCS += llvm-late-gc-lowering-stock
+GC_CODEGEN_SRCS += llvm-final-gc-lowering-stock
 endif
 CODEGEN_SRCS := codegen jitlayers aotcompile debuginfo disasm llvm-simdloop \
 	llvm-pass-helpers llvm-ptls llvm-propagate-addrspaces \

--- a/src/llvm-final-gc-lowering-mmtk.cpp
+++ b/src/llvm-final-gc-lowering-mmtk.cpp
@@ -2,7 +2,7 @@
 
 #include "llvm-gc-interface-passes.h"
 
-#define DEBUG_TYPE "mmtk_final_gc_lowering"
+#define DEBUG_TYPE "final_gc_lowering"
 STATISTIC(GCAllocBytesCount, "Number of lowered GCAllocBytesFunc intrinsics");
 
 Value* FinalLowerGC::lowerGCAllocBytes(CallInst *target, Function &F)

--- a/src/llvm-final-gc-lowering-mmtk.cpp
+++ b/src/llvm-final-gc-lowering-mmtk.cpp
@@ -2,19 +2,31 @@
 
 #include "llvm-gc-interface-passes.h"
 
-Value* LateLowerGCFrame::lowerGCAllocBytesLate(CallInst *target, Function &F)
+#define DEBUG_TYPE "mmtk_final_gc_lowering"
+STATISTIC(GCAllocBytesCount, "Number of lowered GCAllocBytesFunc intrinsics");
+
+Value* FinalLowerGC::lowerGCAllocBytes(CallInst *target, Function &F)
 {
-    assert(target->arg_size() == 3);
+    ++GCAllocBytesCount;
+    CallInst *newI;
 
     IRBuilder<> builder(target);
     auto ptls = target->getArgOperand(0);
     auto type = target->getArgOperand(2);
+    uint64_t derefBytes = 0;
     if (auto CI = dyn_cast<ConstantInt>(target->getArgOperand(1))) {
         size_t sz = (size_t)CI->getZExtValue();
         // This is strongly architecture and OS dependent
         int osize;
         int offset = jl_gc_classify_pools(sz, &osize);
-        if (offset >= 0) {
+        if (offset < 0) {
+            newI = builder.CreateCall(
+                bigAllocFunc,
+                { ptls, ConstantInt::get(T_size, sz + sizeof(void*)), type });
+            if (sz > 0)
+                derefBytes = sz;
+        }
+        else {
             // In this case instead of lowering julia.gc_alloc_bytes to jl_gc_small_alloc
             // We do a slowpath/fastpath check and lower it only on the slowpath, returning
             // the cursor and updating it in the fastpath.
@@ -91,6 +103,70 @@ Value* LateLowerGCFrame::lowerGCAllocBytesLate(CallInst *target, Function &F)
                 return phiNode;
             }
         }
+    } else {
+        auto size = builder.CreateZExtOrTrunc(target->getArgOperand(1), T_size);
+        // allocTypedFunc does not include the type tag in the allocation size!
+        newI = builder.CreateCall(allocTypedFunc, { ptls, size, type });
+        derefBytes = sizeof(void*);
     }
-    return target;
+    newI->setAttributes(newI->getCalledFunction()->getAttributes());
+    unsigned align = std::max((unsigned)target->getRetAlign().valueOrOne().value(), (unsigned)sizeof(void*));
+    newI->addRetAttr(Attribute::getWithAlignment(F.getContext(), Align(align)));
+    if (derefBytes > 0)
+        newI->addDereferenceableRetAttr(derefBytes);
+    newI->takeName(target);
+    return newI;
+}
+
+
+void FinalLowerGC::lowerWriteBarrier(CallInst *target, Function &F) {
+    auto parent = target->getArgOperand(0);
+    IRBuilder<> builder(target);
+    builder.SetCurrentDebugLocation(target->getDebugLoc());
+
+    // FIXME: Currently we call write barrier with the src object (parent).
+    // This works fine for object barrier for generational plans (such as stickyimmix), which does not use the target object at all.
+    // But for other MMTk plans, we need to be careful.
+    const bool INLINE_WRITE_BARRIER = true;
+    if (MMTK_NEEDS_WRITE_BARRIER == MMTK_OBJECT_BARRIER) {
+        if (INLINE_WRITE_BARRIER) {
+            auto i8_ty = Type::getInt8Ty(F.getContext());
+            auto intptr_ty = T_size;
+
+            // intptr_t addr = (intptr_t) (void*) src;
+            // uint8_t* meta_addr = (uint8_t*) (SIDE_METADATA_BASE_ADDRESS + (addr >> 6));
+            intptr_t metadata_base_address = reinterpret_cast<intptr_t>(MMTK_SIDE_LOG_BIT_BASE_ADDRESS);
+            auto metadata_base_val = ConstantInt::get(intptr_ty, metadata_base_address);
+            auto metadata_base_ptr = ConstantExpr::getIntToPtr(metadata_base_val, PointerType::get(i8_ty, 0));
+
+            auto parent_val = builder.CreatePtrToInt(parent, intptr_ty);
+            auto shr = builder.CreateLShr(parent_val, ConstantInt::get(intptr_ty, 6));
+            auto metadata_ptr = builder.CreateGEP(i8_ty, metadata_base_ptr, shr);
+
+            // intptr_t shift = (addr >> 3) & 0b111;
+            auto shift = builder.CreateAnd(builder.CreateLShr(parent_val, ConstantInt::get(intptr_ty, 3)), ConstantInt::get(intptr_ty, 7));
+            auto shift_i8 = builder.CreateTruncOrBitCast(shift, i8_ty);
+
+            // uint8_t byte_val = *meta_addr;
+            auto load_i8 = builder.CreateAlignedLoad(i8_ty, metadata_ptr, Align());
+
+            // if (((byte_val >> shift) & 1) == 1) {
+            auto shifted_load_i8 = builder.CreateLShr(load_i8, shift_i8);
+            auto masked = builder.CreateAnd(shifted_load_i8, ConstantInt::get(i8_ty, 1));
+            auto is_unlogged = builder.CreateICmpEQ(masked, ConstantInt::get(i8_ty, 1));
+
+            // object_reference_write_slow_call((void*) src, (void*) slot, (void*) target);
+            MDBuilder MDB(F.getContext());
+            SmallVector<uint32_t, 2> Weights{1, 9};
+
+            auto mayTriggerSlowpath = SplitBlockAndInsertIfThen(is_unlogged, target, false, MDB.createBranchWeights(Weights));
+            builder.SetInsertPoint(mayTriggerSlowpath);
+            builder.CreateCall(getOrDeclare(jl_intrinsics::queueGCRoot), { parent });
+        } else {
+            Function *wb_func = getOrDeclare(jl_intrinsics::queueGCRoot);
+            builder.CreateCall(wb_func, { parent });
+        }
+    } else {
+        // Using a plan that does not need write barriers
+    }
 }

--- a/src/llvm-final-gc-lowering-stock.cpp
+++ b/src/llvm-final-gc-lowering-stock.cpp
@@ -1,0 +1,80 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include "llvm-gc-interface-passes.h"
+
+#define DEBUG_TYPE "stock_final_gc_lowering"
+STATISTIC(GCAllocBytesCount, "Number of lowered GCAllocBytesFunc intrinsics");
+
+Value* FinalLowerGC::lowerGCAllocBytes(CallInst *target, Function &F)
+{
+    ++GCAllocBytesCount;
+    CallInst *newI;
+
+    IRBuilder<> builder(target);
+    auto ptls = target->getArgOperand(0);
+    auto type = target->getArgOperand(2);
+    uint64_t derefBytes = 0;
+    if (auto CI = dyn_cast<ConstantInt>(target->getArgOperand(1))) {
+        size_t sz = (size_t)CI->getZExtValue();
+        // This is strongly architecture and OS dependent
+        int osize;
+        int offset = jl_gc_classify_pools(sz, &osize);
+        if (offset < 0) {
+            newI = builder.CreateCall(
+                bigAllocFunc,
+                { ptls, ConstantInt::get(T_size, sz + sizeof(void*)), type });
+            if (sz > 0)
+                derefBytes = sz;
+        }
+        else {
+            auto pool_offs = ConstantInt::get(Type::getInt32Ty(F.getContext()), offset);
+            auto pool_osize = ConstantInt::get(Type::getInt32Ty(F.getContext()), osize);
+            newI = builder.CreateCall(smallAllocFunc, { ptls, pool_offs, pool_osize, type });
+            if (sz > 0)
+                derefBytes = sz;
+        }
+    } else {
+        auto size = builder.CreateZExtOrTrunc(target->getArgOperand(1), T_size);
+        // allocTypedFunc does not include the type tag in the allocation size!
+        newI = builder.CreateCall(allocTypedFunc, { ptls, size, type });
+        derefBytes = sizeof(void*);
+    }
+    newI->setAttributes(newI->getCalledFunction()->getAttributes());
+    unsigned align = std::max((unsigned)target->getRetAlign().valueOrOne().value(), (unsigned)sizeof(void*));
+    newI->addRetAttr(Attribute::getWithAlignment(F.getContext(), Align(align)));
+    if (derefBytes > 0)
+        newI->addDereferenceableRetAttr(derefBytes);
+    newI->takeName(target);
+    return newI;
+}
+
+void FinalLowerGC::lowerWriteBarrier(CallInst *target, Function &F) {
+    auto parent = target->getArgOperand(0);
+    IRBuilder<> builder(target);
+    builder.SetCurrentDebugLocation(target->getDebugLoc());
+    auto parBits = builder.CreateAnd(EmitLoadTag(builder, T_size, parent, tbaa_tag), GC_OLD_MARKED, "parent_bits");
+    auto parOldMarked = builder.CreateICmpEQ(parBits, ConstantInt::get(T_size, GC_OLD_MARKED), "parent_old_marked");
+    auto mayTrigTerm = SplitBlockAndInsertIfThen(parOldMarked, target, false);
+    builder.SetInsertPoint(mayTrigTerm);
+    mayTrigTerm->getParent()->setName("may_trigger_wb");
+    Value *anyChldNotMarked = NULL;
+    for (unsigned i = 1; i < target->arg_size(); i++) {
+        Value *child = target->getArgOperand(i);
+        Value *chldBit = builder.CreateAnd(EmitLoadTag(builder, T_size, child, tbaa_tag), GC_MARKED, "child_bit");
+        Value *chldNotMarked = builder.CreateICmpEQ(chldBit, ConstantInt::get(T_size, 0), "child_not_marked");
+        anyChldNotMarked = anyChldNotMarked ? builder.CreateOr(anyChldNotMarked, chldNotMarked) : chldNotMarked;
+    }
+    assert(anyChldNotMarked); // handled by all_of test above
+    MDBuilder MDB(parent->getContext());
+    SmallVector<uint32_t, 2> Weights{1, 9};
+    auto trigTerm = SplitBlockAndInsertIfThen(anyChldNotMarked, mayTrigTerm, false,
+                                                MDB.createBranchWeights(Weights));
+    trigTerm->getParent()->setName("trigger_wb");
+    builder.SetInsertPoint(trigTerm);
+    if (target->getCalledOperand() == write_barrier_func) {
+        builder.CreateCall(getOrDeclare(jl_intrinsics::queueGCRoot), parent);
+    }
+    else {
+        assert(false);
+    }
+}

--- a/src/llvm-final-gc-lowering-stock.cpp
+++ b/src/llvm-final-gc-lowering-stock.cpp
@@ -2,7 +2,7 @@
 
 #include "llvm-gc-interface-passes.h"
 
-#define DEBUG_TYPE "stock_final_gc_lowering"
+#define DEBUG_TYPE "final_gc_lowering"
 STATISTIC(GCAllocBytesCount, "Number of lowered GCAllocBytesFunc intrinsics");
 
 Value* FinalLowerGC::lowerGCAllocBytes(CallInst *target, Function &F)

--- a/src/llvm-gc-interface-passes.h
+++ b/src/llvm-gc-interface-passes.h
@@ -366,9 +366,6 @@ private:
     SmallVector<int, 1> GetPHIRefinements(PHINode *phi, State &S);
     void FixUpRefinements(ArrayRef<int> PHINumbers, State &S);
     void RefineLiveSet(LargeSparseBitVector &LS, State &S, ArrayRef<int> CalleeRoots);
-    Value *EmitTagPtr(IRBuilder<> &builder, Type *T, Type *T_size, Value *V);
-    Value *EmitLoadTag(IRBuilder<> &builder, Type *T_size, Value *V);
-    Value* lowerGCAllocBytesLate(CallInst *target, Function &F);
 };
 
 // The final GC lowering pass. This pass lowers platform-agnostic GC
@@ -404,7 +401,7 @@ private:
     void lowerGetGCFrameSlot(CallInst *target, Function &F);
 
     // Lowers a `julia.gc_alloc_bytes` intrinsic.
-    void lowerGCAllocBytes(CallInst *target, Function &F);
+    Value* lowerGCAllocBytes(CallInst *target, Function &F);
 
     // Lowers a `julia.queue_gc_root` intrinsic.
     void lowerQueueGCRoot(CallInst *target, Function &F);
@@ -412,8 +409,40 @@ private:
     // Lowers a `julia.safepoint` intrinsic.
     void lowerSafepoint(CallInst *target, Function &F);
 
+    // Lowers a `julia.write_barrier` function.
+    void lowerWriteBarrier(CallInst *target, Function &F);
+
     // Check if the pass should be run
     bool shouldRunFinalGC();
 };
+
+// These are used by LateLower and FinalLower
+
+// Size of T is assumed to be `sizeof(void*)`
+inline Value *EmitTagPtr(IRBuilder<> &builder, Type *T, Type *T_size, Value *V)
+{
+    assert(T == T_size || isa<PointerType>(T));
+    return builder.CreateInBoundsGEP(T, V, ConstantInt::get(T_size, -1), V->getName() + ".tag_addr");
+}
+
+inline Value *EmitLoadTag(IRBuilder<> &builder, Type *T_size, Value *V, llvm::MDNode *tbaa_tag)
+{
+    auto addr = EmitTagPtr(builder, T_size, T_size, V);
+    auto &M = *builder.GetInsertBlock()->getModule();
+    LoadInst *load = builder.CreateAlignedLoad(T_size, addr, M.getDataLayout().getPointerABIAlignment(0), V->getName() + ".tag");
+    load->setOrdering(AtomicOrdering::Unordered);
+    // Mark as volatile to prevent optimizers from treating GC tag loads as constants
+    // since GC mark bits can change during runtime (issue #59547)
+    load->setVolatile(true);
+    load->setMetadata(LLVMContext::MD_tbaa, tbaa_tag);
+    MDBuilder MDB(load->getContext());
+    auto *NullInt = ConstantInt::get(T_size, 0);
+    // We can be sure that the tag is at least 16 (1<<4)
+    // Hopefully this is enough to convince LLVM that the value is still not NULL
+    // after masking off the tag bits
+    auto *NonNullInt = ConstantExpr::getAdd(NullInt, ConstantInt::get(T_size, 16));
+    load->setMetadata(LLVMContext::MD_range, MDB.createRange(NonNullInt, NullInt));
+    return load;
+}
 
 #endif // LLVM_GC_PASSES_H

--- a/src/llvm-late-gc-lowering-stock.cpp
+++ b/src/llvm-late-gc-lowering-stock.cpp
@@ -1,9 +1,0 @@
-// This file is a part of Julia. License is MIT: https://julialang.org/license
-
-#include "llvm-gc-interface-passes.h"
-
-Value* LateLowerGCFrame::lowerGCAllocBytesLate(CallInst *target, Function &F)
-{
-    // Do nothing for the stock GC
-    return target;
-}


### PR DESCRIPTION
Moving the lowering functions that are GC-specific (allocation and write barriers) into the final lowering pass.