### PR TITLE
Add a new `make -C doc alldeps` target to install Documenter

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -34,6 +34,9 @@ deps: $(SRCCACHE)/UnicodeData-$(UNICODE_DATA_VERSION).txt
 	$(JLCHECKSUM) "$<"
 	cp "$<" UnicodeData.txt
 
+alldeps: deps
+	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) deps
+
 checksum-unicodedata: $(SRCCACHE)/UnicodeData-$(UNICODE_DATA_VERSION).txt
 	$(JLCHECKSUM) "$<"
 

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -8,6 +8,10 @@ push!(DEPOT_PATH, abspath(Sys.BINDIR, "..", "share", "julia"))
 using Pkg
 Pkg.instantiate()
 
+if "deps" in ARGS
+    exit()
+end
+
 using Documenter
 import LibGit2
 


### PR DESCRIPTION
This adds a new `alldeps` target to `make -C doc` that also downloads the Documenter.jl dependency. The motivation here is to make sure to have all dependencies necessary for running the doctests in an environment that may not have network connectivity (e.g. the OpenAI Codex sandbox).