### PR TITLE
staticdata: Don't discard inlineable code that inference may need

### DIFF
--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2498,4 +2498,10 @@ let m = only(methods(Base.var"@big_str"))
     @test m.specializations === Core.svec() || !isdefined(m.specializations, :cache)
 end
 
+# Issue #58841 - make sure we don't accidentally throw away code for inference
+let io = IOBuffer()
+    run(pipeline(`$(Base.julia_cmd()) --trace-compile=stderr -e 'f() = sin(1.) == 0. ? 1 : 0; exit(f())'`, stderr=io))
+    @test isempty(String(take!(io)))
+end
+
 finish_precompile_test!()


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/issues/58841#issuecomment-3014833096. We were accidentally discarding inferred code during staticdata preparation that we would need immediately afterwards to satisfy inlining requests during code generation for the system image. This was resulting in spurious extra compilation at the first inference after sysimage reload. Additionally it was likely causing various unnecessary dispatch slow paths in the generated inference code. Fixes #58841.