### PR TITLE
Remove unreachable error branch by casting to UInt in parsing

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -261,12 +261,12 @@ tryparse(::Type{Union{}}, slurp...; kwargs...) = error("cannot parse a value as 
 
 function tryparse(::Type{Float64}, s::String)
     hasvalue, val = ccall(:jl_try_substrtod, Tuple{Bool, Float64},
-                          (Ptr{UInt8},Csize_t,Csize_t), s, 0, sizeof(s))
+                          (Ptr{UInt8},Csize_t,Csize_t), s, 0, sizeof(s) % UInt)
     hasvalue ? val : nothing
 end
 function tryparse(::Type{Float64}, s::SubString{String})
     hasvalue, val = ccall(:jl_try_substrtod, Tuple{Bool, Float64},
-                          (Ptr{UInt8},Csize_t,Csize_t), s.string, s.offset, s.ncodeunits)
+                          (Ptr{UInt8},Csize_t,Csize_t), s.string, s.offset, s.ncodeunits % UInt)
     hasvalue ? val : nothing
 end
 function tryparse_internal(::Type{Float64}, s::String, startpos::Int, endpos::Int)
@@ -281,12 +281,12 @@ function tryparse_internal(::Type{Float64}, s::SubString{String}, startpos::Int,
 end
 function tryparse(::Type{Float32}, s::String)
     hasvalue, val = ccall(:jl_try_substrtof, Tuple{Bool, Float32},
-                          (Ptr{UInt8},Csize_t,Csize_t), s, 0, sizeof(s))
+                          (Ptr{UInt8},Csize_t,Csize_t), s, 0, sizeof(s) % UInt)
     hasvalue ? val : nothing
 end
 function tryparse(::Type{Float32}, s::SubString{String})
     hasvalue, val = ccall(:jl_try_substrtof, Tuple{Bool, Float32},
-                          (Ptr{UInt8},Csize_t,Csize_t), s.string, s.offset, s.ncodeunits)
+                          (Ptr{UInt8},Csize_t,Csize_t), s.string, s.offset, s.ncodeunits % UInt)
     hasvalue ? val : nothing
 end
 function tryparse_internal(::Type{Float32}, s::String, startpos::Int, endpos::Int)


### PR DESCRIPTION
The `ncodeunits` field of substrings - and therefore also their size, cannot be negative.

Ideally we would also remove the unnecessary checks in the other `tryparse` methods, that take start and end indices, but that should probably be rewritten to take a view, but that's a PR for another day.