### PR TITLE
`AnnotatedString`: don't force specialization for `show` method

### DIFF
--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -170,8 +170,8 @@ end
 # To make `AnnotatedString`s repr-evaluable, we need to override
 # the generic `AbstractString` 2-arg show method.
 
-function show(io::IO, s::A) where {A <: AnnotatedString}
-    show(io, A)
+function show(io::IO, s::AnnotatedString)
+    show(io, typeof(s))
     print(io, '(')
     show(io, s.string)
     print(io, ", ")


### PR DESCRIPTION
Not sure yet if this makes a difference to inference/type stability, but AFAIK it's better style to use `typeof(arg)` when possible.