### PR TITLE
Use ios to support ridiculous DL_LOAD_PATH length

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -68,8 +68,6 @@ const char *jl_crtdll_name = CRTDLL_BASENAME ".dll";
 #undef CRTDLL_BASENAME
 #endif
 
-#define PATHBUF 4096
-
 #ifdef _OS_WINDOWS_
 void win32_formatmessage(DWORD code, char *reason, int len) JL_NOTSAFEPOINT
 {
@@ -272,7 +270,7 @@ void *jl_find_dynamic_library_by_addr(void *symbol, int throw_err) {
 
 JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, int throw_err)
 {
-    char path[PATHBUF], relocated[PATHBUF];
+    ios_t path, relocated;
     int i;
 #ifdef _OS_WINDOWS_
     int err;
@@ -284,7 +282,6 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
     // number of extensions to try — if modname already ends with the
     // standard extension, then we don't try adding additional extensions
     int n_extensions = endswith_extension(modname) ? 1 : N_EXTENSIONS;
-    int ret;
 
     // modname == NULL is a sentinel value requesting the handle of libjulia-internal
     if (modname == NULL)
@@ -309,6 +306,9 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
     }
 #endif
 
+    ios_mem(&path, IOS_INLSIZE);
+    ios_mem(&relocated, IOS_INLSIZE);
+
     /*
       this branch permutes all base paths in DL_LOAD_PATH with all extensions
       note: skip when !jl_base_module to avoid UndefVarError(:DL_LOAD_PATH),
@@ -325,43 +325,41 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
             size_t j;
             for (j = 0; j < jl_array_nrows(DL_LOAD_PATH); j++) {
                 char *dl_path = jl_string_data(jl_array_ptr_data(DL_LOAD_PATH)[j]);
-                size_t len = strlen(dl_path);
-                if (len == 0)
+                if (*dl_path == 0)
                     continue;
 
+                ios_trunc(&relocated, 0);
+
                 // Is this entry supposed to be relative to the bindir?
-                if (len >= 16 && strncmp(dl_path, "@executable_path", 16) == 0) {
-                    snprintf(relocated, PATHBUF, "%s%s", jl_options.julia_bindir, dl_path + 16);
-                    len = len - 16 + strlen(jl_options.julia_bindir);
+                if (strncmp(dl_path, "@executable_path", 16) == 0) {
+                    ios_printf(&relocated, "%s%s", jl_options.julia_bindir, dl_path + 16);
                 } else {
-                    strncpy(relocated, dl_path, PATHBUF);
-                    relocated[PATHBUF-1] = '\0';
+                    ios_puts(dl_path, &relocated);
                 }
+                ios_putc(0, &relocated);
                 for (i = 0; i < n_extensions; i++) {
+                    ios_trunc(&path, 0);
                     const char *ext = extensions[i];
-                    path[0] = '\0';
-                    if (relocated[len-1] == PATHSEPSTRING[0])
-                        snprintf(path, PATHBUF, "%s%s%s", relocated, modname, ext);
-                    else {
-                        ret = snprintf(path, PATHBUF, "%s" PATHSEPSTRING "%s%s", relocated, modname, ext);
-                        if (ret < 0)
-                            jl_errorf("path is longer than %d\n", PATHBUF);
-                    }
+                    if (relocated.buf[relocated.bpos - 2] == PATHSEPSTRING[0])
+                        ios_printf(&path, "%s%s%s", relocated.buf, modname, ext);
+                    else
+                        ios_printf(&path, "%s" PATHSEPSTRING "%s%s", relocated.buf, modname, ext);
+                    ios_putc(0, &path);
 
 #ifdef _OS_WINDOWS_
                     if (i == 0) { // LoadLibrary already tested the extensions, we just need to check the `stat` result
 #endif
-                        handle = jl_dlopen(path, flags);
+                        handle = jl_dlopen(path.buf, flags);
                         if (handle && !(flags & JL_RTLD_NOLOAD))
                             jl_timing_puts(JL_TIMING_DEFAULT_BLOCK, jl_pathname_for_handle(handle));
                         if (handle)
-                            return handle;
+                            goto success;
 #ifdef _OS_WINDOWS_
                         err = GetLastError();
                     }
 #endif
                     // bail out and show the error if file actually exists
-                    if (jl_stat(path, (char*)&stbuf) == 0)
+                    if (jl_stat(path.buf, (char*)&stbuf) == 0)
                         goto notfound;
                 }
             }
@@ -370,20 +368,21 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
 
     // now fall back and look in default library paths, for all extensions
     for (i = 0; i < n_extensions; i++) {
+        ios_trunc(&path, 0);
         const char *ext = extensions[i];
-        path[0] = '\0';
-        snprintf(path, PATHBUF, "%s%s", modname, ext);
-        handle = jl_dlopen(path, flags);
+        ios_printf(&path, "%s%s", modname, ext);
+        ios_putc(0, &path);
+        handle = jl_dlopen(path.buf, flags);
         if (handle && !(flags & JL_RTLD_NOLOAD))
             jl_timing_puts(JL_TIMING_DEFAULT_BLOCK, jl_pathname_for_handle(handle));
         if (handle)
-            return handle;
+            goto success;
 #ifdef _OS_WINDOWS_
         err = GetLastError();
         break; // LoadLibrary already tested the rest
 #else
         // bail out and show the error if file actually exists
-        if (jl_stat(path, (char*)&stbuf) == 0)
+        if (jl_stat(path.buf, (char*)&stbuf) == 0)
             break;
 #endif
     }
@@ -396,10 +395,15 @@ notfound:
 #else
         const char *reason = dlerror();
 #endif
+        ios_close(&relocated);
+        ios_close(&path);
         jl_errorf("could not load library \"%s\"\n%s", modname, reason);
     }
     handle = NULL;
 
+success:
+    ios_close(&relocated);
+    ios_close(&path);
     return handle;
 }
 


### PR DESCRIPTION
Use `ios_t` as a string builder for library paths to support really long `DL_LOAD_PATH` entries. `jl_load_dynamic_library` can't use the Julia GC to allocate because we're called from `JuliaOJIT::DLSymOptimizer::lookup` with `symbols_mutex` held.

Fixes #59130.