### PR TITLE
remove Irrational from hash(::Real) fallback

### DIFF
--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -117,7 +117,7 @@ function hash(x::Float16, h::UInt)
 end
 
 ## generic hashing for rational values ##
-function hash(x::Real, h::UInt)
+function hash(x::T, h::UInt) where T<:Union{AbstractFloat, Rational, Integer}
     # decompose x as num*2^pow/den
     num, pow, den = decompose(x)
 

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -182,8 +182,6 @@ isinteger(::AbstractIrrational) = false
 iszero(::AbstractIrrational) = false
 isone(::AbstractIrrational) = false
 
-hash(x::Irrational, h::UInt) = 3*objectid(x) - h
-
 widen(::Type{T}) where {T<:Irrational} = T
 
 zero(::AbstractIrrational) = false


### PR DESCRIPTION
_technically_, this will (marginally) improve the mixing / randomness of `hash(::Irrational)` at the (marginal) cost of performance, since instead of `3*objectid(x) -h` it becomes the standard `hash(x::Any) = hash_finalizer(3h - objectid(x))`, but I think in practice this is more or less NFC.

it just fixes the fact that `hash(::Real)` was not in fact generic over all `<:Real` inputs as evidenced by the fact that `hash(::Irrational)` was manually skipping that dispatch and re-implementing the fallback since `Base.decompose` has no `Irrational` method. this PR would tighten the signature and let `hash(::Irrational)` hit the _real_ fallback.