### PR TITLE
Add detail to VersionNumber documentation

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -12,12 +12,12 @@ Version number type which follows the specifications of
 [semantic versioning (semver)](https://semver.org/spec/v2.0.0-rc.2.html), composed of major, minor
 and patch numeric values, followed by pre-release and build
 alphanumeric annotations.
-(As extension to this standard, Julia also allows a single, empty prerelease annotation
+As an extension to this standard, Julia also allows a single, empty prerelease annotation
 if there is no build identifier present (e.g. `1.0-`), or a single, empty build annotation (e.g. `1.0+`).
 
 `VersionNumber` objects can be compared with all of the standard comparison
 operators (`==`, `<`, `<=`, etc.), with the result following semver v2.0.0-rc.2 rules.
-(However, build annotations are not ignored when comparing version numbers.)
+Different from the semver standard, build annotations are not ignored when comparing version numbers.
 
 `VersionNumber` has the following public fields:
 - `v.major::Integer`

--- a/base/version.jl
+++ b/base/version.jl
@@ -12,9 +12,12 @@ Version number type which follows the specifications of
 [semantic versioning (semver)](https://semver.org/spec/v2.0.0-rc.2.html), composed of major, minor
 and patch numeric values, followed by pre-release and build
 alphanumeric annotations.
+(As extension to this standard, Julia also allows a single, empty prerelease annotation
+if there is no build identifier present (e.g. `1.0-`), or a single, empty build annotation (e.g. `1.0+`).
 
 `VersionNumber` objects can be compared with all of the standard comparison
 operators (`==`, `<`, `<=`, etc.), with the result following semver v2.0.0-rc.2 rules.
+(However, build annotations are not ignored when comparing version numbers.)
 
 `VersionNumber` has the following public fields:
 - `v.major::Integer`


### PR DESCRIPTION
I noticed that Julia's `VersionNumber` differs from the cited standard in two ways. This PR documents these differences.