### PR TITLE
Uniqueness `gensym` guarantee goes beyond modules.

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -9,7 +9,12 @@ const is_expr = isexpr
 """
     gensym([tag])
 
-Generates a symbol which will not conflict with other variable names (in the same module).
+Generates a symbol which will not conflict with other variable names
+within the Julia session (including names in other modules).
+
+(Note that precompilation currently happens in a separate session,
+resulting in subtle potential conflicts when calling `gensym` in toplevel scope.
+See [#44903](https://github.com/JuliaLang/julia/issues/44903).)
 """
 gensym() = ccall(:jl_gensym, Ref{Symbol}, ())
 


### PR DESCRIPTION
I am suggesting this after zulip thread [there](https://julialang.zulipchat.com/#narrow/channel/137791-general/topic/gensym.20scope/with/553881361). Thank you @adienes @vchuravy @MasonProtter for discussion.

The guarantee offered by `gensym` is stronger than just *"within the current module"* because it actually spans the entire session.

Because of a bug outlined in #44903, this unfortunately does not mean that uniqueness is actually guaranteed within a module yet. But I believe it is still the intent.