### PR TITLE
`_precompilepkgs`: interactive progress display: declare index var type

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -813,7 +813,7 @@ function _precompilepkgs(pkgs::Vector{String},
             end
             t = Timer(0; interval=1/10)
             anim_chars = ["◐","◓","◑","◒"]
-            i = 1
+            i::Int = 1
             last_length = 0
             bar = MiniProgressBar(; indent=0, header = "Precompiling packages ", color = :green, percentage=false, always_reprint=true)
             n_total = length(direct_deps) * length(configs)


### PR DESCRIPTION
The variable `i` gets `Box`ed because it's captured by the closures below and assigned to there. I think that means declaring `i::Int` might help Julia's type inference.