### PR TITLE
Define `isdebugbuild` before it is imported

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -127,6 +127,12 @@ include("missing.jl")
 # version
 include("version.jl")
 
+#=
+isdebugbuild is defined here as this is imported in libdl.jl (included in libc.jl)
+The method is added in util.jl
+=#
+function isdebugbuild end
+
 # system & environment
 include("sysinfo.jl")
 include("libc.jl")


### PR DESCRIPTION
Following on from https://github.com/JuliaLang/julia/pull/58088, this ensures that `isdebugbuild` is defined in `Base`  before it is imported in `Libdl`.