### PR TITLE
Don't create a type parameter in the closure for captured @nospecialize arguments

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -493,6 +493,7 @@
 (define (vinfo:never-undef v) (< 0 (logand (caddr v) 4)))
 (define (vinfo:read v) (< 0 (logand (caddr v) 8)))
 (define (vinfo:sa v) (< 0 (logand (caddr v) 16)))
+(define (vinfo:nospecialize v) (< 0 (logand (caddr v) 128)))
 (define (set-bit x b val) (if val (logior x b) (logand x (lognot b))))
 ;; record whether var is captured
 (define (vinfo:set-capt! v c)  (set-car! (cddr v) (set-bit (caddr v) 1 c)))
@@ -507,6 +508,7 @@
 ;; occurs undef: mask 32
 ;; whether var is called (occurs in function call head position)
 (define (vinfo:set-called! v a)  (set-car! (cddr v) (set-bit (caddr v) 64 a)))
+(define (vinfo:set-nospecialize! v c)  (set-car! (cddr v) (set-bit (caddr v) 128 c)))
 
 (define var-info-for assq)
 

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -4330,3 +4330,12 @@ let ex = @Meta.lower function return_my_method(); 1; end
     code[end] = Core.ReturnNode(Core.SSAValue(idx))
     @test isa(Core.eval(@__MODULE__, ex), Method)
 end
+
+# Capturing a @nospecialize argument should result in an Any field in the closure
+module NoSpecClosure
+    K(@nospecialize(x)) = y -> x
+end
+let f = NoSpecClosure.K(1)
+    @test f(2) == 1
+    @test typeof(f).parameters == Core.svec()
+end


### PR DESCRIPTION
When we capture a variable without boxing, we always generate a type parameter for the closure.  This probably isn't what the user wants if the captured variable is an argument marked `@nospecialize`.

Before:
```
julia> K(@nospecialize(x)) = @nospecialize(y) -> x
K (generic function with 1 method)

julia> f, g = K(1), K("a")
(var"#K##0#K##1"{Int64}(1), var"#K##0#K##1"{String}("a"))

julia> f(2), g(2)
(1, "a")

julia> methods(f)[1].specializations
svec(MethodInstance for (::var"#K##0#K##1"{Int64})(::Any), MethodInstance for (::var"#K##0#K##1"{String})(::Any), nothing, nothing, nothing, nothing, nothing)

julia> fieldtypes(typeof(f)), fieldtypes(typeof(g))
((Int64,), (String,))
```

After:
```
julia> K(@nospecialize(x)) = @nospecialize(y) -> x
K (generic function with 1 method)

julia> f, g = K(1), K("a")
(var"#K##0#K##1"(1), var"#K##0#K##1"("a"))

julia> f(2), g(2)
(1, "a")

julia> methods(f)[1].specializations
MethodInstance for (::var"#K##0#K##1")(::Any)

julia> fieldtypes(typeof(f)), fieldtypes(typeof(g))
((Any,), (Any,))
```
