### PR TITLE
add: `Meta.isreserved` public api

### DIFF
--- a/base/meta.jl
+++ b/base/meta.jl
@@ -12,13 +12,14 @@ export quot,
        isunaryoperator,
        isbinaryoperator,
        ispostfixoperator,
+       isreserved,
        replace_sourceloc!,
        show_sexpr,
        @dump
 
 public parse
 
-using Base: isidentifier, isoperator, isunaryoperator, isbinaryoperator, ispostfixoperator
+using Base: isidentifier, isoperator, isunaryoperator, isbinaryoperator, ispostfixoperator, isreserved
 import Base: isexpr
 
 """

--- a/base/public.jl
+++ b/base/public.jl
@@ -55,6 +55,7 @@ public
     isambiguous,
     isexpr,
     isidentifier,
+    isreserved,
     issingletontype,
     identify_package,
     locate_package,

--- a/base/show.jl
+++ b/base/show.jl
@@ -1690,6 +1690,37 @@ function operator_associativity(s::Symbol)
     return :left
 end
 
+const keyword_syms = Set([
+    :baremodule, :begin, :break, :catch, :const, :continue, :do, :else, :elseif,
+    :end, :export, :false, :finally, :for, :function, :global, :if, :import,
+    :let, :local, :macro, :module, :public, :quote, :return, :struct, :true,
+    :try, :using, :while ])
+
+"""
+     isreserved(s) -> Bool
+
+Return whether the symbol or string `s` is a reserved julia keyword.
+
+# Examples
+```jldoctest
+julia> Meta.isreserved(:for), Meta.isreserved("cat")
+(true, false)
+```
+
+!!! compat "Julia 1.13"
+    This method requires at least Julia 1.13.
+"""
+isreserved(s::Symbol) = s in keyword_syms
+isreserved(s::AbstractString) = isreserved(Symbol(s))
+
+function is_valid_identifier(sym)
+    return (isidentifier(sym) && !(sym in keyword_syms)) ||
+        (_isoperator(sym) &&
+        !(sym in (Symbol("'"), :(::), :?)) &&
+        !is_syntactic_operator(sym)
+    )
+end
+
 is_quoted(ex)            = false
 is_quoted(ex::QuoteNode) = true
 is_quoted(ex::Expr)      = is_expr(ex, :quote, 1) || is_expr(ex, :inert, 1)
@@ -1772,20 +1803,6 @@ function show_enclosed_list(io::IO, op, items, sep, cl, indent, prec=0, quote_le
     print(io, op)
     show_list(io, items, sep, indent, prec, quote_level, encl_ops, kw)
     print(io, cl)
-end
-
-const keyword_syms = Set([
-    :baremodule, :begin, :break, :catch, :const, :continue, :do, :else, :elseif,
-    :end, :export, :false, :finally, :for, :function, :global, :if, :import,
-    :let, :local, :macro, :module, :public, :quote, :return, :struct, :true,
-    :try, :using, :while ])
-
-function is_valid_identifier(sym)
-    return (isidentifier(sym) && !(sym in keyword_syms)) ||
-        (_isoperator(sym) &&
-        !(sym in (Symbol("'"), :(::), :?)) &&
-        !is_syntactic_operator(sym)
-    )
 end
 
 # show a normal (non-operator) function call, e.g. f(x, y) or A[z]

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -543,6 +543,7 @@ Base.jit_total_bytes
 Meta.quot
 Meta.isexpr
 Meta.isidentifier
+Meta.isreserved
 Meta.isoperator
 Meta.isunaryoperator
 Meta.isbinaryoperator

--- a/test/show.jl
+++ b/test/show.jl
@@ -500,12 +500,20 @@ end
 # isreserved
 @test Meta.isreserved(:for)
 @test Meta.isreserved(:while)
+@test !Meta.isreserved(:primitive)
+@test !Meta.isreserved(:type)
+@test Meta.isreserved(:struct)
 @test !Meta.isreserved(:x)
 @test !Meta.isreserved(:wrong)
+@test !Meta.isreserved(:billa)
 @test Meta.isreserved("begin")
 @test Meta.isreserved("end")
 @test !Meta.isreserved("abcd")
-@test !Meta.isreserved("pqrs")
+@test !Meta.isreserved("billa")
+@test !Meta.isreserved("mutable")
+@test Meta.isreserved("struct")
+@test !Meta.isreserved("primitive")
+@test !Meta.isreserved("type")
 
 # isidentifier
 @test Meta.isidentifier("x")

--- a/test/show.jl
+++ b/test/show.jl
@@ -497,6 +497,16 @@ end
 @test sprint(show, Symbol("'")) == "Symbol(\"'\")"
 @test_repr "var\"'\" = 5"
 
+# isreserved
+@test Meta.isreserved(:for)
+@test Meta.isreserved(:while)
+@test !Meta.isreserved(:x)
+@test !Meta.isreserved(:wrong)
+@test Meta.isreserved("begin")
+@test Meta.isreserved("end")
+@test !Meta.isreserved("abcd")
+@test !Meta.isreserved("pqrs")
+
 # isidentifier
 @test Meta.isidentifier("x")
 @test Meta.isidentifier("x1")


### PR DESCRIPTION
This adds `Meta.isreserved` to check whether a symbol or string is a reserved julia keyword
closes https://github.com/JuliaLang/julia/issues/26090
```julia
julia> Meta.isreserved(:for)
true

julia> Meta.isreserved("cat")
false
```
