### PR TITLE
Fix precompiling when there's no manifest

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2629,7 +2629,7 @@ function __require_prelocked(pkg::PkgId, env)
                 parallel_precompile_attempted = true
                 unlock(require_lock)
                 try
-                    Precompilation.precompilepkgs([pkg.name]; _from_loading=true, ignore_loaded=false)
+                    Precompilation.precompilepkgs([pkg]; _from_loading=true, ignore_loaded=false)
                 finally
                     lock(require_lock)
                 end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/59206

Here there's no Manifest.toml in the Pkg repo

```
% ./julia --start=no --project=../Pkg.jl -q -ie "using Pkg, REPL"
Precompiling Pkg finished.
  1 dependency successfully precompiled in 37 seconds
Precompiling REPLExt finished.
  1 dependency successfully precompiled in 5 seconds
julia>
```