### PR TITLE
add `Random.fork(rng::Xoshiro)` to split `rng` into a new instance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,11 @@ Standard library changes
 
 #### Profile
 
+#### Random
+
+* it's now possible to efficiently create a new `Xoshiro` RNG from an existing one via `Random.fork`, which
+  can be useful in parallel computations ([#58193]).
+
 #### REPL
 
 #### Test

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,7 @@ Standard library changes
 
 #### Random
 
-* it's now possible to efficiently create a new `Xoshiro` RNG from an existing one via `Random.fork`, which
+* It's now possible to efficiently create a new `Xoshiro` RNG from an existing one via `Random.fork`, which
   can be useful in parallel computations ([#58193]).
 
 #### REPL

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,7 @@ Standard library changes
 
 #### Random
 
-* It's now possible to efficiently create a new `Xoshiro` RNG from an existing one via `Random.fork`, which
+* It's now possible to efficiently create a new `Xoshiro` instance from an existing one via `Random.fork`, which
   can be useful in parallel computations ([#58193]).
 
 #### REPL

--- a/src/task.c
+++ b/src/task.c
@@ -1035,6 +1035,7 @@ main RNG state collision.
 [4]:
 https://discourse.julialang.org/t/linear-relationship-between-xoshiro-tasks/110454
 */
+// if this code is updated, the julia equivalent should be updated as well in Random.fork()
 void jl_rng_split(uint64_t dst[JL_RNG_SIZE], uint64_t src[JL_RNG_SIZE]) JL_NOTSAFEPOINT
 {
     // load and advance the internal LCG state

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -83,6 +83,8 @@ Random.TaskLocalRNG
 Random.Xoshiro
 Random.MersenneTwister
 Random.RandomDevice
+Random.fork!
+Random.fork
 ```
 
 ## [Hooking into the `Random` API](@id rand-api-hook)

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -83,7 +83,6 @@ Random.TaskLocalRNG
 Random.Xoshiro
 Random.MersenneTwister
 Random.RandomDevice
-Random.fork!
 Random.fork
 ```
 

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -306,3 +306,61 @@ function hash_seed(str::AbstractString, ctx::SHA_CTX)
     end
     SHA.update!(ctx, (0x05,))
 end
+
+
+## forking
+
+"""
+    Random.fork(rng::AbstractRNG, [dims...])::typeof(rng)
+
+Create deterministically a new independent RNG object from an existing one, of the same type.
+When `dims` is specified (as integers or a tuple of integers),
+an array of such independent RNGs is created.
+
+This is the recommended way to initialize fresh RNG instances when reproducibility might be
+required, and can be useful in particular in multi-threaded contexts, where race conditions
+must be avoided. For example:
+```julia
+function dotask(rng::Xoshiro)
+    num_subtasks = 10
+    rngs = Random.fork(rng, num_subtasks)
+    result = Vector(undef, num_subtasks)
+    Threads.@threads for i=1:num_subtasks
+        result[i] = dosubtask(i, rngs[i])
+    end
+    result
+end
+```
+Note that this functions generally mutates its `rng` argument, so calling it on the same `rng`
+must not be done concurrently from multiple threads.
+
+Currently, a method is only implemented for `Xoshiro`.
+
+!!! note
+    `Random.fork(::Xoshiro)` uses the same algorithm as when the task-local RNG
+    of a new task is created from the task-local RNG of the parent task.
+
+!!! compat "Julia 1.13"
+    This function was introduced in Julia 1.13.
+
+# Examples
+```jldoctest
+julia> x = Xoshiro(0)
+Xoshiro(0xdb2fa90498613fdf, 0x48d73dc42d195740, 0x8c49bc52dc8a77ea, 0x1911b814c02405e8, 0x22a21880af5dc689)
+
+julia> [x, fork(x)] # x is mutated
+2-element Vector{Xoshiro}:
+ Xoshiro(0xdb2fa90498613fdf, 0x48d73dc42d195740, 0x8c49bc52dc8a77ea, 0x1911b814c02405e8, 0x26b589433d8074be)
+ Xoshiro(0x545f53b997598dfb, 0xac80f92d91bb35a5, 0xb6eb3382e8c409ca, 0xa9aa6968fbdd5e83, 0x26b589433d8074be)
+
+julia> fork(x, 3)
+3-element Vector{Xoshiro}:
+ Xoshiro(0xfc86733bafa6df6d, 0x5ff051ecb5937fcf, 0x935c4e55a82ca686, 0xa57b44768cdb84e9, 0x845f4ebfc53d5497)
+ Xoshiro(0x9c49327a59542654, 0x7c2f821b7716e6b7, 0x586a3fe58fed92f7, 0x28bbf526c1aca281, 0x425e2dc6f55934e4)
+ Xoshiro(0xd5cbe598083243e0, 0xfba09a94aaf998af, 0xa674c207f3796c54, 0x084d4986ad49c4eb, 0x52a722b1a914a4b5)
+```
+"""
+fork
+
+fork(rng::AbstractRNG, dims::Dims) = typeof(rng)[fork(rng) for _=LinearIndices(dims)]
+fork(rng::AbstractRNG, d1::Integer, dims::Integer...) = fork(rng, Dims((d1, dims...)))

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -311,15 +311,16 @@ end
 ## forking
 
 """
-    Random.fork(rng::AbstractRNG, [dims...])::typeof(rng)
+    Random.fork(rng::AbstractRNG)::typeof(rng)
+    Random.fork(rng::AbstractRNG, dims...)::Array{typeof(rng)}
 
-Create deterministically a new independent RNG object from an existing one, of the same type.
+Return a new independent RNG derived from `rng`, of the same type.
 When `dims` is specified (as integers or a tuple of integers),
-an array of such independent RNGs is created.
+return an array of independent RNGs.
 
-This is the recommended way to initialize fresh RNG instances when reproducibility might be
-required, and can be useful in particular in multi-threaded contexts, where race conditions
-must be avoided. For example:
+This is the recommended method to initialize reproducible RNG instances,
+especially in multi-threaded contexts, where race conditions must be avoided.
+For example:
 ```julia
 function dotask(rng::Xoshiro)
     num_subtasks = 10
@@ -331,29 +332,28 @@ function dotask(rng::Xoshiro)
     result
 end
 ```
-Note that this functions generally mutates its `rng` argument, so calling it on the same `rng`
-must not be done concurrently from multiple threads.
-
-Currently, a method is only implemented for `Xoshiro`.
+Note that this function generally mutates its `rng` argument, so concurrent
+calls on the same `rng` from multiple threads are unsafe.
 
 !!! note
-    `Random.fork(::Xoshiro)` uses the same algorithm as when the task-local RNG
+    Currently, this function is only implemented for `Xoshiro`, where it uses
+    the same algorithm as when the task-local RNG
     of a new task is created from the task-local RNG of the parent task.
 
 !!! compat "Julia 1.13"
-    This function was introduced in Julia 1.13.
+    This function requires Julia 1.13 or later.
 
 # Examples
 ```jldoctest
 julia> x = Xoshiro(0)
 Xoshiro(0xdb2fa90498613fdf, 0x48d73dc42d195740, 0x8c49bc52dc8a77ea, 0x1911b814c02405e8, 0x22a21880af5dc689)
 
-julia> [x, fork(x)] # x is mutated
+julia> [x, Random.fork(x)] # x is mutated
 2-element Vector{Xoshiro}:
  Xoshiro(0xdb2fa90498613fdf, 0x48d73dc42d195740, 0x8c49bc52dc8a77ea, 0x1911b814c02405e8, 0x26b589433d8074be)
  Xoshiro(0x545f53b997598dfb, 0xac80f92d91bb35a5, 0xb6eb3382e8c409ca, 0xa9aa6968fbdd5e83, 0x26b589433d8074be)
 
-julia> fork(x, 3)
+julia> Random.fork(x, 3)
 3-element Vector{Xoshiro}:
  Xoshiro(0xfc86733bafa6df6d, 0x5ff051ecb5937fcf, 0x935c4e55a82ca686, 0xa57b44768cdb84e9, 0x845f4ebfc53d5497)
  Xoshiro(0x9c49327a59542654, 0x7c2f821b7716e6b7, 0x586a3fe58fed92f7, 0x28bbf526c1aca281, 0x425e2dc6f55934e4)

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -29,7 +29,7 @@ export rand!, randn!,
        randcycle, randcycle!,
        AbstractRNG, MersenneTwister, RandomDevice, TaskLocalRNG, Xoshiro
 
-public fork, fork!, seed!, default_rng, Sampler, SamplerType, SamplerTrivial, SamplerSimple
+public fork, seed!, default_rng, Sampler, SamplerType, SamplerTrivial, SamplerSimple
 
 ## general definitions
 

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -29,7 +29,7 @@ export rand!, randn!,
        randcycle, randcycle!,
        AbstractRNG, MersenneTwister, RandomDevice, TaskLocalRNG, Xoshiro
 
-public seed!, default_rng, Sampler, SamplerType, SamplerTrivial, SamplerSimple
+public fork, fork!, seed!, default_rng, Sampler, SamplerType, SamplerTrivial, SamplerSimple
 
 ## general definitions
 

--- a/stdlib/Random/src/Xoshiro.jl
+++ b/stdlib/Random/src/Xoshiro.jl
@@ -349,7 +349,7 @@ fork!(dst::Union{Xoshiro, TaskLocalRNG}, src::Union{Xoshiro, TaskLocalRNG}=TaskL
 
 Create a new `Xoshiro` object from `src`, in the same way that the task local RNG of a new
 task is created from the task local RNG of the parent task.
-This is the recommanded way to initialize a fresh RNG from an existing one.
+This is the recommended way to initialize a fresh RNG from an existing one.
 
 !!! note
     When `src` is of type `TaskLocalRNG`, this function is guaranteed to return an RNG of


### PR DESCRIPTION
When new tasks are spawned, the task-local RNG of the current task is "split", or "forked", into a new RNG for the new task. This is achieved in a fast and sound way, involving a secondary RNG "hidden" in the 5th field of the `TaskLocalRNG` struct.
`Xoshiro` was made to mirror `TaskLocalRNG` and also has a 5th field, mostly unused. It was useful for example when you want to save the state of `TaskLocalRNG()` via `copy(TaskLocalRNG())`, which returns a `Xoshiro`.

This PR re-implements in julia this forking mechanism from `jl_rng_split()` in "src/task.c", to allow forking `Xoshiro` RNGs independently of task spawning. This is in particular useful for parallel (reproducible) computations, where tasks can be spawned with a forked (explicit) RNG from an initial `Xoshiro` object.

There are alternatives, like "jumping", or for example seeding new RNGs objects from a master seed and a "worker id", like in `Xoshiro([master_seed, worker_id])`, but these techniques require some coordination. For example, it can be unsafe to locally create a new RNG via jumping, because you might have collision with another RNG created from the parent task also via jumping with the same number of steps.
In contrast, "forking" allows to make local decisions about the shape of the computation without risks of collisions.
And it's simpler: you just write `forked_rng = Random.fork(src_rng)`.

Alternative names could be
* `spawn`, which is used in Numpy, but that I find less descriptive than `fork`; or
* `split`, perhaps what is mostly found in the literature, and also appears in the name `jl_rng_split`; one problem being that `Base.split` means something else.

"Fork" seems appropriate as it's used in the name `Random.forkRand` for array-filling with SIMD, and in the long comment above `jl_rng_split`.