### PR TITLE
Make `hypot` docs example more type stable

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -178,7 +178,7 @@ julia> function hypot(x, y)
                return x*sqrt(1 + r*r)
            end
            if y == 0
-               return x
+               return float(x)
            end
            r = x/y
            return y*sqrt(1 + r*r)


### PR DESCRIPTION
Very minor nitpick, but there's an example function `hypot` in the docs which is type unstable for `Int` or `Rational` inputs. It's not necessarily wrong, but I think where possible it's best to show code which is type stable in the manual unless we have a specific reason not to. 