### PR TITLE
syntax-versioning: Define behavior in scripts and REPL

### DIFF
--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -746,20 +746,6 @@ macro reexport(ex)
     return esc(calls)
 end
 
-struct VersionedParse
-    ver::VersionNumber
-end
-
-function (vp::VersionedParse)(code, filename::String, lineno::Int, offset::Int, options::Symbol)
-    if !isdefined(Base, :JuliaSyntax)
-        if vp.ver === VERSION
-            return Core._parse
-        end
-        error("JuliaSyntax module is required for syntax version $(vp.ver), but it is not loaded.")
-    end
-    Base.JuliaSyntax.core_parser_hook(code, filename, lineno, offset, options; syntax_version=vp.ver)
-end
-
 struct VersionedLower
     ver::VersionNumber
 end
@@ -776,7 +762,7 @@ function (vp::VersionedLower)(@nospecialize(code), mod::Module,
 end
 
 function Base.set_syntax_version(m::Module, ver::VersionNumber)
-    parser = VersionedParse(ver)
+    parser = Base.VersionedParse(ver)
     Core.declare_const(m, :_internal_julia_parse, parser)
     #lowerer = VersionedLower(ver)
     #Core.declare_const(m, :_internal_julia_lower, lowerer)

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -271,6 +271,19 @@ function init_active_project()
     )
 end
 
+function init_named_env!(path)
+    try
+        mkpath(dirname(path))
+        open(path, "w") do io
+            print(io, "syntax.julia_version = \"",VERSION,"\"")
+        end
+        return path
+    catch e
+        @warn "Failed to initialize named environment at $path: $e"
+        return nothing
+    end
+end
+
 ## load path expansion: turn LOAD_PATH entries into concrete paths ##
 cmd_suppresses_program(cmd) = cmd in ('e', 'E')
 
@@ -307,7 +320,8 @@ function load_path_expand(env::AbstractString)::Union{String, Nothing}
             end
         end
         isempty(DEPOT_PATH) && return nothing
-        return abspath(DEPOT_PATH[1], "environments", name, project_names[end])
+        new_named_env_path = abspath(DEPOT_PATH[1], "environments", name, project_names[end])
+        return init_named_env!(new_named_env_path)
     end
     # otherwise, it's a path
     path = abspath(env)

--- a/base/show.jl
+++ b/base/show.jl
@@ -2181,7 +2181,12 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
             print(io, "end")
         end
 
+    elseif head === :module && nargs==4 && isa(args[1],VersionNumber) && isa(args[2],Bool)
+        # New 4-argument form: (version, baremodule_flag, name, body)
+        show_block(IOContext(io, beginsym=>false), args[2] ? :module : :baremodule, args[3], args[4], indent, quote_level)
+        print(io, "end")
     elseif head === :module && nargs==3 && isa(args[1],Bool)
+        # Old 3-argument form: (baremodule_flag, name, body)
         show_block(IOContext(io, beginsym=>false), args[1] ? :module : :baremodule, args[2], args[3], indent, quote_level)
         print(io, "end")
 

--- a/doc/src/manual/code-loading.md
+++ b/doc/src/manual/code-loading.md
@@ -464,6 +464,17 @@ The syntax version for a package is determined by the loading mechanism in the f
 
 3. If neither is specified, the current Julia version is used.
 
+#### In scripts and the REPL
+
+Scripts and the REPL use the active project's syntax version. This determination happens:
+
+1. At startup after processing `--project`
+2. Before parsing any REPL input, once for each prompt
+
+In particular, a manual `set_active_project` in a script will not change the syntax versioned used
+for the rest of the script. However, doing so at the REPL (explicitly or implicitly via the Pkg
+REPL mode) will affect the syntax version used to parse the *next* REPL input.
+
 ## Conclusion
 
 Federated package management and precise software reproducibility are difficult but worthy goals in a package system. In combination, these goals lead to a more complex package loading mechanism than most dynamic languages have, but it also yields scalability and reproducibility that is more commonly associated with static languages. Typically, Julia users should be able to use the built-in package manager to manage their projects without needing a precise understanding of these interactions. A call to `Pkg.add("X")` will add to the appropriate project and manifest files, selected via `Pkg.activate("Y")`, so that a future call to `import X` will load `X` without further thought.

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -203,6 +203,7 @@ let
         ccall(:jl_tag_newly_inferred_enable, Cvoid, ())
         try
             repl_workload()
+            precompile(Tuple{typeof(Base.HashArrayMappedTries.next), Base.HashArrayMappedTries.HashState{Base.ScopedValues.ScopedValue{Any}}})
             precompile(Tuple{typeof(Base.setindex!), Base.Dict{Any, Any}, Any, Char})
             precompile(Tuple{typeof(Base.setindex!), Base.Dict{Any, Any}, Any, Int})
             precompile(Tuple{typeof(Base.delete!), Base.Set{Any}, String})

--- a/test/testhelpers/print_syntax_version.jl
+++ b/test/testhelpers/print_syntax_version.jl
@@ -1,0 +1,1 @@
+print((Base.Experimental.@VERSION).syntax)


### PR DESCRIPTION
Syntax versioning is cued off of the `syntax.julia_version` entry in a package's Project.toml. But how should it behave in the REPL and in scripts? Unlike a package, the `Main` module does not have a well-defined Project associated with it - rather its loading behavior depends on the current active project.

It seems fairly clear that syntax versioning should also follow the active project, but what are the exact semantics? One possibility would be to check the active project's Project.toml every time we need to parse something. However, I think it would be somewhat surprising if the syntax version changed in the middle of a script due to a concurrent edit to the active Project.toml (at least in the absence of something like Revise).

This PR instead implements a ScopedValue-based latching mechanism that reads the syntax version:
 1. At startup
 2. For every REPL prompt

Ordinary ScopedValue behavior determines what happens for e.g. tasks (i.e. a task started from one REPL prompt will continue using that prompt's syntax version for e.g. `include`'s), even if the active project changes in the meanwhile.

Note that as a consequence of this, changing the active project in the middle of a script does not change the syntax version (not that it would anyway, because we parse the whole script before we eval it - but this makes it not take effect for `include` either).

I think this is the most sane behavior. Other frontends that want to evaluate into Main can use the same mechanism as the REPL to decide on a policy that makes sense for their use cases.

It is possible we may want to extend the scoped value behavior to the active project itself as well, but it doesn't have the same TOCTOU issues that the syntax version has and scripts are relying on it being side-effecting, so it's not straightforward.

Finally, this adjusts the creation of named environments to implicitly record the syntax version of the julia process that created the named environment. Of course, this is primarily supposed to catch the creation of the `v1.x` global default environments. That said, it's a bit odd that, if we launch 1.14 with an implicit `--project=@v1.13` and that environment does not exist, it would create that as a `1.14` syntax environment. Currently these versioned environments are not special, but maybe we should make them?