### PR TITLE
loading: Clamp Julia syntax version from Manifest as well

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1222,6 +1222,10 @@ function explicit_manifest_entry_load_spec(manifest_file::String, pkg::PkgId, en
     syntax_table = get(entry, "syntax", nothing)
     if syntax_table !== nothing
         syntax_version = VersionNumber(get(syntax_table, "julia_version", nothing))
+        # Clamp to minimum supported syntax version
+        if syntax_version <= NON_VERSIONED_SYNTAX
+            syntax_version = NON_VERSIONED_SYNTAX
+        end
     end
 
     # Resolve path

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1910,6 +1910,8 @@ module M58272_to end
         @test invokelatest(getglobal, (@eval (using VersionedDep1; VersionedDep1)), :ver) == v"1.13"
         # syntax.julia_version from Manifest = "1.14"
         @test invokelatest(getglobal, (@eval (using VersionedDep2; VersionedDep2)), :ver) == v"1.14"
+        # syntax.julia_version from Manifest = "1.0" should be clamped to "1.13"
+        @test invokelatest(getglobal, (@eval (using VersionedDep3; VersionedDep3)), :ver) == v"1.13"
     finally
         Base.ACTIVE_PROJECT[] = old_active_project
         copy!(LOAD_PATH, old_load_path)

--- a/test/project/SyntaxVersioning/explicit/Manifest.toml
+++ b/test/project/SyntaxVersioning/explicit/Manifest.toml
@@ -12,3 +12,8 @@ syntax.julia_version = "1.13.0"
 path = "VersionedDep2"
 uuid = "e127e659-a899-4a00-b565-5b74face18ba"
 syntax.julia_version = "1.14.0"
+
+[[deps.VersionedDep3]]
+path = "VersionedDep3"
+uuid = "6ae26a88-8a9e-4c29-a00a-ea2b9a48e6e1"
+syntax.julia_version = "1.0.0"

--- a/test/project/SyntaxVersioning/explicit/Project.toml
+++ b/test/project/SyntaxVersioning/explicit/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 VersionedDep1 = "f08855a0-36cb-4a32-8ae5-a227b709c612"
 VersionedDep2 = "e127e659-a899-4a00-b565-5b74face18ba"
+VersionedDep3 = "6ae26a88-8a9e-4c29-a00a-ea2b9a48e6e1"

--- a/test/project/SyntaxVersioning/explicit/VersionedDep3/Project.toml
+++ b/test/project/SyntaxVersioning/explicit/VersionedDep3/Project.toml
@@ -1,0 +1,3 @@
+name = "VersionedDep3"
+uuid = "6ae26a88-8a9e-4c29-a00a-ea2b9a48e6e1"
+syntax.julia_version = "1.0"

--- a/test/project/SyntaxVersioning/explicit/VersionedDep3/src/VersionedDep3.jl
+++ b/test/project/SyntaxVersioning/explicit/VersionedDep3/src/VersionedDep3.jl
@@ -1,0 +1,3 @@
+module VersionedDep3
+    const ver = (@Base.Experimental.VERSION).syntax
+end


### PR DESCRIPTION
This is really a Pkg bug, where I forgot to implement the clamping when generating the manifest (and will submit a PR), but since we clamp and override when loading from a Project.toml, it seems reasonable to do the same for Manifest.toml. We never want to use a syntax version less than 1.13, so cut off that path as well, without assuming that Pkg.jl gets it right (too much manual editing of Manifest files happening with AI assistants).

Fixes #60273
Written by Claude.