### PR TITLE
[JuliaLowering] Add remap for assigned-to arguments

### DIFF
--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -71,6 +71,7 @@ struct LinearIRContext{Attrs} <: AbstractLoweringContext
     next_label_id::Ref{Int}
     is_toplevel_thunk::Bool
     lambda_bindings::LambdaBindings
+    argmap::Dict{IdTag, SyntaxTree{Attrs}}
     return_type::Union{Nothing, SyntaxTree{Attrs}}
     break_targets::Dict{String, JumpTarget{Attrs}}
     handler_token_stack::SyntaxList{Attrs, Vector{NodeId}}
@@ -87,7 +88,7 @@ function LinearIRContext(ctx, is_toplevel_thunk, lambda_bindings, return_type)
     rett = isnothing(return_type) ? nothing : reparent(graph, return_type)
     Attrs = typeof(graph.attributes)
     LinearIRContext(graph, SyntaxList(ctx), ctx.bindings, Ref(0),
-                    is_toplevel_thunk, lambda_bindings, rett,
+                    is_toplevel_thunk, lambda_bindings, Dict{IdTag, SyntaxTree{Attrs}}(), rett,
                     Dict{String,JumpTarget{Attrs}}(), SyntaxList(ctx), SyntaxList(ctx),
                     Vector{FinallyHandler{Attrs}}(), Dict{String,JumpTarget{Attrs}}(),
                     Vector{JumpOrigin{Attrs}}(), Dict{Symbol, Any}(), ctx.mod)
@@ -576,13 +577,18 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
     if k == K"BindingId" || is_literal(k) || k == K"quote" || k == K"inert" ||
             k == K"top" || k == K"core" || k == K"Value" || k == K"Symbol" ||
             k == K"SourceLocation" || k == K"static_eval"
+        ex1 = ex
+        if kind(ex1) == K"BindingId"
+            binfo = get_binding(ctx, ex1)
+            ex1 = get(ctx.argmap, binfo.id, ex1)
+        end
         if in_tail_pos
-            emit_return(ctx, ex)
+            emit_return(ctx, ex1)
         elseif needs_value
-            ex
+            ex1
         else
-            if k == K"BindingId" && !is_ssa(ctx, ex)
-                emit(ctx, ex) # keep identifiers for undefined-var checking
+            if k == K"BindingId" && !is_ssa(ctx, ex1)
+                emit(ctx, ex1) # keep identifiers for undefined-var checking
             end
             nothing
         end
@@ -623,7 +629,10 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
                                    mod::K"Value" name::K"Symbol"])
         else
             rhs = compile(ctx, ex[2], true, false)
-            # TODO look up arg-map for renaming if lhs was reassigned
+            if kind(lhs) == K"BindingId"
+                binfo = get_binding(ctx, lhs)
+                lhs = get(ctx.argmap, binfo.id, lhs)
+            end
             if needs_value && !isnothing(rhs)
                 r = emit_assign_tmp(ctx, rhs)
                 emit_simple_assignment(ctx, ex, lhs, r, k)
@@ -918,7 +927,7 @@ function unnecessary_newvar_ids(ctx, stmts)
 end
 
 # flisp: compile-body
-function compile_body(ctx, ex)
+function compile_body(ctx::LinearIRContext, ex)
     compile(ctx, ex, true, true)
 
     # Fix up any symbolic gotos. (We can't do this earlier because the goto
@@ -1057,10 +1066,23 @@ function compile_lambda(outer_ctx, ex)
     lambda_args = ex[1]
     static_parameters = ex[2]
     ret_var = numchildren(ex) == 4 ? ex[4] : nothing
-    # TODO: Add assignments for reassigned arguments to body
     lambda_bindings = ex.lambda_bindings
     ctx = LinearIRContext(outer_ctx, ex.is_toplevel_thunk, lambda_bindings, ret_var)
+    for arg in children(lambda_args)
+        kind(arg) == K"Placeholder" && continue
+        @assert kind(arg) == K"BindingId"
+        id = arg.var_id
+        binfo = get_binding(ctx, id)
+        if binfo.is_assigned
+            @assert !haskey(ctx.argmap, binfo.name)
+            ctx.argmap[binfo.id] = new_local_binding(ctx, binding_ex(ctx, binfo), binfo.name)
+        end
+    end
     compile_body(ctx, ex[3])
+    for (binding_id, local_slot) in pairs(ctx.argmap)
+        binding = binding_ex(ctx, binding_id)
+        pushfirst!(ctx.code, @ast ctx binding [K"=" local_slot binding])
+    end
     slots = Vector{Slot}()
     slot_rewrites = Dict{IdTag,Int}()
     for arg in children(lambda_args)
@@ -1128,7 +1150,8 @@ loops, etc) to gotos and exception handling to enter/leave. We also convert
     # required to call reparent() ...
     Attrs = typeof(graph.attributes)
     _ctx = LinearIRContext(graph, SyntaxList(graph), ctx.bindings,
-                           Ref(0), false, LambdaBindings(), nothing,
+                           Ref(0), false, LambdaBindings(),
+                           Dict{IdTag, SyntaxTree{Attrs}}(), nothing,
                            Dict{String,JumpTarget{Attrs}}(),
                            SyntaxList(graph), SyntaxList(graph),
                            Vector{FinallyHandler{Attrs}}(),

--- a/JuliaLowering/test/closures_ir.jl
+++ b/JuliaLowering/test/closures_ir.jl
@@ -130,21 +130,24 @@ end
 18  SourceLocation::1:10
 19  (call core.svec %₁₆ %₁₇ %₁₈)
 20  --- method core.nothing %₁₉
-    slots: [slot₁/#self#(!read) slot₂/x(single_assign) slot₃/g(single_assign,called) slot₄/x(!read,maybe_undef)]
-    1   (= slot₂/x (call core.Box slot₂/x))
-    2   TestMod.#f#g##0
-    3   (new %₂ slot₂/x)
-    4   (= slot₃/g %₃)
-    5   slot₃/g
-    6   (call %₅)
-    7   slot₂/x
-    8   (call core.isdefined %₇ :contents)
-    9   (gotoifnot %₈ label₁₁)
-    10  (goto label₁₃)
-    11  (newvar slot₄/x)
-    12  slot₄/x
-    13  (call core.getfield %₇ :contents)
-    14  (return %₁₃)
+    slots: [slot₁/#self#(!read) slot₂/x(single_assign) slot₃/g(single_assign,called) slot₄/x(!read,maybe_undef) slot₅/x(!read)]
+    1   (= slot₅/x slot₂/x)
+    2   slot₅/x
+    3   (= slot₅/x (call core.Box %₂))
+    4   TestMod.#f#g##0
+    5   slot₅/x
+    6   (new %₄ %₅)
+    7   (= slot₃/g %₆)
+    8   slot₃/g
+    9   (call %₈)
+    10  slot₅/x
+    11  (call core.isdefined %₁₀ :contents)
+    12  (gotoifnot %₁₁ label₁₄)
+    13  (goto label₁₆)
+    14  (newvar slot₄/x)
+    15  slot₄/x
+    16  (call core.getfield %₁₀ :contents)
+    17  (return %₁₆)
 21  latestworld
 22  TestMod.f
 23  (return %₂₂)

--- a/JuliaLowering/test/decls_ir.jl
+++ b/JuliaLowering/test/decls_ir.jl
@@ -263,33 +263,34 @@ end
 7   SourceLocation::1:10
 8   (call core.svec %₅ %₆ %₇)
 9   --- method core.nothing %₈
-    slots: [slot₁/#self#(!read) slot₂/x slot₃/tmp(!read) slot₄/tmp(!read)]
-    1   1
-    2   TestMod.Int
-    3   (= slot₃/tmp %₁)
-    4   slot₃/tmp
-    5   (call core.isa %₄ %₂)
-    6   (gotoifnot %₅ label₈)
-    7   (goto label₁₁)
-    8   slot₃/tmp
-    9   (call top.convert %₂ %₈)
-    10  (= slot₃/tmp (call core.typeassert %₉ %₂))
-    11  slot₃/tmp
-    12  (= slot₂/x %₁₁)
-    13  2.0
-    14  TestMod.Int
-    15  (= slot₄/tmp %₁₃)
-    16  slot₄/tmp
-    17  (call core.isa %₁₆ %₁₄)
-    18  (gotoifnot %₁₇ label₂₀)
-    19  (goto label₂₃)
-    20  slot₄/tmp
-    21  (call top.convert %₁₄ %₂₀)
-    22  (= slot₄/tmp (call core.typeassert %₂₁ %₁₄))
-    23  slot₄/tmp
-    24  (= slot₂/x %₂₃)
-    25  slot₂/x
-    26  (return %₂₅)
+    slots: [slot₁/#self#(!read) slot₂/x slot₃/tmp(!read) slot₄/tmp(!read) slot₅/x(!read)]
+    1   (= slot₅/x slot₂/x)
+    2   1
+    3   TestMod.Int
+    4   (= slot₃/tmp %₂)
+    5   slot₃/tmp
+    6   (call core.isa %₅ %₃)
+    7   (gotoifnot %₆ label₉)
+    8   (goto label₁₂)
+    9   slot₃/tmp
+    10  (call top.convert %₃ %₉)
+    11  (= slot₃/tmp (call core.typeassert %₁₀ %₃))
+    12  slot₃/tmp
+    13  (= slot₅/x %₁₂)
+    14  2.0
+    15  TestMod.Int
+    16  (= slot₄/tmp %₁₄)
+    17  slot₄/tmp
+    18  (call core.isa %₁₇ %₁₅)
+    19  (gotoifnot %₁₈ label₂₁)
+    20  (goto label₂₄)
+    21  slot₄/tmp
+    22  (call top.convert %₁₅ %₂₁)
+    23  (= slot₄/tmp (call core.typeassert %₂₂ %₁₅))
+    24  slot₄/tmp
+    25  (= slot₅/x %₂₄)
+    26  slot₅/x
+    27  (return %₂₆)
 10  latestworld
 11  TestMod.f
 12  (return %₁₁)


### PR DESCRIPTION
Nearly 1:1 with the usage of `arg-map` in flisp (was noted as TODO in JuliaLowering)

This missing functionality was surprisingly hard to observe since slots are erased in our optimization pipeline, making it impossible for codegen to complain about them. Nonetheless, macros can crash if we do not perform this re-write.

Resolves https://github.com/JuliaLang/JuliaLowering.jl/issues/129