### PR TITLE
Fix package precompilation (PrecompileTools)

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1281,6 +1281,9 @@ JL_DLLEXPORT void jl_force_trace_compile_timing_disable(void);
 JL_DLLEXPORT void jl_force_trace_dispatch_enable(void);
 JL_DLLEXPORT void jl_force_trace_dispatch_disable(void);
 
+JL_DLLEXPORT void jl_tag_newly_inferred_enable(void);
+JL_DLLEXPORT void jl_tag_newly_inferred_disable(void);
+
 uint32_t jl_module_next_counter(jl_module_t *m) JL_NOTSAFEPOINT;
 jl_tupletype_t *arg_type_tuple(jl_value_t *arg1, jl_value_t **args, size_t nargs);
 


### PR DESCRIPTION
With the "classic" inference timing disabled, PrecompileTools and SnoopCompile are non-functional on 1.12 & master. #57074 added timing data to the CodeInstances themselves, which should help restore SnoopCompile. However, without the tree structure provided by the old inference timing system, we still need a way to tag MethodInstances that get inferred inside `PrecompileTools.@compile_workload` blocks.

This adds a simple mechanism modeled after `@trace_compile` that switches to tagging MethodInstances in `jl_push_newly_inferred`. https://github.com/JuliaLang/PrecompileTools.jl/pull/47 contains (or will contain) the corresponding changes to PrecompileTools.jl.