### PR TITLE
Ignore "Library already loaded" libjulia-internal error during jl_init_codegen

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1945,7 +1945,8 @@ JuliaOJIT::JuliaOJIT()
     sys::DynamicLibrary libjulia_internal_dylib = sys::DynamicLibrary::addPermanentLibrary(
       jl_libjulia_internal_handle, &ErrorStr);
     if(!ErrorStr.empty())
-        report_fatal_error(llvm::Twine("FATAL: unable to dlopen libjulia-internal\n") + ErrorStr);
+        if (ErrorStr != "Library already loaded")
+            report_fatal_error(llvm::Twine("FATAL: unable to dlopen libjulia-internal\n") + ErrorStr);
 
     // Make sure SectionMemoryManager::getSymbolAddressInProcess can resolve
     // symbols in the program as well. The nullptr argument to the function


### PR DESCRIPTION
It provides an opportunity to reinit codegen subsystem without aborting, and keep julia in correct state after jl_teardown_codegen(); jl_init_codegen();

Related to https://github.com/JuliaLang/julia/issues/59536