### PR TITLE
fix syntax for `true` and `false` as symbols

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1782,8 +1782,8 @@ end
 
 const keyword_syms = Set([
     :baremodule, :begin, :break, :catch, :const, :continue, :do, :else, :elseif,
-    :end, :export, :false, :finally, :for, :function, :global, :if, :import,
-    :let, :local, :macro, :module, :public, :quote, :return, :struct, :true,
+    :end, :export, :var"false", :finally, :for, :function, :global, :if, :import,
+    :let, :local, :macro, :module, :public, :quote, :return, :struct, :var"true",
     :try, :using, :while ])
 
 function is_valid_identifier(sym)


### PR DESCRIPTION
`isidentifier` already handles these, so this makes no observable difference but I noticed that `keyword_syms` was unexpectedly a `Set{Any}`.