### PR TITLE
Revert "CODEOWNERS: Set `@JuliaLang/committers-available-to-review` as the global (default) codeowners for the `JuliaLang/julia` repo"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,3 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in
-# the repo.
-# Unless a later match takes precedence,
-# a member of the `@JuliaLang/committers-available-to-review` team
-# will be requested for review when someone opens a pull request.
-*       @JuliaLang/committers-available-to-review
-
 CODEOWNERS @JuliaLang/github-actions
 /.github/ @JuliaLang/github-actions
 /.buildkite/ @JuliaLang/github-actions


### PR DESCRIPTION
Reverts JuliaLang/julia#58315

See https://github.com/JuliaLang/julia/pull/58356#event-17578365930, for an example of how this doesn't work.