### PR TITLE
[release-1.12] Fix precompilation tests when run from runtests.jl

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,9 @@ include("buildkitetestjson.jl")
 
 using .BuildkiteTestJSON
 
+# Set JULIA_TESTS so that precompilation output is suppressed in test subprocesses
+ENV["JULIA_TESTS"] = "true"
+
 const longrunning_delay = parse(Int, get(ENV, "JULIA_TEST_LONGRUNNING_DELAY", "45")) * 60 # minutes
 const longrunning_interval = parse(Int, get(ENV, "JULIA_TEST_LONGRUNNING_INTERVAL", "15")) * 60 # minutes
 


### PR DESCRIPTION
`precompilation` has a test for the JULIA_TESTS env var that is required to get tests to work. On master, the check was removed in 42a33bba6f7b6359db86d08be7dc8f0484dac3e7, but on 1.12 it is there and causing problems. Since this is fixed on master, I think the simplest fix is just to set JULIA_TESTS in runtests.jl also on 1.12 to avoid having to mess with the precompilation code itself.

Fixes #59887