### PR TITLE
Fix order of MSYS rules

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -6,6 +6,7 @@ include $(SRCDIR)/llvm-options.mk
 ifneq ($(USE_BINARYBUILDER_LLVM), 1)
 LLVM_GIT_URL:=https://github.com/JuliaLang/llvm-project.git
 LLVM_TAR_URL=https://api.github.com/repos/JuliaLang/llvm-project/tarball/$1
+$(eval $(call git-external,llvm,LLVM,CMakeLists.txt,,$(SRCCACHE)))
 # LLVM's tarball contains symlinks to non-existent targets. This breaks the
 # the default msys strategy `deepcopy` symlink strategy. To workaround this,
 # switch to `native` which tries native windows symlinks (possible if the
@@ -14,7 +15,6 @@ LLVM_TAR_URL=https://api.github.com/repos/JuliaLang/llvm-project/tarball/$1
 # to succeed. We could guard this by a uname check, but it's harmless elsewhere,
 # so let's not incur the additional overhead.
 $(SRCCACHE)/$(LLVM_SRC_DIR)/source-extracted: export MSYS=winsymlinks:native
-$(eval $(call git-external,llvm,LLVM,CMakeLists.txt,,$(SRCCACHE)))
 
 LLVM_BUILDDIR := $(BUILDDIR)/$(LLVM_SRC_DIR)
 LLVM_BUILDDIR_withtype := $(LLVM_BUILDDIR)/build_$(LLVM_BUILDTYPE)


### PR DESCRIPTION
git-external changes the LLVM_SRC_DIR variable, so the target-specific variable applies to the wrong target if defined before it - didn't notice in local testing because I had accidentally switched the variable globally earlier for testing - but showed up on a fresh build.