### PR TITLE
use `hash_bytes` for `hash(::Big)` and re-match `hash_integer` on small values

### DIFF
--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -70,7 +70,8 @@ hash(x::Int64, h::UInt) = hash(bitcast(UInt64, x), h)
 hash(x::Union{Bool, Int8, UInt8, Int16, UInt16, Int32, UInt32}, h::UInt) = hash(Int64(x), h)
 
 function hash_integer(n::Integer, h::UInt)
-    h ⊻= hash_uint((n % UInt) ⊻ h)
+    # when possible, try to make hash_integer match hash
+    h = hash((n % UInt), h)
     n = abs(n)
     n >>>= sizeof(UInt) << 3
     while n != 0
@@ -146,6 +147,7 @@ function hash(x::Real, h::UInt)
             if 0 <= pow # if pow is non-negative, it is an integer
                 left <= 63 && return hash(Int64(num) << Int(pow), h)
                 left <= 64 && !signbit(num) && return hash(UInt64(num) << Int(pow), h)
+                return hash_integer(num << pow, h)
             end # typemin(Int64) handled by Float64 case
             # 2^1024 is the maximum Float64 so if the power is greater, not a Float64
             # Float64s only have 53 mantisa bits (including implicit bit)

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -69,8 +69,13 @@ end
 @test hash(1//6) == hash(0x01//0x06)
 
 # issue #58386
-@testset "hash_integer on small values" begin
-    vals = Integer[typemin(Int), typemax(Int), typemin(UInt), typemax(UInt), zero(Int), zero(UInt), one(Int), one(UInt)]
+@testset "hash_integer on corner cases and small values" begin
+    vals = vcat(
+        Any[], 
+        [f(Int) for f in [typemin, typemax, zero, one, (-)∘one]],
+        [f(UInt) for f in [typemin, typemax, zero, one, (-)∘one]],
+        [zero(BigInt), one(BigInt), -one(BigInt)]
+    )
     for a in vals
         @test (Base.hash_integer(a, Base.HASH_SEED) == hash(a))
     end

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -68,6 +68,14 @@ end
 @test hash(1//6) == hash(big(1)//big(6))
 @test hash(1//6) == hash(0x01//0x06)
 
+# issue #58386
+@testset "hash_integer on small values" begin
+    vals = Integer[typemin(Int), typemax(Int), typemin(UInt), typemax(UInt), zero(Int), zero(UInt), one(Int), one(UInt)]
+    for a in vals
+        @test (Base.hash_integer(a, Base.HASH_SEED) == hash(a))
+    end
+end
+
 # hashing collections (e.g. issue #6870)
 vals = Any[
     [1,2,3,4], [1 3;2 4], Any[1,2,3,4], [1,3,2,4],

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -68,15 +68,16 @@ end
 @test hash(1//6) == hash(big(1)//big(6))
 @test hash(1//6) == hash(0x01//0x06)
 
-# issue #58386
-@testset "hash_integer on corner cases and small values" begin
+@testset "issue #58386" begin
     vals = vcat(
         Any[],
         [f(Int) for f in [typemin, typemax, zero, one, (-)∘one]],
         [f(UInt) for f in [typemin, typemax, zero, one, (-)∘one]],
-        [zero(BigInt), one(BigInt), -one(BigInt)]
+        [f(Int128) for f in [typemin, typemax, zero, one, (-)∘one]],
+        [f(UInt128) for f in [typemin, typemax, zero, one, (-)∘one]],
     )
     for a in vals
+        @test hash(a) == hash(big(a))
         @test (Base.hash_integer(a, Base.HASH_SEED) == hash(a))
     end
 end

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -71,7 +71,7 @@ end
 # issue #58386
 @testset "hash_integer on corner cases and small values" begin
     vals = vcat(
-        Any[], 
+        Any[],
         [f(Int) for f in [typemin, typemax, zero, one, (-)∘one]],
         [f(UInt) for f in [typemin, typemax, zero, one, (-)∘one]],
         [zero(BigInt), one(BigInt), -one(BigInt)]


### PR DESCRIPTION
alternative to https://github.com/JuliaLang/julia/pull/58387, fixes https://github.com/JuliaLang/julia/issues/58386

if a change like this is acceptable, I think it could be a nicer approach. this should be faster on all Big things, especially for very large objects. also more code re-use and less complexity in specialized implementations

@lgoettgens , could you potentially try this PR on your package to see if tests pass?