### PR TITLE
Fix JET warnings in `show(::IOBuffer, ::StackFrame)`

### DIFF
--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -285,7 +285,8 @@ function show_spec_linfo(io::IO, frame::StackFrame)
             else
                 # Equivalent to the default implementation of `show_custom_spec_sig`
                 # for `linfo isa CodeInstance`, but saves an extra dynamic dispatch.
-                show_spec_sig(io, def, frame_mi(frame).specTypes)
+                mi = frame_mi(frame)::MethodInstance
+                show_spec_sig(io, def::Method, mi.specTypes)
             end
         else
             m = linfo::Method
@@ -297,7 +298,8 @@ end
 # Can be extended by compiler packages to customize backtrace display of custom code instance frames
 function show_custom_spec_sig(io::IO, @nospecialize(owner), linfo::CodeInstance, frame::StackFrame)
     mi = Base.get_ci_mi(linfo)
-    return show_spec_sig(io, mi.def, mi.specTypes)
+    m = mi.def::Method # the case ::Module is handled in show_spec_linfo
+    return show_spec_sig(io, m, mi.specTypes)
 end
 
 function show_spec_sig(io::IO, m::Method, @nospecialize(sig::Type))


### PR DESCRIPTION
This gets rid of the following JET warnings (present on julia 1.13.0-beta1 with JET https://github.com/aviatesk/JET.jl/commit/377fa5303a5f532755ece84c65fd1878b8fc2ab6 (see https://github.com/aviatesk/JET.jl/issues/796 why I did not use a released version), no longer present with this patch applied onto julia 1.13.0-beta1)
```julia
julia> @report_call Base.process_backtrace(Base.stacktrace(Base.backtrace()))
[ Info: tracking Base
┌ Warning: skipping var"#sprint#423"(context, sizehint::Integer, ::typeof(sprint), f::Function, args...) @ Base strings/io.jl:102 to avoid parsing too much code
└ @ Revise ~/.julia/packages/Revise/icvyF/src/packagedef.jl:1344
═════ 3 possible errors found ═════
┌ process_backtrace(t::Vector{Base.StackTraces.StackFrame}) @ Base ./errorshow.jl:1094
│┌ process_backtrace(tracecount::Vector{Any}) @ Base ./errorshow.jl:1100
││┌ _backtrace_collapse_repeated_locations!(trace::Vector{Any}) @ Base ./errorshow.jl:1048
│││┌ sprint(f::typeof(show), args::Base.StackTraces.StackFrame) @ Base ./strings/io.jl:102
││││┌ sprint(f::typeof(show), args::Base.StackTraces.StackFrame; context::Nothing, sizehint::Int64) @ Base ./strings/io.jl:109
│││││┌ show(io::IOBuffer, frame::Base.StackTraces.StackFrame) @ Base.StackTraces ./stacktraces.jl:331
││││││┌ show_spec_linfo(io::IOBuffer, frame::Base.StackTraces.StackFrame) @ Base.StackTraces ./stacktraces.jl:282
│││││││┌ show_custom_spec_sig(io::IOBuffer, owner::Any, linfo::Core.CodeInstance, frame::Base.StackTraces.StackFrame) @ Base.StackTraces ./stacktraces.jl:298
││││││││ no matching method found `show_spec_sig(::IOBuffer, ::Module, ::Any)` (1/2 union split): Base.StackTraces.show_spec_sig(io::IOBuffer, mi.def::Union{Method, Module}, mi.specTypes::Any)
│││││││└────────────────────
││││││┌ show_spec_linfo(io::IOBuffer, frame::Base.StackTraces.StackFrame) @ Base.StackTraces ./stacktraces.jl:286
│││││││┌ getproperty(x::Nothing, f::Symbol) @ Base ./Base_compiler.jl:57
││││││││ invalid builtin function call: getfield(x::Nothing, f::Symbol)
│││││││└────────────────────
││││││┌ show_spec_linfo(io::IOBuffer, frame::Base.StackTraces.StackFrame) @ Base.StackTraces ./stacktraces.jl:286
│││││││ no matching method found `show_spec_sig(::IOBuffer, ::Nothing, ::Any)` (1/2 union split): Base.StackTraces.show_spec_sig(io::IOBuffer, def::Union{Nothing, Method}, (Base.StackTraces.frame_mi(frame::Base.StackTraces.StackFrame)::Union{Nothing, Core.MethodInstance}).specTypes::Any)
││││││└────────────────────
```

It would be great to get this backported to 1.12 and 1.13.

cc @fingolfin 