### PR TITLE
Add Base.parse method for CacheFlags

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1729,6 +1729,22 @@ function show(io::IO, cf::CacheFlags)
     print(io, ")")
 end
 
+function Base.parse(::Type{CacheFlags}, s::AbstractString)
+    e = Meta.parse(s)
+    if !(e isa Expr && e.head === :call && length(e.args) == 2 &&
+        e.args[1] === :CacheFlags &&
+        e.args[2] isa Expr && e.args[2].head == :parameters)
+        throw(ArgumentError("Malformed CacheFlags string"))
+    end
+    params = Dict{Symbol, Any}(p.args[1] => p.args[2] for p in e.args[2].args)
+    use_pkgimages = get(params, :use_pkgimages, nothing)
+    debug_level = get(params, :debug_level, nothing)
+    check_bounds = get(params, :check_bounds, nothing)
+    inline = get(params, :inline, nothing)
+    opt_level = get(params, :opt_level, nothing)
+    return CacheFlags(; use_pkgimages, debug_level, check_bounds, inline, opt_level)
+end
+
 struct ImageTarget
     name::String
     flags::Int32

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1310,6 +1310,9 @@ end
     @test cf.inline
     @test cf.opt_level == 3
     @test repr(cf) == "CacheFlags(; use_pkgimages=true, debug_level=3, check_bounds=3, inline=true, opt_level=3)"
+
+    # Round trip CacheFlags
+    @test parse(Base.CacheFlags, repr(cf)) == cf
 end
 
 empty!(Base.DEPOT_PATH)


### PR DESCRIPTION
This will be used by Pkg instead of parsing a single UInt8, so #59035 and other changes to CacheFlags can be made without breaking Pkg in the future, as mentioned in https://github.com/JuliaLang/Pkg.jl/pull/4347 (also ref: https://github.com/JuliaLang/Pkg.jl/pull/4347#issuecomment-3146824265).