### PR TITLE
bump Compiler.jl version to 0.1.1

### DIFF
--- a/Compiler/LICENSE.md
+++ b/Compiler/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2009-2024: Jeff Bezanson, Stefan Karpinski, Viral B. Shah, and other contributors: https://github.com/JuliaLang/julia/contributors
+Copyright (c) 2009-2025: Jeff Bezanson, Stefan Karpinski, Viral B. Shah, and other contributors: https://github.com/JuliaLang/julia/contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/Compiler/Project.toml
+++ b/Compiler/Project.toml
@@ -1,6 +1,6 @@
 name = "Compiler"
 uuid = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
-version = "0.1.0"
+version = "0.1.1"
 
 [compat]
 julia = "1.10"

--- a/Compiler/README.md
+++ b/Compiler/README.md
@@ -19,10 +19,10 @@ Compiler = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
 Compiler = "0.1"
 ```
 
-With the setup above, [the special placeholder version (v0.1.0)](https://github.com/JuliaLang/BaseCompiler.jl)
+With the setup above, [the special placeholder version (v0.1)](https://github.com/JuliaLang/BaseCompiler.jl)
 will be installed by default.[^1]
 
-[^1]: Currently, only version v0.1.0 is registered in the [General](https://github.com/JuliaRegistries/General) registry.
+[^1]: Currently, only version v0.1 is registered in the [General](https://github.com/JuliaRegistries/General) registry.
 
 If needed, you can switch to a custom implementation of the `Compiler` module by running
 ```julia-repl


### PR DESCRIPTION
As the latest version of BaseCompiler.jl will be bumped to v0.1.1 after JuliaRegistries/General#132990.