### PR TITLE
Do not needlessly disable CPU features.

### DIFF
--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -992,19 +992,6 @@ static std::string jl_get_cpu_features_llvm(void)
             attr.append(ele.getKey().str());
         }
     }
-    // Explicitly disabled features need to be added at the end so that
-    // they are not re-enabled by other features that implies them by default.
-    for (auto &ele: HostFeatures) {
-        if (!ele.getValue()) {
-            if (!attr.empty()) {
-                attr.append(",-");
-            }
-            else {
-                attr.append("-");
-            }
-            attr.append(ele.getKey().str());
-        }
-    }
     return attr;
 }
 


### PR DESCRIPTION
On QEMU's RISC-V cpu, LLVM's `getHostCPUFeatures` reports:

```
+zksed,+zkne,+zksh,+zfh,+zfhmin,+zacas,+v,+f,+c,+zvknha,+a,+zfa,+ztso,+zicond,+zihintntl,+zvbb,+zvksh,+zvkg,+zbkb,+zvkned,+zvbc,+zbb,+zvfhmin,+zbkc,+d,+i,+zknh,+zicboz,+zbs,+zvksed,+zbc,+zba,+zvknhb,+zknd,+zvkt,+zbkx,+zkt,+zvfh,+zvkb,+m
```

We change that to:

```
+zksed,+zkne,+zksh,+zfh,+zfhmin,+zacas,+v,+f,+c,+zvknha,+a,+zfa,+ztso,+zicond,+zihintntl,+zvbb,+zvksh,+zvkg,+zbkb,+zvkned,+zvbc,+zbb,+zvfhmin,+zbkc,+d,+i,+zknh,+zicboz,+zbs,+zvksed,+zbc,+zba,+zvknhb,+zknd,+zvkt,+zbkx,+zkt,+zvfh,+zvkb,+m,-zcmop,-zca,-zcd,-zcb,-zve64d,-zve64x,-zve64f,-zawrs,-zve32x,-zimop,-zihintpause,-zcf,-zve32f
```

i.e. we add `-zcmop,-zca,-zcd,-zcb,-zve64d,-zve64x,-zve64f,-zawrs,-zve32x,-zimop,-zihintpause,-zcf,-zve32f`, disabling stuff `zve*` after first enabling `v` (which includes `zvl*b`). That's not valid:

```
LLVM ERROR: 'zvl*b' requires 'v' or 'zve*' extension to also be specified
```

... so disable this post-processing of LLVM feature sets and trust what it spits out. AFAICT this only matters for the fallback path of `processor.cpp`, so shouldn't impact most users.