### PR TITLE
REPL: support `StyledStrings` in `TerminalMenus`

### DIFF
--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -129,7 +129,7 @@ end
 ##################################################################
 
 """
-    header(m::AbstractMenu)::String
+    header(m::AbstractMenu)::AbstractString
 
 Return a header string to be printed above the menu.
 Defaults to "".
@@ -320,7 +320,8 @@ overwriting of the previous display.
 """
 function printmenu(out::IO, m::AbstractMenu, cursoridx::Int; oldstate=nothing, init::Bool=false)
     # TODO Julia 2.0?: get rid of `init` and just use `oldstate`
-    buf = IOBuffer()
+    rawbuf = IOBuffer()
+    buf = IOContext(rawbuf, :color => get(out, :color, false))
     lastoption = numoptions(m)::Int
     ncleared = oldstate === nothing ? m.pagesize-1 : oldstate
 
@@ -355,11 +356,11 @@ function printmenu(out::IO, m::AbstractMenu, cursoridx::Int; oldstate=nothing, i
         downscrollable = i == lastline && i != lastoption
 
         if upscrollable && downscrollable
-            print(buf, updown_arrow(m)::Union{Char,String})
+            print(buf, updown_arrow(m)::Union{AbstractChar,AbstractString})
         elseif upscrollable
-            print(buf, up_arrow(m)::Union{Char,String})
+            print(buf, up_arrow(m)::Union{AbstractChar,AbstractString})
         elseif downscrollable
-            print(buf, down_arrow(m)::Union{Char,String})
+            print(buf, down_arrow(m)::Union{AbstractChar,AbstractString})
         else
             print(buf, ' ')
         end
@@ -380,7 +381,7 @@ function printmenu(out::IO, m::AbstractMenu, cursoridx::Int; oldstate=nothing, i
         print(buf, "\x1b[$(ncleared-newstate)A")
     end
 
-    print(out, String(take!(buf)))
+    print(out, String(take!(rawbuf)))
 
     return newstate
 end
@@ -398,17 +399,17 @@ ctrl_c_interrupt(::AbstractMenu) = CONFIG[:ctrl_c_interrupt]::Bool
 up_arrow(m::ConfiguredMenu) = up_arrow(m.config)
 up_arrow(c::AbstractConfig) = up_arrow(c.config)
 up_arrow(c::Config) = c.up_arrow
-up_arrow(::AbstractMenu) = CONFIG[:up_arrow]::Char
+up_arrow(::AbstractMenu) = CONFIG[:up_arrow]::AbstractChar
 
 down_arrow(m::ConfiguredMenu) = down_arrow(m.config)
 down_arrow(c::AbstractConfig) = down_arrow(c.config)
 down_arrow(c::Config) = c.down_arrow
-down_arrow(::AbstractMenu) = CONFIG[:down_arrow]::Char
+down_arrow(::AbstractMenu) = CONFIG[:down_arrow]::AbstractChar
 
 updown_arrow(m::ConfiguredMenu) = updown_arrow(m.config)
 updown_arrow(c::AbstractConfig) = updown_arrow(c.config)
 updown_arrow(c::Config) = c.updown_arrow
-updown_arrow(::AbstractMenu) = CONFIG[:updown_arrow]::Char
+updown_arrow(::AbstractMenu) = CONFIG[:updown_arrow]::AbstractChar
 
 printcursor(buf, m::ConfiguredMenu, iscursor::Bool) = print(buf, iscursor ? cursor(m.config) : ' ', ' ')
 cursor(c::AbstractConfig) = cursor(c.config)

--- a/stdlib/REPL/src/TerminalMenus/MultiSelectMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/MultiSelectMenu.jl
@@ -28,7 +28,7 @@ You like the following fruits:
 
 """
 mutable struct MultiSelectMenu{C} <: _ConfiguredMenu{C}
-    options::Array{String,1}
+    options::Vector{<:AbstractString}
     pagesize::Int
     pageoffset::Int
     selected::Set{Int}
@@ -38,7 +38,7 @@ end
 
 """
 
-    MultiSelectMenu(options::Vector{String}; pagesize::Int=10, selected=[], kwargs...)
+    MultiSelectMenu(options::Vector{<:AbstractString}; pagesize::Int=10, selected=[], kwargs...)
 
 Create a MultiSelectMenu object. Use `request(menu::MultiSelectMenu)` to get
 user input. It returns a `Set` containing the indices of options that
@@ -46,7 +46,7 @@ were selected by the user.
 
 # Arguments
 
-  - `options::Vector{String}`: Options to be displayed
+  - `options::Vector{<:AbstractString}`: Options to be displayed
   - `pagesize::Int=10`: The number of options to be displayed at one time, the menu will scroll if length(options) > pagesize
   - `selected=[]`: pre-selected items. `i ∈ selected` means that `options[i]` is preselected.
 
@@ -55,7 +55,7 @@ Any additional keyword arguments will be passed to [`TerminalMenus.MultiSelectCo
 !!! compat "Julia 1.6"
     The `selected` argument requires Julia 1.6 or later.
 """
-function MultiSelectMenu(options::Array{String,1}; pagesize::Int=10, selected=Int[], warn::Bool=true, kwargs...)
+function MultiSelectMenu(options::Vector{<:AbstractString}; pagesize::Int=10, selected=Int[], warn::Bool=true, kwargs...)
     length(options) < 1 && error("MultiSelectMenu must have at least one option")
 
     # if pagesize is -1, use automatic paging
@@ -103,7 +103,7 @@ function pick(menu::MultiSelectMenu, cursor::Int)
     return false #break out of the menu
 end
 
-function writeline(buf::IOBuffer, menu::MultiSelectMenu{MultiSelectConfig}, idx::Int, iscursor::Bool)
+function writeline(buf::IO, menu::MultiSelectMenu{MultiSelectConfig}, idx::Int, iscursor::Bool)
     if idx in menu.selected
         print(buf, menu.config.checked, " ")
     else
@@ -129,7 +129,7 @@ end
 
 
 ## Legacy interface
-function TerminalMenus.writeLine(buf::IOBuffer, menu::MultiSelectMenu{<:Dict}, idx::Int, cursor::Bool)
+function TerminalMenus.writeLine(buf::IO, menu::MultiSelectMenu{<:Dict}, idx::Int, cursor::Bool)
     # print a ">" on the selected entry
     cursor ? print(buf, menu.config[:cursor]," ") : print(buf, "  ")
     if idx in menu.selected

--- a/stdlib/REPL/src/TerminalMenus/Pager.jl
+++ b/stdlib/REPL/src/TerminalMenus/Pager.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 mutable struct Pager{C} <: _ConfiguredMenu{C}
-    lines::Vector{String}
+    lines::Vector{<:AbstractString}
     pagesize::Int
     pageoffset::Int
     selected::Nothing
@@ -9,7 +9,8 @@ mutable struct Pager{C} <: _ConfiguredMenu{C}
 end
 
 function Pager(text::AbstractString; pagesize::Int=10, kwargs...)
-    lines = readlines(IOBuffer(text))
+    lines = text isa String ? readlines(IOBuffer(text)) : split(text, '\n')
+    # TODO: remove trailing '\r' and empty last line for AbstractString?
     return Pager(lines, pagesize, 0, nothing, Config(; kwargs...))
 end
 
@@ -26,7 +27,7 @@ cancel(::Pager) = nothing
 
 pick(::Pager, ::Int) = true
 
-function writeline(buf::IOBuffer, pager::Pager{Config}, idx::Int, iscursor::Bool)
+function writeline(buf::IO, pager::Pager{Config}, idx::Int, iscursor::Bool)
     print(buf, pager.lines[idx])
 end
 

--- a/stdlib/REPL/src/TerminalMenus/RadioMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/RadioMenu.jl
@@ -20,7 +20,7 @@ Your favorite fruit is blueberry!
 
 """
 mutable struct RadioMenu{C} <: _ConfiguredMenu{C}
-    options::Array{String,1}
+    options::Vector{<:AbstractString}
     keybindings::Vector{Char}
     pagesize::Int
     pageoffset::Int
@@ -31,7 +31,7 @@ end
 
 """
 
-    RadioMenu(options::Vector{String}; pagesize::Int=10,
+    RadioMenu(options::Vector{<:AbstractString}; pagesize::Int=10,
                                        keybindings::Vector{Char}=Char[],
                                        kwargs...)
 
@@ -41,7 +41,7 @@ user.
 
 # Arguments
 
-  - `options::Vector{String}`: Options to be displayed
+  - `options::Vector{<:AbstractString}`: Options to be displayed
   - `pagesize::Int=10`: The number of options to be displayed at one time, the menu will scroll if length(options) > pagesize
   - `keybindings::Vector{Char}=Char[]`: Shortcuts to pick corresponding entry from `options`
 
@@ -50,7 +50,7 @@ Any additional keyword arguments will be passed to [`TerminalMenus.Config`](@ref
 !!! compat "Julia 1.8"
     The `keybindings` argument requires Julia 1.8 or later.
 """
-function RadioMenu(options::Array{String,1}; pagesize::Int=10, warn::Bool=true, keybindings::Vector{Char}=Char[], kwargs...)
+function RadioMenu(options::Vector{<:AbstractString}; pagesize::Int=10, warn::Bool=true, keybindings::Vector{Char}=Char[], kwargs...)
     length(options) < 1 && error("RadioMenu must have at least one option")
     length(keybindings) in [0, length(options)] || error("RadioMenu must have either no keybindings, or one per option")
 
@@ -87,7 +87,7 @@ function pick(menu::RadioMenu, cursor::Int)
     return true #break out of the menu
 end
 
-function writeline(buf::IOBuffer, menu::RadioMenu{Config}, idx::Int, iscursor::Bool)
+function writeline(buf::IO, menu::RadioMenu{Config}, idx::Int, iscursor::Bool)
     print(buf, replace(menu.options[idx], "\n" => "\\n"))
 end
 
@@ -100,7 +100,7 @@ function keypress(m::RadioMenu, i::UInt32)
 end
 
 # Legacy interface
-function writeLine(buf::IOBuffer, menu::RadioMenu{<:Dict}, idx::Int, cursor::Bool)
+function writeLine(buf::IO, menu::RadioMenu{<:Dict}, idx::Int, cursor::Bool)
     # print a ">" on the selected entry
     cursor ? print(buf, menu.config[:cursor] ," ") : print(buf, "  ")
 

--- a/stdlib/REPL/src/TerminalMenus/TerminalMenus.jl
+++ b/stdlib/REPL/src/TerminalMenus/TerminalMenus.jl
@@ -36,7 +36,7 @@ public pick, cancel, writeline, options, numoptions, selected, header, keypress
 # TODO: remove in Julia 2.0
 # While not exported, AbstractMenu documented these as an extension interface
 @deprecate printMenu printmenu
-function writeLine(buf::IOBuffer, m::AbstractMenu, idx::Int, cursor::Bool)
+function writeLine(buf::IO, m::AbstractMenu, idx::Int, cursor::Bool)
     Base.depwarn("`writeLine` is deprecated, use `writeline` instead.", :writeLine)
     error("unimplemented")
 end

--- a/stdlib/REPL/src/TerminalMenus/config.jl
+++ b/stdlib/REPL/src/TerminalMenus/config.jl
@@ -3,22 +3,22 @@
 abstract type AbstractConfig end
 
 struct Config <: AbstractConfig
-    cursor::Char
-    up_arrow::Char
-    down_arrow::Char
-    updown_arrow::Char
+    cursor::AbstractChar
+    up_arrow::AbstractChar
+    down_arrow::AbstractChar
+    updown_arrow::AbstractChar
     scroll_wrap::Bool
     ctrl_c_interrupt::Bool
 end
 
 struct MultiSelectConfig <: AbstractConfig
     config::Config
-    checked::String
-    unchecked::String
+    checked::AbstractString
+    unchecked::AbstractString
 end
 
 """
-    Config(; scroll_wrap=false, ctrl_c_interrupt=true, charset=:ascii, cursor::Char, up_arrow::Char, down_arrow::Char)
+    Config(; scroll_wrap=false, ctrl_c_interrupt=true, charset=:ascii, cursor::AbstractChar, up_arrow::AbstractChar, down_arrow::AbstractChar)
 
 Configure behavior for selection menus via keyword arguments:
 
@@ -44,10 +44,10 @@ as needed, your `writeline` method should not print them.
 """
 function Config(;
                 charset::Symbol = :ascii,
-                cursor::Char = '\0',
-                up_arrow::Char = '\0',
-                down_arrow::Char = '\0',
-                updown_arrow::Char = '\0',
+                cursor::AbstractChar = '\0',
+                up_arrow::AbstractChar = '\0',
+                down_arrow::AbstractChar = '\0',
+                updown_arrow::AbstractChar = '\0',
                 scroll_wrap::Bool = false,
                 ctrl_c_interrupt::Bool = true)
     charset === :ascii || charset === :unicode ||
@@ -68,7 +68,7 @@ function Config(;
 end
 
 """
-    MultiSelectConfig(; charset=:ascii, checked::String, unchecked::String, kwargs...)
+    MultiSelectConfig(; charset=:ascii, checked::AbstractString, unchecked::AbstractString, kwargs...)
 
 Configure behavior for a multiple-selection menu via keyword arguments:
 
@@ -86,8 +86,8 @@ your `writeline` method.
 """
 function MultiSelectConfig(;
                            charset::Symbol = :ascii,
-                           checked::String = "",
-                           unchecked::String = "",
+                           checked::AbstractString = "",
+                           unchecked::AbstractString = "",
                            kwargs...)
     charset === :ascii || charset === :unicode || throw(ArgumentError("charset should be :ascii or :unicode, received $charset"))
     if isempty(checked)
@@ -112,7 +112,7 @@ Global menu configuration parameters
 !!! compat "Julia 1.6"
     `CONFIG` is deprecated, instead configure menus via their constructors.
 """
-const CONFIG = Dict{Symbol,Union{Char,String,Bool}}()
+const CONFIG = Dict{Symbol,Union{AbstractChar,AbstractString,Bool}}()
 
 """
     config( <see arguments> )
@@ -121,11 +121,11 @@ Keyword-only function to configure global menu parameters
 
 # Arguments
  - `charset::Symbol=:na`: ui characters to use (`:ascii` or `:unicode`); overridden by other arguments
- - `cursor::Char='>'|'→'`: character to use for cursor
- - `up_arrow::Char='^'|'↑'`: character to use for up arrow
- - `down_arrow::Char='v'|'↓'`: character to use for down arrow
- - `checked::String="[X]"|"✓"`: string to use for checked
- - `unchecked::String="[ ]"|"⬚")`: string to use for unchecked
+ - `cursor::AbstractChar='>'|'→'`: character to use for cursor
+ - `up_arrow::AbstractChar='^'|'↑'`: character to use for up arrow
+ - `down_arrow::AbstractChar='v'|'↓'`: character to use for down arrow
+ - `checked::AbstractString="[X]"|"✓"`: string to use for checked
+ - `unchecked::AbstractString="[ ]"|"⬚")`: string to use for unchecked
  - `scroll::Symbol=:nowrap`: If `:wrap` wrap cursor around top and bottom, if :`nowrap` do not wrap cursor
  - `supress_output::Bool=false`: Ignored legacy argument, pass `suppress_output` as a keyword argument to `request` instead.
  - `ctrl_c_interrupt::Bool=true`: If `false`, return empty on ^C, if `true` throw InterruptException() on ^C
@@ -135,12 +135,12 @@ Keyword-only function to configure global menu parameters
 """
 function config(;charset::Symbol = :na,
                 scroll::Symbol = :na,
-                cursor::Char = '\0',
-                up_arrow::Char = '\0',
-                down_arrow::Char = '\0',
-                updown_arrow::Char = '\0',
-                checked::String = "",
-                unchecked::String = "",
+                cursor::AbstractChar = '\0',
+                up_arrow::AbstractChar = '\0',
+                down_arrow::AbstractChar = '\0',
+                updown_arrow::AbstractChar = '\0',
+                checked::AbstractString = "",
+                unchecked::AbstractString = "",
                 supress_output::Union{Nothing, Bool}=nothing,   # typo was documented, unfortunately
                 ctrl_c_interrupt::Union{Nothing, Bool}=nothing)
 

--- a/stdlib/REPL/test/TerminalMenus/multiselect_menu.jl
+++ b/stdlib/REPL/test/TerminalMenus/multiselect_menu.jl
@@ -11,6 +11,9 @@
 @test MultiSelectMenu(string.(1:30), pagesize=-1, charset=:ascii).pagesize == 30
 @test MultiSelectMenu(string.(1:4), pagesize=10, charset=:ascii).pagesize == 4
 @test MultiSelectMenu(string.(1:100), charset=:ascii).pagesize == 10
+cursor, up_arrow, down_arrow = styled"{bold:>↑↓}"
+@test MultiSelectMenu([styled"{red:one}", styled"{yellow:two}", styled"{green:three}"];
+    checked = styled"[{red:X}]", cursor, up_arrow, down_arrow) isa MultiSelectMenu
 
 multi_menu = MultiSelectMenu(string.(1:20), charset=:ascii)
 @test TerminalMenus.options(multi_menu) == string.(1:20)

--- a/stdlib/REPL/test/TerminalMenus/multiselect_with_skip_menu.jl
+++ b/stdlib/REPL/test/TerminalMenus/multiselect_with_skip_menu.jl
@@ -47,7 +47,7 @@ function TerminalMenus.pick(menu::MultiSelectWithSkipMenu, cursor::Int)
     return false
 end
 
-function TerminalMenus.writeline(buf::IOBuffer,
+function TerminalMenus.writeline(buf::IO,
                                  menu::MultiSelectWithSkipMenu,
                                  idx::Int, iscursor::Bool)
     if idx in menu.selected

--- a/stdlib/REPL/test/TerminalMenus/pager.jl
+++ b/stdlib/REPL/test/TerminalMenus/pager.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 content =
-    """
+    styled"""
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
     incididunt ut labore et dolore magna aliqua. Arcu non sodales neque sodales.
     Placerat orci nulla pellentesque dignissim enim sit amet venenatis. Mauris

--- a/stdlib/REPL/test/TerminalMenus/radio_menu.jl
+++ b/stdlib/REPL/test/TerminalMenus/radio_menu.jl
@@ -11,6 +11,8 @@
 @test RadioMenu(string.(1:30), pagesize=-1, charset=:ascii).pagesize == 30
 @test RadioMenu(string.(1:4), pagesize=10, charset=:ascii).pagesize == 4
 @test RadioMenu(string.(1:100); charset=:ascii).pagesize == 10
+cursor, up_arrow, down_arrow = styled"{bold:>↑↓}"
+@test RadioMenu([styled"{red:one}", styled"{yellow:two}", styled"{green:three}"]; cursor, up_arrow, down_arrow) isa RadioMenu
 
 radio_menu = RadioMenu(string.(1:20); charset=:ascii)
 @test TerminalMenus.options(radio_menu) == string.(1:20)
@@ -50,5 +52,6 @@ radio_menu = RadioMenu(["single option"], charset=:ascii)
 @test simulate_input(radio_menu, :up, :up, :down, :up, :enter) == 1
 radio_menu = RadioMenu(string.(1:3), pagesize=1, charset=:ascii)
 @test simulate_input(radio_menu, :down, :down, :down, :down, :enter) == 3
-radio_menu = RadioMenu(["apple", "banana", "cherry"]; keybindings=collect('a':'c'), charset=:ascii)
+radio_menu = RadioMenu([styled"{green:apple}", styled"{yellow:banana}", styled"{red:cherry}"];
+    keybindings=collect('a':'c'), charset=:ascii)
 @test simulate_input(radio_menu, 'b') == 2

--- a/stdlib/REPL/test/TerminalMenus/runtests.jl
+++ b/stdlib/REPL/test/TerminalMenus/runtests.jl
@@ -2,6 +2,7 @@
 
 import REPL
 using REPL.TerminalMenus
+using StyledStrings
 using Test
 
 function simulate_input(menu::TerminalMenus.AbstractMenu, keys...; kwargs...)


### PR DESCRIPTION
The purpose of this PR is to make `TerminalMenus` accept and display `StyledString` arguments.

<details>
<summary>Example</summary>

<img width="452" height="429" alt="styledmenus" src="https://github.com/user-attachments/assets/9aed13e0-d74d-48ac-949a-27289ae79e29" />

Code:
```
using REPL.TerminalMenus

using StyledStrings

options = [styled"{green:apple}", styled"{bright_red:orange}", styled"{magenta:grape}", styled"{red:strawberry}",
            styled"{blue:blueberry}", styled"{bright_red:peach}", styled"{yellow:lemon}", styled"{bright_green:lime}"]

cursor, up_arrow, down_arrow = styled"{bold:>}{cyan:↑↓}"

@info "RadioMenu"

menu = RadioMenu(options; pagesize = 4, cursor, up_arrow, down_arrow)

choice = request(styled"Choose your favorite {underline:fruit}:", menu)

if choice != -1
    println("Your favorite fruit is ", options[choice], "!")
else
    println("Menu canceled.")
end

@info "MultiSelectMenu"

menu = MultiSelectMenu(options; pagesize = 4, cursor, up_arrow, down_arrow, checked = styled"[{cyan:X}]")

choices = request(styled"Select the {underline:fruits} you like:", menu)

if length(choices) > 0
    println("You like the following fruits:")
    for i in choices
        println("  - ", options[i])
    end
else
    println("Menu canceled.")
end

@info "Pager"

request(Pager(join(options, '\n'); pagesize = 4))
```
</details>

The PR does not add functionality beyond that. This probably falls short of what @tecosaur had in mind in #48381 (see also #50817), but it's a small change with a nice result.

#### Additional comments

- I didn't worry about non-concrete types in structs. I don't think that these menus are performance-critical.
- The `IOBuffer` argument in `printmenu` is now wrapped in an `IOContext` to get the colors to work. Another approach would be to use an `AnnotatedIOBuffer`.
- I've made only minimal changes to `Pager`, which apparently is not documented at all.
- I noticed some oddities in the existing code. For example, the keyword argument `updown_arrow` to `Config` is not documented, and most test are outside of a `@testset`. Also, the menu options for `RadioMenu` and `MultiSelectMenu` must be of type `Vector` although `AbstractVector` seems sufficient. I didn't change those things.