### PR TITLE
Use a nonzero initial size with llvm::SmallSet.

### DIFF
--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -246,7 +246,7 @@ struct jl_codegen_params_t {
     SmallVector<cfunc_decl_t,0> cfuncs;
     std::map<void*, GlobalVariable*> global_targets;
     jl_array_t *temporary_roots = nullptr;
-    SmallSet<jl_value_t *, 0> temporary_roots_set;
+    SmallSet<jl_value_t *, 8> temporary_roots_set;
     std::map<std::tuple<jl_code_instance_t*,bool>, GlobalVariable*> external_fns;
     std::map<jl_datatype_t*, DIType*> ditypes;
     std::map<jl_datatype_t*, Type*> llvmtypes;


### PR DESCRIPTION
Fixes compilation warnings and a failed assertion, at least when using LLVM 18:

```
In file included from /home/tim/Julia/src/julia/build/dev/usr/include/llvm/IR/PassManager.h:42,
                 from /home/tim/Julia/src/julia/build/dev/usr/include/llvm/Analysis/TargetTransformInfo.h:27,
                 from /home/tim/Julia/src/julia/src/disasm.cpp:63:
/home/tim/Julia/src/julia/build/dev/usr/include/llvm/ADT/SmallPtrSet.h: In instantiation of 'class llvm::SmallPtrSet<_jl_value_t*, 0>':
/home/tim/Julia/src/julia/build/dev/usr/include/llvm/ADT/SmallSet.h:256:7:   required from 'class llvm::SmallSet<_jl_value_t*, 0>'
/home/tim/Julia/src/julia/src/jitlayers.h:244:31:   required from here
/home/tim/Julia/src/julia/build/dev/usr/include/llvm/ADT/SmallPtrSet.h:462:28: warning: ISO C++ forbids zero-size array [-Wpedantic]
  462 |   const void *SmallStorage[SmallSizePowTwo];
      |                            ^~~~~~~~~~~~~~~
    LINK build/dev/usr/lib/libjulia-codegen.so.1.12.0
    LINK build/dev/usr/lib/libjulia-codegen.so.1.12
    LINK build/dev/usr/lib/libjulia-codegen.so
    JULIA build/dev/usr/lib/julia/basecompiler.ji
julia: /home/tim/Julia/src/julia/build/dev/usr/include/llvm/ADT/SmallPtrSet.h:78: llvm::SmallPtrSetImplBase::SmallPtrSetImplBase(const void**, unsigned int): Assertion `SmallSize && (SmallSize & (SmallSize-1)) == 0 && "Initial size must be a power of two!"' failed.
```

Introduced by #57961. Given that this isn't a problem on LLVM 19, maybe we only want this on the backports branch?