### PR TITLE
Use POSIX shell instead of Bash in escape_json.sh

### DIFF
--- a/contrib/escape_json.sh
+++ b/contrib/escape_json.sh
@@ -1,10 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # print arguments escaped as json list elements
 
 first=true
 for n in "$@"; do
   $first && first=false || printf ', '
-  n="${n//\\/\\\\}"
-  n="${n//\"/\\\"}"
+  n=$(printf '%s' "$n" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
   printf '"%s"' "$n"
 done


### PR DESCRIPTION
`/bin/bash` doesn't exist everywhere (e.g., FreeBSD), while `/bin/sh` should. Luckily the Bashisms that were used are easily replaced with a couple of `sed`s, so the changes are minimal.

Marking for backport to 1.13 since this was introduced before branching and it fixes annoying "no such file or directory" messages observed while building on FreeBSD.