### PR TITLE
Markdown: fix horizontal rules in code blocks

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1894,7 +1894,7 @@ julia> partialsortperm!(ix, v, 2:3)
  4
  3
 ```
- """
+"""
 function partialsortperm!(ix::AbstractVector{<:Integer}, v::AbstractVector,
                           k::Union{Integer, OrdinalRange};
                           lt::Function=isless,

--- a/stdlib/Markdown/src/Common/Common.jl
+++ b/stdlib/Markdown/src/Common/Common.jl
@@ -5,8 +5,8 @@ abstract type MarkdownElement end
 include("block.jl")
 include("inline.jl")
 
-@flavor common [horizontalrule, list, indentcode, blockquote, admonition, footnote, hashheader,
-                fencedcode, setextheader, paragraph,
+@flavor common [fencedcode, horizontalrule, list, indentcode, blockquote, admonition, footnote, hashheader,
+                setextheader, paragraph,
 
                 linebreak, escapes,
                 inline_code,

--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -398,18 +398,18 @@ end
 @breaking true ->
 function horizontalrule(stream::IO, block::MD)
    withstream(stream) do
-       n, rule = 0, ' '
+       eatindent(stream) || return false
+       eof(stream) && return false
+       rule = read(stream, Char)
+       rule in "*-_" || return false
+       n = 1
        for char in readeach(stream, Char)
            char == '\n' && break
            isspace(char) && continue
-           if n == 0
-               rule = char
-           elseif char != rule
-               return false
-           end
+           char == rule || return false
            n += 1
        end
-       is_hr = (n ≥ 3 && rule in "*-_")
+       is_hr = n ≥ 3
        is_hr && push!(block, HorizontalRule())
        return is_hr
    end

--- a/stdlib/Markdown/src/GitHub/GitHub.jl
+++ b/stdlib/Markdown/src/GitHub/GitHub.jl
@@ -23,8 +23,8 @@ function github_paragraph(stream::IO, md::MD)
     return true
 end
 
-@flavor github [horizontalrule, list, indentcode, blockquote, admonition, footnote, hashheader,
-                fencedcode, github_table, github_paragraph,
+@flavor github [fencedcode, horizontalrule, list, indentcode, blockquote, admonition, footnote, hashheader,
+                github_table, github_paragraph,
 
                 linebreak, escapes,
                 en_or_em_dash, inline_code,

--- a/stdlib/Markdown/src/Julia/Julia.jl
+++ b/stdlib/Markdown/src/Julia/Julia.jl
@@ -8,8 +8,8 @@
 include("interp.jl")
 
 @flavor julia [blocktex, blockinterp,
-               horizontalrule, list, indentcode, blockquote, admonition, footnote, hashheader,
-               fencedcode, github_table, setextheader, paragraph,
+               fencedcode, horizontalrule, list, indentcode, blockquote, admonition, footnote, hashheader,
+               github_table, setextheader, paragraph,
 
                linebreak, escapes,
                tex, interp,

--- a/stdlib/Markdown/test/test_spec_html_common.jl
+++ b/stdlib/Markdown/test/test_spec_html_common.jl
@@ -373,7 +373,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<pre><code>***\n</code></pre>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 49
     input = "Foo\n    ***\n"

--- a/stdlib/Markdown/test/test_spec_html_github.jl
+++ b/stdlib/Markdown/test/test_spec_html_github.jl
@@ -373,7 +373,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<pre><code>***\n</code></pre>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 49
     input = "Foo\n    ***\n"

--- a/stdlib/Markdown/test/test_spec_html_julia.jl
+++ b/stdlib/Markdown/test/test_spec_html_julia.jl
@@ -373,7 +373,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<pre><code>***\n</code></pre>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 49
     input = "Foo\n    ***\n"


### PR DESCRIPTION
- adjust the horizontalrule rule to accept at most 3 spaces at the
  start: this simplifies the code, and also makes sure a `***`
  appearing with a code block indent is no longer turned into a
  horizontal rule
- run the `fencedcode` rule first, so that `***` appearing in a
  fenced code block is also not turned into a horizontal rule
