### PR TITLE
release-1.13: Disable the Profile test for the Windows SuspendThread deadlock (#60175)

### DIFF
--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -283,7 +283,7 @@ let cmd = Base.julia_cmd()
 end
 
 # Thread suspend deadlock - run many times (#60042)
-let cmd = Base.julia_cmd()
+@test_skip let cmd = Base.julia_cmd()
     script = """
         using Profile
         @profile println("done")
@@ -293,7 +293,7 @@ let cmd = Base.julia_cmd()
         s = run_with_watchdog(`$cmd -t2 -e $script`, 5)
         good &= occursin("done", s)
     end
-    @test good
+    good
 end
 
 if Sys.isbsd() || Sys.islinux()


### PR DESCRIPTION
(cherry picked from commit eba48a25058a39c7f42c1a5fd3f04179ccacb3ec)