### PR TITLE
re-allow implicit `prevfloat` for signed step sizes

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -870,6 +870,10 @@ applications of [`nextfloat`](@ref) if `n < 0`.
 """
 prevfloat(x::AbstractFloat, d::Integer) = _nextfloat(x, ispositive(d), uabs(d))
 
+# this method improves backwards compatibility for types only specializing
+# nextfloat and relying on an implicit prevfloat 
+prevfloat(x::AbstractFloat, d::T) where {T<:Signed} = nextfloat(x, -d)
+
 """
     prevfloat(x::AbstractFloat)
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -871,7 +871,7 @@ applications of [`nextfloat`](@ref) if `n < 0`.
 prevfloat(x::AbstractFloat, d::Integer) = _nextfloat(x, ispositive(d), uabs(d))
 
 # this method improves backwards compatibility for types only specializing
-# nextfloat and relying on an implicit prevfloat 
+# nextfloat and relying on an implicit prevfloat
 prevfloat(x::AbstractFloat, d::T) where {T<:Signed} = nextfloat(x, -d)
 
 """

--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -316,3 +316,9 @@ end
         end
     end
 end
+
+@testset "nextfloat can be defined without prevfloat for signed step sizes" begin
+    struct MyFloat59661<:AbstractFloat x end
+    Base.nextfloat(x::MyFloat59661, d::Integer) = nextfloat(x.x, d)
+    @test prevfloat(MyFloat59661(1.0), 1) == prevfloat(1.0, 1)
+end


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/59668 changed `prevfloat(x, d)` to no longer just call `nextfloat(x, -d)`, so as to avoid bugs resulting from intermediate overflow when `d` is unsigned.

as predicted in https://github.com/JuliaLang/julia/pull/59668#issuecomment-3341703842 and then observed in https://github.com/JuliaLang/julia/pull/59668#issuecomment-3401562468, this causes some package failures. The failures are exposing a bug, so it's ultimately a good thing, but this PR would restore the old behavior at least when `d isa Signed` and only fails when we'd actually hit the unsigned buggy case.