### PR TITLE
ircode: handle content outside of a module

### DIFF
--- a/src/precompile.c
+++ b/src/precompile.c
@@ -139,7 +139,6 @@ JL_DLLEXPORT void jl_write_compiler_output(void)
         }
     }
 
-    assert(jl_precompile_toplevel_module == NULL);
     void *native_code = NULL;
 
     bool_t emit_native = jl_options.outputo || jl_options.outputbc || jl_options.outputunoptbc || jl_options.outputasm;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3419,9 +3419,6 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
 
 static void jl_write_header_for_incremental(ios_t *f, jl_array_t *worklist, jl_array_t *mod_array, jl_array_t **udeps, int64_t *srctextpos, int64_t *checksumpos)
 {
-    assert(jl_precompile_toplevel_module == NULL);
-    jl_precompile_toplevel_module = (jl_module_t*)jl_array_ptr_ref(worklist, jl_array_len(worklist)-1);
-
     *checksumpos = write_header(f, 0);
     write_uint8(f, jl_cache_flags());
     // write description of contents (name, uuid, buildid)
@@ -3479,9 +3476,7 @@ JL_DLLEXPORT void jl_create_system_image(void **_native_data, jl_array_t *workli
         // Generate _native_data`
         if (_native_data != NULL) {
             jl_prepare_serialization_data(mod_array, newly_inferred, &extext_methods, &new_ext_cis, NULL, &query_cache);
-            jl_precompile_toplevel_module = (jl_module_t*)jl_array_ptr_ref(worklist, jl_array_len(worklist)-1);
             *_native_data = jl_precompile_worklist(worklist, extext_methods, new_ext_cis);
-            jl_precompile_toplevel_module = NULL;
             extext_methods = NULL;
             new_ext_cis = NULL;
         }
@@ -3528,7 +3523,6 @@ JL_DLLEXPORT void jl_create_system_image(void **_native_data, jl_array_t *workli
     // Re-enable running julia code for postoutput hooks, atexit, etc.
     jl_gc_enable_finalizers(ct, 1);
     ct->reentrant_timing &= ~0b1000u;
-    jl_precompile_toplevel_module = NULL;
 
     if (worklist) {
         // Go back and update the checksum in the header

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -34,7 +34,7 @@ htable_t jl_current_modules;
 jl_mutex_t jl_modules_mutex;
 
 // During incremental compilation, the following gets set
-jl_module_t *jl_precompile_toplevel_module = NULL;   // the toplevel module currently being defined
+jl_module_t *jl_precompile_toplevel_module = NULL;   // the first toplevel module being defined
 
 jl_module_t *jl_add_standard_imports(jl_module_t *m)
 {
@@ -172,7 +172,6 @@ static jl_value_t *jl_eval_module_expr(jl_module_t *parent_module, jl_expr_t *ex
         }
     }
 
-    jl_module_t *old_toplevel_module = jl_precompile_toplevel_module;
     size_t last_age = ct->world_age;
 
     if (parent_module == jl_main_module && name == jl_symbol("Base") && jl_base_module == NULL) {
@@ -182,7 +181,7 @@ static jl_value_t *jl_eval_module_expr(jl_module_t *parent_module, jl_expr_t *ex
 
     if (is_parent__toplevel__) {
         jl_register_root_module(newm);
-        if (jl_options.incremental) {
+        if (jl_options.incremental && jl_precompile_toplevel_module == NULL) {
             jl_precompile_toplevel_module = newm;
         }
     }
@@ -240,8 +239,6 @@ static jl_value_t *jl_eval_module_expr(jl_module_t *parent_module, jl_expr_t *ex
             jl_module_run_initializer(m);
         }
     }
-
-    jl_precompile_toplevel_module = old_toplevel_module;
 
     JL_GC_POP();
     return (jl_value_t*)newm;


### PR DESCRIPTION
Specifically, content in an `__init__` block is handled by secret duplicate precompile logic, and any content generated by it was previously not eligible to be included into cache files.

Fix #58449