### PR TITLE
[REPL] Handle empty completion, keywords better

### DIFF
--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -2720,3 +2720,25 @@ let s = "foo58296(findfi"
     @test "findfirst" in c
     @test r == 10:15
 end
+
+# #58931 - only show local names when completing the empty string
+let s = ""
+    c, r = test_complete_foo(s)
+    @test "test" in c
+    @test !("rand" in c)
+end
+
+# #58309, #58832 - don't show every name when completing after a full keyword
+let s = "true"     # bool is a little different (Base.isidentifier special case)
+    c, r = test_complete(s)
+    @test "trues" in c
+    @test "true" in c
+    @test !("rand" in c)
+end
+
+let s = "for"
+    c, r = test_complete(s)
+    @test "for" in c
+    @test "foreach" in c
+    @test !("rand" in c)
+end


### PR DESCRIPTION
When the context is empty, (like "<TAB><TAB>"), return only names local to the module (fixes #58931).

If the cursor is on something that "looks like" an identifier, like a boolean or one of the keywords, treat it as if it was one for completion purposes.  Typing a keyword and hitting tab no longer returns the completions for the empty input (fixes #58309, #58832).