### PR TITLE
Add already existing public docstrings to the manual

### DIFF
--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -209,6 +209,7 @@ Base.isperm
 Base.permute!(::Any, ::AbstractVector)
 Base.invpermute!
 Base.reverse(::AbstractVector; kwargs...)
+Base.reverse(::Tuple)
 Base.reverseind
 Base.reverse!
 ```

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -34,10 +34,13 @@ Main.include
 Base.include_string
 Base.include_dependency
 __init__
+Base.@main
 Base.OncePerProcess
 Base.OncePerTask
 Base.OncePerThread
 Base.which(::Any, ::Any)
+Base.which(::Any)
+Base.which(::Module, ::Symbol)
 Base.methods
 Base.@show
 ans
@@ -172,6 +175,11 @@ Core.setfieldonce!
 Core.isdefined
 Core.isdefinedglobal
 Base.@isdefined
+Base.@__FILE__
+Base.@__DIR__
+Base.@__LINE__
+Base.@__MODULE__
+Base.@__FUNCTION__
 Base.convert
 Base.promote
 Base.oftype
@@ -358,7 +366,9 @@ Base.Sys.get_process_title
 Base.ignorestatus
 Base.detach
 Base.Cmd
+Core.@cmd(::String)
 Base.setenv
+```
 Base.addenv
 Base.withenv
 Base.shell_escape
@@ -370,6 +380,7 @@ Base.escape_microsoft_c_args
 Base.setcpuaffinity
 Base.pipeline(::Any, ::Any, ::Any, ::Any...)
 Base.pipeline(::Base.AbstractCmd)
+Base.pipeline(::Base.AbstractCmd, ::Any)
 Base.Libc.gethostname
 Base.Libc.getpid
 Base.Libc.time()
@@ -409,6 +420,12 @@ Base.Sys.isreadable
 Base.Sys.iswritable
 Base.Sys.which
 Base.Sys.username
+Base.Sys.cpu_info
+Base.Sys.cpu_summary()
+Base.Sys.cpu_summary(::IO)
+Base.Sys.cpu_summary(::IO, ::AbstractVector{Base.Sys.CPUinfo})
+Base.Sys.CPUinfo
+Base.Sys.detectwsl
 Base.@static
 ```
 
@@ -420,6 +437,10 @@ Base.@v_str
 ```
 
 ## Errors
+
+```@docs
+Base.Experimental
+```
 
 ```@docs
 Base.error
@@ -442,6 +463,7 @@ Base.EOFError
 Core.ErrorException
 Core.FieldError
 Core.InexactError
+Core.InitError
 Core.InterruptException
 Base.KeyError
 Base.LoadError
@@ -561,4 +583,10 @@ Meta.isoperator
 Meta.isunaryoperator
 Meta.isbinaryoperator
 Meta.show_sexpr
+Meta.parse(::AbstractString, ::Integer)
+Meta.replace_sourceloc!
+Meta.ispostfixoperator
+Base.operator_precedence
+Base.operator_associativity
+Base.remove_linenums!
 ```

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -88,6 +88,10 @@ Fully implemented by:
 ## Iterable Collections
 
 ```@docs
+Base.Generator
+```
+
+```@docs
 Base.in
 Base.:∉
 Base.hasfastin
@@ -119,15 +123,23 @@ Base.prod
 Base.prod!
 Base.any(::Any)
 Base.any(::AbstractArray, ::Any)
+Base.any(::Any, ::Any)
+Base.any(::AbstractArray)
+Base.any(::Function, ::AbstractArray)
 Base.any!
 Base.all(::Any)
 Base.all(::AbstractArray, ::Any)
+Base.all(::Any, ::Any)
+Base.all(::AbstractArray)
+Base.all(::Function, ::AbstractArray)
 Base.all!
 Base.count
+Base.count!(::AbstractArray, ::Union{Base.AbstractBroadcasted, AbstractArray})
 Base.foreach
 Base.map
 Base.map!
 Base.mapreduce(::Any, ::Any, ::Any)
+Base.mapreduce(::Any, ::Any, ::Union{Base.AbstractBroadcasted, AbstractArray})
 Base.mapfoldl(::Any, ::Any, ::Any)
 Base.mapfoldr(::Any, ::Any, ::Any)
 Base.first

--- a/doc/src/base/constants.md
+++ b/doc/src/base/constants.md
@@ -15,6 +15,19 @@ Base.Sys.WORD_SIZE
 Base.Sys.KERNEL
 Base.Sys.ARCH
 Base.Sys.MACHINE
+Base.Sys.CPU_NAME
+Base.Sys.PAGESIZE
+Base.Sys.JIT
+```
+
+## [Mathematical Constants](@id math-constants)
+
+```@docs
+Base.MathConstants
+Base.MathConstants.π
+Base.MathConstants.ℯ
+Base.MathConstants.γ
+Base.MathConstants.φ
 ```
 
 See also:

--- a/doc/src/base/file.md
+++ b/doc/src/base/file.md
@@ -34,7 +34,9 @@ Base.Filesystem.rm
 Base.Filesystem.touch
 Base.Filesystem.tempname
 Base.Filesystem.tempdir
+Base.Filesystem.mktemp(::Any)
 Base.Filesystem.mktemp(::AbstractString)
+Base.Filesystem.mktemp(::Function)
 Base.Filesystem.mktemp(::Function, ::AbstractString)
 Base.Filesystem.mktempdir(::AbstractString)
 Base.Filesystem.mktempdir(::Function, ::AbstractString)
@@ -67,4 +69,56 @@ Base.Filesystem.splitdir
 Base.Filesystem.splitdrive
 Base.Filesystem.splitext
 Base.Filesystem.splitpath
+Base.Filesystem.StatStruct
+Base.setuid
+Base.setgid
+```
+
+## File Open Flags
+
+```@docs
+Base.Filesystem.JL_O_APPEND
+Base.Filesystem.JL_O_ASYNC
+Base.Filesystem.JL_O_CLOEXEC
+Base.Filesystem.JL_O_CREAT
+Base.Filesystem.JL_O_DIRECT
+Base.Filesystem.JL_O_DIRECTORY
+Base.Filesystem.JL_O_DSYNC
+Base.Filesystem.JL_O_EXCL
+Base.Filesystem.JL_O_FSYNC
+Base.Filesystem.JL_O_LARGEFILE
+Base.Filesystem.JL_O_NDELAY
+Base.Filesystem.JL_O_NOATIME
+Base.Filesystem.JL_O_NOCTTY
+Base.Filesystem.JL_O_NOFOLLOW
+Base.Filesystem.JL_O_NONBLOCK
+Base.Filesystem.JL_O_PATH
+Base.Filesystem.JL_O_RANDOM
+Base.Filesystem.JL_O_RDONLY
+Base.Filesystem.JL_O_RDWR
+Base.Filesystem.JL_O_RSYNC
+Base.Filesystem.JL_O_SEQUENTIAL
+Base.Filesystem.JL_O_SHORT_LIVED
+Base.Filesystem.JL_O_SYNC
+Base.Filesystem.JL_O_TEMPORARY
+Base.Filesystem.JL_O_TMPFILE
+Base.Filesystem.JL_O_TRUNC
+Base.Filesystem.JL_O_WRONLY
+```
+
+## File Permissions
+
+```@docs
+Base.Filesystem.S_IRUSR
+Base.Filesystem.S_IWUSR
+Base.Filesystem.S_IXUSR
+Base.Filesystem.S_IRWXU
+Base.Filesystem.S_IRGRP
+Base.Filesystem.S_IWGRP
+Base.Filesystem.S_IXGRP
+Base.Filesystem.S_IRWXG
+Base.Filesystem.S_IROTH
+Base.Filesystem.S_IWOTH
+Base.Filesystem.S_IXOTH
+Base.Filesystem.S_IRWXO
 ```

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -65,6 +65,7 @@ Base.IOContext(::IO, ::IOContext)
 
 ```@docs
 Base.show(::IO, ::Any)
+Base.showarg
 Base.summary
 Base.print
 Base.println
@@ -141,6 +142,7 @@ Base.Multimedia.istextmime
 
 ```@docs
 Base.bytesavailable
+Base.reseteof
 Base.ntoh
 Base.hton
 Base.ltoh

--- a/doc/src/base/multi-threading.md
+++ b/doc/src/base/multi-threading.md
@@ -52,6 +52,12 @@ Base.Threads.atomic_min!
 Base.Threads.atomic_fence
 ```
 
+## Semaphores
+
+```@docs
+Base.@acquire
+```
+
 ## ccall using a libuv threadpool (Experimental)
 
 ```@docs

--- a/doc/src/base/numbers.md
+++ b/doc/src/base/numbers.md
@@ -83,6 +83,7 @@ Base.big
 Base.signed
 Base.unsigned
 Base.float(::Any)
+Base.float(::AbstractArray)
 Base.Math.significand
 Base.Math.exponent
 Base.complex(::Complex)
@@ -100,7 +101,6 @@ Base.oneunit
 Base.zero
 Base.im
 Base.MathConstants.pi
-Base.MathConstants.ℯ
 Base.MathConstants.catalan
 Base.MathConstants.eulergamma
 Base.MathConstants.golden
@@ -140,6 +140,8 @@ Base.leading_zeros
 Base.leading_ones
 Base.trailing_zeros
 Base.trailing_ones
+Base.bitreverse
+Base.mul_hi
 Base.isodd
 Base.iseven
 Base.@int128_str

--- a/doc/src/base/punctuation.md
+++ b/doc/src/base/punctuation.md
@@ -60,3 +60,21 @@ Extended documentation for mathematical symbols & functions is [here](@ref math-
 | [`\|>`](@ref)       | pipe operator passes output from the left argument to input of the right argument, usually a [function](@ref Function-composition-and-piping) |
 | `∘`         | function composition operator (typed with \circ{tab}) combines two functions as though they are a single larger [function](@ref Function-composition-and-piping) |
 | `_`         | underscores may be assigned values which will not be saved, often used to ignore [multiple return values](@ref destructuring-assignment) or create repetitive [comprehensions](@ref man-comprehensions) |
+
+## Operators
+
+```@docs
+Base.:*(::(Union{AbstractChar, AbstractString, Regex}), ::Vararg{Union{AbstractChar, AbstractString, Regex}})
+Base.:^(::Regex, ::Integer)
+Base.:∋(::Any, ::Any)
+Base.:∋(::Any)
+Base.:∌
+Base.:⊆
+Base.:⊇(::Any)
+Base.:⊇
+Base.:⊉(::Any)
+Base.:⊉
+Base.:⊋(::Any)
+Base.:⊋
+Base.:≉
+```

--- a/doc/src/base/scopedvalues.md
+++ b/doc/src/base/scopedvalues.md
@@ -313,6 +313,8 @@ end
 
 ```@docs
 Base.ScopedValues.ScopedValue
+Base.ScopedValues.LazyScopedValue
+Base.ScopedValues.ScopedThunk
 Base.ScopedValues.with
 Base.ScopedValues.@with
 Base.isassigned(::Base.ScopedValues.ScopedValue)

--- a/doc/src/base/simd-types.md
+++ b/doc/src/base/simd-types.md
@@ -1,5 +1,9 @@
 # SIMD Support
 
+```@docs
+Core.VecElement
+```
+
 Type `VecElement{T}` is intended for building libraries of SIMD operations. Practical use of it
 requires using `llvmcall`. The type is defined as:
 

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -14,6 +14,8 @@ Base.repeat(::AbstractString, ::Integer)
 Base.repeat(::AbstractChar, ::Integer)
 Base.repr(::Any)
 Core.String(::AbstractString)
+Core.String(::AbstractVector{UInt8})
+Core.String
 Base.SubString
 Base.LazyString
 Base.@lazy_str
@@ -22,6 +24,7 @@ Base.unsafe_string
 Base.ncodeunits(::AbstractString)
 Base.codeunit
 Base.codeunits
+Base.CodeUnits
 Base.ascii
 Base.Regex
 Base.@r_str
@@ -48,11 +51,22 @@ Base.ltruncate
 Base.rtruncate
 Base.ctruncate
 Base.findfirst(::AbstractString, ::AbstractString)
+Base.findfirst(::AbstractChar, ::AbstractString)
 Base.findnext(::AbstractString, ::AbstractString, ::Integer)
 Base.findnext(::AbstractChar, ::AbstractString, ::Integer)
+Base.findnext(::Any, ::Any)
+Base.findnext(::Function, ::Any, ::Any)
+Base.findnext(::AbstractVector{<:Union{Int8, UInt8}}, ::AbstractVector{<:Union{Int8, UInt8}}, ::Integer)
 Base.findlast(::AbstractString, ::AbstractString)
 Base.findlast(::AbstractChar, ::AbstractString)
+Base.findlast(::AbstractVector{<:Union{Int8, UInt8}}, ::AbstractVector{<:Union{Int8, UInt8}})
 Base.findprev(::AbstractString, ::AbstractString, ::Integer)
+Base.findprev(::AbstractChar, ::AbstractString, ::Integer)
+Base.findprev(::Any, ::Any)
+Base.findprev(::Function, ::Any, ::Any)
+Base.findprev(::AbstractVector{<:Union{Int8, UInt8}}, ::AbstractVector{<:Union{Int8, UInt8}}, ::Integer)
+Base.findall(::AbstractChar, ::AbstractString)
+Base.findall(::Union{AbstractPattern, AbstractString, AbstractVector{UInt8}}, ::Union{AbstractPattern, AbstractString, AbstractVector{UInt8}})
 Base.occursin
 Base.reverse(::Union{String,SubString{String}})
 Base.replace(::IO, s::AbstractString, ::Pair...)

--- a/stdlib/Artifacts/docs/src/index.md
+++ b/stdlib/Artifacts/docs/src/index.md
@@ -4,6 +4,10 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Artifacts/docs/
 
 # Artifacts
 
+```@docs
+Artifacts
+```
+
 ```@meta
 DocTestSetup = :(using Artifacts)
 ```

--- a/stdlib/CRC32c/docs/src/index.md
+++ b/stdlib/CRC32c/docs/src/index.md
@@ -4,6 +4,10 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/CRC32c/docs/src
 
 # CRC32c
 
+```@docs
+CRC32c
+```
+
 Standard library module for computing the CRC-32c checksum.
 
 ```@docs

--- a/stdlib/Dates/docs/src/index.md
+++ b/stdlib/Dates/docs/src/index.md
@@ -690,6 +690,8 @@ on methods exported from the `Dates` module.
 
 ```@docs
 Dates.Period
+Dates.DatePeriod
+Dates.TimePeriod
 Dates.CompoundPeriod
 Dates.Instant
 Dates.UTInstant
@@ -710,6 +712,7 @@ Dates.DateTime(::Function, ::Any...)
 Dates.DateTime(::Dates.TimeType)
 Dates.DateTime(::AbstractString, ::AbstractString)
 Dates.format(::Dates.TimeType, ::AbstractString)
+Dates.format(::IO, ::Dates.AbstractDateToken, ::TimeType, ::Any)
 Dates.DateFormat
 Dates.@dateformat_str
 Dates.DateTime(::AbstractString, ::Dates.DateFormat)
@@ -744,15 +747,28 @@ Dates.millisecond
 Dates.microsecond
 Dates.nanosecond
 Dates.Year(::Dates.TimeType)
+Dates.Year(::Any)
 Dates.Month(::Dates.TimeType)
+Dates.Month(::Any)
 Dates.Week(::Dates.TimeType)
+Dates.Week(::Any)
 Dates.Day(::Dates.TimeType)
+Dates.Day(::Any)
 Dates.Hour(::DateTime)
+Dates.Hour(::Any)
 Dates.Minute(::DateTime)
+Dates.Minute(::Any)
 Dates.Second(::DateTime)
+Dates.Second(::Any)
 Dates.Millisecond(::DateTime)
+Dates.Millisecond(::Any)
 Dates.Microsecond(::Dates.Time)
+Dates.Microsecond(::Any)
 Dates.Nanosecond(::Dates.Time)
+Dates.Nanosecond(::Any)
+Dates.Quarter(::Date)
+Dates.Quarter(::DateTime)
+Dates.Quarter(::Any)
 Dates.yearmonth
 Dates.monthday
 Dates.yearmonthday
@@ -775,6 +791,9 @@ Dates.dayofyear
 Dates.daysinyear
 Dates.quarterofyear
 Dates.dayofquarter
+Dates.isoyear(::DateTime)
+Dates.isoweekdate(::DateTime)
+Dates.weeksinyear(::Year)
 ```
 
 #### Adjuster Functions
@@ -851,7 +870,7 @@ Dates.datetime2rata
 
 ### Constants
 
-Days of the Week:
+#### Days of the Week
 
 | Variable    | Abbr. | Value (Int) |
 |:----------- |:----- |:----------- |
@@ -863,7 +882,24 @@ Days of the Week:
 | `Saturday`  | `Sat` | 6           |
 | `Sunday`    | `Sun` | 7           |
 
-Months of the Year:
+```@docs
+Dates.Monday
+Dates.Mon
+Dates.Tuesday
+Dates.Tue
+Dates.Wednesday
+Dates.Wed
+Dates.Thursday
+Dates.Thu
+Dates.Friday
+Dates.Fri
+Dates.Saturday
+Dates.Sat
+Dates.Sunday
+Dates.Sun
+```
+
+#### Months of the Year
 
 | Variable    | Abbr. | Value (Int) |
 |:----------- |:----- |:----------- |
@@ -879,6 +915,32 @@ Months of the Year:
 | `October`   | `Oct` | 10          |
 | `November`  | `Nov` | 11          |
 | `December`  | `Dec` | 12          |
+
+```@docs
+Dates.January
+Dates.Jan
+Dates.February
+Dates.Feb
+Dates.March
+Dates.Mar
+Dates.April
+Dates.Apr
+Dates.May
+Dates.June
+Dates.Jun
+Dates.July
+Dates.Jul
+Dates.August
+Dates.Aug
+Dates.September
+Dates.Sep
+Dates.October
+Dates.Oct
+Dates.November
+Dates.Nov
+Dates.December
+Dates.Dec
+```
 
 #### Common Date Formatters
 

--- a/stdlib/FileWatching/docs/src/index.md
+++ b/stdlib/FileWatching/docs/src/index.md
@@ -5,6 +5,10 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/FileWatching/do
 # [File Events](@id lib-filewatching)
 
 ```@docs
+FileWatching.FileWatching
+```
+
+```@docs
 poll_fd
 poll_file
 watch_file

--- a/stdlib/Future/docs/src/index.md
+++ b/stdlib/Future/docs/src/index.md
@@ -4,6 +4,10 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Future/docs/src
 
 # Future
 
+```@docs
+Future
+```
+
 The `Future` module implements future behavior of already existing functions,
 which will replace the current version in a future release of Julia.
 

--- a/stdlib/InteractiveUtils/docs/src/index.md
+++ b/stdlib/InteractiveUtils/docs/src/index.md
@@ -4,6 +4,10 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/InteractiveUtil
 
 # [Interactive Utilities](@id man-interactive-utils)
 
+```@docs
+InteractiveUtils.InteractiveUtils
+```
+
 The `InteractiveUtils` module provides utilities for interactive use of Julia,
 such as code introspection and clipboard access.
 It is intended for interactive work and is loaded automatically in [interactive mode](@ref command-line-interface).
@@ -35,5 +39,7 @@ InteractiveUtils.@code_native
 InteractiveUtils.@time_imports
 InteractiveUtils.@trace_compile
 InteractiveUtils.@trace_dispatch
+InteractiveUtils.@activate
 InteractiveUtils.clipboard
+InteractiveUtils.peakflops
 ```

--- a/stdlib/Libdl/docs/src/index.md
+++ b/stdlib/Libdl/docs/src/index.md
@@ -12,6 +12,13 @@ Libdl
 Libdl.dlopen
 Libdl.dlopen_e
 Libdl.RTLD_NOW
+Libdl.RTLD_LAZY
+Libdl.RTLD_GLOBAL
+Libdl.RTLD_LOCAL
+Libdl.RTLD_FIRST
+Libdl.RTLD_DEEPBIND
+Libdl.RTLD_NOLOAD
+Libdl.RTLD_NODELETE
 Libdl.dlsym
 Libdl.dlsym_e
 Libdl.dlclose

--- a/stdlib/Mmap/docs/src/index.md
+++ b/stdlib/Mmap/docs/src/index.md
@@ -4,6 +4,10 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Mmap/docs/src/i
 
 # Memory-mapped I/O
 
+```@docs
+Mmap
+```
+
 Low level module for mmap (memory mapping of files).
 
 ```@docs

--- a/stdlib/Printf/docs/src/index.md
+++ b/stdlib/Printf/docs/src/index.md
@@ -4,6 +4,10 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Printf/docs/src
 
 # [Printf](@id man-printf)
 
+```@docs
+Printf
+```
+
 The `Printf` module provides formatted output functions similar to the C standard library's `printf`. It allows formatted printing to an output stream or to a string.
 
 ```@docs

--- a/stdlib/Profile/docs/src/index.md
+++ b/stdlib/Profile/docs/src/index.md
@@ -4,6 +4,10 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Profile/docs/sr
 
 # [Profiling](@id lib-profiling)
 
+```@docs
+Profile.Profile
+```
+
 ## CPU Profiling
 
 There are two main approaches to CPU profiling julia code:
@@ -84,6 +88,7 @@ profile data consumer.
 
 ```@docs
 Profile.@profile
+Profile.@profile_walltime
 ```
 
 The methods in `Profile` are not exported and need to be called e.g. as `Profile.print()`.
@@ -98,6 +103,9 @@ Profile.callers
 Profile.clear_malloc_data
 Profile.get_peek_duration
 Profile.set_peek_duration
+Profile.flatten
+Profile.take_page_profile
+Profile.add_fake_meta
 ```
 
 ## Memory profiling

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -4,6 +4,10 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/docs/src/i
 
 # The Julia REPL
 
+```@docs
+REPL
+```
+
 Julia comes with a full-featured interactive command-line REPL (read-eval-print loop) built into
 the `julia` executable. In addition to allowing quick and easy evaluation of Julia statements,
 it has a searchable history, tab-completion, many helpful keybindings, and dedicated help and
@@ -904,6 +908,10 @@ Out[3]: Dict{Int64, Any} with 2 entries:
 
 
 ## TerminalMenus
+
+```@docs
+REPL.TerminalMenus
+```
 
 TerminalMenus is a submodule of the Julia REPL and enables small, low-profile interactive menus in the terminal.
 

--- a/stdlib/Serialization/docs/src/index.md
+++ b/stdlib/Serialization/docs/src/index.md
@@ -4,6 +4,10 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Serialization/d
 
 # Serialization
 
+```@docs
+Serialization
+```
+
 Provides serialization of Julia objects.
 
 ```@docs

--- a/stdlib/SharedArrays/docs/src/index.md
+++ b/stdlib/SharedArrays/docs/src/index.md
@@ -4,6 +4,10 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/SharedArrays/do
 
 # Shared Arrays
 
+```@docs
+SharedArrays.SharedArrays
+```
+
 `SharedArray` represents an array, which is shared across multiple processes, on a single machine.
 
 ```@docs

--- a/stdlib/Sockets/docs/src/index.md
+++ b/stdlib/Sockets/docs/src/index.md
@@ -34,4 +34,6 @@ Sockets.recvfrom
 Sockets.setopt
 Sockets.nagle
 Sockets.quickack
+Sockets.join_multicast_group
+Sockets.leave_multicast_group
 ```

--- a/stdlib/TOML/docs/src/index.md
+++ b/stdlib/TOML/docs/src/index.md
@@ -4,6 +4,10 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/TOML/docs/src/i
 
 # TOML
 
+```@docs
+TOML
+```
+
 TOML.jl is a Julia standard library for parsing and writing [TOML
 v1.0](https://toml.io/en/) files.
 

--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -4,6 +4,10 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Test/docs/src/i
 
 # Unit Testing
 
+```@docs
+Test
+```
+
 ```@meta
 DocTestSetup = :(using Test)
 ```

--- a/stdlib/UUIDs/docs/src/index.md
+++ b/stdlib/UUIDs/docs/src/index.md
@@ -5,8 +5,13 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/UUIDs/docs/src/
 # UUIDs
 
 ```@docs
+UUIDs.UUIDs
+```
+
+```@docs
 UUIDs.uuid1
 UUIDs.uuid4
 UUIDs.uuid5
+UUIDs.uuid7
 UUIDs.uuid_version
 ```


### PR DESCRIPTION
These docstrings already exist for public objects, but are missing from the docs. `doctest` reports them.

This PR isn't complete, but I'm opening to get a WIP count.

Also its done with Claude, so might need some decision making. Some might not make sense for the docs.

```
┌ Warning: 354 docstrings not included in the manual:
│ 
│     Dates.Apr
│     Dates.isoyear :: Tuple{DateTime}
│     Base.JuliaSyntax.highlight :: Tuple{IO, Any}
│     Base.Filesystem.JL_O_NONBLOCK
│     Base.Sys.JIT
│     Base.BinaryPlatforms.Platform
│     Base.CodeUnits
│     Base.JuliaSyntax.source_line :: Tuple{Any}
│     Profile.take_page_profile :: Tuple{IOStream}
│     Base.JuliaSyntax.has_flags :: Tuple{UInt16, Any}
│     Base.BitVector :: Tuple{Tuple{Vararg{Bool}}}
│     Base.Filesystem.S_IRWXU
│     Base.which :: Tuple{Any}
│     Base.which :: Tuple{Module, Symbol}
│     SHA.SHA
│     Dates.May
│     Base.Filesystem.S_IRWXO
│     InteractiveUtils.@activate :: Tuple{Any}
│     Base.JuliaSyntax.source_line_range :: Tuple{Base.JuliaSyntax.SourceFile, Integer}
│     Core.@cmd :: Tuple{String}
│     Base.Filesystem.JL_O_APPEND
│     Base.Libc.Libdl.RTLD_NODELETE
│     Base.count! :: Tuple{AbstractArray, Union{Base.AbstractBroadcasted, AbstractArray}}
│     Base.JuliaSyntax.byte_range
│     Markdown.Markdown
│     Base.:∋ :: Tuple{Any, Any}
│     Base.:∋ :: Tuple{Any}
│     Statistics.Statistics
│     Base.:=>
│     Base.JuliaSyntax.is_prefix_op_call :: Tuple{Any}
│     Base.Iterators.nth :: Tuple{Integer}
│     Base.Iterators.nth :: Tuple{Any, Integer}
│     Mmap.Mmap
│     Base.Rounding.setrounding :: Union{Tuple{T}, Tuple{Function, Type{T}, RoundingMode}} where T
│     Base.Libc.Libdl.RTLD_GLOBAL
│     Base.MathConstants.π
│     Base.BinaryPlatforms.cxxstring_abi :: Tuple{Base.BinaryPlatforms.AbstractPlatform}
│     Base.setuid
│     Dates.Dec
│     Base.Filesystem.JL_O_WRONLY
│     Base.Filesystem.S_IWOTH
│     Dates.February
│     Base.float :: Tuple{AbstractArray{<:AbstractFloat}}
│     Base.float :: Union{Tuple{Type{T}}, Tuple{T}} where T<:Number
│     Base.JuliaSyntax.last_byte :: Tuple{Any}
│     Base.Filesystem.JL_O_CLOEXEC
│     Base.any :: Tuple{Any, Any}
│     Base.any :: Tuple{AbstractArray}
│     Base.any :: Tuple{Function, AbstractArray}
│     Base.pipeline :: Tuple{Base.AbstractCmd, Pair{<:Integer, <:Union{RawFD, Base.FileRedirect, Base.IOServer, IO}}}
│     Base.JuliaSyntax.flags :: Tuple{Base.JuliaSyntax.SyntaxHead}
│     Base.Sys.CPU_NAME
│     StyledStrings.StyledMarkup
│     Base.remove_linenums! :: Tuple{Any}
│     LinearAlgebra.symmetric :: Union{Tuple{AbstractMatrix}, Tuple{AbstractMatrix, Symbol}}
│     LinearAlgebra.AbstractTriangular
│     Base.Libc.Libdl.RTLD_FIRST
│     Base.Filesystem.JL_O_RANDOM
│     Base.Filesystem.S_IROTH
│     Dates.Quarter :: Tuple{DateTime}
│     Dates.Quarter :: Tuple{Any}
│     Dates.Quarter :: Tuple{Date}
│     Base.JuliaSyntax.sourcefile
│     Base.JuliaSyntax.numchildren :: Tuple{Base.JuliaSyntax.TreeNode}
│     SharedArrays.SharedArrays
│     UUIDs.UUIDs
│     Dates.November
│     Dates.March
│     Dates.December
│     Base.Filesystem.JL_O_LARGEFILE
│     Future.Future
│     Dates.Oct
│     Sockets.leave_multicast_group :: Union{Tuple{UDPSocket, String}, Tuple{UDPSocket, String, Union{Nothing, String}}}
│     Base.Filesystem.S_IRUSR
│     Dates.Tuesday
│     Base.BinaryPlatforms.platforms_match :: Tuple{Base.BinaryPlatforms.AbstractPlatform, Base.BinaryPlatforms.AbstractPlatform}
│     Base.JuliaSyntax.is_infix_op_call :: Tuple{Any}
│     Base.BinaryPlatforms.HostPlatform :: Tuple{}
│     Base.BinaryPlatforms.HostPlatform :: Tuple{Base.BinaryPlatforms.AbstractPlatform}
│     Base.Filesystem.JL_O_RDONLY
│     Dates.Wednesday
│     InteractiveUtils.edit :: Union{Tuple{AbstractString}, Tuple{AbstractString, Integer}, Tuple{AbstractString, Integer, Integer}}
│     Dates.Sun
│     Base.JuliaSyntax.SyntaxHead
│     Base.Sys.cpu_summary :: Union{Tuple{}, Tuple{IO}, Tuple{IO, AbstractVector{Base.Sys.CPUinfo}}}
│     Base.ScopedValues.LazyScopedValue
│     Base.JuliaSyntax.Tokenize.tokenize :: Tuple{Any}
│     Base.JuliaSyntax.children :: Tuple{Base.JuliaSyntax.TreeNode}
│     Dates.Wed
│     Base.findfirst :: Tuple{AbstractChar, AbstractString}
│     Base.findfirst :: Tuple{AbstractVector{<:Union{Int8, UInt8}}, AbstractVector{<:Union{Int8, UInt8}}}
│     Dates.Aug
│     Dates.weeksinyear :: Tuple{Year}
│     LinearAlgebra.fillband! :: Union{Tuple{T}, Tuple{AbstractMatrix{T}, Any, Any, Any}} where T
│     Dates.Jun
│     LinearAlgebra.copytrito! :: Tuple{AbstractMatrix, AbstractMatrix, AbstractChar}
│     Base.Sort.DEFAULT_UNSTABLE
│     Base.MathConstants.γ
│     Base.BinaryPlatforms.libc :: Tuple{Base.BinaryPlatforms.AbstractPlatform}
│     Base.:∌
│     Base.JuliaSyntax.sourcetext :: Tuple{Any}
│     Base.JuliaSyntax.sourcetext :: Tuple{Base.JuliaSyntax.SourceFile}
│     Dates.Second :: Tuple{Any}
│     Dates.Second :: Tuple{Time}
│     LinearAlgebra.inertia :: Union{Tuple{BunchKaufman{TS}}, Tuple{TS}, Tuple{TR}} where {TR<:Union{AbstractFloat, Rational}, TS<:Union{Complex{TR}, TR}}
│     LinearAlgebra.zeroslike :: Tuple{Type, Tuple{AbstractUnitRange, Vararg{AbstractUnitRange}}}
│     SparseArrays.SparseArrays
│     Base.Libc.Libdl.RTLD_LOCAL
│     Dates.format :: Tuple{IO, Dates.AbstractDateToken, TimeType, Any}
│     FileWatching.FileWatching
│     Base.Filesystem.S_IXGRP
│     Base.showarg :: Tuple{IO, Any, Any}
│     Artifacts.Artifacts
│     Dates.Sep
│     Base.Filesystem.JL_O_TEMPORARY
│     Base.Filesystem.S_IRWXG
│     Dates.July
│     Base.JuliaSyntax.numeric_flags :: Tuple{Any}
│     Base.Filesystem.S_IWGRP
│     Base.BinaryPlatforms.parse_dl_name_version :: Union{Tuple{String}, Tuple{String, String}}
│     Dates.September
│     Base.JuliaSyntax.Kind
│     Base.Filesystem.JL_O_SEQUENTIAL
│     Base.:* :: Tuple{Union{Regex, AbstractChar, AbstractString}, Vararg{Union{Regex, AbstractChar, AbstractString}}}
│     Base.BinaryPlatforms.wordsize :: Tuple{Base.BinaryPlatforms.AbstractPlatform}
│     Base.Filesystem.JL_O_TRUNC
│     LinearAlgebra.diagview :: Union{Tuple{AbstractMatrix}, Tuple{AbstractMatrix, Integer}}
│     SHA.shake256 :: Tuple{Union{NTuple{N, UInt8} where N, AbstractVector{UInt8}}, UInt64}
│     Base.BinaryPlatforms.detect_libgfortran_version :: Tuple{}
│     Base.JuliaSyntax.tokenize :: Tuple{Any}
│     Base.JuliaSyntax.is_postfix_op_call :: Tuple{Any}
│     Base.JuliaSyntax.GreenTreeCursor
│     Base.Filesystem.JL_O_DIRECT
│     Base.Generator
│     LinearAlgebra.isbanded :: Tuple{AbstractMatrix, Integer, Integer}
│     Base.findprev :: Tuple{Any, Any}
│     Base.findprev :: Tuple{Function, Any, Any}
│     Base.findprev :: Tuple{AbstractChar, AbstractString, Integer}
│     Base.findprev :: Tuple{AbstractVector{<:Union{Int8, UInt8}}, AbstractVector{<:Union{Int8, UInt8}}, Integer}
│     Base.JuliaSyntax.ParseStream
│     Base.JuliaSyntax.head :: Tuple{Base.JuliaSyntax.TreeNode{<:Base.JuliaSyntax.AbstractSyntaxData}}
│     Base.:⊆
│     Test.Test
│     Base.@main :: Tuple
│     Dates.Sat
│     Base.Filesystem.JL_O_NOFOLLOW
│     SparseArrays.fkeep! :: Union{Tuple{F}, Tuple{F, SparseArrays.AbstractSparseMatrixCSC}} where F<:Function
│     Base.AbstractMatch
│     Base.Filesystem.JL_O_FSYNC
│     Dates.Hour :: Tuple{Any}
│     Dates.Hour :: Tuple{Time}
│     Base.:^ :: Tuple{Regex, Integer}
│     Base.Sort.SMALL_ALGORITHM
│     Profile.flatten :: Tuple{Vector, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}}
│     Dates.June
│     LinearAlgebra.LinearAlgebra
│     Dates.Fri
│     Base.Sys.PAGESIZE
│     Dates.Jul
│     Base.:⊋ :: Tuple{Any}
│     Base.:⊋
│     Base.JuliaSyntax.COLON_QUOTE
│     Base.JuliaSyntax.filename :: Tuple{Any}
│     InteractiveUtils.InteractiveUtils
│     Dates.Sunday
│     Dates.October
│     Base.BinaryPlatforms.detect_cxxstring_abi :: Tuple{}
│     LibGit2.LibGit2
│     Base.Filesystem.JL_O_SYNC
│     Base.JuliaSyntax.TRIPLE_STRING_FLAG
│     Base.CoreLogging.@info
│     Base.Meta.replace_sourceloc! :: Tuple{Any, Any}
│     Base.operator_precedence :: Tuple{Symbol}
│     Base.Filesystem.S_IWUSR
│     Base.JuliaSyntax.SourceFile
│     Base.findall :: Tuple{AbstractChar, AbstractString}
│     Base.findall :: Tuple{Union{AbstractPattern, AbstractString, AbstractVector{UInt8}}, Union{AbstractPattern, AbstractString, AbstractVector{UInt8}}}
│     Base.ncodeunits :: Tuple{Char}
│     Base.BinaryPlatforms.platform_name :: Tuple{Base.BinaryPlatforms.AbstractPlatform}
│     Base.Libc.Libdl.RTLD_DEEPBIND
│     Base.Libc.Libdl.RTLD_NOLOAD
│     Base.Filesystem.mktemp :: Tuple{Any}
│     Base.Filesystem.mktemp :: Union{Tuple{Function}, Tuple{Function, AbstractString}}
│     Serialization.Serialization
│     Tar.Tar
│     Base.Filesystem.JL_O_NDELAY
│     LinearAlgebra.hermitian :: Union{Tuple{AbstractMatrix}, Tuple{AbstractMatrix, Symbol}}
│     Base.JuliaSyntax.SyntaxNode
│     LinearAlgebra.fillstored! :: Tuple{Diagonal, Any}
│     Base.Experimental
│     Base.BinaryPlatforms.call_abi :: Tuple{Base.BinaryPlatforms.AbstractPlatform}
│     Base.AbstractSlices
│     Base.Meta.parse :: Tuple{AbstractString, Integer}
│     Dates.Mar
│     Base.HashArrayMappedTries.HAMT
│     Core.VecElement
│     Base.JuliaSyntax.char_range :: Tuple{Any}
│     Base.Sys.cpu_info :: Tuple{}
│     Base.operator_associativity :: Tuple{Symbol}
│     Base.UUID
│     Base.Meta.ispostfixoperator :: Tuple{Union{AbstractString, Symbol}}
│     Base.JuliaSyntax.RAW_STRING_FLAG
│     Base.Filesystem.JL_O_NOCTTY
│     Base.mapreduce :: Union{Tuple{D}, Tuple{Any, Any, Union{Base.AbstractBroadcasted, AbstractArray}}} where D
│     Base.Filesystem.JL_O_SHORT_LIVED
│     Base.JuliaSyntax.Token
│     Dates.Nanosecond :: Tuple{Any}
│     Base.Docs.doc
│     Dates.Jan
│     Base.Filesystem.S_IXOTH
│     Dates.Week :: Tuple{DateTime}
│     Dates.Week :: Tuple{Any}
│     Dates.Week :: Tuple{Date}
│     Base.JuliaSyntax.is_prefix_call :: Tuple{Any}
│     Dates.Thursday
│     Base.AbstractPipe
│     Base.all :: Tuple{Any, Any}
│     Base.all :: Tuple{AbstractArray}
│     Base.all :: Tuple{Function, AbstractArray}
│     Base.JuliaSyntax.is_trivia :: Tuple{Any}
│     Dates.Microsecond :: Tuple{Any}
│     Base.Filesystem.JL_O_DIRECTORY
│     Base.JuliaSyntax.RedTreeCursor
│     Base.Filesystem.S_IRGRP
│     Dates.Month :: Tuple{DateTime}
│     Dates.Month :: Tuple{Any}
│     Dates.Month :: Tuple{Date}
│     Base.load_path :: Tuple{}
│     Core.String :: Tuple{AbstractVector{UInt8}}
│     Core.String
│     Base.JuliaSyntax.MUTABLE_FLAG
│     Dates.April
│     Base.:⊉ :: Tuple{Any}
│     Base.:⊉
│     Base.BinaryPlatforms.CPUID.cpu_isa
│     Base.JuliaSyntax.SHORT_FORM_FUNCTION_FLAG
│     Dates.Saturday
│     Base.JuliaSyntax.GreenNode
│     REPL.REPL
│     Base.BinaryPlatforms.os :: Tuple{Base.BinaryPlatforms.AbstractPlatform}
│     Base.@acquire :: Tuple{Any, Any}
│     DelimitedFiles.DelimitedFiles
│     Downloads.Downloads
│     Base.:≉ :: Tuple
│     Base.Sys.CPUinfo
│     TOML.TOML
│     Dates.Dates
│     Base.reseteof :: Tuple{IO}
│     REPL.TerminalMenus
│     Base.CoreLogging.@warn
│     Dates.TimePeriod
│     Base.JuliaSyntax.BARE_MODULE_FLAG
│     Dates.Monday
│     Base.JuliaSyntax.untokenize :: Tuple{Base.JuliaSyntax.Kind}
│     Base.CoreLogging.@error
│     Base.Filesystem.JL_O_PATH
│     Base.CoreLogging.@debug
│     Base.MathConstants.e
│     Base.Filesystem.JL_O_TMPFILE
│     Base.text_colors
│     LinearAlgebra.hermitian_type :: Union{Tuple{Type{T}}, Tuple{T}, Tuple{S}} where {S, T<:AbstractMatrix{S}}
│     Base.JuliaSyntax.is_suffixed :: Tuple{Any}
│     Dates.January
│     Dates.Minute :: Tuple{Any}
│     Dates.Minute :: Tuple{Time}
│     Base.MathConstants
│     Base.JuliaSyntax.TOPLEVEL_SEMICOLONS_FLAG
│     Base.Filesystem.JL_O_EXCL
│     Base.reverse :: Union{Tuple{AbstractVector, Integer}, Tuple{AbstractVector, Integer, Integer}}
│     Base.reverse :: Union{Tuple{AbstractArray}, Tuple{D}} where D
│     Dates.Year :: Tuple{DateTime}
│     Dates.Year :: Tuple{Any}
│     Dates.Year :: Tuple{Date}
│     SHA.shake128 :: Tuple{Union{NTuple{N, UInt8} where N, AbstractVector{UInt8}}, UInt64}
│     Printf.Printf
│     Downloads.default_downloader! :: Union{Tuple{}, Tuple{Union{Nothing, Downloader}}}
│     Dates.DatePeriod
│     Base.BinaryPlatforms.libgfortran_version :: Tuple{Base.BinaryPlatforms.AbstractPlatform}
│     Base.JuliaSyntax.first_byte :: Tuple{Any}
│     Base.complex :: Tuple{AbstractArray{<:Complex}}
│     Base.complex :: Union{Tuple{Type{T}}, Tuple{T}} where T<:Real
│     Base.MathConstants.φ
│     Base.JuliaSyntax.parseatom :: Union{Tuple{T}, Tuple{Type{T}, AbstractString}} where T
│     Base.Filesystem.JL_O_DSYNC
│     Base.findlast :: Tuple{AbstractVector{<:Union{Int8, UInt8}}, AbstractVector{<:Union{Int8, UInt8}}}
│     Base.JuliaSyntax.is_leaf :: Tuple{Base.JuliaSyntax.TreeNode}
│     Base.JuliaSyntax.parse! :: Tuple{Base.JuliaSyntax.ParseStream}
│     Base.JuliaSyntax.parse! :: Union{Tuple{TreeType}, Tuple{Type{TreeType}, IO}} where TreeType
│     Base.Filesystem.JL_O_CREAT
│     Profile.Profile
│     Base.findnext :: Tuple{Any, Any}
│     Base.findnext :: Tuple{Function, Any, Any}
│     Base.findnext :: Tuple{AbstractVector{<:Union{Int8, UInt8}}, AbstractVector{<:Union{Int8, UInt8}}, Integer}
│     Base.JuliaSyntax.@K_str :: Tuple{Any}
│     Dates.August
│     Base.BinaryPlatforms.libstdcxx_version :: Tuple{Base.BinaryPlatforms.AbstractPlatform}
│     UUIDs.uuid7 :: Union{Tuple{}, Tuple{AbstractRNG}}
│     Base.axes :: Union{Tuple{N}, Tuple{T}, Tuple{AbstractArray{T, N}, Any}} where {T, N}
│     Dates.Thu
│     Base.JuliaSyntax.source_location :: Tuple{Any}
│     Base.__has_internal_change :: Tuple{VersionNumber, Symbol}
│     Dates.Feb
│     Base.BinaryPlatforms.arch :: Tuple{Base.BinaryPlatforms.AbstractPlatform}
│     Dates.Nov
│     Base.AbstractPattern
│     Base.JuliaSyntax.PARENS_FLAG
│     Base.Filesystem.S_IXUSR
│     Base.BinaryPlatforms.platform_dlext :: Union{Tuple{}, Tuple{Base.BinaryPlatforms.AbstractPlatform}}
│     Dates.Millisecond :: Tuple{Any}
│     Dates.Millisecond :: Tuple{Time}
│     Base.Filesystem.JL_O_ASYNC
│     Base.setgid
│     Base.Filesystem.JL_O_NOATIME
│     Dates.isoweekdate :: Tuple{DateTime}
│     Dates.Tue
│     LinearAlgebra.symmetric_type :: Union{Tuple{Type{T}}, Tuple{T}, Tuple{S}} where {S, T<:AbstractMatrix{S}}
│     Base.JuliaSyntax.parsestmt :: Union{Tuple{T}, Tuple{Type{T}, AbstractString}} where T
│     Dates.Day :: Tuple{DateTime}
│     Dates.Day :: Tuple{Any}
│     Dates.Day :: Tuple{Date}
│     Base.Filesystem.JL_O_RDWR
│     Base.BinaryPlatforms.detect_libstdcxx_version :: Union{Tuple{}, Tuple{Int64}}
│     Base.ScopedValues.ScopedThunk
│     Base.mul_hi :: Union{Tuple{T}, Tuple{T, T}} where T<:Integer
│     Sockets.join_multicast_group :: Union{Tuple{UDPSocket, String}, Tuple{UDPSocket, String, Union{Nothing, String}}}
│     Base.BinaryPlatforms.select_platform :: Union{Tuple{Dict}, Tuple{Dict, Base.BinaryPlatforms.AbstractPlatform}}
│     Base.JuliaSyntax.kind :: Tuple{Base.JuliaSyntax.Kind}
│     Base.Sys.detectwsl :: Tuple{}
│     Base.Libc.Libdl.RTLD_LAZY
│     Base.Filesystem.JL_O_RSYNC
│     Base.bitreverse :: Tuple{Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}}
│     Base.Filesystem.mktempdir :: Union{Tuple{Function}, Tuple{Function, AbstractString}}
│     Base.Filesystem.mktempdir :: Union{Tuple{}, Tuple{AbstractString}}
│     Base.AbstractOneTo
│     Compiler.Timings
│     CRC32c.CRC32c
│     Base.JuliaSyntax.span :: Tuple{Base.JuliaSyntax.GreenNode}
│     Base.JuliaSyntax.span :: Tuple{Base.JuliaSyntax.GreenTreeCursor}
│     Base.BinaryPlatforms.os_version :: Tuple{Base.BinaryPlatforms.AbstractPlatform}
│     InteractiveUtils.peakflops :: Union{Tuple{}, Tuple{Integer}}
│     Base.BinaryPlatforms.triplet :: Tuple{Base.BinaryPlatforms.AbstractPlatform}
│     Base.:⊇ :: Tuple{Any}
│     Base.:⊇
│     Base.Filesystem.StatStruct
│     Profile.@profile_walltime :: Tuple{Any}
│     Base.to_index :: Tuple{Any, Any}
│     Base.to_index :: Tuple{Integer}
│     Dates.Mon
│     Base.TOML
│     Base.JuliaSyntax.parseall :: Union{Tuple{T}, Tuple{Type{T}, AbstractString}} where T
│     Profile.add_fake_meta :: Tuple{Any}
│     Base.Libc.Libdl
│     Base.Sort.DEFAULT_STABLE
│     Dates.Friday
│ 
│ These are docstrings in the checked modules (configured with the modules keyword)
│ that are not included in canonical @docs or @autodocs blocks.
└ @ Documenter /cache/build/builder-amdci4-1/julialang/julia-master/deps/jlutilities/depot/packages/Documenter/RfMTA/src/utilities/utilities.jl:49
```