### PR TITLE
Add Base.active_manifest()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,7 +58,8 @@ New library features
 * `sort(keys(::Dict))` and `sort(values(::Dict))` now automatically collect, they previously threw ([#56978]).
 * `Base.AbstractOneTo` is added as a supertype of one-based axes, with `Base.OneTo` as its subtype ([#56902]).
 * `takestring!(::IOBuffer)` removes the content from the buffer, returning the content as a `String`.
-* New `Base.active_manifest()` function to return the path of the active manifest, like `Base.active_project()` ([#57937]).
+* New `Base.active_manifest()` function to return the path of the active manifest, like `Base.active_project()`.
+  Also can return the manifest that would be used for a given project file ([#57937]).
 
 Standard library changes
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,7 @@ New library features
 * `sort(keys(::Dict))` and `sort(values(::Dict))` now automatically collect, they previously threw ([#56978]).
 * `Base.AbstractOneTo` is added as a supertype of one-based axes, with `Base.OneTo` as its subtype ([#56902]).
 * `takestring!(::IOBuffer)` removes the content from the buffer, returning the content as a `String`.
+* New `Base.active_manifest()` function to return the path of the active manifest, like `Base.active_project()` ([#57937]).
 
 Standard library changes
 ------------------------

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -371,6 +371,21 @@ function set_active_project(projfile::Union{AbstractString,Nothing})
     end
 end
 
+"""
+    active_manifest()
+
+Return the path of the active manifest file. See [`Project environments`](@ref) for
+details on the difference between a project and a manifest, and the naming options and
+their priority when searching for a manifest file.
+
+See also [`Base.active_project`](@ref), [`Base.set_active_project`](@ref).
+"""
+function active_manifest(search_load_path::Bool=true)
+    proj = active_project(search_load_path)
+    proj === nothing && return nothing
+    return project_file_manifest_path(proj)
+end
+
 
 """
     load_path()

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -373,19 +373,19 @@ end
 
 """
     active_manifest()
+    active_manifest(project_file::AbstractString)
 
-Return the path of the active manifest file. See [`Project environments`](@ref) for
-details on the difference between a project and a manifest, and the naming options and
-their priority when searching for a manifest file.
+Return the path of the active manifest file, or the manifest file that would be used for a given `project_file`.
+See [`Project environments`](@ref) for details on the difference between a project and a manifest, and the naming
+options and their priority in package loading.
 
 See also [`Base.active_project`](@ref), [`Base.set_active_project`](@ref).
 """
-function active_manifest(search_load_path::Bool=true)
-    proj = active_project(search_load_path)
-    proj === nothing && return nothing
-    return project_file_manifest_path(proj)
+function active_manifest(project_file::Union{AbstractString,Nothing}=nothing, search_load_path::Bool=true)
+    project_file = something(project_file, active_project(search_load_path))
+    project_file === nothing && return nothing
+    return project_file_manifest_path(project_file)
 end
-
 
 """
     load_path()

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -827,6 +827,7 @@ function project_file_manifest_path(project_file::String)::Union{Nothing,String}
         manifest_path === missing || return manifest_path
     end
     dir = abspath(dirname(project_file))
+    isfile_casesensitive(project_file) || return nothing
     d = parsed_toml(project_file)
     base_manifest = workspace_manifest(project_file)
     if base_manifest !== nothing

--- a/base/public.jl
+++ b/base/public.jl
@@ -52,6 +52,7 @@ public
     DL_LOAD_PATH,
     load_path,
     active_project,
+    active_manifest,
 
 # Reflection and introspection
     get_extension,

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -44,6 +44,7 @@ ans
 err
 Base.active_project
 Base.set_active_project
+Base.active_manifest
 ```
 
 ## [Keywords](@id Keywords)


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/57924

This PR adds a new `Base.active_manifest()` function that returns the path of the active manifest file, similar to how `Base.active_project()` returns the active project file path.

```julia
julia> Base.active_project()
"/Users/ian/.julia/environments/v1.13/Project.toml"

julia> Base.active_manifest()
"/Users/ian/.julia/environments/v1.13/Manifest.toml"

(@v1.13) pkg> activate --temp
  Activating new project at `/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCVFBB`

julia> Base.active_project()
"/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_SCVFBB/Project.toml"

julia> Base.active_manifest()

julia>
```

The function also accepts an optional `project_file` argument to return the manifest that would be used for a given project file.

Rebased version of JuliaLang/julia#57937

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>