### PR TITLE
Restrict vector arg eltype of read/copyuntil to UInt8

### DIFF
--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -149,7 +149,7 @@ end
     copyuntil(b, a, UInt8('a'); keep=true)
     @test read(b) == b"xxbcdea"
     seekstart(b)
-    copyuntil(b, a, UInt('w'))
+    copyuntil(b, a, UInt8('w'))
     @test read(b) == b"xxbcdeajdgabdfg"
 end
 

--- a/test/read.jl
+++ b/test/read.jl
@@ -180,9 +180,6 @@ for (name, f) in l
         @test readuntil(io(t), GenericString(s), keep=true) == kept
         @test readuntil(io(t), unsafe_wrap(Vector{UInt8},s)) == unsafe_wrap(Vector{UInt8},m)
         @test readuntil(io(t), unsafe_wrap(Vector{UInt8},s), keep=true) == unsafe_wrap(Vector{UInt8},kept)
-        @test readuntil(io(t), collect(s)::Vector{Char}) == Vector{Char}(m)
-        @test readuntil(io(t), collect(s)::Vector{Char}, keep=true) == Vector{Char}(kept)
-
         buf = IOBuffer()
         @test String(take!(copyuntil(buf, io(t), s))) == m
         @test String(take!(copyuntil(buf, io(t), s, keep=true))) == kept
@@ -692,21 +689,6 @@ end
     @test !isempty(itr)
     first(itr) # consume the iterator
     @test  isempty(itr) # now it is empty
-end
-
-@testset "readuntil/copyuntil fallbacks" begin
-    # test fallback for generic delim::T
-    buf = IOBuffer()
-    fib = [1,1,2,3,5,8,13,21]
-    write(buf, fib)
-    @test readuntil(seekstart(buf), 21) == fib[1:end-1]
-    @test readuntil(buf, 21) == Int[]
-    @test readuntil(seekstart(buf), 21; keep=true) == fib
-    out = IOBuffer()
-    @test copyuntil(out, seekstart(buf), 21) === out
-    @test reinterpret(Int, take!(out)) == fib[1:end-1]
-    @test copyuntil(out, seekstart(buf), 21; keep=true) === out
-    @test reinterpret(Int, take!(out)) == fib
 end
 
 # more tests for reverse(eachline)


### PR DESCRIPTION
The previous implementation of `copyuntil` did not document what the vector delimiter could be, but the implementation allowed it to be a vector of anything. This laxness has the following problems:

1. It's semantically dubious to read until the first T in an IO, when IOs are generally conceptualized to contain bytes, and not Ts. This seems to suggest a notion of an IO "containing" T's instead of bytes (which is a different thing from merely being able to read T's from the IO).

3. The implementation is buggy, or at least has highly surprising consequences. For example:

```julia
julia> println(readuntil(IOBuffer("\1\2\3\4"), 0x0302)) # does not recognize the `0x0302` at bytes 2:3
UInt16[0x0201, 0x0403]

julia> println(readuntil(IOBuffer("\1\2\3\4\5"), 0x0302)) # same as above, but also wrongly errors
ERROR: EOFError: read end of file

julia> println(readuntil(IOBuffer("alpha beta gamma"), ["beta"])) # what does this even mean? And why isn't the "beta" found?
["alpha beta gamma"]
```

These bugs are fundamental to the current implementation, and it's difficult to fix them.

3. The generic implementation is highly inefficient because it depends on `readeach`. It's difficult to make this generically efficient for arbitrary T.

We could also support `AbstractVector{<:AbstractChar}` by converting it to `String`, internally. But I wouldn't support this. It's too messy to have one function do everything, and the user is best served having to construct the string / vector themselves.

Closes #51724