### PR TITLE
fix _apply_pure deprecation

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -1017,7 +1017,7 @@ _setparser!(parser) = setglobal!(Core, :_parse, parser)
 
 # support for deprecated uses of builtin functions
 _apply(x...) = _apply_iterate(Main.Base.iterate, x...)
-_apply_pure(x...) = invoke_in_world_total(typemax_UInt, x...)
+const _apply_pure = _apply
 const _call_latest = invokelatest
 const _call_in_world = invoke_in_world
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -532,7 +532,10 @@ JL_DLLEXPORT jl_value_t *jl_call_in_typeinf_world(jl_value_t **args, int nargs)
     jl_task_t *ct = jl_current_task;
     size_t last_age = ct->world_age;
     ct->world_age = jl_typeinf_world;
+    int last_pure = ct->ptls->in_pure_callback;
+    ct->ptls->in_pure_callback = 0;
     jl_value_t *ret = jl_apply(args, nargs);
+    ct->ptls->in_pure_callback = last_pure;
     ct->world_age = last_age;
     return ret;
 }


### PR DESCRIPTION
Fix typo from #57532 and ensure "inference world" code has the permitted ability to inspect the max world age, since it needs that info in order to cache results correctly.