### PR TITLE
Extend backdating checks to imports and globals

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -44,7 +44,7 @@ using Core: ABIOverride, Builtin, CodeInstance, IntrinsicFunction, MethodInstanc
     typename, unsafe_write, write, stdout, stderr
 
 using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospecializeinfer,
-    PARTITION_KIND_GLOBAL, PARTITION_KIND_UNDEF_CONST, PARTITION_KIND_BACKDATED_CONST, PARTITION_KIND_DECLARED,
+    PARTITION_KIND_GLOBAL, PARTITION_KIND_UNDEF_CONST, PARTITION_KIND_BACKDATED_CONST, PARTITION_KIND_BACKDATED_IMPORT, PARTITION_KIND_BACKDATED_GLOBAL, PARTITION_KIND_DECLARED,
     PARTITION_FLAG_DEPWARN,
     Base, BitVector, Bottom, Callable, DataTypeFieldDesc,
     EffectsOverride, Filter, Generator, NUM_EFFECTS_OVERRIDES,
@@ -55,7 +55,7 @@ using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospeciali
     datatype_pointerfree, decode_effects_override, diff_names, fieldindex, visit,
     generating_output, get_nospecializeinfer_sig, get_world_counter, has_free_typevars,
     hasgenerator, hasintersect, indexed_iterate, isType, is_file_tracked, is_function_def,
-    is_meta_expr, is_meta_expr_head, is_nospecialized, is_nospecializeinfer, is_defined_const_binding,
+    is_meta_expr, is_meta_expr_head, is_nospecialized, is_nospecializeinfer, is_backdated, is_defined_const_binding,
     is_some_const_binding, is_some_guard, is_some_imported, is_some_explicit_imported, is_some_binding_imported, is_valid_intrinsic_elptr,
     isbitsunion, isconcretedispatch, isdispatchelem, isexpr, isfieldatomic, isidentityfree,
     iskindtype, ismutabletypename, ismutationfree, issingletontype, isvarargtype, isvatuple,

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3650,12 +3650,13 @@ function abstract_eval_partition_load(interp::Union{AbstractInterpreter,Nothing}
         end
     end
 
+    if is_backdated(kind)
+        # Infer this as guard. We do not want a later definition to retroactively improve
+        # inference results in an earlier world.
+        return RTEffects(Any, UndefVarError, local_getglobal_effects)
+    end
+
     if is_defined_const_binding(kind)
-        if kind == PARTITION_KIND_BACKDATED_CONST
-            # Infer this as guard. We do not want a later const definition to retroactively improve
-            # inference results in an earlier world.
-            return RTEffects(Any, UndefVarError, local_getglobal_effects)
-        end
         rt = Const(partition_restriction(partition))
         return RTEffects(rt, Union{}, Effects(EFFECTS_TOTAL,
             inaccessiblememonly=is_mutation_free_argtype(rt) ? ALWAYS_TRUE : ALWAYS_FALSE,

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -246,6 +246,8 @@ const PARTITION_KIND_DECLARED           = 0x8
 const PARTITION_KIND_GUARD              = 0x9
 const PARTITION_KIND_UNDEF_CONST        = 0xa
 const PARTITION_KIND_BACKDATED_CONST    = 0xb
+const PARTITION_KIND_BACKDATED_IMPORT   = 0xc
+const PARTITION_KIND_BACKDATED_GLOBAL   = 0xd
 
 const PARTITION_FLAG_EXPORTED     = 0x10
 const PARTITION_FLAG_DEPRECATED   = 0x20
@@ -256,11 +258,12 @@ const PARTITION_MASK_FLAG         = 0xf0
 
 const BINDING_FLAG_ANY_IMPLICIT_EDGES = 0x8
 
+is_backdated(kind::UInt8) = (kind == PARTITION_KIND_BACKDATED_CONST || kind == PARTITION_KIND_BACKDATED_IMPORT || kind == PARTITION_KIND_BACKDATED_GLOBAL)
 is_defined_const_binding(kind::UInt8) = (kind == PARTITION_KIND_CONST || kind == PARTITION_KIND_CONST_IMPORT || kind == PARTITION_KIND_IMPLICIT_CONST || kind == PARTITION_KIND_BACKDATED_CONST)
 is_some_const_binding(kind::UInt8) = (is_defined_const_binding(kind) || kind == PARTITION_KIND_UNDEF_CONST)
-is_some_imported(kind::UInt8) = (kind == PARTITION_KIND_IMPLICIT_GLOBAL || kind == PARTITION_KIND_IMPLICIT_CONST || kind == PARTITION_KIND_EXPLICIT || kind == PARTITION_KIND_IMPORTED)
+is_some_imported(kind::UInt8) = (kind == PARTITION_KIND_IMPLICIT_GLOBAL || kind == PARTITION_KIND_IMPLICIT_CONST || kind == PARTITION_KIND_EXPLICIT || kind == PARTITION_KIND_IMPORTED || kind == PARTITION_KIND_BACKDATED_IMPORT)
 is_some_implicit(kind::UInt8) = (kind == PARTITION_KIND_IMPLICIT_GLOBAL || kind == PARTITION_KIND_IMPLICIT_CONST || kind == PARTITION_KIND_GUARD || kind == PARTITION_KIND_FAILED)
-is_some_explicit_imported(kind::UInt8) = (kind == PARTITION_KIND_EXPLICIT || kind == PARTITION_KIND_IMPORTED)
+is_some_explicit_imported(kind::UInt8) = (kind == PARTITION_KIND_EXPLICIT || kind == PARTITION_KIND_IMPORTED || kind == PARTITION_KIND_BACKDATED_IMPORT)
 is_some_binding_imported(kind::UInt8) = is_some_explicit_imported(kind) || kind == PARTITION_KIND_IMPLICIT_GLOBAL
 is_some_guard(kind::UInt8) = (kind == PARTITION_KIND_GUARD || kind == PARTITION_KIND_FAILED || kind == PARTITION_KIND_UNDEF_CONST)
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -3309,6 +3309,12 @@ function print_partition(io::IO, partition::Core.BindingPartition)
     if kind == PARTITION_KIND_BACKDATED_CONST
         print(io, "backdated constant binding to ")
         print(io, partition_restriction(partition))
+    elseif kind == PARTITION_KIND_BACKDATED_IMPORT
+        print(io, "backdated explicit `import` from ")
+        print(io, partition_restriction(partition).globalref)
+    elseif kind == PARTITION_KIND_BACKDATED_GLOBAL
+        print(io, "backdated global variable with type ")
+        print(io, partition_restriction(partition))
     elseif kind == PARTITION_KIND_CONST
         print(io, "constant binding to ")
         print(io, partition_restriction(partition))

--- a/src/ast.c
+++ b/src/ast.c
@@ -1224,9 +1224,10 @@ JL_DLLEXPORT jl_value_t *jl_fl_lower(jl_value_t *expr, jl_module_t *inmodule,
 JL_DLLEXPORT jl_value_t *jl_lower(jl_value_t *expr, jl_module_t *inmodule,
                                   const char *filename, int line, size_t world, bool_t warn)
 {
-    jl_value_t *core_lower = NULL;
-    if (jl_core_module)
-        core_lower = jl_get_global_value(jl_core_module, jl_symbol("_lower"), jl_current_task->world_age);
+    if (!jl_core_module || !jl_boundp(jl_core_module, jl_symbol("_lower"), jl_current_task->world_age)) {
+        return jl_fl_lower(expr, inmodule, filename, line, world, warn);
+    }
+    jl_value_t *core_lower = jl_get_global_value(jl_core_module, jl_symbol("_lower"), jl_current_task->world_age);
     if (!core_lower || core_lower == jl_nothing) {
         return jl_fl_lower(expr, inmodule, filename, line, world, warn);
     }

--- a/src/julia.h
+++ b/src/julia.h
@@ -694,11 +694,11 @@ typedef struct _jl_weakref_t {
 //
 // We may make this list more permissive in the future.
 //
-// Finally, PARTITION_KIND_BACKDATED_CONST is a special case, and the only case where we may replace an
-// existing partition by a different partition kind in the same world age. As such, it needs special
-// support in inference. Any partition kind that may be replaced by a PARTITION_KIND_BACKDATED_CONST
-// must be inferred accordingly. PARTITION_KIND_BACKDATED_CONST is intended as a temporary compatibility
-// measure. The following kinds may be replaced by PARTITION_KIND_BACKDATED_CONST:
+// Finally, PARTITION_KIND_BACKDATED_* are special cases, and the only cases where we may replace an
+// existing partition by a different partition kind in the same world age. As such, they need special
+// support in inference. Any partition kind that may be replaced by a PARTITION_KIND_BACKDATED_*
+// must be inferred accordingly. PARTITION_KIND_BACKDATED_* are intended as a temporary compatibility
+// measure. The following kinds may be replaced by any backdated partition kind:
 //  - PARTITION_KIND_GUARD
 //  - PARTITION_KIND_FAILED
 //  - PARTITION_KIND_DECLARED
@@ -743,11 +743,17 @@ enum jl_partition_kind {
     // Backated constant. A constant that was backdated for compatibility. In all other
     // ways equivalent to PARTITION_KIND_CONST, but prints a warning on access
     PARTITION_KIND_BACKDATED_CONST = 0xb,
+    // Backdated import. An explicit import that was backdated for compatibility. In all other
+    // ways equivalent to PARTITION_KIND_IMPORTED, but prints a warning on access
+    PARTITION_KIND_BACKDATED_IMPORT = 0xc,
+    // Backdated global. A global that was backdated for compatibility. In all other
+    // ways equivalent to PARTITION_KIND_GLOBAL, but prints a warning on access
+    PARTITION_KIND_BACKDATED_GLOBAL = 0xd,
 
     // This is not a real binding kind, but can be used to ask for a re-resolution
     // of the implicit binding kind
-    PARTITION_FAKE_KIND_IMPLICIT_RECOMPUTE = 0xc,
-    PARTITION_FAKE_KIND_CYCLE = 0xd
+    PARTITION_FAKE_KIND_IMPLICIT_RECOMPUTE = 0xe,
+    PARTITION_FAKE_KIND_CYCLE = 0xf
 };
 
 static const uint8_t PARTITION_MASK_KIND = 0x0f;


### PR DESCRIPTION
Previously, backdated binding warnings were only emitted for constants. This commit extends the backdating mechanism to handle imports and globals. This change was requested by triage to improve compatibility of the new binding partition mechanism given issues like #58511.

With this change the behavior is as follows:
```julia
julia> function foo()
           include_string(Main, "a = 42")
           return a
       end

julia> foo()
WARNING: Detected access to binding `Main.a` in a world prior to its definition world.
  Julia 1.12 has introduced more strict world age semantics for global bindings.
  !!! This code may malfunction under Revise.
  !!! This code will error in future versions of Julia.
Hint: Add an appropriate `invokelatest` around the access to this binding.
To make this warning an error, and hence obtain a stack trace, use `julia --depwarn=error`.
42
```

With `julia --depwarn=error`, the access is rejected:

```julia
julia> foo()
ERROR: UndefVarError: `a` not defined in `Main`
```

I am still not a huge fan of the backdating mechanism in general, but I think this is the least objectionable of the alternatives and provides a big warning to let people know that something is wrong.

Largely written by Claude.