### PR TITLE
[JuliaLowering] get macro name in `ctx.world`; fix lowering iterator

### DIFF
--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -33,55 +33,42 @@ end
 # how we end up putting this into Base.
 
 struct LoweringIterator{GraphType}
-    ctx::MacroExpansionContext{GraphType}
+    expr_compat_mode::Bool # later stored in module?
     todo::Vector{Tuple{SyntaxTree{GraphType}, Bool, Int}}
 end
 
-function lower_init(ex::SyntaxTree, mod::Module, macro_world::UInt; expr_compat_mode::Bool=false)
-    graph = ensure_macro_attributes(syntax_graph(ex))
-    ctx = MacroExpansionContext(graph, mod, expr_compat_mode, macro_world)
-    ex = reparent(ctx, ex)
-    LoweringIterator{typeof(graph)}(ctx, [(ex, false, 0)])
+function lower_init(ex::SyntaxTree{T};
+                    expr_compat_mode::Bool=false) where {T}
+    LoweringIterator{T}(expr_compat_mode, [(ex, false, 0)])
 end
 
-function lower_step(iter, world=Base.get_world_counter(), push_mod=nothing)
-    if !isnothing(push_mod)
-        push_layer!(iter.ctx, push_mod, false)
-    end
-
+function lower_step(iter, mod, world=Base.get_world_counter())
     if isempty(iter.todo)
         return Core.svec(:done)
     end
 
-    ex, is_module_body, child_idx = pop!(iter.todo)
+    top_ex, is_module_body, child_idx = pop!(iter.todo)
     if child_idx > 0
-        next_child = child_idx + 1
-        if child_idx <= numchildren(ex)
-            push!(iter.todo, (ex, is_module_body, next_child))
-            ex = ex[child_idx]
+        if child_idx <= numchildren(top_ex)
+            push!(iter.todo, (top_ex, is_module_body, child_idx + 1))
+            ex = top_ex[child_idx]
+        elseif is_module_body
+            return Core.svec(:end_module)
         else
-            if is_module_body
-                pop_layer!(iter.ctx)
-                return Core.svec(:end_module)
-            else
-                return lower_step(iter)
-            end
+            return lower_step(iter, mod)
         end
+    else
+        ex = top_ex
     end
 
     k = kind(ex)
     if !(k in KSet"toplevel module")
-        ctx1 = let c = iter.ctx
-            MacroExpansionContext(
-                c.graph, c.bindings, c.scope_layers, c.scope_layer_stack,
-                c.expr_compat_mode, world)
-        end
-        ex = expand_forms_1(ctx1, ex)
+        ctx1, ex = expand_forms_1(mod, ex, iter.expr_compat_mode, world)
         k = kind(ex)
     end
     if k == K"toplevel"
         push!(iter.todo, (ex, false, 1))
-        return lower_step(iter)
+        return lower_step(iter, mod)
     elseif k == K"module"
         name = ex[1]
         if kind(name) != K"Identifier"
@@ -383,7 +370,7 @@ function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
             ir
         end
     elseif k == K"Value"
-        ex.value isa LineNumberNode ? QuoteNode(ex.value) : ex.value
+        ex.value
     elseif k == K"goto"
         Core.GotoNode(ex[1].id + stmt_offset)
     elseif k == K"gotoifnot"
@@ -462,7 +449,7 @@ end
 @fzone "JL: eval" function eval(mod::Module, ex::SyntaxTree;
                                 macro_world::UInt=Base.get_world_counter(),
                                 opts...)
-    iter = lower_init(ex, mod, macro_world; opts...)
+    iter = lower_init(ex; opts...)
     _eval(mod, iter)
 end
 
@@ -471,67 +458,30 @@ function eval(mod::Module, ex; opts...)
     eval(mod, expr_to_syntaxtree(ex); opts...)
 end
 
-if VERSION >= v"1.13.0-DEV.1199" # https://github.com/JuliaLang/julia/pull/59604
-
 function _eval(mod, iter)
-    modules = Module[]
-    new_mod = nothing
+    modules = Module[mod]
     result = nothing
     while true
-        thunk = lower_step(iter, Base.get_world_counter(), new_mod)::Core.SimpleVector
-        new_mod = nothing
+        thunk = lower_step(iter, modules[end])::Core.SimpleVector
         type = thunk[1]::Symbol
         if type == :done
             break
         elseif type == :begin_module
-            push!(modules, mod)
             filename = something(thunk[4].file, :none)
-            mod = @ccall jl_begin_new_module(mod::Any, thunk[2]::Symbol, thunk[3]::Cint,
-                                             filename::Cstring, thunk[4].line::Cint)::Module
-            new_mod = mod
+            mod = @ccall jl_begin_new_module(
+                modules[end]::Any, thunk[2]::Symbol, thunk[3]::Cint,
+                filename::Cstring, thunk[4].line::Cint)::Module
+            push!(modules, mod)
         elseif type == :end_module
-            @ccall jl_end_new_module(mod::Module)::Cvoid
-            result = mod
-            mod = pop!(modules)
+            @ccall jl_end_new_module(modules[end]::Module)::Cvoid
+            result = pop!(modules)
         else
             @assert type == :thunk
-            result = Core.eval(mod, thunk[2])
+            result = Core.eval(modules[end], thunk[2])
         end
     end
-    @assert isempty(modules)
+    @assert length(modules) === 1
     return result
-end
-
-else
-
-function _eval(mod, iter, new_mod=nothing)
-    in_new_mod = !isnothing(new_mod)
-    result = nothing
-    while true
-        thunk = lower_step(iter, Base.get_world_counter(), new_mod)::Core.SimpleVector
-        new_mod = nothing
-        type = thunk[1]::Symbol
-        if type == :done
-            @assert !in_new_mod
-            break
-        elseif type == :begin_module
-            name = thunk[2]::Symbol
-            std_defs = thunk[3]
-            result = Core.eval(mod,
-                Expr(:module, std_defs, name,
-                     Expr(:block, thunk[4], Expr(:call, m->_eval(m, iter, m), name)))
-            )
-        elseif type == :end_module
-            @assert in_new_mod
-            return mod
-        else
-            @assert type == :thunk
-            result = Core.eval(mod, thunk[2])
-        end
-    end
-    return result
-end
-
 end
 
 """

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -515,5 +515,27 @@ end
 """)
 code = JuliaLowering.include_string(test_mod, """Mod1.@indirect_MODULE()""")
 @test JuliaLowering.eval(test_mod, code) === test_mod # !== test_mod.Mod1
+# the lowering/eval iterator needs to expand in the correct world age (currently
+# the only way to hit this from user code is macros producing toplevel)
+
+@testset "macros defining macros" begin
+    @eval test_mod macro make_and_use_macro_toplevel()
+        Expr(:toplevel,
+             esc(:(macro from_toplevel_expansion()
+                   :(123)
+               end)),
+             esc(:(@from_toplevel_expansion())))
+    end
+
+    @test JuliaLowering.include_string(
+        test_mod, "@make_and_use_macro_toplevel()"; expr_compat_mode=true) === 123
+
+    if isdefined(test_mod, Symbol("@from_toplevel_expansion"))
+        Base.delete_binding(test_mod, Symbol("@from_toplevel_expansion"))
+    end
+
+    @test JuliaLowering.include_string(
+        test_mod, "@make_and_use_macro_toplevel()"; expr_compat_mode=false) === 123
+end
 
 end

--- a/JuliaLowering/test/macros_ir.jl
+++ b/JuliaLowering/test/macros_ir.jl
@@ -147,7 +147,7 @@ _never_exist = @m_not_exist 42
 #---------------------
 MacroExpansionError while expanding @m_not_exist in module Main.TestMod:
 _never_exist = @m_not_exist 42
-#              └──────────┘ ── Macro not found
+#               └─────────┘ ── Macro not found
 Caused by:
 UndefVarError: `@m_not_exist` not defined in `Main.TestMod`
 Suggestion: check for spelling errors or missing imports.


### PR DESCRIPTION
Evaluating a macro's name should be done in the same world we pass into lowering and use for expansion.  Fix this for all reasonable macro names.

The lowering iterator (currently very cold code only used for module/toplevel expressions that JuliaLowering "controls") also needs to update the expansion world between steps.