### PR TITLE
similar for slices

### DIFF
--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -48,6 +48,8 @@ function Slices(A::P, slicemap::SM, ax::AX) where {P,SM,AX}
     Slices{P,SM,AX,S,N}(A, slicemap, ax)
 end
 
+similar(s::Slices{P,SM,AX,S,N}) where {P,SM,AX,S,N} = Slices{P,SM,AX,S,N}(similar(s.parent), s.slicemap, s.axes)
+
 _slice_check_dims(N) = nothing
 function _slice_check_dims(N, dim, dims...)
     1 <= dim || throw(DimensionMismatch("Invalid dimension $dim"))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2438,7 +2438,12 @@ end
     M = [1 2 3; 4 5 6; 7 8 9]
     @test eachrow(M) == eachslice(M, dims = 1) == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     @test eachcol(M) == eachslice(M, dims = 2) == [[1, 4, 7], [2, 5, 8], [3, 6, 9]]
-    @test eachslice(M, dims = 4) == [[1 2 3; 4 5 6; 7 8 9;;;]]
+    M_slice_d4 = eachslice(M, dims = 4)
+    @test M_slice_d4 == [[1 2 3; 4 5 6; 7 8 9;;;]]
+    @test typeof(eachrow(M)) === typeof(similar(eachrow(M)))
+    @test typeof(eachcol(M)) === typeof(similar(eachcol(M)))
+    @test typeof(M_slice_d4) === typeof(similar(M_slice_d4))
+
 
     SR = @inferred eachrow(M)
     @test SR[2] isa eltype(SR)


### PR DESCRIPTION
currently, with
```julia
x=eachcol(rand(3,4))
similar(x) |> typeof
```
`similar(x)` and x are different types: x isa Slice, whereas similar isa Vector{SubArray}.

Added dispatch and test for similar(::Slices)