### PR TITLE
remove some padding from Task type

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3759,7 +3759,7 @@ void jl_init_types(void) JL_GC_DISABLED
                         NULL,
                         jl_any_type,
                         jl_emptysvec,
-                        jl_perm_symsvec(27,
+                        jl_perm_symsvec(21,
                                         "next",
                                         "queue",
                                         "storage",
@@ -3767,27 +3767,21 @@ void jl_init_types(void) JL_GC_DISABLED
                                         "result",
                                         "scope",
                                         "code",
-                                        "_state",
-                                        "sticky",
-                                        "priority",
-                                        "_isexception",
-                                        "pad00",
-                                        "pad01",
-                                        "pad02",
                                         "rngState0",
                                         "rngState1",
                                         "rngState2",
                                         "rngState3",
                                         "rngState4",
-                                        "metrics_enabled",
-                                        "pad10",
-                                        "pad11",
-                                        "pad12",
                                         "first_enqueued_at",
                                         "last_started_running_at",
                                         "running_time_ns",
-                                        "finished_at"),
-                        jl_svec(27,
+                                        "finished_at",
+                                        "_state",
+                                        "sticky",
+                                        "priority",
+                                        "_isexception",
+                                        "metrics_enabled"),
+                        jl_svec(21,
                                 jl_any_type,
                                 jl_any_type,
                                 jl_any_type,
@@ -3795,35 +3789,29 @@ void jl_init_types(void) JL_GC_DISABLED
                                 jl_any_type,
                                 jl_any_type,
                                 jl_any_type,
+                                jl_uint64_type,
+                                jl_uint64_type,
+                                jl_uint64_type,
+                                jl_uint64_type,
+                                jl_uint64_type,
+                                jl_uint64_type,
+                                jl_uint64_type,
+                                jl_uint64_type,
+                                jl_uint64_type,
                                 jl_uint8_type,
                                 jl_bool_type,
                                 jl_uint16_type,
                                 jl_bool_type,
-                                jl_uint8_type,
-                                jl_uint8_type,
-                                jl_uint8_type,
-                                jl_uint64_type,
-                                jl_uint64_type,
-                                jl_uint64_type,
-                                jl_uint64_type,
-                                jl_uint64_type,
-                                jl_bool_type,
-                                jl_uint8_type,
-                                jl_uint8_type,
-                                jl_uint8_type,
-                                jl_uint64_type,
-                                jl_uint64_type,
-                                jl_uint64_type,
-                                jl_uint64_type),
+                                jl_bool_type),
                         jl_emptysvec,
                         0, 1, 6);
     XX(task);
     jl_value_t *listt = jl_new_struct(jl_uniontype_type, jl_task_type, jl_nothing_type);
     jl_svecset(jl_task_type->types, 0, listt);
-    // Set field 20 (metrics_enabled) as const
-    // Set fields 8 (_state) and 24-27 (metric counters) as atomic
-    const static uint32_t task_constfields[1]  = { 0b00000000000010000000000000000000 };
-    const static uint32_t task_atomicfields[1] = { 0b00000111100000000000000010000000 };
+    // Set field 21 (metrics_enabled) as const
+    const static uint32_t task_constfields[1]  = { 0b00000000000100000000000000000000 };
+    // Set fields 17 (_state) and 13-16 (metric counters) as atomic
+    const static uint32_t task_atomicfields[1] = { 0b00000000000000011111000000000000 };
     jl_task_type->name->constfields = task_constfields;
     jl_task_type->name->atomicfields = task_atomicfields;
 

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -243,16 +243,8 @@ typedef struct _jl_task_t {
     jl_value_t *result;
     jl_value_t *scope;
     jl_function_t *start;
-    _Atomic(uint8_t) _state;
-    uint8_t sticky; // record whether this Task can be migrated to a new thread
-    uint16_t priority;
-    _Atomic(uint8_t) _isexception; // set if `result` is an exception to throw or that we exited with
-    uint8_t pad0[3];
-    // === 64 bytes (cache line)
+    // === 56 bytes
     uint64_t rngState[JL_RNG_SIZE];
-    // flag indicating whether or not to record timing metrics for this task
-    uint8_t metrics_enabled;
-    uint8_t pad1[3];
     // timestamp this task first entered the run queue
     _Atomic(uint64_t) first_enqueued_at;
     // timestamp this task was most recently scheduled to run
@@ -262,21 +254,17 @@ typedef struct _jl_task_t {
     // === 64 bytes (cache line)
     // timestamp this task finished (i.e. entered state DONE or FAILED).
     _Atomic(uint64_t) finished_at;
+    _Atomic(uint8_t) _state;
+    uint8_t sticky; // record whether this Task can be migrated to a new thread
+    uint16_t priority;
+    _Atomic(uint8_t) _isexception; // set if `result` is an exception to throw or that we exited with
+    // flag indicating whether or not to record timing metrics for this task
+    uint8_t metrics_enabled;
 
 // hidden state:
 
     // id of owning thread - does not need to be defined until the task runs
     _Atomic(int16_t) tid;
-    // threadpool id
-    int8_t threadpoolid;
-    // Reentrancy bits
-    // Bit 0: 1 if we are currently running inference/codegen
-    // Bit 1-2: 0-3 counter of how many times we've reentered inference
-    // Bit 3: 1 if we are writing the image and inference is illegal
-    uint8_t reentrant_timing;
-    // 2 bytes of padding on 32-bit, 6 bytes on 64-bit
-    // uint16_t padding2_32;
-    // uint48_t padding2_64;
     // saved gc stack top for context switches
     jl_gcframe_t *gcstack;
     size_t world_age;
@@ -291,6 +279,13 @@ typedef struct _jl_task_t {
     jl_handler_t *eh;
     // saved thread state
     jl_ucontext_t ctx; // pointer into stkbuf, if suspended
+    // threadpool id
+    int8_t threadpoolid;
+    // Reentrancy bits
+    // Bit 0: 1 if we are currently running inference/codegen
+    // Bit 1-2: 0-3 counter of how many times we've reentered inference
+    // Bit 3: 1 if we are writing the image and inference is illegal
+    uint8_t reentrant_timing;
 } jl_task_t;
 
 JL_DLLEXPORT void *jl_get_ptls_states(void);


### PR DESCRIPTION
This makes Task 8 bytes smaller and removes the annoying padding fields.

With another 8 bytes, we'd get into the next lower size class which would be more helpful. One way I found to do that is to move the copy_stack and started fields from jl_ucontext_t back into jl_task_t, avoiding the padding from the nested struct. That is a bit tricky though and might not make sense. Or, we could move the 2 dangling int8 fields (threadpoolid and reentrant_timing) inside jl_ucontext_t which doesn't make much sense either but is probably technically easy. Any other ideas?