### PR TITLE
Clarify news entry for --trim

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ Julia v1.12 Release Notes
 New language features
 ---------------------
 
-* New experimental option `--trim` that creates smaller binaries by only including code that is reachable from the
+* New experimental option `--trim` that creates smaller binaries by only including code that is proven to be reachable from the
   entry points. Entry points can be marked using `Base.Experimental.entrypoint` ([#55047]). Not all
   code is expected to work with this option, and since it is experimental you may encounter problems.
 * Redefinition of constants is now well defined and follows world age semantics ([#57253]). Additional redefinitions

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ Julia v1.12 Release Notes
 New language features
 ---------------------
 
-* New experimental option `--trim` that creates smaller binaries by removing code that can be proven to be _unreachable_ from
+* New experimental option `--trim` that creates smaller binaries by only including code that is reachable from the
   entry points. Entry points can be marked using `Base.Experimental.entrypoint` ([#55047]). Not all
   code is expected to work with this option, and since it is experimental you may encounter problems.
 * Redefinition of constants is now well defined and follows world age semantics ([#57253]). Additional redefinitions

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ Julia v1.12 Release Notes
 New language features
 ---------------------
 
-* New experimental option `--trim` that creates smaller binaries by removing code not proven to be reachable from
+* New experimental option `--trim` that creates smaller binaries by removing code that can be proven to be _unreachable_ from
   entry points. Entry points can be marked using `Base.Experimental.entrypoint` ([#55047]). Not all
   code is expected to work with this option, and since it is experimental you may encounter problems.
 * Redefinition of constants is now well defined and follows world age semantics ([#57253]). Additional redefinitions


### PR DESCRIPTION
The news entry for `--trim` in release 1.12 uses a double negative which is a little confusing. This PR fixes that

EDIT: added description