### PR TITLE
Dimensional `any` and `all` reduce with Boolean operations

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -29,8 +29,11 @@ mul_prod(x::BitSignedSmall, y::BitSignedSmall) = Int(x) * Int(y)
 mul_prod(x::BitUnsignedSmall, y::BitUnsignedSmall) = UInt(x) * UInt(y)
 mul_prod(x::Real, y::Real)::Real = x * y
 
-and_all(x,y) = Bool(x && y)
-or_any(x,y) = Bool(x || y)
+and_all(x, y) = (x && y)::Bool
+or_any(x, y) = (x || y)::Bool
+# As a performance optimization, avoid runtime branches:
+and_all(x::Bool, y::Bool) = (x & y)::Bool
+or_any(x::Bool, y::Bool) = (x | y)::Bool
 
 ## foldl && mapfoldl
 

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -29,6 +29,9 @@ mul_prod(x::BitSignedSmall, y::BitSignedSmall) = Int(x) * Int(y)
 mul_prod(x::BitUnsignedSmall, y::BitUnsignedSmall) = UInt(x) * UInt(y)
 mul_prod(x::Real, y::Real)::Real = x * y
 
+and_all(x,y) = Bool(x && y)
+or_any(x,y) = Bool(x || y)
+
 ## foldl && mapfoldl
 
 function mapfoldl_impl(f::F, op::OP, nt, itr) where {F,OP}
@@ -336,8 +339,8 @@ reduce_empty(::typeof(+), ::Type{T}) where {T} = zero(T)
 reduce_empty(::typeof(+), ::Type{Bool}) = zero(Int)
 reduce_empty(::typeof(*), ::Type{T}) where {T} = one(T)
 reduce_empty(::typeof(*), ::Type{<:AbstractChar}) = ""
-reduce_empty(::typeof(&), ::Type{Bool}) = true
-reduce_empty(::typeof(|), ::Type{Bool}) = false
+reduce_empty(::typeof(and_all), ::Type{T}) where {T} = true
+reduce_empty(::typeof(or_any), ::Type{T}) where {T} = false
 
 reduce_empty(::typeof(add_sum), ::Type{T}) where {T} = reduce_empty(+, T)
 reduce_empty(::typeof(add_sum), ::Type{T}) where {T<:BitSignedSmall}  = zero(Int)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -339,6 +339,8 @@ reduce_empty(::typeof(+), ::Type{T}) where {T} = zero(T)
 reduce_empty(::typeof(+), ::Type{Bool}) = zero(Int)
 reduce_empty(::typeof(*), ::Type{T}) where {T} = one(T)
 reduce_empty(::typeof(*), ::Type{<:AbstractChar}) = ""
+reduce_empty(::typeof(&), ::Type{Bool}) = true
+reduce_empty(::typeof(|), ::Type{Bool}) = false
 reduce_empty(::typeof(and_all), ::Type{T}) where {T} = true
 reduce_empty(::typeof(or_any), ::Type{T}) where {T} = false
 

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -963,12 +963,12 @@ julia> A = [true false; true false]
  1  0
 
 julia> any!(Bool[1; 1], A)
-2-element Vector{Int64}:
+2-element Vector{Bool}:
  1
  1
 
 julia> any!(Bool[1 1], A)
-1×2 Matrix{Int64}:
+1×2 Matrix{Bool}:
  1  0
 ```
 """

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -45,7 +45,7 @@ end
 initarray!(a::AbstractArray{T}, f, ::Union{typeof(min),typeof(max),typeof(_extrema_rf)},
     init::Bool, src::AbstractArray) where {T} = (init && mapfirst!(f, a, src); a)
 
-for (Op, initval) in ((:(typeof(&)), true), (:(typeof(|)), false))
+for (Op, initval) in ((:(typeof(and_all)), true), (:(typeof(or_any)), false))
     @eval initarray!(a::AbstractArray, ::Any, ::$(Op), init::Bool, src::AbstractArray) = (init && fill!(a, $initval); a)
 end
 
@@ -173,8 +173,8 @@ end
 reducedim_init(f::Union{typeof(abs),typeof(abs2)}, op::typeof(max), A::AbstractArray{T}, region) where {T} =
     reducedim_initarray(A, region, zero(f(zero(T))), _realtype(f, T))
 
-reducedim_init(f, op::typeof(&), A::AbstractArrayOrBroadcasted, region) = reducedim_initarray(A, region, true)
-reducedim_init(f, op::typeof(|), A::AbstractArrayOrBroadcasted, region) = reducedim_initarray(A, region, false)
+reducedim_init(f, op::typeof(and_all), A::AbstractArrayOrBroadcasted, region) = reducedim_initarray(A, region, true)
+reducedim_init(f, op::typeof(or_any), A::AbstractArrayOrBroadcasted, region) = reducedim_initarray(A, region, false)
 
 # specialize to make initialization more efficient for common cases
 
@@ -994,7 +994,7 @@ _all(a, ::Colon)                           = _all(identity, a, :)
 
 for (fname, op) in [(:sum, :add_sum), (:prod, :mul_prod),
                     (:maximum, :max), (:minimum, :min),
-                    (:all, :&),       (:any, :|),
+                    (:all, :and_all), (:any, :or_any),
                     (:extrema, :_extrema_rf)]
     fname! = Symbol(fname, '!')
     _fname = Symbol('_', fname)

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -887,13 +887,13 @@ julia> A = [true false; true false]
  1  0
  1  0
 
-julia> all!([1; 1], A)
-2-element Vector{Int64}:
+julia> all!(Bool[1; 1], A)
+2-element Vector{Bool}:
  0
  0
 
-julia> all!([1 1], A)
-1×2 Matrix{Int64}:
+julia> all!(Bool[1 1], A)
+1×2 Matrix{Bool}:
  1  0
 ```
 """
@@ -962,12 +962,12 @@ julia> A = [true false; true false]
  1  0
  1  0
 
-julia> any!([1; 1], A)
+julia> any!(Bool[1; 1], A)
 2-element Vector{Int64}:
  1
  1
 
-julia> any!([1 1], A)
+julia> any!(Bool[1 1], A)
 1×2 Matrix{Int64}:
  1  0
 ```

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -176,6 +176,10 @@ reducedim_init(f::Union{typeof(abs),typeof(abs2)}, op::typeof(max), A::AbstractA
 reducedim_init(f, op::typeof(and_all), A::AbstractArrayOrBroadcasted, region) = reducedim_initarray(A, region, true)
 reducedim_init(f, op::typeof(or_any), A::AbstractArrayOrBroadcasted, region) = reducedim_initarray(A, region, false)
 
+# These definitions are wrong in general; Cf. JuliaLang/julia#45562
+reducedim_init(f, op::typeof(&), A::AbstractArrayOrBroadcasted, region) = reducedim_initarray(A, region, true)
+reducedim_init(f, op::typeof(|), A::AbstractArrayOrBroadcasted, region) = reducedim_initarray(A, region, false)
+
 # specialize to make initialization more efficient for common cases
 
 let

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -682,8 +682,8 @@ end
 end
 
 @testset "issue #45562" begin
-    @test all([true, true,  true], dims = 1) == [true]
-    @test any([true, true,  true], dims = 1) == [true]
+    @test all([true, true, true], dims = 1) == [true]
+    @test any([true, true, true], dims = 1) == [true]
     @test_throws TypeError all([3, 3, 3], dims = 1)
     @test_throws TypeError any([3, 3, 3], dims = 1)
     @test reduce(|, Bool[]) == false

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -686,6 +686,16 @@ end
     @test any([true, true, true], dims = 1) == [true]
     @test_throws TypeError all([3, 3, 3], dims = 1)
     @test_throws TypeError any([3, 3, 3], dims = 1)
+    @test_throws TypeError all(Any[true, 3, 3], dims = 1)
+    @test_throws TypeError any(Any[false, 3, 3], dims = 1)
+    @test_throws TypeError all([1, 1, 1], dims = 1)
+    @test_throws TypeError any([0, 0, 0], dims = 1)
+    @test_throws TypeError all!([false], [3, 3, 3])
+    @test_throws TypeError any!([false], [3, 3, 3])
+    @test_throws TypeError all!([false], Any[true, 3, 3])
+    @test_throws TypeError any!([false], Any[false, 3, 3])
+    @test_throws TypeError all!([false], [1, 1, 1])
+    @test_throws TypeError any!([false], [0, 0, 0])
     @test reduce(|, Bool[]) == false
     @test reduce(&, Bool[]) == true
     @test reduce(|, Bool[], dims=1) == [false]

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -686,6 +686,10 @@ end
     @test any([true, true,  true], dims = 1) == [true]
     @test_throws TypeError all([3, 3, 3], dims = 1)
     @test_throws TypeError any([3, 3, 3], dims = 1)
+    @test reduce(|, Bool[]) == false
+    @test reduce(&, Bool[]) == true
+    @test reduce(|, Bool[], dims=1) == [false]
+    @test reduce(&, Bool[], dims=1) == [true]
 end
 
 # issue #45748

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -681,6 +681,13 @@ end
     end
 end
 
+@testset "issue #45562" begin
+    @test all([true, true,  true], dims = 1) == [true]
+    @test any([true, true,  true], dims = 1) == [true]
+    @test_throws TypeError all([3, 3, 3], dims = 1)
+    @test_throws TypeError any([3, 3, 3], dims = 1)
+end
+
 # issue #45748
 @testset "foldl's stability for nested Iterators" begin
     a = Iterators.flatten((1:3, 1:3))


### PR DESCRIPTION
and not bitwise ones.  Specifically, they are now reductions using these operators:

```julia
and_all(x, y) = (x && y)::Bool
or_any(x, y) = (x || y)::Bool
# As a performance optimization, avoid runtime branches:
and_all(x::Bool, y::Bool) = (x & y)::Bool
or_any(x::Bool, y::Bool) = (x | y)::Bool
```

Fixes half of #45562.