### PR TITLE
Fix conversion from `K"meta"` to `Expr`

### DIFF
--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -538,14 +538,6 @@ end
 # the middle of a pass.
 const CompileHints = Base.ImmutableDict{Symbol,Any}
 
-function CompileHints(d::Dict{Symbol, Any})
-    id = CompileHints()
-    for (k, v) in d
-        id = CompileHints(id, k, v)
-    end
-    id
-end
-
 function setmeta!(ex::SyntaxTree; kws...)
     @assert length(kws) == 1 # todo relax later ?
     key = first(keys(kws))

--- a/JuliaLowering/src/kinds.jl
+++ b/JuliaLowering/src/kinds.jl
@@ -21,8 +21,6 @@ function _register_kinds()
             "Symbol"
             # QuoteNode; not quasiquote
             "inert"
-            # Compiler metadata hints
-            "meta"
             # TODO: Use `meta` for inbounds and loopinfo etc?
             "inbounds"
             "boundscheck"

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -1103,8 +1103,12 @@ function compile_lambda(outer_ctx, ex)
         slot_rewrites[id] = i
     end
     code = renumber_body(ctx, ctx.code, slot_rewrites)
+    meta = CompileHints()
+    for (k, v) in ctx.meta
+        meta = CompileHints(meta, k, v)
+    end
     @ast ctx ex [K"code_info"(is_toplevel_thunk=ex.is_toplevel_thunk,
-                              slots=slots, meta=CompileHints(ctx.meta))
+                              slots=slots, meta=meta)
         [K"block"(ex[3])
             code...
         ]

--- a/JuliaLowering/test/hooks.jl
+++ b/JuliaLowering/test/hooks.jl
@@ -24,45 +24,44 @@ const JL = JuliaLowering
         @test Core.eval(test_mod, lwr) === 2
     end
 
-    if isdefined(Core, :_lower)
-        function jeval(str)
-            prog = parseall(Expr, str)
-            local out
-            try
-                JL.activate!()
-                out = Core.eval(test_mod, prog)
-            finally
-                JL.activate!(false)
-            end
+    function jeval(str)
+        prog = parseall(Expr, str)
+        local out
+        try
+            JL.activate!()
+            out = Core.eval(test_mod, prog)
+        finally
+            JL.activate!(false)
         end
-        @testset "integration: `JuliaLowering.activate!`" begin
-            out = jeval("global asdf = 1")
-            @test out === 1
-            @test isdefined(test_mod, :asdf)
+    end
+    @testset "integration: `JuliaLowering.activate!`" begin
+        out = jeval("global asdf = 1")
+        @test out === 1
+        @test isdefined(test_mod, :asdf)
 
-            out = jeval("module M; x = 1; end")
-            @test out isa Module
-            @test isdefined(test_mod, :M)
-            @test isdefined(test_mod.M, :x)
+        out = jeval("module M; x = 1; end")
+        @test out isa Module
+        @test isdefined(test_mod, :M)
+        @test isdefined(test_mod.M, :x)
 
-            # Tricky cases with symbols
-            out = jeval("""module M2
+        # Tricky cases with symbols
+        out = jeval("""module M2
                 Base.@constprop :aggressive function f(x); x; end
                 const what = ccall(:jl_value_ptr, Ptr{Cvoid}, (Any,), Core.nothing)
             end""")
-            @test out isa Module
-            @test isdefined(test_mod, :M2)
-            @test isdefined(test_mod.M2, :f)
-            @test isdefined(test_mod.M2, :what)
+        @test out isa Module
+        @test isdefined(test_mod, :M2)
+        @test isdefined(test_mod.M2, :f)
+        @test isdefined(test_mod.M2, :what)
 
-            out = jeval(""" "docstring" module M3 end """)
-            @test out isa Module
-            @test isdefined(test_mod, :M3)
+        out = jeval(""" "docstring" module M3 end """)
+        @test out isa Module
+        @test isdefined(test_mod, :M3)
 
-            # Macros may produce toplevel expressions.  Note that julia handles
-            # this case badly (macro expansion replaces M5_inner with a
-            # globalref) and we handle esc(:M5_inner) badly
-            out = jeval("""module M5
+        # Macros may produce toplevel expressions.  Note that julia handles
+        # this case badly (macro expansion replaces M5_inner with a
+        # globalref) and we handle esc(:M5_inner) badly
+        out = jeval("""module M5
             macro newmod()
                 return quote
                     let a = 1
@@ -74,13 +73,11 @@ const JL = JuliaLowering
             end
             @newmod()
             end""")
-            @test out isa Module
-            @test isdefined(test_mod, :M5)
-            @test isdefined(test_mod.M5, :M5_inner)
-            @test isdefined(test_mod.M5.M5_inner, :asdf)
+        @test out isa Module
+        @test isdefined(test_mod, :M5)
+        @test isdefined(test_mod.M5, :M5_inner)
+        @test isdefined(test_mod.M5.M5_inner, :asdf)
 
-            # TODO: broken, commented to prevent error logging
-            # @test jeval("Base.@propagate_inbounds @inline meta_double_quote_issue(x) = x") isa Function
-        end
+        @test jeval("Base.@propagate_inbounds @inline meta_double_quote_issue(x) = x") isa Function
     end
 end

--- a/JuliaSyntax/src/integration/expr.jl
+++ b/JuliaSyntax/src/integration/expr.jl
@@ -634,6 +634,13 @@ end
                 args[i] = Symbol(".", arg.args[1])
             end
         end
+    elseif k == K"meta"
+        # Expr uses plain identifiers, but JuliaSyntax uses quoted (Symbol) identifiers
+        for (i, a) in enumerate(args)
+            if a isa QuoteNode && a.value isa Symbol
+                args[i] = a.value
+            end
+        end
     end
 
     return retexpr

--- a/JuliaSyntax/src/julia/kinds.jl
+++ b/JuliaSyntax/src/julia/kinds.jl
@@ -1032,6 +1032,7 @@ register_kinds!(JuliaSyntax, 0, [
         "vect"
         "parens"
         "importpath"
+        "meta"
         # Concatenation syntax
         "braces"
         "bracescat"


### PR DESCRIPTION
A small tweak: JuliaLowering uses quoted symbols in meta forms, where Expr does not.  

Miscellaneous test fixes are also included (`CompileHints` was overwriting a constructor, and `isdefined(Core, :_lower)` isn't so necessary in this repository)

