### PR TITLE
add safer, more versatile version of rapidhash for any array and for any iterable

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -38,7 +38,6 @@ include("subarray.jl")
 include("views.jl")
 
 # numeric operations
-include("hashing.jl")
 include("div.jl")
 include("twiceprecision.jl")
 include("complex.jl")
@@ -89,6 +88,9 @@ include("strings/string.jl")
 include("strings/substring.jl")
 include("strings/cstring.jl")
 
+include("cartesian.jl")
+using .Cartesian
+include("hashing.jl")
 include("osutils.jl")
 
 # Core I/O
@@ -115,8 +117,6 @@ include("arrayshow.jl")
 include("methodshow.jl")
 
 # multidimensional arrays
-include("cartesian.jl")
-using .Cartesian
 include("multidimensional.jl")
 
 include("broadcast.jl")

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -395,9 +395,9 @@ end
 
 ## Resolve expressions at parsing time ##
 
-const exprresolve_arith_dict = Dict{Symbol,Function}(:+ => +,
+const exprresolve_arith_dict = IdDict{Symbol,Function}(:+ => +,
     :- => -, :* => *, :/ => /, :^ => ^, :div => div)
-const exprresolve_cond_dict = Dict{Symbol,Function}(:(==) => ==,
+const exprresolve_cond_dict = IdDict{Symbol,Function}(:(==) => ==,
     :(<) => <, :(>) => >, :(<=) => <=, :(>=) => >=)
 
 function exprresolve_arith(ex::Expr)

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -248,12 +248,8 @@ isequal(z::Real, w::Complex) = isequal(z,real(w))::Bool & isequal(zero(z),imag(w
 
 in(x::Complex, r::AbstractRange{<:Real}) = isreal(x) && real(x) in r
 
-if UInt === UInt64
-    const h_imag = 0x32a7a07f3e7cd1f9
-else
-    const h_imag = 0x3e7cd1f9
-end
-const hash_0_imag = hash(0, h_imag)
+const h_imag = 0x32a7a07f3e7cd1f % UInt
+const hash_0_imag = 0x153e9f914f9b5b92 % UInt
 
 function hash(z::Complex, h::UInt)
     # TODO: with default argument specialization, this would be better:


### PR DESCRIPTION
Tested that array gives the same answer on random data, and that performance is equivalent (with LLVM 20 on AArch64). Neither of these methods is currently used for anything, but the intent is to change some users (e.g. String) to the array interface and other users (e.g. large Numbers and AbstractString) to the iterator interface (I already have both written–or rather Claude does–but in a different repo right now). The iterator interface does not exist anywhere else, since it is about 8x slower (essentially operating byte by byte instead of the intended 64-bit chunks).

```julia
julia> using BenchmarkTools, Random; for n = 0:67:1000
         a = (i % UInt8 for i in 1:n)
         b = collect(a)
         ## Same results for [] and String
         # b = codeunits(randstring(n))
         # a = Base.Generator(identity, b)
         @btime Base.hash_bytes($a, Base.HASH_SEED, Base.HASH_SECRET)
         @btime Base.hash_bytes($b, Base.HASH_SEED, Base.HASH_SECRET)
         @btime Base.hash_bytes(pointer($b), length($b), Base.HASH_SEED, Base.HASH_SECRET)
         println()
       end
  5.666 ns (0 allocations: 0 bytes) # iterator
  3.625 ns (0 allocations: 0 bytes) # array
  3.625 ns (0 allocations: 0 bytes) # pointer

  20.269 ns (0 allocations: 0 bytes)
  5.375 ns (0 allocations: 0 bytes)
  5.083 ns (0 allocations: 0 bytes)

  35.624 ns (0 allocations: 0 bytes)
  6.250 ns (0 allocations: 0 bytes)
  6.208 ns (0 allocations: 0 bytes)

  50.954 ns (0 allocations: 0 bytes)
  7.625 ns (0 allocations: 0 bytes)
  7.334 ns (0 allocations: 0 bytes)

  66.496 ns (0 allocations: 0 bytes)
  9.083 ns (0 allocations: 0 bytes)
  8.875 ns (0 allocations: 0 bytes)

  82.299 ns (0 allocations: 0 bytes)
  10.719 ns (0 allocations: 0 bytes)
  10.511 ns (0 allocations: 0 bytes)

  98.346 ns (0 allocations: 0 bytes)
  12.888 ns (0 allocations: 0 bytes)
  12.513 ns (0 allocations: 0 bytes)
```

PR implemented mostly by Claude, though I had to fix its math in several places since it got quite confused by the logical nesting of if branches and the implications of extracting trailing bytes.

Test "proof" of correctness:
```
julia> @time for n = 0:10000
         b = codeunits(randstring(n))
         a = Base.Generator(identity, b)
         h1 = Base.hash_bytes(a, Base.HASH_SEED, Base.HASH_SECRET)
         h2 = Base.hash_bytes(b, Base.HASH_SEED, Base.HASH_SECRET)
         h3 = Base.hash_bytes(pointer(b), length(b), Base.HASH_SEED, Base.HASH_SECRET)
         @assert h1 == h2 == h3
       end
  0.174760 seconds (10.00 k allocations: 48.855 MiB, 3.97% gc time)
```