### PR TITLE
Enable io thread by default to see what breaks

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -391,7 +391,7 @@ function __init__()
     if get_bool_env("JULIA_USE_FLISP_PARSER", false) === false
         JuliaSyntax.enable_in_core!()
     end
-
+    Base.Experimental.make_io_thread()
     CoreLogging.global_logger(CoreLogging.ConsoleLogger())
     nothing
 end


### PR DESCRIPTION
This is an experiment to see what happens if we have an IO thread by default. The goal of this is to analyze if this is viable. If so we would implement this differently as to avoid having the extra synchronization currently needed by libuv