### PR TITLE
[JuliaLowering] Mark internal lowering bindings as is_internal

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2797,7 +2797,7 @@ function keyword_function_defs(ctx, srcref, callex_srcref, name_str, typevar_nam
         for n in kw_names
             # If not using slots for the keyword argument values, still declare
             # them for reflection purposes.
-            new_local_binding(ctx, n, n.name_val)
+            push!(kw_val_stmts, @ast ctx n [K"local"(meta=CompileHints(:is_internal, true)) n])
         end
         kw_val_vars = SyntaxList(ctx)
         for val in kw_values

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2797,7 +2797,7 @@ function keyword_function_defs(ctx, srcref, callex_srcref, name_str, typevar_nam
         for n in kw_names
             # If not using slots for the keyword argument values, still declare
             # them for reflection purposes.
-            push!(kw_val_stmts, @ast ctx n [K"local" n])
+            push!(kw_val_stmts, @ast ctx n [K"local"(meta=CompileHints(:is_internal, true)) n])
         end
         kw_val_vars = SyntaxList(ctx)
         for val in kw_values
@@ -4090,7 +4090,7 @@ function expand_struct_def(ctx, ex, docs)
             # Needed for later constdecl to work, though plain global form may be removed soon.
             [K"global" global_struct_name]
             [K"block"
-                [K"local" struct_name]
+                [K"local"(meta=CompileHints(:is_internal, true)) struct_name]
                 [K"always_defined" struct_name]
                 typevar_stmts...
                 [K"="

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -194,7 +194,11 @@ function _find_scope_decls!(ctx, scope, ex)
     if k === K"local" && kind(ex[1]) === K"Identifier"
         var_k = getmeta(ex, :is_destructured_arg, false) ?
             :destructured_arg : :local
-        maybe_declare_in_scope!(ctx, scope, ex[1], var_k)
+        if getmeta(ex, :is_internal, false)
+            declare_in_scope!(ctx, scope, ex[1], var_k; is_internal=true)
+        else
+            maybe_declare_in_scope!(ctx, scope, ex[1], var_k)
+        end
     elseif k === K"global" && kind(ex[1]) === K"Identifier"
         maybe_declare_in_scope!(ctx, scope, ex[1], :global)
     elseif k in KSet"= constdecl assign_or_constdecl_if_global function_decl"

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -194,11 +194,7 @@ function _find_scope_decls!(ctx, scope, ex)
     if k === K"local" && kind(ex[1]) === K"Identifier"
         var_k = getmeta(ex, :is_destructured_arg, false) ?
             :destructured_arg : :local
-        if getmeta(ex, :is_internal, false)
-            declare_in_scope!(ctx, scope, ex[1], var_k; is_internal=true)
-        else
-            maybe_declare_in_scope!(ctx, scope, ex[1], var_k)
-        end
+        maybe_declare_in_scope!(ctx, scope, ex[1], var_k)
     elseif k === K"global" && kind(ex[1]) === K"Identifier"
         maybe_declare_in_scope!(ctx, scope, ex[1], :global)
     elseif k in KSet"= constdecl assign_or_constdecl_if_global function_decl"
@@ -369,7 +365,12 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
         end
         ex_out
     elseif k == K"always_defined"
-        resolve_name(ctx, ex[1]).is_always_defined = true
+        child = ex[1]
+        if kind(child) == K"BindingId"
+            get_binding(ctx, child).is_always_defined = true
+        else
+            resolve_name(ctx, child).is_always_defined = true
+        end
         newleaf(ctx, ex, K"TOMBSTONE")
     elseif k == K"lambda"
         newscope = enter_scope!(ctx, ex)


### PR DESCRIPTION
EDIT: It turned out that the struct local bindings are actually not "internal" after all, since it can appear on source level as well in cases like `struct A; x::Ref{A}; end`. This PR now only adds `is_internal` flag for the kwname binding.

Keyword functions and struct definitions introduce local bindings for internal purposes that are never actually used in source code. This complicates binding usage computation in JETLS.
Mark these bindings as `is_internal` so the language server can safely ignore them.

- kwcall reflection bindings: declared for reflection but never assigned
- struct local bindings: temporary variable for struct type definition