### PR TITLE
Restrict arg of sizehint!(::Dict, n) to Integer

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -190,7 +190,8 @@ end
     return h
 end
 
-function sizehint!(d::Dict{T}, newsz; shrink::Bool=true) where T
+function sizehint!(d::Dict{T}, newsz::Integer; shrink::Bool=true) where T
+    newsz = Int(newsz)::Int
     oldsz = length(d.slots)
     # limit new element count to max_values of the key type
     newsz = min(max(newsz, length(d)), max_values(T)::Int)

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -294,6 +294,14 @@ end
     @test eq(Dict{Int,Int}(), Dict{AbstractString,AbstractString}())
 end
 
+@testset "sizehint!" begin
+    d = Dict()
+    sizehint!(d, UInt(3))
+    @test d == Dict()
+    sizehint!(d, 5)
+    @test isempty(d)
+end
+
 @testset "equality special cases" begin
     @test Dict(1=>0.0) == Dict(1=>-0.0)
     @test !isequal(Dict(1=>0.0), Dict(1=>-0.0))


### PR DESCRIPTION
But also allow other types of integers than Int.

Closes #58531 (for Dict)