### PR TITLE
Print var"string" as raw string

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1832,7 +1832,7 @@ function show_sym(io::IO, sym::Symbol; allow_macroname=false)
         print(io, '@')
         show_sym(io, Symbol(sym_str[2:end]))
     else
-        print(io, "var", repr(string(sym))) # TODO: this is not quite right, since repr uses String escaping rules, and Symbol uses raw string rules
+        print(io, "var\"$(escape_raw_string(string(sym)))\"")
     end
 end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1832,7 +1832,7 @@ function show_sym(io::IO, sym::Symbol; allow_macroname=false)
         print(io, '@')
         show_sym(io, Symbol(sym_str[2:end]))
     else
-        print(io, "var\"$(escape_raw_string(string(sym)))\"")
+        print(io, "var\"", escape_raw_string(string(sym)), '"')
     end
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -2815,3 +2815,13 @@ end
     @test_repr """:(var"do" = 1)"""
     @weak_test_repr """:(let var"let" = 1; var"let"; end)"""
 end
+
+# Issue 57076
+@testset "show raw string given var\"str\"" begin
+    # In show_sym, only backslashes and quotes should be escaped when printing var"this".
+    @test_repr """:(var"\$" = 1)"""
+    @test_repr """:(var"\\"" = 1)""" # var name is one quote character
+    @test_repr """:(var"~!@#\$%^&*[]_+?" = 1)"""
+    @test_repr """:(var"\a\b\t\n\v\f\r\e" = 1)"""
+    @test_repr """:(var"\x01\u03c0\U03c0" = 1)"""
+end


### PR DESCRIPTION
Fixes #57076.  As stated in a TODO comment, `show_sym` prints `var""` symbols as ordinary strings (where [many things](https://github.com/JuliaLang/julia/blob/master/base/strings/io.jl#L485-L491) are escaped), but it should be a raw string (where only quotes and some backslashes are escaped).  This fails the eval-parse-repr printing test.

On master:
```
julia> a = :(var"\t,\$,\",\\,\u03c0," = 1)
:(var"\\t,\\\$,\",\\\\,\\u03c0," = 1)

julia> a = eval(Meta.parse(repr(a)))
:(var"\\\\t,\\\\\\\$,\",\\\\\\\\,\\\\u03c0," = 1)

julia> a = eval(Meta.parse(repr(a)))
:(var"\\\\\\\\t,\\\\\\\\\\\\\\\$,\",\\\\\\\\\\\\\\\\,\\\\\\\\u03c0," = 1)
```

This PR:
```
julia> a = :(var"\t,\$,\",\\,\u03c0," = 1)
:(var"\t,\$,\",\\,\u03c0," = 1)

julia> a = eval(Meta.parse(repr(a)))
:(var"\t,\$,\",\\,\u03c0," = 1)
```
