### PR TITLE
optimizer: fix various `optimize_until` misuses

### DIFF
--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -1044,7 +1044,7 @@ function run_passes_ipo_safe(
     @pass "slot2reg"  ir = slot2reg(ir, ci, sv)
     # TODO: Domsorting can produce an updated domtree - no need to recompute here
     @pass "compact 1" ir = compact!(ir)
-    @pass "Inlining"  ir = ssa_inlining_pass!(ir, sv.inlining, ci.propagate_inbounds)
+    @pass "inlining"  ir = ssa_inlining_pass!(ir, sv.inlining, ci.propagate_inbounds)
     # @timeit "verify 2" verify_ir(ir)
     @pass "compact 2" ir = compact!(ir)
     @pass "SROA"      ir = sroa_pass!(ir, sv.inlining)

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -2218,7 +2218,7 @@ struct Issue52644
 end
 issue52644(::DataType) = :DataType
 issue52644(::UnionAll) = :UnionAll
-let ir = Base.code_ircode((Issue52644,); optimize_until="Inlining") do t
+let ir = Base.code_ircode((Issue52644,); optimize_until="inlining") do t
         issue52644(t.tuple)
     end |> only |> first
     ir.argtypes[1] = Tuple{}
@@ -2227,7 +2227,7 @@ let ir = Base.code_ircode((Issue52644,); optimize_until="Inlining") do t
     @test irfunc(Issue52644(Tuple{<:Integer})) === :UnionAll
 end
 issue52644_single(x::DataType) = :DataType
-let ir = Base.code_ircode((Issue52644,); optimize_until="Inlining") do t
+let ir = Base.code_ircode((Issue52644,); optimize_until="inlining") do t
         issue52644_single(t.tuple)
     end |> only |> first
     ir.argtypes[1] = Tuple{}

--- a/Compiler/test/irpasses.jl
+++ b/Compiler/test/irpasses.jl
@@ -921,7 +921,7 @@ let # Test that CFG simplify doesn't try to merge every block in a loop into
 end
 
 # `cfg_simplify!` shouldn't error in a presence of `try/catch` block
-let ir = Base.code_ircode(; optimize_until="slot2ssa") do
+let ir = Base.code_ircode(; optimize_until="slot2reg") do
         v = try
         catch
         end

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -601,6 +601,7 @@ import .Compiler: NewInstruction, insert_node!
 let ir = Base.code_ircode((Int,Int); optimize_until="inlining") do a, b
         a^b
     end |> only |> first
+    ir = Compiler.compact!(ir)
     nstmts = length(ir.stmts)
     invoke_idx = findfirst(@nospecialize(stmt)->Meta.isexpr(stmt, :invoke), ir.stmts.stmt)
     @test invoke !== nothing
@@ -662,6 +663,7 @@ end
 let ir = Base.code_ircode((Int,Int); optimize_until="inlining") do a, b
         a^b
     end |> only |> first
+    ir = Compiler.compact!(ir)
     invoke_idx = findfirst(@nospecialize(stmt)->Meta.isexpr(stmt, :invoke), ir.stmts.stmt)
     @test invoke_idx !== nothing
     invoke_expr = ir.stmts.stmt[invoke_idx]

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -826,7 +826,7 @@ end
 @test Base.infer_return_type(sin, (Int,)) == InteractiveUtils.@infer_return_type sin(42)
 @test Base.infer_exception_type(sin, (Int,)) == InteractiveUtils.@infer_exception_type sin(42)
 @test first(InteractiveUtils.@code_ircode sin(42)) isa Core.Compiler.IRCode
-@test first(InteractiveUtils.@code_ircode optimize_until="Inlining" sin(42)) isa Core.Compiler.IRCode
+@test first(InteractiveUtils.@code_ircode optimize_until="inlining" sin(42)) isa Core.Compiler.IRCode
 
 @testset "Docstrings" begin
     @test isempty(Docs.undocumented_names(InteractiveUtils))


### PR DESCRIPTION
I fixed a bunch of places where the `optimize_until` path was specified incorrectly. Also, I changed `"Inlining"` to `"inlining"` to match the lowercase style of the other path names.