### PR TITLE
Bump Documenter to v1.11.4

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -57,3 +57,7 @@ deploy: deps
 	@echo "Deploying HTML documentation."
 	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) -- deploy $(DOCUMENTER_OPTIONS)
 	@echo "Build & deploy of docs finished."
+
+update-documenter:
+	@echo "Updating Documenter."
+	JULIA_PKG_PRECOMPILE_AUTO=0 $(JULIA_EXECUTABLE) --project --color=yes -e 'using Pkg; Pkg.update("Documenter")'

--- a/doc/Manifest.toml
+++ b/doc/Manifest.toml
@@ -44,9 +44,9 @@ version = "0.9.4"
 
 [[deps.Documenter]]
 deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
-git-tree-sha1 = "6f8730fd1bdf974009ef296bd81afb2728854fc0"
+git-tree-sha1 = "6c182d0bd94142d7cbc3ae8a1e74668f15d0dd65"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.11.3"
+version = "1.11.4"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]


### PR DESCRIPTION
If at first you don't succeed... https://github.com/JuliaLang/julia/pull/58421#issuecomment-2883941876 and https://github.com/JuliaDocs/Documenter.jl/pull/2723.

Also adds a small `make` command to `doc/` to do a `Pkg.update("Documenter")`.