### PR TITLE
Libdl: Add documentation for LazyLibrary and friends

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3484,6 +3484,10 @@ function abstract_eval_foreigncall(interp::AbstractInterpreter, e::Expr, sstate:
     callee = e.args[1]
     if isexpr(callee, :tuple)
         if length(callee.args) >= 1
+            # Evaluate the arguments to constrain the world, effects, and other info for codegen,
+            # but note there is an implied `if !=(C_NULL)` branch here that might read data
+            # in a different world (the exact cache behavior is unspecified), so we do not use
+            # these results to refine reachability of the subsequent foreigncall.
             abstract_eval_value(interp, callee.args[1], sstate, sv)
             if length(callee.args) >= 2
                 abstract_eval_value(interp, callee.args[2], sstate, sv)

--- a/stdlib/Libdl/docs/src/index.md
+++ b/stdlib/Libdl/docs/src/index.md
@@ -21,3 +21,12 @@ Libdl.dlpath
 Libdl.find_library
 Libdl.DL_LOAD_PATH
 ```
+
+# Lazy Library Loading
+
+```@docs
+Libdl.LazyLibrary
+Libdl.LazyLibraryPath
+Libdl.BundledLazyLibraryPath
+Libdl.add_dependency!
+```

--- a/stdlib/Libdl/src/Libdl.jl
+++ b/stdlib/Libdl/src/Libdl.jl
@@ -11,6 +11,8 @@ export DL_LOAD_PATH, RTLD_DEEPBIND, RTLD_FIRST, RTLD_GLOBAL, RTLD_LAZY, RTLD_LOC
     RTLD_NODELETE, RTLD_NOLOAD, RTLD_NOW, dlclose, dlopen, dlopen_e, dlsym, dlsym_e,
     dlpath, find_library, dlext, dllist, LazyLibrary, LazyLibraryPath, BundledLazyLibraryPath
 
+public add_dependency!
+
 import Base.Libc.Libdl: DL_LOAD_PATH, RTLD_DEEPBIND, RTLD_FIRST, RTLD_GLOBAL, RTLD_LAZY, RTLD_LOCAL,
                         RTLD_NODELETE, RTLD_NOLOAD, RTLD_NOW, dlclose, dlopen, dlopen_e, dlsym, dlsym_e,
                         dlpath, find_library, dlext, dllist, LazyLibrary, LazyLibraryPath,


### PR DESCRIPTION
Adds documentation for `Libdl.LazyLibrary` and related types.

Also extends the C calling manual with an expanded section on using `LazyLibrary` for lazy library loading, including practical examples of platform-specific libraries, dependency management, lazy path construction, and initialization callbacks. Remove a few oddly confusing or incorrect notes as well.

Also fix a `copy` oddly implemented as
`convert(Vector{LazyLibrary}, convert(Vector{Any}, LazyLibrary[]))` from #59233 to just call `copy`.

🤖 Generated with help by Claude Code.