### PR TITLE
`setindex!(::ReinterpretArray, v)` needs to convert before reinterpreting

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -535,7 +535,7 @@ end
 
 @propagate_inbounds function setindex!(a::NonReshapedReinterpretArray{T,0,S}, v) where {T,S}
     if isprimitivetype(S) && isprimitivetype(T)
-        a.parent[] = reinterpret(S, v)
+        a.parent[] = reinterpret(S, convert(T, v))
         return a
     end
     setindex!(a, v, firstindex(a))

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -535,7 +535,7 @@ end
 
 @propagate_inbounds function setindex!(a::NonReshapedReinterpretArray{T,0,S}, v) where {T,S}
     if isprimitivetype(S) && isprimitivetype(T)
-        a.parent[] = reinterpret(S, convert(T, v))
+        a.parent[] = reinterpret(S, convert(T, v)::T)
         return a
     end
     setindex!(a, v, firstindex(a))

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -64,6 +64,44 @@ test_many_wrappers(B) do _B
     @test reinterpret(reshape, Int64, _B) == [5 7 9; 6 8 10]
 end
 
+@testset "setindex! converts before reinterpreting" begin
+    for dims in ((), 1)
+        z = reinterpret(UInt64, fill(1.0, dims))
+        @test z[] == z[1] == 0x3ff0000000000000
+        z[] = Int32(1)//Int32(1)
+        @test z[] == z[1] == 0x0000000000000001
+        z[1] = Int32(2)//Int32(1)
+        @test z[] == z[1] == 0x0000000000000002
+        z[1] = 3//1
+        @test z[] == z[1] == 0x0000000000000003
+        @test_throws InexactError z[] = 3//2
+        @test_throws InexactError z[] = 1.5
+        @test_throws InexactError z[1] = 3//2
+        @test_throws InexactError z[1] = 1.5
+
+        z = reinterpret(UInt64, fill(Int32(16)//Int32(1), dims))
+        @test z[] == z[1] == 0x0000000100000010
+        z[] = Int32(1)//Int32(1)
+        @test z[] == z[1] == 0x0000000000000001
+        z[1] = Int32(2)//Int32(1)
+        @test z[] == z[1] == 0x0000000000000002
+        z[1] = 3//1
+        @test z[] == z[1] == 0x0000000000000003
+        @test_throws InexactError z[] = 3//2
+        @test_throws InexactError z[] = 1.5
+        @test_throws InexactError z[1] = 3//2
+        @test_throws InexactError z[1] = 1.5
+
+        z = reinterpret(Missing, fill(nothing, dims))
+        @test z[] === missing
+        @test z[1] === missing
+        @test_throws "cannot convert" z[] = nothing
+        @test_throws "cannot convert" z[1] = nothing
+        @test z[] === missing
+        @test z[1] === missing
+    end
+end
+
 # setindex
 test_many_wrappers((A, Ars, B)) do (A, Ars, B)
     _A, Ar, _B = deepcopy(A), deepcopy(Ars), deepcopy(B)


### PR DESCRIPTION
Found in https://github.com/JuliaLang/julia/pull/58814#discussion_r2169155093.

Previously, in a very limited situation (a zero-dimensional reinterpret that reinterprets between primitive types that was setindex!'ed with zero indices), we omitted the `convert`.  I believe this was an unintentional oversight, and hopefully nobody is depending on this behavior.