### PR TITLE
relax the dispatch on the `iterate` method for `String`

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -451,7 +451,8 @@ is_valid_continuation(c) = c & 0xc0 == 0x80
 
 ## required core functionality ##
 
-@inline function iterate(s::String, i::Int=firstindex(s))
+@inline function iterate(s::String, i::Integer=firstindex(s))
+    i = i::Int
     (i % UInt) - 1 < ncodeunits(s) || return nothing
     b = @inbounds codeunit(s, i)
     u = UInt32(b) << 24


### PR DESCRIPTION
The type constraint for the second, state, argument of `iterate` should match the type constraint for the same argument on less specific methods.

In this case, these are the more specific and the less specific method:

* `iterate(::AbstractString, ::Integer)`

* `iterate(::String, ::Int)`

The issue is that the more specific method is overly specific. Ideally the state argument of `iterate` methods would always have unconstrained type.

Specifically, the current situation causes useless method instances to be compiled for the `iterate(::AbstractString, ::Integer)` method:

* `iterate(::String, ::UInt64)`

* `iterate(::String, ::Bool)`

This PR should prevent that.

To prevent any regressions from relaxing the method argument type constraint, a `typeassert` is introduced at the beginning of the method body.