### PR TITLE
`typekey_hash`: length-independent run time for hashing long `Vararg`

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1805,6 +1805,9 @@ static unsigned typekey_hash(jl_typename_t *tn, jl_value_t **key, size_t n, int 
         unsigned hashp = type_hash(p, &failed);
         if (failed && !nofail)
             return 0;
+        size_t vararg_length_hash_precision_cutoff = 100000;  // don't spend too much time hashing long Vararg
+        if (vararg_length_hash_precision_cutoff < repeats)
+            repeats = vararg_length_hash_precision_cutoff;
         while (repeats--)
             hash = bitmix(hashp, hash);
     }


### PR DESCRIPTION
I'm not familiar with the C code, and I'm not sure this change is correct, but playing with it in the REPL doesn't reveal any obvious bugs.

Prior to this change, the run time of an operation like `Tuple{Vararg{T, 1000000}} where {T}` scales linearly with the field count (1000000 in this example).  The goal of this change is to make the run time be independent from the field count.

The idea is to simply return the same hash for all field counts greater than or equal to a cut off.

Follows up on PR #50932, which introduced the loop linear in the field count.