### PR TITLE
Compiler: Infer precise `fetch(::Task)` return types and optimize task invocation

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3495,15 +3495,17 @@ function abstract_eval_task_builtin(interp::AbstractInterpreter, arginfo::ArgInf
     if !hasintersect(widenconst(size_arg), Int)
         return Future(CallMeta(Bottom, Any, EFFECTS_THROWS, NoCallInfo()))
     end
-    if isva
-        # The vararg may supply any of the required arguments, so only retain the
-        # builtin's guaranteed return type.
+    if isva && la < 5
+        # Without a fixed invoke target, the vararg may supply any of the required
+        # arguments, so only retain the builtin's guaranteed return type.
         return Future(CallMeta(Task, Any, Effects(), NoCallInfo()))
     end
     func_arg = argtypes[2]
 
-    # Handle optional Method/CodeInstance/Type argument (4th parameter) as invoke
-    if la == 4
+    # Handle the fixed Method/CodeInstance/Type argument (4th parameter) as invoke.
+    # A trailing vararg may be empty; non-empty tails throw an arity error before
+    # the deferred invoke can run.
+    if la >= 4
         invoke_args = Any[Const(Core.invoke), func_arg, argtypes[4]]
         invoke_arginfo = ArgInfo(nothing, invoke_args)
         invoke_future = abstract_invoke(interp, invoke_arginfo, si, vtypes, sv)

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3484,26 +3484,27 @@ function abstract_eval_task_builtin(interp::AbstractInterpreter, arginfo::ArgInf
     (; fargs, argtypes) = arginfo
     la = length(argtypes)
     𝕃ᵢ = typeinf_lattice(interp)
-    # Check argument count: _task(func, size) or _task(func, size, ci)
-    if la < 3 || la > 4
+    if !isempty(argtypes) && !isvarargtype(argtypes[end])
+        if !(3 <= la <= 4)
+            return Future(CallMeta(Bottom, Any, EFFECTS_THROWS, NoCallInfo()))
+        end
+    elseif isempty(argtypes) || la > 5
         return Future(CallMeta(Bottom, Any, EFFECTS_THROWS, NoCallInfo()))
     end
-    # Check that size argument is an Int
     size_arg = argtypes[3]
-    if !(widenconst(size_arg) ⊑ Int)
+    if !hasintersect(widenconst(size_arg), Int)
         return Future(CallMeta(Bottom, Any, EFFECTS_THROWS, NoCallInfo()))
     end
-
     func_arg = argtypes[2]
 
-    # Handle optional Method/CodeInstance/Type argument (4th parameter)
+    # Handle optional Method/CodeInstance/Type argument (4th parameter) as invoke
     if la == 4
         invoke_args = Any[Const(Core.invoke), func_arg, argtypes[4]]
         invoke_arginfo = ArgInfo(nothing, invoke_args)
         invoke_future = abstract_invoke(interp, invoke_arginfo, si, vtypes, sv)
         return Future{CallMeta}(invoke_future, interp, sv) do invoke_result, interp, sv
-            fetch_type = invoke_result.rt
-            fetch_error = invoke_result.exct
+            fetch_type = widenconst(invoke_result.rt)
+            fetch_error = widenconst(invoke_result.exct)
             task_effects = invoke_result.effects
             if fetch_type === Any && fetch_error === Any
                 rt_result = Task
@@ -3515,11 +3516,11 @@ function abstract_eval_task_builtin(interp::AbstractInterpreter, arginfo::ArgInf
         end
     end
 
-    # Fallback to abstract_call for function analysis
+    # Otherwise use abstract_call for function analysis
     callinfo_future = abstract_call(interp, ArgInfo(nothing, Any[func_arg]), StmtInfo(true, si.saw_latestworld), vtypes, sv, #=max_methods=#1)
     return Future{CallMeta}(callinfo_future, interp, sv) do callinfo, interp, sv
-        fetch_type = callinfo.rt
-        fetch_error = callinfo.exct
+        fetch_type = widenconst(callinfo.rt)
+        fetch_error = widenconst(callinfo.exct)
         task_effects = callinfo.effects
         if fetch_type === Any && fetch_error === Any
             rt_result = Task
@@ -4401,6 +4402,8 @@ end
             fields[i] = a
         end
         anyrefine && return PartialStruct(𝕃ᵢ, rt.typ, _getundefs(rt), fields)
+    elseif isa(rt, PartialTask)
+        return rt # already widened, by construction
     end
     if isa(rt, PartialOpaque)
         return rt # XXX: this case was missed in #39512

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -2595,7 +2595,7 @@ function abstract_finalizer(interp::AbstractInterpreter, argtypes::Vector{Any}, 
         finalizer_argvec = Any[argtypes[2], argtypes[3]]
         call = abstract_call(interp, ArgInfo(nothing, finalizer_argvec), StmtInfo(false, false), vtypes, sv, #=max_methods=#1)::Future
         return Future{CallMeta}(call, interp, sv) do call, _, _
-            return CallMeta(Nothing, Any, Effects(), FinalizerInfo(call.info, call.effects))
+            return CallMeta(Nothing, Any, Effects(), IndirectCallInfo(call.info, call.effects, false))
         end
     end
     return Future(CallMeta(Nothing, Any, Effects(), NoCallInfo()))
@@ -2934,6 +2934,8 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
             return Future(abstract_eval_isdefinedglobal(interp, sv, si.saw_latestworld, argtypes))
         elseif f === Core.get_binding_type
             return Future(abstract_eval_get_binding_type(interp, sv, argtypes))
+        elseif f === Core._task
+            return abstract_eval_task_builtin(interp, arginfo, si, vtypes, sv)
         end
         rt = abstract_call_builtin(interp, f, arginfo, vtypes, sv)
         ft = popfirst!(argtypes)
@@ -3475,6 +3477,58 @@ function abstract_eval_splatnew(interp::AbstractInterpreter, e::Expr, sstate::St
     consistent = !ismutabletype(rt) ? ALWAYS_TRUE : CONSISTENT_IF_NOTRETURNED
     effects = Effects(EFFECTS_TOTAL; consistent, nothrow)
     return RTEffects(rt, Any, effects)
+end
+
+function abstract_eval_task_builtin(interp::AbstractInterpreter, arginfo::ArgInfo, si::StmtInfo,
+                                    vtypes::Union{VarTable,Nothing}, sv::AbsIntState)
+    (; fargs, argtypes) = arginfo
+    la = length(argtypes)
+    𝕃ᵢ = typeinf_lattice(interp)
+    # Check argument count: _task(func, size) or _task(func, size, ci)
+    if la < 3 || la > 4
+        return Future(CallMeta(Bottom, Any, EFFECTS_THROWS, NoCallInfo()))
+    end
+    # Check that size argument is an Int
+    size_arg = argtypes[3]
+    if !(widenconst(size_arg) ⊑ Int)
+        return Future(CallMeta(Bottom, Any, EFFECTS_THROWS, NoCallInfo()))
+    end
+
+    func_arg = argtypes[2]
+
+    # Handle optional Method/CodeInstance/Type argument (4th parameter)
+    if la == 4
+        invoke_args = Any[Const(Core.invoke), func_arg, argtypes[4]]
+        invoke_arginfo = ArgInfo(nothing, invoke_args)
+        invoke_future = abstract_invoke(interp, invoke_arginfo, si, vtypes, sv)
+        return Future{CallMeta}(invoke_future, interp, sv) do invoke_result, interp, sv
+            fetch_type = invoke_result.rt
+            fetch_error = invoke_result.exct
+            task_effects = invoke_result.effects
+            if fetch_type === Any && fetch_error === Any
+                rt_result = Task
+            else
+                rt_result = PartialTask(fetch_type, fetch_error)
+            end
+            info_result = IndirectCallInfo(invoke_result.info, task_effects, true)
+            return CallMeta(rt_result, Any, Effects(), info_result)
+        end
+    end
+
+    # Fallback to abstract_call for function analysis
+    callinfo_future = abstract_call(interp, ArgInfo(nothing, Any[func_arg]), StmtInfo(true, si.saw_latestworld), vtypes, sv, #=max_methods=#1)
+    return Future{CallMeta}(callinfo_future, interp, sv) do callinfo, interp, sv
+        fetch_type = callinfo.rt
+        fetch_error = callinfo.exct
+        task_effects = callinfo.effects
+        if fetch_type === Any && fetch_error === Any
+            rt_result = Task
+        else
+            rt_result = PartialTask(fetch_type, fetch_error)
+        end
+        info_result = IndirectCallInfo(callinfo.info, task_effects, true)
+        return CallMeta(rt_result, Any, Effects(), info_result)
+    end
 end
 
 function abstract_eval_new_opaque_closure(interp::AbstractInterpreter, e::Expr, sstate::StatementState,

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3509,34 +3509,26 @@ function abstract_eval_task_builtin(interp::AbstractInterpreter, arginfo::ArgInf
         invoke_args = Any[Const(Core.invoke), func_arg, argtypes[4]]
         invoke_arginfo = ArgInfo(nothing, invoke_args)
         invoke_future = abstract_invoke(interp, invoke_arginfo, si, vtypes, sv)
-        return Future{CallMeta}(invoke_future, interp, sv) do invoke_result, interp, sv
-            fetch_type = widenconst(invoke_result.rt)
-            fetch_error = widenconst(invoke_result.exct)
-            task_effects = invoke_result.effects
-            if fetch_type === Any && fetch_error === Any
-                rt_result = Task
-            else
-                rt_result = PartialTask(fetch_type, fetch_error)
-            end
-            info_result = IndirectCallInfo(invoke_result.info, task_effects, true)
-            return CallMeta(rt_result, Any, Effects(), info_result)
-        end
+        return Future{CallMeta}(task_callmeta, invoke_future, interp, sv)
     end
 
     # Otherwise use abstract_call for function analysis
     callinfo_future = abstract_call(interp, ArgInfo(nothing, Any[func_arg]), StmtInfo(true, si.saw_latestworld), vtypes, sv, #=max_methods=#1)
-    return Future{CallMeta}(callinfo_future, interp, sv) do callinfo, interp, sv
-        fetch_type = widenconst(callinfo.rt)
-        fetch_error = widenconst(callinfo.exct)
-        task_effects = callinfo.effects
-        if fetch_type === Any && fetch_error === Any
-            rt_result = Task
-        else
-            rt_result = PartialTask(fetch_type, fetch_error)
-        end
-        info_result = IndirectCallInfo(callinfo.info, task_effects, true)
-        return CallMeta(rt_result, Any, Effects(), info_result)
+    return Future{CallMeta}(task_callmeta, callinfo_future, interp, sv)
+end
+
+# Convert the `CallMeta` of the task body call into the `CallMeta` of the `Core._task`
+# call that creates it, tracking the body's result/error types with a `PartialTask`.
+function task_callmeta(call::CallMeta, ::AbstractInterpreter, ::AbsIntState)
+    fetch_type = widenconst(call.rt)
+    fetch_error = widenconst(call.exct)
+    if fetch_type === Any && fetch_error === Any
+        rt_result = Task
+    else
+        rt_result = PartialTask(fetch_type, fetch_error)
     end
+    info_result = IndirectCallInfo(call.info, call.effects, true)
+    return CallMeta(rt_result, Any, Effects(), info_result)
 end
 
 function abstract_eval_new_opaque_closure(interp::AbstractInterpreter, e::Expr, sstate::StatementState,

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3479,6 +3479,15 @@ function abstract_eval_splatnew(interp::AbstractInterpreter, e::Expr, sstate::St
     return RTEffects(rt, Any, effects)
 end
 
+# Effects of the `Core._task` builtin itself; the deferred body does not run here.
+# Creating a task returns a fresh mutable object, inherits the current task's scope
+# and forks its RNG state (advancing the parent's internal RNG via `jl_rng_split`),
+# so the call is not consistent, not effect-free, and accesses task state. It may
+# throw, e.g. for an invalid stack size, but always terminates and has no UB.
+const TASK_BUILTIN_EFFECTS = Effects(EFFECTS_TOTAL;
+    consistent=ALWAYS_FALSE, effect_free=ALWAYS_FALSE, nothrow=false,
+    notaskstate=false, inaccessiblememonly=ALWAYS_FALSE)
+
 function abstract_eval_task_builtin(interp::AbstractInterpreter, arginfo::ArgInfo, si::StmtInfo,
                                     vtypes::Union{VarTable,Nothing}, sv::AbsIntState)
     argtypes = arginfo.argtypes
@@ -3498,7 +3507,7 @@ function abstract_eval_task_builtin(interp::AbstractInterpreter, arginfo::ArgInf
     if isva && la < 5
         # Without a fixed invoke target, the vararg may supply any of the required
         # arguments, so only retain the builtin's guaranteed return type.
-        return Future(CallMeta(Task, Any, Effects(), NoCallInfo()))
+        return Future(CallMeta(Task, Any, TASK_BUILTIN_EFFECTS, NoCallInfo()))
     end
     func_arg = argtypes[2]
 
@@ -3528,7 +3537,7 @@ function task_callmeta(call::CallMeta, ::AbstractInterpreter, ::AbsIntState)
         rt_result = PartialTask(fetch_type, fetch_error)
     end
     info_result = IndirectCallInfo(call.info, call.effects, true)
-    return CallMeta(rt_result, Any, Effects(), info_result)
+    return CallMeta(rt_result, Any, TASK_BUILTIN_EFFECTS, info_result)
 end
 
 function abstract_eval_new_opaque_closure(interp::AbstractInterpreter, e::Expr, sstate::StatementState,

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3481,19 +3481,24 @@ end
 
 function abstract_eval_task_builtin(interp::AbstractInterpreter, arginfo::ArgInfo, si::StmtInfo,
                                     vtypes::Union{VarTable,Nothing}, sv::AbsIntState)
-    (; fargs, argtypes) = arginfo
+    argtypes = arginfo.argtypes
     la = length(argtypes)
-    𝕃ᵢ = typeinf_lattice(interp)
-    if !isempty(argtypes) && !isvarargtype(argtypes[end])
-        if !(3 <= la <= 4)
-            return Future(CallMeta(Bottom, Any, EFFECTS_THROWS, NoCallInfo()))
-        end
-    elseif isempty(argtypes) || la > 5
+    isva = !isempty(argtypes) && isvarargtype(argtypes[end])
+    if isva
+        la > 5 && return Future(CallMeta(Bottom, Any, EFFECTS_THROWS, NoCallInfo()))
+        size_arg = argtype_by_index(argtypes, 3)
+    elseif !(3 <= la <= 4)
         return Future(CallMeta(Bottom, Any, EFFECTS_THROWS, NoCallInfo()))
+    else
+        size_arg = argtypes[3]
     end
-    size_arg = argtypes[3]
     if !hasintersect(widenconst(size_arg), Int)
         return Future(CallMeta(Bottom, Any, EFFECTS_THROWS, NoCallInfo()))
+    end
+    if isva
+        # The vararg may supply any of the required arguments, so only retain the
+        # builtin's guaranteed return type.
+        return Future(CallMeta(Task, Any, Effects(), NoCallInfo()))
     end
     func_arg = argtypes[2]
 

--- a/Compiler/src/abstractlattice.jl
+++ b/Compiler/src/abstractlattice.jl
@@ -191,7 +191,7 @@ information that would not be available from the type itself.
 @nospecializeinfer function has_nontrivial_extended_info(𝕃::PartialsLattice, @nospecialize t)
     isa(t, PartialStruct) && return true
     isa(t, PartialOpaque) && return true
-    #isa(t, PartialTask) && return true
+    isa(t, PartialTask) && return true
     return has_nontrivial_extended_info(widenlattice(𝕃), t)
 end
 @nospecializeinfer function has_nontrivial_extended_info(𝕃::ConstsLattice, @nospecialize t)
@@ -226,7 +226,7 @@ that should be forwarded along with constant propagation.
         # return false
     end
     isa(t, PartialOpaque) && return true
-    #isa(t, PartialTask) && return true
+    isa(t, PartialTask) && return true
     return is_const_prop_profitable_arg(widenlattice(𝕃), t)
 end
 @nospecializeinfer function is_const_prop_profitable_arg(𝕃::ConstsLattice, @nospecialize t)
@@ -250,6 +250,7 @@ end
 @nospecializeinfer function is_forwardable_argtype(𝕃::PartialsLattice, @nospecialize x)
     isa(x, PartialStruct) && return true
     isa(x, PartialOpaque) && return true
+    isa(x, PartialTask) && return true
     return is_forwardable_argtype(widenlattice(𝕃), x)
 end
 @nospecializeinfer function is_forwardable_argtype(𝕃::ConstsLattice, @nospecialize x)

--- a/Compiler/src/abstractlattice.jl
+++ b/Compiler/src/abstractlattice.jl
@@ -24,13 +24,13 @@ is_valid_lattice_norec(::ConstsLattice, @nospecialize(elem)) = isa(elem, Const) 
 """
     struct PartialsLattice{𝕃<:AbstractLattice} <: AbstractLattice
 
-A lattice extending a base lattice `𝕃` and adjoining `PartialStruct` and `PartialOpaque`.
+A lattice extending a base lattice `𝕃` and adjoining `PartialStruct`, `PartialOpaque`, and `PartialTask`.
 """
 struct PartialsLattice{𝕃<:AbstractLattice} <: AbstractLattice
     parent::𝕃
 end
 widenlattice(𝕃::PartialsLattice) = 𝕃.parent
-is_valid_lattice_norec(::PartialsLattice, @nospecialize(elem)) = isa(elem, PartialStruct) || isa(elem, PartialOpaque)
+is_valid_lattice_norec(::PartialsLattice, @nospecialize(elem)) = isa(elem, PartialStruct) || isa(elem, PartialOpaque) || isa(elem, PartialTask)
 
 """
     struct ConditionalsLattice{𝕃<:AbstractLattice} <: AbstractLattice
@@ -191,6 +191,7 @@ information that would not be available from the type itself.
 @nospecializeinfer function has_nontrivial_extended_info(𝕃::PartialsLattice, @nospecialize t)
     isa(t, PartialStruct) && return true
     isa(t, PartialOpaque) && return true
+    #isa(t, PartialTask) && return true
     return has_nontrivial_extended_info(widenlattice(𝕃), t)
 end
 @nospecializeinfer function has_nontrivial_extended_info(𝕃::ConstsLattice, @nospecialize t)
@@ -225,6 +226,7 @@ that should be forwarded along with constant propagation.
         # return false
     end
     isa(t, PartialOpaque) && return true
+    #isa(t, PartialTask) && return true
     return is_const_prop_profitable_arg(widenlattice(𝕃), t)
 end
 @nospecializeinfer function is_const_prop_profitable_arg(𝕃::ConstsLattice, @nospecialize t)

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -1718,7 +1718,8 @@ function early_inline_special_case(ir::IRCode, stmt::Expr, flag::UInt32,
         elseif ⊑(optimizer_lattice(state.interp), cond, Bool) && stmt.args[3] === stmt.args[4]
             return SomeCase(stmt.args[3])
         end
-    elseif f === Core.task_result_type
+    elseif (f === Core.task_result_type && length(argtypes) == 2 &&
+            ⊑(optimizer_lattice(state.interp), argtypes[2], Task))
         return SomeCase(quoted(instanceof_tfunc(type)[1]))
     end
     return nothing

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -1201,7 +1201,7 @@ end
 function handle_task_call!(ir::IRCode, idx::Int, stmt::Expr, info::IndirectCallInfo, state::InliningState)
     length(stmt.args) == 3 || return
     # Extract the CodeInstance from the inference result if available
-    info_edge = extract_indirect_invoke(info; check_fully_covers=false)
+    info_edge = extract_indirect_invoke(info)
     info_edge === nothing && return nothing
     info, edge = info_edge
     case = compileable_specialization(edge, Effects(), InliningEdgeTracker(state), info, state)
@@ -1216,15 +1216,13 @@ function handle_task_call!(ir::IRCode, idx::Int, stmt::Expr, info::IndirectCallI
     return nothing
 end
 
-function extract_indirect_invoke(info::IndirectCallInfo; check_fully_covers::Bool)
+function extract_indirect_invoke(info::IndirectCallInfo)
     info = info.info
     info isa MethodResultPure && (info = info.info)
     info isa MethodMatchInfo || return nothing
     length(info.edges) == length(info.results) == 1 || return nothing
     match = info.results[1]::MethodMatch
-    if check_fully_covers
-        match.fully_covers || return nothing
-    end
+    match.fully_covers || return nothing
     edge = info.edges[1]
     edge === nothing && return nothing
     return info, edge
@@ -1525,7 +1523,7 @@ function handle_opaque_closure_call!(todo::Vector{Pair{Int,Any}},
 end
 
 function handle_modifyop!_call!(ir::IRCode, idx::Int, stmt::Expr, info::IndirectCallInfo, state::InliningState)
-    info_edge = extract_indirect_invoke(info; check_fully_covers=true)
+    info_edge = extract_indirect_invoke(info)
     info_edge === nothing && return nothing
     info, edge = info_edge
     case = compileable_specialization(edge, Effects(), InliningEdgeTracker(state), info, state)

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -1206,6 +1206,9 @@ function handle_task_call!(ir::IRCode, idx::Int, stmt::Expr, info::IndirectCallI
     info, edge = info_edge
     case = compileable_specialization(edge, Effects(), InliningEdgeTracker(state), info, state)
     case === nothing && return nothing
+    # The runtime (`jl_f_invoke`) only accepts Method/CodeInstance/Type targets, so
+    # decline if compileable_specialization only found an uncached MethodInstance.
+    case.invoke isa CodeInstance || return nothing
     # Append the CodeInstance as a third argument to the _task call
     # Core._task(func, size) becomes Core._task(func, size, ci)
     push!(stmt.args, case.invoke)
@@ -1568,7 +1571,9 @@ function handle_finalizer_call!(ir::IRCode, idx::Int, stmt::Expr, info::Indirect
                 push!(stmt.args, true)
                 push!(stmt.args, code)
             end
-        elseif isa(item1, InvokeCase)
+        elseif isa(item1, InvokeCase) && item1.invoke isa CodeInstance
+            # like handle_task_call!, an uncached MethodInstance is unusable here, since
+            # `try_resolve_finalizer!` requires a CodeInstance in this argument position
             push!(stmt.args, false)
             push!(stmt.args, item1.invoke)
         elseif isa(item1, ConstantCase)

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -1201,14 +1201,9 @@ end
 function handle_task_call!(ir::IRCode, idx::Int, stmt::Expr, info::IndirectCallInfo, state::InliningState)
     length(stmt.args) == 3 || return
     # Extract the CodeInstance from the inference result if available
-    info = info.info
-    info isa MethodResultPure && (info = info.info)
-    info isa ConstCallInfo && (info = info.call)
-    info isa MethodMatchInfo || return nothing
-    length(info.edges) == length(info.results) == 1 || return nothing
-    match = info.results[1]::MethodMatch
-    edge = info.edges[1]
-    edge === nothing && return nothing
+    info_edge = extract_indirect_invoke(info; check_fully_covers=false)
+    info_edge === nothing && return nothing
+    info, edge = info_edge
     case = compileable_specialization(edge, Effects(), InliningEdgeTracker(state), info, state)
     case === nothing && return nothing
     # Append the CodeInstance as a third argument to the _task call
@@ -1216,6 +1211,20 @@ function handle_task_call!(ir::IRCode, idx::Int, stmt::Expr, info::IndirectCallI
     push!(stmt.args, case.invoke)
     ir[SSAValue(idx)][:stmt] = stmt
     return nothing
+end
+
+function extract_indirect_invoke(info::IndirectCallInfo; check_fully_covers::Bool)
+    info = info.info
+    info isa MethodResultPure && (info = info.info)
+    info isa MethodMatchInfo || return nothing
+    length(info.edges) == length(info.results) == 1 || return nothing
+    match = info.results[1]::MethodMatch
+    if check_fully_covers
+        match.fully_covers || return nothing
+    end
+    edge = info.edges[1]
+    edge === nothing && return nothing
+    return info, edge
 end
 
 # As a matter of convenience, this pass also computes effect-freenes.
@@ -1513,14 +1522,9 @@ function handle_opaque_closure_call!(todo::Vector{Pair{Int,Any}},
 end
 
 function handle_modifyop!_call!(ir::IRCode, idx::Int, stmt::Expr, info::IndirectCallInfo, state::InliningState)
-    info = info.info
-    info isa MethodResultPure && (info = info.info)
-    info isa MethodMatchInfo || return nothing
-    length(info.edges) == length(info.results) == 1 || return nothing
-    match = info.results[1]::MethodMatch
-    match.fully_covers || return nothing
-    edge = info.edges[1]
-    edge === nothing && return nothing
+    info_edge = extract_indirect_invoke(info; check_fully_covers=true)
+    info_edge === nothing && return nothing
+    info, edge = info_edge
     case = compileable_specialization(edge, Effects(), InliningEdgeTracker(state), info, state)
     case === nothing && return nothing
     stmt.head = :invoke_modify

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -1195,6 +1195,27 @@ function narrow_opaque_closure!(ir::IRCode, stmt::Expr, @nospecialize(info::Call
             stmt.args[3] = newT
         end
     end
+    return nothing
+end
+
+function handle_task_call!(ir::IRCode, idx::Int, stmt::Expr, info::IndirectCallInfo, state::InliningState)
+    length(stmt.args) == 3 || return
+    # Extract the CodeInstance from the inference result if available
+    info = info.info
+    info isa MethodResultPure && (info = info.info)
+    info isa ConstCallInfo && (info = info.call)
+    info isa MethodMatchInfo || return nothing
+    length(info.edges) == length(info.results) == 1 || return nothing
+    match = info.results[1]::MethodMatch
+    edge = info.edges[1]
+    edge === nothing && return nothing
+    case = compileable_specialization(edge, Effects(), InliningEdgeTracker(state), info, state)
+    case === nothing && return nothing
+    # Append the CodeInstance as a third argument to the _task call
+    # Core._task(func, size) becomes Core._task(func, size, ci)
+    push!(stmt.args, case.invoke)
+    ir[SSAValue(idx)][:stmt] = stmt
+    return nothing
 end
 
 # As a matter of convenience, this pass also computes effect-freenes.
@@ -1264,7 +1285,8 @@ function process_simple!(todo::Vector{Pair{Int,Any}}, ir::IRCode, idx::Int, flag
                 f !== modifyfield! &&
                 f !== Core.modifyglobal! &&
                 f !== Core.memoryrefmodify! &&
-                f !== atomic_pointermodify)
+                f !== atomic_pointermodify &&
+                f !== Core._task)
                 # No inlining defined for most builtins (just invoke/apply/typeassert/finalizer), so attempt an early exit for them
                 return nothing
             end
@@ -1490,7 +1512,7 @@ function handle_opaque_closure_call!(todo::Vector{Pair{Int,Any}},
     return nothing
 end
 
-function handle_modifyop!_call!(ir::IRCode, idx::Int, stmt::Expr, info::ModifyOpInfo, state::InliningState)
+function handle_modifyop!_call!(ir::IRCode, idx::Int, stmt::Expr, info::IndirectCallInfo, state::InliningState)
     info = info.info
     info isa MethodResultPure && (info = info.info)
     info isa MethodMatchInfo || return nothing
@@ -1507,7 +1529,7 @@ function handle_modifyop!_call!(ir::IRCode, idx::Int, stmt::Expr, info::ModifyOp
     return nothing
 end
 
-function handle_finalizer_call!(ir::IRCode, idx::Int, stmt::Expr, info::FinalizerInfo,
+function handle_finalizer_call!(ir::IRCode, idx::Int, stmt::Expr, info::IndirectCallInfo,
                                 state::InliningState)
     # Finalizers don't return values, so if their execution is not observable,
     # we can just not register them
@@ -1615,14 +1637,22 @@ function assemble_inline_todo!(ir::IRCode, state::InliningState)
         end
 
         # handle special cased builtins
+        f = sig.f
         if isa(info, OpaqueClosureCallInfo)
             handle_opaque_closure_call!(todo, ir, idx, stmt, info, flag, sig, state)
-        elseif isa(info, ModifyOpInfo)
-            handle_modifyop!_call!(ir, idx, stmt, info, state)
-        elseif sig.f === Core.invoke
+        elseif isa(info, IndirectCallInfo)
+            if f === Core.finalizer
+                handle_finalizer_call!(ir, idx, stmt, info, state)
+            elseif f === modifyfield! ||
+                   f === Core.modifyglobal! ||
+                   f === Core.memoryrefmodify! ||
+                   f === atomic_pointermodify
+                handle_modifyop!_call!(ir, idx, stmt, info, state)
+            elseif f === Core._task
+                handle_task_call!(ir, idx, stmt, info, state)
+            end
+        elseif f === Core.invoke
             handle_invoke_call!(todo, ir, idx, stmt, info, flag, sig, state)
-        elseif isa(info, FinalizerInfo)
-            handle_finalizer_call!(ir, idx, stmt, info, state)
         else
             # cascade to the generic (and extendable) handler
             handle_call!(todo, ir, idx, stmt, info, flag, sig, state)

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -1714,6 +1714,8 @@ function early_inline_special_case(ir::IRCode, stmt::Expr, flag::UInt32,
         elseif ⊑(optimizer_lattice(state.interp), cond, Bool) && stmt.args[3] === stmt.args[4]
             return SomeCase(stmt.args[3])
         end
+    elseif f === Core.task_result_type
+        return SomeCase(quoted(instanceof_tfunc(type)[1]))
     end
     return nothing
 end

--- a/Compiler/src/ssair/passes.jl
+++ b/Compiler/src/ssair/passes.jl
@@ -1398,7 +1398,7 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
         elseif is_known_call(stmt, Core.finalizer, compact)
             3 <= length(stmt.args) <= 5 || continue
             info = compact[SSAValue(idx)][:info]
-            if isa(info, FinalizerInfo)
+            if isa(info, IndirectCallInfo)
                 is_finalizer_inlineable(info.effects) || continue
             else
                 # Inlining performs legality checks on the finalizer to determine
@@ -1785,7 +1785,7 @@ function try_resolve_finalizer!(ir::IRCode, alloc_idx::Int, finalizer_idx::Int, 
 
     finalizer_stmt = ir[SSAValue(finalizer_idx)][:stmt]
     argexprs = Any[finalizer_stmt.args[2], finalizer_stmt.args[3]]
-    flag = info isa FinalizerInfo ? flags_for_effects(info.effects) : IR_FLAG_NULL
+    flag = isa(info, IndirectCallInfo) ? flags_for_effects(info.effects) : IR_FLAG_NULL
     if length(finalizer_stmt.args) >= 4
         inline = finalizer_stmt.args[4]
         if inline === nothing

--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -452,7 +452,7 @@ Used for:
  - `Core._task(f, size)` where `f()` will be called when the task runs
  - `Core.finalizer(f, obj)` where `f(obj)` will be called during garbage collection
 
-Contains the CallInfo for the indirect function call, its effects, and whether
+Contains the `CallInfo` for the indirect function call, its effects, and whether
 the indirect call should contribute edges for invalidation tracking.
 """
 struct IndirectCallInfo <: CallInfo
@@ -486,6 +486,5 @@ end
 function add_edges_impl(edges::Vector{Any}, info::GlobalAccessInfo)
     push!(edges, info.b)
 end
-
 
 @specialize

--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -441,33 +441,31 @@ end
 add_edges_impl(edges::Vector{Any}, info::ReturnTypeCallInfo) = add_edges!(edges, info.info)
 
 """
-    info::FinalizerInfo <: CallInfo
+    info::IndirectCallInfo <: CallInfo
 
-Represents the information of a potential (later) call to the finalizer on the given
-object type.
+Represents information about a call that involves an indirect/nested function call.
+Used for:
+ - `modifyfield!(obj, name, op, x, [order])` where `op(getval(), x)` is called
+ - `modifyglobal!(mod, var, op, x, order)` where `op(getval(), x)` is called
+ - `memoryrefmodify!(memref, op, x, order, boundscheck)` where `op(getval(), x)` is called
+ - `Intrinsics.atomic_pointermodify(ptr, op, x, order)` where `op(getval(), x)` is called
+ - `Core._task(f, size)` where `f()` will be called when the task runs
+ - `Core.finalizer(f, obj)` where `f(obj)` will be called during garbage collection
+
+Contains the CallInfo for the indirect function call, its effects, and whether
+the indirect call should contribute edges for invalidation tracking.
 """
-struct FinalizerInfo <: CallInfo
-    info::CallInfo   # the callinfo for the finalizer call
-    effects::Effects # the effects for the finalizer call
+struct IndirectCallInfo <: CallInfo
+    info::CallInfo   # the callinfo for the indirect function call
+    effects::Effects # the effects for the indirect function call
+    add_edges::Bool  # whether to add edges for invalidation tracking
 end
-# merely allocating a finalizer does not imply edges (unless it gets inlined later)
-add_edges_impl(::Vector{Any}, ::FinalizerInfo) = nothing
-
-"""
-    info::ModifyOpInfo <: CallInfo
-
-Represents a resolved call of one of:
- - `modifyfield!(obj, name, op, x, [order])`
- - `modifyglobal!(mod, var, op, x, order)`
- - `memoryrefmodify!(memref, op, x, order, boundscheck)`
- - `Intrinsics.atomic_pointermodify(ptr, op, x, order)`
-
-`info.info` wraps the call information of `op(getval(), x)`.
-"""
-struct ModifyOpInfo <: CallInfo
-    info::CallInfo # the callinfo for the `op(getval(), x)` call
+function add_edges_impl(edges::Vector{Any}, info::IndirectCallInfo)
+    if info.add_edges
+        add_edges!(edges, info.info)
+    end
+    # otherwise add no edges (e.g., for finalizers that don't imply edges unless inlined)
 end
-add_edges_impl(edges::Vector{Any}, info::ModifyOpInfo) = add_edges!(edges, info.info)
 
 struct VirtualMethodMatchInfo <: CallInfo
     info::Union{MethodMatchInfo,UnionSplitInfo,InvokeCallInfo}
@@ -488,5 +486,6 @@ end
 function add_edges_impl(edges::Vector{Any}, info::GlobalAccessInfo)
     push!(edges, info.b)
 end
+
 
 @specialize

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -603,7 +603,6 @@ add_tfunc(Core.bitsizeof, 1, 1, bitsizeof_tfunc, 1)
 end
 add_tfunc(nfields, 1, 1, nfields_tfunc, 1)
 add_tfunc(Core._expr, 1, INT_INF, @nospecs((𝕃::AbstractLattice, args...)->Expr), 100)
-
 add_tfunc(svec, 0, INT_INF, @nospecs((𝕃::AbstractLattice, args...)->SimpleVector), 20)
 
 @nospecs function _svec_len_tfunc(::AbstractLattice, s)

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -3623,7 +3623,10 @@ add_tfunc(Core.get_binding_type, 2, 2, @nospecs((𝕃::AbstractLattice, args...)
 @nospecs function task_result_type_tfunc(𝕃::AbstractLattice, T)
     hasintersect(widenconst(T), Task) || return Union{}
     if T isa PartialTask
-        return widenconst(Const(widenconst(T.fetch_type)))
+        # fetch_type is widened at construction, but re-widen defensively since
+        # PartialTask objects also arrive from cached (serialized) rettype_const
+        # and from external AbstractInterpreters
+        return Const(widenconst(T.fetch_type))
     end
     return Type
 end

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1204,6 +1204,12 @@ end
         end
         s00 = s
     elseif isa(s00, PartialTask)
+        # N.B.: Do not use `PartialTask.fetch_type` to refine any field load here (e.g.
+        # `:result`). Task fields are mutable, so `fetch_type` is not an invariant of the
+        # current field contents; it is only sound as the *checked* side of the `typeassert`
+        # in `fetch` (via `task_result_type_tfunc`). Refining the load itself would let the
+        # optimizer prove that typeassert and delete it, turning a field mutation into
+        # silent type confusion instead of a runtime `TypeError`.
         s00 = Task
     end
     return _getfield_tfunc(widenlattice(𝕃), s00, name, setfield)

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -2615,6 +2615,9 @@ function _builtin_nothrow(𝕃::AbstractLattice, @nospecialize(f::Builtin), argt
     elseif f === Core._svec_ref
         na == 2 || return false
         return _svec_ref_tfunc(𝕃, argtypes[1], argtypes[2]) isa Const
+    elseif f === Core.task_result_type
+        na == 1 || return false
+        return argtypes[1] ⊑ Task
     end
     return false
 end
@@ -2624,7 +2627,6 @@ const _PURE_BUILTINS = Any[
     tuple,
     svec,
     ===,
-    Core.task_result_type,
     typeof,
     has_free_typevars,
     nfields,
@@ -2681,6 +2683,7 @@ const _EFFECT_FREE_BUILTINS = [
     compilerbarrier,
     Core._svec_len,
     Core._svec_ref,
+    Core.task_result_type,
 ]
 
 const _INACCESSIBLEMEM_BUILTINS = Any[

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -2884,6 +2884,7 @@ const _EFFECTS_KNOWN_BUILTINS = Any[
     # Core._structtype,
     Core._svec_len,
     Core._svec_ref,
+    Core._task,
     # Core._typebody!,
     Core._typevar,
     apply_type,
@@ -2988,6 +2989,8 @@ function builtin_effects(𝕃::AbstractLattice, @nospecialize(f::Builtin), argty
             consistent = ALWAYS_FALSE,
             notaskstate = false,
             nothrow)
+    elseif f === Core._task
+        return TASK_BUILTIN_EFFECTS
     else
         if contains_is(_CONSISTENT_BUILTINS, f)
             consistent = ALWAYS_TRUE

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -603,6 +603,7 @@ add_tfunc(Core.bitsizeof, 1, 1, bitsizeof_tfunc, 1)
 end
 add_tfunc(nfields, 1, 1, nfields_tfunc, 1)
 add_tfunc(Core._expr, 1, INT_INF, @nospecs((𝕃::AbstractLattice, args...)->Expr), 100)
+
 add_tfunc(svec, 0, INT_INF, @nospecs((𝕃::AbstractLattice, args...)->SimpleVector), 20)
 
 @nospecs function _svec_len_tfunc(::AbstractLattice, s)
@@ -1203,6 +1204,12 @@ end
             end
         end
         s00 = s
+    elseif isa(s00, PartialTask)
+        # Special case: accessing the 'result' field of a PartialTask returns the fetch_type or error_type or some other value set by the user
+        #if isa(name, Const) && name.val === :result
+        #    return s00.fetch_type
+        #end
+        s00 = Task
     end
     return _getfield_tfunc(widenlattice(𝕃), s00, name, setfield)
 end
@@ -1501,7 +1508,7 @@ end
             elseif isconcretetype(RT) && has_nontrivial_extended_info(𝕃ᵢ, TF2) # isconcrete condition required to form a PartialStruct
                 RT = PartialStruct(fallback_lattice, RT, Union{Nothing,Bool}[false,false], Any[TF, TF2])
             end
-            info = ModifyOpInfo(callinfo.info)
+            info = IndirectCallInfo(callinfo.info, callinfo.effects, true)
             return CallMeta(RT, Any, Effects(), info)
         end
     end
@@ -3375,7 +3382,7 @@ function intrinsic_effects(f::IntrinsicFunction, argtypes::Vector{Any})
         # llvmcall can do arbitrary things
         return Effects()
     elseif f === atomic_pointermodify
-        # atomic_pointermodify has memory effects, plus any effects from the ModifyOpInfo
+        # atomic_pointermodify has memory effects, plus any effects from the IndirectCallInfo
         return Effects()
     end
     is_effect_free = _is_effect_free_infer(f)

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1205,10 +1205,6 @@ end
         end
         s00 = s
     elseif isa(s00, PartialTask)
-        # Special case: accessing the 'result' field of a PartialTask returns the fetch_type or error_type or some other value set by the user
-        #if isa(name, Const) && name.val === :result
-        #    return s00.fetch_type
-        #end
         s00 = Task
     end
     return _getfield_tfunc(widenlattice(𝕃), s00, name, setfield)
@@ -2629,6 +2625,7 @@ const _PURE_BUILTINS = Any[
     tuple,
     svec,
     ===,
+    Core.task_result_type,
     typeof,
     has_free_typevars,
     nfields,
@@ -2698,6 +2695,7 @@ const _INACCESSIBLEMEM_BUILTINS = Any[
     fieldtype,
     isa,
     nfields,
+    Core.task_result_type,
     throw,
     Core.throw_methoderror,
     tuple,
@@ -2930,6 +2928,7 @@ const _EFFECTS_KNOWN_BUILTINS = Any[
     # setglobalonce!,
     swapfield!,
     # swapglobal!,
+    Core.task_result_type,
     throw,
     tuple,
     typeassert,
@@ -3618,6 +3617,15 @@ add_tfunc(modifyglobal!, 4, 5, @nospecs((𝕃::AbstractLattice, args...)->Any), 
 add_tfunc(replaceglobal!, 4, 6, @nospecs((𝕃::AbstractLattice, args...)->Any), 3)
 add_tfunc(setglobalonce!, 3, 5, @nospecs((𝕃::AbstractLattice, args...)->Bool), 3)
 add_tfunc(Core.get_binding_type, 2, 2, @nospecs((𝕃::AbstractLattice, args...)->Type), 0)
+
+@nospecs function task_result_type_tfunc(𝕃::AbstractLattice, T)
+    hasintersect(widenconst(T), Task) || return Union{}
+    if T isa PartialTask
+        return widenconst(Const(widenconst(T.fetch_type)))
+    end
+    return Type
+end
+add_tfunc(Core.task_result_type, 1, 1, task_result_type_tfunc, 0)
 
 # foreigncall
 # ===========

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -706,7 +706,6 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter, cycleid::
 
     # check global cache again for :invoke use, and put in the opt_cache if it wasn't there at this time
     if isdefined(result, :ci)
-
         ci = result.ci
         ipo_effects = encode_effects(result.ipo_effects)
         # populate a few fields that won't change again (and are inspected by optimization)

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -118,6 +118,9 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState, validation
         if isa(result_type, Const)
             rettype_const = result_type.val
             const_flags = const_flag ? 0x3 : 0x2
+        elseif isa(result_type, PartialTask)
+            rettype_const = result_type
+            const_flags = 0x2
         elseif isa(result_type, PartialOpaque)
             rettype_const = result_type
             const_flags = 0x2
@@ -703,6 +706,7 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter, cycleid::
 
     # check global cache again for :invoke use, and put in the opt_cache if it wasn't there at this time
     if isdefined(result, :ci)
+
         ci = result.ci
         ipo_effects = encode_effects(result.ipo_effects)
         # populate a few fields that won't change again (and are inspected by optimization)
@@ -1275,6 +1279,8 @@ function cached_return_type(code::CodeInstance)
         undefs, fields = rettype_const
         return PartialStruct(fallback_lattice, rettype, undefs, fields)
     elseif isa(rettype_const, PartialOpaque) && rettype <: Core.OpaqueClosure
+        return rettype_const
+    elseif isa(rettype_const, PartialTask) && rettype !== PartialTask
         return rettype_const
     elseif isa(rettype_const, InterConditional) && rettype !== InterConditional
         return rettype_const

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1279,7 +1279,7 @@ function cached_return_type(code::CodeInstance)
         return PartialStruct(fallback_lattice, rettype, undefs, fields)
     elseif isa(rettype_const, PartialOpaque) && rettype <: Core.OpaqueClosure
         return rettype_const
-    elseif isa(rettype_const, PartialTask) && rettype !== PartialTask
+    elseif isa(rettype_const, PartialTask) && rettype <: Task
         return rettype_const
     elseif isa(rettype_const, InterConditional) && rettype !== InterConditional
         return rettype_const

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -4,9 +4,9 @@
 # structs/constants #
 #####################
 
-# N.B.: Const/PartialStruct/InterConditional/InterMustAlias are defined in Core,
+# N.B.: Const/PartialStruct/InterConditional/InterMustAlias/PartialTask are defined in Core,
 # to allow them to be used inside the global code cache.
-import Core: Const, InterConditional, PartialStruct, InterMustAlias
+import Core: Const, InterConditional, PartialStruct, InterMustAlias, PartialTask
 
 function may_form_limited_typ(@nospecialize(aty), @nospecialize(bty), @nospecialize(xty))
     if aty isa LimitedAccuracy
@@ -502,6 +502,14 @@ end
     elseif isa(b, PartialOpaque)
         return false
     end
+    if isa(a, PartialTask)
+        if isa(b, PartialTask)
+            return ⊑(lattice, a.fetch_type, b.fetch_type) && ⊑(lattice, a.fetch_error, b.fetch_error)
+        end
+        return ⊑(widenlattice(lattice), Task, b)
+    elseif isa(b, PartialTask)
+        return false
+    end
     return ⊑(widenlattice(lattice), a, b)
 end
 
@@ -569,6 +577,11 @@ end
         return is_lattice_equal(lattice, a.env, b.env)
     end
     isa(b, PartialOpaque) && return false
+    if isa(a, PartialTask)
+        isa(b, PartialTask) || return false
+        return is_lattice_equal(lattice, a.fetch_type, b.fetch_type) && is_lattice_equal(lattice, a.fetch_error, b.fetch_error)
+    end
+    isa(b, PartialTask) && return false
     return is_lattice_equal(widenlattice(lattice), a, b)
 end
 
@@ -631,6 +644,18 @@ end
         ti = typeintersect(widev, t)
         valid_as_lattice(ti, true) || return Bottom
         return PartialOpaque(ti, v.env, v.parent, v.source)
+    elseif isa(v, PartialTask)
+        has_free_typevars(t) && return v
+        if Task <: t
+            return v
+        end
+        ti = typeintersect(Task, t)
+        valid_as_lattice(ti, true) || return Bottom
+        if ti === Task
+            return v
+        else
+            return Bottom  # PartialTask can only be a Task
+        end
     end
     return tmeet(widenlattice(lattice), v, t)
 end
@@ -696,6 +721,7 @@ widenconst(c::Const) = (v = c.val; isa(v, Type) ?
 widenconst(::PartialTypeVar) = TypeVar
 widenconst(t::Core.PartialStruct) = t.typ
 widenconst(t::PartialOpaque) = t.typ
+widenconst(t::PartialTask) = Task
 @nospecializeinfer widenconst(@nospecialize t::AnyType) = t
 widenconst(::TypeVar) = error("unhandled TypeVar")
 widenconst(::TypeofVararg) = error("unhandled Vararg")

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -646,16 +646,7 @@ end
         return PartialOpaque(ti, v.env, v.parent, v.source)
     elseif isa(v, PartialTask)
         has_free_typevars(t) && return v
-        if Task <: t
-            return v
-        end
-        ti = typeintersect(Task, t)
-        valid_as_lattice(ti, true) || return Bottom
-        if ti === Task
-            return v
-        else
-            return Bottom  # PartialTask can only be a Task
-        end
+        return Task <: t ? v : Bottom
     end
     return tmeet(widenlattice(lattice), v, t)
 end

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -405,7 +405,8 @@ end
         return false
     elseif typea isa PartialTask
         typeb isa PartialTask || return false
-        return issimplertype(𝕃, typea.fetch_type, typeb.fetch_type)
+        return issimplertype(𝕃, typea.fetch_type, typeb.fetch_type) &&
+               issimplertype(𝕃, typea.fetch_error, typeb.fetch_error)
     end
     return true
 end

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -403,6 +403,9 @@ end
             return false
         end
         return false
+    elseif typea isa PartialTask
+        typeb isa PartialTask || return false
+        return issimplertype(𝕃, typea.fetch_type, typeb.fetch_type)
     end
     return true
 end
@@ -723,6 +726,24 @@ end
         typea = widenlattice(wl, typea)
     elseif bpo
         typeb = widenlattice(wl, typeb)
+    end
+
+    # type-lattice for PartialTask wrapper
+    apt = isa(typea, PartialTask)
+    bpt = isa(typeb, PartialTask)
+    if apt && bpt
+        # Both are PartialTask - merge their fetch types and errors
+        merged_fetch_type = tmerge(lattice, typea.fetch_type, typeb.fetch_type)
+        merged_fetch_error = tmerge(lattice, typea.fetch_error, typeb.fetch_error)
+        # If both are Any, no additional type information - return Task
+        if merged_fetch_type === Any && merged_fetch_error === Any
+            return Task
+        end
+        return PartialTask(merged_fetch_type, merged_fetch_error)
+    elseif apt
+        typea = Task
+    elseif bpt
+        typeb = Task
     end
 
     return tmerge(wl, typea, typeb)

--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -1605,3 +1605,11 @@ end
 # issue #61590
 @test !Compiler.is_consistent(Base.infer_effects(getproperty, (Core.TypeName, Symbol)))
 @test !Compiler.is_consistent(Base.infer_effects(getfield, (Core.TypeName, Symbol)))
+
+# task_result_type effects modeling (should have !consistent effect)
+let effects = Base.infer_effects(Core.task_result_type, (Task,))
+    @test !Compiler.is_consistent(effects)  # !consistent bit should be set
+    @test Compiler.is_effect_free(effects)
+    @test Compiler.is_nothrow(effects)
+    @test Compiler.is_terminates(effects)
+end

--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -1620,3 +1620,14 @@ end
 for argtypes in ((), (Int,), (Task, Task))
     @test !Compiler.is_nothrow(Base.infer_effects(Core.task_result_type, argtypes))
 end
+
+# Core._task effects modeling: creating a task terminates and has no UB, but
+# accesses task state (scope inheritance, parent RNG split) and may throw
+let effects = Base.infer_effects(Core._task, (Function, Int))
+    @test !Compiler.is_consistent(effects)
+    @test !Compiler.is_effect_free(effects)
+    @test !Compiler.is_nothrow(effects)
+    @test Compiler.is_terminates(effects)
+    @test !Compiler.is_notaskstate(effects)
+    @test Compiler.is_noub(effects)
+end

--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -1613,3 +1613,10 @@ let effects = Base.infer_effects(Core.task_result_type, (Task,))
     @test Compiler.is_nothrow(effects)
     @test Compiler.is_terminates(effects)
 end
+let effects = Base.infer_effects(Core.task_result_type, (Union{Task,Int},))
+    @test Compiler.is_effect_free(effects)
+    @test !Compiler.is_nothrow(effects)
+end
+for argtypes in ((), (Int,), (Task, Task))
+    @test !Compiler.is_nothrow(Base.infer_effects(Core.task_result_type, argtypes))
+end

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -7261,4 +7261,10 @@ end === String
     fetch(Threads.@spawn sin(i))
 end === Float64
 
+# Unknown splats must be handled conservatively, while a fixed invoke target remains precise.
+splatted_task_inference(xs::Tuple) = Core._task(xs...)
+@test Base.infer_return_type(splatted_task_inference, (Tuple,)) === Task
+splatted_task_invalid_size(rest::Tuple) = Core._task(identity, "invalid", rest...)
+@test Base.infer_return_type(splatted_task_invalid_size, (Tuple,)) === Union{}
+
 end # module inference

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -7266,5 +7266,14 @@ splatted_task_inference(xs::Tuple) = Core._task(xs...)
 @test Base.infer_return_type(splatted_task_inference, (Tuple,)) === Task
 splatted_task_invalid_size(rest::Tuple) = Core._task(identity, "invalid", rest...)
 @test Base.infer_return_type(splatted_task_invalid_size, (Tuple,)) === Union{}
+splatted_task_target() = 42
+splatted_task_target(xs...) = xs
+function splatted_task_invoke(@nospecialize(rest::Tuple))
+    targets = (Tuple{Vararg}, rest...)
+    t = Core._task(splatted_task_target, 0, targets...)
+    t.donenotify = Base.ThreadSynchronizer()
+    return fetch(schedule(t))
+end
+@test Base.infer_return_type(splatted_task_invoke, (Tuple,)) === Tuple{}
 
 end # module inference

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -7257,5 +7257,8 @@ end === Core.TypeEgal{String}
 @test Base.infer_return_type((typeof(task_returner),)) do f
     fetch(f())
 end === String
+@test Base.infer_return_type((Int,)) do i
+    fetch(Threads.@spawn sin(i))
+end === Float64
 
 end # module inference

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -7249,4 +7249,13 @@ end == Type{<:Real}
     Compiler.return_type(oc, Tuple{String})
 end == Type{Union{}}
 
+@test Base.infer_return_type(Core.task_result_type, (Task,)) === Type
+task_returner() = Task(() -> "hello")
+@test Base.infer_return_type((typeof(task_returner),)) do f
+    Core.task_result_type(f())
+end === Core.TypeEgal{String}
+@test Base.infer_return_type((typeof(task_returner),)) do f
+    fetch(f())
+end === String
+
 end # module inference

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -1858,12 +1858,10 @@ end
 # ===================
 # Test that _task inlines properly with const prop
 f_task_invoke() = 42
-
 let src = code_typed1(()) do
         return Task(f_task_invoke)
     end
     m = which(f_task_invoke, ())
-    @show src
     @test count(e -> begin
             if iscall((src, Core._task), e) && e isa Expr && e.head === :call && length(e.args) == 4
                 ci = e.args[4]
@@ -2433,6 +2431,13 @@ let mi = Compiler.specialize_method(only(methods(ndims, (Matrix{Float64},))),
     @test codeinst.inferred === nothing
     interp = Compiler.NativeInterpreter()
     @test Compiler.ci_get_source(interp, codeinst) isa Core.CodeInfo
+end
+
+# Test that task_result_type gets inlined to its constant value
+let src = code_typed1((Task,)) do t; Core.task_result_type(t); end
+    # Should be inlined to the `Any` constant, with no call to task_result_type
+    @test count(iscall((src, Core.task_result_type)), src.code) == 0
+    @test src.code[end] == ReturnNode(Any)
 end
 
 end # module inline_tests

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -1873,6 +1873,18 @@ let src = code_typed1(()) do
         end, src.code) == 1
 end
 
+# Test that no invoke target is injected when the single method match does not fully
+# cover the argument type: the task must fall back to generic dispatch so that
+# non-callable bodies still raise a MethodError when the task runs.
+abstract type TaskCallable end
+struct TaskCallableImpl <: TaskCallable end
+(::TaskCallableImpl)() = 1
+let src = code_typed1((TaskCallable,)) do f
+        return Task(f)
+    end
+    @test count(e -> iscall((src, Core._task), e) && length((e::Expr).args) == 3, src.code) == 1
+end
+
 # Test that task_result_type gets inlined to its constant value
 let src = code_typed1((Task,)) do t; Core.task_result_type(t); end
     # Should be inlined to the `Any` constant, with no call to task_result_type

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -1879,6 +1879,17 @@ let src = code_typed1((Task,)) do t; Core.task_result_type(t); end
     @test count(iscall((src, Core.task_result_type)), src.code) == 0
     @test src.code[end] == ReturnNode(Any)
 end
+let src = code_typed1((Union{Task,Int},)) do t; Core.task_result_type(t); end
+    # The Int path throws, so the call cannot be folded away.
+    @test count(iscall((src, Core.task_result_type)), src.code) == 1
+end
+for src in (
+        code_typed1((Int,)) do i; Core.task_result_type(i); end,
+        code_typed1(()) do; Core.task_result_type(); end,
+        code_typed1((Task,Task)) do t, u; Core.task_result_type(t, u); end)
+    # Invalid argument types and arities must retain the throwing call.
+    @test count(iscall((src, Core.task_result_type)), src.code) == 1
+end
 
 # apply `ssa_inlining_pass` multiple times
 func_mul_int(a::Int, b::Int) = Core.Intrinsics.mul_int(a, b)

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -1854,6 +1854,27 @@ let src = code_typed1((AtomicMemoryRef{Int},)) do a
     @test count(isinvokemodify(:+), src.code) == 1
 end
 
+# Core._task handling
+# ===================
+# Test that _task inlines properly with const prop
+f_task_invoke() = 42
+
+let src = code_typed1(()) do
+        return Task(f_task_invoke)
+    end
+    m = which(f_task_invoke, ())
+    @show src
+    @test count(e -> begin
+            if iscall((src, Core._task), e) && e isa Expr && e.head === :call && length(e.args) == 4
+                ci = e.args[4]
+                if ci isa CodeInstance && ci.def.def === m
+                    return true
+                end
+            end
+            return false
+        end, src.code) == 1
+end
+
 # apply `ssa_inlining_pass` multiple times
 func_mul_int(a::Int, b::Int) = Core.Intrinsics.mul_int(a, b)
 multi_inlining1(a::Int, b::Int) = @noinline func_mul_int(a, b)

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -1873,6 +1873,13 @@ let src = code_typed1(()) do
         end, src.code) == 1
 end
 
+# Test that task_result_type gets inlined to its constant value
+let src = code_typed1((Task,)) do t; Core.task_result_type(t); end
+    # Should be inlined to the `Any` constant, with no call to task_result_type
+    @test count(iscall((src, Core.task_result_type)), src.code) == 0
+    @test src.code[end] == ReturnNode(Any)
+end
+
 # apply `ssa_inlining_pass` multiple times
 func_mul_int(a::Int, b::Int) = Core.Intrinsics.mul_int(a, b)
 multi_inlining1(a::Int, b::Int) = @noinline func_mul_int(a, b)
@@ -2431,13 +2438,6 @@ let mi = Compiler.specialize_method(only(methods(ndims, (Matrix{Float64},))),
     @test codeinst.inferred === nothing
     interp = Compiler.NativeInterpreter()
     @test Compiler.ci_get_source(interp, codeinst) isa Core.CodeInfo
-end
-
-# Test that task_result_type gets inlined to its constant value
-let src = code_typed1((Task,)) do t; Core.task_result_type(t); end
-    # Should be inlined to the `Any` constant, with no call to task_result_type
-    @test count(iscall((src, Core.task_result_type)), src.code) == 0
-    @test src.code[end] == ReturnNode(Any)
 end
 
 end # module inline_tests

--- a/NEWS.md
+++ b/NEWS.md
@@ -63,6 +63,12 @@ Command-line option changes
 Multi-threading changes
 -----------------------
 
+  - The return type of `fetch(::Task)` is now inferred precisely when inference can determine the code
+    the task was created to run (for example `fetch(Threads.@spawn f(x))`), instead of always being
+    `Any`. Correspondingly, assigning to the `result` field of a `Task` via property syntax
+    (`t.result = v`) now throws an error: the result of a task is determined by the return value of its
+    code, and the runtime and the compiler now rely on this correspondence. To pass a value to a
+    suspended task, use `schedule(t, val)` or `yieldto(t, val)` ([#59221]).
   - New functions `Threads.atomic_fence_heavy` and `Threads.atomic_fence_light` provide support for
     asymmetric atomic fences, speeding up atomic synchronization where one side of the synchronization
     runs significantly less often than the other ([#60311]).

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -742,7 +742,6 @@ end
 GlobalRef(m::Module, s::Symbol) = ccall(:jl_module_globalref, Ref{GlobalRef}, (Any, Any), m, s)
 Module(name::Symbol=:anonymous, std_imports::Bool=true, default_names::Bool=true) = ccall(:jl_f_new_module, Ref{Module}, (Any, Bool, Bool), name, std_imports, default_names)
 
-
 const NTuple{N,T} = Tuple{Vararg{T,N}}
 
 ## primitive Array constructors

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -682,6 +682,12 @@ struct PartialOpaque
     PartialOpaque(@nospecialize(typ::Type), @nospecialize(env), parent::MethodInstance, source) = new(typ, env, parent, source)
 end
 
+struct PartialTask
+    fetch_type
+    fetch_error
+    PartialTask(@nospecialize(fetch_type), @nospecialize(fetch_error)) = new(fetch_type, fetch_error)
+end
+
 eval(Core, quote
     GotoNode(label::Int) = $(Expr(:new, :GotoNode, :label))
     NewvarNode(slot::SlotNumber) = $(Expr(:new, :NewvarNode, :slot))
@@ -736,9 +742,6 @@ end
 GlobalRef(m::Module, s::Symbol) = ccall(:jl_module_globalref, Ref{GlobalRef}, (Any, Any), m, s)
 Module(name::Symbol=:anonymous, std_imports::Bool=true, default_names::Bool=true) = ccall(:jl_f_new_module, Ref{Module}, (Any, Bool, Bool), name, std_imports, default_names)
 
-function _Task(@nospecialize(f), reserved_stack::Int, completion_future)
-    return ccall(:jl_new_task, Ref{Task}, (Any, Any, Int), f, completion_future, reserved_stack)
-end
 
 const NTuple{N,T} = Tuple{Vararg{T,N}}
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4242,24 +4242,23 @@ Core.finalizer
     Core._task(f, size) -> Task
     Core._task(f, size, invoked) -> Task
 
-This builtin is an implementation detail used by the `Task` constructor and should
-not be called directly by end-users. Use `Task(f)` instead.
-
-Creates a new `Task` that will execute function `f` with the specified stack size.
+Create a new `Task` that will execute function `f` with the specified stack size.
 The optional third argument `invoked` can be a `Method`, `CodeInstance`, or tuple
 `Type` that will be used for optimized task invocation via `Core.invoke`.
 
-This is a low-level interface that bypasses safety checks and initialization
-performed by the public `Task` constructor.
+This builtin is an implementation detail used by the `Task` constructor and should
+not be called directly by end-users. Use `Task(f)` instead. It is a low-level
+interface that bypasses safety checks and initialization performed by the public
+`Task` constructor.
 """
 Core._task
 
 """
     Core.task_result_type(task) -> Type
 
-The builtin function returns a conservative upper bound for the return type of the closure
-provided when the `Task` was created.
-Always return the type `Any`. However inference may replace it with any other Type.
+Return a conservative upper bound for the return type of the closure provided when
+`task` was created. At runtime this builtin always returns the type `Any`; however,
+inference may replace calls to it with a more precise result type.
 """
 Core.task_result_type
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4255,6 +4255,15 @@ performed by the public `Task` constructor.
 Core._task
 
 """
+    Core.task_result_type(task) -> Type
+
+The builtin function returns a conservative upper bound for the return type of the closure
+provided when the Task was created.
+Always return the type `Any`. However inference may replace it with any other Type.
+"""
+Core.task_result_type
+
+"""
     ConcurrencyViolationError(msg) <: Exception
 
 An error thrown when a detectable violation of concurrent semantics has occurred.

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4245,7 +4245,7 @@ Core.finalizer
 This builtin is an implementation detail used by the `Task` constructor and should
 not be called directly by end-users. Use `Task(f)` instead.
 
-Creates a new Task that will execute function `f` with the specified stack size.
+Creates a new `Task` that will execute function `f` with the specified stack size.
 The optional third argument `invoked` can be a `Method`, `CodeInstance`, or tuple
 `Type` that will be used for optimized task invocation via `Core.invoke`.
 
@@ -4258,7 +4258,7 @@ Core._task
     Core.task_result_type(task) -> Type
 
 The builtin function returns a conservative upper bound for the return type of the closure
-provided when the Task was created.
+provided when the `Task` was created.
 Always return the type `Any`. However inference may replace it with any other Type.
 """
 Core.task_result_type

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4239,6 +4239,22 @@ The current differences are:
 Core.finalizer
 
 """
+    Core._task(f, size) -> Task
+    Core._task(f, size, invoked) -> Task
+
+This builtin is an implementation detail used by the `Task` constructor and should
+not be called directly by end-users. Use `Task(f)` instead.
+
+Creates a new Task that will execute function `f` with the specified stack size.
+The optional third argument `invoked` can be a `Method`, `CodeInstance`, or tuple
+`Type` that will be used for optimized task invocation via `Core.invoke`.
+
+This is a low-level interface that bypasses safety checks and initialization
+performed by the public `Task` constructor.
+"""
+Core._task
+
+"""
     ConcurrencyViolationError(msg) <: Exception
 
 An error thrown when a detectable violation of concurrent semantics has occurred.

--- a/base/task.jl
+++ b/base/task.jl
@@ -2,7 +2,11 @@
 
 ## basic task functions and TLS
 
-Core.Task(@nospecialize(f), reserved_stack::Int=0) = Core._Task(f, reserved_stack, ThreadSynchronizer())
+Core.Task(@nospecialize(f), reserved_stack::Int=0) = begin
+    task = Core._task(f, reserved_stack)
+    task.donenotify = ThreadSynchronizer()
+    return task
+end
 
 # Container for a captured exception and its backtrace. Can be serialized.
 struct CapturedException <: Exception

--- a/base/task.jl
+++ b/base/task.jl
@@ -188,6 +188,8 @@ end
         istaskstarted(t) && error("Setting scope on a started task directly is disallowed.")
     elseif field === :invoked
         error("Setting a Task's `invoked` field directly is disallowed because it is an implementation detail.")
+    elseif field === :result
+        error("Setting a Task's `result` field directly is disallowed. The result of a task is determined by the return value of its code; to pass a value to a suspended task, use `schedule(t, val)` or `yieldto(t, val)` instead.")
     end
     return @invoke setproperty!(t::Any, field::Symbol, v::Any)
 end
@@ -1010,7 +1012,7 @@ function enq_work(t::Task)
             # it (the multiqueue heaps are unsized for empty pools, and a
             # task queued during sysimage bootstrap would be serialized
             # into the system image).
-            t.result = ConcurrencyViolationError("deadlock detected: cannot schedule task")
+            setfield!(t, :result, ConcurrencyViolationError("deadlock detected: cannot schedule task"))
             t._isexception = true
             @atomic :release t._state = task_state_failed
             return t

--- a/base/task.jl
+++ b/base/task.jl
@@ -371,6 +371,7 @@ in an error, thrown as a [`TaskFailedException`](@ref) which wraps the failed ta
 Throws a `ConcurrencyViolationError` if `t` is the currently running task, to prevent deadlocks.
 """
 @noinline function wait(t::Task; throw=true)
+    # Inlining a blocking call buys nothing; this also keeps the inlineable `fetch(::Task)` small.
     _wait(t)
     if throw && istaskfailed(t)
         Core.throw(TaskFailedException(t))
@@ -573,7 +574,6 @@ is thrown.
     wait(t)
     return task_result(t)::Core.task_result_type(t)
 end
-
 
 ## lexically-scoped waiting for multiple items
 

--- a/base/task.jl
+++ b/base/task.jl
@@ -2,7 +2,7 @@
 
 ## basic task functions and TLS
 
-Core.Task(@nospecialize(f), reserved_stack::Int=0) = begin
+function Core.Task(@nospecialize(f), reserved_stack::Int=0)
     task = Core._task(f, reserved_stack)
     task.donenotify = ThreadSynchronizer()
     return task
@@ -366,7 +366,7 @@ in an error, thrown as a [`TaskFailedException`](@ref) which wraps the failed ta
 
 Throws a `ConcurrencyViolationError` if `t` is the currently running task, to prevent deadlocks.
 """
-function wait(t::Task; throw=true)
+@noinline function wait(t::Task; throw=true)
     _wait(t)
     if throw && istaskfailed(t)
         Core.throw(TaskFailedException(t))
@@ -565,9 +565,9 @@ Wait for a [`Task`](@ref) to finish, then return its result value.
 If the task fails with an exception, a [`TaskFailedException`](@ref) (which wraps the failed task)
 is thrown.
 """
-function fetch(t::Task)
+@inline function fetch(t::Task)
     wait(t)
-    return task_result(t)
+    return task_result(t)::Core.task_result_type(t)
 end
 
 
@@ -1146,7 +1146,7 @@ function yield(t::Task, @nospecialize(x=nothing))
     record_running_time!(ct)
     # [task] created -scheduled-> wait_time
     maybe_record_enqueued!(t)
-    t.result = x
+    setfield!(t, :result, x)
     enq_work(ct)
     set_next_task(t)
     return try_yieldto(ensure_rescheduled)
@@ -1173,7 +1173,7 @@ function yieldto(t::Task, @nospecialize(x=nothing))
     record_running_time!(ct)
     # [task] created -scheduled-unfairly-> wait_time
     maybe_record_enqueued!(t)
-    t.result = x
+    setfield!(t, :result, x)
     set_next_task(t)
     return try_yieldto(identity)
 end
@@ -1192,12 +1192,12 @@ function try_yieldto(undo)
     end
     if ct._isexception
         exc = ct.result
-        ct.result = nothing
+        setfield!(ct, :result, nothing)
         ct._isexception = false
         throw(exc)
     end
     result = ct.result
-    ct.result = nothing
+    setfield!(ct, :result, nothing)
     return result
 end
 
@@ -1208,7 +1208,7 @@ function throwto(t::Task, @nospecialize exc)
     record_running_time!(ct)
     # [task] created -scheduled-unfairly-> wait_time
     maybe_record_enqueued!(t)
-    t.result = exc
+    setfield!(t, :result, exc)
     t._isexception = true
     set_next_task(t)
     return try_yieldto(identity)

--- a/base/task.jl
+++ b/base/task.jl
@@ -176,6 +176,8 @@ const task_state_failed   = UInt8(2)
         error("""
             Querying a Task's `scope` field is disallowed.
             The private `Core.current_scope()` function is better, though still an implementation detail.""")
+    elseif field === :invoked
+        error("Querying a Task's `invoked` field is disallowed because it is an implementation detail.")
     else
         return getfield(t, field)
     end
@@ -184,6 +186,8 @@ end
 @inline function setproperty!(t::Task, field::Symbol, @nospecialize(v))
     if field === :scope
         istaskstarted(t) && error("Setting scope on a started task directly is disallowed.")
+    elseif field === :invoked
+        error("Setting a Task's `invoked` field directly is disallowed because it is an implementation detail.")
     end
     return @invoke setproperty!(t::Any, field::Symbol, v::Any)
 end

--- a/base/task.jl
+++ b/base/task.jl
@@ -572,6 +572,10 @@ is thrown.
 """
 @inline function fetch(t::Task)
     wait(t)
+    # This typeassert looks redundant, but is required for soundness and must not be
+    # removed: `Task.code`/`Task.result` are mutable, so the precise type inference
+    # may derive here (via `PartialTask`) is a claim that must be re-checked at
+    # runtime, not a proven fact.
     return task_result(t)::Core.task_result_type(t)
 end
 

--- a/doc/src/devdocs/builtins.md
+++ b/doc/src/devdocs/builtins.md
@@ -37,12 +37,136 @@ Core.memoryrefsetonce!
 Core.get_binding_type
 ```
 
+## Various helper functions
+```
+Base.quoted
+Base.isa_ast_node
+```
+
 ## Other
 
 ```@docs
 Core.IntrinsicFunction
 Core.Intrinsics
 Core.IR
-Base.quoted
-Base.isa_ast_node
+Core._task
+```
+
+## Adding New Builtin Functions
+
+This section documents the process for adding a new builtin function to Julia, (using `_task` as an example).
+
+### Overview
+
+Adding a new builtin function requires changes across multiple subsystems in Julia:
+1. C runtime implementation
+2. Julia inference integration
+3. Complex inference integration (if required)
+4. Optimization passes (if applicable)
+4. Codegen changes (if applicable)
+
+### Step-by-Step Process
+
+#### 1. Add to Builtin Function Registry
+
+**File: `src/builtin_proto.h`**
+```c
+// Add to JL_BUILTIN_FUNCTIONS macro (alphabetically)
+#define JL_BUILTIN_FUNCTIONS \
+    XX(apply_type,"apply_type") \
+    XX(_task,"_task") \          // <-- Add your function here
+    // ... other functions
+```
+
+**File: `src/builtins.c`**
+```c
+// Implement the C function
+BUILTIN(_task, 2, 3) {
+    JL_NARGS(_task, 2, 3);
+    JL_TYPECHK(_task, long, args[1]);
+    return jl_new_task_impl(args, nargs);
+}
+
+// Add to jl_init_primitives()
+void jl_init_primitives(void) {
+    // ... existing code
+    add_builtin_func("_task", jl_builtin__task);
+}
+```
+
+**Argument validation**: Always validate argument count and types in the C implementation.
+
+#### 2. Julia Inference Integration
+
+**File: `Compiler/src/tfuncs.jl`**
+```julia
+# Add simple tfunc if no special state is required
+add_tfunc(Core._task, 2, 3, (@nospecialize(f), @nospecialize(size), @nospecialize(optional...)) -> Task, 20)
+
+# OR for complex cases requiring AbstractInterpreter state:
+# Leave out add_tfunc and implement in abstractinterpretation.jl instead
+```
+
+#### 3. Complex Inference Integration (if `add_tfunc` was insufficient)
+
+**File: `Compiler/src/stmtinfo.jl`**
+```julia
+# For builtins that perform indirect calls, use IndirectCallInfo.
+# Set add_edges=true, unless the info is only for inlining and not used by inference
+#
+info_result = IndirectCallInfo(callinfo.info, callinfo.effects, true)
+```
+
+**File: `Compiler/src/abstractinterpretation.jl`**
+```julia
+# Add to builtin handling in abstract_call_builtin
+elseif f === Core._your_builtin
+    return Future(abstract_eval_your_builtin(interp, arginfo, si, sv))
+
+# Implement custom abstract evaluation if needed
+function abstract_eval_your_builtin(interp::AbstractInterpreter, arginfo::ArgInfo, si::StmtInfo, sv::AbsIntState)
+    # Validation and inference logic
+    return CallMeta(return_type, exception_type, effects, call_info)
+end
+```
+
+#### 4. Optimization Passes (if applicable)
+
+For example, if the operator has a special inlining:
+
+**File: `Compiler/src/ssair/inlining.jl`**
+```julia
+# Add to special builtin handling
+if (f !== Core.invoke &&
+    f !== Core.finalizer &&
+    # ... other functions
+    f !== Core._your_builtin)  # <-- Add here
+
+# Add optimization logic in `assemble_inline_todo!`
+elseif f === Core._your_builtin
+    handle_your_builtin_call!(ir, idx, stmt, info, state)
+end
+```
+
+#### 5. Documentation
+
+**File: `base/docs/basedocs.jl`**
+```julia
+"""
+    Core._your_builtin(arg1, arg2) -> ReturnType
+    Core._your_builtin(arg1, arg2, optional_arg) -> ReturnType
+
+This builtin is an implementation detail used by [higher-level function] and should
+not be called directly by end-users. Use `HigherLevelFunction(args...)` instead.
+
+Brief description of what the builtin does and its parameters.
+The optional third argument `optional_arg` can be a [description of types/purpose].
+"""
+Core._your_builtin
+```
+
+**File: `doc/src/devdocs/builtins.md`**
+```julia
+# Add to the @docs block in the appropriate section
+Core._your_builtin
 ```

--- a/doc/src/devdocs/builtins.md
+++ b/doc/src/devdocs/builtins.md
@@ -73,20 +73,22 @@ Adding a new builtin function requires changes across multiple subsystems in Jul
 **File: `src/builtin_proto.h`**
 ```c
 // Add to JL_BUILTIN_FUNCTIONS macro (alphabetically)
-#define JL_BUILTIN_FUNCTIONS \
-    XX(apply_type,"apply_type") \
-    XX(_task,"_task") \          // <-- Add your function here
+#define JL_BUILTIN_FUNCTIONS(XX) \
+    // ... other functions
+    XX(_using, "_using") \
+    XX(_your_builtin,"_your_builtin") \          // <-- Add your function here
+    XX(applicable,"applicable") \
     // ... other functions
 ```
 
 **File: `src/builtins.c`**
 ```c
 // Implement the C function
-JL_CALLABLE(jl_f__task)
+JL_CALLABLE(jl__your_builtin)
 {
-    JL_NARGS(_task, 2, 3);
-    JL_TYPECHK(_task, long, args[1]);
-    return jl_new_task_impl(args, nargs);
+    JL_NARGS(_your_builtin, 2, 3);
+    JL_TYPECHK(_your_builtin, long, args[1]);
+    return _your_builtin_impl(args, nargs);
 }
 ```
 
@@ -97,7 +99,7 @@ JL_CALLABLE(jl_f__task)
 **File: `Compiler/src/tfuncs.jl`**
 ```julia
 # Add simple tfunc if no special state is required
-add_tfunc(Core._task, 2, 3, (@nospecialize(f), @nospecialize(size), @nospecialize(optional...)) -> Task, 20)
+add_tfunc(Core._your_builtin, 2, 3, (@nospecialize(arg1), @nospecialize(arg2), @nospecialize(optional...)) -> Typ, 20)
 
 # OR for complex cases requiring AbstractInterpreter state:
 # Leave out add_tfunc and implement in abstractinterpretation.jl instead

--- a/doc/src/devdocs/builtins.md
+++ b/doc/src/devdocs/builtins.md
@@ -117,14 +117,16 @@ info_result = IndirectCallInfo(callinfo.info, callinfo.effects, true)
 
 **File: `Compiler/src/abstractinterpretation.jl`**
 ```julia
-# Add to builtin handling in abstract_call_builtin
+# Add to the builtin-specific handling in abstract_call_known
 elseif f === Core._your_builtin
-    return Future(abstract_eval_your_builtin(interp, arginfo, si, sv))
+    return abstract_eval_your_builtin(interp, arginfo, si, vtypes, sv)
 
 # Implement custom abstract evaluation if needed
-function abstract_eval_your_builtin(interp::AbstractInterpreter, arginfo::ArgInfo, si::StmtInfo, sv::AbsIntState)
+function abstract_eval_your_builtin(interp::AbstractInterpreter, arginfo::ArgInfo,
+                                    si::StmtInfo, vtypes::Union{VarTable,Nothing},
+                                    sv::AbsIntState)
     # Validation and inference logic
-    return CallMeta(return_type, exception_type, effects, call_info)
+    return Future(CallMeta(return_type, exception_type, effects, call_info))
 end
 ```
 

--- a/doc/src/devdocs/builtins.md
+++ b/doc/src/devdocs/builtins.md
@@ -38,7 +38,7 @@ Core.get_binding_type
 ```
 
 ## Various helper functions
-```
+```@docs
 Base.quoted
 Base.isa_ast_node
 ```
@@ -98,8 +98,12 @@ JL_CALLABLE(jl_f__your_builtin)
 
 **File: `Compiler/src/tfuncs.jl`**
 ```julia
-# Add simple tfunc if no special state is required
-add_tfunc(Core._your_builtin, 2, 3, (@nospecialize(arg1), @nospecialize(arg2), @nospecialize(optional...)) -> Typ, 20)
+# Add simple tfunc if no special state is required (the tfunc always takes the
+# inference lattice as its first argument, before the builtin's own arguments)
+@nospecs function your_builtin_tfunc(𝕃::AbstractLattice, arg1, arg2, optional...)
+    return Typ
+end
+add_tfunc(Core._your_builtin, 2, 3, your_builtin_tfunc, 20)
 
 # OR for complex cases requiring AbstractInterpreter state:
 # Leave out add_tfunc and implement in abstractinterpretation.jl instead

--- a/doc/src/devdocs/builtins.md
+++ b/doc/src/devdocs/builtins.md
@@ -55,7 +55,7 @@ Core.task_result_type
 
 ## Adding New Builtin Functions
 
-This section documents the process for adding a new builtin function to Julia, (using `_task` as an example).
+This section documents the process for adding a new builtin function to Julia (using `_task` as an example).
 
 ### Overview
 
@@ -109,6 +109,11 @@ add_tfunc(Core._your_builtin, 2, 3, your_builtin_tfunc, 20)
 # Leave out add_tfunc and implement in abstractinterpretation.jl instead
 ```
 
+Also model the builtin's effects: register it in `_EFFECTS_KNOWN_BUILTINS` and teach
+`builtin_effects` (and `_builtin_nothrow`, if the throwing conditions can be refined
+from the argument types) about it. Builtins that are absent from that list are
+pessimistically assumed to have fully unknown effects.
+
 #### 3. Complex Inference Integration (if `add_tfunc` was insufficient)
 
 **File: `Compiler/src/stmtinfo.jl`**
@@ -146,8 +151,9 @@ if (f !== Core.invoke &&
     # ... other functions
     f !== Core._your_builtin)  # <-- Add here
 
-# Add optimization logic in `assemble_inline_todo!`
-elseif f === Core._your_builtin
+# Add optimization logic in `assemble_inline_todo!`, dispatching on the `CallInfo`
+# recorded by inference
+elseif isa(info, YourBuiltinCallInfo)
     handle_your_builtin_call!(ir, idx, stmt, info, state)
 end
 ```

--- a/doc/src/devdocs/builtins.md
+++ b/doc/src/devdocs/builtins.md
@@ -84,7 +84,7 @@ Adding a new builtin function requires changes across multiple subsystems in Jul
 **File: `src/builtins.c`**
 ```c
 // Implement the C function
-JL_CALLABLE(jl__your_builtin)
+JL_CALLABLE(jl_f__your_builtin)
 {
     JL_NARGS(_your_builtin, 2, 3);
     JL_TYPECHK(_your_builtin, long, args[1]);

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -22,6 +22,7 @@ extern "C" {
     XX(_structtype,"_structtype") \
     XX(_svec_len,"_svec_len") \
     XX(_svec_ref,"_svec_ref") \
+    XX(_task,"_task") \
     XX(_typebody,"_typebody!") \
     XX(_typevar,"_typevar") \
     XX(_using, "_using") \

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -74,6 +74,7 @@ extern "C" {
     XX(svec,"svec") \
     XX(swapfield,"swapfield!") \
     XX(swapglobal,"swapglobal!") \
+    XX(task_result_type,"task_result_type") \
     XX(throw,"throw") \
     XX(throw_methoderror,"throw_methoderror") \
     XX(tuple,"tuple") \

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2383,6 +2383,20 @@ JL_CALLABLE(jl_f__svec_ref)
     return jl_svecref(s, idx-1);
 }
 
+JL_CALLABLE(jl_f__task)
+{
+    JL_NARGS(_task, 2, 3);
+    jl_value_t *start = args[0];
+    JL_TYPECHK(_task, long, args[1]);
+    size_t ssize = jl_unbox_long(args[1]);
+    jl_value_t *invoke_arg = NULL;
+    if (nargs >= 3)
+        invoke_arg = args[2];
+    jl_task_t *task = jl_new_task(start, jl_nothing, ssize);
+    task->invoked = invoke_arg;
+    return (jl_value_t*)task;
+}
+
 // If a field can reference its enclosing type, then the inlining
 // recursive depth is not statically bounded for some layouts, so we cannot
 // inline it. The only way fields can reference this type (due to

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2397,6 +2397,14 @@ JL_CALLABLE(jl_f__task)
     return (jl_value_t*)task;
 }
 
+JL_CALLABLE(jl_f_task_result_type)
+{
+    JL_NARGS(task_result_type, 1, 1);
+    JL_TYPECHK(task_result_type, task, args[0]);
+    // Without inference, this returns Any, but inference can inject other Types here
+    return (jl_value_t*)jl_any_type;
+}
+
 // If a field can reference its enclosing type, then the inlining
 // recursive depth is not statically bounded for some layouts, so we cannot
 // inline it. The only way fields can reference this type (due to

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2390,8 +2390,12 @@ JL_CALLABLE(jl_f__task)
     JL_TYPECHK(_task, long, args[1]);
     size_t ssize = jl_unbox_long(args[1]);
     jl_value_t *invoke_arg = NULL;
-    if (nargs >= 3)
+    if (nargs >= 3) {
         invoke_arg = args[2];
+        if (!jl_is_method(invoke_arg) && !jl_is_code_instance(invoke_arg) &&
+            !jl_is_tuple_type(jl_unwrap_unionall(invoke_arg)))
+            jl_type_error("_task", (jl_value_t*)jl_anytuple_type_type, invoke_arg);
+    }
     jl_task_t *task = jl_new_task(start, jl_nothing, ssize);
     task->invoked = invoke_arg;
     return (jl_value_t*)task;

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -105,6 +105,7 @@
     XX(opaque_closure_typename, jl_typename_t*) \
     XX(pair_type, jl_value_t*) \
     XX(partial_opaque_type, jl_datatype_t*) \
+    XX(partial_task_type, jl_datatype_t*) \
     XX(partial_struct_type, jl_datatype_t*) \
     XX(phicnode_type, jl_datatype_t*) \
     XX(phinode_type, jl_datatype_t*) \

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -105,8 +105,8 @@
     XX(opaque_closure_typename, jl_typename_t*) \
     XX(pair_type, jl_value_t*) \
     XX(partial_opaque_type, jl_datatype_t*) \
-    XX(partial_task_type, jl_datatype_t*) \
     XX(partial_struct_type, jl_datatype_t*) \
+    XX(partial_task_type, jl_datatype_t*) \
     XX(phicnode_type, jl_datatype_t*) \
     XX(phinode_type, jl_datatype_t*) \
     XX(pinode_type, jl_datatype_t*) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3472,11 +3472,11 @@ void export_jl_sysimg_globals(void)
     jl_##name##_type->smalltag = jl_##name##_tag;
 void jl_init_types(void) JL_GC_DISABLED
 {
-   // n.b. When adding fields to existing types, update const/atomic field bitvectors carefully:
-   //   Bits represent field positions (0-indexed).
-   //   Prefer `0b` notation (converting if needed from `0x`).
-   //   Only set bits for new atomic/const fields, shift existing bits as needed.
-   //   Only 32 bits in one field, overflow goes into the next field.
+    // n.b. When adding fields to existing types, update const/atomic field bitvectors carefully:
+    //   Bits represent field positions (0-indexed).
+    //   Prefer `0b` notation (converting if needed from `0x`).
+    //   Only set bits for new atomic/const fields, shift existing bits as needed.
+    //   Only 32 bits in one field, overflow goes into the next field.
 
     jl_module_t *core = NULL; // will need to be assigned later
     jl_task_t *ct = jl_current_task;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3472,6 +3472,12 @@ void export_jl_sysimg_globals(void)
     jl_##name##_type->smalltag = jl_##name##_tag;
 void jl_init_types(void) JL_GC_DISABLED
 {
+   // n.b. When adding fields to existing types, update const/atomic field bitvectors carefully:
+   //   Bits represent field positions (0-indexed).
+   //   Prefer `0b` notation (converting if needed from `0x`).
+   //   Only set bits for new atomic/const fields, shift existing bits as needed.
+   //   Only 32 bits in one field, overflow goes into the next field.
+
     jl_module_t *core = NULL; // will need to be assigned later
     jl_task_t *ct = jl_current_task;
 
@@ -4335,7 +4341,7 @@ void jl_init_types(void) JL_GC_DISABLED
                         NULL,
                         jl_any_type,
                         jl_emptysvec,
-                        jl_perm_symsvec(29,
+                        jl_perm_symsvec(30,
                                         "next",
                                         "queue",
                                         "storage",
@@ -4364,8 +4370,9 @@ void jl_init_types(void) JL_GC_DISABLED
                                         "running_time_ns",
                                         "finished_at",
                                         "waiting_on",
-                                        "cached_wait_entry"),
-                        jl_svec(29,
+                                        "cached_wait_entry",
+                                        "invoked"),
+                        jl_svec(30,
                                 jl_any_type,
                                 jl_any_type,
                                 jl_any_type,
@@ -4393,6 +4400,7 @@ void jl_init_types(void) JL_GC_DISABLED
                                 jl_uint64_type,
                                 jl_uint64_type,
                                 jl_uint64_type,
+                                jl_any_type,
                                 jl_any_type,
                                 jl_any_type),
                         jl_emptysvec,
@@ -4558,6 +4566,7 @@ void post_boot_hooks(void)
     jl_partial_struct_type = (jl_datatype_t*)core("PartialStruct");
     jl_interconditional_type = (jl_datatype_t*)core("InterConditional");
     jl_partial_opaque_type = (jl_datatype_t*)core("PartialOpaque");
+    jl_partial_task_type = (jl_datatype_t*)core("PartialTask");
     jl_inter_must_alias_type = (jl_datatype_t*)core("InterMustAlias");
 
     export_jl_small_typeof();

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -946,6 +946,7 @@ JL_DLLEXPORT void jl_typeassert(jl_value_t *x, jl_value_t *t) JL_CANSAFEPOINT;
     JL_DLLEXPORT jl_value_t *name(jl_value_t *F, jl_value_t **args, uint32_t nargs)
 
 JL_CALLABLE(jl_f_tuple) JL_CANSAFEPOINT;
+JL_CALLABLE(jl_f_invoke) JL_CANSAFEPOINT;
 void jl_install_default_signal_handlers(void) JL_NOTSAFEPOINT;
 void restore_signals(void) JL_NOTSAFEPOINT;
 void jl_install_thread_signal_handler(jl_ptls_t ptls) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -946,7 +946,6 @@ JL_DLLEXPORT void jl_typeassert(jl_value_t *x, jl_value_t *t) JL_CANSAFEPOINT;
     JL_DLLEXPORT jl_value_t *name(jl_value_t *F, jl_value_t **args, uint32_t nargs)
 
 JL_CALLABLE(jl_f_tuple) JL_CANSAFEPOINT;
-JL_CALLABLE(jl_f_invoke) JL_CANSAFEPOINT;
 void jl_install_default_signal_handlers(void) JL_NOTSAFEPOINT;
 void restore_signals(void) JL_NOTSAFEPOINT;
 void jl_install_thread_signal_handler(jl_ptls_t ptls) JL_NOTSAFEPOINT;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -351,6 +351,7 @@ typedef struct _jl_task_t {
     // A `Base.WaitEntry` cached for reuse across parks (or `nothing`), so the
     // common single-registration park does not allocate. Owned by this task.
     jl_value_t *cached_wait_entry;
+    jl_value_t *invoked; // Method/CodeInstance/tuple Type for optimized task invocation
 
 // hidden state:
 

--- a/src/task.c
+++ b/src/task.c
@@ -1259,6 +1259,7 @@ CFI_NORETURN
 skip_pop_exception:;
     }
     jl_gc_write(ct, ct->result, jl_value_t, res);
+    ct->invoked = NULL;
     jl_finish_task(ct);
     jl_gc_debug_fprint_critical_error(ios_safe_stderr);
     abort();

--- a/src/task.c
+++ b/src/task.c
@@ -1245,6 +1245,13 @@ CFI_NORETURN
             JL_TIMING(ROOT, ROOT);
             // Check if we can use optimized invocation
             if (ct->invoked != NULL) {
+                // The `code`/`invoked` fields are mutable from Julia (`setfield!`), so the
+                // pair read here need not be the pair that was validated when the task was
+                // constructed (`jl_f__task`) or injected by inlining. Soundness relies on
+                // `jl_f_invoke` re-checking the argument against the target's signature and
+                // world bounds at this point: calling a CodeInstance's specptr directly
+                // without those checks would turn a field mutation into an ABI mismatch
+                // (undefined behavior), not a Julia-level error.
                 jl_value_t *invoke_args[2] = {ct->start, ct->invoked};
                 res = jl_f_invoke(NULL, invoke_args, 2);
             }

--- a/src/task.c
+++ b/src/task.c
@@ -1097,6 +1097,7 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_value_t *start, jl_value_t *completion_fu
     t->tls = jl_nothing;
     jl_atomic_store_relaxed(&t->_state, JL_TASK_STATE_RUNNABLE);
     t->start = start;
+    t->invoked = NULL;
     t->result = jl_nothing;
     t->donenotify = completion_future;
     jl_atomic_store_relaxed(&t->_isexception, 0);
@@ -1241,7 +1242,14 @@ CFI_NORETURN
                 jl_sigint_safepoint(ptls);
             }
             JL_TIMING(ROOT, ROOT);
-            res = jl_apply(&ct->start, 1);
+            // Check if we can use optimized invocation
+            if (ct->invoked != NULL) {
+                jl_value_t *invoke_args[2] = {ct->start, ct->invoked};
+                res = jl_f_invoke(NULL, invoke_args, 2);
+            }
+            else {
+                res = jl_apply(&ct->start, 1);
+            }
         }
         JL_CATCH {
             res = jl_current_exception(ct);
@@ -1550,6 +1558,7 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     ct->tls = jl_nothing;
     jl_atomic_store_relaxed(&ct->_state, JL_TASK_STATE_RUNNABLE);
     ct->start = NULL;
+    ct->invoked = NULL;
     ct->result = jl_nothing;
     ct->donenotify = jl_nothing;
     jl_atomic_store_relaxed(&ct->_isexception, 0);

--- a/src/task.c
+++ b/src/task.c
@@ -25,6 +25,7 @@
 #include <inttypes.h>
 #include "julia.h"
 #include "julia_internal.h"
+#include "builtin_proto.h"
 #include "threading.h"
 #include "julia_assert.h"
 

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1739,7 +1739,8 @@ function deserialize(s::AbstractSerializer, ::Type{UnionAll})
 end
 
 function deserialize(s::AbstractSerializer, ::Type{Task})
-    t = Task(()->nothing)
+    # The task code is replaced below, so prevent attaching invoke metadata for the dummy closure.
+    t = Task(Base.inferencebarrier(()->nothing))
     deserialize_cycle(s, t)
     t.code = deserialize(s)
     t.storage = deserialize(s)

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1757,7 +1757,7 @@ function deserialize(s::AbstractSerializer, ::Type{Task})
     else
         @assert false
     end
-    t.result = deserialize(s)
+    setfield!(t, :result, deserialize(s))
     exc = deserialize(s)
     if exc === nothing
         t._isexception = false
@@ -1765,7 +1765,7 @@ function deserialize(s::AbstractSerializer, ::Type{Task})
         t._isexception = exc
     else
         t._isexception = true
-        t.result = exc
+        setfield!(t, :result, exc)
     end
     if format_version(s) >= 31 && (deserialize(s)::Bool)
         setfield!(t, :invoked, deserialize(s))

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -632,6 +632,10 @@ function serialize(s::AbstractSerializer, t::Task)
     if istaskstarted(t) && !istaskdone(t)
         error("cannot serialize a running Task")
     end
+    if isdefined(t, :invoked)
+        error("cannot serialize a Task constructed with invoke info")
+        # we could serialize it though, as long as the info isn't for a CodeInstance
+    end
     writetag(s.io, TASK_TAG)
     serialize(s, t.code)
     serialize(s, t.storage)

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -89,7 +89,7 @@ const TAGS = Any[
 const NTAGS = length(TAGS)
 @assert NTAGS == 255
 
-const ser_version = 30 # do not make changes without bumping the version #!
+const ser_version = 31 # do not make changes without bumping the version #!
 
 format_version(::AbstractSerializer) = ser_version
 format_version(s::Serializer) = s.version
@@ -632,10 +632,9 @@ function serialize(s::AbstractSerializer, t::Task)
     if istaskstarted(t) && !istaskdone(t)
         error("cannot serialize a running Task")
     end
-    if isdefined(t, :invoked)
-        error("cannot serialize a Task constructed with invoke info")
-        # we could serialize it though, as long as the info isn't for a CodeInstance
-    end
+    # Compiler-injected CodeInstances are process-local optimization metadata and are
+    # intentionally omitted. Other targets carry explicit Core.invoke semantics.
+    has_invoked = isdefined(t, :invoked) && !(getfield(t, :invoked) isa Core.CodeInstance)
     writetag(s.io, TASK_TAG)
     serialize(s, t.code)
     serialize(s, t.storage)
@@ -649,6 +648,10 @@ function serialize(s::AbstractSerializer, t::Task)
         serialize(s, t.result)
     end
     serialize(s, t._isexception)
+    serialize(s, has_invoked)
+    if has_invoked
+        serialize(s, getfield(t, :invoked))
+    end
 end
 
 function serialize(s::AbstractSerializer, g::GlobalRef)
@@ -1763,6 +1766,9 @@ function deserialize(s::AbstractSerializer, ::Type{Task})
     else
         t._isexception = true
         t.result = exc
+    end
+    if format_version(s) >= 31 && (deserialize(s)::Bool)
+        setfield!(t, :invoked, deserialize(s))
     end
     t
 end

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -366,6 +366,35 @@ end
 Core.eval(Main, main_ex)
 
 # Task
+# Runnable tasks drop CodeInstance hints but preserve explicit invoke targets.
+serialization_task_result() = 42
+create_serialization_stream() do s
+    t = Task(serialization_task_result)
+    serialize(s, t)
+    seek(s, 0)
+    r = deserialize(s)
+    @test fetch(schedule(r)) === 42
+    @test fetch(schedule(t)) === 42
+end
+
+serialization_task_invoke() = 43
+serialization_task_invoke(x...) = x
+function serialization_task_with_invoke(@nospecialize(f), @nospecialize(invoked))
+    t = Core._task(f, 0, invoked)
+    t.donenotify = Base.ThreadSynchronizer()
+    return t
+end
+for invoked in (Tuple{Vararg}, which(serialization_task_invoke, (Vararg,)))
+    create_serialization_stream() do s
+        t = serialization_task_with_invoke(serialization_task_invoke, invoked)
+        serialize(s, t)
+        seek(s, 0)
+        r = deserialize(s)
+        @test fetch(schedule(r)) === ()
+        @test fetch(schedule(t)) === ()
+    end
+end
+
 create_serialization_stream() do s # user-defined type array
     f = () -> begin task_local_storage(:v, 2); return 1+1 end
     t = Task(f)

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -698,6 +698,10 @@ end
     t = Task(f)
     message = "Querying a Task's `scope` field is disallowed.\nThe private `Core.current_scope()` function is better, though still an implementation detail."
     @test_throws ErrorException(message) t.scope
+    message = "Querying a Task's `invoked` field is disallowed because it is an implementation detail."
+    @test_throws ErrorException(message) t.invoked
+    message = "Setting a Task's `invoked` field directly is disallowed because it is an implementation detail."
+    @test_throws ErrorException(message) (t.invoked = nothing)
     @test t.state == :runnable
 end
 

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -728,10 +728,13 @@ end
     @test fetch(schedule(t1)) === ()
 
     # Test that _task validates argument types
-    t1 = _task(f1, 0, "invalid")
-    schedule(t1)
-    @test_throws TaskFailedException fetch(t1)
     @test_throws TypeError Core._task(f1, "invalid_size")
     @test_throws TypeError Core._task(f1, "invalid_size", m)
     @test_throws ArgumentError Core._task(f1, 0, m, 1)
+    @test_throws TypeError Core._task(f1, 0, "invalid")
+    @test_throws TypeError Core._task(f1, 0, Int)
+    @test_throws TypeError Core._task(f1, 0, nothing)
+    mi = only(Base.specializations(which(f1, ())))
+    @test mi isa Core.MethodInstance
+    @test_throws TypeError Core._task(f1, 0, mi)
 end

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -702,6 +702,8 @@ end
     @test_throws ErrorException(message) t.invoked
     message = "Setting a Task's `invoked` field directly is disallowed because it is an implementation detail."
     @test_throws ErrorException(message) (t.invoked = nothing)
+    message = "Setting a Task's `result` field directly is disallowed. The result of a task is determined by the return value of its code; to pass a value to a suspended task, use `schedule(t, val)` or `yieldto(t, val)` instead."
+    @test_throws ErrorException(message) (t.result = 42)
     @test t.state == :runnable
 end
 


### PR DESCRIPTION
`fetch(::Task)` used to always be inferred as `Any`, defeating type-stable use of task results and trimming/static analysis of task-based code. This PR teaches the compiler to track the code a `Task` is constructed to run and to type `fetch` accordingly, and gives the runtime an optimized invoke path for starting tasks.

Runtime changes:
- New builtin `Core._task(f, reserved_stack[, invoke_target])` constructs a `Task`; `Task(f)` now goes through it. The optional invoke target — a `Method`, `CodeInstance`, or tuple `Type`, validated eagerly at construction — is stored in a new private `Task.invoked` field, and `start_task` runs the task body through `jl_f_invoke` instead of dynamic dispatch when it is present. The field is hidden from property access (like `scope`) and cleared once the task's result is recorded.
- New builtin `Core.task_result_type(t::Task)`, which returns `Any` at runtime but may be refined by inference (below).

Compiler changes:
- New `Core.PartialTask` lattice element: when inference can determine the code a task will run, `Core._task` returns `PartialTask` carrying the inferred result type of the deferred call, with edges registered so that method redefinition invalidates it.
- `Core.task_result_type` folds to that precise type, and `fetch(::Task)` is now defined as `task_result(t)::Core.task_result_type(t)`, so e.g. `fetch(Threads.@spawn f(x))` infers precisely instead of `Any`.
- Inlining injects a compiled `CodeInstance` as the invoke target of `Core._task` calls when a unique, fully-covering method match exists, devirtualizing the task's startup dispatch.
- `FinalizerInfo`/`ModifyOpInfo` are unified into `IndirectCallInfo`, which also serves the new task call tracking.

Soundness under mutation: `Task.code`/`Task.result` remain mutable fields, so precise information is always re-checked at runtime rather than trusted. The `fetch` typeassert cannot be statically discharged (this is why `getfield_tfunc` on `PartialTask` deliberately widens to `Task`), and `jl_f_invoke` revalidates the invoke target against the current field values and world at task start, so field mutations degrade to runtime errors, never to type confusion.

Behavior changes:
- Assigning `t.result = v` via property syntax now throws an error: the runtime and the compiler rely on a task's result being the return value of its code. `schedule(t, val)` and `yieldto(t, val)` remain the supported ways to pass a value to a suspended task (see NEWS).
- `Serialization`: explicit `Method` and tuple-`Type` invoke targets survive round-trips (format version 31), while compiler-injected `CodeInstance` targets are omitted, making deserialized tasks fall back to ordinary dispatch of the same call.

Also documents how to add new builtin functions in the devdocs, using these builtins as a worked example.

Co-authored-by: Jameson Nash <vtjnash@gmail.com>
Co-authored-by: Shuhei Kadowaki <aviatesk@gmail.com>
Co-authored-by: Claude Fable 5 <noreply@anthropic.com>
Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
Co-authored-by: GPT-5.6 Sol <noreply@openai.com>