### PR TITLE
Fix Meta.parse to allow trailing whitespace (fixes #59935)

### DIFF
--- a/base/meta.jl
+++ b/base/meta.jl
@@ -391,7 +391,8 @@ function parse(str::AbstractString;
     if isexpr(ex, :error)
         return ex
     end
-    if pos <= ncodeunits(str)
+           # Check if there are non-whitespace tokens remaining
+    if pos <= ncodeunits(str) && !isempty(strip(SubString(str, pos)))
         raise && throw(ParseError("extra token after end of expression"))
         return Expr(:error, "extra token after end of expression")
     end


### PR DESCRIPTION
In Julia 1.12, Meta.parse started throwing "extra token after end of expression"  errors when parsing expressions with trailing newlines (e.g., Meta.parse("x=1\n\n")).

This fix modifies the parse function to check if remaining characters after  parsing are only whitespace before throwing an error. The condition now checks:
- if pos <= ncodeunits(str) && !isempty(strip(SubString(str, pos)))

This maintains backward compatibility with code that relied on the old behavior  while still detecting actual extra tokens after expressions.