### PR TITLE
Specialize iterate for `IndexLinear` arrays

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1247,7 +1247,7 @@ _check_inrange(state, inds) = state in inds
 _check_inrange(state::Int, inds::AbstractOneTo{Int}) = (state - 1)%UInt < length(inds)%UInt
 function _iterate(A::AbstractArray, state::Integer)
     _check_inrange(state, eachindex(IndexLinear(), A)) || return nothing
-    @inbounds(A[state]), state + 1
+    @inbounds(A[state]), state + oneunit(state)
 end
 
 isempty(a::AbstractArray) = (length(a) == 0)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1234,10 +1234,10 @@ oneunit(x::AbstractMatrix{T}) where {T} = _one(oneunit(T), x)
 # While the definitions for IndexLinear are all simple enough to inline on their
 # own, IndexCartesian's CartesianIndices is more complicated and requires explicit
 # inlining.
-_iterate_starting_state(A) = _iterate_starting_state(A, IndexStyle(A))
-_iterate_starting_state(A, ::IndexLinear) = firstindex(A)
-_iterate_starting_state(A, ::IndexStyle) = (eachindex(A),)
-iterate(A::AbstractArray, state = _iterate_starting_state(A)) = _iterate(A, state)
+iterate_starting_state(A) = iterate_starting_state(A, IndexStyle(A))
+iterate_starting_state(A, ::IndexLinear) = firstindex(A)
+iterate_starting_state(A, ::IndexStyle) = (eachindex(A),)
+iterate(A::AbstractArray, state = iterate_starting_state(A)) = _iterate(A, state)
 function _iterate(A::AbstractArray, state::Tuple)
     y = iterate(state...)
     y === nothing && return nothing

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1244,9 +1244,8 @@ function _iterate(A::AbstractArray, state::Tuple)
     A[y[1]], (state[1], tail(y)...)
 end
 function _iterate(A::AbstractArray, state::Integer)
-    inds = eachindex(IndexLinear(), A)
-    checkindex(Bool, inds, state) || return nothing
-    @inbounds(A[state]), state + step(inds)
+    checkbounds(Bool, A, state) || return nothing
+    @inbounds(A[state]), state + one(state)
 end
 
 isempty(a::AbstractArray) = (length(a) == 0)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1247,7 +1247,7 @@ _check_inrange(state, inds) = state in inds
 _check_inrange(state::Int, inds::AbstractOneTo{Int}) = (state - 1)%UInt < length(inds)%UInt
 function _iterate(A::AbstractArray, state::Integer)
     _check_inrange(state, eachindex(IndexLinear(), A)) || return nothing
-    @inbounds(A[state]), state + oneunit(state)
+    A[state], state + oneunit(state)
 end
 
 isempty(a::AbstractArray) = (length(a) == 0)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1246,7 +1246,7 @@ end
 _check_inrange(state, inds) = state in inds
 _check_inrange(state::Int, inds::AbstractOneTo{Int}) = (state - 1)%UInt < length(inds)%UInt
 function _iterate(A::AbstractArray, state::Integer)
-    _check_inrange(state, eachindex(A)) || return nothing
+    _check_inrange(state, eachindex(IndexLinear(), A)) || return nothing
     @inbounds(A[state]), state + 1
 end
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1243,11 +1243,9 @@ function _iterate(A::AbstractArray, state::Tuple)
     y === nothing && return nothing
     A[y[1]], (state[1], tail(y)...)
 end
-_check_inrange(state, inds) = state in inds
-_check_inrange(state::Int, inds::AbstractOneTo{Int}) = (state - 1)%UInt < length(inds)%UInt
 function _iterate(A::AbstractArray, state::Integer)
     inds = eachindex(IndexLinear(), A)
-    _check_inrange(state, inds) || return nothing
+    checkindex(Bool, inds, state) || return nothing
     @inbounds(A[state]), state + step(inds)
 end
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1248,7 +1248,7 @@ _check_inrange(state::Int, inds::AbstractOneTo{Int}) = (state - 1)%UInt < length
 function _iterate(A::AbstractArray, state::Integer)
     inds = eachindex(IndexLinear(), A)
     _check_inrange(state, inds) || return nothing
-    A[state], state + step(inds)
+    @inbounds(A[state]), state + step(inds)
 end
 
 isempty(a::AbstractArray) = (length(a) == 0)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1246,8 +1246,9 @@ end
 _check_inrange(state, inds) = state in inds
 _check_inrange(state::Int, inds::AbstractOneTo{Int}) = (state - 1)%UInt < length(inds)%UInt
 function _iterate(A::AbstractArray, state::Integer)
-    _check_inrange(state, eachindex(IndexLinear(), A)) || return nothing
-    A[state], state + oneunit(state)
+    inds = eachindex(IndexLinear(), A)
+    _check_inrange(state, inds) || return nothing
+    A[state], state + step(inds)
 end
 
 isempty(a::AbstractArray) = (length(a) == 0)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2291,6 +2291,8 @@ end
     A = [1 2; 3 4]
     v = view(A, :)
     @test sum(x for x in v) == sum(A)
-    v2 = view(A, Base.IdentityUnitRange(1:length(v)))
+    v = view(A, 1:2:lastindex(A))
+    @test sum(x for x in v) == sum(A[1:2:end])
+    v2 = view(A, Base.IdentityUnitRange(1:length(A)))
     @test sum(x for x in v2) == sum(A)
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2286,3 +2286,11 @@ end
         @test_throws "no method matching $Int(::$Infinity)" similar(ones(2), OneToInf())
     end
 end
+
+@testset "iterate for linear indexing" begin
+    A = [1 2; 3 4]
+    v = view(A, :)
+    @test sum(x for x in v) == sum(A)
+    v2 = view(A, Base.IdentityUnitRange(1:length(v)))
+    @test sum(x for x in v2) == sum(A)
+end

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -248,7 +248,7 @@ struct F49231{a,b,c,d,e,f,g} end
         stacktrace(catch_backtrace())
     end
     str = sprint(Base.show_backtrace, st, context = (:limit=>true, :stacktrace_types_limited => Ref(false), :color=>true, :displaysize=>(50,105)))
-    @test contains(str, "[5] \e[0m\e[1mcollect_to!\e[22m\e[0m\e[1m(\e[22m\e[90mdest\e[39m::\e[0mVector\e[90m{…}\e[39m, \e[90mitr\e[39m::\e[0mBase.Generator\e[90m{…}\e[39m, \e[90moffs\e[39m::\e[0m$Int, \e[90mst\e[39m::\e[0mTuple\e[90m{…}\e[39m\e[0m\e[1m)\e[22m\n\e[90m")
+    @test contains(str, "[5] \e[0m\e[1mcollect_to!\e[22m\e[0m\e[1m(\e[22m\e[90mdest\e[39m::\e[0mVector\e[90m{…}\e[39m, \e[90mitr\e[39m::\e[0mBase.Generator\e[90m{…}\e[39m, \e[90moffs\e[39m::\e[0m$Int, \e[90mst\e[39m::\e[0m$Int\e[0m\e[1m)\e[22m\n\e[90m")
 
     st = try
         F49231{Vector,Val{'}'},Vector{Vector{Vector{Vector}}},Tuple{Int,Int,Int,Int,Int,Int,Int},Int,Int,Int}()(1,2,3)


### PR DESCRIPTION
This adds a specialized `iterate` method for linearly indexed arrays. Firstly, we explicitly evaluate the iteration over the range that corresponds to the linear indices. Secondly, we return `nothing` for an out-of-bounds state, instead of throwing a `BoundsError`. This also lets us annotate the actual indexing with `@inbounds`.
On master
```julia
julia> A = rand(1000,1000); v = view(A, :); v2 = view(A, 1:2:lastindex(A));

julia> using LinearAlgebra

julia> @btime norm(Iterators.map(splat(-), zip($A, $A)));
  434.982 μs (0 allocations: 0 bytes)

julia> @btime norm(Iterators.map(splat(-), zip($v, $v)));
  2.080 ms (0 allocations: 0 bytes) # v"1.13.0-DEV.709"
  510.835 μs (0 allocations: 0 bytes) # this PR
```
The performance of iterating over the contiguous `view` becomes comparable to that of the `Array`.

Fixes https://github.com/JuliaLang/julia/issues/43295 without the need to disable bounds-checking.