### PR TITLE
Fix compile-database target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -712,7 +712,7 @@ distcleanall: cleanall
 
 # Generate compilation database (leverages existing clang tooling setup)
 compile-database:
-	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/src compile-database-src
+	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/src compile-database
 
 test: check-whitespace $(JULIA_BUILD_MODE)
 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/test default JULIA_BUILD_MODE=$(JULIA_BUILD_MODE)

--- a/src/Makefile
+++ b/src/Makefile
@@ -259,7 +259,7 @@ endif
 default: $(JULIA_BUILD_MODE) # contains either "debug" or "release"
 all: debug release
 
-release debug: %: libjulia-internal-% libjulia-codegen-% $(BUILDDIR)/compile_commands.json
+release debug: %: libjulia-internal-% libjulia-codegen-% regenerate-compile_commands.json
 
 $(BUILDDIR):
 	mkdir -p $(BUILDDIR)
@@ -558,6 +558,7 @@ clean:
 	-rm -f $(BUILDDIR)/*.dbg.obj $(BUILDDIR)/*.o $(BUILDDIR)/*.dwo $(BUILDDIR)/*.$(SHLIB_EXT) $(BUILDDIR)/*.a $(BUILDDIR)/*.h.gen
 	-rm -f $(BUILDDIR)/julia.expmap
 	-rm -f $(BUILDDIR)/julia_version.h
+	-rm -f $(BUILDDIR)/compile_commands.json
 
 clean-flisp:
 	-$(MAKE) -C $(SRCDIR)/flisp clean BUILDDIR='$(abspath $(BUILDDIR)/flisp)'
@@ -654,7 +655,8 @@ clean-analyzegc:
 	rm -f $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT)
 
 # Compilation database generation using existing clang infrastructure
-$(BUILDDIR)/compile_commands.json:
+.PHONY: regenerate-compile_commands.json
+regenerate-compile_commands.json:
 	@{ \
 		CLANG_TOOLING_C_FLAGS="$$($(JULIAHOME)/contrib/escape_json.sh clang $(CLANG_TOOLING_C_FLAGS))"; \
 		CLANG_TOOLING_CXX_FLAGS="$$($(JULIAHOME)/contrib/escape_json.sh clang $(CLANG_TOOLING_CXX_FLAGS))"; \
@@ -719,7 +721,7 @@ $(BUILDDIR)/compile_commands.json:
 		rm -f $@.tmp; \
 	fi
 
-compile-database: $(BUILDDIR)/compile_commands.json
+compile-database: regenerate-compile_commands.json
 	$(MAKE) -C $(SRCDIR)/flisp compile-database BUILDDIR='$(abspath $(BUILDDIR)/flisp)'
 	$(MAKE) -C $(SRCDIR)/support compile-database BUILDDIR='$(abspath $(BUILDDIR)/support)'
 	@echo "Compilation database created: $<"

--- a/src/Makefile
+++ b/src/Makefile
@@ -658,7 +658,6 @@ clean-analyzegc:
 .PHONY: regenerate-compile_commands
 regenerate-compile_commands:
 	TMPFILE=$$(mktemp -p $(BUILDDIR) compile_commands.json.XXXXXX); \
-	echo "TMPFILE-src = $$TMPFILE"; \
 	{ \
 		CLANG_TOOLING_C_FLAGS="$$($(JULIAHOME)/contrib/escape_json.sh clang $(CLANG_TOOLING_C_FLAGS))"; \
 		CLANG_TOOLING_CXX_FLAGS="$$($(JULIAHOME)/contrib/escape_json.sh clang $(CLANG_TOOLING_CXX_FLAGS))"; \

--- a/src/Makefile
+++ b/src/Makefile
@@ -725,4 +725,4 @@ compile-database: $(BUILDDIR)/compile_commands.json
 	@echo "Compilation database created: $<"
 
 .FORCE:
-.PHONY: default all debug release clean cleanall clean-* libccalltest libllvmcalltest julia_flisp.boot.inc.phony analyzegc analyzesrc compile-database $(BUILDDIR)/compile_commands.json .FORCE
+.PHONY: default all debug release clean cleanall clean-* libccalltest libllvmcalltest julia_flisp.boot.inc.phony analyzegc analyzesrc compile-database .FORCE

--- a/src/Makefile
+++ b/src/Makefile
@@ -657,7 +657,9 @@ clean-analyzegc:
 # Compilation database generation using existing clang infrastructure
 .PHONY: regenerate-compile_commands.json
 regenerate-compile_commands.json:
-	@{ \
+	TMPFILE=$$(mktemp -p $(BUILDDIR) compile_commands.json.XXXXXX); \
+	echo "TMPFILE-src = $$TMPFILE"; \
+	{ \
 		CLANG_TOOLING_C_FLAGS="$$($(JULIAHOME)/contrib/escape_json.sh clang $(CLANG_TOOLING_C_FLAGS))"; \
 		CLANG_TOOLING_CXX_FLAGS="$$($(JULIAHOME)/contrib/escape_json.sh clang $(CLANG_TOOLING_CXX_FLAGS))"; \
 		echo "["; \
@@ -713,12 +715,11 @@ regenerate-compile_commands.json:
 			printf '{\n  "directory": "%s",\n  "file": "%s",\n  "arguments": [%s]\n}' "$(abspath $(SRCDIR))" "$$included_file" "$$cmd"; \
 		done; \
 		echo "]"; \
-	} > $@.tmp
-	@# This ensures we replace the file atomically, and avoid spurious rewrites
-	@if ! cmp -s $@.tmp $@; then \
-		mv $@.tmp $@; \
+	} > $$TMPFILE; \
+	if ! cmp -s $$TMPFILE $(BUILDDIR)/compile_commands.json; then \
+		mv $$TMPFILE $(BUILDDIR)/compile_commands.json; \
 	else \
-		rm -f $@.tmp; \
+		rm -f $$TMPFILE; \
 	fi
 
 compile-database: regenerate-compile_commands.json

--- a/src/Makefile
+++ b/src/Makefile
@@ -724,7 +724,7 @@ regenerate-compile_commands:
 compile-database: regenerate-compile_commands
 	$(MAKE) -C $(SRCDIR)/flisp compile-database BUILDDIR='$(abspath $(BUILDDIR)/flisp)'
 	$(MAKE) -C $(SRCDIR)/support compile-database BUILDDIR='$(abspath $(BUILDDIR)/support)'
-	@echo "Compilation database created: $<"
+	@echo "Compilation database created for src"
 
 .FORCE:
 .PHONY: default all debug release clean cleanall clean-* libccalltest libllvmcalltest julia_flisp.boot.inc.phony analyzegc analyzesrc compile-database .FORCE

--- a/src/Makefile
+++ b/src/Makefile
@@ -259,7 +259,7 @@ endif
 default: $(JULIA_BUILD_MODE) # contains either "debug" or "release"
 all: debug release
 
-release debug: %: libjulia-internal-% libjulia-codegen-% regenerate-compile_commands.json
+release debug: %: libjulia-internal-% libjulia-codegen-% regenerate-compile_commands
 
 $(BUILDDIR):
 	mkdir -p $(BUILDDIR)
@@ -655,8 +655,8 @@ clean-analyzegc:
 	rm -f $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT)
 
 # Compilation database generation using existing clang infrastructure
-.PHONY: regenerate-compile_commands.json
-regenerate-compile_commands.json:
+.PHONY: regenerate-compile_commands
+regenerate-compile_commands:
 	TMPFILE=$$(mktemp -p $(BUILDDIR) compile_commands.json.XXXXXX); \
 	echo "TMPFILE-src = $$TMPFILE"; \
 	{ \
@@ -722,7 +722,7 @@ regenerate-compile_commands.json:
 		rm -f $$TMPFILE; \
 	fi
 
-compile-database: regenerate-compile_commands.json
+compile-database: regenerate-compile_commands
 	$(MAKE) -C $(SRCDIR)/flisp compile-database BUILDDIR='$(abspath $(BUILDDIR)/flisp)'
 	$(MAKE) -C $(SRCDIR)/support compile-database BUILDDIR='$(abspath $(BUILDDIR)/support)'
 	@echo "Compilation database created: $<"

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -178,4 +178,4 @@ clean:
 	rm -f $(BUILDDIR)/compile_commands.json
 	rm -f $(BUILDDIR)/host/*
 
-.PHONY: flisp-deps compile-database $(BUILDDIR)/compile_commands.json
+.PHONY: flisp-deps compile-database

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -142,7 +142,9 @@ INCLUDED_FLISP_FILES := flisp.c:cvalues.c flisp.c:types.c flisp.c:print.c flisp.
 # Compilation database generation
 .PHONY: regenerate-compile_commands.json
 regenerate-compile_commands.json:
-	@{ \
+	TMPFILE=$$(mktemp -p $(BUILDDIR) compile_commands.json.XXXXXX); \
+	echo "TMPFILE-flisp = $$TMPFILE"; \
+	{ \
 		CLANG_TOOLING_C_FLAGS="$$($(JULIAHOME)/contrib/escape_json.sh clang $(CLANG_TOOLING_C_FLAGS))"; \
 		echo "["; \
 		first=true; \
@@ -159,12 +161,11 @@ regenerate-compile_commands.json:
 			printf '{\n  "directory": "%s",\n  "file": "%s",\n  "arguments": [%s]\n}' "$(abspath $(SRCDIR))" "$$included_file" "$$cmd"; \
 		done; \
 		echo "]"; \
-	} > $@.tmp
-	@# This ensures we replace the file atomically, and avoid spurious rewrites
-	@if ! cmp -s $@.tmp $@; then \
-		mv $@.tmp $@; \
+	} > $$TMPFILE; \
+	if ! cmp -s $$TMPFILE $(BUILDDIR)/compile_commands.json; then \
+		mv $$TMPFILE $(BUILDDIR)/compile_commands.json; \
 	else \
-		rm -f $@.tmp; \
+		rm -f $$TMPFILE; \
 	fi
 
 compile-database: regenerate-compile_commands.json

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -61,9 +61,9 @@ DEBUGFLAGS_COMMON += $(FLAGS_COMMON)
 
 default: release
 
-release: $(BUILDDIR)/$(EXENAME)$(EXE) regenerate-compile_commands.json
+release: $(BUILDDIR)/$(EXENAME)$(EXE) regenerate-compile_commands
 
-debug: $(BUILDDIR)/$(EXENAME)-debug$(EXE) regenerate-compile_commands.json
+debug: $(BUILDDIR)/$(EXENAME)-debug$(EXE) regenerate-compile_commands
 
 $(BUILDDIR):
 	mkdir -p $(BUILDDIR)
@@ -140,8 +140,8 @@ CLANG_TOOLING_C_FLAGS = $(CLANGSA_FLAGS) $(DEBUGFLAGS_CLANG) $(JCPPFLAGS_CLANG) 
 INCLUDED_FLISP_FILES := flisp.c:cvalues.c flisp.c:types.c flisp.c:print.c flisp.c:read.c flisp.c:equal.c
 
 # Compilation database generation
-.PHONY: regenerate-compile_commands.json
-regenerate-compile_commands.json:
+.PHONY: regenerate-compile_commands
+regenerate-compile_commands:
 	TMPFILE=$$(mktemp -p $(BUILDDIR) compile_commands.json.XXXXXX); \
 	echo "TMPFILE-flisp = $$TMPFILE"; \
 	{ \
@@ -168,7 +168,7 @@ regenerate-compile_commands.json:
 		rm -f $$TMPFILE; \
 	fi
 
-compile-database: regenerate-compile_commands.json
+compile-database: regenerate-compile_commands
 	@echo "Compilation database created for flisp: $<"
 
 clean:

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -61,9 +61,9 @@ DEBUGFLAGS_COMMON += $(FLAGS_COMMON)
 
 default: release
 
-release: $(BUILDDIR)/$(EXENAME)$(EXE) $(BUILDDIR)/compile_commands.json
+release: $(BUILDDIR)/$(EXENAME)$(EXE) regenerate-compile_commands.json
 
-debug: $(BUILDDIR)/$(EXENAME)-debug$(EXE) $(BUILDDIR)/compile_commands.json
+debug: $(BUILDDIR)/$(EXENAME)-debug$(EXE) regenerate-compile_commands.json
 
 $(BUILDDIR):
 	mkdir -p $(BUILDDIR)
@@ -140,7 +140,8 @@ CLANG_TOOLING_C_FLAGS = $(CLANGSA_FLAGS) $(DEBUGFLAGS_CLANG) $(JCPPFLAGS_CLANG) 
 INCLUDED_FLISP_FILES := flisp.c:cvalues.c flisp.c:types.c flisp.c:print.c flisp.c:read.c flisp.c:equal.c
 
 # Compilation database generation
-$(BUILDDIR)/compile_commands.json:
+.PHONY: regenerate-compile_commands.json
+regenerate-compile_commands.json:
 	@{ \
 		CLANG_TOOLING_C_FLAGS="$$($(JULIAHOME)/contrib/escape_json.sh clang $(CLANG_TOOLING_C_FLAGS))"; \
 		echo "["; \
@@ -166,7 +167,7 @@ $(BUILDDIR)/compile_commands.json:
 		rm -f $@.tmp; \
 	fi
 
-compile-database: $(BUILDDIR)/compile_commands.json
+compile-database: regenerate-compile_commands.json
 	@echo "Compilation database created for flisp: $<"
 
 clean:

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -168,7 +168,7 @@ regenerate-compile_commands:
 	fi
 
 compile-database: regenerate-compile_commands
-	@echo "Compilation database created for flisp: $<"
+	@echo "Compilation database created for src/flisp"
 
 clean:
 	rm -f $(BUILDDIR)/*.o

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -143,7 +143,6 @@ INCLUDED_FLISP_FILES := flisp.c:cvalues.c flisp.c:types.c flisp.c:print.c flisp.
 .PHONY: regenerate-compile_commands
 regenerate-compile_commands:
 	TMPFILE=$$(mktemp -p $(BUILDDIR) compile_commands.json.XXXXXX); \
-	echo "TMPFILE-flisp = $$TMPFILE"; \
 	{ \
 		CLANG_TOOLING_C_FLAGS="$$($(JULIAHOME)/contrib/escape_json.sh clang $(CLANG_TOOLING_C_FLAGS))"; \
 		echo "["; \

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -113,7 +113,7 @@ regenerate-compile_commands:
 	fi
 
 compile-database: regenerate-compile_commands
-	@echo "Compilation database created in support: $<"
+	@echo "Compilation database created for src/support"
 
 clean:
 	rm -f $(BUILDDIR)/*.o

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -125,4 +125,4 @@ clean:
 	rm -f $(BUILDDIR)/compile_commands.json
 	rm -f $(BUILDDIR)/host/*
 
-.PHONY: compile-database $(BUILDDIR)/compile_commands.json
+.PHONY: compile-database

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -81,7 +81,6 @@ INCLUDED_SUPPORT_FILES := hashing.c:MurmurHash3.c
 .PHONY: regenerate-compile_commands
 regenerate-compile_commands:
 	TMPFILE=$$(mktemp -p $(BUILDDIR) compile_commands.json.XXXXXX); \
-	echo "TMPFILE-support = $$TMPFILE"; \
 	{ \
 		CLANG_TOOLING_S_FLAGS="$$($(JULIAHOME)/contrib/escape_json.sh clang $(JCPPFLAGS) $(DEBUGFLAGS))"; \
 		CLANG_TOOLING_C_FLAGS="$$($(JULIAHOME)/contrib/escape_json.sh clang $(JCPPFLAGS) $(JCFLAGS) $(DEBUGFLAGS))"; \

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -53,8 +53,8 @@ $(BUILDDIR)/host/Makefile:
 	@printf "%s\n" 'BUILDING_HOST_TOOLS=1' >> $@
 	@printf "%s\n" 'include $(SRCDIR)/Makefile' >> $@
 
-release: $(BUILDDIR)/libsupport.a regenerate-compile_commands.json
-debug: $(BUILDDIR)/libsupport-debug.a regenerate-compile_commands.json
+release: $(BUILDDIR)/libsupport.a regenerate-compile_commands
+debug: $(BUILDDIR)/libsupport-debug.a regenerate-compile_commands
 
 $(BUILDDIR)/libsupport.a: $(OBJS) | $(BUILDIR)
 	rm -rf $@
@@ -78,8 +78,8 @@ CLANG_TOOLING_C_FLAGS = $(CLANGSA_FLAGS) $(DEBUGFLAGS_CLANG) $(JCPPFLAGS_CLANG) 
 INCLUDED_SUPPORT_FILES := hashing.c:MurmurHash3.c
 
 # Compilation database generation
-.PHONY: regenerate-compile_commands.json
-regenerate-compile_commands.json:
+.PHONY: regenerate-compile_commands
+regenerate-compile_commands:
 	TMPFILE=$$(mktemp -p $(BUILDDIR) compile_commands.json.XXXXXX); \
 	echo "TMPFILE-support = $$TMPFILE"; \
 	{ \
@@ -113,7 +113,7 @@ regenerate-compile_commands.json:
 		rm -f $$TMPFILE; \
 	fi
 
-compile-database: regenerate-compile_commands.json
+compile-database: regenerate-compile_commands
 	@echo "Compilation database created in support: $<"
 
 clean:

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -53,8 +53,8 @@ $(BUILDDIR)/host/Makefile:
 	@printf "%s\n" 'BUILDING_HOST_TOOLS=1' >> $@
 	@printf "%s\n" 'include $(SRCDIR)/Makefile' >> $@
 
-release: $(BUILDDIR)/libsupport.a $(BUILDDIR)/compile_commands.json
-debug: $(BUILDDIR)/libsupport-debug.a $(BUILDDIR)/compile_commands.json
+release: $(BUILDDIR)/libsupport.a regenerate-compile_commands.json
+debug: $(BUILDDIR)/libsupport-debug.a regenerate-compile_commands.json
 
 $(BUILDDIR)/libsupport.a: $(OBJS) | $(BUILDIR)
 	rm -rf $@
@@ -78,7 +78,8 @@ CLANG_TOOLING_C_FLAGS = $(CLANGSA_FLAGS) $(DEBUGFLAGS_CLANG) $(JCPPFLAGS_CLANG) 
 INCLUDED_SUPPORT_FILES := hashing.c:MurmurHash3.c
 
 # Compilation database generation
-$(BUILDDIR)/compile_commands.json:
+.PHONY: regenerate-compile_commands.json
+regenerate-compile_commands.json:
 	@{ \
 		CLANG_TOOLING_S_FLAGS="$$($(JULIAHOME)/contrib/escape_json.sh clang $(JCPPFLAGS) $(DEBUGFLAGS))"; \
 		CLANG_TOOLING_C_FLAGS="$$($(JULIAHOME)/contrib/escape_json.sh clang $(JCPPFLAGS) $(JCFLAGS) $(DEBUGFLAGS))"; \
@@ -111,7 +112,7 @@ $(BUILDDIR)/compile_commands.json:
 		rm -f $@.tmp; \
 	fi
 
-compile-database: $(BUILDDIR)/compile_commands.json
+compile-database: regenerate-compile_commands.json
 	@echo "Compilation database created in support: $<"
 
 clean:

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -80,7 +80,9 @@ INCLUDED_SUPPORT_FILES := hashing.c:MurmurHash3.c
 # Compilation database generation
 .PHONY: regenerate-compile_commands.json
 regenerate-compile_commands.json:
-	@{ \
+	TMPFILE=$$(mktemp -p $(BUILDDIR) compile_commands.json.XXXXXX); \
+	echo "TMPFILE-support = $$TMPFILE"; \
+	{ \
 		CLANG_TOOLING_S_FLAGS="$$($(JULIAHOME)/contrib/escape_json.sh clang $(JCPPFLAGS) $(DEBUGFLAGS))"; \
 		CLANG_TOOLING_C_FLAGS="$$($(JULIAHOME)/contrib/escape_json.sh clang $(JCPPFLAGS) $(JCFLAGS) $(DEBUGFLAGS))"; \
 		echo "["; \
@@ -104,12 +106,11 @@ regenerate-compile_commands.json:
 			printf '{\n  "directory": "%s",\n  "file": "%s",\n  "arguments": [%s]\n}' "$(abspath $(SRCDIR))" "$$included_file" "$$cmd"; \
 		done; \
 		echo "]"; \
-	} > $@.tmp
-	@# This ensures we replace the file atomically, and avoid spurious rewrites
-	@if ! cmp -s $@.tmp $@; then \
-		mv $@.tmp $@; \
+	} > $$TMPFILE; \
+	if ! cmp -s $$TMPFILE $(BUILDDIR)/compile_commands.json; then \
+		mv $$TMPFILE $(BUILDDIR)/compile_commands.json; \
 	else \
-		rm -f $@.tmp; \
+		rm -f $$TMPFILE; \
 	fi
 
 compile-database: regenerate-compile_commands.json


### PR DESCRIPTION
Also fix race conditions caused by targets producing files being incorrectly marked as phony.

Follow up to  #59476 (guess there is a price to pay for using Claude)

@lgoettgens that might help with the issues you are seeing in https://github.com/JuliaPackaging/Yggdrasil/pull/12406