### PR TITLE
codegen: relaxed jl_tls_states_t.safepoint load

### DIFF
--- a/src/llvm-codegen-shared.h
+++ b/src/llvm-codegen-shared.h
@@ -197,6 +197,7 @@ static inline llvm::Value *get_current_signal_page_from_ptls(llvm::IRBuilder<> &
     llvm::Value *psafepoint = builder.CreateConstInBoundsGEP1_32(i8, ptls, nthfield);
     LoadInst *ptls_load = builder.CreateAlignedLoad(
             T_ptr, psafepoint, Align(sizeof(void *)), "safepoint");
+    ptls_load->setOrdering(AtomicOrdering::Monotonic);
     tbaa_decorate(tbaa, ptls_load);
     return ptls_load;
 }


### PR DESCRIPTION
Every function with a safepoint causes spurious thread sanitizer warnings without this change. Codegen is unaffected, except when we build with `ThreadSanitizerPass`.