### PR TITLE
REPL: Fix Ctrl-A behavior after multiline history recall

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1869,7 +1869,7 @@ end
 
 match_input(k::Nothing, s, term, cs, keymap; update_repeats::Bool=true) = (s,p) -> return :ok
 match_input(k::KeyAlias, s::Union{Nothing,MIState}, term, cs, keymap::Dict{Char}; update_repeats::Bool=true) =
-    match_input(keymap, s, IOBuffer(k.seq), Char[], keymap; update_repeats=update_repeats)
+    match_input(keymap, s, IOBuffer(k.seq), Char[], keymap; update_repeats)
 
 function match_input(k::Dict{Char}, s::Union{Nothing,MIState}, term::Union{AbstractTerminal,IOBuffer}=terminal(s), cs::Vector{Char}=Char[], keymap::Dict{Char} = k; update_repeats::Bool=true)
     # if we run out of characters to match before resolving an action,

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1882,7 +1882,7 @@ function match_input(k::Dict{Char}, s::Union{Nothing,MIState}, term::Union{Abstr
     push!(cs, c)
     key = haskey(k, c) ? c : wildcard
     # if we don't match on the key, look for a default action then fallback on 'nothing' to ignore
-    return match_input(get(k, key, nothing), s, term, cs, keymap; update_repeats=update_repeats)
+    return match_input(get(k, key, nothing), s, term, cs, keymap; update_repeats)
 end
 
 update_key_repeats(s, keystroke) = nothing

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2432,6 +2432,8 @@ function move_line_start(s::MIState)
     else
         seek(buf, something(findprev(isequal(UInt8('\n')), buf.data, curpos), 0))
     end
+    s.key_repeats = 0
+    empty!(s.previous_key)
     nothing
 end
 

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2432,8 +2432,6 @@ function move_line_start(s::MIState)
     else
         seek(buf, something(findprev(isequal(UInt8('\n')), buf.data, curpos), 0))
     end
-    s.key_repeats = 0
-    empty!(s.previous_key)
     nothing
 end
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -975,8 +975,8 @@ function history_prev(s::LineEdit.MIState, hist::REPLHistoryProvider,
     if m === :ok
         LineEdit.move_input_start(s)
         LineEdit.reset_key_repeats(s) do
-        LineEdit.move_line_end(s)
-    end
+            LineEdit.move_line_end(s)
+        end
         return LineEdit.refresh_line(s)
     elseif m === :skip
         return history_prev(s, hist, num+1, save_idx)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -974,7 +974,9 @@ function history_prev(s::LineEdit.MIState, hist::REPLHistoryProvider,
     m = history_move(s, hist, hist.cur_idx-num, save_idx)
     if m === :ok
         LineEdit.move_input_start(s)
+        LineEdit.reset_key_repeats(s) do
         LineEdit.move_line_end(s)
+    end
         return LineEdit.refresh_line(s)
     elseif m === :skip
         return history_prev(s, hist, num+1, save_idx)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -975,10 +975,6 @@ function history_prev(s::LineEdit.MIState, hist::REPLHistoryProvider,
     if m === :ok
         LineEdit.move_input_start(s)
         LineEdit.move_line_end(s)
-        # Reset key_repeats and previous_key to avoid triggering repeated key behavior
-        # when the first key is pressed after history recall
-        s.key_repeats = 0
-        empty!(s.previous_key)
         return LineEdit.refresh_line(s)
     elseif m === :skip
         return history_prev(s, hist, num+1, save_idx)
@@ -1005,10 +1001,6 @@ function history_next(s::LineEdit.MIState, hist::REPLHistoryProvider,
     m = history_move(s, hist, cur_idx+num, save_idx)
     if m === :ok
         LineEdit.move_input_end(s)
-        # Reset key_repeats and previous_key to avoid triggering repeated key behavior
-        # when the first key is pressed after history recall
-        s.key_repeats = 0
-        empty!(s.previous_key)
         return LineEdit.refresh_line(s)
     elseif m === :skip
         return history_next(s, hist, num+1, save_idx)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -974,9 +974,11 @@ function history_prev(s::LineEdit.MIState, hist::REPLHistoryProvider,
     m = history_move(s, hist, hist.cur_idx-num, save_idx)
     if m === :ok
         LineEdit.move_input_start(s)
-        LineEdit.reset_key_repeats(s) do
-            LineEdit.move_line_end(s)
-        end
+        LineEdit.move_line_end(s)
+        # Reset key_repeats and previous_key to avoid triggering repeated key behavior
+        # when the first key is pressed after history recall
+        s.key_repeats = 0
+        empty!(s.previous_key)
         return LineEdit.refresh_line(s)
     elseif m === :skip
         return history_prev(s, hist, num+1, save_idx)
@@ -1003,6 +1005,10 @@ function history_next(s::LineEdit.MIState, hist::REPLHistoryProvider,
     m = history_move(s, hist, cur_idx+num, save_idx)
     if m === :ok
         LineEdit.move_input_end(s)
+        # Reset key_repeats and previous_key to avoid triggering repeated key behavior
+        # when the first key is pressed after history recall
+        s.key_repeats = 0
+        empty!(s.previous_key)
         return LineEdit.refresh_line(s)
     elseif m === :skip
         return history_next(s, hist, num+1, save_idx)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -618,13 +618,12 @@ for prompt = ["TestΠ", () -> randstring(rand(1:10))]
         @test ps.parent == repl_mode
         @test LineEdit.input_string(ps) == "wip"
         @test position(LineEdit.buffer(s)) == 3
-        
         # Test that key_repeats is reset after history recall (issue with Ctrl-A behavior)
         # Simulate a multi-line history entry and recalling it
-        s.key_repeats = 1 # Simulate previous key repeats from before history recall
+        s.key_repeats = 1
         empty!(s.previous_key)
-        push!(s.previous_key, '\x01') # Set previous_key to Ctrl-A
-        LineEdit.history_prev(s, hp) # Recall "2 + 2"
+        push!(s.previous_key, '\x01')
+        LineEdit.history_prev(s, hp)
         @test s.key_repeats == 0 "key_repeats should be reset after history recall"
         @test isempty(s.previous_key) "previous_key should be reset after history recall"
         

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -618,6 +618,16 @@ for prompt = ["TestΠ", () -> randstring(rand(1:10))]
         @test ps.parent == repl_mode
         @test LineEdit.input_string(ps) == "wip"
         @test position(LineEdit.buffer(s)) == 3
+        
+        # Test that key_repeats is reset after history recall (issue with Ctrl-A behavior)
+        # Simulate a multi-line history entry and recalling it
+        s.key_repeats = 1 # Simulate previous key repeats from before history recall
+        empty!(s.previous_key)
+        push!(s.previous_key, '\x01') # Set previous_key to Ctrl-A
+        LineEdit.history_prev(s, hp) # Recall "2 + 2"
+        @test s.key_repeats == 0 "key_repeats should be reset after history recall"
+        @test isempty(s.previous_key) "previous_key should be reset after history recall"
+        
         LineEdit.accept_result(s, prefix_mode)
     end
 end

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -626,7 +626,6 @@ for prompt = ["TestΠ", () -> randstring(rand(1:10))]
         LineEdit.history_prev(s, hp)
         @test s.key_repeats == 0 "key_repeats should be reset after history recall"
         @test isempty(s.previous_key) "previous_key should be reset after history recall"
-        
         LineEdit.accept_result(s, prefix_mode)
     end
 end


### PR DESCRIPTION
After recalling a multiline history entry, `key_repeats` could remain non-zero,
causing Ctrl-A to be interpreted as a repeated key press. This resulted in the
cursor jumping to the start of the entire input on first Ctrl-A.

This change ensures that:
### Ctrl-A once moves to the start of the current line
### Repeated Ctrl-A still moves to the start of the input

#AI tools were used to assist with code exploration and reasoning; all changes were implemented and verified manually.


Fixes #60779
