### PR TITLE
Correctly set the variant bits of uuid1

### DIFF
--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -74,8 +74,8 @@ function _build_uuid1(rng::AbstractRNG, timestamp::UInt64)
     # mask off clock sequence and node
     u &= 0x00000000000000003fffffffffffffff
 
-    # set the unicast/multicast bit and version
-    u |= 0x00000000000010000000010000000000
+    # set the version, variant, and unicast/multicast bit
+    u |= 0x00000000000010008000010000000000
 
     ts_low = timestamp & typemax(UInt32)
     ts_mid = (timestamp >> 32) & typemax(UInt16)

--- a/stdlib/UUIDs/test/runtests.jl
+++ b/stdlib/UUIDs/test/runtests.jl
@@ -42,6 +42,15 @@ u7 = uuid7()
     @test uuid_version(u7) == 7
 end
 
+@testset "Extraction of variant bits" begin
+    # RFC 4122, section 4.1.1
+    uuid_variant(u::UUID) = Int((u.value >> 62) & 0x3)
+    @test uuid_variant(u1) == 2
+    @test uuid_variant(u4) == 2
+    @test uuid_variant(u5) == 2
+    @test uuid_variant(u7) == 2
+end
+
 @testset "Parsing from string" begin
     @test u1 == UUID(string(u1)) == UUID(GenericString(string(u1)))
     @test u4 == UUID(string(u4)) == UUID(GenericString(string(u4)))


### PR DESCRIPTION
The `uuid1` function has been incorrect since it was added to Base in Julia 0.4, in that it fails to set the variant bits specified in section 4.1.1 of RFC 4122. This is fixed in this PR and a test is added.

The other implemented uuid versions are doing this correctly.
