### PR TITLE
`axes` for a `Slice` of an `AbstractOneTo` axis

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -469,7 +469,7 @@ iterate(S::IdentityUnitRange, s...) = iterate(S.indices, s...)
 # In general such an indexing operation would produce offset ranges
 # This should also ideally return an AbstractUnitRange{eltype(S)}, but currently
 # we're restricted to eltype(::IdentityUnitRange) == Int by definition
-function getindex(S::AbstractOneTo, I::IdentityUnitRange{<:AbstractUnitRange{<:Integer}})
+function getindex(S::AbstractOneTo{<:Integer}, I::IdentityUnitRange{<:AbstractUnitRange{<:Integer}})
     @inline
     @boundscheck checkbounds(S, I)
     return I

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -387,8 +387,8 @@ Slice{T}(S::Slice) where {T<:AbstractUnitRange} = Slice{T}(T(S.indices))
 
 axes(S::Slice) = (IdentityUnitRange(S.indices),)
 axes1(S::Slice) = IdentityUnitRange(S.indices)
-axes(S::Slice{<:OneTo}) = (S.indices,)
-axes1(S::Slice{<:OneTo}) = S.indices
+axes(S::Slice{<:AbstractOneTo{<:Integer}}) = (S.indices,)
+axes1(S::Slice{<:AbstractOneTo{<:Integer}}) = S.indices
 
 first(S::Slice) = first(S.indices)
 last(S::Slice) = last(S.indices)
@@ -416,8 +416,8 @@ IdentityUnitRange{T}(S::IdentityUnitRange) where {T<:AbstractUnitRange} = Identi
 # IdentityUnitRanges are offset and thus have offset axes, so they are their own axes
 axes(S::IdentityUnitRange) = (S,)
 axes1(S::IdentityUnitRange) = S
-axes(S::IdentityUnitRange{<:OneTo}) = (S.indices,)
-axes1(S::IdentityUnitRange{<:OneTo}) = S.indices
+axes(S::IdentityUnitRange{<:AbstractOneTo{<:Integer}}) = (S.indices,)
+axes1(S::IdentityUnitRange{<:AbstractOneTo{<:Integer}}) = S.indices
 
 first(S::IdentityUnitRange) = first(S.indices)
 last(S::IdentityUnitRange) = last(S.indices)
@@ -465,11 +465,11 @@ end
 show(io::IO, r::IdentityUnitRange) = print(io, "Base.IdentityUnitRange(", r.indices, ")")
 iterate(S::IdentityUnitRange, s...) = iterate(S.indices, s...)
 
-# For OneTo, the values and indices of the values are identical, so this may be defined in Base.
+# For AbstractOneTo, the values and indices of the values are identical, so this may be defined in Base.
 # In general such an indexing operation would produce offset ranges
 # This should also ideally return an AbstractUnitRange{eltype(S)}, but currently
 # we're restricted to eltype(::IdentityUnitRange) == Int by definition
-function getindex(S::OneTo, I::IdentityUnitRange{<:AbstractUnitRange{<:Integer}})
+function getindex(S::AbstractOneTo, I::IdentityUnitRange{<:AbstractUnitRange{<:Integer}})
     @inline
     @boundscheck checkbounds(S, I)
     return I

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -385,9 +385,8 @@ end
 Slice(S::Slice) = S
 Slice{T}(S::Slice) where {T<:AbstractUnitRange} = Slice{T}(T(S.indices))
 
-axes(S::Slice) = (IdentityUnitRange(S.indices),)
+axes(S::Slice) = (axes1(S),)
 axes1(S::Slice) = IdentityUnitRange(S.indices)
-axes(S::Slice{<:AbstractOneTo{<:Integer}}) = (S.indices,)
 axes1(S::Slice{<:AbstractOneTo{<:Integer}}) = S.indices
 
 first(S::Slice) = first(S.indices)
@@ -414,9 +413,8 @@ IdentityUnitRange(S::IdentityUnitRange) = S
 IdentityUnitRange{T}(S::IdentityUnitRange) where {T<:AbstractUnitRange} = IdentityUnitRange{T}(T(S.indices))
 
 # IdentityUnitRanges are offset and thus have offset axes, so they are their own axes
-axes(S::IdentityUnitRange) = (S,)
+axes(S::IdentityUnitRange) = (axes1(S),)
 axes1(S::IdentityUnitRange) = S
-axes(S::IdentityUnitRange{<:AbstractOneTo{<:Integer}}) = (S.indices,)
 axes1(S::IdentityUnitRange{<:AbstractOneTo{<:Integer}}) = S.indices
 
 first(S::IdentityUnitRange) = first(S.indices)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2293,6 +2293,21 @@ end
     end
 end
 
+@testset "AbstractOneTo" begin
+    s = SizedArrays.SizedArray{(2,2)}(ones(2,2))
+    v = view(s, :, 1)
+    @test axes(v,1) isa SizedArrays.SOneTo{2}
+    @test eachindex(v) isa SizedArrays.SOneTo{2}
+
+    ax = axes(v,1)
+    @test ax[Base.IdentityUnitRange(ax)] == ax
+    @test ax[Base.IdentityUnitRange(2:2)] == Base.IdentityUnitRange(2:2)
+
+    # check that IdentityUnitRange behaves like Slice
+    @test axes(Base.IdentityUnitRange(ax), 1) === ax
+    @test eachindex(Base.IdentityUnitRange(ax)) === ax
+end
+
 @testset "effect inference for `iterate` for `Array` and for `Memory`" begin
     for El ∈ (Float32, Real, Any)
         for Arr ∈ (Memory{El}, Array{El, 0}, Vector{El}, Matrix{El}, Array{El, 3})


### PR DESCRIPTION
Currently, we have specialized `axes` methods for `Slice{<:OneTo}` to unwrap the `Slice`. The same logic may be extended to `Base.AbstractOneTo`, so that subtypes of `AbstractOneTo` inherit the behavior.