### PR TITLE
WIP: Don't drop 0-dimensional containers in broadcast's result (but preserve behaviors for Ref and Number)

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -911,7 +911,7 @@ end
 _all_args_can_drop_zerodim_container(::Tuple{}) = true
 _all_args_can_drop_zerodim_container(t::Tuple{<:Broadcasted, Vararg{Any}}) =
     _all_args_can_drop_zerodim_container(t[1].args) && _all_args_can_drop_zerodim_container(tail(t))
-_all_args_can_drop_zerodim_container(t::Tuple{<:Union{Number, Ref}, Vararg{Any}}) =
+_all_args_can_drop_zerodim_container(t::Tuple{<:Union{Number, Ref, AbstractChar}, Vararg{Any}}) =
     _all_args_can_drop_zerodim_container(tail(t))
 _all_args_can_drop_zerodim_container(t::Tuple{<:Any, Vararg{Any}}) = false
 @inline function copy(bc::Broadcasted{<:AbstractArrayStyle{0}})

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -883,7 +883,7 @@ but in some cases it is necessary to always return a container — even in the 0
 @inline function broadcast_preserving_zero_d(f, As...)
     bc = broadcasted(f, As...)
     r = materialize(bc)
-    return length(axes(bc)) == 0 ? fill!(similar(bc, typeof(r)), r) : r
+    return _all_args_can_drop_zerodim_container(bc.args) ? fill!(similar(bc, typeof(r)), r) : r
 end
 @inline broadcast_preserving_zero_d(f) = fill(f())
 @inline broadcast_preserving_zero_d(f, as::Number...) = fill(f(as...))

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -908,7 +908,12 @@ end
 end
 
 ## general `copy` methods
-@inline copy(bc::Broadcasted{<:AbstractArrayStyle{0}}) = bc[CartesianIndex()]
+@inline function copy(bc::Broadcasted{<:AbstractArrayStyle{0}})
+    r = bc[CartesianIndex()]
+    dest = similar(bc, typeof(r))
+    dest[] = r
+    return dest
+end
 copy(bc::Broadcasted{<:Union{Nothing,Unknown}}) =
     throw(ArgumentError("broadcasting requires an assigned BroadcastStyle"))
 

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -883,7 +883,7 @@ but in some cases it is necessary to always return a container — even in the 0
 @inline function broadcast_preserving_zero_d(f, As...)
     bc = broadcasted(f, As...)
     r = materialize(bc)
-    return _all_args_can_drop_zerodim_container(bc.args) ? fill!(similar(bc, typeof(r)), r) : r
+    return _all_args_can_drop_zerodim_container(As) ? fill!(similar(bc, typeof(r)), r) : r
 end
 @inline broadcast_preserving_zero_d(f) = fill(f())
 @inline broadcast_preserving_zero_d(f, as::Number...) = fill(f(as...))


### PR DESCRIPTION
This is a trial balloon of a compromise that _just might_ be able to fix #28866 in a minor-change sort of way.  In short, this changes broadcast's default style such that:
* broadcasts that contain _only_ Number and/or Ref arguments unwrap the 0-dimensional containers
* all other broadcasts (including all other zero-dimensional ones) store the result in a mutable (`similar`) container.

I fully expected this to break a slew of tests in `test/broadcast.jl` and LinearAlgebra... but only one `@test` item failed locally (!!).  I'll let CI run the whole suite and then see what PkgEval says before putting more effort into this, but it might just be workable.

-----------

The one failing test I saw locally is `@test muladd(u2', u2, fill(0)) == dot(u2, u2)` — the muladd there is documented as (and is) `u2'*u2 .+ fill(0)`, which now gives back a `fill(dot(u2, u2))`.