### PR TITLE
Add vscale_range attribute to functions with sve

### DIFF
--- a/src/llvm-cpufeatures.cpp
+++ b/src/llvm-cpufeatures.cpp
@@ -102,6 +102,17 @@ bool lowerCPUFeatures(Module &M) JL_NOTSAFEPOINT
                 Materialized.push_back(I);
             }
         }
+        if (TT.isAArch64()) {
+        Attribute FSAttr = F.getFnAttribute("target-features");
+        StringRef FS =
+            FSAttr.isValid() ? FSAttr.getValueAsString() : jl_ExecutionEngine->getTargetFeatureString();
+        SmallVector<StringRef, 128> Features;
+        FS.split(Features, ',');
+        for (StringRef Feature : Features) {
+            if (Feature == "sve")
+                F.addFnAttr(llvm::Attribute::getWithVScaleRangeArgs(M.getContext(), 1, 16)); //Hardcode for now
+        }
+        }
     }
 
     if (!Materialized.empty()) {


### PR DESCRIPTION
For some reason LLVM expects frontends to do this intead of querying the TTI. So just add a default when it makes sense. ( I wonder if this should be done elsewhere but this pass seems like it can handle this fine and everything is already there)