### PR TITLE
Test: Make test recording thread safe

### DIFF
--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -584,7 +584,7 @@ end
         @test total_error  == 6
         @test total_broken == 0
     end
-    ts.anynonpass = false
+    @atomic ts.anynonpass = 0x00
     deleteat!(Test.get_testset().results, 1)
 end
 


### PR DESCRIPTION
In preparation of #53462, ensure that attempting to record test results to a test set from multiple threads does not cause corruption. Note that other part of `Test` remain non-threadsafe.