### PR TITLE
`append_c_digits`: typeassert `Int` to improve inference

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -845,7 +845,7 @@ function append_c_digits(olength::Int, digits::Unsigned, buf, pos::Int)
     while i >= 2
         d, c = divrem(digits, 0x64)
         digits = oftype(digits, d)
-        @inbounds d100 = _dec_d100[(c % Int) + 1]
+        @inbounds d100 = _dec_d100[(c % Int)::Int + 1]
         @inbounds buf[pos + i - 2] = d100 % UInt8
         @inbounds buf[pos + i - 1] = (d100 >> 0x8) % UInt8
         i -= 2


### PR DESCRIPTION
Makes the sysimage more resistant to method invalidation, when defining a new `Integer` subtype with a right bitshift method.