### PR TITLE
A change list for the compiler

### DIFF
--- a/Compiler/HISTORY.md
+++ b/Compiler/HISTORY.md
@@ -1,0 +1,35 @@
+The Julia compiler is not part of the public interface of Julia's `Core`, and may change in non-breaking Julia releases. However, since several community packages do interface with the compiler, this file lists breaking changes introduced to the compiler, to aid in adapting to those changes.
+
+# v1.12
+
+## Changes to the `IRCode` type
+
+The `linetable` field of `IRCode` has been removed. The same information is now available in a different format in the `debuginfo` field. TODO: Add a high level explanation of the differences and how to adapt.
+
+Related to the above, the `verify_linetable` function that previously took in a `Vector{Core.LineInfoNode}` now wants a `DebugInfoStream`, and also a second argument `nstmts::Int64` for the number of statements.
+
+`IRCode` now has a new field called `valid_worlds`. TODO Explain what it does.
+
+## `InstructionStream` constructors have gotten stricter
+
+The constructor for `InstructionStream` now requires the arguments to be of exactly the correct types. The fields haven't changed, but for instance you need to cast the second argument called `type` to be a `Vector{Any}` instead of being able to pass in something like a `Vector{Type}` and relying on an automatic cast.
+
+## `CodeInstance`s rather than `MethodInstance`s
+
+Something in the `IRCode` type has changed to internally use `CodeInstance` rather than directly `MethodInstance`. For instance, this
+```julia
+f(a) = println(a)
+ir = Base.code_ircode_by_type(Tuple{typeof(f), Int})[1][1]
+println(ir.stmts[1].data.stmt[1].args[1])
+```
+on 1.11 is `MethodInstance for println(::Int64)` but on 1.12 `CodeInstance for MethodInstance for println(::Int64)`.
+
+TODO Explain this whole thing properly.
+
+## `SpecInfo` replaces `MethodInfo`
+
+TODO Explain what the difference is and where this comes up.
+
+## Changes to `OpaqueClosure`s
+
+TODO Explain what's changed.

--- a/Compiler/HISTORY.md
+++ b/Compiler/HISTORY.md
@@ -1,4 +1,4 @@
-The Julia compiler is not part of the public interface of Julia's `Core`, and may change in non-breaking Julia releases. This file lists breaking changes introduced to the compiler to aid in adapting to those changes, intended for packages that do interface with the compiler.
+The Julia compiler is not part of the public interface of Julia's `Core`, and may change in non-breaking Julia releases. This file lists breaking changes introduced to the compiler to aid in adapting to those changes, intended for packages that do interface with the compiler. It is maintained on a best-effort basis and may be incomplete.
 
 # v1.13
 

--- a/Compiler/HISTORY.md
+++ b/Compiler/HISTORY.md
@@ -1,35 +1,41 @@
-The Julia compiler is not part of the public interface of Julia's `Core`, and may change in non-breaking Julia releases. However, since several community packages do interface with the compiler, this file lists breaking changes introduced to the compiler, to aid in adapting to those changes.
+The Julia compiler is not part of the public interface of Julia's `Core`, and may change in non-breaking Julia releases. This file lists breaking changes introduced to the compiler to aid in adapting to those changes, intended for packages that do interface with the compiler.
+
+# v1.13
 
 # v1.12
 
 ## Changes to the `IRCode` type
 
-The `linetable` field of `IRCode` has been removed. The same information is now available in a different format in the `debuginfo` field. TODO: Add a high level explanation of the differences and how to adapt.
+The `linetable` field of `IRCode` has been removed, and the source line information is now available in a different format in the `debuginfo` field. ([#52415](https://github.com/JuliaLang/julia/pull/52415))
 
-Related to the above, the `verify_linetable` function that previously took in a `Vector{Core.LineInfoNode}` now wants a `DebugInfoStream`, and also a second argument `nstmts::Int64` for the number of statements.
+Related to the above, the `verify_linetable` function changed its signature from `verify_linetable(::Vector{Core.LineInfoNode})` to `verify_linetable(::DebugInfoStream, nstmts::Int64)`, the second argument being the number of statements.
 
-`IRCode` now has a new field called `valid_worlds`. TODO Explain what it does.
+`IRCode` now has a `valid_worlds` field, to explicitly communicate which worlds are
+to be considered for type inference and optimization purposes. As 1.12 introduced world-age
+partitioned bindings, this information is key to properly infer through global bindings.
+An upper bound that is not constrained enough may lead to a failure to accurately infer and optimize these.
 
 ## `InstructionStream` constructors have gotten stricter
 
 The constructor for `InstructionStream` now requires the arguments to be of exactly the correct types. The fields haven't changed, but for instance you need to cast the second argument called `type` to be a `Vector{Any}` instead of being able to pass in something like a `Vector{Type}` and relying on an automatic cast.
 
-## `CodeInstance`s rather than `MethodInstance`s
+## `CodeInstance`s replacing certain uses of `MethodInstance`s
 
-Something in the `IRCode` type has changed to internally use `CodeInstance` rather than directly `MethodInstance`. For instance, this
-```julia
-f(a) = println(a)
-ir = Base.code_ircode_by_type(Tuple{typeof(f), Int})[1][1]
-println(ir.stmts[1].data.stmt[1].args[1])
-```
-on 1.11 is `MethodInstance for println(::Int64)` but on 1.12 `CodeInstance for MethodInstance for println(::Int64)`.
+`CodeInstance` has gradually replaced `MethodInstance` in more and more places, over several
+extensive PRs. `CodeInstance` holds the cached results of inference, and usually end up stored in
+the `.cache` field of their parent `MethodInstance`s (with the `.next` field of `CodeInstance`
+allowing a linked list to be formed by holding further `CodeInstance`s).
 
-TODO Explain this whole thing properly.
+One notable change is that the first argument to `invoke` expressions is now a `CodeInstance`
+instead of a `MethodInstance`.
+
+The parent `MethodInstance` of a `CodeInstance` may be accessed with `Compiler.get_ci_mi(code_instance)`.
 
 ## `SpecInfo` replaces `MethodInfo`
 
-TODO Explain what the difference is and where this comes up.
+`MethodInfo` was renamed to `SpecInfo`, and two fields `nargs::Int` and `isva::Bool` have been prepended to it, indicating how many arguments a specialization takes, and whether its signature is variadic (of the form `f(x...)`). ([#55976](https://github.com/JuliaLang/julia/pull/55976))
 
 ## Changes to `OpaqueClosure`s
 
-TODO Explain what's changed.
+`OpaqueClosure` now requires the first argument type of its source `IRCode` to be the type of
+its environment (passed through `env...`), such as `Tuple{Int, Float64}` or `Tuple{}` for no captures. ([#54458](https://github.com/JuliaLang/julia/pull/54458))

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -270,6 +270,7 @@ DevDocs = [
         "devdocs/jit.md",
         "devdocs/builtins.md",
         "devdocs/precompile_hang.md",
+        "devdocs/compiler_changes.md",
     ],
     "Developing/debugging Julia's C code" => [
         "devdocs/backtraces.md",

--- a/doc/src/devdocs/compiler_changes.md
+++ b/doc/src/devdocs/compiler_changes.md
@@ -1,10 +1,10 @@
-The Julia compiler is not part of the public interface of Julia's `Core`, and may change in non-breaking Julia releases. This file lists breaking changes introduced to the compiler to aid in adapting to those changes, intended for packages that do interface with the compiler. It is maintained on a best-effort basis and may be incomplete.
+# History of changes to the compiler
 
-# v1.13
+The Julia compiler is not part of the public interface of Julia's `Core`, and may change in non-breaking Julia releases. This page lists breaking changes introduced to the compiler to aid in adapting to those changes, intended for packages that do interface with the compiler. It is maintained on a best-effort basis and may be incomplete.
 
-# v1.12
+## v1.12
 
-## Changes to the `IRCode` type
+### Changes to the `IRCode` type
 
 The `linetable` field of `IRCode` has been removed, and the source line information is now available in a different format in the `debuginfo` field. ([#52415](https://github.com/JuliaLang/julia/pull/52415))
 
@@ -15,11 +15,11 @@ to be considered for type inference and optimization purposes. As 1.12 introduce
 partitioned bindings, this information is key to properly infer through global bindings.
 An upper bound that is not constrained enough may lead to a failure to accurately infer and optimize these.
 
-## `InstructionStream` constructors have gotten stricter
+### `InstructionStream` constructors have gotten stricter
 
 The constructor for `InstructionStream` now requires the arguments to be of exactly the correct types. The fields haven't changed, but for instance you need to cast the second argument called `type` to be a `Vector{Any}` instead of being able to pass in something like a `Vector{Type}` and relying on an automatic cast.
 
-## `CodeInstance`s replacing certain uses of `MethodInstance`s
+### `CodeInstance`s replacing certain uses of `MethodInstance`s
 
 `CodeInstance` has gradually replaced `MethodInstance` in more and more places, over several
 extensive PRs. `CodeInstance` holds the cached results of inference, and usually end up stored in
@@ -31,11 +31,11 @@ instead of a `MethodInstance`.
 
 The parent `MethodInstance` of a `CodeInstance` may be accessed with `Compiler.get_ci_mi(code_instance)`.
 
-## `SpecInfo` replaces `MethodInfo`
+### `SpecInfo` replaces `MethodInfo`
 
 `MethodInfo` was renamed to `SpecInfo`, and two fields `nargs::Int` and `isva::Bool` have been prepended to it, indicating how many arguments a specialization takes, and whether its signature is variadic (of the form `f(x...)`). ([#55976](https://github.com/JuliaLang/julia/pull/55976))
 
-## Changes to `OpaqueClosure`s
+### Changes to `OpaqueClosure`s
 
 `OpaqueClosure` now requires the first argument type of its source `IRCode` to be the type of
 its environment (passed through `env...`), such as `Tuple{Int, Float64}` or `Tuple{}` for no captures. ([#54458](https://github.com/JuliaLang/julia/pull/54458))


### PR DESCRIPTION
Changes to the compiler in 1.12, while very welcome, caused work for some packages that interface with the compiler. I'm aware of https://github.com/chalk-lab/Mooncake.jl/pull/714 and https://github.com/TuringLang/Libtask.jl/pull/196, there are probably others. This is of course understandable and unavoidable when packages interface with internals that aren't public.

However, as discussed on Slack a few times, it would be very useful for package maintainers if there was even a rough list of changes, and advice on how to adapt to them. To kickstart this, I started a draft with changes I encountered in 1.12. It is very incomplete (reflecting my very superficial understanding of the compiler), and I would be grateful and happy if those who know this stuff better would be up for completing it, merging it, and adding to it as more things happen in 1.13.