### PR TITLE
Support DualMapAllocator on aarch64 macOS, and add MapJITAllocator

### DIFF
--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -1012,7 +1012,7 @@ public:
     void deallocate(std::vector<FinalizedAlloc> Allocs,
                     OnDeallocatedFunction OnDeallocated) override
     {
-        jl_unreachable();
+        OnDeallocated(Error::success());
     }
 
 protected:
@@ -1050,7 +1050,10 @@ class JLJITLinkMemoryManager::InFlightAlloc
 public:
     InFlightAlloc(JLJITLinkMemoryManager &MM, jitlink::LinkGraph &G) : MM(MM), G(G) {}
 
-    void abandon(OnAbandonedFunction OnAbandoned) override { jl_unreachable(); }
+    void abandon(OnAbandonedFunction OnAbandoned) override
+    {
+        OnAbandoned(Error::success());
+    }
 
     void finalize(OnFinalizedFunction OnFinalized) override
     {


### PR DESCRIPTION
In conjunction with #60105, this change brings our optimized memory management over to aarch64 macOS, where JITLink is the only supported linker.

First, this changes the way we test for `DualMapAllocator` support so that it will be selected on macOS again.  We are not allowed to `mmap` RX `MAP_SHARED` pages directly, but it's okay to `mmap` with no protections and `mprotect` afterwards, so test for that.

However, when it is supported, we always prefer to use the new `MapJITAllocator` for executable pages.  `MapJITAllocator` uses [`MAP_JIT`](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.cs.allow-jit) pages, which are "seen" by every thread as either RX or RW, according to the value of a [special thread-local register](https://blog.siguza.net/APRR/).  When we use this allocator, only a single mapping is required, no copies are necessary when JITting, and no `mprotect` syscalls are necessary to finalize the code.  Other threads can continue to execute code in the `MAP_JIT` region while we write to it, since only the thread that is JITting has the `jit_rw` flag enabled.

Bootstrapping sees about a ~10% reduction in peak RSS and run time, with bigger improvements on very JIT-heavy workloads.
