### PR TITLE
better error in juliac for defining main inside a new module

### DIFF
--- a/contrib/juliac/juliac-buildscript.jl
+++ b/contrib/juliac/juliac-buildscript.jl
@@ -37,7 +37,7 @@ function _main(argc::Cint, argv::Ptr{Ptr{Cchar}})::Cint
     return Main.main(args)
 end
 
-let mod = Base.include(Main, ARGS[1])
+let include_result = Base.include(Main, ARGS[1])
     Core.@latestworld
     if ARGS[2] == "--output-exe"
         have_cmain = false
@@ -49,6 +49,11 @@ let mod = Base.include(Main, ARGS[1])
                     break
                 end
             end
+        elseif include_result isa Module && isdefined(include_result, :main)
+            error("""
+                  The `main` function must be defined in `Main`. If you are defining it inside a
+                  module, try adding `import .$(nameof(include_result)).main` to $(ARGS[1]).
+                  """)
         end
         if !have_cmain
             if Base.should_use_main_entrypoint()
@@ -59,7 +64,7 @@ let mod = Base.include(Main, ARGS[1])
                     error("`@main` must accept a `Vector{String}` argument.")
                 end
             else
-                error("To generate an executable a `@main` function must be defined.")
+                error("To generate an executable a `@main` function must be defined in the `Main` module.")
             end
         end
     end


### PR DESCRIPTION
This is more helpful if the script you try to compile defines a module containing main instead of defining it at the toplevel.