### PR TITLE
improve `cosc(::Float32)` and `cosc(::Float64)` accuracy

### DIFF
--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1182,14 +1182,7 @@ polynomial_3;
 
 =#
 
-struct _CosCardinalEvaluationScheme{
-    T <: AbstractFloat,
-    PolynomialsCloseToZero <: (Tuple{Tuple{T, P}, Vararg{Tuple{T, P}}} where {P <: Tuple{T, Vararg{T}}}),
-}
-    polynomials_close_to_origin::PolynomialsCloseToZero
-end
-
-function (sch::_CosCardinalEvaluationScheme)(x::AbstractFloat)
+function _cos_cardinal_eval(x::AbstractFloat, polynomials_close_to_origin::NTuple)
     function choose_poly(a::AbstractFloat, polynomials_close_to_origin::NTuple{2})
         ((b1, p0), (_, p1)) = polynomials_close_to_origin
         if a ≤ b1
@@ -1226,30 +1219,26 @@ function (sch::_CosCardinalEvaluationScheme)(x::AbstractFloat)
 end
 
 const _cosc_f32 = let b = Float32 ∘ Float16
-    _CosCardinalEvaluationScheme(
-        (
-            (b(0.27), (-3.289868f0, 3.246966f0, -1.1443111f0, 0.20542027f0)),
-            (b(0.45), (-3.2898617f0, 3.2467577f0, -1.1420113f0, 0.1965574f0)),
-        ),
+    (
+        (b(0.27), (-3.289868f0, 3.246966f0, -1.1443111f0, 0.20542027f0)),
+        (b(0.45), (-3.2898617f0, 3.2467577f0, -1.1420113f0, 0.1965574f0)),
     )
 end
 
 const _cosc_f64 = let b = Float64 ∘ Float16
-    _CosCardinalEvaluationScheme(
-        (
-            (b(0.17), (-3.289868133696453, 3.2469697011333203, -1.1445109446992934, 0.20918277797812262, -0.023460519561502552, 0.001772485141534688)),
-            (b(0.27), (-3.289868133695205, 3.246969700970421, -1.1445109360543062, 0.20918254132488637, -0.023457115021035743, 0.0017515112964895303)),
-            (b(0.34), (-3.289868133634355, 3.246969697075094, -1.1445108347839286, 0.209181201609773, -0.023448079433318045, 0.001726628430505518)),
-            (b(0.4),  (-3.289868133074254, 3.2469696736659346, -1.1445104406286049, 0.20917785794416457, -0.02343378376047161, 0.0017019796223768677)),
-        ),
+    (
+        (b(0.17), (-3.289868133696453, 3.2469697011333203, -1.1445109446992934, 0.20918277797812262, -0.023460519561502552, 0.001772485141534688)),
+        (b(0.27), (-3.289868133695205, 3.246969700970421, -1.1445109360543062, 0.20918254132488637, -0.023457115021035743, 0.0017515112964895303)),
+        (b(0.34), (-3.289868133634355, 3.246969697075094, -1.1445108347839286, 0.209181201609773, -0.023448079433318045, 0.001726628430505518)),
+        (b(0.4),  (-3.289868133074254, 3.2469696736659346, -1.1445104406286049, 0.20917785794416457, -0.02343378376047161, 0.0017019796223768677)),
     )
 end
 
 function _cosc(x::Float32)
-    _cosc_f32(x)
+    _cos_cardinal_eval(x, _cosc_f32)
 end
 function _cosc(x::Float64)
-    _cosc_f64(x)
+    _cos_cardinal_eval(x, _cosc_f64)
 end
 
 # hard-code Float64/Float32 Taylor series, with coefficients

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1208,7 +1208,6 @@ function _cos_cardinal_eval(x::AbstractFloat, polynomials_close_to_origin::NTupl
         end
     end
     a = abs(x)
-    polynomials_close_to_origin = sch.polynomials_close_to_origin
     if (polynomials_close_to_origin !== ()) && (a ≤ polynomials_close_to_origin[end][1])
         x * evalpoly(x * x, choose_poly(a, polynomials_close_to_origin))
     elseif isinf(x)

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1104,6 +1104,9 @@ Return a `T(NaN)` if `isnan(x)`.
 See also [`sinc`](@ref).
 """
 cosc(x::Number) = _cosc(float(x))
+function _cosc_generic(x)
+    ((pi*x)*cospi(x)-sinpi(x))/((pi*x)*x)
+end
 function _cosc(x::Number)
     # naive cosc formula is susceptible to catastrophic
     # cancellation error near x=0, so we use the Taylor series
@@ -1124,17 +1127,17 @@ function _cosc(x::Number)
         end
         return π*s
     else
-        return isinf_real(x) ? zero(x) : ((pi*x)*cospi(x)-sinpi(x))/((pi*x)*x)
+        return isinf_real(x) ? zero(x) : _cosc_generic(x)
     end
 end
 # hard-code Float64/Float32 Taylor series, with coefficients
 #  Float64.([(-1)^n*big(pi)^(2n)/((2n+1)*factorial(2n-1)) for n = 1:6])
 _cosc(x::Union{Float64,ComplexF64}) =
     fastabs(x) < 0.14 ? x*evalpoly(x^2, (-3.289868133696453, 3.2469697011334144, -1.1445109447325053, 0.2091827825412384, -0.023460810354558236, 0.001781145516372852)) :
-    isinf_real(x) ? zero(x) : ((pi*x)*cospi(x)-sinpi(x))/((pi*x)*x)
+    isinf_real(x) ? zero(x) : _cosc_generic(x)
 _cosc(x::Union{Float32,ComplexF32}) =
     fastabs(x) < 0.26f0 ? x*evalpoly(x^2, (-3.289868f0, 3.2469697f0, -1.144511f0, 0.20918278f0)) :
-    isinf_real(x) ? zero(x) : ((pi*x)*cospi(x)-sinpi(x))/((pi*x)*x)
+    isinf_real(x) ? zero(x) : _cosc_generic(x)
 _cosc(x::Float16) = Float16(_cosc(Float32(x)))
 _cosc(x::ComplexF16) = ComplexF16(_cosc(ComplexF32(x)))
 

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1233,11 +1233,13 @@ const _cosc_f64 = let b = Float64 ∘ Float16
     )
 end
 
-function _cosc(x::Float32)
-    _cos_cardinal_eval(x, _cosc_f32)
-end
-function _cosc(x::Float64)
-    _cos_cardinal_eval(x, _cosc_f64)
+function _cosc(x::Union{Float32, Float64})
+    if x isa Float32
+        pols = _cosc_f32
+    elseif x isa Float64
+        pols = _cosc_f64
+    end
+    _cos_cardinal_eval(x, pols)
 end
 
 # hard-code Float64/Float32 Taylor series, with coefficients

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1190,39 +1190,34 @@ struct _CosCardinalEvaluationScheme{
 end
 
 function (sch::_CosCardinalEvaluationScheme)(x::AbstractFloat)
+    function choose_poly(a::AbstractFloat, polynomials_close_to_origin::NTuple{2})
+        ((b1, p0), (_, p1)) = polynomials_close_to_origin
+        if a ≤ b1
+            p0
+        else
+            p1
+        end
+    end
+    function choose_poly(a::AbstractFloat, polynomials_close_to_origin::NTuple{4})
+        ((b1, p0), (b2, p1), (b3, p2), (_, p3)) = polynomials_close_to_origin
+        if a ≤ b2  # hardcoded binary search
+            if a ≤ b1
+                p0
+            else
+                p1
+            end
+        else
+            if a ≤ b3
+                p2
+            else
+                p3
+            end
+        end
+    end
     a = abs(x)
     polynomials_close_to_origin = sch.polynomials_close_to_origin
     if (polynomials_close_to_origin !== ()) && (a ≤ polynomials_close_to_origin[end][1])
-        let
-            if length(polynomials_close_to_origin) == 1  # hardcode for each allowed tuple size
-                p = only(polynomials_close_to_origin)[2]
-            elseif length(polynomials_close_to_origin) == 2
-                p = let ((b1, p0), (_, p1)) = polynomials_close_to_origin
-                    if a ≤ b1  # hardcoded binary search
-                        p0
-                    else
-                        p1
-                    end
-                end
-            elseif length(polynomials_close_to_origin) == 4
-                p = let ((b1, p0), (b2, p1), (b3, p2), (_, p3)) = polynomials_close_to_origin
-                    if a ≤ b2  # hardcoded binary search
-                        if a ≤ b1
-                            p0
-                        else
-                            p1
-                        end
-                    else
-                        if a ≤ b3
-                            p2
-                        else
-                            p3
-                        end
-                    end
-                end
-            end
-            x * evalpoly(x * x, p)
-        end
+        x * evalpoly(x * x, choose_poly(a, polynomials_close_to_origin))
     elseif isinf(x)
         typeof(x)(0)
     else

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1105,7 +1105,8 @@ See also [`sinc`](@ref).
 """
 cosc(x::Number) = _cosc(float(x))
 function _cosc_generic(x)
-    ((pi*x)*cospi(x)-sinpi(x))/((pi*x)*x)
+    pi_x = pi * x
+    (pi_x*cospi(x)-sinpi(x))/(pi_x*x)
 end
 function _cosc(x::Number)
     # naive cosc formula is susceptible to catastrophic

--- a/test/math.jl
+++ b/test/math.jl
@@ -50,6 +50,7 @@ has_fma = Dict(
             @test Inf == @inferred ulp_error(NaN, 3.0)
             @test Inf == @inferred ulp_error(3.0, NaN)
             @test Inf == @inferred ulp_error(NaN, Inf)
+            @test Inf == @inferred ulp_error(Inf, NaN)
             @test Inf == @inferred ulp_error(Inf, -Inf)
             @test Inf == @inferred ulp_error(-Inf, Inf)
             @test Inf == @inferred ulp_error(0.0, Inf)

--- a/test/math.jl
+++ b/test/math.jl
@@ -28,6 +28,38 @@ has_fma = Dict(
     BigFloat => true,
 )
 
+@testset "meta test: ULPError" begin
+    @testset "edge cases" begin
+        @testset "zero error - two equivalent values" begin
+            @test 0 == @inferred ulp_error(NaN, NaN)
+            @test 0 == @inferred ulp_error(-NaN, -NaN)
+            @test 0 == @inferred ulp_error(-NaN, NaN)
+            @test 0 == @inferred ulp_error(NaN, -NaN)
+            @test 0 == @inferred ulp_error(Inf, Inf)
+            @test 0 == @inferred ulp_error(-Inf, -Inf)
+            @test 0 == @inferred ulp_error(0.0, 0.0)
+            @test 0 == @inferred ulp_error(-0.0, -0.0)
+            @test 0 == @inferred ulp_error(-0.0, 0.0)
+            @test 0 == @inferred ulp_error(0.0, -0.0)
+            @test 0 == @inferred ulp_error(3.0, 3.0)
+            @test 0 == @inferred ulp_error(-3.0, -3.0)
+        end
+        @testset "infinite error" begin
+            @test Inf == @inferred ulp_error(NaN, 0.0)
+            @test Inf == @inferred ulp_error(0.0, NaN)
+            @test Inf == @inferred ulp_error(NaN, 3.0)
+            @test Inf == @inferred ulp_error(3.0, NaN)
+            @test Inf == @inferred ulp_error(NaN, Inf)
+            @test Inf == @inferred ulp_error(Inf, -Inf)
+            @test Inf == @inferred ulp_error(-Inf, Inf)
+            @test Inf == @inferred ulp_error(0.0, Inf)
+            @test Inf == @inferred ulp_error(Inf, 0.0)
+            @test Inf == @inferred ulp_error(3.0, Inf)
+            @test Inf == @inferred ulp_error(Inf, 3.0)
+        end
+    end
+end
+
 @testset "clamp" begin
     let
         @test clamp(0, 1, 3) == 1

--- a/test/math.jl
+++ b/test/math.jl
@@ -59,6 +59,12 @@ has_fma = Dict(
             @test Inf == @inferred ulp_error(Inf, 3.0)
         end
     end
+    @testset "faithful" begin
+        for x in (-2.0, -0.3, 0.1, 1.0)
+            @test 1 == @inferred ulp_error(x, nextfloat(x, 1))
+            @test 1 == @inferred ulp_error(x, nextfloat(x, -1))
+        end
+    end
 end
 
 @testset "clamp" begin

--- a/test/math.jl
+++ b/test/math.jl
@@ -740,9 +740,7 @@ end
 
     @testset "accuracy of `cosc` around the origin" begin
         for t in (Float32, Float64)
-            for x in range(start = t(-1), stop = t(1), length = 5000)
-                @test ulp_error(cosc, x) < 4
-            end
+            @test ulp_error_maximum(cosc, range(start = t(-1), stop = t(1), length = 5000)) < 4
         end
     end
 end

--- a/test/math.jl
+++ b/test/math.jl
@@ -3,6 +3,9 @@
 include("testhelpers/EvenIntegers.jl")
 using .EvenIntegers
 
+include("testhelpers/ULPError.jl")
+using .ULPError
+
 using Random
 using LinearAlgebra
 using Base.Experimental: @force_compile
@@ -684,6 +687,14 @@ end
     setprecision(256) do
         @test cosc(big"0.5") ≈ big"-1.273239544735162686151070106980114896275677165923651589981338752471174381073817" rtol=1e-76
         @test cosc(big"0.499") ≈ big"-1.272045747741181369948389133250213864178198918667041860771078493955590574971317" rtol=1e-76
+    end
+
+    @testset "accuracy of `cosc` around the origin" begin
+        for t in (Float32, Float64)
+            for x in range(start = t(-1), stop = t(1), length = 5000)
+                @test ulp_error(cosc, x) < 4
+            end
+        end
     end
 end
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -29,6 +29,10 @@ has_fma = Dict(
 )
 
 @testset "meta test: ULPError" begin
+    examples_f64 = (-3e0, -2e0, -1e0, -1e-1, -1e-10, -0e0, 0e0, 1e-10, 1e-1, 1e0, 2e0, 3e0)::Tuple{Vararg{Float64}}
+    examples_f16 = Float16.(examples_f64)
+    examples_f32 = Float32.(examples_f64)
+    examples = (examples_f16..., examples_f32..., examples_f64...)
     @testset "edge cases" begin
         @testset "zero error - two equivalent values" begin
             @test 0 == @inferred ulp_error(NaN, NaN)
@@ -60,9 +64,15 @@ has_fma = Dict(
         end
     end
     @testset "faithful" begin
-        for x in (-2.0, -0.3, 0.1, 1.0)
+        for x in examples
             @test 1 == @inferred ulp_error(x, nextfloat(x, 1))
             @test 1 == @inferred ulp_error(x, nextfloat(x, -1))
+        end
+    end
+    @testset "midpoint" begin
+        for x in examples
+            a = abs(x)
+            @test 1 == 2 * @inferred ulp_error(copysign((widen(a) + nextfloat(a, 1))/2, x), x)
         end
     end
 end

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -1,0 +1,55 @@
+module ULPError
+    export ulp_error, ulp_error_maximum
+    @noinline function throw_invalid()
+        throw(ArgumentError("invalid"))
+    end
+    function ulp_error(accurate::AbstractFloat, approximate::AbstractFloat)
+        if isnan(accurate)
+            @noinline throw_invalid()
+        end
+        if isnan(approximate)
+            @noinline throw_invalid()
+        end
+        # the ULP error is usually not required to great accuracy, so `Float32` should be precise enough
+        zero_return = Float32(0)
+        inf_return = Float32(Inf)
+        if isinf(accurate) || iszero(accurate)  # handle floating-point edge cases
+            if isinf(accurate)
+                if isinf(approximate) && (signbit(accurate) == signbit(approximate))
+                    return zero_return
+                end
+                return inf_return
+            end
+            # `iszero(accurate)`
+            if iszero(approximate)
+                return zero_return
+            end
+            return inf_return
+        end
+        # assuming `precision(BigFloat)` is great enough
+        acc = if accurate isa BigFloat
+            accurate
+        else
+            BigFloat(accurate)::BigFloat
+        end
+        err = abs(Float32((approximate - acc) / eps(approximate))::Float32)
+        if isnan(err)
+            @noinline throw_invalid()  # unexpected
+        end
+        err
+    end
+    function ulp_error(accurate::Acc, approximate::App, x::AbstractFloat) where {Acc, App}
+        acc = accurate(x)
+        app = approximate(x)
+        ulp_error(acc, app)
+    end
+    function ulp_error(func::Func, x::AbstractFloat) where {Func}
+        ulp_error(func ∘ BigFloat, func, x)
+    end
+    function ulp_error_maximum(func::Func, iterator) where {Func}
+        function f(x::AbstractFloat)
+            ulp_error(func, x)
+        end
+        maximum(f, iterator)
+    end
+end

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -6,15 +6,17 @@ module ULPError
         throw(ArgumentError("invalid"))
     end
     function ulp_error(accurate::AbstractFloat, approximate::AbstractFloat)
-        if isnan(accurate)
-            @noinline throw_invalid()
-        end
-        if isnan(approximate)
-            @noinline throw_invalid()
-        end
         # the ULP error is usually not required to great accuracy, so `Float32` should be precise enough
         zero_return = Float32(0)
         inf_return = Float32(Inf)
+        let accur_is_nan = isnan(accurate), approx_is_nan = isnan(approximate)
+            if accur_is_nan || approx_is_nan
+                if accur_is_nan === approx_is_nan
+                    return zero_return
+                end
+                return inf_return
+            end
+        end
         if isinf(accurate) || iszero(accurate)  # handle floating-point edge cases
             if isinf(accurate)
                 if isinf(approximate) && (signbit(accurate) == signbit(approximate))

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -15,23 +15,18 @@ module ULPError
         approx_is_inf = isinf(approximate)
         approx_is_nan = isnan(approximate)
         if accur_is_nan || approx_is_nan
-            if accur_is_nan === approx_is_nan
-                return zero_return
+            return if accur_is_nan === approx_is_nan
+                zero_return
+            else
+                inf_return
             end
-            return inf_return
         end
         if accur_is_inf || iszero(accurate)
-            if accur_is_inf
-                if approx_is_inf && (signbit(accurate) == signbit(approximate))
-                    return zero_return
-                end
-                return inf_return
+            return if (approx_is_inf && (signbit(accurate) == signbit(approximate))) || iszero(approximate)
+                zero_return
+            else
+                inf_return
             end
-            # `iszero(accurate)`
-            if iszero(approximate)
-                return zero_return
-            end
-            return inf_return
         end
         if approx_is_inf
             return inf_return

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -10,29 +10,28 @@ module ULPError
         zero_return = Float32(0)
         inf_return = Float32(Inf)
         # handle floating-point edge cases
-        let accur_is_nan = isnan(accurate), approx_is_nan = isnan(approximate)
-            if accur_is_nan || approx_is_nan
-                if accur_is_nan === approx_is_nan
-                    return zero_return
-                end
-                return inf_return
-            end
-        end
+        accur_is_nan = isnan(accurate)
+        accur_is_inf = isinf(accurate)
         approx_is_inf = isinf(approximate)
-        let accur_is_inf = isinf(accurate)
-            if accur_is_inf || iszero(accurate)
-                if accur_is_inf
-                    if approx_is_inf && (signbit(accurate) == signbit(approximate))
-                        return zero_return
-                    end
-                    return inf_return
-                end
-                # `iszero(accurate)`
-                if iszero(approximate)
+        approx_is_nan = isnan(approximate)
+        if accur_is_nan || approx_is_nan
+            if accur_is_nan === approx_is_nan
+                return zero_return
+            end
+            return inf_return
+        end
+        if accur_is_inf || iszero(accurate)
+            if accur_is_inf
+                if approx_is_inf && (signbit(accurate) == signbit(approximate))
                     return zero_return
                 end
                 return inf_return
             end
+            # `iszero(accurate)`
+            if iszero(approximate)
+                return zero_return
+            end
+            return inf_return
         end
         if approx_is_inf
             return inf_return

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -17,10 +17,11 @@ module ULPError
                 return inf_return
             end
         end
+        approx_is_inf = isinf(approximate)
         let accur_is_inf = isinf(accurate)
             if accur_is_inf || iszero(accurate)  # handle floating-point edge cases
                 if accur_is_inf
-                    if isinf(approximate) && (signbit(accurate) == signbit(approximate))
+                    if approx_is_inf && (signbit(accurate) == signbit(approximate))
                         return zero_return
                     end
                     return inf_return
@@ -31,6 +32,9 @@ module ULPError
                 end
                 return inf_return
             end
+        end
+        if approx_is_inf
+            return inf_return
         end
         # assuming `precision(BigFloat)` is great enough
         acc = if accurate isa BigFloat

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -10,20 +10,22 @@ module ULPError
         zero_return = 0f0
         inf_return = Inf32
         # handle floating-point edge cases
-        accur_is_nan = isnan(accurate)
-        approx_is_nan = isnan(approximate)
-        if accur_is_nan || approx_is_nan
-            return if accur_is_nan === approx_is_nan
-                zero_return
-            else
-                inf_return
+        if !(isfinite(accurate) && isfinite(approximate))
+            accur_is_nan = isnan(accurate)
+            approx_is_nan = isnan(approximate)
+            if accur_is_nan || approx_is_nan
+                return if accur_is_nan === approx_is_nan
+                    zero_return
+                else
+                    inf_return
+                end
             end
-        end
-        if isinf(approximate)
-            return if isinf(accurate) && (signbit(accurate) == signbit(approximate))
-                zero_return
-            else
-                inf_return
+            if isinf(approximate)
+                return if isinf(accurate) && (signbit(accurate) == signbit(approximate))
+                    zero_return
+                else
+                    inf_return
+                end
             end
         end
         # assuming `precision(BigFloat)` is great enough

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -41,7 +41,7 @@ module ULPError
         ulp_error(acc, app)
     end
     function ulp_error(func::Func, x::AbstractFloat) where {Func}
-        ulp_error(func ∘ BigFloat, func, x)
+        ulp_error(func, func, x)
     end
     function ulp_error_maximum(func::Func, iterator) where {Func}
         function f(x::AbstractFloat)

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -10,10 +10,12 @@ module ULPError
         zero_return = Float32(0)
         inf_return = Float32(Inf)
         # handle floating-point edge cases
+        accur_is_zero = iszero(accurate)
         accur_is_nan = isnan(accurate)
         accur_is_inf = isinf(accurate)
         approx_is_inf = isinf(approximate)
         approx_is_nan = isnan(approximate)
+        approx_is_zero = iszero(approximate)
         if accur_is_nan || approx_is_nan
             return if accur_is_nan === approx_is_nan
                 zero_return
@@ -21,8 +23,8 @@ module ULPError
                 inf_return
             end
         end
-        if accur_is_inf || iszero(accurate)
-            return if (approx_is_inf && (signbit(accurate) == signbit(approximate))) || iszero(approximate)
+        if accur_is_inf || accur_is_zero
+            return if (accur_is_inf && approx_is_inf && (signbit(accurate) == signbit(approximate))) || (accur_is_zero && approx_is_zero)
                 zero_return
             else
                 inf_return

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -42,9 +42,6 @@ module ULPError
         ulp_error(func ∘ BigFloat, func, x)
     end
     function ulp_error_maximum(func::Func, iterator) where {Func}
-        function f(x::AbstractFloat)
-            ulp_error(func, x)
-        end
-        maximum(f, iterator)
+        maximum(Base.Fix1(ulp_error, func), iterator)
     end
 end

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -28,12 +28,7 @@ module ULPError
                 end
             end
         end
-        # assuming `precision(BigFloat)` is great enough
-        acc = if accurate isa BigFloat
-            accurate
-        else
-            BigFloat(accurate)::BigFloat
-        end
+        acc = Float64(accurate)::Float64
         err = abs(Float32((approximate - acc) / eps(approximate))::Float32)
         if isnan(err)
             @noinline throw_invalid()  # unexpected

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -17,18 +17,20 @@ module ULPError
                 return inf_return
             end
         end
-        if isinf(accurate) || iszero(accurate)  # handle floating-point edge cases
-            if isinf(accurate)
-                if isinf(approximate) && (signbit(accurate) == signbit(approximate))
+        let accur_is_inf = isinf(accurate)
+            if accur_is_inf || iszero(accurate)  # handle floating-point edge cases
+                if accur_is_inf
+                    if isinf(approximate) && (signbit(accurate) == signbit(approximate))
+                        return zero_return
+                    end
+                    return inf_return
+                end
+                # `iszero(accurate)`
+                if iszero(approximate)
                     return zero_return
                 end
                 return inf_return
             end
-            # `iszero(accurate)`
-            if iszero(approximate)
-                return zero_return
-            end
-            return inf_return
         end
         # assuming `precision(BigFloat)` is great enough
         acc = if accurate isa BigFloat

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -2,9 +2,6 @@
 
 module ULPError
     export ulp_error, ulp_error_maximum
-    @noinline function throw_invalid()
-        throw(ArgumentError("invalid"))
-    end
     function ulp_error(accurate::AbstractFloat, approximate::AbstractFloat)
         # the ULP error is usually not required to great accuracy, so `Float32` should be precise enough
         zero_return = 0f0
@@ -29,11 +26,7 @@ module ULPError
             end
         end
         acc = Float64(accurate)::Float64
-        err = abs(Float32((approximate - acc) / eps(approximate))::Float32)
-        if isnan(err)
-            @noinline throw_invalid()  # unexpected
-        end
-        err
+        abs(Float32((approximate - acc) / eps(approximate))::Float32)
     end
     function ulp_error(accurate::Acc, approximate::App, x::AbstractFloat) where {Acc, App}
         acc = accurate(x)

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -10,12 +10,10 @@ module ULPError
         zero_return = Float32(0)
         inf_return = Float32(Inf)
         # handle floating-point edge cases
-        accur_is_zero = iszero(accurate)
         accur_is_nan = isnan(accurate)
         accur_is_inf = isinf(accurate)
         approx_is_inf = isinf(approximate)
         approx_is_nan = isnan(approximate)
-        approx_is_zero = iszero(approximate)
         if accur_is_nan || approx_is_nan
             return if accur_is_nan === approx_is_nan
                 zero_return

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -9,6 +9,7 @@ module ULPError
         # the ULP error is usually not required to great accuracy, so `Float32` should be precise enough
         zero_return = Float32(0)
         inf_return = Float32(Inf)
+        # handle floating-point edge cases
         let accur_is_nan = isnan(accurate), approx_is_nan = isnan(approximate)
             if accur_is_nan || approx_is_nan
                 if accur_is_nan === approx_is_nan
@@ -19,7 +20,7 @@ module ULPError
         end
         approx_is_inf = isinf(approximate)
         let accur_is_inf = isinf(accurate)
-            if accur_is_inf || iszero(accurate)  # handle floating-point edge cases
+            if accur_is_inf || iszero(accurate)
                 if accur_is_inf
                     if approx_is_inf && (signbit(accurate) == signbit(approximate))
                         return zero_return

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -23,15 +23,12 @@ module ULPError
                 inf_return
             end
         end
-        if accur_is_inf || accur_is_zero
-            return if (accur_is_inf && approx_is_inf && (signbit(accurate) == signbit(approximate))) || (accur_is_zero && approx_is_zero)
+        if approx_is_inf
+            return if accur_is_inf && (signbit(accurate) == signbit(approximate))
                 zero_return
             else
                 inf_return
             end
-        end
-        if approx_is_inf
-            return inf_return
         end
         # assuming `precision(BigFloat)` is great enough
         acc = if accurate isa BigFloat

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -33,7 +33,7 @@ module ULPError
         end
         abs(Float32((approximate - acc) / eps(approximate))::Float32)
     end
-    function ulp_error(accurate::Acc, approximate::App, x::AbstractFloat) where {Acc, App}
+    function ulp_error(accurate, approximate, x::AbstractFloat)
         acc = accurate(x)
         app = approximate(x)
         ulp_error(acc, app)

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -11,8 +11,6 @@ module ULPError
         inf_return = Float32(Inf)
         # handle floating-point edge cases
         accur_is_nan = isnan(accurate)
-        accur_is_inf = isinf(accurate)
-        approx_is_inf = isinf(approximate)
         approx_is_nan = isnan(approximate)
         if accur_is_nan || approx_is_nan
             return if accur_is_nan === approx_is_nan
@@ -21,8 +19,8 @@ module ULPError
                 inf_return
             end
         end
-        if approx_is_inf
-            return if accur_is_inf && (signbit(accurate) == signbit(approximate))
+        if isinf(approximate)
+            return if isinf(accurate) && (signbit(accurate) == signbit(approximate))
                 zero_return
             else
                 inf_return

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -34,7 +34,7 @@ module ULPError
         ulp_error(acc, app)
     end
     function ulp_error(func::Func, x::AbstractFloat) where {Func}
-        ulp_error(func, func, x)
+        ulp_error(func ∘ BigFloat, func, x)
     end
     function ulp_error_maximum(func::Func, iterator) where {Func}
         function f(x::AbstractFloat)

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -7,8 +7,8 @@ module ULPError
     end
     function ulp_error(accurate::AbstractFloat, approximate::AbstractFloat)
         # the ULP error is usually not required to great accuracy, so `Float32` should be precise enough
-        zero_return = Float32(0)
-        inf_return = Float32(Inf)
+        zero_return = 0f0
+        inf_return = Inf32
         # handle floating-point edge cases
         accur_is_nan = isnan(accurate)
         approx_is_nan = isnan(approximate)

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -25,7 +25,12 @@ module ULPError
                 end
             end
         end
-        acc = Float64(accurate)::Float64
+        acc = if accurate isa Union{Float16, Float32}
+            # widen for better accuracy when doing so does not impact performance too much
+            widen(accurate)
+        else
+            accurate
+        end
         abs(Float32((approximate - acc) / eps(approximate))::Float32)
     end
     function ulp_error(accurate::Acc, approximate::App, x::AbstractFloat) where {Acc, App}

--- a/test/testhelpers/ULPError.jl
+++ b/test/testhelpers/ULPError.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 module ULPError
     export ulp_error, ulp_error_maximum
     @noinline function throw_invalid()


### PR DESCRIPTION
Accomplished by:

* Using minimax instead of Taylor polynomials. They're more efficient. The minimax polynomials are found using Sollya.

* Using multiple polynomials for different subintervals of the domain. Known as "domain splitting". Enables good accuracy for a wider region around the origin than possible with only a single polynomial.

The polynomial degrees are kept as-is.

Fixes #59065