### PR TITLE
Fix JET warning by avoiding recursion in `getproperty(::DirEntry)`

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -1059,7 +1059,7 @@ struct DirEntry
 end
 function Base.getproperty(obj::DirEntry, p::Symbol)
     if p === :path
-        return joinpath(obj.dir, obj.name)
+        return joinpath(getfield(obj, :dir), getfield(obj, :name))
     else
         return getfield(obj, p)
     end


### PR DESCRIPTION
This lead to JET warnings in e.g. `realpath`.

I would say even better would be to avoid this `getproperty` method altogether. I have an alternative patch which adds a `path(::DirEntry)` method and changes code in REPL and tests to avoid it.