### PR TITLE
fix potential null deref in `merge_vararg_unions`

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -614,7 +614,7 @@ STATIC_INLINE void merge_vararg_unions(jl_value_t **temp, size_t nt)
         size_t min_elements = nfields-1;
         for (long j = i-1; j >= 0; j--) {
             jl_value_t *ttj = temp[j];
-            if (!jl_is_tuple_type(ttj)) break;
+            if (!(ttj && jl_is_tuple_type(ttj))) break;
             size_t nfieldsj = jl_nparams(ttj);
             if (nfieldsj >= min_elements) continue;
             if (nfieldsj != min_elements-1) break;

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -68,6 +68,13 @@ function test_2()
     @test !(Tuple{Int,Vararg{Int,2}} <: Tuple{Int,Int,Int,Vararg{Int,1}})
     @test Tuple{Int,Vararg{Int}} == Tuple{Int,Vararg{Int}}
     @test (@UnionAll N Tuple{Int,Vararg{Int,N}}) == (@UnionAll N Tuple{Int,Vararg{Int,N}})
+    @test Union{
+        Tuple{},
+        Tuple{Int},
+        Tuple{UInt},
+        Tuple{UInt, Vararg{UInt}},
+        Tuple{Int, Int, Vararg{Int}}
+    } == Union{Tuple{UInt, Vararg{UInt}}, Tuple{Vararg{Int}}}
 
     @test issub_strict(Tuple{Tuple{Int,Int},Tuple{Int,Int}}, Tuple{NTuple{N,Int},NTuple{N,Int}} where N)
     @test !issub(Tuple{Tuple{Int,Int},Tuple{Int,}}, Tuple{NTuple{N,Int},NTuple{N,Int}} where N)

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -68,13 +68,13 @@ function test_2()
     @test !(Tuple{Int,Vararg{Int,2}} <: Tuple{Int,Int,Int,Vararg{Int,1}})
     @test Tuple{Int,Vararg{Int}} == Tuple{Int,Vararg{Int}}
     @test (@UnionAll N Tuple{Int,Vararg{Int,N}}) == (@UnionAll N Tuple{Int,Vararg{Int,N}})
-    @test Union{
+    @test Union{Tuple{}, Tuple{Int}, Tuple{UInt}} <: Union{
         Tuple{},
         Tuple{Int},
         Tuple{UInt},
         Tuple{UInt, Vararg{UInt}},
         Tuple{Int, Int, Vararg{Int}}
-    } == Union{Tuple{UInt, Vararg{UInt}}, Tuple{Vararg{Int}}}
+    }
 
     @test issub_strict(Tuple{Tuple{Int,Int},Tuple{Int,Int}}, Tuple{NTuple{N,Int},NTuple{N,Int}} where N)
     @test !issub(Tuple{Tuple{Int,Int},Tuple{Int,}}, Tuple{NTuple{N,Int},NTuple{N,Int}} where N)


### PR DESCRIPTION
so as to avoid segfaults in the following type normalization

```
julia> @test Union{Tuple{}, Tuple{Int}, Tuple{UInt}} <: Union{
        Tuple{},
        Tuple{Int},
        Tuple{UInt},
        Tuple{UInt, Vararg{UInt}},
        Tuple{Int, Int, Vararg{Int}}
    }

[89686] signal 11 (2): Segmentation fault: 11
in expression starting at REPL[2]:1
jl_is_tuple_type at /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-XG3Q6T6R70.0/build/default-honeycrisp-XG3Q6T6R70-0/julialang/julia-master/src/./julia.h:1835 [inlined]
merge_vararg_unions at /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-XG3Q6T6R70.0/build/default-honeycrisp-XG3Q6T6R70-0/julialang/julia-master/src/jltypes.c:617
ijl_type_union at /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-XG3Q6T6R70.0/build/default-honeycrisp-XG3Q6T6R70-0/julialang/julia-master/src/jltypes.c:674
jl_apply at /Users/julia/.julia/scratchspaces/a66863
```