### PR TITLE
set the `auto_refresh_time_delay` to 0 on Windows as well

### DIFF
--- a/stdlib/REPL/src/options.jl
+++ b/stdlib/REPL/src/options.jl
@@ -47,7 +47,7 @@ Options(;
         auto_indent_tmp_off = false,
         auto_indent_bracketed_paste = false,
         auto_indent_time_threshold = 0.005,
-        auto_refresh_time_delay = Sys.iswindows() ? 0.05 : 0.0,
+        auto_refresh_time_delay = 0.0 # this no longer seems beneficial
         hint_tab_completes = true,
         iocontext = Dict{Symbol,Any}()) =
             Options(hascolor, extra_keymap, tabwidth,

--- a/stdlib/REPL/src/options.jl
+++ b/stdlib/REPL/src/options.jl
@@ -47,7 +47,7 @@ Options(;
         auto_indent_tmp_off = false,
         auto_indent_bracketed_paste = false,
         auto_indent_time_threshold = 0.005,
-        auto_refresh_time_delay = 0.0 # this no longer seems beneficial
+        auto_refresh_time_delay = 0.0, # this no longer seems beneficial
         hint_tab_completes = true,
         iocontext = Dict{Symbol,Any}()) =
             Options(hascolor, extra_keymap, tabwidth,


### PR DESCRIPTION
This effectively reverts https://github.com/JuliaLang/julia/pull/39538 since it no longer seems beneficial. With `auto_refresh_time_delay=0.0` on Windows, pasting a 1500 line long function took 29 seconds, while with `auto_refresh_time_delay=0.05` (which is the current value) it took 36 seconds.

https://github.com/JuliaLang/julia/pull/59825 should also effectively make this obsolete.

It also causes other issues like https://github.com/JuliaLang/julia/issues/59788.

Fixes https://github.com/JuliaLang/julia/issues/59788