### PR TITLE
NEWS entry and build changes for p7zip update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,9 +219,6 @@ endif
 JL_PRIVATE_LIBS-0 := libccalltest libccalllazyfoo libccalllazybar libllvmcalltest
 JL_PRIVATE_LIBS-1 := # libraries from USE_SYSTEM=1
 JL_PRIVATE_EXES := 7z
-ifeq ($(OS),WINNT)
-JL_PRIVATE_EXES += 7z.dll
-endif
 JL_PRIVATE_TOOLS :=
 ifeq ($(JULIA_BUILD_MODE),release)
 JL_PRIVATE_LIBS-0 += libjulia-internal libjulia-codegen

--- a/NEWS.md
+++ b/NEWS.md
@@ -125,6 +125,8 @@ Standard library changes
 External dependencies
 ---------------------
 
+  * 7-Zip updated from p7zip v17.06 to upstream 7-Zip v25.01. On Windows, the full 7z.exe/7z.dll bundle is replaced with standalone 7za.exe, which supports fewer formats but unifies cross-platform behavior. ([#60025]).
+
 Tooling Improvements
 --------------------
 


### PR DESCRIPTION
Follow up for #60025

There is no 7z.dll anymore, so I removed that from the Makefile
