### PR TITLE
Add `Base.active_manifest()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -78,6 +78,8 @@ New library features
 * `Base.ScopedValues.LazyScopedValue{T}` is introduced for scoped values that compute their default using a
   `OncePerProcess{T}` callback, allowing for lazy initialization of the default value. `AbstractScopedValue` is
   now the abstract base type for both `ScopedValue` and `LazyScopedValue`. ([#59372])
+* `sort(keys(::Dict))` and `sort(values(::Dict))` now automatically collect, they previously threw ([#56978]).
+* New `Base.active_manifest()` function to return the path of the active manifest, like `Base.active_project()` ([#])
 
 Standard library changes
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -78,7 +78,6 @@ New library features
 * `Base.ScopedValues.LazyScopedValue{T}` is introduced for scoped values that compute their default using a
   `OncePerProcess{T}` callback, allowing for lazy initialization of the default value. `AbstractScopedValue` is
   now the abstract base type for both `ScopedValue` and `LazyScopedValue`. ([#59372])
-* `sort(keys(::Dict))` and `sort(values(::Dict))` now automatically collect, they previously threw ([#56978]).
 * New `Base.active_manifest()` function to return the path of the active manifest, like `Base.active_project()`.
   Also can return the manifest that would be used for a given project file ([#57937])
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -79,7 +79,8 @@ New library features
   `OncePerProcess{T}` callback, allowing for lazy initialization of the default value. `AbstractScopedValue` is
   now the abstract base type for both `ScopedValue` and `LazyScopedValue`. ([#59372])
 * `sort(keys(::Dict))` and `sort(values(::Dict))` now automatically collect, they previously threw ([#56978]).
-* New `Base.active_manifest()` function to return the path of the active manifest, like `Base.active_project()` ([#])
+* New `Base.active_manifest()` function to return the path of the active manifest, like `Base.active_project()`.
+  Also can return the manifest that would be used for a given project file ([#57937])
 
 Standard library changes
 ------------------------

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -371,6 +371,21 @@ function set_active_project(projfile::Union{AbstractString,Nothing})
     end
 end
 
+"""
+    active_manifest()
+
+Return the path of the active manifest file. See [`Project environments`](@ref) for
+details on the difference between a project and a manifest, and the naming options and
+their priority when searching for a manifest file.
+
+See also [`Base.active_project`](@ref), [`Base.set_active_project`](@ref).
+"""
+function active_manifest(search_load_path::Bool=true)
+    proj = active_project(search_load_path)
+    proj === nothing && return nothing
+    return project_file_manifest_path(proj)
+end
+
 
 """
     load_path()

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -376,6 +376,11 @@ end
     active_manifest(project_file::AbstractString)
 
 Return the path of the active manifest file, or the manifest file that would be used for a given `project_file`.
+
+In a stacked environment (where multiple environments exist in the load path), this returns the manifest
+file for the primary (active) environment only, not the manifests from other environments in the stack.
+See the manual section on [Environment stacks](@ref) for more details on how stacked environments work.
+
 See [`Project environments`](@ref project-environments) for details on the difference between a project and a manifest, and the naming
 options and their priority in package loading.
 

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -382,7 +382,8 @@ options and their priority in package loading.
 See also [`Base.active_project`](@ref), [`Base.set_active_project`](@ref).
 """
 function active_manifest(project_file::Union{AbstractString,Nothing}=nothing, search_load_path::Bool=true)
-    project_file === @something project_file active_project(search_load_path)
+    # If `project_file` was specified, use that, otherwise get the active project:
+    project_file === !isnothing(project_file) ? project_file : active_project(search_load_path)
     project_file === nothing && return nothing
     return project_file_manifest_path(project_file)
 end

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -381,7 +381,7 @@ options and their priority in package loading.
 
 See also [`Base.active_project`](@ref), [`Base.set_active_project`](@ref).
 """
-function active_manifest(project_file::Union{AbstractString,Nothing}=nothing, search_load_path::Bool=true)
+function active_manifest(project_file::Union{AbstractString,Nothing}=nothing; search_load_path::Bool=true)
     # If `project_file` was specified, use that, otherwise get the active project:
     project_file === !isnothing(project_file) ? project_file : active_project(search_load_path)
     project_file === nothing && return nothing

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -383,7 +383,7 @@ See also [`Base.active_project`](@ref), [`Base.set_active_project`](@ref).
 """
 function active_manifest(project_file::Union{AbstractString,Nothing}=nothing; search_load_path::Bool=true)
     # If `project_file` was specified, use that, otherwise get the active project:
-    project_file === !isnothing(project_file) ? project_file : active_project(search_load_path)
+    project_file = !isnothing(project_file) ? project_file : active_project(search_load_path)
     project_file === nothing && return nothing
     return project_file_manifest_path(project_file)
 end

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -382,7 +382,7 @@ options and their priority in package loading.
 See also [`Base.active_project`](@ref), [`Base.set_active_project`](@ref).
 """
 function active_manifest(project_file::Union{AbstractString,Nothing}=nothing, search_load_path::Bool=true)
-    project_file === @someting project_file active_project(search_load_path)
+    project_file === @something project_file active_project(search_load_path)
     project_file === nothing && return nothing
     return project_file_manifest_path(project_file)
 end

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -376,7 +376,7 @@ end
     active_manifest(project_file::AbstractString)
 
 Return the path of the active manifest file, or the manifest file that would be used for a given `project_file`.
-See [`Project environments`](@ref) for details on the difference between a project and a manifest, and the naming
+See [`Project environments`](@ref project-environments) for details on the difference between a project and a manifest, and the naming
 options and their priority in package loading.
 
 See also [`Base.active_project`](@ref), [`Base.set_active_project`](@ref).

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -373,19 +373,19 @@ end
 
 """
     active_manifest()
+    active_manifest(project_file::AbstractString)
 
-Return the path of the active manifest file. See [`Project environments`](@ref) for
-details on the difference between a project and a manifest, and the naming options and
-their priority when searching for a manifest file.
+Return the path of the active manifest file, or the manifest file that would be used for a given `project_file`.
+See [`Project environments`](@ref) for details on the difference between a project and a manifest, and the naming
+options and their priority in package loading.
 
 See also [`Base.active_project`](@ref), [`Base.set_active_project`](@ref).
 """
-function active_manifest(search_load_path::Bool=true)
-    proj = active_project(search_load_path)
-    proj === nothing && return nothing
-    return project_file_manifest_path(proj)
+function active_manifest(project_file::Union{AbstractString,Nothing}=nothing, search_load_path::Bool=true)
+    project_file === @someting project_file active_project(search_load_path)
+    project_file === nothing && return nothing
+    return project_file_manifest_path(project_file)
 end
-
 
 """
     load_path()

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -885,6 +885,7 @@ function project_file_manifest_path(project_file::String)::Union{Nothing,String}
         manifest_path === missing || return manifest_path
     end
     dir = abspath(dirname(project_file))
+    isfile_casesensitive(project_file) || return nothing
     d = parsed_toml(project_file)
     base_manifest = workspace_manifest(project_file)
     if base_manifest !== nothing

--- a/base/public.jl
+++ b/base/public.jl
@@ -53,6 +53,7 @@ public
     DL_LOAD_PATH,
     load_path,
     active_project,
+    active_manifest,
 
 # Reflection and introspection
     get_extension,

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -44,6 +44,7 @@ ans
 err
 Base.active_project
 Base.set_active_project
+Base.active_manifest
 ```
 
 ## [Keywords](@id Keywords)

--- a/doc/src/manual/code-loading.md
+++ b/doc/src/manual/code-loading.md
@@ -64,7 +64,7 @@ Each kind of environment defines these three maps differently, as detailed in th
 !!! note
     For ease of understanding, the examples throughout this chapter show full data structures for roots, graph and paths. However, Julia's package loading code does not explicitly create these. Instead, it lazily computes only as much of each structure as it needs to load a given package.
 
-### Project environments
+### [Project environments](@id project-environments)
 
 A project environment is determined by a directory containing a project file called `Project.toml`, and optionally a manifest file called `Manifest.toml`. These files may also be called `JuliaProject.toml` and `JuliaManifest.toml`, in which case `Project.toml` and `Manifest.toml` are ignored. This allows for coexistence with other tools that might consider files called `Project.toml` and `Manifest.toml` significant. For pure Julia projects, however, the names `Project.toml` and `Manifest.toml` are preferred. However, from Julia v1.10.8 onwards, `(Julia)Manifest-v{major}.{minor}.toml` is recognized as a format to make a given julia version use a specific manifest file i.e. in the same folder, a `Manifest-v1.11.toml` would be used by v1.11 and `Manifest.toml` by any other julia version.
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -3,7 +3,7 @@
 using Test
 
 # Tests for @__LINE__ inside and outside of macros
-# NOTE: the __LINE__ numbers for these first couple tests are signifmktempdiricant, so
+# NOTE: the __LINE__ numbers for these first couple tests are significant, so
 # adding any lines here will make those tests fail
 @test (@__LINE__) == 8
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -708,7 +708,7 @@ mktempdir() do dir
     @test success(cmd)
 end
 
-@testset "Base.active_manifest()" begin 
+@testset "Base.active_manifest()" begin
     old_act_proj = Base.ACTIVE_PROJECT[]
     try
         Base.ACTIVE_PROJECT[] = nothing

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -708,6 +708,16 @@ mktempdir() do dir
     @test success(cmd)
 end
 
+@testset "Base.active_manifest()" begin 
+    old_act_proj = Base.ACTIVE_PROJECT[]
+    try
+        Base.ACTIVE_PROJECT[] = nothing
+        @test Base.active_manifest === nothing
+    finally
+        Base.ACTIVE_PROJECT[] = old_act_proj
+    end
+end
+
 @testset "expansion of JULIA_LOAD_PATH" begin
     s = Sys.iswindows() ? ';' : ':'
     tmp = "/this/does/not/exist"

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -709,7 +709,7 @@ mktempdir() do dir
 end
 
 old_act_proj = Base.ACTIVE_PROJECT[]
-function _with_activate(f::Function, project_file::AbstractString)
+function _with_activate(f::Function, project_file::Union{AbstractString, Nothing})
     try
         Base.ACTIVE_PROJECT[] = project_file
         f()
@@ -717,7 +717,7 @@ function _with_activate(f::Function, project_file::AbstractString)
         Base.ACTIVE_PROJECT[] = old_act_proj
     end
 end
-function _activate_and_get_active_manifest_noarg(project_file::AbstractString)
+function _activate_and_get_active_manifest_noarg(project_file::Union{AbstractString, Nothing})
     _with_activate(project_file) do
         Base.active_manifest()
     end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -709,12 +709,17 @@ mktempdir() do dir
 end
 
 old_act_proj = Base.ACTIVE_PROJECT[]
-function _activate_and_get_active_manifest_noarg(f::Function, project_file::AbstractString)
-    return try
+function _with_activate(f::Function, project_file::AbstractString)
+    try
         Base.ACTIVE_PROJECT[] = project_file
-        return Base.active_manifest()
+        f()
     finally
         Base.ACTIVE_PROJECT[] = old_act_proj
+    end
+end
+function _activate_and_get_active_manifest_noarg(project_file::AbstractString)
+    _with_activate(project_file) do
+        Base.active_manifest()
     end
 end
 
@@ -737,7 +742,7 @@ end
 
             # If the project file exists but the manifest file does not, active_manifest() should still return `nothing`:
             touch(proj)
-            @test _activate_and_get_active_manifest_noarg() === nothing
+            @test _activate_and_get_active_manifest_noarg(proj) === nothing
 
             # If the project and manifest files both exist, active_manifest() should return the path to the manifest:
             manif = joinpath(proj, "Manifest.toml")

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -745,7 +745,7 @@ end
             @test _activate_and_get_active_manifest_noarg(proj) === nothing
 
             # If the project and manifest files both exist, active_manifest() should return the path to the manifest:
-            manif = joinpath(proj, "Manifest.toml")
+            manif = joinpath(dir, "Manifest.toml")
             touch(manif)
             @test _activate_and_get_active_manifest_noarg(proj) == manif
 
@@ -771,7 +771,7 @@ end
             @test Base.active_manifest(proj) === nothing
 
             # If the project and manifest files both exist, active_manifest(proj) should return the path to the manifest:
-            manif = joinpath(proj, "Manifest.toml")
+            manif = joinpath(dir, "Manifest.toml")
             touch(manif)
             @test Base.active_manifest(proj) == manif
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -784,7 +784,7 @@ end
     @testset "Project file does not exist => active_manifest() is nothing" begin
         mktempdir() do dir
             proj = joinpath(dir, "Project.toml")
-            @test Base.active_manifest(proj) = nothing
+            @test Base.active_manifest(proj) === nothing
             @test _activate_and_get_active_manifest_noarg(proj) === nothing
         end
     end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -743,7 +743,7 @@ end
         for (proj, expected_man) in test_cases
             @test _activate_and_get_active_manifest_noarg(proj) == expected_man
             # Base.active_manifest() should never return a file that doesn't exist:
-            @test isfile_activate_and_get_active_manifest_noarg(proj))
+            @test isfile(_activate_and_get_active_manifest_noarg(proj))
         end
         mktempdir() do dir
             proj = joinpath(dir, "Project.toml")

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -735,9 +735,18 @@ end
             # If the project file doesn't exist, active_manifest() should return `nothing`:
             @test _activate_and_get_active_manifest_noarg(proj) === nothing
 
-            # Once the project file exists, active_manifest() should return the path to the manifest:
+            # If the project file exists but the manifest file does not, active_manifest() should still return `nothing`:
             touch(proj)
-            @test _activate_and_get_active_manifest_noarg(proj) == joinpath(proj, "Manifest.toml")
+            @test _activate_and_get_active_manifest_noarg() === nothing
+
+            # If the project and manifest files both exist, active_manifest() should return the path to the manifest:
+            manif = joinpath(proj, "Manifest.toml")
+            touch(manif)
+            @test _activate_and_get_active_manifest_noarg(proj) == manif
+
+            # If the manifest file exists but the project file does not, active_manifest() should return `nothing`:
+            rm(proj)
+            @test _activate_and_get_active_manifest_noarg(proj) == nothing
         end
     end
 
@@ -752,9 +761,18 @@ end
             # If the project file doesn't exist, active_manifest(proj) should return `nothing`:
             @test Base.active_manifest(proj) === nothing
 
-            # Once the project file exists, active_manifest(proj) should return the path to the manifest:
+            # If the project file exists but the manifest file does not, active_manifest(proj) should still return `nothing`:
             touch(proj)
-            @test Base.active_manifest(proj) == joinpath(proj, "Manifest.toml")
+            @test Base.active_manifest(proj) === nothing
+
+            # If the project and manifest files both exist, active_manifest(proj) should return the path to the manifest:
+            manif = joinpath(proj, "Manifest.toml")
+            touch(manif)
+            @test Base.active_manifest(proj) == manif
+
+            # If the manifest file exists but the project file does not, active_manifest(proj) should return `nothing`:
+            rm(proj)
+            @test Base.active_manifest(proj) === nothing
         end
     end
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -731,8 +731,10 @@ end
         end
         mktempdir do dir
             proj = joinpath(dir, "Project.toml")
+
             # If the project file doesn't exist, active_manifest() should return `nothing`:
             @test _activate_and_get_active_manifest_noarg(proj) === nothing
+
             # Once the project file exists, active_manifest() should return the path to the manifest:
             touch(proj)
             @test _activate_and_get_active_manifest_noarg(proj) == joinpath(proj, "Manifest.toml")
@@ -746,7 +748,11 @@ end
         end
         mktempdir do dir
             proj = joinpath(dir, "Project.toml")
+
+            # If the project file doesn't exist, active_manifest(proj) should return `nothing`:
             @test Base.active_manifest(proj) === nothing
+
+            # Once the project file exists, active_manifest(proj) should return the path to the manifest:
             touch(proj)
             @test Base.active_manifest(proj) == joinpath(proj, "Manifest.toml")
         end
@@ -761,7 +767,7 @@ end
         mktempdir() do dir
             proj = joinpath(dir, "Project.toml")
             @test Base.active_manifest(proj) = nothing
-            @test _activate_and_get_active_manifest_noarg() === nothing
+            @test _activate_and_get_active_manifest_noarg(proj) === nothing
         end
     end
 end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -3,7 +3,7 @@
 using Test
 
 # Tests for @__LINE__ inside and outside of macros
-# NOTE: the __LINE__ numbers for these first couple tests are significant, so
+# NOTE: the __LINE__ numbers for these first couple tests are signifmktempdiricant, so
 # adding any lines here will make those tests fail
 @test (@__LINE__) == 8
 
@@ -729,7 +729,7 @@ end
         for (proj, expected_man) in test_cases
             @test _activate_and_get_active_manifest_noarg(proj) == expected_man
         end
-        mktempdir do dir
+        mktempdir() do dir
             proj = joinpath(dir, "Project.toml")
 
             # If the project file doesn't exist, active_manifest() should return `nothing`:
@@ -755,7 +755,7 @@ end
         for (proj, expected_man) in test_cases
             @test Base.active_manifest(proj) == expected_man
         end
-        mktempdir do dir
+        mktempdir() do dir
             proj = joinpath(dir, "Project.toml")
 
             # If the project file doesn't exist, active_manifest(proj) should return `nothing`:

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -782,8 +782,10 @@ end
     end
 
     @testset "ACTIVE_PROJECT[] is `nothing` => active_manifest() is nothing" begin
-        @test Base.active_manifest(nothing) === nothing
-        @test _activate_and_get_active_manifest_noarg(nothing) === nothing
+        _with_activate(nothing) do
+            @test Base.active_manifest() === nothing
+            @test Base.active_manifest(nothing) === nothing
+        end
     end
 
     @testset "Project file does not exist => active_manifest() is nothing" begin


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/57924

```
julia> Base.active_project()
"/Users/ian/.julia/environments/v1.13/Project.toml"

julia> Base.active_manifest()
"/Users/ian/.julia/environments/v1.13/Manifest.toml"

(@v1.13) pkg> activate --temp
  Activating new project at `/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCVFBB`

julia> Base.active_project()
"/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCVFBB/Project.toml"

julia> Base.active_manifest()

julia>
```

I'm holding off adding tests because I wasn't sure whether that last case should match `active_project` and return a path to a nonexistant file? i.e. the temp `Project.toml` doesn't exist, nor manifest.