### PR TITLE
Restoring OpenSSL executable

### DIFF
--- a/deps/openssl.mk
+++ b/deps/openssl.mk
@@ -72,10 +72,16 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 
-# Override bindir and only install runtime libraries, otherwise they'll go into build_depsbindir.
+# # Override bindir and only install runtime libraries, otherwise they'll go into build_depsbindir.
+# OPENSSL_INSTALL = \
+# 	mkdir -p $2$$(build_shlibdir) && \
+# 	$$(MAKE) -C $1 install_dev $$(MAKE_COMMON) bindir=$$(build_shlibdir) $3 DESTDIR="$2"
+
 OPENSSL_INSTALL = \
 	mkdir -p $2$$(build_shlibdir) && \
-	$$(MAKE) -C $1 install_dev $$(MAKE_COMMON) bindir=$$(build_shlibdir) $3 DESTDIR="$2"
+	mkdir -p $2$$(build_bindir) && \
+	$$(MAKE) -C $1 install_dev $$(MAKE_COMMON) bindir=$$(build_shlibdir) $3 DESTDIR="$2" && \
+	cp -a $1/apps/openssl$(EXE) $2$$(build_bindir)/openssl$(EXE)
 
 OPENSSL_POST_INSTALL := \
 	$(WIN_MAKE_HARD_LINK) $(build_bindir)/libcrypto-*.dll $(build_bindir)/libcrypto.dll && \


### PR DESCRIPTION
Starting with Julia 1.12, OpenSSL_jll became part of the standard library; it is no longer possible to access the `openssl` executable, as it is not bundled. 

One approach to resolving the issue would be to create a separate OpenSSL_CLI_jll see https://github.com/JuliaPackaging/Yggdrasil/pull/12452 ; however, it has maintainability drawbacks as one may need to keep the JLL in sync with OpenSSL version. Another significant issue is that it is not possible to build `openssl` executable separately with the boundaries of the present OpenSSL build system, and hence, to avoid horrendous build times, it makes sense to repackage the already built executable within openssl.  

Perhaps a more straightforward, more maintainable approach is to restore the `openssl` executable within Julia itself. In this PR, I have done just that. 