### PR TITLE
delete redundant `IteratorSize` method for `Slices`

### DIFF
--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -225,7 +225,6 @@ constructed by [`eachcol`](@ref).
 const ColumnSlices{P<:AbstractMatrix,AX,S<:AbstractVector} = Slices{P,Tuple{Colon,Int},AX,S,1}
 
 
-IteratorSize(::Type{Slices{P,SM,AX,S,N}}) where {P,SM,AX,S,N} = HasShape{N}()
 axes(s::Slices) = s.axes
 size(s::Slices) = map(length, s.axes)
 


### PR DESCRIPTION
Already covered as an `AbstractArray` subtype.