### PR TITLE
Use a dedicated parameter attribute to identify the gstack arg.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6788,9 +6788,12 @@ static Function *emit_modifyhelper(jl_codectx_t &ctx2, const jl_cgval_t &op, con
     rhs.promotion_point = nullptr;
     rhs.promotion_ssa = -1;
     if (gcstack_arg) {
-        w->setCallingConv(CallingConv::Swift);
         AttrBuilder param(ctx.builder.getContext());
-        param.addAttribute(Attribute::SwiftSelf);
+        if (ctx.emission_context.use_swiftcc) {
+            w->setCallingConv(CallingConv::Swift);
+            param.addAttribute(Attribute::SwiftSelf);
+        }
+        param.addAttribute("gcstack");
         param.addAttribute(Attribute::NonNull);
         Argument *gcstackarg = &*AI++;
         gcstackarg->addAttrs(param);
@@ -7966,6 +7969,7 @@ static jl_returninfo_t get_specsig_function(jl_codegen_params_t &params, Module 
         AttrBuilder param(M->getContext());
         if (params.use_swiftcc)
             param.addAttribute(Attribute::SwiftSelf);
+        param.addAttribute("gcstack");
         param.addAttribute(Attribute::NonNull);
         attrs.push_back(AttributeSet::get(M->getContext(), param));
         fsig.push_back(PointerType::get(M->getContext(), 0));

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -88,10 +88,11 @@ llvm::Value *JuliaPassContext::getPGCstack(llvm::Function &F) const
             }
         }
     }
-    if (F.getCallingConv() == CallingConv::Swift) {
-        for (auto &arg : F.args()) {
-            if (arg.hasSwiftSelfAttr())
-                return &arg;
+    for (auto &arg : F.args()) {
+        // Check for the "gcstack" attribute
+        AttributeSet attrs = F.getAttributes().getParamAttrs(arg.getArgNo());
+        if (attrs.hasAttribute("gcstack")) {
+            return &arg;
         }
     }
     return nullptr;

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -344,7 +344,8 @@ bool LowerPTLS::run(bool *CFGModified)
             auto f = call->getCaller();
             Value *pgcstack = NULL;
             for (Function::arg_iterator arg = f->arg_begin(); arg != f->arg_end(); ++arg) {
-                if (arg->hasSwiftSelfAttr()) {
+                AttributeSet attrs = f->getAttributes().getParamAttrs(arg->getArgNo());
+                if (attrs.hasAttribute("gcstack")) {
                     pgcstack = &*arg;
                     break;
                 }

--- a/test/llvmpasses/alloc-opt-pass.ll
+++ b/test/llvmpasses/alloc-opt-pass.ll
@@ -197,10 +197,10 @@ union_move9:                                      ; No predecessors!
 @1 = private unnamed_addr constant i64 0, align 8
 
 ; CHECK-LABEL: @cmpxchg
-; CHECK: alloca 
+; CHECK: alloca
 ; CHECK: alloca
 ; CHECK:  %20 = cmpxchg ptr %2,
-define swiftcc i64 @"cmpxchg"(ptr nonnull swiftself %0) #0 {
+define swiftcc i64 @"cmpxchg"(ptr nonnull swiftself "gcstack" %0) #0 {
   %2 = alloca i64, align 16
   %3 = call ptr @julia.get_pgcstack()
   %4 = getelementptr inbounds i8, ptr %3, i32 -152
@@ -229,7 +229,7 @@ define swiftcc i64 @"cmpxchg"(ptr nonnull swiftself %0) #0 {
 
 19:                                               ; preds = %19, %1
   %20 = phi i64 [ %17, %1 ], [ %23, %19 ]
-  %21 = call swiftcc i64 @"jlsys_+_47"(ptr nonnull swiftself %3, i64 signext %20, i64 signext 1)
+  %21 = call swiftcc i64 @"jlsys_+_47"(ptr nonnull swiftself "gcstack" %3, i64 signext %20, i64 signext 1)
   %22 = cmpxchg ptr addrspace(11) %16, i64 %20, i64 %21 seq_cst monotonic, align 8, !tbaa !25, !alias.scope !23, !noalias !24
   %23 = extractvalue { i64, i1 } %22, 0
   %24 = extractvalue { i64, i1 } %22, 1
@@ -241,7 +241,7 @@ define swiftcc i64 @"cmpxchg"(ptr nonnull swiftself %0) #0 {
 ; CHECK: alloca
 ; CHECK: alloca
 ; CHECK: atomicrmw xchg ptr %2,
-define swiftcc i64 @"atomicrmw"(ptr nonnull swiftself %0) #0 {
+define swiftcc i64 @"atomicrmw"(ptr nonnull swiftself "gcstack" %0) #0 {
   %2 = alloca i64, align 16
   %3 = call ptr @julia.get_pgcstack()
   %4 = getelementptr inbounds i8, ptr %3, i32 -152
@@ -263,7 +263,7 @@ define swiftcc i64 @"atomicrmw"(ptr nonnull swiftself %0) #0 {
   call void @llvm.memcpy.p11.p0.i64(ptr addrspace(11) align 8 %15, ptr align 8 @1, i64 8, i1 false), !tbaa !20, !alias.scope !23, !noalias !24
   %16 = addrspacecast ptr addrspace(10) %14 to ptr addrspace(11)
   %17 = load atomic i64, ptr addrspace(11) %16 monotonic, align 8, !tbaa !25, !alias.scope !23, !noalias !24
-  %18 = call swiftcc i64 @"jlsys_+_47"(ptr nonnull swiftself %3, i64 signext %17, i64 signext 1)
+  %18 = call swiftcc i64 @"jlsys_+_47"(ptr nonnull swiftself "gcstack" %3, i64 signext %17, i64 signext 1)
   %19 = atomicrmw xchg ptr addrspace(11) %16, i64 %18 seq_cst, align 8, !tbaa !25, !alias.scope !23, !noalias !24                                    ; preds = %19
   ret i64 %19
 }

--- a/test/llvmpasses/late-lower-gc-sret.ll
+++ b/test/llvmpasses/late-lower-gc-sret.ll
@@ -6,7 +6,7 @@ declare ptr @julia.get_pgcstack()
 
 declare swiftcc void @sret_call(ptr noalias nocapture noundef nonnull sret([3 x ptr addrspace(10)]), ptr nonnull swiftself, ptr addrspace(10) nonnull)
 
-define hidden swiftcc nonnull ptr addrspace(10) @sret_select(ptr nonnull swiftself %0, ptr addrspace(10) noundef nonnull align 8 dereferenceable(88) %1, i1 %unpredictable) {
+define hidden swiftcc nonnull ptr addrspace(10) @sret_select(ptr nonnull swiftself "gcstack" %0, ptr addrspace(10) noundef nonnull align 8 dereferenceable(88) %1, i1 %unpredictable) {
   ; CHECK-LABEL: @sret_select
   ; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 6)
   ; CHECK: call ptr @julia.get_gc_frame_slot(ptr %gcframe, i32 3)
@@ -17,12 +17,12 @@ define hidden swiftcc nonnull ptr addrspace(10) @sret_select(ptr nonnull swiftse
   %3 = alloca [3 x i64], align 8
   %4 = alloca [3 x i64], align 8
   %5 = select i1 %unpredictable, ptr %3, ptr %4
-  call swiftcc void @sret_call(ptr noalias nocapture noundef nonnull sret([3 x ptr addrspace(10)]) %5, ptr nonnull swiftself %0, ptr addrspace(10) nonnull %1)
+  call swiftcc void @sret_call(ptr noalias nocapture noundef nonnull sret([3 x ptr addrspace(10)]) %5, ptr nonnull swiftself "gcstack" %0, ptr addrspace(10) nonnull %1)
   ; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
   ret ptr addrspace(10) %1
 }
 
-define hidden swiftcc nonnull ptr addrspace(10) @sret_phi(ptr nonnull swiftself %0, ptr addrspace(10) noundef nonnull align 8 dereferenceable(88) %1, i1 %unpredictable) {
+define hidden swiftcc nonnull ptr addrspace(10) @sret_phi(ptr nonnull swiftself "gcstack" %0, ptr addrspace(10) noundef nonnull align 8 dereferenceable(88) %1, i1 %unpredictable) {
 top:
   ; CHECK-LABEL: @sret_phi
   ; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 6)
@@ -43,14 +43,14 @@ false:                                            ; preds = %top
 
 ret:                                              ; preds = %false, %true
   %4 = phi ptr [ %2, %true ], [ %3, %false ]
-  call swiftcc void @sret_call(ptr noalias nocapture noundef nonnull sret([3 x ptr addrspace(10)]) %4, ptr nonnull swiftself %0, ptr addrspace(10) nonnull %1)
+  call swiftcc void @sret_call(ptr noalias nocapture noundef nonnull sret([3 x ptr addrspace(10)]) %4, ptr nonnull swiftself "gcstack" %0, ptr addrspace(10) nonnull %1)
   ; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
   ret ptr addrspace(10) %1
 }
 
 declare swiftcc void @sret_call_gc(ptr noalias nocapture noundef sret({ ptr addrspace(10), i64, i64 }), ptr noalias nocapture noundef, ptr nonnull swiftself)
 
-define hidden swiftcc void @sret_gc_root_phi(ptr nonnull swiftself %0, i1 %unpredictable) {
+define hidden swiftcc void @sret_gc_root_phi(ptr nonnull swiftself "gcstack" %0, i1 %unpredictable) {
 top:
   ; CHECK-LABEL: @sret_gc_root_phi
   ; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 2)
@@ -75,13 +75,13 @@ false:                                            ; preds = %top
 
 ret:                                              ; preds = %false, %true
   %4 = phi ptr [ %2, %true ], [ %3, %false ]
-  call swiftcc void @sret_call_gc(ptr noalias nocapture noundef sret({ ptr addrspace(10), i64, i64 }) %1, ptr noalias nocapture noundef %4, ptr nonnull swiftself %0)
+  call swiftcc void @sret_call_gc(ptr noalias nocapture noundef sret({ ptr addrspace(10), i64, i64 }) %1, ptr noalias nocapture noundef %4, ptr nonnull swiftself "gcstack" %0)
    ; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
   ret void
 }
 
 
-define hidden swiftcc void @sret_gc_root_phi_select(ptr nonnull swiftself %0, i1 %unpredictable, i1 %unpredictable2) {
+define hidden swiftcc void @sret_gc_root_phi_select(ptr nonnull swiftself "gcstack" %0, i1 %unpredictable, i1 %unpredictable2) {
 top:
   ; CHECK-LABEL: @sret_gc_root_phi_select
   ; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 3)
@@ -110,12 +110,12 @@ false:                                            ; preds = %top
 ret:                                              ; preds = %false, %true
   %5 = phi ptr [ %2, %true ], [ %3, %false ]
   %6 = select i1 %unpredictable2, ptr %4, ptr %5
-  call swiftcc void @sret_call_gc(ptr noalias nocapture noundef sret({ ptr addrspace(10), i64, i64 }) %1, ptr noalias nocapture noundef %6, ptr nonnull swiftself %0)
+  call swiftcc void @sret_call_gc(ptr noalias nocapture noundef sret({ ptr addrspace(10), i64, i64 }) %1, ptr noalias nocapture noundef %6, ptr nonnull swiftself "gcstack" %0)
    ; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
   ret void
 }
 
-define hidden swiftcc void @sret_gc_root_select_phi(ptr nonnull swiftself %0, i1 %unpredictable, i1 %unpredictable2) {
+define hidden swiftcc void @sret_gc_root_select_phi(ptr nonnull swiftself "gcstack" %0, i1 %unpredictable, i1 %unpredictable2) {
 top:
   ; CHECK-LABEL: @sret_gc_root_select_phi
   ; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 3)
@@ -145,7 +145,7 @@ false:                                            ; preds = %top
 ret:                                              ; preds = %false, %true
   %6 = phi ptr [ %2, %true ], [ %5, %false ]
 
-  call swiftcc void @sret_call_gc(ptr noalias nocapture noundef sret({ ptr addrspace(10), i64, i64 }) %1, ptr noalias nocapture noundef %6, ptr nonnull swiftself %0)
+  call swiftcc void @sret_call_gc(ptr noalias nocapture noundef sret({ ptr addrspace(10), i64, i64 }) %1, ptr noalias nocapture noundef %6, ptr nonnull swiftself "gcstack" %0)
    ; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
   ret void
 }

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -199,7 +199,7 @@ define void @decayar([2 x {} addrspace(10)* addrspace(11)*] %ar) {
 ; CHECK: %r = call i32 @callee_root(ptr addrspace(10) %l0, ptr addrspace(10) %l1)
 ; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
 
-define swiftcc ptr addrspace(10) @insert_element(ptr swiftself %0) {
+define swiftcc ptr addrspace(10) @insert_element(ptr swiftself "gcstack" %0) {
 ; CHECK-LABEL: @insert_element
   %2 = alloca [10 x i64], i32 1, align 8
 ; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 10)


### PR DESCRIPTION
Otherwise, on systems without SwitfCC support (i.e. RISC-V) `getPGCstack` may return null, disabling the final GC pass.

Fixes https://github.com/JuliaLang/julia/issues/57569#issuecomment-2690422365

@KristofferC To be back-ported if https://github.com/JuliaLang/julia/pull/57410 is.