### PR TITLE
fix: Make `promote_typejoin` public

### DIFF
--- a/base/public.jl
+++ b/base/public.jl
@@ -124,10 +124,12 @@ public
 # filesystem operations
     rename,
 
+# promotion
+    promote_typejoin,
+
 # misc
     notnothing,
     runtests,
     text_colors,
     depwarn,
-    donotdelete,
-    promote_typejoin
+    donotdelete

--- a/base/public.jl
+++ b/base/public.jl
@@ -129,4 +129,5 @@ public
     runtests,
     text_colors,
     depwarn,
-    donotdelete
+    donotdelete,
+    promote_typejoin


### PR DESCRIPTION
The function should be public, because it is referenced to from exported
`promote_rule` and others.
