### PR TITLE
revert some performance-losing changes to max_args

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -51,8 +51,6 @@ function print(io::IO, xs...)
     return nothing
 end
 
-setfield!(typeof(print).name, :max_args, Int32(10), :monotonic)
-
 """
     println([io::IO], xs...)
 
@@ -75,8 +73,6 @@ julia> takestring!(io)
 ```
 """
 println(io::IO, xs...) = print(io, xs..., "\n")
-
-setfield!(typeof(println).name, :max_args, Int32(10), :monotonic)
 ## conversion of general objects to strings ##
 
 """
@@ -148,7 +144,6 @@ function print_to_string(xs...)
     end
     takestring!(s)
 end
-setfield!(typeof(print_to_string).name, :max_args, Int32(10), :monotonic)
 
 function string_with_env(env, xs...)
     if isempty(xs)

--- a/contrib/juliac/juliac-trim-base.jl
+++ b/contrib/juliac/juliac-trim-base.jl
@@ -77,9 +77,12 @@ end
             print(io, T.var.name)
         end
     end
-    # this function is not `--trim`-compatible if it resolves to a Varargs{...} specialization
+    # these functions are not `--trim`-compatible if it resolves to a Varargs{...} specialization
     # and since it only has 1-argument methods this happens too often by default (just 2-3 args)
     setfield!(typeof(throw_eachindex_mismatch_indices).name, :max_args, Int32(5), :monotonic)
+    setfield!(typeof(print).name, :max_args, Int32(10), :monotonic)
+    setfield!(typeof(println).name, :max_args, Int32(10), :monotonic)
+    setfield!(typeof(print_to_string).name, :max_args, Int32(10), :monotonic)
 end
 @eval Base.Sys begin
     __init_build() = nothing # VersionNumber parsing is not supported yet


### PR DESCRIPTION
This heuristic normally helps ensure good code performance. Overriding it (as was done in 97ecdb8595c4a1fbe68ba6f39b3244e8cdabc2c6) is observed to cause allocation regressions.

Fix #58632