### PR TITLE
add single-argument (de)serialize methods operating on vectors of bytes

### DIFF
--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -824,6 +824,12 @@ Open a file and serialize the given value to it.
 """
 serialize(filename::AbstractString, x) = open(io->serialize(io, x), filename, "w")
 
+function serialize(x)::Vector{UInt8}
+    buf = IOBuffer()
+    serialize(buf, x)
+    return take!(buf)
+end
+
 ## deserializing values ##
 
 """
@@ -846,6 +852,8 @@ Open a file and deserialize its contents.
     This method is available as of Julia 1.1.
 """
 deserialize(filename::AbstractString) = open(deserialize, filename)
+
+deserialize(data::Vector{UInt8}) = deserialize(IOBuffer(data))
 
 function deserialize(s::AbstractSerializer)
     handle_deserialize(s, Int32(read(s.io, UInt8)::UInt8))

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -824,6 +824,16 @@ Open a file and serialize the given value to it.
 """
 serialize(filename::AbstractString, x) = open(io->serialize(io, x), filename, "w")
 
+"""
+    serialize(value) -> Vector{UInt8}
+
+Serialize the given value to a byte vector and return it.
+
+See [`serialize(::IO, value)`](@ref serialize(::IO, ::Any)) for more details on serialization format and caveats.
+
+!!! compat "Julia 1.13"
+    This method is available as of Julia 1.13.
+"""
 function serialize(x)::Vector{UInt8}
     buf = IOBuffer()
     serialize(buf, x)
@@ -853,6 +863,16 @@ Open a file and deserialize its contents.
 """
 deserialize(filename::AbstractString) = open(deserialize, filename)
 
+"""
+    deserialize(data::Vector{UInt8})
+
+Deserialize the given byte vector and return the resulting value.
+
+See [`deserialize(::IO)`](@ref deserialize(::IO)) for more details and caveats.
+
+!!! compat "Julia 1.13"
+    This method is available as of Julia 1.13.
+"""
 deserialize(data::Vector{UInt8}) = deserialize(IOBuffer(data))
 
 function deserialize(s::AbstractSerializer)

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -657,6 +657,12 @@ end
     @test l2.parts === ()
 end
 
+# serialize to and deserialize from Vector{UInt8}
+@testset "Vector{UInt8}" begin
+    @test serialize([1, 2, 3]) isa Vector{UInt8}
+    @test deserialize(serialize([1, 2, 3])) == [1, 2, 3]
+end
+
 @testset "Docstrings" begin
     undoc = Docs.undocumented_names(Serialization)
     @test_broken isempty(undoc)


### PR DESCRIPTION
Basically, for convenience: I find myself copy-pasting these methods whenever I load/store Julia serialized data as part of another data format like parquet or sql database. They natively store byte arrays, and would be nice to have these (de)serialize methods going directly back and forth between Julia objects and byte vectors.

Another neat usecase is to quickly copy-paste a Julia object between different Julia sessions (repls, notebooks, remote, ...):
```julia
# in session 1:
x |> serialize |> base64encode
# copy the resulting string

# in session 2:
x = "<paste string here>" |> base64decode |> deserialize
```