### PR TITLE
Fix broken Markdown test

### DIFF
--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1357,8 +1357,8 @@ end
               Misc:
               stuff
 
-                •  line
-                   break
+              • line
+                break
             """
     @test Markdown.plain(s) ==
             raw"""


### PR DESCRIPTION
This was caused by overlapping merge of PRs #60519 and #60520 which passed individually but not together.