### PR TITLE
REPL: add precompile to sysimage

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -86,6 +86,7 @@ precompile(Tuple{typeof(Base.promoteK), Type, Base.Dict{String, Any}})
 precompile(Tuple{typeof(Base.promoteV), Type, Base.Dict{String, Any}, Base.Dict{String, Any}})
 precompile(Tuple{typeof(Base.eval_user_input), Base.PipeEndpoint, Any, Bool})
 precompile(Tuple{typeof(Base.get), Base.PipeEndpoint, Symbol, Bool})
+precompile(Tuple{typeof(Base.HashArrayMappedTries.next), Base.HashArrayMappedTries.HashState{Base.ScopedValues.ScopedValue{Any}}})
 
 # used by Revise.jl
 precompile(Tuple{typeof(Base.parse_cache_header), String})


### PR DESCRIPTION
Fixes #60643

Not sure why it doesn't make it into the REPL pkgimage given it's explicitly called. One workaround is https://github.com/JuliaLang/julia/pull/60652

But this is easier to just merge.
