### PR TITLE
Update Artifacts precompile statement

### DIFF
--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -766,6 +766,5 @@ precompile(NamedTuple{(:pkg_uuid,)}, (Tuple{Base.UUID},))
 precompile(Core.kwfunc(load_artifacts_toml), (NamedTuple{(:pkg_uuid,), Tuple{Base.UUID}}, typeof(load_artifacts_toml), String))
 precompile(parse_mapping, (String, String, String))
 precompile(parse_mapping, (Dict{String, Any}, String, String))
-precompile(Tuple{typeof(Artifacts._artifact_str), Module, String, Base.SubString{String}, String, Base.Dict{String, Any}, Base.SHA1, Base.BinaryPlatforms.Platform, Any})
-
+precompile(Tuple{typeof(Artifacts.__artifact_str), Module, String, Base.SubString{String}, String, Base.Dict{String, Any}, Base.SHA1, Base.BinaryPlatforms.Platform, Base.Val{Artifacts}})
 end # module Artifacts


### PR DESCRIPTION
The `@__artifact_str` macro was updated in https://github.com/JuliaLang/julia/pull/55707.

```julia-repl
# Before
julia> @time import ZeroMQ_jll
  0.119653 seconds (313.44 k allocations: 16.855 MiB, 79.48% compilation time)

# After
julia> @time import ZeroMQ_jll
  0.024658 seconds (22.61 k allocations: 1.830 MiB)
```