### PR TITLE
fix performance regression introduced by #58027

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3728,8 +3728,9 @@ struct AbstractEvalBasicStatementResult
     end
 end
 
-function abstract_eval_basic_statement(interp::AbstractInterpreter, @nospecialize(stmt), sstate::StatementState, frame::InferenceState,
-                                       result::Union{Nothing,Future{RTEffects}}=nothing)
+@inline function abstract_eval_basic_statement(
+    interp::AbstractInterpreter, @nospecialize(stmt), sstate::StatementState, frame::InferenceState,
+    result::Union{Nothing,Future{RTEffects}}=nothing)
     rt = nothing
     exct = Bottom
     changes = nothing


### PR DESCRIPTION
JuliaLang/julia#58027 introduced 5~10% performance regression in the `"inference"` benchmark. This commit fixes the regression by inlining `abstract_eval_basic_statement` that was outlined in the PR.

@nanosoldier `runbenchmarks("inference", vs=":master")`