### PR TITLE
[release-1.11] Restore kwarg tab completions for Type{T}s

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -227,10 +227,6 @@ static void NOINLINE save_stack(jl_ptls_t ptls, jl_task_t *lastt, jl_task_t **pt
     lastt->copy_stack = nb;
     lastt->sticky = 1;
     memcpy_stack_a16((uint64_t*)buf, (uint64_t*)frame_addr, nb);
-    // this task's stack could have been modified after
-    // it was marked by an incremental collection
-    // move the barrier back instead of walking it again here
-    jl_gc_wb_back(lastt);
 }
 
 JL_NO_ASAN static void NOINLINE JL_NORETURN restore_stack(jl_task_t *t, jl_ptls_t ptls, char *p)
@@ -493,6 +489,12 @@ JL_NO_ASAN static void ctx_switch(jl_task_t *lastt)
 #endif
         *pt = NULL; // can't fail after here: clear the gc-root for the target task now
     }
+    // this task's stack or scope field could have been modified after
+    // it was marked by an incremental collection
+    // move the barrier back instead of walking the shadow stack again here to check if that is required
+    // even if killed (dropping the stack) and just the scope field matters,
+    // let the gc figure that out next time it does a quick mark
+    jl_gc_wb_back(lastt);
 
     // set up global state for new task and clear global state for old task
     t->ptls = ptls;

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -1030,7 +1030,7 @@ function complete_keyword_argument(partial, last_idx, context_module)
     # take many seconds to run over the thousands of possible methods. Note that
     # isabstracttype would return naively return true for common constructor calls
     # like Array, but the REPL's introspection here may know their Type{T}.
-    isconcretetype(funct) || return fail
+    isconcretetype(funct) || (Base.isType(funct) && !isabstracttype(funct.parameters[1])) || return fail
     complete_methods!(methods, funct, Any[Vararg{Any}], kwargs_ex, -1, kwargs_flag == 1)
     # TODO: use args_ex instead of Any[Vararg{Any}] and only provide kwarg completion for
     # method calls compatible with the current arguments.

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -2330,3 +2330,31 @@ f54131 = F54131()
     @test_broken REPLCompletions.KeywordArgumentCompletion("kwarg") in a
     @test (@elapsed completions(s, lastindex(s), @__MODULE__, false)) < 1
 end
+
+@kwdef struct T59244
+    asdf = 1
+    qwer = 2
+end
+@kwdef struct S59244{T}
+    asdf::T = 1
+    qwer::T = 2
+end
+@testset "kwarg completion of types" begin
+    s = "T59244(as"
+    a, b, c = completions(s, lastindex(s), @__MODULE__, #= shift =# false)
+    @test REPLCompletions.KeywordArgumentCompletion("asdf") in a
+
+    s = "T59244(; qw"
+    a, b, c = completions(s, lastindex(s), @__MODULE__, #= shift =# false)
+    @test REPLCompletions.KeywordArgumentCompletion("qwer") in a
+    @test REPLCompletions.KeywordArgumentCompletion("qwer") == only(a)
+
+    s = "S59244(as"
+    a, b, c = completions(s, lastindex(s), @__MODULE__, #= shift =# false)
+    @test REPLCompletions.KeywordArgumentCompletion("asdf") in a
+
+    s = "S59244(; qw"
+    a, b, c = completions(s, lastindex(s), @__MODULE__, #= shift =# false)
+    @test REPLCompletions.KeywordArgumentCompletion("qwer") in a
+    @test REPLCompletions.KeywordArgumentCompletion("qwer") == only(a)
+end


### PR DESCRIPTION
(cherry picked from commit da0b845ec70c43e86c2fb7f7ceaf946bdb90952d)

This is effectively #59692, but with different logic since the performance issues persist on 1.11.