### PR TITLE
Add one-argument `argtypes` methods to source reflection functions

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -181,6 +181,7 @@ end
 Return a tuple `(filename,line)` giving the location of a generic `Function` definition.
 """
 functionloc(@nospecialize(f), @nospecialize(types)) = functionloc(which(f,types))
+functionloc(@nospecialize(argtypes::Union{Tuple, Type{<:Tuple}})) = functionloc(which(argtypes))
 
 function functionloc(@nospecialize(f))
     mt = methods(f)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -960,6 +960,7 @@ Returns the method that would be called by the given type signature (as a tuple 
 function which(@nospecialize(tt#=::Type=#))
     return _which(tt).method
 end
+which(@nospecialize(argtypes::Tuple)) = which(to_tuple_type(argtypes))
 
 """
     which(module, symbol)

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -269,7 +269,8 @@ function edit(@nospecialize f)
 end
 edit(m::Method) = edit(functionloc(m)...)
 edit(@nospecialize(f), idx::Integer) = edit(methods(f).ms[idx])
-edit(f, t)  = (@nospecialize; edit(functionloc(f, t)...))
+edit(f, t) = (@nospecialize; edit(functionloc(f, t)...))
+edit(@nospecialize argtypes::Union{Tuple, Type{<:Tuple}}) = edit(functionloc(argtypes)...)
 edit(file::Nothing, line::Integer) = error("could not find source file for function")
 edit(m::Module) = edit(pathof(m))
 

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -329,6 +329,18 @@ catch err13464
     @test startswith(err13464.msg, "expression is not a function call")
 end
 
+@testset "Single-argument forms" begin
+    a = which(+, (Int, Int))
+    b = which((typeof(+), Int, Int))
+    c = which(Tuple{typeof(+), Int, Int})
+    @test a == b == c
+
+    a = functionloc(+, (Int, Int))
+    b = functionloc((typeof(+), Int, Int))
+    c = functionloc(Tuple{typeof(+), Int, Int})
+    @test a == b == c
+end
+
 # PR 57909
 @testset "Support for type annotations as arguments" begin
     @test (@which (::Vector{Int})[::Int]).name === :getindex


### PR DESCRIPTION
Follow-up to https://github.com/JuliaLang/julia/pull/58891#issuecomment-3036419509, extending the feature to `which`, `functionloc`, `edit` and `less`.