### PR TITLE
`_precompilepkgs`: interactive progress display: fix unintended capture

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -835,8 +835,8 @@ function _precompilepkgs(pkgs::Vector{String},
                         # window between print cycles
                         termwidth = displaysize(io)[2] - 4
                         if !final_loop
-                            str = sprint(io -> show_progress(io, bar; termwidth, carriagereturn=false); context=io)
-                            print(iostr, Base._truncate_at_width_or_chars(true, str, termwidth), "\n")
+                            s = sprint(io -> show_progress(io, bar; termwidth, carriagereturn=false); context=io)
+                            print(iostr, Base._truncate_at_width_or_chars(true, s, termwidth), "\n")
                         end
                         for pkg_config in pkg_queue_show
                             dep, config = pkg_config


### PR DESCRIPTION
The variable `str` also exists in one of the enclosing closures. Use a new variable, as was surely intended, instead of capturing and mutating the `str`.

Improves the sysimage's resistance to invalidation.