### PR TITLE
Remove unnecessary `@inbounds` in `fill!`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -336,7 +336,7 @@ function fill!(dest::Array{T}, x) where T
 end
 function _fill!(dest::Array{T}, x::T) where T
     for i in eachindex(dest)
-        @inbounds dest[i] = x
+        dest[i] = x
     end
     return dest
 end


### PR DESCRIPTION
LLVM can elide this and our effect analysis doesn't know that the `@inbounds` is safe here.

```julia-repl
julia> function my_fill(x,y)
           v = Vector{typeof(x)}(undef, y)
           for i in eachindex(v)
               v[i] = y
           end
           v
       end
my_fill (generic function with 1 method)

julia> Base.infer_effects(fill, Tuple{Int, Int})
(!c,+e,!n,!t,+s,+m,!u,+o,+r)

julia> Base.infer_effects(my_fill, Tuple{Int, Int})
(!c,+e,!n,!t,+s,+m,+u,+o,+r)

julia> @b fill(10, 10)
12.152 ns (2 allocs: 144 bytes)

julia> @b fill(10, 10)
12.179 ns (2 allocs: 144 bytes)

julia> @b fill(10, 10)
12.187 ns (2 allocs: 144 bytes)

julia> @b my_fill(10, 10)
11.806 ns (2 allocs: 144 bytes)

julia> @b my_fill(10, 10)
12.152 ns (2 allocs: 144 bytes)

julia> @b my_fill(10, 10)
12.190 ns (2 allocs: 144 bytes)
```