### PR TITLE
Add basic support for nushell (including on Windows)

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -67,7 +67,6 @@ function repl_cmd(cmd, out)
         if shell_name == "nu"
             # remove apostrophes that dont play nice with nushell
             shell_escape_cmd = replace(shell_escape(cmd), "'" => "")
-            shell_escape_cmd = "try { $shell_escape_cmd } catch { |err| \$err.rendered }"
             cmd = `$shell -c $shell_escape_cmd`
         elseif !Sys.iswindows()
             if shell_name == "fish"

--- a/base/client.jl
+++ b/base/client.jl
@@ -65,8 +65,8 @@ function repl_cmd(cmd, out)
         println(out, pwd())
     else
         if shell_name == "nu"
-            # remove backticks and apostrophes that dont play nice with nushell
-            shell_escape_cmd = replace(shell_escape(cmd), "'" => "", "`" => "")
+            # remove apostrophes that dont play nice with nushell
+            shell_escape_cmd = replace(shell_escape(cmd), "'" => "")
             shell_escape_cmd = "try { $shell_escape_cmd } catch { |err| \$err.rendered }"
             cmd = `$shell -c $shell_escape_cmd`
         elseif !Sys.iswindows()

--- a/base/client.jl
+++ b/base/client.jl
@@ -64,7 +64,13 @@ function repl_cmd(cmd, out)
         cd(dir)
         println(out, pwd())
     else
-        @static if !Sys.iswindows()
+        iswindows = @static Sys.iswindows() ? true : false
+        if shell_name == "nu"
+            # remove backticks and apostrophes that dont play nice with nushell
+            shell_escape_cmd = replace(shell_escape(cmd), r"`|'" => "")
+            shell_escape_cmd = "try { $shell_escape_cmd } catch { |err| \$err.rendered }"
+            cmd = `$shell -c $shell_escape_cmd`
+        elseif !iswindows
             if shell_name == "fish"
                 shell_escape_cmd = "begin; $(shell_escape_posixly(cmd)); and true; end"
             else

--- a/base/client.jl
+++ b/base/client.jl
@@ -64,13 +64,12 @@ function repl_cmd(cmd, out)
         cd(dir)
         println(out, pwd())
     else
-        iswindows = @static Sys.iswindows() ? true : false
         if shell_name == "nu"
             # remove backticks and apostrophes that dont play nice with nushell
-            shell_escape_cmd = replace(shell_escape(cmd), r"`|'" => "")
+            shell_escape_cmd = replace(shell_escape(cmd), "'" => "", "`" => "")
             shell_escape_cmd = "try { $shell_escape_cmd } catch { |err| \$err.rendered }"
             cmd = `$shell -c $shell_escape_cmd`
-        elseif !iswindows
+        elseif !Sys.iswindows()
             if shell_name == "fish"
                 shell_escape_cmd = "begin; $(shell_escape_posixly(cmd)); and true; end"
             else


### PR DESCRIPTION
This PR adds basic support for Nushell in shell mode. Should fix #54291.

I have also added this capability for Windows systems, although I know there is a long and ongoing discussion about how best to support shell-model on Windows (see #23597), so I'm happy to leave this out of the PR if that's preferred. However, I am getting exactly the same functionality on Linux and Windows :)

Here are some examples:

<details>

<summary>
Linux
</summary>

```
julia on  nushell-support took 1m2s
❯ $env.SHELL
nu

julia on  nushell-support
❯ ./julia --startup-file=no
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.13.0-DEV.593 (2025-05-14)
 _/ |\__'_|_|_|\__'_|  |  nushell-support/1ed87223be (fork: 1 commits, 0 days)
|__/                   |

shell>

shell> ls
╭────┬─────────────────┬─────────┬──────────┬───────────────╮
│  # │      name       │  type   │   size   │   modified    │
├────┼─────────────────┼─────────┼──────────┼───────────────┤
│  0 │ CITATION.bib    │ file    │    513 B │ 4 months ago  │
│  1 │ CITATION.cff    │ file    │   1.0 kB │ 4 months ago  │
│  2 │ CONTRIBUTING.md │ file    │  24.7 kB │ a day ago     │
│  3 │ Compiler        │ dir     │   4.0 kB │ a day ago     │
│  4 │ HISTORY.md      │ file    │ 416.9 kB │ a day ago     │
│  5 │ LICENSE.md      │ file    │   1.3 kB │ a day ago     │
│  6 │ Make.inc        │ file    │  62.6 kB │ 3 hours ago   │
│  7 │ Makefile        │ file    │  33.0 kB │ a day ago     │
│  8 │ NEWS.md         │ file    │   3.0 kB │ a day ago     │
│  9 │ README.md       │ file    │   7.7 kB │ a day ago     │
│ 10 │ THIRDPARTY.md   │ file    │   5.2 kB │ 4 months ago  │
│ 11 │ VERSION         │ file    │     11 B │ a day ago     │
│ 12 │ base            │ dir     │   4.0 kB │ 3 minutes ago │
│ 13 │ cli             │ dir     │   4.0 kB │ an hour ago   │
│ 14 │ contrib         │ dir     │   4.0 kB │ 3 minutes ago │
│ 15 │ deps            │ dir     │   4.0 kB │ 3 minutes ago │
│ 16 │ doc             │ dir     │   4.0 kB │ 3 minutes ago │
│ 17 │ etc             │ dir     │   4.0 kB │ 4 months ago  │
│ 18 │ julia           │ symlink │     13 B │ 8 minutes ago │
│ 19 │ julia.spdx.json │ file    │  39.6 kB │ 4 months ago  │
│ 20 │ pkgimage.mk     │ file    │   1.4 kB │ a day ago     │
│ 21 │ pr-notes.md     │ file    │   1.0 kB │ a minute ago  │
│ 22 │ src             │ dir     │  12.2 kB │ 3 minutes ago │
│ 23 │ stdlib          │ dir     │   4.0 kB │ 3 minutes ago │
│ 24 │ sysimage.mk     │ file    │   6.9 kB │ a day ago     │
│ 25 │ test            │ dir     │   4.0 kB │ 3 minutes ago │
│ 26 │ typos.toml      │ file    │     78 B │ 4 months ago  │
│ 27 │ usr             │ dir     │   4.0 kB │ an hour ago   │
│ 28 │ usr-staging     │ dir     │   4.0 kB │ an hour ago   │
├────┼─────────────────┼─────────┼──────────┼───────────────┤
│  # │      name       │  type   │   size   │   modified    │
╰────┴─────────────────┴─────────┴──────────┴───────────────╯

shell> ls -l | sort-by size
╭────┬─────────────────┬─────────┬────────────┬──────────┬───────────┬───────────┬─────────┬───────┬───────┬──────────┬────────────┬─────╮
│  # │      name       │  type   │   target   │ readonly │   mode    │ num_links │  inode  │ user  │ group │   size   │  created   │ ... │
├────┼─────────────────┼─────────┼────────────┼──────────┼───────────┼───────────┼─────────┼───────┼───────┼──────────┼────────────┼─────┤
│  0 │ VERSION         │ file    │            │ false    │ rw-r--r-- │         1 │ 1237674 │ sandy │ sandy │     11 B │ a day ago  │ ... │
│  1 │ julia           │ symlink │ usr/bin/ju │ false    │ rwxrwxrwx │         1 │ 1653252 │ sandy │ sandy │     13 B │ 8 minutes  │ ... │
│    │                 │         │ lia        │          │           │           │         │       │       │          │ ago        │     │
│  2 │ typos.toml      │ file    │            │ false    │ rw-r--r-- │         1 │ 1266376 │ sandy │ sandy │     78 B │ 4 months   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│  3 │ CITATION.bib    │ file    │            │ false    │ rw-r--r-- │         1 │ 1237289 │ sandy │ sandy │    513 B │ 4 months   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│  4 │ CITATION.cff    │ file    │            │ false    │ rw-r--r-- │         1 │ 1237291 │ sandy │ sandy │   1.0 kB │ 4 months   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│  5 │ pr-notes.md     │ file    │            │ false    │ rw-r--r-- │         1 │ 1653516 │ sandy │ sandy │   1.0 kB │ a minute   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│  6 │ LICENSE.md      │ file    │            │ false    │ rw-r--r-- │         1 │ 1237661 │ sandy │ sandy │   1.3 kB │ a day ago  │ ... │
│  7 │ pkgimage.mk     │ file    │            │ false    │ rw-r--r-- │         1 │ 1247310 │ sandy │ sandy │   1.4 kB │ a day ago  │ ... │
│  8 │ NEWS.md         │ file    │            │ false    │ rw-r--r-- │         1 │ 1237668 │ sandy │ sandy │   3.0 kB │ a day ago  │ ... │
│  9 │ Compiler        │ dir     │            │ false    │ rwxr-xr-x │         5 │ 1237296 │ sandy │ sandy │   4.0 kB │ 4 months   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│ 10 │ base            │ dir     │            │ false    │ rwxr-xr-x │         7 │ 1237746 │ sandy │ sandy │   4.0 kB │ 4 months   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│ 11 │ cli             │ dir     │            │ false    │ rwxr-xr-x │         3 │ 1238632 │ sandy │ sandy │   4.0 kB │ 4 months   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│ 12 │ contrib         │ dir     │            │ false    │ rwxr-xr-x │        10 │ 1238741 │ sandy │ sandy │   4.0 kB │ 4 months   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│ 13 │ deps            │ dir     │            │ false    │ rwxr-xr-x │         8 │ 1239027 │ sandy │ sandy │   4.0 kB │ 4 months   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│ 14 │ doc             │ dir     │            │ false    │ rwxr-xr-x │         4 │ 1239607 │ sandy │ sandy │   4.0 kB │ 4 months   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│ 15 │ etc             │ dir     │            │ false    │ rwxr-xr-x │         2 │ 1247289 │ sandy │ sandy │   4.0 kB │ 4 months   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│ 16 │ stdlib          │ dir     │            │ false    │ rwxr-xr-x │        64 │ 1247582 │ sandy │ sandy │   4.0 kB │ 4 months   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│ 17 │ test            │ dir     │            │ false    │ rwxr-xr-x │        20 │ 1265907 │ sandy │ sandy │   4.0 kB │ 4 months   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│ 18 │ usr             │ dir     │            │ false    │ rwxr-xr-x │        10 │    2360 │ sandy │ sandy │   4.0 kB │ an hour    │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│ 19 │ usr-staging     │ dir     │            │ false    │ rwxr-xr-x │         2 │ 1641277 │ sandy │ sandy │   4.0 kB │ an hour    │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│ 20 │ THIRDPARTY.md   │ file    │            │ false    │ rw-r--r-- │         1 │ 1237672 │ sandy │ sandy │   5.2 kB │ 4 months   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│ 21 │ sysimage.mk     │ file    │            │ false    │ rw-r--r-- │         1 │ 1265906 │ sandy │ sandy │   6.9 kB │ a day ago  │ ... │
│ 22 │ README.md       │ file    │            │ false    │ rw-r--r-- │         1 │ 1237671 │ sandy │ sandy │   7.7 kB │ a day ago  │ ... │
│ 23 │ src             │ dir     │            │ false    │ rwxr-xr-x │         5 │ 1247311 │ sandy │ sandy │  12.2 kB │ 4 months   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│ 24 │ CONTRIBUTING.md │ file    │            │ false    │ rw-r--r-- │         1 │ 1237285 │ sandy │ sandy │  24.7 kB │ a day ago  │ ... │
│ 25 │ Makefile        │ file    │            │ false    │ rw-r--r-- │         1 │ 1237667 │ sandy │ sandy │  33.0 kB │ a day ago  │ ... │
│ 26 │ julia.spdx.json │ file    │            │ false    │ rw-r--r-- │         1 │ 1247309 │ sandy │ sandy │  39.6 kB │ 4 months   │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│ 27 │ Make.inc        │ file    │            │ false    │ rw-r--r-- │         1 │ 1651602 │ sandy │ sandy │  62.6 kB │ 3 hours    │ ... │
│    │                 │         │            │          │           │           │         │       │       │          │ ago        │     │
│ 28 │ HISTORY.md      │ file    │            │ false    │ rw-r--r-- │         1 │ 1237649 │ sandy │ sandy │ 416.9 kB │ a day ago  │ ... │
├────┼─────────────────┼─────────┼────────────┼──────────┼───────────┼───────────┼─────────┼───────┼───────┼──────────┼────────────┼─────┤
│  # │      name       │  type   │   target   │ readonly │   mode    │ num_links │  inode  │ user  │ group │   size   │  created   │ ... │
╰────┴─────────────────┴─────────┴────────────┴──────────┴───────────┴───────────┴─────────┴───────┴───────┴──────────┴────────────┴─────╯

shell> ls -l | where name =~ stdlib
╭───┬────────┬──────┬────────┬──────────┬───────────┬───────────┬─────────┬───────┬───────┬────────┬──────────────┬───────────────┬─────────────╮
│ # │  name  │ type │ target │ readonly │   mode    │ num_links │  inode  │ user  │ group │  size  │   created    │   accessed    │  modified   │
├───┼────────┼──────┼────────┼──────────┼───────────┼───────────┼─────────┼───────┼───────┼────────┼──────────────┼───────────────┼─────────────┤
│ 0 │ stdlib │ dir  │        │ false    │ rwxr-xr-x │        64 │ 1247582 │ sandy │ sandy │ 4.0 kB │ 4 months ago │ 4 minutes ago │ 4 minutes   │
│   │        │      │        │          │           │           │         │       │       │        │              │               │ ago         │
╰───┴────────┴──────┴────────┴──────────┴───────────┴───────────┴─────────┴───────┴───────┴────────┴──────────────┴───────────────┴─────────────╯

shell> ps | where status == Running
╭───┬────────┬────────┬──────┬─────────┬──────┬─────────┬──────────╮
│ # │  pid   │  ppid  │ name │ status  │ cpu  │   mem   │ virtual  │
├───┼────────┼────────┼──────┼─────────┼──────┼─────────┼──────────┤
│ 0 │ 220530 │ 220107 │ nu   │ Running │ 9.80 │ 21.0 MB │ 114.6 MB │
╰───┴────────┴────────┴──────┴─────────┴──────┴─────────┴──────────╯

shell> open stdlib/Project.toml
╭──────┬────────────────────╮
│ deps │ {record 60 fields} │
╰──────┴────────────────────╯

shell> open stdlib/Project.toml | get deps
╭──────────────────────────────┬──────────────────────────────────────╮
│ ArgTools                     │ 0dad84c5-d112-42e6-8d28-ef12dabb789f │
│ Artifacts                    │ 56f22d72-fd6d-98f1-02f0-08ddc0907c33 │
│ Base64                       │ 2a0f44e3-6c83-55bd-87e4-b1978d98bd5f │
│ CRC32c                       │ 8bf52ea8-c179-5cab-976a-9e18b702a9bc │
│ CompilerSupportLibraries_jll │ e66e0078-7015-5450-92f7-15fbd957f2ae │
│ Dates                        │ ade2ca70-3891-5945-98fb-dc099432e06a │
│ DelimitedFiles               │ 8bb1440f-4735-579b-a4ab-409b98df4dab │
│ Distributed                  │ 8ba89e20-285c-5b6f-9357-94700520ee1b │
│ Downloads                    │ f43a241f-c20a-4ad4-852c-f6b1247861c6 │
│ FileWatching                 │ 7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee │
│ Future                       │ 9fa8497b-333b-5362-9e8d-4d0656e87820 │
│ GMP_jll                      │ 781609d7-10c4-51f6-84f2-b8444358ff6d │
│ InteractiveUtils             │ b77e0a4c-d291-57a0-90e8-8db25a27a240 │
│ JuliaSyntaxHighlighting      │ ac6e5ff7-fb65-4e79-a425-ec3bc9c03011 │
│ LLD_jll                      │ d55e3150-da41-5e91-b323-ecfd1eec6109 │
│ LLVMLibUnwind_jll            │ 47c5dbc3-30ba-59ef-96a6-123e260183d9 │
│ LazyArtifacts                │ 4af54fe1-eca0-43a8-85a7-787d91b784e3 │
│ LibCURL                      │ b27032c2-a3e7-50c8-80cd-2d36dbcbfd21 │
│ LibCURL_jll                  │ deac9b47-8bc7-5906-a0fe-35ac56dc84c0 │
│ LibGit2                      │ 76f85450-5226-5b5a-8eaa-529ad045b433 │
│ LibGit2_jll                  │ e37daf67-58a4-590a-8e99-b0245dd2ffc5 │
│ LibSSH2_jll                  │ 29816b5a-b9ab-546f-933c-edad1886dfa8 │
│ LibUV_jll                    │ 183b4373-6708-53ba-ad28-60e28bb38547 │
│ LibUnwind_jll                │ 745a5e78-f969-53e9-954f-d19f2f74f4e3 │
│ Libdl                        │ 8f399da3-3557-5675-b5ff-fb832c97cbdb │
│ LinearAlgebra                │ 37e2e46d-f89d-539d-b4ee-838fcccc9c8e │
│ Logging                      │ 56ddb016-857b-54e1-b83d-db4d58db5568 │
│ MPFR_jll                     │ 3a97d323-0669-5f0c-9066-3539efd106a3 │
│ Markdown                     │ d6f4376e-aef5-505a-96c1-9c027394607a │
│ Mmap                         │ a63ad114-7e13-5084-954f-fe012c677804 │
│ MozillaCACerts_jll           │ 14a3606d-f60d-562e-9121-12d972cd8159 │
│ NetworkOptions               │ ca575930-c2e3-43a9-ace4-1e988b2c1908 │
│ OpenBLAS_jll                 │ 4536629a-c528-5b80-bd46-f80d51c5b363 │
│ OpenLibm_jll                 │ 05823500-19ac-5b8b-9628-191a04bc5112 │
│ OpenSSL_jll                  │ 458c3c95-2e84-50aa-8efc-19380b2a3a95 │
│ PCRE2_jll                    │ efcefdf7-47ab-520b-bdef-62a2eaa19f15 │
│ Pkg                          │ 44cfe95a-1eb2-52ea-b672-e2afdf69b78f │
│ Printf                       │ de0858da-6303-5e67-8744-51eddeeeb8d7 │
│ Profile                      │ 9abbd945-dff8-562f-b5e8-e1ebf5ef1b79 │
│ REPL                         │ 3fa0cd96-eef1-5676-8a61-b3b8758bbffb │
│ Random                       │ 9a3f8284-a2c9-5f02-9a11-845980a1fd5c │
│ SHA                          │ ea8e919c-243c-51af-8825-aaa63cd721ce │
│ Serialization                │ 9e88b42a-f829-5b0c-bbe9-9e923198166b │
│ SharedArrays                 │ 1a1011a3-84de-559e-8e89-a11a2f7dc383 │
│ Sockets                      │ 6462fe0b-24de-5631-8697-dd941f90decc │
│ SparseArrays                 │ 2f01184e-e22b-5df5-ae63-d93ebab69eaf │
│ Statistics                   │ 10745b16-79ce-11e8-11f9-7d13ad32a3b2 │
│ StyledStrings                │ f489334b-da3d-4c2e-b8f0-e476e12c162b │
│ SuiteSparse_jll              │ bea87d4a-7f5b-5778-9afe-8cc45184846c │
│ TOML                         │ fa267f1f-6049-4f14-aa54-33bafae1ed76 │
│ Tar                          │ a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e │
│ Test                         │ 8dfed614-e22c-5e08-85e1-65c5234f0b40 │
│ UUIDs                        │ cf7118a7-6976-5b1a-9a39-7adc72f591a4 │
│ Unicode                      │ 4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5 │
│ Zlib_jll                     │ 83775a58-1f1d-513f-b197-d71354ab007a │
│ dSFMT_jll                    │ 05ff407c-b0c1-5878-9df8-858cc2e60c36 │
│ libLLVM_jll                  │ 8f36deef-c2a5-5394-99ed-8e07531fb29a │
│ libblastrampoline_jll        │ 8e850b90-86db-534c-a0d3-1478176c7d93 │
│ nghttp2_jll                  │ 8e850ede-7688-5339-a07c-302acd2aaf8d │
│ p7zip_jll                    │ 3f19e933-33d8-53b3-aaab-bd5110c3b7a0 │
╰──────────────────────────────┴──────────────────────────────────────╯

shell> 3 * 10
30

shell> 1 / 0
Error: nu::shell::division_by_zero

  × Division by zero.
   ╭─[source:1:9]
 1 │ try { 1 / 0 } catch { |err| $err.rendered }
   ·         ┬
   ·         ╰── division by zero
   ╰────


shell> (1 + 2) * (4 * 4)
48

shell> ^ls
base          cli       CONTRIBUTING.md  etc         julia.spdx.json  Make.inc     pr-notes.md  stdlib       THIRDPARTY.md  usr-staging
CITATION.bib  Compiler  deps             HISTORY.md  LICENSE.md       NEWS.md      README.md    sysimage.mk  typos.toml     VERSION
CITATION.cff  contrib   doc              julia       Makefile         pkgimage.mk  src          test         usr

shell>
```
</details>


<details>

<summary>
Windows
</summary>

```
PS C:\cygwin64\home\283710C\julia> nu
     __  ,
 .--()°'.' Welcome to Nushell,
'|, . ,'   based on the nu language,
 !_-(_\    where all data is structured!

Version: 0.104.0 (x86_64-pc-windows-msvc)
Please join our Discord community at https://discord.gg/NtAbbGn
Our GitHub repository is at https://github.com/nushell/nushell
Our Documentation is located at https://nushell.sh
And the Latest Nushell News at https://nushell.sh/blog/
Learn how to remove this at: https://nushell.sh/book/configuration.html#remove-welcome-message

It's been this long since Nushell's first commit:
6yrs 3days 14hrs 52mins 8secs 327ms 89µs 500ns

Startup Time: 37ms 994µs 100ns

C:\cygwin64\home\283710C\julia> $env.SHELL = "nu"
C:\cygwin64\home\283710C\julia> ./julia.bat
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.13.0-DEV.593 (2025-05-14)
 _/ |\__'_|_|_|\__'_|  |  nushell-support/1ed87223be (fork: 1 commits, 0 days)
|__/                   |

shell> ls
╭────┬─────────────────────────────┬──────┬──────────┬────────────────╮
│  # │            name             │ type │   size   │    modified    │
├────┼─────────────────────────────┼──────┼──────────┼────────────────┤
│  0 │ .buildkite-external-version │ file │      5 B │ 2 hours ago    │
│  1 │ .clang-format               │ file │   3.3 kB │ 2 hours ago    │
│  2 │ .clangd                     │ file │    114 B │ 2 hours ago    │
│  3 │ .codecov.yml                │ file │     52 B │ 2 hours ago    │
│  4 │ .devcontainer               │ dir  │      0 B │ 2 hours ago    │
│  5 │ .git                        │ dir  │   4.0 kB │ 18 minutes ago │
│  6 │ .git-blame-ignore-revs      │ file │    581 B │ 2 hours ago    │
│  7 │ .gitattributes              │ file │     65 B │ 2 hours ago    │
│  8 │ .github                     │ dir  │   4.0 kB │ 2 hours ago    │
│  9 │ .gitignore                  │ file │    619 B │ 2 hours ago    │
│ 10 │ .mailmap                    │ file │  13.4 kB │ 2 hours ago    │
│ 11 │ CITATION.bib                │ file │    513 B │ 2 hours ago    │
│ 12 │ CITATION.cff                │ file │   1.0 kB │ 2 hours ago    │
│ 13 │ CONTRIBUTING.md             │ file │  24.7 kB │ 2 hours ago    │
│ 14 │ Compiler                    │ dir  │   4.0 kB │ 2 hours ago    │
│ 15 │ HISTORY.md                  │ file │ 416.9 kB │ 2 hours ago    │
│ 16 │ LICENSE.md                  │ file │   1.3 kB │ 2 hours ago    │
│ 17 │ Make.inc                    │ file │  62.6 kB │ 2 hours ago    │
│ 18 │ Make.user                   │ file │     29 B │ 2 hours ago    │
│ 19 │ Makefile                    │ file │  33.0 kB │ 2 hours ago    │
│ 20 │ NEWS.md                     │ file │   3.0 kB │ 2 hours ago    │
│ 21 │ README.md                   │ file │   7.7 kB │ 2 hours ago    │
│ 22 │ THIRDPARTY.md               │ file │   5.2 kB │ 2 hours ago    │
│ 23 │ VERSION                     │ file │     11 B │ 2 hours ago    │
│ 24 │ base                        │ dir  │  65.5 kB │ 18 minutes ago │
│ 25 │ cli                         │ dir  │   4.0 kB │ 2 hours ago    │
│ 26 │ contrib                     │ dir  │  12.2 kB │ an hour ago    │
│ 27 │ deps                        │ dir  │  28.6 kB │ an hour ago    │
│ 28 │ doc                         │ dir  │   4.0 kB │ an hour ago    │
│ 29 │ etc                         │ dir  │      0 B │ 2 hours ago    │
│ 30 │ julia.bat                   │ file │     30 B │ 7 minutes ago  │
│ 31 │ julia.spdx.json             │ file │  39.6 kB │ 2 hours ago    │
│ 32 │ pkgimage.mk                 │ file │   1.4 kB │ 2 hours ago    │
│ 33 │ src                         │ dir  │  81.9 kB │ an hour ago    │
│ 34 │ stdlib                      │ dir  │  20.4 kB │ an hour ago    │
│ 35 │ sysimage.mk                 │ file │   6.9 kB │ 2 hours ago    │
│ 36 │ test                        │ dir  │  49.1 kB │ an hour ago    │
│ 37 │ typos.toml                  │ file │     78 B │ 2 hours ago    │
│ 38 │ usr                         │ dir  │   4.0 kB │ 2 hours ago    │
│ 39 │ usr-staging                 │ dir  │   4.0 kB │ 2 hours ago    │
├────┼─────────────────────────────┼──────┼──────────┼────────────────┤
│  # │            name             │ type │   size   │    modified    │
╰────┴─────────────────────────────┴──────┴──────────┴────────────────╯

shell> ls -l | sort-by size
╭────┬─────────────────────────────┬──────┬────────┬──────────┬──────────┬─────────────┬──────────────┬─────╮
│  # │            name             │ type │ target │ readonly │   size   │   created   │   accessed   │ ... │
├────┼─────────────────────────────┼──────┼────────┼──────────┼──────────┼─────────────┼──────────────┼─────┤
│  0 │ .devcontainer               │ dir  │        │ false    │      0 B │ 2 hours ago │ 19 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│  1 │ etc                         │ dir  │        │ false    │      0 B │ 2 hours ago │ 19 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│  2 │ .buildkite-external-version │ file │        │ false    │      5 B │ 2 hours ago │ 2 hours ago  │ ... │
│  3 │ VERSION                     │ file │        │ false    │     11 B │ 2 hours ago │ 6 minutes    │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│  4 │ Make.user                   │ file │        │ false    │     29 B │ 2 hours ago │ 7 minutes    │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│  5 │ julia.bat                   │ file │        │ false    │     30 B │ an hour ago │ 17 seconds   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│  6 │ .codecov.yml                │ file │        │ false    │     52 B │ 2 hours ago │ 2 hours ago  │ ... │
│  7 │ .gitattributes              │ file │        │ false    │     65 B │ 2 hours ago │ 19 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│  8 │ typos.toml                  │ file │        │ false    │     78 B │ 2 hours ago │ 2 hours ago  │ ... │
│  9 │ .clangd                     │ file │        │ false    │    114 B │ 2 hours ago │ 2 hours ago  │ ... │
│ 10 │ CITATION.bib                │ file │        │ false    │    513 B │ 2 hours ago │ 2 hours ago  │ ... │
│ 11 │ .git-blame-ignore-revs      │ file │        │ false    │    581 B │ 2 hours ago │ 2 hours ago  │ ... │
│ 12 │ .gitignore                  │ file │        │ false    │    619 B │ 2 hours ago │ 19 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 13 │ CITATION.cff                │ file │        │ false    │   1.0 kB │ 2 hours ago │ 2 hours ago  │ ... │
│ 14 │ LICENSE.md                  │ file │        │ false    │   1.3 kB │ 2 hours ago │ 2 hours ago  │ ... │
│ 15 │ pkgimage.mk                 │ file │        │ false    │   1.4 kB │ 2 hours ago │ 7 minutes    │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 16 │ NEWS.md                     │ file │        │ false    │   3.0 kB │ 2 hours ago │ 2 hours ago  │ ... │
│ 17 │ .clang-format               │ file │        │ false    │   3.3 kB │ 2 hours ago │ 2 hours ago  │ ... │
│ 18 │ .git                        │ dir  │        │ false    │   4.0 kB │ 2 hours ago │ 19 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 19 │ .github                     │ dir  │        │ false    │   4.0 kB │ 2 hours ago │ 19 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 20 │ Compiler                    │ dir  │        │ false    │   4.0 kB │ 2 hours ago │ 19 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 21 │ cli                         │ dir  │        │ false    │   4.0 kB │ 2 hours ago │ 19 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 22 │ doc                         │ dir  │        │ false    │   4.0 kB │ 2 hours ago │ 19 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 23 │ usr                         │ dir  │        │ false    │   4.0 kB │ 2 hours ago │ 11 seconds   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 24 │ usr-staging                 │ dir  │        │ false    │   4.0 kB │ 2 hours ago │ 16 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 25 │ THIRDPARTY.md               │ file │        │ false    │   5.2 kB │ 2 hours ago │ 2 hours ago  │ ... │
│ 26 │ sysimage.mk                 │ file │        │ false    │   6.9 kB │ 2 hours ago │ 19 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 27 │ README.md                   │ file │        │ false    │   7.7 kB │ 2 hours ago │ 2 hours ago  │ ... │
│ 28 │ contrib                     │ dir  │        │ false    │  12.2 kB │ 2 hours ago │ 14 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 29 │ .mailmap                    │ file │        │ false    │  13.4 kB │ 2 hours ago │ 19 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 30 │ stdlib                      │ dir  │        │ false    │  20.4 kB │ 2 hours ago │ 3 minutes    │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 31 │ CONTRIBUTING.md             │ file │        │ false    │  24.7 kB │ 2 hours ago │ 2 hours ago  │ ... │
│ 32 │ deps                        │ dir  │        │ false    │  28.6 kB │ 2 hours ago │ 7 minutes    │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 33 │ Makefile                    │ file │        │ false    │  33.0 kB │ 2 hours ago │ 20 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 34 │ julia.spdx.json             │ file │        │ false    │  39.6 kB │ 2 hours ago │ 2 hours ago  │ ... │
│ 35 │ test                        │ dir  │        │ false    │  49.1 kB │ 2 hours ago │ 18 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 36 │ Make.inc                    │ file │        │ false    │  62.6 kB │ 2 hours ago │ 7 minutes    │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 37 │ base                        │ dir  │        │ false    │  65.5 kB │ 2 hours ago │ 14 minutes   │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 38 │ src                         │ dir  │        │ false    │  81.9 kB │ 2 hours ago │ 7 minutes    │ ... │
│    │                             │      │        │          │          │             │ ago          │     │
│ 39 │ HISTORY.md                  │ file │        │ false    │ 416.9 kB │ 2 hours ago │ 2 hours ago  │ ... │
├────┼─────────────────────────────┼──────┼────────┼──────────┼──────────┼─────────────┼──────────────┼─────┤
│  # │            name             │ type │ target │ readonly │   size   │   created   │   accessed   │ ... │
╰────┴─────────────────────────────┴──────┴────────┴──────────┴──────────┴─────────────┴──────────────┴─────╯

shell> ls -l | where name =~ stdlib
╭───┬────────┬──────┬────────┬──────────┬─────────┬─────────────┬───────────────┬─────────────╮
│ # │  name  │ type │ target │ readonly │  size   │   created   │   accessed    │  modified   │
├───┼────────┼──────┼────────┼──────────┼─────────┼─────────────┼───────────────┼─────────────┤
│ 0 │ stdlib │ dir  │        │ false    │ 20.4 kB │ 2 hours ago │ 3 minutes ago │ an hour ago │
╰───┴────────┴──────┴────────┴──────────┴─────────┴─────────────┴───────────────┴─────────────╯

shell> ps | where name =~ julia.exe
╭───┬──────┬──────┬───────────┬──────┬──────────┬──────────╮
│ # │ pid  │ ppid │   name    │ cpu  │   mem    │ virtual  │
├───┼──────┼──────┼───────────┼──────┼──────────┼──────────┤
│ 0 │ 3060 │ 2016 │ julia.exe │ 0.00 │ 304.0 MB │ 390.5 MB │
╰───┴──────┴──────┴───────────┴──────┴──────────┴──────────╯

shell> open stdlib/Project.toml | get deps
╭──────────────────────────────┬──────────────────────────────────────╮
│ ArgTools                     │ 0dad84c5-d112-42e6-8d28-ef12dabb789f │
│ Artifacts                    │ 56f22d72-fd6d-98f1-02f0-08ddc0907c33 │
│ Base64                       │ 2a0f44e3-6c83-55bd-87e4-b1978d98bd5f │
│ CRC32c                       │ 8bf52ea8-c179-5cab-976a-9e18b702a9bc │
│ CompilerSupportLibraries_jll │ e66e0078-7015-5450-92f7-15fbd957f2ae │
│ Dates                        │ ade2ca70-3891-5945-98fb-dc099432e06a │
│ DelimitedFiles               │ 8bb1440f-4735-579b-a4ab-409b98df4dab │
│ Distributed                  │ 8ba89e20-285c-5b6f-9357-94700520ee1b │
│ Downloads                    │ f43a241f-c20a-4ad4-852c-f6b1247861c6 │
│ FileWatching                 │ 7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee │
│ Future                       │ 9fa8497b-333b-5362-9e8d-4d0656e87820 │
│ GMP_jll                      │ 781609d7-10c4-51f6-84f2-b8444358ff6d │
│ InteractiveUtils             │ b77e0a4c-d291-57a0-90e8-8db25a27a240 │
│ JuliaSyntaxHighlighting      │ ac6e5ff7-fb65-4e79-a425-ec3bc9c03011 │
│ LLD_jll                      │ d55e3150-da41-5e91-b323-ecfd1eec6109 │
│ LLVMLibUnwind_jll            │ 47c5dbc3-30ba-59ef-96a6-123e260183d9 │
│ LazyArtifacts                │ 4af54fe1-eca0-43a8-85a7-787d91b784e3 │
│ LibCURL                      │ b27032c2-a3e7-50c8-80cd-2d36dbcbfd21 │
│ LibCURL_jll                  │ deac9b47-8bc7-5906-a0fe-35ac56dc84c0 │
│ LibGit2                      │ 76f85450-5226-5b5a-8eaa-529ad045b433 │
│ LibGit2_jll                  │ e37daf67-58a4-590a-8e99-b0245dd2ffc5 │
│ LibSSH2_jll                  │ 29816b5a-b9ab-546f-933c-edad1886dfa8 │
│ LibUV_jll                    │ 183b4373-6708-53ba-ad28-60e28bb38547 │
│ LibUnwind_jll                │ 745a5e78-f969-53e9-954f-d19f2f74f4e3 │
│ Libdl                        │ 8f399da3-3557-5675-b5ff-fb832c97cbdb │
│ LinearAlgebra                │ 37e2e46d-f89d-539d-b4ee-838fcccc9c8e │
│ Logging                      │ 56ddb016-857b-54e1-b83d-db4d58db5568 │
│ MPFR_jll                     │ 3a97d323-0669-5f0c-9066-3539efd106a3 │
│ Markdown                     │ d6f4376e-aef5-505a-96c1-9c027394607a │
│ Mmap                         │ a63ad114-7e13-5084-954f-fe012c677804 │
│ MozillaCACerts_jll           │ 14a3606d-f60d-562e-9121-12d972cd8159 │
│ NetworkOptions               │ ca575930-c2e3-43a9-ace4-1e988b2c1908 │
│ OpenBLAS_jll                 │ 4536629a-c528-5b80-bd46-f80d51c5b363 │
│ OpenLibm_jll                 │ 05823500-19ac-5b8b-9628-191a04bc5112 │
│ OpenSSL_jll                  │ 458c3c95-2e84-50aa-8efc-19380b2a3a95 │
│ PCRE2_jll                    │ efcefdf7-47ab-520b-bdef-62a2eaa19f15 │
│ Pkg                          │ 44cfe95a-1eb2-52ea-b672-e2afdf69b78f │
│ Printf                       │ de0858da-6303-5e67-8744-51eddeeeb8d7 │
│ Profile                      │ 9abbd945-dff8-562f-b5e8-e1ebf5ef1b79 │
│ REPL                         │ 3fa0cd96-eef1-5676-8a61-b3b8758bbffb │
│ Random                       │ 9a3f8284-a2c9-5f02-9a11-845980a1fd5c │
│ SHA                          │ ea8e919c-243c-51af-8825-aaa63cd721ce │
│ Serialization                │ 9e88b42a-f829-5b0c-bbe9-9e923198166b │
│ SharedArrays                 │ 1a1011a3-84de-559e-8e89-a11a2f7dc383 │
│ Sockets                      │ 6462fe0b-24de-5631-8697-dd941f90decc │
│ SparseArrays                 │ 2f01184e-e22b-5df5-ae63-d93ebab69eaf │
│ Statistics                   │ 10745b16-79ce-11e8-11f9-7d13ad32a3b2 │
│ StyledStrings                │ f489334b-da3d-4c2e-b8f0-e476e12c162b │
│ SuiteSparse_jll              │ bea87d4a-7f5b-5778-9afe-8cc45184846c │
│ TOML                         │ fa267f1f-6049-4f14-aa54-33bafae1ed76 │
│ Tar                          │ a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e │
│ Test                         │ 8dfed614-e22c-5e08-85e1-65c5234f0b40 │
│ UUIDs                        │ cf7118a7-6976-5b1a-9a39-7adc72f591a4 │
│ Unicode                      │ 4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5 │
│ Zlib_jll                     │ 83775a58-1f1d-513f-b197-d71354ab007a │
│ dSFMT_jll                    │ 05ff407c-b0c1-5878-9df8-858cc2e60c36 │
│ libLLVM_jll                  │ 8f36deef-c2a5-5394-99ed-8e07531fb29a │
│ libblastrampoline_jll        │ 8e850b90-86db-534c-a0d3-1478176c7d93 │
│ nghttp2_jll                  │ 8e850ede-7688-5339-a07c-302acd2aaf8d │
│ p7zip_jll                    │ 3f19e933-33d8-53b3-aaab-bd5110c3b7a0 │
╰──────────────────────────────┴──────────────────────────────────────╯

shell> 3 * 10
30

shell> 1 / 0
Error: nu::shell::division_by_zero

  × Division by zero.
   ╭─[source:1:9]
 1 │ try { 1 / 0 } catch { |err| $err.rendered }
   ·         ┬
   ·         ╰── division by zero
   ╰────


shell> (1 + 2) * (4 + 4)
24

shell> ^ls
CITATION.bib     HISTORY.md  Makefile       VERSION  deps       julia.spdx.json  sysimage.mk  usr-staging
CITATION.cff     LICENSE.md  NEWS.md        base     doc        pkgimage.mk      test
CONTRIBUTING.md  Make.inc    README.md      cli      etc        src              typos.toml
Compiler         Make.user   THIRDPARTY.md  contrib  julia.bat  stdlib           usr
```

</details>

**Limitations**: Nushell is not POSIX-compliant, so there are some characters that the user must escape manually in order for them to carry through the Julia backtick syntax and `shell_escape(...)` function. As far as I can tell, the only times a user might came across this is for `'`, `"`and `$`. The obvious workaround is to just escape them:

```
shell> \"Hi!\" | save test.txt -f

shell> open test.txt
Hi!
shell> let x = 5; print \$\"The value of x is (\$x)\"
The value of x is 5
```

Thanks!
