### PR TITLE
remove excessive code from trim script

### DIFF
--- a/contrib/juliac/juliac-trim-base.jl
+++ b/contrib/juliac/juliac-trim-base.jl
@@ -78,38 +78,12 @@ end
         end
     end
     show_type_name(io::IO, tn::Core.TypeName) = print(io, tn.name)
-
-    mapreduce(f::F, op::F2, A::AbstractArrayOrBroadcasted; dims=:, init=_InitialValue()) where {F, F2} =
-    _mapreduce_dim(f, op, init, A, dims)
-    mapreduce(f::F, op::F2, A::AbstractArrayOrBroadcasted...; kw...) where {F, F2} =
-        reduce(op, map(f, A...); kw...)
-
-    _mapreduce_dim(f::F, op::F2, nt, A::AbstractArrayOrBroadcasted, ::Colon) where {F, F2} =
-        mapfoldl_impl(f, op, nt, A)
-
-    _mapreduce_dim(f::F, op::F2, ::_InitialValue, A::AbstractArrayOrBroadcasted, ::Colon) where {F, F2} =
-        _mapreduce(f, op, IndexStyle(A), A)
-
-    _mapreduce_dim(f::F, op::F2, nt, A::AbstractArrayOrBroadcasted, dims) where {F, F2} =
-        mapreducedim!(f, op, reducedim_initarray(A, dims, nt), A)
-
-    _mapreduce_dim(f::F, op::F2, ::_InitialValue, A::AbstractArrayOrBroadcasted, dims) where {F,F2} =
-        mapreducedim!(f, op, reducedim_init(f, op, A, dims), A)
-
-    mapreduce_empty_iter(f::F, op::F2, itr, ItrEltype) where {F, F2} =
-        reduce_empty_iter(MappingRF(f, op), itr, ItrEltype)
-        mapreduce_first(f::F, op::F2, x) where {F,F2} = reduce_first(op, f(x))
-
-    _mapreduce(f::F, op::F2, A::AbstractArrayOrBroadcasted) where {F,F2} = _mapreduce(f, op, IndexStyle(A), A)
-    mapreduce_empty(::typeof(identity), op::F, T) where {F} = reduce_empty(op, T)
-    mapreduce_empty(::typeof(abs), op::F, T) where {F}     = abs(reduce_empty(op, T))
-    mapreduce_empty(::typeof(abs2), op::F, T) where {F}    = abs2(reduce_empty(op, T))
 end
 @eval Base.Sys begin
-    __init_build() = nothing
+    __init_build() = nothing # VersionNumber parsing is not supported yet
 end
 @eval Base.GMP begin
-    function __init__()
+    function __init__() # VersionNumber parsing is not supported yet
         try
             ccall((:__gmp_set_memory_functions, libgmp), Cvoid,
                 (Ptr{Cvoid},Ptr{Cvoid},Ptr{Cvoid}),
@@ -133,29 +107,5 @@ end
                 rethrow()
             end
         end
-    end
-end
-@eval Base.Sort begin
-    issorted(itr;
-        lt::T=isless, by::F=identity, rev::Union{Bool,Nothing}=nothing, order::Ordering=Forward) where {T,F} =
-        issorted(itr, ord(lt,by,rev,order))
-end
-@eval Base.TOML begin
-    function try_return_datetime(p, year, month, day, h, m, s, ms)
-        return DateTime(year, month, day, h, m, s, ms)
-    end
-    function try_return_date(p, year, month, day)
-        return Date(year, month, day)
-    end
-    function parse_local_time(l::Parser)
-        h = @try parse_int(l, false)
-        h in 0:23 || return ParserError(ErrParsingDateTime)
-        _, m, s, ms = @try _parse_local_time(l, true)
-        # TODO: Could potentially parse greater accuracy for the
-        # fractional seconds here.
-        return try_return_time(l, h, m, s, ms)
-    end
-    function try_return_time(p, h, m, s, ms)
-        return Time(h, m, s, ms)
     end
 end

--- a/contrib/juliac/juliac-trim-stdlib.jl
+++ b/contrib/juliac/juliac-trim-stdlib.jl
@@ -53,7 +53,7 @@ let
         Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg"))
     if Pkg !== nothing
         @eval Pkg begin
-            __init__() = rand() #TODO, methods that do nothing don't get codegened
+            __init__() = nothing # Assume the Pkg is not actually used
         end
     end
 
@@ -61,7 +61,7 @@ let
         Base.UUID("f489334b-da3d-4c2e-b8f0-e476e12c162b"), "StyledStrings"))
     if StyledStrings !== nothing
         @eval StyledStrings begin
-            __init__() = rand()
+            __init__() = nothing # Assume that StyledStrings are not actually used
         end
     end
 
@@ -69,7 +69,7 @@ let
         Base.UUID("d6f4376e-aef5-505a-96c1-9c027394607a"), "Markdown"))
     if Markdown !== nothing
         @eval Markdown begin
-            __init__() = rand()
+            __init__() = nothing # Assume that Markdown is not actually used with StyledStrings
         end
     end
 
@@ -77,7 +77,7 @@ let
         Base.UUID("ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"), "JuliaSyntaxHighlighting"))
     if JuliaSyntaxHighlighting !== nothing
         @eval JuliaSyntaxHighlighting begin
-            __init__() = rand()
+            __init__() = nothing # Assume the JuliaSyntaxHighlighting is not actually used with StyledStrings
         end
     end
 end

--- a/test/trimming/basic_jll.jl
+++ b/test/trimming/basic_jll.jl
@@ -25,5 +25,15 @@ function @main(args::Vector{String})::Cint
     fptr = dlsym(Zstd_jll.libzstd_handle, :ZSTD_versionString)
     ccall(cfunc, Cvoid, (Ptr{Cvoid},), fptr)
 
+    # map/mapreduce should work but relies on inlining and other optimizations
+    arr = rand(10)
+    sorted_arr = sort(arr)
+    tot = sum(sorted_arr)
+    tot = prod(sorted_arr)
+    a = any(x -> x > 0, sorted_arr)
+    b = all(x -> x >= 0, sorted_arr)
+    c = map(x -> x^2, sorted_arr)
+    # d = mapreduce(x -> x^2, +, sorted_arr) this doesn't work because of mapreduce_empty_iter having F specialized
+    # e = reduce(xor, rand(Int, 10))
     return 0
 end


### PR DESCRIPTION
This appears to have been mostly a copy of the correct mapreduce implementation, but perhaps with various subtle bugs introduced. Remove this code since no tests seem to break without it. Add some comments to the other patches clarifying why they are needed currently.