### PR TITLE
fix `Core.Box` in REPL

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2181,7 +2181,7 @@ let
     for (left, right) in bracket_pairs
         # Left bracket: insert both and move cursor between them
         bracket_insert_keymap[left] = (s::MIState, o...) -> begin
-            buf = buffer(s)
+            local buf = buffer(s)
             edit_insert(buf, left)
             if eof(buf) || peek(buf, Char) in right_brackets_ws
                 edit_insert(buf, right)
@@ -2192,7 +2192,7 @@ let
 
         # Right bracket: skip over if next char matches, otherwise insert
         bracket_insert_keymap[right] = (s::MIState, o...) -> begin
-            buf = buffer(s)
+            local buf = buffer(s)
             if !eof(buf) && peek(buf, Char) == right
                 edit_move_right(buf)
             else
@@ -2205,7 +2205,7 @@ let
     # Quote characters (need special handling for transpose detection)
     for quote_char in ('"', '\'', '`')
         bracket_insert_keymap[quote_char] = (s::MIState, o...) -> begin
-            buf = buffer(s)
+            local buf = buffer(s)
             if !eof(buf) && peek(buf, Char) == quote_char
                 # Skip over closing quote
                 edit_move_right(buf)
@@ -2233,15 +2233,14 @@ let
             repl = Base.active_repl
             mirepl = isdefined(repl, :mi) ? repl.mi : repl
             main_mode = mirepl.interface.modes[1]
-            buf = copy(buffer(s))
+            local buf = copy(buffer(s))
             transition(s, main_mode) do
                 state(s, main_mode).input_buffer = buf
             end
             return
         end
 
-        buf = buffer(s)
-        if try_remove_paired_delimiter(buf)
+        if try_remove_paired_delimiter(buffer(s))
             return refresh_line(s)
         end
         return edit_backspace(s)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -611,14 +611,15 @@ function print_response(errio::IO, response, backend::Union{REPLBackendRef,Nothi
         try
             if val !== nothing && show_value
                 Base.sigatomic_end() # allow display to be interrupted
+                val_to_show = val
                 val2, iserr = if specialdisplay === nothing
                     # display calls may require being run on the main thread
                     call_on_backend(backend) do
-                        __repl_entry_display(val)
+                        __repl_entry_display(val_to_show)
                     end
                 else
                     call_on_backend(backend) do
-                        __repl_entry_display(specialdisplay, val)
+                        __repl_entry_display(specialdisplay, val_to_show)
                     end
                 end
                 Base.sigatomic_begin()
@@ -675,21 +676,23 @@ end
 """
 function run_repl(repl::AbstractREPL, @nospecialize(consumer = x -> nothing); backend_on_current_task::Bool = true, backend = REPLBackend())
     backend_ref = REPLBackendRef(backend)
-    cleanup = @task try
+    get_module = () -> Base.active_module(repl)
+    cleanup_task(backend_ref, t) = @task try
             destroy(backend_ref, t)
         catch e
             Core.print(Core.stderr, "\nINTERNAL ERROR: ")
             Core.println(Core.stderr, e)
             Core.println(Core.stderr, catch_backtrace())
         end
-    get_module = () -> Base.active_module(repl)
     if backend_on_current_task
         t = @async run_frontend(repl, backend_ref)
+        cleanup = cleanup_task(backend_ref, t)
         errormonitor(t)
         Base._wait2(t, cleanup)
         start_repl_backend(backend, consumer; get_module)
     else
         t = @async start_repl_backend(backend, consumer; get_module)
+        cleanup = cleanup_task(backend_ref, t)
         errormonitor(t)
         Base._wait2(t, cleanup)
         run_frontend(repl, backend_ref)
@@ -1192,9 +1195,10 @@ function mode_keymap(julia_prompt::Prompt)
     AnyDict(
     '\b' => function (s::MIState,o...)
         if isempty(s) || position(LineEdit.buffer(s)) == 0
-            buf = copy(LineEdit.buffer(s))
-            transition(s, julia_prompt) do
-                LineEdit.state(s, julia_prompt).input_buffer = buf
+            let buf = copy(LineEdit.buffer(s))
+                transition(s, julia_prompt) do
+                    LineEdit.state(s, julia_prompt).input_buffer = buf
+                end
             end
         else
             buf = LineEdit.buffer(s)
@@ -1333,9 +1337,10 @@ function setup_interface(
                     for mode in repl.interface.modes
                         if mode isa LineEdit.Prompt && mode.complete isa REPLExt.PkgCompletionProvider
                             # pkg mode
-                            buf = copy(LineEdit.buffer(s))
-                            transition(s, mode) do
-                                LineEdit.state(s, mode).input_buffer = buf
+                            let buf = copy(LineEdit.buffer(s))
+                                transition(s, mode) do
+                                    LineEdit.state(s, mode).input_buffer = buf
+                                end
                             end
                         end
                     end
@@ -1391,9 +1396,10 @@ function setup_interface(
     repl_keymap = AnyDict(
         ';' => function (s::MIState,o...)
             if isempty(s) || position(LineEdit.buffer(s)) == 0
-                buf = copy(LineEdit.buffer(s))
-                transition(s, shell_mode) do
-                    LineEdit.state(s, shell_mode).input_buffer = buf
+                let buf = copy(LineEdit.buffer(s))
+                    transition(s, shell_mode) do
+                        LineEdit.state(s, shell_mode).input_buffer = buf
+                    end
                 end
             else
                 edit_insert(s, ';')
@@ -1402,9 +1408,10 @@ function setup_interface(
         end,
         '?' => function (s::MIState,o...)
             if isempty(s) || position(LineEdit.buffer(s)) == 0
-                buf = copy(LineEdit.buffer(s))
-                transition(s, help_mode) do
-                    LineEdit.state(s, help_mode).input_buffer = buf
+                let buf = copy(LineEdit.buffer(s))
+                    transition(s, help_mode) do
+                        LineEdit.state(s, help_mode).input_buffer = buf
+                    end
                 end
             else
                 edit_insert(s, '?')
@@ -1413,9 +1420,10 @@ function setup_interface(
         end,
         ']' => function (s::MIState,o...)
             if isempty(s) || position(LineEdit.buffer(s)) == 0
-                buf = copy(LineEdit.buffer(s))
-                transition(s, dummy_pkg_mode) do
-                    LineEdit.state(s, dummy_pkg_mode).input_buffer = buf
+                let buf = copy(LineEdit.buffer(s))
+                    transition(s, dummy_pkg_mode) do
+                        LineEdit.state(s, dummy_pkg_mode).input_buffer = buf
+                    end
                 end
                 # load Pkg on another thread if available so that typing in the dummy Pkg prompt
                 # isn't blocked, but instruct the main REPL task to do the transition via s.async_channel
@@ -1427,9 +1435,10 @@ function setup_interface(
                                 LineEdit.mode(s) === dummy_pkg_mode || return :ok
                                 for mode in repl.interface.modes
                                     if mode isa LineEdit.Prompt && mode.complete isa REPLExt.PkgCompletionProvider
-                                        buf = copy(LineEdit.buffer(s))
-                                        transition(s, mode) do
-                                            LineEdit.state(s, mode).input_buffer = buf
+                                        let buf = copy(LineEdit.buffer(s))
+                                            transition(s, mode) do
+                                                LineEdit.state(s, mode).input_buffer = buf
+                                            end
                                         end
                                         if !isempty(s)
                                             @invokelatest(LineEdit.check_show_hint(s))

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -210,14 +210,15 @@ function complete_symbol!(suggestions::Vector{Completion},
     end
 
     if @isdefined(mod) # lookup names available within the module
-        let modname = nameof(mod),
-            is_main = mod===Main
+        let mod_for_check = mod,
+            modname = nameof(mod_for_check),
+            is_main = mod_for_check === Main
             append_filtered_mod_names!(suggestions, mod, name, complete_internal_only) do s::Symbol
-                if Base.isdeprecated(mod, s)
+                if Base.isdeprecated(mod_for_check, s)
                     return false
                 elseif s === modname
                     return false # exclude `Main.Main.Main`, etc.
-                elseif complete_modules_only && !completes_module(mod, s)
+                elseif complete_modules_only && !completes_module(mod_for_check, s)
                     return false
                 elseif is_main && s === :MainInclude
                     return false
@@ -1384,9 +1385,10 @@ function complete_path_string(path, hint::Bool=false;
 
     # Expand '~' if the user hits TAB on a path ending in '/'.
     expanded && (hint || path != dir * "/") && (dir = contractuser(dir))
+    local dir_for_paths = dir
 
     map!(paths) do c::PathCompletion
-        p = joinpath_withsep(dir, c.path; dirsep)
+        p = joinpath_withsep(dir_for_paths, c.path; dirsep)
         PathCompletion(escape(p))
     end
     return sort!(paths, by=p->p.path), success

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -530,26 +530,27 @@ function repl_latex(io::IO, s0::String)
         print(io, "\"")
         printstyled(io, s, color=:cyan)
         print(io, "\" can be typed by ")
-        state::Char = '\0'
+        s_to_print = s
         with_output_color(:cyan, io) do io
-            for c in s
+            state::Char = '\0'
+            for c in s_to_print
                 cstr = string(c)
                 if haskey(symbols_latex, cstr)
-                    latex = symbols_latex[cstr]
-                    if length(latex) == 3 && latex[2] in ('^','_')
+                    latex_symbol = symbols_latex[cstr]
+                    if length(latex_symbol) == 3 && latex_symbol[2] in ('^','_')
                         # coalesce runs of sub/superscripts
-                        if state != latex[2]
+                        if state != latex_symbol[2]
                             '\0' != state && print(io, "<tab>")
-                            print(io, latex[1:2])
-                            state = latex[2]
+                            print(io, latex_symbol[1:2])
+                            state = latex_symbol[2]
                         end
-                        print(io, latex[3])
+                        print(io, latex_symbol[3])
                     else
                         if '\0' != state
                             print(io, "<tab>")
                             state = '\0'
                         end
-                        print(io, latex, "<tab>")
+                        print(io, latex_symbol, "<tab>")
                     end
                 else
                     if '\0' != state
@@ -600,13 +601,14 @@ function _repl(x, brief::Bool=true, mod::Module=Main, internal_accesses::Union{N
                     if kwarg isa Symbol
                         kwarg = :($kwarg::Any)
                     elseif isexpr(kwarg, :kw)
-                        lhs = kwarg.args[1]
-                        rhs = kwarg.args[2]
-                        if lhs isa Symbol
-                            if rhs isa Symbol
-                                kwarg.args[1] = :($lhs::(@isdefined($rhs) ? typeof($rhs) : Any))
-                            else
-                                kwarg.args[1] = :($lhs::typeof($rhs))
+                        let kw_lhs = kwarg.args[1],
+                            kw_rhs = kwarg.args[2]
+                            if kw_lhs isa Symbol
+                                if kw_rhs isa Symbol
+                                    kwarg.args[1] = :($kw_lhs::(@isdefined($kw_rhs) ? typeof($kw_rhs) : Any))
+                                else
+                                    kwarg.args[1] = :($kw_lhs::typeof($kw_rhs))
+                                end
                             end
                         end
                     end
@@ -616,13 +618,13 @@ function _repl(x, brief::Bool=true, mod::Module=Main, internal_accesses::Union{N
                 if kwargs === nothing
                     kwargs = Any[]
                 end
-                lhs = arg.args[1]
-                rhs = arg.args[2]
-                if lhs isa Symbol
-                    if rhs isa Symbol
-                        arg.args[1] = :($lhs::(@isdefined($rhs) ? typeof($rhs) : Any))
+                arg_lhs = arg.args[1]
+                arg_rhs = arg.args[2]
+                if arg_lhs isa Symbol
+                    if arg_rhs isa Symbol
+                        arg.args[1] = :($arg_lhs::(@isdefined($arg_rhs) ? typeof($arg_rhs) : Any))
                     else
-                        arg.args[1] = :($lhs::typeof($rhs))
+                        arg.args[1] = :($arg_lhs::typeof($arg_rhs))
                     end
                 end
                 push!(kwargs, arg)


### PR DESCRIPTION
Various strategies:

- `let` wrapping
- introducing new single assignment variables
- renaming variables to avoid accidental name collision (or using `local`).

Part of #60479 