### PR TITLE
Markdown: adjust input chars which can be escaped

### DIFF
--- a/stdlib/Markdown/src/Common/inline.jl
+++ b/stdlib/Markdown/src/Common/inline.jl
@@ -190,7 +190,7 @@ function en_or_em_dash(stream::IO, md::MD)
     end
 end
 
-const escape_chars = "\\`*_#+-.!{}[]()\$"
+const escape_chars = """!"#\$%&'()*+,-./:;<=>?@[\\]^_`{|}~"""
 
 @trigger '\\' ->
 function escapes(stream::IO, md::MD)

--- a/stdlib/Markdown/test/test_spec.jl
+++ b/stdlib/Markdown/test/test_spec.jl
@@ -88,7 +88,7 @@ end
     input = "\\!\\\"\\#\\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n"
     expected = "<p>!&quot;#\$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 13
     input = "\\\t\\A\\a\\ \\3\\φ\\«\n"
@@ -663,7 +663,7 @@ end
     input = "\\> foo\n------\n"
     expected = "<h2>&gt; foo</h2>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 103
     input = "Foo\n\nbar\n---\nbaz\n"
@@ -3955,7 +3955,7 @@ end
     input = "<a href=\"\\\"\">\n"
     expected = "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
 end
 


### PR DESCRIPTION
The list now matches the CommonMark specification.

Fixes three of the CommonMark spec tests.

Resolves #39913