### PR TITLE
rename `GlobalMethods` to `methodtable` :bike: :house: 

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -369,7 +369,7 @@ function find_union_split_method_matches(interp::AbstractInterpreter, argtypes::
         end
         valid_worlds = intersect(valid_worlds, thismatches.valid_worlds)
         thisfullmatch = any(match::MethodMatch->match.fully_covers, thismatches)
-        mt = Core.GlobalMethods
+        mt = Core.methodtable
         thisinfo = MethodMatchInfo(thismatches, mt, sig_n, thisfullmatch)
         push!(infos, thisinfo)
         for idx = 1:length(thismatches)
@@ -390,7 +390,7 @@ function find_simple_method_matches(interp::AbstractInterpreter, @nospecialize(a
         return FailedMethodMatch("Too many methods matched")
     end
     fullmatch = any(match::MethodMatch->match.fully_covers, matches)
-    mt = Core.GlobalMethods
+    mt = Core.methodtable
     info = MethodMatchInfo(matches, mt, atype, fullmatch)
     applicable = MethodMatchTarget[MethodMatchTarget(matches[idx], info.edges, idx) for idx = 1:length(matches)]
     return MethodMatches(applicable, info, matches.valid_worlds)

--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -49,14 +49,14 @@ function _add_edges_impl(edges::Vector{Any}, info::MethodMatchInfo, mi_edge::Boo
     if !fully_covering(info)
         exists = false
         for i in 2:length(edges)
-            if edges[i] === Core.GlobalMethods && edges[i-1] == info.atype
+            if edges[i] === Core.methodtable && edges[i-1] == info.atype
                 exists = true
                 break
             end
         end
         if !exists
             push!(edges, info.atype)
-            push!(edges, Core.GlobalMethods)
+            push!(edges, Core.methodtable)
         end
     end
     nmatches = length(info.results)

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -3208,7 +3208,7 @@ function _hasmethod_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, sv
     if match === nothing
         rt = Const(false)
         vresults = MethodLookupResult(Any[], valid_worlds, true)
-        mt = Core.GlobalMethods
+        mt = Core.methodtable
         vinfo = MethodMatchInfo(vresults, mt, types, false) # XXX: this should actually be an info with invoke-type edge
     else
         rt = Const(true)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2545,7 +2545,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
 
     add_builtin("Module", (jl_value_t*)jl_module_type);
     add_builtin("MethodTable", (jl_value_t*)jl_methtable_type);
-    add_builtin("GlobalMethods", (jl_value_t*)jl_method_table);
+    add_builtin("methodtable", (jl_value_t*)jl_method_table);
     add_builtin("MethodCache", (jl_value_t*)jl_methcache_type);
     add_builtin("Method", (jl_value_t*)jl_method_type);
     add_builtin("CodeInstance", (jl_value_t*)jl_code_instance_type);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2956,7 +2956,7 @@ void jl_init_types(void) JL_GC_DISABLED
     XX(simplevector);
     jl_methcache_type = jl_new_uninitialized_datatype();
     jl_methtable_type = jl_new_uninitialized_datatype();
-    jl_method_table = jl_new_method_table(jl_symbol("GlobalMethods"), core);
+    jl_method_table = jl_new_method_table(jl_symbol("methodtable"), core);
 
     jl_emptysvec = (jl_svec_t*)jl_gc_permobj(sizeof(void*), jl_simplevector_type, 0);
     jl_set_typetagof(jl_emptysvec, jl_simplevector_tag, GC_OLD_MARKED);

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1081,7 +1081,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         n += jl_printf(out, "nothing");
     }
     else if (v == (jl_value_t*)jl_method_table) {
-        n += jl_printf(out, "Core.GlobalMethods");
+        n += jl_printf(out, "Core.methodtable");
     }
     else if (vt == jl_string_type) {
         n += jl_static_show_string(out, jl_string_data(v), jl_string_len(v), 1, 0);

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1129,7 +1129,7 @@ function deserialize(s::AbstractSerializer, ::Type{Method})
             meth.recursion_relation = recursion_relation
         end
         if !is_for_opaque_closure
-            mt = Core.GlobalMethods
+            mt = Core.methodtable
             if nothing === ccall(:jl_methtable_lookup, Any, (Any, UInt), sig, Base.get_world_counter()) # XXX: quite sketchy?
                 ccall(:jl_method_table_insert, Cvoid, (Any, Any, Ptr{Cvoid}), mt, meth, C_NULL)
             end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2243,7 +2243,7 @@ function detect_ambiguities(mods::Module...;
             end
         end
     end
-    examine(Core.GlobalMethods)
+    examine(Core.methodtable)
     return collect(ambs)
 end
 
@@ -2291,7 +2291,7 @@ function detect_unbound_args(mods...;
             push!(ambs, m)
         end
     end
-    examine(Core.GlobalMethods)
+    examine(Core.methodtable)
     return collect(ambs)
 end
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1632,10 +1632,10 @@ end
 let errs = IOBuffer()
     run(`$(Base.julia_cmd()) -e '
         using Test
-        @test !isempty(Core.GlobalMethods.backedges)
+        @test !isempty(Core.methodtable.backedges)
         Base.Experimental.disable_new_worlds()
         @test_throws "disable_new_worlds" @eval f() = 1
-        @test isempty(Core.GlobalMethods.backedges)
+        @test isempty(Core.methodtable.backedges)
         @test_throws "disable_new_worlds" Base.delete_method(which(+, (Int, Int)))
         @test 1+1 == 2
         using Dates

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -198,7 +198,7 @@ z26506 = Any["ABC"]
 f26506(x::Int) = 2
 g26506(z26506) # Places an entry for f26506(::String) in MethodTable cache
 w26506 = Base.get_world_counter()
-cache26506 = ccall(:jl_mt_find_cache_entry, Any, (Any, Any, UInt), Core.GlobalMethods.cache, Tuple{typeof(f26506),String}, w26506)::Core.TypeMapEntry
+cache26506 = ccall(:jl_mt_find_cache_entry, Any, (Any, Any, UInt), Core.methodtable.cache, Tuple{typeof(f26506),String}, w26506)::Core.TypeMapEntry
 @test cache26506.max_world === typemax(UInt)
 w26506 = Base.get_world_counter()
 f26506(x::String) = 3


### PR DESCRIPTION
This is not a type, so I don't think it should use TypeCase, and it isn't really tied to globals though that isn't so important. This also might move in the future so maybe we should use `_allmethods`? Or maybe `methodtable` (matching `jl_method_table` in C).