### PR TITLE
add static size information for hvcat and hvncat

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2298,16 +2298,11 @@ typed_hvcat(::Type{T}, rows::Tuple{Vararg{Int}}, as...) where T = typed_hvncat(T
         end
     end
 
+    # For generic fallback case, directly call a normal `hvcat_fill!` function
+    # to avoid the overhead of generating a large number of duplicated expressions.
     quote
         a = Matrix{$T}(undef, $nr, $nc)
-        k = 1
-        @inbounds for i in 1:$nr
-            for j in 1:$nc
-                a[i,j] = xs[k]
-                k += 1
-            end
-        end
-        a
+        hvcat_fill!(a, xs)
     end
 end
 @inline function hvcat_static(::Val{rows}, x::T, xs::Vararg{T}) where {rows, T<:Number}


### PR DESCRIPTION
When creating an array using scalar numbers, the array initialization method is currently the fastest way. That is,

```julia
A = Matrix{Float64}(under, 2, 2)
A[1, 1] = x
A[2, 1] = y
A[1, 2] = x
A[2, 2] = y
```

is faster than the concatenation method `[x x; y y]`. This PR tries to close the performance gaps.

Optimization overview:

* Static shape information is now preserved during syntax parsing, which improves performance when concatenating scalar values into 2D or higher-dimensional arrays.
* An additional manual loop unrolling has been introduced for small matrix scenarios to boost performance further.

Key results:

* For small matrices, the performance of array concatenation using `[]` is now comparable to that of direct matrix initialization. This resolves a previously significant performance gap.
* For large matrices, concatenation shows substantial performance improvements. However, it still lags behind direct initialization in terms of speed.

Future work:

* Noticeable performance differences remain for large matrices.

---

# Benchmark performance

The very first version of this commit is implemented based on 1.10.9 release branch, thus I've also included the 1.10-dev performance.
Notice the performance differences between the initialization method and the concatenation method.

## `[x x; y y]` — 2D Matrix Creation

**Same Data Type**

```julia
using BenchmarkTools

f(x, y) = [x x; y y]
@btime f(x, y) setup=(x = rand(); y = rand())
```

**2×2 Matrix**

| Julia version | Initialization (ns) | Concatenation (ns) |
| ------------- | ------------------- | ------------------ |
| 1.9.3         | 18.021              | 37.258             |
| 1.10.9        | 18.634              | 263.918            |
| 1.10-dev      | 19.660              | 19.749             |
| 1.12.0-beta3  | 7.690               | 31.913             |
| 1.13-dev      | 8.644               | 8.793              |

**6×6 Matrix**

| Julia version | Initialization (ns) | Concatenation (ns) |
| ------------- | ------------------- | ------------------ |
| 1.9.3         | 30.865              | 144.490            |
| 1.10.9        | 32.856              | 2198               |
| 1.10-dev      | 32.278              | 31.363             |
| 1.12.0-beta3  | 19.315              | 129.225            |
| 1.13-dev      | 18.553              | 984.615            |

---

**Mixed Data Types**

```julia
f(x, y) = [x x; y y]
@btime f(x, y) setup=(x = rand(); y = rand(1:10))
```

**2×2 Matrix**

| Julia version | Initialization (ns) | Concatenation (ns) |
| ------------- | ------------------- | ------------------ |
| 1.9.3         | 17.794              | 72.243             |
| 1.10.9        | 18.587              | 844.879            |
| 1.10-dev      | 19.467              | 19.394             |
| 1.12.0-beta3  | 8.066               | 72.766             |
| 1.13-dev      | 8.812               | 8.554              |

**6×6 Matrix**

| Julia version | Initialization (ns) | Concatenation (ns) |
| ------------- | ------------------- | ------------------ |
| 1.9.3         | 35.994              | 11284              |
| 1.10.9        | 36.748              | 23835              |
| 1.10-dev      | 32.352              | 646.955            |
| 1.12.0-beta3  | 27.590              | 9873               |
| 1.13-dev      | 29.428              | 7662               |

---

## `[x x;;; y y]` — Higher-Dimensional Array Creation

**Same Data Type**

```julia
g(x, y) = [x x;;; y y]
@btime g(x, y) setup=(x = rand(); y = rand())
```

**1×2×2 Array**

| Julia version | Initialization (ns) | Concatenation (ns) |
| ------------- | ------------------- | ------------------ |
| 1.9.3         | 19.754              | 112.885            |
| 1.10.9        | 20.175              | 108.488            |
| 1.10-dev      | 21.437              | 19.700             |
| 1.12.0-beta3  | 10.646              | 183.057            |
| 1.13-dev      | 9.732               | 10.775             |

**3×3×3 Array**

| Julia version | Initialization (ns) | Concatenation (ns) |
| ------------- | ------------------- | ------------------ |
| 1.9.3         | 43.327              | 445.046            |
| 1.10.9        | 44.832              | 473.566            |
| 1.10-dev      | 44.633              | 48.476             |
| 1.12.0-beta3  | 19.072              | 496.601            |
| 1.13-dev      | 17.061              | 38.536             |

---

**Mixed Data Types**

```julia
g(x, y) = [x x;;; y y]
@btime g(x, y) setup=(x = rand(); y = rand(1:10))
```

**1×2×2 Array**

| Julia version | Initialization (ns) | Concatenation (ns) |
| ------------- | ------------------- | ------------------ |
| 1.9.3         | 19.192              | 147.851            |
| 1.10.9        | 20.126              | 147.297            |
| 1.10-dev      | 20.719              | 19.509             |
| 1.12.0-beta3  | 24.837              | 270.547            |
| 1.13-dev      | 19.595              | 10.131             |

**3×3×3 Array**

| Julia version | Initialization (ns) | Concatenation (ns) |
| ------------- | ------------------- | ------------------ |
| 1.9.3         | 44.267              | 753.900            |
| 1.10.9        | 43.800              | 750.264            |
| 1.10-dev      | 43.620              | 363.485            |
| 1.12.0-beta3  | 47.225              | 837.426            |
| 1.13-dev      | 42.404              | 402.965            |


<details>
<summary> benchmark test script </summary>

```julia
using BenchmarkTools

function hvcat_large_baseline(x, y)
    A = Array{Float64, 2}(undef, 6, 6)
    for i in 1:6
        for j in 1:6
            A[i, j] = i == j ? x : y
        end
    end
    return A
end
hvcat_large(x, y) = [
    x y y y y y
    y x y y y y
    y y x y y y
    y y y x y y
    y y y y x y
    y y y y y x
]

function hvcat_small_baseline(x, y)
    A = Array{Float64, 2}(undef, 2, 2)
    for i in 1:2
        for j in 1:2
            A[i, j] = i == j ? x : y
        end
    end
    return A
end
hvcat_small(x, y) = [
    x y
    y x
]

function hvncat_large_baseline(x, y)
    A = Array{Float64, 3}(undef, 3, 3, 3)
    for i in 1:3
        for j in 1:3
            for k in 1:3
                A[i, j, k] = i == j == k ? x : y
            end
        end
    end
    return A
end
hvncat_large(x, y) = [
    x y y; y y y; y y y;;;
    y y y; y x y; y y y;;;
    y y y; y y y; y y x;;;
]

function hvncat_small_baseline(x, y)
    A = Array{Float64, 3}(undef, 2, 2, 2)
    for i in 1:2
        for j in 1:2
            for k in 1:2
                A[i, j, k] = i == j == k ? x : y
            end
        end
    end
    return A
end
hvncat_small(x, y) = [
    x y; y y;;;
    y y; y x;;;
]

@assert hvcat_large_baseline(1.0, 2.0) == hvcat_large(1.0, 2.0)
@assert hvcat_small_baseline(1.0, 2.0) == hvcat_small(1.0, 2.0)
@assert hvncat_large_baseline(1.0, 2.0) == hvncat_large(1.0, 2.0)
@assert hvncat_small_baseline(1.0, 2.0) == hvncat_small(1.0, 2.0)

@assert hvcat_large_baseline(1.0, 2) == hvcat_large(1.0, 2)
@assert hvcat_small_baseline(1.0, 2) == hvcat_small(1.0, 2)
@assert hvncat_large_baseline(1.0, 2) == hvncat_large(1.0, 2)
@assert hvncat_small_baseline(1.0, 2) == hvncat_small(1.0, 2)

@info "hvcat, large, same type, array initialization"
@btime hvcat_large_baseline(x, y) setup=(x = rand(); y = rand())
@info "hvcat, large, same type, concatenation"
@btime hvcat_large(x, y) setup=(x = rand(); y = rand())
@info "hvcat, large, different type, array initialization"
@btime hvcat_large_baseline(x, y) setup=(x = rand(); y = rand(1:10))
@info "hvcat, large, different type, concatenation"
@btime hvcat_large(x, y) setup=(x = rand(); y = rand(1:10))

@info "hvcat, small, same type, array initialization"
@btime hvcat_small_baseline(x, y) setup=(x = rand(); y = rand())
@info "hvcat, small, same type, concatenation"
@btime hvcat_small(x, y) setup=(x = rand(); y = rand())
@info "hvcat, small, different type, array initialization"
@btime hvcat_small_baseline(x, y) setup=(x = rand(); y = rand(1:10))
@info "hvcat, small, different type, concatenation"
@btime hvcat_small(x, y) setup=(x = rand(); y = rand(1:10))

@info "hvncat, large, same type, array initialization"
@btime hvncat_large_baseline(x, y) setup=(x = rand(); y = rand())
@info "hvncat, large, same type, concatenation"
@btime hvncat_large(x, y) setup=(x = rand(); y = rand())
@info "hvncat, large, different type, array initialization"
@btime hvncat_large_baseline(x, y) setup=(x = rand(); y = rand(1:10))
@info "hvncat, large, different type, concatenation"
@btime hvncat_large(x, y) setup=(x = rand(); y = rand(1:10))

@info "hvncat, small, same type, array initialization"
@btime hvncat_small_baseline(x, y) setup=(x = rand(); y = rand())
@info "hvncat, small, same type, concatenation"
@btime hvncat_small(x, y) setup=(x = rand(); y = rand())
@info "hvncat, small, different type, array initialization"
@btime hvncat_small_baseline(x, y) setup=(x = rand(); y = rand(1:10))
@info "hvncat, small, different type, concatenation"
@btime hvncat_small(x, y) setup=(x = rand(); y = rand(1:10))
```

</details>

fixes #58397