### PR TITLE
[CI] Use fixed version of Julia for whitespace workflow

### DIFF
--- a/.github/workflows/Whitespace.yml
+++ b/.github/workflows/Whitespace.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
       - uses: julia-actions/setup-julia@5c9647d97b78a5debe5164e9eec09d653d29bd71 # v2.6.1
         with:
-          version: '1'
+          version: '1.11.6'
       - name: Check whitespace
         run: |
           contrib/check-whitespace.jl


### PR DESCRIPTION
Jobs are currently failing because they're failing to download v1.11.7 ([example](https://github.com/JuliaLang/julia/actions/runs/17748950373/job/50440011491?pr=59565)), which is currently tagged but not fully released yet.