### PR TITLE
avoid error just computing coverage of generated functions

### DIFF
--- a/base/staticdata.jl
+++ b/base/staticdata.jl
@@ -82,9 +82,9 @@ end
 function needs_instrumentation(codeinst::CodeInstance, mi::MethodInstance, def::Method, validation_world::UInt)
     if JLOptions().code_coverage != 0 || JLOptions().malloc_log != 0
         # test if the code needs to run with instrumentation, in which case we cannot use existing generated code
-        if isdefined(def, :debuginfo) ? # generated_only functions do not have debuginfo, so fall back to considering their codeinst debuginfo though this may be slower (and less accurate?)
+        if isdefined(def, :debuginfo) ? # generated_only functions do not have debuginfo, so fall back to considering their codeinst debuginfo though this may be slower and less reliable
             Compiler.should_instrument(def.module, def.debuginfo) :
-            Compiler.should_instrument(def.module, codeinst.debuginfo)
+            isdefined(codeinst, :debuginfo) && Compiler.should_instrument(def.module, codeinst.debuginfo)
             return true
         end
         gensig = gen_staged_sig(def, mi)


### PR DESCRIPTION
We only put debuginfo here if we ran the optimizer, so if there isn't debuginfo here, then we either didn't run the optimizer or were the result of const-prop. In the former case, we don't need to invalidate the code for instrumentation (it cannot have code from it). In the later case, we should already have an edge from the non-const-prop result. This only matters for generated functions, since otherwise we have Method's source's accurate debuginfo already and this is just a duplicate reference to it.

Fix #58227