### PR TITLE
Don't create a subprocess in the REPL precompile script

### DIFF
--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -64,6 +64,7 @@ function repl_workload()
     display("a string")
     foo(x) = 1
     @time @eval foo(1)
+    ;
     $CTRL_C
     $CTRL_R$CTRL_C#
     ? reinterpret

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -64,7 +64,6 @@ function repl_workload()
     display("a string")
     foo(x) = 1
     @time @eval foo(1)
-    ; pwd
     $CTRL_C
     $CTRL_R$CTRL_C#
     ? reinterpret


### PR DESCRIPTION
We use raw Base.Filesystem.File IO on PTYs in the REPL precompile script.  Due to #24440, spawning a subprocess using the REPL's shell mode clears the O_NONBLOCK flag set on the PTY, resulting in deadlocks when libuv later reads or writes to it from Julia code.  I haven't identified what caused this to become more of a problem recently, but I don't think some extra compilation latency when starting shell mode is worth it if it's causing mystery timeouts in CI.

See also the description of #60141.