### PR TITLE
Test: Add `@include_files` for filtering test files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -108,6 +108,7 @@ Standard library changes
 * Transparent test sets (`@testset let`) now show context when tests error ([#58727]).
 * `@test_throws` now supports a three-argument form `@test_throws ExceptionType pattern expr` to test both exception type and message pattern in one call ([#59117]).
 * The testset stack was changed to use `ScopedValue` rather than task local storage ([#53462]).
+* New `@include_files` macro for organizing test files with optional filtering based on command-line arguments. Supports `Pkg.test(test_args=["--files=pattern"])` for substring matching and `Pkg.test(test_args=["--files-regex=pattern"])` for regex matching to run only matching test files. ([#59951])
 
 #### InteractiveUtils
 

--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -296,6 +296,51 @@ in the test set reporting. The test will not run but gives a `Broken` `Result`.
 Test.@test_skip
 ```
 
+## Organizing Test Files
+
+When working with larger test suites, it's common to split tests across multiple files. The
+`@include_files` macro provides a convenient way to include test files with optional filtering
+based on command-line arguments.
+
+```@docs
+Test.@include_files
+```
+
+For example, a package's `test/runtests.jl` might look like:
+
+```julia
+using Test
+
+# Include utility functions
+include("test_utils.jl")
+
+# Include test files, optionally filtered by command-line args
+@include_files [
+    "basics.jl",
+    "advanced.jl",
+    "performance.jl",
+]
+```
+
+This allows running specific test files:
+
+```julia
+# Run all tests
+Pkg.test("MyPackage")
+
+# Run only files containing "basics"
+Pkg.test("MyPackage", test_args=["--files=basics"])
+
+# Run files containing "basics" or "advanced"
+Pkg.test("MyPackage", test_args=["--files=basics,advanced"])
+
+# Use regex patterns for more complex filtering
+Pkg.test("MyPackage", test_args=["--files-regex=^test_.*_integration\\.jl\$"])
+
+# Match files with "basic" or "advanced" using regex
+Pkg.test("MyPackage", test_args=["--files-regex=basic|advanced"])
+```
+
 ## Test result types
 
 ```@docs

--- a/stdlib/Test/test/include_test/runtests.jl
+++ b/stdlib/Test/test/include_test/runtests.jl
@@ -1,0 +1,3 @@
+using Test
+
+@include_files ["test_foo.jl", "test_bar.jl", "test_baz.jl"]

--- a/stdlib/Test/test/include_test/test_bar.jl
+++ b/stdlib/Test/test/include_test/test_bar.jl
@@ -1,0 +1,1 @@
+println("BAR_RAN")

--- a/stdlib/Test/test/include_test/test_baz.jl
+++ b/stdlib/Test/test/include_test/test_baz.jl
@@ -1,0 +1,1 @@
+println("BAZ_RAN")

--- a/stdlib/Test/test/include_test/test_foo.jl
+++ b/stdlib/Test/test/include_test/test_foo.jl
@@ -1,0 +1,1 @@
+println("FOO_RAN")

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -193,7 +193,7 @@ let
         :TestModSub9475, :d7648, :eval, :f7648, :include])
     imported = Set(Symbol[:convert, :curmod_name, :curmod])
     usings_from_Test = Set(Symbol[
-        Symbol("@inferred"), Symbol("@test"), Symbol("@test_broken"), Symbol("@test_deprecated"),
+        Symbol("@inferred"), Symbol("@include_files"), Symbol("@test"), Symbol("@test_broken"), Symbol("@test_deprecated"),
         Symbol("@test_logs"), Symbol("@test_nowarn"), Symbol("@test_skip"), Symbol("@test_throws"),
         Symbol("@test_warn"), Symbol("@testset"), :GenericArray, :GenericDict, :GenericOrder,
         :GenericSet, :GenericString, :LogRecord, :Test, :TestLogger, :TestSetException,


### PR DESCRIPTION
Formalizes a way to select test files at the Pkg.test level.

i.e. `runtests.jl`
```julia
using Test

include("utils.jl") # common utils

@include_files [
    "foo.jl",
    "bar.jl",
    "baz.jl",
]
```
Then to run tests use `--files` (which matches files using occursin)
```julia
Pkg.test(test_args=["--files=foo"])
```
or using `--files-regex` for regex matching
```julia
Pkg.test(test_args=["--files-regex=foo|bar"])
```
More examples in the docstring.

Backwards compat provided via Compat.jl https://github.com/JuliaLang/Compat.jl/pull/846

---

This is largely inspired by Claude constantly expecting this to work:
```julia
Pkg.test(test_args=["file_name"]) 
```
However I required the `--files` or `--files-regex` arg name because otherwise what Claude wanted would restrict any other usage of test_args/ARGS