### PR TITLE
[JuliaLowering] fix `@nospecialize` on unnamed arguments

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2330,10 +2330,12 @@ function expand_function_arg(ctx, body_stmts, arg, is_last_arg, is_kw, arg_id)
         # Lowering should be able to use placeholder args as rvalues internally,
         # e.g. for kw method dispatch.  Duplicate positional placeholder names
         # should be allowed.
+        is_nospecialize = getmeta(ex, :nospecialize, false)
         name = if is_kw
             @ast ctx ex ex=>K"Identifier"
         else
-            new_local_binding(ctx, ex, "#arg$(string(arg_id))#"; kind=:argument)
+            new_local_binding(ctx, ex, "#arg$(string(arg_id))#"; kind=:argument,
+                              is_nospecialize=is_nospecialize)
         end
     elseif k == K"Identifier"
         name = ex

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -1065,7 +1065,8 @@ function compile_lambda(outer_ctx, ex)
     for arg in children(lambda_args)
         if kind(arg) == K"Placeholder"
             # Unused functions arguments like: `_` or `::T`
-            push!(slots, Slot(arg.name_val, :argument, false, false, false, false, false))
+            push!(slots, Slot(arg.name_val, :argument, getmeta(arg, :nospecialize, false),
+                              false, false, false, false))
         else
             @assert kind(arg) == K"BindingId"
             id = arg.var_id

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -325,6 +325,14 @@ end
     # flagged as nospecialize.
     @test only(methods(test_mod.f_nospecialize)).nospecialize == 0b10100
 
+    # @nospecialize on unnamed arguments (issue #44428)
+    JuliaLowering.include_string(test_mod, """
+    function f_nospecialize_unnamed(@nospecialize(::Any), @nospecialize(x::Any))
+        x
+    end
+    """)
+    @test only(methods(test_mod.f_nospecialize_unnamed)).nospecialize == 0b11
+
     JuliaLowering.include_string(test_mod, """
     function f_slotflags(x, y, f, z)
         f() + x + y


### PR DESCRIPTION
Propagate `is_nospecialize` metadata for Placeholder arguments in desugaring and linear_ir generation.

Separated from #60416.