### PR TITLE
doc: Get stdlib dir from make system rather than executable

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -21,9 +21,9 @@ help:
 	@echo "To fix outdated doctests, use 'make <target> doctest=fix'"
 	@echo "To run doctests using Revise (to test changes without rebuilding the sysimage), use 'make <target> doctest=true revise=true'"
 
-
+VERSDIR := v`cut -d. -f1-2 < $(JULIAHOME)/VERSION`
 DOCUMENTER_OPTIONS := linkcheck=$(linkcheck) doctest=$(doctest) buildroot=$(call cygpath_w,$(BUILDROOT)) \
-    texplatform=$(texplatform) revise=$(revise)
+    texplatform=$(texplatform) revise=$(revise) stdlibdir=$(call cygpath_w,$(build_datarootdir)/julia/stdlib/$(VERSDIR)/)
 
 UNICODE_DATA_VERSION=13.0.0
 $(SRCCACHE)/UnicodeData-$(UNICODE_DATA_VERSION).txt:


### PR DESCRIPTION
The `make.jl` docsystem driver was using `Sys.STDLIB` as the canonical list and location of stdlibs. When `make.jl` is invoked as part of the make system (e.g. `make -C doc`), I think it makes more sense to use make's idea of where the stdlibs are. Of course, if you're using a just-built julia to create the docs, these two notions are identical. However, the docsystem build supports (explicitly via the `JULIA_EXECUTABLE` option), being built with an external julia executable. In this case, we should still use the stdlib source from in tree (as we do with the ordinary base sources). A primary motivation is to let AI agents run the doctests before they submit PRs without having to do a whole julia build.