### PR TITLE
Tweak USDT provider to allow `WITH_DTRACE=1` build on macOS

### DIFF
--- a/contrib/dtrace/gc_all.d
+++ b/contrib/dtrace/gc_all.d
@@ -1,0 +1,33 @@
+BEGIN
+{
+    printf("Tracing Julia GC times... Hit Ctrl-C to end and print results.\n");
+}
+
+julia$target:::gc-begin
+{
+    time[pid] = timestamp;
+    start[pid] = timestamp;
+}
+
+julia$target:::gc-stop_the_world
+/start[pid]/
+{
+    @stop_the_world_usecs[pid] = quantize((timestamp - time[pid]) / 1000);
+    time[pid] = timestamp;
+}
+
+julia$target:::gc-end
+/start[pid]/
+{
+    @gc_total_usecs[pid] = quantize((timestamp - start[pid]) / 1000);
+    @gc_phase_usecs[pid] = quantize((timestamp - time[pid]) / 1000);
+    time[pid] = timestamp;
+    start[pid] = 0;
+}
+
+julia$target:::gc-finalizer
+/time[pid]/
+{
+    @finalizer[pid] = quantize((timestamp - time[pid]) / 1000);
+    time[pid] = 0;
+}

--- a/contrib/dtrace/rt_all.d
+++ b/contrib/dtrace/rt_all.d
@@ -1,0 +1,80 @@
+BEGIN
+{
+    printf("Tracing Julia Task events... Hit Ctrl-C to end.");
+}
+
+julia$target:::rt-run-task
+{
+    printf("Task running: %x", arg0);
+}
+
+julia$target:::rt-pause-task
+{
+    printf("Task pausing: %x", arg0);
+}
+
+julia$target:::rt-new-task
+{
+    printf("Task created: %x (Parent %x)", arg1, arg0);
+}
+
+julia$target:::rt-start-task
+{
+    printf("Task started: %x", arg0);
+}
+
+julia$target:::rt-finish-task
+{
+    printf("Task finished: %x", arg0);
+}
+
+julia$target:::rt-start-process-events
+{
+    printf("Task processing libuv events: %x", arg0);
+}
+
+julia$target:::rt-finish-process-events
+{
+    printf("Task processed libuv events: %x", arg0);
+}
+
+// unused in the runtime, so dtrace complains
+// julia$target:::rt-taskq-insert
+// {
+//     printf("Thread %x inserting task to multiq: %x", arg0, arg1);
+// }
+//
+// julia$target:::rt-taskq-get
+// {
+//     printf("Thread %x popped task from multiq: %x", arg0, arg1);
+// }
+
+julia$target:::rt-sleep-check-wake
+{
+    printf("Thread waking: %x (was sleeping?: %d)", arg0, arg1);
+}
+
+julia$target:::rt-sleep-check-wakeup
+{
+    printf("Thread wakeup: %x", arg0);
+}
+
+julia$target:::rt-sleep-check-sleep
+{
+    printf("Thread trying to sleep: %x", arg0);
+}
+
+julia$target:::rt-sleep-check-taskq-wake
+{
+    printf("Thread waking due to non-empty task queue: %x", arg0);
+}
+
+julia$target:::rt-sleep-check-task-wake
+{
+    printf("Thread waking due to popped task: %x", arg0);
+}
+
+julia$target:::rt-sleep-check-uv-wake
+{
+    printf("Thread waking due to libuv: %x", arg0);
+}

--- a/src/uprobes.d
+++ b/src/uprobes.d
@@ -1,5 +1,8 @@
 /* Julia DTrace provider */
 
+typedef struct { int dummy; } jl_task_t;
+typedef struct { int dummy; } jl_ptls_t;
+
 provider julia {
     probe gc__begin(int collection);
     probe gc__stop_the_world();

--- a/src/uprobes.d
+++ b/src/uprobes.d
@@ -1,5 +1,8 @@
 /* Julia DTrace provider */
 
+/* Work around dtrace bug: older versions (e.g. apple dtrace) require struct and
+ * translator definitions when compiling provider files, even though the
+ * definitions aren't used.  This bug is fixed in bpftrace/"dtrace 2.0". */
 typedef struct { int dummy; } jl_task_t;
 typedef struct { int dummy; } jl_ptls_t;
 


### PR DESCRIPTION
Our USDT provider and `JL_PROBE_*` infrastructure, which appears to be written for bpftrace, is also usable with macOS dtrace as long as we work around a [known dtrace bug](https://www.davepacheco.net/blog/2009/anatomy-of-a-dtrace-usdt-provider/#rough-edges) that many others have worked around in the [same silly way](https://github.com/search?q=language%3ADTrace+%22dummy%22&type=code).

We can't reuse the actual probe definitions in `contrib/bpftrace`, but those can be tweaked to work, e.g. https://gist.github.com/mlechu/8b4fd0125ca1b0b87be802f4ba03a5b4 (run with `sudo dtrace -s ./rt_gc.d -p $(pgrep -n julia)`; no need to disable SIP for these)