### PR TITLE
add wb_back on all task switch paths

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -499,7 +499,7 @@ JL_NO_ASAN static void ctx_switch(jl_task_t *lastt)
     // it was marked by an incremental collection
     // move the barrier back instead of walking the shadow stack again here to check if that is required
     // even if killed (dropping the stack) and just the scope field matters,
-    // let the gc figure out that out next time it does a quick mark
+    // let the gc figure that out next time it does a quick mark
     jl_gc_wb_back(lastt);
 
     // set up global state for new task and clear global state for old task

--- a/src/task.c
+++ b/src/task.c
@@ -198,10 +198,6 @@ static void NOINLINE save_stack(jl_ptls_t ptls, jl_task_t *lastt, jl_task_t **pt
     lastt->ctx.copy_stack = nb;
     lastt->sticky = 1;
     memcpy_stack_a16((uint64_t*)buf, (uint64_t*)frame_addr, nb);
-    // this task's stack could have been modified after
-    // it was marked by an incremental collection
-    // move the barrier back instead of walking it again here
-    jl_gc_wb_back(lastt);
 }
 
 JL_NO_ASAN static void NOINLINE JL_NORETURN restore_stack(jl_ucontext_t *t, jl_ptls_t ptls, char *p)
@@ -499,6 +495,12 @@ JL_NO_ASAN static void ctx_switch(jl_task_t *lastt)
             lastt->ctx.ctx = &lasttstate.ctx;
         }
     }
+    // this task's stack or scope field could have been modified after
+    // it was marked by an incremental collection
+    // move the barrier back instead of walking the shadow stack again here to check if that is required
+    // even if killed (dropping the stack) and just the scope field matters,
+    // let the gc figure out that out next time it does a quick mark
+    jl_gc_wb_back(lastt);
 
     // set up global state for new task and clear global state for old task
     t->ptls = ptls;


### PR DESCRIPTION
Since this task's stack or scope field could have been modified after it was marked by an incremental collection (and not just for copy stacks), move the barrier back unconditionally here.