### PR TITLE
Don't filter `Core` methods from newly-inferred list

### DIFF
--- a/Compiler/src/cicache.jl
+++ b/Compiler/src/cicache.jl
@@ -14,7 +14,7 @@ end
 function setindex!(cache::InternalCodeCache, ci::CodeInstance, mi::MethodInstance)
     @assert ci.owner === cache.owner
     m = mi.def
-    if isa(m, Method) && m.module != Core
+    if isa(m, Method)
         ccall(:jl_push_newly_inferred, Cvoid, (Any,), ci)
     end
     ccall(:jl_mi_cache_insert, Cvoid, (Any, Any), mi, ci)


### PR DESCRIPTION
This allows constructors like `Tuple{Type{Vector{Foo}}, UndefInitializer, Tuple{Int}}` to precompile as usual

Appears to have a minimal effect on the stdlib pkgimages:
```julia
--- before.txt  2025-05-23 08:36:20.171870043 -0400
+++ after.txt   2025-05-22 14:48:49.003869097 -0400
@@ -47,7 +47,7 @@
  20K ../julia/usr/share/julia/compiled/v1.13/Logging/pkgimage.so
  20K ../julia/usr/share/julia/compiled/v1.13/Logging/pkgimage.so
 3.5M ../julia/usr/share/julia/compiled/v1.13/Markdown/pkgimage.so
-3.5M ../julia/usr/share/julia/compiled/v1.13/Markdown/pkgimage.so
+3.6M ../julia/usr/share/julia/compiled/v1.13/Markdown/pkgimage.so
 184K ../julia/usr/share/julia/compiled/v1.13/Mmap/pkgimage.so
 184K ../julia/usr/share/julia/compiled/v1.13/Mmap/pkgimage.so
  28K ../julia/usr/share/julia/compiled/v1.13/MozillaCACerts_jll/pkgimage.so
```

Resolves #58497.