### PR TITLE
doc: `>=`: say not to implement this function directly

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -454,6 +454,14 @@ const ≤ = <=
 
 Greater-than-or-equals comparison operator. Falls back to `y <= x`.
 
+# Implementation
+
+New types should prefer to implement [`<=`](@ref) instead of this function,
+and rely on the fallback definition `>=(x, y) = y <= x`.
+
+Furthermore, in many cases it is enough to implement just [`<`](@ref) and
+[`==`](@ref), relying on the fallback definitions of both `<=` and `>=`.
+
 # Examples
 ```jldoctest
 julia> 'a' >= 'b'


### PR DESCRIPTION
The doc string of function `>` already has a similar note.

Cross-reference issue GenericMappingTools/GMT.jl#1799.