### PR TITLE
faster rand(::RandomDevice, NTuple{N, UInt})

### DIFF
--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -20,7 +20,7 @@ rand(rd::RandomDevice, ::SamplerType{Bool}) = rand(rd, UInt8) % Bool
 # specialization for homogeneous tuple types of builtin integers, to avoid
 # repeated system calls
 rand(rd::RandomDevice, sp::SamplerTag{Ref{Tuple{Vararg{T, N}}}, Tuple{S}}
-     ) where {T, N, S <: Random.SamplerUnion(Base.BitInteger_types...)} =
+     ) where {T, N, S <: SamplerUnion(Base.BitInteger_types...)} =
          Libc.getrandom!(Ref{gentype(sp)}())[]
 
 function rand!(rd::RandomDevice, A::Array{Bool}, ::SamplerType{Bool})

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -16,6 +16,13 @@ seed!(rng::RandomDevice, ::Nothing) = rng
 
 rand(rd::RandomDevice, sp::SamplerBoolBitInteger) = Libc.getrandom!(Ref{sp[]}())[]
 rand(rd::RandomDevice, ::SamplerType{Bool}) = rand(rd, UInt8) % Bool
+
+# specialization for homogeneous tuple types of builtin integers, to avoid
+# repeated system calls
+rand(rd::RandomDevice, sp::SamplerTag{Ref{Tuple{Vararg{T, N}}}, Tuple{S}}
+     ) where {T, N, S <: Random.SamplerUnion(Base.BitInteger_types...)} =
+         Libc.getrandom!(Ref{gentype(sp)}())[]
+
 function rand!(rd::RandomDevice, A::Array{Bool}, ::SamplerType{Bool})
     Libc.getrandom!(A)
     # we need to mask the result so that only the LSB in each byte can be non-zero

--- a/stdlib/Random/src/Xoshiro.jl
+++ b/stdlib/Random/src/Xoshiro.jl
@@ -245,8 +245,7 @@ hash(x::Union{TaskLocalRNG, Xoshiro}, h::UInt) = hash(getstate(x), h + 0x49a62c2
 
 function seed!(rng::Union{TaskLocalRNG, Xoshiro}, ::Nothing)
     # as we get good randomness from RandomDevice, we can skip hashing
-    s0, s1, s2, s3 = rand(RandomDevice(), NTuple{4, UInt64})
-    initstate!(rng, (s0, s1, s2, s3))
+    initstate!(rng, rand(RandomDevice(), NTuple{4, UInt64}))
 end
 
 seed!(rng::Union{TaskLocalRNG, Xoshiro}, seed) =

--- a/stdlib/Random/src/Xoshiro.jl
+++ b/stdlib/Random/src/Xoshiro.jl
@@ -245,11 +245,7 @@ hash(x::Union{TaskLocalRNG, Xoshiro}, h::UInt) = hash(getstate(x), h + 0x49a62c2
 
 function seed!(rng::Union{TaskLocalRNG, Xoshiro}, ::Nothing)
     # as we get good randomness from RandomDevice, we can skip hashing
-    rd = RandomDevice()
-    s0 = rand(rd, UInt64)
-    s1 = rand(rd, UInt64)
-    s2 = rand(rd, UInt64)
-    s3 = rand(rd, UInt64)
+    s0, s1, s2, s3 = rand(RandomDevice(), NTuple{4, UInt64})
     initstate!(rng, (s0, s1, s2, s3))
 end
 

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -824,6 +824,20 @@ end
     @inferred rand(Tuple{Int32,Int64,Float64})
     @inferred rand(NTuple{20,Int})
     @test_throws TypeError rand(Tuple{1:2,3:4})
+
+    @testset "rand(::RandomDevice, ::Type{NTuple{N, Int}})" begin
+        # RandomDevice has a specialization for homogeneous tuple types of builtin integers
+        rd = RandomDevice()
+        @test () == rand(rd, Tuple{})
+        xs = rand(rd, Tuple{Int, Int})
+        @test xs isa Tuple{Int, Int} && xs[1] != xs[2]
+        xs = rand(rd, NTuple{2, Int})
+        @test xs isa Tuple{Int, Int} && xs[1] != xs[2]
+        xs = rand(rd, Tuple{Int, UInt}) # not NTuple
+        @test xs isa Tuple{Int, UInt} && xs[1] != xs[2]
+        xs = rand(rd, Tuple{Bool}) # not included in the specialization
+        @test xs isa Tuple{Bool}
+    end
 end
 
 @testset "GLOBAL_RNG" begin


### PR DESCRIPTION
`RandomDevice` uses `Libc.getrandom!` to get randomness, but such a system call is very expensive.
There was already a specialization for `rand!` on `Array`s of builtin integers to have only one such call; this commit adds a similar specialization for homogeneous tuples of builtin integer types.
One motivation is to instantiate `Xoshiro()` faster from `RandomDevice()`, as requesting 4*64 bits of entropy from the system in one go is, at least on my system, roughly 4 times faster that in 4 calls:
```
julia> @btime Xoshiro()
  1.225 μs (1 allocation: 48 bytes) # master
  319.068 ns (1 allocation: 48 bytes) # PR
```