### PR TITLE
Remove unnecessary check of line number

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8936,8 +8936,6 @@ static jl_llvm_functions_t
                     func = debuginfo->def; // this is inlined
                 struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo->codelocs, pc);
                 size_t i = lineidx.line;
-                if (i < 0) // pc out of range: broken debuginfo?
-                    return false;
                 if (i == 0 && lineidx.to == 0) // no update
                     return false;
                 if (pc > 0 && (jl_value_t*)debuginfo->linetable != jl_nothing) {


### PR DESCRIPTION
Reapply the other half of https://github.com/JuliaLang/julia/pull/59971

Apparently the debug info can still be useful even when the line number is invalid (i.e. function name).

Curretly this seems to occur with callback in single line comprehensions.

---------

Although I don't have the exact system to reproduce, the backtrace in questions is likely sth like,

```
 [1] throw_complex_domainerror(f::Symbol, x::Float64)
   @ Base.Math ./math.jl:33
 [2] sqrt
   @ ./math.jl:645 [inlined]
 [3] #sqrteach##0
   @ ./none:-1 [inlined]
 [4] iterate
   @ ./generator.jl:48 [inlined]
 [5] collect_to!(dest::Vector{…}, itr::Base.Generator{…}, offs::Int64, st::Int64)
   @ Base ./array.jl:886
```

Where the callback from the comprehension doesn't have a line number. This is confirmed with,

```julia
julia> sqrteach(a) = [sqrt(x) for x in a]
sqrteach (generic function with 1 method)

julia> @code_lowered debuginfo=:source sqrteach([1.0])
CodeInfo(
    @ REPL[1]:1 within `unknown scope`
1 ─ %1 = Main.:(var"#sqrteach##0#sqrteach##1")
│        #4 = %new(%1)
│   %3 = #4
│   %4 =   dynamic Base.Generator(%3, a)
│   %5 =   dynamic Base.collect(%4)
└──      return %5
)

julia> cb = Main.:(var"#sqrteach##0#sqrteach##1").instance
#sqrteach##0 (generic function with 1 method)

julia> @code_lowered debuginfo=:source cb(1.0)
CodeInfo(
1 ─ %1 = Main.sqrt
│   %2 =   dynamic (%1)(x)
└──      return %2
)
```

In any case though, there is probably still cases where the line number is missing for some frames where the function name is available so this can still be useful.