### PR TITLE
Markdown: support Linebreak in LaTeX output

### DIFF
--- a/stdlib/Markdown/src/render/latex.jl
+++ b/stdlib/Markdown/src/render/latex.jl
@@ -132,6 +132,10 @@ function latexinline(io::IO, md::Italic)
     end
 end
 
+function latexinline(io::IO, br::LineBreak)
+    println(io, "\\\\")
+end
+
 function latexinline(io::IO, md::Image)
     wrapblock(io, "figure") do
         println(io, "\\centering")

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1291,6 +1291,52 @@ end
     @test sprint(show, MIME("text/plain"), s) == "  Misc:\n  - line\n   break"
 end
 
+@testset "linebreaks in lists" begin
+    # similar to the preceding test, but unlike that, actually uses a Markdown list
+    # (the prior example might look like it uses a list, but it doesn't)
+    s = @md_str """
+       Misc:\\
+       stuff
+       - line\\
+         break
+       """
+    @test sprint(show, MIME("text/plain"), s) * "\n" ==
+            raw"""
+              Misc:
+              stuff
+
+                •  line
+                   break
+            """
+    @test Markdown.plain(s) ==
+            raw"""
+            Misc:
+            stuff
+
+              * line
+                break
+            """
+    @test Markdown.html(s) ==
+            raw"""
+            <p>Misc:<br />stuff</p>
+            <ul>
+            <li><p>line<br />break</p>
+            </li>
+            </ul>
+            """
+    @test Markdown.latex(s) ==
+            raw"""
+            Misc:\\
+            stuff
+
+            \begin{itemize}
+            \item line\\
+            break
+
+            \end{itemize}
+            """
+end
+
 @testset "pullrequest #57664: en_or_em_dash" begin
     # Test that two hyphens (--) is parsed as en dash (–)
     # and three hyphens (---) is parsed as em dash (—)


### PR DESCRIPTION
Found while working on PR #60519. As such, the two PRs interact: the test added in this PR here will need to be adjusted for PR #60519, so these two PRs should *not* be merged simultaneously, otherwise CI will start failing. Rather, if one is merged, then the other needs to be adapted accordingly. I'll be happy to take care of that.