### PR TITLE
Call `realpath` before comparing coverage paths

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8903,7 +8903,12 @@ static jl_llvm_functions_t
                 !jl_is_submodule(mod, jl_core_module));
     };
     auto in_tracked_path = [] (StringRef file) { // falls within an explicitly set file or directory
-        return jl_options.tracked_path != NULL && file.starts_with(jl_options.tracked_path);
+        if (jl_options.tracked_path == NULL)
+            return false;
+        char *absfile = jl_absrealpath(file.data(), 0);
+        bool match = StringRef(absfile).starts_with(jl_options.tracked_path);
+        free(absfile);
+        return match;
     };
     bool mod_is_user_mod = in_user_mod(ctx.module);
     bool mod_is_tracked = in_tracked_path(ctx.file);

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -1170,7 +1170,7 @@ static const char *absformat(const char *in)
     return out;
 }
 
-static char *absrealpath(const char *in, int nprefix)
+JL_DLLEXPORT char *jl_absrealpath(const char *in, int nprefix)
 { // compute an absolute realpath location, so that chdir doesn't change the file reference
   // ignores (copies directly over) nprefix characters at the start of abspath
     char *out;
@@ -1245,7 +1245,7 @@ static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel, const char* julia_bi
         jl_options.julia_bindir = julia_bindir;
     }
     if (jl_options.julia_bindir)
-        jl_options.julia_bindir = absrealpath(jl_options.julia_bindir, 0);
+        jl_options.julia_bindir = jl_absrealpath(jl_options.julia_bindir, 0);
     free(free_path);
     free_path = NULL;
     if (jl_options.image_file) {
@@ -1260,33 +1260,33 @@ static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel, const char* julia_bi
             jl_options.image_file = free_path;
         }
         if (jl_options.image_file)
-            jl_options.image_file = absrealpath(jl_options.image_file, 0);
+            jl_options.image_file = jl_absrealpath(jl_options.image_file, 0);
         if (free_path) {
             free(free_path);
             free_path = NULL;
         }
     }
     if (jl_options.outputo)
-        jl_options.outputo = absrealpath(jl_options.outputo, 0);
+        jl_options.outputo = jl_absrealpath(jl_options.outputo, 0);
     if (jl_options.outputji)
-        jl_options.outputji = absrealpath(jl_options.outputji, 0);
+        jl_options.outputji = jl_absrealpath(jl_options.outputji, 0);
     if (jl_options.outputbc)
-        jl_options.outputbc = absrealpath(jl_options.outputbc, 0);
+        jl_options.outputbc = jl_absrealpath(jl_options.outputbc, 0);
     if (jl_options.outputasm)
-        jl_options.outputasm = absrealpath(jl_options.outputasm, 0);
+        jl_options.outputasm = jl_absrealpath(jl_options.outputasm, 0);
     if (jl_options.machine_file)
-        jl_options.machine_file = absrealpath(jl_options.machine_file, 0);
+        jl_options.machine_file = jl_absrealpath(jl_options.machine_file, 0);
     if (jl_options.output_code_coverage)
         jl_options.output_code_coverage = absformat(jl_options.output_code_coverage);
     if (jl_options.tracked_path)
-        jl_options.tracked_path = absrealpath(jl_options.tracked_path, 0);
+        jl_options.tracked_path = jl_absrealpath(jl_options.tracked_path, 0);
 
     const char **cmdp = jl_options.cmds;
     if (cmdp) {
         for (; *cmdp; cmdp++) {
             const char *cmd = *cmdp;
             if (cmd[0] == 'L') {
-                *cmdp = absrealpath(cmd, 1);
+                *cmdp = jl_absrealpath(cmd, 1);
             }
         }
     }

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1909,6 +1909,7 @@ void jl_log(int level, jl_value_t *module, jl_value_t *group, jl_value_t *id,
             jl_value_t *msg);
 
 JL_DLLEXPORT int jl_isabspath(const char *in) JL_NOTSAFEPOINT;
+JL_DLLEXPORT char *jl_absrealpath(const char *in, int nprefix) JL_NOTSAFEPOINT;
 
 // Commonly used symbols (jl_sym_t* values)
 #define JL_COMMON_SYMBOLS(XX) \


### PR DESCRIPTION
This commit fixes an issue where `--code-coverage=@path` does not work if `path` has any symlinks in it (which happens e.g. when testing `Pkg` in tree - ref #60058). The issue is that we call `realpath` on the cli argument, but do not currently call realpath when inserting the instrumentation. One fix would be to stop calling realpath on the cli argument, but that has the potential to break users who rely on this behavior.

The other fix (implemented here) is to also call realpath when doing the comparison. However, this is a bit aweful, because, as currently structured, this requires us to do a file system query for every line table entry. Most of those line table entries will probably have the same file, so that's a lot of redundant (and depending on filesystem, potentially expensive work).

That said, I think this is the best solution for the time being. At some point in the near future we need to completely overhaul all and move the filtering to the writer side (rather than during codegen), as well as making coverage cacheable and work in the interpreter. Until then, this at least helps with addressing the test failure.