### PR TITLE
Don't look at past partitions when doing inference

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3704,13 +3704,13 @@ function scan_specified_partitions(query::F1, walk_binding_partition::F2,
             @assert lookup_world in partition_validity
             this_rte = query(interp, leaf_binding, leaf_partition)
             if @isdefined(rte)
+                if min_world(total_validity) <= wwr.this
+                    @goto out
+                end
                 if this_rte === rte
                     total_validity = union(total_validity, partition_validity)
                     lookup_world = min_world(total_validity) - 1
                     continue
-                end
-                if min_world(total_validity) <= wwr.this
-                    @goto out
                 end
             end
             total_validity = partition_validity

--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -1075,3 +1075,11 @@ let io = IOBuffer()
     str = String(take!(io))
     @test occursin("julia.write_barrier", str)
 end
+
+f42559 = 5
+foo42559() = f42559
+let io = IOBuffer()
+    code_llvm(io, foo42559, Tuple{}, raw=true, optimize=false)
+    str = String(take!(io))
+    @test !occursin("jl_get_binding_value_seqcst", str)
+end


### PR DESCRIPTION
We were looking at partitions that could never be reached here, causing odd codegen behaviour.

Fixes some part of https://github.com/JuliaLang/julia/issues/42559
