### PR TITLE
Fix JET warning in `_spawn_primitive`

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -140,15 +140,14 @@ end
         if err == 0
             pp = Process(cmd, handle, syncd)
             associate_julia_struct(handle, pp)
+            iolock_end()
+            return pp
         else
             ccall(:jl_forceclose_uv, Cvoid, (Ptr{Cvoid},), handle) # will call free on handle eventually
+            iolock_end()
+            throw(_UVError("could not spawn " * repr(cmd), err))
         end
-        iolock_end()
     end
-    if err != 0
-        throw(_UVError("could not spawn " * repr(cmd), err))
-    end
-    return pp
 end
 
 _spawn(cmds::AbstractCmd) = _spawn(cmds, SpawnIOs())


### PR DESCRIPTION
In various packages I am JETing, I see the same error being reported:

> local variable `pp` may be undefined: pp::Base.Process

This patch helps JET proof that there is no actual problem.


Would be kinda nice to see this backported to 1.12 so that if I run JET with 1.12.4 this is not reported anymore. And of course also to 1.13.