### PR TITLE
trimming: fix-up support for `Core._apply_iterate`

### DIFF
--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -310,7 +310,6 @@ function verify_codeinstance!(interp::NativeInterpreter, codeinst::CodeInstance,
             end
             # TODO: check for calls to Base.atexit?
         elseif isexpr(stmt, :call)
-            error = "unresolved call"
             farg = stmt.args[1]
             ftyp = widenconst(argextype(farg, codeinfo, sptypes))
             if ftyp <: IntrinsicFunction
@@ -371,6 +370,8 @@ function verify_codeinstance!(interp::NativeInterpreter, codeinst::CodeInstance,
                 elseif Core.memoryrefmodify! isa ftyp
                     error = "trim verification not yet implemented for builtin `Core.memoryrefmodify!`"
                 else @assert false "unexpected builtin" end
+            else
+                error = "unresolved call"
             end
             extyp = argextype(SSAValue(i), codeinfo, sptypes)
             if extyp === Union{}

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2956,11 +2956,35 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
             size_t num_mis;
             jl_get_llvm_cis(native_functions, &num_mis, NULL);
             arraylist_grow(&MIs, num_mis);
+
+            // Record MethodInstances for user-provided code (as reported by codegen)
             jl_get_llvm_cis(native_functions, &num_mis, (jl_code_instance_t**)MIs.items);
             for (size_t i = 0; i < num_mis; i++) {
                 jl_code_instance_t *ci = (jl_code_instance_t*)MIs.items[i];
                 MIs.items[i] = (void*)jl_get_ci_mi(ci);
             }
+
+            // Record MethodInstances for built-ins (used when dynamically dispatching to a
+            // built-in, e.g., in the Core._apply_iterate implementation)
+            jl_datatype_t *tt = NULL;
+            JL_GC_PUSH1(&tt);
+            for (size_t i = 0; i < jl_n_builtins; i++) {
+                jl_value_t *builtin = jl_builtin_instances[i];
+                if (builtin == NULL)
+                    continue;
+
+                jl_datatype_t *dt = (jl_datatype_t*)jl_typeof(builtin);
+                jl_value_t *params[2];
+                params[0] = dt->name->wrapper;
+                params[1] = jl_tparam0(jl_anytuple_type);
+                tt = (jl_datatype_t*)jl_apply_tuple_type_v(params, 2);
+                jl_method_instance_t *mi = (jl_method_instance_t *)jl_method_lookup_by_tt(
+                    tt, /* world */ 1, /* mt */ jl_nothing
+                );
+                assert(!jl_is_nothing(mi));
+                arraylist_push(&MIs, mi);
+            }
+            JL_GC_POP();
         }
     }
     if (jl_options.trim) {

--- a/test/trimming/basic_jll.jl
+++ b/test/trimming/basic_jll.jl
@@ -9,6 +9,8 @@ function print_string(fptr::Ptr{Cvoid})
     println(Core.stdout, unsafe_string(ccall(fptr, Cstring, ())))
 end
 
+version_str::String = "1.2.3"
+
 function @main(args::Vector{String})::Cint
     # Test the basic "Hello, world!"
     println(Core.stdout, "Julia! Hello, world!")
@@ -17,6 +19,9 @@ function @main(args::Vector{String})::Cint
     ver = unsafe_string(ccall((:ZSTD_versionString, libzstd), Cstring, ()))
     println(Core.stdout, ver)
     @assert ver == build_ver
+
+    parsed_ver = VersionNumber(version_str)
+    @assert parsed_ver == v"1.2.3"
 
     sleep(0.01)
 


### PR DESCRIPTION
We only support a few built-in versions of this call (due to https://github.com/JuliaLang/julia/issues/57830), but those should at least be working now with this small tweak.

Includes a fix-up for built-in functions to be included in the method table for `--trim`'d executables, so that we can dynamically dispatch to them as the verifier expects.