### PR TITLE
RFC: add ability to avoid printing trailing type parameters

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -83,6 +83,7 @@ JL_DLLEXPORT jl_typename_t *jl_new_typename_in(jl_sym_t *name, jl_module_t *modu
     jl_atomic_store_relaxed(&tn->cache_entry_count, 0);
     tn->max_methods = 0;
     tn->constprop_heuristic = 0;
+    tn->relevant_params = 0;
     return tn;
 }
 
@@ -867,6 +868,7 @@ JL_DLLEXPORT jl_datatype_t *jl_new_datatype(
             // Everything else, gets to use the unified table
             tn->mt = jl_nonfunction_mt;
         }
+        tn->relevant_params = jl_svec_len(t->parameters);
     }
     t->name = tn;
     jl_gc_wb(t, t->name);

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -82,7 +82,7 @@ JL_DLLEXPORT jl_typename_t *jl_new_typename_in(jl_sym_t *name, jl_module_t *modu
     tn->constfields = NULL;
     jl_atomic_store_relaxed(&tn->cache_entry_count, 0);
     tn->max_methods = 0;
-    tn->constprop_heustic = 0;
+    tn->constprop_heuristic = 0;
     return tn;
 }
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2970,6 +2970,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_type_typename = type_type->name;
     jl_type_type_mt = jl_new_method_table(jl_type_typename->name, core);
     jl_type_typename->mt = jl_type_type_mt;
+    jl_type_typename->relevant_params = 1;
 
     // initialize them. lots of cycles.
     // NOTE: types are not actually mutable, but we want to ensure they are heap-allocated with stable addresses
@@ -3008,23 +3009,24 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_typename_type->super = jl_any_type;
     jl_typename_type->parameters = jl_emptysvec;
     jl_typename_type->name->n_uninitialized = 17 - 2;
-    jl_typename_type->name->names = jl_perm_symsvec(17, "name", "module",
+    jl_typename_type->name->names = jl_perm_symsvec(18, "name", "module",
                                                     "names", "atomicfields", "constfields",
                                                     "wrapper", "Typeofwrapper", "cache", "linearcache",
                                                     "mt", "partial",
                                                     "hash", "n_uninitialized",
                                                     "flags", // "abstract", "mutable", "mayinlinealloc",
-                                                    "cache_entry_count", "max_methods", "constprop_heuristic");
+                                                    "cache_entry_count", "max_methods", "constprop_heuristic", "relevant_params");
     const static uint32_t typename_constfields[1]  = { 0b00011101000100111 }; // TODO: put back atomicfields and constfields in this list
     const static uint32_t typename_atomicfields[1] = { 0b00100000110000000 };
     jl_typename_type->name->constfields = typename_constfields;
     jl_typename_type->name->atomicfields = typename_atomicfields;
     jl_precompute_memoized_dt(jl_typename_type, 1);
-    jl_typename_type->types = jl_svec(17, jl_symbol_type, jl_any_type /*jl_module_type*/,
+    jl_typename_type->types = jl_svec(18, jl_symbol_type, jl_any_type /*jl_module_type*/,
                                       jl_simplevector_type, jl_any_type/*jl_voidpointer_type*/, jl_any_type/*jl_voidpointer_type*/,
                                       jl_type_type, jl_type_type, jl_simplevector_type, jl_simplevector_type,
                                       jl_methtable_type, jl_any_type,
                                       jl_any_type /*jl_long_type*/, jl_any_type /*jl_int32_type*/,
+                                      jl_any_type /*jl_uint8_type*/,
                                       jl_any_type /*jl_uint8_type*/,
                                       jl_any_type /*jl_uint8_type*/,
                                       jl_any_type /*jl_uint8_type*/,
@@ -3858,6 +3860,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_typename_type->types, 14, jl_uint8_type);
     jl_svecset(jl_typename_type->types, 15, jl_uint8_type);
     jl_svecset(jl_typename_type->types, 16, jl_uint8_type);
+    jl_svecset(jl_typename_type->types, 17, jl_uint8_type);
     jl_svecset(jl_methtable_type->types, 4, jl_long_type);
     jl_svecset(jl_methtable_type->types, 5, jl_module_type);
     jl_svecset(jl_methtable_type->types, 6, jl_array_any_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -539,6 +539,7 @@ typedef struct {
     _Atomic(uint8_t) cache_entry_count; // (approximate counter of TypeMapEntry for heuristics)
     uint8_t max_methods; // override for inference's max_methods setting (0 = no additional limit or relaxation)
     uint8_t constprop_heuristic; // override for inference's constprop heuristic
+    uint8_t relevant_params; // hint for how many parameters should be printed
 } jl_typename_t;
 
 typedef struct {

--- a/src/julia.h
+++ b/src/julia.h
@@ -538,7 +538,7 @@ typedef struct {
     uint8_t _reserved:5;
     _Atomic(uint8_t) cache_entry_count; // (approximate counter of TypeMapEntry for heuristics)
     uint8_t max_methods; // override for inference's max_methods setting (0 = no additional limit or relaxation)
-    uint8_t constprop_heustic; // override for inference's constprop heuristic
+    uint8_t constprop_heuristic; // override for inference's constprop heuristic
 } jl_typename_t;
 
 typedef struct {

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -80,7 +80,7 @@ const TAGS = Any[
 const NTAGS = length(TAGS)
 @assert NTAGS == 255
 
-const ser_version = 31 # do not make changes without bumping the version #!
+const ser_version = 32 # do not make changes without bumping the version #!
 
 format_version(::AbstractSerializer) = ser_version
 format_version(s::Serializer) = s.version
@@ -554,6 +554,7 @@ function serialize_typename(s::AbstractSerializer, t::Core.TypeName)
 
     ver > 30 && serialize(s, t.cache_entry_count)
     ver > 30 && serialize(s, t.constprop_heuristic)
+    ver > 31 && serialize(s, t.relevant_params)
     nothing
 end
 
@@ -1508,6 +1509,7 @@ function deserialize_typename(s::AbstractSerializer, number)
 
     ver > 30 && (tn.cache_entry_count = deserialize(s)::UInt8)
     ver > 30 && (tn.constprop_heuristic = deserialize(s)::UInt8)
+    ver > 31 && (tn.relevant_params = deserialize(s)::UInt8)
     return tn
 end
 

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -80,7 +80,7 @@ const TAGS = Any[
 const NTAGS = length(TAGS)
 @assert NTAGS == 255
 
-const ser_version = 30 # do not make changes without bumping the version #!
+const ser_version = 31 # do not make changes without bumping the version #!
 
 format_version(::AbstractSerializer) = ser_version
 format_version(s::Serializer) = s.version
@@ -534,6 +534,8 @@ function serialize_typename(s::AbstractSerializer, t::Core.TypeName)
     serialize(s, Base.issingletontype(primary))
     serialize(s, t.flags & 0x1 == 0x1) # .abstract
     serialize(s, t.flags & 0x2 == 0x2) # .mutable
+    ver = format_version(s)
+    ver > 30 && serialize(s, t.flags & 0x4 == 0x4) # .mayinlinealloc
     serialize(s, Int32(length(primary.types) - t.n_uninitialized))
     serialize(s, t.max_methods)
     if isdefined(t, :mt) && t.mt !== Symbol.name.mt
@@ -549,6 +551,9 @@ function serialize_typename(s::AbstractSerializer, t::Core.TypeName)
     else
         writetag(s.io, UNDEFREF_TAG)
     end
+
+    ver > 30 && serialize(s, t.cache_entry_count)
+    ver > 30 && serialize(s, t.constprop_heuristic)
     nothing
 end
 
@@ -1443,8 +1448,10 @@ function deserialize_typename(s::AbstractSerializer, number)
     has_instance = deserialize(s)::Bool
     abstr = deserialize(s)::Bool
     mutabl = deserialize(s)::Bool
+    ver = format_version(s)
+    ver > 30 && deserialize(s)::Bool && (tn.flags |= 0x4)
     ninitialized = deserialize(s)::Int32
-    maxm = format_version(s) >= 18 ? deserialize(s)::UInt8 : UInt8(0)
+    maxm = ver >= 18 ? deserialize(s)::UInt8 : UInt8(0)
 
     if makenew
         # TODO: there's an unhanded cycle in the dependency graph at this point:
@@ -1498,6 +1505,9 @@ function deserialize_typename(s::AbstractSerializer, number)
         mt = Symbol.name.mt
         ccall(:jl_set_nth_field, Cvoid, (Any, Csize_t, Any), tn, Base.fieldindex(Core.TypeName, :mt)-1, mt)
     end
+
+    ver > 30 && (tn.cache_entry_count = deserialize(s)::UInt8)
+    ver > 30 && (tn.constprop_heuristic = deserialize(s)::UInt8)
     return tn
 end
 


### PR DESCRIPTION
Lots of types have extra parameters added just for specialization and conveying no useful additional information. I have gotten requests for some way to avoid printing these to cut down type verbosity e.g. in stack traces. This PR adds a very minimal mechanism that does the job:

```
julia> struct Hidden{A,B,C}
           x::A
       end

julia> Core.typename(Hidden).relevant_params = 1
1

julia> error(Hidden{Int,String,String}(1))
ERROR: Hidden{Int64, String, String}(1)
Stacktrace:
 [1] error(s::Hidden{Int64, …})
   @ Base ./error.jl:54
 [2] top-level scope
   @ REPL[4]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

Note the limit is only applied inside the stack trace and not the exception, but that's an orthogonal feature that could be changed.

It might seem a bit un-principled to just cram a mutable integer field in there; we wouldn't necessarily want this changing all the time. Nevertheless I think this is a pretty efficient and effective way to do this. Using methods would be way too heavyweight. But, we might want to make the field constant and only set once when the type is defined, and have some macro syntax for specifying this.