### PR TITLE
Document and further clean up node creation functions

### DIFF
--- a/JuliaLowering/src/JuliaLowering.jl
+++ b/JuliaLowering/src/JuliaLowering.jl
@@ -17,10 +17,11 @@ using .JuliaSyntax: highlight, Kind, @KSet_str, is_leaf, children, numchildren,
     sourcefile, source_location, span, sourcetext, is_literal, is_infix_op_call,
     is_postfix_op_call, @isexpr, SyntaxHead, is_syntactic_operator,
     SyntaxGraph, SyntaxTree, SyntaxList, NodeId, SourceRef, SourceAttrType,
-    ensure_attributes, ensure_attributes!, delete_attributes, newnode!, hasattr,
+    ensure_attributes, ensure_attributes!, delete_attributes, new_id!, hasattr,
     setattr, setattr!, syntax_graph, is_compatible_graph,
     check_compatible_graph, copy_node, copy_ast, provenance, sourceref,
-    reparent, makeleaf, makenode, mapchildren, mapleaf, flattened_provenance
+    reparent, mapchildren, flattened_provenance, mkleaf, mknode, newleaf,
+    newnode, tree_ids
 
 _include("kinds.jl")
 _register_kinds()

--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -90,12 +90,14 @@ Lexical scope ID
 """
 const ScopeId = Int
 
-function JuliaSyntax.makeleaf(ctx::AbstractLoweringContext, srcref, proto)
-    makeleaf(syntax_graph(ctx), srcref, proto)
+function JuliaSyntax.newleaf(ctx::AbstractLoweringContext,
+                    prov::Union{SyntaxTree, SourceAttrType},
+                    k::Kind)
+    newleaf(syntax_graph(ctx), prov, k)
 end
 
-function newleaf(ctx, srcref, k::Kind, @nospecialize(value))
-    leaf = makeleaf(ctx, srcref, k)
+function JuliaSyntax.newleaf(ctx, prov, k, @nospecialize(value))
+    leaf = newleaf(ctx, prov, k)
     if k == K"Identifier" || k == K"core" || k == K"top" || k == K"Symbol" ||
             k == K"globalref" || k == K"Placeholder"
         setattr!(leaf._graph, leaf._id, :name_val, value)
@@ -122,19 +124,21 @@ function newleaf(ctx, srcref, k::Kind, @nospecialize(value))
     leaf
 end
 
+JuliaSyntax.newnode(ctx::AbstractLoweringContext,
+                    prov::Union{SyntaxTree, SourceAttrType},
+                    k::Kind, cs) =
+    newnode(syntax_graph(ctx), prov, k, cs)
+
 # Convenience functions to create leaf nodes referring to identifiers within
 # the Core and Top modules.
 core_ref(ctx, ex, name) = newleaf(ctx, ex, K"core", name)
-svec_type(ctx, ex) = core_ref(ctx, ex, "svec")
 nothing_(ctx, ex) = core_ref(ctx, ex, "nothing")
-
-top_ref(ctx, ex, name) = makeleaf(ctx, ex, K"top", name)
 
 # Assign `ex` to an SSA variable.
 # Return (variable, assignment_node)
 function assign_tmp(ctx::AbstractLoweringContext, ex, name="tmp")
     var = ssavar(ctx, ex, name)
-    assign_var = makenode(ctx, ex, K"=", NodeId[var._id, ex._id])
+    assign_var = newnode(ctx, ex, K"=", tree_ids(var, ex))
     var, assign_var
 end
 
@@ -143,24 +147,35 @@ function emit_assign_tmp(stmts::SyntaxList, ctx, ex, name="tmp")
         return ex
     end
     var = ssavar(ctx, ex, name)
-    push!(stmts, makenode(ctx, ex, K"=", NodeId[var._id, ex._id]))
+    push!(stmts, newnode(ctx, ex, K"=", tree_ids(var, ex)))
     var
 end
 
 #-------------------------------------------------------------------------------
 # @ast macro
 
-function JuliaSyntax._node_id(graph::SyntaxGraph, ex)
+_node_id(graph::SyntaxGraph, ex::SyntaxTree) = (check_compatible_graph(graph, ex); ex._id)
+
+_node_ids(graph::SyntaxGraph) = ()
+_node_ids(graph::SyntaxGraph, ::Nothing, cs...) = _node_ids(graph, cs...)
+_node_ids(graph::SyntaxGraph, c, cs...) = (_node_id(graph, c), _node_ids(graph, cs...)...)
+_node_ids(graph::SyntaxGraph, cs::SyntaxList, cs1...) = (_node_ids(graph, cs...)..., _node_ids(graph, cs1...)...)
+function _node_ids(graph::SyntaxGraph, cs::SyntaxList)
+    check_compatible_graph(graph, cs)
+    cs.ids
+end
+
+function _node_id(graph::SyntaxGraph, ex)
     # Fallback to give a comprehensible error message for use with the @ast macro
     error("Attempt to use `$(repr(ex))` of type `$(typeof(ex))` as an AST node. Try annotating with `::K\"your_intended_kind\"?`")
 end
-function JuliaSyntax._node_id(graph::SyntaxGraph, ex::AbstractVector{<:SyntaxTree})
+function _node_id(graph::SyntaxGraph, ex::AbstractVector{<:SyntaxTree})
     # Fallback to give a comprehensible error message for use with the @ast macro
     error("Attempt to use vector as an AST node. Did you mean to splat this? (content: `$(repr(ex))`)")
 end
 
 function _push_nodeid!(graph::SyntaxGraph, ids::Vector{NodeId}, val)
-    push!(ids, JuliaSyntax._node_id(graph, val))
+    push!(ids, _node_id(graph, val))
 end
 function _push_nodeid!(graph::SyntaxGraph, ids::Vector{NodeId}, val::Nothing)
     nothing
@@ -238,7 +253,7 @@ function _expand_ast_tree(ctx, srcref, tree)
         # Leaf node with copied attributes
         kind = esc(tree.args[3])
         srcref = esc(tree.args[2])
-        :(mapleaf($ctx, $srcref, $kind))
+        :(setattr!(mkleaf($srcref), :kind, $kind))
     elseif Meta.isexpr(tree, (:vcat, :hcat, :vect))
         # Interior node
         flatargs = []
@@ -262,7 +277,7 @@ function _expand_ast_tree(ctx, srcref, tree)
         end
         push!(child_stmts, :(child_ids))
         let (kind, srcref, kws) = _match_kind(srcref, flatargs[1])
-            n = :(makenode($ctx, $srcref, $kind, $children_ex))
+            n = :(newnode($ctx, $srcref, $kind, $children_ex))
             for (attr, val) in kws
                 n = :(setattr!($n, $attr, $val))
             end
@@ -340,7 +355,7 @@ to indicate that the "primary" location of the source is the location where
 macro ast(ctx, srcref, tree)
     quote
         ctx = $(esc(ctx))
-        srcref = $(_match_srcref(srcref))
+        srcref::$SyntaxTree = $(_match_srcref(srcref))
         $(_expand_ast_tree(:ctx, :srcref, tree))
     end
 end
@@ -351,14 +366,14 @@ function set_scope_layer(ctx, ex, layer_id, force)
     new_layer = force ? layer_id : get(ex, :scope_layer, layer_id)
 
     ex2 = if k == K"module" || k == K"toplevel" || k == K"inert"
-        makenode(ctx, ex, ex, children(ex))
+        mknode(ex, children(ex))
     elseif k == K"."
-        children = NodeId[set_scope_layer(ctx, ex[1], layer_id, force), ex[2]]
-        makenode(ctx, ex, ex, children)
+        cs = tree_ids(set_scope_layer(ctx, ex[1], layer_id, force), ex[2])
+        mknode(ex, cs)
     elseif !is_leaf(ex)
         mapchildren(e->set_scope_layer(ctx, e, layer_id, force), ctx, ex)
     else
-        makeleaf(ctx, ex, ex)
+        mkleaf(ex)
     end
     setattr!(ex2, :scope_layer, new_layer)
 end

--- a/JuliaLowering/src/bindings.jl
+++ b/JuliaLowering/src/bindings.jl
@@ -122,8 +122,7 @@ end
 
 # Create a new SSA binding
 function ssavar(ctx::AbstractLoweringContext, srcref, name="tmp")
-    nameref = makeleaf(ctx, srcref, K"Identifier")
-    nameref.name_val = name
+    nameref = newleaf(ctx, srcref, K"Identifier", name)
     binding_ex(ctx, _new_binding(ctx, nameref, name, :local;
                                  is_ssa=true, is_internal=true))
 end
@@ -132,8 +131,7 @@ end
 function new_local_binding(ctx::AbstractLoweringContext, srcref, name;
                            kind=:local, kws...)
     @assert kind === :local || kind === :argument
-    nameref = makeleaf(ctx, srcref, K"Identifier")
-    nameref.name_val = name
+    nameref = newleaf(ctx, srcref, K"Identifier", name)
     b = _new_binding(ctx, nameref, name, kind; is_internal=true, kws...)
     lbindings = current_lambda_bindings(ctx)
     if !isnothing(lbindings)
@@ -143,8 +141,7 @@ function new_local_binding(ctx::AbstractLoweringContext, srcref, name;
 end
 
 function new_global_binding(ctx::AbstractLoweringContext, srcref, name, mod; kws...)
-    nameref = makeleaf(ctx, srcref, K"Identifier")
-    nameref.name_val = name
+    nameref = newleaf(ctx, srcref, K"Identifier", name)
     binding_ex(ctx, _new_binding(
         ctx, nameref, name, :global; is_internal=true, mod=mod, kws...))
 end

--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -387,7 +387,7 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
             # [K"assert" "toplevel_only"::K"Symbol" [K"inert" ex]]
             make_globaldecl(ctx, ex, binfo.mod, binfo.name, true, _convert_closures(ctx, ex[2]))
         else
-            makeleaf(ctx, ex, K"TOMBSTONE")
+            newleaf(ctx, ex, K"TOMBSTONE")
         end
     elseif k == K"global"
         # Leftover `global` forms become weak globals.
@@ -409,7 +409,7 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
         elseif !binfo.is_always_defined
             @ast ctx ex [K"newvar" var]
         else
-            makeleaf(ctx, ex, K"TOMBSTONE")
+            newleaf(ctx, ex, K"TOMBSTONE")
         end
     elseif k == K"lambda"
         closure_convert_lambda(ctx, ex)
@@ -592,7 +592,7 @@ function closure_convert_lambda(ctx, ex)
         push!(lambda_children, _convert_closures(ctx2, ex[4]))
     end
 
-    lam = makenode(ctx, ex, ex, lambda_children, [:lambda_bindings=>lambda_bindings])
+    lam = setattr!(mknode(ex, lambda_children), :lambda_bindings, lambda_bindings)
     if !isnothing(interpolations) && !isempty(interpolations)
         @ast ctx ex [K"call"
             replace_captured_locals!::K"Value"

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -2,7 +2,7 @@ const JS = JuliaSyntax
 
 function _insert_tree_node(graph::SyntaxGraph, k::Kind, src::SourceAttrType,
                            attrs=[], flags::UInt16=0x0000)
-    id = newnode!(graph)
+    id = new_id!(graph)
     setattr!(graph, id, :kind, k)
     flags !== 0 && setattr!(graph, id, :syntax_flags, flags)
     setattr!(graph, id, :source, src)
@@ -659,15 +659,15 @@ isa_lowering_ast_node(@nospecialize(e)) =
 function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
     st = if e === Core.nothing
         # e.value can't be nothing in `K"Value"`, so represent with K"core"
-        setattr!(makeleaf(graph, src, K"core"), :name_val, "nothing")
+        setattr!(newleaf(graph, src, K"core"), :name_val, "nothing")
     elseif e isa Symbol
-        setattr!(makeleaf(graph, src, K"Identifier"), :name_val, String(e))
+        setattr!(newleaf(graph, src, K"Identifier"), :name_val, String(e))
     elseif e isa QuoteNode
         cid, _ = _expr_to_est(graph, e.value, src)
-        makenode(graph, src, K"inert", NodeId[cid])
+        newnode(graph, src, K"inert", NodeId[cid])
     elseif e isa Expr && e.head === :scope_layer
         @assert length(e.args) === 2 && e.args[1] isa Symbol
-        ident = makeleaf(graph, src, K"Identifier")
+        ident = newleaf(graph, src, K"Identifier")
         setattr!(ident, :name_val, String(e.args[1]))
         setattr!(ident, :scope_layer, e.args[2])
     elseif e isa Expr
@@ -685,9 +685,9 @@ function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
             end
         end
         if isnothing(st_k)
-            setattr!(makenode(graph, src, K"unknown_head", cs), :name_val, head_s)
+            setattr!(newnode(graph, src, K"unknown_head", cs), :name_val, head_s)
         else
-            makenode(graph, old_src, st_k, cs)
+            newnode(graph, old_src, st_k, cs)
         end
     # elseif e isa GlobalRef
         # TODO: Better-behaved as K"globalref", but lowering doesn't know this
@@ -700,7 +700,7 @@ function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
             # linenode oustside of block or toplevel
             src = e
         end
-        setattr!(makeleaf(graph, src, K"Value"), :value, e)
+        setattr!(newleaf(graph, src, K"Value"), :value, e)
     end
 
     return st._id, src

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -268,7 +268,7 @@ function lower_tuple_assignment(ctx, assignment_srcref, lhss, rhs)
             [K"call" "getfield"::K"core" tmp i::K"Integer"]
         ])
     end
-    makenode(ctx, assignment_srcref, K"block", stmts)
+    newnode(ctx, assignment_srcref, K"block", stmts)
 end
 
 # Implement destructuring with `lhs` a tuple expression (possibly with
@@ -403,7 +403,7 @@ function expand_property_destruct(ctx, ex, is_const)
         ]))
     end
     push!(stmts, @ast ctx rhs1 [K"removable" rhs1])
-    makenode(ctx, ex, K"block", stmts)
+    newnode(ctx, ex, K"block", stmts)
 end
 
 # Expands all cases of general tuple destructuring, eg
@@ -444,7 +444,7 @@ function expand_tuple_destruct(ctx, ex, is_const)
     end
     _destructure(ctx, ex, stmts, lhs, rhs1, is_const)
     push!(stmts, @ast ctx rhs1 [K"removable" rhs1])
-    makenode(ctx, ex, K"block", stmts)
+    newnode(ctx, ex, K"block", stmts)
 end
 
 #-------------------------------------------------------------------------------
@@ -1481,7 +1481,7 @@ function expand_condition(ctx, ex)
         # jumps rather than first computing a bool and then jumping.
         cs = expand_cond_children(ctx, test)
         @assert length(cs) > 1
-        test = makenode(ctx, test, k, cs)
+        test = newnode(ctx, test, k, cs)
     else
         test = expand_forms_2(ctx, test)
     end
@@ -2167,9 +2167,10 @@ function make_lhs_decls(ctx, stmts, declkind, declmeta, ex, type_decls=true)
         # other Exprs that cannot be produced by the parser (tested by
         # test/precompile.jl #50538).
         if !isnothing(declmeta)
-            push!(stmts, makenode(ctx, ex, declkind, NodeId[ex._id], [:meta=>declmeta]))
+            push!(stmts, setattr!(newnode(ctx, ex, declkind, tree_ids(ex)),
+                                  :meta, declmeta))
         else
-            push!(stmts, makenode(ctx, ex, declkind, NodeId[ex._id]))
+            push!(stmts, newnode(ctx, ex, declkind, tree_ids(ex)))
         end
     elseif k == K"Placeholder"
         nothing
@@ -2178,7 +2179,7 @@ function make_lhs_decls(ctx, stmts, declkind, declmeta, ex, type_decls=true)
             @chk numchildren(ex) == 2
             name = ex[1]
             if kind(name) == K"Identifier"
-                push!(stmts, makenode(ctx, ex, K"decl", NodeId[name._id, ex[2]._id]))
+                push!(stmts, newnode(ctx, ex, K"decl", tree_ids(name, ex[2])))
             else
                 # TODO: Currently, this ignores the LHS in `_::T = val`.
                 # We should probably do one of the following:
@@ -2222,7 +2223,7 @@ function expand_decls(ctx, ex)
             throw(LoweringError(ex, "invalid syntax in variable declaration"))
         end
     end
-    makenode(ctx, ex, K"block", stmts)
+    newnode(ctx, ex, K"block", stmts)
 end
 
 # Iterate over the variable names assigned to from a "fancy assignment left hand
@@ -3352,7 +3353,7 @@ end
 function _make_macro_name(ctx, ex)
     k = kind(ex)
     if k == K"Identifier" || k == K"Symbol"
-        name = mapleaf(ctx, ex, k)
+        name = setattr!(mkleaf(ex), :kind, k)
         name.name_val = "@$(ex.name_val)"
         name
     elseif is_valid_modref(ex)
@@ -4422,7 +4423,7 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
         # structure. For now we attribute to the parent node.
         cond = length(cs) == 2 ?
             cs[1] :
-            makenode(ctx, ex, k, cs[1:end-1])
+            newnode(ctx, ex, k, cs[1:end-1])
         # This transformation assumes the type assertion `cond::Bool` will be
         # added by a later compiler pass (currently done in codegen)
         if k == K"&&"

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -195,7 +195,7 @@ function set_macro_arg_hygiene(ctx, ex, layer_ids, layer_idx)
     k = kind(ex)
     scope_layer = get(ex, :scope_layer, layer_ids[layer_idx])
     if is_leaf(ex)
-        makeleaf(ctx, ex, ex, [:scope_layer=>scope_layer])
+        setattr!(copy_node(ex), :scope_layer, scope_layer)
     else
         inner_layer_idx = layer_idx
         if k == K"escape"
@@ -356,19 +356,24 @@ function expand_macro(ctx, ex)
     return expanded
 end
 
+_unpack_srcref(graph, srcref::SyntaxTree) = _node_id(graph, srcref)
+_unpack_srcref(graph, srcref::Tuple)      = _node_ids(graph, srcref...)
+_unpack_srcref(graph, srcref)             = srcref
+
 # Add a secondary source of provenance to each expression in the tree `ex`.
 function append_sourceref(ctx, ex, secondary_prov)
     srcref = (ex, secondary_prov)
-    if !is_leaf(ex)
+    out = if !is_leaf(ex)
         if kind(ex) == K"macrocall"
-            makenode(ctx, srcref, ex, children(ex))
+            copy_node(ex)
         else
             cs = map(e->append_sourceref(ctx, e, secondary_prov)._id, children(ex))
-            makenode(ctx, srcref, ex, cs)
+            mknode(ex, cs)
         end
     else
-        makeleaf(ctx, srcref, ex)
+        copy_node(ex)
     end
+    setattr!(out, :source, _unpack_srcref(syntax_graph(ctx), srcref))
 end
 
 function remove_scope_layer!(ex)
@@ -410,7 +415,9 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
         else
             k = all(==('_'), name_str) ? K"Placeholder" : K"Identifier"
             scope_layer = get(ex, :scope_layer, current_layer_id(ctx))
-            makeleaf(ctx, ex, ex, [:kind=>k, :scope_layer=>scope_layer])
+            out = mkleaf(ex)
+            setattr!(out, :kind, k)
+            setattr!(out, :scope_layer, scope_layer)
         end
     elseif k == K"var" || k == K"char" || k == K"parens"
         # Strip "container" nodes

--- a/JuliaLowering/src/runtime.jl
+++ b/JuliaLowering/src/runtime.jl
@@ -45,7 +45,7 @@ _numchildren(@nospecialize(ex)) = ex isa Expr ? length(ex.args) : 0
 _syntax_list(ctx::InterpolationContext) = SyntaxList(ctx)
 _syntax_list(ctx::ExprInterpolationContext) = Any[]
 
-_interp_makenode(ctx::InterpolationContext, ex, args) = makenode(ctx, ex, ex, args)
+_interp_makenode(ctx::InterpolationContext, ex, args) = mknode(ex, args)
 _interp_makenode(ctx::ExprInterpolationContext, ex, args) = Expr((ex::Expr).head, args...)
 
 _is_leaf(ex::SyntaxTree) = is_leaf(ex)
@@ -292,7 +292,7 @@ end
 struct GeneratedFunctionStub
     expr_compat_mode::Bool
     gen::Function
-    srcref::Union{SyntaxTree,LineNumberNode,SourceRef}
+    srcref::Union{LineNumberNode,SourceRef}
     argnames::Core.SimpleVector
     spnames::Core.SimpleVector
 end
@@ -343,7 +343,7 @@ function (g::GeneratedFunctionStub)(world::UInt, source::Method, @nospecialize a
             ex0 = copy_ast(ctx1, ex0)
         end
     else
-        ex0 = @ast ctx1 g.srcref ex0::K"Value"
+        ex0 = newleaf(syntax_graph(ctx1), g.srcref, K"Value", ex0)
     end
     # Expand any macros emitted by the generator
     ex1 = expand_forms_1(ctx1, reparent(ctx1, ex0))

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -338,7 +338,7 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
         record_lambda_var!(ctx, scope, get_binding(ctx, ex), capt=true)
         ex
     elseif k == K"softscope"
-        makeleaf(ctx, ex, K"TOMBSTONE")
+        newleaf(ctx, ex, K"TOMBSTONE")
     elseif !needs_resolution(ex)
         ex
     elseif k == K"local"
@@ -366,7 +366,7 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
         ex_out
     elseif k == K"always_defined"
         resolve_name(ctx, ex[1]).is_always_defined = true
-        makeleaf(ctx, ex, K"TOMBSTONE")
+        newleaf(ctx, ex, K"TOMBSTONE")
     elseif k == K"lambda"
         newscope = enter_scope!(ctx, ex)
         arg_bindings = _resolve_scopes(ctx, ex[1], newscope)
@@ -452,7 +452,7 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
                 end
             end
             push!(stmts, locals_dict)
-            makenode(ctx, ex, K"block", stmts)
+            newnode(ctx, ex, K"block", stmts)
         end
     elseif k == K"assert"
         etype = extension_type(ex)
@@ -476,7 +476,7 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
         else
             throw(LoweringError(ex, "Unknown syntax assertion"))
         end
-        makeleaf(ctx, ex, K"TOMBSTONE")
+        newleaf(ctx, ex, K"TOMBSTONE")
     elseif k == K"function_decl"
         resolved = mapchildren(e->_resolve_scopes(ctx, e, scope), ctx, ex)
         name = resolved[1]

--- a/JuliaLowering/test/compat.jl
+++ b/JuliaLowering/test/compat.jl
@@ -662,10 +662,12 @@ end
         x->Expr(:dummy, x)
     ]
 
+    # TODO: `@ast_` escaping is broken
+    unused = JuliaSyntax.parsestmt(JuliaSyntax.SyntaxTree, "foo")
     local st_wrappers = Function[
-        x->(@assert(!isnothing(x)); @ast _ast_test_graph() @__LINE__() (x::K"Value"))
-        x->(@assert(!isnothing(x)); @ast _ast_test_graph() @__LINE__() [K"inert" x::K"Value"])
-        x->(@assert(!isnothing(x)); @ast _ast_test_graph() @__LINE__() [K"function" x::K"Value"])
+        x->(@assert(!isnothing(x)); @ast unused._graph unused (x::K"Value"))
+        x->(@assert(!isnothing(x)); @ast unused._graph unused [K"inert" x::K"Value"])
+        x->(@assert(!isnothing(x)); @ast unused._graph unused [K"function" x::K"Value"])
     ]
 
     @testset "every basic case" begin

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -498,7 +498,7 @@ end
             $init
             ($y, x)
         end)
-        @ast q q [K"inert" q]
+        @ast q._graph q [K"inert" q]
     end
     """)
     code = JuliaLowering.include_string(test_mod, """@make_quoted_code(x="outer x", x)""")

--- a/JuliaLowering/test/scopes.jl
+++ b/JuliaLowering/test/scopes.jl
@@ -149,7 +149,8 @@ end
     function wrapscope(ex, scope_type)
         g = JuliaLowering.ensure_attributes(ex._graph, scope_type=Symbol)
         ex = JuliaLowering.reparent(g, ex)
-        makenode(g, ex, K"scope_block", [ex._id], [:scope_type=>scope_type])
+        out = JuliaLowering.newnode(g, ex, K"scope_block", [ex._id])
+        setattr!(out, :scope_type, scope_type)
     end
     function use_soft(ex::SyntaxTree)
         @ast ex._graph ex [K"block" (::K"softscope") ex]

--- a/JuliaLowering/test/utils.jl
+++ b/JuliaLowering/test/utils.jl
@@ -15,10 +15,9 @@ import REPL
 using .JuliaSyntax: sourcetext, set_numeric_flags
 
 using .JuliaLowering:
-    SyntaxGraph, newnode!, ensure_attributes!,
+    SyntaxGraph, new_id!, ensure_attributes!,
     Kind, SourceRef, SyntaxTree, NodeId,
-    makenode, makeleaf, setattr!,
-    is_leaf, numchildren, children,
+    setattr!, is_leaf, numchildren, children,
     @ast, flattened_provenance, showprov, LoweringError, MacroExpansionError,
     syntax_graph, Bindings, ScopeLayer, mapchildren
 
@@ -32,7 +31,7 @@ function _ast_test_graph()
 end
 
 function _source_node(graph, src)
-    id = newnode!(graph)
+    id = new_id!(graph)
     setattr!(graph, id, :kind, K"None")
     setattr!(graph, id, :source, src)
     SyntaxTree(graph, id)


### PR DESCRIPTION
This is cleanup separated from another change where I needed
to call these by hand without `@ast` to help me.

The only significant diff is in syntax_graph.jl, where I've addressed a TODO I
left earlier.  Instead of changing `makenode`/`makeleaf`'s behaviour based on
whether `proto` is a SyntaxTree or Kind (there isn't any situation where we
don't know this), split "new node with kind and provenance" functions
`newnode`/`newleaf` and "copy attributes and transform existing node" functions
`mknode`/`mkleaf`.  I will accept some function name bikeshedding if anyone has
suggestions.

Other tweaks:
- Remove the attribute-vector parameter since most of the arbitrary attribute
  stuff happens in `@ast`, where we just produce `setattr!` calls
- Tighten up some signatures, mostly for documentation purposes, and because
  these things are less up-in-the-air than when JL was a new project
