### PR TITLE
binaryplatforms.jl: Don't close library opened with RTLD_NOLOAD

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -931,12 +931,10 @@ function detect_libstdcxx_version(max_minor_version::Int=30)
         # https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html
         for minor_version in max_minor_version:-1:18
             if Libdl.dlsym(libstdcxx, "GLIBCXX_3.4.$(minor_version)"; throw_error=false) !== nothing
-                Libdl.dlclose(libstdcxx)
                 return VersionNumber("3.4.$(minor_version)")
             end
         end
     end
-    Libdl.dlclose(libstdcxx)
     return nothing
 end
 


### PR DESCRIPTION
"Passing this handle to FreeLibrary can cause a module to be unloaded prematurely."

Also crashes in Wine.