### PR TITLE
Print `full_name` after precompiling extension

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -1253,7 +1253,7 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
         if !quick_exit
             logstr = sprint(context=logio) do iostr
                 if fancyprint # replace the progress bar
-                    what = isempty(requested_pkgids) ? "packages finished." : "$(join((p.name for p in requested_pkgids), ", ", " and ")) finished."
+                    what = isempty(requested_pkgids) ? "packages finished." : "$(join((full_name(ext_to_parent, p) for p in requested_pkgids), ", ", " and ")) finished."
                     printpkgstyle(iostr, :Precompiling, what)
                 end
                 plural = length(configs) > 1 ? "dependency configurations" : ndeps == 1 ? "dependency" : "dependencies"

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -933,7 +933,7 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
                     if occursin("Waiting for background task / IO / timer", str)
                         thistaskwaiting = true
                         !liveprinting && !fancyprint && @lock print_lock begin
-                            println(io, pkg.name, color_string(str, Base.warn_color()))
+                            println(io, full_name(ext_to_parent, pkg), color_string(str, Base.warn_color()))
                         end
                         push!(taskwaiting, pkg_config)
                     end
@@ -1326,7 +1326,7 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
         err_str = IOBuffer()
         for ((dep, config), err) in failed_deps
             write(err_str, "\n")
-            print(err_str, "\n", dep.name, " ")
+            print(err_str, "\n", full_name(ext_to_parent, dep), " ")
             join(err_str, config[1], " ")
             print(err_str, "\n", err)
         end


### PR DESCRIPTION
This PR fixes #60047 to print the full package name `ParentPkg → ExtensionName` instead of only the `ExtensionName` to match what the [docs](https://pkgdocs.julialang.org/v1/creating-packages/#Conditional-loading-of-code-in-packages-(Extensions)) say:

> In Pkg output, extension names are always shown together with their parent package name.

 I have looked for more possible locations, which should print the `full_name` and found the possible candidates:

https://github.com/JuliaLang/julia/blob/db0ee4186ee252950a95fdb679bfdc457665844d/base/precompilation.jl#L936

https://github.com/JuliaLang/julia/blob/db0ee4186ee252950a95fdb679bfdc457665844d/base/precompilation.jl#L1329

https://github.com/JuliaLang/julia/blob/db0ee4186ee252950a95fdb679bfdc457665844d/base/precompilation.jl#L1380

For these locations, I'm not entirely sure though whether they should print the full name.

Since this is my first PR to julia itself, I would be grateful for any guidance on anything I might have missed.

Fixes https://github.com/JuliaLang/julia/issues/60047