### PR TITLE
Replace PATH cache update synchronization in REPLCompletions tests

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -331,22 +331,19 @@ end
 const PATH_cache_lock = Base.ReentrantLock()
 const PATH_cache = Set{String}()
 PATH_cache_task::Union{Task,Nothing} = nothing
-PATH_cache_condition::Union{Threads.Condition, Nothing} = nothing # used for sync in tests
 next_cache_update::Float64 = 0.0
 function maybe_spawn_cache_PATH()
-    global PATH_cache_task, PATH_cache_condition, next_cache_update
+    global PATH_cache_task, next_cache_update
     # Extract to local variables to enable flow-sensitive type inference for these global variables
     PATH_cache_task_local = PATH_cache_task
-    PATH_cache_condition_local = PATH_cache_condition
     @lock PATH_cache_lock begin
         PATH_cache_task_local isa Task && !istaskdone(PATH_cache_task_local) && return
         time() < next_cache_update && return
         PATH_cache_task = Threads.@spawn begin
-            REPLCompletions.cache_PATH()
             @lock PATH_cache_lock begin
+            REPLCompletions.cache_PATH()
                 next_cache_update = time() + 10 # earliest next update can run is 10s after
                 PATH_cache_task = nothing # release memory when done
-                PATH_cache_condition_local !== nothing && notify(PATH_cache_condition_local)
             end
         end
         PATH_cache_task_local = PATH_cache_task

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -340,8 +340,8 @@ function maybe_spawn_cache_PATH()
         PATH_cache_task_local isa Task && !istaskdone(PATH_cache_task_local) && return
         time() < next_cache_update && return
         PATH_cache_task = Threads.@spawn begin
-            @lock PATH_cache_lock begin
             REPLCompletions.cache_PATH()
+            @lock PATH_cache_lock begin
                 next_cache_update = time() + 10 # earliest next update can run is 10s after
                 PATH_cache_task = nothing # release memory when done
             end

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1076,39 +1076,6 @@ let c, r, res
     @test res === false
 end
 
-# A pair of utility function for the REPL completions test to test PATH_cache
-# dependent completions, which ordinarily happen asynchronously.
-# Only to be used from the test suite
-function test_only_arm_cache_refresh()
-    @lock REPL.REPLCompletions.PATH_cache_lock begin
-        @assert REPL.REPLCompletions.PATH_cache_condition === nothing
-
-        # Arm a condition we can wait on
-        REPL.REPLCompletions.PATH_cache_condition = Threads.Condition(REPL.REPLCompletions.PATH_cache_lock)
-
-        # Check if the previous update is still running - if so, wait for it to finish
-        while REPL.REPLCompletions.PATH_cache_task !== nothing
-            @assert !istaskdone(REPL.REPLCompletions.PATH_cache_task)
-            wait(REPL.REPLCompletions.PATH_cache_condition)
-        end
-
-        # force the next cache update to happen immediately
-        REPL.REPLCompletions.next_cache_update = 0
-    end
-    return REPL.REPLCompletions.PATH_cache_condition
-end
-
-function test_only_wait_cache_path_done()
-    @lock REPL.REPLCompletions.PATH_cache_lock begin
-        @assert REPL.REPLCompletions.PATH_cache_condition !== nothing
-
-        while REPL.REPLCompletions.next_cache_update == 0.
-            wait(REPL.REPLCompletions.PATH_cache_condition)
-        end
-        REPL.REPLCompletions.PATH_cache_condition = nothing
-    end
-end
-
 if Sys.isunix()
 let s, c, r
     #Assume that we can rely on the existence and accessibility of /tmp
@@ -1240,9 +1207,7 @@ let s, c, r
                 # Files reachable by PATH are cached async when PATH is seen to have been changed by `complete_path`
                 # so changes are unlikely to appear in the first complete. For testing purposes we can wait for
                 # caching to finish
-                test_only_arm_cache_refresh()
-                c,r = test_scomplete(s)
-                test_only_wait_cache_path_done()
+                REPLCompletions.cache_PATH()
                 c,r = test_scomplete(s)
                 @test "tmp-executable" in c
                 @test r == 1:9
@@ -1271,9 +1236,7 @@ let s, c, r
 
             withenv("PATH" => string(tempdir(), ":", dir)) do
                 s = string("repl-completio")
-                test_only_arm_cache_refresh()
-                c,r = test_scomplete(s)
-                test_only_wait_cache_path_done()
+                REPLCompletions.cache_PATH()
                 c,r = test_scomplete(s)
                 @test ["repl-completion"] == c
                 @test s[r] == "repl-completio"


### PR DESCRIPTION
Attempt to fix flakiness (https://buildkite.com/julialang/julia-master/builds/49532#01985bab-e15a-4efb-81a4-d53fdae669d4) by blocking on `REPLCompletions.cache_PATH()` in the tests that rely on it.