### PR TITLE
[release-1.12] Workaround poor inlining behavior for `if @generated` functions

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -88,7 +88,13 @@ function add_tfunc(@nospecialize(f::Builtin), minarg::Int, maxarg::Int, @nospeci
 end
 
 add_tfunc(throw, 1, 1, @nospecs((𝕃::AbstractLattice, x)->Bottom), 0)
-add_tfunc(Core.throw_methoderror, 1, INT_INF, @nospecs((𝕃::AbstractLattice, x)->Bottom), 0)
+
+# FIXME: the inlining cost for this built-in should be 0 (just like throw), but it is set to
+# 1000 to avoid regressions associated with the Compiler inlining too eagerly, especially when
+# encounting `if @generated` expressions.
+#
+# c.f. https://github.com/JuliaLang/julia/issues/58915#issuecomment-3070231392
+add_tfunc(Core.throw_methoderror, 1, INT_INF, @nospecs((𝕃::AbstractLattice, x)->Bottom), 1000)
 
 # the inverse of typeof_tfunc
 # returns (type, isexact, isconcrete, istype)


### PR DESCRIPTION
Restores something very close to the previous inlining behavior, without reverting https://github.com/JuliaLang/julia/pull/54972

This is a hack to workaround https://github.com/JuliaLang/julia/issues/58915#issuecomment-3070231392 for 1.12, but we should leave an issue open so that we can put in a proper fix to inlining for the next major version.

Also improves https://github.com/JuliaLang/julia/issues/58915#issuecomment-3061449594, which was a dynamic `call` on 1.11 and a poorly-chosen `invoke` of the generator fallback on 1.12. This is now an inlined version of the non-fallback path for the generator:
```julia
julia> nt = (next = zero(UInt32), prev = zero(UInt32))
(next = 0x00000000, prev = 0x00000000)

julia> f(nt) = @inline Base.setindex(nt, 2, :next)
f (generic function with 1 method)

julia> @code_warntype optimize=true f(nt)
MethodInstance for f(::@NamedTuple{next::UInt32, prev::UInt32})
  from f(nt) @ Main REPL[2]:1
Arguments
  #self#::Core.Const(Main.f)
  nt::@NamedTuple{next::UInt32, prev::UInt32}
Body::@NamedTuple{next::Int64, prev::UInt32}
1 ─ %1 =   builtin Base.getfield(nt, :prev)::UInt32
│   %2 = %new(@NamedTuple{next::Int64, prev::UInt32}, 2, %1)::@NamedTuple{next::Int64, prev::UInt32}
└──      return %2
```