### PR TITLE
[backports-release-1.11] Fix namespace of `IOError` in `random_seed`

### DIFF
--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -287,7 +287,7 @@ function random_seed()
         # almost surely always getting distinct seeds, while having them printed reasonably tersely
         return rand(RandomDevice(), UInt128)
     catch ex
-        ex isa IOError || rethrow()
+        ex isa Base.IOError || rethrow()
         @warn "Entropy pool not available to seed RNG; using ad-hoc entropy sources."
         return Libc.rand()
     end


### PR DESCRIPTION
This PR addresses an issue with `IOError` not being exported from `Base` and therefore being unavailable within `Random` if not fully qualified.

I'm not entirely certain which branch to make this PR to: `release-1.11` or `backports-release-1.11`. Please change the target branch to the appropriate one if necessary.