### PR TITLE
Set max_methods for `lock` and `unlock` to 1

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -31,7 +31,9 @@ struct SystemError <: Exception
 end
 
 lock(::IO) = nothing
+typeof(lock).name.max_methods = UInt8(1)
 unlock(::IO) = nothing
+typeof(unlock).name.max_methods = UInt8(1)
 
 """
     reseteof(io)


### PR DESCRIPTION
This should prevent invalidations, particularly in IJulia:
```julia
 inserting lock(io::IJulia.IJuliaStdio) @ IJulia ~/git/IJulia.jl/src/stdio.jl:17 invalidated:
   backedges: 1: superseding lock(::IO) @ Base io.jl:33 with MethodInstance for lock(::IO) (150 children)

 inserting unlock(io::IJulia.IJuliaStdio) @ IJulia ~/git/IJulia.jl/src/stdio.jl:18 invalidated:
   backedges: 1: superseding unlock(::IO) @ Base io.jl:34 with MethodInstance for unlock(::IO) (2275 children)
```

See for example: https://github.com/JuliaLang/IJulia.jl/issues/1192#issuecomment-3390755056