### PR TITLE
msys2: Recommend correct cmake package

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -431,9 +431,10 @@ export PKG_CONFIG_PATH = $(JULIAHOME)/usr/lib/pkgconfig
 export PKG_CONFIG_LIBDIR = $(JULIAHOME)/usr/lib/pkgconfig
 
 # Figure out OS and architecture
-BUILD_OS := $(shell uname)
+RAW_BUILD_OS = $(shell uname)
+BUILD_OS := $(RAW_BUILD_OS)
 
-ifneq (,$(findstring CYGWIN,$(BUILD_OS)))
+ifneq (,$(findstring CYGWIN,$(RAW_BUILD_OS)))
 XC_HOST ?= $(shell uname -m)-w64-mingw32
 endif
 

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -77,8 +77,8 @@ endif
 # Detect MSYS2 with cygwin CMake rather than MinGW cmake - the former fails to
 # properly drive MinGW tools
 ifneq (,$(findstring MINGW,$(RAW_BUILD_OS)))
-ifneq (,$(shell ldd $(shell which cmake) | grep msys))
-$(error CMake is Cygwin CMake, not MinGW CMake. Build will fail. Use `pacman -S mingw-w64-x86_64-cmake`.)
+ifneq (,$(shell ldd $(shell which cmake) | grep msys-2.0.dll))
+override CMAKE := echo "ERROR: CMake is Cygwin CMake, not MinGW CMake. Build will fail. Use 'pacman -S mingw-w64-{i686,x86_64}-cmake'."; exit 1; $(CMAKE)
 endif
 endif
 

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -38,6 +38,12 @@ CMAKE_CC := "$$(which $(shell echo $(CC_ARG) | cut -d' ' -f1))"
 CMAKE_CXX := "$$(which $(shell echo $(CXX_ARG) | cut -d' ' -f1))"
 CMAKE_CC_ARG := $(shell echo $(CC_ARG) | cut -s -d' ' -f2-)
 CMAKE_CXX_ARG := $(shell echo $(CXX_ARG) | cut -s -d' ' -f2-)
+else ifneq (,$(findstring MINGW,$(RAW_BUILD_OS)))
+# `cmake` is mingw-native and needs `cygpath -w`, rather than `cygpath -m`, which is the msys2 conversion default
+CMAKE_CC := "$(shell echo $(call cygpath_w, $(shell which $(CC_BASE))))"
+CMAKE_CXX := "$(shell echo $(call cygpath_w, $(shell which $(CXX_BASE))))"
+CMAKE_CC_ARG := $(CC_ARG)
+CMAKE_CXX_ARG := $(CXX_ARG)
 else
 CMAKE_CC := "$$(which $(CC_BASE))"
 CMAKE_CXX := "$$(which $(CXX_BASE))"
@@ -66,6 +72,14 @@ else ifeq ($(CMAKE_GENERATOR),make)
 CMAKE_GENERATOR_COMMAND := -G "Unix Makefiles"
 else
 $(error Unknown CMake generator '$(CMAKE_GENERATOR)'. Options are 'Ninja' and 'make')
+endif
+
+# Detect MSYS2 with cygwin CMake rather than MinGW cmake - the former fails to
+# properly drive MinGW tools
+ifneq (,$(findstring MINGW,$(RAW_BUILD_OS)))
+ifneq (,$(shell ldd $(shell which cmake) | grep msys))
+$(error CMake is Cygwin CMake, not MinGW CMake. Build will fail. Use `pacman -S mingw-w64-x86_64-cmake`.)
+endif
 endif
 
 # If the top-level Makefile is called with environment variables,

--- a/doc/src/devdocs/build/windows.md
+++ b/doc/src/devdocs/build/windows.md
@@ -141,19 +141,19 @@ Note: MSYS2 requires **64 bit** Windows 7 or newer.
     4. Then install tools required to build julia:
 
        ```
-       pacman -S cmake diffutils git m4 make patch tar p7zip curl python
+       pacman -S diffutils git m4 make patch tar p7zip curl python
        ```
 
        For 64 bit Julia, install the x86_64 version:
 
        ```
-       pacman -S mingw-w64-x86_64-gcc
+       pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake
        ```
 
        For 32 bit Julia, install the i686 version:
 
        ```
-       pacman -S mingw-w64-i686-gcc
+       pacman -S mingw-w64-i686-gcc mingw-w64-i686-cmake
        ```
 
     5. Configuration of MSYS2 is complete. Now `exit` the MSYS2 shell.


### PR DESCRIPTION
msys2 ships 2 different cmake packages, one built natively (with mingw prefix in the package name) and one built against the posix emulation environment. The posix emulation one does not work because it will detect unix-style paths, which it then writes into files that native tools process. Unlike during command invocation (where the msys2 runtime library does path translation), when paths are written to files, they are written verbatim.

The practical result of this is that e.g. the LLVM build will fail with a mysterious libz link failure (as e.g. reported in #54981).

This is our fault, because our built instructions tell the user to install the wrong one.

Fix all that by
1. Correcting the build instructions to install the correct cmake
2. Detecting if the wrong cmake is installed and advising the correct one
3. Fixing an issue where the native CMake did not like our CMAKE_C_COMPILER setting.

With all this, CMake runs correctly under msys2 with USE_BINARYBUILDER_LLVM=0.