### PR TITLE
[release-1.12] Revert "Scheduler: Use a "scheduler" task for thread sleep (#57544)"

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -1145,16 +1145,6 @@ function throwto(t::Task, @nospecialize exc)
     return try_yieldto(identity)
 end
 
-@inline function wait_forever()
-    while true
-        wait()
-    end
-end
-
-const get_sched_task = OncePerThread{Task}() do
-    Task(wait_forever)
-end
-
 function ensure_rescheduled(othertask::Task)
     ct = current_task()
     W = workqueue_for(Threads.threadid())
@@ -1191,39 +1181,25 @@ end
 
 checktaskempty = Partr.multiq_check_empty
 
+@noinline function poptask(W::StickyWorkqueue)
+    task = trypoptask(W)
+    if !(task isa Task)
+        task = ccall(:jl_task_get_next, Ref{Task}, (Any, Any, Any), trypoptask, W, checktaskempty)
+    end
+    set_next_task(task)
+    nothing
+end
+
 function wait()
     ct = current_task()
     # [task] user_time -yield-or-done-> wait_time
     record_running_time!(ct)
-    # let GC run
     GC.safepoint()
-    # check for libuv events
-    process_events()
-
-    # get the next task to run
-    result = nothing
-    have_result = false
     W = workqueue_for(Threads.threadid())
-    task = trypoptask(W)
-    if !(task isa Task)
-        # No tasks to run; switch to the scheduler task to run the
-        # thread sleep logic.
-        sched_task = get_sched_task()
-        if ct !== sched_task
-            result = yieldto(sched_task)
-            have_result = true
-        else
-            task = ccall(:jl_task_get_next, Ref{Task}, (Any, Any, Any),
-                         trypoptask, W, checktaskempty)
-        end
-    end
-    # We may have already switched tasks (via the scheduler task), so
-    # only switch if we haven't.
-    if !have_result
-        @assert task isa Task
-        set_next_task(task)
-        result = try_yieldto(ensure_rescheduled)
-    end
+    poptask(W)
+    result = try_yieldto(ensure_rescheduled)
+    process_events()
+    # return when we come out of the queue
     return result
 end
 

--- a/contrib/mac/app/startup.applescript
+++ b/contrib/mac/app/startup.applescript
@@ -1,4 +1,3 @@
 set RootPath to (path to me)
 set JuliaPath to POSIX path of ((RootPath as text) & "Contents:Resources:julia:bin:julia")
-set JuliaFile to POSIX file JuliaPath
-tell application id "com.apple.finder" to open JuliaFile
+do shell script "open -a Terminal '" & JuliaPath & "'"

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -547,12 +547,14 @@ end
         fetch(r)
     end
 
-    let addr = Sockets.InetAddr(ip"192.0.2.5", 4444)
+    let addr = Sockets.InetAddr(ip"127.0.0.1", 4444)
+        srv = listen(addr)
         s = Sockets.TCPSocket()
         Sockets.connect!(s, addr)
         r = @async close(s)
         @test_throws Base._UVError("connect", Base.UV_ECANCELED) Sockets.wait_connected(s)
         fetch(r)
+        close(srv)
     end
 end
 

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -463,14 +463,15 @@ end
         cb = first(async.cond.waitq)
         @test isopen(async)
         ccall(:uv_async_send, Cvoid, (Ptr{Cvoid},), async)
+        ccall(:uv_async_send, Cvoid, (Ptr{Cvoid},), async)
+        @test isempty(Base.Workqueue)
         Base.process_events() # schedule event
         Sys.iswindows() && Base.process_events() # schedule event (windows?)
+        @test length(Base.Workqueue) == 1
         ccall(:uv_async_send, Cvoid, (Ptr{Cvoid},), async)
         @test tc[] == 0
         yield() # consume event
         @test tc[] == 1
-        ccall(:uv_async_send, Cvoid, (Ptr{Cvoid},), async)
-        Base.process_events()
         Sys.iswindows() && Base.process_events() # schedule event (windows?)
         yield() # consume event
         @test tc[] == 2


### PR DESCRIPTION
This reverts commit 640c4e1b5fd11c3b485c6982a90c06cd65cc9717.

See [discussion](https://github.com/JuliaLang/julia/pull/57544#issuecomment-2978227885).

Cc: @KristofferC to confirm that this PR is done correctly (to `release-1.12`).

Cc: @Keno to confirm whether reverting this on 1.12 alone is fine or if you want this reverted on master.