### PR TITLE
inference: ensure source is saved for IRInterp when assumed to be available

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -399,7 +399,7 @@ function transform_result_for_cache(interp::AbstractInterpreter, result::Inferen
     if isa(src, OptimizationState)
         opt = src
         inlining_cost = compute_inlining_cost(interp, result, opt.optresult)
-        discard_optimized_result(interp, opt, inlining_cost) && return nothing
+        discard_optimized_result(interp, opt, inlining_cost, result.ipo_effects) && return nothing
         src = ir_to_codeinf!(opt)
     end
     if isa(src, CodeInfo)
@@ -409,9 +409,8 @@ function transform_result_for_cache(interp::AbstractInterpreter, result::Inferen
     return src
 end
 
-function discard_optimized_result(interp::AbstractInterpreter, opt#=::OptimizationState=#, inlining_cost#=::InlineCostType=#)
-    may_discard_trees(interp) || return false
-    return inlining_cost == MAX_INLINE_COST
+function discard_optimized_result(interp::AbstractInterpreter, opt#=::OptimizationState=#, inlining_cost#=::InlineCostType=#, effects::Effects)
+    return may_discard_trees(interp) && inlining_cost == MAX_INLINE_COST && !is_foldable(effects, #=check_rtcall=#true)
 end
 
 function maybe_compress_codeinfo(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInfo)


### PR DESCRIPTION
I'm not certain whether this is an implementation mistake in IRInterp's legality analysis or in discard_optimized_result. I've currently opted towards changing discard_optimized_result, but I'd be happier to go the other way as it would mean discarding more source. Originally, we would only const-prop code that was inlineable, while currently the IRInterp heuristics appear to potentially lead to weird and complicated non-monotonic interactions since the current decision functions appear to fail to take that consideration into account.

This IRInterp issue adds disk space usage of 4 MB (124 MB -> 128 MB)