### PR TITLE
Set `isreadable(::DevNull) = true`, expand `isreadable` docstring

### DIFF
--- a/base/coreio.jl
+++ b/base/coreio.jl
@@ -20,15 +20,17 @@ closewrite(::DevNull) = nothing
 close(::DevNull) = nothing
 wait_close(::DevNull) = wait()
 bytesavailable(io::DevNull) = 0
+isreadable(::DevNull) = true
 
 let CoreIO = Union{Core.CoreSTDOUT, Core.CoreSTDERR}
     global write(io::CoreIO, x::UInt8) = Core.write(io, x)
     global unsafe_write(io::CoreIO, x::Ptr{UInt8}, nb::UInt) = Core.unsafe_write(io, x, nb)
+    global isreadable(::CoreIO) = false
+
 
     CoreIO = Union{CoreIO, DevNull}
     global read(::CoreIO, ::Type{UInt8}) = throw(EOFError())
     global isopen(::CoreIO) = true
-    global isreadable(::CoreIO) = false
     global iswritable(::CoreIO) = true
     global flush(::CoreIO) = nothing
     global eof(::CoreIO) = true

--- a/base/io.jl
+++ b/base/io.jl
@@ -134,9 +134,13 @@ function readavailable end
 function isexecutable end
 
 """
-    isreadable(io)::Bool
+    isreadable(io::IO)::Bool
 
-Return `false` if the specified IO object is not readable.
+Check if `io` is not readable.
+A readable IO may be EOF, but reading from it will not throw errors during normal
+operation.
+Closing an IO may render it unreadable, depending on the IO.
+
 
 # Examples
 ```jldoctest
@@ -153,6 +157,8 @@ true
 
 julia> rm("myfile.txt")
 ```
+
+See also: [`iswritable`](@ref), [`close`](@ref)
 """
 isreadable(io::IO) = isopen(io)
 
@@ -176,6 +182,8 @@ false
 
 julia> rm("myfile.txt")
 ```
+
+See also: [`isreadable`](@ref)
 """
 iswritable(io::IO) = isopen(io)
 

--- a/test/read.jl
+++ b/test/read.jl
@@ -475,7 +475,7 @@ test_read_nbyte()
 
 
 # devnull
-@test !isreadable(devnull)
+@test isreadable(devnull)
 @test iswritable(devnull)
 @test isopen(devnull)
 @test write(devnull, 0xff) === 1


### PR DESCRIPTION
Devnull is clearly readable, since it's an open, readable but EOF IO object, so the previous implementation must have been buggy. Fix it. Also, expand on what `isreadable` means.

Closes #57942, although there is still an inconsistency in that for some IO objects calling `close` on them does not change their readability (`IOStream`, `DevNull`), whereas others become unreadable (`IOStream`)