### PR TITLE
loading/syntax-versioning: Lookup syntax version in latest world

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -553,7 +553,7 @@ The thrown errors are collected in a stack of exceptions.
 global err = nothing
 
 const main_parser = Base.ScopedValues.ScopedValue{Any}(Core._parse)
-function _internal_julia_parse(args...)
+function var"#_internal_julia_parse"(args...)
     main_parser[](args...)
 end
 
@@ -562,7 +562,7 @@ global InteractiveUtils::Module
 global Distributed::Module
 
 # weakly exposes ans and err variables to Main
-export ans, err, _internal_julia_parse
+export ans, err, var"#_internal_julia_parse"
 end
 
 function should_use_main_entrypoint()

--- a/base/client.jl
+++ b/base/client.jl
@@ -174,7 +174,7 @@ function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
 end
 
 function _parse_input_line_core(s::String, filename::String, mod::Union{Module, Nothing})
-    ex = Meta.parseall(s; filename, mod)
+    ex = Meta.parseall(s; filename, _parse=invokelatest(Meta.parser_for_module, mod))
     if ex isa Expr && ex.head === :toplevel
         if isempty(ex.args)
             return nothing

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -768,7 +768,7 @@ end
 
 function Base.set_syntax_version(m::Module, ver::VersionNumber)
     parser = Base.VersionedParse(ver)
-    Core.declare_const(m, :_internal_julia_parse, parser)
+    Core.declare_const(m, Symbol("#_internal_julia_parse"), parser)
     #lowerer = VersionedLower(ver)
     #Core.declare_const(m, :_internal_julia_lower, lowerer)
     nothing

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3108,7 +3108,8 @@ function include_string(mapexpr::Function, mod::Module, code::AbstractString,
                         filename::AbstractString="string")
     loc = LineNumberNode(1, Symbol(filename))
     try
-        ast = Meta.parseall(code; filename, mod)
+        _parse = invokelatest(Meta.parser_for_module, mod)
+        ast = Meta.parseall(code; filename, _parse)
         if !Meta.isexpr(ast, :toplevel)
             @assert Core._lower != fl_lower
             # Only reached when JuliaLowering and alternate parse functions are activated

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2794,7 +2794,7 @@ register_root_module(Main)
 # to the loaded_modules table instead of getting bindings.
 baremodule __toplevel__
 using Base
-global _internal_julia_parse = Core._parse
+global var"#_internal_julia_parse" = Core._parse
 global _internal_julia_lower = Core._lower
 
 # Used for version checking of precompiled cache files only
@@ -2967,13 +2967,13 @@ function __require_prelocked(pkg::PkgId, env)
     if uuid !== old_uuid
         ccall(:jl_set_module_uuid, Cvoid, (Any, NTuple{2, UInt64}), __toplevel__, uuid)
     end
-    __toplevel__._internal_julia_parse = VersionedParse(spec.julia_syntax_version)
+    __toplevel__.var"#_internal_julia_parse" = VersionedParse(spec.julia_syntax_version)
     unlock(require_lock)
     try
         include(__toplevel__, path)
         loaded = maybe_root_module(pkg)
     finally
-        __toplevel__._internal_julia_parse = Core._parse
+        __toplevel__.var"#_internal_julia_parse" = Core._parse
         lock(require_lock)
         if uuid !== old_uuid
             ccall(:jl_set_module_uuid, Cvoid, (Any, NTuple{2, UInt64}), __toplevel__, old_uuid)
@@ -3303,7 +3303,7 @@ function include_package_for_output(pkg::PkgId, input::String, syntax_version::V
 
     ccall(:jl_set_newly_inferred, Cvoid, (Any,), newly_inferred)
     # This one changes the parser behavior
-    __toplevel__._internal_julia_parse = VersionedParse(syntax_version)
+    __toplevel__.var"#_internal_julia_parse" = VersionedParse(syntax_version)
     # This one is the compatibility marker for cache loading
     __toplevel__._internal_syntax_version = cache_syntax_version(syntax_version)
     try

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -307,8 +307,8 @@ ParseError(msg::AbstractString) = ParseError(msg, nothing)
 # N.B.: Should match definition in src/ast.c:jl_parse
 function parser_for_module(mod::Union{Module, Nothing})
     mod === nothing && return Core._parse
-    isdefined(mod, :_internal_julia_parse) ?
-        getglobal(mod, :_internal_julia_parse) :
+    isdefined(mod, Symbol("#_internal_julia_parse")) ?
+        getglobal(mod, Symbol("#_internal_julia_parse")) :
         Core._parse
 end
 

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -355,8 +355,8 @@ julia> Meta.parse("(α, β) = 3, 5", 11, greedy=false)
 ```
 """
 function parse(str::AbstractString, pos::Integer;
-               filename="none", greedy::Bool=true, raise::Bool=true, depwarn::Bool=true, mod = nothing)
-    ex, pos = _parse_string(str, String(filename), 1, pos, greedy ? :statement : :atom, parser_for_module(mod))
+               filename="none", greedy::Bool=true, raise::Bool=true, depwarn::Bool=true, mod::Union{Nothing, Module}=nothing, _parse = parser_for_module(mod))
+    ex, pos = _parse_string(str, String(filename), 1, pos, greedy ? :statement : :atom, _parse)
     if raise && isexpr(ex, :error)
         err = ex.args[1]
         if err isa String
@@ -395,8 +395,8 @@ julia> Meta.parse("x = ")
 ```
 """
 function parse(str::AbstractString;
-               filename="none", raise::Bool=true, depwarn::Bool=true, mod = nothing)
-    ex, pos = parse(str, 1; filename, greedy=true, raise, depwarn, mod = mod)
+               filename="none", raise::Bool=true, depwarn::Bool=true, mod::Union{Nothing, Module}=nothing, _parse = parser_for_module(mod))
+    ex, pos = parse(str, 1; filename, greedy=true, raise, depwarn, _parse)
     if isexpr(ex, :error)
         return ex
     end
@@ -407,12 +407,12 @@ function parse(str::AbstractString;
     return ex
 end
 
-function parseatom(text::AbstractString, pos::Integer; filename="none", lineno=1, mod = nothing)
-    return _parse_string(text, String(filename), lineno, pos, :atom, parser_for_module(mod))
+function parseatom(text::AbstractString, pos::Integer; filename="none", lineno=1, mod::Union{Nothing, Module}=nothing, _parse = parser_for_module(mod))
+    return _parse_string(text, String(filename), lineno, pos, :atom, _parse)
 end
 
-function parseall(text::AbstractString; filename="none", lineno=1, mod = nothing)
-    ex,_ = _parse_string(text, String(filename), lineno, 1, :all, parser_for_module(mod))
+function parseall(text::AbstractString; filename="none", lineno=1, mod::Union{Nothing, Module}=nothing, _parse = parser_for_module(mod))
+    ex,_ = _parse_string(text, String(filename), lineno, 1, :all, _parse)
     return ex
 end
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -1318,7 +1318,7 @@ jl_value_t *jl_parse(const char *text, size_t text_len, jl_value_t *filename,
 {
     jl_value_t *parser = NULL;
     if (inmodule) {
-        parser = jl_get_global(inmodule, jl_symbol("_internal_julia_parse"));
+        parser = jl_get_global(inmodule, jl_symbol("#_internal_julia_parse"));
     }
     if ((!parser || parser == jl_nothing) && jl_core_module) {
         parser = jl_get_global(jl_core_module, jl_symbol("_parse"));

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1924,4 +1924,14 @@ module M58272_to end
     syntax_version_script = joinpath(@__DIR__, "testhelpers", "print_syntax_version.jl")
     @test parse(VersionNumber, read(`$(Base.julia_cmd()) --project=$(joinpath(explicit_env, "VersionedDep1")) $syntax_version_script`, String)) == v"1.13"
     @test parse(VersionNumber, read(`$(Base.julia_cmd()) --project=$(joinpath(explicit_env, "VersionedDep2")) $syntax_version_script`, String)) == v"1.14"
+
+    function include_world_age()
+       m = @eval(module IncludeWorldAgeTest end)
+       @test_nowarn @test include_string(m, "Base.Experimental.@VERSION").syntax == (Base.Experimental.@VERSION).syntax
+       @test_nowarn @test Core.include(m, joinpath(@__DIR__, "testhelpers", "return_syntax_version.jl")) == (Base.Experimental.@VERSION).syntax
+       Base.Experimental.set_syntax_version!(m, v"1.13")
+       @test_nowarn @test include_string(m, "Base.Experimental.@VERSION").syntax == v"1.13"
+       @test_nowarn @test Core.include(m, joinpath(@__DIR__, "testhelpers", "return_syntax_version.jl")) == v"1.13"
+    end
+    include_world_age()
 end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1929,7 +1929,7 @@ module M58272_to end
        m = @eval(module IncludeWorldAgeTest end)
        @test_nowarn @test include_string(m, "Base.Experimental.@VERSION").syntax == (Base.Experimental.@VERSION).syntax
        @test_nowarn @test Core.include(m, joinpath(@__DIR__, "testhelpers", "return_syntax_version.jl")) == (Base.Experimental.@VERSION).syntax
-       Base.Experimental.set_syntax_version!(m, v"1.13")
+       Base.set_syntax_version(m, v"1.13")
        @test_nowarn @test include_string(m, "Base.Experimental.@VERSION").syntax == v"1.13"
        @test_nowarn @test Core.include(m, joinpath(@__DIR__, "testhelpers", "return_syntax_version.jl")) == v"1.13"
     end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -189,7 +189,7 @@ let
     @test Base.binding_module(TestMod7648.TestModSub9475, :b9475) == TestMod7648.TestModSub9475
     defaultset = Set(Symbol[:Foo7648, :TestMod7648, :a9475, :c7648, :f9475, :foo7648, :foo7648_nomethods])
     allset = defaultset ∪ Set(Symbol[
-        Symbol("#foo7648"), Symbol("#foo7648_nomethods"),
+        Symbol("#foo7648"), Symbol("#foo7648_nomethods"), Symbol("#_internal_julia_parse"),
         :TestModSub9475, :d7648, :eval, :f7648, :include])
     imported = Set(Symbol[:convert, :curmod_name, :curmod])
     usings_from_Test = Set(Symbol[
@@ -275,7 +275,7 @@ let defaultset = Set((:A,))
     imported = Set((:M2,))
     usings_from_Base = delete!(Set(names(Module(); usings=true)), :anonymous) # the name of the anonymous module itself
     usings = Set((:A, :f, :C, :y, :M1, :m1_x)) ∪ usings_from_Base
-    allset = Set((:A, :B, :C, :eval, :include))
+    allset = Set((:A, :B, :C, :eval, :include, Symbol("#_internal_julia_parse")))
     @test Set(names(TestMod54609.A)) == defaultset
     @test Set(names(TestMod54609.A, imported=true)) == defaultset ∪ imported
     @test Set(names(TestMod54609.A, usings=true)) == defaultset ∪ usings

--- a/test/testhelpers/return_syntax_version.jl
+++ b/test/testhelpers/return_syntax_version.jl
@@ -1,0 +1,1 @@
+(Base.Experimental.@VERSION).syntax


### PR DESCRIPTION
Syntax versioning (intentionally) uses a binding partitioned constant to set the syntax version. This gives well defined meaning to changing the parser of the course of a module's lifetime, but open's up the question which world age `include` uses to determine the syntax version. I think the correct answer is that `include` should look at the latest world age, since it also implicitly raises the world age for the statements it executes, so it would be somewhat inconsistent for the parse to happen in the caller's world age. Fixes #60624. Also addresses a somewhat hilarious interaction with backdating where the syntax version depended on the value of `--depwarn` (causing test failures in #60481).