### PR TITLE
libunwind: Link against Julia zlib

### DIFF
--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -3,8 +3,9 @@ include $(SRCDIR)/unwind.version
 include $(SRCDIR)/llvmunwind.version
 
 ifneq ($(USE_BINARYBUILDER_LIBUNWIND),1)
-LIBUNWIND_CFLAGS := -U_FORTIFY_SOURCE $(fPIC) -lz $(SANITIZE_OPTS)
-LIBUNWIND_CPPFLAGS :=
+LIBUNWIND_CFLAGS := -U_FORTIFY_SOURCE $(fPIC) $(SANITIZE_OPTS)
+LIBUNWIND_CPPFLAGS := -I$(build_includedir)
+LIBUNWIND_LDFLAGS := -L$(build_shlibdir)
 
 ifeq ($(USE_SYSTEM_ZLIB),0)
 $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured: | $(build_prefix)/manifest/zlib
@@ -48,7 +49,7 @@ $(SRCCACHE)/libunwind-$(UNWIND_VER)/libunwind-disable-initial-exec-tls.patch-app
 $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured: $(SRCCACHE)/libunwind-$(UNWIND_VER)/source-extracted $(SRCCACHE)/libunwind-$(UNWIND_VER)/libunwind-disable-initial-exec-tls.patch-applied
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
-	$(dir $<)/configure $(CONFIGURE_COMMON) CPPFLAGS="$(CPPFLAGS) $(LIBUNWIND_CPPFLAGS)" CFLAGS="$(CFLAGS) $(LIBUNWIND_CFLAGS)" --enable-shared --disable-minidebuginfo --disable-tests --enable-zlibdebuginfo --disable-conservative-checks --enable-per-thread-cache
+	$(dir $<)/configure $(CONFIGURE_COMMON) CPPFLAGS="$(CPPFLAGS) $(LIBUNWIND_CPPFLAGS)" CFLAGS="$(CFLAGS) $(LIBUNWIND_CFLAGS)" LDFLAGS="$(LDFLAGS) $(LIBUNWIND_LDFLAGS)" --enable-shared --disable-minidebuginfo --disable-tests --enable-zlibdebuginfo --disable-conservative-checks --enable-per-thread-cache
 	echo 1 > $@
 
 $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled: $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured


### PR DESCRIPTION
As we don't add `$(build_shlibdir)` to the search path, currently unwind seems to link against the system zlib. As mentioned in https://github.com/libunwind/libunwind/pull/653 and from `configure --help` the standard way to link against a library in a non standard location is to set the `CPPFLAGS` and `LDFLAGS`. Tested by building with nix and in the package_linux rootfs image where we don't install zlib (though the shared library happens to be in the search path, the headers aren't).

Fixes https://github.com/JuliaLang/julia/issues/55617.
