### PR TITLE
compiler: consolidate staticdata.jl and invalidations.jl into Compiler proper [NFCI]

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -48,8 +48,8 @@ using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospeciali
     PARTITION_KIND_GLOBAL, PARTITION_KIND_UNDEF_CONST, PARTITION_KIND_BACKDATED_CONST, PARTITION_KIND_DECLARED,
     PARTITION_FLAG_DEPWARN,
     Base, BitVector, Bottom, Callable, DataTypeFieldDesc,
-    EffectsOverride, Filter, Generator, IteratorSize, JLOptions, NUM_EFFECTS_OVERRIDES,
-    OneTo, Ordering, RefValue, SizeUnknown, _NAMEDTUPLE_NAME,
+    EffectsOverride, Filter, Generator, NUM_EFFECTS_OVERRIDES,
+    OneTo, Ordering, RefValue, _NAMEDTUPLE_NAME,
     _array_for, _bits_findnext, _methods_by_ftype, _uniontypes, all, allocatedinline, any,
     argument_datatype, binding_kind, cconvert, copy_exprargs, datatype_arrayelem,
     datatype_fieldcount, datatype_fieldtypes, datatype_layoutsize, datatype_nfields,
@@ -64,9 +64,11 @@ using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospeciali
     partition_restriction, quoted, rename_unionall, rewrap_unionall, specialize_method,
     structdiff, tls_world_age, unconstrain_vararg_length, unionlen, uniontype_layout,
     uniontypes, unsafe_convert, unwrap_unionall, unwrapva, vect, widen_diagonal,
-    _uncompressed_ir, maybe_add_binding_backedge!, datatype_min_ninitialized,
+    _uncompressed_ir, datatype_min_ninitialized,
     partialstruct_init_undefs, fieldcount_noerror, _eval_import, _eval_using,
-    get_ci_mi
+    get_ci_mi, get_methodtable, morespecific, specializations, has_image_globalref,
+    PARTITION_MASK_KIND, PARTITION_KIND_GUARD, PARTITION_FLAG_EXPORTED, PARTITION_FLAG_DEPRECATED,
+    BINDING_FLAG_ANY_IMPLICIT_EDGES, is_some_implicit, IteratorSize, SizeUnknown, get_require_world, JLOptions
 
 using Base.Order
 
@@ -187,6 +189,10 @@ include("optimize.jl")
 include("bootstrap.jl")
 include("reflection_interface.jl")
 include("opaque_closure.jl")
+
+baremodule ReinferUtils end
+include(ReinferUtils, "reinfer.jl")
+include(ReinferUtils, "bindinginvalidations.jl")
 
 macro __SOURCE_FILE__()
     __source__.file === nothing && return nothing

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -741,6 +741,13 @@ function Base.iterate(it::ForwardToBackedgeIterator, i::Int = 1)
 end
 
 # record the backedges
+
+function maybe_add_binding_backedge!(b::Core.Binding, edge::Union{Method, CodeInstance})
+    meth = isa(edge, Method) ? edge : get_ci_mi(edge).def
+    ccall(:jl_maybe_add_binding_backedge, Cint, (Any, Any, Any), b, edge, meth)
+    return nothing
+end
+
 function store_backedges(caller::CodeInstance, edges::SimpleVector)
     isa(get_ci_mi(caller).def, Method) || return # don't add backedges to toplevel method instance
 

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -267,9 +267,6 @@ include("uuid.jl")
 include("pkgid.jl")
 include("toml_parser.jl")
 include("linking.jl")
-module StaticData
-include("staticdata.jl")
-end
 include("loading.jl")
 
 # BinaryPlatforms, used by Artifacts.  Needs `Sort`.

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -348,7 +348,6 @@ using .Order
 
 include("coreir.jl")
 include("module.jl")
-include("invalidation.jl")
 
 BUILDROOT::String = ""
 DATAROOT::String = ""
@@ -377,6 +376,7 @@ process_sysimg_args!()
 function isready end
 
 include(strcat(DATAROOT, "julia/Compiler/src/Compiler.jl"))
+using .Compiler.ReinferUtils: ReinferUtils, invalidate_code_for_globalref!
 
 const _return_type = Compiler.return_type
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1288,7 +1288,7 @@ function _include_from_serialized(pkg::PkgId, path::String, ocachepath::Union{No
         extext_methods = sv[5]::Vector{Any}
         internal_methods = sv[6]::Vector{Any}
         Compiler.@zone "CC: INSERT_BACKEDGES" begin
-            StaticData.insert_backedges(edges, ext_edges, extext_methods, internal_methods)
+            ReinferUtils.insert_backedges_typeinf(edges, ext_edges, extext_methods, internal_methods)
         end
         restored = register_restored_modules(sv, pkg, path)
 

--- a/sysimage.mk
+++ b/sysimage.mk
@@ -57,7 +57,6 @@ COMPILER_SRCS := $(addprefix $(JULIAHOME)/, \
 		base/int.jl \
 		base/indices.jl \
 		base/iterators.jl \
-		base/invalidation.jl \
 		base/module.jl \
 		base/namedtuple.jl \
 		base/ntuple.jl \

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1055,9 +1055,9 @@ precompile_test_harness("code caching") do dir
         const glbi = LogBindingInvalidation(2.0)
     end)
     @eval using $StaleC
-    invalidations = Base.StaticData.debug_method_invalidation(true)
+    invalidations = Base.ReinferUtils.debug_method_invalidation(true)
     @eval using $StaleB
-    Base.StaticData.debug_method_invalidation(false)
+    Base.ReinferUtils.debug_method_invalidation(false)
     invokelatest() do
         MB = getfield(@__MODULE__, StaleB)
         MC = getfield(@__MODULE__, StaleC)


### PR DESCRIPTION
This aims to consolidate more of the code that is expected to run in typeinf_world into Compiler proper. The intent is that these are likely to gain more interaction (both directions) with inference, as the compiler should use this mini-compiler and vice versa.

We actually might want a `Base.CompilerUtils` module so that the `Compiler` package itself is smaller and less reliant on internal APIs, but for now just move these into a submodule of Compiler.

Written by Claude