### PR TITLE
Forward the CPU target to the build-time precompilation invocation.

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -347,8 +347,9 @@ generate_precompile_statements() = try # Make sure `ansi_enablecursor` is printe
             Base.Precompilation.precompilepkgs(;fancyprint=true);
             $precompile_script
             """
+        cpu_target = unsafe_string(Base.JLOptions().cpu_target)
         p = run(pipeline(addenv(`$(julia_exepath()) -O0 --trace-compile=$tmp_proc --sysimage $sysimg
-                --cpu-target=native --startup-file=no --color=yes --project=$(pkgpath)`, procenv),
+                --cpu-target=$cpu_target --startup-file=no --color=yes --project=$(pkgpath)`, procenv),
                  stdin=IOBuffer(s), stderr=debug_output, stdout=debug_output))
         n_step1 = 0
         for f in (tmp_prec, tmp_proc)


### PR DESCRIPTION
While debugging an issue with `--cpu-target=native` on RISC-V, I noticed that the output of `generate_precompile.jl` is being fed to a Julia process invoked with `--cpu-target=native` instead of the one specified by the user. I'm not very familiar with the precompilation script logic, but it seems like we should be using the target that the user specified (or fall back to `"native"`)?