### PR TITLE
[`backports-release-1.11`] Backport `7c81745` ("Mmap tests: refresh tempname to avoid windows fs slowness") to Julia 1.11.x

### DIFF
--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -47,6 +47,7 @@ close(s)
 @test_throws ArgumentError mmap(file, Vector{Ref}) # must be bit-type
 GC.gc(); GC.gc()
 
+file = tempname() # new name to reduce chance of issues due slow windows fs
 s = open(f->f,file,"w")
 @test mmap(file) == Vector{UInt8}() # requested len=0 on empty file
 @test mmap(file,Vector{UInt8},0) == Vector{UInt8}()
@@ -191,6 +192,7 @@ m = mmap(file,Vector{UInt8},2,6)
 @test_throws BoundsError m[3]
 finalize(m); m = nothing; GC.gc()
 
+file = tempname() # new name to reduce chance of issues due slow windows fs
 s = open(file, "w")
 write(s, [0xffffffffffffffff,
           0xffffffffffffffff,


### PR DESCRIPTION
Cherry picked from commit 7c81745ff78511135db5e980b5522560c708818e, which was part of #57686.

Targets `backports-release-1.11` (#59336).

## Motivation

I'm hoping that this fixes the test failures in Windows CI (in the Mmap tests) that I'm seeing on `backports-release-1.11`.

## Details

#58998 included a new test in the Mmap tests.

#58998 is now on the `backports-release-1.11` branch.

CI is failing on the `backports-release-1.11` branch (#59336), with a test failure in the Mmap tests, that looks like this:

```
Error in testset Mmap:
Error During Test at C:\buildkite-agent\builds\win2k22-amdci6-1\julialang\julia-release-1-dot-11\julia-ddcbe4dd84\share\julia\stdlib\v1.11\Mmap\test\runtests.jl:344
  Got exception outside of a @test
  IOError: unlink("C:\\Users\\julia\\AppData\\Local\\Temp\\jl_7Yt6Pgdm7K"): permission denied (EACCES)
  Stacktrace:
```