### PR TITLE
CI 1.12: Use the 1.12-specific Buildkite branch

### DIFF
--- a/.buildkite-external-version
+++ b/.buildkite-external-version
@@ -1,1 +1,1 @@
-main
+release-julia-1.12


### PR DESCRIPTION
This points to the [`release-julia-1.12` branch](https://github.com/JuliaCI/julia-buildkite/tree/release-julia-1.12) in the https://github.com/JuliaCI/julia-buildkite repo.