### PR TITLE
inform compiler about local variable definedness

### DIFF
--- a/base/logging/logging.jl
+++ b/base/logging/logging.jl
@@ -411,9 +411,13 @@ function logmsg_code(_module, file, line, level, message, exs...)
                         end
                         line = $(log_data._line)
                         local msg, kwargs
-                        $(logrecord) && $handle_message_nothrow(
-                            logger, level, msg, _module, group, id, file, line;
-                            kwargs...)
+                        if $(logrecord)
+                            @assert @isdefined(msg) "Assertion to tell the compiler about the definedness of this variable"
+                            @assert @isdefined(kwargs) "Assertion to tell the compiler about the definedness of this variable"
+                            $handle_message_nothrow(
+                                logger, level, msg, _module, group, id, file, line;
+                                kwargs...)
+                        end
                     end
                 end
             end

--- a/base/partr.jl
+++ b/base/partr.jl
@@ -107,7 +107,6 @@ function multiq_sift_down(heap::taskheap, idx::Int32)
     end
 end
 
-
 function multiq_size(tpid::Int8)
     nt = UInt32(Threads._nthreads_in_pool(tpid))
     tp = tpid + 1
@@ -137,7 +136,6 @@ function multiq_size(tpid::Int8)
 
     return heap_p
 end
-
 
 function multiq_insert(task::Task, priority::UInt16)
     tpid = ccall(:jl_get_task_threadpoolid, Int8, (Any,), task)
@@ -171,10 +169,8 @@ function multiq_insert(task::Task, priority::UInt16)
     return true
 end
 
-
 function multiq_deletemin()
-    local rn1, rn2
-    local prio1, prio2
+    local rn1::UInt32
 
     tid = Threads.threadid()
     tp = ccall(:jl_threadpoolid, Int8, (Int16,), tid-1) + 1
@@ -207,6 +203,8 @@ function multiq_deletemin()
             unlock(tpheaps[rn1].lock)
         end
     end
+
+    @assert @isdefined(rn1) "Assertion to tell the compiler about the definedness of this variable"
 
     heap = tpheaps[rn1]
     task = heap.tasks[1]

--- a/base/ryu/shortest.jl
+++ b/base/ryu/shortest.jl
@@ -196,6 +196,7 @@ integer. If a `maxsignif` argument is provided, then `b < maxsignif`.
         e10 = 0
 
         if maxsignif !== nothing && b > maxsignif
+            roundup = false
             b_allzero = true
             # reduce to max significant digits
             while true


### PR DESCRIPTION
JET's new analysis pass now detects local variables that may be undefined, which has revealed such issues in several functions within Base (JuliaLang/julia#58762).

This commit addresses local variables whose definedness the compiler cannot properly determine, primarily in functions reachable from JET's test suite. No functional changes are made.