### PR TITLE
[release-1.13] Revert "Make banner size depend on terminal size (#51811)"

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -484,7 +484,7 @@ end
 function run_std_repl(REPL::Module, quiet::Bool, banner::Symbol, history_file::Bool)
     term_env = get(ENV, "TERM", @static Sys.iswindows() ? "" : "dumb")
     term = REPL.Terminals.TTYTerminal(term_env, stdin, stdout, stderr)
-    banner == :no || REPL.banner(term, banner)
+    banner == :no || REPL.banner(term, short=banner==:short)
     if term.term_type == "dumb"
         repl = REPL.BasicREPL(term)
         quiet || @warn "Terminal not fully functional"
@@ -607,26 +607,12 @@ end
 function repl_main(_)
     opts = Base.JLOptions()
     interactiveinput = isa(stdin, Base.TTY)
-    bval = if opts.banner == -1 # Auto
-        Int(interactiveinput)
-    else
-        opts.banner
-    end
-    # All the options produced by `jloptions.c`'s `case opt_banner`.
-    # 0=off, 1=largest, ..., N=smallest
-    banner = if bval == 0
-        :no
-    elseif bval == 1
-        :full
-    elseif bval == 2
-        :narrow
-    elseif bval == 3
-        :short
-    elseif bval == 4
-        :tiny
-    else # For type stability of `banner`
-        :unreachable
-    end
+    b = opts.banner
+    auto = b == -1
+    banner = b == 0 || (auto && !interactiveinput) ? :no  :
+             b == 1 || (auto && interactiveinput)  ? :yes :
+             :short # b == 2
+
     quiet                 = (opts.quiet != 0)
     history_file          = (opts.historyfile != 0)
     return run_main_repl(interactiveinput, quiet, banner, history_file)

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -235,8 +235,7 @@ static const char opts[]  =
     " -i, --interactive                             Interactive mode; REPL runs and\n"
     "                                               `isinteractive()` is true.\n"
     " -q, --quiet                                   Quiet startup: no banner, suppress REPL warnings\n"
-    " --banner={yes|no|auto*|<size>}                Enable or disable startup banner, or specify a\n"
-    "                                               preferred <size> (tiny, short, narrow, or full).\n"
+    " --banner={yes|no|short|auto*}                 Enable or disable startup banner\n"
     " --color={yes|no|auto*}                        Enable or disable color text\n"
     " --history-file={yes*|no}                      Load or save history\n\n"
 
@@ -612,22 +611,16 @@ restart_switch:
                 jl_options.banner = 0;
             break;
         case opt_banner: // banner
-            if (!strcmp(optarg, "auto"))
-                jl_options.banner = -1;
+            if (!strcmp(optarg, "yes"))
+                jl_options.banner = 1;
             else if (!strcmp(optarg, "no"))
                 jl_options.banner = 0;
-            else if (!strcmp(optarg, "yes"))
-                jl_options.banner = 1;
-            else if (!strcmp(optarg, "full"))
-                jl_options.banner = 1; // Same as "yes".
-            else if (!strcmp(optarg, "narrow"))
-                jl_options.banner = 2;
+            else if (!strcmp(optarg, "auto"))
+                jl_options.banner = -1;
             else if (!strcmp(optarg, "short"))
-                jl_options.banner = 3;
-            else if (!strcmp(optarg, "tiny"))
-                jl_options.banner = 4;
+                jl_options.banner = 2;
             else
-                jl_errorf("julia: invalid argument to --banner={yes|no|auto|full|narrow|short|tiny} (%s)", optarg);
+                jl_errorf("julia: invalid argument to --banner={yes|no|auto|short} (%s)", optarg);
             break;
         case opt_experimental_features:
             jl_options.use_experimental_features = JL_OPTIONS_USE_EXPERIMENTAL_FEATURES_YES;

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1704,21 +1704,11 @@ function ends_with_semicolon(code)
     return semi
 end
 
-"""
-    banner(io::IO = stdout, preferred::Symbol = :full)
-
-Print the "Julia" informative banner to `io`, using the `preferred` variant
-if reasonable and known.
-
-!!! warning
-    The particular banner selected by `preferred` is liable to being changed
-    without warning. The current variants are: `:tiny`, `:short`, `:narrow`, and `:full`.
-"""
-function banner(io::IO = stdout, preferred::Symbol = :full)
-    commit_string = if Base.GIT_VERSION_INFO.tagged_commit
-        Base.AnnotatedString(TAGGED_RELEASE_BANNER, :face => :shadow)
+function banner(io::IO = stdout; short = false)
+    if Base.GIT_VERSION_INFO.tagged_commit
+        commit_string = Base.TAGGED_RELEASE_BANNER
     elseif isempty(Base.GIT_VERSION_INFO.commit)
-         styled""
+        commit_string = ""
     else
         days = Int(floor((ccall(:jl_clock_now, Float64, ()) - Base.GIT_VERSION_INFO.fork_master_timestamp) / (60 * 60 * 24)))
         days = max(0, days)
@@ -1727,65 +1717,60 @@ function banner(io::IO = stdout, preferred::Symbol = :full)
         commit = Base.GIT_VERSION_INFO.commit_short
 
         if distance == 0
-            styled"""Commit {grey:$commit} \
-                     ({warning:⌛ {italic:$days $unit}} old master)"""
+            commit_string = "Commit $(commit) ($(days) $(unit) old master)"
         else
             branch = Base.GIT_VERSION_INFO.branch
-            styled"""{emphasis:$branch}/{grey:$commit} \
-                     ({italic:{success:{bold,(slant=normal):↑} $distance commits}, \
-                     {warning:{(slant=normal):⌛} $days $unit}})"""
+            commit_string = "$(branch)/$(commit) (fork: $(distance) commits, $(days) $(unit))"
         end
     end
 
-    commit_date = isempty(Base.GIT_VERSION_INFO.date_string) ? "" : styled" {light:($(split(Base.GIT_VERSION_INFO.date_string)[1]))}"
-    doclink = styled"{bold:Documentation:} {(underline=grey),link={https://docs.julialang.org}:https://docs.julialang.org}"
-    help = styled"Type {repl_prompt_help:?} for help, {repl_prompt_pkg:]?} for {(underline=grey),link={https://pkgdocs.julialang.org/}:Pkg} help."
+    commit_date = isempty(Base.GIT_VERSION_INFO.date_string) ? "" : " ($(split(Base.GIT_VERSION_INFO.date_string)[1]))"
 
-    sizenames = (:tiny, :short, :narrow, :full)
-    maxsize = something(findfirst(==(preferred), sizenames), length(sizenames))
-    size = min(if     all(displaysize(io) .>= (8, 70)); 4 # Full size
-               elseif all(displaysize(io) .>= (8, 45)); 3 # Narrower
-               elseif all(displaysize(io) .>= (3, 50)); 2 # Tiny
-               else 1 end,
-               max(0, maxsize))
+    if get(io, :color, false)::Bool
+        c = Base.text_colors
+        tx = c[:normal] # text
+        jl = c[:normal] # julia
+        d1 = c[:bold] * c[:blue]    # first dot
+        d2 = c[:bold] * c[:red]     # second dot
+        d3 = c[:bold] * c[:green]   # third dot
+        d4 = c[:bold] * c[:magenta] # fourth dot
 
-    if size == 4 # Full size
-        print(io, styled"""
-                                 {bold,green:_}
-                     {bold,blue:_}       _ {bold:{red:_}{green:(_)}{magenta:_}}     {shadow:│}  $doclink
-                    {bold,blue:(_)}     | {bold:{red:(_)} {magenta:(_)}}    {shadow:│}
-                     _ _   _| |_  __ _   {shadow:│}  $help
-                    | | | | | | |/ _` |  {shadow:│}
-                    | | |_| | | | (_| |  {shadow:│}  Version {bold:$VERSION}$commit_date
-                   _/ |\\__'_|_|_|\\__'_|  {shadow:│}  $commit_string
-                  |__/                   {shadow:│}
-                  \n""")
-    elseif size == 3 # Rotated
-        print(io, styled"""
-                                 {bold,green:_}
-                     {bold,blue:_}       _ {bold:{red:_}{green:(_)}{magenta:_}}
-                    {bold,blue:(_)}     | {bold:{red:(_)} {magenta:(_)}}
-                     _ _   _| |_  __ _
-                    | | | | | | |/ _` |
-                    | | |_| | | | (_| |
-                   _/ |\\__'_|_|_|\\__'_|
-                  |__/
+        if short
+            print(io,"""
+              $(d3)o$(tx)  | Version $(VERSION)$(commit_date)
+             $(d2)o$(tx) $(d4)o$(tx) | $(commit_string)
+            """)
+        else
+            print(io,"""               $(d3)_$(tx)
+               $(d1)_$(tx)       $(jl)_$(tx) $(d2)_$(d3)(_)$(d4)_$(tx)     |  Documentation: https://docs.julialang.org
+              $(d1)(_)$(jl)     | $(d2)(_)$(tx) $(d4)(_)$(tx)    |
+               $(jl)_ _   _| |_  __ _$(tx)   |  Type \"?\" for help, \"]?\" for Pkg help.
+              $(jl)| | | | | | |/ _` |$(tx)  |
+              $(jl)| | |_| | | | (_| |$(tx)  |  Version $(VERSION)$(commit_date)
+             $(jl)_/ |\\__'_|_|_|\\__'_|$(tx)  |  $(commit_string)
+            $(jl)|__/$(tx)                   |
 
-                   $doclink
-                   $help
+            """)
+        end
+    else
+        if short
+            print(io,"""
+              o  |  Version $(VERSION)$(commit_date)
+             o o |  $(commit_string)
+            """)
+        else
+            print(io,"""
+                           _
+               _       _ _(_)_     |  Documentation: https://docs.julialang.org
+              (_)     | (_) (_)    |
+               _ _   _| |_  __ _   |  Type \"?\" for help, \"]?\" for Pkg help.
+              | | | | | | |/ _` |  |
+              | | |_| | | | (_| |  |  Version $(VERSION)$(commit_date)
+             _/ |\\__'_|_|_|\\__'_|  |  $(commit_string)
+            |__/                   |
 
-                   Version {bold:$VERSION}$commit_date
-                   $commit_string
-                  \n""")
-    elseif size == 2 # Tiny
-        print(io, styled"""
-                     {bold,green:o}  {shadow:│} Version {bold:$VERSION}$commit_date
-                    {bold:{red:o} {magenta:o}} {shadow:│} $commit_string
-                   """, ifelse(displaysize(io) > (12, 0), "\n", ""))
-    elseif size == 1 && Base.GIT_VERSION_INFO.tagged_commit # Text only
-        print(io, styled"""{bold:{blue:∴} {magenta:Julia} $VERSION}$commit_date\n""")
-    elseif size == 1 # Text only
-        print(io, styled"""{bold:{blue:∴} {magenta:Julia} $VERSION}$commit_date $commit_string\n""")
+            """)
+        end
     end
 end
 

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -223,20 +223,6 @@ let
             precompile(Tuple{typeof(Base.setindex!), Base.Dict{Any, Any}, Any, Int})
             precompile(Tuple{typeof(Base.delete!), Base.Set{Any}, String})
             precompile(Tuple{typeof(Base.:(==)), Char, String})
-            # For the banner
-            # TODO: Fix precompilation so this is no longer needed
-            precompile(Tuple{typeof(Base.AnnotatedDisplay.ansi_write), typeof(Base.write), Base.TTY, Base.AnnotatedString{String}})
-            precompile(Tuple{typeof(Base.all), Tuple{Bool, Bool}})
-            precompile(Tuple{typeof(Base.get), Base.Dict{Tuple{Symbol, Any}, Int64}, Tuple{Symbol, REPL.StyledStrings.Face}, Int64})
-            precompile(Tuple{typeof(Base.get), Base.Dict{Tuple{Symbol, Any}, Int64}, Tuple{Symbol, String}, Int64})
-            precompile(Tuple{typeof(Base.get), Base.Dict{Tuple{Symbol, Any}, Int64}, Tuple{Symbol, Symbol}, Int64})
-            precompile(Tuple{typeof(Base.hashindex), Tuple{Symbol, String}, Int64})
-            precompile(Tuple{typeof(Base.isempty), Base.Dict{String, Any}})
-            precompile(Tuple{typeof(Base.print), Base.TTY, Base.AnnotatedString{String}})
-            precompile(Tuple{typeof(Base.setindex!), Base.Dict{Tuple{Symbol, Any}, Int64}, Int64, Tuple{Symbol, REPL.StyledStrings.Face}})
-            precompile(Tuple{typeof(Base.setindex!), Base.Dict{Tuple{Symbol, Any}, Int64}, Int64, Tuple{Symbol, String}})
-            precompile(Tuple{typeof(Base.setindex!), Base.Dict{Tuple{Symbol, Any}, Int64}, Int64, Tuple{Symbol, Symbol}})
-            precompile(Tuple{typeof(REPL.banner), Base.TTY})
         finally
             ccall(:jl_tag_newly_inferred_disable, Cvoid, ())
         end

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1801,9 +1801,9 @@ let io = IOBuffer()
     seek(io, 0)
     @test countlines(io) == 9
     take!(io)
-    @test REPL.banner(io, :tiny) === nothing
+    @test REPL.banner(io; short=true) === nothing
     seek(io, 0)
-    @test countlines(io) == 1
+    @test countlines(io) == 2
 end
 
 @testset "Docstrings" begin

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -321,21 +321,18 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
 
     # --quiet, --banner
     let p = "print((Base.JLOptions().quiet, Base.JLOptions().banner))"
-        @test read(`$exename                    -e $p`, String) == "(0, -1)"
-        @test read(`$exename -q                 -e $p`, String) == "(1, 0)"
-        @test read(`$exename --quiet            -e $p`, String) == "(1, 0)"
-        @test read(`$exename --banner=auto      -e $p`, String) == "(0, -1)"
-        @test read(`$exename --banner=no        -e $p`, String) == "(0, 0)"
-        @test read(`$exename --banner=yes       -e $p`, String) == "(0, 1)"
-        @test read(`$exename --banner=full      -e $p`, String) == "(0, 1)"
-        @test read(`$exename -q --banner=no     -e $p`, String) == "(1, 0)"
-        @test read(`$exename -q --banner=yes    -e $p`, String) == "(1, 1)"
-        @test read(`$exename -q --banner=tiny   -e $p`, String) == "(1, 4)"
-        @test read(`$exename --banner=no  -q    -e $p`, String) == "(1, 0)"
-        @test read(`$exename --banner=yes -q    -e $p`, String) == "(1, 1)"
-        @test read(`$exename --banner=narrow -q -e $p`, String) == "(1, 2)"
-        @test read(`$exename --banner=short  -q -e $p`, String) == "(1, 3)"
-        @test read(`$exename --banner=tiny   -q -e $p`, String) == "(1, 4)"
+        @test read(`$exename                   -e $p`, String) == "(0, -1)"
+        @test read(`$exename -q                -e $p`, String) == "(1, 0)"
+        @test read(`$exename --quiet           -e $p`, String) == "(1, 0)"
+        @test read(`$exename --banner=no       -e $p`, String) == "(0, 0)"
+        @test read(`$exename --banner=yes      -e $p`, String) == "(0, 1)"
+        @test read(`$exename --banner=short    -e $p`, String) == "(0, 2)"
+        @test read(`$exename -q --banner=no    -e $p`, String) == "(1, 0)"
+        @test read(`$exename -q --banner=yes   -e $p`, String) == "(1, 1)"
+        @test read(`$exename -q --banner=short -e $p`, String) == "(1, 2)"
+        @test read(`$exename --banner=no  -q   -e $p`, String) == "(1, 0)"
+        @test read(`$exename --banner=yes -q   -e $p`, String) == "(1, 1)"
+        @test read(`$exename --banner=short -q -e $p`, String) == "(1, 2)"
     end
 
     # --home


### PR DESCRIPTION
This reverts commit 0f9b2fc19fd201f18d92f823361a4bfd24047a29. This was also reverted on `master` (#59984) but after `release-1.13` had branched, so the same change is needed here; without this, the build cannot complete because precompiling REPL deadlocks. Thanks to @xal-0 and @IanButterworth for their help in identifying the cause.

@KristofferC, given that the current v1.13.0-alpha1 tag is effectively unbuildable, I suggest we delete it and retag once this is merged.