### PR TITLE
precompile_utils: Don't auto-enqueue `macro` methods for pre-compilation

### DIFF
--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -170,6 +170,10 @@ static void jl_compile_all_defs(jl_array_t *mis, int all)
     size_t i, l = jl_array_nrows(allmeths);
     for (i = 0; i < l; i++) {
         jl_method_t *m = (jl_method_t*)jl_array_ptr_ref(allmeths, i);
+        int is_macro_method = jl_symbol_name(m->name)[0] == '@';
+        if (is_macro_method && !all)
+            continue; // Avoid inference / pre-compilation for macros
+
         if (jl_is_datatype(m->sig) && jl_isa_compileable_sig((jl_tupletype_t*)m->sig, jl_emptysvec, m)) {
             // method has a single compilable specialization, e.g. its definition
             // signature is concrete. in this case we can just hint it.

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2410,4 +2410,9 @@ precompile_test_harness("Package top-level load itself") do load_path
     end
 end
 
+# Verify that inference / caching was not performed for any macros in the sysimage
+let m = only(methods(Base.var"@big_str"))
+    @test m.specializations === Core.svec() || !isdefined(m.specializations, :cache)
+end
+
 finish_precompile_test!()


### PR DESCRIPTION
Despite disabling these from being compiled in `gf.c` for dynamic invocations, the pre-compilation code was adding `macro` Methods anyway to the workqueue.

Replaces https://github.com/JuliaLang/julia/pull/57782