### PR TITLE
force `precompile()` directives into pkgimages even if already compiled

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -3956,6 +3956,10 @@ static void _generate_from_hint(jl_method_instance_t *mi, size_t world)
         if (jl_atomic_load_relaxed(&((jl_code_instance_t*)codeinst)->invoke) == jl_fptr_const_return)
             return; // probably not a good idea to generate code
         jl_atomic_store_relaxed(&((jl_code_instance_t*)codeinst)->precompile, 1);
+        // Ensure precompile() directives capture methods for pkgimages
+        // Even if the CodeInstance already existed, we need to add it to newly_inferred
+        // when tagging is enabled so it gets included in the package image
+        jl_push_newly_inferred(codeinst);
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/60643

I think what's happening is that the method is already compiled before `jl_tag_newly_inferred_enable` is enabled, so it's not marked even though it's explicitly requested.

https://github.com/JuliaLang/julia/blob/5c750a278d53cbe587243cc06c454da3abee0e78/stdlib/REPL/src/precompile.jl#L200-L215

This makes `precompile`'s force the addition of the method to the pkgimage etc.