### PR TITLE
doc: workaround for lowering scope mistake

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -406,6 +406,10 @@ function objectdoc(__source__, __module__, str, def, expr, sig = :(Union{}))
             # Special case: `global x` should return nothing to avoid syntax errors with assigning to a value
             val = nothing
         else
+            if isexpr(def, :(=), 2) && isexpr(def.args[1], :curly)
+                # workaround for lowering bug #60001
+                exdef = Expr(:block, exdef)
+            end
             val = :val
             exdef = Expr(:(=), val, exdef)
         end

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1659,3 +1659,12 @@ module DocReturnValue
     end
     @test result11 isa Base.Docs.Binding
 end
+
+# https://github.com/JuliaLang/julia/issues/59949
+struct Foo59949{T} end
+
+"""
+Bar59949{T}
+"""
+Bar59949{T} = Foo59949{T}
+@test docstrings_equal(@doc(Bar59949), doc"Bar59949{T}")


### PR DESCRIPTION
Doc return PR #59882 hits a lowering scope bug #60001 when used with a `x{T} = y{T}` type alias declaration. Adding a block avoids that mistake by breaking up the chained assignment optimizations.

Resolves https://github.com/JuliaLang/julia/issues/59949.