### PR TITLE
Rename `dispatchtuple` to `indivisible_type`

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -129,7 +129,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
         local napplicable = length(applicable)
         for i = 1:napplicable
             local sig = applicable[i].match.spec_types
-            if !isdispatchtuple(sig)
+            if !isindivisibletype(sig)
                 # only infer fully concrete call sites in top-level expressions (ignoring even isa_compileable_sig matches)
                 add_remark!(interp, sv, "Refusing to infer non-concrete call site in top-level expression")
                 return Future(CallMeta(Any, Any, Effects(), NoCallInfo()))

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -1394,8 +1394,8 @@ function compute_inlining_cases(@nospecialize(info::CallInfo), flag::UInt32, sig
             # We will emit an inline MethodError in this case, but that info already came inference, so we must already have the uncovered edge for it
         end
     elseif !isempty(cases)
-        # if we've not seen all candidates, union split is valid only for dispatch tuples
-        filter!(case::InliningCase->isdispatchtuple(case.sig), cases)
+        # if we've not seen all candidates, union split is valid only for indivisible (dispatch) tuples
+        filter!(case::InliningCase->isindivisibletype(case.sig), cases)
     end
     return cases, handled_all_cases, fully_covered, joint_effects
 end

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -361,7 +361,7 @@ function inline_cost_model(interp::AbstractInterpreter, result::InferenceResult,
         return MAX_INLINE_COST
     end
 
-    if declared_inline && isdispatchtuple(specTypes)
+    if declared_inline && isindivisibletype(specTypes)
         # obey @inline declaration if a dispatch barrier would not help
         return MIN_INLINE_COST
     else

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -816,27 +816,27 @@ let src = code_typed((Union{Tuple{Int,Int,Int}, Vector{Int}},)) do xs
     @test count(isinvoke(:g42840), src.code) == 1
 end
 
-# test single, non-dispatchtuple callsite inlining
+# test single, divisible (non-dispatchtuple) callsite inlining
 
-@constprop :none @inline test_single_nondispatchtuple(@nospecialize(t)) =
+@constprop :none @inline test_single_divisible_type(@nospecialize(t)) =
     isa(t, DataType) && t.name === Type.body.name
 let
     src = code_typed1((Any,)) do x
-        test_single_nondispatchtuple(x)
+        test_single_divisible_type(x)
     end
     @test all(src.code) do @nospecialize x
-        !(isinvoke(:test_single_nondispatchtuple, x) || iscall((src, test_single_nondispatchtuple), x))
+        !(isinvoke(:test_single_divisible_type, x) || iscall((src, test_single_divisible_type), x))
     end
 end
 
-@constprop :aggressive @inline test_single_nondispatchtuple(c, @nospecialize(t)) =
+@constprop :aggressive @inline test_single_divisible_type(c, @nospecialize(t)) =
     c && isa(t, DataType) && t.name === Type.body.name
 let
     src = code_typed1((Any,)) do x
-        test_single_nondispatchtuple(true, x)
+        test_single_divisible_type(true, x)
     end
     @test all(src.code) do @nospecialize(x)
-        !(isinvoke(:test_single_nondispatchtuple, x) || iscall((src, test_single_nondispatchtuple), x))
+        !(isinvoke(:test_single_divisible_type, x) || iscall((src, test_single_divisible_type), x))
     end
 end
 
@@ -856,7 +856,7 @@ let
     @test invoke(Any[10]) === false
 end
 
-# test union-split, non-dispatchtuple callsite inlining
+# test union-split, divisible (non-dispatchtuple) callsite inlining
 
 @constprop :none @noinline abstract_unionsplit(@nospecialize x::Any) = Base.inferencebarrier(:Any)
 @constprop :none @noinline abstract_unionsplit(@nospecialize x::Number) = Base.inferencebarrier(:Number)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -818,7 +818,7 @@ export
     isprimitivetype,
     isstructtype,
     isconcretetype,
-    isdispatchtuple,
+    isindivisibletype,
     oftype,
     promote,
     promote_rule,

--- a/base/staticdata.jl
+++ b/base/staticdata.jl
@@ -75,7 +75,7 @@ get_require_world() = unsafe_load(cglobal(:jl_require_world, UInt))
 
 function gen_staged_sig(def::Method, mi::MethodInstance)
     isdefined(def, :generator) || return nothing
-    isdispatchtuple(mi.specTypes) || return nothing
+    isindivisibletype(mi.specTypes) || return nothing
     gen = Core.Typeof(def.generator)
     return Tuple{gen, UInt, Method, Vararg}
     ## more precise method lookup, but more costly and likely not actually better?

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -191,7 +191,7 @@ Base.typeintersect
 Base.promote_type
 Base.promote_rule
 Base.promote_typejoin
-Base.isdispatchtuple
+Base.isindivisibletype
 ```
 
 ### Declared structure

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -100,7 +100,7 @@ jl_datatype_t *jl_new_uninitialized_datatype(void)
     jl_set_typetagof(t, jl_datatype_tag, 0);
     t->hash = 0;
     t->hasfreetypevars = 0;
-    t->isdispatchtuple = 0;
+    t->isindivisibletype = 0;
     t->isbitstype = 0;
     t->isprimitivetype = 0;
     t->zeroinit = 0;

--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -229,7 +229,7 @@ static int precompile_enq_all_specializations__(jl_typemap_entry_t *def, void *c
     jl_method_t *m = def->func.method;
     if (m->external_mt)
         return 1;
-    if ((m->name == jl_symbol("__init__") || m->ccallable) && jl_is_dispatch_tupletype(m->sig)) {
+    if ((m->name == jl_symbol("__init__") || m->ccallable) && jl_is_indivisible_type(m->sig)) {
         // ensure `__init__()` and @ccallables get strongly-hinted, specialized, and compiled
         jl_method_instance_t *mi = jl_specializations_get_linfo(m, m->sig, jl_emptysvec);
         jl_array_ptr_1d_push((jl_array_t*)closure, (jl_value_t*)mi);

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -4411,7 +4411,7 @@ static jl_value_t *intersect_types(jl_value_t *x, jl_value_t *y, int emptiness_o
     jl_stenv_t e;
     if (obviously_disjoint(x, y, 0))
         return jl_bottom_type;
-    if (jl_is_dispatch_tupletype(x) || jl_is_dispatch_tupletype(y)) {
+    if (jl_is_indivisible_type(x) || jl_is_indivisible_type(y)) {
         if (jl_subtype(x, y))
             return x;
         else if (jl_subtype(y, x))

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -543,10 +543,10 @@ static int jl_typemap_intersection_node_visitor(jl_typemap_entry_t *ml, struct t
         closure->ti = jl_type_intersection_env_s(closure->type, (jl_value_t*)ml->sig, penv, &closure->issubty);
         if (closure->ti != (jl_value_t*)jl_bottom_type) {
             // In some corner cases type intersection is conservative and returns something
-            // for intersect(A, B) even though A is a dispatch tuple and !(A <: B).
+            // for intersect(A, B) even though A is an indivisible (dispatch) tuple and !(A <: B).
             // For dispatch purposes in such a case we know there's no match. This check
             // fixes issue #30394.
-            if (closure->issubty || !jl_is_dispatch_tupletype(closure->type))
+            if (closure->issubty || !jl_is_indivisible_type(closure->type))
                 if (!fptr(ml, closure))
                     return 0;
         }
@@ -594,7 +594,7 @@ int jl_typemap_intersection_visitor(jl_typemap_t *map, int offs,
     jl_value_t *ttypes = jl_unwrap_unionall(closure->type);
     assert(jl_is_datatype(ttypes));
     //TODO: fast-path for leaf-type tuples?
-    //if (ttypes->isdispatchtuple) {
+    //if (ttypes->isindivisibletype) {
     //    register jl_typemap_intersection_visitor_fptr fptr = closure->fptr;
     //    struct jl_typemap_assoc search = {(jl_value_t*)closure->type, world, closure->env, 0, ~(size_t)0};
     //    jl_typemap_entry_t *ml = jl_typemap_assoc_by_type(map, search, offs, /*subtype*/1);

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -203,8 +203,8 @@ function _dump_function(@nospecialize(f), @nospecialize(t), native::Bool, wrappe
         world = Base.get_world_counter()
         match = Base._which(signature_type(f, t); world)
         mi = Base.specialize_method(match)
-        # TODO: use jl_is_cacheable_sig instead of isdispatchtuple
-        isdispatchtuple(mi.specTypes) || (warning = GENERIC_SIG_WARNING)
+        # TODO: use jl_is_cacheable_sig instead of isindivisibletype
+        isindivisibletype(mi.specTypes) || (warning = GENERIC_SIG_WARNING)
     else
         world = UInt64(f.world)
         tt = Base.to_tuple_type(t)
@@ -216,7 +216,7 @@ function _dump_function(@nospecialize(f), @nospecialize(t), native::Bool, wrappe
             Base.hasintersect(typeof(f).parameters[1], tt) || (warning = OC_MISMATCH_WARNING)
         else
             mi = Base.specialize_method(f.source, Tuple{typeof(f.captures), tt.parameters...}, Core.svec())
-            isdispatchtuple(mi.specTypes) || (warning = GENERIC_SIG_WARNING)
+            isindivisibletype(mi.specTypes) || (warning = GENERIC_SIG_WARNING)
         end
     end
     # get the code for it

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2107,8 +2107,33 @@ end
 
 let A = Tuple{typeof(identity), Type{Union{}}},
     B = Tuple{typeof(identity), typeof(Union{})}
-    @test A == B && (Base.isdispatchtuple(A) == Base.isdispatchtuple(B))
+    @test A == B && (Base.isindivisibletype(A) == Base.isindivisibletype(B))
 end
+
+# isindivisibletype
+@test Base.isindivisibletype(Int)
+@test Base.isindivisibletype(Bool)
+@test Base.isindivisibletype(Float64)
+@test Base.isindivisibletype(Tuple{Float64})
+@test Base.isindivisibletype(Vector{Float64})
+@test !Base.isindivisibletype(Tuple{Union{Float64,Int64}})
+@test Base.isindivisibletype(Vector{Union{Float64,Int64}})
+@test !Base.isindivisibletype(Vector{T} where T <: Union{Float64,Int64})
+@test !Base.isindivisibletype(DataType)
+
+@test Base.isindivisibletype(Tuple{Tuple{Float64}})
+@test !Base.isindivisibletype(Tuple{Tuple{Union{Int,Float64}}})
+@test !Base.isindivisibletype(Tuple{Tuple})
+
+@test Base.isindivisibletype(Type{Int})
+@test Base.isindivisibletype(Type{Union{Int,Float64}})
+@test Base.isindivisibletype(Type{Any})
+
+@test Base.isdispatchtuple(Tuple{Tuple{Float64}})
+@test Base.isdispatchtuple(Tuple{Tuple{Type{Union{Int,Float64}}}})
+@test !Base.isdispatchtuple(Tuple{Tuple{Union{Int,Float64}}})
+@test !Base.isdispatchtuple(Tuple{Tuple{DataType}})
+@test !Base.isdispatchtuple(Tuple{Tuple})
 
 # issue #45703
 # requires assertions enabled (to catch discrepancy in obvious_subtype)


### PR DESCRIPTION
This is hopefully a more intuitive (type-semantic) notion of what a "dispatch tuple" is.

Ideally, it makes two key properties more obvious:
  1. indivisible types are either type-equal or disjoint with each other (T == U or T != U) - they are never partially overlapping
  2. these signatures ~are always compilable since they~ are "maximally specific"

This new definition should be mostly equivalent to the existing one for Tuples, and it extends the predicate to be be analogously defined over other DataTypes (e.g. `Int` / `Vector{Any}`, which are also indivisible)