### PR TITLE
Docs: Fix indentation within admonitions

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -191,6 +191,7 @@ When `data` is not given, the buffer will be both readable and writable by defau
     offset leaving behind arbitrary values at other offsets. If `maxsize > length(data)`,
     the IOBuffer might re-allocate the data entirely, which
     may or may not be visible in any outstanding bindings to `array`.
+
 # Examples
 ```jldoctest
 julia> io = IOBuffer();

--- a/base/terminfo.jl
+++ b/base/terminfo.jl
@@ -12,7 +12,7 @@ A structured representation of a terminfo file, without any knowledge of
 particular capabilities, solely based on `term(5)`.
 
 !!! warning
-  This is not part of the public API, and thus subject to change without notice.
+    This is not part of the public API, and thus subject to change without notice.
 
 # Fields
 
@@ -44,7 +44,7 @@ end
 A parsed terminfo paired with capability information.
 
 !!! warning
-  This is not part of the public API, and thus subject to change without notice.
+    This is not part of the public API, and thus subject to change without notice.
 
 # Fields
 

--- a/base/terminfo_data.jl
+++ b/base/terminfo_data.jl
@@ -16,7 +16,7 @@ awk '/^#=run/{flag=1;next}/=#/{flag=0}flag{gsub(/__FILE__/,"\"'"$0"'\"");print}'
 Specification of a single terminal capability.
 
 !!! warning
-  This is not part of the public API, and thus subject to change without notice.
+    This is not part of the public API, and thus subject to change without notice.
 
 # Fields
 

--- a/doc/src/devdocs/build/windows.md
+++ b/doc/src/devdocs/build/windows.md
@@ -179,7 +179,7 @@ Note: MSYS2 requires **64 bit** Windows 7 or newer.
       CXX=/mingw64/bin/clang++
       ```
 !!! warning "UCRT Unsupported"
-   Do not try to use any other clang that MSYS2 may install (which may not have the correct default target) or the "Clang" environment(which defaults to the currently unsupported ucrt).
+    Do not try to use any other clang that MSYS2 may install (which may not have the correct default target) or the "Clang" environment(which defaults to the currently unsupported ucrt).
 
     4. Start the build
 

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -95,8 +95,8 @@ ERROR: cannot assign a value to imported variable Base.sqrt from module Main
 ```
 
 !!! compat "Julia 1.12"
-  Note that in versions prior to Julia 1.12, these errors depended on *use* rather than definition of
-  the conflicting binding.
+    Note that in versions prior to Julia 1.12, these errors depended on *use*
+    rather than definition of the conflicting binding.
 
 ## [Allowed Variable Names](@id man-allowed-variable-names)
 


### PR DESCRIPTION
User xiaoxi originally reported some cases on [Discourse](https://discourse.julialang.org/t/possible-error-on-julia-documentation-page/134585). I found some more cases using a simple script:
```julia
function checkfile(path)
    inside = false
    for (i, line) in enumerate(eachline(path))
        if startswith(line, "!!!")
            inside = true
        elseif inside
            if startswith(line, "\"\"\"")
                inside = false
            elseif all(isspace, line)
                inside = false
            else
                indentation = line[begin:begin + 3]
                if !all(isspace, indentation)
                    println("$path L$i wrong indentation: ", indentation)
                end
            end
        end
    end
end

function (@main)(args=ARGS)
    path = first(args)

    for (path, dirs, files) in walkdir(path)
        for file in files
            if endswith(file, ".jl") || endswith(file, ".md")
                checkfile(joinpath(path, file))
            end
        end
    end
end
```