### PR TITLE
Handle large read/write/sendfile to File; return actual bytes written

### DIFF
--- a/test/file.jl
+++ b/test/file.jl
@@ -2204,7 +2204,7 @@ end
 # Partial write() to File should return the actual number of bytes written
 @test let p = Pipe()
     # Create a non-blocking pipe that will fill and return EAGAIN
-    Base.link_pipe!(p; writer_supports_async=true)
+    Base.link_pipe!(p; writer_supports_async=true, reader_supports_async=true)
     try
         f = Base.Filesystem.File(Base._fd(p.in))
         n_read, n_write = 0, 0

--- a/test/file.jl
+++ b/test/file.jl
@@ -2200,3 +2200,36 @@ end
 end
 
 @test Base.infer_return_type(stat, (String,)) == Base.Filesystem.StatStruct
+
+# Partial write() to File should return the actual number of bytes written
+@test let p = Pipe()
+    # Create a non-blocking pipe that will fill and return EAGAIN
+    Base.link_pipe!(p; writer_supports_async=true)
+    try
+        f = Base.Filesystem.File(Base._fd(p.in))
+        n_read, n_write = 0, 0
+        @sync begin
+            @async begin
+                n_write = write(f, rand(UInt8, 1000000))
+                close(p.in)
+            end
+            n_read = length(read(p))
+        end
+        n_write == n_read
+    finally
+        close(p)
+    end
+end
+
+# Very large read() shouldn't return EOFError because the return value was truncated.
+@test_skip let
+    FS = Base.Filesystem
+    f = FS.open("/dev/urandom", FS.JL_O_RDONLY)
+    try
+        v = Vector{UInt8}(undef, 5 * 2^30) # 5 GiB (larger than INT32_MAX)
+        read!(f, v)
+        true
+    finally
+        close(f)
+    end
+end


### PR DESCRIPTION
The return value for the `jl_fs_write/read/sendfile` functions is an `int`, even through they all take `size_t` length arguments, resulting in potentially truncated counts for large file operations.  Instead, on success (including partial read/write), we should return the `uv_fs_t.result` field.

I have added a test for this but have left it disabled because it allocates a 5 GiB Vector to read into.

One consequence of the truncated return values is that we previously mangled large files while copying them with sendfile.  If the return value is truncated to a random negative value, it manifests as #30723 or #39868.  If it is truncated to a positive value, sendfile will create a very large destination file with thousands of repeated sections of the source file, causing #56537. The bug will only manifest if LLVM decides to zero-extend the return value.

This also changes `jl_fs_write` to return the actual number of bytes written, rather than the number of bytes it was asked to write.  If a write returns EAGAIN (usually because the file is O_NONBLOCK/O_NODELAY), we never see the actual number of bytes written.