### PR TITLE
Make `hash_integer` coincide with `hash` for small values

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -856,7 +856,7 @@ if Limb === UInt64 === UInt
             s == 0 && return hash_integer(0, h)
             p = convert(Ptr{UInt64}, n.d)
             b = unsafe_load(p)
-            h ⊻= hash_finalizer(ifelse(s < 0, -b, b) ⊻ h)
+            h = hash(ifelse(s < 0, -b, b), h)
             for k = 2:abs(s)
                 h ⊻= hash_finalizer(unsafe_load(p, k) ⊻ h)
             end

--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -69,8 +69,9 @@ hash(x::UInt64, h::UInt) = hash_uint64(hash_mix_linear(x, h))
 hash(x::Int64, h::UInt) = hash(bitcast(UInt64, x), h)
 hash(x::Union{Bool, Int8, UInt8, Int16, UInt16, Int32, UInt32}, h::UInt) = hash(Int64(x), h)
 
+# this should coincide with the hash of UInt64 if `n` fits in UInt64
 function hash_integer(n::Integer, h::UInt)
-    h ⊻= hash_uint((n % UInt) ⊻ h)
+    h = hash((n % UInt), h)
     n = abs(n)
     n >>>= sizeof(UInt) << 3
     while n != 0

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -815,10 +815,4 @@ end
         bfloat = big(11.0)^i
         @test (hash(bint) == hash(bfloat)) == (bint == bfloat)
     end
-    for n in [-12345, -12, -1, 0, 1, 17, 2049]
-        # hashes of small numbers should coincide with Int
-        @test hash(n) == hash(big(n))
-        # Base.hash_integer should coincide with hash for small numbers (#58386)
-        @test hash(big(n), Base.HASH_SEED) == Base.hash_integer(big(n), Base.HASH_SEED)
-    end
 end

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -815,4 +815,10 @@ end
         bfloat = big(11.0)^i
         @test (hash(bint) == hash(bfloat)) == (bint == bfloat)
     end
+    for n in [-12345, -12, -1, 0, 1, 17, 2049]
+        # hashes of small numbers should coincide with Int
+        @test hash(n) == hash(big(n))
+        # Base.hash_integer should coincide with hash for small numbers (#58386)
+        @test hash(big(n), Base.HASH_SEED) == Base.hash_integer(big(n), Base.HASH_SEED)
+    end
 end

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -311,7 +311,7 @@ end
 @test Core.Compiler.is_foldable_nothrow(Base.infer_effects(hash, Tuple{Type{Int}, UInt}))
 
 @testset "issue #58386" begin
-    for T in [Int, UInt, Int128, UInt128]
+    for T in [Int, UInt]
         for a in [typemin(T), typemax(T), zero(T), one(T), -one(T), T(17)]
             @test hash(a) == hash(big(a))
             @test hash(a) == Base.hash_integer(a, Base.HASH_SEED)

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -311,8 +311,11 @@ end
 @test Core.Compiler.is_foldable_nothrow(Base.infer_effects(hash, Tuple{Type{Int}, UInt}))
 
 @testset "issue #58386" begin
-    for n in [-12345, -12, -1, 0, 1, 17, 2049]
-        # Base.hash_integer should coincide with hash for small numbers (#58386)
-        @test hash(n, Base.HASH_SEED) == Base.hash_integer(n, Base.HASH_SEED)
+    for T in [Int, UInt, Int128, UInt128]
+        for a in [typemin(T), typemax(T), zero(T), one(T), -one(T), T(17)]
+            @test hash(a) == hash(big(a))
+            @test hash(a) == Base.hash_integer(a, Base.HASH_SEED)
+            @test hash(big(a)) == Base.hash_integer(big(a), Base.HASH_SEED)
+        end
     end
 end

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -309,3 +309,10 @@ struct AUnionParam{T<:Union{Nothing,Float32,Float64}} end
 end
 
 @test Core.Compiler.is_foldable_nothrow(Base.infer_effects(hash, Tuple{Type{Int}, UInt}))
+
+@testset "issue #58386" begin
+    for n in [-12345, -12, -1, 0, 1, 17, 2049]
+        # Base.hash_integer should coincide with hash for small numbers (#58386)
+        @test hash(n, Base.HASH_SEED) == Base.hash_integer(n, Base.HASH_SEED)
+    end
+end


### PR DESCRIPTION
Resolves https://github.com/JuliaLang/julia/issues/58386 with the suggested change from there. I furthermore added some basic test that verifies that the expected invariant is kept.

cc @adienes @benlorenz 