### PR TITLE
Document changes for compiler version v1.13

### DIFF
--- a/doc/src/devdocs/compiler_changes.md
+++ b/doc/src/devdocs/compiler_changes.md
@@ -2,6 +2,8 @@
 
 The Julia compiler is not part of the public interface of Julia's `Core`, and may change in non-breaking Julia releases. This page lists breaking changes introduced to the compiler to aid in adapting to those changes, intended for packages that do interface with the compiler. It is maintained on a best-effort basis and may be incomplete.
 
+## v1.13
+
 ## v1.12
 
 ### Changes to the `IRCode` type


### PR DESCRIPTION
Added version header for v1.13 to compiler changes documentation.