### PR TITLE
Move precompilation during package loading behind `@invokelatest`

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2838,8 +2838,6 @@ function set_pkgorigin_version_path(pkg::PkgId, path::String)
     nothing
 end
 
-# Unused
-const PKG_PRECOMPILE_HOOK = Ref{Function}()
 disable_parallel_precompile::Bool = false
 
 # Returns `nothing` or the new(ish) module
@@ -2902,7 +2900,10 @@ function __require_prelocked(pkg::PkgId, env)
                     try
                         if !generating_output() && !parallel_precompile_attempted[] && !disable_parallel_precompile && @isdefined(Precompilation)
                             parallel_precompile_attempted[] = true
-                            precompiled = Precompilation.precompilepkgs([pkg]; _from_loading=true, ignore_loaded=false)
+                            # Note that we use @invokelatest here to avoid world
+                            # age issues when printing, see:
+                            # https://github.com/JuliaLang/julia/issues/60223
+                            precompiled = @invokelatest Precompilation.precompilepkgs([pkg]; _from_loading=true, ignore_loaded=false)
                             # prcompiled returns either nothing, indicating it needs serial precompile,
                             # or the entry(ies) that it found would be best to load (possibly because it just created it)
                             # or an empty set of entries (indicating the precompile should be skipped)


### PR DESCRIPTION
This should fix errors from IJulia and the VS Code extension that redirect stdio to a custom IO type. Packages are loaded in a fixed world-age to prevent invalidations but precompilation will print messages, so if stdout/stderr are set to types defined in a newer world than `Base._require_world_age` (almost guaranteed if from an external package) then `pipe_writer(custom_io)` will end up being called, which will error because it's running in a world before the methods for `custom_io` were defined.

This essentially restores https://github.com/JuliaLang/julia/pull/51397, which was removed in https://github.com/JuliaLang/julia/pull/53403.

Fixes https://github.com/JuliaLang/julia/issues/60223.