### PR TITLE
Switch RISC-V to large model on LLVM 20

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1385,13 +1385,13 @@ namespace {
 #endif
         if (TheTriple.isAArch64())
             codemodel = CodeModel::Small;
+#if JL_LLVM_VERSION < 200000
         else if (TheTriple.isRISCV()) {
-#if JL_LLVM_VERSION >= 200000
-            codemodel = CodeModel::Large;
-#else
+            // RISC-V only supports large code model from LLVM 20
+            // https://github.com/llvm/llvm-project/pull/70308
             codemodel = CodeModel::Medium;
-#endif
         }
+#endif
         // Generate simpler code for JIT
         Reloc::Model relocmodel = Reloc::Static;
         if (TheTriple.isRISCV()) {

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1386,9 +1386,11 @@ namespace {
         if (TheTriple.isAArch64())
             codemodel = CodeModel::Small;
         else if (TheTriple.isRISCV()) {
-            // RISC-V will support large code model in LLVM 21
-            // https://github.com/llvm/llvm-project/pull/70308
+#if JL_LLVM_VERSION >= 200000
+            codemodel = CodeModel::Large;
+#else
             codemodel = CodeModel::Medium;
+#endif
         }
         // Generate simpler code for JIT
         Reloc::Model relocmodel = Reloc::Static;


### PR DESCRIPTION
Given https://github.com/llvm/llvm-project/pull/70308 is in LLVM 20, I guess we can switch to it barring any bugs.
