### PR TITLE
better abstract type inference for `oftype`

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -696,7 +696,10 @@ julia> oftype(y, x)
 4.0
 ```
 """
-oftype(x, y) = y isa typeof(x) ? y : convert(typeof(x), y)::typeof(x)
+function oftype(x, y)
+    X = typeof(x)
+    (y isa X ? y : convert(X, y))::X
+end
 
 unsigned(x::Int) = reinterpret(UInt, x)
 signed(x::UInt) = reinterpret(Int, x)

--- a/test/core.jl
+++ b/test/core.jl
@@ -8094,6 +8094,10 @@ end
 f_isdefined_one(@nospecialize(x)) = isdefined(x, 1)
 @test (try; f_isdefined_one(@__MODULE__); catch err; err; end).got === 1
 
+@testset "worst case abstract type inference for `oftype`" begin
+    @test Number === Base.infer_return_type(oftype, Tuple{Number, Any})
+end
+
 # Unspecialized retrieval of vararg length
 fvarargN(x::Tuple{Vararg{Int, N}}) where {N} = N
 fvarargN(args...) = fvarargN(args)


### PR DESCRIPTION
Achieve better abstract return type inference by moving the typeassert to after the branch, so it affects both sides of the branch. Also deduplicate `typeof(x)` calls.