### PR TITLE
[backports-release-1.11] Don't free regex objects in exit-time finalizer calls

### DIFF
--- a/test/regex.jl
+++ b/test/regex.jl
@@ -245,3 +245,11 @@ end
         @test match(re, "ababc").match === SubString("ababc", 3:5)
     end
 end
+
+@testset "#57817: Don't free Regex during exit finalizer calls" begin
+    # this shouldn't segfault
+    cmd = `$(Base.julia_cmd()) -t2 --startup-file=no -e 're = Regex(""); Threads.@spawn match(re, "", 1, UInt32(0))'`
+    for i in 1:10
+        @test success(pipeline(cmd, stderr=stderr))
+    end
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/57817 on 1.11