### PR TITLE
iterator: improve type inference for `Filter`

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -534,10 +534,15 @@ filter(flt, itr) = Filter(flt, itr)
 function iterate(f::Filter, state...)
     y = iterate(f.itr, state...)
     while y !== nothing
-        if f.flt(y[1])
-            return y
+        v, s = y
+        if f.flt(v)
+            if y isa Tuple{Any,Any}
+                return (v, s) # incorporate type information that may be improved by user-provided `f.flt`
+            else
+                return y
+            end
         end
-        y = iterate(f.itr, y[2])
+        y = iterate(f.itr, s)
     end
     nothing
 end

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -536,10 +536,11 @@ function iterate(f::Filter, state...)
     while y !== nothing
         v, s = y
         if f.flt(v)
-            # Incorporate type information that may be improved by user-provided `f.flt`:
-            # This forces the return value of `iterate(::Filter, state...)` to always be `Tuple{Any,Any}`,
-            # but since that return value is only used by `iterate(::Filter, state...)`, this should be fine.
-            return (v, s)
+            if y isa Tuple{Any,Any}
+                return (v, s) # incorporate type information that may be improved by user-provided `f.flt`
+            else
+                return y
+            end
         end
         y = iterate(f.itr, s)
     end

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -536,11 +536,10 @@ function iterate(f::Filter, state...)
     while y !== nothing
         v, s = y
         if f.flt(v)
-            if y isa Tuple{Any,Any}
-                return (v, s) # incorporate type information that may be improved by user-provided `f.flt`
-            else
-                return y
-            end
+            # Incorporate type information that may be improved by user-provided `f.flt`:
+            # This forces the return value of `iterate(::Filter, state...)` to always be `Tuple{Any,Any}`,
+            # but since that return value is only used by `iterate(::Filter, state...)`, this should be fine.
+            return (v, s)
         end
         y = iterate(f.itr, s)
     end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -1201,3 +1201,8 @@ end
 @testset "Iterators docstrings" begin
     @test isempty(Docs.undocumented_names(Iterators))
 end
+
+# Filtered list comprehension (`Filter` construct) type inference
+@test Base.infer_return_type((Vector{Any},)) do xs
+    [x for x in xs if x isa Int]
+end == Vector{Int}


### PR DESCRIPTION
This addresses type inference issues with filtered list comprehensions reported in JuliaLang/julia#59111. The root cause is the compiler's inability to perform type refinement in cases like:

```julia
let t::Tuple{Any,Any}
    x, y = t
    if x isa Int
        return t # still `::Tuple{Any,Any}`
    end
    nothing
end
```

Fixing this fundamentally would require extensive improvements to
abstract interpretation. As a workaround, I improved the iterators.jl
implementation to avoid this pattern.

One implementation consideration: if `iterate(f.itr, state...)` always
returns `Union{Nothing,Tuple{Any,Any}}`, the `if y isa Tuple{Any,Any}`
branch should be unnecessary. However, it's unclear whether we can
safely assume this for the iterate interface, so I kept the branch for
now.