### PR TITLE
specialize show of `:` to make `reshape` trimmable

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1054,6 +1054,10 @@ struct Colon <: Function
 end
 const (:) = Colon()
 
+function show(io::IO, ::Colon)
+    show_type_name(io, Colon.name)
+    print(io, "()")
+end
 
 """
     Val(c)

--- a/contrib/juliac/juliac-trim-base.jl
+++ b/contrib/juliac/juliac-trim-base.jl
@@ -77,7 +77,6 @@ end
             print(io, T.var.name)
         end
     end
-    show_type_name(io::IO, tn::Core.TypeName) = print(io, tn.name)
     # this function is not `--trim`-compatible if it resolves to a Varargs{...} specialization
     # and since it only has 1-argument methods this happens too often by default (just 2-3 args)
     setfield!(typeof(throw_eachindex_mismatch_indices).name, :max_args, Int32(5), :monotonic)

--- a/test/trimming/trimmability.jl
+++ b/test/trimming/trimmability.jl
@@ -48,5 +48,7 @@ function @main(args::Vector{String})::Cint
     catch
     end
 
+    Base.donotdelete(reshape([1,2,3],:,1,1))
+
     return 0
 end


### PR DESCRIPTION
I also noticed that the standard Base.show_type_name appears to be trimmable so we don't need the override. We might still want it for code size, but probably not a big deal.