### PR TITLE
Fix JET warning in Base.sendfile

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -1267,22 +1267,19 @@ function rename(oldpath::AbstractString, newpath::AbstractString)
 end
 
 function sendfile(src::AbstractString, dst::AbstractString)
-    src_open = false
-    dst_open = false
-    local src_file, dst_file
+    src_file = nothing
+    dst_file = nothing
     try
         src_file = open(src, JL_O_RDONLY)
-        src_open = true
         dst_file = open(dst, JL_O_CREAT | JL_O_TRUNC | JL_O_WRONLY, filemode(src_file))
-        dst_open = true
 
         bytes = filesize(stat(src_file))
         sendfile(dst_file, src_file, Int64(0), Int(bytes))
     finally
-        if src_open && isopen(src_file)
+        if src_file !== nothing && isopen(src_file)
             close(src_file)
         end
-        if dst_open && isopen(dst_file)
+        if dst_file !== nothing && isopen(dst_file)
             close(dst_file)
         end
     end


### PR DESCRIPTION
Help JET (and humans?) understand that src_file and dst_file won't be used without being defined.

Fixes this JET report:
```
│┌ cp(src::AbstractString, dst::String) @ Base.Filesystem ./file.jl:404
││┌ cp(src::AbstractString, dst::String; force::Bool, follow_symlinks::Bool) @ Base.Filesystem ./file.jl:410
│││┌ kwcall(::@NamedTuple{force::Bool, follow_symlinks::Bool}, ::typeof(Base.Filesystem.cptree), src::String, dst::String) @ Base.Filesystem ./file.jl:366
││││┌ cptree(src::String, dst::String; force::Bool, follow_symlinks::Bool) @ Base.Filesystem ./file.jl:379
│││││┌ sendfile(src::String, dst::String) @ Base.Filesystem ./file.jl:1282
││││││ local variable `src_file` may be undefined: src_file::Base.Filesystem.File
│││││└────────────────────
│││││┌ sendfile(src::String, dst::String) @ Base.Filesystem ./file.jl:1283
││││││ local variable `src_file` may be undefined: src_file::Base.Filesystem.File
│││││└────────────────────
│││││┌ sendfile(src::String, dst::String) @ Base.Filesystem ./file.jl:1285
││││││ local variable `dst_file` may be undefined: dst_file::Base.Filesystem.File
│││││└────────────────────
│││││┌ sendfile(src::String, dst::String) @ Base.Filesystem ./file.jl:1286
││││││ local variable `dst_file` may be undefined: dst_file::Base.Filesystem.File
│││││└────────────────────
```