### PR TITLE
Revert changes to inferred valid age that are not consistent with edges model assumed by precompile

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3527,20 +3527,6 @@ function merge_override_effects!(interp::AbstractInterpreter, effects::Effects, 
     # It is possible for arguments (GlobalRef/:static_parameter) to throw,
     # but these will be recomputed during SSA construction later.
     override = decode_statement_effects_override(sv)
-    if override.consistent
-        m = sv.linfo.def
-        if isa(m, Method)
-            # N.B.: We'd like deleted_world here, but we can't add an appropriate edge at this point.
-            # However, in order to reach here in the first place, ordinary method lookup would have
-            # had to add an edge and appropriate invalidation trigger.
-            valid_worlds = WorldRange(m.primary_world, typemax(UInt))
-            if sv.world.this in valid_worlds
-                update_valid_age!(sv, valid_worlds)
-            else
-                override = EffectsOverride(override, consistent=false)
-            end
-        end
-    end
     effects = override_effects(effects, override)
     set_curr_ssaflag!(sv, flags_for_effects(effects), IR_FLAGS_EFFECTS)
     merge_effects!(interp, sv, effects)


### PR DESCRIPTION
Reverts only the code from JuliaLang/julia#58254, not the docs

This adds unsound behavior to the Compiler in a doc PR that is supposed to be about increasing soundness. It isn't easily observable behavior, since the added code only triggers if code gets precompiled and saved and the Method gets used before its official "primary" world, but it can lead to unpredictable and inconsistent inference results.