### PR TITLE
Use unchecked conversion in `clamp`

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -1338,7 +1338,13 @@ function clamp(x, ::Type{T}) where {T<:Integer}
     # think of, e.g., clamp(big(2) ^ 200, Int16)
     lo = typemin(T)
     hi = typemax(T)
-    return (x > hi) ? hi : (x < lo) ? lo : x % T
+    return if x > hi
+        hi
+    elseif x < lo
+        lo
+    else
+        x isa Integer ? x % T : T(x)
+    end
 end
 
 

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -1338,7 +1338,7 @@ function clamp(x, ::Type{T}) where {T<:Integer}
     # think of, e.g., clamp(big(2) ^ 200, Int16)
     lo = typemin(T)
     hi = typemax(T)
-    return (x > hi) ? hi : (x < lo) ? lo : convert(T, x)
+    return (x > hi) ? hi : (x < lo) ? lo : x % T
 end
 
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -66,6 +66,9 @@ has_fma = Dict(
             @test x isa BigInt
             @test x == big(2)
         end
+
+        @test clamp(2.0, Int) === 2
+        @test_throws InexactError clamp(2.5, Int)
     end
 end
 


### PR DESCRIPTION
No need to check twice if the value fits in the range of `T`.