### PR TITLE
Fix `@test_loweringerror` macro to return the `code` correctly.

### DIFF
--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -19,12 +19,12 @@ macro test_parseerror(str, msg)
 end
 
 macro test_loweringerror(ex, msg, opt=nothing)
-    code = :(@test Meta.lower(@__MODULE__, $(esc(ex))) == Expr(:error, $msg))
+    code = :(@test Meta.lower(@__MODULE__, $(esc(ex))) == Expr(:error, $(esc(msg))))
     code.args[2] = __source__
     if opt === :broken
         code.args[1] = :var"@test_broken"
     end
-    code
+    return code
 end
 
 macro test_parseerror(str)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -24,6 +24,7 @@ macro test_loweringerror(ex, msg, opt=nothing)
     if opt === :broken
         code.args[1] = :var"@test_broken"
     end
+    code
 end
 
 macro test_parseerror(str)


### PR DESCRIPTION
for the PR #60556,
the macro returns nothing so nothing has happened.

```julia
using Test

macro test_loweringerror1(ex, msg, opt=nothing)
    code = :(@test Meta.lower(@__MODULE__, $(esc(ex))) == Expr(:error, $msg))
    code.args[2] = __source__
    if opt === :broken
        code.args[1] = :var"@test_broken"
    end
end

macro test_loweringerror2(ex, msg, opt=nothing)
    code = :(@test Meta.lower(@__MODULE__, $(esc(ex))) == Expr(:error, $msg))
    code.args[2] = __source__
    if opt === :broken
        code.args[1] = :var"@test_broken"
    end
    code
end

@test @macroexpand(@test_loweringerror1(Meta.parse("x..."), "HappyNewYear")) === nothing
@test @macroexpand(@test_loweringerror2(Meta.parse("x..."), "HappyNewYear”")) isa Expr
```