### PR TITLE
Fix redundant precompilation info statement when __precompile__(false)

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2937,8 +2937,7 @@ function __require_prelocked(pkg::PkgId, env)
                 @goto load_from_cache # the new cachefile will have the newest mtime so will come first in the search
             elseif isa(loaded, Exception)
                 if precompilableerror(loaded)
-                    local verbosity = isinteractive() ? CoreLogging.Info : CoreLogging.Debug
-                    @logmsg verbosity "Skipping precompilation due to precompilable error. Importing $(repr("text/plain", pkg))." exception=loaded
+                    # Intentionally not logging - __precompile__(false) is not an error
                 else
                     @warn "The call to compilecache failed to create a usable precompiled cache file for $(repr("text/plain", pkg))" exception=loaded
                 end


### PR DESCRIPTION
Fixes #60588

## Summary
Removed the redundant "Skipping precompilation due to precompilable error" message that appeared

## Changes
Commented out the logging statement  in base/loading.jl

## Testing
Built Julia from source using WSL and tested with `__precompile__(false)`:
**Before fix** 3 info messages shown
**After fix** 2 info messages shown(redundant third message removed)

Below is a screenshot showing 2 error messages:

<img width="1920" height="421" alt="removed redundant message" src="https://github.com/user-attachments/assets/8e8f3c21-f62a-4d5f-a204-44f65f2465e5" />

