### PR TITLE
ir: Consider Argument a useref

### DIFF
--- a/Compiler/src/ssair/ir.jl
+++ b/Compiler/src/ssair/ir.jl
@@ -609,7 +609,7 @@ end
     elseif isa(stmt, EnterNode)
         op == 1 || throw(BoundsError())
         stmt = EnterNode(stmt.catch_dest, v)
-    elseif isa(stmt, Union{AnySSAValue, GlobalRef})
+    elseif isa(stmt, Union{AnySSAValue, Argument, GlobalRef})
         op == 1 || throw(BoundsError())
         stmt = v
     elseif isa(stmt, UpsilonNode)
@@ -640,7 +640,7 @@ end
 function userefs(@nospecialize(x))
     relevant = (isa(x, Expr) && is_relevant_expr(x)) ||
         isa(x, GotoIfNot) || isa(x, ReturnNode) || isa(x, SSAValue) || isa(x, OldSSAValue) || isa(x, NewSSAValue) ||
-        isa(x, PiNode) || isa(x, PhiNode) || isa(x, PhiCNode) || isa(x, UpsilonNode) || isa(x, EnterNode)
+        isa(x, PiNode) || isa(x, PhiNode) || isa(x, PhiCNode) || isa(x, UpsilonNode) || isa(x, EnterNode) || isa(x, Argument)
     return UseRefIterator(x, relevant)
 end
 

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -459,7 +459,7 @@ let
             @test stmt.cond === v
         elseif isa(stmt, ReturnNode) || isa(stmt, UpsilonNode)
             @test stmt.val === v
-        elseif isa(stmt, SSAValue) || isa(stmt, NewSSAValue)
+        elseif isa(stmt, SSAValue) || isa(stmt, NewSSAValue) || isa(stmt, Argument)
             @test stmt === v
         elseif isa(stmt, PiNode)
             @test stmt.val === v && stmt.typ === typeof(stmt)
@@ -508,6 +508,7 @@ let
         GotoNode(5),
         SSAValue(7),
         NewSSAValue(9),
+        Argument(1),
         ReturnNode(SSAValue(11)),
     ]
 


### PR DESCRIPTION
A common usecase for `userefs` is to replace an embedded `Argument` by something else (e.g. for inlining like operations). This allows this to be written as a single `userefs` loop rather than adding an additional if case for `Argument`.