### PR TITLE
Remove some unnecessary specialization

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -590,10 +590,10 @@ const undef = UndefInitializer()
 # empty vector constructor
 (self::Type{GenericMemory{kind,T,addrspace}})() where {T,kind,addrspace} = self(undef, 0)
 
-memoryref(mem::GenericMemory) = memoryrefnew(mem)
+memoryref(@nospecialize(mem::GenericMemory)) = memoryrefnew(mem)
 memoryref(mem::GenericMemory, i::Integer) = memoryrefnew(memoryrefnew(mem), Int(i), @_boundscheck)
 memoryref(ref::GenericMemoryRef, i::Integer) = memoryrefnew(ref, Int(i), @_boundscheck)
-GenericMemoryRef(mem::GenericMemory) = memoryref(mem)
+GenericMemoryRef(@nospecialize(mem::GenericMemory)) = memoryref(mem)
 GenericMemoryRef(mem::GenericMemory, i::Integer) = memoryref(mem, i)
 GenericMemoryRef(mem::GenericMemoryRef, i::Integer) = memoryref(mem, i)
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1373,6 +1373,35 @@ end
 # Specialized variant of in for Tuple, which can generate typed comparisons for each element
 # of the tuple, skipping values that are statically known to be != at compile time.
 in(x, itr::Tuple) = _in_tuple(x, itr, false)
+
+# Specialized variant to also skip the complicated inference of the function above,
+# if the tuple is homogenous
+function in(x, itr::NTuple{N, T}) where {N, T}
+    for i in itr
+        i == x && return true
+    end
+    false
+end
+
+# Special methods to handle Missing
+function in(::Missing, itr::Tuple{T, Vararg{T}}) where T
+    @nospecialize
+    @_nospecializeinfer_meta
+    missing
+end
+
+function in(::Any, itr::Tuple{Missing, Vararg{Missing}})
+    @nospecialize
+    @_nospecializeinfer_meta
+    missing
+end
+
+function in(::Missing, itr::Tuple{Missing, Vararg{Missing}})
+    @nospecialize
+    @_nospecializeinfer_meta
+    missing
+end
+
 # This recursive function will be unrolled at compiletime, and will not generate separate
 # llvm-compiled specializations for each step of the recursion.
 function _in_tuple(x, @nospecialize(itr::Tuple), anymissing::Bool)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1376,7 +1376,7 @@ in(x, itr::Tuple) = _in_tuple(x, itr, false)
 
 # Specialized variant to also skip the complicated inference of the function above,
 # if the tuple is homogenous
-function in(x, itr::NTuple{N, T}) where {N, T}
+function in(x, itr::NTuple)
     for i in itr
         i == x && return true
     end

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1374,34 +1374,6 @@ end
 # of the tuple, skipping values that are statically known to be != at compile time.
 in(x, itr::Tuple) = _in_tuple(x, itr, false)
 
-# Specialized variant to also skip the complicated inference of the function above,
-# if the tuple is homogenous
-function in(x, itr::NTuple)
-    for i in itr
-        i == x && return true
-    end
-    false
-end
-
-# Special methods to handle Missing
-function in(::Missing, itr::Tuple{T, Vararg{T}}) where T
-    @nospecialize
-    @_nospecializeinfer_meta
-    missing
-end
-
-function in(::Any, itr::Tuple{Missing, Vararg{Missing}})
-    @nospecialize
-    @_nospecializeinfer_meta
-    missing
-end
-
-function in(::Missing, itr::Tuple{Missing, Vararg{Missing}})
-    @nospecialize
-    @_nospecializeinfer_meta
-    missing
-end
-
 # This recursive function will be unrolled at compiletime, and will not generate separate
 # llvm-compiled specializations for each step of the recursion.
 function _in_tuple(x, @nospecialize(itr::Tuple), anymissing::Bool)

--- a/base/show.jl
+++ b/base/show.jl
@@ -2003,7 +2003,7 @@ function show_unquoted_expr_fallback(io::IO, ex::Expr, indent::Int, quote_level:
 end
 
 # TODO: implement interpolated strings
-function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::Int = 0)
+@nospecializeinfer function show_unquoted(@nospecialize(io::IO), ex::Expr, indent::Int, prec::Int, quote_level::Int = 0)
     head, args, nargs = ex.head, ex.args, length(ex.args)
     unhandled = false
     # dot (i.e. "x.y"), but not compact broadcast exps

--- a/base/show.jl
+++ b/base/show.jl
@@ -182,7 +182,7 @@ function show(io::IO, ::MIME"text/plain", t::AbstractDict{K,V}) where {K,V}
         rows -= 1 # Subtract the summary
 
         # determine max key width to align the output, caching the strings
-        hascolor = get(recur_io, :color, false)
+        hascolor = get(recur_io, :color, false)::Bool
         ks = Vector{String}(undef, min(rows, length(t)))
         vs = Vector{String}(undef, min(rows, length(t)))
         keywidth = 0

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -644,7 +644,11 @@ end
 ## functions ##
 
 isempty(x::Tuple{}) = true
-isempty(@nospecialize x::Tuple) = false
+
+function isempty(@nospecialize x::Tuple)
+    @_nospecializeinfer_meta
+    false
+end
 
 revargs() = ()
 revargs(x, r...) = (revargs(r...)..., x)
@@ -661,9 +665,10 @@ prod(x::Tuple{}) = 1
 prod(x::Tuple{Int, Vararg{Int}}) = *(x...)
 
 # a version of `in` esp. for NamedTuple, to make it pure, and not compiled for each tuple length
-function sym_in(x::Symbol, itr::Tuple{Vararg{Symbol}})
+function sym_in(x::Symbol, @nospecialize(itr::Tuple{Vararg{Symbol}}))
     @noinline
     @_total_meta
+    @_nospecializeinfer_meta
     for y in itr
         y === x && return true
     end

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -25,8 +25,12 @@ _counttuple(::Type) = nothing
 
 ## indexing ##
 
+function firstindex(@nospecialize t::Tuple)
+    @_nospecializeinfer_meta
+    1
+end
+
 length(@nospecialize t::Tuple) = nfields(t)
-firstindex(@nospecialize t::Tuple) = 1
 lastindex(@nospecialize t::Tuple) = length(t)
 size(@nospecialize(t::Tuple), d::Integer) = (d == 1) ? length(t) : throw(ArgumentError("invalid tuple dimension $d"))
 axes(@nospecialize t::Tuple) = (OneTo(length(t)),)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -665,10 +665,9 @@ prod(x::Tuple{}) = 1
 prod(x::Tuple{Int, Vararg{Int}}) = *(x...)
 
 # a version of `in` esp. for NamedTuple, to make it pure, and not compiled for each tuple length
-function sym_in(x::Symbol, @nospecialize(itr::Tuple{Vararg{Symbol}}))
+function sym_in(x::Symbol, itr::Tuple{Vararg{Symbol}})
     @noinline
     @_total_meta
-    @_nospecializeinfer_meta
     for y in itr
         y === x && return true
     end


### PR DESCRIPTION
This is the result of a small hunt I went on to find redundant methodinstances.

The results are disappointing - compared to master (commit 4480f42a), it removes ~830 methodinstances (about 1% of those in the sysimg), and saves only 2.6MB in `sys.so`. Nonetheless, it may as well get merged.

Some more stuff that could be done but I don't know how to
* Revive something like https://github.com/JuliaLang/julia/pull/54668
* Despecialize [the methods here](https://github.com/JuliaLang/julia/blob/9d4e31f7eb9441f1d78f07d9fb181dbac59ce7a8/base/essentials.jl#L10-L15) which has several hundreds needless specializations, but which are defined before `@nospecialize` or `@nospecializeinfer` in the bootstrapping process
* There are some methods that have _huge_ codeinstances. About 80% of the system image savings in this PR is from a single methodinstance. Other bangers include `sroa_pass!(ir::Compiler.IRCode, inlining::Union{Nothing, Compiler.InliningState})`. Maybe those could be singled out for refactoring.