### PR TITLE
Only define `libssp` if our CSL intsall actually has it

### DIFF
--- a/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
+++ b/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
@@ -72,7 +72,10 @@ end
 const libgfortran = LazyLibrary(_libgfortran_path, dependencies=libgfortran_deps)
 const libstdcxx = LazyLibrary(_libstdcxx_path, dependencies=[libgcc_s])
 const libgomp = LazyLibrary(_libgomp_path)
-if @isdefined _libssp_path
+
+# Some installations (such as those from-source) may not have `libssp`
+# So let's do a compile-time check to see if we've got it.
+if @isdefined(_libssp_path) && isfile(string(_libssp_path))
     const libssp = LazyLibrary(_libssp_path)
 end
 


### PR DESCRIPTION
Some CSL installs (such as those from `USE_BINARYBUILDER=0` builds) do not have a `libssp`, because their GCC was built without stack smash protection, or it was statically linked.  This allows our CSL_jll to adapt to that, avoiding issues like those reported in [0].

[0]: https://github.com/JuliaLang/julia/issues/58173

This should fix #58173