### PR TITLE
Rewrite most gensym macros to use automatic hygiene instead

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -30,6 +30,9 @@ let os = ccall(:jl_get_UNAME, Any, ())
     end
 end
 
+# metaprogramming
+include("meta.jl")
+
 # subarrays
 include("subarray.jl")
 include("views.jl")
@@ -156,9 +159,6 @@ include("weakkeydict.jl")
 
 # ScopedValues
 include("scopedvalues.jl")
-
-# metaprogramming
-include("meta.jl")
 
 # Logging
 include("logging/logging.jl")

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -746,7 +746,7 @@ end
 
 # module providing the IR object model
 # excluding types already exported by Core (GlobalRef, QuoteNode, Expr, LineNumberNode)
-# any type beyond these is self-quoting (see also Base.is_ast_node)
+# any type beyond these is self-quoting (see also Base.isa_ast_node)
 module IR
 
 export CodeInfo, MethodInstance, CodeInstance, GotoNode, GotoIfNot, ReturnNode,

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -41,7 +41,7 @@ within this scope, even if the compiler can't prove this to be the case.
     Experimental API. Subject to change without deprecation.
 """
 macro aliasscope(body)
-    sym = gensym()
+    sym = :aliasscope_result
     quote
         $(Expr(:aliasscope))
         $sym = $(esc(body))

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -18,8 +18,120 @@ export quot,
 
 public parse
 
-using Base: isidentifier, isoperator, isunaryoperator, isbinaryoperator, ispostfixoperator
 import Base: isexpr
+
+## AST decoding helpers ##
+
+is_id_start_char(c::AbstractChar) = ccall(:jl_id_start_char, Cint, (UInt32,), c) != 0
+is_id_char(c::AbstractChar) = ccall(:jl_id_char, Cint, (UInt32,), c) != 0
+
+"""
+     isidentifier(s) -> Bool
+
+Return whether the symbol or string `s` contains characters that are parsed as
+a valid ordinary identifier (not a binary/unary operator) in Julia code;
+see also [`Base.isoperator`](@ref).
+
+Internally Julia allows any sequence of characters in a `Symbol` (except `\\0`s),
+and macros automatically use variable names containing `#` in order to avoid
+naming collision with the surrounding code. In order for the parser to
+recognize a variable, it uses a limited set of characters (greatly extended by
+Unicode). `isidentifier()` makes it possible to query the parser directly
+whether a symbol contains valid characters.
+
+# Examples
+```jldoctest
+julia> Meta.isidentifier(:x), Meta.isidentifier("1x")
+(true, false)
+```
+"""
+function isidentifier(s::AbstractString)
+    x = Iterators.peel(s)
+    isnothing(x) && return false
+    (s == "true" || s == "false") && return false
+    c, rest = x
+    is_id_start_char(c) || return false
+    return all(is_id_char, rest)
+end
+isidentifier(s::Symbol) = isidentifier(string(s))
+
+is_op_suffix_char(c::AbstractChar) = ccall(:jl_op_suffix_char, Cint, (UInt32,), c) != 0
+
+_isoperator(s) = ccall(:jl_is_operator, Cint, (Cstring,), s) != 0
+
+"""
+    isoperator(s::Symbol)
+
+Return `true` if the symbol can be used as an operator, `false` otherwise.
+
+# Examples
+```jldoctest
+julia> Meta.isoperator(:+), Meta.isoperator(:f)
+(true, false)
+```
+"""
+isoperator(s::Union{Symbol,AbstractString}) = _isoperator(s) || ispostfixoperator(s)
+
+"""
+    isunaryoperator(s::Symbol)
+
+Return `true` if the symbol can be used as a unary (prefix) operator, `false` otherwise.
+
+# Examples
+```jldoctest
+julia> Meta.isunaryoperator(:-), Meta.isunaryoperator(:√), Meta.isunaryoperator(:f)
+(true, true, false)
+```
+"""
+isunaryoperator(s::Symbol) = ccall(:jl_is_unary_operator, Cint, (Cstring,), s) != 0
+is_unary_and_binary_operator(s::Symbol) = ccall(:jl_is_unary_and_binary_operator, Cint, (Cstring,), s) != 0
+is_syntactic_operator(s::Symbol) = ccall(:jl_is_syntactic_operator, Cint, (Cstring,), s) != 0
+
+"""
+    isbinaryoperator(s::Symbol)
+
+Return `true` if the symbol can be used as a binary (infix) operator, `false` otherwise.
+
+# Examples
+```jldoctest
+julia> Meta.isbinaryoperator(:-), Meta.isbinaryoperator(:√), Meta.isbinaryoperator(:f)
+(true, false, false)
+```
+"""
+function isbinaryoperator(s::Symbol)
+    return _isoperator(s) && (!isunaryoperator(s) || is_unary_and_binary_operator(s)) &&
+        s !== Symbol("'")
+end
+
+"""
+    ispostfixoperator(s::Union{Symbol,AbstractString})
+
+Return `true` if the symbol can be used as a postfix operator, `false` otherwise.
+
+# Examples
+```jldoctest
+julia> Meta.ispostfixoperator(Symbol("'")), Meta.ispostfixoperator(Symbol("'ᵀ")), Meta.ispostfixoperator(:-)
+(true, true, false)
+```
+"""
+function ispostfixoperator(s::Union{Symbol,AbstractString})
+    s = String(s)::String
+    return startswith(s, '\'') && all(is_op_suffix_char, SubString(s, 2))
+end
+
+const keyword_syms = IdSet{Symbol}([
+    :baremodule, :begin, :break, :catch, :const, :continue, :do, :else, :elseif,
+    :end, :export, :var"false", :finally, :for, :function, :global, :if, :import,
+    :let, :local, :macro, :module, :public, :quote, :return, :struct, :var"true",
+    :try, :using, :while ])
+
+function is_valid_identifier(sym)
+    return (isidentifier(sym) && !(sym in keyword_syms)) ||
+        (_isoperator(sym) &&
+        !(sym in (Symbol("'"), :(::), :?)) &&
+        !is_syntactic_operator(sym)
+    )
+end
 
 """
     Meta.quot(ex)::Expr

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -629,6 +629,21 @@ function unescape(@nospecialize ex)
 end
 
 """
+    Meta.reescape(unescaped_expr, original_expr)
+
+Re-wrap `unescaped_expr` with the same level of escaping as `original_expr` had.
+This is the inverse operation of [`unescape`](@ref) - if the original expression
+was escaped, the unescaped expression is wrapped in `:escape` again.
+"""
+function reescape(@nospecialize(unescaped_expr), @nospecialize(original_expr))
+    if isexpr(original_expr, :escape) || isexpr(original_expr, :var"hygienic-scope")
+        return reescape(Expr(:escape, unescaped_expr), original_expr.args[1])
+    else
+        return unescaped_expr
+    end
+end
+
+"""
     Meta.uncurly(expr)
 
 Turn `T{P...}` into just `T`.

--- a/base/show.jl
+++ b/base/show.jl
@@ -1,8 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using .Compiler: has_typevar
-using .Meta: isidentifier, isoperator, isunaryoperator, isbinaryoperator, ispostfixoperator, 
-            is_id_start_char, is_id_char, _isoperator, is_syntactic_operator, is_valid_identifier
+using .Meta: isidentifier, isoperator, isunaryoperator, isbinaryoperator, ispostfixoperator,
+            is_id_start_char, is_id_char, _isoperator, is_syntactic_operator, is_valid_identifier,
+            is_unary_and_binary_operator
 
 function show(io::IO, ::MIME"text/plain", u::UndefInitializer)
     show(io, u)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1,6 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using .Compiler: has_typevar
+using .Meta: isidentifier, isoperator, isunaryoperator, isbinaryoperator, ispostfixoperator, 
+            is_id_start_char, is_id_char, _isoperator, is_syntactic_operator, is_valid_identifier
 
 function show(io::IO, ::MIME"text/plain", u::UndefInitializer)
     show(io, u)
@@ -1542,104 +1544,6 @@ const expr_parens = Dict(:tuple=>('(',')'), :vcat=>('[',']'),
                          :ncat =>('[',']'), :nrow =>('[',']'),
                          :braces=>('{','}'), :bracescat=>('{','}'))
 
-## AST decoding helpers ##
-
-is_id_start_char(c::AbstractChar) = ccall(:jl_id_start_char, Cint, (UInt32,), c) != 0
-is_id_char(c::AbstractChar) = ccall(:jl_id_char, Cint, (UInt32,), c) != 0
-
-"""
-     isidentifier(s) -> Bool
-
-Return whether the symbol or string `s` contains characters that are parsed as
-a valid ordinary identifier (not a binary/unary operator) in Julia code;
-see also [`Base.isoperator`](@ref).
-
-Internally Julia allows any sequence of characters in a `Symbol` (except `\\0`s),
-and macros automatically use variable names containing `#` in order to avoid
-naming collision with the surrounding code. In order for the parser to
-recognize a variable, it uses a limited set of characters (greatly extended by
-Unicode). `isidentifier()` makes it possible to query the parser directly
-whether a symbol contains valid characters.
-
-# Examples
-```jldoctest
-julia> Meta.isidentifier(:x), Meta.isidentifier("1x")
-(true, false)
-```
-"""
-function isidentifier(s::AbstractString)
-    x = Iterators.peel(s)
-    isnothing(x) && return false
-    (s == "true" || s == "false") && return false
-    c, rest = x
-    is_id_start_char(c) || return false
-    return all(is_id_char, rest)
-end
-isidentifier(s::Symbol) = isidentifier(string(s))
-
-is_op_suffix_char(c::AbstractChar) = ccall(:jl_op_suffix_char, Cint, (UInt32,), c) != 0
-
-_isoperator(s) = ccall(:jl_is_operator, Cint, (Cstring,), s) != 0
-
-"""
-    isoperator(s::Symbol)
-
-Return `true` if the symbol can be used as an operator, `false` otherwise.
-
-# Examples
-```jldoctest
-julia> Meta.isoperator(:+), Meta.isoperator(:f)
-(true, false)
-```
-"""
-isoperator(s::Union{Symbol,AbstractString}) = _isoperator(s) || ispostfixoperator(s)
-
-"""
-    isunaryoperator(s::Symbol)
-
-Return `true` if the symbol can be used as a unary (prefix) operator, `false` otherwise.
-
-# Examples
-```jldoctest
-julia> Meta.isunaryoperator(:-), Meta.isunaryoperator(:√), Meta.isunaryoperator(:f)
-(true, true, false)
-```
-"""
-isunaryoperator(s::Symbol) = ccall(:jl_is_unary_operator, Cint, (Cstring,), s) != 0
-is_unary_and_binary_operator(s::Symbol) = ccall(:jl_is_unary_and_binary_operator, Cint, (Cstring,), s) != 0
-is_syntactic_operator(s::Symbol) = ccall(:jl_is_syntactic_operator, Cint, (Cstring,), s) != 0
-
-"""
-    isbinaryoperator(s::Symbol)
-
-Return `true` if the symbol can be used as a binary (infix) operator, `false` otherwise.
-
-# Examples
-```jldoctest
-julia> Meta.isbinaryoperator(:-), Meta.isbinaryoperator(:√), Meta.isbinaryoperator(:f)
-(true, false, false)
-```
-"""
-function isbinaryoperator(s::Symbol)
-    return _isoperator(s) && (!isunaryoperator(s) || is_unary_and_binary_operator(s)) &&
-        s !== Symbol("'")
-end
-
-"""
-    ispostfixoperator(s::Union{Symbol,AbstractString})
-
-Return `true` if the symbol can be used as a postfix operator, `false` otherwise.
-
-# Examples
-```jldoctest
-julia> Meta.ispostfixoperator(Symbol("'")), Meta.ispostfixoperator(Symbol("'ᵀ")), Meta.ispostfixoperator(:-)
-(true, true, false)
-```
-"""
-function ispostfixoperator(s::Union{Symbol,AbstractString})
-    s = String(s)::String
-    return startswith(s, '\'') && all(is_op_suffix_char, SubString(s, 2))
-end
 
 """
     operator_precedence(s::Symbol)
@@ -1778,19 +1682,6 @@ function show_enclosed_list(io::IO, op, items, sep, cl, indent, prec=0, quote_le
     print(io, cl)
 end
 
-const keyword_syms = Set([
-    :baremodule, :begin, :break, :catch, :const, :continue, :do, :else, :elseif,
-    :end, :export, :var"false", :finally, :for, :function, :global, :if, :import,
-    :let, :local, :macro, :module, :public, :quote, :return, :struct, :var"true",
-    :try, :using, :while ])
-
-function is_valid_identifier(sym)
-    return (isidentifier(sym) && !(sym in keyword_syms)) ||
-        (_isoperator(sym) &&
-        !(sym in (Symbol("'"), :(::), :?)) &&
-        !is_syntactic_operator(sym)
-    )
-end
 
 # show a normal (non-operator) function call, e.g. f(x, y) or A[z]
 # kw: `=` expressions are parsed with head `kw` in this context

--- a/base/some.jl
+++ b/base/some.jl
@@ -152,8 +152,9 @@ macro something(args...)
     which is why we need the last argument first
     when building the final expression.
     =#
-    for arg in reverse(args)
-        val = gensym()
+    for i in reverse(eachindex(args))
+        arg  = args[i]
+        val = Cartesian.inlineanonymous(:val, i)
         expr = quote
             $val = $(esc(arg))
             if !isnothing($val)

--- a/base/task.jl
+++ b/base/task.jl
@@ -139,7 +139,7 @@ true
 ```
 """
 macro task(ex)
-    thunk = Base.replace_linenums!(:(()->$(esc(ex))), __source__)
+    thunk = replace_linenums!(:(()->$(esc(ex))), __source__)
     :(Task($thunk))
 end
 
@@ -495,7 +495,7 @@ function _wait_multiple(waiting_tasks, throwexc=false, all=false, failfast=false
         for i in findall(remaining_mask)
             waiter = waiter_tasks[i]
             donenotify = tasks[i].donenotify::ThreadSynchronizer
-            @lock donenotify Base.list_deletefirst!(donenotify.waitq, waiter)
+            @lock donenotify list_deletefirst!(donenotify.waitq, waiter)
         end
         done_tasks = tasks[done_mask]
         if throwexc && exception
@@ -660,15 +660,15 @@ isolating the asynchronous code from changes to the variable's value in the curr
     Interpolating values via `\$` is available as of Julia 1.4.
 """
 macro async(expr)
-    do_async_macro(expr, __source__)
+    do_async_macro(expr, __source__, identity)
 end
 
 # generate the code for @async, possibly wrapping the task in something before
 # pushing it to the wait queue.
-function do_async_macro(expr, linenums; wrap=identity)
-    letargs = Base._lift_one_interp!(expr)
+function do_async_macro(expr, linenums, wrap)
+    letargs = _lift_one_interp!(expr)
 
-    thunk = Base.replace_linenums!(:(()->($(esc(expr)))), linenums)
+    thunk = replace_linenums!(:(()->($(esc(expr)))), linenums)
     var = esc(sync_varname)
     quote
         let $(letargs...)
@@ -708,7 +708,7 @@ fetch(t::UnwrapTaskFailedException) = unwrap_task_failed(fetch, t)
 
 # macro for running async code that doesn't throw wrapped exceptions
 macro async_unwrap(expr)
-    do_async_macro(expr, __source__, wrap=task->:(Base.UnwrapTaskFailedException($task)))
+    do_async_macro(expr, __source__, taskvar->:(UnwrapTaskFailedException($taskvar)))
 end
 
 """
@@ -758,29 +758,37 @@ function errormonitor(t::Task)
 end
 
 # Capture interpolated variables in $() and move them to let-block
-function _lift_one_interp!(e)
+function _lift_one_interp!(@nospecialize e)
     letargs = Any[]  # store the new gensymed arguments
-    _lift_one_interp_helper(e, false, letargs) # Start out _not_ in a quote context (false)
-    letargs
+    _lift_one_interp_helper(e, false, 0, letargs) # Start out _not_ in a quote context (false) and not needing escapes
+    return letargs
 end
-_lift_one_interp_helper(v, _, _) = v
-function _lift_one_interp_helper(expr::Expr, in_quote_context, letargs)
+_lift_one_interp_helper(@nospecialize(v), _::Bool, _::Int, _::Vector{Any}) = v
+function _lift_one_interp_helper(expr::Expr, in_quote_context::Bool, escs::Int, letargs::Vector{Any})
     if expr.head === :$
         if in_quote_context  # This $ is simply interpolating out of the quote
             # Now, we're out of the quote, so any _further_ $ is ours.
             in_quote_context = false
-        else
+        elseif escs == 0
+            # if escs is non-zero, then we cannot hoist expr.args without violating hygiene rules
             newarg = gensym()
             push!(letargs, :($(esc(newarg)) = $(esc(expr.args[1]))))
             return newarg  # Don't recurse into the lifted $() exprs
         end
+    elseif expr.head === :meta || expr.head === :inert
+        return expr
     elseif expr.head === :quote
         in_quote_context = true   # Don't try to lift $ directly out of quotes
     elseif expr.head === :macrocall
         return expr  # Don't recur into macro calls, since some other macros use $
+    elseif expr.head === :var"hygienic-scope"
+        escs += 1
+    elseif expr.head === :escape
+        escs == 0 && return expr
+        escs -= 1
     end
     for (i,e) in enumerate(expr.args)
-        expr.args[i] = _lift_one_interp_helper(e, in_quote_context, letargs)
+        expr.args[i] = _lift_one_interp_helper(e, in_quote_context, escs, letargs)
     end
     expr
 end
@@ -1007,7 +1015,7 @@ function schedule(t::Task, @nospecialize(arg); error=false)
     # schedule a task to be (re)started with the given value or exception
     t._state === task_state_runnable || Base.error("schedule: Task not runnable")
     if error
-        q = t.queue; q === nothing || Base.list_deletefirst!(q::IntrusiveLinkedList{Task}, t)
+        q = t.queue; q === nothing || list_deletefirst!(q::IntrusiveLinkedList{Task}, t)
         setfield!(t, :result, arg)
         setfield!(t, :_isexception, true)
     else
@@ -1033,7 +1041,7 @@ function yield()
     try
         wait()
     catch
-        q = ct.queue; q === nothing || Base.list_deletefirst!(q::IntrusiveLinkedList{Task}, ct)
+        q = ct.queue; q === nothing || list_deletefirst!(q::IntrusiveLinkedList{Task}, ct)
         rethrow()
     end
 end

--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -236,9 +236,9 @@ These expressions are represented as `LineNumberNode`s in Julia.
 ### Macros
 
 Macro hygiene is represented through the expression head pair `escape` and `hygienic-scope`.
-The result of a macro expansion is automatically wrapped in `(hygienic-scope block module)`,
+The result of a macro expansion is automatically wrapped in `(hygienic-scope block module [lno])`,
 to represent the result of the new scope. The user can insert `(escape block)` inside
-to interpolate code from the caller.
+to interpolate code from the caller. The lno is the `__source__` argument of the macro, if included.
 
 
 ## Lowered form

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2229,11 +2229,12 @@ function _inferred(ex, mod, allow = :(Union{}))
                 allow isa Type || throw(ArgumentError("@inferred requires a type as second argument"))
                 $(if any(@nospecialize(a)->(Meta.isexpr(a, :kw) || Meta.isexpr(a, :parameters)), ex.args)
                     # Has keywords
-                    args = gensym()
-                    kwargs = gensym()
+                    # Create the call expression with escaped user expressions
+                    call_expr = :($(esc(ex.args[1]))(args...; kwargs...))
                     quote
-                        $(esc(args)), $(esc(kwargs)), result = $(esc(Expr(:call, _args_and_call, ex.args[2:end]..., ex.args[1])))
-                        inftype = $(gen_call_with_extracted_types(mod, Base.infer_return_type, :($(ex.args[1])($(args)...; $(kwargs)...)); is_source_reflection = false))
+                        args, kwargs, result = $(esc(Expr(:call, _args_and_call, ex.args[2:end]..., ex.args[1])))
+                        # wrap in dummy hygienic-scope to work around scoping issues with `call_expr` already having `esc` on the necessary parts
+                        inftype = $(Expr(:var"hygienic-scope", gen_call_with_extracted_types(mod, Base.infer_return_type, call_expr; is_source_reflection = false), Test))
                     end
                 else
                     # No keywords

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2714,6 +2714,7 @@ function f15894(d)
     s
 end
 @test f15894(fill(1, 100)) == 100
+@test (@nexprs 2 i -> "_i_: $i") == "_i_: 2"
 end
 
 @testset "sign, conj[!], ~" begin

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -4,7 +4,7 @@
 ex = Base.Cartesian.exprresolve(:(if 5 > 4; :x; else :y; end))
 @test ex.args[2] == QuoteNode(:x)
 
-@test Base.Cartesian.lreplace!("val_col", Base.Cartesian.LReplace{String}(:col, "col", 1)) == "val_1"
+@test Base.Cartesian.lreplace_string!("val_col", Base.Cartesian.LReplace{String}(:col, "col", 1)) == "val_1"
 @test Base.setindex(CartesianIndex(1,5,4),3,2) == CartesianIndex(1, 3, 4)
 @testset "Expression Resolve" begin
     @test Base.Cartesian.exprresolve(:(1 + 3)) == 4

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -1098,3 +1098,6 @@ end
     @test Base.mightalias(permutedims(V1), V1)
     @test Base.mightalias(permutedims(V1), permutedims(V1))
 end
+
+
+@test @views quote var"begin" + var"end" end isa Expr


### PR DESCRIPTION
Manual `gensym` code often contains a lot of mistakes, either because the
user uses something like `.` or `+`, or because it combines code from
multiple modules (gensym is only unique within a pre-compile unit). This
replaces most uses for macro local variables with proper scope markers.
I did not rewrite `_lift_one_interp_helper` or `replace_ref_begin_end_`
however, since, while possible by adding `esc` to every argument that
has not used a gensym value, if any other argument did is a value, I
worried that could lead to macroexpand.scm making more new mistakes so I
left if for a separate PR. Better yet, we could make a unhygienic-scope
and unescape pair for marking the inverse/dual of the usual operations
(marking a symbol as unescaped within a region of unhygienic (escaped)
code to make these various uses easier to implement.

But also do rewrite `replace_ref_begin_end_` to respect argument order
and evaluation count (similar to its julia-syntax.scm counterpart) and
scoping (not adding `let` unpredictably).