### PR TITLE
[JuliaLowering] Fix-up always-defined check in `is_valid_body_ir_argument`

### DIFF
--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -103,7 +103,10 @@ function is_valid_body_ir_argument(ctx, ex)
         true
     elseif kind(ex) == K"BindingId"
         binfo = get_binding(ctx, ex)
-        binfo.kind == :argument && binfo.is_always_defined
+        # arguments are inherently always-defined, but the closure
+        # box analysis overrides this flag to mean "valid to leave
+        # unboxed" so we check for them specifically here
+        binfo.kind == :argument || binfo.is_always_defined
     else
         false
     end

--- a/JuliaLowering/test/assignments_ir.jl
+++ b/JuliaLowering/test/assignments_ir.jl
@@ -100,17 +100,15 @@ end
 3   (call %₂)
 4   TestMod.T
 5   (= slot₂/tmp %₃)
-6   slot₂/tmp
-7   (call core.isa %₆ %₄)
-8   (gotoifnot %₇ label₁₀)
-9   (goto label₁₃)
-10  slot₂/tmp
-11  (call top.convert %₄ %₁₀)
-12  (= slot₂/tmp (call core.typeassert %₁₁ %₄))
-13  slot₂/tmp
-14  (= slot₁/x %₁₃)
-15  slot₁/x
-16  (return %₁₅)
+6   (call core.isa slot₂/tmp %₄)
+7   (gotoifnot %₆ label₉)
+8   (goto label₁₁)
+9   (call top.convert %₄ slot₂/tmp)
+10  (= slot₂/tmp (call core.typeassert %₉ %₄))
+11  slot₂/tmp
+12  (= slot₁/x %₁₁)
+13  slot₁/x
+14  (return %₁₃)
 
 ########################################
 # "complex lhs" of `::T` => type-assert, not decl
@@ -136,15 +134,12 @@ X{T} = Y{T,T}
 #---------------------
 1   (call core.TypeVar :T)
 2   (= slot₁/T %₁)
-3   slot₁/T
-4   TestMod.Y
-5   slot₁/T
-6   slot₁/T
-7   (call core.apply_type %₄ %₅ %₆)
-8   (call core.UnionAll %₃ %₇)
-9   (call core.declare_const TestMod :X %₈)
-10  latestworld
-11  (return %₈)
+3   TestMod.Y
+4   (call core.apply_type %₃ slot₁/T slot₁/T)
+5   (call core.UnionAll slot₁/T %₄)
+6   (call core.declare_const TestMod :X %₅)
+7   latestworld
+8   (return %₅)
 
 ########################################
 # UnionAll expansion in local scope
@@ -154,14 +149,11 @@ end
 #---------------------
 1   (call core.TypeVar :T)
 2   (= slot₂/T %₁)
-3   slot₂/T
-4   TestMod.Y
-5   slot₂/T
-6   slot₂/T
-7   (call core.apply_type %₄ %₅ %₆)
-8   (call core.UnionAll %₃ %₇)
-9   (= slot₁/X %₈)
-10  (return %₈)
+3   TestMod.Y
+4   (call core.apply_type %₃ slot₂/T slot₂/T)
+5   (call core.UnionAll slot₂/T %₄)
+6   (= slot₁/X %₅)
+7   (return %₅)
 
 ########################################
 # Error: Invalid lhs in `=`

--- a/JuliaLowering/test/closures_ir.jl
+++ b/JuliaLowering/test/closures_ir.jl
@@ -480,12 +480,11 @@ end
 #---------------------
 1   1
 2   (= slot₁/y (call core.Box))
-3   slot₁/y
-4   (call core.setfield! %₃ :contents %₁)
-5   TestMod.T
-6   (call core.apply_type core.Tuple core.Any %₅)
-7   (call core.apply_type core.Union)
-8   --- opaque_closure_method  core.nothing 2 false SourceLocation::2:31
+3   (call core.setfield! slot₁/y :contents %₁)
+4   TestMod.T
+5   (call core.apply_type core.Tuple core.Any %₄)
+6   (call core.apply_type core.Union)
+7   --- opaque_closure_method  core.nothing 2 false SourceLocation::2:31
     slots: [slot₁/#self#(!read) slot₂/x slot₃/z slot₄/y(!read,maybe_undef)]
     1   TestMod.-
     2   TestMod.+
@@ -501,9 +500,8 @@ end
     12  (call %₂ %₄ %₁₁)
     13  (call %₁ %₁₂ slot₃/z)
     14  (return %₁₃)
-9   slot₁/y
-10  (new_opaque_closure %₆ %₇ core.Any true %₈ %₉)
-11  (return %₁₀)
+8   (new_opaque_closure %₅ %₆ core.Any true %₇ slot₁/y)
+9   (return %₈)
 
 ########################################
 # Opaque closure with `...`
@@ -614,33 +612,31 @@ end
 1   TestMod.y_init
 2   (= slot₁/y (call core.Box))
 3   (= slot₂/#f_kw_closure#0 (call core.Box))
-4   slot₁/y
-5   (call core.setfield! %₄ :contents %₁)
-6   (call core.svec :#f_kw_closure#0)
-7   (call core.svec true)
-8   (call JuliaLowering.eval_closure_type TestMod :#f_kw_closure##0 %₆ %₇)
-9   latestworld
-10  TestMod.#f_kw_closure##0
-11  slot₂/#f_kw_closure#0
-12  (new %₁₀ %₁₁)
-13  (= slot₃/f_kw_closure %₁₂)
-14  (call core.svec :y)
-15  (call core.svec true)
-16  (call JuliaLowering.eval_closure_type TestMod :##f_kw_closure#0##0 %₁₄ %₁₅)
-17  latestworld
-18  TestMod.##f_kw_closure#0##0
-19  slot₁/y
-20  (new %₁₈ %₁₉)
-21  slot₂/#f_kw_closure#0
-22  (call core.setfield! %₂₁ :contents %₂₀)
-23  TestMod.##f_kw_closure#0##0
-24  TestMod.X
-25  TestMod.#f_kw_closure##0
-26  (call core.svec %₂₃ %₂₄ %₂₅)
-27  (call core.svec)
-28  SourceLocation::2:14
-29  (call core.svec %₂₆ %₂₇ %₂₈)
-30  --- method core.nothing %₂₉
+4   (call core.setfield! slot₁/y :contents %₁)
+5   (call core.svec :#f_kw_closure#0)
+6   (call core.svec true)
+7   (call JuliaLowering.eval_closure_type TestMod :#f_kw_closure##0 %₅ %₆)
+8   latestworld
+9   TestMod.#f_kw_closure##0
+10  slot₂/#f_kw_closure#0
+11  (new %₉ %₁₀)
+12  (= slot₃/f_kw_closure %₁₁)
+13  (call core.svec :y)
+14  (call core.svec true)
+15  (call JuliaLowering.eval_closure_type TestMod :##f_kw_closure#0##0 %₁₃ %₁₄)
+16  latestworld
+17  TestMod.##f_kw_closure#0##0
+18  (new %₁₇ slot₁/y)
+19  slot₂/#f_kw_closure#0
+20  (call core.setfield! %₁₉ :contents %₁₈)
+21  TestMod.##f_kw_closure#0##0
+22  TestMod.X
+23  TestMod.#f_kw_closure##0
+24  (call core.svec %₂₁ %₂₂ %₂₃)
+25  (call core.svec)
+26  SourceLocation::2:14
+27  (call core.svec %₂₄ %₂₅ %₂₆)
+28  --- method core.nothing %₂₇
     slots: [slot₁/#self#(!read) slot₂/x slot₃/#self# slot₄/y(!read,maybe_undef)]
     1   (meta :nkw 1)
     2   TestMod.+
@@ -653,14 +649,14 @@ end
     9   (call core.getfield %₃ :contents)
     10  (call %₂ slot₂/x %₉)
     11  (return %₁₀)
-31  latestworld
-32  (call core.typeof core.kwcall)
-33  TestMod.#f_kw_closure##0
-34  (call core.svec %₃₂ core.NamedTuple %₃₃)
-35  (call core.svec)
-36  SourceLocation::2:14
-37  (call core.svec %₃₄ %₃₅ %₃₆)
-38  --- code_info
+29  latestworld
+30  (call core.typeof core.kwcall)
+31  TestMod.#f_kw_closure##0
+32  (call core.svec %₃₀ core.NamedTuple %₃₁)
+33  (call core.svec)
+34  SourceLocation::2:14
+35  (call core.svec %₃₂ %₃₃ %₃₄)
+36  --- code_info
     slots: [slot₁/#self#(!read) slot₂/kws slot₃/#self# slot₄/kwtmp slot₅/x(!read) slot₆/#f_kw_closure#0(!read,maybe_undef)]
     1   (newvar slot₅/x)
     2   (call core.isdefined slot₂/kws :x)
@@ -694,17 +690,17 @@ end
     30  (call core.getfield %₂₄ :contents)
     31  (call %₃₀ %₁₆ slot₃/#self#)
     32  (return %₃₁)
-39  slot₂/#f_kw_closure#0
-40  (call core.svec %₃₉)
-41  (call JuliaLowering.replace_captured_locals! %₃₈ %₄₀)
-42  --- method core.nothing %₃₇ %₄₁
-43  latestworld
-44  TestMod.#f_kw_closure##0
-45  (call core.svec %₄₄)
-46  (call core.svec)
-47  SourceLocation::2:14
-48  (call core.svec %₄₅ %₄₆ %₄₇)
-49  --- method core.nothing %₄₈
+37  slot₂/#f_kw_closure#0
+38  (call core.svec %₃₇)
+39  (call JuliaLowering.replace_captured_locals! %₃₆ %₃₈)
+40  --- method core.nothing %₃₅ %₃₉
+41  latestworld
+42  TestMod.#f_kw_closure##0
+43  (call core.svec %₄₂)
+44  (call core.svec)
+45  SourceLocation::2:14
+46  (call core.svec %₄₃ %₄₄ %₄₅)
+47  --- method core.nothing %₄₆
     slots: [slot₁/#self# slot₂/#f_kw_closure#0(!read,maybe_undef)]
     1   (call core.getfield slot₁/#self# :#f_kw_closure#0)
     2   (call core.isdefined %₁ :contents)
@@ -716,9 +712,9 @@ end
     8   TestMod.x_default
     9   (call %₇ %₈ slot₁/#self#)
     10  (return %₉)
-50  latestworld
-51  slot₃/f_kw_closure
-52  (return %₅₁)
+48  latestworld
+49  slot₃/f_kw_closure
+50  (return %₄₉)
 
 ########################################
 # Closure capturing a typed local must also capture the type expression
@@ -743,16 +739,14 @@ slots: [slot₁/#self#(!read) slot₂/T(!read,maybe_undef) slot₃/tmp(!read)]
 8   slot₂/T
 9   (call core.getfield %₃ :contents)
 10  (= slot₃/tmp %₁)
-11  slot₃/tmp
-12  (call core.isa %₁₁ %₉)
-13  (gotoifnot %₁₂ label₁₅)
-14  (goto label₁₈)
-15  slot₃/tmp
-16  (call top.convert %₉ %₁₅)
-17  (= slot₃/tmp (call core.typeassert %₁₆ %₉))
-18  slot₃/tmp
-19  (call core.setfield! %₂ :contents %₁₈)
-20  (return %₁)
+11  (call core.isa slot₃/tmp %₉)
+12  (gotoifnot %₁₁ label₁₄)
+13  (goto label₁₆)
+14  (call top.convert %₉ slot₃/tmp)
+15  (= slot₃/tmp (call core.typeassert %₁₄ %₉))
+16  slot₃/tmp
+17  (call core.setfield! %₂ :contents %₁₆)
+18  (return %₁)
 
 ########################################
 # Error: Closure outside any top level context

--- a/JuliaLowering/test/decls_ir.jl
+++ b/JuliaLowering/test/decls_ir.jl
@@ -8,16 +8,14 @@ end
 2   1
 3   TestMod.T
 4   (= slot₂/tmp %₂)
-5   slot₂/tmp
-6   (call core.isa %₅ %₃)
-7   (gotoifnot %₆ label₉)
-8   (goto label₁₂)
-9   slot₂/tmp
-10  (call top.convert %₃ %₉)
-11  (= slot₂/tmp (call core.typeassert %₁₀ %₃))
-12  slot₂/tmp
-13  (= slot₁/x %₁₂)
-14  (return %₂)
+5   (call core.isa slot₂/tmp %₃)
+6   (gotoifnot %₅ label₈)
+7   (goto label₁₀)
+8   (call top.convert %₃ slot₂/tmp)
+9   (= slot₂/tmp (call core.typeassert %₈ %₃))
+10  slot₂/tmp
+11  (= slot₁/x %₁₀)
+12  (return %₂)
 
 ########################################
 # Error: Local declarations outside a scope are disallowed
@@ -102,17 +100,15 @@ const xx::T = 10
 #---------------------
 1   TestMod.T
 2   (= slot₁/tmp 10)
-3   slot₁/tmp
-4   (call core.isa %₃ %₁)
-5   (gotoifnot %₄ label₇)
-6   (goto label₁₀)
-7   slot₁/tmp
-8   (call top.convert %₁ %₇)
-9   (= slot₁/tmp (call core.typeassert %₈ %₁))
-10  slot₁/tmp
-11  (call core.declare_const TestMod :xx %₁₀)
-12  latestworld
-13  (return %₁₀)
+3   (call core.isa slot₁/tmp %₁)
+4   (gotoifnot %₃ label₆)
+5   (goto label₈)
+6   (call top.convert %₁ slot₁/tmp)
+7   (= slot₁/tmp (call core.typeassert %₆ %₁))
+8   slot₁/tmp
+9   (call core.declare_const TestMod :xx %₈)
+10  latestworld
+11  (return %₈)
 
 ########################################
 # Const tuple
@@ -141,27 +137,23 @@ const c0 = v0 = v1 = 123
 5   latestworld
 6   (call core.get_binding_type TestMod :v0)
 7   (= slot₁/tmp %₁)
-8   slot₁/tmp
-9   (call core.isa %₈ %₆)
-10  (gotoifnot %₉ label₁₂)
-11  (goto label₁₄)
+8   (call core.isa slot₁/tmp %₆)
+9   (gotoifnot %₈ label₁₁)
+10  (goto label₁₂)
+11  (= slot₁/tmp (call top.convert %₆ slot₁/tmp))
 12  slot₁/tmp
-13  (= slot₁/tmp (call top.convert %₆ %₁₂))
-14  slot₁/tmp
-15  (call core.setglobal! TestMod :v0 %₁₄)
-16  (call core.declare_global TestMod :v1 true)
-17  latestworld
-18  (call core.get_binding_type TestMod :v1)
-19  (= slot₂/tmp %₁)
-20  slot₂/tmp
-21  (call core.isa %₂₀ %₁₈)
-22  (gotoifnot %₂₁ label₂₄)
-23  (goto label₂₆)
-24  slot₂/tmp
-25  (= slot₂/tmp (call top.convert %₁₈ %₂₄))
-26  slot₂/tmp
-27  (call core.setglobal! TestMod :v1 %₂₆)
-28  (return %₁)
+13  (call core.setglobal! TestMod :v0 %₁₂)
+14  (call core.declare_global TestMod :v1 true)
+15  latestworld
+16  (call core.get_binding_type TestMod :v1)
+17  (= slot₂/tmp %₁)
+18  (call core.isa slot₂/tmp %₁₆)
+19  (gotoifnot %₁₈ label₂₁)
+20  (goto label₂₂)
+21  (= slot₂/tmp (call top.convert %₁₆ slot₂/tmp))
+22  slot₂/tmp
+23  (call core.setglobal! TestMod :v1 %₂₂)
+24  (return %₁)
 
 ########################################
 # Global assignment
@@ -171,15 +163,13 @@ xx = 10
 2   latestworld
 3   (call core.get_binding_type TestMod :xx)
 4   (= slot₁/tmp 10)
-5   slot₁/tmp
-6   (call core.isa %₅ %₃)
-7   (gotoifnot %₆ label₉)
-8   (goto label₁₁)
+5   (call core.isa slot₁/tmp %₃)
+6   (gotoifnot %₅ label₈)
+7   (goto label₉)
+8   (= slot₁/tmp (call top.convert %₃ slot₁/tmp))
 9   slot₁/tmp
-10  (= slot₁/tmp (call top.convert %₃ %₉))
-11  slot₁/tmp
-12  (call core.setglobal! TestMod :xx %₁₁)
-13  (return 10)
+10  (call core.setglobal! TestMod :xx %₉)
+11  (return 10)
 
 ########################################
 # Typed global assignment
@@ -194,15 +184,13 @@ global xx::T = 10
 7   latestworld
 8   (call core.get_binding_type TestMod :xx)
 9   (= slot₁/tmp 10)
-10  slot₁/tmp
-11  (call core.isa %₁₀ %₈)
-12  (gotoifnot %₁₁ label₁₄)
-13  (goto label₁₆)
+10  (call core.isa slot₁/tmp %₈)
+11  (gotoifnot %₁₀ label₁₃)
+12  (goto label₁₄)
+13  (= slot₁/tmp (call top.convert %₈ slot₁/tmp))
 14  slot₁/tmp
-15  (= slot₁/tmp (call top.convert %₈ %₁₄))
-16  slot₁/tmp
-17  (call core.setglobal! TestMod :xx %₁₆)
-18  (return 10)
+15  (call core.setglobal! TestMod :xx %₁₄)
+16  (return 10)
 
 ########################################
 # Error: x declared twice
@@ -268,29 +256,25 @@ end
     2   1
     3   TestMod.Int
     4   (= slot₃/tmp %₂)
-    5   slot₃/tmp
-    6   (call core.isa %₅ %₃)
-    7   (gotoifnot %₆ label₉)
-    8   (goto label₁₂)
-    9   slot₃/tmp
-    10  (call top.convert %₃ %₉)
-    11  (= slot₃/tmp (call core.typeassert %₁₀ %₃))
-    12  slot₃/tmp
-    13  (= slot₅/x %₁₂)
-    14  2.0
-    15  TestMod.Int
-    16  (= slot₄/tmp %₁₄)
-    17  slot₄/tmp
-    18  (call core.isa %₁₇ %₁₅)
-    19  (gotoifnot %₁₈ label₂₁)
-    20  (goto label₂₄)
-    21  slot₄/tmp
-    22  (call top.convert %₁₅ %₂₁)
-    23  (= slot₄/tmp (call core.typeassert %₂₂ %₁₅))
-    24  slot₄/tmp
-    25  (= slot₅/x %₂₄)
-    26  slot₅/x
-    27  (return %₂₆)
+    5   (call core.isa slot₃/tmp %₃)
+    6   (gotoifnot %₅ label₈)
+    7   (goto label₁₀)
+    8   (call top.convert %₃ slot₃/tmp)
+    9   (= slot₃/tmp (call core.typeassert %₈ %₃))
+    10  slot₃/tmp
+    11  (= slot₅/x %₁₀)
+    12  2.0
+    13  TestMod.Int
+    14  (= slot₄/tmp %₁₂)
+    15  (call core.isa slot₄/tmp %₁₃)
+    16  (gotoifnot %₁₅ label₁₈)
+    17  (goto label₂₀)
+    18  (call top.convert %₁₃ slot₄/tmp)
+    19  (= slot₄/tmp (call core.typeassert %₁₈ %₁₃))
+    20  slot₄/tmp
+    21  (= slot₅/x %₂₀)
+    22  slot₅/x
+    23  (return %₂₂)
 10  latestworld
 11  TestMod.f
 12  (return %₁₁)

--- a/JuliaLowering/test/destructuring_ir.jl
+++ b/JuliaLowering/test/destructuring_ir.jl
@@ -359,16 +359,14 @@ end
 3   (call top.getproperty %₂ :x)
 4   TestMod.T
 5   (= slot₂/tmp %₃)
-6   slot₂/tmp
-7   (call core.isa %₆ %₄)
-8   (gotoifnot %₇ label₁₀)
-9   (goto label₁₃)
-10  slot₂/tmp
-11  (call top.convert %₄ %₁₀)
-12  (= slot₂/tmp (call core.typeassert %₁₁ %₄))
-13  slot₂/tmp
-14  (= slot₁/x %₁₃)
-15  (return %₂)
+6   (call core.isa slot₂/tmp %₄)
+7   (gotoifnot %₆ label₉)
+8   (goto label₁₁)
+9   (call top.convert %₄ slot₂/tmp)
+10  (= slot₂/tmp (call core.typeassert %₉ %₄))
+11  slot₂/tmp
+12  (= slot₁/x %₁₁)
+13  (return %₂)
 
 ########################################
 # Error: Property destructuring with frankentuple

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -294,15 +294,13 @@ end
     1   TestMod.Int
     2   (gotoifnot slot₂/x label₃)
     3   (= slot₃/tmp 0xff)
-    4   slot₃/tmp
-    5   (call core.isa %₄ %₁)
-    6   (gotoifnot %₅ label₈)
-    7   (goto label₁₁)
-    8   slot₃/tmp
-    9   (call top.convert %₁ %₈)
-    10  (= slot₃/tmp (call core.typeassert %₉ %₁))
-    11  slot₃/tmp
-    12  (return %₁₁)
+    4   (call core.isa slot₃/tmp %₁)
+    5   (gotoifnot %₄ label₇)
+    6   (goto label₉)
+    7   (call top.convert %₁ slot₃/tmp)
+    8   (= slot₃/tmp (call core.typeassert %₇ %₁))
+    9   slot₃/tmp
+    10  (return %₉)
 10  latestworld
 11  TestMod.f
 12  (return %₁₁)
@@ -910,15 +908,13 @@ end
     slots: [slot₁/#self#(called) slot₂/x(!read) slot₃/tmp(!read)]
     1   TestMod.T
     2   (= slot₃/tmp core.nothing)
-    3   slot₃/tmp
-    4   (call core.isa %₃ %₁)
-    5   (gotoifnot %₄ label₇)
-    6   (goto label₁₀)
-    7   slot₃/tmp
-    8   (call top.convert %₁ %₇)
-    9   (= slot₃/tmp (call core.typeassert %₈ %₁))
-    10  slot₃/tmp
-    11  (return %₁₀)
+    3   (call core.isa slot₃/tmp %₁)
+    4   (gotoifnot %₃ label₆)
+    5   (goto label₈)
+    6   (call top.convert %₁ slot₃/tmp)
+    7   (= slot₃/tmp (call core.typeassert %₆ %₁))
+    8   slot₃/tmp
+    9   (return %₈)
 18  latestworld
 19  TestMod.f
 20  (return %₁₉)

--- a/JuliaLowering/test/generators_ir.jl
+++ b/JuliaLowering/test/generators_ir.jl
@@ -260,7 +260,7 @@ T[(x,y) for x in xs, y in ys]
 11  slot₃/next
 12  (call core.=== %₁₁ core.nothing)
 13  (call top.not_int %₁₂)
-14  (gotoifnot %₁₃ label₅₀)
+14  (gotoifnot %₁₃ label₄₉)
 15  slot₃/next
 16  (= slot₄/y (call core.getfield %₁₅ 1))
 17  (call core.getfield %₁₅ 2)
@@ -268,32 +268,31 @@ T[(x,y) for x in xs, y in ys]
 19  slot₂/next
 20  (call core.=== %₁₉ core.nothing)
 21  (call top.not_int %₂₀)
-22  (gotoifnot %₂₁ label₄₄)
+22  (gotoifnot %₂₁ label₄₃)
 23  slot₄/y
 24  (= slot₅/y %₂₃)
 25  slot₂/next
 26  (= slot₆/x (call core.getfield %₂₅ 1))
 27  (call core.getfield %₂₅ 2)
 28  slot₆/x
-29  slot₅/y
-30  (call core.tuple %₂₈ %₂₉)
-31  (gotoifnot %₅ label₃₄)
-32  (call top.push! %₇ %₃₀)
-33  (goto label₃₆)
-34  slot₁/idx
-35  (call top.setindex! %₇ %₃₀ %₃₄)
-36  slot₁/idx
-37  (= slot₁/idx (call top.add_int %₃₆ 1))
-38  (= slot₂/next (call top.iterate %₁ %₂₇))
-39  slot₂/next
-40  (call core.=== %₃₉ core.nothing)
-41  (call top.not_int %₄₀)
-42  (gotoifnot %₄₁ label₄₄)
-43  (goto label₂₃)
-44  (= slot₃/next (call top.iterate %₂ %₁₇))
-45  slot₃/next
-46  (call core.=== %₄₅ core.nothing)
-47  (call top.not_int %₄₆)
-48  (gotoifnot %₄₇ label₅₀)
-49  (goto label₁₅)
-50  (return %₇)
+29  (call core.tuple %₂₈ slot₅/y)
+30  (gotoifnot %₅ label₃₃)
+31  (call top.push! %₇ %₂₉)
+32  (goto label₃₅)
+33  slot₁/idx
+34  (call top.setindex! %₇ %₂₉ %₃₃)
+35  slot₁/idx
+36  (= slot₁/idx (call top.add_int %₃₅ 1))
+37  (= slot₂/next (call top.iterate %₁ %₂₇))
+38  slot₂/next
+39  (call core.=== %₃₈ core.nothing)
+40  (call top.not_int %₃₉)
+41  (gotoifnot %₄₀ label₄₃)
+42  (goto label₂₃)
+43  (= slot₃/next (call top.iterate %₂ %₁₇))
+44  slot₃/next
+45  (call core.=== %₄₄ core.nothing)
+46  (call top.not_int %₄₅)
+47  (gotoifnot %₄₆ label₄₉)
+48  (goto label₁₅)
+49  (return %₇)

--- a/JuliaLowering/test/quoting_ir.jl
+++ b/JuliaLowering/test/quoting_ir.jl
@@ -39,10 +39,9 @@ end
 #---------------------
 1   1
 2   (= slot₁/x %₁)
-3   slot₁/x
-4   (call core.tuple %₃)
-5   (call JuliaLowering.interpolate_ast SyntaxTree (inert (. A ($ x))) %₄)
-6   (return %₅)
+3   (call core.tuple slot₁/x)
+4   (call JuliaLowering.interpolate_ast SyntaxTree (inert (. A ($ x))) %₃)
+5   (return %₄)
 
 ########################################
 # Error: Double escape

--- a/JuliaLowering/test/scopes_ir.jl
+++ b/JuliaLowering/test/scopes_ir.jl
@@ -13,18 +13,16 @@ end
 2   TestMod.T
 3   (newvar slot₂/T)
 4   (= slot₃/tmp %₁)
-5   slot₃/tmp
-6   (call core.isa %₅ %₂)
-7   (gotoifnot %₆ label₉)
-8   (goto label₁₂)
-9   slot₃/tmp
-10  (call top.convert %₂ %₉)
-11  (= slot₃/tmp (call core.typeassert %₁₀ %₂))
-12  slot₃/tmp
-13  (= slot₁/x %₁₂)
-14  (= slot₂/T 1)
-15  slot₂/T
-16  (return %₁₅)
+5   (call core.isa slot₃/tmp %₂)
+6   (gotoifnot %₅ label₈)
+7   (goto label₁₀)
+8   (call top.convert %₂ slot₃/tmp)
+9   (= slot₃/tmp (call core.typeassert %₈ %₂))
+10  slot₃/tmp
+11  (= slot₁/x %₁₀)
+12  (= slot₂/T 1)
+13  slot₂/T
+14  (return %₁₃)
 
 ########################################
 # let syntax with tuple on lhs
@@ -60,10 +58,9 @@ end
 3   (call %₁ %₂)
 4   (= slot₁/x %₃)
 5   TestMod.g
-6   slot₁/x
-7   (call %₅ %₆)
-8   (= slot₂/x %₇)
-9   (return core.nothing)
+6   (call %₅ slot₁/x)
+7   (= slot₂/x %₆)
+8   (return core.nothing)
 
 ########################################
 # let syntax with a function definition in the binding list creates a closure
@@ -403,40 +400,38 @@ end
 #---------------------
 1   1
 2   (= slot₁/x (call core.Box))
-3   slot₁/x
-4   (call core.setfield! %₃ :contents %₁)
-5   (call core.declare_global TestMod :f false)
-6   latestworld
-7   (method TestMod.f)
-8   latestworld
-9   TestMod.f
-10  (call core.Typeof %₉)
-11  (call core.svec %₁₀ core.Any)
-12  (call core.svec)
-13  SourceLocation::2:12
-14  (call core.svec %₁₁ %₁₂ %₁₃)
-15  --- code_info
+3   (call core.setfield! slot₁/x :contents %₁)
+4   (call core.declare_global TestMod :f false)
+5   latestworld
+6   (method TestMod.f)
+7   latestworld
+8   TestMod.f
+9   (call core.Typeof %₈)
+10  (call core.svec %₉ core.Any)
+11  (call core.svec)
+12  SourceLocation::2:12
+13  (call core.svec %₁₀ %₁₁ %₁₂)
+14  --- code_info
     slots: [slot₁/#self#(!read) slot₂/y]
     1   slot₂/y
     2   (captured_local 1)
     3   (call core.setfield! %₂ :contents %₁)
     4   (return %₁)
-16  slot₁/x
-17  (call core.svec %₁₆)
-18  (call JuliaLowering.replace_captured_locals! %₁₅ %₁₇)
-19  --- method core.nothing %₁₄ %₁₈
+15  (call core.svec slot₁/x)
+16  (call JuliaLowering.replace_captured_locals! %₁₄ %₁₅)
+17  --- method core.nothing %₁₃ %₁₆
+18  latestworld
+19  (call core.declare_global TestMod :g false)
 20  latestworld
-21  (call core.declare_global TestMod :g false)
+21  (method TestMod.g)
 22  latestworld
-23  (method TestMod.g)
-24  latestworld
-25  TestMod.g
-26  (call core.Typeof %₂₅)
-27  (call core.svec %₂₆)
-28  (call core.svec)
-29  SourceLocation::3:12
-30  (call core.svec %₂₇ %₂₈ %₂₉)
-31  --- code_info
+23  TestMod.g
+24  (call core.Typeof %₂₃)
+25  (call core.svec %₂₄)
+26  (call core.svec)
+27  SourceLocation::3:12
+28  (call core.svec %₂₅ %₂₆ %₂₇)
+29  --- code_info
     slots: [slot₁/#self#(!read) slot₂/x(!read,maybe_undef)]
     1   (captured_local 1)
     2   (call core.isdefined %₁ :contents)
@@ -446,13 +441,12 @@ end
     6   slot₂/x
     7   (call core.getfield %₁ :contents)
     8   (return %₇)
-32  slot₁/x
-33  (call core.svec %₃₂)
-34  (call JuliaLowering.replace_captured_locals! %₃₁ %₃₃)
-35  --- method core.nothing %₃₀ %₃₄
-36  latestworld
-37  TestMod.g
-38  (return %₃₇)
+30  (call core.svec slot₁/x)
+31  (call JuliaLowering.replace_captured_locals! %₂₉ %₃₀)
+32  --- method core.nothing %₂₈ %₃₁
+33  latestworld
+34  TestMod.g
+35  (return %₃₄)
 
 ########################################
 # Modify assignment operator on closure variable
@@ -462,19 +456,18 @@ end
 #---------------------
 1   1
 2   (= slot₁/x (call core.Box))
-3   slot₁/x
-4   (call core.setfield! %₃ :contents %₁)
-5   (call core.declare_global TestMod :f false)
-6   latestworld
-7   (method TestMod.f)
-8   latestworld
-9   TestMod.f
-10  (call core.Typeof %₉)
-11  (call core.svec %₁₀)
-12  (call core.svec)
-13  SourceLocation::2:12
-14  (call core.svec %₁₁ %₁₂ %₁₃)
-15  --- code_info
+3   (call core.setfield! slot₁/x :contents %₁)
+4   (call core.declare_global TestMod :f false)
+5   latestworld
+6   (method TestMod.f)
+7   latestworld
+8   TestMod.f
+9   (call core.Typeof %₈)
+10  (call core.svec %₉)
+11  (call core.svec)
+12  SourceLocation::2:12
+13  (call core.svec %₁₀ %₁₁ %₁₂)
+14  --- code_info
     slots: [slot₁/#self#(!read) slot₂/x(!read,maybe_undef)]
     1   TestMod.+
     2   (captured_local 1)
@@ -488,10 +481,9 @@ end
     10  (captured_local 1)
     11  (call core.setfield! %₁₀ :contents %₉)
     12  (return %₉)
-16  slot₁/x
-17  (call core.svec %₁₆)
-18  (call JuliaLowering.replace_captured_locals! %₁₅ %₁₇)
-19  --- method core.nothing %₁₄ %₁₈
-20  latestworld
-21  TestMod.f
-22  (return %₂₁)
+15  (call core.svec slot₁/x)
+16  (call JuliaLowering.replace_captured_locals! %₁₄ %₁₅)
+17  --- method core.nothing %₁₃ %₁₆
+18  latestworld
+19  TestMod.f
+20  (return %₁₉)

--- a/JuliaLowering/test/typedefs_ir.jl
+++ b/JuliaLowering/test/typedefs_ir.jl
@@ -4,10 +4,9 @@ A where X
 #---------------------
 1   (call core.TypeVar :X)
 2   (= slot₁/X %₁)
-3   slot₁/X
-4   TestMod.A
-5   (call core.UnionAll %₃ %₄)
-6   (return %₅)
+3   TestMod.A
+4   (call core.UnionAll slot₁/X %₃)
+5   (return %₄)
 
 ########################################
 # where expression with upper bound
@@ -16,10 +15,9 @@ A where X <: UB
 1   TestMod.UB
 2   (call core.TypeVar :X %₁)
 3   (= slot₁/X %₂)
-4   slot₁/X
-5   TestMod.A
-6   (call core.UnionAll %₄ %₅)
-7   (return %₆)
+4   TestMod.A
+5   (call core.UnionAll slot₁/X %₄)
+6   (return %₅)
 
 ########################################
 # where expression with lower bound
@@ -28,10 +26,9 @@ A where X >: LB
 1   TestMod.LB
 2   (call core.TypeVar :X %₁ core.Any)
 3   (= slot₁/X %₂)
-4   slot₁/X
-5   TestMod.A
-6   (call core.UnionAll %₄ %₅)
-7   (return %₆)
+4   TestMod.A
+5   (call core.UnionAll slot₁/X %₄)
+6   (return %₅)
 
 ########################################
 # where expression with both bounds
@@ -41,10 +38,9 @@ A where LB <: X <: UB
 2   TestMod.UB
 3   (call core.TypeVar :X %₁ %₂)
 4   (= slot₁/X %₃)
-5   slot₁/X
-6   TestMod.A
-7   (call core.UnionAll %₅ %₆)
-8   (return %₇)
+5   TestMod.A
+6   (call core.UnionAll slot₁/X %₅)
+7   (return %₆)
 
 ########################################
 # where expression with braces
@@ -52,15 +48,12 @@ A where {X, Y<:X}
 #---------------------
 1   (call core.TypeVar :X)
 2   (= slot₁/X %₁)
-3   slot₁/X
-4   slot₁/X
-5   (call core.TypeVar :Y %₄)
-6   (= slot₂/Y %₅)
-7   slot₂/Y
-8   TestMod.A
-9   (call core.UnionAll %₇ %₈)
-10  (call core.UnionAll %₃ %₉)
-11  (return %₁₀)
+3   (call core.TypeVar :Y slot₁/X)
+4   (= slot₂/Y %₃)
+5   TestMod.A
+6   (call core.UnionAll slot₂/Y %₅)
+7   (call core.UnionAll slot₁/X %₆)
+8   (return %₇)
 
 ########################################
 # Equivalent nested where expression without braces
@@ -68,15 +61,12 @@ A where Y<:X where X
 #---------------------
 1   (call core.TypeVar :X)
 2   (= slot₁/X %₁)
-3   slot₁/X
-4   slot₁/X
-5   (call core.TypeVar :Y %₄)
-6   (= slot₂/Y %₅)
-7   slot₂/Y
-8   TestMod.A
-9   (call core.UnionAll %₇ %₈)
-10  (call core.UnionAll %₃ %₉)
-11  (return %₁₀)
+3   (call core.TypeVar :Y slot₁/X)
+4   (= slot₂/Y %₃)
+5   TestMod.A
+6   (call core.UnionAll slot₂/Y %₅)
+7   (call core.UnionAll slot₁/X %₆)
+8   (return %₇)
 
 ########################################
 # Error: bad type bounds
@@ -191,8 +181,29 @@ abstract type A end
 2   (call core._abstracttype TestMod :A %₁)
 3   (= slot₁/A %₂)
 4   (call core._setsuper! %₂ core.Any)
-5   slot₁/A
-6   (call core._typebody! false %₅)
+5   (call core._typebody! false slot₁/A)
+6   (call core.declare_global TestMod :A false)
+7   latestworld
+8   (call core.isdefinedglobal TestMod :A false)
+9   (gotoifnot %₈ label₁₄)
+10  TestMod.A
+11  (call core._equiv_typedef %₁₀ %₂)
+12  (gotoifnot %₁₁ label₁₄)
+13  (goto label₁₆)
+14  (call core.declare_const TestMod :A %₂)
+15  latestworld
+16  (return core.nothing)
+
+########################################
+# Abstract type definition with supertype
+abstract type A <: B end
+#---------------------
+1   (call core.svec)
+2   (call core._abstracttype TestMod :A %₁)
+3   (= slot₁/A %₂)
+4   TestMod.B
+5   (call core._setsuper! %₂ %₄)
+6   (call core._typebody! false slot₁/A)
 7   (call core.declare_global TestMod :A false)
 8   latestworld
 9   (call core.isdefinedglobal TestMod :A false)
@@ -204,29 +215,6 @@ abstract type A end
 15  (call core.declare_const TestMod :A %₂)
 16  latestworld
 17  (return core.nothing)
-
-########################################
-# Abstract type definition with supertype
-abstract type A <: B end
-#---------------------
-1   (call core.svec)
-2   (call core._abstracttype TestMod :A %₁)
-3   (= slot₁/A %₂)
-4   TestMod.B
-5   (call core._setsuper! %₂ %₄)
-6   slot₁/A
-7   (call core._typebody! false %₆)
-8   (call core.declare_global TestMod :A false)
-9   latestworld
-10  (call core.isdefinedglobal TestMod :A false)
-11  (gotoifnot %₁₀ label₁₆)
-12  TestMod.A
-13  (call core._equiv_typedef %₁₂ %₂)
-14  (gotoifnot %₁₃ label₁₆)
-15  (goto label₁₈)
-16  (call core.declare_const TestMod :A %₂)
-17  latestworld
-18  (return core.nothing)
 
 ########################################
 # Abstract type definition with multiple typevars
@@ -241,19 +229,18 @@ abstract type A{X, Y <: X} end
 7   (call core._abstracttype TestMod :A %₆)
 8   (= slot₁/A %₇)
 9   (call core._setsuper! %₇ core.Any)
-10  slot₁/A
-11  (call core._typebody! false %₁₀)
-12  (call core.declare_global TestMod :A false)
-13  latestworld
-14  (call core.isdefinedglobal TestMod :A false)
-15  (gotoifnot %₁₄ label₂₀)
-16  TestMod.A
-17  (call core._equiv_typedef %₁₆ %₇)
-18  (gotoifnot %₁₇ label₂₀)
-19  (goto label₂₂)
-20  (call core.declare_const TestMod :A %₇)
-21  latestworld
-22  (return core.nothing)
+10  (call core._typebody! false slot₁/A)
+11  (call core.declare_global TestMod :A false)
+12  latestworld
+13  (call core.isdefinedglobal TestMod :A false)
+14  (gotoifnot %₁₃ label₁₉)
+15  TestMod.A
+16  (call core._equiv_typedef %₁₅ %₇)
+17  (gotoifnot %₁₆ label₁₉)
+18  (goto label₂₁)
+19  (call core.declare_const TestMod :A %₇)
+20  latestworld
+21  (return core.nothing)
 
 ########################################
 # Error: Abstract type definition with bad signature
@@ -299,19 +286,18 @@ primitive type P 8 end
 2   (call core._primitivetype TestMod :P %₁ 8)
 3   (= slot₁/P %₂)
 4   (call core._setsuper! %₂ core.Any)
-5   slot₁/P
-6   (call core._typebody! false %₅)
-7   (call core.declare_global TestMod :P false)
-8   latestworld
-9   (call core.isdefinedglobal TestMod :P false)
-10  (gotoifnot %₉ label₁₅)
-11  TestMod.P
-12  (call core._equiv_typedef %₁₁ %₂)
-13  (gotoifnot %₁₂ label₁₅)
-14  (goto label₁₇)
-15  (call core.declare_const TestMod :P %₂)
-16  latestworld
-17  (return core.nothing)
+5   (call core._typebody! false slot₁/P)
+6   (call core.declare_global TestMod :P false)
+7   latestworld
+8   (call core.isdefinedglobal TestMod :P false)
+9   (gotoifnot %₈ label₁₄)
+10  TestMod.P
+11  (call core._equiv_typedef %₁₀ %₂)
+12  (gotoifnot %₁₁ label₁₄)
+13  (goto label₁₆)
+14  (call core.declare_const TestMod :P %₂)
+15  latestworld
+16  (return core.nothing)
 
 ########################################
 # Complex primitive type definition
@@ -326,19 +312,18 @@ primitive type P{X,Y} <: Z 32 end
 7   (= slot₁/P %₆)
 8   TestMod.Z
 9   (call core._setsuper! %₆ %₈)
-10  slot₁/P
-11  (call core._typebody! false %₁₀)
-12  (call core.declare_global TestMod :P false)
-13  latestworld
-14  (call core.isdefinedglobal TestMod :P false)
-15  (gotoifnot %₁₄ label₂₀)
-16  TestMod.P
-17  (call core._equiv_typedef %₁₆ %₆)
-18  (gotoifnot %₁₇ label₂₀)
-19  (goto label₂₂)
-20  (call core.declare_const TestMod :P %₆)
-21  latestworld
-22  (return core.nothing)
+10  (call core._typebody! false slot₁/P)
+11  (call core.declare_global TestMod :P false)
+12  latestworld
+13  (call core.isdefinedglobal TestMod :P false)
+14  (gotoifnot %₁₃ label₁₉)
+15  TestMod.P
+16  (call core._equiv_typedef %₁₅ %₆)
+17  (gotoifnot %₁₆ label₁₉)
+18  (goto label₂₁)
+19  (call core.declare_const TestMod :P %₆)
+20  latestworld
+21  (return core.nothing)
 
 ########################################
 # Primitive type definition with computed size (should this be allowed??)
@@ -350,19 +335,18 @@ primitive type P P_nbits() end
 4   (call core._primitivetype TestMod :P %₁ %₃)
 5   (= slot₁/P %₄)
 6   (call core._setsuper! %₄ core.Any)
-7   slot₁/P
-8   (call core._typebody! false %₇)
-9   (call core.declare_global TestMod :P false)
-10  latestworld
-11  (call core.isdefinedglobal TestMod :P false)
-12  (gotoifnot %₁₁ label₁₇)
-13  TestMod.P
-14  (call core._equiv_typedef %₁₃ %₄)
-15  (gotoifnot %₁₄ label₁₇)
-16  (goto label₁₉)
-17  (call core.declare_const TestMod :P %₄)
-18  latestworld
-19  (return core.nothing)
+7   (call core._typebody! false slot₁/P)
+8   (call core.declare_global TestMod :P false)
+9   latestworld
+10  (call core.isdefinedglobal TestMod :P false)
+11  (gotoifnot %₁₀ label₁₆)
+12  TestMod.P
+13  (call core._equiv_typedef %₁₂ %₄)
+14  (gotoifnot %₁₃ label₁₆)
+15  (goto label₁₈)
+16  (call core.declare_const TestMod :P %₄)
+17  latestworld
+18  (return core.nothing)
 
 ########################################
 # Empty struct
@@ -505,15 +489,13 @@ end
     1   (call core.fieldtype slot₁/#ctor-self# 2)
     2   slot₃/b
     3   (= slot₅/tmp %₂)
-    4   slot₅/tmp
-    5   (call core.isa %₄ %₁)
-    6   (gotoifnot %₅ label₈)
-    7   (goto label₁₀)
+    4   (call core.isa slot₅/tmp %₁)
+    5   (gotoifnot %₄ label₇)
+    6   (goto label₈)
+    7   (= slot₅/tmp (call top.convert %₁ slot₅/tmp))
     8   slot₅/tmp
-    9   (= slot₅/tmp (call top.convert %₁ %₈))
-    10  slot₅/tmp
-    11  (new slot₁/#ctor-self# slot₂/a %₁₀ slot₄/c)
-    12  (return %₁₁)
+    9   (new slot₁/#ctor-self# slot₂/a %₈ slot₄/c)
+    10  (return %₉)
 39  latestworld
 40  TestMod.X
 41  (call core.apply_type core.Type %₄₀)
@@ -762,15 +744,13 @@ end
     1   (call core.fieldtype slot₁/#ctor-self# 1)
     2   slot₂/x
     3   (= slot₃/tmp %₂)
-    4   slot₃/tmp
-    5   (call core.isa %₄ %₁)
-    6   (gotoifnot %₅ label₈)
-    7   (goto label₁₀)
+    4   (call core.isa slot₃/tmp %₁)
+    5   (gotoifnot %₄ label₇)
+    6   (goto label₈)
+    7   (= slot₃/tmp (call top.convert %₁ slot₃/tmp))
     8   slot₃/tmp
-    9   (= slot₃/tmp (call top.convert %₁ %₈))
-    10  slot₃/tmp
-    11  (new slot₁/#ctor-self# %₁₀)
-    12  (return %₁₁)
+    9   (new slot₁/#ctor-self# %₈)
+    10  (return %₉)
 46  latestworld
 47  TestMod.X
 48  (call core.apply_type core.Type %₄₇)
@@ -861,15 +841,13 @@ end
     1   (call core.fieldtype slot₁/#ctor-self# 1)
     2   slot₂/v
     3   (= slot₃/tmp %₂)
-    4   slot₃/tmp
-    5   (call core.isa %₄ %₁)
-    6   (gotoifnot %₅ label₈)
-    7   (goto label₁₀)
+    4   (call core.isa slot₃/tmp %₁)
+    5   (gotoifnot %₄ label₇)
+    6   (goto label₈)
+    7   (= slot₃/tmp (call top.convert %₁ slot₃/tmp))
     8   slot₃/tmp
-    9   (= slot₃/tmp (call top.convert %₁ %₈))
-    10  slot₃/tmp
-    11  (new slot₁/#ctor-self# %₁₀)
-    12  (return %₁₁)
+    9   (new slot₁/#ctor-self# %₈)
+    10  (return %₉)
 61  latestworld
 62  TestMod.X
 63  (call core.apply_type core.Type %₆₂)
@@ -1000,15 +978,13 @@ end
     3   TestMod.+
     4   (call %₃ slot₂/y slot₃/z)
     5   (= slot₄/tmp (new %₂ %₄))
-    6   slot₄/tmp
-    7   (call core.isa %₆ %₁)
-    8   (gotoifnot %₇ label₁₀)
-    9   (goto label₁₃)
-    10  slot₄/tmp
-    11  (call top.convert %₁ %₁₀)
-    12  (= slot₄/tmp (call core.typeassert %₁₁ %₁))
-    13  slot₄/tmp
-    14  (return %₁₃)
+    6   (call core.isa slot₄/tmp %₁)
+    7   (gotoifnot %₆ label₉)
+    8   (goto label₁₁)
+    9   (call top.convert %₁ slot₄/tmp)
+    10  (= slot₄/tmp (call core.typeassert %₉ %₁))
+    11  slot₄/tmp
+    12  (return %₁₁)
 70  latestworld
 71  TestMod.X
 72  (call core.apply_type core.Type %₇₁)
@@ -1251,24 +1227,20 @@ end
     11  slot₁/#ctor-self#
     12  (call core.fieldtype %₁₁ 1)
     13  (= slot₃/tmp (call core.getfield %₁ 1))
-    14  slot₃/tmp
-    15  (call core.isa %₁₄ %₁₂)
-    16  (gotoifnot %₁₅ label₁₈)
-    17  (goto label₂₀)
+    14  (call core.isa slot₃/tmp %₁₂)
+    15  (gotoifnot %₁₄ label₁₇)
+    16  (goto label₁₈)
+    17  (= slot₃/tmp (call top.convert %₁₂ slot₃/tmp))
     18  slot₃/tmp
-    19  (= slot₃/tmp (call top.convert %₁₂ %₁₈))
-    20  slot₃/tmp
-    21  (call core.fieldtype %₁₁ 2)
-    22  (= slot₄/tmp (call core.getfield %₁ 2))
-    23  slot₄/tmp
-    24  (call core.isa %₂₃ %₂₁)
-    25  (gotoifnot %₂₄ label₂₇)
-    26  (goto label₂₉)
-    27  slot₄/tmp
-    28  (= slot₄/tmp (call top.convert %₂₁ %₂₇))
-    29  slot₄/tmp
-    30  (new %₁₁ %₂₀ %₂₉)
-    31  (return %₃₀)
+    19  (call core.fieldtype %₁₁ 2)
+    20  (= slot₄/tmp (call core.getfield %₁ 2))
+    21  (call core.isa slot₄/tmp %₁₉)
+    22  (gotoifnot %₂₁ label₂₄)
+    23  (goto label₂₅)
+    24  (= slot₄/tmp (call top.convert %₁₉ slot₄/tmp))
+    25  slot₄/tmp
+    26  (new %₁₁ %₁₈ %₂₅)
+    27  (return %₂₆)
 47  latestworld
 48  (return core.nothing)
 


### PR DESCRIPTION
I think this was slightly mis-translated from the flisp side:
```scheme
    (define (valid-body-ir-argument? aval)
      (or (valid-ir-argument? aval)
          (and (symbol? aval) ; Arguments are always defined slots
               (or (memq aval (lam:args lam))
                   (let ((vi (get vinfo-table aval #f)))
                     (and vi (vinfo:never-undef vi)))))))
```

Noticed in https://github.com/JuliaLang/julia/pull/60567#discussion_r2672556146