### PR TITLE
Increment state conditionally in `CartesianIndices` iteration

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -454,12 +454,12 @@ module IteratorsMD
     end
     @inline function __inc(state::Tuple{Int,Int,Vararg{Int}}, indices::Tuple{OrdinalRangeInt,OrdinalRangeInt,Vararg{OrdinalRangeInt}})
         rng = indices[1]
-        I = state[1] + step(rng)
         if state[1] != last(rng)
+            I = state[1] + step(rng)
             return true, (I, tail(state)...)
         end
-        valid, I = __inc(tail(state), tail(indices))
-        return valid, (first(rng), I...)
+        valid, Itail = __inc(tail(state), tail(indices))
+        return valid, (first(rng), Itail...)
     end
 
     # 0-d cartesian ranges are special-cased to iterate once and only once


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/53430

```julia
julia> a = rand(100,100); b = similar(a); av = view(a, axes(a)...); bv = view(b, axes(b)...); bv2 = view(b, UnitRange.(axes(b))...);

julia> @btime copyto!($bv2, $av); # slow, indices are UnitRanges
  12.352 μs (0 allocations: 0 bytes) # master, v"1.13.0-DEV.745"
  1.662 μs (0 allocations: 0 bytes) # this PR
  
julia> @btime copyto!($bv, $av); # reference
  1.733 μs (0 allocations: 0 bytes)
```
The performances become comparable after this PR.

I've also renamed the second `I` to `Itail`, as the two variables represent different quantities.