### PR TITLE
Specialize `iterate` for `AbstractOneTo`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -749,7 +749,7 @@ false
 checkindex(::Type{Bool}, inds, i) = throw(ArgumentError(LazyString("unable to check bounds for indices of type ", typeof(i))))
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i::Real) = (first(inds) <= i) & (i <= last(inds))
 checkindex(::Type{Bool}, inds::IdentityUnitRange, i::Real) = checkindex(Bool, inds.indices, i)
-checkindex(::Type{Bool}, inds::AbstractOneTo{T}, i::T) where {T<:BitInteger} = unsigned(i - one(i)) < unsigned(last(inds))
+checkindex(::Type{Bool}, inds::OneTo{T}, i::T) where {T<:BitInteger} = unsigned(i - one(i)) < unsigned(last(inds))
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Colon) = true
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Slice) = true
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i::AbstractRange) =

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -749,7 +749,7 @@ false
 checkindex(::Type{Bool}, inds, i) = throw(ArgumentError(LazyString("unable to check bounds for indices of type ", typeof(i))))
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i::Real) = (first(inds) <= i) & (i <= last(inds))
 checkindex(::Type{Bool}, inds::IdentityUnitRange, i::Real) = checkindex(Bool, inds.indices, i)
-checkindex(::Type{Bool}, inds::OneTo{T}, i::T) where {T<:BitInteger} = unsigned(i - one(i)) < unsigned(last(inds))
+checkindex(::Type{Bool}, inds::AbstractOneTo{T}, i::T) where {T<:BitInteger} = unsigned(i - one(i)) < unsigned(last(inds))
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Colon) = true
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Slice) = true
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i::AbstractRange) =

--- a/base/range.jl
+++ b/base/range.jl
@@ -930,8 +930,10 @@ function _iterate(r::OrdinalRange{T}, i) where {T}
 end
 iterate(r::OrdinalRange, i = nothing) = _iterate(r, i)
 
-function iterate(r::OneTo, i = oneunit(eltype(r)))
-    # checkbounds and checkindex are equivalent here, as a `OneTo` is its own axis.
+# specialized implementation that returns `nothing` for
+# states outside the range
+function iterate(r::AbstractOneTo, i = first(r))
+    # checkbounds and checkindex are equivalent here, as a `AbstractOneTo` is its own axis.
     # We use checkindex to work around failures for non-standard integer types
     # See https://github.com/JuliaLang/julia/pull/27302
     checkindex(Bool, r, i) || return nothing

--- a/base/range.jl
+++ b/base/range.jl
@@ -981,7 +981,7 @@ end
 # unsafe_getindex is separate to make it useful even when running with --check-bounds=yes
 # it assumes the index is inbounds but does not segfault even if the index is out of bounds.
 # it does not check if the index isa bool.
-unsafe_getindex(v::OneTo{T}, i::Integer) where T = convert(T, i)
+unsafe_getindex(v::AbstractOneTo{T}, i::Integer) where T = convert(T, i)
 unsafe_getindex(v::AbstractRange{T}, i::Integer) where T = convert(T, first(v) + (i - oneunit(i))*step_hp(v))
 function unsafe_getindex(r::StepRangeLen{T}, i::Integer) where T
     u = oftype(r.offset, i) - r.offset

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1890,6 +1890,7 @@ struct Position <: Integer
     val::Int
 end
 Position(x::Position) = x # to resolve ambiguity with boot.jl:770
+Base.Int(p::Position) = p.val
 
 struct Displacement <: Integer
     val::Int


### PR DESCRIPTION
Alternate approach to https://github.com/JuliaLang/julia/pull/58635, which produces a similar performance improvement. This is more general, as the improvement would apply to arbitrary iterators that use `AbstractOneTo` axes, and not just to `AbstractArray`s. The idea is that `iterate(r::OneTo, i::Integer)` now returns `nothing` if `i > last(r)`, instead of returning an out-of-bound value. This ensures that iterating over a `OneTo` always produces valid indices.

```julia
julia> using LinearAlgebra

julia> A = rand(1000,1000); v = view(A, :);

julia> @btime norm(Iterators.map(splat(-), zip($v, $v)));
  2.239 ms (0 allocations: 0 bytes) # master
  500.028 μs (0 allocations: 0 bytes) # this PR
```