### PR TITLE
Relax timing restriction in pidfile test

### DIFF
--- a/stdlib/FileWatching/test/pidfile.jl
+++ b/stdlib/FileWatching/test/pidfile.jl
@@ -236,7 +236,7 @@ end
     @test t < 2
     t = @elapsed f = open_exclusive("pidfile", poll_interval=3, stale_age=10)::File
     close(f)
-    @test 8 < t < 20
+    @test 8 < t < 25
     rm("pidfile")
 end
 


### PR DESCRIPTION
This test seems to fail in CI sometimes https://buildkite.com/julialang/julia-master/builds/52432?group_by=test#019ace8b-f069-4916-8efa-b38d6e46614b