### PR TITLE
Docs: Update dispatch benchmark link in performance tips

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1081,7 +1081,7 @@ JIT-compilation machinery to basically execute the equivalent of a switch statem
 lookup in your own code.
 
 Some run-time benchmarks comparing (1) type dispatch, (2) dictionary lookup, and (3) a "switch"
-statement can be found [on the mailing list](https://groups.google.com/forum/#!msg/julia-users/jUMu9A3QKQQ/qjgVWr7vAwAJ).
+statement can be found [on the discourse](https://discourse.julialang.org/t/suggestion-updating-the-dispatch-vs-dict-switch-benchmark-link-in-the-manual/132159).
 
 Perhaps even worse than the run-time impact is the compile-time impact: Julia will compile specialized
 functions for each different `Car{Make, Model}`; if you have hundreds or thousands of such types,

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1081,7 +1081,7 @@ JIT-compilation machinery to basically execute the equivalent of a switch statem
 lookup in your own code.
 
 Some run-time benchmarks comparing (1) type dispatch, (2) dictionary lookup, and (3) a "switch"
-statement can be found [on the discourse](https://discourse.julialang.org/t/suggestion-updating-the-dispatch-vs-dict-switch-benchmark-link-in-the-manual/132159).
+statement can be found [on discourse](https://discourse.julialang.org/t/suggestion-updating-the-dispatch-vs-dict-switch-benchmark-link-in-the-manual/132159).
 
 Perhaps even worse than the run-time impact is the compile-time impact: Julia will compile specialized
 functions for each different `Car{Make, Model}`; if you have hundreds or thousands of such types,


### PR DESCRIPTION
First off, thanks to everyone who has worked on the (fantastic) documentation -- it's been a delight to work through it as I learn the language.

This is PR proposes updating a link in the "Performance tips" section of the manual.

An existing reference in the "dangers of abusing multiple dispatch" subsection seems sub-optimal: it currently links to the now-unused Julia mailing list, and (more relevant) uses pre-v1.0 syntax (i.e. `immutable`). I made a Discourse post that modernizes Tim Holy's example of dispatch vs dict vs switch (and points to the old mailing list to give him credit) to use the current syntax, and using `BenchmarkTools`. The qualitative conclusion of the post is of course identical to that on the mailing list; this change is just about providing a up-to-date resources for new users reading the documentation. 

At least one person has responded with yet another alternative (`Union`-based) and benchmark, so as a minimal change I propose changing "Some run-time benchmarks... can be found on the mailing list" to "...can be found on the discourse".

Related Discourse Topic: [Suggestion: updating the dispatch vs. dict/switch benchmark link in the manual](https://discourse.julialang.org/t/suggestion-updating-the-dispatch-vs-dict-switch-benchmark-link-in-the-manual/132159)
