### PR TITLE
Add single-argument `foreach` method to consume iterable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,7 @@ New library features
 * `Base.AbstractOneTo` is added as a supertype of one-based axes, with `Base.OneTo` as its subtype ([#56902]).
 * `takestring!(::IOBuffer)` removes the content from the buffer, returning the content as a `String`.
 * `chopprefix` and `chopsuffix` can now also accept an `AbstractChar` as the prefix/suffix to remove.
+* `foreach` now accepts a single iterable to consume it for its side effects ([#59913]).
 * The `macroexpand` (with default true) and the new `macroexpand!` (with default false)
   functions now support a `legacyscope` boolean keyword argument to control whether to run
   the legacy scope resolution pass over the result. The legacy scope resolution code has

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3177,6 +3177,7 @@ end
 
 """
     foreach(f, c...) -> nothing
+    foreach(c) -> nothing
 
 Call function `f` on each element of iterable `c`.
 For multiple iterable arguments, `f` is called elementwise, and iteration stops when
@@ -3184,6 +3185,16 @@ any iterator is finished.
 
 `foreach` should be used instead of [`map`](@ref) when the results of `f` are not
 needed, for example in `foreach(println, array)`.
+
+Without supplying `f`, `foreach(c)` simply exhausts the iterable `c` and discards all
+values. This is equivalent to `for _ in c; end; nothing`. Use it when you need to force
+evaluation of an iterator for its side effects (e.g. in a pipeline, with function
+composition or with a generator) but do not need to transform its elements.
+
+The single-argument form is a shorter alternative to `foreach(identity, c)`, and
+avoids the allocations that a comprehension or `collect(c)` would incur.
+
+See also: [`collect`](@ref), [`map`](@ref).
 
 # Examples
 ```jldoctest
@@ -3201,10 +3212,18 @@ julia> foreach((x, y) -> println(x, " with ", y), tri, 'a':'z')
 1 with a
 4 with b
 7 with c
+
+julia> (println(10 + x) for x = tri if x < 5) |> foreach
+11
+14
+
+julia> foreach(tri) === nothing
+true
 ```
 """
 foreach(f, itr) = (for x in itr; f(x); end; nothing)
 foreach(f, itr, itrs...) = (for z in zip(itr, itrs...); f(z...); end; nothing)
+foreach(itr) = (for _ in itr; end; nothing)
 
 ## map over arrays ##
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3194,6 +3194,10 @@ composition or with a generator) but do not need to transform its elements.
 The single-argument form is a shorter alternative to `foreach(identity, c)`, and
 avoids the allocations that a comprehension or `collect(c)` would incur.
 
+!!! compat "Julia 1.13"
+    The single-argument method requires Julia 1.13 or later. To support previous versions,
+    too, use the equivalent `foreach(identity, c)`.
+
 See also: [`collect`](@ref), [`map`](@ref).
 
 # Examples

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3196,7 +3196,7 @@ avoids the allocations that a comprehension or `collect(c)` would incur.
 
 !!! compat "Julia 1.13"
     The single-argument method requires Julia 1.13 or later. To support previous versions,
-    too, use the equivalent `foreach(identity, c)`.
+    too, use the equivalent `foreach(Returns(nothing), c)`.
 
 See also: [`collect`](@ref), [`map`](@ref).
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3220,9 +3220,6 @@ julia> foreach((x, y) -> println(x, " with ", y), tri, 'a':'z')
 julia> (println(10 + x) for x = tri if x < 5) |> foreach
 11
 14
-
-julia> foreach(tri) === nothing
-true
 ```
 """
 foreach(f, itr) = (for x in itr; f(x); end; nothing)


### PR DESCRIPTION
We seem to lack a way to just consume an iterable with a function.

This is not a big deal, but a little quality-of-life improvement and seems to be more or less standard in programming languages nowadays.

`foreach` seems to be the most fitting name for Julia according to this overview from ChatGPT 5:
Summary (just the primary names/keywords):
- Python: for, deque(...)
- JavaScript: for...of
- Java: forEachRemaining, forEach
- C++: for_each (std / ranges)
- C#: foreach
- Go: for range
- Ruby: each
- Rust: for_each
- Swift: forEach
- Kotlin: forEach

Implemented with help from ChatGPT 5.

Probably relevant for Triage:
This method could effectively block the possible future definition
```
foreach(f) = itr -> foreach(f, itr)
```
at least as long as we do not find a way to type-constraint an iterable.