### PR TITLE
Make SecretBuffer and shred! public

### DIFF
--- a/base/public.jl
+++ b/base/public.jl
@@ -13,6 +13,7 @@ public
     AbstractOneTo,
     AbstractPipe,
     AsyncCondition,
+    SecretBuffer,
     CodeUnits,
     Event,
     Fix,
@@ -108,6 +109,7 @@ public
 
 # Strings
     escape_raw_string,
+    shread!,
 
 # IO
     # types

--- a/base/public.jl
+++ b/base/public.jl
@@ -109,7 +109,7 @@ public
 
 # Strings
     escape_raw_string,
-    shread!,
+    shred!,
 
 # IO
     # types


### PR DESCRIPTION
I'm assuming can and should (sometimes) be used, not just by Julia.

[Was it ok where put the public declaration under: shred! ok under Strings? Maybe it or both should go under IO? Where how no effect, except sort of [mis]documenting, the main thing is if this should be made public at all.]