### PR TITLE
Update left-over reference to Core.GlobalMethods

### DIFF
--- a/doc/src/devdocs/functions.md
+++ b/doc/src/devdocs/functions.md
@@ -7,7 +7,7 @@ This document will explain how functions, method definitions, and method tables 
 
 Every function in Julia is a generic function. A generic function is conceptually a single function,
 but consists of many definitions, or methods. The methods of a generic function are stored in a
-method table. There is one global method table (type `MethodTable`) named `Core.GlobalMethods`. Any
+method table. There is one global method table (type `MethodTable`) named `Core.methodtable`. Any
 default operation on methods (such as calls) uses that table.
 
 ## [Function calls](@id Function-calls)


### PR DESCRIPTION
Renaming happened in f9b7d27b753020b828d6a050a341b3c2af49000c / PR #59158 by @JeffBezanson 