### PR TITLE
Fix `hygienic-scope`s in inner macro expansions

### DIFF
--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -513,7 +513,7 @@
                    (body (cadr e))
                    (m (caddr e))
                    (lno  (cdddr e)))
-              (resolve-expansion-vars-with-new-env body env m lno parent-scope inarg #t)))
+              (resolve-expansion-vars-with-new-env body '() m lno parent-scope inarg #t)))
            ((tuple)
             (cons (car e)
                   (map (lambda (x)

--- a/test/core.jl
+++ b/test/core.jl
@@ -2280,6 +2280,31 @@ end
 x6074 = 6074
 @test @X6074() == 6074
 
+# issues #48910, 54417
+macro X43151_nested()
+    quote my_value = "from_nested_macro" end
+end
+macro X43151_parent()
+    quote
+        my_value = "from_parent_macro"
+        @X43151_nested()
+        my_value
+    end
+end
+@test @X43151_parent() == "from_parent_macro"
+
+macro X43151_nested_escaping()
+    quote $(esc(:my_value)) = "from_nested_macro" end
+end
+macro X43151_parent_escaping()
+    quote
+        my_value = "from_parent_macro"
+        @X43151_nested_escaping()
+        my_value
+    end
+end
+@test @X43151_parent_escaping() == "from_nested_macro"
+
 # issue #5536
 test5536(a::Union{Real, AbstractArray}...) = "Splatting"
 test5536(a::Union{Real, AbstractArray}) = "Non-splatting"


### PR DESCRIPTION
Changes from https://github.com/JuliaLang/julia/pull/43151, github just didn't want me to re-open it.

As discussed on slack, any `hygienic-scope` within an outer `hygienic-scope` can read and write variables in the outer one, so it's not particularly hygienic.  The result is that we can't safely nest macro calls unless they know the contents of all inner macro calls.

Should fix #48910.  