### PR TITLE
Updated devcontainer definition

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,9 @@ FROM mcr.microsoft.com/devcontainers/cpp:1-debian
 RUN <<EOT
 apt-get update
 apt-get --yes install --no-install-recommends \
+    ccache \
+    clang \
+    clang-format \
     gfortran \
     m4
 rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/devcontainers/cpp:1-debian
+
+RUN <<EOT
+apt-get update
+apt-get --yes install --no-install-recommends \
+    gfortran \
+    m4
+rm -rf /var/lib/apt/lists/*
+EOT

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,11 +2,23 @@ FROM mcr.microsoft.com/devcontainers/cpp:1-debian
 
 RUN <<EOT
 apt-get update
+# Install required build tools and external libraries
+apt-get --yes install --no-install-recommends \
+    build-essential \
+    cmake \
+    curl \
+    gfortran \
+    git \
+    libatomic1 \
+    m4 \
+    perl \
+    pkg-config \
+    python3 \
+    wget
+# Install additional packages
 apt-get --yes install --no-install-recommends \
     ccache \
     clang \
-    clang-format \
-    gfortran \
-    m4
+    clang-format
 rm -rf /var/lib/apt/lists/*
 EOT

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,18 @@
 {
-  "image": "docker.io/library/julia:latest",
-  "customizations": {
-      "vscode": {
-        "extensions": [
-          "julialang.language-julia",
-          "ms-vscode.cpptools"
-        ]
-     }
+  "build": {
+    "dockerfile": "Dockerfile"
   },
-  "onCreateCommand": "apt-get update && apt-get install -y build-essential libatomic1 python3 gfortran perl wget m4 cmake pkg-config git"
+  "features": {
+    "ghcr.io/julialang/devcontainer-features/julia:1": {
+      "channel": "release"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools-extension-pack",
+        "ms-vscode.makefile-tools"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Ensuring:

* Running as non-root user to make tests pass, notably `Base.runtests("file")` - by basing container on [`mcr.microsoft.com/devcontainers/cpp`](https://github.com/devcontainers/images/tree/main/src/cpp).
* Availability of `gdb`.
* Caching when building/creating container by using build stages (and devcontainer features) instead of `onCreateCommand`.

Also added the Makefile Tools extension (and the C/C++ Extension Pack to quiet vscode/codespaces).
