### PR TITLE
shield `_artifact_str` function behind a world age barrier

### DIFF
--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -542,14 +542,8 @@ function jointail(dir, tail)
     end
 end
 
-const _artifact_str_world_age = Ref{UInt}(typemax(UInt))
-
-function __init__()
-    _artifact_str_world_age[] = Base.get_world_counter()
-end
-
 function _artifact_str(__module__, artifacts_toml, name, path_tail, artifact_dict, hash, platform, ::Val{LazyArtifacts}) where LazyArtifacts
-    world = _artifact_str_world_age[]
+    world = Base._require_world_age[]
     if world == typemax(UInt)
         world = Base.get_world_counter()
     end

--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -542,7 +542,21 @@ function jointail(dir, tail)
     end
 end
 
+const _artifact_str_world_age = Ref{UInt}(typemax(UInt))
+
+function __init__()
+    _artifact_str_world_age[] = Base.get_world_counter()
+end
+
 function _artifact_str(__module__, artifacts_toml, name, path_tail, artifact_dict, hash, platform, ::Val{LazyArtifacts}) where LazyArtifacts
+    world = _artifact_str_world_age[]
+    if world == typemax(UInt)
+        world = Base.get_world_counter()
+    end
+    return Base.invoke_in_world(world, __artifact_str, __module__, artifacts_toml, name, path_tail, artifact_dict, hash, platform, Val(LazyArtifacts))
+end
+
+function __artifact_str(__module__, artifacts_toml, name, path_tail, artifact_dict, hash, platform, ::Val{LazyArtifacts}) where LazyArtifacts
     pkg = Base.PkgId(__module__)
     if pkg.uuid !== nothing
         # Process overrides for this UUID, if we know what it is

--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -579,7 +579,8 @@ function __artifact_str(__module__, artifacts_toml, name, path_tail, artifact_di
             if nameof(LazyArtifacts) in (:Pkg, :Artifacts, :PkgArtifacts)
                 Base.depwarn("using Pkg instead of using LazyArtifacts is deprecated", :var"@artifact_str", force=true)
             end
-            return jointail(LazyArtifacts.ensure_artifact_installed(string(name), meta, artifacts_toml; platform), path_tail)
+            path_base = @invokelatest LazyArtifacts.ensure_artifact_installed(string(name), meta, artifacts_toml; platform)
+            return jointail(path_base, path_tail)
         end
         error("Artifact $(repr(name)) is a lazy artifact; package developers must call `using LazyArtifacts` in $(__module__) before using lazy artifacts.")
     end

--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -573,7 +573,7 @@ function __artifact_str(__module__, artifacts_toml, name, path_tail, artifact_di
             if nameof(LazyArtifacts) in (:Pkg, :Artifacts, :PkgArtifacts)
                 Base.depwarn("using Pkg instead of using LazyArtifacts is deprecated", :var"@artifact_str", force=true)
             end
-            path_base = @invokelatest LazyArtifacts.ensure_artifact_installed(string(name), meta, artifacts_toml; platform)
+            path_base = (@invokelatest LazyArtifacts.ensure_artifact_installed(string(name), meta, artifacts_toml; platform))::String
             return jointail(path_base, path_tail)
         end
         error("Artifact $(repr(name)) is a lazy artifact; package developers must call `using LazyArtifacts` in $(__module__) before using lazy artifacts.")

--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -547,7 +547,7 @@ function _artifact_str(__module__, artifacts_toml, name, path_tail, artifact_dic
     if world == typemax(UInt)
         world = Base.get_world_counter()
     end
-    return Base.invoke_in_world(world, __artifact_str, __module__, artifacts_toml, name, path_tail, artifact_dict, hash, platform, Val(LazyArtifacts))
+    return Base.invoke_in_world(world, __artifact_str, __module__, artifacts_toml, name, path_tail, artifact_dict, hash, platform, Val(LazyArtifacts))::String
 end
 
 function __artifact_str(__module__, artifacts_toml, name, path_tail, artifact_dict, hash, platform, ::Val{LazyArtifacts}) where LazyArtifacts


### PR DESCRIPTION
We already do this for `require` in Base loading, it probably makes sense to do this here as well, as invalidating this function easily adds +1s in load time for a jll. Avoids the big load time penalty from loading IntelOpenMP_jll in https://github.com/JuliaLang/julia/issues/57436#issuecomment-3052258775.

Before:

```
julia> @time using ModelingToolkit
  6.546844 seconds (16.09 M allocations: 938.530 MiB, 11.13% gc time, 16.35% compilation time: 12% of which was recompilation)
```

After:

```
julia> @time using ModelingToolkit
  5.637914 seconds (8.26 M allocations: 533.694 MiB, 11.47% gc time, 3.11% compilation time: 17% of which was recompilation)
```