### PR TITLE
Better order for stdlibs in the Julia manual navbar

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -228,6 +228,15 @@ BaseDocs = [
 
 StdlibDocs = [stdlib.targetfile for stdlib in STDLIB_DOCS]
 
+# HACK: get nicer sorting here, even though we don't have the header
+# of the .md files at hand.
+sort!(StdlibDocs, by=function(x)
+    x = replace(x, "stdlib/" => "")
+    startswith(x, "Libdl") && return lowercase("Dynamic Linker")
+    startswith(x, "Test") && return lowercase("Unit Testing")
+    return lowercase(x)
+end)
+
 DevDocs = [
     "Documentation of Julia's Internals" => [
         "devdocs/init.md",


### PR DESCRIPTION
Resolves #50351 albeit with a bit of a hack. 

Current:
<img width="153" height="191" alt="Screenshot 2025-11-17 at 14 51 36" src="https://github.com/user-attachments/assets/31148738-54b6-4d60-b3d0-d31232231797" />

With this patch:
<img width="159" height="190" alt="Screenshot 2025-11-17 at 14 52 11" src="https://github.com/user-attachments/assets/2223bb47-854f-4200-a22a-2645314cfe9c" />


I deliberately left "The Julia REPL" alone (so it is still sorted under "REPL") as that felt more natural to me compared to sorting it under "Julia" but obviously this could easily be changed as well.