### PR TITLE
faster `rand(TaskLocalRNG(), 1:n)` by outlining `throw`

### DIFF
--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -15,7 +15,9 @@ using Base.GMP.MPZ
 using Base.GMP: Limb
 import SHA
 
-using Base: BitInteger, BitInteger_types, BitUnsigned, require_one_based_indexing
+using Base: BitInteger, BitInteger_types, BitUnsigned, require_one_based_indexing,
+    _throw_argerror
+
 import Base: copymutable, copy, copy!, ==, hash, convert,
              rand, randn, show
 

--- a/stdlib/Random/src/Xoshiro.jl
+++ b/stdlib/Random/src/Xoshiro.jl
@@ -232,7 +232,7 @@ rng_native_52(::TaskLocalRNG) = UInt64
 # this variant of setstate! initializes the internal splitmix state, a.k.a. `s4`
 @inline function initstate!(x::Union{TaskLocalRNG, Xoshiro}, state)
     length(state) == 4 && eltype(state) == UInt64 ||
-        throw(ArgumentError("initstate! expects a list of 4 `UInt64` values"))
+        _throw_argerror("initstate! expects a list of 4 `UInt64` values")
     s0, s1, s2, s3 = state
     setstate!(x, (s0, s1, s2, s3, 1s0 + 3s1 + 5s2 + 7s3))
 end

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -57,7 +57,7 @@ Sampler(::Type{<:AbstractRNG}, I::FloatInterval{BigFloat}, ::Repetition) =
     SamplerBigFloat{typeof(I)}(precision(BigFloat))
 
 function _rand!(rng::AbstractRNG, z::BigFloat, sp::SamplerBigFloat)
-    precision(z) == sp.prec || throw(ArgumentError("incompatible BigFloat precision"))
+    precision(z) == sp.prec || _throw_argerror("incompatible BigFloat precision")
     limbs = sp.limbs
     rand!(rng, limbs)
     @inbounds begin
@@ -229,6 +229,9 @@ uint_sup(::Type{<:Base.BitInteger32}) = UInt32
 uint_sup(::Type{<:Union{Int64,UInt64}}) = UInt64
 uint_sup(::Type{<:Union{Int128,UInt128}}) = UInt128
 
+@noinline empty_collection_error() = throw(ArgumentError("collection must be non-empty"))
+
+
 #### Fast
 
 struct SamplerRangeFast{U<:BitUnsigned,T<:BitInteger} <: Sampler{T}
@@ -242,7 +245,7 @@ SamplerRangeFast(r::AbstractUnitRange{T}) where T<:BitInteger =
     SamplerRangeFast(r, uint_sup(T))
 
 function SamplerRangeFast(r::AbstractUnitRange{T}, ::Type{U}) where {T,U}
-    isempty(r) && throw(ArgumentError("collection must be non-empty"))
+    isempty(r) && empty_collection_error()
     m = (last(r) - first(r)) % unsigned(T) % U # % unsigned(T) to not propagate sign bit
     bw = (Base.top_set_bit(m)) % UInt # bit-width
     mask = ((1 % U) << bw) - (1 % U)
@@ -316,7 +319,7 @@ SamplerRangeInt(r::AbstractUnitRange{T}) where T<:BitInteger =
     SamplerRangeInt(r, uint_sup(T))
 
 function SamplerRangeInt(r::AbstractUnitRange{T}, ::Type{U}) where {T,U}
-    isempty(r) && throw(ArgumentError("collection must be non-empty"))
+    isempty(r) && empty_collection_error()
     a = first(r)
     m = (last(r) - first(r)) % unsigned(T) % U
     k = m + one(U)
@@ -362,7 +365,7 @@ struct SamplerRangeNDL{U<:Unsigned,T} <: Sampler{T}
 end
 
 function SamplerRangeNDL(r::AbstractUnitRange{T}) where {T}
-    isempty(r) && throw(ArgumentError("collection must be non-empty"))
+    isempty(r) && empty_collection_error()
     a = first(r)
     U = uint_sup(T)
     s = (last(r) - first(r)) % unsigned(T) % U + one(U) # overflow ok
@@ -405,7 +408,7 @@ end
 function SamplerBigInt(::Type{RNG}, r::AbstractUnitRange{BigInt}, N::Repetition=Val(Inf)
                        ) where {RNG<:AbstractRNG}
     m = last(r) - first(r)
-    m.size < 0 && throw(ArgumentError("collection must be non-empty"))
+    m.size < 0 && empty_collection_error()
     nlimbs = Int(m.size)
     hm = nlimbs == 0 ? Limb(0) : GC.@preserve m unsafe_load(m.d, nlimbs)
     highsp = Sampler(RNG, Limb(0):hm, N)
@@ -461,7 +464,7 @@ rand(rng::AbstractRNG, sp::SamplerSimple{<:AbstractArray,<:Sampler}) =
 ## random values from Dict
 
 function Sampler(::Type{RNG}, t::Dict, ::Repetition) where RNG<:AbstractRNG
-    isempty(t) && throw(ArgumentError("collection must be non-empty"))
+    isempty(t) && empty_collection_error()
     # we use Val(Inf) below as rand is called repeatedly internally
     # even for generating only one random value from t
     SamplerSimple(t, Sampler(RNG, LinearIndices(t.slots), Val(Inf)))
@@ -490,7 +493,7 @@ rand(rng::AbstractRNG, sp::SamplerTag{<:Set,<:Sampler}) = rand(rng, sp.data).fir
 ## random values from BitSet
 
 function Sampler(RNG::Type{<:AbstractRNG}, t::BitSet, n::Repetition)
-    isempty(t) && throw(ArgumentError("collection must be non-empty"))
+    isempty(t) && empty_collection_error()
     SamplerSimple(t, Sampler(RNG, minimum(t):maximum(t), Val(Inf)))
 end
 

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -97,7 +97,7 @@ end
 #  size-m subset of A where m is fixed!)
 function randsubseq!(r::AbstractRNG, S::AbstractArray, A::AbstractArray, p::Real)
     require_one_based_indexing(S, A)
-    0 <= p <= 1 || throw(ArgumentError("probability $p not in [0,1]"))
+    0 <= p <= 1 || _throw_argerror(LazyString("probability ", p, " not in [0,1]"))
     n = length(A)
     p == 1 && return copyto!(resize!(S, n), A)
     empty!(S)


### PR DESCRIPTION
In #58089, this method took a small performance hit in some contexts. It turns out that by outlining the unlikely branch which throws on empty ranges, this hit can be recovered.

In https://github.com/JuliaLang/julia/pull/50509#issuecomment-2798850590, a graph of the performance improvement of the "speed-up randperm by using our current rand(1:n)" was posted, but I realized it was only true when calls to `rand(1:n)` were prefixed by `@inline`; without `@inline` it was overall slower for `TaskLocalRNG()` for very big arrays (but still faster otherwise).

An alternative to these `@inline` annotation is to outline `throw` like here, for equivalent benefits as `@inline` in that `randperm` PR.

Assuming that PR is merged, this PR improves roughly performance by 2x for `TaskLocalRNG()` (no change for other RNGs):

![new-shuffle-outlinethrow](https://github.com/user-attachments/assets/8c0d4740-3bb4-4bcf-a49d-9af09426bec7)

While at it, I outlined a bunch of other unliky throwing branches.

After that, #50509 can probably be merged, finally!