### PR TITLE
Replace some uses of `Array` by `Vector` or `Matrix`

### DIFF
--- a/Compiler/src/typeutils.jl
+++ b/Compiler/src/typeutils.jl
@@ -48,7 +48,7 @@ has_extended_info(@nospecialize x) = (!isa(x, Type) && !isvarargtype(x)) || isTy
 # certain combinations of `a` and `b` where one/both isa/are `Union`/`UnionAll` type(s)s.
 isnotbrokensubtype(@nospecialize(a), @nospecialize(b)) = (!iskindtype(b) || !isType(a) || hasuniquerep(a.parameters[1]) || b <: a)
 
-function argtypes_to_type(argtypes::Array{Any,1})
+function argtypes_to_type(argtypes::Vector{Any})
     argtypes = anymap(@nospecialize(a) -> isvarargtype(a) ? a : widenconst(a), argtypes)
     filter!(@nospecialize(x) -> !isvarargtype(x) || valid_as_lattice(unwrapva(x), true), argtypes)
     all(@nospecialize(x) -> isvarargtype(x) || valid_as_lattice(x, true), argtypes) || return Bottom

--- a/Compiler/src/utilities.jl
+++ b/Compiler/src/utilities.jl
@@ -21,7 +21,7 @@ function contains_is(itr, @nospecialize(x))
     return false
 end
 
-anymap(f::Function, a::Array{Any,1}) = Any[ f(a[i]) for i in 1:length(a) ]
+anymap(f::Function, a::Vector{Any}) = Any[ f(a[i]) for i in 1:length(a) ]
 
 ############
 # inlining #

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -105,12 +105,12 @@ end
 
 # issue #51694
 @test Compiler.type_more_complex(
-       Base.Generator{Base.Iterators.Flatten{Array{Bool, 1}}, typeof(identity)},
-       Base.Generator{Array{Bool, 1}, typeof(identity)},
+       Base.Generator{Base.Iterators.Flatten{Vector{Bool}}, typeof(identity)},
+       Base.Generator{Vector{Bool}, typeof(identity)},
        Core.svec(), 0, 0, 0)
 @test Compiler.type_more_complex(
-       Base.Generator{Base.Iterators.Flatten{Base.Generator{Array{Bool, 1}, typeof(identity)}}, typeof(identity)},
-       Base.Generator{Array{Bool, 1}, typeof(identity)},
+       Base.Generator{Base.Iterators.Flatten{Base.Generator{Vector{Bool}, typeof(identity)}}, typeof(identity)},
+       Base.Generator{Vector{Bool}, typeof(identity)},
        Core.svec(), 0, 0, 0)
 
 let # 40336
@@ -419,7 +419,7 @@ end
 
 # issue #12826
 f12826(v::Vector{I}) where {I<:Integer} = v[1]
-@test Base.return_types(f12826,Tuple{Array{I,1} where I<:Integer})[1] == Integer
+@test Base.return_types(f12826,Tuple{Vector{I} where I<:Integer})[1] == Integer
 
 
 # non-terminating inference, issue #14009
@@ -1465,8 +1465,8 @@ let egal_tfunc
     @test egal_tfunc(Array, Array) == Bool
     @test egal_tfunc(Array, AbstractArray{Int}) == Bool
     @test egal_tfunc(Array{Real}, AbstractArray{Int}) === Const(false)
-    @test egal_tfunc(Array{Real, 2}, AbstractArray{Real, 2}) === Bool
-    @test egal_tfunc(Array{Real, 2}, AbstractArray{Int, 2}) === Const(false)
+    @test egal_tfunc(Matrix{Real}, AbstractMatrix{Real}) === Bool
+    @test egal_tfunc(Matrix{Real}, AbstractMatrix{Int}) === Const(false)
     @test egal_tfunc(DataType, Int) === Const(false)
     @test egal_tfunc(DataType, Const(Int)) === Bool
     @test egal_tfunc(DataType, Const(Array)) === Const(false)

--- a/base/array.jl
+++ b/base/array.jl
@@ -399,10 +399,10 @@ end
 
 ## Constructors ##
 
-similar(a::Array{T,1}) where {T}                    = Vector{T}(undef, size(a,1))
-similar(a::Array{T,2}) where {T}                    = Matrix{T}(undef, size(a,1), size(a,2))
-similar(a::Array{T,1}, S::Type) where {T}           = Vector{S}(undef, size(a,1))
-similar(a::Array{T,2}, S::Type) where {T}           = Matrix{S}(undef, size(a,1), size(a,2))
+similar(a::Vector{T}) where {T}                    = Vector{T}(undef, size(a,1))
+similar(a::Matrix{T}) where {T}                    = Matrix{T}(undef, size(a,1), size(a,2))
+similar(a::Vector{T}, S::Type) where {T}           = Vector{S}(undef, size(a,1))
+similar(a::Matrix{T}, S::Type) where {T}           = Matrix{S}(undef, size(a,1), size(a,2))
 similar(a::Array{T}, m::Int) where {T}              = Vector{T}(undef, m)
 similar(a::Array, T::Type, dims::Dims{N}) where {N} = Array{T,N}(undef, dims)
 similar(a::Array{T}, dims::Dims{N}) where {T,N}     = Array{T,N}(undef, dims)
@@ -1832,12 +1832,12 @@ julia> insert!(Any[1:6;], 3, "here")
  6
 ```
 """
-function insert!(a::Array{T,1}, i::Integer, item) where T
+function insert!(a::Vector{T}, i::Integer, item) where T
     @_propagate_inbounds_meta
     item = item isa T ? item : convert(T, item)::T
     return _insert!(a, i, item)
 end
-function _insert!(a::Array{T,1}, i::Integer, item::T) where T
+function _insert!(a::Vector{T}, i::Integer, item::T) where T
     @_noub_meta
     # Throw convert error before changing the shape of the array
     _growat!(a, i, 1)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -12,13 +12,13 @@ Mostly used to represent files returned by [`open`](@ref).
 """
 mutable struct IOStream <: IO
     handle::Ptr{Cvoid}
-    ios::Array{UInt8,1}
+    ios::Vector{UInt8}
     name::String
     mark::Int64
     lock::ReentrantLock
     _dolock::Bool
 
-    IOStream(name::AbstractString, buf::Array{UInt8,1}) = new(pointer(buf), buf, name, -1, ReentrantLock(), true)
+    IOStream(name::AbstractString, buf::Vector{UInt8}) = new(pointer(buf), buf, name, -1, ReentrantLock(), true)
 end
 
 function IOStream(name::AbstractString, finalize::Bool)
@@ -470,7 +470,7 @@ take!(s::IOStream) =
     @_lock_ios s ccall(:jl_take_buffer, Vector{UInt8}, (Ptr{Cvoid},), s.ios)
 
 function readuntil(s::IOStream, delim::UInt8; keep::Bool=false)
-    @_lock_ios s ccall(:jl_readuntil, Array{UInt8,1}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, delim, 0, !keep)
+    @_lock_ios s ccall(:jl_readuntil, Vector{UInt8}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, delim, 0, !keep)
 end
 
 # like readuntil, above, but returns a String without requiring a copy

--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -279,7 +279,7 @@ if (Sys.islinux() || Sys.isbsd()) && !Sys.isapple()
 
     # This callback function called by dl_iterate_phdr() on Linux and BSD's
     # DL_ITERATE_PHDR(3) on freebsd
-    function dl_phdr_info_callback(di::dl_phdr_info, size::Csize_t, dynamic_libraries::Array{String,1})
+    function dl_phdr_info_callback(di::dl_phdr_info, size::Csize_t, dynamic_libraries::Vector{String})
         name = unsafe_string(di.name)
         push!(dynamic_libraries, name)
         return Cint(0)

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -255,10 +255,10 @@ library module, only supports two dimensions, so it just defines
 `getindex(A::SparseMatrixCSC, i::Int, j::Int)`. The same holds for [`setindex!`](@ref).
 
 Returning to the sequence of squares from above, we could instead define it as a subtype of an
-`AbstractArray{Int, 1}`:
+`AbstractVector{Int}`:
 
 ```jldoctest squarevectype
-julia> struct SquaresVector <: AbstractArray{Int, 1}
+julia> struct SquaresVector <: AbstractVector{Int}
            count::Int
        end
 

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -541,7 +541,7 @@ of type `Array{Any}`). But, if you're using one of these structures and happen t
 of an element, it helps to share this knowledge with the compiler:
 
 ```julia
-function foo(a::Array{Any,1})
+function foo(a::Vector{Any})
     x = a[1]::Int32
     b = x+1
     ...

--- a/test/core.jl
+++ b/test/core.jl
@@ -462,12 +462,12 @@ end
 mutable struct A3890{T1}
     x::Matrix{Complex{T1}}
 end
-@test A3890{Float64}.types[1] === Array{ComplexF64,2}
+@test A3890{Float64}.types[1] === Matrix{ComplexF64}
 # make sure the field type Matrix{Complex{T1}} isn't cached
 mutable struct B3890{T2}
     x::Matrix{Complex{T2}}
 end
-@test B3890{Float64}.types[1] === Array{ComplexF64,2}
+@test B3890{Float64}.types[1] === Matrix{ComplexF64}
 
 # issue #786
 mutable struct Node{T}
@@ -3894,14 +3894,14 @@ f12092(x::Int, y::Int...) = 2
 
 # issue #12063
 # NOTE: should have > MAX_TUPLETYPE_LEN arguments
-f12063(tt, g, p, c, b, v, cu::T, d::AbstractArray{T, 2}, ve) where {T} = 1
+f12063(tt, g, p, c, b, v, cu::T, d::AbstractMatrix{T}, ve) where {T} = 1
 f12063(args...) = 2
 g12063() = f12063(0, 0, 0, 0, 0, 0, 0.0, zeros(0,0), Int[])
 @test g12063() == 1
 
 # issue #11587
 mutable struct Sampler11587{N}
-    clampedpos::Array{Int,2}
+    clampedpos::Matrix{Int}
     buf::Array{Float64,N}
 end
 function Sampler11587()
@@ -7435,9 +7435,9 @@ end
 @test repackage28445()
 
 # issue #28597
-@test_throws ArgumentError Array{Int, 2}(undef, 0, -10)
-@test_throws ArgumentError Array{Int, 2}(undef, -10, 0)
-@test_throws ArgumentError Array{Int, 2}(undef, -1, -1)
+@test_throws ArgumentError Matrix{Int}(undef, 0, -10)
+@test_throws ArgumentError Matrix{Int}(undef, -10, 0)
+@test_throws ArgumentError Matrix{Int}(undef, -1, -1)
 
 # issue #54244
 # test that zero sized array doesn't throw even with large axes

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -247,17 +247,17 @@ PV = view(P, 2:3, :)
 
 # Similar
 B = similar(A, Float32)
-@test isa(B, OffsetArray{Float32,2})
+@test isa(B, OffsetMatrix{Float32})
 @test axes(B) === axes(A)
 B = similar(A, (3,4))
-@test isa(B, Array{Int,2})
+@test isa(B, Matrix{Int})
 @test size(B) == (3,4)
 @test axes(B) === (Base.OneTo(3), Base.OneTo(4))
 B = similar(A, (-3:3,1:4))
-@test isa(B, OffsetArray{Int,2})
+@test isa(B, OffsetMatrix{Int})
 @test axes(B) === (OffsetArrays.IdOffsetRange(Base.OneTo(7), -4), OffsetArrays.IdOffsetRange(Base.OneTo(4)))
 B = similar(parent(A), (-3:3,1:4))
-@test isa(B, OffsetArray{Int,2})
+@test isa(B, OffsetMatrix{Int})
 @test axes(B) === (OffsetArrays.IdOffsetRange(Base.OneTo(7), -4), OffsetArrays.IdOffsetRange(Base.OneTo(4)))
 
 # Indexing with OffsetArray indices
@@ -923,7 +923,7 @@ end
     @test axes(A) == Base.IdentityUnitRange.((2:3, 4:5))
 
     B = reshape(A0, -10:-9, 9:10)
-    @test isa(B, OffsetArray{Int,2})
+    @test isa(B, OffsetMatrix{Int})
     @test parent(B) == A0
     @test axes(B) == Base.IdentityUnitRange.((-10:-9, 9:10))
 end

--- a/test/specificity.jl
+++ b/test/specificity.jl
@@ -170,7 +170,7 @@ let A = Tuple{Ref, Tuple{T}} where T,
 end
 
 # issue #22339
-let A = Tuple{T, Array{T, 1}} where T,
+let A = Tuple{T, Vector{T}} where T,
     B = Tuple{T} where T,
     C = Tuple{T} where T<:AbstractFloat
     @test args_morespecific(B, A)

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -402,7 +402,7 @@ end
 end
 # test AbstractString functions at beginning of string.jl
 struct tstStringType <: AbstractString
-    data::Array{UInt8,1}
+    data::Vector{UInt8}
 end
 @testset "AbstractString functions" begin
     tstr = tstStringType(unsafe_wrap(Vector{UInt8},"12"))

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -20,22 +20,22 @@ intersection_env(@nospecialize(x), @nospecialize(y)) = ccall(:jl_type_intersecti
 # level 1: no varags, union, UnionAll
 function test_1()
     @test issub_strict(Int, Integer)
-    @test issub_strict(Array{Int,1}, AbstractArray{Int,1})
+    @test issub_strict(Vector{Int}, AbstractVector{Int})
 
     @test isequal_type(Int, Int)
     @test isequal_type(Integer, Integer)
-    @test isequal_type(Array{Int,1}, Array{Int,1})
-    @test isequal_type(AbstractArray{Int,1}, AbstractArray{Int,1})
+    @test isequal_type(Vector{Int}, Vector{Int})
+    @test isequal_type(AbstractVector{Int}, AbstractVector{Int})
 
     @test issub_strict(Tuple{Int,Int}, Tuple{Integer,Integer})
-    @test issub_strict(Tuple{Array{Int,1}}, Tuple{AbstractArray{Int,1}})
+    @test issub_strict(Tuple{Vector{Int}}, Tuple{AbstractVector{Int}})
 
     @test isequal_type(Tuple{Integer,Integer}, Tuple{Integer,Integer})
 
     @test !issub(Tuple{Int,Int}, Tuple{Int})
     @test !issub(Tuple{Int}, Tuple{Integer,Integer})
 
-    @test !issub(Array{Int,1}, Array{Integer,1})
+    @test !issub(Vector{Int}, Vector{Integer})
 end
 
 # level 2: varargs
@@ -109,7 +109,7 @@ function test_diagonal()
     @test !issub(Tuple{Real,Real}, @UnionAll T<:Real Tuple{T,T})
 
     @test issub((@UnionAll S<:Int (@UnionAll R<:AbstractString Tuple{S,R,Vector{Any}})),
-                (@UnionAll T Tuple{T, T, Array{T,1}}))
+                (@UnionAll T Tuple{T, T, Vector{T}}))
 
     @test issub_strict(Tuple{String, Real, Ref{Number}},
                        (@UnionAll T Tuple{Union{T,String}, T, Ref{T}}))
@@ -171,7 +171,7 @@ function test_diagonal()
     end
 
     # #26108
-    @test !issub((Tuple{T, T, Array{T, 1}} where T), Tuple{T, T, Any} where T)
+    @test !issub((Tuple{T, T, Vector{T}} where T), Tuple{T, T, Any} where T)
 
     # #26716
     @test !issub((Union{Tuple{Int,Bool}, Tuple{P,Bool}} where P), Tuple{Union{T,Int}, T} where T)
@@ -188,7 +188,7 @@ end
 
 # level 3: UnionAll
 function test_3()
-    @test issub_strict(Array{Int,1}, @UnionAll T Vector{T})
+    @test issub_strict(Vector{Int}, @UnionAll T Vector{T})
     @test issub_strict((@UnionAll T Pair{T,T}), Pair)
     @test issub(Pair{Int,Int8}, Pair)
     @test issub(Pair{Int,Int8}, (@UnionAll S Pair{Int,S}))
@@ -203,8 +203,8 @@ function test_3()
     @test issub_strict((@UnionAll T Tuple{Array{T},Array{T}}),
                        Tuple{Array, Array})
 
-    AUA = Array{(@UnionAll T Array{T,1}), 1}
-    UAA = (@UnionAll T Array{Array{T,1}, 1})
+    AUA = Vector{(@UnionAll T Vector{T})}
+    UAA = (@UnionAll T Vector{Vector{T}})
 
     @test !issub(AUA, UAA)
     @test !issub(UAA, AUA)
@@ -221,68 +221,68 @@ function test_3()
     @test isequal_type((@UnionAll T Tuple{T}), Tuple{Any})
     @test isequal_type((@UnionAll T<:Real Tuple{T}), Tuple{Real})
 
-    @test  issub(Tuple{Array{Integer,1}, Int},
-                 @UnionAll T<:Integer @UnionAll S<:T Tuple{Array{T,1},S})
+    @test  issub(Tuple{Vector{Integer}, Int},
+                 @UnionAll T<:Integer @UnionAll S<:T Tuple{Vector{T},S})
 
-    @test !issub(Tuple{Array{Integer,1}, Real},
-                 @UnionAll T<:Integer Tuple{Array{T,1},T})
+    @test !issub(Tuple{Vector{Integer}, Real},
+                 @UnionAll T<:Integer Tuple{Vector{T},T})
 
     @test !issub(Tuple{Int,String,Vector{Integer}},
-                 @UnionAll T Tuple{T, T, Array{T,1}})
+                 @UnionAll T Tuple{T, T, Vector{T}})
     @test !issub(Tuple{String,Int,Vector{Integer}},
-                 @UnionAll T Tuple{T, T, Array{T,1}})
+                 @UnionAll T Tuple{T, T, Vector{T}})
     @test !issub(Tuple{Int,String,Vector{Tuple{Integer}}},
-                 @UnionAll T Tuple{T,T,Array{Tuple{T},1}})
+                 @UnionAll T Tuple{T,T,Vector{Tuple{T}}})
 
     @test issub(Tuple{Int,String,Vector{Any}},
-                @UnionAll T Tuple{T, T, Array{T,1}})
+                @UnionAll T Tuple{T, T, Vector{T}})
 
-    @test isequal_type(Array{Int,1}, Array{(@UnionAll T<:Int T), 1})
-    @test isequal_type(Array{Tuple{Any},1}, Array{(@UnionAll T Tuple{T}), 1})
+    @test isequal_type(Vector{Int}, Vector{(@UnionAll T<:Int T)})
+    @test isequal_type(Vector{Tuple{Any}}, Vector{(@UnionAll T Tuple{T})})
 
-    @test isequal_type(Array{Tuple{Int,Int},1},
-                       Array{(@UnionAll T<:Int Tuple{T,T}), 1})
-    @test !issub(Array{Tuple{Int,Integer},1},
-                 Array{(@UnionAll T<:Integer Tuple{T,T}), 1})
+    @test isequal_type(Vector{Tuple{Int,Int}},
+                       Vector{(@UnionAll T<:Int Tuple{T,T})})
+    @test !issub(Vector{Tuple{Int,Integer}},
+                 Vector{(@UnionAll T<:Integer Tuple{T,T})})
 
     @test !issub(Pair{Int,Int8}, (@UnionAll T Pair{T,T}))
 
-    @test !issub(Tuple{Array{Int,1}, Integer},
-                 @UnionAll T<:Integer Tuple{Array{T,1},T})
+    @test !issub(Tuple{Vector{Int}, Integer},
+                 @UnionAll T<:Integer Tuple{Vector{T},T})
 
-    @test !issub(Tuple{Integer, Array{Int,1}},
-                 @UnionAll T<:Integer Tuple{T, Array{T,1}})
+    @test !issub(Tuple{Integer, Vector{Int}},
+                 @UnionAll T<:Integer Tuple{T, Vector{T}})
 
-    @test !issub(Pair{Array{Int,1},Integer}, @UnionAll T Pair{Array{T,1},T})
-    @test  issub(Pair{Array{Int,1},Int}, @UnionAll T Pair{Array{T,1},T})
+    @test !issub(Pair{Vector{Int},Integer}, @UnionAll T Pair{Vector{T},T})
+    @test  issub(Pair{Vector{Int},Int}, @UnionAll T Pair{Vector{T},T})
 
     @test  issub(Tuple{Integer,Int}, @UnionAll T<:Integer @UnionAll S<:T Tuple{T,S})
     @test !issub(Tuple{Integer,Int}, @UnionAll T<:Int     @UnionAll S<:T Tuple{T,S})
     @test !issub(Tuple{Integer,Int}, @UnionAll T<:String  @UnionAll S<:T Tuple{T,S})
 
-    @test issub(Tuple{Float32,Array{Float32,1}},
-                @UnionAll T<:Real @UnionAll S<:AbstractArray{T,1} Tuple{T,S})
+    @test issub(Tuple{Float32,Vector{Float32}},
+                @UnionAll T<:Real @UnionAll S<:AbstractVector{T} Tuple{T,S})
 
-    @test !issub(Tuple{Float32,Array{Float64,1}},
-                 @UnionAll T<:Real @UnionAll S<:AbstractArray{T,1} Tuple{T,S})
+    @test !issub(Tuple{Float32,Vector{Float64}},
+                 @UnionAll T<:Real @UnionAll S<:AbstractVector{T} Tuple{T,S})
 
-    @test issub(Tuple{Float32,Array{Real,1}},
-                @UnionAll T<:Real @UnionAll S<:AbstractArray{T,1} Tuple{T,S})
+    @test issub(Tuple{Float32,Vector{Real}},
+                @UnionAll T<:Real @UnionAll S<:AbstractVector{T} Tuple{T,S})
 
-    @test !issub(Tuple{Number,Array{Real,1}},
-                 @UnionAll T<:Real @UnionAll S<:AbstractArray{T,1} Tuple{T,S})
+    @test !issub(Tuple{Number,Vector{Real}},
+                 @UnionAll T<:Real @UnionAll S<:AbstractVector{T} Tuple{T,S})
 
     @test issub((@UnionAll Int<:T<:Integer T), @UnionAll T<:Real T)
-    @test issub((@UnionAll Int<:T<:Integer Array{T,1}),
-                (@UnionAll T<:Real Array{T,1}))
+    @test issub((@UnionAll Int<:T<:Integer Vector{T}),
+                (@UnionAll T<:Real Vector{T}))
 
     @test  issub((@UnionAll Int<:T<:Integer T), (@UnionAll Integer<:T<:Real T))
-    @test !issub((@UnionAll Int<:T<:Integer Array{T,1}), (@UnionAll Integer<:T<:Real Array{T,1}))
+    @test !issub((@UnionAll Int<:T<:Integer Vector{T}), (@UnionAll Integer<:T<:Real Vector{T}))
 
-    X = (@UnionAll T<:Real @UnionAll S<:AbstractArray{T,1} Tuple{T,S})
-    Y = (@UnionAll A<:Real @UnionAll B<:AbstractArray{A,1} Tuple{A,B})
+    X = (@UnionAll T<:Real @UnionAll S<:AbstractVector{T} Tuple{T,S})
+    Y = (@UnionAll A<:Real @UnionAll B<:AbstractVector{A} Tuple{A,B})
     @test isequal_type(X,Y)
-    Z = (@UnionAll A<:Real @UnionAll B<:AbstractArray{A,1} Tuple{Real,B})
+    Z = (@UnionAll A<:Real @UnionAll B<:AbstractVector{A} Tuple{Real,B})
     @test issub_strict(X,Z)
 
     @test issub_strict((@UnionAll T @UnionAll S<:T Pair{T,S}),
@@ -329,7 +329,7 @@ function test_3()
     @test !issub((Type{AbstractArray{Array{T}} where T}), Type{AbstractArray{S}} where S)
     @test !issub((Val{AbstractArray{Array{T}} where T}), Val{AbstractArray{T}} where T)
     @test !issub((Array{Array{Array{T}} where T}), Array{Array{T}} where T)
-    @test !issub((Array{Array{T, 1}, 1} where T), AbstractArray{Vector})
+    @test !issub((Vector{Vector{T}} where T), AbstractArray{Vector})
 
     @test !issub((Ref{Pair{Pair{T, R}, R} where R} where T),
                  (Ref{Pair{A,          B} where B} where A))
@@ -390,36 +390,36 @@ end
 function test_5()
     u = Union{Int8,Int}
 
-    @test issub(Tuple{String,Array{Int,1}},
-                (@UnionAll T Union{Tuple{T,Array{T,1}}, Tuple{T,Array{Int,1}}}))
+    @test issub(Tuple{String,Vector{Int}},
+                (@UnionAll T Union{Tuple{T,Vector{T}}, Tuple{T,Vector{Int}}}))
 
     @test issub(Tuple{Union{Vector{Int},Vector{Int8}}},
-                @UnionAll T Tuple{Array{T,1}})
+                @UnionAll T Tuple{Vector{T}})
 
     @test !issub(Tuple{Union{Vector{Int},Vector{Int8}},Vector{Int}},
-                 @UnionAll T Tuple{Array{T,1}, Array{T,1}})
+                 @UnionAll T Tuple{Vector{T}, Vector{T}})
 
     @test !issub(Tuple{Union{Vector{Int},Vector{Int8}},Vector{Int8}},
-                 @UnionAll T Tuple{Array{T,1}, Array{T,1}})
+                 @UnionAll T Tuple{Vector{T}, Vector{T}})
 
-    @test !issub(Vector{Int}, @UnionAll T>:u Array{T,1})
-    @test  issub(Vector{Integer}, @UnionAll T>:u Array{T,1})
-    @test  issub(Vector{Union{Int,Int8}}, @UnionAll T>:u Array{T,1})
+    @test !issub(Vector{Int}, @UnionAll T>:u Vector{T})
+    @test  issub(Vector{Integer}, @UnionAll T>:u Vector{T})
+    @test  issub(Vector{Union{Int,Int8}}, @UnionAll T>:u Vector{T})
 
-    @test issub((@UnionAll Int<:T<:u Array{T,1}), (@UnionAll Int<:T<:u Array{T,1}))
+    @test issub((@UnionAll Int<:T<:u Vector{T}), (@UnionAll Int<:T<:u Vector{T}))
 
     # with varargs
     @test !issub(Array{Tuple{Array{Int},Array{Vector{Int16}},Array{Vector{Int}},Array{Int}}},
-                 @UnionAll T<:(@UnionAll S Tuple{Vararg{Union{Array{S}, Array{Array{S,1}}}}}) Array{T})
+                 @UnionAll T<:(@UnionAll S Tuple{Vararg{Union{Array{S}, Array{Vector{S}}}}}) Array{T})
 
     @test  issub(Array{Tuple{Array{Int},Array{Vector{Int}},Array{Vector{Int}},Array{Int}}},
-                 @UnionAll T<:(@UnionAll S Tuple{Vararg{Union{Array{S}, Array{Array{S,1}}}}}) Array{T})
+                 @UnionAll T<:(@UnionAll S Tuple{Vararg{Union{Array{S}, Array{Vector{S}}}}}) Array{T})
 
     @test !issub(Tuple{Array{Int},Array{Vector{Int16}},Array{Vector{Int}},Array{Int}},
-                 @UnionAll S Tuple{Vararg{Union{Array{S},Array{Array{S,1}}}}})
+                 @UnionAll S Tuple{Vararg{Union{Array{S},Array{Vector{S}}}}})
 
     @test  issub(Tuple{Array{Int},Array{Vector{Int}},Array{Vector{Int}},Array{Int}},
-                 @UnionAll S Tuple{Vararg{Union{Array{S},Array{Array{S,1}}}}})
+                 @UnionAll S Tuple{Vararg{Union{Array{S},Array{Vector{S}}}}})
 
     B = @UnionAll S<:u Tuple{S, Tuple{Any,Any,Any}, Ref{S}}
     # these tests require renaming in issub_unionall
@@ -428,8 +428,8 @@ function test_5()
 
     # the `convert(Type{T},T)` pattern, where T is a Union
     # required changing priority of unions and vars
-    @test issub(Tuple{Array{u,1},Int}, @UnionAll T Tuple{Array{T,1}, T})
-    @test issub(Tuple{Array{u,1},Int}, @UnionAll T @UnionAll S<:T Tuple{Array{T,1}, S})
+    @test issub(Tuple{Vector{u},Int}, @UnionAll T Tuple{Vector{T}, T})
+    @test issub(Tuple{Vector{u},Int}, @UnionAll T @UnionAll S<:T Tuple{Vector{T}, S})
 
     @test !issub(Ref{Union{Ref{Int},Ref{Int8}}}, @UnionAll T Ref{Ref{T}})
     @test  issub(Tuple{Union{Ref{Int},Ref{Int8}}}, @UnionAll T Tuple{Ref{T}})
@@ -449,10 +449,10 @@ end
 # tricky type variable lower bounds
 function test_6()
     @test  issub((@UnionAll S<:Int (@UnionAll R<:String Tuple{S,R,Vector{Any}})),
-                 (@UnionAll T Tuple{T, T, Array{T,1}}))
+                 (@UnionAll T Tuple{T, T, Vector{T}}))
 
     @test !issub((@UnionAll S<:Int (@UnionAll R<:String Tuple{S,R,Vector{Integer}})),
-                 (@UnionAll T Tuple{T, T, Array{T,1}}))
+                 (@UnionAll T Tuple{T, T, Vector{T}}))
 
     t = @UnionAll T Tuple{T,T,Ref{T}}
     @test isequal_type(t, @UnionAll S Tuple{S,S,Ref{S}})
@@ -561,8 +561,8 @@ function test_old()
     @test Int8 <: Integer
     @test Int32 <: Integer
     @test Tuple{Int8,Int8} <: Tuple{Integer,Integer}
-    @test !(AbstractArray{Float64,2} <: AbstractArray{Number,2})
-    @test !(AbstractArray{Float64,1} <: AbstractArray{Float64,2})
+    @test !(AbstractMatrix{Float64} <: AbstractMatrix{Number})
+    @test !(AbstractVector{Float64} <: AbstractMatrix{Float64})
     @test Tuple{Integer,Vararg{Integer}} <: Tuple{Integer,Vararg{Real}}
     @test Tuple{Integer,Float64,Vararg{Integer}} <: Tuple{Integer,Vararg{Number}}
     @test Tuple{Integer,Float64} <: Tuple{Integer,Vararg{Number}}
@@ -571,9 +571,9 @@ function test_old()
     @test !(Tuple{Vararg{Int32}} <: Tuple{Int32,})
     @test !(Tuple{Vararg{Int32}} <: Tuple{Number,Integer})
     @test !(Tuple{Vararg{Integer}} <: Tuple{Integer,Integer,Vararg{Integer}})
-    @test !(Array{Int8,1} <: Array{Any,1})
-    @test !(Array{Any,1} <: Array{Int8,1})
-    @test Array{Int8,1} <: Array{Int8,1}
+    @test !(Vector{Int8} <: Vector{Any})
+    @test !(Vector{Any} <: Vector{Int8})
+    @test Vector{Int8} <: Vector{Int8}
     @test !(Type{Bottom} <: Type{Int32})
     @test !(Vector{Float64} <: Vector{Union{Float64,Float32}})
 
@@ -604,10 +604,10 @@ end
 
 const easy_menagerie =
     Any[Any, Int, Int8, Integer, Real,
-        Array{Int,1}, AbstractArray{Int,1},
+        Vector{Int}, AbstractVector{Int},
         Tuple{Int,Vararg{Integer}}, Tuple{Integer,Vararg{Int}}, Tuple{},
         Union{Int,Int8},
-        (@UnionAll T Array{T,1}),
+        (@UnionAll T Vector{T}),
         (@UnionAll T Pair{T,T}),
         (@UnionAll T @UnionAll S Pair{T,S}),
         Pair{Int,Int8},
@@ -617,15 +617,15 @@ const easy_menagerie =
         (@UnionAll T @UnionAll S Tuple{T,S}),
         (@UnionAll T<:Integer @UnionAll S<:Number Tuple{T,S}),
         (@UnionAll T<:Integer @UnionAll S<:Number Tuple{S,T}),
-        Array{(@UnionAll T Array{T,1}),1},
-        (@UnionAll T Array{Array{T,1},1}),
-        Array{(@UnionAll T<:Int T), 1},
-        (@UnionAll T<:Real @UnionAll S<:AbstractArray{T,1} Tuple{T,S}),
+        Vector{(@UnionAll T Vector{T})},
+        (@UnionAll T Vector{Vector{T}}),
+        Vector{(@UnionAll T<:Int T)},
+        (@UnionAll T<:Real @UnionAll S<:AbstractVector{T} Tuple{T,S}),
         Union{Int,Ref{Union{Int,Int8}}},
         ]
 
 const hard_menagerie =
-    Any[(@UnionAll T Union{Tuple{T,Array{T,1}}, Tuple{T,Array{Int,1}}})]
+    Any[(@UnionAll T Union{Tuple{T,Vector{T}}, Tuple{T,Vector{Int}}})]
 
 function add_variants!(types)
     new = Any[]
@@ -769,11 +769,11 @@ function test_intersection()
     @testintersect((@UnionAll T<:Number Array{T}), (@UnionAll T<:String Array{T}),
                    Array{Bottom})
 
-    @testintersect((@UnionAll T Tuple{T, AbstractArray{T}}), Tuple{Number, Array{Int,1}},
-                   Tuple{Int, Array{Int,1}})
+    @testintersect((@UnionAll T Tuple{T, AbstractArray{T}}), Tuple{Number, Vector{Int}},
+                   Tuple{Int, Vector{Int}})
 
-    @testintersect((@UnionAll T Tuple{T, AbstractArray{T}}), Tuple{Int, Array{Number,1}},
-                   Tuple{Int, Array{Number,1}})
+    @testintersect((@UnionAll T Tuple{T, AbstractArray{T}}), Tuple{Int, Vector{Number}},
+                   Tuple{Int, Vector{Number}})
 
     # TODO: improve this result
     #@testintersect((@UnionAll S Tuple{S,Vector{S}}), (@UnionAll T<:Real Tuple{T,AbstractVector{T}}),
@@ -784,10 +784,10 @@ function test_intersection()
     # typevar corresponding to a type it will end up being neither greater than nor
     # less than
     @testintersect((@UnionAll T Tuple{T, Ref{T}}), Tuple{Array{Int}, Ref{AbstractVector}},
-                   Tuple{Array{Int,1}, Ref{AbstractVector}})
+                   Tuple{Vector{Int}, Ref{AbstractVector}})
 
-    @testintersect((@UnionAll T Tuple{T, AbstractArray{T}}), Tuple{Any, Array{Number,1}},
-                   Tuple{Number, Array{Number,1}})
+    @testintersect((@UnionAll T Tuple{T, AbstractArray{T}}), Tuple{Any, Vector{Number}},
+                   Tuple{Number, Vector{Number}})
     @testintersect((@UnionAll T Tuple{Array{T}, Array{T}}), Tuple{Array, Array{Any}}, !Bottom)
 
     @testintersect((@UnionAll T Tuple{T,T}), Tuple{Real, Real}, (@UnionAll T<:Real Tuple{T,T}))
@@ -800,9 +800,9 @@ function test_intersection()
                    @UnionAll Z<:Integer Pair{Z,Z})
 
     @testintersect((@UnionAll T<:Vector Type{T}), (@UnionAll N Type{@UnionAll S<:Number Array{S,N}}),
-                   Type{@UnionAll S<:Number Array{S,1}})
+                   Type{@UnionAll S<:Number Vector{S}})
 
-    @testintersect((@UnionAll T Tuple{Type{Array{T,1}},Array{T,1}}),
+    @testintersect((@UnionAll T Tuple{Type{Vector{T}},Vector{T}}),
                    Tuple{Type{AbstractVector},Vector{Int}}, Bottom)
 
     @testintersect(Tuple{Type{Vector{ComplexF64}}, AbstractVector},
@@ -843,8 +843,8 @@ function test_intersection()
                        @UnionAll N Tuple{Tuple{Int,Vararg{Int}},Array{Int,N}})
 
     @testintersect((@UnionAll N Tuple{NTuple{N,Any},Array{Int,N}}),
-                   Tuple{Tuple{Int,Vararg{Int}},Array{Int,2}},
-                   Tuple{Tuple{Int,Int}, Array{Int,2}})
+                   Tuple{Tuple{Int,Vararg{Int}},Matrix{Int}},
+                   Tuple{Tuple{Int,Int}, Matrix{Int}})
     @testintersect(Type{Any},Type{Complex}, Bottom)
     @testintersect(Type{Any},(@UnionAll T<:Real Type{T}), Bottom)
 
@@ -867,7 +867,7 @@ function test_intersection()
     @testintersect((@UnionAll N Tuple{Array{Int,N},Vararg{Int,N}}), Tuple{Vector{Int},Real,Real,Real}, Bottom)
 
     @testintersect((@UnionAll N Tuple{Array{Int,N},Vararg{Int,N}}), Tuple{Array{Int,0}}, Tuple{Array{Int,0}})
-    @testintersect((@UnionAll N Tuple{Array{Int,N},Vararg{Int,N}}), Tuple{Array{Int,2}}, Bottom)
+    @testintersect((@UnionAll N Tuple{Array{Int,N},Vararg{Int,N}}), Tuple{Matrix{Int}}, Bottom)
 
     @testintersect(Tuple{Int,Vararg{Int}}, Tuple{Int,Int,Int,Vararg{Float64}}, Tuple{Int,Int,Int})
     @testintersect(Tuple{Int,Vararg{Int}}, Tuple{Int,Vararg{Float64}}, Tuple{Int})
@@ -877,11 +877,11 @@ function test_intersection()
     @testintersect((@UnionAll N Tuple{Array{Int,N},Vararg{Int,N}}),
                    Tuple{Matrix{Int},Int,Vararg{Float64}}, Bottom)
 
-    @testintersect(Tuple{Array{Any,1}, Tuple{Int64, Int64, Vararg{Int64}}},
+    @testintersect(Tuple{Vector{Any}, Tuple{Int64, Int64, Vararg{Int64}}},
                    Tuple{Array{T,N}, Tuple{Vararg{Int64,N}}} where N where T,
                    Bottom)
 
-    @testintersect((@UnionAll T<:Union{Float64,Array{Float64,1}} T), Real, Float64)
+    @testintersect((@UnionAll T<:Union{Float64,Vector{Float64}} T), Real, Float64)
 
     # issue #4805
     @testintersect((@UnionAll T<:Int Type{IT4805_2{1,T}}),
@@ -955,20 +955,20 @@ function test_intersection()
                    Tuple{Type{S}, Tuple{Any, Vararg{Any}}} where S<:Tuple{Any, Vararg{Any}})
 
     # part of issue #20450
-    @testintersect(Tuple{Array{Ref{T}, 1}, Array{Pair{M, V}, 1}} where V where T where M,
-                   Tuple{Array{Ref{T}, 1}, Array{Pair{M, T}, 1}, SS} where T where M where SS,
+    @testintersect(Tuple{Vector{Ref{T}}, Vector{Pair{M, V}}} where V where T where M,
+                   Tuple{Vector{Ref{T}}, Vector{Pair{M, T}}, SS} where T where M where SS,
                    Union{})
 
-    @testintersect(Tuple{Array{Ref{T}, 1}, Array{Pair{M, V}, 1}, Int} where V where T where M,
-                   Tuple{Array{Ref{T}, 1}, Array{Pair{M, T}, 1}, Any} where T where M,
-                   Tuple{Array{Ref{T}, 1}, Array{Pair{M, T}, 1}, Int} where T where M)
+    @testintersect(Tuple{Vector{Ref{T}}, Vector{Pair{M, V}}, Int} where V where T where M,
+                   Tuple{Vector{Ref{T}}, Vector{Pair{M, T}}, Any} where T where M,
+                   Tuple{Vector{Ref{T}}, Vector{Pair{M, T}}, Int} where T where M)
 
     @testintersect(Tuple{Int, Ref{Pair{K,V}}} where V where K,
                    Tuple{Any, Ref{Pair{T,T}} where T },
                    Tuple{Int, Ref{Pair{T,T}} where T })
 
     @test_broken isequal_type(_type_intersect(Tuple{T,T} where T,
-                                              Union{Tuple{S,Array{Int64,1}},Tuple{S,Array{S,1}}} where S),
+                                              Union{Tuple{S,Vector{Int64}},Tuple{S,Vector{S}}} where S),
                               Union{Tuple{Vector{Int64},Vector{Int64}},
                                     Tuple{Vector{T},Vector{T}} where T>:Vector})
 
@@ -1046,8 +1046,8 @@ function test_intersection()
                    Tuple{Ref{T}, Ref{T}} where T,
                    Tuple{Ref{Ref{Int}}, Ref{Ref{Int}}})
     @testintersect(Tuple{Vector{Pair{K,V}}, Vector{Pair{K,V}}} where K where V,
-                   Tuple{(Array{Pair{Ref{_2},_1},1} where _2 where _1),
-                         Array{Pair{Ref{Int64},Rational{Int64}},1}},
+                   Tuple{(Vector{Pair{Ref{_2},_1}} where _2 where _1),
+                         Vector{Pair{Ref{Int64},Rational{Int64}}}},
                    Tuple{Vector{Pair{Ref{Int64},Rational{Int64}}},
                          Vector{Pair{Ref{Int64},Rational{Int64}}}})
     @testintersect(Vector{>:Missing}, Vector{Int}, Union{})
@@ -1135,7 +1135,7 @@ let S = ccall(:jl_new_structv, Any, (Any, Ptr{Cvoid}, UInt32), UnionAll, [TypeVa
 end
 
 # issue #20121
-@test NTuple{170,Matrix{Int}} <: (Tuple{Vararg{Union{Array{T,1},Array{T,2},Array{T,3}}}} where T)
+@test NTuple{170,Matrix{Int}} <: (Tuple{Vararg{Union{Vector{T},Matrix{T},Array{T,3}}}} where T)
 
 # Issue #12580
 abstract type AbstractMyType12580{T} end
@@ -1412,24 +1412,24 @@ end
 let
     triangular(::Type{<:AbstractArray{T}}) where {T} = T
     triangular(::Type{<:AbstractArray}) = Any
-    @test triangular(Array{Array{T, 1}, 1} where T) === Any
+    @test triangular(Vector{Vector{T}} where T) === Any
 end
 
 # issue #23908
-@test Array{Union{Int128, Int16, Int32, Int8}, 1} <: Array{Union{Int128, Int32, Int8, _1}, 1} where _1
-let A = Pair{Nothing, Pair{Array{Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}, 1}, Nothing}},
-    B = Pair{Nothing, Pair{Array{Union{Int8, UInt128, UInt16, UInt32, UInt64, UInt8, _1}, 1}, Nothing}} where _1
+@test Vector{Union{Int128, Int16, Int32, Int8}} <: Vector{Union{Int128, Int32, Int8, _1}} where _1
+let A = Pair{Nothing, Pair{Vector{Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}}, Nothing}},
+    B = Pair{Nothing, Pair{Vector{Union{Int8, UInt128, UInt16, UInt32, UInt64, UInt8, _1}}, Nothing}} where _1
     @test A <: B
     @test !(B <: A)
 end
 
 # issue #22688
-let X = Ref{Tuple{Array{Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}, 1}}}
+let X = Ref{Tuple{Vector{Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}}}}
     @test !(X <: Ref{Tuple{Array{Union{Int8, UInt128, UInt16, UInt32, UInt64, UInt8, S}}}} where S)
-    @test X <: Ref{Tuple{Array{Union{Int8, UInt128, UInt16, UInt32, UInt64, UInt8, S}, 1}}} where S
+    @test X <: Ref{Tuple{Vector{Union{Int8, UInt128, UInt16, UInt32, UInt64, UInt8, S}}}} where S
 end
-let X = Ref{Tuple{Array{Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}, 1}, Array{Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}, 1}}},
-    Y = Ref{Tuple{Array{Union{Int8, UInt128, UInt16, UInt32, UInt64, UInt8, S}, 1}, Array{Union{Int8, UInt128, UInt16, UInt32, UInt64, UInt8, T}, 1}}} where S where T
+let X = Ref{Tuple{Vector{Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}}, Vector{Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}}}},
+    Y = Ref{Tuple{Vector{Union{Int8, UInt128, UInt16, UInt32, UInt64, UInt8, S}}, Vector{Union{Int8, UInt128, UInt16, UInt32, UInt64, UInt8, T}}}} where S where T
     @test X <: Y
 end
 
@@ -1591,9 +1591,9 @@ let A = Tuple{Any, Type{Union{Nothing, Int64}}},
     @test I >: Tuple{Int64,Type{Union{Nothing, Int64}}}
     @test J >: Tuple{Int64,Type{Union{Nothing, Int64}}}
 end
-@testintersect(Union{Array{T,1},Array{T,2}} where T<:Union{Float32,Float64},
+@testintersect(Union{Vector{T},Matrix{T}} where T<:Union{Float32,Float64},
                Union{AbstractMatrix{Float32},AbstractVector{Float32}},
-               Union{Array{Float32,2}, Array{Float32,1}})
+               Union{Matrix{Float32}, Vector{Float32}})
 let A = Tuple{Type{Union{Missing,T}},Any} where T,
     B = Tuple{Type{Union{Nothing,T}},Any} where T
     I = typeintersect(A, B)
@@ -1607,16 +1607,16 @@ struct M29955{T, TV<:AbstractVector{T}}
 end
 @testintersect(M29955,
                M29955{<:Any,TV} where TV>:Vector{Float64},
-               M29955{Float64,TV} where Array{Float64,1}<:TV<:AbstractArray{Float64,1})
+               M29955{Float64,TV} where Vector{Float64}<:TV<:AbstractVector{Float64})
 
 struct A29955{T, TV<:AbstractVector{T}, TModel<:M29955{T,TV}}
 end
-@testintersect(Tuple{Type{A29955{Float64,Array{Float64,1},_1}} where _1,
+@testintersect(Tuple{Type{A29955{Float64,Vector{Float64},_1}} where _1,
                      Any},
                Tuple{Type{A29955{T,TV,TM}},
                      TM} where {T,TV<:AbstractVector{T},TM<:M29955{T,TV}},
-               Tuple{Type{A29955{Float64,Array{Float64,1},TM}},
-                   M29955{Float64,Vector{Float64}}} where TM<:M29955{Float64,Array{Float64,1}})
+               Tuple{Type{A29955{Float64,Vector{Float64},TM}},
+                   M29955{Float64,Vector{Float64}}} where TM<:M29955{Float64,Vector{Float64}})
 let M = M29955{T,Vector{Float64}} where T
     @test M == (M29955{T,Vector{Float64}} where T)
     @test M{Float64} == M29955{Float64,Vector{Float64}}
@@ -1689,11 +1689,11 @@ f31082(::Pair{B, C}, ::C, ::C) where {B, C} = 1
                Tuple{Type{Val{T}},Int,Int} where T>:Integer)
 
 # issue #31496
-CovType{T} = Union{AbstractArray{T,2},
+CovType{T} = Union{AbstractMatrix{T},
                    Vector{UpperTriangular{T,Matrix{T}}}}
 @testintersect(Pair{<:Any, <:AbstractMatrix},
                Pair{T,     <:CovType{T}} where T<:AbstractFloat,
-               Pair{T,S} where S<:AbstractArray{T,2} where T<:AbstractFloat)
+               Pair{T,S} where S<:AbstractMatrix{T} where T<:AbstractFloat)
 
 # issue #31703
 @testintersect(Pair{<:Any, Ref{Tuple{Ref{Ref{Tuple{Int}}},Ref{Float64}}}},
@@ -1722,11 +1722,11 @@ const RadialOperator{T,B,M<:AbstractMatrix{T}} = Mul{<:Any,<:Tuple{<:BasisOrRest
 const HFPotentialOperator{T,B} = RadialOperator{T,B,Diagonal{T,Vector{T}}}
 struct HFPotential{kind,T,B,RO<:HFPotentialOperator{T,B},P<:Integer} end
 
-T = HFPotential{_A,Float64,Any,Applied{Int,Tuple{ApplyQuasiArray{Float64,2,Applied{Int,Tuple{Any,BandedMatrix{Int,Ones{Int,2,Tuple{OneTo{Int},OneTo{Int}}},OneTo{Int}}}}},Diagonal{Float64,Array{Float64,1}},ApplyQuasiArray{Float64,2,Applied{Int,Tuple{Adjoint{Int,BandedMatrix{Int,Ones{Int,2,Tuple{OneTo{Int},OneTo{Int}}},OneTo{Int}}},QuasiAdjoint{Float64,Any}}}}}},_B} where _B where _A
+T = HFPotential{_A,Float64,Any,Applied{Int,Tuple{ApplyQuasiArray{Float64,2,Applied{Int,Tuple{Any,BandedMatrix{Int,Ones{Int,2,Tuple{OneTo{Int},OneTo{Int}}},OneTo{Int}}}}},Diagonal{Float64,Vector{Float64}},ApplyQuasiArray{Float64,2,Applied{Int,Tuple{Adjoint{Int,BandedMatrix{Int,Ones{Int,2,Tuple{OneTo{Int},OneTo{Int}}},OneTo{Int}}},QuasiAdjoint{Float64,Any}}}}}},_B} where _B where _A
 
 let A = typeintersect(HFPotential, T),
     B = typeintersect(T, HFPotential)
-    @test A == B == HFPotential{kind,Float64,Any,Applied{Int,Tuple{ApplyQuasiArray{Float64,2,Applied{Int,Tuple{Any,BandedMatrix{Int,Ones{Int,2,Tuple{OneTo{Int},OneTo{Int}}},OneTo{Int}}}}},Diagonal{Float64,Array{Float64,1}},ApplyQuasiArray{Float64,2,Applied{Int,Tuple{Adjoint{Int,BandedMatrix{Int,Ones{Int,2,Tuple{OneTo{Int},OneTo{Int}}},OneTo{Int}}},QuasiAdjoint{Float64,Any}}}}}},P} where P<:Integer where kind
+    @test A == B == HFPotential{kind,Float64,Any,Applied{Int,Tuple{ApplyQuasiArray{Float64,2,Applied{Int,Tuple{Any,BandedMatrix{Int,Ones{Int,2,Tuple{OneTo{Int},OneTo{Int}}},OneTo{Int}}}}},Diagonal{Float64,Vector{Float64}},ApplyQuasiArray{Float64,2,Applied{Int,Tuple{Adjoint{Int,BandedMatrix{Int,Ones{Int,2,Tuple{OneTo{Int},OneTo{Int}}},OneTo{Int}}},QuasiAdjoint{Float64,Any}}}}}},P} where P<:Integer where kind
 end
 end
 
@@ -1759,9 +1759,9 @@ end
 @testintersect(Tuple{Type{<:AbstractVector{T}}, Int} where T,
                Tuple{Type{Vector{T} where Int<:T<:Int}, Any},
                Tuple{Type{Vector{Int}}, Int})
-let X = LinearAlgebra.Symmetric{T, S} where S<:(AbstractArray{U, 2} where U<:T) where T,
-    Y = Union{LinearAlgebra.Hermitian{T, S} where S<:(AbstractArray{U, 2} where U<:T) where T,
-              LinearAlgebra.Symmetric{T, S} where S<:(AbstractArray{U, 2} where U<:T) where T}
+let X = LinearAlgebra.Symmetric{T, S} where S<:(AbstractMatrix{U} where U<:T) where T,
+    Y = Union{LinearAlgebra.Hermitian{T, S} where S<:(AbstractMatrix{U} where U<:T) where T,
+              LinearAlgebra.Symmetric{T, S} where S<:(AbstractMatrix{U} where U<:T) where T}
     @test X <: Y
 end
 
@@ -1799,9 +1799,9 @@ let T31805 = Tuple{Type{Tuple{}}, Tuple{Vararg{Int8, A}}} where A,
 end
 
 @testintersect(
-    Tuple{Array{Tuple{Vararg{Int64,N}},N},Tuple{Vararg{Array{Int64,1},N}}} where N,
-    Tuple{Array{Tuple{Int64},1}, Tuple},
-    Tuple{Array{Tuple{Int64},1},Tuple{Array{Int64,1}}})
+    Tuple{Array{Tuple{Vararg{Int64,N}},N},Tuple{Vararg{Vector{Int64},N}}} where N,
+    Tuple{Vector{Tuple{Int64}}, Tuple},
+    Tuple{Vector{Tuple{Int64}},Tuple{Vector{Int64}}})
 
 @test !isequal_type(Tuple{Int, Vararg{T, 3}} where T<:Real, Tuple{Int, Real, Vararg{T, 2}} where T<:Integer)
 
@@ -1857,7 +1857,7 @@ c32703(::Type{<:Str{C}}, str::Str{C}) where {C<:CSE} = str
 @test c32703(UTF16Str, ASCIIStr()) == 42
 @testintersect(Tuple{Vector{Vector{Float32}},Matrix,Matrix},
                Tuple{Vector{V},Matrix{Int},Matrix{S}} where {S, V<:AbstractVector{S}},
-               Tuple{Array{Array{Float32,1},1},Array{Int,2},Array{Float32,2}})
+               Tuple{Vector{Vector{Float32}},Matrix{Int},Matrix{Float32}})
 
 @testintersect(Tuple{Pair{Int, DataType}, Any},
                Tuple{Pair{A, B} where B<:Type, Int} where A,
@@ -1896,7 +1896,7 @@ s26065 = Ref{Tuple{T,Ref{Union{Ref{Tuple{Ref{Union{Ref{Ref{Tuple{Ref{Tuple{Union
       Val{Tuple{Missing, Vararg{Union{}}}} === Val{Tuple{Missing}}
 
 # issue #36869
-struct F36869{T, V} <: AbstractArray{Union{T, V}, 1}
+struct F36869{T, V} <: AbstractVector{Union{T, V}}
 end
 @testintersect(Tuple{Type{T}, AbstractVector{T}} where T,
                Tuple{Union, F36869{Int64, Missing}},
@@ -2019,9 +2019,9 @@ end
     Type{S} where {N, S<:(Base.IteratorsMD.CartesianIndices{N, B} where B<:Tuple{Vararg{Any, N}})})
 
 # issue #39948
-@testintersect(Tuple{Array{Pair{T, JT} where JT<:Ref{T}, 1} where T, Vector},
+@testintersect(Tuple{Vector{Pair{T, JT} where JT<:Ref{T}} where T, Vector},
     Tuple{Vararg{Vector{T}}} where T,
-    Tuple{Array{Pair{T, JT} where JT<:Ref{T}, 1}, Array{Pair{T, JT} where JT<:Ref{T}, 1}} where T)
+    Tuple{Vector{Pair{T, JT} where JT<:Ref{T}}, Vector{Pair{T, JT} where JT<:Ref{T}}} where T)
 
 # issue #8915
 struct D8915{T<:Union{Float32,Float64}}
@@ -2102,8 +2102,8 @@ end
                Bottom)
 
 # issue #42409
-@testintersect(Tuple{Type{Pair{_A, S} where S<:AbstractArray{<:_A, 2}}, Dict} where _A,
-               Tuple{Type{Pair{_A, S} where S<:AbstractArray{<:_A, 2}} where _A, Union{Array, Pair}},
+@testintersect(Tuple{Type{Pair{_A, S} where S<:AbstractMatrix{<:_A}}, Dict} where _A,
+               Tuple{Type{Pair{_A, S} where S<:AbstractMatrix{<:_A}} where _A, Union{Array, Pair}},
                Bottom)
 
 # https://github.com/JuliaLang/julia/issues/44735
@@ -2494,7 +2494,7 @@ abstract type P47654{A} end
     @test_broken !(A <: B)
 
     #issue 35698
-    @test_broken typeintersect(Type{Tuple{Array{T,1} where T}}, UnionAll) != Union{}
+    @test_broken typeintersect(Type{Tuple{Vector{T} where T}}, UnionAll) != Union{}
 
     #issue 33137
     @test (Tuple{Q,Int} where Q<:Int) <: Tuple{T,T} where T


### PR DESCRIPTION
Progress towards issue #56922 by @LilithHafner. Turns out I didn't find many uses of `Array{T, 1}` or `Array{T, 2}` in `doc` or `base` that were "clearly" in need of being updated to `Vector` or `Matrix`. 

There are a bunch that can't be changed because they occur before `Vector` or `Matrix` are even defined.

There are a couple borderline cases, and I may have overlooked some, but most I looked at felt like "I could change it to Vector or Matrix but I think there is a didactical point in using `Array` here. E.g. in the definition of `struct BitVector <: AbstractArray{Bool, 1}; end` I think the context makes it desirable to leave it at that instead of changing it to `Vector` -- but I admit this is subjective.

There was more in `test`, though that's perhaps less important.

All in all I think we could close #56922