### PR TITLE
staticdata: Remove `new_ext_cis` list

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1283,10 +1283,9 @@ function _include_from_serialized(pkg::PkgId, path::String, ocachepath::Union{No
 
         sv = sv::SimpleVector
         edges = sv[3]::Vector{Any}
-        ext_edges = sv[4]::Union{Nothing,Vector{Any}}
-        extext_methods = sv[5]::Vector{Any}
-        internal_methods = sv[6]::Vector{Any}
-        StaticData.insert_backedges(edges, ext_edges, extext_methods, internal_methods)
+        extext_methods = sv[4]::Vector{Any}
+        internal_methods = sv[5]::Vector{Any}
+        StaticData.insert_backedges(edges, extext_methods, internal_methods)
 
         restored = register_restored_modules(sv, pkg, path)
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -475,9 +475,10 @@ typedef struct _jl_code_instance_t {
     uint16_t time_infer_self; // self cost of julia inference for `inferred` (included in time_infer_total)
     _Atomic(uint16_t) time_compile; // self cost of llvm compilation (e.g. of computing `invoke`)
     //TODO: uint8_t absolute_max; // whether true max world is unknown
-    _Atomic(uint8_t) specsigflags; // & 0b001 == specptr is a specialized function signature for specTypes->rettype
-                                   // & 0b010 == invokeptr matches specptr
-                                   // & 0b100 == From image
+    _Atomic(uint8_t) specsigflags; // & 0b0001 == specptr is a specialized function signature for specTypes->rettype
+                                   // & 0b0010 == invokeptr matches specptr
+                                   // & 0b0100 == from image
+                                   // & 0b1000 == targets external method (serialized in another pkgimage), implies from image
     _Atomic(uint8_t) precompile;  // if set, this will be added to the output system image
     _Atomic(jl_callptr_t) invoke; // jlcall entry point usually, but if this codeinst belongs to an OC Method, then this is an jl_fptr_args_t fptr1 instead, unless it is not, because it is a special token object instead
     union _jl_generic_specptr_t {

--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -302,7 +302,7 @@ JL_DLLEXPORT void jl_suppress_precompile(int suppress)
     suppress_precompile = suppress;
 }
 
-static void *jl_precompile_worklist(jl_array_t *worklist, jl_array_t *extext_methods, jl_array_t *new_ext_cis)
+static void *jl_precompile_worklist(jl_array_t *worklist, jl_array_t *extext_methods)
 {
     if (!worklist)
         return NULL;
@@ -332,13 +332,6 @@ static void *jl_precompile_worklist(jl_array_t *worklist, jl_array_t *extext_met
                     if (mi != jl_nothing)
                         precompile_enq_specialization_((jl_method_instance_t*)mi, m);
                 }
-            }
-        }
-        if (new_ext_cis) {
-            n = jl_array_nrows(new_ext_cis);
-            for (i = 0; i < n; i++) {
-                jl_code_instance_t *ci = (jl_code_instance_t*)jl_array_ptr_ref(new_ext_cis, i);
-                precompile_enq_specialization_(jl_get_ci_mi(ci), m);
             }
         }
     }


### PR DESCRIPTION
As a root for compilation, this list is pretty much redundant with the external CI's that we will discover along the forward call edges in inference. As a filter for code emission, it is mostly redundant with `specsigflags & 0b100`, which is the only thing `jl_emit_native` respects as a filter right now anyway.

The other purpose of this list was to track what needs to be inserted into cache / methods loaded from another pkgimage (i.e. CI's for external methods), which is now tracked by a new `specsigflags & 0b1000` flag.

~~This means that the list of "newly-inferred" CI's / MI's (as defined by `JL_MI_FLAGS_MASK_PRECOMPILED` / `jl_push_newly_inferred` / `jl_tag_newly_inferred_enable`) is purely a "best-effort" list - the runtime itself no longer depends on it.~~

TODO: The last remaining use for this list is to track which MI/CI's for external methods were triggered via `precompile(...)`. Otherwise these will not make it into the queue. 