### PR TITLE
Fix: Improve break label error message

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -5069,7 +5069,7 @@ f(x) = yt(x)
             ((break)
              (let ((labl (assq (cadr e) break-labels)))
                (if (not labl)
-                   (error "break or continue outside loop")
+                   (error (string "break expression is not in a loop named \"" (cadr e) "\""))
                    (begin
                      ;; Check if this is a valued break (break name val)
                      (if (length> e 2)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -215,6 +215,16 @@ macro test999_str(args...); args; end
 @test Meta.parse("(a=1, b=2)") == Expr(:tuple, Expr(:(=), :a, 1), Expr(:(=), :b, 2))
 @test_parseerror "(1 2)" # issue #15248
 
+@testset "break label error" begin
+    err = @test_throws Meta.ParseError Meta.parse("""
+        @label foo for i in 1:10
+            break bar
+        end
+    """)
+
+    @test occursin("break expression is not in a loop named \"bar\"", String(err))
+end
+
 @test Meta.parse("f(x;)") == Expr(:call, :f, Expr(:parameters), :x)
 
 @test Meta.parse("1 == 2|>3") == Expr(:call, :(==), 1, Expr(:call, :(|>), 2, 3))


### PR DESCRIPTION
Fixes #60817

- Updated the break label error message to be specific.
- Added a syntax test in test/syntax.jl to validate the new message.
