### PR TITLE
clarify Base.operator_precedence docs: this is only for binary operators

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1555,7 +1555,8 @@ Return an integer representing the precedence of a binary operator `s`, relative
 other operators. Higher-numbered operators take precedence over lower-numbered
 operators. Return `0` if `s` is not a valid binary operator.
 
-(The precedence of *unary* operators is handled differently.)
+(The precedence of *unary* operators is handled differently, including cases like `+`
+where an operator can be either unary or binary.)
 
 # Examples
 ```jldoctest

--- a/base/show.jl
+++ b/base/show.jl
@@ -1551,9 +1551,11 @@ const expr_parens = Dict(:tuple=>('(',')'), :vcat=>('[',']'),
 """
     operator_precedence(s::Symbol)
 
-Return an integer representing the precedence of operator `s`, relative to
+Return an integer representing the precedence of a binary operator `s`, relative to
 other operators. Higher-numbered operators take precedence over lower-numbered
-operators. Return `0` if `s` is not a valid operator.
+operators. Return `0` if `s` is not a valid binary operator.
+
+(The precedence of *unary* operators is handled differently.)
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
The documentation for `Base.operator_precedence` misleadingly said it returned the precedence of "operators", but in fact this is only *binary* operators.  Unary operators are handled separately, including operators that are both binary and unary:
```jl
julia> Base.operator_precedence(:(√)) # a unary operator, not a binary operator
0

julia> Base.operator_precedence(:+) # both binary and unary
11

julia> dump(:(+x * y)) # unary +x has higher precedence than `*`
Expr
  head: Symbol call
  args: Array{Any}((3,))
    1: Symbol *
    2: Expr
      head: Symbol call
      args: Array{Any}((2,))
        1: Symbol +
        2: Symbol x
    3: Symbol y
```

See also https://discourse.julialang.org/t/question-about-precedence-of-operator-bitwise-not/133760/2?u=stevengj