### PR TITLE
Support "functors" for code reflection utilities

### DIFF
--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -22,7 +22,7 @@ end
 # The tests below assume a certain format and safepoint_on_entry=true breaks that.
 function get_llvm(@nospecialize(f), @nospecialize(t), raw=true, dump_module=false, optimize=true)
     params = Base.CodegenParams(safepoint_on_entry=false, gcstack_arg = false, debug_info_level=Cint(2))
-    d = InteractiveUtils._dump_function(f, t, false, false, raw, dump_module, :att, optimize, :none, false, params)
+    d = InteractiveUtils._dump_function(InteractiveUtils.ArgInfo(f, t), false, false, raw, dump_module, :att, optimize, :none, false, params)
     sprint(print, d)
 end
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -72,7 +72,7 @@ function method_instances(@nospecialize(f), @nospecialize(t), world::UInt)
     return method_instances(tt, world)
 end
 
-function method_instance(@nospecialize(argtypes::Union{Tuple,Type{<:Tuple}}),
+function method_instance(@nospecialize(argtypes::Union{Tuple,Type{<:Tuple}});
                          world=Base.get_world_counter(), method_table=nothing)
     tt = to_tuple_type(argtypes)
     mi = ccall(:jl_method_lookup_by_tt, Any,

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -16,7 +16,7 @@ The keyword `debuginfo` controls the amount of code metadata present in the outp
 Note that an error will be thrown if `types` are not concrete types when `generated` is
 `true` and any of the corresponding methods are an `@generated` method.
 """
-function code_lowered(@nospecialize(f), @nospecialize(t=Tuple); generated::Bool=true, debuginfo::Symbol=:default)
+function code_lowered(@nospecialize(argtypes::Union{Tuple,Type{<:Tuple}}); generated::Bool=true, debuginfo::Symbol=:default)
     if @isdefined(IRShow)
         debuginfo = IRShow.debuginfo(debuginfo)
     elseif debuginfo === :default
@@ -28,7 +28,7 @@ function code_lowered(@nospecialize(f), @nospecialize(t=Tuple); generated::Bool=
     world = get_world_counter()
     world == typemax(UInt) && error("code reflection cannot be used from generated functions")
     ret = CodeInfo[]
-    for m in method_instances(f, t, world)
+    for m in method_instances(argtypes, world)
         if generated && hasgenerator(m)
             if may_invoke_generator(m)
                 code = ccall(:jl_code_for_staged, Ref{CodeInfo}, (Any, UInt, Ptr{Cvoid}), m, world, C_NULL)
@@ -46,12 +46,17 @@ function code_lowered(@nospecialize(f), @nospecialize(t=Tuple); generated::Bool=
     return ret
 end
 
+function code_lowered(@nospecialize(f), @nospecialize(t=Tuple); generated::Bool=true, debuginfo::Symbol=:default)
+    tt = signature_type(f, t)
+    return code_lowered(tt; generated, debuginfo)
+end
+
 # for backwards compat
 const uncompressed_ast = uncompressed_ir
 const _uncompressed_ast = _uncompressed_ir
 
-function method_instances(@nospecialize(f), @nospecialize(t), world::UInt)
-    tt = signature_type(f, t)
+function method_instances(@nospecialize(argtypes::Union{Tuple,Type{<:Tuple}}), world::UInt)
+    tt = to_tuple_type(argtypes)
     results = Core.MethodInstance[]
     # this make a better error message than the typeassert that follows
     world == typemax(UInt) && error("code reflection cannot be used from generated functions")
@@ -62,13 +67,24 @@ function method_instances(@nospecialize(f), @nospecialize(t), world::UInt)
     return results
 end
 
-function method_instance(@nospecialize(f), @nospecialize(t);
-                         world=Base.get_world_counter(), method_table=nothing)
+function method_instances(@nospecialize(f), @nospecialize(t), world::UInt)
     tt = signature_type(f, t)
+    return method_instances(tt, world)
+end
+
+function method_instance(@nospecialize(argtypes::Union{Tuple,Type{<:Tuple}}),
+                         world=Base.get_world_counter(), method_table=nothing)
+    tt = to_tuple_type(argtypes)
     mi = ccall(:jl_method_lookup_by_tt, Any,
                 (Any, Csize_t, Any),
                 tt, world, method_table)
     return mi::Union{Nothing, MethodInstance}
+end
+
+function method_instance(@nospecialize(f), @nospecialize(t);
+                         world=Base.get_world_counter(), method_table=nothing)
+    tt = signature_type(f, t)
+    return method_instance(tt; world, method_table)
 end
 
 default_debug_info_kind() = unsafe_load(cglobal(:jl_default_debug_info_kind, Cint))
@@ -428,6 +444,11 @@ function code_ircode(@nospecialize(f), @nospecialize(types = default_tt(f)); kwa
         error("OpaqueClosure not supported")
     end
     tt = signature_type(f, types)
+    return code_ircode_by_type(tt; kwargs...)
+end
+
+function code_ircode(@nospecialize(argtypes::Union{Tuple,Type{<:Tuple}}); kwargs...)
+    tt = to_tuple_type(argtypes)
     return code_ircode_by_type(tt; kwargs...)
 end
 

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -592,7 +592,9 @@ end # module ReflectionTest
 # Issue #18883, code_llvm/code_native for generated functions
 @generated f18883() = nothing
 @test !isempty(sprint(code_llvm, f18883, Tuple{}))
+@test !isempty(sprint(code_llvm, (typeof(f18883),)))
 @test !isempty(sprint(code_native, f18883, Tuple{}))
+@test !isempty(sprint(code_native, (typeof(f18883),)))
 
 ix86 = r"i[356]86"
 
@@ -863,6 +865,27 @@ let # `default_tt` should work with any function with one method
     @test (code_native(devnull, function (a::Int)
         sin(a)
     end); true)
+end
+
+let # specifying calls as argtypes (incl. arg0) should be supported
+    @test (code_warntype(devnull, (typeof(function ()
+        sin(42)
+    end),)); true)
+    @test (code_warntype(devnull, (typeof(function (a::Int)
+        sin(42)
+    end), Int)); true)
+    @test (code_llvm(devnull, (typeof(function ()
+        sin(42)
+    end),)); true)
+    @test (code_llvm(devnull, (typeof(function (a::Int)
+        sin(42)
+    end), Int)); true)
+    @test (code_native(devnull, (typeof(function ()
+        sin(42)
+    end),)); true)
+    @test (code_native(devnull, (typeof(function (a::Int)
+        sin(42)
+    end), Int)); true)
 end
 
 @testset "code_llvm on opaque_closure" begin

--- a/test/rebinding.jl
+++ b/test/rebinding.jl
@@ -285,7 +285,7 @@ module RangeMerge
 
     function get_llvm(@nospecialize(f), @nospecialize(t), raw=true, dump_module=false, optimize=true)
         params = Base.CodegenParams(safepoint_on_entry=false, gcstack_arg = false, debug_info_level=Cint(2))
-        d = InteractiveUtils._dump_function(f, t, false, false, raw, dump_module, :att, optimize, :none, false, params)
+        d = InteractiveUtils._dump_function(InteractiveUtils.ArgInfo(f, t), false, false, raw, dump_module, :att, optimize, :none, false, params)
         sprint(print, d)
     end
 

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -16,6 +16,11 @@ function test_ir_reflection(freflect, f, types)
     nothing
 end
 
+function test_ir_reflection(freflect, argtypes)
+    @test !isempty(freflect(argtypes))
+    nothing
+end
+
 function test_bin_reflection(freflect, f, types)
     iob = IOBuffer()
     freflect(iob, f, types)
@@ -27,6 +32,9 @@ end
 function test_code_reflection(freflect, f, types, tester)
     tester(freflect, f, types)
     tester(freflect, f, (types.parameters...,))
+    tt = Base.signature_type(f, types)
+    tester(freflect, tt)
+    tester(freflect, (tt.parameters...,))
     nothing
 end
 
@@ -43,6 +51,7 @@ end
 
 test_code_reflections(test_ir_reflection, code_lowered)
 test_code_reflections(test_ir_reflection, code_typed)
+test_code_reflections(test_ir_reflection, Base.code_ircode)
 
 io = IOBuffer()
 Base.print_statement_costs(io, map, (typeof(sqrt), Tuple{Int}))
@@ -682,6 +691,10 @@ end
 @test Base.code_typed_by_type(Tuple{Type{<:Val}})[2][2] == Val
 @test Base.code_typed_by_type(Tuple{typeof(sin), Float64})[1][2] === Float64
 
+# functor-like code_typed(...)
+@test Base.code_typed((Type{<:Val},))[2][2] == Val
+@test Base.code_typed((typeof(sin), Float64))[1][2] === Float64
+
 # New reflection methods in 0.6
 struct ReflectionExample{T<:AbstractFloat, N}
     x::Tuple{T, N}
@@ -1131,9 +1144,12 @@ end
     @test 1+1 == 2
     mi1 = Base.method_instance(+, (Int, Int))
     @test mi1.def.name == :+
-    # Note `jl_method_lookup` doesn't returns CNull if not found
-    mi2 = @ccall jl_method_lookup(Any[+, 1, 1]::Ptr{Any}, 3::Csize_t, Base.get_world_counter()::Csize_t)::Ref{Core.MethodInstance}
-    @test mi1 == mi2
+    mi2 = Base.method_instance((typeof(+), Int, Int))
+    @test mi2.def.name == :+
+    # Note `jl_method_lookup` doesn't return CNull if not found
+    mi3 = @ccall jl_method_lookup(Any[+, 1, 1]::Ptr{Any}, 3::Csize_t, Base.get_world_counter()::Csize_t)::Ref{Core.MethodInstance}
+    @test mi1 == mi3
+    @test mi2 == mi3
 end
 
 Base.@assume_effects :terminates_locally function issue41694(x::Int)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1051,11 +1051,12 @@ _test_at_locals2(1,1,0.5f0)
 
 @testset "issue #31687" begin
     import InteractiveUtils._dump_function
+    import InteractiveUtils.ArgInfo
 
     @noinline f31687_child(i) = f31687_nonexistent(i)
     f31687_parent() = f31687_child(0)
     params = Base.CodegenParams()
-    _dump_function(f31687_parent, Tuple{},
+    _dump_function(ArgInfo(f31687_parent, Tuple{}),
                    #=native=#false, #=wrapper=#false, #=raw=#true,
                    #=dump_module=#true, #=syntax=#:att, #=optimize=#false, :none,
                    #=binary=#false)


### PR DESCRIPTION
As a follow-up to https://github.com/JuliaLang/julia/pull/57911, this updates:
 - `Base.method_instance`
 - `Base.method_instances`
 - `Base.code_ircode`
 - `Base.code_lowered`
 - `InteractiveUtils.code_llvm`
 - `InteractiveUtils.code_native`
 - `InteractiveUtils.code_warntype`
 
 to support "functor" invocations.
 
 e.g. `code_llvm((Foo, Int, Int))` which corresponds to `(::Foo)(::Int, ::Int)`
 