### PR TITLE
Fix JET warning in `artifact_meta`

### DIFF
--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -410,7 +410,7 @@ function artifact_meta(name::String, artifact_dict::Dict, artifacts_toml::String
         dl_dict = Dict{Platform,Dict{String,Any}}()
         for x in meta
             x = x::Dict{String, Any}
-            dl_dict[unpack_platform(x, name, artifacts_toml)] = x
+            dl_dict[unpack_platform(x, name, artifacts_toml)::Platform] = x
         end
         meta = select_platform(dl_dict, platform)
     # If it's NOT a dict, complain


### PR DESCRIPTION
`unpack_platform` might return nothing in case of an error.

Together with PR #60506 and my previous changes, when applied to release-1.12, the JET report for GAP.jl is now free of reports. Well, if I filter out certain "unavoidable issues":
```julia
using Revise, JET, AbstractAlgebra, GAP

struct AnyFrameMethod <: ReportMatcher
    m::Union{Function,Method,Symbol}
end


function JET.match_report(matcher::AnyFrameMethod, @nospecialize(report::JET.InferenceErrorReport))
    # check all VirtualFrames in the VirtualStackTrace for a match to the specified method
    m = matcher.m
    if m isa Symbol
        return any(vf -> vf.linfo.def.name === m, report.vst)
    elseif m isa Method
        return any(vf -> vf.linfo.def === m, report.vst)
    else # if m isa Function
        return any(vf -> vf.linfo.def in methods(m), report.vst)
    end
end

report_package(GAP; ignored_modules=[AnyFrameMethod(:is_loaded_directly)])
```

CC @lgoettgens 