### PR TITLE
results.json: Fix repo paths so links to github work

### DIFF
--- a/test/buildkitetestjson.jl
+++ b/test/buildkitetestjson.jl
@@ -99,10 +99,9 @@ function generalize_file_paths(path::AbstractString)
             string(bindir_dir, pathsep) => ""
         )
         @static if Sys.iswindows()
-            return replace(path, "\\" => "/")
-        else
-            return path
+            path = replace(path, "\\" => "/")
         end
+        return replace(path, "share/julia/" => "")
     end
 end
 


### PR DESCRIPTION
Otherwise the github links for Base and Compiler tests don't work

<img width="554" height="481" alt="Screenshot 2025-07-24 at 2 41 38 PM" src="https://github.com/user-attachments/assets/c7ca8298-9cdc-4c72-a873-7585bbcc6e44" />
