### PR TITLE
RFC: stop wrapping unreachable statements in `Const`

### DIFF
--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -1245,8 +1245,7 @@ function convert_to_ircode(ci::CodeInfo, sv::OptimizationState)
             empty!(sv.cfg.blocks[block].succs)
 
             if !(idx < length(code) && isa(code[idx + 1], ReturnNode) && !isdefined((code[idx + 1]::ReturnNode), :val))
-                # Any statements from here to the end of the block have been wrapped in Core.Const(...)
-                # by type inference (effectively deleting them). Only task left is to replace the block
+                # Any statements from here to the end of the block are unreachable. Replace the block
                 # terminator with an explicit `unreachable` marker.
 
                 if block_end > idx

--- a/Compiler/src/ssair/slot2ssa.jl
+++ b/Compiler/src/ssair/slot2ssa.jl
@@ -638,10 +638,10 @@ function construct_ssa!(ci::CodeInfo, ir::IRCode, sv::OptimizationState,
         end
         phiblocks = iterated_dominance_frontier(cfg, live, domtree)
         for block in phiblocks
+            varstate = sv.bb_vartables[block]
+            varstate === nothing && continue
             push!(phi_slots[block], idx)
             node = PhiNode()
-            varstate = sv.bb_vartables[block]
-            @assert varstate !== nothing
             vt = varstate[idx]
             ssaval = NewSSAValue(insert_node!(ir,
                 first_insert_for_bb(code, cfg, block), NewInstruction(node, vt.typ)).id - length(ir.stmts))

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -870,9 +870,8 @@ function type_annotate!(interp::AbstractInterpreter, sv::InferenceState)
             if is_meta_expr(expr) # keep any lexically scoped expressions
                 ssavaluetypes[i] = Any # 3
             else
-                ssavaluetypes[i] = Bottom # 3
                 # annotate that this statement actually is dead
-                stmts[i] = Const(expr)
+                ssavaluetypes[i] = Bottom # 3
             end
         end
     end


### PR DESCRIPTION
This does not make sense semantically, and we have better sources of reachability info now. The biggest concrete problem is that it makes code_warntype output confusing, e.g.

```
1 ─ %1 = Main.throw::Core.Const(throw)
│   %2 = Main.AssertionError::Core.Const(AssertionError)
│   %3 = Base.string("x1=", x1)::String
│   %4 = (%2)(%3)::Core.PartialStruct(AssertionError, Any[String])
│        (%1)(%4)
└──      Core.Const(:(return %5))
```

where the final unreachable `return` statement looks like a type.

What I have here seems to work (passes Compiler tests) but I need some help because I don't think it's optimal. The change in `construct_ssa!` is not quite right since iterated_dominance_frontier is now reaching unreachable statements that it skipped before, but I haven't yet figured out how it's depending on the `Const` wrapping for that.