### PR TITLE
don't use `IndexSCartesian2` in reshaped reinterpreted array with 0-dim parent

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -249,11 +249,16 @@ struct IndexSCartesian2{K} <: IndexStyle end   # K = sizeof(S) ÷ sizeof(T), a s
 
 IndexStyle(::Type{ReinterpretArray{T,N,S,A,false}}) where {T,N,S,A<:AbstractArray{S,N}} = IndexStyle(A)
 function IndexStyle(::Type{ReinterpretArray{T,N,S,A,true}}) where {T,N,S,A<:AbstractArray{S}}
-    if sizeof(T) < sizeof(S)
-        IndexStyle(A) === IndexLinear() && return IndexSCartesian2{sizeof(S) ÷ sizeof(T)}()
+    if sizeof(T) >= sizeof(S)
+        return IndexStyle(A)
+    end
+
+    # channel dimension added
+    if (IndexStyle(A) === IndexLinear()) && (ndims(A) > 0)
+        return IndexSCartesian2{sizeof(S) ÷ sizeof(T)}()
+    else
         return IndexCartesian()
     end
-    return IndexStyle(A)
 end
 IndexStyle(::IndexSCartesian2{K}, ::IndexSCartesian2{K}) where {K} = IndexSCartesian2{K}()
 

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -607,3 +607,9 @@ let R = reinterpret(reshape, Float32, ComplexF32[1.0f0+2.0f0*im, 4.0f0+3.0f0*im]
     @test !isassigned(R, 5)
     @test Array(R)::Matrix{Float32} == [1.0f0 4.0f0; 2.0f0 3.0f0]
 end
+
+@testset "issue #54623" begin
+    x = 0xabcdef01234567
+    @test reinterpret(reshape, UInt8, fill(x)) == [0x67, 0x45, 0x23, 0x01, 0xef, 0xcd, 0xab, 0x00]
+    @test reinterpret(reshape, UInt8, [x]) == [0x67; 0x45; 0x23; 0x01; 0xef; 0xcd; 0xab; 0x00;;]
+end


### PR DESCRIPTION
fixes https://github.com/JuliaLang/julia/issues/54623

found while writing (but unrelated to) https://github.com/JuliaLang/julia/pull/58814