### PR TITLE
only show backdated binding warning when deprecation warnings are enabled

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -774,13 +774,15 @@ JL_DLLEXPORT jl_module_t *jl_get_module_of_binding(jl_module_t *m, jl_sym_t *var
 
 static NOINLINE void print_backdate_admonition(jl_binding_t *b) JL_NOTSAFEPOINT
 {
-    jl_safe_printf(
-        "WARNING: Detected access to binding `%s.%s` in a world prior to its definition world.\n"
-        "  Julia 1.12 has introduced more strict world age semantics for global bindings.\n"
-        "  !!! This code may malfunction under Revise.\n"
-        "  !!! This code will error in future versions of Julia.\n"
-        "Hint: Add an appropriate `invokelatest` around the access to this binding.\n",
-        jl_symbol_name(b->globalref->mod->name), jl_symbol_name(b->globalref->name));
+    if (jl_options.depwarn != JL_OPTIONS_DEPWARN_OFF) {
+        jl_safe_printf(
+            "WARNING: Detected access to binding `%s.%s` in a world prior to its definition world.\n"
+            "  Julia 1.12 has introduced more strict world age semantics for global bindings.\n"
+            "  !!! This code may malfunction under Revise.\n"
+            "  !!! This code will error in future versions of Julia.\n"
+            "Hint: Add an appropriate `invokelatest` around the access to this binding.\n",
+            jl_symbol_name(b->globalref->mod->name), jl_symbol_name(b->globalref->name));
+    }
 }
 
 static inline void check_backdated_binding(jl_binding_t *b, enum jl_partition_kind kind) JL_NOTSAFEPOINT


### PR DESCRIPTION
I think it is way too spammy right now. You precompile a set of packages and then have pages and pages of this warning. Don't think that is ok to introduce by default in a minor release. With the same argument that deprecation warnings are disabled by default, I think this should be as well.