### PR TITLE
fix `mod` for mixes of `Signed` and `Unsigned`

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -286,8 +286,14 @@ function mod(x::T, y::T) where T<:Integer
     y == -1 && return T(0)   # avoid potential overflow in fld
     return x - fld(x, y) * y
 end
-mod(x::BitSigned, y::Unsigned) = rem(y + unsigned(rem(x, y)), y)
-mod(x::Unsigned, y::Signed) = rem(y + signed(rem(x, y)), y)
+function mod(x::BitSigned, y::Unsigned)
+    remval = rem(x, y) # correct iff x>0 or remval==0
+    return remval + (!iszero(remval) && x<zero(x))*y
+end
+function mod(x::Unsigned, y::Signed)
+    remval =  signed(rem(x, y)) #remval>0 so correct iff y>0 or remval==0
+    return remval + (!iszero(remval) && y<zero(y))*y
+end
 mod(x::T, y::T) where {T<:Unsigned} = rem(x, y)
 
 # Don't promote integers for div/rem/mod since there is no danger of overflow,

--- a/base/int.jl
+++ b/base/int.jl
@@ -288,7 +288,7 @@ function mod(x::T, y::T) where T<:Integer
 end
 function mod(x::BitSigned, y::Unsigned)
     remval = rem(x, y) # correct iff  remval>=0
-    return remval + (remval<zero(remval))*y
+    return unsigned(remval + (remval<zero(remval))*y)
 end
 function mod(x::Unsigned, y::Signed)
     remval =  signed(rem(x, y)) #remval>0 so correct iff y>0 or remval==0

--- a/base/int.jl
+++ b/base/int.jl
@@ -287,8 +287,8 @@ function mod(x::T, y::T) where T<:Integer
     return x - fld(x, y) * y
 end
 function mod(x::BitSigned, y::Unsigned)
-    remval = rem(x, y) # correct iff x>0 or remval==0
-    return remval + (!iszero(remval) && x<zero(x))*y
+    remval = rem(x, y) # correct iff  remval>=0
+    return remval + (remval<zero(remval))*y
 end
 function mod(x::Unsigned, y::Signed)
     remval =  signed(rem(x, y)) #remval>0 so correct iff y>0 or remval==0

--- a/test/int.jl
+++ b/test/int.jl
@@ -362,6 +362,23 @@ end
             end
         end
     end
+    # exhaustive UInt8/Int8 tests for mixed signedness
+    for f in (mod, rem)
+        for i in -128:127
+            for j in 0:255
+                if iszero(i)
+                    @test_throws DivideError f(UInt8(j), Int8(i))
+                else
+                    @test f(UInt8(j), Int8(i)) == f(j, i)
+                end
+                if iszero(j)
+                    @test_throws DivideError f(Int8(i), UInt8(j))
+                else
+                    @test f(Int8(i), UInt8(j)) == f(i,j)
+                end
+            end
+        end
+    end
 end
 
 @testset "Underscores in big_str" begin


### PR DESCRIPTION
Previously this was just overfowing producing wrong answers (both for the sign convention and just the wrong modulo class)
fixes https://github.com/JuliaLang/julia/issues/57851