### PR TITLE
allow specifying projects in a workspace more than one level under it

### DIFF
--- a/doc/src/manual/code-loading.md
+++ b/doc/src/manual/code-loading.md
@@ -406,7 +406,9 @@ A project file can define a workspace by giving a set of projects that is part o
 projects = ["test", "benchmarks", "docs", "SomePackage"]
 ```
 
-Each subfolder contains its own `Project.toml` file, which may include additional dependencies and compatibility constraints. In such cases, the package manager gathers all dependency information from all the projects in the workspace generating a single manifest file that combines the versions of all dependencies.
+Each project listed in the `projects` array is specified by its relative path from the workspace root. This can be a direct child directory (e.g., `"test"`) or a nested subdirectory (e.g., `"nested/subdir/MyPackage"`). Each project contains its own `Project.toml` file, which may include additional dependencies and compatibility constraints. In such cases, the package manager gathers all dependency information from all the projects in the workspace generating a single manifest file that combines the versions of all dependencies.
+
+When Julia loads a project, it searches upward through parent directories until it reaches the user's home directory to find a workspace that includes that project. This allows workspace projects to be nested at arbitrary depth within the workspace directory tree.
 
 Furthermore, workspaces can be "nested", meaning a project defining a workspace can also be part of another workspace. In this scenario, a single manifest file is still utilized, stored alongside the "root project" (the project that doesn't have another workspace including it). An example file structure could look like this:
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1669,6 +1669,14 @@ end
        @test isfile(Base.locate_package(id_dev))
        @test Base.identify_package("Devved2") === nothing
 
+       # Test that workspace projects can be specified with subfolder paths
+       # and that base_project searches upward through multiple directory levels
+       empty!(LOAD_PATH)
+       push!(LOAD_PATH, joinpath(@__DIR__, "project", "SubProject", "nested", "deep"))
+       proj_file = joinpath(@__DIR__, "project", "SubProject", "nested", "deep", "Project.toml")
+       base_proj = Base.base_project(proj_file)
+       @test base_proj == joinpath(@__DIR__, "project", "SubProject", "Project.toml")
+
     finally
        copy!(LOAD_PATH, old_load_path)
     end

--- a/test/project/SubProject/Project.toml
+++ b/test/project/SubProject/Project.toml
@@ -2,7 +2,7 @@ name = "MyPkg"
 uuid = "0cafdeb2-d7a2-40d0-8d22-4411fcc2c4ee"
 
 [workspace]
-projects = ["sub", "PackageThatIsSub", "test"]
+projects = ["sub", "PackageThatIsSub", "test", "nested/deep"]
 
 [deps]
 Devved = "cbce3a6e-7a3d-4e84-8e6d-b87208df7599"

--- a/test/project/SubProject/nested/deep/Project.toml
+++ b/test/project/SubProject/nested/deep/Project.toml
@@ -1,0 +1,2 @@
+name = "DeepNested"
+uuid = "d5e3a334-7f12-4e5f-9ab8-123456789abc"

--- a/test/project/SubProject/nested/deep/src/DeepNested.jl
+++ b/test/project/SubProject/nested/deep/src/DeepNested.jl
@@ -1,0 +1,2 @@
+module DeepNested
+end


### PR DESCRIPTION
we find "parent" projects by searching upwards, in a similar way to how we find a standard project file when we are in a subfolder
