### PR TITLE
fix fallback code path in `take!(::IOBuffer)` method

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -771,7 +771,7 @@ function take!(io::IOBuffer)
         elseif io.writable
             data = wrap(Array, memoryref(io.data, io.ptr), nbytes)
         else
-            data = read!(io, data)
+            error("Unreachable IOBuffer state")
         end
     end
     if io.writable


### PR DESCRIPTION
JET told me that the `data` local variable was inparticular is undefined at this point.
After reviewing this code, I think this code path is unreachable actually since `bytesavailable(io::IOBuffer)` returns `0` when `io` has been closed. So it's probably better to make it clear.