### PR TITLE
Add OncePerDepot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,8 +35,10 @@ Multi-threading changes
 * New types are defined to handle the pattern of code that must run once per process, called
   a `OncePerProcess{T}` type, which allows defining a function that should be run exactly once
   the first time it is called, and then always return the same result value of type `T`
-  every subsequent time afterwards. There are also `OncePerThread{T}` and `OncePerTask{T}` types for
-  similar usage with threads or tasks. ([#TBD])
+  every subsequent time afterwards. There are also `OncePerThread{T}`, `OncePerTask{T}`, and
+  `OncePerDepot{T}` types for similar usage with threads, tasks, or depots respectively.
+  `OncePerDepot{T}` provides cross-process safety by storing results in the depot's `tokens`
+  directory and using `mkpidlock` for coordination. ([#TBD])
 
 Build system changes
 --------------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -110,6 +110,7 @@ export
     Pair,
     PartialQuickSort,
     OncePerProcess,
+    OncePerDepot,
     OncePerTask,
     OncePerThread,
     PermutedDimsArray,

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -988,9 +988,9 @@ end
     OncePerDepot{T}(init::Function, token_name::AbstractString) -> OncePerDepot{T}
 
 Calling a `OncePerDepot` object returns a value of type `T` by running the function
-`initializer` exactly once per depot. All concurrent and future calls within the same
-depot will return exactly the same value. This uses a file-based locking mechanism
-with pidfiles to ensure safety across processes.
+`initializer` exactly once per depot. The value is written into a token file in the depot. All
+concurrent and future calls within the same depot will read this file to return the same
+value. This uses a file-based locking mechanism with pidfiles to ensure safety across processes.
 
 The depot is determined by the first entry in `DEPOT_PATH` that exists and is writable.
 Token files are stored in `depot/tokens/` and use `mkpidlock` to ensure atomic initialization

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -607,6 +607,30 @@ end
         @test x == [1, 2, 3, 4]
     end
 
+    # Test with Nothing (special case for orchestrating initialization)
+    let counter = Ref(0)
+        once = OncePerDepot{Nothing}("test_nothing") do
+            counter[] += 1
+            return nothing
+        end
+        @test typeof(once) <: OncePerDepot{Nothing}
+        @test once() === nothing
+        @test once() === nothing  # Should not run again
+        @test counter[] == 1  # Should have run only once
+    end
+
+    # Test with Nothing using inferred type constructor
+    let counter = Ref(0)
+        once = OncePerDepot("test_nothing_inferred") do
+            counter[] += 1
+            return nothing
+        end
+        @test typeof(once) <: OncePerDepot{Nothing}
+        @test once() === nothing
+        @test once() === nothing  # Should not run again
+        @test counter[] == 1  # Should have run only once
+    end
+
     # Test error handling
     let once = OncePerDepot{String}("test_error") do
             error("expected error")
@@ -621,7 +645,7 @@ end
     if depot_path !== nothing
         tokens_dir = joinpath(depot_path, "tokens")
         if isdir(tokens_dir)
-            for file in ["test_string", "test_bytes", "test_error"]
+            for file in ["test_string", "test_bytes", "test_nothing", "test_nothing_inferred", "test_error"]
                 value_file = joinpath(tokens_dir, file * ".value")
                 lock_file = joinpath(tokens_dir, file)
                 isfile(value_file) && rm(value_file, force=true)


### PR DESCRIPTION
Like OncePerProcess etc. but once for a given depot, across all processes via a pidfile lock.

A welcome message example:
```julia
% ./julia -q
julia> const welcome_message = Base.OncePerDepot{Nothing}("welcome_message") do
          println("Welcome to X! To do Y use Z...")
          return nothing
       end;

julia> welcome_message()
Welcome to X! To do Y use Z...

julia> welcome_message()

shell> ls ~/.julia/tokens
welcome_message.value
```
```julia
% ./julia -q
julia> const welcome_message = Base.OncePerDepot{Nothing}("welcome_message") do
          println("Welcome to X! To do Y use Z...")
          return nothing
       end;

julia> welcome_message()

julia>

```

Developed with Claude.