### PR TITLE
Fix warnings redundant redeclaration of `jl_n_gcthreads`

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -2055,7 +2055,6 @@ JL_DLLEXPORT int jl_is_debugbuild(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_sym_t *jl_get_UNAME(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_sym_t *jl_get_ARCH(void) JL_NOTSAFEPOINT;
 JL_DLLIMPORT jl_value_t *jl_get_libllvm(void) JL_NOTSAFEPOINT;
-extern JL_DLLIMPORT int jl_n_gcthreads;
 extern int jl_n_markthreads;
 extern int jl_n_sweepthreads;
 


### PR DESCRIPTION
Specifically, this warning I see in tests against Julia nightly e.g. [in this log](https://github.com/gap-system/gap/actions/runs/17926134820/job/50972543899?pr=6122#step:7:234):
```
/opt/hostedtoolcache/julia/nightly/x64/include/julia/julia.h:2058:25: error: redundant redeclaration of ‘jl_n_gcthreads’ [-Werror=redundant-decls]
 2058 | extern JL_DLLIMPORT int jl_n_gcthreads;
      |                         ^~~~~~~~~~~~~~
/opt/hostedtoolcache/julia/nightly/x64/include/julia/jl_exported_data.inc:159:8: note: previous declaration of ‘jl_n_gcthreads’ with type ‘int’
  159 |     ZZ(jl_n_gcthreads, int) \
      |        ^~~~~~~~~~~~~~
/opt/hostedtoolcache/julia/nightly/x64/include/julia/julia.h:1043:49: note: in definition of macro ‘XX’
 1043 | #define XX(name, type) extern JL_DLLIMPORT type name;
      |                                                 ^~~~
/opt/hostedtoolcache/julia/nightly/x64/include/julia/julia.h:1044:1: note: in expansion of macro ‘JL_EXPORTED_DATA_SYMBOLS’
 1044 | JL_EXPORTED_DATA_SYMBOLS(XX)
      | ^~~~~~~~~~~~~~~~~~~~~~~~
```
The code seems to be the same in Julia 1.10, 1.11, 1.12 -- but I only see the warning in builds against nightly. I have no idea why...


CC @lgoettgens 