### PR TITLE
#59114 issue: Converted do-block to lambda before the call expression…

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2260,7 +2260,19 @@ function _inferred(ex, mod, allow = :(Union{}))
     if Meta.isexpr(ex, :ref)
         ex = Expr(:call, :getindex, ex.args...)
     end
+    
+    if Meta.isexpr(ex, :do)
+
+        call_part = ex.args[1]
+        func_part = ex.args[2]
+
+        lambda = Expr(:->, func_part.args[1], func_part.args[2])
+
+        ex = Expr(:call, call_part.args[1], lambda, call_part.args[2:end]...)
+    end
+    
     Meta.isexpr(ex, :call)|| error("@inferred requires a call expression")
+
     farg = ex.args[1]
     if isa(farg, Symbol) && farg !== :.. && first(string(farg)) == '.'
         farg = Symbol(string(farg)[2:end])


### PR DESCRIPTION
The issue here was that the macro checks if ex is a :call expression, but as do-block is used so it has't been converted yet 

so the issue is fixed by converting do block to lambda before checking of call expression