### PR TITLE
delete redundant method of function `!=`, defined between bit floats

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -619,7 +619,6 @@ end
 
 ## floating point comparisons ##
 ==(x::T, y::T) where {T<:IEEEFloat} = eq_float(x, y)
-!=(x::T, y::T) where {T<:IEEEFloat} = ne_float(x, y)
 <( x::T, y::T) where {T<:IEEEFloat} = lt_float(x, y)
 <=(x::T, y::T) where {T<:IEEEFloat} = le_float(x, y)
 


### PR DESCRIPTION
The method was originally added way back in commit f1385790c103bb79e9878ecfaecf519c74a0051d.

Deleting the method preserves optimized `code_llvm` output, for example with `code_llvm(!=, NTuple{2, Float64}; debuginfo=:none)`.

After PR #59509 deleted another such unnecessary method, this method is the only nongeneric two-argument method of `!=` in the sysimage.