### PR TITLE
Remove GPL libraries from the Julia build for binary-dist target

### DIFF
--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -15,6 +15,8 @@ include $(JULIAHOME)/deps/*.version
 
 VERSDIR := v$(shell cut -d. -f1-2 < $(JULIAHOME)/VERSION)
 DIRS := $(build_datarootdir)/julia/stdlib/$(VERSDIR) $(build_prefix)/manifest/$(VERSDIR)
+LIBDIR := $(build_datarootdir)/lib/julia
+
 $(foreach dir,$(DIRS),$(eval $(call dir_target,$(dir))))
 
 JLLS = DSFMT GMP CURL LIBGIT2 LLVM LIBSSH2 LIBUV OPENSSL MPFR NGHTTP2 \
@@ -60,8 +62,19 @@ $(foreach module, $(STDLIBS), $(eval $(call symlink_target,$$(JULIAHOME)/stdlib/
 
 STDLIBS_LINK_TARGETS := $(addprefix $(build_datarootdir)/julia/stdlib/$(VERSDIR)/,$(STDLIBS))
 
+remove-gpl-libs:
+ifeq ($(USE_GPL_LIBS),0)
+	@echo Removing GPL libs...
+	-rm -f $(LIBDIR)/libcholmod*
+	-rm -f $(LIBDIR)/libklu_cholmod*
+	-rm -f $(LIBDIR)/librbio*
+	-rm -f $(LIBDIR)/libspqr*
+	-rm -f $(LIBDIR)/libumfpack*
+endif
+
 getall get: $(addprefix get-, $(STDLIBS_EXT) $(JLL_NAMES))
-install: version-check $(addprefix install-, $(STDLIBS_EXT) $(JLL_NAMES)) $(STDLIBS_LINK_TARGETS)
+
+install: version-check $(addprefix install-, $(STDLIBS_EXT) $(JLL_NAMES)) $(STDLIBS_LINK_TARGETS) remove-gpl-libs
 version-check: $(addprefix version-check-, $(STDLIBS_EXT))
 uninstall: $(addprefix uninstall-, $(STDLIBS_EXT))
 extstdlibclean:


### PR DESCRIPTION
Currently we support removing GPL dependencies in the full source build. This will also remove the GPL dependencies from the binary-dist target when built with JLLs.

I almost feel like it would be simpler to have a new SuiteSparse_NOGPL_jll package. Then in the default build, things stay as they are. In the no gpl build use the new JLL. In the no GPL build, if someone then tries to use a GPL SuiteSparse library, a warning can be printed asking them to get a different build of Julia. 

@DilumAluthge @andreasnoack @giordano Thoughts?