### PR TITLE
type stability fixes for `Base.url`

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -401,19 +401,21 @@ function url(m::Method)
     if LibGit2 isa Module
         try
             d = dirname(file)
-            return LibGit2.with(LibGit2.GitRepoExt(d)) do repo
-                LibGit2.with(LibGit2.GitConfig(repo)) do cfg
-                    u = LibGit2.get(cfg, "remote.origin.url", "")
-                    u = (match(LibGit2.GITHUB_REGEX,u)::AbstractMatch).captures[1]
-                    commit = string(LibGit2.head_oid(repo))
-                    root = LibGit2.path(repo)
-                    if startswith(file, root) || startswith(realpath(file), root)
-                        "https://github.com/$u/tree/$commit/"*file[length(root)+1:end]*"#L$line"
-                    else
-                        fileurl(file)
+            return let file = file
+                LibGit2.with(LibGit2.GitRepoExt(d)) do repo
+                    LibGit2.with(LibGit2.GitConfig(repo)) do cfg
+                        u = LibGit2.get(cfg, "remote.origin.url", "")
+                        u = (match(LibGit2.GITHUB_REGEX,u)::AbstractMatch).captures[1]
+                        commit = string(LibGit2.head_oid(repo))
+                        root = LibGit2.path(repo)
+                        if startswith(file, root) || startswith(realpath(file), root)
+                            "https://github.com/$u/tree/$commit/"*file[length(root)+1:end]*"#L$line"
+                        else
+                            fileurl(file)
+                        end
                     end
                 end
-            end
+            end::String
         catch
             # oops, this was a bad idea
         end

--- a/test/show.jl
+++ b/test/show.jl
@@ -877,6 +877,10 @@ else
     @test occursin("https://github.com/JuliaLang/julia/tree/$(Base.GIT_VERSION_INFO.commit)/base/special/trig.jl#L", Base.url(which(sin, (Float64,))))
 end
 
+@testset "method show: method url return type inference" begin
+    @test (isconcretetype ∘ Base.infer_return_type)(Base.url)
+end
+
 # Method location correction (Revise integration)
 dummyloc(m::Method) = :nofile, Int32(123456789)
 Base.methodloc_callback[] = dummyloc

--- a/test/show.jl
+++ b/test/show.jl
@@ -878,7 +878,7 @@ else
 end
 
 @testset "method show: method url return type inference" begin
-    @test (isconcretetype ∘ Base.infer_return_type)(Base.url)
+    @test isconcretetype(Base.infer_return_type(Base.url))
 end
 
 # Method location correction (Revise integration)


### PR DESCRIPTION
Fixing two issues:

* Boxing of a reassignable variable (`file`) captured from a closure, xref issue #15276.

* `LibGit2` is inferred as `Any` within the `Base.url` method, so add a `::String` typeassert.