### PR TITLE
better effects for `iterate` for `Memory` and `Array`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -904,7 +904,7 @@ end
 
 ## Iteration ##
 
-iterate(A::Array, i=1) = (@inline; (i - 1)%UInt < length(A)%UInt ? (@inbounds A[i], i + 1) : nothing)
+iterate(A::Array, i=1) = (@inline; _iterate_array(A, i))
 
 ## Indexing: getindex ##
 

--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -225,7 +225,12 @@ Memory{T}(x::AbstractArray{S,1}) where {T,S} = copyto_axcheck!(Memory{T}(undef, 
 
 ## Iteration ##
 
-iterate(A::Memory, i=1) = (@inline; (i - 1)%UInt < length(A)%UInt ? (@inbounds A[i], i + 1) : nothing)
+function _iterate_array(A::Union{Memory, Array}, i::Int)
+    @inline
+    (i - 1)%UInt < length(A)%UInt ? (A[i], i + 1) : nothing
+end
+
+iterate(A::Memory, i=1) = (@inline; _iterate_array(A, i))
 
 ## Indexing: getindex ##
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2287,6 +2287,20 @@ end
     end
 end
 
+@testset "effect inference for `iterate` for `Array` and for `Memory`" begin
+    for El ∈ (Float32, Real, Any)
+        for Arr ∈ (Memory{El}, Array{El, 0}, Vector{El}, Matrix{El}, Array{El, 3})
+            effects = Base.infer_effects(iterate, Tuple{Arr, Int})
+            @test Base.Compiler.is_effect_free(effects)
+            @test Base.Compiler.is_terminates(effects)
+            @test Base.Compiler.is_notaskstate(effects)
+            @test Base.Compiler.is_noub(effects)
+            @test Base.Compiler.is_nonoverlayed(effects)
+            @test Base.Compiler.is_nortcall(effects)
+        end
+    end
+end
+
 @testset "iterate for linear indexing" begin
     A = [1 2; 3 4]
     v = view(A, :)


### PR DESCRIPTION
After PR #58754 the bounds checking is eliminated by LLVM even without `@inbounds`, so delete `@inbounds` to allow the `noub` effect to be inferred.

Also deduplicate and test for good effect inference.