### PR TITLE
Finer grained precompile native code cache (part 1)

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -2642,7 +2642,7 @@ void jl_dump_native_impl(void *native_code,
         };
 
         write_output(unopt_bc_fname, "unopt_", ".bc", std::mem_fn(&AOTOutputs::unopt));
-        write_output(unopt_bc_fname, "opt_", ".bc", std::mem_fn(&AOTOutputs::opt));
+        write_output(bc_fname, "opt_", ".bc", std::mem_fn(&AOTOutputs::opt));
         write_output(obj_fname, "", ".o", std::mem_fn(&AOTOutputs::obj));
         write_output(asm_fname, "", ".s", std::mem_fn(&AOTOutputs::asm_));
     }

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -249,6 +249,8 @@ static GlobalVariable *emit_plt_thunk(
                                              GlobalVariable::ExternalLinkage,
                                              plt,
                                              fname + "_got");
+    // Should be hidden to avoid indirect through the non-julia GOT
+    got->setVisibility(GlobalVariable::HiddenVisibility);
     if (runtime_lib) {
         got->addAttribute("julia.libname", f_lib);
     } else {

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -249,7 +249,7 @@ static GlobalVariable *emit_plt_thunk(
                                              GlobalVariable::ExternalLinkage,
                                              plt,
                                              fname + "_got");
-    // Should be hidden to avoid indirect through the non-julia GOT
+    // Should be hidden to avoid indirection through the non-julia GOT
     got->setVisibility(GlobalVariable::HiddenVisibility);
     if (runtime_lib) {
         got->addAttribute("julia.libname", f_lib);

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -84,7 +84,7 @@ static bool runtime_sym_gvs(jl_codectx_t &ctx, const char *f_lib, const char *f_
     else {
         std::string name = "ccalllib_";
         name += llvm::sys::path::filename(f_lib);
-        freshen_name(name);
+        name += std::to_string(jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1));
         runtime_lib = true;
         auto &libgv = ctx.emission_context.libMapGV[f_lib];
         if (libgv.first == NULL) {
@@ -104,7 +104,7 @@ static bool runtime_sym_gvs(jl_codectx_t &ctx, const char *f_lib, const char *f_
         std::string name = "ccall_";
         name += f_name;
         name += "_";
-        freshen_name(name);
+        name += std::to_string(jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1));
         auto T_pvoidfunc = getPointerTy(M->getContext());
         llvmgv = new GlobalVariable(*M, T_pvoidfunc, false,
                                     GlobalVariable::ExternalLinkage,
@@ -209,7 +209,7 @@ static Value *runtime_sym_lookup(
         std::string gvname = "libname_";
         gvname += f_name;
         gvname += "_";
-        freshen_name(gvname);
+        gvname += std::to_string(jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1));
         llvmgv = new GlobalVariable(*jl_Module, T_pvoidfunc, false,
                                     GlobalVariable::ExternalLinkage,
                                     Constant::getNullValue(T_pvoidfunc), gvname);
@@ -237,8 +237,7 @@ static GlobalVariable *emit_plt_thunk(
     libptrgv = prepare_global_in(M, libptrgv);
     llvmgv = prepare_global_in(M, llvmgv);
     std::string fname;
-    raw_string_ostream(fname) << "jlplt_" << f_name;
-    freshen_name(fname);
+    raw_string_ostream(fname) << "jlplt_" << f_name << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
     Function *plt = Function::Create(functype,
                                      GlobalVariable::PrivateLinkage,
                                      fname, M);
@@ -838,8 +837,8 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
     std::string ir_name;
     while (true) {
         raw_string_ostream(ir_name)
-            << (ctx.f->getName().str()) << "u";
-        freshen_name(ir_name);
+            << (ctx.f->getName().str()) << "u"
+            << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
         if (jl_Module->getFunction(ir_name) == NULL)
             break;
     }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -491,10 +491,7 @@ Constant *literal_pointer_val_slot(jl_codegen_params_t &params, Module *M, jl_va
         return julia_pgv(params, M, "jl_sym#", addr, NULL, p);
     }
     // something else gets just a generic name
-    std::string name;
-    auto dt = (jl_datatype_t *)jl_typeof(p);
-    raw_string_ostream(name) << "jl_global_" << jl_symbol_name(dt->name->name);
-    return julia_pgv(params, M, name.c_str(), p);
+    return julia_pgv(params, M, "jl_global#", p);
 }
 
 static size_t dereferenceable_size(jl_value_t *jt)

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -401,8 +401,8 @@ static Constant *julia_pgv(jl_codegen_params_t &params, Module *M, const char *c
     StringRef localname;
     std::string gvname;
     if (!gv) {
-        raw_string_ostream(gvname) << cname;
-        freshen_name(gvname);
+        uint64_t id = jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1); // TODO: use params.global_targets.size()
+        raw_string_ostream(gvname) << cname << id;
         localname = StringRef(gvname);
     }
     else {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -401,8 +401,8 @@ static Constant *julia_pgv(jl_codegen_params_t &params, Module *M, const char *c
     StringRef localname;
     std::string gvname;
     if (!gv) {
-        uint64_t id = jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1); // TODO: use params.global_targets.size()
-        raw_string_ostream(gvname) << cname << id;
+        raw_string_ostream(gvname) << cname;
+        freshen_name(gvname);
         localname = StringRef(gvname);
     }
     else {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -491,7 +491,10 @@ Constant *literal_pointer_val_slot(jl_codegen_params_t &params, Module *M, jl_va
         return julia_pgv(params, M, "jl_sym#", addr, NULL, p);
     }
     // something else gets just a generic name
-    return julia_pgv(params, M, "jl_global#", p);
+    std::string name;
+    auto dt = (jl_datatype_t *)jl_typeof(p);
+    raw_string_ostream(name) << "jl_global_" << jl_symbol_name(dt->name->name);
+    return julia_pgv(params, M, name.c_str(), p);
 }
 
 static size_t dereferenceable_size(jl_value_t *jt)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7306,6 +7306,8 @@ static Function *gen_cfun_wrapper(
             funcName, M);
     jl_init_function(cw, params.TargetTriple);
     cw->setAttributes(AttributeList::get(M->getContext(), {attributes, cw->getAttributes()}));
+    // funcName should not be directly accessible from C and must be mangled
+    cw->setVisibility(Function::HiddenVisibility);
 
     jl_codectx_t ctx(M->getContext(), params, 0, 0);
     ctx.f = cw;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1576,7 +1576,18 @@ static const auto &builtin_func_map() {
     return *builtins;
 }
 
-static _Atomic(uint64_t) globalUniqueGeneratedNames{1};
+static StringMap<uint64_t> fresh_name_map;
+static std::mutex fresh_name_lock;
+
+static void freshen_name(std::string &name)
+{
+    uint64_t n;
+    {
+        std::lock_guard guard{fresh_name_lock};
+        n = fresh_name_map[name]++;
+    }
+    raw_string_ostream(name) << "_" << n;
+}
 
 // --- code generation ---
 
@@ -5271,7 +5282,8 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, ArrayR
                         else if (always_inline)
                             need_to_emit = true;
                         if (protoname.empty()) {
-                            raw_string_ostream(name) << (specsig ? "j_" : "j1_") << name_from_method_instance(mi) << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
+                            raw_string_ostream(name) << (specsig ? "j_" : "j1_") << name_from_method_instance(mi);
+                            freshen_name(name);
                             protoname = StringRef(name);
                         }
 
@@ -6184,10 +6196,12 @@ static std::pair<Function*, Function*> get_oc_function(jl_codectx_t &ctx, jl_met
     }
     else {
         if (specsig) {
-            raw_string_ostream(name) << "j_" << name_from_method_instance(mi) << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
+            raw_string_ostream(name) << "j_" << name_from_method_instance(mi);
+            freshen_name(name);
             protoname = StringRef(name);
         }
-        raw_string_ostream(oc) << "j1_" << name_from_method_instance(mi) << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
+        raw_string_ostream(oc) << "j1_" << name_from_method_instance(mi);
+        freshen_name(name);
         proto_oc = StringRef(oc);
     }
 
@@ -6730,7 +6744,8 @@ static std::string get_function_name(bool specsig, bool needsparams, const char 
         if (unadorned_name[0] == '@')
             unadorned_name++;
     }
-    funcName << unadorned_name << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
+    funcName << unadorned_name;
+    freshen_name(_funcName);
     return funcName.str();
 }
 
@@ -6812,7 +6827,8 @@ Function *emit_tojlinvoke(jl_code_instance_t *codeinst, Value *theFunc, Module *
     ++EmittedToJLInvokes;
     jl_codectx_t ctx(M->getContext(), params, codeinst);
     std::string name;
-    raw_string_ostream(name) << "tojlinvoke" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
+    raw_string_ostream(name) << "tojlinvoke";
+    freshen_name(name);
     Function *f = Function::Create(ctx.types().T_jlfunc,
             GlobalVariable::InternalLinkage,
             name, M);
@@ -7111,7 +7127,8 @@ std::string emit_abi_dispatcher(Module *M, jl_codegen_params_t &params, jl_value
         raw_string_ostream(gf_thunk_name) << "jfptr_" << name_from_method_instance(jl_get_ci_mi(codeinst)) << "_";
     else
         raw_string_ostream(gf_thunk_name) << "j_";
-    raw_string_ostream(gf_thunk_name) << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1) << "_gfthunk";
+    raw_string_ostream(gf_thunk_name) << "_gfthunk";
+    freshen_name(gf_thunk_name);
     if (specsig)
         emit_specsig_to_specsig(M, gf_thunk_name, sigt, declrt, is_opaque_closure, nargs, params,
                 target, sigt, codeinst ? codeinst->rettype : (jl_value_t*)jl_any_type, nullptr, nullptr);
@@ -7124,7 +7141,8 @@ std::string emit_abi_constreturn(Module *M, jl_codegen_params_t &params, jl_valu
 {
     bool is_opaque_closure = false;
     std::string gf_thunk_name;
-    raw_string_ostream(gf_thunk_name) << "jconst_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
+    raw_string_ostream(gf_thunk_name) << "jconst";
+    freshen_name(gf_thunk_name);
     if (specsig) {
         emit_specsig_to_specsig(M, gf_thunk_name, sigt, declrt, is_opaque_closure, nargs, params,
                 nullptr, sigt, jl_typeof(rettype_const), nullptr, rettype_const);
@@ -7243,7 +7261,8 @@ static Function *gen_cfun_wrapper(
     bool nest = (!ff || unionall_env);
 
     std::string funcName;
-    raw_string_ostream(funcName) << "jlcapi_" << name << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
+    raw_string_ostream(funcName) << "jlcapi_" << name;
+    freshen_name(funcName);
 
     Module *M = into; // Safe because ctx lock is held by params
     AttributeList attributes = sig.attributes;
@@ -8342,7 +8361,8 @@ static jl_llvm_functions_t
         }();
 
         std::string wrapName;
-        raw_string_ostream(wrapName) << "jfptr_" << ctx.name << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
+        raw_string_ostream(wrapName) << "jfptr_" << ctx.name;
+        freshen_name(wrapName);
         declarations.functionObject = wrapName;
         size_t nparams = jl_nparams(abi);
         gen_invoke_wrapper(lam, abi, jlrettype, jlrettype, returninfo, nparams, retarg, ctx.is_opaque_closure, declarations.functionObject, M, ctx.emission_context);
@@ -9738,13 +9758,16 @@ jl_llvm_functions_t jl_emit_codedecls(
     bool specsig, needsparams;
     std::tie(specsig, needsparams) = uses_specsig(get_ci_abi(codeinst), mi, codeinst->rettype, params.params->prefer_specsig);
     const char *name = name_from_method_instance(mi);
-    if (specsig)
-        raw_string_ostream(decls.functionObject) << "jfptr_" << name << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
+    if (specsig) {
+        raw_string_ostream(decls.functionObject) << "jfptr_" << name;
+        freshen_name(decls.functionObject);
+    }
     else if (needsparams)
         decls.functionObject = "jl_fptr_sparam";
     else
         decls.functionObject = "jl_fptr_args";
-    raw_string_ostream(decls.specFunctionObject) << (specsig ? "j_" : "j1_") << name << "_" << jl_atomic_fetch_add_relaxed(&globalUniqueGeneratedNames, 1);
+    raw_string_ostream(decls.specFunctionObject) << (specsig ? "j_" : "j1_") << name;
+    freshen_name(decls.specFunctionObject);
     M.withModuleDo([&](Module &M) {
             bool is_opaque_closure = jl_is_method(mi->def.value) && mi->def.method->is_for_opaque_closure;
             if (specsig) {


### PR DESCRIPTION
# Overview

This pull request adds a new mode for precompiling sysimages and pkgimages that caches the results of compiling each LLVM module, reducing the time spent emitting native code for CodeInstances that generate identical LLVM IR.  For now, it works only when using the ahead-of-time compiler, but the approach is also valid for JITed code.

## Usage

Set `JULIA_NATIVE_CACHE=<dir>` to look for and store compiled objects in `<dir>`.  When `JULIA_IMAGE_TIMINGS=1` is also set, the cache hit rate will be printed, like:

```
[...]
cache hits: 260/261 (99%)
added 2520 B to cache
[...]
```

## Internals
Normally, `jl_emit_native` emits every CodeInstance into a separate LLVM module before combining everything into a single module.  When the fine-grained cache is enabled, the modules are serialized to bitcode separately.  The cache key for each module is computed from the hash of the serialized bitcode and the LLVM version, and the compiled object file is the value.

The `partitionModule` pass is not run, since multi-threaded compilation is done by having `JULIA_IMAGE_THREADS` worker threads take from the queue of serialized modules.

When the fine-grained cache is used, we generate a single `jl_image_shard_t` table for the entire image.  The `gvar_offsets` are resolved by the linker.

Currently, the cache uses LLVM's `FileCache`, a thread safe key-value store that uses one file per key and write-and-rename to implement atomic updates.  It's a convenient choice for development because the contents can be easily `objdump`ed, but the long term plan is to switch to a more appropriate database, be it [LLVMCAS](https://github.com/llvm/llvm-project/pull/114096) when it is merged, or sqlite.

## Current limitations
- The multiversioning pass requires a combined module.  If it is requested, the native code cache will be disabled.
- Only `.o` outputs are cached.  The fine-grained cache cannot be used if `--output-bc`, `--output-unopt-bc` or `--output-asm` are specified.
- It is unclear how much of a (compile time) performance impact using seperate modules will have.  When we understand how to maximize cache hits I'd like to use some heuristic to emit code into shared modules to mitigate this.
- Cache entries do not currently expire.
- The cache directory hits file system bottlenecks very fast on Windows.  There is much wasted space.
- The APIs intended for external use also require the use of a single module (`jl_get_llvm_module_impl`, `jl_get_llvm_function_impl`, `jl_emit_native_impl` with `llvmmod` set).
- The cache hit rate is predictably quite low because of how we generate names during codegen.  We'll need to change how this works and delay the uniquing to linking to improve this.

## Plan
- [X] Support compiling split modules, emitting a single shard table (this PR)
- [ ] Generate names that are predictable and only unique within one module; rename while linking.
- [ ] Find a good heuristic to generate fewer modules
- [ ] Switch to a better KV store
- [ ] Cache eviction
- [ ] Support multiversioning
