### PR TITLE
[`backports-release-1.11`] Backport #59062 ("remove a testset from MMAP that might cause CI to now fail on Windows")

### DIFF
--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -341,18 +341,18 @@ end
 GC.gc()
 rm(file)
 
-@testset "test for #58982 - mmap with primitive types" begin
-    file = tempname()
-    primitive type PrimType9Bytes 9*8 end
-    arr = Vector{PrimType9Bytes}(undef, 2)
-    write(file, arr)
-    m = mmap(file, Vector{PrimType9Bytes})
-    @test length(m) == 2
-    @test m[1] == arr[1]
-    @test m[2] == arr[2]
-    finalize(m); m = nothing; GC.gc()
-    rm(file)
-end
+# test for #58982 - mmap with primitive types
+file = tempname()
+primitive type PrimType9Bytes 9*8 end
+arr = Vector{PrimType9Bytes}(undef, 2)
+write(file, arr)
+m = mmap(file, Vector{PrimType9Bytes})
+@test length(m) == 2
+@test m[1] == arr[1]
+@test m[2] == arr[2]
+finalize(m); m = nothing; GC.gc()
+rm(file)
+
 
 @testset "Docstrings" begin
     @test isempty(Docs.undocumented_names(Mmap))


### PR DESCRIPTION
Cherry picked from commit 4718f43b5afe34ae7aa12d60755a817f0e4f6808 (#59062).

Targets `backports-release-1.11` (#59336).