### PR TITLE
Proactively compile lambdas when the type of the closure is known

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1642,6 +1642,14 @@ function collectinvokes!(workqueue::CompilationQueue, ci::CodeInfo, sptypes::Vec
                 push!(argtypes, sp_type_rewrap(at[i], linfo, #= isreturn =# false))
             end
             atype = argtypes_to_type(argtypes)
+        elseif isexpr(stmt, :new)
+            # When creating a struct of Function type, check to see if we should
+            # proactively compile the lambda
+            t = argextype(stmt.args[1], ci, sptypes)
+            t isa Const || continue
+            t.val::DataType
+            t.val <: Function || continue
+            atype = Tuple{t.val, Vararg}
         else
             # TODO: handle other StmtInfo like OpaqueClosure?
             continue

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1645,11 +1645,9 @@ function collectinvokes!(workqueue::CompilationQueue, ci::CodeInfo, sptypes::Vec
         elseif isexpr(stmt, :new)
             # When creating a struct of Function type, check to see if we should
             # proactively compile the lambda
-            t = argextype(stmt.args[1], ci, sptypes)
-            t isa Const || continue
-            t.val::DataType
-            t.val <: Function || continue
-            atype = Tuple{t.val, Vararg}
+            t, _, _, _ = instanceof_tfunc(argextype(stmt.args[1], ci, sptypes))
+            t <: Function || continue
+            atype = Tuple{t, Vararg}
         else
             # TODO: handle other StmtInfo like OpaqueClosure?
             continue


### PR DESCRIPTION
If a method we precompile instantiates a closure struct, and there is a single compileable signature for the closure method, we can compile the closure method with few downsides.

For example:
```
f(x::T) where {T <: Number} = y::T -> x+y
precompile(f, (Int,))

f(1)(2)
```

Before, the closure method would not get precompiled, resulting in `--trace-compile` output:
`precompile(Tuple{Foo.var"#f##0#f##1"{Int64, Int64}, Int64})`

This idea was motivated by trying to make the REPL precompile script more "static".  Creating a task with `@task` or `@async` expands into a no-argument lambda, which won't get precompiled with the containing method.