### PR TITLE
CI: `PrAssignee`: Don't add status label to prs automatically

### DIFF
--- a/.github/workflows/PrAssignee.yml
+++ b/.github/workflows/PrAssignee.yml
@@ -172,16 +172,6 @@ jobs:
               assignees: selectedAssignee,
             });
 
-            // Add the "pr review" label
-            const prReviewLabel = 'status: waiting for PR reviewer';
-            console.log('Attempting to add prReviewLabel to this PR...');
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              labels: [prReviewLabel],
-            });
-
             // Now get the updated PR info, and see if we were successful:
             const updatedPrData = await github.rest.pulls.get({
               owner: context.repo.owner,

--- a/.github/workflows/PrAssignee.yml
+++ b/.github/workflows/PrAssignee.yml
@@ -172,6 +172,17 @@ jobs:
               assignees: selectedAssignee,
             });
 
+            // The following is commented out because the label only makes sense in the presence of a larger state machine
+            // // Add the "pr review" label
+            // const prReviewLabel = 'status: waiting for PR reviewer';
+            // console.log('Attempting to add prReviewLabel to this PR...');
+            // await github.rest.issues.addLabels({
+            //   owner: context.repo.owner,
+            //   repo: context.repo.repo,
+            //   issue_number: context.payload.pull_request.number,
+            //   labels: [prReviewLabel],
+            // });
+
             // Now get the updated PR info, and see if we were successful:
             const updatedPrData = await github.rest.pulls.get({
               owner: context.repo.owner,


### PR DESCRIPTION
This status label will be helpful once it has a well defined semantic and we have more statuses to transition between. As is, it is mostly noise and I think it should be (temporarily) removed.