### PR TITLE
Add fast method for count/sum of view of BitArray

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1451,6 +1451,37 @@ function bitcount(Bc::Vector{UInt64}; init::T=0) where {T}
     return n
 end
 
+function _count(
+        ::typeof(identity),
+        v::SubArray{Bool, N, <:BitArray, <:Tuple{Union{Integer, AbstractUnitRange}}, true},
+        ::Colon,
+        init::T
+    ) where {N, T}
+    pi = only(parentindices(v))
+    (fst, lst) = (first(pi), last(pi))
+    fst > lst && return init
+    chunks = parent(v).chunks
+
+    # Mask away the bits in the chunks not inside the view
+    mask1 = typemax(UInt64) << ((fst - 1) & 63)
+    mask2 = typemax(UInt64) >> ((64 - lst) & 63)
+    start_index = ((fst - 1) >>> 6) + 1
+    stop_index = ((lst - 1) >>> 6) + 1
+    # If the whole view is contained in one chunk, then mask it from both sides
+    if start_index == stop_index
+        return (init + count_ones(@inbounds chunks[start_index] & mask1 & mask2)) % T
+    end
+    # Else, mask first and last chunk individually, then add all whole chunks
+    # in a separate loop below.
+    n = init + count_ones(@inbounds chunks[start_index] & mask1)
+    n += count_ones(@inbounds chunks[stop_index] & mask2)
+    for i in (start_index + 1):(stop_index - 1)
+        n += count_ones(@inbounds chunks[i])
+    end
+    return n % T
+end
+
+
 _count(::typeof(identity), B::BitArray, ::Colon, init) = bitcount(B.chunks; init)
 
 function unsafe_bitfindnext(Bc::Vector{UInt64}, start::Int)

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1303,6 +1303,11 @@ timesofar("datamove")
 
     @test count(trues(2, 2), init=0x03) === 0x07
     @test count(trues(2, 2, 2), dims=2) == fill(2, 2, 1, 2)
+
+    m = bitrand(25, 25)
+    for idx in Any[0x03, 5, 21:42, 7:6, :, 10:407, 64:70, 65:127, 315:384, Base.OneTo(111)]
+        @test count(m[idx]) == count(view(m, idx))
+    end
 end
 
 timesofar("find")


### PR DESCRIPTION
The dispatch to this method is not ideal, because it does not handle multi- dimensional views, nor discontiguous views.
Ideally, we would have an internal API that, given a view, would iterate all contiguous sub-views. Then this new method could be called for all the conti- guous chunks.

### Benchmarks
```julia
julia> using BenchmarkTools

julia> x = BitArray(rand(Bool, 1000, 1000));

julia> @btime sum(view(x, 43:849212)); # before
  251.198 μs (4 allocations: 128 bytes)

julia> @btime sum(view(x, 43:849212)); # after
  747.024 ns (4 allocations: 128 bytes)
```