### PR TITLE
[JuliaLowering] Enrich closure tests and fix static parameter capture

### DIFF
--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -302,9 +302,10 @@ function type_for_closure(ctx::ClosureConversionCtx, srcref, name_str, field_sym
 end
 
 function is_boxed(binfo::BindingInfo)
+    # Static parameters can't be reassigned, so they never need boxing
+    binfo.kind === :static_parameter && return false
     # No box needed for:
     # * :argument when it's not reassigned
-    # * :static_parameter (these can't be reassigned)
     defined_but_not_assigned = binfo.is_always_defined && !binfo.is_assigned
     # * Single-assigned variables (local or argument) assigned before any closure captures them
     #   (identified by liveness analysis in optimize_captured_vars!)

--- a/JuliaLowering/test/closures_ir.jl
+++ b/JuliaLowering/test/closures_ir.jl
@@ -255,7 +255,7 @@ end
 1   (method TestMod.f)
 2   latestworld
 3   (call core.svec :T)
-4   (call core.svec true)
+4   (call core.svec false)
 5   (call JuliaLowering.eval_closure_type TestMod :#f#g##2 %₃ %₄)
 6   latestworld
 7   TestMod.#f#g##2
@@ -264,17 +264,11 @@ end
 10  SourceLocation::2:14
 11  (call core.svec %₈ %₉ %₁₀)
 12  --- method core.nothing %₁₁
-    slots: [slot₁/#self#(!read) slot₂/T(!read,maybe_undef)]
+    slots: [slot₁/#self#(!read)]
     1   TestMod.use
     2   (call core.getfield slot₁/#self# :T)
-    3   (call core.isdefined %₂ :contents)
-    4   (gotoifnot %₃ label₆)
-    5   (goto label₈)
-    6   (newvar slot₂/T)
-    7   slot₂/T
-    8   (call core.getfield %₂ :contents)
-    9   (call %₁ %₈)
-    10  (return %₉)
+    3   (call %₁ %₂)
+    4   (return %₃)
 13  latestworld
 14  (= slot₁/T (call core.TypeVar :T))
 15  TestMod.f
@@ -289,10 +283,13 @@ end
     slots: [slot₁/#self#(!read) slot₂/#arg1#(!read) slot₃/g(single_assign)]
     1   TestMod.#f#g##2
     2   static_parameter₁
-    3   (new %₁ %₂)
-    4   (= slot₃/g %₃)
-    5   slot₃/g
-    6   (return %₅)
+    3   (call core.typeof %₂)
+    4   (call core.apply_type %₁ %₃)
+    5   static_parameter₁
+    6   (new %₄ %₅)
+    7   (= slot₃/g %₆)
+    8   slot₃/g
+    9   (return %₈)
 24  latestworld
 25  TestMod.f
 26  (return %₂₅)

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -173,6 +173,14 @@ begin
 end
 """) === ("fallback", (Number, Float64), (Int, Int), "fallback")
 
+# Static parameter may be undefined
+@test JuliaLowering.include_string(test_mod, """
+begin
+    func_undef_static_param(x::Union{T,Nothing}) where T = @isdefined(T)
+    (func_undef_static_param(nothing), func_undef_static_param(42))
+end
+""") === (false, true)
+
 Base.eval(test_mod,
 :(struct X1{T} end)
 )


### PR DESCRIPTION
Add runtime tests to closures.jl that were only present as IR tests in
closures_ir.jl:
- Function arguments captured into closure and assigned
- Closure declaration with no methods
- Closure with keyword arguments
- Anonymous function syntax with `function`
- Static parameter capture

While adding the static parameter capture test, discovered and fixed a bug
where `is_boxed()` incorrectly returned `true` for static parameters.
Static parameters can never be reassigned, so they never need boxing.
The fix adds an early return in `is_boxed()` for static parameters.