### PR TITLE
Fix MethodError in IR validator

### DIFF
--- a/Compiler/src/validation.jl
+++ b/Compiler/src/validation.jl
@@ -35,8 +35,6 @@ const VALID_EXPR_HEADS = IdDict{Symbol,UnitRange{Int}}(
     :aliasscope => 0:0,
     :popaliasscope => 0:0,
     :new_opaque_closure => 5:typemax(Int),
-    :import => 1:typemax(Int),
-    :using => 1:typemax(Int),
     :export => 1:typemax(Int),
     :public => 1:typemax(Int),
     :latestworld => 0:0,
@@ -72,11 +70,13 @@ function maybe_validate_code(mi::MethodInstance, src::CodeInfo, kind::String)
         if !isempty(errors)
             for e in errors
                 if mi.def isa Method
-                    println(stderr, "WARNING: Encountered invalid ", kind, " code for method ",
-                            mi.def, ": ", e)
+                    println(Core.stderr,
+                            "WARNING: Encountered invalid ", kind,
+                            " code for method ", mi.def, ": ", e)
                 else
-                    println(stderr, "WARNING: Encountered invalid ", kind, " code for top level expression in ",
-                            mi.def, ": ", e)
+                    println(Core.stderr,
+                            "WARNING: Encountered invalid ", kind,
+                            " code for top level expression in ", mi.def, ": ", e)
                 end
             end
             error("")

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -796,7 +796,7 @@ struct CoreSTDERR <: IO end
 const stdout = CoreSTDOUT()
 const stderr = CoreSTDERR()
 io_pointer(::CoreSTDOUT) = Intrinsics.pointerref(Intrinsics.cglobal(:jl_uv_stdout, Ptr{Cvoid}), 1, 1)
-io_pointer(::CoreSTDERR) = Intrinsics.pointerref(Intrinsics.cglobal(:jl_uv_stderr, Ptr{Cvoid}), 1, 1)
+io_pointer(::Any) = Intrinsics.pointerref(Intrinsics.cglobal(:jl_uv_stderr, Ptr{Cvoid}), 1, 1)
 
 unsafe_write(io::IO, x::Ptr{UInt8}, nb::UInt) =
     (ccall(:jl_uv_puts, Cvoid, (Ptr{Cvoid}, Ptr{UInt8}, UInt), io_pointer(io), x, nb); nb)

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -796,7 +796,7 @@ struct CoreSTDERR <: IO end
 const stdout = CoreSTDOUT()
 const stderr = CoreSTDERR()
 io_pointer(::CoreSTDOUT) = Intrinsics.pointerref(Intrinsics.cglobal(:jl_uv_stdout, Ptr{Cvoid}), 1, 1)
-io_pointer(::Any) = Intrinsics.pointerref(Intrinsics.cglobal(:jl_uv_stderr, Ptr{Cvoid}), 1, 1)
+io_pointer(::CoreSTDERR) = Intrinsics.pointerref(Intrinsics.cglobal(:jl_uv_stderr, Ptr{Cvoid}), 1, 1)
 
 unsafe_write(io::IO, x::Ptr{UInt8}, nb::UInt) =
     (ccall(:jl_uv_puts, Cvoid, (Ptr{Cvoid}, Ptr{UInt8}, UInt), io_pointer(io), x, nb); nb)


### PR DESCRIPTION
Invalid IR in a debug build makes the validator call `Core.println` with a `Base.TTY`, which makes a bad day worse.  

I'm not sure about the usefulness of this file—I think moving it out of bootstrap would let us make it more powerful—but just fix the error for now.  Also remove a couple of unused expr heads as of #57965.
