### PR TITLE
REPL: fix typo and potential `UndefVarError`

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1866,7 +1866,7 @@ function create_global_out!(mod)
         end
         return out
     end
-    return getglobal(mod, Out)
+    return getglobal(mod, :Out)
 end
 
 function capture_result(n::Ref{Int}, @nospecialize(x))


### PR DESCRIPTION
Detected by the new LS diagnostics:)