### PR TITLE
compiler/ssair: preserve negative NewSSAValue

### DIFF
--- a/Compiler/src/ssair/ir.jl
+++ b/Compiler/src/ssair/ir.jl
@@ -1684,7 +1684,10 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
                 stmt = ssa_rename[stmt.id]
             end
         elseif isa(stmt, NewSSAValue)
-            stmt = SSAValue(stmt.id)
+            if stmt.id > 0
+                # Negative ids reference new_new_nodes and must remain NewSSAValue.
+                stmt = SSAValue(stmt.id)
+            end
         else
             # Constant assign, replace uses of this ssa value with its result
         end

--- a/Compiler/test/irpasses.jl
+++ b/Compiler/test/irpasses.jl
@@ -2134,3 +2134,6 @@ let src = code_typed1((Vector{Any},)) do xs
     end
     @test count(iscall((src, Core.svec)), src.code) == 1
 end
+
+f_57827(arr) = foldl((acc, x) -> ifelse(x > acc[1], (x,), (acc[1],)), arr, init = (-Inf,))
+@test f_57827([1, 20, 3, 4]) == (20,)

--- a/Compiler/test/irpasses.jl
+++ b/Compiler/test/irpasses.jl
@@ -2135,5 +2135,18 @@ let src = code_typed1((Vector{Any},)) do xs
     @test count(iscall((src, Core.svec)), src.code) == 1
 end
 
-f_57827(arr) = foldl((acc, x) -> ifelse(x > acc[1], (x,), (acc[1],)), arr, init = (-Inf,))
-@test f_57827([1, 20, 3, 4]) == (20,)
+# Negative NewSSAValue ids must be preserved during compaction
+function f_57827(op, init, x)
+    v = op(init, x)
+    i = 0
+    while i < 1
+        v = op(v, x)
+        i += 1
+    end
+    return v
+end
+let rf = (acc, x) -> ifelse(x > acc[1], (x,), (acc[1],))
+    @test f_57827(rf, (0.0,), 1) === (1,)
+    ir = first(only(Base.code_ircode(f_57827, (typeof(rf), Tuple{Float64}, Int64); optimize_until="CC: SROA")))
+    @test ir isa Compiler.IRCode
+end


### PR DESCRIPTION
During incremental compaction a forwarded NewSSAValue with a negative id was treated like an SSAValue, producing SSAValue(-n) and tripping `renumber_ssa2` bounds checks. Only convert NewSSAValue to SSAValue when the id is positive, so new_new_nodes references remain valid.

🤖 AI fix for #57827. Putting up for consideration.