### PR TITLE
deps: consistently use `cmake -B` whenever dep uses CMake

### DIFF
--- a/deps/BOLT.mk
+++ b/deps/BOLT.mk
@@ -80,9 +80,7 @@ $(BOLT_BUILDDIR)/build-configured: $(SRCCACHE)/$(BOLT_SRC_DIR)/source-extracted
 
 $(BOLT_BUILDDIR)/build-compiled: $(BOLT_BUILDDIR)/build-configured
 	cd $(BOLT_BUILDDIR) && \
-		$(if $(filter $(CMAKE_GENERATOR),make), \
-		  $(MAKE), \
-		  $(CMAKE) --build . --target bolt)
+		$(CMAKE) --build . --target bolt
 	echo 1 > $@
 
 $(BOLT_BUILDDIR)/build-checked: $(BOLT_BUILDDIR)/build-compiled
@@ -102,7 +100,7 @@ $(eval $(call staged-install, \
 
 clean-bolt:
 	-rm -f $(BOLT_BUILDDIR)/build-configured $(BOLT_BUILDDIR)/build-compiled
-	-$(MAKE) -C $(BOLT_BUILDDIR) clean
+	-$(CMAKE) -B $(BOLT_BUILDDIR) clean
 
 get-bolt: $(BOLT_SRC_FILE)
 extract-bolt: $(SRCCACHE)/$(BOLT_SRC_DIR)/source-extracted

--- a/deps/ittapi.mk
+++ b/deps/ittapi.mk
@@ -14,7 +14,7 @@ $(BUILDDIR)/$(ITTAPI_SRC_DIR)/build-configured: $(SRCCACHE)/$(ITTAPI_SRC_DIR)/so
 	echo 1 > $@
 
 $(BUILDDIR)/$(ITTAPI_SRC_DIR)/build-compiled: $(BUILDDIR)/$(ITTAPI_SRC_DIR)/build-configured
-	$(MAKE) -C $(dir $<)
+	$(CMAKE) -B $(dir $<)
 	echo 1 > $@
 
 define ITTAPI_INSTALL

--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -55,12 +55,12 @@ $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: $(LIBGIT2_SRC_PATH)/source-extr
 	echo 1 > $@
 
 $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-compiled: $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured
-	$(MAKE) -C $(dir $<)
+	$(CMAKE) -B $(dir $<)
 	echo 1 > $@
 
 $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-checked: $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
-	$(MAKE) -C $(dir $@) test
+	$(CMAKE) -B $(dir $@) test
 endif
 	echo 1 > $@
 
@@ -81,7 +81,7 @@ $(eval $(call staged-install, \
 clean-libgit2:
 	-rm -f $(build_datarootdir)/julia/cert.pem
 	-rm -f $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-compiled
-	-$(MAKE) -C $(BUILDDIR)/$(LIBGIT2_SRC_DIR) clean
+	-$(CMAKE) -B $(BUILDDIR)/$(LIBGIT2_SRC_DIR) clean
 
 get-libgit2: $(LIBGIT2_SRC_FILE)
 extract-libgit2: $(SRCCACHE)/$(LIBGIT2_SRC_DIR)/source-extracted

--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -41,12 +41,12 @@ $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured: $(LIBSSH2_SRC_PATH)/source-extr
 	echo 1 > $@
 
 $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-compiled: $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured
-	$(MAKE) -C $(dir $<)
+	$(CMAKE) -B $(dir $<)
 	echo 1 > $@
 
 $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-checked: $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
-	$(MAKE) -C $(dir $@) test
+	$(CMAKE) -B $(dir $@) test
 endif
 	echo 1 > $@
 
@@ -57,7 +57,7 @@ $(eval $(call staged-install, \
 
 clean-libssh2:
 	-rm -f $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-compiled
-	-$(MAKE) -C $(BUILDDIR)/$(LIBSSH2_SRC_DIR) clean
+	-$(CMAKE) -B $(BUILDDIR)/$(LIBSSH2_SRC_DIR) clean
 
 
 get-libssh2: $(LIBSSH2_SRC_FILE)

--- a/deps/libsuitesparse.mk
+++ b/deps/libsuitesparse.mk
@@ -59,8 +59,8 @@ $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled: | $(build_prefix)/
 
 $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/source-patched
 	cd $(dir $<) && $(CMAKE) . $(LIBSUITESPARSE_CMAKE_FLAGS)
-	$(MAKE) -C $(dir $<)
-	$(MAKE) -C $(dir $<) install
+	$(CMAKE) -B $(dir $<)
+	$(CMAKE) -B $(dir $<) install
 	echo 1 > $@
 
 ifeq ($(OS),WINNT)
@@ -70,7 +70,7 @@ LIBSUITESPARSE_SHLIB_ENV:=LD_LIBRARY_PATH="$(build_shlibdir)"
 endif
 $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-checked: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled
 	for PROJ in $(shell echo $(subst ;, ,$(LIBSUITESPARSE_PROJECTS))); do \
-		$(LIBSUITESPARSE_SHLIB_ENV) $(MAKE) -C $(dir $<)$${PROJ} default $(LIBSUITESPARSE_MFLAGS) || exit 1; \
+		$(LIBSUITESPARSE_SHLIB_ENV) $(CMAKE) -B $(dir $<)$${PROJ} default $(LIBSUITESPARSE_MFLAGS) || exit 1; \
 	done
 	echo 1 > $@
 
@@ -83,7 +83,7 @@ clean-libsuitesparse: uninstall-libsuitesparse
 	-rm -f $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled
 	-rm -fr $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/lib
 	-rm -fr $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/include
-	-$(MAKE) -C $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER) clean
+	-$(CMAKE) -B $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER) clean
 
 distclean-libsuitesparse:
 	rm -rf $(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER).tar.gz \

--- a/deps/libtracyclient.mk
+++ b/deps/libtracyclient.mk
@@ -55,9 +55,7 @@ $(LIBTRACYCLIENT_BUILDDIR)/build-configured: $(LIBTRACYCLIENT_BUILDDIR)/libTracy
 
 $(LIBTRACYCLIENT_BUILDDIR)/build-compiled: $(LIBTRACYCLIENT_BUILDDIR)/build-configured
 	cd $(LIBTRACYCLIENT_BUILDDIR) && \
-		$(if $(filter $(CMAKE_GENERATOR),make), \
-		  $(MAKE), \
-		  $(CMAKE) --build .)
+		$(CMAKE) --build .
 	echo 1 > $@
 
 $(eval $(call staged-install, \
@@ -67,7 +65,7 @@ $(eval $(call staged-install, \
 
 clean-libtracyclient:
 	rm -rf $(LIBTRACYCLIENT_BUILDDIR)/build-configured $(LIBTRACYCLIENT_BUILDDIR)/build-compiled
-	-$(MAKE) -C $(LIBTRACYCLIENT_BUILDDIR) clean
+	-$(CMAKE) -B $(LIBTRACYCLIENT_BUILDDIR) clean
 
 get-libtracyclient: $(LIBTRACYCLIENT_SRC_FILE)
 extract-libtracyclient: $(LIBTRACYCLIENT_BUILDDIR)/source-extracted

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -271,9 +271,7 @@ $(LLVM_BUILDDIR_withtype)/build-configured: $(SRCCACHE)/$(LLVM_SRC_DIR)/source-e
 
 $(LLVM_BUILDDIR_withtype)/build-compiled: $(LLVM_BUILDDIR_withtype)/build-configured
 	cd $(LLVM_BUILDDIR_withtype) && \
-		$(if $(filter $(CMAKE_GENERATOR),make), \
-		  $(MAKE), \
-		  $(CMAKE) --build .)
+		$(CMAKE) --build .
 	echo 1 > $@
 
 $(LLVM_BUILDDIR_withtype)/build-checked: $(LLVM_BUILDDIR_withtype)/build-compiled
@@ -304,7 +302,7 @@ $(eval $(call staged-install, \
 
 clean-llvm:
 	-rm -f $(LLVM_BUILDDIR_withtype)/build-configured $(LLVM_BUILDDIR_withtype)/build-compiled
-	-$(MAKE) -C $(LLVM_BUILDDIR_withtype) clean
+	-$(CMAKE) -B $(LLVM_BUILDDIR_withtype) clean
 
 get-llvm: $(LLVM_SRC_FILE)
 extract-llvm: $(SRCCACHE)/$(LLVM_SRC_DIR)/source-extracted

--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -53,12 +53,12 @@ $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured: $(SRCCACHE)/libunwind-$(UN
 	echo 1 > $@
 
 $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled: $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured
-	$(MAKE) -C $(dir $<)
+	$(CMAKE) -B $(dir $<)
 	echo 1 > $@
 
 $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-checked: $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
-	$(MAKE) -C $(dir $@) check
+	$(CMAKE) -B $(dir $@) check
 endif
 	echo 1 > $@
 
@@ -68,7 +68,7 @@ $(eval $(call staged-install, \
 
 clean-unwind:
 	-rm -f $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled
-	-$(MAKE) -C $(BUILDDIR)/libunwind-$(UNWIND_VER) clean
+	-$(CMAKE) -B $(BUILDDIR)/libunwind-$(UNWIND_VER) clean
 
 distclean-unwind:
 	rm -rf $(SRCCACHE)/libunwind-$(UNWIND_VER).tar.gz \
@@ -129,9 +129,7 @@ $(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER)/build-configured: $(SRCCACHE)/llvm-proj
 
 $(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER)/build-compiled: $(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER)/build-configured
 	cd $(dir $<) && \
-	$(if $(filter $(CMAKE_GENERATOR),make), \
-		  $(MAKE), \
-		  $(CMAKE) --build . --target unwind)
+	$(CMAKE) --build . --target unwind
 	echo 1 > $@
 
 LIBUNWIND_INSTALL = \
@@ -146,7 +144,7 @@ $(eval $(call staged-install, \
 clean-llvmunwind:
 	-rm -f $(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER)/build-configured $(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER)/build-compiled
 	rm -rf $(build_includedir)/mach-o/ $(build_includedir)/unwind.h $(build_includedir)/libunwind.h
-	-$(MAKE) -C $(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER) clean
+	-$(CMAKE) -B $(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER) clean
 
 distclean-llvmunwind:
 	rm -rf $(SRCCACHE)/llvm-project-$(LLVMUNWIND_VER).tar.xz \

--- a/deps/zlib.mk
+++ b/deps/zlib.mk
@@ -14,7 +14,7 @@ $(BUILDDIR)/$(ZLIB_SRC_DIR)/build-configured: $(SRCCACHE)/$(ZLIB_SRC_DIR)/source
 	echo 1 > $@
 
 $(BUILDDIR)/$(ZLIB_SRC_DIR)/build-compiled: $(BUILDDIR)/$(ZLIB_SRC_DIR)/build-configured
-	$(MAKE) -C $(dir $<) $(MAKE_COMMON)
+	$(CMAKE) -B $(dir $<) $(MAKE_COMMON)
 	echo 1 > $@
 
 $(eval $(call staged-install, \
@@ -24,7 +24,7 @@ $(eval $(call staged-install, \
 
 clean-zlib:
 	-rm -f $(BUILDDIR)/$(ZLIB_SRC_DIR)/build-configured $(BUILDDIR)/$(ZLIB_SRC_DIR)/build-compiled
-	-$(MAKE) -C $(BUILDDIR)/$(ZLIB_SRC_DIR) clean
+	-$(CMAKE) -B $(BUILDDIR)/$(ZLIB_SRC_DIR) clean
 
 get-zlib: $(ZLIB_SRC_FILE)
 extract-zlib: $(BUILDDIR)/$(ZLIB_SRC_DIR)/source-extracted


### PR DESCRIPTION
There is no point in invoking `make` directly,
`cmake -B` will do that, iff that is the generator that was chosen. But if if was *not*,
then things break. And there is no guarantee
that CMake's default generator *is* Makefiles.

I've previously submitted a patch to do some of this, but in `1.11.4` the ittapi broke down again,
so let's just deal with all of the occurrences so
they stop creeping back in?
