### PR TITLE
[1.12] Fix `codeinfo_for_const` missing `nargs` and `isva` fields

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1052,6 +1052,8 @@ function codeinfo_for_const(interp::AbstractInterpreter, mi::MethodInstance, @no
     tree.ssaflags = [IR_FLAG_NULL]
     tree.rettype = Core.Typeof(val)
     tree.edges = Core.svec()
+    tree.nargs = UInt(nargs)
+    tree.isva = method.isva
     set_inlineable!(tree, true)
     tree.parent = mi
     return tree

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -838,3 +838,15 @@ end
 let ir = Base.code_ircode(_worker_task57153, (), optimize_until="CC: COMPACT_2")[1].first
     @test findfirst(x->x==0, ir.cfg.blocks[1].preds) !== nothing
 end
+
+# codeinfo_for_const should set nargs and isva
+let
+    _const_return_func(@nospecialize(x)) = 42
+    mi = Compiler.specialize_method(only(methods(_const_return_func)), Tuple{typeof(_const_return_func), Int}, Core.svec())
+    ci = Compiler.codeinfo_for_const(Compiler.NativeInterpreter(), mi, 42)
+    @test ci.nargs == 2
+    @test ci.isva == false
+    # inflate_ir! should succeed now that nargs/isva are set
+    ir = Compiler.inflate_ir!(ci, mi)
+    @test ir isa Compiler.IRCode
+end


### PR DESCRIPTION
This PR back-ports a fix that was part of #59413 by @vtjnash to unbreak `Compiler.inflate_ir!` with const-return IR:

```julia
julia> _const_return_func(@nospecialize(x)) = 42
_const_return_func (generic function with 1 method)

julia> mi = Compiler.specialize_method(only(methods(_const_return_func)), Tuple{typeof(_const_return_func), Int}, Core.svec())

MethodInstance for _const_return_func(::Int64)

julia> worlds = Compiler.WorldRange(Base.get_world_counter(), Base.get_world_counter())
Compiler.WorldRange(0x000000000000987a, 0x000000000000987a)

julia> ci = Compiler.codeinfo_for_const(Compiler.NativeInterpreter(), mi, worlds, Core.svec(), 42)
CodeInfo(
1 ─     return 42
)

julia> ir = Compiler.inflate_ir!(ci, mi)
ERROR: AssertionError: invalid `given_argtypes` for `mi`
```

AFAIU this is because of `codeinfo_for_const` not setting `nargs` and `isva` fields on the returned `CodeInfo` object:

```julia
julia> ci.nargs = 2
2

julia> ir = Compiler.inflate_ir!(ci, mi)
 1 ─     return 42                                                                                                                                         │
```