### PR TITLE
[release-1.10] Backport version script fixes

### DIFF
--- a/src/julia.expmap.in
+++ b/src/julia.expmap.in
@@ -1,7 +1,7 @@
 @JULIA_SHLIB_SYMBOL_VERSION@ {
   global:
     pthread*;
-    __stack_chk_guard;
+    __stack_chk_*;
     asprintf*;
     bitvector_*;
     ios_*;

--- a/src/julia.expmap.in
+++ b/src/julia.expmap.in
@@ -2,7 +2,7 @@
   global:
     pthread*;
     __stack_chk_guard;
-    asprintf;
+    asprintf*;
     bitvector_*;
     ios_*;
     arraylist_grow;
@@ -10,33 +10,33 @@
     jl_*;
     ijl_*;
     _jl_mutex_*;
-    rec_backtrace;
+    rec_backtrace*;
     julia_*;
-    libsupport_init;
-    localtime_r;
-    memhash;
-    memhash32;
-    memhash32_seed;
-    memhash_seed;
-    restore_signals;
+    libsupport_init*;
+    localtime_r*;
+    memhash*;
+    memhash32*;
+    memhash32_seed*;
+    memhash_seed*;
+    restore_signals*;
     u8_*;
     uv_*;
-    add_library_mapping;
+    add_library_mapping*;
     utf8proc_*;
-    jlbacktrace;
-    jlbacktracet;
-    _IO_stdin_used;
-    _Z24jl_coverage_data_pointerN4llvm9StringRefEi;
-    _Z22jl_coverage_alloc_lineN4llvm9StringRefEi;
-    _Z22jl_malloc_data_pointerN4llvm9StringRefEi;
+    jlbacktrace*;
+    jlbacktracet*;
+    _IO_stdin_used*; /* glibc expects this to be exported to detect which version of glibc is being used, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=634261#109 for further details */
+    _Z24jl_coverage_data_pointerN4llvm9StringRefEi*;
+    _Z22jl_coverage_alloc_lineN4llvm9StringRefEi*;
+    _Z22jl_malloc_data_pointerN4llvm9StringRefEi*;
     _jl_timing_*;
     LLVMExtra*;
     JLJIT*;
-    llvmGetPassPluginInfo;
+    llvmGetPassPluginInfo*;
 
     /* freebsd */
-    environ;
-    __progname;
+    environ*;
+    __progname*;
 
   local:
     *;

--- a/src/julia.expmap.in
+++ b/src/julia.expmap.in
@@ -5,8 +5,8 @@
     asprintf*;
     bitvector_*;
     ios_*;
-    arraylist_grow;
-    small_arraylist_grow;
+    arraylist_*;
+    small_arraylist_*;
     jl_*;
     ijl_*;
     _jl_mutex_*;


### PR DESCRIPTION
This includes three commits that fix the version script for use with newer LLD. This has already been fixed on 1.11, 1.12, and master.

Commits were cherry-picked from #55363, #57874, and #53633.