### PR TITLE
add `macroexpand!` function and add `legacyscope` kwarg

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -60,6 +60,13 @@ New library features
 * `sort(keys(::Dict))` and `sort(values(::Dict))` now automatically collect, they previously threw ([#56978]).
 * `Base.AbstractOneTo` is added as a supertype of one-based axes, with `Base.OneTo` as its subtype ([#56902]).
 * `takestring!(::IOBuffer)` removes the content from the buffer, returning the content as a `String`.
+* The `macroexpand` (with default true) and the new `macroexpand!` (with default false)
+  functions now support a `legacyscope` boolean keyword argument to control whether to run
+  the legacy scope resolution pass over the result. The legacy scope resolution code has
+  known design bugs and will be disabled by default in a future version. Users should
+  migrate now by calling `legacyscope=false` or using `macroexpand!`. This may often require
+  fixes to the code calling `macroexpand` with `Meta.unescape` and `Meta.reescape` or by
+  updating tests to expect `hygienic-scope` or `escape` markers might appear in the result.
 
 Standard library changes
 ------------------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -837,6 +837,7 @@ export
     gensym,
     @kwdef,
     macroexpand,
+    macroexpand!,
     @macroexpand1,
     @macroexpand,
     parse,

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -538,6 +538,7 @@ Meta.parse(::AbstractString)
 Meta.ParseError
 Core.QuoteNode
 Base.macroexpand
+Base.macroexpand!
 Base.@macroexpand
 Base.@macroexpand1
 Base.code_lowered

--- a/src/ast.c
+++ b/src/ast.c
@@ -1252,24 +1252,15 @@ static jl_value_t *jl_expand_macros(jl_value_t *expr, jl_module_t *inmodule, str
     return expr;
 }
 
-JL_DLLEXPORT jl_value_t *jl_macroexpand(jl_value_t *expr, jl_module_t *inmodule)
+JL_DLLEXPORT jl_value_t *jl_macroexpand(jl_value_t *expr, jl_module_t *inmodule, int recursive, int inplace, int expand_scope)
 {
     JL_TIMING(LOWERING, LOWERING);
     JL_GC_PUSH1(&expr);
-    expr = jl_copy_ast(expr);
-    expr = jl_expand_macros(expr, inmodule, NULL, 0, jl_atomic_load_acquire(&jl_world_counter), 0);
-    expr = jl_call_scm_on_ast("jl-expand-macroscope", expr, inmodule);
-    JL_GC_POP();
-    return expr;
-}
-
-JL_DLLEXPORT jl_value_t *jl_macroexpand1(jl_value_t *expr, jl_module_t *inmodule)
-{
-    JL_TIMING(LOWERING, LOWERING);
-    JL_GC_PUSH1(&expr);
-    expr = jl_copy_ast(expr);
-    expr = jl_expand_macros(expr, inmodule, NULL, 1, jl_atomic_load_acquire(&jl_world_counter), 0);
-    expr = jl_call_scm_on_ast("jl-expand-macroscope", expr, inmodule);
+    if (!inplace)
+        expr = jl_copy_ast(expr);
+    expr = jl_expand_macros(expr, inmodule, NULL, !recursive, jl_atomic_load_acquire(&jl_world_counter), 0);
+    if (expand_scope)
+        expr = jl_call_scm_on_ast("jl-expand-macroscope", expr, inmodule);
     JL_GC_POP();
     return expr;
 }

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -294,7 +294,6 @@
     XX(jl_lseek) \
     XX(jl_lstat) \
     XX(jl_macroexpand) \
-    XX(jl_macroexpand1) \
     XX(jl_malloc) \
     XX(jl_malloc_stack) \
     XX(jl_matching_methods) \


### PR DESCRIPTION
Setting `legacyscope=false` is intended to make it much easier to debug and test macro expansion, since it no longer runs a buggy symbol mangling pass automatically. Adding the mutating version (`macroexpand!`) is mainly a handy way to opt in to the new legacyscope=true, without needing to spell that out.

More background: the macroexpand.scm pass design is buggy, so we'd like to stop using in the future. Currently changing the default causes visible breakage to a lot of buggy packages tests, so for now just provide the option to skip the legacy scope resolution. This is a continuation of https://github.com/JuliaLang/julia/pull/49793 and a prerequisite for eventually replacing the flisp code with JuliaLowering (once we can deprecate this parameter). 

Implement in-place macro expansion with `macroexpand!` (no corresponding `@macroexpand!`) that avoids copying AST nodes when the original expression is no longer needed anyways. But more importantly, add a `legacyscope::Bool` keyword argument to the functions that allows opting out of the legacy scope mangling.

Changes:
- Consolidate `jl_macroexpand` C functions with added parameters for `recursive`, `inplace`, and the (legacy) `expand_scope` control.
- Add `macroexpand!` Julia function with `legacyscope=false` default.
- Update `macroexpand` to have `legacyscope` (default `true`) for backward compatibility, until v2 or earlier.

Added to backporting so that new code can start to be written with `legacyscope=false`. Not entirely a new feature, since this is just adding the ability to disable an old (long deprecated) feature.

🤖 Generated with Claude