### PR TITLE
CI: Fix permissions for the `backport-label-audit` workflow

### DIFF
--- a/.github/workflows/backport-label-audit.yml
+++ b/.github/workflows/backport-label-audit.yml
@@ -22,6 +22,8 @@ on:
 jobs:
   audit:
     uses: JuliaLang/backporter-github-actions-workflows/.github/workflows/backport-label-audit.yml@fe307c87dc20e213a6c5f42cf96b2f363f62de02 # main
+    permissions:
+      pull-requests: write # necessary to be able to remove labels from PRs
     with:
       version: ${{ inputs.version }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/backport-label-audit.yml
+++ b/.github/workflows/backport-label-audit.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   audit:
-    uses: JuliaLang/backporter-github-actions-workflows/.github/workflows/audit.yml@fe307c87dc20e213a6c5f42cf96b2f363f62de02 # main
+    uses: JuliaLang/backporter-github-actions-workflows/.github/workflows/audit.yml@f0cf777a492c5ff31196822a7d643a17ee0efbd1 # main
     permissions:
       pull-requests: write # necessary to be able to remove labels from PRs
     with:

--- a/.github/workflows/backport-label-audit.yml
+++ b/.github/workflows/backport-label-audit.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   audit:
-    uses: JuliaLang/backporter-github-actions-workflows/.github/workflows/backport-label-audit.yml@fe307c87dc20e213a6c5f42cf96b2f363f62de02 # main
+    uses: JuliaLang/backporter-github-actions-workflows/.github/workflows/audit.yml@fe307c87dc20e213a6c5f42cf96b2f363f62de02 # main
     permissions:
       pull-requests: write # necessary to be able to remove labels from PRs
     with:


### PR DESCRIPTION
See also: https://github.com/JuliaLang/backporter-github-actions-workflows/pull/2