### PR TITLE
Fix gcdx to ensure first return value matches gcd for mixed signed/unsigned integers

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -228,8 +228,8 @@ Base.@assume_effects :terminates_locally function gcdx(a::Integer, b::Integer)
     s0, s1 = oneunit(T), zero(T)
     t0, t1 = s1, s0
     # The loop invariant is: s0*a0 + t0*b0 == a && s1*a0 + t1*b0 == b
-    x = a % T
-    y = b % T
+    x = convert(T, a)
+    y = convert(T, b)
     while y != 0
         q, r = divrem(x, y)
         x, y = y, r
@@ -238,6 +238,7 @@ Base.@assume_effects :terminates_locally function gcdx(a::Integer, b::Integer)
     end
     x < 0 ? (-x, -s0, -t0) : (x, s0, t0)
 end
+
 gcdx(a::Real, b::Real) = gcdx(promote(a,b)...)
 gcdx(a::T, b::T) where T<:Real = throw(MethodError(gcdx, (a,b)))
 gcdx(a::Real) = (gcd(a), signbit(a) ? -one(a) : one(a))


### PR DESCRIPTION
This PR fixes an inconsistency in the implementation of gcdx(::Integer, ::Integer) where the first return value (the gcd) could differ from gcd on the same arguments when mixing signed and unsigned integers.
Problem

Before this patch:

julia> gcdx(UInt16(100), Int8(-101))
(0x0005, 0xf855, 0x0003)

julia> gcd(UInt16(100), Int8(-101))
0x0001

Here, the gcd from gcdx was 0x0005, while gcd returned 0x0001.
This mismatch violates the expectation that gcdx(a,b)[1] == gcd(a,b).

Cause

The bug came from using:

x = a % T
y = b % T


which reinterprets values in the promoted type T. For mixed signed/unsigned integers, this led to incorrect values being passed into the Euclidean algorithm.

Fix

We now use proper type conversion:

x = convert(T, a)
y = convert(T, b)


and retain the invariant that the gcd (x at loop end) is made positive, consistent with gcd.

Result

After this fix:

julia> gcdx(UInt16(100), Int8(-101))
(0x0001, 0x0003, -0x0002)

julia> gcd(UInt16(100), Int8(-101))
0x0001


The first return value now always matches gcd.