### PR TITLE
`Compiler`: `walk_to_defs`, `collect_leaves`: specialize for `predecessors`

### DIFF
--- a/Compiler/src/ssair/passes.jl
+++ b/Compiler/src/ssair/passes.jl
@@ -271,7 +271,7 @@ Starting at `val` walk use-def chains to get all the leaves feeding into this `v
 `predecessors(def, compact)` is a callback which should return the set of possible
 predecessors for a "phi-like" node (PhiNode or Core.ifelse) or `nothing` otherwise.
 """
-function walk_to_defs(compact::IncrementalCompact, @nospecialize(defssa), @nospecialize(typeconstraint), predecessors, 𝕃ₒ::AbstractLattice)
+function walk_to_defs(compact::IncrementalCompact, @nospecialize(defssa), @nospecialize(typeconstraint), predecessors::Pre, 𝕃ₒ::AbstractLattice) where {Pre}
     visited_philikes = AnySSAValue[]
     isa(defssa, AnySSAValue) || return Any[defssa], visited_philikes
     def = compact[defssa][:stmt]
@@ -296,7 +296,7 @@ function walk_to_defs(compact::IncrementalCompact, @nospecialize(defssa), @nospe
             end
             possible_predecessors = Int[]
 
-            for n in 1:length(values)::Int
+            for n in 1:length(values)
                 isassigned(values, n) || continue
                 val = values[n]
                 if is_old(compact, defssa) && isa(val, SSAValue)

--- a/Compiler/src/ssair/passes.jl
+++ b/Compiler/src/ssair/passes.jl
@@ -183,7 +183,7 @@ function find_def_for_use(
 end
 
 function collect_leaves(compact::IncrementalCompact, @nospecialize(val), @nospecialize(typeconstraint), 𝕃ₒ::AbstractLattice,
-                        predecessors = ((@nospecialize(def), compact::IncrementalCompact) -> isa(def, PhiNode) ? def.values : nothing))
+                        predecessors::Pre = ((@nospecialize(def), compact::IncrementalCompact) -> isa(def, PhiNode) ? def.values : nothing)) where {Pre}
     if isa(val, Union{OldSSAValue, SSAValue})
         val, typeconstraint = simple_walk_constraint(compact, val, typeconstraint)
     end

--- a/Compiler/src/ssair/passes.jl
+++ b/Compiler/src/ssair/passes.jl
@@ -296,7 +296,7 @@ function walk_to_defs(compact::IncrementalCompact, @nospecialize(defssa), @nospe
             end
             possible_predecessors = Int[]
 
-            for n in 1:length(values)
+            for n in 1:length(values)::Int
                 isassigned(values, n) || continue
                 val = values[n]
                 if is_old(compact, defssa) && isa(val, SSAValue)


### PR DESCRIPTION
Should make the code less vulnerable to invalidation.