### PR TITLE
Scheduler: do not always switch to the scheduler task

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -1568,7 +1568,7 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     ct->queue = jl_nothing;
     ct->tls = jl_nothing;
     jl_atomic_store_relaxed(&ct->_state, JL_TASK_STATE_RUNNABLE);
-    ct->start = NULL;
+    ct->start = jl_nothing;
     ct->result = jl_nothing;
     ct->donenotify = jl_nothing;
     jl_atomic_store_relaxed(&ct->_isexception, 0);


### PR DESCRIPTION
Only switch when the current task is done/failed. Also, ignore all exceptions in the scheduler task.

[Context](https://github.com/JuliaLang/julia/pull/58764#issuecomment-2981441653).

The downside is that when Julia is lightly loaded, Ctrl+C will often do nothing at all. However, Ctrl+C is delivered to an essentially random task anyway so I'm not sure if this is worse.

@Keno and @vtjnash: I think this is a simple fix that can be added to 1.12 instead of backing the scheduler task out altogether. Thoughts?