### PR TITLE
improve behavior of bracket insertion in some situations

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1192,6 +1192,10 @@ function mode_keymap(julia_prompt::Prompt)
                 LineEdit.state(s, julia_prompt).input_buffer = buf
             end
         else
+            buf = LineEdit.buffer(s)
+            if LineEdit.try_remove_paired_delimiter(buf)
+                return LineEdit.refresh_line(s)
+            end
             LineEdit.edit_backspace(s)
         end
     end,


### PR DESCRIPTION
this more closely mimics how other editors do it and should hopefully remove a few annoying cases

see tests for concrete changes

(also make sure that other modes also remove paired delimiters on backspace)

Tests and some code written by Claude Code :robot: 