### PR TITLE
Fix JET warning in `TOML.parse_array`

### DIFF
--- a/base/toml_parser.jl
+++ b/base/toml_parser.jl
@@ -716,8 +716,8 @@ function parse_array(l::Parser{Dates})::Err{Vector} where Dates
         copyto_typed!(new, array)
     elseif T === Union{}
         new = Any[]
-    elseif (T === TOMLDict) || (T == BigInt) || (T === UInt128) || (T === Int128) || (T <: Vector) ||
-        (T === Dates.Date) || (T === Dates.Time) || (T === Dates.DateTime)
+    elseif (T === TOMLDict) || (T === BigInt) || (T === UInt128) || (T === Int128) || (T <: Vector) ||
+        (Dates !== nothing && ((T === Dates.Date) || (T === Dates.Time) || (T === Dates.DateTime)))
         # do nothing, leave as Vector{Any}
         new = array
     else @assert false end


### PR DESCRIPTION
As a bonus, also change `T == BigInt` to `T === BigInt`.

Fixes this:
```
│┌ load_artifacts_toml(artifacts_toml::String) @ Artifacts /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-release-1-dot-12/usr/share/julia/stdlib/v1.12/Artifacts/src/Artifacts.jl:315
││┌ load_artifacts_toml(artifacts_toml::String; pkg_uuid::Nothing) @ Artifacts /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-release-1-dot-12/usr/share/julia/stdlib/v1.12/Artifacts/src/Artifacts.jl:317
│││┌ parse_toml(path::String) @ Artifacts /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-release-1-dot-12/usr/share/julia/stdlib/v1.12/Artifacts/src/Artifacts.jl:26
││││┌ parsed_toml(project_file::String) @ Base ./loading.jl:276
│││││┌ parsed_toml(project_file::String, toml_cache::Base.TOMLCache{nothing}, toml_lock::ReentrantLock) @ Base ./loading.jl:278
││││││┌ lock(f::Base.var"#parsed_toml##0#parsed_toml##1"{String, Base.TOMLCache{nothing}}, l::ReentrantLock) @ Base ./lock.jl:335
│││││││┌ (::Base.var"#parsed_toml##0#parsed_toml##1"{String, Base.TOMLCache{nothing}})() @ Base ./loading.jl:281
││││││││┌ Base.CachedTOMLDict(p::Base.TOML.Parser{nothing}, path::String) @ Base ./loading.jl:222
│││││││││┌ parse(l::Base.TOML.Parser{nothing}) @ Base.TOML ./toml_parser.jl:444
││││││││││┌ tryparse(l::Base.TOML.Parser{nothing}) @ Base.TOML ./toml_parser.jl:453
│││││││││││┌ parse_toplevel(l::Base.TOML.Parser{nothing}) @ Base.TOML ./toml_parser.jl:157
││││││││││││┌ parse_array(l::Base.TOML.Parser{nothing}) @ Base.TOML ./toml_parser.jl:719
│││││││││││││┌ getproperty(x::Nothing, f::Symbol) @ Base ./Base_compiler.jl:54
││││││││││││││ invalid builtin function call: getfield(x::Nothing, f::Symbol)
│││││││││││││└────────────────────
```