### PR TITLE
Fix startup when history file is bad

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1183,7 +1183,7 @@ find_hist_file() = get(ENV, "JULIA_HISTORY",
                        !isempty(DEPOT_PATH) ? joinpath(DEPOT_PATH[1], "logs", "repl_history.jl") :
                        error("DEPOT_PATH is empty and ENV[\"JULIA_HISTORY\"] not set."))
 
-backend(r::AbstractREPL) = hasproperty(r, :backendref) ? r.backendref : nothing
+backend(r::AbstractREPL) = hasproperty(r, :backendref) && isdefined(r, :backendref) ? r.backendref : nothing
 
 
 function eval_on_backend(ast, backend::REPLBackendRef)

--- a/stdlib/REPL/src/Terminals.jl
+++ b/stdlib/REPL/src/Terminals.jl
@@ -123,9 +123,18 @@ cmove_col(t::UnixTerminal, n) = (write(t.out_stream, '\r'); n > 1 && cmove_right
 if Sys.iswindows()
     function raw!(t::TTYTerminal,raw::Bool)
         if Base.ispty(t.in_stream)
-            run((raw ? `stty raw -echo onlcr -ocrnl opost` : `stty sane`),
-                t.in_stream, t.out_stream, t.err_stream)
-            true
+            try
+                run((raw ? `stty raw -echo onlcr -ocrnl opost` : `stty sane`),
+                    t.in_stream, t.out_stream, t.err_stream)
+                true
+            catch ex
+                # Fall back to ccall if stty fails (e.g., in some CI environments)
+                if ex isa ProcessFailedException
+                    ccall(:jl_tty_set_mode, Int32, (Ptr{Cvoid},Int32), t.in_stream.handle::Ptr{Cvoid}, raw) == 0
+                else
+                    rethrow()
+                end
+            end
         else
             ccall(:jl_tty_set_mode, Int32, (Ptr{Cvoid},Int32), t.in_stream.handle::Ptr{Cvoid}, raw) == 0
         end

--- a/stdlib/REPL/test/bad_history_startup.jl
+++ b/stdlib/REPL/test/bad_history_startup.jl
@@ -44,7 +44,11 @@ import .Main.FakePTYs: with_fake_pty
             @test has_disable_message
 
             # Send exit command to clean shutdown
-            write(ptm, "exit()\n")
+            if isopen(ptm)
+                write(ptm, "exit()\n")
+            else
+                @warn "PTY master is already closed before sending exit command"
+            end
 
             # Read any remaining output until the process exits
             try

--- a/stdlib/REPL/test/bad_history_startup.jl
+++ b/stdlib/REPL/test/bad_history_startup.jl
@@ -28,9 +28,9 @@ import .Main.FakePTYs: with_fake_pty
 
             # Read output until we get the prompt, which indicates successful startup
             output = readuntil(ptm, "julia> ", keep=true)
-            println("====== subprocess output ======")
-            println(output)
-            println("====== end subprocess output ======")
+            # println("====== subprocess output ======")
+            # println(output)
+            # println("====== end subprocess output ======")
 
             # Test conditions:
             # 1. We should see the invalid history file error

--- a/stdlib/REPL/test/bad_history_startup.jl
+++ b/stdlib/REPL/test/bad_history_startup.jl
@@ -28,6 +28,9 @@ import .Main.FakePTYs: with_fake_pty
 
             # Read output until we get the prompt, which indicates successful startup
             output = readuntil(ptm, "julia> ", keep=true)
+            println("====== subprocess output ======")
+            println(output)
+            println("====== end subprocess output ======")
 
             # Test conditions:
             # 1. We should see the invalid history file error

--- a/stdlib/REPL/test/bad_history_startup.jl
+++ b/stdlib/REPL/test/bad_history_startup.jl
@@ -1,0 +1,67 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Test that interactive mode starts up without error when history file is bad
+
+using Test
+
+const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
+isdefined(Main, :FakePTYs) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "FakePTYs.jl"))
+import .Main.FakePTYs: with_fake_pty
+
+@testset "Bad history file startup" begin
+    mktempdir() do tmpdir
+        # Create a bad history file
+        hist_file = joinpath(tmpdir, "repl_history.jl")
+        write(hist_file, "{ invalid json content\nmore bad content\n")
+
+        julia_exe = Base.julia_cmd()[1]
+
+        # Test interactive Julia startup with bad history file
+        with_fake_pty() do pts, ptm
+            # Set up environment with our bad history file
+            nENV = copy(ENV)
+            nENV["JULIA_HISTORY"] = hist_file
+
+            # Start Julia in interactive mode
+            p = run(detach(setenv(`$julia_exe --startup-file=no --color=no -q`, nENV)), pts, pts, pts, wait=false)
+            Base.close_stdio(pts)
+
+            # Read output until we get the prompt, which indicates successful startup
+            output = readuntil(ptm, "julia> ", keep=true)
+
+            # Test conditions:
+            # 1. We should see the invalid history file error
+            has_history_error = occursin("Invalid history file", output) ||
+                              occursin("Invalid character", output)
+            @test has_history_error
+
+            # 2. We should NOT see UndefRefError (the bug being fixed)
+            has_undef_error = occursin("UndefRefError", output)
+            @test !has_undef_error
+
+            # 3. We should see the "Disabling history file" message if the fix works
+            has_disable_message = occursin("Disabling history file for this session", output)
+            @test has_disable_message
+
+            # Send exit command to clean shutdown
+            write(ptm, "exit()\n")
+
+            # Read any remaining output until the process exits
+            try
+                read(ptm, String)
+            catch ex
+                # Handle platform-specific EOF behavior
+                if ex isa Base.IOError && ex.code == Base.UV_EIO
+                    # This is expected on some platforms (e.g., Linux)
+                else
+                    rethrow()
+                end
+            end
+
+            # Wait for process to finish
+            wait(p)
+
+            @test p.exitcode == 0
+        end
+    end
+end

--- a/stdlib/REPL/test/runtests.jl
+++ b/stdlib/REPL/test/runtests.jl
@@ -22,6 +22,9 @@ end
 module TerminalMenusTest
     include("TerminalMenus/runtests.jl")
 end
+module BadHistoryStartupTest
+    include("bad_history_startup.jl")
+end
 
 # Restore the original environment
 for k in keys(ENV)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/59406

```
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.13.0-DEV.1029 (2025-08-25)
 _/ |\__'_|_|_|\__'_|  |  ib/bad_history/ce2abad158* (fork: 1 commits, 5 days)
|__/                   |

ERROR: Invalid history file (/tmp/broken_history.jl) format:
If you have a history file left over from an older version of Julia,
try renaming or deleting it.
Invalid character: '{' at line 1
Stacktrace:
 [1] error(::String, ::String, ::String, ::Int64)
   @ Base ./error.jl:54
 [2] hist_from_file(hp::REPL.REPLHistoryProvider, path::String)
   @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:910
 [3] setup_interface(repl::LineEditREPL, hascolor::Bool, extra_repl_keymap::Any)
   @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:1410
 [4] setup_interface
   @ ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:1281 [inlined]
 [5] run_frontend(repl::LineEditREPL, backend::REPL.REPLBackendRef)
   @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:1695
 [6] (::REPL.var"#61#62"{LineEditREPL, REPL.REPLBackendRef})()
   @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.13/REPL/src/REPL.jl:678

[ Info: Disabling history file for this session
julia> 
```