### PR TITLE
Add builtin function name to add methods error

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -1299,7 +1299,7 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
     }
     ft = jl_rewrap_unionall(ft, argtype);
     if (!external_mt && !jl_has_empty_intersection(ft, (jl_value_t*)jl_builtin_type)) // disallow adding methods to Any, Function, Builtin, and subtypes, or Unions of those
-        jl_error("cannot add methods to a builtin function");
+        jl_errorf("cannot add methods to a builtin function `%s`", jl_symbol_name(name));
 
     m = jl_new_method_uninit(module);
     m->external_mt = (jl_value_t*)external_mt;

--- a/src/method.c
+++ b/src/method.c
@@ -1220,7 +1220,7 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
     //    jl_value_t **ttypes = { jl_builtin_type, jl_tparam0(jl_anytuple_type) };
     //    jl_value_t *invalidt = jl_apply_tuple_type_v(ttypes, 2); // Tuple{Union{Builtin,OpaqueClosure}, Vararg}
     //    if (!jl_has_empty_intersection(argtype, invalidt))
-    //        jl_error("cannot add methods to a builtin function");
+    //        jl_error("cannot add methods to builtin function");
     //}
 
     assert(jl_is_linenode(functionloc));
@@ -1299,7 +1299,7 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
     }
     ft = jl_rewrap_unionall(ft, argtype);
     if (!external_mt && !jl_has_empty_intersection(ft, (jl_value_t*)jl_builtin_type)) // disallow adding methods to Any, Function, Builtin, and subtypes, or Unions of those
-        jl_errorf("cannot add methods to a builtin function `%s`", jl_symbol_name(name));
+        jl_errorf("cannot add methods to builtin function `%s`", jl_symbol_name(name));
 
     m = jl_new_method_uninit(module);
     m->external_mt = (jl_value_t*)external_mt;

--- a/test/core.jl
+++ b/test/core.jl
@@ -2661,13 +2661,16 @@ struct D14919 <: Function; end
 @test B14919()() == "It's a brand new world"
 @test C14919()() == D14919()() == "Boo."
 
-let ex = ErrorException("cannot add methods to a builtin function")
+let ex_t = ErrorException, ex_r = r"cannot add methods to a builtin function"
     for f in (:(Core.Any), :(Core.Function), :(Core.Builtin), :(Base.Callable), :(Union{Nothing,F} where F), :(typeof(Core.getfield)), :(Core.IntrinsicFunction))
-        @test_throws ex @eval (::$f)() = 1
+        @test_throws ex_t @eval (::$f)() = 1
+        @test_throws ex_r @eval (::$f)() = 1
     end
-    @test_throws ex @eval (::Union{Nothing,F})() where {F<:Function} = 1
+    @test_throws ex_t @eval (::Union{Nothing,F})() where {F<:Function} = 1
+    @test_throws ex_r @eval (::Union{Nothing,F})() where {F<:Function} = 1
     for f in (:(Core.getfield),)
-        @test_throws ex @eval $f() = 1
+        @test_throws ex_t @eval $f() = 1
+        @test_throws ex_r @eval $f() = 1
     end
 end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -2661,7 +2661,7 @@ struct D14919 <: Function; end
 @test B14919()() == "It's a brand new world"
 @test C14919()() == D14919()() == "Boo."
 
-let ex_t = ErrorException, ex_r = r"cannot add methods to a builtin function"
+let ex_t = ErrorException, ex_r = r"cannot add methods to builtin function"
     for f in (:(Core.Any), :(Core.Function), :(Core.Builtin), :(Base.Callable), :(Union{Nothing,F} where F), :(typeof(Core.getfield)), :(Core.IntrinsicFunction))
         @test_throws ex_t @eval (::$f)() = 1
         @test_throws ex_r @eval (::$f)() = 1


### PR DESCRIPTION
```
julia> Base.throw(x::Int) = 1
ERROR: cannot add methods to builtin function `throw`
Stacktrace:
 [1] top-level scope
   @ REPL[1]:1
```