### PR TITLE
Mark `Base.VecElement` as `public`

### DIFF
--- a/base/baseext.jl
+++ b/base/baseext.jl
@@ -2,6 +2,8 @@
 
 # extensions to Core types to add features in Base
 
+public VecElement
+
 """
     VecElement{T}
 


### PR DESCRIPTION
`Base.VecElement` has a docstring and a [section in the online docs](https://docs.julialang.org/en/v1/base/simd-types/) so I think it's intended to be public.