### PR TITLE
Update documentation.md

### DIFF
--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -242,16 +242,23 @@ As in the example above, we recommend following some simple conventions when wri
    ```
 
    This makes it clearer where docstrings start and end.
-9. Respect the line length limit used in the surrounding code.
+
+   !!! note
+       If using [`Documenter.jl`](https://github.com/JuliaDocs/Documenter.jl) to create documentation, ensure that
+       there are no empty or comment lines between the end of the docstring (`"""`) and the function declaration.
+       Any lines between the end of the docstring and the function declaration will result in `Documenter` not finding
+       the docstring (and ensuring an associated `no docs found` error).
+   
+10. Respect the line length limit used in the surrounding code.
 
    Docstrings are edited using the same tools as code. Therefore, the same conventions should apply.
    It is recommended that lines are at most 92 characters wide.
-10. Provide information allowing custom types to implement the function in an
+11. Provide information allowing custom types to implement the function in an
    `# Implementation` section. These implementation details are intended for developers
    rather than users, explaining e.g. which functions should be overridden and which
    functions automatically use appropriate fallbacks. Such details are best kept separate
    from the main description of the function's behavior.
-11. For long docstrings, consider splitting the documentation with an
+12. For long docstrings, consider splitting the documentation with an
    `# Extended help` header. The typical help-mode will show only the
    material above the header; you can access the full help by adding a '?'
    at the beginning of the expression (i.e., "??foo" rather than "?foo").


### PR DESCRIPTION
If using [`Documenter.jl`](https://github.com/JuliaDocs/Documenter.jl), having empty or comment lines between the last line of the docstring and the function declaration breaks `@doc`, resulting in a `no doc found` error. This appears to be due to how the Julia parser handles this case.

This change adds a note to point 8 that makes it clear that if using `Documenter`, there can be no lines between the end of the docstring and the function declaration.