### PR TITLE
Add `@sprintf` examples to `string(::Int; pad)` method

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -977,7 +977,8 @@ split_sign(n::Unsigned) = n, false
 Convert an integer `n` to a string in the given `base`,
 optionally specifying a number of digits to pad to.
 
-See also [`digits`](@ref), [`bitstring`](@ref), [`count_zeros`](@ref).
+See also [`digits`](@ref), [`bitstring`](@ref), [`count_zeros`](@ref),
+and the Printf standard library.
 
 # Examples
 ```jldoctest
@@ -986,6 +987,14 @@ julia> string(5, base = 13, pad = 4)
 
 julia> string(-13, base = 5, pad = 4)
 "-0023"
+
+julia> using Printf
+
+julia> @sprintf("%04i", 5)
+"0005"
+
+julia> @sprintf("%4i", 5)
+"   5"
 ```
 """
 function string(n::Integer; base::Integer = 10, pad::Integer = 1)


### PR DESCRIPTION
Motivated by [this discourse question](https://discourse.julialang.org/t/converting-float-to-string-with-padding/132865) where someone found `string(::Int; pad)` but wanted floats.