### PR TITLE
improve compile-ability of method errors

### DIFF
--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -315,6 +315,7 @@ the handler for that type.
     This interface is experimental and subject to change or removal without notice.
 """
 function show_error_hints(io, ex, args...)
+    @nospecialize
     hinters = get(_hint_handlers, typeof(ex), nothing)
     isnothing(hinters) && return
     for handler in hinters


### PR DESCRIPTION
This was correct prior to changing closures to use Core.Typeof, but was not corrected when that PR was merged.

This doesn't seem to quite fix issue #56861, since we used to have a precompile workload for this, and now REPL is a separate package.