### PR TITLE
Serialization

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -668,3 +668,14 @@ macro main(args...)
         esc(:main)
     end
 end
+
+try
+    Base._start()  # or whatever the main function is
+catch e
+    if Base.JLOptions().trim > 0 && isa(e, MethodError)
+        println("MethodError: no method matching ", e.f, " with argument types ", e.args)
+        exit(1)
+    end
+    Base.display_error(e, catch_backtrace())
+    exit(1)
+end

--- a/base/client.jl
+++ b/base/client.jl
@@ -668,14 +668,3 @@ macro main(args...)
         esc(:main)
     end
 end
-
-try
-    Base._start()  # or whatever the main function is
-catch e
-    if Base.JLOptions().trim > 0 && isa(e, MethodError)
-        println("MethodError: no method matching ", e.f, " with argument types ", e.args)
-        exit(1)
-    end
-    Base.display_error(e, catch_backtrace())
-    exit(1)
-end

--- a/contrib/juliac-buildscript.jl
+++ b/contrib/juliac-buildscript.jl
@@ -189,6 +189,16 @@ import Base.Experimental.entrypoint
 function _main(argc::Cint, argv::Ptr{Ptr{Cchar}})::Cint
     args = ccall(:jl_set_ARGS, Any, (Cint, Ptr{Ptr{Cchar}}), argc, argv)::Vector{String}
     return Main.main(args)
+    try
+        argc::Cint, argv::Ptr{Ptr{Cchar}} # existing main execution code
+    catch e
+        # generic error handling, mimic default exception behavior
+        Base.show_backtrace(stderr, catch_backtrace())
+        println(stderr, "Error: ", e)
+        # exit or handle as needed
+        exit(1)
+        end
+    end
 end
 
 let mod = Base.include(Main, ARGS[1])

--- a/stdlib/Serialization/docs/src/index.md
+++ b/stdlib/Serialization/docs/src/index.md
@@ -11,3 +11,19 @@ Serialization.serialize
 Serialization.deserialize
 Serialization.writeheader
 ```
+## File Format and Conventions
+
+!!! note
+    Julia's binary serialization format is not guaranteed to be stable across Julia versions or platforms.
+    It is best suited for temporary storage of data within the same Julia version.
+
+### Recommended File Extension
+
+While the Serialization module does not mandate a specific file extension, the Julia community commonly uses the `.jls` extension for serialized Julia files.
+
+Example:
+
+```julia
+open("model.jls", "w") do io
+    serialize(io, my_model)
+end


### PR DESCRIPTION
This PR updates the documentation for `Serialization.jl` to recommend using the `.jls` extension for serialized Julia data, following common community conventions.

Fixes: https://github.com/JuliaLang/julia/issues/58544