### PR TITLE
Expose native_code's jl_sysimg_gvars.

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -108,20 +108,37 @@ jl_get_llvm_mis_impl(void *native_code, size_t *num_elements, jl_method_instance
     }
 }
 
+// get the list of global variables managed by the compiler
 extern "C" JL_DLLEXPORT_CODEGEN void jl_get_llvm_gvs_impl(void *native_code,
                                                           size_t *num_elements, void **data)
 {
-    // map a memory location (jl_value_t or jl_binding_t) to a GlobalVariable
     jl_native_code_desc_t *desc = (jl_native_code_desc_t *)native_code;
-    auto &value_map = desc->jl_value_to_llvm;
+    auto &gvars = desc->jl_sysimg_gvars;
 
     if (data == NULL) {
-        *num_elements = value_map.size();
+        *num_elements = gvars.size();
         return;
     }
 
-    assert(*num_elements == value_map.size());
-    memcpy(data, value_map.data(), *num_elements * sizeof(void *));
+    assert(*num_elements == gvars.size());
+    memcpy(data, gvars.data(), *num_elements * sizeof(void *));
+}
+
+// get the initializer values (jl_value_t or jl_binding_t ptr) of managed global variables
+extern "C" JL_DLLEXPORT_CODEGEN void jl_get_llvm_gv_inits_impl(void *native_code,
+                                                               size_t *num_elements,
+                                                               void **data)
+{
+    jl_native_code_desc_t *desc = (jl_native_code_desc_t *)native_code;
+    auto &inits = desc->jl_value_to_llvm;
+
+    if (data == NULL) {
+        *num_elements = inits.size();
+        return;
+    }
+
+    assert(*num_elements == inits.size());
+    memcpy(data, inits.data(), *num_elements * sizeof(void *));
 }
 
 extern "C" JL_DLLEXPORT_CODEGEN void jl_get_llvm_external_fns_impl(void *native_code,

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -14,6 +14,7 @@ JL_DLLEXPORT void jl_dump_native_fallback(void *native_code,
         const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *asm_fname,
         ios_t *z, ios_t *s) UNAVAILABLE
 JL_DLLEXPORT void jl_get_llvm_gvs_fallback(void *native_code, arraylist_t *gvs) UNAVAILABLE
+JL_DLLEXPORT void jl_get_llvm_gv_inits_fallback(void *native_code, arraylist_t *inits) UNAVAILABLE
 JL_DLLEXPORT void jl_get_llvm_external_fns_fallback(void *native_code, arraylist_t *gvs) UNAVAILABLE
 JL_DLLEXPORT void jl_get_llvm_mis_fallback(void *native_code, arraylist_t* MIs) UNAVAILABLE
 

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -514,6 +514,7 @@
     YY(jl_get_LLVM_VERSION) \
     YY(jl_dump_native) \
     YY(jl_get_llvm_gvs) \
+    YY(jl_get_llvm_gv_inits) \
     YY(jl_get_llvm_external_fns) \
     YY(jl_get_llvm_mis) \
     YY(jl_dump_function_asm) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2040,8 +2040,9 @@ JL_DLLIMPORT void jl_dump_native(void *native_code,
         const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *asm_fname,
         ios_t *z, ios_t *s, jl_emission_params_t *params);
 JL_DLLIMPORT void jl_get_llvm_gvs(void *native_code, size_t *num_els, void **gvs);
+JL_DLLIMPORT void jl_get_llvm_gv_inits(void *native_code, size_t *num_els, void **inits);
 JL_DLLIMPORT void jl_get_llvm_external_fns(void *native_code, size_t *num_els,
-                                           jl_code_instance_t *gvs);
+                                           jl_code_instance_t *fns);
 JL_DLLIMPORT void jl_get_function_id(void *native_code, jl_code_instance_t *ncode,
         int32_t *func_idx, int32_t *specfunc_idx);
 JL_DLLIMPORT void jl_register_fptrs(uint64_t image_base, const struct _jl_image_fptrs_t *fptrs,

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3055,9 +3055,9 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
     int en = jl_gc_enable(0);
     if (native_functions) {
         size_t num_gvars, num_external_fns;
-        jl_get_llvm_gvs(native_functions, &num_gvars, NULL);
+        jl_get_llvm_gv_inits(native_functions, &num_gvars, NULL);
         arraylist_grow(&gvars, num_gvars);
-        jl_get_llvm_gvs(native_functions, &num_gvars, gvars.items);
+        jl_get_llvm_gv_inits(native_functions, &num_gvars, gvars.items);
         jl_get_llvm_external_fns(native_functions, &num_external_fns, NULL);
         arraylist_grow(&external_fns, num_external_fns);
         jl_get_llvm_external_fns(native_functions, &num_external_fns,


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/57010 overhauled how global variables are initialized in code, breaking GPUCompiler.jl. After talking to @vtjnash, we are apparently supposed to use `jl_get_llvm_gvs` now to get the Julia memory location of a global variable (for a binding or constant value), however, the elements in there don't exactly correspond to the global variables in the module (not all module globals are "managed" by Julia, and the order is different).

To make GPUCompiler.jl work again, here I propose renaming `jl_get_llvm_gvs` to `jl_get_llvm_gv_inits`, and making `jl_get_llvm_gvs` instead return the list of the managed global variables, making it possible to perform the global variable initialization that was done by Julia before using something like:

```julia
if VERSION >= v"1.13.0-DEV.533"
    num_gvars = Ref{Csize_t}(0)
    @ccall jl_get_llvm_gvs(native_code::Ptr{Cvoid}, num_gvars::Ptr{Csize_t},
                           C_NULL::Ptr{Cvoid})::Nothing
    gvs = Vector{Ptr{LLVM.API.LLVMOpaqueValue}}(undef, num_gvars[])
    @ccall jl_get_llvm_gvs(native_code::Ptr{Cvoid}, num_gvars::Ptr{Csize_t},
                           gvs::Ptr{LLVM.API.LLVMOpaqueValue})::Nothing
    inits = Vector{Ptr{Cvoid}}(undef, num_gvars[])
    @ccall jl_get_llvm_gv_inits(native_code::Ptr{Cvoid}, num_gvars::Ptr{Csize_t},
                                inits::Ptr{Cvoid})::Nothing

    for (gv_ref, init) in zip(gvs, inits)
        gv = GlobalVariable(gv_ref)
        ptr = const_inttoptr(ConstantInt(Int64(init)), value_type(gv))
        initializer!(gv, ptr)
        obj = Base.unsafe_pointer_to_objref(init)
        @safe_info "Resolved $(name(gv)) to $obj"
    end
end
```