### PR TITLE
coverage: cleaner logs by marking tests that fail on coverage jobs as broken

### DIFF
--- a/Compiler/test/EscapeAnalysis.jl
+++ b/Compiler/test/EscapeAnalysis.jl
@@ -4,6 +4,7 @@ include("setup_Compiler.jl")
 include("irutils.jl")
 
 const EscapeAnalysis = Compiler.EscapeAnalysis
+const coverage_enabled = Base.JLOptions().code_coverage != 0
 
 include("EAUtils.jl")
 
@@ -51,7 +52,7 @@ function is_load_forwardable(x::EscapeInfo)
 end
 
 @testset "EAUtils" begin
-    @test_throws "everything has been constant folded" code_escapes() do; sin(42); end
+    coverage_enabled || @test_throws "everything has been constant folded" code_escapes() do; sin(42); end
     @test code_escapes(sin, (Int,)) isa EAUtils.EscapeResult
     @test code_escapes(sin, (Int,)) isa EAUtils.EscapeResult
 end

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -7,6 +7,8 @@ using Test
 include("setup_Compiler.jl")
 include("irutils.jl")
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 # tests for Compiler correctness and precision
 using .Compiler: Conditional, ⊑
 isdispatchelem(@nospecialize x) = !isa(x, Type) || Compiler.isdispatchelem(x)
@@ -2562,13 +2564,13 @@ end |> only === Int
     end
     return 0
 end |> only === Int
-@test_broken Base.return_types((AliasableField{Union{Nothing,Int}},); interp=MustAliasInterpreter()) do x
+@test Base.return_types((AliasableField{Union{Nothing,Int}},); interp=MustAliasInterpreter()) do x
     if !isnothing(x.f)
         return x.f
     end
     return 0
 end |> only === Int
-@test_broken Base.return_types((AliasableField{Union{Some{Int},Nothing}},); interp=MustAliasInterpreter()) do x
+@test Base.return_types((AliasableField{Union{Some{Int},Nothing}},); interp=MustAliasInterpreter()) do x
     if !isnothing(x.f)
         return x.f
     end
@@ -5187,9 +5189,9 @@ end
 invoke_concretized1(a::Int) = a > 0 ? :int : nothing
 invoke_concretized1(a::Integer) = a > 0 ? "integer" : nothing
 # check if `invoke(invoke_concretized1, Tuple{Integer}, ::Int)` is foldable
-@test Base.infer_effects((Int,)) do a
+@test (Base.infer_effects((Int,)) do a
     @invoke invoke_concretized1(a::Integer)
-end |> Compiler.is_foldable
+end |> Compiler.is_foldable) broken=coverage_enabled
 @test Base.return_types() do
     @invoke invoke_concretized1(42::Integer)
 end |> only === String
@@ -5197,9 +5199,9 @@ end |> only === String
 invoke_concretized2(a::Int) = a > 0 ? :int : nothing
 invoke_concretized2(a::Integer) = a > 0 ? :integer : nothing
 # check if `invoke(invoke_concretized2, Tuple{Integer}, ::Int)` is foldable
-@test Base.infer_effects((Int,)) do a
+@test (Base.infer_effects((Int,)) do a
     @invoke invoke_concretized2(a::Integer)
-end |> Compiler.is_foldable
+end |> Compiler.is_foldable) broken=coverage_enabled
 @test let
     Base.Experimental.@force_compile
     @invoke invoke_concretized2(42::Integer)
@@ -5298,7 +5300,7 @@ type_level_recurse_entry() = Val{type_level_recurse1(1)}()
 f_no_bail_effects_any(x::Any) = x
 f_no_bail_effects_any(x::NamedTuple{(:x,), Tuple{Any}}) = getfield(x, 1)
 g_no_bail_effects_any(x::Any) = f_no_bail_effects_any(x)
-@test Compiler.is_foldable_nothrow(Base.infer_effects(g_no_bail_effects_any, Tuple{Any}))
+@test Compiler.is_foldable_nothrow(Base.infer_effects(g_no_bail_effects_any, Tuple{Any})) broken=coverage_enabled
 
 # issue #48374
 @test (() -> Union{<:Nothing})() == Nothing
@@ -6132,42 +6134,42 @@ end == Val{true}
 end == Val
 
 # 2. getfield modeling for partial struct
-@test Base.infer_effects((Any,Any); optimize=false) do a, b
+@test (Base.infer_effects((Any,Any); optimize=false) do a, b
     getfield(PartiallyInitialized1(a, b), :b)
-end |> Compiler.is_nothrow
+end |> Compiler.is_nothrow)
 @test Base.infer_effects((Any,Any,Symbol,); optimize=false) do a, b, f
     getfield(PartiallyInitialized1(a, b), f, #=boundscheck=#false)
 end |> !Compiler.is_nothrow
-@test Base.infer_effects((Any,Any,Any); optimize=false) do a, b, c
+@test (Base.infer_effects((Any,Any,Any); optimize=false) do a, b, c
     getfield(PartiallyInitialized1(a, b, c), :c)
-end |> Compiler.is_nothrow
-@test Base.infer_effects((Any,Any,Any,Symbol); optimize=false) do a, b, c, f
+end |> Compiler.is_nothrow)
+@test (Base.infer_effects((Any,Any,Any,Symbol); optimize=false) do a, b, c, f
     getfield(PartiallyInitialized1(a, b, c), f, #=boundscheck=#false)
-end |> Compiler.is_nothrow
-@test Base.infer_effects((Any,Any); optimize=false) do a, b
+end |> Compiler.is_nothrow)
+@test (Base.infer_effects((Any,Any); optimize=false) do a, b
     getfield(PartiallyInitialized2(a, b), :b)
-end |> Compiler.is_nothrow
+end |> Compiler.is_nothrow)
 @test Base.infer_effects((Any,Any,Symbol,); optimize=false) do a, b, f
     getfield(PartiallyInitialized2(a, b), f, #=boundscheck=#false)
 end |> !Compiler.is_nothrow
-@test Base.infer_effects((Any,Any,Any); optimize=false) do a, b, c
+@test (Base.infer_effects((Any,Any,Any); optimize=false) do a, b, c
     getfield(PartiallyInitialized2(a, b, c), :c)
-end |> Compiler.is_nothrow
-@test Base.infer_effects((Any,Any,Any,Symbol); optimize=false) do a, b, c, f
+end |> Compiler.is_nothrow)
+@test (Base.infer_effects((Any,Any,Any,Symbol); optimize=false) do a, b, c, f
     getfield(PartiallyInitialized2(a, b, c), f, #=boundscheck=#false)
-end |> Compiler.is_nothrow
+end |> Compiler.is_nothrow)
 
 # isdefined-Conditionals
-@test Base.infer_effects((Base.RefValue{Any},)) do x
+@test (Base.infer_effects((Base.RefValue{Any},)) do x
     if isdefined(x, :x)
         return getfield(x, :x)
     end
-end |> Compiler.is_nothrow
-@test Base.infer_effects((Base.RefValue{Any},)) do x
+end |> Compiler.is_nothrow)
+@test (Base.infer_effects((Base.RefValue{Any},)) do x
     if isassigned(x)
         return x[]
     end
-end |> Compiler.is_nothrow
+end |> Compiler.is_nothrow)
 @test Base.infer_effects((Any,Any); optimize=false) do a, c
     x = PartiallyInitialized2(a)
     x.c = c
@@ -6175,7 +6177,7 @@ end |> Compiler.is_nothrow
         return x.b
     end
 end |> !Compiler.is_nothrow
-@test Base.infer_effects((PartiallyInitialized2,); optimize=false) do x
+@test (Base.infer_effects((PartiallyInitialized2,); optimize=false) do x
     if isdefined(x, :b)
         if isdefined(x, :c)
             return x.c
@@ -6183,14 +6185,14 @@ end |> !Compiler.is_nothrow
         return x.b
     end
     return nothing
-end |> Compiler.is_nothrow
-@test Base.infer_effects((Bool,Int,); optimize=false) do c, b
+end |> Compiler.is_nothrow)
+@test (Base.infer_effects((Bool,Int,); optimize=false) do c, b
     x = c ? PartiallyInitialized1(true) : PartiallyInitialized1(true, b)
     if isdefined(x, :b)
         return Val(x.a), x.b
     end
     return nothing
-end |> Compiler.is_nothrow
+end |> Compiler.is_nothrow)
 
 # refine `undef` information from `@isdefined` check
 function isdefined_nothrow(c, x)
@@ -6251,9 +6253,9 @@ end == TypeError
 # nothrow modeling for `invoke` calls
 f_invoke_nothrow(::Number) = :number
 f_invoke_nothrow(::Int) = :int
-@test Base.infer_effects((Int,)) do x
+@test (Base.infer_effects((Int,)) do x
     @invoke f_invoke_nothrow(x::Number)
-end |> Compiler.is_nothrow
+end |> Compiler.is_nothrow)
 @test Base.infer_effects((Char,)) do x
     @invoke f_invoke_nothrow(x::Number)
 end |> !Compiler.is_nothrow
@@ -6392,16 +6394,16 @@ end
 
 global global_decl_defined
 global_decl_defined = 42
-@test Base.infer_effects(; interp=AssumeBindingsStaticInterp()) do
+@test (Base.infer_effects(; interp=AssumeBindingsStaticInterp()) do
     global global_decl_defined
     return global_decl_defined
-end |> Compiler.is_nothrow
+end |> Compiler.is_nothrow)
 global global_decl_defined2::Int
 global_decl_defined2 = 42
-@test Base.infer_effects(; interp=AssumeBindingsStaticInterp()) do
+@test (Base.infer_effects(; interp=AssumeBindingsStaticInterp()) do
     global global_decl_defined2
     return global_decl_defined2
-end |> Compiler.is_nothrow
+end |> Compiler.is_nothrow)
 
 @eval get_exception() = $(Expr(:the_exception))
 @test Base.infer_return_type() do

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -5,6 +5,8 @@ include("irutils.jl")
 
 using Test
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 using .Compiler: CFG, BasicBlock, NewSSAValue
 
 make_bb(preds, succs) = BasicBlock(Compiler.StmtRange(0, 0), preds, succs)
@@ -568,7 +570,7 @@ end
 
     # get the addition instruction
     add_stmt = ir.stmts[1]
-    @test Meta.isexpr(add_stmt[:stmt], :call) && add_stmt[:stmt].args[3] == 42
+    @test Meta.isexpr(add_stmt[:stmt], :call) && add_stmt[:stmt].args[3] == 42 broken=coverage_enabled
 
     # replace the addition with a slightly different one
     inst = Compiler.NewInstruction(Expr(:call, add_stmt[:stmt].args[1], add_stmt[:stmt].args[2], 999), Int)
@@ -587,7 +589,7 @@ end
     @test Compiler.length(ir.new_nodes) == 0
 
     # test that we performed copy propagation, but that the undef node was trimmed
-    @test length(ir.stmts) == instructions
+    @test length(ir.stmts) == instructions broken=coverage_enabled
 
     @test show(devnull, ir) === nothing
 end

--- a/stdlib/REPL/test/precompilation.jl
+++ b/stdlib/REPL/test/precompilation.jl
@@ -5,6 +5,8 @@ using Test
 Base.include(@__MODULE__, joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "test", "testhelpers", "FakePTYs.jl"))
 import .FakePTYs: open_fake_pty
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 if !Sys.iswindows()
     # TODO: reenable this on Windows. Without it we're not checking that Windows startup has no compilation.
     # On Windows CI runners using `open_fake_pty` is causing:
@@ -40,7 +42,7 @@ if !Sys.iswindows()
 
         n_precompiles = count(r"precompile\(", tracecompile_out)
 
-        @test n_precompiles <= expected_precompiles
+        @test n_precompiles <= expected_precompiles broken=coverage_enabled
 
         if n_precompiles == 0
             @debug "REPL: trace compile output: (none)"

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -4,6 +4,8 @@ using Random, LinearAlgebra
 
 include(joinpath(@__DIR__,"../Compiler/test/irutils.jl"))
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 isdefined(Main, :InfiniteArrays) || @eval Main include("testhelpers/InfiniteArrays.jl")
 using .Main.InfiniteArrays
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -9,6 +9,8 @@ isdefined(@__MODULE__, :T24Linear) || include("testhelpers/arrayindexingtypes.jl
 using Random, LinearAlgebra
 using Dates
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 @testset "basics" begin
     @test length([1, 2, 3]) == 3
     @test count(!iszero, [1, 2, 3]) == 3

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -7,6 +7,8 @@ using Test, Random, InteractiveUtils
 @enum BCOption bc_default bc_on bc_off
 bc_opt = BCOption(Base.JLOptions().check_bounds)
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 # test for boundscheck block eliminated at same level
 @inline function A1()
     r = 0
@@ -255,7 +257,7 @@ function g27079(X)
     r
 end
 
-@test occursin("vector.reduce.add", sprint(code_llvm, g27079, Tuple{Vector{Int}}))
+@test occursin("vector.reduce.add", sprint(code_llvm, g27079, Tuple{Vector{Int}})) broken=coverage_enabled
 
 # Boundschecking removal of indices with different type, see #40281
 getindex_40281(v, a, b, c) = @inbounds getindex(v, a, b, c)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -2,6 +2,8 @@
 
 using Test, Random
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 module TestBroadcastInternals
 
 using Base.Broadcast: check_broadcast_axes, check_broadcast_shape, newindex, _bcs
@@ -1200,8 +1202,8 @@ end
 
 # test that `Broadcast` definition is defined as total and eligible for concrete evaluation
 import Base.Broadcast: BroadcastStyle, DefaultArrayStyle
-@test Base.infer_effects(BroadcastStyle, (DefaultArrayStyle{1},DefaultArrayStyle{2},)) |>
-    Core.Compiler.is_foldable
+@test (Base.infer_effects(BroadcastStyle, (DefaultArrayStyle{1},DefaultArrayStyle{2},)) |>
+    Core.Compiler.is_foldable) broken=coverage_enabled
 
 f51129(v, x) = (1 .- (v ./ x) .^ 2)
 @test @inferred(f51129([13.0], 6.5)) == [-3.0]

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -2,6 +2,8 @@
 
 import Libdl
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 # helper function for passing input to stdin
 # and returning the stdout result
 function writereadpipeline(input, exename; stderr=nothing)
@@ -542,7 +544,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
         opts = Base.JLOptions()
         coverage_file = (opts.output_code_coverage != C_NULL) ?  unsafe_string(opts.output_code_coverage) : ""
         @test !isfile(covfile)
-        @test defaultcov == string(opts.code_coverage != 0 && (isempty(coverage_file) || occursin("%p", coverage_file)))
+        @test defaultcov == string(opts.code_coverage != 0 && (isempty(coverage_file) || occursin("%p", coverage_file))) broken=coverage_enabled
         @test readchomp(`$cov_exename -E "Base.JLOptions().code_coverage" -L $inputfile
             --code-coverage=$covfile --code-coverage=none`) == "0"
         @test !isfile(covfile)
@@ -713,16 +715,16 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             @test popfirst!(got) == "       32     Base.invokelatest(g, x)"
         elseif 12 == (() -> @allocated ccall(:jl_gc_allocobj, Ptr{Cvoid}, (Csize_t,), 8))()
             # See if we have a 12-byte pool with 32 bit tags (MAX_ALIGN = 4)
-            @test popfirst!(got) == "       12     Base.invokelatest(g, 0)"
-            @test popfirst!(got) == "       24     Base.invokelatest(g, x)"
+            @test popfirst!(got) == "       12     Base.invokelatest(g, 0)" broken=coverage_enabled
+            @test popfirst!(got) == "       24     Base.invokelatest(g, x)" broken=coverage_enabled
         else # MAX_ALIGN >= 8
-            @test popfirst!(got) == "        8     Base.invokelatest(g, 0)"
-            @test popfirst!(got) == "       32     Base.invokelatest(g, x)"
+            @test popfirst!(got) == "        8     Base.invokelatest(g, 0)" broken=coverage_enabled
+            @test popfirst!(got) == "       32     Base.invokelatest(g, x)" broken=coverage_enabled
         end
         if Sys.WORD_SIZE == 64
             @test popfirst!(got) == "       32     []"
         else
-            @test popfirst!(got) == "       16     []"
+            @test popfirst!(got) == "       16     []" broken=coverage_enabled
         end
         @test popfirst!(got) == "        - end"
         @test popfirst!(got) == "        - f(1.23)"
@@ -760,7 +762,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
                 # TODO: consider moving test to llvmpasses as this fails on some platforms
                 # without clear reason
                 @test_skip occursin("int.jl", code)
-                @test !occursin("name: \"Int64\"", code)
+                @test !occursin("name: \"Int64\"", code) broken=coverage_enabled
             end
             let code = readchomperrors(`$exename -g2 -E "@eval Int64(1)+Int64(1)"`)
                 @test code[1]
@@ -909,8 +911,8 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             `$exename -i`,
             stderr=io)
         _stderr = String(take!(io))
-        @test length(findall(r"precompile\(", _stderr)) == 5
-        @test length(findall(r" # recompile", _stderr)) == 1
+        @test length(findall(r"precompile\(", _stderr)) == 5 broken=coverage_enabled
+        @test length(findall(r" # recompile", _stderr)) == 1 broken=coverage_enabled
     end
 
     # --trace-dispatch

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -5,6 +5,8 @@ using Random: randcycle
 isdefined(Main, :ImmutableArrays) || @eval Main include("testhelpers/ImmutableArrays.jl")
 using .Main.ImmutableArrays
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 @testset "binomial" begin
     @test binomial(5,-1) == 0
     @test binomial(5,10) == 0
@@ -80,7 +82,7 @@ end
     for T = Base.uniontypes(Union{Base.Checked.SignedInt,Base.Checked.UnsignedInt})
         @testset let T = T
             @test factorial(T(7)) == 5040
-            @test Core.Compiler.is_foldable(Base.infer_effects(factorial, (T,)))
+            @test Core.Compiler.is_foldable(Base.infer_effects(factorial, (T,))) broken=coverage_enabled
         end
     end
     @test factorial(0) == 1

--- a/test/core.jl
+++ b/test/core.jl
@@ -6,6 +6,8 @@ using Random, InteractiveUtils
 
 const Bottom = Union{}
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 # For curmod_*
 include("testenv.jl")
 
@@ -8288,15 +8290,15 @@ struct ModTParamUnionAll{A, B}; end
 # effects for objectid
 for T in (Int, String, Symbol, Module)
     @test Core.Compiler.is_foldable(Base.infer_effects(objectid, (T,)))
-    @test Core.Compiler.is_foldable(Base.infer_effects(hash, (T,)))
+    @test Core.Compiler.is_foldable(Base.infer_effects(hash, (T,))) broken=coverage_enabled
     @test Core.Compiler.is_foldable(Base.infer_effects(objectid, (Some{T},)))
-    @test Core.Compiler.is_foldable(Base.infer_effects(hash, (Some{T},)))
+    @test Core.Compiler.is_foldable(Base.infer_effects(hash, (Some{T},))) broken=coverage_enabled
     @test Core.Compiler.is_foldable(Base.infer_effects(objectid, (Some{Some{T}},)))
-    @test Core.Compiler.is_foldable(Base.infer_effects(hash, (Some{Some{T}},)))
+    @test Core.Compiler.is_foldable(Base.infer_effects(hash, (Some{Some{T}},))) broken=coverage_enabled
     @test Core.Compiler.is_foldable(Base.infer_effects(objectid, (Tuple{T},)))
-    @test Core.Compiler.is_foldable(Base.infer_effects(hash, (Tuple{T},)))
+    @test Core.Compiler.is_foldable(Base.infer_effects(hash, (Tuple{T},))) broken=coverage_enabled
     @test Core.Compiler.is_foldable(Base.infer_effects(objectid, (Tuple{T,T},)))
-    @test Core.Compiler.is_foldable(Base.infer_effects(hash, (Tuple{T,T},)))
+    @test Core.Compiler.is_foldable(Base.infer_effects(hash, (Tuple{T,T},))) broken=coverage_enabled
     @test Core.Compiler.is_foldable(Base.infer_effects(objectid, (Ref{T},)))
     @test Core.Compiler.is_foldable(Base.infer_effects(objectid, (Tuple{Ref{T}},)))
     @test Core.Compiler.is_foldable(Base.infer_effects(objectid, (Tuple{Vector{T}},)))

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -2,6 +2,8 @@
 
 using Random
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 @testset "Pair" begin
     p = Pair(10,20)
     @test p == (10=>20)
@@ -1523,7 +1525,7 @@ end
 for T in (Int, Float64, String, Symbol)
     @testset let T=T
         @test !Core.Compiler.is_consistent(Base.infer_effects(getindex, (Dict{T,Any}, T)))
-        @test Core.Compiler.is_effect_free(Base.infer_effects(getindex, (Dict{T,Any}, T)))
+        @test Core.Compiler.is_effect_free(Base.infer_effects(getindex, (Dict{T,Any}, T))) broken=coverage_enabled
         @test !Core.Compiler.is_nothrow(Base.infer_effects(getindex, (Dict{T,Any}, T)))
         @test Core.Compiler.is_terminates(Base.infer_effects(getindex, (Dict{T,Any}, T)))
     end

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -4,6 +4,8 @@ using Random, LinearAlgebra
 isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
 using .Main.OffsetArrays
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 types = Any[
     Bool,
     Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Float32, Float64,
@@ -316,7 +318,7 @@ struct AUnionParam{T<:Union{Nothing,Float32,Float64}} end
 end
 
 @testset "concrete eval type hash" begin
-    @test Core.Compiler.is_foldable_nothrow(Base.infer_effects(hash, Tuple{Type{Int}, UInt}))
+    @test Core.Compiler.is_foldable_nothrow(Base.infer_effects(hash, Tuple{Type{Int}, UInt})) broken=coverage_enabled
 
     f(h...) = hash(Char, h...);
     src = only(code_typed(f, Tuple{UInt}))[1]

--- a/test/int.jl
+++ b/test/int.jl
@@ -4,6 +4,8 @@
 
 using Random
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 @testset "flipsign/copysign" begin
     for y in (-4, Float32(-4), -4.0, big(-4.0))
         @test flipsign(3, y)  == -3
@@ -206,9 +208,9 @@ end
         for T2 in Base.BitInteger_types
             for op in (>>, <<, >>>)
                 if sizeof(T2)==sizeof(Int) || T <: Signed || (op==>>>) || T2 <: Unsigned
-                    @test Core.Compiler.is_foldable_nothrow(Base.infer_effects(op, (T, T2)))
+                    @test Core.Compiler.is_foldable_nothrow(Base.infer_effects(op, (T, T2))) broken=coverage_enabled
                 else
-                    @test Core.Compiler.is_foldable(Base.infer_effects(op, (T, T2)))
+                    @test Core.Compiler.is_foldable(Base.infer_effects(op, (T, T2))) broken=coverage_enabled
                     # #47835, TODO implement interval arithmetic analysis
                     @test_broken Core.Compiler.is_nothrow(Base.infer_effects(op, (T, T2)))
                 end

--- a/test/interpreter.jl
+++ b/test/interpreter.jl
@@ -2,6 +2,8 @@
 
 using Test
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 # interpreted but inferred/optimized top-level expressions with vars
 let code = """
            while true

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -2,6 +2,8 @@
 
 using Random
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 is_effect_free(args...) = Core.Compiler.is_effect_free(Base.infer_effects(args...))
 
 ⟷(a::T, b::T) where T <: Union{Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128} = a === b
@@ -157,8 +159,8 @@ is_effect_free(args...) = Core.Compiler.is_effect_free(Base.infer_effects(args..
     @test gcd(typemax(UInt), BigInt(1236189723689716298376189726398761298361892)) == 1
 
     @testset "effects" begin
-        @test is_effect_free(gcd, Tuple{Int,Int})
-        @test is_effect_free(lcm, Tuple{Int,Int})
+        @test is_effect_free(gcd, Tuple{Int,Int}) broken=coverage_enabled
+        @test is_effect_free(lcm, Tuple{Int,Int}) broken=coverage_enabled
     end
 end
 
@@ -728,10 +730,10 @@ end
 
 @testset "constant prop in gcd" begin
     ci = code_typed(() -> gcd(14, 21))[][1]
-    @test ci.code == Any[Core.ReturnNode(7)]
+    @test ci.code == Any[Core.ReturnNode(7)] broken=coverage_enabled
 
     ci = code_typed(() -> 14 // 21)[][1]
-    @test ci.code == Any[Core.ReturnNode(2 // 3)]
+    @test ci.code == Any[Core.ReturnNode(2 // 3)] broken=coverage_enabled
 end
 @testset "binomial" begin
     for T in (Int8, Int16, Int32, Int64)
@@ -761,15 +763,15 @@ end
 end
 
 # concrete-foldability
-@test Base.infer_effects(gcd, (Int,Int)) |> Core.Compiler.is_foldable
-@test Base.infer_effects(gcdx, (Int,Int)) |> Core.Compiler.is_foldable
-@test Base.infer_effects(invmod, (Int,Int)) |> Core.Compiler.is_foldable
-@test Base.infer_effects(binomial, (Int,Int)) |> Core.Compiler.is_foldable
+@test (Base.infer_effects(gcd, (Int,Int)) |> Core.Compiler.is_foldable) broken=coverage_enabled
+@test (Base.infer_effects(gcdx, (Int,Int)) |> Core.Compiler.is_foldable) broken=coverage_enabled
+@test (Base.infer_effects(invmod, (Int,Int)) |> Core.Compiler.is_foldable) broken=coverage_enabled
+@test (Base.infer_effects(binomial, (Int,Int)) |> Core.Compiler.is_foldable) broken=coverage_enabled
 @testset "concrete-foldability: `hastypemax`" begin
-    @test Base.infer_effects(Base.hastypemax, (Type,)) |> Core.Compiler.is_foldable
-    @test Base.infer_effects(Base.hastypemax, (DataType,)) |> Core.Compiler.is_foldable
+    @test (Base.infer_effects(Base.hastypemax, (Type,)) |> Core.Compiler.is_foldable) broken=coverage_enabled
+    @test (Base.infer_effects(Base.hastypemax, (DataType,)) |> Core.Compiler.is_foldable) broken=coverage_enabled
     for t in (Bool, Int, BigInt)
-        @test Base.infer_effects(Base.hastypemax, (Type{t},)) |> Core.Compiler.is_foldable
+        @test (Base.infer_effects(Base.hastypemax, (Type{t},)) |> Core.Compiler.is_foldable) broken=coverage_enabled
     end
 end
 

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -8,6 +8,8 @@ using Dates: Date, Day
 isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
 using .Main.OffsetArrays
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 @test (@inferred Base.IteratorSize(Any)) isa Base.SizeUnknown
 
 # zip and filter iterators
@@ -1053,8 +1055,8 @@ end
     simple_types = (Vector, NTuple, NamedTuple{X, Y} where {X, Y <: NTuple})
     example_type = Tuple{Bool, Int8, Vararg{Int16, 20}}
     function test_foldability_inference(f, S::Type)
-        @test Core.Compiler.is_foldable(Base.infer_effects(f, Tuple{S}))
-        @test Core.Compiler.is_foldable(Base.infer_effects(f, Tuple{Type{<:S}}))
+        @test Core.Compiler.is_foldable(Base.infer_effects(f, Tuple{S})) broken=coverage_enabled
+        @test Core.Compiler.is_foldable(Base.infer_effects(f, Tuple{Type{<:S}})) broken=coverage_enabled
     end
     @testset "concrete" begin  # weaker test, only checks foldability for certain concrete types
         @testset "f: $f" for f ∈ functions

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -37,6 +37,8 @@ original_depot_path = copy(Base.DEPOT_PATH)
 include("tempdepot.jl")
 include("precompile_utils.jl")
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 loaded_files = String[]
 push!(Base.include_callbacks, (mod::Module, fn::String) -> push!(loaded_files, fn))
 include("test_sourcepath.jl")
@@ -1585,7 +1587,7 @@ end
                 `$(Base.julia_cmd()) --startup-file=no --pkgimage=yes --code-coverage=@ --project -e 'using CovTest; foo(); exit(0)'`,
                 "JULIA_DEPOT_PATH" => depot,
             ))
-            @test cov_exists()
+            @test cov_exists() broken=coverage_enabled
             rm_cov_files()
 
             # same again but call bar(), which is NOT in the pkgimage, and should generate coverage
@@ -1593,7 +1595,7 @@ end
                 `$(Base.julia_cmd()) --startup-file=no --pkgimage=yes --code-coverage=@ --project -e 'using CovTest; bar(); exit(0)'`,
                 "JULIA_DEPOT_PATH" => depot,
             ))
-            @test cov_exists()
+            @test cov_exists() broken=coverage_enabled
             rm_cov_files()
         end
     end

--- a/test/math.jl
+++ b/test/math.jl
@@ -10,6 +10,8 @@ using Random
 using LinearAlgebra
 using Base.Experimental: @force_compile
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 function isnan_type(::Type{T}, x) where T
     isa(x, T) && isnan(x)
 end
@@ -1797,14 +1799,14 @@ end
                              rt = Base.infer_return_type(f, (T,)),
                              effects = Base.infer_effects(f, (T,))
                     @test rt != Union{}
-                    @test Core.Compiler.is_foldable(effects)
+                    @test Core.Compiler.is_foldable(effects) broken=coverage_enabled
                 end
             end
             @testset let effects = Base.infer_effects(^, (T,Int))
-                @test Core.Compiler.is_foldable(effects)
+                @test Core.Compiler.is_foldable(effects) broken=coverage_enabled
             end
             @testset let effects = Base.infer_effects(^, (T,T))
-                @test Core.Compiler.is_foldable(effects)
+                @test Core.Compiler.is_foldable(effects) broken=coverage_enabled
             end
         end
     end
@@ -1814,7 +1816,7 @@ end;
         @testset let T = T
             for f = Any[exp, exp2, exp10, expm1]
                 @testset let f = f
-                    @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (T,)))
+                    @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (T,))) broken=coverage_enabled
                 end
             end
         end

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -2,7 +2,7 @@
 
 isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
 using .Main.OffsetArrays
-
+const coverage_enabled = Base.JLOptions().code_coverage != 0
 @testset "MissingException" begin
     @test sprint(showerror, MissingException("test")) == "MissingException: test"
 end
@@ -647,7 +647,7 @@ end
 # use LazyString for MissingException to get the better effects
 for func in (round, ceil, floor, trunc)
     @testset let func = func
-        @test Core.Compiler.is_foldable(Base.infer_effects(func, (Type{Int},Union{Int,Missing})))
+        @test Core.Compiler.is_foldable(Base.infer_effects(func, (Type{Int},Union{Int,Missing}))) broken=coverage_enabled
     end
 end
 

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -2,6 +2,8 @@
 
 using Base: delete
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 @test_throws TypeError NamedTuple{1,Tuple{}}
 @test_throws TypeError NamedTuple{(),1}
 @test_throws TypeError NamedTuple{(:a,1),Tuple{Int}}
@@ -408,20 +410,20 @@ for f in (Base.merge, Base.structdiff)
         # test the effects of the fallback path
         fallback_func(a::NamedTuple, b::NamedTuple) = @invoke f(a::NamedTuple, b::NamedTuple)
         @testset let eff = Base.infer_effects(fallback_func)
-            @test Core.Compiler.is_foldable(eff)
+            @test Core.Compiler.is_foldable(eff) broken=coverage_enabled
             @test Core.Compiler.is_nonoverlayed(eff)
         end
         @test only(Base.return_types(fallback_func)) == NamedTuple
         # test if `max_methods = 4` setting works as expected
         general_func(a::NamedTuple, b::NamedTuple) = f(a, b)
         @testset let eff = Base.infer_effects(general_func)
-            @test Core.Compiler.is_foldable(eff)
+            @test Core.Compiler.is_foldable(eff) broken=coverage_enabled
             @test Core.Compiler.is_nonoverlayed(eff)
         end
         @test only(Base.return_types(general_func)) == NamedTuple
     end
 end
-@test Core.Compiler.is_foldable(Base.infer_effects(pairs, Tuple{NamedTuple}))
+@test Core.Compiler.is_foldable(Base.infer_effects(pairs, Tuple{NamedTuple})) broken=coverage_enabled
 
 # Test that merge/diff preserves nt field types
 let a = Base.NamedTuple{(:a, :b), Tuple{Any, Any}}((1, 2)), b = Base.NamedTuple{(:b,), Tuple{Float64}}(3)

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -3,6 +3,8 @@ using InteractiveUtils
 using Core: OpaqueClosure
 using Base.Experimental: @opaque
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 const_int() = 1
 const_int_barrier() = Base.inferencebarrier(1)::typeof(1)
 
@@ -49,8 +51,8 @@ let ci = @code_lowered OcClos2Int(1, 2)();
 end
 @test @inferred(oc_self_call_clos()) == 3
 let opt = @code_typed oc_self_call_clos()
-    @test length(opt[1].code) == 1
-    @test isa(opt[1].code[1], Core.ReturnNode)
+    @test length(opt[1].code) == 1 broken=coverage_enabled
+    @test isa(opt[1].code[1], Core.ReturnNode) broken=coverage_enabled
 end
 
 struct OcClos1Any
@@ -91,8 +93,8 @@ end
 @test @inferred(complicated_identity(1)) == 1
 @test @inferred(complicated_identity("a")) == "a"
 let ci = (@code_typed complicated_identity(1))[1]
-    @test length(ci.code) == 1
-    @test isa(ci.code[1], Core.ReturnNode)
+    @test length(ci.code) == 1 broken=coverage_enabled
+    @test isa(ci.code[1], Core.ReturnNode) broken=coverage_enabled
 end
 
 struct OcOpt

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -6,6 +6,8 @@ using InteractiveUtils: code_llvm
 isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
 using .Main.OffsetArrays
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 @testset "range construction" begin
     @test_throws ArgumentError range(start=1, step=1, stop=2, length=10)
     @test_throws ArgumentError range(start=1, step=1, stop=10, length=11)
@@ -2651,7 +2653,7 @@ function check_ranges(rx, ry)
     end
     rx, ry
 end
-@test Core.Compiler.is_foldable(Base.infer_effects(check_ranges, (UnitRange{Int},UnitRange{Int})))
+@test Core.Compiler.is_foldable(Base.infer_effects(check_ranges, (UnitRange{Int},UnitRange{Int}))) broken=coverage_enabled
 # TODO JET.@test_opt check_ranges(1:2, 3:4)
 
 @testset "checkbounds overflow (#26623)" begin

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -4,6 +4,8 @@ using Random
 isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
 using .Main.OffsetArrays
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 ==ₜ(::Any, ::Any) = false
 ==ₜ(a::T, b::T) where {T} = isequal(a, b)
 
@@ -746,30 +748,30 @@ end
 @testset "concrete eval `[any|all](f, itr::Tuple)`" begin
     intf = in((1,2,3)); Intf = typeof(intf)
     symf = in((:one,:two,:three)); Symf = typeof(symf)
-    @test Core.Compiler.is_foldable(Base.infer_effects(intf, (Int,)))
-    @test Core.Compiler.is_foldable(Base.infer_effects(symf, (Symbol,)))
-    @test Core.Compiler.is_foldable(Base.infer_effects(all, (Intf,Tuple{Int,Int,Int})))
-    @test Core.Compiler.is_foldable(Base.infer_effects(all, (Symf,Tuple{Symbol,Symbol,Symbol})))
-    @test Core.Compiler.is_foldable(Base.infer_effects(any, (Intf,Tuple{Int,Int,Int})))
-    @test Core.Compiler.is_foldable(Base.infer_effects(any, (Symf,Tuple{Symbol,Symbol,Symbol})))
-    @test Base.return_types() do
+    @test Core.Compiler.is_foldable(Base.infer_effects(intf, (Int,))) broken=coverage_enabled
+    @test Core.Compiler.is_foldable(Base.infer_effects(symf, (Symbol,))) broken=coverage_enabled
+    @test Core.Compiler.is_foldable(Base.infer_effects(all, (Intf,Tuple{Int,Int,Int}))) broken=coverage_enabled
+    @test Core.Compiler.is_foldable(Base.infer_effects(all, (Symf,Tuple{Symbol,Symbol,Symbol}))) broken=coverage_enabled
+    @test Core.Compiler.is_foldable(Base.infer_effects(any, (Intf,Tuple{Int,Int,Int}))) broken=coverage_enabled
+    @test Core.Compiler.is_foldable(Base.infer_effects(any, (Symf,Tuple{Symbol,Symbol,Symbol}))) broken=coverage_enabled
+    @test (Base.return_types() do
         Val(all(in((1,2,3)), (1,2,3)))
-    end |> only == Val{true}
-    @test Base.return_types() do
+    end |> only == Val{true}) broken=coverage_enabled
+    @test (Base.return_types() do
         Val(all(in((1,2,3)), (1,2,3,4)))
-    end |> only == Val{false}
-    @test Base.return_types() do
+    end |> only == Val{false}) broken=coverage_enabled
+    @test (Base.return_types() do
         Val(any(in((1,2,3)), (4,5,3)))
-    end |> only == Val{true}
-    @test Base.return_types() do
+    end |> only == Val{true}) broken=coverage_enabled
+    @test (Base.return_types() do
         Val(any(in((1,2,3)), (4,5,6)))
-    end |> only == Val{false}
-    @test Base.return_types() do
+    end |> only == Val{false}) broken=coverage_enabled
+    @test (Base.return_types() do
         Val(all(in((:one,:two,:three)),(:three,:four)))
-    end |> only == Val{false}
-    @test Base.return_types() do
+    end |> only == Val{false}) broken=coverage_enabled
+    @test (Base.return_types() do
         Val(any(in((:one,:two,:three)),(:four,:three)))
-    end |> only == Val{true}
+    end |> only == Val{true}) broken=coverage_enabled
 end
 
 # `reduce(vcat, A)` should not alias the input for length-1 collections

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -4,6 +4,8 @@ using Test
 
 include(joinpath(@__DIR__,"../Compiler/test/irutils.jl"))
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 # code_native / code_llvm (issue #8239)
 # It's hard to really test these, but just running them should be
 # sufficient to catch segfault bugs.
@@ -77,7 +79,7 @@ end # module ReflectionTest
 @test isbits((1,2))
 @test !isbits([1])
 @test isbits(nothing)
-@test fully_eliminated(isbits, (Int,))
+@test fully_eliminated(isbits, (Int,)) broken=coverage_enabled
 
 # issue #16670
 @test isconcretetype(Int)

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -6,6 +6,8 @@ using .Main.OffsetArrays
 isdefined(Main, :TSlow) || @eval Main include("testhelpers/arrayindexingtypes.jl")
 using .Main: TSlow, WrapperArray
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 tslow(a::AbstractArray) = TSlow(a)
 wrapper(a::AbstractArray) = WrapperArray(a)
 fcviews(a::AbstractArray) = view(a, ntuple(Returns(:),ndims(a)-1)..., axes(a)[end])
@@ -642,7 +644,7 @@ end
 
 @testset "effect of StridedReinterpretArray's getindex" begin
     eff = Base.infer_effects(getindex, Base.typesof(reinterpret(Int8, Int[1]), 1))
-    @test Core.Compiler.is_effect_free(eff)
+    @test Core.Compiler.is_effect_free(eff) broken=coverage_enabled
 end
 
 # reinterpret of arbitrary bitstypes

--- a/test/scopedvalues.jl
+++ b/test/scopedvalues.jl
@@ -4,6 +4,8 @@ using Base.ScopedValues
 
 include(joinpath(@__DIR__,"../Compiler/test/irutils.jl"))
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 @testset "errors" begin
     @test ScopedValue{Float64}(1)[] == 1.0
     @test_throws InexactError ScopedValue{Int}(1.5)
@@ -176,7 +178,7 @@ end
 const inlineable_const_sv = ScopedValue(1)
 @test fully_eliminated(; retval=(inlineable_const_sv => 1)) do
     inlineable_const_sv => 1
-end
+end broken=coverage_enabled
 
 # Handle nothrow scope bodies correctly (#56609)
 @eval @noinline function nothrow_scope(@nospecialize(scope_at_entry))

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -9,6 +9,8 @@ using Downloads: Downloads, download
 
 valgrind_off = ccall(:jl_running_on_valgrind, Cint, ()) == 0
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 yescmd = `yes`
 echocmd = `echo`
 sortcmd = `sort`
@@ -1047,7 +1049,7 @@ end
 # effects for Cmd construction
 for f in (() -> `a b c`, () -> `a a$("bb")a $("c")`)
     effects = Base.infer_effects(f)
-    @test Core.Compiler.is_effect_free(effects)
+    @test Core.Compiler.is_effect_free(effects) broken=coverage_enabled
     @test Core.Compiler.is_terminates(effects)
     @test Core.Compiler.is_noub(effects)
     @test !Core.Compiler.is_consistent(effects)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -5,6 +5,8 @@
 using Random
 using Base: remove_linenums!
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 using_JuliaSyntax = parentmodule(Core._parse) != Core.Compiler
 
 macro test_parseerror(str, msg)
@@ -1968,7 +1970,7 @@ end
     p = (2, 3, 4)
     @test p == (2, 3, 4)
     allocs = (() -> @allocated identity(p))()
-    @test allocs == 0
+    @test allocs == 0 broken=coverage_enabled
 end
 
 @test_throws UndefVarError eval(Symbol(""))

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -3,6 +3,8 @@
 isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
 using .Main.OffsetArrays
 
+const coverage_enabled = Base.JLOptions().code_coverage != 0
+
 struct BitPerm_19352
     p::NTuple{8,UInt8}
     function BitPerm(p::NTuple{8,UInt8})
@@ -839,8 +841,8 @@ namedtup = (;a=1, b=2, c=3)
 end
 
 # Make sure that tuple iteration is foldable
-@test Core.Compiler.is_foldable(Base.infer_effects(iterate, Tuple{NTuple{4, Float64}, Int}))
-@test Core.Compiler.is_foldable(Base.infer_effects(eltype, Tuple{Tuple}))
+@test Core.Compiler.is_foldable(Base.infer_effects(iterate, Tuple{NTuple{4, Float64}, Int})) broken=coverage_enabled
+@test Core.Compiler.is_foldable(Base.infer_effects(eltype, Tuple{Tuple})) broken=coverage_enabled
 
 # some basic equivalence handling tests for Union{} appearing in Tuple Vararg parameters
 @test Tuple{} <: Tuple{Vararg{Union{}}}


### PR DESCRIPTION
Otherwise the logs in coverage jobs are unreadably noisy

Ontop of #60543 temporarily