### PR TITLE
`Base`: `macro b_str`: restrict argument to `String`

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -585,7 +585,7 @@ julia> v[2]
 0x32
 ```
 """
-macro b_str(s)
+macro b_str(s::String)
     v = codeunits(unescape_string(s))
     QuoteNode(v)
 end


### PR DESCRIPTION
Should make the sysimage less vulnerable to invalidation.

As far as I understand this change can't break any code, because:
* the macro definition requires `AbstractString`
* the way Julia macros work, the argument is either a literal or an `Expr`
* `String` is the only `AbstractString` with literals