### PR TITLE
Test: Add compiler hint for `ts` variable definedness in `@testset for`

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1975,6 +1975,7 @@ function testset_forloop(args, testloop, source)
             # Handle `return` in test body
             if !first_iteration && !finish_errored
                 pop_testset()
+                @assert @isdefined(ts) "Assertion to tell the compiler about the definedness of this variable"
                 push!(arr, finish(ts))
             end
             copy!(default_rng(), default_rng_orig)


### PR DESCRIPTION
Helps the new language server avoid reporting unused variable reports.