### PR TITLE
fix: `Base.julia_cmd()` did not reflect the --banner and --quiet flags.

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -248,6 +248,16 @@ function julia_cmd(julia=joinpath(Sys.BINDIR, julia_exename()); cpu_target::Unio
     if opts.compress_sysimage == 1
         push!(addflags, "--compress-sysimage=yes")
     end
+    if opts.quiet == 1
+        push!(addflags, "--quiet")
+    end
+    if opts.banner == 0
+        push!(addflags, "--banner=no")
+    elseif opts.banner == 1
+        push!(addflags, "--banner=yes")
+    elseif opts.banner == 2
+        push!(addflags, "--banner=short")
+    end
     return `$julia -C $cpu_target -J$image_file $addflags`
 end
 

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -180,6 +180,11 @@ end
 
                             ("--pkgimages=yes", true),
                             ("--pkgimages=no",  false),
+
+                            ("--banner=auto", true),
+                            ("--banner=no", false),
+                            ("--banner=yes", false),
+                            ("--banner=short", false),
                         )
         @testset "$arg" begin
             str = arg isa Cmd ? join(arg.exec, ' ') : arg

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -185,6 +185,8 @@ end
                             ("--banner=no", false),
                             ("--banner=yes", false),
                             ("--banner=short", false),
+
+                            ("--quiet", false),
                         )
         @testset "$arg" begin
             str = arg isa Cmd ? join(arg.exec, ' ') : arg


### PR DESCRIPTION
closes #57901
As described in the issue `Base.julia_cmd()` was not reflecting the `--banner` and `--quiet` flags. 

I was able to add tests for the `--banner` flag, but I'm not sure how to add tests for the `--quiet` flag.
