### PR TITLE
Markdown: don't allow space between parts of a link

### DIFF
--- a/stdlib/Markdown/src/Common/inline.jl
+++ b/stdlib/Markdown/src/Common/inline.jl
@@ -96,7 +96,6 @@ function link(stream::IO, md::MD)
         startswith(stream, '[') || return
         text = readuntil(stream, ']', match = '[')
         text ≡ nothing && return
-        skipwhitespace(stream)
         startswith(stream, '(') || return
         url = readuntil(stream, ')', match = '(')
         url ≡ nothing && return


### PR DESCRIPTION
In Markdown, links are written as `[desc](URL)`, and no space is allowed between `]` and `(`. However, Julia's Markdown parser explicitly accepted it (not clear why).

This may break links in a few package manuals, but the fix will be easy in each case (just remove the extra spaces).

But being more consistent with most (all??) other Markdown implementations seems more important to me; it is very surprising when one copies basic Markdown that works fine elsewhere into a Julia package manual and it suddenly is treated completely differently.

Resolves https://github.com/JuliaDocs/Documenter.jl/issues/2538
Resolves https://github.com/JuliaDocs/Documenter.jl/issues/2681