### PR TITLE
libgit2: Spread out the port selection a bit more

### DIFF
--- a/stdlib/LibGit2/test/libgit2-tests.jl
+++ b/stdlib/LibGit2/test/libgit2-tests.jl
@@ -3063,7 +3063,7 @@ mktempdir() do dir
                 for attempt in 1:10
                     # Find an available port by listening, but there's a race condition where
                     # another process could grab this port, so retry on failure
-                    port, server = listenany(49152)
+                    port, server = listenany(49052 + rand(1:100) + attempt*10)
                     close(server)
 
                     # Make a fake Julia package and minimal HTTPS server with our generated


### PR DESCRIPTION
We're still seeing the libgit2 tests intermittently fail here due to port re-use (https://github.com/JuliaLang/julia/issues/52310). I suspect what is happening is if we get super unlucky, we have two tests simultaneously in this section and they just bounce port 49152 back and forth between each other in the probe section, so that always the other process has it when openssl tries to acquire it. An even better solution would be to just pass the socket we already have to openssl, but for now, just try to spread out the port probe a bit more.