### PR TITLE
[`backports-release-1.11`]: Revert "fix null comparisons for non-standard address spaces (#58837)"

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1395,17 +1395,10 @@ static void undef_var_error_ifnot(jl_codectx_t &ctx, Value *ok, jl_sym_t *name, 
     ctx.builder.SetInsertPoint(ifok);
 }
 
-// ctx.builder.CreateIsNotNull(v) lowers incorrectly in non-standard
-// address spaces where null is not zero
-// TODO: adapt to https://github.com/llvm/llvm-project/pull/131557 once merged
 static Value *null_pointer_cmp(jl_codectx_t &ctx, Value *v)
 {
     ++EmittedNullchecks;
-    Type *T = v->getType();
-    return ctx.builder.CreateICmpNE(
-            v,
-            ctx.builder.CreateAddrSpaceCast(
-                Constant::getNullValue(ctx.builder.getPtrTy(0)), T));
+    return ctx.builder.CreateIsNotNull(v);
 }
 
 


### PR DESCRIPTION
This reverts commit 3b04664577713059bee663fb3d1cd37080a7ff8e (which backports #58837 to 1.11.x).

For more details, see https://github.com/JuliaLang/julia/pull/59336#issuecomment-3239568360 and https://github.com/JuliaLang/julia/pull/59336#issuecomment-3239575723.

Targets `backports-release-1.11` (#59336).