### PR TITLE
`sizeof(::Array)`: typeassert `::Int` to help abstract type inference

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -232,7 +232,7 @@ function elsize(::Type{Ptr{T}}) where T
 end
 elsize(::Type{Union{}}, slurp...) = 0
 
-sizeof(a::Array) = length(a) * elsize(typeof(a)) # n.b. this ignores bitsunion bytes, as a historical fact
+sizeof(a::Array) = length(a)::Int * elsize(typeof(a)) # n.b. this ignores bitsunion bytes, as a historical fact
 
 function isassigned(a::Array, i::Int...)
     @inline

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -536,6 +536,10 @@ end
     @test_throws BoundsError badpop()
 end
 
+@testset "return type inference of `sizeof(::Array)`" begin
+    @test isconcretetype(Base.infer_return_type(sizeof, Tuple{Array}))
+end
+
 @testset "concatenation" begin
     @test isequal([fill(1.,2,2)  fill(2.,2,1)], [1. 1 2; 1 1 2])
     @test isequal([fill(1.,2,2); fill(2.,1,2)], [1. 1; 1 1; 2 2])


### PR DESCRIPTION
Fix a regression where abstract return type inference of `sizeof(::Array)` used to produce `Any` after Julia v1.11.