### PR TITLE
`dataids(::AbstractArray)` method: elide redundant `UInt` call

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1601,7 +1601,7 @@ parts can specialize this method to return the concatenation of the `dataids` of
 their component parts.  A typical definition for an array that wraps a parent is
 `Base.dataids(C::CustomArray) = dataids(C.parent)`.
 """
-dataids(A::AbstractArray) = (UInt(objectid(A)),)
+dataids(A::AbstractArray) = (objectid(A),)
 dataids(A::Memory) = (UInt(A.ptr),)
 dataids(A::Array) = dataids(A.ref.mem)
 dataids(::AbstractRange) = ()


### PR DESCRIPTION
`objectid` only returns `UInt` anyway.