### PR TITLE
specify that `Iterators.rest` must be given a valid `state`

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -632,7 +632,12 @@ See also: [`Iterators.drop`](@ref), [`Iterators.peel`](@ref), [`Base.rest`](@ref
 
 # Examples
 ```jldoctest
-julia> collect(Iterators.rest([1,2,3,4], 2))
+julia> iter = [1,2,3,4];
+
+julia> val, state = iterate(iter)
+(1, 2)
+
+julia> collect(Iterators.rest(iter, state))
 3-element Vector{Int64}:
  2
  3

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -625,7 +625,8 @@ end
 """
     rest(iter, state)
 
-An iterator that yields the same elements as `iter`, but starting at the given `state`.
+An iterator that yields the same elements as `iter`, but starting at the given `state`, which
+must be a state obtainable via a sequence of one or more calls to `iterate(iter[, state])`
 
 See also: [`Iterators.drop`](@ref), [`Iterators.peel`](@ref), [`Base.rest`](@ref).
 


### PR DESCRIPTION
~currently `Iterators.rest(1:2, 3)` creates an infinite loop. after this PR it would be an `ArgumentError`~

docs only now