### PR TITLE
GC-preserve a Task's scope on start, to prevent freeing unrooted scopes via ScopedThunk

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -1240,6 +1240,9 @@ CFI_NORETURN
     jl_value_t *res;
     assert(ptls->finalizers_inhibited == 0);
     jl_value_t *scope = ct->scope;
+    // Need to root the scope so that it stays alive, even if a new scope is entered, since
+    // the exception-handler's reference to the scope isn't traced.
+    // NOTE: Don't need to pop when Task ends, as the whole gc stack will be freed.
     JL_GC_PUSH1(&scope);
 
 #ifdef MIGRATE_TASKS

--- a/src/task.c
+++ b/src/task.c
@@ -1239,6 +1239,8 @@ CFI_NORETURN
     jl_ptls_t ptls = ct->ptls;
     jl_value_t *res;
     assert(ptls->finalizers_inhibited == 0);
+    jl_value_t *scope = ct->scope;
+    JL_GC_PUSH1(&scope);
 
 #ifdef MIGRATE_TASKS
     jl_task_t *pt = ptls->previous_task;

--- a/test/scopedvalues.jl
+++ b/test/scopedvalues.jl
@@ -225,3 +225,52 @@ end
     end
     sf2()
 end
+
+using Base.ScopedValues: ScopedThunk, ScopedValue, with
+@noinline function test_59483()
+    sv = ScopedValue([])
+    ch = Channel{Bool}()
+
+    # Start a new scope, which we will capture in a ScopedThunk
+    thunk = with(sv=>Any[2]) do
+        # This scoped thunk performs GCs, which could free any unrooted scope below:
+        ScopedThunk(@noinline () -> begin
+            GC.gc()
+            GC.gc()
+            sv[]
+        end)
+    end
+    @test thunk() == Any[2]
+
+    # Spawn a child task, which inherits the parent's Scope
+    @noinline function inner_function()
+        # Block until the parent task has left the scope.
+        take!(ch)
+        # Now, per issue 59483, this task's scope is not rooted, except by the task itself.
+
+        # Now run the thunk, which will switch to the top scope, leaving the current
+        # scope possibly unrooted. When this thunk performs GCs, if the current scope is
+        # freed, then we can crash when we return. The fix for this issue made sure that the
+        # scope in this task remains rooted.
+        val = thunk()
+        @test val == Any[2]
+        # These GCs could crash:
+        GC.gc()
+        GC.gc()
+    end
+    @noinline function spawn_inner()
+        # Set a new Scope in the parent task - this is the scope that could be freed.
+        with(sv=>Any[1]) do
+            return @async inner_function()
+        end
+    end
+
+    # RUN THE TEST:
+    t = spawn_inner()
+    # Exit the scope, and let the child task proceed
+    put!(ch, true)
+    wait(t)
+end
+@testset "issue 59483" begin
+    test_59483()
+end


### PR DESCRIPTION
Explanation of the issue in 59483:

> When a task enters a new scope, the exception handler explicitly roots the new scope, but not the old scope.
> The old scope doesn't need to be rooted, because it was already rooted when _it_ was first entered
> BUT, here's the issue:
> A task can also inherit a scope from another task, when it's spawned!
> In that case, if the parent task leaves the scope, it stops rooting it.
> THEN if the child task enters a new scope, no one is rooting its old scope. 
> AND if the new scope is not a child of the old scope (i.e. via a ScopedThunk), then now no one is rooting the old scope.
> So now the old scope can be freed.
> And so when the task pops back, there's a crash.

This is now fixed by rooting the Scope when starting a new Task.

Fixes https://github.com/JuliaLang/julia/issues/59483.