### PR TITLE
treat empty `AbstractVector` like empty `Vector` in `print_array`

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -361,7 +361,7 @@ print_array(io::IO, X::AbstractArray) = show_nd(io, X, print_matrix, true)
 # typeinfo aware
 # implements: show(io::IO, ::MIME"text/plain", X::AbstractArray)
 function show(io::IO, ::MIME"text/plain", X::AbstractArray)
-    if isempty(X) && (get(io, :compact, false)::Bool || X isa Vector)
+    if isempty(X) && (get(io, :compact, false)::Bool || X isa AbstractVector)
         return show(io, X)
     end
     # 1) show summary before setting :compact


### PR DESCRIPTION
I don't see why an empty `Vector` should be displayed differently from any other empty `AbstractVector`. Here is an example using views:

`Vector` (both master and this PR):
```
julia> [collect(Int8, 1:k) for k in (0,2)]
2-element Vector{Vector{Int8}}:
 []
 [1, 2]

julia> Any[collect(Int8, 1:k) for k in (0,2)]
2-element Vector{Any}:
 Int8[]
 Int8[1, 2]
```

`AbstractVector` in master:
```
julia> v = Int8[1,2]; [view(v, 1:k) for k in (0,2)]
2-element Vector{SubArray{Int8, 1, Vector{Int8}, Tuple{UnitRange{Int64}}, true}}:
 0-element view(::Vector{Int8}, 1:0) with eltype Int8
 [1, 2]

julia> v = Int8[1,2]; Any[view(v, 1:k) for k in (0,2)]
2-element Vector{Any}:
 0-element view(::Vector{Int8}, 1:0) with eltype Int8
 Int8[1, 2]
```

`AbstractVector` with this PR:
```
julia> v = Int8[1,2]; [view(v, 1:k) for k in (0,2)]
2-element Vector{SubArray{Int8, 1, Vector{Int8}, Tuple{UnitRange{Int64}}, true}}:
 []
 [1, 2]

julia> v = Int8[1,2]; Any[view(v, 1:k) for k in (0,2)]
2-element Vector{Any}:
 Int8[]
 Int8[1, 2]
```
