### PR TITLE
Set array size only when safe to do so

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1176,8 +1176,8 @@ function _growend!(a::Vector, delta::Integer)
     newmemlen = offset + newlen - 1
     if memlen < newmemlen
         @noinline _growend_internal!(a, delta, len)
-        setfield!(a, :size, (newlen,))
     end
+    setfield!(a, :size, (newlen,))
     return
 end
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -1225,9 +1225,6 @@ function _growat!(a::Vector, i::Integer, delta::Integer)
         unsafe_copyto!(newmem, newoffset + delta + i - 1, mem, offset + i - 1, len - i + 1)
         setfield!(a, :ref, newref)
         setfield!(a, :size, (newlen,))
-        for j in i:i+delta-1
-            @inbounds _unsetindex!(a, j)
-        end
     end
 end
 


### PR DESCRIPTION
The `.size` of an array might be getting set too early; before the memory is actually allocated.
