### PR TITLE
WIP: Use StyledStrings for all REPL prompt customizations

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -489,7 +489,7 @@ function run_std_repl(REPL::Module, quiet::Bool, banner::Symbol, history_file::B
         repl = REPL.BasicREPL(term)
         quiet || @warn "Terminal not fully functional"
     else
-        repl = REPL.LineEditREPL(term, get(stdout, :color, false), true)
+        repl = REPL.LineEditREPL(term, get(stdout, :color, false))
         repl.history_file = history_file
     end
     # Make sure any displays pushed in .julia/config/startup.jl ends up above the

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -443,16 +443,6 @@ should have at the terminal.
 The formatting `Base.info_color()` (default: cyan, `"\033[36m"`) that info
 should have at the terminal.
 
-### [`JULIA_INPUT_COLOR`](@id JULIA_INPUT_COLOR)
-
-The formatting `Base.input_color()` (default: normal, `"\033[0m"`) that input
-should have at the terminal.
-
-### [`JULIA_ANSWER_COLOR`](@id JULIA_ANSWER_COLOR)
-
-The formatting `Base.answer_color()` (default: normal, `"\033[0m"`) that output
-should have at the terminal.
-
 ### [`NO_COLOR`](@id NO_COLOR)
 
 When this variable is present and not an empty string (regardless of its value) then colored

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -710,43 +710,51 @@ inherit = "julia_rainbow_curly_2"
 
 For a complete list of customizable faces, see the [JuliaSyntaxHighlighting package documentation](https://julialang.github.io/JuliaSyntaxHighlighting.jl/dev/).
 
+## Customizing prompts
+
+The text and colors of the REPL prompts can be customized by setting the `prompt` and `output_prefix`
+fields on the `repl` object within an [`atreplinit`](@ref) hook in your `~/.julia/config/startup.jl` file.
+
+Use styled strings to customize the prompt text and colors:
+
+```julia
+using StyledStrings
+
+atreplinit() do repl
+    repl.prompt = styled"{cyan:myprompt>} "
+    repl.output_prefix = styled"{red:=>} "
+end
+```
+
+The prompt can also be a plain string or a function for dynamic prompts.
+Dynamic prompts can be combined with styling:
+
+```julia
+using StyledStrings
+using Dates
+
+atreplinit() do repl
+    # Dynamic prompt with time
+    repl.output_prefix = () -> string(Dates.format(Dates.now(), "HH:MM:SS"), "> ")
+
+    # Dynamic prompt with Julia version and styling
+    repl.prompt = () -> styled"{bold,magenta:julia v$(VERSION)>} "
+end
+```
+
+To customize other REPL modes (shell, help, pkg), set the corresponding prompt fields:
+
+```julia
+using StyledStrings
+atreplinit() do repl
+    repl.shell_prompt = styled"{green:shell>} "
+    repl.help_prompt = styled"{magenta:help?} "
+end
+```
+
 ## Customizing Colors
 
-The colors used by Julia and the REPL can be customized, as well. To change the
-color of the Julia prompt you can add something like the following to your
-`~/.julia/config/startup.jl` file, which is to be placed inside your home directory:
-
-```julia
-function customize_colors(repl)
-    repl.prompt_color = Base.text_colors[:cyan]
-end
-
-atreplinit(customize_colors)
-```
-
-The available color keys can be seen by typing `Base.text_colors` in the help mode of the REPL.
-In addition, the integers 0 to 255 can be used as color keys for terminals
-with 256 color support.
-
-You can also change the colors for the help and shell prompts and
-input and answer text by setting the appropriate field of `repl` in the `customize_colors` function
-above (respectively, `help_color`, `shell_color`, `input_color`, and `answer_color`). For the
-latter two, be sure that the `envcolors` field is also set to false.
-
-It is also possible to apply boldface formatting by using
-`Base.text_colors[:bold]` as a color. For instance, to print answers in
-boldface font, one can use the following as a `~/.julia/config/startup.jl`:
-
-```julia
-function customize_colors(repl)
-    repl.envcolors = false
-    repl.answer_color = Base.text_colors[:bold]
-end
-
-atreplinit(customize_colors)
-```
-
-You can also customize the color used to render warning and informational messages by
+You can customize the color used to render warning and informational messages by
 setting the appropriate environment variables. For instance, to render error, warning, and informational
 messages respectively in magenta, yellow, and cyan you can add the following to your
 `~/.julia/config/startup.jl` file:
@@ -756,7 +764,6 @@ ENV["JULIA_ERROR_COLOR"] = :magenta
 ENV["JULIA_WARN_COLOR"] = :yellow
 ENV["JULIA_INFO_COLOR"] = :cyan
 ```
-
 
 ## Changing the contextual module which is active at the REPL
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -35,14 +35,26 @@ end
 function __init__()
     Base.REPL_MODULE_REF[] = REPL
     Base.Experimental.register_error_hint(UndefVarError_REPL_hint, UndefVarError)
+    foreach(addface!, REPL_FACES)
     return nothing
 end
 
 using Base.Meta, Sockets, StyledStrings
+using StyledStrings: Face, addface!, @styled_str, getface
 using JuliaSyntaxHighlighting
 import InteractiveUtils
 import FileWatching
 import Base.JuliaSyntax: kind, @K_str, @KSet_str, Tokenize.tokenize
+
+const REPL_FACES = [
+    :repl_prompt_julia => Face(foreground=:green, weight=:bold),
+    :repl_prompt_shell => Face(foreground=:red, weight=:bold),
+    :repl_prompt_help => Face(foreground=:yellow, weight=:bold),
+    :repl_prompt_pkg => Face(foreground=:blue, weight=:bold),
+    :repl_output_prefix_julia => Face(foreground=:red, weight=:bold),
+    :repl_input => Face(),
+    :repl_answer => Face(),
+]
 
 export
     AbstractREPL,
@@ -753,32 +765,33 @@ end
 mutable struct LineEditREPL <: AbstractREPL
     t::TextTerminal
     hascolor::Bool
-    prompt_color::String
-    input_color::String
-    answer_color::String
-    shell_color::String
-    help_color::String
-    pkg_color::String
     history_file::Bool
     in_shell::Bool
     in_help::Bool
-    envcolors::Bool
     waserror::Bool
     specialdisplay::Union{Nothing,AbstractDisplay}
     options::Options
     mistate::Union{MIState,Nothing}
     last_shown_line_infos::Vector{Tuple{String,Int}}
+    prompt::Union{AbstractString,Function,Nothing}
+    output_prefix::Union{AbstractString,Function,Nothing}
+    help_prompt::Union{AbstractString,Function,Nothing}
+    shell_prompt::Union{AbstractString,Function,Nothing}
+    pkg_prompt::Union{AbstractString,Function,Nothing}
+    # Fields below are left uninitialized by the constructor
     interface::ModalInterface
     backendref::REPLBackendRef
     frontend_task::Task
-    function LineEditREPL(t,hascolor,prompt_color,input_color,answer_color,shell_color,help_color,pkg_color,history_file,in_shell,in_help,envcolors)
+    function LineEditREPL(t,hascolor,history_file,in_shell,in_help)
         opts = Options()
         opts.hascolor = hascolor
         if !hascolor
             opts.beep_colors = [""]
         end
-        new(t,hascolor,prompt_color,input_color,answer_color,shell_color,help_color,pkg_color,history_file,in_shell,
-            in_help,envcolors,false,nothing, opts, nothing, Tuple{String,Int}[])
+        new(t,hascolor,history_file,in_shell,
+            in_help,false,nothing, opts, nothing, Tuple{String,Int}[],
+            nothing, nothing, nothing, nothing, nothing)
+            # interface, backendref, frontend_task are left uninitialized
     end
 end
 outstream(r::LineEditREPL) = (t = r.t; t isa TTYTerminal ? t.out_stream : t)
@@ -788,15 +801,7 @@ terminal(r::LineEditREPL) = r.t
 hascolor(r::LineEditREPL) = r.hascolor
 
 LineEditREPL(t::TextTerminal, hascolor::Bool, envcolors::Bool=false) =
-    LineEditREPL(t, hascolor,
-        hascolor ? Base.text_colors[:green] : "",
-        hascolor ? Base.input_color() : "",
-        hascolor ? Base.answer_color() : "",
-        hascolor ? Base.text_colors[:red] : "",
-        hascolor ? Base.text_colors[:yellow] : "",
-        hascolor ? Base.text_colors[:blue] : "",
-        false, false, false, envcolors
-    )
+    LineEditREPL(t, hascolor, false, false, false)
 
 mutable struct REPLCompletionProvider <: CompletionProvider
     modifiers::LineEdit.Modifiers
@@ -1324,11 +1329,17 @@ function setup_interface(
     replc = REPLCompletionProvider()
 
     # Set up the main Julia prompt
-    julia_prompt = Prompt(contextual_prompt(repl, JULIA_PROMPT);
-        # Copy colors from the prompt object
-        prompt_prefix = hascolor ? repl.prompt_color : "",
-        prompt_suffix = hascolor ?
-            (repl.envcolors ? Base.input_color : repl.input_color) : "",
+    julia_prompt_text = if repl.prompt !== nothing
+        repl.prompt
+    else
+        julia_original_prompt = contextual_prompt(repl, JULIA_PROMPT)
+        () -> styled"{repl_prompt_julia:$(julia_original_prompt())}"
+    end
+
+    julia_output_prefix = repl.output_prefix !== nothing ? repl.output_prefix : ""
+
+    julia_prompt = Prompt(julia_prompt_text;
+        output_prefix = julia_output_prefix,
         repl = repl,
         complete = replc,
         on_enter = return_callback,
@@ -1338,10 +1349,13 @@ function setup_interface(
         ])
 
     # Setup help mode
-    help_mode = Prompt(contextual_prompt(repl, HELP_PROMPT),
-        prompt_prefix = hascolor ? repl.help_color : "",
-        prompt_suffix = hascolor ?
-            (repl.envcolors ? Base.input_color : repl.input_color) : "",
+    help_prompt_text = if repl.help_prompt !== nothing
+        repl.help_prompt
+    else
+        help_original_prompt = contextual_prompt(repl, HELP_PROMPT)
+        () -> styled"{repl_prompt_help:$(help_original_prompt())}"
+    end
+    help_mode = Prompt(help_prompt_text,
         repl = repl,
         complete = replc,
         # When we're done transform the entered line into a call to helpmode function
@@ -1350,10 +1364,8 @@ function setup_interface(
 
 
     # Set up shell mode
-    shell_mode = Prompt(SHELL_PROMPT;
-        prompt_prefix = hascolor ? repl.shell_color : "",
-        prompt_suffix = hascolor ?
-            (repl.envcolors ? Base.input_color : repl.input_color) : "",
+    shell_prompt_text = repl.shell_prompt !== nothing ? repl.shell_prompt : styled"{repl_prompt_shell:$SHELL_PROMPT}"
+    shell_mode = Prompt(shell_prompt_text;
         repl = repl,
         complete = ShellCompletionProvider(),
         # Transform "foo bar baz" into `foo bar baz` (shell quoting)
@@ -1368,10 +1380,13 @@ function setup_interface(
 
     # Set up dummy Pkg mode that will be replaced once Pkg is loaded
     # use 6 dots to occupy the same space as the most likely "@v1.xx" env name
-    dummy_pkg_mode = Prompt(Pkg_promptf,
-        prompt_prefix = hascolor ? repl.pkg_color : "",
-        prompt_suffix = hascolor ?
-        (repl.envcolors ? Base.input_color : repl.input_color) : "",
+    pkg_prompt_text = if repl.pkg_prompt !== nothing
+        repl.pkg_prompt
+    else
+        pkg_original_prompt = Pkg_promptf
+        () -> styled"{repl_prompt_pkg:$(pkg_original_prompt())}"
+    end
+    dummy_pkg_mode = Prompt(pkg_prompt_text,
         repl = repl,
         complete = LineEdit.EmptyCompletionProvider(),
         on_done = respond(line->nothing, repl, julia_prompt),
@@ -1409,7 +1424,7 @@ function setup_interface(
             mkpath(dirname(hist_path))
             hp.file_path = hist_path
             hist_open_file(hp)
-            finalizer(replc) do replc
+            finalizer(replc) do _
                 close(hp.history_file)
             end
             hist_from_file(hp, hist_path)
@@ -1710,23 +1725,21 @@ end
 
 mutable struct StreamREPL <: AbstractREPL
     stream::IO
-    prompt_color::String
-    input_color::String
-    answer_color::String
+    prompt::Union{AbstractString,Function}
     waserror::Bool
     frontend_task::Task
-    StreamREPL(stream,pc,ic,ac) = new(stream,pc,ic,ac,false)
+    StreamREPL(stream, prompt) = new(stream, prompt, false)
 end
-StreamREPL(stream::IO) = StreamREPL(stream, Base.text_colors[:green], Base.input_color(), Base.answer_color())
+StreamREPL(stream::IO) = StreamREPL(stream, styled"{repl_prompt_julia:$JULIA_PROMPT}")
 run_repl(stream::IO) = run_repl(StreamREPL(stream))
 
 outstream(s::StreamREPL) = s.stream
 hascolor(s::StreamREPL) = get(s.stream, :color, false)::Bool
 
-answer_color(r::LineEditREPL) = r.envcolors ? Base.answer_color() : r.answer_color
-answer_color(r::StreamREPL) = r.answer_color
-input_color(r::LineEditREPL) = r.envcolors ? Base.input_color() : r.input_color
-input_color(r::StreamREPL) = r.input_color
+# Kept for compatibility - return empty strings (no longer used)
+# Prompt colors are now handled via the face system (see REPL_FACES)
+answer_color(r::Union{LineEditREPL,StreamREPL}) = ""
+input_color(r::Union{LineEditREPL,StreamREPL}) = ""
 
 # heuristic function to decide if the presence of a semicolon
 # at the end of the expression was intended for suppressing output
@@ -1817,13 +1830,8 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
     dopushdisplay = !in(d,Base.Multimedia.displays)
     dopushdisplay && pushdisplay(d)
     while !eof(repl.stream)::Bool
-        if have_color
-            print(repl.stream,repl.prompt_color)
-        end
-        print(repl.stream, JULIA_PROMPT)
-        if have_color
-            print(repl.stream, input_color(repl))
-        end
+        promptstr = LineEdit.prompt_string(repl.prompt)
+        write(IOContext(repl.stream, :color => have_color), promptstr)
         line = readline(repl.stream, keep=true)
         if !isempty(line)
             ast = Base.parse_input_line(line)
@@ -1843,6 +1851,7 @@ end
 module Numbered
 
 using ..REPL
+using StyledStrings: @styled_str
 
 __current_ast_transforms() = Base.active_repl_backend !== nothing ? Base.active_repl_backend.ast_transforms : REPL.repl_ast_transforms
 
@@ -1892,10 +1901,7 @@ end
 
 function set_output_prefix(repl::LineEditREPL, n::Ref{Int})
     julia_prompt = repl.interface.modes[1]
-    if REPL.hascolor(repl)
-        julia_prompt.output_prefix_prefix = Base.text_colors[:red]
-    end
-    julia_prompt.output_prefix = () -> string("Out[", n[], "]: ")
+    julia_prompt.output_prefix = () -> styled"{repl_output_prefix_julia:Out[$(n[])]: }"
     nothing
 end
 

--- a/stdlib/REPL/src/options.jl
+++ b/stdlib/REPL/src/options.jl
@@ -15,7 +15,7 @@ mutable struct Options
     beep_duration::Float64
     beep_blink::Float64
     beep_maxduration::Float64
-    beep_colors::Vector{String}
+    beep_colors::Vector{Symbol}
     beep_use_current::Bool
     backspace_align::Bool
     backspace_adjust::Bool
@@ -40,7 +40,7 @@ Options(;
         kill_ring_max = 100,
         region_animation_duration = 0.2,
         beep_duration = 0.2, beep_blink = 0.2, beep_maxduration = 1.0,
-        beep_colors = ["\e[90m"], # gray (text_colors not yet available)
+        beep_colors = [:bright_black],
         beep_use_current = true,
         backspace_align = true, backspace_adjust = backspace_align,
         confirm_exit = false,

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -503,12 +503,12 @@ end
     termbuf = REPL.Terminals.TerminalBuffer(outbuf)
     @inferred(LineEdit.refresh_multi_line(termbuf, term, ps))
     @test String(take!(outbuf)) ==
-        "\r\e[0K\e[1mJulia is Fun! > \e[0m\r\e[16Cbegin\n" *
+        "\r\e[0KJulia is Fun! > \r\e[16Cbegin\n" *
         "\r\e[16C    julia = :fun\n" *
         "\r\e[16Cend\r\e[19C"
     LineEdit.refresh_multi_line(termbuf, term, ps)
     @test String(take!(outbuf)) ==
-        "\r\e[0K\e[1A\r\e[0K\e[1A\r\e[0K\e[1m> \e[0m\r\e[2Cbegin\n" *
+        "\r\e[0K\e[1A\r\e[0K\e[1A\r\e[0K> \r\e[2Cbegin\n" *
         "\r\e[2C    julia = :fun\n" *
         "\r\e[2Cend\r\e[5C"
 end


### PR DESCRIPTION
This is another version of https://github.com/JuliaLang/julia/pull/51887 (which I didn't know existed until recently) that tries to bring the REPL prompt customization into the post StyledStrings era.

Still need to do some work on it and think about backwards compatbility (some probably needs to be broken) but you can already do something like

```
using StyledStrings
using Dates
atreplinit() do repl
    # Dynamic prompt with time
    repl.output_prefix = () -> begin
      str = string(Dates.format(Dates.now(), "HH:MM:SS"), "> ")
      styled"{bold,bright_red:$str}"
    end

    # Dynamic prompt with Julia version and styling
    repl.prompt = () -> styled"{bold,magenta:julia v$(VERSION)>} "
end
```

and get:

<img width="170" height="63" alt="image" src="https://github.com/user-attachments/assets/731ef461-54c8-41c0-8def-89fb1562d7a1" />

This is the native version of https://kristofferc.github.io/OhMyREPL.jl/latest/features/prompt/.

cc @caleb-allen