### PR TITLE
much faster code-coverage for packages

### DIFF
--- a/Compiler/src/utilities.jl
+++ b/Compiler/src/utilities.jl
@@ -329,7 +329,7 @@ end
 
 inlining_enabled() = (JLOptions().can_inline == 1)
 
-function coverage_enabled(m::Module)
+function instrumentation_enabled(m::Module, only_if_affects_optimizer::Bool)
     generating_output() && return false # don't alter caches
     cov = JLOptions().code_coverage
     if cov == 1 # user
@@ -339,6 +339,17 @@ function coverage_enabled(m::Module)
         return true
     elseif cov == 2 # all
         return true
+    end
+    if !only_if_affects_optimizer
+        log = JLOptions().malloc_log
+        if log == 1 # user
+            m = moduleroot(m)
+            m === Core && return false
+            isdefined(Main, :Base) && m === Main.Base && return false
+            return true
+        elseif log == 2 # all
+            return true
+        end
     end
     return false
 end

--- a/base/staticdata.jl
+++ b/base/staticdata.jl
@@ -2,8 +2,8 @@
 
 module StaticData
 
-using Core: CodeInstance, MethodInstance
-using Base: get_world_counter
+using .Core: CodeInstance, MethodInstance
+using .Base: JLOptions, Compiler, get_world_counter, _methods_by_ftype, get_methodtable
 
 const WORLD_AGE_REVALIDATION_SENTINEL::UInt = 1
 const _jl_debug_method_invalidation = Ref{Union{Nothing,Vector{Any}}}(nothing)
@@ -73,6 +73,51 @@ end
 
 get_require_world() = unsafe_load(cglobal(:jl_require_world, UInt))
 
+function gen_staged_sig(def::Method, mi::MethodInstance)
+    isdefined(def, :generator) || return nothing
+    isdispatchtuple(mi.specTypes) || return nothing
+    gen = Core.Typeof(def.generator)
+    return Tuple{gen, UInt, Method, Vararg}
+    ## more precise method lookup, but more costly and likely not actually better?
+    #tts = (mi.specTypes::DataType).parameters
+    #sps = Any[Core.Typeof(mi.sparam_vals[i]) for i in 1:length(mi.sparam_vals)]
+    #if def.isva
+    #    return Tuple{gen, UInt, Method, sps..., tts[1:def.nargs - 1]..., Tuple{tts[def.nargs - 1:end]...}}
+    #else
+    #    return Tuple{gen, UInt, Method, sps..., tts...}
+    #end
+end
+
+function needs_instrumentation(codeinst::CodeInstance, mi::MethodInstance, def::Method, validation_world::UInt)
+    if JLOptions().code_coverage != 0 || JLOptions().malloc_log != 0
+        # test if the code needs to run with instrumentation, in which case we cannot use existing generated code
+        if isdefined(def, :debuginfo) ? # generated_only functions do not have debuginfo, so fall back to considering their codeinst debuginfo though this may be slower (and less accurate?)
+            Compiler.should_instrument(def.module, def.debuginfo) :
+            Compiler.should_instrument(def.module, codeinst.debuginfo)
+            return true
+        end
+        gensig = gen_staged_sig(def, mi)
+        if gensig !== nothing
+            # if this is defined by a generator, try to consider forcing re-running the generators too, to add coverage for them
+            minworld = Ref{UInt}(1)
+            maxworld = Ref{UInt}(typemax(UInt))
+            has_ambig = Ref{Int32}(0)
+            result = _methods_by_ftype(gensig, nothing, -1, validation_world, #=ambig=#false, minworld, maxworld, has_ambig)
+            if result !== nothing
+                for k = 1:length(result)
+                    match = result[k]::Core.MethodMatch
+                    genmethod = match.method
+                    # no, I refuse to refuse to recurse into your cursed generated function generators and will only test one level deep here
+                    if isdefined(genmethod, :debuginfo) && Compiler.should_instrument(genmethod.module, genmethod.debuginfo)
+                        return true
+                    end
+                end
+            end
+        end
+    end
+    return false
+end
+
 # Test all edges relevant to a method:
 # - Visit the entire call graph, starting from edges[idx] to determine if that method is valid
 # - Implements Tarjan's SCC (strongly connected components) algorithm, simplified to remove the count variable
@@ -84,6 +129,12 @@ function verify_method(codeinst::CodeInstance, stack::Vector{CodeInstance}, visi
             return 0, world, max_valid2
         end
     end
+    mi = get_ci_mi(codeinst)
+    def = mi.def::Method
+    if needs_instrumentation(codeinst, mi, def, validation_world)
+        return 0, world, UInt(0)
+    end
+
     # Implicitly referenced bindings in the current module do not get explicit edges.
     # If they were invalidated, they'll be in `mwis`. If they weren't, they imply a minworld
     # of `get_require_world`. In principle, this is only required for methods that do reference
@@ -92,8 +143,6 @@ function verify_method(codeinst::CodeInstance, stack::Vector{CodeInstance}, visi
     # but no implicit edges) is rare and there would be little benefit to lower the minworld for it
     # in any case, so we just always use `get_require_world` here.
     local minworld::UInt, maxworld::UInt = get_require_world(), validation_world
-    def = get_ci_mi(codeinst).def
-    @assert def isa Method
     if haskey(visiting, codeinst)
         return visiting[codeinst], minworld, maxworld
     end
@@ -225,7 +274,7 @@ function verify_method(codeinst::CodeInstance, stack::Vector{CodeInstance}, visi
         end
         @atomic :monotonic child.max_world = maxworld
         if maxworld == validation_world && validation_world == get_world_counter()
-            Base.Compiler.store_backedges(child, child.edges)
+            Compiler.store_backedges(child, child.edges)
         end
         @assert visiting[child] == length(stack) + 1
         delete!(visiting, child)
@@ -243,7 +292,7 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
     minworld = Ref{UInt}(1)
     maxworld = Ref{UInt}(typemax(UInt))
     has_ambig = Ref{Int32}(0)
-    result = Base._methods_by_ftype(sig, nothing, lim, world, #=ambig=#false, minworld, maxworld, has_ambig)
+    result = _methods_by_ftype(sig, nothing, lim, world, #=ambig=#false, minworld, maxworld, has_ambig)
     if result === nothing
         maxworld[] = 0
     else
@@ -306,11 +355,11 @@ function verify_invokesig(@nospecialize(invokesig), expected::Method, world::UIn
     else
         minworld = 1
         maxworld = typemax(UInt)
-        mt = Base.get_methodtable(expected)
+        mt = get_methodtable(expected)
         if mt === nothing
             maxworld = 0
         else
-            matched, valid_worlds = Base.Compiler._findsup(invokesig, mt, world)
+            matched, valid_worlds = Compiler._findsup(invokesig, mt, world)
             minworld, maxworld = valid_worlds.min_world, valid_worlds.max_world
             if matched === nothing
                 maxworld = 0


### PR DESCRIPTION
We already have an excellent framework for selective code reuse, so use that tool instead of a sledgehammer for inserting selective coverage and malloc instrumentation. As a small bonus, this should also be significantly more accurate by not being vulnerable to precompilation inserting incorrect (uninstrumented) contents into the caches.