### PR TITLE
remove a testset from MMAP that might cause CI to now fail on Windows

### DIFF
--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -343,18 +343,18 @@ end
 GC.gc()
 rm(file)
 
-@testset "test for #58982 - mmap with primitive types" begin
-    file = tempname()
-    primitive type PrimType9Bytes 9*8 end
-    arr = Vector{PrimType9Bytes}(undef, 2)
-    write(file, arr)
-    m = mmap(file, Vector{PrimType9Bytes})
-    @test length(m) == 2
-    @test m[1] == arr[1]
-    @test m[2] == arr[2]
-    finalize(m); m = nothing; GC.gc()
-    rm(file)
-end
+# test for #58982 - mmap with primitive types
+file = tempname()
+primitive type PrimType9Bytes 9*8 end
+arr = Vector{PrimType9Bytes}(undef, 2)
+write(file, arr)
+m = mmap(file, Vector{PrimType9Bytes})
+@test length(m) == 2
+@test m[1] == arr[1]
+@test m[2] == arr[2]
+finalize(m); m = nothing; GC.gc()
+rm(file)
+
 
 @testset "Docstrings" begin
     @test isempty(Docs.undocumented_names(Mmap))


### PR DESCRIPTION
Maybe fixes https://github.com/JuliaLang/julia/issues/59053.

All I know is that this test succeeded until the testset was added and then it started failing and then the PR was merged.