### PR TITLE
fix broken `annotate!` for `AnnotatedChar`

### DIFF
--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -367,8 +367,8 @@ annotate!(s::SubString{<:AnnotatedString}, label::Symbol, @nospecialize(val::Any
 
 Annotate `char` with the labeled value `(label, value)`.
 """
-annotate!(c::AnnotatedChar, label::Symbol, @nospecialize(val::Any)) =
-    (push!(c.annotations, Annotation((; label, val))); c)
+annotate!(c::AnnotatedChar, label::Symbol, @nospecialize(value::Any)) =
+    (push!(c.annotations, Annotation((; label, value))); c)
 
 """
     annotations(str::Union{AnnotatedString, SubString{AnnotatedString}},

--- a/test/strings/annotated.jl
+++ b/test/strings/annotated.jl
@@ -93,6 +93,9 @@ end
     @test str[1] == Base.AnnotatedChar('h', [(:attr, "h0h0")])
     @test str[2] == Base.AnnotatedChar('m', [(:attr, "h0m1"), (:attr, "m1m2")])
     @test str[3] == Base.AnnotatedChar('m', [(:attr, "m1m2")])
+    chr = Base.annotate!(Base.AnnotatedChar('m'), :attr, "h0m1")
+    @test chr == Base.AnnotatedChar('m', [(:attr, "h0m1")])
+    @test Base.annotate!(chr, :attr, "m1m2") == Base.AnnotatedChar('m', [(:attr, "h0m1"), (:attr, "m1m2")])
 end
 
 @testset "Styling preservation" begin


### PR DESCRIPTION
The function `annotate!` has been broken for `AnnotatedChar`, at least since the inclusion StyledStrings.jl into Julia 1.11:
```
julia> using StyledStrings; annotate!(AnnotatedChar('x'), :face, :red)
ERROR: FieldError: type NamedTuple has no field `value`, available fields: `label`, `val`
Stacktrace:
 [1] macro expansion
   @ ./namedtuple.jl:129 [inlined]
 [2] @NamedTuple{label::Symbol, value}(nt::@NamedTuple{label::Symbol, val::Symbol})
   @ Base ./namedtuple.jl:124
 [3] annotate!(c::AnnotatedChar{Char}, label::Symbol, val::Any)
   @ Base ./strings/annotated.jl:370
 [4] top-level scope
   @ REPL[1]:1
```
This PR fixed this:
```
julia> using StyledStrings; annotate!(AnnotatedChar('x'), :face, :red)
'x': ASCII/Unicode U+0078 (category Ll: Letter, lowercase)
```
(The red color is shown in the REPL.)

Side remark: Given that no-one can use this function at present, I wonder if one should reconsider the choice of arguments. Even if the annotations do not form a dictionary, I would see some benefit in writing
```
annotate!(c, label => value)
```
An extension to more than one annotation
```
annotate!(c, label1 => value1, label2 => value2)
```
would then be more natural.