### PR TITLE
Documentation: Remove warning that nonstandard primitive type sizes may reveal LLVM bugs

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -301,7 +301,7 @@ a name. A primitive type can optionally be declared to be a subtype of some supe
 is omitted, then the type defaults to having `Any` as its immediate supertype. The declaration
 of [`Bool`](@ref) above therefore means that a boolean value takes eight bits to store, and has
 [`Integer`](@ref) as its immediate supertype. Currently, only sizes that are multiples of
-8 bits are supported and you are likely to experience LLVM bugs with sizes other than those used above.
+8 bits are supported.
 Therefore, boolean values, although they really need just a single bit, cannot be declared to be any
 smaller than eight bits.
 


### PR DESCRIPTION
Only primitive types which are a multiple of 8 bits in size can be constructed. Therefore, the documentation should not speculate about possible bugs in other non-reachable cases.

Additionally, it's not clear whether these LLVM bugs still exist now that C allows all integers sizes.