### PR TITLE
JLJITLinkMemoryManager: Disable when CodeModel != Large

### DIFF
--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -961,7 +961,8 @@ public:
     void deallocate(std::vector<FinalizedAlloc> Allocs,
                     OnDeallocatedFunction OnDeallocated) override
     {
-        jl_unreachable();
+        // This shouldn't be reachable, but we will get a better error message
+        // from JITLink if we leak this allocation and fail elsewhere.
     }
 
 protected:
@@ -999,7 +1000,10 @@ class JLJITLinkMemoryManager::InFlightAlloc
 public:
     InFlightAlloc(JLJITLinkMemoryManager &MM, jitlink::LinkGraph &G) : MM(MM), G(G) {}
 
-    void abandon(OnAbandonedFunction OnAbandoned) override { jl_unreachable(); }
+    void abandon(OnAbandonedFunction OnAbandoned) override {
+        // This shouldn't be reachable, but we will get a better error message
+        // from JITLink if we leak this allocation and fail elsewhere.
+    }
 
     void finalize(OnFinalizedFunction OnFinalized) override
     {

--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -256,7 +256,7 @@ static void *create_shared_map(size_t size, size_t id) JL_NOTSAFEPOINT
     return addr;
 }
 
-static intptr_t init_shared_map() JL_NOTSAFEPOINT
+[[maybe_unused]] static intptr_t init_shared_map() JL_NOTSAFEPOINT
 {
     anon_hdl = get_anon_hdl();
     if (anon_hdl == -1)
@@ -771,6 +771,7 @@ public:
 std::pair<std::unique_ptr<ROAllocator>, std::unique_ptr<ROAllocator>>
 get_preferred_allocators() JL_NOTSAFEPOINT
 {
+#if !(defined(_CPU_AARCH64_) || defined(_CPU_RISCV64_))
 #ifdef _OS_LINUX_
     if (get_self_mem_fd() != -1)
         return {std::make_unique<SelfMemAllocator>(false),
@@ -779,6 +780,7 @@ get_preferred_allocators() JL_NOTSAFEPOINT
     if (init_shared_map() != -1)
         return {std::make_unique<DualMapAllocator>(false),
                 std::make_unique<DualMapAllocator>(true)};
+#endif
     return {};
 }
 


### PR DESCRIPTION
Under normal circumstances we never deallocate JITted code, and JITLink will never abandon in-flight allocations.  Unfortunately, on platforms where we use a code model that require relocations to not be too large, the linker can bail out if an allocation gets placed somewhere unlucky. [1]

This change forces the use of MapperJITLinkMemoryManager on the platforms where we use a non-large code model so that this can't happen, and removes the jl_unreachable() calls so that the JITLink error gets reported nicely instead of failing in our code.

Since every JITLink platform currently uses a non-large code model, we should no longer use JLJITLinkMemoryManager by default anywhere (except when it has been enabled on a RTDyLD platform, like when sanitizers are enabled).  It is still necessary to have this change for #60031 to go forward, else the previously RTDyLD platforms run out of memory.

Thanks to @IanButterworth and @giordano again.

[1] https://buildkite.com/julialang/julia-master/builds/52316/steps/canvas?sid=019aba85-6699-45e3-b173-55f1420063ca#019aba85-66c0-40f1-80ba-8c5b4da56dba/934-1268