### PR TITLE
Fix associativity inconsistencies of "->", "where" and ":"

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1604,11 +1604,11 @@ julia> Base.operator_associativity(:⊗), Base.operator_associativity(:sin), Bas
 For binary operators `⊙` and `⊡` of identical operator precedence parsing depends on their
 associativity as follows:
 
-| Associativity | Parsing behavior                          |
-|:-------------:|:-----------------------------------------:|
-| `:left`       | `(x ⊙ y) ⊡ z == x ⊙ y ⊡ z != x ⊙ (y ⊡ z)` |
-| `:none`       | `(x ⊙ y) ⊡ z != x ⊙ y ⊡ z != x ⊙ (y ⊡ z)` |
-| `:right`      | `(x ⊙ y) ⊡ z != x ⊙ y ⊡ z == x ⊙ (y ⊡ z)` |
+| Associativity | `x ⊙ y ⊡ z` is parsed as |
+|:-------------:|:------------------------:|
+| `:left`       | `(x ⊙ y) ⊡ z`            |
+| `:none`       | `x ⊙ y ⊡ z`              |
+| `:right`      | `x ⊙ (y ⊡ z)`            |
 
 `⊙` and `⊡` can be the same operator. A difference in parsing behavior does not imply a
 different result of the expression.

--- a/base/show.jl
+++ b/base/show.jl
@@ -1615,7 +1615,7 @@ different result of the expression.
 """
 function operator_associativity(s::Symbol)
     if operator_precedence(s) in (prec_arrow, prec_assignment, prec_control_flow, prec_pair, prec_power) ||
-        (isunaryoperator(s) && !is_unary_and_binary_operator(s)) || s in (:<|, :||, :?, :->, :🢲)
+        (isunaryoperator(s) && !is_unary_and_binary_operator(s)) || s in (:<|, :||, :?, :->)
         return :right
     elseif operator_precedence(s) in (0, prec_comparison) && s != :where || s in (:+, :++, :*, :(:))
         return :none

--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -423,6 +423,9 @@ Julia applies the following order and associativity of operations, from highest 
     The operators `+`, `++` and `*` are non-associative. `a + b + c` is parsed as `+(a, b, c)` not `+(+(a, b),
     c)`. However, the fallback methods for `+(a, b, c, d...)` and `*(a, b, c, d...)` both default to left-associative evaluation.
 
+Parsing is primarily determined by operator precedence. For operators with identical
+operator precedence parsing depends on their associativity.
+
 For a complete list of *every* Julia operator's precedence, see the top of this file:
 [`src/julia-parser.scm`](https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm). Note that some of the operators there are not defined
 in the `Base` module but may be given definitions by standard libraries, packages or user code.

--- a/test/show.jl
+++ b/test/show.jl
@@ -308,7 +308,8 @@ kind_sym(x) = Symbol(Base.JuliaSyntax._kind_int_to_str[x])
 iscolonoperator(op) = kind_int(":") < kind_int(op) <= kind_int("END_COLON")
 isconditionaloperator(op) = kind_int("BEGIN_CONDITIONAL") <= kind_int(op) <= kind_int("END_CONDITIONAL")
 iswordoperator(op) = op |> string |> Base.JuliaSyntax.Kind |> Base.JuliaSyntax.is_word_operator
-isclosedbinaryoperator(op) = !isunaryoperator(op) && !iscolonoperator(op) && !isconditionaloperator(op) && string(op) ∉ ("op=", "'", ".'")
+isclosedbinaryoperator(op) = !Base.isunaryoperator(op) && !iscolonoperator(op) &&
+                             !isconditionaloperator(op) && string(op) ∉ ("op=", "'", ".'")
 space(op) = iswordoperator(op) || op == :🢲 ? Symbol(" $op ") : op
 
 function test_associativity(op)

--- a/test/show.jl
+++ b/test/show.jl
@@ -300,6 +300,36 @@ let ex4 = Expr(:call, :(:), 1, 2, 3, 4),
     @test eval(Meta.parse(repr(ex1))) == ex1
 end
 
+
+# Test associativity of operators
+kind_int(x) = Base.JuliaSyntax._kind_str_to_int[string(x)]
+kind_sym(x) = Symbol(Base.JuliaSyntax._kind_int_to_str[x])
+# Omit :. because it is parsed differently and does not need to be excluded from testing
+iscolonoperator(op) = kind_int(":") < kind_int(op) <= kind_int("END_COLON")
+isconditionaloperator(op) = kind_int("BEGIN_CONDITIONAL") <= kind_int(op) <= kind_int("END_CONDITIONAL")
+iswordoperator(op) = op |> string |> Base.JuliaSyntax.Kind |> Base.JuliaSyntax.is_word_operator
+isclosedbinaryoperator(op) = !isunaryoperator(op) && !iscolonoperator(op) && !isconditionaloperator(op) && string(op) ∉ ("op=", "'", ".'")
+space(op) = iswordoperator(op) || op == :🢲 ? Symbol(" $op ") : op
+
+function test_associativity(op)
+    assoc = Base.operator_associativity(op)
+    # :. does not allow space around the operator, but some operators need it.
+    # Therefore, add space here for those needing it and omit it the line after.
+    op = space(op)
+    left, none, right = ("(x$(op)y)$(op)z", "x$(op)y$(op)z", "x$(op)(y$(op)z)") .|> Meta.parse
+
+    assoc == :left  && @test left == none != right
+    assoc == :none  && @test left != none != right
+    assoc == :right && @test left != none == right
+end
+
+@testset "associativity" begin
+    ops = (kind_sym(i) for i in kind_int("BEGIN_ASSIGNMENTS") : kind_int("END_OPS"))
+    [test_associativity(op) for op in ops if isclosedbinaryoperator(op)]
+    return nothing
+end
+
+
 # Complex
 
 # Meta.parse(repr(:(...))) returns a double-quoted block, so we need to eval twice to unquote it


### PR DESCRIPTION
This is one of the PRs where you start with a simple finding and then you go down the rabbit hole:
- The relationship between operator precedence and associativity does not seem to be documented anywhere. So document it in
  - `operator_associativity`'s docstring
  - `operator_precedence`'s docstring
  - documentation of mathematical operations
- link to each other in the docstrings
- the associativity is not defined, so document it in `operator_associativity`'s extended help.
- test for (nearly) all operators that the used associativity in the parser matches what `Base.operator_associativity` returns
- find that we have indeed not 1, but 3 deviations
- assume that the parser is correct and change `Base.operator_associativity` to fix the inconsistencies

Please focus the review especially on these points:
- check whether `Base.operator_associativity` was wrong or whether this really needs to be fixed withing `JuliaSyntax.jl`.
- check whether the assumed relationship between precedence and associativity is correct.
- check whether the definition of associativity is correct

Probably for the future:
- This PR should probably be backported.
- Currently we only test each operator with itself for correct associativity. In general all operators in the same precedence level should be tested with each other (in both orders). As a heuristic they could all be tested with the first and last operator of the same precedence level of a certain associativity.
- Check whether this logic should really be part of `Base` itself. It feels like poor encapsulation to do so. If this does not lead to bootstrapping problems, I think the logic should be moved to `JuliaSyntax.jl`. `Base` should only have forwarding functions `operator_associativity` and `operator_precedence` to the correspondingly named `JuliaSyntax.jl` functions.