### PR TITLE
Reject decimal points after hex float literals

### DIFF
--- a/JuliaSyntax/src/julia/tokenize.jl
+++ b/JuliaSyntax/src/julia/tokenize.jl
@@ -1057,6 +1057,14 @@ function lex_digit(l::Lexer, kind)
                 if !accept_number(l, isdigit) || !had_digits
                     return emit(l, K"ErrorInvalidNumericConstant") # `0x1p` `0x.p0`
                 end
+                # Check for invalid trailing decimal point
+                # https://github.com/JuliaLang/julia/issues/60189
+                pc = peekchar(l)
+                if pc == '.'
+                    accept_batch(l, c->(c == '.' || isdigit(c)))
+                    # `0x1p3.` `0x1p3.2` `0x1.5p2.3`
+                    return emit(l, K"ErrorInvalidNumericConstant")
+                end
             elseif isfloat
                 return emit(l, K"ErrorHexFloatMustContainP") # `0x.` `0x1.0`
             end

--- a/JuliaSyntax/test/tokenize.jl
+++ b/JuliaSyntax/test/tokenize.jl
@@ -632,6 +632,10 @@ end
     @test onlytok("0x.p0") == K"ErrorInvalidNumericConstant"
     @test onlytok("0x.")   == K"ErrorHexFloatMustContainP"
     @test onlytok("0x1.0") == K"ErrorHexFloatMustContainP"
+    # https://github.com/JuliaLang/julia/issues/60189
+    @test onlytok("0x1p3.") == K"ErrorInvalidNumericConstant"
+    @test onlytok("0x1p3.2") == K"ErrorInvalidNumericConstant"
+    @test onlytok("0x1.5p2.3") == K"ErrorInvalidNumericConstant"
 end
 
 @testset "binary literals" begin

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1684,6 +1684,9 @@ end
 # #16356
 @test_parseerror "0xapi"
 
+# #60189
+@test_parseerror "0x1p3.2"
+
 # #22523 #22712
 @test_parseerror "a?b:c"
 @test_parseerror "a ?b:c"


### PR DESCRIPTION
Hex float literals like `0x1p3 `should not be allowed to be followed by decimal digits or decimal points, as this creates confusing implicit multiplication that looks like a malformed literal. This change makes the parser reject expressions like 0x1p3.2 (previously parsed as 0x1p3 * 0.2) as invalid numeric constants, consistent with the existing restriction on juxtaposing hex integer literals.

Fixes #60189. Written by Claude (obviously - since it's set as the author - trying out the new web thing).

I figure this situation is rare enough and bad enough that we should just change this unconditionally across syntax versions, but if preferred, we could make use of syntax evolution for this (although we'd have to start versioning the lexer).