### PR TITLE
fix Module for Base.jl for Revise.jl

### DIFF
--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -389,5 +389,9 @@ Core._setlowerer!(fl_lower)
 
 # Further definition of Base will happen in Base.jl if loaded.
 
+# Ensure this file is also tracked
+@assert !isassigned(_included_files, 1)
+_included_files[1] = (@__MODULE__, ccall(:jl_prepend_cwd, Any, (Any,), "Base_compiler.jl"))
+
 end # module Base
 using .Base

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-Base.Core.include(Base, "Base.jl") # finish populating Base (currently just has the Compiler)
+Base.include("Base.jl") # finish populating Base (currently just has the Compiler)
 
 # Set up Main module by importing from Base
 using .Base


### PR DESCRIPTION
Just happened to notice in passing that `_included_files[1]` did not get fixed when Base_compiler.jl was split from Base.jl so it causes warnings sometimes in Revise.jl CI