### PR TITLE
Buffer greedy scheduler channel

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -222,7 +222,7 @@ end
 
 function greedy_func(itr, lidx, lbody)
     quote
-        let c = Channel{eltype($itr)}(0,spawn=true) do ch
+        let c = Channel{eltype($itr)}(threadpoolsize(), spawn=true) do ch
             for item in $itr
                 put!(ch, item)
             end


### PR DESCRIPTION
This reduces the overhead of channel communication in the common case where the consumers are slower than the producers, while consuming a minimum amount of memory.

Closes https://github.com/JuliaLang/julia/issues/59514