### PR TITLE
Fix `big(x::BigFloat)` doesn't reset the precision of `x`

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -562,6 +562,7 @@ promote_rule(::Type{BigFloat}, ::Type{<:AbstractFloat}) = BigFloat
 big(::Type{<:AbstractFloat}) = BigFloat
 
 big(x::AbstractFloat) = convert(BigFloat, x)
+big(x::BigFloat) = BigFloat(x)
 
 function Rational{BigInt}(x::AbstractFloat)
     isnan(x) && return zero(BigInt) // zero(BigInt)

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -1116,7 +1116,8 @@ end
     p = precision(BigFloat)
     x = big(pi)
     setprecision(BigFloat, 2p) do
-        @test (BigFloat(x) === big(x)) === (BigFloat(x) == big(x)) === true
-        @test exponent(maxintfloat(big(x))) === exponent(maxintfloat(BigFloat(x))) === 2p
+        @test BigFloat(x) == big(x)
+        @test precision(big(x)) == precision(BigFloat(x)) == 2p
+        @test maxintfloat(big(x)) == maxintfloat(BigFloat(x))
     end
 end

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Serialization
+using Test
 
 import Base.MPFR
 @testset "constructors" begin
@@ -1108,5 +1109,14 @@ end
 @testset "cconvert(Ref{BigFloat}, x)" begin
     for x in (1.0, big"1.0", Ref(big"1.0"))
         @test Base.cconvert(Ref{BigFloat}, x) isa Base.MPFR.BigFloatData
+    end
+end
+
+@testset "issue #60829" begin
+    p = precision(BigFloat)
+    x = big(pi)
+    setprecision(BigFloat, 2p) do
+        @test (BigFloat(x) === big(x)) === (BigFloat(x) == big(x)) === true
+        @test exponent(maxintfloat(big(x))) === exponent(maxintfloat(BigFloat(x))) === 2p
     end
 end


### PR DESCRIPTION
Fixes #60829. 