### PR TITLE
Remove vestigial `reinterpret(::Type{T}, A, dims::Dims)` methods

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -530,9 +530,6 @@ function _copyto_bitarray!(B::BitArray, A::AbstractArray)
     return B
 end
 
-reinterpret(::Type{Bool}, B::BitArray, dims::NTuple{N,Int}) where {N} = reinterpret(B, dims)
-reinterpret(B::BitArray, dims::NTuple{N,Int}) where {N} = reshape(B, dims)
-
 (::Type{T})(x::T) where {T<:BitArray} = copy(x)::T
 BitArray(x::BitArray) = copy(x)
 

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -257,7 +257,6 @@ similar(::Type{TA}, dims::Dims) where {T,N,P,TA<:ReshapedArray{T,N,P}} = similar
 IndexStyle(::Type{<:ReshapedArrayLF}) = IndexLinear()
 parent(A::ReshapedArray) = A.parent
 parentindices(A::ReshapedArray) = map(oneto, size(parent(A)))
-reinterpret(::Type{T}, A::ReshapedArray, dims::Dims) where {T} = reinterpret(T, parent(A), dims)
 elsize(::Type{<:ReshapedArray{<:Any,<:Any,P}}) where {P} = elsize(P)
 
 unaliascopy(A::ReshapedArray) = typeof(A)(unaliascopy(A.parent), A.dims, A.mi)


### PR DESCRIPTION
The `reinterpret` methods with a final `dims::Dims` argument were mostly removed/deprecated in https://github.com/JuliaLang/julia/pull/23750

I don't think this is a breaking change because these methods are not documented and were replaced with the `reshape` function before v1.0 from what I can tell.
