### PR TITLE
ThreadSanitizer: add ignorelist and suppressions file

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -818,7 +818,7 @@ SANITIZE_OPTS += -fsanitize=address
 SANITIZE_LDFLAGS += -fsanitize=address -shared-libasan
 endif
 ifeq ($(SANITIZE_THREAD),1)
-SANITIZE_OPTS += -fsanitize=thread
+SANITIZE_OPTS += -fsanitize=thread -fsanitize-ignorelist=$(JULIAHOME)/contrib/tsan/ignorelist.txt
 SANITIZE_LDFLAGS += -fsanitize=thread
 ifneq ($(CROSS_BOOTSTRAP_JULIA),)
 bootstrap_julia_flags += --target-sanitize=thread

--- a/contrib/tsan/ignorelist.txt
+++ b/contrib/tsan/ignorelist.txt
@@ -1,0 +1,1 @@
+mainfile:*/gc-*.c

--- a/contrib/tsan/suppressions.txt
+++ b/contrib/tsan/suppressions.txt
@@ -1,0 +1,1 @@
+deadlock:invalidate_code_instance


### PR DESCRIPTION
Instrumenting the garbage collector results in a ton of warnings that would require relaxed atomics to suppress, and is a huge performance drag. This change turns off instrumentation for non-atomic operations for everything in `src/gc-*.c`.

Also, adds a `suppressions.txt` to be used with `TSAN_OPTIONS="suppressions=contrib/tsan/suppressions.txt"` that suppresses the lock order inversion warning on method locks, which is documented in https://docs.julialang.org/en/v1.13-dev/devdocs/locks/#Exceptions-to-the-lock-hierarchy.