### PR TITLE
Short-circuit `reshape` for `Array` if the result has the same shape

### DIFF
--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -45,6 +45,7 @@ eltype(::Type{<:ReshapedArrayIterator{I}}) where {I} = @isdefined(I) ? ReshapedI
     if len != length(a)
         throw_dmrsa(dims, length(a))
     end
+    size(a) == dims && return a
     ref = a.ref
     # or we could use `a = Array{T,N}(undef, ntuple(i->0, Val(N))); a.ref = ref; a.size = dims; return a` here to avoid the eval
     return $(Expr(:new, :(Array{T,N}), :ref, :dims))


### PR DESCRIPTION
This avoids allocating an extra `Array` if the reshape is a no-op.
```julia
julia> a = ones(2,2);

julia> @btime reshape($a, size($a));
  9.793 ns (1 allocation: 48 bytes)
```
this PR:
```julia
julia> a = ones(2,2);

julia> @btime reshape($a, size($a));
  4.534 ns (0 allocations: 0 bytes)
```