### PR TITLE
bpart: Tweak `isdefinedglobal` on backdated constant

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -42,7 +42,7 @@ function _isself(ft::DataType)
     name = ftname.singletonname
     ftname.name === name && return false
     mod = parentmodule(ft)
-    return invokelatest(isdefinedglobal, mod, name) && ft === typeof(invokelatest(getglobal, mod, name))
+    return isdefinedglobal(mod, name) && ft === typeof(getglobal(mod, name))
 end
 
 function show(io::IO, ::MIME"text/plain", f::Function)

--- a/src/module.c
+++ b/src/module.c
@@ -1477,10 +1477,14 @@ JL_DLLEXPORT int jl_boundp(jl_module_t *m, jl_sym_t *var, int allow_import) // u
     } else {
         jl_walk_binding_inplace(&b, &bpart, jl_current_task->world_age);
     }
-    if (jl_bkind_is_some_guard(jl_binding_kind(bpart)))
+    enum jl_partition_kind kind = jl_binding_kind(bpart);
+    if (jl_bkind_is_some_guard(kind))
         return 0;
-    if (jl_bkind_is_defined_constant(jl_binding_kind(bpart))) {
-        // N.B.: No backdated check for isdefined
+    if (jl_bkind_is_defined_constant(kind)) {
+        if (__unlikely(kind == PARTITION_KIND_BACKDATED_CONST)) {
+            return !(jl_current_task->ptls->in_pure_callback || jl_options.depwarn == JL_OPTIONS_DEPWARN_ERROR);
+        }
+        // N.B.: No backdated admonition for isdefined
         return 1;
     }
     return jl_atomic_load(&b->value) != NULL;

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -557,7 +557,13 @@ struct FooBackdated
 
     FooBackdated() = new(FooBackdated[])
 end
-@test Base.invoke_in_world(before_backdate_age, isdefined, @__MODULE__, :FooBackdated)
+# For depwarn == 1, this throws a warning on access, for depwarn == 2, it throws an error.
+# `isdefinedglobal` changes with that, but doesn't error.
+if Base.JLOptions().depwarn <= 1
+    @test Base.invoke_in_world(before_backdate_age, isdefinedglobal, @__MODULE__, :FooBackdated)
+else
+    @test !Base.invoke_in_world(before_backdate_age, isdefinedglobal, @__MODULE__, :FooBackdated)
+end
 
 # Test that ambiguous binding intersect the using'd binding's world ranges
 module AmbigWorldTest


### PR DESCRIPTION
In d2cc06193ef4161e4ac161bd4b5b57a51686a89a and prior commits, we made backdated access a conditional error (if depwarns are enabled or in generators). However, we did not touch `isdefinedglobal`. This resulted in the common pattern `isdefinedglobal(m, s) && getglobal(m, s)` to sometimes error. In particular, this could be observed when attempting to print a type from inside a generated function before that type's definition age.

Additionally, I think the usage there, which used `invokelatest` on each of the two queries is problematic because it is racy, since the two `invokelatest` calls may be looking at different world ages.

This makes two tweaks:
1. Makes `isdefinedglobal` consistent with `getglobal` in that it now returns false if `getglobal` would throw due to the above referenced restriction.
2. Removes the implicit `invokelatest` in _isself in the show code. Instead, it will use the current world. I considered having it use the exception age when used for MethodErrors. However, because this is used for printing it matters more how the object can be accessed *now* rather than how it could have been accessed in the past.