### PR TITLE
test: replcompletions: Replace timedwait by proper condvar

### DIFF
--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1073,6 +1073,39 @@ let c, r, res
     @test res === false
 end
 
+# A pair of utility function for the REPL completions test to test PATH_cache
+# dependent completions, which ordinarily happen asynchronously.
+# Only to be used from the test suite
+function test_only_arm_cache_refresh()
+    @lock REPL.REPLCompletions.PATH_cache_lock begin
+        @assert REPL.REPLCompletions.PATH_cache_condition === nothing
+
+        # Arm a condition we can wait on
+        REPL.REPLCompletions.PATH_cache_condition = Threads.Condition(REPL.REPLCompletions.PATH_cache_lock)
+
+        # Check if the previous update is still running - if so, wait for it to finish
+        while REPL.REPLCompletions.PATH_cache_task !== nothing
+            @assert !istaskdone(REPL.REPLCompletions.PATH_cache_task)
+            wait(REPL.REPLCompletions.PATH_cache_condition)
+        end
+
+        # force the next cache update to happen immediately
+        REPL.REPLCompletions.next_cache_update = 0
+    end
+    return REPL.REPLCompletions.PATH_cache_condition
+end
+
+function test_only_wait_cache_path_done()
+    @lock REPL.REPLCompletions.PATH_cache_lock begin
+        @assert REPL.REPLCompletions.PATH_cache_condition !== nothing
+
+        while REPL.REPLCompletions.next_cache_update == 0.
+            wait(REPL.REPLCompletions.PATH_cache_condition)
+        end
+        REPL.REPLCompletions.PATH_cache_condition = nothing
+    end
+end
+
 if Sys.isunix()
 let s, c, r
     #Assume that we can rely on the existence and accessibility of /tmp
@@ -1204,12 +1237,9 @@ let s, c, r
                 # Files reachable by PATH are cached async when PATH is seen to have been changed by `complete_path`
                 # so changes are unlikely to appear in the first complete. For testing purposes we can wait for
                 # caching to finish
-                @lock REPL.REPLCompletions.PATH_cache_lock begin
-                    # force the next cache update to happen immediately
-                    REPL.REPLCompletions.next_cache_update = 0
-                end
+                test_only_arm_cache_refresh()
                 c,r = test_scomplete(s)
-                timedwait(()->REPL.REPLCompletions.next_cache_update != 0, 5) # wait for caching to complete
+                test_only_wait_cache_path_done()
                 c,r = test_scomplete(s)
                 @test "tmp-executable" in c
                 @test r == 1:9
@@ -1238,12 +1268,9 @@ let s, c, r
 
             withenv("PATH" => string(tempdir(), ":", dir)) do
                 s = string("repl-completio")
-                @lock REPL.REPLCompletions.PATH_cache_lock begin
-                    # force the next cache update to happen immediately
-                    REPL.REPLCompletions.next_cache_update = 0
-                end
+                test_only_arm_cache_refresh()
                 c,r = test_scomplete(s)
-                timedwait(()->REPL.REPLCompletions.next_cache_update != 0, 5) # wait for caching to complete
+                test_only_wait_cache_path_done()
                 c,r = test_scomplete(s)
                 @test ["repl-completion"] == c
                 @test s[r] == "repl-completio"


### PR DESCRIPTION
Replace fragile timing-based synchronization with proper condition variable signaling to ensure PATH cache updates complete before testing completions. This eliminates test flakiness on systems where the cache update takes longer than 5s.

The test failure was seen in CI:
https://buildkite.com/julialang/julia-master/builds/48273