### PR TITLE
Update RISC-V building docs.

### DIFF
--- a/doc/src/devdocs/build/riscv.md
+++ b/doc/src/devdocs/build/riscv.md
@@ -11,17 +11,9 @@ including the output from `cat /proc/cpuinfo`.
 
 ## Compiling Julia
 
-For now, Julia will need to be compiled entirely from source, i.e., including
-all of its dependencies. This can be accomplished with the following
-`Make.user`:
-
-```make
-USE_BINARYBUILDER := 0
-```
-
-Additionally, it is required to indicate what architecture, and optionally which
-CPU to build for. This can be done by setting the `MARCH` and `MCPU` variables
-in `Make.user`
+To compilie Julia for RISC-V, you need to manually indicate what architecture, and
+optionally which CPU to build for. This can be done by setting the `MARCH` and `MCPU`
+variables in `Make.user`
 
 The `MARCH` variable needs to be set to a RISC-V ISA string, which can be found by
 looking at the documentation of your device, or by inspecting `/proc/cpuinfo`. Only


### PR DESCRIPTION
We have pre-built binaries for RISC-V now.