### PR TITLE
[CI] Run jobs on `ubuntu-slim` instead of `ubuntu-latest`

### DIFF
--- a/.github/workflows/LabelCheck.yml
+++ b/.github/workflows/LabelCheck.yml
@@ -2,13 +2,15 @@ name: Labels
 
 permissions:
   contents: read
+
 on:
   pull_request:
     types: [labeled, unlabeled, opened, reopened, edited, synchronize]
+
 jobs:
   enforce-labels:
     name: Check for blocking labels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 2
     steps:
     - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2

--- a/.github/workflows/LabelCheck.yml
+++ b/.github/workflows/LabelCheck.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   enforce-labels:
     name: Check for blocking labels
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
     - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2

--- a/.github/workflows/PrAssignee.yml
+++ b/.github/workflows/PrAssignee.yml
@@ -1,4 +1,5 @@
 name: PR Assignee
+
 on:
   # Important security note: Do NOT use `actions/checkout`
   # or any other method for checking out the pull request's source code.
@@ -25,7 +26,7 @@ permissions:
 
 jobs:
   pr-assignee:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ github.event.pull_request.draft != true }}
     steps:
       # Important security note: As discussed above, do NOT use `actions/checkout`

--- a/.github/workflows/Typos.yml
+++ b/.github/workflows/Typos.yml
@@ -7,7 +7,7 @@ on: [pull_request]
 jobs:
   typos-check:
     name: Check for new typos
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
       - name: Checkout the JuliaLang/julia repository

--- a/.github/workflows/Whitespace.yml
+++ b/.github/workflows/Whitespace.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   whitespace:
     name: Check whitespace
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 2
     steps:
       - name: Checkout the JuliaLang/julia repository

--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -2,17 +2,14 @@ name: cffconvert
 
 on:
   push:
-    branches:
+    branches: &branches
       - 'master'
       - 'release-*'
-    paths:
+    paths: &paths
       - CITATION.cff
   pull_request:
-    branches:
-      - 'master'
-      - 'release-*'
-    paths:
-      - CITATION.cff
+    branches: *branches
+    paths: *paths
 
 permissions:
   contents: read
@@ -20,7 +17,7 @@ permissions:
 jobs:
   validate:
     name: "validate"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Check out a copy of the repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
`ubuntu-slim` is a [new runner type](https://github.blog/changelog/2026-01-22-1-vcpu-linux-runner-now-generally-available-in-github-actions/) for running short-lived (max 15 minutes) non-expensive tasks like linting, labelling, and such.