### PR TITLE
Fix `@allocated 1 .+ 1`

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -541,7 +541,7 @@ function is_simply_call(@nospecialize ex)
     end
     # Ensure Expr(:call, .+, ...) get wrapped
     if ex.args[1] isa Symbol
-        sa = String(ex.args[1])
+        sa = String(ex.args[1]::Symbol)
         startswith(sa, ".") &&
             !endswith(sa, ".") &&
             isoperator(Symbol(sa[2:end])) &&

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -539,6 +539,14 @@ function is_simply_call(@nospecialize ex)
         Meta.isexpr(a, :..., 1) && is_simple_atom(a.args[1]) && continue
         return false
     end
+    # Ensure Expr(:call, .+, ...) get wrapped
+    if ex.args[1] isa Symbol
+        sa = String(ex.args[1])
+        startswith(sa, ".") &&
+            !endswith(sa, ".") &&
+            isoperator(Symbol(sa[2:end])) &&
+            return false
+    end
     return true
 end
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1560,6 +1560,9 @@ end
     @allocated _x = 1+2
     @test _x === 3
 
+    # test `@allocated` works for dotted operations
+    @test (@allocated 1 .+ 1) == 0
+
     n, m = 10, 20
     X = rand(n, m)
     treshape59278(X, n, m)


### PR DESCRIPTION
Dot operators (e.g., .+, .-) are lowered to `BroadcastFunction` and do not have corresponding function definitions.
Fix the regression by adding the needed wrapper.
Test added.