### PR TITLE
Don't delete input `expmap` files

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -176,7 +176,7 @@ $(BUILDDIR)/julia.expmap: $(SRCDIR)/julia.expmap.in $(JULIAHOME)/VERSION
 clean: | $(CLEAN_TARGETS)
 	rm -f $(BUILDDIR)/*.o $(BUILDDIR)/*.dbg.obj
 	rm -f $(build_bindir)/julia*
-	rm -f $(BUILDDIR)/julia.expmap*
+	rm -f $(BUILDDIR)/julia.expmap
 	rm -f $(BUILDDIR)/Info.plist*
 
 .PHONY: clean release debug julia-release julia-debug

--- a/src/Makefile
+++ b/src/Makefile
@@ -588,7 +588,7 @@ clean:
 	-rm -rf $(build_shlibdir)/libccalltest* $(build_shlibdir)/libllvmcalltest* $(build_shlibdir)/libccalllazyfoo* $(build_shlibdir)/libccalllazybar*
 	-rm -f $(BUILDDIR)/julia_flisp.boot* $(BUILDDIR)/julia_flisp.boot.inc* $(BUILDDIR)/jl_internal_funcs.inc* $(BUILDDIR)/jl_data_globals_defs.inc*
 	-rm -f $(BUILDDIR)/*.dbg.obj $(BUILDDIR)/*.o $(BUILDDIR)/*.dwo $(BUILDDIR)/*.$(SHLIB_EXT) $(BUILDDIR)/*.a $(BUILDDIR)/*.h.gen
-	-rm -f $(BUILDDIR)/julia.expmap*
+	-rm -f $(BUILDDIR)/julia.expmap
 	-rm -f $(BUILDDIR)/julia_version.h
 	-rm -f $(BUILDDIR)/compile_commands.json*
 


### PR DESCRIPTION
I don't know why this was changed in the first place in #60080, I don't see any other `julia.expmap*` file in my workspace after a build.

Fix #60319.