### PR TITLE
absint: allow ad-hoc cancellation of concrete evaluation

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -872,11 +872,12 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter,
     concrete_eval_result = nothing
     if eligibility === :concrete_eval
         concrete_eval_result = concrete_eval_call(interp, f, result, arginfo, sv, invokecall)
-        # if we don't inline the result of this concrete evaluation,
-        # give const-prop' a chance to inline a better method body
-        if !may_optimize(interp) || (
-            may_inline_concrete_result(concrete_eval_result.const_result::ConcreteResult) ||
-            concrete_eval_result.rt === Bottom) # unless this call deterministically throws and thus is non-inlineable
+        if (concrete_eval_result !== nothing &&  # allow external abstract interpreters to disable concrete evaluation ad-hoc
+            # if we don't inline the result of this concrete evaluation,
+            # give const-prop' a chance to inline a better method body
+            (!may_optimize(interp) ||
+             may_inline_concrete_result(concrete_eval_result.const_result::ConcreteResult) ||
+             concrete_eval_result.rt === Bottom)) # unless this call deterministically throws and thus is non-inlineable
             return concrete_eval_result
         end
         # TODO allow semi-concrete interp for this call?


### PR DESCRIPTION
This change is not necessary for `NativeInterpreter` at all, but is particularly useful for JET. For error reporting, which is the purpose of `JETAnalyzer`, it is desirable to present error causes in a user-understandable form even when concrete evaluation presents errors. This requires analysis using regular abstract interpretation (constant propagation) in general. However, to reduce false positives, the precision that concrete evaluation brings is very important, and completely disabling concrete evaluation is not desirable either. Currently, `JETAnalyzer` aims to avoid this tradeoff by limiting concrete evaluation to only some functions, but this approach does not scale and occasionally causes problems like JuliaLang/julia#59884.

This commit enables ad-hoc cancellation of concrete evaluation based on the result of `concrete_eval_call`, allowing `JETAnalyzer` to fallback to abstract interpretation only when concrete evaluation causes errors, fundamentally avoiding such problems.