### PR TITLE
Markdown: better preserve newlines

### DIFF
--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -24,7 +24,7 @@ function paragraph(stream::IO, md::MD)
             elseif blankline(stream) || _parse(stream, md, breaking = true)
                 break
             else
-                write(buffer, ' ')
+                write(buffer, '\n')
             end
         else
             write(buffer, char)

--- a/stdlib/Markdown/src/Common/inline.jl
+++ b/stdlib/Markdown/src/Common/inline.jl
@@ -60,11 +60,13 @@ end
 function inline_code(stream::IO, md::MD)
     withstream(stream) do
         ticks = matchstart(stream, r"^(`+)").match
-        result = readuntil(stream, ticks)
+        result = readuntil(stream, ticks; newlines=true)
         if result === nothing
             nothing
         else
             result = strip(result)
+            # in code spans, newlines are replaced by spaces
+            result = replace(result, '\n' => ' ')
             # An odd number of backticks wrapping the text will produce a `Code` node, while
             # an even number will result in a `LaTeX` node. This allows for arbitrary
             # backtick combinations to be embedded inside the resulting node, i.e.

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -16,7 +16,7 @@ import Base: show
     @test md"foo ~bar~ baz" == MD(Paragraph(["foo ", Strikethrough("bar"), " baz"]))
     @test md"foo ~~bar~~ baz" == MD(Paragraph(["foo ", Strikethrough("bar"), " baz"]))
     @test md"""foo
-    bar""" == MD(Paragraph(["foo bar"]))
+    bar""" == MD(Paragraph(["foo\nbar"]))
     @test md"""foo\
     bar""" == MD(Paragraph(["foo", LineBreak(), "bar"]))
 
@@ -80,7 +80,7 @@ end
 @testset "linefeeds" begin
     @test isempty(Markdown.parse("\r"))
     @test Markdown.parse("hello\r") == MD(Paragraph(["hello"]))
-    @test Markdown.parse("hello\r*julia*") == MD(Paragraph(Any["hello ", Italic(Any["julia"])]))
+    @test Markdown.parse("hello\r*julia*") == MD(Paragraph(Any["hello\n", Italic(Any["julia"])]))
 end
 
 @testset "footnotes" begin
@@ -376,7 +376,7 @@ end
     @test md"<mailto://a@example.com>" |> html == """<p><a href="mailto://a@example.com">mailto://a@example.com</a></p>\n"""
     @test md"<https://julialang.org/not a link>" |> html == "<p>&lt;https://julialang.org/not a link&gt;</p>\n"
     @test md"""<https://julialang.org/nota
-    link>""" |> html == "<p>&lt;https://julialang.org/nota link&gt;</p>\n"
+    link>""" |> html == "<p>&lt;https://julialang.org/nota\nlink&gt;</p>\n"
     @test md"""Hello
 
     ---
@@ -399,7 +399,14 @@ end
     h2
     ---
     not
-    == =""" |> html == "<h1>h1</h1>\n<h2>h2</h2>\n<p>not == =</p>\n"
+    == =""" |> html ==
+    """
+    <h1>h1</h1>
+    <h2>h2</h2>
+    <p>not
+    == =</p>
+    """
+
 end
 
 @testset "the 'book' example input" begin
@@ -634,7 +641,7 @@ end
     @test md"""
     no|table
     no error
-    """ == MD([Paragraph(Any["no|table no error"])])
+    """ == MD([Paragraph(Any["no|table\nno error"])])
 
     t = """a   |   b
     :-- | --:
@@ -1069,7 +1076,8 @@ end
     # Rendering tests.
     expected =
             """
-            1. A paragraph with two lines.
+            1. A paragraph
+               with two lines.
 
                ```
                indented code
@@ -1099,7 +1107,8 @@ end
     expected =
             """
             <ol>
-            <li><p>A paragraph with two lines.</p>
+            <li><p>A paragraph
+            with two lines.</p>
             <pre><code>indented code
             </code></pre>
             <blockquote>
@@ -1137,7 +1146,8 @@ end
 
     expected =
             """
-            1. A paragraph with two lines.
+            1. A paragraph
+               with two lines.
 
                .. code-block:: julia
 

--- a/stdlib/Markdown/test/test_spec.jl
+++ b/stdlib/Markdown/test/test_spec.jl
@@ -191,7 +191,7 @@ end
     input = "&nbsp &x; &#; &#x;\n&#87654321;\n&#abcdef0;\n&ThisIsNotDefined; &hi?;\n"
     expected = "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x;\n&amp;#87654321;\n&amp;#abcdef0;\n&amp;ThisIsNotDefined; &amp;hi?;</p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 29
     input = "&copy\n"
@@ -579,7 +579,7 @@ end
     input = "Foo\n= =\n\nFoo\n--- -\n"
     expected = "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 89
     input = "Foo  \n-----\n"
@@ -675,13 +675,13 @@ end
     input = "Foo\nbar\n\n---\n\nbaz\n"
     expected = "<p>Foo\nbar</p>\n<hr />\n<p>baz</p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 105
     input = "Foo\nbar\n* * *\nbaz\n"
     expected = "<p>Foo\nbar</p>\n<hr />\n<p>baz</p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 106
     input = "Foo\nbar\n\\---\nbaz\n"
@@ -935,7 +935,7 @@ end
     input = "``` aa ```\nfoo\n"
     expected = "<p><code>aa</code>\nfoo</p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 146
     input = "~~~ aa ``` ~~~\nfoo\n~~~\n"
@@ -1357,7 +1357,7 @@ end
     input = "Foo\n[bar]: /baz\n\n[bar]\n"
     expected = "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 214
     input = "# [Foo]\n[foo]: /url\n> bar\n"
@@ -1406,7 +1406,7 @@ end
     input = "aaa\nbbb\n\nccc\nddd\n"
     expected = "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 221
     input = "aaa\n\n\nbbb\n"
@@ -1430,7 +1430,7 @@ end
     input = "   aaa\nbbb\n"
     expected = "<p>aaa\nbbb</p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 225
     input = "    aaa\nbbb\n"
@@ -1468,19 +1468,19 @@ end
     input = "> # Foo\n> bar\n> baz\n"
     expected = "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 229
     input = "># Foo\n>bar\n> baz\n"
     expected = "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 230
     input = "   > # Foo\n   > bar\n > baz\n"
     expected = "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 231
     input = "    > # Foo\n    > bar\n    > baz\n"
@@ -1558,7 +1558,7 @@ end
     input = "> foo\n> bar\n"
     expected = "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 244
     input = "> foo\n>\n> bar\n"
@@ -1625,7 +1625,7 @@ end
     input = "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n"
     expected = "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 254
     input = "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n"
@@ -2499,7 +2499,7 @@ end
     input = "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n"
     expected = "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 395
     input = "**foo \"*bar*\" foo**\n"
@@ -2565,7 +2565,7 @@ end
     input = "*foo\nbar*\n"
     expected = "<p><em>foo\nbar</em></p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 406
     input = "_foo __bar__ baz_\n"
@@ -2673,7 +2673,7 @@ end
     input = "**foo\nbar**\n"
     expected = "<p><strong>foo\nbar</strong></p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 424
     input = "__foo _bar_ baz__\n"
@@ -3082,7 +3082,7 @@ end
     input = "[link](foo\nbar)\n"
     expected = "<p>[link](foo\nbar)</p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 491
     input = "[link](<foo\nbar>)\n"
@@ -3889,7 +3889,7 @@ end
     input = "< a><\nfoo><bar/ >\n<foo bar=baz\nbim!bop />\n"
     expected = "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;\n&lt;foo bar=baz\nbim!bop /&gt;</p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 622
     input = "<a href='bar'title=title>\n"
@@ -4016,7 +4016,7 @@ end
     input = "`code\\\nspan`\n"
     expected = "<p><code>code\\ span</code></p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 642
     input = "<a href=\"foo  \nbar\">\n"
@@ -4065,7 +4065,7 @@ end
     input = "foo\nbaz\n"
     expected = "<p>foo\nbaz</p>\n"
     actual = Markdown.html(Markdown.parse(input))
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 649
     input = "foo \n baz\n"


### PR DESCRIPTION
This improves round-tripping of Markdown-to-Markdown. It also allows 20 additional CommonMark spec tests to pass.