### PR TITLE
add missing wb in jl_maybe_reresolve_implicit

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -855,8 +855,7 @@ typedef struct _modstack_t {
     jl_binding_t *b;
     struct _modstack_t *prev;
 } modstack_t;
-void jl_check_new_binding_implicit(
-    jl_binding_partition_t *new_bpart JL_MAYBE_UNROOTED, jl_binding_t *b, modstack_t *st, size_t world);
+void jl_check_new_binding_implicit(jl_binding_partition_t *new_bpart, jl_binding_t *b, modstack_t *st, size_t world);
 
 #ifndef __clang_gcanalyzer__
 // The analyzer doesn't like looking through the arraylist, so just model the


### PR DESCRIPTION
Also stop using a custom rooting strategy that is not understandable by the static analysis. Unfortunately, we currently have no checker for missing jl_gc_wb calls however.

Fix #57700