### PR TITLE
fix prefix IntrusiveLinkedList with Base in a REPL test util

### DIFF
--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -32,7 +32,7 @@ function kill_timer(delay)
         # **DON'T COPY ME.**
         # The correct way to handle timeouts is to close the handle:
         # e.g. `close(stdout_read); close(stdin_write)`
-        test_task.queue === nothing || Base.list_deletefirst!(test_task.queue::IntrusiveLinkedList{Task}, test_task)
+        test_task.queue === nothing || Base.list_deletefirst!(test_task.queue::Base.IntrusiveLinkedList{Task}, test_task)
         schedule(test_task, "hard kill repl test"; error=true)
         print(stderr, "WARNING: attempting hard kill of repl test after exceeding timeout\n")
     end


### PR DESCRIPTION
I saw this

```

From worker 6:	Error in Timer:
--
  | From worker 6:	UndefVarError: `IntrusiveLinkedList` not defined in `Main.Test36Main_REPL.REPLTests`
  | From worker 6:	Stacktrace:
  | From worker 6:	 [1] (::Main.Test36Main_REPL.REPLTests.var"#kill_test#kill_timer##0"{Task})(t::Timer)
  | From worker 6:	   @ Main.Test36Main_REPL.REPLTests /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-grannysmith-C07ZQ07RJYVY.0/build/default-grannysmith-C07ZQ07RJYVY-0/julialang/julia-master/julia-6016b0a55d/share/julia/stdlib/v1.13/REPL/test/repl.jl:35
  | From worker 6:	 [2] (::Base.var"#625#626"{Main.Test36Main_REPL.REPLTests.var"#kill_test#kill_timer##0"{Task}, Timer})()
```

in #59778. Introduced in https://github.com/JuliaLang/julia/pull/57344.

cc @gbaraldi 