### PR TITLE
[backports-release-1.11] Don't forget to decay value on struct initialization

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2995,6 +2995,7 @@ static void init_bits_value(jl_codectx_t &ctx, Value *newv, Value *v, MDNode *tb
 static void init_bits_cgval(jl_codectx_t &ctx, Value *newv, const jl_cgval_t& v, MDNode *tbaa)
 {
     // newv should already be tagged
+    newv = maybe_decay_tracked(ctx, newv);
     if (v.ispointer()) {
         unsigned align = std::max(julia_alignment(v.typ), (unsigned)sizeof(void*));
         emit_memcpy(ctx, newv, jl_aliasinfo_t::fromTBAA(ctx, tbaa), v, jl_datatype_size(v.typ), Align(align), Align(julia_alignment(v.typ)));


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/59510