### PR TITLE
[JuliaLowering] Fix generated functions when `expr_compat_mode=true`

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2562,6 +2562,7 @@ function expand_function_generator(ctx, srcref, callex_srcref, func_name, func_n
             # technically have scope resolved at top level.
             [K"new"
                 GeneratedFunctionStub::K"Value" # Use stub type from JuliaLowering
+                ctx.expr_compat_mode::K"Value"
                 gen_name
                 # Truncate provenance to just the source file range, as this
                 # will live permanently in the IR and we probably don't want

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -370,7 +370,7 @@ function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
             ir
         end
     elseif k == K"Value"
-        ex.value
+        ex.value isa LineNumberNode ? QuoteNode(ex.value) : ex.value
     elseif k == K"goto"
         Core.GotoNode(ex[1].id + stmt_offset)
     elseif k == K"gotoifnot"

--- a/JuliaLowering/src/runtime.jl
+++ b/JuliaLowering/src/runtime.jl
@@ -290,8 +290,9 @@ end
 # An alternative to Core.GeneratedFunctionStub which works on SyntaxTree rather
 # than Expr.
 struct GeneratedFunctionStub
-    gen
-    srcref
+    expr_compat_mode::Bool
+    gen::Function
+    srcref::Union{SyntaxTree,LineNumberNode,SourceRef}
     argnames::Core.SimpleVector
     spnames::Core.SimpleVector
 end
@@ -323,14 +324,17 @@ function (g::GeneratedFunctionStub)(world::UInt, source::Method, @nospecialize a
     # Macro expansion. Note that we expand in `tls_world_age()` (see
     # Core.GeneratedFunctionStub)
     macro_world = Base.tls_world_age()
-    ctx1 = MacroExpansionContext(graph, __module__, false, macro_world)
+    ctx1 = MacroExpansionContext(graph, __module__, g.expr_compat_mode, macro_world)
 
     layer = only(ctx1.scope_layers)
 
     # Run code generator - this acts like a macro expander and like a macro
     # expander it gets a MacroContext.
-    mctx = MacroContext(syntax_graph(ctx1), g.srcref, layer, false)
+    mctx = MacroContext(syntax_graph(ctx1), g.srcref, layer, g.expr_compat_mode)
     ex0 = g.gen(mctx, args...)
+    if ex0 isa Expr
+        ex0 = expr_to_syntaxtree(ctx1, ex0, source_location(LineNumberNode, g.srcref))
+    end
     if ex0 isa SyntaxTree
         if !is_compatible_graph(ctx1, ex0)
             # If the macro has produced syntax outside the macro context, copy it over.
@@ -345,7 +349,8 @@ function (g::GeneratedFunctionStub)(world::UInt, source::Method, @nospecialize a
     ex1 = expand_forms_1(ctx1, reparent(ctx1, ex0))
     ctx1 = MacroExpansionContext(delete_attributes(graph, :__macro_ctx__),
                                  ctx1.bindings, ctx1.scope_layers,
-                                 ctx1.scope_layer_stack, false, macro_world)
+                                 ctx1.scope_layer_stack, g.expr_compat_mode,
+                                 macro_world)
     ex1 = reparent(ctx1, ex1)
 
     # Desugaring

--- a/JuliaLowering/src/syntax_graph.jl
+++ b/JuliaLowering/src/syntax_graph.jl
@@ -479,7 +479,10 @@ function _value_string(ex)
           k == K"static_parameter" ? "static_parameter" :
           k == K"symbolic_label" ? "label:$(ex.name_val)" :
           k == K"symbolic_goto" ? "goto:$(ex.name_val)" :
-          k == K"SourceLocation" ? "SourceLocation:$(JuliaSyntax.filename(ex)):$(join(source_location(ex), ':'))" :
+          k == K"SourceLocation" ?
+              "SourceLocation:$(JuliaSyntax.filename(ex)):$(join(source_location(ex), ':'))" :
+          k == K"Value" && ex.value isa SourceRef ?
+              "SourceRef:$(JuliaSyntax.filename(ex)):$(join(source_location(ex), ':'))" :
           repr(get(ex, :value, nothing))
     id = get(ex, :var_id, nothing)
     if isnothing(id)

--- a/JuliaLowering/src/utils.jl
+++ b/JuliaLowering/src/utils.jl
@@ -118,6 +118,7 @@ function print_ir(io::IO, ex, method_filter=nothing)
     _print_ir(io, ex, "")
 end
 
+# TODO: JuliaLowering-the-module should always print the same way, ignoring parent modules
 function _print_ir(io::IO, ex, indent)
     added_indent = "    "
     @assert (kind(ex) == K"lambda" || kind(ex) == K"code_info") && kind(ex[1]) == K"block"

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -501,6 +501,7 @@ end
 end
 
 @testset "Generated functions" begin
+    for expr_compat_mode in (false, true)
     @test JuliaLowering.include_string(test_mod, raw"""
     begin
         @generated function f_gen(x::NTuple{N,T}) where {N,T}
@@ -511,7 +512,7 @@ end
 
         f_gen((1,2,3,4,5))
     end
-    """) == (NTuple{5,Int}, 5, Int)
+    """; expr_compat_mode) == (NTuple{5,Int}, 5, Int)
 
     @test JuliaLowering.include_string(test_mod, """
     begin
@@ -521,7 +522,7 @@ end
 
         f_gen_unnamed_args(Int, UInt8(3), Float64)
     end
-    """) == (Int, UInt8, Float64)
+    """; expr_compat_mode) == (Int, UInt8, Float64)
 
     @test JuliaLowering.include_string(test_mod, raw"""
     begin
@@ -542,8 +543,20 @@ end
 
         (f_partially_gen((1,2)), f_partially_gen((1,2,3,4,5)))
     end
-    """) == ((:shared_stuff, (:nongen, (NTuple{2,Int}, 2, Int))),
-             (:shared_stuff, (:gen, (NTuple{5,Int}, 5, Int))))
+    """; expr_compat_mode) ==
+        ((:shared_stuff, (:nongen, (NTuple{2,Int}, 2, Int))),
+         (:shared_stuff, (:gen, (NTuple{5,Int}, 5, Int))))
+
+    @test JuliaLowering.include_string(test_mod, raw"""
+    begin
+        @generated function f_gen_calls_macros(x::T) where {T}
+            s = @raw_str "foo"
+            :(@raw_str $s)
+        end
+        f_gen_calls_macros(1)
+    end
+    """; expr_compat_mode) === "foo"
+    end
 
     # Test generated function edges to bindings
     # (see also https://github.com/JuliaLang/julia/pull/57230)

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -1559,7 +1559,7 @@ end
 18  (call core.svec %₁₅ %₁₆ %₁₇)
 19  --- method core.nothing %₁₈
     slots: [slot₁/#self#(!read) slot₂/x(!read) slot₃/y(!read)]
-    1   (meta :generated (new JuliaLowering.GeneratedFunctionStub TestMod.#f_only_generated@generator#0 SourceRef(SourceFile("@generated function f_only_generated(x, y)\n    generator_code(x,y)\nend", 0, nothing, 1, [1, 44, 68]), 1, (macrocall (macro_name 1-1::@-t 2-10::Identifier) 11-11::Whitespace-t (function 12-19::function-t 20-20::Whitespace-t (call 21-36::Identifier 37-37::(-t 38-38::Identifier 39-39::,-t 40-40::Whitespace-t 41-41::Identifier 42-42::)-t) (block 43-47::NewlineWs-t (call 48-61::Identifier 62-62::(-t 63-63::Identifier 64-64::,-t 65-65::Identifier 66-66::)-t) 67-67::NewlineWs-t) 68-70::end-t))) (call core.svec :#self# :x :y) (call core.svec)))
+    1   (meta :generated (new JuliaLowering.GeneratedFunctionStub false TestMod.#f_only_generated@generator#0 SourceRef::1:1 (call core.svec :#self# :x :y) (call core.svec)))
     2   (meta :generated_only)
     3   (return core.nothing)
 20  latestworld
@@ -1605,7 +1605,7 @@ end
 18  (call core.svec %₁₅ %₁₆ %₁₇)
 19  --- method core.nothing %₁₈
     slots: [slot₁/#self#(!read) slot₂/x slot₃/y slot₄/maybe_gen_stuff slot₅/nongen_stuff]
-    1   (meta :generated (new JuliaLowering.GeneratedFunctionStub TestMod.#f_partially_generated@generator#0 SourceRef(SourceFile("function f_partially_generated(x, y)\n    nongen_stuff = bothgen(x, y)\n    if @generated\n        quote\n            maybe_gen_stuff = some_gen_stuff(x, y)\n        end\n    else\n        maybe_gen_stuff = some_nongen_stuff(x, y)\n    end\n    (nongen_stuff, maybe_gen_stuff)\nend", 0, nothing, 1, [1, 38, 71, 89, 103, 154, 166, 175, 225, 233, 269]), 1, (function 1-8::function-t 9-9::Whitespace-t (call 10-30::Identifier 31-31::(-t 32-32::Identifier 33-33::,-t 34-34::Whitespace-t 35-35::Identifier 36-36::)-t) (block 37-41::NewlineWs-t (= 42-53::Identifier 54-54::Whitespace-t 55-55::=-t 56-56::Whitespace-t (call 57-63::Identifier 64-64::(-t 65-65::Identifier 66-66::,-t 67-67::Whitespace-t 68-68::Identifier 69-69::)-t)) 70-74::NewlineWs-t (if 75-76::if-t 77-77::Whitespace-t (macrocall (macro_name 78-78::@-t 79-87::Identifier)) (block 88-96::NewlineWs-t (quote (block 97-101::quote-t 102-114::NewlineWs-t (= 115-129::Identifier 130-130::Whitespace-t 131-131::=-t 132-132::Whitespace-t (call 133-146::Identifier 147-147::(-t 148-148::Identifier 149-149::,-t 150-150::Whitespace-t 151-151::Identifier 152-152::)-t)) 153-161::NewlineWs-t 162-164::end-t)) 165-169::NewlineWs-t) 170-173::else-t (block 174-182::NewlineWs-t (= 183-197::Identifier 198-198::Whitespace-t 199-199::=-t 200-200::Whitespace-t (call 201-217::Identifier 218-218::(-t 219-219::Identifier 220-220::,-t 221-221::Whitespace-t 222-222::Identifier 223-223::)-t)) 224-228::NewlineWs-t) 229-231::end-t) 232-236::NewlineWs-t (tuple-p 237-237::(-t 238-249::Identifier 250-250::,-t 251-251::Whitespace-t 252-266::Identifier 267-267::)-t) 268-268::NewlineWs-t) 269-271::end-t)) (call core.svec :#self# :x :y) (call core.svec)))
+    1   (meta :generated (new JuliaLowering.GeneratedFunctionStub false TestMod.#f_partially_generated@generator#0 SourceRef::1:37 (call core.svec :#self# :x :y) (call core.svec)))
     2   TestMod.bothgen
     3   (= slot₅/nongen_stuff (call %₂ slot₂/x slot₃/y))
     4   TestMod.some_nongen_stuff


### PR DESCRIPTION
Pass `expr_compat_mode` through to `GeneratedFunctionStub`.  You can get
    surprisingly far into the stdlibs without testing this!

Also reduce the IR printing I mentioned being an issue in #60226, which tests
     that we're keeping the whole green tree the same.

I initially attemtped to use `SourceLocation` for the generated function's
     provenance instead, but those become LineNumberNodes in `to_lowered_expr`.