### PR TITLE
precompile: fix a myriad of concurrency and cache handling mistakes

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1023,7 +1023,7 @@ end
             write(joinpath(tmp, "Env1", "Manifest.toml"), """
             """)
             # Package in current env not present in manifest
-            pkg, env = Base.identify_package_env("Baz")
+            pkg, env = @lock Base.require_lock Base.identify_package_env("Baz")
             @test Base.locate_package(pkg, env) === nothing
         finally
             copy!(LOAD_PATH, old_load_path)
@@ -1722,7 +1722,8 @@ end
         Base64_key = Base.PkgId(Base.UUID("2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"), "Base64")
         oldBase64 = Base.unreference_module(Base64_key)
         cc = Base.compilecache(Base64_key)
-        @test Base.isprecompiled(Base64_key, cachepaths=String[cc[1]])
+        sourcepath = Base.locate_package(Base64_key)
+        @test Base.stale_cachefile(Base64_key, UInt128(0), sourcepath, cc[1]) !== true
         empty!(DEPOT_PATH)
         Base.require_stdlib(Base64_key)
         push!(DEPOT_PATH, depot_path)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -690,10 +690,10 @@ precompile_test_harness(false) do dir
         Base.require(Main, :FooBar2)
         error("the \"break me\" test failed")
     catch exc
-        isa(exc, Base.Precompilation.PkgPrecompileError) || rethrow()
-        occursin("Failed to precompile FooBar2", exc.msg) || rethrow()
-        # The LoadError is printed to stderr in the precompilepkgs worker and captured in the PkgPrecompileError msg
-        occursin("LoadError: break me", exc.msg) || rethrow()
+        isa(exc, LoadError) || rethrow()
+        exc = exc.error
+        isa(exc, ErrorException) || rethrow()
+        "break me" == exc.msg || rethrow()
     end
 
     # Test that trying to eval into closed modules during precompilation is an error
@@ -709,7 +709,9 @@ precompile_test_harness(false) do dir
         try
             Base.require(Main, :FooBar3)
         catch exc
-            isa(exc, Base.Precompilation.PkgPrecompileError) || rethrow()
+            isa(exc, LoadError) || rethrow()
+            exc = exc.error
+            isa(exc, ErrorException) || rethrow()
             occursin("Evaluation into the closed module `Base` breaks incremental compilation", exc.msg) || rethrow()
         end
     end
@@ -2145,9 +2147,6 @@ precompile_test_harness("Test flags") do load_path
         @test cacheflags.check_bounds == 2
         @test cacheflags.opt_level == 3
     end
-    id = Base.identify_package("TestFlags")
-    @test Base.isprecompiled(id, ;flags=modified_flags)
-    @test !Base.isprecompiled(id, ;flags=current_flags)
 end
 
 if Base.get_bool_env("CI", false) && (Sys.ARCH === :x86_64 || Sys.ARCH === :aarch64)


### PR DESCRIPTION
 * The PR for LOADING_CACHE failed to acquire the lock in many places it was newly made mandatory.
 * The stale_cache_key did not include many relevant parameters.
 * The `isprecompiled` implementation failed to account for the preferred stdlib logic of loading.
 * The `isprecompiled` cache failed to account for either newly compiled packages or other changes to the file system.
 * After parallel precompile noticed a package fails, it would retry with serial precompile, which was very pointless.
 * Semaphore could be <= 0, leading to deadlock.
 * After parallel precompile noticed a failure, it would crash, instead of allowing the program to continue on to load the package normally. We had tests for this, but they had gotten removed.

Marked as draft since this is against the quieter-logging PR (#59652).