### PR TITLE
Fix incorrect result for Base.invmod(<:Signed, <:Unsigned)

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -286,7 +286,7 @@ function invmod(n::Integer, m::Integer)
     g, x, y = gcdx(n, m)
     g != 1 && throw(DomainError((n, m), LazyString("Greatest common divisor is ", g, ".")))
     # Note that m might be negative here.
-    if promote_type(typeof(n), typeof(m))<:Unsigned && hastypemax(typeof(n)) && x > typemax(n)>>1
+    if x isa Unsigned && hastypemax(typeof(x)) && x > typemax(x)>>1
         # x might have wrapped if it would have been negative
         # adding back m forces a correction
         x += m

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -286,7 +286,7 @@ function invmod(n::Integer, m::Integer)
     g, x, y = gcdx(n, m)
     g != 1 && throw(DomainError((n, m), LazyString("Greatest common divisor is ", g, ".")))
     # Note that m might be negative here.
-    if n isa Unsigned && hastypemax(typeof(n)) && x > typemax(n)>>1
+    if promote_type(typeof(n), typeof(m))<:Unsigned && hastypemax(typeof(n)) && x > typemax(n)>>1
         # x might have wrapped if it would have been negative
         # adding back m forces a correction
         x += m

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -261,6 +261,7 @@ end
     for T in (Int8, Int16, Int32, Int64, Int128)
         @test invmod(T(3), unsigned(T)(124)) == 83
     end
+@test invmod(UInt8(3), UInt16(50000)) === 0x411b
 
     for T in (Int8, UInt8)
         for x in typemin(T):typemax(T)

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -258,6 +258,10 @@ end
         @test invmod(T(3), T(124))::T == 83
     end
 
+    for T in (Int8, Int16, Int32, Int64, Int128)
+        @test invmod(T(3), unsigned(T)(124)) == 83
+    end
+
     for T in (Int8, UInt8)
         for x in typemin(T):typemax(T)
             for m in typemin(T):typemax(T)

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -262,8 +262,8 @@ end
         @test invmod(T(3), unsigned(T)(124)) == 83
     end
 
-   # For issue 58010
-   @test invmod(UInt8(3), UInt16(50000)) === 0x411b
+    # Verify issue described in PR 58010 is fixed
+    @test invmod(UInt8(3), UInt16(50000)) === 0x411b
 
     for T in (Int8, UInt8)
         for x in typemin(T):typemax(T)

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -261,7 +261,9 @@ end
     for T in (Int8, Int16, Int32, Int64, Int128)
         @test invmod(T(3), unsigned(T)(124)) == 83
     end
-@test invmod(UInt8(3), UInt16(50000)) === 0x411b
+
+   # For issue 58010
+   @test invmod(UInt8(3), UInt16(50000)) === 0x411b
 
     for T in (Int8, UInt8)
         for x in typemin(T):typemax(T)


### PR DESCRIPTION
MWE of bug:
```julia
julia> Int(invmod(1024, UInt(12289)))
5652

julia> invmod(1024, 12289)
12277
```