### PR TITLE
implement SubArray reindexing without using `@generated`

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -298,15 +298,8 @@ reindex(idxs::Tuple{AbstractMatrix, Vararg{Any}}, subidxs::Tuple{Any, Any, Varar
     (@_propagate_inbounds_meta; (idxs[1][subidxs[1], subidxs[2]], reindex(tail(idxs), tail(tail(subidxs)))...))
 
 # In general, we index N-dimensional parent arrays with N indices
-@generated function reindex(idxs::Tuple{AbstractArray{T,N}, Vararg{Any}}, subidxs::Tuple{Vararg{Any}}) where {T,N}
-    if length(subidxs.parameters) >= N
-        subs = [:(subidxs[$d]) for d in 1:N]
-        tail = [:(subidxs[$d]) for d in N+1:length(subidxs.parameters)]
-        :(@_propagate_inbounds_meta; (idxs[1][$(subs...)], reindex(tail(idxs), ($(tail...),))...))
-    else
-        :(throw(ArgumentError("cannot re-index SubArray with fewer indices than dimensions\nThis should not occur; please submit a bug report.")))
-    end
-end
+reindex(idxs::Tuple{AbstractArray{<:Any,N}, Vararg{Any}}, subidxs::Tuple{Vararg{Any}}) where {N} =
+    (@_propagate_inbounds_meta; (idxs[1][subidxs[1:N]...], reindex(tail(idxs), subidxs[N+1:end])...))
 
 # In general, we simply re-index the parent indices by the provided ones
 SlowSubArray{T,N,P,I} = SubArray{T,N,P,I,false}


### PR DESCRIPTION
The tuple specialization for indexing with UnitRanges is highly optimized, type stable, and constant foldable for statically known values like these.

Seems like a very good thing to just lean on that.  It's how I would've written this in the first place had that optimized method existed when I wrote it.  It's much more readable and — I imagine — it should be quite a bit friendlier to the compiler.    The only time you should see a performance difference here is when you have a SubArray with 11 or more indices **and** one of those indices is 3-dimensional or more.