### PR TITLE
Updating the length of backedges after applying `invalidate_code_instance` in case some rows of backedges where removed.

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -2408,6 +2408,7 @@ void jl_method_table_activate(jl_methtable_t *mt, jl_typemap_entry_t *newentry)
                                 if (replaced_edge) {
                                     invalidate_code_instance(caller, max_world, 1);
                                     invalidated = 1;
+                                    nb = jl_array_nrows(backedges);
                                 }
                                 else {
                                     insb = set_next_edge(backedges, insb, invokeTypes, caller);


### PR DESCRIPTION
This change is necessary to prevent potential out-of-range access errors. The length of backedges may decrease while the upper bound of the while-loop remains based on the old length, leading to possible errors or Segmentation faults.

The affected chunk of code is commited by @vtjnash in 76351909e2d on 2024-11-01.

For example:

```
julia> using FinSetsForCAP
julia> CategoryOfSkeletalFinSets()
signal 11 (1): Segmentation fault
in expression starting at none:1
get_next_edge at /cache/build/builder-amdci4-2/julialang/julia-master/src/method.c:1031
jl_method_table_activate at /cache/build/builder-amdci4-2/julialang/julia-master/src/gf.c:2395
etc ....
```

or see this failing CI: https://github.com/kamalsaleh/CAP_project.jl/actions/runs/14161482338/job/39667596483#step:5:840