### PR TITLE
REPL: make interactive precompiles test more robust

### DIFF
--- a/stdlib/REPL/test/precompilation.jl
+++ b/stdlib/REPL/test/precompilation.jl
@@ -18,7 +18,7 @@ if !Sys.iswindows()
         # start an interactive session, ensuring `TERM` is unset since it can trigger
         # different amounts of precompilation stemming from `base/terminfo.jl` depending
         # on the value, making the test here unreliable
-        cmd = addenv(`$(Base.julia_cmd()[1]) --trace-compile=$f -q --startup-file=no -i`,
+        cmd = addenv(`$(Base.julia_cmd()) --trace-compile=$f -q --startup-file=no -i`,
                      Dict("TERM" => ""))
         pts, ptm = open_fake_pty()
         p = run(cmd, pts, pts, pts; wait=false)
@@ -26,9 +26,9 @@ if !Sys.iswindows()
         std = readuntil(ptm, "julia>")
         # check for newlines instead of equality with "julia>" because color may be on
         occursin("\n", std) && @info "There was output before the julia prompt:\n$std"
-        write(ptm, "\n")  # another prompt
+        @async write(ptm, "\n")  # another prompt
         readuntil(ptm, "julia>")
-        write(ptm, "\n")  # another prompt
+        @async write(ptm, "\n")  # another prompt
         readuntil(ptm, "julia>")
         tracecompile_out = read(f, String)
         close(ptm) # close after reading so we don't get precompiles from error shutdown

--- a/stdlib/REPL/test/precompilation.jl
+++ b/stdlib/REPL/test/precompilation.jl
@@ -26,17 +26,13 @@ if !Sys.iswindows()
         std = readuntil(ptm, "julia>")
         # check for newlines instead of equality with "julia>" because color may be on
         occursin("\n", std) && @info "There was output before the julia prompt:\n$std"
-        # Exit the REPL cleanly to ensure all trace-compile output is flushed
-        write(ptm, '\x04')  # CTRL_D
-        # Read until EOF to ensure all output is consumed before the process exits
-        timedwait(5.0) do
-            eof(ptm) && return true
-            readavailable(ptm)
-            return false
-        end
-        close(ptm)
-        wait(p)
+        write(ptm, "\n")  # another prompt
+        readuntil(ptm, "julia>")
+        write(ptm, "\n")  # another prompt
+        readuntil(ptm, "julia>")
+        sleep(1) # sometimes precompiles output just after prompt appears
         tracecompile_out = read(f, String)
+        close(ptm) # close after reading so we don't get precompiles from error shutdown
 
         # given this test checks that startup is snappy, it's best to add workloads to
         # contrib/generate_precompile.jl rather than increase this number. But if that's not

--- a/stdlib/REPL/test/precompilation.jl
+++ b/stdlib/REPL/test/precompilation.jl
@@ -30,7 +30,6 @@ if !Sys.iswindows()
         readuntil(ptm, "julia>")
         write(ptm, "\n")  # another prompt
         readuntil(ptm, "julia>")
-        sleep(1) # sometimes precompiles output just after prompt appears
         tracecompile_out = read(f, String)
         close(ptm) # close after reading so we don't get precompiles from error shutdown
 

--- a/stdlib/REPL/test/precompilation.jl
+++ b/stdlib/REPL/test/precompilation.jl
@@ -26,9 +26,17 @@ if !Sys.iswindows()
         std = readuntil(ptm, "julia>")
         # check for newlines instead of equality with "julia>" because color may be on
         occursin("\n", std) && @info "There was output before the julia prompt:\n$std"
-        sleep(1) # sometimes precompiles output just after prompt appears
+        # Exit the REPL cleanly to ensure all trace-compile output is flushed
+        write(ptm, '\x04')  # CTRL_D
+        # Read until EOF to ensure all output is consumed before the process exits
+        timedwait(5.0) do
+            eof(ptm) && return true
+            readavailable(ptm)
+            return false
+        end
+        close(ptm)
+        wait(p)
         tracecompile_out = read(f, String)
-        close(ptm) # close after reading so we don't get precompiles from error shutdown
 
         # given this test checks that startup is snappy, it's best to add workloads to
         # contrib/generate_precompile.jl rather than increase this number. But if that's not


### PR DESCRIPTION
Seems this test has become flaky https://buildkite.com/organizations/julialang/analytics/suites/julialang-base/tests/9edb60ba-fd1d-88fa-a5f0-205fa951d302?period=1day

So this tries to make it more robust.

FYI @tecosaur 