### PR TITLE
precompile: fix a number of mistakes in handling precompiled code instance caches

### DIFF
--- a/Compiler/src/bindinginvalidations.jl
+++ b/Compiler/src/bindinginvalidations.jl
@@ -188,7 +188,7 @@ function scan_new_method!(method::Method, image_backedges_only::Bool)
     @atomic method.did_scan_source |= 0x1
 end
 
-function scan_new_methods!(extext_methods::Vector{Any}, internal_methods::Vector{Any}, image_backedges_only::Bool)
+function scan_new_methods!(internal_methods::Vector{Any}, image_backedges_only::Bool)
     if image_backedges_only && generating_output(true)
         # Replacing image bindings is forbidden during incremental precompilation - skip backedge insertion
         return
@@ -197,8 +197,5 @@ function scan_new_methods!(extext_methods::Vector{Any}, internal_methods::Vector
         if isa(method, Method)
            scan_new_method!(method, image_backedges_only)
         end
-    end
-    for tme::Core.TypeMapEntry in extext_methods
-        scan_new_method!(tme.func::Method, image_backedges_only)
     end
 end

--- a/Compiler/src/precompile.jl
+++ b/Compiler/src/precompile.jl
@@ -426,9 +426,6 @@ function compile_and_emit_native(worlds::Vector{UInt},
         invokelatest(exit, 1)
     end
 
-    # Step 5: Always set newly_inferred global for serialization use
-    #ccall(:jl_set_newly_inferred, Cvoid, (Any,), filter(ci -> ci isa CodeInstance, codeinfos))
-
     return codeinfos
 
 end

--- a/Compiler/src/precompile.jl
+++ b/Compiler/src/precompile.jl
@@ -308,33 +308,28 @@ end
 function enqueue_specialization!(all::Bool, worklist, mi::Core.MethodInstance)
     # Translation of precompile_enq_specialization_ from C
     codeinst = isdefined(mi, :cache) ? mi.cache : nothing
-
     while codeinst !== nothing
         do_compile = false
-
         if codeinst.owner !== nothing
             # TODO(vchuravy) native code caching for foreign interpreters
             # Skip foreign code instances
-        elseif !use_const_api(codeinst) # Check if invoke is not jl_fptr_const_return
-            if codeinst.invoke != C_NULL || codeinst.precompile
+        elseif use_const_api(codeinst) # Check if invoke is jl_fptr_const_return
+            do_compile = true
+        elseif codeinst.invoke != C_NULL || codeinst.precompile
+            do_compile = true
+        elseif !do_compile && isdefined(codeinst, :inferred)
+            inferred = codeinst.inferred
+            # Check compilation options and inlining cost
+            if (all || inferred === nothing ||
+                ((isa(inferred, String) || isa(inferred, CodeInfo) || isa(inferred, UInt8)) &&
+                 ccall(:jl_ir_inlining_cost, UInt16, (Any,), inferred) == typemax(UInt16)))
                 do_compile = true
             end
-            if !do_compile && isdefined(codeinst, :inferred)
-                inferred = codeinst.inferred
-                # Check compilation options and inlining cost
-                if (all || inferred === nothing ||
-                    ((isa(inferred, String) || isa(inferred, CodeInfo) || isa(inferred, UInt8)) &&
-                     ccall(:jl_ir_inlining_cost, UInt16, (Any,), inferred) == typemax(UInt16)))
-                    do_compile = true
-                end
-            end
         end
-
         if do_compile
             push!(worklist, mi)
             return true
         end
-
         # Move to the next code instance in the chain
         codeinst = isdefined(codeinst, :next) ? codeinst.next : nothing
     end

--- a/Compiler/src/reinfer.jl
+++ b/Compiler/src/reinfer.jl
@@ -2,10 +2,11 @@
 
 using ..Compiler.Base
 using ..Compiler: _findsup, store_backedges, JLOptions, get_world_counter,
-    _methods_by_ftype, get_methodtable, get_ci_mi, ci_has_abi, should_instrument,
+    _methods_by_ftype, get_methodtable, get_ci_mi, should_instrument,
     morespecific, RefValue, get_require_world, Vector, IdDict
 using .Core: CodeInstance, MethodInstance
 
+const CI_FLAGS_NATIVE_CACHE_VALID = 0b1000
 const WORLD_AGE_REVALIDATION_SENTINEL::UInt = 1
 const _jl_debug_method_invalidation = RefValue{Union{Nothing,Vector{Any}}}(nothing)
 debug_method_invalidation(onoff::Bool) =
@@ -53,8 +54,7 @@ end
 function VerifyMethodInitialState(codeinst::CodeInstance)
     mi = get_ci_mi(codeinst)
     def = mi.def::Method
-    callees = codeinst.edges
-    VerifyMethodInitialState(codeinst, mi, def, callees)
+    VerifyMethodInitialState(codeinst, mi, def, codeinst.edges)
 end
 
 function VerifyMethodWorkState(dummy_cause::CodeInstance)
@@ -68,17 +68,13 @@ end
 
 # Restore backedges to external targets
 # `edges` = [caller1, ...], the list of worklist-owned code instances internally
-# `ext_ci_list` = [caller1, ...], the list of worklist-owned code instances externally
-function insert_backedges(ext_ci_list::Union{Nothing,Vector{Any}}, internal_methods::Vector{Any})
+function insert_backedges(internal_methods::Vector{Any})
     # determine which CodeInstance objects are still valid in our image
     # to enable any applicable new codes
     backedges_only = unsafe_load(cglobal(:jl_first_image_replacement_world, UInt)) == typemax(UInt)
     scan_new_methods!(internal_methods, backedges_only)
     workspace = VerifyMethodWorkspace()
     scan_new_code!(internal_methods, workspace)
-    if ext_ci_list !== nothing
-        insert_ext_cache(ext_ci_list)
-    end
     nothing
 end
 
@@ -96,35 +92,19 @@ function scan_new_code!(internal_methods::Vector{Any}, workspace::VerifyMethodWo
     end
 end
 
-function insert_ext_cache(edges::Vector{Any})
-    for i = 1:length(edges)
-        codeinst = edges[i]::CodeInstance
-        minvalid = codeinst.min_world
-        maxvalid = codeinst.max_world
-        # Finally, if this CI is still valid in some world age and belongs to an external method(specialization),
-        # poke it in that mi's cache, unless there is already one there that has an invoke pointer
-        if maxvalid ≥ minvalid
-            caller = get_ci_mi(codeinst)
-            @assert isdefined(codeinst, :inferred) # See #53586, #53109
-            inferred = @ccall jl_rettype_inferred(
-                codeinst.owner::Any, caller::Any, minvalid::UInt, maxvalid::UInt)::Any
-            if inferred !== nothing && (ci_has_abi(inferred::CodeInstance) || !ci_has_abi(codeinst))
-                # We already got a code instance for this world age range from
-                # somewhere else - we don't need this one.
-            else
-                @ccall jl_mi_cache_insert(caller::Any, codeinst::Any)::Cvoid
-            end
-        end
-    end
-end
-
 function verify_method_graph(codeinst::CodeInstance, validation_world::UInt, workspace::VerifyMethodWorkspace)
-    @assert isempty(workspace.stack); @assert isempty(workspace.visiting);
-    @assert isempty(workspace.initial_states); @assert isempty(workspace.work_states); @assert isempty(workspace.result_states)
+    @assert isempty(workspace.stack) "workspace corrupted"
+    @assert isempty(workspace.visiting) "workspace corrupted"
+    @assert isempty(workspace.initial_states) "workspace corrupted"
+    @assert isempty(workspace.work_states) "workspace corrupted"
+    @assert isempty(workspace.result_states) "workspace corrupted"
     child_cycle, minworld, maxworld = verify_method(codeinst, validation_world, workspace)
     @assert child_cycle == 0
-    @assert isempty(workspace.stack); @assert isempty(workspace.visiting);
-    @assert isempty(workspace.initial_states); @assert isempty(workspace.work_states); @assert isempty(workspace.result_states)
+    @assert isempty(workspace.stack) "workspace corrupted"
+    @assert isempty(workspace.visiting) "workspace corrupted"
+    @assert isempty(workspace.initial_states) "workspace corrupted"
+    @assert isempty(workspace.work_states) "workspace corrupted"
+    @assert isempty(workspace.result_states) "workspace corrupted"
     nothing
 end
 
@@ -206,10 +186,8 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
                 continue
             end
 
-            minworld, maxworld = get_require_world(), validation_world
-
             if haskey(workspace.visiting, initial.codeinst)
-                workspace.result_states[current_depth] = VerifyMethodResultState(workspace.visiting[initial.codeinst], minworld, maxworld)
+                workspace.result_states[current_depth] = VerifyMethodResultState(workspace.visiting[initial.codeinst], UInt(1), validation_world)
                 workspace.work_states[current_depth] = VerifyMethodWorkState(work.depth, work.cause, work.recursive_index, :return_to_parent)
                 continue
             end
@@ -217,6 +195,9 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
             push!(workspace.stack, initial.codeinst)
             depth = length(workspace.stack)
             workspace.visiting[initial.codeinst] = depth
+
+            # unable to backdate before require_world, since Bindings are not able to track that information
+            minworld, maxworld = get_require_world(), validation_world
 
             # Check for invalidation of GlobalRef edges
             if (initial.def.did_scan_source & 0x1) == 0x0
@@ -238,7 +219,7 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
                 while j <= length(initial.callees)
                     local min_valid2::UInt, max_valid2::UInt
                     edge = initial.callees[j]
-                    @assert !(edge isa Method)
+                    @assert !(edge isa Method) "unexpected Method edge indicates corrupt edges list creation"
 
                     if edge isa CodeInstance
                         # Convert CodeInstance to MethodInstance for validation (like original)
@@ -342,12 +323,16 @@ function verify_method(codeinst::CodeInstance, validation_world::UInt, workspace
                     child = pop!(workspace.stack)
                     if result.result_maxworld ≠ 0
                         @atomic :monotonic child.min_world = result.result_minworld
+                        # Finally, if this CI is still valid in some world age and marked as valid in the native cache, poke it in that mi's cache now
+                        if child.flags & CI_FLAGS_NATIVE_CACHE_VALID == CI_FLAGS_NATIVE_CACHE_VALID
+                            @ccall jl_mi_cache_insert(get_ci_mi(child)::Any, child::Any)::Cvoid
+                        end
                     end
                     @atomic :monotonic child.max_world = result.result_maxworld
-                    if result.result_maxworld == validation_world && validation_world == get_world_counter()
+                    if result.result_maxworld == validation_world && validation_world == get_world_counter() && isdefined(child, :edges)
                         store_backedges(child, child.edges)
                     end
-                    @assert workspace.visiting[child] == length(workspace.stack) + 1
+                    @assert workspace.visiting[child] == length(workspace.stack) + 1 "internal error maintaining workspace"
                     delete!(workspace.visiting, child)
                     invalidations = _jl_debug_method_invalidation[]
                     if invalidations !== nothing && result.result_maxworld < validation_world
@@ -509,7 +494,7 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
                 # Fast path is legal when fully_covers=true
                 if fully_covers && !iszero(mi.dispatch_status & METHOD_SIG_LATEST_ONLY)
                     minworld = meth.primary_world
-                    @assert minworld ≤ world
+                    @assert minworld ≤ world "expected method not present in verification world"
                     maxworld = typemax(UInt)
                     return minworld, maxworld
                 end
@@ -517,7 +502,7 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
             # Fast path is legal when fully_covers=true
             if fully_covers && !iszero(meth.dispatch_status & METHOD_SIG_LATEST_ONLY)
                 minworld = meth.primary_world
-                @assert minworld ≤ world
+                @assert minworld ≤ world "expected method not present in verification world"
                 maxworld = typemax(UInt)
                 return minworld, maxworld
             end
@@ -575,7 +560,7 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
             end
             if interference_fast_path_success
                 # All interference sets are covered by expecteds, can return success
-                @assert interference_minworld ≤ world
+                @assert interference_minworld ≤ world "expected method not present in verification world"
                 maxworld = typemax(UInt)
                 return interference_minworld, maxworld
             end
@@ -636,13 +621,13 @@ const METHOD_SIG_LATEST_WHICH = 0x1
 const METHOD_SIG_LATEST_ONLY = 0x2
 
 function verify_invokesig(@nospecialize(invokesig), expected::Method, world::UInt, matches::Vector{Any})
-    @assert invokesig isa Type
+    @assert invokesig isa Type "corrupt edges list"
     local minworld::UInt, maxworld::UInt
     empty!(matches)
     if invokesig === expected.sig && !iszero(expected.dispatch_status & METHOD_SIG_LATEST_WHICH)
         # the invoke match is `expected` for `expected->sig`, unless `expected` is replaced
         minworld = expected.primary_world
-        @assert minworld ≤ world
+        @assert minworld ≤ world "expected method not present in verification world"
         maxworld = typemax(UInt)
     else
         mt = get_methodtable(expected)
@@ -667,7 +652,7 @@ function verify_invokesig(@nospecialize(invokesig), expected::Method, world::UIn
 end
 
 # Wrapper to call insert_backedges in typeinf_world for external calls
-function insert_backedges_typeinf(ext_ci_list::Union{Nothing,Vector{Any}}, internal_methods::Vector{Any})
-    args = Any[insert_backedges, ext_ci_list, internal_methods]
+function insert_backedges_typeinf(internal_methods::Vector{Any})
+    args = Any[insert_backedges, internal_methods]
     return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Any}, Cint), args, length(args))
 end

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1288,6 +1288,8 @@ prepared interp to be able to provide source code for it.
 """
 const SOURCE_MODE_GET_SOURCE = 0xf
 
+ci_has_abi(code::CodeInstance) = (@atomic :acquire code.invoke) !== C_NULL
+
 """
     ci_has_abi(interp::AbstractInterpreter, code::CodeInstance)
 
@@ -1296,7 +1298,7 @@ interp gave it to the runtime system (either because it already has an ->invoke
 ptr, or because interp has source that could be compiled).
 """
 function ci_has_abi(interp::AbstractInterpreter, code::CodeInstance)
-    (@atomic :acquire code.invoke) !== C_NULL && return true
+    ci_has_abi(code) && return true
     return ci_has_source(interp, code)
 end
 

--- a/Compiler/test/invalidation.jl
+++ b/Compiler/test/invalidation.jl
@@ -120,13 +120,13 @@ begin
         # Base.method_instance(pr48932_callee, (Any,))
         ci = mi.cache
         @test isdefined(ci, :next)
-        @test ci.owner === InvalidationTesterToken()
+        @test ci.owner === nothing
         @test ci.max_world == typemax(UInt)
 
         # In cache due to Base.return_types(pr48932_callee, (Any,))
         ci = ci.next
         @test !isdefined(ci, :next)
-        @test ci.owner === nothing
+        @test ci.owner === InvalidationTesterToken()
         @test ci.max_world == typemax(UInt)
     end
     let mi = Base.method_instance(pr48932_caller, (Int,))
@@ -150,11 +150,11 @@ begin
         # Base.method_instance(pr48932_callee, (Any,))
         ci = mi.cache
         @test isdefined(ci, :next)
-        @test ci.owner === nothing
+        @test ci.owner === InvalidationTesterToken()
         @test_broken ci.max_world == typemax(UInt)
         ci = ci.next
         @test !isdefined(ci, :next)
-        @test ci.owner === InvalidationTesterToken()
+        @test ci.owner === nothing
         @test_broken ci.max_world == typemax(UInt)
     end
 
@@ -224,11 +224,11 @@ begin take!(GLOBAL_BUFFER)
     let mi = only(Base.specializations(Base.only(Base.methods(pr48932_callee_inferable))))
         ci = mi.cache
         @test isdefined(ci, :next)
-        @test ci.owner === InvalidationTesterToken()
+        @test ci.owner === nothing
         @test ci.max_world == typemax(UInt)
         ci = ci.next
         @test !isdefined(ci, :next)
-        @test ci.owner === nothing
+        @test ci.owner === InvalidationTesterToken()
         @test ci.max_world == typemax(UInt)
     end
     let mi = Base.method_instance(pr48932_caller_unuse, (Int,))
@@ -249,11 +249,11 @@ begin take!(GLOBAL_BUFFER)
     let mi = Base.method_instance(pr48932_caller_unuse, (Int,))
         ci = mi.cache
         @test isdefined(ci, :next)
-        @test ci.owner === nothing
+        @test ci.owner === InvalidationTesterToken()
         @test_broken ci.max_world == typemax(UInt)
         ci = ci.next
         @test !isdefined(ci, :next)
-        @test ci.owner === InvalidationTesterToken()
+        @test ci.owner === nothing
         @test_broken ci.max_world == typemax(UInt)
     end
     @test isnothing(pr48932_caller_unuse(42))
@@ -284,11 +284,11 @@ begin take!(GLOBAL_BUFFER)
     let mi = Base.method_instance(pr48932_callee_inlined, (Int,))
         ci = mi.cache
         @test isdefined(ci, :next)
-        @test ci.owner === InvalidationTesterToken()
+        @test ci.owner === nothing
         @test ci.max_world == typemax(UInt)
         ci = ci.next
         @test !isdefined(ci, :next)
-        @test ci.owner === nothing
+        @test ci.owner === InvalidationTesterToken()
         @test ci.max_world == typemax(UInt)
     end
     let mi = Base.method_instance(pr48932_caller_inlined, (Int,))
@@ -309,11 +309,11 @@ begin take!(GLOBAL_BUFFER)
     let mi = Base.method_instance(pr48932_caller_inlined, (Int,))
         ci = mi.cache
         @test isdefined(ci, :next)
-        @test ci.owner === nothing
+        @test ci.owner === InvalidationTesterToken()
         @test ci.max_world != typemax(UInt)
         ci = ci.next
         @test !isdefined(ci, :next)
-        @test ci.owner === InvalidationTesterToken()
+        @test ci.owner === nothing
         @test ci.max_world != typemax(UInt)
     end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1283,10 +1283,9 @@ function _include_from_serialized(pkg::PkgId, path::String, ocachepath::Union{No
         end
 
         sv = sv::SimpleVector
-        ext_edges = sv[3]::Union{Nothing,Vector{Any}}
-        internal_methods = sv[4]::Vector{Any}
+        internal_methods = sv[3]::Vector{Any}
         Compiler.@zone "CC: INSERT_BACKEDGES" begin
-            ReinferUtils.insert_backedges_typeinf(ext_edges, internal_methods)
+            ReinferUtils.insert_backedges_typeinf(internal_methods)
         end
         restored = register_restored_modules(sv, pkg, path)
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1283,12 +1283,10 @@ function _include_from_serialized(pkg::PkgId, path::String, ocachepath::Union{No
         end
 
         sv = sv::SimpleVector
-        edges = sv[3]::Vector{Any}
-        ext_edges = sv[4]::Union{Nothing,Vector{Any}}
-        extext_methods = sv[5]::Vector{Any}
-        internal_methods = sv[6]::Vector{Any}
+        ext_edges = sv[3]::Union{Nothing,Vector{Any}}
+        internal_methods = sv[4]::Vector{Any}
         Compiler.@zone "CC: INSERT_BACKEDGES" begin
-            ReinferUtils.insert_backedges_typeinf(edges, ext_edges, extext_methods, internal_methods)
+            ReinferUtils.insert_backedges_typeinf(ext_edges, internal_methods)
         end
         restored = register_restored_modules(sv, pkg, path)
 

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -92,7 +92,7 @@ void jl_get_function_id_impl(void *native_code, jl_code_instance_t *codeinst,
 }
 
 extern "C" JL_DLLEXPORT_CODEGEN void
-jl_get_llvm_mis_impl(void *native_code, size_t *num_elements, jl_method_instance_t **data)
+jl_get_llvm_cis_impl(void *native_code, size_t *num_elements, jl_code_instance_t **data)
 {
     jl_native_code_desc_t *desc = (jl_native_code_desc_t *)native_code;
     auto &map = desc->jl_fvar_map;
@@ -105,7 +105,7 @@ jl_get_llvm_mis_impl(void *native_code, size_t *num_elements, jl_method_instance
     assert(*num_elements == map.size());
     size_t i = 0;
     for (auto &ci : map) {
-        data[i++] = jl_get_ci_mi(ci.first);
+        data[i++] = ci.first;
     }
 }
 

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -897,7 +897,7 @@ void *jl_emit_native_impl(jl_array_t *codeinfos, LLVMOrcThreadSafeModuleRef llvm
                 jl_callptr_t invoke;
                 void *fptr;
                 jl_read_codeinst_invoke(this_code, &specsigflags, &invoke, &fptr, 0);
-                if (invoke != NULL && (specsigflags & 0b100)) {
+                if (invoke != NULL && (specsigflags & JL_CI_FLAGS_FROM_IMAGE)) {
                     // this codeinst is already available externally: keep it only if canPartition demands it for local use
                     // TODO: for performance, avoid generating the src code when we know it would reach here anyways?
                     if (M.withModuleDo([&](Module &M) { return !canPartition(*cast<Function>(M.getNamedValue(cfunc))); })) {

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -13,10 +13,10 @@
 JL_DLLEXPORT void jl_dump_native_fallback(void *native_code,
         const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *asm_fname,
         ios_t *z, ios_t *s) UNAVAILABLE
-JL_DLLEXPORT void jl_get_llvm_gvs_fallback(void *native_code, arraylist_t *gvs) UNAVAILABLE
-JL_DLLEXPORT void jl_get_llvm_gv_inits_fallback(void *native_code, arraylist_t *inits) UNAVAILABLE
-JL_DLLEXPORT void jl_get_llvm_external_fns_fallback(void *native_code, arraylist_t *gvs) UNAVAILABLE
-JL_DLLEXPORT void jl_get_llvm_mis_fallback(void *native_code, arraylist_t* MIs) UNAVAILABLE
+JL_DLLEXPORT void jl_get_llvm_gvs_fallback(void *native_code, size_t *num, void **gvs) UNAVAILABLE
+JL_DLLEXPORT void jl_get_llvm_gv_inits_fallback(void *native_code, size_t *num, void **inits) UNAVAILABLE
+JL_DLLEXPORT void jl_get_llvm_external_fns_fallback(void *native_code, size_t *num, void **gvs) UNAVAILABLE
+JL_DLLEXPORT void jl_get_llvm_cis_fallback(void *native_code, size_t *num, void **CIs) UNAVAILABLE
 
 JL_DLLEXPORT jl_value_t *jl_dump_method_asm_fallback(jl_method_instance_t *linfo, size_t world,
         char emit_mc, char getwrapper, const char* asm_variant, const char *debuginfo, char binary) UNAVAILABLE

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5259,11 +5259,11 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, ArrayR
                             jl_callptr_t invoke;
                             void *fptr;
                             jl_read_codeinst_invoke(codeinst, &specsigflags, &invoke, &fptr, 0);
-                            if (specsig ? specsigflags & 0b1 : invoke == jl_fptr_args_addr) {
+                            if (specsig ? specsigflags & JL_CI_FLAGS_SPECPTR_SPECIALIZED : invoke == jl_fptr_args_addr) {
                                 if (ctx.external_linkage) {
                                     // TODO: Add !specsig support to aotcompile.cpp
                                     // Check that the codeinst is containing native code
-                                    if (specsig && (specsigflags & 0b100)) {
+                                    if (specsig && (specsigflags & JL_CI_FLAGS_FROM_IMAGE)) {
                                         external = !always_inline;
                                         need_to_emit = false;
                                     }

--- a/src/gf.c
+++ b/src/gf.c
@@ -327,9 +327,11 @@ jl_method_t *jl_mk_builtin_func(jl_datatype_t *dt, jl_sym_t *sname, jl_fptr_args
     jl_atomic_store_relaxed(&m->unspecialized, mi);
     jl_gc_wb(m, mi);
 
+    jl_debuginfo_t *di = NULL;
+    jl_svec_t *edges = jl_emptysvec;
     jl_code_instance_t *codeinst = jl_new_codeinst(mi, jl_nothing,
         (jl_value_t*)jl_any_type, (jl_value_t*)jl_any_type, jl_nothing, jl_nothing,
-        0, 1, ~(size_t)0, 0, jl_nothing, NULL, NULL);
+        0, 1, ~(size_t)0, 0, jl_nothing, di, edges);
     jl_atomic_store_relaxed(&codeinst->specptr.fptr1, fptr);
     jl_atomic_store_relaxed(&codeinst->invoke, jl_fptr_args);
     jl_mi_cache_insert(mi, codeinst);
@@ -663,7 +665,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
     codeinst->time_infer_total = 0;
     codeinst->time_infer_self = 0;
     jl_atomic_store_relaxed(&codeinst->time_compile, 0);
-    jl_atomic_store_relaxed(&codeinst->specsigflags, 0);
+    jl_atomic_store_relaxed(&codeinst->flags, 0);
     jl_atomic_store_relaxed(&codeinst->precompile, 0);
     jl_atomic_store_relaxed(&codeinst->next, NULL);
     jl_atomic_store_relaxed(&codeinst->ipo_purity_bits, effects);
@@ -751,12 +753,57 @@ JL_DLLEXPORT void jl_mi_cache_insert(jl_method_instance_t *mi JL_ROOTING_ARGUMEN
     JL_GC_PUSH1(&ci);
     if (jl_is_method(mi->def.method))
         JL_LOCK(&mi->def.method->writelock);
-    jl_code_instance_t *oldci = jl_atomic_load_relaxed(&mi->cache);
-    jl_atomic_store_relaxed(&ci->next, oldci);
-    if (oldci)
-        jl_gc_wb(ci, oldci);
-    jl_atomic_store_release(&mi->cache, ci);
-    jl_gc_wb(mi, ci);
+    // Set native_cache_valid bit when inserting into cache
+    jl_atomic_fetch_or_relaxed(&ci->flags, JL_CI_FLAGS_NATIVE_CACHE_VALID);
+    // find the preferred location for insertion of ci now:
+    //   - invoke+inferred group
+    //   - inferred group
+    //   - others group
+    //   - unmoved
+    //   - after existing entries with same applicable range
+    jl_value_t *parent = (jl_value_t*)mi;
+    _Atomic(jl_code_instance_t*) *slot = &mi->cache;
+    jl_code_instance_t *oldci = jl_atomic_load_relaxed(slot);
+    int hasinvoke = jl_atomic_load_relaxed(&ci->invoke) != NULL;
+    int hasinferred = jl_atomic_load_relaxed(&ci->inferred) != NULL;
+    size_t max_world = jl_atomic_load_relaxed(&ci->max_world);
+    jl_code_instance_t *next = jl_atomic_load_relaxed(&ci->next);
+    while (oldci) {
+        if (oldci == ci)
+            break;
+        int old_hasinvoke = jl_atomic_load_relaxed(&oldci->invoke) != NULL;
+        int old_hasinferred = jl_atomic_load_relaxed(&oldci->inferred) != NULL;
+        size_t old_max_world = jl_atomic_load_relaxed(&oldci->max_world);
+        if (hasinvoke && !old_hasinvoke)
+            break;
+        if (hasinferred && !old_hasinferred)
+            break;
+        if (next == NULL && old_max_world < max_world)
+            break;
+        parent = (jl_value_t*)oldci;
+        slot = &oldci->next;
+        oldci = jl_atomic_load_relaxed(slot);
+    }
+    if (oldci != ci) {
+        jl_atomic_store_relaxed(&ci->next, oldci);
+        if (oldci)
+            jl_gc_wb(ci, oldci);
+        jl_atomic_store_release(slot, ci);
+        jl_gc_wb(parent, ci);
+        if (oldci != NULL) {
+            // list is now potentially circular, need to go find old pointer to ci starting from oldci and insert next there
+            do {
+                parent = (jl_value_t*)oldci;
+                slot = &oldci->next;
+                oldci = jl_atomic_load_relaxed(slot);
+            } while (oldci && oldci != ci);
+            if (oldci) {
+                jl_atomic_store_release(slot, next);
+                if (next)
+                    jl_gc_wb(parent, next);
+            }
+        }
+    }
     if (jl_is_method(mi->def.method))
         JL_UNLOCK(&mi->def.method->writelock);
     JL_GC_POP();
@@ -3396,7 +3443,7 @@ static void record_dispatch_statement_on_first_dispatch(jl_method_instance_t *mf
 // but merely causes it to look into the current JIT worklist.
 void jl_read_codeinst_invoke(jl_code_instance_t *ci, uint8_t *specsigflags, jl_callptr_t *invoke, void **specptr, int waitcompile)
 {
-    uint8_t flags = jl_atomic_load_acquire(&ci->specsigflags); // happens-before for subsequent read of fptr
+    uint8_t flags = jl_atomic_load_acquire(&ci->flags); // happens-before for subsequent read of fptr
     while (1) {
         jl_callptr_t initial_invoke = jl_atomic_load_acquire(&ci->invoke); // happens-before for subsequent read of fptr
         if (initial_invoke == jl_fptr_wait_for_compiled_addr) {
@@ -3417,9 +3464,9 @@ void jl_read_codeinst_invoke(jl_code_instance_t *ci, uint8_t *specsigflags, jl_c
             *specsigflags = 0b00;
             return;
         }
-        while (!(flags & 0b10)) {
+        while (!(flags & JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR)) {
             jl_cpu_pause();
-            flags = jl_atomic_load_acquire(&ci->specsigflags);
+            flags = jl_atomic_load_acquire(&ci->flags);
         }
         jl_callptr_t final_invoke = jl_atomic_load_relaxed(&ci->invoke);
         if (final_invoke == initial_invoke) {
@@ -3473,14 +3520,13 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
                 void *prev_fptr = NULL;
                 // see jitlayers.cpp for the ordering restrictions here
                 if (jl_atomic_cmpswap_acqrel(&codeinst->specptr.fptr, &prev_fptr, fptr)) {
-                    jl_atomic_store_relaxed(&codeinst->specsigflags, specsigflags & 0b1);
                     jl_atomic_store_release(&codeinst->invoke, invoke);
                     // unspec is probably not specsig, but might be using specptr
-                    jl_atomic_store_release(&codeinst->specsigflags, specsigflags & ~0b1); // clear specsig flag
+                    jl_atomic_fetch_or_relaxed(&codeinst->flags, JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR);
                 }
                 else {
                     // someone else already compiled it
-                    while (!(jl_atomic_load_acquire(&codeinst->specsigflags) & 0b10)) {
+                    while (!(jl_atomic_load_acquire(&codeinst->flags) & JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR)) {
                         jl_cpu_pause();
                     }
                     // codeinst is now set up fully, safe to return
@@ -3519,14 +3565,16 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
                     jl_callptr_t invoke;
                     void *fptr;
                     jl_read_codeinst_invoke(unspec, &specsigflags, &invoke, &fptr, 1);
+                    jl_debuginfo_t *di = NULL;
+                    jl_svec_t *edges = jl_emptysvec;
                     jl_code_instance_t *codeinst = jl_new_codeinst(mi, jl_nothing,
                         (jl_value_t*)jl_any_type, (jl_value_t*)jl_any_type, NULL, NULL,
-                        0, 1, ~(size_t)0, 0, jl_nothing, NULL, NULL);
+                        0, 1, ~(size_t)0, 0, jl_nothing, di, edges);
                     codeinst->rettype_const = unspec->rettype_const;
                     jl_atomic_store_relaxed(&codeinst->specptr.fptr, fptr);
                     jl_atomic_store_relaxed(&codeinst->invoke, invoke);
                     // unspec is probably not specsig, but might be using specptr
-                    jl_atomic_store_relaxed(&codeinst->specsigflags, specsigflags & ~0b1); // clear specsig flag
+                    jl_atomic_store_relaxed(&codeinst->flags, specsigflags & JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR);
                     jl_mi_cache_insert(mi, codeinst);
                     record_precompile_statement(mi, 0, 0);
                     return codeinst;
@@ -3540,9 +3588,11 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
         compile_option == JL_OPTIONS_COMPILE_MIN) {
         jl_code_info_t *src = jl_code_for_interpreter(mi, world);
         if (!jl_code_requires_compiler(src, 0)) {
+            jl_debuginfo_t *di = NULL;
+            jl_svec_t *edges = jl_emptysvec;
             jl_code_instance_t *codeinst = jl_new_codeinst(mi, jl_nothing,
                 (jl_value_t*)jl_any_type, (jl_value_t*)jl_any_type, NULL, NULL,
-                0, 1, ~(size_t)0, 0, jl_nothing, NULL, NULL);
+                0, 1, ~(size_t)0, 0, jl_nothing, di, edges);
             jl_atomic_store_release(&codeinst->invoke, jl_fptr_interpret_call);
             jl_mi_cache_insert(mi, codeinst);
             record_precompile_statement(mi, 0, 0);
@@ -3630,14 +3680,16 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
         jl_callptr_t invoke;
         void *fptr;
         jl_read_codeinst_invoke(ucache, &specsigflags, &invoke, &fptr, 1);
+        jl_debuginfo_t *di = NULL;
+        jl_svec_t *edges = jl_emptysvec;
         codeinst = jl_new_codeinst(mi, jl_nothing,
             (jl_value_t*)jl_any_type, (jl_value_t*)jl_any_type, NULL, NULL,
-            0, 1, ~(size_t)0, 0, jl_nothing, NULL, NULL);
+            0, 1, ~(size_t)0, 0, jl_nothing, di, edges);
         codeinst->rettype_const = ucache->rettype_const;
         // unspec is always not specsig, but might use specptr
         jl_atomic_store_relaxed(&codeinst->specptr.fptr, fptr);
         jl_atomic_store_relaxed(&codeinst->invoke, invoke);
-        jl_atomic_store_relaxed(&codeinst->specsigflags, specsigflags & ~0b1); // clear specsig flag
+        jl_atomic_store_relaxed(&codeinst->flags, specsigflags & JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR);
         jl_mi_cache_insert(mi, codeinst);
     }
     jl_atomic_store_relaxed(&codeinst->precompile, 1);

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -517,7 +517,7 @@
     YY(jl_get_llvm_gvs) \
     YY(jl_get_llvm_gv_inits) \
     YY(jl_get_llvm_external_fns) \
-    YY(jl_get_llvm_mis) \
+    YY(jl_get_llvm_cis) \
     YY(jl_dump_function_asm) \
     YY(jl_LLVMCreateDisasm) \
     YY(jl_LLVMDisasmInstruction) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3665,7 +3665,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             "time_infer_self",
                             "time_compile",
                             //"absolute_max",
-                            "specsigflags", "precompile",
+                            "flags", "precompile",
                             "invoke", "specptr"), // function object decls
                         jl_svec(21,
                             jl_any_type,

--- a/src/julia.h
+++ b/src/julia.h
@@ -441,6 +441,13 @@ typedef struct _jl_opaque_closure_t {
 // exclusive ownership of the CodeInstance:
 //   def, owner, rettype, exctype, rettype_const, analysis_results,
 //   time_infer_total, time_infer_self
+
+// flags bits for CodeInstance
+#define JL_CI_FLAGS_SPECPTR_SPECIALIZED      0b0001
+#define JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR   0b0010
+#define JL_CI_FLAGS_FROM_IMAGE               0b0100
+#define JL_CI_FLAGS_NATIVE_CACHE_VALID       0b1000
+
 typedef struct _jl_code_instance_t {
     JL_DATA_TYPE
     jl_value_t *def; // MethodInstance or ABIOverride
@@ -487,9 +494,10 @@ typedef struct _jl_code_instance_t {
     uint16_t time_infer_self; // self cost of julia inference for `inferred` (included in time_infer_total)
     _Atomic(uint16_t) time_compile; // self cost of llvm compilation (e.g. of computing `invoke`)
     //TODO: uint8_t absolute_max; // whether true max world is unknown
-    _Atomic(uint8_t) specsigflags; // & 0b001 == specptr is a specialized function signature for specTypes->rettype
-                                   // & 0b010 == invokeptr matches specptr
-                                   // & 0b100 == From image
+    _Atomic(uint8_t) flags; // & 0b001 == specptr is a specialized function signature for specTypes->rettype
+                            // & 0b010 == invokeptr matches specptr
+                            // & 0b100 == From image
+                            // & 0b1000 == native_cache_valid
     _Atomic(uint8_t) precompile;  // if set, this will be added to the output system image
     _Atomic(jl_callptr_t) invoke; // jlcall entry point usually, but if this codeinst belongs to an OC Method, then this is an jl_fptr_args_t fptr1 instead, unless it is not, because it is a special token object instead
     union _jl_generic_specptr_t {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2067,8 +2067,8 @@ JL_DLLIMPORT void jl_get_function_id(void *native_code, jl_code_instance_t *ncod
         int32_t *func_idx, int32_t *specfunc_idx);
 JL_DLLIMPORT void jl_register_fptrs(uint64_t image_base, const struct _jl_image_fptrs_t *fptrs,
                                     jl_method_instance_t **linfos, size_t n);
-JL_DLLIMPORT void jl_get_llvm_mis(void *native_code, size_t *num_els,
-                                  jl_method_instance_t *MIs);
+JL_DLLIMPORT void jl_get_llvm_cis(void *native_code, size_t *num_els,
+                                  jl_code_instance_t **CIs);
 JL_DLLIMPORT void jl_init_codegen(void);
 JL_DLLIMPORT void jl_teardown_codegen(void) JL_NOTSAFEPOINT;
 JL_DLLIMPORT int jl_getFunctionInfo(jl_frame_t **frames, uintptr_t pointer, int skipC, int noInline) JL_NOTSAFEPOINT;

--- a/src/method.c
+++ b/src/method.c
@@ -772,6 +772,8 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *mi, size_t
         }
 
         if (cache || needs_cache_for_correctness) {
+            // TODO: this should poison the runtime, so that attempts to call save in staticdata afterwards will abort,
+            // since enabling `needs_cache_for_correctness` is unsound in the presence of cache files
             uninferred = (jl_code_info_t*)jl_copy_ast((jl_value_t*)func);
             ci = jl_new_codeinst_for_uninferred(mi, uninferred);
             jl_code_instance_t *cached_ci = jl_cache_uninferred(mi, cache_ci, world, ci);

--- a/src/support/htable.h
+++ b/src/support/htable.h
@@ -33,10 +33,10 @@ typedef struct {
 // initialize hash table, reserving space for `size` expected number of
 // elements. (Expect `h->size > size` for efficient occupancy factor.)
 htable_t *htable_new(htable_t *h, size_t size) JL_NOTSAFEPOINT;
-void htable_free(htable_t *h);
+void htable_free(htable_t *h) JL_NOTSAFEPOINT;
 
 // clear and (possibly) change size
-void htable_reset(htable_t *h, size_t sz);
+void htable_reset(htable_t *h, size_t sz) JL_NOTSAFEPOINT;
 
 // Lookup and mutation. See htable.inc for detail.
 #define HTPROT(HTNAME)                                                  \

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -203,6 +203,7 @@ end
 let
     if Base.generating_output() && Base.JLOptions().use_pkgimages != 0
         repl_workload()
+        precompile(Tuple{typeof(Base.setindex!), Base.Dict{Any, Any}, Any, Char})
         precompile(Tuple{typeof(Base.setindex!), Base.Dict{Any, Any}, Any, Int})
         precompile(Tuple{typeof(Base.delete!), Base.Set{Any}, String})
         precompile(Tuple{typeof(Base.:(==)), Char, String})

--- a/stdlib/REPL/test/precompilation.jl
+++ b/stdlib/REPL/test/precompilation.jl
@@ -33,8 +33,7 @@ if !Sys.iswindows()
         # given this test checks that startup is snappy, it's best to add workloads to
         # contrib/generate_precompile.jl rather than increase this number. But if that's not
         # possible, it'd be helpful to add a comment with the statement and a reason below
-        expected_precompiles = 1
-        # Jameson told me to bump this
+        expected_precompiles = 0
 
         n_precompiles = count(r"precompile\(", tracecompile_out)
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -35,7 +35,7 @@ end
 # sanity tests that our built-in types are marked correctly for atomic fields
 for (T, c) in (
         (Core.CodeInfo, []),
-        (Core.CodeInstance, [:next, :min_world, :max_world, :inferred, :edges, :debuginfo, :ipo_purity_bits, :invoke, :specptr, :specsigflags, :precompile, :time_compile]),
+        (Core.CodeInstance, [:next, :min_world, :max_world, :inferred, :edges, :debuginfo, :ipo_purity_bits, :invoke, :specptr, :flags, :precompile, :time_compile]),
         (Core.Method, [:primary_world, :did_scan_source, :dispatch_status, :interferences]),
         (Core.MethodInstance, [:cache, :flags, :dispatch_status]),
         (Core.MethodTable, [:defs]),

--- a/test/precompile_absint1.jl
+++ b/test/precompile_absint1.jl
@@ -43,33 +43,29 @@ precompile_test_harness() do load_path
         let m = only(methods(TestAbsIntPrecompile1.basic_callee))
             mi = only(Base.specializations(m))
             ci = mi.cache
-            @test_broken isdefined(ci, :next)
-            @test ci.owner === nothing
-            @test ci.max_world == typemax(UInt)
-            @test Base.module_build_id(TestAbsIntPrecompile1) ==
-                Base.object_build_id(ci)
-            @test_skip begin
-            ci = ci.next
-            @test !isdefined(ci, :next)
+            @test isdefined(ci, :next)
             @test ci.owner === cache_owner
             @test ci.max_world == typemax(UInt)
             @test Base.module_build_id(TestAbsIntPrecompile1) ==
                 Base.object_build_id(ci)
-            end
+            ci = ci.next
+            @test !isdefined(ci, :next)
+            @test ci.owner === nothing
+            @test ci.max_world == typemax(UInt)
+            @test Base.module_build_id(TestAbsIntPrecompile1) ==
+                Base.object_build_id(ci)
         end
         let m = only(methods(sum, (Vector{Float64},)))
             found = false
             for mi in Base.specializations(m)
                 if mi isa Core.MethodInstance && mi.specTypes == Tuple{typeof(sum),Vector{Float64}}
                     ci = mi.cache
-                    @test_broken isdefined(ci, :next)
-                    @test_broken ci.owner === cache_owner
-                    @test_skip begin
+                    @test isdefined(ci, :next)
+                    @test ci.owner === cache_owner
                     @test ci.max_world == typemax(UInt)
                     @test Base.module_build_id(TestAbsIntPrecompile1) ==
                         Base.object_build_id(ci)
                     ci = ci.next
-                    end
                     @test !isdefined(ci, :next)
                     @test ci.owner === nothing
                     @test ci.max_world == typemax(UInt)

--- a/test/precompile_absint2.jl
+++ b/test/precompile_absint2.jl
@@ -63,33 +63,29 @@ precompile_test_harness() do load_path
         let m = only(methods(TestAbsIntPrecompile2.basic_callee))
             mi = only(Base.specializations(m))
             ci = mi.cache
-            @test_broken isdefined(ci, :next)
-            @test ci.owner === nothing
-            @test ci.max_world == typemax(UInt)
-            @test Base.module_build_id(TestAbsIntPrecompile2) ==
-                Base.object_build_id(ci)
-            @test_skip begin
-            ci = ci.next
-            @test !isdefined(ci, :next)
+            @test isdefined(ci, :next)
             @test ci.owner === cache_owner
             @test ci.max_world == typemax(UInt)
             @test Base.module_build_id(TestAbsIntPrecompile2) ==
                 Base.object_build_id(ci)
-            end
+            ci = ci.next
+            @test !isdefined(ci, :next)
+            @test ci.owner === nothing
+            @test ci.max_world == typemax(UInt)
+            @test Base.module_build_id(TestAbsIntPrecompile2) ==
+                Base.object_build_id(ci)
         end
         let m = only(methods(sum, (Vector{Float64},)))
             found = false
             for mi = Base.specializations(m)
                 if mi isa Core.MethodInstance && mi.specTypes == Tuple{typeof(sum),Vector{Float64}}
                     ci = mi.cache
-                    @test_broken isdefined(ci, :next)
-                    @test_broken ci.owner === cache_owner
-                    @test_skip begin
+                    @test isdefined(ci, :next)
+                    @test ci.owner === cache_owner
                     @test ci.max_world == typemax(UInt)
                     @test Base.module_build_id(TestAbsIntPrecompile2) ==
                         Base.object_build_id(ci)
                     ci = ci.next
-                    end
                     @test !isdefined(ci, :next)
                     @test ci.owner === nothing
                     @test ci.max_world == typemax(UInt)


### PR DESCRIPTION
Get the real list of external code instances worthwhile to re-cache
directly from `native_functions` instead of calling
`jl_compute_new_ext_cis` a second time if we have `native_functions`. If
not saving native code though, we can still call it to get a list of
code instances that might be worth including even without native code.