### PR TITLE
Markdown: improve handling of horizontal rules

### DIFF
--- a/stdlib/Markdown/src/Common/Common.jl
+++ b/stdlib/Markdown/src/Common/Common.jl
@@ -5,10 +5,8 @@ abstract type MarkdownElement end
 include("block.jl")
 include("inline.jl")
 
-
-
-@flavor common [list, indentcode, blockquote, admonition, footnote, hashheader,
-                horizontalrule, paragraph,
+@flavor common [horizontalrule, list, indentcode, blockquote, admonition, footnote, hashheader,
+                paragraph,
 
                 linebreak, escapes,
                 inline_code,

--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -358,6 +358,7 @@ pushitem!(list, buffer) = push!(list.items, parse(takestring!(buffer)).content)
 mutable struct HorizontalRule <: MarkdownElement
 end
 
+@breaking true ->
 function horizontalrule(stream::IO, block::MD)
    withstream(stream) do
        n, rule = 0, ' '

--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -371,7 +371,7 @@ function horizontalrule(stream::IO, block::MD)
                return false
            end
        end
-       is_hr = (n ≥ 3 && rule in "*-")
+       is_hr = (n ≥ 3 && rule in "*-_")
        is_hr && push!(block, HorizontalRule())
        return is_hr
    end

--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -365,12 +365,12 @@ function horizontalrule(stream::IO, block::MD)
        for char in readeach(stream, Char)
            char == '\n' && break
            isspace(char) && continue
-           if n==0 || char==rule
+           if n == 0
                rule = char
-               n += 1
-           else
+           elseif char != rule
                return false
            end
+           n += 1
        end
        is_hr = (n ≥ 3 && rule in "*-_")
        is_hr && push!(block, HorizontalRule())

--- a/stdlib/Markdown/src/GitHub/GitHub.jl
+++ b/stdlib/Markdown/src/GitHub/GitHub.jl
@@ -57,7 +57,7 @@ function github_paragraph(stream::IO, md::MD)
     return true
 end
 
-@flavor github [list, indentcode, blockquote, admonition, footnote, hashheader,
+@flavor github [horizontalrule, list, indentcode, blockquote, admonition, footnote, hashheader,
                 fencedcode, github_table, github_paragraph,
 
                 linebreak, escapes,

--- a/stdlib/Markdown/src/Julia/Julia.jl
+++ b/stdlib/Markdown/src/Julia/Julia.jl
@@ -8,8 +8,8 @@
 include("interp.jl")
 
 @flavor julia [blocktex, blockinterp,
-               list, indentcode, blockquote, admonition, footnote, hashheader,
-               fencedcode, github_table, horizontalrule, setextheader, paragraph,
+               horizontalrule, list, indentcode, blockquote, admonition, footnote, hashheader,
+               fencedcode, github_table, setextheader, paragraph,
 
                linebreak, escapes,
                tex, interp,

--- a/stdlib/Markdown/test/test_spec.jl
+++ b/stdlib/Markdown/test/test_spec.jl
@@ -295,7 +295,7 @@ end
     input = "***\n---\n___\n"
     expected = "<hr />\n<hr />\n<hr />\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 44
     input = "+++\n"
@@ -337,7 +337,7 @@ end
     input = "_____________________________________\n"
     expected = "<hr />\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 51
     input = " - - -\n"

--- a/stdlib/Markdown/test/test_spec.jl
+++ b/stdlib/Markdown/test/test_spec.jl
@@ -343,7 +343,7 @@ end
     input = " - - -\n"
     expected = "<hr />\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 52
     input = " **  * ** * ** * **\n"
@@ -355,13 +355,13 @@ end
     input = "-     -      -      -\n"
     expected = "<hr />\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 54
     input = "- - - -    \n"
     expected = "<hr />\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 55
     input = "_ _ _ _ a\n\na------\n\n---a---\n"
@@ -385,7 +385,7 @@ end
     input = "Foo\n***\nbar\n"
     expected = "<p>Foo</p>\n<hr />\n<p>bar</p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 59
     input = "Foo\n---\nbar\n"


### PR DESCRIPTION
- support horizontal rules consisting of underscores
- add missing 'breaking' decoration for `horizontalrule` to fix support for horizontal rules e.g. inside of lists
- add support for horizontal rules to the GitHub flavor (it seems like an accident that it was missing before)
- slightly rearrange the code to make it easier to understand (at least for me)

Fixes 6 CommonMark spec tests.