### PR TITLE
codegen: gc wb for atomic FCA stores

### DIFF
--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -1069,3 +1069,9 @@ let io = IOBuffer()
     str = String(take!(io))
     @test !occursin("jtbaa_unionselbyte", str)
 end
+
+let io = IOBuffer()
+    code_llvm(io, (x, y) -> (@atomic x[1] = y; nothing), (AtomicMemory{Pair{Any,Any}}, Pair{Any,Any},), raw=true, optimize=false)
+    str = String(take!(io))
+    @test occursin("julia.write_barrier", str)
+end

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2683,6 +2683,11 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
                 ctx.builder.CreateStore(r, intcast);
                 r = ctx.builder.CreateLoad(intcast_eltyp, intcast);
             }
+            else if (!isboxed && intcast_eltyp) {
+                assert(issetfield);
+                // issetfield doesn't use intcast, so need to reload rhs with the correct type
+                r = emit_unbox(ctx, intcast_eltyp, rhs, jltype);
+            }
             if (!isboxed)
                 emit_write_multibarrier(ctx, parent, r, rhs.typ);
             else


### PR DESCRIPTION
Need to re-load the correct `r` since issetfield skips the intcast, resulting in no gc wb for the FCA.

Fix #58760