### PR TITLE
add new abstract types `BitSigned` & `BitUnsigned`

### DIFF
--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -229,12 +229,12 @@ tuplemerge_test(Tuple{}, Tuple{Complex, Vararg{Union{ComplexF32, ComplexF64}}},
 @test Compiler.tmerge(Vector{Int}, Compiler.tmerge(Vector{String}, Vector{Bool})) ==
     Union{Vector{Bool}, Vector{Int}, Vector{String}}
 @test Compiler.tmerge(Vector{Int}, Compiler.tmerge(Vector{String}, Union{Vector{Bool}, Vector{Symbol}})) == Vector
-@test Compiler.tmerge(Base.BitIntegerType, Union{}) === Base.BitIntegerType
-@test Compiler.tmerge(Union{}, Base.BitIntegerType) === Base.BitIntegerType
+@test Compiler.tmerge(Base.BitInteger128Type, Union{}) === Base.BitInteger128Type
+@test Compiler.tmerge(Union{}, Base.BitInteger128Type) === Base.BitInteger128Type
 @test Compiler.tmerge(Compiler.fallback_ipo_lattice, Compiler.InterConditional(1, Int, Union{}), Compiler.InterConditional(2, String, Union{})) === Compiler.Const(true)
 # test issue behind https://github.com/JuliaLang/julia/issues/50458
-@test Compiler.tmerge(Nothing, Tuple{Base.BitInteger, Int}) == Union{Nothing, Tuple{Base.BitInteger, Int}}
-@test Compiler.tmerge(Union{Nothing, Tuple{Int, Int}}, Tuple{Base.BitInteger, Int}) == Union{Nothing, Tuple{Any, Int}}
+@test Compiler.tmerge(Nothing, Tuple{Base.BitInteger128, Int}) == Union{Nothing, Tuple{Base.BitInteger128, Int}}
+@test Compiler.tmerge(Union{Nothing, Tuple{Int, Int}}, Tuple{Base.BitInteger128, Int}) == Union{Nothing, Tuple{Any, Int}}
 @test Compiler.tmerge(Nothing, Tuple{Union{Char, String, SubString{String}, Symbol}, Int}) == Union{Nothing, Tuple{Union{Char, String, SubString{String}, Symbol}, Int}}
 @test Compiler.tmerge(Union{Nothing, Tuple{Char, Int}}, Tuple{Union{Char, String, SubString{String}, Symbol}, Int}) == Union{Nothing, Tuple{Union{Char, String, SubString{String}, Symbol}, Int}}
 @test Compiler.tmerge(Nothing, Tuple{Integer, Int}) == Union{Nothing, Tuple{Integer, Int}}
@@ -254,7 +254,7 @@ tuplemerge_test(Tuple{}, Tuple{Complex, Vararg{Union{ComplexF32, ComplexF64}}},
 
 # test that recursively more complicated types don't widen all the way to Any when there is a useful valid type upper bound
 # Specifically test with base types of a trivial type, a simple union, a complicated union, and a tuple.
-for T in (Nothing, Base.BitInteger, Union{Int, Int32, Int16, Int8}, Tuple{Int, Int})
+for T in (Nothing, Base.BitInteger128, Union{Int, Int32, Int16, Int8}, Tuple{Int, Int})
     Ta, Tb = T, T
     for i in 1:10
         Ta = Union{Tuple{Ta}, Nothing}
@@ -264,9 +264,9 @@ for T in (Nothing, Base.BitInteger, Union{Int, Int32, Int16, Int8}, Tuple{Int, I
 end
 
 struct SomethingBits
-    x::Base.BitIntegerType
+    x::Base.BitInteger128Type
 end
-@test Base.return_types(getproperty, (SomethingBits, Symbol)) == Any[Base.BitIntegerType]
+@test Base.return_types(getproperty, (SomethingBits, Symbol)) == Any[Base.BitInteger128Type]
 
 
 # issue 9770

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@ Language changes
 * `mod(x::AbstractFloat, -Inf)` now returns `x` (as long as `x` is finite), this aligns with C standard and
 is considered a bug fix ([#47102])
 
+  - `Base` internal types `BitSigned` and `BitUnsigned` now refer to abstract types instead of unions, and
+    `BitInteger` is defined to `Union{BitSigned, BitUnsigned}`; builtin integer types inherit either from
+    `BitSigned` or `BitUnsigned`.
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,9 +11,9 @@ Language changes
 * `mod(x::AbstractFloat, -Inf)` now returns `x` (as long as `x` is finite), this aligns with C standard and
 is considered a bug fix ([#47102])
 
-  - `Base` internal types `BitSigned` and `BitUnsigned` now refer to abstract types instead of unions, and
-    `BitInteger` is defined to `Union{BitSigned, BitUnsigned}`; builtin integer types inherit either from
-    `BitSigned` or `BitUnsigned`.
+* Internal types `BitSigned` and `BitUnsigned` from `Base` now refer to abstract types instead of unions, and
+  `BitInteger` is defined equal to `Union{BitSigned, BitUnsigned}`; builtin integer types inherit either from
+  `BitSigned` or `BitUnsigned` ([#58104]).
 
 Compiler/Runtime improvements
 -----------------------------

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -90,7 +90,11 @@ function union!(s::AbstractSet, sets...)
 end
 
 max_values(::Type) = typemax(Int)
-max_values(T::Union{map(X -> Type{X}, BitIntegerSmall_types)...}) = 1 << (8*sizeof(T))
+max_values(::Type{T}) where {T <: BitInteger} =
+    T isa Union ? invoke(max_values, Tuple{Union}, T) :
+    is_small_int_type(T) ? 1 << (8*sizeof(T)) :
+    typemax(Int)
+
 # saturated addition to prevent overflow with typemax(Int)
 function max_values(T::Union)
     a = max_values(T.a)::Int

--- a/base/array.jl
+++ b/base/array.jl
@@ -2096,7 +2096,6 @@ function cmp(a::Array{UInt8,1}, b::Array{UInt8,1})
     return c < 0 ? -1 : c > 0 ? +1 : cmp(length(a),length(b))
 end
 
-
 const BitIntegerArray{N} = Array{<:BitInteger, N} where N
 
 # use memcmp for == on bit integer types

--- a/base/array.jl
+++ b/base/array.jl
@@ -2096,9 +2096,12 @@ function cmp(a::Array{UInt8,1}, b::Array{UInt8,1})
     return c < 0 ? -1 : c > 0 ? +1 : cmp(length(a),length(b))
 end
 
-const BitIntegerArray{N} = Union{map(T->Array{T,N}, BitInteger_types)...} where N
+
+const BitIntegerArray{N} = Array{<:BitInteger, N} where N
+
 # use memcmp for == on bit integer types
 function ==(a::Arr, b::Arr) where {Arr <: BitIntegerArray}
+    isconcretetype(eltype(Arr)) || return invoke((==), Tuple{AbstractArray, AbstractArray}, a, b)
     if size(a) == size(b)
         aref = a.ref
         bref = b.ref
@@ -2116,6 +2119,7 @@ function ==(a::Arr, b::Arr) where {Arr <: BitIntegerArray}
 end
 
 function ==(a::Arr, b::Arr) where Arr <: BitIntegerArray{1}
+    isconcretetype(eltype(Arr)) || return invoke((==), Tuple{AbstractArray, AbstractArray}, a, b)
     len = length(a)
     if len == length(b)
         aref = a.ref

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -251,6 +251,8 @@ abstract type AbstractFloat <: Real end
 abstract type Integer  <: Real end
 abstract type Signed   <: Integer end
 abstract type Unsigned <: Integer end
+abstract type BitSigned   <: Signed end
+abstract type BitUnsigned <: Unsigned end
 
 primitive type Float16 <: AbstractFloat 16 end
 primitive type Float32 <: AbstractFloat 32 end
@@ -262,16 +264,16 @@ primitive type BFloat16 <: AbstractFloat 16 end
 abstract type AbstractChar end
 primitive type Char <: AbstractChar 32 end
 
-primitive type Int8    <: Signed   8 end
-#primitive type UInt8   <: Unsigned 8 end
-primitive type Int16   <: Signed   16 end
-#primitive type UInt16  <: Unsigned 16 end
-#primitive type Int32   <: Signed   32 end
-#primitive type UInt32  <: Unsigned 32 end
-#primitive type Int64   <: Signed   64 end
-#primitive type UInt64  <: Unsigned 64 end
-primitive type Int128  <: Signed   128 end
-primitive type UInt128 <: Unsigned 128 end
+primitive type Int8    <: BitSigned   8 end
+#primitive type UInt8   <: BitUnsigned 8 end
+primitive type Int16   <: BitSigned   16 end
+#primitive type UInt16  <: BitUnsigned 16 end
+#primitive type Int32   <: BitSigned   32 end
+#primitive type UInt32  <: BitUnsigned 32 end
+#primitive type Int64   <: BitSigned   64 end
+#primitive type UInt64  <: BitUnsigned 64 end
+primitive type Int128  <: BitSigned   128 end
+primitive type UInt128 <: BitUnsigned 128 end
 
 if Int === Int64
     const UInt = UInt64

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -248,9 +248,9 @@ const setproperty! = setfield!
 abstract type Number end
 abstract type Real     <: Number end
 abstract type AbstractFloat <: Real end
-abstract type Integer  <: Real end
-abstract type Signed   <: Integer end
-abstract type Unsigned <: Integer end
+abstract type Integer     <: Real end
+abstract type Signed      <: Integer end
+abstract type Unsigned    <: Integer end
 abstract type BitSigned   <: Signed end
 abstract type BitUnsigned <: Unsigned end
 

--- a/base/div.jl
+++ b/base/div.jl
@@ -322,7 +322,7 @@ end
 
 # For bootstrapping purposes, we define div for integers directly. Provide the
 # generic signature also
-div(a::T, b::T, ::typeof(RoundToZero)) where {T<:Union{BitSigned, BitUnsigned64}} = div(a, b)
+div(a::T, b::T, ::typeof(RoundToZero)) where {T<:BitInteger} = div(a, b)
 div(a::Bool, b::Bool, r::RoundingMode) = div(a, b)
 # Prevent ambiguities
 for rm in (RoundUp, RoundDown, RoundToZero, RoundFromZero)
@@ -335,10 +335,6 @@ function div(x::Bool, y::Bool, rnd::Union{typeof(RoundNearest),
 end
 fld(a::T, b::T) where {T<:Union{Integer,AbstractFloat}} = div(a, b, RoundDown)
 cld(a::T, b::T) where {T<:Union{Integer,AbstractFloat}} = div(a, b, RoundUp)
-div(a::Int128, b::Int128, ::typeof(RoundToZero)) = div(a, b)
-div(a::UInt128, b::UInt128, ::typeof(RoundToZero)) = div(a, b)
-rem(a::Int128, b::Int128, ::typeof(RoundToZero)) = rem(a, b)
-rem(a::UInt128, b::UInt128, ::typeof(RoundToZero)) = rem(a, b)
 
 # These are kept for compatibility with external packages overriding fld / cld.
 # In 2.0, packages should extend div(a, b, r) instead, in which case, these can

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2261,7 +2261,8 @@ Internal abstract supertype for all builtin signed integers (`Int8`, `Int128`, .
 They are defined via `primitive type`, and most of the basic arithmetic operations
 defined on them are handled directly by LLVM.
 Subtypes of `Core.BitSigned` must behave like builtin signed integers in all respects,
-but their `sizeof` can be arbitrarily large, and can't be assumed to be a power of two.
+but their `sizeof` can be any arbitrarily large positive integer, and in particular
+can't be assumed to be a power of two, nor even.
 """
 Core.BitSigned
 
@@ -2272,7 +2273,8 @@ Internal abstract supertype for all builtin unsigned integers (`UInt8`, `UInt128
 They are defined via `primitive type`, and most of the basic arithmetic operations
 defined on them are handled directly by LLVM.
 Subtypes of `Core.BitUnsigned` must behave like builtin unsigned integers in all respects,
-but their `sizeof` can be arbitrarily large, and can't be assumed to be a power of two.
+but their `sizeof` can be any arbitrarily large positive integer, and in particular
+can't be assumed to be a power of two, nor even.
 """
 Core.BitUnsigned
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2255,6 +2255,28 @@ julia> unsigned(true)
 Unsigned
 
 """
+    Core.BitSigned <: Signed
+
+Internal abstract supertype for all builtin signed integers (`Int8`, `Int128`, ...)
+They are defined via `primitive type`, and most of the basic arithmetic operations
+defined on them are handled directly by LLVM.
+Subtypes of `Core.BitSigned` must behave like builtin signed integers in all respects,
+but their `sizeof` can be arbitrarily large, and can't be assumed to be a power of two.
+"""
+Core.BitSigned
+
+"""
+    Core.BitUnsigned <: Signed
+
+Internal abstract supertype for all builtin unsigned integers (`UInt8`, `UInt128`, ...)
+They are defined via `primitive type`, and most of the basic arithmetic operations
+defined on them are handled directly by LLVM.
+Subtypes of `Core.BitUnsigned` must behave like builtin unsigned integers in all respects,
+but their `sizeof` can be arbitrarily large, and can't be assumed to be a power of two.
+"""
+Core.BitUnsigned
+
+"""
     Bool <: Integer
 
 Boolean type, containing the values `true` and `false`.

--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -299,9 +299,9 @@ function cmp(a::Memory{UInt8}, b::Memory{UInt8})
     return c < 0 ? -1 : c > 0 ? +1 : cmp(length(a),length(b))
 end
 
-const BitIntegerMemory{N} = Union{map(T->Memory{T}, BitInteger_types)...}
 # use memcmp for == on bit integer types
-function ==(a::M, b::M) where {M <: BitIntegerMemory}
+function ==(a::M, b::M) where {M <: Memory{<:BitInteger}}
+    isconcretetype(eltype(M)) || return invoke((==), Tuple{AbstractArray, AbstractArray}, a, b)
     if length(a) == length(b)
         ta = @_gc_preserve_begin a
         tb = @_gc_preserve_begin b

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -348,15 +348,16 @@ end
 
 rem(x::BigInt, ::Type{Bool}) = !iszero(x) & unsafe_load(x.d) % Bool # never unsafe here
 
-rem(x::BigInt, ::Type{T}) where T<:Union{SLimbMax,ULimbMax} =
-    iszero(x) ? zero(T) : flipsign(unsafe_load(x.d) % T, x.size)
-
-function rem(x::BigInt, ::Type{T}) where T<:Union{Base.BitUnsigned,Base.BitSigned}
-    u = zero(T)
-    for l = 1:min(abs(x.size), cld(sizeof(T), sizeof(Limb)))
-        u += (unsafe_load(x.d, l) % T) << ((sizeof(Limb)<<3)*(l-1))
+function rem(x::BigInt, ::Type{T}) where T<:Base.BitInteger
+    if sizeof(T) <= sizeof(Limb)
+        iszero(x) ? zero(T) : flipsign(unsafe_load(x.d) % T, x.size)
+    else
+        u = zero(T)
+        for l = 1:min(abs(x.size), cld(sizeof(T), sizeof(Limb)))
+            u += (unsafe_load(x.d, l) % T) << ((sizeof(Limb)<<3)*(l-1))
+        end
+        flipsign(u, x.size)
     end
-    flipsign(u, x.size)
 end
 
 rem(x::Integer, ::Type{BigInt}) = BigInt(x)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -649,8 +649,8 @@ function bit_ndigits0z(x::UInt128)
     return n + ndigits0z(UInt64(x))
 end
 
-ndigits0z(x::BitSigned) = bit_ndigits0z(unsigned(abs(x)))
-ndigits0z(x::BitUnsigned) = bit_ndigits0z(x)
+ndigits0z(x::BitSigned128) = bit_ndigits0z(unsigned(abs(x)))
+ndigits0z(x::BitUnsigned128) = bit_ndigits0z(x)
 ndigits0z(x::Integer) = ndigits0zpb(x, 10)
 
 ## ndigits with specified base ##

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -77,7 +77,7 @@ type [`Union`](@ref)s. Also see info on [Types](@ref man-types).
 # Examples
 ```jldoctest
 julia> supertype(Int32)
-Signed
+Core.BitSigned
 
 julia> supertype(Vector)
 DenseVector (alias for DenseArray{T, 1} where T)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -16,11 +16,11 @@ integers are promoted to `Int`/`UInt`.
 add_sum(x, y) = x + y
 add_sum(x::BitSigned, y::BitSigned) = is_small_int_type(x) && is_small_int_type(y) ?
     Int(x) + Int(y) :
-    (x + y)::BitSigned
+    (x + y)::Real
 
 add_sum(x::BitUnsigned, y::BitUnsigned) = is_small_int_type(x) && is_small_int_type(y) ?
     UInt(x) + UInt(y) :
-    (x + y)::BitUnsigned
+    (x + y)::Real
 
 add_sum(x::Real, y::Real)::Real = x + y
 

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -14,8 +14,14 @@ The reduction operator used in `sum`. The main difference from [`+`](@ref) is th
 integers are promoted to `Int`/`UInt`.
 """
 add_sum(x, y) = x + y
-add_sum(x::BitSignedSmall, y::BitSignedSmall) = Int(x) + Int(y)
-add_sum(x::BitUnsignedSmall, y::BitUnsignedSmall) = UInt(x) + UInt(y)
+add_sum(x::BitSigned, y::BitSigned) = is_small_int_type(x) && is_small_int_type(y) ?
+    Int(x) + Int(y) :
+    (x + y)::BitSigned
+
+add_sum(x::BitUnsigned, y::BitUnsigned) = is_small_int_type(x) && is_small_int_type(y) ?
+    UInt(x) + UInt(y) :
+    (x + y)::BitUnsigned
+
 add_sum(x::Real, y::Real)::Real = x + y
 
 """
@@ -25,8 +31,14 @@ The reduction operator used in `prod`. The main difference from [`*`](@ref) is t
 integers are promoted to `Int`/`UInt`.
 """
 mul_prod(x, y) = x * y
-mul_prod(x::BitSignedSmall, y::BitSignedSmall) = Int(x) * Int(y)
-mul_prod(x::BitUnsignedSmall, y::BitUnsignedSmall) = UInt(x) * UInt(y)
+mul_prod(x::BitSigned, y::BitSigned) = is_small_int_type(x) && is_small_int_type(y) ?
+    Int(x) * Int(y) :
+    x * y
+
+mul_prod(x::BitUnsigned, y::BitUnsigned) = is_small_int_type(x) && is_small_int_type(y) ?
+    UInt(x) * UInt(y) :
+    x * y
+
 mul_prod(x::Real, y::Real)::Real = x * y
 
 and_all(x, y) = (x && y)::Bool
@@ -347,12 +359,17 @@ reduce_empty(::typeof(|), ::Type{Bool}) = false
 reduce_empty(::typeof(and_all), ::Type{T}) where {T} = true
 reduce_empty(::typeof(or_any), ::Type{T}) where {T} = false
 
-reduce_empty(::typeof(add_sum), ::Type{T}) where {T} = reduce_empty(+, T)
-reduce_empty(::typeof(add_sum), ::Type{T}) where {T<:BitSignedSmall}  = zero(Int)
-reduce_empty(::typeof(add_sum), ::Type{T}) where {T<:BitUnsignedSmall} = zero(UInt)
-reduce_empty(::typeof(mul_prod), ::Type{T}) where {T} = reduce_empty(*, T)
-reduce_empty(::typeof(mul_prod), ::Type{T}) where {T<:BitSignedSmall}  = one(Int)
-reduce_empty(::typeof(mul_prod), ::Type{T}) where {T<:BitUnsignedSmall} = one(UInt)
+reduce_empty(::typeof(add_sum), ::Type{T}) where {T} = if is_small_int_type(T)
+    T <: BitSigned ? zero(Int) : zero(UInt)
+else
+    reduce_empty(+, T)
+end
+
+reduce_empty(::typeof(mul_prod), ::Type{T}) where {T} = if is_small_int_type(T)
+    T <: BitSigned ? one(Int) : one(UInt)
+else
+    reduce_empty(*, T)
+end
 
 reduce_empty(op::BottomRF, ::Type{T}) where {T} = reduce_empty(op.rf, T)
 reduce_empty(op::MappingRF, ::Type{T}) where {T} = mapreduce_empty(op.f, op.rf, T)
@@ -401,12 +418,17 @@ reduce_first(op, x) = x
 reduce_first(::typeof(+), x::Bool) = Int(x)
 reduce_first(::typeof(*), x::AbstractChar) = string(x)
 
-reduce_first(::typeof(add_sum), x) = reduce_first(+, x)
-reduce_first(::typeof(add_sum), x::BitSignedSmall)   = Int(x)
-reduce_first(::typeof(add_sum), x::BitUnsignedSmall) = UInt(x)
-reduce_first(::typeof(mul_prod), x) = reduce_first(*, x)
-reduce_first(::typeof(mul_prod), x::BitSignedSmall)   = Int(x)
-reduce_first(::typeof(mul_prod), x::BitUnsignedSmall) = UInt(x)
+reduce_first(::typeof(add_sum), x) = if is_small_int_type(x)
+    x isa BitSigned ? Int(x) : UInt(x)
+else
+    reduce_first(+, x)
+end
+
+reduce_first(::typeof(mul_prod), x) = if is_small_int_type(x)
+    x isa BitSigned ? Int(x) : UInt(x)
+else
+    reduce_first(*, x)
+end
 
 """
     Base.mapreduce_first(f, op, x)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -33,11 +33,11 @@ integers are promoted to `Int`/`UInt`.
 mul_prod(x, y) = x * y
 mul_prod(x::BitSigned, y::BitSigned) = is_small_int_type(x) && is_small_int_type(y) ?
     Int(x) * Int(y) :
-    x * y
+    (x * y)::Real
 
 mul_prod(x::BitUnsigned, y::BitUnsigned) = is_small_int_type(x) && is_small_int_type(y) ?
     UInt(x) * UInt(y) :
-    x * y
+    (x * y)::Real
 
 mul_prod(x::Real, y::Real)::Real = x * y
 

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -183,7 +183,7 @@ reducedim_init(f, op::typeof(|), A::AbstractArrayOrBroadcasted, region) = reduce
 # specialize to make initialization more efficient for common cases
 
 let
-    BitIntFloat = Union{BitInteger, IEEEFloat}
+    BitIntFloat = Union{BitInteger128, IEEEFloat}
     T = Union{
         Any[AbstractArray{t} for t in uniontypes(BitIntFloat)]...,
         Any[AbstractArray{Complex{t}} for t in uniontypes(BitIntFloat)]...}

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -5,7 +5,7 @@ module Sort
 using Base.Order
 
 using Base: copymutable, midpoint, require_one_based_indexing, uinttype, tail,
-    sub_with_overflow, add_with_overflow, OneTo, BitSigned, BitIntegerType, top_set_bit
+    sub_with_overflow, add_with_overflow, OneTo, BitSigned, top_set_bit
 
 import Base:
     sort,
@@ -2270,7 +2270,8 @@ uint_map(x::Signed, ::ForwardOrdering) =
 uint_unmap(::Type{T}, u::Unsigned, ::ForwardOrdering) where T <: Signed =
     xor(signed(u), typemin(T))
 
-UIntMappable(T::BitIntegerType, ::ForwardOrdering) = unsigned(T)
+UIntMappable(T::Type{<:Base.BitInteger}, ::ForwardOrdering) =
+    isconcretetype(T) ? unsigned(T) : nothing
 
 # Floats are not UIntMappable under regular orderings because they fail on NaN edge cases.
 # uint mappings for floats are defined in Float, where the Left and Right orderings

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -556,7 +556,7 @@ isvalid(s::String, i::Int) = checkbounds(Bool, s, i) && thisind(s, i) == i
 isascii(s::String) = isascii(codeunits(s))
 
 # don't assume effects for general integers since we cannot know their implementation
-@assume_effects :foldable repeat(c::Char, r::BitInteger) = @invoke repeat(c::Char, r::Integer)
+@assume_effects :foldable repeat(c::Char, r::BitInteger128) = @invoke repeat(c::Char, r::Integer)
 
 """
     repeat(c::AbstractChar, r::Integer)::String

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -268,7 +268,7 @@ end
 
 # don't assume effects for general integers since we cannot know their implementation
 # not nothrow because r<0 throws
-@assume_effects :foldable repeat(s::String, r::BitInteger) = @invoke repeat(s::String, r::Integer)
+@assume_effects :foldable repeat(s::String, r::BitInteger128) = @invoke repeat(s::String, r::Integer)
 
 function repeat(s::Union{String, SubString{String}}, r::Integer)
     r < 0 && throw(ArgumentError("can't repeat a string $r times"))

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3933,16 +3933,17 @@ void post_boot_hooks(void)
     jl_floatingpoint_type = (jl_datatype_t*)core("AbstractFloat");
     jl_number_type  = (jl_datatype_t*)core("Number");
     jl_signed_type  = (jl_datatype_t*)core("Signed");
-    jl_datatype_t *jl_unsigned_type = (jl_datatype_t*)core("Unsigned");
     jl_datatype_t *jl_integer_type = (jl_datatype_t*)core("Integer");
+    jl_datatype_t *jl_bit_unsigned_type = (jl_datatype_t*)core("BitUnsigned");
+    jl_datatype_t *jl_bit_signed_type = (jl_datatype_t*)core("BitSigned");
 
     jl_bool_type->super = jl_integer_type;
-    jl_uint8_type->super = jl_unsigned_type;
-    jl_uint16_type->super = jl_unsigned_type;
-    jl_uint32_type->super = jl_unsigned_type;
-    jl_uint64_type->super = jl_unsigned_type;
-    jl_int32_type->super = jl_signed_type;
-    jl_int64_type->super = jl_signed_type;
+    jl_uint8_type->super = jl_bit_unsigned_type;
+    jl_uint16_type->super = jl_bit_unsigned_type;
+    jl_uint32_type->super = jl_bit_unsigned_type;
+    jl_uint64_type->super = jl_bit_unsigned_type;
+    jl_int32_type->super = jl_bit_signed_type;
+    jl_int64_type->super = jl_bit_signed_type;
 
     jl_stackovf_exception       = jl_new_struct_uninit((jl_datatype_t*)core("StackOverflowError"));
     jl_diverror_exception       = jl_new_struct_uninit((jl_datatype_t*)core("DivideError"));

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -314,7 +314,7 @@ See also [`subtypes`](@ref).
 # Examples
 ```jldoctest
 julia> supertypes(Int)
-(Int64, Signed, Integer, Real, Number, Any)
+(Int64, Core.BitSigned, Signed, Integer, Real, Number, Any)
 ```
 """
 function supertypes(T::Type)

--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -390,7 +390,7 @@ function fmt(buf, pos, arg, spec::Spec{T}) where {T <: Ints}
     arg2 = toint(arg)
     n = i = ndigits(arg2, base=bs, pad=1)
     neg = arg2 < 0
-    x = arg2 isa Base.BitSigned ? unsigned(abs(arg2)) : abs(arg2)
+    x = arg2 isa Base.BitSigned128 ? unsigned(abs(arg2)) : abs(arg2)
     arglen = n + (neg || (plus | space)) +
         (T == Val{'o'} && hash ? 1 : 0) +
         (T == Val{'x'} && hash ? 2 : 0) + (T == Val{'X'} && hash ? 2 : 0)

--- a/stdlib/Random/src/MersenneTwister.jl
+++ b/stdlib/Random/src/MersenneTwister.jl
@@ -489,7 +489,7 @@ function rand!(r::MersenneTwister, A::UnsafeView{UInt128}, ::SamplerType{UInt128
     A
 end
 
-for T in BitInteger_types
+for T in BitInteger128_types
     @eval function rand!(r::MersenneTwister, A::Array{$T}, sp::SamplerType{$T})
         GC.@preserve A rand!(r, UnsafeView(pointer(A), length(A)), sp)
         A

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -79,7 +79,7 @@ rand(rd::RandomDevice, ::SamplerType{Bool}) = rand(rd, UInt8) % Bool
 # specialization for homogeneous tuple types of builtin integers, to avoid
 # repeated system calls
 rand(rd::RandomDevice, sp::SamplerTag{Ref{Tuple{Vararg{T, N}}}, Tuple{S}}
-     ) where {T, N, S <: SamplerUnion(Base.BitInteger_types...)} =
+     ) where {T, N, S <: SamplerUnion(Base.BitInteger128_types...)} =
          Libc.getrandom!(Ref{gentype(sp)}())[]
 
 function rand!(rd::RandomDevice, A::Array{Bool}, ::SamplerType{Bool})
@@ -94,7 +94,7 @@ function rand!(rd::RandomDevice, A::Array{Bool}, ::SamplerType{Bool})
     end
     return A
 end
-for T in BitInteger_types
+for T in BitInteger128_types
     @eval rand!(rd::RandomDevice, A::Array{$T}, ::SamplerType{$T}) = Libc.getrandom!(A)
 end
 
@@ -160,7 +160,7 @@ function rand(rng::SeedHasher, ::SamplerType{UInt8})
     rng.bytes[rng.idx += 1]
 end
 
-for TT = Base.BitInteger_types
+for TT = Base.BitInteger128_types
     TT === UInt8 && continue
     @eval function rand(rng::SeedHasher, ::SamplerType{$TT})
         xx = zero($TT)

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -15,7 +15,7 @@ using Base.GMP.MPZ
 using Base.GMP: Limb
 using SHA: SHA, SHA2_256_CTX, SHA2_512_CTX, SHA_CTX
 
-using Base: BitInteger, BitInteger_types, BitUnsigned, require_one_based_indexing
+using Base: BitInteger, BitInteger128_types, BitUnsigned, require_one_based_indexing
 import Base: copymutable, copy, copy!, ==, hash, convert,
              rand, randn, show
 
@@ -167,7 +167,7 @@ Base.getindex(::SamplerType{T}) where {T} = T
 
 # SamplerUnion(X, Y, ...}) == Union{SamplerType{X}, SamplerType{Y}, ...}
 SamplerUnion(U...) = Union{Any[SamplerType{T} for T in U]...}
-const SamplerBoolBitInteger = SamplerUnion(Bool, BitInteger_types...)
+const SamplerBoolBitInteger = SamplerUnion(Bool, BitInteger128_types...)
 
 
 struct SamplerTrivial{T,E} <: Sampler{E}

--- a/stdlib/Random/src/XoshiroSimd.jl
+++ b/stdlib/Random/src/XoshiroSimd.jl
@@ -4,7 +4,7 @@ module XoshiroSimd
 # Getting the xoroshiro RNG to reliably vectorize is somewhat of a hassle without Simd.jl.
 import ..Random: rand!
 using ..Random: TaskLocalRNG, rand, Xoshiro, CloseOpen01, UnsafeView, SamplerType, SamplerTrivial, getstate, setstate!, _uint2float
-using Base: BitInteger_types
+using Base: BitInteger128_types
 using Base.Libc: memcpy
 using Core.Intrinsics: llvmcall
 
@@ -299,7 +299,7 @@ function rand!(rng::Union{TaskLocalRNG, Xoshiro}, dst::MutableDenseArray{T}, ::S
     dst
 end
 
-for T in BitInteger_types
+for T in BitInteger128_types
     @eval function rand!(rng::Union{TaskLocalRNG, Xoshiro}, dst::MutableDenseArray{$T}, ::SamplerType{$T})
         GC.@preserve dst xoshiro_bulk(rng, convert(Ptr{UInt8}, pointer(dst)), length(dst)*sizeof($T), UInt8, xoshiroWidth())
         dst

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -303,7 +303,7 @@ for rng in ([], [MersenneTwister(0)], [RandomDevice()], [Xoshiro(0)], [SeedHashe
     ftypes = [Float16, Float32, Float64, FakeFloat64, BigFloat]
     cftypes = [ComplexF16, ComplexF32, ComplexF64, ftypes...]
     types = [Bool, Char, BigFloat, Tuple{Bool, Tuple{Int, Char}}, Pair{Int8, UInt32},
-             Base.BitInteger_types..., cftypes...]
+             Base.BitInteger128_types..., cftypes...]
     randset = Set(rand(Int, 20))
     randdict = Dict(zip(rand(Int,10), rand(Int, 10)))
 
@@ -901,7 +901,7 @@ end
         B = fill!(B, 1.0)
         @test rand!(GLOBAL_RNG, A, I1) === A == rand!(xo, B, I1) === B
     end
-    for T in Base.BitInteger_types
+    for T in Base.BitInteger128_types
         x = Random.SamplerType{T}()
         B = fill!(B, 1.0)
         @test rand!(GLOBAL_RNG, A, x) === A == rand!(xo, B, x) === B
@@ -1233,7 +1233,7 @@ end
     # 2) if n != m, then hash_seed(n) != hash_seed(m)
     rngs = (Xoshiro(0), TaskLocalRNG(), MersenneTwister(0))
     seeds = Any[]
-    for T = Base.BitInteger_types
+    for T = Base.BitInteger128_types
         append!(seeds, rand(T, 8))
         push!(seeds, typemin(T), typemin(T) + T(1), typemin(T) + T(2),
               typemax(T), typemax(T) - T(1), typemax(T) - T(2))

--- a/test/core.jl
+++ b/test/core.jl
@@ -249,18 +249,18 @@ Type{AbstractSet}  # cache this
 @test f20511(Union{AbstractSet,Set{T}} where T) == 1
 
 # join
-@test typejoin(Int8,Int16) === Signed
+@test typejoin(Int8,Int16) === Core.BitSigned
 @test typejoin(Int,AbstractString) === Any
 @test typejoin(Array{Float64},BitArray) <: AbstractArray
 @test typejoin(Array{Bool},BitArray) <: AbstractArray{Bool}
-@test typejoin(Tuple{Int,Int8},Tuple{Int8,Float64}) === Tuple{Signed,Real}
+@test typejoin(Tuple{Int,Int8},Tuple{Int8,Float64}) === Tuple{Core.BitSigned,Real}
 @test typejoin(Tuple{String,String}, Tuple{GenericString,String},
                Tuple{String,GenericString}, Tuple{Int,String,Int}) ==
     Tuple{Any,AbstractString,Vararg{Int}}
 @test typejoin(Tuple{Int8,Vararg{Int}}, Tuple{Int8,Int8}) ==
-    Tuple{Int8,Vararg{Signed}}
+    Tuple{Int8,Vararg{Core.BitSigned}}
 @test typejoin(Tuple{Int8,Vararg{Int}}, Tuple{Int8,Vararg{Int8}}) ==
-    Tuple{Int8,Vararg{Signed}}
+    Tuple{Int8,Vararg{Core.BitSigned}}
 @test typejoin(Tuple{Int8,UInt8,Vararg{Int}}, Tuple{Int8,Vararg{Int8}}) ==
     Tuple{Int8,Vararg{Integer}}
 @test typejoin(Union{Int,AbstractString}, Int) == Union{Int,AbstractString}

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -22,7 +22,7 @@ g = Float16(1.)
     @test !isequal(Float16(-0.0), Float16(0.0))
     @test !isequal(Float16(0.0), Float16(-0.0))
 
-    for T = Base.BitInteger_types
+    for T = Base.BitInteger128_types
         @test -Inf16 < typemin(T)
         @test -Inf16 <= typemin(T)
         @test typemin(T) > -Inf16

--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -258,7 +258,7 @@ end
 end
 
 @testset "isapprox and unsigned integers" begin
-    for T in Base.BitUnsigned_types
+    for T in Base.BitUnsigned128_types
         # Test also combinations of different integer types
         W = widen(T)
         # The order of the operands for difference between unsigned integers is
@@ -294,7 +294,7 @@ end
 end
 
 @testset "Conversion from floating point to integer near extremes (exhaustive)" begin
-    for Ti in Base.BitInteger_types, Tf in (Float16, Float32, Float64), x in (typemin(Ti), typemax(Ti))
+    for Ti in Base.BitInteger128_types, Tf in (Float16, Float32, Float64), x in (typemin(Ti), typemax(Ti))
         y = Tf(x)
         for i in -3:3
             z = nextfloat(y, i)

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -577,7 +577,7 @@ end
     end
     _rand(F::Type{<:AbstractFloat}) = F(_rand(BigInt, round(Int, log2(floatmax(F))))) + rand(F)
     _rand(T) = rand(T)
-    for T in (Base.BitInteger_types..., BigInt, Float64, Float32, Float16)
+    for T in (Base.BitInteger128_types..., BigInt, Float64, Float32, Float16)
         @test cmp(big(2)^130, one(T)) === 1
         @test cmp(-big(2)^130, one(T)) === -1
         c = cmp(_rand(BigInt), _rand(T))

--- a/test/int.jl
+++ b/test/int.jl
@@ -20,10 +20,10 @@ using Random
     end
 
     # Result type must be type of first argument, except for Bool
-    for U in (Base.BitInteger_types..., BigInt,
+    for U in (Base.BitInteger128_types..., BigInt,
               Rational{Int}, Rational{BigInt},
               Float16, Float32, Float64)
-        for T in (Base.BitInteger_types..., BigInt,
+        for T in (Base.BitInteger128_types..., BigInt,
                   Rational{Int}, Rational{BigInt},
                   Float16, Float32, Float64)
             @test typeof(copysign(T(3), U(4))) === T
@@ -39,8 +39,8 @@ using Random
         end
     end
 
-    @testset "flipsign/copysign(typemin($T), -1)" for T in Base.BitInteger_types
-        for U in (Base.BitSigned_types..., BigInt, Float16, Float32, Float64)
+    @testset "flipsign/copysign(typemin($T), -1)" for T in Base.BitInteger128_types
+        for U in (Base.BitSigned128_types..., BigInt, Float16, Float32, Float64)
             @test flipsign(typemin(T), U(-1)) == typemin(T)
             @test copysign(typemin(T), U(-1)) == typemin(T)
         end
@@ -131,8 +131,8 @@ primitive type MyBitsType <: Signed 8 end
 @test_throws MethodError ~reinterpret(MyBitsType, 0x7b)
 @test signed(MyBitsType) === MyBitsType
 
-UItypes = Base.BitUnsigned_types
-SItypes = Base.BitSigned_types
+UItypes = Base.BitUnsigned128_types
+SItypes = Base.BitSigned128_types
 
 @testset "promotions" begin
     for T in UItypes, S in UItypes
@@ -171,7 +171,7 @@ end
     end
 end
 @testset "bit shifts" begin
-    for T in Base.BitInteger_types
+    for T in Base.BitInteger128_types
         nbits = 8*sizeof(T)
         issigned = typemin(T) < 0
         highbit = T(2) ^ (nbits-1)
@@ -203,7 +203,7 @@ end
                 @test val >> -scount === val << ucount
             end
         end
-        for T2 in Base.BitInteger_types
+        for T2 in Base.BitInteger128_types
             for op in (>>, <<, >>>)
                 if sizeof(T2)==sizeof(Int) || T <: Signed || (op==>>>) || T2 <: Unsigned
                     @test Core.Compiler.is_foldable_nothrow(Base.infer_effects(op, (T, T2)))
@@ -223,7 +223,7 @@ end
     @test 0b01101100 === bitrotate(val1, -3)
     @test val1 === bitrotate(val1, 0)
 
-    for T in Base.BitInteger_types
+    for T in Base.BitInteger128_types
         @test val1 === bitrotate(val1, sizeof(T) * 8) === bitrotate(val1, sizeof(T) * -8)
     end
 
@@ -288,13 +288,13 @@ end
     @test unsafe_trunc(Int8, -128) === Int8(-128)
     @test unsafe_trunc(Int8, -129) === Int8(127)
 end
-@testset "x % T returns a T, T = $T" for T in [Base.BitInteger_types..., BigInt],
-    U in [Base.BitInteger_types..., BigInt]
+@testset "x % T returns a T, T = $T" for T in [Base.BitInteger128_types..., BigInt],
+    U in [Base.BitInteger128_types..., BigInt]
     @test typeof(rand(U(0):U(127)) % T) === T
 end
 
 @testset "Signed, Unsigned, signed, unsigned for bitstypes" begin
-    for (S,U) in zip(Base.BitSigned_types, Base.BitUnsigned_types)
+    for (S,U) in zip(Base.BitSigned128_types, Base.BitUnsigned128_types)
         @test signed(U) === S
         @test unsigned(S) === U
         @test typemin(S) % Signed === typemin(S)
@@ -344,8 +344,8 @@ end
 
 # issue #9292
 @testset "mixed signedness arithmetic" begin
-    for T in Base.BitInteger_types
-        for S in Base.BitInteger_types
+    for T in Base.BitInteger128_types
+        for S in Base.BitInteger128_types
             a, b = one(T), one(S)
             for c in (a+b, a-b, a*b)
                 if T === S
@@ -456,7 +456,7 @@ end
 end
 
 @testset "bitreverse" begin
-    for T in Base.BitInteger_types
+    for T in Base.BitInteger128_types
         x = rand(T)::T
         @test bitreverse(x) isa T
         @test reverse(bitstring(x)) == bitstring(bitreverse(x))
@@ -467,8 +467,8 @@ end
 end
 
 @testset "BitIntegerType" begin
-    @test Int isa Base.BitIntegerType
-    @test Base.BitIntegerType === Union{
+    @test Int isa Base.BitInteger128Type
+    @test Base.BitInteger128Type === Union{
         Type{ Int8}, Type{ Int16}, Type{ Int32}, Type{ Int64}, Type{ Int128},
         Type{UInt8}, Type{UInt16}, Type{UInt32}, Type{UInt64}, Type{UInt128}}
 end

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -406,7 +406,7 @@ end
 
     # issue #29148
     @test ndigits(typemax(UInt64), base=-2) == ndigits(big(typemax(UInt64)), base=-2)
-    for T in Base.BitInteger_types
+    for T in Base.BitInteger128_types
         n = rand(T)
         b = -rand(2:100)
         @test ndigits(n, base=b) == ndigits(big(n), base=b)

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -514,7 +514,7 @@ end
 @test collect(flatten(Any[2:1])) == Any[]
 @test (@inferred eltype(flatten(UnitRange{Int8}[1:2, 3:4]))) == Int8
 @test (@inferred eltype(flatten(([1, 2], [3.0, 4.0])))) == Real
-@test (@inferred eltype(flatten((a = [1, 2], b = Int8[3, 4])))) == Signed
+@test (@inferred eltype(flatten((a = [1, 2], b = Int8[3, 4])))) == Core.BitSigned
 @test (@inferred eltype(flatten((Int[], Nothing[], Int[])))) == Union{Int, Nothing}
 @test (@inferred eltype(flatten((String[],)))) == String
 @test (@inferred eltype(flatten((Int[], UInt[], Int8[],)))) == Integer

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -854,7 +854,7 @@ end
     @test trunc(UInt8, parse(BigFloat,"255.1")) == UInt8(255)
     @test_throws InexactError trunc(UInt8, parse(BigFloat,"256.1"))
 
-    @testset "inexact limits ($T)" for T in Base.BitInteger_types
+    @testset "inexact limits ($T)" for T in Base.BitInteger128_types
         typemin_and_half = BigFloat(typemin(T)) - 0.5
         typemax_and_half = BigFloat(typemax(T)) + 0.5
         typemin_and_one = BigFloat(typemin(T)) - 1

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1258,7 +1258,7 @@ end
     @test (Complex(1,2)/Complex(2.5,3.0))*Complex(2.5,3.0) ≈ Complex(1,2)
     @test 0.7 < real(sqrt(Complex(0,1))) < 0.707107
 end
-for T in Base.BitSigned_types
+for T in Base.BitSigned128_types
     @test abs(typemin(T)) == -typemin(T)
     #for x in (typemin(T),convert(T,-1),zero(T),one(T),typemax(T))
     #    @test signed(unsigned(x)) == x
@@ -2634,7 +2634,7 @@ end
 end
 
 @testset "PR #16995" begin
-    let types = (Base.BitInteger_types..., BigInt, Bool,
+    let types = (Base.BitInteger128_types..., BigInt, Bool,
                  Rational{Int}, Rational{BigInt},
                  Float16, Float32, Float64, BigFloat,
                  Complex{Int}, Complex{UInt}, ComplexF16, ComplexF32, ComplexF64)
@@ -2657,7 +2657,7 @@ end
         @test @inferred(Base.promote_op(!, Bool)) === Bool
     end
 
-    let types = (Base.BitInteger_types..., BigInt, Bool,
+    let types = (Base.BitInteger128_types..., BigInt, Bool,
                  Rational{Int}, Rational{BigInt},
                  Float16, Float32, Float64, BigFloat)
         for S in types, T in types
@@ -2667,7 +2667,7 @@ end
         end
     end
 
-    let types = (Base.BitInteger_types..., BigInt, Bool)
+    let types = (Base.BitInteger128_types..., BigInt, Bool)
         for S in types
             T = @inferred Base.promote_op(~, S)
             t = @inferred ~one(S)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2583,9 +2583,9 @@ end
 
 @test length(range(1, length=typemax(Int128))) === typemax(Int128)
 
-@testset "firstindex(::StepRange{<:Base.BitInteger})" begin
+@testset "firstindex(::StepRange{<:Base.BitInteger128})" begin
     test_firstindex(x) = firstindex(x) === first(Base.axes1(x))
-    for T in Base.BitInteger_types, S in Base.BitInteger_types
+    for T in Base.BitInteger128_types, S in Base.BitInteger128_types
         @test test_firstindex(StepRange{T,S}(1, 1, 1))
         @test test_firstindex(StepRange{T,S}(1, 1, 0))
     end

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -749,7 +749,7 @@ end
 end
 
 @testset "Promotions on binary operations with Rationals (#36277)" begin
-    inttypes = (Base.BitInteger_types..., BigInt)
+    inttypes = (Base.BitInteger128_types..., BigInt)
     for T in inttypes, S in inttypes
         U = Rational{promote_type(T, S)}
         @test typeof(one(Rational{T}) + one(S)) == typeof(one(S) + one(Rational{T})) == typeof(one(Rational{T}) + one(Rational{S})) == U

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -576,8 +576,8 @@ end
 @testset "type of sum(::Array{$T}" for T in [UInt8, Int8, Int32, Int64, BigInt]
     result = sum(T[1 2 3; 4 5 6; 7 8 9], dims=2)
     @test result == hcat([6, 15, 24])
-    @test eltype(result) === (T <: Base.BitSignedSmall ? Int :
-                              T <: Base.BitUnsignedSmall ? UInt :
+    @test eltype(result) === (Base.is_small_int_type(T) && T <: Base.BitSigned ? Int :
+                              Base.is_small_int_type(T) && T <: Base.BitUnsigned ? UInt :
                               T)
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -703,7 +703,7 @@ let oldout = stdout, olderr = stderr
         redirect_stderr(olderr)
         close(wrout)
         close(wrerr)
-        @test fetch(out) == "primitive type Int64 <: Signed\nTESTA\nTESTB\nΑ1Β2\"A\"\nA\n123\"C\"\n"
+        @test fetch(out) == "primitive type Int64 <: Core.BitSigned\nTESTA\nTESTB\nΑ1Β2\"A\"\nA\n123\"C\"\n"
         @test fetch(err) == "TESTA\nTESTB\nΑ1Β2\"A\"\n"
     finally
         redirect_stdout(oldout)
@@ -1337,7 +1337,7 @@ end
         @test repr == "Tuple <: Any\n"
     end
     let repr = sprint(dump, Int64)
-        @test repr == "primitive type Int64 <: Signed\n"
+        @test repr == "primitive type Int64 <: Core.BitSigned\n"
     end
     let repr = sprint(dump, Any)
         @test repr == "abstract type Any\n"
@@ -1506,7 +1506,7 @@ end
 
 @test sprint(show, Main) == "Main"
 
-@test sprint(Base.show_supertypes, Int64) == "Int64 <: Signed <: Integer <: Real <: Number <: Any"
+@test sprint(Base.show_supertypes, Int64) == "Int64 <: Core.BitSigned <: Signed <: Integer <: Real <: Number <: Any"
 @test sprint(Base.show_supertypes, Vector{String}) == "Vector{String} <: DenseVector{String} <: AbstractVector{String} <: Any"
 
 # static_show

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -696,7 +696,7 @@ end
         for (U, T) in [(UInt16, Float16), (UInt32, Float32), (UInt64, Float64)]]
 
     ints = [T[17, -T(17), 0, -one(T), 1, typemax(T), typemin(T), typemax(T)-1, typemin(T)+1]
-        for T in Base.BitInteger_types]
+        for T in Base.BitInteger128_types]
 
     char = Char['\n', ' ', Char(0), Char(8), Char(17), typemax(Char)]
 

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2408,10 +2408,10 @@ let S = Tuple{F1, Dict{Int, S1}} where {F1, S1<:Union{Int8, Val{F1}}},
 end
 
 let S = Tuple{F1, Val{S1}} where {F1, S1<:Dict{F1}}
-    T = Tuple{Any, Val{S2}} where {F2, S2<:Union{map(T->Dict{T}, Base.BitInteger_types)...}}
+    T = Tuple{Any, Val{S2}} where {F2, S2<:Union{map(T->Dict{T}, Base.BitInteger128_types)...}}
     ST = typeintersect(S, T)
     TS = typeintersect(S, T)
-    for U in Base.BitInteger_types
+    for U in Base.BitInteger128_types
         @test Tuple{U, Val{Dict{U,Nothing}}} <: S
         @test Tuple{U, Val{Dict{U,Nothing}}} <: T
         @test Tuple{U, Val{Dict{U,Nothing}}} <: ST
@@ -2523,8 +2523,8 @@ end
 abstract type MyAbstract47877{C}; end
 struct MyType47877{A,B} <: MyAbstract47877{A} end
 let A = Tuple{Type{T}, T} where T,
-    B = Tuple{Type{MyType47877{W, V} where V<:Union{Base.BitInteger, MyAbstract47877{W}}}, MyAbstract47877{<:Base.BitInteger}} where W
-    C = Tuple{Type{MyType47877{W, V} where V<:Union{MyAbstract47877{W}, Base.BitInteger}}, MyType47877{W, V} where V<:Union{MyAbstract47877{W}, Base.BitInteger}} where W<:Base.BitInteger
+    B = Tuple{Type{MyType47877{W, V} where V<:Union{Base.BitInteger128, MyAbstract47877{W}}}, MyAbstract47877{<:Base.BitInteger128}} where W
+    C = Tuple{Type{MyType47877{W, V} where V<:Union{MyAbstract47877{W}, Base.BitInteger128}}, MyType47877{W, V} where V<:Union{MyAbstract47877{W}, Base.BitInteger128}} where W<:Base.BitInteger128
     # ensure that merge_env for innervars does not blow up (the large Unions ensure this will take excessive memory if it does)
     @testintersect(A, B, C)
 end
@@ -2537,8 +2537,8 @@ let
 end
 
 #issue 48582
-@test !<:(Tuple{Pair{<:T,<:T}, Val{S} where {S}} where {T<:Base.BitInteger},
-          Tuple{Pair{<:T,<:T}, Val{Int}} where {T<:Base.BitInteger})
+@test !<:(Tuple{Pair{<:T,<:T}, Val{S} where {S}} where {T<:Base.BitInteger128},
+          Tuple{Pair{<:T,<:T}, Val{Int}} where {T<:Base.BitInteger128})
 
 struct T48695{T, N, H<:AbstractArray} <: AbstractArray{Union{Missing, T}, N} end
 struct S48695{T, N, H<:AbstractArray{T, N}} <: AbstractArray{T, N} end
@@ -2602,7 +2602,7 @@ let T = Tuple{Union{Type{T}, Type{S}}, Union{Val{T}, Val{S}}, Union{Val{T}, S}} 
 end
 
 #issue #49857
-@test !<:(Type{Vector{Union{Base.BitInteger, Base.IEEEFloat, StridedArray, Missing, Nothing, Val{T}}}} where {T}, Type{Array{T}} where {T})
+@test !<:(Type{Vector{Union{Base.BitInteger128, Base.IEEEFloat, StridedArray, Missing, Nothing, Val{T}}}} where {T}, Type{Array{T}} where {T})
 
 #issue 50195
 let a = Tuple{Type{X} where X<:Union{Nothing, Val{X1} where {X4, X1<:(Pair{X2, Val{X2}} where X2<:Val{X4})}}},


### PR DESCRIPTION
Fix #37752.
Before, `Base.BitSigned` was a `Union` of builtin bitstype integers (and similarly for `Base.BitUnsigned`); many methods were coded against this private interface. But it was often the case that what mattered was not to have one of the few `Base` integer types, but to have 2-complement integers which are bitstype.

This PR changes `Base.BitSigned` to be an abstract type, subtype of `Signed`, and supertype of all `IntNN` base types (and similarly for `Base.BitUnsigned`). This will help a lot when defining integer bitstypes similar to `Base` ones (e.g. via the BitIntegers.jl package), as a lot more methods will work out of the box.

The change here tries to be as conservative as possible: replace `Base.BitSigned` by `Base.BitSigned128` (the equivalent of the old `Base.BitSigned`) when in doubt, and keep `Base.BitSigned` when the code is clearly valid for any such integer type.

The idea is not to force `Base` developers to support all `BitSigned` types, just to allow them to. For example, the current implementation of `bitrotate` in `Base` supports only a power-of-two number of bits, and it isn't required from `Base` to support other sizes.

~Few tests are still not passing, so setting as "draft".~ EDIT: I believe this is fixed now. 