### PR TITLE
Narrow `@inbounds` annotations in `accumulate.jl` to only indexing calls

### DIFF
--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2908,6 +2908,11 @@ end
     @inferred accumulate(+, randn(3))
     @inferred accumulate(+, randn(3); init=1)
 
+    # inbounds propagation
+    Base.@propagate_inbounds op_bounds(a, b) = (1, 2)[a] + (1, 2)[b]
+    @test_throws BoundsError accumulate(op_bounds, 1:10)
+    @test_throws BoundsError Base.accumulate_pairwise(op_bounds, 1:10)
+
     # asymmetric operation
     op(x,y) = 2x+y
     @test accumulate(op, [10, 20, 30]) == [10, op(10, 20), op(op(10, 20), 30)] == [10, 40, 110]

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2908,11 +2908,6 @@ end
     @inferred accumulate(+, randn(3))
     @inferred accumulate(+, randn(3); init=1)
 
-    # inbounds propagation
-    Base.@propagate_inbounds op_bounds(a, b) = (1, 2)[a] + (1, 2)[b]
-    @test_throws BoundsError accumulate(op_bounds, 1:10)
-    @test_throws BoundsError Base.accumulate_pairwise(op_bounds, 1:10)
-
     # asymmetric operation
     op(x,y) = 2x+y
     @test accumulate(op, [10, 20, 30]) == [10, op(10, 20), op(op(10, 20), 30)] == [10, 40, 110]

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -239,6 +239,13 @@ if bc_opt != bc_off
     @test_throws BoundsError BadVector20469([1,2,3])[:]
 end
 
+# Accumulate: do not set inbounds context for user-supplied functions
+if bc_opt != bc_off
+    Base.@propagate_inbounds op58200(a, b) = (1, 2)[a] + (1, 2)[b]
+    @test_throws BoundsError accumulate(op58200, 1:10)
+    @test_throws BoundsError Base.accumulate_pairwise(op58200, 1:10)
+end
+
 # Ensure iteration over arrays is vectorizable
 function g27079(X)
     r = 0


### PR DESCRIPTION
`op` should not be `inbounds`-ed here

the test case I added might technically be an illegal (or at least bad) use of `@propagate_inbounds` in case anyone has a suggestion for a more natural test case, but nonetheless it demonstrates getting a `BoundsError` instead of a segfault (worse) or incorrect / junk data (more worse), both of which happen on master