### PR TITLE
[JuliaLowering] Quick fix for bad `append_sourceref` performance

### DIFF
--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -155,16 +155,6 @@ end
 # @ast macro
 
 _node_id(graph::SyntaxGraph, ex::SyntaxTree) = (check_compatible_graph(graph, ex); ex._id)
-
-_node_ids(graph::SyntaxGraph) = ()
-_node_ids(graph::SyntaxGraph, ::Nothing, cs...) = _node_ids(graph, cs...)
-_node_ids(graph::SyntaxGraph, c, cs...) = (_node_id(graph, c), _node_ids(graph, cs...)...)
-_node_ids(graph::SyntaxGraph, cs::SyntaxList, cs1...) = (_node_ids(graph, cs...)..., _node_ids(graph, cs1...)...)
-function _node_ids(graph::SyntaxGraph, cs::SyntaxList)
-    check_compatible_graph(graph, cs)
-    cs.ids
-end
-
 function _node_id(graph::SyntaxGraph, ex)
     # Fallback to give a comprehensible error message for use with the @ast macro
     error("Attempt to use `$(repr(ex))` of type `$(typeof(ex))` as an AST node. Try annotating with `::K\"your_intended_kind\"?`")

--- a/JuliaLowering/src/runtime.jl
+++ b/JuliaLowering/src/runtime.jl
@@ -56,9 +56,10 @@ _is_leaf(@nospecialize(ex)) = true
 function _interpolated_value(ctx::InterpolationContext, srcref, ex)
     if ex isa SyntaxTree
         if !is_compatible_graph(ctx, ex)
-            ex = copy_ast(ctx, ex)
+            append_sourceref(ctx, ex, srcref)
+        else
+            append_sourceref!(ctx, ex, srcref)
         end
-        append_sourceref(ctx, ex, srcref)
     elseif ex isa Symbol
         # Plain symbols become identifiers. This is an accommodation for
         # compatibility to allow `:x` (a Symbol) and `:(x)` (a SyntaxTree) to

--- a/JuliaLowering/test/quoting.jl
+++ b/JuliaLowering/test/quoting.jl
@@ -27,9 +27,8 @@ end
 @test sprint(io->showprov(io, ex[1][3], tree=true)) == raw"""
     (call g z)
     ├─ (call g z)
-    │  └─ (call g z)
-    │     └─ (call g ✘ z ✘)
-    │        └─ @ string:3
+    │  └─ (call g ✘ z ✘)
+    │     └─ @ string:3
     └─ ($ y)
        └─ ($ $ y)
           └─ @ string:5


### PR DESCRIPTION
Should resolve the worst of https://github.com/JuliaLang/julia/issues/60756.  `append_sourceref` copied every node in an expansion (despite the nodes almost always being freshly copied) to set its `.source` to an unpacked, then re-packed tuple of provenance.  This PR just mutates the node's `.source` in most cases.

There's more I'd like to do here for performance later, as it's still not great in `expand_forms_1`:
- I'm still copying the node when `.source` is a LineNumberNode or SourceRef (i.e. not NodeId or Tuple) since random things start breaking with non-NodeIds in a tuple.
- I think we should separate the "primary" source and the appended ones entirely, since the primary one is almost always the one we want from `.source`.  Maybe we could add a `.macro_source` attribute for the node ID of the most recent expansion, which in turn points to node IDs of outer expansions.
- We should be converting expr<->syntaxtree lazily