### PR TITLE
Add 'sysimage' keyword for `JULIA_CPU_TARGET` to match (or extend) the sysimage target

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,7 +48,7 @@ New library functions
 * `ispositive(::Real)` and `isnegative(::Real)` are provided for performance and convenience ([#53677]).
 * Exporting function `fieldindex` to get the index of a struct's field ([#58119]).
 * `Base.donotdelete` is now public. It prevents deadcode elemination of its arguments ([#55774]).
-* `Sys.sysimage_cpu_target_str()` returns the CPU target string used to build the current system image ([#58970]).
+* `Sys.sysimage_target()` returns the CPU target string used to build the current system image ([#58970]).
 
 New library features
 --------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@ Command-line option changes
 ---------------------------
 
 * The option `--sysimage-native-code=no` has been deprecated.
+* The `JULIA_CPU_TARGET` environment variable now supports a `sysimage` keyword to match (or extend) the CPU target used to build the current system image ([#58970]).
 
 Multi-threading changes
 -----------------------
@@ -47,6 +48,7 @@ New library functions
 * `ispositive(::Real)` and `isnegative(::Real)` are provided for performance and convenience ([#53677]).
 * Exporting function `fieldindex` to get the index of a struct's field ([#58119]).
 * `Base.donotdelete` is now public. It prevents deadcode elemination of its arguments ([#55774]).
+* `Sys.sysimage_cpu_target_str()` returns the CPU target string used to build the current system image ([#58970]).
 
 New library features
 --------------------

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -16,7 +16,7 @@ export BINDIR,
        JIT,
        cpu_info,
        cpu_summary,
-       sysimage_cpu_target_str,
+       sysimage_target,
        uptime,
        loadavg,
        free_memory,
@@ -314,7 +314,7 @@ function cpu_info()
 end
 
 """
-    Sys.sysimage_cpu_target_str()
+    Sys.sysimage_target()
 
 Return the CPU target string that was used to build the current system image.
 
@@ -326,7 +326,7 @@ If the system image was built with the default settings this will return `"nativ
 
 See also [`JULIA_CPU_TARGET`](@ref).
 """
-function sysimage_cpu_target_str()
+function sysimage_target()
     return ccall(:jl_get_sysimage_cpu_target, Ref{String}, ())
 end
 

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -16,6 +16,7 @@ export BINDIR,
        JIT,
        cpu_info,
        cpu_summary,
+       sysimage_cpu_target_str,
        uptime,
        loadavg,
        free_memory,
@@ -310,6 +311,23 @@ function cpu_info()
     end
     ccall(:uv_free_cpu_info, Cvoid, (Ptr{UV_cpu_info_t}, Int32), UVcpus[], count[])
     return cpus
+end
+
+"""
+    Sys.sysimage_cpu_target_str()
+
+Return the CPU target string that was used to build the current system image.
+
+This function returns the original CPU target specification that was passed to Julia
+when the system image was compiled. This can be useful for reproducing the same
+system image or for understanding what CPU features were enabled during compilation.
+
+If the system image was built with the default settings this will return `"native"`.
+
+See also [`JULIA_CPU_TARGET`](@ref).
+"""
+function sysimage_cpu_target_str()
+    return ccall(:jl_get_sysimage_cpu_target, Ref{String}, ())
 end
 
 """

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -397,6 +397,7 @@ Base.Sys.total_memory
 Base.Sys.free_physical_memory
 Base.Sys.total_physical_memory
 Base.Sys.uptime
+Base.Sys.sysimage_cpu_target_str
 Base.Sys.isjsvm
 Base.Sys.loadavg
 Base.Sys.isexecutable

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -397,7 +397,7 @@ Base.Sys.total_memory
 Base.Sys.free_physical_memory
 Base.Sys.total_physical_memory
 Base.Sys.uptime
-Base.Sys.sysimage_cpu_target_str
+Base.Sys.sysimage_target
 Base.Sys.isjsvm
 Base.Sys.loadavg
 Base.Sys.isexecutable

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -479,9 +479,15 @@ stored in memory.
 
 Valid values for [`JULIA_CPU_TARGET`](@ref JULIA_CPU_TARGET) can be obtained by executing `julia -C help`.
 
+To get the CPU target string that was used to build the current system image,
+use [`Sys.sysimage_cpu_target_str()`](@ref). This can be useful for reproducing
+the same system image or understanding what CPU features were enabled during compilation.
+
 Setting [`JULIA_CPU_TARGET`](@ref JULIA_CPU_TARGET) is important for heterogeneous compute systems where processors of
 distinct types or features may be present. This is commonly encountered in high performance
-computing (HPC) clusters since the component nodes may be using distinct processors.
+computing (HPC) clusters since the component nodes may be using distinct processors. In this case,
+you may want to use the `sysimage` CPU target to maintain the same configuration as the sysimage.
+See below for more details.
 
 The CPU target string is a list of strings separated by `;` each string starts with a CPU
 or architecture name and followed by an optional list of features separated by `,`.
@@ -490,13 +496,20 @@ which is at least the architecture the C/C++ runtime is compiled with. Each stri
 is interpreted by LLVM.
 
 A few special features are supported:
-1. `clone_all`
+
+1. `sysimage`
+
+     A special keyword that can be used as a CPU target name, which will be replaced
+     with the CPU target string that was used to build the current system image. This allows
+     you to specify CPU targets that build upon or extend the current sysimage's target.
+
+2. `clone_all`
 
      This forces the target to have all functions in sysimg cloned.
      When used in negative form (i.e. `-clone_all`), this disables full clone that's
      enabled by default for certain targets.
 
-2. `base([0-9]*)`
+3. `base([0-9]*)`
 
      This specifies the (0-based) base target index. The base target is the target
      that the current target is based on, i.e. the functions that are not being cloned
@@ -504,11 +517,11 @@ A few special features are supported:
      fully cloned (as if `clone_all` is specified for it) if it is not the default target (0).
      The index can only be smaller than the current index.
 
-3. `opt_size`
+4. `opt_size`
 
      Optimize for size with minimum performance impact. Clang/GCC's `-Os`.
 
-4. `min_size`
+5. `min_size`
 
      Optimize only for size. Clang's `-Oz`.
 

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -480,7 +480,7 @@ stored in memory.
 Valid values for [`JULIA_CPU_TARGET`](@ref JULIA_CPU_TARGET) can be obtained by executing `julia -C help`.
 
 To get the CPU target string that was used to build the current system image,
-use [`Sys.sysimage_cpu_target_str()`](@ref). This can be useful for reproducing
+use [`Sys.sysimage_target()`](@ref). This can be useful for reproducing
 the same system image or understanding what CPU features were enabled during compilation.
 
 Setting [`JULIA_CPU_TARGET`](@ref JULIA_CPU_TARGET) is important for heterogeneous compute systems where processors of
@@ -501,7 +501,8 @@ A few special features are supported:
 
      A special keyword that can be used as a CPU target name, which will be replaced
      with the CPU target string that was used to build the current system image. This allows
-     you to specify CPU targets that build upon or extend the current sysimage's target.
+     you to specify CPU targets that build upon or extend the current sysimage's target, which
+     is particularly helpful for creating package images that are as flexible as the sysimage.
 
 2. `clone_all`
 

--- a/pkgimage.mk
+++ b/pkgimage.mk
@@ -26,7 +26,7 @@ print-depot-path:
 	@$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --startup-file=no -e '@show Base.DEPOT_PATH')
 
 $(BUILDDIR)/stdlib/%.image: $(JULIAHOME)/stdlib/Project.toml $(JULIAHOME)/stdlib/Manifest.toml $(INDEPENDENT_STDLIBS_SRCS) $(DEPOTDIR)/compiled
-	@$(call PRINT_JULIA, JULIA_CPU_TARGET="$(JULIA_CPU_TARGET)" $(call spawn,$(JULIA_EXECUTABLE)) --startup-file=no -e \
+	@$(call PRINT_JULIA, JULIA_CPU_TARGET="sysimage" $(call spawn,$(JULIA_EXECUTABLE)) --startup-file=no -e \
 		'Base.Precompilation.precompilepkgs(configs=[``=>Base.CacheFlags(debug_level=2, opt_level=3), ``=>Base.CacheFlags(check_bounds=1, debug_level=2, opt_level=3)])')
 	touch $@
 

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -190,6 +190,7 @@
     XX(jl_check_binding_currently_writable) \
     XX(jl_get_cpu_name) \
     XX(jl_get_cpu_features) \
+    XX(jl_get_sysimage_cpu_target) \
     XX(jl_cpu_has_fma) \
     XX(jl_get_current_task) \
     XX(jl_get_default_sysimg_path) \

--- a/src/processor.h
+++ b/src/processor.h
@@ -195,6 +195,8 @@ typedef struct {
     //  This contains the number of targets
     //  in addition to the name and feature set of each target.
     const void *target_data;
+    // Original CPU target string used to build this sysimage
+    const char *cpu_target_string;
 } jl_image_pointers_t;
 
 /**
@@ -210,10 +212,15 @@ typedef struct {
 jl_image_t jl_init_processor_sysimg(jl_image_buf_t image, const char *cpu_target);
 jl_image_t jl_init_processor_pkgimg(jl_image_buf_t image);
 
+// Internal function to set the sysimage CPU target during initialization
+void jl_set_sysimage_cpu_target(const char *cpu_target);
+
 // Return the name of the host CPU as a julia string.
 JL_DLLEXPORT jl_value_t *jl_get_cpu_name(void);
 // Return the features of the host CPU as a julia string.
 JL_DLLEXPORT jl_value_t *jl_get_cpu_features(void);
+// Return the CPU target string used to build the current sysimage
+JL_DLLEXPORT jl_value_t *jl_get_sysimage_cpu_target(void);
 // Dump the name and feature set of the host CPU
 JL_DLLEXPORT jl_value_t *jl_cpu_has_fma(int bits);
 // Check if the CPU has native FMA instructions;

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1033,7 +1033,7 @@ end
     withenv("JULIA_CPU_TARGET" => "sysimage") do
         v = readchomp(`$julia_path -E "Sys.sysimage_target()"`)
         # Local builds will likely be "native" but CI shouldn't be.
-        invalid_results = Base.get_bool_env("CI", false) ? ("native", "sysimage") : ("sysimage",)
+        invalid_results = Base.get_bool_env("CI", false) ? ("", "native", "sysimage") : ("", "sysimage",)
         @test !in(v, invalid_results)
     end
 end

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1028,6 +1028,14 @@ end
         @test v[2] == ""
         @test contains(v[3], "More than one command line CPU targets specified")
     end
+
+    # Testing this more precisely would be very platform and build system dependent and brittle.
+    withenv("JULIA_CPU_TARGET" => "sysimage") do
+        v = readchomp(`$julia_path -E "Sys.sysimage_target()"`)
+        # Local builds will likely be "native" but CI shouldn't be.
+        invalid_results = Base.get_bool_env("CI", false) ? ("native", "sysimage") : ("sysimage",)
+        @test !in(v, invalid_results)
+    end
 end
 
 # Find the path of libjulia (or libjulia-debug, as the case may be)


### PR DESCRIPTION
Adds the `sysimage` special flag so you can keep (or extend) the flexibility/performance of the shipped julia versions via `JULIA_CPU_TARGET=sysimage`, rather than the default to generate native code which will make heterogenous systems hit precompilation when they are sharing a depot.

Also add `Sys.sysimage_cpu_target_str()` to get the string that was used for the sysimage build.
```
% JULIA_CPU_TARGET="generic;apple-m1,clone_all" make -j6
...
% ./julia -E "Sys.sysimage_cpu_target_str()"
"generic;apple-m1,clone_all"
```

Claude helped.
