### PR TITLE
Adjust applescript workaround

### DIFF
--- a/contrib/mac/app/startup.applescript
+++ b/contrib/mac/app/startup.applescript
@@ -1,4 +1,3 @@
 set RootPath to (path to me)
 set JuliaPath to POSIX path of ((RootPath as text) & "Contents:Resources:julia:bin:julia")
-set JuliaFile to POSIX file JuliaPath
-do shell script "open -a Terminal '" & JuliaFile & "'"
+do shell script "open -a Terminal '" & JuliaPath & "'"


### PR DESCRIPTION
It turns out that there are two path types in applescript, and I had mixed two of them in my previous patch.  Annoyingly, things seemed to work when editing locally, unsure why.