### PR TITLE
Markdown: Make `Table`/`LaTeX` objects subtypes of `MarkdownElement`

### DIFF
--- a/stdlib/Markdown/src/GitHub/table.jl
+++ b/stdlib/Markdown/src/GitHub/table.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-mutable struct Table
+mutable struct Table <: MarkdownElement
     rows::Vector{Vector{Any}}
     align::Vector{Symbol}
 end

--- a/stdlib/Markdown/src/IPython/IPython.jl
+++ b/stdlib/Markdown/src/IPython/IPython.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-mutable struct LaTeX
+mutable struct LaTeX <: MarkdownElement
     formula::String
 end
 


### PR DESCRIPTION
These objects satisfy the requirements of the `MarkdownElement` interface (such as implementing `Markdown.plain`), so they should be subtypes of `MarkdownElement`. This is convenient when defining functions for `MarkdownElement` in other packages.