### PR TITLE
Test suite: switch to `httpbingo.julialang`, fall back to `httpbin.julialang` on failure

### DIFF
--- a/test/download_exec.jl
+++ b/test/download_exec.jl
@@ -10,7 +10,7 @@ mktempdir() do temp_dir
         "https://httpbin.julialang.org"
     catch ex
         bt = catch_backtrace()
-        @info "Looks like there is a problem with a JuliaLang mirror of httpbin." 
+        @info "Looks like there is a problem with a JuliaLang mirror of httpbin."
         @info "Trying httpbingo" exception=(ex,bt)
         "https://httpbingo.julialang.org/"
     end

--- a/test/download_exec.jl
+++ b/test/download_exec.jl
@@ -5,22 +5,28 @@ module TestDownload
 using Test
 
 mktempdir() do temp_dir
+    try
+        download("https://httpbin.julialang.org")
+        global url = "https://httpbin.julialang.org"
+    catch
+        global url = "https://httpbin.org"
+    end
     # Download a file
     file = joinpath(temp_dir, "ip")
-    @test download("https://httpbin.julialang.org/ip", file) == file
+    @test download("$url/ip", file) == file
     @test isfile(file)
     @test !isempty(read(file))
     ip = read(file, String)
 
     # Download an empty file
     empty_file = joinpath(temp_dir, "empty")
-    @test download("https://httpbin.julialang.org/status/200", empty_file) == empty_file
+    @test download("$url/status/200", empty_file) == empty_file
     @test isfile(empty_file)
     @test isempty(read(empty_file))
 
     # Make sure that failed downloads do not leave files around
     missing_file = joinpath(temp_dir, "missing")
-    @test_throws Exception download("https://httpbin.julialang.org/status/404", missing_file)
+    @test_throws Exception download("$url/status/404", missing_file)
     @test !isfile(missing_file)
 
     # Use a TEST-NET (192.0.2.0/24) address which shouldn't be bound

--- a/test/download_exec.jl
+++ b/test/download_exec.jl
@@ -5,11 +5,11 @@ module TestDownload
 using Test
 
 mktempdir() do temp_dir
-    try
+    url = try
         download("https://httpbin.julialang.org")
-        global url = "https://httpbin.julialang.org"
+        "https://httpbin.julialang.org"
     catch
-        global url = "https://httpbin.org"
+        "https://httpbin.org"
     end
     # Download a file
     file = joinpath(temp_dir, "ip")

--- a/test/download_exec.jl
+++ b/test/download_exec.jl
@@ -10,7 +10,8 @@ mktempdir() do temp_dir
         "https://httpbin.julialang.org"
     catch ex
         bt = catch_backtrace()
-        @info "Looks like there is a problem with a JuliaLang mirror of httpbin(go)" exception=(ex,bt)
+        @info "Looks like there is a problem with a JuliaLang mirror of httpbin." 
+        @info "Trying httpbingo" exception=(ex,bt)
         "https://httpbingo.julialang.org/"
     end
     # Download a file

--- a/test/download_exec.jl
+++ b/test/download_exec.jl
@@ -9,7 +9,7 @@ mktempdir() do temp_dir
         download("https://httpbin.julialang.org")
         "https://httpbin.julialang.org"
     catch
-        "https://httpbin.org"
+        "https://httpbingo.org"
     end
     # Download a file
     file = joinpath(temp_dir, "ip")

--- a/test/download_exec.jl
+++ b/test/download_exec.jl
@@ -9,7 +9,7 @@ mktempdir() do temp_dir
         download("https://httpbin.julialang.org")
         "https://httpbin.julialang.org"
     catch
-        "https://httpbingo.org"
+        "https://httpbingo.julialang.org/"
     end
     # Download a file
     file = joinpath(temp_dir, "ip")

--- a/test/download_exec.jl
+++ b/test/download_exec.jl
@@ -8,7 +8,9 @@ mktempdir() do temp_dir
     url = try
         download("https://httpbin.julialang.org")
         "https://httpbin.julialang.org"
-    catch
+    catch ex
+        bt = catch_backtrace()
+        @info "Looks like there is a problem with a JuliaLang mirror of httpbin(go)" exception=(ex,bt)
         "https://httpbingo.julialang.org/"
     end
     # Download a file

--- a/test/download_exec.jl
+++ b/test/download_exec.jl
@@ -6,13 +6,13 @@ using Test
 
 mktempdir() do temp_dir
     url = try
-        download("https://httpbin.julialang.org")
-        "https://httpbin.julialang.org"
+        download("https://httpbingo.julialang.org")
+        "https://httpbingo.julialang.org"
     catch ex
         bt = catch_backtrace()
-        @info "Looks like there is a problem with a JuliaLang mirror of httpbin."
-        @info "Trying httpbingo" exception=(ex,bt)
-        "https://httpbingo.julialang.org/"
+        @info "Looks like there is a problem with a JuliaLang mirror of httpbingo"
+        @info "Trying httpbin" exception=(ex,bt)
+        "https://httpbin.julialang.org/"
     end
     # Download a file
     file = joinpath(temp_dir, "ip")


### PR DESCRIPTION
we've been failing all the prs for a few days now, is it worth adding a backup for the httpbin mirror?