### PR TITLE
Compiler: use inline Const storage in RTEffects

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -2620,7 +2620,7 @@ function abstract_eval_replaceglobal!(interp::AbstractInterpreter, sv::AbsIntSta
                         partition_T = partition_restriction(partition)
                     end
                     partition_exct = Union{partition_rte.exct, global_assignment_binding_rt_exct(interp, partition, v′[])[2]}
-                    partition_rte = RTEffects(partition_rte.rt, partition_exct, partition_rte.effects)
+                    partition_rte = RTEffects(get_rt(partition_rte), partition_exct, partition_rte.effects)
                     Pair{RTEffects, Any}(partition_rte, partition_T)
                 end
                 update_valid_age!(sv, world, valid_worlds)
@@ -3043,9 +3043,9 @@ function abstract_eval_value(interp::AbstractInterpreter, @nospecialize(e), ssta
     if isa(e, Expr)
         return abstract_eval_value_expr(interp, e, sv)
     else
-        (;rt, effects) = abstract_eval_special_value(interp, e, sstate, sv)
-        merge_effects!(interp, sv, effects)
-        return collect_limitations!(rt, sv)
+        rte = abstract_eval_special_value(interp, e, sstate, sv)
+        merge_effects!(interp, sv, rte.effects)
+        return collect_limitations!(get_rt(rte), sv)
     end
 end
 
@@ -3062,19 +3062,33 @@ function collect_argtypes(interp::AbstractInterpreter, ea::Vector{Any}, sstate::
     return argtypes
 end
 
+const _RT_NOT_CONST = Const(nothing)
+
 struct RTEffects
-    rt::Any
+    _const_rt::Const
+    _other_rt::Any
     exct::Any
     effects::Effects
     refinements # ::Union{Nothing,SlotRefinement,Vector{Any}}
-    function RTEffects(rt, exct, effects::Effects, refinements=nothing)
-        @nospecialize rt exct refinements
-        return new(rt, exct, effects, refinements)
+
+    function RTEffects(rt::Const, exct, effects::Effects, refinements=nothing)
+        @nospecialize exct refinements
+        return new(rt, nothing, exct, effects, refinements)
+    end
+
+    function RTEffects(@nospecialize(rt), exct, effects::Effects, refinements=nothing)
+        @nospecialize exct refinements
+        return new(_RT_NOT_CONST, rt, exct, effects, refinements)
     end
 end
 
+@inline function get_rt(rte::RTEffects)
+    other = getfield(rte, :_other_rt)
+    return other === nothing ? getfield(rte, :_const_rt) : other
+end
+
 CallMeta(rte::RTEffects, info::CallInfo) =
-    CallMeta(rte.rt, rte.exct, rte.effects, info, rte.refinements)
+    CallMeta(get_rt(rte), rte.exct, rte.effects, info, rte.refinements)
 
 function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo, sstate::StatementState, sv::InferenceState)
     unused = call_result_unused(sv, sv.currpc)
@@ -3351,7 +3365,7 @@ function abstract_eval_isdefinedglobal(interp::AbstractInterpreter, mod::Module,
     # XXX: it is unsound to ignore valid_worlds here
     if rte.exct == Union{}
         rt = Const(true)
-    elseif rte.rt === Union{} && rte.exct === UndefVarError
+    elseif get_rt(rte) === Union{} && rte.exct === UndefVarError
         rt = Const(false)
     else
         effects = Effects(generic_isdefinedglobal_effects, nothrow=true)
@@ -3569,7 +3583,7 @@ function abstract_eval_phi(interp::AbstractInterpreter, phi::PhiNode, sstate::St
         val = phi.values[i]
         # N.B.: Phi arguments are restricted to not have effects, so we can drop
         # them here safely.
-        thisval = abstract_eval_special_value(interp, val, sstate, sv).rt
+        thisval = get_rt(abstract_eval_special_value(interp, val, sstate, sv))
         rt = tmerge(typeinf_lattice(interp), rt, thisval)
     end
     return rt
@@ -3617,7 +3631,7 @@ function abstract_eval_globalref_type(g::GlobalRef, src::Union{CodeInfo, IRCode,
     if min_world(valid_worlds) > min_world(worlds) || max_world(valid_worlds) < max_world(worlds)
         return Any
     end
-    return rte.rt
+    return get_rt(rte)
 end
 
 function lookup_binding_partition!(interp::AbstractInterpreter, g::Union{GlobalRef, Core.Binding}, sv::AbsIntState)
@@ -3847,7 +3861,8 @@ end
             stmt = stmt.args[2]
         end
         if !isa(stmt, Expr)
-            (; rt, exct, effects, refinements) = abstract_eval_special_value(interp, stmt, sstate, frame)
+            rte = abstract_eval_special_value(interp, stmt, sstate, frame)
+            rt, exct, effects, refinements = get_rt(rte), rte.exct, rte.effects, rte.refinements
         else
             hd = stmt.head
             if hd === :method
@@ -3876,7 +3891,7 @@ end
                     end
                 end
                 result = result[]
-                (; rt, exct, effects, refinements) = result
+                rt, exct, effects, refinements = get_rt(result), result.exct, result.effects, result.refinements
                 if effects.noub === NOUB_IF_NOINBOUNDS
                     if has_curr_ssaflag(frame, IR_FLAG_INBOUNDS)
                         effects = Effects(effects; noub=ALWAYS_FALSE)

--- a/Compiler/src/ssair/irinterp.jl
+++ b/Compiler/src/ssair/irinterp.jl
@@ -163,7 +163,8 @@ function reprocess_instruction!(interp::AbstractInterpreter, inst::Instruction, 
             end
             @assert length(irsv.callstack) == irsv.frameid && isempty(irsv.tasks)
             result isa Future && (result = result[])
-            (; rt, effects) = result
+            rt = get_rt(result)
+            effects = result.effects
             add_flag!(inst, flags_for_effects(effects))
         elseif head === :invoke  # COMBAK: || head === :invoke_modifyfield (similar to call, but for args[2:end])
             rt, (nothrow, noub) = abstract_eval_invoke_inst(interp, inst, irsv)


### PR DESCRIPTION
Store Const values inline in RTEffects to avoid boxing allocation when
the return type is a Const. This moves the allocation from construction
time to access time (via get_rt()), but when inlined, the compiler can
often eliminate the allocation entirely.

The struct adds a _const_rt::Const field for inline storage and uses
_other_rt::Any for non-Const types. A sentinel value _RT_NOT_CONST
distinguishes between the two cases.

This is less of a clear cut optimization. We allocate a lot of Const everywhere since this pattern is quite common, so we may want to move to something that avoids boxing `Const` always. Notably this means that RTEffects is 8 bytes larger so it's not always a win. 
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
