### PR TITLE
Remove potential unitialized memory in the GC stack

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2430,6 +2430,43 @@ static inline jl_cgval_t value_to_pointer(jl_codectx_t &ctx, const jl_cgval_t &v
         Align align(julia_alignment(v.typ));
         Type *ty = julia_type_to_llvm(ctx, v.typ);
         AllocaInst *loc = emit_static_alloca(ctx, ty, align);
+        if (CountTrackedPointers(ty).count > 0) {
+            auto tracked = TrackCompositeType(ty);
+            jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
+            Instruction *last_inserted = ctx.topalloca;
+            for (const auto &indices : tracked) {
+                // Walk through indices one at a time to find the field type,
+                // matching how TrackCompositeType traverses the type
+                Type *field_ty = ty;
+                for (unsigned idx : indices) {
+                    field_ty = GetElementPtrInst::getTypeAtIndex(field_ty, idx);
+                    assert(field_ty && "field_ty is null");
+                }
+                if (field_ty && field_ty->isPointerTy() &&
+                    field_ty->getPointerAddressSpace() == AddressSpace::Tracked) {
+                    Value *field_ptr;
+                    if (indices.empty()) {
+                        // Type itself is a tracked pointer, store directly to loc
+                        field_ptr = loc;
+                    } else {
+                        SmallVector<Value*, 4> gep_indices;
+                        gep_indices.push_back(ConstantInt::get(Type::getInt32Ty(ctx.builder.getContext()), 0));
+                        for (unsigned idx : indices) {
+                            gep_indices.push_back(ConstantInt::get(Type::getInt32Ty(ctx.builder.getContext()), idx));
+                        }
+                        auto *gep = GetElementPtrInst::CreateInBounds(ty, loc, gep_indices);
+                        gep->insertAfter(last_inserted);
+                        setName(ctx.emission_context, gep, "tracked_field_addr");
+                        last_inserted = gep;
+                        field_ptr = gep;
+                    }
+                    auto *store = new StoreInst(Constant::getNullValue(field_ty), field_ptr, false, Align(sizeof(void*)));
+                    store->insertAfter(last_inserted);
+                    ai.decorateInst(store);
+                    last_inserted = store;
+                }
+            }
+        }
         auto tbaa = v.V == nullptr ? ctx.tbaa().tbaa_gcframe : ctx.tbaa().tbaa_stack;
         auto stack_ai = jl_aliasinfo_t::fromTBAA(ctx, tbaa);
         recombine_value(ctx, v, loc, stack_ai, align, false);


### PR DESCRIPTION
Fixes #60622 

This was a very messy thing. But apparently the code we generate for value_to_pointer is liable to being transformed by LLVM, and under some transformations specifically LICM we can materialize a root that didn't exist at codegen time and that root is liable to being being undef which can cause segfaults
This conservativaly initializes the gc pointers to zero.
 
