### PR TITLE
more accurate `rad2deg` and `deg2rad` for `Float16` and `Float32`

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -228,6 +228,30 @@ end
     return hi, lo
 end
 
+# generic, but involves double rounding
+function _180_over_pi(z::AbstractFloat)
+    180 / oftype(z, pi)
+end
+function _pi_over_180(z::AbstractFloat)
+    oftype(z, pi) / 180
+end
+
+# rounded to closest representable number where necessary
+function _180_over_pi(z::Union{Float16, Float32})
+    if z isa Float16
+        r = Float16(57.28)
+    elseif z isa Float32
+        r = 57.29578f0
+    end
+    r
+end
+function _pi_over_180(z::Union{Float16})
+    if z isa Float16
+        r = Float16(0.01746)
+    end
+    r
+end
+
 """
     rad2deg(x)
 
@@ -241,7 +265,7 @@ julia> rad2deg(pi)
 180.0
 ```
 """
-rad2deg(z::AbstractFloat) = z * (180 / oftype(z, pi))
+rad2deg(z::AbstractFloat) = z * _180_over_pi(z)
 
 """
     deg2rad(x)
@@ -256,7 +280,7 @@ julia> deg2rad(90)
 1.5707963267948966
 ```
 """
-deg2rad(z::AbstractFloat) = z * (oftype(z, pi) / 180)
+deg2rad(z::AbstractFloat) = z * _pi_over_180(z)
 rad2deg(z::Real) = rad2deg(float(z))
 deg2rad(z::Real) = deg2rad(float(z))
 rad2deg(z::Number) = (z/pi)*180

--- a/base/math.jl
+++ b/base/math.jl
@@ -245,11 +245,8 @@ function _180_over_pi(z::Union{Float16, Float32})
     end
     r
 end
-function _pi_over_180(z::Union{Float16})
-    if z isa Float16
-        r = Float16(0.01746)
-    end
-    r
+function _pi_over_180(::Float16)
+    Float16(0.01746)
 end
 
 """

--- a/test/math.jl
+++ b/test/math.jl
@@ -448,13 +448,23 @@ end
 end
 
 @testset "deg2rad/rad2deg" begin
-    @testset "$T" for T in (Int, Float64, BigFloat)
+    @testset "$T" for T in (Int, Float16, Float32, Float64, BigFloat)
         @test deg2rad(T(180)) ≈ 1pi
         @test deg2rad.(T[45, 60]) ≈ [pi/T(4), pi/T(3)]
         @test rad2deg.([pi/T(4), pi/T(3)]) ≈ [45, 60]
         @test rad2deg(T(1)*pi) ≈ 180
         @test rad2deg(T(1)) ≈ rad2deg(true)
         @test deg2rad(T(1)) ≈ deg2rad(true)
+    end
+    @testset "accuracy" begin
+        @testset "$T" for T in (Float16, Float32, Float64)
+            @test rad2deg(T(1)) === setprecision(BigFloat, 500) do
+                T(180 / BigFloat(pi))
+            end
+            @test deg2rad(T(1)) === setprecision(BigFloat, 500) do
+                T(BigFloat(pi) / 180)
+            end
+        end
     end
     @test deg2rad(180 + 60im) ≈ pi + (pi/3)*im
     @test rad2deg(pi + (pi/3)*im) ≈ 180 + 60im


### PR DESCRIPTION
Both `deg2rad(::AbstractFloat)` and `rad2deg(::AbstractFloat)` just multiply the input argument with a constant-foldable factor of the same type as of the input argument.

The generic code for computing the factor involves a double rounding, so the factor is not guaranteed to be correctly rounded.

Introduce special cases for `Float16` and `Float32` to make the factor correctly rounded. This is not necessary for `Float64`, as the factor happens to be correctly rounded in that case.

Direct improvements:

* improve accuracy of `deg2rad(::Float16)`

* improve accuracy of `rad2deg(::Float16)`

* improve accuracy of `rad2deg(::Float32)`

Example indirect improvements:

* improving accuracy of `rad2deg(::Float32)` also improves accuracy of `asind(::Float32)`, `acosd(::Float32)`, `atand(::Float32)`