### PR TITLE
[Linux] Prevent GC from running during process teardown

### DIFF
--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -1033,6 +1033,10 @@ static void *signal_listener(void *arg)
         }
 #endif
         if (doexit) {
+            // Let's forbid threads from running GC while we're trying to exit,
+            // also let's make sure we're not in the middle of GC.
+            jl_atomic_fetch_add(&jl_gc_disable_counter, 1);
+            jl_safepoint_wait_gc(NULL);
             // The exit can get stuck if it happens at an unfortunate spot in thread 0
             // (unavoidable due to its async nature).
             // Try much harder to exit next time, if we get multiple exit requests.

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -559,6 +559,7 @@ static int thread0_exit_signo = 0;
 static void JL_NORETURN jl_exit_thread0_cb(void)
 {
 CFI_NORETURN
+    jl_atomic_fetch_add(&jl_gc_disable_counter, -1);
     jl_critical_error(thread0_exit_signo, 0, NULL, jl_current_task);
     jl_atexit_hook(128);
     jl_raise(thread0_exit_signo);

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -1033,10 +1033,6 @@ static void *signal_listener(void *arg)
         }
 #endif
         if (doexit) {
-            // Let's forbid threads from running GC while we're trying to exit,
-            // also let's make sure we're not in the middle of GC.
-            jl_atomic_fetch_add(&jl_gc_disable_counter, 1);
-            jl_safepoint_wait_gc(NULL);
             // The exit can get stuck if it happens at an unfortunate spot in thread 0
             // (unavoidable due to its async nature).
             // Try much harder to exit next time, if we get multiple exit requests.
@@ -1093,6 +1089,10 @@ static void *signal_listener(void *arg)
 //#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 199309L && !HAVE_KEVENT
 //            si_code = info.si_code;
 //#endif
+            // Let's forbid threads from running GC while we're trying to exit,
+            // also let's make sure we're not in the middle of GC.
+            jl_atomic_fetch_add(&jl_gc_disable_counter, 1);
+            jl_safepoint_wait_gc(NULL);
             jl_exit_thread0(sig, signal_bt_data, signal_bt_size);
         }
         else if (critical) {


### PR DESCRIPTION
## Context

We send a signal 15 to shutdown our servers.

We noticed that some of our servers that receive the termination signal are segfaulting in GC, which leads to false alarms in our internal monitors that track GC-related crashes.

## Hypothesis

We suspect this pathological case may be happening:

- Process receives signal 15, which is captured by the signal listener thread.
- Signal listener initiates process' teardown (e.g. through `raise`).
- IIRC such operation is not atomic in Linux, i.e. the kernel will gradually kill the threads, but it's possible for us to spent a few ms in a state where part of the threads in the system are alive, and part have already been killed (this point needs some confirmation).
- With part of the process alive, and part of the process dead, we try to enter a GC, see a bunch of Julia data structures in an intermediate/corrupted state, which leads us to crash when running the GC.

## Mitigation

Since our main goal is to get rid of the GC crashes that happen around server shutdown, we believe that it would be sufficient to just prevent the last bullet point. I.e. we prevent the system from even running a GC when we're about to kill the process, and we wait for any ongoing GC to finish.

Co-debugged with @kpamnany.