### PR TITLE
iobuffer: fix overflow OOB read/write bugs

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -613,7 +613,7 @@ function alloc_request(buffer::IOBuffer, recommended_size::UInt)
     ensureroom(buffer, recommended_size)
     ptr = buffer.append ? buffer.size + 1 : buffer.ptr
     start_offset = ptr - 1
-    nb = min(length(buffer.data) - start_offset, buffer.maxsize - (start_offset - get_offset(buffer)))
+    nb = max(0, min(length(buffer.data) - start_offset, buffer.maxsize - (start_offset - get_offset(buffer))))
     return (Ptr{Cvoid}(pointer(buffer.data, ptr)), nb)
 end
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -612,7 +612,8 @@ end
 function alloc_request(buffer::IOBuffer, recommended_size::UInt)
     ensureroom(buffer, recommended_size)
     ptr = buffer.append ? buffer.size + 1 : buffer.ptr
-    nb = min(length(buffer.data), buffer.maxsize + get_offset(buffer)) - ptr + 1
+    start_offset = ptr - 1
+    nb = min(length(buffer.data) - start_offset, buffer.maxsize - (start_offset - get_offset(buffer)))
     return (Ptr{Cvoid}(pointer(buffer.data, ptr)), nb)
 end
 


### PR DESCRIPTION
maxsize is usually typemax, so need to be careful to not do comparisons after adding to it. Substracting from it should normally be perfectly fine. At worst we should compute a negative amount of space remaining.