### PR TITLE
replaced Typo by with be & correct World age link

### DIFF
--- a/doc/src/devdocs/types.md
+++ b/doc/src/devdocs/types.md
@@ -526,5 +526,5 @@ considered more specific. However, `morespecific` does get a bonus for length: i
 `Tuple{Int,Int}` is more specific than `Tuple{Int,Vararg{Int}}`.
 
 Additionally, if 2 methods are defined with identical signatures, per type-equal, then they
-will instead by compared by order of addition, such that the later method is more specific
+will instead be compared by order of addition, such that the later method is more specific
 than the earlier one.

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -582,7 +582,7 @@ However, future calls to `tryeval` will continue to see the definition of `newfu
 
 You may want to try this for yourself to see how it works.
 
-The implementation of this behavior is a "world age counter", which is further described in the [Worldage](@ref man-worldage)
+The implementation of this behavior is a "world age counter", which is further described in the [World Age](@ref man-world-age)
 manual chapter.
 
 ## Design Patterns with Parametric Methods

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -582,7 +582,7 @@ However, future calls to `tryeval` will continue to see the definition of `newfu
 
 You may want to try this for yourself to see how it works.
 
-The implementation of this behavior is a "world age counter", which is further described in the [World Age](@ref man-world-age)
+The implementation of this behavior is a "world age counter", which is further described in the [World Age](@ref World-age-in-general)
 manual chapter.
 
 ## Design Patterns with Parametric Methods


### PR DESCRIPTION
1. There was a typo in the last section. https://github.com/JuliaLang/julia/blob/master/doc/src/devdocs/types.md#subtyping-and-method-sorting

>Additionally, if 2 methods are defined with identical signatures, per type-equal, then they will instead *by compared by order of addition, such that the later method is more specific than the earlier one.

2. Also correct the World age link in the last line of [Redefining Methods](https://docs.julialang.org/en/v1/manual/methods/#Redefining-Methods) .

>The implementation of this behavior is a "world age counter", which is further described in the [Worldage](https://docs.julialang.org/en/v1/base/math/#Base.:--Tuple{Any,%20Any}) manual chapter.