### PR TITLE
Set max_methods 1 for several IO functions

### DIFF
--- a/base/coreio.jl
+++ b/base/coreio.jl
@@ -1,5 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+function print end
+typeof(print).name.max_methods = UInt8(1)
+
 print(x) = print(stdout, x)
 print(x1, x2) = print(stdout, x1, x2)
 println(x) = print(stdout, x, "\n")

--- a/base/io.jl
+++ b/base/io.jl
@@ -68,6 +68,7 @@ false
 ```
 """
 function isopen end
+typeof(isopen).name.max_methods = UInt8(1)
 
 """
     close(io::IO)
@@ -85,6 +86,7 @@ closed IO does not cause undefined behaviour.
 See also: [`isopen`](@ref)
 """
 function close end
+typeof(close).name.max_methods = UInt8(1)
 
 """
     closewrite(stream)
@@ -112,6 +114,7 @@ julia> read(io, String)
 ```
 """
 function closewrite end
+typeof(closewrite).name.max_methods = UInt8(1)
 
 """
     flush(io::IO)
@@ -121,6 +124,7 @@ This has a default implementation `flush(::IO) = nothing`, so may be called
 in generic IO code.
 """
 function flush end
+typeof(flush).name.max_methods = UInt8(1)
 
 """
     bytesavailable(io)
@@ -136,6 +140,7 @@ julia> bytesavailable(io)
 ```
 """
 function bytesavailable end
+typeof(bytesavailable).name.max_methods = UInt8(1)
 
 """
     readavailable(stream)
@@ -149,8 +154,11 @@ data has already been buffered. The result is a `Vector{UInt8}`.
     should generally be used instead.
 """
 function readavailable end
+typeof(readavailable).name.max_methods = UInt8(1)
 
 function isexecutable end
+typeof(isexecutable).name.max_methods = UInt8(1)
+
 
 """
     isreadable(io)::Bool
@@ -221,6 +229,7 @@ true
 ```
 """
 function eof end
+typeof(eof).name.max_methods = UInt8(1)
 
 function copy end
 function wait_readnb end
@@ -320,6 +329,7 @@ Base.RefValue{MyStruct}(MyStruct(42.0))
 ```
 """
 function write end
+typeof(write).name.max_methods = UInt8(1)
 
 read(s::IO, ::Type{UInt8}) = error(typeof(s)," does not support byte I/O")
 write(s::IO, x::UInt8) = error(typeof(s)," does not support byte I/O")
@@ -532,6 +542,7 @@ read(filename::AbstractString, ::Type{T}) where {T} = open(io->read(io, T), conv
 Read binary data from an I/O stream or file, filling in `array`.
 """
 function read! end
+typeof(read!).name.max_methods = UInt8(1)
 
 read!(filename::AbstractString, a) = open(io->read!(io, a), convert(String, filename)::String)
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -159,7 +159,6 @@ typeof(readavailable).name.max_methods = UInt8(1)
 function isexecutable end
 typeof(isexecutable).name.max_methods = UInt8(1)
 
-
 """
     isreadable(io)::Bool
 


### PR DESCRIPTION
This reduces the number of invalidations of loading BufferIO.jl commit 957f141 from 1026 to 549. The large number of invalidations come from excessive world splitting on un-inferred IO objects, which, ironically, are probably intentionally left un-inferred to reduce unnecessary compilation.

This is a poor bandaid solution: World splitting delenda est and all that. If that is not feasible, then an option to selectively disable it e.g. through a future `@max_methods 0` would impove the situation. For example, about 400 methods are invalidated due to the addition of a new `write(::T, ::Char)` method, which invalidates the single, world split `write(::IO, ::Char)` method.

However, deeper fixes of this issue is outside the scope of this PR.