### PR TITLE
`Base`: restrict argument of macro `kwdef` to `Expr`

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -578,7 +578,7 @@ Stacktrace:
 [...]
 ```
 """
-macro kwdef(expr)
+macro kwdef(expr::Expr)
     expr = macroexpand(__module__, expr) # to expand @static
     isexpr(expr, :struct) || error("Invalid usage of @kwdef")
     _, T, fieldsblock = expr.args


### PR DESCRIPTION
The motivation is to make the sysimage less vulnerable to invalidation.

The restriction to `Expr` is already implied by the doc string, and I believe anything else currently throws anyway.