### PR TITLE
Replace julia-repl with jldoctest in two doc blocks

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -750,7 +750,7 @@ Union{Missing, Int64}[]
 
 When the iterator is non-empty, the result type depends only on values:
 
-```julia-repl
+```jldoctest
 julia> [rand(Bool) ? 1 : missing for _ in [""]]
 1-element Vector{Int64}:
  1

--- a/base/c.jl
+++ b/base/c.jl
@@ -52,7 +52,7 @@ over the local variable `callable` (this is not supported on all architectures).
 See [manual section on ccall and cfunction usage](@ref Calling-C-and-Fortran-Code).
 
 # Examples
-```julia-repl
+```jldoctest
 julia> function foo(x::Int, y::Int)
            return x + y
        end


### PR DESCRIPTION
This PR replaces two instances of julia-repl code blocks with jldoctest as part of [#56921]
This was my approach to solve a good first issue as suggested by @LilithHafner 