### PR TITLE
Mark `fieldindex` as public

### DIFF
--- a/base/public.jl
+++ b/base/public.jl
@@ -66,6 +66,7 @@ public
     isexported,
     ispublic,
     remove_linenums!,
+    fieldindex,
 
 # Operators
     operator_associativity,


### PR DESCRIPTION
This is a useful function which has an old docstring so should probably be public. Otherwise, in order to go from a field's symbol to the field index (which is required for exported functions like `fieldtype`, and `fieldoffset`), you need to generate big messy if-else loopnests. 