### PR TITLE
Don't inline callees if they might require `_compute_sparams`

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -396,7 +396,7 @@ function inline_cost_model(interp::AbstractInterpreter, result::InferenceResult,
                 cost_threshold += 4*default
             end
         end
-        return inline_cost_model(ir, params, cost_threshold)
+        return inline_cost_model(mi, ir, params, cost_threshold)
     end
 end
 

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -2342,4 +2342,11 @@ let src = code_typed1(callcall_f58996, (Any,))
     @test count(isinvoke(Returns(true)), src.code) == 0
 end
 
+f59013_using_sparams(::T) where {T} = T
+f59013(x) = f59013_using_sparams(x)
+let src = code_typed1(f59013, (Any,))
+    @test length(src.code) == 2
+    @test iscall((src, f59013_using_sparams), src.code[1])
+end
+
 end # module inline_tests


### PR DESCRIPTION
Fixes #58915. See #58996 for an initial workaround to that issue.

This PR prevents inlining callees that use static parameters in a way that results in the insertion of a `_compute_sparams` call that may survive post-inlining optimizations, because that built-in is quite expensive. The implementation in this PR is quite conservative, because post-inlining optimizations may remove `_compute_sparams`, therefore I'm not sure this is the right approach (one way might be via DCA on the inlined body if the returned value is unused and the static parameter was used to compute that return value). However, a more robust approach would most likely require to inline, optimize then de-inline if `_compute_sparams` survives, which seems like it would add quite a lot of complexity.

EDIT: a more recent PR #59018 also addresses the original issue with a different approach, which might be a more robust fix and easier to get in.