### PR TITLE
Empty NamedTuple definitions for get to appease JET

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -382,8 +382,10 @@ end
 keys(nt::NamedTuple{names}) where {names} = names::Tuple{Vararg{Symbol}}
 values(nt::NamedTuple) = Tuple(nt)
 haskey(nt::NamedTuple, key::Union{Integer, Symbol}) = isdefined(nt, key)
+get(::NamedTuple{}, key::Union{Integer, Symbol}, default) = default
 get(nt::NamedTuple, key::Union{Integer, Symbol}, default) = isdefined(nt, key) ? getfield(nt, key) : default
 get(f::Callable, nt::NamedTuple, key::Union{Integer, Symbol}) = isdefined(nt, key) ? getfield(nt, key) : f()
+get(f::Callable, ::NamedTuple{}, key::Union{Integer, Symbol}) = f()
 tail(t::NamedTuple{names}) where names = NamedTuple{tail(names::Tuple)}(t)
 front(t::NamedTuple{names}) where names = NamedTuple{front(names::Tuple)}(t)
 reverse(nt::NamedTuple) = NamedTuple{reverse(keys(nt))}(reverse(values(nt)))


### PR DESCRIPTION
Without these, we end up with JET errors like:

```
┌ get(f::StructUtils.var"#31#33", nt::@NamedTuple{}, key::Int64) @ Base ./namedtuple.jl:389
 │ invalid builtin function call: Base.getfield(nt::@NamedTuple{}, key::Int64)
```

I'm no expert in JET, and not sure if there are other simpler ways to fix this kind of thing, but it didn't seem like any assertion would work (can't assert that a NamedTuple has at least 1 key). Or because the `isdefined` on NamedTuple doesn't provide enough guarantee that `nt` is then definitely not empty? cc: @aviatesk 