### PR TITLE
remove unnecessary edge from `exp_impl` to `pow`

### DIFF
--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -224,7 +224,7 @@ end
             twopk = (k + UInt64(53)) << 52
             return reinterpret(T, twopk + reinterpret(UInt64, small_part))*0x1p-53
         end
-        #k == 1024 && return (small_part * 2.0) * 2.0^1023
+        #k == 1024 && return (small_part * 2.0) * 0x1p1023
     end
     twopk = Int64(k) << 52
     return reinterpret(T, twopk + reinterpret(Int64, small_part))
@@ -252,7 +252,7 @@ end
             twopk = (k + UInt64(53)) << 52
             return reinterpret(T, twopk + reinterpret(UInt64, small_part))*0x1p-53
         end
-        k == 1024 && return (small_part * 2.0) * 2.0^1023
+        k == 1024 && return (small_part * 2.0) * 0x1p1023
     end
     twopk = Int64(k) << 52
     return reinterpret(T, twopk + reinterpret(Int64, small_part))


### PR DESCRIPTION
This was just intended to be a constant and we have binary Float64 constants