### PR TITLE
fix waitall deadlock if any errors occur

### DIFF
--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1372,9 +1372,7 @@ end
                 tasks = [Threads.@spawn(div(1, i)) for i = 0:1]
                 wait(tasks[1]; throw=false)
                 wait(tasks[2]; throw=false)
-                @test_throws CompositeException begin
-                    waitall(Threads.@spawn(div(1, i)) for i = 0:1)
-                end
+                @test_throws CompositeException waitall(tasks)
             end
         end
     end


### PR DESCRIPTION
When errors occur, `waitall` may skip allocating Channel producers, leading to deadlock in the subsequent loop in the event that the user asked it to failfast (ironically). This is seen often in the failing of the threads_exec test ever since the test was added for this call. Simplify this to just use separate loops for the wait and the return computation.