### PR TITLE
fix string completion with cursor in the middle of text

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -1047,7 +1047,7 @@ function completions(string::String, pos::Int, context_module::Module=Main, shif
     #  "~/example.txt TAB => "/home/user/example.txt"
     r, closed = find_str(cur)
     if r !== nothing
-        s = do_string_unescape(string[r])
+        s = do_string_unescape(string[intersect(r, 1:pos)])
         ret, success = complete_path_string(s, hint; string_escape=true,
                                             dirsep=Sys.iswindows() ? '\\' : '/')
         if length(ret) == 1 && !closed && close_path_completion(ret[1].path)

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1458,6 +1458,40 @@ let (c, r) = test_complete("cd(\"folder_do_not_exist_77/file")
     @test length(c) == 0
 end
 
+# Test path completion in the middle of a line (issue #60050)
+mktempdir() do path
+    # Create test directory structure
+    foo_dir = joinpath(path, "foo_dir")
+    mkpath(foo_dir)
+    touch(joinpath(path, "foo_file.txt"))
+
+    # Completion at end of line should work
+    let (c, r, res) = test_complete("\"$(path)/foo")
+        @test res
+        @test length(c) == 2
+        @test "$(path)/foo_dir/" in c
+        @test "$(path)/foo_file.txt" in c
+    end
+
+    # Completion in middle of line should also work (regression in 1.12)
+    let (c, r, res) = test_complete_pos("\"$(path)/foo|/bar.toml\"")
+        @test res
+        @test length(c) == 2
+        @test "$(path)/foo_dir/" in c
+        @test "$(path)/foo_file.txt" in c
+        # Check that the range covers only the part before the cursor
+        @test findfirst("/bar", "\"$(path)/foo/bar.toml\"")[1] - 1 in r
+    end
+
+    # Completion in middle of function call with trailing arguments
+    let (c, r, res) = test_complete_pos("run_something(\"$(path)/foo|/bar.toml\"; kwarg=true)")
+        @test res
+        @test length(c) == 2
+        @test "$(path)/foo_dir/" in c
+        @test "$(path)/foo_file.txt" in c
+    end
+end
+
 if Sys.iswindows()
     tmp = tempname()
     touch(tmp)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/60050

We can see how this is symmetric with how e.g. keys in dicts are handled:

https://github.com/JuliaLang/julia/blob/d665f8980f2bada7cd87fd79610ab769e44e95f7/stdlib/REPL/src/REPLCompletions.jl#L1025

I think this got introdced in https://github.com/JuliaLang/julia/pull/57767

Tests written by Claude Code 🤖 
