### PR TITLE
Specify type signatures for CartesianIndices iteration states

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -481,7 +481,7 @@ module IteratorsMD
     end
 
     # 0-d cartesian ranges are special-cased to iterate once and only once
-    iterate(iter::CartesianIndices{0}, done=false) = done ? nothing : (CartesianIndex(), true)
+    iterate(iter::CartesianIndices{0}, done::Bool=false) = done ? nothing : (CartesianIndex(), true)
 
     size(iter::CartesianIndices) = map(length, iter.indices)
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -447,7 +447,7 @@ module IteratorsMD
         end
         iterfirst, iterfirst
     end
-    @inline function iterate(iter::CartesianIndices, state)
+    @inline function iterate(iter::CartesianIndices, state::CartesianIndex)
         valid, I = __inc(state.I, iter.indices)
         valid || return nothing
         return CartesianIndex(I...), CartesianIndex(I...)
@@ -960,7 +960,7 @@ Fallback to `iterate` by default, but optimized for indices type in `Base`.
 _prechecked_iterate(iter::AbstractUnitRange, i = first(iter)) = i, convert(eltype(iter), i + step(iter))
 _prechecked_iterate(iter::LinearIndices, i = first(iter)) = i, i + 1
 _prechecked_iterate(iter::CartesianIndices) = first(iter), first(iter)
-function _prechecked_iterate(iter::CartesianIndices, i)
+function _prechecked_iterate(iter::CartesianIndices, i::CartesianIndex)
     i′ = IteratorsMD.inc(i.I, iter.indices)
     return i′, i′
 end


### PR DESCRIPTION
These methods are clearly meant to be used with a `CartesianIndex` state, and this PR makes this explicit.