### PR TITLE
`REPL.LineEdit`: add escape for literal `'^'` in key binding sequences

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -298,7 +298,7 @@ Julia's REPL keybindings may be fully customized to a user's preferences by pass
 to `REPL.setup_interface`. The keys of this dictionary may be characters or strings. The key
 `'*'` refers to the default action. Control plus character `x` bindings are indicated with `"^x"`.
 Meta plus `x` can be written `"\\M-x"` or `"\ex"`, and Control plus `x` can be written
-`"\\C-x"` or `"^x"`.
+`"\\C-x"` or `"^x"`. A literal `^` can be escaped as `"\\^"`.
 The values of the custom keymap must be `nothing` (indicating
 that the input should be ignored) or functions that accept the signature
 `(PromptState, AbstractREPL, Char)`.

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1804,6 +1804,8 @@ function normalize_key(key::Union{String,SubString{String}})
                 c, i = iterate(key, i)
                 write(buf, '\e')
                 write(buf, c)
+            elseif c == '^'
+                write(buf, c)
             end
         else
             write(buf, c)


### PR DESCRIPTION
Currently, the `'^'` in key binding sequences is used to indicate the Ctrl modifier (as in `"^A"`). This makes it hard to enter a literal `'^'`. (One way would be `"^$('^'+64)"`.) With this PR one can escape a literal `'^'` as in `"\\^"`.

I don't know how many users would like to remap the caret directly. However, it may appear in the key codes of certain editors. For example, [rxvt-unicode](https://pod.tst.eu/http://cvs.schmorp.de/rxvt-unicode/doc/rxvt.7.pod#Key_Codes) reports Ctrl-Home as `"\e[7^"`.

Side remark: REPL/src/LineEdit.jl contains dedicated rxvt codes for Ctrl-Left and Ctrl-Right already. Would you be interested in a more complete list?

