### PR TITLE
Help compiler know integer bounds in vector resizing ops

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1265,9 +1265,9 @@ function _deletebeg!(a::Vector, delta::Integer)
     delta = Int(delta)
     len = length(a)
     # See comment in _deleteend!
-    unsigned(delta) > unsigned(len) && throw(
-        ArgumentError("_deletebeg! requires delta in 0:length(a)")
-    )
+    if unsigned(delta) > unsigned(len)
+        throw(ArgumentError("_deletebeg! requires delta in 0:length(a)"))
+    end
     for i in 1:delta
         @inbounds _unsetindex!(a, i)
     end
@@ -1285,9 +1285,9 @@ function _deleteend!(a::Vector, delta::Integer)
     # Do the comparison unsigned, to so the compiler knows `len` cannot be negative.
     # This works because if delta is negative, it will overflow and still trigger.
     # This enables the compiler to skip the check sometimes.
-    unsigned(delta) > unsigned(len) && throw(
-        ArgumentError("_deleteend! requires delta in 0:length(a)")
-    )
+    if unsigned(delta) > unsigned(len)
+        throw(ArgumentError("_deleteend! requires delta in 0:length(a)"))
+    end
     newlen = len - delta
     for i in newlen+1:len
         @inbounds _unsetindex!(a, i)

--- a/base/array.jl
+++ b/base/array.jl
@@ -2119,7 +2119,12 @@ end
 splice!(a::Vector, inds) = (dltds = eltype(a)[]; _deleteat!(a, inds, dltds); dltds)
 
 function empty!(a::Vector)
-    _deleteend!(a, length(a))
+    T = eltype(a)
+    if isconcretetype(T) && datatype_pointerfree(T)
+        setfield!(a, :size, (0,))
+    else
+        _deleteend!(a, length(a))
+    end
     return a
 end
 


### PR DESCRIPTION
This produces much better code than _deleteend!, because it skips a needless error check for negative length. It's also easier on the compiler because it does not produce _unsetindex! code which is optimised away.

`empty!` is already pretty fast, but this produces smaller code more likely to inline.