### PR TITLE
Allow underscore (unused) args in presence of kwargs

### DIFF
--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2897,6 +2897,9 @@ end
     @test Meta.isexpr(Meta.lower(Main, :(for _ in 1:2; 1; end)), :thunk)
     @test (try; throw(1); catch _; 2; end) === 2
     @test (let _ = 1; 2; end) === 2
+    @test (function f(_, _); 2; end)(0,0) === 2
+    @test (function f(_, _=1); 2; end)(0,0) === 2
+    @test (function f(_, _; kw1=2); kw1; end)(0,0) === 2
     # ERROR: syntax: all-underscore identifiers are write-only and their values cannot be used in expressions
     @test Meta.isexpr(Meta.lower(Main, :(_ = 1; a = _)), :error)
     @test Meta.isexpr(Meta.lower(Main, :(let; function f(); _; end; end)), :error)


### PR DESCRIPTION
Admittedly fixed because I thought I introduced this bug recently, but actually, fix #32727. `f(_; kw) = 1` should now lower in a similar way to `f(::Any; kw) = 1`, where we use a gensym for the first argument.

Not in this PR, but TODO: `nospecialize` underscore-only names