### PR TITLE
`Base`: shell escaping: inference improvement to prevent invalidation

### DIFF
--- a/base/shell.jl
+++ b/base/shell.jl
@@ -344,7 +344,7 @@ function shell_escape_csh(io::IO, args::AbstractString...)
 end
 shell_escape_csh(args::AbstractString...) =
     sprint(shell_escape_csh, args...;
-           sizehint = mapreduce(sizeof, +, args; init = 0) + length(args) * 3)
+           sizehint = sum(sizeof, args) + length(args) * 3)
 
 """
     shell_escape_wincmd(s::AbstractString)

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -494,4 +494,4 @@ function escape_microsoft_c_args(io::IO, args::AbstractString...)
 end
 escape_microsoft_c_args(args::AbstractString...) =
     sprint(escape_microsoft_c_args, args...;
-           sizehint = (mapreduce(sizeof, +, args; init = 0) + 3*length(args)))
+           sizehint = (sum(sizeof, args) + 3*length(args)))

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -344,7 +344,7 @@ function shell_escape_csh(io::IO, args::AbstractString...)
 end
 shell_escape_csh(args::AbstractString...) =
     sprint(shell_escape_csh, args...;
-           sizehint = sum(sizeof.(args)) + length(args) * 3)
+           sizehint = mapreduce(sizeof, +, args; init = 0) + length(args) * 3)
 
 """
     shell_escape_wincmd(s::AbstractString)
@@ -494,4 +494,4 @@ function escape_microsoft_c_args(io::IO, args::AbstractString...)
 end
 escape_microsoft_c_args(args::AbstractString...) =
     sprint(escape_microsoft_c_args, args...;
-           sizehint = (sum(sizeof.(args)) + 3*length(args)))
+           sizehint = (mapreduce(sizeof, +, args; init = 0) + 3*length(args)))


### PR DESCRIPTION
Should make the sysimage more resistant to invalidation.