### PR TITLE
[JuliaLowering] Fix handling of unnamed args in `@generated` functions

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2534,6 +2534,16 @@ function expand_function_generator(ctx, srcref, callex_srcref, func_name, func_n
         ]
     ]
 
+    function stub_argname(n::SyntaxTree, i)
+        if kind(n) == K"Identifier"
+            return n.name_val::String
+        elseif kind(n) == K"BindingId"
+            # flisp lowering calls these unnamed arguments "#unused#", but JL does
+            # not accept that as a repeated argument name
+            return "#arg" * string(i) * "#"
+        else @assert false "Unexpected argument kind: $(kind(n))" end
+    end
+
     # Extract non-generated body
     nongen_body = @ast ctx body [K"block"
         # The Julia runtime associates the code generator with the
@@ -2562,7 +2572,7 @@ function expand_function_generator(ctx, srcref, callex_srcref, func_name, func_n
                 [K"call"
                     "svec"::K"core"
                     "#self#"::K"Symbol"
-                    (n.name_val::K"Symbol"(n) for n in arg_names[2:end])...
+                    (stub_argname(n,i)::K"Symbol"(n) for (i,n) in enumerate(arg_names[2:end]))...
                 ]
                 [K"call"
                     "svec"::K"core"

--- a/JuliaLowering/src/runtime.jl
+++ b/JuliaLowering/src/runtime.jl
@@ -339,7 +339,7 @@ function (g::GeneratedFunctionStub)(world::UInt, source::Method, @nospecialize a
             ex0 = copy_ast(ctx1, ex0)
         end
     else
-        ex0 = @ast ctx ex expanded::K"Value"
+        ex0 = @ast ctx1 g.srcref ex0::K"Value"
     end
     # Expand any macros emitted by the generator
     ex1 = expand_forms_1(ctx1, reparent(ctx1, ex0))

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -513,6 +513,16 @@ end
     end
     """) == (NTuple{5,Int}, 5, Int)
 
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        @generated function f_gen_unnamed_args(::Type{T}, y, ::Type{U}) where {T, U}
+            return (T, y, U)
+        end
+
+        f_gen_unnamed_args(Int, UInt8(3), Float64)
+    end
+    """) == (Int, UInt8, Float64)
+
     @test JuliaLowering.include_string(test_mod, raw"""
     begin
         function f_partially_gen(x::NTuple{N,T}) where {N,T}


### PR DESCRIPTION
This is required to get Dates pre-compiling with JuliaLowering.