### PR TITLE
inference: Make test indepdent of the `Complex` method table

### DIFF
--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -3549,8 +3549,14 @@ f31974(n::Int) = f31974(1:n)
 # call cycles.
 @test code_typed(f31974, Tuple{Int}) !== nothing
 
-f_overly_abstract_complex() = Complex(Ref{Number}(1)[])
-@test Base.return_types(f_overly_abstract_complex, Tuple{}) == [Complex]
+# Issue #33472
+struct WrapperWithUnionall33472{T<:Real}
+    x::T
+end
+
+f_overly_abstract33472() = WrapperWithUnionall33472(Base.inferencebarrier(1)::Number)
+# Check that this doesn't infer as `WrapperWithUnionall33472{T<:Number}`.
+@test Base.return_types(f_overly_abstract33472, Tuple{}) == [WrapperWithUnionall33472]
 
 # Issue 26724
 const IntRange = AbstractUnitRange{<:Integer}


### PR DESCRIPTION
The test helpers in both the base tests and linear algebra add `(::Type{<:Number})(::Furlong)` methods (for their own respective copies of furlong). These methods intersect with `Complex(::Any)`. Having only one of these isn't a problem, but if both get added, we consider that too many methods and bail. In discussion this with Jeff (who originally wrote the test), our preference is that inference tests should be as standalone from the base system's method tables as possible, so adjust the test (as opposed to e.g. changing the Furlong signatures).

Fixes #59073