### PR TITLE
verify that `optimize_until` is a valid pass

### DIFF
--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -1008,19 +1008,11 @@ matchpass(::Nothing, _, _) = false
 function run_passes_ipo_safe(
     ci::CodeInfo,
     sv::OptimizationState,
-    optimize_until::Union{Nothing, Int, String} = nothing,  # run all passes by default
-)
-    if optimize_until isa String
-        found_pass = false
-        for pass in ALL_PASS_NAMES
-            if optimize_until == pass
-                found_pass = true
-                break
-            end
-        end
-        if !found_pass
-            error("invalid `optimize_until` argument, no such optimization pass")
-        end
+    optimize_until::Union{Nothing, Int, String} = nothing)  # run all passes by default
+    if optimize_until isa String && !contains_is(ALL_PASS_NAMES, optimize_until)
+        error("invalid `optimize_until` argument, no such optimization pass")
+    elseif optimize_until isa Int && (optimize_until < 1 || optimize_until > length(ALL_PASS_NAMES))
+        error("invalid `optimize_until` argument, no such optimization pass")
     end
 
     __stage__ = 0  # used by @pass

--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -1010,8 +1010,17 @@ function run_passes_ipo_safe(
     sv::OptimizationState,
     optimize_until::Union{Nothing, Int, String} = nothing,  # run all passes by default
 )
-    if optimize_until isa String && !(optimize_until in ALL_PASS_NAMES)
-        error("invalid `optimize_until` argument, no such optimization pass")
+    if optimize_until isa String
+        found_pass = false
+        for pass in ALL_PASS_NAMES
+            if optimize_until == pass
+                found_pass = true
+                break
+            end
+        end
+        if !found_pass
+            error("invalid `optimize_until` argument, no such optimization pass")
+        end
     end
 
     __stage__ = 0  # used by @pass

--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -988,14 +988,16 @@ function optimize(interp::AbstractInterpreter, opt::OptimizationState, caller::I
     return nothing
 end
 
-macro pass(name, expr)
+const ALL_PASS_NAMES = String[]
+macro pass(name::String, expr)
     optimize_until = esc(:optimize_until)
     stage = esc(:__stage__)
-    macrocall = :(@timeit $(esc(name)) $(esc(expr)))
+    macrocall = :(@timeit $name $(esc(expr)))
     macrocall.args[2] = __source__  # `@timeit` may want to use it
+    push!(ALL_PASS_NAMES, name)
     quote
         $macrocall
-        matchpass($optimize_until, ($stage += 1), $(esc(name))) && $(esc(:(@goto __done__)))
+        matchpass($optimize_until, ($stage += 1), $name) && $(esc(:(@goto __done__)))
     end
 end
 
@@ -1006,8 +1008,12 @@ matchpass(::Nothing, _, _) = false
 function run_passes_ipo_safe(
     ci::CodeInfo,
     sv::OptimizationState,
-    optimize_until = nothing,  # run all passes by default
+    optimize_until::Union{Nothing, Int, String} = nothing,  # run all passes by default
 )
+    if optimize_until isa String && !(optimize_until in ALL_PASS_NAMES)
+        error("invalid `optimize_until` argument, no such optimization pass")
+    end
+
     __stage__ = 0  # used by @pass
     # NOTE: The pass name MUST be unique for `optimize_until::String` to work
     @pass "convert"   ir = convert_to_ircode(ci, sv)

--- a/Compiler/test/irpasses.jl
+++ b/Compiler/test/irpasses.jl
@@ -1459,7 +1459,7 @@ function f_with_early_try_catch_exit()
     result
 end
 
-let ir = first(only(Base.code_ircode(f_with_early_try_catch_exit, (); optimize_until="compact")))
+let ir = first(only(Base.code_ircode(f_with_early_try_catch_exit, (); optimize_until="slot2reg")))
     for i = 1:length(ir.stmts)
         expr = ir.stmts[i][:stmt]
         if isa(expr, PhiCNode)

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -823,3 +823,4 @@ let cl = Int32[32, 1, 1, 1000, 240, 230]
 end
 
 @test_throws ErrorException Base.code_ircode(+, (Float64, Float64); optimize_until = "nonexisting pass name")
+@test_throws ErrorException Base.code_ircode(+, (Float64, Float64); optimize_until = typemax(Int))

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -821,3 +821,5 @@ let cl = Int32[32, 1, 1, 1000, 240, 230]
     cl2 = ccall(:jl_uncompress_codelocs, Any, (Any, Int), str, 2)
     @test cl == cl2
 end
+
+@test_throws ErrorException Base.code_ircode(+, (Float64, Float64); optimize_until = "nonexisting pass name")

--- a/test/show.jl
+++ b/test/show.jl
@@ -2563,7 +2563,7 @@ end
     mktemp() do f, io
         redirect_stdout(io) do
             let io = IOBuffer()
-                for i = 1:10
+                for i = 1:length(Base.Compiler.ALL_PASS_NAMES)
                     # make sure we don't error on printing IRs at any optimization level
                     ir = only(Base.code_ircode(sin, (Float64,); optimize_until=i))[1]
                     @test try; show(io, ir); true; catch; false; end


### PR DESCRIPTION
I've noticed a few places in tests where `optimize_until` is called with a non-existent pass name. This is an attempt to catch those places and hopefully prevent further possible regressions when someone renames a pass and forgets to update the tests that matches on that name.