### PR TITLE
Set types of boxed variables in `abstract_eval_nonlinearized_foreigncall_name`

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3457,7 +3457,7 @@ function abstract_eval_nonlinearized_foreigncall_name(
         callresult = Future{CallMeta}()
         i::Int = 1
         nextstate::UInt8 = 0x0
-        local ai, res
+        local ai::Future, res::Future
         function evalargs(interp, sv)
             if nextstate === 0x1
                 @goto state1


### PR DESCRIPTION
This prevents invalidations of `isready()` from loading Distributed on 1.12:
```julia
 inserting isready(pool::Distributed.WorkerPool) @ Distributed ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/stdlib/v1.12/Distributed/src/workerpool.jl:168 invalidated:
   mt_backedges: 1: signature Tuple{typeof(isready), Any} triggered MethodInstance for (::Compiler.var"#evalargs#abstract_eval_nonlinearized_foreigncall_name##0"{Expr, Compiler.StatementState, Compiler.Future{Compiler.CallMeta}, Vector{Any}, Int64})(::Compiler.AbstractInterpreter, ::Compiler.InferenceState) (0 children)
                 2: signature Tuple{typeof(isready), Any} triggered MethodInstance for (::Compiler.var"#evalargs#abstract_eval_nonlinearized_foreigncall_name##0"{Expr, Compiler.StatementState, Compiler.Future{Compiler.CallMeta}, Vector{Any}, Int64})(::Compiler.NativeInterpreter, ::Compiler.InferenceState) (0 children)
                 3: signature Tuple{typeof(isready), Any} triggered MethodInstance for (::Compiler.var"#evalargs#abstract_eval_nonlinearized_foreigncall_name##0"{Expr, Compiler.StatementState, Compiler.Future{Compiler.CallMeta}, Vector{Any}, Int64})(::Compiler.AbstractInterpreter, ::Compiler.InferenceState) (249 children)
```

I think ideally it wouldn't use a closure at all, but I'm not familiar enough with the code to refactor it that much. I'm making the PR against the `release-1.12` branch because this function is deleted entirely on master by #59165.