### PR TITLE
Changed basedocs.jl (temporarily pushed off) and logging.jl to only use jldoctest

### DIFF
--- a/base/logging/logging.jl
+++ b/base/logging/logging.jl
@@ -117,8 +117,8 @@ filtered, before any other work is done to construct the log record data
 structure itself.
 
 # Examples
-```julia-repl
-julia> Logging.LogLevel(0) == Logging.Info
+```jldoctest
+julia> import Logging; Logging.LogLevel(0) == Logging.Info
 true
 ```
 """

--- a/base/logging/logging.jl
+++ b/base/logging/logging.jl
@@ -117,8 +117,8 @@ filtered, before any other work is done to construct the log record data
 structure itself.
 
 # Examples
-```jldoctest
-julia> import Logging; Logging.LogLevel(0) == Logging.Info
+```jldoctest; setup = :(import Logging)
+julia> Logging.LogLevel(0) == Logging.Info
 true
 ```
 """


### PR DESCRIPTION
https://github.com/JuliaLang/julia/issues/56921

Small update of two files (logging.jl and basedocs.jl) to switch from `julia-repl` tag to `jldoctest` tags.

Would prefer for reviewer to double check that `make -C doc doctest=true` works for them