### PR TITLE
add bounds check to `LinearIndices` construction

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -522,8 +522,8 @@ julia> linear[1,2]
 """
 struct LinearIndices{N,R<:NTuple{N,AbstractUnitRange{Int}}} <: AbstractArray{Int,N}
     indices::R
-    @propagate_inbounds function LinearIndices{N,R}(indices::R) where {N,R<:NTuple{N,AbstractUnitRange{Int}}}
-        @boundscheck if N > 0
+    function LinearIndices{N,R}(indices::R) where {N,R<:NTuple{N,AbstractUnitRange{Int}}}
+        if N > 0
             indexcount = 1 # == one(eltype(LinearIndices{N,R}))
             for r in indices
                 indexcount = Base.checked_mul(indexcount, length(r))

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -522,11 +522,22 @@ julia> linear[1,2]
 """
 struct LinearIndices{N,R<:NTuple{N,AbstractUnitRange{Int}}} <: AbstractArray{Int,N}
     indices::R
+    @propagate_inbounds function LinearIndices{N,R}(indices::R) where {N,R<:NTuple{N,AbstractUnitRange{Int}}}
+        @boundscheck if N > 0
+            indexcount = 1 # == one(eltype(LinearIndices{N,R}))
+            for r in indices
+                indexcount = Base.checked_mul(indexcount, length(r))
+            end
+        end
+        new{N,R}(indices)
+    end
 end
 convert(::Type{LinearIndices{N,R}}, inds::LinearIndices{N}) where {N,R<:NTuple{N,AbstractUnitRange{Int}}} =
     LinearIndices{N,R}(convert(R, inds.indices))::LinearIndices{N,R}
 
 LinearIndices(::Tuple{}) = LinearIndices{0,typeof(())}(())
+LinearIndices(inds::NTuple{N,AbstractUnitRange{Int}}) where {N} =
+    LinearIndices{N,typeof(inds)}(inds)
 LinearIndices(inds::NTuple{N,AbstractUnitRange{<:Integer}}) where {N} =
     LinearIndices(map(r->convert(AbstractUnitRange{Int}, r), inds))
 LinearIndices(inds::NTuple{N,Union{<:Integer,AbstractUnitRange{<:Integer}}}) where {N} =

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -307,7 +307,7 @@ end
         end
 
         big_index = isqrt(typemax(Int))
-        @test_throws ArgumentError LinearIndices((big_index, big_index, 2))
+        @test_throws OverflowError LinearIndices((big_index, big_index, 2))
     end
 
     @testset "IdentityUnitRange" begin

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -305,6 +305,9 @@ end
             R = CartesianIndices(oinds)
             @test size(R) == oinds
         end
+
+        big_index = isqrt(typemax(Int))
+        @test_throws ArgumentError LinearIndices((big_index, big_index, 2))
     end
 
     @testset "IdentityUnitRange" begin


### PR DESCRIPTION
master:
```
julia> big_index = isqrt(typemax(Int))
3037000499

julia> LI = LinearIndices((big_index, big_index, 2));

julia> LI[end, end, 2]
-11857053614
```

PR:
```
julia> big_index = isqrt(typemax(Int))
3037000499

julia> LI = LinearIndices((big_index, big_index, 2));
ERROR: OverflowError: 9223372030926249001 * 2 overflowed for type Int64
Stacktrace:
```

I suppose there is a more general discussion in https://github.com/JuliaLang/julia/issues/50486 about which operations should be careful around internal overflows, but this seems like one of them. I did try to add `@boundscheck` and `@propagate_inbounds` to make this skippable, but I couldn't get it to work right