### PR TITLE
counting and summing Bools with a small integer `init` promote to `Int`

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -14,9 +14,11 @@ The reduction operator used in `sum`. The main difference from [`+`](@ref) is th
 integers are promoted to `Int`/`UInt`.
 """
 add_sum(x, y) = x + y
-add_sum(x::Bool, y::Bool) = Int(x) + Int(y)
-add_sum(x::Union{Bool,BitSignedSmall}, y::Union{Bool,BitSignedSmall}) = Int(x) + Int(y)
-add_sum(x::Union{Bool,BitUnsignedSmall}, y::Union{Bool,BitUnsignedSmall}) = UInt(x) + UInt(y)
+add_sum(x::Integer, y::Integer)::Integer = add_sum_integer(x, y)
+add_sum_integer(x::Bool, y::Bool) = Int(x) + Int(y)
+add_sum_integer(x::Union{Bool,BitSignedSmall}, y::Union{Bool,BitSignedSmall}) = Int(x) + Int(y)
+add_sum_integer(x::Union{Bool,BitUnsignedSmall}, y::Union{Bool,BitUnsignedSmall}) = UInt(x) + UInt(y)
+add_sum_integer(x, y) = x+y
 add_sum(x::Real, y::Real)::Real = x + y
 
 """
@@ -403,8 +405,7 @@ reduce_first(::typeof(+), x::Bool) = Int(x)
 reduce_first(::typeof(*), x::AbstractChar) = string(x)
 
 reduce_first(::typeof(add_sum), x) = reduce_first(+, x)
-reduce_first(::typeof(add_sum), x::Bool)   = Int(x)
-reduce_first(::typeof(add_sum), x::BitSignedSmall)   = Int(x)
+reduce_first(::typeof(add_sum), x::Union{Bool,BitSignedSmall})   = Int(x)
 reduce_first(::typeof(add_sum), x::BitUnsignedSmall) = UInt(x)
 reduce_first(::typeof(mul_prod), x) = reduce_first(*, x)
 reduce_first(::typeof(mul_prod), x::BitSignedSmall)   = Int(x)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -1075,8 +1075,8 @@ julia> count(i->(4<=i<=6), [2,3,4,5,6])
 julia> count([true, false, true, true])
 3
 
-julia> count(>(3), 1:7, init=0x03)
-0x07
+julia> count(>(3), 1:7, init=0x00)
+0x0000000000000004
 ```
 """
 count(itr; init=0) = count(identity, itr; init)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -14,11 +14,8 @@ The reduction operator used in `sum`. The main difference from [`+`](@ref) is th
 integers are promoted to `Int`/`UInt`.
 """
 add_sum(x, y) = x + y
-add_sum(x::Integer, y::Integer)::Integer = add_sum_integer(x, y)
-add_sum_integer(x::Bool, y::Bool) = Int(x) + Int(y)
-add_sum_integer(x::Union{Bool,BitSignedSmall}, y::Union{Bool,BitSignedSmall}) = Int(x) + Int(y)
-add_sum_integer(x::Union{Bool,BitUnsignedSmall}, y::Union{Bool,BitUnsignedSmall}) = UInt(x) + UInt(y)
-add_sum_integer(x, y) = x+y
+add_sum(x::Union{Bool,BitIntegerSmall}, y::Union{Bool,BitIntegerSmall}) = Int(x) + Int(y)
+add_sum(x::BitUnsignedSmall, y::BitUnsignedSmall) = UInt(x) + UInt(y)
 add_sum(x::Real, y::Real)::Real = x + y
 
 """
@@ -1076,7 +1073,7 @@ julia> count(i->(4<=i<=6), [2,3,4,5,6])
 julia> count([true, false, true, true])
 3
 
-julia> count(>(3), 1:7, init=0x00)
+julia> count(>(3), 1:7, init=UInt(0))
 0x0000000000000004
 ```
 """

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -402,7 +402,7 @@ reduce_first(::typeof(+), x::Bool) = Int(x)
 reduce_first(::typeof(*), x::AbstractChar) = string(x)
 
 reduce_first(::typeof(add_sum), x) = reduce_first(+, x)
-reduce_first(::typeof(add_sum), x::Union{Bool,BitSignedSmall})   = Int(x)
+reduce_first(::typeof(add_sum), x::BitSignedSmall)   = Int(x)
 reduce_first(::typeof(add_sum), x::BitUnsignedSmall) = UInt(x)
 reduce_first(::typeof(mul_prod), x) = reduce_first(*, x)
 reduce_first(::typeof(mul_prod), x::BitSignedSmall)   = Int(x)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -586,11 +586,11 @@ struct NonFunctionIsZero end
 @test count(NonFunctionIsZero(), [0]) == 1
 @test count(NonFunctionIsZero(), [1]) == 0
 
-@test count(Iterators.repeated(true, 3), init=0x04) === 0x07
-@test count(!=(2), Iterators.take(1:7, 3), init=Int32(0)) === Int32(2)
-@test count(identity, [true, false], init=Int8(5)) === Int8(6)
-@test count(!, [true false; false true], dims=:, init=Int16(0)) === Int16(2)
-@test isequal(count(identity, [true false; false true], dims=2, init=UInt(4)), reshape(UInt[5, 5], 2, 1))
+@test count(Iterators.repeated(true, 3), init=0x00) === UInt(3)
+@test count(!=(2), Iterators.take(1:7, 3), init=Int32(0)) === 2
+@test count(identity, [true, false], init=Int8(0)) === 1
+@test count(!, [true false; false true], dims=:, init=Int16(0)) === 2
+@test isequal(count(identity, [true false; false true], dims=2, init=UInt(0)), reshape(UInt[1, 1], 2, 1))
 
 ## cumsum, cummin, cummax
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -586,7 +586,7 @@ struct NonFunctionIsZero end
 @test count(NonFunctionIsZero(), [0]) == 1
 @test count(NonFunctionIsZero(), [1]) == 0
 
-@test count(Iterators.repeated(true, 3), init=0x00) === UInt(3)
+@test count(Iterators.repeated(true, 3), init=UInt(0)) === UInt(3)
 @test count(!=(2), Iterators.take(1:7, 3), init=Int32(0)) === 2
 @test count(identity, [true, false], init=Int8(0)) === 1
 @test count(!, [true false; false true], dims=:, init=Int16(0)) === 2

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -693,7 +693,7 @@ end
     @test_throws TypeError count!([1], [1])
 end
 
-@test @inferred(UInt16, count(false:true, dims=:, init=0x0000)) === UInt(1)
+@test @inferred(UInt16, count(false:true, dims=:, init=0x0000)) === 1
 @test @inferred(count(isodd, reshape(1:9, 3, 3), dims=:, init=Int128(0))) === Int128(5)
 
 @testset "reduced_index for BigInt (issue #39995)" begin

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -88,12 +88,12 @@ safe_minabs(A::Array{T}, region) where {T} = safe_mapslices(minimum, abs.(A), re
     @test @inferred(count(!, Breduc, dims=region)) ≈ safe_count(.!Breduc, region)
 
     @test isequal(
-        @inferred(count(Breduc, dims=region, init=0x02)),
-        safe_count(Breduc, region) .% UInt8 .+ 0x02,
+        @inferred(Array{UInt8,ndims(Breduc)}, count(Breduc, dims=region, init=0x00)),
+        safe_count(Breduc, region),
     )
     @test isequal(
-        @inferred(count(!, Breduc, dims=region, init=Int16(0))),
-        safe_count(.!Breduc, region) .% Int16,
+        @inferred(Array{Int16,ndims(Breduc)}, count(!, Breduc, dims=region, init=Int16(0))),
+        safe_count(.!Breduc, region),
     )
 end
 
@@ -693,7 +693,7 @@ end
     @test_throws TypeError count!([1], [1])
 end
 
-@test @inferred(count(false:true, dims=:, init=0x0004)) === 0x0005
+@test @inferred(UInt16, count(false:true, dims=:, init=0x0000)) === UInt(1)
 @test @inferred(count(isodd, reshape(1:9, 3, 3), dims=:, init=Int128(0))) === Int128(5)
 
 @testset "reduced_index for BigInt (issue #39995)" begin


### PR DESCRIPTION
This is a small but concrete and independent change that can easily be split out from #58241 and is required for more pairwise reassociations (like #52397).

Specifically, it's required because `count` and `sum` use `Base.add_sum`, which very intentionally promotes small integers to `Int` or `Uint`.   And if you add two `Bool`s together, they also promote to `Int`.  But if an `init=0x00` is provided, then we get into a strange situation.  This is the status quo on master right now:

```julia
julia> const +ₛ = Base.add_sum
add_sum (generic function with 4 methods)

julia> (((0x00 +ₛ true) +ₛ true) +ₛ true) +ₛ true
0x04

julia> ((0x00 +ₛ true) +ₛ true) +ₛ ((0x00 +ₛ true) +ₛ true)
0x0000000000000004
```

In other words, if we _happen_ to choose to re-associate the branches here, we end up with a `0x02 +ₛ 0x02`, which promotes to `Uint`.

This change here adds `Bool` into the extra promotion behaviors for `add_sum`.  So with this commit, the above session becomes:

```julia
julia> (((0x00 +ₛ true) +ₛ true) +ₛ true) +ₛ true
0x0000000000000004

julia> ((0x00 +ₛ true) +ₛ true) +ₛ ((0x00 +ₛ true) +ₛ true)
0x0000000000000004
```


