### PR TITLE
Use `readbytes!` instead of `readavailable` in `write(to::IO, from::IO)`

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -891,7 +891,7 @@ function write(to::IO, from::IO)
     n::Int64 = 0
     buf = UInt8[]
     while !eof(from)
-        nb = Int(clamp(bytesavailable(from), 2^10, 2^24))
+        nb = Int(clamp(bytesavailable(from), 1, 2^24))
         resize!(buf, nb)
         nr = Int(readbytes!(from, buf))
         resize!(buf, nr)


### PR DESCRIPTION
This PR changes the fallback implementation of `write(to::IO, from::IO)` from using `readavailable` to instead use `readbytes!`.

As described in https://github.com/JuliaLang/julia/issues/57994 and https://github.com/JuliaLang/julia/pull/7478
`readavailable` is both difficult to implement correctly and difficult to use correctly.

Also, since `readavailable` has no fallback implementations, `IO` types in packages may not support a `write(to::IO, from::IO)` using `readavailable`:
https://github.com/fhs/ZipFile.jl/pull/75
https://github.com/reallyasi9/TruncatedStreams.jl/issues/6

This PR also slightly improves performance and fixes an integer overflow issue on 32-bit systems.

Here is a benchmark:
```julia
using Chairmarks
f = tempname()
write(f, ones(UInt8, 2^30))
f2 = tempname()
@be open(f) do source
  open(f2; write= true) do sink
    write(sink, source)
  end
end seconds=10.0
```

PR:
Benchmark: 19 samples with 1 evaluation
 min    340.150 ms (21 allocs: 33.055 KiB)
 median 555.801 ms (21 allocs: 33.055 KiB)
 mean   536.123 ms (21 allocs: 33.060 KiB)
 max    652.772 ms (21 allocs: 33.086 KiB)

master:
Benchmark: 19 samples with 1 evaluation
 min    368.953 ms (98321 allocs: 1.002 GiB, 2.64% gc time)
 median 588.090 ms (98321 allocs: 1.002 GiB, 2.85% gc time)
 mean   551.741 ms (98321 allocs: 1.002 GiB, 3.09% gc time)
 max    635.504 ms (98321 allocs: 1.002 GiB, 4.39% gc time)



