### PR TITLE
[release-1.11] Fix KeyError in require_stdlib for non-stdlib extensions 

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2694,6 +2694,7 @@ function require_stdlib(package_uuidkey::PkgId, ext::Union{Nothing, String}, fro
         return newm
     end
     env = Sys.STDLIB
+    loading_started = false
     try
         depot_path = append_bundled_depot_path!(empty(DEPOT_PATH))
         from_stdlib = true # set to false if `from` is a normal package so we do not want the internal loader for the extension either
@@ -2718,10 +2719,11 @@ function require_stdlib(package_uuidkey::PkgId, ext::Union{Nothing, String}, fro
             set_pkgorigin_version_path(this_uuidkey, sourcepath)
             newm = start_loading(this_uuidkey, UInt128(0), true)
             newm === nothing || return newm
+            loading_started = true
             newm = _require_search_from_serialized(this_uuidkey, sourcepath, UInt128(0), false; DEPOT_PATH=depot_path)
         end
     finally
-        end_loading(this_uuidkey, newm)
+        loading_started && end_loading(this_uuidkey, newm)
     end
     if newm isa Module
         # After successfully loading, notify downstream consumers

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1654,7 +1654,7 @@ end
         # This should not throw a KeyError from end_loading
         Base.require_stdlib(Pkg_pkgid, "REPLExt", FakeREPL)
         # Verify the extension was loaded
-        Base.maybe_root_module(REPLExt_pkgid) isa Module || error("Issue #60392 has returned!")
+        Base.maybe_root_module(REPLExt_pkgid) isa Module || error("Something is wrong")
     '`
     @test success(cmd)
 end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1639,3 +1639,22 @@ end
         end
     end
 end
+@testset "require_stdlib extension with non-stdlib from module" begin
+    # Test that require_stdlib doesn't error when called with an extension
+    # and the `from` module is not from the bundled depot (from_stdlib=false path)
+    # This is a regression test for https://github.com/JuliaLang/julia/issues/60392
+    cmd = `$(Base.julia_cmd()) --startup-file=no -e '
+        Pkg_pkgid = Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg")
+        REPLExt_pkgid = Base.PkgId(Base.uuid5(Pkg_pkgid.uuid, "REPLExt"), "REPLExt")
+        # Create and register a fake REPL module to simulate a non-stdlib module being loaded
+        # This triggers the from_stdlib=false path since the fake module is not from the bundled depot
+        FakeREPL = Module(:REPL)
+        FakeREPL_pkgid = Base.PkgId(Base.UUID("3fa0cd96-eef1-5676-8a61-b3b8758bbffb"), "REPL")
+        Base.register_root_module(FakeREPL)
+        # This should not throw a KeyError from end_loading
+        Base.require_stdlib(Pkg_pkgid, "REPLExt", FakeREPL)
+        # Verify the extension was loaded
+        Base.maybe_root_module(REPLExt_pkgid) isa Module || error("Issue #60392 has returned!")
+    '`
+    @test success(cmd)
+end


### PR DESCRIPTION
When require_stdlib is called with an extension and the 'from' module is not from the bundled depot (from_stdlib=false), start_loading was not called but end_loading was still called in the finally block, causing a KeyError when trying to pop from package_locks.

Track whether start_loading was called and only call end_loading when appropriate.

Fixes #60392

Reproducer (test added):
```
% julia +1.11.8 --startup-file=no -e '
    Pkg_pkgid = Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg")
    REPLExt_pkgid = Base.PkgId(Base.uuid5(Pkg_pkgid.uuid, "REPLExt"), "REPLExt")
    FakeREPL = Module(:REPL)
    FakeREPL_pkgid = Base.PkgId(Base.UUID("3fa0cd96-eef1-5676-8a61-b3b8758bbffb"), "REPL")
    Base.register_root_module(FakeREPL)
    Base.require_stdlib(Pkg_pkgid, "REPLExt", FakeREPL)
    Base.maybe_root_module(REPLExt_pkgid) isa Module || error("")
    println("Success!")
'
ERROR: KeyError: key Base.PkgId(Base.UUID("e5eb5ef1-03cf-53a7-ae1d-5a66b08e832b"), "REPLExt") not found
Stacktrace:
 [1] pop!
   @ ./dict.jl:583 [inlined]
 [2] end_loading
   @ ./loading.jl:2140 [inlined]
 [3] macro expansion
   @ ./loading.jl:2724 [inlined]
 [4] macro expansion
   @ ./lock.jl:273 [inlined]
 [5] require_stdlib(package_uuidkey::Base.PkgId, ext::String, from::Module)
   @ Base ./loading.jl:2689
 [6] top-level scope
   @ none:7
```