### PR TITLE
Base.get_extension & Dates.format made public

### DIFF
--- a/base/public.jl
+++ b/base/public.jl
@@ -54,6 +54,7 @@ public
     active_project,
 
 # Reflection and introspection
+    get_extension,
     isambiguous,
     isexpr,
     isidentifier,

--- a/stdlib/Dates/src/Dates.jl
+++ b/stdlib/Dates/src/Dates.jl
@@ -81,4 +81,6 @@ export Period, DatePeriod, TimePeriod,
        # io.jl
        ISODateTimeFormat, ISODateFormat, ISOTimeFormat, DateFormat, RFC1123Format, @dateformat_str
 
+public format
+
 end # module


### PR DESCRIPTION
`Base.get_extension` and `Dates.format` both appear in the manual and should therefore be `public` symbols according to [51335](https://github.com/JuliaLang/julia/issues/51335#issuecomment-1743091402).

They appear in the manual [here](https://docs.julialang.org/en/v1/base/base/#Base.get_extension) and
[here](https://docs.julialang.org/en/v1/stdlib/Dates/#Dates.format-Tuple%7BTimeType,%20AbstractString%7D).

Please also consider back porting this to version 1.12