### PR TITLE
Improving build instructions for RHEL derivatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ and then use the command prompt to change into the resulting julia directory. By
 Julia. However, most users should use the [most recent stable version](https://github.com/JuliaLang/julia/releases)
 of Julia. You can get this version by running:
 
-    git checkout v1.11.5
+    git checkout v1.11.6
 
 To build the `julia` executable, run `make` from within the julia directory.
 

--- a/doc/src/devdocs/build/build.md
+++ b/doc/src/devdocs/build/build.md
@@ -181,6 +181,11 @@ On Debian-based distributions (e.g. Ubuntu), you can easily install them with `a
 sudo apt-get install build-essential libatomic1 python gfortran perl wget m4 cmake pkg-config curl
 ```
 
+On Red Hat-based distributions (e.g. Fedora, CentOS), you can install them with `yum`:
+```
+sudo dnf install gcc gcc-c++ gcc-gfortran python3 perl wget m4 cmake pkgconfig curl
+```
+
 Julia uses the following external libraries, which are automatically
 downloaded (or in a few cases, included in the Julia source
 repository) and then compiled from source the first time you run


### PR DESCRIPTION
For a start, I've only added the package names for `rpm`-based distributions and fixed a wrong number. If you want to, you can merge it right away. But I can also try and see whether there are more hints and docs that I can update in the following week(s).