### PR TITLE
Binding invalidation data race fixes

### DIFF
--- a/base/invalidation.jl
+++ b/base/invalidation.jl
@@ -122,23 +122,23 @@ function invalidate_code_for_globalref!(b::Core.Binding, invalidated_bpart::Core
                 invalidated_any |= invalidate_method_for_globalref!(gr, method, invalidated_bpart, new_max_world)
             end
         end
-        if isdefined(b, :backedges)
-            for edge in b.backedges
-                if isa(edge, CodeInstance)
-                    ccall(:jl_invalidate_code_instance, Cvoid, (Any, UInt), edge, new_max_world)
-                    invalidated_any = true
-                elseif isa(edge, Core.Binding)
-                    isdefined(edge, :partitions) || continue
-                    latest_bpart = edge.partitions
-                    latest_bpart.max_world == typemax(UInt) || continue
-                    is_some_imported(binding_kind(latest_bpart)) || continue
-                    if is_some_binding_imported(binding_kind(latest_bpart))
-                        partition_restriction(latest_bpart) === b || continue
-                    end
-                    push!(queued_bindings, (edge, latest_bpart, latest_bpart))
-                else
-                    invalidated_any |= invalidate_method_for_globalref!(gr, edge::Method, invalidated_bpart, new_max_world)
+        nbackedges = ccall(:jl_binding_backedges_length, Csize_t, (Any,), b)
+        for i = 1:nbackedges
+            edge = ccall(:jl_binding_backedges_getindex, Any, (Any, Csize_t), b, i)
+            if isa(edge, CodeInstance)
+                ccall(:jl_invalidate_code_instance, Cvoid, (Any, UInt), edge, new_max_world)
+                invalidated_any = true
+            elseif isa(edge, Core.Binding)
+                isdefined(edge, :partitions) || continue
+                latest_bpart = edge.partitions
+                latest_bpart.max_world == typemax(UInt) || continue
+                is_some_imported(binding_kind(latest_bpart)) || continue
+                if is_some_binding_imported(binding_kind(latest_bpart))
+                    partition_restriction(latest_bpart) === b || continue
                 end
+                push!(queued_bindings, (edge, latest_bpart, latest_bpart))
+            else
+                invalidated_any |= invalidate_method_for_globalref!(gr, edge::Method, invalidated_bpart, new_max_world)
             end
         end
     end

--- a/base/invalidation.jl
+++ b/base/invalidation.jl
@@ -149,7 +149,7 @@ function invalidate_code_for_globalref!(b::Core.Binding, invalidated_bpart::Core
         usings_backedges = ccall(:jl_get_module_usings_backedges, Any, (Any,), gr.mod)
         if usings_backedges !== nothing
             for user::Module in usings_backedges::Vector{Any}
-                user_binding = ccall(:jl_get_module_binding_or_nothing, Any, (Any, Any), user, gr.name)
+                user_binding = ccall(:jl_get_module_binding_or_nothing, Any, (Any, Any), user, gr.name)::Union{Core.Binding, Nothing}
                 user_binding === nothing && continue
                 isdefined(user_binding, :partitions) || continue
                 latest_bpart = user_binding.partitions


### PR DESCRIPTION
Fix the data races described in https://github.com/JuliaLang/julia/issues/57457#issuecomment-3028911737,
summarized here so it can be included in the commit message.  It's difficult to
get either of these to crash reliably without tsan, but it does appear in the
wild from time to time (#57457).  I'll add these tests when we get tsan to run
on CI.

## Data race on `jl_binding_t.backedges`

Guard `jl_binding_t.backedges` with the module's lock, using the same strategy
we use for the scanned methods array to use it from `invalidations.jl`, namely
taking the lock once to get the length and then locking every time we get the
ith entry in the array.  I'm not yet convinced this will avoid missing
invalidations in all circumstances, but it should avoid deadlocks and data
races.

```julia
module M
    const x = 0 
end
t = Threads.@spawn for i=1:100
    @eval M const x = $i
end
for i=1:100
    s = Symbol("f$i")
    @eval ($s() = M.x; $s())
end
wait(t)
```

```
$ ./usr/bin/julia -t4,0 --gcthreads=1 test.jl
==================
WARNING: ThreadSanitizer: data race (pid=3644)
  Write of size 8 at 0xffff9e714960 by main thread:
    #0 ijl_array_grow_end /home/user/c/julia/src/array.c (libjulia-internal.so.1.13+0x9f5f4)
    #1 ijl_array_ptr_1d_push /home/user/c/julia/src/array.c:260:5 (libjulia-internal.so.1.13+0x9f8b0)
    #2 jl_add_binding_backedge /home/user/c/julia/src/module.c:1634:5 (libjulia-internal.so.1.13+0x8e2e4)
    #3 jl_maybe_add_binding_backedge /home/user/c/julia/src/module.c:1654:5 (libjulia-internal.so.1.13+0x90cf0)
    #4 maybe_add_binding_backedge! invalidation.jl:175 (sys.so+0x74ce8c)
    #5 julia_store_backedges_11269 ../usr/share/julia/Compiler/src/typeinfer.jl:768 (sys.so+0x74ce8c)
    #6 julia_codeinst_as_edge_11265 ../usr/share/julia/Compiler/src/typeinfer.jl:1029 (sys.so+0x10ee660)
[snip]

  Previous read of size 8 at 0xffff9e714960 by thread T9:
    #0 length essentials.jl:11 (sys.so+0x8a9188)
    #1 checkbounds essentials.jl:383 (sys.so+0x8a9188)
    #2 _iterate_array genericmemory.jl:230 (sys.so+0x8a9188)
    #3 iterate array.jl:907 (sys.so+0x8a9188)
    #4 julia_invalidate_code_for_globalrefNOT._86900 invalidation.jl:139 (sys.so+0x8a9188)
[snip]
```

## Data race on `jl_module_t.usings_backedges`

`jl_get_module_usings_backedges` is still guarded by `world_counter_lock`, but
we needed to take it in `jl_new_module_`.

```julia
Threads.@spawn for i=1:10000
    @eval Core const foo = $i
end
Threads.@threads for i=1:10000
    Module()
end
```

```
==================
WARNING: ThreadSanitizer: data race (pid=9714)
  Write of size 8 at 0xffff7db5b3b0 by thread T11:
    #0 ijl_array_grow_end /home/user/c/julia/src/gc-wb-stock.h (libjulia-internal.so.1.13+0x9f834)
    #1 ijl_array_ptr_1d_push /home/user/c/julia/src/array.c:260:5 (libjulia-internal.so.1.13+0x9f99c)
    #2 jl_add_usings_backedge /home/user/c/julia/src/module.c:1323:5 (libjulia-internal.so.1.13+0x8e73c)
    #3 jl_module_initial_using /home/user/c/julia/src/module.c:1337:5 (libjulia-internal.so.1.13+0x89a34)
    #4 jl_add_default_names /home/user/c/julia/src/module.c:517:13 (libjulia-internal.so.1.13+0x89a34)
    #5 jl_new_module_ /home/user/c/julia/src/module.c:530:5 (libjulia-internal.so.1.13+0x89a34)
    #6 jl_f_new_module /home/user/c/julia/src/module.c:650:22 (libjulia-internal.so.1.13+0x8a9b4)
[snip]

  Previous read of size 8 at 0xffff7db5b3b0 by thread T9:
    #0 getindex essentials.jl:967 (sys.so+0x40a1e4)
    #1 _iterate_array genericmemory.jl:230 (sys.so+0x40a1e4)
    #2 iterate array.jl:907 (sys.so+0x40a1e4)
    #3 iterate array.jl:907 (sys.so+0x40a1e4)
    #4 julia_invalidate_code_for_globalrefNOT._86900 invalidation.jl:148 (sys.so+0x40a1e4)
[snip]
```

## Remove type instability in `invalidate_code_for_globalref!`

We hold `world_counter_lock` while running `invalidate_code_for_globalref!`, so
we need to avoid triggering inference entirely.  A typeassert avoids the last
few dynamic calls:

```
171 ─ %450 =   dynamic Base.getproperty(%438, :partitions)::Any
└────        goto #172
172 ┄ %452 = φ (#170 => %448, #171 => %450)::Any
│     @ invalidation.jl:175 within `invalidate_code_for_globalref!`
│     %453 =   builtin (isa)(%452, Module)::Bool
└────        goto #174 if not %453
173 ─ %455 = π (%452, Module)
│    ┌ @ Base_compiler.jl:47 within `getproperty`
│    │ %456 =   builtin Base.getglobal(%455, :max_world)::Any
│    └
└────        goto #175
174 ─ %458 =   dynamic Base.getproperty(%452, :max_world)::Any
└────        goto #175
175 ┄ %460 = φ (#173 => %456, #174 => %458)::Any
│     %461 =   dynamic (%460 == 0xffffffffffffffff)::Any
└────        goto #203 if not %461
```

TODO: write guidelines for runtime code written in Julia somewhere in devdocs/locks.
