### PR TITLE
Remove useless size check in Memory allocation

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4137,9 +4137,9 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         if (argv[2].constant) {
             if (!jl_is_long(argv[2].constant))
                 return false;
-            size_t nel = jl_unbox_long(argv[2].constant);
-            if (nel < 0)
-                return false;
+            // Cast to a unsigned size and let `emit_const_len_memorynew`
+            // make sure that `nel` fits in a positive signed integer.
+            size_t nel = (size_t)jl_unbox_long(argv[2].constant);
             *ret = emit_const_len_memorynew(ctx, typ, nel, inst);
         }
         else {


### PR DESCRIPTION
Reapply half of https://github.com/JuliaLang/julia/pull/59971.

The check is unnecessary/confusing since `emit_const_len_memorynew` already does better check with proper user error message.
