### PR TITLE
Profile: make `@Compiler` test robust

### DIFF
--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -220,9 +220,19 @@ end
 
 import InteractiveUtils
 
+@generated function compile_takes_1_second(x)
+    t = time_ns()
+    while time_ns() < t + 1e9
+        # busy wait for 1 second
+    end
+    return :(x)
+end
 @testset "Module short names" begin
     Profile.clear()
-    @profile InteractiveUtils.peakflops()
+    @profile begin
+        @eval compile_takes_1_second(1) # to increase chance of profiling hitting compilation code
+        InteractiveUtils.peakflops()
+    end
     io = IOBuffer()
     ioc = IOContext(io, :displaysize=>(1000,1000))
     Profile.print(ioc, C=true)


### PR DESCRIPTION
Fixes https://buildkite.com/julialang/julia-master/builds/46446#0195f712-1844-4e81-8b16-27b953fedcd3/899-1778

```
  | Error in testset Profile:
  | Test Failed at /cache/build/tester-amdci5-10/julialang/julia-master/julia-7c9af464cc/share/julia/stdlib/v1.13/Profile/test/runtests.jl:231
  | Expression: occursin("@Compiler" * slash, str)
  | Evaluated: occursin("@Compiler/", "Overhead ╎ [+additional indent] Count File:Line  Function\n=========================================================\n   ╎9   @juliasrc/task.c:1249  start_task\n   ╎ 9   @juliasrc/julia.h:2353  jl_apply\n   ╎  9   @juliasrc/gf.c:3693  ijl_apply_generic\n   ╎   9   @juliasrc/gf.c:3493  _jl_invoke\n   ╎    9   [unknown stackframe]\n   ╎     9   @Distributed/src/process_messages.jl:287  (::Distributed.var\"#handle_msg##2#handle_msg##3\"{Distributed.CallMsg{:call_fetch}, Distributed.MsgHeader, Sockets.TCPSocket})()\n   ╎    ╎ 9   @Distributed/src/process_messages.jl:70  run_work_thunk(thunk::Distributed.var\"#handle_msg##4#handle_msg##5\"{Distributed.CallMsg{:call_fetch}}, print_error::Bool)\n   ╎    ╎  9   @Distributed/src/process_messages.jl:287  (::Distributed.var\"#handle_msg##4#handle_msg##5\"{Distributed.CallMsg{:call_fetch}})()\n   ╎    ╎   9   @juliasrc/builtins.c:841  jl_f__apply_iterate\n   ╎    ╎    9   @juliasrc/julia.h:2353  jl_apply\n   ╎    ╎     9   @juliasrc/gf.c:3693  ijl_apply_generic\n   ╎    ╎    ╎ 9   @juliasrc/gf.c:3493  _jl_invoke\n   ╎    ╎    ╎  9   @Base/Base_compiler.jl:223  kwcall(::@NamedTuple{seed::UInt128}, ::typeof(invokelatest), ::Function, ::String, ::Vararg{String})\n   ╎    ╎    ╎   9   @juliasrc/builtins.c:841  jl_f__apply_iterate\n   ╎    ╎    ╎    9   @juliasrc/julia.h:2353  jl_apply\n   ╎    ╎    ╎     9   @juliasrc/gf.c:3693  ijl_apply_generic\n   ╎    ╎    ╎    ╎ 9   @juliasrc/gf.c:3493  _jl_invoke\n   ╎    ╎    ╎    ╎  9   @juliasrc/builtins.c:853  jl_f_invokelatest\n   ╎    ╎    ╎    ╎   9   @juliasrc/julia.h:2353  jl_apply\n   ╎    ╎    ╎    ╎    9   @juliasrc/gf.c:3693  ijl_apply_generic\n   ╎    ╎    ╎    ╎     9   @juliasrc/gf.c:3493  _jl_invoke\n   ╎    ╎    ╎    ╎    ╎ 9   [unknown stackframe]\n   ╎    ╎    ╎    ╎    ╎  9   /cache/build/tester-amdci5-10/julialang/julia-master/julia-7c9af464cc/share/julia/test/testdefs.jl:7  kwcall(::@NamedTuple{seed::UInt128}, ::typeof(runtests), name::String, path::String)\n   ╎    ╎    ╎    ╎    ╎   9   /cache/build/tester-amdci5-10/julialang/julia-master/julia-7c9af464cc/share/julia/test/testdefs.jl:7  runtests\n   ╎    ╎    ╎    ╎    ╎    9   /cache/build/tester-amdci5-10/julialang/julia-master/julia-7c9af464cc/share/julia/test/testdefs.jl:13  runtests(name::String, path::String, isolate::Bool; seed::UInt128)\n   ╎    ╎    ╎    ╎    ╎     9   @Base/env.jl:265  withenv(f::var\"#4#5\"{UInt128, String, String, Bool, Bool}, keyvals::Pair{String, Bool})\n   ╎    ╎    ╎    ╎    ╎    ╎ 9   /cache/build/tester-amdci5-10/julialang/julia-master/julia-7c9af464cc/share/julia/test/testdefs.jl:27  (::var\"#4#5\"{UInt128, String, String, Bool, Bool})()\n   ╎    ╎    ╎    ╎    ╎    ╎  9   @Base/timing.jl:621  macro expansion\n   ╎    ╎    ╎    ╎    ╎    ╎   9   /cache/build/tester-amdci5-10/julialang/julia-master/julia-7c9af464cc/share/julia/test/testdefs.jl:29  macro expansion\n   ╎    ╎    ╎    ╎    ╎    ╎    9   @Test/src/Test.jl:1835  macro expansion\n   ╎    ╎    ╎    ╎    ╎    ╎     9   /cache/build/tester-amdci5-10/julialang/julia-master/julia-7c9af464cc/share/julia/test/testdefs.jl:37  macro expansion\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎ 9   @Base/Base.jl:303  include(mod::Module, _path::String)\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎  9   @Base/loading.jl:2925  _include(mapexpr::Function, mod::Module, _path::String)\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎   9   @juliasrc/gf.c:3693  ijl_apply_generic\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎    9   @juliasrc/gf.c:3493  _jl_invoke\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎     9   @Base/loading.jl:2865  include_string(mapexpr::typeof(identity), mod::Module, code::String, filename::String)\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 9   @Base/boot.jl:489  eval(m::Module, e::Any)\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  9   @juliasrc/toplevel.c:1095  ijl_toplevel_eval_in\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   9   @juliasrc/toplevel.c:1050  ijl_toplevel_eval\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    9   @juliasrc/toplevel.c:978  jl_toplevel_eval_flex\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     9   @juliasrc/toplevel.c:1038  jl_toplevel_eval_flex\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 9   @juliasrc/interpreter.c:897  jl_interpret_toplevel_thunk\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  9   @juliasrc/interpreter.c:557  eval_body\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   9   @juliasrc/interpreter.c:557  eval_body\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    9   @juliasrc/interpreter.c:557  eval_body\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     9   @juliasrc/interpreter.c:692  eval_body\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 9   @juliasrc/interpreter.c:193  eval_stmt_value\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  9   @juliasrc/interpreter.c:242  eval_value\n   ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   9   @juliasrc/interpreter.c:124  do_call\n   ╎    ╎    ╎    ╎
...
```