### PR TITLE
JuliaSyntax tokenize.jl:  don‘t hardcode unicode ops range

### DIFF
--- a/JuliaSyntax/src/julia/tokenize.jl
+++ b/JuliaSyntax/src/julia/tokenize.jl
@@ -173,7 +173,7 @@ function optakessuffix(k)
         k == K"!"   ||
         k == K".'"  ||
         k == K"->"  ||
-        K"¬" <= k <= K"∜"
+        K"BEGIN_UNICODE_OPS" <= k <= K"END_UNICODE_OPS"
     )
 end
 


### PR DESCRIPTION
There are very nice `(BEGIN|END)_UNICODE_OPS` kinds; they should be used!

---

Ported from JuliaLang/JuliaSyntax.jl#404; thanks are due to @c42f for the notification and instructions on how to move this.