### PR TITLE
Perf improvement for 2 arg show for `UnitRange` type

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -1105,7 +1105,11 @@ function getindex(r::LinRange{T}, s::OrdinalRange{S}) where {T, S<:Integer}
 end
 
 show(io::IO, r::AbstractRange) = print(io, repr(first(r)), ':', repr(step(r)), ':', repr(last(r)))
-show(io::IO, r::UnitRange) = print(io, repr(first(r)), ':', repr(last(r)))
+function show(io::IO, r::UnitRange)
+    show(io, first(r))
+    print(io, ':')
+    show(io, last(r))
+end
 show(io::IO, r::OneTo) = print(io, "Base.OneTo(", r.stop, ")")
 function show(io::IO, r::StepRangeLen)
     if !iszero(step(r))


### PR DESCRIPTION
Mentioned in https://github.com/JuliaLang/julia/pull/57697#discussion_r2001497340 and https://github.com/JuliaLang/julia/pull/57697#discussion_r2001723774
also improves #57697 

benchmarks on my configuration:

```julia
julia> f(io, a) = print(io, repr(first(a)), ':', repr(last(a)))
f (generic function with 1 method)

julia> function g(io, a)
       show(io, first(a))
       print(io, ':')
       show(io, last(a))
       end
g (generic function with 1 method)

julia> using BenchmarkTools

julia> @btime f(io, a) setup=(io=devnull; a=big(2)^(2^10):big(6)^(2^10);)
  4.889 μs (17 allocations: 5.23 KiB)

julia> @btime g(io, a) setup=(io=devnull; a=big(2)^(2^10):big(6)^(2^10);)
  4.021 μs (11 allocations: 3.86 KiB)

julia> @btime f(io, a) setup=(io=devnull; a=10000000000000000:10000000000000001;)
  312.814 ns (12 allocations: 576 bytes)

julia> @btime g(io, a) setup=(io=devnull; a=10000000000000000:10000000000000001;)
  62.859 ns (4 allocations: 208 bytes)
```
