### PR TITLE
static_show: Use `reinterpret` for types with non-default constructors

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2378,8 +2378,20 @@ JL_CALLABLE(jl_f__equiv_typedef)
 
 JL_CALLABLE(jl_f__defaultctors)
 {
-    JL_NARGS(_defaultctors, 2, 2);
-    jl_ctor_def(args[0], args[1]);
+    JL_NARGS(_defaultctors, 3, 3);
+
+    jl_datatype_t *dt = (jl_datatype_t*)jl_unwrap_unionall(args[0]);
+    JL_TYPECHK(_defaultctors, datatype, (jl_value_t *)dt);
+    JL_TYPECHK(_defaultctors, linenumbernode, args[1]);
+    JL_TYPECHK(_defaultctors, bool, args[2]);
+
+    if (args[2] == jl_true) {
+        jl_ctor_def(args[0], args[1]);
+        dt->name->hasdefaultctors = 1;
+    } else {
+        dt->name->hasdefaultctors = 0;
+    }
+
     return jl_nothing;
 }
 

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -85,6 +85,7 @@ JL_DLLEXPORT jl_typename_t *jl_new_typename_in(jl_sym_t *name, jl_module_t *modu
     tn->abstract = abstract;
     tn->mutabl = mutabl;
     tn->mayinlinealloc = 0;
+    tn->hasdefaultctors = 0;
     tn->partial = NULL;
     tn->atomicfields = NULL;
     tn->constfields = NULL;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3133,6 +3133,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_tuple_typename = jl_anytuple_type->name;
     // fix some miscomputed values, since we didn't know this was going to be a Tuple in jl_precompute_memoized_dt
     jl_tuple_typename->wrapper = (jl_value_t*)jl_anytuple_type; // remove UnionAll wrappers
+    jl_tuple_typename->hasdefaultctors = 1;
     jl_anytuple_type->isconcretetype = 0;
     jl_anytuple_type->maybe_subtype_of_cache = 0;
     jl_anytuple_type->layout = NULL;

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1023,8 +1023,8 @@
        ;; added alongside (replacing) the old ones, than to not have them and need them.
        ;; Commonly Revise.jl should be used to figure out actually which methods should
        ;; actually be deleted or added anew.
-       ,(if (null? defs)
-          `(call (core _defaultctors) ,newdef (inert ,loc))
+       (call (core _defaultctors) ,newdef (inert ,loc) ,(if (null? defs) '(true) '(false)))
+       ,(if (null? defs) '()
           `(scope-block
             (block
              (hardscope)

--- a/src/julia.h
+++ b/src/julia.h
@@ -529,7 +529,8 @@ typedef struct {
     uint8_t abstract:1;
     uint8_t mutabl:1;
     uint8_t mayinlinealloc:1;
-    uint8_t _unused:5;
+    uint8_t hasdefaultctors:1;
+    uint8_t _unused:4;
     _Atomic(uint8_t) cache_entry_count; // (approximate counter of TypeMapEntry for heuristics)
     uint8_t max_methods; // override for inference's max_methods setting (0 = no additional limit or relaxation)
     uint8_t constprop_heustic; // override for inference's constprop heuristic

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1355,7 +1355,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         // In many cases, default constructors may not be available (e.g. primitive types
         // never have them), so print these as "reinterpret(Foo, ...)" to make sure that
         // these round-trip as expected.
-        int reinterpret = isprimitivetype;
+        int reinterpret = (!vt->name->hasdefaultctors && !istuple && !isnamedtuple) || isprimitivetype;
 
         size_t tlen = jl_datatype_nfields(vt);
         if (reinterpret)

--- a/test/show.jl
+++ b/test/show.jl
@@ -1520,7 +1520,7 @@ function static_shown(x)
 end
 
 # Test for PR 17803
-@test static_shown(Int128(-1)) == "Int128(0xffffffffffffffffffffffffffffffff)"
+@test static_shown(Int128(-1)) == "Base.reinterpret(Int128, 0xffffffffffffffffffffffffffffffff)"
 
 # PR #22160
 @test static_shown(:aa) == ":aa"
@@ -1618,9 +1618,12 @@ struct var"%X%" end  # Invalid name without '#'
             Val(1),       Val(Int8(1)),  Val(Int16(1)),  Val(Int32(1)),  Val(Int64(1)),  Val(Int128(1)),
             Val(UInt(1)), Val(UInt8(1)), Val(UInt16(1)), Val(UInt32(1)), Val(UInt64(1)), Val(UInt128(1)),
 
+            # Primitive types should round-trip via reinterpret(...)
+            Val(Char('u')), Val(Char('\0')),
+
             # BROKEN
             # Symbol("a\xffb"),
-            # User-defined primitive types
+            # User-defined primitive types with size not a power-of-two
             # Non-canonical NaNs
             # BFloat16
         )


### PR DESCRIPTION
The idea here is that we can reasonably expect that types with default inner constructors can be constructed as `Foo(field1, field2, field3)` in most cases. That's because, if an outer constructor "covers" the full-length default constructor, then it can only construct the object it needs via `@invoke`, `reinterpret`, `Expr(:new, ...)` or similar workarounds (the full-length default constructor is not available via dispatch and neither is `new`)

This gives us a compact output for the majority of `isbits` types:
```julia
julia> struct Foo
           x::Int
           y::Int
           z::Int
       end
julia> ccall(:jl_, Cvoid, (Any,), Foo(1,2,3))
Foo(1, 2, 3)
```

but also evaluates to the correct value when inner constructors are present that do strange things:
```julia
julia> struct Bar
           x::Int
           y::Int
           z::Int
           Bar(z, y, x) = new(x, y, z)
       end
julia> ccall(:jl_, Cvoid, (Any,), Bar(1,2,3))
Base.reinterpret(Bar, (1, 2, 3))
```

Mostly a proof-of-concept to illustrate this approach. Lots of tests still needed (and `hasdefaultctors` may need to be tracked very differently)