### PR TITLE
fix hashing of complex values with zero imaginary part

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -33,6 +33,33 @@ end
 # metaprogramming
 include("meta.jl")
 
+# Strings
+include("multimedia.jl")
+using .Multimedia
+
+include("char.jl")
+function array_new_memory(mem::Memory{UInt8}, newlen::Int)
+    # add an optimization to array_new_memory for StringVector
+    if (@assume_effects :total @ccall jl_genericmemory_owner(mem::Any,)::Any) === mem
+        # TODO: when implemented, this should use a memory growing call
+        return typeof(mem)(undef, newlen)
+    else
+        # If data is in a String, keep it that way.
+        # When implemented, this could use jl_gc_expand_string(oldstr, newlen) as an optimization
+        str = _string_n(newlen)
+        return (@assume_effects :total !:consistent @ccall jl_string_to_genericmemory(str::Any,)::Memory{UInt8})
+    end
+end
+include("strings/basic.jl")
+include("strings/string.jl")
+include("strings/substring.jl")
+include("strings/cstring.jl")
+
+include("cartesian.jl")
+using .Cartesian
+include("hashing.jl")
+include("osutils.jl")
+
 # subarrays
 include("subarray.jl")
 include("views.jl")
@@ -60,38 +87,11 @@ include("reduce.jl")
 include("reshapedarray.jl")
 include("reinterpretarray.jl")
 
-include("multimedia.jl")
-using .Multimedia
-
 # Some type
 include("some.jl")
 
 include("dict.jl")
 include("set.jl")
-
-# Strings
-include("char.jl")
-function array_new_memory(mem::Memory{UInt8}, newlen::Int)
-    # add an optimization to array_new_memory for StringVector
-    if (@assume_effects :total @ccall jl_genericmemory_owner(mem::Any,)::Any) === mem
-        # TODO: when implemented, this should use a memory growing call
-        return typeof(mem)(undef, newlen)
-    else
-        # If data is in a String, keep it that way.
-        # When implemented, this could use jl_gc_expand_string(oldstr, newlen) as an optimization
-        str = _string_n(newlen)
-        return (@assume_effects :total !:consistent @ccall jl_string_to_genericmemory(str::Any,)::Memory{UInt8})
-    end
-end
-include("strings/basic.jl")
-include("strings/string.jl")
-include("strings/substring.jl")
-include("strings/cstring.jl")
-
-include("cartesian.jl")
-using .Cartesian
-include("hashing.jl")
-include("osutils.jl")
 
 # Core I/O
 include("io.jl")

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -249,7 +249,7 @@ isequal(z::Real, w::Complex) = isequal(z,real(w))::Bool & isequal(zero(z),imag(w
 
 in(x::Complex, r::AbstractRange{<:Real}) = isreal(x) && real(x) in r
 
-const h_imag = 0x32a7a07f3e7cd1f % UInt
+const h_imag = 0x32a7a07f3e7cd1f9 % UInt
 const hash_0_imag = 0x153e9f914f9b5b92 % UInt
 
 function hash(z::Complex, h::UInt)

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -250,7 +250,7 @@ isequal(z::Real, w::Complex) = isequal(z,real(w))::Bool & isequal(zero(z),imag(w
 in(x::Complex, r::AbstractRange{<:Real}) = isreal(x) && real(x) in r
 
 const h_imag = 0x32a7a07f3e7cd1f9 % UInt
-const hash_0_imag = 0x153e9f914f9b5b92 % UInt
+const hash_0_imag = hash(0, h_imag)
 
 function hash(z::Complex, h::UInt)
     # TODO: with default argument specialization, this would be better:

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -11,7 +11,7 @@ struct StringIndexError <: Exception
 end
 @noinline string_index_err((@nospecialize s::AbstractString), i::Integer) =
     throw(StringIndexError(s, Int(i)))
-function Base.showerror(io::IO, exc::StringIndexError)
+function showerror(io::IO, exc::StringIndexError)
     s = exc.string
     print(io, "StringIndexError: ", "invalid index [$(exc.index)]")
     if firstindex(s) <= exc.index <= ncodeunits(s)

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -37,6 +37,7 @@ for T = types[2:end], x = vals
     a = coerce(T, x)
     @test hash(a, zero(UInt)) == invoke(hash, Tuple{Real, UInt}, a, zero(UInt))
     @test hash(a, one(UInt)) == invoke(hash, Tuple{Real, UInt}, a, one(UInt))
+    @test hash(a) == hash(complex(a))
 end
 
 let collides = 0


### PR DESCRIPTION
follow up to a minor typo introduced in https://github.com/JuliaLang/julia/pull/59185 which caused `hash(0im) != hash(0)`, and adds some tests for this case