### PR TITLE
add doc string for `IO` and include it into the docs

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -5,7 +5,7 @@
 """
     IO
 
-Abstract supertype for input/output interfaces.
+Abstract supertype for input/output types.
 """
 IO
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -3,6 +3,13 @@
 # Generic IO stubs -- all subtypes should implement these (if meaningful)
 
 """
+    IO
+
+Abstract supertype for input/output interfaces.
+"""
+IO
+
+"""
     EOFError()
 
 No more data was available to read from a file or stream.

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -3,6 +3,7 @@
 ## General I/O
 
 ```@docs
+IO
 Base.stdout
 Base.stderr
 Base.stdin


### PR DESCRIPTION
The intention is to add just a minimal doc string. Other PRs attempt to document the interface, such as:

* #41291

* #58024

* #59069