### PR TITLE
Adjust `print_response` to separate error-printing from result display, remove loop

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -93,7 +93,7 @@ function scrub_repl_backtrace(bt)
     if bt !== nothing && !(bt isa Vector{Any}) # ignore our sentinel value types
         bt = bt isa Vector{StackFrame} ? copy(bt) : stacktrace(bt)
         # remove REPL-related frames from interactive printing
-        eval_ind = findlast(frame -> !frame.from_c && startswith(String(frame.func), "__repl_entry"), bt)
+        eval_ind = findlast(frame -> !frame.from_c && (startswith(String(frame.func), "__repl_entry") || occursin("repl_backend_loop", String(frame.func))), bt)
         eval_ind === nothing || deleteat!(bt, eval_ind:length(bt))
     end
     return bt

--- a/base/client.jl
+++ b/base/client.jl
@@ -93,7 +93,8 @@ function scrub_repl_backtrace(bt)
     if bt !== nothing && !(bt isa Vector{Any}) # ignore our sentinel value types
         bt = bt isa Vector{StackFrame} ? copy(bt) : stacktrace(bt)
         # remove REPL-related frames from interactive printing
-        eval_ind = findlast(frame -> !frame.from_c && (startswith(String(frame.func), "__repl_entry") || occursin("repl_backend_loop", String(frame.func))), bt)
+        eval_ind = findlast(frame -> !frame.from_c && startswith(String(frame.func), "__repl_entry"), bt)
+        eval_ind === nothing && (eval_ind = findlast(frame -> !frame.from_c && occursin("repl_backend_loop", String(frame.func)), bt))
         eval_ind === nothing || deleteat!(bt, eval_ind:length(bt))
     end
     return bt

--- a/base/client.jl
+++ b/base/client.jl
@@ -94,7 +94,6 @@ function scrub_repl_backtrace(bt)
         bt = bt isa Vector{StackFrame} ? copy(bt) : stacktrace(bt)
         # remove REPL-related frames from interactive printing
         eval_ind = findlast(frame -> !frame.from_c && startswith(String(frame.func), "__repl_entry"), bt)
-        eval_ind === nothing && (eval_ind = findlast(frame -> !frame.from_c && occursin("repl_backend_loop", String(frame.func)), bt))
         eval_ind === nothing || deleteat!(bt, eval_ind:length(bt))
     end
     return bt

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -613,7 +613,7 @@ function print_response(errio::IO, response, backend::Union{REPLBackendRef,Nothi
                     # minimize the possibility of further errors.
                     println(errio)
                     println(errio, "SYSTEM (REPL): caught exception of type ", typeof(e).name.name,
-                            " while trying to handle a nested exception; giving up")
+                            " while trying to print an exception; giving up")
                 end
             end
             break


### PR DESCRIPTION
Took a stab at fixing #59209 , but it could be introducing other ways it could fail that I'm not appreciating?

1.11.4 logic:

1. If it's an error, print the error then break and return
2. If it's an error, and printing the error causes an error, catch it, try two levels of fallback printing, then break and return
3. If it's okay, display the result then break and return
4. If it's okay, and displaying the result causes an error, print a message, rethrow, catch, populate the response variables with the new exception info, and start the loop over to follow the error printing pathway for those values

In no case does the loop execute more than twice.

In 1.11.5+, condition 4 ends up following path 2, and path 4 would only be followed if there's an exception in the scaffolding around the `display` invocations.

I restructured it to take out the loop, now it just attempts display if there was no error, accounts for errors during display, and then errors from either response or display are printed.

I'm not sure if I used the `sigatomic_end` calls correctly. **EDIT: See comment below**

Also tweaked the final fallback message because it suggests the issue is that the exception per se is a nested type, rather than that printing one exception is triggering another exception. And added a condition to trim REPL frames when it originates from within `print_response`.

Fixes #59209 