### PR TITLE
Copy module metadata for source module, if any.

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -846,11 +846,12 @@ void *jl_emit_native_impl(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvm
                 continue; // skip any duplicates that accidentally made there way in here (or make this an error?)
             if (jl_ir_inlining_cost((jl_value_t*)src) < UINT16_MAX)
                 params.safepoint_on_entry = false; // ensure we don't block ExpandAtomicModifyPass from inlining this code if applicable
-            orc::ThreadSafeModule result_m = jl_create_ts_module(
-                name_from_method_instance(jl_get_ci_mi(codeinst)), params.tsctx,
-                clone.getModuleUnlocked()->getDataLayout(),
-                Triple(clone.getModuleUnlocked()->getTargetTriple()),
-                clone.getModuleUnlocked());
+            orc::ThreadSafeModule result_m =
+                jl_create_ts_module(name_from_method_instance(jl_get_ci_mi(codeinst)),
+                                    params.tsctx,
+                                    clone.getModuleUnlocked()->getDataLayout(),
+                                    Triple(clone.getModuleUnlocked()->getTargetTriple()),
+                                    clone.getModuleUnlocked());
             jl_llvm_functions_t decls;
             if (!(params.params->force_emit_all) && jl_atomic_load_relaxed(&codeinst->invoke) == jl_fptr_const_return_addr)
                 decls.functionObject = "jl_fptr_const_return";

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -849,7 +849,8 @@ void *jl_emit_native_impl(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvm
             orc::ThreadSafeModule result_m = jl_create_ts_module(
                 name_from_method_instance(jl_get_ci_mi(codeinst)), params.tsctx,
                 clone.getModuleUnlocked()->getDataLayout(),
-                Triple(clone.getModuleUnlocked()->getTargetTriple()), false);
+                Triple(clone.getModuleUnlocked()->getTargetTriple()),
+                clone.getModuleUnlocked());
             jl_llvm_functions_t decls;
             if (!(params.params->force_emit_all) && jl_atomic_load_relaxed(&codeinst->invoke) == jl_fptr_const_return_addr)
                 decls.functionObject = "jl_fptr_const_return";

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -846,9 +846,10 @@ void *jl_emit_native_impl(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvm
                 continue; // skip any duplicates that accidentally made there way in here (or make this an error?)
             if (jl_ir_inlining_cost((jl_value_t*)src) < UINT16_MAX)
                 params.safepoint_on_entry = false; // ensure we don't block ExpandAtomicModifyPass from inlining this code if applicable
-            orc::ThreadSafeModule result_m = jl_create_ts_module(name_from_method_instance(jl_get_ci_mi(codeinst)),
-                    params.tsctx, clone.getModuleUnlocked()->getDataLayout(),
-                    Triple(clone.getModuleUnlocked()->getTargetTriple()));
+            orc::ThreadSafeModule result_m = jl_create_ts_module(
+                name_from_method_instance(jl_get_ci_mi(codeinst)), params.tsctx,
+                clone.getModuleUnlocked()->getDataLayout(),
+                Triple(clone.getModuleUnlocked()->getTargetTriple()), false);
             jl_llvm_functions_t decls;
             if (!(params.params->force_emit_all) && jl_atomic_load_relaxed(&codeinst->invoke) == jl_fptr_const_return_addr)
                 decls.functionObject = "jl_fptr_const_return";

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2991,7 +2991,8 @@ std::unique_ptr<Module> jl_create_llvm_module(StringRef name, LLVMContext &conte
         // Copy other module-level properties
         m->setStackProtectorGuard(source->getStackProtectorGuard());
         m->setOverrideStackAlignment(source->getOverrideStackAlignment());
-    } else {
+    }
+    else {
         // No source: set default Julia flags
         // According to clang darwin above 10.10 supports dwarfv4
         m->addModuleFlag(llvm::Module::Warning, "Dwarf Version", 4);

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -684,20 +684,20 @@ private:
 extern JuliaOJIT *jl_ExecutionEngine;
 std::unique_ptr<Module> jl_create_llvm_module(StringRef name, LLVMContext &ctx,
                                               const DataLayout &DL, const Triple &triple,
-                                              bool toplevel) JL_NOTSAFEPOINT;
+                                              Module *source = nullptr) JL_NOTSAFEPOINT;
 inline orc::ThreadSafeModule jl_create_ts_module(StringRef name, orc::ThreadSafeContext ctx,
                                                  const DataLayout &DL, const Triple &triple,
-                                                 bool toplevel = true) JL_NOTSAFEPOINT
+                                                 Module *source = nullptr) JL_NOTSAFEPOINT
 {
     auto lock = ctx.getLock();
     return orc::ThreadSafeModule(
-        jl_create_llvm_module(name, *ctx.getContext(), DL, triple, toplevel), ctx);
+        jl_create_llvm_module(name, *ctx.getContext(), DL, triple, source), ctx);
 }
 
 Module &jl_codegen_params_t::shared_module() JL_NOTSAFEPOINT {
     if (!_shared_module) {
         _shared_module =
-            jl_create_llvm_module("globals", getContext(), DL, TargetTriple, true);
+            jl_create_llvm_module("globals", getContext(), DL, TargetTriple);
     }
     return *_shared_module;
 }

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -682,15 +682,22 @@ private:
     OptSelLayerT OptSelLayer;
 };
 extern JuliaOJIT *jl_ExecutionEngine;
-std::unique_ptr<Module> jl_create_llvm_module(StringRef name, LLVMContext &ctx, const DataLayout &DL, const Triple &triple) JL_NOTSAFEPOINT;
-inline orc::ThreadSafeModule jl_create_ts_module(StringRef name, orc::ThreadSafeContext ctx, const DataLayout &DL, const Triple &triple) JL_NOTSAFEPOINT {
+std::unique_ptr<Module> jl_create_llvm_module(StringRef name, LLVMContext &ctx,
+                                              const DataLayout &DL, const Triple &triple,
+                                              bool toplevel) JL_NOTSAFEPOINT;
+inline orc::ThreadSafeModule jl_create_ts_module(StringRef name, orc::ThreadSafeContext ctx,
+                                                 const DataLayout &DL, const Triple &triple,
+                                                 bool toplevel = true) JL_NOTSAFEPOINT
+{
     auto lock = ctx.getLock();
-    return orc::ThreadSafeModule(jl_create_llvm_module(name, *ctx.getContext(), DL, triple), ctx);
+    return orc::ThreadSafeModule(
+        jl_create_llvm_module(name, *ctx.getContext(), DL, triple, toplevel), ctx);
 }
 
 Module &jl_codegen_params_t::shared_module() JL_NOTSAFEPOINT {
     if (!_shared_module) {
-        _shared_module = jl_create_llvm_module("globals", getContext(), DL, TargetTriple);
+        _shared_module =
+            jl_create_llvm_module("globals", getContext(), DL, TargetTriple, true);
     }
     return *_shared_module;
 }

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -696,8 +696,7 @@ inline orc::ThreadSafeModule jl_create_ts_module(StringRef name, orc::ThreadSafe
 
 Module &jl_codegen_params_t::shared_module() JL_NOTSAFEPOINT {
     if (!_shared_module) {
-        _shared_module =
-            jl_create_llvm_module("globals", getContext(), DL, TargetTriple);
+        _shared_module = jl_create_llvm_module("globals", getContext(), DL, TargetTriple);
     }
     return *_shared_module;
 }


### PR DESCRIPTION
Instead, rely on the linker automatically inheriting the metadata from the parent module. This avoids warnings and aborts with external users such as GPUCompiler.jl.