### PR TITLE
cfunction: store `fptr` / `world` contiguously

### DIFF
--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -224,7 +224,6 @@ struct cfunc_decl_t {
     jl_value_t *sigt;
     size_t nargs;
     bool specsig;
-    llvm::GlobalVariable *theFptr;
     llvm::GlobalVariable *cfuncdata;
 };
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1628,7 +1628,7 @@ JL_DLLEXPORT jl_value_t *jl_get_cfunction_trampoline(
     jl_value_t *fobj, jl_datatype_t *result, htable_t *cache, jl_svec_t *fill,
     void *(*init_trampoline)(void *tramp, void **nval),
     jl_unionall_t *env, jl_value_t **vals);
-JL_DLLEXPORT void *jl_get_abi_converter(jl_task_t *ct, _Atomic(void*) *fptr, _Atomic(size_t) *last_world, void *data);
+JL_DLLEXPORT void *jl_get_abi_converter(jl_task_t *ct, void *data);
 JL_DLLIMPORT void *jl_jit_abi_converter(jl_task_t *ct, void *unspecialized, jl_value_t *declrt, jl_value_t *sigt, size_t nargs, int specsig,
     jl_code_instance_t *codeinst, jl_callptr_t invoke, void *target, int target_specsig);
 


### PR DESCRIPTION
This shouldn't affect things very much right now, but this reduces the pointers that an `invokelatest` OpaqueClosure-like will have to carry around.