### PR TITLE
Make `var"#self#"` also work for callable structs

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -180,8 +180,7 @@
            (needs-alias?
              (and (not have-self-arg?)
                   (expr-contains-p
-                    (lambda (x) (and
-                                     (eq? x '|#self#|)))
+                    (lambda (x) (eq? x '|#self#|))
                     body))))
       (when needs-alias?
         (set! body

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -180,7 +180,7 @@
            (needs-alias?
              (and (not have-self-arg?)
                   (expr-contains-p
-                    (lambda (x) (and (symbol? x)
+                    (lambda (x) (and
                                      (eq? x '|#self#|)))
                     body))))
       (when needs-alias?


### PR DESCRIPTION
The `var"#self#"` symbol refers to the enclosing innermost function. This PR defines it for callable structs to help make usage symmetric. This was first mentioned in https://github.com/JuliaLang/julia/issues/6733#issuecomment-919730591 (@c42f).

This is independent of #58909, but would help make a potential `@__FUNCTION__` macro more general.

```julia
julia> struct Foo end

julia> (foo::Foo)() = var"#self#";

julia> Foo()()
Foo()

julia> bar() = var"#self#";

julia> bar()
bar (generic function with 1 method)
```

In the current code, `var"#self#"` does not work with callable structs:

```julia
julia> struct Foo end

julia> (foo::Foo)() = var"#self#";

julia> Foo()()
ERROR: UndefVarError: `#self#` not defined in `Main`
```

---

If combined with #58909 we can update the tests to use `@__FUNCTION__` rather than `var"#symbol#"`.
