### PR TITLE
[release-1.12] Fix missing CodeInstance owner lookup in _jl_invoke

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -3980,7 +3980,8 @@ STATIC_INLINE jl_value_t *_jl_invoke(jl_value_t *F, jl_value_t **args, uint32_t 
     // manually inlined copy of jl_method_compiled
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mfunc->cache);
     while (codeinst) {
-        if (jl_atomic_load_relaxed(&codeinst->min_world) <= world && world <= jl_atomic_load_relaxed(&codeinst->max_world)) {
+        if (jl_atomic_load_relaxed(&codeinst->min_world) <= world && world <= jl_atomic_load_relaxed(&codeinst->max_world)
+            && codeinst->owner == jl_nothing) {
             jl_callptr_t invoke = jl_atomic_load_acquire(&codeinst->invoke);
             if (invoke != NULL) {
                 jl_value_t *res = invoke(F, args, nargs, codeinst);


### PR DESCRIPTION
Fixed on main as 92fc06fd83a, but not fixed in earlier Julia versions

(cherry picked from commit 69ef5ce9959b317a83399dd4930adb247e84cbb0)

x-ref: #59558
