### PR TITLE
Add missing module qualifier

### DIFF
--- a/Compiler/test/AbstractInterpreter.jl
+++ b/Compiler/test/AbstractInterpreter.jl
@@ -548,4 +548,17 @@ let interp = InvokeInterp()
     mi = @ccall jl_method_lookup(Any[f, args...]::Ptr{Any}, (1+length(args))::Csize_t, Base.tls_world_age()::Csize_t)::Ref{Core.MethodInstance}
     ci = Compiler.typeinf_ext_toplevel(interp, mi, source_mode)
     @test invoke(f, ci, args...) == 2
+
+    f = error
+    args = "test"
+    mi = @ccall jl_method_lookup(Any[f, args...]::Ptr{Any}, (1+length(args))::Csize_t, Base.tls_world_age()::Csize_t)::Ref{Core.MethodInstance}
+    ci = Compiler.typeinf_ext_toplevel(interp, mi, source_mode)
+    result = nothing
+    try
+        invoke(f, ci, args...)
+    catch e
+        result = sprint(Base.show_backtrace, catch_backtrace())
+    end
+    @test isa(result, String)
+    @test contains(result, "[1] error(::Char, ::Char, ::Char, ::Char)")
 end

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -290,7 +290,7 @@ end
 
 # Can be extended by compiler packages to customize backtrace display of custom code instance frames
 function show_custom_spec_sig(io::IO, @nospecialize(owner), linfo::CodeInstance, frame::StackFrame)
-    mi = get_ci_mi(linfo)
+    mi = Base.get_ci_mi(linfo)
     return show_spec_sig(io, mi.def, mi.specTypes)
 end
 


### PR DESCRIPTION
A very simple fix addressing the following bug:
```julia
Validation: Error During Test at REPL[61]:1
  Got exception outside of a @test
  #=ERROR showing exception stack=# UndefVarError: `get_ci_mi` not defined in `Base.StackTraces`
  Suggestion: check for spelling errors or missing imports.
  Hint: a global variable of this name also exists in Base.
      - Also declared public in Compiler (loaded but not imported in Main).
  Stacktrace:
    [1] show_custom_spec_sig(io::IOContext{IOBuffer}, owner::Any, linfo::Core.CodeInstance, frame::Base.StackTraces.StackFrame)
      @ Base.StackTraces ./stacktraces.jl:293
    [2] show_spec_linfo(io::IOContext{IOBuffer}, frame::Base.StackTraces.StackFrame)
      @ Base.StackTraces ./stacktraces.jl:278
    [3] print_stackframe(io::IOContext{IOBuffer}, i::Int64, frame::Base.StackTraces.StackFrame, n::Int64, ndigits_max::Int64, modulecolor::Symbol; prefix::Nothing)
      @ Base ./errorshow.jl:786
```

AFAIK this occurs when printing a stacktrace from a `CodeInstance` that has a non-default owner.