### PR TITLE
JuliaSyntax: Disallow broadcasted getindex

### DIFF
--- a/JuliaSyntax/src/julia/parser.jl
+++ b/JuliaSyntax/src/julia/parser.jl
@@ -1744,6 +1744,14 @@ function parse_call_chain(ps::ParseState, mark, is_macrocall=false)
                 emit(ps, emark, K"error",
                      error="the .' operator for transpose is discontinued")
                 emit(ps, mark, K"dotcall", POSTFIX_OP_FLAG)
+            elseif k == K"[" || k == K"{"
+                # f.[x]  ==>  (error f x)
+                # f.{x}  ==>  (error f x)
+                # Parse as broadcasted brackets, then wrap in error
+                close = k == K"[" ? K"]" : K"}"
+                bump(ps, TRIVIA_FLAG)
+                parse_cat(ParseState(ps, end_symbol=true), close, ps.end_symbol)
+                emit(ps, mark, K"error", error="brackets are not allowed after `.`")
             else
                 if saw_misplaced_atsym
                     # If we saw a misplaced `@` earlier, this might be the place

--- a/JuliaSyntax/test/diagnostics.jl
+++ b/JuliaSyntax/test/diagnostics.jl
@@ -48,6 +48,10 @@ end
         Diagnostic(3, 4, :error, "`@` must appear on first or last macro name component")
     @test diagnostic("@M.(x)") ==
         Diagnostic(1, 3, :error, "dot call syntax not supported for macros")
+    @test diagnostic("a.[x]") ==
+        Diagnostic(1, 5, :error, "brackets are not allowed after `.`")
+    @test diagnostic("a.{x}") ==
+        Diagnostic(1, 5, :error, "brackets are not allowed after `.`")
 
     @test diagnostic("try x end") ==
         Diagnostic(1, 9, :error, "try without catch or finally")

--- a/JuliaSyntax/test/parser.jl
+++ b/JuliaSyntax/test/parser.jl
@@ -447,6 +447,9 @@ tests = [
         "A.@x"      =>  "(macrocall (. A (macro_name x)))"
         "A.@x a"    =>  "(macrocall (. A (macro_name x)) a)"
         "@A.B.@x a" =>  "(macrocall (macro_name (. (. A B) (error-t) x)) a)"
+        # .[ and .{ disallowed
+        "f.[x]"  =>  "(error f x)"
+        "f.{x}"  =>  "(error f x)"
         # .' discontinued
         "f.'"    =>  "(dotcall-post f (error '))"
         # Field/property syntax

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -946,9 +946,8 @@ g21054(>:) = >:2
 @test g21054(-) == -2
 
 # issue #21168
-@test_loweringerror(:(a.[1]), "invalid syntax \"a.[1]\"", broken)
-@test_loweringerror(:(a.[1]), "invalid syntax \"a.[1]\"", broken)
-@test_loweringerror(:(a.{1}), "invalid syntax \"a.{1}\"", broken)
+@test_parseerror "a.[1]"
+@test_parseerror "a.{1}"
 
 # Issue #21225
 let abstr = Meta.parse("abstract type X end")
@@ -1516,10 +1515,7 @@ end
 @test c27964(8) == (8, 2)
 
 # issue #26739
-let exc = try Core.eval(@__MODULE__, :(sin.[1])) catch exc ; exc end
-    @test_broken exc isa ErrorException
-    @test_broken startswith(exc.msg, "syntax: invalid syntax \"sin.[1]\"")
-end
+@test_parseerror "sin.[1]"
 
 # issue #26873
 f26873 = 0


### PR DESCRIPTION
The flisp parser rejects expressions like `[1,2].[(1,2)]` with a syntax error, but JuliaSyntax was allowing them to parse and then fail at runtime with a confusing MethodError about getproperty.

Note that in the flisp parser, this was allowed in the parser, but then disallowed in lowering. It's all a bit messy. My preference is to disallow this at the parser level for now and then introduce this as a proper feature with syntax evolution in the future. I don't think we want the production here to match what the flisp parser used to do. Given all those considerations, I think a syntax error is appropriate here for the moment.

Fixes #60270