### PR TITLE
`Base`: delete unnecessary `hastypemax` methods

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -10,7 +10,7 @@ import .Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor, 
              trailing_zeros, trailing_ones, count_ones, count_zeros, tryparse_internal,
              bin, oct, dec, hex, isequal, invmod, _prevpow2, _nextpow2, ndigits0zpb,
              widen, signed, unsafe_trunc, trunc, iszero, isone, big, flipsign, signbit,
-             sign, hastypemax, isodd, iseven, digits!, hash, hash_integer, top_set_bit,
+             sign, isodd, iseven, digits!, hash, hash_integer, top_set_bit,
              clamp, unsafe_takestring
 
 import Core: Signed, Float16, Float32, Float64
@@ -284,8 +284,6 @@ signed(x::BigInt) = x
 
 BigInt(x::BigInt) = x
 Signed(x::BigInt) = x
-
-hastypemax(::Type{BigInt}) = false
 
 function tryparse_internal(::Type{BigInt}, s::AbstractString, startpos::Int, endpos::Int, base_::Integer, raise::Bool)
     # don't make a copy in the common case where we are parsing a whole String

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -1066,8 +1066,6 @@ end
 
 Return `true` if and only if the extrema `typemax(T)` and `typemin(T)` are defined.
 """
-hastypemax(::Base.BitIntegerType) = true
-hastypemax(::Type{Bool}) = true
 hastypemax(::Type{T}) where {T} = applicable(typemax, T) && applicable(typemin, T)
 
 """

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -623,6 +623,19 @@ end
 @test Base.infer_effects(gcdx, (Int,Int)) |> Core.Compiler.is_foldable
 @test Base.infer_effects(invmod, (Int,Int)) |> Core.Compiler.is_foldable
 @test Base.infer_effects(binomial, (Int,Int)) |> Core.Compiler.is_foldable
+@testset "concrete-foldability: `hastypemax`" begin
+    @test Base.infer_effects(Base.hastypemax, (Type,)) |> Core.Compiler.is_foldable
+    @test Base.infer_effects(Base.hastypemax, (DataType,)) |> Core.Compiler.is_foldable
+    for t in (Bool, Int, BigInt)
+        @test Base.infer_effects(Base.hastypemax, (Type{t},)) |> Core.Compiler.is_foldable
+    end
+end
+
+@testset "`hastypemax`" begin
+    @test Base.hastypemax(Bool)
+    @test Base.hastypemax(Int)
+    @test !Base.hastypemax(BigInt)
+end
 
 @testset "literal power" begin
     @testset for T in Base.uniontypes(Base.HWReal)


### PR DESCRIPTION
The hardcoded methods are covered by the fallback method correctly. The reason these methods existed is probably that the fallback was not foldable at some point. Now it is foldable, so delete the unnecessary methods.

Also add tests.