### PR TITLE
Eagerly evaluate indices in `eachindex` check

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -321,13 +321,13 @@ eachindex(itrs...) = keys(itrs...)
 eachindex(A::AbstractVector) = (@inline(); axes1(A))
 
 
-@noinline function throw_eachindex_mismatch_indices(::IndexLinear, A...)
-    inds = map(x -> eachindex(IndexLinear(), x), A)
-    throw(DimensionMismatch(LazyString("all inputs to eachindex must have the same indices, got ", join(inds, ", ", " and "))))
+@noinline function throw_eachindex_mismatch_indices(indices_str, indsA, indsBs...)
+    inds = (indsA, indsBs...)
+    throw(DimensionMismatch(LazyString("all inputs to eachindex must have the same ", indices_str, ", got ", join(inds, ", ", " and "))))
 end
-@noinline function throw_eachindex_mismatch_indices(::IndexCartesian, A...)
-    inds = map(x -> eachindex(IndexCartesian(), x), A)
-    throw(DimensionMismatch(LazyString("all inputs to eachindex must have the same axes, got ", join(inds, ", ", " and "))))
+@noinline function throw_eachindex_mismatch_indices(indices_str, indsA, indsB)
+    inds = (indsA, indsB)
+    throw(DimensionMismatch(LazyString("all inputs to eachindex must have the same ", indices_str, ", got ", indsA, " and ", indsB)))
 end
 
 """
@@ -392,8 +392,9 @@ eachindex(::IndexLinear, A::AbstractVector) = (@inline; axes1(A))
 function eachindex(::IndexLinear, A::AbstractArray, B::AbstractArray...)
     @inline
     indsA = eachindex(IndexLinear(), A)
-    all(==(indsA), map(X -> eachindex(IndexLinear(), X), B)) ||
-        throw_eachindex_mismatch_indices(IndexLinear(), A, B...)
+    indsBs = map(X -> eachindex(IndexLinear(), X), B)
+    all(==(indsA), indsBs) ||
+        throw_eachindex_mismatch_indices("indices", indsA, indsBs...)
     indsA
 end
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -321,11 +321,13 @@ eachindex(itrs...) = keys(itrs...)
 eachindex(A::AbstractVector) = (@inline(); axes1(A))
 
 
-@noinline function throw_eachindex_mismatch_indices(::IndexLinear, inds...)
-    throw(DimensionMismatch("all inputs to eachindex must have the same indices, got $(join(inds, ", ", " and "))"))
+@noinline function throw_eachindex_mismatch_indices(::IndexLinear, A...)
+    inds = map(x -> eachindex(IndexLinear(), x), A)
+    throw(DimensionMismatch(lazy"all inputs to eachindex must have the same indices, got $(join(inds, \", \", \" and \"))"))
 end
-@noinline function throw_eachindex_mismatch_indices(::IndexCartesian, inds...)
-    throw(DimensionMismatch("all inputs to eachindex must have the same axes, got $(join(inds, ", ", " and "))"))
+@noinline function throw_eachindex_mismatch_indices(::IndexCartesian, A...)
+    inds = map(x -> eachindex(IndexCartesian(), x), A)
+    throw(DimensionMismatch(lazy"all inputs to eachindex must have the same axes, got $(join(inds, \", \", \" and \"))"))
 end
 
 """
@@ -390,8 +392,8 @@ eachindex(::IndexLinear, A::AbstractVector) = (@inline; axes1(A))
 function eachindex(::IndexLinear, A::AbstractArray, B::AbstractArray...)
     @inline
     indsA = eachindex(IndexLinear(), A)
-    _all_match_first(X->eachindex(IndexLinear(), X), indsA, B...) ||
-        throw_eachindex_mismatch_indices(IndexLinear(), eachindex(A), eachindex.(B)...)
+    all(==(indsA), map(X -> eachindex(IndexLinear(), X), B)) ||
+        throw_eachindex_mismatch_indices(IndexLinear(), A, B...)
     indsA
 end
 function _all_match_first(f::F, inds, A, B...) where F<:Function

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -321,13 +321,13 @@ eachindex(itrs...) = keys(itrs...)
 eachindex(A::AbstractVector) = (@inline(); axes1(A))
 
 
+# we unroll the join for easier inference
+_join_comma_and(indsA, indsB) = LazyString(indsA, " and ", indsB)
+_join_comma_and(indsA, indsB, indsC...) = LazyString(indsA, ", ", _join_comma_and(indsB, indsC...))
 @noinline function throw_eachindex_mismatch_indices(indices_str, indsA, indsBs...)
-    inds = (indsA, indsBs...)
-    throw(DimensionMismatch(LazyString("all inputs to eachindex must have the same ", indices_str, ", got ", join(inds, ", ", " and "))))
-end
-@noinline function throw_eachindex_mismatch_indices(indices_str, indsA, indsB)
-    inds = (indsA, indsB)
-    throw(DimensionMismatch(LazyString("all inputs to eachindex must have the same ", indices_str, ", got ", indsA, " and ", indsB)))
+    throw(DimensionMismatch(
+            LazyString("all inputs to eachindex must have the same ", indices_str, ", got ",
+                _join_comma_and(indsA, indsBs...))))
 end
 
 """

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -396,11 +396,6 @@ function eachindex(::IndexLinear, A::AbstractArray, B::AbstractArray...)
         throw_eachindex_mismatch_indices(IndexLinear(), A, B...)
     indsA
 end
-function _all_match_first(f::F, inds, A, B...) where F<:Function
-    @inline
-    (inds == f(A)) & _all_match_first(f, inds, B...)
-end
-_all_match_first(f::F, inds) where F<:Function = true
 
 # keys with an IndexStyle
 keys(s::IndexStyle, A::AbstractArray, B::AbstractArray...) = eachindex(s, A, B...)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -323,11 +323,11 @@ eachindex(A::AbstractVector) = (@inline(); axes1(A))
 
 @noinline function throw_eachindex_mismatch_indices(::IndexLinear, A...)
     inds = map(x -> eachindex(IndexLinear(), x), A)
-    throw(DimensionMismatch(lazy"all inputs to eachindex must have the same indices, got $(join(inds, \", \", \" and \"))"))
+    throw(DimensionMismatch(LazyString("all inputs to eachindex must have the same indices, got ", join(inds, ", ", " and "))))
 end
 @noinline function throw_eachindex_mismatch_indices(::IndexCartesian, A...)
     inds = map(x -> eachindex(IndexCartesian(), x), A)
-    throw(DimensionMismatch(lazy"all inputs to eachindex must have the same axes, got $(join(inds, \", \", \" and \"))"))
+    throw(DimensionMismatch(LazyString("all inputs to eachindex must have the same axes, got ", join(inds, ", ", " and "))))
 end
 
 """

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -416,8 +416,9 @@ module IteratorsMD
 
     @inline function eachindex(::IndexCartesian, A::AbstractArray, B::AbstractArray...)
         axsA = axes(A)
-        all(==(axsA), map(axes, B)) ||
-            Base.throw_eachindex_mismatch_indices(IndexCartesian(), A, B...)
+        axsBs = map(axes, B)
+        all(==(axsA), axsBs) ||
+            Base.throw_eachindex_mismatch_indices("axes", axsA, axsBs...)
         CartesianIndices(axsA)
     end
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -416,7 +416,8 @@ module IteratorsMD
 
     @inline function eachindex(::IndexCartesian, A::AbstractArray, B::AbstractArray...)
         axsA = axes(A)
-        Base._all_match_first(axes, axsA, B...) || Base.throw_eachindex_mismatch_indices(IndexCartesian(), axes(A), axes.(B)...)
+        all(==(axsA), map(axes, B)) ||
+            Base.throw_eachindex_mismatch_indices(IndexCartesian(), A, B...)
         CartesianIndices(axsA)
     end
 

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -271,7 +271,8 @@ SCartesianIndices2{K}(indices2::AbstractUnitRange{Int}) where {K} = (@assert K::
 eachindex(::IndexSCartesian2{K}, A::ReshapedReinterpretArray) where {K} = SCartesianIndices2{K}(eachindex(IndexLinear(), parent(A)))
 @inline function eachindex(style::IndexSCartesian2{K}, A::AbstractArray, B::AbstractArray...) where {K}
     iter = eachindex(style, A)
-    _all_match_first(C->eachindex(style, C), iter, B...) || throw_eachindex_mismatch_indices(IndexSCartesian2{K}(), axes(A), axes.(B)...)
+    itersBs = map(C->eachindex(style, C), B)
+    all(==(iter), itersBs) || throw_eachindex_mismatch_indices("axes", axes(A), map(axes, B)...)
     return iter
 end
 


### PR DESCRIPTION
This reduces TTFX in `eachindex` calls with multiple arguments, with minimal impact on performance. Much of the latency comes from the error path, and specializing it for the common case of 2 arguments helps a lot with reducing latency. In this, I've also unrolled the `join` in the error path, and we recursively generate a `LazyString`s instead. This helps in reducing TTFX for a longer list of arguments.

```julia
julia> a = zeros(2,2);

julia> @time eachindex(a, a);
  0.046902 seconds (128.39 k allocations: 6.652 MiB, 99.93% compilation time) # nightly
  0.015368 seconds (19.91 k allocations: 1.048 MiB, 99.79% compilation time) # this PR

julia> @btime eachindex($a, $a, $a, $a, $a, $a, $a, $a);
  6.945 ns (0 allocations: 0 bytes) # nightly
  6.855 ns (0 allocations: 0 bytes) # this PR
```
This reduces TTFX for a longer list of arguments as well:
```julia
julia> @time eachindex(a, a, a, a, a, a, a, a);
  0.052552 seconds (196.87 k allocations: 10.068 MiB, 99.53% compilation time) # nightly
  0.043401 seconds (69.13 k allocations: 3.454 MiB, 99.34% compilation time) # this PR
```
For Cartesian indexing,
```julia
julia> a = zeros(2,2);

julia> v = view(a, 1:2, 1:2);

julia> @time eachindex(a, v);
  0.051333 seconds (171.34 k allocations: 8.921 MiB, 99.94% compilation time) # nightly
  0.016340 seconds (26.95 k allocations: 1.405 MiB, 99.79% compilation time) # this PR

julia> @btime eachindex($a, $v, $a, $v, $a, $v, $a, $v);
  9.339 ns (0 allocations: 0 bytes) # nightly
  9.357 ns (0 allocations: 0 bytes) # this PR
```