### PR TITLE
add a way to add text to timing zones from julia

### DIFF
--- a/Compiler/src/timing.jl
+++ b/Compiler/src/timing.jl
@@ -1,4 +1,43 @@
 if ccall(:jl_timing_enabled, Cint, ()) != 0
+    have_scoped = isdefined(@__MODULE__, :Base) && isdefined(Base, :ScopedValues)
+    if have_scoped
+        using Base.ScopedValues: ScopedValue
+        const TRACY_CONTEXT = ScopedValue{Ptr{Cvoid}}(C_NULL)
+
+        function _get_current_tracy_block()
+            ctx = TRACY_CONTEXT[]
+            if ctx === C_NULL
+                error("must be called from within a @zone")
+            end
+            return ctx
+        end
+
+        function timing_print(str)
+            ccall(
+                :jl_timing_puts,
+                Cvoid,
+                (Ptr{Cvoid}, Cstring),
+                _get_current_tracy_block(),
+                string(str)
+            )
+        end
+
+        #=
+        macro timing_printf(fmt, args...)
+            esc(:(
+                ccall(
+                    :jl_timing_printf,
+                    Cvoid,
+                    (Ptr{Cvoid}, Cstring, Cstring...),
+                    _get_current_tracy_block(),
+                    $fmt,
+                    $(args...)
+                )
+            ))
+        end
+        =#
+    end
+
     function getzonedexpr(name::Union{Symbol, String}, ex::Expr, func::Symbol, file::Symbol, line::Integer, color::Integer)
         event = RefValue{Ptr{Cvoid}}(C_NULL)
         name = QuoteNode(Symbol(name))
@@ -8,22 +47,28 @@ if ccall(:jl_timing_enabled, Cint, ()) != 0
         # XXX: This buffer must be large enough to store any jl_timing_block_t (runtime-checked)
         buffer = (0, 0, 0, 0, 0, 0, 0)
         buffer_size = Core.sizeof(buffer)
+
+        scope_expr = have_scoped ?
+            :(Base.ScopedValues.Scope(Core.current_scope(), TRACY_CONTEXT => timing_block_ptr)) :
+            nothing
+
         return quote
             if $event[] === C_NULL
                 $event[] = ccall(:_jl_timing_event_create, Ptr{Cvoid},
                                  (Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt8}, Cint, Cint),
                                  :CORE_COMPILER, $name, $func, $file, $line, $color)
             end
-            timing_block = RefValue($buffer)
-            block_ptr = pointer_from_objref(timing_block)
+            local timing_block = RefValue($buffer)
+            local timing_block_ptr = pointer_from_objref(timing_block)
             $(Expr(:gc_preserve, quote
-                ccall(:_jl_timing_block_init, Cvoid, (Ptr{Cvoid}, Csize_t, Ptr{Cvoid}), block_ptr, $buffer_size, $event[])
-                ccall(:_jl_timing_block_start, Cvoid, (Ptr{Cvoid},), block_ptr)
+                ccall(:_jl_timing_block_init, Cvoid, (Ptr{Cvoid}, Csize_t, Ptr{Cvoid}), timing_block_ptr, $buffer_size, $event[])
+                ccall(:_jl_timing_block_start, Cvoid, (Ptr{Cvoid},), timing_block_ptr)
                 $(Expr(:tryfinally,
                     :($(Expr(:escape, ex))),
                     quote
-                        ccall(:_jl_timing_block_end, Cvoid, (Ptr{Cvoid},), block_ptr)
-                    end
+                        ccall(:_jl_timing_block_end, Cvoid, (Ptr{Cvoid},), timing_block_ptr)
+                    end,
+                    :($scope_expr)
                 ))
             end, :timing_block))
         end
@@ -35,4 +80,10 @@ else
     macro zone(name, ex::Expr)
         return esc(ex)
     end
+    timing_print(str) = nothing
+    #=
+    macro timing_printf(fmt, args...)
+        return nothing
+    end
+    =#
 end

--- a/Compiler/src/timing.jl
+++ b/Compiler/src/timing.jl
@@ -75,7 +75,7 @@ if ccall(:jl_timing_enabled, Cint, ()) != 0
     macro zone(name, ex::Expr)
         return getzonedexpr(name, ex, :unknown_julia_function, __source__.file, __source__.line, 0)
     end
-    @inline function timing_print(str::Union{String, SubString{String}, Symbol})
+    @inline function timing_print(str::Union{String, Symbol})
         ccall(
             :jl_timing_puts,
             Cvoid,
@@ -88,5 +88,5 @@ else
     macro zone(name, ex::Expr)
         return esc(ex)
     end
-    timing_print(str::Union{String, SubString{String}, Symbol}) = nothing
+    timing_print(str::Union{String, Symbol}) = nothing
 end

--- a/Compiler/src/timing.jl
+++ b/Compiler/src/timing.jl
@@ -75,18 +75,18 @@ if ccall(:jl_timing_enabled, Cint, ()) != 0
     macro zone(name, ex::Expr)
         return getzonedexpr(name, ex, :unknown_julia_function, __source__.file, __source__.line, 0)
     end
-    @inline function timing_print(str)
+    @inline function timing_print(str::Union{String, SubString{String}, Symbol})
         ccall(
             :jl_timing_puts,
             Cvoid,
             (Ptr{Cvoid}, Ptr{UInt8}),
             _get_current_timing_block(),
-            string(str)
+            str
         )
     end
 else
     macro zone(name, ex::Expr)
         return esc(ex)
     end
-    timing_print(str::String) = nothing
+    timing_print(str::Union{String, SubString{String}, Symbol}) = nothing
 end

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -157,6 +157,8 @@ include("weakkeydict.jl")
 # ScopedValues
 include("scopedvalues.jl")
 
+include("../Compiler/src/timing.jl")
+
 # metaprogramming
 include("meta.jl")
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2332,7 +2332,10 @@ function require(into::Module, mod::Symbol)
     if world == typemax(UInt)
         world = get_world_counter()
     end
-    return Compiler.@zone "LOAD_Require" invoke_in_world(world, __require, into, mod)
+    return @zone "LOAD_Require" begin
+        timing_print(mod)
+        invoke_in_world(world, __require, into, mod)
+    end
 end
 
 function check_for_hint(into, mod)


### PR DESCRIPTION
Right now, there is no way to add text to a zone from the julia defined zones (text being e.g. the yellow text in)

<img width="424" alt="image" src="https://github.com/user-attachments/assets/2fadb650-9638-4767-a25c-6803dda2a47a" />

When we moved the `require` code into Julia we for example lost the name of the package being loaded due to this.

To add this functionality, we need a way to get the "current active block" for the timing. Here I used a ScopeValue for this (inspired by https://github.com/topolarity/Tracy.jl/pull/36). However, this means that we only get access to this functionality quite late, maybe we want to be able to add text from `Compiler` as well. So maybe we want some more basic way to do this. I thought about using a sentinel value but we don't have any "hard scopes" that we can define a `local` variable in. Then I thought about the outer `@zone`, looking into the expression and "injecting" its own block into any `timer_print` calls it can find. That may work. Other ideas are welcome.