### PR TITLE
inference: fix union split handling for custom lattices

### DIFF
--- a/Compiler/src/typeutils.jl
+++ b/Compiler/src/typeutils.jl
@@ -244,8 +244,9 @@ function _switchtupleunion(𝕃::AbstractLattice, t::Vector{Any}, i::Int, tunion
                 _switchtupleunion(𝕃, t, i - 1, tunion, origt)
             end
             t[i] = origti
-        elseif has_extended_unionsplit(𝕃) && !isa(ti, Const) && !isvarargtype(ti) && isa(widenconst(ti), Union)
-            for ty in uniontypes(ti)
+        elseif (has_extended_unionsplit(𝕃) && !isa(ti, Const) && !isvarargtype(ti) &&
+            (wty = widenconst(ti); isa(wty, Union)))
+            for ty in uniontypes(wty)
                 t[i] = ty
                 _switchtupleunion(𝕃, t, i - 1, tunion, origt)
             end

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -2597,6 +2597,15 @@ end == Integer
     Val(isdefined(xxx.value, :x))
 end == Val{true}
 
+# Test union splitting for MustAlias
+struct GetSomethingA; x::Union{Nothing,Int}; end
+struct GetSomethingB; x::Int; end
+getsomethingx(a::GetSomethingA) = something(a.x, 0)
+getsomethingx(b::GetSomethingB) = b.x
+@test Base.infer_return_type((Union{GetSomethingA,GetSomethingB},); interp=MustAliasInterpreter()) do x
+    getsomethingx(x)
+end == Int
+
 @testset "issue #56913: `BoundsError` in type inference" begin
     R = UnitRange{Int}
     @test Type{AbstractVector} == Base.infer_return_type(Base.promote_typeof, Tuple{R, R, Vector{Any}, Vararg{R}})


### PR DESCRIPTION
`MustAlias` has `has_extended_unionsplit(::MustAliasLattice) === true` so it is treated as a target for union split, but `uniontypes` does not handle `MustAlias` specially, causing union split to fail for `MustAlias`.

This issue is addressed by always applying `uniontypes` to the result of `widenconst(x)`.
External custom lattice implementations could previously provide their own `uniontypes`, but it would be cleaner interface design if they just overload  `widenconst` for their custom lattice elements so that it returns `Union`-type.