### PR TITLE
fix: give access to displaysize when displaying at REPL

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -473,6 +473,8 @@ function Base.showerror(io::IO, e::LimitIOException)
     print(io, "$LimitIOException: aborted printing after attempting to print more than $(Base.format_bytes(e.maxbytes)) within a `LimitIO`.")
 end
 
+Base.displaysize(io::LimitIO) = _displaysize(io.io)
+
 function Base.write(io::LimitIO, v::UInt8)
     io.n > io.maxbytes && throw(LimitIOException(io.maxbytes))
     n_bytes = write(io.io, v)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1948,6 +1948,9 @@ end
         @test output == "…[printing stopped after displaying 0 bytes; $hint]"
         @test sprint(io -> show(REPL.LimitIO(io, 5), "abc")) == "\"abc\""
         @test_throws REPL.LimitIOException(1) sprint(io -> show(REPL.LimitIO(io, 1), "abc"))
+
+        # displaying objects at the REPL sometimes needs access to displaysize, like Dict
+        @test displaysize(IOContext(REPL.LimitIO(stdout, 100), stdout)) == displaysize(stdout)
     finally
         REPL.SHOW_MAXIMUM_BYTES = previous
     end


### PR DESCRIPTION
In #53959, an new `LimitIO` object was defined to display at the REPL, but it hid the displaysize of the underlying `io`. This patch just forwards this information.

Before:
```
julia> Dict(1 => fill(UInt(0), 4))
Dict{Int64, Vector{UInt64}} with 1 entry:
  1 => [0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x000000000…
```
After:
```
Dict{Int64, Vector{UInt64}} with 1 entry:
  1 => [0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000]
```