### PR TITLE
test: math: test floating-point behavior when mapping zero to zero

### DIFF
--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1112,6 +1112,7 @@ function _cosc(x::Number)
         # generic Taylor series: π ∑ (-1)^n (πx)^{2n-1}/a(n) where
         # a(n) = (1+2n)*(2n-1)! (= OEIS A174549)
         s = (term = -(π*x))/3
+        iszero(s) && return s  # preserve floating-point signed zero
         π²x² = term^2
         ε = eps(fastabs(term)) # error threshold to stop sum
         n = 1

--- a/test/math.jl
+++ b/test/math.jl
@@ -599,6 +599,7 @@ end
             identity, deg2rad, rad2deg, cbrt, log1p, expm1, sinh, tanh, asinh, atanh,
             sin, sind, sinpi, tan, tand, tanpi, asin, asind, atan, atand, Base.Fix2(atan, n1), Base.Fix2(atand, n1),
             Base.Fix1(round, typ), Base.Fix1(trunc, typ), +, ∘(-, -), ∘(-, cosc),
+            Base.Fix1(*, n1), Base.Fix2(*, n1), Base.Fix2(/, n1),
         )
             @testset "s: $s" for s in (-1, 1)
                 z = s * n0

--- a/test/math.jl
+++ b/test/math.jl
@@ -592,8 +592,7 @@ end
 
 @testset "behavior at signed zero of monotonic floating-point functions mapping zero to zero" begin
     @testset "typ: $typ" for typ in (Float16, Float32, Float64)
-        n0 = typ(0)
-        n1 = typ(1)
+        (n0, n1) = typ.(0:1)
         @testset "f: $f" for f in (
             # all strictly increasing
             identity, deg2rad, rad2deg, cbrt, log1p, expm1, sinh, tanh, asinh, atanh,

--- a/test/math.jl
+++ b/test/math.jl
@@ -595,7 +595,7 @@ end
         @testset "f: $f" for f in (
             # all strictly increasing
             identity, deg2rad, rad2deg, cbrt, log1p, expm1, sinh, tanh, asinh, atanh,
-            sin, sind, sinpi, tan, tand, tanpi, asin, asind, atan, atand,
+            sin, sind, sinpi, tan, tand, tanpi, asin, asind, atan, atand, Base.Fix2(atan, one(typ)), Base.Fix2(atand, one(typ)),
             Base.Fix1(round, typ), Base.Fix1(trunc, typ), (+), ∘(-, -), ∘(-, cosc),
         )
             @testset "s: $s" for s in (-1, 1)

--- a/test/math.jl
+++ b/test/math.jl
@@ -596,7 +596,7 @@ end
             # all strictly increasing
             identity, deg2rad, rad2deg, cbrt, log1p, expm1, sinh, tanh, asinh, atanh,
             sin, sind, sinpi, tan, tand, tanpi, asin, asind, atan, atand,
-            Base.Fix1(round, typ), Base.Fix1(trunc, typ), ∘(-, -), ∘(-, cosc),
+            Base.Fix1(round, typ), Base.Fix1(trunc, typ), (+), ∘(-, -), ∘(-, cosc),
         )
             @testset "s: $s" for s in (-1, 1)
                 z = s * typ(0)

--- a/test/math.jl
+++ b/test/math.jl
@@ -590,6 +590,23 @@ end
     @test ismissing(scdm[2])
 end
 
+@testset "behavior at signed zero of monotonic floating-point functions mapping zero to zero" begin
+    @testset "typ: $typ" for typ in (Float32, Float64)
+        @testset "f: $f" for f in (
+            # all strictly increasing
+            identity, deg2rad, rad2deg, cbrt, log1p, expm1, sinh, tanh, asinh, atanh,
+            sin, sind, sinpi, tan, tand, tanpi, asin, asind, atan, atand,
+            Base.Fix1(round, typ), Base.Fix1(trunc, typ), ∘(-, -), ∘(-, cosc),
+        )
+            @testset "s: $s" for s in (-1, 1)
+                z = s * typ(0)
+                z::typ
+                @test z === @inferred f(z)
+            end
+        end
+    end
+end
+
 @testset "Integer and Inf args for sinpi/cospi/tanpi/sinc/cosc" begin
     for (sinpi, cospi) in ((sinpi, cospi), (x->sincospi(x)[1], x->sincospi(x)[2]))
         @test sinpi(1) === 0.0

--- a/test/math.jl
+++ b/test/math.jl
@@ -592,14 +592,16 @@ end
 
 @testset "behavior at signed zero of monotonic floating-point functions mapping zero to zero" begin
     @testset "typ: $typ" for typ in (Float16, Float32, Float64)
+        n0 = typ(0)
+        n1 = typ(1)
         @testset "f: $f" for f in (
             # all strictly increasing
             identity, deg2rad, rad2deg, cbrt, log1p, expm1, sinh, tanh, asinh, atanh,
-            sin, sind, sinpi, tan, tand, tanpi, asin, asind, atan, atand, Base.Fix2(atan, one(typ)), Base.Fix2(atand, one(typ)),
+            sin, sind, sinpi, tan, tand, tanpi, asin, asind, atan, atand, Base.Fix2(atan, n1), Base.Fix2(atand, n1),
             Base.Fix1(round, typ), Base.Fix1(trunc, typ), +, ∘(-, -), ∘(-, cosc),
         )
             @testset "s: $s" for s in (-1, 1)
-                z = s * typ(0)
+                z = s * n0
                 z::typ
                 @test z === @inferred f(z)
             end

--- a/test/math.jl
+++ b/test/math.jl
@@ -591,13 +591,24 @@ end
 end
 
 @testset "behavior at signed zero of monotonic floating-point functions mapping zero to zero" begin
+    function rounder(rm::RoundingMode)
+        function closure(::Type{T}, x::AbstractFloat) where {T <: AbstractFloat}
+            round(T, x, rm)
+        end
+    end
+    rounding_modes = (
+        RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp, RoundToZero, RoundFromZero, RoundUp, RoundDown,
+    )
+    rounders = map(rounder, rounding_modes)
     @testset "typ: $typ" for typ in (Float16, Float32, Float64)
         (n0, n1) = typ.(0:1)
+        rounders_typ = Base.Fix1.(rounders, typ)
         @testset "f: $f" for f in (
             # all strictly increasing
             identity, deg2rad, rad2deg, cbrt, log1p, expm1, sinh, tanh, asinh, atanh,
             sin, sind, sinpi, tan, tand, tanpi, asin, asind, atan, atand, Base.Fix2(atan, n1), Base.Fix2(atand, n1),
             Base.Fix1(round, typ), Base.Fix1(trunc, typ), +, ∘(-, -), ∘(-, cosc),
+            rounders_typ...,
             Base.Fix1(*, n1), Base.Fix2(*, n1), Base.Fix2(/, n1),
         )
             @testset "s: $s" for s in (-1, 1)

--- a/test/math.jl
+++ b/test/math.jl
@@ -591,7 +591,7 @@ end
 end
 
 @testset "behavior at signed zero of monotonic floating-point functions mapping zero to zero" begin
-    @testset "typ: $typ" for typ in (Float32, Float64)
+    @testset "typ: $typ" for typ in (Float16, Float32, Float64)
         @testset "f: $f" for f in (
             # all strictly increasing
             identity, deg2rad, rad2deg, cbrt, log1p, expm1, sinh, tanh, asinh, atanh,

--- a/test/math.jl
+++ b/test/math.jl
@@ -596,7 +596,7 @@ end
             # all strictly increasing
             identity, deg2rad, rad2deg, cbrt, log1p, expm1, sinh, tanh, asinh, atanh,
             sin, sind, sinpi, tan, tand, tanpi, asin, asind, atan, atand, Base.Fix2(atan, one(typ)), Base.Fix2(atand, one(typ)),
-            Base.Fix1(round, typ), Base.Fix1(trunc, typ), (+), ∘(-, -), ∘(-, cosc),
+            Base.Fix1(round, typ), Base.Fix1(trunc, typ), +, ∘(-, -), ∘(-, cosc),
         )
             @testset "s: $s" for s in (-1, 1)
                 z = s * typ(0)

--- a/test/math.jl
+++ b/test/math.jl
@@ -600,7 +600,7 @@ end
         RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp, RoundToZero, RoundFromZero, RoundUp, RoundDown,
     )
     rounders = map(rounder, rounding_modes)
-    @testset "typ: $typ" for typ in (Float16, Float32, Float64)
+    @testset "typ: $typ" for typ in (Float16, Float32, Float64, BigFloat)
         (n0, n1) = typ.(0:1)
         rounders_typ = Base.Fix1.(rounders, typ)
         @testset "f: $f" for f in (
@@ -614,6 +614,9 @@ end
             @testset "s: $s" for s in (-1, 1)
                 z = s * n0
                 z::typ
+                @test z == f(z)::typ
+                @test signbit(z) === signbit(f(z))
+                isbitstype(typ) &&
                 @test z === @inferred f(z)
             end
         end


### PR DESCRIPTION
The idea for this addition to the test suite originates here, where stevengj suggested to do this test for `cosc` specifically:

* https://github.com/JuliaLang/julia/pull/59087#issuecomment-3183764523

This PR instead tests all applicable functions I could find.

Also fix the sign of `cosc(::BigFloat)` for zero input, thanks to stevengj.