### PR TITLE
Improve error message for missing dependencies in packages

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2377,7 +2377,8 @@ function __require(into::Module, mod::Symbol)
             else
                 manifest_warnings = collect_manifest_warnings()
                 throw(ArgumentError("""
-                Package $(where.name) does not have $mod in its dependencies:
+                Cannot load (`using/import`) module $mod into module $into in package $(where.name)
+                because package $(where.name) does not have $mod in its dependencies:
                 $manifest_warnings- You may have a partially installed environment. Try `Pkg.instantiate()`
                   to ensure all packages in the environment are installed.
                 - Or, if you have $(where.name) checked out for development and have


### PR DESCRIPTION
Improve the error message when a module cannot be loaded because dependencies are missing.

I encountered the error message `Package X does not have Y in its dependencies:`, and this did not give me enough context to understand what the actual problem was.

What was unclear to me is whether this is an error in package X, trying to load Y (it isn't), or whether this is an error in a different module Z try to load X (that's the real reason). The problem is that X is in an inconsistent state and thus cannot be loaded.

The new error message also states that this error comes from a `using` or `import` statement, and it includes also the name of the module (Z) where the failing using/import statement occurs.