### PR TITLE
assume effects `terminates`, `noub` for `finalizer`

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -2650,6 +2650,10 @@ function builtin_effects(𝕃::AbstractLattice, @nospecialize(f::Builtin), argty
         2 ≤ length(argtypes) ≤ 3 || return EFFECTS_THROWS
         # Modeled more precisely in abstract_eval_getglobal
         return generic_getglobal_effects
+    elseif f === Core.finalizer
+        if length(argtypes) == 2
+            return Effects(EFFECTS_TOTAL; effect_free = ALWAYS_FALSE, inaccessiblememonly = ALWAYS_FALSE)
+        end
     elseif f === Core.get_binding_type
         length(argtypes) == 2 || return EFFECTS_THROWS
         # Modeled more precisely in abstract_eval_get_binding_type

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -83,7 +83,11 @@ end
 """
 function finalizer(@nospecialize(f), @nospecialize(o))
     _check_mutable(o)
-    Core.finalizer(f, o)
+    let fin = Core.finalizer  # only apply the effects to the call of `fin`
+        @_terminates_globally_meta
+        @_noub_meta
+        fin(f, o)
+    end
     return o
 end
 

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -83,11 +83,7 @@ end
 """
 function finalizer(@nospecialize(f), @nospecialize(o))
     _check_mutable(o)
-    let fin = Core.finalizer  # only apply the effects to the call of `fin`
-        @_terminates_globally_meta
-        @_noub_meta
-        fin(f, o)
-    end
+    Core.finalizer(f, o)
     return o
 end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -4654,6 +4654,7 @@ end
 
 @testset "effects for `finalizer`" begin
     @test (Base.Compiler.is_noub ∘ Base.infer_effects)(finalizer, Tuple{Function, Any})
+    @test (Base.Compiler.is_nothrow ∘ Base.infer_effects)(finalizer, Tuple{Function, Any})
     @test (Base.Compiler.is_terminates ∘ Base.infer_effects)(finalizer, Tuple{Function, Any})
 end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -4652,6 +4652,11 @@ end
     end
 end
 
+@testset "effects for `finalizer`" begin
+    @test (Base.Compiler.is_noub ∘ Base.infer_effects)(finalizer, Tuple{Function, Any})
+    @test (Base.Compiler.is_terminates ∘ Base.infer_effects)(finalizer, Tuple{Function, Any})
+end
+
 # issue #15283
 j15283 = 0
 let

--- a/test/core.jl
+++ b/test/core.jl
@@ -4654,7 +4654,7 @@ end
 
 @testset "effects for `finalizer`" begin
     @test (Base.Compiler.is_noub ∘ Base.infer_effects)(finalizer, Tuple{Function, Any})
-    @test (Base.Compiler.is_nothrow ∘ Base.infer_effects)(finalizer, Tuple{Function, Any})
+    @test (Base.Compiler.is_nothrow ∘ Base.infer_effects)(finalizer, Tuple{Function, TestMutable})  # throws for non-`mutable struct`
     @test (Base.Compiler.is_terminates ∘ Base.infer_effects)(finalizer, Tuple{Function, Any})
 end
 


### PR DESCRIPTION
While a particular finalizer (the first argument, when finally called) may lack these effects, it is my understanding that:

* A `Core.finalizer(f, o)` call always returns, thus always terminates.

* The `Core.finalizer` call in the method of `Base.finalizer` is `noub` because it is preceded by an error check for the second argument.