### PR TITLE
Add diagnostic hint for transpose/adjoint MethodErrors

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -327,6 +327,15 @@ function showerror(io::IO, ex::MethodError)
             print(io, "\nFor element-wise $nounf, use broadcasting with dot syntax: $first .$fstring $second")
         end
     end
+    # catch transpose and adjoint on arrays with unsupported element types
+    if f isa Function && (f === transpose || f === adjoint) && length(san_arg_types_param) == 1
+        # if the argument is not an array, it's likely an element type that doesn't support the operation
+        if !(san_arg_types_param[1] <: AbstractArray)
+            fname = f === transpose ? "transpose" : "adjoint"
+            print(io, "\n$fname is a linear-algebra operation that applies recursively to elements.")
+            print(io, "\nTo permute dimensions of an array, use permutedims.")
+        end
+    end
     if ft <: AbstractArray
         print(io, "\nIn case you're trying to index into the array, use square brackets [] instead of parentheses ().")
     end

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -442,6 +442,23 @@ let err_str
     @test occursin("For element-wise subtraction, use broadcasting with dot syntax: array .- scalar", err_str)
 end
 
+# Issue 39938 - transpose/adjoint hint for unsupported element types
+let err_str
+    struct NoTransposeType x::Int end
+    v = [NoTransposeType(1)]
+    err_str = @except_str transpose(v)[1,1] MethodError
+    @test occursin("MethodError: no method matching transpose(", err_str)
+    @test occursin("transpose is a linear-algebra operation that applies recursively to elements.", err_str)
+    @test occursin("To permute dimensions of an array, use permutedims.", err_str)
+
+    struct NoAdjointType x::Int end
+    v2 = [NoAdjointType(1)]
+    err_str = @except_str adjoint(v2)[1,1] MethodError
+    @test occursin("MethodError: no method matching adjoint(", err_str)
+    @test occursin("adjoint is a linear-algebra operation that applies recursively to elements.", err_str)
+    @test occursin("To permute dimensions of an array, use permutedims.", err_str)
+end
+
 import Core: String
 method_defs_lineno = @__LINE__() + 1
 String() = throw(ErrorException("1"))


### PR DESCRIPTION
### Summary  
Add a diagnostic hint for `MethodErrors` raised by `transpose` and `adjoint` when applied to arrays with unsupported element types, guiding users to use `permutedims` for dimension reordering.

### Changes  
- Add a diagnostic hint in `base/errorshow.jl` for `transpose` / `adjoint` `MethodErrors` on unsupported element types  
- Explain that these operations are linear-algebra operations applied recursively to elements  
- Suggest `permutedims` as the correct alternative for permuting dimensions  
- Add tests following the existing `errorshow.jl` error-hint testing pattern

### Testing  
Added tests verifying that:
- The original `MethodError` is preserved for both `transpose` and `adjoint`  
- The new diagnostic hint appears for element types without transpose/adjoint support

### Related Issues  
Fixes #39938
