### PR TITLE
added a few assertions in the GC to document a lock-free list invariant in code

### DIFF
--- a/src/gc-stock.h
+++ b/src/gc-stock.h
@@ -70,7 +70,7 @@ typedef struct {
 // large arrays that have not been scanned yet)
 
 typedef enum {
-    GC_empty_chunk = 0, // sentine value representing no chunk
+    GC_empty_chunk = 0, // sentinel value representing no chunk
     GC_objary_chunk,    // for chunk of object array
     GC_ary8_chunk,      // for chunk of array with 8 bit field descriptors
     GC_ary16_chunk,     // for chunk of array with 16 bit field descriptors


### PR DESCRIPTION
See PR title. I believe it's a good idea to document this property in code with an assertion, since it's a tricky invariant that makes it safe to use our current lock-free list implementation.

In the long term, it might be better to use a lock-free list with an actual ABA-prevention mechanism to make the code more robust.