### PR TITLE
Tracy: annotate timings in `JIT_Total` zone with function names

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2027,6 +2027,13 @@ void JuliaOJIT::addModule(orc::ThreadSafeModule TSM)
     TSM = (*JITPointers)(std::move(TSM));
     auto Lock = TSM.getContext().getLock();
     Module &M = *TSM.getModuleUnlocked();
+
+    for (auto &f : M) {
+        if (!f.isDeclaration()){
+            jl_timing_puts(JL_TIMING_DEFAULT_BLOCK, f.getName().str().c_str());
+        }
+    }
+
     // Treat this as if one of the passes might contain a safepoint
     // even though that shouldn't be the case and might be unwise
     Expected<std::unique_ptr<MemoryBuffer>> Obj = CompileLayer.getCompiler()(M);


### PR DESCRIPTION
Suggestion by @topolarity while we were finding functions that took way too long to JIT.  This change corresponds to the `expand_forms_2` annotations in the image below.

<img width="1536" alt="a" src="https://github.com/user-attachments/assets/f6754b94-d70d-42ea-9e61-2bf8beedc419" />
