### PR TITLE
InteractiveUtils: Support unannotated values after `Vararg` type annotation

### DIFF
--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -23,13 +23,6 @@ function make_tuple_type(types::Vector{Any})
     throw(ArgumentError("More than one `Core.Vararg` type present in argument tuple ($(join(types[varargs], ", "))); if provided, it must be unique"))
 end
 
-function is_vararg_symbol(@nospecialize ex)
-    ex = ignore_qualifiers(ex)
-    name = isexpr(ex, :curly) ? ex.args[1] : ex
-    return in(name, (:Vararg, Vararg))
-end
-ignore_qualifiers(@nospecialize ex) = isexpr(ex, :(.), 2) ? ex.args[2] : ex
-
 function extract_where_parameters(ex::Expr)
     isexpr(ex, :where) || return ex, nothing
     ex.args[1], ex.args[2:end]

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -35,7 +35,7 @@ function make_tuple_type(types::Vector{Any})
     return Tuple{@view(types[1:vararg])...}
 end
 
-skip_type_check(@nospecialize(T)) = isa(T, TypeVar) || isa(T, UnionAll) || Core.has_free_typevars(T)
+skip_type_check(@nospecialize(T)) = isa(T, TypeVar) || Core.has_free_typevars(T)
 
 function extract_where_parameters(ex::Expr)
     isexpr(ex, :where) || return ex, nothing

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -18,7 +18,7 @@ function make_tuple_type(types::Vector{Any})
         i == 1 && continue # ignore function type
         type = types[i]
         if isa(type, Core.TypeofVararg)
-            vararg !== -1 && throw(ArgumentError("More than one `Core.Vararg` type present in argument tuple ($type detected after $(types[vararg])))); if provided, it must be unique"))
+            vararg !== -1 && throw(ArgumentError("More than one `Core.Vararg` type present in argument tuple ($type detected after $(types[vararg])); if provided, it must be unique"))
             vararg = i
             if isdefined(type, :N)
                 n = length(types) - vararg

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -35,7 +35,7 @@ function make_tuple_type(types::Vector{Any})
     return Tuple{@view(types[1:vararg])...}
 end
 
-skip_type_check(@nospecialize(T)) = isa(T, TypeVar) || Core.has_free_typevars(T)
+skip_type_check(@nospecialize(T)) = Core.has_free_typevars(T)
 
 function extract_where_parameters(ex::Expr)
     isexpr(ex, :where) || return ex, nothing

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -452,16 +452,23 @@ end
         @test_throws "Inconsistent type `Float64`" @eval @code_typed +(1, 2, 3, 4::Int..., 5.0)
         @test_throws "Inconsistent type `Float64`" @eval @code_typed +(1, 2, 3, 4::Vararg{Int}, ::Float64)
         @test_throws "Inconsistent type `Any`" @eval @code_typed +(1, 2, 3, 4::Vararg{Int}, ::Any)
-        @test_throws "exactly 2 types" @eval @code_typed +(1, 2, 3, 4::Vararg{Int,2}, 5)
-        @test_throws "found 1 instead" @eval @code_typed +(1, 2, 3, 4::Vararg{Int,2}, 5)
-        @test_throws "found 3 instead" @eval @code_typed +(1, 2, 3, 4::Vararg{Int,2}, 5, 6, 7)
+        @test_throws r"at most 2 types .* found 3 instead" @eval @code_typed +(1, 2, 3, 4::Vararg{Int,2}, 5, 6)
         @test (@code_typed +(1, 2, 3, 4::Vararg{Int}))[2] === Int
         @test (@code_typed +(1, 2, 3, 4::Vararg{Int}, 5))[2] === Int
-        @test (@code_typed +(1, 2, 3, 4::Vararg{Int, 3}, 5, 6, 7))[2] === Int
+        @test (@code_typed +(1, 2, 3, 4::Vararg{Int, 3}))[2] === Int
+        @test (@code_typed +(1, 2, 3, 4::Vararg{Int, 3}, 5))[2] === Int
+        @test (@code_typed +(1, 2, 3, 4::Vararg{Int, 3}, 5, 6))[2] === Int
         @test (@code_typed +(1, 2, 3, 4::Vararg))[2] === Any
         @test (@code_typed +(1, 2, 3, 4::Vararg, 5.0))[2] === Any
         @test (@code_typed +(1, 2, 3, ::Int...))[2] === Int
         @test (@code_typed +(1, 2, 3, ::Int..., 5))[2] === Int
+        # We just ignore the checks with `where` parameters for simplicity of implementation.
+        @test isa((@code_typed +(::T, ::Vararg{T}, ::T) where {T}), Vector{Any})
+        @test isa((@code_typed +(::T, ::Vararg{T}, ::Float64) where {T<:Real}), Vector{Any})
+        @test isa((@code_typed +(::T, ::Vararg{T}, ::Float64) where {T<:Real}), Vector{Any})
+        @test isa((@code_typed +(::T, ::Vararg{T}, ::Int) where {T<:Real}), Vector{Any})
+        @test isa((@code_typed +(::T, ::Vararg{Vector{T}}, ::Int) where {T<:Real}), Vector{Any})
+        @test isa((@code_typed +(::T, ::Vararg{Int}, ::T) where {T<:Real}), Vector{Any})
     end
 end
 

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -445,6 +445,17 @@ end
         _, rt = ret
         @test rt === Bool
     end
+
+    @testset "Vararg handling" begin
+        @test_throws "cannot come after" @eval @code_typed +(::Vararg{Int}, ::Float64)
+        @test_throws "cannot come after" @eval @code_typed +(::Int..., ::Float64)
+        @test (@code_typed +(1, 2, 3, 4::Vararg{Int}))[2] === Int
+        @test (@code_typed +(1, 2, 3, 4::Vararg{Int}, 5))[2] === Int
+        @test (@code_typed +(1, 2, 3, 4::Vararg{Int}, 5.0))[2] === Int # 5.0 gets purposefully ignored
+        @test (@code_typed +(1, 2, 3, ::Int...))[2] === Int
+        @test (@code_typed +(1, 2, 3, ::Int..., 5))[2] === Int
+        @test (@code_typed +(1, 2, 3, ::Int..., 5.0))[2] === Int
+    end
 end
 
 module HygieneTest

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -447,11 +447,11 @@ end
     end
 
     @testset "Vararg handling" begin
-        @test_throws "cannot come after" @eval @code_typed +(::Vararg{Int}, ::Float64)
-        @test_throws "cannot come after" @eval @code_typed +(::Int..., ::Float64)
+        @test_throws "More than one `Core.Vararg`" @eval (@code_typed +(1, 2::Vararg{Int}, 3, 4::Vararg{Int}))[2]
         @test (@code_typed +(1, 2, 3, 4::Vararg{Int}))[2] === Int
         @test (@code_typed +(1, 2, 3, 4::Vararg{Int}, 5))[2] === Int
         @test (@code_typed +(1, 2, 3, 4::Vararg{Int}, 5.0))[2] === Int # 5.0 gets purposefully ignored
+        @test (@code_typed +(1, 2, 3, 4::Vararg{Int}, ::Float64))[2] === Int # same for the Float64 type annotation
         @test (@code_typed +(1, 2, 3, ::Int...))[2] === Int
         @test (@code_typed +(1, 2, 3, ::Int..., 5))[2] === Int
         @test (@code_typed +(1, 2, 3, ::Int..., 5.0))[2] === Int

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -447,14 +447,21 @@ end
     end
 
     @testset "Vararg handling" begin
-        @test_throws "More than one `Core.Vararg`" @eval (@code_typed +(1, 2::Vararg{Int}, 3, 4::Vararg{Int}))[2]
+        @test_throws "More than one `Core.Vararg`" @eval @code_typed +(1, 2::Vararg{Int}, 3, 4::Vararg{Float64})
+        @test_throws "Inconsistent type `Float64`" @eval @code_typed +(1, 2, 3, 4::Vararg{Int}, 5.0)
+        @test_throws "Inconsistent type `Float64`" @eval @code_typed +(1, 2, 3, 4::Int..., 5.0)
+        @test_throws "Inconsistent type `Float64`" @eval @code_typed +(1, 2, 3, 4::Vararg{Int}, ::Float64)
+        @test_throws "Inconsistent type `Any`" @eval @code_typed +(1, 2, 3, 4::Vararg{Int}, ::Any)
+        @test_throws "exactly 2 types" @eval @code_typed +(1, 2, 3, 4::Vararg{Int,2}, 5)
+        @test_throws "found 1 instead" @eval @code_typed +(1, 2, 3, 4::Vararg{Int,2}, 5)
+        @test_throws "found 3 instead" @eval @code_typed +(1, 2, 3, 4::Vararg{Int,2}, 5, 6, 7)
         @test (@code_typed +(1, 2, 3, 4::Vararg{Int}))[2] === Int
         @test (@code_typed +(1, 2, 3, 4::Vararg{Int}, 5))[2] === Int
-        @test (@code_typed +(1, 2, 3, 4::Vararg{Int}, 5.0))[2] === Int # 5.0 gets purposefully ignored
-        @test (@code_typed +(1, 2, 3, 4::Vararg{Int}, ::Float64))[2] === Int # same for the Float64 type annotation
+        @test (@code_typed +(1, 2, 3, 4::Vararg{Int, 3}, 5, 6, 7))[2] === Int
+        @test (@code_typed +(1, 2, 3, 4::Vararg))[2] === Any
+        @test (@code_typed +(1, 2, 3, 4::Vararg, 5.0))[2] === Any
         @test (@code_typed +(1, 2, 3, ::Int...))[2] === Int
         @test (@code_typed +(1, 2, 3, ::Int..., 5))[2] === Int
-        @test (@code_typed +(1, 2, 3, ::Int..., 5.0))[2] === Int
     end
 end
 


### PR DESCRIPTION
Implements #58900, ignoring any arguments coming after a `::Vararg`/`::Vararg{...}`/`::T...` annotation, after having ensured that no explicit type annotations were present on the dropped arguments.

The logic to detect whether it is a call to `Vararg` is a bit fishy, as we assume `A.B.C.Vararg` is the same as `Core.Vararg`, and we ignore that hygiene may apply another scope, but I think it is a reasonable behavior/expectation that if someone annotates an argument with`Vararg` they mean `Core.Vararg`, not a custom `Vararg` type. I don't feel strongly about that though.