### PR TITLE
build: Set CC and CXX in PGO+LTO build

### DIFF
--- a/contrib/pgo-lto/Makefile
+++ b/contrib/pgo-lto/Makefile
@@ -32,7 +32,13 @@ STAGE2_FLAGS:=LDFLAGS="-fuse-ld=lld -flto=thin -Wl,--undefined-version -fprofile
 			CFLAGS="-fprofile-use=$(PROFILE_FILE)" $\
 			CXXFLAGS="-fprofile-use=$(PROFILE_FILE)"
 
-COMMON_FLAGS:=USE_BINARYBUILDER_LLVM=0
+COMMON_FLAGS = $\
+	"CC=$(STAGE0_TOOLS)clang" $\
+	"CXX=$(STAGE0_TOOLS)clang++" $\
+	"LD=$(STAGE0_TOOLS)ld.lld" $\
+	"AR=$(STAGE0_TOOLS)llvm-ar" $\
+	"RANLIB=$(STAGE0_TOOLS)llvm-ranlib" $\
+	"USE_BINARYBUILDER_LLVM=0"
 
 all: stage2 # Default target as first in file
 


### PR DESCRIPTION
Broke in https://github.com/JuliaLang/julia/pull/58795, where we removed specifying `USE_CLANG=1` without setting `CC` and `CXX`. I also set `LD`, `AR` and `RANLIB` because pgo+lto+bolt build does (presumably useful).
