### PR TITLE
remove comment from julia-syntax that is no longer true

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -545,10 +545,7 @@
         ;; call with keyword args pre-sorted - original method code goes here
         ,(method-def-expr-
           mangled sparams
-          `((|::| ,mangled (call (core typeof) ,mangled)) ,@vars ,@restkw
-            ;; strip type off function self argument if not needed for a static param.
-            ;; then it is ok for cl-convert to move this definition above the original def.
-            ,@not-optional ,@vararg)
+          `((|::| ,mangled (call (core typeof) ,mangled)) ,@vars ,@restkw ,@not-optional ,@vararg)
           (insert-after-meta `(block
                                ,@stmts)
                              (cons `(meta nkw ,(+ (length vars) (length restkw)))


### PR DESCRIPTION
The code this referred to was removed by c6c3d72d1cbddb3d27e0df0e739bb27dd709a413

Just happened across this and it confused me. What was I doing in 2019.

[ci skip]
