### PR TITLE
use the versioned MPFR in `ccall`s

### DIFF
--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -253,7 +253,7 @@ function irrational(sym, val, def)
     bigconvert = isa(def,Symbol) ? quote
         function Base.BigFloat(::Irrational{$qsym}, r::MPFR.MPFRRoundingMode=Rounding.rounding_raw(BigFloat); precision=precision(BigFloat))
             c = BigFloat(;precision=precision)
-            ccall(($(string("mpfr_const_", def)), :libmpfr),
+            ccall(($(string("mpfr_const_", def)), Base.MPFR.libmpfr),
                   Cint, (Ref{BigFloat}, MPFR.MPFRRoundingMode), c, r)
             return c
         end

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -80,7 +80,7 @@ function _rand!(rng::AbstractRNG, z::BigFloat, sp::SamplerBigFloat, ::CloseOpen0
     randbool = _rand!(rng, z, sp)
     z.exp = 0
     randbool &&
-        ccall((:mpfr_sub_d, :libmpfr), Int32,
+        ccall((:mpfr_sub_d, Base.MPFR.libmpfr), Int32,
               (Ref{BigFloat}, Ref{BigFloat}, Cdouble, Base.MPFR.MPFRRoundingMode),
               z, z, 0.5, Base.MPFR.ROUNDING_MODE[])
     z
@@ -91,7 +91,7 @@ end
 function _rand!(rng::AbstractRNG, z::BigFloat, sp::SamplerBigFloat, ::CloseOpen01{BigFloat},
                 ::Nothing)
     _rand!(rng, z, sp, CloseOpen12(BigFloat))
-    ccall((:mpfr_sub_ui, :libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, Culong, Base.MPFR.MPFRRoundingMode),
+    ccall((:mpfr_sub_ui, Base.MPFR.libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, Culong, Base.MPFR.MPFRRoundingMode),
           z, z, 1, Base.MPFR.ROUNDING_MODE[])
     z
 end


### PR DESCRIPTION
The other `ccall`s to MPFR use the versioned lib name. I suppose the `ccall`s modified in this change were simply missed in PR #47676.