### PR TITLE
Introduce `Iterators.called(f[, n])`

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1116,7 +1116,7 @@ called(f, n::Integer) = take(called(f), Int(n))
 
 IteratorSize(::Type{<:Called}) = IsInfinite()
 
-iterate(it::Called{T, F}, state...) where {T, F} = (it.f()::T, nothing)
+iterate(it::Called{F}, state...) where {F} = (it.f(), nothing)
 
 reverse(it::Union{Called, Take{<:Called}}) = it
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -32,7 +32,7 @@ import Base:
     getindex, setindex!, get, iterate,
     popfirst!, isdone, peek, intersect
 
-export enumerate, zip, rest, countfrom, take, drop, takewhile, dropwhile, cycle, repeated, product, flatten, flatmap, partition, nth, findeach
+export enumerate, zip, rest, countfrom, take, drop, takewhile, dropwhile, cycle, repeated, called, product, flatten, flatmap, partition, nth, findeach
 public accumulate, filter, map, peel, reverse, Stateful
 
 """
@@ -1076,6 +1076,52 @@ IteratorEltype(::Type{<:Repeated}) = HasEltype()
 
 reverse(it::Union{Repeated,Take{<:Repeated}}) = it
 last(it::Union{Repeated,Take{<:Repeated}}) = first(it)
+
+struct Called{F}
+    f::F
+
+    Called(f::F) where {F} = new{F}(f)
+end
+
+called(f) = Called(f)
+
+"""
+    called(f[, n::Int])
+
+An iterator that calles the function `f` forever. If `n` is specified, `f()`
+is called that many times (equivalent to `take(called(f), n)`).
+
+!!! compat "Julia 1.13"
+    The method `called(f, n)` was added in Julia 1.13.
+
+# Examples
+```jldoctest
+julia> a = Iterators.called(() -> Dict{UInt, UInt}(), 4);
+
+julia> a_collected = collect(a)
+4-element Vector{Dict{UInt64, UInt64}}:
+ Dict()
+ Dict()
+ Dict()
+ Dict()
+
+julia> a_collected == fill(Dict{UInt, UInt}(), 4)
+true
+
+julia> a_collected[1] === a_collected[2]
+false
+```
+"""
+called(f, n::Integer) = take(called(f), Int(n))
+
+IteratorSize(::Type{<:Called}) = IsInfinite()
+
+iterate(it::Called{T, F}, state...) where {T, F} = (it.f()::T, nothing)
+
+reverse(it::Union{Called, Take{<:Called}}) = it
+
+last(it::Union{Called, Take{<:Called}}) = first(it)
+
 
 # Product -- cartesian product of iterators
 struct ProductIterator{T<:Tuple}

--- a/doc/src/base/iterators.md
+++ b/doc/src/base/iterators.md
@@ -13,6 +13,7 @@ Base.Iterators.dropwhile
 Base.Iterators.findeach
 Base.Iterators.cycle
 Base.Iterators.repeated
+Base.Iterators.called
 Base.Iterators.product
 Base.Iterators.flatten
 Base.Iterators.flatmap

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -306,8 +306,12 @@ let i = 0
         i <= 10 || break
     end
 end
+@test (@inferred eltype(repeated(0)))    == Int
+@test (@inferred eltype(repeated(0, 5))) == Int
 @test (@inferred Base.IteratorSize(repeated(0)))      == Base.IsInfinite()
 @test (@inferred Base.IteratorSize(repeated(0, 5)))   == Base.HasLength()
+@test (@inferred Base.IteratorEltype(repeated(0)))    == Base.HasEltype()
+@test (@inferred Base.IteratorEltype(repeated(0, 5))) == Base.HasEltype()
 @test (@inferred Base.IteratorSize(zip(repeated(0), repeated(0)))) == Base.IsInfinite()
 
 # called
@@ -326,12 +330,8 @@ let i = 0
         i <= 10 || break
     end
 end
-@test (@inferred eltype(called(Returns(1))))    == Int
-@test (@inferred eltype(called(() -> Dict{Any, Any}(), 5))) == Dict{Any, Any}
 @test (@inferred Base.IteratorSize(called(Returns(1))))      == Base.IsInfinite()
 @test (@inferred Base.IteratorSize(called(Returns(1), 5)))   == Base.HasLength()
-@test (@inferred Base.IteratorEltype(called(Returns(1))))    == Base.HasEltype()
-@test (@inferred Base.IteratorEltype(called(Returns(1), 5))) == Base.HasEltype()
 @test (@inferred Base.IteratorSize(zip(called(Returns(1)), called(Returns(1))))) == Base.IsInfinite()
 
 # product

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -306,13 +306,33 @@ let i = 0
         i <= 10 || break
     end
 end
-@test (@inferred eltype(repeated(0)))    == Int
-@test (@inferred eltype(repeated(0, 5))) == Int
 @test (@inferred Base.IteratorSize(repeated(0)))      == Base.IsInfinite()
 @test (@inferred Base.IteratorSize(repeated(0, 5)))   == Base.HasLength()
-@test (@inferred Base.IteratorEltype(repeated(0)))    == Base.HasEltype()
-@test (@inferred Base.IteratorEltype(repeated(0, 5))) == Base.HasEltype()
 @test (@inferred Base.IteratorSize(zip(repeated(0), repeated(0)))) == Base.IsInfinite()
+
+# called
+# ------
+let i = 0
+    for j = called(Returns(1), 10)
+        @test j == 1
+        i += 1
+    end
+    @test i == 10
+end
+let i = 0
+    for j = called(Returns(1))
+        @test j == 1
+        i += 1
+        i <= 10 || break
+    end
+end
+@test (@inferred eltype(called(Returns(1))))    == Int
+@test (@inferred eltype(called(() -> Dict{Any, Any}(), 5))) == Dict{Any, Any}
+@test (@inferred Base.IteratorSize(called(Returns(1))))      == Base.IsInfinite()
+@test (@inferred Base.IteratorSize(called(Returns(1), 5)))   == Base.HasLength()
+@test (@inferred Base.IteratorEltype(called(Returns(1))))    == Base.HasEltype()
+@test (@inferred Base.IteratorEltype(called(Returns(1), 5))) == Base.HasEltype()
+@test (@inferred Base.IteratorSize(zip(called(Returns(1)), called(Returns(1))))) == Base.IsInfinite()
 
 # product
 # -------


### PR DESCRIPTION
This introduces `Iterators.called(f[, n])`, which produces an iterator that infinitely calls `f()` or an iterator that calls it `n` times. Although this behavior may be similar to `Iterators.repeated(f(), n)` in many cases, it facalitates instances where `f()` produces a unique value each time it is called. For example, if `f()::Dict` then collecting on `Iterators.repeated(f(), n)` may produce unexpected results for users when modifying one of it's items mutates all of it's items.

There may be some more work that could be done here with regards to `eltype`, since construction through type calls is a common method of creating a new instance. However, I assume more discussion around improving generic storage of types in fields (such as https://github.com/JuliaLang/julia/issues/59774) should come before approaching that.