### PR TITLE
Markdown: rename HTML to HTMLBlock

### DIFF
--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -405,11 +405,11 @@ end
 # HTML
 # ––––––––––
 
-mutable struct HTML <: MarkdownElement
-    content
+mutable struct HTMLBlock <: MarkdownElement
+    content::Vector{String}
 end
 
-HTML() = HTML([])
+HTMLBlock() = HTMLBlock(String[])
 
 # spaces, tabs, and up to one line ending
 const SPACES = "(?:[ \t]*(?:[ \t\n])[ \t]*)"
@@ -440,18 +440,21 @@ const ATTRIBUTE_VALUE_SPEC = "$SPACES?=$SPACES?$ATTRIBUTE_VALUE"
 # specification restricted to ASCII. HTML5 is laxer.)
 const ATTRIBUTE_NAME = "[a-zA-Z_:][a-zA-Z0-9_.:-]*"
 
-# An attribute consists of spaces, tabs, and up to one line ending, an attribute name, and an optional attribute value specification.
+# An attribute consists of spaces, tabs, and up to one line ending, an
+# attribute name, and an optional attribute value specification.
 const ATTRIBUTE = "$SPACES$ATTRIBUTE_NAME(?:$ATTRIBUTE_VALUE_SPEC)?"
 
-# A tag name consists of an ASCII letter followed by zero or more ASCII letters, digits, or hyphens (-).
+# A tag name consists of an ASCII letter followed by zero or more ASCII
+# letters, digits, or hyphens (-).
 const TAG_NAME = "[a-zA-Z][a-zA-Z0-9-]*"
 
-# An open tag consists of a < character, a tag name, zero or more attributes, optional spaces, tabs,
-# and up to one line ending, an optional / character, and a > character.
+# An open tag consists of a < character, a tag name, zero or more attributes,
+# optional spaces, tabs, and up to one line ending, an optional / character,
+# and a > character.
 const OPEN_TAG = "<($TAG_NAME)((?:$ATTRIBUTE)*)$SPACES?/?>"
 
-# A closing tag consists of the string </, a tag name, optional spaces, tabs, and up to one line
-# ending, and the character >.
+# A closing tag consists of the string </, a tag name, optional spaces, tabs,
+# and up to one line ending, and the character >.
 const CLOSING_TAG = "</$TAG_NAME$SPACES?>"
 
 # Regex for a the HTML block start condition of type 7
@@ -494,7 +497,7 @@ function html_block(stream::IO, block::MD)
             return false
         end
 
-        html = HTML()
+        html = HTMLBlock()
 
         # return to start, and read line by line
         seek(stream, pos)
@@ -524,7 +527,7 @@ function html_block_type7(stream::IO, block::MD)
         eatindent(stream) || return false
         startswith(stream, TYPE_7_REGEX) || return false
 
-        html = HTML()
+        html = HTMLBlock()
 
         # return to start, and read line by line
         seek(stream, pos)

--- a/stdlib/Markdown/src/render/html.jl
+++ b/stdlib/Markdown/src/render/html.jl
@@ -94,7 +94,7 @@ function html(io::IO, md::Paragraph)
     end
 end
 
-function html(io::IO, md::HTML)
+function html(io::IO, md::HTMLBlock)
     for line in md.content[1:end-1]
         println(io, line)
     end

--- a/stdlib/Markdown/src/render/plain.jl
+++ b/stdlib/Markdown/src/render/plain.jl
@@ -33,7 +33,7 @@ function plain(io::IO, p::Paragraph)
     println(io)
 end
 
-function plain(io::IO, md::HTML)
+function plain(io::IO, md::HTMLBlock)
     for line in md.content
         println(io, line)
     end

--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -26,7 +26,7 @@ function term(io::IO, md::Paragraph, columns)
     end
 end
 
-function term(io::IO, md::HTML, columns)
+function term(io::IO, md::HTMLBlock, columns)
     for line in md.content[1:end-1]
         println(io, line)
     end


### PR DESCRIPTION
Avoids clash with Base.HTML, and fits better with future Markdown.HTMLInline type. This is also the name used by MarkdownAST.

Extracted from PR #60732. Unlike that, this PR here can be merged immediately (assuming CI passes), and it will allow us to start working on MarkdownAST integration (without having to support both the old and new name simultaneously).