### PR TITLE
[JuliaLowering] Avoid analyzing variables 'owned' by outer closures

### DIFF
--- a/JuliaLowering/test/closures.jl
+++ b/JuliaLowering/test/closures.jl
@@ -472,4 +472,20 @@ end
 @test_throws UndefVarError test_mod.f_undef_static_param(nothing)()
 @test test_mod.f_undef_static_param(42)() == Int
 
+# https://github.com/JuliaLang/JuliaLowering.jl/issues/134#issuecomment-3739626003
+JuliaLowering.include_string(test_mod, """
+function f_update_outer_capture()
+    local response # declare outside closure
+    f = ()->begin
+        response = 1
+    end
+    f()
+    return (f, response)
+end
+""")
+let (f, response) = test_mod.f_update_outer_capture()
+    @test f.response isa Core.Box
+    @test response == 1
+end
+
 end


### PR DESCRIPTION
I should have noticed this when reviewing #60567 . The justification / comments added by Claude here were very misleading. They explain that these values are different but not why.

That said, the confusion here is a bit understandable. The `is_capt` naming is a probably overloaded: "captured anywhere" is very different than "introduced in an outer function". Might be worth revisiting in a future re-factor.
