### PR TITLE
Markdown: improve soft line break handling

### DIFF
--- a/stdlib/Markdown/src/render/html.jl
+++ b/stdlib/Markdown/src/render/html.jl
@@ -177,7 +177,14 @@ function htmlinline(io::IO, code′::Code)
 end
 
 function htmlinline(io::IO, md::Union{Symbol,AbstractString})
-    htmlesc(io, md)
+    htmlinline(io, String(md))
+end
+
+function htmlinline(io::IO, s::String)
+    # Spaces at the end of the line and beginning of the next line are removed
+    s = replace(s, r"[ \t]+\n" => "\n")
+    s = replace(s, r"\n[ \t]+" => "\n")
+    htmlesc(io, s)
 end
 
 function htmlinline(io::IO, md::Bold)

--- a/stdlib/Markdown/test/test_spec_html_common.jl
+++ b/stdlib/Markdown/test/test_spec_html_common.jl
@@ -380,7 +380,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>Foo\n***</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 50
     input = "_____________________________________\n"
@@ -534,7 +534,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>foo\n# bar</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 71
     input = "## foo ##\n  ###   bar    ###\n"
@@ -660,7 +660,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>Foo\n---</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 88
     input = "Foo\n= =\n\nFoo\n--- -\n"
@@ -849,7 +849,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>Foo\nbar</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 114
     input = "    foo\nbar\n"
@@ -1640,14 +1640,14 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>aaa\nbbb</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 223
     input = "aaa\n             bbb\n                                       ccc\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>aaa\nbbb\nccc</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 224
     input = "   aaa\nbbb\n"
@@ -4006,7 +4006,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>[\n]</p>\n<p>[\n]: /uri</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 553
     input = "[foo][]\n\n[foo]: /url \"title\"\n"
@@ -4720,7 +4720,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>foo\nbaz</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
 end
 

--- a/stdlib/Markdown/test/test_spec_html_github.jl
+++ b/stdlib/Markdown/test/test_spec_html_github.jl
@@ -380,7 +380,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>Foo\n***</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 50
     input = "_____________________________________\n"
@@ -534,7 +534,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>foo\n# bar</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 71
     input = "## foo ##\n  ###   bar    ###\n"
@@ -849,7 +849,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>Foo\nbar</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 114
     input = "    foo\nbar\n"
@@ -1640,14 +1640,14 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>aaa\nbbb</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 223
     input = "aaa\n             bbb\n                                       ccc\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>aaa\nbbb\nccc</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 224
     input = "   aaa\nbbb\n"
@@ -4006,7 +4006,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>[\n]</p>\n<p>[\n]: /uri</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 553
     input = "[foo][]\n\n[foo]: /url \"title\"\n"
@@ -4720,7 +4720,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>foo\nbaz</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
 end
 

--- a/stdlib/Markdown/test/test_spec_html_julia.jl
+++ b/stdlib/Markdown/test/test_spec_html_julia.jl
@@ -380,7 +380,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>Foo\n***</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 50
     input = "_____________________________________\n"
@@ -534,7 +534,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>foo\n# bar</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 71
     input = "## foo ##\n  ###   bar    ###\n"
@@ -849,7 +849,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>Foo\nbar</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 114
     input = "    foo\nbar\n"
@@ -1640,14 +1640,14 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>aaa\nbbb</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 223
     input = "aaa\n             bbb\n                                       ccc\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>aaa\nbbb\nccc</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 224
     input = "   aaa\nbbb\n"
@@ -4006,7 +4006,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>[\n]</p>\n<p>[\n]: /uri</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 553
     input = "[foo][]\n\n[foo]: /url \"title\"\n"
@@ -4720,7 +4720,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>foo\nbaz</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
 end
 


### PR DESCRIPTION
Spaces before or after a soft line break are removed.
