### PR TITLE
#57287 Issue:Resolved the problem of missing colon

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -159,7 +159,7 @@ struct Fail <: Result
         return new(test_type,
             string(orig_expr),
             data === nothing ? nothing : string(data),
-            string(isa(data, Type) ? typeof(value) : value),
+            repr(isa(data, Type) ? typeof(value) : value),
             context,
             source,
             message_only,


### PR DESCRIPTION
Here I found the problem during the ternary operator 
the string(:sym) is evaluated as "sym".  So replaced it with repr(:sym) which is now evaluated as ":sym". and we got our colon saved

References #57287