### PR TITLE
Don't set `Attribute::StackProtectStrong` when not using `CodeModel::Large`

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8722,7 +8722,9 @@ static jl_llvm_functions_t
     if (src->inlining == 2)
         FnAttrs.addAttribute(Attribute::NoInline);
 
-#ifdef JL_DEBUG_BUILD
+    // Add strong stack protection for debug builds only when using the large code model,
+    // otherwise LLVM might try to relocate the stack canary out of range (see e.g. #59303)
+#if defined(JL_DEBUG_BUILD) && !(defined(_CPU_AARCH64_) || defined(_CPU_RISCV_))
     FnAttrs.addAttribute(Attribute::StackProtectStrong);
 #endif
 


### PR DESCRIPTION
We're currently setting `Attribute::StackProtectStrong` for all debug builds, but that can run into issues like what was observed on FreeBSD AArch64 in #59303, where the stack canary gets relocated out of the range permitted by the (there, small) code model. To avoid this problem more generally, we can just not set the strong stack protection attribute for debug builds on platforms not using a large code model. An alternative would be to use the large code model on more platforms, but some combinations of architecture and code model are not well-maintained in LLVM, so this seems safer.

Fixes #59303