### PR TITLE
Makefile: add `clean-utf8proc` to `make cleanall`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -714,7 +714,7 @@ clean: | $(CLEAN_TARGETS)
 .PHONY: cleanall
 cleanall: clean
 	@-$(MAKE) -C $(BUILDROOT)/src clean-flisp clean-support
-	@-$(MAKE) -C $(BUILDROOT)/deps clean-libuv
+	@-$(MAKE) -C $(BUILDROOT)/deps clean-libuv clean-utf8proc
 	-rm -fr $(build_prefix) $(build_staging)
 
 .PHONY: distcleanall


### PR DESCRIPTION
This dep locally compiles code by default, so it seems reasonable to clean it up with `make cleanall`.

This change makes switching back and forth from a cross-compiled `x86_64-w64-mingw32` <-> native Linux build possible with `make cleanall`, instead of `make distcleanall`.