### PR TITLE
ssair: fix phi edge cleanup for current block

### DIFF
--- a/Compiler/src/ssair/ir.jl
+++ b/Compiler/src/ssair/ir.jl
@@ -1382,7 +1382,6 @@ function kill_edge!(ir::IRCode, from::Int, to::Int, callback=nothing)
     kill_edge!(ir.cfg.blocks, from, to, callback)
 end
 
-# N.B.: from and to are non-renamed indices
 @inline function compacted_stmt_range(compact::IncrementalCompact, bb::BasicBlock, active_bb::Int, to::Int)
     to == active_bb && return StmtRange(first(bb.stmts), compact.result_idx - 1)
     return bb.stmts
@@ -1393,7 +1392,7 @@ end
 
 Kill a CFG edge while compacting a terminator in `active_bb`. Assumes all PhiNode
 block statements in `to` have already been processed, so the active BB may only
-scan the compacted prefix when `to == active_bb`.
+scan the compacted prefix when `to == active_bb`. `from` and `to` are non-renamed indices.
 """
 function kill_edge_terminator!(compact::IncrementalCompact, active_bb::Int, from::Int, to::Int)
     # Note: We recursively kill as many edges as are obviously dead.

--- a/Compiler/src/ssair/ir.jl
+++ b/Compiler/src/ssair/ir.jl
@@ -1421,7 +1421,7 @@ function kill_edge!(compact::IncrementalCompact, active_bb::Int, from::Int, to::
         # Remove this edge from all phi nodes in `to` block
         # NOTE: It is possible for `to` to contain only `nothing` statements,
         #       so we must be careful to stop at its last statement
-        if to < active_bb
+        if to <= active_bb
             stmts = result_bbs[bb_rename_succ[to]].stmts
             idx = first(stmts)
             while idx <= last(stmts)

--- a/Compiler/src/ssair/ir.jl
+++ b/Compiler/src/ssair/ir.jl
@@ -1383,7 +1383,19 @@ function kill_edge!(ir::IRCode, from::Int, to::Int, callback=nothing)
 end
 
 # N.B.: from and to are non-renamed indices
-function kill_edge!(compact::IncrementalCompact, active_bb::Int, from::Int, to::Int)
+@inline function compacted_stmt_range(compact::IncrementalCompact, bb::BasicBlock, active_bb::Int, to::Int)
+    to == active_bb && return StmtRange(first(bb.stmts), compact.result_idx - 1)
+    return bb.stmts
+end
+
+"""
+    kill_edge_terminator!(compact::IncrementalCompact, active_bb::Int, from::Int, to::Int)
+
+Kill a CFG edge while compacting a terminator in `active_bb`. Assumes all PhiNode
+block statements in `to` have already been processed, so the active BB may only
+scan the compacted prefix when `to == active_bb`.
+"""
+function kill_edge_terminator!(compact::IncrementalCompact, active_bb::Int, from::Int, to::Int)
     # Note: We recursively kill as many edges as are obviously dead.
     (; bb_rename_pred, bb_rename_succ, result_bbs, domtree) = compact.cfg_transform
     preds = result_bbs[bb_rename_succ[to]].preds
@@ -1399,7 +1411,7 @@ function kill_edge!(compact::IncrementalCompact, active_bb::Int, from::Int, to::
         for succ in copy(to_succs)
             new_succ = findfirst(x::Int->x==succ, bb_rename_pred)
             new_succ === nothing && continue
-            kill_edge!(compact, active_bb, to, new_succ)
+            kill_edge_terminator!(compact, active_bb, to, new_succ)
         end
         empty!(preds)
         empty!(to_succs)
@@ -1422,7 +1434,8 @@ function kill_edge!(compact::IncrementalCompact, active_bb::Int, from::Int, to::
         # NOTE: It is possible for `to` to contain only `nothing` statements,
         #       so we must be careful to stop at its last statement
         if to <= active_bb
-            stmts = result_bbs[bb_rename_succ[to]].stmts
+            bb = result_bbs[bb_rename_succ[to]]
+            stmts = compacted_stmt_range(compact, bb, active_bb, to)
             idx = first(stmts)
             while idx <= last(stmts)
                 stmt = compact.result[idx][:stmt]
@@ -1502,14 +1515,14 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
             if cond
                 ssa_rename[idx] = nothing
                 result[result_idx][:stmt] = nothing
-                kill_edge!(compact, active_bb, active_bb, stmt.dest)
+                kill_edge_terminator!(compact, active_bb, active_bb, stmt.dest)
                 # Don't increment result_idx => Drop this statement
             else
                 label = bb_rename_succ[stmt.dest]
                 @assert label > 0
                 ssa_rename[idx] = SSAValue(result_idx)
                 result[result_idx][:stmt] = GotoNode(label)
-                kill_edge!(compact, active_bb, active_bb, active_bb+1)
+                kill_edge_terminator!(compact, active_bb, active_bb, active_bb+1)
                 result_idx += 1
             end
         else

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -109,6 +109,21 @@ let cfg = CFG(BasicBlock[
     @test length(compact.cfg_transform.result_bbs) == 4 && 0 in compact.cfg_transform.result_bbs[3].preds
 end
 
+# Test that removing a self-edge during compaction only scans compacted phi statements.
+let code = Any[
+        # Block 1
+        Compiler.GotoNode(2),
+        # Block 2
+        Core.PhiNode(Int32[1, 3], Any[1, 2]),
+        Compiler.GotoIfNot(true, 2),
+        # Block 3
+        Compiler.ReturnNode(0),
+    ]
+    ir = make_ircode(code)
+    ir = Compiler.compact!(ir, true)
+    @test Compiler.verify_ir(ir) === nothing
+end
+
 # Issue #32579 - Optimizer bug involving type constraints
 function f32579(x::Int, b::Bool)
     if b

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -845,3 +845,19 @@ end
 let ir = Base.code_ircode(_worker_task57153, (), optimize_until="CC: COMPACT_2")[1].first
     @test findfirst(x->x==0, ir.cfg.blocks[1].preds) !== nothing
 end
+
+# Tests that CFG edge cleanup during compaction doesn't corrupt iteration codegen.
+Trips_60660 = let
+    Ts = (Float64, Float32)
+    [(Ta, Tb, Tc) for Ta in Ts for Tb in Ts for Tc in Ts]
+end
+@test Trips_60660 == [
+    (Float64, Float64, Float64),
+    (Float64, Float64, Float32),
+    (Float64, Float32, Float64),
+    (Float64, Float32, Float32),
+    (Float32, Float64, Float64),
+    (Float32, Float64, Float32),
+    (Float32, Float32, Float64),
+    (Float32, Float32, Float32),
+]


### PR DESCRIPTION
:robot:: When removing an edge during compaction, phi pruning treated only blocks with to < active_bb as already compacted. If the edge was removed into the current block, its phi nodes had already been rewritten with renamed predecessors, but the cleanup path still searched using the old predecessor ID in the pre-compact IR. This left a live block with a phi edge from a dead predecessor and broke IR verification. Treat `to == active_bb` as already compacted so phi edges are removed from the result stream with renamed predecessor IDs.

AI fix (take 2) of https://github.com/JuliaLang/julia/issues/60660. Putting up for consideration. 

The test only reproduces on 1.13 but figured I might as well add it in for potential backport.