### PR TITLE
InteractiveUtils: access bindings in latest world

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -2114,7 +2114,9 @@ void append_module_names(jl_array_t* a, jl_module_t *m, int all, int imported, i
         if (jl_atomic_load_relaxed(&bpart->min_world) < defined_since)
             continue;
         enum jl_partition_kind kind = jl_binding_kind(bpart);
-        if ((((jl_atomic_load_relaxed(&b->flags) & BINDING_FLAG_PUBLICP) && !jl_bkind_is_some_guard(kind)) ||
+        if (jl_bkind_is_some_guard(kind) && !jl_bpart_is_exported(bpart->kind))
+            continue;
+        if (((jl_atomic_load_relaxed(&b->flags) & BINDING_FLAG_PUBLICP) ||
              jl_bpart_is_exported(bpart->kind) ||
              (imported && (kind == PARTITION_KIND_CONST_IMPORT || kind == PARTITION_KIND_IMPORTED)) ||
              (usings && kind == PARTITION_KIND_EXPLICIT) ||


### PR DESCRIPTION
InteractiveUtils provides a number of utilities for querying and accessing the contents of modules. Because these modules can gain new bindings, some callers of InteractiveUtils functions produce warnings

    WARNING: Detected access to binding ... prior to its definition world.

One dramatic example occurs with the sequence

    using OptimizationProblems: OptimizationProblems
    using OptimizationProblems.ADNLPProblems
    using ADNLPModels: ADNLPModel

when running with Revise, where it can produce hundreds of warnings. ADNLPProblems loads new problems via Requires, and starting with v3.13 Revise queries `InteractiveUtils.subtypes` to cache dependent fieldtypes. This triggers the warning, and because it runs in a separate task, the `--depwarn=error` trick unfortunately failed to produce a stacktrace. Thus this was quite difficult to track down.

Fixes https://github.com/timholy/Revise.jl/issues/993

CC @aviatesk, @Keno