### PR TITLE
[JuliaLowering] Fix linearize step when arguments have no value

### DIFF
--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -161,7 +161,11 @@ function compile_args(ctx, args)
     args_out = SyntaxList(ctx)
     for arg in args
         arg_val = compile(ctx, arg, true, false)
-        if (all_simple || is_const_read_arg(ctx, arg_val)) && is_valid_body_ir_argument(ctx, arg_val)
+        if isnothing(arg_val)
+            # arguments that don't return a value, e.g. `f(return)`
+            push!(args_out, nothing_(ctx, arg))
+        elseif (all_simple || is_const_read_arg(ctx, arg_val)) &&
+            is_valid_body_ir_argument(ctx, arg_val)
             push!(args_out, arg_val)
         else
             push!(args_out, emit_assign_tmp(ctx, arg_val))

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -164,8 +164,8 @@ function compile_args(ctx, args)
         if isnothing(arg_val)
             # arguments that don't return a value, e.g. `f(return)`
             push!(args_out, nothing_(ctx, arg))
-        elseif (all_simple || is_const_read_arg(ctx, arg_val)) &&
-            is_valid_body_ir_argument(ctx, arg_val)
+        elseif ((all_simple || is_const_read_arg(ctx, arg_val)) &&
+                is_valid_body_ir_argument(ctx, arg_val))
             push!(args_out, arg_val)
         else
             push!(args_out, emit_assign_tmp(ctx, arg_val))

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -222,6 +222,22 @@ end
 (f_return_in_value_pos(), x)
 """) === (42, 0)
 
+@test JuliaLowering.include_string(test_mod, """
+function f_return_in_call()
+    f_return_in_call(return 123)
+end
+
+f_return_in_call()
+""") === 123
+
+@test JuliaLowering.include_string(test_mod, raw"""
+function f_return_in_interpolation()
+    :(1 + $(return 123))
+end
+
+f_return_in_interpolation()
+""") === 123
+
 @testset "Default positional arguments" begin
     @test JuliaLowering.include_string(test_mod, """
     begin


### PR DESCRIPTION
Matches flisp. This currently causes a MethodError in lowering.