### PR TITLE
`getindex(::Array, ::Colon)`: typeassert `::Int` to help type inference

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -954,7 +954,7 @@ end
 getindex(a::Array, r::AbstractUnitRange{Bool}) = getindex(a, to_index(r))
 
 function getindex(A::Array, c::Colon)
-    lI = length(A)
+    lI = length(A)::Int
     X = similar(A, lI)
     if lI > 0
         unsafe_copyto!(X, 1, A, 1, lI)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -221,6 +221,12 @@ end
     end
 end
 
+@testset "return type inference of `getindex(::Array, ::Colon)`" begin
+    f = a -> a[:]
+    @test Vector === Base.infer_return_type(f, Tuple{Array})
+    @test Vector{Float32} === Base.infer_return_type(f, Tuple{Array{Float32}})
+end
+
 struct Z26163 <: AbstractArray{Int,0}; end
 Base.size(::Z26163) = ()
 Base.getindex(::Z26163) = 0


### PR DESCRIPTION
Fix a regression where abstract return type inference of `getindex(::Array, ::Colon)` used to produce `Any` after Julia v1.11.