### PR TITLE
Disable boundschecks in `unsafe_copyto!`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -281,7 +281,7 @@ the same manner as C.
 """
 function unsafe_copyto!(dest::Array, doffs, src::Array, soffs, n)
     n == 0 && return dest
-    unsafe_copyto!(memoryref(dest.ref, doffs), memoryref(src.ref, soffs), n)
+    @inbounds unsafe_copyto!(memoryref(dest.ref, doffs), memoryref(src.ref, soffs), n)
     return dest
 end
 


### PR DESCRIPTION
It seems silly to have a dedicated unsafe version of copyto!, specifically added because it does not check its argument, and then insert precisely those checks anyway.