### PR TITLE
Add `Compiler._verify_trim_world_age` for better printing

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1641,7 +1641,8 @@ function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim_m
     return codeinfos
 end
 
-verify_typeinf_trim(codeinfos::Vector{Any}, onlywarn::Bool) = invokelatest(verify_typeinf_trim, stdout, codeinfos, onlywarn)
+const _verify_trim_world_age = RefValue{UInt}(typemax(UInt))
+verify_typeinf_trim(codeinfos::Vector{Any}, onlywarn::Bool) = Core._call_in_world(_verify_trim_world_age[], verify_typeinf_trim, stdout, codeinfos, onlywarn)
 
 function return_type(@nospecialize(f), t::DataType) # this method has a special tfunc
     world = tls_world_age()

--- a/contrib/juliac-buildscript.jl
+++ b/contrib/juliac-buildscript.jl
@@ -4,6 +4,10 @@ inputfile = ARGS[1]
 output_type = ARGS[2]
 add_ccallables = ARGS[3] == "true"
 
+# Run the verifier in the current world (before modifications), so that error
+# messages and types print in their usual way.
+Core.Compiler._verify_trim_world_age[] = Base.get_world_counter()
+
 # Initialize some things not usually initialized when output is requested
 Sys.__init__()
 Base.init_depot_path()


### PR DESCRIPTION
The `juliac-buildscript` is quite aggressive in how it modifies type printing, so caching the pre-buildscript world like this allows us to print stacktraces in their usual fidelity.

Before:
```
 [1] get_size_dict!(ne::StaticNestedEinsum{?, ?}, xs::Any, size_info::Dict{Char, Int64})
   @ OMEinsum ~/.julia/dev/OMEinsum/src/einsequence.jl:269
 ...
```

After:
```
 [1] get_size_dict!(ne::StaticNestedEinsum{nothing, ('j','k','l')}, xs::Any, size_info::Dict{Char, Int64})
   @ OMEinsum ~/.julia/dev/OMEinsum/src/einsequence.jl:269
 ...
```