### PR TITLE
[backports-release-1.10] Remove bfloat16 condition accidentally backported

### DIFF
--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -1158,13 +1158,6 @@ extern "C" JL_DLLEXPORT std::vector<jl_target_spec_t> jl_get_llvm_clone_targets(
                 break;
             }
         }
-        static constexpr uint32_t clone_bf16[] = {Feature::avx512bf16};
-        for (auto fe: clone_bf16) {
-            if (!test_nbit(features0, fe) && test_nbit(t.en.features, fe)) {
-                t.en.flags |= JL_TARGET_CLONE_BFLOAT16;
-                break;
-            }
-        }
     }
     if (image_targets.empty())
         jl_error("No targets specified");


### PR DESCRIPTION
This BFloat16 part was backported to 1.10 as part of https://github.com/JuliaLang/julia/pull/54471, but 1.10 doesn't actually have the  BFloat16 support that this goes along with, and it has broken the build. So remove the condition.

cc @gbaraldi