### PR TITLE
TaskLocalRNG: delete confusing warning in docstring

### DIFF
--- a/stdlib/Random/src/Xoshiro.jl
+++ b/stdlib/Random/src/Xoshiro.jl
@@ -195,9 +195,6 @@ task creation, simulation results are also independent of the number of availabl
 threads / CPUs. The random stream should not depend on hardware specifics, up to
 endianness and possibly word size.
 
-Using or seeding the RNG of any other task than the one returned by `current_task()`
-is undefined behavior: it will work most of the time, and may sometimes fail silently.
-
 When seeding `TaskLocalRNG()` with [`seed!`](@ref), the passed seed, if any,
 may be any integer.
 


### PR DESCRIPTION
Mutating the task-local RNG of another task than the current one seems to be impossible without resorting to internals, like in
```
t = current_task()
fetch(@async t.rngState0 = 0)
```
The reason is that `TaskLocalRNG()` is a singleton object that doesn't hold any state by itself, and which always refers to the current task. So something like `rng = TaskLocalRNG(); fetch(@async rand(rng))` is equivalent to `fetch(@async rand())`, i.e. only the RNG of the spawned task is used.