### PR TITLE
rm extraneous function included in #21858

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1142,10 +1142,6 @@ function complex(A::AbstractArray{T}) where T
     convert(AbstractArray{typeof(complex(zero(T)))}, A)
 end
 
-## Promotion to complex ##
-
-_default_type(T::Type{Complex}) = Complex{Int}
-
 ## Machine epsilon for complex ##
 
 eps(z::Complex{<:AbstractFloat}) = hypot(eps(real(z)), eps(imag(z)))


### PR DESCRIPTION
Removes an apparently extraneous function accidentally included in #21858, as noted in https://github.com/JuliaLang/julia/pull/21858/files#r2233250284.