### PR TITLE
threads: Implement asymmetric atomic fences

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -716,7 +716,7 @@ end
 @nospecs function pointerset_tfunc(𝕃::AbstractLattice, a, v, i, align)
     return a
 end
-@nospecs function atomic_fence_tfunc(𝕃::AbstractLattice, order)
+@nospecs function atomic_fence_tfunc(𝕃::AbstractLattice, order, syncscope)
     return Nothing
 end
 @nospecs function atomic_pointerref_tfunc(𝕃::AbstractLattice, a, order)
@@ -757,7 +757,7 @@ add_tfunc(add_ptr, 2, 2, pointerarith_tfunc, 1)
 add_tfunc(sub_ptr, 2, 2, pointerarith_tfunc, 1)
 add_tfunc(pointerref, 3, 3, pointerref_tfunc, 4)
 add_tfunc(pointerset, 4, 4, pointerset_tfunc, 5)
-add_tfunc(atomic_fence, 1, 1, atomic_fence_tfunc, 4)
+add_tfunc(atomic_fence, 2, 2, atomic_fence_tfunc, 4)
 add_tfunc(atomic_pointerref, 2, 2, atomic_pointerref_tfunc, 4)
 add_tfunc(atomic_pointerset, 3, 3, atomic_pointerset_tfunc, 5)
 add_tfunc(atomic_pointerswap, 3, 3, atomic_pointerswap_tfunc, 5)

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,10 @@ Command-line option changes
 Multi-threading changes
 -----------------------
 
+  - New functions `Threads.atomic_fence_heavy` and `Threads.atoimc_fence_light` provide support for
+    asymmetric atomic fences, speeding up atomic synchronization where one side of the synchronization
+    runs significantly less often than the other ([#60311]).
+
 Build system changes
 --------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,7 @@ Command-line option changes
 Multi-threading changes
 -----------------------
 
-  - New functions `Threads.atomic_fence_heavy` and `Threads.atoimc_fence_light` provide support for
+  - New functions `Threads.atomic_fence_heavy` and `Threads.atomic_fence_light` provide support for
     asymmetric atomic fences, speeding up atomic synchronization where one side of the synchronization
     runs significantly less often than the other ([#60311]).
 

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -165,7 +165,7 @@ function _trywait(t::Union{Timer, AsyncCondition})
     set = t.set
     if set
         # full barrier now for AsyncCondition
-        t isa Timer || Core.Intrinsics.atomic_fence(:acquire_release)
+        t isa Timer || Core.Intrinsics.atomic_fence(:acquire_release, :system)
     else
         if !isopen(t)
             set = t.set

--- a/base/atomics.jl
+++ b/base/atomics.jl
@@ -10,7 +10,7 @@ export
     atomic_add!, atomic_sub!,
     atomic_and!, atomic_nand!, atomic_or!, atomic_xor!,
     atomic_max!, atomic_min!,
-    atomic_fence
+    atomic_fence, atomic_fence_light, atomic_fence_heavy
 
 """
     Threads.Atomic{T}
@@ -334,23 +334,23 @@ atomic_fence() = Core.Intrinsics.atomic_fence(:sequentially_consistent, :system)
 """
     Threads.atomic_fence_light()
 
-This is a read-optimized sequential-consistency memory fence.
-On supported operating systems and architectures, this fence is cheaper
-than `Threads.atomic_fence()`, but synchronizes only with
-[`atomic_fence_heavy`](@ref) calls from other threads.
+Insert the light side of an asymmetric sequential-consistency memory fence.
+Asymmetric memory fences are useful in scenarios where one side of the
+synchronization runs significantly less often than the other side. Use this
+function on the side that runs often and [`atomic_fence_heavy`](@ref) on the
+side that runs rarely.
+
+On supported operating systems and architectures this fence is cheaper than
+`Threads.atomic_fence()`, but synchronizes only with [`atomic_fence_heavy`](@ref)
+calls from other threads.
 """
 atomic_fence_light() = Core.Intrinsics.atomic_fence(:sequentially_consistent, :singlethread)
 
 """
     Threads.atomic_fence_heavy()
 
-This is a write-optimized sequential-consistency memory fence.
-This fence is significantly more expensive than `Threads.atomic_fence`.
-It generally requires a system call and a full interprocessor interrupt
-to all other processors in the system. It synchronizes with both
-[`atomic_fence_light`](@ref) and [`atomic_fence`](@ref) calls from other threads.
-
-For further details, see the Linux `membarrier` syscall or the Windows
-`FlushProcessWriteBuffers` API.
+Insert the heavy side of an asymmetric sequential-consistency memory fence.
+Use this function on the side that runs rarely.
+See [`atomic_fence_light`](@ref) for more details.
 """
 atomic_fence_heavy() = ccall(:jl_membarrier, Cvoid, ())

--- a/base/atomics.jl
+++ b/base/atomics.jl
@@ -329,4 +329,28 @@ fences should not be necessary in most cases.
 
 For further details, see LLVM's `fence` instruction.
 """
-atomic_fence() = Core.Intrinsics.atomic_fence(:sequentially_consistent)
+atomic_fence() = Core.Intrinsics.atomic_fence(:sequentially_consistent, :system)
+
+"""
+    Threads.atomic_fence_light()
+
+This is a read-optimized sequential-consistency memory fence.
+On supported operating systems and architectures, this fence is cheaper
+than `Threads.atomic_fence()`, but synchronizes only with
+[`atomic_fence_heavy`](@ref) calls from other threads.
+"""
+atomic_fence_light() = Core.Intrinsics.atomic_fence(:sequentially_consistent, :singlethread)
+
+"""
+    Threads.atomic_fence_heavy()
+
+This is a write-optimized sequential-consistency memory fence.
+This fence is significantly more expensive than `Threads.atomic_fence`.
+It generally requires a system call and a full interprocessor interrupt
+to all other processors in the system. It synchronizes with both
+[`atomic_fence_light`](@ref) and [`atomic_fence`](@ref) calls from other threads.
+
+For further details, see the Linux `membarrier` syscall or the Windows
+`FlushProcessWriteBuffers` API.
+"""
+atomic_fence_heavy() = ccall(:jl_membarrier, Cvoid, ())

--- a/doc/src/base/multi-threading.md
+++ b/doc/src/base/multi-threading.md
@@ -50,6 +50,8 @@ Base.Threads.atomic_xor!
 Base.Threads.atomic_max!
 Base.Threads.atomic_min!
 Base.Threads.atomic_fence
+Base.Threads.atomic_fence_heavy
+Base.Threads.atomic_fence_light
 ```
 
 ## ccall using a libuv threadpool (Experimental)

--- a/src/ast.c
+++ b/src/ast.c
@@ -319,6 +319,8 @@ void jl_init_common_symbols(void)
     jl_atomic_sym = jl_symbol("atomic");
     jl_not_atomic_sym = jl_symbol("not_atomic");
     jl_unordered_sym = jl_symbol("unordered");
+    jl_singlethread_sym = jl_symbol("singlethread");
+    jl_system_sym = jl_symbol("system");
     jl_monotonic_sym = jl_symbol("monotonic");
     jl_acquire_sym = jl_symbol("acquire");
     jl_release_sym = jl_symbol("release");

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -95,7 +95,7 @@
     ADD_I(pointerref, 3) \
     ADD_I(pointerset, 4) \
     /*  pointer atomics */ \
-    ADD_I(atomic_fence, 1) \
+    ADD_I(atomic_fence, 2) \
     ADD_I(atomic_pointerref, 2) \
     ADD_I(atomic_pointerset, 3) \
     ADD_I(atomic_pointerswap, 3) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -506,6 +506,7 @@
     XX(jl_vprintf) \
     XX(jl_wakeup_thread) \
     XX(jl_write_compiler_output) \
+    XX(jl_membarrier) \
 
 #define JL_RUNTIME_EXPORTED_FUNCS_WIN(XX) \
     XX(jl_setjmp) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1689,7 +1689,7 @@ STATIC_INLINE int is_valid_intrinsic_elptr(jl_value_t *ety)
 JL_DLLEXPORT jl_value_t *jl_bitcast(jl_value_t *ty, jl_value_t *v);
 JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t *align);
 JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *align, jl_value_t *i);
-JL_DLLEXPORT jl_value_t *jl_atomic_fence(jl_value_t *order);
+JL_DLLEXPORT jl_value_t *jl_atomic_fence(jl_value_t *order, jl_value_t *syncscope);
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerref(jl_value_t *p, jl_value_t *order);
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *order);
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerswap(jl_value_t *p, jl_value_t *x, jl_value_t *order);
@@ -2010,6 +2010,8 @@ JL_DLLEXPORT int jl_isabspath(const char *in) JL_NOTSAFEPOINT;
     XX(uninferred_sym) \
     XX(unordered_sym) \
     XX(unused_sym) \
+    XX(singlethread_sym) \
+    XX(system_sym)
 
 #define XX(name) extern JL_DLLEXPORT jl_sym_t *jl_##name;
 JL_COMMON_SYMBOLS(XX)

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -622,9 +622,16 @@ JL_DLLEXPORT jl_value_t *jl_atomic_pointerreplace(jl_value_t *p, jl_value_t *exp
     return result;
 }
 
-JL_DLLEXPORT jl_value_t *jl_atomic_fence(jl_value_t *order_sym)
+JL_DLLEXPORT jl_value_t *jl_atomic_fence(jl_value_t *order_sym, jl_value_t *syncscope_sym)
 {
     JL_TYPECHK(fence, symbol, order_sym);
+    JL_TYPECHK(fence, symbol, syncscope_sym);
+    if ((jl_sym_t*)syncscope_sym == jl_singlethread_sym) {
+        asm volatile ("" : : : "memory");
+        return jl_nothing;
+    } else if ((jl_sym_t*)syncscope_sym != jl_system_sym) {
+        jl_error("atomic_fence: invalid syncscope");
+    }
     enum jl_memory_order order = jl_get_atomic_order_checked((jl_sym_t*)order_sym, 1, 1);
     if (order > jl_memory_order_monotonic)
         jl_fence();

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -626,13 +626,13 @@ JL_DLLEXPORT jl_value_t *jl_atomic_fence(jl_value_t *order_sym, jl_value_t *sync
 {
     JL_TYPECHK(fence, symbol, order_sym);
     JL_TYPECHK(fence, symbol, syncscope_sym);
+    enum jl_memory_order order = jl_get_atomic_order_checked((jl_sym_t*)order_sym, 1, 1);
     if ((jl_sym_t*)syncscope_sym == jl_singlethread_sym) {
         asm volatile ("" : : : "memory");
         return jl_nothing;
     } else if ((jl_sym_t*)syncscope_sym != jl_system_sym) {
         jl_error("atomic_fence: invalid syncscope");
     }
-    enum jl_memory_order order = jl_get_atomic_order_checked((jl_sym_t*)order_sym, 1, 1);
     if (order > jl_memory_order_monotonic)
         jl_fence();
     return jl_nothing;

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -1276,17 +1276,47 @@ JL_DLLEXPORT int jl_repl_raise_sigtstp(void)
 }
 
 #if !defined(_OS_DARWIN_)
+// Thread suspension based membarrier fallback.
+// This is a sound but slow implementation that suspends and resumes each thread
+// to force them to execute memory barriers via the signal handling mechanism.
+// This is used as a fallback when neither the membarrier syscall nor the mprotect
+// hack are available or working.
+static void jl_thread_suspend_membarrier(void)
+{
+    bt_context_t ctx;
+    // Suspend each thread and immediately resume it.
+    // The act of suspending/resuming forces a memory barrier via
+    // the signal handler mechanism.
+    // jl_thread_suspend tries to interrupt the thread for up to 1 second,
+    // so we retry in a loop until it succeeds or we determine the thread
+    // is no longer alive.
+    for (int tid = 0; tid < jl_atomic_load_acquire(&jl_n_threads); tid++) {
+        while (!jl_thread_suspend(tid, &ctx)) {
+            jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+            jl_task_t *ct2 = ptls2 ? jl_atomic_load_relaxed(&ptls2->current_task) : NULL;
+            if (ct2 == NULL) {
+                // this thread is not alive or already dead, move to next
+                goto next_thread;
+            }
+            // thread is alive but suspend failed, retry
+        }
+        jl_thread_resume(tid);
+next_thread:;
+    }
+}
+
 // Implementation of the `mprotect` based membarrier fallback.
 // This is a common fallback based on the observation that `mprotect` happens to
 // issue the necessary memory barriers. However, there is no spec that
-// guarantees this behavior, and indeed AArch64 Darwin does not (so we don't use it
-// there). However, we only use it as a fallback here for older versions of
-// Linux and FreeBSD where we know that it happens to work. We also use it as a
-// fallback for unknown Unix systems under the assumption that it will work,
-// but this is not guaranteed.
+// guarantees this behavior. On AArch64, it is known not to work on either
+// Linux or FreeBSD, so we don't use it there. However, we use it as a fallback
+// here for older versions of Linux and FreeBSD on x86 where we know that it
+// happens to work.
+#if !defined(_CPU_AARCH64_) && !defined(_CPU_ARM_)
 static pthread_mutex_t mprotect_barrier_lock = PTHREAD_MUTEX_INITIALIZER;
 static _Atomic(uint64_t) *mprotect_barrier_page = NULL;
-static void jl_init_mprotect_membarrier(void)
+// Returns 1 on success, 0 on failure (e.g. mlock fails)
+static int jl_init_mprotect_membarrier(void)
 {
     int result = pthread_mutex_lock(&mprotect_barrier_lock);
     assert(result == 0);
@@ -1297,18 +1327,25 @@ static void jl_init_mprotect_membarrier(void)
                                      mmap(NULL, pagesize, PROT_READ | PROT_WRITE,
                                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         if (mprotect_barrier_page == MAP_FAILED) {
-            jl_safe_printf("fatal: failed to allocate barrier page.\n");
-            abort();
+            mprotect_barrier_page = NULL;
+            result = pthread_mutex_unlock(&mprotect_barrier_lock);
+            assert(result == 0);
+            return 0;
         }
         result = mlock(mprotect_barrier_page, pagesize);
         if (result != 0) {
-            jl_safe_printf("fatal: failed to mlock barrier page (try increasing RLIMIT_MEMLOCK with `ulimit -l`).\n");
-            abort();
+            // mlock failed (e.g. RLIMIT_MEMLOCK too low), fall back to thread suspension
+            munmap(mprotect_barrier_page, pagesize);
+            mprotect_barrier_page = NULL;
+            result = pthread_mutex_unlock(&mprotect_barrier_lock);
+            assert(result == 0);
+            return 0;
         }
     }
     result = pthread_mutex_unlock(&mprotect_barrier_lock);
     assert(result == 0);
     (void)result;
+    return 1;
 }
 
 static void jl_mprotect_membarrier(void)
@@ -1325,10 +1362,19 @@ static void jl_mprotect_membarrier(void)
     assert(result == 0);
     (void)result;
 }
-#endif
+#endif // !_CPU_AARCH64_ && !_CPU_ARM_
 
-// Linux and FreeBSD have compatible membarrier support
-#if defined(_OS_LINUX_) || defined(_OS_FREEBSD_)
+// Membarrier implementation selection
+enum membarrier_implementation {
+    MEMBARRIER_IMPLEMENTATION_UNKNOWN        = 0,
+    MEMBARRIER_IMPLEMENTATION_SYS_MEMBARRIER = 1,
+    MEMBARRIER_IMPLEMENTATION_MPROTECT       = 2,
+    MEMBARRIER_IMPLEMENTATION_THREAD_SUSPEND = 3
+};
+
+static _Atomic(enum membarrier_implementation) membarrier_impl = MEMBARRIER_IMPLEMENTATION_UNKNOWN;
+
+// Linux and FreeBSD have compatible membarrier syscall support
 #if defined(_OS_LINUX_)
 #   include <sys/syscall.h>
 #   if defined(__NR_membarrier)
@@ -1338,32 +1384,20 @@ enum membarrier_cmd {
     MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED   = (1 << 4),
 };
 #    define membarrier(...) syscall(__NR_membarrier, __VA_ARGS__)
+#    define HAVE_MEMBARRIER_SYSCALL
 #  else
 #    warning "Missing linux kernel headers for membarrier syscall, support disabled"
-#    define membarrier(...) (errno = ENOSYS, -1)
 #  endif
 #elif defined(_OS_FREEBSD_)
 #  include <sys/param.h>
 #  if __FreeBSD_version >= 1401500
 #    include <sys/membarrier.h>
-#  else
-#    define MEMBARRIER_CMD_QUERY                         0x00
-#    define MEMBARRIER_CMD_PRIVATE_EXPEDITED             0x08
-#    define MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED    0x10
-#    define membarrier(...) (errno = ENOSYS, -1)
+#    define HAVE_MEMBARRIER_SYSCALL
 #  endif
 #endif
 
-// Implementation of `jl_membarrier`
-enum membarrier_implementation {
-    MEMBARRIER_IMPLEMENTATION_UNKNOWN        = 0,
-    MEMBARRIER_IMPLEMENTATION_SYS_MEMBARRIER = 1,
-    MEMBARRIER_IMPLEMENTATION_MPROTECT       = 2
-};
-
-static _Atomic(enum membarrier_implementation) membarrier_impl = MEMBARRIER_IMPLEMENTATION_UNKNOWN;
-
 static enum membarrier_implementation jl_init_membarrier(void) {
+#ifdef HAVE_MEMBARRIER_SYSCALL
     int ret = membarrier(MEMBARRIER_CMD_QUERY, 0);
     int needed = MEMBARRIER_CMD_PRIVATE_EXPEDITED | MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED;
     if (ret > 0 && ((ret & needed) == needed)) {
@@ -1374,9 +1408,17 @@ static enum membarrier_implementation jl_init_membarrier(void) {
             return MEMBARRIER_IMPLEMENTATION_SYS_MEMBARRIER;
         }
     }
-    jl_init_mprotect_membarrier();
-    jl_atomic_store_relaxed(&membarrier_impl, MEMBARRIER_IMPLEMENTATION_MPROTECT);
-    return MEMBARRIER_IMPLEMENTATION_MPROTECT;
+#endif
+    // The mprotect fallback is known not to work on AArch64, so skip it there
+#if !defined(_CPU_AARCH64_) && !defined(_CPU_ARM_)
+    if (jl_init_mprotect_membarrier()) {
+        jl_atomic_store_relaxed(&membarrier_impl, MEMBARRIER_IMPLEMENTATION_MPROTECT);
+        return MEMBARRIER_IMPLEMENTATION_MPROTECT;
+    }
+#endif
+    // Fall back to thread suspension (sound but slow)
+    jl_atomic_store_relaxed(&membarrier_impl, MEMBARRIER_IMPLEMENTATION_THREAD_SUSPEND);
+    return MEMBARRIER_IMPLEMENTATION_THREAD_SUSPEND;
 }
 
 JL_DLLEXPORT void jl_membarrier(void) {
@@ -1384,19 +1426,25 @@ JL_DLLEXPORT void jl_membarrier(void) {
     if (impl == MEMBARRIER_IMPLEMENTATION_UNKNOWN) {
         impl = jl_init_membarrier();
     }
-    if (impl == MEMBARRIER_IMPLEMENTATION_SYS_MEMBARRIER) {
+    switch (impl) {
+#ifdef HAVE_MEMBARRIER_SYSCALL
+    case MEMBARRIER_IMPLEMENTATION_SYS_MEMBARRIER: {
         int ret = membarrier(MEMBARRIER_CMD_PRIVATE_EXPEDITED, 0);
         assert(ret == 0);
         (void)ret;
-    } else {
-        assert(impl == MEMBARRIER_IMPLEMENTATION_MPROTECT);
+        break;
+    }
+#endif
+#if !defined(_CPU_AARCH64_) && !defined(_CPU_ARM_)
+    case MEMBARRIER_IMPLEMENTATION_MPROTECT:
         jl_mprotect_membarrier();
+        break;
+#endif
+    case MEMBARRIER_IMPLEMENTATION_THREAD_SUSPEND:
+        jl_thread_suspend_membarrier();
+        break;
+    default:
+        abort();
     }
 }
-#elif !defined(_OS_DARWIN_)
-JL_DLLEXPORT void jl_membarrier(void) {
-    if (!mprotect_barrier_page)
-        jl_init_mprotect_membarrier();
-    jl_mprotect_membarrier();
-}
-#endif
+#endif // !_OS_DARWIN_

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -1294,7 +1294,7 @@ static void jl_init_mprotect_membarrier(void)
         size_t pagesize = jl_getpagesize();
 
         mprotect_barrier_page = (_Atomic(uint64_t) *)
-                                     mmap(NULL, pagesize, PROT_NONE,
+                                     mmap(NULL, pagesize, PROT_READ | PROT_WRITE,
                                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         if (mprotect_barrier_page == MAP_FAILED) {
             jl_safe_printf("fatal: failed to allocate barrier page.\n");

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -664,3 +664,7 @@ void jl_install_thread_signal_handler(jl_ptls_t ptls)
         have_backtrace_fiber = 1;
     }
 }
+
+JL_DLLEXPORT void jl_membarrier(void) {
+    FlushProcessWriteBuffers();
+}

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -395,13 +395,13 @@ end
 end
 
 using Base.Experimental: @force_compile
-@test_throws ConcurrencyViolationError("invalid atomic ordering") (@force_compile; Core.Intrinsics.atomic_fence(:u)) === nothing
-@test_throws ConcurrencyViolationError("invalid atomic ordering") (@force_compile; Core.Intrinsics.atomic_fence(Symbol("u", "x"))) === nothing
-@test_throws ConcurrencyViolationError("invalid atomic ordering") Core.Intrinsics.atomic_fence(Symbol("u", "x")) === nothing
+@test_throws ConcurrencyViolationError("invalid atomic ordering") (@force_compile; Core.Intrinsics.atomic_fence(:u, :system)) === nothing
+@test_throws ConcurrencyViolationError("invalid atomic ordering") (@force_compile; Core.Intrinsics.atomic_fence(Symbol("u", "x"), :system)) === nothing
+@test_throws ConcurrencyViolationError("invalid atomic ordering") Core.Intrinsics.atomic_fence(Symbol("u", "x"), :system) === nothing
 for order in (:not_atomic, :monotonic, :acquire, :release, :acquire_release, :sequentially_consistent)
-    @test Core.Intrinsics.atomic_fence(order) === nothing
-    @test (order -> Core.Intrinsics.atomic_fence(order))(order) === nothing
-    @test Base.invokelatest(@eval () -> Core.Intrinsics.atomic_fence($(QuoteNode(order)))) === nothing
+    @test Core.Intrinsics.atomic_fence(order, :system) === nothing
+    @test (order -> Core.Intrinsics.atomic_fence(order, :system))(order) === nothing
+    @test Base.invokelatest(@eval () -> Core.Intrinsics.atomic_fence($(QuoteNode(order)), :system)) === nothing
 end
 @test Core.Intrinsics.atomic_pointerref(C_NULL, :sequentially_consistent) === nothing
 @test (@force_compile; Core.Intrinsics.atomic_pointerref(C_NULL, :sequentially_consistent)) === nothing

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -464,6 +464,54 @@ function test_fence()
 end
 test_fence()
 
+# Test asymmetric thread fences
+const asymmetric_test_count = 200_000
+struct AsymmetricFenceTestData
+    x::AtomicMemory{Int}
+    y::AtomicMemory{Int}
+    read_x::AtomicMemory{Int}
+    read_y::AtomicMemory{Int}
+end
+function test_asymmetric_fence(data::AsymmetricFenceTestData, cond1, cond2, threadid, it)
+    if (threadid % 2) == 0
+        @atomic :monotonic data.x[it] = 1
+        Threads.atomic_fence_heavy()
+        @atomic :monotonic data.read_y[it] = @atomic :monotonic data.y[it]
+        wait(cond1)
+        notify(cond2)
+    else
+        @atomic :monotonic data.y[it] = 1
+        Threads.atomic_fence_light()
+        @atomic :monotonic data.read_x[it] = data.x[it]
+        notify(cond1)
+        wait(cond2)
+    end
+end
+function test_asymmetric_fence(data, cond1, cond2, threadid)
+    for i = 1:asymmetric_test_count
+        test_asymmetric_fence(data, cond1, cond2, threadid, i)
+    end
+end
+function test_asymmetric_fence()
+    cond1 = Threads.Event(true)
+    cond2 = Threads.Event(true)
+    data = AsymmetricFenceTestData(AtomicMemory{Int}(undef, asymmetric_test_count),
+                                  AtomicMemory{Int}(undef, asymmetric_test_count),
+                                  AtomicMemory{Int}(undef, asymmetric_test_count),
+                                  AtomicMemory{Int}(undef, asymmetric_test_count))
+    for i = 1:asymmetric_test_count
+        @atomic :monotonic data.x[i] = 0
+        @atomic :monotonic data.y[i] = 0
+        @atomic :monotonic data.read_x[i] = typemax(Int)
+        @atomic :monotonic data.read_y[i] = typemax(Int)
+    end
+    t1 = @Threads.spawn test_asymmetric_fence(data, cond1, cond2, 1)
+    t2 = @Threads.spawn test_asymmetric_fence(data, cond1, cond2, 2)
+    wait(t1); wait(t2)
+    @test !any((data.read_x .== 0) .& (data.read_y .== 0))
+end
+test_asymmetric_fence()
+
 # Test load / store with various types
 let atomictypes = (Int8, Int16, Int32, Int64, Int128,
                    UInt8, UInt16, UInt32, UInt64, UInt128,


### PR DESCRIPTION
Asymmetric atomic fences are a performance optimization of regular atomic fences (the seq_cst version of which we expose as `Base.Threads.atomic_fence`). The problem with these regular fences is that they require a CPU fence instruction, which can be very expensive and is thus unsuitable for code in the hot path. Asymmetric fences on the other hand split an ordinary fence into two: A `light` side where the fence is extremely cheap (only a compiler reordering barrier) and a `heavy` side where the fence is very expensive.

Basically the way it works is that the heavy side does a system call that issues an inter-processor-interrupt (IPI) which then issues the appropriate barrier instruction on the other CPU (i.e. both CPUs will have issues a barrier instruction, one of them just does it asynchronously due to interrupt).

The `light` and `heavy` naming here is taken from C++ PR1202R5 [1], which is the proposal for the same feature in the C++ standard library (to appear in the next iteration of the C++ concurrency spec).

On the julia side, these functions are exposed as
`Threads.atomic_fence_light` and `Threads.atomic_fence_heavy`. The light side lowers to `fence singlethread` in llvm IR (the Core.Intrinsic atomic_fence is adjusted appropriately to faciliate this). The heavy side has OS-specifc implementations, where:

1. Linux/FreeBSD try to use the `membarrier` syscall or a fallback to `mprotect` for systems that don't have it.
2. Windows uses the `FlushProcessWriteBuffers` syscall.
3. macOS uses an implementation from the dotnet runtime (https://github.com/dotnet/runtime/pull/44670), which the dotnet folks have checked with Apple does the right thing by happenstance (i.e. an IPI/memory barrier is needed to execute the syscall), but looks a little nonsensical by itself. However, since it's what Apple recommended to dotnet, I don't see much risk here, though I wouldn't be surprised if Apple added a proper syscall for this in the future (since freebsd has it now).

Note that unlike the C++ spec, I have specified that `atomic_fence_heavy` does synchronize with `atomic_fence`. This matches the underlying system call. I suspect C++ chose to omit this for a hypothetical future architecture that has instruction support for doing this from userspace that would then not synchronize with ordinary barriers, but I think I would rather cross that bridge when we get there.

I intend to use this in #60281, but it's an independently useful feature.

[1] https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1202r5.pdf