### PR TITLE
Fix unary + for AbstractArrays to use broadcasting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,9 @@ Standard library changes
 * `codepoint(c)` now succeeds for overlong encodings.  `Base.ismalformed`, `Base.isoverlong`, and
   `Base.show_invalid` are now `public` and documented (but not exported) ([#55152]).
 
+* Unary `+` on `AbstractArray`s now uses broadcasting. Consequently, `+` on `Bool` arrays now
+  returns `Int` arrays (#60767).
+
 #### JuliaSyntaxHighlighting
 
 #### LinearAlgebra

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -288,7 +288,6 @@ reim(A::AbstractArray)
 
 -(A::AbstractArray) = broadcast_preserving_zero_d(-, A)
 
-#+(x::AbstractArray{<:Number}) = x
 +(x::AbstractArray) = broadcast_preserving_zero_d(+, x)
 *(x::AbstractArray{<:Number,2}) = x
 

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -288,7 +288,8 @@ reim(A::AbstractArray)
 
 -(A::AbstractArray) = broadcast_preserving_zero_d(-, A)
 
-+(x::AbstractArray{<:Number}) = x
+#+(x::AbstractArray{<:Number}) = x
++(x::AbstractArray) = broadcast_preserving_zero_d(+, x)
 *(x::AbstractArray{<:Number,2}) = x
 
 # index A[:,:,...,i,:,:,...] where "i" is in dimension "d"

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -963,6 +963,11 @@ end
         @test +(A) == A
         @test *(A) == A
     end
+    # Test for PR #60767: fix unary + for AbstractArrays
+    let A = [true, false, true]
+        @test +A == [1, 0, 1]
+        @test eltype(+A) === Int
+    end
 end
 
 @testset "reverse dim on empty" begin

--- a/test/test_fix.jl
+++ b/test/test_fix.jl
@@ -1,0 +1,28 @@
+# test_fix.jl
+
+# 1. Test the Boolean Array case (The original bug)
+v = [true, false]
+result = +v
+println("Original Bug Test:")
+println("Input: $v (Eltype: $(eltype(v)))")
+println("Output: $result (Eltype: $(eltype(result)))")
+
+if eltype(result) == Int
+    println("✅ SUCCESS: Bools turned into Ints!")
+else
+    println("❌ FAIL: Still Bools.")
+end
+
+println("-"^20)
+
+# 2. Test the Consistency case (Mutation check)
+v2 = [1, 2]
+result2 = +v2
+println("Consistency Test:")
+println("Is the result the EXACT same object? ", result2 === v2)
+
+if result2 !== v2
+    println("✅ SUCCESS: Result is a copy (not the same object).")
+else
+    println("❌ FAIL: Result is the same object (Identity).")
+end


### PR DESCRIPTION
Fixes #58295. I have implemented the fix to use broadcast_preserving_zero_d for unary plus on arrays. This ensures + on a Bool array returns an Int array.