### PR TITLE
[backports-release-1.11] Change Distributed branch from `master` to `release-julia-1.11` (but keep the commit the same)

### DIFF
--- a/stdlib/Distributed.version
+++ b/stdlib/Distributed.version
@@ -1,4 +1,4 @@
-DISTRIBUTED_BRANCH = master
+DISTRIBUTED_BRANCH = release-julia-1.11
 DISTRIBUTED_SHA1 = 6c7cdb5860fa5cb9ca191ce9c52a3d25a9ab3781
 DISTRIBUTED_GIT_URL := https://github.com/JuliaLang/Distributed.jl
 DISTRIBUTED_TAR_URL = https://api.github.com/repos/JuliaLang/Distributed.jl/tarball/$1


### PR DESCRIPTION
Targets `backports-release-1.11` (https://github.com/JuliaLang/julia/pull/59336).

This PR will be followed up with a stdlib bump with the Distributed backports.