### PR TITLE
Add Base.Sys.which to docs

### DIFF
--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -397,6 +397,7 @@ Base.Sys.loadavg
 Base.Sys.isexecutable
 Base.Sys.isreadable
 Base.Sys.iswritable
+Base.Sys.which
 Base.Sys.username
 Base.@static
 ```


### PR DESCRIPTION
Looks like this is probably missing by accident.