### PR TITLE
CI: Add backport label audit and cleanup workflows

### DIFF
--- a/.github/workflows/backport-label-audit.yml
+++ b/.github/workflows/backport-label-audit.yml
@@ -1,0 +1,62 @@
+name: Backport Label Audit
+# Run this workflow manually to audit backport labels on pull requests
+# and remove labels from PRs that have already been backported.
+# Optionally specify a release version to limit the audit to that version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to audit (e.g., 1.13). Leave empty to audit all versions.'
+        required: false
+        type: string
+      dry_run:
+        description: 'Dry run (only report, do not modify)'
+        required: true
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+        default: 'true'
+
+jobs:
+  audit-backport-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout Backporter
+        uses: actions/checkout@v4
+        with:
+          repository: KristofferC/Backporter
+          ref: master
+          path: backporter
+
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+
+      - name: Cache Julia packages
+        uses: julia-actions/cache@v2
+        with:
+          cache-name: backporter
+
+      - name: Install dependencies
+        run: |
+          cd backporter
+          julia --project -e 'using Pkg; Pkg.instantiate()'
+
+      - name: Run backport label audit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd backporter
+          ARGS="--audit -r ${{ github.repository }}"
+          if [ -n "${{ inputs.version }}" ]; then
+            ARGS="$ARGS -v ${{ inputs.version }}"
+          fi
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          julia --project backporter.jl $ARGS

--- a/.github/workflows/backport-label-cleanup.yml
+++ b/.github/workflows/backport-label-cleanup.yml
@@ -1,0 +1,64 @@
+name: Backport Label Cleanup
+# Runs automatically when a pull request to a release branch is merged
+# to remove backport labels from the merged PRs
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - 'release-*'
+
+jobs:
+  remove-backport-labels:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Extract version from branch
+        id: extract
+        run: |
+          BRANCH="${{ github.event.pull_request.base.ref }}"
+          if [[ "$BRANCH" =~ ^release-([0-9]+\.[0-9]+)$ ]]; then
+            echo "version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "Branch $BRANCH does not match release-X.Y pattern"
+            exit 0
+          fi
+
+      - name: Checkout Backporter
+        if: steps.extract.outputs.version != ''
+        uses: actions/checkout@v4
+        with:
+          repository: KristofferC/Backporter
+          ref: master
+          path: backporter
+
+      - name: Setup Julia
+        if: steps.extract.outputs.version != ''
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+
+      - name: Cache Julia packages
+        if: steps.extract.outputs.version != ''
+        uses: julia-actions/cache@v2
+        with:
+          cache-name: backporter
+
+      - name: Install dependencies
+        if: steps.extract.outputs.version != ''
+        run: |
+          cd backporter
+          julia --project -e 'using Pkg; Pkg.instantiate()'
+
+      - name: Run backport label cleanup
+        if: steps.extract.outputs.version != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd backporter
+          julia --project backporter.jl --audit \
+            -v ${{ steps.extract.outputs.version }} \
+            -r ${{ github.repository }} \
+            --cleanup-pr ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Add two workflows to help manage backport labels on pull requests:

- backport-label-audit.yml: A manually triggered workflow that audits backport labels and removes them from PRs that have already been backported. Supports filtering by release version and has a dry-run mode for previewing changes.

- backport-label-cleanup.yml: Runs automatically when a PR targeting a release branch is merged. Extracts the version from the branch name and removes the corresponding backport label from the original PR.

Both workflows use https://github.com/KristofferC/Backporter to perform the label management, and are already deployed on Pkg.jl.
Example manually triggered audit run: https://github.com/JuliaLang/Pkg.jl/actions/runs/21013827675/job/60414659867