### PR TITLE
loading: More simplification

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -623,9 +623,12 @@ function test_find(
 end
 
 @testset "find_package with one env in load path" begin
-    for (env, (_, _, roots, graph, paths)) in envs
-        push!(empty!(LOAD_PATH), env)
-        test_find(roots, graph, paths)
+    for idx in eachindex(envs)
+        @testset let idx=idx
+            (env, (_, _, roots, graph, paths)) = envs[idx]
+            push!(empty!(LOAD_PATH), env)
+            test_find(roots, graph, paths)
+        end
     end
 end
 


### PR DESCRIPTION
Mostly unswitches the distinction between a top-level load and a load into another project. The hope is that by keeping the code load flow more linear, it becomes easier to follow. No behavioral changes intended.