### PR TITLE
Make callable-related MethodError messages more descriptive

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -291,7 +291,9 @@ function showerror(io::IO, ex::MethodError)
     elseif isempty(methods(f)) && isa(f, DataType) && isabstracttype(f)
         print(io, "no constructors have been defined for ", f)
     elseif isempty(methods(f)) && !isa(f, Function) && !isa(f, Type)
-        print(io, "objects of type ", ft, " are not callable")
+        println(io, "objects of type ", ft, " are not callable.")
+        print(io, "In case you did not try calling it explicitly, check if a ", ft,
+            " has been passed as an argument to a method that expects a callable instead.")
     else
         if ft <: Function && isempty(ft.parameters) && _isself(ft)
             f_is_function = true
@@ -323,7 +325,7 @@ function showerror(io::IO, ex::MethodError)
         end
     end
     if ft <: AbstractArray
-        print(io, "\nUse square brackets [] for indexing an Array.")
+        print(io, "\nIn case you're trying to index into the array, use square brackets [] instead of parentheses ().")
     end
     # Check for local functions that shadow methods in Base
     let name = ft.name.mt.name

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -419,7 +419,10 @@ let err_str,
     err_str = @except_str FunctionLike()() MethodError
     @test occursin("MethodError: no method matching (::$(curmod_prefix)FunctionLike)()", err_str)
     err_str = @except_str [1,2](1) MethodError
-    @test occursin("MethodError: objects of type Vector{$Int} are not callable\nUse square brackets [] for indexing an Array.", err_str)
+    @test occursin("MethodError: objects of type Vector{$Int} are not callable.\n"*
+        "In case you did not try calling it explicitly, check if a Vector{$Int}"*
+        " has been passed as an argument to a method that expects a callable instead.\n"*
+        "In case you're trying to index into the array, use square brackets [] instead of parentheses ().", err_str)
     # Issue 14940
     err_str = @except_str randn(1)() MethodError
     @test occursin("MethodError: objects of type Vector{Float64} are not callable", err_str)


### PR DESCRIPTION
Addresses https://github.com/JuliaLang/julia/issues/57807 to some extent, although the error message may be improved further.

On nightly,
```julia
julia> stack(1:3, 1:3)
ERROR: MethodError: objects of type UnitRange{Int64} are not callable
Use square brackets [] for indexing an Array.
The object of type `UnitRange{Int64}` exists, but no method is defined for this combination of argument types when trying to treat it as a callable object.
```
The second sentence seems unrelated to the first, and the source of the error remains unclear from the message.

This PR makes the message more verbose, and provides pointers.
```julia
julia> stack(1:3, 200)
ERROR: MethodError: objects of type UnitRange{Int64} are not callable.
In case you did not try calling it explicitly, check if a UnitRange{Int64} has been passed as an argument to a method that expects a callable instead.
In case you're trying to index into the array, use square brackets [] instead of parentheses ().
The object of type `UnitRange{Int64}` exists, but no method is defined for this combination of argument types when trying to treat it as a callable object.

```