### PR TITLE
add a precompile workload to TOML

### DIFF
--- a/stdlib/TOML/src/TOML.jl
+++ b/stdlib/TOML/src/TOML.jl
@@ -148,4 +148,6 @@ Internals.reinit!(p::Parser, str::String; filepath::Union{Nothing, String}=nothi
 Internals.parse(p::Parser) = Internals.parse(p._p)
 Internals.tryparse(p::Parser) = Internals.tryparse(p._p)
 
+include("precompile.jl")
+
 end

--- a/stdlib/TOML/src/precompile.jl
+++ b/stdlib/TOML/src/precompile.jl
@@ -1,0 +1,38 @@
+if Base.generating_output()
+let
+    # Test TOML content
+    test_toml = """
+    title = "Example"
+    with_quotes = \"quoted\"
+    number = 42
+    float = 3.14
+    boolean = true
+    date = 2023-01-01
+    datetime = 2023-01-01T12:00:00Z
+    time = 12:00:00
+    array = [1, 2, 3]
+    inline = {a=1, b=1.0, c=[1,2,3], d="foo"}
+
+    [nested]
+    key = "value"
+    """
+
+    test_dict = TOML.parse(test_toml)
+
+    TOML.parse(test_toml)
+
+    io_stream = IOBuffer(test_toml)
+    TOML.parse(io_stream)
+
+    mktemp() do path, io
+        write(io, test_toml)
+        close(io)
+        TOML.parsefile(path)
+    end
+
+    mktemp() do path, io
+        TOML.print(io, test_dict)
+        close(io)
+    end
+end
+end

--- a/stdlib/TOML/src/print.jl
+++ b/stdlib/TOML/src/print.jl
@@ -33,7 +33,6 @@ function print_toml_escaped(io::IO, s::AbstractString)
     end
 end
 
-const MbyFunc = Union{Function, Nothing}
 const TOMLValue = Union{AbstractVector, AbstractDict, Bool, Integer, AbstractFloat, AbstractString,
                         Dates.DateTime, Dates.Time, Dates.Date, Base.TOML.DateTime, Base.TOML.Time, Base.TOML.Date}
 
@@ -59,8 +58,8 @@ function printkey(io::IO, keys::Vector{String})
     end
 end
 
-function to_toml_value(f::MbyFunc, value)
-    if f === nothing
+function to_toml_value(@nospecialize(f::Function), value)
+    if f === identity
         error("type `$(typeof(value))` is not a valid TOML type, pass a conversion function to `TOML.print`")
     end
     toml_value = f(value)
@@ -75,12 +74,12 @@ end
 ##########
 
 # Fallback
-function printvalue(f::MbyFunc, io::IO, value, sorted::Bool)
+function printvalue(f::Function, io::IO, value, sorted::Bool)
     toml_value = to_toml_value(f, value)
     @invokelatest printvalue(f, io, toml_value, sorted)
 end
 
-function printvalue(f::MbyFunc, io::IO, value::AbstractVector, sorted::Bool)
+function printvalue(f::Function, io::IO, value::AbstractVector, sorted::Bool)
     Base.print(io, "[")
     for (i, x) in enumerate(value)
         i != 1 && Base.print(io, ", ")
@@ -89,7 +88,7 @@ function printvalue(f::MbyFunc, io::IO, value::AbstractVector, sorted::Bool)
     Base.print(io, "]")
 end
 
-function printvalue(f::MbyFunc, io::IO, value::TOMLValue, sorted::Bool)
+function printvalue(f::Function, io::IO, value::TOMLValue, sorted::Bool)
     value isa Base.TOML.DateTime && (value = Dates.DateTime(value))
     value isa Base.TOML.Time && (value = Dates.Time(value))
     value isa Base.TOML.Date && (value = Dates.Date(value))
@@ -117,7 +116,7 @@ function print_integer(io::IO, value::Integer)
     return
 end
 
-function print_inline_table(f::MbyFunc, io::IO, value::AbstractDict, sorted::Bool)
+function print_inline_table(f::Function, io::IO, value::AbstractDict, sorted::Bool)
     vkeys = collect(keys(value))
     if sorted
         sort!(vkeys)
@@ -138,15 +137,14 @@ end
 # Tables #
 ##########
 
-is_table(value)           = isa(value, AbstractDict)
-is_array_of_tables(value) = isa(value, AbstractArray) &&
-                            length(value) > 0 && (
-                                isa(value, AbstractArray{<:AbstractDict}) ||
-                                all(v -> isa(v, AbstractDict), value)
-                            )
-is_tabular(value)         = is_table(value) || @invokelatest(is_array_of_tables(value))
+is_table(@nospecialize(value)) = isa(value, AbstractDict)
+is_array_of_tables(@nospecialize(value)) =
+    isa(value, AbstractArray) &&
+    length(value) > 0 && (isa(value, AbstractArray{<:AbstractDict}) ||
+                          all(v -> isa(v, AbstractDict), value))
+is_tabular(@nospecialize(value)) = is_table(value) || @invokelatest(is_array_of_tables(value))
 
-function print_table(f::MbyFunc, io::IO, a::AbstractDict,
+function print_table(f::Function, io::IO, a::AbstractDict,
     ks::Vector{String} = String[];
     indent::Int = 0,
     first_block::Bool = true,
@@ -228,7 +226,11 @@ end
 # API #
 #######
 
-print(f::MbyFunc, io::IO, a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}()) = print_table(f, io, a; sorted, by, inline_tables)
-print(f::MbyFunc,         a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}()) = print(f, stdout, a; sorted, by, inline_tables)
-print(io::IO, a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}()) = print_table(nothing, io, a; sorted, by, inline_tables)
-print(        a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}()) = print(nothing, stdout, a; sorted, by, inline_tables)
+print(f::Function, io::IO, a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}()) =
+    print_table(f, io, a; sorted, by, inline_tables)
+print(f::Function, a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}()) =
+    print(f, stdout, a; sorted, by, inline_tables)
+print(io::IO, a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}()) =
+    print_table(identity, io, a; sorted, by, inline_tables)
+print(a::AbstractDict; sorted::Bool=false, by=identity, inline_tables::IdSet{<:AbstractDict}=IdSet{Dict{String}}()) =
+    print(identity, stdout, a; sorted, by, inline_tables)


### PR DESCRIPTION
Pkg needs a bunch of this anyway, so it makes sense to push these compiled methods upstream.

I also added some `@nospecialize` in some strategic places because I saw Pkg was specializing on stuff like:

```
      is_table specialized for Tuple{typeof(TOML.Internals.Printer.is_table), Dict{String, String}}
      is_table specialized for Tuple{typeof(TOML.Internals.Printer.is_table), Integer}
      is_table specialized for Tuple{typeof(TOML.Internals.Printer.is_table), String}
      is_table specialized for Tuple{typeof(TOML.Internals.Printer.is_table), Vector{Dict{String, Any}}}
      is_table specialized for Tuple{typeof(TOML.Internals.Printer.is_table), Vector{Dict{String, Dates.DateTime}}}
      is_table specialized for Tuple{typeof(TOML.Internals.Printer.is_table), Vector{Dict}}
      is_tabular specialized for Tuple{typeof(TOML.Internals.Printer.is_tabular), Any}
      is_tabular specialized for Tuple{typeof(TOML.Internals.Printer.is_tabular), Base.TOML.DateTime}
      is_tabular specialized for Tuple{typeof(TOML.Internals.Printer.is_tabular), Base.TOML.Date}
      is_tabular specialized for Tuple{typeof(TOML.Internals.Printer.is_tabular), Base.TOML.Time}
      is_tabular specialized for Tuple{typeof(TOML.Internals.Printer.is_tabular), Dates.DateTime}
      is_tabular specialized for Tuple{typeof(TOML.Internals.Printer.is_tabular), Dates.Date}
```