### PR TITLE
[backports-release-1.11] Re-enable tab completion of kwargs for large method tables (#58012)

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -1025,7 +1025,13 @@ function complete_keyword_argument(partial, last_idx, context_module)
     kwargs_flag == 2 && return fail # one of the previous kwargs is invalid
 
     methods = Completion[]
-    complete_methods!(methods, funct, Any[Vararg{Any}], kwargs_ex, MAX_METHOD_COMPLETIONS, kwargs_flag == 1)
+    # Limit kwarg completions to cases when function is concretely known; looking up
+    # matching methods for abstract functions — particularly `Any` or `Function` — can
+    # take many seconds to run over the thousands of possible methods. Note that
+    # isabstracttype would return naively return true for common constructor calls
+    # like Array, but the REPL's introspection here may know their Type{T}.
+    isconcretetype(funct) || return fail
+    complete_methods!(methods, funct, Any[Vararg{Any}], kwargs_ex, -1, arg_pos == :kwargs)
     # TODO: use args_ex instead of Any[Vararg{Any}] and only provide kwarg completion for
     # method calls compatible with the current arguments.
 

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -2301,3 +2301,32 @@ let s = "Issue53126()."
     @test res
     @test isempty(c)
 end
+
+function g54131 end
+for i in 1:498
+    @eval g54131(::Val{$i}) = i
+end
+g54131(::Val{499}; kwarg=true) = 499*kwarg
+struct F54131; end
+Base.getproperty(::F54131, ::Symbol) = Any[cos, sin, g54131][rand(1:3)]
+f54131 = F54131()
+@testset "performance of kwarg completion with large method tables" begin
+    # The goal here is to simply ensure we aren't hitting catestrophically bad
+    # behaviors when shift isn't pressed. The difference between good and bad
+    # is on the order of tens of milliseconds vs tens of seconds; using 1 sec as
+    # a very rough canary that is hopefully robust even in the noisy CI coalmines
+    s = "g54131(kwa"
+    a, b, c = completions(s, lastindex(s), @__MODULE__, #= shift =# false)
+    @test REPLCompletions.KeywordArgumentCompletion("kwarg") in a
+    @test (@elapsed completions(s, lastindex(s), @__MODULE__, false)) < 1
+
+    s = "f54131.x("
+    a, b, c = completions(s, lastindex(s), @__MODULE__, false)
+    @test only(a) isa REPLCompletions.TextCompletion
+    @test (@elapsed completions(s, lastindex(s), @__MODULE__, false)) < 1
+
+    s = "f54131.x(kwa"
+    a, b, c = completions(s, lastindex(s), @__MODULE__, false)
+    @test_broken REPLCompletions.KeywordArgumentCompletion("kwarg") in a
+    @test (@elapsed completions(s, lastindex(s), @__MODULE__, false)) < 1
+end


### PR DESCRIPTION
Manual backport of #58012 for release-1.11