### PR TITLE
fix: Make `showarg` a public function

### DIFF
--- a/base/public.jl
+++ b/base/public.jl
@@ -111,6 +111,7 @@ public
     reseteof,
     link_pipe!,
     dup,
+    showarg,
 
 # filesystem operations
     rename,


### PR DESCRIPTION
`showarg` is meant to be public and it is directly specified in the
documentation that it is meant for overriding.

Fixes: #57513