### PR TITLE
Fix spelling mistakes in comments

### DIFF
--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -15,7 +15,7 @@ end
 
 function _broadcast_preserving_zero_d(f, A::Array, B::Array, Cs::Array...)
     # we already know that the shapes are compatible.
-    # We just need to select the size corresponding to the higest ndims
+    # We just need to select the size corresponding to the highest ndims
     # and reshape all the arrays to that size
     arrays = (A, B, Cs...)
     sz = mapreduce(size, (x,y) -> length(x) > length(y) ? x : y, arrays)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3082,7 +3082,7 @@ function require_stdlib(package_uuidkey::PkgId, ext::Union{Nothing, String}, fro
         run_package_callbacks(this_uuidkey)
     else
         # if the user deleted their bundled depot, next try to load it completely normally
-        # if it is an extension, we first need to indicate where to find its parant via EXT_PRIMED
+        # if it is an extension, we first need to indicate where to find its parent via EXT_PRIMED
         ext isa String && (EXT_PRIMED[this_uuidkey] = PkgId[package_uuidkey])
         newm = _require_prelocked(this_uuidkey)
     end
@@ -3608,7 +3608,7 @@ function rename_unique_ocachefile(tmppath_so::String, ocachefile_orig::String, o
         end
         # Windows prevents renaming a file that is in use so if there is a Julia session started
         # with a package image loaded, we cannot rename that file.
-        # The code belows append a `_i` to the name of the cache file where `i` is the smallest number such that
+        # The code below appends a `_i` to the name of the cache file where `i` is the smallest number such that
         # that cache file does not exist.
         ocachename, ocacheext = splitext(ocachefile_orig)
         ocachefile_unique = ocachename * "_$num" * ocacheext

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1118,7 +1118,7 @@ end
 function mightalias(A::SubArray, B::SubArray)
     # There are three ways that SubArrays might _problematically_ alias one another:
     #   1. The parents are the same we can conservatively check if the indices might overlap OR
-    #   2. The parents alias eachother in a more complicated manner (and we can't trace indices) OR
+    #   2. The parents alias each other in a more complicated manner (and we can't trace indices) OR
     #   3. One's parent is used in the other's indices
     # Note that it's ok for just the indices to alias each other as those should not be mutated,
     # so we can always do better than the default !_isdisjoint(dataids(A), dataids(B))

--- a/src/julia.h
+++ b/src/julia.h
@@ -688,7 +688,7 @@ typedef struct _jl_weakref_t {
 // in the new world age) from any partition kind to any other.
 //
 // However, not all transitions are allowed syntactically. We have the following rules for SYNTACTIC invalidation:
-// 1. It is always syntactically permissable to replace a weaker binding by a stronger binding
+// 1. It is always syntactically permissible to replace a weaker binding by a stronger binding
 // 2. Implicit bindings can be syntactically changed to other implicit bindings by changing the `using` set.
 // 3. Finally, we syntactically permit replacing one PARTITION_KIND_CONST(_IMPORT) by another of a different value.
 //

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -828,7 +828,7 @@ static size_t jl_static_show_float(JL_STREAM *out, double v,
 {
     size_t n = 0;
     // TODO: non-canonical NaNs do not round-trip
-    // TOOD: BFloat16
+    // TODO: BFloat16
     const char *size_suffix = vt == jl_float16_type ? "16" :
                               vt == jl_float32_type ? "32" :
                                                       "";

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3327,7 +3327,7 @@ static void jl_write_header_for_incremental(ios_t *f, jl_array_t *worklist, jl_a
     write_worklist_for_header(f, worklist);
     // Determine unique (module, abspath, fsize, hash, mtime) dependencies for the files defining modules in the worklist
     // (see Base._require_dependencies). These get stored in `udeps` and written to the ji-file header
-    // (abspath will be converted to a relocateable @depot path before writing, cf. Base.replace_depot_path).
+    // (abspath will be converted to a relocatable @depot path before writing, cf. Base.replace_depot_path).
     // Also write Preferences.
     // last word of the dependency list is the end of the data / start of the srctextpos
     *srctextpos = write_dependency_list(f, worklist, udeps);  // srctextpos: position of srctext entry in header index (update later)


### PR DESCRIPTION
## Summary
This PR fixes spelling mistakes in code comments found using [codespell](https://github.com/codespell-project/codespell).

## Changes
- `base/arraymath.jl:18` - `higest` → `highest`
- `base/multidimensional.jl:1121` - `eachother` → `each other`
- `base/loading.jl:3085` - `parant` → `parent`
- `base/loading.jl:3611` - `belows append` → `below appends`
- `src/julia.h:691` - `permissable` → `permissible`
- `src/rtutils.c:831` - `TOOD` → `TODO`
- `src/staticdata.c:3330` - `relocateable` → `relocatable`

## Testing
These changes only affect comments and have no impact on functionality.