### PR TITLE
[1.11] Backport #60718+#60746: Fix and test `jl_method_lookup_by_tt`

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1503,7 +1503,7 @@ static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt JL_PROPAGATE
     if (!mi) {
         size_t min_valid = 0;
         size_t max_valid = ~(size_t)0;
-        matc = _gf_invoke_lookup((jl_value_t*)tt, jl_nothing, world, &min_valid, &max_valid);
+        matc = _gf_invoke_lookup((jl_value_t*)tt, (jl_value_t*)mt, world, &min_valid, &max_valid);
         if (matc) {
             jl_method_t *m = matc->method;
             jl_svec_t *env = matc->sparams;

--- a/test/compiler/contextual.jl
+++ b/test/compiler/contextual.jl
@@ -150,6 +150,32 @@ methods = Base._methods_by_ftype(Tuple{typeof(sin), Float64}, OverlayModule.mt, 
 methods = Base._methods_by_ftype(Tuple{typeof(sin), Int}, OverlayModule.mt, 1, Base.get_world_counter())
 @test isempty(methods)
 
+# fresh module to ensure uncached methods
+module OverlayMTTest
+    using Base.Experimental: @MethodTable, @overlay
+    @MethodTable(mt)
+
+    function overlay_only end
+    @overlay mt overlay_only(x::Int) = x * 2
+end
+
+# #60702 & #60716: Overlay methods must be found without prior cache population
+let world = Base.get_world_counter()
+    mi = Base.method_instance(OverlayMTTest.overlay_only, Tuple{Int};
+                              world, method_table=OverlayMTTest.mt)
+    @test mi isa Core.MethodInstance
+    @test mi.def.module === OverlayMTTest
+end
+
+# #60712: Global-only methods must NOT be found via custom MT
+let
+    @eval global_only_func(x::Int) = x + 1
+    world = Base.get_world_counter()
+    mi = Base.method_instance(global_only_func, Tuple{Int};
+                              world, method_table=OverlayMTTest.mt)
+    @test mi === nothing
+end
+
 # precompilation
 
 load_path = mktempdir()


### PR DESCRIPTION
I'm only backporting this because I know we're doing another 1.11 release anyway. This fixes bugs with GPUCompiler.jl that would otherwise require expensive workarounds for every GPU kernel launch.