### PR TITLE
aotcompile: Fix early-exit if CI not found for `cfunction`

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -652,7 +652,7 @@ static void generate_cfunc_thunks(jl_codegen_params_t &params, jl_compiled_funct
             }
         }
         Function *f = codeinst ? aot_abi_converter(params, M, cfunc.abi, codeinst, defM, func, "", false) : unspec;
-        return assign_fptr(f);
+        assign_fptr(f);
     }
 }
 


### PR DESCRIPTION
As written, this was accidentally skipping all the subsequent `cfuncs` that need adapters.