### PR TITLE
Support SANITIZE_ADDRESS on macOS aarch64

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -98,7 +98,7 @@ void win32_formatmessage(DWORD code, char *reason, int len) JL_NOTSAFEPOINT
 }
 #endif
 
-#if defined(_COMPILER_MSAN_ENABLED_) || defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_)
+#if defined(_COMPILER_MSAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_)
 struct link_map;
 typedef void* (dlopen_prototype)(const char* filename, int flags);
 

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -98,7 +98,7 @@ void win32_formatmessage(DWORD code, char *reason, int len) JL_NOTSAFEPOINT
 }
 #endif
 
-#if defined(_COMPILER_MSAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_)
+#if (defined(_COMPILER_MSAN_ENABLED_) || defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_)) && __GLIBC__
 struct link_map;
 typedef void* (dlopen_prototype)(const char* filename, int flags);
 

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -97,8 +97,10 @@ CCLD := $(CC)
 
 # Override `-shared-libasan` from root Make.inc
 ifeq ($(SANITIZE),1)
+ifneq ($(OS),Darwin) # "static AddressSanitizer runtime is not supported on darwin"
 ifeq ($(SANITIZE_ADDRESS),1)
 JLDFLAGS += -static-libsan
+endif
 endif
 endif
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -56,6 +56,26 @@ static inline uintptr_t jmpbuf_sp(jl_jmp_buf *buf)
 {
     return demangle_ptr((uintptr_t)(*buf)[0].__jmpbuf[JB_RSP]);
 }
+#elif defined(__APPLE__) && defined(_CPU_AARCH64_)
+/*
+ * jmpbuf layout:    see libplatform/src/setjmp/arm64/setjmp.s
+ * pointer mangling: see xnu/libsyscall/os/tsd.h
+ */
+static inline uintptr_t demangle_ptr(uintptr_t var)
+{
+    uintptr_t token, out;
+    asm ("mrs %0, TPIDRRO_EL0\n\t"
+         "bic %0, %0, #3\n\t"
+         "ldr %0, [%x0, #56]\n\t"
+         "eor %2, %1, %0"
+         : "=r"(token), "=r"(out)
+         : "r"(var));
+    return out;
+}
+static inline uintptr_t jmpbuf_sp(jl_jmp_buf *buf)
+{
+    return demangle_ptr(((uintptr_t *) buf)[12]);
+}
 #else
 #error Need to implement jmpbuf_sp for this architecture
 #endif

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -151,7 +151,9 @@ namespace {
             // bool UseOdrIndicator = CodeGenOpts.SanitizeAddressUseOdrIndicator;
             // llvm::AsanDtorKind DestructorKind =
             //     CodeGenOpts.getSanitizeAddressDtor();
-            // AddressSanitizerOptions Opts;
+            AddressSanitizerOptions Opts;
+            // Apple's addrsan really wants to be used with Apple LLVM.
+            Opts.InsertVersionCheck = !__APPLE__;
             // Opts.CompileKernel = CompileKernel;
             // Opts.Recover = CodeGenOpts.SanitizeRecover.has(Mask);
             // Opts.UseAfterScope = CodeGenOpts.SanitizeAddressUseAfterScope;
@@ -160,7 +162,7 @@ namespace {
             //Let's assume the defaults are actually fine for our purposes
             // MPM.addPass(AddressSanitizerPass(
             //     Opts, UseGlobalGC, UseOdrIndicator, DestructorKind));
-            MPM.addPass(AddressSanitizerPass(AddressSanitizerOptions(), true, false));
+            MPM.addPass(AddressSanitizerPass(Opts, true, false));
         //   }
         };
         ASanPass(/*SanitizerKind::Address, */false);

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -153,7 +153,9 @@ namespace {
             //     CodeGenOpts.getSanitizeAddressDtor();
             AddressSanitizerOptions Opts;
             // Apple's addrsan really wants to be used with Apple LLVM.
-            Opts.InsertVersionCheck = !__APPLE__;
+    #ifdef __APPLE__
+            Opts.InsertVersionCheck = false;
+    #endif
             // Opts.CompileKernel = CompileKernel;
             // Opts.Recover = CodeGenOpts.SanitizeRecover.has(Mask);
             // Opts.UseAfterScope = CodeGenOpts.SanitizeAddressUseAfterScope;


### PR DESCRIPTION
Handy for local development on mac. Apple's addrsan changes the version check symbol that our LLVM looks for, so we disable this check (it seems fine).