### PR TITLE
[backports-release-1.10] fix accidental save (and restore) of sigmask…

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -540,7 +540,7 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip,
                 }
                 // store current top of exception stack for restore in pop_exception.
                 s->locals[jl_source_nslots(s->src) + ip] = jl_box_ulong(jl_excstack_state());
-                if (!jl_setjmp(__eh.eh_ctx, 1)) {
+                if (!jl_setjmp(__eh.eh_ctx, 0)) {
                     return eval_body(stmts, s, next_ip, toplevel);
                 }
                 else if (s->continue_at) { // means we reached a :leave expression


### PR DESCRIPTION
… when interpreting try (#59878)

Noticed during bug hunting of
ericphanson/LicenseCheck.jl#11 (comment)
and may cause performance degradation for interpreter-executed try blocks or scope entry.