### PR TITLE
Re-add old function name for backward compatibility in init

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -238,6 +238,7 @@
     XX(jl_init_) \
     XX(jl_init_options) \
     XX(jl_init_restored_module) \
+    XX(jl_init_with_image) \
     XX(jl_init_with_image_file) \
     XX(jl_init_with_image_handle) \
     XX(jl_install_sigint_handler) \

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -120,6 +120,13 @@ JL_DLLEXPORT void jl_init_with_image_file(const char *julia_bindir,
     jl_exception_clear();
 }
 
+// Deprecated function, kept for backward compatibility
+JL_DLLEXPORT void jl_init_with_image(const char *julia_bindir,
+                                    const char *image_path)
+{
+    jl_init_with_image_file(julia_bindir, image_path);
+}
+
 /**
  * @brief Initialize the Julia runtime.
  *


### PR DESCRIPTION
While julia has no C-API backwards compatibility guarantees this is simple enough to add.

Fixes #58859