### PR TITLE
Fix and test stdlib JLL deps on Windows

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -796,6 +796,17 @@ function platform_dlext(p::AbstractPlatform = HostPlatform())
     end
 end
 
+# Not general purpose, just for parse_dl_name_version
+function _this_os_name()
+    if Sys.iswindows()
+        return "windows"
+    elseif Sys.isapple()
+        return "macos"
+    else
+        return "other"
+    end
+end
+
 """
     parse_dl_name_version(path::String, platform::AbstractPlatform)
 
@@ -806,9 +817,10 @@ valid dynamic library, this method throws an error.  If no soversion
 can be extracted from the filename, as in "libbar.so" this method
 returns `"libbar", nothing`.
 """
-function parse_dl_name_version(path::String, os::String)
+function parse_dl_name_version(path::String, os::String=_this_os_name())
     # Use an extraction regex that matches the given OS
     local dlregex
+    # Keep this up to date with _this_os_name
     if os == "windows"
         # On Windows, libraries look like `libnettle-6.dll`
         dlregex = r"^(.*?)(?:-((?:[\.\d]+)*))?\.dll$"sa
@@ -837,7 +849,7 @@ function parse_dl_name_version(path::String, os::String)
 end
 
 # Adapter for `AbstractString`
-function parse_dl_name_version(path::AbstractString, os::AbstractString)
+function parse_dl_name_version(path::AbstractString, os::AbstractString=_this_os_name())
     return parse_dl_name_version(string(path)::String, string(os)::String)
 end
 

--- a/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
+++ b/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
@@ -76,7 +76,12 @@ const libgfortran = LazyLibrary(_libgfortran_path, dependencies=_libgfortran_dep
 _libstdcxx_dependencies = LazyLibrary[libgcc_s]
 const libstdcxx = LazyLibrary(_libstdcxx_path, dependencies=_libstdcxx_dependencies)
 
-const libgomp = LazyLibrary(_libgomp_path)
+if Sys.iswindows()
+    _libgomp_dependencies = LazyLibrary[libgcc_s]
+else
+    _libgomp_dependencies = LazyLibrary[]
+end
+const libgomp = LazyLibrary(_libgomp_path, dependencies=_libgomp_dependencies)
 
 # Some installations (such as those from-source) may not have `libssp`
 # So let's do a compile-time check to see if we've got it.

--- a/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
+++ b/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
@@ -13,80 +13,123 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
+
+libatomic_path::String = ""
+const libatomic = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libatomic-1.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libatomic.1.dylib")
+    elseif Sys.isfreebsd()
+        BundledLazyLibraryPath("libatomic.so.3")
+    elseif Sys.islinux()
+        BundledLazyLibraryPath("libatomic.so.1")
+    else
+        error("CompilerSupportLibraries_jll: Library 'libatomic' is not available for $(Sys.KERNEL)")
+    end
+)
+
+if Sys.iswindows() || Sys.isapple() || arch(HostPlatform()) ∈ ("x86_64", "i686")
+    global libquadmath_path::String = ""
+    const libquadmath = LazyLibrary(
+        if Sys.iswindows()
+            BundledLazyLibraryPath("libquadmath-0.dll")
+        elseif Sys.isapple()
+            BundledLazyLibraryPath("libquadmath.0.dylib")
+        elseif (Sys.islinux() || Sys.isfreebsd()) && arch(HostPlatform()) ∈ ("x86_64", "i686")
+            BundledLazyLibraryPath("libquadmath.so.0")
+        else
+            error("CompilerSupportLibraries_jll: Library 'libquadmath' is not available for $(Sys.KERNEL)")
+        end
+    )
+end
+
 libgcc_s_path::String = ""
+const libgcc_s = LazyLibrary(
+    if Sys.iswindows()
+        if arch(HostPlatform()) == "x86_64"
+            BundledLazyLibraryPath("libgcc_s_seh-1.dll")
+        else
+            BundledLazyLibraryPath("libgcc_s_sjlj-1.dll")
+        end
+    elseif Sys.isapple()
+        if arch(HostPlatform()) == "aarch64" || libgfortran_version(HostPlatform()) == v"5"
+            BundledLazyLibraryPath("libgcc_s.1.1.dylib")
+        else
+            BundledLazyLibraryPath("libgcc_s.1.dylib")
+        end
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libgcc_s.so.1")
+    else
+        error("CompilerSupportLibraries_jll: Library 'libgcc_s' is not available for $(Sys.KERNEL)")
+    end
+)
+
 libgfortran_path::String = ""
+const libgfortran = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath(string("libgfortran-", libgfortran_version(HostPlatform()).major, ".dll"))
+    elseif Sys.isapple()
+        BundledLazyLibraryPath(string("libgfortran.", libgfortran_version(HostPlatform()).major, ".dylib"))
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath(string("libgfortran.so.", libgfortran_version(HostPlatform()).major))
+    else
+        error("CompilerSupportLibraries_jll: Library 'libgfortran' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = @static if @isdefined(libquadmath)
+        LazyLibrary[libgcc_s, libquadmath]
+    else
+        LazyLibrary[libgcc_s]
+    end
+)
+
 libstdcxx_path::String = ""
+const libstdcxx = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libstdc++-6.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libstdc++.6.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libstdc++.so.6")
+    else
+        error("CompilerSupportLibraries_jll: Library 'libstdcxx' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = LazyLibrary[libgcc_s]
+)
+
 libgomp_path::String = ""
-
-if Sys.iswindows()
-    const _libatomic_path = BundledLazyLibraryPath("libatomic-1.dll")
-    const _libquadmath_path = BundledLazyLibraryPath("libquadmath-0.dll")
-    if arch(HostPlatform()) == "x86_64"
-        const _libgcc_s_path = BundledLazyLibraryPath("libgcc_s_seh-1.dll")
+const libgomp = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libgomp-1.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libgomp.1.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libgomp.so.1")
     else
-        const _libgcc_s_path = BundledLazyLibraryPath("libgcc_s_sjlj-1.dll")
-    end
-    const _libgfortran_path = BundledLazyLibraryPath(string("libgfortran-", libgfortran_version(HostPlatform()).major, ".dll"))
-    const _libstdcxx_path = BundledLazyLibraryPath("libstdc++-6.dll")
-    const _libgomp_path = BundledLazyLibraryPath("libgomp-1.dll")
-    const _libssp_path = BundledLazyLibraryPath("libssp-0.dll")
-elseif Sys.isapple()
-    const _libatomic_path = BundledLazyLibraryPath("libatomic.1.dylib")
-    const _libquadmath_path = BundledLazyLibraryPath("libquadmath.0.dylib")
-    if arch(HostPlatform()) == "aarch64" || libgfortran_version(HostPlatform()) == v"5"
-        const _libgcc_s_path = BundledLazyLibraryPath("libgcc_s.1.1.dylib")
+        error("CompilerSupportLibraries_jll: Library 'libgomp' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = if Sys.iswindows()
+        LazyLibrary[libgcc_s]
     else
-        const _libgcc_s_path = BundledLazyLibraryPath("libgcc_s.1.dylib")
+        LazyLibrary[]
     end
-    const _libgfortran_path = BundledLazyLibraryPath(string("libgfortran.", libgfortran_version(HostPlatform()).major, ".dylib"))
-    const _libstdcxx_path = BundledLazyLibraryPath("libstdc++.6.dylib")
-    const _libgomp_path = BundledLazyLibraryPath("libgomp.1.dylib")
-    const _libssp_path = BundledLazyLibraryPath("libssp.0.dylib")
-else
-    if Sys.isfreebsd()
-        const _libatomic_path = BundledLazyLibraryPath("libatomic.so.3")
-    else
-        const _libatomic_path = BundledLazyLibraryPath("libatomic.so.1")
+)
+
+# only define if isfile
+let
+    if Sys.iswindows() || Sys.isapple() || libc(HostPlatform()) != "musl"
+        _libssp_path = if Sys.iswindows()
+            BundledLazyLibraryPath("libssp-0.dll")
+        elseif Sys.isapple()
+            BundledLazyLibraryPath("libssp.0.dylib")
+        elseif Sys.islinux() && libc(HostPlatform()) != "musl"
+            BundledLazyLibraryPath("libssp.so.0")
+        end
+        if isfile(string(_libssp_path))
+            global libssp_path::String = ""
+            @eval const libssp = LazyLibrary($(_libssp_path))
+        end
     end
-    const _libgcc_s_path = BundledLazyLibraryPath("libgcc_s.so.1")
-    const _libgfortran_path = BundledLazyLibraryPath(string("libgfortran.so.", libgfortran_version(HostPlatform()).major))
-    const _libstdcxx_path = BundledLazyLibraryPath("libstdc++.so.6")
-    const _libgomp_path = BundledLazyLibraryPath("libgomp.so.1")
-    if libc(HostPlatform()) != "musl"
-        const _libssp_path = BundledLazyLibraryPath("libssp.so.0")
-    end
-    if arch(HostPlatform()) ∈ ("x86_64", "i686")
-        const _libquadmath_path = BundledLazyLibraryPath("libquadmath.so.0")
-    end
-end
-
-if @isdefined(_libatomic_path)
-    const libatomic = LazyLibrary(_libatomic_path)
-end
-const libgcc_s = LazyLibrary(_libgcc_s_path)
-
-_libgfortran_deps = [libgcc_s]
-if @isdefined _libquadmath_path
-    const libquadmath = LazyLibrary(_libquadmath_path)
-    push!(_libgfortran_deps, libquadmath)
-end
-
-const libgfortran = LazyLibrary(_libgfortran_path, dependencies=_libgfortran_deps)
-
-_libstdcxx_dependencies = LazyLibrary[libgcc_s]
-const libstdcxx = LazyLibrary(_libstdcxx_path, dependencies=_libstdcxx_dependencies)
-
-if Sys.iswindows()
-    _libgomp_dependencies = LazyLibrary[libgcc_s]
-else
-    _libgomp_dependencies = LazyLibrary[]
-end
-const libgomp = LazyLibrary(_libgomp_path, dependencies=_libgomp_dependencies)
-
-# Some installations (such as those from-source) may not have `libssp`
-# So let's do a compile-time check to see if we've got it.
-if @isdefined(_libssp_path) && isfile(string(_libssp_path))
-    const libssp = LazyLibrary(_libssp_path)
 end
 
 # Conform to LazyJLLWrappers API
@@ -108,19 +151,17 @@ end
 is_available() = true
 
 function __init__()
-    if @isdefined _libatomic_path
-        global libatomic_path = string(_libatomic_path)
+    global libatomic_path = string(libatomic.path)
+    global libgcc_s_path = string(libgcc_s.path)
+    global libgomp_path = string(libgomp.path)
+    if @isdefined libquadmath_path
+        global libquadmath_path = string(libquadmath.path)
     end
-    global libgcc_s_path = string(_libgcc_s_path)
-    global libgomp_path = string(_libgomp_path)
-    if @isdefined _libquadmath_path
-        global libquadmath_path = string(_libquadmath_path)
+    if @isdefined libssp_path
+        global libssp_path = string(libssp.path)
     end
-    if @isdefined _libssp_path
-        global libssp_path = string(_libssp_path)
-    end
-    global libgfortran_path = string(_libgfortran_path)
-    global libstdcxx_path = string(_libstdcxx_path)
+    global libgfortran_path = string(libgfortran.path)
+    global libstdcxx_path = string(libstdcxx.path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libgcc_s_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/LLVMLibUnwind_jll/src/LLVMLibUnwind_jll.jl
+++ b/stdlib/LLVMLibUnwind_jll/src/LLVMLibUnwind_jll.jl
@@ -13,17 +13,17 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
-llvmlibunwind_path::String = ""
 
-const _llvmlibunwind_path = BundledLazyLibraryPath("libunwind")
-const llvmlibunwind = LazyLibrary(_llvmlibunwind_path)
+llvmlibunwind_path::String = ""
+const llvmlibunwind = LazyLibrary(BundledLazyLibraryPath("libunwind"))
+
 function eager_mode()
     dlopen(llvmlibunwind)
 end
 is_available() = @static Sys.isapple() ? true : false
 
 function __init__()
-    global llvmlibunwind_path = string(_llvmlibunwind_path)
+    global llvmlibunwind_path = string(llvmlibunwind.path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(llvmlibunwind_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/LibCURL_jll/Project.toml
+++ b/stdlib/LibCURL_jll/Project.toml
@@ -3,12 +3,13 @@ uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
 version = "8.12.1+1"
 
 [deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+CompilerSupportLibraries_jll = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 LibSSH2_jll = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-nghttp2_jll = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 Zlib_jll = "83775a58-1f1d-513f-b197-d71354ab007a"
-Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+nghttp2_jll = "8e850ede-7688-5339-a07c-302acd2aaf8d"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -17,4 +18,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 test = ["Test"]
 
 [compat]
+CompilerSupportLibraries_jll = "1.3.0"
 julia = "1.11"

--- a/stdlib/LibCURL_jll/src/LibCURL_jll.jl
+++ b/stdlib/LibCURL_jll/src/LibCURL_jll.jl
@@ -5,7 +5,6 @@
 baremodule LibCURL_jll
 using Base, Libdl, nghttp2_jll, LibSSH2_jll, Zlib_jll
 if !(Sys.iswindows() || Sys.isapple())
-    # On Windows and macOS we use system SSL/crypto libraries
     using OpenSSL_jll
 end
 if Sys.iswindows()
@@ -20,36 +19,35 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
+
 libcurl_path::String = ""
-
-_libcurl_dependencies = LazyLibrary[libz, libnghttp2, libssh2]
-if Sys.iswindows()
-    push!(_libcurl_dependencies, libgcc_s)
-elseif !Sys.isapple()
-    append!(_libcurl_dependencies, [libssl, libcrypto])
-end
-
-if Sys.iswindows()
-    const _libcurl_path = BundledLazyLibraryPath("libcurl-4.dll")
-elseif Sys.isapple()
-    const _libcurl_path = BundledLazyLibraryPath("libcurl.4.dylib")
-else
-    const _libcurl_path = BundledLazyLibraryPath("libcurl.so.4")
-end
-
 const libcurl = LazyLibrary(
-    _libcurl_path,
-    dependencies=_libcurl_dependencies,
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libcurl-4.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libcurl.4.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libcurl.so.4")
+    else
+        error("LibCURL_jll: Library 'libcurl' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = if Sys.iswindows()
+        LazyLibrary[libz, libnghttp2, libssh2, libgcc_s]
+    elseif Sys.islinux() || Sys.isfreebsd()
+        LazyLibrary[libz, libnghttp2, libssh2, libssl, libcrypto]
+    elseif Sys.isapple()
+        LazyLibrary[libz, libnghttp2, libssh2]
+    end
 )
 
 function eager_mode()
     Zlib_jll.eager_mode()
     nghttp2_jll.eager_mode()
     LibSSH2_jll.eager_mode()
-    @static if Sys.iswindows()
+    @static if @isdefined CompilerSupportLibraries_jll
         CompilerSupportLibraries_jll.eager_mode()
     end
-    @static if !(Sys.iswindows() || Sys.isapple())
+    @static if @isdefined OpenSSL_jll
         OpenSSL_jll.eager_mode()
     end
     dlopen(libcurl)
@@ -57,7 +55,7 @@ end
 is_available() = true
 
 function __init__()
-    global libcurl_path = string(_libcurl_path)
+    global libcurl_path = string(libcurl.path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libcurl_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/LibCURL_jll/src/LibCURL_jll.jl
+++ b/stdlib/LibCURL_jll/src/LibCURL_jll.jl
@@ -8,6 +8,7 @@ if !(Sys.iswindows() || Sys.isapple())
     # On Windows and macOS we use system SSL/crypto libraries
     using OpenSSL_jll
 end
+using CompilerSupportLibraries_jll
 
 export libcurl
 
@@ -20,7 +21,9 @@ artifact_dir::String = ""
 libcurl_path::String = ""
 
 _libcurl_dependencies = LazyLibrary[libz, libnghttp2, libssh2]
-if !(Sys.iswindows() || Sys.isapple())
+if Sys.iswindows()
+    push!(_libcurl_dependencies, libgcc_s)
+elseif !Sys.isapple()
     append!(_libcurl_dependencies, [libssl, libcrypto])
 end
 
@@ -41,6 +44,12 @@ function eager_mode()
     Zlib_jll.eager_mode()
     nghttp2_jll.eager_mode()
     LibSSH2_jll.eager_mode()
+    @static if Sys.iswindows()
+        CompilerSupportLibraries_jll.eager_mode()
+    end
+    @static if !(Sys.iswindows() || Sys.isapple())
+        OpenSSL_jll.eager_mode()
+    end
     dlopen(libcurl)
 end
 is_available() = true

--- a/stdlib/LibCURL_jll/src/LibCURL_jll.jl
+++ b/stdlib/LibCURL_jll/src/LibCURL_jll.jl
@@ -8,7 +8,9 @@ if !(Sys.iswindows() || Sys.isapple())
     # On Windows and macOS we use system SSL/crypto libraries
     using OpenSSL_jll
 end
-using CompilerSupportLibraries_jll
+if Sys.iswindows()
+    using CompilerSupportLibraries_jll
+end
 
 export libcurl
 

--- a/stdlib/LibCURL_jll/src/LibCURL_jll.jl
+++ b/stdlib/LibCURL_jll/src/LibCURL_jll.jl
@@ -7,7 +7,7 @@ using Base, Libdl, nghttp2_jll, LibSSH2_jll, Zlib_jll
 if !(Sys.iswindows() || Sys.isapple())
     using OpenSSL_jll
 end
-if Sys.iswindows()
+if Sys.iswindows() && Sys.WORD_SIZE == 32
     using CompilerSupportLibraries_jll
 end
 
@@ -32,7 +32,11 @@ const libcurl = LazyLibrary(
         error("LibCURL_jll: Library 'libcurl' is not available for $(Sys.KERNEL)")
     end;
     dependencies = if Sys.iswindows()
-        LazyLibrary[libz, libnghttp2, libssh2, libgcc_s]
+        if  Sys.WORD_SIZE == 32
+            LazyLibrary[libz, libnghttp2, libssh2, libgcc_s]
+        else
+            LazyLibrary[libz, libnghttp2, libssh2]
+        end
     elseif Sys.islinux() || Sys.isfreebsd()
         LazyLibrary[libz, libnghttp2, libssh2, libssl, libcrypto]
     elseif Sys.isapple()

--- a/stdlib/LibGit2_jll/Project.toml
+++ b/stdlib/LibGit2_jll/Project.toml
@@ -7,9 +7,11 @@ OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 LibSSH2_jll = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+CompilerSupportLibraries_jll = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 
 [compat]
 julia = "1.9"
+CompilerSupportLibraries_jll = "1.3.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/LibGit2_jll/src/LibGit2_jll.jl
+++ b/stdlib/LibGit2_jll/src/LibGit2_jll.jl
@@ -30,7 +30,7 @@ end
 
 if Sys.iswindows()
     _libgit2_dependencies = LazyLibrary[libssh2, libgcc_s]
-elseif Sys.isfreebsd()
+elseif Sys.isfreebsd() || Sys.islinux()
     _libgit2_dependencies = LazyLibrary[libssh2, libssl, libcrypto]
 else
     _libgit2_dependencies = LazyLibrary[libssh2]

--- a/stdlib/LibGit2_jll/src/LibGit2_jll.jl
+++ b/stdlib/LibGit2_jll/src/LibGit2_jll.jl
@@ -7,7 +7,7 @@ using Base, Libdl, LibSSH2_jll
 if !(Sys.iswindows() || Sys.isapple())
     using OpenSSL_jll
 end
-if Sys.iswindows()
+if Sys.iswindows() && Sys.WORD_SIZE == 32
     using CompilerSupportLibraries_jll
 end
 
@@ -31,8 +31,12 @@ const libgit2 = LazyLibrary(
     else
         error("LibGit2_jll: Library 'libgit2' is not available for $(Sys.KERNEL)")
     end;
-    dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
-        LazyLibrary[libssh2, libgcc_s]
+    dependencies = if Sys.iswindows()
+        if Sys.WORD_SIZE == 32
+            LazyLibrary[libssh2, libgcc_s]
+        else
+            LazyLibrary[libssh2]
+        end
     elseif Sys.isfreebsd() || Sys.islinux()
         LazyLibrary[libssh2, libssl, libcrypto]
     else

--- a/stdlib/LibGit2_jll/src/LibGit2_jll.jl
+++ b/stdlib/LibGit2_jll/src/LibGit2_jll.jl
@@ -8,6 +8,7 @@ if !(Sys.iswindows() || Sys.isapple())
     # On Windows and macOS we use system SSL/crypto libraries
     using OpenSSL_jll
 end
+using CompilerSupportLibraries_jll
 
 export libgit2
 
@@ -27,7 +28,9 @@ else
     const _libgit2_path = BundledLazyLibraryPath("libgit2.so.1.9")
 end
 
-if Sys.isfreebsd()
+if Sys.iswindows()
+    _libgit2_dependencies = LazyLibrary[libssh2, libgcc_s]
+elseif Sys.isfreebsd()
     _libgit2_dependencies = LazyLibrary[libssh2, libssl, libcrypto]
 else
     _libgit2_dependencies = LazyLibrary[libssh2]
@@ -38,6 +41,9 @@ function eager_mode()
     LibSSH2_jll.eager_mode()
     @static if !(Sys.iswindows() || Sys.isapple())
         OpenSSL_jll.eager_mode()
+    end
+    @static if Sys.iswindows()
+        CompilerSupportLibraries_jll.eager_mode()
     end
     dlopen(libgit2)
 end

--- a/stdlib/LibGit2_jll/src/LibGit2_jll.jl
+++ b/stdlib/LibGit2_jll/src/LibGit2_jll.jl
@@ -8,7 +8,9 @@ if !(Sys.iswindows() || Sys.isapple())
     # On Windows and macOS we use system SSL/crypto libraries
     using OpenSSL_jll
 end
-using CompilerSupportLibraries_jll
+if Sys.iswindows()
+    using CompilerSupportLibraries_jll
+end
 
 export libgit2
 

--- a/stdlib/LibGit2_jll/src/LibGit2_jll.jl
+++ b/stdlib/LibGit2_jll/src/LibGit2_jll.jl
@@ -30,7 +30,7 @@ else
     const _libgit2_path = BundledLazyLibraryPath("libgit2.so.1.9")
 end
 
-if Sys.iswindows()
+if Sys.iswindows() && Sys.WORD_SIZE == 32
     _libgit2_dependencies = LazyLibrary[libssh2, libgcc_s]
 elseif Sys.isfreebsd() || Sys.islinux()
     _libgit2_dependencies = LazyLibrary[libssh2, libssl, libcrypto]

--- a/stdlib/LibGit2_jll/src/LibGit2_jll.jl
+++ b/stdlib/LibGit2_jll/src/LibGit2_jll.jl
@@ -5,7 +5,6 @@
 baremodule LibGit2_jll
 using Base, Libdl, LibSSH2_jll
 if !(Sys.iswindows() || Sys.isapple())
-    # On Windows and macOS we use system SSL/crypto libraries
     using OpenSSL_jll
 end
 if Sys.iswindows()
@@ -20,31 +19,33 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
+
 libgit2_path::String = ""
-
-if Sys.iswindows()
-    const _libgit2_path = BundledLazyLibraryPath("libgit2.dll")
-elseif Sys.isapple()
-    const _libgit2_path = BundledLazyLibraryPath("libgit2.1.9.dylib")
-else
-    const _libgit2_path = BundledLazyLibraryPath("libgit2.so.1.9")
-end
-
-if Sys.iswindows() && Sys.WORD_SIZE == 32
-    _libgit2_dependencies = LazyLibrary[libssh2, libgcc_s]
-elseif Sys.isfreebsd() || Sys.islinux()
-    _libgit2_dependencies = LazyLibrary[libssh2, libssl, libcrypto]
-else
-    _libgit2_dependencies = LazyLibrary[libssh2]
-end
-const libgit2 = LazyLibrary(_libgit2_path, dependencies=_libgit2_dependencies)
+const libgit2 = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libgit2.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libgit2.1.9.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libgit2.so.1.9")
+    else
+        error("LibGit2_jll: Library 'libgit2' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
+        LazyLibrary[libssh2, libgcc_s]
+    elseif Sys.isfreebsd() || Sys.islinux()
+        LazyLibrary[libssh2, libssl, libcrypto]
+    else
+        LazyLibrary[libssh2]
+    end
+)
 
 function eager_mode()
     LibSSH2_jll.eager_mode()
-    @static if !(Sys.iswindows() || Sys.isapple())
+    @static if @isdefined OpenSSL_jll
         OpenSSL_jll.eager_mode()
     end
-    @static if Sys.iswindows()
+    @static if @isdefined CompilerSupportLibraries_jll
         CompilerSupportLibraries_jll.eager_mode()
     end
     dlopen(libgit2)
@@ -52,7 +53,7 @@ end
 is_available() = true
 
 function __init__()
-    global libgit2_path = string(_libgit2_path)
+    global libgit2_path = string(libgit2.path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libgit2_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/LibSSH2_jll/Project.toml
+++ b/stdlib/LibSSH2_jll/Project.toml
@@ -7,9 +7,11 @@ OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Zlib_jll = "83775a58-1f1d-513f-b197-d71354ab007a"
+CompilerSupportLibraries_jll = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 
 [compat]
 julia = "1.8"
+CompilerSupportLibraries_jll = "1.3.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/LibSSH2_jll/src/LibSSH2_jll.jl
+++ b/stdlib/LibSSH2_jll/src/LibSSH2_jll.jl
@@ -7,8 +7,9 @@ using Base, Libdl, Zlib_jll
 if !Sys.iswindows()
     # On Windows we use system SSL/crypto libraries
     using OpenSSL_jll
+else
+    using CompilerSupportLibraries_jll
 end
-using CompilerSupportLibraries_jll
 
 export libssh2
 

--- a/stdlib/LibSSH2_jll/src/LibSSH2_jll.jl
+++ b/stdlib/LibSSH2_jll/src/LibSSH2_jll.jl
@@ -8,6 +8,7 @@ if !Sys.iswindows()
     # On Windows we use system SSL/crypto libraries
     using OpenSSL_jll
 end
+using CompilerSupportLibraries_jll
 
 export libssh2
 
@@ -22,7 +23,7 @@ libssh2_path::String = ""
 
 if Sys.iswindows()
     const _libssh2_path = BundledLazyLibraryPath("libssh2.dll")
-    _libssh2_dependencies = LazyLibrary[]
+    _libssh2_dependencies = LazyLibrary[libgcc_s]
 elseif Sys.isapple()
     const _libssh2_path = BundledLazyLibraryPath("libssh2.1.dylib")
     _libssh2_dependencies = LazyLibrary[libz, libcrypto]
@@ -40,6 +41,8 @@ function eager_mode()
     Zlib_jll.eager_mode()
     @static if !Sys.iswindows()
         OpenSSL_jll.eager_mode()
+    else
+        CompilerSupportLibraries_jll.eager_mode()
     end
     dlopen(libssh2)
 end

--- a/stdlib/LibSSH2_jll/src/LibSSH2_jll.jl
+++ b/stdlib/LibSSH2_jll/src/LibSSH2_jll.jl
@@ -3,10 +3,14 @@
 ## dummy stub for https://github.com/JuliaBinaryWrappers/LibSSH2_jll.jl
 
 baremodule LibSSH2_jll
-using Base, Libdl, Zlib_jll
-if Sys.iswindows()
+using Base, Libdl
+if Sys.isfreebsd() || Sys.isapple()
+    using Zlib_jll
+end
+if Sys.iswindows() && Sys.WORD_SIZE == 32
     using CompilerSupportLibraries_jll
-else
+end
+if !Sys.iswindows()
     using OpenSSL_jll
 end
 
@@ -31,7 +35,11 @@ const libssh2 = LazyLibrary(
         error("LibSSH2_jll: Library 'libssh2' is not available for $(Sys.KERNEL)")
     end;
     dependencies = if Sys.iswindows()
-        LazyLibrary[libgcc_s]
+        if Sys.WORD_SIZE == 32
+            LazyLibrary[libgcc_s]
+        else
+            LazyLibrary[]
+        end
     elseif Sys.islinux()
         LazyLibrary[libcrypto]
     elseif Sys.isfreebsd() || Sys.isapple()
@@ -40,7 +48,9 @@ const libssh2 = LazyLibrary(
 )
 
 function eager_mode()
-    Zlib_jll.eager_mode()
+    @static if @isdefined Zlib_jll
+        Zlib_jll.eager_mode()
+    end
     @static if @isdefined CompilerSupportLibraries_jll
         CompilerSupportLibraries_jll.eager_mode()
     end

--- a/stdlib/LibUnwind_jll/src/LibUnwind_jll.jl
+++ b/stdlib/LibUnwind_jll/src/LibUnwind_jll.jl
@@ -17,20 +17,19 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
+
 libunwind_path::String = ""
-
-const _libunwind_path = BundledLazyLibraryPath("libunwind.so.8")
-
-if Sys.isfreebsd()
-    _libunwind_dependencies = LazyLibrary[libz]
-else
-    _libunwind_dependencies = LazyLibrary[libgcc_s, libz]
-end
-const libunwind = LazyLibrary(_libunwind_path, dependencies=_libunwind_dependencies)
-
+const libunwind = LazyLibrary(
+    BundledLazyLibraryPath("libunwind.so.8"),
+    dependencies = if Sys.isfreebsd()
+        LazyLibrary[libz]
+    else
+        LazyLibrary[libgcc_s, libz]
+    end
+)
 
 function eager_mode()
-    @static if !Sys.isfreebsd()
+    @static if @isdefined CompilerSupportLibraries_jll
         CompilerSupportLibraries_jll.eager_mode()
     end
     Zlib_jll.eager_mode()
@@ -39,7 +38,7 @@ end
 is_available() = @static(Sys.islinux() || Sys.isfreebsd()) ? true : false
 
 function __init__()
-    global libunwind_path = string(_libunwind_path)
+    global libunwind_path = string(libunwind.path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libunwind_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/LibUnwind_jll/src/LibUnwind_jll.jl
+++ b/stdlib/LibUnwind_jll/src/LibUnwind_jll.jl
@@ -4,8 +4,10 @@
 
 baremodule LibUnwind_jll
 using Base, Libdl
-using CompilerSupportLibraries_jll
 using Zlib_jll
+if !Sys.isfreebsd()
+    using CompilerSupportLibraries_jll
+end
 
 export libunwind
 
@@ -28,7 +30,9 @@ const libunwind = LazyLibrary(_libunwind_path, dependencies=_libunwind_dependenc
 
 
 function eager_mode()
-    CompilerSupportLibraries_jll.eager_mode()
+    @static if !Sys.isfreebsd()
+        CompilerSupportLibraries_jll.eager_mode()
+    end
     Zlib_jll.eager_mode()
     dlopen(libunwind)
 end

--- a/stdlib/MPFR_jll/Project.toml
+++ b/stdlib/MPFR_jll/Project.toml
@@ -3,11 +3,13 @@ uuid = "3a97d323-0669-5f0c-9066-3539efd106a3"
 version = "4.2.2+0"
 
 [deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+CompilerSupportLibraries_jll = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 GMP_jll = "781609d7-10c4-51f6-84f2-b8444358ff6d"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [compat]
+CompilerSupportLibraries_jll = "1.3.0"
 julia = "1.6"
 
 [extras]

--- a/stdlib/MPFR_jll/src/MPFR_jll.jl
+++ b/stdlib/MPFR_jll/src/MPFR_jll.jl
@@ -2,7 +2,10 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/MPFR_jll.jl
 baremodule MPFR_jll
-using Base, Libdl, GMP_jll, CompilerSupportLibraries_jll
+using Base, Libdl, GMP_jll
+if Sys.iswindows()
+    using CompilerSupportLibraries_jll
+end
 
 export libmpfr
 

--- a/stdlib/MPFR_jll/src/MPFR_jll.jl
+++ b/stdlib/MPFR_jll/src/MPFR_jll.jl
@@ -15,35 +15,36 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
+
 libmpfr_path::String = ""
-
-if Sys.iswindows()
-    const _libmpfr_path = BundledLazyLibraryPath("libmpfr-6.dll")
-elseif Sys.isapple()
-    const _libmpfr_path = BundledLazyLibraryPath("libmpfr.6.dylib")
-else
-    const _libmpfr_path = BundledLazyLibraryPath("libmpfr.so.6")
-end
-
-if Sys.iswindows()
-    _libmpfr_dependencies = LazyLibrary[libgmp, libgcc_s]
-else
-    _libmpfr_dependencies = LazyLibrary[libgmp]
-end
-
-const libmpfr = LazyLibrary(_libmpfr_path, dependencies=_libmpfr_dependencies)
+const libmpfr = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libmpfr-6.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libmpfr.6.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libmpfr.so.6")
+    else
+        error("MPFR_jll: Library 'libmpfr' is not available for $(Sys.KERNEL)")
+    end,
+    dependencies = if Sys.iswindows()
+        LazyLibrary[libgmp, libgcc_s]
+    else
+        LazyLibrary[libgmp]
+    end
+)
 
 function eager_mode()
-    dlopen(libmpfr)
     GMP_jll.eager_mode()
-    @static if Sys.iswindows()
+    @static if @isdefined CompilerSupportLibraries_jll
         CompilerSupportLibraries_jll.eager_mode()
     end
+    dlopen(libmpfr)
 end
 is_available() = true
 
 function __init__()
-    global libmpfr_path = string(_libmpfr_path)
+    global libmpfr_path = string(libmpfr.path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libmpfr_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/MPFR_jll/src/MPFR_jll.jl
+++ b/stdlib/MPFR_jll/src/MPFR_jll.jl
@@ -2,7 +2,7 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/MPFR_jll.jl
 baremodule MPFR_jll
-using Base, Libdl, GMP_jll
+using Base, Libdl, GMP_jll, CompilerSupportLibraries_jll
 
 export libmpfr
 
@@ -22,12 +22,20 @@ else
     const _libmpfr_path = BundledLazyLibraryPath("libmpfr.so.6")
 end
 
-_libmpfr_dependencies = LazyLibrary[libgmp]
+if Sys.iswindows()
+    _libmpfr_dependencies = LazyLibrary[libgmp, libgcc_s]
+else
+    _libmpfr_dependencies = LazyLibrary[libgmp]
+end
 
 const libmpfr = LazyLibrary(_libmpfr_path, dependencies=_libmpfr_dependencies)
 
 function eager_mode()
     dlopen(libmpfr)
+    GMP_jll.eager_mode()
+    @static if Sys.iswindows()
+        CompilerSupportLibraries_jll.eager_mode()
+    end
 end
 is_available() = true
 

--- a/stdlib/Manifest.toml
+++ b/stdlib/Manifest.toml
@@ -91,7 +91,7 @@ uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 version = "0.6.4"
 
 [[deps.LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
 version = "8.12.1+1"
 
@@ -101,12 +101,12 @@ uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 version = "1.11.0"
 
 [[deps.LibGit2_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
 version = "1.9.0+0"
 
 [[deps.LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "OpenSSL_jll", "Zlib_jll"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl", "OpenSSL_jll", "Zlib_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 version = "1.11.3+1"
 
@@ -134,7 +134,7 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 version = "1.11.0"
 
 [[deps.MPFR_jll]]
-deps = ["Artifacts", "GMP_jll", "Libdl"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "GMP_jll", "Libdl"]
 uuid = "3a97d323-0669-5f0c-9066-3539efd106a3"
 version = "4.2.2+0"
 
@@ -149,7 +149,7 @@ version = "1.11.0"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2025.2.25"
+version = "2025.5.20"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -161,7 +161,7 @@ uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
 version = "0.3.29+0"
 
 [[deps.OpenLibm_jll]]
-deps = ["Artifacts", "Libdl"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
 version = "0.8.5+0"
 
@@ -275,7 +275,7 @@ uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 version = "1.3.1+2"
 
 [[deps.Zstd_jll]]
-deps = ["Libdl"]
+deps = ["CompilerSupportLibraries_jll", "Libdl"]
 uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
 version = "1.5.7+1"
 
@@ -295,7 +295,7 @@ uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
 version = "5.12.0+0"
 
 [[deps.nghttp2_jll]]
-deps = ["Artifacts", "Libdl"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
 version = "1.65.0+0"
 

--- a/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
+++ b/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
@@ -13,7 +13,7 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
-libopenblas_path::String = ""
+
 
 if Base.USE_BLAS64
     const libsuffix = "64_"
@@ -21,27 +21,30 @@ else
     const libsuffix = ""
 end
 
-if Sys.iswindows()
-    const _libopenblas_path = BundledLazyLibraryPath(string("libopenblas", libsuffix, ".dll"))
-elseif Sys.isapple()
-    const _libopenblas_path = BundledLazyLibraryPath(string("libopenblas", libsuffix, ".dylib"))
-else
-    const _libopenblas_path = BundledLazyLibraryPath(string("libopenblas", libsuffix, ".so"))
-end
-
-_libopenblas_dependencies = LazyLibrary[libgfortran]
-if Sys.isapple()
-    if isdefined(CompilerSupportLibraries_jll, :libquadmath)
-        push!(_libopenblas_dependencies, CompilerSupportLibraries_jll.libquadmath)
+libopenblas_path::String = ""
+const libopenblas = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath(string("libopenblas", libsuffix, ".dll"))
+    elseif Sys.isapple()
+        BundledLazyLibraryPath(string("libopenblas", libsuffix, ".dylib"))
+    else
+        BundledLazyLibraryPath(string("libopenblas", libsuffix, ".so"))
+    end,
+    dependencies = if Sys.iswindows()
+        LazyLibrary[libgfortran, libgcc_s]
+    elseif Sys.isapple()
+        deps = LazyLibrary[libgfortran]
+        if isdefined(CompilerSupportLibraries_jll, :libquadmath)
+            push!(deps, CompilerSupportLibraries_jll.libquadmath)
+        end
+        if Sys.ARCH != :aarch64
+            push!(deps, CompilerSupportLibraries_jll.libgcc_s)
+        end
+        deps
+    else
+        LazyLibrary[libgfortran]
     end
-    if Sys.ARCH != :aarch64
-        push!(_libopenblas_dependencies, CompilerSupportLibraries_jll.libgcc_s)
-    end
-end
-if Sys.iswindows()
-    push!(_libopenblas_dependencies, CompilerSupportLibraries_jll.libgcc_s)
-end
-const libopenblas = LazyLibrary(_libopenblas_path, dependencies=_libopenblas_dependencies)
+)
 
 # Conform to LazyJLLWrappers API
 function eager_mode()
@@ -51,7 +54,7 @@ end
 is_available() = true
 
 function __init__()
-    global libopenblas_path = string(_libopenblas_path)
+    global libopenblas_path = string(libopenblas.path)
     # make sure OpenBLAS does not set CPU affinity (#1070, #9639)
     if !(haskey(ENV, "OPENBLAS_MAIN_FREE"))
         ENV["OPENBLAS_MAIN_FREE"] = "1"
@@ -68,7 +71,7 @@ function __init__()
         ENV["OPENBLAS_DEFAULT_NUM_THREADS"] = "1"
     end
 
-    global libopenblas_path = string(_libopenblas_path)
+    global libopenblas_path = string(libopenblas.path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libopenblas_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
+++ b/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
@@ -38,6 +38,9 @@ if Sys.isapple()
         push!(_libopenblas_dependencies, CompilerSupportLibraries_jll.libgcc_s)
     end
 end
+if Sys.iswindows()
+    push!(_libopenblas_dependencies, CompilerSupportLibraries_jll.libgcc_s)
+end
 const libopenblas = LazyLibrary(_libopenblas_path, dependencies=_libopenblas_dependencies)
 
 # Conform to LazyJLLWrappers API

--- a/stdlib/OpenLibm_jll/Project.toml
+++ b/stdlib/OpenLibm_jll/Project.toml
@@ -3,10 +3,12 @@ uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
 version = "0.8.5+0"
 
 [deps]
-Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+CompilerSupportLibraries_jll = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
+CompilerSupportLibraries_jll = "1.3.0"
 julia = "1.0"
 
 [extras]

--- a/stdlib/OpenLibm_jll/src/OpenLibm_jll.jl
+++ b/stdlib/OpenLibm_jll/src/OpenLibm_jll.jl
@@ -26,7 +26,7 @@ const libopenlibm = LazyLibrary(
         BundledLazyLibraryPath("libopenlibm.so.4")
     end,
     dependencies = if Sys.iswindows()
-        LazyLibrary[CompilerSupportLibraries_jll.libgcc_s]
+        LazyLibrary[libgcc_s]
     else
         LazyLibrary[]
     end

--- a/stdlib/OpenLibm_jll/src/OpenLibm_jll.jl
+++ b/stdlib/OpenLibm_jll/src/OpenLibm_jll.jl
@@ -3,7 +3,9 @@
 ## dummy stub for https://github.com/JuliaBinaryWrappers/OpenLibm_jll.jl
 baremodule OpenLibm_jll
 using Base, Libdl
-using CompilerSupportLibraries_jll
+if Sys.iswindows()
+    using CompilerSupportLibraries_jll
+end
 
 export libopenlibm
 
@@ -13,32 +15,33 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
-libopenlibm_path::String = ""
 
-if Sys.iswindows()
-    const _libopenlibm_path = BundledLazyLibraryPath("libopenlibm.dll")
-elseif Sys.isapple()
-    const _libopenlibm_path = BundledLazyLibraryPath("libopenlibm.4.dylib")
-else
-    const _libopenlibm_path = BundledLazyLibraryPath("libopenlibm.so.4")
-end
-if Sys.iswindows()
-    const _libopenlibm_dependencies = LazyLibrary[CompilerSupportLibraries_jll.libgcc_s]
-else
-    const _libopenlibm_dependencies = LazyLibrary[]
-end
-const libopenlibm = LazyLibrary(_libopenlibm_path, dependencies=_libopenlibm_dependencies)
+libopenlibm_path::String = ""
+const libopenlibm = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libopenlibm.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libopenlibm.4.dylib")
+    else
+        BundledLazyLibraryPath("libopenlibm.so.4")
+    end,
+    dependencies = if Sys.iswindows()
+        LazyLibrary[CompilerSupportLibraries_jll.libgcc_s]
+    else
+        LazyLibrary[]
+    end
+)
 
 function eager_mode()
     dlopen(libopenlibm)
-    @static if Sys.iswindows()
+    @static if @isdefined CompilerSupportLibraries_jll
         CompilerSupportLibraries_jll.eager_mode()
     end
 end
 is_available() = true
 
 function __init__()
-    global libopenlibm_path = string(_libopenlibm_path)
+    global libopenlibm_path = string(libopenlibm.path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libopenlibm_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/OpenLibm_jll/src/OpenLibm_jll.jl
+++ b/stdlib/OpenLibm_jll/src/OpenLibm_jll.jl
@@ -3,6 +3,7 @@
 ## dummy stub for https://github.com/JuliaBinaryWrappers/OpenLibm_jll.jl
 baremodule OpenLibm_jll
 using Base, Libdl
+using CompilerSupportLibraries_jll
 
 export libopenlibm
 
@@ -21,11 +22,18 @@ elseif Sys.isapple()
 else
     const _libopenlibm_path = BundledLazyLibraryPath("libopenlibm.so.4")
 end
-
-const libopenlibm = LazyLibrary(_libopenlibm_path)
+if Sys.iswindows()
+    const _libopenlibm_dependencies = LazyLibrary[CompilerSupportLibraries_jll.libgcc_s]
+else
+    const _libopenlibm_dependencies = LazyLibrary[]
+end
+const libopenlibm = LazyLibrary(_libopenlibm_path, dependencies=_libopenlibm_dependencies)
 
 function eager_mode()
     dlopen(libopenlibm)
+    @static if Sys.iswindows()
+        CompilerSupportLibraries_jll.eager_mode()
+    end
 end
 is_available() = true
 

--- a/stdlib/OpenSSL_jll/src/OpenSSL_jll.jl
+++ b/stdlib/OpenSSL_jll/src/OpenSSL_jll.jl
@@ -13,29 +13,41 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
+
 libcrypto_path::String = ""
-libssl_path::String = ""
-
-if Sys.iswindows()
-    if arch(HostPlatform()) == "x86_64"
-        const _libcrypto_path = BundledLazyLibraryPath("libcrypto-3-x64.dll")
-        const _libssl_path = BundledLazyLibraryPath("libssl-3-x64.dll")
+const libcrypto = LazyLibrary(
+    if Sys.iswindows()
+        if arch(HostPlatform()) == "x86_64"
+            BundledLazyLibraryPath("libcrypto-3-x64.dll")
+        else
+            BundledLazyLibraryPath("libcrypto-3.dll")
+        end
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libcrypto.3.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libcrypto.so.3")
     else
-        const _libcrypto_path = BundledLazyLibraryPath("libcrypto-3.dll")
-        const _libssl_path = BundledLazyLibraryPath("libssl-3.dll")
+        error("OpenSSL_jll: Library 'libcrypto' is not available for $(Sys.KERNEL)")
     end
-elseif Sys.isapple()
-    const _libcrypto_path = BundledLazyLibraryPath("libcrypto.3.dylib")
-    const _libssl_path = BundledLazyLibraryPath("libssl.3.dylib")
-else
-    const _libcrypto_path = BundledLazyLibraryPath("libcrypto.so.3")
-    const _libssl_path = BundledLazyLibraryPath("libssl.so.3")
-end
+)
 
-const libcrypto = LazyLibrary(_libcrypto_path)
-
-_libssl_dependencies = LazyLibrary[libcrypto]
-const libssl = LazyLibrary(_libssl_path, dependencies=_libssl_dependencies)
+libssl_path::String = ""
+const libssl = LazyLibrary(
+    if Sys.iswindows()
+        if arch(HostPlatform()) == "x86_64"
+            BundledLazyLibraryPath("libssl-3-x64.dll")
+        else
+            BundledLazyLibraryPath("libssl-3.dll")
+        end
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libssl.3.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libssl.so.3")
+    else
+        error("OpenSSL_jll: Library 'libssl' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = LazyLibrary[libcrypto]
+)
 
 function eager_mode()
     dlopen(libcrypto)
@@ -44,8 +56,8 @@ end
 is_available() = true
 
 function __init__()
-    global libcrypto_path = string(_libcrypto_path)
-    global libssl_path = string(_libssl_path)
+    global libcrypto_path = string(libcrypto.path)
+    global libssl_path = string(libssl.path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libssl_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/PCRE2_jll/src/PCRE2_jll.jl
+++ b/stdlib/PCRE2_jll/src/PCRE2_jll.jl
@@ -12,17 +12,19 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
+
 libpcre2_8_path::String = ""
-
-if Sys.iswindows()
-    const _libpcre2_8_path = BundledLazyLibraryPath("libpcre2-8-0.dll")
-elseif Sys.isapple()
-    const _libpcre2_8_path = BundledLazyLibraryPath("libpcre2-8.0.dylib")
-else
-    const _libpcre2_8_path = BundledLazyLibraryPath("libpcre2-8.so.0")
-end
-
-const libpcre2_8 = LazyLibrary(_libpcre2_8_path)
+const libpcre2_8 = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libpcre2-8.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libpcre2-8.0.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libpcre2-8.so.0")
+    else
+        error("PCRE2_jll: Library 'libpcre2_8' is not available for $(Sys.KERNEL)")
+    end
+)
 
 function eager_mode()
     dlopen(libpcre2_8)
@@ -30,7 +32,7 @@ end
 is_available() = true
 
 function __init__()
-    global libpcre2_8_path = string(_libpcre2_8_path)
+    global libpcre2_8_path = string(libpcre2_8.path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libpcre2_8_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
+++ b/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
@@ -4,7 +4,9 @@
 baremodule SuiteSparse_jll
 using Base, Libdl
 using libblastrampoline_jll
-using CompilerSupportLibraries_jll
+if !(Sys.isfreebsd() || Sys.isapple())
+    using CompilerSupportLibraries_jll
+end
 
 export libamd, libbtf, libcamd, libccolamd, libcholmod, libcolamd, libklu, libldl, librbio, libspqr, libsuitesparseconfig, libumfpack
 
@@ -66,7 +68,7 @@ const libcolamd = LazyLibrary(
     else
         error("SuiteSparse_jll: Library 'libcolamd' is not available for $(Sys.KERNEL)")
     end;
-    dependencies = if Sys.iswindows()
+    dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
         LazyLibrary[libsuitesparseconfig, libgcc_s]
     else
         LazyLibrary[libsuitesparseconfig]
@@ -224,7 +226,9 @@ const libumfpack = LazyLibrary(
 )
 
 function eager_mode()
-    CompilerSupportLibraries_jll.eager_mode()
+    @static if @isdefined CompilerSupportLibraries_jll
+        CompilerSupportLibraries_jll.eager_mode()
+    end
     libblastrampoline_jll.eager_mode()
 
     dlopen(libamd)

--- a/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
+++ b/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
@@ -2,7 +2,9 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/SuiteSparse_jll.jl
 baremodule SuiteSparse_jll
-using Base, Libdl, libblastrampoline_jll, CompilerSupportLibraries_jll
+using Base, Libdl
+using libblastrampoline_jll
+using CompilerSupportLibraries_jll
 
 export libamd, libbtf, libcamd, libccolamd, libcholmod, libcolamd, libklu, libldl, librbio, libspqr, libsuitesparseconfig, libumfpack
 
@@ -13,132 +15,213 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
-libamd_path::String = ""
-libbtf_path::String = ""
-libcamd_path::String = ""
-libccolamd_path::String = ""
-libcholmod_path::String = ""
-libcolamd_path::String = ""
-libklu_path::String = ""
-libldl_path::String = ""
-librbio_path::String = ""
-libspqr_path::String = ""
+
 libsuitesparseconfig_path::String = ""
+const libsuitesparseconfig = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libsuitesparseconfig.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libsuitesparseconfig.7.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libsuitesparseconfig.so.7")
+    else
+        error("SuiteSparse_jll: Library 'libsuitesparseconfig' is not available for $(Sys.KERNEL)")
+    end
+)
+
+libldl_path::String = ""
+const libldl = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libldl.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libldl.3.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libldl.so.3")
+    else
+        error("SuiteSparse_jll: Library 'libldl' is not available for $(Sys.KERNEL)")
+    end
+)
+
+libbtf_path::String = ""
+const libbtf = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libbtf.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libbtf.2.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libbtf.so.2")
+    else
+        error("SuiteSparse_jll: Library 'libbtf' is not available for $(Sys.KERNEL)")
+    end
+)
+
+libcolamd_path::String = ""
+const libcolamd = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libcolamd.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libcolamd.3.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libcolamd.so.3")
+    else
+        error("SuiteSparse_jll: Library 'libcolamd' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = if Sys.iswindows()
+        LazyLibrary[libsuitesparseconfig, libgcc_s]
+    else
+        LazyLibrary[libsuitesparseconfig]
+    end
+)
+
+libamd_path::String = ""
+const libamd = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libamd.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libamd.3.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libamd.so.3")
+    else
+        error("SuiteSparse_jll: Library 'libamd' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
+        LazyLibrary[libsuitesparseconfig, libgcc_s]
+    else
+        LazyLibrary[libsuitesparseconfig]
+    end
+)
+
+libcamd_path::String = ""
+const libcamd = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libcamd.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libcamd.3.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libcamd.so.3")
+    else
+        error("SuiteSparse_jll: Library 'libcamd' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
+        LazyLibrary[libsuitesparseconfig, libgcc_s]
+    else
+        LazyLibrary[libsuitesparseconfig]
+    end
+)
+
+libccolamd_path::String = ""
+const libccolamd = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libccolamd.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libccolamd.3.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libccolamd.so.3")
+    else
+        error("SuiteSparse_jll: Library 'libccolamd' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
+        LazyLibrary[libsuitesparseconfig, libgcc_s]
+    else
+        LazyLibrary[libsuitesparseconfig]
+    end
+)
+
+librbio_path::String = ""
+const librbio = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("librbio.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("librbio.4.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("librbio.so.4")
+    else
+        error("SuiteSparse_jll: Library 'librbio' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
+        LazyLibrary[libsuitesparseconfig, libgcc_s]
+    else
+        LazyLibrary[libsuitesparseconfig]
+    end
+)
+
+libcholmod_path::String = ""
+const libcholmod = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libcholmod.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libcholmod.5.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libcholmod.so.5")
+    else
+        error("SuiteSparse_jll: Library 'libcholmod' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = if Sys.iswindows()
+        LazyLibrary[
+            libsuitesparseconfig, libamd, libcamd, libccolamd, libcolamd, libblastrampoline, libgcc_s
+        ]
+    else
+        LazyLibrary[
+            libsuitesparseconfig, libamd, libcamd, libccolamd, libcolamd, libblastrampoline
+        ]
+    end
+)
+
+libklu_path::String = ""
+const libklu = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libklu.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libklu.2.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libklu.so.2")
+    else
+        error("SuiteSparse_jll: Library 'libklu' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
+        LazyLibrary[libsuitesparseconfig, libamd, libcolamd, libbtf, libgcc_s]
+    else
+        LazyLibrary[libsuitesparseconfig, libamd, libcolamd, libbtf]
+    end
+)
+
+libspqr_path::String = ""
+const libspqr = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libspqr.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libspqr.4.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libspqr.so.4")
+    else
+        error("SuiteSparse_jll: Library 'libspqr' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = if Sys.iswindows()
+        LazyLibrary[libsuitesparseconfig, libcholmod, libblastrampoline, libgcc_s]
+    elseif Sys.isfreebsd() || Sys.isapple()
+        LazyLibrary[libsuitesparseconfig, libcholmod, libblastrampoline]
+    else
+        LazyLibrary[libsuitesparseconfig, libcholmod, libblastrampoline, libstdcxx, libgcc_s]
+    end
+)
+
 libumfpack_path::String = ""
-
-if Sys.iswindows()
-    const _libamd_path = BundledLazyLibraryPath("libamd.dll")
-    const _libbtf_path = BundledLazyLibraryPath("libbtf.dll")
-    const _libcamd_path = BundledLazyLibraryPath("libcamd.dll")
-    const _libccolamd_path = BundledLazyLibraryPath("libccolamd.dll")
-    const _libcholmod_path = BundledLazyLibraryPath("libcholmod.dll")
-    const _libcolamd_path = BundledLazyLibraryPath("libcolamd.dll")
-    const _libklu_path = BundledLazyLibraryPath("libklu.dll")
-    const _libldl_path = BundledLazyLibraryPath("libldl.dll")
-    const _librbio_path = BundledLazyLibraryPath("librbio.dll")
-    const _libspqr_path = BundledLazyLibraryPath("libspqr.dll")
-    const _libsuitesparseconfig_path = BundledLazyLibraryPath("libsuitesparseconfig.dll")
-    const _libumfpack_path = BundledLazyLibraryPath("libumfpack.dll")
-elseif Sys.isapple()
-    const _libamd_path = BundledLazyLibraryPath("libamd.3.dylib")
-    const _libbtf_path = BundledLazyLibraryPath("libbtf.2.dylib")
-    const _libcamd_path = BundledLazyLibraryPath("libcamd.3.dylib")
-    const _libccolamd_path = BundledLazyLibraryPath("libccolamd.3.dylib")
-    const _libcholmod_path = BundledLazyLibraryPath("libcholmod.5.dylib")
-    const _libcolamd_path = BundledLazyLibraryPath("libcolamd.3.dylib")
-    const _libklu_path = BundledLazyLibraryPath("libklu.2.dylib")
-    const _libldl_path = BundledLazyLibraryPath("libldl.3.dylib")
-    const _librbio_path = BundledLazyLibraryPath("librbio.4.dylib")
-    const _libspqr_path = BundledLazyLibraryPath("libspqr.4.dylib")
-    const _libsuitesparseconfig_path = BundledLazyLibraryPath("libsuitesparseconfig.7.dylib")
-    const _libumfpack_path = BundledLazyLibraryPath("libumfpack.6.dylib")
-else
-    const _libamd_path = BundledLazyLibraryPath("libamd.so.3")
-    const _libbtf_path = BundledLazyLibraryPath("libbtf.so.2")
-    const _libcamd_path = BundledLazyLibraryPath("libcamd.so.3")
-    const _libccolamd_path = BundledLazyLibraryPath("libccolamd.so.3")
-    const _libcholmod_path = BundledLazyLibraryPath("libcholmod.so.5")
-    const _libcolamd_path = BundledLazyLibraryPath("libcolamd.so.3")
-    const _libklu_path = BundledLazyLibraryPath("libklu.so.2")
-    const _libldl_path = BundledLazyLibraryPath("libldl.so.3")
-    const _librbio_path = BundledLazyLibraryPath("librbio.so.4")
-    const _libspqr_path = BundledLazyLibraryPath("libspqr.so.4")
-    const _libsuitesparseconfig_path = BundledLazyLibraryPath("libsuitesparseconfig.so.7")
-    const _libumfpack_path = BundledLazyLibraryPath("libumfpack.so.6")
-end
-
-const libsuitesparseconfig = LazyLibrary(_libsuitesparseconfig_path)
-const libldl = LazyLibrary(_libldl_path)
-const libbtf = LazyLibrary(_libbtf_path)
-
-if Sys.iswindows()
-    _libcolamd_dependencies = LazyLibrary[libsuitesparseconfig, libgcc_s]
-else
-    _libcolamd_dependencies = LazyLibrary[libsuitesparseconfig]
-end
-const libcolamd = LazyLibrary(_libcolamd_path; dependencies=_libcolamd_dependencies)
-
-if Sys.iswindows() && Sys.WORD_SIZE == 32
-    _libamd_dependencies = LazyLibrary[libsuitesparseconfig, libgcc_s]
-else
-    _libamd_dependencies = LazyLibrary[libsuitesparseconfig]
-end
-const libamd = LazyLibrary(_libamd_path; dependencies=_libamd_dependencies)
-
-if Sys.iswindows() && Sys.WORD_SIZE == 32
-    _libcamd_dependencies = LazyLibrary[libsuitesparseconfig, libgcc_s]
-else
-    _libcamd_dependencies = LazyLibrary[libsuitesparseconfig]
-end
-const libcamd = LazyLibrary(_libcamd_path; dependencies=_libcamd_dependencies)
-
-if Sys.iswindows() && Sys.WORD_SIZE == 32
-    _libccolamd_dependencies = LazyLibrary[libsuitesparseconfig, libgcc_s]
-else
-    _libccolamd_dependencies = LazyLibrary[libsuitesparseconfig]
-end
-const libccolamd = LazyLibrary(_libccolamd_path; dependencies=_libccolamd_dependencies)
-
-if Sys.iswindows() && Sys.WORD_SIZE == 32
-    _librbio_dependencies = LazyLibrary[libsuitesparseconfig, libgcc_s]
-else
-    _librbio_dependencies = LazyLibrary[libsuitesparseconfig]
-end
-const librbio = LazyLibrary(_librbio_path; dependencies=_librbio_dependencies)
-
-if Sys.iswindows()
-    _libcholmod_dependencies = LazyLibrary[
-        libsuitesparseconfig, libamd, libcamd, libccolamd, libcolamd, libblastrampoline, libgcc_s
-    ]
-else
-    _libcholmod_dependencies = LazyLibrary[
-        libsuitesparseconfig, libamd, libcamd, libccolamd, libcolamd, libblastrampoline
-    ]
-end
-const libcholmod = LazyLibrary(_libcholmod_path; dependencies=_libcholmod_dependencies)
-
-if Sys.iswindows() && Sys.WORD_SIZE == 32
-    _libklu_dependencies = LazyLibrary[libsuitesparseconfig, libamd, libcolamd, libbtf, libgcc_s]
-else
-    _libklu_dependencies = LazyLibrary[libsuitesparseconfig, libamd, libcolamd, libbtf]
-end
-const libklu = LazyLibrary(_libklu_path; dependencies=_libklu_dependencies)
-
-if Sys.iswindows()
-    _libspqr_dependencies = LazyLibrary[libsuitesparseconfig, libcholmod, libblastrampoline, libgcc_s]
-elseif Sys.isfreebsd() || Sys.isapple()
-    _libspqr_dependencies = LazyLibrary[libsuitesparseconfig, libcholmod, libblastrampoline]
-else
-    _libspqr_dependencies = LazyLibrary[libsuitesparseconfig, libcholmod, libblastrampoline, libstdcxx, libgcc_s]
-end
-const libspqr = LazyLibrary(_libspqr_path; dependencies=_libspqr_dependencies)
-
-if Sys.iswindows() && Sys.WORD_SIZE == 32
-    _libumfpack_dependencies = LazyLibrary[libsuitesparseconfig, libamd, libcholmod, libblastrampoline, libgcc_s]
-else
-    _libumfpack_dependencies = LazyLibrary[libsuitesparseconfig, libamd, libcholmod, libblastrampoline]
-end
-const libumfpack = LazyLibrary(_libumfpack_path; dependencies=_libumfpack_dependencies)
+const libumfpack = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libumfpack.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libumfpack.6.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libumfpack.so.6")
+    else
+        error("SuiteSparse_jll: Library 'libumfpack' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
+        LazyLibrary[libsuitesparseconfig, libamd, libcholmod, libblastrampoline, libgcc_s]
+    else
+        LazyLibrary[libsuitesparseconfig, libamd, libcholmod, libblastrampoline]
+    end
+)
 
 function eager_mode()
     CompilerSupportLibraries_jll.eager_mode()
@@ -161,23 +244,23 @@ is_available() = true
 
 function __init__()
     # BSD-3-Clause
-    global libamd_path = string(_libamd_path)
-    global libcamd_path = string(_libcamd_path)
-    global libccolamd_path = string(_libccolamd_path)
-    global libcolamd_path = string(_libcolamd_path)
-    global libsuitesparseconfig_path = string(_libsuitesparseconfig_path)
+    global libamd_path = string(libamd.path)
+    global libcamd_path = string(libcamd.path)
+    global libccolamd_path = string(libccolamd.path)
+    global libcolamd_path = string(libcolamd.path)
+    global libsuitesparseconfig_path = string(libsuitesparseconfig.path)
 
     # LGPL-2.1+
-    global libbtf_path = string(_libbtf_path)
-    global libklu_path = string(_libklu_path)
-    global libldl_path = string(_libldl_path)
+    global libbtf_path = string(libbtf.path)
+    global libklu_path = string(libklu.path)
+    global libldl_path = string(libldl.path)
 
     # GPL-2.0+
     if Base.USE_GPL_LIBS
-        global libcholmod_path = string(_libcholmod_path)
-        global librbio_path = string(_librbio_path)
-        global libspqr_path = string(_libspqr_path)
-        global libumfpack_path = string(_libumfpack_path)
+        global libcholmod_path = string(libcholmod.path)
+        global librbio_path = string(librbio.path)
+        global libspqr_path = string(libspqr.path)
+        global libumfpack_path = string(libumfpack.path)
     end
     global artifact_dir = dirname(Sys.BINDIR)
 end

--- a/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
+++ b/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
@@ -71,37 +71,73 @@ const libsuitesparseconfig = LazyLibrary(_libsuitesparseconfig_path)
 const libldl = LazyLibrary(_libldl_path)
 const libbtf = LazyLibrary(_libbtf_path)
 
-_libcolamd_dependencies = LazyLibrary[libsuitesparseconfig]
+if Sys.iswindows()
+    _libcolamd_dependencies = LazyLibrary[libsuitesparseconfig, libgcc_s]
+else
+    _libcolamd_dependencies = LazyLibrary[libsuitesparseconfig]
+end
 const libcolamd = LazyLibrary(_libcolamd_path; dependencies=_libcolamd_dependencies)
 
-_libamd_dependencies = LazyLibrary[libsuitesparseconfig]
+if Sys.iswindows()
+    _libamd_dependencies = LazyLibrary[libsuitesparseconfig, libgcc_s]
+else
+    _libamd_dependencies = LazyLibrary[libsuitesparseconfig]
+end
 const libamd = LazyLibrary(_libamd_path; dependencies=_libamd_dependencies)
 
-_libcamd_dependencies = LazyLibrary[libsuitesparseconfig]
+if Sys.iswindows()
+    _libcamd_dependencies = LazyLibrary[libsuitesparseconfig, libgcc_s]
+else
+    _libcamd_dependencies = LazyLibrary[libsuitesparseconfig]
+end
 const libcamd = LazyLibrary(_libcamd_path; dependencies=_libcamd_dependencies)
 
-_libccolamd_dependencies = LazyLibrary[libsuitesparseconfig]
+if Sys.iswindows()
+    _libccolamd_dependencies = LazyLibrary[libsuitesparseconfig, libgcc_s]
+else
+    _libccolamd_dependencies = LazyLibrary[libsuitesparseconfig]
+end
 const libccolamd = LazyLibrary(_libccolamd_path; dependencies=_libccolamd_dependencies)
 
-_librbio_dependencies = LazyLibrary[libsuitesparseconfig]
+if Sys.iswindows()
+    _librbio_dependencies = LazyLibrary[libsuitesparseconfig, libgcc_s]
+else
+    _librbio_dependencies = LazyLibrary[libsuitesparseconfig]
+end
 const librbio = LazyLibrary(_librbio_path; dependencies=_librbio_dependencies)
 
-_libcholmod_dependencies = LazyLibrary[
-    libsuitesparseconfig, libamd, libcamd, libccolamd, libcolamd, libblastrampoline
+if Sys.iswindows()
+    _libcholmod_dependencies = LazyLibrary[
+        libsuitesparseconfig, libamd, libcamd, libccolamd, libcolamd, libblastrampoline, libgcc_s
     ]
+else
+    _libcholmod_dependencies = LazyLibrary[
+        libsuitesparseconfig, libamd, libcamd, libccolamd, libcolamd, libblastrampoline
+    ]
+end
 const libcholmod = LazyLibrary(_libcholmod_path; dependencies=_libcholmod_dependencies)
 
-_libklu_dependencies = LazyLibrary[libsuitesparseconfig, libamd, libcolamd, libbtf]
+if Sys.iswindows()
+    _libklu_dependencies = LazyLibrary[libsuitesparseconfig, libamd, libcolamd, libbtf, libgcc_s]
+else
+    _libklu_dependencies = LazyLibrary[libsuitesparseconfig, libamd, libcolamd, libbtf]
+end
 const libklu = LazyLibrary(_libklu_path; dependencies=_libklu_dependencies)
 
-if Sys.isfreebsd() || Sys.isapple()
+if Sys.iswindows()
+    _libspqr_dependencies = LazyLibrary[libsuitesparseconfig, libcholmod, libblastrampoline, libgcc_s]
+elseif Sys.isfreebsd() || Sys.isapple()
     _libspqr_dependencies = LazyLibrary[libsuitesparseconfig, libcholmod, libblastrampoline]
 else
     _libspqr_dependencies = LazyLibrary[libsuitesparseconfig, libcholmod, libblastrampoline, libstdcxx, libgcc_s]
 end
 const libspqr = LazyLibrary(_libspqr_path; dependencies=_libspqr_dependencies)
 
-_libumfpack_dependencies = LazyLibrary[libsuitesparseconfig, libamd, libcholmod, libblastrampoline]
+if Sys.iswindows()
+    _libumfpack_dependencies = LazyLibrary[libsuitesparseconfig, libamd, libcholmod, libblastrampoline, libgcc_s]
+else
+    _libumfpack_dependencies = LazyLibrary[libsuitesparseconfig, libamd, libcholmod, libblastrampoline]
+end
 const libumfpack = LazyLibrary(_libumfpack_path; dependencies=_libumfpack_dependencies)
 
 function eager_mode()

--- a/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
+++ b/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
@@ -78,28 +78,28 @@ else
 end
 const libcolamd = LazyLibrary(_libcolamd_path; dependencies=_libcolamd_dependencies)
 
-if Sys.iswindows()
+if Sys.iswindows() && Sys.WORD_SIZE == 32
     _libamd_dependencies = LazyLibrary[libsuitesparseconfig, libgcc_s]
 else
     _libamd_dependencies = LazyLibrary[libsuitesparseconfig]
 end
 const libamd = LazyLibrary(_libamd_path; dependencies=_libamd_dependencies)
 
-if Sys.iswindows()
+if Sys.iswindows() && Sys.WORD_SIZE == 32
     _libcamd_dependencies = LazyLibrary[libsuitesparseconfig, libgcc_s]
 else
     _libcamd_dependencies = LazyLibrary[libsuitesparseconfig]
 end
 const libcamd = LazyLibrary(_libcamd_path; dependencies=_libcamd_dependencies)
 
-if Sys.iswindows()
+if Sys.iswindows() && Sys.WORD_SIZE == 32
     _libccolamd_dependencies = LazyLibrary[libsuitesparseconfig, libgcc_s]
 else
     _libccolamd_dependencies = LazyLibrary[libsuitesparseconfig]
 end
 const libccolamd = LazyLibrary(_libccolamd_path; dependencies=_libccolamd_dependencies)
 
-if Sys.iswindows()
+if Sys.iswindows() && Sys.WORD_SIZE == 32
     _librbio_dependencies = LazyLibrary[libsuitesparseconfig, libgcc_s]
 else
     _librbio_dependencies = LazyLibrary[libsuitesparseconfig]
@@ -117,7 +117,7 @@ else
 end
 const libcholmod = LazyLibrary(_libcholmod_path; dependencies=_libcholmod_dependencies)
 
-if Sys.iswindows()
+if Sys.iswindows() && Sys.WORD_SIZE == 32
     _libklu_dependencies = LazyLibrary[libsuitesparseconfig, libamd, libcolamd, libbtf, libgcc_s]
 else
     _libklu_dependencies = LazyLibrary[libsuitesparseconfig, libamd, libcolamd, libbtf]
@@ -133,7 +133,7 @@ else
 end
 const libspqr = LazyLibrary(_libspqr_path; dependencies=_libspqr_dependencies)
 
-if Sys.iswindows()
+if Sys.iswindows() && Sys.WORD_SIZE == 32
     _libumfpack_dependencies = LazyLibrary[libsuitesparseconfig, libamd, libcholmod, libblastrampoline, libgcc_s]
 else
     _libumfpack_dependencies = LazyLibrary[libsuitesparseconfig, libamd, libcholmod, libblastrampoline]

--- a/stdlib/Zlib_jll/src/Zlib_jll.jl
+++ b/stdlib/Zlib_jll/src/Zlib_jll.jl
@@ -12,16 +12,19 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
-libz_path::String = ""
 
-if Sys.iswindows()
-    const _libz_path = BundledLazyLibraryPath("libz.dll")
-elseif Sys.isapple()
-    const _libz_path = BundledLazyLibraryPath("libz.1.dylib")
-else
-    const _libz_path = BundledLazyLibraryPath("libz.so.1")
-end
-const libz = LazyLibrary(_libz_path)
+libz_path::String = ""
+const libz = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libz.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libz.1.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libz.so.1")
+    else
+        error("Zlib_jll: Library 'libz' is not available for $(Sys.KERNEL)")
+    end
+)
 
 function eager_mode()
     dlopen(libz)
@@ -29,7 +32,7 @@ end
 is_available() = true
 
 function __init__()
-    global libz_path = string(_libz_path)
+    global libz_path = string(libz.path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libz_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/Zstd_jll/Project.toml
+++ b/stdlib/Zstd_jll/Project.toml
@@ -3,9 +3,11 @@ uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
 version = "1.5.7+1"
 
 [deps]
+CompilerSupportLibraries_jll = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
+CompilerSupportLibraries_jll = "1.3.0"
 julia = "1.6"
 
 [extras]

--- a/stdlib/Zstd_jll/src/Zstd_jll.jl
+++ b/stdlib/Zstd_jll/src/Zstd_jll.jl
@@ -16,22 +16,24 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
+
 libzstd_path::String = ""
-
-if Sys.iswindows()
-    const _libzstd_path = BundledLazyLibraryPath("libzstd-1.dll")
-elseif Sys.isapple()
-    const _libzstd_path = BundledLazyLibraryPath("libzstd.1.dylib")
-else
-    const _libzstd_path = BundledLazyLibraryPath("libzstd.so.1")
-end
-
-if Sys.iswindows()
-    _libzstd_dependencies = LazyLibrary[libgcc_s]
-else
-    _libzstd_dependencies = LazyLibrary[]
-end
-const libzstd = LazyLibrary(_libzstd_path, dependencies=_libzstd_dependencies)
+const libzstd = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libzstd-1.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libzstd.1.dylib")
+    elseif Sys.islinux() || Sys.isfreebsd()
+        BundledLazyLibraryPath("libzstd.so.1")
+    else
+        error("Zstd_jll: Library 'libzstd' is not available for $(Sys.KERNEL)")
+    end;
+    dependencies = if Sys.iswindows()
+        LazyLibrary[libgcc_s]
+    else
+        LazyLibrary[]
+    end
+)
 
 if Sys.iswindows()
     const zstd_exe = "zstd.exe"
@@ -82,7 +84,7 @@ zstdmt() = adjust_ENV(`$(joinpath(Sys.BINDIR, Base.PRIVATE_LIBEXECDIR, zstdmt_ex
 
 # Function to eagerly dlopen our library and thus resolve all dependencies
 function eager_mode()
-    @static if Sys.iswindows()
+    @static if @isdefined CompilerSupportLibraries_jll
         CompilerSupportLibraries_jll.eager_mode()
     end
     dlopen(libzstd)
@@ -91,7 +93,7 @@ end
 is_available() = true
 
 function __init__()
-    global libzstd_path = string(_libzstd_path)
+    global libzstd_path = string(libzstd.path)
     global artifact_dir = dirname(Sys.BINDIR)
 end
 

--- a/stdlib/Zstd_jll/src/Zstd_jll.jl
+++ b/stdlib/Zstd_jll/src/Zstd_jll.jl
@@ -4,7 +4,7 @@
 #
 baremodule Zstd_jll
 using Base, Libdl
-if Sys.iswindows()
+if Sys.iswindows() && Sys.WORD_SIZE == 32
     using CompilerSupportLibraries_jll
 end
 
@@ -28,7 +28,7 @@ const libzstd = LazyLibrary(
     else
         error("Zstd_jll: Library 'libzstd' is not available for $(Sys.KERNEL)")
     end;
-    dependencies = if Sys.iswindows()
+    dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
         LazyLibrary[libgcc_s]
     else
         LazyLibrary[]

--- a/stdlib/Zstd_jll/src/Zstd_jll.jl
+++ b/stdlib/Zstd_jll/src/Zstd_jll.jl
@@ -3,7 +3,10 @@
 ## dummy stub for https://github.com/JuliaBinaryWrappers/Zstd_jll.j:
 #
 baremodule Zstd_jll
-using Base, Libdl, CompilerSupportLibraries_jll
+using Base, Libdl
+if Sys.iswindows()
+    using CompilerSupportLibraries_jll
+end
 
 export libzstd, zstd, zstdmt
 
@@ -79,10 +82,10 @@ zstdmt() = adjust_ENV(`$(joinpath(Sys.BINDIR, Base.PRIVATE_LIBEXECDIR, zstdmt_ex
 
 # Function to eagerly dlopen our library and thus resolve all dependencies
 function eager_mode()
-    dlopen(libzstd)
     @static if Sys.iswindows()
         CompilerSupportLibraries_jll.eager_mode()
     end
+    dlopen(libzstd)
 end
 
 is_available() = true

--- a/stdlib/Zstd_jll/src/Zstd_jll.jl
+++ b/stdlib/Zstd_jll/src/Zstd_jll.jl
@@ -3,7 +3,7 @@
 ## dummy stub for https://github.com/JuliaBinaryWrappers/Zstd_jll.j:
 #
 baremodule Zstd_jll
-using Base, Libdl
+using Base, Libdl, CompilerSupportLibraries_jll
 
 export libzstd, zstd, zstdmt
 
@@ -23,7 +23,12 @@ else
     const _libzstd_path = BundledLazyLibraryPath("libzstd.so.1")
 end
 
-const libzstd = LazyLibrary(_libzstd_path)
+if Sys.iswindows()
+    _libzstd_dependencies = LazyLibrary[libgcc_s]
+else
+    _libzstd_dependencies = LazyLibrary[]
+end
+const libzstd = LazyLibrary(_libzstd_path, dependencies=_libzstd_dependencies)
 
 if Sys.iswindows()
     const zstd_exe = "zstd.exe"
@@ -75,6 +80,9 @@ zstdmt() = adjust_ENV(`$(joinpath(Sys.BINDIR, Base.PRIVATE_LIBEXECDIR, zstdmt_ex
 # Function to eagerly dlopen our library and thus resolve all dependencies
 function eager_mode()
     dlopen(libzstd)
+    @static if Sys.iswindows()
+        CompilerSupportLibraries_jll.eager_mode()
+    end
 end
 
 is_available() = true

--- a/stdlib/dSFMT_jll/src/dSFMT_jll.jl
+++ b/stdlib/dSFMT_jll/src/dSFMT_jll.jl
@@ -13,17 +13,17 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
+
 libdSFMT_path::String = ""
-
-if Sys.iswindows()
-    const _libdSFMT_path = BundledLazyLibraryPath("libdSFMT.dll")
-elseif Sys.isapple()
-    const _libdSFMT_path = BundledLazyLibraryPath("libdSFMT.dylib")
-else
-    const _libdSFMT_path = BundledLazyLibraryPath("libdSFMT.so")
-end
-
-const libdSFMT = LazyLibrary(_libdSFMT_path)
+const libdSFMT = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libdSFMT.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libdSFMT.dylib")
+    else
+        BundledLazyLibraryPath("libdSFMT.so")
+    end
+)
 
 function eager_mode()
     dlopen(libdSFMT)
@@ -31,7 +31,7 @@ end
 is_available() = true
 
 function __init__()
-    global libdSFMT_path = string(_libdSFMT_path)
+    global libdSFMT_path = string(libdSFMT.path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libdSFMT_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/libLLVM_jll/src/libLLVM_jll.jl
+++ b/stdlib/libLLVM_jll/src/libLLVM_jll.jl
@@ -3,7 +3,11 @@
 ## dummy stub for https://github.com/JuliaBinaryWrappers/libLLVM_jll.jl
 
 baremodule libLLVM_jll
-using Base, Libdl, Zlib_jll, Zstd_jll, CompilerSupportLibraries_jll
+using Base, Libdl, Zlib_jll, Zstd_jll
+
+if !Sys.isapple()
+    using CompilerSupportLibraries_jll
+end
 
 export libLLVM
 
@@ -33,7 +37,9 @@ const libLLVM = LazyLibrary(
 )
 
 function eager_mode()
-    CompilerSupportLibraries_jll.eager_mode()
+    @static if @isdefined CompilerSupportLibraries_jll
+        CompilerSupportLibraries_jll.eager_mode()
+    end
     Zlib_jll.eager_mode()
     # Zstd_jll.eager_mode() # Not lazy yet
     dlopen(libLLVM)

--- a/stdlib/libLLVM_jll/src/libLLVM_jll.jl
+++ b/stdlib/libLLVM_jll/src/libLLVM_jll.jl
@@ -13,27 +13,23 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
+
 libLLVM_path::String = ""
-
-if Sys.iswindows()
-    const _libLLVM_path = BundledLazyLibraryPath("$(Base.libllvm_name).dll")
-elseif Sys.isapple()
-    const _libLLVM_path = BundledLazyLibraryPath("libLLVM.dylib")
-else
-    const _libLLVM_path = BundledLazyLibraryPath("$(Base.libllvm_name).so")
-end
-
-if Sys.isapple()
-    _libLLVM_dependencies = LazyLibrary[libz, libzstd]
-elseif Sys.isfreebsd()
-    _libLLVM_dependencies = LazyLibrary[libz, libzstd, libgcc_s]
-else
-    _libLLVM_dependencies = LazyLibrary[libz, libzstd, libstdcxx, libgcc_s]
-end
-
 const libLLVM = LazyLibrary(
-    _libLLVM_path,
-    dependencies=_libLLVM_dependencies,
+    if Sys.iswindows()
+        BundledLazyLibraryPath("$(Base.libllvm_name).dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libLLVM.dylib")
+    else
+        BundledLazyLibraryPath("$(Base.libllvm_name).so")
+    end,
+    dependencies = if Sys.isapple()
+        LazyLibrary[libz, libzstd]
+    elseif Sys.isfreebsd()
+        LazyLibrary[libz, libzstd, libgcc_s]
+    else
+        LazyLibrary[libz, libzstd, libstdcxx, libgcc_s]
+    end
 )
 
 function eager_mode()
@@ -45,7 +41,7 @@ end
 is_available() = true
 
 function __init__()
-    global libLLVM_path = string(_libLLVM_path)
+    global libLLVM_path = string(libLLVM.path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libLLVM_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/libblastrampoline_jll/src/libblastrampoline_jll.jl
+++ b/stdlib/libblastrampoline_jll/src/libblastrampoline_jll.jl
@@ -13,8 +13,6 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
-libblastrampoline_path::String = ""
-
 
 # Because LBT needs to have a weak-dependence on OpenBLAS (or any other BLAS)
 # we must manually construct a list of which modules and libraries we're going
@@ -33,16 +31,19 @@ function add_dependency!(mod::Module, lib::LazyLibrary, on_load_callback::Functi
     push!(on_load_callbacks, on_load_callback)
 end
 
-# NOTE: keep in sync with `Base.libblas_name` and `Base.liblapack_name`.
-const _libblastrampoline_path = if Sys.iswindows()
-    BundledLazyLibraryPath("libblastrampoline-5.dll")
-elseif Sys.isapple()
-    BundledLazyLibraryPath("libblastrampoline.5.dylib")
-else
-    BundledLazyLibraryPath("libblastrampoline.so.5")
-end
-const libblastrampoline = LazyLibrary(_libblastrampoline_path, dependencies=[],
-                                      on_load_callback=libblastrampoline_on_load_callback)
+libblastrampoline_path::String = ""
+const libblastrampoline = LazyLibrary(
+    # NOTE: keep in sync with `Base.libblas_name` and `Base.liblapack_name`.
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libblastrampoline-5.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libblastrampoline.5.dylib")
+    else
+        BundledLazyLibraryPath("libblastrampoline.so.5")
+    end,
+    dependencies = LazyLibrary[],
+    on_load_callback = libblastrampoline_on_load_callback
+)
 
 function eager_mode()
     for mod in eager_mode_modules
@@ -53,7 +54,7 @@ end
 is_available() = true
 
 function __init__()
-    global libblastrampoline_path = string(_libblastrampoline_path)
+    global libblastrampoline_path = string(libblastrampoline.path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libblastrampoline_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/nghttp2_jll/Project.toml
+++ b/stdlib/nghttp2_jll/Project.toml
@@ -3,10 +3,12 @@ uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
 version = "1.65.0+0"
 
 [deps]
-Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+CompilerSupportLibraries_jll = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
+CompilerSupportLibraries_jll = "1.3.0"
 julia = "1.11"
 
 [extras]

--- a/stdlib/nghttp2_jll/src/nghttp2_jll.jl
+++ b/stdlib/nghttp2_jll/src/nghttp2_jll.jl
@@ -3,7 +3,7 @@
 ## dummy stub for https://github.com/JuliaBinaryWrappers/nghttp2_jll.jl
 baremodule nghttp2_jll
 using Base, Libdl
-if Sys.iswindows()
+if Sys.iswindows() && Sys.WORD_SIZE == 32
     using CompilerSupportLibraries_jll
 end
 
@@ -25,7 +25,7 @@ const libnghttp2 = LazyLibrary(
     else
         BundledLazyLibraryPath("libnghttp2.so.14")
     end,
-    dependencies = if Sys.iswindows()
+    dependencies = if Sys.iswindows() && Sys.WORD_SIZE == 32
         LazyLibrary[libgcc_s]
     else
         LazyLibrary[]

--- a/stdlib/nghttp2_jll/src/nghttp2_jll.jl
+++ b/stdlib/nghttp2_jll/src/nghttp2_jll.jl
@@ -15,33 +15,33 @@ const PATH_list = String[]
 const LIBPATH = Ref("")
 const LIBPATH_list = String[]
 artifact_dir::String = ""
+
 libnghttp2_path::String = ""
-
-if Sys.iswindows()
-    const _libnghttp2_path = BundledLazyLibraryPath("libnghttp2-14.dll")
-elseif Sys.isapple()
-    const _libnghttp2_path = BundledLazyLibraryPath("libnghttp2.14.dylib")
-else
-    const _libnghttp2_path = BundledLazyLibraryPath("libnghttp2.so.14")
-end
-
-if Sys.iswindows()
-    _libnghttp2_dependencies = LazyLibrary[libgcc_s]
-else
-    _libnghttp2_dependencies = LazyLibrary[]
-end
-const libnghttp2 = LazyLibrary(_libnghttp2_path, dependencies=_libnghttp2_dependencies)
+const libnghttp2 = LazyLibrary(
+    if Sys.iswindows()
+        BundledLazyLibraryPath("libnghttp2-14.dll")
+    elseif Sys.isapple()
+        BundledLazyLibraryPath("libnghttp2.14.dylib")
+    else
+        BundledLazyLibraryPath("libnghttp2.so.14")
+    end,
+    dependencies = if Sys.iswindows()
+        LazyLibrary[libgcc_s]
+    else
+        LazyLibrary[]
+    end
+)
 
 function eager_mode()
-    dlopen(libnghttp2)
-    @static if Sys.iswindows()
+    @static if @isdefined CompilerSupportLibraries_jll
         CompilerSupportLibraries_jll.eager_mode()
     end
+    dlopen(libnghttp2)
 end
 is_available() = true
 
 function __init__()
-    global libnghttp2_path = string(_libnghttp2_path)
+    global libnghttp2_path = string(libnghttp2.path)
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libnghttp2_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/nghttp2_jll/src/nghttp2_jll.jl
+++ b/stdlib/nghttp2_jll/src/nghttp2_jll.jl
@@ -2,7 +2,10 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/nghttp2_jll.jl
 baremodule nghttp2_jll
-using Base, Libdl, CompilerSupportLibraries_jll
+using Base, Libdl
+if Sys.iswindows()
+    using CompilerSupportLibraries_jll
+end
 
 export libnghttp2
 
@@ -31,7 +34,9 @@ const libnghttp2 = LazyLibrary(_libnghttp2_path, dependencies=_libnghttp2_depend
 
 function eager_mode()
     dlopen(libnghttp2)
-    Sys.iswindows() && CompilerSupportLibraries_jll.eager_mode()
+    @static if Sys.iswindows()
+        CompilerSupportLibraries_jll.eager_mode()
+    end
 end
 is_available() = true
 

--- a/stdlib/nghttp2_jll/src/nghttp2_jll.jl
+++ b/stdlib/nghttp2_jll/src/nghttp2_jll.jl
@@ -2,7 +2,7 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/nghttp2_jll.jl
 baremodule nghttp2_jll
-using Base, Libdl
+using Base, Libdl, CompilerSupportLibraries_jll
 
 export libnghttp2
 
@@ -22,10 +22,16 @@ else
     const _libnghttp2_path = BundledLazyLibraryPath("libnghttp2.so.14")
 end
 
-const libnghttp2 = LazyLibrary(_libnghttp2_path)
+if Sys.iswindows()
+    _libnghttp2_dependencies = LazyLibrary[libgcc_s]
+else
+    _libnghttp2_dependencies = LazyLibrary[]
+end
+const libnghttp2 = LazyLibrary(_libnghttp2_path, dependencies=_libnghttp2_dependencies)
 
 function eager_mode()
     dlopen(libnghttp2)
+    Sys.iswindows() && CompilerSupportLibraries_jll.eager_mode()
 end
 is_available() = true
 

--- a/test/stdlib_dependencies.jl
+++ b/test/stdlib_dependencies.jl
@@ -250,7 +250,7 @@ try
                     # This is a manually-managed special case
                     if stdlib_name == "libblastrampoline_jll" &&
                        prop_name == :libblastrampoline &&
-                       extraneous_deps == ["libopenblas64_"]
+                       extraneous_deps in (["libopenblas64_"], ["libopenblas"])
                         deps_mismatch = false
                     end
 

--- a/test/stdlib_dependencies.jl
+++ b/test/stdlib_dependencies.jl
@@ -173,7 +173,11 @@ try
             "vcruntime140",
             "msvcp140",
             "libwinpthread",
-            "ntdll"
+            "ntdll",
+            "crypt32",
+            "bcrypt",
+            "winhttp",
+            "secur32",
         ]
         return any(syslib -> lowercase(lib) == syslib, system_libs)
     end

--- a/test/stdlib_dependencies.jl
+++ b/test/stdlib_dependencies.jl
@@ -26,6 +26,7 @@ try
                             lib_name = last(split(lib_name, "@rpath/"))
                             # Get basename
                             lib_name = basename(lib_name)
+                            isempty(splitext(lib_name)[2]) && continue # skip frameworks
                             push!(raw_libs, lib_name)
                         end
                     end

--- a/test/stdlib_dependencies.jl
+++ b/test/stdlib_dependencies.jl
@@ -1,202 +1,219 @@
-using Pkg, Test, Libdl
+using Libdl
+using Pkg
+using Test
+prev_env = Base.active_project()
+Pkg.activate(temp=true)
+Pkg.add(Pkg.PackageSpec(name="ObjectFile", uuid="d8793406-e978-5875-9003-1fc021f44a92"))
+using ObjectFile
+try
 
-# Remove `.X.dylib` or just `.dylib`
-function strip_soversion_macos(lib)
-    m = match(r"^(.*?)(\.\d+)*\.dylib$", lib)
-    if m !== nothing
-        return m.captures[1]
-    end
-    return lib
-end
-
-# Remove `.so.X` or just `.so`
-function strip_soversion_linux(lib)
-    m = match(r"^(.*?)\.so(\.\d+)*$", lib)
-    if m !== nothing
-        return m.captures[1]
-    end
-    return lib
-end
-
-# Remove `-X.dll` or just `.dll`
-function strip_soversion_windows(lib)
-    m = match(r"^(.*?)(-\d+)*\.dll$", lib)
-    if m !== nothing
-        return m.captures[1]
-    end
-    return lib
-end
-
-
-function get_deps_otool(lib_path::String)
-    libs = split(readchomp(`otool -L $(lib_path)`), "\n")[2:end]
-    # Get rid of `(compatibility version x.y.x)` at the end
-    libs = first.(split.(libs, (" (compatibility",)))
-    # Get rid of any `@rpath/` stuff at the beginning
-    libs = last.(split.(libs, ("@rpath/",)))
-
-    # If there are any absolute paths left, get rid of them here
-    libs = basename.(strip.(libs))
-
-    # Now that we've got the basenames of each library, remove `.x.dylib` if it exists:
-    libs = strip_soversion_macos.(libs)
-
-    # Get rid of any self-referential links
-    self_lib = strip_soversion_macos(basename(lib_path))
-    libs = filter(!=(self_lib), libs)
-    return libs
-end
-
-function is_system_lib_macos(lib)
-    system_libs = [
-        "libSystem.B",
-        "libc++", # While we package libstdc++, we do NOT package libc++.
-        "libiconv", # some things (like git) link against system libiconv
-
-        # macOS frameworks used by things like LibCurl
-        "CoreFoundation",
-        "CoreServices",
-        "Security",
-        "SystemConfiguration"
-    ]
-    return lib ∈ system_libs
-end
-
-function is_system_lib_linux(lib)
-    system_libs = [
-        "libdl",
-        "libc",
-        "libm",
-        "librt",
-        "libpthread",
-        "ld-linux-x86-64",
-        "ld-linux-x86",
-        "ld-linux-aarch64",
-        "ld-linux-armhf",
-        "ld-linux-i386",
-    ]
-    return lib ∈ system_libs
-end
-
-function is_system_lib_freebsd(lib)
-    system_libs = [
-        "libdl",
-        "libc",
-        "libm",
-        "libthr",      # primary threading library
-        "libpthread",  # alias kept for compatibility
-        "librt",
-        "libutil",
-        "libexecinfo",
-        "libc++",
-        "libcxxrt",
-    ]
-    return lib ∈ system_libs
-end
-
-function get_deps_readelf(lib_path::String)
-    # Split into lines
-    libs = split(readchomp(`readelf -d $(lib_path)`), "\n")
-
-    # Only keep `(NEEDED)` lines
-    needed_str = Sys.isfreebsd() ? "NEEDED" : "(NEEDED)"
-    libs = filter(contains(needed_str), libs)
-
-    # Grab the SONAME from "Shared library: [$SONAME]"
-    libs = map(libs) do lib
-        m = match(r"Shared library: \[(.*)\]$", lib)
+    # Remove `.X.dylib` or just `.dylib`
+    function strip_soversion_macos(lib)
+        m = match(r"^(.*?)(\.\d+)*\.dylib$", lib)
         if m !== nothing
-            return basename(m.captures[1])
+            return m.captures[1]
         end
-        return ""
+        return lib
     end
-    libs = filter(!isempty, strip.(libs))
 
-    # Get rid of soversions in the filenames
-    libs = strip_soversion_linux.(libs)
-    return libs
-end
-
-function get_deps_dumpbin(lib_path::String)
-    # Use dumpbin to get the imports from a Windows DLL
-    libs = split(readchomp(`dumpbin /imports $(lib_path)`), "\n")
-    libs = filter(contains("dll"), libs)
-    libs = map(libs) do lib
-        m = match(r"\s+(\S+\.dll)$"i, lib)
+    # Remove `.so.X` or just `.so`
+    function strip_soversion_linux(lib)
+        m = match(r"^(.*?)\.so(\.\d+)*$", lib)
         if m !== nothing
-            return lowercase(m.captures[1])
+            return m.captures[1]
         end
-        return ""
+        return lib
     end
-    libs = filter(!isempty, strip.(libs))
-    libs = strip_soversion_windows.(libs)
-    # Remove self-reference
-    self_lib = strip_soversion_windows(lowercase(basename(lib_path)))
-    libs = filter(!=(self_lib), libs)
-    return libs
-end
 
-function is_system_lib_windows(lib)
-    system_libs = [
-        "kernel32",
-        "user32",
-        "gdi32",
-        "advapi32",
-        "ole32",
-        "oleaut32",
-        "shell32",
-        "ws2_32",
-        "comdlg32",
-        "shlwapi",
-        "rpcrt4",
-        "msvcrt",
-        "comctl32",
-        "ucrtbase",
-        "vcruntime140",
-        "msvcp140"
-    ]
-    return any(syslib -> lowercase(lib) == syslib, system_libs)
-end
+    # Remove `-X.dll` or just `.dll`
+    function strip_soversion_windows(lib)
+        m = match(r"^(.*?)(-\d+)*\.dll$", lib)
+        if m !== nothing
+            return m.captures[1]
+        end
+        return lib
+    end
 
-throw_no_test = true
-skip = false
-# Check for required tools based on platform
-if Sys.islinux() || Sys.isfreebsd()
-    if Sys.which("readelf") === nothing
-        throw_no_test && error("`readelf` is required to run `stdlib_dependencies.jl` on Linux or FreeBSD.")
-        @debug("Silently skipping stdlib_dependencies.jl as `readelf` not available.")
-        skip = true
-    end
-    get_deps = get_deps_readelf
-    strip_soversion = strip_soversion_linux
-    is_system_lib = Sys.islinux() ? is_system_lib_linux : is_system_lib_freebsd
-elseif Sys.isapple()
-    # On macOS, we need `otool` available
-    if Sys.which("otool") === nothing
-        throw_no_test && error("`otool` is required to run `stdlib_dependencies.jl` on macOS.")
-        @debug("Silently skipping stdlib_dependencies.jl as `otool` not available.")
-        skip = true
-    end
-    get_deps = get_deps_otool
-    strip_soversion = strip_soversion_macos
-    is_system_lib = is_system_lib_macos
-elseif Sys.iswindows()
-    # On Windows, we need `dumpbin` available
-    if Sys.which("dumpbin") === nothing
-        throw_no_test && error("`dumpbin` is required to run `stdlib_dependencies.jl` on Windows.")
-        @debug("Silently skipping stdlib_dependencies.jl as `dumpbin` not available.")
-        skip = true
-    end
-    get_deps = get_deps_dumpbin
-    strip_soversion = strip_soversion_windows
-    is_system_lib = is_system_lib_windows
-else
-    throw_no_test && error("Unsupported platform for `stdlib_dependencies.jl`. Only Linux, FreeBSD, macOS, and Windows are supported.")
-    @debug("Don't know how to run `stdlib_dependencies.jl` on this platform")
-    skip = true
-end
+    function get_deps_objectfile_macos(lib_path::String)
+        open(lib_path, "r") do io
+            obj_handles = readmeta(io)
+            obj = only(obj_handles)  # If more than one its unclear what to do
+            raw_libs = String[]
 
-if !skip
+            # For Mach-O files, get load commands
+            if isa(obj, ObjectFile.MachOHandle)
+                for lc in ObjectFile.MachOLoadCmds(obj)
+                    if lc isa ObjectFile.MachO.MachOLoadDylibCmd
+                        # Extract the library name from the load command
+                        lib_name = ObjectFile.dylib_name(lc)
+                        if lib_name !== nothing
+                            # Remove @rpath/ prefix if present
+                            lib_name = last(split(lib_name, "@rpath/"))
+                            # Get basename
+                            lib_name = basename(lib_name)
+                            push!(raw_libs, lib_name)
+                        end
+                    end
+                end
+            end
+
+            libs = strip_soversion_macos.(raw_libs)
+            # Get rid of any self-referential links
+            self_lib = strip_soversion_macos(basename(lib_path))
+            libs = filter(!=(self_lib), libs)
+            return libs
+        end
+    end
+
+    function get_deps_objectfile_linux_freebsd(lib_path::String)
+        open(lib_path, "r") do io
+            obj_handles = readmeta(io)
+            obj = first(obj_handles)  # Take the first handle from the vector
+            raw_libs = String[]
+
+            # For ELF files, get dynamic dependencies
+            if isa(obj, ObjectFile.ELFHandle)
+                # Get all dynamic entries
+                dyn_entries = ObjectFile.ELFDynEntries(obj)
+                for entry in dyn_entries
+                    # Check if the entry is of type DT_NEEDED
+                    if ObjectFile.dyn_entry_type(entry) == ObjectFile.ELF.DT_NEEDED
+                        lib_name = ObjectFile.strtab_lookup(entry)
+                        if lib_name !== nothing && !isempty(lib_name)
+                            push!(raw_libs, basename(lib_name))
+                        end
+                    end
+                end
+            end
+
+            libs = strip_soversion_linux.(raw_libs)
+            # Self-reference is typically not listed in NEEDED for ELF, so no explicit filter here.
+            return libs
+        end
+    end
+
+    function get_deps_objectfile_windows(lib_path::String)
+        open(lib_path, "r") do io
+            obj_handles = readmeta(io)
+            obj = first(obj_handles)  # Take the first handle from the vector
+            raw_libs_set = Set{String}() # Use Set for uniqueness of DLL names
+
+            # For COFF/PE files, get import table
+            if isa(obj, ObjectFile.COFFHandle)
+                # Get dynamic links
+                dls = ObjectFile.DynamicLinks(obj)
+                for link in dls
+                    lib_name = ObjectFile.path(link)
+                    if lib_name !== nothing && !isempty(lib_name)
+                        # COFF library names are case-insensitive
+                        push!(raw_libs_set, lowercase(lib_name))
+                    end
+                end
+            end
+
+            libs = strip_soversion_windows.(collect(raw_libs_set))
+            # Remove self-reference
+            self_lib = strip_soversion_windows(lowercase(basename(lib_path)))
+            libs = filter(!=(self_lib), libs)
+            return libs
+        end
+    end
+
+    function get_deps_objectfile(lib_path::String)
+        if Sys.isapple()
+            return get_deps_objectfile_macos(lib_path)
+        elseif Sys.islinux() || Sys.isfreebsd()
+            return get_deps_objectfile_linux_freebsd(lib_path)
+        elseif Sys.iswindows()
+            return get_deps_objectfile_windows(lib_path)
+        else
+            error("Unsupported platform for ObjectFile.jl dependency extraction")
+        end
+    end
+
+    function is_system_lib_macos(lib)
+        system_libs = [
+            "libSystem.B",
+            "libc++", # While we package libstdc++, we do NOT package libc++.
+            "libiconv", # some things (like git) link against system libiconv
+
+            # macOS frameworks used by things like LibCurl
+            "CoreFoundation",
+            "CoreServices",
+            "Security",
+            "SystemConfiguration"
+        ]
+        return lib ∈ system_libs
+    end
+
+    function is_system_lib_linux(lib)
+        system_libs = [
+            "libdl",
+            "libc",
+            "libm",
+            "librt",
+            "libpthread",
+            "ld-linux-x86-64",
+            "ld-linux-x86",
+            "ld-linux-aarch64",
+            "ld-linux-armhf",
+            "ld-linux-i386",
+        ]
+        return lib ∈ system_libs
+    end
+
+    function is_system_lib_freebsd(lib)
+        system_libs = [
+            "libdl",
+            "libc",
+            "libm",
+            "libthr",      # primary threading library
+            "libpthread",  # alias kept for compatibility
+            "librt",
+            "libutil",
+            "libexecinfo",
+            "libc++",
+            "libcxxrt",
+        ]
+        return lib ∈ system_libs
+    end
+
+    function is_system_lib_windows(lib)
+        system_libs = [
+            "kernel32",
+            "user32",
+            "gdi32",
+            "advapi32",
+            "ole32",
+            "oleaut32",
+            "shell32",
+            "ws2_32",
+            "comdlg32",
+            "shlwapi",
+            "rpcrt4",
+            "msvcrt",
+            "comctl32",
+            "ucrtbase",
+            "vcruntime140",
+            "msvcp140"
+        ]
+        return any(syslib -> lowercase(lib) == syslib, system_libs)
+    end
+
+    # Set up platform-specific functions
+    if Sys.islinux() || Sys.isfreebsd()
+        strip_soversion = strip_soversion_linux
+        is_system_lib = Sys.islinux() ? is_system_lib_linux : is_system_lib_freebsd
+    elseif Sys.isapple()
+        strip_soversion = strip_soversion_macos
+        is_system_lib = is_system_lib_macos
+    elseif Sys.iswindows()
+        strip_soversion = strip_soversion_windows
+        is_system_lib = is_system_lib_windows
+    else
+        error("Unsupported platform for `stdlib_dependencies.jl`. Only Linux, FreeBSD, macOS, and Windows are supported.")
+    end
+
     # Iterate over all JLL stdlibs, check their lazy libraries to ensure
     # that they list all valid library dependencies, avoiding a situation
     # where the JLL wrapper code has fallen out of sync with the binaries
@@ -218,7 +235,7 @@ if !skip
                 if isa(prop, Libdl.LazyLibrary)
                     lib_path = dlpath(prop)
                     lazy_lib_deps = strip_soversion.(basename.(dlpath.(prop.dependencies)))
-                    real_lib_deps = filter(!is_system_lib, get_deps(lib_path))
+                    real_lib_deps = filter(!is_system_lib, get_deps_objectfile(lib_path))
 
                     # See if there are missing dependencies in the lazy library deps
                     missing_deps = setdiff(real_lib_deps, lazy_lib_deps)
@@ -229,8 +246,8 @@ if !skip
 
                     # This is a manually-managed special case
                     if stdlib_name == "libblastrampoline_jll" &&
-                    prop_name == :libblastrampoline &&
-                    extraneous_deps == ["libopenblas64_"]
+                       prop_name == :libblastrampoline &&
+                       extraneous_deps == ["libopenblas64_"]
                         deps_mismatch = false
                     end
 
@@ -239,15 +256,23 @@ if !skip
                     # Print out the deps mismatch if we find one
                     if deps_mismatch
                         @warn("Dependency mismatch",
-                            jll=stdlib_name,
-                            library=string(prop_name),
-                            missing_deps=join(missing_deps, ", "),
-                            extraneous_deps=join(extraneous_deps, ", "),
-                            actual_deps=join(real_lib_deps, ", "),
+                            jll = stdlib_name,
+                            library = string(prop_name),
+                            missing_deps = join(missing_deps, ", "),
+                            extraneous_deps = join(extraneous_deps, ", "),
+                            actual_deps = join(real_lib_deps, ", "),
                         )
                     end
                 end
             end
         end
+    end
+
+finally
+    if prev_env !== nothing
+        Pkg.activate(prev_env)
+    else
+        # If no previous environment, activate the default one
+        Pkg.activate()
     end
 end

--- a/test/stdlib_dependencies.jl
+++ b/test/stdlib_dependencies.jl
@@ -3,7 +3,7 @@ using Pkg
 using Test
 prev_env = Base.active_project()
 Pkg.activate(temp=true)
-Pkg.add(Pkg.PackageSpec(name="ObjectFile", uuid="d8793406-e978-5875-9003-1fc021f44a92"))
+Pkg.add(Pkg.PackageSpec(name="ObjectFile", uuid="d8793406-e978-5875-9003-1fc021f44a92", version="0.4"))
 using ObjectFile
 try
 

--- a/test/stdlib_dependencies.jl
+++ b/test/stdlib_dependencies.jl
@@ -195,7 +195,9 @@ try
             "comctl32",
             "ucrtbase",
             "vcruntime140",
-            "msvcp140"
+            "msvcp140",
+            "libwinpthread",
+            "ntdll"
         ]
         return any(syslib -> lowercase(lib) == syslib, system_libs)
     end

--- a/test/stdlib_dependencies.jl
+++ b/test/stdlib_dependencies.jl
@@ -153,6 +153,7 @@ try
             "libm",
             "librt",
             "libpthread",
+            "ld-linux",
             "ld-linux-x86-64",
             "ld-linux-x86",
             "ld-linux-aarch64",

--- a/test/stdlib_dependencies.jl
+++ b/test/stdlib_dependencies.jl
@@ -268,6 +268,10 @@ try
                     end
                 end
             end
+            if isdefined(m, :eager_mode)
+                # If the JLL has an eager_mode function, call it
+                Base.invokelatest(getproperty(m, :eager_mode))
+            end
         end
     end
 


### PR DESCRIPTION
- Extends testing added in https://github.com/JuliaLang/julia/pull/58444 to Windows
- Uses ObjectFile.jl instead of relying on system libs being installed
- Reworks the JLLs to be a bit easier to work with, and not have global internal objects