### PR TITLE
make the Base.rest method for Array also cover Memory

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -207,8 +207,7 @@ julia> first, Base.rest(a, state)
 function rest end
 rest(t::Tuple) = t
 rest(t::Tuple, i::Int) = ntuple(x -> getfield(t, x+i-1), length(t)-i+1)
-rest(a::Array, i::Int=1) = a[i:end]
-rest(a::Core.SimpleVector, i::Int=1) = a[i:end]
+rest(a::Union{Array,Memory,Core.SimpleVector}, i::Int=1) = a[i:end]
 rest(itr, state...) = Iterators.rest(itr, state...)
 
 """


### PR DESCRIPTION
Intended to improve the performance of destructuring a `Memory`.

If `Array` is special-cased, it seems fair to also special-case `Memory`, instead of treating it as a generic iterator.

Also merge the `Core.SimpleVector` method into this one.