### PR TITLE
Fix several Windows build warnings

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1594,7 +1594,7 @@ JLDFLAGS += -Wl,--stack,8388608
 ifeq ($(ARCH),i686)
 JLDFLAGS += -Wl,--large-address-aware
 endif
-JCPPFLAGS += -D_WIN32_WINNT=_WIN32_WINNT_WIN8
+JCPPFLAGS += -D_WIN32_WINNT=0x0602 # (0x0602 = _WIN32_WINNT_WIN8)
 UNTRUSTED_SYSTEM_LIBM := 1
 # Use hard links for files on windows, rather than soft links
 #   https://stackoverflow.com/questions/3648819/how-to-make-a-symbolic-link-with-cygwin-in-windows-7

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -331,6 +331,7 @@ void JITDebugInfoRegistry::registerJITObject(const object::ObjectFile &Object,
             }
         }
     }
+    (void)catchjmp;
     assert(catchjmp);
     assert(UnwindData);
     assert(SectionLoadCheck);

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -115,7 +115,7 @@ void __cdecl crt_sig_handler(int sig, int num)
                 event_source, EVENTLOG_ERROR_TYPE, /* category */ 0, /* event_id */ (DWORD)0xE0000000L,
                /* user_sid */ NULL, /* n_strings */ 1, /* data_size */ 0, strings, /* data */ NULL
             );
-            free(strings[0]);
+            free((void *)strings[0]);
 
             if (jl_options.alert_on_critical_error) {
                 MessageBoxW(NULL, /* message */ L"error: libjulia received a fatal signal.\n\n"
@@ -379,14 +379,14 @@ LONG WINAPI jl_exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo)
             event_source, EVENTLOG_ERROR_TYPE, /* category */ 0, /* event_id */ (DWORD)0xE0000000L,
            /* user_sid */ NULL, /* n_strings */ 1, /* data_size */ 0, strings, /* data */ NULL
         );
-        free(strings[0]);
+        free((void *)strings[0]);
 
         if (jl_options.alert_on_critical_error) {
             ios_putc('\0', &summary);
             const wchar_t *message = ios_utf8_to_wchar(summary.buf);
             MessageBoxW(NULL, message, /* title */ L"fatal error in libjulia",
                         MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
-            free(message);
+            free((void *)message);
         }
     }
 

--- a/src/sys.c
+++ b/src/sys.c
@@ -496,8 +496,8 @@ JL_DLLEXPORT uint64_t jl_hrtime(void) JL_NOTSAFEPOINT
 #ifdef __APPLE__
 #include <crt_externs.h>
 #else
-#if !defined(_OS_WINDOWS_) || defined(_COMPILER_GCC_)
-extern char **environ;
+#if !defined(_OS_WINDOWS_) || (defined(_COMPILER_GCC_) && defined(_POSIX_C_SOURCE))
+extern JL_DLLIMPORT char **environ;
 #endif
 #endif
 

--- a/src/task.c
+++ b/src/task.c
@@ -753,7 +753,7 @@ JL_DLLEXPORT JL_NORETURN void jl_no_exc_handler(jl_value_t *e, jl_task_t *ct)
             event_source, EVENTLOG_ERROR_TYPE, /* category */ 0, /* event_id */ (DWORD)0xE0000000L,
            /* user_sid */ NULL, /* n_strings */ 1, /* data_size */ 0, strings, /* data */ NULL
         );
-        free(strings[0]);
+        free((void *)strings[0]);
 
         if (jl_options.alert_on_critical_error) {
             MessageBoxW(NULL, /* message */ L"fatal: error thrown and no exception handler available\n\n"

--- a/src/threading.c
+++ b/src/threading.c
@@ -331,7 +331,7 @@ jl_ptls_t jl_init_threadtls(int16_t tid)
         abort();
     jl_ptls_t ptls;
 #if defined(_OS_WINDOWS_)
-    ptls = _aligned_malloc(sizeof(jl_tls_states_t), alignof(jl_tls_states_t));
+    ptls = (jl_ptls_t)_aligned_malloc(sizeof(jl_tls_states_t), alignof(jl_tls_states_t));
     if (ptls == NULL)
         abort();
 #else


### PR DESCRIPTION
Should fix:
  - `[-Wstrict-prototypes]`
  - `[-Wattributes]`
  - `[-Wc++-compat]`
  - `[-Wunused-but-set-variable]`
  - `[-Wdiscarded-qualifiers]`
  - `[-Wundef]`

This leaves:
  - `[-Warray-bounds]`
  - `[-Winfinite-recursion]`

see https://github.com/JuliaCI/julia-buildkite/pull/484