### PR TITLE
[backports-release-1.12] Fix JET warnings in `show(::IOBuffer, ::StackFrame)`

### DIFF
--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -273,9 +273,10 @@ function show_spec_linfo(io::IO, frame::StackFrame)
         if linfo isa Union{MethodInstance, CodeInstance}
             def = frame_method_or_module(frame)
             if def isa Module
-                Base.show_mi(io, linfo, #=from_stackframe=#true)
+                Base.show_mi(io, linfo::MethodInstance, #=from_stackframe=#true)
             else
-                show_spec_sig(io, def, frame_mi(frame).specTypes)
+                mi = frame_mi(frame)::MethodInstance
+                show_spec_sig(io, def::Method, mi.specTypes)
             end
         else
             m = linfo::Method


### PR DESCRIPTION
This backports the part of https://github.com/JuliaLang/julia/pull/60645 that is applicable to 1.12. Furthermore, I added a type assertion two lines above the other changes that was taken from https://github.com/JuliaLang/julia/pull/58430. Without this, there are still JET warnings in 1.12 for the above query.

cc @DilumAluthge 