### PR TITLE
CI: Dependabot config: We've renamed the `domain:ci` label to `ci`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
-      - "domain:ci"
+      - "ci"


### PR DESCRIPTION
We've already renamed the `domain:ci` label back to `ci`, so we should update the Dependabot config to reflect that change.