### PR TITLE
use a "locally frozen world age" to invoke `_artifact_str` in

### DIFF
--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -16,6 +16,13 @@ using Base.TOML: TOML
 export artifact_exists, artifact_path, artifact_meta, artifact_hash,
        select_downloadable_artifacts, find_artifacts_toml, @artifact_str
 
+const _artifacts_world_age = Ref{UInt}(typemax(UInt))
+
+function __init__()
+    _artifacts_world_age[] = Base.get_world_counter()
+    nothing
+end
+
 """
     parse_toml(path::String)
 
@@ -543,7 +550,7 @@ function jointail(dir, tail)
 end
 
 function _artifact_str(__module__, artifacts_toml, name, path_tail, artifact_dict, hash, platform, ::Val{LazyArtifacts}) where LazyArtifacts
-    world = Base._require_world_age[]
+    world = _artifacts_world_age[]
     if world == typemax(UInt)
         world = Base.get_world_counter()
     end


### PR DESCRIPTION
piggy backing on the one defined in `loading.jl` causes world age errors when Artifacts.jl is not in the sysimage (https://github.com/JuliaLang/PackageCompiler.jl/issues/1076)
