### PR TITLE
improve performance of `powermod`

### DIFF
--- a/base/multinverses.jl
+++ b/base/multinverses.jl
@@ -2,7 +2,7 @@
 
 module MultiplicativeInverses
 
-import Base: div, divrem, mul_hi, rem, unsigned
+import Base: div, divrem, mul_hi, rem, unsigned, mod
 using  Base: IndexLinear, IndexCartesian, tail
 export multiplicativeinverse
 
@@ -151,6 +151,13 @@ rem(a::T, b::MultiplicativeInverse{T}) where {T} =
 function divrem(a::T, b::MultiplicativeInverse{T}) where T
     d = div(a, b)
     (d, a - d*b.divisor)
+end
+
+mod(a::T, b::UnsignedMultiplicativeInverse{T}) where {T} = rem(a, b)
+
+function mod(a::T, b::SignedMultiplicativeInverse{T}) where {T}
+    r = rem(a, b)
+    return (iszero(r) || signbit(r) == signbit(b.divisor)) ? r : r + b.divisor
 end
 
 multiplicativeinverse(x::Signed) = SignedMultiplicativeInverse(x)

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -385,6 +385,10 @@ end
 
     @test powermod(-3, 0x80, 7) === 2
     @test powermod(0x03, 0x80, 0x07) === 0x02
+
+    @test powermod(511, 1, 0x00000021) === 0x00000010
+    @test powermod(Int8(-1), 0xff, Int8(33)) === Int8(32)
+    @test powermod(0, 10, -5) === 0
 end
 
 @testset "nextpow/prevpow" begin


### PR DESCRIPTION
based off of and closes https://github.com/JuliaLang/julia/pull/54866

differences to https://github.com/JuliaLang/julia/pull/54866 are:

* checks `iszero(r)` in `mod(a, ::SignedMultiplicativeInverse)` for cases like `mod(0, multiplicativeinverse(-5))`
* catches some cases of mismatched signed-ness of `x, m` that were failing
* added a very very rough heuristic `(p > 2sizeof(mm))` so we don't bother computing the mi when the power is very small
* switched to LSB multiplication loop from MSB

benchmark:
```
using BenchmarkTools

function setup()
    x,p,m = rand(NTuple{3, Int})
    while iszero(m) || ((p < 0) && !isone(gcd(x, m)))
        x,p,m = rand(NTuple{3, Int})
    end
    return (x, p, m)
end

@benchmark powermod(x, p, m) setup=((x,p,m) = setup())


#master
BenchmarkTools.Trial: 10000 samples with 10 evaluations per sample.
 Range (min … max):  1.304 μs …   8.938 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.779 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.803 μs ± 270.848 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

               ▂▄▅████▇▆▄▁▁                                    
  ▁▁▁▁▁▁▁▂▂▃▅▅▇█████████████▆▅▄▃▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  1.3 μs          Histogram: frequency by time        2.76 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.



#PR
julia> @benchmark powermod(x, p, m) setup=((x,p,m) = setup())
BenchmarkTools.Trial: 10000 samples with 135 evaluations per sample.
 Range (min … max):  667.896 ns …  1.267 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     854.015 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   886.407 ns ± 74.610 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                        ▂▃▆██▅▂                                 
  ▂▂▁▁▂▂▂▂▂▂▂▂▂▂▃▃▃▄▄▅▆▇████████▆▅▄▃▃▃▃▃▄▄▅▆▆▇▇████▇▆▆▅▄▃▃▃▃▂▂ ▄
  668 ns          Histogram: frequency by time         1.06 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```