### PR TITLE
[gcchecker] Don't bail out of analysis when calling a C++ constructor

### DIFF
--- a/src/clangsa/GCChecker.cpp
+++ b/src/clangsa/GCChecker.cpp
@@ -1421,10 +1421,8 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
   // These checks should have no effect on the surrounding environment
   // (globals should not be invalidated, etc), hence the use of evalCall.
   const CallExpr *CE = dyn_cast<CallExpr>(Call.getOriginExpr());
-  if (!CE)
-    return false;
   unsigned CurrentDepth = C.getState()->get<GCDepth>();
-  auto name = C.getCalleeName(CE);
+  auto name = CE ? C.getCalleeName(CE) : "";
   if (name == "JL_GC_POP") {
     if (CurrentDepth == 0) {
       report_error(C, "JL_GC_POP without corresponding push");

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -602,6 +602,7 @@ static void prepare_compile(jl_code_instance_t *codeinst) JL_NOTSAFEPOINT_LEAVE 
             assert(waiting == std::get<1>(it->second));
             std::get<1>(it->second) = 0;
             auto &params = std::get<0>(it->second);
+            JL_GC_PROMISE_ROOTED(&params);
             params.tsctx_lock = params.tsctx.getLock();
             waiting = jl_analyze_workqueue(codeinst, params, true); // may safepoint
             assert(!waiting); (void)waiting;
@@ -633,6 +634,7 @@ static void complete_emit(jl_code_instance_t *edge) JL_NOTSAFEPOINT_LEAVE JL_NOT
         assert(it != incompletemodules.end());
         if (--std::get<1>(it->second) == 0) {
             auto &params = std::get<0>(it->second);
+            JL_GC_PROMISE_ROOTED(&params);
             params.tsctx_lock = params.tsctx.getLock();
             assert(callee == it->first);
             orc::ThreadSafeModule &M = emittedmodules[callee];

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -287,7 +287,7 @@ struct jl_codegen_params_t {
     bool imaging_mode;
     bool safepoint_on_entry = true;
     bool use_swiftcc = true;
-    jl_codegen_params_t(orc::ThreadSafeContext ctx, DataLayout DL, Triple triple) JL_NOTSAFEPOINT  JL_NOTSAFEPOINT_ENTER
+    jl_codegen_params_t(orc::ThreadSafeContext ctx, DataLayout DL, Triple triple) JL_NOTSAFEPOINT
       : tsctx(std::move(ctx)),
         tsctx_lock(tsctx.getLock()),
         DL(std::move(DL)),


### PR DESCRIPTION
In 4f5606f36bb6178d4be7413ca94d17f894a42f4e, we stopped analyzing CXXConstructExpr and CXXTemporaryObjectExpr calls, causing us to ignore the GCChecker annotations on jl_unique_gcsafe_lock's constructor and destructor.

We can handle these correctly, but some code will need to be updated to fix the new GCChecker errors.