### PR TITLE
Read the terminal colour scheme on REPL startup

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -28,9 +28,16 @@ export run_interface, Prompt, ModalInterface, transition, reset_state, edit_inse
 
 const StringLike = Union{Char,String,SubString{String}}
 
+const ANSI_COLOR_ORDER = (
+    :black, :red, :green, :yellow, :blue, :magenta, :cyan, :white,
+    :bright_black, :bright_red, :bright_green, :bright_yellow,
+    :bright_blue, :bright_magenta, :bright_cyan, :bright_white)
+
 mutable struct TerminalProperties
     da1::Union{Nothing, Vector{Int}}  # DA1 feature parameters
-    TerminalProperties() = new(nothing)
+    colors::Vector{Pair{Symbol, StyledStrings.RGBTuple}}
+    awaiting_colors::Bool
+    TerminalProperties() = new(nothing, Pair{Symbol, StyledStrings.RGBTuple}[], false)
 end
 
 """
@@ -63,6 +70,153 @@ function receive_da1!(props::TerminalProperties, io::IO)
     end
     props.da1 = params
     return
+end
+
+"""
+    read_osc_response(io::IO)
+
+Read the body of an OSC response from `io` (after `\\e]` has been consumed by
+the keymap), up to a BEL, ST, or `^C` terminator.
+
+`^C` is accepted so that a malformed or truncated response cannot hang the REPL.
+"""
+function read_osc_response(io::IO)
+    data = Base.StringVector(0)
+    while !eof(io)
+        b = read(io, UInt8)
+        b ∈ (0x03, 0x07, 0x9c) && break  # ^C, BEL, or ST (8-bit)
+        if b == UInt8('\e')              # ST (7-bit, "\e\\")
+            b = read(io, UInt8)
+            b == UInt8('\\') && break
+            push!(data, UInt8('\e'))
+        end
+        push!(data, b)
+    end
+    String(data)
+end
+
+"""
+    interpret_color(spec::AbstractString)
+
+Interpret an X11 `rgb:`/`rgba:` colour `spec` as an `RGBTuple`, or return
+`nothing` if it is malformed.
+
+Components may be given with any number of hex digits (`rgb:RR/GG/BB` and
+`rgb:RRRR/GGGG/BBBB` are both common); they are scaled down to 8 bits. Any
+alpha component is ignored.
+
+# Examples
+```julia
+julia> interpret_color("rgb:2424/2727/3030")
+(r = 0x24, g = 0x27, b = 0x30)
+```
+"""
+function interpret_color(spec::AbstractString)
+    ncomponents = if startswith(spec, "rgb:")
+        3
+    elseif startswith(spec, "rgba:")
+        4
+    else
+        return
+    end
+    # The prefix is one character longer than the number of components it announces.
+    components = split(@view(spec[ncomponents+2:end]), '/')
+    length(components) == ncomponents || return
+    function tryparsecolor(chex)
+        ndigits = ncodeunits(chex)
+        ndigits in 1:4 || return nothing
+        cnum = tryparse(UInt16, chex, base=16)
+        isnothing(cnum) && return nothing
+        # Scale to 8 bits: "R" is widened to "RR", "RRRR" truncated to its high byte.
+        if ndigits == 1
+            UInt8(cnum * 0x11)
+        else
+            UInt8(cnum ÷ 16^(ndigits - 2))
+        end
+    end
+    r = tryparsecolor(components[1])
+    isnothing(r) && return
+    g = tryparsecolor(components[2])
+    isnothing(g) && return
+    b = tryparsecolor(components[3])
+    isnothing(b) && return
+    (; r, g, b)
+end
+
+"""
+    receive_osc!(props::TerminalProperties, io::IO)
+
+Read an OSC response from `io` (after `\\e]` has been consumed by the keymap)
+and record any colour it reports in `props.colors`.
+
+Recognises the foreground (`10`), background (`11`), and ANSI palette (`4`)
+responses issued by [`query_colors`](@ref). The background is queried last, so
+its reply means every colour the terminal intends to report has been seen, and
+the palette is applied with `StyledStrings.setcolors!`.
+"""
+function receive_osc!(props::TerminalProperties, io::IO)
+    parts = split(read_osc_response(io), ';')
+    opcode = tryparse(Int, first(parts))
+    (isnothing(opcode) || !props.awaiting_colors) && return
+    if opcode == 10 || opcode == 11
+        if length(parts) == 2
+            color = interpret_color(parts[2])
+            isnothing(color) ||
+                push!(props.colors, ifelse(opcode == 10, :foreground, :background) => color)
+        end
+        if opcode == 11
+            props.awaiting_colors = false
+            StyledStrings.setcolors!(props.colors)
+        end
+    elseif opcode == 4
+        # "4;<index>;<spec>", possibly repeated for terminals that batch replies.
+        for i in 2:2:length(parts)-1
+            index = tryparse(Int, parts[i])
+            isnothing(index) && continue
+            index in 0:15 || continue
+            color = interpret_color(parts[i+1])
+            isnothing(color) || push!(props.colors, ANSI_COLOR_ORDER[index+1] => color)
+        end
+    end
+    return
+end
+
+"""
+    query_colors(props::TerminalProperties, term::TextTerminal)
+
+Ask the terminal for its foreground, background, and ANSI palette colours,
+which [`receive_osc!`](@ref) applies once they arrive.
+
+The palette is queried first and the foreground/background last, so that the
+latter's response acts as a sentinel: terminals answer queries in order, so
+whatever has arrived by then is everything that is coming. Terminals that
+answer nothing simply leave the colours untouched.
+
+!!! warning
+    The responses are only collected while the REPL is reading input, which
+    dispatches `\\e]` to [`receive_osc!`](@ref).
+"""
+function query_colors(props::TerminalProperties, term::TextTerminal)
+    empty!(props.colors)
+    props.awaiting_colors = true
+    raw!(term, true)  # so the tty does not echo the replies
+    # NOTE: In theory, as per <https://www.xfree86.org/current/ctlseqs.html>
+    # 'Operating System Controls' > 'P s = 4', multiple queries may be provided:
+    #
+    #   "Because more than one pair of color number and specification can be given
+    #    in one control sequence, xterm can make more than one reply."
+    #
+    # However, in practice, while some terminals are good and support this
+    # (e.g. Kitty, Wezterm, and Foot) others, even those with good reputations
+    # for being faithful VTs, do not (e.g. Ghostty, Alacritty, Konsole).
+    #
+    # So, we resort to sending 16 individual OSC queries instead of one large one 🥲.
+    for n in 0:15
+        print(term, "\e]4;$n;?\e\\")
+    end
+    print(term, "\e]10;?\e\\\e]11;?\e\\")
+    flush(term)
+    nothing
 end
 
 # interface for TextInterface
@@ -2116,6 +2270,8 @@ const escape_defaults = merge!(
         "\eO*" => nothing,
         # Intercept DA1 responses
         "\e[?" => (s::MIState, o...) -> receive_da1!(s.terminal_properties, terminal(s)),
+        # Intercept OSC responses
+        "\e]" => (s::MIState, o...) -> receive_osc!(s.terminal_properties, terminal(s)),
         # Also ignore extended escape sequences
         # TODO: Support ranges of characters
         "\e[1**" => nothing,
@@ -2811,6 +2967,7 @@ const prefix_history_keymap = merge!(
         "\e[*" => "*",
         "\eO*"  => "*",
         "\e[?" => "*",
+        "\e]" => "*",
         "\e[1;5*" => "*", # Ctrl-Arrow
         "\e[1;2*" => "*", # Shift-Arrow
         "\e[1;3*" => "*", # Meta-Arrow

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1732,6 +1732,7 @@ function run_frontend(repl::LineEditREPL, backend::REPLBackendRef)
     end
     repl.backendref = backend
     repl.mistate = LineEdit.init_state(terminal(repl), interface)
+    LineEdit.query_colors(repl.mistate.terminal_properties, terminal(repl))
     # Copy prompt_ready_event from repl to mistate (used by precompilation)
     if isdefined(repl, :prompt_ready_event) && repl.prompt_ready_event !== nothing
         repl.mistate.prompt_ready_event = repl.prompt_ready_event

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -1246,3 +1246,76 @@ end
         @test s.terminal_properties.da1 === nothing
     end
 end
+
+# Test OSC colour response parsing (see `query_colors`)
+@testset "OSC colour responses" begin
+    RGB(r, g, b) = (; r=UInt8(r), g=UInt8(g), b=UInt8(b))
+    # `awaiting` mirrors a pending `query_colors`, so the sentinel applies the palette.
+    function receive(responses...; awaiting = true)
+        props = LineEdit.TerminalProperties()
+        props.awaiting_colors = awaiting
+        for r in responses
+            LineEdit.receive_osc!(props, IOBuffer(r))
+        end
+        props
+    end
+
+    @testset "interpret_color" begin
+        @test LineEdit.interpret_color("rgb:24/27/30") == RGB(0x24, 0x27, 0x30)
+        @test LineEdit.interpret_color("rgb:1/2/3") == RGB(0x11, 0x22, 0x33)
+        @test LineEdit.interpret_color("rgb:242/272/303") == RGB(0x24, 0x27, 0x30)
+        @test LineEdit.interpret_color("rgb:2424/2727/3030") == RGB(0x24, 0x27, 0x30)
+        @test LineEdit.interpret_color("rgb:24242/2/3") === nothing
+        @test LineEdit.interpret_color("rgba:24/27/30/ff") == RGB(0x24, 0x27, 0x30)
+        @test LineEdit.interpret_color("#242730") === nothing
+        @test LineEdit.interpret_color("rgb:24/27") === nothing
+        @test LineEdit.interpret_color("rgb:24/27/30/ff") === nothing
+        @test LineEdit.interpret_color("rgba:24/27/30") === nothing
+        @test LineEdit.interpret_color("rgb:zz/27/30") === nothing
+    end
+
+    @testset "read_osc_response terminators" begin
+        for term in ("\a", "\e\\", "\x9c", "\x03")
+            @test LineEdit.read_osc_response(IOBuffer("10;rgb:24/27/30" * term)) == "10;rgb:24/27/30"
+        end
+        # An unterminated response ends at EOF rather than blocking.
+        @test LineEdit.read_osc_response(IOBuffer("10;rgb:24/27/30")) == "10;rgb:24/27/30"
+    end
+
+    @testset "colour accumulation" begin
+        props = receive("4;1;rgb:ff/00/00\a", "4;2;rgb:00/ff/00\a")
+        @test props.colors == [:red => RGB(0xff, 0, 0), :green => RGB(0, 0xff, 0)]
+        @test receive("4;15;rgb:ff/ff/ff\a").colors == [:bright_white => RGB(0xff, 0xff, 0xff)]
+        # Out-of-range indices and malformed specs are dropped, not stored.
+        @test isempty(receive("4;16;rgb:ff/ff/ff\a").colors)
+        @test isempty(receive("4;0;not-a-color\a").colors)
+        @test isempty(receive("nonsense\a").colors)
+    end
+
+    @testset "foreground/background sentinel" begin
+        props = receive("4;0;rgb:00/00/00\a", "10;rgb:bb/c2/cf\a", "11;rgb:24/27/30\a")
+        @test props.colors == [:black => RGB(0, 0, 0), :foreground => RGB(0xbb, 0xc2, 0xcf),
+                               :background => RGB(0x24, 0x27, 0x30)]
+        props = receive("4;0;rgb:00/00/00\a", "10;rgb:bb/c2/cf\a")
+        @test props.awaiting_colors
+        LineEdit.receive_osc!(props, IOBuffer("11;rgb:24/27/30\a"))
+        @test !props.awaiting_colors
+    end
+
+    @testset "partial response" begin
+        # A terminal that answers only fg/bg still applies its colours.
+        props = receive("10;rgb:bb/c2/cf\a", "11;rgb:24/27/30\a")
+        @test props.colors == [:foreground => RGB(0xbb, 0xc2, 0xcf), :background => RGB(0x24, 0x27, 0x30)]
+        @test !props.awaiting_colors
+        # One that answers only the palette never reaches the sentinel.
+        props = receive("4;0;rgb:00/00/00\a")
+        @test props.awaiting_colors
+        # A malformed sentinel reply still ends the query.
+        props = receive("10;garbage\a", "11;rgb:24/27/30\a")
+        @test props.colors == [:background => RGB(0x24, 0x27, 0x30)]
+        @test !props.awaiting_colors
+        # Responses outside a query are ignored.
+        props = receive("4;1;rgb:ff/00/00\a", awaiting = false)
+        @test isempty(props.colors)
+    end
+end


### PR DESCRIPTION
Wouldn't it be nice if Julia/the REPL knew what your terminal colours were, and displayed content appropriately?

This introduces light/dark theme detection, as well as your ANSI 8-colour theme. With this capability, we can avoid accidental low-contrast highlights and related issues that will only become worse as we try to extend the graphical capabilities of the REPL.

Sneak peek:

<img width="450" height="auto" alt="image" src="https://github.com/user-attachments/assets/b084961e-6602-4dd2-b8bf-af319376910c" />

### Query durations

- initial query on a local machine: ~0.1s (which I suspect is due to other work that gets scheduled before the response is read)
- subsequent queries on a local machine: <0.01s
- initial query over SSH (100ms latency): ~0.3s

> [!IMPORTANT]
> This is asynchronous, and does not impact startup latency 

## Tested terminals

<details>
<summary>
Test script
</summary>

```julia
using StyledStrings
let (; FACES, SimpleColor, rgbcolor) = StyledStrings  # Grab some private API
    colors = Iterators.flatten((c, Symbol("bright_" * String(c))) for c in
        [:black, :green, :cyan, :blue, :magenta, :red, :yellow, :white])
    println(styled"{bold:    Swatch test  Read  Actual}\n ", '━'^30)
    termfg, termbg = @. SimpleColor(rgbcolor((:foreground, :background)))
    println(styled"     foreground  {(bg=$termfg):  }    {inverse:  }")
    println(styled"     background {light,grey:▕{(bg=$termbg):  }▏  ▕{:  }▏}")
    for color in colors
        termc = SimpleColor(FACES.basecolors[color])
        println(styled" $(lpad(color, 14))  {(bg=$termc):  }    {(bg=$color):  }")
    end
    print(styled"\n {bold:Platform:} {emphasis:$(Sys.KERNEL){grey:/}$(ENV[\"TERM\"])} {grey:(truecolor }")
    println(if Base.ttyhastruecolor() styled"{green,bold:✓}" else styled"{red,bold:✕}" end, styled"{grey:)}")
    println(styled" Do the swatches match?")
end
```
</details>

### Everything works

* Linux
  * Kitty
  * Wezterm
  * Foot
  * Ghostty
  * Xterm
  * Alacritty
  * St (Suckless)
  * Ubuntu terminal (Gnome terminal?)
  * Tilix
* Mac
  * Terminal.app
  * iTerm2
  * WezTerm
  * Alacritty
  * Ghostty
  * Kitty
* Windows
  * Windows terminal (it messes up inverse video though)
  * Windows terminal: WSL

### Misbehaving (terminal's fault)

* Linux
  * Konsole (lies about values)
* Emacs
  * Eat (doesn't supply colours)
  * Vterm (doesn't report anything)
* Mac
  * iTerm2 + Tmux (doesn't report anything)
* Windows
  * Wezterm via Ubuntu WSL (doesn't report anything)
  
### Misbehaving (our fault)

* Nothing yet :slightly_smiling_face: 