### PR TITLE
Add new public functions `raw_substring` and `unannotate`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,16 @@ New library functions
 * `Base.generating_output()` has been made `public` (but not exported) to allow
   checking whether the current process is performing compilation for a
   pkgimage/sysimage ([#61224]).
+* `ispositive(::Real)` and `isnegative(::Real)` are provided for performance and convenience ([#53677]).
+* The `Test` module now supports the `JULIA_TEST_VERBOSE` environment variable. When set to `true`,
+  it enables verbose testset entry/exit messages with timing information and sets the default `verbose=true`
+  for `DefaultTestSet` to show detailed hierarchical test summaries ([#59295]).
+* Exporting function `fieldindex` to get the index of a struct's field ([#58119]).
+* `Base.donotdelete` is now public. It prevents deadcode elimination of its arguments ([#55774]).
+* `Sys.sysimage_target()` returns the CPU target string used to build the current system image ([#58970]).
+* `Iterators.findeach` is a lazy version of `findall` ([#54124])
+* `Base.unsafe_substring` is an unexported, public constructor to build a `SubString` without checking for
+   valid string indices.
 
 New library features
 --------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -71,8 +71,8 @@ New library functions
   pkgimage/sysimage ([#61224]).
 - `Base.raw_substring` is an unexported, public constructor to build a `SubString`
   without checking for valid string indices.
-- `Base.unannotate(::AnnotatedString)` returns a string equal to the input string, but
-  with its annotation removed.
+- `Base.unannotate(::AnnotatedString)` returns the underlying un-annotated string
+  of the input string.
 
 New library features
 --------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -69,16 +69,8 @@ New library functions
 * `Base.generating_output()` has been made `public` (but not exported) to allow
   checking whether the current process is performing compilation for a
   pkgimage/sysimage ([#61224]).
-* `ispositive(::Real)` and `isnegative(::Real)` are provided for performance and convenience ([#53677]).
-* The `Test` module now supports the `JULIA_TEST_VERBOSE` environment variable. When set to `true`,
-  it enables verbose testset entry/exit messages with timing information and sets the default `verbose=true`
-  for `DefaultTestSet` to show detailed hierarchical test summaries ([#59295]).
-* Exporting function `fieldindex` to get the index of a struct's field ([#58119]).
-* `Base.donotdelete` is now public. It prevents deadcode elimination of its arguments ([#55774]).
-* `Sys.sysimage_target()` returns the CPU target string used to build the current system image ([#58970]).
-* `Iterators.findeach` is a lazy version of `findall` ([#54124])
-* `Base.unsafe_substring` is an unexported, public constructor to build a `SubString` without checking for
-   valid string indices.
+- `Base.unsafe_substring` is an unexported, public constructor to build a `SubString`
+  without checking for valid string indices.
 
 New library features
 --------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -69,7 +69,7 @@ New library functions
 * `Base.generating_output()` has been made `public` (but not exported) to allow
   checking whether the current process is performing compilation for a
   pkgimage/sysimage ([#61224]).
-- `Base.unsafe_substring` is an unexported, public constructor to build a `SubString`
+- `Base.raw_substring` is an unexported, public constructor to build a `SubString`
   without checking for valid string indices.
 
 New library features

--- a/NEWS.md
+++ b/NEWS.md
@@ -71,6 +71,8 @@ New library functions
   pkgimage/sysimage ([#61224]).
 - `Base.raw_substring` is an unexported, public constructor to build a `SubString`
   without checking for valid string indices.
+- `Base.unannotate(::AnnotatedString)` returns a string equal to the input string, but
+  with its annotation removed.
 
 New library features
 --------------------

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -637,7 +637,7 @@ end
         @inbounds isvalid(s, si) || string_index_err(s, si)
         @inbounds isvalid(s, sj) || string_index_err(s, sj)
     end
-    @inbounds raw_substring(s, i - 1, j)
+    @inbounds raw_substring(s, i + 1, j)
 end
 
 # This method is slightly different because it returns a SubString{SubString},
@@ -650,7 +650,7 @@ end
         @inbounds isvalid(s, si) || string_index_err(s, si)
         @inbounds isvalid(s, sj) || string_index_err(s, sj)
     end
-    ss = @inbounds raw_substring(s, i - 1, j)
+    ss = @inbounds raw_substring(s, i + 1, j)
     SubString{T}(ss)
 end
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -637,7 +637,7 @@ end
         @inbounds isvalid(s, si) || string_index_err(s, si)
         @inbounds isvalid(s, sj) || string_index_err(s, sj)
     end
-    @inbounds unsafe_substring(s, i - 1, j)
+    @inbounds raw_substring(s, i - 1, j)
 end
 
 # This method is slightly different because it returns a SubString{SubString},
@@ -650,7 +650,7 @@ end
         @inbounds isvalid(s, si) || string_index_err(s, si)
         @inbounds isvalid(s, sj) || string_index_err(s, sj)
     end
-    ss = @inbounds unsafe_substring(s, i - 1, j)
+    ss = @inbounds raw_substring(s, i - 1, j)
     SubString{T}(ss)
 end
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -631,4 +631,27 @@ end
     return true
 end
 
+@deprecate SubString{T}(s::T, i::Int, j::Int, ::Val{:noshift}) where {T <: AbstractString} begin
+    @boundscheck if !(i == j == 0)
+        si, sj = i + 1, prevind(s, j + i + 1)
+        @inbounds isvalid(s, si) || string_index_err(s, si)
+        @inbounds isvalid(s, sj) || string_index_err(s, sj)
+    end
+    @inbounds unsafe_substring(s, i - 1, j)
+end
+
+# This method is slightly different because it returns a SubString{SubString},
+# therefore it requires an explicit SubString{T}(ss) call at the end.
+# We discourage creating substrings of substrings, but the deprecated method
+# allowed it.
+@deprecate SubString{T}(s::T, i::Int, j::Int, ::Val{:noshift}) where {T <: SubString} begin
+    @boundscheck if !(i == j == 0)
+        si, sj = i + 1, prevind(s, j + i + 1)
+        @inbounds isvalid(s, si) || string_index_err(s, si)
+        @inbounds isvalid(s, sj) || string_index_err(s, sj)
+    end
+    ss = @inbounds unsafe_substring(s, i - 1, j)
+    SubString{T}(ss)
+end
+
 # END 1.14 deprecations

--- a/base/public.jl
+++ b/base/public.jl
@@ -114,6 +114,7 @@ public
 # Strings
     escape_raw_string,
     unsafe_substring,
+    unannotate,
 
 # Chars
     ismalformed,

--- a/base/public.jl
+++ b/base/public.jl
@@ -113,6 +113,7 @@ public
 
 # Strings
     escape_raw_string,
+    unsafe_substring,
 
 # Chars
     ismalformed,

--- a/base/public.jl
+++ b/base/public.jl
@@ -113,7 +113,7 @@ public
 
 # Strings
     escape_raw_string,
-    unsafe_substring,
+    raw_substring,
     unannotate,
 
 # Chars

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -455,12 +455,10 @@ end
 
 function _annotatedmatch(m::RegexMatch{S}, str::AnnotatedString{S}) where {S<:AbstractString}
     RegexMatch{AnnotatedString{S}}(
-        (@inbounds SubString{AnnotatedString{S}}(
-            str, m.match.offset, m.match.ncodeunits, Val(:noshift))),
+        (@inbounds unsafe_substring(str, m.match.offset + 1, m.match.ncodeunits)),
         Union{Nothing,SubString{AnnotatedString{S}}}[
             if !isnothing(cap)
-                (@inbounds SubString{AnnotatedString{S}}(
-                    str, cap.offset, cap.ncodeunits, Val(:noshift)))
+                (@inbounds unsafe_substring(str, cap.offset + 1, cap.ncodeunits))
             end for cap in m.captures],
         m.offset, m.offsets, m.regex)
 end

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -455,10 +455,10 @@ end
 
 function _annotatedmatch(m::RegexMatch{S}, str::AnnotatedString{S}) where {S<:AbstractString}
     RegexMatch{AnnotatedString{S}}(
-        (@inbounds unsafe_substring(str, m.match.offset + 1, m.match.ncodeunits)),
+        (@inbounds raw_substring(str, m.match.offset + 1, m.match.ncodeunits)),
         Union{Nothing,SubString{AnnotatedString{S}}}[
             if !isnothing(cap)
-                (@inbounds unsafe_substring(str, cap.offset + 1, cap.ncodeunits))
+                (@inbounds raw_substring(str, cap.offset + 1, cap.ncodeunits))
             end for cap in m.captures],
         m.offset, m.offsets, m.regex)
 end

--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -158,10 +158,29 @@ eltype(::Type{<:AnnotatedString{S}}) where {S} = AnnotatedChar{eltype(S)}
 firstindex(s::AnnotatedString) = firstindex(s.string)
 lastindex(s::AnnotatedString) = lastindex(s.string)
 
-plain_substring(s::AnnotatedString) = @inbounds unsafe_substring(s.string, 1, ncodeunits(s))
+"""
+    unannotate(s::AnnotatedString{S})::S
+    unannotate(s::SubString{AnnotatedString{S}})::SubString{S}
 
-function plain_substring(s::SubString{<:AnnotatedString})
-    @inbounds unsafe_substring(s.string.string, s.offset + 1, s.ncodeunits)
+Get the underlying string of `s`, without copying.
+
+# Examples
+```jldoctest; setup=:(using Base: AnnotatedString)
+julia> s = AnnotatedString("abcde", [(1:3, :A, 4)])
+"abcde"
+
+julia> u = unannotate(s)
+"abcde"
+
+julia> typeof(u)
+String
+```
+"""
+unannotate(s::AnnotatedString) = s.string
+
+function unannotate(s::SubString{<:AnnotatedString})
+    start_index = first(parentindices(s)[1])
+    @inbounds unsafe_substring(parent(s).string, start_index, ncodeunits(s))
 end
 
 
@@ -211,14 +230,14 @@ cmp(a::AnnotatedString, b::AnnotatedString) = cmp(a.string, b.string)
 # To prevent substring equality from hitting the generic fallback
 
 function ==(a::SubString{<:AnnotatedString}, b::SubString{<:AnnotatedString})
-    plain_substring(a) == plain_substring(b) && annotations(a) == annotations(b)
+    unannotate(a) == unannotate(b) && annotations(a) == annotations(b)
 end
 
 ==(a::SubString{<:AnnotatedString}, b::AnnotatedString) =
-    annotations(a) == annotations(b) && plain_substring(a) == b.string
+    annotations(a) == annotations(b) && unannotate(a) == b.string
 
 ==(a::SubString{<:AnnotatedString}, b::AbstractString) =
-    isempty(annotations(a)) && plain_substring(a) == b
+    isempty(annotations(a)) && unannotate(a) == b
 
 ==(a::AbstractString, b::SubString{<:AnnotatedString}) = b == a
 
@@ -267,7 +286,7 @@ function annotatedstring(xs...)
                     push!(annotations, @inline(setindex(annot, rstart:rstop, :region)))
                 end
             end
-            print(s, plain_substring(x))
+            print(s, unannotate(x))
         elseif x isa AnnotatedChar
             for annot in x.annotations
                 push!(annotations, (region=1+size:1+size, annot...))

--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -158,6 +158,13 @@ eltype(::Type{<:AnnotatedString{S}}) where {S} = AnnotatedChar{eltype(S)}
 firstindex(s::AnnotatedString) = firstindex(s.string)
 lastindex(s::AnnotatedString) = lastindex(s.string)
 
+plain_substring(s::AnnotatedString) = @inbounds unsafe_substring(s.string, 1, ncodeunits(s))
+
+function plain_substring(s::SubString{<:AnnotatedString})
+    @inbounds unsafe_substring(s.string.string, s.offset + 1, s.ncodeunits)
+end
+
+
 function getindex(s::AnnotatedString, i::Integer)
     @boundscheck checkbounds(s, i)
     @inbounds if isvalid(s, i)
@@ -204,16 +211,14 @@ cmp(a::AnnotatedString, b::AnnotatedString) = cmp(a.string, b.string)
 # To prevent substring equality from hitting the generic fallback
 
 function ==(a::SubString{<:AnnotatedString}, b::SubString{<:AnnotatedString})
-    SubString(a.string.string, a.offset, a.ncodeunits, Val(:noshift)) ==
-        SubString(b.string.string, b.offset, b.ncodeunits, Val(:noshift)) &&
-        annotations(a) == annotations(b)
+    plain_substring(a) == plain_substring(b) && annotations(a) == annotations(b)
 end
 
 ==(a::SubString{<:AnnotatedString}, b::AnnotatedString) =
-    annotations(a) == annotations(b) && SubString(a.string.string, a.offset, a.ncodeunits, Val(:noshift)) == b.string
+    annotations(a) == annotations(b) && plain_substring(a) == b.string
 
 ==(a::SubString{<:AnnotatedString}, b::AbstractString) =
-    isempty(annotations(a)) && SubString(a.string.string, a.offset, a.ncodeunits, Val(:noshift)) == b
+    isempty(annotations(a)) && plain_substring(a) == b
 
 ==(a::AbstractString, b::SubString{<:AnnotatedString}) = b == a
 
@@ -262,7 +267,7 @@ function annotatedstring(xs...)
                     push!(annotations, @inline(setindex(annot, rstart:rstop, :region)))
                 end
             end
-            print(s, SubString(x.string.string, x.offset, x.ncodeunits, Val(:noshift)))
+            print(s, plain_substring(x))
         elseif x isa AnnotatedChar
             for annot in x.annotations
                 push!(annotations, (region=1+size:1+size, annot...))

--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -169,7 +169,7 @@ Get the underlying string of `s`, without copying.
 julia> s = AnnotatedString("abcde", [(1:3, :A, 4)])
 "abcde"
 
-julia> u = unannotate(s)
+julia> u = Base.unannotate(s)
 "abcde"
 
 julia> typeof(u)

--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -175,6 +175,10 @@ julia> u = unannotate(s)
 julia> typeof(u)
 String
 ```
+
+!!! compat "Julia 1.14"
+    This function requires at least Julia 1.14.
+
 """
 unannotate(s::AnnotatedString) = s.string
 

--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -161,6 +161,7 @@ lastindex(s::AnnotatedString) = lastindex(s.string)
 """
     unannotate(s::AnnotatedString{S})::S
     unannotate(s::SubString{AnnotatedString{S}})::SubString{S}
+    unannotate(s::SubString{AnnotatedString{SubString{S}}})::SubString{S}
 
 Get the underlying string of `s`, without copying.
 

--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -180,7 +180,7 @@ unannotate(s::AnnotatedString) = s.string
 
 function unannotate(s::SubString{<:AnnotatedString})
     start_index = first(parentindices(s)[1])
-    @inbounds unsafe_substring(parent(s).string, start_index, ncodeunits(s))
+    @inbounds raw_substring(parent(s).string, start_index, ncodeunits(s))
 end
 
 

--- a/base/strings/stringview.jl
+++ b/base/strings/stringview.jl
@@ -145,10 +145,7 @@ function chomp(s::StringViewAndSub)
         has_cr = has_lf & two_bytes & (cu[ncu - two_bytes] == 0x0d)
         ncu - (has_lf + has_cr)
     end
-    off = s isa StringView ? 0 : s.offset
-    par = s isa StringView ? s : s.string
-    T = s isa SubString ? typeof(s) : SubString{typeof(s)}
-    return @inbounds @inline T(par, off, len, Val{:noshift}())
+    @inbounds unsafe_substring(s, 1, len)
 end
 
 function replace(io::IO, s::DenseStringViewAndSub, pat_f::Pair...; count = typemax(Int))

--- a/base/strings/stringview.jl
+++ b/base/strings/stringview.jl
@@ -145,7 +145,7 @@ function chomp(s::StringViewAndSub)
         has_cr = has_lf & two_bytes & (cu[ncu - two_bytes] == 0x0d)
         ncu - (has_lf + has_cr)
     end
-    @inbounds unsafe_substring(s, 1, len)
+    @inbounds raw_substring(s, 1, len)
 end
 
 function replace(io::IO, s::DenseStringViewAndSub, pat_f::Pair...; count = typemax(Int))

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -43,18 +43,6 @@ struct SubString{T<:AbstractString} <: AbstractString
     end
 end
 
-function check_codeunit_bounds(s::AbstractString, first_index::Int, n_codeunits::Int)
-    last_index = first_index + n_codeunits - 1
-    bad_index = if first_index < 1
-        first_index
-    elseif last_index > ncodeunits(s)
-        last_index
-    else
-        return nothing
-    end
-    throw(BoundsError(s, bad_index))
-end
-
 """
     unsafe_substring(s::AbstractString, first_index::Int, n_codeunits::Int)::SubString{typeof(s)}
     unsafe_substring(s::SubString{S}, first_index::Int, n_codeunits::Int)::SubString{S}
@@ -63,10 +51,14 @@ Create a substring of `s` spanning the codeunits `first_index:(first_index + n_c
 
 If `first_index` < 1, or `first_index + n_codeunits - 1 > ncodeunits(s)`, throw a `BoundsError`.
 
-This function does check bounds, but does not validate that the arguments corresponds to valid
+This function does check bounds, but does not validate that the arguments correspond to valid
 start and end indices in `s`, and so the resulting substring may contain truncated characters.
-The presence of truncated characters is safe and well-defined for `String` and `SubString{String}`,
-but may not be permitted for custom subtypes of `AbstractString`.
+The presence of truncated characters is safe and well-defined for `String`, `StringView`, and
+substrings of these, but may not be permitted for custom subtypes of `AbstractString`.
+
+!!! warning
+    For `AbstractString` other than `String`, `StringView` or substrings of those, callers should
+    ensure that the value of `n_codeunits` does not result in truncated codeunits.
 
 # Examples
 ```jldoctest
@@ -91,9 +83,8 @@ function unsafe_substring(s::AbstractString, first_index::Int, n_codeunits::Int)
 end
 
 function unsafe_substring(s::SubString, first_index::Int, n_codeunits::Int)
-    @boundscheck @inline check_codeunit_bounds(s, first_index, n_codeunits)
-    string = s.string
-    return _unsafe_substring(string, first_index + s.offset - 1, n_codeunits)
+    @boundscheck @inline checkbounds(codeunits(s), first_index:(first_index + n_codeunits - 1))
+    _unsafe_substring(s.string, first_index + s.offset - 1, n_codeunits)
 end
 
 @propagate_inbounds SubString(s::T, i::Int, j::Int) where {T<:AbstractString} = SubString{T}(s, i, j)
@@ -106,8 +97,12 @@ end
 end
 
 SubString(s::AbstractString) = @inbounds unsafe_substring(s, 1, Int(ncodeunits(s))::Int)
-SubString{T}(s::T) where {T<:AbstractString} = SubString(s)
 SubString(s::SubString) = s
+
+# Unlike the un-parameterized SubString constructor, this function must allow creating
+# e.g. a SubString{SubString{String}}, as this type is what the user may have explicitly
+# requested.
+SubString{T}(s::T) where {T<:AbstractString} = @inbounds _unsafe_substring(s, 0, ncodeunits(s))
 
 @propagate_inbounds view(s::AbstractString, r::AbstractUnitRange{<:Integer}) = SubString(s, r)
 @propagate_inbounds maybeview(s::AbstractString, r::AbstractUnitRange{<:Integer}) = view(s, r)

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -24,13 +24,13 @@ may throw a `StringIndexError`.
 julia> s = "Hello, Bjørn!";
 
 julia> ss = Base.raw_substring(s, 3, 10)
-"lo, Bjørn"
+"llo, Bjør"
 
 julia> typeof(ss)
 SubString{String}
 
-julia> ss2 = Base.raw_substring(ss, 2, 6)
-"o, Bj\\xc3"
+julia> ss2 = Base.raw_substring(ss, 3, 7)
+"o, Bjø"
 
 julia> typeof(ss2)
 SubString{String}

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -39,6 +39,10 @@ julia> ss3 = raw_substring(s, 11, 4); ss3[1]
 ERROR: StringIndexError:
 [...]
 ```
+
+!!! compat "Julia 1.14"
+    This function requires at least Julia 1.14.
+
 """
 function raw_substring end
 

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -80,13 +80,24 @@ struct SubString{T<:AbstractString} <: AbstractString
     end
 
     global function raw_substring(s::T, first_index::Int, n_codeunits::Int) where {T <: AbstractString}
-        @boundscheck @inline checkbounds(codeunits(s), first_index:(first_index + n_codeunits - 1))
+        @boundscheck if n_codeunits < 0 || first_index < 1 || (n_codeunits > ncodeunits(s) - first_index + 1)
+            throw(BoundsError(s, first_index:(first_index+n_codeunits-1)))
+        end
         new{T}(s, first_index - 1, n_codeunits)
     end
 
     global function raw_substring(s::SubString{T}, first_index::Int, n_codeunits::Int) where {T <: AbstractString}
-        @boundscheck @inline checkbounds(codeunits(s), first_index:(first_index + n_codeunits - 1))
+        @boundscheck if n_codeunits < 0 || first_index < 1 || (n_codeunits > ncodeunits(s) - first_index + 1)
+            throw(BoundsError(s, first_index:(first_index+n_codeunits-1)))
+        end
         new{T}(s.string, first_index + s.offset - 1, n_codeunits)
+    end
+
+    # Unlike the un-parameterized SubString constructor, this function must allow creating
+    # e.g. a SubString{SubString{String}}, as this type is what the user may have explicitly
+    # requested.
+    function SubString{T}(s::T) where {T <: AbstractString}
+        new{T}(s, 0, ncodeunits(s))
     end
 end
 
@@ -101,11 +112,6 @@ end
 
 SubString(s::AbstractString) = @inbounds raw_substring(s, 1, Int(ncodeunits(s))::Int)
 SubString(s::SubString) = s
-
-# Unlike the un-parameterized SubString constructor, this function must allow creating
-# e.g. a SubString{SubString{String}}, as this type is what the user may have explicitly
-# requested.
-SubString{T}(s::T) where {T<:AbstractString} = @inbounds raw_substring(s, 1, ncodeunits(s))
 
 @propagate_inbounds view(s::AbstractString, r::AbstractUnitRange{<:Integer}) = SubString(s, r)
 @propagate_inbounds maybeview(s::AbstractString, r::AbstractUnitRange{<:Integer}) = view(s, r)

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -1,54 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 """
-    SubString(s::AbstractString, i::Integer, j::Integer=lastindex(s))
-    SubString(s::AbstractString, r::UnitRange{<:Integer})
-
-Like [`getindex`](@ref), but returns a view into the parent string `s`
-within range `i:j` or `r` respectively instead of making a copy.
-
-The [`@views`](@ref) macro converts any string slices `s[i:j]` into
-substrings `SubString(s, i, j)` in a block of code.
-
-# Examples
-```jldoctest
-julia> SubString("abc", 1, 2)
-"ab"
-
-julia> SubString("abc", 1:2)
-"ab"
-
-julia> SubString("abc", 2)
-"bc"
-```
-"""
-struct SubString{T<:AbstractString} <: AbstractString
-    string::T
-    offset::Int
-    ncodeunits::Int
-
-    function SubString{T}(s::T, i::Int, j::Int) where T<:AbstractString
-        i ≤ j || return new(s, 0, 0)
-        @boundscheck begin
-            checkbounds(s, i:j)
-            @inbounds isvalid(s, i) || string_index_err(s, i)
-            @inbounds isvalid(s, j) || string_index_err(s, j)
-        end
-        return new(s, i-1, nextind(s,j)-i)
-    end
-
-    global function raw_substring(s::T, first_index::Int, ncodeunits::Int) where {T <: AbstractString}
-        @boundscheck @inline checkbounds(codeunits(s), first_index:(first_index + n_codeunits - 1))
-        new{T}(s, first_index - 1, ncodeunits)
-    end
-
-    global function raw_substring(s::SubString{T}, first_index::Int, ncodeunits::Int) where {T <: AbstractString}
-        @boundscheck @inline checkbounds(codeunits(s), first_index:(first_index + n_codeunits - 1))
-        new{T}(s.string, first_index + s.offset - 1, n_codeunits)
-    end
-end
-
-"""
     raw_substring(s::AbstractString, first_index::Int, n_codeunits::Int)::SubString{typeof(s)}
     raw_substring(s::SubString{S}, first_index::Int, n_codeunits::Int)::SubString{S}
 
@@ -90,10 +42,52 @@ ERROR: StringIndexError:
 """
 function raw_substring end
 
+"""
+    SubString(s::AbstractString, i::Integer, j::Integer=lastindex(s))
+    SubString(s::AbstractString, r::UnitRange{<:Integer})
 
-function raw_substring(s::AbstractString, first_index::Int, n_codeunits::Int)
-    @boundscheck @inline checkbounds(codeunits(s), first_index:(first_index + n_codeunits - 1))
-    return @inbounds raw_substring(s, first_index, n_codeunits)
+Like [`getindex`](@ref), but returns a view into the parent string `s`
+within range `i:j` or `r` respectively instead of making a copy.
+
+The [`@views`](@ref) macro converts any string slices `s[i:j]` into
+substrings `SubString(s, i, j)` in a block of code.
+
+# Examples
+```jldoctest
+julia> SubString("abc", 1, 2)
+"ab"
+
+julia> SubString("abc", 1:2)
+"ab"
+
+julia> SubString("abc", 2)
+"bc"
+```
+"""
+struct SubString{T<:AbstractString} <: AbstractString
+    string::T
+    offset::Int
+    ncodeunits::Int
+
+    function SubString{T}(s::T, i::Int, j::Int) where T<:AbstractString
+        i ≤ j || return new(s, 0, 0)
+        @boundscheck begin
+            checkbounds(s, i:j)
+            @inbounds isvalid(s, i) || string_index_err(s, i)
+            @inbounds isvalid(s, j) || string_index_err(s, j)
+        end
+        return new(s, i-1, nextind(s,j)-i)
+    end
+
+    global function raw_substring(s::T, first_index::Int, n_codeunits::Int) where {T <: AbstractString}
+        @boundscheck @inline checkbounds(codeunits(s), first_index:(first_index + n_codeunits - 1))
+        new{T}(s, first_index - 1, n_codeunits)
+    end
+
+    global function raw_substring(s::SubString{T}, first_index::Int, n_codeunits::Int) where {T <: AbstractString}
+        @boundscheck @inline checkbounds(codeunits(s), first_index:(first_index + n_codeunits - 1))
+        new{T}(s.string, first_index + s.offset - 1, n_codeunits)
+    end
 end
 
 @propagate_inbounds SubString(s::T, i::Int, j::Int) where {T<:AbstractString} = SubString{T}(s, i, j)

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -23,19 +23,19 @@ may throw a `StringIndexError`.
 ```jldoctest
 julia> s = "Hello, Bjørn!";
 
-julia> ss = raw_substring(s, 3, 10)
+julia> ss = Base.raw_substring(s, 3, 10)
 "lo, Bjørn"
 
 julia> typeof(ss)
 SubString{String}
 
-julia> ss2 = raw_substring(ss, 2, 6)
+julia> ss2 = Base.raw_substring(ss, 2, 6)
 "o, Bj\\xc3"
 
 julia> typeof(ss2)
 SubString{String}
 
-julia> ss3 = raw_substring(s, 11, 4); ss3[1]
+julia> ss3 = Base.raw_substring(s, 11, 4); ss3[1]
 ERROR: StringIndexError:
 [...]
 ```

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -37,20 +37,20 @@ struct SubString{T<:AbstractString} <: AbstractString
         return new(s, i-1, nextind(s,j)-i)
     end
 
-    global function unsafe_substring(s::T, first_index::Int, ncodeunits::Int) where {T <: AbstractString}
+    global function raw_substring(s::T, first_index::Int, ncodeunits::Int) where {T <: AbstractString}
         @boundscheck @inline checkbounds(codeunits(s), first_index:(first_index + n_codeunits - 1))
         new{T}(s, first_index - 1, ncodeunits)
     end
 
-    global function unsafe_substring(s::SubString{T}, first_index::Int, ncodeunits::Int) where {T <: AbstractString}
+    global function raw_substring(s::SubString{T}, first_index::Int, ncodeunits::Int) where {T <: AbstractString}
         @boundscheck @inline checkbounds(codeunits(s), first_index:(first_index + n_codeunits - 1))
         new{T}(s.string, first_index + s.offset - 1, n_codeunits)
     end
 end
 
 """
-    unsafe_substring(s::AbstractString, first_index::Int, n_codeunits::Int)::SubString{typeof(s)}
-    unsafe_substring(s::SubString{S}, first_index::Int, n_codeunits::Int)::SubString{S}
+    raw_substring(s::AbstractString, first_index::Int, n_codeunits::Int)::SubString{typeof(s)}
+    raw_substring(s::SubString{S}, first_index::Int, n_codeunits::Int)::SubString{S}
 
 Create a substring of `s` spanning the codeunits `first_index:(first_index + n_codeunits - 1)`.
 
@@ -69,25 +69,25 @@ substrings of these, but may not be permitted for custom subtypes of `AbstractSt
 ```jldoctest
 julia> s = "Hello, Bjørn!";
 
-julia> ss = unsafe_substring(s, 3, 10)
+julia> ss = raw_substring(s, 3, 10)
 "lo, Bjørn"
 
 julia> typeof(ss)
 SubString{String}
 
-julia> ss2 = unsafe_substring(ss, 2, 6)
+julia> ss2 = raw_substring(ss, 2, 6)
 "o, Bj\\xc3"
 
 julia> typeof(ss2)
 SubString{String}
 ```
 """
-function unsafe_substring end
+function raw_substring end
 
 
-function unsafe_substring(s::AbstractString, first_index::Int, n_codeunits::Int)
+function raw_substring(s::AbstractString, first_index::Int, n_codeunits::Int)
     @boundscheck @inline checkbounds(codeunits(s), first_index:(first_index + n_codeunits - 1))
-    return @inbounds unsafe_substring(s, first_index, n_codeunits)
+    return @inbounds raw_substring(s, first_index, n_codeunits)
 end
 
 @propagate_inbounds SubString(s::T, i::Int, j::Int) where {T<:AbstractString} = SubString{T}(s, i, j)
@@ -99,13 +99,13 @@ end
     SubString(s.string, s.offset+i, s.offset+j)
 end
 
-SubString(s::AbstractString) = @inbounds unsafe_substring(s, 1, Int(ncodeunits(s))::Int)
+SubString(s::AbstractString) = @inbounds raw_substring(s, 1, Int(ncodeunits(s))::Int)
 SubString(s::SubString) = s
 
 # Unlike the un-parameterized SubString constructor, this function must allow creating
 # e.g. a SubString{SubString{String}}, as this type is what the user may have explicitly
 # requested.
-SubString{T}(s::T) where {T<:AbstractString} = @inbounds unsafe_substring(s, 1, ncodeunits(s))
+SubString{T}(s::T) where {T<:AbstractString} = @inbounds raw_substring(s, 1, ncodeunits(s))
 
 @propagate_inbounds view(s::AbstractString, r::AbstractUnitRange{<:Integer}) = SubString(s, r)
 @propagate_inbounds maybeview(s::AbstractString, r::AbstractUnitRange{<:Integer}) = view(s, r)

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -60,6 +60,8 @@ This function does check bounds, but does not validate that the arguments corres
 start and end indices in `s`, and so the resulting substring may contain truncated characters.
 The presence of truncated characters is safe and well-defined for `String`, `StringView`, and
 substrings of these, but may not be permitted for custom subtypes of `AbstractString`.
+Note that accessing characters that are whole in the parent string but truncated by the `SubString`
+may throw a `StringIndexError`.
 
 !!! warning
     For `AbstractString` other than `String`, `StringView` or substrings of those, callers should
@@ -80,6 +82,10 @@ julia> ss2 = raw_substring(ss, 2, 6)
 
 julia> typeof(ss2)
 SubString{String}
+
+julia> ss3 = raw_substring(s, 11, 4); ss3[1]
+ERROR: StringIndexError:
+[...]
 ```
 """
 function raw_substring end

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -36,10 +36,15 @@ struct SubString{T<:AbstractString} <: AbstractString
         end
         return new(s, i-1, nextind(s,j)-i)
     end
-    # We don't expose this, because the exposed constructor needs to avoid constructing
-    # a SubString{SubString{T}} when passed a substring.
-    global function _unsafe_substring(s::T, offset::Int, ncodeunits::Int) where {T <: AbstractString}
-        new{T}(s, offset, ncodeunits)
+
+    global function unsafe_substring(s::T, first_index::Int, ncodeunits::Int) where {T <: AbstractString}
+        @boundscheck @inline checkbounds(codeunits(s), first_index:(first_index + n_codeunits - 1))
+        new{T}(s, first_index - 1, ncodeunits)
+    end
+
+    global function unsafe_substring(s::SubString{T}, first_index::Int, ncodeunits::Int) where {T <: AbstractString}
+        @boundscheck @inline checkbounds(codeunits(s), first_index:(first_index + n_codeunits - 1))
+        new{T}(s.string, first_index + s.offset - 1, n_codeunits)
     end
 end
 
@@ -77,14 +82,12 @@ julia> typeof(ss2)
 SubString{String}
 ```
 """
+function unsafe_substring end
+
+
 function unsafe_substring(s::AbstractString, first_index::Int, n_codeunits::Int)
     @boundscheck @inline checkbounds(codeunits(s), first_index:(first_index + n_codeunits - 1))
-    return _unsafe_substring(s, first_index - 1, n_codeunits)
-end
-
-function unsafe_substring(s::SubString, first_index::Int, n_codeunits::Int)
-    @boundscheck @inline checkbounds(codeunits(s), first_index:(first_index + n_codeunits - 1))
-    _unsafe_substring(s.string, first_index + s.offset - 1, n_codeunits)
+    return @inbounds unsafe_substring(s, first_index, n_codeunits)
 end
 
 @propagate_inbounds SubString(s::T, i::Int, j::Int) where {T<:AbstractString} = SubString{T}(s, i, j)
@@ -102,7 +105,7 @@ SubString(s::SubString) = s
 # Unlike the un-parameterized SubString constructor, this function must allow creating
 # e.g. a SubString{SubString{String}}, as this type is what the user may have explicitly
 # requested.
-SubString{T}(s::T) where {T<:AbstractString} = @inbounds _unsafe_substring(s, 0, ncodeunits(s))
+SubString{T}(s::T) where {T<:AbstractString} = @inbounds unsafe_substring(s, 1, ncodeunits(s))
 
 @propagate_inbounds view(s::AbstractString, r::AbstractUnitRange{<:Integer}) = SubString(s, r)
 @propagate_inbounds maybeview(s::AbstractString, r::AbstractUnitRange{<:Integer}) = view(s, r)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -388,7 +388,7 @@ end
     end
     off = s isa String ? 0 : s.offset
     par = s isa String ? s : s.string
-    @inbounds @inline SubString{String}(par, off, len, Val{:noshift}())
+    @inbounds unsafe_substring(s, 1, len)
 end
 """
     lstrip([pred=isspace,] str::AbstractString)::SubString

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -388,7 +388,7 @@ end
     end
     off = s isa String ? 0 : s.offset
     par = s isa String ? s : s.string
-    @inbounds unsafe_substring(s, 1, len)
+    @inbounds raw_substring(s, 1, len)
 end
 """
     lstrip([pred=isspace,] str::AbstractString)::SubString

--- a/codex_julia_depot/environments/v1.14/Project.toml
+++ b/codex_julia_depot/environments/v1.14/Project.toml
@@ -1,1 +1,0 @@
-syntax.julia_version = "1.14.0-DEV.2285"

--- a/codex_julia_depot/environments/v1.14/Project.toml
+++ b/codex_julia_depot/environments/v1.14/Project.toml
@@ -1,0 +1,1 @@
+syntax.julia_version = "1.14.0-DEV.2285"

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -10,85 +10,9 @@ module. For a general introduction to strings in Julia language, please refer to
 Core.AbstractChar
 Core.Char
 Base.codepoint
-Base.length(::AbstractString)
-Base.sizeof(::AbstractString)
-Base.:*(::Union{AbstractChar, AbstractString}, ::Union{AbstractChar, AbstractString}...)
-Base.:^(::Union{AbstractString, AbstractChar}, ::Integer)
-Base.string
-Base.repeat(::AbstractString, ::Integer)
-Base.repeat(::AbstractChar, ::Integer)
-Base.repr(::Any)
-Core.String(::AbstractString)
-Base.SubString
-Base.unsafe_substring
-Base.LazyString
-Base.@lazy_str
-Base.transcode
-Base.unsafe_string
-Base.ncodeunits(::AbstractString)
-Base.codeunit
-Base.codeunits
-Base.ascii
-Base.Regex
-Base.@r_str
-Base.SubstitutionString
-Base.@s_str
-Base.@raw_str
-Base.@b_str
-Base.takestring!
-Base.Docs.@html_str
-Base.Docs.@text_str
-Base.isvalid(::Any)
-Base.isvalid(::Any, ::Any)
-Base.isvalid(::AbstractString, ::Integer)
-Base.match
-Base.eachmatch
-Base.RegexMatch
-Base.keys(::RegexMatch)
-Base.isless(::AbstractString, ::AbstractString)
-Base.:(==)(::AbstractString, ::AbstractString)
-Base.cmp(::AbstractString, ::AbstractString)
-Base.lpad
-Base.rpad
-Base.ltruncate
-Base.rtruncate
-Base.ctruncate
-Base.findfirst(::AbstractString, ::AbstractString)
-Base.findnext(::AbstractString, ::AbstractString, ::Integer)
-Base.findnext(::AbstractChar, ::AbstractString, ::Integer)
-Base.findlast(::AbstractString, ::AbstractString)
-Base.findlast(::AbstractChar, ::AbstractString)
-Base.findprev(::AbstractString, ::AbstractString, ::Integer)
-Base.occursin
-Base.reverse(::Union{String,SubString{String}})
-Base.replace(::IO, s::AbstractString, ::Pair...)
-Base.eachsplit
-Base.eachrsplit
-Base.split
-Base.rsplit
-Base.strip
-Base.lstrip
-Base.rstrip
-Base.startswith
-Base.endswith
-Base.contains
-Base.first(::AbstractString, ::Integer)
-Base.last(::AbstractString, ::Integer)
-Base.uppercase
-Base.lowercase
-Base.titlecase
-Base.uppercasefirst
-Base.lowercasefirst
-Base.join
-Base.chop
-Base.chopprefix
-Base.chopsuffix
-Base.chomp
-Base.thisind
-Base.nextind(::AbstractString, ::Integer, ::Integer)
-Base.prevind(::AbstractString, ::Integer, ::Integer)
-Base.textwidth
-Base.isascii
+```
+
+```@docs
 Base.iscntrl
 Base.isdigit
 Base.isletter

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -10,9 +10,85 @@ module. For a general introduction to strings in Julia language, please refer to
 Core.AbstractChar
 Core.Char
 Base.codepoint
-```
-
-```@docs
+Base.length(::AbstractString)
+Base.sizeof(::AbstractString)
+Base.:*(::Union{AbstractChar, AbstractString}, ::Union{AbstractChar, AbstractString}...)
+Base.:^(::Union{AbstractString, AbstractChar}, ::Integer)
+Base.string
+Base.repeat(::AbstractString, ::Integer)
+Base.repeat(::AbstractChar, ::Integer)
+Base.repr(::Any)
+Core.String(::AbstractString)
+Base.SubString
+Base.unsafe_substring
+Base.LazyString
+Base.@lazy_str
+Base.transcode
+Base.unsafe_string
+Base.ncodeunits(::AbstractString)
+Base.codeunit
+Base.codeunits
+Base.ascii
+Base.Regex
+Base.@r_str
+Base.SubstitutionString
+Base.@s_str
+Base.@raw_str
+Base.@b_str
+Base.takestring!
+Base.Docs.@html_str
+Base.Docs.@text_str
+Base.isvalid(::Any)
+Base.isvalid(::Any, ::Any)
+Base.isvalid(::AbstractString, ::Integer)
+Base.match
+Base.eachmatch
+Base.RegexMatch
+Base.keys(::RegexMatch)
+Base.isless(::AbstractString, ::AbstractString)
+Base.:(==)(::AbstractString, ::AbstractString)
+Base.cmp(::AbstractString, ::AbstractString)
+Base.lpad
+Base.rpad
+Base.ltruncate
+Base.rtruncate
+Base.ctruncate
+Base.findfirst(::AbstractString, ::AbstractString)
+Base.findnext(::AbstractString, ::AbstractString, ::Integer)
+Base.findnext(::AbstractChar, ::AbstractString, ::Integer)
+Base.findlast(::AbstractString, ::AbstractString)
+Base.findlast(::AbstractChar, ::AbstractString)
+Base.findprev(::AbstractString, ::AbstractString, ::Integer)
+Base.occursin
+Base.reverse(::Union{String,SubString{String}})
+Base.replace(::IO, s::AbstractString, ::Pair...)
+Base.eachsplit
+Base.eachrsplit
+Base.split
+Base.rsplit
+Base.strip
+Base.lstrip
+Base.rstrip
+Base.startswith
+Base.endswith
+Base.contains
+Base.first(::AbstractString, ::Integer)
+Base.last(::AbstractString, ::Integer)
+Base.uppercase
+Base.lowercase
+Base.titlecase
+Base.uppercasefirst
+Base.lowercasefirst
+Base.join
+Base.chop
+Base.chopprefix
+Base.chopsuffix
+Base.chomp
+Base.thisind
+Base.nextind(::AbstractString, ::Integer, ::Integer)
+Base.prevind(::AbstractString, ::Integer, ::Integer)
+Base.textwidth
+Base.isascii
 Base.iscntrl
 Base.isdigit
 Base.isletter
@@ -23,6 +99,7 @@ Base.ispunct
 Base.isspace
 Base.isuppercase
 Base.isxdigit
+Base.unsafe_substring
 ```
 
 ## String Basics

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -314,4 +314,5 @@ Base.AnnotatedChar
 Base.annotatedstring
 Base.annotations
 Base.annotate!
+Base.unannotate
 ```

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -23,7 +23,7 @@ Base.ispunct
 Base.isspace
 Base.isuppercase
 Base.isxdigit
-Base.unsafe_substring
+Base.raw_substring
 ```
 
 ## String Basics

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -181,11 +181,11 @@ global_logger(prev_logger)
 begin # SubString noshift deprecations
     @test_deprecated SubString{String}("abcd", 0, 1, Val(:noshift)) == "a"
     let ss = SubString("abcd", 2, 3)
-        @test_deprecated let sss = SubString{typeof(ss)}(ss, 0, 1, Val(:noshift))
-            sss == "b" && sss isa SubString{typeof(ss)}
-        end
+        @test_deprecated (SubString{typeof(ss)}(ss, 0, 1, Val(:noshift)) == "b")
+        @test_deprecated (SubString{typeof(ss)}(ss, 0, 1, Val(:noshift)) isa SubString{typeof(ss)})
     end
 end
+
 
 # END 1.14 deprecations
 

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -176,6 +176,20 @@ global_logger(prev_logger)
 
 
 #-------------------------------------------------------------------------------
+# BEGIN 1.14 deprecations
+
+begin # SubString noshift deprecations
+    @test_deprecated SubString{String}("abcd", 0, 1, Val(:noshift)) == "a"
+    let ss = SubString("abcd", 2, 3)
+        @test_deprecated let sss = SubString{typeof(ss)}(ss, 0, 1, Val(:noshift))
+            sss == "b" && sss isa SubString{typeof(ss)}
+        end
+    end
+end
+
+# END 1.14 deprecations
+
+#-------------------------------------------------------------------------------
 # BEGIN 0.7 deprecations
 
 begin # parser syntax deprecations

--- a/test/strings/annotated.jl
+++ b/test/strings/annotated.jl
@@ -77,6 +77,17 @@
 
     @test Bool === Base.infer_return_type(isvalid, Tuple{Base.AnnotatedString, Vararg})
     @test Int === Base.infer_return_type(ncodeunits, Tuple{Base.AnnotatedString})
+
+    @testset "unannotate" begin
+        s = "some string"
+        str = Base.AnnotatedString(s, [(2:5, :A, 3)])
+        @test Base.unannotate(str) === s
+
+        str2 = SubString(str, 2:9)
+        u = Base.unannotate(str2)
+        @test u isa SubString{String}
+        @test u == SubString(s, 2:9)
+    end
 end
 
 @testset "AnnotatedChar" begin

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -233,10 +233,17 @@ end
         @test (@views (x[3], x[1:2], x[[1,4]])) == ('c', "ab", "ad")
     end
 
-    @testset ":noshift constructor" begin
-        @test SubString("", 0, 0, Val(:noshift)) == ""
-        @test SubString("abcd", 0, 1, Val(:noshift)) == "a"
-        @test SubString("abcd", 0, 4, Val(:noshift)) == "abcd"
+    @testset "unsafe_substring" begin
+        s = "abcdefgøø"
+        @test unsafe_substring(s, 1, 11) == s
+        @test unsafe_substring(s, 1, 3) == "abc"
+        @test unsafe_substring(s, 3, 3) == "cde"
+        @test unsafe_substring(s, 5, 4) == String(codeunits(s)[5:8])
+        @test unsafe_substring(s, 1, 2) isa SubString{String}
+        @test unsafe_substring(unsafe_substring(s, 2, 8), 1, 3) isa SubString{String}
+
+        @test_throws BoundsError unsafe_substring(s, 0, 2)
+        @test_throws BoundsError unsafe_substring(s, 2, 11)
     end
 end
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -239,11 +239,30 @@ end
         @test raw_substring(s, 1, 3) == "abc"
         @test raw_substring(s, 3, 3) == "cde"
         @test raw_substring(s, 5, 4) == String(codeunits(s)[5:8])
+        @test raw_substring(s, 11, 1) == String(codeunits(s)[11:11])
         @test raw_substring(s, 1, 2) isa SubString{String}
         @test raw_substring(raw_substring(s, 2, 8), 1, 3) isa SubString{String}
 
+        @test raw_substring(s, 1, 0) == ""
+        @test raw_substring(s, 11, 0) == ""
+        @test_throws BoundsError raw_substring(s, 0, 0)
+        @test_throws BoundsError raw_substring(s, 11, 2)
+        @test_throws BoundsError raw_substring(s, 3, -1)
+
         @test_throws BoundsError raw_substring(s, 0, 2)
         @test_throws BoundsError raw_substring(s, 2, 11)
+    end
+
+    # if Substring of SubString is explicitly requested by typing out the type,
+    # we CAN construct them
+    @testset "Explicit sub-substring" begin
+        s = "abcdefg"
+        ss = view(s, 2:6)
+        sss = SubString{SubString{String}}(ss, 2, 3)
+        @test sss isa SubString{SubString{String}}
+        @test sss == "cd"
+        sss = SubString{SubString{String}}(ss)
+        @test sss == ss
     end
 end
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -233,17 +233,17 @@ end
         @test (@views (x[3], x[1:2], x[[1,4]])) == ('c', "ab", "ad")
     end
 
-    @testset "unsafe_substring" begin
+    @testset "raw_substring" begin
         s = "abcdefgøø"
-        @test unsafe_substring(s, 1, 11) == s
-        @test unsafe_substring(s, 1, 3) == "abc"
-        @test unsafe_substring(s, 3, 3) == "cde"
-        @test unsafe_substring(s, 5, 4) == String(codeunits(s)[5:8])
-        @test unsafe_substring(s, 1, 2) isa SubString{String}
-        @test unsafe_substring(unsafe_substring(s, 2, 8), 1, 3) isa SubString{String}
+        @test raw_substring(s, 1, 11) == s
+        @test raw_substring(s, 1, 3) == "abc"
+        @test raw_substring(s, 3, 3) == "cde"
+        @test raw_substring(s, 5, 4) == String(codeunits(s)[5:8])
+        @test raw_substring(s, 1, 2) isa SubString{String}
+        @test raw_substring(raw_substring(s, 2, 8), 1, 3) isa SubString{String}
 
-        @test_throws BoundsError unsafe_substring(s, 0, 2)
-        @test_throws BoundsError unsafe_substring(s, 2, 11)
+        @test_throws BoundsError raw_substring(s, 0, 2)
+        @test_throws BoundsError raw_substring(s, 2, 11)
     end
 end
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -235,6 +235,8 @@ end
 
     @testset "raw_substring" begin
         s = "abcdefgøø"
+        raw_substring = Base.raw_substring
+
         @test raw_substring(s, 1, 11) == s
         @test raw_substring(s, 1, 3) == "abc"
         @test raw_substring(s, 3, 3) == "cde"


### PR DESCRIPTION
This commit includes several, interlocked changes:
1. It removes an undocumented SubString constructor which triage has agreed can be considered internal and should be removed
    * EDIT: After triage comments, the method is now deprecated, but not removed.
2. It adds a new public, but unexported function `raw_substring`, which creates a substring without checking for valid string indices. This new function is used in place of the old removed method, internally in Julia.
    * EDIT: After triage comments, this was renamed from `unsafe_substring` to `raw_substring`
3. It adds a new public, but unexported function `unannotate`, which gives the underlying non-annotated string of an `AnnotatedString` or `SubString{AnnotatedString}`. The reason for this change is that currently, code outside Base (namely, in StyledStrings and JuliaSyntaxHighlighting) relies on this operation. Its current implementation reaches into both `AnnotatedString` and `SubString` internals. Instead, I provide the function here in Base, and let the two stdlibs use it. Also in general, I think it's a completely reasonable basic function to have for annotated strings.

For reviewers: We can make these functions exported (I don't have a strong opinion on that).

For this PR to land, it also requires compatible PRs in StyledStrings.jl and JuliaSyntaxHighlighting.jl, which uses the removed constructor.

This depends on two PRs to be merged first:
1. https://github.com/JuliaLang/JuliaSyntaxHighlighting.jl/pull/13
2. https://github.com/JuliaLang/StyledStrings.jl/pull/125

Supersedes https://github.com/JuliaLang/julia/pull/59606
Supersedes https://github.com/JuliaLang/julia/pull/55458
Closes https://github.com/JuliaLang/julia/issues/59610
Closes https://github.com/JuliaLang/julia/issues/55247