### PR TITLE
Fixup ccall docstring

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -441,11 +441,18 @@ The string literal could also be used directly before the function
 name, if desired `"libglib-2.0".g_uri_escape_string(...`
 
 It's possible to declare the ccall as `gc_safe` by using the `gc_safe = true` option:
+
     @ccall gc_safe=true strlen(s::Cstring)::Csize_t
+
 This allows the garbage collector to run concurrently with the ccall, which can be useful whenever
 the `ccall` may block outside of julia.
-WARNING: This option should be used with caution, as it can lead to undefined behavior if the ccall
-calls back into the julia runtime. (`@cfunction`/`@ccallables` are safe however)
+
+!!! warning
+	This option should be used with caution, as it can lead to undefined behavior if the ccall
+	calls back into the julia runtime. (`@cfunction`/`@ccallables` are safe however)
+
+!!! compat "Julia 1.12"
+	The `gc_safe` argument requires Julia 1.12 or higher.
 """
 macro ccall(exprs...)
     return ccall_macro_lower((:ccall), ccall_macro_parse(exprs)...)

--- a/base/c.jl
+++ b/base/c.jl
@@ -448,11 +448,11 @@ This allows the garbage collector to run concurrently with the ccall, which can 
 the `ccall` may block outside of julia.
 
 !!! warning
-	This option should be used with caution, as it can lead to undefined behavior if the ccall
-	calls back into the julia runtime. (`@cfunction`/`@ccallables` are safe however)
+    This option should be used with caution, as it can lead to undefined behavior if the ccall
+    calls back into the julia runtime. (`@cfunction`/`@ccallables` are safe however)
 
 !!! compat "Julia 1.12"
-	The `gc_safe` argument requires Julia 1.12 or higher.
+    The `gc_safe` argument requires Julia 1.12 or higher.
 """
 macro ccall(exprs...)
     return ccall_macro_lower((:ccall), ccall_macro_parse(exprs)...)


### PR DESCRIPTION
* Fix formatting
* Add a compat note of Julia 1.12 to the new `gc_safe` option. 