### PR TITLE
remove jl_function_t typealias

### DIFF
--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -658,10 +658,10 @@ for important details on how to modify these fields safely.
     The ABI to use when calling `fptr`. Some significant ones include:
 
       * 0 - Not compiled yet
-      * 1 - `JL_CALLABLE` `jl_value_t *(*)(jl_function_t *f, jl_value_t *args[nargs], uint32_t nargs)`
+      * 1 - `JL_CALLABLE` `jl_value_t *(*)(jl_value_t *f, jl_value_t *args[nargs], uint32_t nargs)`
       * 2 - Constant (value stored in `rettype_const`)
-      * 3 - With Static-parameters forwarded `jl_value_t *(*)(jl_svec_t *sparams, jl_function_t *f, jl_value_t *args[nargs], uint32_t nargs)`
-      * 4 - Run in interpreter `jl_value_t *(*)(jl_method_instance_t *meth, jl_function_t *f, jl_value_t *args[nargs], uint32_t nargs)`
+      * 3 - With Static-parameters forwarded `jl_value_t *(*)(jl_svec_t *sparams, jl_value_t *f, jl_value_t *args[nargs], uint32_t nargs)`
+      * 4 - Run in interpreter `jl_value_t *(*)(jl_method_instance_t *meth, jl_value_t *f, jl_value_t *args[nargs], uint32_t nargs)`
 
   * `min_world` / `max_world`
 

--- a/doc/src/devdocs/debuggingtips.md
+++ b/doc/src/devdocs/debuggingtips.md
@@ -177,7 +177,7 @@ $2 = void
 
 The most recent `jl_apply` is at frame #3, so we can go back there and look at the AST for the
 function `julia_convert_16886`. This is the uniqued name for some method of `convert`. `f` in
-this frame is a `jl_function_t*`, so we can look at the type signature, if any, from the `specTypes`
+this frame is a `jl_value_t*`, so we can look at the type signature, if any, from the `specTypes`
 field:
 
 ```

--- a/doc/src/devdocs/functions.md
+++ b/doc/src/devdocs/functions.md
@@ -38,7 +38,7 @@ This entry point for the same functionality accepts the function separately, so 
 does not contain the function:
 
 ```c
-jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, int32_t nargs);
+jl_value_t *jl_call(jl_value_t *f, jl_value_t **args, int32_t nargs);
 ```
 
 ## Adding methods

--- a/doc/src/devdocs/object.md
+++ b/doc/src/devdocs/object.md
@@ -155,7 +155,7 @@ jl_sym_t *jl_symbol(const char *str);
 Functions and MethodInstance:
 
 ```c
-jl_function_t *jl_new_generic_function(jl_sym_t *name);
+jl_value_t *jl_new_generic_function(jl_sym_t *name);
 jl_method_instance_t *jl_new_method_instance(jl_value_t *ast, jl_tuple_t *sparams);
 ```
 

--- a/doc/src/manual/embedding.md
+++ b/doc/src/manual/embedding.md
@@ -228,7 +228,7 @@ passing arguments computed in C to Julia. For this you will need to invoke Julia
 using `jl_call`:
 
 ```c
-jl_function_t *func = jl_get_function(jl_base_module, "sqrt");
+jl_value_t *func = jl_get_function(jl_base_module, "sqrt");
 jl_value_t *argument = jl_box_float64(2.0);
 jl_value_t *ret = jl_call1(func, argument);
 ```
@@ -240,7 +240,7 @@ the function is called using `jl_call1`. `jl_call0`, `jl_call2`, and `jl_call3` 
 exist, to conveniently handle different numbers of arguments. To pass more arguments, use `jl_call`:
 
 ```
-jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, int32_t nargs)
+jl_value_t *jl_call(jl_value_t *f, jl_value_t **args, int32_t nargs)
 ```
 
 Its second argument `args` is an array of `jl_value_t*` arguments and `nargs` is the number of
@@ -319,7 +319,7 @@ jl_value_t *ret1 = jl_eval_string("sqrt(2.0)");
 JL_GC_PUSH1(&ret1);
 jl_value_t *ret2 = 0;
 {
-    jl_function_t *func = jl_get_function(jl_base_module, "exp");
+    jl_value_t *func = jl_get_function(jl_base_module, "exp");
     ret2 = jl_call1(func, ret1);
     JL_GC_PUSH1(&ret2);
     // Do something with ret2.
@@ -350,7 +350,7 @@ properly with mutable types.
 ```c
 // This functions shall be executed only once, during the initialization.
 jl_value_t* refs = jl_eval_string("refs = IdDict()");
-jl_function_t* setindex = jl_get_function(jl_base_module, "setindex!");
+jl_value_t* setindex = jl_get_function(jl_base_module, "setindex!");
 
 ...
 
@@ -374,7 +374,7 @@ container is created by `jl_call*`, then you will need to reload the pointer to 
 ```c
 // This functions shall be executed only once, during the initialization.
 jl_value_t* refs = jl_eval_string("refs = IdDict()");
-jl_function_t* setindex = jl_get_function(jl_base_module, "setindex!");
+jl_value_t* setindex = jl_get_function(jl_base_module, "setindex!");
 jl_datatype_t* reft = (jl_datatype_t*)jl_eval_string("Base.RefValue{Any}");
 
 ...
@@ -401,7 +401,7 @@ The GC can be allowed to deallocate a variable by removing the reference to it f
 the function `delete!`, provided that no other reference to the variable is kept anywhere:
 
 ```c
-jl_function_t* delete = jl_get_function(jl_base_module, "delete!");
+jl_value_t* delete = jl_get_function(jl_base_module, "delete!");
 jl_call2(delete, refs, rvar);
 ```
 
@@ -505,7 +505,7 @@ for (size_t i = 0; i < jl_array_nrows(x); i++)
 Now let us call a Julia function that performs an in-place operation on `x`:
 
 ```c
-jl_function_t *func = jl_get_function(jl_base_module, "reverse!");
+jl_value_t *func = jl_get_function(jl_base_module, "reverse!");
 jl_call1(func, (jl_value_t*)x);
 ```
 
@@ -517,7 +517,7 @@ If a Julia function returns an array, the return value of `jl_eval_string` and `
 cast to a `jl_array_t*`:
 
 ```c
-jl_function_t *func  = jl_get_function(jl_base_module, "reverse");
+jl_value_t *func  = jl_get_function(jl_base_module, "reverse");
 jl_array_t *y = (jl_array_t*)jl_call1(func, (jl_value_t*)x);
 ```
 
@@ -664,7 +664,7 @@ double c_func(int i)
     printf("[C %08x] i = %d\n", pthread_self(), i);
 
     // Call the Julia sqrt() function to compute the square root of i, and return it
-    jl_function_t *sqrt = jl_get_function(jl_base_module, "sqrt");
+    jl_value_t *sqrt = jl_get_function(jl_base_module, "sqrt");
     jl_value_t* arg = jl_box_int32(i);
     double ret = jl_unbox_float64(jl_call1(sqrt, arg));
 

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -663,8 +663,8 @@ static jl_value_t *jl_arrayref(jl_array_t *a, size_t i)
 JL_CALLABLE(jl_f__apply_iterate)
 {
     JL_NARGSV(_apply_iterate, 2);
-    jl_function_t *iterate = args[0];
-    jl_function_t *f = args[1];
+    jl_value_t *iterate = args[0];
+    jl_value_t *f = args[1];
     assert(iterate);
     args += 1;
     nargs -= 1;

--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -460,7 +460,7 @@ JL_DLLEXPORT void jl_gc_add_quiescent(jl_ptls_t ptls, void **v, void *f) JL_NOTS
     jl_gc_add_finalizer_(ptls, (void*)(((uintptr_t)v) | 3), f);
 }
 
-JL_DLLEXPORT void jl_gc_add_finalizer_th(jl_ptls_t ptls, jl_value_t *v, jl_function_t *f) JL_NOTSAFEPOINT
+JL_DLLEXPORT void jl_gc_add_finalizer_th(jl_ptls_t ptls, jl_value_t *v, jl_value_t *f) JL_NOTSAFEPOINT
 {
     if (__unlikely(jl_typetagis(f, jl_voidpointer_type))) {
         jl_gc_add_ptr_finalizer(ptls, v, jl_unbox_voidpointer(f));
@@ -470,7 +470,7 @@ JL_DLLEXPORT void jl_gc_add_finalizer_th(jl_ptls_t ptls, jl_value_t *v, jl_funct
     }
 }
 
-JL_DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f)
+JL_DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_value_t *f)
 {
     jl_ptls_t ptls = jl_current_task->ptls;
     jl_gc_add_finalizer_th(ptls, v, f);

--- a/src/gc-common.h
+++ b/src/gc-common.h
@@ -195,7 +195,7 @@ extern arraylist_t to_finalize;
 void schedule_finalization(void *o, void *f) JL_NOTSAFEPOINT;
 void run_finalizer(jl_task_t *ct, void *o, void *ff);
 void run_finalizers(jl_task_t *ct, int finalizers_thread);
-JL_DLLEXPORT void jl_gc_add_finalizer_th(jl_ptls_t ptls, jl_value_t *v, jl_function_t *f) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_gc_add_finalizer_th(jl_ptls_t ptls, jl_value_t *v, jl_value_t *f) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_finalize_th(jl_task_t *ct, jl_value_t *o);
 
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -939,12 +939,12 @@ int jl_foreach_reachable_mtable(int (*visit)(jl_methtable_t *mt, void *env), jl_
     return 1;
 }
 
-jl_function_t *jl_typeinf_func JL_GLOBALLY_ROOTED = NULL;
+jl_value_t *jl_typeinf_func JL_GLOBALLY_ROOTED = NULL;
 JL_DLLEXPORT size_t jl_typeinf_world = 1;
 
 JL_DLLEXPORT void jl_set_typeinf_func(jl_value_t *f)
 {
-    jl_typeinf_func = (jl_function_t*)f;
+    jl_typeinf_func = (jl_value_t*)f;
     jl_typeinf_world = jl_get_tls_world_age();
 }
 
@@ -4342,7 +4342,7 @@ jl_sym_t *jl_gf_supertype_name(jl_sym_t *name)
 }
 
 // Return value is rooted globally
-jl_function_t *jl_new_generic_function_with_supertype(jl_sym_t *name, jl_module_t *module, jl_datatype_t *st, size_t new_world)
+jl_value_t *jl_new_generic_function_with_supertype(jl_sym_t *name, jl_module_t *module, jl_datatype_t *st, size_t new_world)
 {
     // type name is function name prefixed with #
     jl_sym_t *tname = jl_gf_supertype_name(name);
@@ -4358,10 +4358,10 @@ jl_function_t *jl_new_generic_function_with_supertype(jl_sym_t *name, jl_module_
     ftype->instance = f;
     jl_gc_wb(ftype, f);
     JL_GC_POP();
-    return (jl_function_t*)f;
+    return (jl_value_t*)f;
 }
 
-jl_function_t *jl_new_generic_function(jl_sym_t *name, jl_module_t *module, size_t new_world)
+jl_value_t *jl_new_generic_function(jl_sym_t *name, jl_module_t *module, size_t new_world)
 {
     return jl_new_generic_function_with_supertype(name, module, jl_function_type, new_world);
 }

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -317,7 +317,7 @@ enum CompilationPolicy {
     Extern = 1,
 };
 
-Function *jl_cfunction_object(jl_function_t *f, jl_value_t *rt, jl_tupletype_t *argt,
+Function *jl_cfunction_object(jl_value_t *f, jl_value_t *rt, jl_tupletype_t *argt,
     jl_codegen_params_t &params);
 
 extern "C" JL_DLLEXPORT_CODEGEN

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -282,12 +282,12 @@ JL_DLLEXPORT const char *jl_string_ptr(jl_value_t *s)
 /**
  * @brief Call a Julia function with a specified number of arguments.
  *
- * @param f A pointer to `jl_function_t` representing the Julia function to call.
+ * @param f A pointer to `jl_value_t` representing the Julia function to call.
  * @param args An array of pointers to `jl_value_t` representing the arguments.
  * @param nargs The number of arguments in the array.
  * @return A pointer to `jl_value_t` representing the result of the function call.
  */
-JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, uint32_t nargs)
+JL_DLLEXPORT jl_value_t *jl_call(jl_value_t *f, jl_value_t **args, uint32_t nargs)
 {
     jl_value_t *v;
     jl_task_t *ct = jl_current_task;
@@ -317,10 +317,10 @@ JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, uint32_t n
  *
  * A specialized case of `jl_call` for simpler scenarios.
  *
- * @param f A pointer to `jl_function_t` representing the Julia function to call.
+ * @param f A pointer to `jl_value_t` representing the Julia function to call.
  * @return A pointer to `jl_value_t` representing the result of the function call.
  */
-JL_DLLEXPORT jl_value_t *jl_call0(jl_function_t *f)
+JL_DLLEXPORT jl_value_t *jl_call0(jl_value_t *f)
 {
     jl_value_t *v;
     jl_task_t *ct = jl_current_task;
@@ -345,11 +345,11 @@ JL_DLLEXPORT jl_value_t *jl_call0(jl_function_t *f)
  *
  * A specialized case of `jl_call` for simpler scenarios.
  *
- * @param f A pointer to `jl_function_t` representing the Julia function to call.
+ * @param f A pointer to `jl_value_t` representing the Julia function to call.
  * @param a A pointer to `jl_value_t` representing the argument to the function.
  * @return A pointer to `jl_value_t` representing the result of the function call.
  */
-JL_DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a)
+JL_DLLEXPORT jl_value_t *jl_call1(jl_value_t *f, jl_value_t *a)
 {
     jl_value_t *v;
     jl_task_t *ct = jl_current_task;
@@ -377,12 +377,12 @@ JL_DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a)
  *
  * A specialized case of `jl_call` for simpler scenarios.
  *
- * @param f A pointer to `jl_function_t` representing the Julia function to call.
+ * @param f A pointer to `jl_value_t` representing the Julia function to call.
  * @param a A pointer to `jl_value_t` representing the first argument.
  * @param b A pointer to `jl_value_t` representing the second argument.
  * @return A pointer to `jl_value_t` representing the result of the function call.
  */
-JL_DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b)
+JL_DLLEXPORT jl_value_t *jl_call2(jl_value_t *f, jl_value_t *a, jl_value_t *b)
 {
     jl_value_t *v;
     jl_task_t *ct = jl_current_task;
@@ -411,13 +411,13 @@ JL_DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b
  *
  * A specialized case of `jl_call` for simpler scenarios.
  *
- * @param f A pointer to `jl_function_t` representing the Julia function to call.
+ * @param f A pointer to `jl_value_t` representing the Julia function to call.
  * @param a A pointer to `jl_value_t` representing the first argument.
  * @param b A pointer to `jl_value_t` representing the second argument.
  * @param c A pointer to `jl_value_t` representing the third argument.
  * @return A pointer to `jl_value_t` representing the result of the function call.
  */
-JL_DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a,
+JL_DLLEXPORT jl_value_t *jl_call3(jl_value_t *f, jl_value_t *a,
                                   jl_value_t *b, jl_value_t *c)
 {
     jl_value_t *v;
@@ -448,14 +448,14 @@ JL_DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a,
  *
  * A specialized case of `jl_call` for simpler scenarios.
  *
- * @param f A pointer to `jl_function_t` representing the Julia function to call.
+ * @param f A pointer to `jl_value_t` representing the Julia function to call.
  * @param a A pointer to `jl_value_t` representing the first argument.
  * @param b A pointer to `jl_value_t` representing the second argument.
  * @param c A pointer to `jl_value_t` representing the third argument.
  * @param d A pointer to `jl_value_t` representing the fourth argument.
  * @return A pointer to `jl_value_t` representing the result of the function call.
  */
-JL_DLLEXPORT jl_value_t *jl_call4(jl_function_t *f, jl_value_t *a,
+JL_DLLEXPORT jl_value_t *jl_call4(jl_value_t *f, jl_value_t *a,
                                   jl_value_t *b, jl_value_t *c,
                                   jl_value_t *d)
 {
@@ -961,8 +961,8 @@ static NOINLINE int true_main(int argc, char *argv[])
     size_t last_age = ct->world_age;
     ct->world_age = jl_get_world_counter();
 
-    jl_function_t *start_client = jl_base_module ?
-        (jl_function_t*)jl_get_global_value(jl_base_module, jl_symbol("_start"), ct->world_age) : NULL;
+    jl_value_t *start_client = jl_base_module ?
+        (jl_value_t*)jl_get_global_value(jl_base_module, jl_symbol("_start"), ct->world_age) : NULL;
 
     if (start_client) {
         int ret = 1;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1245,7 +1245,7 @@ extern void JL_GC_POP() JL_NOTSAFEPOINT;
 
 #endif
 
-JL_DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_value_t *f) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_gc_add_ptr_finalizer(jl_ptls_t ptls, jl_value_t *v, void *f) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_gc_add_quiescent(jl_ptls_t ptls, void **v, void *f) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_finalize(jl_value_t *o);
@@ -2375,13 +2375,13 @@ STATIC_INLINE jl_value_t *jl_apply(jl_value_t **args, uint32_t nargs)
     return jl_apply_generic(args[0], &args[1], nargs - 1);
 }
 
-JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f JL_MAYBE_UNROOTED, jl_value_t **args, uint32_t nargs);
-JL_DLLEXPORT jl_value_t *jl_call0(jl_function_t *f JL_MAYBE_UNROOTED);
-JL_DLLEXPORT jl_value_t *jl_call1(jl_function_t *f JL_MAYBE_UNROOTED, jl_value_t *a JL_MAYBE_UNROOTED);
-JL_DLLEXPORT jl_value_t *jl_call2(jl_function_t *f JL_MAYBE_UNROOTED, jl_value_t *a JL_MAYBE_UNROOTED, jl_value_t *b JL_MAYBE_UNROOTED);
-JL_DLLEXPORT jl_value_t *jl_call3(jl_function_t *f JL_MAYBE_UNROOTED, jl_value_t *a JL_MAYBE_UNROOTED,
+JL_DLLEXPORT jl_value_t *jl_call(jl_value_t *f JL_MAYBE_UNROOTED, jl_value_t **args, uint32_t nargs);
+JL_DLLEXPORT jl_value_t *jl_call0(jl_value_t *f JL_MAYBE_UNROOTED);
+JL_DLLEXPORT jl_value_t *jl_call1(jl_value_t *f JL_MAYBE_UNROOTED, jl_value_t *a JL_MAYBE_UNROOTED);
+JL_DLLEXPORT jl_value_t *jl_call2(jl_value_t *f JL_MAYBE_UNROOTED, jl_value_t *a JL_MAYBE_UNROOTED, jl_value_t *b JL_MAYBE_UNROOTED);
+JL_DLLEXPORT jl_value_t *jl_call3(jl_value_t *f JL_MAYBE_UNROOTED, jl_value_t *a JL_MAYBE_UNROOTED,
                                   jl_value_t *b JL_MAYBE_UNROOTED, jl_value_t *c JL_MAYBE_UNROOTED);
-JL_DLLEXPORT jl_value_t *jl_call4(jl_function_t *f JL_MAYBE_UNROOTED, jl_value_t *a JL_MAYBE_UNROOTED,
+JL_DLLEXPORT jl_value_t *jl_call4(jl_value_t *f JL_MAYBE_UNROOTED, jl_value_t *a JL_MAYBE_UNROOTED,
                                   jl_value_t *b JL_MAYBE_UNROOTED, jl_value_t *c JL_MAYBE_UNROOTED,
                                   jl_value_t *d JL_MAYBE_UNROOTED);
 
@@ -2410,7 +2410,7 @@ struct _jl_handler_t {
 #define JL_TASK_STATE_DONE     1
 #define JL_TASK_STATE_FAILED   2
 
-JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t*, jl_value_t*, size_t);
+JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t*, jl_value_t*, size_t);
 JL_DLLEXPORT void jl_switchto(jl_task_t **pt);
 JL_DLLEXPORT int jl_set_task_tid(jl_task_t *task, int16_t tid) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_set_task_threadpoolid(jl_task_t *task, int8_t tpid) JL_NOTSAFEPOINT;
@@ -2722,9 +2722,9 @@ typedef struct {
 #define jl_root_task (jl_current_task->ptls->root_task)
 JL_DLLEXPORT jl_task_t *jl_get_current_task(void) JL_GLOBALLY_ROOTED JL_NOTSAFEPOINT;
 
-STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)
+STATIC_INLINE jl_value_t *jl_get_function(jl_module_t *m, const char *name)
 {
-    return (jl_function_t*)jl_get_global(m, jl_symbol(name));
+    return (jl_value_t*)jl_get_global(m, jl_symbol(name));
 }
 
 // TODO: we need to pin the task while using this (set pure bit)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -418,7 +418,7 @@ extern arraylist_t eytzinger_image_tree;
 extern arraylist_t eytzinger_idxs;
 
 extern JL_DLLEXPORT size_t jl_page_size;
-extern JL_DLLEXPORT jl_function_t *jl_typeinf_func JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_value_t *jl_typeinf_func JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT size_t jl_typeinf_world;
 extern _Atomic(jl_typemap_entry_t*) call_cache[N_CALL_CACHE] JL_GLOBALLY_ROOTED;
 
@@ -867,8 +867,8 @@ jl_value_t *modify_value(jl_value_t *ty, _Atomic(jl_value_t*) *p, jl_value_t *pa
 jl_value_t *modify_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value_t *parent, jl_value_t *op, jl_value_t *rhs, enum atomic_kind isatomic);
 int setonce_bits(jl_datatype_t *rty, char *p, jl_value_t *owner, jl_value_t *rhs, enum atomic_kind isatomic);
 jl_expr_t *jl_exprn(jl_sym_t *head, size_t n);
-jl_function_t *jl_new_generic_function(jl_sym_t *name, jl_module_t *module, size_t new_world);
-jl_function_t *jl_new_generic_function_with_supertype(jl_sym_t *name, jl_module_t *module, jl_datatype_t *st, size_t new_world);
+jl_value_t *jl_new_generic_function(jl_sym_t *name, jl_module_t *module, size_t new_world);
+jl_value_t *jl_new_generic_function_with_supertype(jl_sym_t *name, jl_module_t *module, jl_datatype_t *st, size_t new_world);
 int jl_foreach_reachable_mtable(int (*visit)(jl_methtable_t *mt, void *env), jl_array_t *mod_array, void *env);
 void jl_init_main_module(void);
 JL_DLLEXPORT int jl_is_submodule(jl_module_t *child, jl_module_t *parent) JL_NOTSAFEPOINT;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -225,9 +225,6 @@ typedef struct _jl_tls_states_t {
 
 #define JL_RNG_SIZE 5 // xoshiro 4 + splitmix 1
 
-// all values are callable as Functions
-typedef jl_value_t jl_function_t;
-
 typedef struct _jl_timing_block_t jl_timing_block_t;
 typedef struct _jl_timing_event_t jl_timing_event_t;
 typedef struct _jl_excstack_t jl_excstack_t;
@@ -242,7 +239,7 @@ typedef struct _jl_task_t {
     jl_value_t *donenotify;
     jl_value_t *result;
     jl_value_t *scope;
-    jl_function_t *start;
+    jl_value_t *start;
     _Atomic(uint8_t) _state;
     uint8_t sticky; // record whether this Task can be migrated to a new thread
     uint16_t priority;

--- a/src/module.c
+++ b/src/module.c
@@ -1634,7 +1634,7 @@ void jl_invalidate_binding_refs(jl_globalref_t *ref, jl_binding_partition_t *inv
         jl_error("Binding invalidation is not permitted during bootstrap.");
     jl_value_t **fargs;
     JL_GC_PUSHARGS(fargs, 5);
-    fargs[0] = (jl_function_t*)invalidate_code_for_globalref;
+    fargs[0] = (jl_value_t*)invalidate_code_for_globalref;
     fargs[1] = (jl_value_t*)ref;
     fargs[2] = (jl_value_t*)invalidated_bpart;
     fargs[3] = (jl_value_t*)new_bpart;

--- a/src/task.c
+++ b/src/task.c
@@ -311,7 +311,7 @@ CFI_NORETURN
 #endif
 
 /* Rooted by the base module */
-static _Atomic(jl_function_t*) task_done_hook_func JL_GLOBALLY_ROOTED = NULL;
+static _Atomic(jl_value_t*) task_done_hook_func JL_GLOBALLY_ROOTED = NULL;
 
 void JL_NORETURN jl_finish_task(jl_task_t *ct)
 {
@@ -337,9 +337,9 @@ void JL_NORETURN jl_finish_task(jl_task_t *ct)
     ct->ptls->in_pure_callback = 0;
     ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
     // let the runtime know this task is dead and find a new task to run
-    jl_function_t *done = jl_atomic_load_relaxed(&task_done_hook_func);
+    jl_value_t *done = jl_atomic_load_relaxed(&task_done_hook_func);
     if (done == NULL) {
-        done = (jl_function_t*)jl_get_global_value(jl_base_module, jl_symbol("task_done_hook"), ct->world_age);
+        done = (jl_value_t*)jl_get_global_value(jl_base_module, jl_symbol("task_done_hook"), ct->world_age);
         if (done != NULL)
             jl_atomic_store_release(&task_done_hook_func, done);
     }
@@ -1073,7 +1073,7 @@ void jl_rng_split(uint64_t dst[JL_RNG_SIZE], uint64_t src[JL_RNG_SIZE]) JL_NOTSA
     }
 }
 
-JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion_future, size_t ssize)
+JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t *start, jl_value_t *completion_future, size_t ssize)
 {
     jl_task_t *ct = jl_current_task;
     jl_task_t *t = (jl_task_t*)jl_gc_alloc(ct->ptls, sizeof(jl_task_t), jl_task_type);

--- a/src/threading.c
+++ b/src/threading.c
@@ -409,15 +409,15 @@ jl_ptls_t jl_init_threadtls(int16_t tid)
     return ptls;
 }
 
-static _Atomic(jl_function_t*) init_task_lock_func JL_GLOBALLY_ROOTED = NULL;
+static _Atomic(jl_value_t*) init_task_lock_func JL_GLOBALLY_ROOTED = NULL;
 
 static void jl_init_task_lock(jl_task_t *ct)
 {
     size_t last_age = ct->world_age;
     ct->world_age = jl_get_world_counter();
-    jl_function_t *done = jl_atomic_load_relaxed(&init_task_lock_func);
+    jl_value_t *done = jl_atomic_load_relaxed(&init_task_lock_func);
     if (done == NULL) {
-        done = (jl_function_t*)jl_get_global_value(jl_base_module, jl_symbol("init_task_lock"), ct->world_age);
+        done = (jl_value_t*)jl_get_global_value(jl_base_module, jl_symbol("init_task_lock"), ct->world_age);
         if (done != NULL)
             jl_atomic_store_release(&init_task_lock_func, done);
     }

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -100,7 +100,7 @@ jl_array_t *jl_get_loaded_modules(void)
     if (loaded_modules_array == NULL && jl_base_module != NULL)
         loaded_modules_array = jl_get_global(jl_base_module, jl_symbol("loaded_modules_array"));
     if (loaded_modules_array != NULL)
-        return (jl_array_t*)jl_call0((jl_function_t*)loaded_modules_array);
+        return (jl_array_t*)jl_call0((jl_value_t*)loaded_modules_array);
     return NULL;
 }
 

--- a/test/embedding/embedding.c
+++ b/test/embedding/embedding.c
@@ -61,7 +61,7 @@ int main()
     {
         // Same as above but with function handle (more flexible)
 
-        jl_function_t *func = jl_get_function(jl_base_module, "sqrt");
+        jl_value_t *func = jl_get_function(jl_base_module, "sqrt");
         jl_value_t* argument = jl_box_float64(2.0);
         jl_value_t* ret = jl_call1(func, argument);
         double retDouble = jl_unbox_float64(ret);
@@ -92,7 +92,7 @@ int main()
         for (i = 0; i < jl_array_nrows(x); i++)
             xData[i] = i;
 
-        jl_function_t *func  = jl_get_function(jl_base_module, "reverse!");
+        jl_value_t *func  = jl_get_function(jl_base_module, "reverse!");
         jl_call1(func, (jl_value_t*) x);
 
         printf("x = [");
@@ -109,7 +109,7 @@ int main()
 
         checked_eval_string("my_func(x) = 2 * x");
 
-        jl_function_t *func = jl_get_function(jl_main_module, "my_func");
+        jl_value_t *func = jl_get_function(jl_main_module, "my_func");
         jl_value_t* arg = jl_box_float64(5.0);
         double ret = jl_unbox_float64(jl_call1(func, arg));
 


### PR DESCRIPTION
This has been an alias for a long time now, remove it since it is just confusing/misleading to be different from jl_value_t.

Written by Claude (though can you really call a PR by simple perl/awk/sed script that was just planned and reviewed by Claude to actually by anybody?)