### PR TITLE
Simplify `Dict` representation

### DIFF
--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -1331,7 +1331,7 @@ test_const_return(()->sizeof(Int), Tuple{}, sizeof(Int))
 test_const_return(()->sizeof(1), Tuple{}, sizeof(Int))
 test_const_return(()->sizeof(DataType), Tuple{}, sizeof(DataType))
 test_const_return(()->sizeof(1 < 2), Tuple{}, 1)
-test_const_return(()->fieldtype(Dict{Int64,Nothing}, :age), Tuple{}, UInt)
+test_const_return(()->fieldtype(Dict{Int64,Nothing}, :age), Tuple{}, UInt32)
 test_const_return(@eval(()->Core.sizeof($(Array{Int,0}(undef)))), Tuple{}, 2 * sizeof(Int))
 test_const_return(@eval(()->Core.sizeof($(Matrix{Float32}(undef, 2, 2)))), Tuple{}, 4 * sizeof(Int))
 # TODO: do we want to implement these?

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -573,7 +573,7 @@ end
 
 function pop!(h::Dict)
     isempty(h) && throw(ArgumentError("dict must be non-empty"))
-    idx = skip_deleted!(h,1 )
+    idx = skip_deleted(h, 1)
     @inbounds key = h.keys[idx]
     @inbounds val = h.vals[idx]
     _delete!(h, idx)
@@ -654,7 +654,7 @@ end
 end
 @propagate_inbounds function iterate(t::Dict)
     isempty(t) && return nothing
-    _iterate_dict(t, t.count==0 ? 0 : skip_deleted(t, 1))
+    _iterate_dict(t, skip_deleted(t, 1))
 end
 @propagate_inbounds iterate(t::Dict, i) = _iterate_dict(t, skip_deleted(t, i))
 

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -586,6 +586,9 @@ function _delete!(h::Dict{K,V}, index) where {K,V}
     sz = length(slots)
     _unsetindex!(h.keys, index)
     _unsetindex!(h.vals, index)
+    if max(16, h.count*8) <= sz # if <1/8th full and not tiny, resize to 1/2 full
+        return rehash!(h, h.count*2)
+    end
     # if the next slot is empty we don't need a tombstone
     # and can remove all tombstones that were required by the element we just deleted
     ndel = 1

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -223,7 +223,6 @@ end
 function ht_keyindex(h::Dict{K,V}, key) where V where K
     isempty(h) && return -1
     sz = length(h.keys)
-    iter = 0
     index, sh = hashindex(key, sz)
     keys = h.keys
 
@@ -237,7 +236,6 @@ function ht_keyindex(h::Dict{K,V}, key) where V where K
         end
 
         index = (index & (sz-1)) + 1
-        iter += 1
     end
     # This line is unreachable
 end
@@ -254,7 +252,6 @@ function ht_keyindex2_shorthash!(h::Dict{K,V}, key) where V where K
         index, sh = hashindex(key, length(h.keys))
         return -index, sh
     end
-    iter = 0
     index, sh = hashindex(key, sz)
     avail = 0
     keys = h.keys
@@ -278,7 +275,6 @@ function ht_keyindex2_shorthash!(h::Dict{K,V}, key) where V where K
         end
 
         index = (index & (sz-1)) + 1
-        iter += 1
     end
 end
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -376,7 +376,7 @@ macro _nospecializeinfer_meta()
 end
 
 # These special checkbounds methods are defined early for bootstrapping
-function checkbounds(::Type{Bool}, A::Union{Array, Memory}, i::Int)
+function checkbounds(::Type{Bool}, A::Union{Array, GenericMemory}, i::Int)
     @inline
     ult_int(bitcast(UInt, sub_int(i, 1)), bitcast(UInt, length(A)))
 end

--- a/base/set.jl
+++ b/base/set.jl
@@ -52,7 +52,7 @@ function Set{T}(s::KeySet{T, <:Dict{T}}) where {T}
     slots = copy(d.slots)
     keys = copy(d.keys)
     vals = similar(d.vals, Nothing)
-    _Set(Dict{T,Nothing}(slots, keys, vals, d.ndel, d.count, d.age, d.idxfloor, d.maxprobe))
+    _Set(Dict{T,Nothing}(slots, keys, vals, d.ndel, d.count, d.age))
 end
 
 Set(itr) = _Set(itr, IteratorEltype(itr))
@@ -956,7 +956,7 @@ function _replace!(new::Callable, t::Dict{K,V}, A::AbstractDict, count::Int) whe
     count == 0 && return t
     c = 0
     news = Pair{K,V}[]
-    i = skip_deleted_floor!(t)
+    i = skip_deleted(t, 1)
     @inbounds while i != 0
         k1, v1 = t.keys[i], t.vals[i]
         x1 = Pair{K,V}(k1, v1)

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -65,7 +65,7 @@ WeakKeyDict(kv) = Base.dict_with_eltype((K, V) -> WeakKeyDict{K, V}, kv, eltype(
 function _cleanup_locked(h::WeakKeyDict)
     if h.dirty
         h.dirty = false
-        idx = skip_deleted_floor!(h.ht)
+        idx = skip_deleted(h.ht, 1)
         while idx != 0
             if h.ht.keys[idx].value === nothing
                 _delete!(h.ht, idx)

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1531,27 +1531,6 @@ for T in (Int, Float64, String, Symbol)
     end
 end
 
-struct BadHash
-    i::Int
-end
-Base.hash(::BadHash, ::UInt)=UInt(1)
-@testset "maxprobe reset #51595" begin
-    d = Dict(BadHash(i)=>nothing for i in 1:20)
-    empty!(d)
-    sizehint!(d, 0)
-    @test d.maxprobe < length(d.keys)
-    d[BadHash(1)]=nothing
-    @test !(BadHash(2) in keys(d))
-    d = Dict(BadHash(i)=>nothing for i in 1:20)
-    for _ in 1:20
-        pop!(d)
-    end
-    sizehint!(d, 0)
-    @test d.maxprobe < length(d.keys)
-    d[BadHash(1)]=nothing
-    @test !(BadHash(2) in keys(d))
-end
-
 # Issue #52066
 let d = Dict()
     d[1] = 'a'


### PR DESCRIPTION
remove `idxfloor` and `maxprobe`, and shrink `age` to `UInt32`.

`idxfloor` is removed because the only thing it helps with is speeding up `iterate` calls (very slightly since it only speeds up the first call), and the speedup comes at a cost on insertions and deletions that happen to land near the front of the dict.

`maxprobe` is removed because if the hash function is good, we know that the `Dict` will spread values well, and if the `hash` function isn't good, `rehashing` won't fix anything, so we spend a lot of effort tracking `maxprobe`, but in most circumstances, it won't do anything, and in the circumstances where it does, it probably would be better off if it didn't.

Rebased and slightly more aggressive version of https://github.com/JuliaLang/julia/pull/48380 (rebasing was going to be more annoying since that PR was pre `Memory`).