### PR TITLE
Fix FwCharPosIter constructor and add test coverage

### DIFF
--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -54,10 +54,10 @@ struct FwCharPosIter{S}
     last_char_byte::UInt8
 end
 
-function FwCharPosIter(s::Union{String, SubString{String}}, c::AbstractChar)
-    char = Char(c)::Char
+function FwCharPosIter(s::S, c::AbstractChar) where S <: AbstractString
+    char = Char(c)
     byte = last_utf8_byte(char)
-    FwCharPosIter{typeof(s)}(s, char, byte)
+    return FwCharPosIter{S}(s, char, byte)
 end
 
 # i is the index in the string to search from.

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -563,3 +563,11 @@ for T = (UInt, BigInt)
         @test findprev(isletter, astr, T(x)) isa Int
     end
 end
+
+@testset "FwCharPosIter constructor" begin
+    s = "hello world"
+    iter = FwCharPosIter(s, 'o')
+    @test iter.string == s
+    @test iter.char == 'o'
+    @test iter.last_char_byte == last_utf8_byte('o')
+end


### PR DESCRIPTION
Fix FwCharPosIter constructor and add corresponding test

Previously, the constructor used `FwCharPosIter{typeof(s)}(s, char, byte)`,
which could lead to errors due to incorrect type inference or struct field mismatch.

This commit defines a proper outer constructor:

    function FwCharPosIter(s::S, c::AbstractChar) where S <: AbstractString
        char = Char(c)
        byte = last_utf8_byte(char)
        return FwCharPosIter{S}(s, char, byte)
    end

A test has also been added in `test/strings/search.jl` to ensure that the
constructor works as expected for both `String` and `SubString{String}` inputs.
