### PR TITLE
Fix improper alignment of matrices with elided strings

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -3033,6 +3033,8 @@ end
 
 nocolor(io::IO) = IOContext(io, :color => false)
 alignment_from_show(io::IO, x::Any) =
+    textwidth(sprint(show, x, context=nocolor(io), sizehint=0))
+alignment_from_show(io::IO, x::AbstractString) =
     textwidth(sprint(show, MIME"text/plain"(), x, context=nocolor(io), sizehint=0))
 
 """

--- a/base/show.jl
+++ b/base/show.jl
@@ -3033,7 +3033,7 @@ end
 
 nocolor(io::IO) = IOContext(io, :color => false)
 alignment_from_show(io::IO, x::Any) =
-    textwidth(sprint(show, x, context=nocolor(io), sizehint=0))
+    textwidth(sprint(show, MIME"text/plain"(), x, context=nocolor(io), sizehint=0))
 
 """
 `alignment(io, X)` returns a tuple (left,right) showing how many characters are

--- a/test/show.jl
+++ b/test/show.jl
@@ -32,6 +32,13 @@ end
 @test replstr(Array{Any}(undef, 2,2,2)) == "2×2×2 Array{Any, 3}:\n[:, :, 1] =\n #undef  #undef\n #undef  #undef\n\n[:, :, 2] =\n #undef  #undef\n #undef  #undef"
 @test replstr([1f10]) == "1-element Vector{Float32}:\n 1.0f10"
 
+# alignment of elided strings
+lens = length.(eachline(IOBuffer(replstr([" "^100 10;10 10]))))
+@test lens[2] == lens[3]
+# alignment of multiline items in arrays
+lens = length.(eachline(IOBuffer(replstr([[Array{Pair,0}(undef)] 10;10 10]))))
+@test lens[2] == lens[3]
+
 struct T5589
     names::Vector{String}
 end


### PR DESCRIPTION
matrices use this alignment function to decide how wide rows are supposed to be, but the string elision requires the 3-argument show.

before:
```
julia> ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" 0 0 0 0;0 0 0 0 0]
2×5 Matrix{Any}:
  "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" ⋯ 23 bytes ⋯ "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  0  0  0  0
 0                                                                                         0  0  0  0

julia> ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" 0 0;0 0 0]
2×3 Matrix{Any}:
  "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" ⋯ 33 bytes ⋯ "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  …  0  0
 0                                                                                                      0  
0
```

after:
```
julia> ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" 0 0 0 0;0 0
 0 0 0]
2×5 Matrix{Any}:
  "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" ⋯ 23 bytes ⋯ "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  0  0  0  0
 0                                                                                  0  0  0  0

julia> ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" 0 0 0 0;0 0 0 0 0]
2×5 Matrix{Any}:
  "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" ⋯ 98 bytes ⋯ "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  0  0  0  0
 0                                                                                 0  0  0  0
```