### PR TITLE
[DOC] Update installation docs: /downloads/ => /install/

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ and installing Julia, below.
 ## Resources
 
 - **Homepage:** <https://julialang.org>
-- **Binaries:** <https://julialang.org/downloads/>
+- **Install:** <https://julialang.org/install/>
 - **Source code:** <https://github.com/JuliaLang/julia>
 - **Documentation:** <https://docs.julialang.org>
 - **Packages:** <https://julialang.org/packages/>
@@ -63,17 +63,22 @@ helpful to start contributing to the Julia codebase.
 
 ## Binary Installation
 
-If you would rather not compile the latest Julia from source,
-platform-specific tarballs with pre-compiled binaries are also
-[available for download](https://julialang.org/downloads/). The
-downloads page also provides details on the
-[different tiers of support](https://julialang.org/downloads/#supported_platforms)
-for OS and platform combinations.
+The recommended way of installing Julia is to use `juliaup` which will install
+the latest stable `julia` for you and help keep it up to date. It can also let
+you install and run different Julia versions simultaneously. Instructions for
+this can be find [here](https://julialang.org/install/). If you want to manually
+download specific Julia binaries, you can find those on the [downloads
+page](https://julialang.org/downloads/). The downloads page also provides
+details on the [different tiers of
+support](https://julialang.org/downloads/#supported_platforms) for OS and
+platform combinations.
 
-If everything works correctly, you will see a Julia banner and an
-interactive prompt into which you can enter expressions for
-evaluation. You can read about [getting
-started](https://docs.julialang.org/en/v1/manual/getting-started/) in the manual.
+If everything works correctly, you will get a `julia` program and when you run
+it in a terminal or command prompt, you will see a Julia banner and an
+interactive prompt into which you can enter expressions for evaluation. You can
+read about [getting
+started](https://docs.julialang.org/en/v1/manual/getting-started/) in the
+manual.
 
 **Note**: Although some OS package managers provide Julia, such
 installations are neither maintained nor endorsed by the Julia

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -321,7 +321,7 @@ Website:  https://julialang.org/
 .br
 Documentation:  https://docs.julialang.org/
 .br
-Downloads:  https://julialang.org/downloads/
+Install:  https://julialang.org/install/
 
 .SH LICENSING
 Julia is an open-source project. It is made available under the MIT license.

--- a/doc/src/devdocs/build/windows.md
+++ b/doc/src/devdocs/build/windows.md
@@ -32,7 +32,7 @@ or edit `%USERPROFILE%\.gitconfig` and add/edit the lines:
 ## Binary distribution
 
 For the binary distribution installation notes on Windows please see the instructions at
-[https://julialang.org/downloads/platform/#windows](https://julialang.org/downloads/platform/#windows).
+[https://julialang.org/downloads/platform/#windows](https://julialang.org/downloads/platform/#windows). Note, however, that on all platforms [using `juliaup`](https://julialang.org/install/) is recommended over manually installing binaries.
 
 ## Source distribution
 

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -37,7 +37,7 @@ Markdown.parse("""
 Below is a non-exhaustive list of links that will be useful as you learn and use the Julia programming language.
 
 - [Julia Homepage](https://julialang.org)
-- [Download Julia](https://julialang.org/downloads/)
+- [Install Julia](https://julialang.org/install/)
 - [Discussion forum](https://discourse.julialang.org)
 - [Julia YouTube](https://www.youtube.com/user/JuliaLanguage)
 - [Find Julia Packages](https://julialang.org/packages/)

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -1090,8 +1090,7 @@ You may wish to test against the nightly version to ensure that such regressions
 Finally, you may also consider building Julia from source for yourself. This option is mainly for those individuals who are comfortable at the command line, or interested in learning.
 If this describes you, you may also be interested in reading our [guidelines for contributing](https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md).
 
-Links to each of these download types can be found on the download page at [https://julialang.org/downloads/](https://julialang.org/downloads/).
-Note that not all versions of Julia are available for all platforms.
+The [`juliaup` install manager](https://julialang.org/install/) has pre-defined channels named `release` and `lts` for the latest stable release and the current LTS release, as well as version-specific channels.
 
 ### How can I transfer the list of installed packages after updating my version of Julia?
 

--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -1,7 +1,7 @@
 # [Getting Started](@id man-getting-started)
 
 Julia installation is straightforward, whether using precompiled binaries or compiling from source.
-Download and install Julia by following the instructions at [https://julialang.org/downloads/](https://julialang.org/downloads/).
+Download and install Julia by following the instructions at [https://julialang.org/install/](https://julialang.org/install/).
 
 If you are coming to Julia from one of the following languages, then you should start by reading the section on noteworthy differences from [MATLAB](@ref Noteworthy-differences-from-MATLAB), [R](@ref Noteworthy-differences-from-R), [Python](@ref Noteworthy-differences-from-Python), [C/C++](@ref Noteworthy-differences-from-C/C) or [Common Lisp](@ref Noteworthy-differences-from-Common-Lisp). This will help you avoid some common pitfalls since Julia differs from those languages in many subtle ways.
 


### PR DESCRIPTION
I've created an [Install](https://julialang.org/install/) page separate from the [Downloads](https://julialang.org/downloads/) page on the website. This updates various references to point to the correct pages.