### PR TITLE
Profile: remove scope from profile macros

### DIFF
--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -79,11 +79,11 @@ end
 function _prof_expr(expr, opts)
     quote
         $start(; $(esc(opts)))
-        try
+        Base.@__tryfinally(
             $(esc(expr))
-        finally
+            ,
             $stop()
-        end
+        )
     end
 end
 

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -56,12 +56,12 @@ appended to an internal buffer of backtraces.
 """
 macro profile(ex)
     return quote
-        try
-            start_timer()
+        start_timer()
+        Base.@__tryfinally(
             $(esc(ex))
-        finally
+            ,
             stop_timer()
-        end
+        )
     end
 end
 
@@ -78,12 +78,12 @@ it can be used to diagnose performance issues such as lock contention, IO bottle
 """
 macro profile_walltime(ex)
     return quote
-        try
-            start_timer(true)
+        start_timer(true);
+        Base.@__tryfinally(
             $(esc(ex))
-        finally
+            ,
             stop_timer()
-        end
+        )
     end
 end
 

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -155,6 +155,20 @@ end
 @test z == 10
 end
 
+@testset "@profile no scope" begin
+    @profile no_scope_57858_1 = 1
+    @test @isdefined no_scope_57858_1
+    Profile.clear()
+
+    @profile_walltime no_scope_57858_1 = 1
+    @test @isdefined no_scope_57858_1
+    Profile.clear()
+
+    Profile.Allocs.@profile no_scope_57858_2 = 1
+    @test @isdefined no_scope_57858_2
+    Profile.Allocs.clear()
+end
+
 @testset "setting sample count and delay in init" begin
     n_, delay_ = Profile.init()
     n_original = n_


### PR DESCRIPTION
Fixes this, which breaks expectations from the way `@time` doesn't introduce a new scope.
```
julia> using Profile

julia> @profile x = 1
1

julia> x
ERROR: UndefVarError: `x` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
```