### PR TITLE
Improve char to int parsing, and add `tryparse` method

### DIFF
--- a/test/parse.jl
+++ b/test/parse.jl
@@ -29,6 +29,13 @@
     @test parse(Int, 'a', base=16) == 10
     @test_throws ArgumentError parse(Int, 'a')
     @test_throws ArgumentError parse(Int,typemax(Char))
+
+    @test tryparse(Int, '8') === 8
+    @test tryparse(Int, 'a') === nothing
+    @test tryparse(Int, 'a'; base=11) === 10
+    @test tryparse(Int32, 'a'; base=11) === Int32(10)
+    @test tryparse(UInt8, 'f'; base=16) === 0x0f
+    @test tryparse(UInt8, 'f'; base=15) === nothing
 end
 
 # Issue 29451


### PR DESCRIPTION
This was orignially a larger PR, but I've shelved the larger refactoring for now.
This PR does two things:

* Add a new method `tryparse(::Type{T}, c::AbstractChar; base::Integer=10) where {T <: Integer}` which was previously missing
* Speed up parsing of chars to integer by ~4x