### PR TITLE
Disable the Profile test for the Windows SuspendThread deadlock

### DIFF
--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -283,7 +283,7 @@ let cmd = Base.julia_cmd()
 end
 
 # Thread suspend deadlock - run many times (#60042)
-let cmd = Base.julia_cmd()
+@test_skip let cmd = Base.julia_cmd()
     script = """
         using Profile
         @profile println("done")
@@ -293,7 +293,7 @@ let cmd = Base.julia_cmd()
         s = run_with_watchdog(`$cmd -t2 -e $script`, 5)
         good &= occursin("done", s)
     end
-    @test good
+    good
 end
 
 if Sys.isbsd() || Sys.islinux()


### PR DESCRIPTION
This test was supposed to catch the bug that caused #60042, but triggering the bug requires launching many Julia subprocesses and may take too long to run on CI.  This change disables it instead of trying to guess a timeout that wont fail.