### PR TITLE
Libdl: fix race condition in LazyLibrary parallel loading

### DIFF
--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -506,6 +506,9 @@ function dlopen(ll::LazyLibrary, flags::Integer = ll.flags; kwargs...)
                 if ll.on_load_callback !== nothing
                     ll.on_load_callback()
                 end
+            else
+                # Another thread loaded the library while we were waiting
+                handle = @atomic :acquire ll.handle
             end
         end
     else


### PR DESCRIPTION
When multiple threads tried to load a LazyLibrary simultaneously, threads that waited on the lock would return C_NULL instead of the loaded handle. This happened because the local 'handle' variable was not updated when another thread had already loaded the library while waiting for the lock.

The issue in #60378 happens because when dlopen returns C_NULL, the subsequent dlsym(C_NULL, :dgemm_64_) call searches RTLD_DEFAULT instead of the actual BLAS library, which is why the error message mentions libjulia-internal.so i.e. that's where the linker looked but couldn't find the symbol.

Fixes #60378

Helped by Claude