### PR TITLE
add regression tests that stdlibs are empty of `Core.Box`

### DIFF
--- a/JuliaLowering/test/runtests.jl
+++ b/JuliaLowering/test/runtests.jl
@@ -1,3 +1,7 @@
+using Test, JuliaLowering
+
+@test isempty(Test.detect_closure_boxes(JuliaLowering))
+
 include("utils.jl")
 
 @testset "JuliaLowering.jl" begin

--- a/JuliaSyntax/test/runtests.jl
+++ b/JuliaSyntax/test/runtests.jl
@@ -4,6 +4,11 @@ end
 
 using Test
 
+# JuliaSyntax is not only tested on master
+if isdefined(Test, :detect_closure_boxes)
+    @test isempty(Test.detect_closure_boxes(JuliaSyntax))
+end
+
 include("test_utils.jl")
 include("test_utils_tests.jl")
 include("fuzz_test.jl")

--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -5,6 +5,8 @@ using Artifacts, Test, Base.BinaryPlatforms
 using Artifacts: with_artifacts_directory, pack_platform!, unpack_platform, load_overrides
 using TOML
 
+@test isempty(Test.detect_closure_boxes(Artifacts))
+
 # prepare for the package tests by ensuring the required artifacts are downloaded now
 artifacts_dir = mktempdir()
 run(addenv(`$(Base.julia_cmd()) --color=no $(joinpath(@__DIR__, "refresh_artifacts.jl")) $(artifacts_dir)`, "TERM"=>"dumb"))

--- a/stdlib/Base64/test/runtests.jl
+++ b/stdlib/Base64/test/runtests.jl
@@ -9,6 +9,8 @@ using Base64:
     base64decode,
     stringmime
 
+@test isempty(Test.detect_closure_boxes(Base64))
+
 const inputText = "Man is distinguished, not only by his reason, but by this singular passion from other animals, which is a lust of the mind, that by a perseverance of delight in the continued and indefatigable generation of knowledge, exceeds the short vehemence of any carnal pleasure."
 const encodedMaxLine76 = """
 TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz

--- a/stdlib/CRC32c/test/runtests.jl
+++ b/stdlib/CRC32c/test/runtests.jl
@@ -10,6 +10,8 @@ using .Main.OffsetArrays: Origin
 isdefined(Main, :FillArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "FillArrays.jl"))
 using .Main.FillArrays: Fill
 
+@test isempty(Test.detect_closure_boxes(CRC32c))
+
 function test_crc32c(crc32c)
     # CRC32c checksum (test data generated from @andrewcooke's CRC.jl package)
     for (n,crc) in [(0,0x00000000),(1,0xa016d052),(2,0x03f89f52),(3,0xf130f21e),(4,0x29308cf4),(5,0x53518fab),(6,0x4f4dfbab),(7,0xbd3a64dc),(8,0x46891f81),(9,0x5a14b9f9),(10,0xb219db69),(11,0xd232a91f),(12,0x51a15563),(13,0x9f92de41),(14,0x4d8ae017),(15,0xc8b74611),(16,0xa0de6714),(17,0x672c992a),(18,0xe8206eb6),(19,0xc52fd285),(20,0x327b0397),(21,0x318263dd),(22,0x08485ccd),(23,0xea44d29e),(24,0xf6c0cb13),(25,0x3969bba2),(26,0x6a8810ec),(27,0x75b3d0df),(28,0x82d535b1),(29,0xbdf7fc12),(30,0x1f836b7d),(31,0xd29f33af),(32,0x8e4acb3e),(33,0x1cbee2d1),(34,0xb25f7132),(35,0xb0fa484c),(36,0xb9d262b4),(37,0x3207fe27),(38,0xa024d7ac),(39,0x49a2e7c5),(40,0x0e2c157f),(41,0x25f7427f),(42,0x368c6adc),(43,0x75efd4a5),(44,0xa84c5c31),(45,0x0fc817b2),(46,0x8d99a881),(47,0x5cc3c078),(48,0x9983d5e2),(49,0x9267c2db),(50,0xc96d4745),(51,0x058d8df3),(52,0x453f9cf3),(53,0xb714ade1),(54,0x55d3c2bc),(55,0x495710d0),(56,0x3bddf494),(57,0x4f2577d0),(58,0xdae0f604),(59,0x3c57c632),(60,0xfe39bbb0),(61,0x6f5d1d41),(62,0x7d996665),(63,0x68c738dc),(64,0x8dfea7ae)]

--- a/stdlib/Dates/test/runtests.jl
+++ b/stdlib/Dates/test/runtests.jl
@@ -4,6 +4,8 @@ module DateTests
 
 using Test, Dates
 
+@test isempty(Test.detect_closure_boxes(Dates))
+
 for file in readlines(joinpath(@__DIR__, "testgroups"))
     include(file * ".jl")
 end

--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -4,6 +4,8 @@ using Test, FileWatching
 using Base: uv_error, Experimental
 using Base.Filesystem: StatStruct
 
+@test isempty(Test.detect_closure_boxes(FileWatching))
+
 @testset "FileWatching" begin
 
 # This script does the following

--- a/stdlib/Future/test/runtests.jl
+++ b/stdlib/Future/test/runtests.jl
@@ -3,6 +3,8 @@
 using Test
 using Future
 
+@test isempty(Test.detect_closure_boxes(Future))
+
 @testset "Docstrings" begin
     @test isempty(Docs.undocumented_names(Future))
 end

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -2,6 +2,8 @@
 
 using Test, InteractiveUtils
 
+@test isempty(Test.detect_closure_boxes(InteractiveUtils))
+
 @testset "highlighting" begin
     include("highlighting.jl")
 end

--- a/stdlib/LibGit2/test/runtests.jl
+++ b/stdlib/LibGit2/test/runtests.jl
@@ -2,6 +2,8 @@
 
 using Test, LibGit2
 
+@test isempty(Test.detect_closure_boxes(LibGit2))
+
 @testset verbose=true "LibGit2 $test" for test in eachline(joinpath(@__DIR__, "testgroups"))
     include("$test.jl")
 end

--- a/stdlib/Libdl/test/runtests.jl
+++ b/stdlib/Libdl/test/runtests.jl
@@ -3,6 +3,8 @@
 using Test
 using Libdl
 
+@test isempty(Test.detect_closure_boxes(Libdl))
+
 # these could fail on an embedded installation
 # but for now, we don't handle that case
 dlls = Libdl.dllist()

--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -4,6 +4,8 @@ using Test, Logging
 
 import Logging: min_enabled_level, shouldlog, handle_message
 
+@test isempty(Test.detect_closure_boxes(Logging))
+
 @noinline func1() = backtrace()
 
 # see "custom log macro" testset

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -4,6 +4,8 @@ using Test, Markdown, StyledStrings
 import Markdown: MD, Paragraph, Header, Italic, Bold, Strikethrough, LineBreak, Table, Code, LaTeX, Footnote
 import Base: show
 
+@test isempty(Test.detect_closure_boxes(Markdown))
+
 # Basics
 # Equality is checked by making sure the HTML output is
 # the same – the structure itself may be different.

--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -2,6 +2,8 @@
 
 using Test, Mmap, Random
 
+@test isempty(Test.detect_closure_boxes(Mmap))
+
 file = tempname()
 write(file, "Hello World\n")
 t = b"Hello World"

--- a/stdlib/Printf/test/runtests.jl
+++ b/stdlib/Printf/test/runtests.jl
@@ -2,6 +2,8 @@
 
 using Test, Printf
 
+@test isempty(Test.detect_closure_boxes(Printf))
+
 @testset "Printf" begin
 
 @testset "%p" begin

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -3,6 +3,8 @@
 using Test, Profile, Serialization, Logging
 using Base.StackTraces: StackFrame
 
+@test isempty(Test.detect_closure_boxes(Profile))
+
 @test_throws "The profiling data buffer is not initialized. A profile has not been requested this session." Profile.print()
 
 Profile.clear()

--- a/stdlib/REPL/test/runtests.jl
+++ b/stdlib/REPL/test/runtests.jl
@@ -1,4 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
+using Test, REPL
+
+@test isempty(Test.detect_closure_boxes(REPL))
 
 # Make a copy of the original environment
 original_env = copy(ENV)

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -3,6 +3,8 @@
 using Test, SparseArrays
 using Test: guardseed
 
+@test isempty(Test.detect_closure_boxes(Random))
+
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "test")
 isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "OffsetArrays.jl"))
 using .Main.OffsetArrays

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -3,6 +3,8 @@
 using Test, Random, Serialization, Base64
 using Base.ScopedValues: with
 
+@test isempty(Test.detect_closure_boxes(Serialization))
+
 # Check that serializer hasn't gone out-of-frame
 @test Serialization.sertag(Symbol) == 1
 @test Serialization.sertag(()) == 68

--- a/stdlib/SharedArrays/test/runtests.jl
+++ b/stdlib/SharedArrays/test/runtests.jl
@@ -3,6 +3,8 @@
 using Test, Distributed, SharedArrays, Random
 include(joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "test", "testenv.jl"))
 
+@test isempty(Test.detect_closure_boxes(SharedArrays))
+
 # These processes explicitly want to share memory, we can't have
 # them in separate rr sessions
 addprocs_with_testenv(4; rr_allowed=false)

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -3,6 +3,8 @@
 using Sockets, Random, Test
 using Base: Experimental
 
+@test isempty(Test.detect_closure_boxes(Sockets))
+
 # This is for debugging only - if the system doesn't have `netstat`, we just ignore it
 netstat() = try; read(ignorestatus(`netstat -ndi`), String); catch; return ""; end
 const netstat_before = netstat()

--- a/stdlib/TOML/test/runtests.jl
+++ b/stdlib/TOML/test/runtests.jl
@@ -5,6 +5,8 @@ using Dates
 
 using TOML: TOML, parse, tryparse, ParserError, Internals, print
 
+@test isempty(Test.detect_closure_boxes(TOML))
+
 function roundtrip(data)
     mktemp() do file, io
         data_parsed = TOML.parse(data)

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -7,6 +7,8 @@ using Distributed: RemoteException
 
 import Logging: Debug, Info, Warn, with_logger
 
+@test isempty(Test.detect_closure_boxes(Test))
+
 @testset "@test" begin
     atol = 1
     a = (; atol=2)

--- a/stdlib/UUIDs/test/runtests.jl
+++ b/stdlib/UUIDs/test/runtests.jl
@@ -3,6 +3,8 @@
 using Test, UUIDs, Random
 using UUIDs: _build_uuid1, _build_uuid7
 
+@test isempty(Test.detect_closure_boxes(UUIDs))
+
 # results similar to Python builtin uuid
 # To reproduce the sequence
 #=

--- a/stdlib/Unicode/test/runtests.jl
+++ b/stdlib/Unicode/test/runtests.jl
@@ -5,6 +5,8 @@ using Unicode
 using Unicode: normalize, isassigned, julia_chartransform
 import Random
 
+@test isempty(Test.detect_closure_boxes(Unicode))
+
 Random.seed!(12345)
 
 @testset "string normalization" begin


### PR DESCRIPTION
Should add a separate PR that checks that the number doesn't increase in Base (there are currently 6 Compiler methods with boxes).