### PR TITLE
ScopedValues: print valid code for undef value

### DIFF
--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -232,9 +232,7 @@ function Base.show(io::IO, val::AbstractScopedValue)
     end
     print(io, '(')
     v = get(val)
-    if v === nothing
-        print(io, "undefined")
-    else
+    if v !== nothing
         show(IOContext(io, :typeinfo => eltype(val)), something(v))
     end
     print(io, ')')

--- a/test/scopedvalues.jl
+++ b/test/scopedvalues.jl
@@ -80,7 +80,7 @@ import Base.Threads: @spawn
 end
 
 @testset "show" begin
-    @test sprint(show, ScopedValue{Int}(), context=(:module=>Core,)) == "Base.ScopedValues.ScopedValue{$Int}(undefined)"
+    @test sprint(show, ScopedValue{Int}(), context=(:module=>Core,)) == "Base.ScopedValues.ScopedValue{$Int}()"
     @test sprint(show, sval, context=(:module=>Core,)) == "Base.ScopedValues.ScopedValue{$Int}(1)"
     with(sval => 2.0) do
         @test sprint(show, sval, context=(:module=>Core,)) == "Base.ScopedValues.ScopedValue{$Int}(2)"


### PR DESCRIPTION
Seemed a bit odd to me for the printing of ScopedValues without a default to not print as valid code, when that seems perfectly clear.

Before (on `master`):
```julia
julia> ScopedValue{Int}()
ScopedValue{Int64}(undefined)

julia> ScopedValue{String}()
ScopedValue{String}(undefined)
```
Now (this PR):
```julia
julia> ScopedValue{Int}()
ScopedValue{Int64}()

julia> ScopedValue{String}()
ScopedValue{String}()
```