### PR TITLE
[RFC] Log a backtrace on entrance to type inference (option 1)

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -2574,6 +2574,7 @@ JL_DLLEXPORT void jl_flush_cstdio(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_stderr_obj(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_backtrace_from_here(int returnsp, int skip);
 JL_DLLEXPORT void jl_print_backtrace(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jlbacktrace(void) JL_NOTSAFEPOINT; // deprecated
 // Mainly for debugging, use `void*` so that no type cast is needed in C++.


### PR DESCRIPTION
This is needed to eliminate the `Core.Compiler.Timings` module while still keeping SnoopCompile working.

This is one mechanism to add a backtrace to each entrance to inference. An alternative approach is presented in #58124. Only one of these should be merged.