### PR TITLE
add `activate!` support for `JuliaSyntax` and `JuliaLowering`

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -1015,6 +1015,21 @@ _parse = nothing
 
 _setparser!(parser) = setglobal!(Core, :_parse, parser)
 
+
+# Binding for the julia lowerer, called as
+#
+#    Core._lower(expr, module, filename, linenum)
+#
+# Lower Julia code from the buffer `expr`, attributing
+# it to `filename`. `expr` must be the result of `_parse`
+#
+# `_lower` must return an Expr with appropriate internals to be evaled
+#
+# The internal jl_expand_with_loc_warn will call into Core._lower if not `nothing`.
+_lower = nothing
+
+_setlowerer!(lowerer) = setglobal!(Core, :_lowerer, lowerer)
+
 # support for deprecated uses of builtin functions
 _apply(x...) = _apply_iterate(Main.Base.iterate, x...)
 const _apply_pure = _apply

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -1028,7 +1028,7 @@ _setparser!(parser) = setglobal!(Core, :_parse, parser)
 # The internal jl_expand_with_loc_warn will call into Core._lower if not `nothing`.
 _lower = nothing
 
-_setlowerer!(lowerer) = setglobal!(Core, :_lowerer, lowerer)
+_setlowerer!(lowerer) = setglobal!(Core, :_lower, lowerer)
 
 # support for deprecated uses of builtin functions
 _apply(x...) = _apply_iterate(Main.Base.iterate, x...)

--- a/src/ast.c
+++ b/src/ast.c
@@ -1358,17 +1358,16 @@ JL_DLLEXPORT jl_value_t *jl_expand_with_loc_warn(jl_value_t *expr, jl_module_t *
     }
 
     jl_value_t **args;
-    JL_GC_PUSHARGS(args, 4);
+    JL_GC_PUSHARGS(args, 5);
     args[0] = core_lower;
-    args[1] = (jl_value_t*)jl_alloc_svec(2);
-    jl_svecset(args[1], 0, jl_box_uint8pointer((uint8_t*)text));
-    jl_svecset(args[1], 1, jl_box_long(text_len));
-    args[2] = filename;
-    args[3] = jl_box_long(lineno);
+    args[1] = expr
+    args[2] = inmodule
+    args[3] = filename;
+    args[4] = jl_box_long(lineno);
     jl_task_t *ct = jl_current_task;
     size_t last_age = ct->world_age;
     ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
-    jl_value_t *result = jl_apply(args, 4);
+    jl_value_t *result = jl_apply(args, 5);
     ct->world_age = last_age;
     args[0] = result; // root during error checks below
     JL_GC_POP();

--- a/src/ast.c
+++ b/src/ast.c
@@ -1356,12 +1356,17 @@ JL_DLLEXPORT jl_value_t *jl_expand_with_loc_warn(jl_value_t *expr, jl_module_t *
         JL_GC_POP();
         return expr;
     }
+
     jl_value_t **args;
     JL_GC_PUSHARGS(args, 4);
     args[0] = core_lower;
-    args[1] = inmodule;
+    args[1] = (jl_value_t*) inmodule;
+    jl_value_t *filename = NULL;
+    JL_GC_PUSH1(&filename);
+    filename = jl_cstr_to_string(file);
     args[2] = filename;
-    args[3] = jl_box_long(lineno);
+    JL_GC_POP();
+    args[3] = jl_box_long(line);
     jl_task_t *ct = jl_current_task;
     size_t last_age = ct->world_age;
     ct->world_age = jl_atomic_load_acquire(&jl_world_counter);

--- a/src/ast.c
+++ b/src/ast.c
@@ -1358,19 +1358,20 @@ JL_DLLEXPORT jl_value_t *jl_expand_with_loc_warn(jl_value_t *expr, jl_module_t *
     }
 
     jl_value_t **args;
-    JL_GC_PUSHARGS(args, 4);
+    JL_GC_PUSHARGS(args, 5);
     args[0] = core_lower;
-    args[1] = (jl_value_t*) inmodule;
+    args[1] = expr;
+    args[2] = (jl_value_t*) inmodule;
     jl_value_t *filename = NULL;
     JL_GC_PUSH1(&filename);
     filename = jl_cstr_to_string(file);
-    args[2] = filename;
+    args[3] = filename;
     JL_GC_POP();
-    args[3] = jl_box_long(line);
+    args[4] = jl_box_long(line);
     jl_task_t *ct = jl_current_task;
     size_t last_age = ct->world_age;
     ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
-    jl_value_t *result = jl_apply(args, 6);
+    jl_value_t *result = jl_apply(args, 5);
     ct->world_age = last_age;
     JL_TYPECHK(parse, expr, result);
     JL_GC_POP();

--- a/src/ast.c
+++ b/src/ast.c
@@ -1310,7 +1310,7 @@ JL_DLLEXPORT jl_value_t *jl_expand_with_loc_warn(jl_value_t *expr, jl_module_t *
     jl_timing_show_location(file, line, inmodule, JL_TIMING_DEFAULT_BLOCK);
     jl_value_t *core_lower = NULL;
     if (jl_core_module) {
-        core_lower = jl_get_global(jl_core_module, jl_symbol("_parse"));
+        core_lower = jl_get_global(jl_core_module, jl_symbol("_lower"));
     }
     if (!core_lower || core_lower == jl_nothing) {
         // In bootstrap, directly call the builtin lowerer.

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -1128,7 +1128,7 @@ static jl_value_t *jl_parse_eval_all(jl_module_t *module, jl_value_t *text,
     ast = jl_svecref(jl_parse(jl_string_data(text), jl_string_len(text),
                               filename, 1, 0, (jl_value_t*)jl_all_sym), 0);
     if (!jl_is_expr(ast) || ((jl_expr_t*)ast)->head != jl_toplevel_sym) {
-        jl_errorf("jl_parse_all() must generate a top level expression");
+        jl_errorf("jl_parse() must generate a top level expression");
     }
 
     jl_task_t *ct = jl_current_task;

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -455,6 +455,9 @@ For `@activate Compiler`, the following options are available:
 2. `:codegen`   - Activate the compiler for internal codegen purposes. The new compiler
                   will be invoked whenever the runtime requests compilation.
 
+For `@activate JuliaSyntax`, the following options are available:
+1. `:for_lowering` - Activate JuliaSyntax such that it is compatible with JuliaLowering
+
 `@activate Compiler` without options is equivalent to `@activate Compiler[:reflection]`.
 
 """

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -440,7 +440,7 @@ in the current environment.
 When using `@activate`, additional options for a component may be specified in
 square brackets `@activate Compiler[:option1, :option]`
 
-Currently `@activate Compiler` is the only available component that may be
+Currently `Compiler`, `JuliaSyntax`, and `JuliaLowering` are the only available components that may be
 activatived.
 
 For `@activate Compiler`, the following options are available:
@@ -475,7 +475,7 @@ macro activate(what)
     if !isa(Component, Symbol)
         error("Usage Error: Component $Component is not a symbol")
     end
-    allowed_components = (:Compiler,)
+    allowed_components = (:Compiler, :JuliaSyntax, :JuliaLowering)
     if !(Component in allowed_components)
         error("Usage Error: Component $Component is not recognized. Expected one of $allowed_components")
     end


### PR DESCRIPTION
requires https://github.com/JuliaLang/JuliaSyntax.jl/pull/547 for JuliaSyntax and https://github.com/c42f/JuliaLowering.jl/pull/10 for JuliaLowering

Usage:
```
using JuliaSyntax, JuliaLowering
@activate JuliaSyntax[:for_julia_lowering]
@activate JuliaLowering # this will fail parsing and fallback to flisp, but theoretically after this line, everything should work using JuliaLowering
```