### PR TITLE
Bugfix: Use Base.aligned_sizeof instead of sizeof in Mmap.mmap

### DIFF
--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -343,17 +343,18 @@ end
 GC.gc()
 rm(file)
 
-# test for #58982
-file = tempname()
-primitive type PrimType9Bytes 9*8 end
-arr = Vector{PrimType9Bytes}(undef, 2)
-write(file, arr)
-m = mmap(file, Vector{PrimType9Bytes})
-@test length(m) == 2
-@test m[1] == arr[1]
-@test m[2] == arr[2]
-finalize(m); m = nothing; GC.gc()
-rm(file)
+@testset "test for #58982 - mmap with primitive types" begin
+    file = tempname()
+    primitive type PrimType9Bytes 9*8 end
+    arr = Vector{PrimType9Bytes}(undef, 2)
+    write(file, arr)
+    m = mmap(file, Vector{PrimType9Bytes})
+    @test length(m) == 2
+    @test m[1] == arr[1]
+    @test m[2] == arr[2]
+    finalize(m); m = nothing; GC.gc()
+    rm(file)
+end
 
 @testset "Docstrings" begin
     @test isempty(Docs.undocumented_names(Mmap))

--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -343,6 +343,18 @@ end
 GC.gc()
 rm(file)
 
+# test for #58982
+file = tempname()
+primitive type PrimType9Bytes 9*8 end
+arr = Vector{PrimType9Bytes}(undef, 2)
+write(file, arr)
+m = mmap(file, Vector{PrimType9Bytes})
+@test length(m) == 2
+@test m[1] == arr[1]
+@test m[2] == arr[2]
+finalize(m); m = nothing; GC.gc()
+rm(file)
+
 @testset "Docstrings" begin
     @test isempty(Docs.undocumented_names(Mmap))
 end

--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -44,7 +44,7 @@ s = open(file)
 @test length(@inferred mmap(s, Vector{Int8}, 12, 0; grow=false)) == 12
 @test length(@inferred mmap(s, Vector{Int8}, 12, 0; shared=false)) == 12
 close(s)
-@test_throws ErrorException mmap(file, Vector{Ref}) # must be bit-type
+@test_throws ArgumentError mmap(file, Vector{Ref}) # must be bit-type
 GC.gc(); GC.gc()
 
 file = tempname() # new name to reduce chance of issues due slow windows fs


### PR DESCRIPTION
The purpose of this PR is to fix #58982 .

The current (bugged) behaviour is:
```
julia> primitive type MyPrim9 9*8 end

julia> sizeof(MyPrim9)
9

julia> Base.aligned_sizeof(MyPrim9)
16


julia> arr = Vector{MyPrim9}(undef, 2)
2-element Vector{MyPrim9}:
 MyPrim9(0x700000000000000002)
 MyPrim9(0xd000007fb7705a2c30)

julia> write("file", arr)
32

julia> using Mmap

julia> mmap("file", Vector{MyPrim9})
3-element Vector{MyPrim9}:
 MyPrim9(0x700000000000000002)
 MyPrim9(0xd000007fb7705a2c30)
 MyPrim9(0x000000000000000000)
```

This is because `Mmap` erroneously uses `sizeof` instead of `Base.aligned_sizeof` to compute the number of elements (` 32 ÷ 9 == 3 `).
This has gone undetected for a long time because `sizeof(T) == Base.aligned_sizeof(T)` is true for most types including structs. (Padding is to a multiple of 8 bytes is  included in `sizeof(T)`) 


closes #58982



edit:
Previously, `sizeof` would throw an error exception when presented with a non-mappable type such as `Ref`.
This occurred within the default argument generation. `Base.aligned_sizeof` does not error here, and this is instead caught in the dedicated `isbits` check.
This seems desirable and I changed the test to require an `ArgumentError`.