### PR TITLE
Sockets: Added possibility for skipping UDP IPv6 broadcast test if failing `join_multicast_group`

### DIFF
--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -494,10 +494,10 @@ end
                 @test_throws ErrorException wait_with_timeout(recvs, 2e8)
             end
         catch e
-            if isa(e, Base.IOError) && Base.uverrorname(e.code) == "EPERM"
+            if isa(e, Base.IOError) && Base.uverrorname(e.code) == "ENODEV"
+                @warn "UDP IPv6 broadcast test skipped (no IPv6 device with multicast enabled)"
+            elseif isa(e, Base.IOError) && Base.uverrorname(e.code) == "EPERM"
                 @warn "UDP IPv6 broadcast test skipped (permission denied upon send, restrictive firewall?)"
-            elseif isa(e, Base.IOError) && Base.uverrorname(e.code) == "ENODEV"
-                @warn "UDP IPv6 broadcast test skipped (`join_multicast_group`/`udp_set_membership` likely threw IOError: uv_udp_set_membership: no such device (ENODEV))"
             else
                 rethrow()
             end

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -496,6 +496,8 @@ end
         catch e
             if isa(e, Base.IOError) && Base.uverrorname(e.code) == "EPERM"
                 @warn "UDP IPv6 broadcast test skipped (permission denied upon send, restrictive firewall?)"
+            elseif isa(e, Base.IOError) && Base.uverrorname(e.code) == "ENODEV"
+                @warn "UDP IPv6 broadcast test skipped (`join_multicast_group`/`udp_set_membership` likely threw IOError: uv_udp_set_membership: no such device (ENODEV))"
             else
                 rethrow()
             end


### PR DESCRIPTION
The UDP IPv6 broadcast test would otherwise fail in a standard Docker container, e.g. via `docker run --rm julia:1.10 julia --eval 'Base.runtests("Sockets")'` (with Julia 1.10.10).

Workaround for https://github.com/JuliaLang/julia/issues/59282