### PR TITLE
`Base`: `macro cmd`: restrict argument to `String`

### DIFF
--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -504,7 +504,7 @@ julia> run(cm)
 Process(`echo 1`, ProcessExited(0))
 ```
 """
-macro cmd(str)
+macro cmd(str::String)
     cmd_ex = shell_parse(str, special=shell_special, filename=String(__source__.file))[1]
     return :(cmd_gen($(esc(cmd_ex))))
 end


### PR DESCRIPTION
Should make the sysimage less vulnerable to invalidation.

As far as I understand this change can't break any code, because:
* the macro definition requires `AbstractString`
* the way Julia macros work, the argument is either a literal or an `Expr`
* `String` is the only `AbstractString` with literals