### PR TITLE
remove another log spam from precompilepkg code

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -835,8 +835,6 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
                 if single_requested_pkg && (liveprinting || !isempty(str))
                     @lock print_lock begin
                         if !liveprinting
-                            printpkgstyle(io, :Info, "Given $(pkg.name) was explicitly requested, output will be shown live $ansi_cleartoendofline",
-                                color = Base.info_color())
                             liveprinting = true
                             pkg_liveprinted[] = pkg
                         end


### PR DESCRIPTION
The program doesn't need to tell you it might do what you just told it to do. It should just do it.