### PR TITLE
source build: fix openssl race in installing libssh2

### DIFF
--- a/deps/BOLT.mk
+++ b/deps/BOLT.mk
@@ -68,7 +68,7 @@ LLVM_CMAKE += -DCMAKE_EXE_LINKER_FLAGS="$(LLVM_LDFLAGS)" \
 	-DCMAKE_SHARED_LINKER_FLAGS="$(LLVM_LDFLAGS)"
 
 ifeq ($(USE_SYSTEM_ZLIB), 0)
-$(BOLT_BUILDDIR)/build-configured: | $(build_prefix)/manifest/zlib
+$(BOLT_BUILDDIR)/build-configured: | install-zlib
 endif
 
 $(BOLT_BUILDDIR)/build-configured: $(SRCCACHE)/$(BOLT_SRC_DIR)/source-extracted

--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -2,19 +2,19 @@
 include $(SRCDIR)/curl.version
 
 ifeq ($(USE_SYSTEM_OPENSSL), 0)
-$(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/openssl
+$(BUILDDIR)/curl-$(CURL_VER)/build-configured: | install-openssl
 endif
 
 ifeq ($(USE_SYSTEM_LIBSSH2), 0)
-$(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/libssh2
+$(BUILDDIR)/curl-$(CURL_VER)/build-configured: | install-libssh2
 endif
 
 ifeq ($(USE_SYSTEM_ZLIB), 0)
-$(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/zlib
+$(BUILDDIR)/curl-$(CURL_VER)/build-configured: | install-zlib
 endif
 
 ifeq ($(USE_SYSTEM_NGHTTP2), 0)
-$(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/nghttp2
+$(BUILDDIR)/curl-$(CURL_VER)/build-configured: | install-nghttp2
 endif
 
 ifneq ($(USE_BINARYBUILDER_CURL),1)

--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -7,19 +7,19 @@ $(eval $(call git-external,libgit2,LIBGIT2,CMakeLists.txt,,$(SRCCACHE)))
 $(SRCCACHE)/$(LIBGIT2_SRC_DIR)/source-extracted: export MSYS=$(MSYS_NONEXISTENT_SYMLINK_TARGET_FIX)
 
 ifeq ($(USE_SYSTEM_LIBSSH2), 0)
-$(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: | $(build_prefix)/manifest/libssh2
+$(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: | install-libssh2
 endif
 
 ifeq ($(USE_SYSTEM_OPENSSL), 0)
-$(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: | $(build_prefix)/manifest/openssl
+$(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: | install-openssl
 endif
 
 ifeq ($(USE_SYSTEM_PCRE), 0)
-$(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: | $(build_prefix)/manifest/pcre
+$(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: | install-pcre
 endif
 
 ifeq ($(USE_SYSTEM_ZLIB), 0)
-$(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: | $(build_prefix)/manifest/zlib
+$(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: | install-zlib
 endif
 
 LIBGIT2_OPTS := $(CMAKE_COMMON) -DCMAKE_BUILD_TYPE=Release -DUSE_THREADS=ON -DUSE_BUNDLED_ZLIB=OFF -DUSE_SSH=ON -DREGEX_BACKEND=pcre2 -DBUILD_CLI=OFF -DBUILD_TESTS=OFF

--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -5,7 +5,7 @@ LIBSSH2_TAR_URL = https://api.github.com/repos/libssh2/libssh2/tarball/$1
 $(eval $(call git-external,libssh2,LIBSSH2,CMakeLists.txt,,$(SRCCACHE)))
 
 ifeq ($(USE_SYSTEM_OPENSSL), 0)
-$(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured: | $(build_prefix)/manifest/openssl
+$(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured: | install-openssl
 endif
 
 LIBSSH2_OPTS := $(CMAKE_COMMON) -DBUILD_SHARED_LIBS=ON -DBUILD_EXAMPLES=OFF \

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -256,11 +256,11 @@ $(eval $(call LLVM_PATCH,llvm-ittapi-cmake))
 endif
 
 ifeq ($(USE_SYSTEM_ZLIB), 0)
-$(LLVM_BUILDDIR_withtype)/build-configured: | $(build_prefix)/manifest/zlib
+$(LLVM_BUILDDIR_withtype)/build-configured: | install-zlib
 endif
 
 ifeq ($(USE_SYSTEM_ZSTD), 0)
-$(LLVM_BUILDDIR_withtype)/build-configured: | $(build_prefix)/manifest/zstd
+$(LLVM_BUILDDIR_withtype)/build-configured: | install-zstd
 endif
 
 

--- a/deps/mpfr.mk
+++ b/deps/mpfr.mk
@@ -2,7 +2,7 @@
 include $(SRCDIR)/mpfr.version
 
 ifeq ($(USE_SYSTEM_GMP), 0)
-$(BUILDDIR)/mpfr-$(MPFR_VER)/build-configured: | $(build_prefix)/manifest/gmp
+$(BUILDDIR)/mpfr-$(MPFR_VER)/build-configured: | install-gmp
 endif
 
 ifneq ($(USE_BINARYBUILDER_MPFR),1)

--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -8,11 +8,11 @@ LIBUNWIND_CPPFLAGS := -I$(build_includedir)
 LIBUNWIND_LDFLAGS := -L$(build_shlibdir)
 
 ifeq ($(USE_SYSTEM_ZLIB),0)
-$(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured: | $(build_prefix)/manifest/zlib
+$(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured: | install-zlib
 endif
 
 ifeq ($(USE_SYSTEM_LLVM),0)
-$(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER)/build-configured: | $(build_prefix)/manifest/llvm
+$(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER)/build-configured: | install-llvm
 endif
 
 $(SRCCACHE)/libunwind-$(UNWIND_VER).tar.gz: | $(SRCCACHE)


### PR DESCRIPTION
Change libssh2 to depend on `install-openssl` instead of just the manifest file to ensure OpenSSL is fully installed before libssh2 configuration.

Fixes build failures where libssh2 CMake configuration runs before OpenSSL installation is complete, causing "Could NOT find OpenSSL" errors.

Claude suggested this based on https://buildkite.com/julialang/julia-buildkite-scheduled/builds/1333#01985642-15fe-4526-ac73-1cbbd40d85b4