### PR TITLE
Check type hash as an early out in `egal_types`

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -176,6 +176,8 @@ static int egal_types(const jl_value_t *a, const jl_value_t *b, jl_typeenv_t *en
     if (dtag == jl_datatype_tag << 4) {
         jl_datatype_t *dta = (jl_datatype_t*)a;
         jl_datatype_t *dtb = (jl_datatype_t*)b;
+        if (dta->hash && dtb->hash && dta->hash != dtb->hash)
+            return 0;
         if (dta->name != dtb->name)
             return 0;
         size_t i, l = jl_nparams(dta);


### PR DESCRIPTION
We were mostly curious whether the `hash` field of `jl_datatype_t` could be utilized to speed up type comparisons, as those showed up in our CPU profiles during package image loading (i.e. in `jl_types_equal` and `jl_types_egal`). After discussing this idea briefly in the public Julia slack ([thread](https://julialang.slack.com/archives/C688QKS7Q/p1763743659581359)), @nathan and @topolarity suggested bringing this idea forward to discuss whether it's legal and worthwhile with a broader audience.

CC: @vtjnash, who perhaps knows best whether the idea makes sense.