### PR TITLE
[JuliaLowering] Workaround `:@macrocall` in doc-expressions

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -4372,6 +4372,18 @@ end
 #-------------------------------------------------------------------------------
 # Expand docstring-annotated expressions
 
+function isquotedmacrocall(ex)
+    kind(ex) == K"call" || return false
+    numchildren(ex) == 3 || return false
+    let (f, ex) = (ex[1], ex[3])
+        kind(f) == K"Value" || return false
+        kind(ex) == K"inert" || return false
+        f.value === interpolate_ast || return false
+        kind(ex[1]) == K"macrocall" || return false
+        return true
+    end
+end
+
 function expand_doc(ctx, ex, docex, mod=ctx.mod)
     if kind(ex) in (K"Identifier", K".")
         expand_forms_2(ctx, @ast ctx docex [K"call"
@@ -4382,6 +4394,9 @@ function expand_doc(ctx, ex, docex, mod=ctx.mod)
             ::K"SourceLocation"(ex)
             Union{}::K"Value"
         ])
+    elseif isquotedmacrocall(ex)
+        # TODO: implement proper `doc!` support here
+        expand_forms_2(ctx, ex, docex)
     elseif is_eventually_call(ex)
         expand_function_def(ctx, @ast(ctx, ex, [K"function" ex [K"block"]]),
                             docex; doc_only=true)

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -236,6 +236,12 @@ end
     @test d |> string === "docstr12\n"
     @test d.meta[:results][1].data[:typesig] === Union{Tuple{Int, U, T}, Tuple{Int, U}} where {T, U<:Number}
 
+    # doc-strings on macrocalls (punned on quoted macrocall)
+    # TODO: implement and test `doc!` support for this
+    @test jeval(test_mod, """
+        "doc string"
+        :@test
+    """) isa Expr
 end
 
 # SyntaxTree @eval should pass along expr_compat_mode

--- a/test/JuliaLowering_stdlibs.jl
+++ b/test/JuliaLowering_stdlibs.jl
@@ -2,12 +2,11 @@ import Libdl
 
 # known precompilation failures under JL
 const INCOMPATIBLE_STDLIBS = String[
-    "InteractiveUtils", # Invalid function name
     "LibGit2", # op isa Symbol (JuliaLang/JuliaLowering.jl#126)
     "SparseArrays", # type-alias bug (JuliaLang/JuliaLowering.jl#123)
     "TOML", # @invokelatest / QuoteNode bug
-    "Test", # depends on InteractiveUtils
-    "REPL", # depends on InteractiveUtils
+    "Test", # nested + destructured args splat (JuliaLang/JuliaLowering.jl#133)
+    "REPL", # infinite softscope (in REPL code)
     "Pkg", # depends on TOML
     "SuiteSparse", # depends on SparseArrays
     "LazyArtifacts", # depends on Pkg


### PR DESCRIPTION
This leaves the `doc!` support unimplemented, but at least avoids crashing when encountering:

```julia
"doc comment"
:@some_macro
```

I'd be happy to fill in some of the `doc!` support if @mlechu or @c42f know what's missing where. Although I am surprised TBH that we don't just rely on the existing system used by flisp lowering instead of re-implementing large portions of docs.

Partially resolves https://github.com/JuliaLang/JuliaLowering.jl/issues/132