### PR TITLE
Remove use of ArrayRef(std::nullopt_t) constructor

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -625,7 +625,7 @@ static AttributeList get_attrs_noreturn(LLVMContext &C)
     return AttributeList::get(C,
                 Attributes(C, {Attribute::NoReturn}),
                 AttributeSet(),
-                None);
+                {});
 }
 
 static AttributeList get_attrs_basic(LLVMContext &C)
@@ -633,7 +633,7 @@ static AttributeList get_attrs_basic(LLVMContext &C)
     return AttributeList::get(C,
                 AttributeSet(),
                 Attributes(C, {Attribute::NonNull}),
-                None);
+                {});
 }
 
 static AttributeList get_attrs_box_float(LLVMContext &C, unsigned nbytes)
@@ -649,7 +649,7 @@ static AttributeList get_attrs_box_float(LLVMContext &C, unsigned nbytes)
     return AttributeList::get(C,
                 AttributeSet::get(C, FnAttrs),
                 AttributeSet::get(C, RetAttrs),
-                None);
+                {});
 }
 
 static AttributeList get_attrs_box_sext(LLVMContext &C, unsigned nbytes)
@@ -936,7 +936,7 @@ static const auto jltopeval_func = new JuliaFunction<>{
     [](LLVMContext &C) { return AttributeList::get(C,
             AttributeSet(),
             Attributes(C, {Attribute::NonNull}),
-            None); },
+            {}); },
 };
 static const auto jlcopyast_func = new JuliaFunction<>{
     XSTR(jl_copy_ast),
@@ -948,7 +948,7 @@ static const auto jlcopyast_func = new JuliaFunction<>{
     [](LLVMContext &C) { return AttributeList::get(C,
             AttributeSet(),
             Attributes(C, {Attribute::NonNull}),
-            None); },
+            {}); },
 };
 static const auto jlapplygeneric_func = new JuliaFunction<>{
     XSTR(jl_apply_generic),
@@ -1052,7 +1052,7 @@ static const auto jlleave_func = new JuliaFunction<>{
             return AttributeList::get(C,
                 AttributeSet::get(C, FnAttrs),
                 AttributeSet(),
-                None);
+                {});
         },
 };
 static const auto jlleave_noexcept_func = new JuliaFunction<>{
@@ -1069,7 +1069,7 @@ static const auto jlleave_noexcept_func = new JuliaFunction<>{
             return AttributeList::get(C,
                 AttributeSet::get(C, FnAttrs),
                 AttributeSet(),
-                None);
+                {});
         },
 };
 static const auto jl_restore_excstack_func = new JuliaFunction<TypeFnContextAndSizeT>{
@@ -1099,7 +1099,7 @@ static const auto jlegalx_func = new JuliaFunction<TypeFnContextAndSizeT>{
         return AttributeList::get(C,
                 AttributeSet::get(C, FnAttrs),
                 AttributeSet(),
-                None); },
+                {}); },
 };
 static const auto jl_alloc_obj_func = new JuliaFunction<TypeFnContextAndSizeT>{
     "julia.gc_alloc_obj",
@@ -1122,7 +1122,7 @@ static const auto jl_alloc_obj_func = new JuliaFunction<TypeFnContextAndSizeT>{
         return AttributeList::get(C,
             AttributeSet::get(C, FnAttrs),
             AttributeSet::get(C, RetAttrs),
-            None);
+            {});
     },
 };
 static const auto jl_alloc_genericmemory_unchecked_func = new JuliaFunction<TypeFnContextAndSizeT>{
@@ -1145,7 +1145,7 @@ static const auto jl_alloc_genericmemory_unchecked_func = new JuliaFunction<Type
         return AttributeList::get(C,
             AttributeSet::get(C, FnAttrs),
             AttributeSet::get(C, RetAttrs),
-            None);
+            {});
     },
 };
 static const auto jl_newbits_func = new JuliaFunction<>{
@@ -1158,7 +1158,7 @@ static const auto jl_newbits_func = new JuliaFunction<>{
     [](LLVMContext &C) { return AttributeList::get(C,
             AttributeSet(),
             Attributes(C, {Attribute::NonNull}),
-            None); },
+            {}); },
 };
 // `julia.typeof` does read memory, but it is effectively readnone before we lower
 // the allocation function. This is OK as long as we lower `julia.typeof` no later than
@@ -1178,7 +1178,7 @@ static const auto jl_typeof_func = new JuliaFunction<>{
         return AttributeList::get(C,
             AttributeSet::get(C, FnAttrs),
             Attributes(C, {Attribute::NonNull}),
-            None); },
+            {}); },
 };
 
 static const auto jl_write_barrier_func = new JuliaFunction<>{
@@ -1230,7 +1230,7 @@ static const auto jlapplytype_func = new JuliaFunction<>{
             AttributeSet(),
             AttributeSet::get(C, ArrayRef<Attribute>({Attribute::get(C, Attribute::NonNull),
                                                Attribute::getWithAlignment(C, Align(16))})),
-            None);
+            {});
     },
 };
 static const auto jl_object_id__func = new JuliaFunction<TypeFnContextAndSizeT>{
@@ -1251,7 +1251,7 @@ static const auto setjmp_func = new JuliaFunction<TypeFnContextAndTriple>{
     [](LLVMContext &C) { return AttributeList::get(C,
             Attributes(C, {Attribute::ReturnsTwice}),
             AttributeSet(),
-            None); },
+            {}); },
 };
 static const auto memcmp_func = new JuliaFunction<TypeFnContextAndSizeT>{
     XSTR(memcmp),
@@ -1264,7 +1264,7 @@ static const auto memcmp_func = new JuliaFunction<TypeFnContextAndSizeT>{
         return AttributeList::get(C,
             AttributeSet::get(C, FnAttrs),
             AttributeSet(),
-            None); },
+            {}); },
     // TODO: inferLibFuncAttributes(*memcmp_func, TLI);
 };
 static const auto jldlsym_func = new JuliaFunction<>{
@@ -1298,7 +1298,7 @@ static const auto jlgetnthfieldchecked_func = new JuliaFunction<TypeFnContextAnd
     [](LLVMContext &C) { return AttributeList::get(C,
             AttributeSet(),
             Attributes(C, {Attribute::NonNull}),
-            None); },
+            {}); },
 };
 static const auto jlfieldindex_func = new JuliaFunction<>{
     XSTR(jl_field_index),
@@ -1315,7 +1315,7 @@ static const auto jlfieldindex_func = new JuliaFunction<>{
         return AttributeList::get(C,
             AttributeSet::get(C, FnAttrs),
             AttributeSet(),
-            None); }, // This function can error if the third argument is 1 so don't do that.
+            {}); }, // This function can error if the third argument is 1 so don't do that.
 };
 static const auto jlfieldisdefinedchecked_func = new JuliaFunction<TypeFnContextAndSizeT>{
     XSTR(jl_field_isdefined_checked),
@@ -1327,7 +1327,7 @@ static const auto jlfieldisdefinedchecked_func = new JuliaFunction<TypeFnContext
     [](LLVMContext &C) { return AttributeList::get(C,
             AttributeSet(),
             Attributes(C, {}),
-            None); },
+            {}); },
 };
 static const auto jlgetcfunctiontrampoline_func = new JuliaFunction<>{
     XSTR(jl_get_cfunction_trampoline),
@@ -1349,7 +1349,7 @@ static const auto jlgetcfunctiontrampoline_func = new JuliaFunction<>{
     [](LLVMContext &C) { return AttributeList::get(C,
             AttributeSet(),
             Attributes(C, {Attribute::NonNull}),
-            None); },
+            {}); },
 };
 static const auto jlgetabiconverter_func = new JuliaFunction<TypeFnContextAndSizeT>{
     XSTR(jl_get_abi_converter),
@@ -1389,7 +1389,7 @@ static const auto jl_allocgenericmemory = new JuliaFunction<TypeFnContextAndSize
             return AttributeList::get(C,
                 AttributeSet::get(C, FnAttrs),
                 AttributeSet::get(C, RetAttrs),
-                None); },
+                {}); },
 };
 #define BOX_FUNC(ct,at,attrs,nbytes)                                                    \
 static const auto box_##ct##_func = new JuliaFunction<>{                           \
@@ -1431,7 +1431,7 @@ static const auto jldnd_func = new JuliaFunction<>{
         return AttributeList::get(C,
                 AttributeSet::get(C, FnAttrs),
                 Attributes(C, {}),
-                None);
+                {});
     },
 };
 
@@ -1466,7 +1466,7 @@ static const auto pointer_from_objref_func = new JuliaFunction<>{
         return AttributeList::get(C,
             AttributeSet::get(C, FnAttrs),
             Attributes(C, {Attribute::NonNull}),
-            None); },
+            {}); },
 };
 static const auto gc_loaded_func = new JuliaFunction<>{
     "julia.gc_loaded",
@@ -1680,7 +1680,7 @@ struct jl_aliasinfo_t {
                 MDNode *operand = cast<MDNode>(this->scope->getOperand(0));
                 auto scope_name = cast<MDString>(operand->getOperand(0))->getString();
                 if (scope_name == "jnoalias_const")
-                    inst->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(inst->getContext(), None));
+                    inst->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(inst->getContext(), {}));
             }
         }
 
@@ -2065,7 +2065,7 @@ jl_aliasinfo_t jl_aliasinfo_t::fromTBAA(jl_codectx_t &ctx, MDNode *tbaa) {
 
 static Type *julia_type_to_llvm(jl_codectx_t &ctx, jl_value_t *jt, bool *isboxed = NULL);
 static jl_returninfo_t get_specsig_function(jl_codegen_params_t &ctx, Module *M, Value *fval, StringRef name, jl_value_t *sig, jl_value_t *jlrettype, bool is_opaque_closure,
-        ArrayRef<const char*> ArgNames=None, unsigned nreq=0);
+        ArrayRef<const char*> ArgNames={}, unsigned nreq=0);
 static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval = -1);
 static jl_cgval_t emit_checked_var(jl_codectx_t &ctx, Value *bp, jl_sym_t *name, jl_value_t *scope, bool isvol, MDNode *tbaa);
 static jl_cgval_t emit_sparam(jl_codectx_t &ctx, size_t i);
@@ -2243,7 +2243,7 @@ static inline jl_cgval_t ghostValue(jl_codectx_t &ctx, jl_value_t *typ)
     if (jl_is_type_type(typ)) {
         assert(is_uniquerep_Type(typ));
         // replace T::Type{T} with T, by assuming that T must be a leaftype of some sort
-        jl_cgval_t constant(NULL, true, typ, NULL, best_tbaa(ctx.tbaa(), typ), None);
+        jl_cgval_t constant(NULL, true, typ, NULL, best_tbaa(ctx.tbaa(), typ), ArrayRef<Value*>());
         constant.constant = jl_tparam0(typ);
         if (typ == (jl_value_t*)jl_typeofbottom_type->super)
             constant.isghost = true;
@@ -2267,13 +2267,13 @@ static inline jl_cgval_t mark_julia_const(jl_codectx_t &ctx, jl_value_t *jv)
         if (jl_is_datatype_singleton((jl_datatype_t*)typ))
             return ghostValue(ctx, typ);
     }
-    jl_cgval_t constant(NULL, true, typ, NULL, best_tbaa(ctx.tbaa(), typ), None);
+    jl_cgval_t constant(NULL, true, typ, NULL, best_tbaa(ctx.tbaa(), typ), ArrayRef<Value*>());
     constant.constant = jv;
     return constant;
 }
 
 
-static inline jl_cgval_t mark_julia_slot(Value *v, jl_value_t *typ, Value *tindex, MDNode *tbaa, ArrayRef<Value*> inline_roots=None)
+static inline jl_cgval_t mark_julia_slot(Value *v, jl_value_t *typ, Value *tindex, MDNode *tbaa, ArrayRef<Value*> inline_roots={})
 {
     // this enables lazy-copying of immutable values and stack or argument slots
     jl_cgval_t tagval(v, false, typ, tindex, tbaa, inline_roots);
@@ -2353,7 +2353,7 @@ static inline jl_cgval_t mark_julia_type(jl_codectx_t &ctx, Value *v, bool isbox
     if (type_is_ghost(T))
         return ghostValue(ctx, typ);
     if (isboxed)
-        return jl_cgval_t(v, isboxed, typ, NULL, best_tbaa(ctx.tbaa(), typ), None);
+        return jl_cgval_t(v, isboxed, typ, NULL, best_tbaa(ctx.tbaa(), typ), ArrayRef<Value*>());
     if (v && v->getType()->isAggregateType()) {
         // eagerly put this back onto the stack
         // llvm mem2reg pass will remove this if unneeded
@@ -2414,7 +2414,7 @@ static inline jl_cgval_t update_julia_type(jl_codectx_t &ctx, const jl_cgval_t &
                 return jl_cgval_t();
             }
             if (v.Vboxed && (v.isboxed || alwaysboxed)) {
-                return jl_cgval_t(v.Vboxed, true, typ, NULL, best_tbaa(ctx.tbaa(), typ), None);
+                return jl_cgval_t(v.Vboxed, true, typ, NULL, best_tbaa(ctx.tbaa(), typ), ArrayRef<Value*>());
             }
         }
         if (!jl_is_concrete_type(typ))
@@ -2529,7 +2529,7 @@ static jl_cgval_t convert_julia_type_to_union(jl_codectx_t &ctx, const jl_cgval_
             }
             else if (jl_subtype(v.typ, typ)) {
                 // convert to a simple isboxed value, since it must be boxed in the new union
-                return jl_cgval_t(boxed(ctx, v), true, typ, new_tindex, best_tbaa(ctx.tbaa(), typ), None);
+                return jl_cgval_t(boxed(ctx, v), true, typ, new_tindex, best_tbaa(ctx.tbaa(), typ), ArrayRef<Value*>());
             }
             else {
                 if (!allow_mismatch)
@@ -2792,7 +2792,7 @@ static jl_cgval_t convert_julia_type_to_union(jl_codectx_t &ctx, const jl_cgval_
     if (!computed_new_index_early && isa<Constant>(new_tindex)) {
         // no new tindex (it is set to UNION_BOX_MARKER), so the new value must be something boxed in the new union
         // TODO: use ret.Vboxed or box_union directly to set skip instead of emitting a trap?
-        return jl_cgval_t(boxed(ctx, v), true, typ, new_tindex, best_tbaa(ctx.tbaa(), typ), None);
+        return jl_cgval_t(boxed(ctx, v), true, typ, new_tindex, best_tbaa(ctx.tbaa(), typ), ArrayRef<Value*>());
     }
     // some of the values are still unboxed
     setName(ctx.emission_context, new_tindex, "tindex");
@@ -5770,7 +5770,7 @@ static jl_cgval_t emit_varinfo(jl_codectx_t &ctx, jl_varinfo_t &vi, jl_sym_t *va
             Value *tindex = NULL;
             if (vi.pTIndex)
                 tindex = ctx.builder.CreateAlignedLoad(getInt8Ty(ctx.builder.getContext()), vi.pTIndex, Align(1), vi.isVolatile);
-            v = mark_julia_slot(ssaslot, vi.value.typ, tindex, ctx.tbaa().tbaa_stack, None);
+            v = mark_julia_slot(ssaslot, vi.value.typ, tindex, ctx.tbaa().tbaa_stack);
         }
         if (vi.inline_roots) {
             AllocaInst *varslot = vi.inline_roots;
@@ -6734,7 +6734,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaidx_
         SmallVector<Metadata *, 8> MDs;
 
         // Reserve first location for self reference to the LoopID metadata node.
-        TempMDTuple TempNode = MDNode::getTemporary(ctx.builder.getContext(), None);
+        TempMDTuple TempNode = MDNode::getTemporary(ctx.builder.getContext(), {});
         MDs.push_back(TempNode.get());
 
         for (int i = 0, ie = nargs; i < ie; ++i) {
@@ -8799,7 +8799,7 @@ static jl_llvm_functions_t
             AllocaInst *roots = sizes.second > 0 ? emit_static_roots(ctx, sizes.second) : nullptr;
             if (bits) bits->setName(jl_symbol_name(s));
             if (roots) roots->setName(StringRef(".roots.") + jl_symbol_name(s));
-            varinfo.value = mark_julia_slot(bits, jt, NULL, ctx.tbaa().tbaa_stack, None);
+            varinfo.value = mark_julia_slot(bits, jt, NULL, ctx.tbaa().tbaa_stack, {});
             varinfo.inline_roots = roots;
             varinfo.inline_roots_count = sizes.second;
             alloc_def_flag(ctx, varinfo);

--- a/src/llvm-codegen-shared.h
+++ b/src/llvm-codegen-shared.h
@@ -158,7 +158,7 @@ static inline llvm::Instruction *tbaa_decorate(llvm::MDNode *md, llvm::Instructi
     using namespace llvm;
     inst->setMetadata(llvm::LLVMContext::MD_tbaa, md);
     if (llvm::isa<llvm::LoadInst>(inst) && md && md == get_tbaa_const(md->getContext())) {
-        inst->setMetadata(llvm::LLVMContext::MD_invariant_load, llvm::MDNode::get(md->getContext(), std::nullopt));
+        inst->setMetadata(llvm::LLVMContext::MD_invariant_load, llvm::MDNode::get(md->getContext(), {}));
     }
     return inst;
 }

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2198,7 +2198,7 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
                 } else {
                     // remove all operand bundles
 #if JL_LLVM_VERSION >= 200000
-                    CallInst *NewCall = CallInst::Create(CI, None, CI->getIterator());
+                    CallInst *NewCall = CallInst::Create(CI, {}, CI->getIterator());
 #else
                     CallInst *NewCall = CallInst::Create(CI, None, CI);
 #endif

--- a/src/llvm-multiversioning.cpp
+++ b/src/llvm-multiversioning.cpp
@@ -520,7 +520,7 @@ Function *CloneCtx::create_trampoline(Function *F, GlobalVariable *slot, bool au
 
     auto ptr = irbuilder.CreateLoad(F->getType(), slot);
     ptr->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_const);
-    ptr->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(F->getContext(), None));
+    ptr->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(F->getContext(), {}));
 
     SmallVector<Value *, 0> Args;
     for (auto &arg : trampoline->args())
@@ -876,7 +876,7 @@ static void replaceUsesWithLoad(Function &F, Type *T_size, I2GV should_replace, 
 #endif
             Instruction *ptr = new LoadInst(F.getType(), slot, "", false, insert_before);
             ptr->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_const);
-            ptr->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(ptr->getContext(), None));
+            ptr->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(ptr->getContext(), {}));
             use_i->setOperand(info.use->getOperandNo(),
                                 rewrite_inst_use(uses.get_stack(), T_size, ptr,
                                                 insert_before));

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -225,7 +225,7 @@ void LowerPTLS::fix_pgcstack_use(CallInst *pgcstack, Function *pgcstack_getter, 
             //     pgcstack = getter();    // slow
             auto offset = builder.CreateLoad(T_size, pgcstack_offset);
             offset->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_const);
-            offset->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(pgcstack->getContext(), None));
+            offset->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(pgcstack->getContext(), {}));
             auto cmp = builder.CreateICmpNE(offset, Constant::getNullValue(offset->getType()));
             MDBuilder MDB(pgcstack->getContext());
             SmallVector<uint32_t, 2> Weights{9, 1};
@@ -250,7 +250,7 @@ void LowerPTLS::fix_pgcstack_use(CallInst *pgcstack, Function *pgcstack_getter, 
             builder.SetInsertPoint(pgcstack);
             auto getter = builder.CreateLoad(T_pgcstack_getter, pgcstack_func_slot);
             getter->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_const);
-            getter->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(pgcstack->getContext(), None));
+            getter->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(pgcstack->getContext(), {}));
             pgcstack->setCalledFunction(pgcstack->getFunctionType(), getter);
             set_pgcstack_attrs(pgcstack);
 
@@ -265,11 +265,11 @@ void LowerPTLS::fix_pgcstack_use(CallInst *pgcstack, Function *pgcstack_getter, 
         // since we may not know which getter function to use ahead of time.
         auto getter = builder.CreateLoad(T_pgcstack_getter, pgcstack_func_slot);
         getter->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_const);
-        getter->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(pgcstack->getContext(), None));
+        getter->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(pgcstack->getContext(), {}));
         if (TargetTriple.isOSDarwin()) {
             auto key = builder.CreateLoad(T_size, pgcstack_key_slot);
             key->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_const);
-            key->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(pgcstack->getContext(), None));
+            key->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(pgcstack->getContext(), {}));
             auto new_pgcstack = builder.CreateCall(FT_pgcstack_getter, getter, {key});
             new_pgcstack->takeName(pgcstack);
             pgcstack->replaceAllUsesWith(new_pgcstack);


### PR DESCRIPTION
This is deprecated on LLVM 21 and in almost all cases this could be replaced with a simple `{}` which is both shorter and clearer that it was an array argument expected here. Only exception is constructor of `jl_cgval_t` due to an ambiguity.

As far as I can tell, all the places that was replaced has always been taking an `ArrayRef` so this should work on older LLVM versions as well.
