### PR TITLE
reduce: unalias arrays for hcat/vcat (map)reduce

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -407,6 +407,8 @@ reduce_first(::typeof(add_sum), x::BitUnsignedSmall) = UInt(x)
 reduce_first(::typeof(mul_prod), x) = reduce_first(*, x)
 reduce_first(::typeof(mul_prod), x::BitSignedSmall)   = Int(x)
 reduce_first(::typeof(mul_prod), x::BitUnsignedSmall) = UInt(x)
+reduce_first(::typeof(vcat), x) = vcat(x)
+reduce_first(::typeof(hcat), x) = hcat(x)
 
 """
     Base.mapreduce_first(f, op, x)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -771,3 +771,9 @@ end
         Val(any(in((:one,:two,:three)),(:four,:three)))
     end |> only == Val{true}
 end
+
+# `reduce(vcat, A)` should not alias the input for length-1 collections
+let A=[1;;]
+    @test reduce(vcat, Any[A]) !== A
+    @test reduce(hcat, Any[A]) !== A
+end


### PR DESCRIPTION
I was using `reduce(vcat, list_of_arrays)` and then modifying the resulting array. This worked great, except that in the case when `length(list_of_arrays) == 1`, the resulting array would alias the input, resulting in the input being modified and causing havoc down the road. Of course the proper fix for this is better built-in support for immutable arrays (and possibly memory ownership) to encode those assumptions explicitly. However, while this hack is unsatisfying, I do think it is somewhat defensible. One argument `hcat` and `vcat` perform the copy, as do the various optimized special cases for these functions. Of course, this is fragile and would break as soon as someone puts it in a closure, but maybe it saves at least a little bit of headache.

I considered a more aggressive change to make the generic fallback `reduce_first(op, x) = op(x)`, but in discussion with Jeff, this was deemed too breaking, since it would add an assumption that `op` has a one-arg form.