### PR TITLE
Undo explicit extra bindings hack in Logging

### DIFF
--- a/stdlib/Logging/src/Logging.jl
+++ b/stdlib/Logging/src/Logging.jl
@@ -8,70 +8,33 @@ and available by default.
 """
 module Logging
 
-# Import the CoreLogging implementation into Logging as new const bindings.
-# Doing it this way (rather than with import) makes these symbols accessible to
-# tab completion.
-for sym in [
-    :LogLevel,
-    :AbstractLogger,
-    :NullLogger,
-    :handle_message, :shouldlog, :min_enabled_level, :catch_exceptions,
-    Symbol("@debug"),
-    Symbol("@info"),
-    Symbol("@warn"),
-    Symbol("@error"),
-    Symbol("@logmsg"),
-    :with_logger,
-    :current_logger,
-    :global_logger,
-    :disable_logging,
-    :SimpleLogger]
-    @eval const $sym = Base.CoreLogging.$sym
-end
-
-# LogLevel aliases (re-)documented here (JuliaLang/julia#40978)
-"""
-    Debug
-
-Alias for [`LogLevel(-1000)`](@ref LogLevel).
-"""
-const Debug = Base.CoreLogging.Debug
-"""
-    Info
-
-Alias for [`LogLevel(0)`](@ref LogLevel).
-"""
-const Info = Base.CoreLogging.Info
-"""
-    Warn
-
-Alias for [`LogLevel(1000)`](@ref LogLevel).
-"""
-const Warn = Base.CoreLogging.Warn
-"""
-    Error
-
-Alias for [`LogLevel(2000)`](@ref LogLevel).
-"""
-const Error = Base.CoreLogging.Error
-"""
-    BelowMinLevel
-
-Alias for [`LogLevel(-1_000_001)`](@ref LogLevel).
-"""
-const BelowMinLevel = Base.CoreLogging.BelowMinLevel
-"""
-    AboveMaxLevel
-
-Alias for [`LogLevel(1_000_001)`](@ref LogLevel).
-"""
-const AboveMaxLevel = Base.CoreLogging.AboveMaxLevel
-
-using Base.CoreLogging:
-    closed_stream, ConsoleLogger, default_metafmt
-
-# Some packages use `Logging.default_logcolor`
-const default_logcolor = Base.CoreLogging.default_logcolor
+import Base.CoreLogging:
+    LogLevel,
+    AbstractLogger,
+    NullLogger,
+    handle_message, shouldlog, min_enabled_level, catch_exceptions,
+    var"@debug",
+    var"@info",
+    var"@warn",
+    var"@error",
+    var"@logmsg",
+    with_logger,
+    current_logger,
+    global_logger,
+    disable_logging,
+    SimpleLogger,
+    Debug,
+    Info,
+    Warn,
+    Error,
+    BelowMinLevel,
+    AboveMaxLevel,
+    default_logcolor,
+    closed_stream,
+    ConsoleLogger,
+    default_metafmt,
+    # Some packages use `Logging.default_logcolor`
+    default_logcolor
 
 export
     AbstractLogger,
@@ -95,12 +58,6 @@ export
     Error,
     AboveMaxLevel
 
-# The following are also part of the public API, but not exported:
-#
-# 1. Log levels:
-#   BelowMinLevel, Debug, Info, Warn, Error, AboveMaxLevel,
-#
-# 2. AbstractLogger message related functions:
-#  handle_message, shouldlog, min_enabled_level, catch_exceptions,
+public handle_message, shouldlog, min_enabled_level, catch_exceptions
 
 end


### PR DESCRIPTION
We now have `public` to indicate public symbols, which addresses the original reason this hack was introduced. Semantically reverts #32473.