### PR TITLE
MersenneTwister: fix constructor involving jumped state

### DIFF
--- a/stdlib/Random/src/MersenneTwister.jl
+++ b/stdlib/Random/src/MersenneTwister.jl
@@ -634,8 +634,6 @@ function advance!(r::MersenneTwister, adv_jump, adv, adv_vals, idxF, adv_ints, i
         _advance_F!(r, adv_vals, idxF, work)
     elseif advI
         _advance_I!(r, adv_ints, idxI, work)
-    else
-        @assert adv == 0
     end
     _advance_to!(r, adv, work)
     r

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -967,6 +967,13 @@ end
         m = MersenneTwister(0); rand(m, Int64); rand(m)
         @test string(m) == "MersenneTwister(0x48d73dc42d195740db2fa90498613fdf, 0x1911b814c02405e88c49bc52dc8a77ea, 0, 2256, 1254, 1, 0, 1)"
         @test m == MersenneTwister(0x48d73dc42d195740db2fa90498613fdf, 0x1911b814c02405e88c49bc52dc8a77ea, 0, 2256, 1254, 1, 0, 1)
+
+        # generate then jump
+        m = MersenneTwister(123)
+        rand(m)
+        Random.jump!(m, 2*big(10)^20)
+        @test string(m) == "MersenneTwister(0xf80cc98e147960c1fefa8d41b8f5dca5, 0xea7a7dcb2e787c0120e2ccc17662fc1d, 200000000000000000000, 1002)"
+        @test m == MersenneTwister(0xf80cc98e147960c1fefa8d41b8f5dca5, 0xea7a7dcb2e787c0120e2ccc17662fc1d, 200000000000000000000, 1002)
     end
 
     @testset "RandomDevice" begin


### PR DESCRIPTION
`show` for `MersenneTwister` outputs valid input syntax, by dumping a condensed state, which is used by the constructor to reconstruct the real state.

In the case where `rand` is called on an instance which is then jumped, the output state was triggering an assertion error when parsed back; this assertion was wrong, so remove it. For example:
```
julia> m = MersenneTwister(123); rand(m); Random.jump!(m, big(10)^20)
MersenneTwister(0xf80cc98..., 0xea7a7d..., 100000000000000000000, 1002)

julia> MersenneTwister(0xf80cc98..., 0xea7a7d..., 100000000000000000000, 1002)
ERROR: AssertionError: adv == 0
Stacktrace:
[...]
```