### PR TITLE
Add world age hint for UndefVarError

### DIFF
--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -943,6 +943,24 @@ end
     @test_throws expected_message X.x
 end
 
+# Module for UndefVarError world age testing
+module TestWorldAgeUndef end
+
+@testset "UndefVarError world age hint" begin
+    ex = try
+        TestWorldAgeUndef.newvar
+    catch e
+        e
+    end
+    @test ex isa UndefVarError
+
+    Core.eval(TestWorldAgeUndef, :(newvar = 42))
+
+    err_str = sprint(Base.showerror, ex)
+    @test occursin("The binding may be too new: running in world age", err_str)
+    @test occursin("while current world is", err_str)
+end
+
 # test showing MethodError with type argument
 struct NoMethodsDefinedHere; end
 let buf = IOBuffer()


### PR DESCRIPTION
Similar to the existing world age hint for MethodError, this adds
a helpful message when an UndefVarError occurs because a binding
was defined in a newer world age than the code trying to access it.

The implementation checks if a binding that was undefined at the
error's world age is now defined in the current world, and displays:
"The binding may be too new: running in world age X, while current
world is Y."

Additionally, for all binding kinds, the error hint now notes when
the binding state has changed between the error's world and the
current world.

🤖 Generated with [Claude Code](https://claude.ai/code)