### PR TITLE
Add `pipeline` convenience method for passing extra fds

### DIFF
--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -474,8 +474,20 @@ function pipeline(cmd::AbstractCmd; stdin=nothing, stdout=nothing, stderr=nothin
     return cmd
 end
 
-pipeline(cmd::AbstractCmd, dest) = pipeline(cmd, stdout=dest)
+pipeline(cmd::AbstractCmd, dest::Union{AbstractCmd, AbstractString, Redirectable}) = pipeline(cmd, stdout=dest)
 pipeline(src::Union{Redirectable,AbstractString}, cmd::AbstractCmd) = pipeline(cmd, stdin=src)
+
+"""
+    pipeline(command, redir::Pair{<:Integer, <:Redirectable})
+
+Redirect fd number `redir.first` of `command` to or from the given `redir.second`, which can be
+an I/O stream, a filename, or a file descriptor. This method is primarily used to pass additional
+fds beyond the standard ios that are not supported by the keyword argument interface.
+
+!!! compat "Julia 1.13"
+    This method requires Julia 1.13 or later.
+"""
+pipeline(cmd::AbstractCmd, redir::Pair{<:Integer, <:Redirectable}) = CmdRedirect(cmd, redir.second, Int(redir.first))
 
 """
     pipeline(from, to, ...)

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -1066,6 +1066,11 @@ end
     @test Cmd(["ls", args...]) == `ls -l /tmp`
 end
 
+let buf = IOBuffer()
+    run(pipeline(`$(Base.julia_cmd()) -e 'println(Base.PipeEndpoint(RawFD(3)), "Hello")'`, 3=>buf))
+    @test String(take!(buf)) == "Hello\n"
+end
+
 # Test passing a pipe server as an addition fd
 @testset "Pipe server as additional fd" begin
     if !Sys.iswindows()


### PR DESCRIPTION
Our underlying infrastructure supports passing fds beyond stdio, but there isn't really any support from them in the surface API. This adds a convenient method to `pipeline`, which is the usual method to set up various sorts of redirects. It basically mirrors the `3> foo` syntax in bash.