### PR TITLE
make more cases of mapreduce trimmable

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -374,7 +374,7 @@ mapreduce_empty(f::typeof(abs),  ::typeof(max), T) = abs(zero(T))
 mapreduce_empty(f::typeof(abs2), ::typeof(max), T) = abs2(zero(T))
 
 # For backward compatibility:
-mapreduce_empty_iter(f, op, itr, ItrEltype) =
+mapreduce_empty_iter(f::F, op::F2, itr, ItrEltype) where {F,F2} =
     reduce_empty_iter(MappingRF(f, op), itr, ItrEltype)
 
 @inline reduce_empty_iter(op, itr) = reduce_empty_iter(op, itr, IteratorEltype(itr))

--- a/test/trimming/basic_jll.jl
+++ b/test/trimming/basic_jll.jl
@@ -24,16 +24,5 @@ function @main(args::Vector{String})::Cint
     cfunc = @cfunction(print_string, Cvoid, (Ptr{Cvoid},))
     fptr = dlsym(Zstd_jll.libzstd_handle, :ZSTD_versionString)
     ccall(cfunc, Cvoid, (Ptr{Cvoid},), fptr)
-
-    # map/mapreduce should work but relies on inlining and other optimizations
-    arr = rand(10)
-    sorted_arr = sort(arr)
-    tot = sum(sorted_arr)
-    tot = prod(sorted_arr)
-    a = any(x -> x > 0, sorted_arr)
-    b = all(x -> x >= 0, sorted_arr)
-    c = map(x -> x^2, sorted_arr)
-    # d = mapreduce(x -> x^2, +, sorted_arr) this doesn't work because of mapreduce_empty_iter having F specialized
-    # e = reduce(xor, rand(Int, 10))
     return 0
 end

--- a/test/trimming/hello.jl
+++ b/test/trimming/hello.jl
@@ -30,7 +30,7 @@ function @main(args::Vector{String})::Cint
     a = any(x -> x > 0, sorted_arr)
     b = all(x -> x >= 0, sorted_arr)
     c = map(x -> x^2, sorted_arr)
-    # d = mapreduce(x -> x^2, +, sorted_arr) this doesn't work because of mapreduce_empty_iter having F specialized
+    d = mapreduce(x -> x^2, +, sorted_arr)
     # e = reduce(xor, rand(Int, 10))
     return 0
 end

--- a/test/trimming/hello.jl
+++ b/test/trimming/hello.jl
@@ -3,8 +3,34 @@ const str = OncePerProcess{String}() do
     return "Hello, " * world
 end
 
+abstract type Shape end
+struct Square <: Shape
+    side::Float64
+end
+struct Circle <: Shape
+    radius::Float64
+end
+area(s::Square) = s.side^2
+area(c::Circle) = pi*c.radius^2
+
+sum_areas(v::Vector{Shape}) = sum(area, v)
+
 function @main(args::Vector{String})::Cint
     println(Core.stdout, str())
     foreach(x->println(Core.stdout, x), args)
+
+    # test map/mapreduce; should work but relies on inlining and other optimizations
+    # test that you can dispatch to some number of concrete cases
+    println(Core.stdout, sum_areas(Shape[Circle(1), Square(2)]))
+
+    arr = rand(10)
+    sorted_arr = sort(arr)
+    tot = sum(sorted_arr)
+    tot = prod(sorted_arr)
+    a = any(x -> x > 0, sorted_arr)
+    b = all(x -> x >= 0, sorted_arr)
+    c = map(x -> x^2, sorted_arr)
+    # d = mapreduce(x -> x^2, +, sorted_arr) this doesn't work because of mapreduce_empty_iter having F specialized
+    # e = reduce(xor, rand(Int, 10))
     return 0
 end

--- a/test/trimming/trimming.jl
+++ b/test/trimming/trimming.jl
@@ -6,8 +6,8 @@ bindir = dirname(ARGS[1])
 let exe_suffix = splitext(Base.julia_exename())[2]
 
     hello_exe = joinpath(bindir, "hello" * exe_suffix)
-    @test readchomp(`$hello_exe arg1 arg2`) == "Hello, world!\n$hello_exe\narg1\narg2"
-    @test filesize(hello_exe) < 2_000_000
+    @test readchomp(`$hello_exe arg1 arg2`) == "Hello, world!\n$hello_exe\narg1\narg2\n$(4.0+pi)"
+    @test filesize(hello_exe) < 2_500_000
 
     basic_jll_exe = joinpath(bindir, "basic_jll" * exe_suffix)
     lines = split(readchomp(`$basic_jll_exe`), "\n")


### PR DESCRIPTION
add test for trimming with limited dynamic dispatch

move mapreduce tests out of basic_jll test
