### PR TITLE
Allow linking a system image with jl_image_unpack with libjulia

### DIFF
--- a/src/null_sysimage.c
+++ b/src/null_sysimage.c
@@ -7,9 +7,7 @@
  * These symbols support statically linking the sysimage with libjulia-internal.
  *
  * Here we provide dummy definitions that are used when these are not linked
- * together (the default build configuration). The 0 value of jl_system_image_size
+ * together (the default build configuration). The 0 value of jl_image_unpack
  * is used as a sentinel to indicate that the sysimage should be loaded externally.
  **/
-char jl_system_image_data = 0;
-size_t jl_system_image_size = 0;
-jl_image_pointers_t jl_image_pointers = { 0 };
+jl_image_unpack_func_t *jl_image_unpack = NULL;

--- a/src/processor.h
+++ b/src/processor.h
@@ -240,9 +240,8 @@ JL_DLLEXPORT int32_t jl_get_default_nans(void);
  * libjulia-* and the sysimage together (see null_sysimage.c), in which
  * case they allow accessing the local copy of the sysimage.
  **/
-extern char jl_system_image_data;
-extern size_t jl_system_image_size;
-extern jl_image_pointers_t jl_image_pointers;
+typedef void jl_image_unpack_func_t(void *handle, jl_image_buf_t *image);
+extern jl_image_unpack_func_t *jl_image_unpack;
 
 #ifdef __cplusplus
 }

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3635,7 +3635,6 @@ JL_DLLEXPORT jl_image_buf_t jl_preload_sysimg(const char *fname)
     }
 }
 
-typedef void jl_image_unpack_func_t(void *handle, jl_image_buf_t *image);
 
 static void jl_prefetch_system_image(const char *data, size_t size)
 {
@@ -3722,19 +3721,17 @@ static jl_image_buf_t get_image_buf(void *handle, int is_pkgimage)
     };
 
     // verification passed, lookup the buffer pointers
-    if (jl_system_image_size == 0 || is_pkgimage) {
+    if (jl_image_unpack == NULL || is_pkgimage) {
         // in the usual case, the sysimage was not statically linked to libjulia-internal
         // look up the external sysimage symbols via the dynamic linker
         jl_dlsym(handle, "jl_image_unpack", (void **)&unpack, 1);
-        (*unpack)(handle, &image);
     }
     else {
         // the sysimage was statically linked directly against libjulia-internal
         // use the internal symbols
-        image.size = jl_system_image_size;
-        image.pointers = &jl_image_pointers;
-        image.data = &jl_system_image_data;
+        unpack = &jl_image_unpack;
     }
+    (*unpack)(handle, &image);
 
 #ifdef _OS_WINDOWS_
     image.base = (intptr_t)handle;


### PR DESCRIPTION
After #59227 changed the way we load system images, the symbols in `null_sysimg.c` are no longer correct. Replace them with `jl_image_unpack` so linking a system image with libjulia is possible again.