### PR TITLE
RFC: Expand documentation of `seek`, `position` and related functions

### DIFF
--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -137,7 +137,7 @@ Seek a stream to the given position.
 
 The `pos` argument should be a value that can be returned by `position(s)`.
 Seeking before the first position should throw an error. Seeking after the
-final position should throw an error if the stream is not writable.
+final position may throw an error, if the seek is too large.
 If the stream is writable, reading will throw an error, and writing will fill
 in zeros (`0x00`) between the largest previous position and the new position.
 


### PR DESCRIPTION
This commit intentionally omits expanding the documentation of `mark` etc., which although related, is a somewhat different mechanism.

I'm interested in discussion about what the right behaviour is:

* Here, I documented `seek` is able to seek past the end of the IO, if the IO is seekable, in which case writing to it will fill in zero bytes. But I don't actually like this. It feels like that API is mixing up the behaviour of `truncate` and `seek`. It really feels like this should be an error. It also makes the behaviour of `skip` more awkward, because implementing this by reading a bunch of bytes no longer corresponds to seeking. It also creates a weird mismatch between reading and writing IOs. IMO, the congruence with libc's `lseek` is not enough to warrant this. IMO this should throw an exception when the seeking goes out of bounds in either direction.

* This PR kind of chickens out and doesn't go ahead and say that `position` should return a zero-based `Int`. Having it be more generic is nice for e.g. [BGZF's virtualoffset](https://github.com/BioJulia/BGZFStreams.jl/blob/master/src/virtualoffset.jl), but it also makes it harder to use. Probably, IOs will not document what their `position` returns, so in practice, users will just rely on it returning a zero-based `Int` without it being documented.

* [A comment from Jameson](https://github.com/JuliaLang/julia/issues/57639#issuecomment-2698751048) suggests `position`'s return value should support arithmetic. That makes sense, since it then allows `skip` and relative seeking. However, the only non-integer position type I know of, BGZF's virtual offset, does not support arithmetic. So it feels like documenting this gets the worst of both worlds: It neither enables custom position types, nor do you get the convenience of knowing the return value is a zero-indexed `Int`

## TODO
- [ ] Discuss the points above and reach a conclusion
- [ ] Make sure Base's types actually follow this behaviour. They currently behave inconsistently.

Closes #57618
Closes #57639
