### PR TITLE
windows: replace Win32 MBS conversions with WTF-8

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -10628,9 +10628,10 @@ extern "C" JL_DLLEXPORT_CODEGEN jl_value_t *jl_get_libllvm_impl(void) JL_NOTSAFE
     DWORD n16 = GetModuleFileNameW(mod, path16, MAX_PATH);
     if (n16 <= 0)
         return jl_nothing;
-    path16[n16++] = 0;
     char path8[MAX_PATH * 3];
-    if (!WideCharToMultiByte(CP_UTF8, 0, path16, n16, path8, MAX_PATH * 3, NULL, NULL))
+    char *path8_ptr = path8;
+    size_t path8_len = sizeof(path8) - 1;
+    if (uv_utf16_to_wtf8((uint16_t*)path16, n16, &path8_ptr, &path8_len))
         return jl_nothing;
     return (jl_value_t*) jl_symbol(path8);
 #else

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1675,9 +1675,6 @@ JL_DLLIMPORT void *jl_jit_abi_converter(jl_task_t *ct, jl_abi_t from_abi, jl_cod
 #define JL_LIBJULIA_INTERNAL_DL_LIBNAME ((const char*)3)
 JL_DLLEXPORT const char *jl_dlfind(const char *name);
 
-// libuv wrappers:
-JL_DLLEXPORT int jl_fs_rename(const char *src_path, const char *dst_path);
-
 // -- Runtime intrinsics -- //
 JL_DLLEXPORT const char *jl_intrinsic_name(int f) JL_NOTSAFEPOINT;
 JL_DLLEXPORT unsigned jl_intrinsic_nargs(int f) JL_NOTSAFEPOINT;

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -117,7 +117,6 @@ JL_DLLEXPORT ssize_t ios_fillbuf(ios_t *s);
 /* stream creation */
 JL_DLLEXPORT
 ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int trunc) JL_NOTSAFEPOINT;
-JL_DLLEXPORT ios_t *ios_mkstemp(ios_t *f, char *fname);
 JL_DLLEXPORT ios_t *ios_mem(ios_t *s, size_t initsize) JL_NOTSAFEPOINT;
 ios_t *ios_str(ios_t *s, char *str);
 ios_t *ios_static_buffer(ios_t *s, char *buf, size_t sz);

--- a/src/sys.c
+++ b/src/sys.c
@@ -714,16 +714,10 @@ JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle)
         free(pth16);
         return NULL;
     }
-    pth16[n16] = L'\0';
-    DWORD n8 = WideCharToMultiByte(CP_UTF8, 0, pth16, -1, NULL, 0, NULL, NULL);
-    if (n8 == 0) {
+    char *filepath = NULL;
+    size_t n8 = 0;
+    if (uv_utf16_to_wtf8((uint16_t*)pth16, n16, &filepath, &n8)) {
         free(pth16);
-        return NULL;
-    }
-    char *filepath = (char*)malloc_s(++n8);
-    if (!WideCharToMultiByte(CP_UTF8, 0, pth16, -1, filepath, n8, NULL, NULL)) {
-        free(pth16);
-        free(filepath);
         return NULL;
     }
     free(pth16);


### PR DESCRIPTION
Replace all WideCharToMultiByte/MultiByteToWideChar API calls with WTF-8 based conversions using libuv helpers (uv_utf16_to_wtf8, uv_wtf8_to_utf16, etc.) in the runtime, and a standalone copy of the libuv algorithm in the CLI loader.

Refs #33486