### PR TITLE
`REPL.LineEdit`: add several functions to `:movement` command group

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -275,7 +275,8 @@ end
 
 const COMMAND_GROUPS =
     Dict(:movement    => [:edit_move_left, :edit_move_right, :edit_move_word_left, :edit_move_word_right,
-                          :edit_move_up, :edit_move_down, :edit_exchange_point_and_mark],
+                          :edit_move_up, :edit_move_down, :edit_exchange_point_and_mark,
+                          :move_line_start, :move_line_end, :move_input_start, :move_input_end],
          :deletion    => [:edit_clear, :edit_backspace, :edit_delete, :edit_werase,
                           :edit_delete_prev_word,
                           :edit_delete_next_word,


### PR DESCRIPTION
The functions for moving the cursor to the beginning or end of the current line or of the whole input are currently not part of the `:movement` command group. This means that one cannot use them for extending the region. For example, given that Home moves to the the beginning of the input, a user might want to map Shift-Home to
```
(s::MIState,o...) -> (edit_shift_move(s, move_input_start); refresh_line(s))
```
for making the region start at the beginning of the input, analogously to

https://github.com/JuliaLang/julia/blob/4d04bb6b3b1b879f4dbb918d194c5c939a1e7f3c/stdlib/REPL/src/LineEdit.jl#L2607

for Shift-Left. (For Home already, `refresh_line` is called after `move_input_start`.) However, this key inding currently errors because the second argument to `edit_shift_move` must be a function belonging to the `:movement` group. With this PR this works.

Disclaimer: I tested mappings like the above one for all four new movement commands, and it seems to work. I'm not a REPL expert, so I may miss some subtlety here.