### PR TITLE
[CompilerDevTools] Use `with_new_compiler` directly

### DIFF
--- a/Compiler/extras/CompilerDevTools/src/CompilerDevTools.jl
+++ b/Compiler/extras/CompilerDevTools/src/CompilerDevTools.jl
@@ -48,7 +48,7 @@ end
 function Compiler.transform_result_for_cache(interp::SplitCacheInterp, result::Compiler.InferenceResult, edges::Compiler.SimpleVector)
     opt = result.src::Compiler.OptimizationState
     ir = opt.result.ir::Compiler.IRCode
-    override = GlobalRef(@__MODULE__(), :with_new_compiler)
+    override = with_new_compiler
     for inst in ir.stmts
         stmt = inst[:stmt]
         isexpr(stmt, :call) || continue


### PR DESCRIPTION
Otherwise this fails IR validation potentially, because the bounds of that globalref are not being taken into account in the world ages, e.g. (In julia-debug):
```
julia> CompilerDevTools.with_new_compiler(Base.fdio, Int32(1))
Unbound or partitioned GlobalRef not allowed in value position
ERROR: IR verification failed.
    Code location: lock.jl:174
  Method instance: MethodInstance for Base._trylock(::ReentrantLock, ::Task)
Stacktrace:
  [1] error(::String, ::String, ::String, ::Symbol, ::String, ::Int32, ::String, ::String, ::Core.MethodInstance)
    @ Base ./error.jl:54
  [2] (::Compiler.var"#raise_error#verify_ir##0"{Compiler.IRCode, Core.MethodInstance})()
    @ Compiler ./../usr/share/julia/Compiler/src/ssair/verify.jl:125
  [3] check_op(ir::Compiler.IRCode, domtree::Compiler.GenericDomTree{…}, op::Any, use_bb::Int64, use_idx::Int64, printed_use_idx::Int64, print::Bool, isforeigncall::Bool, arg_idx::Int64, allow_frontend_forms::Bool, raise_error::Any)
    @ Compiler ./../usr/share/julia/Compiler/src/ssair/verify.jl:71
  [4] verify_ir(ir::Compiler.IRCode, print::Bool, allow_frontend_forms::Bool, 𝕃ₒ::Compiler.PartialsLattice{…}, mi::Core.MethodInstance)
    @ Compiler ./../usr/share/julia/Compiler/src/ssair/verify.jl:429
  [5] run_passes_ipo_safe(ci::Core.CodeInfo, sv::Compiler.OptimizationState{CompilerDevTools.SplitCacheInterp}, optimize_until::Nothing)
    @ Compiler ./../usr/share/julia/Compiler/src/optimize.jl:1027
  [6] run_passes_ipo_safe
    @ ./../usr/share/julia/Compiler/src/optimize.jl:1011 [inlined]
  [7] optimize(interp::CompilerDevTools.SplitCacheInterp, opt::Compiler.OptimizationState{…}, caller::Compiler.InferenceResult)
    @ Compiler ./../usr/share/julia/Compiler/src/optimize.jl:985
  [8] finish_nocycle(::CompilerDevTools.SplitCacheInterp, frame::Compiler.InferenceState, time_before::UInt64)
    @ Compiler ./../usr/share/julia/Compiler/src/typeinfer.jl:213
  [9] typeinf(interp::CompilerDevTools.SplitCacheInterp, frame::Compiler.InferenceState)
    @ Compiler ./../usr/share/julia/Compiler/src/abstractinterpretation.jl:4435
 [10] typeinf_ext(interp::CompilerDevTools.SplitCacheInterp, mi::Core.MethodInstance, source_mode::UInt8)
    @ Compiler ./../usr/share/julia/Compiler/src/typeinfer.jl:1311
 [11] typeinf_ext_toplevel(interp::CompilerDevTools.SplitCacheInterp, mi::Core.MethodInstance, source_mode::UInt8)
    @ Compiler ./../usr/share/julia/Compiler/src/typeinfer.jl:1403
 [12] typeinf(owner::CompilerDevTools.SplitCacheOwner, mi::Core.MethodInstance, source_mode::UInt8)
    @ CompilerDevTools ~/julia/Compiler/extras/CompilerDevTools/src/CompilerDevTools.jl:35
 [13] with_new_compiler(f::Function, owner::CompilerDevTools.SplitCacheOwner, args::Int32)
    @ CompilerDevTools ~/julia/Compiler/extras/CompilerDevTools/src/CompilerDevTools.jl:71
 [14] with_new_compiler(f::Function, args::Int32)
    @ CompilerDevTools ~/julia/Compiler/extras/CompilerDevTools/src/CompilerDevTools.jl:67
```