### PR TITLE
Roll up msys2/clang/windows build fixes

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1580,7 +1580,9 @@ ifeq ($(OS), WINNT)
 HAVE_SSP := 1
 OSLIBS += -Wl,--export-all-symbols -Wl,--version-script=$(BUILDROOT)/src/julia.expmap \
 	$(NO_WHOLE_ARCHIVE) -lpsapi -lkernel32 -lws2_32 -liphlpapi -lwinmm -ldbghelp -luserenv -lsecur32 -latomic -lole32
-JLDFLAGS += -Wl,--stack,8388608 --disable-auto-import --disable-runtime-pseudo-reloc
+# N.B.: Unlike in the sysimage, we cannot -Wl,--disable-auto-import -Wl,--disable-runtime-pseudo-reloc here, because libstdc++/LLVM are not fully correct under
+# enforced visibility at this point.
+JLDFLAGS += -Wl,--stack,8388608
 ifeq ($(ARCH),i686)
 JLDFLAGS += -Wl,--large-address-aware
 endif

--- a/base/linking.jl
+++ b/base/linking.jl
@@ -140,7 +140,15 @@ function link_image_cmd(path, out)
     LIBS = isdebugbuild() ? ("-ljulia-debug", "-ljulia-internal-debug") :
                         ("-ljulia", "-ljulia-internal")
     @static if Sys.iswindows()
-        LIBS = (LIBS..., "-lopenlibm", "-lssp", "-lgcc_s", "-lgcc", "-lmsvcrt")
+        LIBS = (LIBS..., "-lopenlibm", "-lgcc_s", "-lgcc", "-lmsvcrt")
+        if isdebugbuild()
+            LIBS = (LIBS..., "-lssp")
+            if isfile(joinpath(private_libdir(), "libmingwex.a"))
+                # In MinGW 11, the ssp implementation was moved from libssp to
+                # libmingwex with ssp only being a stub. See #59020.
+                LIBS = (LIBS..., "-lmingwex", "-lkernel32")
+            end
+        end
     end
 
     V = verbose_linking() ? "--verbose" : ""

--- a/cli/loader.h
+++ b/cli/loader.h
@@ -36,9 +36,9 @@
 // Borrow definition from `support/dtypes.h`
 #ifdef _OS_WINDOWS_
 # ifdef JL_LIBRARY_EXPORTS
-#  define JL_DLLEXPORT __declspec(dllexport)
+#  define JL_DLLEXPORT __declspec(dllexport) __attribute__ ((visibility("default")))
 # endif
-#  define JL_DLLIMPORT __declspec(dllimport)
+#  define JL_DLLIMPORT __declspec(dllimport) __attribute__ ((visibility("default")))
 #define JL_HIDDEN
 #else
 # define JL_DLLIMPORT __attribute__ ((visibility("default")))

--- a/cli/loader_win_utils.c
+++ b/cli/loader_win_utils.c
@@ -12,6 +12,10 @@ static FILE _stderr = { INVALID_HANDLE_VALUE };
 FILE *stdout = &_stdout;
 FILE *stderr = &_stderr;
 
+void JL_HIDDEN free(void* mem) {
+    HeapFree(GetProcessHeap(), 0, mem);
+}
+
 int JL_HIDDEN fwrite(const char *str, size_t nchars, FILE *out) {
     DWORD written;
     if (out->isconsole) {
@@ -42,10 +46,6 @@ void JL_HIDDEN *malloc(const size_t size) {
 
 void JL_HIDDEN *realloc(void * mem, const size_t size) {
     return HeapReAlloc(GetProcessHeap(), HEAP_GENERATE_EXCEPTIONS, mem, size);
-}
-
-void JL_HIDDEN free(void* mem) {
-    HeapFree(GetProcessHeap(), 0, mem);
 }
 
 LPWSTR *CommandLineToArgv(LPWSTR lpCmdLine, int *pNumArgs) {

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -42,9 +42,10 @@ ifeq ($(USE_SYSTEM_LIBBLASTRAMPOLINE), 0)
 DEP_LIBS += blastrampoline
 endif
 
-ifeq ($(USE_SYSTEM_CSL), 0)
+# We need to run this whether or not USE_SYSTEM_CSL is set.
+# If it is, this target copies the system CSLs into the location our
+# build system expects.
 DEP_LIBS += csl
-endif
 
 ifeq ($(SANITIZE), 1)
 DEP_LIBS += sanitizers

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -292,6 +292,12 @@ $(LLVM_BUILDDIR_withtype)/build-configured: $(SRCCACHE)/$(LLVM_SRC_DIR)/source-e
 	echo 1 > $@
 
 $(LLVM_BUILDDIR_withtype)/build-compiled: $(LLVM_BUILDDIR_withtype)/build-configured
+ifeq ($(OS),WINNT)
+ifeq ($(USEGCC),1)
+	echo "LLVM source build is currently known to fail using GCC due to exceeded export table limits. Try clang."
+	exit 1
+endif
+endif
 	cd $(LLVM_BUILDDIR_withtype) && \
 		$(if $(filter $(CMAKE_GENERATOR),make), \
 		  $(MAKE), \

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -312,8 +312,8 @@ endif
 	echo 1 > $@
 
 LLVM_INSTALL = \
-	cd $1 && mkdir -p $2$$(build_depsbindir) && \
-	cp -r $$(SRCCACHE)/$$(LLVM_SRC_DIR)/llvm/utils/lit $2$$(build_depsbindir)/ && \
+	cd $1 && mkdir -p $2$$(build_depsbindir)/lit && \
+	cp -r $$(SRCCACHE)/$$(LLVM_SRC_DIR)/llvm/utils/lit/{*.py,*.toml,lit/} $2$$(build_depsbindir)/lit/ && \
 	$$(CMAKE) -DCMAKE_INSTALL_PREFIX="$2$$(build_prefix)" -P cmake_install.cmake
 ifeq ($(OS), WINNT)
 LLVM_INSTALL += && cp $2$$(build_shlibdir)/$(LLVM_SHARED_LIB_NAME).dll $2$$(build_depsbindir)

--- a/deps/p7zip.mk
+++ b/deps/p7zip.mk
@@ -19,7 +19,7 @@ checksum-p7zip: $(SRCCACHE)/p7zip-$(P7ZIP_VER).tar.gz
 
 $(BUILDDIR)/p7zip-$(P7ZIP_VER)/build-configured: $(BUILDDIR)/p7zip-$(P7ZIP_VER)/source-extracted
 $(BUILDDIR)/p7zip-$(P7ZIP_VER)/build-compiled: $(BUILDDIR)/p7zip-$(P7ZIP_VER)/build-configured
-	$(MAKE) -C $(dir $<) $(MAKE_COMMON) $(P7ZIP_BUILD_OPTS) 7za$(EXE)
+	$(MAKE) -C $(dir $<) $(MAKE_COMMON) $(P7ZIP_BUILD_OPTS) 7za
 	echo 1 > $@
 
 define P7ZIP_INSTALL

--- a/deps/zstd.mk
+++ b/deps/zstd.mk
@@ -3,6 +3,8 @@ ifneq ($(USE_BINARYBUILDER_ZSTD), 1)
 ZSTD_GIT_URL := https://github.com/facebook/zstd.git
 ZSTD_TAR_URL = https://api.github.com/repos/facebook/zstd/tarball/$1
 $(eval $(call git-external,zstd,ZSTD,,,$(BUILDDIR)))
+# See note in llvm.mk for source tarballs with symlinks to non-existent targets
+$(BUILDDIR)/$(ZSTD_SRC_DIR)/source-extracted: export MSYS=winsymlinks:native
 
 ZSTD_BUILD_OPTS := MOREFLAGS="-DZSTD_MULTITHREAD $(fPIC)" bindir=$(build_private_libexecdir)
 

--- a/doc/src/devdocs/build/windows.md
+++ b/doc/src/devdocs/build/windows.md
@@ -147,13 +147,13 @@ Note: MSYS2 requires **64 bit** Windows 7 or newer.
        For 64 bit Julia, install the x86_64 version:
 
        ```
-       pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake
+       pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-clang
        ```
 
        For 32 bit Julia, install the i686 version:
 
        ```
-       pacman -S mingw-w64-i686-gcc mingw-w64-i686-cmake
+       pacman -S mingw-w64-i686-gcc mingw-w64-i686-cmake mingw-w64-i686-clang
        ```
 
     5. Configuration of MSYS2 is complete. Now `exit` the MSYS2 shell.
@@ -171,7 +171,15 @@ Note: MSYS2 requires **64 bit** Windows 7 or newer.
        cd julia
        ```
 
-    3. Start the build
+    3. If you want to use clang (currently required if building LLVM from source), put the following in your Make.user
+      ```
+      CC=/mingw64/bin/clang
+      CXX=/mingw64/bin/clang++
+      ```
+!!! warning "UCRT Unsupported"
+   Do not try to use any other clang that MSYS2 may install (which may not have the correct default target) or the "Clang" environment(which defaults to the currently unsupported ucrt).
+
+    4. Start the build
 
        ```
        make -j$(nproc)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -239,13 +239,13 @@ extern void __stack_chk_fail();
 
 #ifdef _OS_WINDOWS_
 #if defined(_CPU_X86_64_)
-#if defined(_COMPILER_GCC_)
+#if defined(__MINGW32__)
 extern void ___chkstk_ms(void);
 #else
 extern void __chkstk(void);
 #endif
 #else
-#if defined(_COMPILER_GCC_)
+#if defined(__MINGW32__)
 #undef _alloca
 extern void _alloca(void);
 #else
@@ -10050,13 +10050,13 @@ static void init_jit_functions(void)
 #ifdef _OS_WINDOWS_
 #if defined(_CPU_X86_64_)
     add_named_global("__julia_personality", &__julia_personality);
-#if defined(_COMPILER_GCC_)
+#if defined(__MINGW32__)
     add_named_global("___chkstk_ms", &___chkstk_ms);
 #else
     add_named_global("__chkstk", &__chkstk);
 #endif
 #else
-#if defined(_COMPILER_GCC_)
+#if defined(__MINGW32__)
     add_named_global("_alloca", &_alloca);
 #else
     add_named_global("_chkstk", &_chkstk);

--- a/src/gf.c
+++ b/src/gf.c
@@ -3355,19 +3355,19 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
     return codeinst;
 }
 
-JL_DLLEXPORT jl_value_t *jl_fptr_const_return(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *m)
+jl_value_t *jl_fptr_const_return(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *m)
 {
     return m->rettype_const;
 }
 
-JL_DLLEXPORT jl_value_t *jl_fptr_args(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *m)
+jl_value_t *jl_fptr_args(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *m)
 {
     jl_fptr_args_t invoke = jl_atomic_load_relaxed(&m->specptr.fptr1);
     assert(invoke && "Forgot to set specptr for jl_fptr_args!");
     return invoke(f, args, nargs);
 }
 
-JL_DLLEXPORT jl_value_t *jl_fptr_sparam(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *m)
+jl_value_t *jl_fptr_sparam(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *m)
 {
     jl_svec_t *sparams = jl_get_ci_mi(m)->sparam_vals;
     assert(sparams != jl_emptysvec);

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -8,6 +8,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+// Needs to come before windows platform headers
+#include "support/dtypes.h"
+
 #ifdef _OS_WINDOWS_
 #include <ws2tcpip.h>
 #include <malloc.h>

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -182,7 +182,16 @@ JL_DLLIMPORT void __tsan_switch_to_fiber(void *fiber, unsigned flags);
 #endif
 #endif
 
+#if defined(HAVE_SSP) && defined(_OS_DARWIN_)
+// On Darwin, this is provided by libSystem and imported
+extern JL_DLLIMPORT uintptr_t __stack_chk_guard;
+#elif defined(HAVE_SSP)
+// Added by compiler runtime in final link - not DLLIMPORT
+extern uintptr_t __stack_chk_guard;
+#else
+// The system doesn't have it - we define our own
 extern JL_DLLEXPORT uintptr_t __stack_chk_guard;
+#endif
 
 // If this is detected in a backtrace of segfault, it means the functions
 // that use this value must be reworked into their async form with cb arg

--- a/src/module.c
+++ b/src/module.c
@@ -1597,7 +1597,7 @@ JL_DLLEXPORT void jl_set_global(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *va
     jl_checked_assignment(bp, m, var, val);
 }
 
-JL_DLLEXPORT void jl_set_initial_const(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT, int exported)
+void jl_set_initial_const(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT, int exported)
 {
     // this function is only valid during initialization, so there is no risk of data races her are not too important to use
     int kind = PARTITION_KIND_CONST | (exported ? PARTITION_FLAG_EXPORTED : 0);

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -25,6 +25,9 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #define WIN32_LEAN_AND_MEAN
+/* Clang does not like fvisibility=hidden with windows headers. This adds the visibility attribute there.
+   Arguably this is a clang bug. */
+#define DECLSPEC_IMPORT __declspec(dllimport) __attribute__ ((visibility("default")))
 #include <windows.h>
 
 #if defined(_COMPILER_MICROSOFT_) && !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)
@@ -36,21 +39,6 @@ typedef intptr_t ssize_t;
 #define _SSIZE_T_DEFINED
 
 #endif /* defined(_COMPILER_MICROSOFT_) && !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED) */
-
-#if !defined(_COMPILER_GCC_)
-
-#define strtoull                                            _strtoui64
-#define strtoll                                             _strtoi64
-#define strcasecmp                                          _stricmp
-#define strncasecmp                                         _strnicmp
-#define snprintf                                            _snprintf
-#define stat                                                _stat
-
-#define STDIN_FILENO                                        0
-#define STDOUT_FILENO                                       1
-#define STDERR_FILENO                                       2
-
-#endif /* !_COMPILER_GCC_ */
 
 #endif /* _OS_WINDOWS_ */
 
@@ -73,13 +61,13 @@ typedef intptr_t ssize_t;
 #ifdef _OS_WINDOWS_
 #define STDCALL  __stdcall
 # ifdef JL_LIBRARY_EXPORTS_INTERNAL
-#  define JL_DLLEXPORT __declspec(dllexport)
+#  define JL_DLLEXPORT __declspec(dllexport) __attribute__ ((visibility("default")))
 # endif
 # ifdef JL_LIBRARY_EXPORTS_CODEGEN
-#  define JL_DLLEXPORT_CODEGEN __declspec(dllexport)
+#  define JL_DLLEXPORT_CODEGEN __declspec(dllexport) __attribute__ ((visibility("default")))
 # endif
 #define JL_HIDDEN
-#define JL_DLLIMPORT   __declspec(dllimport)
+#define JL_DLLIMPORT   __declspec(dllimport) __attribute__ ((visibility("default")))
 #else
 #define STDCALL
 #define JL_DLLIMPORT __attribute__ ((visibility("default")))
@@ -123,11 +111,7 @@ typedef intptr_t ssize_t;
 #define STATIC_INLINE static inline
 #define FORCE_INLINE static inline __attribute__((always_inline))
 
-#ifdef _OS_WINDOWS_
-#define EXTERN_INLINE_DECLARE inline
-#else
 #define EXTERN_INLINE_DECLARE inline __attribute__ ((visibility("default")))
-#endif
 #define EXTERN_INLINE_DEFINE extern inline JL_DLLEXPORT
 
 #if defined(_OS_WINDOWS_) && !defined(_COMPILER_GCC_)

--- a/sysimage.mk
+++ b/sysimage.mk
@@ -18,7 +18,7 @@ $(build_private_libdir)/%.$(SHLIB_EXT): $(build_private_libdir)/%-o.a
 	@$(call PRINT_LINK, $(CXX) $(LDFLAGS) -shared $(fPIC) -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -o $@ \
 		$(WHOLE_ARCHIVE) $< $(NO_WHOLE_ARCHIVE) \
 		$(if $(findstring -debug,$(notdir $@)),-ljulia-internal-debug -ljulia-debug,-ljulia-internal -ljulia) \
-		$$([ $(OS) = WINNT ] && echo '' $(LIBM) -lssp --disable-auto-import --disable-runtime-pseudo-reloc))
+		$$([ $(OS) = WINNT ] && echo '' $(LIBM) -lssp -Wl,--disable-auto-import -Wl,--disable-runtime-pseudo-reloc))
 	@$(INSTALL_NAME_CMD)$(notdir $@) $@
 	@$(DSYMUTIL) $@
 


### PR DESCRIPTION
This rolls up everything I had to change to get a successful source build of Julia under msys2. It's a misc collection of msys2, clang and other fixes. With this, I can use the following Make.user:

```
USE_SYSTEM_CSL=1
USE_BINARYBUILDER_LLVM=0
CC=clang
CXX=clang++
FC=gfortran
```

The default USE_SYSTEM_CSL is broken due to #56840 With USE_SYSTEM_CSL=1, LLVM is broken due to #57021 Clang is required because gcc can't do an LLVM source build due to known export symbol size limits (ref JuliaPackaging/Yggdrasil#11652).

That said, if we address the ABI issues in #56840, the default Make.user should build again (with BB-provided LLVM).