### PR TITLE
add `print_signature_only` argument to `Base.show_method`

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -216,7 +216,7 @@ show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m; kwar
 
 function show_method(io::IO, m::Method;
                      modulecolor = :light_black, digit_align_width = 1,
-                     print_signature_only::Bool = get(io, :print_signature_only, false)::Bool)
+                     print_signature_only::Bool = get(io, :print_method_signature_only, false)::Bool)
     tv, decls, file, line = arg_decl_parts(m)
     sig = unwrap_unionall(m.sig)
     if sig === Tuple

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -252,7 +252,7 @@ function show_method(io::IO, m::Method;
         show_method_params(io, tv)
     end
 
-    if print_signature_only
+    if !print_signature_only
         if !(get(io, :compact, false)::Bool) # single-line mode
             println(io)
             digit_align_width += 4

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -216,7 +216,7 @@ show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m; kwar
 
 function show_method(io::IO, m::Method;
                      modulecolor = :light_black, digit_align_width = 1,
-                     print_signature_only::Bool = true)
+                     print_signature_only::Bool = get(io, :print_signature_only, false)::Bool)
     tv, decls, file, line = arg_decl_parts(m)
     sig = unwrap_unionall(m.sig)
     if sig === Tuple

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -214,7 +214,9 @@ show(io::IO, m::Method; kwargs...) = show_method(IOContext(io, :compact=>true), 
 
 show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m; kwargs...)
 
-function show_method(io::IO, m::Method; modulecolor = :light_black, digit_align_width = 1)
+function show_method(io::IO, m::Method;
+                     modulecolor = :light_black, digit_align_width = 1,
+                     print_signature_only::Bool = true)
     tv, decls, file, line = arg_decl_parts(m)
     sig = unwrap_unionall(m.sig)
     if sig === Tuple
@@ -250,12 +252,14 @@ function show_method(io::IO, m::Method; modulecolor = :light_black, digit_align_
         show_method_params(io, tv)
     end
 
-    if !(get(io, :compact, false)::Bool) # single-line mode
-        println(io)
-        digit_align_width += 4
+    if print_signature_only
+        if !(get(io, :compact, false)::Bool) # single-line mode
+            println(io)
+            digit_align_width += 4
+        end
+        # module & file, re-using function from errorshow.jl
+        print_module_path_file(io, parentmodule(m), string(file), line; modulecolor, digit_align_width)
     end
-    # module & file, re-using function from errorshow.jl
-    print_module_path_file(io, parentmodule(m), string(file), line; modulecolor, digit_align_width)
 end
 
 function show_method_list_header(io::IO, ms::MethodList, namefmt::Function)

--- a/test/show.jl
+++ b/test/show.jl
@@ -2885,3 +2885,11 @@ end
     @test_repr """:(var"\a\b\t\n\v\f\r\e" = 1)"""
     @test_repr """:(var"\x01\u03c0\U03c0" = 1)"""
 end
+
+# test `print_signature_only::Bool` argument of `Base.show_method`
+f_show_method(x::T) where T<:Integer = :integer
+let io = IOBuffer()
+    m = only(methods(f_show_method))
+    Base.show_method(io, m; print_signature_only=false)
+    @test "f_show_method(x::T) where T<:Integer" == String(take!(io))
+end

--- a/test/show.jl
+++ b/test/show.jl
@@ -2890,6 +2890,6 @@ end
 f_show_method(x::T) where T<:Integer = :integer
 let io = IOBuffer()
     m = only(methods(f_show_method))
-    Base.show_method(io, m; print_signature_only=false)
+    Base.show_method(io, m; print_signature_only=true)
     @test "f_show_method(x::T) where T<:Integer" == String(take!(io))
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -2888,8 +2888,12 @@ end
 
 # test `print_signature_only::Bool` argument of `Base.show_method`
 f_show_method(x::T) where T<:Integer = :integer
-let io = IOBuffer()
-    m = only(methods(f_show_method))
-    Base.show_method(io, m; print_signature_only=true)
-    @test "f_show_method(x::T) where T<:Integer" == String(take!(io))
+let m = only(methods(f_show_method))
+    let io = IOBuffer()
+        Base.show_method(io, m; print_signature_only=true)
+        @test "f_show_method(x::T) where T<:Integer" == String(take!(io))
+    end
+    let s = sprint(show, m; context=:print_method_signature_only=>true)
+        @test "f_show_method(x::T) where T<:Integer" == s
+    end
 end


### PR DESCRIPTION
The output of `Base.show_method` is useful for tooling like language server, and it's good to have an option to print the method signature only.
