### PR TITLE
Fix MethodError when indexing 0-length StepRange of TimePeriod

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -1042,8 +1042,11 @@ function getindex(r::StepRange, s::AbstractRange{T}) where {T<:Integer}
         start = oftype(f, f + (fs - firstindex(r)) * st)
         st *= step(s)
         len = length(s)
-        # mimic steprange_last_empty here, to try to avoid overflow
-        stop = oftype(f, start + (len - oneunit(len)) * (iszero(len) ? copysign(oneunit(st), st) : st))
+        # Handle empty slice without copysign (fixes #57056 for types like TimePeriod)
+        if iszero(len)
+            return range(start, step=st, length=0)
+        end
+        stop = oftype(f, start + (len - oneunit(len)) * st)
         return range(start, stop; step=st)
     end
 end

--- a/stdlib/Dates/test/ranges.jl
+++ b/stdlib/Dates/test/ranges.jl
@@ -611,4 +611,12 @@ end
     @test_throws OverflowError StepRange(dmin, Day(1), dmax)
 end
 
+# Issue #57056 - 0-length index into StepRange of TimePeriod
+@testset "empty indexing into StepRange of TimePeriod" begin
+    r = Dates.Hour(1):Dates.Hour(1):Dates.Hour(2)
+    @test r[1:0] == Dates.Hour[]
+    @test isempty(r[1:0])
+    @test r[2:1] == Dates.Hour[]  # another empty slice
+end
+
 end  # RangesTest module


### PR DESCRIPTION
Fixes #57056

## Summary
This PR fixes a `MethodError: no method matching copysign` that occurs when taking a 0-length slice (e.g., `[1:0]`) of a `StepRange` containing `TimePeriod` objects (such as `Dates.Hour`).

## Problem
When indexing a `StepRange` with a range resulting in length 0, the `getindex` implementation in `base/range.jl` attempts to calculate the `stop` value using `copysign` to preserve the direction of the step.

```julia
# Previous logic in base/range.jl
stop = oftype(f, start + (len - oneunit(len)) * (iszero(len) ? copysign(oneunit(st), st) : st))

However, copysign is not defined for Dates.TimePeriod types, leading to a crash:
using Dates
r = Dates.Hour(1):Dates.Hour(1):Dates.Hour(2)
r[1:0]
# ERROR: MethodError: no method matching copysign(::Hour, ::Hour)

Solution
Instead of defining copysign for all Period types (which may not be semantically appropriate), this PR modifies getindex in base/range.jl to handle the empty slice case explicitly.

If the resulting length (len) is zero, we immediately return an empty range using the length constructor. This bypasses the problematic stop calculation entirely.
if iszero(len)
    return range(start, step=st, length=0)
end

This change is safe because the end point (stop) of an empty range is semantically irrelevant, and this avoids unnecessary arithmetic operations for empty results.