### PR TITLE
Add informational note to user-signalled `SIGSEGV`

### DIFF
--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -636,6 +636,10 @@ void jl_critical_error(int sig, int si_code, bt_context_t *context, jl_task_t *c
             jl_safe_printf("\n[%d] signal %d (%d): %s\n", getpid(), sig, si_code, strsignal(sig));
         else
             jl_safe_printf("\n[%d] signal %d: %s\n", getpid(), sig, strsignal(sig));
+#ifdef _OS_LINUX_
+        if ((sig == SIGBUS || sig == SIGSEGV) && (si_code <= 0))
+            jl_safe_printf("signal came from user-land, signal handlers may be mis-configured.\n");
+#endif
     }
     jl_safe_printf("in expression starting at %s:%d\n", jl_atomic_load_relaxed(&jl_filename), jl_atomic_load_relaxed(&jl_lineno));
     if (context && ct) {

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -632,7 +632,7 @@ void jl_critical_error(int sig, int si_code, bt_context_t *context, jl_task_t *c
             sigaddset(&sset, sig);
         pthread_sigmask(SIG_UNBLOCK, &sset, NULL);
 #endif
-        if (si_code)
+        if (si_code != INT_MAX)
             jl_safe_printf("\n[%d] signal %d (%d): %s\n", getpid(), sig, si_code, strsignal(sig));
         else
             jl_safe_printf("\n[%d] signal %d: %s\n", getpid(), sig, strsignal(sig));

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -579,7 +579,7 @@ static void jl_try_deliver_sigint(void)
 
 static void JL_NORETURN jl_exit_thread0_cb(int signo)
 {
-    jl_critical_error(signo, 0, NULL, jl_current_task);
+    jl_critical_error(signo, INT_MAX, NULL, jl_current_task);
     jl_atexit_hook(128);
     jl_raise(signo);
 }

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -560,7 +560,7 @@ static void JL_NORETURN jl_exit_thread0_cb(void)
 {
 CFI_NORETURN
     jl_atomic_fetch_add(&jl_gc_disable_counter, -1);
-    jl_critical_error(thread0_exit_signo, 0, NULL, jl_current_task);
+    jl_critical_error(thread0_exit_signo, INT_MAX, NULL, jl_current_task);
     jl_atexit_hook(128);
     jl_raise(thread0_exit_signo);
 }

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -98,7 +98,7 @@ void __cdecl crt_sig_handler(int sig, int num)
         RtlCaptureContext(&Context);
         if (sig == SIGILL)
             jl_show_sigill(&Context);
-        jl_critical_error(sig, 0, &Context, jl_get_current_task());
+        jl_critical_error(sig, INT_MAX, &Context, jl_get_current_task());
         raise(sig);
     }
 }
@@ -335,7 +335,7 @@ LONG WINAPI jl_exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo)
     jl_safe_printf(" at 0x%zx -- ", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
     jl_print_native_codeloc((uintptr_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
 
-    jl_critical_error(0, 0, ExceptionInfo->ContextRecord, ct);
+    jl_critical_error(0, INT_MAX, ExceptionInfo->ContextRecord, ct);
     static int recursion = 0;
     if (recursion++)
         exit(1);


### PR DESCRIPTION
If we hit a segfault from a user-triggered SIGSEGV, that usually means that someone has tampered with our signal handlers (as in https://github.com/JuliaInterop/Clang.jl/pull/549)

Prints as:
```julia
julia> Threads.@threads for i in 1:1000; zeros(1024, 1024) .+ zeros(1024, 1024); end

[29561] signal 11 (-6): Segmentation fault
signal came from user-land, signal handlers may be mis-configured.
in expression starting at REPL[3]:1
```

This will not help if the signal handler was dropped on the floor or intercepted by another application without forwarding, but it will at least be useful to detect bad signal forwarding from another library.