### PR TITLE
InteractiveUtils: support syntax found in stacktraces for introspection macros

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,7 +47,7 @@ Standard library changes
 
 #### InteractiveUtils
 
-* Introspection utilities such as `@code_typed`, `@which` and `@edit` now accept type annotations as substitutes for values, recognizing forms such as `f(1, ::Float64, 3)` or even `sum(::Vector{T}; init = ::T) where {T<:Real}` ([#57909]).
+* Introspection utilities such as `@code_typed`, `@which` and `@edit` now accept type annotations as substitutes for values, recognizing forms such as `f(1, ::Float64, 3)` or even `sum(::Vector{T}; init = ::T) where {T<:Real}`. Type-annotated variables as in `f(val::Int; kw::Float64)` are not evaluated if the type annotation provides the necessary information, making this syntax compatible with signatures found in stacktraces ([#57909], [#58222]).
 
 External dependencies
 ---------------------

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -337,6 +337,7 @@ end
     @test (@which (::Base.RefValue{Int}).x = ::Int).name === :setproperty!
     @test (@which (::Float64)^2).name === :literal_pow
     @test (@which [::Int]).name === :vect
+    @test (@which [undef_var::Int]).name === :vect
     @test (@which [::Int 2]).name === :hcat
     @test (@which [::Int; 2]).name === :vcat
     @test (@which Int[::Int 2]).name === :typed_hcat
@@ -345,6 +346,7 @@ end
     @test (@which Int[::Int 2;3 (::Int)]).name === :typed_hvcat
     @test (@which (::Vector{Float64})').name === :adjoint
     @test (@which "$(::Symbol) is a symbol").sig === Tuple{typeof(string), Vararg{Union{Char, String, Symbol}}}
+    @test (@which +(some_x::Int, some_y::Float64)).name === :+
     @test (@which +(::Any, ::Any, ::Any, ::Any...)).sig === Tuple{typeof(+), Any, Any, Any, Vararg{Any}}
     @test (@which +(::Any, ::Any, ::Any, ::Vararg{Any})).sig === Tuple{typeof(+), Any, Any, Any, Vararg{Any}}
     n = length(@code_typed +(::Float64, ::Vararg{Float64}))
@@ -358,6 +360,7 @@ end
     @test (@which +(::T, ::T) where {T<:Number}).sig === Tuple{typeof(+), T, T} where {T<:Number}
     @test (@which round(::Float64; digits=3)).name === :round
     @test (@which round(1.2; digits = ::Int)).name === :round
+    @test (@which round(1.2; digits::Int)).name === :round
     @test (@code_typed round(::T; digits = ::T) where {T<:Float64})[2] === Union{}
     @test (@code_typed round(::T; digits = ::T) where {T<:Int})[2] === Float64
     base = 10


### PR DESCRIPTION
Continuing the work done at #57909, this PR adds support for the following syntax:
```julia
@code_typed f(some_undef_var::Int) # some_undef_var is ignored, only the annotation is used
@code_typed f(; x::Int) # same here, the name is used but not the value
```
This should allow us to copy and paste signatures found in stacktraces, such as
```julia
julia> f(x; y = 3) = error()
f (generic function with 1 method)

julia> f(1)
ERROR: 
Stacktrace:
 [1] error()
   @ Base ./error.jl:45
 [2] f(x::Int64; y::Int64)
   @ Main ./REPL[40]:1
 [3] top-level scope
   @ REPL[41]:1
   
julia> asin(-2)
ERROR: DomainError with -2.0:
asin(x) is not defined for |x| > 1.
Stacktrace:
 [1] asin_domain_error(x::Float64)
   @ Base.Math ./special/trig.jl:429
 [2] asin(x::Float64)
   @ Base.Math ./special/trig.jl:443
```

where any function call may be copied and pasted into `@code_typed`, `@edit` etc as is, provided that the function and argument types are defined in the active module (i.e. `Main`).

Thanks @topolarity for the idea.