### PR TITLE
docs: remove Base.require from manual

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -3373,7 +3373,7 @@ AssertionError
 """
     LoadError(file::AbstractString, line::Int, error)
 
-An error occurred while [`include`](@ref Base.include)ing, [`require`](@ref Base.require)ing, or [`using`](@ref) a file. The error specifics
+An error occurred while [`include`](@ref Base.include)ing, [`import`](@ref)ing, or [`using`](@ref) a file. The error specifics
 should be available in the `.error` field.
 
 !!! compat "Julia 1.7"

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2553,27 +2553,6 @@ See also: [Command-line Interface](@ref cli) for the `--trace-eval` option.
 """
 TRACE_EVAL::Union{Symbol,Nothing} = nothing
 
-"""
-    require(into::Module, module::Symbol)
-
-This function is part of the implementation of [`using`](@ref) / [`import`](@ref), if a module is not
-already defined in `Main`. It can also be called directly to force reloading a module,
-regardless of whether it has been loaded before (for example, when interactively developing
-libraries).
-
-Loads a source file, in the context of the `Main` module, on every active node, searching
-standard locations for files. `require` is considered a top-level operation, so it sets the
-current `include` path but does not use it to search for files (see help for [`include`](@ref)).
-This function is typically used to load library code, and is implicitly called by `using` to
-load packages.
-
-When searching for files, `require` first looks for package code in the global array
-[`LOAD_PATH`](@ref). `require` is case-sensitive on all platforms, including those with
-case-insensitive filesystems like macOS and Windows.
-
-For more details regarding code loading, see the manual sections on [modules](@ref modules) and
-[parallel computing](@ref code-availability).
-"""
 function require(into::Module, mod::Symbol)
     world = _require_world_age[]
     if world == typemax(UInt)

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -521,7 +521,6 @@ Docs.undocumented_names
 ```@docs
 Base.identify_package
 Base.locate_package
-Base.require
 Base.compilecache
 Base.isprecompiled
 Base.get_extension

--- a/doc/src/devdocs/require.md
+++ b/doc/src/devdocs/require.md
@@ -1,6 +1,6 @@
 # Module loading
 
-[`Base.require`](@ref) is responsible for loading modules and it also manages the
+`Base.require` is responsible for loading modules and it also manages the
 precompilation cache. It is the implementation of the `import` statement.
 
 ## Experimental features


### PR DESCRIPTION
Also remove its docstring, which was very wrong in several points. This was reported in 2018 yetnobody fixed it since then. Since nobody who understands the code enough to update the docstring has done so in the past 7.5 years, it seems better to just remove it than to spread incorrect information.

Resolves #27822