### PR TITLE
fix error message for `eachindex(::Vararg{Tuple})`

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -151,7 +151,7 @@ function keys(t::Tuple, t2::Tuple...)
     @inline
     lent = length(t)
     if !all(==(lent) ∘ length, t2)
-        let inds = map(axes, (t, t2...))
+        let inds = map(only ∘ axes, (t, t2...))
             throw_eachindex_mismatch_indices("indices", inds...)
         end
     end

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -150,7 +150,11 @@ nextind(@nospecialize(t::Tuple), i::Integer) = Int(i)+1
 function keys(t::Tuple, t2::Tuple...)
     @inline
     lent = length(t)
-    all(x->length(x) == lent, t2) || throw_eachindex_mismatch_indices(IndexLinear(), t, t2...)
+    if !all(==(lent) ∘ length, t2)
+        let inds = map(axes, (t, t2...))
+            throw_eachindex_mismatch_indices("indices", inds...)
+        end
+    end
     Base.OneTo(lent)
 end
 


### PR DESCRIPTION
Make the error message in case of mismatch less confusing and consistent with the error message for arrays.

While at it, also made other changes of the same line of source code:

* use function composition instead of an anonymous closure

* expand the one-liner into a multiline `if`