### PR TITLE
[JuliaLowering] Don't recurse on `.source` when removing scope layer

### DIFF
--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -393,7 +393,7 @@ function remove_scope_layer!(ex)
 end
 
 function remove_scope_layer(ctx, ex)
-    remove_scope_layer!(copy_ast(ctx, ex))
+    remove_scope_layer!(copy_ast(ctx, ex; copy_source=false))
 end
 
 """


### PR DESCRIPTION
A simpler way to address #60756 than #60765.  `append_sourceref` should still be tweaked, but I realize the slowness is a result of multiple copies amplifying each other.