### PR TITLE
JuliaSyntax:force specialize on function in `parse_brackets`

### DIFF
--- a/JuliaSyntax/src/julia/parser.jl
+++ b/JuliaSyntax/src/julia/parser.jl
@@ -3189,8 +3189,8 @@ end
 # (a,b=1; c,d=2; e,f=3)  ==>  (tuple-p a (= b 1) (parameters c (= d 2)) (parameters e (= f 3)))
 #
 # flisp: parts of parse-paren- and parse-arglist
-function parse_brackets(after_parse::Function,
-                        ps::ParseState, closing_kind, generator_is_last=true)
+function parse_brackets(after_parse::F,
+                        ps::ParseState, closing_kind, generator_is_last=true) where {F}
     ps = ParseState(ps, range_colon_enabled=true,
                     space_sensitive=false,
                     where_enabled=true,


### PR DESCRIPTION
Brings over https://github.com/JuliaLang/JuliaSyntax.jl/pull/601 here now that the repo has moved. But we need this on 1.13 (and 1.12) as well.

Without this the REPL becomes very laggy after loading GLMakie:

```
#= 3586.0 ms =# precompile(Tuple{typeof(REPL.LineEdit.refresh_multi_line), Base.Terminals.TerminalBuffer, Base.Terminals.UnixTerminal, Union{REPL.LineEdit.PrefixSearchState, REPL.LineEdit.PromptState}}) # recompile
```

Even though the function is directly called in the function body, I think the fact that there is a default argument prevents specialization from happening. To elaborate:

```
g(f, x=1) = f(..., x)
```

is rewritten internally as:

```
g(f, x) = f(..., x)
g(f) = g(f, 1)
```

now, the second generated method does not call `f` directly so it will heuristically be despecialized.
