### PR TITLE
lowering: increment world age after toplevel expressions

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -5090,6 +5090,7 @@ f(x) = yt(x)
              (check-top-level e)
              (let ((val (make-ssavalue)))
                (emit `(= ,val ,e))
+               (emit `(latestworld))
                (if tail (emit-return tail val))
                val))
 

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -598,3 +598,21 @@ function f()
 end
 end
 @test_throws ErrorException("importing Random into M57965 conflicts with an existing global") M57965.f()
+
+# issue #59429 - world age semantics with toplevel in macros
+module M59429
+using Test
+macro new_enum(T::Symbol, args...)
+   esc(quote
+      @enum $T $(args...)
+      function Base.hash(x::$T, h::UInt)
+        rand(UInt)
+      end
+    end)
+end
+
+@new_enum Foo59429 bar59429 baz59429
+
+# Test that the hash function works without world age issues
+@test hash(bar59429, UInt(0)) isa UInt
+end


### PR DESCRIPTION
When a macro expands to `:toplevel` expression, it seems reasonable (as would be if the expression were not wrapped in `:toplevel`) that any contained struct definitions be available thereafter. For example, this applies to `@enum`, which countrly causes world age erros when attempting to define a method on an enum within the same expression. Fix this by having lowering insert and explicit `latestworld` after toplevel.

Fixes #59429

Written by Claude