### PR TITLE
tests: remove extraneous REPL and Pkg dependencies

### DIFF
--- a/test/gcext/gcext-test.jl
+++ b/test/gcext/gcext-test.jl
@@ -2,7 +2,6 @@
 
 # tests the output of the embedding example is correct
 using Test
-using Pkg
 
 if Sys.iswindows()
     # libjulia needs to be in the same directory as the embedding executable or in path

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,9 +3,6 @@
 using Test
 using Distributed
 using Dates
-if !Sys.iswindows() && isa(stdin, Base.TTY)
-    import REPL
-end
 using Printf: @sprintf
 using Base: Experimental
 using Base.ScopedValues
@@ -239,9 +236,9 @@ cd(@__DIR__) do
         if !Sys.iswindows() && isa(stdin, Base.TTY)
             t = current_task()
             stdin_monitor = @async begin
-                term = REPL.Terminals.TTYTerminal("xterm", stdin, stdout, stderr)
+                term = Base.Terminals.TTYTerminal("xterm", stdin, stdout, stderr)
                 try
-                    REPL.Terminals.raw!(term, true)
+                    Base.Terminals.raw!(term, true)
                     while true
                         c = read(term, Char)
                         if c == '\x3'
@@ -258,7 +255,7 @@ cd(@__DIR__) do
                 catch e
                     isa(e, InterruptException) || rethrow()
                 finally
-                    REPL.Terminals.raw!(term, false)
+                    Base.Terminals.raw!(term, false)
                 end
             end
         end

--- a/test/stdlib_dependencies.jl
+++ b/test/stdlib_dependencies.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 using Libdl
 using Pkg
 using Test


### PR DESCRIPTION
We do not need these anymore to test Base functions, since kind souls have moved the relevant functions to Base.