### PR TITLE
`eachindex` for linear indexing for `Array` and `Memory`: typeassert

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -387,7 +387,7 @@ function eachindex(A::AbstractArray, B::AbstractArray...)
     @inline
     eachindex(IndexStyle(A,B...), A, B...)
 end
-eachindex(::IndexLinear, A::Union{Array, Memory}) = unchecked_oneto(length(A))
+eachindex(::IndexLinear, A::Union{Array, Memory}) = unchecked_oneto(length(A)::Int)
 eachindex(::IndexLinear, A::AbstractArray) = (@inline; oneto(length(A)))
 eachindex(::IndexLinear, A::AbstractVector) = (@inline; axes1(A))
 function eachindex(::IndexLinear, A::AbstractArray, B::AbstractArray...)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2654,6 +2654,13 @@ let A = zeros(Int, 2, 2), B = zeros(Float64, 2, 2)
     end
 end
 
+@testset "return type inference of linear `eachindex` for `Array` and `Memory`" begin
+    f = a -> eachindex(IndexLinear(), a)
+    for typ in (Array, Memory, Union{Array, Memory})
+        @test isconcretetype(Base.infer_return_type(f, Tuple{typ}))
+    end
+end
+
 # issue #14482
 @inferred map(Int8, Int[0])
 


### PR DESCRIPTION
The method return type is known concretely as `OneTo{Int}`, however the compiler can't tell because there are too many methods matching `length(::Array)`, over the world-splitting threshold, `max_methods`.

Cross-reference WIP PR #57627, which might help here in another way by decreasing the number of unnecessary methods, however merging that PR would also cause regressions if world-splitting is not disabled first for `length` (xref WIP PR #59377).

Fix that by asserting the return type of the `length` call as `Int`.

The `typeassert` should improve abstract return type inference, and consequently make the sysimage more resistant to invalidation.