### PR TITLE
Improve `insertdims` & `dropdims` docstrings

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -49,13 +49,16 @@ _sub(t::Tuple, s::Tuple) = _sub(tail(t), tail(s))
     dropdims(A; dims)
 
 Return an array with the same data as `A`, but with the dimensions specified by
-`dims` removed. `size(A,d)` must equal 1 for every `d` in `dims`,
-and repeated dimensions or numbers outside `1:ndims(A)` are forbidden.
+`dims` removed.
+
+Repeated dimensions or numbers outside `1:ndims(A)` are forbidden.
+Moreover `size(A,d)` must equal 1 for every `d` in `dims`.
 
 The result shares the same underlying data as `A`, such that the
 result is mutable if and only if `A` is mutable, and setting elements of one
 alters the values of the other.
 
+Inverse of [`dropdims`](@ref).
 See also: [`reshape`](@ref), [`vec`](@ref).
 
 # Examples
@@ -103,8 +106,7 @@ _dropdims(A::AbstractArray, dim::Integer) = _dropdims(A, (Int(dim),))
 """
     insertdims(A; dims)
 
-Inverse of [`dropdims`](@ref); return an array with new singleton dimensions
-at every dimension in `dims`.
+Return an array with new singleton dimensions at every dimension in `dims`.
 
 Repeated dimensions are forbidden and the largest entry in `dims` must be
 less than or equal than `ndims(A) + length(dims)`.
@@ -113,7 +115,9 @@ The result shares the same underlying data as `A`, such that the
 result is mutable if and only if `A` is mutable, and setting elements of one
 alters the values of the other.
 
-See also: [`dropdims`](@ref), [`reshape`](@ref), [`vec`](@ref).
+Inverse of [`dropdims`](@ref).
+See also: [`reshape`](@ref), [`vec`](@ref).
+
 # Examples
 ```jldoctest
 julia> x = [1 2 3; 4 5 6]

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -58,7 +58,7 @@ The result shares the same underlying data as `A`, such that the
 result is mutable if and only if `A` is mutable, and setting elements of one
 alters the values of the other.
 
-Inverse of [`dropdims`](@ref).
+Inverse of [`insertdims`](@ref).
 See also: [`reshape`](@ref), [`vec`](@ref).
 
 # Examples


### PR DESCRIPTION
Make sure both refer to each other and make them similar, seeing as they are inverse to each other.

Replaces and hence closes #59169