### PR TITLE
Docs: Increase the visibility of our genAI disclosure requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ will not be reflected, unless you use `Revise`.
 ## For all changes
 
 1. Run `make fix-whitespace` before creating the PR to make sure you're not committing any whitespace errors.
+2. Add the AI tool as a Git co-author on all commits created by that tool.
+3. Whenever a pull request is opened, you MUST disclose that the pull request was written with the assistance of generative AI.
 
 ## Building Julia
 
@@ -119,3 +121,4 @@ When creating pull requests:
 1. If the pull request consists of one commit only, use the body of the commit for the body of the pull request.
 2. If there are multiple commits in the pull request, follow the same guidelines for the pull request as for the commit body.
 3. Make sure that the base commit of the pull request is recent (within the past two days) - if not rebase your changes first.
+4. You MUST disclose that the pull request was written with the assistance of generative AI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,11 @@ Hi! If you are new to the Julia community: welcome, and thanks for trying Julia.
 
 If you are already familiar with Julia itself, this blog post by Katharine Hyatt on [Making your first Julia pull request](https://kshyatt.github.io/post/firstjuliapr/) is a great way to get started.
 
+New contributors are encouraged to start by reading [CONTRIBUTING.md](https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md).
+
+> [!IMPORTANT]
+> If your pull request contains substantial contributions from a generative AI tool, please disclose so with details, and review all changes before opening.
+
 ## Learning Julia
 
 [The learning page](https://julialang.org/learning) has a great list of resources for new and experienced users alike.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,6 @@ Hi! If you are new to the Julia community: welcome, and thanks for trying Julia.
 
 If you are already familiar with Julia itself, this blog post by Katharine Hyatt on [Making your first Julia pull request](https://kshyatt.github.io/post/firstjuliapr/) is a great way to get started.
 
-New contributors are encouraged to start by reading [CONTRIBUTING.md](https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md).
-
 > [!IMPORTANT]
 > If your pull request contains substantial contributions from a generative AI tool, please disclose so with details, and review all changes before opening.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ documentation improvements, tests, and performance enhancements.
 
 New contributors are encouraged to start by reading [CONTRIBUTING.md](https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md).
 
+> [!IMPORTANT]
+> If your pull request contains substantial contributions from a generative AI tool, please disclose so with details, and review all changes before opening.
 
 ### Learning Julia
 


### PR DESCRIPTION
Currently, we [already mention](https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md#contributor-checklist) this in `CONTRIBUTING.md`. But that's clearly not sufficient (because we keep getting genAI PRs without disclosure).

So this PR tries to make our disclosure requirement easier to notice:

1. Put a note in the README.
2. Put another note at the top of CONTRIBUTING, with the purple "important" formatting, to try to increase visibility.[^1]
3. Add two notes to AGENTS.md.[^2]
    - Tell the AI tool to add itself as a Git co-author on commits.
    - Tell the AI tool to disclose AI use when opening the PR.

[^1]: Currently, we only mention the disclosure requirement further down in CONTRIBUTING. Maybe people aren't scrolling that far down, so perhaps it'll help to have the note near the top of CONTRIBUTING.
[^2]: Suggested in https://github.com/JuliaLang/julia/pull/59484#issuecomment-3723935315