### PR TITLE
[Test] Allow passing `time_start` as a keyword argument to `DefaultTestSet`

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1235,7 +1235,14 @@ mutable struct DefaultTestSet <: AbstractTestSet
     results_lock::ReentrantLock
     results::Vector{Any}
 end
-function DefaultTestSet(desc::AbstractString; verbose::Bool = something(Base.ScopedValues.get(VERBOSE_TESTSETS)), showtiming::Bool = true, failfast::Union{Nothing,Bool} = nothing, source = nothing, rng = nothing)
+function DefaultTestSet(desc::AbstractString;
+                        verbose::Bool = something(Base.ScopedValues.get(VERBOSE_TESTSETS)),
+                        showtiming::Bool = true,
+                        failfast::Union{Nothing,Bool} = nothing,
+                        source = nothing,
+                        time_start::Float64 = time(),
+                        rng = nothing,
+                        )
     if isnothing(failfast)
         # pass failfast state into child testsets
         parent_ts = get_testset()
@@ -1247,7 +1254,7 @@ function DefaultTestSet(desc::AbstractString; verbose::Bool = something(Base.Sco
     end
     return DefaultTestSet(String(desc)::String,
         verbose, showtiming, failfast, extract_file(source),
-        time(), rng, 0, 0., 0x00, ReentrantLock(), Any[])
+        time_start, rng, 0, 0., 0x00, ReentrantLock(), Any[])
 end
 extract_file(source::LineNumberNode) = extract_file(source.file)
 extract_file(file::Symbol) = string(file)

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -2020,7 +2020,7 @@ end
     io = IOBuffer()
 
     # Create a testset with passing and failing tests
-    ts = Test.DefaultTestSet("IO Test")
+    ts = Test.DefaultTestSet("IO Test"; time_start=1.36071654e9)
     Test.record(ts, Test.Pass(:test, nothing, nothing, nothing, LineNumberNode(1), false))
     fail = Test.Fail(:test, "1 == 2", nothing, nothing, LineNumberNode(2, Symbol("test.jl")))
     push!(ts.results, fail)


### PR DESCRIPTION
#59374 made `time_start` a `const` but now there's no way to instantiate a `DefaultTestSet` with a custom `time_start` without passing also ***all*** other fields.