### PR TITLE
gf.c: Fix backedge de-duplication bug

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -706,6 +706,8 @@ function store_backedges(caller::CodeInstance, edges::SimpleVector)
             # `invoke` edge
             elseif isa(callee, CodeInstance)
                 callee = get_ci_mi(callee)
+            else
+                callee = callee::MethodInstance
             end
             ccall(:jl_method_instance_add_backedge, Cvoid, (Any, Any, Any), callee, item, caller)
             i += 2

--- a/src/gf.c
+++ b/src/gf.c
@@ -2004,7 +2004,7 @@ JL_DLLEXPORT void jl_method_instance_add_backedge(jl_method_instance_t *callee, 
                 if (ciedge != (jl_value_t*)caller)
                     continue;
                 jl_value_t *invokeTypes = i > 0 ? jl_array_ptr_ref(backedges, i - 1) : NULL;
-                if (invokeTypes && jl_is_method_instance(invokeTypes))
+                if (invokeTypes && jl_is_code_instance(invokeTypes))
                     invokeTypes = NULL;
                 if ((invokesig == NULL && invokeTypes == NULL) ||
                     (invokesig && invokeTypes && jl_types_equal(invokesig, invokeTypes))) {


### PR DESCRIPTION
This code was checking for the old edge type (`MethodInstance`) instead of the new one (`CodeInstance`), causing duplicate non-invoke edges to accumulate in our `backedges`.