### PR TITLE
[JuliaSyntax] improve type stability of `SyntaxTree` query APIs

### DIFF
--- a/JuliaLowering/test/utils.jl
+++ b/JuliaLowering/test/utils.jl
@@ -12,7 +12,7 @@ import FileWatching
 using Markdown
 import REPL
 
-using .JuliaSyntax: sourcetext, set_numeric_flags
+using .JuliaSyntax: SourceAttrType, sourcetext, set_numeric_flags
 
 using .JuliaLowering:
     SyntaxGraph, new_id!, ensure_attributes!,
@@ -25,7 +25,7 @@ function _ast_test_graph()
     graph = SyntaxGraph()
     ensure_attributes!(graph,
                        kind=Kind, syntax_flags=UInt16,
-                       source=Union{SourceRef,NodeId,Tuple,LineNumberNode},
+                       source=SourceAttrType,
                        var_id=Int, value=Any, name_val=String, is_toplevel_thunk=Bool,
                        toplevel_pure=Bool)
 end

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -356,12 +356,11 @@ function provenance(ex::SyntaxTree)
     end
 end
 
-
 function _sourceref(sources, id)
     i = 1
     while true
         i += 1
-        s = sources[id]
+        s = sources[id]::SourceAttrType
         if s isa NodeId
             id = s
         else
@@ -371,8 +370,8 @@ function _sourceref(sources, id)
 end
 
 function sourceref(ex::SyntaxTree)
-    sources = ex._graph.source
-    id::NodeId = ex._id
+    sources = ex._graph.source::Dict{NodeId,SourceAttrType}
+    id = ex._id
     while true
         s, _ = _sourceref(sources, id)
         if s isa Tuple
@@ -424,7 +423,7 @@ function is_ancestor(ex, ancestor)
     end
 end
 
-const SourceAttrType = Union{SourceRef,LineNumberNode,NodeId,Tuple}
+const SourceAttrType = Union{SourceRef,LineNumberNode,NodeId,Tuple{Vararg{NodeId}}}
 
 function reparent(ctx, ex::SyntaxTree)
     # Ensure `ex` has the same parent graph, in a somewhat loose sense.

--- a/JuliaSyntax/test/runtests.jl
+++ b/JuliaSyntax/test/runtests.jl
@@ -39,3 +39,9 @@ if VERSION >= v"1.6"
 end
 
 include("serialization.jl")
+
+# Basic inference tests
+@static if isdefined(Base, :infer_return_type)
+    @test Base.infer_return_type(JuliaSyntax.sourcetext, (JuliaSyntax.SyntaxTree,)) <: AbstractString
+    @test Base.infer_return_type(JuliaSyntax.byte_range, (JuliaSyntax.SyntaxTree,)) == UnitRange{Int}
+end


### PR DESCRIPTION
The current JuliaSyntax attribution system is type unstable, particularly because the source attribution type is defined as `const SourceAttrType = Union{SourceRef,LineNumberNode,NodeId,Tuple}`, inference does not work for accesses like
`st._graph.source[idx::Int]` on `st::SyntaxTree` due to the type instability of `Tuple`.
As a result, the return types of query tools like
`byte_range(::SyntaxTree)` and `sourcetext(::SyntaxTree)`, which are heavily used by external tools (JETLS in particular), are not inferred properly.

This commit improves type stability of these basic user-facing `SyntaxTree` query interfaces by refining the type to `const SourceAttrType =
Union{SourceRef,LineNumberNode,NodeId,Tuple{Vararg{NodeId}}}`. The key change is to `_sourceref` (the internal utility that accesses `ex._graph.source`), where by adding type annotations using the new `SourceAttrType`, inference now is able to infer the return type of this method to be
`Union{SourceRef,LineNumberNode,Tuple{Vararg{NodeId}}`, allowing to figure out that `sourceref` only returns `Union{SourceRef,LineNumberNode}`

Regarding the `Tuple` case needed for multi-provenance: the current design stores `NodeId`s for multi-provenance references, so this refinement should not cause issues for existing use cases. If fully generic `SourceAttrType` were desired, it would be better to make it a type parameter of `SyntaxGraph` rather than defining `const SourceAttrType`. However, I believe such genericity has no practical use case and would only serve to stress the compiler unnecessarily, so I believe this change is preferrable.