### PR TITLE
Change REPL completion for U+022D8 character

### DIFF
--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -2712,4 +2712,3 @@ const symbols_latex_canonical = Dict(
     "⊽" => "\\nor",
     "≠" => "\\ne",
 )
-

--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -765,6 +765,7 @@ const latex_symbols = Dict(
     "\\pitchfork" => "⋔",
     "\\lessdot" => "⋖",
     "\\gtrdot" => "⋗",
+    "\\verymuchless" => "⋘",
     "\\lll" => "⋘",
     "\\ggg" => "⋙",
     "\\lesseqgtr" => "⋚",

--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -765,7 +765,7 @@ const latex_symbols = Dict(
     "\\pitchfork" => "⋔",
     "\\lessdot" => "⋖",
     "\\gtrdot" => "⋗",
-    "\\verymuchless" => "⋘",
+    "\\lll" => "⋘",
     "\\ggg" => "⋙",
     "\\lesseqgtr" => "⋚",
     "\\gtreqless" => "⋛",
@@ -2712,3 +2712,4 @@ const symbols_latex_canonical = Dict(
     "⊽" => "\\nor",
     "≠" => "\\ne",
 )
+


### PR DESCRIPTION
AMS defines `\lll` command for U+022D8 (Very Much Less-Than) character, which is more "standard" than currently defined `\verymuchless` and more consistent with using `\ggg` for U+022D9 (Very Much Greater-Than) character.

This should resolve #59387.