### PR TITLE
Use `checked_length` when collecting ranges

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -900,3 +900,9 @@ function bitreverse(x::BitInteger)
     z = ((z & mask4) << 4) | ((z >> 4) & mask4)
     return bswap(z) % typeof(x)
 end
+
+# length check when concatenating ranges.
+# Defined here to use BitInteger for dispatch.
+function _maybe_checked_length(ra::OrdinalRange{<:BitInteger,<:BitInteger})
+    checked_length(ra)
+end

--- a/base/range.jl
+++ b/base/range.jl
@@ -1380,10 +1380,11 @@ promote_rule(::Type{LinRange{A,L}}, b::Type{StepRangeLen{T2,R2,S2,L2}}) where {A
 
 ## concatenation ##
 
+_maybe_checked_length(ra) = length(ra)
 function vcat(rs::AbstractRange{T}...) where T
     n::Int = 0
     for ra in rs
-        n += length(ra)
+        n += _maybe_checked_length(ra)
     end
     a = Vector{T}(undef, n)
     i = 1
@@ -1400,7 +1401,7 @@ end
 # See https://github.com/JuliaLang/julia/pull/27302
 # Similarly, collect(r::AbstractRange) uses iteration
 function Array{T,1}(r::AbstractRange{T}) where {T}
-    a = Vector{T}(undef, length(r))
+    a = Vector{T}(undef, _maybe_checked_length(r))
     i = 1
     for x in r
         @inbounds a[i] = x

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2817,3 +2817,9 @@ end
     @test StepRange(r) == r
     @test StepRange(r) isa StepRange{Date,Day}
 end
+
+@testset "collect with oversized range" begin
+    r = typemin(Int):typemax(Int)
+    @test_throws OverflowError collect(r)
+    @test_throws OverflowError vcat(r)
+end


### PR DESCRIPTION
This improves the status quo slightly, as it avoids a segfault if the length computation for the ranges overflow. This is only possible for known `Integer` types in `Base`, for which a `checked_length` method exists. However, this is enough to address common cases.

After this,
```julia
julia> r = typemin(Int):typemax(Int)
-9223372036854775808:9223372036854775807

julia> collect(r)
ERROR: OverflowError: 9223372036854775807 - -9223372036854775808 overflowed for type Int64
```
Fixes https://github.com/JuliaLang/julia/issues/58245

The performance of `collect` seems unaffected by this change, as this check should be inexpensive compared to the following `setindex!`.