### PR TITLE
Move thunk and export evaluation out of `jl_toplevel_eval_flex`

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8494,13 +8494,8 @@ static jl_llvm_functions_t
     }
     else if ((jl_value_t*)src->debuginfo != jl_nothing) {
         // look for the file and line info of the original start of this block, as reported by lowering
-        jl_debuginfo_t *debuginfo = src->debuginfo;
-        while ((jl_value_t*)debuginfo->linetable != jl_nothing)
-            debuginfo = debuginfo->linetable;
-        ctx.file = jl_debuginfo_file(debuginfo);
-        struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo->codelocs, 0);
-        ctx.line = lineidx.line;
-        toplineno = std::max((int32_t)0, lineidx.line);
+        ctx.file = jl_debuginfo_firstline(src->debuginfo, &toplineno);
+        toplineno = std::max(0, toplineno);
     }
     if (ctx.file.empty())
         ctx.file = "<missing>";

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -460,6 +460,7 @@
     XX(jl_too_many_args) \
     XX(jl_toplevel_eval) \
     XX(jl_toplevel_eval_in) \
+    XX(jl_eval_thunk) \
     XX(jl_try_substrtod) \
     XX(jl_try_substrtof) \
     XX(jl_tty_set_mode) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -315,6 +315,7 @@
     XX(jl_module_names) \
     XX(jl_module_parent) \
     XX(jl_module_getloc) \
+    XX(jl_module_public) \
     XX(jl_module_public_p) \
     XX(jl_module_using) \
     XX(jl_module_usings) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -2048,7 +2048,7 @@ JL_DLLEXPORT jl_binding_partition_t *jl_declare_constant_val2(jl_binding_t *b JL
 JL_DLLEXPORT void jl_module_import(jl_task_t *ct, jl_module_t *to, jl_module_t *from, jl_sym_t *asname, jl_sym_t *s, int explici);
 JL_DLLEXPORT void jl_import_module(jl_task_t *ct, jl_module_t *m, jl_module_t *import, jl_sym_t *asname);
 JL_DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from, size_t flags);
-int jl_module_public_(jl_module_t *from, jl_sym_t *s, int exported, size_t new_world);
+JL_DLLEXPORT void jl_module_public(jl_module_t *from, jl_value_t **symbols, size_t nsymbols, int exported);
 JL_DLLEXPORT int jl_is_imported(jl_module_t *m, jl_sym_t *s);
 JL_DLLEXPORT int jl_module_exports_p(jl_module_t *m, jl_sym_t *var);
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -904,7 +904,7 @@ JL_DLLEXPORT void jl_declare_global(jl_module_t *m, jl_value_t *arg, jl_value_t 
 JL_DLLEXPORT jl_binding_partition_t *jl_declare_constant_val3(jl_binding_t *b JL_ROOTING_ARGUMENT, jl_module_t *mod, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT JL_MAYBE_UNROOTED, enum jl_partition_kind, size_t new_world) JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int expanded, const char **toplevel_filename, int *toplevel_lineno);
 JL_DLLEXPORT jl_value_t *jl_eval_thunk(jl_module_t *JL_NONNULL m, jl_code_info_t *thk, int fast);
-
+int jl_module_public_(jl_module_t *from, jl_sym_t *s, int exported, size_t new_world);
 void jl_module_initial_using(jl_module_t *to, jl_module_t *from);
 STATIC_INLINE struct _jl_module_using *module_usings_getidx(jl_module_t *m JL_PROPAGATES_ROOT, size_t i) JL_NOTSAFEPOINT;
 STATIC_INLINE jl_module_t *module_usings_getmod(jl_module_t *m JL_PROPAGATES_ROOT, size_t i) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -903,6 +903,7 @@ void jl_binding_set_type(jl_binding_t *b, jl_module_t *mod, jl_sym_t *sym, jl_va
 JL_DLLEXPORT void jl_declare_global(jl_module_t *m, jl_value_t *arg, jl_value_t *set_type, int strong);
 JL_DLLEXPORT jl_binding_partition_t *jl_declare_constant_val3(jl_binding_t *b JL_ROOTING_ARGUMENT, jl_module_t *mod, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT JL_MAYBE_UNROOTED, enum jl_partition_kind, size_t new_world) JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int expanded, const char **toplevel_filename, int *toplevel_lineno);
+JL_DLLEXPORT jl_value_t *jl_eval_thunk(jl_module_t *JL_NONNULL m, jl_code_info_t *thk, int fast);
 
 void jl_module_initial_using(jl_module_t *to, jl_module_t *from);
 STATIC_INLINE struct _jl_module_using *module_usings_getidx(jl_module_t *m JL_PROPAGATES_ROOT, size_t i) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -749,7 +749,7 @@ STATIC_INLINE jl_method_instance_t *jl_get_ci_mi(jl_code_instance_t *ci JL_PROPA
     return (jl_method_instance_t*)def;
 }
 
-JL_DLLEXPORT const char *jl_debuginfo_file(jl_debuginfo_t *debuginfo) JL_NOTSAFEPOINT;
+JL_DLLEXPORT const char *jl_debuginfo_firstline(jl_debuginfo_t *debuginfo, int *line) JL_NOTSAFEPOINT;
 JL_DLLEXPORT const char *jl_debuginfo_file1(jl_debuginfo_t *debuginfo) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_module_t *jl_debuginfo_module1(jl_value_t *debuginfo_def) JL_NOTSAFEPOINT;
 JL_DLLEXPORT const char *jl_debuginfo_name(jl_value_t *func) JL_NOTSAFEPOINT;

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -792,12 +792,17 @@ const char *jl_debuginfo_file1(jl_debuginfo_t *debuginfo)
     return "<unknown>";
 }
 
-const char *jl_debuginfo_file(jl_debuginfo_t *debuginfo)
+// File name and line number of first line
+const char *jl_debuginfo_firstline(jl_debuginfo_t *debuginfo, int* line)
 {
     jl_debuginfo_t *linetable = debuginfo->linetable;
     while ((jl_value_t*)linetable != jl_nothing) {
         debuginfo = linetable;
         linetable = debuginfo->linetable;
+    }
+    if (line) {
+        struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo->codelocs, 0);
+        *line = lineidx.line;
     }
     return jl_debuginfo_file1(debuginfo);
 }
@@ -849,7 +854,7 @@ static void jl_fprint_debugloc(ios_t *s, jl_debuginfo_t *debuginfo, jl_value_t *
         if (ip2 < 0) // set broken debug info to ignored
             ip2 = 0;
         const char *func_name = jl_debuginfo_name(func);
-        const char *file = jl_debuginfo_file(debuginfo);
+        const char *file = jl_debuginfo_firstline(debuginfo, NULL);
         jl_safe_fprint_codeloc(s, func_name, file, ip2, inlined);
     }
 }

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -665,30 +665,16 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval_flex(jl_module_t *JL_NONNULL m, jl_val
         return val;
     }
     else if (head == jl_export_sym || head == jl_public_sym) {
-        int exp = (head == jl_export_sym);
-        volatile int any_new = 0;
-        JL_LOCK(&world_counter_lock);
-        size_t new_world = jl_atomic_load_acquire(&jl_world_counter)+1;
-        JL_TRY {
-            for (size_t i = 0; i < jl_array_nrows(ex->args); i++) {
-                jl_sym_t *name = (jl_sym_t*)jl_array_ptr_ref(ex->args, i);
-                if (!jl_is_symbol(name))
-                    jl_eval_errorf(m, *toplevel_filename, *toplevel_lineno,
-                         exp ? "syntax: malformed \"export\" statement" :
-                               "syntax: malformed \"public\" statement");
-                if (jl_module_public_(m, name, exp, new_world))
-                    any_new = 1;
-            }
+        int exported = head == jl_export_sym;
+        for (size_t i = 0; i < jl_array_nrows(ex->args); i++) {
+            jl_sym_t *name = (jl_sym_t*)jl_array_ptr_ref(ex->args, i);
+            if (!jl_is_symbol(name))
+                jl_eval_errorf(m, *toplevel_filename, *toplevel_lineno,
+                     exported ? "syntax: malformed \"export\" statement" :
+                                "syntax: malformed \"public\" statement");
         }
-        JL_CATCH {
-            if (any_new)
-                jl_atomic_store_release(&jl_world_counter, new_world);
-            JL_UNLOCK(&world_counter_lock);
-            jl_rethrow();
-        }
-        if (any_new)
-            jl_atomic_store_release(&jl_world_counter, new_world);
-        JL_UNLOCK(&world_counter_lock);
+        jl_module_public(m, jl_array_data(ex->args, jl_value_t*),
+                         jl_array_len(ex->args), exported);
         JL_GC_POP();
         return jl_nothing;
     }

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -568,12 +568,14 @@ JL_DLLEXPORT jl_binding_partition_t *jl_declare_constant_val2(
     jl_binding_t *b, jl_module_t *mod, jl_sym_t *var, jl_value_t *val,
     enum jl_partition_kind constant_kind)
 {
+    JL_GC_PUSH1(&val);
     JL_LOCK(&world_counter_lock);
     size_t new_world = jl_atomic_load_relaxed(&jl_world_counter) + 1;
     jl_binding_partition_t *bpart = jl_declare_constant_val3(b, mod, var, val, constant_kind, new_world);
     if (jl_atomic_load_relaxed(&bpart->min_world) == new_world)
         jl_atomic_store_release(&jl_world_counter, new_world);
     JL_UNLOCK(&world_counter_lock);
+    JL_GC_POP();
     return bpart;
 }
 


### PR DESCRIPTION
Separate toplevel CodeInfo evaluation out of `jl_toplevel_eval_flex` into
`jl_eval_thunk` so that `CodeInfo` can become the basic unit of toplevel
evaluation rather than `Expr` and there's no need to construct an
`Expr(:thunk)`.

The latest world age set and restore now moves entirely into
jl_eval_thunk as jl_toplevel_eval_flex no longer modifies the task's
world age. (Note that the world age needs to be set in jl_eval_thunk before
the calls to jl_resolve_definition_effects_in_ir. Previously this happened
to work because the callers of jl_toplevel_eval_flex increment the world
age)

Also move public/export batching out of jl_toplevel_eval_flex
and into a C runtime function `jl_module_public` which can be called
without using eval and without constructing an Expr.

Both of these changes help with JuliaLowering integration and with
disentangling top level evaluation from Expr and from the code in
toplevel.c.