### PR TITLE
deps: fix rpath of 7z after moving to libexecdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -548,7 +548,6 @@ ifneq ($(DARWIN_FRAMEWORK),1)
 endif
 else ifneq (,$(findstring $(OS),Linux FreeBSD))
 	for j in $(JL_PRIVATE_EXES) ; do \
-		[ $$j = 7z ] && continue; \
 		[ -L $(DESTDIR)$(private_libexecdir)/$$j ] && continue; \
 		$(PATCHELF) $(PATCHELF_SET_RPATH_ARG) '$$ORIGIN/$(reverse_private_libexecdir_rel)' $(DESTDIR)$(private_libexecdir)/$$j || exit 1; \
 	done

--- a/deps/p7zip.mk
+++ b/deps/p7zip.mk
@@ -51,10 +51,14 @@ $(eval $(call bb-install,p7zip,P7ZIP,false))
 # move from bindir to shlibdir, where we expect to install it
 install-p7zip: post-install-p7zip
 uninstall-p7zip: pre-uninstall-p7zip
-post-install-p7zip: $(build_prefix)/manifest/p7zip
+post-install-p7zip: $(build_prefix)/manifest/p7zip $(PATCHELF_MANIFEST)
 	mkdir -p $(build_private_libexecdir)/
 	[ ! -e $(build_bindir)/7z$(EXE) ] || mv $(build_bindir)/7z$(EXE) $(build_private_libexecdir)/7z$(EXE)
 	[ -e $(build_private_libexecdir)/7z$(EXE) ]
+ifneq (,$(findstring $(OS),Linux FreeBSD))
+	[ -L $(build_private_libexecdir)/7z ] || \
+	$(PATCHELF) $(PATCHELF_SET_RPATH_ARG) '$$ORIGIN/$(reverse_build_private_libexecdir_rel)' $(build_private_libexecdir)/7z$(EXE)
+endif
 pre-uninstall-p7zip:
 	-rm -f $(build_private_libexecdir)/7z$(EXE)
 


### PR DESCRIPTION
After moving the 7z binary from bindir to private_libexecdir on Linux and FreeBSD, we need to update its rpath to point to the correct location of shared libraries (for libstdc++.so.6 after install). This change uses patchelf to set the rpath to $ORIGIN/../../lib/julia (via reverse_build_private_libexecdir_rel), using exactly the same logic as for zstd.

Fixes https://github.com/JuliaLang/julia/pull/58344#issuecomment-3426065749

🤖 Generated by Claude Code