### PR TITLE
Fix GCC warnings about jumps crossing initializers

### DIFF
--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -139,20 +139,22 @@ NOINLINE jl_gc_pagemeta_t *jl_gc_alloc_page(void) JL_NOTSAFEPOINT
         goto exit;
     }
     // must map a new set of pages
-    char *data = jl_gc_try_alloc_pages();
-    meta = (jl_gc_pagemeta_t*)malloc_s(block_pg_cnt * sizeof(jl_gc_pagemeta_t));
-    for (int i = 0; i < block_pg_cnt; i++) {
-        jl_gc_pagemeta_t *pg = &meta[i];
-        pg->data = data + GC_PAGE_SZ * i;
-        gc_alloc_map_maybe_create(pg->data);
-        if (i == 0) {
-            gc_alloc_map_set(pg->data, GC_PAGE_ALLOCATED);
+    {
+        char *data = jl_gc_try_alloc_pages();
+        meta = (jl_gc_pagemeta_t*)malloc_s(block_pg_cnt * sizeof(jl_gc_pagemeta_t));
+        for (int i = 0; i < block_pg_cnt; i++) {
+            jl_gc_pagemeta_t *pg = &meta[i];
+            pg->data = data + GC_PAGE_SZ * i;
+            gc_alloc_map_maybe_create(pg->data);
+            if (i == 0) {
+                gc_alloc_map_set(pg->data, GC_PAGE_ALLOCATED);
+            }
+            else {
+                push_lf_back(&global_page_pool_clean, pg);
+            }
         }
-        else {
-            push_lf_back(&global_page_pool_clean, pg);
-        }
+        uv_mutex_unlock(&gc_pages_lock);
     }
-    uv_mutex_unlock(&gc_pages_lock);
 exit:
 #ifdef _OS_WINDOWS_
     VirtualAlloc(meta->data, GC_PAGE_SZ, MEM_COMMIT, PAGE_READWRITE);

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -4024,56 +4024,58 @@ JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p)
             // case 1: full page; `cell` must be an object
             goto valid_object;
         }
-        jl_gc_pool_t *pool =
-            gc_all_tls_states[meta->thread_n]->gc_tls.heap.norm_pools +
-            meta->pool_n;
-        if (meta->fl_begin_offset == UINT16_MAX) {
-            // case 2: this is a page on the newpages list
-            jl_taggedvalue_t *newpages = pool->newpages;
-            // Check if the page is being allocated from via newpages
-            if (!newpages)
-                return NULL;
-            char *data = gc_page_data(newpages);
-            if (data != meta->data) {
-                // Pages on newpages form a linked list where only the
-                // first one is allocated from (see gc_reset_page()).
-                // All other pages are empty.
-                return NULL;
+        {
+            jl_gc_pool_t *pool =
+                gc_all_tls_states[meta->thread_n]->gc_tls.heap.norm_pools +
+                meta->pool_n;
+            if (meta->fl_begin_offset == UINT16_MAX) {
+                // case 2: this is a page on the newpages list
+                jl_taggedvalue_t *newpages = pool->newpages;
+                // Check if the page is being allocated from via newpages
+                if (!newpages)
+                    return NULL;
+                char *data = gc_page_data(newpages);
+                if (data != meta->data) {
+                    // Pages on newpages form a linked list where only the
+                    // first one is allocated from (see gc_reset_page()).
+                    // All other pages are empty.
+                    return NULL;
+                }
+                // This is the first page on the newpages list, where objects
+                // are allocated from.
+                if ((char *)cell >= (char *)newpages) // past allocation pointer
+                    return NULL;
+                goto valid_object;
             }
-            // This is the first page on the newpages list, where objects
-            // are allocated from.
-            if ((char *)cell >= (char *)newpages) // past allocation pointer
-                return NULL;
-            goto valid_object;
+            // case 3: this is a page with a freelist
+            // marked or old objects can't be on the freelist
+            if (cell->bits.gc)
+                goto valid_object;
+            // When allocating from a freelist, three subcases are possible:
+            // * The freelist of a page has been exhausted; this was handled
+            //   under case 1, as nfree == 0.
+            // * The freelist of the page has not been used, and the age bits
+            //   reflect whether a cell is on the freelist or an object.
+            // * The freelist is currently being allocated from. In this case,
+            //   pool->freelist will point to the current page; any cell with
+            //   a lower address will be an allocated object, and for cells
+            //   with the same or a higher address, the corresponding age
+            //   bit will reflect whether it's on the freelist.
+            // Age bits are set in sweep_page() and are 0 for freelist
+            // entries and 1 for live objects. The above subcases arise
+            // because allocating a cell will not update the age bit, so we
+            // need extra logic for pages that have been allocated from.
+            // We now distinguish between the second and third subcase.
+            // Freelist entries are consumed in ascending order. Anything
+            // before the freelist pointer was either live during the last
+            // sweep or has been allocated since.
+            if (gc_page_data(cell) == gc_page_data(pool->freelist)
+                && (char *)cell < (char *)pool->freelist)
+                goto valid_object;
+            // already skipped marked or old objects above, so here
+            // the age bits are 0, thus the object is on the freelist
+            return NULL;
         }
-        // case 3: this is a page with a freelist
-        // marked or old objects can't be on the freelist
-        if (cell->bits.gc)
-            goto valid_object;
-        // When allocating from a freelist, three subcases are possible:
-        // * The freelist of a page has been exhausted; this was handled
-        //   under case 1, as nfree == 0.
-        // * The freelist of the page has not been used, and the age bits
-        //   reflect whether a cell is on the freelist or an object.
-        // * The freelist is currently being allocated from. In this case,
-        //   pool->freelist will point to the current page; any cell with
-        //   a lower address will be an allocated object, and for cells
-        //   with the same or a higher address, the corresponding age
-        //   bit will reflect whether it's on the freelist.
-        // Age bits are set in sweep_page() and are 0 for freelist
-        // entries and 1 for live objects. The above subcases arise
-        // because allocating a cell will not update the age bit, so we
-        // need extra logic for pages that have been allocated from.
-        // We now distinguish between the second and third subcase.
-        // Freelist entries are consumed in ascending order. Anything
-        // before the freelist pointer was either live during the last
-        // sweep or has been allocated since.
-        if (gc_page_data(cell) == gc_page_data(pool->freelist)
-            && (char *)cell < (char *)pool->freelist)
-            goto valid_object;
-        // already skipped marked or old objects above, so here
-        // the age bits are 0, thus the object is on the freelist
-        return NULL;
         // Not a freelist entry, therefore a valid object.
     valid_object:
         // We have to treat objects with type `jl_buff_tag` differently,

--- a/src/gf.c
+++ b/src/gf.c
@@ -4108,6 +4108,9 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
         (callsite >> 24 | callsite << 8) & (N_CALL_CACHE - 1)};
     jl_typemap_entry_t *entry = NULL;
     int i;
+    jl_method_instance_t *mfunc;
+    jl_tupletype_t *tt = NULL;
+    int64_t last_alloc = 0;
     // check each cache entry to see if it matches
     //#pragma unroll
     //for (i = 0; i < 4; i++) {
@@ -4128,8 +4131,6 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
     LOOP_BODY(3);
 #undef LOOP_BODY
     i = 4;
-    jl_tupletype_t *tt = NULL;
-    int64_t last_alloc = 0;
     if (i == 4) {
         // if no method was found in the associative cache, check the full cache
         JL_TIMING(METHOD_LOOKUP_FAST, METHOD_LOOKUP_FAST);
@@ -4170,7 +4171,6 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
         }
     }
 
-    jl_method_instance_t *mfunc;
     if (entry) {
 have_entry:
         mfunc = entry->func.linfo;

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -793,7 +793,7 @@ static jl_value_t *jl_decode_value(jl_ircode_state *s)
     case 0:
         tag = read_uint8(s->s);
         return jl_deser_tag(tag);
-    case TAG_RELOC_METHODROOT:
+    case TAG_RELOC_METHODROOT: {
         key = read_uint64(s->s);
         tag = read_uint8(s->s);
         assert(tag == TAG_METHODROOT || tag == TAG_LONG_METHODROOT);
@@ -804,6 +804,7 @@ static jl_value_t *jl_decode_value(jl_ircode_state *s)
             index = read_uint32(s->s);
         assert(index >= 0);
         return lookup_root(s->method, key, index);
+    }
     case TAG_METHODROOT:
         return lookup_root(s->method, 0, read_uint8(s->s));
     case TAG_LONG_METHODROOT:

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -152,7 +152,7 @@ static void _jl_exception_clear(jl_task_t *ct) JL_NOTSAFEPOINT
  */
 JL_DLLEXPORT jl_value_t *jl_eval_string(const char *str)
 {
-    jl_value_t *r;
+    jl_value_t *r = NULL;
     jl_task_t *ct = jl_current_task;
     JL_TRY {
         const char filename[] = "none";
@@ -165,7 +165,6 @@ JL_DLLEXPORT jl_value_t *jl_eval_string(const char *str)
     }
     JL_CATCH {
         ct->ptls->previous_exception = jl_current_exception(ct);
-        r = NULL;
     }
     return r;
 }
@@ -289,7 +288,7 @@ JL_DLLEXPORT const char *jl_string_ptr(jl_value_t *s)
  */
 JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, uint32_t nargs)
 {
-    jl_value_t *v;
+    jl_value_t *v = NULL;
     jl_task_t *ct = jl_current_task;
     nargs++; // add f to args
     JL_TRY {
@@ -307,7 +306,6 @@ JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, uint32_t n
     }
     JL_CATCH {
         ct->ptls->previous_exception = jl_current_exception(ct);
-        v = NULL;
     }
     return v;
 }
@@ -322,7 +320,7 @@ JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, uint32_t n
  */
 JL_DLLEXPORT jl_value_t *jl_call0(jl_function_t *f)
 {
-    jl_value_t *v;
+    jl_value_t *v = NULL;
     jl_task_t *ct = jl_current_task;
     JL_TRY {
         JL_GC_PUSH1(&f);
@@ -335,7 +333,6 @@ JL_DLLEXPORT jl_value_t *jl_call0(jl_function_t *f)
     }
     JL_CATCH {
         ct->ptls->previous_exception = jl_current_exception(ct);
-        v = NULL;
     }
     return v;
 }
@@ -351,7 +348,7 @@ JL_DLLEXPORT jl_value_t *jl_call0(jl_function_t *f)
  */
 JL_DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a)
 {
-    jl_value_t *v;
+    jl_value_t *v = NULL;
     jl_task_t *ct = jl_current_task;
     JL_TRY {
         jl_value_t **argv;
@@ -367,7 +364,6 @@ JL_DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a)
     }
     JL_CATCH {
         ct->ptls->previous_exception = jl_current_exception(ct);
-        v = NULL;
     }
     return v;
 }
@@ -384,7 +380,7 @@ JL_DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a)
  */
 JL_DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b)
 {
-    jl_value_t *v;
+    jl_value_t *v = NULL;
     jl_task_t *ct = jl_current_task;
     JL_TRY {
         jl_value_t **argv;
@@ -401,7 +397,6 @@ JL_DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b
     }
     JL_CATCH {
         ct->ptls->previous_exception = jl_current_exception(ct);
-        v = NULL;
     }
     return v;
 }
@@ -420,7 +415,7 @@ JL_DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b
 JL_DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a,
                                   jl_value_t *b, jl_value_t *c)
 {
-    jl_value_t *v;
+    jl_value_t *v = NULL;
     jl_task_t *ct = jl_current_task;
     JL_TRY {
         jl_value_t **argv;
@@ -438,7 +433,6 @@ JL_DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a,
     }
     JL_CATCH {
         ct->ptls->previous_exception = jl_current_exception(ct);
-        v = NULL;
     }
     return v;
 }
@@ -459,7 +453,7 @@ JL_DLLEXPORT jl_value_t *jl_call4(jl_function_t *f, jl_value_t *a,
                                   jl_value_t *b, jl_value_t *c,
                                   jl_value_t *d)
 {
-    jl_value_t *v;
+    jl_value_t *v = NULL;
     jl_task_t *ct = jl_current_task;
     JL_TRY {
         jl_value_t **argv;
@@ -478,7 +472,6 @@ JL_DLLEXPORT jl_value_t *jl_call4(jl_function_t *f, jl_value_t *a,
     }
     JL_CATCH {
         ct->ptls->previous_exception = jl_current_exception(ct);
-        v = NULL;
     }
     return v;
 }
@@ -492,7 +485,7 @@ JL_DLLEXPORT jl_value_t *jl_call4(jl_function_t *f, jl_value_t *a,
  */
 JL_DLLEXPORT jl_value_t *jl_get_field(jl_value_t *o, const char *fld)
 {
-    jl_value_t *v;
+    jl_value_t *v = NULL;
     jl_task_t *ct = jl_current_task;
     JL_TRY {
         jl_value_t *s = (jl_value_t*)jl_symbol(fld);
@@ -502,7 +495,6 @@ JL_DLLEXPORT jl_value_t *jl_get_field(jl_value_t *o, const char *fld)
     }
     JL_CATCH {
         ct->ptls->previous_exception = jl_current_exception(ct);
-        v = NULL;
     }
     return v;
 }

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -656,7 +656,7 @@ restart_switch:
             if (!jl_options.cpu_target)
                 jl_error("julia: failed to allocate memory");
             break;
-        case 't': // threads
+        case 't': { // threads
             errno = 0;
             jl_options.nthreadpools = 2;
             // By default:
@@ -706,6 +706,7 @@ restart_switch:
             ntpp[1] = (int16_t)nthreadsi;
             jl_options.nthreads_per_pool = ntpp;
             break;
+        }
         case 'p': // procs
             errno = 0;
             if (!strcmp(optarg,"auto")) {
@@ -1006,7 +1007,7 @@ restart_switch:
             if (jl_options.heap_target_increment == 0)
                 jl_errorf("julia: invalid memory size specified in --heap-target-increment=<size>[<unit>]");
             break;
-        case opt_gc_threads:
+        case opt_gc_threads: {
             errno = 0;
             long nmarkthreads = strtol(optarg, &endptr, 10);
             if (errno != 0 || optarg == endptr || nmarkthreads < 1 || nmarkthreads >= INT16_MAX) {
@@ -1022,6 +1023,7 @@ restart_switch:
                 jl_options.nsweepthreads = (int8_t)nsweepthreads;
             }
             break;
+        }
         case opt_permalloc_pkgimg:
             if (!strcmp(optarg,"yes"))
                 jl_options.permalloc_pkgimg = 1;
@@ -1030,13 +1032,14 @@ restart_switch:
             else
                 jl_errorf("julia: invalid argument to --permalloc-pkgimg={yes|no} (%s)", optarg);
             break;
-        case opt_timeout_for_safepoint_straggler:
+        case opt_timeout_for_safepoint_straggler: {
             errno = 0;
             long timeout = strtol(optarg, &endptr, 10);
             if (errno != 0 || optarg == endptr || timeout < 1 || timeout > INT16_MAX)
                 jl_errorf("julia: --timeout-for-safepoint-straggler=<seconds>; seconds must be an integer between 1 and %d", INT16_MAX);
             jl_options.timeout_for_safepoint_straggler_s = (int16_t)timeout;
             break;
+        }
         case opt_gc_sweep_always_full:
             jl_options.gc_sweep_always_full = 1;
             break;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -599,42 +599,44 @@ static int simple_subtype(jl_value_t *a, jl_value_t *b, int hasfree, int isUnion
 STATIC_INLINE void merge_vararg_unions(jl_value_t **temp, size_t nt)
 {
     for (size_t i = nt-1; i > 0; i--) {
-        // match types of form Tuple{T, ..., Vararg{T}}
-        jl_value_t *tt = temp[i];
-        if (!(tt && jl_is_tuple_type(tt))) continue;
-        size_t nfields = jl_nparams(tt);
-        if (nfields <= 1) continue;
-        jl_value_t *va = jl_tparam(tt, nfields-1);
-        if (jl_vararg_kind(va) != JL_VARARG_UNBOUND) continue;
-        jl_value_t *t = jl_unwrap_vararg(va);
-        for (size_t j = 0; j < nfields-1; j++)
-            if (!jl_egal(jl_tparam(tt, j), t)) goto outer_loop;
+        {
+            // match types of form Tuple{T, ..., Vararg{T}}
+            jl_value_t *tt = temp[i];
+            if (!(tt && jl_is_tuple_type(tt))) continue;
+            size_t nfields = jl_nparams(tt);
+            if (nfields <= 1) continue;
+            jl_value_t *va = jl_tparam(tt, nfields-1);
+            if (jl_vararg_kind(va) != JL_VARARG_UNBOUND) continue;
+            jl_value_t *t = jl_unwrap_vararg(va);
+            for (size_t j = 0; j < nfields-1; j++)
+                if (!jl_egal(jl_tparam(tt, j), t)) goto outer_loop;
 
-        // look for Tuple{T, T, ...} then Tuple{T, ...}, etc
-        size_t min_elements = nfields-1;
-        for (long j = i-1; j >= 0; j--) {
-            jl_value_t *ttj = temp[j];
-            if (!jl_is_tuple_type(ttj)) break;
-            size_t nfieldsj = jl_nparams(ttj);
-            if (nfieldsj >= min_elements) continue;
-            if (nfieldsj != min_elements-1) break;
-            for (size_t k = 0; k < nfieldsj; k++)
-                if (!jl_egal(jl_tparam(ttj, k), t)) goto inner_loop;
+            // look for Tuple{T, T, ...} then Tuple{T, ...}, etc
+            size_t min_elements = nfields-1;
+            for (long j = i-1; j >= 0; j--) {
+                jl_value_t *ttj = temp[j];
+                if (!jl_is_tuple_type(ttj)) break;
+                size_t nfieldsj = jl_nparams(ttj);
+                if (nfieldsj >= min_elements) continue;
+                if (nfieldsj != min_elements-1) break;
+                for (size_t k = 0; k < nfieldsj; k++)
+                    if (!jl_egal(jl_tparam(ttj, k), t)) goto inner_loop;
 
-            temp[j] = NULL;
-            min_elements--;
+                temp[j] = NULL;
+                min_elements--;
  inner_loop:
             continue;
-        }
+            }
 
-        if (min_elements == nfields-1) continue;
-        jl_value_t** params;
-        JL_GC_PUSHARGS(params, min_elements+1);
-        for (size_t j = 0; j < min_elements; j++)
-            params[j] = t;
-        params[min_elements] = va;
-        temp[i] = jl_apply_type((jl_value_t*)jl_tuple_type, params, min_elements+1);
-        JL_GC_POP();
+            if (min_elements == nfields-1) continue;
+            jl_value_t** params;
+            JL_GC_PUSHARGS(params, min_elements+1);
+            for (size_t j = 0; j < min_elements; j++)
+                params[j] = t;
+            params[min_elements] = va;
+            temp[i] = jl_apply_type((jl_value_t*)jl_tuple_type, params, min_elements+1);
+            JL_GC_POP();
+        }
  outer_loop:
         continue;
     }

--- a/src/julia.h
+++ b/src/julia.h
@@ -2471,7 +2471,7 @@ extern void (*real_siglongjmp)(jmp_buf _Buf, int _Value);
 #endif
 
 
-#ifdef __clang_gcanalyzer__
+#if defined(__clang_gcanalyzer__) || defined(__clang_analyzer__)
 
 extern int had_exception;
 
@@ -2493,19 +2493,30 @@ extern int had_exception;
 
 #else
 
-#define JL_TRY                                                      \
-    int i__try, i__catch; jl_handler_t __eh; jl_task_t *__eh_ct;    \
-    __eh_ct = jl_current_task;                                      \
-    size_t __excstack_state = jl_excstack_state(__eh_ct);           \
-    jl_enter_handler(__eh_ct, &__eh);                               \
-    if (!jl_setjmp(__eh.eh_ctx, 0))                                 \
-        for (i__try=1, __eh_ct->eh = &__eh; i__try; i__try=0, /* TRY BLOCK; */ jl_eh_restore_state_noexcept(__eh_ct, &__eh))
+struct jl_trystate {
+    int i_try;
+    int i_catch;
+    size_t excstack_state;
+    jl_task_t *eh_ct;
+    jl_handler_t eh;
+};
 
-#define JL_CATCH                                                    \
-    else                                                            \
-        for (i__catch=1, jl_eh_restore_state(__eh_ct, &__eh); i__catch; i__catch=0, /* CATCH BLOCK; */ jl_restore_excstack(__eh_ct, __excstack_state))
+#define JL_TRY                                                                                \
+    for (struct jl_trystate __jltry = {1, 1, 0, jl_current_task}; __jltry.i_try && __jltry.i_catch; ) \
+    for (__jltry.excstack_state = jl_excstack_state(__jltry.eh_ct),                           \
+         jl_enter_handler(__jltry.eh_ct, &__jltry.eh); __jltry.i_try && __jltry.i_catch; )    \
+    if (!jl_setjmp(__jltry.eh.eh_ctx, 0))                                                     \
+        for (__jltry.eh_ct->eh = &__jltry.eh; __jltry.i_try; __jltry.i_try=0,\
+             /* TRY BLOCK; */ jl_eh_restore_state_noexcept(__jltry.eh_ct, &__jltry.eh))
+
+#define JL_CATCH                                                                     \
+    else                                                                             \
+        for (jl_eh_restore_state(__jltry.eh_ct, &__jltry.eh);     \
+             __jltry.i_catch; __jltry.i_catch=0, /* CATCH BLOCK; */                  \
+             jl_restore_excstack(__jltry.eh_ct, __jltry.excstack_state))
 
 #endif
+
 
 // I/O system -----------------------------------------------------------------
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3730,29 +3730,32 @@ static int jl_validate_binding_partition(jl_binding_t *b, jl_binding_partition_t
         if (jl_atomic_load_relaxed(&bpart->min_world) > jl_require_world)
             goto invalidated;
     }
-    if (!jl_bkind_is_some_explicit_import(kind) && kind != PARTITION_KIND_IMPLICIT_GLOBAL)
-        return 1;
-    jl_binding_t *imported_binding = (jl_binding_t*)bpart->restriction;
-    if (no_replacement)
-        goto add_backedge;
-    jl_binding_partition_t *latest_imported_bpart = jl_atomic_load_relaxed(&imported_binding->partitions);
-    if (!latest_imported_bpart)
-        return 1;
-    if (jl_atomic_load_relaxed(&latest_imported_bpart->min_world) <=
-        jl_atomic_load_relaxed(&bpart->min_world)) {
+    {
+        if (!jl_bkind_is_some_explicit_import(kind) && kind != PARTITION_KIND_IMPLICIT_GLOBAL)
+            return 1;
+        jl_binding_t *imported_binding = (jl_binding_t*)bpart->restriction;
+        jl_binding_partition_t *latest_imported_bpart = NULL;
+        if (no_replacement)
+            goto add_backedge;
+        latest_imported_bpart = jl_atomic_load_relaxed(&imported_binding->partitions);
+        if (!latest_imported_bpart)
+            return 1;
+        if (jl_atomic_load_relaxed(&latest_imported_bpart->min_world) <=
+            jl_atomic_load_relaxed(&bpart->min_world)) {
 add_backedge:
-        // Imported binding is still valid
-        if ((kind == PARTITION_KIND_EXPLICIT || kind == PARTITION_KIND_IMPORTED) &&
-                external_blob_index((jl_value_t*)imported_binding) != mod_idx) {
-            jl_add_binding_backedge(imported_binding, (jl_value_t*)b);
+            // Imported binding is still valid
+            if ((kind == PARTITION_KIND_EXPLICIT || kind == PARTITION_KIND_IMPORTED) &&
+                    external_blob_index((jl_value_t*)imported_binding) != mod_idx) {
+                jl_add_binding_backedge(imported_binding, (jl_value_t*)b);
+            }
+            return 1;
         }
-        return 1;
-    }
-    else {
-        // Binding partition was invalidated
-        assert(jl_atomic_load_relaxed(&bpart->min_world) == jl_require_world);
-        jl_atomic_store_relaxed(&bpart->min_world,
-            jl_atomic_load_relaxed(&latest_imported_bpart->min_world));
+        else {
+            // Binding partition was invalidated
+            assert(jl_atomic_load_relaxed(&bpart->min_world) == jl_require_world);
+            jl_atomic_store_relaxed(&bpart->min_world,
+                jl_atomic_load_relaxed(&latest_imported_bpart->min_world));
+        }
     }
 invalidated:
     // We need to go through and re-validate any bindings in the same image that

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1112,29 +1112,31 @@ static int subtype_tuple_varargs(
             }
         }
     }
-    int x_same = vx > 1 || (lastx && obviously_egal(xp0, lastx));
-    int y_same = vy > 1 || (lasty && obviously_egal(yp0, lasty));
-    // keep track of number of consecutive identical subtyping
-    x_reps = y_same && x_same ? x_reps + 1 : 1;
-    if (x_reps > 2) {
-        // an identical type on the left doesn't need to be compared to the same
-        // element type on the right more than twice.
-    }
-    else if (x_same && e->Runions.depth == 0 && y_same &&
-        !jl_has_free_typevars(xp0) && !jl_has_free_typevars(yp0)) {
-        // fast path for repeated elements
-    }
-    else if ((e->Runions.depth == 0 ? !jl_has_free_typevars(xp0) : jl_is_concrete_type(xp0)) && !jl_has_free_typevars(yp0)) {
-        // fast path for separable sub-formulas
-        if (!jl_subtype(xp0, yp0))
-            return 0;
-    }
-    else {
-        // in Vararg{T1} <: Vararg{T2}, need to check subtype twice to
-        // simulate the possibility of multiple arguments, which is needed
-        // to implement the diagonal rule correctly.
-        if (!subtype(xp0, yp0, e, param)) return 0;
-        if (x_reps < 2 && !subtype(xp0, yp0, e, 1)) return 0;
+    {
+        int x_same = vx > 1 || (lastx && obviously_egal(xp0, lastx));
+        int y_same = vy > 1 || (lasty && obviously_egal(yp0, lasty));
+        // keep track of number of consecutive identical subtyping
+        x_reps = y_same && x_same ? x_reps + 1 : 1;
+        if (x_reps > 2) {
+            // an identical type on the left doesn't need to be compared to the same
+            // element type on the right more than twice.
+        }
+        else if (x_same && e->Runions.depth == 0 && y_same &&
+            !jl_has_free_typevars(xp0) && !jl_has_free_typevars(yp0)) {
+            // fast path for repeated elements
+        }
+        else if ((e->Runions.depth == 0 ? !jl_has_free_typevars(xp0) : jl_is_concrete_type(xp0)) && !jl_has_free_typevars(yp0)) {
+            // fast path for separable sub-formulas
+            if (!jl_subtype(xp0, yp0))
+                return 0;
+        }
+        else {
+            // in Vararg{T1} <: Vararg{T2}, need to check subtype twice to
+            // simulate the possibility of multiple arguments, which is needed
+            // to implement the diagonal rule correctly.
+            if (!subtype(xp0, yp0, e, param)) return 0;
+            if (x_reps < 2 && !subtype(xp0, yp0, e, 1)) return 0;
+        }
     }
 
 constrain_length:


### PR DESCRIPTION
Mostly by adding extra blocks around the variables in question.