### PR TITLE
Fix `replace_beginend` with `kw`

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -611,10 +611,11 @@ function replace_beginend(ctx, ex, arr, n, splats, is_last)
             replace_beginend(ctx, ex[1], arr, n, splats, is_last)
             ex[2:end]...
         ]
-    # elseif k == K"kw" - keyword args - what does this mean here?
-    #   # note from flisp
-    #   # TODO: this probably should not be allowed since keyword args aren't
-    #   # positional, but in this context we have just used their positions anyway
+    elseif k == K"kw"
+        # note from flisp
+        # TODO: this probably should not be allowed since keyword args aren't
+        # positional, but in this context we have just used their positions anyway
+        @ast ctx ex [K"kw" ex[1] replace_beginend(ctx, ex[2], arr, n, splats, is_last)]
     else
         mapchildren(e->replace_beginend(ctx, e, arr, n, splats, is_last), ctx, ex)
     end

--- a/JuliaLowering/test/arrays.jl
+++ b/JuliaLowering/test/arrays.jl
@@ -145,4 +145,18 @@ let
 end
 """) == (3, 7, 2, 5)
 
+# begin/end not replaced in some cases
+JuliaLowering.include_string(test_mod, "f(args...;kws...) = 2")
+@test JuliaLowering.include_string(test_mod, """
+    [7,8,9][f(;var"end"=123, var"begin"=456)]
+""") === 8
+@test JuliaLowering.include_string(test_mod, """
+    [7,8,9][f(quote var"end" end)]
+""") === 8
+@test JuliaLowering.include_string(test_mod, """
+let var"end" = [1,2,3], y = [7,8,9]
+    y[var"end"[var"end"]]
+end
+""") === 9
+
 end # @testset "Array syntax" begin


### PR DESCRIPTION
Match flisp; we shouldn't replace begin/end in the first argument of `kw`.  Fix #60309.