### PR TITLE
Convert more stdlibs to LazyLibraries

### DIFF
--- a/stdlib/LLVMLibUnwind_jll/src/LLVMLibUnwind_jll.jl
+++ b/stdlib/LLVMLibUnwind_jll/src/LLVMLibUnwind_jll.jl
@@ -5,38 +5,28 @@
 baremodule LLVMLibUnwind_jll
 using Base, Libdl
 
-const PATH_list = String[]
-const LIBPATH_list = String[]
-
 export llvmlibunwind
 
 # These get calculated in __init__()
 const PATH = Ref("")
+const PATH_list = String[]
 const LIBPATH = Ref("")
+const LIBPATH_list = String[]
 artifact_dir::String = ""
-llvmlibunwind_handle::Ptr{Cvoid} = C_NULL
 llvmlibunwind_path::String = ""
 
-const llvmlibunwind = "libunwind"
+const _llvmlibunwind_path = BundledLazyLibraryPath("libunwind")
+const llvmlibunwind = LazyLibrary(_llvmlibunwind_path)
+function eager_mode()
+    dlopen(llvmlibunwind)
+end
+is_available() = @static Sys.isapple() ? true : false
 
 function __init__()
-    # We only dlopen something on MacOS
-    @static if Sys.isapple()
-        global llvmlibunwind_handle = dlopen(llvmlibunwind)
-        global llvmlibunwind_path = dlpath(llvmlibunwind_handle)
-        global artifact_dir = dirname(Sys.BINDIR)
-        LIBPATH[] = dirname(llvmlibunwind_path)
-        push!(LIBPATH_list, LIBPATH[])
-    end
+    global llvmlibunwind_path = string(_llvmlibunwind_path)
+    global artifact_dir = dirname(Sys.BINDIR)
+    LIBPATH[] = dirname(llvmlibunwind_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
-
-# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
-# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
-# there isn't one.  It instead returns the overall Julia prefix.
-is_available() = @static Sys.isapple() ? true : false
-find_artifact_dir() = artifact_dir
-dev_jll() = error("stdlib JLLs cannot be dev'ed")
-best_wrapper = nothing
-get_llvmlibunwind_path() = llvmlibunwind_path
 
 end  # module LLVMLibUnwind_jll

--- a/stdlib/LLVMLibUnwind_jll/test/runtests.jl
+++ b/stdlib/LLVMLibUnwind_jll/test/runtests.jl
@@ -1,16 +1,14 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Test, Libdl
-using LLVMLibUnwind_jll: llvmlibunwind_handle
-
+using Test, Libdl, LLVMLibUnwind_jll
 @testset "LLVMLibUnwind_jll" begin
     if Sys.isapple()
-        @test dlsym(llvmlibunwind_handle, :unw_getcontext; throw_error=false) !== nothing
-        @test dlsym(llvmlibunwind_handle, :unw_init_local; throw_error=false) !== nothing
-        @test dlsym(llvmlibunwind_handle, :unw_init_local_dwarf; throw_error=false) !== nothing
-        @test dlsym(llvmlibunwind_handle, :unw_step; throw_error=false) !== nothing
-        @test dlsym(llvmlibunwind_handle, :unw_get_reg; throw_error=false) !== nothing
-        @test dlsym(llvmlibunwind_handle, :unw_set_reg; throw_error=false) !== nothing
-        @test dlsym(llvmlibunwind_handle, :unw_resume; throw_error=false) !== nothing
+        @test dlsym(llvmlibunwind, :unw_getcontext; throw_error=false) !== nothing
+        @test dlsym(llvmlibunwind, :unw_init_local; throw_error=false) !== nothing
+        @test dlsym(llvmlibunwind, :unw_init_local_dwarf; throw_error=false) !== nothing
+        @test dlsym(llvmlibunwind, :unw_step; throw_error=false) !== nothing
+        @test dlsym(llvmlibunwind, :unw_get_reg; throw_error=false) !== nothing
+        @test dlsym(llvmlibunwind, :unw_set_reg; throw_error=false) !== nothing
+        @test dlsym(llvmlibunwind, :unw_resume; throw_error=false) !== nothing
     end
 end

--- a/stdlib/LibCURL_jll/src/LibCURL_jll.jl
+++ b/stdlib/LibCURL_jll/src/LibCURL_jll.jl
@@ -9,41 +9,46 @@ if !(Sys.iswindows() || Sys.isapple())
     using OpenSSL_jll
 end
 
-const PATH_list = String[]
-const LIBPATH_list = String[]
-
 export libcurl
 
 # These get calculated in __init__()
 const PATH = Ref("")
+const PATH_list = String[]
 const LIBPATH = Ref("")
+const LIBPATH_list = String[]
 artifact_dir::String = ""
-libcurl_handle::Ptr{Cvoid} = C_NULL
 libcurl_path::String = ""
 
+_libcurl_dependencies = LazyLibrary[
+    libz, libnghttp2, libssh2
+]
 if Sys.iswindows()
-    const libcurl = "libcurl-4.dll"
+    const _libcurl_path = BundledLazyLibraryPath("libcurl-4.dll")
 elseif Sys.isapple()
-    const libcurl = "@rpath/libcurl.4.dylib"
+    const _libcurl_path = BundledLazyLibraryPath("libcurl.4.dylib")
 else
-    const libcurl = "libcurl.so.4"
+    const _libcurl_path = BundledLazyLibraryPath("libcurl.so.4")
+    append!(_libcurl_dependencies, [libssl, libcrypto])
 end
 
+const libcurl = LazyLibrary(
+    _libcurl_path,
+    dependencies=_libcurl_dependencies,
+)
+
+function eager_mode()
+    Zlib_jll.eager_mode()
+    nghttp2_jll.eager_mode()
+    LibSSH2_jll.eager_mode()
+    dlopen(libcurl)
+end
+is_available() = true
+
 function __init__()
-    global libcurl_handle = dlopen(libcurl)
-    global libcurl_path = dlpath(libcurl_handle)
+    global libcurl_path = string(_libcurl_path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libcurl_path)
     push!(LIBPATH_list, LIBPATH[])
 end
-
-# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
-# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
-# there isn't one.  It instead returns the overall Julia prefix.
-is_available() = true
-find_artifact_dir() = artifact_dir
-dev_jll() = error("stdlib JLLs cannot be dev'ed")
-best_wrapper = nothing
-get_libcurl_path() = libcurl_path
 
 end  # module LibCURL_jll

--- a/stdlib/LibGit2_jll/src/LibGit2_jll.jl
+++ b/stdlib/LibGit2_jll/src/LibGit2_jll.jl
@@ -9,41 +9,42 @@ if !(Sys.iswindows() || Sys.isapple())
     using OpenSSL_jll
 end
 
-const PATH_list = String[]
-const LIBPATH_list = String[]
-
 export libgit2
 
 # These get calculated in __init__()
 const PATH = Ref("")
+const PATH_list = String[]
 const LIBPATH = Ref("")
+const LIBPATH_list = String[]
 artifact_dir::String = ""
-libgit2_handle::Ptr{Cvoid} = C_NULL
 libgit2_path::String = ""
 
+_libgit2_dependencies = LazyLibrary[libssh2]
 if Sys.iswindows()
-    const libgit2 = "libgit2.dll"
+    const _libgit2_path = BundledLazyLibraryPath("libgit2.dll")
 elseif Sys.isapple()
-    const libgit2 = "@rpath/libgit2.1.9.dylib"
+    const _libgit2_path = BundledLazyLibraryPath("libgit2.1.9.dylib")
 else
-    const libgit2 = "libgit2.so.1.9"
+    const _libgit2_path = BundledLazyLibraryPath("libgit2.so.1.9")
+    append!(_libgit2_dependencies, [libcrypto, libssl])
 end
 
+const libgit2 = LazyLibrary(_libgit2_path, dependencies=_libgit2_dependencies)
+
+function eager_mode()
+    LibSSH2_jll.eager_mode()
+    @static if !(Sys.iswindows() || Sys.isapple())
+        OpenSSL_jll.eager_mode()
+    end
+    dlopen(libgit2)
+end
+is_available() = true
+
 function __init__()
-    global libgit2_handle = dlopen(libgit2)
-    global libgit2_path = dlpath(libgit2_handle)
+    global libgit2_path = string(_libgit2_path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libgit2_path)
     push!(LIBPATH_list, LIBPATH[])
 end
-
-# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
-# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
-# there isn't one.  It instead returns the overall Julia prefix.
-is_available() = true
-find_artifact_dir() = artifact_dir
-dev_jll() = error("stdlib JLLs cannot be dev'ed")
-best_wrapper = nothing
-get_libgit2_path() = libgit2_path
 
 end  # module LibGit2_jll

--- a/stdlib/LibUnwind_jll/Project.toml
+++ b/stdlib/LibUnwind_jll/Project.toml
@@ -3,8 +3,10 @@ uuid = "745a5e78-f969-53e9-954f-d19f2f74f4e3"
 version = "1.8.1+2"
 
 [deps]
-Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+CompilerSupportLibraries_jll = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+Zlib_jll = "83775a58-1f1d-513f-b197-d71354ab007a"
 
 [compat]
 julia = "1.6"

--- a/stdlib/LibUnwind_jll/src/LibUnwind_jll.jl
+++ b/stdlib/LibUnwind_jll/src/LibUnwind_jll.jl
@@ -4,39 +4,36 @@
 
 baremodule LibUnwind_jll
 using Base, Libdl
-
-const PATH_list = String[]
-const LIBPATH_list = String[]
+using CompilerSupportLibraries_jll
+using Zlib_jll
 
 export libunwind
 
 # These get calculated in __init__()
 const PATH = Ref("")
+const PATH_list = String[]
 const LIBPATH = Ref("")
+const LIBPATH_list = String[]
 artifact_dir::String = ""
-libunwind_handle::Ptr{Cvoid} = C_NULL
 libunwind_path::String = ""
 
-const libunwind = "libunwind.so.8"
+const _libunwind_path = BundledLazyLibraryPath("libunwind.so.8")
+const libunwind = LazyLibrary(
+    _libunwind_path, dependencies=[libgcc_s, libz]
+)
+
+function eager_mode()
+    CompilerSupportLibraries_jll.eager_mode()
+    Zlib_jll.eager_mode()
+    dlopen(libunwind)
+end
+is_available() = @static(Sys.islinux() || Sys.isfreebsd()) ? true : false
 
 function __init__()
-    # We only do something on Linux/FreeBSD
-    @static if Sys.islinux() || Sys.isfreebsd()
-        global libunwind_handle = dlopen(libunwind)
-        global libunwind_path = dlpath(libunwind_handle)
-        global artifact_dir = dirname(Sys.BINDIR)
-        LIBPATH[] = dirname(libunwind_path)
-        push!(LIBPATH_list, LIBPATH[])
-    end
+    global libunwind_path = string(_libunwind_path)
+    global artifact_dir = dirname(Sys.BINDIR)
+    LIBPATH[] = dirname(libunwind_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
-
-# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
-# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
-# there isn't one.  It instead returns the overall Julia prefix.
-is_available() = @static (Sys.islinux() || Sys.isfreebsd()) ? true : false
-find_artifact_dir() = artifact_dir
-dev_jll() = error("stdlib JLLs cannot be dev'ed")
-best_wrapper = nothing
-get_libunwind_path() = libunwind_path
 
 end  # module LibUnwind_jll

--- a/stdlib/LibUnwind_jll/test/runtests.jl
+++ b/stdlib/LibUnwind_jll/test/runtests.jl
@@ -4,6 +4,6 @@ using Test, Libdl, LibUnwind_jll
 
 @testset "LibUnwind_jll" begin
     if !Sys.isapple() && !Sys.iswindows()
-        @test dlsym(LibUnwind_jll.libunwind_handle, :unw_backtrace; throw_error=false) !== nothing
+        @test dlsym(LibUnwind_jll.libunwind, :unw_backtrace; throw_error=false) !== nothing
     end
 end

--- a/stdlib/OpenBLAS_jll/Project.toml
+++ b/stdlib/OpenBLAS_jll/Project.toml
@@ -3,10 +3,9 @@ uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
 version = "0.3.29+0"
 
 [deps]
-# See note in `src/OpenBLAS_jll.jl` about this dependency.
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 CompilerSupportLibraries_jll = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [compat]
 julia = "1.11"

--- a/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
+++ b/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
@@ -2,7 +2,7 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/OpenBLAS_jll.jl
 baremodule OpenBLAS_jll
-using Base, Libdl, Base.BinaryPlatforms
+using Base, Libdl
 using CompilerSupportLibraries_jll
 
 export libopenblas

--- a/stdlib/OpenSSL_jll/src/OpenSSL_jll.jl
+++ b/stdlib/OpenSSL_jll/src/OpenSSL_jll.jl
@@ -5,54 +5,48 @@
 baremodule OpenSSL_jll
 using Base, Libdl, Base.BinaryPlatforms
 
-const PATH_list = String[]
-const LIBPATH_list = String[]
-
 export libcrypto, libssl
 
 # These get calculated in __init__()
 const PATH = Ref("")
+const PATH_list = String[]
 const LIBPATH = Ref("")
+const LIBPATH_list = String[]
 artifact_dir::String = ""
-libcrypto_handle::Ptr{Cvoid} = C_NULL
 libcrypto_path::String = ""
-libssl_handle::Ptr{Cvoid} = C_NULL
 libssl_path::String = ""
 
 if Sys.iswindows()
     if arch(HostPlatform()) == "x86_64"
-        const libcrypto = "libcrypto-3-x64.dll"
-        const libssl = "libssl-3-x64.dll"
+        const _libcrypto_path = BundledLazyLibraryPath("libcrypto-3-x64.dll")
+        const _libssl_path = BundledLazyLibraryPath("libssl-3-x64.dll")
     else
-        const libcrypto = "libcrypto-3.dll"
-        const libssl = "libssl-3.dll"
+        const _libcrypto_path = BundledLazyLibraryPath("libcrypto-3.dll")
+        const _libssl_path = BundledLazyLibraryPath("libssl-3.dll")
     end
 elseif Sys.isapple()
-    const libcrypto = "@rpath/libcrypto.3.dylib"
-    const libssl = "@rpath/libssl.3.dylib"
+    const _libcrypto_path = BundledLazyLibraryPath("libcrypto.3.dylib")
+    const _libssl_path = BundledLazyLibraryPath("libssl.3.dylib")
 else
-    const libcrypto = "libcrypto.so.3"
-    const libssl = "libssl.so.3"
+    const _libcrypto_path = BundledLazyLibraryPath("libcrypto.so.3")
+    const _libssl_path = BundledLazyLibraryPath("libssl.so.3")
 end
 
+const libcrypto = LazyLibrary(_libcrypto_path)
+const libssl = LazyLibrary(_libssl_path, dependencies=[libcrypto])
+
+function eager_mode()
+    dlopen(libcrypto)
+    dlopen(libssl)
+end
+is_available() = true
+
 function __init__()
-    global libcrypto_handle = dlopen(libcrypto)
-    global libcrypto_path = dlpath(libcrypto_handle)
-    global libssl_handle = dlopen(libssl)
-    global libssl_path = dlpath(libssl_handle)
+    global libcrypto_path = string(_libcrypto_path)
+    global libssl_path = string(_libssl_path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libssl_path)
     push!(LIBPATH_list, LIBPATH[])
 end
-
-# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
-# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
-# there isn't one.  It instead returns the overall Julia prefix.
-is_available() = true
-find_artifact_dir() = artifact_dir
-dev_jll() = error("stdlib JLLs cannot be dev'ed")
-best_wrapper = nothing
-get_libcrypto_path() = libcrypto_path
-get_libssl_path() = libssl_path
 
 end  # module OpenSSL_jll

--- a/stdlib/Zlib_jll/src/Zlib_jll.jl
+++ b/stdlib/Zlib_jll/src/Zlib_jll.jl
@@ -4,41 +4,35 @@
 baremodule Zlib_jll
 using Base, Libdl
 
-const PATH_list = String[]
-const LIBPATH_list = String[]
-
 export libz
 
 # These get calculated in __init__()
 const PATH = Ref("")
+const PATH_list = String[]
 const LIBPATH = Ref("")
+const LIBPATH_list = String[]
 artifact_dir::String = ""
-libz_handle::Ptr{Cvoid} = C_NULL
 libz_path::String = ""
 
 if Sys.iswindows()
-    const libz = "libz.dll"
+    const _libz_path = BundledLazyLibraryPath("libz.dll")
 elseif Sys.isapple()
-    const libz = "@rpath/libz.1.dylib"
+    const _libz_path = BundledLazyLibraryPath("libz.1.dylib")
 else
-    const libz = "libz.so.1"
+    const _libz_path = BundledLazyLibraryPath("libz.so.1")
 end
+const libz = LazyLibrary(_libz_path)
+
+function eager_mode()
+    dlopen(libz)
+end
+is_available() = true
 
 function __init__()
-    global libz_handle = dlopen(libz)
-    global libz_path = dlpath(libz_handle)
+    global libz_path = string(_libz_path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libz_path)
     push!(LIBPATH_list, LIBPATH[])
 end
-
-# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
-# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
-# there isn't one.  It instead returns the overall Julia prefix.
-is_available() = true
-find_artifact_dir() = artifact_dir
-dev_jll() = error("stdlib JLLs cannot be dev'ed")
-best_wrapper = nothing
-get_libz_path() = libz_path
 
 end  # module Zlib_jll

--- a/stdlib/nghttp2_jll/src/nghttp2_jll.jl
+++ b/stdlib/nghttp2_jll/src/nghttp2_jll.jl
@@ -4,41 +4,36 @@
 baremodule nghttp2_jll
 using Base, Libdl
 
-const PATH_list = String[]
-const LIBPATH_list = String[]
-
 export libnghttp2
 
 # These get calculated in __init__()
 const PATH = Ref("")
+const PATH_list = String[]
 const LIBPATH = Ref("")
+const LIBPATH_list = String[]
 artifact_dir::String = ""
-libnghttp2_handle::Ptr{Cvoid} = C_NULL
 libnghttp2_path::String = ""
 
 if Sys.iswindows()
-    const libnghttp2 = "libnghttp2-14.dll"
+    const _libnghttp2_path = BundledLazyLibraryPath("libnghttp2-14.dll")
 elseif Sys.isapple()
-    const libnghttp2 = "@rpath/libnghttp2.14.dylib"
+    const _libnghttp2_path = BundledLazyLibraryPath("libnghttp2.14.dylib")
 else
-    const libnghttp2 = "libnghttp2.so.14"
+    const _libnghttp2_path = BundledLazyLibraryPath("libnghttp2.so.14")
 end
 
+const libnghttp2 = LazyLibrary(_libnghttp2_path)
+
+function eager_mode()
+    dlopen(libnghttp2)
+end
+is_available() = true
+
 function __init__()
-    global libnghttp2_handle = dlopen(libnghttp2)
-    global libnghttp2_path = dlpath(libnghttp2_handle)
+    global libnghttp2_path = string(_libnghttp2_path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libnghttp2_path)
     push!(LIBPATH_list, LIBPATH[])
 end
-
-# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
-# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
-# there isn't one.  It instead returns the overall Julia prefix.
-is_available() = true
-find_artifact_dir() = artifact_dir
-dev_jll() = error("stdlib JLLs cannot be dev'ed")
-best_wrapper = nothing
-get_libnghttp2_path() = libnghttp2_path
 
 end  # module nghttp2_jll


### PR DESCRIPTION
This converts more JLL stdlibs to use lazily-loaded libraries, and as a useful side-effect, causes them to be loaded by absolute path, isolating them all from `LD_LIBRARY_PATH`-like effects.