### PR TITLE
Don't make graph type abstract in SyntaxTree

### DIFF
--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -562,9 +562,9 @@ end
 # Context wrapper which helps to construct a list of statements to be executed
 # prior to some expression. Useful when we need to use subexpressions multiple
 # times.
-struct StatementListCtx{Ctx, GraphType} <: AbstractLoweringContext
+struct StatementListCtx{Ctx, Attrs} <: AbstractLoweringContext
     ctx::Ctx
-    stmts::SyntaxList{GraphType}
+    stmts::SyntaxList{Attrs, Vector{NodeId}}
 end
 
 function Base.getproperty(ctx::StatementListCtx, field::Symbol)

--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -1,19 +1,20 @@
-struct ClosureInfo{GraphType}
+struct ClosureInfo{Attrs}
     # Global name of the type of the closure
-    type_name::SyntaxTree{GraphType}
+    type_name::SyntaxTree{Attrs}
     # Names of fields for use with getfield, in order
-    field_names::SyntaxList{GraphType}
+    field_names::SyntaxList{Attrs, Vector{NodeId}}
     # Map from the original BindingId of closed-over vars to the index of the
     # associated field in the closure type.
     field_inds::Dict{IdTag,Int}
 end
 
-struct ClosureConversionCtx{GraphType} <: AbstractLoweringContext
-    graph::GraphType
+struct ClosureConversionCtx{Attrs} <: AbstractLoweringContext
+    graph::SyntaxGraph{Attrs}
     bindings::Bindings
     mod::Module
     closure_bindings::Dict{IdTag,ClosureBindings}
-    capture_rewriting::Union{Nothing,ClosureInfo{GraphType},SyntaxList{GraphType}}
+    capture_rewriting::Union{Nothing,ClosureInfo{Attrs},
+                             SyntaxList{Attrs, Vector{NodeId}}}
     lambda_bindings::LambdaBindings
     # True if we're in a section of code which preserves top-level sequencing
     # such that closure types can be emitted inline with other code.
@@ -23,17 +24,17 @@ struct ClosureConversionCtx{GraphType} <: AbstractLoweringContext
     # functions to refer to globals that have already been declared, without
     # triggering the "function body AST not pure" error.
     toplevel_pure::Bool
-    toplevel_stmts::SyntaxList{GraphType}
-    closure_infos::Dict{IdTag,ClosureInfo{GraphType}}
+    toplevel_stmts::SyntaxList{Attrs, Vector{NodeId}}
+    closure_infos::Dict{IdTag,ClosureInfo{Attrs}}
 end
 
-function ClosureConversionCtx(graph::GraphType, bindings::Bindings,
+function ClosureConversionCtx(graph::SyntaxGraph{Attrs}, bindings::Bindings,
                               mod::Module, closure_bindings::Dict{IdTag,ClosureBindings},
-                              lambda_bindings::LambdaBindings) where {GraphType}
-    ClosureConversionCtx{GraphType}(
+                              lambda_bindings::LambdaBindings) where {Attrs}
+    ClosureConversionCtx{Attrs}(
         graph, bindings, mod, closure_bindings, nothing,
         lambda_bindings, false, true, SyntaxList(graph),
-        Dict{IdTag,ClosureInfo{GraphType}}())
+        Dict{IdTag,ClosureInfo{Attrs}}())
 end
 
 function current_lambda_bindings(ctx::ClosureConversionCtx)

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -1,7 +1,7 @@
 # Lowering Pass 2 - syntax desugaring
 
-struct DesugaringContext{GraphType} <: AbstractLoweringContext
-    graph::GraphType
+struct DesugaringContext{Attrs} <: AbstractLoweringContext
+    graph::SyntaxGraph{Attrs}
     bindings::Bindings
     scope_layers::Vector{ScopeLayer}
     mod::Module

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -32,9 +32,9 @@ end
 # We might consider changing at least the second of these choices, depending on
 # how we end up putting this into Base.
 
-struct LoweringIterator{GraphType}
+struct LoweringIterator{Attrs}
     expr_compat_mode::Bool # later stored in module?
-    todo::Vector{Tuple{SyntaxTree{GraphType}, Bool, Int}}
+    todo::Vector{Tuple{SyntaxTree{Attrs}, Bool, Int}}
 end
 
 function lower_init(ex::SyntaxTree{T};

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -25,36 +25,36 @@ end
 
 # Target to jump to, including info on try handler nesting and catch block
 # nesting
-struct JumpTarget{GraphType}
-    label::SyntaxTree{GraphType}
-    handler_token_stack::SyntaxList{GraphType, Vector{NodeId}}
-    catch_token_stack::SyntaxList{GraphType, Vector{NodeId}}
+struct JumpTarget{Attrs}
+    label::SyntaxTree{Attrs}
+    handler_token_stack::SyntaxList{Attrs, Vector{NodeId}}
+    catch_token_stack::SyntaxList{Attrs, Vector{NodeId}}
 end
 
-function JumpTarget(label::SyntaxTree{GraphType}, ctx) where {GraphType}
-    JumpTarget{GraphType}(label, copy(ctx.handler_token_stack), copy(ctx.catch_token_stack))
+function JumpTarget(label::SyntaxTree{Attrs}, ctx) where {Attrs}
+    JumpTarget{Attrs}(label, copy(ctx.handler_token_stack), copy(ctx.catch_token_stack))
 end
 
-struct JumpOrigin{GraphType}
-    goto::SyntaxTree{GraphType}
+struct JumpOrigin{Attrs}
+    goto::SyntaxTree{Attrs}
     index::Int
-    handler_token_stack::SyntaxList{GraphType, Vector{NodeId}}
-    catch_token_stack::SyntaxList{GraphType, Vector{NodeId}}
+    handler_token_stack::SyntaxList{Attrs, Vector{NodeId}}
+    catch_token_stack::SyntaxList{Attrs, Vector{NodeId}}
 end
 
-function JumpOrigin(goto::SyntaxTree{GraphType}, index, ctx) where {GraphType}
-    JumpOrigin{GraphType}(goto, index, copy(ctx.handler_token_stack), copy(ctx.catch_token_stack))
+function JumpOrigin(goto::SyntaxTree{Attrs}, index, ctx) where {Attrs}
+    JumpOrigin{Attrs}(goto, index, copy(ctx.handler_token_stack), copy(ctx.catch_token_stack))
 end
 
-struct FinallyHandler{GraphType}
-    tagvar::SyntaxTree{GraphType}
-    target::JumpTarget{GraphType}
-    exit_actions::Vector{Tuple{Symbol,Union{Nothing,SyntaxTree{GraphType}}}}
+struct FinallyHandler{Attrs}
+    tagvar::SyntaxTree{Attrs}
+    target::JumpTarget{Attrs}
+    exit_actions::Vector{Tuple{Symbol,Union{Nothing,SyntaxTree{Attrs}}}}
 end
 
-function FinallyHandler(tagvar::SyntaxTree{GraphType}, target::JumpTarget) where {GraphType}
-    FinallyHandler{GraphType}(tagvar, target,
-        Vector{Tuple{Symbol, Union{Nothing,SyntaxTree{GraphType}}}}())
+function FinallyHandler(tagvar::SyntaxTree{Attrs}, target::JumpTarget) where {Attrs}
+    FinallyHandler{Attrs}(tagvar, target,
+        Vector{Tuple{Symbol, Union{Nothing,SyntaxTree{Attrs}}}}())
 end
 
 
@@ -64,20 +64,20 @@ Context for creating linear IR.
 One of these is created per lambda expression to flatten the body down to
 a sequence of statements (linear IR), which eventually becomes one CodeInfo.
 """
-struct LinearIRContext{GraphType} <: AbstractLoweringContext
-    graph::GraphType
-    code::SyntaxList{GraphType, Vector{NodeId}}
+struct LinearIRContext{Attrs} <: AbstractLoweringContext
+    graph::SyntaxGraph{Attrs}
+    code::SyntaxList{Attrs, Vector{NodeId}}
     bindings::Bindings
     next_label_id::Ref{Int}
     is_toplevel_thunk::Bool
     lambda_bindings::LambdaBindings
-    return_type::Union{Nothing, SyntaxTree{GraphType}}
-    break_targets::Dict{String, JumpTarget{GraphType}}
-    handler_token_stack::SyntaxList{GraphType, Vector{NodeId}}
-    catch_token_stack::SyntaxList{GraphType, Vector{NodeId}}
-    finally_handlers::Vector{FinallyHandler{GraphType}}
-    symbolic_jump_targets::Dict{String,JumpTarget{GraphType}}
-    symbolic_jump_origins::Vector{JumpOrigin{GraphType}}
+    return_type::Union{Nothing, SyntaxTree{Attrs}}
+    break_targets::Dict{String, JumpTarget{Attrs}}
+    handler_token_stack::SyntaxList{Attrs, Vector{NodeId}}
+    catch_token_stack::SyntaxList{Attrs, Vector{NodeId}}
+    finally_handlers::Vector{FinallyHandler{Attrs}}
+    symbolic_jump_targets::Dict{String,JumpTarget{Attrs}}
+    symbolic_jump_origins::Vector{JumpOrigin{Attrs}}
     meta::Dict{Symbol, Any}
     mod::Module
 end
@@ -85,12 +85,12 @@ end
 function LinearIRContext(ctx, is_toplevel_thunk, lambda_bindings, return_type)
     graph = syntax_graph(ctx)
     rett = isnothing(return_type) ? nothing : reparent(graph, return_type)
-    GraphType = typeof(graph)
+    Attrs = typeof(graph.attributes)
     LinearIRContext(graph, SyntaxList(ctx), ctx.bindings, Ref(0),
                     is_toplevel_thunk, lambda_bindings, rett,
-                    Dict{String,JumpTarget{GraphType}}(), SyntaxList(ctx), SyntaxList(ctx),
-                    Vector{FinallyHandler{GraphType}}(), Dict{String,JumpTarget{GraphType}}(),
-                    Vector{JumpOrigin{GraphType}}(), Dict{Symbol, Any}(), ctx.mod)
+                    Dict{String,JumpTarget{Attrs}}(), SyntaxList(ctx), SyntaxList(ctx),
+                    Vector{FinallyHandler{Attrs}}(), Dict{String,JumpTarget{Attrs}}(),
+                    Vector{JumpOrigin{Attrs}}(), Dict{Symbol, Any}(), ctx.mod)
 end
 
 function current_lambda_bindings(ctx::LinearIRContext)
@@ -1125,14 +1125,14 @@ loops, etc) to gotos and exception handling to enter/leave. We also convert
                               id=Int)
     # TODO: Cleanup needed - `_ctx` is just a dummy context here. But currently
     # required to call reparent() ...
-    GraphType = typeof(graph)
+    Attrs = typeof(graph.attributes)
     _ctx = LinearIRContext(graph, SyntaxList(graph), ctx.bindings,
                            Ref(0), false, LambdaBindings(), nothing,
-                           Dict{String,JumpTarget{typeof(graph)}}(),
+                           Dict{String,JumpTarget{Attrs}}(),
                            SyntaxList(graph), SyntaxList(graph),
-                           Vector{FinallyHandler{GraphType}}(),
-                           Dict{String, JumpTarget{GraphType}}(),
-                           Vector{JumpOrigin{GraphType}}(),
+                           Vector{FinallyHandler{Attrs}}(),
+                           Dict{String, JumpTarget{Attrs}}(),
+                           Vector{JumpOrigin{Attrs}}(),
                            Dict{Symbol, Any}(), ctx.mod)
     res = compile_lambda(_ctx, reparent(_ctx, ex))
     _ctx, res

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -1,7 +1,7 @@
 # Lowering pass 1: Macro expansion, simple normalizations and quote expansion
 
-struct MacroExpansionContext{GraphType} <: AbstractLoweringContext
-    graph::GraphType
+struct MacroExpansionContext{Attrs} <: AbstractLoweringContext
+    graph::SyntaxGraph{Attrs}
     bindings::Bindings
     scope_layers::Vector{ScopeLayer}
     scope_layer_stack::Vector{LayerId}

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -52,8 +52,8 @@ function ScopeInfo(ctx, parent_id, node_id, is_lambda, is_permeable)
     return s
 end
 
-struct ScopeResolutionContext{GraphType} <: AbstractLoweringContext
-    graph::GraphType
+struct ScopeResolutionContext{Attrs} <: AbstractLoweringContext
+    graph::SyntaxGraph{Attrs}
     bindings::Bindings
     mod::Module
     # Every lexical scope, indexed by ScopeId
@@ -529,14 +529,14 @@ end
 
 ClosureBindings(name_stack) = ClosureBindings(name_stack, Vector{LambdaBindings}())
 
-struct VariableAnalysisContext{GraphType} <: AbstractLoweringContext
-    graph::GraphType
+struct VariableAnalysisContext{Attrs} <: AbstractLoweringContext
+    graph::SyntaxGraph{Attrs}
     bindings::Bindings
     mod::Module
     scopes::Vector{ScopeInfo}
     lambda_bindings::LambdaBindings
     # Stack of method definitions for closure naming
-    method_def_stack::SyntaxList{GraphType}
+    method_def_stack::SyntaxList{Attrs, Vector{NodeId}}
     # Collection of information about each closure, principally which methods
     # are part of the closure (and hence captures).
     closure_bindings::Dict{IdTag,ClosureBindings}

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -192,8 +192,8 @@ end
 An ECS-style AST used in JuliaLowering.  Unstable, but may eventually replace
 SyntaxNode.
 """
-struct SyntaxTree{GraphType}
-    _graph::GraphType
+struct SyntaxTree{Attrs}
+    _graph::SyntaxGraph{Attrs}
     _id::NodeId
 end
 
@@ -448,19 +448,17 @@ byte_range(ex::SyntaxTree) = byte_range(sourceref(ex))
 
 #-------------------------------------------------------------------------------
 # Lightweight vector of nodes ids with associated pointer to graph stored separately.
-mutable struct SyntaxList{GraphType, NodeIdVecType} <: AbstractVector{SyntaxTree}
-    graph::GraphType
+mutable struct SyntaxList{Attrs, NodeIdVecType} <: AbstractVector{SyntaxTree}
+    graph::SyntaxGraph{Attrs}
     ids::NodeIdVecType
 end
 
-function SyntaxList(graph::SyntaxGraph, ids::AbstractVector{NodeId})
-    SyntaxList{typeof(graph), typeof(ids)}(graph, ids)
+function SyntaxList(graph::SyntaxGraph{T}, ids::AbstractVector{NodeId}) where {T}
+    SyntaxList{T, typeof(ids)}(graph, ids)
 end
 
 SyntaxList(graph::SyntaxGraph) = SyntaxList(graph, Vector{NodeId}())
 SyntaxList(ctx) = SyntaxList(syntax_graph(ctx))
-SyntaxList(ctx, v::Vector{SyntaxTree}) =
-    SyntaxList(syntax_graph(ctx), NodeId[x._id for x in v])
 
 syntax_graph(lst::SyntaxList) = lst.graph
 


### PR DESCRIPTION
I didn't notice we had both (1) abstract attribute storage in SyntaxGraph and
(2) abstract graph type in SyntaxTree and other structs.  This PR keeps the first
(it's established that we might experiment with this type to try and improve
performance), but removes the second, as there's only one graph type that works
with SyntaxTree (which is just a graph and integer node ID).  It would be easier
to define a new tree type than support a different graph in SyntaxTree.

Noticed while scrolling through all methodinstances and seeing a weird mix of
partially-parameterized SyntaxTrees in signatures; reduces precompilation time
by about 25% (we are down to less than double JuliaSyntax now!)
