### PR TITLE
Add names to most allocas created and attrs to jl_excstack_state

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1369,6 +1369,9 @@ static std::tuple<Value*, jl_gc_roots_t, MDNode*> split_value(jl_codectx_t &ctx,
         }
         Align align_dst(julia_alignment((jl_value_t*)typ));
         AllocaInst *alloca = emit_static_alloca(ctx, sizes.first, align_dst);
+        setName(ctx.emission_context, alloca, [&]() {
+            return "split::" + std::string(jl_symbol_name(typ->name->name));
+        });
         auto stack_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack);
         split_value_into(ctx, x, x_alignment, alloca, align_dst, stack_ai, false);
         bits = alloca;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2421,6 +2421,10 @@ static inline jl_cgval_t value_to_pointer(jl_codectx_t &ctx, Value *v, jl_value_
     }
     else {
         loc = emit_static_alloca(ctx, v->getType(), align);
+        setName(ctx.emission_context, loc, [&]() {
+            std::string type_str = jl_is_datatype(typ) ? jl_symbol_name(((jl_datatype_t*)typ)->name->name) : "<unknown type>";
+            return "slot::" + type_str;
+        });
         ctx.builder.CreateAlignedStore(v, loc, align);
     }
     return mark_julia_slot(loc, typ, tindex, ctx.tbaa().tbaa_stack);
@@ -2433,6 +2437,10 @@ static inline jl_cgval_t value_to_pointer(jl_codectx_t &ctx, const jl_cgval_t &v
         Align align(julia_alignment(v.typ));
         Type *ty = julia_type_to_llvm(ctx, v.typ);
         AllocaInst *loc = emit_static_alloca(ctx, ty, align);
+        setName(ctx.emission_context, loc, [&]() {
+            std::string type_str = jl_is_datatype(v.typ) ? jl_symbol_name(((jl_datatype_t*)v.typ)->name->name) : "<unknown type>";
+            return "slot::" + type_str;
+        });
         jl_datatype_t *dt = (jl_datatype_t *)v.typ;
         size_t npointers = dt->layout->first_ptr >= 0 ? dt->layout->npointers : 0;
         if (npointers > 0) {
@@ -5308,7 +5316,10 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_clos
         } else {
             result = emit_static_alloca(ctx, returninfo.union_bytes, Align(returninfo.union_align));
         }
-        setName(ctx.emission_context, result, "sret_box");
+        setName(ctx.emission_context, result, [&]() {
+            std::string type_str = jl_is_datatype(jlretty) ? jl_symbol_name(((jl_datatype_t*)jlretty)->name->name) : "<unknown type>";
+            return "sret::" + type_str;
+        });
         argvals[idx] = result;
         idx++;
     }
@@ -5316,7 +5327,10 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_clos
     AllocaInst *return_roots = nullptr;
     if (returninfo.return_roots) {
         return_roots = emit_static_roots(ctx, returninfo.return_roots);
-        setName(ctx.emission_context, return_roots, "return_roots");
+        setName(ctx.emission_context, return_roots, [&]() {
+            std::string type_str = jl_is_datatype(jlretty) ? jl_symbol_name(((jl_datatype_t*)jlretty)->name->name) : "<unknown type>";
+            return "return_roots::" + type_str;
+        });
         argvals[idx] = return_roots;
         idx++;
     }
@@ -6104,6 +6118,7 @@ static void emit_phinode_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r)
                             ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0));
                     AllocaInst *phi = cast<AllocaInst>(dest->clone());
                     phi->insertAfter(dest);
+                    setName(ctx.emission_context, phi, "union_phi");
                     ctx.builder.CreateMemCpy(phi, Align(min_align), dest, dest->getAlign(), nbytes, false);
                     ctx.builder.CreateLifetimeEnd(dest);
                     ptr = ctx.builder.CreateSelect(isboxed,
@@ -6151,12 +6166,20 @@ static void emit_phinode_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r)
             Align align(julia_alignment(phiType));
             unsigned nb = jl_datatype_size(phiType);
             dest = emit_static_alloca(ctx, nb, align);
+            setName(ctx.emission_context, dest, [&]() {
+                std::string type_str = jl_is_datatype(phiType) ? jl_symbol_name(((jl_datatype_t*)phiType)->name->name) : "<unknown type>";
+                return "phi::" + type_str;
+            });
             phi = cast<AllocaInst>(dest->clone());
 #if JL_LLVM_VERSION >= 200000
             phi->insertBefore(dest->getIterator());
 #else
             phi->insertBefore(dest);
 #endif
+            setName(ctx.emission_context, phi, [&]() {
+                std::string type_str = jl_is_datatype(phiType) ? jl_symbol_name(((jl_datatype_t*)phiType)->name->name) : "<unknown type>";
+                return "phi_result::" + type_str;
+            });
             ctx.builder.CreateMemCpy(phi, align, dest, align, nb, false);
             ctx.builder.CreateLifetimeEnd(dest);
         }
@@ -9718,6 +9741,7 @@ static jl_llvm_functions_t
                 auto *handler_sz64 = ConstantInt::get(Type::getInt64Ty(ctx.builder.getContext()),
                   sizeof(jl_handler_t));
                 AllocaInst* ehbuff = emit_static_alloca(ctx, sizeof(jl_handler_t), Align(16));
+                setName(ctx.emission_context, ehbuff, "exception_handler");
                 ctx.eh_buffers[stmt] = ehbuff;
                 ctx.builder.CreateLifetimeStart(ehbuff, handler_sz64);
                 ctx.builder.CreateCall(prepare_call(jlenter_func), {ct, ehbuff});

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -482,7 +482,7 @@ static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x)
     if (!x.inline_roots.empty()) {
         AllocaInst *combined = emit_static_alloca(ctx, to, Align(alignment));
         setName(ctx.emission_context, combined, [&]() {
-            std::string type_str = jl_is_datatype(jt) ? jl_symbol_name(((jl_datatype_t*)jt)->name->name) : "<unknown type>";
+            std::string type_str = jl_is_datatype(x.typ) ? jl_symbol_name(((jl_datatype_t*)x.typ)->name->name) : "<unknown type>";
             return "unbox::" + type_str;
         });
         auto combined_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -481,6 +481,10 @@ static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x)
     jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, x.tbaa);
     if (!x.inline_roots.empty()) {
         AllocaInst *combined = emit_static_alloca(ctx, to, Align(alignment));
+        setName(ctx.emission_context, combined, [&]() {
+            std::string type_str = jl_is_datatype(jt) ? jl_symbol_name(((jl_datatype_t*)jt)->name->name) : "<unknown type>";
+            return "unbox::" + type_str;
+        });
         auto combined_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack);
         recombine_value(ctx, x, combined, combined_ai, Align(alignment), false);
         p = combined;

--- a/src/llvm-codegen-shared.h
+++ b/src/llvm-codegen-shared.h
@@ -194,7 +194,7 @@ static inline llvm::Value *get_current_signal_page_from_ptls(llvm::IRBuilder<> &
     auto T_ptr = builder.getPtrTy();
     auto i8 = builder.getInt8Ty();
     int nthfield = offsetof(jl_tls_states_t, safepoint);
-    llvm::Value *psafepoint = builder.CreateConstInBoundsGEP1_32(i8, ptls, nthfield);
+    llvm::Value *psafepoint = builder.CreateConstInBoundsGEP1_32(i8, ptls, nthfield, "safepoint_addr");
     LoadInst *ptls_load = builder.CreateAlignedLoad(
             T_ptr, psafepoint, Align(sizeof(void *)), "safepoint");
     ptls_load->setOrdering(AtomicOrdering::Monotonic);


### PR DESCRIPTION
This adds names to lots of places in the IR and allows LLVM to delete some dead calls to `jl_excstack_state`

Written with the help of cursor/claude