### PR TITLE
CI: Add `backport-label-audit`, which calls out to reusable workflow

### DIFF
--- a/.github/workflows/backport-label-audit.yml
+++ b/.github/workflows/backport-label-audit.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   audit:
+    # TODO: Change from `main` to specific commit
     uses: JuliaLang/backporter-github-actions-workflows/.github/workflows/backport-label-audit.yml@main
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/backport-label-audit.yml
+++ b/.github/workflows/backport-label-audit.yml
@@ -22,3 +22,6 @@ on:
 jobs:
   audit:
     uses: JuliaLang/backporter-github-actions-workflows/.github/workflows/backport-label-audit.yml@main
+    with:
+      version: ${{ inputs.version }}
+      dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/backport-label-audit.yml
+++ b/.github/workflows/backport-label-audit.yml
@@ -21,8 +21,7 @@ on:
 
 jobs:
   audit:
-    # TODO: Change from `main` to specific commit
-    uses: JuliaLang/backporter-github-actions-workflows/.github/workflows/backport-label-audit.yml@main
+    uses: JuliaLang/backporter-github-actions-workflows/.github/workflows/backport-label-audit.yml@fe307c87dc20e213a6c5f42cf96b2f363f62de02 # main
     with:
       version: ${{ inputs.version }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/backport-label-audit.yml
+++ b/.github/workflows/backport-label-audit.yml
@@ -1,0 +1,24 @@
+name: Backport Label Audit
+# Run this workflow manually to audit backport labels on pull requests
+# and remove labels from PRs that have already been backported.
+# Optionally specify a release version to limit the audit to that version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to audit (e.g., 1.13). Leave empty to audit all versions.'
+        required: false
+        type: string
+      dry_run:
+        description: 'Dry run (only report, do not modify)'
+        required: true
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+        default: 'true'
+
+jobs:
+  audit:
+    uses: JuliaLang/backporter-github-actions-workflows/.github/workflows/backport-label-audit.yml@main


### PR DESCRIPTION
The reusable workflows will live here: https://github.com/JuliaLang/backporter-github-actions-workflows

This PR only adds `backport-label-audit`, because `backport-label-cleanup` hasn't been tested out on Pkg.jl yet.

Alternative to #60717