### PR TITLE
fix elision for matrices with a wide first col

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -215,7 +215,7 @@ function _print_matrix(io, @nospecialize(X::AbstractVecOrMat), pre, sep, post, h
                 if i != last(rowsA); println(io); end
             end
         else # rows fit down screen but cols don't, so need horizontal ellipsis
-            c = div(screenwidth-length(hdots)::Int+1,2)+1  # what goes to right of ellipsis
+            c = min(div(screenwidth-length(hdots)::Int+1,2)+1, screenwidth-sum(A[1])-length(hdots))  # what goes to right of ellipsis
             Ralign = reverse(alignment(io, X, rowsA, reverse(colsA), c, c, sepsize, ncols)) # alignments for right
             c = screenwidth - sum(map(sum,Ralign)) - (length(Ralign)-1)*sepsize - length(hdots)::Int
             Lalign = alignment(io, X, rowsA, colsA, c, c, sepsize, ncols) # alignments for left of ellipsis
@@ -242,7 +242,7 @@ function _print_matrix(io, @nospecialize(X::AbstractVecOrMat), pre, sep, post, h
                 end
             end
         else # neither rows nor cols fit, so use all 3 kinds of dots
-            c = div(screenwidth-length(hdots)::Int+1,2)+1
+            c = min(div(screenwidth-length(hdots)::Int+1,2)+1, screenwidth-sum(A[1])-length(hdots))
             Ralign = reverse(alignment(io, X, rowsA, reverse(colsA), c, c, sepsize, ncols))
             c = screenwidth - sum(map(sum,Ralign)) - (length(Ralign)-1)*sepsize - length(hdots)::Int
             Lalign = alignment(io, X, rowsA, colsA, c, c, sepsize, ncols)

--- a/test/show.jl
+++ b/test/show.jl
@@ -936,6 +936,22 @@ Base.methodloc_callback[] = nothing
     @test replstr(permutedims([Dict(),Dict()])) == "1×2 Matrix{Dict{Any, Any}}:\n Dict()  Dict()"
     @test replstr(permutedims([undef,undef])) == "1×2 Matrix{UndefInitializer}:\n UndefInitializer()  UndefInitializer()"
     @test replstr([zeros(3,0),zeros(2,0)]) == "2-element Vector{Matrix{Float64}}:\n 3×0 Matrix{Float64}\n 2×0 Matrix{Float64}"
+
+    # long elements in column 1
+    a = Matrix(big(1)I, 10, 10)
+    a[1] = big(10)^70
+    @test replstr(a) == """
+10×10 Matrix{BigInt}:
+ 10000000000000000000000000000000000000000000000000000000000000000000000  …  0
+                                                                       0     0
+                                                                       0     0
+                                                                       0     0
+                                                                       0     0
+                                                                       0  …  0
+                                                                       0     0
+                                                                       0     0
+                                                                       0     0
+                                                                       0     1"""
 end
 
 # string show with elision


### PR DESCRIPTION
when the first column is wider than half the screen, it can't be elided, so you have to reduce the space that the right half of the matrix is allowed to be printed in.

before:
```
julia> [10000000000000000000000000000000000000000000000000000000000 0 0 0 0 0 0
;0 0 0 0 0 0 10]
2×7 Matrix{BigInt}:
 10000000000000000000000000000000000000000000000000000000000  …  0  0  0  0  0 
  0
                                                           0     0  0  0  0  0 
 10
```

after:
```
julia> [10000000000000000000000000000000000000000000000000000000000 0 0 0 0 0 0
;0 0 0 0 0 0 10]
2×7 Matrix{BigInt}:
 10000000000000000000000000000000000000000000000000000000000  …  0  0  0   0
                                                           0     0  0  0  10
```

useful test string:
```
julia> [0 0 0 0 0 0 0 0 0 10; 0 0 0 0 0 0 0 0 0 10; 0 0 0 0 0 0 0 0 0 10;10000000000000000000000000000000000000000000000000000000000 0 0 0 0 0 0 0 0 0; "testing the screen width" 0 0 0 0 0 0 0 0 10; 0 0 0 0 0 0 0 0 0 10; 0 0 0 0 0 0 0 0 0 10]
7×10 Matrix{Any}:
                                                           0                            …  0  0  0  0  10
                                                           0                               0  0  0  0  10
                                                           0                               0  0  0  0  10
 10000000000000000000000000000000000000000000000000000000000                               0  0  0  0   0
                                                            "testing the screen width"     0  0  0  0  10
                                                           0                            …  0  0  0  0  10
                                                           0                               0  0  0  0  10


```