### PR TITLE
Define `checkindex` for `AbstractOneTo`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -749,7 +749,7 @@ false
 checkindex(::Type{Bool}, inds, i) = throw(ArgumentError(LazyString("unable to check bounds for indices of type ", typeof(i))))
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i::Real) = (first(inds) <= i) & (i <= last(inds))
 checkindex(::Type{Bool}, inds::IdentityUnitRange, i::Real) = checkindex(Bool, inds.indices, i)
-checkindex(::Type{Bool}, inds::OneTo{T}, i::T) where {T<:BitInteger} = unsigned(i - one(i)) < unsigned(last(inds))
+checkindex(::Type{Bool}, inds::AbstractOneTo{T}, i::T) where {T<:BitInteger} = unsigned(i - one(i)) < unsigned(last(inds))
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Colon) = true
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Slice) = true
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i::AbstractRange) =

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -6,6 +6,9 @@ using InteractiveUtils: code_llvm
 isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
 using .Main.OffsetArrays
 
+isdefined(Main, :SizedArrays) || @eval Main include("testhelpers/SizedArrays.jl")
+using .Main.SizedArrays
+
 @testset "range construction" begin
     @test_throws ArgumentError range(start=1, step=1, stop=2, length=10)
     @test_throws ArgumentError range(start=1, step=1, stop=10, length=11)
@@ -2816,4 +2819,13 @@ end
     r = StepRangeLen(Date(2020,1,1), Day(1), 4)
     @test StepRange(r) == r
     @test StepRange(r) isa StepRange{Date,Day}
+end
+
+@testset "AbstractOneTo" begin
+    r = SizedArrays.SOneTo(4)
+    @test !Base.checkindex(Bool, r, 0)
+    for i in r
+        @test Base.checkindex(Bool, r, i)
+    end
+    @test !Base.checkindex(Bool, r, length(r)+1)
 end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2822,10 +2822,18 @@ end
 end
 
 @testset "AbstractOneTo" begin
-    r = SizedArrays.SOneTo(4)
-    @test !Base.checkindex(Bool, r, 0)
-    for i in r
-        @test Base.checkindex(Bool, r, i)
+    @testset "checkindex" begin
+        r = SizedArrays.SOneTo(4)
+        @test !Base.checkindex(Bool, r, 0)
+        for i in r
+            @test Base.checkindex(Bool, r, i)
+        end
+        @test !Base.checkindex(Bool, r, length(r)+1)
+
+        for v in (0, 1, typemin(Int), typemax(Int))
+            @test !checkindex(Bool, Base.OneTo(0), v)
+        end
+        @test checkindex(Bool, Base.OneTo(typemax(Int)), typemax(Int))
+        @test !checkindex(Bool, Base.OneTo(typemax(Int)-1), typemax(Int))
     end
-    @test !Base.checkindex(Bool, r, length(r)+1)
 end


### PR DESCRIPTION
This generalizes the `checkindex` method for `OneTo` to `AbstractOneTo`