### PR TITLE
Fix msys symlink override rule

### DIFF
--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -4,7 +4,7 @@ ifneq ($(USE_BINARYBUILDER_LIBGIT2),1)
 LIBGIT2_GIT_URL := https://github.com/libgit2/libgit2.git
 LIBGIT2_TAR_URL = https://api.github.com/repos/libgit2/libgit2/tarball/$1
 $(eval $(call git-external,libgit2,LIBGIT2,CMakeLists.txt,,$(SRCCACHE)))
-$(SRCCACHE)/$(LIBGIT2_SRC_DIR)/source-extracted: $(MSYS_NONEXISTENT_SYMLINK_TARGET_FIX)
+$(SRCCACHE)/$(LIBGIT2_SRC_DIR)/source-extracted: export MSYS=$(MSYS_NONEXISTENT_SYMLINK_TARGET_FIX)
 
 ifeq ($(USE_SYSTEM_LIBSSH2), 0)
 $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: | $(build_prefix)/manifest/libssh2

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -14,7 +14,7 @@ $(eval $(call git-external,llvm,LLVM,CMakeLists.txt,,$(SRCCACHE)))
 # symlinks. We don't particularly care either way - we just need to symlinks
 # to succeed. We could guard this by a uname check, but it's harmless elsewhere,
 # so let's not incur the additional overhead.
-$(SRCCACHE)/$(LLVM_SRC_DIR)/source-extracted: $(MSYS_NONEXISTENT_SYMLINK_TARGET_FIX)
+$(SRCCACHE)/$(LLVM_SRC_DIR)/source-extracted: export MSYS=$(MSYS_NONEXISTENT_SYMLINK_TARGET_FIX)
 
 LLVM_BUILDDIR := $(BUILDDIR)/$(LLVM_SRC_DIR)
 LLVM_BUILDDIR_withtype := $(LLVM_BUILDDIR)/build_$(LLVM_BUILDTYPE)

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -102,7 +102,7 @@ endif
 # symlinks. We don't particularly care either way - we just need to symlinks
 # to succeed. We could guard this by a uname check, but it's harmless elsewhere,
 # so let's not incur the additional overhead.
-MSYS_NONEXISTENT_SYMLINK_TARGET_FIX := export MSYS=winsymlinks:native
+MSYS_NONEXISTENT_SYMLINK_TARGET_FIX := winsymlinks:native
 
 # If the top-level Makefile is called with environment variables,
 # they will override the values passed above to ./configure

--- a/deps/zstd.mk
+++ b/deps/zstd.mk
@@ -3,7 +3,7 @@ ifneq ($(USE_BINARYBUILDER_ZSTD), 1)
 ZSTD_GIT_URL := https://github.com/facebook/zstd.git
 ZSTD_TAR_URL = https://api.github.com/repos/facebook/zstd/tarball/$1
 $(eval $(call git-external,zstd,ZSTD,,,$(BUILDDIR)))
-$(BUILDDIR)/$(ZSTD_SRC_DIR)/source-extracted: $(MSYS_NONEXISTENT_SYMLINK_TARGET_FIX)
+$(BUILDDIR)/$(ZSTD_SRC_DIR)/source-extracted: export MSYS=$(MSYS_NONEXISTENT_SYMLINK_TARGET_FIX)
 
 ZSTD_BUILD_OPTS := MOREFLAGS="-DZSTD_MULTITHREAD $(fPIC)" bindir=$(build_private_libexecdir)
 ifeq ($(OS), WINNT)


### PR DESCRIPTION
The `export VAR=VAL` is syntax, so it can't be expanded. Fixes #59096 