### PR TITLE
Fix JET-reported issues in `BinaryPlatforms.triplet(::AbstractPlatform)`

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -520,14 +520,17 @@ function triplet(p::AbstractPlatform)
     )
 
     # Tack on optional compiler ABI flags
-    if libgfortran_version(p) !== nothing
-        str = string(str, "-libgfortran", libgfortran_version(p).major)
+    libgfortran_version_ = libgfortran_version(p)
+    if libgfortran_version_ !== nothing
+        str = string(str, "-libgfortran", libgfortran_version_.major)
     end
-    if cxxstring_abi(p) !== nothing
-        str = string(str, "-", cxxstring_abi(p))
+    cxxstring_abi_ = cxxstring_abi(p)
+    if cxxstring_abi_ !== nothing
+        str = string(str, "-", cxxstring_abi_)
     end
-    if libstdcxx_version(p) !== nothing
-        str = string(str, "-libstdcxx", libstdcxx_version(p).patch)
+    libstdcxx_version_ = libstdcxx_version(p)
+    if libstdcxx_version_ !== nothing
+        str = string(str, "-libstdcxx", libstdcxx_version_.patch)
     end
 
     # Tack on all extra tags


### PR DESCRIPTION
The issue is that JET reported that in `libgfortran_version(p).major` the first arg of `getproperty` could be `nothing`. This is already checked in the previous line, but in a way that the compiler cannot remember until that call. Putting it into a variable should fix that.

It would be great if this could get backported to at least 1.12 (1.10 and 1.11 would also be great), since that is where people try to use JET for their packages, and this reduces the Base noise in the output.