### PR TITLE
Make some tests not fail with uid 0

### DIFF
--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1249,7 +1249,10 @@ let s, c, r
                 @test s[r] == "tmp-execu"
 
                 c,r = test_scomplete("replcompletions-link")
-                @test isempty(c)
+                if !Sys.isunix() || Libc.getuid() != 0
+                    # Root bypasses permissions
+                    @test isempty(c)
+                end
             end
         finally
             # If we don't fix the permissions here, our cleanup fails.

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2249,7 +2249,7 @@ precompile_test_harness("Issue #52063") do load_path
         @test e isa SystemError
         @test e.prefix == "opening file or folder $(repr(fname))"
         true
-    end
+    end skip = (Sys.isunix() && Libc.geteuid() == 0)
     dir = mktempdir() do dir
         @test include_dependency(dir) === nothing
         chmod(dir, 0x000)
@@ -2259,7 +2259,7 @@ precompile_test_harness("Issue #52063") do load_path
             @test e isa SystemError
             @test e.prefix == "opening file or folder $(repr(dir))"
             true
-        end
+        end skip = (Sys.isunix() && Libc.geteuid() == 0)
         dir
     end
     @test try

--- a/test/sysinfo.jl
+++ b/test/sysinfo.jl
@@ -35,7 +35,12 @@ if Sys.isunix()
         original_path = ENV["PATH"]
         ENV["PATH"] = string(firstdir, ":", seconddir, ":", original_path)
         try
-            @test abspath(Base.Sys.which("foo")) == abspath(joinpath(seconddir, "foo"))
+            if Libc.geteuid() == 0
+                # Root bypasses permission checks
+                @test abspath(Base.Sys.which("foo")) == abspath(joinpath(firstdir, "foo"))
+            else
+                @test abspath(Base.Sys.which("foo")) == abspath(joinpath(seconddir, "foo"))
+            end
         finally
             # clean up
             chmod(firstdir, 0o777)


### PR DESCRIPTION
When running as UID 0 (system root, but also container root in various sandboxing technologies), the system ignores unix permissions. We have a number of tests that assume that a 000 mode means the file is not readable. Adjust these tests appropriately.

There are more failures, but I'll look at those in a follow-up.