### PR TITLE
binaryplatforms: Add abi tags for ucrt/cxxlib

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -999,6 +999,13 @@ BUILD_MACHINE := $(shell $(HOSTCC) -dumpmachine)
 # don't recognize that, so canonicalize to mingw32
 BUILD_MACHINE := $(subst windows-gnu,mingw32,$(BUILD_MACHINE))
 
+# Detect a request for ucrt libc
+ifeq (,$(findstring MINGW,$(RAW_BUILD_OS)))
+ifeq (UCRT64,$(MSYSTEM))
+BUILD_MACHINE := $(subst mingw32,ucrt-mingw32,$(BUILD_MACHINE))
+endif
+endif
+
 ifeq ($(ARCH),)
 override ARCH := $(shell $(CC) -dumpmachine | sed "s/\([^-]*\).*$$/\1/")
 else

--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -26,7 +26,8 @@ system, libc implementation, etc...  It is, at its heart, a key-value mapping of
 `"os" => "windows"`, etc...).  `Platform` objects are extensible in that the tag mapping
 is open for users to add their own mappings to, as long as the mappings do not conflict
 with the set of reserved tags: `arch`, `os`, `os_version`, `libc`, `call_abi`,
-`libgfortran_version`, `libstdcxx_version`, `cxxstring_abi` and `julia_version`.
+`libgfortran_version`, `libstdcxx_version`, `cxxlib`, `cxxlib_version`,
+`cxxstring_abi` and `julia_version`.
 
 Valid tags and values are composed of alphanumeric and period characters.  All tags and
 values will be lowercased when stored to reduce variation.
@@ -64,11 +65,22 @@ struct Platform <: AbstractPlatform
                 continue
             end
 
+            # For compatibility, libstdcxx_version counts as both cxxlib=libstdcxx and
+            # cxxlib_version, but don't override an explicit existing cxxlib tag (the
+            # verifier will check for inconsistencies).
+            if tag == "libstdcxx_version"
+                haskey(tags, "cxxlib") || add_tag!(tags, "cxxlib", "libstdcxx")
+                tag = "cxxlib_version"
+            elseif tag == "cxxstring_abi"
+                # Implies cxxlib=libstdcxx for compatibility
+                haskey(tags, "cxxlib") || add_tag!(tags, "cxxlib", "libstdcxx")
+            end
+
             # Normalize things that are known to be version numbers so that comparisons are easy.
             # Note that in our effort to be extremely compatible, we actually allow something that
             # doesn't parse nicely into a VersionNumber to persist, but if `validate_strict` is
             # set to `true`, it will cause an error later on.
-            if tag ∈ ("libgfortran_version", "libstdcxx_version", "os_version")
+            if tag ∈ ("libgfortran_version", "cxxlib_version", "os_version")
                 if isa(value, VersionNumber)
                     value = string(value)
                 elseif isa(value, String)
@@ -87,6 +99,10 @@ struct Platform <: AbstractPlatform
         if os == "linux" && !haskey(tags, "libc")
             # Default to `glibc` on Linux
             tags["libc"] = "glibc"
+        end
+        if os == "windows" && !haskey(tags, "libc")
+            # Default to `msvcrt` on Windows
+            tags["libc"] = "msvcrt"
         end
         if os == "linux" && arch ∈ ("armv7l", "armv6l") && "call_abi" ∉ keys(tags)
             # default `call_abi` to `eabihf` on 32-bit ARM
@@ -217,6 +233,10 @@ function validate_tags(tags::Dict)
         if tags["libc"] ∉ ("glibc", "musl")
             throw_libc_mismatch()
         end
+    elseif tags["os"] == "windows"
+        if tags["libc"] ∉ ("msvcrt", "ucrt")
+            throw_libc_mismatch()
+        end
     else
         # Nothing else is allowed to have a `libc` entry
         if haskey(tags, "libc")
@@ -244,14 +264,19 @@ function validate_tags(tags::Dict)
         throw_version_number("libgfortran_version")
     end
 
-    # Validate `cxxstring_abi` is one of the two valid options:
-    if "cxxstring_abi" in keys(tags) && tags["cxxstring_abi"] ∉ ("cxx03", "cxx11")
+    # Validate `cxxlib` is one of the valid options.
+    if haskey(tags, "cxxlib") && tags["cxxlib"] ∉ ("libstdcxx", "libcxx")
+        throw_invalid_key("cxxlib")
+    end
+
+    # Validate `cxxstring_abi` is one of the two valid options and only used with libstdc++.
+    if haskey(tags, "cxxstring_abi") && (tags["cxxstring_abi"] ∉ ("cxx03", "cxx11") || !haskey(tags, "cxxlib") || tags["cxxlib"] != "libstdcxx")
         throw_invalid_key("cxxstring_abi")
     end
 
-    # Validate `libstdcxx_version` is a parsable `VersionNumber`
-    if "libstdcxx_version" in keys(tags) && tryparse(VersionNumber, tags["libstdcxx_version"]) === nothing
-        throw_version_number("libstdcxx_version")
+    # Validate `cxxlib_version` is a parsable `VersionNumber`
+    if haskey(tags, "cxxlib_version") && tryparse(VersionNumber, tags["cxxlib_version"]) === nothing
+        throw_version_number("cxxlib_version")
     end
 end
 
@@ -331,8 +356,8 @@ function HostPlatform(p::AbstractPlatform)
     if haskey(p, "os_version")
         set_compare_strategy!(p, "os_version", compare_version_cap)
     end
-    if haskey(p, "libstdcxx_version")
-        set_compare_strategy!(p, "libstdcxx_version", compare_version_cap)
+    if haskey(p, "cxxlib") && p["cxxlib"] == "libstdcxx" && haskey(p, "cxxlib_version")
+        set_compare_strategy!(p, "cxxlib_version", compare_version_cap)
     end
     return p
 end
@@ -399,6 +424,7 @@ julia> libc(Platform("aarch64", "linux"; libc="musl"))
 "musl"
 
 julia> libc(Platform("i686", "Windows"))
+"msvcrt"
 ```
 """
 libc(p::AbstractPlatform) = get(tags(p), "libc", nothing)
@@ -457,9 +483,19 @@ libgfortran_version(p::AbstractPlatform) = VNorNothing(tags(p), "libgfortran_ver
     libstdcxx_version(p::AbstractPlatform)
 
 Get the libstdc++ version dictated by this `Platform` object, or `nothing` if no
-compatibility bound is imposed.
+compatibility bound is imposed.  This is a compatibility accessor for
+`cxxlib = "libstdcxx"` platforms with a `cxxlib_version`.
 """
-libstdcxx_version(p::AbstractPlatform) = VNorNothing(tags(p), "libstdcxx_version")
+function libstdcxx_version(p::AbstractPlatform)
+    platform_tags = tags(p)
+    if haskey(platform_tags, "libstdcxx_version")
+        return VNorNothing(platform_tags, "libstdcxx_version")
+    end
+    if get(platform_tags, "cxxlib", nothing) == "libstdcxx"
+        return VNorNothing(platform_tags, "cxxlib_version")
+    end
+    return nothing
+end
 
 """
     cxxstring_abi(p::AbstractPlatform)
@@ -538,6 +574,14 @@ function triplet(p::AbstractPlatform)
         if tag ∈ ("os", "arch", "libc", "call_abi", "libgfortran_version", "libstdcxx_version", "cxxstring_abi", "os_version")
             continue
         end
+        if tag == "cxxlib" && val == "libstdcxx" && (cxxstring_abi_ !== nothing || libstdcxx_version_ !== nothing)
+            # Implied by above
+            continue
+        end
+        if tag == "cxxlib_version" && get(tags(p), "cxxlib", nothing) == "libstdcxx"
+            # Emitted as a libstdcxx compatibility tag above
+            continue
+        end
         str = string(str, "-", tag, "+", val)
     end
     return str
@@ -554,7 +598,7 @@ function os_str(p::AbstractPlatform)
             return "-apple-darwin"
         end
     elseif os(p) == "windows"
-        return "-w64-mingw32"
+        return "-w64"
     elseif os(p) == "freebsd"
         osvn = os_version(p)
         if osvn !== nothing
@@ -576,6 +620,10 @@ function libc_str(p::AbstractPlatform)
         return ""
     elseif lc === "glibc"
         return "-gnu"
+    elseif lc === "msvcrt"
+        return "-mingw32"
+    elseif lc === "ucrt"
+        return "-ucrt-mingw32"
     else
         return string("-", lc)
     end
@@ -636,11 +684,13 @@ const os_mapping = Dict(
     "macos" => "-apple-darwin[\\d\\.]*",
     "freebsd" => "-(.*-)?freebsd[\\d\\.]*",
     "openbsd" => "-(.*-)?openbsd[\\d\\.]*",
-    "windows" => "-w64-mingw32",
+    "windows" => "-w64",
     "linux" => "-(.*-)?linux",
 )
 const libc_mapping = Dict(
     "libc_nothing" => "",
+    "ucrt"  => "-ucrt-mingw32",
+    "msvcrt" => "-mingw32", # We default to msvcrt for plain -mingw32 on Windows
     "glibc" => "-gnu",
     "musl" => "-musl",
 )

--- a/contrib/normalize_triplet.py
+++ b/contrib/normalize_triplet.py
@@ -21,13 +21,15 @@ platform_mapping = {
     'darwin': "-apple-darwin[\\d\\.]*",
     'freebsd': "-(.*-)?freebsd[\\d\\.]*",
     'openbsd': "-(.*-)?openbsd[\\d\\.]*",
-    'windows': "-w64-mingw32",
+    'windows': "-w64",
     'linux': "-(.*-)?linux",
 }
 libc_mapping = {
     'blank_libc': "",
     'gnu': "-gnu",
     'musl': "-musl",
+    'msvcrt': "-mingw32",
+    'ucrt': "-ucrt-mingw32",
 }
 call_abi_mapping = {
     'blank_call_abi': "",
@@ -88,7 +90,10 @@ def r(x):
     x = x.replace("blank_call_abi", "")
     x = x.replace("blank_libgfortran", "")
     x = x.replace("blank_cxx_abi", "")
-    x = x.replace("blank_libc", "")
+    # We combine platform and libc below, since the windows mapping
+    # needs to know the platform for the correct default libc, so
+    # replace this one with `-` included.
+    x = x.replace("-blank_libc", "")
     return x
 
 def p(x):
@@ -96,6 +101,8 @@ def p(x):
     # capture group names, unfortunately:
     os_remapping = {
         'darwin': 'apple-darwin',
+        'windows-msvcrt': 'w64-mingw32',
+        'windows-ucrt': 'w64-ucrt-mingw32',
         'windows': 'w64-mingw32',
         'freebsd': 'unknown-freebsd',
         'openbsd': 'unknown-openbsd',
@@ -141,7 +148,7 @@ if cxx_abi == "blank_cxx_abi":
             "": "",
         }[sys.argv[3]]
 
-print(arch+p(platform)+p(libc)+r(call_abi)+p(libgfortran_version)+p(cxx_abi))
+print(arch+p(platform+"-"+libc)+r(call_abi)+p(libgfortran_version)+p(cxx_abi))
 
 # Testing suite:
 # triplets="i686-w64-mingw32 x86_64-pc-linux-musl arm-linux-musleabihf x86_64-linux-gnu arm-linux-gnueabihf x86_64-apple-darwin14 x86_64-unknown-freebsd11.1"

--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -132,19 +132,20 @@ end
     # Next, fuzz it out!  Ensure that we exactly reconstruct our platforms!
     platforms = Platform[]
     for libgfortran_version in (v"3", v"4", v"5", nothing),
-        libstdcxx_version in (v"3.4.11", v"3.4.19", nothing),
+        cxxlib in ("libstdcxx",),
+        cxxlib_version in (v"3.4.11", v"3.4.19", nothing),
         cxxstring_abi in ("cxx03", "cxx11", nothing)
 
         for arch in ("x86_64", "i686", "aarch64", "armv7l"),
             libc in ("glibc", "musl")
 
-            push!(platforms, Platform(arch, "linux"; libc, libgfortran_version, libstdcxx_version, cxxstring_abi))
+            push!(platforms, Platform(arch, "linux"; libc, libgfortran_version, cxxlib, cxxlib_version, cxxstring_abi))
         end
-        push!(platforms, Platform("x86_64", "windows"; libgfortran_version, libstdcxx_version, cxxstring_abi))
-        push!(platforms, Platform("i686", "windows"; libgfortran_version, libstdcxx_version, cxxstring_abi))
-        push!(platforms, Platform("x86_64", "macOS"; libgfortran_version, libstdcxx_version, cxxstring_abi))
-        push!(platforms, Platform("aarch64", "macOS"; libgfortran_version, libstdcxx_version, cxxstring_abi))
-        push!(platforms, Platform("x86_64", "FreeBSD"; libgfortran_version, libstdcxx_version, cxxstring_abi))
+        push!(platforms, Platform("x86_64", "windows"; libgfortran_version, cxxlib, cxxlib_version, cxxstring_abi))
+        push!(platforms, Platform("i686", "windows"; libgfortran_version, cxxlib, cxxlib_version, cxxstring_abi))
+        push!(platforms, Platform("x86_64", "macOS"; libgfortran_version, cxxlib, cxxlib_version, cxxstring_abi))
+        push!(platforms, Platform("aarch64", "macOS"; libgfortran_version, cxxlib, cxxlib_version, cxxstring_abi))
+        push!(platforms, Platform("x86_64", "FreeBSD"; libgfortran_version, cxxlib, cxxlib_version, cxxstring_abi))
     end
 
     for p in platforms

--- a/test/binaryplatforms.jl
+++ b/test/binaryplatforms.jl
@@ -124,7 +124,9 @@ P(args...; kwargs...) = Platform(args...; validate_strict=true, kwargs...)
     @test_throws ArgumentError P("armv6l", "linux"; call_abi="kekeke")
     @test_throws ArgumentError P("armv6l", "linux"; libgfortran_version="lel")
     @test_throws ArgumentError P("x86_64", "linux"; cxxstring_abi="lel")
-    @test_throws ArgumentError P("x86_64", "windows"; libstdcxx_version="lel")
+    @test_throws ArgumentError P("x86_64", "windows"; cxxlib_version="lel")
+    @test_throws ArgumentError P("x86_64", "windows"; cxxlib="other")
+    @test_throws ArgumentError P("x86_64", "windows"; cxxlib="libcxx", cxxstring_abi="cxx11")
     @test_throws ArgumentError P("i686", "macos")
     @test_throws ArgumentError P("x86_64", "macos"; libc="glibc")
     @test_throws ArgumentError P("x86_64", "macos"; call_abi="eabihf")
@@ -193,6 +195,16 @@ end
     # Now test libgfortran/cxxstring ABIs
     @test triplet(P("x86_64", "linux"; libgfortran_version=v"3", cxxstring_abi="cxx11")) == "x86_64-linux-gnu-libgfortran3-cxx11"
     @test triplet(P("armv7l", "linux"; libc="musl", cxxstring_abi="cxx03")) == "armv7l-linux-musleabihf-cxx03"
+    @test triplet(P("x86_64", "windows"; libc="ucrt")) == "x86_64-w64-ucrt-mingw32"
+    @test triplet(P("x86_64", "linux"; cxxlib="libstdcxx", cxxlib_version=v"3.4.26")) == "x86_64-linux-gnu-libstdcxx26"
+    libcxx_platform = P("x86_64", "linux"; cxxlib="libcxx", cxxlib_version=v"18")
+    libcxx_triplet = triplet(libcxx_platform)
+    @test startswith(libcxx_triplet, "x86_64-linux-gnu")
+    @test occursin("-cxxlib+libcxx", libcxx_triplet)
+    @test occursin("-cxxlib_version+18.0.0", libcxx_triplet)
+    @test parse(Platform, libcxx_triplet; validate_strict=true) == libcxx_platform
+    @test libstdcxx_version(P("x86_64", "linux"; cxxlib="libstdcxx", cxxlib_version=v"3.4.26")) == v"3.4.26"
+    @test libstdcxx_version(libcxx_platform) === nothing
     if !isnothing(detect_libgfortran_version())
         # When `libgfortran` can be detected at runtime, make sure
         # `HostPlatform` has the appropriate key.
@@ -246,6 +258,7 @@ end
     @test R("powerpc64le-linux-gnu") == P("powerpc64le", "linux")
     @test R("ppc64le-linux-gnu") == P("powerpc64le", "linux")
     @test R("x86_64-w64-mingw32") == P("x86_64", "windows")
+    @test R("x86_64-w64-ucrt-mingw32") == P("x86_64", "windows"; libc="ucrt")
     @test R("i686-w64-mingw32") == P("i686", "windows")
 
     # FreeBSD has lots of arch names that don't match elsewhere
@@ -261,7 +274,7 @@ end
     @test R("x86_64-linux-gnu-gcc4-cxx11") == P("x86_64", "linux"; libgfortran_version=v"3", cxxstring_abi="cxx11")
     @test R("x86_64-linux-gnu-cxx11") == P("x86_64", "linux"; cxxstring_abi="cxx11")
     @test R("x86_64-linux-gnu-libgfortran3-cxx03") == P("x86_64", "linux"; libgfortran_version=v"3", cxxstring_abi="cxx03")
-    @test R("x86_64-linux-gnu-libstdcxx26") ==  P("x86_64", "linux"; libstdcxx_version=v"3.4.26")
+    @test R("x86_64-linux-gnu-libstdcxx26") ==  P("x86_64", "linux"; cxxlib="libstdcxx", cxxlib_version=v"3.4.26")
 
     @test_throws ArgumentError R("totally FREEFORM text!!1!!!1!")
     @test_throws ArgumentError R("invalid-triplet-here")
@@ -288,10 +301,11 @@ end
     # Just do a quick combinatorial sweep for completeness' sake for platform matching
     linux = P("x86_64", "linux")
     for libgfortran_version in (nothing, v"3", v"5"),
-        libstdcxx_version in (nothing, v"3.4.18", v"3.4.26"),
+        cxxlib in ("libstdcxx",),
+        cxxlib_version in (nothing, v"3.4.18", v"3.4.26"),
         cxxstring_abi in (nothing, :cxx03, :cxx11)
 
-        p = P("x86_64", "linux"; libgfortran_version, libstdcxx_version, cxxstring_abi)
+        p = P("x86_64", "linux"; libgfortran_version, cxxlib, cxxlib_version, cxxstring_abi)
         @test platforms_match(linux, p)
         @test platforms_match(p, linux)
 


### PR DESCRIPTION
This is a prepratory commit for reflecting windows/mingw32 libc information in our binary platforms, as well as adding the basic detection for ucrt in our Makefiles (so it doesn't accidentally try to use binaries with the wrong ABI). Of course there are policy choices to be made about what we want to ship and test. This does not make any of those policy choices, it simply aims to provide the capability to represent these ABIs in case we decide to add them later.

To reflect the possibility of a libc++ difference (mingw comes in both libc++ and libstdc++ flavors these days and the same is true for linux of course, although less prominently so), this adds a new `cxxlib` abi tag that can be either `libstdcxx` or `libcxx` (perhaps `msvc` in the future, since clang does support that). There is also `cxxlib_version`. For compatibility the existing `libstdcxx_version` implies both `cxxlib=libstdcxx` as well as the corresponding versions. I'm not weeded to this representation, I just figured it was a reasonable first attempt.

Fixes #59009