### PR TITLE
Eliminate (almost) all invalidations by disabling world splitting

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -140,7 +140,7 @@ baremodule BuildSettings
 using Core: ARGS, include, Int, ===
 using ..Compiler: >, getindex, length
 
-global MAX_METHODS::Int = 3
+global MAX_METHODS::Int = 1
 
 if length(ARGS) > 2 && ARGS[2] === "--buildsettings"
     include(BuildSettings, ARGS[3])

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -122,6 +122,12 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
         return Future(CallMeta(Any, Any, Effects(), NoCallInfo()))
     end
 
+    # Disable inference when not fully covered (similar to union split limit)
+    if !fully_covering(matches)
+        add_remark!(interp, sv, "Inference disabled for method without full coverage")
+        return Future(CallMeta(Any, Any, Effects(), NoCallInfo()))
+    end
+
     (; valid_worlds, applicable) = matches
     update_valid_age!(sv, get_inference_world(interp), valid_worlds) # need to record the negative world now, since even if we don't generate any useful information, inlining might want to add an invoke edge and it won't have this information anymore
     if bail_out_toplevel_call(interp, sv)


### PR DESCRIPTION
Let's see if we can keep runtime performance while getting rid of a major cause of compile time performance issues.

- **Set max methods to 1 (mostly disable world splitting)**
- **Also disable word splitting when the matches are not fully covered (regardless of number of methods) [Using Claude]**
