### PR TITLE
[backports-release-1.11] REPL: only load stdlibs during precompilation script

### DIFF
--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -6,7 +6,7 @@ module Precompile
 import ..REPL
 # Prepare this staging area with all the loaded packages available
 for (_pkgid, _mod) in Base.loaded_modules
-    if !(_pkgid.name in ("Main", "Core", "Base", "REPL"))
+    if !(_pkgid.name in ("Main", "Core", "Base", "REPL")) && Base.is_stdlib(_pkgid)
         eval(:(const $(Symbol(_mod)) = $_mod))
     end
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/57939

Not tested as it's quite involved... requires building a custom sysimage.