### PR TITLE
stdlib/Dates: Fix doctest regex to handle DateTime with 0 microseconds

### DIFF
--- a/stdlib/Dates/src/conversions.jl
+++ b/stdlib/Dates/src/conversions.jl
@@ -85,7 +85,7 @@ Return a `DateTime` corresponding to the user's system time as UTC/GMT.
 For other time zones, see the TimeZones.jl package.
 
 # Examples
-```jldoctest; filter = r"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}" => "2023-01-04T10:52:24.864"
+```jldoctest; filter = r"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{3})?" => "2023-01-04T10:52:24.864"
 julia> now(UTC)
 2023-01-04T10:52:24.864
 ```


### PR DESCRIPTION
The `now(UTC)` doctest can fail when the DateTime has exactly 0 milliseconds, as the output format omits the fractional seconds entirely (e.g., "2023-01-04T10:52:24" instead of "2023-01-04T10:52:24.000").

Update the regex filter to make the milliseconds portion optional by using `(\\.\\d{3})?` instead of `\\.\\d{3}`.

Fixes CI failure: https://buildkite.com/julialang/julia-master/builds/49144#0197fd72-d1c6-44d6-9c59-5f548ab98f04

🤖 Generated with [Claude Code](https://claude.ai/code)