### PR TITLE
Remove `jl_gc_external_obj_hdr_size`

### DIFF
--- a/src/gc-mmtk.c
+++ b/src/gc-mmtk.c
@@ -1191,11 +1191,6 @@ void jl_gc_debug_fprint_status(ios_t *s) JL_NOTSAFEPOINT
                     pool_count + big_count, pool_count, big_count, gc_num.pause);
 }
 
-JL_DLLEXPORT size_t jl_gc_external_obj_hdr_size(void)
-{
-    return sizeof(bigval_t);
-}
-
 void jl_print_gc_stats(JL_STREAM *s)
 {
 }

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -4132,11 +4132,6 @@ JL_DLLEXPORT size_t jl_gc_max_internal_obj_size(void)
     return GC_MAX_SZCLASS;
 }
 
-JL_DLLEXPORT size_t jl_gc_external_obj_hdr_size(void)
-{
-    return sizeof(bigval_t);
-}
-
 JL_DLLEXPORT void jl_gc_schedule_foreign_sweepfunc(jl_ptls_t ptls, jl_value_t *obj)
 {
     arraylist_push(&ptls->gc_tls.sweep_objs, obj);

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -144,7 +144,6 @@
     XX(jl_gc_enable) \
     XX(jl_gc_enable_conservative_gc_support) \
     XX(jl_gc_enable_finalizers) \
-    XX(jl_gc_external_obj_hdr_size) \
     XX(jl_gc_find_taggedvalue_pool) \
     XX(jl_gc_get_total_bytes) \
     XX(jl_gc_get_max_memory) \

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -63,7 +63,6 @@ JL_DLLEXPORT int jl_reinit_foreign_type(
 JL_DLLEXPORT int jl_is_foreign_type(jl_datatype_t *dt) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT size_t jl_gc_max_internal_obj_size(void) JL_NOTSAFEPOINT;
-JL_DLLEXPORT size_t jl_gc_external_obj_hdr_size(void) JL_NOTSAFEPOINT;
 
 // Field layout descriptor for custom types that do
 // not fit Julia layout conventions. This is associated with

--- a/test/gcext/gcext.c
+++ b/test/gcext/gcext.c
@@ -219,7 +219,6 @@ static uint64_t xorshift_rng(void)
 }
 
 static treap_t *bigvals;
-static size_t bigval_startoffset;
 
 // Hooks to allocate and free external objects (bigval_t's).
 
@@ -649,8 +648,6 @@ int main()
             module,
             jl_symbol("StackDataLarge"),
             (jl_value_t *)datatype_stack_external);
-    // Remember the offset of external objects
-    bigval_startoffset = jl_gc_external_obj_hdr_size();
     // Run the actual tests
     checked_eval_string(
             "let dir = dirname(unsafe_string(Base.JLOptions().julia_bin))\n"


### PR DESCRIPTION
This is no longer needed for gcext in GAP.jl. I am not aware of anyone else using this.