### PR TITLE
CSL_jll: Fix `libatomic` path for FreeBSD

### DIFF
--- a/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
+++ b/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
@@ -41,7 +41,9 @@ elseif Sys.isapple()
     const _libgomp_path = BundledLazyLibraryPath("libgomp.1.dylib")
     const _libssp_path = BundledLazyLibraryPath("libssp.0.dylib")
 else
-    if !Sys.isfreebsd()
+    if Sys.isfreebsd()
+        const _libatomic_path = BundledLazyLibraryPath("libatomic.so.3")
+    else
         const _libatomic_path = BundledLazyLibraryPath("libatomic.so.1")
     end
     const _libgcc_s_path = BundledLazyLibraryPath("libgcc_s.so.1")


### PR DESCRIPTION
This is required to avoid introducing a name / binding in the Module without a corresponding definition.

Resolves #57808