### PR TITLE
CI: Record one result with duration

### DIFF
--- a/test/buildkitetestjson.jl
+++ b/test/buildkitetestjson.jl
@@ -258,9 +258,18 @@ function serialize_testset_result_file(dir::String, testset::Test.DefaultTestSet
 end
 
 # deserilalizes the results files and writes them to collated JSON files of 5000 max results
-function write_testset_json_files(dir::String)
+function write_testset_json_files(dir::String, testset::Test.DefaultTestSet)
     data = Dict{String,Any}[]
     read_files = String[]
+    # Set one result to represent the overall duration, given results have no duration
+    overall_ts = result_dict(testset)
+    overall_ts["location"] = "unknown"
+    overall_ts["result"] = "unknown"
+    job_label = replace(get(ENV, "BUILDKITE_LABEL", "job label not found"), r":\w+:\s*" => "")
+    overall_ts["name"] = job_label
+    overall_ts["file_name"] = "unknown"
+    push!(data, overall_ts)
+    # Load all the serialized results files
     for res_dat in filter!(x -> occursin(r"^results.*\.dat$", x), readdir(dir))
         res_file = joinpath(dir, res_dat)
         append!(data, Serialization.deserialize(res_file))

--- a/test/buildkitetestjson.jl
+++ b/test/buildkitetestjson.jl
@@ -263,11 +263,9 @@ function write_testset_json_files(dir::String, testset::Test.DefaultTestSet)
     read_files = String[]
     # Set one result to represent the overall duration, given results have no duration
     overall_ts = result_dict(testset)
-    overall_ts["location"] = "unknown"
+    # don't set location or file name for this result. They aren't required by BK
     overall_ts["result"] = "unknown"
-    job_label = replace(get(ENV, "BUILDKITE_LABEL", "job label not found"), r":\w+:\s*" => "")
-    overall_ts["name"] = job_label
-    overall_ts["file_name"] = "unknown"
+    overall_ts["name"] = replace(get(ENV, "BUILDKITE_LABEL", "job label not found"), r":\w+:\s*" => "")
     push!(data, overall_ts)
     # Load all the serialized results files
     for res_dat in filter!(x -> occursin(r"^results.*\.dat$", x), readdir(dir))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -342,8 +342,6 @@ cd(@__DIR__) do
         end
     end
 
-    BuildkiteTestJSON.write_testset_json_files(@__DIR__)
-
     #=
 `   Construct a testset on the master node which will hold results from all the
     test files run on workers and on node1. The loop goes through the results,
@@ -369,6 +367,7 @@ cd(@__DIR__) do
     Test.TESTSET_PRINT_ENABLE[] = false
     o_ts = Test.DefaultTestSet("Overall")
     o_ts.time_end = o_ts.time_start + o_ts_duration # manually populate the timing
+    BuildkiteTestJSON.write_testset_json_files(@__DIR__, o_ts)
     Test.push_testset(o_ts)
     completed_tests = Set{String}()
     for (testname, (resp,), duration) in results


### PR DESCRIPTION
Helps fill this out with something meaningful, which is better than the current zero duration and the old overcounting.

https://buildkite.com/organizations/julialang/analytics/suites/julialang-base?branch=master

<img width="1046" alt="Screenshot 2025-03-30 at 11 19 20 PM" src="https://github.com/user-attachments/assets/76e25e2d-aef8-4687-b349-c7017a7b3cdd" />
