### PR TITLE
Expose `Core.memoryrefoffset` as `Base.memoryindex`

### DIFF
--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -71,7 +71,27 @@ size(a::GenericMemory) = (length(a),)
 IndexStyle(::Type{<:GenericMemory}) = IndexLinear()
 
 parent(ref::GenericMemoryRef) = ref.mem
-parentindices(ref::GenericMemoryRef) = (memoryrefoffset(ref),)
+
+"""
+    memoryindex(ref::GenericMemoryRef)::Int
+
+Get the 1-based index of `ref` in its `GenericMemory`.
+
+# Examples
+```jldoctest
+julia> mem = Memory{String}(undef, 10);
+
+julia> ref = Base.memoryindex(memoryref(mem, 3))
+3
+
+julia> Base.memoryindex(memoryref(Memory{Nothing}, 10), 8)
+8
+```
+
+!!! compat "Julia 1.13"
+    This function requires at least Julia 1.13.
+"""
+memoryindex(ref::GenericMemoryRef) = memoryrefoffset(ref)
 
 pointer(mem::GenericMemoryRef) = unsafe_convert(Ptr{Cvoid}, mem) # no bounds check, even for empty array
 

--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -84,7 +84,7 @@ julia> mem = Memory{String}(undef, 10);
 julia> ref = Base.memoryindex(memoryref(mem, 3))
 3
 
-julia> Base.memoryindex(memoryref(Memory{Nothing}, 10), 8)
+julia> Base.memoryindex(memoryref(Memory{Nothing}(undef, 10), 8))
 8
 ```
 

--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -71,6 +71,7 @@ size(a::GenericMemory) = (length(a),)
 IndexStyle(::Type{<:GenericMemory}) = IndexLinear()
 
 parent(ref::GenericMemoryRef) = ref.mem
+parentindices(ref::GenericMemoryRef) = (memoryrefoffset(ref),)
 
 pointer(mem::GenericMemoryRef) = unsafe_convert(Ptr{Cvoid}, mem) # no bounds check, even for empty array
 

--- a/base/public.jl
+++ b/base/public.jl
@@ -34,6 +34,7 @@ public
 # arrays
     has_offset_axes,
     require_one_based_indexing,
+    memoryindex,
 
 # collections
     IteratorEltype,

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -34,6 +34,7 @@ Base.GenericMemory
 Base.Memory
 Base.Memory(::UndefInitializer, ::Int)
 Base.memoryref
+Base.memoryindex
 Base.Slices
 Base.RowSlices
 Base.ColumnSlices

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3385,11 +3385,11 @@ end
     mem = Memory{Float32}(undef, 3)
     ref = memoryref(mem, 2)
     @test parent(ref) === mem
-    @test parentindices(ref) === (2,)
+    @test Base.memoryindex(ref) === 2
 
     # Test for zero-sized structs
     mem = Memory{Nothing}(undef, 10)
     ref = memoryref(mem, 8)
     @test parent(ref) === mem
-    @test parentindices(ref) === (8,)
+    @test Base.memoryindex(ref) === 8
 end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3385,4 +3385,11 @@ end
     mem = Memory{Float32}(undef, 3)
     ref = memoryref(mem, 2)
     @test parent(ref) === mem
+    @test parentindices(ref) === (2,)
+
+    # Test for zero-sized structs
+    mem = Memory{Nothing}(undef, 10)
+    ref = memoryref(mem, 8)
+    @test parent(ref) === mem
+    @test parentindices(ref) === (8,)
 end


### PR DESCRIPTION
This exposes Core.memoryrefoffset as API through a generic function - currently the public, unexported `Base.memoryindex`

This closes https://github.com/JuliaLang/julia/issues/59574.

In the issue, we did not reach consensus on what function should be used. The possibilities floated were:
1. Make the built-in `Core.memoryrefoffset` public
2. Define `Base.parentindices(::GenericMemoryRef)` (what this PR originally did)
3. Create and export/make public a new generic function specifically for memoryrefs.

I don't care much either way, but went with option 2 initially.