### PR TITLE
clear up `isdone` docstring

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1225,8 +1225,9 @@ Stateful iterators that want to opt into this feature should define an `isdone`
 method that returns true/false depending on whether the iterator is done or
 not. Stateless iterators need not implement this function.
 
-If the result is `missing`, callers may go ahead and compute
-`iterate(x, state) === nothing` to compute a definite answer.
+If the result is `missing`, then `isdone` cannot determine whether the iterator
+state is terminal, and callers must compute `iterate(itr, state) === nothing`
+to obtain a definitive answer.
 
 See also [`iterate`](@ref), [`isempty`](@ref)
 """


### PR DESCRIPTION
I got pretty confused on my first reading of this docstring because for some reason I thought it was saying that `isdone(itr, state) == missing` implied that it was true that `iterate(itr, state) === nothing` (aka that `state` is indeed final). which of course is wrong and doesn't make sense, but it's still how I read it. I think the new docstring is a bit more explicit.