### PR TITLE
Add "localized world age" fast-path to `staticdata.jl`

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -372,7 +372,9 @@ function find_union_split_method_matches(interp::AbstractInterpreter, argtypes::
         end
         valid_worlds = intersect(valid_worlds, thismatches.valid_worlds)
         thisfullmatch = any(match::MethodMatch->match.fully_covers, thismatches)
-        thisinfo = MethodMatchInfo(thismatches, mt, sig_n, thisfullmatch)
+        thismaxworld = thismatches.valid_worlds.max_world
+        mt_age = (thismaxworld == typemax(UInt)) ? mt.local_age : nothing
+        thisinfo = MethodMatchInfo(thismatches, mt, mt_age, sig_n, thisfullmatch)
         push!(infos, thisinfo)
         for idx = 1:length(thismatches)
             push!(applicable, MethodMatchTarget(thismatches[idx], thisinfo.edges, idx))
@@ -397,7 +399,9 @@ function find_simple_method_matches(interp::AbstractInterpreter, @nospecialize(a
         return FailedMethodMatch("Too many methods matched")
     end
     fullmatch = any(match::MethodMatch->match.fully_covers, matches)
-    info = MethodMatchInfo(matches, mt, atype, fullmatch)
+    max_world = matches.valid_worlds.max_world
+    mt_age = (max_world == typemax(UInt)) ? mt.local_age : nothing
+    info = MethodMatchInfo(matches, mt, mt_age, atype, fullmatch)
     applicable = MethodMatchTarget[MethodMatchTarget(matches[idx], info.edges, idx) for idx = 1:length(matches)]
     return MethodMatches(applicable, info, matches.valid_worlds)
 end

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -3204,7 +3204,7 @@ function _hasmethod_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, sv
     if match === nothing
         rt = Const(false)
         vresults = MethodLookupResult(Any[], valid_worlds, true)
-        vinfo = MethodMatchInfo(vresults, mt, types, false) # XXX: this should actually be an info with invoke-type edge
+        vinfo = MethodMatchInfo(vresults, mt, nothing, types, false) # XXX: this should actually be an info with invoke-type edge
     else
         rt = Const(true)
         vinfo = InvokeCallInfo(nothing, match, nothing, types)

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -586,8 +586,11 @@ function store_backedges(caller::CodeInstance, edges::SimpleVector)
         i > length(edges) && return nothing
         item = edges[i]
         if item isa Int
-            i += 2
+            i += 3
             continue # ignore the query information if present but process the contents
+        elseif item isa UInt
+            i += 1
+            continue # ignore the local age information but process the contents
         elseif isa(item, Method)
             # ignore `Method`-edges (from e.g. failed `abstract_call_method`)
             i += 1

--- a/doc/src/devdocs/world_age.md
+++ b/doc/src/devdocs/world_age.md
@@ -1,0 +1,19 @@
+# World Age Semantics in Julia
+
+## Global World Age
+
+The global world age is a monotonically increasing counter that increments whenever a dispatch-impacting event occurs, such as:
+  - `Method` registration (`Method` addition or deletion)
+  - `Binding` modification (re-defining a function or constant)
+
+A `world` represents a snapshot of the dispatch state at a given point in time.
+
+## Localized World Ages
+
+A "localized world age" is similar, but it only tracks changes to specific portions of the method table.
+
+Each `Core.MethodTable` has a `local_age` field that counts dispatch-affecting events specific to that function. For example, a method registration for `read(::Foo)` affects the global world age, as well as the local age of `read`, but it would not be counted as part of the local age of `write`.
+
+Similar to the global world age, Julia can use these ages to refer to a "snapshot" of portions of the method table and avoid unnecessary validation when loading packages. During precompilation, Julia records the local age of each MethodTable it queries. If the latest local age matches the pre-compiled "snapshot", the compiler can skip revalidation for that function, improving load times.
+
+Loading guarantees that all of the dispatch-affecting events that happened during pre-compilation are applied to the dispatch table again at run-time, so that any modifications from other loaded packages (outside of our pre-compilation dependencies) would trigger a strictly larger local age.

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -652,11 +652,6 @@ void *jl_create_native_impl(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvm
     if (jl_typeinf_func) {
         fargs[0] = (jl_value_t*)jl_typeinf_func;
         fargs[1] = (jl_value_t*)methods;
-#ifdef _P64
-        jl_value_t *jl_array_ulong_type = jl_array_uint64_type;
-#else
-        jl_value_t *jl_array_ulong_type = jl_array_uint32_type;
-#endif
         jl_array_t *worlds = jl_alloc_array_1d(jl_array_ulong_type, 1 + compiler_world);
         fargs[2] = (jl_value_t*)worlds;
         jl_array_data(worlds, size_t)[0] = jl_typeinf_world;

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -51,6 +51,8 @@ JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *mo
     jl_atomic_store_relaxed(&mt->leafcache, (jl_genericmemory_t*)jl_an_empty_memory_any);
     jl_atomic_store_relaxed(&mt->cache, jl_nothing);
     jl_atomic_store_relaxed(&mt->max_args, 0);
+    jl_atomic_store_relaxed(&mt->local_age, 0);
+    jl_atomic_store_relaxed(&mt->last_update_world, 0);
     mt->backedges = NULL;
     JL_MUTEX_INIT(&mt->writelock, "methodtable->writelock");
     mt->offs = 0;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3034,19 +3034,22 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_methtable_type->name->mt = jl_nonfunction_mt;
     jl_methtable_type->super = jl_any_type;
     jl_methtable_type->parameters = jl_emptysvec;
-    jl_methtable_type->name->n_uninitialized = 11 - 6;
-    jl_methtable_type->name->names = jl_perm_symsvec(11, "name", "defs",
+    jl_methtable_type->name->n_uninitialized = 13 - 8;
+    jl_methtable_type->name->names = jl_perm_symsvec(13, "name", "defs",
                                                      "leafcache", "cache", "max_args",
+                                                     "local_age", "last_update_world",
                                                      "module", "backedges",
                                                      "", "", "offs", "");
-    const static uint32_t methtable_constfields[1] = { 0x00000020 }; // (1<<5);
-    const static uint32_t methtable_atomicfields[1] = { 0x0000001e }; // (1<<1)|(1<<2)|(1<<3)|(1<<4);
+    const static uint32_t methtable_constfields[1]  = { 0b0000010000000 }; // (1<<7);
+    const static uint32_t methtable_atomicfields[1] = { 0b0000001111110 }; // (1<<1)|(1<<2)|(1<<3)|(1<<4)|(1<<5)|(1<<6);
     jl_methtable_type->name->constfields = methtable_constfields;
     jl_methtable_type->name->atomicfields = methtable_atomicfields;
     jl_precompute_memoized_dt(jl_methtable_type, 1);
-    jl_methtable_type->types = jl_svec(11, jl_symbol_type, jl_any_type, jl_any_type,
+    jl_methtable_type->types = jl_svec(13, jl_symbol_type, jl_any_type, jl_any_type,
                                        jl_any_type, jl_any_type/*jl_long*/,
-                                       jl_any_type/*module*/, jl_any_type/*any vector*/,
+                                       jl_any_type/*jl_ulong*/, jl_any_type/*jl_ulong*/,
+                                       jl_any_type/*module*/,
+                                       jl_any_type/*any vector*/,
                                        jl_any_type/*voidpointer*/, jl_any_type/*int32*/,
                                        jl_any_type/*uint8*/, jl_any_type/*uint8*/);
 
@@ -3857,12 +3860,14 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_typename_type->types, 14, jl_uint8_type);
     jl_svecset(jl_typename_type->types, 15, jl_uint8_type);
     jl_svecset(jl_methtable_type->types, 4, jl_long_type);
-    jl_svecset(jl_methtable_type->types, 5, jl_module_type);
-    jl_svecset(jl_methtable_type->types, 6, jl_array_any_type);
-    jl_svecset(jl_methtable_type->types, 7, jl_long_type); // voidpointer
-    jl_svecset(jl_methtable_type->types, 8, jl_long_type); // uint32_t plus alignment
-    jl_svecset(jl_methtable_type->types, 9, jl_uint8_type);
-    jl_svecset(jl_methtable_type->types, 10, jl_uint8_type);
+    jl_svecset(jl_methtable_type->types, 5, jl_ulong_type);
+    jl_svecset(jl_methtable_type->types, 6, jl_ulong_type);
+    jl_svecset(jl_methtable_type->types, 7, jl_module_type);
+    jl_svecset(jl_methtable_type->types, 8, jl_array_any_type);
+    jl_svecset(jl_methtable_type->types, 9, jl_long_type); // voidpointer
+    jl_svecset(jl_methtable_type->types, 10, jl_long_type); // uint32_t plus alignment
+    jl_svecset(jl_methtable_type->types, 11, jl_uint8_type);
+    jl_svecset(jl_methtable_type->types, 12, jl_uint8_type);
     jl_svecset(jl_method_type->types, 13, jl_method_instance_type);
     //jl_svecset(jl_debuginfo_type->types, 0, jl_method_instance_type); // union(jl_method_instance_type, jl_method_type, jl_symbol_type)
     jl_svecset(jl_method_instance_type->types, 4, jl_code_instance_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -881,6 +881,8 @@ typedef struct _jl_methtable_t {
     _Atomic(jl_genericmemory_t*) leafcache;
     _Atomic(jl_typemap_t*) cache;
     _Atomic(intptr_t) max_args;  // max # of non-vararg arguments in a signature
+    _Atomic(size_t) local_age; // total # of operations applied to this portion of the method table
+    _Atomic(size_t) last_update_world; // world age when last update to MethodTable was made
     jl_module_t *module; // sometimes used for debug printing
     jl_array_t *backedges; // (sig, caller::CodeInstance) pairs
     jl_mutex_t writelock;
@@ -1656,7 +1658,7 @@ static inline int jl_field_isconst(jl_datatype_t *st, int i) JL_NOTSAFEPOINT
 #define jl_is_code_info(v)   jl_typetagis(v,jl_code_info_type)
 #define jl_is_method(v)      jl_typetagis(v,jl_method_type)
 #define jl_is_module(v)      jl_typetagis(v,jl_module_tag<<4)
-#define jl_is_mtable(v)      jl_typetagis(v,jl_methtable_type)
+#define jl_is_methtable(v)   jl_typetagis(v,jl_methtable_type)
 #define jl_is_task(v)        jl_typetagis(v,jl_task_tag<<4)
 #define jl_is_string(v)      jl_typetagis(v,jl_string_tag<<4)
 #define jl_is_cpointer(v)    jl_is_cpointer_type(jl_typeof(v))
@@ -1983,23 +1985,29 @@ JL_DLLEXPORT uint8_t *jl_unbox_uint8pointer(jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_get_size(jl_value_t *val, size_t *pnt);
 
 #ifdef _P64
-#define jl_box_long(x)   jl_box_int64(x)
-#define jl_box_ulong(x)  jl_box_uint64(x)
-#define jl_unbox_long(x) jl_unbox_int64(x)
-#define jl_unbox_ulong(x) jl_unbox_uint64(x)
-#define jl_is_long(x)    jl_is_int64(x)
-#define jl_is_ulong(x)   jl_is_uint64(x)
-#define jl_long_type     jl_int64_type
-#define jl_ulong_type    jl_uint64_type
+#define jl_box_long(x)       jl_box_int64(x)
+#define jl_box_ulong(x)      jl_box_uint64(x)
+#define jl_unbox_long(x)     jl_unbox_int64(x)
+#define jl_unbox_ulong(x)    jl_unbox_uint64(x)
+#define jl_is_long(x)        jl_is_int64(x)
+#define jl_is_ulong(x)       jl_is_uint64(x)
+#define jl_long_type         jl_int64_type
+#define jl_ulong_type        jl_uint64_type
+#define jl_memory_ulong_type jl_memory_uint64_type
+#define jl_array_long_type   jl_array_int64_type
+#define jl_array_ulong_type  jl_array_uint64_type
 #else
-#define jl_box_long(x)   jl_box_int32(x)
-#define jl_box_ulong(x)  jl_box_uint32(x)
-#define jl_unbox_long(x) jl_unbox_int32(x)
-#define jl_unbox_ulong(x) jl_unbox_uint32(x)
-#define jl_is_long(x)    jl_is_int32(x)
-#define jl_is_ulong(x)   jl_is_uint32(x)
-#define jl_long_type     jl_int32_type
-#define jl_ulong_type    jl_uint32_type
+#define jl_box_long(x)       jl_box_int32(x)
+#define jl_box_ulong(x)      jl_box_uint32(x)
+#define jl_unbox_long(x)     jl_unbox_int32(x)
+#define jl_unbox_ulong(x)    jl_unbox_uint32(x)
+#define jl_is_long(x)        jl_is_int32(x)
+#define jl_is_ulong(x)       jl_is_uint32(x)
+#define jl_long_type         jl_int32_type
+#define jl_ulong_type        jl_uint32_type
+#define jl_memory_ulong_type jl_memory_uint32_type
+#define jl_array_long_type   jl_array_int32_type
+#define jl_array_ulong_type  jl_array_uint32_type
 #endif
 
 // structs

--- a/src/method.c
+++ b/src/method.c
@@ -801,7 +801,7 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *mi, size_t
                     else if (jl_is_binding(kind)) {
                         jl_add_binding_backedge((jl_binding_t*)kind, (jl_value_t*)ci);
                     }
-                    else if (jl_is_mtable(kind)) {
+                    else if (jl_is_methtable(kind)) {
                         assert(i < l);
                         ex = data[i++];
                         jl_method_table_add_backedge((jl_methtable_t*)kind, ex, ci);
@@ -809,6 +809,7 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *mi, size_t
                     else {
                         assert(i < l);
                         ex = data[i++];
+                        assert(jl_is_method_instance(ex));
                         jl_method_instance_add_backedge((jl_method_instance_t*)ex, kind, ci);
                     }
                 }


### PR DESCRIPTION
This PR introduces the notion of "localized world age" (see the [added devdocs](https://github.com/topolarity/julia/blob/0f822b49f4a901547811084f171f87c4bc98bebc/doc/src/devdocs/world_age.md)) and adds a fast path to staticdata.jl

On my machine, this saves us ~420k of the ~720k method look-ups that we perform (~58%) for loading "using CairoMakie".

The load-time improvements are more modest (about ~1-1.5 seconds) since these were already very fast (~3 μs on average) and we still spend a lot of time walking to these edges that we don't need to verify.

I suspect there are more gains to be had here. The fast-path is moderately warm, but most of the non-fast-pathed calls are targeting "dense" MethodTables, like `(::Type)(...)` or highly ad-hoc-polymorphic tables like `haskey(...)` which will be implemented over many user types.

It should be possible to generalize this to have sub-MethodTable granularity like this (numbers made up):
```
world (age: 12342)
├─ haskey (age: 484)
│    ├─ haskey(::T, ...) where moduleroot(parentmodule(typename(T))) === Base (age: 201)
│    ├─ haskey(::T, ...) where moduleroot(parentmodule(typename(T))) === PkgFoo (age: 12)
│    └─ haskey(::T, ...) where moduleroot(parentmodule(typename(T))) === PkgBar (age: 34)
├─ read (age: 200)
...
```

which would make many of those eligible for the fast path at the cost of an extra lookup or two.

Nonetheless, I wanted to open this first to get input (esp. @vtjnash's and @timholy's) and see if this approach is sound (and to work out how to best do the edge encoding etc. - it's not very efficient right now)