### PR TITLE
separate the function `Base._iterate` into two functions

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1238,13 +1238,13 @@ oneunit(x::AbstractMatrix{T}) where {T} = _one(oneunit(T), x)
 iterate_starting_state(A) = iterate_starting_state(A, IndexStyle(A))
 iterate_starting_state(A, ::IndexLinear) = firstindex(A)
 iterate_starting_state(A, ::IndexStyle) = (eachindex(A),)
-@inline iterate(A::AbstractArray, state = iterate_starting_state(A)) = _iterate(A, state)
-@inline function _iterate(A::AbstractArray, state::Tuple)
+@inline iterate(A::AbstractArray, state = iterate_starting_state(A)) = _iterate_abstractarray(A, state)
+@inline function _iterate_abstractarray(A::AbstractArray, state::Tuple)
     y = iterate(state...)
     y === nothing && return nothing
     A[y[1]], (state[1], tail(y)...)
 end
-@inline function _iterate(A::AbstractArray, state::Integer)
+@inline function _iterate_abstractarray(A::AbstractArray, state::Integer)
     checkbounds(Bool, A, state) || return nothing
     A[state], state + one(state)
 end

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -698,11 +698,11 @@ function skip_deleted_floor!(h::Dict)
     idx
 end
 
-@propagate_inbounds _iterate(t::Dict{K,V}, i) where {K,V} = i == 0 ? nothing : (Pair{K,V}(t.keys[i],t.vals[i]), i == typemax(Int) ? 0 : i+1)
+@propagate_inbounds _iterate_dict(t::Dict{K,V}, i) where {K,V} = i == 0 ? nothing : (Pair{K,V}(t.keys[i],t.vals[i]), i == typemax(Int) ? 0 : i+1)
 @propagate_inbounds function iterate(t::Dict)
-    _iterate(t, skip_deleted(t, t.idxfloor))
+    _iterate_dict(t, skip_deleted(t, t.idxfloor))
 end
-@propagate_inbounds iterate(t::Dict, i) = _iterate(t, skip_deleted(t, i))
+@propagate_inbounds iterate(t::Dict, i) = _iterate_dict(t, skip_deleted(t, i))
 
 isempty(t::Dict) = (t.count == 0)
 length(t::Dict) = t.count


### PR DESCRIPTION
Clearly the three methods were not meant to belong to the same function:

* one method is specific to `Dict`

* two methods are specific to `AbstractArray`

Fix that.