### PR TITLE
force inline `pow_fast`

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -297,7 +297,7 @@ exp10_fast(x::Union{Float32,Float64}) = Base.Math.exp10_fast(x)
 
 # builtins
 
-function pow_fast(x::Float64, y::Integer)
+@inline function pow_fast(x::Float64, y::Integer)
     z = y % Int32
     z == y ? pow_fast(x, z) : x^y
 end


### PR DESCRIPTION
fixes #59804

From #59804:

```julia
function norm_me_base(V)
    return sqrt(V[1]^2 + V[2]^2 + V[3]^2)
end

@fastmath function norm_me_fast(V)
    return sqrt(V[1]^2 + V[2]^2 + V[3]^2)
end

function norm_me_base_ntimes(V, n::Int)
    y = 0.0
    for i = 1:n
        y += norm_me_base(V)
    end
    return y
end

function norm_me_fast_ntimes(V, n::Int)
    y = 0.0
    for i = 1:n
        y += norm_me_fast(V)
    end
    return y
end

using BenchmarkTools
using StaticArrays

function benchmark_that()
	v = SVector{3}(10.567, 5.4, 2.28)
	@btime norm_me_base($v)
	@btime norm_me_fast($v)
	@btime norm_me_base_ntimes($v, 1000)
	@btime norm_me_fast_ntimes($v, 1000)
end
```

1.11:

```
julia> benchmark_that()
  1.500 ns (0 allocations: 0 bytes)
  1.500 ns (0 allocations: 0 bytes)
  380.951 ns (0 allocations: 0 bytes)
  381.158 ns (0 allocations: 0 bytes)
```

1.12:

```
julia> benchmark_that()
  1.541 ns (0 allocations: 0 bytes)
  6.958 ns (0 allocations: 0 bytes)
  381.188 ns (0 allocations: 0 bytes)
  8.181 μs (0 allocations: 0 bytes)
```

PR:

```
julia> benchmark_that()
  1.541 ns (0 allocations: 0 bytes)
  1.500 ns (0 allocations: 0 bytes)
  381.632 ns (0 allocations: 0 bytes)
  381.360 ns (0 allocations: 0 bytes)
```