### PR TITLE
test: add missing closewrite call

### DIFF
--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -82,6 +82,7 @@ end
         try
             run(pipeline(cmd, stdout=io, stderr=io))
         catch
+            closewrite(io)
             @error "cmd failed" cmd read(io, String)
             rethrow()
         end


### PR DESCRIPTION
This test would previously just hang if there was any error, instead of printing the error as intended.

This might be better as an IOBuffer so closewrite is implicit, but that's behavior is not well-specified right now with multiple writers, as is done here.