### PR TITLE
add syntax highlighting to the REPL input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -97,6 +97,7 @@ Standard library changes
 #### REPL
 
 * The Julia REPL now support bracketed paste on Windows which should significantly speed up pasting large code blocks into the REPL ([#59825])
+* The REPL now provides syntax highlighting for input as you type. See the REPL docs for more info about customization.
 * The display of `AbstractChar`s in the main REPL mode now includes LaTeX input information like what is shown in help mode ([#58181]).
 * Display of repeated frames and cycles in stack traces has been improved by bracketing them in the trace and treating them consistently ([#55841]).
 

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -41,6 +41,7 @@ precompile(Tuple{typeof(Base.Terminals.enable_bracketed_paste), Base.Terminals.T
 precompile(Tuple{typeof(Base.Terminals.width), Base.Terminals.TTYTerminal})
 precompile(Tuple{typeof(Base.Terminals.height), Base.Terminals.TTYTerminal})
 precompile(Tuple{typeof(Base.write), Base.Terminals.TTYTerminal, Array{UInt8, 1}})
+precompile(Tuple{typeof(Base.isempty), Base.AnnotatedString{String}}
 
 # loading.jl - without these each precompile worker would precompile these because they're hit before pkgimages are loaded
 precompile(Base.__require, (Module, Symbol))

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -533,6 +533,183 @@ mmap(file::AbstractString, ::Type{T}, len::Integer) where T<:BitArray in Mmap at
 mmap(file::AbstractString, ::Type{T}, len::Integer, offset::Integer; grow, shared) where T<:BitArray in Mmap at Mmap/src/Mmap.jl:322
 ```
 
+## Syntax Highlighting
+
+The REPL provides syntax highlighting for input as you type.
+Syntax highlighting is enabled by default but can be disabled in your `~/.julia/config/startup.jl`:
+
+```julia
+atreplinit() do repl
+    repl.options.style_input = false
+end
+```
+
+### Customizing Syntax Highlighting Colors
+
+The default syntax highlighting theme is quite conservative but can be customized using a TOML file `faces.toml` (https://julialang.github.io/StyledStrings.jl/dev/#stdlib-styledstrings-face-toml) in `.julia/config` (or by explicitly loading the faces from a face toml file).
+
+
+<details>
+<summary>Example: Monokai color theme (click to expand)</summary>
+
+```toml
+# Monokai color theme for Julia syntax highlighting
+
+[julia_macro]
+foreground = "#A6E22E"
+
+[julia_symbol]
+foreground = "#AE81FF"
+
+[julia_singleton_identifier]
+inherit = "julia_symbol"
+
+[julia_type]
+foreground = "#66D9EF"
+
+[julia_typedec]
+foreground = "#66D9EF"
+weight = "bold"
+
+[julia_comment]
+foreground = "#75715E"
+italic = true
+
+[julia_string]
+foreground = "#E6DB74"
+
+[julia_regex]
+inherit = "julia_string"
+
+[julia_backslash_literal]
+foreground = "#FD971F"
+inherit = "julia_string"
+
+[julia_string_delim]
+foreground = "#E6DB74"
+weight = "bold"
+
+[julia_cmdstring]
+inherit = "julia_string"
+
+[julia_char]
+inherit = "julia_string"
+
+[julia_char_delim]
+inherit = "julia_string_delim"
+
+[julia_number]
+foreground = "#AE81FF"
+
+[julia_bool]
+foreground = "#AE81FF"
+weight = "bold"
+
+[julia_funcall]
+foreground = "#A6E22E"
+
+[julia_broadcast]
+foreground = "#F92672"
+weight = "bold"
+
+[julia_builtin]
+foreground = "#66D9EF"
+weight = "bold"
+
+[julia_operator]
+foreground = "#F92672"
+
+[julia_comparator]
+inherit = "julia_operator"
+
+[julia_assignment]
+foreground = "#F92672"
+weight = "bold"
+
+[julia_keyword]
+foreground = "#F92672"
+weight = "bold"
+
+[julia_parentheses]
+foreground = "#F8F8F2"
+
+[julia_unpaired_parentheses]
+background = "#F92672"
+foreground = "#F8F8F0"
+weight = "bold"
+
+[julia_error]
+background = "#F92672"
+foreground = "#F8F8F0"
+
+[julia_rainbow_paren_1]
+foreground = "#A6E22E"
+inherit = "julia_parentheses"
+
+[julia_rainbow_paren_2]
+foreground = "#66D9EF"
+inherit = "julia_parentheses"
+
+[julia_rainbow_paren_3]
+foreground = "#FD971F"
+inherit = "julia_parentheses"
+
+[julia_rainbow_paren_4]
+inherit = "julia_rainbow_paren_1"
+
+[julia_rainbow_paren_5]
+inherit = "julia_rainbow_paren_2"
+
+[julia_rainbow_paren_6]
+inherit = "julia_rainbow_paren_3"
+
+# Rainbow brackets
+[julia_rainbow_bracket_1]
+foreground = "#AE81FF"
+inherit = "julia_parentheses"
+
+[julia_rainbow_bracket_2]
+foreground = "#E6DB74"
+inherit = "julia_parentheses"
+
+[julia_rainbow_bracket_3]
+inherit = "julia_rainbow_bracket_1"
+
+[julia_rainbow_bracket_4]
+inherit = "julia_rainbow_bracket_2"
+
+[julia_rainbow_bracket_5]
+inherit = "julia_rainbow_bracket_1"
+
+[julia_rainbow_bracket_6]
+inherit = "julia_rainbow_bracket_2"
+
+# Rainbow curlies
+[julia_rainbow_curly_1]
+foreground = "#F92672"
+inherit = "julia_parentheses"
+
+[julia_rainbow_curly_2]
+foreground = "#A6E22E"
+inherit = "julia_parentheses"
+
+[julia_rainbow_curly_3]
+inherit = "julia_rainbow_curly_1"
+
+[julia_rainbow_curly_4]
+inherit = "julia_rainbow_curly_2"
+
+[julia_rainbow_curly_5]
+inherit = "julia_rainbow_curly_1"
+
+[julia_rainbow_curly_6]
+inherit = "julia_rainbow_curly_2"
+```
+
+</details>
+
+For a complete list of customizable faces, see the [JuliaSyntaxHighlighting package documentation](https://julialang.github.io/JuliaSyntaxHighlighting.jl/dev/).
+
 ## Customizing Colors
 
 The colors used by Julia and the REPL can be customized, as well. To change the

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -4,9 +4,12 @@ module LineEdit
 
 import ..REPL
 using ..REPL: AbstractREPL, Options
+using ..REPL.StylingPasses: StylingPass, SyntaxHighlightPass, RegionHighlightPass, EnclosingParenHighlightPass, StylingContext, apply_styling_passes, merge_annotations
 
 using ..Terminals
 import ..Terminals: raw!, width, height, clear_line, beep
+
+using StyledStrings
 
 import Base: ensureroom, show, AnyDict, position
 using Base: something
@@ -58,6 +61,7 @@ mutable struct Prompt <: TextInterface
     on_done::Function
     hist::HistoryProvider  # TODO?: rename this `hp` (consistency with other TextInterfaces), or is the type-assert useful for mode(s)?
     sticky::Bool
+    styling_passes::Vector{StylingPass}  # Styling passes to apply to input
 end
 
 show(io::IO, x::Prompt) = show(io, string("Prompt(\"", prompt_string(x.prompt), "\",...)"))
@@ -565,6 +569,8 @@ function maybe_show_hint(s::PromptState)
     return nothing
 end
 
+max_highlight_size::Int = 10000 # bytes
+
 function refresh_multi_line(s::PromptState; kw...)
     if s.refresh_wait !== nothing
         close(s.refresh_wait)
@@ -611,6 +617,42 @@ function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf
         reader isa Base.TTY && !Base.ispty(reader)::Bool
     else false end
 
+    # Get the styling passes from the prompt
+    prompt_obj = nothing
+    if prompt isa PromptState
+        prompt_obj = prompt.p
+    elseif prompt isa PrefixSearchState || prompt isa SearchState
+        if isdefined(prompt, :parent) && prompt.parent isa Prompt
+            prompt_obj = prompt.parent
+        end
+    end
+
+    styled_buffer = AnnotatedString("")
+    if buf.size > 0 && buf.size <= max_highlight_size
+        full_input = String(buf.data[1:buf.size])
+        if !isempty(full_input)
+            passes = StylingPass[]
+            context = StylingContext(buf_pos, regstart, regstop)
+
+            # Add prompt-specific styling passes if the prompt has them and styling is enabled
+            enable_style_input = prompt_obj === nothing ? false :
+                (isdefined(prompt_obj, :repl) && prompt_obj.repl !== nothing ?
+                    prompt_obj.repl.options.style_input : false)
+
+            if enable_style_input && prompt_obj !== nothing
+                append!(passes, prompt_obj.styling_passes)
+            end
+
+            if region_active
+                push!(passes, RegionHighlightPass())
+            end
+
+            if !isempty(passes)
+                styled_buffer = apply_styling_passes(full_input, passes, context)
+            end
+        end
+    end
+
     # Now go through the buffer line by line
     seek(buf, 0)
     moreinput = true # add a blank line if there is a trailing newline on the last line
@@ -636,12 +678,26 @@ function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf
         llength = textwidth(line)
         slength = sizeof(line)
         cur_row += 1
-        # lwrite: what will be written to termbuf
-        lwrite = region_active ? highlight_region(line, regstart, regstop, written, slength) :
-                                 line
+
+        # Extract the portion of styled_buffer corresponding to this line.
+        if !isempty(styled_buffer)
+            # Calculate byte positions for this line in the buffer
+            line_start_byte = written + 1
+            line_end_byte = written + slength
+
+            # Convert to valid character indices (handles UTF-8 boundaries)
+            start_idx = thisind(styled_buffer, line_start_byte)
+            end_idx = thisind(styled_buffer, line_end_byte)
+
+            lwrite = @view styled_buffer[start_idx:end_idx]
+        else
+            lwrite = line
+        end
+
         written += slength
         cmove_col(termbuf, lindent + 1)
-        write(termbuf, lwrite)
+
+        write(IOContext(termbuf, :color => hascolor(terminal)), lwrite)
         # We expect to be line after the last valid output line (due to
         # the '\n' at the end of the previous line)
         if curs_row == -1
@@ -690,18 +746,6 @@ function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf
     cmove_col(termbuf, curs_pos + 1)
     # Updated cur_row,curs_row
     return InputAreaState(cur_row, curs_row)
-end
-
-function highlight_region(lwrite::Union{String,SubString{String}}, regstart::Int, regstop::Int, written::Int, slength::Int)
-    if written <= regstop <= written+slength
-        i = thisind(lwrite, regstop-written)
-        lwrite = lwrite[1:i] * Base.disable_text_style[:reverse] * lwrite[nextind(lwrite, i):end]
-    end
-    if written <= regstart <= written+slength
-        i = thisind(lwrite, regstart-written)
-        lwrite = lwrite[1:i] * Base.text_colors[:reverse] * lwrite[nextind(lwrite, i):end]
-    end
-    return lwrite
 end
 
 function refresh_multi_line(terminal::UnixTerminal, args...; kwargs...)
@@ -999,7 +1043,9 @@ function edit_insert(s::PromptState, c::StringLike)
         offset += position(buf) - beginofline(buf) # size of current line
         spinner = '\0'
         delayup = !eof(buf) || old_wait
-        if offset + textwidth(str) <= w && !(after == 0 && delayup)
+        # Disable fast path when syntax highlighting is enabled
+        use_fast_path = offset + textwidth(str) <= w && !(after == 0 && delayup) && !options(s).style_input
+        if use_fast_path
             # Avoid full update when appending characters to the end
             # and an update of curs_row isn't necessary (conservatively estimated)
             write(termbuf, str)
@@ -2226,6 +2272,13 @@ function replace_line(s::PrefixSearchState, l::Union{String,SubString{String}})
     nothing
 end
 
+function write_prompt(terminal, s::SearchState, color::Bool)
+    failed = s.failed ? "failed " : ""
+    promptstr = s.backward ? "($(failed)reverse-i-search)`" : "($(failed)forward-i-search)`"
+    write(terminal, promptstr)
+    return textwidth(promptstr)
+end
+
 function refresh_multi_line(termbuf::TerminalBuffer, s::SearchState)
     buf = IOBuffer()
     unsafe_write(buf, pointer(s.query_buffer.data), s.query_buffer.ptr-1)
@@ -2236,9 +2289,7 @@ function refresh_multi_line(termbuf::TerminalBuffer, s::SearchState)
     write(buf, read(s.response_buffer, String))
     buf.ptr = offset + ptr - 1
     s.response_buffer.ptr = ptr
-    failed = s.failed ? "failed " : ""
-    ias = refresh_multi_line(termbuf, s.terminal, buf, s.ias,
-                             s.backward ? "($(failed)reverse-i-search)`" : "($(failed)forward-i-search)`")
+    ias = refresh_multi_line(termbuf, s.terminal, buf, s.ias, s)
     s.ias = ias
     return ias
 end
@@ -2823,10 +2874,11 @@ function Prompt(prompt
     on_enter = default_enter_cb,
     on_done = ()->nothing,
     hist = EmptyHistoryProvider(),
-    sticky = false)
+    sticky = false,
+    styling_passes = StylingPass[])
 
     return Prompt(prompt, prompt_prefix, prompt_suffix, output_prefix, output_prefix_prefix, output_prefix_suffix,
-                   keymap_dict, repl, complete, on_enter, on_done, hist, sticky)
+                   keymap_dict, repl, complete, on_enter, on_done, hist, sticky, styling_passes)
 end
 
 run_interface(::Prompt) = nothing

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -66,6 +66,8 @@ using Base.Terminals
 abstract type AbstractREPL end
 
 include("options.jl")
+include("StylingPasses.jl")
+using .StylingPasses
 
 include("LineEdit.jl")
 using .LineEdit
@@ -1329,7 +1331,11 @@ function setup_interface(
             (repl.envcolors ? Base.input_color : repl.input_color) : "",
         repl = repl,
         complete = replc,
-        on_enter = return_callback)
+        on_enter = return_callback,
+        styling_passes = StylingPasses.StylingPass[
+            StylingPasses.SyntaxHighlightPass(),
+            StylingPasses.EnclosingParenHighlightPass()
+        ])
 
     # Setup help mode
     help_mode = Prompt(contextual_prompt(repl, HELP_PROMPT),

--- a/stdlib/REPL/src/StylingPasses.jl
+++ b/stdlib/REPL/src/StylingPasses.jl
@@ -1,0 +1,165 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Each pass takes the input string and returns an AnnotatedString with styling annotations
+
+module StylingPasses
+
+using StyledStrings
+using StyledStrings: Face
+using JuliaSyntaxHighlighting
+import Base: AnnotatedString, annotate!, annotations, JuliaSyntax
+
+export StylingPass, StylingContext, SyntaxHighlightPass, RegionHighlightPass,
+       EnclosingParenHighlightPass, apply_styling_passes, merge_annotations
+
+# Context information passed to all styling passes
+struct StylingContext
+    cursor_pos::Int
+    region_start::Int
+    region_stop::Int
+end
+
+StylingContext(cursor_pos::Int) = StylingContext(cursor_pos, 0, 0)
+
+abstract type StylingPass end
+
+function merge_annotations(annotated_strings::Vector{<:AnnotatedString})
+    isempty(annotated_strings) && return AnnotatedString("")
+
+    result = AnnotatedString(annotated_strings[1])
+
+    for source in annotated_strings
+        for ann in annotations(source)
+            annotate!(result, ann.region, ann.label, ann.value)
+        end
+    end
+
+    return result
+end
+
+function apply_style(pass::StylingPass, input::String, context::StylingContext)
+    return pass(input, context)::AnnotatedString{String}
+end
+
+function apply_styling_passes(input::String, passes::Vector{StylingPass}, context::StylingContext)
+    if isempty(passes)
+        return AnnotatedString(input)
+    end
+
+    results = [apply_style(pass, input, context) for pass in passes]
+    return merge_annotations(results)
+end
+
+# Applies Julia syntax highlighting
+struct SyntaxHighlightPass <: StylingPass end
+
+function (::SyntaxHighlightPass)(input::String, ::StylingContext)
+    try
+        return JuliaSyntaxHighlighting.highlight(input)
+    catch e
+        e isa InterruptException && rethrow()
+        @error "Error in SyntaxHighlightPass" exception=(e, catch_backtrace()) maxlog=1
+        return AnnotatedString(input)
+    end
+end
+
+# Applies inverse video styling to the selected region
+struct RegionHighlightPass <: StylingPass end
+
+function (::RegionHighlightPass)(input::String, context::StylingContext)
+    result = AnnotatedString(input)
+
+    if context.region_start > 0 && context.region_stop >= context.region_start
+        # Add inverse face to the region
+        # Region positions are 1-based byte positions
+        region_range = context.region_start:context.region_stop
+        annotate!(result, region_range, :face, Face(inverse=true))
+    end
+
+    return result
+end
+
+# Applies bold styling to parentheses that enclose the cursor position
+struct EnclosingParenHighlightPass <: StylingPass
+    face::Face
+end
+
+EnclosingParenHighlightPass() = EnclosingParenHighlightPass(Face(weight=:bold, underline=true))
+
+function (pass::EnclosingParenHighlightPass)(input::String, context::StylingContext)
+    result = AnnotatedString(input)
+
+    if isempty(input) || context.cursor_pos < 1
+        return result
+    end
+
+    try
+        ast = JuliaSyntax.parseall(JuliaSyntax.GreenNode, input; ignore_errors=true)
+        paren_pairs = find_enclosing_parens(input, ast, context.cursor_pos)
+
+        for (open_pos, close_pos) in paren_pairs
+            annotate!(result, open_pos:open_pos, :face, pass.face)
+            annotate!(result, close_pos:close_pos, :face, pass.face)
+        end
+    catch e
+        e isa InterruptException && rethrow()
+        @error "Error in EnclosingParenHighlightPass" exception=(e, catch_backtrace()) maxlog=1
+    end
+
+    return result
+end
+
+function paren_type(k)
+    if     k == JuliaSyntax.K"(";  1, :paren
+    elseif k == JuliaSyntax.K")"; -1, :paren
+    elseif k == JuliaSyntax.K"[";  1, :bracket
+    elseif k == JuliaSyntax.K"]"; -1, :bracket
+    elseif k == JuliaSyntax.K"{";  1, :curly
+    elseif k == JuliaSyntax.K"}"; -1, :curly
+    else                           0, :none
+    end
+end
+
+function find_enclosing_parens(content::String, ast, cursor_pos::Int)
+    innermost_pairs = Dict{Symbol,Tuple{Int,Int}}()
+    paren_stack = Tuple{Int,Int,Symbol}[]  # (open_pos, depth, type)
+
+    walk_tree(ast, content, 0) do node, offset
+        nkind = JuliaSyntax.kind(node)
+        pos = firstindex(content) + offset
+
+        depthchange, ptype = paren_type(nkind)
+
+        if ptype != :none
+            if depthchange > 0
+                # Opening paren - push to stack
+                push!(paren_stack, (pos, length(paren_stack) + 1, ptype))
+            elseif depthchange < 0 && !isempty(paren_stack)
+                # Closing paren - pop from stack and check if cursor is inside
+                open_pos, depth, open_ptype = pop!(paren_stack)
+                if open_ptype == ptype && open_pos <= cursor_pos < pos
+                    # Cursor is inside this paren pair - keep only innermost per type
+                    # Only update if this is the first pair or if it's smaller (more inner) than existing
+                    if !haskey(innermost_pairs, ptype) || (pos - open_pos) < (innermost_pairs[ptype][2] - innermost_pairs[ptype][1])
+                        innermost_pairs[ptype] = (open_pos, pos)
+                    end
+                end
+            end
+        end
+    end
+
+    return collect(values(innermost_pairs))
+end
+
+function walk_tree(f::Function, node, content::String, offset::Int)
+    f(node, offset)
+
+    if JuliaSyntax.numchildren(node) > 0
+        for child in JuliaSyntax.children(node)
+            walk_tree(f, child, content, offset)
+            offset += JuliaSyntax.span(child)
+        end
+    end
+end
+
+end # module StylingPasses

--- a/stdlib/REPL/src/options.jl
+++ b/stdlib/REPL/src/options.jl
@@ -28,6 +28,7 @@ mutable struct Options
     # refresh after time delay
     auto_refresh_time_delay::Float64
     hint_tab_completes::Bool
+    style_input::Bool # enable syntax highlighting for input
     # default IOContext settings at the REPL
     iocontext::Dict{Symbol,Any}
 end
@@ -49,6 +50,7 @@ Options(;
         auto_indent_time_threshold = 0.005,
         auto_refresh_time_delay = 0.0, # this no longer seems beneficial
         hint_tab_completes = true,
+        style_input = true,
         iocontext = Dict{Symbol,Any}()) =
             Options(hascolor, extra_keymap, tabwidth,
                     kill_ring_max, region_animation_duration,
@@ -57,7 +59,7 @@ Options(;
                     backspace_align, backspace_adjust, confirm_exit,
                     auto_indent, auto_indent_tmp_off, auto_indent_bracketed_paste,
                     auto_indent_time_threshold, auto_refresh_time_delay,
-                    hint_tab_completes,
+                    hint_tab_completes, style_input,
                     iocontext)
 
 # for use by REPLs not having an options field


### PR DESCRIPTION
Python now ships their default REPL with syntax highlighting (https://realpython.com/python-repl-autocompletion-highlighting/#syntax-highlighting), and I find it unacceptable that the default Python REPL should be (in some cases) better than ours ( :wink: ).

It has long been possible to get syntax highlighting from the external OhMyREPL package, but now, since we have StyledStrings + JuliaSyntaxHighlighting as stdlibs, it seems kind of a waste not to use those for this. OhMyREPL also has to touch a lot of internals and there are some awkward corner cases with it so proper first-class support would avoid this.

In addition to the highlighting it also adds a little marker showing what parenthesis you are inside (analogous to https://kristofferc.github.io/OhMyREPL.jl/latest/features/bracket_highlighting/). The existing region marking is also implemented in the "pass framework" here.

By default, the JuliaSyntaxHighlighting is quite conservative:

<img width="298" height="226" alt="image" src="https://github.com/user-attachments/assets/64dbb301-17e1-4447-92ee-52906fb1fcc3" />

But with a custom `faces.toml` file (as shown in the docs) you can fancy it up to your liking:

<img width="294" height="228" alt="image" src="https://github.com/user-attachments/assets/183539be-c4da-4d5d-92d4-ab46fae812b5" />

WIP Because of tests.

Written in a beautiful symbiosis between man and machine.