### PR TITLE
inference: avoid `LimitedAccuracy` within slot wrappers

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3255,7 +3255,7 @@ function abstract_eval_copyast(interp::AbstractInterpreter, e::Expr, sstate::Sta
     return RTEffects(rt, Any, effects)
 end
 
-function abstract_eval_isdefined_expr(interp::AbstractInterpreter, e::Expr, sstate::StatementState,
+function abstract_eval_isdefined_expr(::AbstractInterpreter, e::Expr, sstate::StatementState,
                                       sv::AbsIntState)
     sym = e.args[1]
     if isa(sym, SlotNumber) && sstate.vtypes !== nothing

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -40,6 +40,9 @@ struct Conditional
                          isdefined::Bool=false)
         assert_nested_slotwrapper(thentype)
         assert_nested_slotwrapper(elsetype)
+        if thentype isa LimitedAccuracy || elsetype isa LimitedAccuracy
+            return Bool
+        end
         return new(slot, thentype, elsetype, isdefined)
     end
 end
@@ -83,6 +86,9 @@ struct MustAlias
         assert_nested_slotwrapper(fldtyp)
         # @assert !isalreadyconst(vartyp) "vartyp is already const"
         # @assert !isalreadyconst(fldtyp) "fldtyp is already const"
+        if vartyp isa LimitedAccuracy || fldtyp isa LimitedAccuracy
+            return fldtyp
+        end
         return new(slot, vartyp, fldidx, fldtyp)
     end
 end
@@ -104,6 +110,9 @@ struct InterMustAlias
         assert_nested_slotwrapper(fldtyp)
         # @assert !isalreadyconst(vartyp) "vartyp is already const"
         # @assert !isalreadyconst(fldtyp) "fldtyp is already const"
+        if vartyp isa LimitedAccuracy || fldtyp isa LimitedAccuracy
+            return fldtyp
+        end
         return new(slot, vartyp, fldidx, fldtyp)
     end
 end


### PR DESCRIPTION
I looked at all the usage sites of these constructors within the compiler, and fortunately it appears that none of the usage sites require that the return values of these constructors be objects of their respective types. So in cases where `LimitedAccuracy` is given as a wrapped element, these slot type refinements simply will not be performed.

- fixes JuliaLang/julia#59004