### PR TITLE
bindings: Define behavior of `using` an ambiguous binding

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -106,7 +106,6 @@ static void update_implicit_resolution(struct implicit_search_resolution *to_upd
         return;
     }
     if (to_update->ultimate_kind == PARTITION_KIND_GUARD) {
-        assert(resolution.binding_or_const);
         to_update->ultimate_kind = resolution.ultimate_kind;
         to_update->binding_or_const = resolution.binding_or_const;
         to_update->debug_only_import_from = resolution.debug_only_import_from;
@@ -329,6 +328,10 @@ struct implicit_search_resolution jl_resolve_implicit_import(jl_binding_t *b, mo
                 imp_resolution.binding_or_const = tempbpart->restriction;
                 imp_resolution.debug_only_ultimate_binding = tempb;
                 imp_resolution.ultimate_kind = PARTITION_KIND_IMPLICIT_CONST;
+            } else if (kind == PARTITION_KIND_FAILED) {
+                imp_resolution.binding_or_const = NULL;
+                imp_resolution.debug_only_ultimate_binding = tempb;
+                imp_resolution.ultimate_kind = PARTITION_KIND_FAILED;
             }
         }
         // If this using has the reexport flag, mark that the binding should be reexported

--- a/test/core.jl
+++ b/test/core.jl
@@ -8672,3 +8672,17 @@ primitive type ByteString58434 (18 * 8) end
 
 @test Base.datatype_isbitsegal(Tuple{ByteString58434}) == false
 @test Base.datatype_haspadding(Tuple{ByteString58434}) == (length(Base.padding(Tuple{ByteString58434})) > 0)
+
+# #60659 - Behavior of using'd ambiguous bindings
+module AmbiguousUsing60659
+    using Test
+    module A
+        export X
+        module B; struct X; end; export X; end
+        module C; struct X; end; export X; end
+        using .B, .C
+    end
+    module D; struct X; end; export X; end
+    using .D, .A
+    @test_throws UndefVarError X
+end


### PR DESCRIPTION
We were missing handling for the case where the binding that we're using is ambiguous. There are two possible behaviors:

1. The ambiguous binding gets ignored for the purpose of resolution
2. The ambiguity poisons and the imported binding is also ambiguous

Current behavior between these two depends on resolution order (which is bad and part of what the assert was complaining about). This decides that case #2 is the correct behavior and fixes #60659.