### PR TITLE
Make `SubString(::AbstractString)` a noop construction

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -447,12 +447,10 @@ end
 
 function _annotatedmatch(m::RegexMatch{S}, str::AnnotatedString{S}) where {S<:AbstractString}
     RegexMatch{AnnotatedString{S}}(
-        (@inbounds SubString{AnnotatedString{S}}(
-            str, m.match.offset, m.match.ncodeunits, Val(:noshift))),
+        _unsafe_new_substring(str, m.match.offset, m.match.ncodeunits),
         Union{Nothing,SubString{AnnotatedString{S}}}[
             if !isnothing(cap)
-                (@inbounds SubString{AnnotatedString{S}}(
-                    str, cap.offset, cap.ncodeunits, Val(:noshift)))
+                _unsafe_new_substring(str, cap.offset, cap.ncodeunits)
             end for cap in m.captures],
         m.offset, m.offsets, m.regex)
 end

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -44,7 +44,7 @@ struct SubString{T<:AbstractString} <: AbstractString
         end
         new(s, i, j)
     end
-    function _unsafe_new_substring(s::AbstractString, offset::Int, ncodeunits::Int)
+    global function _unsafe_new_substring(s::AbstractString, offset::Int, ncodeunits::Int)
         new{typeof(s)}(s, offset, ncodeunits)
     end
 end

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -56,8 +56,16 @@ end
     SubString(s.string, s.offset+i, s.offset+j)
 end
 
-SubString(s::AbstractString) = SubString(s, 1, lastindex(s)::Int)
-SubString{T}(s::T) where {T<:AbstractString} = SubString{T}(s, 1, lastindex(s)::Int)
+function SubString(s::AbstractString)
+    # Note: This is always valid, and will make the construction a noop
+    return @inbounds @inline SubString{typeof(s)}(
+        s, 0, Int(ncodeunits(s))::Int, Val{:noshift}()
+    )
+end
+
+SubString{T}(s::T) where {T<:AbstractString} = SubString(s)
+
+SubString(s::SubString) = s
 
 @propagate_inbounds view(s::AbstractString, r::AbstractUnitRange{<:Integer}) = SubString(s, r)
 @propagate_inbounds maybeview(s::AbstractString, r::AbstractUnitRange{<:Integer}) = view(s, r)

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -44,6 +44,9 @@ struct SubString{T<:AbstractString} <: AbstractString
         end
         new(s, i, j)
     end
+    function _unsafe_new_substring(s::AbstractString, offset::Int, ncodeunits::Int)
+        new{typeof(s)}(s, offset, ncodeunits)
+    end
 end
 
 @propagate_inbounds SubString(s::T, i::Int, j::Int) where {T<:AbstractString} = SubString{T}(s, i, j)
@@ -58,9 +61,7 @@ end
 
 function SubString(s::AbstractString)
     # Note: This is always valid, and will make the construction a noop
-    return @inbounds @inline SubString{typeof(s)}(
-        s, 0, Int(ncodeunits(s))::Int, Val{:noshift}()
-    )
+    _unsafe_new_substring(s, 0, Int(ncodeunits(s))::Int)
 end
 
 SubString{T}(s::T) where {T<:AbstractString} = SubString(s)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -377,7 +377,7 @@ end
     end
     off = s isa String ? 0 : s.offset
     par = s isa String ? s : s.string
-    @inbounds @inline SubString{String}(par, off, len, Val{:noshift}())
+    _unsafe_new_substring(par, off, len)
 end
 """
     lstrip([pred=isspace,] str::AbstractString)::SubString


### PR DESCRIPTION
This is always valid, and requires no checks or index computations.

Note that this PR is purely internal. There is a separate discussion to be had about an API for this (which I also think we should have), ref https://github.com/JuliaLang/julia/issues/59610