### PR TITLE
Fix embedding with MSVC

### DIFF
--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -27,7 +27,9 @@
 #define WIN32_LEAN_AND_MEAN
 /* Clang does not like fvisibility=hidden with windows headers. This adds the visibility attribute there.
    Arguably this is a clang bug. */
-#define DECLSPEC_IMPORT __declspec(dllimport) __attribute__ ((visibility("default")))
+# ifndef _COMPILER_MICROSOFT_
+#  define DECLSPEC_IMPORT __declspec(dllimport) __attribute__ ((visibility("default")))
+# endif
 #include <windows.h>
 
 #if defined(_COMPILER_MICROSOFT_) && !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)
@@ -59,15 +61,21 @@ typedef intptr_t ssize_t;
 */
 
 #ifdef _OS_WINDOWS_
+# ifndef _COMPILER_MICROSOFT_
+#  define JL_VISIBILITY_DEFAULT __attribute__ ((visibility("default")))
+# else
+#  define JL_VISIBILITY_DEFAULT
+#  define JL_VISIBILITY_HIDDEN
+# endif
 #define STDCALL  __stdcall
 # ifdef JL_LIBRARY_EXPORTS_INTERNAL
-#  define JL_DLLEXPORT __declspec(dllexport) __attribute__ ((visibility("default")))
+#  define JL_DLLEXPORT __declspec(dllexport) JL_VISIBILITY_DEFAULT
 # endif
 # ifdef JL_LIBRARY_EXPORTS_CODEGEN
-#  define JL_DLLEXPORT_CODEGEN __declspec(dllexport) __attribute__ ((visibility("default")))
+#  define JL_DLLEXPORT_CODEGEN __declspec(dllexport) JL_VISIBILITY_DEFAULT
 # endif
 #define JL_HIDDEN
-#define JL_DLLIMPORT   __declspec(dllimport) __attribute__ ((visibility("default")))
+#define JL_DLLIMPORT   __declspec(dllimport) JL_VISIBILITY_DEFAULT
 #else
 #define STDCALL
 #define JL_DLLIMPORT __attribute__ ((visibility("default")))


### PR DESCRIPTION
The use of `__attribute__` in headers causes compile errors on MSVC, this PR removes these when compiling a program that includes Julia headers with MSVC.

The `DECLSPEC_IMPORT` macro is also defined by default on MSVC, so it is deactivated when in MSVC.

See the [log starting here](https://github.com/JuliaInterop/libcxxwrap-julia/actions/runs/19379560768/job/55455166299#step:4:60) for an example of the errors.