### PR TITLE
Fix syntax issue in codeunit method for AbstractString and Integer

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -104,7 +104,7 @@ UInt8
 
 See also [`ncodeunits`](@ref), [`checkbounds`](@ref).
 """
-@propagate_inbounds codeunit(s::AbstractString, i::Integer) = begin
+@propagate_inbounds function codeunit(s::AbstractString, i::Integer)
     i isa Int ? throw(MethodError(codeunit, (s, i))) : codeunit(s, Int(i))
 end
 

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -104,8 +104,10 @@ UInt8
 
 See also [`ncodeunits`](@ref), [`checkbounds`](@ref).
 """
-@propagate_inbounds codeunit(s::AbstractString, i::Integer) = i isa Int ?
-    throw(MethodError(codeunit, (s, i))) : codeunit(s, Int(i))
+@propagate_inbounds codeunit(s::AbstractString, i::Integer) = begin
+    i isa Int ? throw(MethodError(codeunit, (s, i))) : codeunit(s, Int(i))
+end
+
 
 """
     isvalid(s::AbstractString, i::Integer)::Bool


### PR DESCRIPTION
This PR resolves a syntax issue in `base/strings/basic.jl` line 107, where a ternary expression using `isa` was used directly in a one-liner with `@propagate_inbounds`. Julia's parser can misinterpret such syntax, especially across lines.

The fix wraps the ternary expression in a `begin...end` block to ensure correct behavior and better readability.
