### PR TITLE
Work around LLVM JITLink stack overflow issue.

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -689,7 +689,10 @@ static void jl_compile_codeinst_now(jl_code_instance_t *codeinst)
             if (!decls.specFunctionObject.empty())
                 NewDefs.push_back(decls.specFunctionObject);
         }
-            // Split batches to avoid stack overflow in the JIT linker.
+        // Split batches to avoid stack overflow in the JIT linker.
+        // FIXME: Patch ORCJITs InPlaceTaskDispatcher to not recurse on task dispatches but
+        // push the tasks to a queue to be drained later. This avoids the stackoverflow caused by recursion
+        // in the linker when compiling a large number of functions at once.
         SmallVector<uint64_t, 0> Addrs;
         for (size_t i = 0; i < NewDefs.size(); i += 1000) {
             auto end = std::min(i + 1000, NewDefs.size());

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1268,3 +1268,6 @@ end
         end
     end
 end
+
+# https://github.com/JuliaLang/julia/issues/58229 Recursion in jitlinkin with inline=no
+@test success(`$(Base.julia_cmd()) --inline=no -e 'Base.compilecache(Base.identify_package("Pkg"))'`)

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1269,5 +1269,5 @@ end
     end
 end
 
-# https://github.com/JuliaLang/julia/issues/58229 Recursion in jitlinkin with inline=no
+# https://github.com/JuliaLang/julia/issues/58229 Recursion in jitlinking with inline=no
 @test success(`$(Base.julia_cmd()) --inline=no -e 'Base.compilecache(Base.identify_package("Pkg"))'`)


### PR DESCRIPTION
The JITLinker recurses for every symbol in the list so limit the size of the list

This is kind of ugly. Also 1000 might be too large, we don't want to go too small because that wastes memory and 1000 was fine locally for the things I tested.

Fixes https://github.com/JuliaLang/julia/issues/58229