### PR TITLE
static_show: Don't print field names of structs in `--trace-compile` output

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -2865,7 +2865,11 @@ static void record_precompile_statement(jl_method_instance_t *mi, double compila
         if (force_trace_compile || jl_options.trace_compile_timing)
             jl_printf(s_precompile, "#= %6.1f ms =# ", compilation_time / 1e6);
         jl_printf(s_precompile, "precompile(");
-        jl_static_show(s_precompile, mi->specTypes);
+        jl_static_show_config_t config = {
+            /* suppress_datatype_names */ 0,
+            /* suppress_field_names */ 1,
+        };
+        jl_static_show_(s_precompile, mi->specTypes, config);
         jl_printf(s_precompile, ")");
         if (is_recompile) {
             jl_printf(s_precompile, " # recompile");
@@ -2924,7 +2928,11 @@ static void record_dispatch_statement(jl_method_instance_t *mi)
     }
     if (!jl_has_free_typevars(mi->specTypes)) {
         jl_printf(s_dispatch, "precompile(");
-        jl_static_show(s_dispatch, mi->specTypes);
+        jl_static_show_config_t config = {
+            /* suppress_datatype_names */ 0,
+            /* suppress_field_names */ 1,
+        };
+        jl_static_show_(s_dispatch, mi->specTypes, config);
         jl_printf(s_dispatch, ")\n");
         if (s_dispatch != JL_STDERR)
             ios_flush(&f_dispatch);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -636,8 +636,12 @@ void jl_gc_reset_alloc_count(void);
 uint32_t jl_get_gs_ctr(void);
 void jl_set_gs_ctr(uint32_t ctr);
 
-typedef struct _jl_static_show_config_t { uint8_t quiet; } jl_static_show_config_t;
-size_t jl_static_show_func_sig_(JL_STREAM *s, jl_value_t *type, jl_static_show_config_t ctx) JL_NOTSAFEPOINT;
+typedef struct _jl_static_show_config_t {
+    uint8_t suppress_datatype_names;
+    uint8_t suppress_field_names;
+} jl_static_show_config_t;
+JL_DLLEXPORT size_t jl_static_show_(JL_STREAM *out, jl_value_t *v, jl_static_show_config_t ctx) JL_NOTSAFEPOINT;
+JL_DLLEXPORT size_t jl_static_show_func_sig_(JL_STREAM *s, jl_value_t *type, jl_static_show_config_t ctx) JL_NOTSAFEPOINT;
 
 STATIC_INLINE jl_value_t *undefref_check(jl_datatype_t *dt, jl_value_t *v) JL_NOTSAFEPOINT
 {

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1369,18 +1369,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
             size_t i = 0;
             if (vt == jl_typemap_entry_type)
                 i = 1;
-            jl_value_t *names = isnamedtuple ? jl_tparam0(vt) : (jl_value_t*)jl_field_names(vt);
             for (; i < tlen; i++) {
-                if (!istuple) {
-                    jl_sym_t *fname = (jl_sym_t*)(isnamedtuple ? jl_fieldref_noalloc(names, i) : jl_svecref(names, i));
-                    if (fname == NULL || !jl_is_symbol(fname))
-                        n += jl_static_show_x(out, (jl_value_t*)fname, depth, ctx);
-                    else if (jl_is_operator(jl_symbol_name(fname)))
-                        n += jl_printf(out, "(%s)", jl_symbol_name(fname));
-                    else
-                        n += jl_static_show_symbol(out, fname);
-                    n += jl_printf(out, "=");
-                }
                 size_t offs = jl_field_offset(vt, i);
                 char *fld_ptr = (char*)v + offs;
                 if (jl_field_isptr(vt, i)) {

--- a/src/timing.c
+++ b/src/timing.c
@@ -549,7 +549,10 @@ JL_DLLEXPORT void jl_timing_show_func_sig(jl_value_t *v, jl_timing_block_t *cur_
     ios_mem(&buf, IOS_INLSIZE);
     buf.growable = 0; // Restrict to inline buffer to avoid allocation
 
-    jl_static_show_config_t config = { /* quiet */ 1 };
+    jl_static_show_config_t config = {
+        /* suppress_datatype_names */ 1,
+        /* suppress_field_names */ 1,
+    };
     jl_static_show_func_sig_((JL_STREAM*)&buf, v, config);
     if (buf.size == buf.maxsize)
         memset(&buf.buf[IOS_INLSIZE - 3], '.', 3);


### PR DESCRIPTION
This is a revival of https://github.com/JuliaLang/julia/pull/40652, to remove spurious reasons that `--trace-compile` output does not `eval` properly right now (I don't know if we'll be able to fix all of the flaws, but it seems worthwhile to fix the easy cases so that we can focus on the hard ones)

The default REPL printing does not think it's worth printing these field names:
```julia
julia> struct Foo
           x::Int
           y::Int
           z::Int
       end

julia> Foo(1,2,3)
Foo(1, 2, 3)
```
so I'm not sure why our `static_show` would find it necessary.