### PR TITLE
Fix printing of errors in juliac + searchsorted functions for LinearAlgebra

### DIFF
--- a/contrib/juliac/juliac-buildscript.jl
+++ b/contrib/juliac/juliac-buildscript.jl
@@ -8,6 +8,7 @@ Core.Compiler._verify_trim_world_age[] = Base.get_world_counter()
 
 # Initialize some things not usually initialized when output is requested
 Sys.__init__()
+Base.reinit_stdio()
 Base.init_depot_path()
 Base.init_load_path()
 Base.init_active_project()

--- a/contrib/juliac/juliac-trim-base.jl
+++ b/contrib/juliac/juliac-trim-base.jl
@@ -78,6 +78,9 @@ end
         end
     end
     show_type_name(io::IO, tn::Core.TypeName) = print(io, tn.name)
+    # this function is not `--trim`-compatible if it resolves to a Varargs{...} specialization
+    # and since it only has 1-argument methods this happens too often by default (just 2-3 args)
+    setfield!(typeof(throw_eachindex_mismatch_indices).name, :max_args, Int32(5), :monotonic)
 end
 @eval Base.Sys begin
     __init_build() = nothing # VersionNumber parsing is not supported yet

--- a/contrib/juliac/juliac-trim-base.jl
+++ b/contrib/juliac/juliac-trim-base.jl
@@ -85,6 +85,7 @@ end
 # Used for LinearAlgebre ldiv with SVD
 for s in [:searchsortedfirst, :searchsortedlast, :searchsorted]
     @eval Base.Sort begin
+        # identical to existing Base def. but specializes on `lt` / `by`
         $s(v::AbstractVector, x, o::Ordering) = $s(v,x,firstindex(v),lastindex(v),o)
         $s(v::AbstractVector, x;
             lt::T=isless, by::F=identity, rev::Union{Bool,Nothing}=nothing, order::Ordering=Forward) where {T,F} =
@@ -120,5 +121,7 @@ end
 end
 
 @eval Base.CoreLogging begin
+    # Disable logging (TypedCallable is required to support the existing dynamic
+    # logger interface, but it's not implemented yet)
     @inline current_logger_for_env(std_level::LogLevel, group, _module) = nothing
 end

--- a/contrib/juliac/juliac-trim-base.jl
+++ b/contrib/juliac/juliac-trim-base.jl
@@ -82,6 +82,15 @@ end
 @eval Base.Sys begin
     __init_build() = nothing # VersionNumber parsing is not supported yet
 end
+# Used for LinearAlgebre ldiv with SVD
+for s in [:searchsortedfirst, :searchsortedlast, :searchsorted]
+    @eval Base.Sort begin
+        $s(v::AbstractVector, x, o::Ordering) = $s(v,x,firstindex(v),lastindex(v),o)
+        $s(v::AbstractVector, x;
+            lt::T=isless, by::F=identity, rev::Union{Bool,Nothing}=nothing, order::Ordering=Forward) where {T,F} =
+            $s(v,x,ord(lt,by,rev,order))
+    end
+end
 @eval Base.GMP begin
     function __init__() # VersionNumber parsing is not supported yet
         try

--- a/contrib/juliac/juliac-trim-base.jl
+++ b/contrib/juliac/juliac-trim-base.jl
@@ -118,3 +118,7 @@ end
         end
     end
 end
+
+@eval Base.CoreLogging begin
+    @inline current_logger_for_env(std_level::LogLevel, group, _module) = nothing
+end


### PR DESCRIPTION
We may want to move this changes to base proper. 
@LilithHafner should sort functions just always specialize on the `by`/`lt` params? It currently sometimes relies on inlining for good performance