### PR TITLE
array: avoid overallocation when inserting at beginning of empty arrays

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1087,14 +1087,14 @@ end
 # Specifically we are wasting ~10% of memory for small arrays
 # by not picking memory sizes that max out a GC pool
 function overallocation(maxsize)
-    maxsize < 8 && return 8;
-    # compute maxsize = maxsize + 4*maxsize^(7/8) + maxsize/8
+    # compute maxsize = maxsize + 3*maxsize^(7/8) + maxsize/8
     # for small n, we grow faster than O(n)
     # for large n, we grow at O(n/8)
     # and as we reach O(memory) for memory>>1MB,
     # this means we end by adding about 10% of memory each time
+    # most commonly, this will take steps of 0-3-9-34 or 1-4-16-66 or 2-8-33
     exp2 = sizeof(maxsize) * 8 - Core.Intrinsics.ctlz_int(maxsize)
-    maxsize += (1 << div(exp2 * 7, 8)) * 4 + div(maxsize, 8)
+    maxsize += (1 << div(exp2 * 7, 8)) * 3 + div(maxsize, 8)
     return maxsize
 end
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -613,7 +613,7 @@ function alloc_request(buffer::IOBuffer, recommended_size::UInt)
     ensureroom(buffer, recommended_size)
     ptr = buffer.append ? buffer.size + 1 : buffer.ptr
     start_offset = ptr - 1
-    nb = min(length(buffer.data) - start_offset, buffer.maxsize - (start_offset - get_offset(buffer)))
+    nb = max(0, min(length(buffer.data) - start_offset, buffer.maxsize - (start_offset - get_offset(buffer))))
     return (Ptr{Cvoid}(pointer(buffer.data, ptr)), nb)
 end
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -612,7 +612,8 @@ end
 function alloc_request(buffer::IOBuffer, recommended_size::UInt)
     ensureroom(buffer, recommended_size)
     ptr = buffer.append ? buffer.size + 1 : buffer.ptr
-    nb = min(length(buffer.data), buffer.maxsize + get_offset(buffer)) - ptr + 1
+    start_offset = ptr - 1
+    nb = min(length(buffer.data) - start_offset, buffer.maxsize - (start_offset - get_offset(buffer)))
     return (Ptr{Cvoid}(pointer(buffer.data, ptr)), nb)
 end
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -525,6 +525,12 @@ end
     v = empty!(collect(1:100))
     pushfirst!(v, 1)
     @test length(v.ref.mem) == 100
+
+    # test that insert! at position 1 doesn't allocate for empty arrays with capacity (issue #58640)
+    v = empty!(Vector{Int}(undef, 5))
+    insert!(v, 1, 10)
+    @test v == [10]
+    @test length(v.ref.mem) == 5
 end
 
 @testset "popat!(::Vector, i, [default])" begin

--- a/test/core.jl
+++ b/test/core.jl
@@ -6852,9 +6852,6 @@ Base._growat!(A, 4, 1)
 Base._growat!(A, 2, 3)
 @test getindex(A, 1) === 0x01
 @test getindex(A, 2) === missing
-@test getindex(A, 3) === missing
-@test getindex(A, 4) === missing
-@test getindex(A, 5) === missing
 @test getindex(A, 6) === 0x03
 @test getindex(A, 7) === missing
 @test getindex(A, 8) === missing


### PR DESCRIPTION
array: reduce overallocation when inserting into small arrays

Fixes a minor nuisance where length 0 would grow to 8 and length 7 would also grow to 8. Instead growing by a flat 3x even initially.

Fixes #58640
