### PR TITLE
REPL: delay compilation in macros like `@time` to avoid the need for `@eval`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,9 @@ New language features
 Language changes
 ----------------
 
+* Calling `@time expr` in the repl or top-level no longer requires `@time @eval expr` to capture all compilation
+  time spent compiling `expr`. ([#58015])
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -289,6 +289,10 @@ macro __tryfinally(ex, fin)
        )
 end
 
+macro latestworld_if_toplevel()
+    Expr(Symbol("latestworld-if-toplevel"))
+end
+
 """
     @time expr
     @time "description" expr
@@ -618,6 +622,7 @@ macro timed(ex)
         local elapsedtime = time_ns()
         cumulative_compile_timing(true)
         local compile_elapsedtimes = cumulative_compile_time_ns()
+        @latestworld_if_toplevel
         local val = @__tryfinally($(esc(ex)),
             (elapsedtime = time_ns() - elapsedtime;
             cumulative_compile_timing(false);
@@ -644,6 +649,7 @@ end
 macro time_imports(ex)
     quote
         Base.Threads.atomic_add!(Base.TIMING_IMPORTS, 1)
+        @latestworld_if_toplevel
         @__tryfinally(
             # try
             $(esc(ex)),
@@ -656,6 +662,7 @@ end
 macro trace_compile(ex)
     quote
         ccall(:jl_force_trace_compile_timing_enable, Cvoid, ())
+        @latestworld_if_toplevel
         @__tryfinally(
             # try
             $(esc(ex)),
@@ -668,6 +675,7 @@ end
 macro trace_dispatch(ex)
     quote
         ccall(:jl_force_trace_dispatch_enable, Cvoid, ())
+        @latestworld_if_toplevel
         @__tryfinally(
             # try
             $(esc(ex)),

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -308,6 +308,7 @@ Optionally provide a description string to print before the time report.
 In some cases the system will look inside the `@time` expression and compile some of the
 called code before execution of the top-level expression begins. When that happens, some
 compilation time will not be counted. To include this time you can run `@time @eval ...`.
+However since julia 1.13 this is not necessary anymore when in the repl or at the top-level.
 
 See also [`@showtime`](@ref), [`@timev`](@ref), [`@timed`](@ref), [`@elapsed`](@ref),
 [`@allocated`](@ref), and [`@allocations`](@ref).

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -185,7 +185,7 @@ end
 write(IOBuffer(), "")
 
 # precompile @time report generation and printing
-@time @eval Base.Experimental.@force_compile
+@time Base.Experimental.@force_compile
 """
 
 julia_exepath() = joinpath(Sys.BINDIR, Base.julia_exename())

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1412,15 +1412,12 @@ compiled. The [`@time`](@ref) macro family illustrates this.
 julia> foo() = rand(2,2) * rand(2,2)
 foo (generic function with 1 method)
 
-julia> @time @eval foo();
+julia> @time foo();
   0.252395 seconds (1.12 M allocations: 56.178 MiB, 2.93% gc time, 98.12% compilation time)
 
-julia> @time @eval foo();
+julia> @time foo();
   0.000156 seconds (63 allocations: 2.453 KiB)
 ```
-
-Note that `@time @eval` is better for measuring compilation time because without [`@eval`](@ref), some compilation may
-already be done before timing starts.
 
 When developing a package, you may be able to improve the experience of your users with *precompilation*
 so that when they use the package, the code they use is already compiled. To precompile package code effectively, it's

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -59,7 +59,7 @@ function repl_workload()
     display([1])
     display([1 2; 3 4])
     foo(x) = 1
-    @time @eval foo(1)
+    @time foo(1)
     ; pwd
     $CTRL_C
     $CTRL_R$CTRL_C#


### PR DESCRIPTION
Avoids the need to use `@eval` with `@time` etc. in the REPL

With this
```
julia> @trace_compile rand(2,2) * rand(2,2)
#=   13.6 ms =# precompile(Tuple{Core.GeneratedFunctionStub, UInt64, Method, Any, Vararg{Any}}) # recompile
#=   56.2 ms =# precompile(Tuple{typeof(Base.rand), Int64, Int64})
#=    2.9 ms =# precompile(Tuple{typeof(Base.:(*)), Array{Float64, 2}, Array{Float64, 2}})
2×2 Matrix{Float64}:
 0.740604  0.959697
 0.938691  0.937117

julia> @trace_compile rand(2,2) * rand(2,2)
2×2 Matrix{Float64}:
 0.1135    0.162588
 0.463798  0.891144
```
```
julia> @time rand(2,2) * rand(2,2)
  0.090083 seconds (174.88 k allocations: 7.729 MiB, 99.95% compilation time)
2×2 Matrix{Float64}:
 0.402414  0.39624
 0.287094  0.210326

julia> @time rand(2,2) * rand(2,2)
  0.000014 seconds (13 allocations: 528 bytes)
2×2 Matrix{Float64}:
 0.1135    0.162588
 0.463798  0.891144
```

Without (master)
```
julia> @trace_compile rand(2,2) * rand(2,2)
2×2 Matrix{Float64}:
 0.686422  0.833379
 1.08226   1.23549

```
```
julia> @time rand(2,2) * rand(2,2)
  0.000005 seconds (6 allocations: 336 bytes)
2×2 Matrix{Float64}:
 0.183913  0.224988
 0.362542  0.366543
```

However it currently breaks for silenced entries.. the expr check needs work..
```
julia> @trace_compile rand(2,2) * rand(2,2);

julia>
```