### PR TITLE
`Base.incomplete_tag`: deduplicate code and typeassert

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -223,10 +223,13 @@ function incomplete_tag(ex::Expr)
         return :none
     elseif isempty(ex.args)
         return :other
-    elseif ex.args[1] isa String
-        return fl_incomplete_tag(ex.args[1])
     else
-        return incomplete_tag(ex.args[1])
+        a = ex.args[1]
+        if a isa String
+            return fl_incomplete_tag(a)::Symbol
+        else
+            return incomplete_tag(a)::Symbol
+        end
     end
 end
 incomplete_tag(exc::Meta.ParseError) = incomplete_tag(exc.detail)


### PR DESCRIPTION
The code deduplication should enable `a` to be inferred as `String` in the branch after the `a isa String` check.

Also added some `::Symbol` (concrete) typeasserts just in case, because this is recursive code so more demanding for inference.

Should improve the resistance to invalidation of the sysimage.