### PR TITLE
Fix linearly indexed array math by reshaping arrays

### DIFF
--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -2,40 +2,10 @@
 
 ## Binary arithmetic operators ##
 
-function _broadcast_preserving_zero_d(f, A, B)
-    broadcast_preserving_zero_d(f, A, B)
-end
-
-# Using map over broadcast enables vectorization for wide matrices with few rows.
-# This is because we use linear indexing in `map` as opposed to Cartesian indexing in broadcasting.
-# https://github.com/JuliaLang/julia/issues/47873#issuecomment-1352472461
-function _broadcast_preserving_zero_d(f, A::Array{<:Any,N}, B::Array{<:Any,N}, Cs::Array{<:Any,N}...) where {N}
-    map(f, A, B, Cs...)
-end
-
-function _broadcast_preserving_zero_d(f, A::Array, B::Array, Cs::Array...)
-    # we already know that the shapes are compatible.
-    # We just need to select the size corresponding to the higest ndims
-    # and reshape all the arrays to that size
-    arrays = (A, B, Cs...)
-    sz = mapreduce(size, (x,y) -> length(x) > length(y) ? x : y, arrays)
-    # Skip reshaping where possible to avoid the overhead
-    arrays_sameshape = map(x -> length(sz) == ndims(x) ? x : reshape(x, sz), arrays)
-    map(f, arrays_sameshape...)
-end
-
-function _broadcast_preserving_zero_d(f, A::Array, B::Number)
-    map(Fix2(f, B), A)
-end
-
-function _broadcast_preserving_zero_d(f, A::Number, B::Array)
-    map(Fix1(f, A), B)
-end
-
 for f in (:+, :-)
     @eval function ($f)(A::AbstractArray, B::AbstractArray)
         promote_shape(A, B) # check size compatibility
-        _broadcast_preserving_zero_d($f, A, B)
+        broadcast_preserving_zero_d($f, A, B)
     end
 end
 
@@ -44,15 +14,15 @@ function +(A::Array, B::Array, Cs::Array...)
     for C in Cs
         promote_shape(A, C) # check size compatibility
     end
-    _broadcast_preserving_zero_d(+, A, B, Cs...)
+    broadcast_preserving_zero_d(+, A, B, Cs...)
 end
 
 for f in (:/, :\, :*)
     if f !== :/
-        @eval ($f)(A::Number, B::AbstractArray) = _broadcast_preserving_zero_d($f, A, B)
+        @eval ($f)(A::Number, B::AbstractArray) = broadcast_preserving_zero_d($f, A, B)
     end
     if f !== :\
-        @eval ($f)(A::AbstractArray, B::Number) = _broadcast_preserving_zero_d($f, A, B)
+        @eval ($f)(A::AbstractArray, B::Number) = broadcast_preserving_zero_d($f, A, B)
     end
 end
 

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -2,10 +2,40 @@
 
 ## Binary arithmetic operators ##
 
+function _broadcast_preserving_zero_d(f, A, B)
+    broadcast_preserving_zero_d(f, A, B)
+end
+
+# Using map over broadcast enables vectorization for wide matrices with few rows.
+# This is because we use linear indexing in `map` as opposed to Cartesian indexing in broadcasting.
+# https://github.com/JuliaLang/julia/issues/47873#issuecomment-1352472461
+function _broadcast_preserving_zero_d(f, A::Array{<:Any,N}, B::Array{<:Any,N}, Cs::Array{<:Any,N}...) where {N}
+    map(f, A, B, Cs...)
+end
+
+function _broadcast_preserving_zero_d(f, A::Array, B::Array, Cs::Array...)
+    # we already know that the shapes are compatible.
+    # We just need to select the size corresponding to the higest ndims
+    # and reshape all the arrays to that size
+    arrays = (A, B, Cs...)
+    sz = mapreduce(size, (x,y) -> length(x) > length(y) ? x : y, arrays)
+    # Skip reshaping where possible to avoid the overhead
+    arrays_sameshape = map(x -> length(sz) == ndims(x) ? x : reshape(x, sz), arrays)
+    map(f, arrays_sameshape...)
+end
+
+function _broadcast_preserving_zero_d(f, A::Array, B::Number)
+    map(Fix2(f, B), A)
+end
+
+function _broadcast_preserving_zero_d(f, A::Number, B::Array)
+    map(Fix1(f, A), B)
+end
+
 for f in (:+, :-)
     @eval function ($f)(A::AbstractArray, B::AbstractArray)
         promote_shape(A, B) # check size compatibility
-        broadcast_preserving_zero_d($f, A, B)
+        _broadcast_preserving_zero_d($f, A, B)
     end
 end
 
@@ -14,15 +44,15 @@ function +(A::Array, B::Array, Cs::Array...)
     for C in Cs
         promote_shape(A, C) # check size compatibility
     end
-    broadcast_preserving_zero_d(+, A, B, Cs...)
+    _broadcast_preserving_zero_d(+, A, B, Cs...)
 end
 
 for f in (:/, :\, :*)
     if f !== :/
-        @eval ($f)(A::Number, B::AbstractArray) = broadcast_preserving_zero_d($f, A, B)
+        @eval ($f)(A::Number, B::AbstractArray) = _broadcast_preserving_zero_d($f, A, B)
     end
     if f !== :\
-        @eval ($f)(A::AbstractArray, B::Number) = broadcast_preserving_zero_d($f, A, B)
+        @eval ($f)(A::AbstractArray, B::Number) = _broadcast_preserving_zero_d($f, A, B)
     end
 end
 

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -9,8 +9,8 @@ end
 # Using map over broadcast enables vectorization for wide matrices with few rows.
 # This is because we use linear indexing in `map` as opposed to Cartesian indexing in broadcasting.
 # https://github.com/JuliaLang/julia/issues/47873#issuecomment-1352472461
-function _broadcast_preserving_zero_d(f, A::Array, B::Array)
-    map(f, A, B)
+function _broadcast_preserving_zero_d(f, A::Array{<:Any,N}, Bs::Array{<:Any,N}...) where {N}
+    map(f, A, Bs...)
 end
 
 function _broadcast_preserving_zero_d(f, A::Array, B::Number)
@@ -32,7 +32,7 @@ function +(A::Array, Bs::Array...)
     for B in Bs
         promote_shape(A, B) # check size compatibility
     end
-    map(+, A, Bs...)
+    _broadcast_preserving_zero_d(+, A, Bs...)
 end
 
 for f in (:/, :\, :*)

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -13,6 +13,16 @@ function _broadcast_preserving_zero_d(f, A::Array{<:Any,N}, Bs::Array{<:Any,N}..
     map(f, A, Bs...)
 end
 
+function _broadcast_preserving_zero_d(f, A::Array, Bs::Array...) where {N}
+    # we already know that the shapes are compatible.
+    # We just need to select the size corresponding to the higest ndims
+    # and reshape all the arrays to that size
+    sz = mapreduce(size, (x,y) -> length(x) > length(y) ? x : y, (A, Bs...))
+    # Skip reshaping where possible to avoid the overhead
+    As_sameshape = map(x -> length(sz) == ndims(x) ? x : reshape(x, sz), (A, Bs...))
+    map(f, As_sameshape...)
+end
+
 function _broadcast_preserving_zero_d(f, A::Array, B::Number)
     map(Fix2(f, B), A)
 end

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -39,11 +39,12 @@ for f in (:+, :-)
     end
 end
 
-function +(A::Array, Bs::Array...)
-    for B in Bs
-        promote_shape(A, B) # check size compatibility
+function +(A::Array, B::Array, Cs::Array...)
+    promote_shape(A, B)
+    for C in Cs
+        promote_shape(A, C) # check size compatibility
     end
-    _broadcast_preserving_zero_d(+, A, Bs...)
+    _broadcast_preserving_zero_d(+, A, B, Cs...)
 end
 
 for f in (:/, :\, :*)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -885,6 +885,33 @@ end
 @inline broadcast_preserving_zero_d(f) = fill(f())
 @inline broadcast_preserving_zero_d(f, as::Number...) = fill(f(as...))
 
+# Using map over broadcast enables vectorization for wide matrices with few rows.
+# This is because we use linear indexing in `map` as opposed to Cartesian indexing in broadcasting.
+# https://github.com/JuliaLang/julia/issues/47873#issuecomment-1352472461
+function broadcast_preserving_zero_d(f, A::Array{<:Any,N}, Bs::Array{<:Any,N}...) where {N}
+    map(f, A, Bs...)
+end
+
+function broadcast_preserving_zero_d(f, A::Array, B::Array, Cs::Array...)
+    # we already know that the shapes are compatible.
+    # We just need to select the size corresponding to the higest ndims
+    # and reshape all the arrays to that size
+    arrays = (A, B, Cs...)
+    sz = mapreduce(size, (x,y) -> length(x) > length(y) ? x : y, arrays)
+    # Skip reshaping where possible to avoid the overhead
+    arrays_sameshape = map(x -> length(sz) == ndims(x) ? x : reshape(x, sz), arrays)
+    map(f, arrays_sameshape...)
+end
+
+function broadcast_preserving_zero_d(f, A::Array, B::Number)
+    map(Base.Fix2(f, B), A)
+end
+
+function broadcast_preserving_zero_d(f, A::Number, B::Array)
+    map(Base.Fix1(f, A), B)
+end
+
+
 """
     Broadcast.materialize(bc)
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2378,8 +2378,9 @@ end
 end
 
 @testset "size promotion in addition/subtraction" begin
-    A = ones(1)
-    B = ones(1,1)
-    @test A + B == fill(2.0,1,1)
-    @test A - B == zeros(1,1)
+    for A in Any[ones(), ones(1), ones(1,1,1)], B in Any[ones(), ones(1), ones(1,1,1)]
+        sz = ndims(A) > ndims(B) ? size(A) : size(B)
+        @test A + B == fill(2.0,sz)
+        @test A - B == zeros(sz)
+    end
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2378,11 +2378,14 @@ end
 end
 
 @testset "size promotion in addition/subtraction" begin
-    for A in Any[ones(), ones(1), ones(1,1,1)], B in Any[ones(), ones(1), ones(1,1,1)]
-        sz = ndims(A) > ndims(B) ? size(A) : size(B)
-        @test A + B == fill(2.0,sz)
-        @test A - B == zeros(sz)
-        @test A + B + zeros() == A + B
-        @test A - B - zeros() == A - B
+    for A in Any[ones(), ones(1), ones(1,1,1)]
+        @test +(A) == A
+        for B in Any[ones(), ones(1), ones(1,1,1)]
+            sz = ndims(A) > ndims(B) ? size(A) : size(B)
+            @test A + B == fill(2.0,sz)
+            @test A - B == zeros(sz)
+            @test A + B + zeros() == A + B
+            @test A - B - zeros() == A - B
+        end
     end
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2376,3 +2376,10 @@ end
     show(io, m2)
     @test String(take!(io)) == "Any[#= circular reference @-1 =# 3; 2 4;;; 5 7; 6 8]"
 end
+
+@testset "size promotion in addition/subtraction" begin
+    A = ones(1)
+    B = ones(1,1)
+    @test A + B == fill(2.0,1,1)
+    @test A - B == zeros(1,1)
+end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2382,5 +2382,7 @@ end
         sz = ndims(A) > ndims(B) ? size(A) : size(B)
         @test A + B == fill(2.0,sz)
         @test A - B == zeros(sz)
+        @test A + B + zeros() == A + B
+        @test A - B - zeros() == A - B
     end
 end


### PR DESCRIPTION
This was broken in https://github.com/JuliaLang/julia/pull/59961, as `map` deals with trailing singleton axes differently from broadcasting:
```julia
julia> map(+, ones(1), ones(1,1)) |> size
(1,)

julia> broadcast(+, ones(1), ones(1,1)) |> size
(1, 1)
```
This PR limits the new method to the case where the ndims match, in which case there are no trailing axes and the two are equivalent. The alternate approach suggested in https://github.com/JuliaLang/julia/pull/59961#issuecomment-3543230569 is to reshape the arrays, but this adds overhead that nullifies the performance improvement for small arrays.