### PR TITLE
only show unique entries in history search when filtering

### DIFF
--- a/stdlib/REPL/src/History/resumablefiltering.jl
+++ b/stdlib/REPL/src/History/resumablefiltering.jl
@@ -253,24 +253,26 @@ end
 
 
 """
-    filterchunkrev!(out, candidates, spec; idx, maxtime, maxresults) -> Int
+    filterchunkrev!(out, candidates, spec; idx, maxtime, maxresults, seen) -> Int
 
 Incrementally filter `candidates[1:idx]` in reverse order.
 
 Pushes matches onto `out` until either `maxtime` is exceeded or `maxresults`
-collected, then returns the new resume index. Only unique entries (by content)
-are added to avoid showing duplicate history items.
+collected, then returns the new resume index. When `seen` is provided (a Set{String}),
+only unique entries (by content) are added to avoid showing duplicate history items.
 """
 function filterchunkrev!(out::Vector{HistEntry}, candidates::DenseVector{HistEntry},
                          spec::FilterSpec, idx::Int = length(candidates);
-                         maxtime::Float64 = Inf, maxresults::Int = length(candidates))
-    seen = Set(e.content for e in out)
+                         maxtime::Float64 = Inf, maxresults::Int = length(candidates),
+                         seen::Union{Nothing,Set{String}} = nothing)
     batchsize = clamp(length(candidates) ÷ 512, 10, 1000)
     for batch in Iterators.partition(idx:-1:1, batchsize)
         time() > maxtime && break
         for outer idx in batch
             entry = candidates[idx]
-            entry.content ∈ seen && continue
+            if !isnothing(seen) && entry.content ∈ seen
+                continue
+            end
             if !isempty(spec.modes)
                 entry.mode ∈ spec.modes || continue
             end
@@ -296,7 +298,7 @@ function filterchunkrev!(out::Vector{HistEntry}, candidates::DenseVector{HistEnt
                 end
             end
             matchfail && continue
-            push!(seen, entry.content)
+            !isnothing(seen) && push!(seen, entry.content)
             pushfirst!(out, entry)
             length(out) == maxresults && break
         end

--- a/stdlib/REPL/src/History/resumablefiltering.jl
+++ b/stdlib/REPL/src/History/resumablefiltering.jl
@@ -253,25 +253,23 @@ end
 
 
 """
-    filterchunkrev!(out, candidates, spec; idx, maxtime, maxresults, seen, deduplicate) -> Int
+    filterchunkrev!(out, candidates, spec, seen, idx; maxtime, maxresults) -> Int
 
 Incrementally filter `candidates[1:idx]` in reverse order.
 
 Pushes matches onto `out` until either `maxtime` is exceeded or `maxresults`
-collected, then returns the new resume index. When `deduplicate` is true,
-only unique entries (by mode and content) are added to avoid showing duplicate history items.
+collected, then returns the new resume index. Only unique entries (by mode and content)
+are added to avoid showing duplicate history items.
 """
 function filterchunkrev!(out::Vector{HistEntry}, candidates::DenseVector{HistEntry},
-                         spec::FilterSpec, idx::Int = length(candidates);
-                         maxtime::Float64 = Inf, maxresults::Int = length(candidates),
-                         seen::Set{Tuple{Symbol,String}} = Set{Tuple{Symbol,String}}(),
-                         deduplicate::Bool = false)
+                         spec::FilterSpec, seen::Set{Tuple{Symbol,String}}, idx::Int = length(candidates);
+                         maxtime::Float64 = Inf, maxresults::Int = length(candidates))
     batchsize = clamp(length(candidates) ÷ 512, 10, 1000)
     for batch in Iterators.partition(idx:-1:1, batchsize)
         time() > maxtime && break
         for outer idx in batch
             entry = candidates[idx]
-            if deduplicate && (entry.mode, entry.content) ∈ seen
+            if (entry.mode, entry.content) ∈ seen
                 continue
             end
             if !isempty(spec.modes)
@@ -299,7 +297,7 @@ function filterchunkrev!(out::Vector{HistEntry}, candidates::DenseVector{HistEnt
                 end
             end
             matchfail && continue
-            deduplicate && push!(seen, (entry.mode, entry.content))
+            push!(seen, (entry.mode, entry.content))
             pushfirst!(out, entry)
             length(out) == maxresults && break
         end

--- a/stdlib/REPL/test/history.jl
+++ b/stdlib/REPL/test/history.jl
@@ -279,69 +279,80 @@ end
                 empty!(results)
                 cset = ConditionSet("hello")
                 spec = FilterSpec(cset)
-                @test filterchunkrev!(results, entries, spec) == 0
+                seen = Set{Tuple{Symbol,String}}()
+                @test filterchunkrev!(results, entries, spec, seen) == 0
                 @test results == [entries[1], entries[7]]
                 empty!(results)
                 cset2 = ConditionSet("world")
                 spec2 = FilterSpec(cset2)
-                @test filterchunkrev!(results, entries, spec2) == 0
+                empty!(seen)
+                @test filterchunkrev!(results, entries, spec2, seen) == 0
                 @test results == [entries[1], entries[7]]
                 empty!(results)
                 cset3 = ConditionSet("World")
                 spec3 = FilterSpec(cset3)
-                @test filterchunkrev!(results, entries, spec3) == 0
+                empty!(seen)
+                @test filterchunkrev!(results, entries, spec3, seen) == 0
                 @test results == [entries[7]]
             end
             @testset "Exact" begin
                 empty!(results)
                 cset = ConditionSet("=test")
                 spec = FilterSpec(cset)
-                @test filterchunkrev!(results, entries, spec, maxresults = 2) == 5
+                seen = Set{Tuple{Symbol,String}}()
+                @test filterchunkrev!(results, entries, spec, seen; maxresults = 2) == 5
                 @test results == [entries[6], entries[9]]
                 empty!(results)
                 cset2 = ConditionSet("=test case")
                 spec2 = FilterSpec(cset2)
-                @test filterchunkrev!(results, entries, spec2) == 0
+                empty!(seen)
+                @test filterchunkrev!(results, entries, spec2, seen) == 0
                 @test results == [entries[3]]
             end
             @testset "Negative" begin
                 empty!(results)
                 cset = ConditionSet("!hello ; !test;! cos")
                 spec = FilterSpec(cset)
-                @test filterchunkrev!(results, entries, spec) == 0
+                seen = Set{Tuple{Symbol,String}}()
+                @test filterchunkrev!(results, entries, spec, seen) == 0
                 @test results == [entries[2], entries[7], entries[8]]
             end
             @testset "Initialism" begin
                 empty!(results)
                 cset = ConditionSet("`tc")
                 spec = FilterSpec(cset)
-                @test filterchunkrev!(results, entries, spec) == 0
+                seen = Set{Tuple{Symbol,String}}()
+                @test filterchunkrev!(results, entries, spec, seen) == 0
                 @test results == [entries[3]]
                 empty!(results)
                 cset2 = ConditionSet("`fb")
                 spec2 = FilterSpec(cset2)
-                @test filterchunkrev!(results, entries, spec2) == 0
+                empty!(seen)
+                @test filterchunkrev!(results, entries, spec2, seen) == 0
                 @test results == [entries[8]]
             end
             @testset "Regexp" begin
                 empty!(results)
                 cset = ConditionSet("/^c.s\\b")
                 spec = FilterSpec(cset)
-                @test filterchunkrev!(results, entries, spec) == 0
+                seen = Set{Tuple{Symbol,String}}()
+                @test filterchunkrev!(results, entries, spec, seen) == 0
                 @test results == [entries[4], entries[5]]
             end
             @testset "Mode" begin
                 empty!(results)
                 cset = ConditionSet(">shell")
                 spec = FilterSpec(cset)
-                @test filterchunkrev!(results, entries, spec) == 0
+                seen = Set{Tuple{Symbol,String}}()
+                @test filterchunkrev!(results, entries, spec, seen) == 0
                 @test results == [entries[7]]
             end
             @testset "Fuzzy" begin
                 empty!(results)
                 cset = ConditionSet("~cs")
                 spec = FilterSpec(cset)
-                @test filterchunkrev!(results, entries, spec) == 0
+                seen = Set{Tuple{Symbol,String}}()
+                @test filterchunkrev!(results, entries, spec, seen) == 0
                 @test results == entries[3:6]
             end
             @testset "Uniqueness" begin
@@ -360,16 +371,14 @@ end
                 cset = ConditionSet("cos")
                 spec = FilterSpec(cset)
                 seen = Set{Tuple{Symbol,String}}()
-                @test filterchunkrev!(results, dup_entries, spec; seen=seen, deduplicate=true) == 0
+                @test filterchunkrev!(results, dup_entries, spec, seen) == 0
                 # Should only get unique entries matching the filter
                 # Since we iterate in reverse (7->1), we keep the most recent occurrence of each unique content
                 @test length(results) == 1
                 @test results[1] == dup_entries[5]  # cos(2π) - most recent
-                # When browsing without seen Set, duplicates are kept
+                # When browsing without filtering, duplicates are kept
                 empty!(results)
-                cset2 = ConditionSet("")  # No filter
-                spec2 = FilterSpec(cset2)
-                @test filterchunkrev!(results, dup_entries, spec2) == 0
+                append!(results, dup_entries)
                 @test length(results) == 7  # All entries, including duplicates
                 @test results == dup_entries
                 # Test that same content in different modes is NOT deduplicated
@@ -380,10 +389,10 @@ end
                     HistEntry(:julia, now(UTC), "ls", 3),  # duplicate in :julia mode
                     HistEntry(:shell, now(UTC), "pwd", 4),
                 ]
-                seen = Set{Tuple{Symbol,String}}()
+                empty!(seen)
                 cset3 = ConditionSet("ls")
                 spec3 = FilterSpec(cset3)
-                @test filterchunkrev!(results, mode_entries, spec3; seen=seen, deduplicate=true) == 0
+                @test filterchunkrev!(results, mode_entries, spec3, seen) == 0
                 @test length(results) == 2  # "ls" from :julia and "ls" from :shell
                 @test results[1] == mode_entries[2]  # :shell ls
                 @test results[2] == mode_entries[3]  # :julia ls (most recent)


### PR DESCRIPTION
I quite often get the whole history search filled with duplicates which feels like low signal ratio. This only keep uniques:

Before vs after

<img width="408" height="204" alt="Screenshot 2025-11-06 at 21 27 19" src="https://github.com/user-attachments/assets/ad19487f-f871-4d8c-96f4-7e6957695ebd" />

<img width="414" height="200" alt="Screenshot 2025-11-06 at 21 27 26" src="https://github.com/user-attachments/assets/a3482074-88b5-474e-a3d4-b6c05b60fe7a" />

cc @tecosaur @topolarity 

Tests written by Claude Code 🤖 