### PR TITLE
Markdown.plain(): fix indentation of list items

### DIFF
--- a/stdlib/Markdown/src/render/plain.jl
+++ b/stdlib/Markdown/src/render/plain.jl
@@ -35,10 +35,11 @@ end
 
 function plain(io::IO, list::List)
     for (i, item) in enumerate(list.items)
-        print(io, isordered(list) ? "$(i + list.ordered - 1). " : "  * ")
+        bullet = isordered(list) ? "$(i + list.ordered - 1). " : "  * "
+        print(io, bullet)
         lines = split(rstrip(sprint(plain, item)), "\n")
         for (n, line) in enumerate(lines)
-            print(io, (n == 1 || isempty(line)) ? "" : "    ", line)
+            print(io, (n == 1 || isempty(line)) ? "" : (" "^length(bullet)), line)
             n < length(lines) && println(io)
         end
         println(io)


### PR DESCRIPTION
(This has been extracted from PR #57788. While I still like that PR, I feel uncomfortable merging it without some more explicit buy in by others. In the meantime, the fix in here should be uncontroversial and does not need to wait for #57788 being accepted.)

Adjust the indentation to the width of the actual bullet, instead of hardcoding it as 4. This mostly affects ordered list, where the bullet width depends on the ordinal used to label the list item.

```julia
m = md"""
An ordered list:
1. top level\
   with an extra line
   1. second level\
      again with an extra line
       999. third level\
            yet again with an extra line
            1. fourth level\
               and another extra line
               1. fifth level\
                  final extra line
      1000. more third level\
            with an extra line
1. back to top level
""";
print(Markdown.plain(m))
```

Before this patch:
```md
An ordered list:

1. top level
    with an extra line

    1. second level
        again with an extra line

        999. third level
            yet again with an extra line

            1. fourth level
                and another extra line

                1. fifth level
                    final extra line
        1000. more third level
            with an extra line
2. back to top level
```

After this patch:
```md
An ordered list:

1. top level
   with an extra line

   1. second level
      again with an extra line

      999. third level
           yet again with an extra line

           1. fourth level
              and another extra line

              1. fifth level
                 final extra line
      1000. more third level
            with an extra line
2. back to top level
```