### PR TITLE
loading: Delete unsafe `normpath` where possible

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -94,6 +94,9 @@ New library functions
 New library features
 --------------------
 
+* `normpath` and `abspath` now accept a `safe=true` keyword argument that preserves
+  `..` components so normalization does not change paths containing symbolic links
+  ([#60251]).
 * `IOContext` supports a new boolean `hexunsigned` option that allows for
   printing unsigned integers in decimal instead of hexadecimal ([#60267]).
 * `lazy"..."` strings now support a flag `lazy"..."c` that adds `compact` and `limit` flags

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -352,16 +352,16 @@ function load_path_expand(env::AbstractString)::Union{String, Nothing}
             path = joinpath(depot, "environments", name)
             isdir(path) || continue
             for proj in project_names
-                file = abspath(path, proj)
+                file = abspath(path, proj; safe=true)
                 isfile_casesensitive(file) && return file
             end
         end
         isempty(DEPOT_PATH) && return nothing
-        new_named_env_path = abspath(DEPOT_PATH[1], "environments", name, project_names[end])
+        new_named_env_path = abspath(DEPOT_PATH[1], "environments", name, project_names[end]; safe=true)
         return init_named_env!(new_named_env_path)
     end
     # otherwise, it's a path
-    path = abspath(env)
+    path = abspath(env; safe=true)
     if isdir(path)
         # directory with a project file?
         for proj in project_names
@@ -388,7 +388,7 @@ function active_project(search_load_path::Bool=true)
         # there are backedges here from abspath(::AbstractString, ::String)
         project = project::String
         if !isfile_casesensitive(project) && basename(project) ∉ project_names
-            project = abspath(project, "Project.toml")
+            project = abspath(project, "Project.toml"; safe=true)
         end
         return project
     end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1021,7 +1021,7 @@ function project_file_manifest_path(project_file::String)::Union{Nothing,String}
         manifest_path = get(cache.project_file_manifest_path, project_file, missing)
         manifest_path === missing || return manifest_path
     end
-    dir = abspath(dirname(project_file))
+    dir = abspath(dirname(project_file); safe=true)
     isfile_casesensitive(project_file) || return nothing
     d = parsed_toml(project_file)
     base_manifest = workspace_manifest(project_file)
@@ -1031,7 +1031,7 @@ function project_file_manifest_path(project_file::String)::Union{Nothing,String}
     explicit_manifest = get(d, "manifest", nothing)::Union{String, Nothing}
     manifest_path = nothing
     if explicit_manifest !== nothing
-        manifest_file = normpath(joinpath(dir, explicit_manifest))
+        manifest_file = joinpath(dir, explicit_manifest)
         if isfile_casesensitive(manifest_file)
             manifest_path = manifest_file
         end
@@ -1055,10 +1055,10 @@ end
 # given a directory (implicit env from LOAD_PATH) and a name,
 # check if it is an implicit package
 function entry_point_and_project_file_inside(dir::String, name::String)::Union{Tuple{Nothing,Nothing},Tuple{String,Nothing},Tuple{String,String}}
-    path = normpath(joinpath(dir, "src", "$name.jl"))
+    path = joinpath(dir, "src", "$name.jl")
     isfile_casesensitive(path) || return nothing, nothing
     for proj in project_names
-        project_file = normpath(joinpath(dir, proj))
+        project_file = joinpath(dir, proj)
         isfile_casesensitive(project_file) || continue
         return path, project_file
     end
@@ -1075,7 +1075,7 @@ function entry_point_and_project_file(dir::String, name::String)::Union{Tuple{No
     path, project_file = entry_point_and_project_file_inside(dir_jl, name)
     path === nothing || return path, project_file
     # check for less likely case with a bare file and no src directory last to minimize stat calls
-    path = normpath(joinpath(dir, "$name.jl"))
+    path = joinpath(dir, "$name.jl")
     isfile_casesensitive(path) && return path, nothing
     return nothing, nothing
 end
@@ -1095,9 +1095,9 @@ end
 
 # given a path, name, and possibly an entryfile, return the entry point
 function entry_path(path::String, name::String, entryfile::Union{Nothing,String})::String
-    isfile_casesensitive(path) && return normpath(path)
+    isfile_casesensitive(path) && return path
     entrypoint = entryfile === nothing ? joinpath("src", "$name.jl") : entryfile
-    return normpath(joinpath(path, entrypoint))
+    return joinpath(path, entrypoint)
 end
 
 ## explicit project & manifest API ##
@@ -1262,7 +1262,7 @@ function explicit_manifest_uuid_load_spec(project_file::String, pkg::PkgId)::Uni
                     error("failed to find source of parent package: \"$name\"")
                 end
                 parent_path = parent_load_spec.path
-                p = normpath(dirname(parent_path), "..")
+                p = joinpath(dirname(parent_path), "..")
                 return PkgLoadSpec(find_ext_path(p, pkg.name), parent_load_spec.julia_syntax_version)
             end
         end
@@ -1290,7 +1290,7 @@ function explicit_manifest_entry_load_spec(manifest_file::String, pkg::PkgId, en
     path = get(entry, "path", nothing)::Union{Nothing, String}
     entryfile = get(entry, "entryfile", nothing)::Union{Nothing, String}
     if path !== nothing
-        path = entry_path(normpath(abspath(dirname(manifest_file), path)), pkg.name, entryfile)
+        path = entry_path(abspath(dirname(manifest_file), path; safe=true), pkg.name, entryfile)
         return PkgLoadSpec(path, syntax_version)
     end
     hash = get(entry, "git-tree-sha1", nothing)::Union{Nothing, String}
@@ -1310,7 +1310,7 @@ function explicit_manifest_entry_load_spec(manifest_file::String, pkg::PkgId, en
     for slug in (version_slug(uuid, hash), version_slug(uuid, hash, 4))
         for depot in DEPOT_PATH
             path = joinpath(depot, "packages", pkg.name, slug)
-            ispath(path) && return PkgLoadSpec(entry_path(abspath(path), pkg.name, entryfile), syntax_version)
+            ispath(path) && return PkgLoadSpec(entry_path(abspath(path; safe=true), pkg.name, entryfile), syntax_version)
         end
     end
     # no depot contains the package, return missing to stop looking
@@ -2425,9 +2425,9 @@ function _include_dependency!(dep_list::Vector{Any}, track_dependencies::Bool,
                               track_content::Bool, path_may_be_dir::Bool)
     prev = source_path(nothing)
     if prev === nothing
-        path = abspath(_path)
+        path = abspath(_path; safe=true)
     else
-        path = normpath(joinpath(dirname(prev), _path))
+        path = normpath(joinpath(dirname(prev), _path); safe=true)
     end
     if !track_dependencies[]
         if !path_may_be_dir && !isfile(path)
@@ -3046,9 +3046,9 @@ function require_stdlib(package_uuidkey::PkgId, ext::Union{Nothing, String}, fro
         if from_stdlib
             # first since this is a stdlib, try to look there directly first
             if ext === nothing
-                sourcepath = normpath(env, this_uuidkey.name, "src", this_uuidkey.name * ".jl")
+                sourcepath = joinpath(env, this_uuidkey.name, "src", this_uuidkey.name * ".jl")
             else
-                sourcepath = find_ext_path(normpath(joinpath(env, package_uuidkey.name)), ext)
+                sourcepath = find_ext_path(joinpath(env, package_uuidkey.name), ext)
             end
             set_pkgorigin_version_path(this_uuidkey, sourcepath)
             newm = _require_search_from_serialized(this_uuidkey, PkgLoadSpec(sourcepath, VERSION), UInt128(0), false; DEPOT_PATH=depot_path)
@@ -3235,13 +3235,14 @@ function evalfile(path::AbstractString, args::Vector{String}=String[])
 end
 evalfile(path::AbstractString, args::Vector) = evalfile(path, String[args...])
 
+# Used in Pkg.jl
 function load_path_setup_code(load_path::Bool=true)
     code = """
-    append!(empty!(Base.DEPOT_PATH), $(repr(map(abspath, DEPOT_PATH))))
-    append!(empty!(Base.DL_LOAD_PATH), $(repr(map(abspath, DL_LOAD_PATH))))
+    append!(empty!(Base.DEPOT_PATH), $(repr(map(x -> abspath(x; safe=true), DEPOT_PATH))))
+    append!(empty!(Base.DL_LOAD_PATH), $(repr(map(x -> abspath(x; safe=true), DL_LOAD_PATH))))
     """
     if load_path
-        load_path = map(abspath, Base.load_path())
+        load_path = map(x -> abspath(x; safe=true), Base.load_path())
         path_sep = Sys.iswindows() ? ';' : ':'
         any(path -> path_sep in path, load_path) &&
             error("LOAD_PATH entries cannot contain $(repr(path_sep))")
@@ -3356,9 +3357,9 @@ function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, outpu
     @nospecialize internal_stderr internal_stdout
     rm(output, force=true)   # Remove file if it exists
     output_o === nothing || rm(output_o, force=true)
-    depot_path = String[abspath(x) for x in DEPOT_PATH]
-    dl_load_path = String[abspath(x) for x in DL_LOAD_PATH]
-    load_path = String[abspath(x) for x in Base.load_path()]
+    depot_path = String[abspath(x; safe=true) for x in DEPOT_PATH]
+    dl_load_path = String[abspath(x; safe=true) for x in DL_LOAD_PATH]
+    load_path = String[abspath(x; safe=true) for x in Base.load_path()]
     # if pkg is a stdlib, append its parent Project.toml to the load path
     triggers = get(EXT_PRIMED, pkg, nothing)
     if triggers !== nothing
@@ -3418,7 +3419,7 @@ function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, outpu
         Base.track_nested_precomp($(_pkg_str(vcat(Base.precompilation_stack, pkg))))
         Base.loadable_extensions = $(_pkg_str(loadable_exts))
         Base.precompiling_extension = $(loading_extension)
-        Base.include_package_for_output($(_pkg_str(pkg)), $(repr(abspath(input.path))), $(repr(input.julia_syntax_version)), $(repr(depot_path)), $(repr(dl_load_path)),
+        Base.include_package_for_output($(_pkg_str(pkg)), $(repr(abspath(input.path; safe=true))), $(repr(input.julia_syntax_version)), $(repr(depot_path)), $(repr(dl_load_path)),
             $(repr(load_path)), $(_pkg_str(concrete_deps)), $(repr(source_path(nothing))))
         """)
     close(io.in)
@@ -3447,7 +3448,7 @@ function compilecache_path(pkg::PkgId, prefs_blob::String; flags::CacheFlags=Cac
     cachepath = joinpath(DEPOT_PATH[1], entrypath)
     isdir(cachepath) || mkpath(cachepath)
     if pkg.uuid === nothing
-        abspath(cachepath, entryfile) * ".ji"
+        abspath(cachepath, entryfile; safe=true) * ".ji"
     else
         crc = _crc32c(project)
         crc = _crc32c(unsafe_string(JLOptions().image_file), crc)
@@ -3461,7 +3462,7 @@ function compilecache_path(pkg::PkgId, prefs_blob::String; flags::CacheFlags=Cac
         crc = _crc32c(cpu_target, crc)
         crc = _crc32c(prefs_blob, crc)
         project_precompile_slug = slug(crc, 5)
-        abspath(cachepath, string(entryfile, "_", project_precompile_slug, ".ji"))
+        abspath(cachepath, string(entryfile, "_", project_precompile_slug, ".ji"); safe=true)
     end
 end
 
@@ -3704,25 +3705,48 @@ function CacheHeaderIncludes(dep_tuple::Tuple{Module, String, UInt64, UInt32, Fl
     return CacheHeaderIncludes(PkgId(dep_tuple[1]), dep_tuple[2:end]..., String[])
 end
 
-function replace_depot_path(path::AbstractString, depots::Vector{String}=normalize_depots_for_relocation())
+function replace_depot_path(path::AbstractString,
+                            depots::AbstractVector{<:Union{String, Tuple{String, String}}}=normalize_depots_for_relocation())
+    # We must handle several cases:
+    # 1. The depot itself is in a symlink'ed path
+    # 2. The files were symlinked into the depot
+    # 3. A combination of both
     for depot in depots
-        if startswith(path, string(depot, Filesystem.pathsep())) || path == depot
-            path = replace(path, depot => "@depot"; count=1)
-            break
+        depotpath = depot isa Tuple{String, String} ? depot[1] : depot
+        if startswith(path, string(depotpath, Filesystem.pathsep())) || path == depotpath
+            # Preserve the path spelling, including case, when it is already within the depot.
+            return replace(path, depotpath => "@depot"; count=1)
+        end
+    end
+    this_realpath = Filesystem.realpath_default(path, nothing)
+    if this_realpath !== nothing
+        for depot in depots
+            depotrealpath = depot isa Tuple{String, String} ? depot[2] : depot
+            if startswith(this_realpath, string(depotrealpath, Filesystem.pathsep())) ||
+                    this_realpath == depotrealpath
+                # Otherwise, use real paths to handle symlinked depots and files.
+                return replace(this_realpath, depotrealpath => "@depot"; count=1)
+            end
         end
     end
     return path
 end
 
 function normalize_depots_for_relocation()
-    depots = String[]
+    depots = Union{String, Tuple{String, String}}[]
     sizehint!(depots, length(DEPOT_PATH))
     for d in DEPOT_PATH
         isdir(d) || continue
         if isdirpath(d)
             d = dirname(d)
         end
-        push!(depots, abspath(d))
+        depotrealpath = realpath(d)
+        depotabspath = abspath(d; safe=true)
+        if depotrealpath != depotabspath
+            push!(depots, (depotabspath, depotrealpath))
+        else
+            push!(depots, depotrealpath)
+        end
     end
     return depots
 end

--- a/base/path.jl
+++ b/base/path.jl
@@ -538,38 +538,55 @@ function _split_at_separators(path::AbstractString; keepempty = true)
 end
 
 """
-    normpath(path::AbstractString)::String
+    normpath(path::AbstractString; safe=false)::String
 
-Normalize a path, removing "." and ".." entries and changing "/" to the canonical path separator
-for the system.
+Normalize a path, removing "." and changing "/" to the canonical path separator
+for the system. If `safe` is false, also removes ".." entries.
+
+!!! warning
+    Normalization with `safe == false` may change the meaning of a path if the
+    directory immediately preceding a ".." entry is a symbolic link.
+    For example, if `a` is a symbolic link in `a/../b`, then this path will
+    resolve to `b` in the link target's parent directory. However,
+    `normpath("a/../b")` will return `b`, which will resolve `b` in the
+    current working directory.
+
+!!! compat "Julia 1.14"
+    The `safe` keyword argument was added in Julia 1.14.
 
 # Examples
 ```jldoctest
 julia> normpath("/home/myuser/../example.jl")
 "/home/example.jl"
 
+julia> normpath("/home/myuser/../example.jl"; safe=true)
+"/home/myuser/../example.jl"
+
 julia> normpath("Documents/Julia") == joinpath("Documents", "Julia")
 true
 ```
 """
-function normpath(path::String)
+function normpath(path::String; safe=false)
     isabs = isabspath(path)
     isdir = isdirpath(path)
     drive, path = splitdrive(path)
     parts = _split_at_separators(path, keepempty = false)
     filter!(!=("."), parts)
-    while true
-        clean = true
-        for j = 1:length(parts)-1
-            if parts[j] != ".." && parts[j+1] == ".."
-                deleteat!(parts, j:j+1)
-                clean = false
-                break
+    if !safe
+        while true
+            clean = true
+            for j = 1:length(parts)-1
+                if parts[j] != ".." && parts[j+1] == ".."
+                    deleteat!(parts, j:j+1)
+                    clean = false
+                    break
+                end
             end
+            clean && break
         end
-        clean && break
     end
     if isabs
+        # N.B.: `..` at the beginning of a path may always be removed
         while !isempty(parts) && parts[1] == ".."
             popfirst!(parts)
         end
@@ -587,18 +604,22 @@ function normpath(path::String)
 end
 
 """
-    normpath(path::AbstractString, paths::AbstractString...)::String
+    normpath(path::AbstractString, paths::AbstractString...; safe=false)::String
 
 Convert a set of paths to a normalized path by joining them together and removing
-"." and ".." entries. Equivalent to `normpath(joinpath(path, paths...))`.
+"." and ".." entries. Equivalent to
+`normpath(joinpath(path, paths...); safe=safe)`.
 """
-normpath(a::AbstractString, b::AbstractString...) = normpath(joinpath(a,b...))
+normpath(a::AbstractString, b::AbstractString...; safe=false) = normpath(joinpath(a,b...); safe)
 
 """
-    abspath(path::AbstractString)::String
+    abspath(path::AbstractString; safe=false)::String
 
 Convert a path to an absolute path by adding the current directory if necessary.
-Also normalizes the path as in [`normpath`](@ref).
+
+The resulting path is normalized as in normpath. If `safe` is false, `..` entries
+are also removed, but the resulting path may not refer to the same location. See
+[`normpath`](@ref) for details.
 
 # Examples
 
@@ -609,8 +630,11 @@ If you are in a directory called `JuliaExample` and the data you are using is tw
 Which gives a path like `"/home/JuliaUser/data/"`.
 
 See also [`joinpath`](@ref), [`pwd`](@ref), [`expanduser`](@ref).
+
+!!! compat "Julia 1.14"
+    The `safe` keyword argument was added in Julia 1.14.
 """
-@noinline function abspath(a::String)::String
+@noinline function abspath(a::String; safe=false)::String
     if !isabspath(a)
         cwd = pwd()
         a_drive, a_nodrive = splitdrive(a)
@@ -621,16 +645,17 @@ See also [`joinpath`](@ref), [`pwd`](@ref), [`expanduser`](@ref).
             a = joinpath(cwd, a)
         end
     end
-    return normpath(a)
+    return normpath(a; safe)
 end
 
 """
-    abspath(path::AbstractString, paths::AbstractString...)::String
+    abspath(path::AbstractString, paths::AbstractString...; safe=false)::String
 
 Convert a set of paths to an absolute path by joining them together and adding the
-current directory if necessary. Equivalent to `abspath(joinpath(path, paths...))`.
+current directory if necessary. Equivalent to
+`abspath(joinpath(path, paths...); safe=safe)`.
 """
-abspath(a::AbstractString, b::AbstractString...) = abspath(joinpath(a,b...))
+abspath(a::AbstractString, b::AbstractString...; safe=false) = abspath(joinpath(a,b...); safe)
 
 if Sys.iswindows()
 
@@ -651,16 +676,7 @@ end
 end # os-test
 
 
-"""
-    realpath(path::AbstractString)::String
-
-Canonicalize a path by expanding symbolic links and removing "." and ".." entries.
-On case-insensitive case-preserving filesystems (typically Mac and Windows), the
-filesystem's stored case for the path is returned.
-
-(This function throws an exception if `path` does not exist in the filesystem.)
-"""
-function realpath(path::AbstractString)
+function _realpath(path::AbstractString, @nospecialize(default), return_default::Bool)
     req = Libc.malloc(_sizeof_uv_fs)
     try
         ret = ccall(:uv_fs_realpath, Cint,
@@ -668,6 +684,9 @@ function realpath(path::AbstractString)
                     C_NULL, req, path, C_NULL)
         if ret < 0
             uv_fs_req_cleanup(req)
+            if return_default && ret in (Base.UV_ENOENT, Base.UV_ENOTDIR)
+                return default
+            end
             uv_error("realpath($(repr(path)))", ret)
         end
         path = unsafe_string(ccall(:jl_uv_fs_t_ptr, Cstring, (Ptr{Cvoid},), req))
@@ -677,6 +696,25 @@ function realpath(path::AbstractString)
         Libc.free(req)
     end
 end
+
+"""
+    realpath(path::AbstractString)::String
+
+Canonicalize a path by expanding symbolic links and removing "." and ".." entries.
+On case-insensitive case-preserving filesystems (typically Mac and Windows), the
+filesystem's stored case for the path is returned.
+
+(This function throws an exception if `path` does not exist in the filesystem.)
+"""
+realpath(path::AbstractString) = _realpath(path, nothing, false)
+
+"""
+    realpath_default(path::AbstractString, default)
+
+Like [`realpath`](@ref), but returns `default` instead of throwing an exception
+if `path` does not exist in the filesystem.
+"""
+realpath_default(path::AbstractString, @nospecialize(default)) = _realpath(path, default, true)
 
 if Sys.iswindows()
 

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -59,10 +59,12 @@ static void write_srctext(ios_t *f, jl_array_t *udeps, int64_t srctextpos) {
             // because these may not be Julia code (and could be huge)
             JL_TYPECHK(write_srctext, deptuple, deptuple);
             if (depmod != (jl_value_t*)jl_main_module) {
-                jl_value_t *abspath = jl_fieldref_noalloc(deptuple, 1);  // file abspath
-                const char *abspathstr = jl_string_data(abspath);
-                if (!abspathstr[0])
+                jl_value_t *abspath_or_uuid = jl_fieldref_noalloc(deptuple, 1);  // file abspath
+                const char *abspathstr = jl_string_data(abspath_or_uuid);
+                if (!abspathstr[0]) {
+                    // UUID or empty string
                     continue;
+                }
                 ios_t *srctp = ios_file(&srctext, abspathstr, 1, 0, 0, 0);
                 if (!srctp) {
                     jl_printf(JL_STDERR, "WARNING: could not cache source text for \"%s\".\n",
@@ -72,7 +74,7 @@ static void write_srctext(ios_t *f, jl_array_t *udeps, int64_t srctextpos) {
 
                 jl_value_t *replace_depot_args[3];
                 replace_depot_args[0] = replace_depot_func;
-                replace_depot_args[1] = abspath;
+                replace_depot_args[1] = abspath_or_uuid;
                 replace_depot_args[2] = depots;
                 jl_value_t *depalias = (jl_value_t*)jl_apply(replace_depot_args, 3);
 

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -799,20 +799,22 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
     for (i = 0; i < l; i++) {
         jl_value_t *deptuple = jl_array_ptr_ref(udeps, i);
         JL_TYPECHK(write_dependency_list, deptuple, deptuple);
-        jl_value_t *deppath = jl_fieldref_noalloc(deptuple, 1);
+        jl_value_t *deppath_or_uuid = jl_fieldref_noalloc(deptuple, 1);
+        const char *deppathstr = jl_string_data(deppath_or_uuid);
 
-        if (replace_depot_func) {
+        if (replace_depot_func && deppathstr[0]) {
+            // deppathstr[0] == '\0' indicates a binpack'ed uuid, not a path
             jl_value_t *replace_depot_args[3];
             replace_depot_args[0] = replace_depot_func;
-            replace_depot_args[1] = deppath;
+            replace_depot_args[1] = deppath_or_uuid;
             replace_depot_args[2] = depots;
-            deppath = (jl_value_t*)jl_apply(replace_depot_args, 3);
-            JL_TYPECHK(write_dependency_list, string, deppath);
+            deppath_or_uuid = (jl_value_t*)jl_apply(replace_depot_args, 3);
+            JL_TYPECHK(write_dependency_list, string, deppath_or_uuid);
         }
 
-        size_t slen = jl_string_len(deppath);
+        size_t slen = jl_string_len(deppath_or_uuid);
         write_int32(s, slen);
-        ios_write(s, jl_string_data(deppath), slen);
+        ios_write(s, jl_string_data(deppath_or_uuid), slen);
         write_uint64(s, jl_unbox_uint64(jl_fieldref(deptuple, 2)));    // fsize
         write_uint32(s, jl_unbox_uint32(jl_fieldref(deptuple, 3)));    // hash
         write_float64(s, jl_unbox_float64(jl_fieldref(deptuple, 4)));  // mtime

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -313,7 +313,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
 
     # ~ expansion in --project and JULIA_PROJECT
     if !Sys.iswindows()
-        let expanded = abspath(expanduser("~/foo/Project.toml"))
+        let expanded = abspath(expanduser("~/foo/Project.toml"); safe=true)
             @test expanded == readchomp(`$exename --project='~/foo' -e 'println(Base.active_project())'`)
             @test expanded == readchomp(`$exename -P '~/foo' -e 'println(Base.active_project())'`)
             @test expanded == readchomp(setenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "~/foo", "HOME" => homedir()))
@@ -321,20 +321,20 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     end
 
     # handling of @projectname in --project and JULIA_PROJECT
-    let expanded = abspath(Base.load_path_expand("@foo"))
+    let expanded = abspath(Base.load_path_expand("@foo"); safe=true)
         @test expanded == readchomp(`$exename --project='@foo' -e 'println(Base.active_project())'`)
         @test expanded == readchomp(`$exename -P '@foo' -e 'println(Base.active_project())'`)
         @test expanded == readchomp(addenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "@foo", "HOME" => homedir()))
     end
 
     # --project=@script handling
-    let expanded = abspath(joinpath(@__DIR__, "project", "ScriptProject"))
+    let expanded = abspath(joinpath(@__DIR__, "project", "ScriptProject"); safe=true)
         script = joinpath(expanded, "bin", "script.jl")
         # Check running julia with --project=@script both within and outside the script directory
         @testset "--@script from $name" for (name, dir) in [("project", expanded), ("outside", pwd())]
-            @test joinpath(expanded, "Project.toml") == readchomp(Cmd(`$exename --project=@script $script`; dir))
-            @test joinpath(expanded, "Project.toml") == readchomp(Cmd(`$exename -P @script $script`; dir))
-            @test joinpath(expanded, "SubProject", "Project.toml") == readchomp(Cmd(`$exename --project=@script/../SubProject $script`; dir))
+            @test samefile(joinpath(expanded, "Project.toml"), readchomp(Cmd(`$exename --project=@script $script`; dir)))
+            @test samefile(joinpath(expanded, "Project.toml"), readchomp(Cmd(`$exename -P @script $script`; dir)))
+            @test samefile(joinpath(expanded, "SubProject", "Project.toml"), readchomp(Cmd(`$exename --project=@script/../SubProject $script`; dir)))
         end
     end
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -274,7 +274,7 @@ end
         n = map(String, split(names, '.'))
         pkg = recurse_package(n...)
         @test pkg == PkgId(UUID(uuid), n[end])
-        @test joinpath(@__DIR__, normpath(path)) == locate_package(pkg)
+        @test samefile(joinpath(@__DIR__, path), locate_package(pkg))
         @test Base.compilecache_path(pkg, "") == Base.compilecache_path(pkg, "")
     end
     @test identify_package("Baz") === nothing
@@ -350,19 +350,19 @@ module NotPkgModule; end
     @test Foo.which == "path"
 
     @testset "pathof" begin
-        @test pathof(Foo) == normpath(abspath(@__DIR__, "project/deps/Foo1/src/Foo.jl"))
+        @test samefile(pathof(Foo), joinpath(@__DIR__, "project/deps/Foo1/src/Foo.jl"))
         @test pathof(NotPkgModule) === nothing
     end
 
     @testset "pkgdir" begin
-        @test pkgdir(Foo) == normpath(abspath(@__DIR__, "project/deps/Foo1"))
-        @test pkgdir(Foo.SubFoo1) == normpath(abspath(@__DIR__, "project/deps/Foo1"))
-        @test pkgdir(Foo.SubFoo2) == normpath(abspath(@__DIR__, "project/deps/Foo1"))
+        @test samefile(pkgdir(Foo), joinpath(@__DIR__, "project/deps/Foo1"))
+        @test samefile(pkgdir(Foo.SubFoo1), joinpath(@__DIR__, "project/deps/Foo1"))
+        @test samefile(pkgdir(Foo.SubFoo2), joinpath(@__DIR__, "project/deps/Foo1"))
         @test pkgdir(NotPkgModule) === nothing
 
-        @test pkgdir(Foo, "src") == normpath(abspath(@__DIR__, "project/deps/Foo1/src"))
-        @test pkgdir(Foo.SubFoo1, "src") == normpath(abspath(@__DIR__, "project/deps/Foo1/src"))
-        @test pkgdir(Foo.SubFoo2, "src") == normpath(abspath(@__DIR__, "project/deps/Foo1/src"))
+        @test samefile(pkgdir(Foo, "src"), joinpath(@__DIR__, "project/deps/Foo1/src"))
+        @test samefile(pkgdir(Foo.SubFoo1, "src"), joinpath(@__DIR__, "project/deps/Foo1/src"))
+        @test samefile(pkgdir(Foo.SubFoo2, "src"), joinpath(@__DIR__, "project/deps/Foo1/src"))
         @test pkgdir(NotPkgModule, "src") === nothing
     end
 
@@ -1358,7 +1358,9 @@ end
         _ext = Base.get_extension(parent, ext)
         _ext isa Module || error("expected extension \$ext to be loaded")
         _pkgdir = pkgdir(_ext)
-        _pkgdir == pkgdir(parent) !== nothing || error("unexpected extension \$ext pkgdir path: \$_pkgdir")
+        _parent_pkgdir = pkgdir(parent)
+        _pkgdir !== nothing && _parent_pkgdir !== nothing && samefile(_pkgdir, _parent_pkgdir) ||
+            error("unexpected extension \$ext pkgdir path: \$_pkgdir")
         _pkgversion = pkgversion(_ext)
         _pkgversion == pkgversion(parent) || error("unexpected extension \$ext version: \$_pkgversion")
     end
@@ -2163,5 +2165,48 @@ end
         @test contains(output, "SUCCESS")
     finally
         rm(tmpdir; recursive=true, force=true)
+    end
+end
+
+# Test loading when project or depot paths contain the symlink/.. pattern
+if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
+    @testset "symlink/.. in project or depot paths" begin
+        mktempdir() do dir
+            old_load_path = copy(LOAD_PATH)
+            old_active_project = Base.ACTIVE_PROJECT[]
+
+            # Create a symlinked subdirectory
+            symlink_dir = joinpath(dir, "project_symlink")
+            target_dir = joinpath(@__DIR__, "project", "deps", "Foo1", "src")
+            symlink(target_dir, symlink_dir)
+            symlink_parent = joinpath(symlink_dir, "..")
+            try
+                # test symlink'd project path
+                Base.set_active_project(symlink_parent)
+                push!(empty!(LOAD_PATH), "@")
+
+                Foo1_uuid = Base.UUID("1a6589dc-c33c-4d54-9a54-f7fc4b3ff616")
+                id = Base.identify_package("Foo")
+                @test id.uuid == Foo1_uuid
+                located = Base.locate_package(id)
+                @test located !== nothing
+                @test samefile(located, joinpath(target_dir, "Foo.jl"))
+
+                # Test symlink'd depot path
+                symlink_depot = joinpath(dir, "depot_symlink")
+                target_dir = joinpath(@__DIR__, "depot", "packages")
+                symlink(target_dir, symlink_depot)
+                push!(empty!(LOAD_PATH), joinpath(@__DIR__, "project"))
+                push!(empty!(DEPOT_PATH), joinpath(symlink_depot, ".."))
+                pkg = Base.identify_package(
+                    Base.PkgId(Base.UUID("2a550a13-6bab-4a91-a4ee-dff34d6b99d0"), "Bar"), "Baz")
+                @test pkg !== nothing
+                @test samefile(Base.locate_package(pkg), joinpath(target_dir, "Baz", "81oLe", "src", "Baz.jl"))
+            finally
+                Base.ACTIVE_PROJECT[] = old_active_project
+                copy!(LOAD_PATH, old_load_path)
+                copy!(DEPOT_PATH, original_depot_path)
+            end
+        end
     end
 end

--- a/test/path.jl
+++ b/test/path.jl
@@ -9,6 +9,8 @@ using Main: samepath
     @testset "isabspath and abspath" begin
         @test abspath(S("foo")) == "$dir$(sep)foo"
         @test abspath(S("foo"), S("bar")) == "$dir$(sep)foo$(sep)bar"
+        @test abspath(S("foo"), S(".."), S("bar"); safe=true) ==
+            joinpath(dir, "foo", "..", "bar")
         @test isabspath(S(homedir()))
         @test !isabspath(S("foo"))
     end
@@ -165,6 +167,7 @@ using Main: samepath
         @test normpath(S(joinpath("foo",".","..","..","bar"))) == "..$(sep)bar"
         @test normpath(S(joinpath("foo","..",".","..","bar"))) == "..$(sep)bar"
         @test normpath(S(joinpath("foo","..","..",".","bar"))) == "..$(sep)bar"
+        @test normpath(S("foo"), S(".."), S("bar"); safe=true) == "foo$(sep)..$(sep)bar"
         @test normpath(normpath(S(joinpath("a", "..", "b", ".", "c")))) == normpath(S(joinpath("a", "..", "b", ".", "c")))
     end
     @test relpath(S(joinpath("foo","bar")), S("foo")) == "bar"

--- a/test/relocatedepot.jl
+++ b/test/relocatedepot.jl
@@ -58,6 +58,19 @@ if !test_relocated_depot
                 @test Base.replace_depot_path(jlrc) != "@depot-rc2"
                 @test Base.replace_depot_path(jlrc) == jlrc
             end
+
+            # Preserve a dependency's lexical path when it is a symlink within the depot.
+            if !Sys.iswindows()
+                empty!(DEPOT_PATH)
+                mkdepottempdir() do dir
+                    target = joinpath(dir, "target")
+                    link = joinpath(dir, "link")
+                    touch(target)
+                    symlink(target, link)
+                    push!(DEPOT_PATH, dir)
+                    @test Base.replace_depot_path(link) == joinpath("@depot", "link")
+                end
+            end
         end
 
         # deal with and without trailing path separators


### PR DESCRIPTION
Unix path semantics allow a symbolic link followed by .. to resolve through the link target, so lexical normalization can change which file a path names. Loading and precompilation were applying normpath directly or through abspath, causing packages in these paths to fail to load.

Add a safe normalization mode that removes harmless dot components while preserving .., use it throughout code loading, and keep depot relocation path spellings intact before falling back to realpath. This preserves symlink semantics and avoids case-folding dependency names on case-insensitive filesystems.

CI failure: https://buildkite.com/julialang/julia-master/builds/52413#019acc0f-d552-4fb6-afd2-7cf7d1266411

Written with AI assistance (OpenAI Codex).