### PR TITLE
libgit2/test: Handle a partially broken openssl install

### DIFF
--- a/stdlib/LibGit2/test/libgit2-tests.jl
+++ b/stdlib/LibGit2/test/libgit2-tests.jl
@@ -3096,7 +3096,15 @@ mktempdir() do dir
                 conf = joinpath(root, common_name * ".conf")
 
                 # Make sure test doesn't depend on system OpenSSL config (which may be broken)
-                touch(conf)
+                open(conf, "w") do io
+                    write(io, """
+                        [req]
+                        distinguished_name = req_distinguished_name
+
+                        [req_distinguished_name]
+                        CN = $common_name
+                        """)
+                end
 
                 # Generated a certificate which has the CN set correctly but no subjectAltName
                 err = IOBuffer()

--- a/stdlib/LibGit2/test/libgit2-tests.jl
+++ b/stdlib/LibGit2/test/libgit2-tests.jl
@@ -3093,9 +3093,15 @@ mktempdir() do dir
                 key = joinpath(root, common_name * ".key")
                 cert = joinpath(root, common_name * ".crt")
                 pem = joinpath(root, common_name * ".pem")
+                conf = joinpath(root, common_name * ".conf")
+
+                # Make sure test doesn't depend on system OpenSSL config (which may be broken)
+                touch(conf)
 
                 # Generated a certificate which has the CN set correctly but no subjectAltName
-                run(pipeline(`openssl req -new -x509 -newkey rsa:2048 -sha256 -nodes -keyout $key -out $cert -days 1 -subj "/CN=$common_name"`, stderr=devnull))
+                run(pipeline(addenv(
+                    `openssl req -new -x509 -newkey rsa:2048 -sha256 -nodes -keyout $key -out $cert -days 1 -subj "/CN=$common_name"`,
+                    "OPENSSL_CONF" => conf), stderr=devnull))
                 run(`openssl x509 -in $cert -out $pem -outform PEM`)
 
                 local pobj, port

--- a/stdlib/LibGit2/test/libgit2-tests.jl
+++ b/stdlib/LibGit2/test/libgit2-tests.jl
@@ -3099,9 +3099,14 @@ mktempdir() do dir
                 touch(conf)
 
                 # Generated a certificate which has the CN set correctly but no subjectAltName
-                run(pipeline(addenv(
+                err = IOBuffer()
+                p = run(pipeline(addenv(
                     `openssl req -new -x509 -newkey rsa:2048 -sha256 -nodes -keyout $key -out $cert -days 1 -subj "/CN=$common_name"`,
-                    "OPENSSL_CONF" => conf), stderr=devnull))
+                    "OPENSSL_CONF" => conf), stderr=err); wait=false)
+                wait(p)
+                @testset let err = String(take!(err))
+                    @test success(p)
+                end
                 run(`openssl x509 -in $cert -out $pem -outform PEM`)
 
                 local pobj, port


### PR DESCRIPTION
The path to the openssl config file gets baked in at build time and is wrong for the openssl we ship in JLLs causing trouble here if there is no systemwide openssl. However, for our purposes an empty openssl cnf is fine and probably better for reproducability anyway, so just set that.