### PR TITLE
Update list of COMPILER_SRCS in sysimage.mk

### DIFF
--- a/sysimage.mk
+++ b/sysimage.mk
@@ -31,32 +31,48 @@ COMPILER_SRCS := $(addprefix $(JULIAHOME)/, \
 		base/abstractset.jl \
 		base/iddict.jl \
 		base/idset.jl \
+		base/anyall.jl \
 		base/array.jl \
+		base/baseext.jl \
 		base/bitarray.jl \
 		base/bitset.jl \
 		base/bool.jl \
+		base/c.jl \
+		base/checked.jl \
+		base/cmem.jl \
+		base/coreio.jl \
+		base/coreir.jl \
 		base/ctypes.jl \
 		base/error.jl \
 		base/essentials.jl \
 		base/expr.jl \
 		base/exports.jl \
+		base/flfrontend.jl \
+		base/float.jl \
+		base/gcutils.jl \
 		base/generator.jl \
+		base/genericmemory.jl \
 		base/int.jl \
 		base/indices.jl \
 		base/iterators.jl \
 		base/invalidation.jl \
 		base/module.jl \
 		base/namedtuple.jl \
+		base/ntuple.jl \
 		base/number.jl \
 		base/operators.jl \
 		base/options.jl \
+		base/ordering.jl \
 		base/pair.jl \
 		base/pointer.jl \
 		base/promotion.jl \
+		base/public.jl \
 		base/range.jl \
-		base/runtime_internals.jl \
-		base/traits.jl \
 		base/refvalue.jl \
+		base/rounding.jl \
+		base/runtime_internals.jl \
+		base/strings/lazy.jl \
+		base/traits.jl \
 		base/tuple.jl)
 COMPILER_SRCS += $(shell find $(JULIAHOME)/Compiler/src -name \*.jl -and -not -name verifytrim.jl -and -not -name show.jl)
 # sort these to remove duplicates


### PR DESCRIPTION
This list needs to match all source files included in Base_compiler.jl.

Written by claude.