### PR TITLE
doc: Fix grammar, typos, and formatting issues across documentation

### DIFF
--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 Julia Base contains a range of functions and macros appropriate for performing
-scientific and numerical computing, but is also as broad as those of many general purpose programming
+scientific and numerical computing, but is also as broad as those of many general-purpose programming
 languages. Additional functionality is available from a growing collection of
 [available packages](https://julialang.org/packages/).
 Functions are grouped by topic below.

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -275,7 +275,7 @@ Partially implemented by:
 
   * [`Array`](@ref)
 
-## Dequeues
+## Deques
 
 ```@docs
 Base.push!

--- a/doc/src/base/numbers.md
+++ b/doc/src/base/numbers.md
@@ -148,7 +148,7 @@ Base.@uint128_str
 
 ## [BigFloats and BigInts](@id BigFloats-and-BigInts)
 
-The [`BigFloat`](@ref) and [`BigInt`](@ref) types implements
+The [`BigFloat`](@ref) and [`BigInt`](@ref) types implement
 arbitrary-precision floating point and integer arithmetic, respectively. For
 [`BigFloat`](@ref) the [GNU MPFR library](https://www.mpfr.org/) is used,
 and for [`BigInt`](@ref) the [GNU Multiple Precision Arithmetic Library (GMP)]

--- a/doc/src/base/parallel.md
+++ b/doc/src/base/parallel.md
@@ -159,5 +159,5 @@ non-atomic assignment of `ev.task`)
 In this example, `notify(ev::OneWayEvent)` is allowed to call `schedule(ev.task)` if and
 only if *it* modifies the state from `OWE_WAITING` to `OWE_NOTIFYING`. This lets us know that
 the task executing `wait(ev::OneWayEvent)` is now in the `ok` branch and that there cannot be
-other tasks that tries to `schedule(ev.task)` since their
+other tasks that try to `schedule(ev.task)` since their
 `@atomicreplace(ev.state, state => OWE_NOTIFYING)` will fail.

--- a/doc/src/base/reflection.md
+++ b/doc/src/base/reflection.md
@@ -142,7 +142,7 @@ For more information see [`@code_lowered`](@ref), [`@code_typed`](@ref), [`@code
 ### Printing of debug information
 
 The aforementioned functions and macros take the keyword argument `debuginfo` that controls the level
-debug information printed.
+of debug information printed.
 
 ```jldoctest; setup = :(using InteractiveUtils), filter = r"int.jl:\d+"
 julia> InteractiveUtils.@code_typed debuginfo=:source +(1,1)

--- a/doc/src/base/scopedvalues.md
+++ b/doc/src/base/scopedvalues.md
@@ -25,7 +25,7 @@ provided scoped value taking priority over previous definitions.
 
 Let's first look at an example of **lexical** scope. A `let` statement begins
 a new lexical scope within which the outer definition of `x` is shadowed by
-it's inner definition.
+its inner definition.
 
 ```jldoctest
 julia> x = 1

--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -163,7 +163,7 @@ parses as:
 ```
 (if a (block (line 2) b)
     (elseif (block (line 3) c) (block (line 4) d)
-            (block (line 6 e))))
+            (block (line 6) e)))
 ```
 
 A `while` loop parses as `(while condition body)`.

--- a/doc/src/devdocs/backtraces.md
+++ b/doc/src/devdocs/backtraces.md
@@ -128,4 +128,4 @@ Note that this is only works on Linux. The blog post on [Time Travelling Bug Rep
 A few terms have been used as shorthand in this guide:
 
   * `<julia_root>` refers to the root directory of the Julia source tree; e.g. it should contain folders
-    such as `base`, `deps`, `src`, `test`, etc.....
+    such as `base`, `deps`, `src`, `test`, etc.

--- a/doc/src/devdocs/builtins.md
+++ b/doc/src/devdocs/builtins.md
@@ -33,7 +33,9 @@ Core.memoryrefsetonce!
 
 ## Module bindings
 
+```@docs
 Core.get_binding_type
+```
 
 ## Other
 

--- a/doc/src/devdocs/callconv.md
+++ b/doc/src/devdocs/callconv.md
@@ -18,10 +18,10 @@ signature.
   * LLVM scalars and vectors are passed by value.
   * LLVM aggregates (arrays and structs) are passed by reference.
 
-A small return values is returned as LLVM return values. A large return values is returned via
+A small return value is returned as LLVM return values. A large return value is returned via
 the "structure return" (`sret`) convention, where the caller provides a pointer to a return slot.
 
-An argument or return values that is a homogeneous tuple is sometimes represented as an LLVM vector
+An argument or return value that is a homogeneous tuple is sometimes represented as an LLVM vector
 instead of an LLVM array.
 
 ## JL Call Convention

--- a/doc/src/devdocs/compiler.md
+++ b/doc/src/devdocs/compiler.md
@@ -110,7 +110,7 @@ The general principles are that:
 - Primitive types get passed in int/float registers.
 - Tuples of VecElement types get passed in vector registers.
 - Structs get passed on the stack.
-- Return values are handle similarly to arguments,
+- Return values are handled similarly to arguments,
   with a size-cutoff at which they will instead be returned via a hidden sret argument.
 
 The total logic for this is implemented by `get_specsig_function` and `deserves_sret`.

--- a/doc/src/devdocs/contributing/formatting.md
+++ b/doc/src/devdocs/contributing/formatting.md
@@ -3,20 +3,20 @@
 ## General Formatting Guidelines for Julia code contributions
 
  - Follow the latest dev version of [Julia Style Guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- - use whitespace to make the code more readable
- - no whitespace at the end of a line (trailing whitespace)
- - comments are good, especially when they explain the algorithm
- - try to adhere to a 92 character line length limit
- - it is generally preferred to use ASCII operators and identifiers over
+ - Use whitespace to make the code more readable
+ - No whitespace at the end of a line (trailing whitespace)
+ - Comments are good, especially when they explain the algorithm
+ - Try to adhere to a 92 character line length limit
+ - It is generally preferred to use ASCII operators and identifiers over
    Unicode equivalents whenever possible
- - in docstrings refer to the language as "Julia" and the executable as "`julia`"
+ - In docstrings refer to the language as "Julia" and the executable as "`julia`"
 
 ## General Formatting Guidelines For C code contributions
 
  - 4 spaces per indentation level, no tabs
- - space between `if` and `(` (`if (x) ...`)
- - newline before opening `{` in function definitions
+ - Space between `if` and `(` (`if (x) ...`)
+ - Newline before opening `{` in function definitions
  - `f(void)` for 0-argument function declarations
- - newline between `}` and `else` instead of `} else {`
- - if one part of an `if..else` chain uses `{ }` then all should
- - no whitespace at the end of a line
+ - Newline between `}` and `else` instead of `} else {`
+ - If one part of an `if..else` chain uses `{ }` then all should
+ - No whitespace at the end of a line

--- a/doc/src/devdocs/debuggingtips.md
+++ b/doc/src/devdocs/debuggingtips.md
@@ -200,7 +200,7 @@ Expr(:return, Expr(:call, :box, :Float32, Expr(:call, :fptrunc, :Float32, :x)::A
 ```
 
 Finally, and perhaps most usefully, we can force the function to be recompiled in order to step
-through the codegen process. To do this, clear the cached `functionObject` from the `jl_lamdbda_info_t*`:
+through the codegen process. To do this, clear the cached `functionObject` from the `jl_lambda_info_t*`:
 
 ```
 (gdb) p f->linfo->functionObject

--- a/doc/src/devdocs/eval.md
+++ b/doc/src/devdocs/eval.md
@@ -15,7 +15,7 @@ function, and primitive function, before turning into the desired result (hopefu
         short.
       * AST
 
-        Abstract Syntax Tree The AST is the digital representation of the code structure. In this form
+        Abstract Syntax Tree. The AST is the digital representation of the code structure. In this form
         the code has been tokenized for meaning so that it is more suitable for manipulation and execution.
 
 

--- a/doc/src/devdocs/gc-sa.md
+++ b/doc/src/devdocs/gc-sa.md
@@ -57,7 +57,7 @@ code base to make things work.
 
 ## GC Invariants
 
-There is two simple invariants correctness:
+There are two simple invariants for correctness:
 - All `GC_PUSH` calls need to be followed by an appropriate `GC_POP` (in practice we enforce this
   at the function level)
 - If a value was previously not rooted at any safepoint, it may no longer be referenced
@@ -101,7 +101,7 @@ we place on a given function are indeed correct given the implementation of said
 ## The analyzer annotations
 
 These annotations are found in src/support/analyzer_annotations.h.
-The are only active when the analyzer is being used and expand either
+They are only active when the analyzer is being used and expand either
 to nothing (for prototype annotations) or to no-ops (for function like annotations).
 
 ### `JL_NOTSAFEPOINT`

--- a/doc/src/devdocs/gc.md
+++ b/doc/src/devdocs/gc.md
@@ -23,7 +23,7 @@ Julia's pool allocator follows a "tiered" allocation discipline. When requesting
 
 - Try to claim a page from `page_pool_lazily_freed`, which contains pages which were empty on the last stop-the-world phase, but not yet madvised by a concurrent sweeper GC thread.
 
-- If it failed claiming a page from `page_pool_lazily_freed`, it will try to claim a page from `the page_pool_clean`, which contains pages which were mmaped on a previous page allocation request but never accessed.
+- If it failed claiming a page from `page_pool_lazily_freed`, it will try to claim a page from `page_pool_clean`, which contains pages which were mmaped on a previous page allocation request but never accessed.
 
 - If it failed claiming a page from `pool_page_clean` and from `page_pool_lazily_freed`, it will try to claim a page
   from `page_pool_freed`, which contains pages which have already been madvised by a concurrent sweeper GC thread and whose underlying virtual address can be recycled.

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -103,7 +103,7 @@ same type, then that is its `eltype`. If they all have a common
 [promotion type](@ref conversion-and-promotion) then they get converted to that type using
 [`convert`](@ref) and that type is the array's `eltype`. Otherwise, a heterogeneous array
 that can hold anything — a `Vector{Any}` — is constructed; this includes the literal `[]`
-where no arguments are given. [Array literal can be typed](@ref man-array-typed-literal) with
+where no arguments are given. [Array literals can be typed](@ref man-array-typed-literal) with
 the syntax `T[A, B, C, ...]` where `T` is a type.
 
 ```jldoctest

--- a/doc/src/manual/asynchronous-programming.md
+++ b/doc/src/manual/asynchronous-programming.md
@@ -162,7 +162,7 @@ constructors to explicitly link a set of channels with a set of producer/consume
 
 ### More on Channels
 
-A channel can be visualized as a pipe, i.e., it has a write end and a read end :
+A channel can be visualized as a pipe, i.e., it has a write end and a read end:
 
   * Multiple writers in different tasks can write to the same channel concurrently via [`put!`](@ref)
     calls.

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -69,7 +69,7 @@ julia> unsafe_string(path)
 
 In practice, especially when providing reusable functionality, one generally wraps `@ccall`
 uses in Julia functions that set up arguments and then check for errors in whatever manner the
-C or Fortran function specifies. And if an error occurs it is thrown as a normal Julia exception. This is especially
+C or Fortran function specifies. If an error occurs it is thrown as a normal Julia exception. This is especially
 important since C and Fortran APIs are notoriously inconsistent about how they indicate error
 conditions. For example, the `getenv` C library function is wrapped in the following Julia function,
 which is a simplified version of the actual definition from [`env.jl`](https://github.com/JuliaLang/julia/blob/master/base/env.jl):
@@ -224,7 +224,7 @@ julia> A
 ```
 
 As the example shows, the original Julia array `A` has now been sorted: `[-2.7, 1.3, 3.1, 4.4]`. Note that Julia
-[takes care of converting the array to a `Ptr{Cdouble}`](@ref automatic-type-conversion)), computing
+[takes care of converting the array to a `Ptr{Cdouble}`](@ref automatic-type-conversion), computing
 the size of the element type in bytes, and so on.
 
 For fun, try inserting a `println("mycompare($a, $b)")` line into `mycompare`, which will allow
@@ -357,7 +357,7 @@ an `Int` in Julia).
 | `unsigned long long`                                    |                          | `Culonglong`         | `UInt64`                                                                                                       |
 | `intmax_t`                                              |                          | `Cintmax_t`          | `Int64`                                                                                                        |
 | `uintmax_t`                                             |                          | `Cuintmax_t`         | `UInt64`                                                                                                       |
-| `float`                                                 | `REAL*4i`                | `Cfloat`             | `Float32`                                                                                                      |
+| `float`                                                 | `REAL*4`                 | `Cfloat`             | `Float32`                                                                                                      |
 | `double`                                                | `REAL*8`                 | `Cdouble`            | `Float64`                                                                                                      |
 | `complex float`                                         | `COMPLEX*8`              | `ComplexF32`         | `Complex{Float32}`                                                                                             |
 | `complex double`                                        | `COMPLEX*16`             | `ComplexF64`         | `Complex{Float64}`                                                                                             |
@@ -1015,7 +1015,7 @@ be a calling convention specifier (the `@ccall` macro currently does not support
 giving a calling convention). Without any specifier, the platform-default C
 calling convention is used. Other supported conventions are: `stdcall`, `cdecl`,
 `fastcall`, and `thiscall` (no-op on 64-bit Windows). For example (from
-`base/libc.jl`) we see the same `gethostname``ccall` as above, but with the
+`base/libc.jl`) we see the same `gethostname` `ccall` as above, but with the
 correct signature for Windows:
 
 ```julia

--- a/doc/src/manual/code-loading.md
+++ b/doc/src/manual/code-loading.md
@@ -36,7 +36,7 @@ An *environment* determines what `import X` and `using X` mean in various code c
 
 These can be intermixed to create **a stacked environment**: an ordered set of project environments and package directories, overlaid to make a single composite environment. The precedence and visibility rules then combine to determine which packages are available and where they get loaded from. Julia's load path forms a stacked environment, for example.
 
-These environment each serve a different purpose:
+These environments each serve a different purpose:
 
 * Project environments provide **reproducibility**. By checking a project environment into version control—e.g. a git repository—along with the rest of the project's source code, you can reproduce the exact state of the project and all of its dependencies. The manifest file, in particular, captures the exact version of every dependency, identified by a cryptographic hash of its source tree, which makes it possible for `Pkg` to retrieve the correct versions and be sure that you are running the exact code that was recorded for all dependencies.
 * Package directories provide **convenience** when a full carefully-tracked project environment is unnecessary. They are useful when you want to put a set of packages somewhere and be able to directly use them, without needing to create a project environment for them.
@@ -123,7 +123,7 @@ This manifest file describes a possible complete dependency graph for the `App` 
 - There are two different packages named `Priv` that the application uses. It uses a private package, which is a root dependency, and a public one, which is an indirect dependency through `Pub`. These are differentiated by their distinct UUIDs, and they have different deps:
   * The private `Priv` depends on the `Pub` and `Zebra` packages.
   * The public `Priv` has no dependencies.
-- The application also depends on the `Pub` package, which in turn depends on the public `Priv ` and the same `Zebra` package that the private `Priv` package depends on.
+- The application also depends on the `Pub` package, which in turn depends on the public `Priv` and the same `Zebra` package that the private `Priv` package depends on.
 
 
 This dependency graph represented as a dictionary, looks like this:
@@ -155,7 +155,7 @@ graph[UUID("c07ecb7d-0dc9-4db7-8803-fadaaeaf08e1")][:Priv]
 
 and gets `2d15fe94-a1f7-436c-a4d8-07a9a496e01c`, which indicates that in the context of the `Pub` package, `import Priv` refers to the public `Priv` package, rather than the private one which the app depends on directly. This is how the name `Priv` can refer to different packages in the main project than it does in one of its package's dependencies, which allows for duplicate names in the package ecosystem.
 
-What happens if `import Zebra` is evaluated in the main `App` code base? Since `Zebra` does not appear in the project file, the import will fail even though `Zebra` *does* appear in the manifest file. Moreover, if `import Zebra` occurs in the public `Priv` package—the one with UUID `2d15fe94-a1f7-436c-a4d8-07a9a496e01c`—then that would also fail since that `Priv` package has no declared dependencies in the manifest file and therefore cannot load any packages. The `Zebra` package can only be loaded by packages for which it appear as an explicit dependency in the manifest file: the  `Pub` package and one of the `Priv` packages.
+What happens if `import Zebra` is evaluated in the main `App` code base? Since `Zebra` does not appear in the project file, the import will fail even though `Zebra` *does* appear in the manifest file. Moreover, if `import Zebra` occurs in the public `Priv` package—the one with UUID `2d15fe94-a1f7-436c-a4d8-07a9a496e01c`—then that would also fail since that `Priv` package has no declared dependencies in the manifest file and therefore cannot load any packages. The `Zebra` package can only be loaded by packages for which it appears as an explicit dependency in the manifest file: the `Pub` package and one of the `Priv` packages.
 
 **The paths map** of a project environment is extracted from the manifest file. The path of a package `uuid` named `X` is determined by these rules (in order):
 
@@ -191,7 +191,7 @@ paths = Dict(
     # Priv – the public one:
     (UUID("2d15fe94-a1f7-436c-a4d8-07a9a496e01c"), :Priv) =>
         # package installed in the system depot:
-        "/usr/local/julia/packages/Priv/HDkr/src/Priv.jl",
+        "/usr/local/julia/packages/Priv/HDkrT/src/Priv.jl",
     # Pub:
     (UUID("c07ecb7d-0dc9-4db7-8803-fadaaeaf08e1"), :Pub) =>
         # package installed in the user depot:

--- a/doc/src/manual/command-line-interface.md
+++ b/doc/src/manual/command-line-interface.md
@@ -41,7 +41,7 @@ See also [Scripting](@ref man-scripting) for more information on writing Julia s
 
 ## The `Main.main` entry point
 
-As of Julia, 1.11, `Base` exports the macro `@main`. This macro expands to the symbol `main`,
+As of Julia 1.11, `Base` exports the macro `@main`. This macro expands to the symbol `main`,
 but at the conclusion of executing a script or expression, `julia` will attempt to execute
 `Main.main(Base.ARGS)` if such a function `Main.main` has been defined and this behavior was opted into
 by using the `@main` macro.
@@ -148,7 +148,7 @@ atreplinit() do repl
     # ...
 end
 ```
-If [`JULIA_DEPOT_PATH`](@ref JULIA_DEPOT_PATH) is set, the startup file should be located there
+If [`JULIA_DEPOT_PATH`](@ref JULIA_DEPOT_PATH) is set, the startup file should be located there:
 `$JULIA_DEPOT_PATH/config/startup.jl`.
 
 ## [Command-line switches for Julia](@id command-line-interface)
@@ -177,7 +177,7 @@ The following is a complete list of command-line switches available when launchi
 |`--pkgimages={yes*\|no\|existing}`     |Enable or disable usage of native code caching in the form of pkgimages. The `existing` option allows use of existing pkgimages but disallows creation of new ones|
 |`-e`, `--eval <expr>`                  |Evaluate `<expr>`|
 |`-E`, `--print <expr>`                 |Evaluate `<expr>` and display the result|
-|`-m`, `--module <Package> [args]`      |Run entry point of `Package` (`@main` function) with `args'|
+|`-m`, `--module <Package> [args]`      |Run entry point of `Package` (`@main` function) with `args`|
 |`-L`, `--load <file>`                  |Load `<file>` immediately on all processors|
 |`-t`, `--threads {auto\|N[,auto\|M]}`  |Enable N[+M] threads; N threads are assigned to the `default` threadpool, and if M is specified, M threads are assigned to the `interactive` threadpool; `auto` tries to infer a useful default number of threads to use but the exact behavior might change in the future. Currently sets N to the number of CPUs assigned to this Julia process based on the OS-specific affinity assignment interface if supported (Linux and Windows) or to the number of CPU threads if not supported (MacOS) or if process affinity is not configured, and sets M to 1.|
 | `--gcthreads=N[,M]`                   |Use N threads for the mark phase of GC and M (0 or 1) threads for the concurrent sweeping phase of GC. N is set to the number of compute threads and M is set to 0 if unspecified.|

--- a/doc/src/manual/distributed-computing.md
+++ b/doc/src/manual/distributed-computing.md
@@ -197,7 +197,7 @@ loaded
       From worker 2:    loaded
 ```
 
-As usual, this does not bring `DummyModule` into scope on any of the process, which requires
+As usual, this does not bring `DummyModule` into scope on any of the processes, which requires
 [`using`](@ref) or [`import`](@ref). Moreover, when `DummyModule` is brought into scope on one process, it
 is not on any other:
 

--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -34,7 +34,7 @@ The basic syntax is simple: any string appearing just before an object
 the documented object. Here is a basic example:
 
 ```julia
-"Tell whether there are too foo items in the array."
+"Tell whether there are too many foo items in the array."
 foo(xs::Array) = ...
 ```
 !!! note "Reminder"


### PR DESCRIPTION
👨 , I made an LLM go through the manual to find obvious errors. I reviewed what it found and think they are ok.

---

🤖 

Fixed numerous obvious errors throughout the Julia documentation including:
- Grammar errors (subject-verb agreement, missing articles)
- Typos and spelling corrections
- Formatting inconsistencies
- Missing punctuation and syntax errors
- Capitalization standardization

🤖 Generated with [Claude Code](https://claude.ai/code)