### PR TITLE
[JuliaLowering] Add support for `Expr(:loopinfo, ...)`

### DIFF
--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -435,6 +435,7 @@ function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
                k == K"="         ? :(=)        :
                k == K"leave"     ? :leave      :
                k == K"isdefined" ? :isdefined  :
+               k == K"loopinfo"  ? :loopinfo   :
                k == K"latestworld"       ? :latestworld       :
                k == K"pop_exception"     ? :pop_exception     :
                k == K"captured_local"    ? :captured_local    :

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -792,7 +792,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         end
     elseif k == K"gc_preserve_begin"
         makenode(ctx, ex, k, compile_args(ctx, children(ex)))
-    elseif k == K"gc_preserve_end"
+    elseif k == K"gc_preserve_end" || k == K"loopinfo"
         if needs_value
             throw(LoweringError(ex, "misplaced kind $k in value position"))
         end

--- a/test/JuliaLowering_stdlibs.jl
+++ b/test/JuliaLowering_stdlibs.jl
@@ -2,18 +2,15 @@ import Libdl
 
 # known precompilation failures under JL
 const INCOMPATIBLE_STDLIBS = String[
-    "InteractiveUtils"
-    "LazyArtifacts"
-    "LibGit2"
-    "Pkg"
-    "REPL"
-    "REPLExt"
-    "SparseArrays"
-    "SparseArraysExt"
-    "Statistics"
-    "SuiteSparse"
-    "TOML"
-    "Test"
+    "InteractiveUtils", # Invalid function name
+    "LibGit2", # op isa Symbol (JuliaLang/JuliaLowering.jl#126)
+    "SparseArrays", # type-alias bug (JuliaLang/JuliaLowering.jl#123)
+    "TOML", # @invokelatest / QuoteNode bug
+    "Test", # depends on InteractiveUtils
+    "REPL", # depends on InteractiveUtils
+    "Pkg", # depends on TOML
+    "SuiteSparse", # depends on SparseArrays
+    "LazyArtifacts", # depends on Pkg
 ]
 
 const JULIA_EXECUTABLE = Base.unsafe_string(Base.JLOptions().julia_bin)


### PR DESCRIPTION
Very trivial change, but this is enough to get Statistics precompiling.

I also confirmed that we see the expected performance delta on our [performance-tips example](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-annotations):
```julia
julia> timeit(1000, 1000)
GFlop/sec        = 3.918357111230404
GFlop/sec (SIMD) = 39.943280541630884
```