### PR TITLE
doc: Fix version reading in Makefile on Windows

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -21,7 +21,7 @@ help:
 	@echo "To fix outdated doctests, use 'make <target> doctest=fix'"
 	@echo "To run doctests using Revise (to test changes without rebuilding the sysimage), use 'make <target> doctest=true revise=true'"
 
-VERSDIR := v`cut -d. -f1-2 < $(JULIAHOME)/VERSION`
+VERSDIR := v$(shell cut -d. -f1-2 < $(JULIAHOME)/VERSION)
 DOCUMENTER_OPTIONS := linkcheck=$(linkcheck) doctest=$(doctest) buildroot=$(call cygpath_w,$(BUILDROOT)) \
     texplatform=$(texplatform) revise=$(revise) stdlibdir=$(call cygpath_w,$(build_datarootdir)/julia/stdlib/$(VERSDIR)/)
 


### PR DESCRIPTION
I copied this expression from the toplevel Makefile, but here we need to read the version eargerly, because otherwise cygpath_w does not work. This had broken the windows build, but I did not notice due to the ongoing CI difficulties.