### PR TITLE
Fix signedness typo in world range update

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3545,7 +3545,7 @@ function merge_override_effects!(interp::AbstractInterpreter, effects::Effects, 
             # N.B.: We'd like deleted_world here, but we can't add an appropriate edge at this point.
             # However, in order to reach here in the first place, ordinary method lookup would have
             # had to add an edge and appropriate invalidation trigger.
-            valid_worlds = WorldRange(m.primary_world, typemax(Int))
+            valid_worlds = WorldRange(m.primary_world, typemax(UInt))
             if sv.world.this in valid_worlds
                 update_valid_age!(sv, valid_worlds)
             else

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -475,7 +475,7 @@ function adjust_effects(ipo_effects::Effects, def::Method, world::UInt)
     valid_worlds = WorldRange(0, typemax(UInt))
     if is_effect_overridden(override, :consistent)
         # See note on `typemax(Int)` instead of `deleted_world` in adjust_effects!
-        override_valid_worlds = WorldRange(def.primary_world, typemax(Int))
+        override_valid_worlds = WorldRange(def.primary_world, typemax(UInt))
         if world in override_valid_worlds
             ipo_effects = Effects(ipo_effects; consistent=ALWAYS_TRUE)
             valid_worlds = override_valid_worlds


### PR DESCRIPTION
This manifested itself as a missing invalidation downstream, but I don't know if this is visible from Base. In general, we don't set the InferenceState's max_world to `typemax(UInt)`, but rather to the maximum world age at start of inference, and then we check at the end of inference if the world age is still the same, and only then raise it to `typemax(UInt)` (which arms the backedges). The downstream setup is a bit more complex, and I don't entirely know where this leaked out, but this change fixed it regardless.