### PR TITLE
reflection: Label "dynamic invoke" in `code_typed`

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -2227,6 +2227,12 @@ function get_ci_mi(ci::CodeInstance)
     return def::MethodInstance
 end
 
+function get_ci_abi(ci::CodeInstance)
+    def = ci.def
+    isa(def, ABIOverride) && return def.abi
+    return (def::MethodInstance).specTypes
+end
+
 function abstract_invoke(interp::AbstractInterpreter, arginfo::ArgInfo, si::StmtInfo, sv::AbsIntState)
     argtypes = arginfo.argtypes
     ft′ = argtype_by_index(argtypes, 2)

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -2215,7 +2215,7 @@ function abstract_call_unionall(interp::AbstractInterpreter, argtypes::Vector{An
     return CallMeta(ret, Any, Effects(EFFECTS_TOTAL; nothrow), call.info)
 end
 
-function ci_abi(ci::CodeInstance)
+function get_ci_abi(ci::CodeInstance)
     def = ci.def
     isa(def, ABIOverride) && return def.abi
     (def::MethodInstance).specTypes
@@ -2225,12 +2225,6 @@ function get_ci_mi(ci::CodeInstance)
     def = ci.def
     isa(def, ABIOverride) && return def.def
     return def::MethodInstance
-end
-
-function get_ci_abi(ci::CodeInstance)
-    def = ci.def
-    isa(def, ABIOverride) && return def.abi
-    return (def::MethodInstance).specTypes
 end
 
 function abstract_invoke(interp::AbstractInterpreter, arginfo::ArgInfo, si::StmtInfo, sv::AbsIntState)
@@ -2244,7 +2238,7 @@ function abstract_invoke(interp::AbstractInterpreter, arginfo::ArgInfo, si::Stmt
         if isa(method_or_ci, CodeInstance)
             our_world = sv.world.this
             argtype = argtypes_to_type(pushfirst!(argtype_tail(argtypes, 4), ft))
-            specsig = ci_abi(method_or_ci)
+            specsig = get_ci_abi(method_or_ci)
             defdef = get_ci_mi(method_or_ci).def
             exct = method_or_ci.exctype
             if !hasintersect(argtype, specsig)

--- a/Compiler/src/ssair/show.jl
+++ b/Compiler/src/ssair/show.jl
@@ -12,7 +12,8 @@ using .Compiler: ALWAYS_FALSE, ALWAYS_TRUE, argextype, BasicBlock, block_for_ins
     CachedMethodTable, CFG, compute_basic_blocks, DebugInfoStream, Effects,
     EMPTY_SPTYPES, getdebugidx, IncrementalCompact, InferenceResult, InferenceState,
     InvalidIRError, IRCode, LimitedAccuracy, NativeInterpreter, scan_ssa_use!,
-    singleton_type, sptypes_from_meth_instance, StmtRange, Timings, VarState, widenconst
+    singleton_type, sptypes_from_meth_instance, StmtRange, Timings, VarState, widenconst,
+    get_ci_mi, get_ci_abi
 
 @nospecialize
 
@@ -95,16 +96,14 @@ function print_stmt(io::IO, idx::Int, @nospecialize(stmt), code::Union{IRCode,Co
     elseif isexpr(stmt, :invoke) && length(stmt.args) >= 2 && isa(stmt.args[1], Union{MethodInstance,CodeInstance})
         stmt = stmt::Expr
         # TODO: why is this here, and not in Base.show_unquoted
-        printstyled(io, "   invoke "; color = :light_black)
-        mi = stmt.args[1]
-        if !(mi isa Core.MethodInstance)
-            mi = (mi::Core.CodeInstance).def
-        end
-        if isa(mi, Core.ABIOverride)
-            abi = mi.abi
-            mi = mi.def
+        ci = stmt.args[1]
+        if ci isa Core.CodeInstance
+            printstyled(io, "   invoke "; color = :light_black)
+            mi = get_ci_mi(ci)
+            abi = get_ci_abi(ci)
         else
-            abi = mi.specTypes
+            printstyled(io, "dynamic invoke "; color = :yellow)
+            abi = (ci::Core.MethodInstance).specTypes
         end
         show_unquoted(io, stmt.args[2], indent)
         print(io, "(")


### PR DESCRIPTION
I ran into this when inference was trying to compile a signature and then exhausted its recursion heuristic and refused (correctly) to cache the CI, meaning that this codegen edge was not fully resolved (despite being left as an invoke).

A "dynamic invoke" like this can also be an intended result if inference knows what method you're dispatching to (e.g. `convert(::Foo, ::Integer)`) but the optimizer decides that it wants to specialize this call more aggressively (e.g. `convert(::Foo, ::UInt8)`, `convert(::Foo, ::Int8)`, `convert(::Foo, ::UInt16)`, etc.) when generating machine code.

I think the compiler currently does that rarely in practice (it prefers to not add the edge if it cannot enumerate the code on the other side), but either way, we should highlight this in `code_typed`