### PR TITLE
Markdown: print list without space in front of `*`

### DIFF
--- a/stdlib/Markdown/src/render/plain.jl
+++ b/stdlib/Markdown/src/render/plain.jl
@@ -41,7 +41,7 @@ end
 
 function plain(io::IO, list::List)
     for (i, item) in enumerate(list.items)
-        list_marker = isordered(list) ? "$(i + list.ordered - 1). " : "  * "
+        list_marker = isordered(list) ? "$(i + list.ordered - 1). " : "* "
         print(io, list_marker)
         content = sprint(list.loose ? plain : plaintight, item)
         lines = split(rstrip(content), "\n")

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -236,14 +236,14 @@ end
     @test md"""
     > foo
     >
-    >   * bar
+    > * bar
     >
     > ```
     > baz
     > ```""" |> Markdown.plain == """
     > foo
     >
-    >   * bar
+    > * bar
     >
     > ```
     > baz
@@ -461,8 +461,8 @@ end
 
         Some **bolded**
 
-          * list1
-          * list2
+        * list1
+        * list2
         """
 
     out =
@@ -958,9 +958,9 @@ end
 
 
             !!! warning "custom title"
-                  * foo
-                  * bar
-                  * baz
+                * foo
+                * bar
+                * baz
 
                 foo bar baz
 
@@ -1073,18 +1073,18 @@ end
 
                > A block quote.
 
-              * one
+            * one
 
             two
 
-              * one
+            * one
 
-                two
-              * baz
+              two
+            * baz
 
-              * ```
-                foo
-                ```
+            * ```
+              foo
+              ```
 
             1. foo
             2. bar
@@ -1404,8 +1404,8 @@ end
             Misc:\
             stuff
 
-              * line\
-                break
+            * line\
+              break
             """
     @test Markdown.html(s) ==
             raw"""
@@ -1595,17 +1595,17 @@ end
     expected = raw"""
     An unordered list:
 
-      * top level\
-        with an extra line
-          * second level\
-            again with an extra line
-              * third level\
-                yet again with an extra line
-                  * fourth level\
-                    and another extra line
-                      * fifth level\
-                        final extra line
-      * back to top level
+    * top level\
+      with an extra line
+      * second level\
+        again with an extra line
+        * third level\
+          yet again with an extra line
+          * fourth level\
+            and another extra line
+            * fifth level\
+              final extra line
+    * back to top level
     """
 
     actual = Markdown.plain(m)

--- a/stdlib/REPL/test/docview.jl
+++ b/stdlib/REPL/test/docview.jl
@@ -157,7 +157,7 @@ module InternalWarningsTests
     using Test, REPL
     @testset "internal warnings" begin
         header = "!!! warning\n    The following bindings may be internal; they may change or be removed in future versions:\n\n"
-        prefix(warnings) = header * join("      * `$(@__MODULE__).$w`\n" for w in warnings) * "\n\n"
+        prefix(warnings) = header * join("    * `$(@__MODULE__).$w`\n" for w in warnings) * "\n\n"
         docstring(input) = string(eval(REPL.helpmode(IOBuffer(), input, @__MODULE__)))
 
         @test docstring("A") == "No docstring or readme file found for internal module `$(@__MODULE__).A`.\n\n# Public names\n\n`B`, `B3`\n"


### PR DESCRIPTION
I noticed, that round tripping markdown adds spaces in front of `*`:
```julia
marky = md"""
# Test

* test test
"""
string(marky)
```
Results in:
```
"# Test\n\n  * test test\n"
```
I guess there are no round tripping guarantees for this, but I think this is not what a markdown formatter would do? I'm not sure what `plain` wants to achieve here with the space, so I wanted to put this up for discussion via this PR!  
Not really important in any way, but for my use case it would be nice to drop the space ;)