### PR TITLE
[1.13] Fix `codeinfo_for_const` missing `nargs` and `isva` fields

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1186,6 +1186,8 @@ function codeinfo_for_const(::AbstractInterpreter, mi::MethodInstance, worlds::W
     tree.min_world = first(worlds)
     tree.max_world = last(worlds)
     tree.edges = edges
+    tree.nargs = UInt(nargs)
+    tree.isva = method.isva
     set_inlineable!(tree, true)
     tree.parent = mi
     return tree


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/pull/60787