### PR TITLE
subtype: use bitvector API for bits stack access

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -27,6 +27,7 @@
 #include "julia.h"
 #include "julia_internal.h"
 #include "julia_assert.h"
+#include "bitvector.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -148,7 +149,7 @@ static int statestack_get(jl_unionstate_t *st, int i) JL_NOTSAFEPOINT
         stack = stack->next;
         i -= sizeof(stack->data) * 8;
     }
-    return (stack->data[i>>5] & (1u<<(i&31))) != 0;
+    return bitvector_get(stack->data, i) != 0;
 }
 
 static void statestack_set(jl_unionstate_t *st, int i, int val) JL_NOTSAFEPOINT
@@ -163,10 +164,7 @@ static void statestack_set(jl_unionstate_t *st, int i, int val) JL_NOTSAFEPOINT
         stack = stack->next;
         i -= sizeof(stack->data) * 8;
     }
-    if (val)
-        stack->data[i>>5] |= (1u<<(i&31));
-    else
-        stack->data[i>>5] &= ~(1u<<(i&31));
+    bitvector_set(stack->data, i, val);
 }
 
 #define has_next_union_state(e, R) ((((R) ? &(e)->Runions : &(e)->Lunions)->more) != 0)

--- a/src/support/bitvector.c
+++ b/src/support/bitvector.c
@@ -46,14 +46,14 @@ size_t bitvector_nwords(uint64_t nbits)
 void bitvector_set(uint32_t *b, uint64_t n, uint32_t c)
 {
     if (c)
-        b[n>>5] |= (1<<(n&31));
+        b[n>>5] |= (1u<<(n&31));
     else
-        b[n>>5] &= ~(1<<(n&31));
+        b[n>>5] &= ~(1u<<(n&31));
 }
 
 uint32_t bitvector_get(uint32_t *b, uint64_t n)
 {
-    return b[n>>5] & (1<<(n&31));
+    return b[n>>5] & (1u<<(n&31));
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Replace "manual" bitmask operations in `statestack_get()` and `statestack_set()` with the API provided by bitvector to reduce duplication of bit maipulation logic.

In addition let's make the bit operations in bitvector to use unsigned constants for type consistency with `uint` data.