### PR TITLE
iterators: merge duplicate `iterate` methods for `Reverse`

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -120,14 +120,6 @@ IteratorSize(::Type{Reverse{T}}) where {T} = IteratorSize(T)
 IteratorEltype(::Type{Reverse{T}}) where {T} = IteratorEltype(T)
 last(r::Reverse) = first(r.itr) # the first shall be last
 
-# reverse-order array iterators: assumes more-specialized Reverse for eachindex
-@propagate_inbounds function iterate(A::Reverse{<:AbstractArray}, state=(reverse(eachindex(A.itr)),))
-    y = iterate(state...)
-    y === nothing && return y
-    idx, itrs = y
-    (A.itr[idx], (state[1], itrs))
-end
-
 # Fallback method of `iterate(::Reverse{T})` which assumes the collection has `getindex(::T) and `reverse(eachindex(::T))`
 # don't propagate inbounds for this just in case
 function iterate(A::Reverse, state=(reverse(eachindex(A.itr)),))


### PR DESCRIPTION
The method bodies and state optional argument definition are exactly the same.

The only difference between the two methods, is that the more specific method, for `Reverse{<:AbstractArray}`, had a `propagate_inbounds` macro applied. I simply deleted the more specific method, together with the macro. Deleting the macro annotation is consistent with the fact that the `iterate(::AbstractArray)` method, in abstractarray.jl, has no such annotation.

For context, this PR follows up on PR #43110, which added the less specific method, copying the body of the preexisting more specific method.