### PR TITLE
Documentation: Add notes about subtypes of concrete types

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -31,9 +31,9 @@ each other: all concrete types are final and may only have abstract types as the
 While this might at first seem unduly restrictive, it has many beneficial consequences with surprisingly
 few drawbacks. It turns out that being able to inherit behavior is much more important than being
 able to inherit structure, and inheriting both causes significant difficulties in traditional
-object-oriented languages. Despite these restrictions, concrete types may have abstract subtypes, but
-there are only few examples of this (see e.g. [Abstract Types](@ref man-abstract-types)) and subtypes
-of concrete types cannot be declared manually inside the language.
+object-oriented languages. While concrete types do have abstract subtypes, there are only two examples of this
+([`Union{}`](@ref man-abstract-types) and [`Type{T}`](@ref man-typet-type))) and additional subtypes
+of concrete types cannot be declared.
 
 Other high-level aspects of Julia's type system that should be mentioned up front are:
 
@@ -185,8 +185,7 @@ When no supertype is given, the default supertype is `Any` -- a predefined abstr
 all objects are instances of and all types are subtypes of. In type theory, `Any` is commonly
 called "top" because it is at the apex of the type graph. Julia also has a predefined abstract
 "bottom" type, at the nadir of the type graph, which is written as `Union{}`. It is the exact
-opposite of `Any`: no object is an instance of `Union{}` and all types are supertypes of `Union{}`.
-This also means that concrete types formally have `Union{}` as a (abstract) subtype.
+opposite of `Any`: no object is an instance of `Union{}` and all types (including concrete types) are supertypes of `Union{}`.
 
 Let's consider some of the abstract types that make up Julia's numerical hierarchy:
 
@@ -1310,7 +1309,7 @@ julia> WrapType(Float64) # sharpened constructor, note more precise Type{Float64
 WrapType{Type{Float64}}(Float64)
 ```
 
-This behavior of `Type{Float64}` is another example of an abstract type subtyping a
+This behavior of `Type{Float64}` is an example of an abstract type subtyping a
 concrete type (here `DataType`).
 
 ## Type Aliases

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -31,8 +31,11 @@ each other: all concrete types are final and may only have abstract types as the
 While this might at first seem unduly restrictive, it has many beneficial consequences with surprisingly
 few drawbacks. It turns out that being able to inherit behavior is much more important than being
 able to inherit structure, and inheriting both causes significant difficulties in traditional
-object-oriented languages. Other high-level aspects of Julia's type system that should be mentioned
-up front are:
+object-oriented languages. Despite these restrictions, concrete types may have abstract subtypes, but
+there are only few examples of this (see e.g. [Abstract Types](@ref man-abstract-types)) and subtypes
+of concrete types cannot be declared manually inside the language.
+
+Other high-level aspects of Julia's type system that should be mentioned up front are:
 
   * There is no division between object and non-object values: all values in Julia are true objects
     having a type that belongs to a single, fully connected type graph, all nodes of which are equally
@@ -183,6 +186,7 @@ all objects are instances of and all types are subtypes of. In type theory, `Any
 called "top" because it is at the apex of the type graph. Julia also has a predefined abstract
 "bottom" type, at the nadir of the type graph, which is written as `Union{}`. It is the exact
 opposite of `Any`: no object is an instance of `Union{}` and all types are supertypes of `Union{}`.
+This also means that concrete types formally have `Union{}` as a (abstract) subtype.
 
 Let's consider some of the abstract types that make up Julia's numerical hierarchy:
 
@@ -1305,6 +1309,9 @@ WrapType
 julia> WrapType(Float64) # sharpened constructor, note more precise Type{Float64}
 WrapType{Type{Float64}}(Float64)
 ```
+
+This behavior of `Type{Float64}` is another example of an abstract type subtyping a
+concrete type (here `DataType`).
 
 ## Type Aliases
 


### PR DESCRIPTION
Based on this [discussion on Discourse](https://discourse.julialang.org/t/how-to-interpret-type-t-where-t-in-julias-type-system/37402/21?u=sevi)

This is my shot at adding three short sentences that hopefully clarify the restrictions of subtyping concrete types.

There seems to be some recurring confusion by Julia users (including myself) about how to imagine Julia's type hierarchy.
I think the language in the manual page is sufficiently clear already (i.e. there is no mention of a "type tree" and it is also mentioned that only _concrete subtypes of concrete types_ are strictly not possible), but adding the proposed sentences could help readers to keep in mind that e.g. `Type{...}` and `Union{}` are counterexamples to a strict "type tree" image.

I tried to be conservative with the changes though, because I'm not sure how far this should be discussed here and whether my current mental model of Julia's type graph is actually correct.

---

The docs are still working with `make docs` and look correct for me. I looked at the [contributing](https://github.com/JuliaLang/julia/blob/75d5588d46bf7445626837f05e7a284ad85c7d30/CONTRIBUTING.md#improving-documentation) guidelines, but since this is my first contribution here (or in any open source project, really), I'm happy about any hints or improvements.