### PR TITLE
[JuliaLowering] `ccall((lib,sym)...)` and `cfunction` fixes

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -1724,13 +1724,12 @@ end
 
 # Expand the (sym,lib) argument to ccall/cglobal
 function expand_C_library_symbol(ctx, ex)
-    expanded = expand_forms_2(ctx, ex)
     if kind(ex) == K"tuple"
-        expanded = @ast ctx ex [K"static_eval"(meta=name_hint("function name and library expression"))
-            expanded
+        return @ast ctx ex [K"static_eval"(meta=name_hint("function name and library expression"))
+            mapchildren(e->expand_forms_2(ctx,e), ctx, ex)
         ]
     end
-    return expanded
+    return expand_forms_2(ctx, ex)
 end
 
 function expand_ccall(ctx, ex)

--- a/JuliaLowering/src/syntax_macros.jl
+++ b/JuliaLowering/src/syntax_macros.jl
@@ -90,10 +90,10 @@ function Base.var"@cfunction"(__context__::MacroContext, callable, return_type, 
         typ = Base.CFunction
     else
         # Kinda weird semantics here - without `$`, the callable is a top level
-        # expression which will be evaluated by `jl_resolve_globals_in_ir`,
-        # implicitly within the module where the `@cfunction` is expanded into.
-        fptr = @ast __context__ callable [K"static_eval"(
-                meta=name_hint("cfunction function name"))
+        # expression evaluated within the module where the `@cfunction` is
+        # expanded into.
+        fptr = @ast __context__ callable [K"inert"(
+                meta=CompileHints(:as_Expr, true))
             callable
         ]
         typ = Ptr{Cvoid}

--- a/JuliaLowering/test/function_calls_ir.jl
+++ b/JuliaLowering/test/function_calls_ir.jl
@@ -370,7 +370,7 @@ ccall((:strlen, libc), Csize_t, (Cstring,), "asdfg")
 1   TestMod.Cstring
 2   (call top.cconvert %₁ "asdfg")
 3   (call top.unsafe_convert %₁ %₂)
-4   (foreigncall (static_eval (call core.tuple :strlen TestMod.libc)) (static_eval TestMod.Csize_t) (static_eval (call core.svec TestMod.Cstring)) 0 :ccall %₃ %₂)
+4   (foreigncall (static_eval (tuple-p :strlen TestMod.libc)) (static_eval TestMod.Csize_t) (static_eval (call core.svec TestMod.Cstring)) 0 :ccall %₃ %₂)
 5   (return %₄)
 
 ########################################
@@ -521,7 +521,7 @@ ccall(:foo, Csize_t, (Cstring..., Cstring...), "asdfg", "blah")
 cglobal((:sym, lib), Int)
 #---------------------
 1   TestMod.Int
-2   (call core.cglobal (static_eval (call core.tuple :sym TestMod.lib)) %₁)
+2   (call core.cglobal (static_eval (tuple-p :sym TestMod.lib)) %₁)
 3   (return %₂)
 
 ########################################

--- a/JuliaLowering/test/misc_ir.jl
+++ b/JuliaLowering/test/misc_ir.jl
@@ -355,7 +355,7 @@ JuxtuposeTest.@emit_juxtupose
 # @cfunction expansion with global generic function as function argument
 @cfunction(callable, Int, (Int, Float64))
 #---------------------
-1   (cfunction Ptr{Nothing} (static_eval TestMod.callable) (static_eval TestMod.Int) (static_eval (call core.svec TestMod.Int TestMod.Float64)) :ccall)
+1   (cfunction Ptr{Nothing} (inert callable) (static_eval TestMod.Int) (static_eval (call core.svec TestMod.Int TestMod.Float64)) :ccall)
 2   (return %₁)
 
 ########################################


### PR DESCRIPTION
- `ccall` with a `lib,sym` tuple argument was being desugared to a call to `Core.Tuple` when we actually want an `Expr(:tuple)`

- `cfunction` only worked in simple cases, since the check for local variables in scope resolution will fail with any nontrivial function body.  I know that using the new `static_eval` head could be considered a bugfix (see discussion at https://github.com/JuliaLang/JuliaLowering.jl/pull/36), but this PR just uses `inert` to match Base.

stdlib status: 38/51 (with #60255)