### PR TITLE
improve type stability of `stat`

### DIFF
--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -139,7 +139,7 @@ export File,
 import .Base:
     IOError, _UVError, _sizeof_uv_fs, check_open, close, closewrite, eof, eventloop, fd, isopen,
     bytesavailable, position, read, read!, readbytes!, readavailable, seek, seekend, show,
-    skip, stat, unsafe_read, unsafe_write, write, transcode, uv_error,
+    skip, stat, unsafe_read, unsafe_write, write, transcode, uv_error, _uv_error,
     setup_stdio, rawhandle, OS_HANDLE, INVALID_OS_HANDLE, windowserror, filesize,
     isexecutable, isreadable, iswritable, MutableDenseArrayType, truncate
 

--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -103,7 +103,8 @@ struverror(err::Int32) = unsafe_string(ccall(:uv_strerror, Cstring, (Int32,), er
 uverrorname(err::Int32) = unsafe_string(ccall(:uv_err_name, Cstring, (Int32,), err))
 
 uv_error(prefix::Symbol, c::Integer) = uv_error(string(prefix), c)
-uv_error(prefix::AbstractString, c::Integer) = c < 0 ? throw(_UVError(prefix, c)) : nothing
+uv_error(prefix::AbstractString, c::Integer) = c < 0 ? _uv_error(prefix, c) : nothing
+_uv_error(prefix::AbstractString, c::Integer) = throw(_UVError(prefix, c))
 
 ## event loop ##
 

--- a/base/stat.jl
+++ b/base/stat.jl
@@ -183,7 +183,8 @@ show(io::IO, ::MIME"text/plain", st::StatStruct) = show_statstruct(io, st, false
 
 # stat & lstat functions
 
-checkstat(s::StatStruct) = Int(s.ioerrno) in (0, Base.UV_ENOENT, Base.UV_ENOTDIR, Base.UV_EINVAL) ? s : uv_error(string("stat(", repr(s.desc), ")"), s.ioerrno)
+checkstat(s::StatStruct) = Int(s.ioerrno) in (0, Base.UV_ENOENT, Base.UV_ENOTDIR, Base.UV_EINVAL) ? s :
+    _uv_error(string("stat(", repr(s.desc), ")"), s.ioerrno)
 
 macro stat_call(sym, arg1type, arg)
     return quote

--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -488,11 +488,10 @@ end
 
 function getproperty(fdw::FDWatcher, s::Symbol)
     # support deprecated field names
-    s === :readable && return fdw.mask.readable
-    s === :writable && return fdw.mask.writable
+    s === :readable && return getfield(fdw, :mask).readable
+    s === :writable && return getfield(fdw, :mask).writable
     return getfield(fdw, s)
 end
-
 
 close(t::_FDWatcher, mask::FDEvent) = close(t, mask.readable, mask.writable)
 function close(t::_FDWatcher, readable::Bool, writable::Bool)

--- a/test/file.jl
+++ b/test/file.jl
@@ -2165,3 +2165,5 @@ end
     @test dstat.total < 32PB
     @test dstat.used + dstat.available == dstat.total
 end
+
+@test Base.infer_return_type(stat, (String,)) == Base.Filesystem.StatStruct


### PR DESCRIPTION
Make sure that its return type is inferred to be `String`. Allows JET to not report false positive errors from `@report_call Downloads.download(::String)`