### PR TITLE
Finish PR: inference: fix the ptrfree field check

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3079,6 +3079,15 @@ function abstract_eval_call(interp::AbstractInterpreter, e::Expr, sstate::Statem
     end
 end
 
+# TODO: try doing layout of dt so this doesn’t crash julia
+# function is_field_pointerfree(dt::DataType, fidx::Int)
+#     DataTypeFieldDesc(dt)[fidx].isptr && return false
+#     ft = fieldtype(dt, fidx)
+#     return ft isa DataType && datatype_pointerfree(ft)
+# end
+maybe_field_pointerfree(@nospecialize ft) =
+    !isconcretetype(ft) || datatype_pointerfree(ft)
+
 function abstract_eval_new(interp::AbstractInterpreter, e::Expr, sstate::StatementState,
                            sv::AbsIntState)
     𝕃ᵢ = typeinf_lattice(interp)
@@ -3089,9 +3098,8 @@ function abstract_eval_new(interp::AbstractInterpreter, e::Expr, sstate::Stateme
         ismutable = ismutabletype(ut)
         fcount = datatype_fieldcount(ut)
         nargs = length(e.args) - 1
-        has_any_uninitialized = (fcount === nothing || (fcount > nargs && (let t = rt
-                any(i::Int -> !is_undefref_fieldtype(fieldtype(t, i)), (nargs+1):fcount)
-            end)))
+        has_any_uninitialized = fcount === nothing || (fcount > nargs &&
+            any(i::Int->maybe_field_pointerfree(fieldtype(ut,i)), (nargs+1):fcount))
         if has_any_uninitialized
             # allocation with undefined field is inconsistent always
             consistent = ALWAYS_FALSE

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3080,7 +3080,7 @@ function abstract_eval_call(interp::AbstractInterpreter, e::Expr, sstate::Statem
 end
 
 function is_field_pointerfree(dt::DataType, fidx::Int)
-    dt.layout == C_NULL && return false
+    dt.layout::Ptr{Cvoid} == C_NULL && return false
     DataTypeFieldDesc(dt)[fidx].isptr && return false
     ft = fieldtype(dt, fidx)
     return ft isa DataType && datatype_pointerfree(ft)

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1286,18 +1286,6 @@ end
     return rewrap_unionall(R, s00)
 end
 
-# checks if a field of this type is guaranteed to be defined to a value
-# and that access to an uninitialized field will cause an `UndefRefError` or return zero
-# - is_undefref_fieldtype(String) === true
-# - is_undefref_fieldtype(Integer) === true
-# - is_undefref_fieldtype(Any) === true
-# - is_undefref_fieldtype(Int) === false
-# - is_undefref_fieldtype(Union{Int32,Int64}) === false
-# - is_undefref_fieldtype(T) === false
-function is_undefref_fieldtype(@nospecialize ftyp)
-    return !has_free_typevars(ftyp) && !allocatedinline(ftyp)
-end
-
 @nospecs function setfield!_tfunc(𝕃::AbstractLattice, o, f, v, order)
     if !isvarargtype(order)
         hasintersect(widenconst(order), Symbol) || return Bottom

--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -266,6 +266,9 @@ end |> Compiler.is_consistent
 @test Base.infer_effects() do
     Maybe{String}()[]
 end |> Compiler.is_consistent
+@test Base.infer_effects() do
+    Maybe{Some{Base.RefValue{Int}}}()
+end |> Compiler.is_consistent
 let f() = Maybe{String}()[]
     @test Base.return_types() do
         f() # this call should be concrete evaluated


### PR DESCRIPTION
This should address the `# TODO` item in https://github.com/JuliaLang/julia/pull/57550. 

Unconditionally indexing `DataTypeFieldDesc(dt::DataType)[fidx]` will error when `dt` has no layout because we define
```julia
struct DataTypeFieldDesc
    dt::DataType
    function DataTypeFieldDesc(dt::DataType)
        dt.layout == C_NULL && throw(UndefRefError())
        new(dt)
    end
end
``` 
For all the `DataType`s I could find, they only had `dt.layout == C_NULL`  if `!isconcretetype(dt)`, so maybe it would be preferable to check if they're `!isconcretetype` rather than checking if `dt.layout == C_NULL`, but I figured it'd be safer to just mimic the validation logic in `DataTypeFieldDesc` instead.