### PR TITLE
CI: add results.json tags back

### DIFF
--- a/test/buildkitetestjson.jl
+++ b/test/buildkitetestjson.jl
@@ -69,6 +69,8 @@ function result_dict(testset::Test.DefaultTestSet, prefix::String="")
             "arch" => string(Sys.ARCH),
             "julia_version" => string(VERSION),
             "testset" => testset.description,
+            "job_group" => get(ENV, "BUILDKITE_GROUP_LABEL", "unknown"),
+            "job_label" => get(ENV, "BUILDKITE_LABEL", "unknown"),
         ),
         # note we drop some of this from common_data before merging into individual results
         "history" => if !isnothing(testset.time_end)


### PR DESCRIPTION
I had moved setting these to the upload jobs during the upload call to save repetition in the json, but had forgotten that the labels need to be from the test job not the upload one.
Corresponding PR https://github.com/JuliaCI/julia-buildkite/pull/438