### PR TITLE
make NEWS-update.jl more robust in trimming existing links

### DIFF
--- a/doc/NEWS-update.jl
+++ b/doc/NEWS-update.jl
@@ -5,7 +5,7 @@ NEWS = get(ARGS, 1, "NEWS.md")
 
 s = read(NEWS, String)
 
-m = match(r"\[#[0-9]+\]:", s)
+m = match(r"^\[#[0-9]+\]:"m, s)
 if m !== nothing
     s = s[1:m.offset-1]
 end


### PR DESCRIPTION
The `NEWS-update.jl` script trims away any existing links from the end of the `NEWS.md` file, so that it is safe to run multiple times.   This PR makes that trimming a bit more robust by trimming only `[#...]:` patterns that start at the beginning of a line.

(I ran into this in re-using the same script for another project.)