### PR TITLE
Fix ccall example for function 'f'

### DIFF
--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -1152,7 +1152,7 @@ A table of translations between the macro and function interfaces is given below
 | `@ccall`                                                                     | `ccall`                                                                     |
 |------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | `@ccall clock()::Int32`                                                      | `ccall(:clock, Int32, ())`                                                  |
-| `@ccall f(a::Cint)::Cint`                                                    | `ccall(:a, Cint, (Cint,), a)`                                               |
+| `@ccall f(a::Cint)::Cint`                                                    | `ccall(:f, Cint, (Cint,), a)`                                               |
 | `@ccall "mylib".f(a::Cint, b::Cdouble)::Cvoid`                               | `ccall((:f, "mylib"), Cvoid, (Cint, Cdouble), a, b)`                        |
 | `@ccall $fptr.f()::Cvoid`                                                    | `ccall(fptr, f, Cvoid, ())`                                                 |
 | `@ccall printf("%s = %d\n"::Cstring ; "foo"::Cstring, foo::Cint)::Cint`      | `<unavailable>`                                                             |


### PR DESCRIPTION
This fixes a small typo in the example demonstrating the difference between the `@ccall` macro and the `ccall` syntax.