### PR TITLE
Simplify fill! bootstrapping and remove `@inbounds` for AbstractArray

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -327,18 +327,50 @@ copyto!(dest::Array{T}, src::Array{T}) where {T} = _copyto2arg!(dest, src)
 copyto!(dest::Array{T}, src::Memory{T}) where {T} = _copyto2arg!(dest, src)
 copyto!(dest::Memory{T}, src::Array{T}) where {T} = _copyto2arg!(dest, src)
 
-# N.B: The generic definition in multidimensional.jl covers, this, this is just here
-# for bootstrapping purposes.
-function fill!(dest::Array{T}, x) where T
+# N.B: This generic definition in for multidimensional arrays is here instead of
+# `multidimensional.jl` for bootstrapping purposes.
+"""
+    fill!(A, x)
+
+Fill array `A` with the value `x`. If `x` is an object reference, all elements will refer to
+the same object. `fill!(A, Foo())` will return `A` filled with the result of evaluating
+`Foo()` once.
+
+# Examples
+```jldoctest
+julia> A = zeros(2,3)
+2×3 Matrix{Float64}:
+ 0.0  0.0  0.0
+ 0.0  0.0  0.0
+
+julia> fill!(A, 2.)
+2×3 Matrix{Float64}:
+ 2.0  2.0  2.0
+ 2.0  2.0  2.0
+
+julia> a = [1, 1, 1]; A = fill!(Vector{Vector{Int}}(undef, 3), a); a[1] = 2; A
+3-element Vector{Vector{Int64}}:
+ [2, 1, 1]
+ [2, 1, 1]
+ [2, 1, 1]
+
+julia> x = 0; f() = (global x += 1; x); fill!(Vector{Int}(undef, 3), f())
+3-element Vector{Int64}:
+ 1
+ 1
+ 1
+```
+"""
+function fill!(A::AbstractArray{T}, x) where T
     @inline
-    x = x isa T ? x : convert(T, x)::T
-    return _fill!(dest, x)
+    xT = x isa T ? x : convert(T, x)::T
+    return _fill!(A, xT)
 end
-function _fill!(dest::Array{T}, x::T) where T
-    for i in eachindex(dest)
-        dest[i] = x
+function _fill!(A::AbstractArray{T}, x::T) where T
+    for i in eachindex(A)
+        A[i] = x
     end
-    return dest
+    return A
 end
 
 """

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1173,46 +1173,6 @@ end
 # And in general, checking the intersection is too much work
 _indicesmightoverlap(A::Tuple{Any, Vararg{Any}}, B::Tuple{Any, Vararg{Any}}) = true
 
-"""
-    fill!(A, x)
-
-Fill array `A` with the value `x`. If `x` is an object reference, all elements will refer to
-the same object. `fill!(A, Foo())` will return `A` filled with the result of evaluating
-`Foo()` once.
-
-# Examples
-```jldoctest
-julia> A = zeros(2,3)
-2×3 Matrix{Float64}:
- 0.0  0.0  0.0
- 0.0  0.0  0.0
-
-julia> fill!(A, 2.)
-2×3 Matrix{Float64}:
- 2.0  2.0  2.0
- 2.0  2.0  2.0
-
-julia> a = [1, 1, 1]; A = fill!(Vector{Vector{Int}}(undef, 3), a); a[1] = 2; A
-3-element Vector{Vector{Int64}}:
- [2, 1, 1]
- [2, 1, 1]
- [2, 1, 1]
-
-julia> x = 0; f() = (global x += 1; x); fill!(Vector{Int}(undef, 3), f())
-3-element Vector{Int64}:
- 1
- 1
- 1
-```
-"""
-function fill!(A::AbstractArray{T}, x) where T
-    xT = convert(T, x)
-    for I in eachindex(A)
-        @inbounds A[I] = xT
-    end
-    A
-end
-
 function copyto!(dest::AbstractArray{T1,N}, Rdest::CartesianIndices{N},
                   src::AbstractArray{T2,N}, Rsrc::CartesianIndices{N}) where {T1,T2,N}
     isempty(Rdest) && return dest


### PR DESCRIPTION
Notably, the compiler will not be able to elide bounds checking for all arrays so this could be a performance hit in some cases (otoh better effects could be a performance boon).

I think that 
```julia
for i in eachindex(a::AbstractVector{T})
    @inbounds a[i] = x::T
end
```
is one of the safest possible uses of `@inbounds` on an abstract array and any resulting UB is the fault of the array type so I'm not actually enthusiastic about this change. I made the change based on https://github.com/JuliaLang/julia/pull/59174#issuecomment-3141683213 and https://github.com/JuliaLang/julia/pull/59174#issuecomment-3141886682 but am now having second thoughts.

cc. @giordano @oscardssmith 