### PR TITLE
Backport `@fastmath x^2` inlining regression to 1.12

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -297,12 +297,13 @@ exp10_fast(x::Union{Float32,Float64}) = Base.Math.exp10_fast(x)
 
 # builtins
 
-@inline function pow_fast(x::Float64, y::Integer)
+@inline function pow_fast(x::Union{Float32, Float64}, y::Integer)
     z = y % Int32
     z == y ? pow_fast(x, z) : x^y
 end
-pow_fast(x::Float32, y::Integer) = x^y
-pow_fast(x::Float64, y::Int32) = ccall("llvm.powi.f64.i32", llvmcall, Float64, (Float64, Int32), x, y)
+@inline pow_fast(x::Float16, y::Integer) = Float16(pow_fast(Float32(x), y))
+pow_fast(x::Float64, y::Int32) = ccall("llvm.powi", llvmcall, Float64, (Float64, Int32), x, y)
+pow_fast(x::Float32, y::Int32) = ccall("llvm.powi", llvmcall, Float32, (Float32, Int32), x, y)
 pow_fast(x::FloatTypes, ::Val{p}) where {p} = pow_fast(x, p) # inlines already via llvm.powi
 @inline pow_fast(x, v::Val) = Base.literal_pow(^, x, v)
 


### PR DESCRIPTION
This isn't a direct backport of https://github.com/JuliaLang/julia/pull/60640/ because because `llvm.powi.f16.i32` is very broken on LLVM 18 (at least for targets without hardware fp16 support like x86).

This is only a performance backport, but it is a pretty important regression that was introduced in 1.12.