### PR TITLE
Clarify `@main` error message for invalid return type

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -563,11 +563,17 @@ function _start()
             # or run the fallback REPL
             ret = repl_main(ARGS)
         end
-        ret === nothing && (ret = 0)
-        ret = Cint(ret)
     catch
         ret = Cint(1)
         invokelatest(display_error, scrub_repl_backtrace(current_exceptions()))
+    else
+        ret === nothing && (ret = 0)
+        ret = try
+            Cint(ret)
+        catch
+            @error "The return value of `main` should be `nothing` or convertible to `Cint`"
+            Cint(1)
+        end
     end
     if is_interactive && get(stdout, :color, false)
         print(color_normal)

--- a/base/client.jl
+++ b/base/client.jl
@@ -563,10 +563,6 @@ function _start()
             # or run the fallback REPL
             ret = repl_main(ARGS)
         end
-    catch
-        ret = Cint(1)
-        invokelatest(display_error, scrub_repl_backtrace(current_exceptions()))
-    else
         ret === nothing && (ret = 0)
         ret = try
             Cint(ret)
@@ -574,6 +570,9 @@ function _start()
             @error "The return value of `main` should be `nothing` or convertible to `Cint`"
             Cint(1)
         end
+    catch
+        ret = Cint(1)
+        invokelatest(display_error, scrub_repl_backtrace(current_exceptions()))
     end
     if is_interactive && get(stdout, :color, false)
         print(color_normal)


### PR DESCRIPTION
When the `@main` function returns a value that is not nothing or convertible to `Cint`, the current error message may be a bit unclear or unhelpful.

For example, running the script below results in an error message that doesn’t clearly point to the underlying cause:
```julia
#!/usr/bin/env julia

# Lengthy, potentially flawed code

function @main(args)
	# Lengthy, potentially flawed code
	[] # Valid in regular functions, but not in `@main`
end
```
In this case, returning an empty array (`[]`) is perfectly fine in a normal function, but it’s not allowed in a `@main` context. The current error message doesn’t clearly emphasize this, which can make it tricky for users to understand and resolve the issue:

```julia
ERROR: MethodError: no method matching Int32(::Vector{Any})
The type `Int32` exists, but no method is defined for this combination of argument types when trying to construct it.

Closest candidates are:
  Int32(::Float64)
   @ Base float.jl:895
  Int32(::Float32)
   @ Base float.jl:919
  Int32(::Float16)
   @ Base float.jl:919
  ...

Stacktrace:
 [1] _start()
   @ Base ./client.jl:568
```