### PR TITLE
GC Always Full Flag

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -66,6 +66,7 @@ struct JLOptions
     trim::Int8
     task_metrics::Int8
     timeout_for_safepoint_straggler_s::Int16
+    gc_sweep_always_full::Int8
 end
 
 # This runs early in the sysimage != is not defined yet

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -530,17 +530,6 @@ Allows you to enable or disable zones for a specific Julia run.
 For instance, setting the variable to `+GC,-INFERENCE` will enable the `GC` zones and disable
 the `INFERENCE` zones. See [Dynamically Enabling and Disabling Zones](@ref).
 
-### [`JULIA_GC_NO_GENERATIONAL`](@id JULIA_GC_NO_GENERATIONAL)
-
-If set to anything besides `0`, then the Julia garbage collector never performs
-"quick sweeps" of memory.
-
-!!! note
-
-    This environment variable only has an effect if Julia was compiled with
-    garbage-collection debugging (that is, if `WITH_GC_DEBUG_ENV` is set to `1`
-    in the build configuration).
-
 ### [`JULIA_GC_WAIT_FOR_DEBUGGER`](@id JULIA_GC_WAIT_FOR_DEBUGGER)
 
 If set to anything besides `0`, then the Julia garbage collector will wait for

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -892,10 +892,7 @@ void gc_heuristics_summary(
 void jl_gc_debug_init(void)
 {
 #ifdef GC_DEBUG_ENV
-    char *env = getenv("JULIA_GC_NO_GENERATIONAL");
-    if (env && strcmp(env, "0") != 0)
-        jl_gc_debug_env.always_full = 1;
-    env = getenv("JULIA_GC_WAIT_FOR_DEBUGGER");
+    char *env = getenv("JULIA_GC_WAIT_FOR_DEBUGGER");
     jl_gc_debug_env.wait_for_debugger = env && strcmp(env, "0") != 0;
     gc_debug_alloc_init(&jl_gc_debug_env.pool, "POOL");
     gc_debug_alloc_init(&jl_gc_debug_env.other, "OTHER");

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -3155,7 +3155,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
     // If the live data outgrows the suggested max_total_memory
     // we keep going with minimum intervals and full gcs until
     // we either free some space or get an OOM error.
-    if (gc_sweep_always_full) {
+    if (jl_options.gc_sweep_always_full) {
         sweep_full = 1;
         gc_count_full_sweep_reason(FULL_SWEEP_REASON_SWEEP_ALWAYS_FULL);
     }

--- a/src/gc-stock.h
+++ b/src/gc-stock.h
@@ -44,7 +44,6 @@ typedef struct {
 } jl_alloc_num_t;
 
 typedef struct {
-    int always_full;
     int wait_for_debugger;
     jl_alloc_num_t pool;
     jl_alloc_num_t other;
@@ -647,14 +646,12 @@ NOINLINE void gc_mark_loop_unwind(jl_ptls_t ptls, jl_gc_markqueue_t *mq, int off
 
 #ifdef GC_DEBUG_ENV
 JL_DLLEXPORT extern jl_gc_debug_env_t jl_gc_debug_env;
-#define gc_sweep_always_full jl_gc_debug_env.always_full
 int jl_gc_debug_check_other(void);
 int gc_debug_check_pool(void);
 void jl_gc_debug_print(void);
 void gc_scrub_record_task(jl_task_t *ta) JL_NOTSAFEPOINT;
 void gc_scrub(void);
 #else
-#define gc_sweep_always_full 0
 static inline int jl_gc_debug_check_other(void)
 {
     return 0;

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -70,6 +70,7 @@ typedef struct {
     int8_t trim;
     int8_t task_metrics;
     int16_t timeout_for_safepoint_straggler_s;
+    int8_t gc_sweep_always_full;
 } jl_options_t;
 
 #endif

--- a/test/gc.jl
+++ b/test/gc.jl
@@ -82,6 +82,15 @@ end
 @testset "Full GC reasons" begin
     full_sweep_reasons_test()
 end
+
+@testset "GC Always Full" begin
+    prog = "using Test;\n
+        for _ in 1:10; GC.gc(); end;\n
+        reasons = Base.full_sweep_reasons();\n
+        @test reasons[:FULL_SWEEP_REASON_SWEEP_ALWAYS_FULL] >= 10;"
+    cmd = `$(Base.julia_cmd()) --depwarn=error --startup-file=no --gc-sweep-always-full -e $prog`
+    @test success(cmd)
+end
 end
 
 @testset "Base.GC docstrings" begin


### PR DESCRIPTION
This used to be an environment variable (`JULIA_GC_NO_GENERATIONAL`) that could only be enabled if Julia was built with `WITH_GC_DEBUG_ENV`.

People benchmarking GC may want to disable generational behavior in non-debug builds as well.

This PR introduces `gc-sweep-always-full` as a hidden command-line-option.

It also moves the docstrings for `--hard-heap-limit` and `--heap-target-increment` into `opts_hidden`, as it should have been done in the original PR.