### PR TITLE
Fix broken `debug` building

### DIFF
--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -5,7 +5,7 @@ module Libdl
 Interface to libdl. Provides dynamic linking support.
 """ Libdl
 
-import Base.DL_LOAD_PATH
+import Base: DL_LOAD_PATH, isdebugbuild
 
 export DL_LOAD_PATH, RTLD_DEEPBIND, RTLD_FIRST, RTLD_GLOBAL, RTLD_LAZY, RTLD_LOCAL,
     RTLD_NODELETE, RTLD_NOLOAD, RTLD_NOW, dlclose, dlopen, dlopen_e, dlsym, dlsym_e,
@@ -341,7 +341,8 @@ Base.print(io::IO, llp::LazyLibraryPath) = print(io, string(llp))
 # Helper to get `$(private_shlibdir)` at runtime
 struct PrivateShlibdirGetter; end
 const private_shlibdir = Base.OncePerProcess{String}() do
-    dirname(dlpath("libjulia-internal"))
+    libname = ifelse(isdebugbuild(), "libjulia-internal-debug", "libjulia-internal")
+    dirname(dlpath(libname))
 end
 Base.string(::PrivateShlibdirGetter) = private_shlibdir()
 

--- a/base/linking.jl
+++ b/base/linking.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 module Linking
 
+import Base: isdebugbuild
 import Base.Libc: Libdl
 
 # from LLD_jll
@@ -123,7 +124,6 @@ else
     "-shared"
 end
 
-is_debug() = ccall(:jl_is_debugbuild, Cint, ()) == 1
 libdir() = abspath(Sys.BINDIR, Base.LIBDIR)
 private_libdir() = abspath(Sys.BINDIR, Base.PRIVATE_LIBDIR)
 if Sys.iswindows()
@@ -137,7 +137,7 @@ verbose_linking() = something(Base.get_bool_env("JULIA_VERBOSE_LINKING", false),
 function link_image_cmd(path, out)
     PRIVATE_LIBDIR = "-L$(private_libdir())"
     SHLIBDIR = "-L$(shlibdir())"
-    LIBS = is_debug() ? ("-ljulia-debug", "-ljulia-internal-debug") :
+    LIBS = isdebugbuild() ? ("-ljulia-debug", "-ljulia-internal-debug") :
                         ("-ljulia", "-ljulia-internal")
     @static if Sys.iswindows()
         LIBS = (LIBS..., "-lopenlibm", "-lssp", "-lgcc_s", "-lgcc", "-lmsvcrt")


### PR DESCRIPTION
In commit f5278d80, a `OncePerProcess` variable `private_shlibdir` was added to improve the library path resolving logic. However it only consindered release building and left debug mode broken. This brings it back.

Also during the research of getting the building mode at runtime, I found two small similar functions, and it may be better to combine them.