### PR TITLE
juliac: apply `buildscript` modifications after user code

### DIFF
--- a/contrib/juliac/juliac-buildscript.jl
+++ b/contrib/juliac/juliac-buildscript.jl
@@ -2,10 +2,6 @@
 
 # Script to run in the process that generates juliac's object file output
 
-# Run the verifier in the current world (before modifications), so that error
-# messages and types print in their usual way.
-Core.Compiler._verify_trim_world_age[] = Base.get_world_counter()
-
 # Initialize some things not usually initialized when output is requested
 Sys.__init__()
 Base.init_depot_path()
@@ -21,10 +17,6 @@ uuid_tuple = (UInt64(0), UInt64(0))
 ccall(:jl_set_module_uuid, Cvoid, (Any, NTuple{2, UInt64}), Base.__toplevel__, uuid_tuple)
 if Base.get_bool_env("JULIA_USE_FLISP_PARSER", false) === false
     Base.JuliaSyntax.enable_in_core!()
-end
-
-if Base.JLOptions().trim != 0
-    include(joinpath(@__DIR__, "juliac-trim-base.jl"))
 end
 
 # Load user code
@@ -80,7 +72,12 @@ let include_result = Base.include(Main, ARGS[1])
     end
 end
 
+# Run the verifier in the current world (before build-script modifications),
+# so that error messages and types print in their usual way.
+Core.Compiler._verify_trim_world_age[] = Base.get_world_counter()
+
 if Base.JLOptions().trim != 0
+    include(joinpath(@__DIR__, "juliac-trim-base.jl"))
     include(joinpath(@__DIR__, "juliac-trim-stdlib.jl"))
 end
 


### PR DESCRIPTION
These modifications to the MethodTable should be performed at the "link-stage", after all user top-level code has executed. This should be closer to the upcoming 1.13 pipeline, which will move all top-level user code to its standard package execution context.

This also makes any user-provided functionality for type printing available to the `TrimVerifier`.

Resolves https://github.com/JuliaLang/julia/issues/59280.