### PR TITLE
clangsa: Propagate sysroot flag from GCC

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1710,6 +1710,12 @@ ifeq ($(USEGCC),1)
 # try to help clang find the c++ files for CC by guessing the value for --prefix
 # by dropping lib/gcc/<platform>/<version> from the install directory it reports
 CLANGSA_CXXFLAGS += --gcc-toolchain="$(abspath $(shell LANG=C $(CC) -print-search-dirs | grep '^install: ' | sed -e "s/^install: //")/../../../..)"
+ifneq ($(OS), Darwin)
+GCC_SYSROOT := $(shell $(CC) --print-sysroot 2>/dev/null)
+ifneq ($(GCC_SYSROOT),)
+CLANGSA_FLAGS += --sysroot=$(GCC_SYSROOT)
+endif
+endif
 endif
 
 


### PR DESCRIPTION
If GCC is built with a sysroot (e.g. in a BB2 environment), we need to propagate this flag for clang to find the system headers. Fix by Claude.