### PR TITLE
delete redundant method of function `!=`, defined between types

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -293,7 +293,6 @@ isunordered(x::AbstractFloat) = isnan(x)
 isunordered(x::Missing) = true
 
 ==(T::Type, S::Type) = (@_total_meta; ccall(:jl_types_equal, Cint, (Any, Any), T, S) != 0)
-!=(T::Type, S::Type) = (@_total_meta; !(T == S))
 ==(T::TypeVar, S::Type) = false
 ==(T::Type, S::TypeVar) = false
 


### PR DESCRIPTION
The method was originally added way back in PR #15575.

Pretty sure it is not necessary any more, as deleting it preserves the effect inference:

```julia-repl
julia> Base.infer_effects(!=, Tuple{Type, Type})
(+c,+e,+n,+t,+s,+m,+u,+o,+r)

julia> Base.infer_effects(((l, r) -> l != r), Tuple{Type, Type})
(+c,+e,+n,+t,+s,+m,+u,+o,+r)

julia> Base.delete_method(@which Int != Int)

julia> Base.infer_effects(((l, r) -> l != r), Tuple{Type, Type})
(+c,+e,+n,+t,+s,+m,+u,+o,+r)

julia> Base.infer_effects(!=, Tuple{Type, Type})
(+c,+e,+n,+t,+s,+m,+u,+o,+r)
```