### PR TITLE
Document `break`, `@label` and `continue` more thoroughly

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1171,9 +1171,6 @@ kw"finally"
 
 """
     break
-
-Break out of the current, innermost loop immediately.
-
     break name
     break name expr
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1171,27 +1171,37 @@ kw"finally"
 
 """
     break
+    break name
+    break name expr
 
-Break out of the innermost loop or [`@label`](@ref) block immediately.
+Break out of a loop or [`@label`](@ref) block immediately, evaluating and returning `expr`.
 
-`break` exits the innermost breakable scope, which may be a `for` or `while` loop, or
-an `@label` block.
+If `expr` is not passed, `break` evaluates to `nothing`.
+
+If `name` is passed, break out of the loop or block named with the corresponding
+`@label name`. Otherwise, break out of the current, innermost loop.
+
+See also: [`@label`](@ref), [`continue`](@ref)
 
 # Examples
 ```jldoctest
-julia> i = 0
+julia> i = j = 0
 0
 
-julia> while true
+julia> @label outer_loop while true
            global i += 1
-           i > 5 && break
-           println(i)
+           for _ in 1:1000
+               global j += 1
+               i > 2 && break outer_loop "Done!"
+               println(i, " ", j)
+               j > 2 && break
+           end
        end
-1
-2
-3
-4
-5
+1 1
+1 2
+1 3
+2 4
+"Done!"
 ```
 
 Labeled break can be used to exit early from a labeled block created with [`@label`](@ref).
@@ -1215,18 +1225,27 @@ kw"break"
 
 """
     continue
+    continue name
 
-Skip the rest of the current loop iteration.
+Skip the rest of the current loop iteration of the loop named `name` by `@label`.
+If `label` is not passed, skip the rest of the current iteration of the
+innermost loop.
+
+See also: [`break`](@ref), [`@label`](@ref)
 
 # Examples
 ```jldoctest
-julia> for i = 1:6
-           iseven(i) && continue
-           println(i)
+julia> @label outer for i in 1:3
+           for j in 1:3
+               j == 2 && continue
+               i == 2 && continue outer
+               println(i, " ", j)
+           end
        end
-1
-3
-5
+1 1
+1 3
+3 1
+3 3
 ```
 
 Labeled continue can be used to skip to the next iteration of a labeled loop created with [`@label`](@ref).

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1171,6 +1171,9 @@ kw"finally"
 
 """
     break
+
+Break out of the current, innermost loop immediately.
+
     break name
     break name expr
 
@@ -1183,24 +1186,42 @@ If `name` is passed, break out of the loop or block named with the corresponding
 
 See also: [`@label`](@ref), [`continue`](@ref)
 
+!!! compat "Julia 1.14"
+    Two-argument and three-argument `break` was added in Julia 1.14.
+
 # Examples
 ```jldoctest
-julia> i = j = 0
-0
+julia> i = 0;
 
-julia> @label outer_loop while true
+julia> while true
+           global i += 1
+           i > 3 && break
+           println(i)
+       end
+1
+2
+3
+
+julia> @label someblock begin
+           i > 2 && break someblock "Broke out"
+           "Did not break out"
+       end
+"Broke out"
+
+julia> i = j = 0;
+
+julia> result = @label outer_loop while true
            global i += 1
            for _ in 1:1000
                global j += 1
                i > 2 && break outer_loop "Done!"
-               println(i, " ", j)
+               print(i, ',', j, '-')
                j > 2 && break
            end
-       end
-1 1
-1 2
-1 3
-2 4
+       end;
+1,1-1,2-1,3-2,4-
+
+julia> result
 "Done!"
 ```
 
@@ -1232,6 +1253,9 @@ If `label` is not passed, skip the rest of the current iteration of the
 innermost loop.
 
 See also: [`break`](@ref), [`@label`](@ref)
+
+!!! compat "Julia 1.14"
+    Two-argument `continue` was added in Julia 1.14.
 
 # Examples
 ```jldoctest

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1174,9 +1174,11 @@ kw"finally"
     break name
     break name expr
 
-Break out of a loop or [`@label`](@ref) block immediately, evaluating and returning `expr`.
+Break out of a loop or [`@label`](@ref) block immediately, making the loop or block
+evaluate to `expr`.
 
-If `expr` is not passed, `break` evaluates to `nothing`.
+If `expr` is not passed, it defaults to `nothing`.
+The expression `expr` is evaluated at the break statement.
 
 If `name` is passed, break out of the loop or block named with the corresponding
 `@label name`. Otherwise, break out of the current, innermost loop.

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -531,6 +531,58 @@ negating the condition and placing the `println` call inside the `if` block. In 
 there is more code to be evaluated after the `continue`, and often there are multiple points from
 which one calls `continue`.
 
+When multiple loops are nested, `break` and `continue` will, by default, only break out of, or
+continue, the innermost loop:
+
+```jldoctest
+julia> for i in 1:3
+           for j in 1:2
+               println(j)
+               i > 1 && break
+           end
+       end
+1
+2
+1
+1
+```
+
+When working with nested loops, it is sometimes convenient to be able to use `break` or `continue`
+to target a different loop than the innermost one.
+This can be done by naming a code block with the `@label` macro, then using `continue name` or `break name`
+to target the named block:
+
+```jldoctest
+julia> @label outer for i in 1:3
+           for j in 1:2
+               i == 3 && break outer
+               println((i, j))
+           end
+       end
+(1, 1)
+(1, 2)
+(2, 1)
+(2, 2)
+```
+
+The combination of `@label` and named `break` can also be used to break out of code blocks other than loops.
+When doing so, the three argument `break name value` is particularly useful.
+This construct breaks out of the block named `name`, and makes the block evaluate to `value`.
+Three-valued `break` can often be used as a more structured alternative to [goto statements](@ref goto):
+
+```jldoctest
+julia> x = 3;
+
+julia> result = @label myblock begin
+           x > 5 && break myblock "big"
+           x > 0 && break myblock "positive"
+           "negative"
+       end;
+
+julia> result
+"positive"
+```
+
 Multiple nested `for` loops can be combined into a single outer loop, forming the cartesian product
 of its iterables:
 
@@ -946,7 +998,7 @@ Tasks are a control flow feature that allows computations to be suspended and re
 manner. We mention them here only for completeness; for a full discussion see
 [Asynchronous Programming](@ref man-asynchronous).
 
-## Low level control flow with goto
+## (Low level control flow with goto)[@id goto]
 The control flow constructs mentioned above, such as while- or for loop, and if/else statements
 are examples of *structured control flow*, where control is managed by structuring the source code
 into (typically indented) blocks.

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -945,3 +945,41 @@ julia> try
 Tasks are a control flow feature that allows computations to be suspended and resumed in a flexible
 manner. We mention them here only for completeness; for a full discussion see
 [Asynchronous Programming](@ref man-asynchronous).
+
+## Low level control flow with goto
+The control flow constructs mentioned above, such as while- or for loop, and if/else statements
+are examples of *structured control flow*, where control is managed by structuring the source code
+into (typically indented) blocks.
+
+Such structured control flow is implemented using a lower-level instruction called a goto statement,
+which causes execution to jump directly from the goto statement statement to its destination,
+and coninue from there.
+
+Julia provides goto statements using the statement `@goto mylabel`, which jumps to a location
+marked by `@label mylabel`.
+The `@label` statement, when executed, does nothing.
+
+For example, the following while loop:
+
+```julia
+while x < 10
+    x += 1
+end
+```
+
+May be expressed using `@label` and `@goto` pairs:
+
+```julia
+@label loop_start
+x < 10 || @goto loop_end
+x += 1
+@goto loop_start
+@label loop_end
+```
+
+Julia's `@goto` statements cannot jump to other top-level statements, e.g. from one function to another.
+
+Because structured control flow is easier to reason about than goto statements,
+goto statements should generally be avoided, and only reached for in the rare cases
+where the ordinary control flow mechanisms will not suffice.
+One such example is optimized state machines.

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -1005,7 +1005,7 @@ into (typically indented) blocks.
 
 Such structured control flow is implemented using a lower-level instruction called a goto statement,
 which causes execution to jump directly from the goto statement statement to its destination,
-and coninue from there.
+and continue execution from there.
 
 Julia provides goto statements using the statement `@goto mylabel`, which jumps to a location
 marked by `@label mylabel`.

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -538,7 +538,7 @@ continue, the innermost loop:
 julia> for i in 1:3
            for j in 1:2
                println(j)
-               i > 1 && break
+               i > 1 && break # break `j` loop only
            end
        end
 1
@@ -565,7 +565,7 @@ julia> @label outer for i in 1:3
 (2, 2)
 ```
 
-The combination of `@label` and named `break` can also be used to break out of code blocks other than loops.
+The combination of `@label` and named `break` can be used to break out of several types of code blocks, not only loops.
 When doing so, the three argument `break name value` is particularly useful.
 This construct breaks out of the block named `name`, and makes the block evaluate to `value`.
 Three-valued `break` can often be used as a more structured alternative to [goto statements](@ref goto):
@@ -999,15 +999,15 @@ manner. We mention them here only for completeness; for a full discussion see
 [Asynchronous Programming](@ref man-asynchronous).
 
 ## (Low level control flow with goto)[@id goto]
-The control flow constructs mentioned above, such as while- or for loop, and if/else statements
-are examples of *structured control flow*, where control is managed by structuring the source code
+The control flow constructs mentioned above, such as while loops, for loops, and if/else statements
+are examples of *structured control flow*, where control is managed by structuring source code
 into (typically indented) blocks.
 
 Such structured control flow is implemented using a lower-level instruction called a goto statement,
 which causes execution to jump directly from the goto statement statement to its destination,
 and continue execution from there.
 
-Julia provides goto statements using the statement `@goto mylabel`, which jumps to a location
+Julia provides goto statements with the statement `@goto mylabel`, which jumps to a location
 marked by `@label mylabel`.
 The `@label` statement, when executed, does nothing.
 
@@ -1019,7 +1019,7 @@ while x < 10
 end
 ```
 
-May be expressed using `@label` and `@goto` pairs:
+May be expressed using `@label` and conditional `@goto`:
 
 ```julia
 @label loop_start

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -998,7 +998,7 @@ Tasks are a control flow feature that allows computations to be suspended and re
 manner. We mention them here only for completeness; for a full discussion see
 [Asynchronous Programming](@ref man-asynchronous).
 
-## (Low level control flow with goto)[@id goto]
+## [Low level control flow with goto](@id goto)
 The control flow constructs mentioned above, such as while loops, for loops, and if/else statements
 are examples of *structured control flow*, where control is managed by structuring source code
 into (typically indented) blocks.

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -999,11 +999,8 @@ manner. We mention them here only for completeness; for a full discussion see
 [Asynchronous Programming](@ref man-asynchronous).
 
 ## [Low level control flow with goto](@id goto)
-The control flow constructs mentioned above, such as while loops, for loops, and if/else statements
-are examples of *structured control flow*, where control is managed by structuring source code
-into (typically indented) blocks.
-
-Such structured control flow is implemented using a lower-level instruction called a goto statement,
+The user-friendly control flow constructs mentioned above, such as while loops, for loops, and if/else statements
+are implemented using a lower-level construct called a goto statement,
 which causes execution to jump directly from the goto statement statement to its destination,
 and continue execution from there.
 
@@ -1031,7 +1028,6 @@ x += 1
 
 Julia's `@goto` statements cannot jump to other top-level statements, e.g. from one function to another.
 
-Because structured control flow is easier to reason about than goto statements,
+Because loops and if-statements are easier to reason about than goto statements,
 goto statements should generally be avoided, and only reached for in the rare cases
 where the ordinary control flow mechanisms will not suffice.
-One such example is optimized state machines.


### PR DESCRIPTION
Documentation was largely missing from #60481.

Also document `@goto`, which was not in the manual. 