### PR TITLE
Fix a JET warning

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -110,7 +110,7 @@ end
                 error("invalid spawn handle $h from $io")
             end
             for io in stdio]
-        syncd = Task[io.t for io in stdio if io isa SyncCloseFD]
+        syncd = Task[(io::SyncCloseFD).t for io in stdio if io isa SyncCloseFD]
         handle = Libc.malloc(_sizeof_uv_process)
         disassociate_julia_struct(handle)
         (; exec, flags, env, dir) = cmd


### PR DESCRIPTION
Encountered while looking through JET report for GAP.jl

> invalid builtin function call: `getfield(x::RawFD, f::Symbol)`

Clearly the code itself really is fine, but the annotation silences this warning.

Full context:
```
┌ _spawn_primitive(file::String, cmd::Cmd, stdio::Memory{Union{RawFD, Base.SyncCloseFD, IO}}) @ Base ./process.jl:113
│┌ collect(::Type{Task}, itr::Base.Generator{Base.Iterators.Filter{…}, Base.var"#_spawn_primitive##0#_spawn_primitive##1"}) @ Base ./array.jl:641
││┌ _collect(::Type{…}, itr::Base.Generator{…}, isz::Base.SizeUnknown) @ Base ./array.jl:647
│││┌ iterate(::Base.Generator{Base.Iterators.Filter{…}, Base.var"#_spawn_primitive##0#_spawn_primitive##1"}) @ Base ./generator.jl:48
││││┌ (::Base.var"#_spawn_primitive##0#_spawn_primitive##1")(io::Union{RawFD, Base.SyncCloseFD, IO}) @ Base ./none:0
│││││┌ getproperty(x::RawFD, f::Symbol) @ Base ./Base_compiler.jl:54
││││││ invalid builtin function call: getfield(x::RawFD, f::Symbol)
│││││└────────────────────
```