### PR TITLE
fix trimming for scheduler task

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -1152,7 +1152,7 @@ end
 end
 
 const get_sched_task = OncePerThread{Task}() do
-    @task wait_forever()
+    Task(wait_forever)
 end
 
 function ensure_rescheduled(othertask::Task)

--- a/contrib/juliac-buildscript.jl
+++ b/contrib/juliac-buildscript.jl
@@ -197,6 +197,7 @@ let mod = Base.include(Base.__toplevel__, inputfile)
     #entrypoint(join, (Base.GenericIOBuffer{Memory{UInt8}}, Array{String, 1}, Char))
     entrypoint(Base.task_done_hook, (Task,))
     entrypoint(Base.wait, ())
+    entrypoint(Base.wait_forever, ())
     entrypoint(Base.trypoptask, (Base.StickyWorkqueue,))
     entrypoint(Base.checktaskempty, ())
     if add_ccallables


### PR DESCRIPTION
This unfortunately passed tests because it segfaults (sometimes) on another thread while the main thread successfully executes. Soon we'll have a general solution for tasks but this fixes it for now.