### PR TITLE
Markdown: adjust definition of :common flavor

### DIFF
--- a/stdlib/Markdown/src/Common/Common.jl
+++ b/stdlib/Markdown/src/Common/Common.jl
@@ -6,7 +6,7 @@ include("block.jl")
 include("inline.jl")
 
 @flavor common [horizontalrule, list, indentcode, blockquote, admonition, footnote, hashheader,
-                paragraph,
+                fencedcode, setextheader, paragraph,
 
                 linebreak, escapes,
                 inline_code,

--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -120,6 +120,40 @@ function indentcode(stream::IO, block::MD)
     end
 end
 
+@breaking true ->
+function fencedcode(stream::IO, block::MD)
+    withstream(stream) do
+        startswith(stream, "~~~", padding = true) || startswith(stream, "```", padding = true) || return false
+        skip(stream, -1)
+        ch = read(stream, Char)
+        trailing = strip(readline(stream))
+        flavor = lstrip(trailing, ch)
+        n = 3 + length(trailing) - length(flavor)
+
+        # inline code block
+        ch in flavor && return false
+
+        buffer = IOBuffer()
+        while !eof(stream)
+            line_start = position(stream)
+            if startswith(stream, string(ch) ^ n)
+                if !startswith(stream, string(ch))
+                    if flavor == "math"
+                        push!(block, LaTeX(takestring!(buffer) |> chomp))
+                    else
+                        push!(block, Code(flavor, takestring!(buffer) |> chomp))
+                    end
+                    return true
+                else
+                    seek(stream, line_start)
+                end
+            end
+            write(buffer, readline(stream, keep=true))
+        end
+        return false
+    end
+end
+
 # --------
 # Footnote
 # --------

--- a/stdlib/Markdown/src/GitHub/GitHub.jl
+++ b/stdlib/Markdown/src/GitHub/GitHub.jl
@@ -2,40 +2,6 @@
 
 include("table.jl")
 
-@breaking true ->
-function fencedcode(stream::IO, block::MD)
-    withstream(stream) do
-        startswith(stream, "~~~", padding = true) || startswith(stream, "```", padding = true) || return false
-        skip(stream, -1)
-        ch = read(stream, Char)
-        trailing = strip(readline(stream))
-        flavor = lstrip(trailing, ch)
-        n = 3 + length(trailing) - length(flavor)
-
-        # inline code block
-        ch in flavor && return false
-
-        buffer = IOBuffer()
-        while !eof(stream)
-            line_start = position(stream)
-            if startswith(stream, string(ch) ^ n)
-                if !startswith(stream, string(ch))
-                    if flavor == "math"
-                        push!(block, LaTeX(takestring!(buffer) |> chomp))
-                    else
-                        push!(block, Code(flavor, takestring!(buffer) |> chomp))
-                    end
-                    return true
-                else
-                    seek(stream, line_start)
-                end
-            end
-            write(buffer, readline(stream, keep=true))
-        end
-        return false
-    end
-end
-
 function github_paragraph(stream::IO, md::MD)
     skipwhitespace(stream)
     buffer = IOBuffer()

--- a/stdlib/Markdown/test/test_spec_html_common.jl
+++ b/stdlib/Markdown/test/test_spec_html_common.jl
@@ -149,7 +149,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<pre><code>\\[\\]\n</code></pre>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 20
     input = "<https://example.com?find=\\*>\n"
@@ -450,7 +450,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<h2>Foo</h2>\n<p>bar</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 60
     input = "* Foo\n* * *\n* Bar\n"
@@ -611,7 +611,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 81
     input = "Foo *bar\nbaz*\n====\n"
@@ -639,7 +639,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 85
     input = "    Foo\n    ---\n\n    Foo\n---\n"
@@ -653,7 +653,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<h2>Foo</h2>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 87
     input = "Foo\n    ---\n"
@@ -674,21 +674,21 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<h2>Foo</h2>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 90
     input = "Foo\\\n----\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<h2>Foo\\</h2>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 91
     input = "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 92
     input = "> Foo\n---\n"
@@ -723,7 +723,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 97
     input = "\n====\n"
@@ -765,14 +765,14 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<h2>&gt; foo</h2>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 103
     input = "Foo\n\nbar\n---\nbaz\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>Foo</p>\n<h2>bar</h2>\n<p>baz</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 104
     input = "Foo\nbar\n\n---\n\nbaz\n"
@@ -863,7 +863,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<h1>Heading</h1>\n<pre><code>foo\n</code></pre>\n<h2>Heading</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 116
     input = "        foo\n    bar\n"
@@ -898,14 +898,14 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<pre><code>&lt;\n &gt;\n</code></pre>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 120
     input = "~~~\n<\n >\n~~~\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<pre><code>&lt;\n &gt;\n</code></pre>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 121
     input = "``\nfoo\n``\n"
@@ -919,14 +919,14 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<pre><code>aaa\n~~~\n</code></pre>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 123
     input = "~~~\naaa\n```\n~~~\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<pre><code>aaa\n```\n</code></pre>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 124
     input = "````\naaa\n```\n``````\n"
@@ -940,7 +940,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<pre><code>aaa\n~~~\n</code></pre>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 126
     input = "```\n"
@@ -968,14 +968,14 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<pre><code>\n  \n</code></pre>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 130
     input = "```\n```\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<pre><code></code></pre>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 131
     input = " ```\n aaa\naaa\n```\n"
@@ -1045,21 +1045,21 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 141
     input = "foo\n---\n~~~\nbar\n~~~\n# baz\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 142
     input = "```ruby\ndef foo(x)\n  return 3\nend\n```\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 143
     input = "~~~~    ruby startline=3 \$%@#\$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n"
@@ -1073,7 +1073,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<pre><code class=\"language-;\"></code></pre>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 145
     input = "``` aa ```\nfoo\n"
@@ -1563,7 +1563,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 213
     input = "Foo\n[bar]: /baz\n\n[bar]\n"

--- a/stdlib/Markdown/test/test_spec_roundtrip_common.jl
+++ b/stdlib/Markdown/test/test_spec_roundtrip_common.jl
@@ -16,7 +16,7 @@ using Markdown
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 2
     input = "  \tfoo\tbaz\t\tbim\n"
@@ -30,28 +30,28 @@ using Markdown
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 4
     input = "  - foo\n\n\tbar\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 5
     input = "- foo\n\n\t\tbar\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 6
     input = ">\t\tfoo\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 7
     input = "-\t\tfoo\n"
@@ -65,14 +65,14 @@ using Markdown
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 9
     input = " - foo\n   - bar\n\t - baz\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 10
     input = "#\tFoo\n"
@@ -142,7 +142,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 19
     input = "~~~\n\\[\\]\n~~~\n"
@@ -275,7 +275,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 37
     input = "&#42;foo&#42;\n*foo*\n"
@@ -527,7 +527,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 70
     input = "foo\n    # bar\n"
@@ -646,7 +646,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 86
     input = "Foo\n   ----      \n"
@@ -681,7 +681,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 91
     input = "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n"
@@ -751,7 +751,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 101
     input = "> foo\n-----\n"
@@ -765,7 +765,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 103
     input = "Foo\n\nbar\n---\nbaz\n"
@@ -807,7 +807,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 108
     input = "  - foo\n\n    bar\n"
@@ -828,21 +828,21 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 111
     input = "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 112
     input = "    chunk1\n      \n      chunk2\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 113
     input = "Foo\n    bar\n\n"
@@ -856,35 +856,35 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 115
     input = "# Heading\n    foo\nHeading\n------\n    foo\n----\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 116
     input = "        foo\n    bar\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 117
     input = "\n    \n    foo\n    \n\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 118
     input = "    foo  \n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
 end
 
@@ -975,7 +975,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 131
     input = " ```\n aaa\naaa\n```\n"
@@ -1003,7 +1003,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 135
     input = "```\naaa\n  ```\n"
@@ -1094,7 +1094,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
 end
 
@@ -1346,21 +1346,21 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 183
     input = "  <!-- foo -->\n\n    <!-- foo -->\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 184
     input = "  <div>\n\n    <div>\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 185
     input = "Foo\n<div>\nbar\n</div>\n"
@@ -1409,7 +1409,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
 end
 
@@ -1556,7 +1556,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 212
     input = "```\n[foo]: /url\n```\n\n[foo]\n"
@@ -1661,7 +1661,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 226
     input = "aaa     \nbbb     \n"
@@ -1717,7 +1717,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 232
     input = "> # Foo\n> bar\nbaz\n"
@@ -1752,7 +1752,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 237
     input = "> ```\nfoo\n```\n"
@@ -1766,7 +1766,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 239
     input = ">\n"
@@ -1864,7 +1864,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
 end
 
@@ -1878,7 +1878,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 254
     input = "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n"
@@ -2011,7 +2011,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 273
     input = "1.     indented code\n\n   paragraph\n\n       more code\n"
@@ -2130,21 +2130,21 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 290
     input = "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 291
     input = "  1.  A paragraph\n    with two lines.\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 292
     input = "> 1. > Blockquote\ncontinued here.\n"
@@ -2277,7 +2277,7 @@ end
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 310
     input = "- a\n - b\n  - c\n   - d\n  - e\n - f\n- g\n"


### PR DESCRIPTION
I am making the assumption here that the "common" flavor stands for "CommonMark". And both fencedcode and setext headers are part of CommonMark.