### PR TITLE
[tests] Fix an invalidation test in the precompile testset (extracted out of #59413)

### DIFF
--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1125,7 +1125,8 @@ precompile_test_harness("code caching") do dir
         end
         @test invalidations[idxv-1].def.def.name === :flbi
         idxv = findnext(==("verify_methods"), invalidations, idxv+1)
-        @test invalidations[idxv-1].def.def.name === :useflbi
+        # Temporarily skip the next test on Windows (https://github.com/JuliaLang/julia/issues/59846):
+        @test invalidations[idxv-1].def.def.name === :useflbi skip=Sys.iswindows()
 
         m = only(methods(MB.map_nbits))
         @test !hasvalid(m.specializations::Core.MethodInstance, world+1) # insert_backedges invalidations also trigger their backedges

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1123,10 +1123,9 @@ precompile_test_harness("code caching") do dir
         if invalidations[idxv-1].def.def.name === :getproperty
             idxv = findnext(==("verify_methods"), invalidations, idxv+1)
         end
-        @test invalidations[idxv-1].def.def.name === :flbi
-        idxv = findnext(==("verify_methods"), invalidations, idxv+1)
-        # Temporarily skip the next test on Windows (https://github.com/JuliaLang/julia/issues/59846):
-        @test invalidations[idxv-1].def.def.name === :useflbi skip=Sys.iswindows()
+        idxv = findnext(==(invalidations[idxv-1]), invalidations, idxv+1)
+        @test invalidations[idxv-1] == "verify_methods"
+        @test invalidations[idxv-2].def.def.name === :useflbi
 
         m = only(methods(MB.map_nbits))
         @test !hasvalid(m.specializations::Core.MethodInstance, world+1) # insert_backedges invalidations also trigger their backedges


### PR DESCRIPTION
Fixes #59846
Extracted out of #59413 

---

Previous description:

~~Ref #59846.~~

~~It's not helpful to have this test frequently failing on Windows and causing noise.~~

~~The fix (#59413) isn't ready yet, so let's skip (on Windows) for now, and we can stop skipping once the fix lands.~~