### PR TITLE
Minor fixes for IRInterp in presence of ABI overrides

### DIFF
--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -867,7 +867,7 @@ end
 
 function IRInterpretationState(interp::AbstractInterpreter,
     codeinst::CodeInstance, mi::MethodInstance, argtypes::Vector{Any}, world::UInt)
-    @assert codeinst.def === mi "method instance is not synced with code instance"
+    @assert get_ci_mi(codeinst) === mi "method instance is not synced with code instance"
     src = @atomic :monotonic codeinst.inferred
     if isa(src, String)
         src = _uncompressed_ir(codeinst, src)

--- a/Compiler/src/ssair/irinterp.jl
+++ b/Compiler/src/ssair/irinterp.jl
@@ -18,7 +18,7 @@ function concrete_eval_invoke(interp::AbstractInterpreter, ci::CodeInstance, arg
         end
         return Pair{Any,Tuple{Bool,Bool}}(Const(value), (true, true))
     else
-        mi = ci.def
+        mi = get_ci_mi(ci)
         if is_constprop_edge_recursed(mi, parent)
             return Pair{Any,Tuple{Bool,Bool}}(nothing, (is_nothrow(effects), is_noub(effects)))
         end


### PR DESCRIPTION
Encountered in DAECompiler, when performing IR interpretation on IR that contains ABI overrides.