### PR TITLE
codegen: fix segfault in llvmcall with singleton/ghost types

### DIFF
--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -205,6 +205,9 @@ end
 f34166(x) = Base.llvmcall("ret i$(Sys.WORD_SIZE) %0", Int, (Int,), x)
 @test_throws ErrorException f34166(1)
 
+# Test that ghost types (zero-size types) are rejected
+@test_throws ErrorException("llvmcall: argument 1 is a singleton or zero-size type and cannot be passed as an LLVM value") Base.llvmcall("ret i8 %0", Int8, Tuple{Nothing}, nothing)
+
 # Test that codegen can construct constant LLVMPtr #38864
 struct MyStruct
     kern::UInt64


### PR DESCRIPTION
**Description** This PR fixes a segmentation fault that occurs when passing ghost types (zero-sized types like Nothing, Missing, or empty structs) to Base.llvmcall.

The Issue When llvmcall parses arguments, it expects every argument to map to an LLVM SSA value (e.g., %0). However, Julia's codegen does not emit values for zero-sized types. Consequently, attempting to rewrite the IR for these arguments resulted in a null pointer dereference/segfault in llvm_type_rewrite.

**The Fix** I added a validation step in emit_llvmcall (in src/ccall.cpp) that iterates through the argument types. If a type is found to be a singleton/zero-size type, the compiler now throws a standard Julia ErrorException rather than proceeding to codegen.

**fixes #60063**

**Test Plan**

Added a regression test in test/llvmcall.jl.

Verified that f(nothing) now throws a clear error instead of segfaulting.

Ran make test-llvmcall locally and it passed.

**About Me** I’m a 3rd-year undergraduate pursuing a dual degree in Computer Science and Mathematics. I have a strong interest in compiler design and low-level systems programming. This is my first contribution to Julia, and I'm eager to learn more about the codegen pipeline! I am also looking to participate in **Google Summer of Code 2026** with the Julia organization and would love to start getting involved with the community.