### PR TITLE
Index a `CartesianIndex` with `begin`/`end`

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -5,7 +5,7 @@ module IteratorsMD
     import .Base: eltype, length, size, first, last, in, getindex, setindex!,
                   min, max, zero, oneunit, isless, eachindex,
                   convert, show, iterate, promote_rule, to_indices, copy,
-                  isassigned
+                  isassigned, lastindex, firstindex
 
     import .Base: +, -, *, (:)
     import .Base: simd_outer_range, simd_inner_length, simd_index, setindex
@@ -103,6 +103,8 @@ module IteratorsMD
 
     # indexing
     getindex(index::CartesianIndex, i::Integer) = index.I[i]
+    firstindex(index::CartesianIndex) = firstindex(index.I)
+    lastindex(index::CartesianIndex) = lastindex(index.I)
     Base.get(A::AbstractArray, I::CartesianIndex, default) = get(A, I.I, default)
     eltype(::Type{T}) where {T<:CartesianIndex} = eltype(fieldtype(T, :I))
 

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -582,3 +582,9 @@ end
     c = CartesianIndex(3, 3)
     @test sprint(show, c) == "CartesianIndex(3, 3)"
 end
+
+@testset "CartesianIndex indexing with begin/end" begin
+    I = CartesianIndex(3,4)
+    @test I[begin] == I[1]
+    @test I[end] == I[2]
+end


### PR DESCRIPTION
Currently, it is possible to index into a `CartesianIndex` using an `Int` index.
```julia
julia> I = CartesianIndex(4,3)
CartesianIndex(4, 3)

julia> I[1]
4

julia> I[2]
3
```
This PR adds the ability to use `begin`/`end` in the indexing:
```julia
julia> I[begin]
4

julia> I[end]
3
```
The advantage of this (particularly indexing with `end`) is that one doesn't need to know the number of dimensions. This makes writing generic code that accepts either a vector or a matrix easier.