### PR TITLE
Fix windows profiler deadlock

### DIFF
--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -3586,7 +3586,6 @@ void jl_start_gc_threads(void)
         else {
             uv_thread_create(&uvtid, jl_parallel_gc_threadfun, t);
         }
-        uv_thread_detach(&uvtid);
     }
 }
 

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -445,6 +445,7 @@ static int jl_thread_suspend_and_get_state(int tid, int timeout, bt_context_t *c
     if (ct2 == NULL) // this thread is already dead
         return 0;
     HANDLE hThread = ptls2->system_id;
+    assert(GetCurrentThreadId() != GetThreadId(hThread));
     if ((DWORD)-1 == SuspendThread(hThread)) {
         // jl_safe_fprintf(ios_safe_stderr, "failed to suspend thread %d: %lu\n", tid, GetLastError());
         return 0;


### PR DESCRIPTION
Wasn't sure if we could get away with deleting the `uv_thread_detach`, but
apparently we can.  On Windows, it's definitely unsafe to keep using the thread
handle after closing it.  POSIX is a little less clear about what you're allowed
to do with a `pthread_t` after detaching it, but the GC threads never exit
normally anyway.

Fixes #60042.
