### PR TITLE
REPL, styling, bracket match: Use a `UInt32` for offset

### DIFF
--- a/stdlib/REPL/src/StylingPasses.jl
+++ b/stdlib/REPL/src/StylingPasses.jl
@@ -124,7 +124,7 @@ function find_enclosing_parens(content::String, ast, cursor_pos::Int)
     innermost_pairs = Dict{Symbol,Tuple{Int,Int}}()
     paren_stack = Tuple{Int,Int,Symbol}[]  # (open_pos, depth, type)
 
-    walk_tree(ast, content, 0) do node, offset
+    walk_tree(ast, content, UInt32(0)) do node, offset
         nkind = JuliaSyntax.kind(node)
         pos = firstindex(content) + offset
 
@@ -151,7 +151,7 @@ function find_enclosing_parens(content::String, ast, cursor_pos::Int)
     return collect(values(innermost_pairs))
 end
 
-function walk_tree(f::Function, node, content::String, offset::Int)
+function walk_tree(f::Function, node, content::String, offset::UInt32)
     f(node, offset)
 
     if JuliaSyntax.numchildren(node) > 0


### PR DESCRIPTION
This is what JuliaSyntax returns from `span`: https://github.com/JuliaLang/JuliaSyntax.jl/blob/99e975a726a82994de3f8e961e6fa8d39aed0d37/src/core/parse_stream.jl#L132

Fixes https://github.com/JuliaLang/julia/issues/59851
