### PR TITLE
Improve rendering Markdown lists in a terminal

### DIFF
--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -71,7 +71,6 @@ function term(io::IO, f::Footnote, columns)
 end
 
 const _list_bullets = ("• ", "– ", "▪ ")
-const _bullet_width = 2  # all bullets must have the same "length"
 
 function term(io::IO, md::List, columns, depth::Int = 1)
     dterm(io, md, columns, _depth)      = term(io, md, columns)
@@ -103,7 +102,7 @@ function term(io::IO, md::List, columns, depth::Int = 1)
              for line in Iterators.filter(!isempty, lines)),
             init=if isempty(lines) 0 else length(first(lines)) end)
         for (l, line) in enumerate(lines)
-            l > 1 && print(io, ' '^(margin + _bullet_width))
+            l > 1 && print(io, ' '^(margin + length(bullet)))
             !isempty(line) && print(io, line[common_indent+1:end])
             l < length(lines) && println(io)
         end

--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -77,7 +77,7 @@ function term(io::IO, md::List, columns, depth::Int = 1)
     dterm(io, md::List, columns, depth) = term(io, md, columns, depth)
     for (i, point) in enumerate(md.items)
         bullet = if isordered(md)
-            string(lpad(i + md.ordered - 1, ndigits(length(md.items))), ". ")
+            string(lpad(i + md.ordered - 1, ndigits(length(md.items) + md.ordered - 1)), ". ")
         elseif depth == 1
             first(_list_bullets)
         else

--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -70,7 +70,8 @@ function term(io::IO, f::Footnote, columns)
     end
 end
 
-const _list_bullets = ("•  ", "–  ", "▪  ")
+const _list_bullets = ("• ", "– ", "▪ ")
+const _bullet_width = 2  # all bullets must have the same "length"
 
 function term(io::IO, md::List, columns, depth::Int = 1)
     dterm(io, md, columns, _depth)      = term(io, md, columns)
@@ -83,7 +84,7 @@ function term(io::IO, md::List, columns, depth::Int = 1)
         else
             _list_bullets[2 + mod(depth, length(_list_bullets) - 1)]
         end
-        print(io, ' '^ifelse(depth == 1, 2margin, 2*(depth-1)), styled"{markdown_list:$bullet}")
+        print(io, ' '^margin, styled"{markdown_list:$bullet}")
         buf = AnnotatedIOBuffer()
         if point isa Vector && !isempty(point)
             for (i, elt) in enumerate(point[1:end-1])
@@ -102,7 +103,7 @@ function term(io::IO, md::List, columns, depth::Int = 1)
              for line in Iterators.filter(!isempty, lines)),
             init=if isempty(lines) 0 else length(first(lines)) end)
         for (l, line) in enumerate(lines)
-            l > 1 && print(io, ' '^ifelse(depth == 1, 2margin + 3, 3))
+            l > 1 && print(io, ' '^(margin + _bullet_width))
             !isempty(line) && print(io, line[common_indent+1:end])
             l < length(lines) && println(io)
         end

--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -75,7 +75,8 @@ const _list_bullets = ("• ", "– ", "▪ ")
 function term(io::IO, md::List, columns, depth::Int = 1)
     dterm(io, md, columns, _depth)      = term(io, md, columns)
     dterm(io, md::List, columns, depth) = term(io, md, columns, depth)
-    for (i, point) in enumerate(md.items)
+
+    function make_bullet(i::Int)
         bullet = if isordered(md)
             string(lpad(i + md.ordered - 1, ndigits(length(md.items) + md.ordered - 1)), ". ")
         elseif depth == 1
@@ -83,17 +84,26 @@ function term(io::IO, md::List, columns, depth::Int = 1)
         else
             _list_bullets[2 + mod(depth, length(_list_bullets) - 1)]
         end
+    end
+
+    # adjust column count to ensure word wrap works correctly; the last
+    # label will be the widest (for ordered lists; for unordered lists they
+    # are all the same anyway)
+    columns -= length(make_bullet(length(md.items)))
+
+    for (i, point) in enumerate(md.items)
+        bullet = make_bullet(i)
         print(io, ' '^margin, styled"{markdown_list:$bullet}")
         buf = AnnotatedIOBuffer()
         if point isa Vector && !isempty(point)
             for (i, elt) in enumerate(point[1:end-1])
-                dterm(buf, elt, columns - 10, depth + 1)
+                dterm(buf, elt, columns, depth + 1)
                 println(buf)
                 (!(point[i+1] isa List) || point[i+1].loose) && println(buf)
             end
-            dterm(buf, point[end], columns - 10, depth + 1)
+            dterm(buf, point[end], columns, depth + 1)
         else
-            dterm(buf, point, columns - 10, depth + 1)
+            dterm(buf, point, columns, depth + 1)
         end
         content = read(seekstart(buf), AnnotatedString)
         lines = split(rstrip(content), '\n')

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1406,3 +1406,45 @@ end
 @testset "Lazy Strings" begin
     @test Markdown.parse(lazy"foo") == Markdown.parse("foo")
 end
+
+@testset "#40508: terminal rendering of nested lists, with hard breaks" begin
+    m = md"""
+    Before the list:
+    - top level\
+      with an extra line
+      - second level\
+        again with an extra line
+        - third level\
+          yet again with an extra line
+          - fourth level\
+            and another extra line
+            - fifth level\
+              final extra line
+    - back to top level
+    """
+
+    # check the terminal output
+
+    expected = """
+      Before the list:
+
+      • top level
+        with an extra line
+        – second level
+          again with an extra line
+          ▪ third level
+            yet again with an extra line
+            – fourth level
+              and another extra line
+              ▪ fifth level
+                final extra line
+      • back to top level
+    """
+
+    io = IOBuffer()
+    show(io, "text/plain", m)
+    println(io)
+    actual = String(take!(io))
+
+    @test expected == actual
+end

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1441,10 +1441,7 @@ end
       • back to top level
     """
 
-    io = IOBuffer()
-    show(io, "text/plain", m)
-    println(io)
-    actual = String(take!(io))
+    actual = sprint(show, MIME("text/plain"), m) * "\n"
 
     @test expected == actual
 end

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1408,8 +1408,11 @@ end
 end
 
 @testset "#40508: terminal rendering of nested lists, with hard breaks" begin
+    #
+    # Test an unordered list.
+    #
     m = md"""
-    Before the list:
+    An unordered list:
     - top level\
       with an extra line
       - second level\
@@ -1423,10 +1426,8 @@ end
     - back to top level
     """
 
-    # check the terminal output
-
     expected = """
-      Before the list:
+      An unordered list:
 
       • top level
         with an extra line
@@ -1442,6 +1443,64 @@ end
     """
 
     actual = sprint(show, MIME("text/plain"), m) * "\n"
+    @test expected == actual
 
+    #
+    # Test an ordered list. These behave differently if the number of list
+    # entries increases to another power of ten. For example, when going from
+    # 9 to 10 list entries. We test this here.
+    #
+    m = md"""
+    An unordered list:
+    1. top level\
+       with an extra line
+       1. second level\
+          again with an extra line
+          1. third level\
+             yet again with an extra line
+             1. fourth level\
+                and another extra line
+                1. fifth level\
+                   final extra line
+          1. more third level
+          1. more third level
+          1. more third level
+          1. more third level
+          1. more third level
+          1. more third level
+          1. more third level
+          1. more third level
+          1. more third level\
+             with an extra line
+    1. back to top level
+    """
+
+    expected = """
+      An unordered list:
+
+      1. top level
+         with an extra line
+         1. second level
+            again with an extra line
+             1. third level
+                yet again with an extra line
+                1. fourth level
+                   and another extra line
+                   1. fifth level
+                      final extra line
+             2. more third level
+             3. more third level
+             4. more third level
+             5. more third level
+             6. more third level
+             7. more third level
+             8. more third level
+             9. more third level
+            10. more third level
+                with an extra line
+      2. back to top level
+    """
+
+    actual = sprint(show, MIME("text/plain"), m) * "\n"
     @test expected == actual
 end

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1455,9 +1455,9 @@ end
               ▪ fifth level
                 final extra line
       • back to top level
-    """
+    """ |> chomp
 
-    actual = sprint(show, MIME("text/plain"), m) * "\n"
+    actual = sprint(show, MIME("text/plain"), m)
     @test expected == actual
 
     #
@@ -1471,22 +1471,14 @@ end
        with an extra line
        1. second level\
           again with an extra line
-          1. third level\
-             yet again with an extra line
-             1. fourth level\
-                and another extra line
-                1. fifth level\
-                   final extra line
-          1. more third level
-          1. more third level
-          1. more third level
-          1. more third level
-          1. more third level
-          1. more third level
-          1. more third level
-          1. more third level
-          1. more third level\
-             with an extra line
+           999. third level\
+                yet again with an extra line
+                1. fourth level\
+                   and another extra line
+                   1. fifth level\
+                      final extra line
+          1000. more third level\
+                with an extra line
     1. back to top level
     """
 
@@ -1497,25 +1489,17 @@ end
          with an extra line
          1. second level
             again with an extra line
-             1. third level
-                yet again with an extra line
-                1. fourth level
-                   and another extra line
-                   1. fifth level
-                      final extra line
-             2. more third level
-             3. more third level
-             4. more third level
-             5. more third level
-             6. more third level
-             7. more third level
-             8. more third level
-             9. more third level
-            10. more third level
-                with an extra line
+             999. third level
+                  yet again with an extra line
+                  1. fourth level
+                     and another extra line
+                     1. fifth level
+                        final extra line
+            1000. more third level
+                  with an extra line
       2. back to top level
-    """
+    """ |> chomp
 
-    actual = sprint(show, MIME("text/plain"), m) * "\n"
+    actual = sprint(show, MIME("text/plain"), m)
     @test expected == actual
 end

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -377,7 +377,22 @@ table = md"""
 # mime output
 let out =
     @test sprint(show, "text/plain", book) ==
-        "  Title\n  ≡≡≡≡≡\n\n  Some discussion\n\n  │  A quote\n\n  Section important\n  =================\n\n  Some bolded\n\n    •  list1\n    •  list2"
+        """
+          Title
+          ≡≡≡≡≡
+
+          Some discussion
+
+          │  A quote
+
+          Section important
+          =================
+
+          Some bolded
+
+          • list1
+          • list2
+        """ |> chomp
     @test sprint(show, "text/plain", md"#") == "" # edge case of empty header
     @test sprint(show, "text/markdown", book) ==
         """


### PR DESCRIPTION
This changes how Markdown lists are rendered in the Terminal:
- the list is no longer indented by two spaces
- the bullet points are now followed by a single space, not two
- extra lines in an entry are indented correctly across all levels
- fix printing / indentation for ordered lists starting at an index other than 1: the padding for the labels was being computed incorrectly
- fix word wrap with a given column limit

Consider this Markdown input:
```md
Before the list:
- top level\
  with an extra line
  - second level\
    again with an extra line
    - third level\
      yet again with an extra line
      - fourth level\
        and another extra line
        - fifth level\
          final extra line
- back to top level
```

Then with Julia master it renders in the terminal like this:
```
  Before the list:

    •  top level
       with an extra line
       –  second level
        again with an extra line
          ▪  third level
         yet again with an extra line
             –  fourth level
          and another extra line
                ▪  fifth level
           final extra line
    •  back to top level
```

With this PR:
```
  Before the list:

  • top level
    with an extra line
    – second level
      again with an extra line
      ▪ third level
        yet again with an extra line
        – fourth level
          and another extra line
          ▪ fifth level
            final extra line
  • back to top level
```

Resolves #40508, resolves #58514