### PR TITLE
Refactor julia initialization by finding and loading the sysimage earlier

### DIFF
--- a/doc/src/manual/embedding.md
+++ b/doc/src/manual/embedding.md
@@ -54,7 +54,7 @@ linking against `libjulia`.
 The first thing that must be done before calling any other Julia C function is to
 initialize Julia. This is done by calling `jl_init`, which tries to automatically determine
 Julia's install location. If you need to specify a custom location, or specify which system
-image to load, use `jl_init_with_image` instead.
+image to load, use `jl_init_with_image_file` or `jl_init_with_image_handle` instead.
 
 The second statement in the test program evaluates a Julia statement using a call to `jl_eval_string`.
 

--- a/src/init.c
+++ b/src/init.c
@@ -834,7 +834,7 @@ static void julia_init(jl_image_buf_t sysimage)
     // initialize many things, in no particular order
     // but generally running from simple platform things to optional
     // configuration features
-    jl_init_timing();
+
     // Make sure we finalize the tls callback before starting any threads.
     (void)jl_get_pgcstack();
 
@@ -946,6 +946,7 @@ static void julia_init(jl_image_buf_t sysimage)
 // This function is responsible for loading the image and initializing paths in jl_options
 JL_DLLEXPORT void jl_load_image_and_init(JL_IMAGE_SEARCH rel, const char* julia_bindir, void *handle) {
     libsupport_init();
+    jl_init_timing();
 
     jl_resolve_sysimg_location(rel, julia_bindir);
 

--- a/src/init.c
+++ b/src/init.c
@@ -642,10 +642,16 @@ static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel, const char* julia_bi
     jl_options.julia_bin = (char*)malloc_s(path_size + 1);
     memcpy((char*)jl_options.julia_bin, free_path, path_size);
     ((char*)jl_options.julia_bin)[path_size] = '\0';
-    if (!julia_bindir) {
+    if (julia_bindir == NULL) {
         jl_options.julia_bindir = getenv("JULIA_BINDIR");
         if (!jl_options.julia_bindir) {
-            jl_options.julia_bindir = dirname(free_path);
+#ifdef _OS_WINDOWS_
+            jl_options.julia_bindir = strdup(jl_get_libdir());
+#else
+            int written = asprintf((char**)&jl_options.julia_bindir, "%s" PATHSEPSTRING ".." PATHSEPSTRING "%s", jl_get_libdir(), "bin");
+            if (written < 0)
+                abort(); // unexpected: memory allocation failed
+#endif
         }
     } else {
         jl_options.julia_bindir = julia_bindir;

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -235,9 +235,11 @@
     XX(jl_hrtime) \
     XX(jl_idtable_rehash) \
     XX(jl_init) \
+    XX(jl_init_) \
     XX(jl_init_options) \
     XX(jl_init_restored_module) \
-    XX(jl_init_with_image) \
+    XX(jl_init_with_image_file) \
+    XX(jl_init_with_image_handle) \
     XX(jl_install_sigint_handler) \
     XX(jl_instantiate_type_in_env) \
     XX(jl_instantiate_unionall) \

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -26,11 +26,13 @@ extern "C" {
 #include <fenv.h>
 #endif
 
+static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel, const char* julia_bindir);
+
 /**
  * @brief Check if Julia is already initialized.
  *
- * Determine if Julia has been previously initialized
- * via `jl_init` or `jl_init_with_image`.
+ * Determine if Julia has been previously initialized via `jl_init` or
+ * `jl_init_with_image_file` or `jl_init_with_image_handle`.
  *
  * @return Returns 1 if Julia is initialized, 0 otherwise.
  */
@@ -68,13 +70,18 @@ JL_DLLEXPORT void jl_set_ARGS(int argc, char **argv)
     }
 }
 
-JL_DLLEXPORT void jl_init_with_handle(void *handle) {
+JL_DLLEXPORT void jl_init_with_image_handle(void *handle) {
     if (jl_is_initialized())
         return;
+
     const char *image_path = jl_pathname_for_handle(handle);
-    jl_enter_threaded_region(); // This should maybe be behind a lock, but it's harmless if done twice
     jl_options.image_file = image_path;
-    jl_load_image_and_init(JL_IMAGE_JULIA_HOME, NULL, handle);
+
+    jl_resolve_sysimg_location(JL_IMAGE_JULIA_HOME, NULL);
+    jl_image_buf_t sysimage = jl_set_sysimg_so(handle);
+
+    jl_init_(sysimage);
+
     jl_exception_clear();
 }
 /**
@@ -91,8 +98,8 @@ JL_DLLEXPORT void jl_init_with_handle(void *handle) {
  * @param image_path The path of a system image file (*.so). Interpreted as relative to julia_bindir
  *                   or the default Julia home directory if not an absolute path.
  */
-JL_DLLEXPORT void jl_init_with_image(const char *julia_bindir,
-                                     const char *image_path)
+JL_DLLEXPORT void jl_init_with_image_file(const char *julia_bindir,
+                                          const char *image_path)
 {
     if (jl_is_initialized())
         return;
@@ -100,7 +107,12 @@ JL_DLLEXPORT void jl_init_with_image(const char *julia_bindir,
         jl_options.image_file = image_path;
     else
         jl_options.image_file = jl_get_default_sysimg_path();
-    jl_load_image_and_init(JL_IMAGE_JULIA_HOME, julia_bindir, NULL);
+
+    jl_resolve_sysimg_location(JL_IMAGE_JULIA_HOME, julia_bindir);
+    jl_image_buf_t sysimage = jl_preload_sysimg(jl_options.image_file);
+
+    jl_init_(sysimage);
+
     jl_exception_clear();
 }
 
@@ -112,7 +124,7 @@ JL_DLLEXPORT void jl_init_with_image(const char *julia_bindir,
  */
 JL_DLLEXPORT void jl_init(void)
 {
-    jl_init_with_image(NULL, jl_get_default_sysimg_path());
+    jl_init_with_image_file(NULL, jl_get_default_sysimg_path());
 }
 
 static void _jl_exception_clear(jl_task_t *ct) JL_NOTSAFEPOINT
@@ -1097,7 +1109,15 @@ JL_DLLEXPORT int jl_repl_entrypoint(int argc, char *argv[])
 #endif
         jl_error("Failed to self-execute");
     }
-    jl_load_image_and_init(jl_options.image_file_specified ? JL_IMAGE_CWD : JL_IMAGE_JULIA_HOME, NULL, NULL);
+
+    JL_IMAGE_SEARCH rel = jl_options.image_file_specified ? JL_IMAGE_CWD : JL_IMAGE_JULIA_HOME;
+    jl_resolve_sysimg_location(rel, NULL);
+    jl_image_buf_t sysimage = { JL_IMAGE_KIND_NONE };
+    if (jl_options.image_file)
+        sysimage = jl_preload_sysimg(jl_options.image_file);
+
+    jl_init_(sysimage);
+
     if (lisp_prompt) {
         jl_current_task->world_age = jl_get_world_counter();
         jl_lisp_prompt();
@@ -1106,6 +1126,180 @@ JL_DLLEXPORT int jl_repl_entrypoint(int argc, char *argv[])
     int ret = true_main(argc, (char**)new_argv);
     jl_atexit_hook(ret);
     return ret;
+}
+
+// create an absolute-path copy of the input path format string
+// formed as `joinpath(replace(pwd(), "%" => "%%"), in)`
+// unless `in` starts with `%`
+static const char *absformat(const char *in)
+{
+    if (in[0] == '%' || jl_isabspath(in))
+        return in;
+    // get an escaped copy of cwd
+    size_t path_size = JL_PATH_MAX;
+    char path[JL_PATH_MAX];
+    if (uv_cwd(path, &path_size)) {
+        jl_error("fatal error: unexpected error while retrieving current working directory");
+    }
+    size_t sz = strlen(in) + 1;
+    size_t i, fmt_size = 0;
+    for (i = 0; i < path_size; i++)
+        fmt_size += (path[i] == '%' ? 2 : 1);
+    char *out = (char*)malloc_s(fmt_size + 1 + sz);
+    fmt_size = 0;
+    for (i = 0; i < path_size; i++) { // copy-replace pwd portion
+        char c = path[i];
+        out[fmt_size++] = c;
+        if (c == '%')
+            out[fmt_size++] = '%';
+    }
+    out[fmt_size++] = PATHSEPSTRING[0]; // path sep
+    memcpy(out + fmt_size, in, sz); // copy over format, including nul
+    return out;
+}
+
+static char *absrealpath(const char *in, int nprefix)
+{ // compute an absolute realpath location, so that chdir doesn't change the file reference
+  // ignores (copies directly over) nprefix characters at the start of abspath
+#ifndef _OS_WINDOWS_
+    char *out = realpath(in + nprefix, NULL);
+    if (out) {
+        if (nprefix > 0) {
+            size_t sz = strlen(out) + 1;
+            char *cpy = (char*)malloc_s(sz + nprefix);
+            memcpy(cpy, in, nprefix);
+            memcpy(cpy + nprefix, out, sz);
+            free(out);
+            out = cpy;
+        }
+    }
+    else {
+        size_t sz = strlen(in + nprefix) + 1;
+        if (in[nprefix] == PATHSEPSTRING[0]) {
+            out = (char*)malloc_s(sz + nprefix);
+            memcpy(out, in, sz + nprefix);
+        }
+        else {
+            size_t path_size = JL_PATH_MAX;
+            char *path = (char*)malloc_s(JL_PATH_MAX);
+            if (uv_cwd(path, &path_size)) {
+                jl_error("fatal error: unexpected error while retrieving current working directory");
+            }
+            out = (char*)malloc_s(path_size + 1 + sz + nprefix);
+            memcpy(out, in, nprefix);
+            memcpy(out + nprefix, path, path_size);
+            out[nprefix + path_size] = PATHSEPSTRING[0];
+            memcpy(out + nprefix + path_size + 1, in + nprefix, sz);
+            free(path);
+        }
+    }
+#else
+    // GetFullPathName intentionally errors if given an empty string so manually insert `.` to invoke cwd
+    char *in2 = (char*)malloc_s(JL_PATH_MAX);
+    if (strlen(in) - nprefix == 0) {
+        memcpy(in2, in, nprefix);
+        in2[nprefix] = '.';
+        in2[nprefix+1] = '\0';
+        in = in2;
+    }
+    DWORD n = GetFullPathName(in + nprefix, 0, NULL, NULL);
+    if (n <= 0) {
+        jl_error("fatal error: jl_options.image_file path too long or GetFullPathName failed");
+    }
+    char *out = (char*)malloc_s(n + nprefix);
+    DWORD m = GetFullPathName(in + nprefix, n, out + nprefix, NULL);
+    if (n != m + 1) {
+        jl_error("fatal error: jl_options.image_file path too long or GetFullPathName failed");
+    }
+    memcpy(out, in, nprefix);
+    free(in2);
+#endif
+    return out;
+}
+
+static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel, const char* julia_bindir)
+{
+    libsupport_init();
+    jl_init_timing();
+
+    // this function resolves the paths in jl_options to absolute file locations as needed
+    // and it replaces the pointers to `julia_bindir`, `julia_bin`, `image_file`, and output file paths
+    // it may fail, print an error, and exit(1) if any of these paths are longer than JL_PATH_MAX
+    //
+    // note: if you care about lost memory, you should call the appropriate `free()` function
+    // on the original pointer for each `char*` you've inserted into `jl_options`, after
+    // calling `jl_init_()`
+    char *free_path = (char*)malloc_s(JL_PATH_MAX);
+    size_t path_size = JL_PATH_MAX;
+    if (uv_exepath(free_path, &path_size)) {
+        jl_error("fatal error: unexpected error while retrieving exepath");
+    }
+    if (path_size >= JL_PATH_MAX) {
+        jl_error("fatal error: jl_options.julia_bin path too long");
+    }
+    jl_options.julia_bin = (char*)malloc_s(path_size + 1);
+    memcpy((char*)jl_options.julia_bin, free_path, path_size);
+    ((char*)jl_options.julia_bin)[path_size] = '\0';
+    if (julia_bindir == NULL) {
+        jl_options.julia_bindir = getenv("JULIA_BINDIR");
+        if (!jl_options.julia_bindir) {
+#ifdef _OS_WINDOWS_
+            jl_options.julia_bindir = strdup(jl_get_libdir());
+#else
+            int written = asprintf((char**)&jl_options.julia_bindir, "%s" PATHSEPSTRING ".." PATHSEPSTRING "%s", jl_get_libdir(), "bin");
+            if (written < 0)
+                abort(); // unexpected: memory allocation failed
+#endif
+        }
+    } else {
+        jl_options.julia_bindir = julia_bindir;
+    }
+    if (jl_options.julia_bindir)
+        jl_options.julia_bindir = absrealpath(jl_options.julia_bindir, 0);
+    free(free_path);
+    free_path = NULL;
+    if (jl_options.image_file) {
+        if (rel == JL_IMAGE_JULIA_HOME && !jl_isabspath(jl_options.image_file)) {
+            // build time path, relative to JULIA_BINDIR
+            free_path = (char*)malloc_s(JL_PATH_MAX);
+            int n = snprintf(free_path, JL_PATH_MAX, "%s" PATHSEPSTRING "%s",
+                             jl_options.julia_bindir, jl_options.image_file);
+            if (n >= JL_PATH_MAX || n < 0) {
+                jl_error("fatal error: jl_options.image_file path too long");
+            }
+            jl_options.image_file = free_path;
+        }
+        if (jl_options.image_file)
+            jl_options.image_file = absrealpath(jl_options.image_file, 0);
+        if (free_path) {
+            free(free_path);
+            free_path = NULL;
+        }
+    }
+    if (jl_options.outputo)
+        jl_options.outputo = absrealpath(jl_options.outputo, 0);
+    if (jl_options.outputji)
+        jl_options.outputji = absrealpath(jl_options.outputji, 0);
+    if (jl_options.outputbc)
+        jl_options.outputbc = absrealpath(jl_options.outputbc, 0);
+    if (jl_options.outputasm)
+        jl_options.outputasm = absrealpath(jl_options.outputasm, 0);
+    if (jl_options.machine_file)
+        jl_options.machine_file = absrealpath(jl_options.machine_file, 0);
+    if (jl_options.output_code_coverage)
+        jl_options.output_code_coverage = absformat(jl_options.output_code_coverage);
+    if (jl_options.tracked_path)
+        jl_options.tracked_path = absrealpath(jl_options.tracked_path, 0);
+
+    const char **cmdp = jl_options.cmds;
+    if (cmdp) {
+        for (; *cmdp; cmdp++) {
+            const char *cmd = *cmdp;
+            if (cmd[0] == 'L') {
+                *cmdp = absrealpath(cmd, 1);
+            }
+        }
+    }
 }
 
 #ifdef __cplusplus

--- a/src/julia.h
+++ b/src/julia.h
@@ -2224,10 +2224,9 @@ typedef struct _jl_image_t jl_image_t;
 
 JL_DLLIMPORT const char *jl_get_libdir(void);
 JL_DLLEXPORT void jl_init(void);
-JL_DLLEXPORT void jl_init_with_image(const char *julia_bindir,
-                                     const char *image_path);
-JL_DLLEXPORT void jl_load_image_and_init(JL_IMAGE_SEARCH rel, const char* julia_bindir, void *handle);
-JL_DLLEXPORT void jl_init_with_handle(void *handle);
+JL_DLLEXPORT void jl_init_with_image_file(const char *julia_bindir,
+                                          const char *image_path);
+JL_DLLEXPORT void jl_init_with_image_handle(void *handle);
 JL_DLLEXPORT const char *jl_get_default_sysimg_path(void);
 JL_DLLEXPORT int jl_is_initialized(void);
 JL_DLLEXPORT void jl_atexit_hook(int status);

--- a/src/julia.h
+++ b/src/julia.h
@@ -2223,10 +2223,11 @@ struct _jl_image_t;
 typedef struct _jl_image_t jl_image_t;
 
 JL_DLLIMPORT const char *jl_get_libdir(void);
-JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel);
 JL_DLLEXPORT void jl_init(void);
 JL_DLLEXPORT void jl_init_with_image(const char *julia_bindir,
                                      const char *image_path);
+JL_DLLEXPORT void jl_load_image_and_init(JL_IMAGE_SEARCH rel, const char* julia_bindir, void *handle);
+JL_DLLEXPORT void jl_init_with_handle(void *handle);
 JL_DLLEXPORT const char *jl_get_default_sysimg_path(void);
 JL_DLLEXPORT int jl_is_initialized(void);
 JL_DLLEXPORT void jl_atexit_hook(int status);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -196,6 +196,7 @@ void JL_UV_LOCK(void);
 extern _Atomic(unsigned) _threadedregion;
 extern _Atomic(uint16_t) io_loop_tid;
 
+JL_DLLEXPORT void jl_init_(jl_image_buf_t sysimage);
 JL_DLLEXPORT void jl_enter_threaded_region(void);
 JL_DLLEXPORT void jl_exit_threaded_region(void);
 int jl_running_under_rr(int recheck) JL_NOTSAFEPOINT;

--- a/src/threading.c
+++ b/src/threading.c
@@ -461,7 +461,7 @@ JL_DLLEXPORT jl_gcframe_t **jl_autoinit_and_adopt_thread(void)
                             "       (this should not happen, please file a bug report)\n");
             exit(1);
         }
-        jl_init_with_handle(handle);
+        jl_init_with_image_handle(handle);
         return &jl_get_current_task()->gcstack;
     }
 

--- a/src/threading.c
+++ b/src/threading.c
@@ -461,9 +461,7 @@ JL_DLLEXPORT jl_gcframe_t **jl_autoinit_and_adopt_thread(void)
                             "       (this should not happen, please file a bug report)\n");
             exit(1);
         }
-        const char *image_path = jl_pathname_for_handle(handle);
-        jl_enter_threaded_region(); // This should maybe be behind a lock, but it's harmless if done twice
-        jl_init_with_image(NULL, image_path);
+        jl_init_with_handle(handle);
         return &jl_get_current_task()->gcstack;
     }
 

--- a/test/trimming/init.c
+++ b/test/trimming/init.c
@@ -1,9 +1,11 @@
+#define _GNU_SOURCE
+#include <dlfcn.h>
 #include <julia.h>
 
 __attribute__((constructor)) void static_init(void)
 {
     if (jl_is_initialized())
         return;
-    julia_init(JL_IMAGE_IN_MEMORY);
+    jl_init_with_image_handle((void *)RTLD_DEFAULT);
     jl_exception_clear();
 }


### PR DESCRIPTION
This changes the order of initialization slightly. The goal is to be able to initialize executables and share libraries without having to explicitly call init functions.

This still doesn't address the thread safety