### PR TITLE
Emit deprecation warnings when inlining deprecated bindings during inference

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3665,6 +3665,9 @@ function abstract_eval_partition_load(interp::Union{AbstractInterpreter,Nothing}
             # inference results in an earlier world.
             return RTEffects(Any, UndefVarError, local_getglobal_effects)
         end
+        if isdepwarn
+            ccall(:jl_binding_deprecation_check, Cvoid, (Any,), binding)
+        end
         rt = Const(partition_restriction(partition))
         return RTEffects(rt, Union{}, Effects(EFFECTS_TOTAL,
             inaccessiblememonly=is_mutation_free_argtype(rt) ? ALWAYS_TRUE : ALWAYS_FALSE,


### PR DESCRIPTION
## Summary

Fixes #60560

When type inference inlines a deprecated const binding, the deprecation warning was not being emitted. This happened because the warning was only emitted during code generation (for runtime execution), but not during abstract interpretation (for inference).

## Changes

- Added a call to `jl_binding_deprecation_check` in `abstract_eval_partition_load` when a deprecated const binding is encountered
- This ensures deprecation warnings are emitted consistently whether code is executed or just type-inferred

## Testing

Tested with the example from the issue:
- With `--compile=all --depwarn=error`, the deprecated binding now throws an error during inference
- With `--compile=min --depwarn=error`, behavior is unchanged (still throws)
- Warning message is correctly formatted with the binding name and deprecation message

## Example

```julia
module Foo
    import Base: @deprecate_binding
    NotDeprecated = (1,2)
    @deprecate_binding Deprecated NotDeprecated
end

function foo()
    Foo.Deprecated  # Now emits deprecation warning during inference
end
```

Before this fix, running with `--compile=all` would inline the value without warning.
After this fix, the deprecation warning is properly emitted.