### PR TITLE
Get rid of all PointerType::get call with element type

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1299,7 +1299,7 @@ std::string generate_func_sig(const char *fname)
             }
             retattrs.addAttribute(Attribute::NoAlias);
             paramattrs.push_back(AttributeSet::get(LLVMCtx, retattrs));
-            fargt_sig.push_back(PointerType::get(lrt, 0));
+            fargt_sig.push_back(PointerType::get(LLVMCtx, 0));
             sret = 1;
             prt = lrt;
         }
@@ -1357,7 +1357,7 @@ std::string generate_func_sig(const char *fname)
             pat = t;
         }
         else if (byRef) {
-            pat = PointerType::get(t, AddressSpace::Derived);
+            pat = PointerType::get(LLVMCtx, AddressSpace::Derived);
         }
         else {
             pat = abi->preferred_llvm_type((jl_datatype_t*)tti, false, LLVMCtx);

--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -51,7 +51,7 @@ void FinalLowerGC::lowerPushGCFrame(CallInst *target, Function &F)
             builder.CreateAlignedLoad(T_ppjlvalue, pgcstack, Align(sizeof(void*)), "task.gcstack"),
             builder.CreatePointerCast(
                     builder.CreateConstInBoundsGEP1_32(T_prjlvalue, gcframe, 1, "frame.prev"),
-                    PointerType::get(T_ppjlvalue, 0)),
+                    PointerType::get(T_ppjlvalue->getContext(), 0)),
             Align(sizeof(void*)));
     inst->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
     builder.CreateAlignedStore(

--- a/src/llvm-propagate-addrspaces.cpp
+++ b/src/llvm-propagate-addrspaces.cpp
@@ -163,14 +163,14 @@ Value *PropagateJuliaAddrspacesVisitor::LiftPointer(Module *M, Value *V, Instruc
             Instruction *InstV = cast<Instruction>(V);
             Instruction *NewV = InstV->clone();
             ToInsert.push_back(std::make_pair(NewV, InstV));
-            Type *NewRetTy = PointerType::get(InstV->getType(), allocaAddressSpace);
+            Type *NewRetTy = PointerType::get(InstV->getContext(), allocaAddressSpace);
             NewV->mutateType(NewRetTy);
             LiftingMap[InstV] = NewV;
             ToRevisit.push_back(NewV);
         }
     }
     auto CollapseCastsAndLift = [&](Value *CurrentV, Instruction *InsertPt) -> Value * {
-        PointerType *TargetType = PointerType::get(CurrentV->getType(), allocaAddressSpace);
+        PointerType *TargetType = PointerType::get(CurrentV->getContext(), allocaAddressSpace);
         while (!LiftingMap.count(CurrentV)) {
             if (isa<BitCastInst>(CurrentV))
                 CurrentV = cast<BitCastInst>(CurrentV)->getOperand(0);

--- a/src/llvmcalltest.cpp
+++ b/src/llvmcalltest.cpp
@@ -26,7 +26,7 @@ extern "C" {
 DLLEXPORT const char *MakeIdentityFunction(jl_value_t* jl_AnyTy) {
     LLVMContext Ctx;
     // FIXME: get TrackedTy via jl_type_to_llvm(Ctx, jl_AnyTy)
-    Type *TrackedTy = PointerType::get(StructType::get(Ctx), AddressSpace::Tracked);
+    Type *TrackedTy = PointerType::get(Ctx, AddressSpace::Tracked);
     Module *M = new llvm::Module("shadow", Ctx);
     Function *F = Function::Create(
         FunctionType::get(


### PR DESCRIPTION
This is now deprecated on LLVM 21.