### PR TITLE
Make `gensym` names generated during precompilation distinct.

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -9,7 +9,7 @@ const is_expr = isexpr
 """
     gensym([tag])
 
-Generates a symbol which will not conflict with other variable names.
+Generates a symbol which will not conflict with other variable names (in the same module).
 """
 gensym() = ccall(:jl_gensym, Ref{Symbol}, ())
 

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -9,7 +9,7 @@ const is_expr = isexpr
 """
     gensym([tag])
 
-Generates a symbol which will not conflict with other variable names (in the same module).
+Generates a symbol which will not conflict with other variable names.
 """
 gensym() = ccall(:jl_gensym, Ref{Symbol}, ())
 

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -166,7 +166,7 @@ JL_DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, size_t len)
     char *n;
     name[0] = '#';
     name[1] = '#';
-	name[2 + len] = '#';
+    name[2 + len] = '#';
     memcpy(name + 2, str, len);
 
     uint32_t ctr = jl_atomic_fetch_add_relaxed(&gs_ctr, 1);

--- a/test/GensymTestPkg/Project.toml
+++ b/test/GensymTestPkg/Project.toml
@@ -1,0 +1,3 @@
+name = "GensymTestPkg"
+uuid = "1b3fb196-5de8-411a-a32d-2880806ceb7a"
+version = "0.1.0"

--- a/test/GensymTestPkg/src/GensymTestPkg.jl
+++ b/test/GensymTestPkg/src/GensymTestPkg.jl
@@ -1,0 +1,8 @@
+module GensymTestPkg
+
+s1 = gensym()
+f() = gensym() != s1
+
+export f
+
+end # module GensymTestPkg

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -286,3 +286,12 @@ end
 @testset "Base.Meta docstrings" begin
     @test isempty(Docs.undocumented_names(Meta))
 end
+
+@testset "gensym relocation tests" begin
+    res = run(`$(joinpath(dirname(pwd()), ".", "julia")) --startup=no -e """
+    push!(LOAD_PATH, $(repr(joinpath(pwd(), "GensymTestPkg")) ));
+    using GensymTestPkg;
+    f() || error()
+    """`)
+    @test res.exitcode == 0
+end


### PR DESCRIPTION
Should supersede https://github.com/JuliaLang/julia/pull/60049, and fix https://github.com/JuliaLang/julia/issues/44903

As @cstjean noted in https://github.com/JuliaLang/julia/pull/45182#discussion_r866028605, the problem is not limited to `gensym` failing to be unique between modules, can fail within a module if one gensym was emitted during precompilation and the other was not. 

This PR changes the machinery underlying `gensym` so that during precompilation, it will emit symbols suffixed with `#precomp` so that they are distinguishable from those emitted during normal runtime.

This does *not* fix the issue of symbols from two different precompilation units conflicting with eachother, but it should stop symbols emitted from precompilation from conflicting with symbols in a process that loads that unit

Sorry if the test I added was a bit crude, I wasn't sure about the best way to do this (or where exactly the test should go). 