### PR TITLE
WIP/RFC: Change lowering of GC.preserve to be lexical

### DIFF
--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -502,4 +502,15 @@ function add_edges_impl(edges::Vector{Any}, info::GlobalAccessInfo)
     push!(edges, info.b)
 end
 
+"""
+    info::GCPreserveCallInfo <: CallInfo
+
+Wraps another CallInfo, indicating that this call came from a looked-through GCPreserveDuring.
+"""
+struct GCPreserveDuringCallInfo <: CallInfo
+    info::CallInfo
+end
+add_edges_impl(edges::Vector{Any}, info::GCPreserveDuringCallInfo) =
+    add_edges_impl(edges, info.info)
+
 @specialize

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -370,6 +370,11 @@ function start_profile_listener()
     ccall(:jl_set_peek_cond, Cvoid, (Ptr{Cvoid},), cond.handle)
 end
 
+function print_padded_time(io, mod, maxlen, t)
+    print(io, rpad(string(mod) * "  ", maxlen + 3, "─"))
+    Base.time_print(io, t * 10^9); println(io)
+end
+
 function __init__()
     # Base library init
     global _atexit_hooks_finished = false

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -136,7 +136,8 @@ convert(::Type{Any}, Core.@nospecialize x) = x
 convert(::Type{T}, x::T) where {T} = x
 include("coreio.jl")
 
-import Core: @doc, @__doc__, WrappedException, @int128_str, @uint128_str, @big_str, @cmd
+import Core: @doc, @__doc__, WrappedException, @int128_str, @uint128_str, @big_str, @cmd,
+    GCPreserveDuring
 
 # Export list
 include("exports.jl")

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3807,6 +3807,10 @@ static Value *boxed(jl_codectx_t &ctx, const jl_cgval_t &vinfo, bool is_promotab
     if (jt == jl_bottom_type || jt == NULL)
         // We have an undef value on a (hopefully) dead branch
         return UndefValue::get(ctx.types().T_prjlvalue);
+    Value *box;
+    if (vinfo.wrapped_typ) {
+        assert(false && "TODO");
+    }
     if (vinfo.constant)
         return track_pjlvalue(ctx, literal_pointer_val(ctx, vinfo.constant));
     // This can happen in early bootstrap for `gc_preserve_begin` return value.
@@ -3818,7 +3822,6 @@ static Value *boxed(jl_codectx_t &ctx, const jl_cgval_t &vinfo, bool is_promotab
         return vinfo.V;
     }
 
-    Value *box;
     if (vinfo.TIndex) {
         SmallBitVector skip_none;
         box = box_union(ctx, vinfo, skip_none);

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -126,6 +126,7 @@
     XX(jl_task_type) \
     XX(jl_top_module) \
     XX(jl_trimfailure_type) \
+    XX(jl_gc_preserve_during_type) \
     XX(jl_true) \
     XX(jl_tuple_typename) \
     XX(jl_tvar_type) \

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -22,10 +22,10 @@
                `(incomplete ,msg)
                (cons 'error (cdr e))))
          (begin
-           ;;(newline)
-           ;;(display "unexpected error: ")
-           ;;(prn e)
-           ;;(print-stack-trace (stacktrace))
+           (newline)
+           (display "unexpected error: ")
+           (prn e)
+           (print-stack-trace (stacktrace))
            '(error "malformed expression"))))
    thk))
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3956,6 +3956,7 @@ void post_boot_hooks(void)
     jl_initerror_type        = (jl_datatype_t*)core("InitError");
     jl_missingcodeerror_type = (jl_datatype_t*)core("MissingCodeError");
     jl_trimfailure_type      = (jl_datatype_t*)core("TrimFailure");
+    jl_gc_preserve_during_type = (jl_datatype_t*)core("GCPreserveDuring");
 
     jl_pair_type             = core("Pair");
     jl_value_t *kwcall_func  = core("kwcall");

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2556,6 +2556,17 @@
                         (every check-path (cdar e)))))
     (error (string "malformed \"" what "\" statement"))))
 
+(define (wrap-gc-preserve e x)
+  (if (pair? e)
+    (cond ((memq (car e) '(method lambda)) e)
+      ((eq? (car e) 'foreigncall)
+        `(,(car e) ,@(list-head (cdr e) 5) ,@(map (lambda (c) (wrap-gc-preserve c x)) (list-tail e 6))))
+      ((eq? (car e) 'cfunction) e)
+      ((eq? (car e) 'call)
+        `(call (new (top GCPreserveDuring) ,(cadr e) ,x) ,@(map (lambda (c) (wrap-gc-preserve c x)) (cddr e))))
+      (else `(,(car e) ,@(map (lambda (c) (wrap-gc-preserve c x)) (cdr e)))))
+    e))
+
 ;; table mapping expression head to a function expanding that form
 (define expand-table
   (table
@@ -2945,13 +2956,7 @@
 
     'gc_preserve
     (lambda (e)
-      (let* ((s (make-ssavalue))
-             (r (make-ssavalue)))
-        `(block
-          (= ,s (gc_preserve_begin ,@(cddr e)))
-          (= ,r ,(expand-forms (cadr e)))
-          (gc_preserve_end ,s)
-          ,r)))
+      (wrap-gc-preserve (expand-forms (cadr e)) (caddr e)))
 
     'line
     (lambda (e)

--- a/src/julia.h
+++ b/src/julia.h
@@ -1036,6 +1036,7 @@ extern JL_DLLIMPORT jl_datatype_t *jl_fielderror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_atomicerror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_missingcodeerror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_trimfailure_type JL_GLOBALLY_ROOTED;
+extern JL_DLLIMPORT jl_datatype_t *jl_gc_preserve_during_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_lineinfonode_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_abioverride_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_value_t *jl_stackovf_exception JL_GLOBALLY_ROOTED;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -116,7 +116,7 @@ extern "C" {
 // TODO: put WeakRefs on the weak_refs list during deserialization
 // TODO: handle finalizers
 
-#define NUM_TAGS    151
+#define NUM_TAGS    152
 
 // An array of references that need to be restored from the sysimg
 // This is a manually constructed dual of the gvars array, which would be produced by codegen for Julia code, for C.
@@ -282,6 +282,7 @@ static void get_tags(jl_value_t **tags[NUM_TAGS])
     INSERT_TAG(jl_opaque_closure_method);
     INSERT_TAG(jl_nulldebuginfo);
     INSERT_TAG(jl_method_table);
+    INSERT_TAG(jl_gc_preserve_during_type);
     // n.b. must update NUM_TAGS when you add something here
 #undef INSERT_TAG
     assert(i == NUM_TAGS - 1);


### PR DESCRIPTION
# Disclaimer

This is an attempt to resolve #59124. It is incompletely implemented, but I think the key pieces are implemented in each of the involved subsystems. The idea of this PR is to facilitate discussion of this solution while making sure there aren't any major unknown unknowns (which I don't think there are).

# Design

This PR adds a new struct defined as:
```
struct GCPreserveDuring
    f::Any
    # N.B: This field is opaque - the compiler is allowed to arbitrarily change it
    # as long as it has the same GC rooting behavior.
    root::Any
    GCPreserveDuring(@nospecialize(f), @nospecialize(root)) = new(f, root)
end

# This has special support in inference and codegen and is only ever actually called
# in fallback cases.
function (this::GCPreserveDuring)(args...)
    @noinline
    r = this.f(args...)
    # N.B.: This is correct, but stronger than required. If the call to `f` is deleted,
    # this may be deleted as well.
    donotdelete(this.root)
    return r
end
```

The idea is that the call method here exists for semantics, but is essentially never actually used. Instead, inference treats it transparently (as if a call to the wrapped function) and codegen codegens it as the original call plus a `jl_roots` operand bundle (which our LLVM passes already supported, because it's used in the gc preserve implementation for foreigncall).

# Key notes for relevant subsystems

## Lowering

In lowering, the `gc_preserve` syntax form is expanded by first expanding its first argument and then rewriting every call in the expansion from `(call f ,@args)` to `(call (new (top GCPreserveDuring) f preservee) ,@args)`. As lowering is lexical, this will apply to every call in the lexical scope of the macro (and no other calls).

Now, of course the preservee itself is not lexical. Lowering itself does not care and simply copies whatever value you put there. However, to preserve the existing semantics of the `@GC.preserve` macro, the implementation of the macro has changed to introduce and intermediate slot (thus capturing the value of the preserved slot at entry to the macro).

As a result, the case where the entry to the macro is not evaluated for any reason now errors with an UndefVarError, rather than crashing in the optimizer.

## Inlining

Inlining for calls of `GCPreserveDuring` is adjusted to apply the same `GCPreserveDuring` to every statement being inlined.

## :invoke_modify

The `:invoke_modify` expr head gains a new case for invokes of `GCPreserveDuring`, which if recognized as such are treated the same as regular `:invoke`s, except that the preservation is applied. I should note though that this causes problems for existing `:invoke_modify`', since there is a semantic ambiguity of whether they are permitted to be decayed to `:invoke`. Currently this is handled by just bailing in this case, but we may want a new expr head instead.

## Codegen

Codegen is the least implemented. In the current design, the `jl_cgval_t` struct gains a new `wrapped_typ` field that if set indicates that this is a GCPreserveDuring of the indicated type. `boxed` would reconstitute it as such and the various `emit_` wrappers would turn it back into a non-wrapped `jl_cgval_t` and treat the preservees as appropriate. I'm not sure this'll be the final design.

In any case, the preservees are turned into jl_roots operand bundles.