### PR TITLE
Avoid most boxes in precompilation code

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -409,6 +409,53 @@ function excluded_circular_deps_explanation(io::IOContext{IO}, ext_to_parent::Di
     return msg
 end
 
+
+function scan_pkg!(stack, could_be_cycle, cycles, pkg, dmap)
+    if haskey(could_be_cycle, pkg)
+        return could_be_cycle[pkg]
+    else
+        return scan_deps!(stack, could_be_cycle, cycles, pkg, dmap)
+    end
+end
+function scan_deps!(stack, could_be_cycle, cycles, pkg, dmap)
+    push!(stack, pkg)
+    cycle = nothing
+    for dep in dmap[pkg]
+        if dep in stack
+            # Created fresh cycle
+            cycle′ = stack[findlast(==(dep), stack):end]
+            if cycle === nothing || length(cycle′) < length(cycle)
+                cycle = cycle′ # try to report smallest cycle possible
+            end
+        elseif scan_pkg!(stack, could_be_cycle, cycles, dep, dmap)
+            # Reaches an existing cycle
+            could_be_cycle[pkg] = true
+            pop!(stack)
+            return true
+        end
+    end
+    pop!(stack)
+    if cycle !== nothing
+        push!(cycles, cycle)
+        could_be_cycle[pkg] = true
+        return true
+    end
+    could_be_cycle[pkg] = false
+    return false
+end
+
+# restrict to dependencies of given packages
+function collect_all_deps(direct_deps, dep, alldeps=Set{Base.PkgId}())
+    for _dep in direct_deps[dep]
+        if !(_dep in alldeps)
+            push!(alldeps, _dep)
+            collect_all_deps(direct_deps, _dep, alldeps)
+        end
+    end
+    return alldeps
+end
+
+
 function precompilepkgs(pkgs::Vector{String}=String[];
                         internal_call::Bool=false,
                         strict::Bool = false,
@@ -434,7 +481,7 @@ function _precompilepkgs(pkgs::Vector{String},
                          timing::Bool,
                          _from_loading::Bool,
                          configs::Vector{Config},
-                         io::IOContext{IO},
+                         _io::IOContext{IO},
                          fancyprint::Bool,
                          manifest::Bool,
                          ignore_loaded::Bool)
@@ -452,10 +499,9 @@ function _precompilepkgs(pkgs::Vector{String},
     num_tasks = parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(default_num_tasks)))
     parallel_limiter = Base.Semaphore(num_tasks)
 
-    if _from_loading && !Sys.isinteractive() && Base.get_bool_env("JULIA_TESTS", false)
-        # suppress passive loading printing in julia test suite. `JULIA_TESTS` is set in Base.runtests
-        io = IOContext{IO}(devnull)
-    end
+    # suppress passive loading printing in julia test suite. `JULIA_TESTS` is set in Base.runtests
+    io = (_from_loading && !Sys.isinteractive() && Base.get_bool_env("JULIA_TESTS", false)) ? IOContext{IO}(devnull) : _io
+
 
     nconfigs = length(configs)
     hascolor = get(io, :color, false)::Bool
@@ -552,7 +598,7 @@ function _precompilepkgs(pkgs::Vector{String},
             end
         end
 
-        indirect_deps = Dict{Base.PkgId, Set{Base.PkgId}}()
+        local indirect_deps = Dict{Base.PkgId, Set{Base.PkgId}}()
         for package in keys(direct_deps)
             # Initialize a set to keep track of all dependencies for 'package'
             all_deps = Set{Base.PkgId}()
@@ -619,46 +665,14 @@ function _precompilepkgs(pkgs::Vector{String},
     could_be_cycle = Dict{Base.PkgId, Bool}()
     # temporary stack for the SCC-like algorithm below
     stack = Base.PkgId[]
-    function scan_pkg!(pkg, dmap)
-        if haskey(could_be_cycle, pkg)
-            return could_be_cycle[pkg]
-        else
-            return scan_deps!(pkg, dmap)
-        end
-    end
-    function scan_deps!(pkg, dmap)
-        push!(stack, pkg)
-        cycle = nothing
-        for dep in dmap[pkg]
-            if dep in stack
-                # Created fresh cycle
-                cycle′ = stack[findlast(==(dep), stack):end]
-                if cycle === nothing || length(cycle′) < length(cycle)
-                    cycle = cycle′ # try to report smallest cycle possible
-                end
-            elseif scan_pkg!(dep, dmap)
-                # Reaches an existing cycle
-                could_be_cycle[pkg] = true
-                pop!(stack)
-                return true
-            end
-        end
-        pop!(stack)
-        if cycle !== nothing
-            push!(cycles, cycle)
-            could_be_cycle[pkg] = true
-            return true
-        end
-        could_be_cycle[pkg] = false
-        return false
-    end
+
     # set of packages that depend on a cycle (either because they are
     # a part of a cycle themselves or because they transitively depend
     # on a package in some cycle)
     circular_deps = Base.PkgId[]
     for pkg in keys(direct_deps)
         @assert isempty(stack)
-        if scan_pkg!(pkg, direct_deps)
+        if scan_pkg!(stack, could_be_cycle, cycles, pkg, direct_deps)
             push!(circular_deps, pkg)
             for pkg_config in keys(was_processed)
                 # notify all to allow skipping
@@ -674,16 +688,6 @@ function _precompilepkgs(pkgs::Vector{String},
     if !manifest
         if isempty(pkgs)
             pkgs = [pkg.name for pkg in project_deps]
-        end
-        # restrict to dependencies of given packages
-        function collect_all_deps(direct_deps, dep, alldeps=Set{Base.PkgId}())
-            for _dep in direct_deps[dep]
-                if !(_dep in alldeps)
-                    push!(alldeps, _dep)
-                    collect_all_deps(direct_deps, _dep, alldeps)
-                end
-            end
-            return alldeps
         end
         keep = Set{Base.PkgId}()
         for dep in direct_deps
@@ -711,13 +715,13 @@ function _precompilepkgs(pkgs::Vector{String},
         end
     end
 
-    target = nothing
+    target = Ref{Union{Nothing, String}}(nothing)
     if nconfigs == 1
         if !isempty(only(configs)[1])
-            target = "for configuration $(join(only(configs)[1], " "))"
+            target[] = "for configuration $(join(only(configs)[1], " "))"
         end
     else
-        target = "for $nconfigs compilation configurations..."
+        target[] = "for $nconfigs compilation configurations..."
     end
     @debug "precompile: packages filtered"
 
@@ -727,7 +731,7 @@ function _precompilepkgs(pkgs::Vector{String},
 
     print_lock = io.io isa Base.LibuvStream ? io.io.lock::ReentrantLock : ReentrantLock()
     first_started = Base.Event()
-    printloop_should_exit::Bool = !fancyprint # exit print loop immediately if not fancy printing
+    printloop_should_exit = Ref{Bool}(!fancyprint) # exit print loop immediately if not fancy printing
     interrupted_or_done = Base.Event()
 
     ansi_moveup(n::Int) = string("\e[", n, "A")
@@ -736,19 +740,19 @@ function _precompilepkgs(pkgs::Vector{String},
     ansi_cleartoendofline = "\e[0K"
     ansi_enablecursor = "\e[?25h"
     ansi_disablecursor = "\e[?25l"
-    n_done::Int = 0
-    n_already_precomp::Int = 0
-    n_loaded::Int = 0
-    interrupted = false
+    n_done = Ref(0)
+    n_already_precomp = Ref(0)
+    n_loaded = Ref(0)
+    interrupted = Ref(false)
 
-    function handle_interrupt(err, in_printloop = false)
+    function handle_interrupt(err, in_printloop::Bool)
         notify(interrupted_or_done)
         in_printloop || wait(t_print) # wait to let the print loop cease first
         if err isa InterruptException
             @lock print_lock begin
                 println(io, " Interrupted: Exiting precompilation...", ansi_cleartoendofline)
             end
-            interrupted = true
+            interrupted[] = true
             return true
         else
             return false
@@ -757,21 +761,21 @@ function _precompilepkgs(pkgs::Vector{String},
     std_outputs = Dict{PkgConfig,IOBuffer}()
     taskwaiting = Set{PkgConfig}()
     pkgspidlocked = Dict{PkgConfig,String}()
-    pkg_liveprinted = nothing
+    pkg_liveprinted = Ref{Union{Nothing, PkgId}}(nothing)
 
     function monitor_std(pkg_config, pipe; single_requested_pkg=false)
         pkg, config = pkg_config
         try
             liveprinting = false
             while !eof(pipe)
-                str = readline(pipe, keep=true)
+                local str = readline(pipe, keep=true)
                 if single_requested_pkg && (liveprinting || !isempty(str))
                     @lock print_lock begin
                         if !liveprinting
                             printpkgstyle(io, :Info, "Given $(pkg.name) was explicitly requested, output will be shown live $ansi_cleartoendofline",
                                 color = Base.info_color())
                             liveprinting = true
-                            pkg_liveprinted = pkg
+                            pkg_liveprinted[] = pkg
                         end
                         print(io, ansi_cleartoendofline, str)
                     end
@@ -800,8 +804,8 @@ function _precompilepkgs(pkgs::Vector{String},
             wait(first_started)
             (isempty(pkg_queue) || interrupted_or_done.set) && return
             @lock print_lock begin
-                if target !== nothing
-                    printpkgstyle(io, :Precompiling, target)
+                if target[] !== nothing
+                    printpkgstyle(io, :Precompiling, target[])
                 end
                 if fancyprint
                     print(io, ansi_disablecursor)
@@ -813,10 +817,10 @@ function _precompilepkgs(pkgs::Vector{String},
             last_length = 0
             bar = MiniProgressBar(; indent=0, header = "Precompiling packages ", color = :green, percentage=false, always_reprint=true)
             n_total = length(direct_deps) * length(configs)
-            bar.max = n_total - n_already_precomp
+            bar.max = n_total - n_already_precomp[]
             final_loop = false
             n_print_rows = 0
-            while !printloop_should_exit
+            while !printloop_should_exit[]
                 @lock print_lock begin
                     term_size = displaysize(io)
                     num_deps_show = max(term_size[1] - 3, 2) # show at least 2 deps
@@ -829,8 +833,8 @@ function _precompilepkgs(pkgs::Vector{String},
                         if i > 1
                             print(iostr, ansi_cleartoend)
                         end
-                        bar.current = n_done - n_already_precomp
-                        bar.max = n_total - n_already_precomp
+                        bar.current = n_done[] - n_already_precomp[]
+                        bar.max = n_total - n_already_precomp[]
                         # when sizing to the terminal width subtract a little to give some tolerance to resizing the
                         # window between print cycles
                         termwidth = displaysize(io)[2] - 4
@@ -877,10 +881,10 @@ function _precompilepkgs(pkgs::Vector{String},
                     last_length = length(pkg_queue_show)
                     n_print_rows = count("\n", str_)
                     print(io, str_)
-                    printloop_should_exit = interrupted_or_done.set && final_loop
+                    printloop_should_exit[] = interrupted_or_done.set && final_loop
                     final_loop = interrupted_or_done.set # ensures one more loop to tidy last task after finish
                     i += 1
-                    printloop_should_exit || print(io, ansi_moveup(n_print_rows), ansi_movecol1)
+                    printloop_should_exit[] || print(io, ansi_moveup(n_print_rows), ansi_movecol1)
                 end
                 wait(t)
             end
@@ -933,7 +937,7 @@ function _precompilepkgs(pkgs::Vector{String},
                         name = describe_pkg(pkg, is_project_dep, flags, cacheflags)
                         @lock print_lock begin
                             if !fancyprint && isempty(pkg_queue)
-                                printpkgstyle(io, :Precompiling, something(target, "packages..."))
+                                printpkgstyle(io, :Precompiling, something(target[], "packages..."))
                             end
                         end
                         push!(pkg_queue, pkg_config)
@@ -969,7 +973,7 @@ function _precompilepkgs(pkgs::Vector{String},
                                 end
                                 was_recompiled[pkg_config] = true
                             end
-                            loaded && (n_loaded += 1)
+                            loaded && (n_loaded[] += 1)
                         catch err
                             # @show err
                             close(std_pipe.in) # close pipe to end the std output monitor
@@ -990,15 +994,15 @@ function _precompilepkgs(pkgs::Vector{String},
                             Base.release(parallel_limiter)
                         end
                     else
-                        is_stale || (n_already_precomp += 1)
+                        is_stale || (n_already_precomp[] += 1)
                     end
-                    n_done += 1
+                    n_done[] += 1
                     notify(was_processed[pkg_config])
                 catch err_outer
                     # For debugging:
                     # println("Task failed $err_outer")
                     # Base.display_error(ErrorException(""), Base.catch_backtrace())# logging doesn't show here
-                    handle_interrupt(err_outer) || rethrow()
+                    handle_interrupt(err_outer, false) || rethrow()
                     notify(was_processed[pkg_config])
                 finally
                     filter!(!istaskdone, tasks)
@@ -1013,13 +1017,13 @@ function _precompilepkgs(pkgs::Vector{String},
     try
         wait(interrupted_or_done)
     catch err
-        handle_interrupt(err) || rethrow()
+        handle_interrupt(err, false) || rethrow()
     finally
         Base.LOADING_CACHE[] = nothing
     end
     notify(first_started) # in cases of no-op or !fancyprint
     fancyprint && wait(t_print)
-    quick_exit = !all(istaskdone, tasks) || interrupted # if some not finished internal error is likely
+    quick_exit = !all(istaskdone, tasks) || interrupted[] # if some not finished internal error is likely
     seconds_elapsed = round(Int, (time_ns() - time_start) / 1e9)
     ndeps = count(values(was_recompiled))
     if ndeps > 0 || !isempty(failed_deps) || (quick_exit && !isempty(std_outputs))
@@ -1031,18 +1035,18 @@ function _precompilepkgs(pkgs::Vector{String},
                 end
                 plural = length(configs) > 1 ? "dependency configurations" : ndeps == 1 ? "dependency" : "dependencies"
                 print(iostr, "  $(ndeps) $(plural) successfully precompiled in $(seconds_elapsed) seconds")
-                if n_already_precomp > 0 || !isempty(circular_deps)
-                    n_already_precomp > 0 && (print(iostr, ". $n_already_precomp already precompiled"))
+                if n_already_precomp[] > 0 || !isempty(circular_deps)
+                    n_already_precomp[] > 0 && (print(iostr, ". $(n_already_precomp[]) already precompiled"))
                     !isempty(circular_deps) && (print(iostr, ". $(length(circular_deps)) skipped due to circular dependency"))
                     print(iostr, ".")
                 end
-                if n_loaded > 0
-                    plural1 = length(configs) > 1 ? "dependency configurations" : n_loaded == 1 ? "dependency" : "dependencies"
-                    plural2 = n_loaded == 1 ? "a different version is" : "different versions are"
-                    plural3 = n_loaded == 1 ? "" : "s"
-                    plural4 = n_loaded == 1 ? "this package" : "these packages"
+                if n_loaded[] > 0
+                    local plural1 = length(configs) > 1 ? "dependency configurations" : n_loaded[] == 1 ? "dependency" : "dependencies"
+                    local plural2 = n_loaded[] == 1 ? "a different version is" : "different versions are"
+                    local plural3 = n_loaded[] == 1 ? "" : "s"
+                    local plural4 = n_loaded[] == 1 ? "this package" : "these packages"
                     print(iostr, "\n  ",
-                        color_string(string(n_loaded), Base.warn_color()),
+                        color_string(string(n_loaded[]), Base.warn_color()),
                         " $(plural1) precompiled but ",
                         color_string("$(plural2) currently loaded", Base.warn_color()),
                         ". Restart julia to access the new version$(plural3). \
@@ -1062,12 +1066,12 @@ function _precompilepkgs(pkgs::Vector{String},
             let std_outputs = Tuple{PkgConfig,SubString{String}}[(pkg_config, strip(String(take!(io)))) for (pkg_config,io) in std_outputs]
                 filter!(kv -> !isempty(last(kv)), std_outputs)
                 if !isempty(std_outputs)
-                    plural1 = length(std_outputs) == 1 ? "y" : "ies"
-                    plural2 = length(std_outputs) == 1 ? "" : "s"
+                    local plural1 = length(std_outputs) == 1 ? "y" : "ies"
+                    local plural2 = length(std_outputs) == 1 ? "" : "s"
                     print(iostr, "\n  ", color_string("$(length(std_outputs))", Base.warn_color()), " dependenc$(plural1) had output during precompilation:")
                     for (pkg_config, err) in std_outputs
                         pkg, config = pkg_config
-                        err = if pkg == pkg_liveprinted
+                        err = if pkg == pkg_liveprinted[]
                             "[Output was shown above]"
                         else
                             join(split(err, "\n"), color_string("\n│  ", Base.warn_color()))

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -301,7 +301,7 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing, carriagere
     else
         string(p.current, "/",  p.max)
     end
-    termwidth = @something termwidth displaysize(io)[2]
+    termwidth = @something termwidth (displaysize(io)::Tuple{Int,Int})[2]
     max_progress_width = max(0, min(termwidth - textwidth(p.header) - textwidth(progress_text) - 10 , p.width))
     n_filled = floor(Int, max_progress_width * perc / 100)
     partial_filled = (max_progress_width * perc / 100) - n_filled
@@ -822,7 +822,7 @@ function _precompilepkgs(pkgs::Vector{String},
             n_print_rows = 0
             while !printloop_should_exit[]
                 @lock print_lock begin
-                    term_size = displaysize(io)
+                    term_size = displaysize(io)::Tuple{Int, Int}
                     num_deps_show = max(term_size[1] - 3, 2) # show at least 2 deps
                     pkg_queue_show = if !interrupted_or_done.set && length(pkg_queue) > num_deps_show
                         last(pkg_queue, num_deps_show)
@@ -837,7 +837,7 @@ function _precompilepkgs(pkgs::Vector{String},
                         bar.max = n_total - n_already_precomp[]
                         # when sizing to the terminal width subtract a little to give some tolerance to resizing the
                         # window between print cycles
-                        termwidth = displaysize(io)[2] - 4
+                        termwidth = (displaysize(io)::Tuple{Int,Int})[2] - 4
                         if !final_loop
                             s = sprint(io -> show_progress(io, bar; termwidth, carriagereturn=false); context=io)
                             print(iostr, Base._truncate_at_width_or_chars(true, s, termwidth), "\n")


### PR DESCRIPTION
- Use `local` where variable names accidentally overlapped and caused boxes
- Use `@lock` to avoid closures
- Move out some recursive closures to top-level normal function to avoid boxing them
- Use explicit boxes (`Ref`) instead of relying on the typeassert on the `Core.Box` because it it hard to determine if a `Core.Box` is benign or not.
- Only assign to `io` once to avoid boxing it.


The two remaining boxes after this is `t_print` and `monitor_std`.