### PR TITLE
Add ThreadSanitzer hooks for jl_mutex_t

### DIFF
--- a/src/gc-mmtk.c
+++ b/src/gc-mmtk.c
@@ -3,6 +3,10 @@
 #include "mmtkMutator.h"
 #include "threading.h"
 
+#ifdef _COMPILER_TSAN_ENABLED_
+#include <sanitizer/tsan_interface.h>
+#endif
+
 // File exists in the binding
 #include "mmtk.h"
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -99,12 +99,6 @@ static inline void msan_unpoison(const volatile void *a, size_t size) JL_NOTSAFE
 static inline void msan_allocated_memory(const volatile void *a, size_t size) JL_NOTSAFEPOINT {}
 static inline void msan_unpoison_string(const volatile char *a) JL_NOTSAFEPOINT {}
 #endif
-#ifdef _COMPILER_TSAN_ENABLED_
-JL_DLLIMPORT void *__tsan_create_fiber(unsigned flags);
-JL_DLLIMPORT void *__tsan_get_current_fiber(void);
-JL_DLLIMPORT void __tsan_destroy_fiber(void *fiber);
-JL_DLLIMPORT void __tsan_switch_to_fiber(void *fiber, unsigned flags);
-#endif
 
 #ifndef _OS_WINDOWS_
     #if defined(_CPU_ARM_) || defined(_CPU_PPC_) || defined(_CPU_WASM_)

--- a/src/task.c
+++ b/src/task.c
@@ -37,6 +37,10 @@
 #include "threading.h"
 #include "julia_assert.h"
 
+#ifdef _COMPILER_TSAN_ENABLED_
+#include <sanitizer/tsan_interface.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Lets us detect lock order inversions on `jl_mutex_t`s, races on mutex initialization, and shows the list of locked mutexes when some other ThreadSanitizer warning is shown.