### PR TITLE
Fix inconsistent behaviour for `last(::Zip)` with differing iterator size types

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -473,11 +473,7 @@ zip_iteratoreltype() = HasEltype()
 zip_iteratoreltype(a) = a
 zip_iteratoreltype(a, tail...) = and_iteratoreltype(a, zip_iteratoreltype(tail...))
 
-function last(z::Zip)
-    IteratorSize(z) == SizeUnknown() &&
-        throw(ArgumentError("Cannot get last element of zipped iterators of undefined lengths"))
-    return nth(z, length(z))
-end
+last(z::Zip) = nth(z, length(z))
 
 function reverse(z::Zip)
     if !first(_zip_lengths_finite_equal(z.is))

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -473,7 +473,11 @@ zip_iteratoreltype() = HasEltype()
 zip_iteratoreltype(a) = a
 zip_iteratoreltype(a, tail...) = and_iteratoreltype(a, zip_iteratoreltype(tail...))
 
-last(z::Zip) = nth(z, length(z))
+function last(z::Zip)
+    IteratorSize(z) == SizeUnknown() &&
+        throw(ArgumentError("Cannot get last element of zipped iterators of undefined lengths"))
+    return nth(z, length(z))
+end
 
 function reverse(z::Zip)
     if !first(_zip_lengths_finite_equal(z.is))

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -473,7 +473,8 @@ zip_iteratoreltype() = HasEltype()
 zip_iteratoreltype(a) = a
 zip_iteratoreltype(a, tail...) = and_iteratoreltype(a, zip_iteratoreltype(tail...))
 
-last(z::Zip) = getindex.(z.is, minimum(Base.map(lastindex, z.is)))
+last(z::Zip) = nth(z, length(z))
+
 function reverse(z::Zip)
     if !first(_zip_lengths_finite_equal(z.is))
         throw(ArgumentError("Cannot reverse zipped iterators of unknown, infinite, or unequal lengths"))
@@ -1700,6 +1701,9 @@ function _nth(::IteratorSize, itr, n::Integer)
     y === nothing && throw(BoundsError(itr, n))
     y[1]
 end
+
+_nth(::Union{HasShape, HasLength}, z::Zip, n::Integer) = Base.map(nth(n), z.is)
+
 """
     nth(n::Integer)
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1706,7 +1706,7 @@ function _nth(::IteratorSize, itr, n::Integer)
     y[1]
 end
 
-_nth(::Union{HasShape, HasLength}, z::Zip, n::Integer) = Base.map(nth(n), z.is)
+_nth(::IteratorSize, z::Zip, n::Integer) = Base.map(nth(n), z.is)
 
 """
     nth(n::Integer)

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -1218,4 +1218,15 @@ end == Vector{Int}
     @test last(zip(1:3, Iterators.cycle(('x', 'y')))) == (3, 'x')
     @test last(zip(1:3, Iterators.repeated('x'))) == (3, 'x')
     @test last(zip(OffsetArray(1:10, 2), OffsetArray(1:10, 3))) == (10, 10)
+
+    # Cannot statically know length of zipped iterator if any of its components are of
+    # unknown length
+    @test_throws ArgumentError last(zip(1:3, Iterators.filter(x -> x > 0, -5:5))) # (3, 3)
+    @test_throws ArgumentError last(zip(Iterators.filter(x -> x > 0, -5:5), 1:3)) # (3, 3)
+    @test_throws ArgumentError last(zip(1:10, Iterators.filter(x -> x > 0, -5:5))) # (5, 5)
+
+    # We also can't know the length of zipped iterators when all constituents are of an
+    # unknown length.  In this test, the answer is (5, 4), but we can't know that without
+    # a greedy algorithm
+    @test_throws ArgumentError last(zip(Iterators.filter(x -> x > 0, -5:5), Iterators.filter(x -> x % 2 == 0, -5:5)))  # (5, 4)
 end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -1221,12 +1221,12 @@ end == Vector{Int}
 
     # Cannot statically know length of zipped iterator if any of its components are of
     # unknown length
-    @test_throws ArgumentError last(zip(1:3, Iterators.filter(x -> x > 0, -5:5))) # (3, 3)
-    @test_throws ArgumentError last(zip(Iterators.filter(x -> x > 0, -5:5), 1:3)) # (3, 3)
-    @test_throws ArgumentError last(zip(1:10, Iterators.filter(x -> x > 0, -5:5))) # (5, 5)
+    @test_throws MethodError last(zip(1:3, Iterators.filter(x -> x > 0, -5:5))) # (3, 3)
+    @test_throws MethodError last(zip(Iterators.filter(x -> x > 0, -5:5), 1:3)) # (3, 3)
+    @test_throws MethodError last(zip(1:10, Iterators.filter(x -> x > 0, -5:5))) # (5, 5)
 
     # We also can't know the length of zipped iterators when all constituents are of an
     # unknown length.  In this test, the answer is (5, 4), but we can't know that without
     # a greedy algorithm
-    @test_throws ArgumentError last(zip(Iterators.filter(x -> x > 0, -5:5), Iterators.filter(x -> x % 2 == 0, -5:5)))  # (5, 4)
+    @test_throws MethodError last(zip(Iterators.filter(x -> x > 0, -5:5), Iterators.filter(x -> x % 2 == 0, -5:5)))  # (5, 4)
 end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -5,6 +5,9 @@ using Random
 using Base: IdentityUnitRange
 using Dates: Date, Day
 
+isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
+using .Main.OffsetArrays
+
 @test (@inferred Base.IteratorSize(Any)) isa Base.SizeUnknown
 
 # zip and filter iterators
@@ -1140,7 +1143,6 @@ end
 end
 
 @testset "nth" begin
-
     Z = Array{Int,0}(undef)
     Z[] = 17
     it_result_pairs = Dict(
@@ -1169,7 +1171,6 @@ end
         (Iterators.cycle("String", 10), 16) => 'i',
         (Iterators.cycle(((),)), 1000) => ()
     )
-
 
     @testset "iter: $IT" for (IT, n) in keys(it_result_pairs)
         @test it_result_pairs[(IT, n)] == nth(IT, n)
@@ -1206,3 +1207,15 @@ end
 @test Base.infer_return_type((Vector{Any},)) do xs
     [x for x in xs if x isa Int]
 end == Vector{Int}
+
+@testset "issue #58922" begin
+    # `last` short circuits correctly
+    @test last(zip(1:10, 2:11)) == (10, 11)  # same length
+    @test last(zip(1:3, 2:11)) == (3, 4)     # different length
+
+    # Finite-guarded zip iterator: one iterator bounded and the other is not
+    @test last(zip(1:3, Iterators.countfrom(2))) == (3, 4)
+    @test last(zip(1:3, Iterators.cycle(('x', 'y')))) == (3, 'x')
+    @test last(zip(1:3, Iterators.repeated('x'))) == (3, 'x')
+    @test last(zip(OffsetArray(1:10, 2), OffsetArray(1:10, 3))) == (10, 10)
+end


### PR DESCRIPTION
This PR fixes two bugs relating to `last(::Zip)`, closing #58922.

First: there is inconsistent behaviour for `last(::Zip)` with differing iterator size types (a mixture of known-size and not) are passed in the `Zip`, causing a `MethodError`.

`last(::Zip)` works with finite zipped iterators of different lengths, but fails when one of them is an infinite iterator.  In the case where there are a mixture of known-length (finite) and infinite iterators in the `Zip`, we can know their length statically.  (I call these `Zip`s "finite-guarded," because the `Zip` is finite due to its finite component.)

The desired behaviour is to match the behaviour of `last` with finite iterators of different lengths.

Second: while standardising this behaviour, [a bug in `last(::Zip)` for `OffsetArray`s](https://github.com/JuliaLang/julia/issues/58922#issuecomment-3045850520) is fixed.  The issue was subtle and didn't error, but produced the wrong answer (noticed by @adienes).

We also add an explicit `ArgumentError` when `last` is called on a `Zip` whose size is unknown (good call by @Seelengrab).  Previously this was a `MethodError` for `lastindex`, used by the [previous implementation of `last(::Zip)`](https://github.com/JuliaLang/julia/blob/80f7db8e51b2ba1dd21e913611c23a6d5b75ecab/base/iterators.jl#L476).

This PR does **not** give support to any [functionality involving iterators of unknown size](https://github.com/JuliaLang/julia/pull/59217/files#discussion_r2256315847).  This may be done in future.