### PR TITLE
Implement a `cmp` specialization for ranges

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -1168,7 +1168,7 @@ function ==(r::AbstractRange, s::AbstractRange)
     return true
 end
 
-function cmp(r1::AbstractRange{T}, r2::AbstractRange{T}) where {T}
+function cmp(r1::T, r2::T) where {T <: AbstractRange}
     firstindex(r1) == firstindex(r2) || return cmp(firstindex(r1), firstindex(r2))
     (isempty(r1) || isempty(r2)) && return cmp(isempty(r2), isempty(r1))
     first(r1) != first(r2) && return cmp(first(r1), first(r2))

--- a/base/range.jl
+++ b/base/range.jl
@@ -1168,6 +1168,17 @@ function ==(r::AbstractRange, s::AbstractRange)
     return true
 end
 
+function cmp(r1::AbstractRange{T}, r2::AbstractRange{T}) where {T}
+    firstindex(r1) == firstindex(r2) || return cmp(firstindex(r1), firstindex(r2))
+    (isempty(r1) || isempty(r2)) && return cmp(isempty(r2), isempty(r1))
+    first(r1) != first(r2) && return cmp(first(r1), first(r2))
+    # Assume that ranges are monotonic and use the last shared element as a high precision proxy for step.
+    n = min(lastindex(r1), lastindex(r2))
+    x1, x2 = r1[n], r2[n]
+    x1 != x2 && return cmp(x1, x2)
+    cmp(length(r1), length(r2))
+end
+
 intersect(r::OneTo, s::OneTo) = OneTo(min(r.stop,s.stop))
 union(r::OneTo, s::OneTo) = OneTo(max(r.stop,s.stop))
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -1173,8 +1173,7 @@ function cmp(r1::AbstractRange{T}, r2::AbstractRange{T}) where {T}
     (isempty(r1) || isempty(r2)) && return cmp(isempty(r2), isempty(r1))
     first(r1) != first(r2) && return cmp(first(r1), first(r2))
     # Assume that ranges are monotonic and use the last shared element as a high precision proxy for step.
-    n = min(lastindex(r1), lastindex(r2))
-    x1, x2 = r1[n], r2[n]
+    x1, x2 = last(zip(r1, r2))
     x1 != x2 && return cmp(x1, x2)
     cmp(length(r1), length(r2))
 end

--- a/base/range.jl
+++ b/base/range.jl
@@ -1173,7 +1173,8 @@ function cmp(r1::AbstractRange{T}, r2::AbstractRange{T}) where {T}
     (isempty(r1) || isempty(r2)) && return cmp(isempty(r2), isempty(r1))
     first(r1) != first(r2) && return cmp(first(r1), first(r2))
     # Assume that ranges are monotonic and use the last shared element as a high precision proxy for step.
-    x1, x2 = last(zip(r1, r2))
+    n = min(lastindex(r1), lastindex(r2))
+    x1, x2 = r1[n], r2[n]
     x1 != x2 && return cmp(x1, x2)
     cmp(length(r1), length(r2))
 end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2851,6 +2851,8 @@ const EXAMPLE_RANGES = AbstractRange[
     UInt8(1):UInt8(10),
     UInt8(10):-UInt8(1):UInt8(1),
     'a':'z',
+    LinRange(0.3376448676263234, 1.509664528429199, 3),
+    range(0.3376448676263234, step=0.5860098304014378, length=3),
 ]
 
 @testset "cmp(::AbstractRange, ::AbstractRange)" begin

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2831,3 +2831,28 @@ end
     @test StepRange(r) == r
     @test StepRange(r) isa StepRange{Date,Day}
 end
+
+const EXAMPLE_RANGES = AbstractRange[
+    1:10,
+    1:5,
+    1:0,
+    1:1,
+    3:2,
+    3:0,
+    10:-1:1,
+    1:2:10,
+    10:-2:1,
+    LinRange(1.0, 10.0, 10),
+    LinRange(10.0, 1.0, 10),
+    StepRangeLen(1, 2, 5),
+    StepRangeLen(10, -2, 5),
+    UInt8(1):UInt8(10),
+    UInt8(10):-UInt8(1):UInt8(1),
+    'a':'z',
+]
+
+@testset "cmp(::AbstractRange, ::AbstractRange)" begin
+    for a in EXAMPLE_RANGES, b in EXAMPLE_RANGES
+        @test try cmp(a, b) catch e; e end == try cmp(collect(a), collect(b)) catch e; e end
+    end
+end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2844,6 +2844,8 @@ const EXAMPLE_RANGES = AbstractRange[
     10:-2:1,
     LinRange(1.0, 10.0, 10),
     LinRange(10.0, 1.0, 10),
+    1e10:1.99:(1e10 + 2),
+    1e10:(1.99+eps()):(1e10 + 2),
     StepRangeLen(1, 2, 5),
     StepRangeLen(10, -2, 5),
     UInt8(1):UInt8(10),


### PR DESCRIPTION
- **Implement a `cmp` specialization for ranges**
- **Add tests (gen AI helped populate `const EXAMPLE_RANGES`)**

Fixes #60334 