### PR TITLE
fix breakage with `jl_get_global`

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -1327,9 +1327,8 @@ JL_DLLEXPORT jl_value_t *jl_lower(jl_value_t *expr, jl_module_t *inmodule,
                                   const char *filename, int line, size_t world, bool_t warn)
 {
     jl_value_t *core_lower = NULL;
-    if (jl_core_module) {
-        core_lower = jl_get_global(jl_core_module, jl_symbol("_lower"));
-    }
+    if (jl_core_module)
+        core_lower = jl_get_global_value(jl_core_module, jl_symbol("_lower"));
     if (!core_lower || core_lower == jl_nothing) {
         return jl_fl_lower(expr, inmodule, filename, line, world, warn);
     }

--- a/src/gf.c
+++ b/src/gf.c
@@ -512,12 +512,13 @@ JL_DLLEXPORT jl_code_info_t *jl_gdbcodetyped1(jl_method_instance_t *mi, size_t w
     ct->world_age = jl_typeinf_world;
     jl_value_t **fargs;
     JL_GC_PUSHARGS(fargs, 4);
-    jl_module_t *CC = (jl_module_t*)jl_get_global(jl_core_module, jl_symbol("Compiler"));
+    jl_module_t *CC = (jl_module_t*)jl_get_global_value(jl_core_module, jl_symbol("Compiler"));
     if (CC != NULL && jl_is_module(CC)) {
-        fargs[0] = jl_get_global(CC, jl_symbol("NativeInterpreter"));;
+        JL_GC_PROMISE_ROOTED(CC);
+        fargs[0] = jl_get_global_value(CC, jl_symbol("NativeInterpreter"));;
         fargs[1] = jl_box_ulong(world);
         fargs[1] = jl_apply(fargs, 2);
-        fargs[0] = jl_get_global(CC, jl_symbol("typeinf_code"));
+        fargs[0] = jl_get_global_value(CC, jl_symbol("typeinf_code"));
         fargs[2] = (jl_value_t*)mi;
         fargs[3] = jl_true;
         ci = (jl_code_info_t*)jl_apply(fargs, 4);

--- a/src/init.c
+++ b/src/init.c
@@ -249,7 +249,7 @@ JL_DLLEXPORT void jl_atexit_hook(int exitcode) JL_NOTSAFEPOINT_ENTER
     if (jl_base_module) {
         size_t last_age = ct->world_age;
         ct->world_age = jl_get_world_counter();
-        jl_value_t *f = jl_get_global(jl_base_module, jl_symbol("_atexit"));
+        jl_value_t *f = jl_get_global_value(jl_base_module, jl_symbol("_atexit"));
         if (f != NULL) {
             jl_value_t **fargs;
             JL_GC_PUSHARGS(fargs, 2);
@@ -355,13 +355,14 @@ JL_DLLEXPORT void jl_postoutput_hook(void)
 
     if (jl_base_module) {
         jl_task_t *ct = jl_get_current_task();
-        jl_value_t *f = jl_get_global(jl_base_module, jl_symbol("_postoutput"));
+        size_t last_age = ct->world_age;
+        ct->world_age = jl_get_world_counter();
+        jl_value_t *f = jl_get_global_value(jl_base_module, jl_symbol("_postoutput"));
         if (f != NULL) {
             JL_TRY {
-                size_t last_age = ct->world_age;
-                ct->world_age = jl_get_world_counter();
+                JL_GC_PUSH1(&f);
                 jl_apply(&f, 1);
-                ct->world_age = last_age;
+                JL_GC_POP();
             }
             JL_CATCH {
                 jl_printf((JL_STREAM*)STDERR_FILENO, "\npostoutput hook threw an error: ");
@@ -370,6 +371,7 @@ JL_DLLEXPORT void jl_postoutput_hook(void)
                 jlbacktrace(); // written to STDERR_FILENO
             }
         }
+        ct->world_age = last_age;
     }
     return;
 }
@@ -599,7 +601,6 @@ static NOINLINE void _finish_jl_init_(jl_image_buf_t sysimage, jl_ptls_t ptls, j
         jl_init_primitives();
         jl_init_main_module();
         jl_load(jl_core_module, "boot.jl");
-        jl_current_task->world_age = jl_atomic_load_acquire(&jl_world_counter);
         post_boot_hooks();
     }
 
@@ -612,7 +613,6 @@ static NOINLINE void _finish_jl_init_(jl_image_buf_t sysimage, jl_ptls_t ptls, j
         jl_n_threads_per_pool[JL_THREADPOOL_ID_INTERACTIVE] = 0;
         jl_n_threads_per_pool[JL_THREADPOOL_ID_DEFAULT] = 1;
     } else {
-        jl_current_task->world_age = jl_atomic_load_acquire(&jl_world_counter);
         post_image_load_hooks();
     }
     jl_start_threads();

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -161,14 +161,16 @@ static jl_value_t *do_invoke(jl_value_t **args, size_t nargs, interpreter_state 
     return result;
 }
 
+// get the global (throwing if null) in the current world
 jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e)
 {
-    jl_value_t *v = jl_get_global(m, e);
+    jl_value_t *v = jl_get_global_value(m, e);
     if (v == NULL)
         jl_undefined_var_error(e, (jl_value_t*)m);
     return v;
 }
 
+// get the global (throwing if null) in the current world, optimized
 jl_value_t *jl_eval_globalref(jl_globalref_t *g)
 {
     jl_value_t *v = jl_get_globalref_value(g);

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -160,10 +160,10 @@ static void jl_uv_call_close_callback(jl_value_t *val)
 {
     jl_value_t **args;
     JL_GC_PUSHARGS(args, 2); // val is "rooted" in the finalizer list only right now
-    args[0] = jl_get_global(jl_base_relative_to(((jl_datatype_t*)jl_typeof(val))->name->module),
+    args[0] = jl_eval_global_var(
+            jl_base_relative_to(((jl_datatype_t*)jl_typeof(val))->name->module),
             jl_symbol("_uv_hook_close")); // topmod(typeof(val))._uv_hook_close
     args[1] = val;
-    assert(args[0]);
     jl_apply(args, 2); // TODO: wrap in try-catch?
     JL_GC_POP();
 }

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -955,12 +955,14 @@ static NOINLINE int true_main(int argc, char *argv[])
     ct->world_age = jl_get_world_counter();
 
     jl_function_t *start_client = jl_base_module ?
-        (jl_function_t*)jl_get_global(jl_base_module, jl_symbol("_start")) : NULL;
+        (jl_function_t*)jl_get_global_value(jl_base_module, jl_symbol("_start")) : NULL;
 
     if (start_client) {
         int ret = 1;
         JL_TRY {
+            JL_GC_PUSH1(&start_client);
             jl_value_t *r = jl_apply(&start_client, 1);
+            JL_GC_POP();
             if (jl_typeof(r) != (jl_value_t*)jl_int32_type)
                 jl_type_error("typeassert", (jl_value_t*)jl_int32_type, r);
             ret = jl_unbox_int32(r);

--- a/src/julia.h
+++ b/src/julia.h
@@ -2096,6 +2096,7 @@ JL_DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var);
 JL_DLLEXPORT int jl_globalref_is_const(jl_globalref_t *gr);
 JL_DLLEXPORT jl_value_t *jl_get_globalref_value(jl_globalref_t *gr);
 JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var);
+JL_DLLEXPORT jl_value_t *jl_get_global_value(jl_module_t *m, jl_sym_t *var);
 JL_DLLEXPORT void jl_set_global(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT);
 JL_DLLEXPORT void jl_set_const(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT);
 void jl_set_initial_const(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT, int exported);
@@ -2689,12 +2690,7 @@ JL_DLLEXPORT jl_task_t *jl_get_current_task(void) JL_GLOBALLY_ROOTED JL_NOTSAFEP
 
 STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)
 {
-    jl_task_t *ct = jl_get_current_task();
-    size_t last_world = ct->world_age;
-    ct->world_age = jl_get_world_counter();
-    jl_value_t *r = jl_get_global(m, jl_symbol(name));
-    ct->world_age = last_world;
-    return (jl_function_t*)r;
+    return (jl_function_t*)jl_get_global(m, jl_symbol(name));
 }
 
 // TODO: we need to pin the task while using this (set pure bit)

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -36,27 +36,30 @@ void write_srctext(ios_t *f, jl_array_t *udeps, int64_t srctextpos) {
         //   char*: src text
         // At the end we write int32(0) as a terminal sentinel.
         size_t len = jl_array_nrows(udeps);
-        static jl_value_t *replace_depot_func = NULL;
-        if (!replace_depot_func)
-            replace_depot_func = jl_get_global(jl_base_module, jl_symbol("replace_depot_path"));
-        static jl_value_t *normalize_depots_func = NULL;
-        if (!normalize_depots_func)
-            normalize_depots_func = jl_get_global(jl_base_module, jl_symbol("normalize_depots_for_relocation"));
         ios_t srctext;
-        jl_value_t *deptuple = NULL, *depots = NULL;
-        JL_GC_PUSH3(&deptuple, &udeps, &depots);
+        jl_value_t *replace_depot_func = NULL;
+        jl_value_t *normalize_depots_func = NULL;
+        jl_value_t *deptuple = NULL;
+        jl_value_t *depots = NULL;
         jl_task_t *ct = jl_current_task;
         size_t last_age = ct->world_age;
         ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
+        JL_GC_PUSH4(&deptuple, &depots, &replace_depot_func, &normalize_depots_func);
+        replace_depot_func = jl_eval_global_var(jl_base_module, jl_symbol("replace_depot_path"));
+        normalize_depots_func = jl_eval_global_var(jl_base_module, jl_symbol("normalize_depots_for_relocation"));
         depots = jl_apply(&normalize_depots_func, 1);
-        ct->world_age = last_age;
+        jl_datatype_t *deptuple_p[5] = {jl_module_type, jl_string_type, jl_uint64_type, jl_uint32_type, jl_float64_type};
+        jl_value_t *jl_deptuple_type = jl_apply_tuple_type_v((jl_value_t**)deptuple_p, 5);
+        JL_GC_PROMISE_ROOTED(jl_deptuple_type);
+#define jl_is_deptuple(v) (jl_typeis((v), jl_deptuple_type))
         for (size_t i = 0; i < len; i++) {
             deptuple = jl_array_ptr_ref(udeps, i);
-            jl_value_t *depmod = jl_fieldref(deptuple, 0);  // module
+            jl_value_t *depmod = jl_fieldref_noalloc(deptuple, 0);  // module
             // Dependencies declared with `include_dependency` are excluded
             // because these may not be Julia code (and could be huge)
+            JL_TYPECHK(write_srctext, deptuple, deptuple);
             if (depmod != (jl_value_t*)jl_main_module) {
-                jl_value_t *abspath = jl_fieldref(deptuple, 1);  // file abspath
+                jl_value_t *abspath = jl_fieldref_noalloc(deptuple, 1);  // file abspath
                 const char *abspathstr = jl_string_data(abspath);
                 if (!abspathstr[0])
                     continue;
@@ -67,17 +70,11 @@ void write_srctext(ios_t *f, jl_array_t *udeps, int64_t srctextpos) {
                     continue;
                 }
 
-                jl_value_t **replace_depot_args;
-                JL_GC_PUSHARGS(replace_depot_args, 3);
+                jl_value_t *replace_depot_args[3];
                 replace_depot_args[0] = replace_depot_func;
                 replace_depot_args[1] = abspath;
                 replace_depot_args[2] = depots;
-                jl_task_t *ct = jl_current_task;
-                size_t last_age = ct->world_age;
-                ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
                 jl_value_t *depalias = (jl_value_t*)jl_apply(replace_depot_args, 3);
-                ct->world_age = last_age;
-                JL_GC_POP();
 
                 size_t slen = jl_string_len(depalias);
                 write_int32(f, slen);
@@ -91,6 +88,8 @@ void write_srctext(ios_t *f, jl_array_t *udeps, int64_t srctextpos) {
                 ios_seek_end(f);
             }
         }
+        ct->world_age = last_age;
+#undef jl_is_deptuple
         JL_GC_POP();
     }
     write_int32(f, 0); // mark the end of the source text

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1509,15 +1509,17 @@ JL_DLLEXPORT void jl_test_failure_breakpoint(jl_value_t *v)
 
 // logging tools --------------------------------------------------------------
 
+// DO NOT USE THIS FUNCTION FOR NEW CODE
+// The internal should not be doing anything that requires logging, which means most functions would trigger UB if calling this
 void jl_log(int level, jl_value_t *module, jl_value_t *group, jl_value_t *id,
             jl_value_t *file, jl_value_t *line, jl_value_t *kwargs,
             jl_value_t *msg)
 {
-    static jl_value_t *logmsg_func = NULL;
-    if (!logmsg_func && jl_base_module) {
-        jl_value_t *corelogging = jl_get_global(jl_base_module, jl_symbol("CoreLogging"));
+    jl_value_t *logmsg_func = NULL;
+    if (jl_base_module) {
+        jl_value_t *corelogging = jl_get_global_value(jl_base_module, jl_symbol("CoreLogging"));
         if (corelogging && jl_is_module(corelogging)) {
-            logmsg_func = jl_get_global((jl_module_t*)corelogging, jl_symbol("logmsg_shim"));
+            logmsg_func = jl_get_global_value((jl_module_t*)corelogging, jl_symbol("logmsg_shim"));
         }
     }
     if (!logmsg_func) {

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -329,12 +329,15 @@ void jl_task_wait_empty(void)
     jl_task_t *ct = jl_current_task;
     if (jl_atomic_load_relaxed(&ct->tid) == 0 && jl_base_module) {
         jl_wait_empty_begin();
-        jl_value_t *f = jl_get_global(jl_base_module, jl_symbol("wait"));
-        wait_empty = ct;
         size_t lastage = ct->world_age;
         ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
-        if (f)
+        jl_value_t *f = jl_get_global_value(jl_base_module, jl_symbol("wait"));
+        wait_empty = ct;
+        if (f) {
+            JL_GC_PUSH1(&f);
             jl_apply_generic(f, NULL, 0);
+            JL_GC_POP();
+        }
         // we are back from jl_task_get_next now
         ct->world_age = lastage;
         wait_empty = NULL;

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -532,35 +532,40 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
 {
     int64_t initial_pos = 0;
     int64_t pos = 0;
-    static jl_array_t *deps = NULL;
-    if (!deps)
-        deps = (jl_array_t*)jl_get_global(jl_base_module, jl_symbol("_require_dependencies"));
-
-    // unique(deps) to eliminate duplicates while preserving order:
-    // we preserve order so that the topmost included .jl file comes first
-    static jl_value_t *unique_func = NULL;
-    if (!unique_func)
-        unique_func = jl_get_global(jl_base_module, jl_symbol("unique"));
-    jl_value_t *uniqargs[2] = {unique_func, (jl_value_t*)deps};
     jl_task_t *ct = jl_current_task;
     size_t last_age = ct->world_age;
     ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
-    jl_array_t *udeps = (*udepsp = deps && unique_func ? (jl_array_t*)jl_apply(uniqargs, 2) : NULL);
-    ct->world_age = last_age;
-
-    static jl_value_t *replace_depot_func = NULL;
-    if (!replace_depot_func)
-        replace_depot_func = jl_get_global(jl_base_module, jl_symbol("replace_depot_path"));
-    static jl_value_t *normalize_depots_func = NULL;
-    if (!normalize_depots_func)
-        normalize_depots_func = jl_get_global(jl_base_module, jl_symbol("normalize_depots_for_relocation"));
-
     jl_value_t *depots = NULL, *prefs_hash = NULL, *prefs_list = NULL;
-    JL_GC_PUSH2(&depots, &prefs_list);
-    last_age = ct->world_age;
-    ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
+    jl_value_t *unique_func = NULL;
+    jl_value_t *replace_depot_func = NULL;
+    jl_value_t *normalize_depots_func = NULL;
+    jl_value_t *toplevel = NULL;
+    jl_value_t *prefs_hash_func = NULL;
+    jl_value_t *get_compiletime_prefs_func = NULL;
+    JL_GC_PUSH8(&depots, &prefs_list, &unique_func, &replace_depot_func, &normalize_depots_func, &toplevel, &prefs_hash_func, &get_compiletime_prefs_func);
+
+    jl_array_t *udeps = (jl_array_t*)jl_get_global_value(jl_base_module, jl_symbol("_require_dependencies"));
+    *udepsp = udeps;
+
+    // unique(udeps) to eliminate duplicates while preserving order:
+    // we preserve order so that the topmost included .jl file comes first
+    if (udeps) {
+        unique_func = jl_eval_global_var(jl_base_module, jl_symbol("unique"));
+        jl_value_t *uniqargs[2] = {unique_func, (jl_value_t*)udeps};
+        udeps = (jl_array_t*)jl_apply(uniqargs, 2);
+        *udepsp = udeps;
+        JL_TYPECHK(write_dependency_list, array_any, (jl_value_t*)udeps);
+    }
+
+    replace_depot_func = jl_get_global_value(jl_base_module, jl_symbol("replace_depot_path"));
+    normalize_depots_func = jl_eval_global_var(jl_base_module, jl_symbol("normalize_depots_for_relocation"));
+
     depots = jl_apply(&normalize_depots_func, 1);
-    ct->world_age = last_age;
+
+    jl_datatype_t *deptuple_p[5] = {jl_module_type, jl_string_type, jl_uint64_type, jl_uint32_type, jl_float64_type};
+    jl_value_t *jl_deptuple_type = jl_apply_tuple_type_v((jl_value_t**)deptuple_p, 5);
+    JL_GC_PROMISE_ROOTED(jl_deptuple_type);
+#define jl_is_deptuple(v) (jl_typeis((v), jl_deptuple_type))
 
     // write a placeholder for total size so that we can quickly seek past all of the
     // dependencies if we don't need them
@@ -569,20 +574,16 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
     size_t i, l = udeps ? jl_array_nrows(udeps) : 0;
     for (i = 0; i < l; i++) {
         jl_value_t *deptuple = jl_array_ptr_ref(udeps, i);
-        jl_value_t *deppath = jl_fieldref(deptuple, 1);
+        JL_TYPECHK(write_dependency_list, deptuple, deptuple);
+        jl_value_t *deppath = jl_fieldref_noalloc(deptuple, 1);
 
         if (replace_depot_func) {
-            jl_value_t **replace_depot_args;
-            JL_GC_PUSHARGS(replace_depot_args, 3);
+            jl_value_t *replace_depot_args[3];
             replace_depot_args[0] = replace_depot_func;
             replace_depot_args[1] = deppath;
             replace_depot_args[2] = depots;
-            ct = jl_current_task;
-            size_t last_age = ct->world_age;
-            ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
             deppath = (jl_value_t*)jl_apply(replace_depot_args, 3);
-            ct->world_age = last_age;
-            JL_GC_POP();
+            JL_TYPECHK(write_dependency_list, string, deppath);
         }
 
         size_t slen = jl_string_len(deppath);
@@ -591,7 +592,7 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
         write_uint64(s, jl_unbox_uint64(jl_fieldref(deptuple, 2)));    // fsize
         write_uint32(s, jl_unbox_uint32(jl_fieldref(deptuple, 3)));    // hash
         write_float64(s, jl_unbox_float64(jl_fieldref(deptuple, 4)));  // mtime
-        jl_module_t *depmod = (jl_module_t*)jl_fieldref(deptuple, 0);  // evaluating module
+        jl_module_t *depmod = (jl_module_t*)jl_fieldref_noalloc(deptuple, 0);  // evaluating module
         jl_module_t *depmod_top = depmod;
         while (!is_serialization_root_module(depmod_top))
             depmod_top = depmod_top->parent;
@@ -615,34 +616,31 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
     // Calculate Preferences hash for current package.
     if (jl_base_module) {
         // Toplevel module is the module we're currently compiling, use it to get our preferences hash
-        jl_value_t * toplevel = (jl_value_t*)jl_get_global(jl_base_module, jl_symbol("__toplevel__"));
-        jl_value_t * prefs_hash_func = jl_get_global(jl_base_module, jl_symbol("get_preferences_hash"));
-        jl_value_t * get_compiletime_prefs_func = jl_get_global(jl_base_module, jl_symbol("get_compiletime_preferences"));
+        toplevel = jl_get_global_value(jl_base_module, jl_symbol("__toplevel__"));
+        prefs_hash_func = jl_eval_global_var(jl_base_module, jl_symbol("get_preferences_hash"));
+        get_compiletime_prefs_func = jl_eval_global_var(jl_base_module, jl_symbol("get_compiletime_preferences"));
 
-        if (toplevel && prefs_hash_func && get_compiletime_prefs_func) {
-            // Temporary invoke in newest world age
-            size_t last_age = ct->world_age;
-            ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
-
+        if (toplevel) {
             // call get_compiletime_prefs(__toplevel__)
             jl_value_t *args[3] = {get_compiletime_prefs_func, (jl_value_t*)toplevel, NULL};
             prefs_list = (jl_value_t*)jl_apply(args, 2);
+            JL_TYPECHK(write_dependency_list, array, prefs_list);
 
             // Call get_preferences_hash(__toplevel__, prefs_list)
             args[0] = prefs_hash_func;
             args[2] = prefs_list;
             prefs_hash = (jl_value_t*)jl_apply(args, 3);
-
-            // Reset world age to normal
-            ct->world_age = last_age;
+            JL_TYPECHK(write_dependency_list, uint64, prefs_hash);
         }
     }
+    ct->world_age = last_age;
 
     // If we successfully got the preferences, write it out, otherwise write `0` for this `.ji` file.
     if (prefs_hash != NULL && prefs_list != NULL) {
         size_t i, l = jl_array_nrows(prefs_list);
         for (i = 0; i < l; i++) {
             jl_value_t *pref_name = jl_array_ptr_ref(prefs_list, i);
+            JL_TYPECHK(write_dependency_list, string, pref_name);
             size_t slen = jl_string_len(pref_name);
             write_int32(s, slen);
             ios_write(s, jl_string_data(pref_name), slen);
@@ -660,6 +658,7 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
         write_uint64(s, 0);
     }
     JL_GC_POP(); // for depots, prefs_list
+#undef jl_is_deptuple
 
     // write a dummy file position to indicate the beginning of the source-text
     pos = ios_pos(s);

--- a/src/task.c
+++ b/src/task.c
@@ -335,7 +335,7 @@ void JL_NORETURN jl_finish_task(jl_task_t *ct)
     // let the runtime know this task is dead and find a new task to run
     jl_function_t *done = jl_atomic_load_relaxed(&task_done_hook_func);
     if (done == NULL) {
-        done = (jl_function_t*)jl_get_global(jl_base_module, jl_symbol("task_done_hook"));
+        done = (jl_function_t*)jl_get_global_value(jl_base_module, jl_symbol("task_done_hook"));
         if (done != NULL)
             jl_atomic_store_release(&task_done_hook_func, done);
     }

--- a/src/threading.c
+++ b/src/threading.c
@@ -409,9 +409,11 @@ static _Atomic(jl_function_t*) init_task_lock_func JL_GLOBALLY_ROOTED = NULL;
 
 static void jl_init_task_lock(jl_task_t *ct)
 {
+    size_t last_age = ct->world_age;
+    ct->world_age = jl_get_world_counter();
     jl_function_t *done = jl_atomic_load_relaxed(&init_task_lock_func);
     if (done == NULL) {
-        done = (jl_function_t*)jl_get_global(jl_base_module, jl_symbol("init_task_lock"));
+        done = (jl_function_t*)jl_get_global_value(jl_base_module, jl_symbol("init_task_lock"));
         if (done != NULL)
             jl_atomic_store_release(&init_task_lock_func, done);
     }
@@ -424,6 +426,7 @@ static void jl_init_task_lock(jl_task_t *ct)
             jl_no_exc_handler(jl_current_exception(ct), ct);
         }
     }
+    ct->world_age = last_age;
 }
 
 JL_DLLEXPORT jl_gcframe_t **jl_adopt_thread(void)
@@ -446,7 +449,6 @@ JL_DLLEXPORT jl_gcframe_t **jl_adopt_thread(void)
     JL_GC_PROMISE_ROOTED(ct);
     uv_random(NULL, NULL, &ct->rngState, sizeof(ct->rngState), 0, NULL);
     jl_atomic_fetch_add(&jl_gc_disable_counter, -1);
-    ct->world_age = jl_get_world_counter(); // root_task sets world_age to 1
     jl_init_task_lock(ct);
     return &ct->gcstack;
 }

--- a/sysimage.mk
+++ b/sysimage.mk
@@ -71,7 +71,7 @@ RELDATADIR := $(call rel_path,$(JULIAHOME)/base,$(build_datarootdir))/ # <-- mak
 $(build_private_libdir)/basecompiler.ji: $(COMPILER_SRCS)
 	@$(call PRINT_JULIA, cd $(JULIAHOME)/base && \
 	JULIA_NUM_THREADS=1 $(call spawn,$(JULIA_EXECUTABLE)) $(HEAPLIM) --output-ji $(call cygpath_w,$@).tmp \
-		--startup-file=no --warn-overwrite=yes -g$(BOOTSTRAP_DEBUG_LEVEL) -O1 Base_compiler.jl --buildroot $(RELBUILDROOT) --dataroot $(RELDATADIR))
+		--startup-file=no --warn-overwrite=yes --depwarn=error -g$(BOOTSTRAP_DEBUG_LEVEL) -O1 Base_compiler.jl --buildroot $(RELBUILDROOT) --dataroot $(RELDATADIR))
 	@mv $@.tmp $@
 
 define base_builder
@@ -80,7 +80,7 @@ $$(build_private_libdir)/basecompiler$1-o.a $$(build_private_libdir)/basecompile
 	WINEPATH="$$(call cygpath_w,$$(build_bindir));$$$$WINEPATH" \
 	JULIA_NUM_THREADS=1 \
 		$$(call spawn, $3) $2 -C "$$(JULIA_CPU_TARGET)" $$(HEAPLIM) --output-$$* $$(call cygpath_w,$$@).tmp \
-		--startup-file=no --warn-overwrite=yes -g$$(BOOTSTRAP_DEBUG_LEVEL) Base_compiler.jl --buildroot $$(RELBUILDROOT) --dataroot $$(RELDATADIR))
+		--startup-file=no --warn-overwrite=yes --depwarn=error -g$$(BOOTSTRAP_DEBUG_LEVEL) Base_compiler.jl --buildroot $$(RELBUILDROOT) --dataroot $$(RELDATADIR))
 	@mv $$@.tmp $$@
 $$(build_private_libdir)/sysbase$1.ji: $$(build_private_libdir)/basecompiler$1.$$(SHLIB_EXT) $$(JULIAHOME)/VERSION $$(BASE_SRCS) $$(STDLIB_SRCS)
 	@$$(call PRINT_JULIA, cd $$(JULIAHOME)/base && \
@@ -88,7 +88,7 @@ $$(build_private_libdir)/sysbase$1.ji: $$(build_private_libdir)/basecompiler$1.$
 	     WINEPATH="$$(call cygpath_w,$$(build_bindir));$$$$WINEPATH" \
 		 JULIA_NUM_THREADS=1 \
 			$$(call spawn, $$(JULIA_EXECUTABLE)) -g1 $2 -C "$$(JULIA_CPU_TARGET)" $$(HEAPLIM) --output-ji $$(call cygpath_w,$$@).tmp $$(JULIA_SYSIMG_BUILD_FLAGS) \
-			--startup-file=no --warn-overwrite=yes --sysimage $$(call cygpath_w,$$<) sysimg.jl --buildroot $$(RELBUILDROOT) --dataroot $$(RELDATADIR); then \
+			--startup-file=no --warn-overwrite=yes --depwarn=error --sysimage $$(call cygpath_w,$$<) sysimg.jl --buildroot $$(RELBUILDROOT) --dataroot $$(RELDATADIR); then \
 		echo '*** This error might be fixed by running `make clean`. If the error persists$$(COMMA) try `make cleanall`. ***'; \
 		false; \
 	fi )
@@ -103,7 +103,7 @@ $$(build_private_libdir)/sysbase$1-o.a $$(build_private_libdir)/sysbase$1-bc.a :
 	     WINEPATH="$$(call cygpath_w,$$(build_bindir));$$$$WINEPATH" \
 		 JULIA_NUM_THREADS=1 \
 			$$(call spawn, $$(JULIA_EXECUTABLE)) -g1 $2 -C "$$(JULIA_CPU_TARGET)" $$(HEAPLIM) --output-$$* $$(call cygpath_w,$$@).tmp $$(JULIA_SYSIMG_BUILD_FLAGS) \
-			--startup-file=no --warn-overwrite=yes --sysimage $$(call cygpath_w,$$<) sysimg.jl --buildroot $$(RELBUILDROOT) --dataroot $$(RELDATADIR); then \
+			--startup-file=no --warn-overwrite=yes --depwarn=error --sysimage $$(call cygpath_w,$$<) sysimg.jl --buildroot $$(RELBUILDROOT) --dataroot $$(RELDATADIR); then \
 		echo '*** This error might be fixed by running `make clean`. If the error persists$$(COMMA) try `make cleanall`. ***'; \
 		false; \
 	fi )
@@ -117,7 +117,7 @@ $$(build_private_libdir)/sys$1-o.a $$(build_private_libdir)/sys$1-bc.a : $$(buil
 		 JULIA_DEPOT_PATH=':' \
 		 JULIA_NUM_THREADS=1 \
 			$$(call spawn, $3) $2 -C "$$(JULIA_CPU_TARGET)" $$(HEAPLIM) --output-$$* $$(call cygpath_w,$$@).tmp $$(JULIA_SYSIMG_BUILD_FLAGS) \
-			--startup-file=no --warn-overwrite=yes --sysimage $$(call cygpath_w,$$<) $$(call cygpath_w,$$(JULIAHOME)/contrib/generate_precompile.jl) $(JULIA_PRECOMPILE); then \
+			--startup-file=no --warn-overwrite=yes --depwarn=error --sysimage $$(call cygpath_w,$$<) $$(call cygpath_w,$$(JULIAHOME)/contrib/generate_precompile.jl) $(JULIA_PRECOMPILE); then \
 		echo '*** This error is usually fixed by running `make clean`. If the error persists$$(COMMA) try `make cleanall`. ***'; \
 		false; \
 	fi )


### PR DESCRIPTION
Introduce a new `jl_get_global_value` to do the new world-aware behavior, while preserving the old behavior for `jl_get_global`. Choose between `jl_get_global`, `jl_get_global_value`, and `jl_eval_global_var`, depending on what behavior is required. Also take this opportunity to fix some data race mistakes introduced by bindings (relaxed loads of jl_world_counter outside of assert) and lacking type asserts / unnecessary globals in precompile code.

Fix #58097
Addresses post-review comment https://github.com/JuliaLang/julia/pull/57213#discussion_r1939814835, so this is already tested against by existing logic