### PR TITLE
Bump Documenter to 1.16.1

### DIFF
--- a/deps/jlutilities/documenter/Manifest.toml
+++ b/deps/jlutilities/documenter/Manifest.toml
@@ -53,10 +53,10 @@ version = "0.9.5"
 
 [[deps.Documenter]]
 deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
-git-tree-sha1 = "70c521ca3a23c576e12655d15963977c9766c26b"
+git-tree-sha1 = "b37458ae37d8bdb643d763451585cd8d0e5b4a9e"
 registries = "General"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.16.0"
+version = "1.16.1"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
@@ -116,10 +116,10 @@ version = "1.7.1"
 
 [[deps.JSON]]
 deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
-git-tree-sha1 = "eb04df293213df64ddd720c86de3c431f5f8ccf1"
+git-tree-sha1 = "5b6bb73f555bc753a6153deec3717b8904f5551c"
 registries = "General"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "1.2.1"
+version = "1.3.0"
 
     [deps.JSON.extensions]
     JSONArrowExt = ["ArrowTypes"]
@@ -146,7 +146,7 @@ version = "1.0.0"
 [[deps.LibCURL_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "Zstd_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.16.0+0"
+version = "8.17.0+0"
 
 [[deps.LibGit2]]
 deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]


### PR DESCRIPTION
At this point, Julia `master` and `release-1.12` are at Documenter 1.16.0; while `release-1.13` and `backports-release-1.10` are at 1.15.0 (and `release-1.10` is at Documenter 0.27.23).

Since the location of the `Manifest.toml` changed between 1.10/1.12 versus 1.13/master, this will require manual backporting.

Considering manual work is needed anyway, and moreover the pairs 1.10/1.12 resp. 1.13/master also differ in what they have, it seems best to do all three backports manually, and directly to 1.16.1. I will open corresponding PRs, and removed the backport labels from #60073 and #60132. I hope that is the right way to do it.

- Backport to 1.13: PR #60216
- Backport to 1.12: PR #60217
- Backport to 1.10: PR #60218
