### PR TITLE
replace 45 line "is translated into:" to  "is equivalent to:"

### DIFF
--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -42,7 +42,7 @@ for item in iter   # or  "for item = iter"
 end
 ```
 
-is translated into:
+is equivalent to:
 
 ```julia
 next = iterate(iter)


### PR DESCRIPTION
In documentation 45 line is translated into: should be replaced with is equivalent to:for clarity otherwise it creates confusion.
https://discourse.julialang.org/t/how-do-you-actually-find-out-how-to-use-an-interface-in-julia-like-the-concept-of-iterator-end/134796/9