### PR TITLE
Markdown: fix interpolation inside `BlockQuote`

### DIFF
--- a/stdlib/Markdown/src/Julia/interp.jl
+++ b/stdlib/Markdown/src/Julia/interp.jl
@@ -46,7 +46,7 @@ toexpr(x) = x
 toexpr(xs::Union{Vector{Any},Vector{Vector{Any}}}) =
     Expr(:call, GlobalRef(Base,:getindex), Any, mapany(toexpr, xs)...)
 
-for T in Any[MD, Paragraph, Header, Link, Bold, Italic, Footnote, Admonition]
+for T in Any[MD, Paragraph, Header, Link, Bold, Italic, Footnote, Admonition, BlockQuote]
     @eval function toexpr(md::$T)
         Expr(:call, typeof(md), $(map(x->:(toexpr(md.$x)), fieldnames(Base.unwrap_unionall(T)))...))
     end

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -502,8 +502,8 @@ sum_ref = md"Behaves like $(ref(sum))"
 @test plain(sum_ref) == "Behaves like sum (see Julia docs)\n"
 @test html(sum_ref) == "<p>Behaves like sum &#40;see Julia docs&#41;</p>\n"
 
-# JuliaLang/julia#59783
-let x = 1,
+@testset "JuliaLang/julia#59783 and #53362" begin
+    x = 1
     result = md"""
     $x
 
@@ -511,7 +511,9 @@ let x = 1,
 
     !!! note
     $x
-    """,
+
+    > $x
+    """
     expected = """
     1
 
@@ -522,6 +524,9 @@ let x = 1,
 
 
     1
+
+    > 1
+
     """
     @test plain(result) == expected
 end


### PR DESCRIPTION
Resolves #53362 -- the original issue there was actually resolved by PR #59806 and I just adapted that fix to also address the later on added variant involving block quotes.