### PR TITLE
Partially revert #59877 (Windows profile timeout)

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -271,9 +271,6 @@ extern uv_mutex_t bt_data_prof_lock;
 #define PROFILE_STATE_THREAD_SLEEPING (2)
 #define PROFILE_STATE_WALL_TIME_PROFILING (3)
 void jl_profile_task(void);
-#if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
-JL_DLLEXPORT void jl_set_profile_abort_ptr(_Atomic(int) *abort_ptr) JL_NOTSAFEPOINT;
-#endif
 
 // number of cycles since power-on
 static inline uint64_t cycleclock(void) JL_NOTSAFEPOINT

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -548,14 +548,6 @@ void jl_fin_stackwalk(void)
     }
 }
 
-// Set the abort_profile_ptr in TLS
-#ifdef _CPU_X86_64_
-JL_DLLEXPORT void jl_set_profile_abort_ptr(_Atomic(int) *abort_ptr) JL_NOTSAFEPOINT
-{
-    abort_profile_ptr = abort_ptr;
-}
-#endif
-
 static int jl_unw_init(bt_cursor_t *cursor, bt_context_t *Context)
 {
     int result;


### PR DESCRIPTION
The Profile test is failing again on Windows x86_64 (#60306), but we have not seen Windows i686 failures since soon after #59877 (8e7ed1d5f06e7807681f696252b2b432c58690ce), suggesting we should try reverting the x86_64-specific profile timeout.