### PR TITLE
Use all the threads during AOT compilation

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -2059,7 +2059,7 @@ static unsigned compute_image_thread_count(const ModuleInfo &info) {
         return 1;
     }
 
-    unsigned threads = std::max(jl_effective_threads() / 2, 1);
+    unsigned threads = std::max(jl_effective_threads(), 1);
 
     auto max_threads = info.globals / 100;
     if (max_threads < threads) {


### PR DESCRIPTION
So this helps long tail cases where there is one big package
This saves around 3 seconds of something like Documenter (16->13 sec) 

We may want to implement a jobserver to avoid too much oversubscription when compiling code