### PR TITLE
Fix `jl_set_precompile_field_replace` for 0-size fields

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1767,7 +1767,7 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
                 tot = offset;
                 size_t fsz = jl_field_size(t, i);
                 jl_value_t *replace = (jl_value_t*)ptrhash_get(&bits_replace, (void*)slot);
-                if (replace != HT_NOTFOUND) {
+                if (replace != HT_NOTFOUND && fsz > 0) {
                     assert(t->name->mutabl && !jl_field_isptr(t, i));
                     jl_value_t *rty = jl_typeof(replace);
                     size_t sz = jl_datatype_size(rty);
@@ -2961,7 +2961,7 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
             if (jl_field_isptr(st, field)) {
                 record_field_change((jl_value_t**)fldaddr, newval);
             }
-            else {
+            else if (jl_field_size(st, field) > 0) {
                 // replace the bits
                 ptrhash_put(&bits_replace, (void*)fldaddr, newval);
                 // and any pointers inside

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -105,6 +105,11 @@ precompile_test_harness(false) do dir
               process_state_calls = 0
               @assert process_state() === process_state()
               @assert process_state_calls === 0
+
+              const empty_state = Base.OncePerProcess{Nothing}() do
+                  return nothing
+              end
+              @assert empty_state() === nothing
           end
           """)
     write(Foo2_file,


### PR DESCRIPTION
We need to make sure this doesn't end up in the `bits_replace` table, or else we can be confused by these non-unique field addresses.

This makes `Base.OncePerProcess{Nothing}` work during pre-compilation