### PR TITLE
RFC/AISlop: `match` statement and declared exceptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,10 @@ If you made changes to the runtime (any files in `src/`), you will need to rebui
 julia. Run `make -j` to rebuild julia. This process may take up to 10 minutes
 depending on your changes.
 
+If you made changes to Scheme files (e.g. `src/julia-syntax.scm`, `src/julia-parser.scm`),
+you can test them quickly with `make -C src` which rebuilds just the flisp bootstrap.
+After that, run `make -j` to rebuild the full system with the changes.
+
 After making changes, run static analysis checks:
   - First run `make -C src install-analysis-deps` to initialize dependencies (only needed once the first time).
   - Run `make -C src analyze-<filename> --output-sync -j8` (replace `<filename>` with the basename of any C or C++ file you modified, excluding headers).

--- a/JuliaSyntax/src/integration/expr.jl
+++ b/JuliaSyntax/src/integration/expr.jl
@@ -610,6 +610,11 @@ end
     elseif k == K"juxtapose"
         retexpr.head = :call
         pushfirst!(args, :*)
+    elseif k == K"match"
+        # Change head to match? when EXCEPT_FLAG is set
+        if has_flags(nodehead, EXCEPT_FLAG)
+            retexpr.head = Symbol("match?")
+        end
     elseif k == K"struct"
         @assert args[2].head == :block
         orig_fields = args[2].args

--- a/JuliaSyntax/src/julia/julia_parse_stream.jl
+++ b/JuliaSyntax/src/julia/julia_parse_stream.jl
@@ -58,6 +58,11 @@ Set for K"module" when it's not bare (`module`, not `baremodule`)
 """
 const BARE_MODULE_FLAG = RawFlags(1<<8)
 
+"""
+Set for K"match" when it's an exception-catching match (`match?`, not `match`)
+"""
+const EXCEPT_FLAG = RawFlags(1<<8)
+
 # Flags holding the dimension of an nrow or other UInt8 not held in the source
 # TODO: Given this is only used for nrow/ncat, we could actually use all the flags?
 const NUMERIC_FLAGS = RawFlags(RawFlags(0xff)<<8)

--- a/JuliaSyntax/src/julia/kinds.jl
+++ b/JuliaSyntax/src/julia/kinds.jl
@@ -229,6 +229,7 @@ register_kinds!(JuliaSyntax, 0, [
         "try"
         "using"
         "while"
+        "match"
         "BEGIN_BLOCK_CONTINUATION_KEYWORDS"
             "catch"
             "finally"
@@ -1055,6 +1056,10 @@ register_kinds!(JuliaSyntax, 0, [
         "macro_name"
         # Container for a single statement/atom plus any trivia and errors
         "wrapper"
+        # Pattern matching
+        "matcharm"
+        "match-assign"
+        "guard"
     "END_SYNTAX_KINDS"
 
     # Special tokens

--- a/JuliaSyntax/src/julia/kinds.jl
+++ b/JuliaSyntax/src/julia/kinds.jl
@@ -1060,6 +1060,8 @@ register_kinds!(JuliaSyntax, 0, [
         "matcharm"
         "match-assign"
         "guard"
+        # Declared exceptions
+        "postfix-?"
     "END_SYNTAX_KINDS"
 
     # Special tokens

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,19 @@ Julia v1.14 Release Notes
 New language features
 ---------------------
 
+  - New `match` expression for pattern matching. The `match` statement allows matching values against
+    patterns with support for literals, wildcards (`_`), variable capture, type constraints (`::T`),
+    tuple destructuring, alternation (`|`), value escaping (`$`), and constructor patterns.
+    A `MatchError` is thrown if no pattern matches.
+    ```julia
+    match x
+        0 -> "zero"
+        n::Int -> "integer: $n"
+        (a, b) -> "tuple: $a, $b"
+        _ -> "other"
+    end
+    ```
+
   - It is now possible to control which version of the Julia syntax will be used to parse a package by setting the
     `compat.julia` or `syntax.julia_version` key in Project.toml. This feature is similar to the notion of "editions"
     in other language ecosystems and will allow non-breaking evolution of Julia syntax in future versions.
@@ -26,6 +39,9 @@ Build system changes
 
 New library functions
 ---------------------
+
+  - New `MatchError` exception type, thrown when a `match` expression fails to find a matching pattern.
+  - New `@match` macro providing pattern matching via a `begin...end` block syntax.
 
 New library features
 --------------------

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -93,8 +93,7 @@ include("some.jl")
 # Pattern matching runtime support
 include("match.jl")
 
-# Declared exceptions runtime support
-include("except.jl")
+# Declared exceptions runtime support is in Base_compiler.jl (except.jl)
 
 include("dict.jl")
 include("set.jl")

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -90,6 +90,9 @@ include("reinterpretarray.jl")
 # Some type
 include("some.jl")
 
+# Pattern matching runtime support
+include("match.jl")
+
 include("dict.jl")
 include("set.jl")
 

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -93,6 +93,9 @@ include("some.jl")
 # Pattern matching runtime support
 include("match.jl")
 
+# Declared exceptions runtime support
+include("except.jl")
+
 include("dict.jl")
 include("set.jl")
 

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -311,6 +311,9 @@ include("traits.jl")
 include("range.jl")
 include("error.jl")
 
+# Declared exceptions runtime support (needed early for type annotations)
+include("except.jl")
+
 # core numeric operations & types
 ==(x, y) = x === y
 include("bool.jl")

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -147,15 +147,21 @@ macro enum(T::Union{Symbol,Expr}, syms...)
     end
     basetype = Int32
     typename = T
-    if isa(T, Expr) && T.head === :(::) && length(T.args) == 2 && isa(T.args[1], Symbol)
-        typename = T.args[1]
-        basetype = Core.eval(__module__, T.args[2])
-        if !isa(basetype, DataType) || !(basetype <: Integer) || !isbitstype(basetype)
-            throw(ArgumentError(
-                LazyString("invalid base type for Enum ", typename, ", ", T, "=::", basetype, "; base type must be an integer primitive type")))
+    match T
+        T::Expr -> begin
+            if T.head === :(::) && length(T.args) == 2 && isa(T.args[1], Symbol)
+                typename = T.args[1]
+                basetype = Core.eval(__module__, T.args[2])
+                if !isa(basetype, DataType) || !(basetype <: Integer) || !isbitstype(basetype)
+                    throw(ArgumentError(
+                        LazyString("invalid base type for Enum ", typename, ", ", T, "=::", basetype, "; base type must be an integer primitive type")))
+                end
+            else
+                throw(ArgumentError(LazyString("invalid type expression for enum ", T)))
+            end
         end
-    elseif !isa(T, Symbol)
-        throw(ArgumentError(LazyString("invalid type expression for enum ", T)))
+        T::Symbol -> nothing
+        _ -> throw(ArgumentError(LazyString("invalid type expression for enum ", T)))
     end
     values = Vector{basetype}()
     seen = Set{Symbol}()
@@ -168,22 +174,27 @@ macro enum(T::Union{Symbol,Expr}, syms...)
     end
     for s in syms
         s isa LineNumberNode && continue
-        if isa(s, Symbol)
-            if i == typemin(basetype) && !isempty(values)
-                throw(ArgumentError(LazyString("overflow in value \"", s, "\" of Enum ", typename)))
+        match s
+            s::Symbol -> begin
+                if i == typemin(basetype) && !isempty(values)
+                    throw(ArgumentError(LazyString("overflow in value \"", s, "\" of Enum ", typename)))
+                end
             end
-        elseif isa(s, Expr) &&
-               (s.head === :(=) || s.head === :kw) &&
-               length(s.args) == 2 && isa(s.args[1], Symbol)
-            i = Core.eval(__module__, s.args[2]) # allow exprs, e.g. uint128"1"
-            if !isa(i, Integer)
-                throw(ArgumentError(LazyString("invalid value for Enum ", typename, ", ", s, "; values must be integers")))
+            s::Expr -> begin
+                if (s.head === :(=) || s.head === :kw) &&
+                   length(s.args) == 2 && isa(s.args[1], Symbol)
+                    i = Core.eval(__module__, s.args[2]) # allow exprs, e.g. uint128"1"
+                    if !isa(i, Integer)
+                        throw(ArgumentError(LazyString("invalid value for Enum ", typename, ", ", s, "; values must be integers")))
+                    end
+                    i = convert(basetype, i)
+                    s = s.args[1]
+                    hasexpr = true
+                else
+                    throw(ArgumentError(LazyString("invalid argument for Enum ", typename, ": ", s)))
+                end
             end
-            i = convert(basetype, i)
-            s = s.args[1]
-            hasexpr = true
-        else
-            throw(ArgumentError(LazyString("invalid argument for Enum ", typename, ": ", s)))
+            _ -> throw(ArgumentError(LazyString("invalid argument for Enum ", typename, ": ", s)))
         end
         s = s::Symbol
         if !Base.isidentifier(s)

--- a/base/accumulate.jl
+++ b/base/accumulate.jl
@@ -22,9 +22,9 @@ function _accumulate_pairwise!(op::Op, c::AbstractVector{T}, v::AbstractVector, 
     return s_
 end
 
-function accumulate_pairwise!(op::Op, result::AbstractVector, v::AbstractVector) where Op
+function accumulate_pairwise!(op::Op, result::AbstractVector, v::AbstractVector)::Except{typeof(result), DimensionMismatch} where Op
     li = LinearIndices(v)
-    li != LinearIndices(result) && throw(DimensionMismatch("input and output array sizes and indices must match"))
+    li != LinearIndices(result) && throw(DimensionMismatch("input and output array sizes and indices must match"))?
     n = length(li)
     n == 0 && return result
     i1 = first(li)
@@ -278,7 +278,7 @@ julia> accumulate(+, fill(1, 2, 5), dims=2, init=100.0)
  101.0  102.0  103.0  104.0  105.0
 ```
 """
-function accumulate(op, A; dims::Union{Nothing,Integer}=nothing, kw...)
+function accumulate(op, A; dims::Union{Nothing,Integer}=nothing, kw...)::AnyExcept{ArgumentError}
     if dims === nothing && !(A isa AbstractVector)
         # This branch takes care of the cases not handled by `_accumulate!`.
         return collect(Iterators.accumulate(op, A; kw...))
@@ -286,7 +286,7 @@ function accumulate(op, A; dims::Union{Nothing,Integer}=nothing, kw...)
 
     nt = values(kw)
     if !(isempty(kw) || keys(nt) === (:init,))
-        throw(ArgumentError("accumulate does not support the keyword arguments $(setdiff(keys(nt), (:init,)))"))
+        throw(ArgumentError("accumulate does not support the keyword arguments $(setdiff(keys(nt), (:init,)))"))?
     end
 
     out = similar(A, _accumulate_promote_op(op, A; kw...))
@@ -344,19 +344,19 @@ julia> accumulate!(*, B, A, dims=2, init=10)
  40  200  1200
 ```
 """
-function accumulate!(op, B, A; dims::Union{Integer, Nothing} = nothing, kw...)
+function accumulate!(op, B, A; dims::Union{Integer, Nothing} = nothing, kw...)::AnyExcept{ArgumentError}
     nt = values(kw)
     if isempty(kw)
         _accumulate!(op, B, A, dims, nothing)
     elseif keys(kw) === (:init,)
         _accumulate!(op, B, A, dims, Some(nt.init))
     else
-        throw(ArgumentError("accumulate! does not support the keyword arguments $(setdiff(keys(nt), (:init,)))"))
+        throw(ArgumentError("accumulate! does not support the keyword arguments $(setdiff(keys(nt), (:init,)))"))?
     end
 end
 
-function _accumulate!(op, B, A, dims::Nothing, init::Union{Nothing, Some})
-    throw(ArgumentError("Keyword argument dims must be provided for multidimensional arrays"))
+function _accumulate!(op, B, A, dims::Nothing, init::Union{Nothing, Some})::AnyExcept{ArgumentError}
+    throw(ArgumentError("Keyword argument dims must be provided for multidimensional arrays"))?
 end
 
 function _accumulate!(op, B, A::AbstractVector, dims::Nothing, init::Nothing)
@@ -371,10 +371,10 @@ function _accumulate!(op, B, A::AbstractVector, dims::Nothing, init::Some)
     _accumulate1!(op, B, v1, A, 1)
 end
 
-function _accumulate!(op, B, A, dims::Integer, init::Union{Nothing, Some})
-    dims > 0 || throw(ArgumentError("dims must be a positive integer"))
+function _accumulate!(op, B, A, dims::Integer, init::Union{Nothing, Some})::Except{typeof(B), Union{ArgumentError, DimensionMismatch}}
+    dims > 0 || throw(ArgumentError("dims must be a positive integer"))?
     inds_t = axes(A)
-    axes(B) == inds_t || throw(DimensionMismatch("shape of B must match A"))
+    axes(B) == inds_t || throw(DimensionMismatch("shape of B must match A"))?
     dims > ndims(A) && return copyto!(B, A)
     isempty(inds_t[dims]) && return B
     if dims == 1
@@ -433,10 +433,10 @@ end
     B
 end
 
-function _accumulate1!(op, B, v1, A::AbstractVector, dim::Integer)
-    dim > 0 || throw(ArgumentError("dim must be a positive integer"))
+function _accumulate1!(op, B, v1, A::AbstractVector, dim::Integer)::Except{typeof(B), Union{ArgumentError, DimensionMismatch}}
+    dim > 0 || throw(ArgumentError("dim must be a positive integer"))?
     inds = LinearIndices(A)
-    inds == LinearIndices(B) || throw(DimensionMismatch("LinearIndices of A and B don't match"))
+    inds == LinearIndices(B) || throw(DimensionMismatch("LinearIndices of A and B don't match"))?
     dim > 1 && return copyto!(B, A)
     (i1, state) = iterate(inds)::NTuple{2,Any} # We checked earlier that A isn't empty
     cur_val = v1

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1918,13 +1918,13 @@ end
 # BitArray I/O
 
 write(s::IO, B::BitArray) = write(s, B.chunks)
-function read!(s::IO, B::BitArray)
+function read!(s::IO, B::BitArray)::Except{BitArray, DimensionMismatch}
     n = length(B)
     Bc = B.chunks
     nc = length(read!(s, Bc))
     if length(Bc) > 0 && Bc[end] & _msk_end(n) ≠ Bc[end]
         Bc[end] &= _msk_end(n) # ensure that the BitArray is not broken
-        throw(DimensionMismatch("read mismatch, found non-zero bits after BitArray length"))
+        throw(DimensionMismatch("read mismatch, found non-zero bits after BitArray length"))?
     end
     return B
 end

--- a/base/error.jl
+++ b/base/error.jl
@@ -321,3 +321,4 @@ function retry(f;  delays=ExponentialBackOff(), check=nothing)
         return f(args...; kwargs...)
     end
 end
+

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -82,12 +82,10 @@ function showerror(io::IO, ex::TypeError)
     elseif ex.func === :var"dict key"
         print(io, "$(limitrepr(ex.got)) is not a valid key for type $(ex.expected)")
     else
-        if isvarargtype(ex.got)
-            targs = (ex.got,)
-        elseif isa(ex.got, Type)
-            targs = ("Type{", ex.got, "}")
-        else
-            targs = ("a value of type $(typeof(ex.got))",)
+        targs = match ex.got
+            g if isvarargtype(g) -> (g,)
+            g::Type -> ("Type{", g, "}")
+            g -> ("a value of type $(typeof(g))",)
         end
         if ex.context == ""
             ctx = "in $(ex.func)"

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1288,15 +1288,16 @@ macro world(sym, world)
     if world == :∞
         world = Expr(:call, get_world_counter)
     end
-    if isa(sym, Symbol)
-        return :($(_resolve_in_world)($(esc(world)), $(QuoteNode(GlobalRef(__module__, sym)))))
-    elseif isa(sym, GlobalRef)
-        return :($(_resolve_in_world)($(esc(world)), $(QuoteNode(sym))))
-    elseif isa(sym, Expr) && sym.head === :(.) &&
-            length(sym.args) == 2 && isa(sym.args[2], QuoteNode) && isa(sym.args[2].value, Symbol)
-        return :($(_resolve_in_world)($(esc(world)), $(GlobalRef)($(esc(sym.args[1])), $(sym.args[2]))))
-    else
-        error("`@world` requires a symbol or GlobalRef")
+    match sym
+        sym::Symbol ->
+            :($(_resolve_in_world)($(esc(world)), $(QuoteNode(GlobalRef(__module__, sym)))))
+        sym::GlobalRef ->
+            :($(_resolve_in_world)($(esc(world)), $(QuoteNode(sym))))
+        sym::Expr if sym.head === :(.) &&
+                length(sym.args) == 2 && isa(sym.args[2], QuoteNode) && isa(sym.args[2].value, Symbol) ->
+            :($(_resolve_in_world)($(esc(world)), $(GlobalRef)($(esc(sym.args[1])), $(sym.args[2]))))
+        _ ->
+            error("`@world` requires a symbol or GlobalRef")
     end
 end
 

--- a/base/except.jl
+++ b/base/except.jl
@@ -159,14 +159,4 @@ function convert(::Type{Except{T,E}}, e::Except{T2,E2}) where {T, E, T2, E2}
     end
 end
 
-function show(io::IO, e::Except{T,E}) where {T,E}
-    if is_exception(e)
-        print(io, "Except{", T, ", ", E, "}(exception: ")
-        show(io, e._exception)
-        print(io, ")")
-    else
-        print(io, "Except{", T, ", ", E, "}(")
-        show(io, e._value)
-        print(io, ")")
-    end
-end
+# show method is defined in show.jl

--- a/base/except.jl
+++ b/base/except.jl
@@ -1,0 +1,172 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Declared exceptions runtime support
+
+"""
+    Except{T, E}
+
+A wrapper type for values that may be either a successful result of type `T`
+or an exception of type `E`. Similar to Rust's `Result<T, E>`.
+
+Functions can declare their exception types using `Except` as a return type annotation:
+
+```julia
+function getindex(a::Vector{T}, i::Int)::Except{T, BoundsError}
+    # ...
+end
+```
+
+For multiple exception types, use `Union`:
+```julia
+function foo()::Except{Int, Union{KeyError, BoundsError}}
+    # ...
+end
+```
+
+See also: [`AnyExcept`](@ref), [`unwrap`](@ref), [`is_exception`](@ref)
+"""
+mutable struct Except{T, E}
+    _value::T
+    _exception::Union{E, Nothing}
+
+    # Success constructor - value only
+    function Except{T,E}(val) where {T, E}
+        e = new{T,E}()
+        e._value = val
+        e._exception = nothing
+        return e
+    end
+
+    # Internal constructor for exception case
+    function Except{T,E}(::Nothing, exc::E) where {T, E}
+        e = new{T,E}()
+        e._exception = exc
+        return e
+    end
+end
+
+"""
+    AnyExcept{E}
+
+Convenience alias for `Except{Any, E}`. Use when you want to declare exception types
+without constraining the return type.
+
+```julia
+function may_fail()::AnyExcept{IOError}
+    # ...
+end
+```
+"""
+const AnyExcept{E} = Except{Any, E}
+
+"""
+    except_value(::Type{Except{T,E}}, val) where {T, E}
+
+Create an `Except` containing a successful value.
+"""
+except_value(::Type{Except{T,E}}, val) where {T, E} = Except{T,E}(val)
+
+"""
+    except_exception(::Type{Except{T,E}}, exc::E) where {T, E}
+
+Create an `Except` containing an exception.
+"""
+except_exception(::Type{Except{T,E}}, exc::E) where {T, E} = Except{T,E}(nothing, exc)
+
+"""
+    is_exception(e::Except) -> Bool
+
+Return `true` if `e` contains an exception, `false` if it contains a value.
+"""
+is_exception(e::Except) = e._exception !== nothing
+
+"""
+    unwrap(e::Except)
+
+Extract the value from an `Except`. If `e` contains an exception, throw it.
+
+# Examples
+```julia
+e = Except{Int, BoundsError}(42)
+unwrap(e)  # returns 42
+
+e_err = except_exception(Except{Int, BoundsError}, BoundsError([1,2], 5))
+unwrap(e_err)  # throws BoundsError
+```
+"""
+function unwrap(e::Except)
+    if is_exception(e)
+        throw(e._exception)
+    end
+    return e._value
+end
+
+"""
+    get_exception(e::Except)
+
+Return the exception contained in `e`, or `nothing` if `e` contains a value.
+"""
+get_exception(e::Except) = e._exception
+
+"""
+    forward_or_unwrap(e::Except{T,E}) where {T,E}
+
+For the postfix `?` operator: if `e` contains an exception, return a new `Except`
+with that exception (for forwarding). Otherwise, return the unwrapped value.
+"""
+function forward_or_unwrap(e::Except{T,E}) where {T,E}
+    if is_exception(e)
+        return except_exception(Except{T,E}, e._exception)
+    end
+    return e._value
+end
+
+# For non-Except values, just return them (identity)
+forward_or_unwrap(x) = x
+
+"""
+    ExceptRaw
+
+Sentinel type used to dispatch to the raw (non-unwrapping) version of a function
+that returns `Except`. Used internally by the `?` and `match?` operators.
+"""
+struct ExceptRaw end
+
+"""
+    except_raw
+
+Singleton instance of `ExceptRaw` used to call the raw version of Except-returning functions.
+"""
+const except_raw = ExceptRaw()
+
+# Convert a value to Except (wrap as success)
+function convert(::Type{Except{T,E}}, val) where {T, E}
+    return Except{T,E}(convert(T, val))
+end
+
+# Convert between Except types when the exception is compatible
+function convert(::Type{Except{T,E}}, e::Except{T2,E2}) where {T, E, T2, E2}
+    if is_exception(e)
+        exc = e._exception
+        if exc isa E
+            return Except{T,E}(nothing, exc)
+        else
+            # Exception type mismatch - this shouldn't happen with proper usage
+            throw(TypeError(:convert, "exception type", E, exc))
+        end
+    else
+        return Except{T,E}(convert(T, e._value))
+    end
+end
+
+function show(io::IO, e::Except{T,E}) where {T,E}
+    if is_exception(e)
+        print(io, "Except{", T, ", ", E, "}(exception: ")
+        show(io, e._exception)
+        print(io, ")")
+    else
+        print(io, "Except{", T, ", ", E, "}(")
+        show(io, e._value)
+        print(io, ")")
+    end
+end

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -834,10 +834,9 @@ information. In particular, `(@VERSION).syntax` provides the syntax version used
 function var"@VERSION"(__source__::Union{LineNumberNode, Core.MacroSource}, __module__::Module)
     # This macro has special handling in the parser, which puts the current syntax
     # version into __source__.
-    if isa(__source__, LineNumberNode)
-        return :((; syntax = v"1.13", runtime = VERSION))
-    else
-        return :((; syntax = $(__source__.syntax_ver), runtime = VERSION))
+    match __source__
+        ::LineNumberNode -> :((; syntax = v"1.13", runtime = VERSION))
+        src::Core.MacroSource -> :((; syntax = $(src.syntax_ver), runtime = VERSION))
     end
 end
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -88,6 +88,9 @@ export
     Dict,
     Dims,
     Enum,
+    Except,
+    AnyExcept,
+    ExceptRaw,
     ExponentialBackOff,
     IndexCartesian,
     IndexLinear,
@@ -183,6 +186,14 @@ export
     TaskFailedException,
     SystemError,
     StringIndexError,
+
+# Declared exceptions
+    is_exception,
+    unwrap,
+    get_exception,
+    except_value,
+    except_exception,
+    except_raw,
 
 # Global constants and variables
     ARGS,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -177,6 +177,7 @@ export
     EOFError,
     InvalidStateException,
     KeyError,
+    MatchError,
     MissingException,
     ProcessFailedException,
     TaskFailedException,
@@ -779,6 +780,7 @@ export
     skipmissing,
     @something,
     something,
+    @match,
     isnothing,
     nonmissingtype,
 

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -67,14 +67,12 @@ end
 # copy parts of an IR that the compiler mutates
 # (this is not a general-purpose copy for an Expr AST)
 function copy_exprs(@nospecialize(x))
-    if isa(x, Expr)
-        return copy(x)
-    elseif isa(x, PhiNode)
-        return copy(x)
-    elseif isa(x, PhiCNode)
-        return copy(x)
+    match x
+        ::Expr -> copy(x)
+        ::PhiNode -> copy(x)
+        ::PhiCNode -> copy(x)
+        _ -> x
     end
-    return x
 end
 copy_exprargs(x::Array{Any,1}) = Any[copy_exprs(@inbounds x[i]) for i in eachindex(x)]
 

--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -56,8 +56,8 @@ Look up a symbol from a shared library handle, return callable function pointer 
 If the symbol cannot be found, this method throws an error, unless the keyword argument
 `throw_error` is set to `false`, in which case this method returns `nothing`.
 """
-function dlsym(hnd::Ptr, s::Union{Symbol,AbstractString}; throw_error::Bool = true)
-    hnd == C_NULL && throw(ArgumentError("NULL library handle"))
+function dlsym(hnd::Ptr, s::Union{Symbol,AbstractString}; throw_error::Bool = true)::AnyExcept{ArgumentError}
+    hnd == C_NULL && throw(ArgumentError("NULL library handle"))?
     val = Ref(Ptr{Cvoid}(0))
     symbol_found = ccall(:jl_dlsym, Cint,
         (Ptr{Cvoid}, Cstring, Ref{Ptr{Cvoid}}, Cint, Cint),
@@ -524,7 +524,7 @@ function dlopen(ll::LazyLibrary, flags::Integer = ll.flags; kwargs...)
 
     return handle
 end
-dlopen(x::Any) = throw(TypeError(:dlopen, "", Union{Symbol,String,LazyLibrary}, x))
+dlopen(x::Any)::AnyExcept{TypeError} = throw(TypeError(:dlopen, "", Union{Symbol,String,LazyLibrary}, x))?
 dlsym(ll::LazyLibrary, args...; kwargs...) = dlsym(dlopen(ll), args...; kwargs...)
 dlpath(ll::LazyLibrary) = dlpath(dlopen(ll))
 end # module Libdl

--- a/base/match.jl
+++ b/base/match.jl
@@ -1,0 +1,303 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Pattern matching runtime support
+
+"""
+    MatchError <: Exception
+
+Exception thrown when a `match` expression fails to match any pattern.
+
+# Examples
+```julia
+match x
+    1 -> "one"
+    2 -> "two"
+end  # throws MatchError if x is not 1 or 2
+```
+"""
+struct MatchError <: Exception
+    value::Any
+end
+
+function showerror(io::IO, e::MatchError)
+    print(io, "MatchError: no pattern matched value ")
+    show(io, e.value)
+end
+
+# Abstract base type for all matchers
+abstract type Matcher end
+
+# Wildcard matcher: matches anything, captures nothing
+struct Wildcard <: Matcher end
+
+function match(::Wildcard, @nospecialize(value))
+    return Dict{Symbol,Any}()
+end
+
+# Literal matcher: matches by ==
+struct Literal <: Matcher
+    value::Any
+end
+
+function match(m::Literal, @nospecialize(value))
+    m.value == value ? Dict{Symbol,Any}() : nothing
+end
+
+# Capture matcher: captures value under a name
+struct Capture <: Matcher
+    name::Symbol
+end
+
+function match(m::Capture, @nospecialize(value))
+    return Dict{Symbol,Any}(m.name => value)
+end
+
+# Type matcher: matches by isa
+struct TypeMatcher <: Matcher
+    type::Type
+end
+
+function match(m::TypeMatcher, @nospecialize(value))
+    value isa m.type ? Dict{Symbol,Any}() : nothing
+end
+
+# Typed capture: captures with type constraint
+struct TypedCapture <: Matcher
+    name::Symbol
+    type::Type
+end
+
+function match(m::TypedCapture, @nospecialize(value))
+    value isa m.type ? Dict{Symbol,Any}(m.name => value) : nothing
+end
+
+# Tuple matcher: structural match for tuples
+struct TupleMatcher <: Matcher
+    matchers::Vector{Matcher}
+end
+
+TupleMatcher(matchers::Matcher...) = TupleMatcher(collect(Matcher, matchers))
+
+function match(m::TupleMatcher, @nospecialize(value))
+    value isa Tuple || return nothing
+    length(value) == length(m.matchers) || return nothing
+    bindings = Dict{Symbol,Any}()
+    for (matcher, v) in zip(m.matchers, value)
+        result = match(matcher, v)
+        result === nothing && return nothing
+        merge!(bindings, result)
+    end
+    return bindings
+end
+
+# Alternation matcher: tries each pattern, returns first match
+struct Alternation <: Matcher
+    matchers::Vector{Matcher}
+end
+
+Alternation(matchers::Matcher...) = Alternation(collect(Matcher, matchers))
+
+function match(m::Alternation, @nospecialize(value))
+    for matcher in m.matchers
+        result = match(matcher, value)
+        result !== nothing && return result
+    end
+    return nothing
+end
+
+# Call matcher: matches constructor patterns like Some(x)
+struct CallMatcher <: Matcher
+    f::Any  # The constructor/type to match
+    matchers::Vector{Matcher}
+end
+
+CallMatcher(f, matchers::Matcher...) = CallMatcher(f, collect(Matcher, matchers))
+
+function match(m::CallMatcher, @nospecialize(value))
+    # For types, check if value is an instance
+    if m.f isa Type
+        value isa m.f || return nothing
+        # Match against fields
+        nfields(value) == length(m.matchers) || return nothing
+        bindings = Dict{Symbol,Any}()
+        for (i, matcher) in enumerate(m.matchers)
+            result = match(matcher, getfield(value, i))
+            result === nothing && return nothing
+            merge!(bindings, result)
+        end
+        return bindings
+    else
+        # For non-type constructors, we can't deconstruct
+        # This is for future extensibility
+        return nothing
+    end
+end
+
+# @match macro - provides macro-level pattern matching
+"""
+    @match value begin
+        pattern1 -> result1
+        pattern2 -> result2
+        _ -> default
+    end
+
+Pattern matching macro. Evaluates `value` and matches it against each pattern
+in order. Returns the result of the first matching pattern's expression.
+
+Throws `MatchError` if no pattern matches.
+
+# Patterns
+- Literals: `1`, `"hello"`, `:symbol`
+- Wildcard: `_` matches anything
+- Variables: `x` captures the matched value
+- Type assertions: `x::Int` captures with type check, `::Int` just checks type
+- Tuples: `(a, b, c)` destructures tuples
+- Alternation: `p1 | p2` matches if either pattern matches
+- Value escaping: `\$x` matches against the value of variable `x`
+
+# Examples
+```julia
+result = @match x begin
+    0 -> "zero"
+    n::Int -> "integer: \$n"
+    (a, b) -> "tuple: \$a, \$b"
+    _ -> "something else"
+end
+```
+"""
+macro match(value, body)
+    # Transform the body from begin...end block with -> expressions
+    # into a match expression
+    if !(body isa Expr && body.head === :block)
+        error("@match body must be a begin...end block")
+    end
+
+    arms = Expr[]
+    for ex in body.args
+        ex isa LineNumberNode && continue
+        if ex isa Expr && ex.head === :->
+            push!(arms, ex)
+        else
+            error("@match arms must be `pattern -> result` expressions")
+        end
+    end
+
+    if isempty(arms)
+        error("@match requires at least one arm")
+    end
+
+    # Build nested if/else structure
+    scrutinee = gensym("value")
+    result = :(throw(MatchError($scrutinee)))
+
+    for arm in reverse(arms)
+        pattern = arm.args[1]
+        body_expr = arm.args[2]
+        cond, bindings = pattern_to_condition(pattern, scrutinee)
+
+        if isempty(bindings)
+            result = Expr(:if, cond, body_expr, result)
+        else
+            # Create a let block for the bindings
+            let_bindings = [Expr(:(=), name, val) for (name, val) in bindings]
+            body_with_bindings = Expr(:let, Expr(:block, let_bindings...), body_expr)
+            result = Expr(:if, cond, body_with_bindings, result)
+        end
+    end
+
+    return esc(Expr(:let, Expr(:(=), scrutinee, value), result))
+end
+
+# Convert a pattern to a condition expression and bindings
+function pattern_to_condition(pattern, scrutinee)
+    if pattern === :_
+        # Wildcard
+        return true, Pair{Symbol,Any}[]
+    elseif pattern isa Symbol
+        # Variable capture
+        return true, [pattern => scrutinee]
+    elseif pattern isa Union{Number, String, Char, Bool}
+        # Literal
+        return :($scrutinee == $pattern), Pair{Symbol,Any}[]
+    elseif pattern isa QuoteNode
+        # Quoted symbol
+        return :($scrutinee === $(pattern)), Pair{Symbol,Any}[]
+    elseif pattern isa Expr
+        if pattern.head === :$
+            # Escaped value
+            return :($scrutinee == $(pattern.args[1])), Pair{Symbol,Any}[]
+        elseif pattern.head === :(::)
+            if length(pattern.args) == 1
+                # ::T - just type check
+                T = pattern.args[1]
+                return :($scrutinee isa $T), Pair{Symbol,Any}[]
+            else
+                # x::T - capture with type check
+                name = pattern.args[1]
+                T = pattern.args[2]
+                return :($scrutinee isa $T), [name => scrutinee]
+            end
+        elseif pattern.head === :tuple
+            # Tuple destructuring
+            n = length(pattern.args)
+            conds = [:($scrutinee isa Tuple), :(length($scrutinee) == $n)]
+            bindings = Pair{Symbol,Any}[]
+            for (i, p) in enumerate(pattern.args)
+                elem_var = gensym("elem")
+                elem_cond, elem_bindings = pattern_to_condition(p, elem_var)
+                if elem_cond !== true
+                    push!(conds, :($elem_var = $scrutinee[$i]; $elem_cond))
+                else
+                    for (name, _) in elem_bindings
+                        push!(bindings, name => :($scrutinee[$i]))
+                    end
+                    continue
+                end
+                for (name, val) in elem_bindings
+                    if val === elem_var
+                        push!(bindings, name => :($scrutinee[$i]))
+                    else
+                        push!(bindings, name => val)
+                    end
+                end
+            end
+            cond = foldl((a, b) -> :($a && $b), conds; init=true)
+            return cond, bindings
+        elseif pattern.head === :call && pattern.args[1] === :|
+            # Alternation
+            conds = Any[]
+            all_bindings = Pair{Symbol,Any}[]
+            for p in pattern.args[2:end]
+                c, b = pattern_to_condition(p, scrutinee)
+                push!(conds, c)
+                append!(all_bindings, b)
+            end
+            cond = foldl((a, b) -> :($a || $b), conds)
+            # For alternation, bindings are tricky - for now just use first set
+            return cond, unique(first, all_bindings)
+        elseif pattern.head === :call
+            # Constructor pattern
+            f = pattern.args[1]
+            conds = [:($scrutinee isa $f)]
+            bindings = Pair{Symbol,Any}[]
+            for (i, p) in enumerate(pattern.args[2:end])
+                field_var = gensym("field")
+                field_cond, field_bindings = pattern_to_condition(p, field_var)
+                if field_cond !== true
+                    push!(conds, :($field_var = getfield($scrutinee, $i); $field_cond))
+                end
+                for (name, val) in field_bindings
+                    if val === field_var
+                        push!(bindings, name => :(getfield($scrutinee, $i)))
+                    else
+                        push!(bindings, name => val)
+                    end
+                end
+            end
+            cond = foldl((a, b) -> :($a && $b), conds; init=true)
+            return cond, bindings
+        end
+    end
+    # Default: treat as literal comparison
+    return :($scrutinee == $pattern), Pair{Symbol,Any}[]
+end

--- a/base/options.jl
+++ b/base/options.jl
@@ -101,10 +101,10 @@ function show(io::IO, opt::JLOptions)
     nfields = length(fields)
     for (i, f) in enumerate(fields)
         v = getfield(opt, i)
-        if isa(v, Ptr{UInt8})
-            v = (v != C_NULL) ? unsafe_string(v) : ""
-        elseif isa(v, Ptr{Ptr{UInt8}})
-            v = unsafe_load_commands(v)
+        v = match v
+            v::Ptr{UInt8} -> (v != C_NULL) ? unsafe_string(v) : ""
+            v::Ptr{Ptr{UInt8}} -> unsafe_load_commands(v)
+            v -> v
         end
         print(io, f, " = ", repr(v), i < nfields ? ", " : "")
     end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1147,14 +1147,11 @@ function bodyfunction(basemethod::Method)
                     elseif fsym.mod === Core && fsym.name === :_apply_iterate
                         fsym = callexpr.args[3]
                     end
-                    if isa(fsym, Symbol)
-                        return getfield(fmod, fsym)::Function
-                    elseif isa(fsym, GlobalRef)
-                        return getfield(fsym.mod, fsym.name)::Function
-                    elseif isa(fsym, Core.SSAValue)
-                        fsym = ast.code[fsym.id]
-                    else
-                        return nothing
+                    match fsym
+                        fsym::Symbol -> return getfield(fmod, fsym)::Function
+                        fsym::GlobalRef -> return getfield(fsym.mod, fsym.name)::Function
+                        fsym::Core.SSAValue -> (fsym = ast.code[fsym.id])
+                        _ -> return nothing
                     end
                 elseif isa(fsym, Core.SSAValue)
                     fsym = ast.code[fsym.id]

--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -224,11 +224,12 @@ function Base.getindex(val::AbstractScopedValue{T})::T where T
 end
 
 function Base.show(io::IO, val::AbstractScopedValue)
-    if isa(val, ScopedValue)
-        print(io, ScopedValue)
-        print(io, '{', eltype(val), '}')
-    else
-        print(io, typeof(val))
+    match val
+        val::ScopedValue -> begin
+            print(io, ScopedValue)
+            print(io, '{', eltype(val), '}')
+        end
+        _ -> print(io, typeof(val))
     end
     print(io, '(')
     v = get(val)

--- a/base/show.jl
+++ b/base/show.jl
@@ -3389,3 +3389,16 @@ function show(io::IO, ei::Core.EvalInto)
         show_default(io, ei)
     end
 end
+
+# Except type display
+function show(io::IO, e::Except{T,E}) where {T,E}
+    if is_exception(e)
+        print(io, "Except{", T, ", ", E, "}(exception: ")
+        show(io, e._exception)
+        print(io, ")")
+    else
+        print(io, "Except{", T, ", ", E, "}(")
+        show(io, e._value)
+        print(io, ")")
+    end
+end

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -112,20 +112,14 @@ function sprint(f::Function, args...; context=nothing, sizehint::Integer=0)
 end
 
 function _str_sizehint(x)
-    if x isa Float64
-        return 20
-    elseif x isa Float32
-        return 12
-    elseif x isa String || x isa SubString{String}
-        return sizeof(x)
-    elseif x isa Char
-        return ncodeunits(x)
-    elseif x isa UInt64 || x isa UInt32
-        return ndigits(x)
-    elseif x isa Int64 || x isa Int32
-        return ndigits(x) + (x < zero(x))
-    else
-        return 8
+    match x
+        ::Float64 -> 20
+        ::Float32 -> 12
+        x::Union{String, SubString{String}} -> sizeof(x)
+        x::Char -> ncodeunits(x)
+        x::Union{UInt64, UInt32} -> ndigits(x)
+        x::Union{Int64, Int32} -> ndigits(x) + (x < zero(x))
+        _ -> 8
     end
 end
 

--- a/base/toml_parser.jl
+++ b/base/toml_parser.jl
@@ -371,11 +371,10 @@ end
 @inline function accept(l::Parser, f::Union{Function, Char})::Bool
     c = peek(l)
     c == EOF_CHAR && return false
-    ok = false
-    if isa(f, Function)
-        ok = f(c)
-    elseif isa(f, Char)
-        ok = c === f
+    ok = match f
+        f::Function -> f(c)
+        f::Char -> c === f
+        _ -> false
     end
     ok && eat_char(l)
     return ok

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -21,7 +21,7 @@ const TESTNAMES = [
         "combinatorics", "sysinfo", "env", "rounding", "ranges", "mod2pi",
         "euler", "show", "client", "terminfo",
         "errorshow", "sets", "goto", "llvmcall", "llvmcall2", "ryu",
-        "some", "meta", "stacktraces", "docs", "gc",
+        "some", "match", "meta", "stacktraces", "docs", "gc",
         "misc", "threads", "stress", "binaryplatforms","stdlib_dependencies", "atexit",
         "enums", "cmdlineargs", "int", "interpreter",
         "checked", "bitset", "floatfuncs", "precompile", "relocatedepot",

--- a/test/except.jl
+++ b/test/except.jl
@@ -1,0 +1,123 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Tests for declared exceptions (Except type, postfix ?, match?)
+
+@testset "Except type" begin
+    # Success case
+    e = Except{Int, BoundsError}(42)
+    @test !is_exception(e)
+    @test unwrap(e) == 42
+    @test get_exception(e) === nothing
+
+    # Exception case
+    ex = Base.except_exception(Except{Int, BoundsError}, BoundsError([1,2,3], 5))
+    @test is_exception(ex)
+    @test get_exception(ex) isa BoundsError
+    @test_throws BoundsError unwrap(ex)
+end
+
+@testset "AnyExcept alias" begin
+    e = AnyExcept{KeyError}("test value")
+    @test typeof(e) == Except{Any, KeyError}
+    @test !is_exception(e)
+    @test unwrap(e) == "test value"
+end
+
+@testset "except_value and except_exception" begin
+    # except_value creates success
+    e1 = Base.except_value(Except{Int, KeyError}, 42)
+    @test !is_exception(e1)
+    @test unwrap(e1) == 42
+
+    # except_exception creates exception
+    e2 = Base.except_exception(Except{Int, KeyError}, KeyError(:foo))
+    @test is_exception(e2)
+    @test get_exception(e2) isa KeyError
+end
+
+@testset "postfix ? operator" begin
+    # Success case - unwraps value
+    e1 = Except{Int, BoundsError}(42)
+    @test e1? == 42
+
+    # Exception case - forwards exception (returns Except)
+    e2 = Base.except_exception(Except{Int, BoundsError}, BoundsError([1,2], 3))
+    result = e2?
+    @test result isa Except
+    @test is_exception(result)
+end
+
+@testset "match? basic" begin
+    # Success case returns unwrapped value
+    e1 = Except{Int, BoundsError}(42)
+    result = match? e1
+        ::BoundsError -> "bounds"
+        _ -> "other"
+    end
+    @test result == 42
+
+    # Exception case matches pattern
+    e2 = Base.except_exception(Except{Int, BoundsError}, BoundsError([1,2], 3))
+    result = match? e2
+        ::BoundsError -> "bounds"
+        _ -> "other"
+    end
+    @test result == "bounds"
+end
+
+@testset "match? multiple exception types" begin
+    e_bounds = Base.except_exception(Except{Int, Exception}, BoundsError([1,2], 3))
+    e_key = Base.except_exception(Except{Int, Exception}, KeyError(:foo))
+    e_other = Base.except_exception(Except{Int, Exception}, ErrorException("test"))
+
+    function classify(e)
+        match? e
+            ::BoundsError -> "bounds"
+            ::KeyError -> "key"
+            _ -> "other"
+        end
+    end
+
+    @test classify(e_bounds) == "bounds"
+    @test classify(e_key) == "key"
+    @test classify(e_other) == "other"
+end
+
+@testset "match? with capture" begin
+    e = Base.except_exception(Except{Int, BoundsError}, BoundsError([1,2,3], 5))
+
+    # Capture exception value
+    result = match? e
+        err::BoundsError -> (err.a, err.i)
+        _ -> nothing
+    end
+    @test result == ([1,2,3], 5)
+end
+
+@testset "match? wildcard" begin
+    e = Base.except_exception(Except{Int, ErrorException}, ErrorException("test"))
+
+    result = match? e
+        _ -> "caught any"
+    end
+    @test result == "caught any"
+end
+
+@testset "match? no match rethrows" begin
+    e = Base.except_exception(Except{Int, ErrorException}, ErrorException("test"))
+
+    # Only BoundsError arm - should rethrow ErrorException
+    @test_throws ErrorException match? e
+        ::BoundsError -> "bounds"
+    end
+end
+
+@testset "Except show" begin
+    e1 = Except{Int, BoundsError}(42)
+    @test contains(sprint(show, e1), "42")
+    @test contains(sprint(show, e1), "Except")
+
+    e2 = Base.except_exception(Except{Int, BoundsError}, BoundsError([1], 2))
+    @test contains(sprint(show, e2), "exception")
+    @test contains(sprint(show, e2), "BoundsError")
+end

--- a/test/match.jl
+++ b/test/match.jl
@@ -1,0 +1,258 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Tests for the match statement and @match macro
+
+@testset "MatchError" begin
+    @test MatchError <: Exception
+    e = MatchError(42)
+    @test e.value == 42
+    @test sprint(showerror, e) == "MatchError: no pattern matched value 42"
+end
+
+@testset "Wildcard matcher" begin
+    m = Base.Wildcard()
+    @test Base.match(m, 1) == Dict{Symbol,Any}()
+    @test Base.match(m, "hello") == Dict{Symbol,Any}()
+    @test Base.match(m, nothing) == Dict{Symbol,Any}()
+end
+
+@testset "Literal matcher" begin
+    m = Base.Literal(42)
+    @test Base.match(m, 42) == Dict{Symbol,Any}()
+    @test Base.match(m, 42.0) == Dict{Symbol,Any}()  # 42.0 == 42
+    @test Base.match(m, 43) === nothing
+    @test Base.match(m, "42") === nothing
+
+    # String literals
+    m_str = Base.Literal("hello")
+    @test Base.match(m_str, "hello") == Dict{Symbol,Any}()
+    @test Base.match(m_str, "world") === nothing
+end
+
+@testset "Capture matcher" begin
+    m = Base.Capture(:x)
+    @test Base.match(m, 42) == Dict{Symbol,Any}(:x => 42)
+    @test Base.match(m, "hello") == Dict{Symbol,Any}(:x => "hello")
+end
+
+@testset "TypeMatcher" begin
+    m = Base.TypeMatcher(Int)
+    @test Base.match(m, 42) == Dict{Symbol,Any}()
+    @test Base.match(m, 42.0) === nothing
+    @test Base.match(m, "42") === nothing
+
+    m_num = Base.TypeMatcher(Number)
+    @test Base.match(m_num, 42) == Dict{Symbol,Any}()
+    @test Base.match(m_num, 3.14) == Dict{Symbol,Any}()
+    @test Base.match(m_num, "42") === nothing
+end
+
+@testset "TypedCapture matcher" begin
+    m = Base.TypedCapture(:x, Int)
+    @test Base.match(m, 42) == Dict{Symbol,Any}(:x => 42)
+    @test Base.match(m, 42.0) === nothing
+
+    m_num = Base.TypedCapture(:n, Number)
+    @test Base.match(m_num, 42) == Dict{Symbol,Any}(:n => 42)
+    @test Base.match(m_num, 3.14) == Dict{Symbol,Any}(:n => 3.14)
+    @test Base.match(m_num, "42") === nothing
+end
+
+@testset "TupleMatcher" begin
+    m = Base.TupleMatcher(Base.Capture(:a), Base.Capture(:b))
+    @test Base.match(m, (1, 2)) == Dict{Symbol,Any}(:a => 1, :b => 2)
+    @test Base.match(m, (1, 2, 3)) === nothing  # wrong length
+    @test Base.match(m, [1, 2]) === nothing  # not a tuple
+    @test Base.match(m, 1) === nothing  # not a tuple
+
+    # Nested tuple
+    m_nested = Base.TupleMatcher(
+        Base.TupleMatcher(Base.Capture(:a), Base.Capture(:b)),
+        Base.Capture(:c)
+    )
+    @test Base.match(m_nested, ((1, 2), 3)) == Dict{Symbol,Any}(:a => 1, :b => 2, :c => 3)
+
+    # With literals
+    m_lit = Base.TupleMatcher(Base.Literal(1), Base.Capture(:x))
+    @test Base.match(m_lit, (1, 42)) == Dict{Symbol,Any}(:x => 42)
+    @test Base.match(m_lit, (2, 42)) === nothing
+end
+
+@testset "Alternation matcher" begin
+    m = Base.Alternation(Base.Literal(1), Base.Literal(2))
+    @test Base.match(m, 1) == Dict{Symbol,Any}()
+    @test Base.match(m, 2) == Dict{Symbol,Any}()
+    @test Base.match(m, 3) === nothing
+
+    # With captures
+    m_cap = Base.Alternation(
+        Base.TupleMatcher(Base.Literal(:a), Base.Capture(:x)),
+        Base.TupleMatcher(Base.Literal(:b), Base.Capture(:x))
+    )
+    @test Base.match(m_cap, (:a, 1)) == Dict{Symbol,Any}(:x => 1)
+    @test Base.match(m_cap, (:b, 2)) == Dict{Symbol,Any}(:x => 2)
+    @test Base.match(m_cap, (:c, 3)) === nothing
+end
+
+@testset "CallMatcher" begin
+    # Test with Some type
+    m = Base.CallMatcher(Some, Base.Capture(:x))
+    @test Base.match(m, Some(42)) == Dict{Symbol,Any}(:x => 42)
+    @test Base.match(m, 42) === nothing
+    @test Base.match(m, nothing) === nothing
+
+    # With literal
+    m_lit = Base.CallMatcher(Some, Base.Literal(1))
+    @test Base.match(m_lit, Some(1)) == Dict{Symbol,Any}()
+    @test Base.match(m_lit, Some(2)) === nothing
+end
+
+@testset "@match macro basics" begin
+    # Literal matching
+    @test (@match 1 begin
+        1 -> "one"
+        2 -> "two"
+        _ -> "other"
+    end) == "one"
+
+    @test (@match 2 begin
+        1 -> "one"
+        2 -> "two"
+        _ -> "other"
+    end) == "two"
+
+    @test (@match 3 begin
+        1 -> "one"
+        2 -> "two"
+        _ -> "other"
+    end) == "other"
+end
+
+@testset "@match variable capture" begin
+    result = @match 42 begin
+        x -> x + 1
+    end
+    @test result == 43
+
+    result = @match (1, 2) begin
+        (a, b) -> a + b
+    end
+    @test result == 3
+end
+
+@testset "@match type constraints" begin
+    test_type_match(x) = @match x begin
+        n::Int -> "int: $n"
+        s::String -> "string: $s"
+        _ -> "other"
+    end
+
+    @test test_type_match(42) == "int: 42"
+    @test test_type_match("hello") == "string: hello"
+    @test test_type_match(3.14) == "other"
+end
+
+@testset "@match no match throws MatchError" begin
+    @test_throws MatchError @match 3 begin
+        1 -> "one"
+        2 -> "two"
+    end
+end
+
+@testset "@match value escaping" begin
+    expected = 42
+    result = @match 42 begin
+        $expected -> "matched"
+        _ -> "not matched"
+    end
+    @test result == "matched"
+
+    result = @match 43 begin
+        $expected -> "matched"
+        _ -> "not matched"
+    end
+    @test result == "not matched"
+end
+
+@testset "@match tuple destructuring" begin
+    result = @match (1, (2, 3)) begin
+        (a, (b, c)) -> a + b + c
+    end
+    @test result == 6
+
+    result = @match (1, 2, 3) begin
+        (1, x, y) -> x + y
+        _ -> 0
+    end
+    @test result == 5
+end
+
+@testset "match statement if guards" begin
+    # Basic guard
+    result = match 5
+        n if n > 0 -> "positive"
+        n if n < 0 -> "negative"
+        _ -> "zero"
+    end
+    @test result == "positive"
+
+    result = match -3
+        n if n > 0 -> "positive"
+        n if n < 0 -> "negative"
+        _ -> "zero"
+    end
+    @test result == "negative"
+
+    result = match 0
+        n if n > 0 -> "positive"
+        n if n < 0 -> "negative"
+        _ -> "zero"
+    end
+    @test result == "zero"
+
+    # Guard with tuple destructuring
+    result = match (3, 4)
+        (a, b) if a + b > 5 -> "sum > 5"
+        (a, b) -> "sum <= 5"
+    end
+    @test result == "sum > 5"
+
+    result = match (1, 2)
+        (a, b) if a + b > 5 -> "sum > 5"
+        (a, b) -> "sum <= 5"
+    end
+    @test result == "sum <= 5"
+
+    # Guard that fails, falling through to next arm
+    result = match 10
+        x if x < 5 -> "small"
+        x if x < 15 -> "medium"
+        _ -> "large"
+    end
+    @test result == "medium"
+end
+
+@testset "match statement inline destructuring" begin
+    # Basic inline match-destructuring
+    match (x, y) = (10, 20)
+    @test x == 10
+    @test y == 20
+
+    # Nested tuple destructuring
+    match (a, (b, c)) = (1, (2, 3))
+    @test a == 1
+    @test b == 2
+    @test c == 3
+
+    # MatchError when pattern doesn't match
+    @test_throws MatchError match (p, q) = (1, 2, 3)
+
+    # With type constraint
+    match (m::Int, n::Int) = (5, 6)
+    @test m == 5
+    @test n == 6
+
+    # Type constraint mismatch throws MatchError
+    @test_throws MatchError match (r::String, s) = (1, 2)
+end
+


### PR DESCRIPTION
This is a fairly chunky syntax PR that implements two new features that are technically unrelated, but I would like to propose together:

1. The `match` control flow statement (previously discussed in #18285)
2. A syntax for "declared exceptions" (a variant on #7026)

The semantics for match are described in https://gist.github.com/Keno/e08874a423e0f1df4d11a798c7ed147c.
The full semantics for declared exceptions are described in https://gist.github.com/Keno/7d1fb27a003afba6de50686ccfbb6610

However, the basic gist is that you can annotate expected exception types together with return types
```
function read(io, ::Type{UInt8})::Except{UInt8, Union{IOError, CancellationRequest}}
...
end
```

then, there is a new postfix `?` operator that propagates declared (and only declared) exceptions:
```
function read(io, ::Type{String})::Except{String, Union{IOError, CancellationRequest}}
    String(collect(takewhile(!=(0), read(io, UInt8)? for _ in  repeated(nothing))))
end
```

The semantics of postfix `?` are to propagate any declared exceptions, otherwise they get `throw`n. To more selectively treat exceptions there is a new `match?` control-flow structure, with the same semantics as `match` described in the link above, but operating on the declared exceptions only (if in the exceptional path). Example:

```
function read_thing(io)::Except{String, CancellationRequest}
    match? read(io, String)
        # ENOENT expected, return empty string
        IOError(UV_ENOENT) -> ""
     end? # All other IOErrors get thrown, CancellationRequest gets propagated as a declared exception
end
```

This PR is semi-functional, but entirely AI slop - do not read the implementation, you have been warned. The purpose of this PR is to provide a dummy implementation that can be used to feel out the design ergonomics and discover any unexpected corner cases.