### PR TITLE
Apply debug_compile_units hack also in remove-addrspaces

### DIFF
--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -334,7 +334,11 @@ bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
 
         GV->setInitializer(nullptr);
     }
-
+    // Same workauraound as in CloneCtx::prepare_vmap to avoid LLVM bug when cloning
+    auto &MD = VMap.MD();
+    for (auto cu: M.debug_compile_units()) {
+        MD[cu].reset(cu);
+    }
     // Similarly, copy over and rewrite function bodies
     for (Function *F : Functions) {
         Function *NF = cast<Function>(VMap[F]);
@@ -413,6 +417,7 @@ bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
             F->eraseFromParent();
         }
     }
+
 
     return true;
 }

--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -334,7 +334,7 @@ bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
 
         GV->setInitializer(nullptr);
     }
-    // Same workauraound as in CloneCtx::prepare_vmap to avoid LLVM bug when cloning
+    // Same workaround as in CloneCtx::prepare_vmap to avoid LLVM bug when cloning
     auto &MD = VMap.MD();
     for (auto cu: M.debug_compile_units()) {
         MD[cu].reset(cu);


### PR DESCRIPTION
This fixes the issues seen in the LLVM 20 PR