### PR TITLE
add `TYPE_CACHE_INSERT` to the disabled frequent event list

### DIFF
--- a/src/timing.c
+++ b/src/timing.c
@@ -194,6 +194,7 @@ void jl_init_timing(void)
     error |= jl_timing_set_enable("METHOD_LOOKUP_FAST", 0);
     error |= jl_timing_set_enable("AST_COMPRESS", 0);
     error |= jl_timing_set_enable("AST_UNCOMPRESS", 0);
+    error |= jl_timing_set_enable("TYPE_CACHE_INSERT", 0);
     if (error)
         jl_error("invalid timing subsystem encountered in jl_init_timing");
 #endif


### PR DESCRIPTION
these are often sub 100 ns and generate a very large number of zones