### PR TITLE
docs: make `doc/src/devdocs/eval.md` and `init.md` less wrong

### DIFF
--- a/doc/src/devdocs/eval.md
+++ b/doc/src/devdocs/eval.md
@@ -26,11 +26,13 @@ function, and primitive function, before turning into the desired result (hopefu
 The 10,000 foot view of the whole process is as follows:
 
 1. The user starts `julia`.
-2. The C function `main()` from `cli/loader_exe.c` gets called. This function processes the command line
-   arguments, filling in the `jl_options` struct and setting the variable `ARGS`. It then initializes
-   Julia (by calling [`julia_init` in `init.c`](https://github.com/JuliaLang/julia/blob/master/src/init.c),
+2. The C function `main()` from [`cli/loader_exe.c`](https://github.com/JuliaLang/julia/blob/master/cli/loader_exe.c)
+   gets called. This loads Julia by calling `jl_load_repl()` in
+   [`cli/loader_lib.c`](https://github.com/JuliaLang/julia/blob/master/cli/loader_lib.c).
+   It ultimately ends up calling `jl_init_` in [`init.c`](https://github.com/JuliaLang/julia/blob/master/src/init.c),
    which may load a previously compiled [sysimg](@ref dev-sysimg)). Finally, it passes off control to Julia
    by calling [`Base._start()`](https://github.com/JuliaLang/julia/blob/master/base/client.jl).
+   For more details on this and the next step, see [Initialization of the Julia runtime](@ref).
 3. When `_start()` takes over control, the subsequent sequence of commands depends on the command
    line arguments given. For example, if a filename was supplied, it will proceed to execute that
    file. Otherwise, it will start an interactive REPL.


### PR DESCRIPTION
Partial progress towards resolving #60729 

It is only partial progress because more in that text is wrong, and needs to be addressed. E.g. the `repl_entrypoint()` section is outdated. In general I did not touch later parts, so this really only "helps" with the first part if `init.md`.

Maybe also some discussions which details to mention and which not (right now a lot of what happens is skipped, sometimes surely for good reasons, in others cases I am not so sure)...

See also #60760