### PR TITLE
Small documentation improvement for `insertdims`

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -48,7 +48,7 @@ _sub(t::Tuple, s::Tuple) = _sub(tail(t), tail(s))
 """
     dropdims(A; dims)
 
-Return an array with the same data as `A`, but with the dimensions specified by
+Inverse of [`insertdims`](@ref); return an array with the same data as `A`, but with the dimensions specified by
 `dims` removed. `size(A,d)` must equal 1 for every `d` in `dims`,
 and repeated dimensions or numbers outside `1:ndims(A)` are forbidden.
 
@@ -56,7 +56,7 @@ The result shares the same underlying data as `A`, such that the
 result is mutable if and only if `A` is mutable, and setting elements of one
 alters the values of the other.
 
-See also: [`reshape`](@ref), [`vec`](@ref).
+See also: [`insertdims`](@ref), [`reshape`](@ref), [`vec`](@ref).
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Hi,

I noticed we do a reference from `insertdims` to `dropdims` but not the other way round.

So I added a similar reference as in `dropdims` which is added in 1.12 (#45793)


Best,

Felix