### PR TITLE
Allow `K"error"` when parsing to SyntaxTree

### DIFF
--- a/JuliaLowering/test/syntax_graph.jl
+++ b/JuliaLowering/test/syntax_graph.jl
@@ -45,6 +45,13 @@ end
     @test Expr(parsestmt(SyntaxTree, "begin a + b ; c end", filename="none")) ==
         Meta.parse("begin a + b ; c end")
 
+    # Parsing to SyntaxTree: errors should fall through
+    @test parsestmt(SyntaxTree, "@"; ignore_errors=true) isa SyntaxTree
+    @test parsestmt(SyntaxTree, "@@@"; ignore_errors=true) isa SyntaxTree
+    @test parsestmt(SyntaxTree, "(a b c)"; ignore_errors=true) isa SyntaxTree
+    @test parsestmt(SyntaxTree, "'a b c'"; ignore_errors=true) isa SyntaxTree
+
+    # @SyntaxTree
     tree1 = JuliaLowering.@SyntaxTree :(some_unique_identifier)
     @test tree1 isa SyntaxTree
     @test kind(tree1) == K"Identifier"


### PR DESCRIPTION
I had assumed a valid parse since parse errors would detonate in lowering
     anyway, but that was wrong: JETLS uses `ignore_errors=true` in parsing to
     SyntaxTree.  I plan to make some larger changes where I'll make sure
     `RawGreenNode->SyntaxTree` is more thoroughly tested, but this is a quick
     fix to get JETLS working.