### PR TITLE
[`backports-release-1.11`] Revert "Make late gc lower handle insertelement of alloca use. (#58637)"

### DIFF
--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1115,7 +1115,7 @@ void RecursivelyVisit(callback f, Value *V) {
         if (isa<CallInst>(TheUser) || isa<LoadInst>(TheUser) ||
             isa<SelectInst>(TheUser) || isa<PHINode>(TheUser) || // TODO: should these be removed from this list?
             isa<StoreInst>(TheUser) || isa<PtrToIntInst>(TheUser) ||
-            isa<ICmpInst>(TheUser) || isa<InsertElementInst>(TheUser)|| // ICmpEQ/ICmpNE can be used with ptr types
+            isa<ICmpInst>(TheUser) || // ICmpEQ/ICmpNE can be used with ptr types
             isa<AtomicCmpXchgInst>(TheUser) || isa<AtomicRMWInst>(TheUser))
             continue;
         if (isa<GetElementPtrInst>(TheUser) || isa<BitCastInst>(TheUser) || isa<AddrSpaceCastInst>(TheUser)) {

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -226,20 +226,6 @@ define void @decayar([2 x {} addrspace(10)* addrspace(11)*] %ar) {
 ; OPAQUE: %r = call i32 @callee_root(ptr addrspace(10) %l0, ptr addrspace(10) %l1)
 ; OPAQUE: call void @julia.pop_gc_frame(ptr %gcframe)
 
-define swiftcc ptr addrspace(10) @insert_element(ptr swiftself %0) {
-; CHECK-LABEL: @insert_element
-  %2 = alloca [10 x i64], i32 1, align 8
-; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 10)
-; CHECK: [[gc_slot_addr_:%.*]] = call ptr @julia.get_gc_frame_slot(ptr %gcframe, i32 0)
-; CHECK: call void @julia.push_gc_frame(ptr %gcframe, i32 10)
-  call void null(ptr sret([2 x [5 x ptr addrspace(10)]]) %2, ptr null, ptr addrspace(11) null, ptr null)
-  %4 = insertelement <4 x ptr> zeroinitializer, ptr %2, i32 0
-; CHECK: [[gc_slot_addr_:%.*]] = insertelement <4 x ptr> zeroinitializer, ptr [[gc_slot_addr_:%.*]], i32 0
-; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
-  ret ptr addrspace(10) null
-}
-
-
 !0 = !{i64 0, i64 23}
 !1 = !{!1}
 !2 = !{!7} ; scope list


### PR DESCRIPTION
This reverts commit 47d905df994c69f91ac416d72ec0481c1fd011da (which backports #58637 to 1.11).

Targets `backports-release-1.11` (#59336).

## Motivation

Let's see if this fixes the `llvmpasses` CI job on `backports-release-1.11` (#59336).