### PR TITLE
change the Compiler.jl stdlib version to 0.1.0

### DIFF
--- a/Compiler/Project.toml
+++ b/Compiler/Project.toml
@@ -1,6 +1,6 @@
 name = "Compiler"
 uuid = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
-version = "0.0.0"
+version = "0.1.0"
 
 [compat]
 julia = "1.10"

--- a/Compiler/README.md
+++ b/Compiler/README.md
@@ -16,13 +16,13 @@ your `Project.toml` as follows:
 Compiler = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
 
 [compat]
-Compiler = "0"
+Compiler = "0.1"
 ```
 
-With the setup above, [the special placeholder version (v0.0.0)](https://github.com/JuliaLang/BaseCompiler.jl)
+With the setup above, [the special placeholder version (v0.1.0)](https://github.com/JuliaLang/BaseCompiler.jl)
 will be installed by default.[^1]
 
-[^1]: Currently, only version v0.0.0 is registered in the [General](https://github.com/JuliaRegistries/General) registry.
+[^1]: Currently, only version v0.1.0 is registered in the [General](https://github.com/JuliaRegistries/General) registry.
 
 If needed, you can switch to a custom implementation of the `Compiler` module by running
 ```julia-repl


### PR DESCRIPTION
In JuliaRegistries/General#130304 I proposed naming the placeholder version of the Compiler stdlib "v0.0.0" and made changes accordingly. However, after further discussions around adjusting Pkg.jl (c.f. JuliaLang/PKg.jl#4233), we decided to call it "v0.1.0" instead since the idea may sound to be an abuse of semver and that versioning wouldn't be able to handle cases when any changes to the implementation of that special version are needed in the future.

As a result, this commit changes the version of the Compiler.jl stdlib implementation maintained in the base from v0.0.0 to v0.1.0.

Since BaseCompiler.jl is a very internal, special package that doesn’t yet follow proper versioning, there’s no need to worry about ecosystem impact from this change.