### PR TITLE
Fix desugaring of `const x::T = y` for complex `y`

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1645,9 +1645,9 @@
                (expand-forms
                 ;; TODO: This behaviour (`const _:T = ...` does not call convert,
                 ;; but still evaluates RHS) should be documented.
-                `(const ,(car e) ,(if (underscore-symbol? (car e))
-                                rhs
-                                (convert-for-type-decl rhs T #t #f))))
+                `(const (= ,(car e) ,(if (underscore-symbol? (car e))
+                                         rhs
+                                         (convert-for-type-decl rhs T #t #f)))))
                (expand-forms
                 `(block ,@(cdr e)
                         ;; TODO: When x is a complex expression, this acts as a

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -4305,6 +4305,24 @@ end
 @test letf_57470(3) == 5
 @test letT_57470 === Int64
 
+# Closure conversion should happen on const assignment rhs
+module M59128
+using Test
+const        x0::Int = (()->1)()
+global       x1::Int = (()->1)()
+global const x2::Int = (()->1)()
+const global x3::Int = (()->1)()
+@test x0 === x1 === x2 === x3 === 1
+let g = 1
+    global       x4::Vector{T} where {T<:Number} = let; (()->[g])(); end
+    const global x5::Vector{T} where {T<:Number} = let; (()->[g])(); end
+    global const x6::Vector{T} where {T<:Number} = let; (()->[g])(); end
+end
+@test x4 == x5 == x6 == [1]
+const letT_57470{T} = (()->Int64)()
+@test letT_57470 == Int64
+end
+
 end # M57470_sub
 
 # lowering globaldecl with complex type


### PR DESCRIPTION
Fix #59128

Assignment desugaring of `(const (= (|::| x T) rhs))` would pre-expand to, then re-expand `(const x ,(convert-for-type-decl rhs T))`, but two-arg (IR) const is expected to have a simple RHS---closure conversion doesn't recurse here (should it?), giving us partially-lowered IR, and hence our bug.

Fix: Pre-expand to the one-arg AST const form `(const (= x ,(convert-for-type-decl rhs T)))` instead.  This also gives us a `(latestworld)` we were missing before, so this lowering may have been originally intended.