### PR TITLE
`REPL`: typeassert `displaysize` return value

### DIFF
--- a/stdlib/REPL/src/Terminals.jl
+++ b/stdlib/REPL/src/Terminals.jl
@@ -146,7 +146,7 @@ end
 @eval clear_line(t::UnixTerminal) = write(t.out_stream, $"\r$(CSI)0K")
 beep(t::UnixTerminal) = write(t.err_stream,"\x7")
 
-Base.displaysize(t::UnixTerminal) = displaysize(t.out_stream)
+Base.displaysize(t::UnixTerminal) = displaysize(t.out_stream)::Tuple{Int,Int}
 
 hascolor(t::TTYTerminal) = get(t.out_stream, :color, false)::Bool
 

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1953,6 +1953,10 @@ end
     end
 end
 
+@testset "`displaysize` return type inference" begin
+    @test Tuple{Int, Int} === Base.infer_return_type(displaysize, Tuple{REPL.Terminals.UnixTerminal})
+end
+
 @testset "Dummy Pkg prompt" begin
     # do this in an empty depot to test default for new users
     withenv("JULIA_DEPOT_PATH" => mktempdir() * (Sys.iswindows() ? ";" : ":"), "JULIA_LOAD_PATH" => nothing) do


### PR DESCRIPTION
Improve abstract type inference. This is OK because `displaysize` is documented to always return a `Tuple{Int, Int}` value.

Also add a test.