### PR TITLE
`Base`: `PCRE`: `exec`: type assert `String` after construction

### DIFF
--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -199,7 +199,7 @@ end
 exec(re, subject::Union{String,SubString{String}}, offset, options, match_data) =
     _exec(re, subject, offset, options, match_data)
 exec(re, subject, offset, options, match_data) =
-    _exec(re, String(subject), offset, options, match_data)
+    _exec(re, String(subject)::String, offset, options, match_data)
 
 function _exec(re, subject, offset, options, match_data)
     rc = ccall((:pcre2_match_8, PCRE_LIB), Cint,


### PR DESCRIPTION
Should prevent some invalidation in the sysimage.