### PR TITLE
precompilation: suppress error output when called from loading

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -908,14 +908,17 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
     pkgspidlocked = Dict{PkgConfig,String}()
     pkg_liveprinted = Ref{Union{Nothing, PkgId}}(nothing)
 
-    function monitor_std(pkg_config, pipe; single_requested_pkg=false)
+    function monitor_std(pkg_config, pipe; single_requested_pkg=false, suppress_output::Bool=fancyprint)
         local pkg, config = pkg_config
         try
             local liveprinting = false
             local thistaskwaiting = false
             while !eof(pipe)
                 local str = readline(pipe, keep=true)
-                if single_requested_pkg && (liveprinting || !isempty(str))
+                # Always buffer the output
+                write(get!(IOBuffer, std_outputs, pkg_config), str)
+                # Only print if output is not suppressed (suppress when called from loading)
+                if !suppress_output && single_requested_pkg && (liveprinting || !isempty(str))
                     @lock print_lock begin
                         if !liveprinting
                             liveprinting = true
@@ -924,18 +927,17 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
                         print(io, ansi_cleartoendofline, str)
                     end
                 end
-                write(get!(IOBuffer, std_outputs, pkg_config), str)
                 if thistaskwaiting
                     if occursin("Waiting for background task / IO / timer", str)
                         thistaskwaiting = true
-                        !liveprinting && !fancyprint && @lock print_lock begin
+                        !suppress_output && !liveprinting && @lock print_lock begin
                             println(io, pkg.name, color_string(str, Base.warn_color()))
                         end
                         push!(taskwaiting, pkg_config)
                     end
                 else
                     # XXX: don't just re-enable IO for random packages without printing the context for them first
-                    !liveprinting && !fancyprint && @lock print_lock begin
+                    !suppress_output && !liveprinting && @lock print_lock begin
                         print(io, ansi_cleartoendofline, str)
                     end
                 end
@@ -1054,6 +1056,8 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
     @debug "precompile: starting precompilation loop" direct_deps project_deps
     ## precompilation loop
 
+    should_suppress_live_output = fancyprint || _from_loading
+
     for (pkg, deps) in direct_deps
         cachepaths = Base.find_all_in_cache_path(pkg)
         freshpaths = String[]
@@ -1100,7 +1104,7 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
 
                         # std monitoring
                         std_pipe = Base.link_pipe!(Pipe(); reader_supports_async=true, writer_supports_async=true)
-                        t_monitor = @async monitor_std(pkg_config, std_pipe; single_requested_pkg)
+                        t_monitor = @async monitor_std(pkg_config, std_pipe; single_requested_pkg, suppress_output=should_suppress_live_output)
 
                         local name
                         try
@@ -1281,27 +1285,26 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
             end
         end
     end
-    if !isempty(std_outputs)
+    # Extract std_outputs into a list
+    std_outputs_list = Tuple{PkgConfig,String}[(pkg_config, strip(String(take!(buf)))) for (pkg_config, buf) in std_outputs]
+    filter!(!isempty∘last, std_outputs_list)
+
+    outputs_to_show = filter(((pkg_config, _),) -> !haskey(failed_deps, pkg_config), std_outputs_list)
+    if should_suppress_live_output && !isempty(outputs_to_show)
         str = sprint(context=io) do iostr
             # show any stderr output, even if Pkg.precompile has been interrupted (quick_exit=true), given user may be
             # interrupting a hanging precompile job with stderr output.
-            let std_outputs = Tuple{PkgConfig,SubString{String}}[(pkg_config, strip(String(take!(io)))) for (pkg_config,io) in std_outputs]
-                filter!(!isempty∘last, std_outputs)
-                if !isempty(std_outputs)
-                    local plural1 = length(std_outputs) == 1 ? "y" : "ies"
-                    local plural2 = length(std_outputs) == 1 ? "" : "s"
-                    print(iostr, "\n  ", color_string("$(length(std_outputs))", Base.warn_color()), " dependenc$(plural1) had output during precompilation:")
-                    for (pkg_config, err) in std_outputs
-                        pkg, config = pkg_config
-                        err = if pkg == pkg_liveprinted[]
-                            "[Output was shown above]"
-                        else
-                            join(split(err, "\n"), color_string("\n│  ", Base.warn_color()))
-                        end
-                        name = full_name(ext_to_parent, pkg)
-                        print(iostr, color_string("\n┌ ", Base.warn_color()), name, color_string("\n│  ", Base.warn_color()), err, color_string("\n└  ", Base.warn_color()))
-                    end
+            local plural1 = length(outputs_to_show) == 1 ? "y" : "ies"
+            print(iostr, "\n  ", color_string("$(length(outputs_to_show))", Base.warn_color()), " dependenc$(plural1) had output during precompilation:")
+            for (pkg_config, output) in outputs_to_show
+                pkg, config = pkg_config
+                output = if pkg == pkg_liveprinted[]
+                    "[Output was shown above]"
+                else
+                    join(split(output, "\n"), color_string("\n│  ", Base.warn_color()))
                 end
+                name = full_name(ext_to_parent, pkg)
+                print(iostr, color_string("\n┌ ", Base.warn_color()), name, color_string("\n│  ", Base.warn_color()), output, color_string("\n└  ", Base.warn_color()))
             end
         end
         isempty(str) || @lock print_lock begin
@@ -1314,13 +1317,25 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
     end
     # Fail noisily now with failed_deps if any.
     # Include all messages from compilecache since any might be relevant in the failure.
+    # When _from_loading, also include stderr output in the error message (since it wasn't shown above).
     if !isempty(failed_deps)
+        # Build a lookup for stderr output from failed packages (only needed when _from_loading)
+        failed_outputs = Dict{PkgConfig,String}(pkg_config => output for (pkg_config, output) in std_outputs_list if haskey(failed_deps, pkg_config))
+
         err_str = IOBuffer()
         for ((dep, config), err) in failed_deps
             write(err_str, "\n")
             print(err_str, "\n", dep.name, " ")
             join(err_str, config[1], " ")
             print(err_str, "\n", err)
+            # Include stderr output if available (only when _from_loading, since otherwise it was already shown)
+            pkg_config = (dep, config)
+            if haskey(failed_outputs, pkg_config)
+                output = failed_outputs[pkg_config]
+                if !isempty(output)
+                    print(err_str, "\n", output)
+                end
+            end
         end
         n_errs = length(failed_deps)
         pluraled = n_errs == 1 ? "" : "s"

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2641,6 +2641,7 @@ end
         # Call precompilepkgs with output redirected to a file
         LoadsFailPkg_output = joinpath(depot, "LoadsFailPkg_output.txt")
         DependsOnly_output = joinpath(depot, "DependsOnly_output.txt")
+        loadfail_err = nothing
         original_depot_path = copy(Base.DEPOT_PATH)
         old_proj = Base.active_project()
         try
@@ -2658,6 +2659,7 @@ end
             end
             loadsfailpkg = precompile_capture(LoadsFailPkg_output, "LoadsFailPkg")
             @test loadsfailpkg isa Base.Precompilation.PkgPrecompileError
+            loadfail_err = loadsfailpkg.msg
             dependsonly = precompile_capture(DependsOnly_output, "DependsOnly")
             @test length(dependsonly) == 1
         finally
@@ -2667,12 +2669,12 @@ end
 
         output = read(LoadsFailPkg_output, String)
         # LoadsFailPkg should fail because it tries to load FailPkg with --compiled-modules=strict
-        @test count("LoadError: expected fail", output) == 1
-        @test count("expected fail", output) == 1
+        @test count("LoadError: expected fail", loadfail_err) == 1
+        @test count("expected fail", loadfail_err) == 1
         @test count("✗ FailPkg", output) > 0
         @test count("✗ LoadsFailPkg", output) > 0
-        @test count("Now FailPkg is running.", output) == 1
-        @test count("Now LoadsFailPkg is running.", output) == 1
+        @test count("Now FailPkg is running.", loadfail_err) == 1
+        @test count("Now LoadsFailPkg is running.", loadfail_err) == 1
         @test count("DependsOnly precompiling.", output) == 0
 
         # DependsOnly should succeed because it doesn't actually load FailPkg


### PR DESCRIPTION
As noted in #60148, we currenly dump a bunch of error output to stderr in our precompile tests (for cases where an error occurs during precompilation). One easy answer would just be to wrap this in redirect_stderr. However, it seems bad to me to separate the actual PrecompileError from the output that explains why the precompilation failed. So instead, this PR

1. Disables forwarding of output from loading in !fancyprint mode also.
2. In both fancyprint and non-fancyprint mode, prints any additional output from *successfully* precompiled packages after precompilation succeeds, but
3. Puts the output from *failed* precompilations into the error instead.

I wasn't sure how much I like this separation, but on the other hand output from successfully-precompiled packages is likely to be informational, while the output from failed packages is not - it makes sense to treat these separately.

Fixes #60148