### PR TITLE
deps: fix libunwind build with GCC < 11

### DIFF
--- a/deps/patches/libunwind-missing-parameter-names.patch
+++ b/deps/patches/libunwind-missing-parameter-names.patch
@@ -1,0 +1,28 @@
+From 9ebe5e12b8a0063953f9ef196b2433eca9933559 Mon Sep 17 00:00:00 2001
+From: Stephen Webb <swebb@qnx.com>
+Date: Tue, 15 Apr 2025 10:48:20 -0400
+Subject: [PATCH] Fix FTBFS in src/ptrace/_UPT_ptrauth_insn_mask.c
+
+Added missing parameter names to make C code comply to ISO/IEC 9899.
+---
+ src/ptrace/_UPT_ptrauth_insn_mask.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/ptrace/_UPT_ptrauth_insn_mask.c b/src/ptrace/_UPT_ptrauth_insn_mask.c
+index dcc512370..e7b3a514b 100644
+--- a/src/ptrace/_UPT_ptrauth_insn_mask.c
++++ b/src/ptrace/_UPT_ptrauth_insn_mask.c
+@@ -49,9 +49,10 @@ unw_word_t _UPT_ptrauth_insn_mask (UNUSED unw_addr_space_t as, void *arg)
+ 
+ #else
+ 
+-unw_word_t _UPT_ptrauth_insn_mask (unw_addr_space_t, void *)
++unw_word_t _UPT_ptrauth_insn_mask (UNUSED unw_addr_space_t as, UNUSED void *arg)
+ {
+   return 0;
+ }
+ 
+-#endif
+\ No newline at end of file
++#endif
++

--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -39,10 +39,14 @@ $(SRCCACHE)/libunwind-$(UNWIND_VER)/libunwind-disable-initial-exec-tls.patch-app
 	cd $(SRCCACHE)/libunwind-$(UNWIND_VER) && patch -p1 -f -u -l < $(SRCDIR)/patches/libunwind-disable-initial-exec-tls.patch
 	echo 1 > $@
 
+$(SRCCACHE)/libunwind-$(UNWIND_VER)/libunwind-missing-parameter-names.patch-applied: $(SRCCACHE)/libunwind-$(UNWIND_VER)/libunwind-disable-initial-exec-tls.patch-applied
+	cd $(SRCCACHE)/libunwind-$(UNWIND_VER) && patch -p1 -f -u -l < $(SRCDIR)/patches/libunwind-missing-parameter-names.patch
+	echo 1 > $@
+
 # note minidebuginfo requires liblzma, which we do not have a source build for
 # (it will be enabled in BinaryBuilder-based downloads however)
 # since https://github.com/JuliaPackaging/Yggdrasil/commit/0149e021be9badcb331007c62442a4f554f3003c
-$(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured: $(SRCCACHE)/libunwind-$(UNWIND_VER)/source-extracted $(SRCCACHE)/libunwind-$(UNWIND_VER)/libunwind-disable-initial-exec-tls.patch-applied
+$(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured: $(SRCCACHE)/libunwind-$(UNWIND_VER)/source-extracted $(SRCCACHE)/libunwind-$(UNWIND_VER)/libunwind-missing-parameter-names.patch-applied
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 	$(dir $<)/configure $(CONFIGURE_COMMON) CPPFLAGS="$(CPPFLAGS) $(LIBUNWIND_CPPFLAGS)" CFLAGS="$(CFLAGS) $(LIBUNWIND_CFLAGS)" LDFLAGS="$(LDFLAGS) $(LIBUNWIND_LDFLAGS)" --enable-shared --disable-minidebuginfo --disable-tests --enable-zlibdebuginfo --disable-conservative-checks --enable-per-thread-cache


### PR DESCRIPTION
Apply patch from libunwind/libunwind#853 to add missing parameter names
in _UPT_ptrauth_insn_mask function to comply with ISO/IEC 9899.

Prior to GCC 11, omitting parameter names in function definitions
was an error. GCC 11 changed this behavior in commit
https://gcc.gnu.org/pipermail/gcc-cvs/2020-October/336068.html
to allow omitted parameter names as a C2x extension, making it
a pedantic warning instead of an error.

Since we build without -Wpedantic, the code compiles fine with
GCC 11+ but fails with older GCC versions.

Fixes scheduled CI failures in libunwind build:
https://buildkite.com/julialang/julia-master-scheduled/builds/1160