### PR TITLE
[release-1.12][Windows][Makefile] Avoid installing `basecompiler-o.a` / `sysbase-o.a`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,8 +325,7 @@ else ifeq ($(JULIA_BUILD_MODE),debug)
 	-$(INSTALL_M) $(build_libdir)/libjulia-debug.dll.a $(DESTDIR)$(libdir)/
 	-$(INSTALL_M) $(build_libdir)/libjulia-internal-debug.dll.a $(DESTDIR)$(libdir)/
 endif
-	-$(INSTALL_M) $(wildcard $(build_private_libdir)/*.a) $(DESTDIR)$(private_libdir)/
-	-rm -f $(DESTDIR)$(private_libdir)/sys-o.a
+	-$(INSTALL_M) $(filter-out %-bc.a %-o.a,$(wildcard $(build_private_libdir)/lib*.a)) $(DESTDIR)$(private_libdir)/
 
 	-$(INSTALL_M) $(build_bindir)/libopenlibm.dll.a $(DESTDIR)$(libdir)/
 	-$(INSTALL_M) $(build_libdir)/libssp.dll.a $(DESTDIR)$(libdir)/


### PR DESCRIPTION
We've been shipping ~400 MB of unnecessary `.a` files on Windows 1.12:
```julia
PS C:\Users\cody> dir .\.julia\juliaup\julia-1.12.1+0.x64.w64.mingw32\lib\julia\

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----        10/17/2025  10:54 AM       67062872 basecompiler-o.a
-a----        10/17/2025  10:40 AM        6754998 libgcc.a
-a----        10/17/2025  10:40 AM          86286 libgcc_s.a
-a----        10/17/2025  10:40 AM        1476006 libmsvcrt.a
-a----        10/17/2025  10:40 AM           9136 libssp.dll.a
-a----        10/17/2025   1:07 PM      301278696 sys.dll
-a----        10/17/2025  10:59 AM      360308788 sysbase-o.a
```

This was fixed very quietly in https://github.com/JuliaLang/julia/pull/58344/, so this is technically a backport.
