### PR TITLE
Fix `hasmethod` for worlds greater than the latest world

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1030,7 +1030,8 @@ parentmodule(m::Method) = m.module
     hasmethod(f, t::Type{<:Tuple}[, kwnames]; world=get_world_counter())::Bool
 
 Determine whether the given generic function has a method matching the given
-`Tuple` of argument types with the upper bound of world age given by `world`.
+`Tuple` of argument types in the world age given by `world`.  Note that this is
+always false when `world` is greater than the current latest world.
 
 If a tuple of keyword argument names `kwnames` is provided, this also checks
 whether the method of `f` matching `t` has the given keyword argument names.
@@ -1073,7 +1074,6 @@ end
 
 function hasmethod(f, t, kwnames::Tuple{Vararg{Symbol}}; world::UInt=get_world_counter())
     @nospecialize
-    world == typemax(UInt) && error("code reflection cannot be used from generated functions")
     isempty(kwnames) && return hasmethod(f, t; world)
     t = to_tuple_type(t)
     ft = Core.Typeof(f)


### PR DESCRIPTION
`hasmethod` returns false when the `world` argument specified is greater than the global latest world.  We often use `typemax(UInt)` as a token for "latest world" though; JuliaLowering uses this to check if there's a provenance-preserving macro of a given name before falling back to the Expr macro (a bit of a hack, but losing provenance with every `@nospecialize` would be unfortunate for JETLS, and we want to call our own version of `@ccall`). 

@Keno suggested throwing an error for too-large worlds other than typemax, which is implemented here.