### PR TITLE
make `eltype` throw for some known noniterators

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -458,4 +458,5 @@ macro coalesce(args...)
     return :(let val; $expr; end)
 end
 
+eltype(::Missing) = Any  # imprecise but correct approximation for the element type of an unknown iterator
 eltype(::Type{<:Union{Nothing, Missing}}) = throw(ArgumentError("not an iterator, doesn't have an element type"))

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -457,3 +457,5 @@ macro coalesce(args...)
     end
     return :(let val; $expr; end)
 end
+
+eltype(::Type{<:Union{Nothing, Missing}}) = throw(ArgumentError("not an iterator, doesn't have an element type"))

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -1133,6 +1133,14 @@ end
     end
 end
 
+@testset "noniterator has no element type" begin
+    for x ∈ (nothing, missing)
+        @test_throws ArgumentError eltype(x)
+        @test_throws ArgumentError eltype(typeof(x))
+    end
+    @test_throws ArgumentError eltype(Union{Nothing, Missing})
+end
+
 @testset "Iterators docstrings" begin
     @test isempty(Docs.undocumented_names(Iterators))
 end


### PR DESCRIPTION
Neither `Nothing` or `Missing` are iterators, `iterate(nothing)` throws: thus `eltype` should throw for such arguments as well.