### PR TITLE
Type-assert `isfinite(::AbstractFloat)`

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -708,7 +708,7 @@ See also: [`iszero`](@ref), [`isone`](@ref), [`isinf`](@ref), [`ismissing`](@ref
 isnan(x::AbstractFloat) = (x != x)::Bool
 isnan(x::Number) = false
 
-isfinite(x::AbstractFloat) = !isnan(x - x)
+isfinite(x::AbstractFloat) = (!isnan(x - x))::Bool
 isfinite(x::Real) = decompose(x)[3] != 0
 isfinite(x::Integer) = true
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -708,7 +708,7 @@ See also: [`iszero`](@ref), [`isone`](@ref), [`isinf`](@ref), [`ismissing`](@ref
 isnan(x::AbstractFloat) = (x != x)::Bool
 isnan(x::Number) = false
 
-isfinite(x::AbstractFloat) = (!isnan(x - x))::Bool
+isfinite(x::AbstractFloat) = !(isnan(x - x)::Bool)
 isfinite(x::Real) = decompose(x)[3] != 0
 isfinite(x::Integer) = true
 


### PR DESCRIPTION
Currently it's inferred as `Any` because of the subtraction operation.

Should fix the second-to-last invalidation here from PythonCall.jl (CC @cjdoris):
```julia
 inserting &(x::Number, y::PythonCall.Py) @ PythonCall.Core ~/git/PythonCall.jl/src/Core/Py.jl:430 invalidated:                                                                                                                                
   mt_backedges:  1: signature Tuple{typeof(&), Bool, Any} triggered MethodInstance for Base.var"#string#403"(::Int64, ::Int64, ::typeof(string), ::Unsigned) (0 children)                                                                     
                  2: signature Tuple{typeof(&), Bool, Any} triggered MethodInstance for Base.var"#string#403"(::Int64, ::Int64, ::typeof(string), ::Signed) (0 children)                                                                       
                  3: signature Tuple{typeof(&), Bool, Any} triggered MethodInstance for Base.var"#string#403"(::Int64, ::Int64, ::typeof(string), ::Integer) (0 children)                                                                      
                  4: signature Tuple{typeof(&), Bool, Any} triggered MethodInstance for div(::Unsigned, ::Int64, ::RoundingMode{:Up}) (1 children)                                                                                             
                  5: signature Tuple{typeof(&), Bool, Any} triggered MethodInstance for isempty(::StepRange{Tuple{LineNumberNode, Expr}}) (2 children)                                                                                         
                  6: signature Tuple{typeof(&), Int64, Any} triggered MethodInstance for Base.hashindex(::Any, ::Any) (4 children)                                                                                                             
                  7: signature Tuple{typeof(&), Bool, Any} triggered MethodInstance for Base.Broadcast._broadcast_getindex_evalf(::typeof(&), ::Bool, ::Any) (5 children)                                                                      
                  8: signature Tuple{typeof(&), Bool, Any} triggered MethodInstance for isempty(::StepRange{String}) (10 children)                                                                                                             
                  9: signature Tuple{typeof(&), Int64, Any} triggered MethodInstance for Base.hashindex(::WeakRef, ::Any) (18 children)                                                                                                        
                 10: signature Tuple{typeof(&), Bool, Any} triggered MethodInstance for Base.checkbounds_indices(::Type{Bool}, ::Tuple, ::Tuple{CartesianIndex{2}}) (53 children)                                                              
                 11: signature Tuple{typeof(&), Bool, Any} triggered MethodInstance for isinf(::AbstractFloat) (202 children)                                                                                                                  
                 12: signature Tuple{typeof(&), Bool, Any} triggered MethodInstance for div(::Unsigned, ::Int64, ::RoundingMode{:Down}) (588 children)                                                                                         
```

Which according to Cthulhu is:
```julia
isinf(x::Real) @ Base ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/base/float.jl:723                                                                                                                                              
723 isinf(x::AbstractFloat::Real)::Any = !(isnan(x::AbstractFloat)::Bool)::Bool & !(isfinite(x::AbstractFloat)::Any)::Any
```

Which leads to:
```julia
isfinite(x::AbstractFloat) @ Base ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/base/float.jl:712
712 isfinite(x::AbstractFloat::AbstractFloat)::Any = !isnan((x::AbstractFloat - x::AbstractFloat)::Any)::Any
```