### PR TITLE
[release-1.11] malloc: use jl_get_current_task to fix null check

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -4119,7 +4119,7 @@ JL_DLLEXPORT void *jl_realloc(void *p, size_t sz)
 
 JL_DLLEXPORT void *jl_gc_counted_malloc(size_t sz)
 {
-    jl_task_t *ct = jl_current_task;
+    jl_task_t *ct = jl_get_current_task();
     void *data = malloc(sz);
     if (data != NULL && ct != NULL && ct->world_age) {
         sz = memory_block_usable_size(data, 0);
@@ -4136,7 +4136,7 @@ JL_DLLEXPORT void *jl_gc_counted_malloc(size_t sz)
 
 JL_DLLEXPORT void *jl_gc_counted_calloc(size_t nm, size_t sz)
 {
-    jl_task_t *ct = jl_current_task;
+    jl_task_t *ct = jl_get_current_task();
     void *data = calloc(nm, sz);
     if (data != NULL && ct != NULL && ct->world_age) {
         sz = memory_block_usable_size(data, 0);


### PR DESCRIPTION
Since 1.11.5 we are getting crashes from OpenMP threads of an external library which uses GMP numbers. This did not happen on 1.11.4. Version 1.12 and nightly are also unaffected.

Attaching `gdb` shows that the task struct is an invalid pointer (but not `NULL`):
```
(gdb) p ct
$1 = (jl_task_t *) 0xffffffffffffff90
```
This value seems to come from the `jl_current_task` macro
```
#define jl_current_task (container_of(jl_get_pgcstack(), jl_task_t, gcstack))
```
which doesn't check whether `jl_get_pgcstack()` returns `NULL` for foreign threads. Two lines further down is a check for `ct != NULL` but this cannot happen since `container_of` will just subtract a fixed offset from a NULL-pointer.
https://github.com/JuliaLang/julia/blob/2d89891cf852b7ad362404fcbf2280b840db2b28/src/gc.c#L4122-L4124

I changed the relevant two lines to use `jl_get_current_task()` which will properly return `NULL` if `jl_get_pgcstack()` returns `NULL`. This also aligns it with the current master:
https://github.com/JuliaLang/julia/blob/16eca6e2658de5cffa8d98583ad325d52566dbab/src/gc-stock.c#L3741-L3742

This was probably introduced during the backport in #57880, @gbaraldi.

Note that this PR targets `release-1.11`, not sure if this is correct but there is no `backports-release-1.11` branch right now.

cc: @lgoettgens
x-ref: https://github.com/oscar-system/Oscar.jl/issues/4806