### PR TITLE
test/spawn: download busybox to a filename ending with .exe on Windows

### DIFF
--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -25,7 +25,7 @@ busybox_hash_correct(file) = bytes2hex(open(SHA.sha256, file)) == "ed2f95da95552
 
 function _tryonce_download_from_cache(desired_url::AbstractString)
     cache_url = "https://cache.julialang.org/$(desired_url)"
-    cache_output_filename = joinpath(mktempdir(), "busybox")
+    cache_output_filename = joinpath(mktempdir(), "busybox" * (Sys.iswindows() ? ".exe" : ""))
     cache_response = Downloads.request(
         cache_url;
         output = cache_output_filename,


### PR DESCRIPTION
Otherwise, it cannot be executed:

```julia
julia> busybox = download_from_cache("https://frippery.org/files/busybox/busybox-w32-FRP-5467-g9376eebd8.exe")
"C:\\Users\\kcarl\\AppData\\Local\\Temp\\jl_XqObvQ\\busybox"

julia> run(`$busybox`)
ERROR: IOError: could not spawn `'C:\Users\kcarl\AppData\Local\Temp\jl_XqObvQ\busybox'`: no such file or directory (ENOENT)
Stacktrace:
 [1] _spawn_primitive(file::String, cmd::Cmd, stdio::Vector{Union{RawFD, Base.Libc.WindowsRawSocket, IO}})
   @ Base .\process.jl:128
...

julia> mv(busybox, busybox * ".exe")
"C:\\Users\\kcarl\\AppData\\Local\\Temp\\jl_XqObvQ\\busybox.exe"

julia> run(`$(busybox * ".exe")`)
BusyBox v1.37.0-FRP-5467-g9376eebd8 (2024-09-15 08:56:36 UTC)
(mingw32-gcc 14.1.1-3.fc40; mingw32-crt 11.0.1-3.fc40; glob)
```