### PR TITLE
upgrade rapidhash v1 to v3 and fix several bugs in _hash_integer translation

### DIFF
--- a/stdlib/TOML/test/print.jl
+++ b/stdlib/TOML/test/print.jl
@@ -83,18 +83,18 @@ loaders = ["gzip", { driver = "csv", args = {delim = "\t"}}]
 @testset "vec with dicts and non-dicts" begin
     # https://github.com/JuliaLang/julia/issues/45340
     d =  Dict("b" => Any[111, Dict("a" =>  222, "d" => 333)])
-    @test toml_str(d) == (sizeof(Int) == 8 ?
+    @test toml_str(d) == (sizeof(Int) == 4 ?
         "b = [111, {a = 222, d = 333}]\n" :
         "b = [111, {d = 333, a = 222}]\n")
 
 
     d =  Dict("b" => Any[Dict("a" =>  222, "d" => 333), 111])
-    @test toml_str(d) == (sizeof(Int) == 8 ?
+    @test toml_str(d) == (sizeof(Int) == 4 ?
         "b = [{a = 222, d = 333}, 111]\n" :
         "b = [{d = 333, a = 222}, 111]\n")
 
     d =  Dict("b" => Any[Dict("a" =>  222, "d" => 333)])
-    @test toml_str(d) == (sizeof(Int) == 8 ?
+    @test toml_str(d) == (sizeof(Int) == 4 ?
         """
         [[b]]
         a = 222


### PR DESCRIPTION
The rapidhash v3 algorithm supports streaming data, which makes it much more suitable for use as a string hasher than the original. This is actually v3 nano, since it is more similar to the original v1, but without as much vectorization performance improvements v3. This is intended to be the first in a sequence of several more PRs to improve upon this code to be usable in more generic situations.

It also fixes several bugs in the translation to hashing integers.

Initial version written by Claude, with full review and correction by myself afterwards (it caught none of the bugs, but got most of the updates right).