### PR TITLE
Use jl_dlsym with search_deps=1 for ccalls

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1748,7 +1748,7 @@ struct JuliaOJIT::DLSymOptimizer {
 
     void *lookup_symbol(void *libhandle, const char *fname) JL_NOTSAFEPOINT {
         void *addr;
-        jl_dlsym(libhandle, fname, &addr, 0, 0);
+        jl_dlsym(libhandle, fname, &addr, 0, 1);
         return addr;
     }
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -2195,11 +2195,7 @@ enum JL_RTLD_CONSTANT {
      /* MacOS X 10.5+: */
      JL_RTLD_FIRST=128U
 };
-#ifdef _OS_DARWIN_
-#define JL_RTLD_DEFAULT (JL_RTLD_LAZY | JL_RTLD_DEEPBIND | JL_RTLD_FIRST)
-#else
 #define JL_RTLD_DEFAULT (JL_RTLD_LAZY | JL_RTLD_DEEPBIND)
-#endif
 
 typedef void *jl_libhandle; // compatible with dlopen (void*) / LoadLibrary (HMODULE)
 JL_DLLEXPORT jl_libhandle jl_load_dynamic_library(const char *fname, unsigned flags, int throw_err);

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -59,7 +59,7 @@ void *jl_load_and_lookup(const char *f_lib, const char *f_name, _Atomic(void*) *
     if (!handle)
         jl_atomic_store_release(hnd, (handle = jl_get_library(f_lib)));
     void * ptr;
-    jl_dlsym(handle, f_name, &ptr, 1, 0);
+    jl_dlsym(handle, f_name, &ptr, 1, 1);
     return ptr;
 }
 
@@ -80,7 +80,7 @@ void *jl_lazy_load_and_lookup(jl_value_t *lib_val, const char *f_name)
     } else
         jl_type_error("ccall", (jl_value_t*)jl_symbol_type, lib_val);
     void *ptr;
-    jl_dlsym(lib_ptr, f_name, &ptr, 1, 0);
+    jl_dlsym(lib_ptr, f_name, &ptr, 1, 1);
     return ptr;
 }
 

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1981,8 +1981,6 @@ let llvm = sprint(code_llvm, gc_safe_ccall, ())
 end
 
 @testset "jl_dlfind and dlsym" begin
-    # We shouldn't be able to call libc functions through libccalltest
-    @test_throws ErrorException ccall((:sqrt, libccalltest), Cdouble, (Cdouble,), 2.0)
     # Test that jl_dlfind finds things in the expected places.
     @test ccall(:jl_dlfind, Int, (Cstring,), "doesnotexist") == 0       # not found (RTLD_DEFAULT)
     @static if !Sys.iswindows()


### PR DESCRIPTION
Reverts the behaviour change for ccalls with an explicit library introduced by #58815.  This is motivated by libraries like MPI, where the dynamic library that actually defines a symbol is difficult to predict:
https://github.com/JuliaParallel/MPI.jl/issues/915#issuecomment-3293046616