### PR TITLE
Use Documenter-style details admonition in REPL docs

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -580,164 +580,161 @@ end
 The default syntax highlighting theme is quite conservative but can be customized using a TOML file `faces.toml` (https://julialang.github.io/StyledStrings.jl/dev/#stdlib-styledstrings-face-toml) in `.julia/config` (or by explicitly loading the faces from a face toml file).
 
 
-<details>
-<summary>Example: Monokai color theme (click to expand)</summary>
+!!! details "Example: Monokai color theme (click to expand)"
+    ```toml
 
-```toml
-# Monokai color theme for Julia syntax highlighting
+    # Monokai color theme for Julia syntax highlighting
 
-[julia_macro]
-foreground = "#A6E22E"
+    [julia_macro]
+    foreground = "#A6E22E"
 
-[julia_symbol]
-foreground = "#AE81FF"
+    [julia_symbol]
+    foreground = "#AE81FF"
 
-[julia_singleton_identifier]
-inherit = "julia_symbol"
+    [julia_singleton_identifier]
+    inherit = "julia_symbol"
 
-[julia_type]
-foreground = "#66D9EF"
+    [julia_type]
+    foreground = "#66D9EF"
 
-[julia_typedec]
-foreground = "#66D9EF"
-weight = "bold"
+    [julia_typedec]
+    foreground = "#66D9EF"
+    weight = "bold"
 
-[julia_comment]
-foreground = "#75715E"
-italic = true
+    [julia_comment]
+    foreground = "#75715E"
+    italic = true
 
-[julia_string]
-foreground = "#E6DB74"
+    [julia_string]
+    foreground = "#E6DB74"
 
-[julia_regex]
-inherit = "julia_string"
+    [julia_regex]
+    inherit = "julia_string"
 
-[julia_backslash_literal]
-foreground = "#FD971F"
-inherit = "julia_string"
+    [julia_backslash_literal]
+    foreground = "#FD971F"
+    inherit = "julia_string"
 
-[julia_string_delim]
-foreground = "#E6DB74"
-weight = "bold"
+    [julia_string_delim]
+    foreground = "#E6DB74"
+    weight = "bold"
 
-[julia_cmdstring]
-inherit = "julia_string"
+    [julia_cmdstring]
+    inherit = "julia_string"
 
-[julia_char]
-inherit = "julia_string"
+    [julia_char]
+    inherit = "julia_string"
 
-[julia_char_delim]
-inherit = "julia_string_delim"
+    [julia_char_delim]
+    inherit = "julia_string_delim"
 
-[julia_number]
-foreground = "#AE81FF"
+    [julia_number]
+    foreground = "#AE81FF"
 
-[julia_bool]
-foreground = "#AE81FF"
-weight = "bold"
+    [julia_bool]
+    foreground = "#AE81FF"
+    weight = "bold"
 
-[julia_funcall]
-foreground = "#A6E22E"
+    [julia_funcall]
+    foreground = "#A6E22E"
 
-[julia_broadcast]
-foreground = "#F92672"
-weight = "bold"
+    [julia_broadcast]
+    foreground = "#F92672"
+    weight = "bold"
 
-[julia_builtin]
-foreground = "#66D9EF"
-weight = "bold"
+    [julia_builtin]
+    foreground = "#66D9EF"
+    weight = "bold"
 
-[julia_operator]
-foreground = "#F92672"
+    [julia_operator]
+    foreground = "#F92672"
 
-[julia_comparator]
-inherit = "julia_operator"
+    [julia_comparator]
+    inherit = "julia_operator"
 
-[julia_assignment]
-foreground = "#F92672"
-weight = "bold"
+    [julia_assignment]
+    foreground = "#F92672"
+    weight = "bold"
 
-[julia_keyword]
-foreground = "#F92672"
-weight = "bold"
+    [julia_keyword]
+    foreground = "#F92672"
+    weight = "bold"
 
-[julia_parentheses]
-foreground = "#F8F8F2"
+    [julia_parentheses]
+    foreground = "#F8F8F2"
 
-[julia_unpaired_parentheses]
-background = "#F92672"
-foreground = "#F8F8F0"
-weight = "bold"
+    [julia_unpaired_parentheses]
+    background = "#F92672"
+    foreground = "#F8F8F0"
+    weight = "bold"
 
-[julia_error]
-background = "#F92672"
-foreground = "#F8F8F0"
+    [julia_error]
+    background = "#F92672"
+    foreground = "#F8F8F0"
 
-[julia_rainbow_paren_1]
-foreground = "#A6E22E"
-inherit = "julia_parentheses"
+    [julia_rainbow_paren_1]
+    foreground = "#A6E22E"
+    inherit = "julia_parentheses"
 
-[julia_rainbow_paren_2]
-foreground = "#66D9EF"
-inherit = "julia_parentheses"
+    [julia_rainbow_paren_2]
+    foreground = "#66D9EF"
+    inherit = "julia_parentheses"
 
-[julia_rainbow_paren_3]
-foreground = "#FD971F"
-inherit = "julia_parentheses"
+    [julia_rainbow_paren_3]
+    foreground = "#FD971F"
+    inherit = "julia_parentheses"
 
-[julia_rainbow_paren_4]
-inherit = "julia_rainbow_paren_1"
+    [julia_rainbow_paren_4]
+    inherit = "julia_rainbow_paren_1"
 
-[julia_rainbow_paren_5]
-inherit = "julia_rainbow_paren_2"
+    [julia_rainbow_paren_5]
+    inherit = "julia_rainbow_paren_2"
 
-[julia_rainbow_paren_6]
-inherit = "julia_rainbow_paren_3"
+    [julia_rainbow_paren_6]
+    inherit = "julia_rainbow_paren_3"
 
-# Rainbow brackets
-[julia_rainbow_bracket_1]
-foreground = "#AE81FF"
-inherit = "julia_parentheses"
+    # Rainbow brackets
+    [julia_rainbow_bracket_1]
+    foreground = "#AE81FF"
+    inherit = "julia_parentheses"
 
-[julia_rainbow_bracket_2]
-foreground = "#E6DB74"
-inherit = "julia_parentheses"
+    [julia_rainbow_bracket_2]
+    foreground = "#E6DB74"
+    inherit = "julia_parentheses"
 
-[julia_rainbow_bracket_3]
-inherit = "julia_rainbow_bracket_1"
+    [julia_rainbow_bracket_3]
+    inherit = "julia_rainbow_bracket_1"
 
-[julia_rainbow_bracket_4]
-inherit = "julia_rainbow_bracket_2"
+    [julia_rainbow_bracket_4]
+    inherit = "julia_rainbow_bracket_2"
 
-[julia_rainbow_bracket_5]
-inherit = "julia_rainbow_bracket_1"
+    [julia_rainbow_bracket_5]
+    inherit = "julia_rainbow_bracket_1"
 
-[julia_rainbow_bracket_6]
-inherit = "julia_rainbow_bracket_2"
+    [julia_rainbow_bracket_6]
+    inherit = "julia_rainbow_bracket_2"
 
-# Rainbow curlies
-[julia_rainbow_curly_1]
-foreground = "#F92672"
-inherit = "julia_parentheses"
+    # Rainbow curlies
+    [julia_rainbow_curly_1]
+    foreground = "#F92672"
+    inherit = "julia_parentheses"
 
-[julia_rainbow_curly_2]
-foreground = "#A6E22E"
-inherit = "julia_parentheses"
+    [julia_rainbow_curly_2]
+    foreground = "#A6E22E"
+    inherit = "julia_parentheses"
 
-[julia_rainbow_curly_3]
-inherit = "julia_rainbow_curly_1"
+    [julia_rainbow_curly_3]
+    inherit = "julia_rainbow_curly_1"
 
-[julia_rainbow_curly_4]
-inherit = "julia_rainbow_curly_2"
+    [julia_rainbow_curly_4]
+    inherit = "julia_rainbow_curly_2"
 
-[julia_rainbow_curly_5]
-inherit = "julia_rainbow_curly_1"
+    [julia_rainbow_curly_5]
+    inherit = "julia_rainbow_curly_1"
 
-[julia_rainbow_curly_6]
-inherit = "julia_rainbow_curly_2"
-```
-
-</details>
+    [julia_rainbow_curly_6]
+    inherit = "julia_rainbow_curly_2"
+    ```
 
 For a complete list of customizable faces, see the [JuliaSyntaxHighlighting package documentation](https://julialang.github.io/JuliaSyntaxHighlighting.jl/dev/).
 


### PR DESCRIPTION
Previously, HTML tags details and summary was used, but these do not render correctly with Documenter.
Instead, use an equivalent Documenter-style admonition `!!! details` block.

Here's how it looks on current master:
<img width="835" height="404" alt="image" src="https://github.com/user-attachments/assets/4d115718-c7e2-4477-b7a3-4a4bf458385a" />

And here's how it looks on this PR:
<img width="834" height="226" alt="image" src="https://github.com/user-attachments/assets/07b1c0af-7ca0-47e7-ba2e-4e1c7b28bcc4" />
