### PR TITLE
[Base64] implement `isopen` for `Base64EncodePipe`

### DIFF
--- a/stdlib/Base64/src/encode.jl
+++ b/stdlib/Base64/src/encode.jl
@@ -46,6 +46,7 @@ end
 
 Base.isreadable(::Base64EncodePipe) = false
 Base.iswritable(pipe::Base64EncodePipe) = iswritable(pipe.io)
+Base.isopen(pipe::Base64EncodePipe) = isopen(pipe.io)
 
 function Base.unsafe_write(pipe::Base64EncodePipe, ptr::Ptr{UInt8}, n::UInt)::Int
     buffer = pipe.buffer

--- a/stdlib/Base64/test/runtests.jl
+++ b/stdlib/Base64/test/runtests.jl
@@ -40,6 +40,7 @@ const longDecodedText = "name = \"Genie\"\nuuid = \"c43c736e-a2d1-11e8-161f-af95
     buf = IOBuffer()
     pipe = Base64EncodePipe(buf)
     @test !isreadable(pipe) && iswritable(pipe)
+    @test isopen(pipe)
     for char in inputText
         write(pipe, UInt8(char))
     end


### PR DESCRIPTION
This is needed to make `Base64EncodePipe` work nicely with TranscodingStreams.jl