### PR TITLE
SyntaxGraph utilities: `unalias_nodes`, `prune`, `annotate_parent!`

### DIFF
--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -740,6 +740,160 @@ function _copy_ast(graph2::SyntaxGraph, graph1::SyntaxGraph,
     return id2
 end
 
+"""
+    unalias_nodes(st::SyntaxTree)
+
+Return a tree where each descendent of `st` has exactly one parent in `st`.  The
+returned tree is identical to `st` in all but underlying representation, where
+every additional parent to a subtree generates a copy of that subtree.  Apart
+from achieving this, `unalias_nodes` should not allocate new nodes.
+
+    unalias_nodes(sl::SyntaxList)
+
+If a `SyntaxList` is given, every resulting tree will be unique with respect to
+each other as well as internally.  A duplicate entry will produce a copied tree.
+"""
+unalias_nodes(st::SyntaxTree) = SyntaxTree(
+    syntax_graph(st),
+    _unalias_nodes(syntax_graph(st), st._id, Set{NodeId}(), Set{Int}()))
+
+function unalias_nodes(sl::SyntaxList)
+    seen = Set{NodeId}()
+    seen_edges = Set{Int}()
+    SyntaxList(syntax_graph(sl),
+               map(id->_unalias_nodes(syntax_graph(sl), id, seen, seen_edges),
+                   sl.ids))
+end
+
+# Note that `seen_edges` is only needed for when edge ranges overlap, which is a
+# situation we don't produce yet.
+function _unalias_nodes(graph::SyntaxGraph, id::NodeId,
+                        seen::Set{NodeId}, seen_edges::Set{Int})
+    if id in seen
+        id = copy_ast(graph, SyntaxTree(graph, id); copy_source=false)._id
+    end
+    if !isempty(intersect(seen_edges, graph.edge_ranges[id]))
+        # someone is referencing our edges; run away so we can modify them
+        # (we don't produce this situation.  delete if we decide we never will)
+        next_edge = length(graph.edges) + 1
+        append!(graph.edges, children(graph, id))
+        graph.edge_ranges[id] = next_edge:lastindex(graph.edges)
+    end
+    union!(seen_edges, graph.edge_ranges[id])
+    push!(seen, id)
+
+    for (c, i) in zip(children(graph, id), graph.edge_ranges[id])
+        c2 = _unalias_nodes(graph, c, seen, seen_edges)
+        # the new child should be the same in every way to the old one, so
+        # modify the edge instead of triggering copies with `mapchildren`
+        c !== c2 && (graph.edges[i] = c2)
+    end
+    return id
+end
+
+"""
+Return a tree where unreachable nodes (non-descendents of `st`) in its graph
+have been deleted, and where provenance data has been minimized.
+
+If `keep` is not nothing, also consider descendents of it reachable.  It's
+usually useful to provide `keep=your_parser_output` (so we have expression
+provenance back to the original parsed nodes, but no lowering-internal
+provenance.)  In any case, we still retain byte (or, from old macros,
+LineNumberNode) provenance.
+
+Provenance shrinkage: The green tree will be delete unless specified in `keep`.
+If node A references node B as its `.source` and B is unreachable, A adopts the
+source of B.
+"""
+function prune(st::SyntaxTree;
+               keep::Union{SyntaxTree, SyntaxList, Nothing}=nothing)
+    entrypoints = NodeId[st._id]
+    keep isa SyntaxList && append!(entrypoints, keep.ids)
+    keep isa SyntaxTree && push!(entrypoints, keep._id)
+    prune(syntax_graph(st), unique(entrypoints))[1]
+end
+
+# This implementation unaliases nodes, which undoes a small amount of space
+# savings from the DAG representation, but it allows us to (1) omit the whole
+# `edges` array (TODO), and (2) make the pruning algorithm simpler.  The
+# invariant we win is having `edge_ranges` be one or more interleaved
+# level-order traversals where every node's set of children is contiguous, so
+# its entries can refer to itself instead of an external `edges` vector.
+function prune(graph1_a::SyntaxGraph, entrypoints_a::Vector{NodeId})
+    @assert length(entrypoints_a) === length(unique(entrypoints_a))
+    unaliased = unalias_nodes(SyntaxList(graph1_a, entrypoints_a))
+    (graph1, entrypoints) = (unaliased.graph, unaliased.ids)
+
+    nodes1 = copy(entrypoints)      # Current reachable subset of graph1
+    map12 = Dict{NodeId, Int}()     # graph1 => graph2 mapping
+    graph2 = ensure_attributes!(SyntaxGraph(); attrdefs(graph1)...)
+    while length(graph2.edge_ranges) < length(nodes1)
+        n2 = length(graph2.edge_ranges) + 1
+        n1 = nodes1[n2]
+        map12[n1] = n2
+        push!(graph2.edge_ranges, is_leaf(graph1, n1) ?
+            (0:-1) : (1:numchildren(graph1, n1)) .+ length(nodes1))
+        for c1 in children(graph1, n1)
+            push!(nodes1, c1)
+        end
+    end
+    graph2.edges = 1:length(nodes1) # our reward for unaliasing
+
+    for attr in attrnames(graph1)
+        attr === :source && continue
+        for (n2, n1) in enumerate(nodes1)
+            if (begin
+                    attrval = get(graph1.attributes[attr], n1, nothing)
+                    !isnothing(attrval)
+                end)
+                graph2.attributes[attr][n2] = attrval
+            end
+        end
+    end
+
+    # Resolve provenance.  Tricky to avoid dangling `.source` references.
+    resolved_sources = Dict{NodeId, SourceAttrType}() # graph1 id => graph2 src
+    function get_resolved!(id1::NodeId)
+        out = get(resolved_sources, id1, nothing)
+        if isnothing(out)
+            src1 = graph1.source[id1]
+            out = if haskey(map12, src1)
+                map12[src1]
+            elseif src1 isa NodeId
+                get_resolved!(src1)
+            elseif src1 isa Tuple
+                map(get_resolved!, src1)
+            else
+                src1
+            end
+            resolved_sources[id1] = out
+        end
+        return out
+    end
+
+    for (n2, n1) in enumerate(nodes1)
+        graph2.source[n2] = get_resolved!(n1)
+    end
+
+    # The first n entries in nodes1 were our entrypoints, unique from unaliasing
+    return SyntaxList(graph2, 1:length(entrypoints))
+end
+
+"""
+Give each descendent of `st` a `parent::NodeId` attribute.
+"""
+function annotate_parent!(st::SyntaxTree)
+    g = unfreeze_attrs(syntax_graph(st))
+    st = unalias_nodes(SyntaxTree(g, st._id))
+    ensure_attributes!(g; parent=NodeId)
+    mapchildren(t->_annotate_parent!(t, st._id), syntax_graph(st), st)
+end
+
+function _annotate_parent!(st::SyntaxTree, pid::NodeId)
+    setattr!(st, :parent, pid)
+    mapchildren(t->_annotate_parent!(t, st._id), syntax_graph(st), st)
+end
+
 #-------------------------------------------------------------------------------
 # AST destructuring utilities
 

--- a/JuliaSyntax/test/syntax_graph.jl
+++ b/JuliaSyntax/test/syntax_graph.jl
@@ -117,17 +117,6 @@ end
         @test st[1][1].source == stu[1][1].source == stu[2][1].source
         @test stu[1][1]._id != stu[2][1]._id
 
-        # Try again with overlapping edge_ranges
-        g = testgraph([1:2, 3:3, 3:3, 0:-1], [2, 3, 4])
-        st = SyntaxTree(g, 1)
-        stu = JuliaSyntax.unalias_nodes(st)
-        @test st ≈ stu
-        @test length(stu._graph.edge_ranges) == 5
-        @test length(stu._graph.edges) == 4
-        @test 4 == stu[1][1].orig == stu[2][1].orig
-        @test st[1][1].source == stu[1][1].source == stu[2][1].source
-        @test stu[1][1]._id != stu[2][1]._id
-
         #           +-> 5
         #           |
         # 1 -+-> 2 -+---->>>-> 6

--- a/JuliaSyntax/test/syntax_graph.jl
+++ b/JuliaSyntax/test/syntax_graph.jl
@@ -1,4 +1,4 @@
-using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, freeze_attrs, unfreeze_attrs, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm
+using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, freeze_attrs, unfreeze_attrs, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef
 
 @testset "SyntaxGraph attrs" begin
     st = parsestmt(SyntaxTree, "function foo end")
@@ -55,10 +55,12 @@ end
     function testgraph(edge_ranges, edges, more_attrs...)
         kinds = Dict(map(i->(i=>K"block"), eachindex(edge_ranges)))
         sources = Dict(map(i->(i=>LineNumberNode(i)), eachindex(edge_ranges)))
+        orig = Dict(map(i->(i=>i), eachindex(edge_ranges)))
         SyntaxGraph(
             edge_ranges,
             edges,
-            Dict(:kind => kinds, :source => sources, more_attrs...))
+            Dict(:kind => kinds, :source => sources,
+                 :orig => orig, more_attrs...))
     end
 
     @testset "copy_ast" begin
@@ -98,6 +100,194 @@ end
         new_g = ensure_attributes!(SyntaxGraph(); attrdefs(g)...)
         # Disallow for now, since we can't prevent dangling sourcerefs
         @test_throws ErrorException copy_ast(new_g, st; copy_source=false)
+    end
+
+    @testset "unalias_nodes" begin
+        # 1 -+-> 2 ->-> 4
+        #    |      |
+        #    +-> 3 -+
+        g = testgraph([1:2, 3:3, 4:4, 0:-1], [2, 3, 4, 4])
+        st = SyntaxTree(g, 1)
+        stu = JuliaSyntax.unalias_nodes(st)
+        @test st ≈ stu
+        @test length(stu._graph.edge_ranges) == 5
+        @test length(stu._graph.edges) == 4
+        # Properties of node 4 should be preserved
+        @test 4 == stu[1][1].orig == stu[2][1].orig
+        @test st[1][1].source == stu[1][1].source == stu[2][1].source
+        @test stu[1][1]._id != stu[2][1]._id
+
+        # Try again with overlapping edge_ranges
+        g = testgraph([1:2, 3:3, 3:3, 0:-1], [2, 3, 4])
+        st = SyntaxTree(g, 1)
+        stu = JuliaSyntax.unalias_nodes(st)
+        @test st ≈ stu
+        @test length(stu._graph.edge_ranges) == 5
+        @test length(stu._graph.edges) == 4
+        @test 4 == stu[1][1].orig == stu[2][1].orig
+        @test st[1][1].source == stu[1][1].source == stu[2][1].source
+        @test stu[1][1]._id != stu[2][1]._id
+
+        #           +-> 5
+        #           |
+        # 1 -+-> 2 -+---->>>-> 6
+        #    |           |||
+        #    +-> 3 -> 7 -+||
+        #    |            ||
+        #    +-> 4 -+-----+|
+        #           |      |
+        #           +------+
+        g = testgraph([1:3, 4:5, 6:6, 7:8, 0:-1, 0:-1, 9:9],
+                      [2, 3, 4, 5, 6, 7, 6, 6, 6])
+        st = SyntaxTree(g, 1)
+        stu = JuliaSyntax.unalias_nodes(st)
+        @test st ≈ stu
+        # node 6 should be copied three times
+        @test length(stu._graph.edge_ranges) == 10
+        @test length(stu._graph.edges) == 9
+        # the four copies of node 6 should have attrs identical to the original and distinct ids
+        @test 6 == stu[1][2].orig == stu[2][1][1].orig == stu[3][1].orig == stu[3][2].orig
+        @test stu[1][2]._id != stu[2][1][1]._id != stu[3][1]._id != stu[3][2]._id
+
+        # 1 -+-> 2 ->-> 4 -+----> 5 ->-> 7
+        #    |      |      |         |
+        #    +-> 3 -+      +-->-> 6 -+
+        #        |            |
+        #        +------------+
+        g = testgraph([1:2, 3:3, 4:5, 6:7, 8:8, 9:9, 0:-1],
+                      [2,3,4,4,6,5,6,7,7])
+        st = SyntaxTree(g, 1)
+        stu = JuliaSyntax.unalias_nodes(st)
+        @test st ≈ stu
+        @test length(stu._graph.edge_ranges) == 15
+        @test length(stu._graph.edges) == 14
+        # attrs of nodes 4-7
+        @test 4 == stu[1][1].orig == stu[2][1].orig
+        @test 5 == stu[1][1][1].orig == stu[2][1][1].orig
+        @test 6 == stu[1][1][2].orig == stu[2][1][2].orig == stu[2][2].orig
+        @test 7 == stu[1][1][1][1].orig == stu[1][1][2][1].orig ==
+            stu[2][1][1][1].orig == stu[2][1][2][1].orig == stu[2][2][1].orig
+        # ensure no duplication
+        @test stu[1][1][1][1]._id != stu[1][1][2][1]._id !=
+            stu[2][1][1][1]._id != stu[2][1][2][1]._id != stu[2][2][1]._id
+    end
+
+    @testset "prune" begin
+        # [1]-+-> 2         5 --> 6
+        #     |
+        #     +-> 3 --> 4   7
+        g = testgraph([1:2, 0:-1, 3:3, 0:-1, 4:4, 0:-1, 0:-1], [2, 3, 4, 6])
+        st = SyntaxTree(g, 1)
+        stp = JuliaSyntax.prune(st)
+        @test st ≈ stp
+        @test length(stp._graph.edge_ranges) === 4
+        @test stp.source == LineNumberNode(1)
+        @test stp[1].source == LineNumberNode(2)
+        @test stp[2].source == LineNumberNode(3)
+        @test stp[2][1].source == LineNumberNode(4)
+
+        # (also checks that the last prune didn't destroy the graph)
+        # 1 -+-> 2         5 --> 6
+        #    |
+        #    +-> 3 --> 4  [7]
+        st = SyntaxTree(g, 7)
+        stp = JuliaSyntax.prune(st)
+        @test st ≈ stp
+        @test length(stp._graph.edge_ranges) === 1
+        @test stp.orig == 7
+
+        # 1 -+->[2]->-> 4
+        #    |      |
+        #    +-> 3 -+
+        g = testgraph([1:2, 3:3, 4:4, 0:-1], [2, 3, 4, 4])
+        st = SyntaxTree(g, 2)
+        stp = JuliaSyntax.prune(st)
+        @test st ≈ stp
+        @test length(stp._graph.edge_ranges) === 2
+        @test stp.orig == 2
+        @test stp[1].orig == 4
+
+        #  9 -->[1]--> 5    src(1) = 2
+        # 10 --> 2 --> 6    src(2) = 3
+        # 11 --> 3 --> 7    src(3) = 4
+        # 12 --> 4 --> 8    else src(i) = line(i)
+        g = testgraph([1:1, 2:2, 3:3, 4:4, 0:-1, 0:-1, 0:-1, 0:-1, 5:5, 6:6, 7:7, 8:8],
+                      [5, 6, 7, 8, 1, 2, 3, 4],
+                      :source => Dict(
+                          1=>2, 2=>3, 3=>4,
+                          map(i->(i=>LineNumberNode(i)), 4:12)...))
+        st = SyntaxTree(g, 1)
+        stp = JuliaSyntax.prune(st; keep=SyntaxList(g, NodeId[4]))
+        @test st ≈ stp
+        # 1, 5, 4, 8 should remain
+        @test length(stp._graph.edge_ranges) === 4
+        @test stp.source isa NodeId
+        orig_4 = SyntaxTree(stp._graph, stp.source)
+        @test orig_4.source === LineNumberNode(4)
+        @test numchildren(orig_4) === 1
+        @test orig_4[1].source === LineNumberNode(8)
+        @test stp[1].source === LineNumberNode(5)
+
+        # Try again with node 3 explicitly marked reachable
+        stp = JuliaSyntax.prune(st, keep=SyntaxList(g, NodeId[3, 4]))
+        @test st ≈ stp
+        # 1, 5, 4, 8, and now 3, 7 as well
+        @test length(stp._graph.edge_ranges) === 6
+        @test stp.source isa NodeId
+        @test stp[1].source === LineNumberNode(5)
+
+        orig_3 = SyntaxTree(stp._graph, stp.source)
+        @test orig_3.source isa NodeId
+        orig_4 = SyntaxTree(stp._graph, orig_3.source)
+        @test orig_4.source === LineNumberNode(4)
+
+        @test numchildren(orig_3) === 1
+        @test numchildren(orig_4) === 1
+        @test orig_3[1].source === LineNumberNode(7)
+        @test orig_4[1].source === LineNumberNode(8)
+
+        # Try again with no node provenance
+        stp = JuliaSyntax.prune(st, keep=nothing)
+        @test st ≈ stp
+        @test length(stp._graph.edge_ranges) === 2
+        @test stp.source === LineNumberNode(4)
+        @test stp[1].source === LineNumberNode(5)
+
+        # test with real parsed, then copied output---not many properties we can
+        # check without fragile tests, but there are some.
+        code = "begin; x1=1; x2=2; x3=3; x4=begin; 4; end; begin; end; end"
+        st0 = parsestmt(SyntaxTree, code)
+        st0_dup1 = JuliaSyntax.mknode(st0, children(st0))
+        st0_dup2 = JuliaSyntax.mknode(st0_dup1, children(st0_dup1))
+        stp = JuliaSyntax.prune(st0_dup2; keep=st0)
+        @test st0_dup2 ≈ stp
+        @test length(stp._graph.edge_ranges) <
+            length(st0_dup2._graph.edge_ranges)
+        @test stp.source isa NodeId
+        @test SyntaxTree(stp._graph, stp.source) ≈ st0
+        @test sourcetext(stp) == code
+        # try without preserving st0
+        stp = JuliaSyntax.prune(st0_dup2, keep=nothing)
+        @test st0_dup2 ≈ stp
+        @test length(stp._graph.edge_ranges) <
+            length(st0_dup2._graph.edge_ranges)
+        @test stp.source isa SourceRef
+        @test sourcetext(stp) == code
+    end
+
+    @testset "annotate_parent" begin
+        chk_parent(st, parent) = get(st, :parent, nothing) === parent &&
+            all(c->chk_parent(c, st._id), children(st))
+        # 1 -+-> 2 ->-> 4 --> 5
+        #    |      |
+        #    +-> 3 -+
+        g = testgraph([1:2, 3:3, 4:4, 5:5, 0:-1], [2, 3, 4, 4, 5])
+        st = JuliaSyntax.annotate_parent!(SyntaxTree(g, 1))
+        @test chk_parent(st, nothing)
+        # NamedTuple-based attrs
+        g = JuliaSyntax.freeze_attrs(testgraph([1:2, 3:3, 4:4, 5:5, 0:-1], [2, 3, 4, 4, 5]))
+        st = JuliaSyntax.annotate_parent!(SyntaxTree(g, 1))
+        @test chk_parent(st, nothing)
     end
 end
 


### PR DESCRIPTION
Update of https://github.com/JuliaLang/JuliaLowering.jl/pull/35 upon request of @aviatesk.  `SyntaxGraph` has some pitfalls that these utilities can help with:
- `unalias_nodes` converts a DAG to a tree given a root, copying as few nodes as possible
- `prune` unaliases, then trims unreferenced nodes in a tree given one or more roots
- `annotate_parent!` unaliases, then adds a `.parent::NodeId` attribute to all nodes given a root

The last one is very simple, and @c42f is right that we probably shouldn't be using it in lowering, so we could consider just putting it in JETLS (which will probably end up needing a bunch of passes that add attributes in the same way anyway).