### PR TITLE
Add `fieldoffsets` for consistent struct introspection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@ New language features
 ---------------------
 
   - New `Base.@acquire` macro for a non-closure version of `Base.acquire(f, s::Base.Semaphore)`, like `@lock`. ([#56845])
+  - More consistent struct introspection methods:
+    - `fieldname`, `fieldoffset` and `fieldtype` now all have a plural form returning the information for all fields
+    - `fieldoffset` and `fieldtype` now both accept a field index or a field name
+    - `fieldindex` and `fieldname` can be used to convert between the field's index and its name
 
 Language changes
 ----------------
@@ -24,9 +28,13 @@ Build system changes
 New library functions
 ---------------------
 
+* New function `fieldoffsets` to get all offsets of the fields of a struct
+* Exporting function `fieldindex` to get the index of a field of a struct
+
 New library features
 --------------------
 
+* `fieldtype` now also accepts the field name as a symbol as `fieldtype` already did.
 * `sort(keys(::Dict))` and `sort(values(::Dict))` now automatically collect, they previously threw ([#56978]).
 * `Base.AbstractOneTo` is added as a supertype of one-based axes, with `Base.OneTo` as its subtype ([#56902]).
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -805,6 +805,7 @@ export
     replaceproperty!,
     setpropertyonce!,
     fieldoffset,
+    fieldoffsets,
     fieldname,
     fieldnames,
     fieldcount,

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1036,6 +1036,36 @@ julia> structinfo(Base.Filesystem.StatStruct)
 fieldoffset(x::DataType, idx::Integer) = (@_foldable_meta; ccall(:jl_get_field_offset, Csize_t, (Any, Cint), x, idx))
 
 """
+    fieldoffsets(T::Type)
+
+The field offsets of all fields in a composite DataType `T` as a tuple.
+
+!!! compat "Julia 1.13"
+    This function requires at least Julia 1.13.
+
+# Examples
+```jldoctest
+julia> struct Foo
+           a::Int32
+           b::Int16
+           c::UInt8
+       end
+
+julia> fieldoffsets(Foo)
+(0x0000000000000000, 0x0000000000000004, 0x0000000000000006)
+
+julia> struct Bar
+           x::Int16
+           y::Int32
+       end
+
+julia> fieldoffsets(Bar)
+(0x0000000000000000, 0x0000000000000004)
+```
+"""
+fieldoffsets(T::Type) = (@_foldable_meta; ntupleany(i -> fieldoffset(T, i), fieldcount(T)))
+
+"""
     fieldtype(T, name::Symbol | index::Int)
 
 Determine the declared type of a field (specified by name or index) in a composite DataType `T`.

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -224,6 +224,7 @@ Base.isconcretetype
 Base.isbits
 Base.isbitstype
 Base.fieldoffset
+Base.fieldoffsets
 Base.datatype_alignment
 Base.datatype_haspadding
 Base.datatype_pointerfree

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -346,6 +346,7 @@ tlayout = TLayout(5,7,11)
 @test !hasproperty(tlayout, :p)
 @test [(fieldoffset(TLayout,i), fieldname(TLayout,i), fieldtype(TLayout,i)) for i = 1:fieldcount(TLayout)] ==
     [(0, :x, Int8), (2, :y, Int16), (4, :z, Int32)]
+@test fieldoffsets(TLayout) == (0, 2, 4)
 @test fieldnames(Complex) === (:re, :im)
 @test_throws BoundsError fieldtype(TLayout, 0)
 @test_throws ArgumentError fieldname(TLayout, 0)


### PR DESCRIPTION
This completes my mini-series to get more consistent struct introspection by adding, exporting, documenting and testing `fieldoffsets`.

We now have more consistent introspection methods:
- `fieldname`, `fieldoffset` and `fieldtype` now all have a plural form returning the information for all fields
- `fieldoffset` and `fieldtype` now both accept a field index or a field name
- `fieldindex` and `fieldname` can be used to convert between the field's index and its name

I hope that with these additions using the introspection methods feels very natural and reduces the mental load for the user to remember what's supported and what is not supported.