### PR TITLE
Support complex numbers in eps (rebased)

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1150,6 +1150,7 @@ _default_type(T::Type{Complex}) = Complex{Int}
 
 function eps(z::Complex{T}) where {T<:AbstractFloat}
     x, y = eps(real(z)), eps(imag(z))
+    # inline version of hypot(x,y) since it's not defined until later
     if x < y
        x, y = y, x
     end

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1148,4 +1148,11 @@ _default_type(T::Type{Complex}) = Complex{Int}
 
 ## Machine epsilon for complex ##
 
-eps(z::Complex{T}) where {T<:AbstractFloat} = hypot(eps(real(z)), eps(imag(z)))
+function eps(z::Complex{T}) where {T<:AbstractFloat}
+    x, y = eps(real(z)), eps(imag(z))
+    if x < y
+       x, y = y, x
+    end
+    r = y/x
+    x * sqrt(one(T) + r * r)
+end

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1141,3 +1141,11 @@ function complex(A::AbstractArray{T}) where T
     end
     convert(AbstractArray{typeof(complex(zero(T)))}, A)
 end
+
+## Promotion to complex ##
+
+_default_type(T::Type{Complex}) = Complex{Int}
+
+## Machine epsilon for complex ##
+
+eps(z::Complex{T}) where {T<:AbstractFloat} = hypot(eps(real(z)), eps(imag(z)))

--- a/base/float.jl
+++ b/base/float.jl
@@ -1069,10 +1069,6 @@ julia> 1.0 + eps()/2
 For complex inputs `T`, `eps(T)` is defined as the distance bound to the nearest
 floating-point complex value, i.e. for z=a+ib and the closest floating-point
 complex value z̃=ã+ib̃=fl(a)+ifl(b), |z - z̃| ≤ ε/2.
-```jldoctest
-
-```
-
 """
 eps(::Type{<:AbstractFloat})
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -977,6 +977,8 @@ isodd(x::AbstractFloat) = isinteger(x) && abs(x) ≤ maxintfloat(x) && isodd(Int
     eps(::Type{Float16}) = $(bitcast(Float16, 0x1400))
     eps(::Type{Float32}) = $(bitcast(Float32, 0x34000000))
     eps(::Type{Float64}) = $(bitcast(Float64, 0x3cb0000000000000))
+    eps(::Type{Complex{T}}) where {T<:AbstractFloat} = eps(T)
+    eps(x::Complex{T}) where {T<:AbstractFloat} = eps(norm(x))
     eps() = eps(Float64)
 end
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -978,7 +978,6 @@ isodd(x::AbstractFloat) = isinteger(x) && abs(x) ≤ maxintfloat(x) && isodd(Int
     eps(::Type{Float32}) = $(bitcast(Float32, 0x34000000))
     eps(::Type{Float64}) = $(bitcast(Float64, 0x3cb0000000000000))
     eps(::Type{Complex{T}}) where {T<:AbstractFloat} = eps(T)
-    eps(z::Complex{T}) where {T<:AbstractFloat} = hypot(eps(real(z)), eps(imag(z)))
     eps() = eps(Float64)
 end
 
@@ -1066,6 +1065,14 @@ julia> 1.0 + eps()
 julia> 1.0 + eps()/2
 1.0
 ```
+
+For complex inputs `T`, `eps(T)` is defined as the distance bound to the nearest
+floating-point complex value, i.e. for z=a+ib and the closest floating-point
+complex value z̃=ã+ib̃=fl(a)+ifl(b), |z - z̃| ≤ ε/2.
+```jldoctest
+
+```
+
 """
 eps(::Type{<:AbstractFloat})
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -978,7 +978,7 @@ isodd(x::AbstractFloat) = isinteger(x) && abs(x) ≤ maxintfloat(x) && isodd(Int
     eps(::Type{Float32}) = $(bitcast(Float32, 0x34000000))
     eps(::Type{Float64}) = $(bitcast(Float64, 0x3cb0000000000000))
     eps(::Type{Complex{T}}) where {T<:AbstractFloat} = eps(T)
-    eps(x::Complex{T}) where {T<:AbstractFloat} = eps(norm(x))
+    eps(z::Complex{T}) where {T<:AbstractFloat} = hypot(eps(real(z)), eps(imag(z)))
     eps() = eps(Float64)
 end
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -1068,7 +1068,8 @@ julia> 1.0 + eps()/2
 
 For complex inputs `T`, `eps(T)` is defined as the distance bound to the nearest
 floating-point complex value, i.e. for ``z=a+ib`` and the closest floating-point
-complex value ``z̃=ã+ib̃=fl(a)+ifl(b)``, ``|z - z̃| ≤ ε/2``.
+complex value ``z̃=ã+ib̃=fl(a)+ifl(b)`` where ``fl(x)`` is the closest
+floating-point value to a real ``x``, ``eps(z)`` satisfies ``|z - z̃| ≤ eps(z)/2``.
 """
 eps(::Type{<:AbstractFloat})
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -1067,8 +1067,8 @@ julia> 1.0 + eps()/2
 ```
 
 For complex inputs `T`, `eps(T)` is defined as the distance bound to the nearest
-floating-point complex value, i.e. for `z=a+ib` and the closest floating-point
-complex value `z̃=ã+ib̃=fl(a)+ifl(b)`, `|z - z̃| ≤ ε/2`.
+floating-point complex value, i.e. for ``z=a+ib`` and the closest floating-point
+complex value ``z̃=ã+ib̃=fl(a)+ifl(b)``, ``|z - z̃| ≤ ε/2``.
 """
 eps(::Type{<:AbstractFloat})
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -977,7 +977,7 @@ isodd(x::AbstractFloat) = isinteger(x) && abs(x) ≤ maxintfloat(x) && isodd(Int
     eps(::Type{Float16}) = $(bitcast(Float16, 0x1400))
     eps(::Type{Float32}) = $(bitcast(Float32, 0x34000000))
     eps(::Type{Float64}) = $(bitcast(Float64, 0x3cb0000000000000))
-    eps(::Type{Complex{T}}) where {T<:AbstractFloat} = eps(T)
+    eps(::Type{Complex{T}}) where {T<:AbstractFloat} = sqrt(2*one(T))*eps(T)
     eps() = eps(Float64)
 end
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -1067,8 +1067,8 @@ julia> 1.0 + eps()/2
 ```
 
 For complex inputs `T`, `eps(T)` is defined as the distance bound to the nearest
-floating-point complex value, i.e. for z=a+ib and the closest floating-point
-complex value z̃=ã+ib̃=fl(a)+ifl(b), |z - z̃| ≤ ε/2.
+floating-point complex value, i.e. for `z=a+ib` and the closest floating-point
+complex value `z̃=ã+ib̃=fl(a)+ifl(b)`, `|z - z̃| ≤ ε/2`.
 """
 eps(::Type{<:AbstractFloat})
 

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -933,10 +933,10 @@ end
 end
 
 @testset "eps" begin
-    @test eps(1.0+1.0im) == 3.1401849173675503e-16
-    @test eps(Complex128) == eps(1.0+1.0im)
-    @test eps(Complex64) == 1.1920929f-7
-    @test eps(Float32(1.0)+Float32(1.0)im) == eps(Complex{Float32})
+    @test eps(1.0+1.0im) === 3.1401849173675503e-16
+    @test eps(Complex128) === eps(1.0+1.0im)
+    @test eps(Complex64) === 1.6858739f-7
+    @test eps(Float32(1.0)+Float32(1.0)im) === eps(Complex{Float32})
 end
 
 @testset "cis" begin

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -932,6 +932,13 @@ end
     end
 end
 
+@testset "eps" begin
+    @test eps(1.0+1.0im) == 3.1401849173675503e-16
+    @test eps(Complex128) == eps(1.0+1.0im)
+    @test eps(Complex64) == 1.1920929f-7
+    @test eps(Float32(1.0)+Float32(1.0)im) == eps(Complex{Float32})
+end
+
 @testset "cis" begin
     @test cis(0.0+1.0im) ≈ 0.367879441171442321595523770161460867445811131031767834507836+0.0im
     @test cis(1.0+0.0im) ≈ 0.54030230586813971740093660744297660373231042061+0.84147098480789650665250232163029899962256306079im


### PR DESCRIPTION
## Summary
- Adds support for complex numbers in `eps()` function
- Implements `eps(z::Complex{T})` using an optimized inline version of `hypot`
- This is a rebased version of PR #21858

## Background
This PR adds the ability to compute machine epsilon for complex numbers, which is useful for numerical computing with complex values. The implementation provides the distance bound to the nearest floating-point complex value.

## Changes
- Added `eps(z::Complex{T})` method in `base/complex.jl`
- Added `eps(::Type{Complex{T}})` method in `base/float.jl`
- Includes appropriate documentation

🤖 Generated with [Claude Code](https://claude.ai/code)