### PR TITLE
inference: model `Core._svec_ref`

### DIFF
--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -1467,3 +1467,13 @@ end
 @test Base.infer_effects(Core.invoke_in_world, Tuple{Vararg{Any}}) == Compiler.Effects()
 @test Base.infer_effects(invokelatest, Tuple{Vararg{Any}}) == Compiler.Effects()
 @test Base.infer_effects(invoke, Tuple{Vararg{Any}}) == Compiler.Effects()
+
+# Core._svec_ref effects modeling (required for external abstract interpreter that doesn't run optimization)
+let effects = Base.infer_effects((Core.SimpleVector,Int); optimize=false) do svec, i
+        Core._svec_ref(svec, i)
+    end
+    @test !Compiler.is_consistent(effects)
+    @test Compiler.is_effect_free(effects)
+    @test !Compiler.is_nothrow(effects)
+    @test Compiler.is_terminates(effects)
+end

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3887,7 +3887,7 @@ void jl_init_types(void) JL_GC_DISABLED
     // override ismutationfree for builtin types that are mutable for identity
     jl_string_type->ismutationfree = jl_string_type->isidentityfree = 1;
     jl_symbol_type->ismutationfree = jl_symbol_type->isidentityfree = 1;
-    jl_simplevector_type->ismutationfree = jl_simplevector_type->isidentityfree = 1;
+    jl_simplevector_type->isidentityfree = 1;
     jl_typename_type->ismutationfree = 1;
     jl_datatype_type->ismutationfree = 1;
     jl_uniontype_type->ismutationfree = 1;

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1211,6 +1211,8 @@ end
 
 @test Base.ismutationfree(Type{Union{}})
 
+@test !Base.ismutationfree(Core.SimpleVector)
+
 module TestNames
 
 public publicized


### PR DESCRIPTION
`Core._svec_ref` was added in JuliaLang/julia#45062, but its rt, effects and exct have not been properly modeled in the compiler.

This usually isn't a problem because `Core._svec_ref` gets optimized away by the `lift_svec_ref!` pass during optimization. However, external abstract interpreters like JET, which don't run these optimizations, can have type inference issues because of this. This commit adds the correct handling.

Also, `Base.ismutationfree(Core.Simplevector)` was incorrectly returning `true`. This commit fixes that too.