### PR TITLE
add to docstring to `methods` specifying specifics of specificity ordering

### DIFF
--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1542,6 +1542,10 @@ Return the method table for `f`.
 If `types` is specified, return an array of methods whose types match.
 If `module` is specified, return an array of methods defined in that module.
 A list of modules can also be specified as an array or set.
+    
+The methods are ordered from most to least specific. The relative order of
+methods without a specificity relationship (i.e. ambiguous or incomparable)
+is unspecified.
 
 !!! compat "Julia 1.4"
     At least Julia 1.4 is required for specifying a module.

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1542,7 +1542,7 @@ Return the method table for `f`.
 If `types` is specified, return an array of methods whose types match.
 If `module` is specified, return an array of methods defined in that module.
 A list of modules can also be specified as an array or set.
-    
+
 The methods are ordered from most to least specific. The relative order of
 methods without a specificity relationship (i.e. ambiguous or incomparable)
 is unspecified.


### PR DESCRIPTION
this appears to be true, and per [this comment](https://github.com/JuliaLang/julia/issues/3025#issuecomment-314470929) so it's probably a good thing to call out in the docs especially as it may be useful for debugging dispatch flows