### PR TITLE
WIP: Docstring refactoring

### DIFF
--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -143,7 +143,7 @@ include("exports.jl")
 
 # core docsystem
 include("docs/core.jl")
-Core.atdoc!(CoreDocs.docm)
+Core._set_setdoc!(CoreDocs.boot_setdoc)
 
 eval(x) = Core.eval(Base, x)
 eval(m::Module, x) = Core.eval(m, x)

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -68,7 +68,6 @@ include("bindings.jl")
 import .Base.Meta: quot, isexpr, unblock, unescape, uncurly
 import .Base: Callable, with_output_color
 using .Base: RefValue, mapany
-import ..CoreDocs: lazy_iterpolate
 
 export doc, hasdoc, undocumented_names
 
@@ -98,55 +97,6 @@ function initmeta(m::Module)
     return invokelatest(getglobal, m, META)
 end
 
-function signature!(tv::Vector{Any}, expr::Expr)
-    is_macrocall = isexpr(expr, :macrocall)
-    if is_macrocall || isexpr(expr, :call)
-        sig = :(Union{Tuple{}})
-        first_arg = is_macrocall ? 3 : 2 # skip function arguments
-        for arg in expr.args[first_arg:end]
-            isexpr(arg, :parameters) && continue
-            if isexpr(arg, :kw) # optional arg
-                push!(sig.args, :(Tuple{$((sig.args[end]::Expr).args[2:end]...)}))
-            end
-            push!((sig.args[end]::Expr).args, argtype(arg))
-        end
-        if isexpr(expr.args[1], :curly) && isempty(tv)
-            append!(tv, mapany(tvar, (expr.args[1]::Expr).args[2:end]))
-        end
-        for i = length(tv):-1:1
-            push!(sig.args, :(Tuple{$((tv[i]::Expr).args[1])}))
-        end
-        for i = length(tv):-1:1
-            sig = Expr(:where, sig, tv[i])
-        end
-        return sig
-    elseif isexpr(expr, :where)
-        append!(tv, mapany(tvar, expr.args[2:end]))
-        return signature!(tv, expr.args[1])
-    else
-        return signature!(tv, expr.args[1])
-    end
-end
-signature!(tv::Vector{Any}, @nospecialize(other)) = :(Union{})
-signature(expr::Expr) = signature!([], expr)
-signature(@nospecialize other) = signature!([], other)
-
-function argtype(expr::Expr)
-    isexpr(expr, :(::))  && return expr.args[end]
-    isexpr(expr, :(...)) && return :(Vararg{$(argtype(expr.args[1]))})
-    if isexpr(expr, :meta) && length(expr.args) == 2
-        a1 = expr.args[1]
-        if a1 === :nospecialize || a1 === :specialize
-            return argtype(expr.args[2])
-        end
-    end
-    return argtype(expr.args[1])
-end
-argtype(@nospecialize other) = :Any
-
-tvar(x::Expr)   = x
-tvar(s::Symbol) = :($s <: Any)
-
 # Docsystem types.
 # ================
 
@@ -168,35 +118,11 @@ mutable struct DocStr
     data   :: Dict{Symbol, Any}
 end
 
-function docstr(binding::Binding, typesig = Union{})
-    @nospecialize typesig
-    for m in modules
-        dict = meta(m; autoinit=false)
-        isnothing(dict) && continue
-        if haskey(dict, binding)
-            docs = dict[binding].docs
-            if haskey(docs, typesig)
-                return docs[typesig]
-            end
-        end
-    end
-    error("could not find matching docstring for '$binding :: $typesig'.")
-end
-docstr(object, data = Dict{Symbol,Any}()) = _docstr(object, data)
-
-_docstr(vec::Core.SimpleVector, data::Dict{Symbol,Any}) = DocStr(vec,            nothing, data)
-_docstr(str::AbstractString,    data::Dict{Symbol,Any}) = DocStr(Core.svec(str), nothing, data)
-_docstr(object,                 data::Dict{Symbol,Any}) = DocStr(Core.svec(),     object, data)
-
-_docstr(doc::DocStr, data::Dict{Symbol,Any}) = (doc.data = merge(data, doc.data); doc)
-
 macro ref(x)
     binding = bindingexpr(namify(x))
     typesig = signature(x)
     return esc(docexpr(__source__, __module__, binding, typesig))
 end
-
-docexpr(__source__, __module__, args...) = Expr(:call, docstr, args...)
 
 """
     MultiDoc
@@ -284,9 +210,6 @@ function getdoc end
 getdoc(@nospecialize(x), @nospecialize(sig)) = getdoc(x)
 getdoc(@nospecialize(x)) = nothing
 
-# Utilities.
-# ==========
-
 """
 `catdoc(xs...)`: Combine the documentation metadata `xs` into a single meta object.
 """
@@ -294,152 +217,6 @@ catdoc() = nothing
 catdoc(xs...) = vcat(xs...)
 
 const keywords = Dict{Symbol, DocStr}()
-
-namify(@nospecialize x) = astname(x, isexpr(x, :macro))::Union{Symbol,Expr,GlobalRef}
-
-function astname(x::Expr, ismacro::Bool)
-    head = x.head
-    if head === :.
-        ismacro ? macroname(x) : x
-    elseif head === :call && isexpr(x.args[1], :(::))
-        return astname((x.args[1]::Expr).args[end], ismacro)
-    else
-        n = isexpr(x, (:module, :struct)) ? 2 : 1
-        astname(x.args[n], ismacro)
-    end
-end
-astname(q::QuoteNode, ismacro::Bool) = astname(q.value, ismacro)
-astname(s::Symbol, ismacro::Bool)    = ismacro ? macroname(s) : s
-astname(@nospecialize(other), ismacro::Bool) = other
-
-macroname(s::Symbol) = Symbol('@', s)
-macroname(x::Expr)   = Expr(x.head, x.args[1], macroname(x.args[end].value))
-
-isfield(@nospecialize x) = isexpr(x, :.) &&
-    (isa(x.args[1], Symbol) || isfield(x.args[1])) &&
-    (isa(x.args[2], QuoteNode) || isexpr(x.args[2], :quote))
-
-# @doc expression builders.
-# =========================
-
-"""
-    Docs.metadata(source, module, expr, ismodule)
-
-Build a `Dict` expression containing metadata captured from the expression `expr`.
-
-Fields that may be included in the returned `Dict`:
-
-- `:path`:       Symbol representing the file where `expr` is defined.
-- `:linenumber`: Linenumber where `expr` is defined.
-- `:module`:     Module where the docstring is defined.
-- `:fields`:     `Dict` of all field docs found in `expr`. Only for concrete types.
-"""
-function metadata(__source__, __module__, expr, ismodule)
-    args = []
-    # Filename and linenumber of the docstring.
-    __file__ = isa(__source__.file, Symbol) ? String(__source__.file) : ""
-    push!(args, Pair(:path, __file__))
-    push!(args, Pair(:linenumber, __source__.line))
-    # Module in which the docstring is defined.
-    if ismodule # Module docs go inside the module with name `expr`
-        push!(args, :($Pair(:module, $expr)))
-    else
-        push!(args, Pair(:module, __module__))
-    end
-    if isexpr(expr, :struct)
-        # Field docs for concrete types.
-        P = Pair{Symbol,Any}
-        fields = P[]
-        last_docstr = nothing
-        for each in (expr.args[3]::Expr).args
-            eachex = unescape(each)
-            if isa(eachex, Symbol) || isexpr(eachex, :(::))
-                # a field declaration
-                if last_docstr !== nothing
-                    push!(fields, P(namify(eachex::Union{Symbol,Expr}), last_docstr))
-                    last_docstr = nothing
-                end
-            elseif isexpr(eachex, :function) || isexpr(eachex, :(=))
-                break
-            elseif isa(eachex, String) || isexpr(eachex, :string) || isexpr(eachex, :call) ||
-                (isexpr(eachex, :macrocall) && eachex.args[1] === Symbol("@doc_str"))
-                # forms that might be doc strings
-                last_docstr = each
-            end
-        end
-        dict = :($(Dict{Symbol,Any})($([(:($(P)($(quot(f)), $d)))::Expr for (f, d) in fields]...)))
-        push!(args, :($(Pair)(:fields, $dict)))
-    end
-    return :($(Dict{Symbol,Any})($(args...)))
-end
-
-function keyworddoc(__source__, __module__, str, def::Base.BaseDocs.Keyword)
-    @nospecialize str
-    docstr = esc(docexpr(__source__, __module__, lazy_iterpolate(str), metadata(__source__, __module__, def, false)))
-    return :($setindex!($(keywords), $docstr, $(esc(quot(def.name)))); nothing)
-end
-
-function objectdoc(__source__, __module__, str, def, expr, sig = :(Union{}))
-    @nospecialize str def expr sig
-    binding = esc(bindingexpr(namify(expr)))
-    docstr  = esc(docexpr(__source__, __module__, lazy_iterpolate(str), metadata(__source__, __module__, expr, false)))
-    # Note: we want to avoid introducing line number nodes here (issue #24468)
-    return Expr(:block, esc(def), :($(doc!)($__module__, $binding, $docstr, $(esc(sig)))))
-end
-
-function calldoc(__source__, __module__, str, def::Expr)
-    @nospecialize str
-    args = callargs(def)
-    if isempty(args) || all(validcall, args)
-        objectdoc(__source__, __module__, str, nothing, def, signature(def))
-    else
-        docerror(def)
-    end
-end
-callargs(ex::Expr) = isexpr(ex, :where) ? callargs(ex.args[1]) :
-    isexpr(ex, :call) ? ex.args[2:end] : error("Invalid expression to callargs: $ex")
-validcall(x) = isa(x, Symbol) || isexpr(x, (:(::), :..., :kw, :parameters))
-
-function moduledoc(__source__, __module__, meta, def, def′::Expr)
-    @nospecialize meta def
-    name  = namify(def′)
-    docex = Expr(:call, doc!, name, bindingexpr(name),
-        docexpr(__source__, name, lazy_iterpolate(meta), metadata(__source__, __module__, name, true)))
-    if def === nothing
-        esc(:(Core.eval($name, $(quot(docex)))))
-    else
-        def = unblock(def)
-        block = def.args[3].args
-        if !def.args[1]
-            pushfirst!(block, :(import Base: @doc))
-        end
-        push!(block, docex)
-        esc(Expr(:toplevel, def))
-    end
-end
-
-# Shares a single doc, `meta`, between several expressions from the tuple expression `ex`.
-function multidoc(__source__, __module__, meta, ex::Expr, define::Bool)
-    @nospecialize meta
-    out = Expr(:block)
-    str = docexpr(__source__, __module__, lazy_iterpolate(meta), metadata(__source__, __module__, ex, false))
-    ref = RefValue{DocStr}()
-    first = true
-    for arg in ex.args
-        # The first `arg` to be documented needs to also create the docstring for the group
-        # (after doing the action defined by the argument).
-        # Subsequent `arg`s just need `ref` to be able to find the docstring without having
-        # to create an entirely new one each.
-        if first
-            first = false
-            docstr = :($getindex($setindex!($(ref), $str)))
-        else
-            docstr = :($getindex($(ref)))
-        end
-        push!(out.args, docm(__source__, __module__, docstr, arg, define))
-    end
-    return out
-end
 
 """
     @__doc__(ex)
@@ -505,73 +282,7 @@ more than one expression is marked then the same docstring is applied to each ex
 """
 :(Core.@__doc__)
 
-function __doc__!(source, mod, meta, def, define::Bool)
-    @nospecialize source mod meta def
-    # Two cases must be handled here to avoid redefining all definitions contained in `def`:
-    if define
-        function replace_meta_doc(each)
-            each.head = :macrocall
-            each.args = Any[Symbol("@doc"), source, mod, nothing, meta, each.args[end], define]
-        end
-
-        # `def` has not been defined yet (this is the common case, i.e. when not generating
-        # the Base image). We just need to convert each `@__doc__` marker to an `@doc`.
-        found = finddoc(replace_meta_doc, mod, def; expand_toplevel = false)
-
-        if !found
-            found = finddoc(replace_meta_doc, mod, def; expand_toplevel = true)
-        end
-    else
-        # `def` has already been defined during Base image gen so we just need to find and
-        # document any subexpressions marked with `@__doc__`.
-        docs  = []
-        found = finddoc(mod, def; expand_toplevel = true) do each
-            push!(docs, :(@doc($source, $mod, $meta, $(each.args[end]), $define)))
-        end
-        # If any subexpressions have been documented then replace the entire expression with
-        # just those documented subexpressions to avoid redefining any definitions.
-        if found
-            def.head = :toplevel
-            def.args = docs
-        end
-    end
-    return found
-end
-# Walk expression tree `def` and call `λ` when any `@__doc__` markers are found. Returns
-# `true` to signify that at least one `@__doc__` has been found, and `false` otherwise.
-function finddoc(λ, mod::Module, def::Expr; expand_toplevel::Bool=false)
-    if isexpr(def, :block, 2) && isexpr(def.args[1], :meta, 1) && (def.args[1]::Expr).args[1] === :doc
-        # Found the macroexpansion of an `@__doc__` expression.
-        λ(def)
-        true
-    else
-        if expand_toplevel && isexpr(def, :toplevel)
-            for i = 1:length(def.args)
-                def.args[i] = macroexpand(mod, def.args[i])
-            end
-        end
-        found = false
-        for each in def.args
-            found |= finddoc(λ, mod, each; expand_toplevel)
-        end
-        found
-    end
-end
-finddoc(λ, mod::Module, @nospecialize def; expand_toplevel::Bool=false) = false
-
-# Predicates and helpers for `docm` expression selection:
-
-const FUNC_HEADS    = [:function, :macro, :(=)]
-const BINDING_HEADS = [:const, :global, :(=)]
-# For the special `:@mac` / `:(Base.@mac)` syntax for documenting a macro after definition.
-isquotedmacrocall(@nospecialize x) =
-    isexpr(x, :copyast, 1) &&
-    isa(x.args[1], QuoteNode) &&
-    isexpr(x.args[1].value, :macrocall, 2)
-# Simple expressions / atoms the may be documented.
-isbasicdoc(@nospecialize x) = isexpr(x, :.) || isa(x, Union{QuoteNode, Symbol})
-is_signature(@nospecialize x) = isexpr(x, :call) || (isexpr(x, :(::), 2) && isexpr(x.args[1], :call)) || isexpr(x, :where)
-
+# Helpers for single-arg @doc
 function _lookup_doc(binding::Binding, sig::Type = Union{})
     if defined(binding)
         result = getdoc(resolve(binding), sig)
@@ -594,13 +305,11 @@ function _lookup_doc(binding::Binding, sig::Type = Union{})
     end
     return nothing
 end
-
-# Some additional convenience `doc` methods that take objects rather than `Binding`s.
 _lookup_doc(obj::UnionAll) = _lookup_doc(Base.unwrap_unionall(obj))
 _lookup_doc(object, sig::Type = Union{}) = _lookup_doc(aliasof(object, typeof(object)), sig)
 _lookup_doc(object, sig...)              = _lookup_doc(object, Tuple{sig...})
 
-function _getdoc(source::LineNumberNode, mod::Module, ex)
+function _docm_get(source::LineNumberNode, mod::Module, ex)
     @nospecialize ex
     if (REPL = Base.REPL_MODULE_REF[]) !== Base
         # TODO: this is a shim to continue to allow `@doc` for looking up docstrings
@@ -625,117 +334,6 @@ function _getdoc(source::LineNumberNode, mod::Module, ex)
     end
     return nothing
 end
-# Drop incorrect line numbers produced by nested macro calls.
-docm(source::LineNumberNode, mod::Module, _, _, x...) = docm(source, mod, x...)
-
-# iscallexpr checks if an expression is a :call expression. The call expression may be
-# also part of a :where expression, so it unwraps the :where layers until it reaches the
-# "actual" expression
-iscallexpr(ex::Expr) = isexpr(ex, :where) ? iscallexpr(ex.args[1]) : isexpr(ex, :call)
-iscallexpr(ex) = false
-
-function docm(source::LineNumberNode, mod::Module, meta, ex, define::Bool = true)
-    @nospecialize meta ex
-    # Some documented expressions may be decorated with macro calls which obscure the actual
-    # expression. Expand the macro calls.
-    x = macroexpand(mod, ex)
-    return _docm(source, mod, meta, x, define)
-end
-
-function _docm(source::LineNumberNode, mod::Module, meta, x, define::Bool = true)
-    if isexpr(x, :var"hygienic-scope")
-        x.args[1] = _docm(source, mod, meta, x.args[1])
-        return x
-    elseif isexpr(x, :escape)
-        x.args[1] = _docm(source, mod, meta, x.args[1])
-        return x
-    elseif isexpr(x, :block)
-        docarg = 0
-        for i = 1:length(x.args)
-            isa(x.args[i], LineNumberNode) && continue
-            if docarg == 0
-                docarg = i
-                continue
-            end
-            # More than one documentable expression in the block, treat it as a whole
-            # expression, which will fall through and look for (Expr(:meta, doc))
-            docarg = 0
-            break
-        end
-        if docarg != 0
-            x.args[docarg] = _docm(source, mod, meta, x.args[docarg], define)
-            return x
-        end
-    end
-
-    # Don't try to redefine expressions. This is only needed for `Base` img gen since
-    # otherwise calling `loaddocs` would redefine all documented functions and types.
-    def = define ? x : nothing
-    if isa(x, GlobalRef) && (x::GlobalRef).mod == mod
-        x = (x::GlobalRef).name
-    end
-
-    # Keywords using the `@kw_str` macro in `base/docs/basedocs.jl`.
-    #
-    #   "..."
-    #   kw"if", kw"else"
-    #
-    doc =
-    isa(x, Base.BaseDocs.Keyword) ? keyworddoc(source, mod, meta, x) :
-
-    # Method / macro definitions and "call" syntax.
-    #
-    #   function f(...) ... end
-    #   f(...) = ...
-    #   macro m(...) end
-    #   function f end
-    #   f(...)
-    #
-    # Including if the "call" expression is wrapped in "where" expression(s) (#32960), i.e.
-    #
-    #   f(::T) where T
-    #   f(::T, ::U) where T where U
-    #
-    isexpr(x, FUNC_HEADS) && is_signature((x::Expr).args[1]) ? objectdoc(source, mod, meta, def, x::Expr, signature(x::Expr)) :
-    isexpr(x, [:function, :macro])  && !isexpr((x::Expr).args[1], :call) ? objectdoc(source, mod, meta, def, x::Expr) :
-    iscallexpr(x) ? calldoc(source, mod, meta, x::Expr) :
-
-    # Type definitions.
-    #
-    #   struct T ... end
-    #   abstract type T end
-    #   primitive type T N end
-    #
-    isexpr(x, [:struct, :abstract, :primitive]) ? objectdoc(source, mod, meta, def, x::Expr) :
-
-    # "Bindings". Names that resolve to objects with different names, ie.
-    #
-    #   const T = S
-    #   T = S
-    #   global T = S
-    #
-    isexpr(x, BINDING_HEADS) && !isexpr((x::Expr).args[1], :call) ? objectdoc(source, mod, meta, def, x::Expr) :
-
-    # Quoted macrocall syntax. `:@time` / `:(Base.@time)`.
-    isquotedmacrocall(x) ? objectdoc(source, mod, meta, def, x) :
-    # Modules and baremodules.
-    isexpr(x, :module) ? moduledoc(source, mod, meta, def, x::Expr) :
-    # Document several expressions with the same docstring. `a, b, c`.
-    isexpr(x, :tuple) ? multidoc(source, mod, meta, x::Expr, define) :
-    # Errors generated by calling `macroexpand` are passed back to the call site.
-    isexpr(x, :error) ? esc(x) :
-    # When documenting macro-generated code we look for embedded `@__doc__` calls.
-    __doc__!(source, mod, meta, x, define) ? esc(x) :
-    # Any "basic" expression such as a bare function or module name or numeric literal.
-    isbasicdoc(x) ? objectdoc(source, mod, meta, nothing, x) :
-
-    # All other expressions are undocumentable and should be handled on a case-by-case basis
-    # with `@__doc__`. Unbound string literals are also undocumentable since they cannot be
-    # retrieved from the module's metadata `IdDict` without a reference to the string.
-    docerror(x)
-
-    return doc
-end
 
 function docerror(@nospecialize ex)
     txt = """
@@ -750,18 +348,39 @@ end
 
 include("utils.jl")
 
+# Generally x is a Julia object, but we can document undefined names with Symbol
+function setdoc(mod::Module, str::Core.SimpleVector, lnn::LineNumberNode,
+                @nospecialize(x), foo, @nospecialize(sig=Union{}))
+    mdict = Dict{Symbol,Any}()
+    mdict[:path] = String(lnn.file)
+    mdict[:linenumber] = lnn.line
+    mdict[:module] = mod
+    # TODO struct field metadata
+    dstr = DocStr(str, x, mdict)
+
+    if x isa Base.BaseDocs.Keyword
+        setindex!(keywords, dstr, x.name)
+        return nothing
+    end
+    name = x isa Symbol ? x :
+        x isa Method ? x.name :
+        x isa Module || x isa Function ? nameof(x) :
+        Symbol(string(x))
+
+    if x isa Method
+        sig = x.sig
+    end
+    doc!(mod, Binding(mod, name), dstr, sig)
+    # x
+end
+
 # Swap out the bootstrap macro with the real one.
-Core.atdoc!(docm)
-Core._set_getdoc!(_getdoc)
+Core._set_docm_get!(_docm_get)
+Core._set_setdoc!(setdoc)
 
 function loaddocs(docs::Base.CoreDocs.DocLinkedList)
-    while isdefined(docs, :doc)
-        (mod, ex, str, file, line) = docs.doc
-        data = Dict{Symbol,Any}(:path => string(file), :linenumber => line)
-        doc = docstr(str, data)
-        lno = LineNumberNode(line, file)
-        docstring = docm(lno, mod, doc, ex, false) # expand the real @doc macro now
-        Core.eval(mod, Expr(:var"hygienic-scope", docstring, Docs, lno))
+    while isdefined(docs, :args)
+        setdoc(docs.args...)
         docs = docs.next
     end
     nothing

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -602,9 +602,7 @@ _lookup_doc(object, sig...)              = _lookup_doc(object, Tuple{sig...})
 
 function _getdoc(source::LineNumberNode, mod::Module, ex)
     @nospecialize ex
-    if isexpr(ex, :->) && length(ex.args) > 1
-        return docm(source, mod, ex.args...)
-    elseif (REPL = Base.REPL_MODULE_REF[]) !== Base
+    if (REPL = Base.REPL_MODULE_REF[]) !== Base
         # TODO: this is a shim to continue to allow `@doc` for looking up docstrings
         return invokelatest(REPL.lookup_doc, ex)
     end

--- a/base/docs/core.jl
+++ b/base/docs/core.jl
@@ -33,7 +33,5 @@ function docm(source::LineNumberNode, mod::Module, str, x)
     end
     return Expr(:escape, out)
 end
-docm(source::LineNumberNode, mod::Module, x) =
-    (isa(x, Expr) && x.head === :->) ? docm(source, mod, x.args[1], x.args[2].args[2]) : error("invalid '@doc'.")
 
 end

--- a/base/docs/core.jl
+++ b/base/docs/core.jl
@@ -4,34 +4,19 @@ module CoreDocs
 
 import Core: @nospecialize, SimpleVector
 
+# Temporary storage until the full docsystem is available
 struct DocLinkedList
-    doc::SimpleVector
+    args::Tuple
     next::DocLinkedList
     DocLinkedList() = new()
-    DocLinkedList(doc::SimpleVector, next::DocLinkedList) = new(doc, next)
+    DocLinkedList(args::Tuple, next::DocLinkedList) = new(args, next)
 end
 
 global DOCS = DocLinkedList()
-function doc!(source::LineNumberNode, mod::Module, str, ex)
-    global DOCS
-    DOCS = DocLinkedList(Core.svec(mod, ex, str, source.file, source.line), DOCS)
+
+function boot_setdoc(args...)
+    global DOCS = DocLinkedList(args, DOCS)
     nothing
-end
-
-isexpr(x, h::Symbol) = isa(x, Expr) && x.head === h
-
-lazy_iterpolate(s::AbstractString) = Expr(:call, Core.svec, s)
-lazy_iterpolate(x) = isexpr(x, :string) ? Expr(:call, Core.svec, x.args...) : x
-
-function docm(source::LineNumberNode, mod::Module, str, x)
-    out = Expr(:call, doc!, QuoteNode(source), mod, lazy_iterpolate(str), QuoteNode(x))
-    if isexpr(x, :module)
-        out = Expr(:toplevel, out, x)
-    elseif isexpr(x, :call)
-    else
-        out = Expr(:block, x, out)
-    end
-    return Expr(:escape, out)
 end
 
 end

--- a/src/ast.c
+++ b/src/ast.c
@@ -327,6 +327,7 @@ void jl_init_common_symbols(void)
     jl_sequentially_consistent_sym = jl_symbol("sequentially_consistent");
     jl_uninferred_sym = jl_symbol("uninferred");
     jl_latestworld_sym = jl_symbol("latestworld");
+    jl_doc_sym = jl_symbol("doc");
 }
 
 JL_DLLEXPORT void jl_lisp_prompt(void)

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -145,10 +145,12 @@
 (define *in-lowering* #f)
 
 (define (lower-toplevel-expr e file line)
-  (cond ((or (atom? e) (toplevel-only-expr? e))
+  (cond ((atom? e)
          (if (underscore-symbol? e)
              (error "all-underscore identifiers are write-only and their values cannot be used in expressions"))
          e)
+        ((toplevel-only-expr? e) e)
+        ((and (eq? (car e) 'doc) (toplevel-only-expr? (caddr e))) (lower-toplevel-doc e))
         (else
          (let ((last *in-lowering*))
            (if (not last)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1928,6 +1928,7 @@ JL_DLLEXPORT int jl_isabspath(const char *in) JL_NOTSAFEPOINT;
     XX(core_sym) \
     XX(coverageeffect_sym) \
     XX(do_sym) \
+    XX(doc_sym) \
     XX(dot_sym) \
     XX(empty_sym) \
     XX(enter_sym) \

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -612,14 +612,14 @@ let __source__ = LineNumberNode(0),
             :(f(x = 1)),
             :(f(; x = 1))
         ]
-        @test Meta.isexpr(Docs.docm(__source__, __module__, "...", each), :block)
+        @test Meta.isexpr(Core.old_docm(__source__, __module__, "...", each), :block)
     end
     for each in [ # invalid syntax
             :(f("...")),
             :(f(1, 2)),
             :(f(() -> ()))
         ]
-        result = Docs.docm(__source__, __module__, "...", each)
+        result = Core.old_docm(__source__, __module__, "...", each)
         @test Meta.isexpr(result, :call)
         @test result.args[1] === error
     end
@@ -1519,8 +1519,8 @@ struct B_20087 end
 
 # issue #27832
 
-_last_atdoc = Core.atdoc
-Core.atdoc!(Base.CoreDocs.docm)  # test bootstrap doc system
+_last_setdoc = Core.old_docm
+Core._set_old_docm!(Base.CoreDocs.docm)  # test bootstrap doc system
 
 """
 """
@@ -1533,7 +1533,7 @@ for fn in (:isdone,)
 end
 end
 @test M27832.xs == ":(\$(Expr(:\$, :fn)))"
-Core.atdoc!(_last_atdoc)
+Core._set_old_docm!(_last_setdoc)
 
 # issue #29432
 "First docstring" module Module29432 end


### PR DESCRIPTION
This change moves the construction of docstring registration calls into lowering
instead of doing so in a macro.  The original intent was just to fix #58630,
but some refactoring is necessary to do this in a good way.

Not all of the following is implemented yet.  Feedback on the design is welcome!

## Current design
Docstrings are stored in a module-scoped IdDict mapping Base.Docs.Binding to
Base.Docs.MultiDoc, which either contains a single docstring, or a map from
method signature to docstring.

Docstrings are parsed to `@doc str x` calls (this macro is also public and
used).  `@doc` defers to `Core.atdoc!`, which figures out if it's one of the
many things we can document, tries to guess the signature of any methods if `x`
is a function, and returns a quoted call to `Docs.doc!`, which registers the
docstring.

A few things make our current design complex:
1. Docstring registration calls are computed during macro expansion, so we're
   trying to figure out what we're documenting purely by Expr.  We need to dig
   through struct contents and call expressions to find field docstrings and
   signatures.
   - The implicit first argument in a signature tuple is excluded from our keys
2. `@doc` is sometimes responsible for evaluating the expression it's given, and
   sometimes not.

Complicating matters further are a few "doc-only" special cases where adding a
docstring changes the semantics of the following expression

```julia
"foo"
x         # Will never throw an UndefVarError

"foo"
Mod.x     # Same for x, but Mod needs to be defined.

"foo"
f(x::T)   # f isn't called.  Neither f nor x need to be defined, but T does.
```

## This change
- Structures and the information we store (other than including signatures'
  first arguments in keys) are both unchanged.
- Change two-arg `@doc` to produce `Expr(:doc, ...)` instead of calling 
  `Core.atdoc`
- New `Expr(:doc, str, x, linenode)` form.  Generally, this lowers `x`
  as usual followed by a call like

  ```julia
  Core.setdoc(m::Module, docstr::Core.SimpleVector, linenode, x::Any)
  ```

  and returns the value of `x` if we're not in a doc-only case.  Pending parser
  changes, this lets us prevent docstrings from changing what an expression
  returns (modulo doc-only cases).
- Unlike `Core.atdoc`, the new `Core.setdoc` gets the answers from lowering, and
  can query the runtime about the object to document.  The "signature" key we
  use for method `x` is now exactly `x.sig`.

### Misc
- Rename some @doc helpers to distinguish between the `@doc x` ("get docs for
  x") and `@doc str x` (set docstring `str` for `x`) code paths, which are
  pretty disjoint.
- Remove `@doc "foo" -> bar` syntax, which appears to be an undocumented special
  syntax.  I'll put it back if people use it.
- `@doc` used to take all arguments and pass them to `atdoc!`, so had at least
  one secret undocumented argument `define`.  Remove this option.

### Potential issues
- Signature-guessing is necessary in determining the key for doc-only call
  expressions where there's nothing to lower.  In its current form, this PR
  breaks these.
- The REPL uses the same signature-guessing logic for lookup and needs something
  to replace it.
- More lisp?! (but it's a relatively simple addition to lowering, and I
  don't mind being the one to add this to JuliaLowering too).

## Todo
- Parse `"str" x` as `Expr(:doc, ...)` instead of a call to `@doc` (JuliaSyntax
  already does this internally before Expr-converting it)
- It might be worth cleaning up the semantics of `Expr(:doc)`; so far I've 
  tried to stay faithful to existing behaviour.
  https://github.com/mlechu/julia/blob/docsystem-wrangling/src/julia-syntax.scm#L2604-L2617
- Store our new signatures in a vector instead of an IdDict (see #58630).
- Fix up docs for `(::T)(x) = x`
  - We currently count these as docs for `T`
- Check for IR spam, use multidoc instead of duplicated strings
- Two-arg `@doc` should ideally return the same thing (Base.Docs.Binding) as
  before, probably by just calling one-arg `@doc`
- Implement docs for `@__doc__` and quoted macro calls (should be easy)
- Struct field docs
