### PR TITLE
avoid overflow when `inline_cost_threshold == typemax(Int)`

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -440,18 +440,20 @@ function inline_cost_model(interp::AbstractInterpreter, result::InferenceResult,
         # compute the cost (size) of inlining this code
         params = OptimizationParams(interp)
         cost_threshold = default = params.inline_cost_threshold
-        if ⊑(optimizer_lattice(interp), rt, Tuple) && !isconcretetype(widenconst(rt))
-            cost_threshold += params.inline_tupleret_bonus
-        end
-        # if the method is declared as `@inline`, increase the cost threshold 20x
-        if declared_inline
-            cost_threshold += 19*default
-        end
-        # a few functions get special treatment
-        if def.module === _topmod(def.module)
-            name = def.name
-            if name === :iterate || name === :unsafe_convert || name === :cconvert
-                cost_threshold += 4*default
+        if cost_threshold != typemax(Int)
+            if ⊑(optimizer_lattice(interp), rt, Tuple) && !isconcretetype(widenconst(rt))
+                cost_threshold += params.inline_tupleret_bonus
+            end
+            # if the method is declared as `@inline`, increase the cost threshold 20x
+            if declared_inline
+                cost_threshold += 19*default
+            end
+            # a few functions get special treatment
+            if def.module === _topmod(def.module)
+                name = def.name
+                if name === :iterate || name === :unsafe_convert || name === :cconvert
+                    cost_threshold += 4*default
+                end
             end
         end
         return inline_cost_model(ir, params, cost_threshold)

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -2345,4 +2345,14 @@ let src = code_typed1(Base.setindex, (@NamedTuple{next::UInt32,prev::UInt32}, In
     @test count(iscall((src, Base.merge_fallback)), src.code) == 0
 end
 
+let
+    interp = Compiler.NativeInterpreter(; opt_params=Compiler.OptimizationParams(; inline_cost_threshold=typemax(Int)))
+    res = Base.code_ircode((Tuple{Tuple{Val{4}}, Tuple{Float32}},); interp) do t
+        t[1]
+    end
+    @test !isempty(res)
+    ir, rt = only(res)
+    @test rt == Tuple{Val{4}}
+end
+
 end # module inline_tests

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -2345,11 +2345,10 @@ let src = code_typed1(Base.setindex, (@NamedTuple{next::UInt32,prev::UInt32}, In
     @test count(iscall((src, Base.merge_fallback)), src.code) == 0
 end
 
+f60121(t) = t[1]
 let
     interp = Compiler.NativeInterpreter(; opt_params=Compiler.OptimizationParams(; inline_cost_threshold=typemax(Int)))
-    res = Base.code_ircode((Tuple{Tuple{Val{4}}, Tuple{Float32}},); interp) do t
-        t[1]
-    end
+    res = Base.code_ircode(f60121, (Tuple{Tuple{Val{4}}, Tuple{Float32}},); interp)
     @test !isempty(res)
     ir, rt = only(res)
     @test rt == Tuple{Val{4}}


### PR DESCRIPTION
GPUCompiler will set `inline_cost_threshold` to `typemax(Int)` as a way to force inlining, make sure this doesn't cause integer overflow.

should fix JuliaGPU/AMDGPU.jl#846