### PR TITLE
Fix Base.method_instance abort with non-concrete inputs (#59964)

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1928,6 +1928,8 @@ JL_DLLEXPORT jl_typemap_entry_t *jl_mt_find_cache_entry(jl_methcache_t *mc JL_PR
 
 static jl_method_instance_t *jl_mt_assoc_by_type(jl_methcache_t *mc JL_PROPAGATES_ROOT, jl_datatype_t *tt JL_MAYBE_UNROOTED, size_t world)
 {
+    if (!tt || !jl_is_dispatch_tuple(tt))
+        return NULL;
     jl_typemap_entry_t *entry = jl_mt_find_cache_entry(mc, tt, world);
     if (entry)
         return entry->func.linfo;


### PR DESCRIPTION
Fixes #59964 — Prevents Base.method_instance from aborting when called with non-concrete inputs.

- Added a condition check in `jl_mt_assoc_by_type` to handle non-concrete type tuples safely before assertion.