### PR TITLE
Markdown: add support for "Raw" or "Inline" HTML

### DIFF
--- a/stdlib/Markdown/src/Common/Common.jl
+++ b/stdlib/Markdown/src/Common/Common.jl
@@ -9,8 +9,9 @@ include("inline.jl")
 @flavor common [fencedcode, horizontalrule, list, indentcode, blockquote, admonition, footnote, hashheader,
                 html_block, html_block_type7, setextheader, paragraph,
 
+                # Backslash escapes do not work in code blocks, code spans, autolinks, or raw HTML
+                inline_code, autolink, html_inline,
                 linebreak, escapes, entity,
-                inline_code,
                 asterisk_bold, underscore_bold,
                 asterisk_italic, underscore_italic,
-                image, footnote_link, link, autolink]
+                image, footnote_link, link]

--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -416,7 +416,7 @@ const SPACES = "(?:[ \t]*(?:[ \t\n])[ \t]*)"
 
 # An unquoted attribute value is a nonempty string of characters not including
 # spaces, tabs, line endings, ", ', =, <, >, or `.
-const UNQUOTED_ATTRIBUTE_VALUE = "[^ \t\n\"'=<>`]"
+const UNQUOTED_ATTRIBUTE_VALUE = "[^ \t\n\"'=<>`]+"
 
 # A single-quoted attribute value consists of ', zero or more characters not
 # including ', and a final '.
@@ -429,6 +429,7 @@ const DOUBLE_QUOTED_ATTRIBUTE_VALUE = "\"[^\"]*\""
 # An attribute value consists of an unquoted attribute value, a single-quoted
 # attribute value, or a double-quoted attribute value.
 const ATTRIBUTE_VALUE = "(?:(?:$UNQUOTED_ATTRIBUTE_VALUE)|(?:$SINGLE_QUOTED_ATTRIBUTE_VALUE)|(?:$DOUBLE_QUOTED_ATTRIBUTE_VALUE))"
+const ATTRIBUTE_VALUE_REGEX = Regex("^$ATTRIBUTE_VALUE")
 
 # An attribute value specification consists of optional spaces, tabs, and up
 # to one line ending, a = character, optional spaces, tabs, and up to one line
@@ -439,6 +440,7 @@ const ATTRIBUTE_VALUE_SPEC = "$SPACES?=$SPACES?$ATTRIBUTE_VALUE"
 # more ASCII letters, digits, _, ., :, or -. (Note: This is the XML
 # specification restricted to ASCII. HTML5 is laxer.)
 const ATTRIBUTE_NAME = "[a-zA-Z_:][a-zA-Z0-9_.:-]*"
+const ATTRIBUTE_NAME_REGEX = Regex("^$ATTRIBUTE_NAME")
 
 # An attribute consists of spaces, tabs, and up to one line ending, an
 # attribute name, and an optional attribute value specification.
@@ -447,6 +449,7 @@ const ATTRIBUTE = "$SPACES$ATTRIBUTE_NAME(?:$ATTRIBUTE_VALUE_SPEC)?"
 # A tag name consists of an ASCII letter followed by zero or more ASCII
 # letters, digits, or hyphens (-).
 const TAG_NAME = "[a-zA-Z][a-zA-Z0-9-]*"
+const TAG_NAME_REGEX = Regex("^$TAG_NAME")
 
 # An open tag consists of a < character, a tag name, zero or more attributes,
 # optional spaces, tabs, and up to one line ending, an optional / character,

--- a/stdlib/Markdown/src/GitHub/GitHub.jl
+++ b/stdlib/Markdown/src/GitHub/GitHub.jl
@@ -31,9 +31,11 @@ end
 @flavor github [fencedcode, horizontalrule, list, indentcode, blockquote, admonition, footnote, hashheader,
                 html_block, html_block_type7, github_table, github_paragraph,
 
+                # Backslash escapes do not work in code blocks, code spans, autolinks, or raw HTML
+                inline_code, autolink, html_inline,
                 linebreak, escapes, entity,
-                en_or_em_dash, inline_code,
+                en_or_em_dash,
                 double_tilde_strikethrough, tilde_strikethrough,
                 asterisk_bold, underscore_bold,
                 asterisk_italic, underscore_italic,
-                image, footnote_link, link, autolink]
+                image, footnote_link, link]

--- a/stdlib/Markdown/src/Julia/Julia.jl
+++ b/stdlib/Markdown/src/Julia/Julia.jl
@@ -11,10 +11,12 @@ include("interp.jl")
                fencedcode, horizontalrule, list, indentcode, blockquote, admonition, footnote, hashheader,
                html_block, html_block_type7, github_table, setextheader, paragraph,
 
+               # Backslash escapes do not work in code blocks, code spans, autolinks, or raw HTML
+               inline_code, autolink, html_inline,
                linebreak, escapes, entity,
                tex, interp,
-               en_or_em_dash, inline_code,
+               en_or_em_dash,
                double_tilde_strikethrough, tilde_strikethrough,
                asterisk_bold, underscore_bold,
                asterisk_italic, underscore_italic,
-               image, footnote_link, link, autolink]
+               image, footnote_link, link]

--- a/stdlib/Markdown/src/render/html.jl
+++ b/stdlib/Markdown/src/render/html.jl
@@ -227,6 +227,8 @@ function htmlinline(io::IO, br::LineBreak)
     println(io)
 end
 
+htmlinline(io::IO, md::HTMLInline) = print(io, md.content)
+
 htmlinline(io::IO, x) = tohtml(io, x)
 
 # API

--- a/stdlib/Markdown/src/render/plain.jl
+++ b/stdlib/Markdown/src/render/plain.jl
@@ -160,6 +160,8 @@ end
 
 plaininline(io::IO, br::LineBreak) = println(io, "\\")
 
+plaininline(io::IO, md::HTMLInline) = print(io, md.content)
+
 plaininline(io::IO, x) = show(io, MIME"text/plain"(), x)
 
 # show

--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -264,6 +264,8 @@ function terminline(io::IO, tex::LaTeX)
     print(io, styled"{markdown_latex:$(tex.formula)}")
 end
 
+terminline(io::IO, md::HTMLInline) = print(io, md.content)
+
 function terminline(io::IO, md::MarkdownElement)
     a = IOContext(AnnotatedIOBuffer(), io)
     terminline(a, md)

--- a/stdlib/Markdown/test/test_spec_html_common.jl
+++ b/stdlib/Markdown/test/test_spec_html_common.jl
@@ -1248,7 +1248,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p><del><em>foo</em></del></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 169
     input = "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print \$ parseTags tags\n</code></pre>\nokay\n"
@@ -1381,7 +1381,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>Foo\n<a href=\"bar\">\nbaz</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 188
     input = "<div>\n\n*Emphasized* text.\n\n</div>\n"
@@ -1486,7 +1486,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>[foo]: <bar>(baz)</p>\n<p>[foo]</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 202
     input = "[foo]: /url\\bar\\*baz \"foo\\\"bar\\baz\"\n\n[foo]\n"
@@ -2536,7 +2536,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p><a href=\"`\">`</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 345
     input = "`<https://foo.bar.`baz>`\n"
@@ -3579,7 +3579,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>[link](<foo\nbar>)</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 492
     input = "[a](<b)c>)\n"
@@ -4454,35 +4454,35 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p><a><bab><c2c></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 614
     input = "<a/><b2/>\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p><a/><b2/></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 615
     input = "<a  /><b2\ndata=\"foo\" >\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p><a  /><b2\ndata=\"foo\" ></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 616
     input = "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 617
     input = "Foo <responsive-image src=\"foo.jpg\" />\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>Foo <responsive-image src=\"foo.jpg\" /></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 618
     input = "<33> <__>\n"
@@ -4524,7 +4524,7 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p></a></foo ></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 624
     input = "</a href=\"foo\">\n"
@@ -4538,49 +4538,49 @@ end
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>foo <!-- this is a --\ncomment - with hyphens --></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 626
     input = "foo <!--> foo -->\n\nfoo <!---> foo -->\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>foo <!--> foo --&gt;</p>\n<p>foo <!---> foo --&gt;</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 627
     input = "foo <?php echo \$a; ?>\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>foo <?php echo \$a; ?></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 628
     input = "foo <!ELEMENT br EMPTY>\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>foo <!ELEMENT br EMPTY></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 629
     input = "foo <![CDATA[>&<]]>\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>foo <![CDATA[>&<]]></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 630
     input = "foo <a href=\"&ouml;\">\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>foo <a href=\"&ouml;\"></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 631
     input = "foo <a href=\"\\*\">\n"
     md = Markdown.parse(input; flavor=:common)
     expected = "<p>foo <a href=\"\\*\"></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 632
     input = "<a href=\"\\\"\">\n"

--- a/stdlib/Markdown/test/test_spec_html_github.jl
+++ b/stdlib/Markdown/test/test_spec_html_github.jl
@@ -1248,7 +1248,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p><del><em>foo</em></del></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 169
     input = "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print \$ parseTags tags\n</code></pre>\nokay\n"
@@ -1381,7 +1381,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>Foo\n<a href=\"bar\">\nbaz</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 188
     input = "<div>\n\n*Emphasized* text.\n\n</div>\n"
@@ -1486,7 +1486,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>[foo]: <bar>(baz)</p>\n<p>[foo]</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 202
     input = "[foo]: /url\\bar\\*baz \"foo\\\"bar\\baz\"\n\n[foo]\n"
@@ -2536,7 +2536,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p><a href=\"`\">`</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 345
     input = "`<https://foo.bar.`baz>`\n"
@@ -3579,7 +3579,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>[link](<foo\nbar>)</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 492
     input = "[a](<b)c>)\n"
@@ -4454,35 +4454,35 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p><a><bab><c2c></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 614
     input = "<a/><b2/>\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p><a/><b2/></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 615
     input = "<a  /><b2\ndata=\"foo\" >\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p><a  /><b2\ndata=\"foo\" ></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 616
     input = "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 617
     input = "Foo <responsive-image src=\"foo.jpg\" />\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>Foo <responsive-image src=\"foo.jpg\" /></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 618
     input = "<33> <__>\n"
@@ -4524,7 +4524,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p></a></foo ></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 624
     input = "</a href=\"foo\">\n"
@@ -4538,7 +4538,7 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>foo <!-- this is a --\ncomment - with hyphens --></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 626
     input = "foo <!--> foo -->\n\nfoo <!---> foo -->\n"
@@ -4552,35 +4552,35 @@ end
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>foo <?php echo \$a; ?></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 628
     input = "foo <!ELEMENT br EMPTY>\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>foo <!ELEMENT br EMPTY></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 629
     input = "foo <![CDATA[>&<]]>\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>foo <![CDATA[>&<]]></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 630
     input = "foo <a href=\"&ouml;\">\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>foo <a href=\"&ouml;\"></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 631
     input = "foo <a href=\"\\*\">\n"
     md = Markdown.parse(input; flavor=:github)
     expected = "<p>foo <a href=\"\\*\"></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 632
     input = "<a href=\"\\\"\">\n"

--- a/stdlib/Markdown/test/test_spec_html_julia.jl
+++ b/stdlib/Markdown/test/test_spec_html_julia.jl
@@ -1248,7 +1248,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p><del><em>foo</em></del></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 169
     input = "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print \$ parseTags tags\n</code></pre>\nokay\n"
@@ -1381,7 +1381,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>Foo\n<a href=\"bar\">\nbaz</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 188
     input = "<div>\n\n*Emphasized* text.\n\n</div>\n"
@@ -1486,7 +1486,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>[foo]: <bar>(baz)</p>\n<p>[foo]</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 202
     input = "[foo]: /url\\bar\\*baz \"foo\\\"bar\\baz\"\n\n[foo]\n"
@@ -2536,7 +2536,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p><a href=\"`\">`</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 345
     input = "`<https://foo.bar.`baz>`\n"
@@ -3579,7 +3579,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>[link](<foo\nbar>)</p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 492
     input = "[a](<b)c>)\n"
@@ -4454,35 +4454,35 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p><a><bab><c2c></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 614
     input = "<a/><b2/>\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p><a/><b2/></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 615
     input = "<a  /><b2\ndata=\"foo\" >\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p><a  /><b2\ndata=\"foo\" ></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 616
     input = "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 617
     input = "Foo <responsive-image src=\"foo.jpg\" />\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>Foo <responsive-image src=\"foo.jpg\" /></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 618
     input = "<33> <__>\n"
@@ -4524,7 +4524,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p></a></foo ></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 624
     input = "</a href=\"foo\">\n"
@@ -4538,7 +4538,7 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>foo <!-- this is a --\ncomment - with hyphens --></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 626
     input = "foo <!--> foo -->\n\nfoo <!---> foo -->\n"
@@ -4552,35 +4552,35 @@ end
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>foo <?php echo \$a; ?></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 628
     input = "foo <!ELEMENT br EMPTY>\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>foo <!ELEMENT br EMPTY></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 629
     input = "foo <![CDATA[>&<]]>\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>foo <![CDATA[>&<]]></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 630
     input = "foo <a href=\"&ouml;\">\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>foo <a href=\"&ouml;\"></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 631
     input = "foo <a href=\"\\*\">\n"
     md = Markdown.parse(input; flavor=:julia)
     expected = "<p>foo <a href=\"\\*\"></p>\n"
     actual = Markdown.html(md)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 632
     input = "<a href=\"\\\"\">\n"

--- a/stdlib/Markdown/test/test_spec_roundtrip_julia.jl
+++ b/stdlib/Markdown/test/test_spec_roundtrip_julia.jl
@@ -4552,7 +4552,7 @@ end
     expected = Markdown.parse(input; flavor=:julia)
     new_input = Markdown.plain(expected)
     actual = Markdown.parse(new_input; flavor=:julia)
-    @test_broken expected == actual
+    @test expected == actual
 
     # Example 628
     input = "foo <!ELEMENT br EMPTY>\n"


### PR DESCRIPTION
In `doc/src/manual/noteworthy-differences.md:440` there is a Markdown table containing HTML, namely `<br>`. It [renders as text](https://docs.julialang.org/en/v1.12/manual/noteworthy-differences/#Julia-C/C:-Quick-reference), not as a line break. E.g. we see
```
assembling<br>software modules
```
instead of
```
assembling
software modules
```
in one of the table cells

With this PR, we parse inline / raw HTML correctly, which is the basis for fixing the above.

However, to actually work, also Documenter and/or MarkdownAST will have to learn about the new `Markdown.HTMLInline` node type. (And I am guessing also about the other node types I recently added: `Markdown.HTMLBlock` and `Markdown.Strikethrough`). Otherwise, the example table cell from above renders as
```
assemblingMarkdown.HTMLInline("<br>")software modules
```
which I'd say is even worse than the current status quo.

Therefore I've marked this PR as draft: before merging this, I'd like to have patches for `Documenter` and `MarkdownAST` ready.

CC @mortenpi 