### PR TITLE
Markdown: add strikethrough support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,11 @@ Standard library changes
 
 #### LinearAlgebra
 
+#### Markdown
+
+  * Strikethrough text via `~strike~` or `~~through~~` is now supported by the
+    Markdown parser. ([#60537])
+
 #### Profile
 
 #### Random

--- a/stdlib/Markdown/docs/src/index.md
+++ b/stdlib/Markdown/docs/src/index.md
@@ -28,6 +28,14 @@ Surround words with one asterisk, `*`, to display the enclosed text in italics.
 A paragraph containing an *italicized* word.
 ```
 
+### Strikethrough
+
+Surround words with one or two tildes, `~` or`~~`, to display the enclosed text with a strikethrough, or a line through it.
+
+```
+A paragraph containing a ~~struck~~ word.
+```
+
 ### Literals
 
 Surround text that should be displayed exactly as written with single backticks, ``` ` ``` .

--- a/stdlib/Markdown/src/Common/Common.jl
+++ b/stdlib/Markdown/src/Common/Common.jl
@@ -5,8 +5,12 @@ abstract type MarkdownElement end
 include("block.jl")
 include("inline.jl")
 
+
+
 @flavor common [list, indentcode, blockquote, admonition, footnote, hashheader, horizontalrule,
                 paragraph,
 
                 linebreak, escapes, inline_code,
-                asterisk_bold, underscore_bold, asterisk_italic, underscore_italic, image, footnote_link, link, autolink]
+                asterisk_bold, underscore_bold,
+                asterisk_italic, underscore_italic,
+                image, footnote_link, link, autolink]

--- a/stdlib/Markdown/src/Common/Common.jl
+++ b/stdlib/Markdown/src/Common/Common.jl
@@ -7,10 +7,11 @@ include("inline.jl")
 
 
 
-@flavor common [list, indentcode, blockquote, admonition, footnote, hashheader, horizontalrule,
-                paragraph,
+@flavor common [list, indentcode, blockquote, admonition, footnote, hashheader,
+                horizontalrule, paragraph,
 
-                linebreak, escapes, inline_code,
+                linebreak, escapes,
+                inline_code,
                 asterisk_bold, underscore_bold,
                 asterisk_italic, underscore_italic,
                 image, footnote_link, link, autolink]

--- a/stdlib/Markdown/src/Common/inline.jl
+++ b/stdlib/Markdown/src/Common/inline.jl
@@ -36,6 +36,22 @@ function underscore_bold(stream::IO, md::MD)
     return result === nothing ? nothing : Bold(parseinline(result, md))
 end
 
+mutable struct Strikethrough <: MarkdownElement
+    text
+end
+
+@trigger '~' ->
+function tilde_strikethrough(stream::IO, md::MD)
+    result = parse_inline_wrapper(stream, "~")
+    return result === nothing ? nothing : Strikethrough(parseinline(result, md))
+end
+
+@trigger '~' ->
+function double_tilde_strikethrough(stream::IO, md::MD)
+    result = parse_inline_wrapper(stream, "~~")
+    return result === nothing ? nothing : Strikethrough(parseinline(result, md))
+end
+
 # ––––
 # Code
 # ––––

--- a/stdlib/Markdown/src/GitHub/GitHub.jl
+++ b/stdlib/Markdown/src/GitHub/GitHub.jl
@@ -60,5 +60,7 @@ end
 @flavor github [list, indentcode, blockquote, admonition, footnote, fencedcode, hashheader,
                 github_table, github_paragraph,
 
-                linebreak, escapes, en_or_em_dash, inline_code, asterisk_bold,
-                underscore_bold, asterisk_italic, underscore_italic, image, footnote_link, link, autolink]
+                linebreak, escapes, en_or_em_dash, inline_code,
+                asterisk_bold, underscore_bold,
+                asterisk_italic, underscore_italic,
+                image, footnote_link, link, autolink]

--- a/stdlib/Markdown/src/GitHub/GitHub.jl
+++ b/stdlib/Markdown/src/GitHub/GitHub.jl
@@ -57,10 +57,11 @@ function github_paragraph(stream::IO, md::MD)
     return true
 end
 
-@flavor github [list, indentcode, blockquote, admonition, footnote, fencedcode, hashheader,
-                github_table, github_paragraph,
+@flavor github [list, indentcode, blockquote, admonition, footnote, hashheader,
+                fencedcode, github_table, github_paragraph,
 
-                linebreak, escapes, en_or_em_dash, inline_code,
+                linebreak, escapes,
+                en_or_em_dash, inline_code,
                 asterisk_bold, underscore_bold,
                 asterisk_italic, underscore_italic,
                 image, footnote_link, link, autolink]

--- a/stdlib/Markdown/src/GitHub/GitHub.jl
+++ b/stdlib/Markdown/src/GitHub/GitHub.jl
@@ -62,6 +62,7 @@ end
 
                 linebreak, escapes,
                 en_or_em_dash, inline_code,
+                double_tilde_strikethrough, tilde_strikethrough,
                 asterisk_bold, underscore_bold,
                 asterisk_italic, underscore_italic,
                 image, footnote_link, link, autolink]

--- a/stdlib/Markdown/src/Julia/Julia.jl
+++ b/stdlib/Markdown/src/Julia/Julia.jl
@@ -14,6 +14,7 @@ include("interp.jl")
                linebreak, escapes,
                tex, interp,
                en_or_em_dash, inline_code,
+               double_tilde_strikethrough, tilde_strikethrough,
                asterisk_bold, underscore_bold,
                asterisk_italic, underscore_italic,
                image, footnote_link, link, autolink]

--- a/stdlib/Markdown/src/Julia/Julia.jl
+++ b/stdlib/Markdown/src/Julia/Julia.jl
@@ -11,4 +11,6 @@ include("interp.jl")
                blockquote, admonition, footnote, github_table, horizontalrule, setextheader, paragraph,
 
                linebreak, escapes, tex, interp, en_or_em_dash, inline_code,
-               asterisk_bold, underscore_bold, asterisk_italic, underscore_italic, image, footnote_link, link, autolink]
+               asterisk_bold, underscore_bold,
+               asterisk_italic, underscore_italic,
+               image, footnote_link, link, autolink]

--- a/stdlib/Markdown/src/Julia/Julia.jl
+++ b/stdlib/Markdown/src/Julia/Julia.jl
@@ -7,10 +7,13 @@
 
 include("interp.jl")
 
-@flavor julia [blocktex, blockinterp, hashheader, list, indentcode, fencedcode,
-               blockquote, admonition, footnote, github_table, horizontalrule, setextheader, paragraph,
+@flavor julia [blocktex, blockinterp,
+               list, indentcode, blockquote, admonition, footnote, hashheader,
+               fencedcode, github_table, horizontalrule, setextheader, paragraph,
 
-               linebreak, escapes, tex, interp, en_or_em_dash, inline_code,
+               linebreak, escapes,
+               tex, interp,
+               en_or_em_dash, inline_code,
                asterisk_bold, underscore_bold,
                asterisk_italic, underscore_italic,
                image, footnote_link, link, autolink]

--- a/stdlib/Markdown/src/Julia/interp.jl
+++ b/stdlib/Markdown/src/Julia/interp.jl
@@ -46,7 +46,7 @@ toexpr(x) = x
 toexpr(xs::Union{Vector{Any},Vector{Vector{Any}}}) =
     Expr(:call, GlobalRef(Base,:getindex), Any, mapany(toexpr, xs)...)
 
-for T in Any[MD, Paragraph, Header, Link, Bold, Italic, Footnote, Admonition, BlockQuote]
+for T in Any[MD, Paragraph, Header, Link, Bold, Italic, Strikethrough, Footnote, Admonition, BlockQuote]
     @eval function toexpr(md::$T)
         Expr(:call, typeof(md), $(map(x->:(toexpr(md.$x)), fieldnames(Base.unwrap_unionall(T)))...))
     end

--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -148,6 +148,7 @@ if Base.generating_output()
     **bold text**
     *italicized text*
     ***bold and italicized text***
+    ~~strikethrough effect~~
     > blockquote
     1. First item
     2. Second item

--- a/stdlib/Markdown/src/render/html.jl
+++ b/stdlib/Markdown/src/render/html.jl
@@ -163,6 +163,12 @@ function htmlinline(io::IO, md::Italic)
     end
 end
 
+function htmlinline(io::IO, md::Strikethrough)
+    withtag(io, :s) do
+        htmlinline(io, md.text)
+    end
+end
+
 function htmlinline(io::IO, md::Image)
     tag(io, :img, :src=>md.url, :alt=>md.alt)
 end

--- a/stdlib/Markdown/src/render/latex.jl
+++ b/stdlib/Markdown/src/render/latex.jl
@@ -132,6 +132,12 @@ function latexinline(io::IO, md::Italic)
     end
 end
 
+function latexinline(io::IO, md::Strikethrough)
+    wrapinline(io, "sout") do  # requires the ulem package
+        latexinline(io, md.text)
+    end
+end
+
 function latexinline(io::IO, br::LineBreak)
     println(io, "\\\\")
 end

--- a/stdlib/Markdown/src/render/plain.jl
+++ b/stdlib/Markdown/src/render/plain.jl
@@ -119,6 +119,8 @@ plaininline(io::IO, md::Bold) = plaininline(io, "**", md.text, "**")
 
 plaininline(io::IO, md::Italic) = plaininline(io, "*", md.text, "*")
 
+plaininline(io::IO, md::Strikethrough) = plaininline(io, "~~", md.text, "~~")
+
 function plaininline(io::IO, md::Code)
     if occursin("`", md.code)
         n = maximum(length(m.match) for m in eachmatch(r"(`+)", md.code))

--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -209,6 +209,10 @@ function terminline(io::AnnotIO, md::Italic)
     with_output_annotations(io -> terminline(io, md.text), io, :face => :italic)
 end
 
+function terminline(io::AnnotIO, md::Strikethrough)
+    with_output_annotations(io -> terminline(io, md.text), io, :face => :strikethrough)
+end
+
 function terminline(io::IO, md::LineBreak)
     println(io)
 end

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1,7 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Test, Markdown, StyledStrings
-import Markdown: MD, Paragraph, Header, Italic, Bold, LineBreak, insert_hlines, plain, term, html, rst, Table, Code, LaTeX, Footnote
+import Markdown: MD, Paragraph, Header, Italic, Bold, Strikethrough, LineBreak, Table, Code, LaTeX, Footnote
+import Markdown: insert_hlines, plain, term, html, rst
 import Base: show
 
 # Basics
@@ -13,6 +14,8 @@ import Base: show
 @test md"foo _bar_ baz" == MD(Paragraph(["foo ", Italic("bar"), " baz"]))
 @test md"foo **bar** baz" == MD(Paragraph(["foo ", Bold("bar"), " baz"]))
 @test md"foo __bar__ baz" == MD(Paragraph(["foo ", Bold("bar"), " baz"]))
+@test md"foo ~bar~ baz" == MD(Paragraph(["foo ", Strikethrough("bar"), " baz"]))
+@test md"foo ~~bar~~ baz" == MD(Paragraph(["foo ", Strikethrough("bar"), " baz"]))
 @test md"""foo
 bar""" == MD(Paragraph(["foo bar"]))
 @test md"""foo\
@@ -25,8 +28,8 @@ bar""" == MD(Paragraph(["foo", LineBreak(), "bar"]))
   empty
   """ == MD(Header{1}(""), Paragraph("empty"))
 @test md"## section" == MD(Header{2}("section"))
-@test md"# title *foo* `bar` **baz**" ==
-    MD(Header{1}(["title ", Italic("foo")," ",Code("bar")," ",Bold("baz")]))
+@test md"# title *foo* `bar` **baz** ~~qux~~" ==
+    MD(Header{1}(["title ", Italic("foo")," ",Code("bar")," ",Bold("baz")," ",Strikethrough("qux")]))
 @test md"""
 h1
 ===""" == md"# h1"
@@ -1271,6 +1274,7 @@ end
     @test contains_X(md"[$x](..)") # Link
     @test contains_X(md"**$x**") # Bold
     @test contains_X(md"*$x*") # Italic
+    @test contains_X(md"~$x~") # Strikethrough
     @test contains_X( # Table
         md"""
         | name |


### PR DESCRIPTION
Resolves #34898

Not supported in rst output. Also in LaTeX output I made an arbitrary choice to use the `ulem` package, as there is no built-in support.

GitHub supports both single and double flavor tilde, so does this PR for both the "GitHub and "Julia" Markdown flavors. We could of course decide that for Julia only e.g. the double tilde version should be supported.