### PR TITLE
Set world bounds on `CodeInfo` created for `OpaqueClosure(::IRCode)`

### DIFF
--- a/Compiler/src/opaque_closure.jl
+++ b/Compiler/src/opaque_closure.jl
@@ -48,6 +48,8 @@ function Core.OpaqueClosure(ir::IRCode, @nospecialize env...;
     end
     src.slotflags = fill(zero(UInt8), nargtypes)
     src.slottypes = copy(ir.argtypes)
+    src.min_world = ir.valid_worlds.min_world
+    src.max_world = ir.valid_worlds.max_world
     src.isva = isva
     src.nargs = UInt(nargtypes)
     src = ir_to_codeinf!(src, ir)


### PR DESCRIPTION
Setting world bounds on the created `CodeInfo` allows us to interpret opaque closures faster.

Taking the following example:

```julia
julia> f(x, y) = x + y
f (generic function with 1 method)

julia> ir = Base.code_ircode_by_type(Tuple{typeof(f), Int, Int})[1][1]
1 1 ─ %1 = intrinsic Base.add_int(_2, _3)::Int64                                                                                                                                                                                 │╻ +
  └──      return %1                                                                                                                                                                                                             ││
                                                                                                                                                                                                                                   

julia> ir.argtypes[1] = Tuple{}
Tuple{}

julia> oc = Core.OpaqueClosure(ir; do_compile=true)
(::Int64, ::Int64)->◌::Int64
```

this is what we emitted before
```julia
julia> @code_typed oc(1, 2)
Pair{Core.CodeInfo, Any}(CodeInfo(
    @ REPL[8]:1 within `f`
   ┌ @ int.jl:87 within `+`
1 ─│ %1 =   dynamic Base.add_int(none@_2, none@_3)::Int64
└──│      return %1
   └
), Int64)

julia> using BenchmarkTools; @btime $oc(1, 2)
  39.765 ns (0 allocations: 0 bytes)
```

and now:
```julia
julia> @code_typed oc(1, 2)
Pair{Core.CodeInfo, Any}(CodeInfo(
    @ REPL[93]:1 within `f`
   ┌ @ int.jl:87 within `+`
1 ─│ %1 = intrinsic Base.add_int(none@_2, none@_3)::Int64
└──│      return %1
   └
), Int64)

julia> using BenchmarkTools; @btime $oc(1, 2)
  2.678 ns (0 allocations: 0 bytes)
```

The overhead notably adds more and more with every statement, which for ~20 statements led to > 1 µs of overhead, and multiple allocations. This overhead is observed on 1.12+ only (1.11 evaluates as fast as with this change), which may have been surfaced by the partitioned bindings feature.