### PR TITLE
no longer bundle pkgimages for stdlibs with forced bounds checking since Pkg.test no longer defaults to this

### DIFF
--- a/pkgimage.mk
+++ b/pkgimage.mk
@@ -27,7 +27,7 @@ print-depot-path:
 
 $(BUILDDIR)/stdlib/%.image: $(JULIAHOME)/stdlib/Project.toml $(JULIAHOME)/stdlib/Manifest.toml $(INDEPENDENT_STDLIBS_SRCS) $(DEPOTDIR)/compiled
 	@$(call PRINT_JULIA, JULIA_CPU_TARGET="sysimage" $(call spawn,$(JULIA_EXECUTABLE)) --startup-file=no -e \
-		'Base.Precompilation.precompilepkgs(configs=[``=>Base.CacheFlags(debug_level=2, opt_level=3), ``=>Base.CacheFlags(check_bounds=1, debug_level=2, opt_level=3)])')
+		'Base.Precompilation.precompilepkgs(configs=[``=>Base.CacheFlags(debug_level=2, opt_level=3)])')
 	touch $@
 
 $(BUILDDIR)/stdlib/release.image: $(build_private_libdir)/sys.$(SHLIB_EXT)


### PR DESCRIPTION
To be merged if https://github.com/JuliaLang/Pkg.jl/pull/4494 is merged. Triage might have fun with this one. To be decided for 1.13. 

For people that want to test with forced bounds check on e.g. CI they can use the cache artifact functionality to cache those package images.