### PR TITLE
Disallow reading from underscore sparams in function arg decls

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -298,7 +298,8 @@
             `(,@head ,las)))))
 
 (define (replace-vars e renames)
-  (cond ((symbol? e)      (lookup e renames e))
+  (cond ((underscore-symbol? e) e)
+        ((symbol? e)      (lookup e renames e))
         ((or (not (pair? e)) (quoted? e))  e)
         ((memq (car e) '(-> function scope-block)) e)
         (else

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2980,6 +2980,16 @@ end
     @test ncalls_in_lowered(quote a, _... = (b...,) end, GlobalRef(Base, :rest)) == 0
 end
 
+@testset "all-underscore static params in signatures" begin
+    # historically buggy.  hits a special case where desugaring (`replace-vars`)
+    # does scope resolution
+    err_str = "all-underscore identifiers are write-only and their values cannot be used in expressions"
+    @test_loweringerror(:(function f60626(x::_) where _; x; end), err_str)
+    @test_loweringerror(:(function f60626(x::Vector{Vector{_}}) where _<:Number; x; end), err_str)
+    @test_loweringerror(:(function f60626(x, y; z::_) where _; x; end), err_str)
+    @test_loweringerror(:(((x::_) where _) -> 1), err_str)
+end
+
 # issue #38501
 @test :"a $b $("str") c" == Expr(:string, "a ", :b, " ", Expr(:string, "str"), " c")
 

--- a/test/testhelpers/arrayindexingtypes.jl
+++ b/test/testhelpers/arrayindexingtypes.jl
@@ -21,7 +21,7 @@ T24Linear(::Type{T}, dims::Int...) where T = T24Linear(T, dims)
 T24Linear(::Type{T}, dims::NTuple{N,Int}) where {T,N} = T24Linear{T,N,dims}()
 
 T24Linear(     X::AbstractArray{T,N}) where {T,N  } = T24Linear{T,N}(X)
-T24Linear{T  }(X::AbstractArray{_,N}) where {T,N,_} = T24Linear{T,N}(X)
+T24Linear{T  }(X::AbstractArray{M,N}) where {T,N,M} = T24Linear{T,N}(X)
 T24Linear{T,N}(X::AbstractArray     ) where {T,N  } = T24Linear{T,N,size(X)}(X...)
 
 Base.size(::T24Linear{T,N,dims}) where {T,N,dims} = dims
@@ -40,7 +40,7 @@ TSlow(::Type{T}, dims::NTuple{N,Int}) where {T,N} = TSlow{T,N}(Dict{NTuple{N,Int
 
 TSlow{T,N}(X::TSlow{T,N})         where {T,N  } = X
 TSlow(     X::AbstractArray{T,N}) where {T,N  } = TSlow{T,N}(X)
-TSlow{T  }(X::AbstractArray{_,N}) where {T,N,_} = TSlow{T,N}(X)
+TSlow{T  }(X::AbstractArray{M,N}) where {T,N,M} = TSlow{T,N}(X)
 TSlow{T,N}(X::AbstractArray     ) where {T,N  } = begin
     A = TSlow(T, size(X))
     for I in CartesianIndices(X)


### PR DESCRIPTION
```
julia> function foo(x::_) where _; x; end
foo (generic function with 1 method)

julia> foo(1)
1

julia> function bar(x::Vector{Vector{_}}) where _; x; end
bar (generic function with 1 method)

julia> bar([[2]])
1-element Vector{Vector{Int64}}:
 [2]
```

This slips through because sparam name replacement happens in desugaring.  Detected while scanning our files; `test/testhelpers/arrayindexingtypes.jl` unfortunately used this behaviour, but I think it's reasonable to call it a bug.

I'll add a test once https://github.com/JuliaLang/julia/pull/60598 is resolved.