### PR TITLE
compiler: eliminate most of unused variables in the compiler

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -111,7 +111,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
                                   arginfo::ArgInfo, si::StmtInfo, @nospecialize(atype),
                                   sv::AbsIntState, max_methods::Int)
     𝕃ₚ, 𝕃ᵢ = ipo_lattice(interp), typeinf_lattice(interp)
-    ⊑ₚ, ⋤ₚ, ⊔ₚ, ⊔ᵢ  = partialorder(𝕃ₚ), strictneqpartialorder(𝕃ₚ), join(𝕃ₚ), join(𝕃ᵢ)
+    ⊑ₚ, ⊔ₚ, ⊔ᵢ  = partialorder(𝕃ₚ), join(𝕃ₚ), join(𝕃ᵢ)
     argtypes = arginfo.argtypes
     if si.saw_latestworld
         add_remark!(interp, sv, "Cannot infer call, because we previously saw :latestworld")
@@ -309,7 +309,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
                 local napplicable = length(applicable)
                 local multiple_matches = napplicable > 1
                 while inferidx[] <= napplicable
-                    (; match, edges, edge_idx) = applicable[inferidx[]]
+                    (; match) = applicable[inferidx[]]
                     inferidx[] += 1
                     local method = match.method
                     local sig = match.spec_types
@@ -343,7 +343,7 @@ function find_method_matches(interp::AbstractInterpreter, argtypes::Vector{Any},
                              max_union_splitting::Int = InferenceParams(interp).max_union_splitting,
                              max_methods::Int = InferenceParams(interp).max_methods)
     if is_union_split_eligible(typeinf_lattice(interp), argtypes, max_union_splitting)
-        return find_union_split_method_matches(interp, argtypes, atype, max_methods)
+        return find_union_split_method_matches(interp, argtypes, max_methods)
     end
     return find_simple_method_matches(interp, atype, max_methods)
 end
@@ -353,7 +353,7 @@ is_union_split_eligible(𝕃::AbstractLattice, argtypes::Vector{Any}, max_union_
     1 < unionsplitcost(𝕃, argtypes) <= max_union_splitting
 
 function find_union_split_method_matches(interp::AbstractInterpreter, argtypes::Vector{Any},
-                                         @nospecialize(atype), max_methods::Int)
+                                         max_methods::Int)
     split_argtypes = switchtupleunion(typeinf_lattice(interp), argtypes)
     infos = MethodMatchInfo[]
     applicable = MethodMatchTarget[]
@@ -994,7 +994,7 @@ function collect_const_args(argtypes::Vector{Any}, start::Int)
 end
 
 function concrete_eval_call(interp::AbstractInterpreter,
-    @nospecialize(f), result::MethodCallResult, arginfo::ArgInfo, sv::AbsIntState,
+    @nospecialize(f), result::MethodCallResult, arginfo::ArgInfo, ::AbsIntState,
     invokecall::Union{InvokeCall,Nothing}=nothing)
     args = collect_const_args(arginfo, #=start=#2)
     if invokecall !== nothing
@@ -1006,7 +1006,7 @@ function concrete_eval_call(interp::AbstractInterpreter,
     edge = result.edge::CodeInstance
     value = try
         Core._call_in_world_total(world, f, args...)
-    catch e
+    catch
         # The evaluation threw. By :consistent-cy, we're guaranteed this would have happened at runtime.
         # Howevever, at present, :consistency does not mandate the type of the exception
         concrete_result = ConcreteResult(edge, result.effects)
@@ -1368,7 +1368,6 @@ function const_prop_call(interp::AbstractInterpreter,
         inf_result.result = concrete_eval_result.rt
         inf_result.ipo_effects = concrete_eval_result.effects
     end
-    typ = inf_result.result
     return const_prop_result(inf_result)
 end
 
@@ -1466,7 +1465,7 @@ function ssa_def_slot(@nospecialize(arg), sv::InferenceState)
 end
 
 # No slots in irinterp
-ssa_def_slot(@nospecialize(arg), sv::IRInterpretationState) = nothing
+ssa_def_slot(@nospecialize(arg), ::IRInterpretationState) = nothing
 
 struct AbstractIterationResult
     cti::Vector{Any}
@@ -2262,7 +2261,7 @@ function abstract_invoke(interp::AbstractInterpreter, arginfo::ArgInfo, si::Stmt
         end
     else
         hasintersect(widenconst(types), Union{Method, CodeInstance}) && return Future(CallMeta(Any, Any, Effects(), NoCallInfo()))
-        (types, isexact, isconcrete, istype) = instanceof_tfunc(argtype_by_index(argtypes, 3), false)
+        types, isexact, _, _ = instanceof_tfunc(argtype_by_index(argtypes, 3), false)
         isexact || return Future(CallMeta(Any, Any, Effects(), NoCallInfo()))
         unwrapped = unwrap_unionall(types)
         types === Bottom && return Future(CallMeta(Bottom, Any, EFFECTS_THROWS, NoCallInfo()))
@@ -2344,7 +2343,7 @@ function abstract_finalizer(interp::AbstractInterpreter, argtypes::Vector{Any}, 
     if length(argtypes) == 3
         finalizer_argvec = Any[argtypes[2], argtypes[3]]
         call = abstract_call(interp, ArgInfo(nothing, finalizer_argvec), StmtInfo(false, false), sv, #=max_methods=#1)::Future
-        return Future{CallMeta}(call, interp, sv) do call, interp, sv
+        return Future{CallMeta}(call, interp, sv) do call, _, _
             return CallMeta(Nothing, Any, Effects(), FinalizerInfo(call.info, call.effects))
         end
     end
@@ -2369,7 +2368,7 @@ function abstract_throw(interp::AbstractInterpreter, argtypes::Vector{Any}, ::Ab
     return Future(CallMeta(Union{}, exct, EFFECTS_THROWS, NoCallInfo()))
 end
 
-function abstract_throw_methoderror(interp::AbstractInterpreter, argtypes::Vector{Any}, ::AbsIntState)
+function abstract_throw_methoderror(::AbstractInterpreter, argtypes::Vector{Any}, ::AbsIntState)
     exct = if length(argtypes) == 1
         ArgumentError
     elseif !isvarargtype(argtypes[2])
@@ -2579,7 +2578,7 @@ end
 function abstract_eval_replaceglobal!(interp::AbstractInterpreter, sv::AbsIntState, saw_latestworld::Bool, argtypes::Vector{Any})
     if !isvarargtype(argtypes[end])
         if length(argtypes) in (5, 6, 7)
-            (M, s, x, v) = argtypes[2], argtypes[3], argtypes[4], argtypes[5]
+            (M, s, v) = argtypes[2], argtypes[3], argtypes[5]
             T = nothing
             if isa(M, Const) && isa(s, Const)
                 M, s = M.val, s.val
@@ -2855,7 +2854,6 @@ function abstract_call_opaque_closure(interp::AbstractInterpreter,
 end
 
 function most_general_argtypes(closure::PartialOpaque)
-    ret = Any[]
     cc = widenconst(closure)
     argt = (unwrap_unionall(cc)::DataType).parameters[1]
     if !isa(argt, DataType) || argt.name !== typename(Tuple)
@@ -3054,7 +3052,7 @@ function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo, sstate::St
     end
     si = StmtInfo(!unused, sstate.saw_latestworld)
     call = abstract_call(interp, arginfo, si, sv)::Future
-    Future{Any}(call, interp, sv) do call, interp, sv
+    Future{Any}(call, interp, sv) do call, _, sv
         # this only is needed for the side-effect, sequenced before any task tries to consume the return value,
         # which this will do even without returning this Future
         sv.stmt_info[sv.currpc] = call.info
@@ -3072,7 +3070,7 @@ function abstract_eval_call(interp::AbstractInterpreter, e::Expr, sstate::Statem
     end
     arginfo = ArgInfo(ea, argtypes)
     call = abstract_call(interp, arginfo, sstate, sv)::Future
-    return Future{RTEffects}(call, interp, sv) do call, interp, sv
+    return Future{RTEffects}(call, interp, sv) do call, _, _
         (; rt, exct, effects, refinements) = call
         return RTEffects(rt, exct, effects, refinements)
     end
@@ -3081,7 +3079,7 @@ end
 function abstract_eval_new(interp::AbstractInterpreter, e::Expr, sstate::StatementState,
                            sv::AbsIntState)
     𝕃ᵢ = typeinf_lattice(interp)
-    rt, isexact = instanceof_tfunc(abstract_eval_value(interp, e.args[1], sstate, sv), true)
+    rt, _... = instanceof_tfunc(abstract_eval_value(interp, e.args[1], sstate, sv), true)
     ut = unwrap_unionall(rt)
     exct = Union{ErrorException,TypeError}
     if isa(ut, DataType) && !isabstracttype(ut)
@@ -3234,7 +3232,7 @@ function abstract_eval_new_opaque_closure(interp::AbstractInterpreter, e::Expr, 
                 pushfirst!(argtypes, rt.env)
                 callinfo = abstract_call_opaque_closure(interp, rt,
                     ArgInfo(nothing, argtypes), StmtInfo(true, false), sv, #=check=#false)::Future
-                Future{Any}(callinfo, interp, sv) do callinfo, interp, sv
+                Future{Any}(callinfo, interp, sv) do callinfo, _, sv
                     sv.stmt_info[sv.currpc] = OpaqueClosureCreateInfo(callinfo)
                     nothing
                 end
@@ -3311,7 +3309,7 @@ function abstract_eval_isdefinedglobal(interp::AbstractInterpreter, mod::Module,
         end
     end
 
-    (valid_worlds, rte) = abstract_load_all_consistent_leaf_partitions(interp, gr, sv.world)
+    (_, rte) = abstract_load_all_consistent_leaf_partitions(interp, gr, sv.world)
     if rte.exct == Union{}
         rt = Const(true)
     elseif rte.rt === Union{} && rte.exct === UndefVarError
@@ -3607,13 +3605,10 @@ world_range(compact::IncrementalCompact) = world_range(compact.ir)
 
 function abstract_eval_globalref_type(g::GlobalRef, src::Union{CodeInfo, IRCode, IncrementalCompact})
     worlds = world_range(src)
-    partition = lookup_binding_partition(min_world(worlds), g)
-
     (valid_worlds, rte) = abstract_load_all_consistent_leaf_partitions(nothing, g, WorldWithRange(min_world(worlds), worlds))
     if min_world(valid_worlds) > min_world(worlds) || max_world(valid_worlds) < max_world(worlds)
         return Any
     end
-
     return rte.rt
 end
 
@@ -3730,7 +3725,7 @@ scan_leaf_partitions(query::F, interp::AbstractInterpreter, g::GlobalRef, wwr::W
     scan_specified_partitions(query, walk_binding_partition, interp, g, wwr)
 
 function scan_partitions(query::F, interp::AbstractInterpreter, g::GlobalRef, wwr::WorldWithRange) where F
-    walk_binding_partition = function (b::Core.Binding, partition::Core.BindingPartition, world::UInt)
+    walk_binding_partition = function (b::Core.Binding, partition::Core.BindingPartition, ::UInt)
         Pair{WorldRange, Pair{Core.Binding, Core.BindingPartition}}(
             WorldRange(partition.min_world, partition.max_world), b=>partition)
     end
@@ -4489,7 +4484,6 @@ function typeinf(interp::AbstractInterpreter, frame::InferenceState)
     nextstates = CurrentState[]
     takenext = frame.frameid
     minwarn = warnlength
-    takeprev = 0
     while takenext >= frame.frameid
         callee = takenext == 0 ? frame : callstack[takenext]::InferenceState
         if !isempty(callstack)

--- a/Compiler/src/bootstrap.jl
+++ b/Compiler/src/bootstrap.jl
@@ -48,7 +48,6 @@ function bootstrap!()
             end
         end
         starttime = time()
-        methods = Any[]
         world = get_world_counter()
         for f in fs
             if isa(f, DataType) && f.name === typename(Tuple)

--- a/Compiler/src/inferenceresult.jl
+++ b/Compiler/src/inferenceresult.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-function matching_cache_argtypes(𝕃::AbstractLattice, mi::MethodInstance)
+function matching_cache_argtypes(::AbstractLattice, mi::MethodInstance)
     (; def, specTypes) = mi
     return most_general_argtypes(isa(def, Method) ? def : nothing, specTypes)
 end
@@ -16,7 +16,7 @@ struct WidenedArgtypes
     argtypes::Vector{Any}
 end
 
-function matching_cache_argtypes(𝕃::AbstractLattice, mi::MethodInstance,
+function matching_cache_argtypes(𝕃::AbstractLattice, ::MethodInstance,
                                  simple_argtypes::Union{SimpleArgtypes, WidenedArgtypes},
                                  cache_argtypes::Vector{Any})
     (; argtypes) = simple_argtypes

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -340,12 +340,12 @@ mutable struct InferenceState
         ssavalue_uses = find_ssavalue_uses(code, nssavalues)
         nstmts = length(code)
         edges = []
-        stmt_info = CallInfo[ NoCallInfo() for i = 1:nstmts ]
+        stmt_info = CallInfo[ NoCallInfo() for _ = 1:nstmts ]
 
         nslots = length(src.slotflags)
         slottypes = Vector{Any}(undef, nslots)
-        bb_saw_latestworld = Bool[false for i = 1:length(cfg.blocks)]
-        bb_vartables = Union{Nothing,VarTable}[ nothing for i = 1:length(cfg.blocks) ]
+        bb_saw_latestworld = Bool[false for _ = 1:length(cfg.blocks)]
+        bb_vartables = Union{Nothing,VarTable}[ nothing for _ = 1:length(cfg.blocks) ]
         bb_vartable1 = bb_vartables[1] = VarTable(undef, nslots)
         argtypes = result.argtypes
 
@@ -360,7 +360,7 @@ mutable struct InferenceState
             slottypes[i] = argtyp
             bb_vartable1[i] = VarState(argtyp, i > nargtypes)
         end
-        src.ssavaluetypes = ssavaluetypes = Any[ NOT_FOUND for i = 1:nssavalues ]
+        src.ssavaluetypes = ssavaluetypes = Any[ NOT_FOUND for _ = 1:nssavalues ]
         ssaflags = copy(src.ssaflags)
 
         unreachable = BitSet()
@@ -549,7 +549,7 @@ function (::ComputeTryCatch{Handler})(code::Vector{Any}, bbs::Union{Vector{Basic
                         l += 1
                     end
                     cur_hand = cur_stacks[1]
-                    for i = 1:l
+                    for _ = 1:l
                         cur_hand = handler_at[get_enter_idx(handlers[cur_hand])][1]
                     end
                     cur_stacks = (cur_hand, cur_stacks[2])

--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -135,7 +135,7 @@ function add_one_edge!(edges::Vector{Any}, edge::CodeInstance)
     push!(edges, edge)
     nothing
 end
-nsplit_impl(info::MethodMatchInfo) = 1
+nsplit_impl(::MethodMatchInfo) = 1
 getsplit_impl(info::MethodMatchInfo, idx::Int) = (@assert idx == 1; info.results)
 getresult_impl(::MethodMatchInfo, ::Int) = nothing
 
@@ -279,7 +279,7 @@ struct InvokeCICallInfo <: CallInfo
 end
 add_edges_impl(edges::Vector{Any}, info::InvokeCICallInfo) =
     add_inlining_edge!(edges, info.edge)
-nsplit_impl(info::InvokeCICallInfo) = 0
+nsplit_impl(::InvokeCICallInfo) = 0
 
 """
     info::InvokeCallInfo
@@ -392,7 +392,7 @@ function add_inlining_edge!(edges::Vector{Any}, edge::CodeInstance)
     nothing
 end
 
-nsplit_impl(info::InvokeCallInfo) = 1
+nsplit_impl(::InvokeCallInfo) = 1
 getsplit_impl(info::InvokeCallInfo, idx::Int) = (@assert idx == 1; MethodLookupResult(Core.MethodMatch[info.match],
     WorldRange(typemin(UInt), typemax(UInt)), false))
 getresult_impl(info::InvokeCallInfo, idx::Int) = (@assert idx == 1; info.result)

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -2750,9 +2750,8 @@ function memoryop_noub(@nospecialize(f), argtypes::Vector{Any})
     return false
 end
 
-function current_scope_tfunc(interp::AbstractInterpreter, sv::InferenceState)
+function current_scope_tfunc(::AbstractInterpreter, sv::InferenceState)
     pc = sv.currpc
-    handler_info = sv.handler_info
     while true
         pchandler = gethandler(sv, pc)
         if pchandler === nothing
@@ -2774,7 +2773,7 @@ function current_scope_tfunc(interp::AbstractInterpreter, sv::InferenceState)
         pc = pchandler.enter_idx
     end
 end
-current_scope_tfunc(interp::AbstractInterpreter, sv) = Any
+current_scope_tfunc(::AbstractInterpreter, ::IRInterpretationState) = Any
 
 hasvarargtype(argtypes::Vector{Any}) = !isempty(argtypes) && isvarargtype(argtypes[end])
 
@@ -2964,7 +2963,7 @@ function intrinsic_exct(𝕃::AbstractLattice, f::IntrinsicFunction, argtypes::V
     end
 
     if f === Intrinsics.bitcast
-        ty, isexact, isconcrete = instanceof_tfunc(argtypes[1], true)
+        ty, _, isconcrete, _ = instanceof_tfunc(argtypes[1], true)
         xty = widenconst(argtypes[2])
         if !isconcrete
             return Union{ErrorException, TypeError}
@@ -2980,7 +2979,7 @@ function intrinsic_exct(𝕃::AbstractLattice, f::IntrinsicFunction, argtypes::V
              Intrinsics.sitofp, Intrinsics.fptrunc, Intrinsics.fpext)
         # If !isconcrete, `ty` may be Union{} at runtime even if we have
         # isprimitivetype(ty).
-        ty, isexact, isconcrete = instanceof_tfunc(argtypes[1], true)
+        ty, _, isconcrete, _ = instanceof_tfunc(argtypes[1], true)
         if !isconcrete
             return Union{ErrorException, TypeError}
         end
@@ -3010,7 +3009,7 @@ function intrinsic_exct(𝕃::AbstractLattice, f::IntrinsicFunction, argtypes::V
     end
 
     if f === Intrinsics.have_fma
-        ty, isexact, isconcrete = instanceof_tfunc(argtypes[1], true)
+        ty, _, isconcrete, _ = instanceof_tfunc(argtypes[1], true)
         if !(isconcrete && isprimitivetype(ty))
             return TypeError
         end
@@ -3140,7 +3139,7 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
     end
     call = abstract_call(interp, ArgInfo(nothing, argtypes_vec), si, sv, #=max_methods=#-1)
     tt = Core.Box(tt)
-    return Future{CallMeta}(call, interp, sv) do call, interp, sv
+    return Future{CallMeta}(call, interp, sv) do call, _, sv
         if isa(sv, InferenceState)
             sv.restrict_abstract_call_sites = old_restrict
         end
@@ -3218,7 +3217,7 @@ function _hasmethod_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, sv
     else
         return CallMeta(Any, Any, Effects(), NoCallInfo())
     end
-    (types, isexact, isconcrete, istype) = instanceof_tfunc(argtype_by_index(argtypes, typeidx), false)
+    (types, isexact, _, _) = instanceof_tfunc(argtype_by_index(argtypes, typeidx), false)
     isexact || return CallMeta(Bool, Any, Effects(), NoCallInfo())
     unwrapped = unwrap_unionall(types)
     if types === Bottom || !(unwrapped isa DataType) || unwrapped.name !== Tuple.name
@@ -3295,7 +3294,7 @@ add_tfunc(Core.get_binding_type, 2, 2, @nospecs((𝕃::AbstractLattice, args...)
 
 const FOREIGNCALL_ARG_START = 6
 
-function foreigncall_effects(@nospecialize(abstract_eval), e::Expr)
+function foreigncall_effects(@nospecialize(abstract_eval), ::Expr)
     # `:foreigncall` can potentially perform all sorts of operations, including calling
     # overlay methods, but the `:foreigncall` itself is not dispatched, and there is no
     # concern that the method calls that potentially occur within the `:foreigncall` will
@@ -3318,7 +3317,7 @@ function new_genericmemory_nothrow(@nospecialize(abstract_eval), args::Vector{An
     0 < dimval < typemax(Int) || return false
     tot, ovflw = Intrinsics.checked_smul_int(dimval, elsz)
     ovflw && return false
-    isboxed = 1; isunion = 2
+    isunion = 2
     tot, ovflw = Intrinsics.checked_sadd_int(tot, arrayelem == isunion ? 1 + dimval : 1)
     ovflw && return false
     return true

--- a/Compiler/src/timing.jl
+++ b/Compiler/src/timing.jl
@@ -32,7 +32,7 @@ if ccall(:jl_timing_enabled, Cint, ()) != 0
         return getzonedexpr(name, ex, :unknown_julia_function, __source__.file, __source__.line, 0)
     end
 else
-    macro zone(name, ex::Expr)
+    macro zone(_, ex::Expr)
         return esc(ex)
     end
 end

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -91,7 +91,7 @@ If set to `true`, record per-method-instance timings within type inference in th
 __set_measure_typeinf(onoff::Bool) = __measure_typeinf__[] = onoff
 const __measure_typeinf__ = RefValue{Bool}(false)
 
-function result_edges(interp::AbstractInterpreter, caller::InferenceState)
+function result_edges(::AbstractInterpreter, caller::InferenceState)
     result = caller.result
     opt = result.src
     if isa(opt, OptimizationState)
@@ -198,7 +198,6 @@ function finish!(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInstan
     di = src.debuginfo
     rettype = Any
     exctype = Any
-    rettype_const = nothing
     const_flags = 0x0
     ipo_effects = zero(UInt32)
     min_world = src.min_world
@@ -433,7 +432,7 @@ function transform_result_for_cache(interp::AbstractInterpreter, result::Inferen
     return src
 end
 
-function discard_optimized_result(interp::AbstractInterpreter, opt#=::OptimizationState=#, inlining_cost#=::InlineCostType=#)
+function discard_optimized_result(interp::AbstractInterpreter, _#=::OptimizationState=#, inlining_cost#=::InlineCostType=#)
     may_discard_trees(interp) || return false
     return inlining_cost == MAX_INLINE_COST
 end
@@ -683,7 +682,7 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter, cycleid::
     nothing
 end
 
-function is_already_cached(interp::AbstractInterpreter, result::InferenceResult, ci::CodeInstance)
+function is_already_cached(interp::AbstractInterpreter, result::InferenceResult, ::CodeInstance)
     # check if the existing linfo metadata is also sufficient to describe the current inference result
     # to decide if it is worth caching this right now
     mi = result.linfo
@@ -840,7 +839,7 @@ function find_dominating_assignment(id::Int, idx::Int, sv::InferenceState)
 end
 
 # annotate types of all symbols in AST, preparing for optimization
-function type_annotate!(interp::AbstractInterpreter, sv::InferenceState)
+function type_annotate!(::AbstractInterpreter, sv::InferenceState)
     # widen `Conditional`s from `slottypes`
     slottypes = sv.slottypes
     for i = 1:length(slottypes)
@@ -1173,7 +1172,7 @@ for the code of a function that inference has found to just return a constant. F
 stored - the constant is used directly. However, because this is an ABI implementation detail, it is nice to maintain
 consistency and just synthesize a CodeInfo when the reflection APIs ask for them - this function does that.
 """
-function codeinfo_for_const(interp::AbstractInterpreter, mi::MethodInstance, worlds::WorldRange, edges::SimpleVector, @nospecialize(val))
+function codeinfo_for_const(::AbstractInterpreter, mi::MethodInstance, worlds::WorldRange, edges::SimpleVector, @nospecialize(val))
     method = mi.def::Method
     tree = ccall(:jl_new_code_info_uninit, Ref{CodeInfo}, ())
     tree.code = Any[ ReturnNode(quoted(val)) ]
@@ -1490,7 +1489,7 @@ function collectinvokes!(workqueue::CompilationQueue, ci::CodeInfo, sptypes::Vec
                 continue
             end
         elseif isexpr(stmt, :cfunction) && length(stmt.args) == 5
-            (pointer_type, f, rt, at, call_type) = stmt.args
+            (_, f, _, at, _) = stmt.args
             linfo = ci.parent
 
             linfo isa MethodInstance || continue

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -269,7 +269,7 @@ function type_more_complex(@nospecialize(t), @nospecialize(c), sources::SimpleVe
         if isType(t)
             # Type is fairly important, so do not widen it as fast as other types if avoidable
             tt = tP[1]
-            ttu = unwrap_unionall(tt) # TODO: use argument_datatype(tt) after #50692 fixed
+            # ttu = unwrap_unionall(tt) # TODO: use argument_datatype(tt) after #50692 fixed
             if isType(c)
                 ct = c.parameters[1]
             else

--- a/Compiler/src/types.jl
+++ b/Compiler/src/types.jl
@@ -416,7 +416,7 @@ InferenceParams(interp::NativeInterpreter) = interp.inf_params
 OptimizationParams(interp::NativeInterpreter) = interp.opt_params
 get_inference_world(interp::NativeInterpreter) = interp.world
 get_inference_cache(interp::NativeInterpreter) = interp.inf_cache
-cache_owner(interp::NativeInterpreter) = nothing
+cache_owner(::NativeInterpreter) = nothing
 
 engine_reserve(interp::AbstractInterpreter, mi::MethodInstance) = engine_reserve(mi, cache_owner(interp))
 engine_reserve(mi::MethodInstance, @nospecialize owner) = ccall(:jl_engine_reserve, Any, (Any, Any), mi, owner)::CodeInstance
@@ -460,7 +460,7 @@ and may be safely discarded between calls to this function.
 By default, a value of `nothing` is returned indicating that `CodeInstance`s should not be added to the JIT.
 Attempting to execute them via `invoke` will result in an error.
 """
-codegen_cache(interp::AbstractInterpreter) = nothing
+codegen_cache(::AbstractInterpreter) = nothing
 codegen_cache(interp::NativeInterpreter) = interp.codegen
 
 """

--- a/Compiler/src/typeutils.jl
+++ b/Compiler/src/typeutils.jl
@@ -171,7 +171,7 @@ function typesubtract(@nospecialize(a), @nospecialize(b), max_union_splitting::I
 end
 
 _typename(@nospecialize a) = Union{}
-_typename(a::TypeVar) = Core.TypeName
+_typename(::TypeVar) = Core.TypeName
 function _typename(a::Union)
     ta = _typename(a.a)
     tb = _typename(a.b)

--- a/Compiler/src/utilities.jl
+++ b/Compiler/src/utilities.jl
@@ -167,7 +167,7 @@ isa_compileable_sig(@nospecialize(atype), sparams::SimpleVector, method::Method)
     !iszero(ccall(:jl_isa_compileable_sig, Int32, (Any, Any, Any), atype, sparams, method))
 
 isa_compileable_sig(m::MethodInstance) = (def = m.def; !isa(def, Method) || isa_compileable_sig(m.specTypes, m.sparam_vals, def))
-isa_compileable_sig(m::ABIOverride) = false
+isa_compileable_sig(::ABIOverride) = false
 
 has_typevar(@nospecialize(t), v::TypeVar) = ccall(:jl_has_typevar, Cint, (Any, Any), t, v) != 0
 
@@ -269,7 +269,7 @@ function foreach_anyssa(@specialize(f), @nospecialize(stmt))
 end
 
 function find_ssavalue_uses(body::Vector{Any}, nvals::Int)
-    uses = BitSet[ BitSet() for i = 1:nvals ]
+    uses = BitSet[ BitSet() for _ = 1:nvals ]
     for line in 1:length(body)
         e = body[line]
         if isa(e, ReturnNode)

--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -117,7 +117,7 @@ function verify_print_error(io::IOContext{IO}, desc::CallMissing, parents::Paren
     nothing
 end
 
-function verify_print_error(io::IOContext{IO}, desc::CCallableMissing, parents::ParentMap)
+function verify_print_error(io::IOContext{IO}, desc::CCallableMissing, ::ParentMap)
     print(io, desc.desc, " for ", desc.sig, " => ", desc.rt, "\n\n")
     nothing
 end
@@ -257,7 +257,7 @@ function verify_codeinstance!(interp::NativeInterpreter, codeinst::CodeInstance,
             end
         elseif isexpr(stmt, :cfunction)
             length(stmt.args) != 5 && continue # required by IR legality
-            (pointer_type, f, rt, at, call_type) = stmt.args
+            f, at = stmt.args[2], stmt.args[4]
 
             at isa SimpleVector || continue  # required by IR legality
             ft = argextype(f, codeinfo, sptypes)


### PR DESCRIPTION
Found by opening the compiler folder with JETLS.