### PR TITLE
trimming: Add `_uv_hook_close` support

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -732,7 +732,8 @@ static void jl_queue_module_for_serialization(jl_serializer_state *s, jl_module_
                  !strcmp(jl_symbol_name(b->globalref->name), "__init__") ||
                  // ... or point to Base functions accessed by the runtime
                  (m == jl_base_module && (!strcmp(jl_symbol_name(b->globalref->name), "wait") ||
-                                          !strcmp(jl_symbol_name(b->globalref->name), "task_done_hook"))))) {
+                                          !strcmp(jl_symbol_name(b->globalref->name), "task_done_hook") ||
+                                          !strcmp(jl_symbol_name(b->globalref->name), "_uv_hook_close"))))) {
                 jl_queue_for_serialization(s, b);
             }
         }

--- a/test/trimming/basic_jll.jl
+++ b/test/trimming/basic_jll.jl
@@ -18,6 +18,8 @@ function @main(args::Vector{String})::Cint
     println(Core.stdout, ver)
     @assert ver == build_ver
 
+    sleep(0.01)
+
     # Add an indirection via `@cfunction` / 1-arg ccall
     cfunc = @cfunction(print_string, Cvoid, (Ptr{Cvoid},))
     fptr = dlsym(Zstd_jll.libzstd_handle, :ZSTD_versionString)


### PR DESCRIPTION
Resolves https://github.com/JuliaLang/julia/issues/58862.

Since this hook is called internally by the runtime, `--trim` was not aware of the callee edge required here.