### PR TITLE
Drop C linkage declaration on functions returning C++ objects

### DIFF
--- a/src/processor.h
+++ b/src/processor.h
@@ -245,21 +245,21 @@ extern jl_image_pointers_t jl_image_pointers;
 #include <vector>
 
 extern JL_DLLEXPORT bool jl_processor_print_help;
-// NOLINTBEGIN(clang-diagnostic-return-type-c-linkage)
+
 /**
  * Returns the CPU name and feature string to be used by LLVM JIT.
  *
  * If the detected/specified CPU name is not available on the LLVM version specified,
  * a fallback CPU name will be used. Unsupported features will be ignored.
  */
-extern "C" JL_DLLEXPORT std::pair<std::string,llvm::SmallVector<std::string, 0>> jl_get_llvm_target(const char *cpu_target, bool imaging, uint32_t &flags) JL_NOTSAFEPOINT;
+JL_DLLEXPORT std::pair<std::string,llvm::SmallVector<std::string, 0>> jl_get_llvm_target(const char *cpu_target, bool imaging, uint32_t &flags) JL_NOTSAFEPOINT;
 
 /**
  * Returns the CPU name and feature string to be used by LLVM disassembler.
  *
  * This will return a generic CPU name and a full feature string.
  */
-extern "C" JL_DLLEXPORT const std::pair<std::string,std::string> &jl_get_llvm_disasm_target(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT const std::pair<std::string,std::string> &jl_get_llvm_disasm_target(void) JL_NOTSAFEPOINT;
 
 struct jl_target_spec_t {
     // LLVM target name
@@ -276,8 +276,8 @@ struct jl_target_spec_t {
 /**
  * Return the list of targets to clone
  */
-extern "C" JL_DLLEXPORT llvm::SmallVector<jl_target_spec_t, 0> jl_get_llvm_clone_targets(const char *cpu_target) JL_NOTSAFEPOINT;
-// NOLINTEND(clang-diagnostic-return-type-c-linkage)
+JL_DLLEXPORT llvm::SmallVector<jl_target_spec_t, 0> jl_get_llvm_clone_targets(const char *cpu_target) JL_NOTSAFEPOINT;
+
 struct FeatureName {
     const char *name;
     uint32_t bit; // bit index into a `uint32_t` array;


### PR DESCRIPTION
Note that the linter had to be told to ignore this. This seems like a better solution.

Closes #49825 which attempted something similar but was incomplete. On that PR @keno wrote:

> These declarations were added in https://github.com/JuliaLang/julia/commit/628209c1f2f746e3fc21ccd7cb34e67289403d44 as part of the general split of codegen and runtime, so I think the addition of extern "C" here was mechanical and not intended to be used from something that actually uses the C ABI, so I think it is fine to remove this, since I don't think any packages, etc are depending on this (and if they are it's easy to put back).