### PR TITLE
feat(REPL): Added `active_module` context to numbered REPL

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1883,10 +1883,10 @@ end
 
 function set_prompt(repl::LineEditREPL, n::Ref{Int})
     julia_prompt = repl.interface.modes[1]
-    julia_prompt.prompt = function()
+    julia_prompt.prompt = REPL.contextual_prompt(repl, function()
         n[] = repl_eval_counter(julia_prompt.hist)+1
         string("In [", n[], "]: ")
-    end
+    end)
     nothing
 end
 


### PR DESCRIPTION
Previously in numbered REPL:
```julia 
In [1]: t = 6
6

In [2]: REPL.activate(REPL)

In [3]: r = 4
4
```
now
```julia 
In [1]: t = 6
6

In [2]: REPL.activate(REPL)

(REPL) In [3]: r = 4
4
```

This makes the module activation same at the standard module context prompt.

However, the `Out` global variable is not accessible in the module i.e.
```julia
(REPL) In [4]: Out[3]
ERROR: UndefVarError: `Out` not defined in `REPL`
Suggestion: check for spelling errors or missing imports.
Stacktrace:
 [1] top-level scope
   @ REPL[4]:1
 [2] top-level scope
   @ ~/Dev/julia/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:1840
```
It must be accessed from the `Main` module.
```julia
(REPL) In [5]: Main.Out[3]
4
```

This is an orthogonal issue though and perhaps is a nonissue.

What to consider: 
- Should the output prefix also be for the output?
- Should an error hint be registered for the `UndefVarError`?
