### PR TITLE
Set `HAVE_SSP` and import `__stack_chk_guard` from libc on FreeBSD

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1566,6 +1566,7 @@ endif
 ifeq ($(OS), FreeBSD)
 JLDFLAGS += -Wl,-Bdynamic
 OSLIBS += -lelf -lkvm -lrt -lpthread -latomic
+HAVE_SSP := 1
 
 # Tweak order of libgcc_s in DT_NEEDED,
 # make it loaded first to

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -176,8 +176,8 @@ static inline void msan_unpoison_string(const volatile char *a) JL_NOTSAFEPOINT 
 #endif
 #endif
 
-#if defined(HAVE_SSP) && defined(_OS_DARWIN_)
-// On Darwin, this is provided by libSystem and imported
+#if defined(HAVE_SSP) && (defined(_OS_DARWIN_) || defined(_OS_FREEBSD_))
+// This is provided by libSystem on Darwin and libc on FreeBSD, and imported
 extern JL_DLLIMPORT uintptr_t __stack_chk_guard;
 #elif defined(HAVE_SSP)
 // Added by compiler runtime in final link - not DLLIMPORT


### PR DESCRIPTION
The stack canary symbol is defined in libc on FreeBSD, so we can import it there like we do on macOS. Also, set `HAVE_SSP` because we have SSP.