### PR TITLE
Add support for optionally printing unsigned integers as decimals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,9 @@ New library functions
 New library features
 --------------------
 
+* `IOContext` supports a new boolean `hexunsigned` option that allows for
+  printing unsigned integers in decimal instead of hexadecimal ([#60267]).
+
 Standard library changes
 ------------------------
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1302,7 +1302,11 @@ function show(io::IO, n::Unsigned)
     if get(io, :hexunsigned, true)::Bool
         print(io, "0x", string(n, pad = sizeof(n)<<1, base = 16))
     else
-        print(io, string(n), "u")
+        if get(io, :typeinfo, Nothing)::Type == typeof(n)
+            print(io, n)
+        else
+            print(io, typeof(n), "($(n))")
+        end
     end
 end
 print(io::IO, n::Unsigned) = print(io, string(n))

--- a/base/show.jl
+++ b/base/show.jl
@@ -385,6 +385,11 @@ The following properties are in common use:
  - `:color`: Boolean specifying whether ANSI color/escape codes are supported/expected.
    By default, this is determined by whether `io` is a compatible terminal and by any
    `--color` command-line flag when `julia` was launched.
+ - `:hexunsigned`: Boolean specifying whether to print unsigned integers in
+   hexadecimal. Defaults to `true`, otherwise they will be printed in decimal.
+
+!!! compat "Julia 1.14"
+    The `:hexunsigned` option requires Julia 1.14 or later.
 
 # Examples
 
@@ -1293,7 +1298,13 @@ nonnothing_nonmissing_typeinfo(io::IO) = nonmissingtype(nonnothingtype(get(io, :
 show(io::IO, b::Bool) = print(io, nonnothing_nonmissing_typeinfo(io) === Bool ? (b ? "1" : "0") : (b ? "true" : "false"))
 show(io::IO, ::Nothing) = print(io, "nothing")
 show(io::IO, n::Signed) = (write(io, string(n)); nothing)
-show(io::IO, n::Unsigned) = print(io, "0x", string(n, pad = sizeof(n)<<1, base = 16))
+function show(io::IO, n::Unsigned)
+    if get(io, :hexunsigned, true)::Bool
+        print(io, "0x", string(n, pad = sizeof(n)<<1, base = 16))
+    else
+        print(io, string(n), "u")
+    end
+end
 print(io::IO, n::Unsigned) = print(io, string(n))
 
 has_tight_type(p::Pair) =

--- a/test/show.jl
+++ b/test/show.jl
@@ -1364,7 +1364,10 @@ end
         @test repr == "Ptr{UInt8}($(Base.repr(UInt(1))))\n"
     end
     let repr = sprint(show, UInt(42); context=(:hexunsigned => false))
-        @test repr == "42u"
+        @test repr == "$(UInt)(42)"
+    end
+    let repr = sprint(show, UInt16[1, 2]; context=(:hexunsigned => false))
+        @test repr == "UInt16[1, 2]"
     end
     let repr = sprint(dump, Core.svec())
         @test repr == "empty SimpleVector\n"

--- a/test/show.jl
+++ b/test/show.jl
@@ -1363,6 +1363,9 @@ end
     let repr = sprint(dump, Ptr{UInt8}(UInt(1)))
         @test repr == "Ptr{UInt8}($(Base.repr(UInt(1))))\n"
     end
+    let repr = sprint(show, UInt(42); context=(:hexunsigned => false))
+        @test repr == "42u"
+    end
     let repr = sprint(dump, Core.svec())
         @test repr == "empty SimpleVector\n"
     end


### PR DESCRIPTION
This is something I've wanted for a while as I sometimes work with unsigned data. There's some previous discussion here: https://github.com/JuliaLang/julia/issues/30167. Note that this PR only adds an option to enable decimal printing rather than making it the default.

Following a suggestion in that issue I made `show()` add a `u` suffix, but one could argue people would mistake it as Julia syntax for unsigned literals (as it is in e.g. C++). I think that's an ok tradeoff to keep it obvious that a value is unsigned, but I don't feel very strongly about it.

Some examples of it in action:
```julia-repl
julia> function Base.show(io::IO, n::Unsigned)
           if get(io, :hexunsigned, true)::Bool
               print(io, "0x", string(n, pad = sizeof(n)<<1, base = 16))
           else
               print(io, string(n), "u")
           end
       end

julia> Base.active_repl.options.iocontext[:hexunsigned] = false
false

julia> rand(UInt8, 10)
10-element Vector{UInt8}:
 222u
 249u
  72u
 143u
 136u
  25u
 103u
  55u
  25u
  22u

julia> using Sockets

julia> listenany(8080)
(8080u, Sockets.TCPServer(RawFD(23) active))
```