### PR TITLE
Provide mechanism for Julia syntax evolution

### DIFF
--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -6463,6 +6463,7 @@ end == TypeError
 # Issue #58257 - Hang in inference during BindingPartition resolution
 module A58257
     module B58257
+        const age = Base.get_world_counter()
         using ..A58257
         # World age here is N
     end
@@ -6474,7 +6475,7 @@ end
 ## The sequence of events is critical here.
 A58257.get!      # Creates binding partition in A, N+1:∞
 A58257.B58257.get!    # Creates binding partition in A.B, N+1:∞
-Base.invoke_in_world(UInt(38678), getglobal, A58257, :get!) # Expands binding partition in A through <N
+Base.invoke_in_world(A58257.B58257.age, getglobal, A58257, :get!) # Expands binding partition in A through <N
 @test Base.infer_return_type(A58257.f) == typeof(Base.get!) # Attempt to lookup A.B in world age N hangs
 
 function tt57873(a::Vector{String}, pref)

--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -175,6 +175,7 @@ function makeleaf(ctx, srcref, k::Kind, value; kws...)
               k == K"Char"    ? convert(Char,    value) :
               k == K"Value"   ? value                   :
               k == K"Bool"    ? value                   :
+              k == K"VERSION" ? value                   :
               error("Unexpected leaf kind `$k`")
         makeleaf(graph, srcref, k; value=val, kws...)
     end

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -70,19 +70,26 @@ function lower_step(iter, mod, world=Base.get_world_counter())
         push!(iter.todo, (ex, false, 1))
         return lower_step(iter, mod)
     elseif k == K"module"
-        name = ex[1]
+        name_or_version = ex[1]
+        version = nothing
+        if kind(name_or_version) == K"VERSION"
+            version = name_or_version.value
+            name = ex[2]
+        else
+            name = name_or_version
+        end
         if kind(name) != K"Identifier"
             throw(LoweringError(name, "Expected module name"))
         end
         newmod_name = Symbol(name.name_val)
-        body = ex[2]
+        body = ex[end]
         if kind(body) != K"block"
             throw(LoweringError(body, "Expected block in module body"))
         end
         std_defs = !has_flags(ex, JuliaSyntax.BARE_MODULE_FLAG)
         loc = source_location(LineNumberNode, ex)
         push!(iter.todo, (body, true, 1))
-        return Core.svec(:begin_module, newmod_name, std_defs, loc)
+        return Core.svec(:begin_module, version, newmod_name, std_defs, loc)
     else
         # Non macro expansion parts of lowering
         ctx2, ex2 = expand_forms_2(ctx1, ex)
@@ -467,10 +474,10 @@ function _eval(mod, iter)
         if type == :done
             break
         elseif type == :begin_module
-            filename = something(thunk[4].file, :none)
+            filename = something(thunk[5].file, :none)
             mod = @ccall jl_begin_new_module(
-                modules[end]::Any, thunk[2]::Symbol, thunk[3]::Cint,
-                filename::Cstring, thunk[4].line::Cint)::Module
+                modules[end]::Any, thunk[3]::Symbol, thunk[2]::Any, thunk[4]::Cint,
+                filename::Cstring, thunk[5].line::Cint)::Module
             push!(modules, mod)
         elseif type == :end_module
             @ccall jl_end_new_module(modules[end]::Module)::Cvoid

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -431,6 +431,7 @@ end
         )
     end
     """) ≈ @ast_ [K"module"
+        v"1.14.0"::K"VERSION"
         "AA"::K"Identifier"
         [K"block"
         ]

--- a/JuliaSyntax/src/integration/expr.jl
+++ b/JuliaSyntax/src/integration/expr.jl
@@ -199,7 +199,7 @@ end
 
 function parseargs!(retexpr::Expr, loc::LineNumberNode, cursor, source, txtbuf::Vector{UInt8}, txtbuf_offset::UInt32)
     args = retexpr.args
-    firstchildhead = head(cursor)
+    firstchildhead = secondchildhead = head(cursor)
     firstchildrange::UnitRange{UInt32} = byte_range(cursor)
     itr = reverse_nontrivia_children(cursor)
     r = iterate(itr)
@@ -208,11 +208,12 @@ function parseargs!(retexpr::Expr, loc::LineNumberNode, cursor, source, txtbuf::
         r = iterate(itr, state)
         expr = node_to_expr(child, source, txtbuf, txtbuf_offset)
         @assert expr !== nothing
+        secondchildhead = firstchildhead
         firstchildhead = head(child)
         firstchildrange = byte_range(child)
         pushfirst!(args, fixup_Expr_child(head(cursor), expr, r === nothing))
     end
-    return (firstchildhead, firstchildrange)
+    return (firstchildhead, secondchildhead, firstchildrange)
 end
 
 _expr_leaf_val(node::SyntaxNode, _...) = node.val
@@ -235,6 +236,9 @@ function node_to_expr(cursor, source, txtbuf::Vector{UInt8}, txtbuf_offset::UInt
             return k == K"error" ?
                 Expr(:error) :
                 Expr(:error, "$(_token_error_descriptions[k]): `$(source[srcrange])`")
+        elseif k == K"VERSION"
+            nv = numeric_flags(flags(nodehead))
+            return VersionNumber(1, nv ÷ 10, nv % 10)
         else
             scoped_val = _expr_leaf_val(cursor, txtbuf, txtbuf_offset)
             val = @isexpr(scoped_val, :scope_layer) ? scoped_val.args[1] : scoped_val
@@ -292,10 +296,11 @@ function node_to_expr(cursor, source, txtbuf::Vector{UInt8}, txtbuf_offset::UInt
     end
 
     # Now recurse to parse all arguments
-    (firstchildhead, firstchildrange) = parseargs!(retexpr, loc, cursor, source, txtbuf, txtbuf_offset)
+    (firstchildhead, secondchildhead, firstchildrange) =
+        parseargs!(retexpr, loc, cursor, source, txtbuf, txtbuf_offset)
 
     return _node_to_expr(retexpr, loc, srcrange,
-                         firstchildhead, firstchildrange,
+                         firstchildhead, secondchildhead, firstchildrange,
                          nodehead, source)
 end
 
@@ -318,7 +323,7 @@ end
 # tree types.
 @noinline function _node_to_expr(retexpr::Expr, loc::LineNumberNode,
                                  srcrange::UnitRange{UInt32},
-                                 firstchildhead::SyntaxHead,
+                                 firstchildhead::SyntaxHead, secondchildhead::SyntaxHead,
                                  firstchildrange::UnitRange{UInt32},
                                  nodehead::SyntaxHead,
                                  source)
@@ -354,6 +359,11 @@ end
             if @isexpr(a2, :macrocall) && kind(firstchildhead) == K"CmdMacroName"
                 # Fix up for custom cmd macros like foo`x`
                 args[2] = a2.args[3]
+            end
+            if kind(secondchildhead) == K"VERSION"
+                # Encode the syntax version into `loc` so that the argument order
+                # matches what ordinary macros expect.
+                loc = Core.MacroSource(loc, popat!(args, 2))
             end
         end
         do_lambda = _extract_do_lambda!(args)
@@ -554,8 +564,8 @@ end
             pushfirst!((args[2]::Expr).args, loc)
         end
     elseif k == K"module"
-        pushfirst!(args, !has_flags(nodehead, BARE_MODULE_FLAG))
-        pushfirst!((args[3]::Expr).args, loc)
+        insert!(args, kind(firstchildhead) == K"VERSION" ? 2 : 1, !has_flags(nodehead, BARE_MODULE_FLAG))
+        pushfirst!((args[end]::Expr).args, loc)
     elseif k == K"quote"
         if length(args) == 1
             a1 = only(args)

--- a/JuliaSyntax/src/integration/hooks.jl
+++ b/JuliaSyntax/src/integration/hooks.jl
@@ -162,7 +162,7 @@ end
 # Debug log file for dumping parsed code
 const _debug_log = Ref{Union{Nothing,IO}}(nothing)
 
-function core_parser_hook(code, filename::String, lineno::Int, offset::Int, options::Symbol)
+function core_parser_hook(code, filename::String, lineno::Int, offset::Int, options::Symbol; syntax_version = v"1.13")
     try
         # TODO: Check that we do all this input wrangling without copying the
         # code buffer
@@ -184,7 +184,7 @@ function core_parser_hook(code, filename::String, lineno::Int, offset::Int, opti
             write(_debug_log[], code)
         end
 
-        stream = ParseStream(code, offset+1)
+        stream = ParseStream(code, offset+1; version = syntax_version)
         if options === :statement || options === :atom
             # To copy the flisp parser driver:
             # * Parsing atoms      consumes leading trivia

--- a/JuliaSyntax/src/julia/kinds.jl
+++ b/JuliaSyntax/src/julia/kinds.jl
@@ -247,6 +247,7 @@ register_kinds!(JuliaSyntax, 0, [
             "public"
             "type"
             "var"
+            "VERSION"
         "END_CONTEXTUAL_KEYWORDS"
     "END_KEYWORDS"
 

--- a/JuliaSyntax/src/julia/literal_parsing.jl
+++ b/JuliaSyntax/src/julia/literal_parsing.jl
@@ -408,6 +408,9 @@ function parse_julia_literal(txtbuf::Vector{UInt8}, head::SyntaxHead, srcrange)
         return had_error ? ErrorVal() : String(take!(io))
     elseif k == K"Bool"
         return txtbuf[first(srcrange)] == u8"t"
+    elseif k == K"VERSION"
+        nv = numeric_flags(head)
+        return VersionNumber(1, nv ÷ 10, nv % 10)
     end
 
     # TODO: Avoid allocating temporary String here

--- a/JuliaSyntax/src/julia/tokenize.jl
+++ b/JuliaSyntax/src/julia/tokenize.jl
@@ -1253,12 +1253,12 @@ function lex_identifier(l::Lexer, c)
     end
 end
 
-# This creates a hash for chars in [a-z] using 5 bit per char.
+# This creates a hash for chars in [A-z] using 6 bit per char.
 # Requires an additional input-length check somewhere, because
-# this only works up to ~12 chars.
+# this only works up to ~10 chars.
 @inline function simple_hash(c::Char, h::UInt64)
-    bytehash = (clamp(c - 'a' + 1, -1, 30) % UInt8) & 0x1f
-    h << 5 + bytehash
+    bytehash = (clamp(c - 'A' + 1, -1, 60) % UInt8) & 0x3f
+    h << 6 + bytehash
 end
 
 function simple_hash(str)
@@ -1313,10 +1313,11 @@ K"outer",
 K"primitive",
 K"type",
 K"var",
+K"VERSION"
 ]
 
 const _true_hash = simple_hash("true")
 const _false_hash = simple_hash("false")
-const _kw_hash = Dict(simple_hash(lowercase(string(kw))) => kw for kw in kws)
+const _kw_hash = Dict(simple_hash(string(kw)) => kw for kw in kws)
 
 end # module

--- a/JuliaSyntax/test/expr.jl
+++ b/JuliaSyntax/test/expr.jl
@@ -55,7 +55,7 @@
             @test parsestmt("a;b") ==
                 Expr(:toplevel, :a, :b)
 
-            @test parsestmt("module A\n\nbody\nend") ==
+            @test parsestmt("module A\n\nbody\nend"; version=v"1.13") ==
                 Expr(:module,
                      true,
                      :A,
@@ -798,9 +798,11 @@
     end
 
     @testset "module" begin
-        @test parsestmt("module A end") ==
+        @test parsestmt("module A end"; version=v"1.13") ==
             Expr(:module, true,  :A, Expr(:block, LineNumberNode(1), LineNumberNode(1)))
-        @test parsestmt("baremodule A end") ==
+        @test parsestmt("module A end"; version=v"1.14") ==
+            Expr(:module, v"1.14", true,  :A, Expr(:block, LineNumberNode(1), LineNumberNode(1)))
+        @test parsestmt("baremodule A end"; version=v"1.13") ==
             Expr(:module, false, :A, Expr(:block, LineNumberNode(1), LineNumberNode(1)))
     end
 

--- a/JuliaSyntax/test/parser.jl
+++ b/JuliaSyntax/test/parser.jl
@@ -377,6 +377,14 @@ tests = [
         "@doc x\n\ny"  =>  "(macrocall (macro_name doc) x)"
         "@doc x\nend"  =>  "(macrocall (macro_name doc) x)"
 
+        # Special 1.14 @VERSION parsing rules
+        ((v=v"1.13",), "@VERSION")        =>  "(macrocall (macro_name VERSION))"
+        ((v=v"1.13",), "@A.B.VERSION")    =>  "(macrocall (macro_name (. (. A B) VERSION)))"
+        ((v=v"1.13",), "A.B.@VERSION")     =>  "(macrocall (. (. A B) (macro_name VERSION)))"
+        ((v=v"1.14",), "@VERSION")        =>  "(macrocall (macro_name VERSION) v\"1.14.0\")"
+        ((v=v"1.14",), "@A.B.VERSION")    =>  "(macrocall (macro_name (. (. A B) VERSION)) v\"1.14.0\")"
+        ((v=v"1.14",), "A.B.@VERSION")     =>  "(macrocall (. (. A B) (macro_name VERSION)) v\"1.14.0\")"
+
         # calls with brackets
         "f(a,b)"  => "(call f a b)"
         "f(a,)"   => "(call-, f a)"

--- a/JuliaSyntax/test/test_utils.jl
+++ b/JuliaSyntax/test/test_utils.jl
@@ -210,7 +210,7 @@ function parsers_agree_on_file(text, filename; exprs_equal=exprs_equal_no_linenu
         return true
     end
     try
-        stream = ParseStream(text)
+        stream = ParseStream(text; version=v"1.13")
         parse!(stream)
         ex = build_tree(Expr, stream, filename=filename)
         return !JuliaSyntax.any_error(stream) && exprs_equal(fl_ex, ex)

--- a/JuliaSyntax/test/tokenize.jl
+++ b/JuliaSyntax/test/tokenize.jl
@@ -988,6 +988,7 @@ const all_kws = Set([
     "primitive",
     "type",
     "var",
+    "VERSION",
     # Word-like operators
     "in",
     "isa",

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@ New language features
     is now a valid operator with arrow precedence, accessible as `\hookunderrightarrow` at the REPL.
     ([JuliaLang/JuliaSyntax.jl#525], [#57143])
   - Support for Unicode 17 ([#59534]).
+  - It is now possible to control which version of the Julia syntax will be used to parse a package by setting the
+    `compat.julia` or `syntax.julia_version` key in Project.toml. This feature is similar to the notion of "editions"
+    in other language ecosystems and will allow non-breaking evolution of Julia syntax in future versions.
+    See the "Syntax Versioning" section in the code loading documentation ([#60018]).
 
 Language changes
 ----------------

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -141,6 +141,20 @@ import Core: @doc, @__doc__, WrappedException, @int128_str, @uint128_str, @big_s
 # Export list
 include("exports.jl")
 
+function set_syntax_version end
+_topmod(m::Module) = ccall(:jl_base_relative_to, Any, (Any,), m)::Module
+function _setup_module!(mod::Module, Core.@nospecialize syntax_ver)
+    # using Base
+    Core._using(mod, _topmod(mod), UInt8(0))
+    Core.declare_const(mod, :include, IncludeInto(mod))
+    Core.declare_const(mod, :eval, Core.EvalInto(mod))
+    if syntax_ver === nothing
+        return nothing
+    end
+    set_syntax_version(mod, syntax_ver)
+    return nothing
+end
+
 # core docsystem
 include("docs/core.jl")
 Core.atdoc!(CoreDocs.docm)

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -1141,4 +1141,10 @@ typename(union::UnionAll) = typename(union.body)
 
 include(Core, "optimized_generics.jl")
 
+# Used only be the magic @VERSION macro
+struct MacroSource
+    lno::Any # ::LineNumberNode, but needs to be a pointer
+    syntax_ver::Any # ::VersionNumber =#
+end
+
 ccall(:jl_set_istopmod, Cvoid, (Any, Bool), Core, true)

--- a/base/client.jl
+++ b/base/client.jl
@@ -173,8 +173,8 @@ function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
     nothing
 end
 
-function _parse_input_line_core(s::String, filename::String)
-    ex = Meta.parseall(s, filename=filename)
+function _parse_input_line_core(s::String, filename::String, mod::Union{Module, Nothing})
+    ex = Meta.parseall(s; filename, mod)
     if ex isa Expr && ex.head === :toplevel
         if isempty(ex.args)
             return nothing
@@ -189,18 +189,18 @@ function _parse_input_line_core(s::String, filename::String)
     return ex
 end
 
-function parse_input_line(s::String; filename::String="none", depwarn=true)
+function parse_input_line(s::String; filename::String="none", depwarn=true, mod::Union{Module, Nothing}=nothing)
     # For now, assume all parser warnings are depwarns
     ex = if depwarn
-        _parse_input_line_core(s, filename)
+        _parse_input_line_core(s, filename, mod)
     else
         with_logger(NullLogger()) do
-            _parse_input_line_core(s, filename)
+            _parse_input_line_core(s, filename, mod)
         end
     end
     return ex
 end
-parse_input_line(s::AbstractString) = parse_input_line(String(s))
+parse_input_line(s::AbstractString; kwargs...) = parse_input_line(String(s); kwargs...)
 
 # detect the reason which caused an :incomplete expression
 # from the error message
@@ -443,7 +443,7 @@ function run_fallback_repl(interactive::Bool)
     let input = stdin
         if isa(input, File) || isa(input, IOStream)
             # for files, we can slurp in the whole thing at once
-            ex = parse_input_line(read(input, String))
+            ex = parse_input_line(read(input, String); mod=Main)
             if Meta.isexpr(ex, :toplevel)
                 # if we get back a list of statements, eval them sequentially
                 # as if we had parsed them sequentially
@@ -466,7 +466,7 @@ function run_fallback_repl(interactive::Bool)
                     ex = nothing
                     while !eof(input)
                         line *= readline(input, keep=true)
-                        ex = parse_input_line(line)
+                        ex = parse_input_line(line; mod=Main)
                         if !(isa(ex, Expr) && ex.head === :incomplete)
                             break
                         end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -572,3 +572,14 @@ to_power_type(x) = oftype(x*x, x)
 @deprecate merge(combine::Callable, d::AbstractDict, others::AbstractDict...) mergewith(combine, d, others...)
 
 # end 1.13 deprecations
+
+# BEGIN 1.14 deprecations
+
+# Revise calls this
+function explicit_manifest_entry_path(args...)
+    spec = explicit_manifest_entry_load_spec(args...)
+    spec === nothing && return nothing
+    return spec.path
+end
+
+# END 1.14 deprecations

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -306,7 +306,9 @@ elseif head === :call && length(x.args) >= 1 && isexpr(x.args[1], :(::))
         # otherwise, for documenting `x::y`, it will be extracted from x
         astname((x.args[1]::Expr).args[end], ismacro)
     else
-        n = if isexpr(x, (:module, :struct))
+        n = if isexpr(x, :module)
+            isa(x.args[1], Bool) ? 2 : 3
+        elseif isexpr(x, :struct)
             2
         elseif isexpr(x, (:call, :macrocall, :function, :(=), :macro, :where, :curly,
                           :(::), :(<:), :(>:), :local, :global, :const, :atomic,
@@ -439,9 +441,10 @@ function moduledoc(__source__, __module__, meta, def, def′::Expr)
     if def === nothing
         esc(:(Core.eval($name, $(quot(docex)))))
     else
+        has_version = !isa(def.args[1], Bool)
         def = unblock(def)
-        block = def.args[3].args
-        if !def.args[1]
+        block = def.args[3 + has_version].args
+        if !def.args[1 + has_version]
             pushfirst!(block, :(import Base: @doc))
         end
         push!(block, docex)

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -746,4 +746,99 @@ macro reexport(ex)
     return esc(calls)
 end
 
+struct VersionedParse
+    ver::VersionNumber
+end
+
+function (vp::VersionedParse)(code, filename::String, lineno::Int, offset::Int, options::Symbol)
+    if !isdefined(Base, :JuliaSyntax)
+        if vp.ver === VERSION
+            return Core._parse
+        end
+        error("JuliaSyntax module is required for syntax version $(vp.ver), but it is not loaded.")
+    end
+    Base.JuliaSyntax.core_parser_hook(code, filename, lineno, offset, options; syntax_version=vp.ver)
+end
+
+struct VersionedLower
+    ver::VersionNumber
+end
+
+function (vp::VersionedLower)(@nospecialize(code), mod::Module,
+                              file="none", line=0, world=typemax(Csize_t), warn=false)
+    if !isdefined(Base, :JuliaLowering)
+        if vp.ver === VERSION
+            return Core._parse
+        end
+        error("JuliaLowering module is required for syntax version $(vp.ver), but it is not loaded.")
+    end
+    Base.JuliaLowering.core_lowering_hook(code, filename, lineno, offset, options; syntax_version=vp.ver)
+end
+
+function Base.set_syntax_version(m::Module, ver::VersionNumber)
+    parser = VersionedParse(ver)
+    Core.declare_const(m, :_internal_julia_parse, parser)
+    #lowerer = VersionedLower(ver)
+    #Core.declare_const(m, :_internal_julia_lower, lowerer)
+    nothing
+end
+
+"""
+    Base.Experimental.@set_syntax_version ver
+
+Sets the syntax version to the current module to `ver`. This overrides settings of `syntax.julia_version` or
+`compat.julia` from Project.toml.
+
+!!! compat "Julia 1.14"
+    This macro was added in Julia 1.14.
+
+!!! warning
+    The new syntax version will take effect only for code parsed after the *invocation* of the result of the macro
+    expansion. This may be unintuitive if the macro is used inside a module body, as the entire module will be parsed
+    before any statements therein are executed, e.g. consider.
+
+    ```
+    @set_syntax_version v"1.13"
+    module ChangeSyntax
+        @set_syntax_version v"1.14"
+        expr1 # Parsed with syntax version 1.13
+     # The call itself is parsed with syntax version 1.13, but the included code is parsed with syntax version 1.14
+        include_string(ChangeSyntax, "expr2")
+        expr3 # Parsed with syntax version 1.13
+    end
+    ```
+
+    For this reason, the Project.toml mechanism is strongly preferred for packages.
+    However, this macro may be useful for scripts or the REPL.
+
+!!! warning
+    This interface is experimental and subject to change or removal without notice.
+"""
+macro set_syntax_version(ver)
+    Expr(:call, Base.set_syntax_version, __module__, esc(ver))
+end
+
+"""
+    Base.Experimental.@VERSION ver
+
+This macro provides access to parser (and possibly in the future other frontend component) language version
+information. In particular, `(@VERSION).syntax` provides the syntax version used to parse the location where the macro is invoked.
+
+!!! compat "Julia 1.14"
+    This macro was added in Julia 1.14.
+
+!!! note
+    Calls to this macro have special handling in the parser and the name `@VERSION` is mandatory. At this time, other macros do not
+    have access to source syntax version information.
+"""
+function var"@VERSION"(__source__::Union{LineNumberNode, Core.MacroSource}, __module__::Module)
+    # This macro has special handling in the parser, which puts the current syntax
+    # version into __source__.
+    if isa(__source__, LineNumberNode)
+        return :((; syntax = v"1.13", runtime = VERSION))
+    else
+        return :((; syntax = $(__source__.syntax_ver), runtime = VERSION))
+    end
+end
+
 end # module

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1800,9 +1800,6 @@ hasintersect(@nospecialize(a), @nospecialize(b)) = typeintersect(a, b) !== Botto
 # scoping #
 ###########
 
-_topmod(m::Module) = ccall(:jl_base_relative_to, Any, (Any,), m)::Module
-
-
 # high-level, more convenient method lookup functions
 
 function visit(f, mt::Core.MethodTable)

--- a/base/version.jl
+++ b/base/version.jl
@@ -275,3 +275,470 @@ else
 end
 
 libllvm_path() = ccall(:jl_get_libllvm, Any, ())
+
+
+################
+# VersionBound #
+################
+struct VersionBound
+    t::NTuple{3, UInt32}
+    n::Int
+    function VersionBound(tin::NTuple{n, Integer}) where {n}
+        n <= 3 || throw(ArgumentError("VersionBound: you can only specify major, minor and patch versions"))
+        n == 0 && return new((0, 0, 0), n)
+        n == 1 && return new((tin[1], 0, 0), n)
+        n == 2 && return new((tin[1], tin[2], 0), n)
+        n == 3 && return new((tin[1], tin[2], tin[3]), n)
+        error("invalid $n")
+    end
+end
+VersionBound(t::Integer...) = VersionBound(t)
+VersionBound(v::VersionNumber) = VersionBound(v.major, v.minor, v.patch)
+
+Base.getindex(b::VersionBound, i::Int) = b.t[i]
+
+function ≲(v::VersionNumber, b::VersionBound)
+    b.n == 0 && return true
+    b.n == 1 && return v.major <= b[1]
+    b.n == 2 && return (v.major, v.minor) <= (b[1], b[2])
+    return (v.major, v.minor, v.patch) <= (b[1], b[2], b[3])
+end
+
+function ≲(b::VersionBound, v::VersionNumber)
+    b.n == 0 && return true
+    b.n == 1 && return v.major >= b[1]
+    b.n == 2 && return (v.major, v.minor) >= (b[1], b[2])
+    return (v.major, v.minor, v.patch) >= (b[1], b[2], b[3])
+end
+
+function isless_ll(a::VersionBound, b::VersionBound)
+    m, n = a.n, b.n
+    for i in 1:min(m, n)
+        a[i] < b[i] && return true
+        a[i] > b[i] && return false
+    end
+    return m < n
+end
+
+stricterlower(a::VersionBound, b::VersionBound) = isless_ll(a, b) ? b : a
+
+# Comparison between two upper bounds
+function isless_uu(a::VersionBound, b::VersionBound)
+    m, n = a.n, b.n
+    for i in 1:min(m, n)
+        a[i] < b[i] && return true
+        a[i] > b[i] && return false
+    end
+    return m > n
+end
+
+stricterupper(a::VersionBound, b::VersionBound) = isless_uu(a, b) ? a : b
+
+# `isjoinable` compares an upper bound of a range with the lower bound of the next range
+# to determine if they can be joined, as in [1.5-2.8, 2.5-3] -> [1.5-3]. Used by `union!`.
+# The equal-length-bounds case is special since e.g. `1.5` can be joined with `1.6`,
+# `2.3.4` can be joined with `2.3.5` etc.
+
+function isjoinable(up::VersionBound, lo::VersionBound)
+    up.n == 0 && lo.n == 0 && return true
+    if up.n == lo.n
+        n = up.n
+        for i in 1:(n - 1)
+            up[i] > lo[i] && return true
+            up[i] < lo[i] && return false
+        end
+        up[n] < lo[n] - 1 && return false
+        return true
+    else
+        l = min(up.n, lo.n)
+        for i in 1:l
+            up[i] > lo[i] && return true
+            up[i] < lo[i] && return false
+        end
+    end
+    return true
+end
+
+Base.hash(r::VersionBound, h::UInt) = hash(r.t, hash(r.n, h))
+
+# Hot code
+function VersionBound(s::AbstractString)
+    s = strip(s)
+    s == "*" && return VersionBound()
+    first(s) == 'v' && (s = SubString(s, 2))
+    l = lastindex(s)
+
+    p = findnext('.', s, 1)
+    b = p === nothing ? l : (p - 1)
+    i = parse(Int64, SubString(s, 1, b))
+    p === nothing && return VersionBound(i)
+
+    a = p + 1
+    p = findnext('.', s, a)
+    b = p === nothing ? l : (p - 1)
+    j = parse(Int64, SubString(s, a, b))
+    p === nothing && return VersionBound(i, j)
+
+    a = p + 1
+    p = findnext('.', s, a)
+    b = p === nothing ? l : (p - 1)
+    k = parse(Int64, SubString(s, a, b))
+    p === nothing && return VersionBound(i, j, k)
+
+    error("invalid VersionBound string $(repr(s))")
+end
+
+################
+# VersionRange #
+################
+struct VersionRange
+    lower::VersionBound
+    upper::VersionBound
+    # NOTE: ranges are allowed to be empty; they are ignored by VersionSpec anyway
+    function VersionRange(lo::VersionBound, hi::VersionBound)
+        # lo.t == hi.t implies that digits past min(lo.n, hi.n) are zero
+        # lo.n < hi.n example: 1.2-1.2.0 => 1.2.0
+        # lo.n > hi.n example: 1.2.0-1.2 => 1.2
+        lo.t == hi.t && (lo = hi)
+        return new(lo, hi)
+    end
+end
+VersionRange(b::VersionBound = VersionBound()) = VersionRange(b, b)
+VersionRange(t::Integer...) = VersionRange(VersionBound(t...))
+VersionRange(v::VersionNumber) = VersionRange(VersionBound(v))
+VersionRange(lo::VersionNumber, hi::VersionNumber) = VersionRange(VersionBound(lo), VersionBound(hi))
+
+# The vast majority of VersionRanges are in practice equal to "1"
+const VersionRange_1 = VersionRange(VersionBound("1"), VersionBound("1"))
+function VersionRange(s::AbstractString)
+    s == "1" && return VersionRange_1
+    p = split(s, "-")
+    if length(p) != 1 && length(p) != 2
+        throw(ArgumentError("invalid version range: $(repr(s))"))
+    end
+    lower = VersionBound(p[1])
+    upper = length(p) == 1 ? lower : VersionBound(p[2])
+    return VersionRange(lower, upper)
+end
+
+function Base.isempty(r::VersionRange)
+    for i in 1:min(r.lower.n, r.upper.n)
+        r.lower[i] > r.upper[i] && return true
+        r.lower[i] < r.upper[i] && return false
+    end
+    return false
+end
+
+function Base.print(io::IO, r::VersionRange)
+    m, n = r.lower.n, r.upper.n
+    return if (m, n) == (0, 0)
+        print(io, '*')
+    elseif m == 0
+        print(io, "0 -")
+        join(io, r.upper.t, '.')
+    elseif n == 0
+        join(io, r.lower.t, '.')
+        print(io, " - *")
+    else
+        join(io, r.lower.t[1:m], '.')
+        if r.lower != r.upper
+            print(io, " - ")
+            join(io, r.upper.t[1:n], '.')
+        end
+    end
+end
+Base.show(io::IO, r::VersionRange) = print(io, "VersionRange(\"", r, "\")")
+
+Base.in(v::VersionNumber, r::VersionRange) = r.lower ≲ v ≲ r.upper
+
+Base.intersect(a::VersionRange, b::VersionRange) = VersionRange(stricterlower(a.lower, b.lower), stricterupper(a.upper, b.upper))
+
+function Base.union!(ranges::Vector{<:VersionRange})
+    l = length(ranges)
+    l == 0 && return ranges
+
+    sort!(ranges, lt = (a, b) -> (isless_ll(a.lower, b.lower) || (a.lower == b.lower && isless_uu(a.upper, b.upper))))
+
+    k0 = 1
+    ks = findfirst(!isempty, ranges)
+    ks === nothing && return empty!(ranges)
+
+    lo, up, k0 = ranges[ks].lower, ranges[ks].upper, 1
+    for k in (ks + 1):l
+        isempty(ranges[k]) && continue
+        lo1, up1 = ranges[k].lower, ranges[k].upper
+        if isjoinable(up, lo1)
+            isless_uu(up, up1) && (up = up1)
+            continue
+        end
+        vr = VersionRange(lo, up)
+        @assert !isempty(vr)
+        ranges[k0] = vr
+        k0 += 1
+        lo, up = lo1, up1
+    end
+    vr = VersionRange(lo, up)
+    if !isempty(vr)
+        ranges[k0] = vr
+        k0 += 1
+    end
+    resize!(ranges, k0 - 1)
+    return ranges
+end
+
+Base.minimum(r::VersionRange) = r.lower
+
+###############
+# VersionSpec #
+###############
+struct VersionSpec
+    ranges::Vector{VersionRange}
+    VersionSpec(r::Vector{<:VersionRange}) = new(length(r) == 1 ? r : union!(r))
+    VersionSpec(vs::VersionSpec) = vs
+end
+
+VersionSpec(r::VersionRange) = VersionSpec(VersionRange[r])
+VersionSpec(v::VersionNumber) = VersionSpec(VersionRange(v))
+const _all_versionsspec = VersionSpec(VersionRange())
+VersionSpec() = _all_versionsspec
+VersionSpec(s::AbstractString) = VersionSpec(VersionRange(s))
+VersionSpec(v::AbstractVector) = VersionSpec(map(VersionRange, v))
+
+# Hot code
+function Base.in(v::VersionNumber, s::VersionSpec)
+    for r in s.ranges
+        v in r && return true
+    end
+    return false
+end
+
+# Optimized batch version check for version lists
+# Fills dest[1:n] indicating which versions are in the VersionSpec
+# Optimized for sorted version lists (but works correctly even if unsorted)
+# Note: Only fills indices 1:n, leaves rest of dest unchanged
+function matches_spec_range!(dest::BitVector, versions::AbstractVector{VersionNumber}, spec::VersionSpec, n::Int)
+    @assert length(versions) == n
+    @assert length(dest) >= n
+
+    # Initialize to false
+    dest[1:n] .= false
+
+    isempty(spec.ranges) && return dest
+
+    # Assumes versions are sorted (as created in Operations.jl:1002)
+    # If sorted, this avoids O(n*m) comparisons by scanning linearly
+    @inbounds for range in spec.ranges
+        # Find first version that could be in range
+        i = 1
+        while i <= n && !(range.lower ≲ versions[i])
+            i += 1
+        end
+
+        # Mark all versions in range
+        while i <= n && versions[i] ≲ range.upper
+            dest[i] = true
+            i += 1
+        end
+    end
+
+    return dest
+end
+
+Base.copy(vs::VersionSpec) = VersionSpec(vs)
+
+const empty_versionspec = VersionSpec(VersionRange[])
+const _empty_symbol = "∅"
+
+Base.isempty(s::VersionSpec) = all(isempty, s.ranges)
+@assert isempty(empty_versionspec)
+# Hot code, measure performance before changing
+function Base.intersect(A::VersionSpec, B::VersionSpec)
+    (isempty(A) || isempty(B)) && return copy(empty_versionspec)
+    ranges = Vector{VersionRange}(undef, length(A.ranges) * length(B.ranges))
+    i = 1
+    @inbounds for a in A.ranges, b in B.ranges
+        ranges[i] = intersect(a, b)
+        i += 1
+    end
+    return VersionSpec(ranges)
+end
+Base.intersect(a::VersionNumber, B::VersionSpec) = a in B ? VersionSpec(a) : empty_versionspec
+Base.intersect(A::VersionSpec, b::VersionNumber) = intersect(b, A)
+
+function Base.union(A::VersionSpec, B::VersionSpec)
+    A == B && return A
+    Ar = copy(A.ranges)
+    append!(Ar, B.ranges)
+    union!(Ar)
+    return VersionSpec(Ar)
+end
+
+Base.:(==)(A::VersionSpec, B::VersionSpec) = A.ranges == B.ranges
+Base.hash(s::VersionSpec, h::UInt) = hash(s.ranges, h + (0x2fd2ca6efa023f44 % UInt))
+
+function Base.print(io::IO, s::VersionSpec)
+    isempty(s) && return print(io, _empty_symbol)
+    length(s.ranges) == 1 && return print(io, s.ranges[1])
+    print(io, '[')
+    for i in 1:length(s.ranges)
+        1 < i && print(io, ", ")
+        print(io, s.ranges[i])
+    end
+    return print(io, ']')
+end
+
+function Base.show(io::IO, s::VersionSpec)
+    print(io, "VersionSpec(")
+    if length(s.ranges) == 1
+        print(io, '"', s.ranges[1], '"')
+    else
+        print(io, "[")
+        for i in 1:length(s.ranges)
+            1 < i && print(io, ", ")
+            print(io, '"', s.ranges[i], '"')
+        end
+        print(io, ']')
+    end
+    return print(io, ")")
+end
+
+Base.minimum(v::VersionSpec) = minimum(v.ranges[1])
+
+###################
+# Semver notation #
+###################
+
+function semver_spec(s::String; throw = true)
+    ranges = VersionRange[]
+    for ver in strip.(split(strip(s), ','))
+        range = nothing
+        found_match = false
+        for (ver_reg, f) in ver_regs
+            if occursin(ver_reg, ver)
+                range = f(match(ver_reg, ver))
+                found_match = true
+                break
+            end
+        end
+        if !found_match
+            if throw
+                error("invalid version specifier: \"$s\"")
+            else
+                return nothing
+            end
+        end
+        push!(ranges, range)
+    end
+    return VersionSpec(ranges)
+end
+
+function semver_interval(m::RegexMatch)
+    @assert length(m.captures) == 4
+    n_significant = count(x -> x !== nothing, m.captures) - 1
+    typ, _major, _minor, _patch = m.captures
+    major = parse(Int, _major)
+    minor = (n_significant < 2) ? 0 : parse(Int, _minor)
+    patch = (n_significant < 3) ? 0 : parse(Int, _patch)
+    if n_significant == 3 && major == 0 && minor == 0 && patch == 0
+        error("invalid version: \"0.0.0\"")
+    end
+    # Default type is :caret
+    vertyp = (typ == "" || typ == "^") ? :caret : :tilde
+    v0 = VersionBound((major, minor, patch))
+    return if vertyp === :caret
+        if major != 0
+            return VersionRange(v0, VersionBound((v0[1],)))
+        elseif minor != 0
+            return VersionRange(v0, VersionBound((v0[1], v0[2])))
+        else
+            if n_significant == 1
+                return VersionRange(v0, VersionBound((0,)))
+            elseif n_significant == 2
+                return VersionRange(v0, VersionBound((0, 0)))
+            else
+                return VersionRange(v0, VersionBound((0, 0, v0[3])))
+            end
+        end
+    else
+        if n_significant == 3 || n_significant == 2
+            return VersionRange(v0, VersionBound((v0[1], v0[2])))
+        else
+            return VersionRange(v0, VersionBound((v0[1],)))
+        end
+    end
+end
+
+const _inf = VersionBound("*")
+function inequality_interval(m::RegexMatch)
+    @assert length(m.captures) == 4
+    typ, _major, _minor, _patch = m.captures
+    n_significant = count(x -> x !== nothing, m.captures) - 1
+    major = parse(Int, _major)
+    minor = (n_significant < 2) ? 0 : parse(Int, _minor)
+    patch = (n_significant < 3) ? 0 : parse(Int, _patch)
+    if n_significant == 3 && major == 0 && minor == 0 && patch == 0
+        error("invalid version: 0.0.0")
+    end
+    v = VersionBound(major, minor, patch)
+    if occursin(r"^<\s*$", typ)
+        nil = VersionBound(0, 0, 0)
+        if v[3] == 0
+            if v[2] == 0
+                v1 = VersionBound(v[1] - 1)
+            else
+                v1 = VersionBound(v[1], v[2] - 1)
+            end
+        else
+            v1 = VersionBound(v[1], v[2], v[3] - 1)
+        end
+        return VersionRange(nil, v1)
+    elseif occursin(r"^=\s*$", typ)
+        return VersionRange(v)
+    elseif occursin(r"^>=\s*$", typ) || occursin(r"^≥\s*$", typ)
+        return VersionRange(v, _inf)
+    else
+        error("invalid prefix $typ")
+    end
+end
+
+function hyphen_interval(m::RegexMatch)
+    @assert length(m.captures) == 6
+    _lower_major, _lower_minor, _lower_patch, _upper_major, _upper_minor, _upper_patch = m.captures
+    if isnothing(_lower_minor)
+        lower_bound = VersionBound(parse(Int, _lower_major))
+    elseif isnothing(_lower_patch)
+        lower_bound = VersionBound(
+            parse(Int, _lower_major),
+            parse(Int, _lower_minor)
+        )
+    else
+        lower_bound = VersionBound(
+            parse(Int, _lower_major),
+            parse(Int, _lower_minor),
+            parse(Int, _lower_patch)
+        )
+    end
+    if isnothing(_upper_minor)
+        upper_bound = VersionBound(parse(Int, _upper_major))
+    elseif isnothing(_upper_patch)
+        upper_bound = VersionBound(
+            parse(Int, _upper_major),
+            parse(Int, _upper_minor)
+        )
+    else
+        upper_bound = VersionBound(
+            parse(Int, _upper_major),
+            parse(Int, _upper_minor),
+            parse(Int, _upper_patch)
+        )
+    end
+    return VersionRange(lower_bound, upper_bound)
+end
+
+const version = "v?([0-9]+?)(?:\\.([0-9]+?))?(?:\\.([0-9]+?))?"
+const ver_regs =
+    Pair{Regex, Any}[
+    Regex("^([~^]?)?$version\$") => semver_interval, # 0.5 ^0.4 ~0.3.2
+    Regex("^((?:≥\\s*)|(?:>=\\s*)|(?:=\\s*)|(?:<\\s*)|(?:=\\s*))v?$version\$") => inequality_interval, # < 0.2 >= 0.5,2
+    Regex("^[\\s]*$version[\\s]*?\\s-\\s[\\s]*?$version[\\s]*\$") => hyphen_interval, # 0.7 - 1.3
+]

--- a/doc/src/manual/code-loading.md
+++ b/doc/src/manual/code-loading.md
@@ -438,6 +438,32 @@ Preferences in environments higher up in the environment stack get overridden by
 This allows depot-wide preference defaults to exist, with active projects able to merge or even completely overwrite these inherited preferences.
 See the docstring for `Preferences.set_preferences!()` for the full details of how to set preferences to allow or disallow merging.
 
+### [Syntax Versioning](@id syntax-versioning)
+
+Syntax versioning allows packages to specify which version of Julia's syntax they use. In particular, different
+packages can use different versions of the Julia syntax. This allows evolution of Julia's syntax in a non-breaking
+way, while allowing packages to upgrade at their own pace. The syntax version is determined from the package's
+corresponding Project.toml and propagates to all modules defined in the package.
+
+#### Syntax Version Determination
+
+The syntax version for a package is determined by the loading mechanism in the following order of precedence:
+
+1. If a `syntax.julia_version` field is present in the project file, it is used directly:
+   ```toml
+   name = "MyPackage"
+   uuid = "..."
+   syntax.julia_version = "1.14"
+   ```
+
+2. Otherwise, if a `[compat]` section specifies a Julia version constraint, the minimum compatible version is used:
+   ```toml
+   [compat]
+   julia = "1.13-2"  # implies syntax version 1.13.0
+   ```
+
+3. If neither is specified, the current Julia version is used.
+
 ## Conclusion
 
 Federated package management and precise software reproducibility are difficult but worthy goals in a package system. In combination, these goals lead to a more complex package loading mechanism than most dynamic languages have, but it also yields scalability and reproducibility that is more commonly associated with static languages. Typically, Julia users should be able to use the built-in package manager to manage their projects without needing a precise understanding of these interactions. A call to `Pkg.add("X")` will add to the appropriate project and manifest files, selected via `Pkg.activate("Y")`, so that a future call to `import X` will load `X` without further thought.

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -932,6 +932,7 @@ STATIC_INLINE size_t module_usings_max(jl_module_t *m) JL_NOTSAFEPOINT {
 }
 
 JL_DLLEXPORT jl_sym_t *jl_module_name(jl_module_t *m) JL_NOTSAFEPOINT;
+jl_module_t *jl_module_root(jl_module_t *m);
 void jl_add_scanned_method(jl_module_t *m, jl_method_t *meth);
 jl_value_t *jl_eval_global_var(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *e, size_t world);
 JL_DLLEXPORT jl_value_t *jl_eval_globalref(jl_globalref_t *g, size_t world);
@@ -1366,7 +1367,7 @@ jl_tupletype_t *arg_type_tuple(jl_value_t *arg1, jl_value_t **args, size_t nargs
 JL_DLLEXPORT int jl_has_meta(jl_array_t *body, jl_sym_t *sym) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT jl_value_t *jl_parse(const char *text, size_t text_len, jl_value_t *filename,
-                                  size_t lineno, size_t offset, jl_value_t *options);
+                                  size_t lineno, size_t offset, jl_value_t *options, jl_module_t *inmodule);
 jl_code_info_t *jl_inner_ctor_body(jl_array_t *fieldkinds, jl_module_t *inmodule, const char *file, int line);
 jl_code_info_t *jl_outer_ctor_body(jl_value_t *thistype, size_t nfields, size_t nsparams, jl_module_t *inmodule, const char *file, int line);
 void jl_ctor_def(jl_value_t *ty, jl_value_t *functionloc);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3304,10 +3304,25 @@ static int ci_not_internal_cache(jl_code_instance_t *ci)
     return !(jl_atomic_load_relaxed(&ci->flags) & JL_CI_FLAGS_NATIVE_CACHE_VALID) || jl_object_in_image(mi->def.value);
 }
 
+static uint8_t jl_get_toplevel_syntax_version(void)
+{
+    jl_task_t *ct = jl_current_task;
+    jl_module_t *toplevel = (jl_module_t*)jl_get_global_value(jl_base_module, jl_symbol("__toplevel__"), ct->world_age);
+    JL_GC_PROMISE_ROOTED(toplevel);
+    jl_value_t *syntax_version = jl_get_global_value(toplevel, jl_symbol("_internal_syntax_version"), ct->world_age);
+    return jl_unbox_uint8(syntax_version);
+}
+
 static void jl_write_header_for_incremental(ios_t *f, jl_array_t *worklist, jl_array_t *mod_array, jl_array_t **udeps, int64_t *srctextpos, int64_t *checksumpos)
 {
     *checksumpos = write_header(f, 0);
     write_uint8(f, jl_cache_flags());
+    // write the syntax version marker. Note that unlike a VersionNumber, this is
+    // private to the serialization format and only needs to be reloaded by the
+    // same version of Julia that wrote it. As a result, we don't store the full
+    // VersionNumber, only an index of which of the supported syntax versions to
+    // select.
+    write_uint8(f, jl_get_toplevel_syntax_version());
     // write description of contents (name, uuid, buildid)
     write_worklist_for_header(f, worklist);
     // Determine unique (module, abspath, fsize, hash, mtime) dependencies for the files defining modules in the worklist
@@ -3359,6 +3374,7 @@ JL_DLLEXPORT void jl_create_system_image(void **_native_data, jl_array_t *workli
         if (emit_split) {
             checksumpos_ff = write_header(ff, 1);
             write_uint8(ff, jl_cache_flags());
+            write_uint8(ff, jl_get_toplevel_syntax_version());
             write_mod_list(ff, mod_array);
         }
         else {
@@ -4305,6 +4321,8 @@ static jl_value_t *jl_validate_cache_file(ios_t *f, jl_array_t *depmods, uint64_
     if (pkgimage && !jl_match_cache_flags_current(flags)) {
         return jl_get_exceptionf(jl_errorexception_type, "Pkgimage flags mismatch");
     }
+    // Syntax version mismatch is not fatal to load
+    (void)read_uint8(f); // syntax_version
     if (!pkgimage) {
         // skip past the worklist
         size_t len;

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -652,7 +652,7 @@ static const char *jl_git_commit(void)
 
 
 // "magic" string and version header of .ji file
-static const int JI_FORMAT_VERSION = 12;
+static const int JI_FORMAT_VERSION = 13;
 static const char JI_MAGIC[] = "\373jli\r\n\032\n"; // based on PNG signature
 static const uint16_t BOM = 0xFEFF; // byte-order marker
 static int64_t write_header(ios_t *s, uint8_t pkgimage)

--- a/src/timing.c
+++ b/src/timing.c
@@ -10,8 +10,6 @@
 #define DISABLE_FREQUENT_EVENTS
 #endif
 
-jl_module_t *jl_module_root(jl_module_t *m);
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -993,6 +993,7 @@ end
 
 function completions(string::String, pos::Int, context_module::Module=Main, shift::Bool=true, hint::Bool=false)
     # filename needs to be string so macro can be evaluated
+    # TODO: JuliaSyntax version API here
     node = parseall(CursorNode, string, ignore_errors=true, keep_parens=true, filename="none")
     cur = @something seek_pos(node, pos) node
 

--- a/test/project/SyntaxVersioning/explicit/Manifest.toml
+++ b/test/project/SyntaxVersioning/explicit/Manifest.toml
@@ -1,0 +1,14 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.14.0-DEV"
+manifest_format = "2.1"
+
+[[deps.VersionedDep1]]
+path = "VersionedDep1"
+uuid = "f08855a0-36cb-4a32-8ae5-a227b709c612"
+syntax.julia_version = "1.13.0"
+
+[[deps.VersionedDep2]]
+path = "VersionedDep2"
+uuid = "e127e659-a899-4a00-b565-5b74face18ba"
+syntax.julia_version = "1.14.0"

--- a/test/project/SyntaxVersioning/explicit/Project.toml
+++ b/test/project/SyntaxVersioning/explicit/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+VersionedDep1 = "f08855a0-36cb-4a32-8ae5-a227b709c612"
+VersionedDep2 = "e127e659-a899-4a00-b565-5b74face18ba"

--- a/test/project/SyntaxVersioning/explicit/VersionedDep1/Project.toml
+++ b/test/project/SyntaxVersioning/explicit/VersionedDep1/Project.toml
@@ -1,0 +1,3 @@
+name = "VersionedDep1"
+uuid = "f08855a0-36cb-4a32-8ae5-a227b709c612"
+syntax.julia_version = "1.13"

--- a/test/project/SyntaxVersioning/explicit/VersionedDep1/src/VersionedDep1.jl
+++ b/test/project/SyntaxVersioning/explicit/VersionedDep1/src/VersionedDep1.jl
@@ -1,0 +1,3 @@
+module VersionedDep1
+    const ver = (@Base.Experimental.VERSION).syntax
+end

--- a/test/project/SyntaxVersioning/explicit/VersionedDep2/Project.toml
+++ b/test/project/SyntaxVersioning/explicit/VersionedDep2/Project.toml
@@ -1,0 +1,3 @@
+name = "VersionedDep2"
+uuid = "e127e659-a899-4a00-b565-5b74face18ba"
+syntax.julia_version = "1.14"

--- a/test/project/SyntaxVersioning/explicit/VersionedDep2/src/VersionedDep2.jl
+++ b/test/project/SyntaxVersioning/explicit/VersionedDep2/src/VersionedDep2.jl
@@ -1,0 +1,3 @@
+module VersionedDep2
+    const ver = (@Base.Experimental.VERSION).syntax
+end

--- a/test/project/SyntaxVersioning/implicit/Versioned1/Project.toml
+++ b/test/project/SyntaxVersioning/implicit/Versioned1/Project.toml
@@ -1,0 +1,3 @@
+name = "Versioned1"
+uuid = "5039f352-f8db-42c3-a2c5-1d61ed1e55b8"
+syntax.julia_version = "1.13"

--- a/test/project/SyntaxVersioning/implicit/Versioned1/src/Versioned1.jl
+++ b/test/project/SyntaxVersioning/implicit/Versioned1/src/Versioned1.jl
@@ -1,0 +1,3 @@
+module Versioned1
+    const ver = (@Base.Experimental.VERSION).syntax
+end

--- a/test/project/SyntaxVersioning/implicit/Versioned2/Project.toml
+++ b/test/project/SyntaxVersioning/implicit/Versioned2/Project.toml
@@ -1,0 +1,3 @@
+name = "Versioned2"
+uuid = "3a4c0187-8e98-47c1-abc0-783d1a175621"
+syntax.julia_version = "1.14"

--- a/test/project/SyntaxVersioning/implicit/Versioned2/src/Versioned2.jl
+++ b/test/project/SyntaxVersioning/implicit/Versioned2/src/Versioned2.jl
@@ -1,0 +1,3 @@
+module Versioned2
+    const ver = (@Base.Experimental.VERSION).syntax
+end

--- a/test/project/SyntaxVersioning/implicit/Versioned3/Project.toml
+++ b/test/project/SyntaxVersioning/implicit/Versioned3/Project.toml
@@ -1,0 +1,5 @@
+name = "Versioned3"
+uuid = "06d511b3-69b4-4d20-8d3b-d39263331254"
+
+[compat]
+julia = "1.13 - 2"

--- a/test/project/SyntaxVersioning/implicit/Versioned3/src/Versioned3.jl
+++ b/test/project/SyntaxVersioning/implicit/Versioned3/src/Versioned3.jl
@@ -1,0 +1,3 @@
+module Versioned3
+    const ver = (@Base.Experimental.VERSION).syntax
+end

--- a/test/project/SyntaxVersioning/implicit/Versioned4/Project.toml
+++ b/test/project/SyntaxVersioning/implicit/Versioned4/Project.toml
@@ -1,0 +1,2 @@
+name = "Versioned4"
+uuid = "3a4c0187-8e98-47c1-abc0-783d1a175621"

--- a/test/project/SyntaxVersioning/implicit/Versioned4/src/Versioned4.jl
+++ b/test/project/SyntaxVersioning/implicit/Versioned4/src/Versioned4.jl
@@ -1,0 +1,3 @@
+module Versioned4
+    const ver = (@Base.Experimental.VERSION).syntax
+end

--- a/test/project/SyntaxVersioning/implicit/Versioned5/Project.toml
+++ b/test/project/SyntaxVersioning/implicit/Versioned5/Project.toml
@@ -1,0 +1,5 @@
+name = "Versioned5"
+uuid = "1805a4d1-8cc9-402d-b9fb-3f94ad9a89b5"
+
+[compat]
+julia = "1.14 - 2"

--- a/test/project/SyntaxVersioning/implicit/Versioned5/src/Versioned5.jl
+++ b/test/project/SyntaxVersioning/implicit/Versioned5/src/Versioned5.jl
@@ -1,0 +1,3 @@
+module Versioned5
+    const ver = (@Base.Experimental.VERSION).syntax
+end


### PR DESCRIPTION
# Motivation
There are several corner cases in the Julia syntax that are essentially bugs or mistakes that we'd like to possibly remove, but can't due to backwards compatibility concerns.

Similarly, when adding new syntax features, there are often cases that overlap with valid (but often nonsensical) existing syntax. In the past, we've mostly done judegement calls of these being "minor changes", but as the package ecosystem grows, so does the chance of someone accidentally using these anyway and our "minor changes" have (subjectively) resulted in more breakages recently.

Fortunately, all the recent work on making the parser replacable, combined with the fact that JuliaSyntax already supports parsing multiple revisions of Julia syntax provides a solution here: Just let packages declare what version of the Julia syntax they are using. That way, packages would not break if we make changes to the syntax and they can be upgraded at their own pace the next time the author of that particular package upgrades to a new julia version.

# Core mechanism
The way this works is simple. Right now, the parser function is always looked up in `Core._parse`. With this PR, it is instead looked up as `mod._internal_julia_parse` (slightly longer name to avoid conflicting with existing bindings of the name in downstream packages), or `Core._parse` if no such binding exists. Similar for `_lower`.

There is a macro `@Base.Experimental.set_syntax_version v"1.xx"` that will set the `_internal_julia_parse` (and inte the future the _lower version) to one that propagates the version to the parser, so users are not expected to manipulate the binding directly.

# Versioned package loading
The loading system is extended to look at a new `syntax.julia_version` key in Project.toml (and Manifest for explicit environments). If no such key exists, it defaults to the minimum allowed version of the Julia compat. If no compat is defined, it defaults to the current Julia version. This is technically slightly less backwards compatible than defaulting this to Julia 1.13, but I think it will be less suprising in the future for the default syntax to match what is in the REPL. Most julia packages do already define a julia compat.

Note that as a result of this, the code for parse compat ranges moves from Pkg to Base.

# Syntax changes
This introduces two parser changes:
1. `@VERSION` (and similar macrocall forms of a macro named `VERSION`) are now special and trigger the parser to push its version information into the source location field of the macrocall. Note that because this is in the parser, this affects all macros with the name. However, there is also logic on the macrocall side that discards this again if the macro cannot accept it. This special mechanism is used by the `Base.Experimental.@VERSION` macro to let users detect the parse version.

2. The `module` syntax form gains a syntax version argument that is automatically populated with the parser's current version. This is the mechanism to propagate syntax information from the parser to the core mechanism above.

Note that these are only active if a module has opted into 1.14 syntax, so macros that process `:module` exprs will not see these changes unless and until the calling module opts into 1.14 syntax via the above mentioned mechanisms (which is the primary advantage of this scheme).

# Final words

I should emphasize that I'm not proposing using this for any big syntax revolutions or anything. I would just like to start cleaning up a few corners of the syntax that I think are universally agreed to be bad but that we've kept for backwards compatibility. This way, by the time we get around to making a breaking revision, our entire ecosystem will have already upgraded to the new syntax.

# Remaining TODO
- [x] Standalone tests for the parser changes
- [x] JuliaLowering update
- [x] Pkg.jl side changes (https://github.com/JuliaLang/Pkg.jl/pull/4520)
- [x] NEWS entry

# Open questions

- [x] What should be the version of the flisp parser?

Some doc and test edits by Claude but mostly manual.