### PR TITLE
codegen: fix bug in jl_set_ptls_rng

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1707,8 +1707,8 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         const int rng_offset = offsetof(jl_tls_states_t, rngseed);
         Value *rng_ptr = ctx.builder.CreateInBoundsGEP(getInt8Ty(ctx.builder.getContext()), ptls_p, ConstantInt::get(ctx.types().T_size, rng_offset / sizeof(int8_t)));
         setName(ctx.emission_context, rng_ptr, "rngseed_ptr");
-        assert(argv[0].V->getType() == getInt64Ty(ctx.builder.getContext()));
-        auto store = ctx.builder.CreateAlignedStore(argv[0].V, rng_ptr, Align(sizeof(void*)));
+        Value *val64 = emit_unbox(ctx, getInt64Ty(ctx.builder.getContext()), argv[0], (jl_value_t*)jl_uint64_type);
+        auto store = ctx.builder.CreateAlignedStore(val64, rng_ptr, Align(sizeof(void*)));
         jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
         ai.decorateInst(store);
         return ghostValue(ctx, jl_nothing_type);


### PR DESCRIPTION
This is not an Int64Ty, but can be converted to one, which made this
code brittle. It also appears that no other ccall optimization makes
this mistake, so this was the only one that needed to be fixed.
