### PR TITLE
fix null comparisons for non-standard address spaces

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1611,7 +1611,7 @@ static Value *null_pointer_cmp(jl_codectx_t &ctx, Value *v)
     return ctx.builder.CreateICmpNE(
             v,
             ctx.builder.CreateAddrSpaceCast(
-                Constant::getNullValue(ctx.builder.getPtrTy(0)), T);
+                Constant::getNullValue(ctx.builder.getPtrTy(0)), T));
 }
 
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1601,10 +1601,18 @@ static void undef_var_error_ifnot(jl_codectx_t &ctx, Value *ok, jl_sym_t *name, 
     ctx.builder.SetInsertPoint(ifok);
 }
 
+// ctx.builder.CreateIsNotNull(v) lowers incorrectly in non-standard
+// address spaces where null is not zero
+// TODO: adapt to https://github.com/llvm/llvm-project/pull/131557 once merged
 static Value *null_pointer_cmp(jl_codectx_t &ctx, Value *v)
 {
     ++EmittedNullchecks;
-    return ctx.builder.CreateIsNotNull(v);
+    Type *T = v->getType();
+    return ctx.builder.CreateICmpNE(
+            v,
+            ctx.builder.CreateAddrSpaceCast(
+                Constant::getNullValue(ctx.builder.getPtrTy(AddressSpace::Derived)),
+                PointerType::get(T, T->getPointerAddressSpace())));
 }
 
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1611,8 +1611,7 @@ static Value *null_pointer_cmp(jl_codectx_t &ctx, Value *v)
     return ctx.builder.CreateICmpNE(
             v,
             ctx.builder.CreateAddrSpaceCast(
-                Constant::getNullValue(ctx.builder.getPtrTy(AddressSpace::Derived)),
-                PointerType::get(T, T->getPointerAddressSpace())));
+                Constant::getNullValue(ctx.builder.getPtrTy(0)), T);
 }
 
 


### PR DESCRIPTION
Apparently this is what clang does. Still need to go through other
places we create or compare against null pointers. Also needs tests.
Thanks to @gbaraldi for helping me debug!

fixes JuliaGPU/AMDGPU.jl#780, JuliaGPU/AMDGPU.jl#766

ref ROCm/llvm-project#281
