### PR TITLE
bump slop for twiceprecision division

### DIFF
--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -230,7 +230,7 @@ end
             @test cmp_sn2(Tw(xw+yw), astuple(x+y)..., slopbits)
             @test cmp_sn2(Tw(xw-yw), astuple(x-y)..., slopbits)
             @test cmp_sn2(Tw(xw*yw), astuple(x*y)..., slopbits)
-            @test cmp_sn2(Tw(xw/yw), astuple(x/y)..., slopbits)
+            @test cmp_sn2(Tw(xw/yw), astuple(x/y)..., slopbits+1) # extra bit because division is hard
             y = rand(T)
             yw = widen(widen(y))
             @test cmp_sn2(Tw(xw+yw), astuple(x+y)..., slopbits)


### PR DESCRIPTION
division (unlike the other intrinsics) can have table-maker dilema problems since the true result has infinite bits. Bumping the slop for it by 1 reduces failures from 80 in 10^10 to <1 in 10^11.

I think accepting an extra bit of inaccuracy is reasonable here (the alternative would be to make the division do an extra loop and do some extra extended precision, which seems unlikely to be worth it.

fixes https://github.com/JuliaLang/julia/issues/23497