### PR TITLE
Use unsigned integers for debuginfo address differences/slide

### DIFF
--- a/src/debug-registry.h
+++ b/src/debug-registry.h
@@ -11,7 +11,7 @@
 typedef struct {
     const llvm::object::ObjectFile *obj;
     llvm::DIContext *ctx;
-    int64_t slide;
+    uint64_t slide;
     std::map<uintptr_t, StringRef, std::greater<size_t>> *symbolmap;
 } jl_object_file_entry_t;
 
@@ -112,7 +112,7 @@ private:
     struct SectionInfo {
         LazyObjectInfo *object;
         size_t SectionSize;
-        ptrdiff_t slide;
+        uint64_t slide;
         uint64_t SectionIndex;
         SectionInfo() = delete;
         ~SectionInfo() JL_NOTSAFEPOINT = default;

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -395,7 +395,7 @@ void JITDebugInfoRegistry::registerJITObject(const object::ObjectFile &Object,
             objectmap.insert(std::pair{SectionLoadAddr, SectionInfo{
                 ObjectCopy,
                 (size_t)SectionSize,
-                (ptrdiff_t)(SectionAddr - SectionLoadAddr),
+                SectionAddr - SectionLoadAddr,
                 Section->getIndex()
                 }});
         });
@@ -448,7 +448,7 @@ done:
 // func_name and file_name are either NULL or malloc'd pointers
 static int lookup_pointer(
         object::SectionRef Section, DIContext *context,
-        jl_frame_t **frames, size_t pointer, int64_t slide,
+        jl_frame_t **frames, size_t pointer, uint64_t slide,
         bool demangle, bool noInline) JL_NOTSAFEPOINT
 {
     // This function is not allowed to reference any TLS variables
@@ -719,7 +719,7 @@ static inline void ignoreError(T &err) JL_NOTSAFEPOINT
 }
 
 static void get_function_name_and_base(llvm::object::SectionRef Section, std::map<uintptr_t, StringRef, std::greater<size_t>> *symbolmap,
-                                       size_t pointer, int64_t slide, bool inimage,
+                                       size_t pointer, uint64_t slide, bool inimage,
                                        void **saddr, char **name, bool untrusted_dladdr) JL_NOTSAFEPOINT
 {
     bool needs_saddr = saddr && (!*saddr || untrusted_dladdr);
@@ -1011,14 +1011,14 @@ static jl_object_file_entry_t find_object_file(uint64_t fbase, StringRef fname) 
             }
         }
 
-        int64_t slide = 0;
+        uint64_t slide = 0;
         if (auto *OF = dyn_cast<const object::COFFObjectFile>(debugobj)) {
             if (!iswindows) // the COFF parser accepts some garbage inputs (like empty files) that the other parsers correctly reject, so we can end up here even when we should not
                 return entry;
             slide = OF->getImageBase() - fbase;
         }
         else {
-            slide = -(int64_t)fbase;
+            slide = -fbase;
         }
 
         auto context = DWARFContext::create(*debugobj).release();
@@ -1051,7 +1051,7 @@ static object::SectionRef getModuleSectionForAddress(const object::ObjectFile *o
 }
 
 
-bool jl_dylib_DI_for_fptr(size_t pointer, object::SectionRef *Section, int64_t *slide, llvm::DIContext **context,
+bool jl_dylib_DI_for_fptr(size_t pointer, object::SectionRef *Section, uint64_t *slide, llvm::DIContext **context,
     bool onlyImage, bool *isImage, uint64_t *_fbase, void **saddr, char **name, char **filename) JL_NOTSAFEPOINT
 {
     *Section = object::SectionRef();
@@ -1190,7 +1190,7 @@ static int jl_getDylibFunctionInfo(jl_frame_t **frames, size_t pointer, int skip
 #endif
     object::SectionRef Section;
     llvm::DIContext *context = NULL;
-    int64_t slide;
+    uint64_t slide;
     bool isImage;
     void *saddr;
     uint64_t fbase;
@@ -1222,7 +1222,7 @@ static int jl_getDylibFunctionInfo(jl_frame_t **frames, size_t pointer, int skip
     return lookup_pointer(Section, context, frames, pointer, slide, isImage, noInline);
 }
 
-int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, int64_t *slide,
+int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, uint64_t *slide,
         object::SectionRef *Section, llvm::DIContext **context) JL_NOTSAFEPOINT
 {
     int found = 0;
@@ -1283,7 +1283,7 @@ extern "C" JL_DLLEXPORT_CODEGEN int jl_getFunctionInfo_impl(jl_frame_t **frames_
 
     llvm::DIContext *context = nullptr;
     object::SectionRef Section;
-    int64_t slide;
+    uint64_t slide;
     uint64_t symsize;
     if (jl_DI_for_fptr(pointer, &symsize, &slide, &Section, &context)) {
         frames[0].ci = getJITDebugRegistry().lookupCodeInstance(pointer);

--- a/src/debuginfo.h
+++ b/src/debuginfo.h
@@ -3,10 +3,10 @@
 // Declarations for debuginfo.cpp
 void jl_jit_add_bytes(size_t bytes) JL_NOTSAFEPOINT;
 
-int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, int64_t *slide,
+int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, uint64_t *slide,
         llvm::object::SectionRef *Section, llvm::DIContext **context) JL_NOTSAFEPOINT;
 
-bool jl_dylib_DI_for_fptr(size_t pointer, llvm::object::SectionRef *Section, int64_t *slide, llvm::DIContext **context,
+bool jl_dylib_DI_for_fptr(size_t pointer, llvm::object::SectionRef *Section, uint64_t *slide, llvm::DIContext **context,
     bool onlyImage, bool *isImage, uint64_t* fbase, void **saddr, char **name, char **filename) JL_NOTSAFEPOINT;
 
 static object::SectionedAddress makeAddress(

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -543,7 +543,7 @@ jl_value_t *jl_dump_function_ir_impl(jl_llvmf_dump_t *dump, char strip_ir_metada
 }
 
 static void jl_dump_asm_internal(
-        uintptr_t Fptr, size_t Fsize, int64_t slide,
+        uintptr_t Fptr, size_t Fsize, uint64_t slide,
         object::SectionRef Section,
         DIContext *di_ctx,
         raw_ostream &rstream,
@@ -593,7 +593,7 @@ jl_value_t *jl_dump_fptr_asm_impl(uint64_t fptr, char emit_mc, const char* asm_v
 
     // Find debug info (line numbers) to print alongside
     object::SectionRef Section;
-    int64_t slide = 0;
+    uint64_t slide = 0;
     uint64_t symsize = 0;
     llvm::DIContext *context = NULL;
     if (!jl_DI_for_fptr(fptr, &symsize, &slide, &Section, &context)) {
@@ -646,9 +646,9 @@ class SymbolTable {
     int Pass;
     const object::ObjectFile *object;
     uint64_t ip; // virtual instruction pointer of the current instruction
-    int64_t slide;
+    uint64_t slide;
 public:
-    SymbolTable(MCContext &Ctx, const object::ObjectFile *object, int64_t slide, const FuncMCView &MemObj) JL_NOTSAFEPOINT
+    SymbolTable(MCContext &Ctx, const object::ObjectFile *object, uint64_t slide, const FuncMCView &MemObj) JL_NOTSAFEPOINT
         : Ctx(Ctx), MemObj(MemObj), object(object), ip(0), slide(slide) {}
     ~SymbolTable() JL_NOTSAFEPOINT = default;
     const FuncMCView &getMemoryObject() const JL_NOTSAFEPOINT { return MemObj; }
@@ -851,7 +851,7 @@ std::string rawCodeComment(const llvm::ArrayRef<uint8_t>& Memory, const llvm::Tr
 }
 
 static void jl_dump_asm_internal(
-        uintptr_t Fptr, size_t Fsize, int64_t slide,
+        uintptr_t Fptr, size_t Fsize, uint64_t slide,
         object::SectionRef Section,
         DIContext *di_ctx,
         raw_ostream &rstream,


### PR DESCRIPTION
Replace all uses of `ptrdiff_t slide` and `int64_t slide` with `uint64_t`.  If a
JITted object is ever assigned an address in the upper half of the address space
on a platform with `sizeof(char *) = 4`, which is quite common on 32-bit Linux,
the following can happen:

In JITDebugInfoRegistry::registerJITObject, `SectionAddr - SectionLoadAddr`
is computed in uint64_t (ok), then cast to ptrdiff_t (two's complement of
the uint64_t version mod 2^32).  This is apparently implementation-defined
behaviour rather than undefined.

Say SectionAddr = 0x1000UL, SectionLoadAddr = 0xe93b2000UL and
size_t pointer = 0xe93b20abU.
```
(ptrdiff_t)(SectionAddr - SectionLoadAddr) == (ptrdiff_t)0xffffffff16c4f000
                                           == 382005248
```

jl_DI_for_fptr implicitly converts the ptrdiff_t to int64_t:
```
(int64_t)382005248 == 382005248L
```

lookup_pointer adds `size_t pointer` to `int64_t slide`.  Both are converted
to int64_t because it can represent every size_t:
```
(int64_t)0xe93b20abU + 382005248L == 3912966315L + 382005248L
                                  == 4294971563L
```

This is converted back to uint64_t by makeAddress, resulting in an address other
than the 0x10ab we expected:
```
(uint64_t)4294971563L == 0x1000010abUL
```

It is easier to use unsigned integers everywhere we need a difference, since
they avoid the problem of losing upper bits after sign extension and avoid weird
UB from signed overflow.

Cherry-picked from #60031.

[1] https://buildkite.com/julialang/julia-master/builds/52196/steps/canvas?sid=019a9d6f-14a6-4ffc-be19-f2f835d1e719
