### PR TITLE
Declare `AbstractOneTo` public

### DIFF
--- a/base/public.jl
+++ b/base/public.jl
@@ -10,6 +10,7 @@ public
 
 # Types
     AbstractLock,
+    AbstractOneTo,
     AbstractPipe,
     AsyncCondition,
     CodeUnits,


### PR DESCRIPTION
Since `AbstractOneTo` is meant to be subtyped by packages, this needs to be public. This was missed out in https://github.com/JuliaLang/julia/pull/56902.