### PR TITLE
Markdown: improve support for Windows line ends

### DIFF
--- a/stdlib/Markdown/src/Common/inline.jl
+++ b/stdlib/Markdown/src/Common/inline.jl
@@ -184,7 +184,7 @@ mutable struct LineBreak <: MarkdownElement end
 
 @trigger '\\' ->
 function linebreak(stream::IO, md::MD)
-    if startswith(stream, "\\\n")
+    if startswith(stream, "\\\n") || startswith(stream, "\\\r\n") || startswith(stream, "\\\r")
         return LineBreak()
     end
 end

--- a/stdlib/Markdown/src/GitHub/GitHub.jl
+++ b/stdlib/Markdown/src/GitHub/GitHub.jl
@@ -8,6 +8,11 @@ function github_paragraph(stream::IO, md::MD)
     p = Paragraph()
     push!(md, p)
     for char in readeach(stream, Char)
+        # handle Windows line ends
+        if char == '\r'
+            peek(stream, Char) == '\n' && read(stream, Char)
+            char = '\n'
+        end
         if char == '\n'
             eof(stream) && break
             if blankline(stream) || _parse(stream, md, breaking = true)

--- a/stdlib/Markdown/src/parse/util.jl
+++ b/stdlib/Markdown/src/parse/util.jl
@@ -4,9 +4,12 @@ const whitespace = " \t\r"
 
 """
 Skip any leading whitespace. Returns io.
+If `newlines=true` then also skip line ends.
 """
 function skipwhitespace(io::IO; newlines = true)
-    while !eof(io) && (peek(io, Char) in whitespace || (newlines && peek(io) == UInt8('\n')))
+    while !eof(io)
+        c = peek(io, Char)
+        c in whitespace || (newlines && c == '\n') || break
         read(io, Char)
     end
     return io

--- a/stdlib/Markdown/test/regenerate_test_spec.jl
+++ b/stdlib/Markdown/test/regenerate_test_spec.jl
@@ -18,6 +18,18 @@ function check_commonmark_spec_html1(tst; report::Bool=false, flavor::Symbol=:ju
     parsed = Markdown.parse(input; flavor)
     expected = tst["html"]
     actual = Markdown.html(parsed)
+
+    # extra: check that replacing Unix line ends (a single "line feed" also known as LF, '\n' or U+000A)
+    # by classic macOS line ends (a single "carriage return", also known as CR, '\r' or U+000D) or
+    # by Windows line ends (CR+LF) does not change how we parse things
+    input2 = replace(input, "\n" => "\r\n")
+    parsed2 = Markdown.parse(input2; flavor)
+    parsed == parsed2 || println("test ", tst["example"], " is parsed differently with CRLF line ends")
+
+    input3 = replace(input, "\n" => "\r")
+    parsed3 = Markdown.parse(input2; flavor)
+    parsed == parsed3 || println("test ", tst["example"], " is parsed differently with CR line ends")
+
     if expected != actual && report
         printstyled("============================================\n"; color=:cyan)
         println("failed test ", tst["example"], ":")


### PR DESCRIPTION
Fixes #29344 

Tested by modifying the CommonMark spec tests, replacing all LF in the input once by CRLF (Windows line ends), and once by CR (classic macOS line ends), and making sure it still parses the modified inputs exactly as the non-modified inputs. (The CommonMark spec prescribes that all three line ends should be accepted)

Of course this may still have missed cases where it doesn't work right; if anyone observes that, a bug report with details on how to reproduce it is highly welcome.