### PR TITLE
Add matches for invoke invalidations

### DIFF
--- a/base/staticdata.jl
+++ b/base/staticdata.jl
@@ -163,7 +163,8 @@ function verify_method(codeinst::CodeInstance, stack::Vector{CodeInstance}, visi
                     meth = callee::Method
                 end
                 min_valid2, max_valid2 = verify_invokesig(edge, meth, world)
-                matches = nothing
+                match, _ = Base.invoke_default_compiler(:_findsup, edge, nothing, world)
+                matches = match === nothing ? nothing : Any[match.method]
                 j += 2
             end
             if minworld < min_valid2

--- a/base/staticdata.jl
+++ b/base/staticdata.jl
@@ -316,7 +316,7 @@ function verify_invokesig(@nospecialize(invokesig), expected::Method, world::UIn
                 maxworld = 0
             else
                 matched = Any[matched.method]
-                if matched[] != expected
+                if matched[] !== expected
                     maxworld = 0
                 end
             end

--- a/base/staticdata.jl
+++ b/base/staticdata.jl
@@ -162,9 +162,7 @@ function verify_method(codeinst::CodeInstance, stack::Vector{CodeInstance}, visi
                 else
                     meth = callee::Method
                 end
-                min_valid2, max_valid2 = verify_invokesig(edge, meth, world)
-                match, _ = Base.invoke_default_compiler(:_findsup, edge, nothing, world)
-                matches = match === nothing ? nothing : Any[match.method]
+                min_valid2, max_valid2, matches = verify_invokesig(edge, meth, world)
                 j += 2
             end
             if minworld < min_valid2
@@ -296,6 +294,7 @@ end
 function verify_invokesig(@nospecialize(invokesig), expected::Method, world::UInt)
     @assert invokesig isa Type
     local minworld::UInt, maxworld::UInt
+    matched = nothing
     if invokesig === expected.sig
         # the invoke match is `expected` for `expected->sig`, unless `expected` is invalid
         minworld = expected.primary_world
@@ -315,12 +314,15 @@ function verify_invokesig(@nospecialize(invokesig), expected::Method, world::UIn
             minworld, maxworld = valid_worlds.min_world, valid_worlds.max_world
             if matched === nothing
                 maxworld = 0
-            elseif matched.method != expected
-                maxworld = 0
+            else
+                matched = Any[matched.method]
+                if matched[] != expected
+                    maxworld = 0
+                end
             end
         end
     end
-    return minworld, maxworld
+    return minworld, maxworld, matched
 end
 
 end # module StaticData


### PR DESCRIPTION
While working on https://github.com/timholy/SnoopCompile.jl/pull/418 I noticed that the *edge* invalidation (but not the corresponding method-insertion invalidation) of the form

```julia
Package InvalidA:
module InvalidA
f(::Integer) = 1
invokesfs(x) = invoke(f, Tuple{Signed}, x)
end

Package InvalidB:
module InvalidB
using InvalidA
InvalidA.invokesfs(1)   # precompile
end
```

used as

```julia
using PkgA
InvalidA.f(::Signed) = 4
using PkgB
```

did not attribute a "cause":

```
...
Tuple{typeof(InvalidA.f), Signed}
 "insert_backedges_callee"
 CodeInstance for MethodInstance for InvalidA.invokesfs(::Int64)
 nothing
...
```

This aims to fill in the new method that replaced the previous dispatch.