### PR TITLE
Markdown: implement URI encoding

### DIFF
--- a/stdlib/Markdown/src/render/html.jl
+++ b/stdlib/Markdown/src/render/html.jl
@@ -17,7 +17,7 @@ include("rich.jl")
 # URIs.jl package, but that is not an option for us, as it is not a stdlib...
 #
 # As a special affordance, we deviate from the "reserved" list in one way: we
-# do *not* excllude '[' and ']' from percent encoding, even thoug they are in
+# do *not* exclude '[' and ']' from percent encoding, even though they are in
 # the gen-delims set. They are only used to encode IPv6 literal addresses in
 # the URI, which is (still) rare. But they do occur in query strings and
 # indeed in the CommonMark spec tests.

--- a/stdlib/Markdown/src/render/html.jl
+++ b/stdlib/Markdown/src/render/html.jl
@@ -4,12 +4,32 @@ include("rich.jl")
 
 # Utils
 
+
+# Handle URI encoding, poorly. The code here was initially copied from
+# Base.Filesystem, then modified. The original code implements RFC3986 Section
+# 2.1 and 2.2.
+#
+# We changed encode_uri_component to not encode characters declared as
+# "reserved" by RFC3986 Section 2.2 (i.e., those from the gen-delims and
+# sub-delims sets). Instead the user is expected to percent encode these (or
+# not) as needed -- the alternative would be implement full URI parsing, which
+# is non-trivial. That said, it would be better to do that, by e.g. using the
+# URIs.jl package, but that is not an option for us, as it is not a stdlib...
+#
+# As a special affordance, we deviate from the "reserved" list in one way: we
+# do *not* excllude '[' and ']' from percent encoding, even thoug they are in
+# the gen-delims set. They are only used to encode IPv6 literal addresses in
+# the URI, which is (still) rare. But they do occur in query strings and
+# indeed in the CommonMark spec tests.
+
+percent_escape(s) = '%' * join(map(b -> uppercase(string(b, base=16)), codeunits(s)), '%')
+encode_uri_component(s::AbstractString) = replace(s, r"[^A-Za-z0-9\-_.~/:?#@!$&'()*+,;=]+" => percent_escape)
+encode_uri_component(s::Symbol) = encode_uri_component(string(s))
+
 function withtag(f, io::IO, tag, attrs...)
     print(io, "<$tag")
     for (attr, value) in attrs
-        print(io, " ")
-        htmlesc(io, attr)
-        print(io, "=\"")
+        print(io, " ", attr, "=\"")
         htmlesc(io, value)
         print(io, "\"")
     end
@@ -159,7 +179,7 @@ function htmlinline(io::IO, md::Strikethrough)
 end
 
 function htmlinline(io::IO, md::Image)
-    tag(io, :img, :src=>md.url, :alt=>md.alt)
+    tag(io, :img, :src=>encode_uri_component(md.url), :alt=>md.alt)
 end
 
 
@@ -170,7 +190,7 @@ function htmlinline(io::IO, f::Footnote)
 end
 
 function htmlinline(io::IO, link::Link)
-    withtag(io, :a, :href=>link.url) do
+    withtag(io, :a, :href=>encode_uri_component(link.url)) do
         htmlinline(io, link.text)
     end
 end

--- a/stdlib/Markdown/test/test_spec.jl
+++ b/stdlib/Markdown/test/test_spec.jl
@@ -136,7 +136,7 @@ end
     input = "<https://example.com?find=\\*>\n"
     expected = "<p><a href=\"https://example.com?find=%5C*\">https://example.com?find=\\*</a></p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 21
     input = "<a href=\"/bar\\/)\">\n"
@@ -2204,7 +2204,7 @@ end
     input = "<https://foo.bar.`baz>`\n"
     expected = "<p><a href=\"https://foo.bar.%60baz\">https://foo.bar.`baz</a>`</p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 347
     input = "```foo``\n"
@@ -3154,7 +3154,7 @@ end
     input = "[link](foo\\bar)\n"
     expected = "<p><a href=\"foo%5Cbar\">link</a></p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 503
     input = "[link](foo%20b&auml;)\n"
@@ -3166,7 +3166,7 @@ end
     input = "[link](\"title\")\n"
     expected = "<p><a href=\"%22title%22\">link</a></p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 505
     input = "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n"
@@ -3184,7 +3184,7 @@ end
     input = "[link](/url\uA0\"title\")\n"
     expected = "<p><a href=\"/url%C2%A0%22title%22\">link</a></p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 508
     input = "[link](/url \"title \"and\" title\")\n"
@@ -3774,7 +3774,7 @@ end
     input = "<https://example.com/\\[\\>\n"
     expected = "<p><a href=\"https://example.com/%5C%5B%5C\">https://example.com/\\[\\</a></p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 604
     input = "<foo@bar.example.com>\n"


### PR DESCRIPTION
This is a bit of a hack, but short of using URIs.jl (which isn't a stdlib) or re-implanting a big part of it, it seems like a valid compromise. More details in a code comment.

Fixes six CommonMark spec tests.