### PR TITLE
LibGit2: Try collecting github sideband messages

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -374,6 +374,7 @@ function getpass(input::TTY, output::IO, prompt::AbstractString; with_suffix::Bo
                 write(s, c)
             end
         end
+        println(output) # Add newline after password input
         return seekstart(s)
     end
 end

--- a/stdlib/LibGit2/src/error.jl
+++ b/stdlib/LibGit2/src/error.jl
@@ -93,7 +93,7 @@ struct GitError <: Exception
     code::Code
     msg::String
 end
-Base.show(io::IO, err::GitError) = print(io, "GitError(Code:$(err.code), Class:$(err.class), $(err.msg))")
+Base.show(io::IO, err::GitError) = print(io, """GitError: Code:$(err.code), Class:$(err.class), Message:\n$(err.msg)""")
 
 function last_error()
     ensure_initialized()

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -274,6 +274,13 @@ function RemoteCallbacks(c::Callbacks)
         payloads[name] = payload
     end
 
+    # Always add sideband_progress callback to capture remote messages
+    # This helps capture "remote:" messages from services like GitHub
+    if !haskey(callbacks, :sideband_progress)
+        callbacks[:sideband_progress] = sideband_progress_cb()
+        payloads[:sideband_progress] = nothing
+    end
+
     RemoteCallbacks(; payload=payloads, callbacks...)
 end
 


### PR DESCRIPTION
github sends "sideband" messages to `git clone` that would be helpful for Pkg to show.
See the `remote: ` prefixed messages here.
```
% git clone https://github.com/IanButterworth/Private.jl
Cloning into 'Private.jl'...
Username for 'https://github.com': IanButterworth
Password for 'https://IanButterworth@github.com':
remote: Support for password authentication was removed on August 13, 2021.
remote: Please see https://docs.github.com/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls for information on currently recommended modes of authentication.
fatal: Authentication failed for 'https://github.com/IanButterworth/Private.jl/'
```

This PR tries to capture and show them as part of our GitError (trying to fix https://github.com/JuliaLang/Pkg.jl/issues/2701), but currently it doesn't detect any messages. I'm not sure why not.

The error below isn't relevant if you have github auth setup, it's only about user/password entry, but I thought maybe we should generally capture things github etc. is telling us.

Note LibGit2 tries 3 times.
```
julia> LibGit2.clone("https://github.com/IanButterworth/Private.jl", "/tmp/test_private_clone"; callbacks=LibGit2.Callbacks())
Username for 'https://github.com': IanButterworth
Password for 'https://IanButterworth@github.com': 
Username for 'https://github.com' [IanButterworth]:
Password for 'https://IanButterworth@github.com': 
Username for 'https://github.com' [IanButterworth]: 
Password for 'https://IanButterworth@github.com': 
ERROR: GitError: Code:EAUTH, Class:Callback, Message:
Aborting, maximum number of prompts reached.
Stacktrace:
 [1] macro expansion
   @ ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/LibGit2/src/error.jl:124 [inlined]
 [2] clone(repo_url::String, repo_path::String, clone_opts::LibGit2.CloneOptions)
   @ LibGit2 ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/LibGit2/src/repository.jl:470
 [3] clone(repo_url::String, repo_path::String; branch::String, isbare::Bool, remote_cb::Ptr{Nothing}, credentials::Nothing, callbacks::Dict{Symbol, Tuple{…}})
   @ LibGit2 ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/LibGit2/src/LibGit2.jl:592
 [4] top-level scope
   @ REPL[2]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

(Note `Base.getpass` doesn't currently add a newline after entry like `Base,prompt` does. I think that's a bug which is tentatively fixed here..)