### PR TITLE
lowering: Fix `@nospecialize` on unnamed arguments

### DIFF
--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -2345,4 +2345,21 @@ let src = code_typed1(Base.setindex, (@NamedTuple{next::UInt32,prev::UInt32}, In
     @test count(iscall((src, Base.merge_fallback)), src.code) == 0
 end
 
+# @nospecialize annotation on uunamed arguments
+# https://github.com/JuliaLang/julia/issues/44428
+@noinline _issue44428_1(@nospecialize _::Any) = println(Base.inferencebarrier(0))
+@noinline _issue44428_2(@nospecialize ::Any) = println(Base.inferencebarrier(0))
+@noinline _issue44428_3(@nospecialize _) = println(Base.inferencebarrier(0))
+function issue44428(x)
+    _issue44428_1(x)
+    _issue44428_2(x)
+    _issue44428_3(x)
+end
+let src = code_typed1(issue44428, (Any,))
+    @test count(isinvoke(:_issue44428_1), src.code) == 1
+    @test count(isinvoke(:_issue44428_2), src.code) == 1
+    @test count(isinvoke(:_issue44428_3), src.code) == 1
+    @test count(x->Meta.isexpr(x,:call), src.code) == 0
+end
+
 end # module inline_tests


### PR DESCRIPTION
Consists of two commits.
The first commit is a fix to the scheme lowerer, ~~and the second is a fix to JuliaLowering.jl.~~ The second one was split into #60432 .

Both commits include fixes for keyword arguments as well, but since `@nospecialize` for keyword arguments doesn't seem to have been tested well yet, and I think we probably first need to think about how to pass `@nospecialize` to the keyword sorter function if we want to properly support it, it might be fine to remove it.

Fixes #44428 