### PR TITLE
Improve contributor onboarding visibility in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ and installing Julia, below.
 We welcome contributions from developers of all experience levels, including bug fixes,
 documentation improvements, tests, and performance enhancements.
 
-New contributors are encouraged to start by reading:
-- CONTRIBUTING.md: https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md
+New contributors are encouraged to start by reading [CONTRIBUTING.md](https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md).
 
 
 ### Learning Julia

--- a/README.md
+++ b/README.md
@@ -62,19 +62,10 @@ documentation improvements, tests, and performance enhancements.
 New contributors are encouraged to start by reading:
 - CONTRIBUTING.md: https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md
 
-To find suitable issues:
-- Browse GitHub issues: https://github.com/JuliaLang/julia/issues
-- Look for labels such as `good first issue`, `docs`, or `help wanted`
-
-For questions and discussion:
-- Discourse: https://discourse.julialang.org
-- Zulip: https://julialang.zulipchat.com
-
 
 ### Learning Julia
 
 - [**Learning resources**](https://julialang.org/learning/)
-
 
 ## Binary Installation
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,28 @@ and installing Julia, below.
 - **YouTube:** <https://www.youtube.com/user/JuliaLanguage>
 - **Code coverage:** <https://coveralls.io/r/JuliaLang/julia>
 
-New developers may find the notes in
-[CONTRIBUTING](https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md)
-helpful to start contributing to the Julia codebase.
+
+## Contributing to Julia
+
+We welcome contributions from developers of all experience levels, including bug fixes,
+documentation improvements, tests, and performance enhancements.
+
+New contributors are encouraged to start by reading:
+- CONTRIBUTING.md: https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md
+
+To find suitable issues:
+- Browse GitHub issues: https://github.com/JuliaLang/julia/issues
+- Look for labels such as `good first issue`, `docs`, or `help wanted`
+
+For questions and discussion:
+- Discourse: https://discourse.julialang.org
+- Zulip: https://julialang.zulipchat.com
+
 
 ### Learning Julia
 
 - [**Learning resources**](https://julialang.org/learning/)
+
 
 ## Binary Installation
 


### PR DESCRIPTION
The README already references CONTRIBUTING.md, but the entry point for new contributors
is easy to miss. This PR adds a small, dedicated “Contributing” section to improve
discoverability, without duplicating existing documentation or changing contribution rules.
