### PR TITLE
fix: cmdlineargs test segfault 

### DIFF
--- a/;;;/environments/v1.14/Project.toml
+++ b/;;;/environments/v1.14/Project.toml
@@ -1,1 +1,0 @@
-syntax.julia_version = "1.14.0-DEV.1499"

--- a/;;;/environments/v1.14/Project.toml
+++ b/;;;/environments/v1.14/Project.toml
@@ -1,0 +1,1 @@
+syntax.julia_version = "1.14.0-DEV.1499"


### PR DESCRIPTION
issue: #60039
send SIGQUIT periodically until the process terminate.

```julia
t = Timer(0, interval=10) do _
   Base.kill(p, Base.SIGQUIT)
end
```