### PR TITLE
Markdown: refactor some code

### DIFF
--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -56,7 +56,7 @@ function hashheader(stream::IO, md::MD)
 
         c = ' '
         # Allow empty headers, but require a space
-        !eof(stream) && (c = read(stream, Char); !(c in " \n")) &&
+        !eof(stream) && (c = read(stream, Char); !(c in " \t\n")) &&
             return false
 
         if c != '\n' # Empty header

--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -248,7 +248,7 @@ end
 
 mutable struct List <: MarkdownElement
     items::Vector{Any}
-    ordered::Int # `-1` is unordered, `>= 0` is ordered.
+    ordered::Int # `-1` is unordered, `>= 0` is ordered and indicates the start index.
     loose::Bool # TODO: Renderers should use this field
 end
 List(x::AbstractVector, b::Integer) = List(x, b, false)

--- a/stdlib/Markdown/src/Common/inline.jl
+++ b/stdlib/Markdown/src/Common/inline.jl
@@ -59,7 +59,7 @@ end
 @trigger '`' ->
 function inline_code(stream::IO, md::MD)
     withstream(stream) do
-        ticks = startswith(stream, r"^(`+)")
+        ticks = matchstart(stream, r"^(`+)").match
         result = readuntil(stream, ticks)
         if result === nothing
             nothing
@@ -123,11 +123,11 @@ end
 function footnote_link(stream::IO, md::MD)
     withstream(stream) do
         regex = r"^\[\^(\w+)\]"
-        str = startswith(stream, regex)
-        if isempty(str)
+        m = matchstart(stream, regex)
+        if m === nothing
             return
         else
-            ref = (match(regex, str)::AbstractMatch).captures[1]
+            ref = m.captures[1]
             return Footnote(ref, nothing)
         end
     end

--- a/stdlib/Markdown/src/parse/util.jl
+++ b/stdlib/Markdown/src/parse/util.jl
@@ -1,13 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-macro dotimes(n, body)
-    quote
-        for i = 1:$(esc(n))
-            $(esc(body))
-        end
-    end
-end
-
 const whitespace = " \t\r"
 
 """
@@ -92,16 +84,19 @@ function startswith(stream::IO, ss::Vector{<:AbstractString}; kws...)
     any(s->startswith(stream, s; kws...), ss)
 end
 
-function startswith(stream::IO, r::Regex; eat = true, padding = false)
+function matchstart(stream::IO, r::Regex; eat = true, padding = false)
     @assert Base.startswith(r.pattern, "^")
     start = position(stream)
     padding && skipwhitespace(stream)
     line = readline(stream)
     seek(stream, start)
     m = match(r, line)
-    m === nothing && return ""
-    eat && @dotimes length(m.match) read(stream, Char)
-    return m.match
+    if eat && m !== nothing
+        for i in 1:length(m.match)
+            read(stream, Char)
+        end
+    end
+    return m
 end
 
 """

--- a/stdlib/Markdown/test/test_spec.jl
+++ b/stdlib/Markdown/test/test_spec.jl
@@ -69,7 +69,7 @@ using Markdown
     input = "#\tFoo\n"
     expected = "<h1>Foo</h1>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 11
     input = "*\t*\t*\t\n"


### PR DESCRIPTION
- improve comment for `ordered` field of `List`
- allow tab at start of hash header
- change `startswith` method for regex and rename it to `matchstart`

The new code returns the `RegexMatch` object (if there is one), so
the calling code does not have to match the regex a second time.
Use this to simplify the parsing of `List` bullets.

Both the old and the new code did not return a boolean, so it
does not really seem proper to have it as a method for `startswith`,
so a new name was need.

---

This fixes just one CommonMark spec test, but that wasn't the
main point, it's more about enabling future changes.