### PR TITLE
Test: Hide REPL internals in backtraces

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -222,7 +222,8 @@ struct Error <: Result
         end
         if test_type === :test_error || test_type === :nontest_error
             bt_str = try # try the latest world for this, since we might have eval'd new code for show
-                    Base.invokelatest(sprint, Base.show_exception_stack, bt; context=stdout)
+                    # Apply REPL backtrace scrubbing to hide REPL internals, similar to how REPL.jl handles it
+                    Base.invokelatest(sprint, Base.show_exception_stack, Base.scrub_repl_backtrace(bt); context=stdout)
                 catch ex
                     "#=ERROR showing exception stack=# " *
                         try


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/56908

Currently
```
julia> @testset "foo" begin
       error()
       end

foo: Error During Test at REPL[2]:1
  Got exception outside of a @test
  Stacktrace:
    [1] error()
      @ Base ./error.jl:45
    [2] top-level scope
      @ REPL[2]:2
    [3] macro expansion
      @ ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/Test/src/Test.jl:1837 [inlined]
    [4] macro expansion
      @ REPL[2]:2 [inlined]
    [5] __repl_entry_eval_expanded_with_loc(mod::Module, ast::Any, toplevel_file::Ref{Ptr{UInt8}}, toplevel_line::Ref{UInt64})
      @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:304
    [6] toplevel_eval_with_hooks(mod::Module, ast::Any, toplevel_file::Any, toplevel_line::Any)
      @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:311
    [7] toplevel_eval_with_hooks(mod::Module, ast::Any, toplevel_file::Any, toplevel_line::Any)
      @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:315
    [8] toplevel_eval_with_hooks
      @ ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:308 [inlined]
    [9] eval_user_input(ast::Any, backend::REPL.REPLBackend, mod::Module)
      @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:333
   [10] repl_backend_loop(backend::REPL.REPLBackend, get_module::Function)
      @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:460
   [11] start_repl_backend(backend::REPL.REPLBackend, consumer::Any; get_module::Function)
      @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:435
   [12] start_repl_backend
      @ ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:432 [inlined]
   [13] run_repl(repl::REPL.AbstractREPL, consumer::Any; backend_on_current_task::Bool, backend::Any)
      @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:671
   [14] run_repl(repl::REPL.AbstractREPL, consumer::Any)
      @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:657
   [15] run_std_repl(REPL::Module, quiet::Bool, banner::Symbol, history_file::Bool)
      @ Base ./client.jl:485
   [16] run_main_repl(interactive::Bool, quiet::Bool, banner::Symbol, history_file::Bool)
      @ Base ./client.jl:506
   [17] repl_main
      @ ./client.jl:593 [inlined]
   [18] _start()
      @ Base ./client.jl:568
Test Summary: | Error  Total  Time
foo           |     1      1  0.9s
RNG of the outermost testset: Random.Xoshiro(0x437bbb598dd23f39, 0x21943d5a15a1d7b0, 0x171a94189eb215f1, 0x1a205853764b80ee, 0xd29fc22b2442ba80)
ERROR: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
```

This PR
```
julia> @testset "foo" begin
       error()
       end

foo: Error During Test at REPL[2]:1
  Got exception outside of a @test
  Stacktrace:
   [1] error()
     @ Base ./error.jl:45
   [2] top-level scope
     @ REPL[2]:2
   [3] macro expansion
     @ ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/Test/src/Test.jl:1838 [inlined]
   [4] macro expansion
     @ REPL[2]:2 [inlined]
Test Summary: | Error  Total  Time
foo           |     1      1  0.9s
RNG of the outermost testset: Random.Xoshiro(0x330624dbdef761e2, 0x60b8cfb99def173f, 0x38d7e0f25a8e0ffa, 0xc355b3e0536dea90, 0xc8bfe3e6c58c6171)
ERROR: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
```