### PR TITLE
Core._eval_import: don't throw away "from" path

### DIFF
--- a/base/module.jl
+++ b/base/module.jl
@@ -107,15 +107,14 @@ function _eval_import(imported::Bool, to::Module, from::Union{Expr, Nothing}, pa
         elseif path.head !== :.
             fail()
         end
-        old_from = from
-        from, name = eval_import_path(to, from, path, keyword)
+        m, name = eval_import_path(to, from, path, keyword)
 
         if name !== nothing
             asname = asname === nothing ? name : asname
             check_macro_rename(name, asname, keyword)
-            Core._import(to, from, asname, name, imported)
+            Core._import(to, m, asname, name, imported)
         else
-            Core._import(to, from, asname === nothing ? nameof(from) : asname)
+            Core._import(to, m, asname === nothing ? nameof(m) : asname)
         end
     end
 end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1737,3 +1737,15 @@ module M57965
     import Random as R
 end
 @test M57965.R === Base.require(M57965, :Random)
+
+# #58272 - _eval_import accidentally reuses evaluated "from" path
+module M58272_1
+    const x = 1
+    module M58272_2
+        const y = 3
+        const x = 2
+    end
+end
+module M58272_to end
+@eval M58272_to import ..M58272_1: M58272_2.y, x
+@test @eval M58272_to x === 1


### PR DESCRIPTION
Fixes accidental variable reuse that caused #58272