### PR TITLE
Document changing view indices after construction as undefined behavior.

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -173,7 +173,8 @@ Calling [`getindex`](@ref) or [`setindex!`](@ref) on the returned value
 (often a [`SubArray`](@ref)) computes the indices to access or modify the
 parent array on the fly.  The behavior is undefined if the shape of the parent array is
 changed after `view` is called because there is no bound check for the parent array; e.g.,
-it may cause a segmentation fault.
+it may cause a segmentation fault. It is likewise undefined behavior to modify the `inds`
+array(s) after construction of the view.
 
 Some immutable parent arrays (like ranges) may choose to simply
 recompute a new array in some circumstances instead of returning


### PR DESCRIPTION
Cf. https://discourse.julialang.org/t/is-it-defined-behavior-to-modify-iter-while-for-looping-over-it/132477/11?u=gunnarfarneback

```
julia> v = collect(1:7);

julia> i = collect(1:7);

julia> w = view(v, i);

julia> i[end] = 0;

julia> w[end]
128974949945120
```