### PR TITLE
Don't `@inbounds` AbstractArray's iterate method; optimize `checkbounds` instead

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -387,6 +387,7 @@ function eachindex(A::AbstractArray, B::AbstractArray...)
     @inline
     eachindex(IndexStyle(A,B...), A, B...)
 end
+eachindex(::IndexLinear, A::Union{Array, Memory}) = unchecked_oneto(length(A))
 eachindex(::IndexLinear, A::AbstractArray) = (@inline; oneto(length(A)))
 eachindex(::IndexLinear, A::AbstractVector) = (@inline; axes1(A))
 function eachindex(::IndexLinear, A::AbstractArray, B::AbstractArray...)
@@ -1237,7 +1238,7 @@ oneunit(x::AbstractMatrix{T}) where {T} = _one(oneunit(T), x)
 iterate_starting_state(A) = iterate_starting_state(A, IndexStyle(A))
 iterate_starting_state(A, ::IndexLinear) = firstindex(A)
 iterate_starting_state(A, ::IndexStyle) = (eachindex(A),)
-iterate(A::AbstractArray, state = iterate_starting_state(A)) = _iterate(A, state)
+@inline iterate(A::AbstractArray, state = iterate_starting_state(A)) = _iterate(A, state)
 function _iterate(A::AbstractArray, state::Tuple)
     y = iterate(state...)
     y === nothing && return nothing
@@ -1245,7 +1246,7 @@ function _iterate(A::AbstractArray, state::Tuple)
 end
 function _iterate(A::AbstractArray, state::Integer)
     checkbounds(Bool, A, state) || return nothing
-    @inbounds(A[state]), state + one(state)
+    A[state], state + one(state)
 end
 
 isempty(a::AbstractArray) = (length(a) == 0)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1239,12 +1239,12 @@ iterate_starting_state(A) = iterate_starting_state(A, IndexStyle(A))
 iterate_starting_state(A, ::IndexLinear) = firstindex(A)
 iterate_starting_state(A, ::IndexStyle) = (eachindex(A),)
 @inline iterate(A::AbstractArray, state = iterate_starting_state(A)) = _iterate(A, state)
-function _iterate(A::AbstractArray, state::Tuple)
+@inline function _iterate(A::AbstractArray, state::Tuple)
     y = iterate(state...)
     y === nothing && return nothing
     A[y[1]], (state[1], tail(y)...)
 end
-function _iterate(A::AbstractArray, state::Integer)
+@inline function _iterate(A::AbstractArray, state::Integer)
     checkbounds(Bool, A, state) || return nothing
     A[state], state + one(state)
 end

--- a/base/array.jl
+++ b/base/array.jl
@@ -902,10 +902,6 @@ function grow_to!(dest, itr, st)
     return dest
 end
 
-## Iteration ##
-
-iterate(A::Array, i=1) = (@inline; _iterate_array(A, i))
-
 ## Indexing: getindex ##
 
 """

--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -223,15 +223,6 @@ Memory{T}(x::AbstractArray{S,1}) where {T,S} = copyto_axcheck!(Memory{T}(undef, 
 
 ## copying iterators to containers
 
-## Iteration ##
-
-function _iterate_array(A::Union{Memory, Array}, i::Int)
-    @inline
-    (i - 1)%UInt < length(A)%UInt ? (A[i], i + 1) : nothing
-end
-
-iterate(A::Memory, i=1) = (@inline; _iterate_array(A, i))
-
 ## Indexing: getindex ##
 
 # Faster contiguous indexing using copyto! for AbstractUnitRange and Colon

--- a/base/range.jl
+++ b/base/range.jl
@@ -810,10 +810,8 @@ let bigints = Union{Int, UInt, Int64, UInt64, Int128, UInt128},
         # n.b. !(s isa T)
         if s isa Unsigned || -1 <= s <= 1 || s == -s
             a = div(diff, s) % typeof(diff)
-        elseif s < 0
-            a = div(unsigned(-diff), -s) % typeof(diff)
         else
-            a = div(unsigned(diff), s) % typeof(diff)
+            a = div(unsigned(sign(s)*diff), abs(s)) % typeof(diff)
         end
         return a + oneunit(a)
     end

--- a/base/range.jl
+++ b/base/range.jl
@@ -811,7 +811,7 @@ let bigints = Union{Int, UInt, Int64, UInt64, Int128, UInt128},
         if s isa Unsigned || -1 <= s <= 1 || s == -s
             a = div(diff, s) % typeof(diff)
         else
-            a = div(unsigned(sign(s)*diff), abs(s)) % typeof(diff)
+            a = div(unsigned(flipsign(diff, s)), abs(s)) % typeof(diff)
         end
         return a + oneunit(a)
     end

--- a/base/range.jl
+++ b/base/range.jl
@@ -687,7 +687,7 @@ end
 ## interface implementations
 
 length(r::AbstractRange) = error("length implementation missing") # catch mistakes
-size(r::AbstractRange) = (length(r),)
+size(r::AbstractRange) = (@inline; (length(r),))
 
 isempty(r::StepRange) =
     # steprange_last(r.start, r.step, r.stop) == r.stop
@@ -802,6 +802,7 @@ let bigints = Union{Int, UInt, Int64, UInt64, Int128, UInt128},
     # slightly more accurate length and checked_length in extreme cases
     # (near typemax) for types with known `unsigned` functions
     function length(r::OrdinalRange{T}) where T<:bigints
+        @inline
         s = step(r)
         diff = last(r) - first(r)
         isempty(r) && return zero(diff)
@@ -810,8 +811,10 @@ let bigints = Union{Int, UInt, Int64, UInt64, Int128, UInt128},
         # n.b. !(s isa T)
         if s isa Unsigned || -1 <= s <= 1 || s == -s
             a = div(diff, s) % typeof(diff)
+        elseif s < 0
+            a = div(unsigned(-diff), -s) % typeof(diff)
         else
-            a = div(unsigned(flipsign(diff, s)), abs(s)) % typeof(diff)
+            a = div(unsigned(diff), s) % typeof(diff)
         end
         return a + oneunit(a)
     end

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -797,7 +797,7 @@ size(s::CodeUnits) = (length(s),)
 elsize(s::Type{<:CodeUnits{T}}) where {T} = sizeof(T)
 @propagate_inbounds getindex(s::CodeUnits, i::Int) = codeunit(s.s, i)
 IndexStyle(::Type{<:CodeUnits}) = IndexLinear()
-checkbounds(::Type{Bool}, s::CodeUnits, i) = checkbounds(Bool, s.s, i)
+checkbounds(::Type{Bool}, s::CodeUnits, i::Integer) = checkbounds(Bool, s.s, i)
 
 
 write(io::IO, s::CodeUnits) = write(io, s.s)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -797,7 +797,7 @@ size(s::CodeUnits) = (length(s),)
 elsize(s::Type{<:CodeUnits{T}}) where {T} = sizeof(T)
 @propagate_inbounds getindex(s::CodeUnits, i::Int) = codeunit(s.s, i)
 IndexStyle(::Type{<:CodeUnits}) = IndexLinear()
-@inline iterate(s::CodeUnits, i=1) = (i % UInt) - 1 < length(s) ? (@inbounds s[i], i + 1) : nothing
+@inline iterate(s::CodeUnits, i=1) = checkbounds(Bool, s.s, i) ? (s[i], i + 1) : nothing
 
 
 write(io::IO, s::CodeUnits) = write(io, s.s)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -797,7 +797,7 @@ size(s::CodeUnits) = (length(s),)
 elsize(s::Type{<:CodeUnits{T}}) where {T} = sizeof(T)
 @propagate_inbounds getindex(s::CodeUnits, i::Int) = codeunit(s.s, i)
 IndexStyle(::Type{<:CodeUnits}) = IndexLinear()
-@inline iterate(s::CodeUnits, i=1) = checkbounds(Bool, s.s, i) ? (s[i], i + 1) : nothing
+checkbounds(::Type{Bool}, s::CodeUnits, i) = checkbounds(Bool, s.s, i)
 
 
 write(io::IO, s::CodeUnits) = write(io, s.s)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -324,11 +324,6 @@ FastSubArray{T,N,P,I} = SubArray{T,N,P,I,true}
 @inline _reindexlinear(V::FastSubArray, i::Int) = V.offset1 + V.stride1*i
 @inline _reindexlinear(V::FastSubArray, i::AbstractUnitRange{Int}) = V.offset1 .+ V.stride1 .* i
 
-# For Fast subarrays, we can safely compute the parent's index for its checkbounds; this
-# helps with automatic bounds elision (but isn't possible generally because it's precisely
-# the re-indexing into `V.indices` that might go out-of-bounds)
-checkbounds(::Type{Bool}, V::FastSubArray, i::Int) = (@inline(); checkbounds(Bool, V.parent, _reindexlinear(V, i)))
-
 function getindex(V::FastSubArray, i::Int)
     @inline
     @boundscheck checkbounds(V, i)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -528,9 +528,10 @@ function _indices_sub(i1::AbstractArray, I...)
 end
 
 axes1(::SubArray{<:Any,0}) = OneTo(1)
-axes1(S::SubArray) = (@inline; axes1(S.indices[1]))
-_axes1_sub(::Real, I...) = (@inline; _axes1_sub(I...))
+axes1(S::SubArray) = (@inline; _axes1_sub(S.indices...))
 _axes1_sub() = ()
+_axes1_sub(::Real, I...) = (@inline; _axes1_sub(I...))
+_axes1_sub(::AbstractArray{<:Any,0}, I...) = _axes1_sub(I...)
 function _axes1_sub(i1::AbstractArray, I...)
     @inline
     axes1(i1)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -515,13 +515,20 @@ end
 # Since bounds-checking is performance-critical and uses
 # indices, it's worth optimizing these implementations thoroughly
 axes(S::SubArray) = (@inline; _indices_sub(S.indices...))
-axes1(::SubArray{<:Any,0}) = OneTo(1)
-axes1(S::SubArray) = (@inline; axes1(S.indices[1]))
 _indices_sub(::Real, I...) = (@inline; _indices_sub(I...))
 _indices_sub() = ()
 function _indices_sub(i1::AbstractArray, I...)
     @inline
     (axes(i1)..., _indices_sub(I...)...)
+end
+
+axes1(::SubArray{<:Any,0}) = OneTo(1)
+axes1(S::SubArray) = (@inline; axes1(S.indices[1]))
+_axes1_sub(::Real, I...) = (@inline; _axes1_sub(I...))
+_axes1_sub() = ()
+function _axes1_sub(i1::AbstractArray, I...)
+    @inline
+    axes1(i1)
 end
 
 has_offset_axes(S::SubArray) = has_offset_axes(S.indices...)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -515,6 +515,8 @@ end
 # Since bounds-checking is performance-critical and uses
 # indices, it's worth optimizing these implementations thoroughly
 axes(S::SubArray) = (@inline; _indices_sub(S.indices...))
+axes1(::SubArray{<:Any,0}) = OneTo(1)
+axes1(S::SubArray) = (@inline; axes1(S.indices[1]))
 _indices_sub(::Real, I...) = (@inline; _indices_sub(I...))
 _indices_sub() = ()
 function _indices_sub(i1::AbstractArray, I...)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -324,6 +324,11 @@ FastSubArray{T,N,P,I} = SubArray{T,N,P,I,true}
 @inline _reindexlinear(V::FastSubArray, i::Int) = V.offset1 + V.stride1*i
 @inline _reindexlinear(V::FastSubArray, i::AbstractUnitRange{Int}) = V.offset1 .+ V.stride1 .* i
 
+# For Fast subarrays, we can safely compute the parent's index for its checkbounds; this
+# helps with automatic bounds elision (but isn't possible generally because it's precisely
+# the re-indexing into `V.indices` that might go out-of-bounds)
+checkbounds(::Type{Bool}, V::FastSubArray, i::Int) = (@inline(); checkbounds(Bool, V.parent, _reindexlinear(V, i)))
+
 function getindex(V::FastSubArray, i::Int)
     @inline
     @boundscheck checkbounds(V, i)

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -353,4 +353,20 @@ if bc_opt == bc_default
     @test (@allocated no_alias_prove(5)) == 0
 end
 
+@testset "automatic boundscheck elision for iteration on some important types" begin
+    f = (bc_opt == bc_on) ? identity : (!)
+
+    @test f(contains(sprint(code_llvm, iterate, (Memory{UInt8}, Int)), "unreachable"))
+
+    @test f(contains(sprint(code_llvm, iterate, (Vector{UInt8}, Int)), "unreachable"))
+    @test f(contains(sprint(code_llvm, iterate, (Matrix{UInt8}, Int)), "unreachable"))
+    @test f(contains(sprint(code_llvm, iterate, (Array{UInt8,3}, Int)), "unreachable"))
+
+    @test f(contains(sprint(code_llvm, iterate, (SubArray{Float64, 1, Vector{Float64}, Tuple{Base.Slice{Base.OneTo{Int64}}}, true}, Int)), "unreachable"))
+    @test f(contains(sprint(code_llvm, iterate, (SubArray{Float64, 2, Matrix{Float64}, Tuple{Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}}, true}, Int)), "unreachable"))
+    @test f(contains(sprint(code_llvm, iterate, (SubArray{Float64, 2, Matrix{Float64}, Tuple{Base.Slice{Base.OneTo{Int64}}, UnitRange{Int64}}, true}, Int)), "unreachable"))
+
+    @test f(contains(sprint(code_llvm, iterate, (Base.CodeUnits{UInt8,String}, Int)), "unreachable"))
+end
+
 end

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -354,19 +354,19 @@ if bc_opt == bc_default
 end
 
 @testset "automatic boundscheck elision for iteration on some important types" begin
-    f = (bc_opt == bc_on) ? identity : (!)
+    if bc_opt != bc_on
+        @test !contains(sprint(code_llvm, iterate, (Memory{UInt8}, Int)), "unreachable")
 
-    @test f(contains(sprint(code_llvm, iterate, (Memory{UInt8}, Int)), "unreachable"))
+        @test !contains(sprint(code_llvm, iterate, (Vector{UInt8}, Int)), "unreachable")
+        @test !contains(sprint(code_llvm, iterate, (Matrix{UInt8}, Int)), "unreachable")
+        @test !contains(sprint(code_llvm, iterate, (Array{UInt8,3}, Int)), "unreachable")
 
-    @test f(contains(sprint(code_llvm, iterate, (Vector{UInt8}, Int)), "unreachable"))
-    @test f(contains(sprint(code_llvm, iterate, (Matrix{UInt8}, Int)), "unreachable"))
-    @test f(contains(sprint(code_llvm, iterate, (Array{UInt8,3}, Int)), "unreachable"))
+        @test !contains(sprint(code_llvm, iterate, (SubArray{Float64, 1, Vector{Float64}, Tuple{Base.Slice{Base.OneTo{Int64}}}, true}, Int)), "unreachable")
+        @test !contains(sprint(code_llvm, iterate, (SubArray{Float64, 2, Matrix{Float64}, Tuple{Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}}, true}, Int)), "unreachable")
+        @test !contains(sprint(code_llvm, iterate, (SubArray{Float64, 2, Matrix{Float64}, Tuple{Base.Slice{Base.OneTo{Int64}}, UnitRange{Int64}}, true}, Int)), "unreachable")
 
-    @test f(contains(sprint(code_llvm, iterate, (SubArray{Float64, 1, Vector{Float64}, Tuple{Base.Slice{Base.OneTo{Int64}}}, true}, Int)), "unreachable"))
-    @test f(contains(sprint(code_llvm, iterate, (SubArray{Float64, 2, Matrix{Float64}, Tuple{Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}}, true}, Int)), "unreachable"))
-    @test f(contains(sprint(code_llvm, iterate, (SubArray{Float64, 2, Matrix{Float64}, Tuple{Base.Slice{Base.OneTo{Int64}}, UnitRange{Int64}}, true}, Int)), "unreachable"))
-
-    @test f(contains(sprint(code_llvm, iterate, (Base.CodeUnits{UInt8,String}, Int)), "unreachable"))
+        @test !contains(sprint(code_llvm, iterate, (Base.CodeUnits{UInt8,String}, Int)), "unreachable")
+    end
 end
 
 end


### PR DESCRIPTION
Split off from #58785, this simplifies `iterate` and removes the `@inbounds` call that was added in https://github.com/JuliaLang/julia/pull/58635.  It achieves the same (or better!) performance, however, by targeting optimizations in `checkbounds` and — in particular — the construction of a linear `eachindex` (against which the bounds are checked).