### PR TITLE
[Mmap] Turn PAGESIZE into a function

### DIFF
--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -268,6 +268,7 @@ A2 = mmap(s, Matrix{Int}, (m,n))
 seek(s, 0)
 A3 = mmap(s, Matrix{Int}, (m,n), convert(Int64, 2*sizeof(Int)))
 @test A == A3
+seek(s, 0)
 A4 = mmap(s, Matrix{Int}, (m,150), convert(Int64, (2+150*m)*sizeof(Int)))
 @test A[:, 151:end] == A4
 close(s)


### PR DESCRIPTION
`PAGESIZE` is currently fixed at compile time, but the machine where Julia runs
may have a different memory page size than the one where the stdlib was compiled
on.  It's not worth making this a `OncePerProcess` object because the underlying
function call is very cheap, cheaper than the overhead of `OncePerProcess`.

This is somewhat breaking for those packages which [referred to the non-public `Mmap.PAGESIZE` symbol](https://juliahub.com/ui/Search?type=code&q=Mmap.PAGESIZE), luckily they are only three.