### PR TITLE
[JuliaLowering] Restrict `K"VERSION"` to module arg

### DIFF
--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -125,6 +125,15 @@ ctx, expanded = JuliaLowering.expand_forms_1(test_mod, ex, false, Base.get_world
 @test JuliaLowering.include_string(test_mod, raw"""
 v"1.14"
 """) isa VersionNumber
+@test JuliaLowering.include_string(test_mod, raw"""
+v"1.14"
+""";expr_compat_mode=true) isa VersionNumber
+@test JuliaLowering.include_string(test_mod, raw"""
+Base.Experimental.@VERSION
+""") isa NamedTuple
+@test JuliaLowering.include_string(test_mod, raw"""
+Base.Experimental.@VERSION
+""";expr_compat_mode=true) isa NamedTuple
 
 # World age support for macro expansion
 JuliaLowering.include_string(test_mod, raw"""

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -122,6 +122,10 @@ ctx, expanded = JuliaLowering.expand_forms_1(test_mod, ex, false, Base.get_world
     "y"
 ]
 
+@test JuliaLowering.include_string(test_mod, raw"""
+v"1.14"
+""") isa VersionNumber
+
 # World age support for macro expansion
 JuliaLowering.include_string(test_mod, raw"""
 macro world_age_test()


### PR DESCRIPTION
Fixes stdlib precompilation after #60018: the `v_str` macro produces a
     `VersionNumber`, which becomes `K"VERSION"`, which is unhandled syntax.  I
     think the intent was to only give it special treatment as the child of a
     module expression (not make VersionNumber special syntax).