### PR TITLE
Remove libjulia-internal.so dependency on libstdc++ and libgcc

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -97,6 +97,9 @@ WITH_TRACY_CALLSTACKS := 0
 # Enable Timing Counts support
 WITH_TIMING_COUNTS := 0
 
+# Should --gc-sections/-dead_strip be used to remove unreferenced code?
+USE_LINKER_GC:=1
+
 # Prevent picking up $ARCH from the environment variables
 ARCH:=
 
@@ -930,6 +933,17 @@ endif
 ifeq ($(WITH_NVTX), 1)
 JCXXFLAGS += -DUSE_NVTX
 JCFLAGS += -DUSE_NVTX
+endif
+
+# Linker garbage collection
+ifeq ($(USE_LINKER_GC), 1)
+ifeq ($(OS), Darwin)
+  JLDFLAGS += -Wl,-dead_strip
+else
+  JLDFLAGS += -Wl,--gc-sections
+  JCFLAGS += -ffunction-sections -fdata-sections
+  JCXXFLAGS += -ffunction-sections -fdata-sections
+endif
 endif
 
 # ===========================================================================

--- a/Make.inc
+++ b/Make.inc
@@ -939,7 +939,15 @@ JCXXFLAGS += -DUSE_NVTX
 JCFLAGS += -DUSE_NVTX
 endif
 
+ifeq ($(OS), WINNT)
+  USE_RT_STATIC_LIBGCC:=0
+  USE_RT_STATIC_LIBSTDCXX:=0
+endif
+
 # Linker garbage collection
+ifeq ($(OS), WINNT)
+  USE_LINKER_GC := 0
+endif
 ifeq ($(USE_LINKER_GC), 1)
 ifeq ($(OS), Darwin)
   JLDFLAGS += -Wl,-dead_strip

--- a/Make.inc
+++ b/Make.inc
@@ -939,15 +939,13 @@ JCXXFLAGS += -DUSE_NVTX
 JCFLAGS += -DUSE_NVTX
 endif
 
-ifeq ($(OS), WINNT)
-  USE_RT_STATIC_LIBGCC:=0
-  USE_RT_STATIC_LIBSTDCXX:=0
+ifneq ($(findstring $(OS),WINNT FreeBSD OpenBSD),)
+  USE_LINKER_GC := 0
+  USE_RT_STATIC_LIBGCC := 0
+  USE_RT_STATIC_LIBSTDCXX := 0
 endif
 
 # Linker garbage collection
-ifeq ($(OS), WINNT)
-  USE_LINKER_GC := 0
-endif
 ifeq ($(USE_LINKER_GC), 1)
 ifeq ($(OS), Darwin)
   JLDFLAGS += -Wl,-dead_strip

--- a/Make.inc
+++ b/Make.inc
@@ -63,6 +63,10 @@ USE_SYSTEM_ZSTD:=0
 USE_SYSTEM_P7ZIP:=0
 USE_SYSTEM_LLD:=0
 
+# Link libjulia-internal with static libgcc and libstdc++
+USE_RT_STATIC_LIBGCC:=1
+USE_RT_STATIC_LIBSTDCXX:=1
+
 # Link to the LLVM shared library
 USE_LLVM_SHLIB := 1
 

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -39,6 +39,11 @@ $(BUILDDIR)/loader_lib.o: export MSYS2_ARG_CONV_EXCL = -DDEP_LIBS=
 $(BUILDDIR)/loader_lib.dbg.obj: export MSYS2_ARG_CONV_EXCL = -DDEP_LIBS=
 endif # MSYS2
 
+ifeq ($(USE_RT_STATIC_LIBSTDCXX),1)
+SHIPFLAGS += -DRT_STATIC_LIBSTDCXX
+DEBUGFLAGS += -DRT_STATIC_LIBSTDCXX
+endif # USE_RT_STATIC_LIBSTDCXX
+
 EXE_OBJS := $(BUILDDIR)/loader_exe.o
 EXE_DOBJS := $(BUILDDIR)/loader_exe.dbg.obj
 LIB_OBJS := $(BUILDDIR)/loader_lib.o

--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -497,7 +497,13 @@ __attribute__((constructor)) void jl_load_libjulia_internal(void) {
                 // If the probe rejected the system libstdc++ (or didn't find one!)
                 // just load our bundled libstdc++ as identified by curr_dep;
                 if (!probe_successful) {
+# ifdef RT_STATIC_LIBSTDCXX
+                    // If we have a statically-linked libstdc++, it is ok for
+                    // this to fail.
+                    load_library(curr_dep, lib_dir, 0);
+# else
                     load_library(curr_dep, lib_dir, 1);
+# endif
                 }
 #endif
             } else if (special_idx == 1) {

--- a/src/Makefile
+++ b/src/Makefile
@@ -207,6 +207,15 @@ RT_LIBS := $(call whole_archive,$(LIBUV)) $(call whole_archive,$(LIBUTF8PROC)) $
 # NB: CG needs uv_mutex_* symbols, but we expect to export them from libjulia-internal
 CG_LIBS := $(LIBUNWIND) $(CG_LLVMLINK) $(OSLIBS) $(LIBTRACYCLIENT) $(LIBITTAPI)
 
+ifeq ($(USEGCC),1)
+ifeq ($(USE_RT_STATIC_LIBGCC),1)
+RT_LIBS := -static-libgcc
+endif
+ifeq ($(USE_RT_STATIC_LIBSTDCXX),1)
+RT_LIBS := -static-libstdc++
+endif
+endif
+
 ifeq (${USE_THIRD_PARTY_GC},mmtk)
 RT_LIBS += $(MMTK_LIB)
 CG_LIBS += $(MMTK_LIB)

--- a/src/Makefile
+++ b/src/Makefile
@@ -209,10 +209,10 @@ CG_LIBS := $(LIBUNWIND) $(CG_LLVMLINK) $(OSLIBS) $(LIBTRACYCLIENT) $(LIBITTAPI)
 
 ifeq ($(USEGCC),1)
 ifeq ($(USE_RT_STATIC_LIBGCC),1)
-RT_LIBS := -static-libgcc
+RT_LIBS += -static-libgcc
 endif
 ifeq ($(USE_RT_STATIC_LIBSTDCXX),1)
-RT_LIBS := -static-libstdc++
+RT_LIBS += -static-libstdc++
 endif
 endif
 

--- a/src/coverage.cpp
+++ b/src/coverage.cpp
@@ -143,10 +143,11 @@ static void write_log_data(logdata_t &logData, const char *extension) JL_NOTSAFE
                 char line[1024];
                 int l = 1;
                 unsigned block = 0;
-                while (fscanf(inf, "%1023[^\n]", line) != EOF) {
+                int ret = 0;
+                while (ret != EOF && (ret = fscanf(inf, "%1023[^\n]", line)) != EOF) {
                     // Skip n non-newline chars and a single trailing newline
-                    fscanf(inf, "%*[^\n]");
-                    fscanf(inf, "%*1[\n]");
+                    if ((ret = fscanf(inf, "%*[^\n]")) != EOF)
+                        ret = fscanf(inf, "%*1[\n]");
                     logdata_block *data = NULL;
                     if (block < values.size()) {
                         data = values[block];

--- a/src/coverage.cpp
+++ b/src/coverage.cpp
@@ -3,9 +3,6 @@
 #include <cstdint>
 #include <pthread.h>
 #include <string>
-#include <fstream>
-#include <map>
-#include <vector>
 
 #include "llvm-version.h"
 #include <llvm/ADT/StringRef.h>
@@ -137,26 +134,19 @@ static void write_log_data(logdata_t &logData, const char *extension) JL_NOTSAFE
         if (!values.empty()) {
             if (!jl_isabspath(filename.c_str()))
                 filename = base + filename;
-            std::ifstream inf(filename.c_str());
-            if (!inf.is_open())
+            FILE *inf = fopen(filename.c_str(), "r");
+            if (!inf)
                 continue;
             std::string outfile = filename + extension;
-            std::ofstream outf(outfile.c_str(), std::ofstream::trunc | std::ofstream::out | std::ofstream::binary);
-            if (outf.is_open()) {
-                inf.exceptions(std::ifstream::badbit);
-                outf.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+            FILE *outf = fopen(outfile.c_str(), "wb");
+            if (outf) {
                 char line[1024];
                 int l = 1;
                 unsigned block = 0;
-                while (!inf.eof()) {
-                    inf.getline(line, sizeof(line));
-                    if (inf.fail()) {
-                        if (inf.eof())
-                            break; // no content on trailing line
-                        // Read through lines longer than sizeof(line)
-                        inf.clear();
-                        inf.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-                    }
+                while (fscanf(inf, "%1023[^\n]", line) != EOF) {
+                    // Skip n non-newline chars and a single trailing newline
+                    fscanf(inf, "%*[^\n]");
+                    fscanf(inf, "%*1[\n]");
                     logdata_block *data = NULL;
                     if (block < values.size()) {
                         data = values[block];
@@ -166,24 +156,24 @@ static void write_log_data(logdata_t &logData, const char *extension) JL_NOTSAFE
                         l = 0;
                         block++;
                     }
-                    outf.width(9);
                     if (value == 0)
-                        outf << '-';
+                        fprintf(outf, "        -");
                     else
-                        outf << (value - 1);
-                    outf.width(0);
-                    outf << " " << line << '\n';
+                        fprintf(outf, "%9" PRIu64, value - 1);
+                    fprintf(outf, " %s\n", line);
+                    line[0] = 0;
                 }
-                outf.close();
+                fclose(outf);
             }
-            inf.close();
+            fclose(inf);
         }
     }
 }
 
 static void write_lcov_data(logdata_t &logData, const std::string &outfile) JL_NOTSAFEPOINT
 {
-    std::ofstream outf(outfile.c_str(), std::ofstream::ate | std::ofstream::out | std::ofstream::binary);
+    FILE *outf = fopen(outfile.c_str(), "ab");
+    if (!outf) return;
     //std::string base = std::string(jl_options.julia_bindir);
     //base = base + "/../share/julia/base/";
     logdata_t::iterator it = logData.begin();
@@ -191,7 +181,7 @@ static void write_lcov_data(logdata_t &logData, const std::string &outfile) JL_N
         StringRef filename = it->first();
         const SmallVector<logdata_block*, 0> &values = it->second;
         if (!values.empty()) {
-            outf << "SF:" << filename.str() << '\n';
+            fprintf(outf, "SF:%.*s\n", (int)filename.size(), filename.data());
             size_t n_covered = 0;
             size_t n_instrumented = 0;
             size_t lno = 0;
@@ -204,7 +194,7 @@ static void write_lcov_data(logdata_t &logData, const std::string &outfile) JL_N
                             n_instrumented++;
                             if (cov > 1)
                                 n_covered++;
-                            outf << "DA:" << lno << ',' << (cov - 1) << '\n';
+                            fprintf(outf, "DA:%zu,%" PRIu64 "\n", lno, cov - 1);
                         }
                         lno++;
                     }
@@ -213,12 +203,12 @@ static void write_lcov_data(logdata_t &logData, const std::string &outfile) JL_N
                     lno += logdata_blocksize;
                 }
             }
-            outf << "LH:" << n_covered << '\n';
-            outf << "LF:" << n_instrumented << '\n';
-            outf << "end_of_record\n";
+            fprintf(outf, "LH:%zu\n", n_covered);
+            fprintf(outf, "LF:%zu\n", n_instrumented);
+            fprintf(outf, "end_of_record\n");
         }
     }
-    outf.close();
+    fclose(outf);
 }
 
 extern "C" JL_DLLEXPORT void jl_write_coverage_data(const char *output) JL_NOTSAFEPOINT

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -16,7 +16,6 @@
 #include "julia.h"
 #include "julia_internal.h"
 
-#include <map>
 #include <algorithm>
 
 #include "julia_assert.h"
@@ -24,8 +23,6 @@
 #ifndef _OS_WINDOWS_
 #include <dlfcn.h>
 #endif
-
-#include <iostream>
 
 // CPU target string is a list of strings separated by `;` each string starts with a CPU
 // or architecture name and followed by an optional list of features separated by `,`.

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -1,7 +1,6 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
 #include "llvm-version.h"
-#include <map>
 #include <string>
 #include <llvm/ADT/StringMap.h>
 #include <llvm/TargetParser/Host.h>
@@ -25,7 +24,7 @@ using namespace llvm;
 jl_value_t *jl_libdl_dlopen_func JL_GLOBALLY_ROOTED;
 
 // map from user-specified lib names to handles
-static std::map<std::string, void*> libMap;
+static StringMap<void*> libMap;
 static jl_mutex_t libmap_lock;
 extern "C"
 void *jl_get_library_(const char *f_lib, int throw_err)


### PR DESCRIPTION
Some testing by @BenChung has revealed how hard it is to load a JuliaC-built library into a program that has already loaded a very old version of libstdc++.  Even with probing disabled, `libjulia-internal.so` fails because of missing GLIBCXX symbols.

We use so little of the C++ standard library in `libjulia-internal.so` that it's worth the tradeoff to link it statically: it barely changes the size of the resulting library, removes a medium-size library we have to ship in trimmed bundles, and solves some of our hermeticity issues when being loaded by other software.  `libjulia-codegen.so` uses it more extensively, and we expect to be able to load it as a plugin for `opt`, meaning it may have to remain dynamically linked.

This PR contains a series of changes to enable statically linked libstdc++ by default and mitigate the size impact:
- We enable `--gc-sections` when building with gcc/ld.bfd.  This saves us some code already, since we can trim out a lot of libLLVMSupport/libLLVMTargetParser.  On macOS, we can use `-dead_strip` to save some space even though the rest of these changes are not applicable.
- Two flags for `-static-libstdc++` and `-static-libgcc`, called `USE_RT_STATIC_LIBSTDCXX` and `USE_RT_STATIC_LIBGCC`, are added and enabled by default.
- Most of the additional code that gets linked into `libjulia-internal.so` is related to locales for iostreams.  Replace these with standard C IO and LLVM helpers that don't have weird locale-related behaviour.
- (NOT IMPLEMENTED) `--gc-sections` removes unused executable code, but leaves us with a lot of irrelevant debug info.  I tested the effect of `llvm-dwarfutil --garbage-collection` and saw pretty good savings, but that is not included in this PR because BinaryBuilder doesn't have a new enough version of the LLVM tools.

| Change                               | Size of `libjulia-internal.so` (KiB) |
|--------------------------------------|--------------------------------------|
| No change                            |                                14524 |
| Linker GC enabled                    |                                13220 |
| -static-libstdc++ and -static-libgcc |                                22136 |
| Excise iostreams                     |                                15036 |
| DWARF GC (not in this PR)            |                                11488 |

This is a comparison of symbols that were added and removed.  Even though 15 times more code is removed than added, the resulting `libjulia-internal.so` has a similar size to the original because of the additional debug info.

```
WHERE     NUM      SIZE
both     4678
removed  3727   1188754
added     448     78255

Largest added:
    17336 d_print_comp_inner
     2667 d_type
     2368 d_print_mod
     2122 execute_cfa_program
     2100 d_exprlist
     1862 execute_stack_op
     1785 search_object
     1691 d_expression_1
     1672 uw_frame_state_for
     1658 d_encoding
     1632 cplus_demangle_operators
     1442 d_demangle_callback.constprop.0
     1419 d_name
     1351 __gxx_personality_v0
     1168 _Unwind_IteratePhdrCallback
     1163 d_unqualified_name
     1088 cplus_demangle_builtin_types
     1074 d_print_mod_list
     1064 uw_update_context_1
      944 d_maybe_print_fold_expression.isra.0
      829 d_print_function_type.isra.0
      760 _Unwind_RaiseException
      729 d_print_array_type.isra.0
      680 std::__cxx11::basic_string<char, std::char_traits<char>, std::allocat…
      617 llvm::support::detail::provider_format_adapter<int&>::format(llvm::ra…
      617 llvm::support::detail::provider_format_adapter<unsigned long&>::forma…
      571 d_cv_qualifiers
      562 _Unwind_Find_FDE
      531 d_substitution
      417 d_operator_name
      415 uw_install_context_1
      408 _Unwind_ForcedUnwind
      392 standard_subs
      392 _Unwind_Resume
      384 frame_hdr_cache
      373 uw_init_context_1
      369 linear_search_fdes
      369 d_expr_primary
      339 __cxa_demangle
      339 d_source_name
      331 classify_object_over_fdes
      322 read_encoded_value_with_base(unsigned char, unsigned long, unsigned c…
      322 read_encoded_value_with_base
      314 std::__cxx11::basic_string<char, std::char_traits<char>, std::allocat…
      309 __cxxabiv1::__si_class_type_info::__do_dyncast(long, __cxxabiv1::__cl…
      299 add_fdes
      290 __deregister_frame_info_bases
      290 get_cie_encoding
      287 std::__cxx11::basic_string<char, std::char_traits<char>, std::allocat…
      284 (anonymous namespace)::pool::free(void*) (.constprop.0)

Largest removed:
    12115 llvm::cl::ParseCommandLineOptions(int, char const* const*, llvm::Stri…
    12115 llvm::cl::ParseCommandLineOptions(int, char const* const*, llvm::Stri…
    11449 Execute(llvm::sys::ProcessInfo&, llvm::StringRef, llvm::ArrayRef<llvm…
    10310 llvm::DisplayGraph(llvm::StringRef, bool, llvm::GraphProgram::Name)
     8071 llvm::itanium_demangle::AbstractManglingParser<llvm::itanium_demangle…
     8018 gc_collect_neighbors
     6652 llvm::ARM::getDefaultExtensions(llvm::StringRef, llvm::ARM::ArchKind)
     6572 void std::__introsort_loop<__gnu_cxx::__normal_iterator<llvm::TimerGr…
     6509 llvm::vfs::RedirectingFileSystemParser::parseEntry(llvm::yaml::Node*,…
     6116 printSymbolizedStackTrace(llvm::StringRef, void**, int, llvm::raw_ost…
     5820 llvm::ARM::getDefaultFPU(llvm::StringRef, llvm::ARM::ArchKind)
     5820 llvm::ARM::getDefaultFPU(llvm::StringRef, llvm::ARM::ArchKind) (.loca…
     5688 llvm::sys::unicode::isPrintable(int)::PrintableRanges
     5508 llvm::itanium_demangle::AbstractManglingParser<llvm::itanium_demangle…
     5485 (anonymous namespace)::CommandLineCommonOptions::CommandLineCommonOpt…
     5485 (anonymous namespace)::CommandLineCommonOptions::CommandLineCommonOpt…
     5289 llvm::sys::detail::getHostCPUNameForARM(llvm::StringRef)
     4886 llvm::sys::Wait(llvm::sys::ProcessInfo const&, std::optional<unsigned…
     4886 llvm::sys::Wait(llvm::sys::ProcessInfo const&, std::optional<unsigned…
     4872 llvm::DebugCounter::print(llvm::raw_ostream&) const
     4872 llvm::DebugCounter::print(llvm::raw_ostream&) const (.localalias)
     4828 llvm::cl::ExpansionContext::expandResponseFiles(llvm::SmallVectorImpl…
     4828 llvm::cl::ExpansionContext::expandResponseFiles(llvm::SmallVectorImpl…
     4811 void std::__introsort_loop<llvm::SMFixIt*, long, __gnu_cxx::__ops::_I…
     4647 llvm::yaml::Document::parseBlockNode()
     4647 llvm::yaml::Document::parseBlockNode() (.localalias)
     4643 llvm::detail::IEEEFloat::toString(llvm::SmallVectorImpl<char>&, unsig…
     4643 llvm::detail::IEEEFloat::toString(llvm::SmallVectorImpl<char>&, unsig…
     4417 parseArch(llvm::StringRef)
     4399 llvm::vfs::RedirectingFileSystemParser::parse(llvm::yaml::Node*, llvm…
     4300 llvm::APIntOps::SolveQuadraticEquationWrap(llvm::APInt, llvm::APInt, …
     4008 llvm::itanium_demangle::AbstractManglingParser<llvm::itanium_demangle…
     3916 llvm::Triple::normalize[abi:cxx11](llvm::StringRef, llvm::Triple::Can…
     3645 void std::__introsort_loop<__gnu_cxx::__normal_iterator<llvm::vfs::YA…
     3524 llvm::xxh3_128bits(llvm::ArrayRef<unsigned char>)
     3432 RedirectIO(std::optional<llvm::StringRef>, int, std::__cxx11::basic_s…
     3203 llvm::yaml::escape[abi:cxx11](llvm::StringRef, bool)
     3142 llvm::yaml::dumpTokens(llvm::StringRef, llvm::raw_ostream&)
     3142 llvm::vfs::RedirectingFileSystem::dir_begin(llvm::Twine const&, std::…
     3142 llvm::vfs::RedirectingFileSystem::dir_begin(llvm::Twine const&, std::…
     3129 llvm::TimerGroup::PrintQueuedTimers(llvm::raw_ostream&) (.localalias)
     3129 llvm::TimerGroup::PrintQueuedTimers(llvm::raw_ostream&)
     3007 (anonymous namespace)::CategorizedHelpPrinter::printOptions(llvm::Sma…
     2966 llvm::TimerGroup::TimerGroup(llvm::StringRef, llvm::StringRef, llvm::…
     2966 llvm::TimerGroup::TimerGroup(llvm::StringRef, llvm::StringRef, llvm::…
     2908 llvm::DebugCounter::push_back(std::__cxx11::basic_string<char, std::c…
     2908 llvm::DebugCounter::push_back(std::__cxx11::basic_string<char, std::c…
     2877 llvm::itanium_demangle::AbstractManglingParser<llvm::itanium_demangle…
     2855 llvm::yaml::Node::getVerbatimTag[abi:cxx11]() const
     2851 llvm::vfs::RedirectingFileSystem::create(llvm::ArrayRef<std::pair<std…
```