### PR TITLE
Add 0 predecessor to entry basic block and handle it in inlining

### DIFF
--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -126,10 +126,11 @@ function cfg_inline_item!(ir::IRCode, idx::Int, todo::InliningTodo, state::CFGIn
     block = block_for_inst(ir, idx)
     inline_into_block!(state, block)
 
-    if !isempty(inlinee_cfg.blocks[1].preds)
+    if length(inlinee_cfg.blocks[1].preds) > 1
         need_split_before = true
+    else
+        @assert inlinee_cfg.blocks[1].preds[1] == 0
     end
-
     last_block_idx = last(state.cfg.blocks[block].stmts)
     if false # TODO: ((idx+1) == last_block_idx && isa(ir[SSAValue(last_block_idx)], GotoNode))
         need_split = false
@@ -166,12 +167,15 @@ function cfg_inline_item!(ir::IRCode, idx::Int, todo::InliningTodo, state::CFGIn
     end
     new_block_range = (length(state.new_cfg_blocks)-length(inlinee_cfg.blocks)+1):length(state.new_cfg_blocks)
 
-    # Fixup the edges of the newely added blocks
+    # Fixup the edges of the newly added blocks
     for (old_block, new_block) in enumerate(bb_rename_range)
         if old_block != 1 || need_split_before
             p = state.new_cfg_blocks[new_block].preds
             let bb_rename_range = bb_rename_range
                 map!(p, p) do old_pred_block
+                    if old_block == 1 && old_pred_block == 0
+                        return first(bb_rename_range) - 1
+                    end
                     return old_pred_block == 0 ? 0 : bb_rename_range[old_pred_block]
                 end
             end
@@ -184,10 +188,6 @@ function cfg_inline_item!(ir::IRCode, idx::Int, todo::InliningTodo, state::CFGIn
                 end
             end
         end
-    end
-
-    if need_split_before
-        push!(state.new_cfg_blocks[first(bb_rename_range)].preds, first(bb_rename_range)-1)
     end
 
     any_edges = false
@@ -399,7 +399,7 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
     else
         bb_offset, post_bb_id = popfirst!(todo_bbs)
         # This implements the need_split_before flag above
-        need_split_before = !isempty(item.ir.cfg.blocks[1].preds)
+        need_split_before = length(item.ir.cfg.blocks[1].preds) > 1
         if need_split_before
             finish_current_bb!(compact, 0)
         end

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -173,9 +173,12 @@ function cfg_inline_item!(ir::IRCode, idx::Int, todo::InliningTodo, state::CFGIn
             p = state.new_cfg_blocks[new_block].preds
             let bb_rename_range = bb_rename_range
                 map!(p, p) do old_pred_block
+                    # the meaning of predecessor 0 depends on the block we encounter it:
+                    #   - in the first block, it represents the function entry and so needs to be re-mapped
                     if old_block == 1 && old_pred_block == 0
                         return first(bb_rename_range) - 1
                     end
+                    #   - elsewhere, it represents external control-flow from a caught exception which is un-affected by inlining
                     return old_pred_block == 0 ? 0 : bb_rename_range[old_pred_block]
                 end
             end

--- a/Compiler/src/ssair/ir.jl
+++ b/Compiler/src/ssair/ir.jl
@@ -105,6 +105,9 @@ function compute_basic_blocks(stmts::Vector{Any})
     end
     # Compute successors/predecessors
     for (num, b) in enumerate(blocks)
+        if b.stmts.start == 1
+            push!(b.preds, 0) # the entry block has a virtual predecessor
+        end
         terminator = stmts[last(b.stmts)]
         if isa(terminator, ReturnNode)
             # return never has any successors


### PR DESCRIPTION
Makes it so that the cfg always has #0 (control flow from outside the function) predecessor on the entry block to model entering the function.

Fixes https://github.com/JuliaLang/julia/issues/57153. Me and @topolarity  found a couple places that were relying on the entry block not having an extra pred but hopefully we've gotten them all