### PR TITLE
Add swapat! to Base with basic tests

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -215,9 +215,19 @@ String
      For arrays, this function requires at least Julia 1.2.
 """
 valtype(A::Type{<:AbstractArray}) = eltype(A)
-
 prevind(::AbstractArray, i::Integer) = Int(i)-1
 nextind(::AbstractArray, i::Integer) = Int(i)+1
+
+"""
+    swapat!(A, i, j)
+
+Swap the elements of array `A` at indices `i` and `j` in-place.
+"""
+@inline function swapat!(A::AbstractArray, i, j)
+    A[i], A[j] = A[j], A[i]
+    return A
+end
+
 
 
 """

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1057,6 +1057,17 @@ end
 @test nextind(zeros(2,3), CartesianIndex(2,1)) == CartesianIndex(1, 2)
 @test prevind(zeros(4), 2) == 1
 @test prevind(zeros(2,3), CartesianIndex(2,1)) == CartesianIndex(1, 1)
+@testset "swapat!" begin
+    A = [1, 2, 3]
+    swapat!(A, 1, 3)
+    @test A == [3, 2, 1]
+
+    B = reshape(1:4, 2, 2)
+    swapat!(B, 1, 4)
+    @test B[1] == 4
+    @test B[4] == 1
+end
+
 
 @testset "ImageCore #40" begin
     Base.convert(::Type{Array{T,n}}, a::Array{T,n}) where {T<:Number,n} = a


### PR DESCRIPTION
This PR adds a small utility function `swapat!` to Base for swapping two elements
of an array in-place.

-> Added `swapat!` implementation in `base/abstractarray.jl`
-> Added minimal tests for 1D and 2D arrays in `test/abstractarray.jl`

This is intended as a minimal, discussion-starting implementation.
