### PR TITLE
Type-assert the return type of `collect(...)` in TOML

### DIFF
--- a/stdlib/TOML/src/print.jl
+++ b/stdlib/TOML/src/print.jl
@@ -117,7 +117,7 @@ function print_integer(io::IO, value::Integer)
 end
 
 function print_inline_table(f::Function, io::IO, value::AbstractDict, sorted::Bool)
-    vkeys = collect(keys(value))
+    vkeys = collect(keys(value))::AbstractArray
     if sorted
         sort!(vkeys)
     end


### PR DESCRIPTION
On 1.12 this prevents the majority of invalidations from ChunkSplitters (dependency of OhMyThreads), going from:
```julia
1-element Vector{SnoopCompile.MethodInvalidations}:
 inserting enumerate(c::ChunkSplitters.Internals.AbstractChunks) @ ChunkSplitters.Internals ~/.julia/packages/ChunkSplitters/SGtAq/src/internals.jl:123 invalidated:
   backedges: 1: superseding enumerate(iter) @ Base.Iterators iterators.jl:191 with MethodInstance for enumerate(::Any) (242 children)
```

To:
```julia
1-element Vector{SnoopCompile.MethodInvalidations}:
 inserting enumerate(c::ChunkSplitters.Internals.AbstractChunks) @ ChunkSplitters.Internals /path/to/julia-depot/packages/ChunkSplitters/SGtAq/src/internals.jl:123 invalidated:
   backedges: 1: superseding enumerate(iter) @ Base.Iterators iterators.jl:191 with MethodInstance for enumerate(::Any) (3 children)
```

Cthulhu showed that most invalidations were coming from this method in TOML.jl:
```julia
print_inline_table(f::Union{Nothing, Function}, io::IO, value::AbstractDict, sorted::Bool) @ TOML.Internals.Printer ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/stdlib/v1.12/TOML/src/print.jl:120
120 function print_inline_table(f::Function::MbyFunc, io::IOBuffer::IO, value::AbstractDict::AbstractDict, sorted::Bool::Bool)::Core.Const(nothing)
121     vkeys::Any = collect(keys(value::AbstractDict)::Any)::Any
122     if sorted
123         sort!(vkeys::Any)
124     end
125     Base.print::Core.Const(print)(io, "{")
126     for (i::Int64, k::Any) in enumerate(vkeys::Any)::Union{ChunkSplitters.Internals.Enumerate, Base.Iterators.Enumerate}::Union{Nothing, Tuple{Tuple{Int64, Any}, Int64}, Tuple{Tuple{Int64, Any}, Tuple{Int64, Any}}}
127         v::Any = value::AbstractDict[k::Any]::Any
128         (i::Int64 != 1)::Bool && Base.print::Core.Const(print)(io, ", ")
129         printkey(io::IOBuffer, [String(k::Any)::Any]::Vector)
130         Base.print::Core.Const(print)(io, " = ")
131         printvalue(f::Function, io::IOBuffer, v::Any, sorted::Bool)
132     end
133     Base.print::Core.Const(print)(io, "}")
134 end
```

`vkeys` is inferred as Any so on line 126 `enumerate(::Any)` is called, which is invalidated by ChunkSplitters defining its own `Base.enumerate` method: https://github.com/JuliaFolds2/ChunkSplitters.jl/blob/715991816504a40cbbe21cf057f29f1b82a7c349/src/internals.jl#L123

It could be fixed by asserting `vkeys::Vector`, but I figured it's better to type assert `collect(itr)` since that's guaranteed to return an Vector anyway.