### PR TITLE
InteractiveUtils: Use `typeof` instead of `Typeof` for keyword arguments

### DIFF
--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -960,3 +960,13 @@ end # module
     using .OuterModule
     @test_nowarn subtypes(Integer);
 end
+
+@testset "Lowering behavior for keyword arguments" begin
+    f_with_kw(; T = Int) = T
+    _, rt = @code_typed f_with_kw()
+    @test rt === Type{Int}
+    _, rt = @code_typed f_with_kw(; T::Type{Int})
+    @test rt === Type{Int}
+    _, rt = @code_typed f_with_kw(; T = Int)
+    @test rt === DataType
+end


### PR DESCRIPTION
Recent code introspection refactors introduced more precise types for `Type` keyword arguments. However, the `NamedTuple` generated by lowering to represent these keyword arguments has `Type` parameters widened to `DataType` (just like we do for `Tuple`), so we should do the same to more accurately represent the code.