### PR TITLE
replcompletions: Try to make the test more robust

### DIFF
--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1095,7 +1095,7 @@ function test_only_arm_cache_refresh()
         # force the next cache update to happen immediately
         REPL.REPLCompletions.next_cache_update = 0
     end
-    return REPL.REPLCompletions.PATH_cache_condition
+    return nothing
 end
 
 function test_only_wait_cache_path_done()


### PR DESCRIPTION
This is an alternative to #59161, attempting to fix the same observed CI behavior. I don't think #59161 is the best way to fix it, as the point of these tests is to make sure that REPL completions looks up the PATH internally. Calling the path update function explicitly defeats that somewhat. The extra synchronization here to make this deterministic is messy, but I do think it makes the test closer to real-world usage.

The core attempted fix here is to move the read of the PATH_ locals inside `maybe_spawn_cache_PATH` into the locked region. If they are not under the lock, they could be unconditionally overwritten by a second call to this function, causing issues in the state machine. I do not know whether this is the cause of the observed CI hangs, but it's worth fixing anyway.