### PR TITLE
Fix xcrun SDK version lookup on macOS

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -80,7 +80,7 @@ else
 endif
 ifeq ($(OS), Darwin)
 	@printf "%s\n" "const MACOS_PRODUCT_VERSION = \"$(shell sw_vers -productVersion)\"" >> $@
-	@printf "%s\n" "const MACOS_PLATFORM_VERSION = \"$(shell xcrun --show-sdk-version)\"" >> $@
+	@printf "%s\n" "const MACOS_PLATFORM_VERSION = \"$(shell xcrun --sdk macosx --show-sdk-version)\"" >> $@
 endif
 	@printf "%s\n" "const BUILD_TRIPLET = \"$(BB_TRIPLET_LIBGFORTRAN_CXXABI)\"" >> $@
 


### PR DESCRIPTION
## Summary
- Use explicit `--sdk macosx` flag when querying the SDK version with `xcrun`
- Fixes build failures when the default SDK path is misconfigured (e.g., `xcode-select` pointing to Xcode but `xcrun` defaulting to Command Line Tools)

Without this fix, `xcrun --show-sdk-version` can fail with:
```
xcodebuild: error: SDK "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" cannot be located.
xcrun: error: unable to lookup item 'SDKVersion' in SDK '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
```

This causes `MACOS_PLATFORM_VERSION` to be empty, which later breaks the linker:
```
lld -flavor darwin ... -platform_version macos 26.1 '' ''
```

## Test plan
- [x] Verified `xcrun --sdk macosx --show-sdk-version` works when `xcrun --show-sdk-version` fails

🤖 Generated with [Claude Code](https://claude.ai/code)