### PR TITLE
Avoid method instance normalization for opaque closure methods

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -3809,7 +3809,7 @@ JL_DLLEXPORT jl_value_t *jl_normalize_to_compilable_sig(jl_tupletype_t *ti, jl_s
 jl_method_instance_t *jl_normalize_to_compilable_mi(jl_method_instance_t *mi JL_PROPAGATES_ROOT)
 {
     jl_method_t *def = mi->def.method;
-    if (!jl_is_method(def) || !jl_is_datatype(mi->specTypes))
+    if (!jl_is_method(def) || !jl_is_datatype(mi->specTypes) || def->is_for_opaque_closure)
         return mi;
     jl_value_t *compilationsig = jl_normalize_to_compilable_sig((jl_datatype_t*)mi->specTypes, mi->sparam_vals, def, 1);
     if (compilationsig == jl_nothing || jl_egal(compilationsig, mi->specTypes))

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -297,6 +297,20 @@ let src = code_typed((Int,Int)) do x, y...
         @test oc(1,2) === (1,(2,))
         @test_throws MethodError oc(1,2,3)
     end
+
+    # with manually constructed IRCode, without round-trip to CodeInfo
+    f59222(xs...) = length(xs)
+    ir = Base.code_ircode_by_type(Tuple{typeof(f59222), Symbol, Symbol})[1][1]
+    ir.argtypes[1] = Tuple{}
+    let oc = Core.OpaqueClosure(ir; isva=true)
+        @test oc(:a, :b) == 2
+    end
+    ir = Base.code_ircode_by_type(Tuple{typeof(f59222), Symbol, Vararg{Symbol}})[1][1]
+    ir.argtypes[1] = Tuple{}
+    let oc = Core.OpaqueClosure(ir; isva=true)
+        @test oc(:a) == 1
+        @test oc(:a, :b, :c) == 3
+    end
 end
 
 # Check for correct handling in case of broken return type.

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -302,12 +302,12 @@ let src = code_typed((Int,Int)) do x, y...
     f59222(xs...) = length(xs)
     ir = Base.code_ircode_by_type(Tuple{typeof(f59222), Symbol, Symbol})[1][1]
     ir.argtypes[1] = Tuple{}
-    let oc = Core.OpaqueClosure(ir; isva=true)
+    let oc = OpaqueClosure(ir; isva=true)
         @test oc(:a, :b) == 2
     end
     ir = Base.code_ircode_by_type(Tuple{typeof(f59222), Symbol, Vararg{Symbol}})[1][1]
     ir.argtypes[1] = Tuple{}
-    let oc = Core.OpaqueClosure(ir; isva=true)
+    let oc = OpaqueClosure(ir; isva=true)
         @test oc(:a) == 1
         @test oc(:a, :b, :c) == 3
     end


### PR DESCRIPTION
Fixes #59222.

This issue was caused by a mismatch with `jl_new_opaque_closure_from_code_info_in_world` filling in the unnormalized method instance, and `new_opaque_closure` getting its `spec_ptr` from the normalized one via `jl_compile_method_internal`.

For example, `g(xs...)` specialized as `g(:a, :b)` resulted in a different method instance than the corresponding normalized one:
```julia
Tuple{Tuple{typeof(Main.g)}, Symbol, Symbol} # unnormalized
Tuple{Tuple{typeof(Main.g)}, Symbol, Vararg{Symbol}} # normalized
```

Here I chose to align on using the unnormalized one from the `CodeInfo` at `OpaqueClosure` construction (the fix being a single-line change in that case), but we could also choose the normalized one if that is deemed preferable, so long as we use the same when storing the inferred code and when retrieving the `spec_ptr`.

---

🤖 Generated with some assistance from Claude Code.