### PR TITLE
`Expr`/`SyntaxTree` parity: trivial conversions

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -626,3 +626,106 @@ function JuliaSyntax.fixup_Expr_child(::Type{<:SyntaxTree}, head::SyntaxHead,
 end
 
 Base.Expr(ex::SyntaxTree) = JuliaSyntax.to_expr(ex)
+
+#-------------------------------------------------------------------------------
+# WIP: Expr<->EST
+
+function expr_to_est(@nospecialize(e), lnn::LineNumberNode=LineNumberNode(0, :none))
+    graph = ensure_attributes!(
+        SyntaxGraph(),
+        kind=Kind, syntax_flags=UInt16,
+        source=SourceAttrType, var_id=Int, value=Any,
+        name_val=String, is_toplevel_thunk=Bool,
+        scope_layer=LayerId, meta=CompileHints,
+        toplevel_pure=Bool)
+    SyntaxTree(graph, _expr_to_est(graph, e, lnn)[1])
+end
+
+function _get_inner_lnn(e::Expr, default::LineNumberNode)
+    e.head in (:function, :macro, :module) || return default
+    length(e.args) >= 2 || return default
+    b = e.args[end]
+    b isa Expr && b.head === :block || return default
+    length(b.args) >= 1 && b.args[1] isa LineNumberNode || return default
+    return b.args[1]
+end
+
+function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
+    st = if e === Core.nothing
+        # e.value can't be nothing in `K"Value"`, so represent with K"core"
+        setattr!(makeleaf(graph, src, K"core"), :name_val, "nothing")
+    elseif e isa Symbol
+        setattr!(makeleaf(graph, src, K"Identifier"), :name_val, String(e))
+    elseif e isa QuoteNode
+        cid, _ = _expr_to_est(graph, e.value, src)
+        makenode(graph, src, K"inert_expr", NodeId[cid])
+    elseif e isa Expr && e.head === :scope_layer
+        @assert length(e.args) === 2 && e.args[1] isa Symbol
+        ident = makeleaf(graph, src, K"Identifier")
+        setattr!(ident, :name_val, String(e.args[1]))
+        setattr!(ident, :scope_layer, e.args[2])
+    elseif e isa Expr
+        head_s = string(e.head)
+        st_k = find_kind(head_s)
+        old_src = _get_inner_lnn(e, src)
+        cs = NodeId[]
+        rm_linenodes = e.head in (:block, :toplevel)
+        for arg in e.args
+            if rm_linenodes && arg isa LineNumberNode
+                src = arg
+            else
+                cid, src = _expr_to_est(graph, arg, src)
+                push!(cs, cid)
+            end
+        end
+        if isnothing(st_k)
+            setattr!(makenode(graph, src, K"unknown_head", cs), :name_val, head_s)
+        else
+            makenode(graph, old_src, st_k, cs)
+        end
+    # elseif e isa GlobalRef
+        # TODO: Better-behaved as K"globalref", but lowering doesn't know this
+    else
+        # We may want additional special cases for other types where
+        # `Base.isa_ast_node(e)`, but `K"Value"` should be fine for most
+        if e isa LineNumberNode
+            # linenode oustside of block or toplevel
+            src = e
+        end
+        setattr!(makeleaf(graph, src, K"Value"), :value, e)
+    end
+
+    return st._id, src
+end
+
+function est_to_expr(st::SyntaxTree)
+    k = kind(st)
+    return if k === K"Identifier"
+        n = Symbol(st.name_val)
+        hasattr(st, :scope_layer) ? Expr(:scope_layer, n, st.scope_layer) : n
+    elseif k === K"Value"
+        st.value
+    elseif k === K"core" && numchildren(st) === 0 && st.name_val === "nothing"
+        nothing
+    elseif k === K"inert_expr"
+        QuoteNode(est_to_expr(st[1]))
+    else
+        @assert !is_leaf(st)
+        # In a partially-expanded or quoted AST, there may be heads with no
+        # corresponding kind
+        head = Symbol(k === K"unknown_head" ? st.name_val : untokenize(k))
+        need_lnns = head in (:block, :toplevel)
+        out = Expr(head)
+        for c in children(st)
+            need_lnns && push!(out.args, source_location(LineNumberNode, c))
+            push!(out.args, est_to_expr(c))
+        end
+        # extra linenodes
+        n = length(out.args)
+        if (k === K"module" && 3 <= n <= 4 && kind(st[end]) === K"block") ||
+            (k in KSet"function macro" && n === 2 && kind(st[end]) === K"block")
+            pushfirst!(out.args[end].args, source_location(LineNumberNode, st))
+        end
+        out
+    end
+end

--- a/JuliaLowering/src/kinds.jl
+++ b/JuliaLowering/src/kinds.jl
@@ -21,7 +21,6 @@ function _register_kinds()
             "Symbol"
             # QuoteNode; not quasiquote
             "inert"
-            "inert_expr"
             "unknown_head"
             # TODO: Use `meta` for inbounds and loopinfo etc?
             "inbounds"

--- a/JuliaLowering/src/kinds.jl
+++ b/JuliaLowering/src/kinds.jl
@@ -21,6 +21,8 @@ function _register_kinds()
             "Symbol"
             # QuoteNode; not quasiquote
             "inert"
+            "inert_expr"
+            "unknown_head"
             # TODO: Use `meta` for inbounds and loopinfo etc?
             "inbounds"
             "boundscheck"

--- a/JuliaLowering/test/compat.jl
+++ b/JuliaLowering/test/compat.jl
@@ -634,6 +634,30 @@ const JL = JuliaLowering
 end
 
 @testset "Expr<->EST" begin
+
+    local roundtrip = e->JuliaLowering.est_to_expr(JuliaLowering.expr_to_est(e))
+    local roundtrip_eq = x->x==roundtrip(x)
+
+    @testset "every basic case" begin
+        @test roundtrip_eq(LineNumberNode(1))
+        @test roundtrip_eq(:foo)
+        @test roundtrip_eq(Expr(:foo, 1))
+        @test roundtrip_eq(GlobalRef(Core, :nothing))
+        @test roundtrip_eq(nothing)
+
+        @test roundtrip_eq(QuoteNode(LineNumberNode(1)))
+        @test roundtrip_eq(QuoteNode(:foo))
+        @test roundtrip_eq(QuoteNode(Expr(:foo, 1)))
+        @test roundtrip_eq(QuoteNode(GlobalRef(Core, :nothing)))
+        @test roundtrip_eq(QuoteNode(nothing))
+
+        @test roundtrip_eq(QuoteNode(QuoteNode(LineNumberNode(1))))
+        @test roundtrip_eq(QuoteNode(QuoteNode(:foo)))
+        @test roundtrip_eq(QuoteNode(QuoteNode(Expr(:foo, 1))))
+        @test roundtrip_eq(QuoteNode(QuoteNode(GlobalRef(Core, :nothing))))
+        @test roundtrip_eq(QuoteNode(QuoteNode(nothing)))
+    end
+
     # copied from JuliaSyntax/test/parse_packages.jl
     function find_source_in_path(basedir)
         src_list = String[]
@@ -680,10 +704,10 @@ end
         end
     end
 
-    # ignore_lnn=false is good for checking, but too noisy to use much
-    function expr_equal_forgiving(e1, e2; ignore_lnn=true)
+    # ignore_linenums=false is good for checking, but too noisy to use much
+    function expr_equal_forgiving(e1, e2; ignore_linenums=true)
         !(e1 isa Expr && e2 isa Expr) && return e1 == e2
-        if ignore_lnn
+        if ignore_linenums
             e1, e2 = let e1b = Expr(e1.head), e2b = Expr(e2.head)
                 e1b.args = filter(x->!(x isa LineNumberNode), e1.args)
                 e2b.args = filter(x->!(x isa LineNumberNode), e2.args)
@@ -692,16 +716,14 @@ end
         end
 
         e1.head === e2.head && length(e1.args) === length(e2.args) &&
-            all(expr_equal_forgiving(a1, a2; ignore_lnn) for (a1, a2) in
+            all(expr_equal_forgiving(a1, a2; ignore_linenums) for (a1, a2) in
                     zip(e1.args, e2.args))
     end
-
-    local roundtrip = e->JuliaLowering.est_to_expr(JuliaLowering.expr_to_est(e))
 
     jl_dir = joinpath(@__DIR__, "..")
     test_each_in_path(roundtrip, jl_dir)
 
-    @testset "including linenodes" begin
+    @testset "linenodes equal (modules and functions have extra)" begin
         e = JuliaSyntax.parseall(Expr, """
         module M
         function f()


### PR DESCRIPTION
As discussed on slack with @c42f and @topolarity, I gave expansion-time conversions an honest try, but couldn't see the end of the tunnel in terms of correctness.  The equivalence between SyntaxNode and Expr is only defined on surface syntax or fully-macro-expanded syntax, and not the steps in between, or if errors occur.  We have a plan for syntax evolution now, too, so there compelling reasons not to lump changes to AST layout into JuliaLowering's macro expansion.

Let `EST` be the "new" Expr-like SyntaxTree I'm working on and `CST` be the current SyntaxNode-like version. PRs planned:
1. https://github.com/JuliaLang/julia/pull/60370
2. (this PR) Trivial `EST`<->`Expr` conversion, tested by parsing code in bulk and round-tripping
3. `RawGreenNode`->`EST` (identical logic to existing `RawGreenNode`->`Expr`, and testable with this PR's `Expr`->`EST`)
4. `EST`->`CST*`: This would just be a simplification of our existing `Expr`->`CST`, and prevents us from needing to make huge changes in desugaring (which understands `CST*`).  Macro expansion will become `EST`->`EST` rather than `CST`->`CST*`.
5. Before one or both of the above, I may try and merge a basic SyntaxTree pattern-matching macro so operating on these things is less tedious.  This is already written, but needs tests.

