### PR TITLE
Drop sysimage caches for --code-coverage=all

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@ Command-line option changes
 
 * The option `--sysimage-native-code=no` has been deprecated.
 * The `JULIA_CPU_TARGET` environment variable now supports a `sysimage` keyword to match (or extend) the CPU target used to build the current system image ([#58970]).
+* The `--code-coverage=all` option now automatically throws away sysimage caches so that code coverage can be accurately measured on methods within the sysimage. It is thrown away after startup (and after startup.jl), before any user code is executed ([#59234])
 
 Multi-threading changes
 -----------------------

--- a/base/client.jl
+++ b/base/client.jl
@@ -280,6 +280,12 @@ function exec_options(opts)
         end
     end
 
+    # drop all caches if code coverage is enabled. Do it here not earlier, so julia has a chance
+    # of starting up quickly
+    if Base.JLOptions().code_coverage == 2
+        Base.drop_all_caches()
+    end
+
     # process cmds list
     for (cmd, arg) in cmds
         if cmd == 'e'

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1453,3 +1453,20 @@ function destructure_callex(topmod::Module, @nospecialize(ex))
     end
     return f, args, kwargs
 end
+
+"""
+    Base.drop_all_caches()
+
+Internal function to drop all native code caches and increment world age.
+This invalidates all compiled code as if a method was added that intersects
+with all existing methods.
+"""
+function drop_all_caches()
+    ccall(:jl_drop_all_caches, Cvoid, ())
+
+    # Reset loading.jl world age so that loading code is regenerated
+    _require_world_age[] = typemax(UInt)
+
+    # Call Base.Compiler.activate!() after dropping caching to activate coverage of the Compiler code itself
+    Base.Compiler.activate!()
+end

--- a/src/julia.h
+++ b/src/julia.h
@@ -1980,6 +1980,7 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo, siz
 JL_DLLEXPORT jl_code_info_t *jl_copy_code_info(jl_code_info_t *src);
 JL_DLLEXPORT size_t jl_get_world_counter(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_get_tls_world_age(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_drop_all_caches(void);
 JL_DLLEXPORT jl_value_t *jl_box_bool(int8_t x) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_box_int8(int8_t x) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_box_uint8(uint8_t x) JL_NOTSAFEPOINT;

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -1395,7 +1395,9 @@ function complete_path_string(path, hint::Bool=false;
 end
 
 function __init__()
-    COMPLETION_WORLD[] = Base.get_world_counter()
+    if !Base.Compiler.should_insert_coverage(@__MODULE__, debuginfo)
+        COMPLETION_WORLD[] = Base.get_world_counter()
+    end
     return nothing
 end
 

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -1395,9 +1395,7 @@ function complete_path_string(path, hint::Bool=false;
 end
 
 function __init__()
-    if !Base.Compiler.should_insert_coverage(@__MODULE__, debuginfo)
-        COMPLETION_WORLD[] = Base.get_world_counter()
-    end
+    COMPLETION_WORLD[] = Base.get_world_counter()
     return nothing
 end
 


### PR DESCRIPTION
Introduces `Base.drop_all_caches()`  which invalidates all compiled method caches and increments the world age, forcing recompilation of all methods on next invocation.

And calls the new function in `client.jl` after startup.jl is run and just before user code is run, if `--code-coverage=all` is set.

Developed with Claude.

re. https://github.com/JuliaLang/julia/issues/57668#issuecomment-3156748844