### PR TITLE
Make more types jl_static_show readably

### DIFF
--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -836,12 +836,7 @@ static size_t jl_static_show_float(JL_STREAM *out, double v,
         n += jl_printf(out, "%sInf%s", v < 0 ? "-" : "", size_suffix);
     }
     else if (vt == jl_float64_type) {
-        size_t m = snprintf(buf, sizeof buf, "%.17g", v);
-        jl_uv_puts(out, buf, m);
-        n += m;
-        // If there is no decimal point or exponent, disambiguate
-        if (!strpbrk(buf, ".e"))
-            jl_printf(out, ".0");
+        n += jl_printf(buf, sizeof buf, "%#.17g", v);
     }
     else if (vt == jl_float32_type) {
         size_t m = snprintf(buf, sizeof buf, "%.9g", v);

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -739,13 +739,13 @@ static size_t jl_static_show_string(JL_STREAM *out, const char *str, size_t len,
                 else {
                      if (c == '"')
                          for (escapes++; escapes > 0; escapes--)
-                             n += jl_uv_puts(out, "\\", 1);
+                             n += jl_printf(out, "\\");
                      escapes = 0;
                 }
-                n += jl_uv_puts(out, str + i, 1);
+                n += jl_printf(out, "%c", str[i]);
             }
             for (; escapes > 0; escapes--)
-                n += jl_uv_puts(out, "\\", 1);
+                n += jl_printf(out, "\\");
         }
         else {
             char buf[512];
@@ -836,7 +836,7 @@ static size_t jl_static_show_float(JL_STREAM *out, double v,
         n += jl_printf(out, "%sInf%s", v < 0 ? "-" : "", size_suffix);
     }
     else if (vt == jl_float64_type) {
-        n += jl_printf(buf, sizeof buf, "%#.17g", v);
+        n += jl_printf(out, "%#.17g", v);
     }
     else if (vt == jl_float32_type) {
         size_t m = snprintf(buf, sizeof buf, "%.9g", v);
@@ -845,13 +845,14 @@ static size_t jl_static_show_float(JL_STREAM *out, double v,
         if (p)
             *p = 'f';
         jl_uv_puts(out, buf, m);
+        n += m;
         // If no exponent was printed, we must add one
         if (!p)
-            jl_printf(out, "f0");
+            n += jl_printf(out, "f0");
     }
     else {
         assert(vt == jl_float16_type);
-        n += jl_printf(out, "Float16(%.5g)", v);
+        n += jl_printf(out, "Float16(%#.5g)", v);
     }
     return n;
 }

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -841,7 +841,7 @@ static size_t jl_static_show_float(JL_STREAM *out, double v,
     else if (vt == jl_float32_type) {
         size_t m = snprintf(buf, sizeof buf, "%.9g", v);
         // If the exponent was printed, replace it with 'f'
-        char *p = memchr(buf, 'e', m);
+        char *p = (char *)memchr(buf, 'e', m);
         if (p)
             *p = 'f';
         jl_uv_puts(out, buf, m);

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -827,7 +827,7 @@ static size_t jl_static_show_float(JL_STREAM *out, double v,
         // If no decimal point or exponent will be printed, we must add ".0"
         double ipart, fpart;
         fpart = modf(v, &ipart);
-        int dotzero = v == 0 || (fpart == 0.0 && ipart < 1e17);
+        int dotzero = v == 0 || (fpart == 0.0 && fabs(ipart) < 1e17);
         n += jl_printf(out, "%.17g%s", v, dotzero ? ".0" : "");
     }
     else if (vt == jl_float32_type) {

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -739,13 +739,13 @@ static size_t jl_static_show_string(JL_STREAM *out, const char *str, size_t len,
                 else {
                      if (c == '"')
                          for (escapes++; escapes > 0; escapes--)
-                             jl_uv_puts(out, "\\", 1);
+                             n += jl_uv_puts(out, "\\", 1);
                      escapes = 0;
                 }
-                jl_uv_puts(out, str + i, 1);
+                n += jl_uv_puts(out, str + i, 1);
             }
             for (; escapes > 0; escapes--)
-                jl_uv_puts(out, "\\", 1);
+                n += jl_uv_puts(out, "\\", 1);
         }
         else {
             char buf[512];

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1018,7 +1018,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         n += jl_printf(out, "#<intrinsic #%d %s>", f, jl_intrinsic_name(f));
     }
     else if (vt == jl_long_type) {
-        // Avoid unecessary Int64(x)/Int32(x)
+        // Avoid unnecessary Int64(x)/Int32(x)
         n += jl_printf(out, "%" PRIdPTR, *(intptr_t*)v);
     }
     else if (vt == jl_int64_type) {

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -5,6 +5,8 @@
 */
 #include "platform.h"
 
+#include <float.h>
+#include <math.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -691,12 +693,12 @@ static int is_globfunction(jl_value_t *v, jl_datatype_t *dv, jl_sym_t **globname
     return 0;
 }
 
-static size_t jl_static_show_string(JL_STREAM *out, const char *str, size_t len, int wrap) JL_NOTSAFEPOINT
+static size_t jl_static_show_string(JL_STREAM *out, const char *str, size_t len, int wrap, int raw) JL_NOTSAFEPOINT
 {
     size_t n = 0;
     if (wrap)
         n += jl_printf(out, "\"");
-    if (!u8_isvalid(str, len)) {
+    if (!raw && !u8_isvalid(str, len)) {
         // alternate print algorithm that preserves data if it's not UTF-8
         static const char hexdig[] = "0123456789abcdef";
         for (size_t i = 0; i < len; i++) {
@@ -713,7 +715,11 @@ static size_t jl_static_show_string(JL_STREAM *out, const char *str, size_t len,
         int special = 0;
         for (size_t i = 0; i < len; i++) {
             uint8_t c = str[i];
-            if (c < 32 || c == 0x7f || c == '\\' || c == '"' || c == '$') {
+            if (raw && ((c == '\\' && i == len-1) || c == '"')) {
+                special = 1;
+                break;
+            }
+            else if (!raw && (c < 32 || c == 0x7f || c == '\\' || c == '"' || c == '$')) {
                 special = 1;
                 break;
             }
@@ -721,6 +727,17 @@ static size_t jl_static_show_string(JL_STREAM *out, const char *str, size_t len,
         if (!special) {
             jl_uv_puts(out, str, len);
             n += len;
+        }
+        else if (raw) {
+            for (size_t i = 0; i < len; i++) {
+                uint8_t c = str[i];
+                if (c == '"')
+                    jl_uv_puts(out, "\\\"", 2);
+                else if (c == '\\' && i == len - 1)
+                    jl_uv_puts(out, "\\\\", 2);
+                else
+                    jl_uv_puts(out, str + i, 1);
+            }
         }
         else {
             char buf[512];
@@ -737,18 +754,28 @@ static size_t jl_static_show_string(JL_STREAM *out, const char *str, size_t len,
     return n;
 }
 
+static int jl_is_quoted_sym(const char *sn)
+{
+    static const char *const quoted_syms[] = {":", "::", ":=", "=", "==", "===", "=>", "`"};
+    for (int i = 0; i < sizeof quoted_syms / sizeof *quoted_syms; i++)
+        if (!strcmp(sn, quoted_syms[i]))
+            return 1;
+    return 0;
+}
+
+// TODO: in theory, we need a separate function for showing symbols in an
+// expression context (where `Symbol("foo\x01bar")` is ok) and a syntactic
+// context (where var"" must be used).
 static size_t jl_static_show_symbol(JL_STREAM *out, jl_sym_t *name) JL_NOTSAFEPOINT
 {
     size_t n = 0;
     const char *sn = jl_symbol_name(name);
-    int quoted = !jl_is_identifier(sn) && !jl_is_operator(sn);
-    if (quoted) {
-        n += jl_printf(out, "var");
-        // TODO: this is not quite right, since repr uses String escaping rules, and Symbol uses raw string rules
-        n += jl_static_show_string(out, sn, strlen(sn), 1);
+    if (jl_is_identifier(sn) || (jl_is_operator(sn) && !jl_is_quoted_sym(sn))) {
+        n += jl_printf(out, "%s", sn);
     }
     else {
-        n += jl_printf(out, "%s", sn);
+        n += jl_printf(out, "var");
+        n += jl_static_show_string(out, sn, strlen(sn), 1, 1);
     }
     return n;
 }
@@ -775,6 +802,42 @@ static int jl_static_is_function_(jl_datatype_t *vt) JL_NOTSAFEPOINT {
         _iter_count += 1;
     }
     return 0;
+}
+
+static size_t jl_static_show_float(JL_STREAM *out, double v,
+                                   jl_datatype_t *vt) JL_NOTSAFEPOINT
+{
+    size_t n = 0;
+    // TODO: non-canonical NaNs do not round-trip
+    // TOOD: BFloat16
+    const char *size_suffix = vt == jl_float16_type ? "16" :
+                              vt == jl_float32_type ? "32" :
+                                                      "";
+    // Digits required to print p significand bits: ceil(p * log(10, 2))
+    //   Float16   4
+    //   Float32   8
+    //   Float64  17
+    if (isnan(v)) {
+        n += jl_printf(out, "NaN%s", size_suffix);
+    }
+    else if (isinf(v)) {
+        n += jl_printf(out, "%sInf%s", v < 0 ? "-" : "", size_suffix);
+    }
+    else if (vt == jl_float64_type) {
+        // If no decimal point or exponent will be printed, we must add ".0"
+        double ipart, fpart;
+        fpart = modf(v, &ipart);
+        int dotzero = v == 0 || (fpart == 0.0 && ipart < 1e17);
+        n += jl_printf(out, "%.17g%s", v, dotzero ? ".0" : "");
+    }
+    else if (vt == jl_float32_type) {
+        n += jl_printf(out, "Float32(%.8g)", v);
+    }
+    else {
+        assert(vt == jl_float16_type);
+        n += jl_printf(out, "Float16(%.4g)", v);
+    }
+    return n;
 }
 
 // `v` might be pointing to a field inlined in a structure therefore
@@ -954,17 +1017,21 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         int f = *(uint32_t*)jl_data_ptr(v);
         n += jl_printf(out, "#<intrinsic #%d %s>", f, jl_intrinsic_name(f));
     }
+    else if (vt == jl_long_type) {
+        // Avoid unecessary Int64(x)/Int32(x)
+        n += jl_printf(out, "%" PRIdPTR, *(intptr_t*)v);
+    }
     else if (vt == jl_int64_type) {
-        n += jl_printf(out, "%" PRId64, *(int64_t*)v);
+        n += jl_printf(out, "Int64(%" PRId64 ")", *(int64_t*)v);
     }
     else if (vt == jl_int32_type) {
-        n += jl_printf(out, "%" PRId32, *(int32_t*)v);
+        n += jl_printf(out, "Int32(%" PRId32 ")", *(int32_t*)v);
     }
     else if (vt == jl_int16_type) {
-        n += jl_printf(out, "%" PRId16, *(int16_t*)v);
+        n += jl_printf(out, "Int16(%" PRId16 ")", *(int16_t*)v);
     }
     else if (vt == jl_int8_type) {
-        n += jl_printf(out, "%" PRId8, *(int8_t*)v);
+        n += jl_printf(out, "Int8(%" PRId8 ")", *(int8_t*)v);
     }
     else if (vt == jl_uint64_type) {
         n += jl_printf(out, "0x%016" PRIx64, *(uint64_t*)v);
@@ -985,11 +1052,14 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         n += jl_printf(out, "0x%08" PRIx32, *(uint32_t*)v);
 #endif
     }
+    else if (vt == jl_float16_type) {
+        n += jl_static_show_float(out, julia_half_to_float(*(uint16_t *)v), vt);
+    }
     else if (vt == jl_float32_type) {
-        n += jl_printf(out, "%gf", *(float*)v);
+        n += jl_static_show_float(out, *(float *)v, vt);
     }
     else if (vt == jl_float64_type) {
-        n += jl_printf(out, "%g", *(double*)v);
+        n += jl_static_show_float(out, *(double *)v, vt);
     }
     else if (vt == jl_bool_type) {
         n += jl_printf(out, "%s", *(uint8_t*)v ? "true" : "false");
@@ -998,7 +1068,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         n += jl_printf(out, "nothing");
     }
     else if (vt == jl_string_type) {
-        n += jl_static_show_string(out, jl_string_data(v), jl_string_len(v), 1);
+        n += jl_static_show_string(out, jl_string_data(v), jl_string_len(v), 1, 0);
     }
     else if (v == jl_bottom_type) {
         n += jl_printf(out, "Union{}");
@@ -1528,10 +1598,10 @@ void jl_log(int level, jl_value_t *module, jl_value_t *group, jl_value_t *id,
         }
         jl_printf(str, "\n@ ");
         if (jl_is_string(file)) {
-            jl_static_show_string(str, jl_string_data(file), jl_string_len(file), 0);
+            jl_static_show_string(str, jl_string_data(file), jl_string_len(file), 0, 0);
         }
         else if (jl_is_symbol(file)) {
-            jl_static_show_string(str, jl_symbol_name((jl_sym_t*)file), strlen(jl_symbol_name((jl_sym_t*)file)), 0);
+            jl_static_show_string(str, jl_symbol_name((jl_sym_t*)file), strlen(jl_symbol_name((jl_sym_t*)file)), 0, 0);
         }
         jl_printf(str, ":");
         jl_static_show(str, line);

--- a/test/show.jl
+++ b/test/show.jl
@@ -1582,10 +1582,14 @@ struct var"%X%" end  # Invalid name without '#'
             Float16(0.4893243538921085), Float32(0.4893243538921085), Float64(0.4893243538921085),
             floatmax(Float16),           floatmax(Float32),           floatmax(Float64),
             floatmin(Float16),           floatmin(Float32),           floatmin(Float64),
-            typemax(Float16),            typemax(Float32),            typemax(Float64),
-            typemin(Float16),            typemin(Float32),            typemin(Float64),
+            Inf16,                       Inf32,                       Inf,
+            -Inf16,                      -Inf32,                      -Inf,
             nextfloat(Float16(0)),       nextfloat(Float32(0)),       nextfloat(Float64(0)),
             NaN16,                       NaN32,                       NaN,
+            Float16(1e3),                1f7,                         1e16,
+            Float16(-1e3),               -1f7,                        -1e16,
+            Float16(1e4),                1f8,                         1e17,
+            Float16(-1e4),               -1f8,                        -1e17,
 
             # :var"" escaping rules differ from strings (#58484)
             :foo,
@@ -1597,6 +1601,12 @@ struct var"%X%" end  # Invalid name without '#'
             :+, :var"+-",
             :(=), :(:), :(::),  # Requires quoting
             Symbol("a\nb"),
+
+            Val(Float16(1.0)), Val(1f0),      Val(1.0),
+            Val(:abc),         Val(:(=)),     Val(:var"a\b"),
+
+            Val(1),       Val(Int8(1)),  Val(Int16(1)),  Val(Int32(1)),  Val(Int64(1)),  Val(Int128(1)),
+            Val(UInt(1)), Val(UInt8(1)), Val(UInt16(1)), Val(UInt32(1)), Val(UInt64(1)), Val(UInt128(1)),
 
             # BROKEN
             # Symbol("a\xffb"),

--- a/test/show.jl
+++ b/test/show.jl
@@ -1600,7 +1600,7 @@ struct var"%X%" end  # Invalid name without '#'
 
             # BROKEN
             # Symbol("a\xffb"),
-            # User-defined primtive types
+            # User-defined primitive types
             # Non-canonical NaNs
             # BFloat16
         )

--- a/test/show.jl
+++ b/test/show.jl
@@ -1597,7 +1597,10 @@ struct var"%X%" end  # Invalid name without '#'
             :var"a $b",         # No escaping for $ in raw string
             :var"a\b",          # No escaping for backslashes in middle
             :var"a\\",          # Backslashes must be escaped at the end
-            :var"\"",
+            :var"a\\\\",
+            :var"a\"b",
+            :var"a\"",
+            :var"\\\"",
             :+, :var"+-",
             :(=), :(:), :(::),  # Requires quoting
             Symbol("a\nb"),

--- a/test/show.jl
+++ b/test/show.jl
@@ -1580,6 +1580,8 @@ struct var"%X%" end  # Invalid name without '#'
             Float16(1),                  Float32(1),                  Float64(1),
             Float16(1.5),                Float32(1.5),                Float64(1.5),
             Float16(0.4893243538921085), Float32(0.4893243538921085), Float64(0.4893243538921085),
+            # Examples that require the full 5, 9, and 17 digits of precision
+            Float16(0.00010014),         Float32(1.00000075f-36),     Float64(-1.561051336605761e-182),
             floatmax(Float16),           floatmax(Float32),           floatmax(Float64),
             floatmin(Float16),           floatmin(Float32),           floatmin(Float64),
             Inf16,                       Inf32,                       Inf,

--- a/test/show.jl
+++ b/test/show.jl
@@ -703,7 +703,7 @@ let oldout = stdout, olderr = stderr
         redirect_stderr(olderr)
         close(wrout)
         close(wrerr)
-        @test fetch(out) == "primitive type Int64 <: Signed\nTESTA\nTESTB\nΑ1Β2\"A\"\nA\n123.0\"C\"\n"
+        @test fetch(out) == "primitive type Int64 <: Signed\nTESTA\nTESTB\nΑ1Β2\"A\"\nA\n123.0000000000000000\"C\"\n"
         @test fetch(err) == "TESTA\nTESTB\nΑ1Β2\"A\"\n"
     finally
         redirect_stdout(oldout)
@@ -1584,6 +1584,8 @@ struct var"%X%" end  # Invalid name without '#'
             Float16(0.00010014),         Float32(1.00000075f-36),     Float64(-1.561051336605761e-182),
             floatmax(Float16),           floatmax(Float32),           floatmax(Float64),
             floatmin(Float16),           floatmin(Float32),           floatmin(Float64),
+            Float16(0.0),                0.0f0,                       0.0,
+            Float16(-0.0),               -0.0f0,                      -0.0,
             Inf16,                       Inf32,                       Inf,
             -Inf16,                      -Inf32,                      -Inf,
             nextfloat(Float16(0)),       nextfloat(Float32(0)),       nextfloat(Float64(0)),


### PR DESCRIPTION
Makes more types survive `jl_static_show`:
- Symbols
  - Symbols printed in the `:var"foo"` form use raw string escaping, fixing `:var"a\b"`, `:var"a\\"`, `:var"$a"`, etc.
  - Symbols that require parens use parens (`:(=)`, ...)
- Signed integers: Except for `Int`, signed integers print like `Int8(1)`.
- Floats: floats are printed in a naive but reversible (TODO: double check) way. `Inf(16|32|)` and `NaN(16|32|)` are printed, and `Float16`/`Float32` print the type (`Float32(1.5)`).  `Float64`s are printed with a trailing `.0` if it is necessary to disambiguate from `Int`.

Fixes #52677, https://github.com/JuliaLang/julia/issues/58484#issuecomment-2902468354, https://github.com/JuliaLang/julia/issues/58484#issuecomment-2898733637, and the specific case mentioned in #58484.  Improves the situation for #38902 but does not close it, because a few cases still do not round-trip (inexhaustive list):
- Non-canonical NaNs
- BFloat16
- User-defined primitive types.  This one is tricky, because they can have a size different from any type we have literals for.
- Without #40652 or something similar, precompile statements will still fail with field names.
