### PR TITLE
Support field name in `fieldoffset`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ New library functions
 New library features
 --------------------
 
+* `fieldoffset` now also accepts the field name as a symbol as `fieldtype` already did ([#58100]).
 * `sort(keys(::Dict))` and `sort(values(::Dict))` now automatically collect, they previously threw ([#56978]).
 * `Base.AbstractOneTo` is added as a supertype of one-based axes, with `Base.OneTo` as its subtype ([#56902]).
 

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1007,10 +1007,26 @@ morespecific(@nospecialize(a), @nospecialize(b)) = (@_total_meta; ccall(:jl_type
 morespecific(a::Method, b::Method) = ccall(:jl_method_morespecific, Cint, (Any, Any), a, b) != 0
 
 """
-    fieldoffset(type, i)
+    fieldoffset(type, name::Symbol | i::Int)
 
-The byte offset of field `i` of a type relative to the data start. For example, we could
-use it in the following manner to summarize information about a struct:
+The byte offset of a field (specified by name or index) of a type relative to its start.
+
+# Examples
+```jldoctest
+julia> struct Foo
+           x::Int64
+           y::String
+       end
+
+julia> fieldoffset(Foo, 2)
+0x0000000000000008
+
+julia> fieldoffset(Foo, :x)
+0x0000000000000000
+```
+
+We can use it to summarize information about a struct (see
+[`About.jl`](https://juliapackages.com/p/about) for a package with similar functionality):
 
 ```jldoctest
 julia> structinfo(T) = [(fieldoffset(T,i), fieldname(T,i), fieldtype(T,i)) for i = 1:fieldcount(T)];
@@ -1034,6 +1050,7 @@ julia> structinfo(Base.Filesystem.StatStruct)
 ```
 """
 fieldoffset(x::DataType, idx::Integer) = (@_foldable_meta; ccall(:jl_get_field_offset, Csize_t, (Any, Cint), x, idx))
+fieldoffset(x::DataType, name::Symbol) = fieldoffset(x, fieldindex(x, name))
 
 """
     fieldtype(T, name::Symbol | index::Int)

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1007,7 +1007,7 @@ morespecific(@nospecialize(a), @nospecialize(b)) = (@_total_meta; ccall(:jl_type
 morespecific(a::Method, b::Method) = ccall(:jl_method_morespecific, Cint, (Any, Any), a, b) != 0
 
 """
-    fieldoffset(type, name::Symbol | i::Int)
+    fieldoffset(type, name::Symbol | i::Integer)
 
 The byte offset of a field (specified by name or index) of a type relative to its start.
 

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1047,6 +1047,9 @@ julia> structinfo(Base.Filesystem.StatStruct)
  (0x0000000000000060, :ctime, Float64)
  (0x0000000000000068, :ioerrno, Int32)
 ```
+
+!!! compat "Julia 1.13"
+    Specifying the field by name rather than index requires Julia 1.13 or later.
 """
 fieldoffset(x::DataType, idx::Integer) = (@_foldable_meta; ccall(:jl_get_field_offset, Csize_t, (Any, Cint), x, idx))
 fieldoffset(x::DataType, name::Symbol) = fieldoffset(x, fieldindex(x, name))

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1025,8 +1025,7 @@ julia> fieldoffset(Foo, :x)
 0x0000000000000000
 ```
 
-We can use it to summarize information about a struct (see
-[`About.jl`](https://juliapackages.com/p/about) for a package with similar functionality):
+We can use it to summarize information about a struct:
 
 ```jldoctest
 julia> structinfo(T) = [(fieldoffset(T,i), fieldname(T,i), fieldtype(T,i)) for i = 1:fieldcount(T)];

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -346,6 +346,7 @@ tlayout = TLayout(5,7,11)
 @test !hasproperty(tlayout, :p)
 @test [(fieldoffset(TLayout,i), fieldname(TLayout,i), fieldtype(TLayout,i)) for i = 1:fieldcount(TLayout)] ==
     [(0, :x, Int8), (2, :y, Int16), (4, :z, Int32)]
+@test [fieldoffset(TLayout, s) for s = (:x, :y, :z)] == [0, 2, 4]
 @test fieldnames(Complex) === (:re, :im)
 @test_throws BoundsError fieldtype(TLayout, 0)
 @test_throws ArgumentError fieldname(TLayout, 0)


### PR DESCRIPTION
`fieldtype` accepts both the field's name or the field's index. It's inconsistent that `fieldoffset` only accepts the field's index, but not its name.

This commit adds support to `fieldoffset` for the field's name, documents and tests it.