### PR TITLE
Unicode: Force-inline isgraphemebreak!

### DIFF
--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -800,7 +800,7 @@ isgraphemebreak(c1::AbstractChar, c2::AbstractChar) =
 # Stateful grapheme break required by Unicode-9 rules: the string
 # must be processed in sequence, with state initialized to Ref{Int32}(0).
 # Requires utf8proc v2.0 or later.
-function isgraphemebreak!(state::Ref{Int32}, c1::AbstractChar, c2::AbstractChar)
+@inline function isgraphemebreak!(state::Ref{Int32}, c1::AbstractChar, c2::AbstractChar)
     if ismalformed(c1) || ismalformed(c2)
         state[] = 0
         return true

--- a/stdlib/Unicode/test/runtests.jl
+++ b/stdlib/Unicode/test/runtests.jl
@@ -284,6 +284,8 @@ end
     @test_throws BoundsError graphemes("äöüx", 2:5)
     @test_throws BoundsError graphemes("äöüx", 5:5)
     @test_throws ArgumentError graphemes("äöüx", 0:1)
+
+    @test @allocated(length(graphemes("äöüx"))) == 0
 end
 
 @testset "#3721, #6939 up-to-date character widths" begin


### PR DESCRIPTION
When this API was added, this function inlined, which is important, because the API relies on the allocation of the `Ref` being elided. At some point (I went back to 1.8) this regressed. For example, it is currently responsible for substantially all non-Expr allocations in JuliaParser. Before (parsing all of Base with JuliaParser):
```
│     Memory estimate: 76.93 MiB, allocs estimate: 719922.
```
After:
```
│     Memory estimate: 53.31 MiB, allocs estimate: 156.
```

Also add a test to make sure this doesn't regress again.