### PR TITLE
Temporarily reintroduce a global type inference lock

### DIFF
--- a/doc/src/devdocs/locks.md
+++ b/doc/src/devdocs/locks.md
@@ -100,6 +100,7 @@ exception frames, and taking/releasing locks.
 No Julia code may be called while holding a lock above this point.
 
 * `world_counter_lock`
+* `jl_typeinf_lock`
 
 ### Level 7
 

--- a/src/init.c
+++ b/src/init.c
@@ -559,6 +559,7 @@ extern jl_mutex_t precomp_statement_out_lock;
 extern jl_mutex_t newly_inferred_mutex;
 extern jl_mutex_t global_roots_lock;
 extern jl_mutex_t profile_show_peek_cond_lock;
+extern jl_mutex_t jl_typeinf_lock;
 
 static void restore_fp_env(void)
 {
@@ -684,6 +685,7 @@ static void init_global_mutexes(void) {
     JL_MUTEX_INIT(&global_roots_lock, "global_roots_lock");
     JL_MUTEX_INIT(&typecache_lock, "typecache_lock");
     JL_MUTEX_INIT(&profile_show_peek_cond_lock, "profile_show_peek_cond_lock");
+    JL_MUTEX_INIT(&jl_typeinf_lock, "jl_typeinf_lock");
 }
 
 JL_DLLEXPORT void jl_init_(jl_image_buf_t sysimage)


### PR DESCRIPTION
It is likely the performance regressions caused by unecessary `tojlinvoke`/`specsig_to_fptr1` trampolines outweigh the benefit of multithreaded inference (see #60241).  With this change, we have a global lock protecting `jl_type_infer`, serializing all type inference and LLVM code generation (similar to 1.11), but leave LLVM compilation alone.

All the infrastructure to do multithreaded inference is left in place, so that it can be re-enabled when we're able to emit LLVM IR before all the outgoing edges are themselves emitted (for example, with #60031).