### PR TITLE
special: trig: smaller polynomials for sinpi,cospi kernels for f16,f32

### DIFF
--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -726,7 +726,7 @@ function acos(x::T) where T <: Union{Float32, Float64}
 end
 
 # Not used at run time, so prevent unnecessary specialization/inference.
-Base.@nospecializeinfer function _exact_string_to_floating_point((@nospecialize type::Type{<:AbstractFloat}), string::String, precision::Int)
+Base.@nospecializeinfer function _exact_string_to_floating_point((@nospecialize type::Type{<:AbstractFloat}), string::String, precision::Int = 1000)
     bf = BigFloat(string; precision)
     f = type(bf)
     (f == bf) || throw(ArgumentError("not exact"))


### PR DESCRIPTION
Regenerate the polynomials for polynomial approximation used in the implementation of `sinpi` and `cospi` kernels for `Float16` and `Float32`. The main difference is that smaller polynomials are used, which should help performance. There should be no loss in accuracy, as the kernels for `Float16` and `Float32` are "wide", computed in increased precision before rounding the final result back to the original narrow type. The current minimax polynomials for these wide kernels have unnecessarily great degree.

Another difference, for `cospi`, is that coefficient 0 is not constrained to be exactly equal to `1` any more. This means the polynomial approximation is not exact for zero inputs any more, however this should be OK, considering the result is rounded to a narrower type before returning it to the user in any case. Relaxing the value of coefficient 0 possibly allows further minimizing the overall maximum relative error (if keeping the polynomial degree fixed).

The polynomials for the kernel implementations are generated using Sollya. Apart from generating the minimax polynomial using the Remez algorithm, Sollya also takes care of rounding the big coefficients into machine precision in a way that loses less accuracy than with naive coefficient-wise rounding.

All relevant Sollya code is included in relevant doc strings.