### PR TITLE
apply effects and `gc_safe` to GMP functionality

### DIFF
--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -83,7 +83,11 @@ end
 """
 function finalizer(@nospecialize(f), @nospecialize(o))
     _check_mutable(o)
-    Core.finalizer(f, o)
+    let fin = Core.finalizer  # only apply the effects to the call of `fin`
+        @_terminates_globally_meta
+        @_noub_meta
+        fin(f, o)
+    end
     return o
 end
 

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -66,10 +66,14 @@ mutable struct BigInt <: Signed
     size::Cint
     d::Ptr{Limb}
 
-    function BigInt(; nbits::Integer=0)
+    Base.@assume_effects :effect_free function BigInt(; nbits::Integer=0)
+        function clear!(b::BigInt)
+            Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+                @ccall gc_safe=true "$libgmp".__gmpz_clear(b::Ref{BigInt})::Cvoid
+            end
+        end
         b = MPZ.init2!(new(), nbits)
-        finalizer(cglobal((:__gmpz_clear, libgmp)), b)
-        return b
+        finalizer(clear!, b)
     end
 end
 
@@ -151,15 +155,35 @@ using ..GMP: BigInt, Limb, BITS_PER_LIMB, libgmp
 const mpz_t = Ref{BigInt}
 const bitcnt_t = Culong
 
-gmpz(op::Symbol) = (Symbol(:__gmpz_, op), libgmp)
+_gmpz(op::Symbol) = Symbol(:__gmpz_, op)
 
-init!(x::BigInt) = (ccall((:__gmpz_init, libgmp), Cvoid, (mpz_t,), x); x)
-init2!(x::BigInt, a) = (ccall((:__gmpz_init2, libgmp), Cvoid, (mpz_t, bitcnt_t), x, a); x)
+function init!(x::BigInt)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_init(x::mpz_t)::Cvoid
+    end
+    x
+end
+function init2!(x::BigInt, a)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_init2(x::mpz_t, a::bitcnt_t)::Cvoid
+    end
+    x
+end
 
-realloc2!(x, a) = (ccall((:__gmpz_realloc2, libgmp), Cvoid, (mpz_t, bitcnt_t), x, a); x)
-realloc2(a) = realloc2!(BigInt(), a)
+function realloc2!(x, a)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_realloc2(x::mpz_t, a::bitcnt_t)::Cvoid
+    end
+    x
+end
+Base.@assume_effects :effect_free realloc2(a) = realloc2!(BigInt(), a)
 
-sizeinbase(a::BigInt, b) = Int(ccall((:__gmpz_sizeinbase, libgmp), Csize_t, (mpz_t, Cint), a, b))
+function sizeinbase(a::BigInt, b)
+    x = Base.@assume_effects :effect_free :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_sizeinbase(a::mpz_t, b::Cint)::Csize_t
+    end
+    Int(x)
+end
 
 for (op, nbits) in (:add => :(BITS_PER_LIMB*(1 + max(abs(a.size), abs(b.size)))),
                     :sub => :(BITS_PER_LIMB*(1 + max(abs(a.size), abs(b.size)))),
@@ -168,44 +192,77 @@ for (op, nbits) in (:add => :(BITS_PER_LIMB*(1 + max(abs(a.size), abs(b.size))))
                     :gcd => 0, :lcm => 0, :and => 0, :ior => 0, :xor => 0)
     op! = Symbol(op, :!)
     @eval begin
-        $op!(x::BigInt, a::BigInt, b::BigInt) = (ccall($(gmpz(op)), Cvoid, (mpz_t, mpz_t, mpz_t), x, a, b); x)
-        $op(a::BigInt, b::BigInt) = $op!(BigInt(nbits=$nbits), a, b)
+        function $op!(x::BigInt, a::BigInt, b::BigInt)
+            Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+                @ccall gc_safe=true "$libgmp".$(_gmpz(op))(x::mpz_t, a::mpz_t, b::mpz_t)::Cvoid
+            end
+            x
+        end
+        Base.@assume_effects :effect_free $op(a::BigInt, b::BigInt) = $op!(BigInt(nbits=$nbits), a, b)
         $op!(x::BigInt, b::BigInt) = $op!(x, x, b)
     end
 end
 
-invert!(x::BigInt, a::BigInt, b::BigInt) =
-    ccall((:__gmpz_invert, libgmp), Cint, (mpz_t, mpz_t, mpz_t), x, a, b)
+function invert!(x::BigInt, a::BigInt, b::BigInt)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_invert(x::mpz_t, a::mpz_t, b::mpz_t)::Cint
+    end
+end
 invert!(x::BigInt, b::BigInt) = invert!(x, x, b)
-invert(a::BigInt, b::BigInt) = (ret=BigInt(); invert!(ret, a, b); ret)
+Base.@assume_effects :effect_free invert(a::BigInt, b::BigInt) = (ret=BigInt(); invert!(ret, a, b); ret)
 
 for op in (:add_ui, :sub_ui, :mul_ui, :mul_2exp, :fdiv_q_2exp, :pow_ui, :bin_ui)
     op! = Symbol(op, :!)
     @eval begin
-        $op!(x::BigInt, a::BigInt, b) = (ccall($(gmpz(op)), Cvoid, (mpz_t, mpz_t, Culong), x, a, b); x)
-        $op(a::BigInt, b) = $op!(BigInt(), a, b)
+        function $op!(x::BigInt, a::BigInt, b)
+            Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+                @ccall gc_safe=true "$libgmp".$(_gmpz(op))(x::mpz_t, a::mpz_t, b::Culong)::Cvoid
+            end
+            x
+        end
+        Base.@assume_effects :effect_free $op(a::BigInt, b) = $op!(BigInt(), a, b)
         $op!(x::BigInt, b) = $op!(x, x, b)
     end
 end
 
-ui_sub!(x::BigInt, a, b::BigInt) = (ccall((:__gmpz_ui_sub, libgmp), Cvoid, (mpz_t, Culong, mpz_t), x, a, b); x)
-ui_sub(a, b::BigInt) = ui_sub!(BigInt(), a, b)
+function ui_sub!(x::BigInt, a, b::BigInt)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_ui_sub(x::mpz_t, a::Culong, b::mpz_t)::Cvoid
+    end
+    x
+end
+Base.@assume_effects :effect_free ui_sub(a, b::BigInt) = ui_sub!(BigInt(), a, b)
 
 for op in (:scan1, :scan0)
     # when there is no meaningful answer, ccall returns typemax(Culong), where Culong can
     # be UInt32 (Windows) or UInt64; we return -1 in this case for all architectures
-    @eval $op(a::BigInt, b) = Int(signed(ccall($(gmpz(op)), Culong, (mpz_t, Culong), a, b)))
+    @eval function $op(a::BigInt, b)
+        x = Base.@assume_effects :effect_free :nothrow :terminates_globally :notaskstate let
+            @ccall gc_safe=true "$libgmp".$(_gmpz(op))(a::mpz_t, b::Culong)::Culong
+        end
+        Int(signed(x))
+    end
 end
 
-mul_si!(x::BigInt, a::BigInt, b) = (ccall((:__gmpz_mul_si, libgmp), Cvoid, (mpz_t, mpz_t, Clong), x, a, b); x)
-mul_si(a::BigInt, b) = mul_si!(BigInt(), a, b)
+function mul_si!(x::BigInt, a::BigInt, b)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_mul_si(x::mpz_t, a::mpz_t, b::Clong)::Cvoid
+    end
+    x
+end
+Base.@assume_effects :effect_free mul_si(a::BigInt, b) = mul_si!(BigInt(), a, b)
 mul_si!(x::BigInt, b) = mul_si!(x, x, b)
 
 for op in (:neg, :com, :sqrt, :set)
     op! = Symbol(op, :!)
     @eval begin
-        $op!(x::BigInt, a::BigInt) = (ccall($(gmpz(op)), Cvoid, (mpz_t, mpz_t), x, a); x)
-        $op(a::BigInt) = $op!(BigInt(), a)
+        function $op!(x::BigInt, a::BigInt)
+            Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+                @ccall gc_safe=true "$libgmp".$(_gmpz(op))(x::mpz_t, a::mpz_t)::Cvoid
+            end
+            x
+        end
+        Base.@assume_effects :effect_free $op(a::BigInt) = $op!(BigInt(), a)
     end
     op === :set && continue # MPZ.set!(x) would make no sense
     @eval $op!(x::BigInt) = $op!(x, x)
@@ -214,62 +271,143 @@ end
 for (op, T) in ((:fac_ui, Culong), (:set_ui, Culong), (:set_si, Clong), (:set_d, Cdouble))
     op! = Symbol(op, :!)
     @eval begin
-        $op!(x::BigInt, a) = (ccall($(gmpz(op)), Cvoid, (mpz_t, $T), x, a); x)
-        $op(a) = $op!(BigInt(), a)
+        function $op!(x::BigInt, a)
+            Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+                @ccall gc_safe=true "$libgmp".$(_gmpz(op))(x::mpz_t, a::$T)::Cvoid
+            end
+            x
+        end
+        Base.@assume_effects :effect_free $op(a) = $op!(BigInt(), a)
     end
 end
 
-popcount(a::BigInt) = Int(signed(ccall((:__gmpz_popcount, libgmp), Culong, (mpz_t,), a)))
+function popcount(a::BigInt)
+    x = Base.@assume_effects :effect_free :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_popcount(a::mpz_t)::Culong
+    end
+    Int(signed(x))
+end
 
-mpn_popcount(d::Ptr{Limb}, s::Integer) = Int(ccall((:__gmpn_popcount, libgmp), Culong, (Ptr{Limb}, Csize_t), d, s))
+function mpn_popcount(d::Ptr{Limb}, s::Integer)
+    x = Base.@assume_effects :effect_free :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpn_popcount(d::Ptr{Limb}, s::Csize_t)::Culong
+    end
+    Int(x)
+end
 mpn_popcount(a::BigInt) = mpn_popcount(a.d, abs(a.size))
 
 function tdiv_qr!(x::BigInt, y::BigInt, a::BigInt, b::BigInt)
-    ccall((:__gmpz_tdiv_qr, libgmp), Cvoid, (mpz_t, mpz_t, mpz_t, mpz_t), x, y, a, b)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_tdiv_qr(x::mpz_t, y::mpz_t, a::mpz_t, b::mpz_t)::Cvoid
+    end
     x, y
 end
-tdiv_qr(a::BigInt, b::BigInt) = tdiv_qr!(BigInt(), BigInt(), a, b)
+Base.@assume_effects :effect_free tdiv_qr(a::BigInt, b::BigInt) = tdiv_qr!(BigInt(), BigInt(), a, b)
 
-powm!(x::BigInt, a::BigInt, b::BigInt, c::BigInt) =
-    (ccall((:__gmpz_powm, libgmp), Cvoid, (mpz_t, mpz_t, mpz_t, mpz_t), x, a, b, c); x)
-powm(a::BigInt, b::BigInt, c::BigInt) = powm!(BigInt(), a, b, c)
+function powm!(x::BigInt, a::BigInt, b::BigInt, c::BigInt)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_powm(x::mpz_t, a::mpz_t, b::mpz_t, c::mpz_t)::Cvoid
+    end
+    x
+end
+Base.@assume_effects :effect_free powm(a::BigInt, b::BigInt, c::BigInt) = powm!(BigInt(), a, b, c)
 powm!(x::BigInt, b::BigInt, c::BigInt) = powm!(x, x, b, c)
 
 function gcdext!(x::BigInt, y::BigInt, z::BigInt, a::BigInt, b::BigInt)
-    ccall((:__gmpz_gcdext, libgmp), Cvoid, (mpz_t, mpz_t, mpz_t, mpz_t, mpz_t), x, y, z, a, b)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_gcdext(x::mpz_t, y::mpz_t, z::mpz_t, a::mpz_t, b::mpz_t)::Cvoid
+    end
     x, y, z
 end
-gcdext(a::BigInt, b::BigInt) = gcdext!(BigInt(), BigInt(), BigInt(), a, b)
+Base.@assume_effects :effect_free gcdext(a::BigInt, b::BigInt) = gcdext!(BigInt(), BigInt(), BigInt(), a, b)
 
-cmp(a::BigInt, b::BigInt) = Int(ccall((:__gmpz_cmp, libgmp), Cint, (mpz_t, mpz_t), a, b))
-cmp_si(a::BigInt, b) = Int(ccall((:__gmpz_cmp_si, libgmp), Cint, (mpz_t, Clong), a, b))
-cmp_ui(a::BigInt, b) = Int(ccall((:__gmpz_cmp_ui, libgmp), Cint, (mpz_t, Culong), a, b))
-cmp_d(a::BigInt, b) = Int(ccall((:__gmpz_cmp_d, libgmp), Cint, (mpz_t, Cdouble), a, b))
+function cmp(a::BigInt, b::BigInt)
+    x = Base.@assume_effects :effect_free :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_cmp(a::mpz_t, b::mpz_t)::Cint
+    end
+    Int(x)
+end
+function cmp_si(a::BigInt, b)
+    x = Base.@assume_effects :effect_free :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_cmp_si(a::mpz_t, b::Clong)::Cint
+    end
+    Int(x)
+end
+function cmp_ui(a::BigInt, b)
+    x = Base.@assume_effects :effect_free :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_cmp_ui(a::mpz_t, b::Culong)::Cint
+    end
+    Int(x)
+end
+function cmp_d(a::BigInt, b)
+    x = Base.@assume_effects :effect_free :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_cmp_d(a::mpz_t, b::Cdouble)::Cint
+    end
+    Int(x)
+end
 
-mpn_cmp(a::Ptr{Limb}, b::Ptr{Limb}, c) = ccall((:__gmpn_cmp, libgmp), Cint, (Ptr{Limb}, Ptr{Limb}, Clong), a, b, c)
+function mpn_cmp(a::Ptr{Limb}, b::Ptr{Limb}, c)
+    Base.@assume_effects :effect_free :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpn_cmp(a::Ptr{Limb}, b::Ptr{Limb}, c::Clong)::Cint
+    end
+end
 mpn_cmp(a::BigInt, b::BigInt, c) = mpn_cmp(a.d, b.d, c)
 
-get_str!(x, a, b::BigInt) = (ccall((:__gmpz_get_str,libgmp), Ptr{Cchar}, (Ptr{Cchar}, Cint, mpz_t), x, a, b); x)
-set_str!(x::BigInt, a, b) = Int(ccall((:__gmpz_set_str, libgmp), Cint, (mpz_t, Ptr{UInt8}, Cint), x, a, b))
-get_d(a::BigInt) = ccall((:__gmpz_get_d, libgmp), Cdouble, (mpz_t,), a)
+function get_str!(x, a, b::BigInt)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_get_str(x::Ptr{Cchar}, a::Cint, b::mpz_t)::Ptr{Cchar}
+    end
+    x
+end
+function set_str!(x::BigInt, a, b)
+    z = Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_set_str(x::mpz_t, a::Ptr{UInt8}, b::Cint)::Cint
+    end
+    Int(z)
+end
+function get_d(a::BigInt)
+    Base.@assume_effects :effect_free :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_get_d(a::mpz_t)::Cdouble
+    end
+end
 
 function export!(a::AbstractVector{T}, n::BigInt; order::Integer=-1, nails::Integer=0, endian::Integer=0) where {T<:Base.BitInteger}
     stride(a, 1) == 1 || throw(ArgumentError("a must have stride 1"))
-    ndigits = cld(sizeinbase(n, 2), 8*sizeof(T) - nails)
+    siz = sizeof(T)
+    ndigits = cld(sizeinbase(n, 2), 8*siz - nails)
     length(a) < ndigits && resize!(a, ndigits)
     fill!(a, zero(T))
     count = Ref{Csize_t}()
-    ccall((:__gmpz_export, libgmp), Ptr{T}, (Ptr{T}, Ref{Csize_t}, Cint, Csize_t, Cint, Csize_t, mpz_t),
-        a, count, order, sizeof(T), endian, nails, n)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_export(a::Ptr{T}, count::Ref{Csize_t}, order::Cint, siz::Csize_t, endian::Cint, nails::Csize_t, n::mpz_t)::Ptr{T}
+    end
     @assert count[] ≤ length(a)
     return a, Int(count[])
 end
 
-limbs_write!(x::BigInt, a) = ccall((:__gmpz_limbs_write, libgmp), Ptr{Limb}, (mpz_t, Clong), x, a)
-limbs_finish!(x::BigInt, a) = ccall((:__gmpz_limbs_finish, libgmp), Cvoid, (mpz_t, Clong), x, a)
+function limbs_write!(x::BigInt, a)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_limbs_write(x::mpz_t, a::Clong)::Ptr{Limb}
+    end
+end
+function limbs_finish!(x::BigInt, a)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_limbs_finish(x::mpz_t, a::Clong)::Cvoid
+    end
+end
 
-setbit!(x, a) = (ccall((:__gmpz_setbit, libgmp), Cvoid, (mpz_t, bitcnt_t), x, a); x)
-tstbit(a::BigInt, b) = ccall((:__gmpz_tstbit, libgmp), Cint, (mpz_t, bitcnt_t), a, b) % Bool
+function setbit!(x, a)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_setbit(x::mpz_t, a::bitcnt_t)::Cvoid
+    end
+    x
+end
+function tstbit(a::BigInt, b)
+    x = Base.@assume_effects :effect_free :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpz_tstbit(a::mpz_t, b::bitcnt_t)::Cint
+    end
+    x % Bool
+end
 
 end # module MPZ
 
@@ -917,7 +1055,7 @@ module MPQ
 import .Base: unsafe_rational, __throw_rational_argerror_zero
 import ..GMP: BigInt, MPZ, Limb, libgmp
 
-gmpq(op::Symbol) = (Symbol(:__gmpq_, op), libgmp)
+_gmpq(op::Symbol) = Symbol(:__gmpq_, op)
 
 mutable struct _MPQ
     num_alloc::Cint
@@ -948,32 +1086,39 @@ function sync_rational!(xq::_MPQ)
     return xq.rat
 end
 
-function Rational{BigInt}(num::BigInt, den::BigInt)
+Base.@assume_effects :effect_free function Rational{BigInt}(num::BigInt, den::BigInt)
     if iszero(den)
         iszero(num) && __throw_rational_argerror_zero(BigInt)
         return set_si(flipsign(1, num), 0)
     end
     xq = _MPQ(MPZ.set(num), MPZ.set(den))
-    ccall((:__gmpq_canonicalize, libgmp), Cvoid, (mpq_t,), xq)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpq_canonicalize(xq::mpq_t)::Cvoid
+    end
     return sync_rational!(xq)
 end
 
 # define set, set_ui, set_si, set_z, and their inplace versions
 function set!(z::Rational{BigInt}, x::Rational{BigInt})
+    zx = _MPQ(x)
     zq = _MPQ(z)
-    ccall((:__gmpq_set, libgmp), Cvoid, (mpq_t, mpq_t), zq, _MPQ(x))
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpq_set(zq::mpq_t, zx::mpq_t)::Cvoid
+    end
     return sync_rational!(zq)
 end
 
 function set_z!(z::Rational{BigInt}, x::BigInt)
     zq = _MPQ(z)
-    ccall((:__gmpq_set_z, libgmp), Cvoid, (mpq_t, MPZ.mpz_t), zq, x)
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpq_set_z(zq::mpq_t, x::MPZ.mpz_t)::Cvoid
+    end
     return sync_rational!(zq)
 end
 
 for (op, T) in ((:set, Rational{BigInt}), (:set_z, BigInt))
     op! = Symbol(op, :!)
-    @eval $op(a::$T) = $op!(unsafe_rational(BigInt(), BigInt()), a)
+    @eval Base.@assume_effects :effect_free $op(a::$T) = $op!(unsafe_rational(BigInt(), BigInt()), a)
 end
 
 # note that rationals returned from set_ui and set_si are not checked,
@@ -983,10 +1128,12 @@ for (op, T1, T2) in ((:set_ui, Culong, Culong), (:set_si, Clong, Culong))
     @eval begin
         function $op!(z::Rational{BigInt}, a, b)
             zq = _MPQ(z)
-            ccall($(gmpq(op)), Cvoid, (mpq_t, $T1, $T2), zq, a, b)
+            Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+                @ccall gc_safe=true "$libgmp".$(_gmpq(op))(zq::mpq_t, a::$T1, b::$T2)::Cvoid
+            end
             return sync_rational!(zq)
         end
-        $op(a, b) = $op!(unsafe_rational(BigInt(), BigInt()), a, b)
+        Base.@assume_effects :effect_free $op(a, b) = $op!(unsafe_rational(BigInt(), BigInt()), a, b)
     end
 end
 
@@ -998,9 +1145,12 @@ function add!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
         end
         return set!(z, iszero(x.den) ? x : y)
     end
+    xq = _MPQ(x)
+    yq = _MPQ(y)
     zq = _MPQ(z)
-    ccall((:__gmpq_add, libgmp), Cvoid,
-          (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpq_add(zq::mpq_t, xq::mpq_t, yq::mpq_t)::Cvoid
+    end
     return sync_rational!(zq)
 end
 
@@ -1012,9 +1162,12 @@ function sub!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
         iszero(x.den) && return set!(z, x)
         return set_si!(z, flipsign(-1, y.num), 0)
     end
+    xq = _MPQ(x)
+    yq = _MPQ(y)
     zq = _MPQ(z)
-    ccall((:__gmpq_sub, libgmp), Cvoid,
-          (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpq_sub(zq::mpq_t, xq::mpq_t, yq::mpq_t)::Cvoid
+    end
     return sync_rational!(zq)
 end
 
@@ -1025,9 +1178,12 @@ function mul!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
         end
         return set_si!(z, ifelse(xor(isnegative(x.num), isnegative(y.num)), -1, 1), 0)
     end
+    xq = _MPQ(x)
+    yq = _MPQ(y)
     zq = _MPQ(z)
-    ccall((:__gmpq_mul, libgmp), Cvoid,
-          (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpq_mul(zq::mpq_t, xq::mpq_t, yq::mpq_t)::Cvoid
+    end
     return sync_rational!(zq)
 end
 
@@ -1046,9 +1202,12 @@ function div!(z::Rational{BigInt}, x::Rational{BigInt}, y::Rational{BigInt})
         end
         return set_si!(z, flipsign(1, x.num), 0)
     end
+    xq = _MPQ(x)
+    yq = _MPQ(y)
     zq = _MPQ(z)
-    ccall((:__gmpq_div, libgmp), Cvoid,
-          (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
+    Base.@assume_effects :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpq_div(zq::mpq_t, xq::mpq_t, yq::mpq_t)::Cvoid
+    end
     return sync_rational!(zq)
 end
 
@@ -1056,12 +1215,17 @@ for (fJ, fC) in ((:+, :add), (:-, :sub), (:*, :mul), (://, :div))
     fC! = Symbol(fC, :!)
     @eval begin
         ($fC!)(x::Rational{BigInt}, y::Rational{BigInt}) = $fC!(x, x, y)
-        (Base.$fJ)(x::Rational{BigInt}, y::Rational{BigInt}) = $fC!(unsafe_rational(BigInt(), BigInt()), x, y)
+        Base.@assume_effects :effect_free (Base.$fJ)(x::Rational{BigInt}, y::Rational{BigInt}) = $fC!(unsafe_rational(BigInt(), BigInt()), x, y)
     end
 end
 
 function Base.cmp(x::Rational{BigInt}, y::Rational{BigInt})
-    Int(ccall((:__gmpq_cmp, libgmp), Cint, (mpq_t, mpq_t), _MPQ(x), _MPQ(y)))
+    xq = _MPQ(x)
+    yq = _MPQ(y)
+    z = Base.@assume_effects :effect_free :nothrow :terminates_globally :notaskstate let
+        @ccall gc_safe=true "$libgmp".__gmpq_cmp(xq::mpq_t, yq::mpq_t)::Cint
+    end
+    Int(z)
 end
 
 end # MPQ module

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -719,6 +719,31 @@ e = Rational{BigInt}(12345678901234567890123456789, 1234567890222222221211111110
     end
 end
 
+@testset "good effects" begin
+    @testset "test directly" begin
+        for f in (+, -, *)
+            @test (Base.Compiler.is_removable_if_unused ∘ Base.infer_effects)(f, Tuple{BigInt, BigInt})
+        end
+        for f in ((x -> x + 3), (x -> x - 3), (x -> x * 3), (x -> 3 + x), (x -> 3 - x), (x -> 3 * x))
+            @test (Base.Compiler.is_removable_if_unused ∘ Base.infer_effects)(f, Tuple{BigInt})
+        end
+    end
+    @testset "removable arithmetic gets optimized out" begin
+        function f(x)
+            x + 3
+            x - 3
+            x * 3
+            3 + x
+            3 - x
+            3 * x
+            x + x
+            x - x
+            x * x
+            x
+        end
+        @test (isone ∘ length ∘ (x -> x.code) ∘ first ∘ only ∘ code_typed)(f, Tuple{BigInt})
+    end
+end
 
 aa = 1//2
 bb = -1//3


### PR DESCRIPTION
* Use `ccall` macro, instead of raw `ccall`, to allow using `gc_safe=true`.

* Apply some effects:

    * `ccall`s get:

        * `nothrow`, C code does not throw

        * `terminates_globally`, GMP calls return

        * `notaskstate`, GMP cannot know about Julia's tasks AFAIK

    * non-mutating functions additionally get:

        * `effect_free`

* In the `BigInt()` constructor, call the new form of `finalizer`: `finalizer(func, b)` instead of `finalizer(ptr, b)`. The new form is a builtin, so it is handled better by the compiler. See PR #45423 and PR #59553.