### PR TITLE
C API for module creation

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -330,6 +330,8 @@
     XX(jl_new_method_table) \
     XX(jl_new_method_uninit) \
     XX(jl_new_module) \
+    XX(jl_begin_new_module) \
+    XX(jl_end_new_module) \
     XX(jl_new_opaque_closure_from_code_info) \
     XX(jl_new_opaque_closure_from_code_info_in_world) \
     XX(jl_new_primitivetype) \


### PR DESCRIPTION
Provide a way to create new modules without resorting to passing an `Expr(:module, ...)` to `eval()` by splitting up `jl_eval_module_expr()` into three pieces:

Two module creation functions which are exported:

* `jl_begin_new_module()`
  - Creates the module
  - Situates it within the module hierarchy (creating a binding within the parent module, setting the module parent and inheriting uuid, registering root modules)
  - Deals with global rooting during initialization and state for detecting whether the module is open for eval.
  - Creates standard imports and bindings for module-local eval and include
* `jl_end_new_module()` cleans up some of this state and calls `__init__()` for the module and its children when necessary.

The `Expr`-related machinery is left in the internal function `jl_eval_module_expr()`.

Something along these lines is required to avoid calling `eval(Expr(:module, ...))` in the JuliaLowering implementation of module evaluation where we try never to construct `Expr`.

There's clearly further cleanup which could be done here. It would be nice to use less global state (`jl_current_modules` and `jl_module_init_order`) and to not to have the `Base.__toplevel__` hack. However I wanted to keep this PR small so I've resisted the temptation to change anything more for now.

Similar to #57965 in the sense that it splits more functionality out of `eval()`.