### PR TITLE
REPL: call display on the backend

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1145,7 +1145,7 @@ find_hist_file() = get(ENV, "JULIA_HISTORY",
                        !isempty(DEPOT_PATH) ? joinpath(DEPOT_PATH[1], "logs", "repl_history.jl") :
                        error("DEPOT_PATH is empty and ENV[\"JULIA_HISTORY\"] not set."))
 
-backend(r::AbstractREPL) = r.backendref
+backend(r::AbstractREPL) = hasproperty(r, :backendref) ? r.backendref : nothing
 
 
 function eval_with_backend(ast::Expr, backend::REPLBackendRef)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -925,7 +925,7 @@ function test19864()
     @eval Base.showerror(io::IO, e::Error19864) = print(io, "correct19864")
     buf = IOBuffer()
     fake_response = (Base.ExceptionStack([(exception=Error19864(),backtrace=Ptr{Cvoid}[])]),true)
-    REPL.print_response(buf, fake_response, false, false, nothing)
+    REPL.print_response(buf, fake_response, nothing, false, false, nothing)
     return String(take!(buf))
 end
 @test occursin("correct19864", test19864())


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/57742

With this PR (The last 2 are pasted in in one operation)
```julia
% ./julia -q -t8,0

julia> struct Foo end

julia> Base.display(::Foo) = @show Threads.threadid()

julia> Foo()
Threads.threadid() = 1

julia> Foo()
Threads.threadid() = 1

julia> Foo()
Threads.threadid() = 1

julia> Foo()
Threads.threadid() = 1
```