### PR TITLE
more conservative `promote_rule` for `Some`

### DIFF
--- a/base/some.jl
+++ b/base/some.jl
@@ -14,8 +14,6 @@ end
 
 Some(::Type{T}) where {T} = Some{Type{T}}(T)
 
-promote_rule(::Type{Some{T}}, ::Type{Some{S}}) where {T, S<:T} = Some{T}
-
 nonnothingtype(@nospecialize(T::Type)) = typesplit(T, Nothing)
 promote_rule(T::Type{Nothing}, S::Type) = Union{S, Nothing}
 function promote_rule(T::Type{>:Nothing}, S::Type)

--- a/test/some.jl
+++ b/test/some.jl
@@ -3,7 +3,7 @@
 ## promote()
 
 @test promote_type(Some{Int}, Some{Float64}) == Some
-@test promote_type(Some{Int}, Some{Real}) == Some{Real}
+@test promote_type(Some{Int}, Some{Real}) == Some
 @test promote_type(Some{Int}, Nothing) == Union{Some{Int},Nothing}
 
 ## convert()


### PR DESCRIPTION
to quote @mbauman
> I don't think the magic here is that Pair is a "wrapper" or "container." The bigger consideration to me is that it doesn't support mathematics in the first place. You can't do ("a"=>0.2) + ("b"=>2.0), so why should we bother promoting ("a"=>0.2) + ("b"=>2)? Mathematics aside, are there any "combining" operations that only work because Pair has promotion here?
> This promotion rule was very intentionally added very long ago — https://github.com/JuliaLang/julia/pull/19171 — and was explicitly targeting promotion in vectors like this.
> Ideally, I think we should remove this rule.

~copies also the defensive `convert` that exists for `Dict` as observed here https://github.com/JuliaLang/julia/issues/12187#issuecomment-122350154~


edit for posterity: this PR now only contains the change to `Some`