### PR TITLE
[Windows] Add DLL notification queue to avoid deadlock

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -1081,6 +1081,9 @@ bool jl_dylib_DI_for_fptr(size_t pointer, object::SectionRef *Section, uint64_t 
     IMAGEHLP_MODULE64 ModuleInfo;
     ModuleInfo.SizeOfStruct = sizeof(IMAGEHLP_MODULE64);
     uv_mutex_lock(&jl_in_stackwalk);
+    uv_mutex_lock(&jl_dll_notify_lock);
+    jl_profile_process_dll_events();
+    uv_mutex_unlock(&jl_dll_notify_lock);
     bool isvalid = SymGetModuleInfo64(GetCurrentProcess(), (DWORD64)pointer, &ModuleInfo);
     uv_mutex_unlock(&jl_in_stackwalk);
     if (!isvalid)
@@ -1182,6 +1185,9 @@ static int jl_getDylibFunctionInfo(jl_frame_t **frames, size_t pointer, int skip
     static IMAGEHLP_LINE64 frame_info_line;
     DWORD dwDisplacement = 0;
     uv_mutex_lock(&jl_in_stackwalk);
+    uv_mutex_lock(&jl_dll_notify_lock);
+    jl_profile_process_dll_events();
+    uv_mutex_unlock(&jl_dll_notify_lock);
     DWORD64 dwAddress = pointer;
     frame_info_line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
     if (SymGetLineFromAddr64(GetCurrentProcess(), dwAddress, &dwDisplacement, &frame_info_line)) {

--- a/src/julia_atomics.h
+++ b/src/julia_atomics.h
@@ -190,6 +190,7 @@ T jl_atomic_exchange_explicit(std::atomic<T> *ptr, S desired, std::memory_order 
 {
      return std::atomic_exchange_explicit<T>(ptr, desired, order);
 }
+#define jl_atomic_exchange_acquire(ptr, val) jl_atomic_exchange_explicit(ptr, val, memory_order_acquire)
 #define jl_atomic_exchange_release(ptr, val) jl_atomic_exchange_explicit(ptr, val, memory_order_release)
 #define jl_atomic_exchange_relaxed(ptr, val) jl_atomic_exchange_explicit(ptr, val, memory_order_relaxed)
 extern "C" {
@@ -218,6 +219,8 @@ extern "C" {
 // TODO: Maybe add jl_atomic_cmpswap_weak for spin lock
 #  define jl_atomic_exchange(obj, desired)       \
     atomic_exchange(obj, desired)
+#  define jl_atomic_exchange_acquire(obj, desired)      \
+    atomic_exchange_explicit(obj, desired, memory_order_acquire)
 #  define jl_atomic_exchange_release(obj, desired)      \
     atomic_exchange_explicit(obj, desired, memory_order_release)
 #  define jl_atomic_exchange_relaxed(obj, desired)      \
@@ -266,6 +269,7 @@ extern "C" {
 #define _Atomic(T) T
 
 #undef jl_atomic_exchange
+#undef jl_atomic_exchange_acquire
 #undef jl_atomic_exchange_release
 #undef jl_atomic_exchange_relaxed
 #define jl_atomic_exchange(obj, desired) \
@@ -275,6 +279,7 @@ extern "C" {
             *p__analyzer__ = (desired); \
             temp__analyzer__; \
         }))
+#define jl_atomic_exchange_acquire jl_atomic_exchange
 #define jl_atomic_exchange_release jl_atomic_exchange
 #define jl_atomic_exchange_relaxed jl_atomic_exchange
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1499,7 +1499,9 @@ typedef struct {
     CONTEXT context;
 } bt_cursor_t;
 #endif
+extern uv_mutex_t jl_dll_notify_lock;
 extern JL_DLLEXPORT uv_mutex_t jl_in_stackwalk;
+void jl_profile_process_dll_events(void) JL_NOTSAFEPOINT;
 #elif !defined(JL_DISABLE_LIBUNWIND)
 // This gives unwind only local unwinding options ==> faster code
 #  define UNW_LOCAL_ONLY

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -611,6 +611,10 @@ void jl_init_stackwalk(void)
 // Finalize stackwalk infrastructure
 void jl_fin_stackwalk(void)
 {
+    // To avoid deadlocks (due to suspending the main thread during `ExitProcess()`)
+    // and other misbehavior (due to missed DLL notifications during exit), take the
+    // profile lock here to effectively disable any active profiling threads.
+    jl_lock_profile_wr();
     if (dll_notification_cookie) {
         LdrUnregisterDllNotification(dll_notification_cookie);
         dll_notification_cookie = NULL;

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -16,6 +16,7 @@
 #ifdef _OS_WINDOWS_
 #include <winternl.h>
 uv_mutex_t jl_in_stackwalk;
+uv_mutex_t jl_dll_notify_lock;
 #define jl_unw_get(context) (RtlCaptureContext(context), 0)
 #elif !defined(JL_DISABLE_LIBUNWIND)
 #define jl_unw_get(context) unw_getcontext(context)
@@ -494,6 +495,16 @@ typedef const LDR_DLL_NOTIFICATION_DATA *PCLDR_DLL_NOTIFICATION_DATA;
 #define LDR_DLL_NOTIFICATION_REASON_LOADED   1
 #define LDR_DLL_NOTIFICATION_REASON_UNLOADED 2
 
+typedef struct dll_notification_event {
+    ULONG      NotificationReason;
+    wchar_t   *FullDllName;
+    wchar_t   *BaseDllName;
+    uintptr_t  DllBase;
+    ULONG      SizeOfImage;
+    struct dll_notification_event *next;
+} dll_notification_event_t;
+static dll_notification_event_t *dll_notify_queue = NULL;
+
 // Forward declarations for ntdll functions
 typedef VOID CALLBACK (*PLDR_DLL_NOTIFICATION_FUNCTION)(
   ULONG                       NotificationReason,
@@ -503,6 +514,56 @@ typedef VOID CALLBACK (*PLDR_DLL_NOTIFICATION_FUNCTION)(
 NTSTATUS NTAPI LdrRegisterDllNotification(ULONG Flags, PLDR_DLL_NOTIFICATION_FUNCTION NotificationFunction, PVOID Context, PVOID *Cookie);
 NTSTATUS NTAPI LdrUnregisterDllNotification(PVOID Cookie);
 
+// caller should hold jl_in_stackwalk and jl_dll_notify_lock locks
+void jl_profile_process_dll_events(void) JL_NOTSAFEPOINT
+{
+    dll_notification_event_t *event = dll_notify_queue;
+    while (event) {
+        if (event->NotificationReason == LDR_DLL_NOTIFICATION_REASON_LOADED) {
+            SymLoadModuleExW(GetCurrentProcess(), NULL,
+                             event->FullDllName,
+                             event->BaseDllName,
+                             event->DllBase,
+                             event->SizeOfImage,
+                             NULL,
+                             0);
+            free(event->FullDllName);
+            free(event->BaseDllName);
+        }
+        else if (event->NotificationReason == LDR_DLL_NOTIFICATION_REASON_UNLOADED) {
+            // if this unload event has an earlier load event in the queue, process neither
+            //
+            // this ensures that we do not try to process DLL symbols for a module that was
+            // already unloaded, or which is concurrently unloading
+            int prior_enqueued_load_of_same_module = 0;
+            dll_notification_event_t *prior_event = event;
+            while (prior_event->next) {
+                if (prior_event->next->DllBase == event->DllBase) {
+                    assert(prior_event->next->NotificationReason == LDR_DLL_NOTIFICATION_REASON_LOADED);
+                    prior_enqueued_load_of_same_module = 1;
+                    break;
+                }
+                prior_event = prior_event->next;
+            }
+            if (prior_enqueued_load_of_same_module) {
+                // skip processing for the prior load event and this unload event
+                dll_notification_event_t *load_event = prior_event->next;
+                prior_event->next = load_event->next;
+                free(load_event->FullDllName);
+                free(load_event->BaseDllName);
+                free(load_event);
+            } else {
+                SymUnloadModule64(GetCurrentProcess(), event->DllBase);
+            }
+        }
+
+        dll_notification_event_t *next = event->next;
+        free(event);
+        event = next;
+    }
+    dll_notify_queue = NULL;
+}
+
 // Callback for LdrRegisterDllNotification
 static VOID CALLBACK dll_notification_callback(
     ULONG NotificationReason,
@@ -510,29 +571,37 @@ static VOID CALLBACK dll_notification_callback(
     PVOID Context)
 {
     (void)Context;
-    uv_mutex_lock(&jl_in_stackwalk);
-    // Store DLL information and update symbol handler based on notification reason
+
+    dll_notification_event_t *event = (dll_notification_event_t*)malloc(sizeof(dll_notification_event_t));
     if (NotificationReason == LDR_DLL_NOTIFICATION_REASON_LOADED) {
         const LDR_DLL_LOADED_NOTIFICATION_DATA *data = &NotificationData->Loaded;
-        SymLoadModuleExW(GetCurrentProcess(), NULL,
-                         data->FullDllName->Buffer,
-                         data->BaseDllName->Buffer,
-                         (uintptr_t)data->DllBase,
-                         data->SizeOfImage,
-                         NULL,
-                         0);
+        event->FullDllName = _wcsdup(data->FullDllName->Buffer);
+        event->BaseDllName = _wcsdup(data->BaseDllName->Buffer);
+        event->DllBase = (uintptr_t)data->DllBase;
+        event->SizeOfImage = data->SizeOfImage;
     }
     else if (NotificationReason == LDR_DLL_NOTIFICATION_REASON_UNLOADED) {
-        const LDR_DLL_UNLOADED_NOTIFICATION_DATA *data = &NotificationData->Unloaded;
-        SymUnloadModule64(GetCurrentProcess(), (uintptr_t)data->DllBase);
+        event->DllBase = (uintptr_t)NotificationData->Unloaded.DllBase;
     }
-    uv_mutex_unlock(&jl_in_stackwalk);
+
+    // This lock guards both the data structure, as well as the possibility
+    // that a DLL is about to unloaded that is concurrently being processed
+    // by `SymLoadModuleExW`
+    uv_mutex_lock(&jl_dll_notify_lock);
+
+    event->NotificationReason = NotificationReason;
+    event->next = dll_notify_queue;
+    dll_notify_queue = event;
+
+    uv_mutex_unlock(&jl_dll_notify_lock);
+    return; // process later
 }
 
 // Initialize stackwalk infrastructure (DLL tracking and profiling)
 void jl_init_stackwalk(void)
 {
     uv_mutex_init(&jl_in_stackwalk);
+    uv_mutex_init(&jl_dll_notify_lock);
     SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES | SYMOPT_IGNORE_CVREC);
     if (!SymInitialize(GetCurrentProcess(), "", 1))
         jl_safe_printf("WARNING: failed to initialize stack walk info\n");
@@ -559,6 +628,7 @@ JL_DLLEXPORT void jl_set_profile_abort_ptr(_Atomic(int) *abort_ptr) JL_NOTSAFEPO
 static int jl_unw_init(bt_cursor_t *cursor, bt_context_t *Context)
 {
     int result;
+
 #if !defined(_CPU_X86_64_)
     memset(&cursor->stackframe, 0, sizeof(cursor->stackframe));
     cursor->stackframe.AddrPC.Offset = Context->Eip;


### PR DESCRIPTION
This adds a queue so that the DLL processing can be deferred to a profiling thread if the `jl_in_stackwalk` lock is contended.

The problem was: It is possible for a thread to be suspended for profiling in the middle of a DLL load / unload event, in which case our watchdog may wake the thread up and it will finish loading the DLL. However, the load will immediately try to load symbols for the DLL and hit a deadlock trying to obtain the `jl_in_stackwalk` lock still held by the profiling thread.

See https://github.com/JuliaLang/julia/pull/60463#issuecomment-3688139013 for more information.

Locally this resolves the rest of https://github.com/JuliaLang/julia/issues/60306 for me, at least for the MWE I have.