### PR TITLE
ir: Don't fail if :invoke has zero arguments

### DIFF
--- a/Compiler/src/ssair/passes.jl
+++ b/Compiler/src/ssair/passes.jl
@@ -9,7 +9,9 @@ end
 function is_known_invoke_or_call(@nospecialize(x), @nospecialize(func), ir::Union{IRCode,IncrementalCompact})
     isinvoke = isexpr(x, :invoke)
     (isinvoke || isexpr(x, :call)) || return false
-    ft = argextype(x.args[isinvoke ? 2 : 1], ir)
+    narg = isinvoke ? 2 : 1
+    length(x.args) < narg && return false
+    ft = argextype(x.args[narg], ir)
     return singleton_type(ft) === func
 end
 


### PR DESCRIPTION
All julia functions always have at least one argument (ignoring toplevel thunks, but those have special representation). However, with ABIOverride it is possible to create zero argument CodeInstances and :invoke them. I'm not entirely sure this is useful, but things do generally seem to go through, so let's not unnecessarily error in the optimizer.