### PR TITLE
BOLT: Fix libjulia* being rebulit after being instrumented

### DIFF
--- a/contrib/bolt/Makefile
+++ b/contrib/bolt/Makefile
@@ -73,7 +73,7 @@ stage1: | $(STAGE1_BUILD)
 copy_originals: stage1
 	for file in $(FILES_TO_OPTIMIZE); do \
 		abs_file=$(STAGE1_BUILD)/usr/lib/$$file; \
-		cp $$abs_file "$$abs_file.original"; \
+		cp -a $$abs_file "$$abs_file.original"; \
 	done && \
 	touch $@
 
@@ -83,10 +83,9 @@ copy_originals: stage1
 bolt_instrument: copy_originals
 	for file in $(FILES_TO_OPTIMIZE); do \
 		abs_file=$(STAGE1_BUILD)/usr/lib/$$file; \
-		old_time=$$(stat -c %Y $$abs_file); \
 		$(LLVM_BOLT) "$$abs_file.original" -o $$abs_file --instrument --instrumentation-file-append-pid --instrumentation-file="$(PROFILE_DIR)/$$file-prof" -no-huge-pages; \
 		mkdir -p $$(dirname "$(PROFILE_DIR)/$$file-prof"); \
-		touch -d "@$$old_time" $$abs_file; \
+		touch -r "$$abs_file.original" $$abs_file; \
 		printf "\n"; \
 	done && \
 	touch $@
@@ -111,9 +110,8 @@ merge_data: bolt_instrument
 bolt: merge_data
 	for file in $(FILES_TO_OPTIMIZE); do \
         abs_file=$(STAGE1_BUILD)/usr/lib/$$file; \
-		old_time=$$(stat -c %Y $$abs_file); \
 		$(LLVM_BOLT) "$$abs_file.original" -data "$(PROFILE_DIR)/$$file-prof.merged.fdata" -o $$abs_file $(BOLT_ARGS) $$(if [ "$$file" != $(shell readlink $(STAGE1_BUILD)/usr/lib/libjulia-internal.so) ]; then echo "--use-old-text -split-strategy=cdsplit"; fi); \
-		touch -d "@$$old_time" $$abs_file; \
+		touch -r "$$abs_file.original" $$abs_file; \
     done && \
     touch $@
 

--- a/contrib/pgo-lto-bolt/Makefile
+++ b/contrib/pgo-lto-bolt/Makefile
@@ -117,7 +117,7 @@ stage2: $(PGO_PROFILE_FILE) | $(STAGE2_BUILD)
 copy_originals: stage2
 	for file in $(FILES_TO_OPTIMIZE); do \
 		abs_file=$(STAGE2_BUILD)/usr/lib/$$file; \
-		cp $$abs_file "$$abs_file.original"; \
+		cp -a $$abs_file "$$abs_file.original"; \
 	done && \
 	touch $@
 
@@ -127,10 +127,9 @@ copy_originals: stage2
 bolt_instrument: copy_originals
 	for file in $(FILES_TO_OPTIMIZE); do \
 		abs_file=$(STAGE2_BUILD)/usr/lib/$$file; \
-		old_time=$$(stat -c %Y $$abs_file); \
 		$(LLVM_BOLT) "$$abs_file.original" -o $$abs_file --instrument --instrumentation-file-append-pid --instrumentation-file="$(BOLT_PROFILE_DIR)/$$file-prof" -no-huge-pages; \
 		mkdir -p $$(dirname "$(BOLT_PROFILE_DIR)/$$file-prof"); \
-		touch -d "@$$old_time" $$abs_file; \
+		touch -r "$$abs_file.original" $$abs_file; \
 		printf "\n"; \
 	done && \
 	touch $@
@@ -158,9 +157,8 @@ merge_data: bolt_instrument
 bolt: merge_data
 	for file in $(FILES_TO_OPTIMIZE); do \
         abs_file=$(STAGE2_BUILD)/usr/lib/$$file; \
-		old_time=$$(stat -c %Y $$abs_file); \
 		$(LLVM_BOLT) "$$abs_file.original" -data "$(BOLT_PROFILE_DIR)/$$file-prof.merged.fdata" -o $$abs_file $(BOLT_ARGS) $$(if [ "$$file" != $(shell readlink $(STAGE2_BUILD)/usr/lib/libjulia-internal.so) ]; then echo "--use-old-text -split-strategy=cdsplit"; fi); \
-		touch -d "@$$old_time" $$abs_file; \
+		touch -r "$$abs_file.original" $$abs_file; \
     done && \
     touch $@
 


### PR DESCRIPTION
After we instrument and optimize the libjulia* shared libraries we reset their mtime so make doesn't rebuild them. We were doing this by calling `stat -c` to get the mtime then setting it using touch however, `stat -c` returns an epoch timestamp in seconds and I believe not using the full precision was causing make to be rebuild the `.so`s. Instead now we tell `touch` to reset to the timestamps in a copy of the original file (which should have the same timestamps by using `cp -a`)

Tested this fixed the issue I was seeing where they were being rebuilt.