### PR TITLE
Fix #55820 : missing _convert_rounding methods for RoundFromZero

### DIFF
--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -281,6 +281,16 @@ function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:ToZero}) where T
         y < x ? nextfloat(y) : y
     end
 end
+function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:FromZero}) where T<:AbstractFloat
+    y = convert(T, x)::T
+    if x > 0
+        y < x ? nextfloat(y) : y
+    elseif x < 0
+        y > x ? prevfloat(y) : y
+    else
+        y
+    end
+end
 
 # Default definitions
 

--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -281,16 +281,15 @@ function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:ToZero}) where T
         y < x ? nextfloat(y) : y
     end
 end
-function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:FromZero}) where T<:AbstractFloat
+function _convert_rounding(::Type{T}, x::Real, ::RoundingMode{:FromZero}) where T<:AbstractFloat
     y = convert(T, x)::T
-    if x > 0
-        y < x ? nextfloat(y) : y
-    elseif x < 0
+    if x < 0.0
         y > x ? prevfloat(y) : y
     else
-        y
+        y < x ? nextfloat(y) : y
     end
 end
+
 
 # Default definitions
 

--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -281,8 +281,8 @@ function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:ToZero}) where T
         y < x ? nextfloat(y) : y
     end
 end
-function _convert_rounding(::Type{T}, x::Real, ::RoundingMode{:FromZero}) where T<:AbstractFloat
-    y = convert(T, x)::T
+function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:FromZero}) where T<:AbstractFloat
+    y = convert(T,x)::T
     if x < 0.0
         y > x ? prevfloat(y) : y
     else

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -495,3 +495,11 @@ end
         end
     end
 end
+
+@testset "Rounding to Zero with RoundFromZero" begin
+    @testset "Testing float types: $f" for f ∈ (Float16, Float32, Float64, BigFloat)
+        @testset "Testing value types: $t" for t ∈ (Bool, Rational{Int8})
+            @test iszero(f(zero(t), RoundFromZero))
+        end
+    end
+end

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -496,7 +496,7 @@ end
     end
 end
 
-@testset "Rounding to Zero with RoundFromZero" begin
+@testset "Rounding to floating point types with RoundFromZero #55820" begin
     @testset "Testing float types: $f" for f ∈ (Float16, Float32, Float64, BigFloat)
         @testset "Testing value types: $t" for t ∈ (Bool, Rational{Int8})
             @test iszero(f(zero(t), RoundFromZero))

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -502,4 +502,9 @@ end
             @test iszero(f(zero(t), RoundFromZero))
         end
     end
+    @test Float16(100000, RoundToZero) === floatmax(Float16)
+    @test Float16(100000, RoundFromZero) === Inf16
+    @test Float16(-100000, RoundToZero) === -floatmax(Float16)
+    @test Float16(-100000, RoundFromZero) === -Inf16
+    @test Float32(nextfloat(0.0), RoundFromZero) === nextfloat(0.0f0)
 end


### PR DESCRIPTION
- Implemented `_convert_rounding` method for `RoundingMode{:FromZero}` to handle conversions to `AbstractFloat`.
- Supported conversions for the following floating-point types:
  - Float16, Float32, Float64, AbstractFloat, BigFloat
- Handled real number types including:
  - Bool, Rational{Int8}
- Added tests to validate conversions for all affected type combinations.