### PR TITLE
`StackTraces.lookup(::Base.InterpreterIP)`: fix some boxing and some bad inference

### DIFF
--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -180,7 +180,7 @@ function lookup(ip::Base.InterpreterIP)
             return sf
         end
     end
-    return map(closure, scopes)
+    return map(closure, scopes)::Vector{StackFrame}
 end
 
 """

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -167,7 +167,7 @@ function lookup(ip::Base.InterpreterIP)
     if isempty(scopes)
         return [StackFrame(func, file, line, code, false, false, 0)]
     end
-    closure = let inlined::Bool = false, def = def, codeinfo = codeinfo
+    closure = let inlined::Bool = false, def = def
         function closure_inner(lno)
             if inlined
                 def = lno.method

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -180,7 +180,7 @@ function lookup(ip::Base.InterpreterIP)
             return sf
         end
     end
-    return map(closure, scopes)::Vector{StackFrame}
+    return map(closure, scopes)
 end
 
 """

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -147,11 +147,14 @@ function lookup(ip::Base.InterpreterIP)
             if isa(def, Core.ABIOverride)
                 def = def.def
             end
-            if isa(def, MethodInstance) && isa(def.def, Method)
-                meth = def.def
-                func = meth.name
-                file = meth.file
-                line = meth.line
+            if isa(def, MethodInstance)
+                let meth = def.def
+                    if isa(meth, Method)
+                        func = meth.name
+                        file = meth.file
+                        line = meth.line
+                    end
+                end
             end
         else
             codeinfo = code::CodeInfo

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -376,3 +376,7 @@ end
     @test sp[1] < ptr1
     @test all(diff(Int128.(UInt.(sp))) .> 0)
 end
+
+@testset "`lookup` return type inference" begin
+    @test Vector{StackTraces.StackFrame} === Base.infer_return_type(lookup)
+end


### PR DESCRIPTION
* Use common subexpression elimination to help type inference through a branch.

* Delay some boxing due to closure capture.

* Help a closure capture (`inlined`) to be inferred as `Bool`.

* Add a test to check that `lookup` always has a concretely inferred return type.