### PR TITLE
Accept non-`AbstractArray`s in 2-arg `axes`/`size`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -18,7 +18,7 @@ convert(::Type{AbstractArray{T}}, a::AbstractArray) where {T} = AbstractArray{T}
 convert(::Type{AbstractArray{T,N}}, a::AbstractArray{<:Any,N}) where {T,N} = AbstractArray{T,N}(a)::AbstractArray{T,N}
 
 """
-    size(A::AbstractArray, [dim])
+    size(A, [dim])
 
 Return a tuple containing the dimensions of `A`. Optionally you can specify a
 dimension to just get the length of that dimension.
@@ -39,7 +39,7 @@ julia> size(A, 2)
 3
 ```
 """
-size(t::AbstractArray{T,N}, d) where {T,N} = d::Integer <= N ? size(t)[d] : 1
+size(A, d) where {T,N} = d::Integer <= ndims(A) ? size(A)[d] : 1
 
 """
     axes(A, d)
@@ -72,9 +72,9 @@ ix[2:end]          # will work for eg Vector, but may fail in general
 ix[(begin+1):end]  # works for generalized indexes
 ```
 """
-function axes(A::AbstractArray{T,N}, d) where {T,N}
+function axes(A, d)
     @inline
-    d::Integer <= N ? axes(A)[d] : OneTo(1)
+    d::Integer <= ndims(A) ? axes(A)[d] : OneTo(1)
 end
 
 """

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -99,7 +99,7 @@ function axes(A, d)
 end
 function _axes(::HasShape, ax::Tuple, d::Integer)
     @inline
-    d_Int = convert(Int, d)
+    d_Int = Int(d)::Int
     d_Int <= length(ax) ? ax[d_Int] : OneTo(1)
 end
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -51,7 +51,7 @@ function size(A, d)
 end
 function _size(::HasShape, s::Tuple, d::Integer)
     @inline
-    d_Int = convert(Int, d)
+    d_Int = Int(d)::Int
     d_Int <= length(s) ? s[d_Int] : 1
 end
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -95,7 +95,7 @@ ix[(begin+1):end]  # works for generalized indexes
 """
 function axes(A, d)
    @inline
-   _axes(IteratorSize(A), axes(A), d) 
+   _axes(IteratorSize(A), axes(A), d)
 end
 function _axes(::HasShape, ax::Tuple, d::Integer)
     @inline

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1221,3 +1221,11 @@ end
     @test bc[1] == bc[CartesianIndex(1)] == bc[1, CartesianIndex()]
     @test a .+ [1 2] == a.a .+ [1 2]
 end
+
+@testset "axes/size for a specific broadcasted axis" begin
+    b = Broadcast.broadcasted(+, ones(2), ones(2,3))
+    @test axes(b,1) == 1:2
+    @test axes(b,2) == 1:3
+    @test size(b,1) == 2
+    @test size(b,2) == 3
+end


### PR DESCRIPTION
With this change, any type that implements `axes(A)` gets `axes(A, d)` for free, and similarly for `size`. These would make it easier to accept array-like types such as `Broadcasted` in functions that require indexing.

One caveat is that the default assumption here is that for `d > ndims(A)`, we return a single-element axis `OneTo` similar to what we do for `AbstractArray`s. This may not always be meaningful for arbitrary types, and indexing with trailing unit indices might not be supported. Such types currently implement `axes(A, d)` for themselves and should continue doing so.