### PR TITLE
fix the docstring signature of `getfield`

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2470,15 +2470,15 @@ julia> Tuple(Real[1, 2, pi])  # takes a collection
 tuple
 
 """
-    getfield(value, name::Symbol, [boundscheck::Bool=true], [order::Symbol])
-    getfield(value, i::Int, [boundscheck::Bool=true], [order::Symbol])
+    getfield(value, name::Symbol, [order::Symbol], [boundscheck::Bool=true])
+    getfield(value, i::Int, [order::Symbol], [boundscheck::Bool=true])
 
 Extract a field from a composite `value` by name or position.
 
-Optionally, an ordering can be defined for the operation.  If the field was
-declared `@atomic`, the specification is strongly recommended to be compatible
-with the stores to that location. Otherwise, if not declared as `@atomic`, this
-parameter must be `:not_atomic` if specified.
+Optionally, an ordering can be defined for the operation.
+If the field was declared `@atomic`, the specification is strongly recommended to be
+compatible with the stores to that location.
+Otherwise, if not declared as `@atomic`, this parameter must be `:not_atomic` if specified.
 
 The bounds check may be disabled, in which case the behavior of this function is
 undefined if `i` is out of bounds.


### PR DESCRIPTION
When both `order` and `boundscheck` arguments are given to a `getfield` call, the order need to be `order` -> `boundscheck`. The docstring should reflect this.