### PR TITLE
Revert recent PRs causing CI failures

### DIFF
--- a/base/public.jl
+++ b/base/public.jl
@@ -2,7 +2,6 @@
 
 public
 # Modules
-    Cartesian,
     Checked,
     Filesystem,
     Order,

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -29,13 +29,6 @@
     @test parse(Int, 'a', base=16) == 10
     @test_throws ArgumentError parse(Int, 'a')
     @test_throws ArgumentError parse(Int,typemax(Char))
-
-    @test tryparse(Int, '8') === 8
-    @test tryparse(Int, 'a') === nothing
-    @test tryparse(Int, 'a'; base=11) === 10
-    @test tryparse(Int32, 'a'; base=11) === Int32(10)
-    @test tryparse(UInt8, 'f'; base=16) === 0x0f
-    @test tryparse(UInt8, 'f'; base=15) === nothing
 end
 
 # Issue 29451


### PR DESCRIPTION
Revert PRs that are causing CI failures, specifically #59603
and #59459 which are causing test failures. This bulk revert
will restore CI stability.