### PR TITLE
[Optimizer] Use `OptimizationResult` rather than `OptimizationState` in more places

### DIFF
--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -165,14 +165,13 @@ mutable struct OptimizationResult
     const src::CodeInfo
     ir::IRCode
     simplified::Bool # indicates whether the IR was processed with `cfg_simplify!`
-    const inline_flag::UInt8
     inlining_cost::InlineCostType # `MAX_INLINE_COST` if not computed yet via `compute_inlining_cost!`
     const rt::Any # return type computed by inference
 
     # uninitialized fields
     code_info::CodeInfo
 
-    OptimizationResult(mi::MethodInstance, src::CodeInfo, ir::IRCode, inline_flag::UInt8, rt::Any; simplified::Bool = false) = new(mi, src, ir, simplified, inline_flag, MAX_INLINE_COST, rt)
+    OptimizationResult(mi::MethodInstance, src::CodeInfo, ir::IRCode, rt::Any; simplified::Bool = false) = new(mi, src, ir, simplified, MAX_INLINE_COST, rt)
 end
 
 function simplify_ir!(optresult::OptimizationResult)
@@ -244,9 +243,8 @@ function OptimizationState(mi::MethodInstance, interp::AbstractInterpreter)
 end
 
 function OptimizationResult(opt::OptimizationState, ir::IRCode, result::InferenceResult)
-    inline_flag = ccall(:jl_ir_flag_inlining, UInt8, (Any,), opt.src)
     rt = result.result
-    OptimizationResult(result.linfo, opt.src, ir, inline_flag, rt)
+    OptimizationResult(result.linfo, opt.src, ir, rt)
 end
 
 function argextype end # imported by EscapeAnalysis

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -979,6 +979,7 @@ function retrieve_ir_for_inlining(mi::MethodInstance, ir::IRCode, preserve_local
     return ir, spec_info, DebugInfo(ir.debuginfo, length(ir.stmts))
 end
 function retrieve_ir_for_inlining(mi::MethodInstance, optresult::OptimizationResult, preserve_local_sources::Bool)
+    isdefined(optresult, :code_info) && return retrieve_ir_for_inlining(mi, optresult.code_info, preserve_local_sources)
     !optresult.simplified && simplify_ir!(optresult)
     return retrieve_ir_for_inlining(mi, optresult.ir, preserve_local_sources)
 end

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -958,6 +958,10 @@ end
 function retrieve_ir_for_inlining(cached_result::CodeInstance, src::CodeInfo)
     return inflate_ir!(copy(src), cached_result.def), SpecInfo(src), src.debuginfo
 end
+function retrieve_ir_for_inlining(cached_result::CodeInstance, optresult::OptimizationResult)
+    code_info = ir_to_codeinf!(optresult)
+    return retrieve_ir_for_inlining(cached_result, code_info)
+end
 function retrieve_ir_for_inlining(mi::MethodInstance, src::CodeInfo, preserve_local_sources::Bool)
     if preserve_local_sources
         src = copy(src)
@@ -975,13 +979,9 @@ function retrieve_ir_for_inlining(mi::MethodInstance, ir::IRCode, preserve_local
     ir.debuginfo.def = mi
     return ir, spec_info, DebugInfo(ir.debuginfo, length(ir.stmts))
 end
-function retrieve_ir_for_inlining(mi::MethodInstance, opt::OptimizationState, preserve_local_sources::Bool)
-    result = opt.optresult
-    if result !== nothing
-        !result.simplified && simplify_ir!(result)
-        return retrieve_ir_for_inlining(mi, result.ir, preserve_local_sources)
-    end
-    retrieve_ir_for_inlining(mi, opt.src, preserve_local_sources)
+function retrieve_ir_for_inlining(mi::MethodInstance, optresult::OptimizationResult, preserve_local_sources::Bool)
+    !optresult.simplified && simplify_ir!(optresult)
+    return retrieve_ir_for_inlining(mi, optresult.ir, preserve_local_sources)
 end
 
 function handle_single_case!(todo::Vector{Pair{Int,Any}},

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -959,8 +959,7 @@ function retrieve_ir_for_inlining(cached_result::CodeInstance, src::CodeInfo)
     return inflate_ir!(copy(src), cached_result.def), SpecInfo(src), src.debuginfo
 end
 function retrieve_ir_for_inlining(cached_result::CodeInstance, optresult::OptimizationResult)
-    code_info = ir_to_codeinf!(optresult)
-    return retrieve_ir_for_inlining(cached_result, code_info)
+    return retrieve_ir_for_inlining(cached_result.def, optresult, true)
 end
 function retrieve_ir_for_inlining(mi::MethodInstance, src::CodeInfo, preserve_local_sources::Bool)
     if preserve_local_sources

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -171,7 +171,8 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState, validation
             end
         end
     elseif isa(result.src, OptimizationState)
-        # XXX: what should we do with the edges?
+        @assert caller.cache_mode === CACHE_MODE_NULL || caller.cache_mode === CACHE_MODE_VOLATILE
+        # Result won't be cached, so we can discard inlining edges.
         result.src = result.src.optresult
     end
     return nothing

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -394,7 +394,7 @@ function transform_result_for_cache(interp::AbstractInterpreter, result::Inferen
     src = result.src
     if isa(src, OptimizationState)
         optresult = src.optresult
-        inlining_cost = compute_inlining_cost!(optresult, interp)
+        compute_inlining_cost!(optresult, interp)
         discard_optimized_result(interp, optresult) && return optresult
         return ir_to_codeinf!(optresult, edges)
     elseif isa(src, CodeInfo)

--- a/Compiler/test/AbstractInterpreter.jl
+++ b/Compiler/test/AbstractInterpreter.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module abstractinterpreter_tests
+
 using Test
 
 include("setup_Compiler.jl")
@@ -549,3 +551,5 @@ let interp = InvokeInterp()
     ci = Compiler.typeinf_ext_toplevel(interp, mi, source_mode)
     @test invoke(f, ci, args...) == 2
 end
+
+end # module abstractinterpreter_tests

--- a/Compiler/test/contextual.jl
+++ b/Compiler/test/contextual.jl
@@ -110,7 +110,7 @@ module MiniCassette
     end
 end
 
-using .MiniCassette
+import .MiniCassette: overdub, Ctx
 
 # Test #265 for Cassette
 f() = 1

--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module effects_tests
+
 using Test
 
 include("setup_Compiler.jl")
@@ -1479,3 +1481,5 @@ let effects = Base.infer_effects((Core.SimpleVector,Int); optimize=false) do sve
     @test !Compiler.is_nothrow(effects)
     @test Compiler.is_terminates(effects)
 end
+
+end # module effects_tests


### PR DESCRIPTION
This is a data-flow refactor that removes the need to carry `OptimizationState` around as much, especially during `finish!` and in `result.src` for inlining. Instead, more fields have been defined for `OptimizationResult` to hold the minimal amount of information needed to perform these possibly required transforms:
- `compute_inlining_cost!`, relying on `.inlining_cost::InlineCostType` and `.rt::Any`.
- `ir_to_codeinf!`, relying on `src::CodeInfo` and `code_info::CodeInfo`. Strictly speaking, only one field is required as `ir_to_codeinf!(src, ir)` mutates `src` in place, but I'd rather avoid ambiguity.

With this in mind, `transform_result_for_local_cache` and `transform_result_for_cache` should now return an `OptimizationResult`, and `result.src` should no longer be of type `OptimizationState` once `finish!` returns.

The next step (in a future PR unless it is deemed preferable to do it in this one) would be to try to replace the volatile inference mechanism introduced in https://github.com/JuliaLang/julia/pull/51934 with `OptimizationResult` by using its ability to hold `IRCode` without requiring a round-trip to `CodeInfo` upon retrieval for inlining passes.