### PR TITLE
Forward `to_shape` for `AbstractOneTo` to `Integer` method

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -840,7 +840,9 @@ to_shape(dims::DimsOrInds) = map(to_shape, dims)::DimsOrInds
 # each dimension
 to_shape(i::Int) = i
 to_shape(i::Integer) = Int(i)
-to_shape(r::AbstractOneTo) = Int(last(r))
+to_shape(r::AbstractOneTo) = _to_shape(last(r))
+_to_shape(x::Integer) = to_shape(x)
+_to_shape(x) = Int(x)
 to_shape(r::AbstractUnitRange) = r
 
 """

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2246,5 +2246,7 @@ end
         b = similar(A, SizedArrays.SOneTo(1), 2, Base.OneTo(2))
         @test b isa Array{Int, 3}
         @test size(b) == (1, 2, 2)
+
+        @test_throws "no method matching $Int(::$Infinity)" similar(ones(2), OneToInf())
     end
 end

--- a/test/testhelpers/InfiniteArrays.jl
+++ b/test/testhelpers/InfiniteArrays.jl
@@ -37,7 +37,7 @@ Define an `AbstractInfUnitRange` that behaves like `1:∞`, with the added
 distinction that the limits are guaranteed (by the type system) to
 be 1 and ∞.
 """
-struct OneToInf{T<:Integer} <: AbstractUnitRange{T} end
+struct OneToInf{T<:Integer} <: Base.AbstractOneTo{T} end
 
 OneToInf() = OneToInf{Int}()
 


### PR DESCRIPTION
This allows custom `Integer` types to add methods to `to_shape` and have the behavior of `OneTo` be altered accordingly.