### PR TITLE
Don't introduce a block around `y` in parsing `x' = y`

### DIFF
--- a/JuliaSyntax/src/integration/expr.jl
+++ b/JuliaSyntax/src/integration/expr.jl
@@ -528,8 +528,9 @@ end
     elseif k == K"function"
         if length(args) > 1
             if has_flags(nodehead, SHORT_FORM_FUNCTION_FLAG)
+                a1 = args[1]
                 a2 = args[2]
-                if !@isexpr(a2, :block)
+                if !@isexpr(a2, :block) && !@isexpr(a1, Symbol("'"))
                     args[2] = Expr(:block, a2)
                 end
                 retexpr.head = :(=)

--- a/JuliaSyntax/test/expr.jl
+++ b/JuliaSyntax/test/expr.jl
@@ -269,6 +269,12 @@
                  Expr(:block,
                       LineNumberNode(3)))
 
+        # short-form postfix function shouldn't introduce a block
+        @test parsestmt("x' = 1") ==
+            Expr(:(=),
+                 Expr(Symbol("'"), :x),
+                 1)
+
         # `.=` doesn't introduce short form functions
         @test parsestmt("f() .= xs") ==
             Expr(:(.=), Expr(:call, :f), :xs)


### PR DESCRIPTION
Closes #59911.  `'` is generally treated as its own thing in Expr and flisp, but treated as a special type of call in JuliaSyntax.  This change makes `x' = y` parse to the <=1.11 `(= (|'| x) y)` instead of wrapping the body in a block like we do when parsing `f(x) = y`.  

The special case is fine to me given that it's a more understandable parse, and we're hoping to move away from LineNumberNodes in the future anyway. (I think this was the original reason for the block-wrap for `f(x) = y`).

Backporting will be a pain.  My plan is to get this reviewed, then make a branch `backports-x` in the separate JuliaSyntax repository and push this change directly to it, then make a version bump PR to this repository's `backports-release-x` for `x` in 1.12, 1.13.  Suggestions for how to improve this situation are welcome!  