### PR TITLE
[backports-release-1.11] Revert "precompile: don't waste memory on useless inferred code"

### DIFF
--- a/base/compiler/effects.jl
+++ b/base/compiler/effects.jl
@@ -329,7 +329,6 @@ is_inaccessiblemem_or_argmemonly(effects::Effects) = effects.inaccessiblememonly
 
 is_consistent_overlay(effects::Effects) = effects.nonoverlayed === CONSISTENT_OVERLAY
 
-# (sync this with codegen.cpp and staticdata.c effects_foldable functions)
 function encode_effects(e::Effects)
     return ((e.consistent          % UInt32) << 0)  |
            ((e.effect_free         % UInt32) << 3)  |

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9679,10 +9679,10 @@ jl_llvm_functions_t jl_emit_codeinst(
                 // Julia-level optimization will never need to see it
                 else if (jl_is_method(def) && // don't delete toplevel code
                          inferred != jl_nothing && // and there is something to delete (test this before calling jl_ir_inlining_cost)
-                         ((!effects_foldable(codeinst->ipo_purity_bits) && // don't delete code we may want for irinterp
-                           (jl_ir_inlining_cost(inferred) == UINT16_MAX) && // don't delete inlineable code
-                           !jl_generating_output()) || // don't delete code when generating a precompile file, trading memory in the short term for avoiding likely duplicating inference work for aotcompile
-                          jl_atomic_load_relaxed(&codeinst->invoke) == jl_fptr_const_return_addr)) { // unless it is constant (although this shouldn't have had code in the first place)
+                         !effects_foldable(codeinst->ipo_purity_bits) && // don't delete code we may want for irinterp
+                         ((jl_ir_inlining_cost(inferred) == UINT16_MAX) || // don't delete inlineable code
+                          jl_atomic_load_relaxed(&codeinst->invoke) == jl_fptr_const_return_addr) && // unless it is constant
+                         !(params.imaging_mode || jl_options.incremental)) { // don't delete code when generating a precompile file
                     jl_atomic_store_release(&codeinst->inferred, jl_nothing);
                 }
             }

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -725,16 +725,6 @@ static uintptr_t jl_fptr_id(void *fptr)
         return *(uintptr_t*)pbp;
 }
 
-static int effects_foldable(uint32_t effects)
-{
-    // N.B.: This needs to be kept in sync with Core.Compiler.is_foldable(effects, true)
-    return ((effects & 0x7) == 0) && // is_consistent(effects)
-           (((effects >> 10) & 0x03) == 0) && // is_noub(effects)
-           (((effects >> 3) & 0x03) == 0) && // is_effect_free(effects)
-           ((effects >> 6) & 0x01); // is_terminates(effects)
-}
-
-
 // `jl_queue_for_serialization` adds items to `serialization_order`
 #define jl_queue_for_serialization(s, v) jl_queue_for_serialization_((s), (jl_value_t*)(v), 1, 0)
 static void jl_queue_for_serialization_(jl_serializer_state *s, jl_value_t *v, int recursive, int immediate) JL_GC_DISABLED;
@@ -848,25 +838,8 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
             // TODO: if (ci in ci->defs->cache)
             record_field_change((jl_value_t**)&ci->next, NULL);
         }
-        jl_value_t *inferred = jl_atomic_load_relaxed(&ci->inferred);
-        if (inferred && inferred != jl_nothing) { // disregard if there is nothing here to delete (e.g. builtins, unspecialized)
-            if (!is_relocatable_ci(&relocatable_ext_cis, ci))
-                record_field_change((jl_value_t**)&ci->inferred, jl_nothing);
-            else if (jl_is_method(ci->def->def.method) && // don't delete toplevel code
-                     ci->def->def.method->source) { // don't delete code from optimized opaque closures that can't be reconstructed (and builtins)
-                if (jl_atomic_load_relaxed(&ci->max_world) != ~(size_t)0 || // delete all code that cannot run
-                    jl_atomic_load_relaxed(&ci->invoke) == jl_fptr_const_return) { // delete all code that just returns a constant
-                    record_field_change((jl_value_t**)&ci->inferred, jl_nothing);
-                }
-                else if (native_functions && // don't delete any code if making a ji file
-                         (ci->owner == jl_nothing) && // don't delete code for external interpreters
-                         !effects_foldable(ci->ipo_purity_bits) && // don't delete code we may want for irinterp
-                         jl_ir_inlining_cost(inferred) == UINT16_MAX) { // don't delete inlineable code
-                    // delete the code now: if we thought it was worth keeping, it would have been converted to object code
-                    record_field_change((jl_value_t**)&ci->inferred, jl_nothing);
-                }
-            }
-        }
+        if (jl_atomic_load_relaxed(&ci->inferred) && !is_relocatable_ci(&relocatable_ext_cis, ci))
+            record_field_change((jl_value_t**)&ci->inferred, jl_nothing);
     }
 
     if (immediate) // must be things that can be recursively handled, and valid as type parameters


### PR DESCRIPTION
This reverts commit bdf8219ee80557ea6035b421b00d91b1174234f2, from #56749

**Note that this PR is made against `backports-release-1.11`.**

Rationale: when coverage is on, both the native code and the inferred code might be eliminated, a complete loss of all precompilation results. There are intentions to adopt a new strategy for Julia 1.12, but in the meantime we should revert this change since it is "just" a sysimg size reduction.

Affected Julia versions: 1.11.3, 1.11.4

xref https://github.com/timholy/SnoopCompile.jl/pull/413#issuecomment-2743794491