### PR TITLE
fix `hash` docstring from `==` to `isequal`

### DIFF
--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -11,7 +11,7 @@ const HASH_SECRET = (
 """
     hash(x[, h::UInt])::UInt
 
-Compute an integer hash code such that `isequal(x,y)` implies `hash(x)==hash(y)`. The
+Compute an integer hash code such that `isequal(x,y)` implies `isequal(hash(x), hash(y))`. The
 optional second argument `h` is another hash code to be mixed with the result.
 
 New types should implement the 2-argument form, typically by calling the 2-argument `hash`


### PR DESCRIPTION
as stated this is not correct.

```
julia> hash(0.0)
0x23238f9f15dcda9e

julia> hash(-0.0)
0x3969366b98f98664
```