### PR TITLE
fix `reshape` regression in 1.12+

### DIFF
--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -41,6 +41,7 @@ eltype(::Type{<:ReshapedArrayIterator{I}}) where {I} = @isdefined(I) ? ReshapedI
 ## reshape(::Array, ::Dims) returns a new Array (to avoid conditionally aliasing the structure, only the data)
 # reshaping to same # of dimensions
 @eval function reshape(a::Array{T,M}, dims::NTuple{N,Int}) where {T,N,M}
+    a.size == dims && return a
     len = Core.checked_dims(dims...) # make sure prod(dims) doesn't overflow (and because of the comparison to length(a))
     if len != length(a)
         throw_dmrsa(dims, length(a))


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/56236 removed the optimization of returning the original array where the new size matches the old size. This adds that optimization back, saving an allocation. Since this fixes a change of aliasing, IMO this is also a bugfix.