### PR TITLE
lowering: Don't closure-convert in `import` or `using`

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -4003,7 +4003,7 @@ f(x) = yt(x)
        ((atom? e) e)
        (else
         (case (car e)
-          ((quote top core globalref thismodule lineinfo line break inert module toplevel null true false meta) e)
+          ((quote top core globalref thismodule lineinfo line break inert module toplevel null true false meta import using) e)
           ((toplevel-only)
            ;; hack to avoid generating a (method x) expr for struct types
            (if (eq? (cadr e) 'struct)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2693,6 +2693,18 @@ import .TestImportAs.Mod2 as M2
 @test !@isdefined(Mod2)
 @test M2 === TestImportAs.Mod2
 
+# 57702: nearby bindings shouldn't cause us to closure-convert in import/using
+module OddImports
+using Test
+module ABC end
+x = let; let; import .ABC; end; let; ABC() = (ABC,); end; end
+y = let; let; using  .ABC; end; let; ABC() = (ABC,); end; end
+z = let; let; import SHA: R; end; let; R(x...) = R(x); end; end
+@test x isa Function
+@test y isa Function
+@test z isa Function
+end
+
 @testset "unicode modifiers after '" begin
     @test Meta.parse("a'ᵀ") == Expr(:call, Symbol("'ᵀ"), :a)
     @test Meta.parse("a'⁻¹") == Expr(:call, Symbol("'⁻¹"), :a)


### PR DESCRIPTION
Fixes #57702.  We're calling cl-convert- on `using` and `import` statements when we shouldn't, so if there's a nearby local that gets boxed (recursive function definition in this case), and the local shares a name with something in an import statement, we get a box access where we want a raw symbol.  

Before:
```
julia> let; let; import SHA: R; end; let; R(x...) = R(x); end; end
ERROR: TypeError: in import, expected Symbol, got a value of type Expr
Stacktrace:
 [1] top-level scope
   @ REPL[1]:1
```

After:
```
julia> let; let; import SHA: R; end; let; R(x...) = R(x); end; end
(::var"#R#R##0") (generic function with 1 method)
```

Previously, symbols in `import`/`using` statements would be wrapped with `outerref`, which cl-convert- wouldn't peek into. This protected us from this problem in 1.11.
