### PR TITLE
Drop `<<` and `>>` from sametype heuristic

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1300,5 +1300,3 @@ typename(typeof(function <= end)).constprop_heuristic = Core.SAMETYPE_HEURISTIC
 typename(typeof(function >= end)).constprop_heuristic = Core.SAMETYPE_HEURISTIC
 typename(typeof(function < end)).constprop_heuristic  = Core.SAMETYPE_HEURISTIC
 typename(typeof(function > end)).constprop_heuristic  = Core.SAMETYPE_HEURISTIC
-typename(typeof(function << end)).constprop_heuristic = Core.SAMETYPE_HEURISTIC
-typename(typeof(function >> end)).constprop_heuristic = Core.SAMETYPE_HEURISTIC


### PR DESCRIPTION
These heuristics were added in #32105. However, I think `>>` and `<<` should be dropped because
1. The original analysis predates irinterp, which is significantly faster at constprop
2. These functions actuall have non-trivial bodies that do benefit (in ir size at least) from constprop (#58329).

Fixes #58329