### PR TITLE
Revert "Restrict COFF to a single thread when symbol count is high (#50874)"

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -1196,7 +1196,6 @@ static FunctionInfo getFunctionWeight(const Function &F)
 }
 
 struct ModuleInfo {
-    Triple triple;
     size_t globals;
     size_t funcs;
     size_t bbs;
@@ -1207,7 +1206,6 @@ struct ModuleInfo {
 
 ModuleInfo compute_module_info(Module &M) {
     ModuleInfo info;
-    info.triple = Triple(M.getTargetTriple());
     info.globals = 0;
     info.funcs = 0;
     info.bbs = 0;
@@ -2005,12 +2003,6 @@ static unsigned compute_image_thread_count(const ModuleInfo &info) {
 #endif
     if (jl_is_timing_passes) // LLVM isn't thread safe when timing the passes https://github.com/llvm/llvm-project/issues/44417
         return 1;
-    // COFF has limits on external symbols (even hidden) up to 65536. We reserve the last few
-    // for any of our other symbols that we insert during compilation.
-    if (info.triple.isOSBinFormatCOFF() && info.globals > 64000) {
-        LLVM_DEBUG(dbgs() << "COFF is restricted to a single thread for large images\n");
-        return 1;
-    }
     // This is not overridable because empty modules do occasionally appear, but they'll be very small and thus exit early to
     // known easy behavior. Plus they really don't warrant multiple threads
     if (info.weight < 1000) {


### PR DESCRIPTION


This reverts commit eb4416b16b8a865376da5c76451a4d60516e2c4a.

As of LLVM 16, we automatically emit:
```
.drectve `-exclude-symbols:"<symbol>"`
```

which mitigates this issue where it is supported by the linker (GCC 11+ and LLD 14+ are tested working)

PackageCompiler on Windows now ships GCC 14 (https://github.com/JuliaLang/PackageCompiler.jl/pull/1012), so we should no longer need this workaround that can make a 15-minute sysimage compilation take an hour+