### PR TITLE
jldoctest complete in logging.jl

### DIFF
--- a/base/logging/logging.jl
+++ b/base/logging/logging.jl
@@ -117,7 +117,7 @@ filtered, before any other work is done to construct the log record data
 structure itself.
 
 # Examples
-```julia-repl
+```jldoctest
 julia> Logging.LogLevel(0) == Logging.Info
 true
 ```


### PR DESCRIPTION
This is an initial switch from julia-repl to jldoctest, as requested here: https://github.com/JuliaLang/julia/issues/56921

Longer term plan is to create a second PR where switch all julia-repl to jldoctest that does not necessarily need filter = regex, then a third for the filter = regex.

Tested with test/corelogging

