### PR TITLE
[JuliaLowering] Quote generated function body before desugaring

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -1646,7 +1646,7 @@ function expand_named_tuple(ctx, ex, kws, eq_is_kw;
             end
             name = to_symbol(ctx, kw[2])
             value = kw
-        elseif k == K"call" && is_infix_op_call(kw) && numchildren(kw) == 3 &&
+        elseif k == K"call" && numchildren(kw) == 3 &&
                 is_same_identifier_like(kw[1], "=>")
             # a=>b   ==>  $a=b
             appended_nt = _named_tuple_expr(ctx, kw, (kw[2],), (kw[3],))
@@ -2461,44 +2461,15 @@ function trim_used_typevars(ctx, arg_types, typevar_names, typevar_stmts)
     return trimmed_typevar_names
 end
 
-function is_if_generated(ex)
-    kind(ex) == K"if" && kind(ex[1]) == K"generated"
-end
-
-# Return true if a function body contains a code generator from `@generated` in
-# the form `[K"if" [K"generated"] ...]`
-function is_generated(ex)
-    if is_if_generated(ex)
-        return true
-    elseif is_quoted(ex) || kind(ex) == K"function"
-        return false
-    else
-        return any(is_generated, children(ex))
-    end
-end
-
-function split_generated(ctx, ex, gen_part)
-    if is_leaf(ex)
-        ex
-    elseif is_if_generated(ex)
-        gen_part ? @ast(ctx, ex, [K"$" ex[2]]) : ex[3]
-    else
-        mapchildren(e->split_generated(ctx, e, gen_part), ctx, ex)
-    end
-end
-
 # Split @generated function body into two parts:
 # * The code generator
 # * The non-generated function body
-function expand_function_generator(ctx, srcref, callex_srcref, func_name, func_name_str, body, arg_names, typevar_names)
-    gen_body = if is_if_generated(body)
-        body[2] # Simple case - don't need interpolation when the whole body is generated
-    else
-        expand_quote(ctx, @ast ctx body [K"block" split_generated(ctx, body, true)])
-    end
+function expand_function_generator(ctx, srcref, callex_srcref, func_name,
+                                   func_name_str, gen_body, nongen_body_orig,
+                                   arg_names, typevar_names)
     gen_name_str = reserve_module_binding_i(ctx.mod,
                         "#$(isnothing(func_name_str) ? "_" : func_name_str)@generator#")
-    gen_name = new_global_binding(ctx, body, gen_name_str, ctx.mod)
+    gen_name = new_global_binding(ctx, srcref, gen_name_str, ctx.mod)
 
     # Set up the arguments for the code generator
     gen_arg_names = SyntaxList(ctx)
@@ -2548,7 +2519,7 @@ function expand_function_generator(ctx, srcref, callex_srcref, func_name, func_n
     end
 
     # Extract non-generated body
-    nongen_body = @ast ctx body [K"block"
+    nongen_body = @ast ctx nongen_body_orig [K"block"
         # The Julia runtime associates the code generator with the
         # non-generated method by adding this meta to the body. This feels like
         # a hack though since the generator ultimately gets attached to the
@@ -2584,7 +2555,7 @@ function expand_function_generator(ctx, srcref, callex_srcref, func_name, func_n
                 ]
             ]
         ]
-        split_generated(ctx, body, false)
+        nongen_body_orig
     ]
 
     return gen_func_method_defs, nongen_body
@@ -2945,7 +2916,11 @@ function is_invalid_func_name(ex)
 end
 
 function expand_function_def(ctx, ex, docs, rewrite_call=identity, rewrite_body=identity; doc_only=false)
-    @chk numchildren(ex) in (1,2)
+    if kind(ex) === K"generated_function"
+        @assert numchildren(ex) === 3 && rewrite_body == identity
+    else
+        @chk numchildren(ex) in (1,2)
+    end
     name = ex[1]
     if numchildren(ex) == 1 && is_identifier_like(name)
         # Function declaration with no methods
@@ -3167,10 +3142,9 @@ function expand_function_def(ctx, ex, docs, rewrite_call=identity, rewrite_body=
     end
 
     gen_func_method_defs = nothing
-    if is_generated(body)
-        gen_func_method_defs, body =
-            expand_function_generator(ctx, ex, callex, name, name_str, body, arg_names, typevar_names)
-
+    if kind(ex) === K"generated_function"
+        gen_func_method_defs, body = expand_function_generator(
+            ctx, ex, callex, name, name_str, ex[2], ex[3], arg_names, typevar_names)
     end
 
     if isnothing(keywords)
@@ -4511,7 +4485,7 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
         expand_forms_2(ctx, expand_generator(ctx, ex))
     elseif k == K"->" || k == K"do"
         expand_forms_2(ctx, expand_arrow(ctx, ex))
-    elseif k == K"function"
+    elseif k == K"function" || k == K"generated_function"
         expand_forms_2(ctx, expand_function_def(ctx, ex, docs))
     elseif k == K"macro"
         @ast ctx ex [K"block"

--- a/JuliaLowering/src/kinds.jl
+++ b/JuliaLowering/src/kinds.jl
@@ -10,6 +10,8 @@ function _register_kinds()
             "atomic"
             # Flag for @generated parts of a function
             "generated"
+            # Like (function call body) but (generated_function call gen nongen)
+            "generated_function"
             # Temporary rooting of identifiers (GC.@preserve)
             "gc_preserve"
             "gc_preserve_begin"

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -580,9 +580,12 @@ has_if_generated(st::SyntaxTree) = JuliaSyntax.@stm st begin
     _ -> any(has_if_generated, children(st))
 end
 split_generated(st::SyntaxTree, gen_part) = JuliaSyntax.@stm st begin
-    (_, when=is_leaf(st)) -> st
-    [K"if" [K"generated"] gen nongen] -> gen_part ?
-        @ast(st._graph, st, [K"$" gen]) : nongen
+    (_, when=is_leaf(st)||is_quoted(st)) -> st
+    [K"if" [K"generated"] gen nongen] -> if gen_part
+        @ast(st._graph, st, [K"$" gen])
+    else
+        nongen
+    end
     _ -> mapchildren(x->split_generated(x, gen_part), st._graph, st)
 end
 

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -543,16 +543,24 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
                 k = K"dotcall"
                 farg = farg[1]
             end
-            # Preserve call type flags (mostly ignored in the next pass as
-            # we've already reordered arguments.)
-            callflags = JuliaSyntax.call_type_flags(ex)
-            @ast ctx ex [k(syntax_flags=(callflags == 0 ? nothing : callflags))
+            @ast ctx ex [k
                 expand_forms_1(ctx, farg)
                 (expand_forms_1(ctx, a) for a in args)...
             ]
         end
     elseif is_leaf(ex)
         ex
+    elseif k === K"function" && numchildren(ex) === 2
+        # The (if (generated) gen nongen) form is troublesome because everything
+        # surrounding it is implicitly quoted (with `gen` interpolated into it),
+        # so doing anything to the body AST before quoting is incorrect.
+        e1 = expand_forms_1(ctx,ex[1])
+        e2 = expand_forms_1(ctx,ex[2])
+        has_if_generated(e2) || return @ast ctx ex [K"function" e1 e2]
+        gen = expand_forms_1(ctx, expand_quote(
+            ctx, @ast ctx e2 [K"block" split_generated(e2, true)]))
+        nongen = split_generated(e2, false)
+        @ast ctx ex [K"generated_function" e1 gen nongen]
     elseif k == K"<:" || k == K">:" || k == K"-->"
         # TODO: Should every form get layerid systematically? Or only the ones
         # which expand_forms_2 needs?
@@ -562,6 +570,20 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
     else
         mapchildren(e->expand_forms_1(ctx,e), ctx, ex)
     end
+end
+
+has_if_generated(st::SyntaxTree) = JuliaSyntax.@stm st begin
+    (_, when=is_leaf(st)||is_quoted(st)) -> false
+    [K"function" _...] -> false
+    ([K"=" call _], when=is_eventually_call(call)) -> false
+    [K"if" [K"generated"] _ _] -> true
+    _ -> any(has_if_generated, children(st))
+end
+split_generated(st::SyntaxTree, gen_part) = JuliaSyntax.@stm st begin
+    (_, when=is_leaf(st)) -> st
+    [K"if" [K"generated"] gen nongen] -> gen_part ?
+        @ast(st._graph, st, [K"$" gen]) : nongen
+    _ -> mapchildren(x->split_generated(x, gen_part), st._graph, st)
 end
 
 function ensure_macro_attributes(graph)

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -716,6 +716,21 @@ end
                              "first"::K"Identifier"]
                    "nongen"::K"Identifier"]
 
+    genfunc_quote_s = raw"""
+    begin
+        @eval function f_gen_quote_1(::Tuple{T}) where {T}
+            out = $(Expr(:quote, Expr(:call, :+, 1, Expr(:if, Expr(:generated), 1, 2))))
+            if @generated
+            else
+            end
+            return out
+        end
+        f_gen_quote_1((1,))
+    end
+    """
+    @test JuliaLowering.include_string(
+        test_mod, genfunc_quote_s; expr_compat_mode=true) ==
+            :(1 + $(Expr(:if, Expr(:generated), 1, 2)))
 
     # Test generated function edges to bindings
     # (see also https://github.com/JuliaLang/julia/pull/57230)

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -577,8 +577,7 @@ end
     end
 end
 
-@testset "Generated functions" begin
-    for expr_compat_mode in (false, true)
+@testset "Generated functions" begin; for expr_compat_mode in (false, true)
     @test JuliaLowering.include_string(test_mod, raw"""
     begin
         @generated function f_gen(x::NTuple{N,T}) where {N,T}
@@ -633,7 +632,90 @@ end
         f_gen_calls_macros(1)
     end
     """; expr_compat_mode) === "foo"
+end
+
+    genfunc_quote_s = """
+    begin
+        function f_gen_quote_1(::Tuple{T}) where {T}
+            out = :(:x1,first)
+            if @generated
+            else
+            end
+            return out
+        end
+
+        f_gen_quote_1((1,))
     end
+    """
+    @test JuliaLowering.include_string(
+        test_mod, genfunc_quote_s; expr_compat_mode=true) == :(:x1,first)
+    @test JuliaLowering.include_string(
+        test_mod, genfunc_quote_s; expr_compat_mode=false) ≈
+            @ast_ [K"tuple" [K"quote" "x1"::K"Identifier"] "first"::K"Identifier"]
+
+    genfunc_quote_s = """
+    begin
+        function f_gen_quote_2(::Tuple{T}) where {T}
+            out = nothing
+            if @generated
+                :(out = :(:x2,generated))
+            else
+                out = (:x2,nongen)
+            end
+            return out
+        end
+
+        f_gen_quote_2((1,))
+    end
+    """
+    @test JuliaLowering.include_string(
+        test_mod, genfunc_quote_s; expr_compat_mode=true) == :(:x2,generated)
+    @test JuliaLowering.include_string(
+        test_mod, genfunc_quote_s; expr_compat_mode=false) ≈
+            @ast_ [K"tuple" [K"quote" "x2"::K"Identifier"] "generated"::K"Identifier"]
+
+    genfunc_quote_s = """
+    begin
+        function f_gen_quote_3(::Tuple{T}) where {T}
+            if @generated
+            else
+            end
+            return :(:x4,after)
+        end
+
+        f_gen_quote_3((1,))
+    end
+    """
+    @test JuliaLowering.include_string(
+        test_mod, genfunc_quote_s; expr_compat_mode=true) == :(:x4,after)
+    @test JuliaLowering.include_string(
+        test_mod, genfunc_quote_s; expr_compat_mode=false) ≈
+            @ast_ [K"tuple" [K"quote" "x4"::K"Identifier"] "after"::K"Identifier"]
+
+    genfunc_quote_s = raw"""
+    begin
+        function f_gen_interpolate(::Tuple{T}) where {T}
+            out = :(:x1,first)
+            if @generated
+                out = :($out, generated)
+            else
+                out = :($out, nongen)
+            end
+            return out
+        end
+
+        f_gen_interpolate((1,))
+    end
+    """
+    @test JuliaLowering.include_string(
+        test_mod, genfunc_quote_s; expr_compat_mode=true) == :((:x1,first),nongen)
+    @test JuliaLowering.include_string(
+        test_mod, genfunc_quote_s; expr_compat_mode=false) ≈
+            @ast_ [K"tuple" [K"tuple"
+                             [K"quote" "x1"::K"Identifier"]
+                             "first"::K"Identifier"]
+                   "nongen"::K"Identifier"]
+
 
     # Test generated function edges to bindings
     # (see also https://github.com/JuliaLang/julia/pull/57230)

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -1629,7 +1629,9 @@ end
     slots: [slot₁/#self#(!read) slot₂/__context__(!read) slot₃/#self#(!read) slot₄/x(nospecialize) slot₅/y(nospecialize)]
     1   TestMod.generator_code
     2   (call %₁ slot₄/x slot₅/y)
-    3   (return %₂)
+    3   (call core.tuple %₂)
+    4   (call JuliaLowering.interpolate_ast SyntaxTree (inert_syntaxtree (block ($ (block (call generator_code x y))))) %₃)
+    5   (return %₄)
 12  latestworld
 13  TestMod.f_only_generated
 14  (call core.Typeof %₁₃)


### PR DESCRIPTION
This change moves the separation of the generated and non-generated function body ahead of desugaring using a new `(generated_function callex gen_body nongen_body)` form.  Previously, desugaring would search for an `(if (generated) gen_ex nongen_ex)` form in the function body, then create a method with body `(stuff_surrounding_if_expression... $gen_ex)`.  However, our pre-desugaring (and soon AST conversion) alter `stuff_surrounding_if_expression` in a way we can't correctly convert back to Expr.  This PR handles quoting of the generated body at the same time everything else is quoted.

Atop https://github.com/JuliaLang/julia/pull/60704 (our previous "shortcut" avoiding `interpolate_ast` papered over a bug where `return` expressions couldn't be interpolated.  We probably want that shortcut in `interpolate_ast` anyway). Also atop https://github.com/JuliaLang/julia/pull/60706 (unexpected, but we probably weren't reading the `meta` attribute somewhere)

