### PR TITLE
Support Base.filter on iterators, eagerly collecting

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3389,6 +3389,8 @@ end
 # map on collections
 map(f, A::AbstractArray) = collect_similar(A, Generator(f,A))
 
+filter(f, itr) = collect(Iterators.filter(f, itr))
+
 mapany(f, A::AbstractArray) = map!(f, Vector{Any}(undef, length(A)), A)
 mapany(f, itr) = Any[f(x) for x in itr]
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -893,6 +893,10 @@ function test_checksquare()
     @test_throws DimensionMismatch LinearAlgebra.checksquare(zeros(2,3))
 end
 
+@testset "issue ##45337 filter on iterators" begin
+    @test filter(((x,i),)->isodd(x), enumerate([1,2,3])) == [(1, 1), (3, 3)]
+end
+
 #----- run tests -------------------------------------------------------------#
 
 @testset for T in (T24Linear, TSlow), shape in ((24,), (2, 12), (2,3,4), (1,2,3,4), (4,3,2,1))


### PR DESCRIPTION
<img width="417" height="117" alt="251218_23h39m29s_screenshot" src="https://github.com/user-attachments/assets/40bbea5f-0f3f-46c0-b037-c4bd2a2397c1" />

solves issue: #45337 
Added the  filter on enumerate, and the example mentioned in issue to test.
PS: Please correct me if I have made a mistake(first time contributor), 
thankyou for your time