### PR TITLE
use `_string_n` instead of `StringMemory` to reduce allocations for a few `string` calls

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -875,7 +875,7 @@ function bin(x::Unsigned, pad::Int, neg::Bool)
     GC.@preserve str begin
         p = pointer(str)
         i = n
-        @inbounds while i >= 4
+        while i >= 4
             b = UInt32((x % UInt8)::UInt8)
             d = 0x30303030 + ((b * 0x08040201) >> 0x3) & 0x01010101
             unsafe_store!(p, (d >> 0x00) % UInt8, i-3)
@@ -886,7 +886,7 @@ function bin(x::Unsigned, pad::Int, neg::Bool)
             i -= 4
         end
         while i > neg
-            @inbounds unsafe_store!(p, 0x30 + ((x % UInt8)::UInt8 & 0x1), i)
+            unsafe_store!(p, 0x30 + ((x % UInt8)::UInt8 & 0x1), i)
             x >>= 0x1
             i -= 1
         end
@@ -903,7 +903,7 @@ function oct(x::Unsigned, pad::Int, neg::Bool)
         p = pointer(str)
         i = n
         while i > neg
-            @inbounds unsafe_store!(p, 0x30 + ((x % UInt8)::UInt8 & 0x7), i)
+            unsafe_store!(p, 0x30 + ((x % UInt8)::UInt8 & 0x7), i)
             x >>= 0x3
             i -= 1
         end
@@ -1021,14 +1021,14 @@ function hex(x::Unsigned, pad::Int, neg::Bool)
         while i >= 2
             b = (x % UInt8)::UInt8
             d1, d2 = b >> 0x4, b & 0xf
-            @inbounds unsafe_store!(p, d1 + ifelse(d1 > 0x9, 0x57, 0x30), i-1)
-            @inbounds unsafe_store!(p, d2 + ifelse(d2 > 0x9, 0x57, 0x30), i)
+            unsafe_store!(p, d1 + ifelse(d1 > 0x9, 0x57, 0x30), i-1)
+            unsafe_store!(p, d2 + ifelse(d2 > 0x9, 0x57, 0x30), i)
             x >>= 0x8
             i -= 2
         end
         if i > neg
             d = (x % UInt8)::UInt8 & 0xf
-            @inbounds unsafe_store!(p, d + ifelse(d > 0x9, 0x57, 0x30), i)
+            unsafe_store!(p, d + ifelse(d > 0x9, 0x57, 0x30), i)
         end
         neg && unsafe_store!(p, 0x2d, 1) # UInt8('-')
     end
@@ -1137,7 +1137,7 @@ function bitstring(x::T) where {T}
     GC.@preserve str begin
         p = pointer(str)
         i = sz
-        @inbounds while i >= 4
+        while i >= 4
             b = UInt32(sizeof(T) == 1 ? bitcast(UInt8, x) : trunc_int(UInt8, x))
             d = 0x30303030 + ((b * 0x08040201) >> 0x3) & 0x01010101
             unsafe_store!(p, (d >> 0x00) % UInt8, i-3)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -871,42 +871,45 @@ ndigits(x::Integer; base::Integer=10, pad::Integer=1) = max(pad, ndigits0z(x, ba
 function bin(x::Unsigned, pad::Int, neg::Bool)
     m = top_set_bit(x)
     n = neg + max(pad, m)
-    a = StringMemory(n)
-    # for i in 0x0:UInt(n-1) # automatic vectorization produces redundant codes
-    #     @inbounds a[n - i] = 0x30 + (((x >> i) % UInt8)::UInt8 & 0x1)
-    # end
-    i = n
-    @inbounds while i >= 4
-        b = UInt32((x % UInt8)::UInt8)
-        d = 0x30303030 + ((b * 0x08040201) >> 0x3) & 0x01010101
-        a[i-3] = (d >> 0x00) % UInt8
-        a[i-2] = (d >> 0x08) % UInt8
-        a[i-1] = (d >> 0x10) % UInt8
-        a[i]   = (d >> 0x18) % UInt8
-        x >>= 0x4
-        i -= 4
+    str = _string_n(n)
+    GC.@preserve str begin
+        p = pointer(str)
+        i = n
+        @inbounds while i >= 4
+            b = UInt32((x % UInt8)::UInt8)
+            d = 0x30303030 + ((b * 0x08040201) >> 0x3) & 0x01010101
+            unsafe_store!(p, (d >> 0x00) % UInt8, i-3)
+            unsafe_store!(p, (d >> 0x08) % UInt8, i-2)
+            unsafe_store!(p, (d >> 0x10) % UInt8, i-1)
+            unsafe_store!(p, (d >> 0x18) % UInt8, i)
+            x >>= 0x4
+            i -= 4
+        end
+        while i > neg
+            @inbounds unsafe_store!(p, 0x30 + ((x % UInt8)::UInt8 & 0x1), i)
+            x >>= 0x1
+            i -= 1
+        end
+        neg && unsafe_store!(p, 0x2d, 1) # UInt8('-')
     end
-    while i > neg
-        @inbounds a[i] = 0x30 + ((x % UInt8)::UInt8 & 0x1)
-        x >>= 0x1
-        i -= 1
-    end
-    neg && (@inbounds a[1] = 0x2d) # UInt8('-')
-    unsafe_takestring(a)
+    return str
 end
 
 function oct(x::Unsigned, pad::Int, neg::Bool)
     m = div(top_set_bit(x) + 2, 3)
     n = neg + max(pad, m)
-    a = StringMemory(n)
-    i = n
-    while i > neg
-        @inbounds a[i] = 0x30 + ((x % UInt8)::UInt8 & 0x7)
-        x >>= 0x3
-        i -= 1
+    str = _string_n(n)
+    GC.@preserve str begin
+        p = pointer(str)
+        i = n
+        while i > neg
+            @inbounds unsafe_store!(p, 0x30 + ((x % UInt8)::UInt8 & 0x7), i)
+            x >>= 0x3
+            i -= 1
+        end
+        neg && unsafe_store!(p, 0x2d, 1) # UInt8('-')
     end
-    neg && (@inbounds a[1] = 0x2d) # UInt8('-')
-    unsafe_takestring(a)
+    return str
 end
 
 # 2-digit decimal characters ("00":"99")
@@ -973,31 +976,63 @@ end
 
 function dec(x::Unsigned, pad::Int, neg::Bool)
     n = neg + ndigits(x, pad=pad)
-    a = StringMemory(n)
-    append_c_digits_fast(n, x, a, 1)
-    neg && (@inbounds a[1] = 0x2d) # UInt8('-')
-    unsafe_takestring(a)
+    str = _string_n(n)
+    GC.@preserve str begin
+        p = pointer(str)
+        i = n
+        @inbounds while i > 9 && x > typemax(UInt)
+            d, r = divrem(x, 0x3b9aca00) # 10^9
+            x = oftype(x, d)
+            r32 = r % UInt32
+            for j in 0:3
+                q, s = divrem(r32, 0x64)
+                r32 = q
+                v = _dec_d100[1 + (s % Int)]
+                unsafe_store!(p, (v >> 8) % UInt8, i - 2*j)
+                unsafe_store!(p, v % UInt8, i - 2*j - 1)
+            end
+            unsafe_store!(p, 0x30 + (r32 % UInt8), i - 8)
+            i -= 9
+        end
+        y = x % UInt
+        @inbounds while i >= 2
+            d, r = divrem(y, 0x64)
+            y = d
+            v = _dec_d100[1 + (r % Int)]
+            unsafe_store!(p, (v >> 8) % UInt8, i)
+            unsafe_store!(p, v % UInt8, i - 1)
+            i -= 2
+        end
+        if i > neg
+            unsafe_store!(p, 0x30 + (rem(y, 0xa) % UInt8), i)
+        end
+        neg && unsafe_store!(p, 0x2d, 1) # '-'
+    end
+    return str
 end
 
 function hex(x::Unsigned, pad::Int, neg::Bool)
     m = 2 * sizeof(x) - (leading_zeros(x) >> 2)
     n = neg + max(pad, m)
-    a = StringMemory(n)
-    i = n
-    while i >= 2
-        b = (x % UInt8)::UInt8
-        d1, d2 = b >> 0x4, b & 0xf
-        @inbounds a[i-1] = d1 + ifelse(d1 > 0x9, 0x57, 0x30)
-        @inbounds a[i]   = d2 + ifelse(d2 > 0x9, 0x57, 0x30)
-        x >>= 0x8
-        i -= 2
+    str = _string_n(n)
+    GC.@preserve str begin
+        p = pointer(str)
+        i = n
+        while i >= 2
+            b = (x % UInt8)::UInt8
+            d1, d2 = b >> 0x4, b & 0xf
+            @inbounds unsafe_store!(p, d1 + ifelse(d1 > 0x9, 0x57, 0x30), i-1)
+            @inbounds unsafe_store!(p, d2 + ifelse(d2 > 0x9, 0x57, 0x30), i)
+            x >>= 0x8
+            i -= 2
+        end
+        if i > neg
+            d = (x % UInt8)::UInt8 & 0xf
+            @inbounds unsafe_store!(p, d + ifelse(d > 0x9, 0x57, 0x30), i)
+        end
+        neg && unsafe_store!(p, 0x2d, 1) # UInt8('-')
     end
-    if i > neg
-        d = (x % UInt8)::UInt8 & 0xf
-        @inbounds a[i] = d + ifelse(d > 0x9, 0x57, 0x30)
-    end
-    neg && (@inbounds a[1] = 0x2d) # UInt8('-')
-    unsafe_takestring(a)
+    return str
 end
 
 const base36digits = UInt8['0':'9';'a':'z']
@@ -1009,20 +1044,23 @@ function _base(base::Integer, x::Integer, pad::Int, neg::Bool)
     b = (base % Int)::Int
     digits = abs(b) <= 36 ? base36digits : base62digits
     n = neg + ndigits(x, base=b, pad=pad)
-    a = StringMemory(n)
-    i = n
-    @inbounds while i > neg
-        if b > 0
-            a[i] = digits[1 + (rem(x, b) % Int)::Int]
-            x = div(x,b)
-        else
-            a[i] = digits[1 + (mod(x, -b) % Int)::Int]
-            x = cld(x,b)
+    str = _string_n(n)
+    GC.@preserve str begin
+        p = pointer(str)
+        i = n
+        @inbounds while i > neg
+            if b > 0
+                unsafe_store!(p, digits[1 + (rem(x, b) % Int)::Int], i)
+                x = div(x,b)
+            else
+                unsafe_store!(p, digits[1 + (mod(x, -b) % Int)::Int], i)
+                x = cld(x,b)
+            end
+            i -= 1
         end
-        i -= 1
+        neg && unsafe_store!(p, 0x2d, 1) # UInt8('-')
     end
-    neg && (@inbounds a[1] = 0x2d) # UInt8('-')
-    unsafe_takestring(a)
+    return str
 end
 
 split_sign(n::Integer) = unsigned(abs(n)), n < 0
@@ -1095,19 +1133,22 @@ julia> bitstring(2.2)
 function bitstring(x::T) where {T}
     isprimitivetype(T) || throw(ArgumentError(LazyString(T, " not a primitive type")))
     sz = sizeof(T) * 8
-    str = StringMemory(sz)
-    i = sz
-    @inbounds while i >= 4
-        b = UInt32(sizeof(T) == 1 ? bitcast(UInt8, x) : trunc_int(UInt8, x))
-        d = 0x30303030 + ((b * 0x08040201) >> 0x3) & 0x01010101
-        str[i-3] = (d >> 0x00) % UInt8
-        str[i-2] = (d >> 0x08) % UInt8
-        str[i-1] = (d >> 0x10) % UInt8
-        str[i]   = (d >> 0x18) % UInt8
-        x = lshr_int(x, 4)
-        i -= 4
+    str = _string_n(sz)
+    GC.@preserve str begin
+        p = pointer(str)
+        i = sz
+        @inbounds while i >= 4
+            b = UInt32(sizeof(T) == 1 ? bitcast(UInt8, x) : trunc_int(UInt8, x))
+            d = 0x30303030 + ((b * 0x08040201) >> 0x3) & 0x01010101
+            unsafe_store!(p, (d >> 0x00) % UInt8, i-3)
+            unsafe_store!(p, (d >> 0x08) % UInt8, i-2)
+            unsafe_store!(p, (d >> 0x10) % UInt8, i-1)
+            unsafe_store!(p, (d >> 0x18) % UInt8, i)
+            x = lshr_int(x, 4)
+            i -= 4
+        end
     end
-    return unsafe_takestring(str)
+    return str
 end
 
 """

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -980,14 +980,14 @@ function dec(x::Unsigned, pad::Int, neg::Bool)
     GC.@preserve str begin
         p = pointer(str)
         i = n
-        @inbounds while i > 9 && x > typemax(UInt)
+        while i > 9 && x > typemax(UInt)
             d, r = divrem(x, 0x3b9aca00) # 10^9
             x = oftype(x, d)
             r32 = r % UInt32
             for j in 0:3
                 q, s = divrem(r32, 0x64)
                 r32 = q
-                v = _dec_d100[1 + (s % Int)]
+                v = @inbounds _dec_d100[1 + (s % Int)]
                 unsafe_store!(p, (v >> 8) % UInt8, i - 2*j)
                 unsafe_store!(p, v % UInt8, i - 2*j - 1)
             end
@@ -995,10 +995,10 @@ function dec(x::Unsigned, pad::Int, neg::Bool)
             i -= 9
         end
         y = x % UInt
-        @inbounds while i >= 2
+        while i >= 2
             d, r = divrem(y, 0x64)
             y = d
-            v = _dec_d100[1 + (r % Int)]
+            v = @inbounds _dec_d100[1 + (r % Int)]
             unsafe_store!(p, (v >> 8) % UInt8, i)
             unsafe_store!(p, v % UInt8, i - 1)
             i -= 2
@@ -1048,12 +1048,12 @@ function _base(base::Integer, x::Integer, pad::Int, neg::Bool)
     GC.@preserve str begin
         p = pointer(str)
         i = n
-        @inbounds while i > neg
+        while i > neg
             if b > 0
-                unsafe_store!(p, digits[1 + (rem(x, b) % Int)::Int], i)
+                unsafe_store!(p, @inbounds(digits[1 + (rem(x, b) % Int)::Int]), i)
                 x = div(x,b)
             else
-                unsafe_store!(p, digits[1 + (mod(x, -b) % Int)::Int], i)
+                unsafe_store!(p, @inbounds(digits[1 + (mod(x, -b) % Int)::Int]), i)
                 x = cld(x,b)
             end
             i -= 1

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -1278,12 +1278,15 @@ function bytes2hex end
 
 function bytes2hex(itr)
     eltype(itr) === UInt8 || throw(ArgumentError("eltype of iterator not UInt8"))
-    b = Base.StringMemory(2*length(itr))
-    @inbounds for (i, x) in enumerate(itr)
-        b[2i - 1] = hex_chars[1 + x >> 4]
-        b[2i    ] = hex_chars[1 + x & 0xf]
+    str = Base._string_n(2*length(itr))
+    GC.@preserve str begin
+        p = pointer(str)
+        @inbounds for (i, x) in enumerate(itr)
+            unsafe_store!(p, hex_chars[1 + x >> 4], 2i - 1)
+            unsafe_store!(p, hex_chars[1 + x & 0xf], 2i)
+        end
     end
-    return unsafe_takestring(b)
+    return str
 end
 
 function bytes2hex(io::IO, itr)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -1281,9 +1281,9 @@ function bytes2hex(itr)
     str = Base._string_n(2*length(itr))
     GC.@preserve str begin
         p = pointer(str)
-        @inbounds for (i, x) in enumerate(itr)
-            unsafe_store!(p, hex_chars[1 + x >> 4], 2i - 1)
-            unsafe_store!(p, hex_chars[1 + x & 0xf], 2i)
+        for (i, x) in enumerate(itr)
+            unsafe_store!(p, @inbounds(hex_chars[1 + x >> 4]), 2i - 1)
+            unsafe_store!(p, @inbounds(hex_chars[1 + x & 0xf]), 2i)
         end
     end
     return str

--- a/base/uuid.jl
+++ b/base/uuid.jl
@@ -92,13 +92,19 @@ let groupings = [36:-1:25; 23:-1:20; 18:-1:15; 13:-1:10; 8:-1:1]
     global string
     function string(u::UUID)
         u = u.value
-        a = Base.StringMemory(36)
-        for i in groupings
-            @inbounds a[i] = hex_chars[1 + u & 0xf]
-            u >>= 4
+        str = Base._string_n(36)
+        GC.@preserve str begin
+            p = pointer(str)
+            for i in groupings
+                @inbounds unsafe_store!(p, hex_chars[1 + u & 0xf], i)
+                u >>= 4
+            end
+            @inbounds unsafe_store!(p, UInt8('-'), 9)
+            @inbounds unsafe_store!(p, UInt8('-'), 14)
+            @inbounds unsafe_store!(p, UInt8('-'), 19)
+            @inbounds unsafe_store!(p, UInt8('-'), 24)
         end
-        @inbounds a[24] = a[19] = a[14] = a[9] = '-'
-        return unsafe_takestring(a)
+        return str
     end
 end
 

--- a/base/uuid.jl
+++ b/base/uuid.jl
@@ -96,7 +96,7 @@ let groupings = [36:-1:25; 23:-1:20; 18:-1:15; 13:-1:10; 8:-1:1]
         GC.@preserve str begin
             p = pointer(str)
             for i in groupings
-                @inbounds unsafe_store!(p, hex_chars[1 + u & 0xf], i)
+                unsafe_store!(p, @inbounds(hex_chars[1 + u & 0xf]), i)
                 u >>= 4
             end
             unsafe_store!(p, UInt8('-'), 9)

--- a/base/uuid.jl
+++ b/base/uuid.jl
@@ -99,10 +99,10 @@ let groupings = [36:-1:25; 23:-1:20; 18:-1:15; 13:-1:10; 8:-1:1]
                 @inbounds unsafe_store!(p, hex_chars[1 + u & 0xf], i)
                 u >>= 4
             end
-            @inbounds unsafe_store!(p, UInt8('-'), 9)
-            @inbounds unsafe_store!(p, UInt8('-'), 14)
-            @inbounds unsafe_store!(p, UInt8('-'), 19)
-            @inbounds unsafe_store!(p, UInt8('-'), 24)
+            unsafe_store!(p, UInt8('-'), 9)
+            unsafe_store!(p, UInt8('-'), 14)
+            unsafe_store!(p, UInt8('-'), 19)
+            unsafe_store!(p, UInt8('-'), 24)
         end
         return str
     end


### PR DESCRIPTION
I might be missing something about legality, but as long as it's safe this seems like a clear performance win.

before
```
using BenchmarkTools                                        # min    / median / mean
@benchmark string(u) setup=u=Base.UUID(rand(UInt128))       # 37.5ns / 37.8ns / 42.7ns (2 allocs: 96 bytes)
@benchmark string($(big(123)^456))                          # 3.75μs / 3.84μs / 4.00μs (9 allocs: 3.93 KiB)
@benchmark bytes2hex(b) setup=b=rand(UInt8, 64)             # 60.5ns / 61.9ns / 70.7ns (2 allocs: 192 bytes)


@benchmark string(x) setup=x=rand(Int)                      # 30.9ns / 32.4ns / 38.0ns (2 allocs: 80 bytes)
@benchmark string(x; base=2) setup=x=rand(Int)              # 30.0ns / 32.5ns / 38.9ns (2 allocs: 112 bytes)
@benchmark string(x; base=8) setup=x=rand(Int)              # 28.4ns / 30.5ns / 35.6ns (2 allocs: 80 bytes)
@benchmark string(x; base=10) setup=x=rand(Int)             # 30.4ns / 32.4ns / 37.5ns (2 allocs: 64 bytes)
@benchmark string(x; base=16) setup=x=rand(Int)             # 26.6ns / 28.9ns / 34.0ns (2 allocs: 64 bytes)
@benchmark string(x; base=20) setup=x=rand(Int)             # 38.3ns / 46.0ns / 50.1ns (2 allocs: 64 bytes)
```


after
```
@benchmark string(u) setup=u=Base.UUID(rand(UInt128))       # 26.4ns / 27.4ns / 30.9ns (1 alloc: 64 bytes)
@benchmark string($(big(123)^456))                          # 3.81μs / 3.91μs / 4.06μs (8 allocs: 3.90 KiB)
@benchmark bytes2hex(b) setup=b=rand(UInt8, 64)             # 48.6ns / 49.5ns / 55.5ns (1 alloc: 160 bytes)


@benchmark string(x) setup=x=rand(Int)                      # 18.9ns / 22.2ns / 24.3ns (1 alloc: 48 bytes)
@benchmark string(x; base=2) setup=x=rand(Int)              # 18.4ns / 23.4ns / 26.5ns (1 alloc: 80 bytes)
@benchmark string(x; base=8) setup=x=rand(Int)              # 18.3ns / 21.8ns / 23.3ns (1 alloc: 48 bytes)
@benchmark string(x; base=10) setup=x=rand(Int)             # 18.6ns / 22.2ns / 24.3ns (1 alloc: 32 bytes)
@benchmark string(x; base=16) setup=x=rand(Int)             # 16.4ns / 20.0ns / 21.4ns (1 alloc: 32 bytes)
@benchmark string(x; base=20) setup=x=rand(Int)             # 28.9ns / 36.1ns / 38.8ns (1 alloc: 32 bytes)
```

🤖Gemini originally noticed & suggested the change, and helped inline `append_c_digits_fast` to the new `dec`. the rest is just pattern matching