### PR TITLE
Pkg: Allow configuring can_fancyprint(io::IO) using IOContext

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -355,7 +355,7 @@ Base.show(io::IO, err::PkgPrecompileError) = print(io, "PkgPrecompileError: ", e
 
 import Base: StaleCacheKey
 
-can_fancyprint(io::IO) = io isa Base.TTY && (get(ENV, "CI", nothing) != "true")
+can_fancyprint(io::IO) = @something(get(io, :Pkg_force_fancyprint, nothing), io isa Base.TTY && (get(ENV, "CI", nothing) != "true"))
 
 function printpkgstyle(io, header, msg; color=:green)
     printstyled(io, header; color, bold=true)

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -355,7 +355,7 @@ Base.show(io::IO, err::PkgPrecompileError) = print(io, "PkgPrecompileError: ", e
 
 import Base: StaleCacheKey
 
-can_fancyprint(io::IO) = @something(get(io, :Pkg_force_fancyprint, nothing), io isa Base.TTY && (get(ENV, "CI", nothing) != "true"))
+can_fancyprint(io::IO) = @something(get(io, :force_fancyprint, nothing), (io isa Base.TTY && (get(ENV, "CI", nothing) != "true")))
 
 function printpkgstyle(io, header, msg; color=:green)
     printstyled(io, header; color, bold=true)


### PR DESCRIPTION
> Moved from https://github.com/JuliaLang/Pkg.jl/pull/4042 (see this PR for previous discussion) because of https://github.com/JuliaLang/julia/pull/53403

Hi!

This PR adds the ability to override `can_fancyprint(io::IO)` (used by Pkg and precompilation for terminal animations) for a self-provided IO by setting an IOContext flag:  `:Pkg_force_fancyprint` can be set to true or false.

# Why
My use case is Pluto, where we call Pkg functions like `Pkg.precompile()` with a **buffer as `io`**. Our display (in the browser) supports fancy-printing, but because the buffer is not a `<: Base.TTY`, Pkg will not fancy-print.

The current workaround in Pluto is to add type piracy to the `Pkg.can_fancyprint` function, defining a new, more specific method for `can_fancyprint(io::IOContext{BufferStream})` where we set it to `true`, but I want to avoid this solution.

