### PR TITLE
CI: `PrAssignee.yml`: Add note about public membership in the bot comment

### DIFF
--- a/.github/workflows/PrAssignee.yml
+++ b/.github/workflows/PrAssignee.yml
@@ -197,7 +197,7 @@ jobs:
             // }
 
             // Post a comment
-            const commentBody = `Hello! I am a bot.\n\nThank you for your pull request!\n\nI have assigned \`@${selectedAssignee}\` to this pull request.\n\n\`@${selectedAssignee}\` can either choose to review this pull request themselves, or they can choose to find someone else to review this pull request.`
+            const commentBody = `Hello! I am a bot.\n\nThank you for your pull request!\n\nI have assigned \`@${selectedAssignee}\` to this pull request.\n\n\`@${selectedAssignee}\` can either choose to review this pull request themselves, or they can choose to find someone else to review this pull request.\n\nNote: If you are a Julia committer, please make sure that your organization membership is public.`
             console.log('Attempting to post bot comment on the PR...');
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
At the bottom of the bot comment, add a brief comment asking Julia committers to make sure that their org membership is public.