### PR TITLE
jitlayers: Enable FastISel on AArch64 at -O0/-O1

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1897,7 +1897,7 @@ void optimizeDLSyms(Module &M) JL_NOTSAFEPOINT_LEAVE JL_NOTSAFEPOINT_ENTER {
 void fixupTM(TargetMachine &TM) {
     auto TheTriple = TM.getTargetTriple();
     if (jl_options.opt_level < 2) {
-        if (!TheTriple.isARM() && !TheTriple.isPPC64() && !TheTriple.isAArch64())
+        if (!TheTriple.isARM() && !TheTriple.isPPC64())
             TM.setFastISel(true);
         else    // FastISel seems to be buggy Ref #13321
             TM.setFastISel(false);


### PR DESCRIPTION
FastISel was disabled on AArch64 in #13393 to fix issue #13321, but that issue was specifically about 32-bit ARM (ARMv7) segfaults during bootstrap. AFAICT the AArch64 exclusion was added conservatively alongside the ARM fix.

AArch64 FastISel has been actively maintained upstream with recent bug fixes:
- https://github.com/llvm/llvm-project/pull/75993 (Jan 2024)
- https://github.com/llvm/llvm-project/pull/133987 (May 2025)

This enables faster instruction selection for JIT compilation on AArch64 at lower optimization levels, reducing compilation latency.

Co-authored-by: Claude