### PR TITLE
Fix tbaa usage when storing into heap allocated immutable structs

### DIFF
--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -1047,3 +1047,22 @@ f57872() = (Core.isdefinedglobal(@__MODULE__, Base.compilerbarrier(:const, :x578
 @noinline f_mutateany(@nospecialize x) = x[] = 1
 g_mutateany() = (y = Ref(0); f_mutateany(y); y[])
 @test g_mutateany() === 1
+
+# 58470 tbaa for unionselbyte for mut and immut
+
+mutable struct Wrapper58470
+    x::Union{Nothing,Int}
+end
+
+function findsomething58470(dict, inds)
+    default = Wrapper58470(nothing)
+    for i in inds
+        x = get(dict, i, default).x
+        if !isnothing(x)
+            return x
+        end
+    end
+    return nothing
+end
+
+@test occursin("tindex_ptr", get_llvm(findsomething58470, Tuple{Dict{Int64, Wrapper58470}, Vector{Int}}))

--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -1048,8 +1048,7 @@ f57872() = (Core.isdefinedglobal(@__MODULE__, Base.compilerbarrier(:const, :x578
 g_mutateany() = (y = Ref(0); f_mutateany(y); y[])
 @test g_mutateany() === 1
 
-# 58470 tbaa for unionselbyte for mut and immut
-
+# 58470 tbaa for unionselbyte of heap allocated mutables
 mutable struct Wrapper58470
     x::Union{Nothing,Int}
 end
@@ -1065,4 +1064,8 @@ function findsomething58470(dict, inds)
     return nothing
 end
 
-@test occursin("tindex_ptr", get_llvm(findsomething58470, Tuple{Dict{Int64, Wrapper58470}, Vector{Int}}))
+let io = IOBuffer()
+    code_llvm(io, findsomething58470, Tuple{Dict{Int64, Wrapper58470}, Vector{Int}}, dump_module=true, raw=true, optimize=false)
+    str = String(take!(io))
+    @test !occursin("jtbaa_unionselbyte", str)
+end

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -4141,7 +4141,7 @@ static jl_cgval_t emit_setfield(jl_codectx_t &ctx,
         size_t fsz1 = jl_field_size(sty, idx0) - 1;
         Value *ptindex = emit_ptrgep(ctx, addr, fsz1);
         setNameWithField(ctx.emission_context, ptindex, get_objname, sty, idx0, Twine(".tindex_ptr"));
-        return union_store(ctx, addr, ptindex, rhs, cmp, jfty, tbaa, ctx.tbaa().tbaa_unionselbyte,
+        return union_store(ctx, addr, ptindex, rhs, cmp, jfty, tbaa, strct.tbaa,
             Order, FailOrder,
             needlock, issetfield, isreplacefield, isswapfield, ismodifyfield, issetfieldonce,
             modifyop, fname);
@@ -4409,7 +4409,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
         undef_derived_strct(ctx, strct, sty, strctinfo.tbaa);
         for (size_t i = nargs; i < nf; i++) {
             if (!jl_field_isptr(sty, i) && jl_is_uniontype(jl_field_type(sty, i))) {
-                jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_unionselbyte);
+                jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, strctinfo.tbaa);
                 ai.decorateInst(ctx.builder.CreateAlignedStore(
                         ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0),
                         emit_ptrgep(ctx, strct, jl_field_offset(sty, i) + jl_field_size(sty, i) - 1),


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/58470. In https://github.com/JuliaLang/julia/pull/54604 this was half fixed but at that point I was already skeptical of the union selector being part of stack, where it's actually part of a value. ~~This creates a immutunionselbyte tbaa and a mut version.~~