### PR TITLE
Improve --trace-dispatch coverage: emit in "full-cache" fast path as well.

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -3107,6 +3107,19 @@ static void record_dispatch_statement(jl_method_instance_t *mi)
     JL_UNLOCK(&dispatch_statement_out_lock);
 }
 
+static void record_dispatch_statement_on_first_dispatch(jl_method_instance_t *mfunc) {
+    uint8_t force_trace_dispatch = jl_atomic_load_relaxed(&jl_force_trace_dispatch_enabled);
+    if (force_trace_dispatch || jl_options.trace_dispatch != NULL) {
+        uint8_t miflags = jl_atomic_load_relaxed(&mfunc->flags);
+        uint8_t was_dispatched = miflags & JL_MI_FLAGS_MASK_DISPATCHED;
+        if (!was_dispatched) {
+            miflags |= JL_MI_FLAGS_MASK_DISPATCHED;
+            jl_atomic_store_relaxed(&mfunc->flags, miflags);
+            record_dispatch_statement(mfunc);
+        }
+    }
+}
+
 // If waitcompile is 0, this will return NULL if compiling is on-going in the JIT. This is
 // useful for the JIT itself, since it just doesn't cause redundant work or missed updates,
 // but merely causes it to look into the current JIT worklist.
@@ -3866,8 +3879,6 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
     nargs++; // add F to argument count
     jl_value_t *FT = jl_typeof(F);
 
-    bool_t took_slow_path = 0;  // For --trace-dispatch logging
-
     /*
       search order:
       check associative hash based on callsite address for leafsig match
@@ -3914,7 +3925,6 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
     if (i == 4) {
         // if no method was found in the associative cache, check the full cache
         JL_TIMING(METHOD_LOOKUP_FAST, METHOD_LOOKUP_FAST);
-        took_slow_path = 1;
         jl_methcache_t *mc = jl_method_table->cache;
         jl_genericmemory_t *leafcache = jl_atomic_load_relaxed(&mc->leafcache);
         entry = NULL;
@@ -3945,6 +3955,11 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
             jl_atomic_store_relaxed(&pick_which[cache_idx[0]], which);
             jl_atomic_store_release(&call_cache[cache_idx[which & 3]], entry);
         }
+        if (entry) {
+            // mfunc was found in slow path, so log --trace-dispatch
+            jl_method_instance_t *mfunc = entry->func.linfo;
+            record_dispatch_statement_on_first_dispatch(mfunc);
+        }
     }
 
     jl_method_instance_t *mfunc;
@@ -3954,7 +3969,6 @@ have_entry:
     }
     else {
         assert(tt);
-        took_slow_path = 1;
         // cache miss case
         jl_methcache_t *mc = jl_method_table->cache;
         mfunc = jl_mt_assoc_by_type(mc, tt, world);
@@ -3968,26 +3982,14 @@ have_entry:
             jl_method_error(F, args, nargs, world);
             // unreachable
         }
+        // mfunc was found in slow path, so log --trace-dispatch
+        record_dispatch_statement_on_first_dispatch(mfunc);
     }
 
 #ifdef JL_TRACE
     if (traceen)
         jl_printf(JL_STDOUT, " at %s:%d\n", jl_symbol_name(mfunc->def.method->file), mfunc->def.method->line);
 #endif
-
-    // mfunc is about to be dispatched - log --trace-dispatch
-    if (__unlikely(took_slow_path)) {
-        uint8_t force_trace_dispatch = jl_atomic_load_relaxed(&jl_force_trace_dispatch_enabled);
-        if (force_trace_dispatch || jl_options.trace_dispatch != NULL) {
-            uint8_t miflags = jl_atomic_load_relaxed(&mfunc->flags);
-            uint8_t was_dispatched = miflags & JL_MI_FLAGS_MASK_DISPATCHED;
-            if (!was_dispatched) {
-                miflags |= JL_MI_FLAGS_MASK_DISPATCHED;
-                jl_atomic_store_relaxed(&mfunc->flags, miflags);
-                record_dispatch_statement(mfunc);
-            }
-        }
-    }
 
     return mfunc;
 }

--- a/src/gf.c
+++ b/src/gf.c
@@ -3096,7 +3096,7 @@ static void record_dispatch_statement(jl_method_instance_t *mi)
             s_dispatch = (JL_STREAM*) &f_dispatch;
         }
     }
-    // NOTE: Sometimes the specType is just `Tuple`, which is not useful to print.
+    // NOTE: For builtin functions, the specType is just `Tuple`, which is not useful to print.
     if (!jl_has_free_typevars(mi->specTypes) && (jl_datatype_t*)mi->specTypes != jl_tuple_type) {
         jl_printf(s_dispatch, "precompile(");
         jl_static_show(s_dispatch, mi->specTypes);


### PR DESCRIPTION
This PR moves the `--trace-dispatch` logging inside `jl_lookup_generic_` from only the `cache miss case` to also logging it inside the `no method was found in the associative cache, check the full cache` case.

This PR contains two possible commits. I'm happy with either one. I _think_ the second one *might* be faster in the fast-path case since it gets to skip a branch in the common case? But it also might be worse since i think it's more code duplication if that function is inlined? I'm not sure.

In the first commit, we do that by setting `took_slow_path = 1` in both cases, and then logging right before returning if the result was found.

In the second commit, I removed that boolean, and just explicitly do the logging call inside each of the two slow-path cases.
