### PR TITLE
make range indexing into a `String` produce a `SubString` (consistent with the generic fallback)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,9 @@ New language features
 
 Language changes
 ----------------
+
+* Range indexing into a `String` now produces a `SubString` (like the generic fallback always did).
+
 * `mod(x::AbstractFloat, -Inf)` now returns `x` (as long as `x` is finite), this aligns with C standard and is considered a bug fix ([#47102])
 
 * The `hash` algorithm and its values have changed for certain types, most notably AbstractString. Any `hash` specializations for equal types to those that changed, such as some third-party string packages, may need to be deleted. ([#57509], [#59691])

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -299,7 +299,7 @@ function lreplace!(sym::Symbol, r::LReplace, in_quote_context::Bool, escs::Int)
     Symbol(lreplace_string!(string(sym), r))
 end
 
-function lreplace_string!(str::String, r::LReplace)
+function lreplace_string!(str::AbstractString, r::LReplace)
     i = firstindex(str)
     pat = r.pat_str
     j = firstindex(pat)
@@ -331,7 +331,7 @@ function lreplace_string!(str::String, r::LReplace)
         if matching && j > lastindex(pat)
             if i > lastindex(str) || str[i] == '_'
                 # We have a match
-                return string(str[1:prevind(str, istart)], r.val, lreplace_string!(str[i:end], r))
+                return string(str[1:prevind(str, istart)], r.val, lreplace_string!(String(str[i:end]), r))
             end
             matching = false
             j = firstindex(pat)

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -516,23 +516,6 @@ function getindex_continued(s, i::Int, u::UInt32)
     return reinterpret(Char, u)
 end
 
-getindex(s::String, r::AbstractUnitRange{<:Integer}) = s[Int(first(r)):Int(last(r))]
-
-@inline function getindex(s::String, r::UnitRange{Int})
-    isempty(r) && return ""
-    i, j = first(r), last(r)
-    @boundscheck begin
-        checkbounds(s, r)
-        @inbounds isvalid(s, i) || string_index_err(s, i)
-        @inbounds isvalid(s, j) || string_index_err(s, j)
-    end
-    j = nextind(s, j) - 1
-    n = j - i + 1
-    ss = _string_n(n)
-    GC.@preserve s ss unsafe_copyto!(pointer(ss), pointer(s, i), n)
-    return ss
-end
-
 # nothrow because we know the start and end indices are valid
 @assume_effects :nothrow length(s::String) = length_continued(s, 1, ncodeunits(s), ncodeunits(s))
 

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -934,7 +934,7 @@ function complete_keyword_argument!(suggestions::Vector{Completion},
     return kwargs_flag != 0 && arg_pos == :kwargs
 end
 
-function get_loading_candidates(pkgstarts::String, project_file::String)
+function get_loading_candidates(pkgstarts::Union{String, SubString{String}}, project_file::String)
     loading_candidates = String[]
     d = Base.parsed_toml(project_file)
     pkg = get(d, "name", nothing)::Union{String, Nothing}
@@ -950,7 +950,7 @@ function get_loading_candidates(pkgstarts::String, project_file::String)
     return loading_candidates
 end
 
-function complete_loading_candidates!(suggestions::Vector{Completion}, s::String)
+function complete_loading_candidates!(suggestions::Vector{Completion}, s::Union{String, SubString{String}})
     for name in ("Core", "Base")
         startswith(name, s) && push!(suggestions, PackageCompletion(name))
     end


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/issues/59828#issuecomment-3410990374.

It doesn't make sense to me if the generic fallback is to produce a sub string that `String` should not follow this.

But I guess this will lead to a lot of code that returns `Union{String, SubString{String}}`. But it will allocate less. Don't know if it is worth it or not but thought I would put up a PR at least.

cc @jakobnissen 