### PR TITLE
LibGit2: Add GitTree constructor that wraps git_tree_lookup

### DIFF
--- a/stdlib/LibGit2/src/tree.jl
+++ b/stdlib/LibGit2/src/tree.jl
@@ -7,6 +7,28 @@ function GitTree(c::GitCommit)
 end
 
 """
+    GitTree(repo::GitRepo, tree_oid::GitHash)
+
+Look up a tree object in the repository using its GitHash.
+This constructor wraps the libgit2 git_tree_lookup function.
+
+# Examples
+```julia
+tree_hash = LibGit2.GitHash(repo, "HEAD^{tree}")
+tree = LibGit2.GitTree(repo, tree_hash)
+```
+"""
+function GitTree(repo::GitRepo, tree_oid::GitHash)
+    ensure_initialized()
+    tree_out = Ref{Ptr{Cvoid}}(C_NULL)
+    oid_ptr = Ref(tree_oid)
+    @check ccall((:git_tree_lookup, libgit2), Cint,
+                 (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{GitHash}),
+                 tree_out, repo, oid_ptr)
+    return GitTree(repo, tree_out[])
+end
+
+"""
     treewalk(f, tree::GitTree, post::Bool=false)
 
 Traverse the entries in `tree` and its subtrees in post or pre order. Preorder

--- a/stdlib/LibGit2/test/libgit2-tests.jl
+++ b/stdlib/LibGit2/test/libgit2-tests.jl
@@ -1082,6 +1082,14 @@ mktempdir() do dir
                         rethrow()
                     end
                 end
+
+                # Test GitTree constructor with GitHash
+                tree1 = LibGit2.GitTree(repo, "HEAD^{tree}")
+                tree_hash = LibGit2.GitHash(tree1)
+                tree2 = LibGit2.GitTree(repo, tree_hash)
+                @test isa(tree2, LibGit2.GitTree)
+                @test LibGit2.GitHash(tree1) == LibGit2.GitHash(tree2)
+                @test LibGit2.count(tree1) == LibGit2.count(tree2)
             end
         end
 


### PR DESCRIPTION
This adds a new constructor GitTree(repo::GitRepo, tree_oid::GitHash) that directly wraps the libgit2 git_tree_lookup function. This provides a more efficient and direct way to create a GitTree object when you already have the tree hash, complementing the existing constructor that creates a GitTree from a GitCommit.

Written by Claude.