### PR TITLE
Doc uabs as alterative (it is public)

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -198,11 +198,11 @@ copysign(x::Signed, y::Real)    = copysign(x, -oftype(x, signbit(y)))
 
 The absolute value of `x`.
 
-When `abs` is applied to signed integers, overflow may occur,
+When `abs` is applied to (negative) signed integers, overflow may occur,
 resulting in the return of a negative value. This overflow occurs only
 when `abs` is applied to the minimum representable value of a signed
 integer. That is, when `x == typemin(typeof(x))`, `abs(x) == x < 0`,
-not `-x` as might be expected.
+not `-x` as might be expected. This never happens with `Base.uabs`.
 
 See also: [`abs2`](@ref), [`unsigned`](@ref), [`sign`](@ref).
 


### PR DESCRIPTION
It is public, already used in code, and help?> uabs doesn't find it, only:

help?> Base.uabs
  │ Warning
  │
  │  The following bindings may be internal; they may change or be removed in future versions:
  │
  │    •  Base.uabs
..

and since it is public it will likely never be removed (or be changed, is quite simple); and I'm not sure what triggers it but that Warning should go. Please add to this PR to make it disappear before merging it.

https://github.com/search?q=repo%3AJuliaDSP%2FDSP.jl%20uabs&type=code

[I doubt it should be exported, is quite short so might conflict... would have been ideal from the start.]