### PR TITLE
Avoid an error when `show`ing a `Platform` with an unrecognized OS

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -432,9 +432,11 @@ const platform_names = Dict(
     platform_name(p::AbstractPlatform)
 
 Get the "platform name" of the given platform, returning e.g. "Linux" or "Windows".
+If the platform's OS is not recognized, `os(p)` is returned.
 """
 function platform_name(p::AbstractPlatform)
-    return platform_names[os(p)]
+    oh_ess = os(p)
+    return get(platform_names, oh_ess, oh_ess)
 end
 
 function VNorNothing(d::Dict, key)

--- a/test/binaryplatforms.jl
+++ b/test/binaryplatforms.jl
@@ -66,6 +66,8 @@ end
     for platform in platforms
         @test platform_name(P("x86_64", platform)) == platform
     end
+    # `validate_strict=false` with unrecognized OS/arch
+    @test platform_name(Platform("x86", "winnt")) == "winnt"
 
     # Test `arch()`
     arch_names = ("x86_64", "i686", "powerpc64le", "armv7l", "armv6l", "aarch64")
@@ -420,4 +422,10 @@ end
     @test !platforms_match(ac, bc)
     @test platforms_match(ac, ac)
     @test platforms_match(bc, bc)
+end
+
+@testset "Platform printing" begin
+    # Unrecognized OS without strict validation
+    weirdos = Platform("x86", "winnt")
+    @test sprint(show, MIME("text/plain"), weirdos) == "winnt x86"
 end

--- a/test/binaryplatforms.jl
+++ b/test/binaryplatforms.jl
@@ -425,6 +425,18 @@ end
 end
 
 @testset "Platform printing" begin
+    # No additional tags
+    p = Platform("x86_64", "Windows")
+    @test sprint(show, p) == "Platform(\"x86_64\", \"windows\")"
+    @test sprint(show, MIME("text/plain"), p) == "Windows x86_64"
+    # One additional tag
+    p = Platform("aarch64", "freebsd"; os_version="14.3")
+    @test sprint(show, p) == "Platform(\"aarch64\", \"freebsd\"; os_version=\"14.3.0\")"
+    @test sprint(show, MIME("text/plain"), p) == "FreeBSD aarch64 {os_version=14.3.0}"
+    # Multiple tags; ensure they appear in sorted order for consistency/stability
+    p = Platform("armv7l", "linux"; libc="musl", libgfortran_version=v"3", cxxstring_abi="cxx11")
+    @test sprint(show, p) == "Platform(\"armv7l\", \"linux\"; call_abi=\"eabihf\", cxxstring_abi=\"cxx11\", libc=\"musl\", libgfortran_version=\"3.0.0\")"
+    @test sprint(show, MIME("text/plain"), p) == "Linux armv7l {call_abi=eabihf, cxxstring_abi=cxx11, libc=musl, libgfortran_version=3.0.0}"
     # Unrecognized OS without strict validation
     weirdos = Platform("x86", "winnt")
     @test sprint(show, MIME("text/plain"), weirdos) == "winnt x86"


### PR DESCRIPTION
Currently:
```julia-repl
julia> Platform("x86_64", "winnt")

Error showing value of type Platform:
ERROR: KeyError: key "winnt" not found
Stacktrace:
  [1] getindex
    @ ./dict.jl:479 [inlined]
  [2] platform_name(p::Platform)
    @ Base.BinaryPlatforms ./binaryplatforms.jl:437
  [3] show(io::IOContext{REPL.LimitIO{Base.TTY}}, ::MIME{Symbol("text/plain")}, p::Platform)
    @ Base.BinaryPlatforms ./binaryplatforms.jl:185
...
```
This PR:
```julia-repl
julia> Platform("x86_64", "winnt")
winnt x86_64
```
This changes the behavior of `platform_name` to return the `os` tag if the OS isn't among the handful of explicitly recognized platforms.

In a separate commit, I fixed a pet peeve of mine, which is:
```julia-repl
julia> show(Platform("x86_64", "windows"))
Platform("x86_64", "windows"; )
```
Note the `;` with no keyword arguments. As part of this commit, I also made the two `show` methods that exist for `Platform` more consistent with one another, primarily in that both will now show keyword arguments in sorted order (currently only one of them does).