### PR TITLE
`Compiler.IRShow`: prevent a closure capture boxing with the usual workaround

### DIFF
--- a/Compiler/src/ssair/show.jl
+++ b/Compiler/src/ssair/show.jl
@@ -301,7 +301,7 @@ function compute_ir_line_annotations(code::Union{IRCode,CodeInfo})
             x = min(length(last_stack), length(stack))
             depth = length(stack) - 1
             # Compute the last depth that was in common
-            first_mismatch = let last_stack=last_stack
+            first_mismatch = let last_stack=last_stack, stack=stack
                 findfirst(i->last_stack[i] != stack[i], 1:x)
             end
             # If the first mismatch is the last stack frame, that might just


### PR DESCRIPTION
Works around issue #15276 in the only method of the function:

```julia
Compiler.IRShow.compute_ir_line_annotations
```

As a result of making the boxing unnecessary and improving inferrability, this change should make the sysimage more resistant to invalidation.