### PR TITLE
REPL: show user loaded packages in the banner

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1738,7 +1738,9 @@ function banner(io::IO = stdout; short = false)
     if isempty(loaded_user_modules)
         loaded_modules_string = ""
     else
-        loaded_modules_string = "Loaded packages: $(join(loaded_user_models, ", "))"
+        # account for what has been printed before on this line
+        allowed_width = displaysize(io)[2] - 26
+        loaded_modules_string = rtruncate("Loaded packages: $(join(loaded_user_modules, ", "))", allowed_width)
     end
 
     commit_date = isempty(Base.GIT_VERSION_INFO.date_string) ? "" : " ($(split(Base.GIT_VERSION_INFO.date_string)[1]))"

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1732,6 +1732,15 @@ function banner(io::IO = stdout; short = false)
         end
     end
 
+    loaded_user_modules = filter(names(Main,imported=true)) do m
+        typeof(getfield(Main, m)) <: Module && m ∉ (:Base, :Core, :Main)
+    end
+    if isempty(loaded_user_modules)
+        loaded_modules_string = ""
+    else
+        loaded_modules_string = "Loaded packages: $(join(loaded_user_models, ", "))"
+    end
+
     commit_date = isempty(Base.GIT_VERSION_INFO.date_string) ? "" : " ($(split(Base.GIT_VERSION_INFO.date_string)[1]))"
 
     if get(io, :color, false)::Bool
@@ -1756,7 +1765,7 @@ function banner(io::IO = stdout; short = false)
               $(jl)| | | | | | |/ _` |$(tx)  |
               $(jl)| | |_| | | | (_| |$(tx)  |  Version $(VERSION)$(commit_date)
              $(jl)_/ |\\__'_|_|_|\\__'_|$(tx)  |  $(commit_string)
-            $(jl)|__/$(tx)                   |
+            $(jl)|__/$(tx)                   |  $(loaded_modules_string)
 
             """)
         end


### PR DESCRIPTION
I think it would be helpful to inform the user what was automatically loaded by startup.jl (or by `-ie "using Foo"` but less useful)
```
% ./julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.13.0-DEV.563 (2025-05-09)
 _/ |\__'_|_|_|\__'_|  |  Commit 6180ca0e53* (0 days old master)
|__/                   |  Loaded packages: Revise, SimpleLooper

julia>
```

In particular it's helpful to be reminded whether Revise is loaded when working between multiple machines.