### PR TITLE
Add a long running warn to Base.runtests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -199,10 +199,10 @@ cd(@__DIR__) do
         at = lpad("($wrkr)", name_align - textwidth(name) + 1, " ")
         lock(print_lock)
         try
-            printstyled(name, at, " |", " "^elapsed_align,
-                    "started at $(now())",
+            printstyled(name, at, " |", " "^elapsed_align, color=:white)
+            printstyled("started at $(now())",
                     (pid > 0 ? " on pid $pid" : ""),
-                    "\n", color=:white)
+                    "\n", color=:light_black)
         finally
             unlock(print_lock)
         end
@@ -296,7 +296,12 @@ cd(@__DIR__) do
                                 @lock print_lock begin
                                     print(test)
                                     print(lpad("($(wrkr))", name_align - textwidth(test) + 1, " "), " | ")
-                                    printstyled("       has been running for $(elapsed_str)\n", color=Base.warn_color())
+                                    # Calculate total width of data columns: "Time (s) | GC (s) | GC % | Alloc (MB) | RSS (MB)"
+                                    # This is: elapsed_align + 3 + gc_align + 3 + percent_align + 3 + alloc_align + 3 + rss_align
+                                    data_width = elapsed_align + gc_align + percent_align + alloc_align + rss_align + 12  # 12 = 4 * " | "
+                                    message = "has been running for $(elapsed_str)"
+                                    centered_message = lpad(rpad(message, (data_width + textwidth(message)) ÷ 2), data_width)
+                                    printstyled(centered_message, "\n", color=:light_black)
                                 end
                             end
                         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -286,8 +286,7 @@ cd(@__DIR__) do
                                 elapsed_minutes = elapsed.value ÷ (1000 * 60)
 
                                 elapsed_str = if elapsed_minutes >= 60
-                                    hours = elapsed_minutes ÷ 60
-                                    mins = elapsed_minutes % 60
+                                    hours, mins = divrem(elapsed_minutes, 60)
                                     "$(hours)h $(mins)m"
                                 else
                                     "$(elapsed_minutes)m"
@@ -403,7 +402,7 @@ cd(@__DIR__) do
             schedule(stdin_monitor, InterruptException(); error=true)
         end
         if @isdefined test_timers
-            foreach(close, timer in values(test_timers))
+            foreach(close, values(test_timers))
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,16 +13,8 @@ include("choosetests.jl")
 include("testenv.jl")
 include("buildkitetestjson.jl")
 
-longrunning_delay = if haskey(ENV, "JULIA_TEST_LONGRUNNING_DELAY") # minutes
-    parse(Int, ENV["JULIA_TEST_LONGRUNNING_DELAY"]) * 60
-else
-    45 * 60  # 45 minutes
-end
-longrunning_interval = if haskey(ENV, "JULIA_TEST_LONGRUNNING_INTERVAL") # minutes
-    parse(Int, ENV["JULIA_TEST_LONGRUNNING_INTERVAL"]) * 60
-else
-    15 * 60  # 15 minutes
-end
+const longrunning_delay = parse(Int, get(ENV, "JULIA_TEST_LONGRUNNING_DELAY", "45")) * 60 # minutes
+const longrunning_interval = parse(Int, get(ENV, "JULIA_TEST_LONGRUNNING_INTERVAL", "15")) * 60 # minutes
 
 (; tests, net_on, exit_on_error, use_revise, buildroot, seed) = choosetests(ARGS)
 tests = unique(tests)


### PR DESCRIPTION
- Add a long-running message to Base.runtests. Otherwise when there's lots of output it can be tricky to figure out which worker is still running which test.
- Also deemphasize the "started at" message as it confuses reading the table

Example with very short `JULIA_TEST_LONGRUNNING_DELAY=1 JULIA_TEST_LONGRUNNING_INTERVAL=1`
It's tunable so that it can be adjusted for e.g. the coverage CI which takes a lot longer.

<img width="879" height="472" alt="Screenshot 2025-08-15 at 2 24 00 PM" src="https://github.com/user-attachments/assets/16c673e1-2774-4744-be87-5bc218a44c15" />





