### PR TITLE
build: add --fix option for check-whitespace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ will not be reflected, unless you use `Revise`.
 
 ## For all changes
 
-1. Run `make check-whitespace` before creating the PR to make sure you're not committing any whitespace errors.
+1. Run `make fix-whitespace` before creating the PR to make sure you're not committing any whitespace errors.
 
 ## Building Julia
 

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,15 @@ else
 	$(warn "Skipping whitespace check because git is unavailable")
 endif
 
+fix-whitespace:
+ifneq ($(NO_GIT), 1)
+	@# Append the directory containing the julia we just built to the end of `PATH`,
+	@# to give us the best chance of being able to run this check.
+	@PATH="$(PATH):$(dir $(JULIA_EXECUTABLE))" julia $(call cygpath_w,$(JULIAHOME)/contrib/check-whitespace.jl) --fix
+else
+	$(warn "Skipping whitespace fix because git is unavailable")
+endif
+
 release-candidate: release testall
 	@$(JULIA_EXECUTABLE) $(JULIAHOME)/contrib/add_license_to_files.jl #add license headers
 	@#Check documentation
@@ -686,7 +695,7 @@ distcleanall: cleanall
 	@-$(MAKE) -C $(BUILDROOT)/doc cleanall
 
 .FORCE:
-.PHONY: .FORCE default debug release check-whitespace release-candidate \
+.PHONY: .FORCE default debug release check-whitespace fix-whitespace release-candidate \
 	julia-debug julia-release julia-stdlib julia-deps julia-deps-libs \
 	julia-cli-release julia-cli-debug julia-src-release julia-src-debug \
 	julia-symlink julia-base julia-sysimg julia-sysimg-ji julia-sysimg-release julia-sysimg-debug \

--- a/contrib/check-whitespace.jl
+++ b/contrib/check-whitespace.jl
@@ -32,10 +32,39 @@ allow_tabs(path) =
     endswith(path, "test/syntax.jl") ||
     endswith(path, "test/triplequote.jl")
 
-const errors = Set{Tuple{String,Int,String}}()
-
 function check_whitespace()
-    for path in eachline(`git ls-files -- $patterns`)
+    # Get file list from ARGS if provided, otherwise use git ls-files
+    errors = Set{Tuple{String,Int,String}}()
+    files_to_check = filter(arg -> arg != "--fix", ARGS)
+    if isempty(files_to_check)
+        files_to_check = eachline(`git ls-files -- $patterns`)
+    end
+
+    files_fixed = 0
+    if "--fix" in ARGS
+        for path in files_to_check
+            content = newcontent = read(path, String)
+            isempty(content) && continue
+            if !allow_tabs(path)
+                tabpattern = r"^([ \t]+)"m => (x -> replace(x, r"((?: {4})*)( *\t)" => s"\1    ")) # Replace tab sequences at start of line after any number of 4-space groups
+                newcontent = replace(newcontent, tabpattern)
+            end
+            newcontent = replace(newcontent,
+                r"\s*$" => '\n',                # Remove trailing whitespace and normalize line ending at eof
+                r"\s*?[\r\n]" => '\n',          # Remove trailing whitespace and normalize line endings on each line
+                r"\xa0" => ' '                  # Replace non-breaking spaces
+            )
+            if content != newcontent
+                write(path, newcontent)
+                files_fixed += 1
+            end
+        end
+        if files_fixed > 0
+            println(stderr, "Fixed whitespace issues in $files_fixed files.")
+        end
+    end
+
+    for path in files_to_check
         lineno = 0
         non_blank = 0
 


### PR DESCRIPTION
Help agents (and humans) to solve whitespace quicker. New options include  to try fixing issues before checking for errors that cannot be automatically fixed (tabs in the middle of lines) and the ability to pass specific files as arguments (particularly for testing this script or for files that aren't yet in git).

Partially written by Claude.