### PR TITLE
Docs: Recommend that packages using non-public Base functionality specify a tilde or equals compat entry for Julia

### DIFF
--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -54,7 +54,9 @@ to open an [issue](https://github.com/JuliaLang/julia/issues) or
 [pull request](https://github.com/JuliaLang/julia/pulls) to start a discussion for turning it
 into a public API. However, we do not discourage the attempt to create packages that expose
 stable public interfaces while relying on non-public implementation details of Julia and
-buffering the differences across different Julia versions.
+buffering the differences across different Julia versions. Such packages should use tilde
+(`julia = "~1.10"`) or equals (`julia = "=1.10.5"`) specifiers in their Julia `[compat]` entries,
+instead of the default (caret) specifier.
 
 ### The documentation is not accurate enough. Can I rely on the existing behavior?
 


### PR DESCRIPTION
This is a follow-up to #35715.

## Motivation

As I see it, my reasoning here is similar to our reasoning for requiring upper-bounded `[compat]` entries for packages registered in General. We don't let people register a package with a `[compat]` entry of the form `MyDep = ">= 1.1.1"`, because there's no way for the package author to know or guarantee that MyDep v2 won't break their package.

Similarly, if a package author is using non-public Base functionality, then I don't think they should have a `[compat]` entry of the form `julia = "1.12"` (or `julia = "^1.12"`), because there's no way for the package author to know whether or not Julia 1.13 will break (or remove) the non-public functionality. It's thus safer for the package author to do `julia = "~1.12"`, which will prevent users of Julia 1.13 from installing a broken version of the package.

A very risk-averse package author would do `julia = "=1.12.0, =1.12.1, =1.12.2, ..."`, in case the functionality they rely on changes in a patch version. I don't think we need to recommend that level of strictness.

## Arguments against tilde (or equals) `[compat]` specifiers

### Breaks PkgEval

One argument against `julia = "~1.12"` is that it renders the package untestable in the PkgEval for the `release-1.13` branch, because the Julia version on the `release-1.13` branch is of the form `1.13.0-DEV...`, which is incompatible with `julia = "~1.12"`. So PkgEval wouldn't be able to test any packages with tilde (or equals) Julia `[compat]` entries. This is a problem, because the same package that uses non-Base public functionality is probably using some public Base functionality, and we want to run PkgEval to make sure we don't break the public Base functionality in that package.

I think we can work around this by having some special logic in PkgEval that rewrites tilde/equals compat entries to caret compat entries, thus allowing us to test these packages in PkgEval.

### Breaks package CI on Julia nightly

Same reasoning as PkgEval. Basically, nobody would be able to run their package CI (e.g. GitHub Actions) on Julia nightly.