### PR TITLE
don't hash buflen at start of stream

### DIFF
--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -280,7 +280,7 @@ end
     )
     # Adapted with gratitude from [rapidhash](https://github.com/Nicoshev/rapidhash)
     buflen = UInt64(n)
-    seed = seed ⊻ (hash_mix(seed ⊻ secret[1], secret[2]) ⊻ buflen)
+    seed ⊻= hash_mix(seed ⊻ secret[1], secret[2])
 
     a = zero(UInt64)
     b = zero(UInt64)


### PR DESCRIPTION
fixes https://github.com/JuliaLang/julia/issues/59172

@ScottPJones , is it important that the `⊻ buflen` at the very end on L343 is also removed? or only at the beginning