### PR TITLE
Make `jl_reinit_foreign_type` idempotent even with asserts

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -1042,10 +1042,14 @@ JL_DLLEXPORT int jl_reinit_foreign_type(jl_datatype_t *dt,
     const jl_datatype_layout_t *layout = dt->layout;
     jl_fielddescdyn_t * desc =
       (jl_fielddescdyn_t *) ((char *)layout + sizeof(*layout));
-    assert(!desc->markfunc);
-    assert(!desc->sweepfunc);
-    desc->markfunc = markfunc;
-    desc->sweepfunc = sweepfunc;
+    if (desc->markfunc != markfunc) {
+        assert(!desc->markfunc);
+        desc->markfunc = markfunc;
+    }
+    if (desc->sweepfunc != sweepfunc) {
+        assert(!desc->sweepfunc);
+        desc->sweepfunc = sweepfunc;
+    }
     return 1;
 }
 


### PR DESCRIPTION
That is, if it is called twice (e.g. because precompilation is disabled) with identical arguments, then this should not trigger an assertion.

This should resolve https://github.com/oscar-system/GAP.jl/issues/1314