### PR TITLE
Markdown: fix whitespace handling in emphasis runs

### DIFF
--- a/stdlib/Markdown/src/parse/util.jl
+++ b/stdlib/Markdown/src/parse/util.jl
@@ -181,12 +181,12 @@ function parse_inline_wrapper(stream::IO, delimiter::AbstractString; rep = false
         startswith(stream, delimiter^n) || return nothing
         while startswith(stream, delimiter); n += 1; end
         !rep && n > nmin && return nothing
-        !eof(stream) && peek(stream, Char) in whitespace && return nothing
+        !eof(stream) && isspace(peek(stream, Char)) && return nothing
 
         buffer = IOBuffer()
         for char in readeach(stream, Char)
             write(buffer, char)
-            if !(char in whitespace || char == '\n' || char in delimiter) && startswith(stream, delimiter^n)
+            if !(isspace(char) || char in delimiter) && startswith(stream, delimiter^n)
                 trailing = 0
                 while startswith(stream, delimiter); trailing += 1; end
                 trailing == 0 && return takestring!(buffer)

--- a/stdlib/Markdown/test/regenerate_test_spec.jl
+++ b/stdlib/Markdown/test/regenerate_test_spec.jl
@@ -90,7 +90,7 @@ function escape_spec_string(s::String)
     # avoid string interpolation
     s = replace(s, "\$" => raw"\$")
     # encode non-breaking whitespace to make contrib/check-whitespace.jl happy
-    s = replace(s, "\uA0" => raw"\uA0")
+    s = replace(s, "\uA0" => raw"\u00A0")
     return s
 end
 

--- a/stdlib/Markdown/test/test_spec_html_common.jl
+++ b/stdlib/Markdown/test/test_spec_html_common.jl
@@ -114,7 +114,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a heading\n[foo]: /url &quot;not a reference&quot;\n&amp;ouml; not a character entity</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 15
     input = "\\\\*emphasis*\n"
@@ -2606,7 +2606,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>*\u00A0a\u00A0*</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 354
     input = "*\$*alpha.\n\n*£*bravo.\n\n*€*charlie.\n"
@@ -2823,7 +2823,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>__\nfoo bar__</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 385
     input = "a__\"foo\"__\n"

--- a/stdlib/Markdown/test/test_spec_html_common.jl
+++ b/stdlib/Markdown/test/test_spec_html_common.jl
@@ -196,7 +196,7 @@ end
     # Example 25
     input = "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n"
     md = Markdown.parse(input; flavor=:common)
-    expected = "<p>\uA0 &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n"
+    expected = "<p>\u00A0 &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n"
     actual = Markdown.html(md)
     @test expected == actual
 
@@ -2455,16 +2455,16 @@ end
     @test_broken expected == actual
 
     # Example 333
-    input = "`\uA0b\uA0`\n"
+    input = "`\u00A0b\u00A0`\n"
     md = Markdown.parse(input; flavor=:common)
-    expected = "<p><code>\uA0b\uA0</code></p>\n"
+    expected = "<p><code>\u00A0b\u00A0</code></p>\n"
     actual = Markdown.html(md)
     @test_broken expected == actual
 
     # Example 334
-    input = "`\uA0`\n`  `\n"
+    input = "`\u00A0`\n`  `\n"
     md = Markdown.parse(input; flavor=:common)
-    expected = "<p><code>\uA0</code>\n<code>  </code></p>\n"
+    expected = "<p><code>\u00A0</code>\n<code>  </code></p>\n"
     actual = Markdown.html(md)
     @test_broken expected == actual
 
@@ -2602,9 +2602,9 @@ end
     @test_broken expected == actual
 
     # Example 353
-    input = "*\uA0a\uA0*\n"
+    input = "*\u00A0a\u00A0*\n"
     md = Markdown.parse(input; flavor=:common)
-    expected = "<p>*\uA0a\uA0*</p>\n"
+    expected = "<p>*\u00A0a\u00A0*</p>\n"
     actual = Markdown.html(md)
     @test_broken expected == actual
 
@@ -3687,7 +3687,7 @@ end
     @test_broken expected == actual
 
     # Example 507
-    input = "[link](/url\uA0\"title\")\n"
+    input = "[link](/url\u00A0\"title\")\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p><a href=\"/url%C2%A0%22title%22\">link</a></p>\n"
     actual = Markdown.html(md)

--- a/stdlib/Markdown/test/test_spec_html_github.jl
+++ b/stdlib/Markdown/test/test_spec_html_github.jl
@@ -196,7 +196,7 @@ end
     # Example 25
     input = "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n"
     md = Markdown.parse(input; flavor=:github)
-    expected = "<p>\uA0 &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n"
+    expected = "<p>\u00A0 &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n"
     actual = Markdown.html(md)
     @test expected == actual
 
@@ -2455,16 +2455,16 @@ end
     @test_broken expected == actual
 
     # Example 333
-    input = "`\uA0b\uA0`\n"
+    input = "`\u00A0b\u00A0`\n"
     md = Markdown.parse(input; flavor=:github)
-    expected = "<p><code>\uA0b\uA0</code></p>\n"
+    expected = "<p><code>\u00A0b\u00A0</code></p>\n"
     actual = Markdown.html(md)
     @test_broken expected == actual
 
     # Example 334
-    input = "`\uA0`\n`  `\n"
+    input = "`\u00A0`\n`  `\n"
     md = Markdown.parse(input; flavor=:github)
-    expected = "<p><code>\uA0</code>\n<code>  </code></p>\n"
+    expected = "<p><code>\u00A0</code>\n<code>  </code></p>\n"
     actual = Markdown.html(md)
     @test_broken expected == actual
 
@@ -2602,9 +2602,9 @@ end
     @test_broken expected == actual
 
     # Example 353
-    input = "*\uA0a\uA0*\n"
+    input = "*\u00A0a\u00A0*\n"
     md = Markdown.parse(input; flavor=:github)
-    expected = "<p>*\uA0a\uA0*</p>\n"
+    expected = "<p>*\u00A0a\u00A0*</p>\n"
     actual = Markdown.html(md)
     @test_broken expected == actual
 
@@ -3687,7 +3687,7 @@ end
     @test_broken expected == actual
 
     # Example 507
-    input = "[link](/url\uA0\"title\")\n"
+    input = "[link](/url\u00A0\"title\")\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p><a href=\"/url%C2%A0%22title%22\">link</a></p>\n"
     actual = Markdown.html(md)

--- a/stdlib/Markdown/test/test_spec_html_github.jl
+++ b/stdlib/Markdown/test/test_spec_html_github.jl
@@ -114,7 +114,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a heading\n[foo]: /url &quot;not a reference&quot;\n&amp;ouml; not a character entity</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 15
     input = "\\\\*emphasis*\n"
@@ -2606,7 +2606,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>*\u00A0a\u00A0*</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 354
     input = "*\$*alpha.\n\n*£*bravo.\n\n*€*charlie.\n"
@@ -2823,7 +2823,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>__\nfoo bar__</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 385
     input = "a__\"foo\"__\n"

--- a/stdlib/Markdown/test/test_spec_html_julia.jl
+++ b/stdlib/Markdown/test/test_spec_html_julia.jl
@@ -114,7 +114,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a heading\n[foo]: /url &quot;not a reference&quot;\n&amp;ouml; not a character entity</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 15
     input = "\\\\*emphasis*\n"
@@ -2606,7 +2606,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>*\u00A0a\u00A0*</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 354
     input = "*\$*alpha.\n\n*£*bravo.\n\n*€*charlie.\n"
@@ -2823,7 +2823,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>__\nfoo bar__</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 385
     input = "a__\"foo\"__\n"

--- a/stdlib/Markdown/test/test_spec_html_julia.jl
+++ b/stdlib/Markdown/test/test_spec_html_julia.jl
@@ -196,7 +196,7 @@ end
     # Example 25
     input = "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n"
     md = Markdown.parse(input; flavor=:julia)
-    expected = "<p>\uA0 &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n"
+    expected = "<p>\u00A0 &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n"
     actual = Markdown.html(md)
     @test expected == actual
 
@@ -2455,16 +2455,16 @@ end
     @test_broken expected == actual
 
     # Example 333
-    input = "`\uA0b\uA0`\n"
+    input = "`\u00A0b\u00A0`\n"
     md = Markdown.parse(input; flavor=:julia)
-    expected = "<p><code>\uA0b\uA0</code></p>\n"
+    expected = "<p><code>\u00A0b\u00A0</code></p>\n"
     actual = Markdown.html(md)
     @test_broken expected == actual
 
     # Example 334
-    input = "`\uA0`\n`  `\n"
+    input = "`\u00A0`\n`  `\n"
     md = Markdown.parse(input; flavor=:julia)
-    expected = "<p><code>\uA0</code>\n<code>  </code></p>\n"
+    expected = "<p><code>\u00A0</code>\n<code>  </code></p>\n"
     actual = Markdown.html(md)
     @test_broken expected == actual
 
@@ -2602,9 +2602,9 @@ end
     @test_broken expected == actual
 
     # Example 353
-    input = "*\uA0a\uA0*\n"
+    input = "*\u00A0a\u00A0*\n"
     md = Markdown.parse(input; flavor=:julia)
-    expected = "<p>*\uA0a\uA0*</p>\n"
+    expected = "<p>*\u00A0a\u00A0*</p>\n"
     actual = Markdown.html(md)
     @test_broken expected == actual
 
@@ -3687,7 +3687,7 @@ end
     @test_broken expected == actual
 
     # Example 507
-    input = "[link](/url\uA0\"title\")\n"
+    input = "[link](/url\u00A0\"title\")\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p><a href=\"/url%C2%A0%22title%22\">link</a></p>\n"
     actual = Markdown.html(md)

--- a/stdlib/Markdown/test/test_spec_roundtrip_common.jl
+++ b/stdlib/Markdown/test/test_spec_roundtrip_common.jl
@@ -2455,14 +2455,14 @@ end
     @test expected == actual
 
     # Example 333
-    input = "`\uA0b\uA0`\n"
+    input = "`\u00A0b\u00A0`\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
     @test expected == actual
 
     # Example 334
-    input = "`\uA0`\n`  `\n"
+    input = "`\u00A0`\n`  `\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
@@ -2602,7 +2602,7 @@ end
     @test expected == actual
 
     # Example 353
-    input = "*\uA0a\uA0*\n"
+    input = "*\u00A0a\u00A0*\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)
@@ -3687,7 +3687,7 @@ end
     @test expected == actual
 
     # Example 507
-    input = "[link](/url\uA0\"title\")\n"
+    input = "[link](/url\u00A0\"title\")\n"
     expected = Markdown.parse(input; flavor=:common)
     new_input = Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:common)

--- a/stdlib/Markdown/test/test_spec_roundtrip_github.jl
+++ b/stdlib/Markdown/test/test_spec_roundtrip_github.jl
@@ -2455,14 +2455,14 @@ end
     @test expected == actual
 
     # Example 333
-    input = "`\uA0b\uA0`\n"
+    input = "`\u00A0b\u00A0`\n"
     expected = Markdown.parse(input; flavor=:github)
     new_input = Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:github)
     @test expected == actual
 
     # Example 334
-    input = "`\uA0`\n`  `\n"
+    input = "`\u00A0`\n`  `\n"
     expected = Markdown.parse(input; flavor=:github)
     new_input = Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:github)
@@ -2602,7 +2602,7 @@ end
     @test expected == actual
 
     # Example 353
-    input = "*\uA0a\uA0*\n"
+    input = "*\u00A0a\u00A0*\n"
     expected = Markdown.parse(input; flavor=:github)
     new_input = Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:github)
@@ -3687,7 +3687,7 @@ end
     @test expected == actual
 
     # Example 507
-    input = "[link](/url\uA0\"title\")\n"
+    input = "[link](/url\u00A0\"title\")\n"
     expected = Markdown.parse(input; flavor=:github)
     new_input = Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:github)

--- a/stdlib/Markdown/test/test_spec_roundtrip_julia.jl
+++ b/stdlib/Markdown/test/test_spec_roundtrip_julia.jl
@@ -2455,14 +2455,14 @@ end
     @test expected == actual
 
     # Example 333
-    input = "`\uA0b\uA0`\n"
+    input = "`\u00A0b\u00A0`\n"
     expected = Markdown.parse(input; flavor=:julia)
     new_input = Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:julia)
     @test expected == actual
 
     # Example 334
-    input = "`\uA0`\n`  `\n"
+    input = "`\u00A0`\n`  `\n"
     expected = Markdown.parse(input; flavor=:julia)
     new_input = Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:julia)
@@ -2602,7 +2602,7 @@ end
     @test expected == actual
 
     # Example 353
-    input = "*\uA0a\uA0*\n"
+    input = "*\u00A0a\u00A0*\n"
     expected = Markdown.parse(input; flavor=:julia)
     new_input = Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:julia)
@@ -3687,7 +3687,7 @@ end
     @test expected == actual
 
     # Example 507
-    input = "[link](/url\uA0\"title\")\n"
+    input = "[link](/url\u00A0\"title\")\n"
     expected = Markdown.parse(input; flavor=:julia)
     new_input = Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:julia)


### PR DESCRIPTION
- **Markdown: fix nbsp handling in regenerate_test_spec**
- **Markdown: fix whitespace handling in emphasis runs**
