### PR TITLE
The Fanciest REPL History in the Land

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -99,6 +99,7 @@ Standard library changes
 * The Julia REPL now support bracketed paste on Windows which should significantly speed up pasting large code blocks into the REPL ([#59825])
 * The REPL now provides syntax highlighting for input as you type. See the REPL docs for more info about customization.
 * The REPL now supports automatic insertion of closing brackets, parentheses, and quotes. See the REPL docs for more info about customization.
+* History searching has been rewritten to use a new interactive modal dialogue, using a fzf-like style.
 * The display of `AbstractChar`s in the main REPL mode now includes LaTeX input information like what is shown in help mode ([#58181]).
 * Display of repeated frames and cycles in stack traces has been improved by bracketing them in the trace and treating them consistently ([#55841]).
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -649,17 +649,17 @@ replace_err(repl) = error("Bad replacement string: $repl")
 function _write_capture(io::IO, group::Int, str, r, re::RegexAndMatchData)
     len = PCRE.substring_length_bynumber(re.match_data, group)
     # in the case of an optional group that doesn't match, len == 0
-    len == 0 && return
+    len == 0 && return len
     ensureroom(io, len+1)
     PCRE.substring_copy_bynumber(re.match_data, group,
         pointer(io.data, io.ptr), len+1)
     io.ptr += len
     io.size = max(io.size, io.ptr - 1)
-    nothing
+    return len
 end
 function _write_capture(io::IO, group::Int, str, r, re)
     group == 0 || replace_err("pattern is not a Regex")
-    return print(io, SubString(str, r))
+    return write(io, SubString(str, r))
 end
 
 
@@ -673,12 +673,13 @@ function _replace(io, repl_s::SubstitutionString, str, r, re)
     repl = unescape_string(repl_s.string, KEEP_ESC)
     i = firstindex(repl)
     e = lastindex(repl)
+    nb = 0
     while i <= e
         if repl[i] == SUB_CHAR
             next_i = nextind(repl, i)
             next_i > e && replace_err(repl)
             if repl[next_i] == SUB_CHAR
-                write(io, SUB_CHAR)
+                nb += write(io, SUB_CHAR)
                 i = nextind(repl, next_i)
             elseif isdigit(repl[next_i])
                 group = parse(Int, repl[next_i])
@@ -691,7 +692,7 @@ function _replace(io, repl_s::SubstitutionString, str, r, re)
                         break
                     end
                 end
-                _write_capture(io, group, str, r, re)
+                nb += _write_capture(io, group, str, r, re)
             elseif repl[next_i] == GROUP_CHAR
                 i = nextind(repl, next_i)
                 if i > e || repl[i] != LBRACKET
@@ -713,16 +714,17 @@ function _replace(io, repl_s::SubstitutionString, str, r, re)
                 else
                     group = -1
                 end
-                _write_capture(io, group, str, r, re)
+                nb += _write_capture(io, group, str, r, re)
                 i = nextind(repl, i)
             else
                 replace_err(repl)
             end
         else
-            write(io, repl[i])
+            nb += write(io, repl[i])
             i = nextind(repl, i)
         end
     end
+    nb
 end
 
 struct RegexMatchIterator{S <: AbstractString}

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -639,6 +639,7 @@ julia> uppercase("Julia")
 """
 uppercase(s::AbstractString) = map(uppercase, s)
 uppercase(s::AnnotatedString) = annotated_chartransform(uppercase, s)
+uppercase(s::SubString{<:AnnotatedString}) = uppercase(AnnotatedString(s))
 
 """
     lowercase(s::AbstractString)
@@ -655,6 +656,7 @@ julia> lowercase("STRINGS AND THINGS")
 """
 lowercase(s::AbstractString) = map(lowercase, s)
 lowercase(s::AnnotatedString) = annotated_chartransform(lowercase, s)
+lowercase(s::SubString{<:AnnotatedString}) = lowercase(AnnotatedString(s))
 
 """
     titlecase(s::AbstractString; [wordsep::Function], strict::Bool=true)::String
@@ -720,6 +722,9 @@ function titlecase(s::AnnotatedString; wordsep::Function = !isletter, strict::Bo
     end
 end
 
+titlecase(s::SubString{<:AnnotatedString}; wordsep::Function = !isletter, strict::Bool=true) =
+    titlecase(AnnotatedString(s); wordsep=wordsep, strict=strict)
+
 """
     uppercasefirst(s::AbstractString)::String
 
@@ -754,6 +759,7 @@ function uppercasefirst(s::AnnotatedString)
         end
     end
 end
+uppercasefirst(s::SubString{<:AnnotatedString}) = uppercasefirst(AnnotatedString(s))
 
 """
     lowercasefirst(s::AbstractString)
@@ -787,6 +793,7 @@ function lowercasefirst(s::AnnotatedString)
         end
     end
 end
+lowercasefirst(s::SubString{<:AnnotatedString}) = lowercasefirst(AnnotatedString(s))
 
 ############################################################################
 # iterators for grapheme segmentation

--- a/stdlib/Manifest.toml
+++ b/stdlib/Manifest.toml
@@ -195,7 +195,7 @@ uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 version = "1.11.0"
 
 [[deps.REPL]]
-deps = ["FileWatching", "InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+deps = ["Dates", "FileWatching", "InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 version = "1.11.0"
 

--- a/stdlib/REPL/Project.toml
+++ b/stdlib/REPL/Project.toml
@@ -3,6 +3,7 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 version = "1.11.0"
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JuliaSyntaxHighlighting = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -205,83 +205,92 @@ at the beginning of the line. The prompt for this mode is `pkg>`. It supports it
 entered by pressing `?` at the beginning  of the line of the `pkg>` prompt. The Package manager mode is
 documented in the Pkg manual, available at [https://julialang.github.io/Pkg.jl/v1/](https://julialang.github.io/Pkg.jl/v1/).
 
-### Search modes
+### History searching
 
 In all of the above modes, the executed lines get saved to a history file, which can be searched.
- To initiate an incremental search through the previous history, type `^R` -- the control key
-together with the `r` key. The prompt will change to ```(reverse-i-search)`':```, and as you
-type the search query will appear in the quotes. The most recent result that matches the query
-will dynamically update to the right of the colon as more is typed. To find an older result using
-the same query, simply type `^R` again.
+ To initiate an interactive search through the previous history, type `^R` -- the control key
+together with the `r` key.
 
-Just as `^R` is a reverse search, `^S` is a forward search, with the prompt ```(i-search)`':```.
- The two may be used in conjunction with each other to move through the previous or next matching
-results, respectively.
+You will be presented with an interactive history viewer. As you type your search history will be filtered;
+pressing enter will insert the selected history entry into the REPL. Detailed help for the history
+searcher is available within the REPL with the special queries `?`  and `??`.
 
 All executed commands in the Julia REPL are logged into `~/.julia/logs/repl_history.jl` along with a timestamp of when it was executed
-and the current REPL mode you were in. Search mode queries this log file in order to find the commands which you previously ran.
-This can be disabled at startup by passing the `--history-file=no` flag to Julia.
+and the current REPL mode you were in. The history searcher reads this log file in order to find the commands which you previously ran.
+Multiple REPLs can write to this file at once, and every time you begin a search the newest history is fetched.
+Use of this file can be disabled at startup by passing the `--history-file=no` flag to Julia.
 
 ## Key bindings
 
 The Julia REPL makes great use of key bindings. Several control-key bindings were already introduced
-above (`^D` to exit, `^R` and `^S` for searching), but there are many more. In addition to the
+above (`^D` to exit, `^R` for searching), but there are many more. In addition to the
 control-key, there are also meta-key bindings. These vary more by platform, but most terminals
 default to using alt- or option- held down with a key to send the meta-key (or can be configured
 to do so), or pressing Esc and then the key.
 
-| Keybinding          | Description                                                                                                |
-|:------------------- |:---------------------------------------------------------------------------------------------------------- |
-| **Program control** |                                                                                                            |
-| `^D`                | Exit (when buffer is empty)                                                                                |
-| `^C`                | Interrupt or cancel                                                                                        |
-| `^L`                | Clear console screen                                                                                       |
-| Return/Enter, `^J`  | New line, executing if it is complete                                                                      |
-| meta-Return/Enter   | Insert new line without executing it                                                                       |
-| `?` or `;`          | Enter help or shell mode (when at start of a line)                                                         |
-| `^R`, `^S`          | Incremental history search, described above                                                                |
-| **Cursor movement** |                                                                                                            |
-| Right arrow, `^F`   | Move right one character                                                                                   |
-| Left arrow, `^B`    | Move left one character                                                                                    |
-| ctrl-Right, `meta-F`| Move right one word                                                                                        |
-| ctrl-Left, `meta-B` | Move left one word                                                                                         |
-| Home, `^A`          | Move to beginning of line                                                                                  |
-| End, `^E`           | Move to end of line                                                                                        |
-| Up arrow, `^P`      | Move up one line (or change to the previous history entry that matches the text before the cursor)         |
-| Down arrow, `^N`    | Move down one line (or change to the next history entry that matches the text before the cursor)           |
-| Shift-Arrow Key     | Move cursor according to the direction of the Arrow key, while activating the region ("shift selection")   |
-| Page-up, `meta-P`   | Change to the previous history entry                                                                       |
-| Page-down, `meta-N` | Change to the next history entry                                                                           |
-| `meta-<`            | Change to the first history entry (of the current session if it is before the current position in history) |
-| `meta->`            | Change to the last history entry                                                                           |
-| `^-Space`           | Set the "mark" in the editing region (and de-activate the region if it's active)                           |
-| `^-Space ^-Space`   | Set the "mark" in the editing region and make the region "active", i.e. highlighted                        |
-| `^G`                | De-activate the region (i.e. make it not highlighted)                                                      |
-| `^X^X`              | Exchange the current position with the mark                                                                |
-| **Editing**         |                                                                                                            |
-| Backspace, `^H`     | Delete the previous character, or the whole region when it's active                                        |
-| Delete, `^D`        | Forward delete one character (when buffer has text)                                                        |
-| meta-Backspace      | Delete the previous word                                                                                   |
-| `meta-d`            | Forward delete the next word                                                                               |
-| `^W`                | Delete previous text up to the nearest whitespace                                                          |
-| `meta-w`            | Copy the current region in the kill ring                                                                   |
-| `meta-W`            | "Kill" the current region, placing the text in the kill ring                                               |
-| `^U`                | "Kill" to beginning of line, placing the text in the kill ring                                             |
-| `^K`                | "Kill" to end of line, placing the text in the kill ring                                                   |
-| `^Y`                | "Yank" insert the text from the kill ring                                                                  |
-| `meta-y`            | Replace a previously yanked text with an older entry from the kill ring                                    |
-| `^T`                | Transpose the characters about the cursor                                                                  |
-| `meta-Up arrow`     | Transpose current line with line above                                                                     |
-| `meta-Down arrow`   | Transpose current line with line below                                                                     |
-| `meta-u`            | Change the next word to uppercase                                                                          |
-| `meta-c`            | Change the next word to titlecase                                                                          |
-| `meta-l`            | Change the next word to lowercase                                                                          |
-| `^/`, `^_`          | Undo previous editing action                                                                               |
-| `^Q`                | Write a number in REPL and press `^Q` to open editor at corresponding stackframe or method                 |
-| `meta-Left Arrow`   | Indent the current line on the left                                                                        |
-| `meta-Right Arrow`  | Indent the current line on the right                                                                       |
-| `meta-.`            | Insert last word from previous history entry                                                               |
-| `meta-e`            | Edit the current input in an editor                                                                        |
+| Keybinding            | Description                                                                                                |
+|:----------------------|:-----------------------------------------------------------------------------------------------------------|
+| **Program control**   |                                                                                                            |
+| `^D`                  | Exit (when buffer is empty)                                                                                |
+| `^C`                  | Interrupt or cancel                                                                                        |
+| `^L`                  | Clear console screen                                                                                       |
+| Return/Enter, `^J`    | New line, executing if it is complete                                                                      |
+| meta-Return/Enter     | Insert new line without executing it                                                                       |
+| `?` or `;`            | Enter help or shell mode (when at start of a line)                                                         |
+| `^R`, `^S`            | Interactive history search, described above                                                                |
+| **Cursor movement**   |                                                                                                            |
+| Right arrow, `^F`     | Move right one character                                                                                   |
+| Left arrow, `^B`      | Move left one character                                                                                    |
+| ctrl-Right, `meta-F`  | Move right one word                                                                                        |
+| ctrl-Left, `meta-B`   | Move left one word                                                                                         |
+| Home, `^A`            | Move to beginning of line                                                                                  |
+| End, `^E`             | Move to end of line                                                                                        |
+| Up arrow, `^P`        | Move up one line (or change to the previous history entry that matches the text before the cursor)         |
+| Down arrow, `^N`      | Move down one line (or change to the next history entry that matches the text before the cursor)           |
+| Shift-Arrow Key       | Move cursor according to the direction of the Arrow key, while activating the region ("shift selection")   |
+| Page-up, `meta-P`     | Change to the previous history entry                                                                       |
+| Page-down, `meta-N`   | Change to the next history entry                                                                           |
+| `meta-<`              | Change to the first history entry (of the current session if it is before the current position in history) |
+| `meta->`              | Change to the last history entry                                                                           |
+| `^-Space`             | Set the "mark" in the editing region (and de-activate the region if it's active)                           |
+| `^-Space ^-Space`     | Set the "mark" in the editing region and make the region "active", i.e. highlighted                        |
+| `^G`                  | De-activate the region (i.e. make it not highlighted)                                                      |
+| `^X^X`                | Exchange the current position with the mark                                                                |
+| **Editing**           |                                                                                                            |
+| Backspace, `^H`       | Delete the previous character, or the whole region when it's active                                        |
+| Delete, `^D`          | Forward delete one character (when buffer has text)                                                        |
+| meta-Backspace        | Delete the previous word                                                                                   |
+| `meta-d`              | Forward delete the next word                                                                               |
+| `^W`                  | Delete previous text up to the nearest whitespace                                                          |
+| `meta-w`              | Copy the current region in the kill ring                                                                   |
+| `meta-W`              | "Kill" the current region, placing the text in the kill ring                                               |
+| `^U`                  | "Kill" to beginning of line, placing the text in the kill ring                                             |
+| `^K`                  | "Kill" to end of line, placing the text in the kill ring                                                   |
+| `^Y`                  | "Yank" insert the text from the kill ring                                                                  |
+| `meta-y`              | Replace a previously yanked text with an older entry from the kill ring                                    |
+| `^T`                  | Transpose the characters about the cursor                                                                  |
+| `meta-Up arrow`       | Transpose current line with line above                                                                     |
+| `meta-Down arrow`     | Transpose current line with line below                                                                     |
+| `meta-u`              | Change the next word to uppercase                                                                          |
+| `meta-c`              | Change the next word to titlecase                                                                          |
+| `meta-l`              | Change the next word to lowercase                                                                          |
+| `^/`, `^_`            | Undo previous editing action                                                                               |
+| `^Q`                  | Write a number in REPL and press `^Q` to open editor at corresponding stackframe or method                 |
+| `meta-Left Arrow`     | Indent the current line on the left                                                                        |
+| `meta-Right Arrow`    | Indent the current line on the right                                                                       |
+| `meta-.`              | Insert last word from previous history entry                                                               |
+| `meta-e`              | Edit the current input in an editor                                                                        |
+| **History search**    |                                                                                                            |
+| Up arrow, `^P`, `^K`  | Move the focus one entry up                                                                                |
+| Down arrow, `^P`, `^N`| Move the focus one entry down                                                                              |
+| Page up, `^B`         | Move the focus one page up                                                                                 |
+| Page down, `^F`       | Move the focus one page down                                                                               |
+| `meta-<`              | Focus on the first (oldest) history entry                                                                  |
+| `meta->`              | Focus on the last (most recent) history entry                                                              |
+| Tab                   | Toggle selection of the currently focused entry                                                            |
+| Enter                 | Accept the currently focused/selected entries                                                              |
+| `^S`                  | Save the focused/selected entries to the clipboard or a file                                               |
+| `^C`, `^D`, `^G`      | Abort the history search                                                                                   |
 
 ### Customizing keybindings
 
@@ -731,6 +740,21 @@ inherit = "julia_rainbow_curly_2"
 </details>
 
 For a complete list of customizable faces, see the [JuliaSyntaxHighlighting package documentation](https://julialang.github.io/JuliaSyntaxHighlighting.jl/dev/).
+
+## Customising the history searcher
+
+The history searcher uses the following default faces, that can be customised:
+
+```toml
+[REPL.History.search]
+separator.fg  = "blue"
+prefix.fg = "magenta"
+selected.fg = "blue"
+unselected.fg = "grey"
+hint = { fg = "magenta", slant = "italic", weight ="light" }
+results.inherit = "shadow"
+match = { weight = "bold", underline = true }
+```
 
 ## Customizing Colors
 

--- a/stdlib/REPL/src/History/History.jl
+++ b/stdlib/REPL/src/History/History.jl
@@ -1,0 +1,34 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module History
+
+using ..REPL: REPL
+
+using StyledStrings: @styled_str as @S_str, Face, addface!, face!, annotations, AnnotatedIOBuffer, AnnotatedString, AnnotatedChar
+using JuliaSyntaxHighlighting: highlight
+using Base.Threads
+using Dates
+using InteractiveUtils: clipboard
+
+export HistoryFile, HistEntry, update!, runsearch
+
+const FACES = (
+    :REPL_History_search_separator   => Face(foreground=:blue),
+    :REPL_History_search_prefix      => Face(foreground=:magenta),
+    :REPL_History_search_selected    => Face(foreground=:blue),
+    :REPL_History_search_unselected  => Face(foreground=:grey),
+    # :REPL_History_search_preview_box => Face(foreground=:grey),
+    :REPL_History_search_hint        => Face(foreground=:magenta, slant=:italic, weight=:light),
+    :REPL_History_search_results     => Face(inherit=:shadow),
+    :REPL_History_search_match       => Face(weight = :bold, underline = true),
+)
+
+include("histfile.jl")
+include("resumablefiltering.jl")
+include("prompt.jl")
+include("display.jl")
+include("search.jl")
+
+__init__() = foreach(addface!, FACES)
+
+end

--- a/stdlib/REPL/src/History/display.jl
+++ b/stdlib/REPL/src/History/display.jl
@@ -1,0 +1,801 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+struct SelectorState
+    area::@NamedTuple{height::Int, width::Int}
+    query::String
+    filter::FilterSpec
+    candidates::Vector{HistEntry}
+    scroll::Int
+    selection::@NamedTuple{active::Vector{Int}, gathered::Vector{HistEntry}}
+    hover::Int
+end
+
+SelectorState((height, width), query::String, filter::FilterSpec, candidates::Vector{HistEntry} = HistEntry[], gathered::Vector{HistEntry} = HistEntry[]) =
+    SelectorState((height, width), query, filter, candidates, -length(gathered), (; active = Int[], gathered), 1)
+
+const EMPTY_STATE = SelectorState((0, 0), "", FilterSpec(), [], 0, (active = Int[], gathered = HistEntry[]), 0)
+
+STATES = Pair{SelectorState, SelectorState}[]
+
+const LABELS = (
+    gatherdivider = S"{italic:carried over}",
+    preview_suggestion = S"Ctrl+S to save",
+    help_prompt = S"{REPL_History_search_hint,shadow:try {REPL_History_search_hint,(slant=normal):?} for help} ",
+)
+
+const SYNC_UPDATE_BEGIN = "\eP=1s\e\\"
+const SYNC_UPDATE_END = "\eP=2s\e\\"
+const CLEAR_BELOW = "\e[1G\e[J"
+
+"""
+    redisplay_all(io::IO, oldstate::SelectorState, newstate::SelectorState, pstate::PromptState; buf)
+
+Diff and redraw the entire UI (candidates, preview, prompt).
+
+Uses ANSI sync sequences to update only changed regions between
+`oldstate` and `newstate`, then reprints the prompt.
+"""
+function redisplay_all(io::IO, oldstate::SelectorState, newstate::SelectorState, pstate::REPL.LineEdit.PromptState;
+                       buf::IOContext{IOBuffer} = IOContext(IOBuffer(), io))
+    # Calculate dimensions
+    oldrows = componentrows(oldstate)
+    newrows = componentrows(newstate)
+    # Redisplay components
+    synccap = haskey(Base.current_terminfo(), :Sync)
+    synccap && print(buf, SYNC_UPDATE_BEGIN)
+    currentrow = 0
+    if newstate.query == FILTER_SHORTHELP_QUERY
+        print(buf, CLEAR_BELOW * '\n', FILTER_SHORTHELP)
+        currentrow += 1 + count('\n', String(FILTER_SHORTHELP))
+    elseif newstate.query == FILTER_LONGHELP_QUERY
+        print(buf, CLEAR_BELOW * '\n', FILTER_LONGHELP)
+        currentrow += 1 + count('\n', String(FILTER_LONGHELP))
+    else
+        println(buf) # Move to line under prompt
+        currentrow += 1
+        if oldstate.area.width > newstate.area.width || oldstate.query == FILTER_SHORTHELP_QUERY
+            print(buf, CLEAR_BELOW)
+            oldstate = EMPTY_STATE
+        end
+        refresh_cands = oldstate.query != newstate.query ||
+            length(oldstate.candidates) != length(newstate.candidates) ||
+            oldstate.area != newstate.area ||
+            oldstate.scroll != newstate.scroll ||
+            oldstate.selection.active != newstate.selection.active ||
+            oldstate.hover != newstate.hover ||
+            oldstate.filter != newstate.filter
+        refresh_preview = refresh_cands ||
+            oldstate.selection.gathered != newstate.selection.gathered ||
+            gethover(oldstate) != gethover(newstate)
+        if refresh_cands
+            redisplay_candidates(buf, oldstate, oldrows.candidates, newstate, newrows.candidates)
+            currentrow += newrows.candidates
+        end
+        if refresh_preview
+            if !refresh_cands
+                print(buf, '\n' ^ newrows.candidates)
+                currentrow += newrows.candidates
+            end
+            redisplay_preview(buf, oldstate, oldrows.preview, newstate, newrows.preview)
+            currentrow += max(0, newrows.preview - 1)
+        end
+    end
+    # Restore row pos
+    print(buf, "\e[", currentrow, "A\e[1G")
+    redisplay_prompt(buf, oldstate, newstate, pstate)
+    # Restore column pos
+    print(buf, "\e[", textwidth(PROMPT_TEXT) + position(pstate.input_buffer) + 1, 'G')
+    synccap && print(buf, SYNC_UPDATE_END)
+    write(io, seekstart(buf.io))
+    truncate(buf.io, 0)
+    flush(io)
+end
+
+"""
+    componentrows(state::SelectorState) -> (; candidates::Int, preview::Int)
+
+Split available terminal rows into candidate list and preview panes.
+
+Clamps preview height between one-third and two-thirds of the usable area.
+"""
+function componentrows(state::SelectorState)
+    available_rows = 2 * (state.area.height - 1) ÷ 3 # REVIEW: maybe `min(height, ?)`
+    preview_min, preview_max = available_rows ÷ 3, 2 * available_rows ÷ 3
+    nlines_preview = countlines_selected(state)
+    # To prevent jittering when key-repeat is happening with TAB at
+    # the end of a list of multiple selected candidates, stop
+    # the final candidate from affecting the size of the preview pane.
+    if length(state.selection.active) > 2 &&
+        last(state.selection.active) == lastindex(state.candidates)
+        nlines_preview -= count('\n', state.candidates[end].content) + 1
+    end
+    preview_rows = clamp(nlines_preview, preview_min, preview_max)
+    if preview_min <= 2
+        preview_rows = 0 # Not worth just showing the frame
+    end
+    candidate_rows = available_rows - preview_rows
+    (; candidates = candidate_rows, preview = preview_rows)
+end
+
+"""
+    countlines_selected(state::SelectorState) -> Int
+
+Count display lines needed for active and gathered entries.
+
+Includes one line per entry plus extra lines for multi-line content
+and a divider if any gathered entries exist.
+"""
+function countlines_selected((; candidates, selection)::SelectorState)
+    (; active, gathered) = selection
+    nlines = 0
+    for idx in active
+        entry = candidates[idx]
+        nlines += 1 + count('\n', entry.content)
+    end
+    if !isempty(gathered)
+        nlines += 1 # The divider line
+        for entry in gathered
+            nlines += 1 + count('\n', entry.content)
+        end
+    end
+    nlines
+end
+
+const BASE_MODE = :julia
+
+const MODE_FACES = Dict(
+    :julia => :green,
+    :shell => :red,
+    :pkg => :blue,
+    :help => :yellow,
+)
+
+"""
+    redisplay_prompt(io::IO, oldstate::SelectorState, newstate::SelectorState, pstate::PromptState)
+
+Redraw just the prompt line with updated query, separators, and hints.
+
+Styles prefixes, match-type indicators, and result counts based on cursor position in `pstate`.
+"""
+function redisplay_prompt(io::IO, oldstate::SelectorState, newstate::SelectorState, pstate::REPL.LineEdit.PromptState)
+    # oldstate.query == newstate.query && return
+    hov = gethover(newstate)
+    query = newstate.query
+    styquery = S"$query"
+    styconds = ConditionSet(styquery)
+    qpos = position(pstate.input_buffer)
+    kindname = ""
+    patend = 0
+    for (name, substrs) in (("words", styconds.words),
+                            ("exact", styconds.exacts),
+                            ("negated", styconds.negatives),
+                            ("initialism", styconds.initialisms),
+                            ("regexp", styconds.regexps),
+                            ("fuzzy", styconds.fuzzy),
+                            ("mode", styconds.modes))
+        for substr in substrs
+            start, len = substr.offset, substr.ncodeunits
+            patend = max(patend, start + len)
+            if start > 1
+                if query[start] == FILTER_SEPARATOR
+                    face!(styquery[start:start], :REPL_History_search_separator)
+                else
+                    face!(styquery[start:start], :REPL_History_search_prefix)
+                    face!(styquery[start-1:start-1], :REPL_History_search_separator)
+                end
+            elseif start > 0
+                face!(styquery[start:start],
+                      if query[start] == FILTER_SEPARATOR
+                          :REPL_History_search_separator
+                      else
+                          :REPL_History_search_prefix
+                      end)
+            end
+            isempty(kindname) || continue
+            if start <= qpos <= start + len
+                kindname = name
+                break
+            end
+        end
+    end
+    if patend < ncodeunits(query)
+        if query[patend+1] == FILTER_SEPARATOR
+            face!(styquery[patend+1:patend+1], :REPL_History_search_separator)
+            if patend + 1 < ncodeunits(query) && query[patend+2] ∈ FILTER_PREFIXES
+                face!(styquery[patend+2:patend+2], :REPL_History_search_prefix)
+            elseif isempty(kindname)
+                kindname = "separator"
+            end
+        elseif ncodeunits(query) == 1 && query[1] ∈ FILTER_PREFIXES
+            face!(styquery[1:1], :REPL_History_search_prefix)
+        end
+    end
+    prefix = S"{bold:▪:} "
+    ncand = length(newstate.candidates)
+    resultnum = S"{REPL_History_search_results:[$(ncand - newstate.hover + 1)/$ncand]}"
+    padspaces = newstate.area.width - sum(textwidth, (prefix, styquery, resultnum))
+    suffix = if isempty(styquery)
+        LABELS.help_prompt
+    elseif newstate.query ∈ (FILTER_SHORTHELP_QUERY, FILTER_LONGHELP_QUERY)
+        S"{REPL_History_search_hint:help} "
+    elseif kindname != ""
+        S"{REPL_History_search_hint:$kindname} "
+    else
+        S""
+    end
+    if textwidth(suffix) < padspaces
+        padspaces -= textwidth(suffix)
+    else
+        suffix = S""
+    end
+    # TODO: Replace with a face-based approach when possible
+    print(io, pstate.p.prompt_prefix, prefix, "\e[0m",
+          styquery, ' ' ^ max(0, padspaces), suffix, resultnum)
+end
+
+# Unicode circles:
+# - large: ● ○
+# - medium: ⏺🞉🞈🞇🞆🞅⚬🞊⦿⦾
+# - small: •⋅∙∘◦
+# - dots: 🞄⁃·
+
+const LIST_MARKERS = if Sys.isapple()
+    # '🞇' is not available by default, and '⬤' is oversized, so we must compromise.
+    (selected = AnnotatedChar('⏺', [(:face, :REPL_History_search_selected)]),
+     hover = AnnotatedChar('⦿', [(:face, :REPL_History_search_selected)]),
+     unselected = AnnotatedChar('◦', [(:face, :REPL_History_search_unselected)]),
+     pending = AnnotatedChar('·', [(:face, :shadow)]))
+else
+    # Linux tends to have pretty fantastic OOTB Unicode support, with fonts
+    # like Symbola installed by default, so we can go for the best symbols.
+    (selected = AnnotatedChar('⬤', [(:face, :REPL_History_search_selected)]),
+     hover = AnnotatedChar('🞇', [(:face, :REPL_History_search_selected)]),
+     unselected = AnnotatedChar('◦', [(:face, :REPL_History_search_unselected)]),
+     pending = AnnotatedChar('🞄', [(:face, :shadow)]))
+end
+
+const NEWLINE_MARKER = S"{shadow:↩ }"
+const LINE_ELLIPSIS = S"{shadow:…}"
+
+"""
+    hoveridx(state::SelectorState) -> Int
+
+Compute the signed index into `candidates` or `gathered` for hover.
+
+Positive values index `candidates`, negative values index `gathered`, zero is
+invalid.
+"""
+function hoveridx(state::SelectorState)
+    if state.hover > 0
+        length(state.candidates) - state.hover + 1
+    else
+        state.hover
+    end
+end
+
+"""
+    ishover(state::SelectorState, idx::Int) -> Bool
+
+Return true if `idx` matches the current hover position.
+
+Used to highlight the hovered line in the UI.
+"""
+ishover(state::SelectorState, idx::Int) = idx == hoveridx(state)
+
+"""
+    gethover(state::SelectorState) -> Union{HistEntry, Nothing}
+
+Return the `HistEntry` under the cursor (hover position), or `nothing`.
+
+Handles positive hover for `candidates` and negative for `gathered`.
+"""
+function gethover(state::SelectorState)
+    idx = hoveridx(state)
+    if idx ∈ axes(state.candidates, 1)
+        state.candidates[idx]
+    elseif idx < 0 && -idx ∈ axes(state.selection.gathered, 1)
+        state.selection.gathered[-idx]
+    end
+end
+
+struct CandsState{V<:AbstractVector{HistEntry}}
+    search::FilterSpec
+    entries::V
+    selected::Vector{Int}
+    hover::Int
+    rows::Int
+    width::Int
+end
+
+
+"""
+    candidates(state::SelectorState, rows::Int) -> (; active::CandsState, gathered::CandsState)
+
+Compute visible slices of active and gathered entries for display.
+"""
+function candidates(state::SelectorState, rows::Int)
+    gathshift = 0
+    gathcount = clamp(-state.scroll, 0, length(state.selection.gathered))
+    if gathcount >= rows
+        gathshift = gathcount - rows + 1
+        gathcount = rows - 1
+    end
+    actcount = rows - gathcount - sign(gathcount)
+    offset = max(0, length(state.candidates) - actcount - max(0, state.scroll))
+    candend = offset + actcount
+    actcands = @view state.candidates[max(begin, begin+offset):min(end, candend)]
+    actempty = actcount - length(actcands)
+    actsel = Int[idx - offset for idx in state.selection.active]
+    if !isempty(state.selection.gathered)
+        append!(actsel, filter!(!isnothing, indexin(state.selection.gathered, actcands)))
+    end
+    active = CandsState(
+        state.filter,
+        actcands,
+        actsel,
+        rows + state.scroll - state.hover - actempty + gathshift + (state.scroll >= 0),
+        actcount,
+        state.area.width)
+    gathcands = @view state.selection.gathered[begin+gathshift:min(end, gathshift+gathcount)]
+    gathered = CandsState(
+        state.filter,
+        gathcands,
+        collect(axes(gathcands, 1)),
+        -state.hover - gathshift,
+        gathcount,
+        state.area.width)
+    (; active, gathered)
+end
+
+"""
+    redisplay_candidates(io::IO, oldstate::SelectorState, oldrows::Int, newstate::SelectorState, newrows::Int)
+
+Diff and redraw the candidate list pane between two states.
+
+Only lines that changed (entry text, selection, hover, width) are reprinted;
+unchanged lines remain.
+"""
+function redisplay_candidates(io::IO, oldstate::SelectorState, oldrows::Int, newstate::SelectorState, newrows::Int)
+    danglingdivider = false
+    if oldstate.scroll < 0 && newstate.scroll == 0
+        newrows -= 1
+        danglingdivider = true
+    end
+    oldcands = candidates(oldstate, oldrows)
+    newcands = candidates(newstate, newrows)
+    samefilter = oldstate.filter == newstate.filter
+    # Redisplay active candidates
+    update_candidates(io, oldcands.active, newcands.active,
+                      !samefilter || oldstate.scroll == 0 && !isempty(oldstate.selection.gathered))
+    # Redisplay gathered candidates
+    gathchange = oldrows != newrows || length(oldcands.gathered.entries) != length(newcands.gathered.entries)
+    if isempty(newcands.gathered.entries) && !danglingdivider
+    elseif gathchange || danglingdivider || oldstate.area != newstate.area
+        netlines = newstate.area.width - textwidth(LABELS.gatherdivider) - 6
+        leftlines = netlines ÷ 2
+        rightlines = netlines - leftlines
+        println(io, S" {shadow:╶$('─' ^ leftlines)╴$(LABELS.gatherdivider)╶$('─' ^ rightlines)╴} ")
+    else
+        println(io)
+    end
+    update_candidates(io, oldcands.gathered, newcands.gathered, gathchange != 0)
+end
+
+"""
+    update_candidates(io::IO, oldcands::CandsState, newcands::CandsState, force::Bool = false)
+
+Write an update to `io` that changes the display from `oldcands` to `newcands`.
+
+Only changes are printed, and exactly `length(newcands.entries)` lines are printed.
+"""
+function update_candidates(io::IO, oldcands::CandsState, newcands::CandsState, force::Bool = false)
+    thisline = 1
+    for (i, (old, new)) in enumerate(zip(oldcands.entries, newcands.entries))
+        oldsel, newsel = i ∈ oldcands.selected, i ∈ newcands.selected
+        oldhov, newhov = i == oldcands.hover, i == newcands.hover
+        if !force && old == new && oldsel == newsel && oldhov == newhov && oldcands.width == newcands.width
+            println(io)
+        else
+            print_candidate(io, newcands.search, new, newcands.width;
+                            selected = newsel, hover = newhov)
+        end
+        thisline = i + 1
+    end
+    for (i, new) in enumerate(newcands.entries)
+        i <= length(oldcands.entries) && continue
+        print_candidate(io, newcands.search, new, newcands.width;
+                        selected = i ∈ newcands.selected,
+                        hover = i == newcands.hover)
+        thisline = i + 1
+    end
+    for _ in thisline:newcands.rows
+        print(io, "\e[K ", LIST_MARKERS.pending, '\n')
+    end
+end
+
+const DURATIONS = (
+    m = 60,
+    h = 60 * 60,
+    d = 24 * 60 * 60,
+    w = 7 * 24 * 60 * 60,
+    y = 365 * 24 * 60 * 60,
+)
+
+"""
+    humanage(seconds::Integer) -> String
+
+Convert `seconds` into a compact age string with largest unit.
+
+```julia-repl
+julia> humanage(70)
+"1m"
+
+julia> humanage(4000)
+"1h"
+```
+"""
+function humanage(seconds::Integer)
+    unit, count = :s, seconds
+    for (dunit, dsecs) in pairs(DURATIONS)
+        n = seconds ÷ dsecs
+        n == 0 && break
+        unit, count = dunit, n
+    end
+    "$count$unit"
+end
+
+"""
+    print_candidate(io::IO, search::FilterSpec, cand::HistEntry, width::Int; selected::Bool, hover::Bool)
+
+Render one history entry line with markers, mode hint, age, and highlighted content.
+
+Truncates and focuses on matches to fit `width`.
+"""
+function print_candidate(io::IO, search::FilterSpec, cand::HistEntry, width::Int; selected::Bool, hover::Bool)
+    print(io, ' ', if selected
+              LIST_MARKERS.selected
+          elseif hover
+              LIST_MARKERS.hover
+          else
+              LIST_MARKERS.unselected
+          end, ' ')
+    age = humanage(floor(Int, ((now(UTC) - cand.date)::Millisecond).value ÷ 1000))
+    agedec = S" {shadow,light,italic:$age}"
+    modehint = if cand.mode == BASE_MODE
+        S""
+    else
+        modeface = get(MODE_FACES, cand.mode, :grey)
+        if hover
+            S"{region: {bold,inverse,$modeface: $(cand.mode) }}"
+        elseif ncodeunits(age) == 2
+            S" {$modeface:◼}  "
+        else
+            S" {$modeface:◼} "
+        end
+    end
+    decorationlen = 3 #= spc + marker + spc =# + textwidth(modehint) + textwidth(agedec) + 1 #= spc =#
+    flatcand = replace(highlightcand(cand), r"\r?\n\s*" => NEWLINE_MARKER)
+    candstr = focus_matches(search, flatcand, width - decorationlen)
+    if hover
+        face!(candstr, :region)
+        face!(agedec, :region)
+    end
+    println(io, candstr, modehint, agedec, ' ')
+end
+
+"""
+    highlightcand(cand::HistEntry) -> AnnotatedString
+
+Syntax-highlight Julia content or return raw content otherwise.
+"""
+function highlightcand(cand::HistEntry)
+    if cand.mode === :julia
+        highlight(cand.content)
+    else
+        S"$(cand.content)"
+    end
+end
+
+"""
+    focus_matches(search::FilterSpec, content::AnnotatedString, targetwidth::Int) -> AnnotatedString
+
+Center and trim `content` around matching regions, adding ellipses.
+
+To best display matches, this function operates in multiple stages:
+1. Find all matching character ranges in `content` via `matchregions(search, String(content))`.
+2. Choose a primary match region that can be fully shown within `targetwidth`,
+   preferring the first match.
+3. Starting from the end of that region, expand a window leftwards up to
+   `targetwidth`, accounting for character widths.
+4. If the left bound exceeds the start of `content`, reserve space for a leading
+   ellipsis (`LINE_ELLIPSIS`) and adjust the window.
+5. Expand the window rightwards similarly, inserting a trailing ellipsis if
+   there is remaining text.
+6. Slice out the computed substring from `content`, preserving existing annotations.
+7. Re-apply the match highlight face (`:REPL_History_search_match`) to any
+   regions within the window.
+8. Pad the result with spaces if its width is less than `targetwidth`.
+
+The returned `AnnotatedString` is exactly `targetwidth` columns wide,
+guaranteeing at least one full match is visible and highlighted.
+"""
+function focus_matches(search::FilterSpec, content::AnnotatedString{String}, targetwidth::Int)
+    cstr = String(content) # zero-cost
+    mregions = matchregions(search, cstr)
+    isempty(mregions) && return rpad(rtruncate(content, targetwidth, LINE_ELLIPSIS), targetwidth)
+    mstart = first(first(mregions))
+    mlast = first(mregions)
+    ellipwidth = textwidth(LINE_ELLIPSIS)
+    # Assume approximately one cell per character, and refine later
+    for (i, region) in Iterators.reverse(enumerate(mregions))
+        if first(region) - mstart <= targetwidth - 2 * ellipwidth
+            mlast = region
+            break
+        end
+    end
+    # Start at the end of the last region, and extend backwards `targetwidth` characters
+    left, right = let pos = thisind(cstr, last(mlast)); (pos, pos) end
+    width = textwidth(cstr[left])
+    while left > firstindex(cstr)
+        lnext = prevind(cstr, left)
+        lwidth = textwidth(cstr[lnext])
+        if width + lwidth > targetwidth - 2 * ellipwidth
+            break
+        end
+        width += lwidth
+        left = lnext
+    end
+    # Check to see if we have reached the beginning of the first match,
+    # if we haven't we want to shrink the region to the left until the
+    # beginning of the first match is reached.
+    if left > first(mstart)
+        while left > first(mstart)
+            left = prevind(cstr, left)
+            lwidth = textwidth(cstr[left])
+            width += lwidth
+            # We'll move according to the assumption that each character
+            # is one cell wide, but account for the width correctly and
+            # adjust for any underestimate later.
+            for _ in 1:lwidth
+                width -= textwidth(cstr[right])
+                right = prevind(cstr, right)
+                right == left && break
+            end
+        end
+    end
+    isltrunc, isrtrunc = left > firstindex(cstr), right < lastindex(cstr)
+    # Use any available space to extend to the left.
+    if width < targetwidth - (isltrunc + isrtrunc) * ellipwidth && left < firstindex(cstr)
+        while left < firstindex(cstr)
+            lnext = prevind(cstr, left)
+            lwidth = textwidth(cstr[lnext])
+            isnextltrunc = lnext > firstindex(cstr)
+            nellipsis = isnextltrunc + isrtrunc
+            if width + lwidth > targetwidth - nellipsis * ellipwidth
+                break
+            end
+            width += lwidth
+            left = lnext
+        end
+        isltrunc = left > firstindex(cstr)
+    end
+    # Use any available space to extend to the right.
+    if width < targetwidth - (isltrunc + isrtrunc) * ellipwidth && right < lastindex(cstr)
+        while right < lastindex(cstr)
+            rnext = nextind(cstr, right)
+            rwidth = textwidth(cstr[rnext])
+            isnextrtrunc = rnext < lastindex(cstr)
+            nellipsis = isltrunc + isnextrtrunc
+            if width + rwidth > targetwidth - nellipsis * ellipwidth
+                break
+            end
+            width += rwidth
+            right = rnext
+        end
+    end
+    # Construct the new region
+    regstr = AnnotatedString(content[left:right])
+    # Emphasise matches
+    for region in mregions
+        (last(region) < left || first(region) > right) && continue
+        adjregion = (max(left, first(region)) - left + 1):(min(right, last(region)) - left + 1)
+        face!(regstr, adjregion, :REPL_History_search_match)
+    end
+    # Add ellipses
+    ellipstr = if left > firstindex(cstr) && right < lastindex(cstr)
+        width += 2 * ellipwidth
+        LINE_ELLIPSIS * regstr * LINE_ELLIPSIS
+    elseif left > firstindex(cstr)
+        width += ellipwidth
+        LINE_ELLIPSIS * regstr
+    elseif right < lastindex(cstr)
+        width += ellipwidth
+        regstr * LINE_ELLIPSIS
+    else
+        regstr
+    end
+    # Pad (if necessary)
+    if width < targetwidth
+        rpad(ellipstr, targetwidth)
+    else
+        ellipstr
+    end
+end
+
+"""
+    redisplay_preview(io::IO, oldstate::SelectorState, oldrows::Int, newstate::SelectorState, newrows::Int)
+
+Diff and redraw the preview pane (right side) with boxed content.
+
+Shows hover or gathered entries in a box.
+"""
+function redisplay_preview(io::IO, oldstate::SelectorState, oldrows::Int, newstate::SelectorState, newrows::Int)
+    newrows == 0 && return
+    function getcand(state::SelectorState, idx::Int)
+        if idx ∈ axes(state.candidates, 1)
+            state.candidates[idx]
+        elseif -idx ∈ axes(state.selection.gathered, 1)
+            state.selection.gathered[-idx]
+        else
+            throw(ArgumentError("Invalid candidate index: $idx")) # Should never happen
+        end
+    end
+    function getselidxs(state::SelectorState)
+        idxs = collect(-1:-1:-length(state.selection.gathered))
+        append!(idxs, state.selection.active)
+        sort!(idxs, by = i -> getcand(state, i).index)
+    end
+    rtruncpad(s::AbstractString, width::Int) =
+        rpad(rtruncate(s, width, LINE_ELLIPSIS), width)
+    bar = S"{shadow:│}"
+    innerwidth = newstate.area.width - 2
+    if oldstate.area != newstate.area || (oldstate.area.height - oldrows) != (newstate.area.height - newrows)
+        println(io, S"{shadow:╭$('─' ^ innerwidth)╮}")
+    else
+        println(io)
+    end
+    if newrows - 2 < 1
+        # Well, this is awkward.
+    elseif isempty(newstate.selection.active) && isempty(newstate.selection.gathered)
+        linesprinted = if (gethover(newstate) != gethover(oldstate) ||
+            oldstate.area != newstate.area ||
+            oldrows != newrows ||
+            oldstate.filter != newstate.filter)
+            hovcand = gethover(newstate)
+            if !isnothing(hovcand)
+                hovcontent = highlightcand(hovcand)
+                for region in matchregions(newstate.filter, String(hovcontent))
+                    face!(hovcontent[region], :REPL_History_search_match)
+                end
+                if hovcand.mode !== BASE_MODE
+                    mcolor = get(MODE_FACES, hovcand.mode, :grey)
+                    hovcontent = S"{bold,$mcolor:$(hovcand.mode)>} " * hovcontent
+                end
+                boxedcontent(io, hovcontent, newstate.area.width, newrows - 2)
+            else
+                0
+            end
+        else
+            print(io, '\n' ^ (newrows - 2))
+            newrows - 2
+        end
+        for _ in (linesprinted + 1):(newrows - 2)
+            println(io, bar, ' '^innerwidth, bar)
+        end
+    else
+        linesprinted = 0
+        seltexts = AnnotatedString{String}[]
+        for idx in getselidxs(newstate)
+            entry = getcand(newstate, idx)
+            content = highlightcand(entry)
+            ishover(newstate, idx) && face!(content, :region)
+            push!(seltexts, content)
+        end
+        linecount = sum(t -> 1 + count('\n', String(t)), seltexts, init=0)
+        for (i, content) in enumerate(seltexts)
+            clines = 1 + count('\n', String(content))
+            if linesprinted + clines < newrows - 2 || (i == length(seltexts) && linesprinted + clines == newrows - 2)
+                for line in eachsplit(content, '\n')
+                    println(io, bar, ' ', rtruncpad(line, innerwidth - 2), ' ', bar)
+                end
+                linesprinted += clines
+            else
+                remaininglines = newrows - 2 - linesprinted
+                for (i, line) in enumerate(eachsplit(content, '\n'))
+                    i == remaininglines && break
+                    println(io, bar, ' ', rtruncpad(line, innerwidth - 2), ' ', bar)
+                end
+                msg = S"{julia_comment:⋮ {italic:$(linecount - newrows + 3) lines hidden}}"
+                println(io, bar, ' ', rtruncpad(msg, innerwidth - 2), ' ', bar)
+                linesprinted += remaininglines
+                break
+            end
+        end
+        for _ in (linesprinted + 1):(newrows - 2)
+            println(io, bar, ' ' ^ innerwidth, bar)
+        end
+    end
+    if oldstate.area != newstate.area || length(oldstate.selection.active) != length(newstate.selection.active)
+        if textwidth(LABELS.preview_suggestion) < innerwidth
+            line = '─' ^ (innerwidth - textwidth(LABELS.preview_suggestion) - 2)
+            print(io, S"{shadow:╰$(line)╴$(LABELS.preview_suggestion)╶╯}")
+        else
+            print(io, S"{shadow:╰$('─' ^ innerwidth)╯}")
+        end
+    end
+end
+
+"""
+    boxedcontent(io::IO, content::AnnotatedString, width::Int, maxlines::Int) -> Int
+
+Draw `content` inside a Unicode box, wrapping or truncating to `width` and `maxlines`.
+
+Returns the number of printed lines.
+"""
+function boxedcontent(io::IO, content::AnnotatedString{String}, width::Int, maxlines::Int)
+    function breaklines(content::AnnotatedString{String}, maxwidth::Int)
+        textwidth(content) <= maxwidth && return [content]
+        spans = AnnotatedString{String}[]
+        basestr = String(content) # Because of expensive char iteration
+        start, pos, linewidth = 1, 0, 0
+        for char in basestr
+            linewidth += textwidth(char)
+            pos = nextind(basestr, pos)
+            if linewidth > maxwidth
+                spans = push!(spans, AnnotatedString(content[start:prevind(basestr, pos)]))
+                start = pos
+                linewidth = textwidth(char)
+            end
+        end
+        if start <= length(basestr)
+            spans = push!(spans, AnnotatedString(content[start:end]))
+        end
+        spans
+    end
+    left, right = S"{shadow:│} ", S" {shadow:│}"
+    leftcont, rightcont = S"{shadow:┊▸}", S"{shadow:◂┊}"
+    if maxlines == 1
+        println(io, left,
+                rpad(rtruncate(content, width - 4, LINE_ELLIPSIS), width - 4),
+                right)
+        return 1
+    end
+    printedlines = 0
+    if ncodeunits(content) > (width * maxlines)
+        content = AnnotatedString(rtruncate(content, width * maxlines, ' '))
+    end
+    lines = split(content, '\n')
+    innerwidth = width - 4
+    for (i, line) in enumerate(lines)
+        printedlines >= maxlines && break
+        if textwidth(line) <= innerwidth
+            println(io, left, rpad(line, innerwidth), right)
+            printedlines += 1
+            continue
+        end
+        plainline = String(line)
+        indent, ichars = 0, 1
+        while isspace(plainline[ichars])
+            indent += textwidth(plainline[ichars])
+            ichars = nextind(plainline, ichars)
+        end
+        line = @view line[ichars:end]
+        spans = breaklines(AnnotatedString(line), innerwidth - 2 - indent)
+        for (i, span) in enumerate(spans)
+            prefix, suffix = if i == 1
+                S"", S"$LINE_ELLIPSIS "
+            elseif i == length(spans)
+                S"$LINE_ELLIPSIS", S" "
+            else
+                LINE_ELLIPSIS, LINE_ELLIPSIS
+            end
+            printedlines += 1
+            println(io, ifelse(i == 1, left, leftcont), ' ' ^ indent,
+                    prefix, rpad(span, innerwidth - 2 - indent), suffix,
+                    ifelse(i == length(spans) || printedlines == maxlines,
+                           right, rightcont))
+            printedlines >= maxlines && break
+        end
+    end
+    printedlines
+end

--- a/stdlib/REPL/src/History/histfile.jl
+++ b/stdlib/REPL/src/History/histfile.jl
@@ -1,0 +1,288 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+"""
+    REPL_DATE_FORMAT
+
+The `DateFormat` used to parse and format timestamps in the REPL history file.
+"""
+const REPL_DATE_FORMAT = dateformat"yyyy-mm-dd HH:MM:SS"
+
+const HIST_OPEN_FLAGS =
+    Base.Filesystem.JL_O_APPEND |
+    Base.Filesystem.JL_O_RDWR |
+    Base.Filesystem.JL_O_CREAT |
+    Base.Filesystem.JL_O_CLOEXEC
+
+struct HistEntry
+    mode::Symbol
+    date::DateTime
+    # cwd::String
+    content::String
+    # resulttype::String
+    # session::UInt64
+    index::UInt32
+    # sindex::UInt16
+    # error::Bool
+end
+
+"""
+    HistoryFile(path::String) -> HistoryFile
+
+Create a handle to the history file at `path`, and store the `HistEntry` records.
+
+See also: `update!(::HistoryFile)`.
+"""
+struct HistoryFile <: AbstractVector{HistEntry}
+    path::String
+    file::Base.Filesystem.File
+    lock::ReentrantLock
+    records::Vector{HistEntry}
+end
+
+HistoryFile(path::String) = HistoryFile(
+    path, Base.Filesystem.open(path, HIST_OPEN_FLAGS, 0o640), ReentrantLock(), [])
+
+function HistoryFile()
+    nofile = Base.Filesystem.File(Base.Filesystem.INVALID_OS_HANDLE)
+    nofile.open = false
+    HistoryFile("", nofile, ReentrantLock(), [])
+end
+
+Base.lock(hist::HistoryFile) = lock(hist.lock)
+Base.trylock(hist::HistoryFile) = trylock(hist.lock)
+Base.unlock(hist::HistoryFile) = unlock(hist.lock)
+
+Base.size(hist::HistoryFile) = @lock hist (length(hist.records),)
+Base.getindex(hist::HistoryFile, i::Int) = hist.records[i]
+
+function ensureopen(hist::HistoryFile)
+    isopen(hist.file) && return true
+    isempty(hist.path) && return false
+    try
+        lock(hist)
+        newfile = Base.Filesystem.open(hist.path, HIST_OPEN_FLAGS, 0o640)
+        newfile.open || return false
+        hist.file.handle = newfile.handle
+        hist.file.open = true
+    finally
+        unlock(hist)
+    end
+end
+
+Base.close(hist::HistoryFile) = close(hist.file)
+
+"""
+    update!(hist::HistoryFile) -> HistoryFile
+
+Read any new entries from the history file and record them as `HistEntry`s.
+
+Malformed entries are skipped, and if the last entry is incomplete the IO
+position will be reset to the start of the entry.
+"""
+function update!(hist::HistoryFile)
+    (; file, records) = hist
+    # If the file has grown since the last read,
+    # we need to trigger a synchronisation of the
+    # stream state. This can be done with `fseek`,
+    # but that can't easily be called from Julia.
+    # Instead, we can use `filesize` to detect when
+    # we need to do this, and then use `peek` to
+    # trigger the synchronisation. This relies on
+    # undocumented implementation details, but
+    # there's not much to be done about that.
+    ensureopen(hist) || return hist
+    offset = position(file)
+    offset == filesize(file) && return hist
+    try
+        lock(hist)
+        bytes = read(file)
+        function findnext(data::Vector{UInt8}, index::Int, byte::UInt8, limit::Int = length(data))
+            for i in index:limit
+                data[i] == byte && return i
+            end
+            limit
+        end
+        function isstrmatch(data::Vector{UInt8}, at::Int, str::String)
+            at + ncodeunits(str) <= length(data) || return false
+            for (i, byte) in enumerate(codeunits(str))
+                data[at + i - 1] == byte || return false
+            end
+            true
+        end
+        histindex = if isempty(hist.records)
+            0
+        else
+            hist.records[end].index
+        end
+        pos = firstindex(bytes)
+        while true
+            pos >= length(bytes) && break
+            entrystart = pos
+            if bytes[pos] != UInt8('#')
+                @warn S"Malformed history entry: expected meta-line starting with {success:'#'} at byte {emphasis:$(offset + pos - 1)} in \
+                       {(underline=grey),link=$(Base.Filesystem.uripath(hist.path)):$(contractuser(hist.path))}, but found \
+                       {error:$(sprint(show, Char(bytes[pos])))} instead" _id=:invalid_history_entry maxlog=3 _file=nothing _line=nothing
+                pos = findnext(bytes, pos, UInt8('\n')) + 1
+                continue
+            end
+            time, mode = zero(DateTime), :julia
+            while pos < length(bytes) && bytes[pos] == UInt8('#')
+                pos += 1
+                while pos < length(bytes) && bytes[pos] == UInt8(' ')
+                    pos += 1
+                end
+                metastart = pos
+                metaend = findnext(bytes, pos, UInt8(':'))
+                pos = metaend + 1
+                while pos < length(bytes) && bytes[pos] == UInt8(' ')
+                    pos += 1
+                end
+                valstart = pos
+                valend = findnext(bytes, pos, UInt8('\n'))
+                pos = valend + 1
+                if isstrmatch(bytes, metastart, "mode:")
+                    mode = if isstrmatch(bytes, valstart, "julia") && bytes[valstart + ncodeunits("julia")] ∈ (UInt8('\n'), UInt8('\r'))
+                        :julia
+                    elseif isstrmatch(bytes, valstart, "help") && bytes[valstart + ncodeunits("help")] ∈ (UInt8('\n'), UInt8('\r'))
+                        :help
+                    elseif all(>(0x5a), view(bytes, valstart:valend-1))
+                        Symbol(bytes[valstart:valend-1])
+                    else
+                        Symbol(lowercase(String(bytes[valstart:valend-1])))
+                    end
+                elseif isstrmatch(bytes, metastart, "time:")
+                    valend = min(valend, valstart + ncodeunits("0000-00-00 00:00:00"))
+                    timestr = String(bytes[valstart:valend-1]) # It would be nice to avoid the string, but oh well
+                    timeval = tryparse(DateTime, timestr, REPL_DATE_FORMAT)
+                    if !isnothing(timeval)
+                        time = timeval
+                    end
+                end
+            end
+            if pos >= length(bytes)
+                # Potentially incomplete entry; roll back to start
+                seek(file, offset + entrystart - 1)
+                break
+            elseif bytes[pos] == UInt8(' ')
+                @warn S"Malformed history content: expected line to start with {success:'\\t'} at byte {emphasis:$(offset + pos - 1)} in \
+                        {(underline=grey),link=$(Base.Filesystem.uripath(hist.path)):$(contractuser(hist.path))}, but found \
+                        space ({error:' '}) instead. A text editor may have converted tabs to spaces in the \
+                        history file." _id=:invalid_history_content_spc maxlog=1 _file=nothing _line=nothing
+                continue
+            elseif bytes[pos] != UInt8('\t')
+                @warn S"Malformed history content: expected line to start with {success:'\\t'} at byte {emphasis:$(offset + pos - 1)} in \
+                        {(underline=grey),link=$(Base.Filesystem.uripath(hist.path)):$(contractuser(hist.path))}, but found \
+                        {error:$(sprint(show, Char(bytes[pos])))} instead" _id=:invalid_history_content maxlog=3 _file=nothing _line=nothing
+                continue
+            end
+            contentstart = pos
+            nlines = 0
+            while true
+                pos = findnext(bytes, pos, UInt8('\n'))
+                nlines += 1
+                if pos < length(bytes) && bytes[pos+1] == UInt8('\t')
+                    pos += 1
+                else
+                    break
+                end
+            end
+            contentend, pos = pos, contentstart
+            content = Vector{UInt8}(undef, contentend - contentstart - nlines)
+            bytescopied = 0
+            while pos < contentend
+                lineend = findnext(bytes, pos, UInt8('\n'))
+                nbytes = lineend - pos - (lineend == contentend)
+                copyto!(content, bytescopied + 1, bytes, pos + 1, nbytes)
+                bytescopied += nbytes
+                pos = lineend + 1
+            end
+            entry = HistEntry(mode, time, String(content), histindex += 1)
+            push!(records, entry)
+        end
+        seek(file, offset + pos - 1)
+    finally
+        unlock(hist)
+    end
+    hist
+end
+
+function Base.push!(hist::HistoryFile, entry::HistEntry)
+    try
+        lock(hist)
+        update!(hist)
+        entry = HistEntry(
+            if all(islowercase, String(entry.mode))
+                entry.mode
+            else
+                Symbol(lowercase(String(entry.mode)))
+            end,
+            round(entry.date, Dates.Second),
+            entry.content,
+            length(hist.records) + 1)
+        push!(hist.records, entry)
+        isopen(hist.file) || return hist
+        content = IOBuffer()
+        write(content, "# time: ",
+              Dates.format(entry.date, REPL_DATE_FORMAT), "Z\n",
+              "# mode: ", String(entry.mode), '\n')
+        replace(content, entry.content, r"^"ms => "\t")
+        write(content, '\n')
+        # Short version:
+        #
+        # Libuv supports opening files with an atomic append flag,
+        # and so if we pass the entire new entry to `uv_fs_write`
+        # with an offset of `-1`, the OS will ensure that the write
+        # is atomic. There are some caveats around this, but there's
+        # no silver bullet.
+        #
+        # Long version:
+        #
+        # Normally, we would need to make sure we've got unique access to the file,
+        # however because we opened it with `O_APPEND` the OS (as of POSIX.1-2017, and on:
+        # Linux/FreeBSD/Darwin/Windows) guarantees that concurrent writes will not tear.
+        #
+        # This requires that a single `write` call be used to write the entire new entry.
+        # This is not obvious, but if you look at `base/filesystem.jl` we can see that
+        # the `unsafe_write` call below is turned into a `uv_fs_write` call.
+        # Following this to `src/jl_uv.c` we can see this quickly turns into a `uv_fs_write`
+        # call, which will produce a `uv__fs_write_all` call, and then calls `uv__fs_write`
+        # in a loop until everything is written.
+        #
+        # This loop seems like it might allow writes to be interleaved, but since
+        # we know that `nbufs = 1` and `off = -1` (from the parameters set in `unsafe_write`
+        # and `jl_uv_write`), we can see that `uv__fs_write` will call the `write`
+        # syscall directly, and so we get the `O_APPEND` semantics guaranteed by the OS.
+        #
+        # POSIX does mention that `write` may write less bytes than it is asked to,
+        # but only when either:
+        # 1. There is insufficient space on the device, or
+        # 2. The size of the write exceeds `RLIMIT_FSIZE`, or
+        # 3. The call is interrupted by a signal handler.
+        #
+        # Any of these would cause issues regardless.
+        #
+        # Over in Windows-land, `FILE_APPEND_DATA` has been around for a while (and is used
+        # by libuv), and from reading `win/fs.c` we can see that a similar approach is taken
+        # using `WriteFile` calls. Before Windows 10 (on NTFS), v10.0.14393 update atomicity
+        # could be as small as 1 byte, but after that testing indicates that writes through
+        # to 1MB are written in a single operation. Given that this is not an upper limit,
+        # and it would be quite an extraordinary REPL entry, this seem safe enough.
+        #
+        # While in theory a split write may occur, in practice this seems exceptionally rare
+        # (near non-existent), and the previous pidfile locking approach is no silver bullet
+        # either, with its own set of "reasonable assumptions" like:
+        # 1. PIDs not being rapidly recycled
+        # 2. No process being able to delete and write a file faster than another
+        #    process can do the same
+        # 3. The PID number itself being written in one shot (see the above lack of
+        #    formal guarantees around `write`, which also applies here)
+        #
+        # All in all, relying on kernel inode locking with `O_APPEND` and whole writes
+        # seems like the sanest approach overall. Mutual exclusion isn't the priority
+        # here, safe appending is.
+        unsafe_write(hist.file, pointer(content.data), position(content) % UInt, Int64(-1))
+    finally
+        unlock(hist)
+    end
+    hist
+end

--- a/stdlib/REPL/src/History/prompt.jl
+++ b/stdlib/REPL/src/History/prompt.jl
@@ -1,0 +1,165 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+const PROMPT_TEXT = "▪: "
+
+struct Event <: Function
+    info::Channel{Symbol}
+    name::Symbol
+end
+
+function (e::Event)(_...)
+    push!(e.info, e.name)
+    :ignore
+end
+
+"""
+    select_keymap(events::Channel{Symbol})
+
+Build a REPL.LineEdit keymap that pushes symbols into `events`.
+
+Binds arrows, page keys, Tab, Ctrl-C/D/S, and meta-< / > to
+`Event` or `Returns` actions for driving the prompt loop.
+"""
+function select_keymap(events::Channel{Symbol})
+    REPL.LineEdit.keymap([
+        Dict{Any, Any}(
+            # Up Arrow
+            "\e[A" => Event(events, :up),
+            "^P" => Event(events, :up),
+            # Down Arrow
+            "\e[B" => Event(events, :down),
+            "^N" => Event(events, :down),
+            # Tab
+            '\t' => Event(events, :tab),
+            # Page up
+            "\e[5~" => Event(events, :pageup),
+            "\ev" => Event(events, :pageup),
+            # Page down
+            "\e[6~" => Event(events, :pagedown),
+            "^V" => Event(events, :pagedown),
+            # Meta + < / >
+            "\e<" => Event(events, :jumpfirst),
+            "\e>" => Event(events, :jumplast),
+            #
+            "^L" => Event(events, :clear),
+            # Exits
+            "^C" => Returns(:abort),
+            "^D" => Returns(:abort),
+            "^G" => Returns(:abort),
+            "\e\e" => Returns(:abort),
+            "^S" => Returns(:save),
+            "^Y" => Returns(:copy),
+        ),
+        REPL.LineEdit.default_keymap,
+        REPL.LineEdit.escape_defaults])
+end
+
+"""
+    create_prompt(events::Channel{Symbol}, term)
+
+Initialize a custom REPL prompt tied to `events` using the existing `term`.
+
+Returns a tuple `(term, prompt, istate, pstate)` ready for
+input handling and display.
+"""
+function create_prompt(events::Channel{Symbol}, term, prefix::String = "\e[90m")
+    prompt = REPL.LineEdit.Prompt(
+        PROMPT_TEXT, # prompt
+        prefix, "\e[0m", # prompt_prefix, prompt_suffix
+        "", "", "", # output_prefix, output_prefix_prefix, output_prefix_suffix
+        select_keymap(events), # keymap_dict
+        nothing, # repl
+        REPL.LatexCompletions(), # complete
+        _ -> true, # on_enter
+        () -> nothing, # on_done
+        REPL.LineEdit.EmptyHistoryProvider(), # hist
+        false, # sticky
+        REPL.StylingPasses.StylingPass[]) # styling_passes
+    interface = REPL.LineEdit.ModalInterface([prompt])
+    istate = REPL.LineEdit.init_state(term, interface)
+    pstate = istate.mode_state[prompt]
+    (; term, prompt, istate, pstate)
+end
+
+"""
+    runprompt!((; term,prompt,pstate,istate), events::Channel{Symbol})
+
+Drive the prompt input loop until confirm, save, or abort.
+
+Emits `:edit`, `:confirm`, `:save`, or `:abort` into `events`,
+manages raw mode and bracketed paste, and cleans up on exit.
+"""
+function runprompt!((; term, prompt, pstate, istate), events::Channel{Symbol})
+    Base.reseteof(term)
+    REPL.LineEdit.raw!(term, true)
+    REPL.LineEdit.enable_bracketed_paste(term)
+    try
+        pstate.ias = REPL.LineEdit.InputAreaState(0, 0)
+        REPL.LineEdit.refresh_multi_line(term, pstate)
+        while true
+            kmap = REPL.LineEdit.keymap(pstate, prompt)
+            matchfn = REPL.LineEdit.match_input(kmap, istate)
+            kdata = REPL.LineEdit.keymap_data(pstate, prompt)
+            status = matchfn(istate, kdata)
+            if status === :ok
+                push!(events, :edit)
+            elseif status === :ignore
+                istate.last_action = istate.current_action
+            elseif status === :done
+                print("\e[F")
+                push!(events, :confirm)
+                break
+            elseif status === :copy
+                print("\e[1G\e[J")
+                push!(events, status)
+                break
+            elseif status === :save
+                print("\e[1G\e[J")
+                dest = savedest(term)
+                if isnothing(dest)
+                    push!(events, :redraw)
+                else
+                    push!(events, dest)
+                    break
+                end
+            else
+                push!(events, :abort)
+                break
+            end
+        end
+    finally
+        REPL.LineEdit.raw!(term, false) &&
+            REPL.LineEdit.disable_bracketed_paste(term)
+    end
+end
+
+function savedest(term::Base.Terminals.TTYTerminal)
+    out = term.out_stream
+    print(out, "\e[1G\e[J")
+    clipsave = true
+    try
+        print(out, get(Base.current_terminfo(), :cursor_invisible, ""))
+        fclip, ffile = [:emphasis, :bold], [:grey]
+        char = '\0'
+        while true
+            print(out, S"\e[1G\e[2K{bold,grey:history>} {bold,emphasis:save to} {$fclip,inverse: Clipboard } {$ffile,inverse: File }   {shadow:Tab to toggle ⋅ ⏎ to select}")
+            ichar = read(term.in_stream, Char)
+            if ichar ∈ ('\x03', '\x18', '\a') || char == ichar == '\e'
+                return
+            elseif ichar == '\r'
+                break
+            end
+            char = ichar
+            fclip, ffile = ffile, fclip
+            clipsave = !clipsave
+        end
+    finally
+        # NOTE: While it may look like `:cursor_visible` would be the
+        # appropriate choice to reverse `:cursor_invisible`, unfortunately
+        # tmux-256color declares a sequence that doesn't actually make
+        # the cursor become visible again 😑.
+        print(out, get(Base.current_terminfo(), :cursor_normal, ""))
+        print(out, "\e[1G\e[2K")
+    end
+    if clipsave; :copy else :filesave end
+end

--- a/stdlib/REPL/src/History/resumablefiltering.jl
+++ b/stdlib/REPL/src/History/resumablefiltering.jl
@@ -1,0 +1,332 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+struct ConditionSet{S}
+    words::Vector{SubString{S}}
+    exacts::Vector{SubString{S}}
+    negatives::Vector{SubString{S}}
+    initialisms::Vector{SubString{S}}
+    fuzzy::Vector{SubString{S}}
+    regexps::Vector{SubString{S}}
+    modes::Vector{SubString{S}}
+end
+
+ConditionSet{S}() where {S} = ConditionSet{S}([], [], [], [], [], [], [])
+
+"""
+    FILTER_SEPARATOR
+
+Character used to separate multiple search conditions in a single query.
+"""
+const FILTER_SEPARATOR = ';'
+
+"""
+    FILTER_PREFIXES
+
+List of single-character prefixes that set search modes.
+"""
+const FILTER_PREFIXES = ('!', '`', '=', '/', '~', '>')
+
+"""
+    FILTER_SHORTHELP_QUERY
+
+The special single-character query that triggers display of `FILTER_SHORTHELP`.
+"""
+const FILTER_SHORTHELP_QUERY = "?"
+
+"""
+    FILTER_LONGHELP_QUERY
+
+The special query that triggers display of `FILTER_LONGHELP`.
+"""
+const FILTER_LONGHELP_QUERY = "??"
+
+"""
+    FILTER_SHORTHELP
+
+Annotated help text displayed when the user enters the help query (`$FILTER_SHORTHELP_QUERY`).
+"""
+const FILTER_SHORTHELP = S"""
+ {bold,magenta:Interactive history search}
+
+ Enter a search term at the prompt, and see matching candidates.
+ A search term that is {italic:just} '{REPL_History_search_prefix:?}' brings up this help page.
+
+ See more information on behaviour and keybindings with '{REPL_History_search_prefix:??}'.
+
+ Different search modes are available via prefixes, as follows:
+ {emphasis:•} {REPL_History_search_prefix:=} looks for exact matches
+ {emphasis:•} {REPL_History_search_prefix:!} {italic:excludes} exact matches
+ {emphasis:•} {REPL_History_search_prefix:/} performs a regexp search
+ {emphasis:•} {REPL_History_search_prefix:~} looks for fuzzy matches
+ {emphasis:•} {REPL_History_search_prefix:>} looks for a particular REPL mode
+ {emphasis:•} {REPL_History_search_prefix:`} looks for an initialism (text with matching initials)
+
+ You can also apply multiple restrictions with the separator '{REPL_History_search_separator:$FILTER_SEPARATOR}'.
+
+ For example, {region:{REPL_History_search_prefix:/}^foo{REPL_History_search_separator:$FILTER_SEPARATOR}\
+{REPL_History_search_prefix:`}bar{REPL_History_search_separator:$FILTER_SEPARATOR}\
+{REPL_History_search_prefix:>}shell} will look for history entries that start with "{code:foo}",
+ contains "{code:b... a... r...}", {italic:and} is a shell history entry.
+"""
+
+const FILTER_LONGHELP = S"""
+ {bold,magenta:Interactive history search — behaviour and keybindings}
+
+ Search your REPL history interactively by constructing filters.
+
+ With no mode specified (see the basic help with '{REPL_History_search_prefix:?}'), entries are matched
+ if they contain all of the words in the search string, in any order.
+
+ If the entire search string is lowercase, the search is case-insensitive.
+
+ If you want to include the filter separator '{REPL_History_search_separator:$FILTER_SEPARATOR}' in a query, or start
+ a words filter with a prefix character, you may escape it with a backslash (e.g. {code:\\;}).
+
+ Search results can be navigated with:
+ {emphasis:•} {code:↑}, {code:Ctrl+P}, or {code:Ctrl+K} to move up
+ {emphasis:•} {code:↓}, {code:Ctrl+N}, or {code:Ctrl+J} to move down
+ {emphasis:•} {code:PageUp} or {code:Ctrl+B} to page up
+ {emphasis:•} {code:PageDown} or {code:Ctrl+F} to page down
+ {emphasis:•} {code:Alt+<} to jump to the first result
+ {emphasis:•} {code:Alt+>} to jump to the last result
+
+ Multiple search results can be selected with {code:Tab} and confirmed with {code:Enter}.
+ You may use {code:Ctrl+S} to save selected entries to a file or the clipboard.
+
+ To abort the search, use {code:Ctrl+C}, {code:Ctrl+D}, {code:Ctrl+G}, or {code:Esc Esc}.
+"""
+
+"""
+    ConditionSet(spec::AbstractString) -> ConditionSet
+
+Parse the raw search string `spec` into a `ConditionSet`.
+
+Parsing is performed by splitting on unescaped `FILTER_SEPARATOR` and
+dispatching each segment according to its leading prefix character.
+"""
+function ConditionSet(spec::S) where {S <: AbstractString}
+    function addcond!(condset::ConditionSet, cond::SubString)
+        isempty(cond) && return
+        kind = first(cond)
+        if kind ∈ ('!', '=', '`', '/', '>', '~')
+            value = @view cond[2:end]
+            if kind ∈ ('`', '>', '~')
+                value = strip(value)
+            elseif !all(isspace, value)
+                value = if kind == '/'
+                    rstrip(value)
+                else # kind ∈ ('!', '=')
+                    strip(value)
+                end
+            end
+            isempty(value) && return
+            if startswith(cond, '!')
+                push!(condset.negatives, value)
+            elseif startswith(cond, '=')
+                push!(condset.exacts, value)
+            elseif startswith(cond, '`')
+                push!(condset.initialisms, value)
+            elseif startswith(cond, '/')
+                push!(condset.regexps, value)
+            elseif startswith(cond, '>')
+                push!(condset.modes, SubString(lowercase(value)))
+            elseif startswith(cond, '~')
+                push!(condset.fuzzy, value)
+            end
+        else
+            if startswith(cond, '\\') && !(length(cond) > 1 && cond[2] == '\\')
+                cond = @view cond[2:end]
+            end
+            push!(condset.words, strip(cond))
+        end
+        nothing
+    end
+    cset = ConditionSet{S}()
+    pos = firstindex(spec)
+    mark = pos
+    lastind = lastindex(spec)
+    escaped = false
+    dropbytes = Int[]
+    while pos <= lastind
+        chr = spec[pos]
+        if escaped
+            chr == FILTER_SEPARATOR && push!(dropbytes, pos - mark)
+            escaped = false
+        elseif chr == '\\'
+            escaped = true
+        elseif chr == FILTER_SEPARATOR
+            str = SubString(spec, mark:pos - 1)
+            if !isempty(dropbytes)
+                str = SubString(convert(S, String(deleteat!(collect(codeunits(str)), dropbytes))))
+                empty!(dropbytes)
+            end
+            addcond!(cset, lstrip(str))
+            mark = pos + 1
+        end
+        pos = nextind(spec, pos)
+    end
+    if mark <= lastind
+        str = SubString(spec, mark:pos - 1)
+        if !isempty(dropbytes)
+            str = SubString(convert(S, String(deleteat!(collect(codeunits(str)), dropbytes))))
+        end
+        addcond!(cset, lstrip(SubString(spec, mark:lastind)))
+    end
+    cset
+end
+
+"""
+    ismorestrict(a::ConditionSet, b::ConditionSet) -> Bool
+
+Whether `a` is at least as restrictive as `b`, across all conditions.
+"""
+function ismorestrict(a::ConditionSet, b::ConditionSet)
+    length(a.fuzzy) == length(b.fuzzy) &&
+        all(splat(==), zip(a.fuzzy, b.fuzzy)) || return false
+    length(a.regexps) == length(b.regexps) &&
+        all(splat(==), zip(a.regexps, b.regexps)) || return false
+    length(a.modes) == length(b.modes) &&
+        all(splat(==), zip(a.modes, b.modes)) || return false
+    length(a.exacts) >= length(b.exacts) &&
+        all(splat(occursin), zip(b.exacts, a.exacts)) || return false
+    length(a.words) >= length(b.words) &&
+        all(splat(occursin), zip(b.words, a.words)) || return false
+    length(a.negatives) >= length(b.negatives) &&
+        all(splat(occursin), zip(a.negatives, b.negatives)) || return false
+    length(a.initialisms) >= length(b.initialisms) &&
+        all(splat(occursin), zip(b.initialisms, a.initialisms)) || return false
+    true
+end
+
+struct FilterSpec
+    exacts::Vector{String}
+    negatives::Vector{String}
+    regexps::Vector{Regex}
+    modes::Vector{Symbol}
+end
+
+FilterSpec() = FilterSpec([], [], [], [])
+
+function FilterSpec(cset::ConditionSet)
+    spec = FilterSpec([], [], [], [])
+    for term in cset.exacts
+        push!(spec.exacts, String(term))
+    end
+    for words in cset.words
+        casesensitive = any(isuppercase, words)
+        for word in eachsplit(words)
+            if casesensitive
+                push!(spec.exacts, String(word))
+            else
+                push!(spec.regexps, Regex(string("\\Q", word, "\\E"), "i"))
+            end
+        end
+    end
+    for term in cset.negatives
+        push!(spec.negatives, String(term))
+    end
+    for rx in cset.regexps
+        try
+            push!(spec.regexps, Regex(rx))
+        catch _
+            # Regex error, skip
+        end
+    end
+    for itlsm in cset.initialisms
+        rx = Regex(join((string("(?:(?:\\b|_+)(?:\\Q", ltr, "\\E|\\Q", uppercase(ltr),
+                                "\\E)\\w+|\\p{Ll}\\Q", uppercase(ltr), "\\E)")
+                         for ltr in itlsm), "[\\W_]*?"))
+        push!(spec.regexps, rx)
+    end
+    for fuzz in cset.fuzzy
+        for word in eachsplit(fuzz)
+            rx = Regex(join((string("\\Q", ltr, "\\E") for ltr in word), "[^\\s\"#%&()*+,\\-\\/:;<=>?@[\\]^`{|}~]*?"),
+                       ifelse(any(isuppercase, fuzz), "", "i"))
+            push!(spec.regexps, rx)
+        end
+    end
+    for mode in cset.modes
+        push!(spec.modes, Symbol(mode))
+    end
+    spec
+end
+
+
+"""
+    filterchunkrev!(out, candidates, spec; idx, maxtime, maxresults) -> Int
+
+Incrementally filter `candidates[1:idx]` in reverse order.
+
+Pushes matches onto `out` until either `maxtime` is exceeded or `maxresults`
+collected, then returns the new resume index.
+"""
+function filterchunkrev!(out::Vector{HistEntry}, candidates::DenseVector{HistEntry},
+                         spec::FilterSpec, idx::Int = length(candidates);
+                         maxtime::Float64 = Inf, maxresults::Int = length(candidates))
+    batchsize = clamp(length(candidates) ÷ 512, 10, 1000)
+    for batch in Iterators.partition(idx:-1:1, batchsize)
+        time() > maxtime && break
+        for outer idx in batch
+            entry = candidates[idx]
+            if !isempty(spec.modes)
+                entry.mode ∈ spec.modes || continue
+            end
+            matchfail = false
+            for text in spec.exacts
+                if !occursin(text, entry.content)
+                    matchfail = true
+                    break
+                end
+            end
+            matchfail && continue
+            for text in spec.negatives
+                if occursin(text, entry.content)
+                    matchfail = true
+                    break
+                end
+            end
+            matchfail && continue
+            for rx in spec.regexps
+                if !occursin(rx, entry.content)
+                    matchfail = true
+                    break
+                end
+            end
+            matchfail && continue
+            pushfirst!(out, entry)
+            length(out) == maxresults && break
+        end
+    end
+    max(0, idx - 1)
+end
+
+"""
+    matchregions(spec::FilterSpec, candidate::AbstractString) -> Vector{UnitRange{Int}}
+
+Find all matching character ranges in `candidate` for `spec`.
+
+Collects exact-substring and regex matches, then returns them
+sorted by start index (and longer matches first).
+"""
+function matchregions(spec::FilterSpec, candidate::AbstractString)
+    matches = UnitRange{Int}[]
+    for text in spec.exacts
+        append!(matches, findall(text, candidate))
+    end
+    for rx in spec.regexps
+        for (; match) in eachmatch(rx, candidate)
+            push!(matches, 1+match.offset:thisind(candidate, match.offset + match.ncodeunits))
+        end
+    end
+    sort!(matches, by = m -> (first(m), -last(m)))
+    # Combine adjacent matches separated by a single space
+    for (i, match) in enumerate(matches)
+        i == length(matches) && break
+        nextmatch = matches[i + 1]
+        if last(match) + 1 == first(nextmatch) - 1 && candidate[last(match)+1] == ' '
+            matches[i] = first(match):last(nextmatch)
+            matches[i+1] = last(nextmatch)+1:last(nextmatch)
+        end
+    end
+    filter!(!isempty, matches)
+end

--- a/stdlib/REPL/src/History/search.jl
+++ b/stdlib/REPL/src/History/search.jl
@@ -1,0 +1,375 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+"""
+    runsearch() -> (; mode::Union{Symbol, Nothing}, text::String)
+
+Launch the interactive REPL history search interface.
+
+Spawns prompt and display tasks, waits for user confirm or abort,
+and returns the final selection (if any).
+"""
+function runsearch(histfile::HistoryFile, term, prefix::String = "\e[90m")
+    update!(histfile)
+    events = Channel{Symbol}(Inf)
+    pspec = create_prompt(events, term, prefix)
+    ptask = @spawn runprompt!(pspec, events)
+    dtask = @spawn run_display!(pspec, events, histfile.records)
+    wait(ptask)
+    fullselection(fetch(dtask))
+end
+
+"""
+    fullselection(state::SelectorState) -> (; mode::Symbol, text::String)
+
+Gather all selected and hovered entries and return them as joined text.
+"""
+function fullselection(state::SelectorState)
+    text = IOBuffer()
+    entries = copy(state.selection.gathered)
+    for act in state.selection.active
+        push!(entries, state.candidates[act])
+    end
+    if isempty(entries) && state.hover ∈ axes(state.candidates, 1)
+        push!(entries, state.candidates[end-state.hover+1])
+    end
+    sort!(entries, by = e -> e.index)
+    mainmode = if !isempty(entries) first(entries).mode end
+    join(text, Iterators.map(e -> e.content, entries), '\n')
+    (mode = mainmode, text = String(take!(text)))
+end
+
+"""
+    run_display!((; term,pstate), events::Channel{Symbol}, hist::Vector{HistEntry})
+
+Drive the display event loop until confirm or abort.
+
+Listens for navigation, edits, save, and abort events, re-filters history
+incrementally, and re-renders via `redisplay_all`.
+"""
+function run_display!((; term, pstate), events::Channel{Symbol}, hist::Vector{HistEntry})
+    # Output-related variables
+    out = term.out_stream
+    outsize = displaysize(out)
+    buf = IOContext(IOBuffer(), out)
+    # Main state variables
+    state = SelectorState(outsize, "", FilterSpec(), hist)
+    redisplay_all(out, EMPTY_STATE, state, pstate; buf)
+    # Candidate cache
+    cands_cache = Pair{ConditionSet{String}, Vector{HistEntry}}[]
+    cands_cachestate = zero(UInt8)
+    cands_current = HistEntry[]
+    cands_cond = ConditionSet{String}()
+    cands_temp = HistEntry[]
+    # Filter state
+    filter_idx = 0
+    # Event loop
+    while true
+        event = @lock events if !isempty(events) take!(events) end
+        if isnothing(event)
+        elseif event === :abort
+            print(out, "\e[1G\e[J")
+            return EMPTY_STATE
+        elseif event === :confirm
+            print(out, "\e[1G\e[J")
+            return state
+        elseif event === :clear
+            print(out, "\e[H\e[2J")
+            redisplay_all(out, EMPTY_STATE, state, pstate; buf)
+            continue
+        elseif event === :redraw
+            print(out, "\e[1G\e[J")
+            redisplay_all(out, EMPTY_STATE, state, pstate; buf)
+            continue
+        elseif event ∈ (:up, :down, :pageup, :pagedown)
+            prevstate, state = state, movehover(state, event ∈ (:up, :pageup), event ∈ (:pageup, :pagedown))
+            @lock events begin
+                nextevent = if !isempty(events) first(events.data) end
+                while nextevent ∈ (:up, :down, :pageup, :pagedown)
+                    take!(events)
+                    state = movehover(state, nextevent ∈ (:up, :pageup), event ∈ (:pageup, :pagedown))
+                    nextevent = if !isempty(events) first(events.data) end
+                end
+            end
+            redisplay_all(out, prevstate, state, pstate; buf)
+            continue
+        elseif event === :jumpfirst
+            prevstate = state
+            state = SelectorState(
+                state.area, state.query, state.filter, state.candidates,
+                length(state.candidates) - componentrows(state).candidates,
+                state.selection, length(state.candidates))
+            redisplay_all(out, prevstate, state, pstate; buf)
+            continue
+        elseif event === :jumplast
+            prevstate = state
+            state = SelectorState(
+                state.area, state.query, state.filter, state.candidates,
+                0, state.selection, 1)
+            redisplay_all(out, prevstate, state, pstate; buf)
+            continue
+        elseif event === :tab
+            prevstate, state = state, toggleselection(state)
+            redisplay_all(out, prevstate, state, pstate; buf)
+            continue
+        elseif event === :edit
+            @lock events begin
+                while !isempty(events) && first(events.data) === :edit
+                    take!(events)
+                end
+            end
+            query = REPL.LineEdit.input_string(pstate)
+            if query === state.query
+                redisplay_all(out, state, state, pstate; buf)
+                continue
+            end
+            # Determine the conditions/filter spec
+            cands_cond = ConditionSet(query)
+            filter_spec = FilterSpec(cands_cond)
+            # Construct a provisional new state
+            prevstate, state = state, SelectorState(
+                outsize, query, filter_spec, HistEntry[], state.selection.gathered)
+            # Gather selected candidates
+            if !isempty(prevstate.selection.active)
+                for act in prevstate.selection.active
+                    push!(state.selection.gathered, prevstate.candidates[act])
+                end
+                sort!(state.selection.gathered, by = e -> e.index)
+                state = SelectorState(
+                    state.area, state.query, state.filter, state.candidates,
+                    -min(length(state.selection.gathered), state.area.height ÷ 8),
+                    state.selection, 1)
+            end
+            # Show help?
+            if query ∈ (FILTER_SHORTHELP_QUERY,FILTER_LONGHELP_QUERY)
+                redisplay_all(out, prevstate, state, pstate; buf)
+                continue
+            end
+            # Parse the conditions and find a good candidate list
+            cands_current = hist
+            for (cond, cands) in Iterators.reverse(cands_cache)
+                if ismorestrict(cands_cond, cond)
+                    cands_current = cands
+                    break
+                end
+            end
+            # Start filtering candidates
+            filter_idx = filterchunkrev!(
+                state, cands_current;
+                maxtime = time() + 0.01,
+                maxresults = outsize[1])
+            if filter_idx == 0
+                cands_cachestate = addcache!(
+                    cands_cache, cands_cachestate, cands_cond => state.candidates)
+            end
+            redisplay_all(out, prevstate, state, pstate; buf)
+            continue
+        elseif event === :copy
+            content = strip(fullselection(state).text)
+            isempty(content) || saveclipboard(term.out_stream, content)
+            return EMPTY_STATE
+        elseif event === :filesave
+            content = strip(fullselection(state).text)
+            isempty(content) || savefile(term, content)
+            return EMPTY_STATE
+        else
+            error("Unknown event: $event")
+        end
+        if displaysize(out) != outsize
+            outsize = displaysize(out)
+            prevstate, state = state, SelectorState(
+                outsize, state.query, state.filter, state.candidates,
+                state.scroll, state.selection, state.hover)
+            redisplay_all(out, prevstate, state, pstate; buf)
+        elseif filter_idx != 0
+            append!(empty!(cands_temp), state.candidates)
+            prevstate = SelectorState(
+                state.area, state.query, state.filter, cands_temp,
+                state.scroll, state.selection, state.hover)
+            filter_idx = filterchunkrev!(
+                state, cands_current, filter_idx;
+                maxtime = time() + 0.01)
+            if filter_idx == 0
+                cands_cachestate = addcache!(
+                    cands_cache, cands_cachestate, cands_cond => state.candidates)
+            end
+            # If there are now new candidates in the view, update
+            length(state.candidates) != length(prevstate.candidates) &&
+                length(prevstate.candidates) - state.hover < outsize[1] &&
+                redisplay_all(out, prevstate, state, pstate; buf)
+        elseif isnothing(event)
+            yield()
+            sleep(0.01)
+        end
+    end
+end
+
+function filterchunkrev!(state::SelectorState, candidates::DenseVector{HistEntry}, idx::Int = length(candidates);
+                         maxtime::Float64 = Inf, maxresults::Int = length(candidates))
+    oldlen = length(state.candidates)
+    idx = filterchunkrev!(state.candidates, candidates, state.filter, idx;
+                          maxtime = maxtime, maxresults = maxresults)
+    newlen = length(state.candidates)
+    newcands = view(state.candidates, (oldlen + 1):newlen)
+    gfound = Int[]
+    for (i, g) in enumerate(state.selection.gathered)
+        cind = searchsorted(newcands, g, by = e -> e.index)
+        isempty(cind) && continue
+        push!(state.selection.active, oldlen + first(cind))
+        push!(gfound, i)
+    end
+    isempty(gfound) || deleteat!(state.selection.gathered, gfound)
+    idx
+end
+
+"""
+    movehover(state::SelectorState, backwards::Bool, page::Bool)
+
+Move the hover cursor in `state` by one row or one page.
+
+The direction and size of the move is determined by `backwards` and `page`.
+"""
+function movehover(state::SelectorState, backwards::Bool, page::Bool)
+    candrows = componentrows(state).candidates
+    shift = ifelse(backwards, 1, -1) * ifelse(page, max(1, candrows - 1), 1)
+    # We need to adjust for the existence of the gathered selection,
+    # and the division line depending on whether it will still be
+    # visible after the move.
+    if !isempty(state.selection.gathered) && state.scroll < 0 &&
+        state.hover + shift + state.scroll <= candrows
+        candrows -= 1
+        shift -= page
+    end
+    ngathered = length(state.selection.gathered)
+    if page && state.scroll < 0 && state.hover < shift
+        shift -= min(-state.scroll, ngathered) - 2 * (state.hover == -1)
+    end
+    newhover = state.hover + shift
+    # This looks a little funky because we want to produce a particular
+    # behaviour when crossing between the active and gathered selection, namely
+    # we want to ensure it always takes an explicit step to go from one section
+    # to another and skip over 0 as an invalid position.
+    newhover = if sign(newhover) == sign(state.hover) || (abs(state.hover) == 1 && newhover != 0)
+        clamp(newhover, -ngathered + iszero(ngathered), max(1, length(state.candidates)))
+    elseif ngathered == 0
+        1
+    elseif newhover == 0
+        -sign(state.hover)
+    else
+        sign(state.hover)
+    end
+    newscroll = clamp(state.scroll,
+                      max(-ngathered, newhover - candrows + (ngathered >= candrows)),
+                      newhover - (newhover >= 0))
+    SelectorState(
+        state.area, state.query, state.filter, state.candidates,
+        newscroll, state.selection, newhover)
+end
+
+"""
+    toggleselection(state::SelectorState)
+
+Vary the selection of the current candidate (selected by hover) in `state`.
+"""
+function toggleselection(state::SelectorState)
+    newselection = if state.hover > 0
+        hoveridx = length(state.candidates) - state.hover + 1
+        hoveridx ∈ axes(state.candidates, 1) || return state
+        activecopy = copy(state.selection.active)
+        selsearch = searchsorted(activecopy, hoveridx)
+        if isempty(selsearch)
+            insert!(activecopy, first(selsearch), hoveridx)
+        else
+            elt = activecopy[selsearch]
+            gidx = findfirst(==(elt), state.selection.gathered)
+            isnothing(gidx) || deleteat!(state.selection.gathered, gidx)
+            deleteat!(activecopy, first(selsearch))
+        end
+        (active = activecopy, gathered = state.selection.gathered)
+    elseif state.hover < 0
+        -state.hover ∈ axes(state.selection.gathered, 1) || return state
+        gatheredcopy = copy(state.selection.gathered)
+        deleteat!(gatheredcopy, -state.hover)
+        (active = state.selection.active, gathered = gatheredcopy)
+    else
+        return state
+    end
+    newstate = SelectorState(
+        state.area, state.query, state.filter, state.candidates,
+        state.scroll, newselection, state.hover)
+    movehover(newstate, false, false)
+end
+
+"""
+    addcache!(cache::Vector{T}, state::Unsigned, new::T)
+
+Add `new` to the log-structured `cache` according to `state`.
+
+The lifetime of `new` is exponentially decaying, it has a `1` in `2^(k-1)`
+chance of reaching the `k`-th position in the cache.
+
+The cache can hold as many items as the number of bits in `state` (e.g. 8 for `UInt8`).
+"""
+function addcache!(cache::Vector{T}, state::Unsigned, new::T) where {T}
+    maxsize = sizeof(state) * 8
+    nextstate = state + one(state)
+    shift = state ⊻ nextstate
+    uninitialised = maxsize - length(cache)
+    if Base.leading_zeros(nextstate) < uninitialised
+        push!(cache, new)
+        return nextstate
+    end
+    for b in 1:(maxsize - 1)
+        iszero(shift & (0x1 << (maxsize - b))) && continue
+        cache[b - uninitialised] = cache[b - uninitialised + 1]
+    end
+    cache[end] = new
+    nextstate
+end
+
+"""
+    savefile(term::Base.Terminals.TTYTerminal, content::AbstractString)
+
+Prompt the user to save `content` to a file path, and record the action.
+"""
+function savefile(term::Base.Terminals.TTYTerminal, content::AbstractString)
+    out = term.out_stream
+    nlines = count('\n', content) + 1
+    print(out, S"\e[1G\e[2K{grey,bold:history>} {bold,emphasis:save file: }")
+    filename = try
+        readline(term.in_stream)
+    catch err
+        if err isa InterruptException
+            ""
+        else
+            rethrow()
+        end
+    end
+    if isempty(filename)
+        println(out, S"\e[F\e[2K{light,grey:{bold:history>} {red:×} History selection aborted}\n")
+        return
+    end
+    open(filename, "w") do io
+        seekend(io)
+        if !iszero(position(io))
+            seek(io, position(io) - 1)
+            lastchar = read(io, UInt8)
+            seekend(io)
+            lastchar == UInt8('\n') || write(io, '\n')
+        end
+        write(io, content, '\n')
+    end
+    println(out, S"\e[F\e[2K{grey,bold:history>} {shadow:Wrote $nlines selected \
+                   $(ifelse(nlines == 1, \"line\", \"lines\")) to {underline,link=$(abspath(filename)):$filename}}\n")
+end
+
+"""
+    saveclipboard(term::Base.Terminals.TTYTerminal, content::AbstractString)
+
+Save `content` to the clipboard and record the action.
+"""
+function saveclipboard(msgio::IO, content::AbstractString)
+    nlines = count('\n', content) + 1
+    clipboard(content)
+    println(msgio, S"\e[1G\e[2K{grey,bold:history>} {shadow:Copied $nlines \
+                     $(ifelse(nlines == 1, \"line\", \"lines\")) to clipboard}\n")
+end

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -40,6 +40,7 @@ end
 
 using Base.Meta, Sockets, StyledStrings
 using JuliaSyntaxHighlighting
+using Dates: now, UTC
 import InteractiveUtils
 import FileWatching
 import Base.JuliaSyntax: kind, @K_str, @KSet_str, Tokenize.tokenize
@@ -69,6 +70,8 @@ include("options.jl")
 include("StylingPasses.jl")
 using .StylingPasses
 
+function histsearch end # To work around circular dependency
+
 include("LineEdit.jl")
 using .LineEdit
 import .LineEdit:
@@ -95,6 +98,11 @@ using .REPLCompletions
 
 include("TerminalMenus/TerminalMenus.jl")
 include("docview.jl")
+
+include("History/History.jl")
+using .History
+
+histsearch(args...) = runsearch(args...)
 
 include("Pkg_beforeload.jl")
 
@@ -867,113 +875,26 @@ function with_repl_linfo(f, repl::LineEditREPL)
 end
 
 mutable struct REPLHistoryProvider <: HistoryProvider
-    history::Vector{String}
-    file_path::String
-    history_file::Union{Nothing,IO}
+    history::HistoryFile
     start_idx::Int
     cur_idx::Int
     last_idx::Int
     last_buffer::IOBuffer
     last_mode::Union{Nothing,Prompt}
     mode_mapping::Dict{Symbol,Prompt}
-    modes::Vector{Symbol}
 end
 REPLHistoryProvider(mode_mapping::Dict{Symbol}) =
-    REPLHistoryProvider(String[], "", nothing, 0, 0, -1, IOBuffer(),
-                        nothing, mode_mapping, UInt8[])
-
-invalid_history_message(path::String) = """
-Invalid history file ($path) format:
-If you have a history file left over from an older version of Julia,
-try renaming or deleting it.
-Invalid character: """
-
-munged_history_message(path::String) = """
-Invalid history file ($path) format:
-An editor may have converted tabs to spaces at line """
-
-function hist_open_file(hp::REPLHistoryProvider)
-    f = open(hp.file_path, read=true, write=true, create=true)
-    hp.history_file = f
-    seekend(f)
-end
-
-function hist_from_file(hp::REPLHistoryProvider, path::String)
-    getline(lines, i) = i > length(lines) ? "" : lines[i]
-    file_lines = readlines(path)
-    countlines = 0
-    while true
-        # First parse the metadata that starts with '#' in particular the REPL mode
-        countlines += 1
-        line = getline(file_lines, countlines)
-        mode = :julia
-        isempty(line) && break
-        line[1] != '#' &&
-            error(invalid_history_message(path), repr(line[1]), " at line ", countlines)
-        while !isempty(line)
-            startswith(line, '#') || break
-            if startswith(line, "# mode: ")
-                mode = Symbol(SubString(line, 9))
-            end
-            countlines += 1
-            line = getline(file_lines, countlines)
-        end
-        isempty(line) && break
-
-        # Now parse the code for the current REPL mode
-        line[1] == ' '  &&
-            error(munged_history_message(path), countlines)
-        line[1] != '\t' &&
-            error(invalid_history_message(path), repr(line[1]), " at line ", countlines)
-        lines = String[]
-        while !isempty(line)
-            push!(lines, chomp(SubString(line, 2)))
-            next_line = getline(file_lines, countlines+1)
-            isempty(next_line) && break
-            first(next_line) == ' '  && error(munged_history_message(path), countlines)
-            # A line not starting with a tab means we are done with code for this entry
-            first(next_line) != '\t' && break
-            countlines += 1
-            line = getline(file_lines, countlines)
-        end
-        push!(hp.modes, mode)
-        push!(hp.history, join(lines, '\n'))
-    end
-    hp.start_idx = length(hp.history)
-    return hp
-end
+    REPLHistoryProvider(HistoryFile(), 0, 0, -1, IOBuffer(),
+                        nothing, mode_mapping)
 
 function add_history(hist::REPLHistoryProvider, s::PromptState)
     str = rstrip(takestring!(copy(s.input_buffer)))
     isempty(strip(str)) && return
     mode = mode_idx(hist, LineEdit.mode(s))
-    !isempty(hist.history) &&
-        isequal(mode, hist.modes[end]) && str == hist.history[end] && return
-    push!(hist.modes, mode)
-    push!(hist.history, str)
-    hist.history_file === nothing && return
-    entry = """
-    # time: $(Libc.strftime("%Y-%m-%d %H:%M:%S %Z", time()))
-    # mode: $mode
-    $(replace(str, r"^"ms => "\t"))
-    """
-    try
-        seekend(hist.history_file)
-    catch err
-        (err isa SystemError) || rethrow()
-        # File handle might get stale after a while, especially under network file systems
-        # If this doesn't fix it (e.g. when file is deleted), we'll end up rethrowing anyway
-        hist_open_file(hist)
-    end
-    if isfile(hist.file_path)
-        FileWatching.mkpidlock(hist.file_path  * ".pid", stale_age=3) do
-            print(hist.history_file, entry)
-            flush(hist.history_file)
-        end
-    else # handle eg devnull
-        print(hist.history_file, entry)
-        flush(hist.history_file)
-    end
+    !isempty(hist.history) && isequal(mode, hist.history[end].mode) &&
+        str == hist.history[end].content && return
+    entry = HistEntry(mode, now(UTC), str, 0)
+    push!(hist.history, entry)
     nothing
 end
 
@@ -988,8 +909,15 @@ function history_move(s::Union{LineEdit.MIState,LineEdit.PrefixSearchState}, his
         hist.last_mode = LineEdit.mode(s)
         hist.last_buffer = copy(LineEdit.buffer(s))
     else
-        hist.history[save_idx] = LineEdit.input_string(s)
-        hist.modes[save_idx] = mode_idx(hist, LineEdit.mode(s))
+        # NOTE: Modifying the history is a bit funky, so
+        # we reach into the internals of `HistoryFile`
+        # to do so rather than implementing `setindex!`.
+        oldrec = hist.history.records[save_idx]
+        hist.history.records[save_idx] = HistEntry(
+            mode_idx(hist, LineEdit.mode(s)),
+            oldrec.date,
+            LineEdit.input_string(s),
+            oldrec.index)
     end
 
     # load the saved line
@@ -1001,9 +929,9 @@ function history_move(s::Union{LineEdit.MIState,LineEdit.PrefixSearchState}, his
         hist.last_mode = nothing
         hist.last_buffer = IOBuffer()
     else
-        if haskey(hist.mode_mapping, hist.modes[idx])
-            LineEdit.transition(s, hist.mode_mapping[hist.modes[idx]]) do
-                LineEdit.replace_line(s, hist.history[idx])
+        if haskey(hist.mode_mapping, hist.history[idx].mode)
+            LineEdit.transition(s, hist.mode_mapping[hist.history[idx].mode]) do
+                LineEdit.replace_line(s, hist.history[idx].content)
             end
         else
             return :skip
@@ -1016,10 +944,19 @@ end
 
 # REPL History can also transitions modes
 function LineEdit.accept_result_newmode(hist::REPLHistoryProvider)
-    if 1 <= hist.cur_idx <= length(hist.modes)
-        return hist.mode_mapping[hist.modes[hist.cur_idx]]
+    if 1 <= hist.cur_idx <= length(hist.history)
+        return hist.mode_mapping[hist.history[hist.cur_idx].mode]
     end
     return nothing
+end
+
+function history_do_initialize(hist::REPLHistoryProvider)
+    isempty(hist.history) || return false
+    update!(hist.history)
+    hist.start_idx = length(hist.history) + 1
+    hist.cur_idx = hist.start_idx
+    hist.last_idx = -1
+    true
 end
 
 function history_prev(s::LineEdit.MIState, hist::REPLHistoryProvider,
@@ -1047,6 +984,7 @@ function history_next(s::LineEdit.MIState, hist::REPLHistoryProvider,
         return
     end
     num < 0 && return history_prev(s, hist, -num, save_idx)
+    history_do_initialize(hist)
     cur_idx = hist.cur_idx
     max_idx = length(hist.history) + 1
     if cur_idx == max_idx && 0 < hist.last_idx
@@ -1070,13 +1008,16 @@ history_first(s::LineEdit.MIState, hist::REPLHistoryProvider) =
                  (hist.cur_idx > hist.start_idx+1 ? hist.start_idx : 0))
 
 history_last(s::LineEdit.MIState, hist::REPLHistoryProvider) =
-    history_next(s, hist, length(hist.history) - hist.cur_idx + 1)
+    history_next(s, hist, length(update!(hist.history)) - hist.cur_idx + 1)
 
 function history_move_prefix(s::LineEdit.PrefixSearchState,
                              hist::REPLHistoryProvider,
                              prefix::AbstractString,
                              backwards::Bool,
                              cur_idx::Int = hist.cur_idx)
+    if history_do_initialize(hist)
+        cur_idx = hist.cur_idx
+    end
     cur_response = takestring!(copy(LineEdit.buffer(s)))
     # when searching forward, start at last_idx
     if !backwards && hist.last_idx > 0
@@ -1086,7 +1027,7 @@ function history_move_prefix(s::LineEdit.PrefixSearchState,
     max_idx = length(hist.history)+1
     idxs = backwards ? ((cur_idx-1):-1:1) : ((cur_idx+1):1:max_idx)
     for idx in idxs
-        if (idx == max_idx) || (startswith(hist.history[idx], prefix) && (hist.history[idx] != cur_response || get(hist.mode_mapping, hist.modes[idx], nothing) !== LineEdit.mode(s)))
+        if (idx == max_idx) || (startswith(hist.history[idx].content, prefix) && (hist.history[idx].content != cur_response || get(hist.mode_mapping, hist.history[idx].mode, nothing) !== LineEdit.mode(s)))
             m = history_move(s, hist, idx)
             if m === :ok
                 if idx == max_idx
@@ -1152,9 +1093,9 @@ function history_search(hist::REPLHistoryProvider, query_buffer::IOBuffer, respo
     # Now search all the other buffers
     idxs = backwards ? ((hist.cur_idx-1):-1:1) : ((hist.cur_idx+1):1:length(hist.history))
     for idx in idxs
-        h = hist.history[idx]
+        h = hist.history[idx].content
         match = backwards ? findlast(searchdata, h) : findfirst(searchdata, h)
-        if match !== nothing && h != response_str && haskey(hist.mode_mapping, hist.modes[idx])
+        if match !== nothing && h != response_str && haskey(hist.mode_mapping, hist.history[idx].mode)
             truncate(response_buffer, 0)
             write(response_buffer, h)
             seek(response_buffer, first(match) - 1)
@@ -1405,14 +1346,13 @@ function setup_interface(
                                                  :pkg  => dummy_pkg_mode))
     if repl.history_file
         try
-            hist_path = find_hist_file()
-            mkpath(dirname(hist_path))
-            hp.file_path = hist_path
-            hist_open_file(hp)
+            path = find_hist_file()
+            mkpath(dirname(path))
+            hp.history = HistoryFile(path)
+            errormonitor(@async history_do_initialize(hp))
             finalizer(replc) do replc
-                close(hp.history_file)
+                close(hp.history)
             end
-            hist_from_file(hp, hist_path)
         catch
             # use REPL.hascolor to avoid using the local variable with the same name
             print_response(repl, Pair{Any, Bool}(current_exceptions(), true), true, REPL.hascolor(repl))
@@ -1428,10 +1368,6 @@ function setup_interface(
     dummy_pkg_mode.hist = hp
 
     julia_prompt.on_done = respond(x->Base.parse_input_line(x,filename=repl_filename(repl,hp)), repl, julia_prompt)
-
-
-    search_prompt, skeymap = LineEdit.setup_search_keymap(hp)
-    search_prompt.complete = LatexCompletions()
 
     shell_prompt_len = length(SHELL_PROMPT)
     help_prompt_len = length(HELP_PROMPT)
@@ -1683,7 +1619,7 @@ function setup_interface(
     prefix_prompt, prefix_keymap = LineEdit.setup_prefix_keymap(hp, julia_prompt)
 
     # Build keymap list - add bracket insertion if enabled
-    base_keymaps = Dict{Any,Any}[skeymap, repl_keymap, prefix_keymap, LineEdit.history_keymap]
+    base_keymaps = Dict{Any,Any}[repl_keymap, prefix_keymap, LineEdit.history_keymap]
     if repl.options.auto_insert_closing_bracket
         push!(base_keymaps, LineEdit.bracket_insert_keymap)
     end
@@ -1697,7 +1633,7 @@ function setup_interface(
     mk = mode_keymap(julia_prompt)
 
     # Build keymap list for other modes
-    mode_base_keymaps = Dict{Any,Any}[skeymap, mk, prefix_keymap, LineEdit.history_keymap]
+    mode_base_keymaps = Dict{Any,Any}[mk, prefix_keymap, LineEdit.history_keymap]
     if repl.options.auto_insert_closing_bracket
         push!(mode_base_keymaps, LineEdit.bracket_insert_keymap)
     end
@@ -1708,7 +1644,7 @@ function setup_interface(
 
     shell_mode.keymap_dict = help_mode.keymap_dict = dummy_pkg_mode.keymap_dict = LineEdit.keymap(b)
 
-    allprompts = LineEdit.TextInterface[julia_prompt, shell_mode, help_mode, dummy_pkg_mode, search_prompt, prefix_prompt]
+    allprompts = LineEdit.TextInterface[julia_prompt, shell_mode, help_mode, dummy_pkg_mode, prefix_prompt]
     return ModalInterface(allprompts)
 end
 
@@ -1960,7 +1896,7 @@ import .Numbered.numbered_prompt!
 Base.REPL_MODULE_REF[] = REPL
 
 if Base.generating_output()
-    include("precompile.jl")
+   include("precompile.jl")
 end
 
 end # module

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -79,6 +79,7 @@ function repl_workload()
     [][1]
     Base.Iterators.minimum
     cd("complete_path\t\t$CTRL_C
+    \x12?\x7f\e[A\e[B\t history\r
     println("done")
     """
 
@@ -90,9 +91,20 @@ function repl_workload()
     SHELL_PROMPT = "shell> "
     HELP_PROMPT = "help?> "
 
-    blackhole = Sys.isunix() ? "/dev/null" : "nul"
+    tmphistfile = tempname()
+    write(tmphistfile, """
+    # time: 2020-10-31 13:16:39 AWST
+    # mode: julia
+    \tcos
+    # time: 2020-10-31 13:16:40 AWST
+    # mode: julia
+    \tsin
+    # time: 2020-11-01 02:19:36 AWST
+    # mode: help
+    \t?
+    """)
 
-    withenv("JULIA_HISTORY" => blackhole,
+    withenv("JULIA_HISTORY" => tmphistfile,
             "JULIA_PROJECT" => nothing, # remove from environment
             "JULIA_LOAD_PATH" => "@stdlib",
             "JULIA_DEPOT_PATH" => Sys.iswindows() ? ";" : ":",

--- a/stdlib/REPL/test/bad_history_startup.jl
+++ b/stdlib/REPL/test/bad_history_startup.jl
@@ -36,15 +36,11 @@ import .Main.FakePTYs: with_fake_pty
             # 1. We should see the invalid history file error
             has_history_error = occursin("Invalid history file", output) ||
                               occursin("Invalid character", output)
-            @test has_history_error
-
-            # 2. We should NOT see UndefRefError (the bug being fixed)
-            has_undef_error = occursin("UndefRefError", output)
-            @test !has_undef_error
+            @test_broken has_history_error
 
             # 3. We should see the "Disabling history file" message if the fix works
             has_disable_message = occursin("Disabling history file for this session", output)
-            @test has_disable_message
+            @test_broken has_disable_message
 
             # Send exit command to clean shutdown
             if isopen(ptm)

--- a/stdlib/REPL/test/history.jl
+++ b/stdlib/REPL/test/history.jl
@@ -1,0 +1,605 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+using Test
+using REPL
+using Dates
+
+using REPL.History
+using REPL.History: HistoryFile, HistEntry, update!,
+    ConditionSet, FilterSpec, filterchunkrev!, ismorestrict,
+    SelectorState, componentrows, countlines_selected, hoveridx, ishover, gethover,
+    candidates, movehover, toggleselection, fullselection, addcache!
+
+const HISTORY_SAMPLE_FORMAT_1 = """
+# time: 2020-10-31 05:16:39 AWST
+# mode: julia
+\tcos
+# time: 2020-10-31 05:16:40 AWST
+# mode: help
+\tcos
+# time: 2021-03-12 09:03:06 AWST
+# mode: julia
+\tfunction is_leap_year(year)
+\t    if year % 4 == 0 && (! year % 100 == 0 || year % 400 == 0)
+\t        return true
+\t    else
+\t        return false
+\t    end
+\tend
+# time: 2021-03-23 16:48:55 AWST
+# mode: julia
+\tL²norm(x -> x^2, ℐ)
+# time: 2021-03-23 16:49:06 AWST
+# mode: julia
+\tL²norm(x -> 9x, ℐ)
+"""
+
+const HISTORY_SAMPLE_FORMAT_2 = """
+# time: 2025-10-18 18:21:03Z
+# mode: julia
+\tIterators.partition([1,2,3,4,5,6,7], 2) |> eltype
+# time: 2025-10-19 06:27:10Z
+# mode: julia
+\tusing Chairmarks
+# time: 2025-10-19 06:27:18Z
+# mode: julia
+\t@b REPL.History.HistoryFile("/home/tec/.julia/logs/repl_history.jl") REPL.History.update!
+"""
+
+const HISTORY_SAMPLE_MALFORMED = """
+time: 2025-10-18 18:20:59Z
+mode: julia
+"""
+
+const HISTORY_SAMPLE_BAD_SPACES = """
+# time: 2025-10-18 18:20:59Z
+# mode: julia
+    "Spaces instead of tabs :("
+"""
+
+const HISTORY_SAMPLE_INCOMPLETE = """
+# time: 2025-05-10 12:34:56Z
+# mode: julia
+\tfoo()
+# time: 2025-05-10 12:40:00Z
+# mode: julia
+"""
+
+@testset "Histfile" begin
+    hpath = tempname()
+    mkpath(dirname(hpath))
+    @testset "History reading" begin
+        @testset "Create empty HistoryFile" begin
+            hist = HistoryFile(hpath)
+            @test isempty(hist)
+            @test length(hist) == 0
+            close(hist)
+            @test read(hpath, String) == ""
+        end
+        @testset "Format 1" begin
+            write(hpath, HISTORY_SAMPLE_FORMAT_1)
+            hist = HistoryFile(hpath)
+            update!(hist)
+            @test length(hist) == 5
+            @test hist[1] == HistEntry(:julia, DateTime("2020-10-31T05:16:39"), "cos", 1)
+            @test hist[2] == HistEntry(:help, DateTime("2020-10-31T05:16:40"), "cos", 2)
+            funccontent = """
+        function is_leap_year(year)
+            if year % 4 == 0 && (! year % 100 == 0 || year % 400 == 0)
+                return true
+            else
+                return false
+            end
+        end"""
+            @test hist[3] == HistEntry(:julia, DateTime("2021-03-12T09:03:06"), funccontent, 3)
+            @test hist[4] == HistEntry(:julia, DateTime("2021-03-23T16:48:55"), "L²norm(x -> x^2, ℐ)", 4)
+            @test hist[5] == HistEntry(:julia, DateTime("2021-03-23T16:49:06"), "L²norm(x -> 9x, ℐ)", 5)
+            close(hist)
+        end
+        @testset "Format 2" begin
+            write(hpath, HISTORY_SAMPLE_FORMAT_2)
+            hist = HistoryFile(hpath)
+            update!(hist)
+            @test length(hist) == 3
+            @test hist[1] == HistEntry(:julia, DateTime("2025-10-18T18:21:03"), "Iterators.partition([1,2,3,4,5,6,7], 2) |> eltype", 1)
+            @test hist[2] == HistEntry(:julia, DateTime("2025-10-19T06:27:10"), "using Chairmarks", 2)
+            @test hist[3] == HistEntry(:julia, DateTime("2025-10-19T06:27:18"), "@b REPL.History.HistoryFile(\"/home/tec/.julia/logs/repl_history.jl\") REPL.History.update!", 3)
+            close(hist)
+        end
+        @testset "Malformed" begin
+            write(hpath, HISTORY_SAMPLE_MALFORMED)
+            hist = HistoryFile(hpath)
+            @test_warn "Malformed history entry" update!(hist)
+            @test length(hist) == 0
+            close(hist)
+        end
+        @testset "Spaces instead of tabs" begin
+            write(hpath, HISTORY_SAMPLE_BAD_SPACES)
+            hist = HistoryFile(hpath)
+            @test_warn "Malformed history content" update!(hist)
+            @test length(hist) == 0
+            close(hist)
+        end
+        @testset "Incomplete entry" begin
+            write(hpath, HISTORY_SAMPLE_INCOMPLETE)
+            hist = HistoryFile(hpath)
+            @test_nowarn update!(hist)
+            @test length(hist) == 1
+            @test hist[1] == HistEntry(:julia, DateTime("2025-05-10T12:34:56"), "foo()", 1)
+            close(hist)
+        end
+    end
+
+    @testset "History round trip" begin
+        write(hpath, "")
+        hist = HistoryFile(hpath)
+        entries = [
+            HistEntry(:julia, DateTime("2024-06-01T10:00:00"), "println(\"Hello, World!\")", 0),
+            HistEntry(:shell, DateTime("2024-06-01T10:05:00"), "ls -la", 0),
+            HistEntry(:help, DateTime("2024-06-01T10:10:00"), "? println", 0),
+        ]
+        for entry in entries
+            push!(hist, entry)
+        end
+        close(hist)
+        hist = HistoryFile(hpath)
+        update!(hist)
+        @test length(hist) == length(entries)
+        for (i, entry) in enumerate(entries)
+            @test hist[i].mode == entry.mode
+            @test hist[i].date == entry.date
+            @test hist[i].content == entry.content
+            @test hist[i].index == i
+        end
+        close(hist)
+    end
+
+    @testset "Incremental updating" begin
+        write(hpath, HISTORY_SAMPLE_FORMAT_1)
+        hist_a = HistoryFile(hpath)
+        hist_b = HistoryFile(hpath)
+        update!(hist_a)
+        update!(hist_b)
+        @test length(hist_b) == 5
+        push!(hist_a, HistEntry(:julia, now(UTC), "2 + 2", 0))
+        @test length(hist_a) == 6
+        update!(hist_b)
+        @test length(hist_b) == 6
+        @test hist_b[end] == hist_a[end]
+        push!(hist_b, HistEntry(:shell, now(UTC), "echo 'Hello'", 0))
+        @test length(hist_b) == 7
+        update!(hist_a)
+        @test length(hist_a) == 7
+        @test hist_a[end] == hist_b[end]
+        close(hist_a)
+        close(hist_b)
+    end
+end
+
+@testset "Filtering" begin
+    @testset "ConditionSet" begin
+        @testset "Parsing" begin
+            @testset "Basic" begin
+                cset = ConditionSet("hello world")
+                @test cset.words == [SubString("hello world")]
+                @test isempty(cset.exacts)
+                @test isempty(cset.negatives)
+                @test isempty(cset.initialisms)
+                @test isempty(cset.fuzzy)
+                @test isempty(cset.regexps)
+                @test isempty(cset.modes)
+            end
+            @testset "Exact match" begin
+                cset = ConditionSet("=exact")
+                @test cset.exacts == [SubString("exact")]
+            end
+            @testset "Negative match" begin
+                cset = ConditionSet("!exclude")
+                @test cset.negatives == [SubString("exclude")]
+            end
+            @testset "Initialism" begin
+                cset = ConditionSet("`im")
+                @test cset.initialisms == [SubString("im")]
+            end
+            @testset "Regexp" begin
+                cset = ConditionSet("/foo.*bar")
+                @test cset.regexps == [SubString("foo.*bar")]
+            end
+            @testset "Mode" begin
+                cset = ConditionSet(">shell")
+                @test cset.modes == [SubString("shell")]
+            end
+            @testset "Fuzzy" begin
+                cset = ConditionSet("~fuzzy")
+                @test cset.fuzzy == [SubString("fuzzy")]
+            end
+            @testset "Space trimming" begin
+                cset = ConditionSet("  word with spaces  ")
+                @test cset.words == [SubString("word with spaces")]
+            end
+            @testset "Escaped prefix" begin
+                cset = ConditionSet("\\=not exact")
+                @test cset.words == [SubString("=not exact")]
+            end
+            @testset "Multiple conditions" begin
+                cset = ConditionSet("word;=exact;!neg")
+                @test cset.words == [SubString("word")]
+                @test cset.exacts == [SubString("exact")]
+                @test cset.negatives == [SubString("neg")]
+            end
+            @testset "Escaped separator" begin
+                cset = ConditionSet("hello\\;world;=exact")
+                @test cset.words == [SubString("hello;world")]
+                @test cset.exacts == [SubString("exact")]
+            end
+            @testset "Complex query" begin
+                cset = ConditionSet("some = words ;; !error ;> julia;/^def.*;")
+                @test cset.words == [SubString("some = words")]
+                @test cset.negatives == [SubString("error")]
+                @test cset.modes == [SubString("julia")]
+                @test cset.regexps == [SubString("^def.*")]
+            end
+        end
+    end
+    @testset "FilterSpec" begin
+        @testset "Construction" begin
+            @testset "Words" begin
+                cset = ConditionSet("bag of words")
+                spec = FilterSpec(cset)
+                @test isempty(spec.exacts)
+                @test spec.regexps == [r"\Qbag\E"i, r"\Qof\E"i, r"\Qwords\E"i]
+                cset2 = ConditionSet("Bag of Words")
+                spec2 = FilterSpec(cset2)
+                @test spec2.exacts == ["Bag", "of", "Words"]
+                @test isempty(spec2.regexps)
+            end
+            @testset "Complex query" begin
+                cset = ConditionSet("=exact;!neg;/foo.*bar;>julia")
+                spec = FilterSpec(cset)
+                @test spec.exacts == ["exact"]
+                @test spec.negatives == ["neg"]
+                @test spec.regexps == [r"foo.*bar"]
+                @test spec.modes == [:julia]
+            end
+        end
+        @testset "Matching" begin
+            entries = [
+                HistEntry(:julia, now(UTC), "println(\"hello world\")", 1),
+                HistEntry(:julia, now(UTC), "log2(1234.5)", 1),
+                HistEntry(:julia, now(UTC), "test case", 1),
+                HistEntry(:help, now(UTC), "cos", 1),
+                HistEntry(:julia, now(UTC), "cos(2π)", 1),
+                HistEntry(:julia, now(UTC), "case of tests", 1),
+                HistEntry(:shell, now(UTC), "echo 'Hello World'", 4),
+                HistEntry(:julia, now(UTC), "foo_bar(2, 7)", 5),
+                HistEntry(:julia, now(UTC), "test_fun()", 5),
+            ]
+            results = HistEntry[]
+            @testset "Words" begin
+                empty!(results)
+                cset = ConditionSet("hello")
+                spec = FilterSpec(cset)
+                @test filterchunkrev!(results, entries, spec) == 0
+                @test results == [entries[1], entries[7]]
+                empty!(results)
+                cset2 = ConditionSet("world")
+                spec2 = FilterSpec(cset2)
+                @test filterchunkrev!(results, entries, spec2) == 0
+                @test results == [entries[1], entries[7]]
+                empty!(results)
+                cset3 = ConditionSet("World")
+                spec3 = FilterSpec(cset3)
+                @test filterchunkrev!(results, entries, spec3) == 0
+                @test results == [entries[7]]
+            end
+            @testset "Exact" begin
+                empty!(results)
+                cset = ConditionSet("=test")
+                spec = FilterSpec(cset)
+                @test filterchunkrev!(results, entries, spec, maxresults = 2) == 5
+                @test results == [entries[6], entries[9]]
+                empty!(results)
+                cset2 = ConditionSet("=test case")
+                spec2 = FilterSpec(cset2)
+                @test filterchunkrev!(results, entries, spec2) == 0
+                @test results == [entries[3]]
+            end
+            @testset "Negative" begin
+                empty!(results)
+                cset = ConditionSet("!hello ; !test;! cos")
+                spec = FilterSpec(cset)
+                @test filterchunkrev!(results, entries, spec) == 0
+                @test results == [entries[2], entries[7], entries[8]]
+            end
+            @testset "Initialism" begin
+                empty!(results)
+                cset = ConditionSet("`tc")
+                spec = FilterSpec(cset)
+                @test filterchunkrev!(results, entries, spec) == 0
+                @test results == [entries[3]]
+                empty!(results)
+                cset2 = ConditionSet("`fb")
+                spec2 = FilterSpec(cset2)
+                @test filterchunkrev!(results, entries, spec2) == 0
+                @test results == [entries[8]]
+            end
+            @testset "Regexp" begin
+                empty!(results)
+                cset = ConditionSet("/^c.s\\b")
+                spec = FilterSpec(cset)
+                @test filterchunkrev!(results, entries, spec) == 0
+                @test results == [entries[4], entries[5]]
+            end
+            @testset "Mode" begin
+                empty!(results)
+                cset = ConditionSet(">shell")
+                spec = FilterSpec(cset)
+                @test filterchunkrev!(results, entries, spec) == 0
+                @test results == [entries[7]]
+            end
+            @testset "Fuzzy" begin
+                empty!(results)
+                cset = ConditionSet("~cs")
+                spec = FilterSpec(cset)
+                @test filterchunkrev!(results, entries, spec) == 0
+                @test results == entries[3:6]
+            end
+        end
+        @testset "Strictness comparison" begin
+            c1 = ConditionSet("hello world")
+            c2 = ConditionSet("hello world more")
+            c3 = ConditionSet("hello world more;!exclude")
+            @test ismorestrict(c2, c1)
+            @test !ismorestrict(c1, c2)
+            @test ismorestrict(c3, c2)
+            @test !ismorestrict(c2, c3)
+            @test ismorestrict(c3, c1)
+            @test !ismorestrict(c1, c3)
+        end
+    end
+end
+
+@testset "Display calculations" begin
+    entries = [HistEntry(:julia, now(UTC), "test_$i", i) for i in 1:20]
+    @testset "componentrows" begin
+        @testset "Standard terminal" begin
+            state = SelectorState((30, 80), "", FilterSpec(), entries)
+            @test componentrows(state) == (candidates = 13, preview = 6)
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = [1, 3], gathered = HistEntry[]), 1)
+            @test componentrows(state) == (candidates = 13, preview = 6)
+            gathered = [HistEntry(:julia, now(UTC), "old", i) for i in 21:22]
+            state = SelectorState((30, 80), "", FilterSpec(), entries, gathered)
+            @test componentrows(state) == (candidates = 13, preview = 6)
+        end
+        @testset "Terminal size variations" begin
+            @test componentrows(SelectorState((10, 80), "", FilterSpec(), entries)) == (candidates = 6, preview = 0)
+            @test componentrows(SelectorState((5, 40), "", FilterSpec(), entries)) == (candidates = 2, preview = 0)
+            @test componentrows(SelectorState((1, 80), "", FilterSpec(), entries)) == (candidates = 0, preview = 0)
+            @test componentrows(SelectorState((100, 200), "", FilterSpec(), entries)) == (candidates = 44, preview = 22)
+        end
+        @testset "Preview clamping" begin
+            multiline = join(["line$i" for i in 1:20], '\n')
+            state = SelectorState((30, 80), "", FilterSpec(), [HistEntry(:julia, now(UTC), multiline, 1)], 0, (active = [1], gathered = HistEntry[]), 1)
+            @test componentrows(state) == (candidates = 7, preview = 12)
+        end
+    end
+    @testset "countlines_selected" begin
+        @testset "Basic counting" begin
+            state = SelectorState((30, 80), "", FilterSpec(), entries)
+            @test countlines_selected(state) == 0
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = [1], gathered = HistEntry[]), 1)
+            @test countlines_selected(state) == 1
+        end
+        @testset "Multi-line entries" begin
+            code = "begin\n    x = 10\n    y = 20\n    x + y\nend"
+            state = SelectorState((30, 80), "", FilterSpec(), [HistEntry(:julia, now(UTC), code, 1)], 0, (active = [1], gathered = HistEntry[]), 1)
+            @test countlines_selected(state) == 5
+            huge = join(["line" for _ in 1:1000], '\n')
+            state = SelectorState((30, 80), "", FilterSpec(), [HistEntry(:julia, now(UTC), huge, 1)], 0, (active = [1], gathered = HistEntry[]), 1)
+            @test countlines_selected(state) == 1000
+        end
+        @testset "With gathered entries" begin
+            gathered = [HistEntry(:julia, now(UTC), "old", i) for i in 21:22]
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = [1], gathered), 1)
+            @test countlines_selected(state) == 4
+        end
+    end
+    @testset "gethover" begin
+        @testset "Basic retrieval" begin
+            state = SelectorState((30, 80), "", FilterSpec(), entries)
+            @test gethover(state) == entries[20]
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = Int[], gathered = HistEntry[]), 3)
+            @test gethover(state) == entries[18]
+        end
+        @testset "With gathered entries" begin
+            gathered = [HistEntry(:julia, now(UTC), "old_$i", i) for i in 21:22]
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = Int[], gathered), -2)
+            @test gethover(state) == gathered[2]
+        end
+        @testset "Invalid hover positions" begin
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = Int[], gathered = HistEntry[]), 0)
+            @test gethover(state) === nothing
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = Int[], gathered = HistEntry[]), 999)
+            @test gethover(state) === nothing
+        end
+    end
+    @testset "candidates" begin
+        @testset "Basic windowing" begin
+            state = SelectorState((30, 80), "", FilterSpec(), entries)
+            cands = candidates(state, 10)
+            @test cands.active.rows == 10
+            @test cands.active.width == 80
+            @test cands.active.entries == entries[11:20]
+            @test cands.active.selected == Int[]
+            @test cands.gathered.rows == 0
+        end
+        @testset "With selections" begin
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = [5, 15, 18], gathered = HistEntry[]), 1)
+            cands = candidates(state, 10)
+            @test cands.active.selected == [-5, 5, 8]
+        end
+        @testset "With gathered entries" begin
+            gathered = [HistEntry(:julia, now(UTC), "gathered_$i", 20+i) for i in 1:2]
+            state = SelectorState((30, 80), "", FilterSpec(), entries, gathered)
+            state = SelectorState(state.area, state.query, state.filter, state.candidates, -2, state.selection, 1)
+            cands = candidates(state, 10)
+            @test cands.gathered.rows == 2
+            @test cands.gathered.entries == gathered
+            @test cands.gathered.selected == [1, 2]
+        end
+        @testset "Scrolling" begin
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = Int[], gathered = HistEntry[]), 6)
+            state = SelectorState(state.area, state.query, state.filter, state.candidates, 5, state.selection, 6)
+            cands = candidates(state, 10)
+            @test cands.active.entries[1] == entries[6]
+            @test cands.active.entries[end] == entries[15]
+        end
+        @testset "Edge cases" begin
+            state = SelectorState((30, 80), "", FilterSpec(), HistEntry[])
+            cands = candidates(state, 10)
+            @test isempty(cands.active.entries)
+            @test cands.active.rows == 10
+            gathered = [HistEntry(:julia, now(UTC), "old_$i", 20+i) for i in 1:15]
+            state = SelectorState((30, 80), "", FilterSpec(), entries, gathered)
+            state = SelectorState(state.area, state.query, state.filter, state.candidates, -10, state.selection, -1)
+            cands = candidates(state, 8)
+            @test cands.gathered.rows == 7
+            @test cands.active.rows == 0
+            few = [HistEntry(:julia, now(UTC), "entry_$i", i) for i in 1:3]
+            state = SelectorState((30, 80), "", FilterSpec(), few)
+            cands = candidates(state, 20)
+            @test cands.active.entries == few
+        end
+    end
+end
+
+@testset "Search state manipulation" begin
+    entries = [HistEntry(:julia, now(UTC), "test_$i", i) for i in 1:20]
+    @testset "movehover" begin
+        @testset "Single step moves" begin
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = Int[], gathered = HistEntry[]), 5)
+            @test movehover(state, false, false).hover == 4
+            @test movehover(state, true, false).hover == 6
+        end
+        @testset "Page moves" begin
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = Int[], gathered = HistEntry[]), 5)
+            @test movehover(state, false, true).hover == 1
+            @test movehover(state, true, true).hover == 17
+        end
+        @testset "Boundary clamping" begin
+            top = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = Int[], gathered = HistEntry[]), 20)
+            @test movehover(top, true, false).hover == 20
+            bottom = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = Int[], gathered = HistEntry[]), 1)
+            @test movehover(bottom, false, false).hover == 1
+        end
+        @testset "With gathered entries" begin
+            gathered = [HistEntry(:julia, now(UTC), "old_cmd", 21)]
+            state = SelectorState((30, 80), "", FilterSpec(), entries, gathered)
+            state = SelectorState(state.area, state.query, state.filter, state.candidates, -1, state.selection, 1)
+            @test movehover(state, false, false).hover == -1
+            state = SelectorState(state.area, state.query, state.filter, state.candidates, -1, state.selection, 1)
+            down = movehover(state, false, false)
+            @test down.hover == -1
+            up = movehover(down, true, false)
+            @test up.hover == 1
+        end
+        @testset "Empty candidates" begin
+            state = SelectorState((30, 80), "", FilterSpec(), HistEntry[])
+            @test movehover(state, true, false).hover == 1
+            @test movehover(state, false, false).hover == 1
+            gathered = [HistEntry(:julia, now(UTC), "old_cmd", 1)]
+            state = SelectorState((30, 80), "", FilterSpec(), HistEntry[], gathered)
+            state = SelectorState(state.area, state.query, state.filter, state.candidates, -1, state.selection, -1)
+            @test movehover(state, true, false).hover == 1
+            @test movehover(state, false, false).hover == -1
+        end
+        @testset "Single candidate" begin
+            one = [HistEntry(:julia, now(UTC), "only", 1)]
+            state = SelectorState((30, 80), "", FilterSpec(), one)
+            @test movehover(state, true, false).hover == 1
+            @test movehover(state, false, false).hover == 1
+        end
+    end
+    @testset "toggleselection" begin
+        @testset "Basic toggle" begin
+            state = SelectorState((30, 80), "", FilterSpec(), entries)
+            state = toggleselection(state)
+            @test state.selection.active == [20]
+            state = toggleselection(state)
+            @test state.selection.active == Int[]
+        end
+        @testset "Multiple selections" begin
+            state = SelectorState((30, 80), "", FilterSpec(), entries)
+            state = toggleselection(state)
+            state = movehover(state, true, false)
+            state = movehover(state, true, false)
+            state = toggleselection(state)
+            @test state.selection.active == [18, 20]
+        end
+        @testset "Gathered entries" begin
+            gathered = [HistEntry(:julia, now(UTC), "old_$i", 20+i) for i in 1:2]
+            state = SelectorState((30, 80), "", FilterSpec(), entries, -1, (active = Int[], gathered), -1)
+            @test toggleselection(state).selection.gathered == [gathered[2]]
+        end
+        @testset "Edge cases" begin
+            invalid = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = Int[], gathered = HistEntry[]), 0)
+            @test toggleselection(invalid) === invalid
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20], gathered = HistEntry[]), 1)
+            result = toggleselection(state)
+            @test 20 ∉ result.selection.active
+            state = SelectorState((30, 80), "", FilterSpec(), HistEntry[])
+            @test toggleselection(state) === state
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = Int[], gathered = HistEntry[]), 100)
+            @test toggleselection(state) === state
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = Int[], gathered = HistEntry[]), 20)
+            @test 1 in toggleselection(state).selection.active
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = Int[], gathered = HistEntry[]), 1)
+            @test 20 in toggleselection(state).selection.active
+        end
+    end
+    @testset "fullselection" begin
+        entries = [
+            HistEntry(:julia, now(UTC), "using DataFrames", 1),
+            HistEntry(:julia, now(UTC), "df = load_data()", 2),
+            HistEntry(:shell, now(UTC), "cat data.csv", 3),
+            HistEntry(:julia, now(UTC), "describe(df)", 4),
+        ]
+        @testset "No selection" begin
+            state = SelectorState((30, 80), "", FilterSpec(), entries)
+            @test fullselection(state) == (mode = :julia, text = "describe(df)")
+        end
+        @testset "Single selection" begin
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = [2], gathered = HistEntry[]), 1)
+            @test fullselection(state) == (mode = :julia, text = "df = load_data()")
+        end
+        @testset "Multiple selections" begin
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = [4, 1, 3], gathered = HistEntry[]), 1)
+            @test fullselection(state) == (mode = :julia, text = "using DataFrames\ncat data.csv\ndescribe(df)")
+        end
+        @testset "With gathered entries" begin
+            gathered = [HistEntry(:julia, now(UTC), "ENV[\"COLUMNS\"] = 120", 0)]
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = [2], gathered), 1)
+            @test fullselection(state) == (mode = :julia, text = "ENV[\"COLUMNS\"] = 120\ndf = load_data()")
+        end
+        @testset "Edge cases" begin
+            state = SelectorState((30, 80), "", FilterSpec(), HistEntry[], 0, (active = Int[], gathered = HistEntry[]), 1)
+            @test fullselection(state) == (mode = nothing, text = "")
+            state = SelectorState((30, 80), "", FilterSpec(), entries, 0, (active = Int[], gathered = HistEntry[]), 100)
+            @test fullselection(state) == (mode = nothing, text = "")
+            state = SelectorState((30, 80), "", FilterSpec(), HistEntry[], 0, (active = Int[], gathered = HistEntry[]), -1)
+            @test fullselection(state) == (mode = nothing, text = "")
+            gathered = [HistEntry(:julia, now(UTC), "old_1", 1)]
+            state = SelectorState((30, 80), "", FilterSpec(), HistEntry[], 0, (active = Int[], gathered), -1)
+            @test fullselection(state) == (mode = :julia, text = "old_1")
+        end
+    end
+    @testset "addcache!" begin
+        cache, state = Int[], zero(UInt8)
+        for i in 1:128
+            state = addcache!(cache, state, i)
+        end
+        @test cache == [1, 65, 97, 113, 121, 125, 127, 128]
+    end
+end
+
+# TODO: Prompt handling/events, terminal rendering, and end-to-end integration tests

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -443,14 +443,13 @@ function AddCustomMode(repl, prompt)
         end
     )
 
-    search_prompt, skeymap = LineEdit.setup_search_keymap(hp)
     mk = REPL.mode_keymap(main_mode)
 
-    b = Dict{Any,Any}[skeymap, mk, LineEdit.history_keymap, LineEdit.default_keymap, LineEdit.escape_defaults]
+    b = Dict{Any,Any}[mk, LineEdit.history_keymap, LineEdit.default_keymap, LineEdit.escape_defaults]
     foobar_mode.keymap_dict = LineEdit.keymap(b)
 
     main_mode.keymap_dict = LineEdit.keymap_merge(main_mode.keymap_dict, foobar_keymap)
-    foobar_mode, search_prompt
+    foobar_mode
 end
 
 # Note: since the \t character matters for the REPL file history,
@@ -503,21 +502,20 @@ for prompt = ["TestΠ", () -> randstring(rand(1:10))]
         shell_mode = repl.interface.modes[2]
         help_mode = repl.interface.modes[3]
         pkg_mode = repl.interface.modes[4]
-        histp = repl.interface.modes[5]
-        prefix_mode = repl.interface.modes[6]
+        # histp = repl.interface.modes[5]
+        prefix_mode = repl.interface.modes[5]
 
         hp = REPL.REPLHistoryProvider(Dict{Symbol,Any}(:julia => repl_mode,
                                                        :shell => shell_mode,
                                                        :help  => help_mode))
         hist_path = tempname()
         write(hist_path, fakehistory)
-        REPL.hist_from_file(hp, hist_path)
-        f = open(hist_path, read=true, write=true, create=true)
-        hp.history_file = f
-        seekend(f)
+        hp.history = REPL.History.HistoryFile(hist_path)
+        REPL.history_do_initialize(hp)
         REPL.history_reset_state(hp)
 
-        histp.hp = repl_mode.hist = shell_mode.hist = help_mode.hist = hp
+        # histp.hp = repl_mode.hist = shell_mode.hist = help_mode.hist = hp
+        repl_mode.hist = shell_mode.hist = help_mode.hist = hp
 
         # Some manual setup
         s = LineEdit.init_state(repl.t, repl.interface)
@@ -571,6 +569,7 @@ for prompt = ["TestΠ", () -> randstring(rand(1:10))]
         @test buffercontents(LineEdit.buffer(s)) == "wip"
         @test position(LineEdit.buffer(s)) == 3
         # test that history_first jumps to beginning of current session's history
+        @test hp.start_idx == 11
         hp.start_idx -= 5 # temporarily alter history
         LineEdit.history_first(s, hp)
         @test hp.cur_idx == 6
@@ -619,115 +618,6 @@ for prompt = ["TestΠ", () -> randstring(rand(1:10))]
         @test LineEdit.input_string(ps) == "wip"
         @test position(LineEdit.buffer(s)) == 3
         LineEdit.accept_result(s, prefix_mode)
-
-        # Test that searching backwards puts you into the correct mode and
-        # skips invalid modes.
-        LineEdit.enter_search(s, histp, true)
-        ss = LineEdit.state(s, histp)
-        write(ss.query_buffer, "l")
-        LineEdit.update_display_buffer(ss, ss)
-        LineEdit.accept_result(s, histp)
-        @test LineEdit.mode(s) == shell_mode
-        @test buffercontents(LineEdit.buffer(s)) == "ls"
-        @test position(LineEdit.buffer(s)) == 0
-
-        # Test that searching for `ll` actually matches `ll` after
-        # both letters are types rather than jumping to `shell`
-        LineEdit.history_prev(s, hp)
-        LineEdit.enter_search(s, histp, true)
-        write(ss.query_buffer, "l")
-        LineEdit.update_display_buffer(ss, ss)
-        @test buffercontents(ss.response_buffer) == "ll"
-        @test position(ss.response_buffer) == 1
-        write(ss.query_buffer, "l")
-        LineEdit.update_display_buffer(ss, ss)
-        LineEdit.accept_result(s, histp)
-        @test LineEdit.mode(s) == shell_mode
-        @test buffercontents(LineEdit.buffer(s)) == "ll"
-        @test position(LineEdit.buffer(s)) == 0
-
-        # Test that searching backwards with a one-letter query doesn't
-        # return indefinitely the same match (#9352)
-        LineEdit.enter_search(s, histp, true)
-        write(ss.query_buffer, "l")
-        LineEdit.update_display_buffer(ss, ss)
-        LineEdit.history_next_result(s, ss)
-        LineEdit.update_display_buffer(ss, ss)
-        LineEdit.accept_result(s, histp)
-        @test LineEdit.mode(s) == repl_mode
-        @test buffercontents(LineEdit.buffer(s)) == "shell"
-        @test position(LineEdit.buffer(s)) == 4
-
-        # Test that searching backwards doesn't skip matches (#9352)
-        # (for a search with multiple one-byte characters, or UTF-8 characters)
-        LineEdit.enter_search(s, histp, true)
-        write(ss.query_buffer, "é") # matches right-most "é" in "éé"
-        LineEdit.update_display_buffer(ss, ss)
-        @test position(ss.query_buffer) == sizeof("é")
-        LineEdit.history_next_result(s, ss) # matches left-most "é" in "éé"
-        LineEdit.update_display_buffer(ss, ss)
-        LineEdit.accept_result(s, histp)
-        @test buffercontents(LineEdit.buffer(s)) == "éé"
-        @test position(LineEdit.buffer(s)) == 0
-
-        # Issue #7551
-        # Enter search mode and try accepting an empty result
-        REPL.history_reset_state(hp)
-        LineEdit.edit_clear(s)
-        cur_mode = LineEdit.mode(s)
-        LineEdit.enter_search(s, histp, true)
-        LineEdit.accept_result(s, histp)
-        @test LineEdit.mode(s) == cur_mode
-        @test buffercontents(LineEdit.buffer(s)) == ""
-        @test position(LineEdit.buffer(s)) == 0
-
-        # Test that new modes can be dynamically added to the REPL and will
-        # integrate nicely
-        foobar_mode, custom_histp = AddCustomMode(repl, prompt)
-
-        # ^R l, should now find `ls` in foobar mode
-        LineEdit.enter_search(s, histp, true)
-        ss = LineEdit.state(s, histp)
-        write(ss.query_buffer, "l")
-        LineEdit.update_display_buffer(ss, ss)
-        LineEdit.accept_result(s, histp)
-        @test LineEdit.mode(s) == foobar_mode
-        @test buffercontents(LineEdit.buffer(s)) == "ls"
-        @test position(LineEdit.buffer(s)) == 0
-
-        # Try the same for prefix search
-        LineEdit.history_next(s, hp)
-        LineEdit.history_prev_prefix(ps, hp, "l")
-        @test ps.parent == foobar_mode
-        @test LineEdit.input_string(ps) == "ls"
-        @test position(LineEdit.buffer(s)) == 1
-
-        # Some Unicode handling testing
-        LineEdit.history_prev(s, hp)
-        LineEdit.enter_search(s, histp, true)
-        write(ss.query_buffer, "x")
-        LineEdit.update_display_buffer(ss, ss)
-        @test buffercontents(ss.response_buffer) == "x ΔxΔ"
-        @test position(ss.response_buffer) == 4
-        write(ss.query_buffer, " ")
-        LineEdit.update_display_buffer(ss, ss)
-        LineEdit.accept_result(s, histp)
-        @test LineEdit.mode(s) == repl_mode
-        @test buffercontents(LineEdit.buffer(s)) == "x ΔxΔ"
-        @test position(LineEdit.buffer(s)) == 0
-
-        LineEdit.edit_clear(s)
-        LineEdit.enter_search(s, histp, true)
-        ss = LineEdit.state(s, histp)
-        write(ss.query_buffer, "Å") # should not be in history
-        LineEdit.update_display_buffer(ss, ss)
-        @test buffercontents(ss.response_buffer) == ""
-        @test position(ss.response_buffer) == 0
-        LineEdit.history_next_result(s, ss) # should not throw BoundsError
-        LineEdit.accept_result(s, histp)
-
-        # Try entering search mode while in custom repl mode
-        LineEdit.enter_search(s, custom_histp, true)
     end
 end
 
@@ -1035,7 +925,7 @@ function history_move_prefix(s::LineEdit.MIState,
     hist.last_idx = -1
     idxs = backwards ? ((cur_idx-1):-1:1) : ((cur_idx+1):length(hist.history))
     for idx in idxs
-        if startswith(hist.history[idx], prefix) && hist.history[idx] != allbuf
+        if startswith(hist.history[idx].content, prefix) && hist.history[idx].content != allbuf
             REPL.history_move(s, hist, idx)
             seek(LineEdit.buffer(s), pos)
             LineEdit.refresh_line(s)
@@ -1091,7 +981,7 @@ for keys = [altkeys, merge(altkeys...)],
 
             # Close the history file
             # (otherwise trying to delete it fails on Windows)
-            close(repl.interface.modes[1].hist.history_file)
+            close(repl.interface.modes[1].hist.history)
 
             # Check that the correct prompt was displayed
             output = readuntil(stdout_read, "1 * 1;", keep=true)
@@ -1726,21 +1616,20 @@ for prompt = ["TestΠ", () -> randstring(rand(1:10))]
         shell_mode = repl.interface.modes[2]
         help_mode = repl.interface.modes[3]
         pkg_mode = repl.interface.modes[4]
-        histp = repl.interface.modes[5]
-        prefix_mode = repl.interface.modes[6]
+        # histp = repl.interface.modes[5]
+        prefix_mode = repl.interface.modes[5]
 
         hp = REPL.REPLHistoryProvider(Dict{Symbol,Any}(:julia => repl_mode,
                                                        :shell => shell_mode,
                                                        :help  => help_mode))
         hist_path = tempname()
         write(hist_path, fakehistory_2)
-        REPL.hist_from_file(hp, hist_path)
-        f = open(hist_path, read=true, write=true, create=true)
-        hp.history_file = f
-        seekend(f)
+        histfile = REPL.HistoryFile(hist_path)
+        hp.history = histfile
+        REPL.history_do_initialize(hp)
         REPL.history_reset_state(hp)
 
-        histp.hp = repl_mode.hist = shell_mode.hist = help_mode.hist = hp
+        # histp.hp = repl_mode.hist = shell_mode.hist = help_mode.hist = hp
 
         s = LineEdit.init_state(repl.t, prefix_mode)
         prefix_prev() = REPL.history_prev_prefix(s, hp, "x")

--- a/stdlib/REPL/test/runtests.jl
+++ b/stdlib/REPL/test/runtests.jl
@@ -22,6 +22,9 @@ end
 module TerminalMenusTest
     include("TerminalMenus/runtests.jl")
 end
+module HistoryTest
+    include("history.jl")
+end
 module BadHistoryStartupTest
     include("bad_history_startup.jl")
 end

--- a/typos.toml
+++ b/typos.toml
@@ -1,2 +1,5 @@
 [default]
 extend-ignore-words-re = ["^[a-zA-Z]?[a-zA-Z]?[a-zA-Z]?[a-zA-Z]?$"]
+
+[default.extend-words]
+indexin = "indexin"


### PR DESCRIPTION
## The Fanciest REPL History in the Land :sparkles: 

Do you dread typing out code for the second time? Are you a particular enjoyed of REPL history?

Well, I know I am, and for years I have *yearned* for something better than the current `readline`-style completion, better than OhMyREPL.jl's fzf-driven completion, better than any REPL history I've seen before!

It's not quite finished baking, but we're onto the final stretch :grinning:

[repl_history_demo.webm](https://github.com/user-attachments/assets/9cb0f4b1-7da4-43da-b6df-017972e1227e)

Thanks to @kdheepak, @jakobnissen, and @digital-carver for helping me design the UI and UX over on Zulip ([#repl > Revamped REPL history](https://julialang.zulipchat.com/#narrow/channel/404905-repl/topic/Revamped.20REPL.20history/with/544416134)).

## Features

- Zippy searching
  - Event-driven asynchronous filtering UI
  - Incremental, resumable searching with dynamic batch sizes
  - Log-structured search checkpoints
- Multi-selection
- Faster histfile parsing (~2x)
- Multiple search modes
- A friendly help page
- Syntax highlighting
- Save multiple items to a file or your clipboard

## TODO

- [x] Introduce annotation-preserving `replace` method
- [x] Thoroughly test the new `replace` method
- [ ] Ask somebody more compiler-y about the performance pitfalls of the `replace` method (see: the `REVIEW: ...` code comments in `annotated_io.jl`)
- [x] Implement flashy REPL history
- [x] Restore up/down arrow history rotation in the REPL (collateral damage of over-zealous deleting)
- [x] Create a new test set for the new history
- [x] Make sure that enough is precompiled to be relatively snappy

-----

This PR is on top of #59778, because I think I can safely assume that will be merged first.