### PR TITLE
cgutils: fix write barrier of atomic-setonce

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2676,9 +2676,11 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
                     assert(!isboxed && maybe_null_if_boxed);
                     Value *first_ptr = extract_first_ptr(ctx, realinstr);
                     assert(first_ptr != nullptr);
-                    Done = ctx.builder.CreateIsNotNull(first_ptr);
+                    // Done = Success || first_ptr != NULL
+                    Done = ctx.builder.CreateOr(Success, ctx.builder.CreateIsNotNull(first_ptr));
                 }
                 else {
+                    // Done = Success || first_ptr == NULL || oldval == cmpop)
                     // Done = !(!Success && (first_ptr != NULL && oldval == cmpop))
                     Done = emit_guarded_test(ctx, ctx.builder.CreateNot(Success), false, [&] {
                         Value *first_ptr = nullptr;

--- a/test/atomics.jl
+++ b/test/atomics.jl
@@ -57,9 +57,8 @@ swap(x, y) = y
 struct UndefComplex{T}
     re::T
     im::T
-    UndefComplex{T}() where {T} = new{T}()
 end
-Base.convert(T::Type{<:UndefComplex}, S) = T()
+Base.convert(T::Type{<:UndefComplex}, S) = T(S, 0)
 
 let T1 = Refxy{NTuple{3,UInt8}},
     T2 = ARefxy{NTuple{3,UInt8}}


### PR DESCRIPTION
Thanks to PermutationGroups.jl for dog-fooding our typos! This now matches the runtime implementation in datatype.c (setonce_bits) and ensures that we properly compute the success bit. The test that was intended to check for this is now written to inline that struct and thus actually test for this (undef fields are not eligible for inlining).

Fix #59883