### PR TITLE
docs: improve 'See also' in many docstrings

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -9,7 +9,7 @@ Supertype for `N`-dimensional arrays (or array-like types) with elements of type
 [`Array`](@ref) and other types are subtypes of this. See the manual section on the
 [`AbstractArray` interface](@ref man-interface-array).
 
-See also: [`AbstractVector`](@ref), [`AbstractMatrix`](@ref), [`eltype`](@ref), [`ndims`](@ref).
+See also [`AbstractVector`](@ref), [`AbstractMatrix`](@ref), [`eltype`](@ref), [`ndims`](@ref).
 """
 AbstractArray
 
@@ -26,7 +26,7 @@ dimension to just get the length of that dimension.
 Note that `size` may not be defined for arrays with non-standard indices, in which case [`axes`](@ref)
 may be useful. See the manual chapter on [arrays with custom indices](@ref man-custom-indices).
 
-See also: [`length`](@ref), [`ndims`](@ref), [`eachindex`](@ref), [`sizeof`](@ref).
+See also [`length`](@ref), [`ndims`](@ref), [`eachindex`](@ref), [`sizeof`](@ref).
 
 # Examples
 ```jldoctest
@@ -86,7 +86,7 @@ end
 
 Return the tuple of valid indices for array `A`.
 
-See also: [`size`](@ref), [`keys`](@ref), [`eachindex`](@ref).
+See also [`size`](@ref), [`keys`](@ref), [`eachindex`](@ref).
 
 # Examples
 
@@ -229,7 +229,7 @@ For dictionary types, this will be a `Pair{KeyType,ValType}`. The definition
 instead of types. However the form that accepts a type argument should be defined for new
 types.
 
-See also: [`keytype`](@ref), [`typeof`](@ref).
+See also [`keytype`](@ref), [`typeof`](@ref).
 
 # Examples
 ```jldoctest
@@ -265,7 +265,7 @@ elsize(A::AbstractArray) = elsize(typeof(A))
 
 Return the number of dimensions of `A`.
 
-See also: [`size`](@ref), [`axes`](@ref).
+See also [`size`](@ref), [`axes`](@ref).
 
 # Examples
 ```jldoctest
@@ -286,7 +286,7 @@ Return the number of elements in the collection.
 
 Use [`lastindex`](@ref) to get the last valid index of an indexable collection.
 
-See also: [`size`](@ref), [`ndims`](@ref), [`eachindex`](@ref).
+See also [`size`](@ref), [`ndims`](@ref), [`eachindex`](@ref).
 
 # Examples
 ```jldoctest
@@ -415,7 +415,7 @@ Return the last index of `collection`. If `d` is given, return the last index of
 The syntaxes `A[end]` and `A[end, end]` lower to `A[lastindex(A)]` and
 `A[lastindex(A, 1), lastindex(A, 2)]`, respectively.
 
-See also: [`axes`](@ref), [`firstindex`](@ref), [`eachindex`](@ref), [`prevind`](@ref).
+See also [`axes`](@ref), [`firstindex`](@ref), [`eachindex`](@ref), [`prevind`](@ref).
 
 # Examples
 ```jldoctest
@@ -438,7 +438,7 @@ Return the first index of `collection`. If `d` is given, return the first index 
 The syntaxes `A[begin]` and `A[1, begin]` lower to `A[firstindex(A)]` and
 `A[1, firstindex(A, 2)]`, respectively.
 
-See also: [`first`](@ref), [`axes`](@ref), [`lastindex`](@ref), [`nextind`](@ref).
+See also [`first`](@ref), [`axes`](@ref), [`lastindex`](@ref), [`nextind`](@ref).
 
 # Examples
 ```jldoctest
@@ -460,7 +460,7 @@ firstindex(a, d) = (@inline; first(axes(a, d)))
 Get the first element of an iterable collection. Return the start point of an
 [`AbstractRange`](@ref) even if it is empty.
 
-See also: [`only`](@ref), [`firstindex`](@ref), [`last`](@ref).
+See also [`only`](@ref), [`firstindex`](@ref), [`last`](@ref).
 
 # Examples
 ```jldoctest
@@ -483,10 +483,10 @@ end
 Get the first `n` elements of the iterable collection `itr`, or fewer elements if `itr` is not
 long enough.
 
-See also: [`startswith`](@ref), [`Iterators.take`](@ref).
-
 !!! compat "Julia 1.6"
     This method requires at least Julia 1.6.
+
+See also [`startswith`](@ref), [`Iterators.take`](@ref).
 
 # Examples
 ```jldoctest
@@ -564,7 +564,7 @@ end
 
 Return a tuple of the memory strides in each dimension.
 
-See also: [`stride`](@ref).
+See also [`stride`](@ref).
 
 # Examples
 ```jldoctest
@@ -581,7 +581,7 @@ function strides end
 
 Return the distance in memory (in number of elements) between adjacent elements in dimension `k`.
 
-See also: [`strides`](@ref).
+See also [`strides`](@ref).
 
 # Examples
 ```jldoctest
@@ -818,7 +818,7 @@ julia> similar(falses(10), Float64, 2, 4)
  2.18425e-314  2.18425e-314  2.18425e-314  2.18425e-314
 ```
 
-See also: [`undef`](@ref), [`isassigned`](@ref).
+See also [`undef`](@ref), [`isassigned`](@ref).
 """
 similar(a::AbstractArray{T}) where {T}                             = similar(a, T)
 similar(a::AbstractArray, ::Type{T}) where {T}                     = similar(a, T, axes(a))
@@ -881,7 +881,7 @@ similar(::Type{T}, dims::Dims) where {T<:AbstractArray} = T(undef, dims)
 
 Create an empty vector similar to `v`, optionally changing the `eltype`.
 
-See also: [`empty!`](@ref), [`isempty`](@ref), [`isassigned`](@ref).
+See also [`empty!`](@ref), [`isempty`](@ref), [`isassigned`](@ref).
 
 # Examples
 
@@ -3466,7 +3466,7 @@ collection. `destination` must be at least as large as the smallest collection.
 
 $(_DOCS_ALIASING_WARNING)
 
-See also: [`map`](@ref), [`foreach`](@ref), [`zip`](@ref), [`copyto!`](@ref).
+See also [`map`](@ref), [`foreach`](@ref), [`zip`](@ref), [`copyto!`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -59,7 +59,7 @@ result is mutable if and only if `A` is mutable, and setting elements of one
 alters the values of the other.
 
 Inverse of [`insertdims`](@ref).
-See also: [`reshape`](@ref), [`vec`](@ref).
+See also [`reshape`](@ref), [`vec`](@ref).
 
 # Examples
 ```jldoctest
@@ -116,7 +116,7 @@ result is mutable if and only if `A` is mutable, and setting elements of one
 alters the values of the other.
 
 Inverse of [`dropdims`](@ref).
-See also: [`reshape`](@ref), [`vec`](@ref).
+See also [`reshape`](@ref), [`vec`](@ref).
 
 # Examples
 ```jldoctest
@@ -304,7 +304,7 @@ Return a view of all the data of `A` where the index for dimension `d` equals `i
 
 Equivalent to `view(A,:,:,...,i,:,:,...)` where `i` is in position `d`.
 
-See also: [`eachslice`](@ref).
+See also [`eachslice`](@ref).
 
 # Examples
 ```jldoctest
@@ -346,7 +346,7 @@ first dimension.
 The generated code is most efficient when the shift amounts are known at compile-time, i.e.,
 compile-time constants.
 
-See also: [`circshift!`](@ref), [`circcopy!`](@ref), [`bitrotate`](@ref), [`<<`](@ref).
+See also [`circshift!`](@ref), [`circcopy!`](@ref), [`bitrotate`](@ref), [`<<`](@ref).
 
 # Examples
 ```jldoctest
@@ -419,7 +419,7 @@ end
 
 Construct an array by repeating array `A` a given number of times in each dimension, specified by `counts`.
 
-See also: [`fill`](@ref), [`Iterators.repeated`](@ref), [`Iterators.cycle`](@ref).
+See also [`fill`](@ref), [`Iterators.repeated`](@ref), [`Iterators.cycle`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -203,7 +203,7 @@ intersect!(s::AbstractSet, itr) =
 Construct the set of elements in `s` but not in any of the iterables in `itrs`.
 Maintain order with arrays. The result will have the same element type as `s`.
 
-See also [`setdiff!`](@ref), [`union`](@ref) and [`intersect`](@ref).
+See also [`setdiff!`](@ref), [`union`](@ref), [`intersect`](@ref).
 
 # Examples
 ```jldoctest
@@ -259,7 +259,7 @@ end
 Construct the symmetric difference of elements in the passed in sets.
 When `s` is not an `AbstractSet`, the order is maintained.
 
-See also [`symdiff!`](@ref), [`setdiff`](@ref), [`union`](@ref) and [`intersect`](@ref).
+See also [`symdiff!`](@ref), [`setdiff`](@ref), [`union`](@ref), [`intersect`](@ref).
 
 # Examples
 ```jldoctest
@@ -505,7 +505,7 @@ used to implement specialized methods.
 Determine whether `a` and `b` have the same elements. Equivalent
 to `a ⊆ b && b ⊆ a` but more efficient when possible.
 
-See also: [`isdisjoint`](@ref), [`union`](@ref).
+See also [`isdisjoint`](@ref), [`union`](@ref).
 
 # Examples
 ```jldoctest
@@ -553,7 +553,7 @@ issetequal(a) = Fix2(issetequal, a)
 Determine whether the collections `a` and `b` are disjoint.
 Equivalent to `isempty(a ∩ b)` but more efficient when possible.
 
-See also: [`intersect`](@ref), [`isempty`](@ref), [`issetequal`](@ref).
+See also [`intersect`](@ref), [`isempty`](@ref), [`issetequal`](@ref).
 
 !!! compat "Julia 1.5"
     This function requires at least Julia 1.5.

--- a/base/anyall.jl
+++ b/base/anyall.jl
@@ -13,7 +13,7 @@ If the input contains [`missing`](@ref) values, return `missing` if all non-miss
 values are `false` (or equivalently, if the input contains no `true` value), following
 [three-valued logic](https://en.wikipedia.org/wiki/Three-valued_logic).
 
-See also: [`all`](@ref), [`count`](@ref), [`sum`](@ref), [`|`](@ref), [`||`](@ref).
+See also [`all`](@ref), [`count`](@ref), [`sum`](@ref), [`|`](@ref), [`||`](@ref).
 
 # Examples
 ```jldoctest
@@ -51,7 +51,7 @@ If the input contains [`missing`](@ref) values, return `missing` if all non-miss
 values are `true` (or equivalently, if the input contains no `false` value), following
 [three-valued logic](https://en.wikipedia.org/wiki/Three-valued_logic).
 
-See also: [`all!`](@ref), [`any`](@ref), [`count`](@ref), [`&`](@ref), [`&&`](@ref), [`allunique`](@ref).
+See also [`all!`](@ref), [`any`](@ref), [`count`](@ref), [`&`](@ref), [`&&`](@ref), [`allunique`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/array.jl
+++ b/base/array.jl
@@ -540,7 +540,7 @@ julia> v2
  []
 ```
 
-See also: [`fill!`](@ref), [`zeros`](@ref), [`ones`](@ref), [`similar`](@ref).
+See also [`fill!`](@ref), [`zeros`](@ref), [`ones`](@ref), [`similar`](@ref).
 
 # Examples
 ```jldoctest
@@ -1632,7 +1632,7 @@ Remove an item in `collection` and return it. If `collection` is an
 ordered container, the last item is returned; for unordered containers,
 an arbitrary element is returned.
 
-See also: [`popfirst!`](@ref), [`popat!`](@ref), [`delete!`](@ref), [`deleteat!`](@ref), [`splice!`](@ref), and [`push!`](@ref).
+See also [`popfirst!`](@ref), [`popat!`](@ref), [`delete!`](@ref), [`deleteat!`](@ref), [`splice!`](@ref), [`push!`](@ref).
 
 # Examples
 ```jldoctest
@@ -1683,7 +1683,7 @@ are shifted to fill the resulting gap.
 When `i` is not a valid index for `a`, return `default`, or throw an error if
 `default` is not specified.
 
-See also: [`pop!`](@ref), [`popfirst!`](@ref), [`deleteat!`](@ref), [`splice!`](@ref).
+See also [`pop!`](@ref), [`popfirst!`](@ref), [`deleteat!`](@ref), [`splice!`](@ref).
 
 !!! compat "Julia 1.5"
     This function is available as of Julia 1.5.
@@ -1777,7 +1777,7 @@ Remove the first `item` from `collection`.
 
 This function is called `shift` in many other programming languages.
 
-See also: [`pop!`](@ref), [`popat!`](@ref), [`delete!`](@ref).
+See also [`pop!`](@ref), [`popat!`](@ref), [`delete!`](@ref).
 
 # Examples
 ```jldoctest
@@ -1817,7 +1817,7 @@ end
 Insert an `item` into `a` at the given `index`. `index` is the index of `item` in
 the resulting `a`.
 
-See also: [`push!`](@ref), [`replace`](@ref), [`popat!`](@ref), [`splice!`](@ref).
+See also [`push!`](@ref), [`replace`](@ref), [`popat!`](@ref), [`splice!`](@ref).
 
 # Examples
 ```jldoctest
@@ -1852,7 +1852,7 @@ end
 Remove the item at the given `i` and return the modified `a`. Subsequent items
 are shifted to fill the resulting gap.
 
-See also: [`keepat!`](@ref), [`delete!`](@ref), [`popat!`](@ref), [`splice!`](@ref).
+See also [`keepat!`](@ref), [`delete!`](@ref), [`popat!`](@ref), [`splice!`](@ref).
 
 # Examples
 ```jldoctest
@@ -1993,7 +1993,7 @@ Subsequent items are shifted left to fill the resulting gap.
 If specified, replacement values from an ordered
 collection will be spliced in place of the removed item.
 
-See also: [`replace`](@ref), [`delete!`](@ref), [`deleteat!`](@ref), [`pop!`](@ref), [`popat!`](@ref).
+See also [`replace`](@ref), [`delete!`](@ref), [`deleteat!`](@ref), [`pop!`](@ref), [`popat!`](@ref).
 
 # Examples
 ```jldoctest
@@ -2382,7 +2382,7 @@ To search for other kinds of values, pass a predicate as the first argument.
 Indices or keys are of the same type as those returned by [`keys(A)`](@ref)
 and [`pairs(A)`](@ref).
 
-See also: [`findall`](@ref), [`findnext`](@ref), [`findlast`](@ref), [`searchsortedfirst`](@ref).
+See also [`findall`](@ref), [`findnext`](@ref), [`findlast`](@ref), [`searchsortedfirst`](@ref).
 
 # Examples
 ```jldoctest
@@ -2532,7 +2532,7 @@ or `nothing` if not found.
 Indices are of the same type as those returned by [`keys(A)`](@ref)
 and [`pairs(A)`](@ref).
 
-See also: [`findnext`](@ref), [`findfirst`](@ref), [`findall`](@ref).
+See also [`findnext`](@ref), [`findfirst`](@ref), [`findall`](@ref).
 
 # Examples
 ```jldoctest
@@ -2568,7 +2568,7 @@ Return `nothing` if there is no `true` value in `A`.
 Indices or keys are of the same type as those returned by [`keys(A)`](@ref)
 and [`pairs(A)`](@ref).
 
-See also: [`findfirst`](@ref), [`findprev`](@ref), [`findall`](@ref).
+See also [`findfirst`](@ref), [`findprev`](@ref), [`findall`](@ref).
 
 # Examples
 ```jldoctest
@@ -2774,7 +2774,7 @@ To search for other kinds of values, pass a predicate as the first argument.
 Indices or keys are of the same type as those returned by [`keys(A)`](@ref)
 and [`pairs(A)`](@ref).
 
-See also: [`findfirst`](@ref), [`searchsorted`](@ref).
+See also [`findfirst`](@ref), [`searchsorted`](@ref).
 
 # Examples
 ```jldoctest
@@ -2834,7 +2834,7 @@ Return an array containing the first index in `b` for
 each value in `a` that is a member of `b`. The output
 array contains `nothing` wherever `a` is not a member of `b`.
 
-See also: [`sortperm`](@ref), [`findfirst`](@ref).
+See also [`sortperm`](@ref), [`findfirst`](@ref).
 
 # Examples
 ```jldoctest
@@ -2970,7 +2970,7 @@ The function `f` is passed one argument.
 !!! compat "Julia 1.4"
     Support for `a` as a tuple requires at least Julia 1.4.
 
-See also: [`filter!`](@ref), [`Iterators.filter`](@ref).
+See also [`filter!`](@ref), [`Iterators.filter`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -213,7 +213,7 @@ isopen(t::Union{Timer, AsyncCondition}) = @atomic :acquire t.isopen
 Close an object `t` and thus mark it as inactive. Once a timer or condition is inactive, it will not produce
 a new event.
 
-See also: [`isopen`](@ref)
+See also [`isopen`](@ref).
 """
 function close(t::Union{Timer, AsyncCondition})
     t.handle == C_NULL && !t.isopen && return # short-circuit path, :monotonic

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -8,7 +8,7 @@ Complex number type with real and imaginary part of type `T`.
 `ComplexF16`, `ComplexF32` and `ComplexF64` are aliases for
 `Complex{Float16}`, `Complex{Float32}` and `Complex{Float64}` respectively.
 
-See also: [`Real`](@ref), [`complex`](@ref), [`real`](@ref).
+See also [`Real`](@ref), [`complex`](@ref), [`real`](@ref).
 """
 struct Complex{T<:Real} <: Number
     re::T
@@ -22,7 +22,7 @@ Complex(x::Real) = Complex(x, zero(x))
 
 The imaginary unit.
 
-See also: [`imag`](@ref), [`angle`](@ref), [`complex`](@ref).
+See also [`imag`](@ref), [`angle`](@ref), [`complex`](@ref).
 
 # Examples
 ```jldoctest
@@ -61,7 +61,7 @@ float(::Type{Complex{T}}) where {T} = Complex{float(T)}
 
 Return the real part of the complex number `z`.
 
-See also: [`imag`](@ref), [`reim`](@ref), [`complex`](@ref), [`isreal`](@ref), [`Real`](@ref).
+See also [`imag`](@ref), [`reim`](@ref), [`complex`](@ref), [`isreal`](@ref), [`Real`](@ref).
 
 # Examples
 ```jldoctest
@@ -76,7 +76,7 @@ real(z::Complex) = z.re
 
 Return the imaginary part of the complex number `z`.
 
-See also: [`conj`](@ref), [`reim`](@ref), [`adjoint`](@ref), [`angle`](@ref).
+See also [`conj`](@ref), [`reim`](@ref), [`adjoint`](@ref), [`angle`](@ref).
 
 # Examples
 ```jldoctest
@@ -265,7 +265,7 @@ end
 
 Compute the complex conjugate of a complex number `z`.
 
-See also: [`angle`](@ref), [`adjoint`](@ref).
+See also [`angle`](@ref), [`adjoint`](@ref).
 
 # Examples
 ```jldoctest
@@ -621,7 +621,7 @@ Compute the phase angle in radians of a complex number `z`.
 Returns a number `-pi ≤ angle(z) ≤ pi`, and is thus discontinuous
 along the negative real axis.
 
-See also: [`atan`](@ref), [`cis`](@ref), [`rad2deg`](@ref).
+See also [`atan`](@ref), [`cis`](@ref), [`rad2deg`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -540,7 +540,7 @@ end
 
 Return whether the binding of a symbol in a module is resolved.
 
-See also: [`isexported`](@ref), [`ispublic`](@ref), [`isdeprecated`](@ref)
+See also [`isexported`](@ref), [`ispublic`](@ref), [`isdeprecated`](@ref).
 
 ```jldoctest
 julia> module Mod

--- a/base/div.jl
+++ b/base/div.jl
@@ -182,7 +182,7 @@ The quotient and remainder from Euclidean division.
 Equivalent to `(div(x, y, r), rem(x, y, r))`. Equivalently, with the default
 value of `r`, this call is equivalent to `(x ÷ y, x % y)`.
 
-See also: [`fldmod`](@ref), [`cld`](@ref).
+See also [`fldmod`](@ref), [`cld`](@ref).
 
 # Examples
 ```jldoctest
@@ -286,7 +286,7 @@ end
 The floored quotient and modulus after division. A convenience wrapper for
 `divrem(x, y, RoundDown)`. Equivalent to `(fld(x, y), mod(x, y))`.
 
-See also: [`fld`](@ref), [`cld`](@ref), [`fldmod1`](@ref).
+See also [`fld`](@ref), [`cld`](@ref), [`fldmod1`](@ref).
 """
 fldmod(x, y) = divrem(x, y, RoundDown)
 

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -879,7 +879,7 @@ Return a sorted vector of undocumented symbols in `module` (that is, lacking doc
 `export`, whereas `private=true` returns all symbols in the module (excluding
 compiler-generated hidden symbols starting with `#`).
 
-See also: [`names`](@ref), [`Docs.hasdoc`](@ref), [`Base.ispublic`](@ref).
+See also [`names`](@ref), [`Docs.hasdoc`](@ref), [`Base.ispublic`](@ref).
 """
 function undocumented_names(mod::Module; private::Bool=false)
     filter!(names(mod; all=true)) do sym

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -161,7 +161,7 @@ runtime initialization functions of external C libraries and initializing global
 that involve pointers returned by external libraries.
 See the [manual section about modules](@ref modules) for more details.
 
-See also: [`OncePerProcess`](@ref).
+See also [`OncePerProcess`](@ref).
 
 # Examples
 ```julia
@@ -338,7 +338,6 @@ Reuse an existing local variable for iteration in a `for` loop.
 See the [manual section on variable scoping](@ref scope-of-variables) for more information.
 
 See also [`for`](@ref).
-
 
 # Examples
 ```jldoctest
@@ -744,7 +743,7 @@ Quote an expression `expr`, returning the abstract syntax tree (AST) of `expr`.
 The AST may be of type `Expr`, `Symbol`, or a literal value.
 The syntax `:identifier` evaluates to a `Symbol`.
 
-See also: [`Expr`](@ref), [`Symbol`](@ref), [`Meta.parse`](@ref)
+See also [`Expr`](@ref), [`Symbol`](@ref), [`Meta.parse`](@ref).
 
 # Examples
 ```jldoctest
@@ -1389,7 +1388,7 @@ Note that if `y` is an expression, it is only evaluated when `x` is `false`, whi
 Also, `y` does not need to have a boolean value.  This means that `(condition) || (statement)` can be used as shorthand for
 `if !(condition); statement; end` for an arbitrary `statement`.
 
-See also: [`|`](@ref), [`xor`](@ref), [`&&`](@ref).
+See also [`|`](@ref), [`xor`](@ref), [`&&`](@ref).
 
 # Examples
 ```jldoctest
@@ -1637,7 +1636,7 @@ devnull
 
 A type with no fields that is the type of [`nothing`](@ref).
 
-See also: [`isnothing`](@ref), [`Some`](@ref), [`Missing`](@ref).
+See also [`isnothing`](@ref), [`Some`](@ref), [`Missing`](@ref).
 """
 Nothing
 
@@ -1649,7 +1648,7 @@ The singleton instance of type [`Nothing`](@ref), used by convention when there 
 
 A return value of `nothing` is not displayed by the REPL and similar interactive environments.
 
-See also: [`isnothing`](@ref), [`something`](@ref), [`missing`](@ref).
+See also [`isnothing`](@ref), [`something`](@ref), [`missing`](@ref).
 """
 nothing
 
@@ -2495,7 +2494,7 @@ Otherwise, if not declared as `@atomic`, this parameter must be `:not_atomic` if
 The bounds check may be disabled, in which case the behavior of this function is
 undefined if `i` is out of bounds.
 
-See also [`getproperty`](@ref Base.getproperty) and [`fieldnames`](@ref).
+See also [`getproperty`](@ref Base.getproperty), [`fieldnames`](@ref).
 
 # Examples
 ```jldoctest
@@ -2523,6 +2522,7 @@ mutable and `x` must be a subtype of `fieldtype(typeof(value), name)`.
 Additionally, an ordering can be specified for this operation. If the field was
 declared `@atomic`, this specification is mandatory. Otherwise, if not declared
 as `@atomic`, it must be `:not_atomic` if specified.
+
 See also [`setproperty!`](@ref Base.setproperty!).
 
 # Examples
@@ -2579,6 +2579,9 @@ optimized to the appropriate hardware instruction, otherwise it'll use a loop.
 
 !!! compat "Julia 1.7"
     This function requires Julia 1.7 or later.
+
+See also [`modifyproperty!`](@ref Base.modifyproperty!),
+[`setfield!`](@ref Base.setfield!).
 """
 modifyfield!
 
@@ -2603,6 +2606,10 @@ instruction, otherwise it'll use a loop.
 
 !!! compat "Julia 1.7"
     This function requires Julia 1.7 or later.
+
+See also [`replaceproperty!`](@ref Base.replaceproperty!),
+[`setfield!`](@ref Base.setfield!),
+[`setfieldonce!`](@ref Base.setfieldonce!).
 """
 replacefield!
 
@@ -2621,6 +2628,10 @@ a given value, only if it was previously not set.
 
 !!! compat "Julia 1.11"
     This function requires Julia 1.11 or later.
+
+See also [`setpropertyonce!`](@ref Base.setpropertyonce!),
+[`setfield!`](@ref Base.setfield!),
+[`replacefield!`](@ref Base.replacefield!).
 """
 setfieldonce!
 
@@ -2644,7 +2655,7 @@ Most users should not have to call this function directly -- The
 !!! compat "Julia 1.9"
     This function requires Julia 1.9 or later.
 
-See also [`getproperty`](@ref Base.getproperty) and [`setglobal!`](@ref).
+See also [`getproperty`](@ref Base.getproperty), [`setglobal!`](@ref).
 
 # Examples
 ```jldoctest
@@ -2683,7 +2694,7 @@ cases.
 !!! compat "Julia 1.9"
     This function requires Julia 1.9 or later.
 
-See also [`setproperty!`](@ref Base.setproperty!) and [`getglobal`](@ref)
+See also [`setproperty!`](@ref Base.setproperty!), [`getglobal`](@ref)
 
 # Examples
 ```jldoctest; filter = r"Stacktrace:(\\n \\[[0-9]+\\].*\\n.*)*"
@@ -2725,7 +2736,7 @@ Atomically perform the operations to simultaneously get and set a global.
 !!! compat "Julia 1.11"
     This function requires Julia 1.11 or later.
 
-See also [`swapproperty!`](@ref Base.swapproperty!) and [`setglobal!`](@ref).
+See also [`swapproperty!`](@ref Base.swapproperty!), [`setglobal!`](@ref).
 """
 swapglobal!
 
@@ -2738,7 +2749,7 @@ the function `op`.
 !!! compat "Julia 1.11"
     This function requires Julia 1.11 or later.
 
-See also [`modifyproperty!`](@ref Base.modifyproperty!) and [`setglobal!`](@ref).
+See also [`modifyproperty!`](@ref Base.modifyproperty!), [`setglobal!`](@ref).
 """
 modifyglobal!
 
@@ -2752,7 +2763,7 @@ a given value.
 !!! compat "Julia 1.11"
     This function requires Julia 1.11 or later.
 
-See also [`replaceproperty!`](@ref Base.replaceproperty!) and [`setglobal!`](@ref).
+See also [`replaceproperty!`](@ref Base.replaceproperty!), [`setglobal!`](@ref).
 """
 replaceglobal!
 
@@ -2766,7 +2777,7 @@ a given value, only if it was previously not set.
 !!! compat "Julia 1.11"
     This function requires Julia 1.11 or later.
 
-See also [`setpropertyonce!`](@ref Base.setpropertyonce!) and [`setglobal!`](@ref).
+See also [`setpropertyonce!`](@ref Base.setpropertyonce!), [`setglobal!`](@ref).
 """
 setglobalonce!
 
@@ -3162,8 +3173,9 @@ Array{T,N}(::Missing, dims)
     UndefInitializer
 
 Singleton type used in array initialization, indicating the array-constructor-caller
-would like an uninitialized array. See also [`undef`](@ref),
-an alias for `UndefInitializer()`.
+would like an uninitialized array.
+
+See also [`undef`](@ref), an alias for `UndefInitializer()`.
 
 # Examples
 ```julia-repl
@@ -3183,7 +3195,7 @@ Alias for `UndefInitializer()`, which constructs an instance of the singleton ty
 [`UndefInitializer`](@ref), used in array initialization to indicate the
 array-constructor-caller would like an uninitialized array.
 
-See also: [`missing`](@ref), [`similar`](@ref).
+See also [`missing`](@ref), [`similar`](@ref).
 
 # Examples
 ```julia-repl
@@ -3238,7 +3250,7 @@ true
 
 Unary minus operator.
 
-See also: [`abs`](@ref), [`flipsign`](@ref).
+See also [`abs`](@ref), [`flipsign`](@ref).
 
 # Examples
 ```jldoctest
@@ -3678,7 +3690,7 @@ Also note that using methods is often preferable. See also this style guide docu
 for more information: [Prefer exported methods over direct field access](@ref).
 
 See also [`getfield`](@ref Core.getfield),
-[`propertynames`](@ref Base.propertynames) and
+[`propertynames`](@ref Base.propertynames),
 [`setproperty!`](@ref Base.setproperty!).
 """
 Base.getproperty
@@ -3691,12 +3703,12 @@ The syntax `a.b = c` calls `setproperty!(a, :b, c)`.
 The syntax `@atomic order a.b = c` calls `setproperty!(a, :b, c, :order)`
 and the syntax `@atomic a.b = c` calls `setproperty!(a, :b, c, :sequentially_consistent)`.
 
+See also [`setfield!`](@ref Core.setfield!),
+[`propertynames`](@ref Base.propertynames),
+[`getproperty`](@ref Base.getproperty).
+
 !!! compat "Julia 1.8"
     `setproperty!` on modules requires at least Julia 1.8.
-
-See also [`setfield!`](@ref Core.setfield!),
-[`propertynames`](@ref Base.propertynames) and
-[`getproperty`](@ref Base.getproperty).
 """
 Base.setproperty!
 
@@ -3706,8 +3718,8 @@ Base.setproperty!
 The syntax `@atomic a.b, _ = c, a.b` returns `(c, swapproperty!(a, :b, c, :sequentially_consistent))`,
 where there must be one `getproperty` expression common to both sides.
 
-See also [`swapfield!`](@ref Core.swapfield!)
-and [`setproperty!`](@ref Base.setproperty!).
+See also [`swapfield!`](@ref Core.swapfield!),
+[`setproperty!`](@ref Base.setproperty!).
 """
 Base.swapproperty!
 
@@ -3723,8 +3735,8 @@ Invocation of `op(getproperty(x, f), v)` must return a value that can be stored 
 [`setproperty!`](@ref Base.setproperty!), the `convert` function is not called
 automatically.
 
-See also [`modifyfield!`](@ref Core.modifyfield!)
-and [`setproperty!`](@ref Base.setproperty!).
+See also [`modifyfield!`](@ref Core.modifyfield!),
+[`setproperty!`](@ref Base.setproperty!).
 """
 Base.modifyproperty!
 
@@ -3735,7 +3747,7 @@ Perform a compare-and-swap operation on `x.f` from `expected` to `desired`, per
 egal. The syntax `@atomicreplace x.f expected => desired` can be used instead
 of the function call form.
 
-See also [`replacefield!`](@ref Core.replacefield!)
+See also [`replacefield!`](@ref Core.replacefield!),
 [`setproperty!`](@ref Base.setproperty!),
 [`setpropertyonce!`](@ref Base.setpropertyonce!).
 """
@@ -3747,12 +3759,12 @@ Base.replaceproperty!
 Perform a compare-and-swap operation on `x.f` to set it to `value` if previously unset.
 The syntax `@atomiconce x.f = value` can be used instead of the function call form.
 
-See also [`setfieldonce!`](@ref Core.replacefield!),
-[`setproperty!`](@ref Base.setproperty!),
-[`replaceproperty!`](@ref Base.replaceproperty!).
-
 !!! compat "Julia 1.11"
     This function requires Julia 1.11 or later.
+
+See also [`setfieldonce!`](@ref Core.setfieldonce!),
+[`setproperty!`](@ref Base.setproperty!),
+[`replaceproperty!`](@ref Base.replaceproperty!).
 """
 Base.setpropertyonce!
 
@@ -3890,7 +3902,7 @@ Unsafe pointer operations are compatible with loading and storing pointers decla
 `_Atomic` and `std::atomic` type in C11 and C++23 respectively. An error may be thrown if
 there is not support for atomically loading the Julia type `T`.
 
-See also: [`unsafe_load`](@ref), [`unsafe_modify!`](@ref), [`unsafe_replace!`](@ref), [`unsafe_store!`](@ref), [`unsafe_swap!`](@ref)
+See also [`unsafe_load`](@ref), [`unsafe_modify!`](@ref), [`unsafe_replace!`](@ref), [`unsafe_store!`](@ref), [`unsafe_swap!`](@ref)
 """
 kw"atomic"
 

--- a/base/docs/intrinsicsdocs.jl
+++ b/base/docs/intrinsicsdocs.jl
@@ -94,7 +94,7 @@ Atomically perform the operations to simultaneously get and set a `MemoryRef` va
 !!! compat "Julia 1.11"
     This function requires Julia 1.11 or later.
 
-See also [`swapproperty!`](@ref Base.swapproperty!) and [`Core.memoryrefset!`](@ref).
+See also [`swapproperty!`](@ref Base.swapproperty!), [`Core.memoryrefset!`](@ref).
 """
 Core.memoryrefswap!
 
@@ -107,7 +107,7 @@ the function `op`.
 !!! compat "Julia 1.11"
     This function requires Julia 1.11 or later.
 
-See also [`modifyproperty!`](@ref Base.modifyproperty!) and [`Core.memoryrefset!`](@ref).
+See also [`modifyproperty!`](@ref Base.modifyproperty!), [`Core.memoryrefset!`](@ref).
 """
 Core.memoryrefmodify!
 
@@ -120,7 +120,7 @@ Atomically perform the operations to get and conditionally set a `MemoryRef` val
 !!! compat "Julia 1.11"
     This function requires Julia 1.11 or later.
 
-See also [`replaceproperty!`](@ref Base.replaceproperty!) and [`Core.memoryrefset!`](@ref).
+See also [`replaceproperty!`](@ref Base.replaceproperty!), [`Core.memoryrefset!`](@ref).
 """
 Core.memoryrefreplace!
 
@@ -134,7 +134,7 @@ a given value, only if it was previously not set.
 !!! compat "Julia 1.11"
     This function requires Julia 1.11 or later.
 
-See also [`setpropertyonce!`](@ref Base.replaceproperty!) and [`Core.memoryrefset!`](@ref).
+See also [`setpropertyonce!`](@ref Base.replaceproperty!), [`Core.memoryrefset!`](@ref).
 """
 Core.memoryrefsetonce!
 

--- a/base/error.jl
+++ b/base/error.jl
@@ -21,7 +21,7 @@
 
 Throw an object as an exception.
 
-See also: [`rethrow`](@ref), [`error`](@ref).
+See also [`rethrow`](@ref), [`error`](@ref).
 """
 throw
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -459,7 +459,7 @@ julia> y === x
 true
 ```
 
-See also: [`round`](@ref), [`trunc`](@ref), [`oftype`](@ref), [`reinterpret`](@ref).
+See also [`round`](@ref), [`trunc`](@ref), [`oftype`](@ref), [`reinterpret`](@ref).
 """
 function convert end
 
@@ -520,7 +520,7 @@ argtail(_, rest...) = rest
 
 Return a `Tuple` consisting of all but the first component of `x`.
 
-See also: [`front`](@ref Base.front), [`rest`](@ref Base.rest), [`first`](@ref), [`Iterators.peel`](@ref).
+See also [`front`](@ref Base.front), [`rest`](@ref Base.rest), [`first`](@ref), [`Iterators.peel`](@ref).
 
 # Examples
 ```jldoctest
@@ -950,7 +950,7 @@ The block evaluates to `value` if a `break` statement is executed, otherwise it 
 the result of `expr`. Use `@label _ expr` for anonymous blocks (break with `break _`) or
 `@label name expr` for named blocks (break with `break name`).
 
-# Example
+# Examples
 ```julia
 result = @label myblock begin
     for i in 1:10
@@ -1188,7 +1188,7 @@ values(itr) = itr
 A type with no fields whose singleton instance [`missing`](@ref) is used
 to represent missing values.
 
-See also: [`skipmissing`](@ref), [`nonmissingtype`](@ref), [`Nothing`](@ref).
+See also [`skipmissing`](@ref), [`nonmissingtype`](@ref), [`Nothing`](@ref).
 """
 struct Missing end
 
@@ -1197,7 +1197,7 @@ struct Missing end
 
 The singleton instance of type [`Missing`](@ref) representing a missing value.
 
-See also: [`NaN`](@ref), [`skipmissing`](@ref), [`nonmissingtype`](@ref).
+See also [`NaN`](@ref), [`skipmissing`](@ref), [`nonmissingtype`](@ref).
 """
 const missing = Missing()
 
@@ -1206,7 +1206,7 @@ const missing = Missing()
 
 Indicate whether `x` is [`missing`](@ref).
 
-See also: [`skipmissing`](@ref), [`isnothing`](@ref), [`isnan`](@ref).
+See also [`skipmissing`](@ref), [`isnothing`](@ref), [`isnan`](@ref).
 """
 ismissing(x) = x === missing
 
@@ -1302,7 +1302,10 @@ is newer than the world currently running.
 The `@world` macro is primarily used in the printing of bindings that are no longer
 available in the current world.
 
-## Example
+!!! compat "Julia 1.12"
+    This functionality requires at least Julia 1.12.
+
+# Examples
 ```julia-repl
 julia> struct Foo; a::Int; end
 Foo
@@ -1318,9 +1321,6 @@ Foo
 julia> fold
 @world(Foo, 26866)(1)
 ```
-
-!!! compat "Julia 1.12"
-    This functionality requires at least Julia 1.12.
 """
 macro world(sym, world)
     if world == :∞

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -27,7 +27,7 @@ That is, `maxintfloat` returns the smallest positive integer-valued floating-poi
 
 When an `Integer`-type value is needed, use `Integer(maxintfloat(T))`.
 
-See also: [`typemax`](@ref), [`floatmax`](@ref).
+See also [`typemax`](@ref), [`floatmax`](@ref).
 """
 maxintfloat(::Type{Float64}) = 9007199254740992.
 maxintfloat(::Type{Float32}) = Float32(16777216.)

--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -35,7 +35,7 @@ julia> hash(10, a) # only use the output of another hash function as the second 
 0x03158cd61b1b0bd1
 ```
 
-See also: [`objectid`](@ref), [`Dict`](@ref), [`Set`](@ref).
+See also [`objectid`](@ref), [`Dict`](@ref), [`Set`](@ref).
 """
 hash(data::Any) = hash(data, HASH_SEED)
 hash(w::WeakRef, h::UInt) = hash(w.value, h)

--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -325,16 +325,16 @@ Helper type for lazily constructed library paths for use with [`LazyLibrary`](@r
 Path pieces are stored unevaluated and joined with `joinpath()` when the library is first
 accessed. Arguments must be able to have `string()` called on them.
 
-# Example
-
-```julia
-const mylib = LazyLibrary(LazyLibraryPath(artifact_dir, "lib", "libmylib.so.1.2.3"))
-```
-
 !!! compat "Julia 1.11"
     `LazyLibraryPath` was added in Julia 1.11.
 
 See also [`LazyLibrary`](@ref), [`BundledLazyLibraryPath`](@ref).
+
+# Examples
+
+```julia
+const mylib = LazyLibrary(LazyLibraryPath(artifact_dir, "lib", "libmylib.so.1.2.3"))
+```
 """
 struct LazyLibraryPath
     pieces::Tuple{Vararg{Any}}
@@ -403,6 +403,12 @@ tasks block until loading completes. The handle is then cached and reused for al
 calls (there is no dlclose for lazy library and dlclose should not be called on the returned
 handled).
 
+!!! compat "Julia 1.11"
+    `LazyLibrary` was added in Julia 1.11.
+
+See also [`LazyLibraryPath`](@ref), [`BundledLazyLibraryPath`](@ref), [`dlopen`](@ref),
+[`dlsym`](@ref), [`add_dependency!`](@ref).
+
 # Examples
 
 ```julia
@@ -418,12 +424,6 @@ const libbar = LazyLibrary("libbar"; dependencies=[libfoo])
 For more examples including platform-specific libraries, lazy path construction, and
 migration from `__init__()` patterns, see the manual section on
 [Using LazyLibrary for Lazy Loading](@ref man-lazylibrary).
-
-!!! compat "Julia 1.11"
-    `LazyLibrary` was added in Julia 1.11.
-
-See also [`LazyLibraryPath`](@ref), [`BundledLazyLibraryPath`](@ref), [`dlopen`](@ref),
-[`dlsym`](@ref), [`add_dependency!`](@ref).
 """
 mutable struct LazyLibrary
     # Name and flags to open with

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -324,10 +324,10 @@ available.
 When this function returns, the `lock` has been released, so the caller should
 not attempt to `unlock` it.
 
-See also: [`@lock`](@ref).
-
 !!! compat "Julia 1.7"
     Using a [`Channel`](@ref) as the second argument requires Julia 1.7 or later.
+
+See also [`@lock`](@ref).
 """
 function lock(f, l::AbstractLock)
     lock(l)
@@ -409,7 +409,7 @@ holding the lock.
 !!! compat "Julia 1.11"
     Requires at least Julia 1.11.
 
-## Example
+# Examples
 
 ```jldoctest
 julia> locked_list = Base.Lockable(Int[]);
@@ -707,7 +707,7 @@ which won't get serialized.
 !!! compat "Julia 1.12"
     This type requires Julia 1.12 or later.
 
-## Example
+# Examples
 
 ```jldoctest
 julia> const global_state = Base.OncePerProcess{Vector{UInt32}}() do
@@ -815,12 +815,12 @@ if that behavior is correct within your library's threading-safety design.
     may get deprecated in the future. If initializer yields, the thread running the current
     task after the call might not be the same as the one at the start of the call.
 
-See also: [`OncePerTask`](@ref).
-
 !!! compat "Julia 1.12"
     This type requires Julia 1.12 or later.
 
-## Example
+See also [`OncePerTask`](@ref).
+
+# Examples
 
 ```jldoctest
 julia> const thread_state = Base.OncePerThread{Vector{UInt32}}() do
@@ -952,12 +952,12 @@ end
 Calling a `OncePerTask` object returns a value of type `T` by running the function `initializer`
 exactly once per Task. All future calls in the same Task will return exactly the same value.
 
-See also: [`task_local_storage`](@ref).
-
 !!! compat "Julia 1.12"
     This type requires Julia 1.12 or later.
 
-## Example
+See also [`task_local_storage`](@ref).
+
+# Examples
 
 ```jldoctest
 julia> const task_state = Base.OncePerTask{Vector{UInt32}}() do

--- a/base/math.jl
+++ b/base/math.jl
@@ -85,6 +85,8 @@ a Goertzel-like [^DK62] algorithm if `x` is complex.
 !!! compat "Julia 1.4"
     This function requires Julia 1.4 or later.
 
+See also [`@evalpoly`](@ref).
+
 # Examples
 ```jldoctest
 julia> evalpoly(2, (1, 2, 3))
@@ -254,7 +256,7 @@ end
 
 Convert `x` from radians to degrees.
 
-See also [`deg2rad`](@ref).
+See also [`deg2rad`](@ref), [`pi`](@ref).
 
 # Examples
 ```jldoctest
@@ -269,7 +271,7 @@ rad2deg(z::AbstractFloat) = z * _180_over_pi(z)
 
 Convert `x` from degrees to radians.
 
-See also [`rad2deg`](@ref), [`sind`](@ref), [`pi`](@ref).
+See also [`rad2deg`](@ref), [`pi`](@ref).
 
 # Examples
 ```jldoctest
@@ -290,6 +292,8 @@ log(b::T, x::T) where {T<:Number} = log(x)/log(b)
 
 Compute the base `b` logarithm of `x`. Throw a [`DomainError`](@ref) for negative
 [`Real`](@ref) arguments.
+
+See also [`log2`](@ref), [`log10`](@ref).
 
 # Examples
 ```jldoctest; filter = r"Stacktrace:(\\n \\[[0-9]+\\].*)*"
@@ -335,7 +339,7 @@ const libm = Base.libm_name
 
 Compute hyperbolic sine of `x`.
 
-See also [`sin`](@ref).
+See also [`sin`](@ref), [`asinh`](@ref).
 """
 sinh(x::Number)
 
@@ -344,7 +348,7 @@ sinh(x::Number)
 
 Compute hyperbolic cosine of `x`.
 
-See also [`cos`](@ref).
+See also [`cos`](@ref), [`acosh`](@ref).
 """
 cosh(x::Number)
 
@@ -412,6 +416,8 @@ atan(x::Number)
     asinh(x)
 
 Compute the inverse hyperbolic sine of `x`.
+
+See also [`sinh`](@ref), [`asin`](@ref).
 """
 asinh(x::Number)
 
@@ -462,7 +468,7 @@ Compute cosine of `x`, where `x` is in radians.
 
 Throw a [`DomainError`](@ref) if `isinf(x)`, return a `T(NaN)` if `isnan(x)`.
 
-See also [`cosd`](@ref), [`cospi`](@ref), [`sincos`](@ref), [`cis`](@ref).
+See also [`cosd`](@ref), [`cospi`](@ref), [`sincos`](@ref), [`cis`](@ref), [`acos`](@ref).
 """
 cos(x::Number)
 
@@ -503,6 +509,8 @@ asin(x::Number)
 Compute the inverse cosine of `x`, where the output is in radians.
 
 Return a `T(NaN)` if `isnan(x)`.
+
+See also [`acosd`](@ref) for output in degrees.
 """
 acos(x::Number)
 
@@ -510,6 +518,8 @@ acos(x::Number)
     acosh(x)
 
 Compute the inverse hyperbolic cosine of `x`.
+
+See also [`cosh`](@ref), [`acos`](@ref).
 """
 acosh(x::Number)
 
@@ -517,6 +527,8 @@ acosh(x::Number)
     atanh(x)
 
 Compute the inverse hyperbolic tangent of `x`.
+
+See also [`tanh`](@ref), [`tanh`](@ref).
 """
 atanh(x::Number)
 
@@ -532,7 +544,7 @@ Use [`Complex`](@ref) arguments to obtain [`Complex`](@ref) results.
     `log` has a branch cut along the negative real axis; `-0.0im` is taken
     to be below the axis.
 
-See also [`ℯ`](@ref), [`log1p`](@ref), [`log2`](@ref), [`log10`](@ref).
+See also [`ℯ`](@ref), [`exp`](@ref), [`log1p`](@ref), [`log2`](@ref), [`log10`](@ref).
 
 # Examples
 ```jldoctest; filter = r"Stacktrace:(\\n \\[[0-9]+\\].*)*"
@@ -567,7 +579,7 @@ log(x::Number)
 Compute the logarithm of `x` to base 2. Throw a [`DomainError`](@ref) for negative
 [`Real`](@ref) arguments.
 
-See also: [`exp2`](@ref), [`ldexp`](@ref), [`ispow2`](@ref).
+See also: [`exp2`](@ref), [`log`](@ref), [`ldexp`](@ref), [`ispow2`](@ref).
 
 # Examples
 ```jldoctest; filter = r"Stacktrace:(\\n \\[[0-9]+\\].*)*"
@@ -598,6 +610,8 @@ log2(x)
 
 Compute the logarithm of `x` to base 10.
 Throw a [`DomainError`](@ref) for negative [`Real`](@ref) arguments.
+
+See also: [`exp10`](@ref), [`log`](@ref).
 
 # Examples
 ```jldoctest; filter = r"Stacktrace:(\\n \\[[0-9]+\\].*)*"
@@ -660,7 +674,7 @@ The prefix operator `√` is equivalent to `sqrt`.
     `sqrt` has a branch cut along the negative real axis; `-0.0im` is taken
     to be below the axis.
 
-See also: [`hypot`](@ref).
+See also [`cbrt`](@ref), [`fourthroot`](@ref), [`hypot`](@ref).
 
 # Examples
 ```jldoctest; filter = r"Stacktrace:(\\n \\[[0-9]+\\].*)*"
@@ -693,7 +707,9 @@ sqrt(x)
 """
     fourthroot(x)
 
-Return the fourth root of `x` by applying `sqrt` twice successively.
+Return the fourth root of `x`.
+
+See also [`cbrt`](@ref), [`sqrt`](@ref).
 """
 fourthroot(x::Number) = sqrt(sqrt(x))
 

--- a/base/number.jl
+++ b/base/number.jl
@@ -11,6 +11,8 @@ convert(::Type{T}, x::Number) where {T<:Number} = T(x)::T
 
 Test whether `x` is numerically equal to some integer.
 
+See also [`iszero`](@ref), [`isone`](@ref), [`isfinite`](@ref), [`isnan`](@ref).
+
 # Examples
 ```jldoctest
 julia> isinteger(4.0)
@@ -25,7 +27,7 @@ isinteger(x::Integer) = true
 Return `true` if `x == zero(x)`; if `x` is an array, this checks whether
 all of the elements of `x` are zero.
 
-See also: [`isone`](@ref), [`isinteger`](@ref), [`isfinite`](@ref), [`isnan`](@ref).
+See also [`isone`](@ref), [`isinteger`](@ref), [`isfinite`](@ref), [`isnan`](@ref).
 
 # Examples
 ```jldoctest
@@ -47,6 +49,8 @@ iszero(x) = x == zero(x) # fallback method
 Return `true` if `x == one(x)`; if `x` is an array, this checks whether
 `x` is an identity matrix.
 
+See also [`iszero`](@ref), [`isinteger`](@ref), [`isfinite`](@ref), [`isnan`](@ref).
+
 # Examples
 ```jldoctest
 julia> isone(1.0)
@@ -65,6 +69,8 @@ isone(x) = x == one(x) # fallback method
     isfinite(f)::Bool
 
 Test whether a number is finite.
+
+See also [`iszero`](@ref), [`isone`](@ref), [`isinteger`](@ref), [`isnan`](@ref).
 
 # Examples
 ```jldoctest
@@ -117,7 +123,7 @@ copy(x::Number) = x # some code treats numbers as collection-like
 
 Return `true` if the value of the sign of `x` is negative, otherwise `false`.
 
-See also [`sign`](@ref) and [`copysign`](@ref).
+See also [`sign`](@ref), [`copysign`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -573,7 +573,7 @@ minmax(x,y) = isless(y, x) ? (y, x) : (x, y)
 
 The identity function. Returns its argument.
 
-See also: [`one`](@ref), [`oneunit`](@ref), and [`LinearAlgebra`](@ref man-linalg)'s `I`.
+See also [`one`](@ref), [`oneunit`](@ref), [`LinearAlgebra.I`](@ref).
 
 # Examples
 ```jldoctest
@@ -816,7 +816,7 @@ end
 Remainder from Euclidean division, returning a value of the same sign as `x`, and smaller in
 magnitude than `y`. This value is always exact.
 
-See also: [`div`](@ref), [`mod`](@ref), [`mod1`](@ref), [`divrem`](@ref).
+See also [`div`](@ref), [`mod`](@ref), [`mod1`](@ref), [`divrem`](@ref).
 
 # Examples
 ```jldoctest
@@ -843,7 +843,7 @@ const % = rem
 The quotient from Euclidean (integer) division. Generally equivalent
 to a mathematical operation x/y without a fractional part.
 
-See also: [`cld`](@ref), [`fld`](@ref), [`rem`](@ref), [`divrem`](@ref).
+See also [`cld`](@ref), [`fld`](@ref), [`rem`](@ref), [`divrem`](@ref).
 
 # Examples
 ```jldoctest
@@ -1449,7 +1449,7 @@ corresponding position in `collection`. To get a vector indicating whether each 
 in `items` is in `collection`, wrap `collection` in a tuple or a `Ref` like this:
 `in.(items, Ref(collection))` or `items .∈ Ref(collection)`.
 
-See also: [`∉`](@ref), [`insorted`](@ref), [`contains`](@ref), [`occursin`](@ref), [`issubset`](@ref).
+See also [`∉`](@ref), [`insorted`](@ref), [`contains`](@ref), [`occursin`](@ref), [`issubset`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -967,7 +967,7 @@ Return the method of `f` (a `Method` object) that would be called for arguments 
 
 If `types` is an abstract type, then the method that would be called by `invoke` is returned.
 
-See also: [`parentmodule`](@ref), [`@which`](@ref Main.InteractiveUtils.@which), and [`@edit`](@ref Main.InteractiveUtils.@edit).
+See also [`parentmodule`](@ref), [`@which`](@ref Main.InteractiveUtils.@which), [`@edit`](@ref Main.InteractiveUtils.@edit).
 """
 function which(@nospecialize(f), @nospecialize(t))
     tt = signature_type(f, t)

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -7,7 +7,7 @@
 
 Get a module's enclosing `Module`. `Main` is its own parent.
 
-See also: [`names`](@ref), [`nameof`](@ref), [`fullname`](@ref), [`@__MODULE__`](@ref).
+See also [`names`](@ref), [`nameof`](@ref), [`fullname`](@ref), [`@__MODULE__`](@ref).
 
 # Examples
 ```jldoctest
@@ -113,7 +113,7 @@ since it is not idiomatic to explicitly mark names from `Main` as public.
 !!! compat "Julia 1.12"
     The `usings` argument requires Julia 1.12 or later.
 
-See also: [`Base.isexported`](@ref), [`Base.ispublic`](@ref), [`Base.@locals`](@ref), [`@__MODULE__`](@ref).
+See also [`Base.isexported`](@ref), [`Base.ispublic`](@ref), [`Base.@locals`](@ref), [`@__MODULE__`](@ref).
 """
 names(m::Module; kwargs...) = sort!(unsorted_names(m; kwargs...))
 unsorted_names(m::Module; all::Bool=false, imported::Bool=false, usings::Bool=false) =
@@ -124,7 +124,7 @@ unsorted_names(m::Module; all::Bool=false, imported::Bool=false, usings::Bool=fa
 
 Return whether a symbol is exported from a module.
 
-See also: [`ispublic`](@ref), [`names`](@ref)
+See also [`ispublic`](@ref), [`names`](@ref).
 
 ```jldoctest
 julia> module Mod
@@ -155,7 +155,7 @@ Exported symbols are considered public.
 !!! compat "Julia 1.11"
     This function and the notion of publicity were added in Julia 1.11.
 
-See also: [`isexported`](@ref), [`names`](@ref)
+See also [`isexported`](@ref), [`names`](@ref).
 
 ```jldoctest
 julia> module Mod
@@ -1001,7 +1001,7 @@ iskindtype(@nospecialize t) = (t === DataType || t === UnionAll || t === Union |
 Return true if `T` is a [concrete type](@ref isconcretetype) that could appear
 as an element of a [dispatch tuple](@ref isdispatchtuple).
 
-See also: [`isdispatchtuple`](@ref).
+See also [`isdispatchtuple`](@ref).
 
 # Examples
 ```jldoctest
@@ -1050,7 +1050,7 @@ If `T` is not a type, then return `false`.
     possible for a type `U` to exist such that `T == U`, `isconcretetype(T)`,
     but `!isconcretetype(U)`.
 
-See also: [`isbits`](@ref), [`isabstracttype`](@ref), [`issingletontype`](@ref).
+See also [`isbits`](@ref), [`isabstracttype`](@ref), [`issingletontype`](@ref).
 
 # Examples
 ```jldoctest
@@ -1093,7 +1093,7 @@ If `T` is not a type, then return `false`.
     vice versa, types can be neither concrete nor abstract (for example,
     `Vector` (a [`UnionAll`](@ref))).
 
-See also: [`isconcretetype`](@ref).
+See also [`isconcretetype`](@ref).
 
 # Examples
 ```jldoctest
@@ -1478,7 +1478,7 @@ of the documented interface of `x`.   If you want it to also return "private"
 property names intended for internal use, pass `true` for the optional second argument.
 REPL tab completion on `x.` shows only the `private=false` properties.
 
-See also: [`hasproperty`](@ref), [`hasfield`](@ref).
+See also [`hasproperty`](@ref), [`hasfield`](@ref).
 """
 propertynames(x) = fieldnames(typeof(x))
 propertynames(m::Module) = names(m)
@@ -1493,7 +1493,7 @@ Return a boolean indicating whether the object `x` has `s` as one of its own pro
 !!! compat "Julia 1.2"
      This function requires at least Julia 1.2.
 
-See also: [`propertynames`](@ref), [`hasfield`](@ref).
+See also [`propertynames`](@ref), [`hasfield`](@ref).
 """
 hasproperty(x, s::Symbol) = s in propertynames(x)
 
@@ -1546,7 +1546,7 @@ A list of modules can also be specified as an array or set.
 !!! compat "Julia 1.4"
     At least Julia 1.4 is required for specifying a module.
 
-See also: [`which`](@ref), [`@which`](@ref Main.InteractiveUtils.@which) and [`methodswith`](@ref Main.InteractiveUtils.methodswith).
+See also [`which`](@ref), [`@which`](@ref Main.InteractiveUtils.@which), [`methodswith`](@ref Main.InteractiveUtils.methodswith).
 """
 function methods(@nospecialize(f), @nospecialize(t),
                  mod::Union{Tuple{Module},AbstractArray{Module},AbstractSet{Module},Nothing}=nothing)

--- a/base/set.jl
+++ b/base/set.jl
@@ -9,8 +9,8 @@
 Elements in a `Set` are unique, as determined by the elements' definition of `isequal`.
 The order of elements in a `Set` is an implementation detail and cannot be relied on.
 
-See also: [`AbstractSet`](@ref), [`BitSet`](@ref), [`Dict`](@ref),
-[`push!`](@ref), [`empty!`](@ref), [`union!`](@ref), [`in`](@ref), [`isequal`](@ref)
+See also [`AbstractSet`](@ref), [`BitSet`](@ref), [`Dict`](@ref),
+[`push!`](@ref), [`empty!`](@ref), [`union!`](@ref), [`in`](@ref), [`isequal`](@ref).
 
 # Examples
 ```jldoctest; filter = r"^  '.'"ma
@@ -98,10 +98,10 @@ If `x` is in `s`, return `true`. If not, push `x` into `s` and return `false`.
 This is equivalent to `in(x, s) ? true : (push!(s, x); false)`, but may have a
 more efficient implementation.
 
-See also: [`in`](@ref), [`push!`](@ref), [`Set`](@ref)
-
 !!! compat "Julia 1.11"
     This function requires at least 1.11.
+
+See also [`in`](@ref), [`push!`](@ref), [`Set`](@ref).
 
 # Examples
 ```jldoctest; filter = r"^\\s+\\d\$"m
@@ -205,7 +205,7 @@ as determined by [`isequal`](@ref) and [`hash`](@ref), in the order that the fir
 set of equivalent elements originally appears. The element type of the
 input is preserved.
 
-See also: [`unique!`](@ref), [`allunique`](@ref), [`allequal`](@ref).
+See also [`unique!`](@ref), [`allunique`](@ref), [`allequal`](@ref).
 
 # Examples
 ```jldoctest
@@ -489,10 +489,10 @@ The precise number of calls is regarded as an implementation detail.
 
 `allunique` may use a specialized implementation when the input is sorted.
 
-See also: [`unique`](@ref), [`issorted`](@ref), [`allequal`](@ref).
-
 !!! compat "Julia 1.11"
     The method `allunique(f, itr)` requires at least Julia 1.11.
+
+See also [`unique`](@ref), [`issorted`](@ref), [`allequal`](@ref).
 
 # Examples
 ```jldoctest
@@ -611,13 +611,13 @@ Or if all of `[f(x) for x in itr]` are equal, for the second method.
 Note that `allequal(f, itr)` may call `f` fewer than `length(itr)` times.
 The precise number of calls is regarded as an implementation detail.
 
-See also: [`unique`](@ref), [`allunique`](@ref).
-
 !!! compat "Julia 1.8"
     The `allequal` function requires at least Julia 1.8.
 
 !!! compat "Julia 1.11"
     The method `allequal(f, itr)` requires at least Julia 1.11.
+
+See also [`unique`](@ref), [`allunique`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/show.jl
+++ b/base/show.jl
@@ -1265,7 +1265,7 @@ show_supertypes(typ::DataType) = show_supertypes(stdout, typ)
 
 Prints one or more expressions, and their results, to `stdout`, and returns the last result.
 
-See also: [`show`](@ref), [`@info`](@ref man-logging), [`println`](@ref).
+See also [`show`](@ref), [`@info`](@ref man-logging), [`println`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -93,13 +93,13 @@ dimensions having size 1.
 
 See [`stack`](@ref)`(slices; dims)` for the inverse of `eachslice(A; dims::Integer)`.
 
-See also [`eachrow`](@ref), [`eachcol`](@ref), [`mapslices`](@ref) and [`selectdim`](@ref).
-
 !!! compat "Julia 1.1"
      This function requires at least Julia 1.1.
 
 !!! compat "Julia 1.9"
      Prior to Julia 1.9, this returned an iterator, and only a single dimension `dims` was supported.
+
+See also [`eachrow`](@ref), [`eachcol`](@ref), [`mapslices`](@ref), [`selectdim`](@ref).
 
 # Examples
 
@@ -141,13 +141,13 @@ Row slices are returned as `AbstractVector` views of `A`.
 
 For the inverse, see [`stack`](@ref)`(rows; dims=1)`.
 
-See also [`eachcol`](@ref), [`eachslice`](@ref) and [`mapslices`](@ref).
-
 !!! compat "Julia 1.1"
      This function requires at least Julia 1.1.
 
 !!! compat "Julia 1.9"
      Prior to Julia 1.9, this returned an iterator.
+
+See also [`eachcol`](@ref), [`eachslice`](@ref), [`mapslices`](@ref).
 
 # Examples
 
@@ -179,13 +179,13 @@ Column slices are returned as `AbstractVector` views of `A`.
 
 For the inverse, see [`stack`](@ref)`(cols)` or `reduce(`[`hcat`](@ref)`, cols)`.
 
-See also [`eachrow`](@ref), [`eachslice`](@ref) and [`mapslices`](@ref).
-
 !!! compat "Julia 1.1"
      This function requires at least Julia 1.1.
 
 !!! compat "Julia 1.9"
      Prior to Julia 1.9, this returned an iterator.
+
+See also [`eachrow`](@ref), [`eachslice`](@ref), [`mapslices`](@ref).
 
 # Examples
 

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -325,7 +325,7 @@ searched value `x` as well as the values in `v`.
 The range is generally found using binary search, but there are optimized
 implementations for some inputs.
 
-See also: [`searchsortedfirst`](@ref), [`sort!`](@ref), [`insorted`](@ref), [`findall`](@ref).
+See also [`searchsortedfirst`](@ref), [`sort!`](@ref), [`insorted`](@ref), [`findall`](@ref).
 
 # Examples
 ```jldoctest
@@ -364,7 +364,7 @@ values in `v`.
 The index is generally found using binary search, but there are optimized
 implementations for some inputs.
 
-See also: [`searchsortedlast`](@ref), [`searchsorted`](@ref), [`findfirst`](@ref).
+See also [`searchsortedlast`](@ref), [`searchsorted`](@ref), [`findfirst`](@ref).
 
 # Examples
 ```jldoctest
@@ -2248,7 +2248,7 @@ a linear ordering for `a, b <: typeof(x)`. Satisfies
 `isless(order, a, b) === (uint_map(a, order) < uint_map(b, order))`
 and `x === uint_unmap(typeof(x), uint_map(x, order), order)`
 
-See also: [`UIntMappable`](@ref) [`uint_unmap`](@ref)
+See also [`UIntMappable`](@ref), [`uint_unmap`](@ref).
 """
 function uint_map end
 
@@ -2258,7 +2258,7 @@ function uint_map end
 Reconstruct the unique value `x::T` that uint_maps to `u`. Satisfies
 `x === uint_unmap(T, uint_map(x::T, order), order)` for all `x <: T`.
 
-See also: [`uint_map`](@ref) [`UIntMappable`](@ref)
+See also [`uint_map`](@ref), [`UIntMappable`](@ref).
 """
 function uint_unmap end
 

--- a/base/special/cbrt.jl
+++ b/base/special/cbrt.jl
@@ -22,6 +22,8 @@ Return the cube root of `x`, i.e. ``x^{1/3}``. Negative values are accepted
 
 The prefix operator `∛` is equivalent to `cbrt`.
 
+See also [`sqrt`](@ref), [`fourthroot`](@ref).
+
 # Examples
 ```jldoctest
 julia> cbrt(big(27))

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -336,7 +336,7 @@ end
 
 Compute the natural base exponential of `x`, in other words ``ℯ^x``.
 
-See also [`exp2`](@ref), [`exp10`](@ref) and [`cis`](@ref).
+See also [`exp2`](@ref), [`exp10`](@ref), [`expm1`](@ref), [`cis`](@ref), [`log`](@ref).
 
 # Examples
 ```jldoctest
@@ -353,7 +353,7 @@ true
 
 Compute the base 2 exponential of `x`, in other words ``2^x``.
 
-See also [`ldexp`](@ref), [`<<`](@ref).
+See also [`exp`](@ref), [`log2`](@ref), [`ldexp`](@ref), [`<<`](@ref).
 
 # Examples
 ```jldoctest
@@ -373,6 +373,8 @@ exp2(x)
     exp10(x)
 
 Compute the base 10 exponential of `x`, in other words ``10^x``.
+
+See also, [`exp`](@ref), [`log10`](@ref).
 
 # Examples
 ```jldoctest
@@ -492,6 +494,9 @@ end
 
 Accurately compute ``e^x-1``. It avoids the loss of precision involved in the direct
 evaluation of exp(x) - 1 for small values of x.
+
+See also [`exp`](@ref), [`log1p`](@ref).
+
 # Examples
 ```jldoctest
 julia> expm1(1e-16)

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -824,7 +824,7 @@ Compute ``\\cos(\\pi x)`` more accurately than `cos(pi*x)`, especially for large
 
 Throw a [`DomainError`](@ref) if `isinf(x)`, return a `T(NaN)` if `isnan(x)`.
 
-See also: [`cispi`](@ref), [`sincosd`](@ref), [`sinpi`](@ref).
+See also [`cispi`](@ref), [`sincosd`](@ref), [`sinpi`](@ref).
 """
 function cospi(x::T) where T<:IEEEFloat
     x = abs(x)
@@ -860,7 +860,7 @@ Throw a [`DomainError`](@ref) if `isinf(x)`, return a `(T(NaN), T(NaN))` tuple i
 !!! compat "Julia 1.6"
     This function requires Julia 1.6 or later.
 
-See also: [`cispi`](@ref), [`sincosd`](@ref), [`sinpi`](@ref).
+See also [`cispi`](@ref), [`sincosd`](@ref), [`sinpi`](@ref).
 """
 function sincospi(_x::T) where T<:IEEEFloat
     x = abs(_x)

--- a/base/stat.jl
+++ b/base/stat.jl
@@ -54,7 +54,7 @@ The following fields of this struct are considered public API:
 | mtime   | `Float64`                       | Unix timestamp of when the file was last modified                  |
 | ctime   | `Float64`                       | Unix timestamp of when the file's metadata was changed             |
 
-See also: [`stat`](@ref)
+See also [`stat`](@ref).
 """
 struct StatStruct
     desc    :: Union{String, OS_HANDLE} # for show method, not included in equality or hash
@@ -406,6 +406,8 @@ ischardev(st::StatStruct) = filemode(st) & 0xf000 == 0x2000
 
 Return `true` if `path` points to a directory, `false` otherwise.
 
+See also [`isfile`](@ref), [`ispath`](@ref).
+
 # Examples
 ```jldoctest
 julia> isdir(homedir())
@@ -414,8 +416,6 @@ true
 julia> isdir("not/a/directory")
 false
 ```
-
-See also [`isfile`](@ref) and [`ispath`](@ref).
 """
 isdir(st::StatStruct) = filemode(st) & 0xf000 == 0x4000
 
@@ -434,6 +434,8 @@ isblockdev(st::StatStruct) = filemode(st) & 0xf000 == 0x6000
 
 Return `true` if `path` points to a regular file, `false` otherwise.
 
+See also [`isdir`](@ref), [`ispath`](@ref).
+
 # Examples
 ```jldoctest
 julia> isfile(homedir())
@@ -451,8 +453,6 @@ julia> rm(filename);
 julia> isfile(filename)
 false
 ```
-
-See also [`isdir`](@ref) and [`ispath`](@ref).
 """
 isfile(st::StatStruct) = filemode(st) & 0xf000 == 0x8000
 
@@ -519,7 +519,7 @@ is read+write, the bitfield is "110", which maps to the decimal
 value of 0+2+4=6. This is reflected in the printing of the
 returned `UInt8` value.
 
-See also [`gperm`](@ref) and [`operm`](@ref).
+See also [`gperm`](@ref), [`operm`](@ref).
 
 ```jldoctest
 julia> touch("dummy_file");  # Create test-file without contents

--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -75,8 +75,8 @@ More specifically, this is a simple wrapper around any other
 [`AbstractChar`](@ref), which holds a list of arbitrary labelled annotations
 (`$Annotation`) with the wrapped character.
 
-See also: [`AnnotatedString`](@ref), [`annotatedstring`](@ref), `annotations`,
-and `annotate!`.
+See also [`AnnotatedString`](@ref), [`annotatedstring`](@ref), `annotations`,
+`annotate!`.
 
 # Constructors
 
@@ -228,7 +228,7 @@ Create a `AnnotatedString` from any number of `values` using their
 This acts like [`string`](@ref), but takes care to preserve any annotations
 present (in the form of [`AnnotatedString`](@ref) or [`AnnotatedChar`](@ref) values).
 
-See also [`AnnotatedString`](@ref) and [`AnnotatedChar`](@ref).
+See also [`AnnotatedString`](@ref), [`AnnotatedChar`](@ref).
 
 ## Examples
 
@@ -384,7 +384,7 @@ a vector of region–annotation tuples.
 In accordance with the semantics documented in [`AnnotatedString`](@ref), the
 order of annotations returned matches the order in which they were applied.
 
-See also: [`annotate!`](@ref).
+See also [`annotate!`](@ref).
 """
 annotations(s::AnnotatedString) = s.annotations
 

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -173,7 +173,7 @@ highly efficient, then it may make sense to add a method to `string` and
 define `print(io::IO, x::MyType) = print(io, string(x))` to ensure the
 functions are consistent.
 
-See also: [`String`](@ref), [`repr`](@ref), [`sprint`](@ref), [`show`](@ref @show).
+See also [`String`](@ref), [`repr`](@ref), [`sprint`](@ref), [`show`](@ref @show).
 
 # Examples
 ```jldoctest

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -392,7 +392,7 @@ The default behaviour is to remove leading whitespace and delimiters: see
 The optional `chars` argument specifies which characters to remove: it can be a single
 character, or a vector or set of characters.
 
-See also [`strip`](@ref) and [`rstrip`](@ref).
+See also [`strip`](@ref), [`rstrip`](@ref).
 
 # Examples
 ```jldoctest
@@ -427,7 +427,7 @@ The default behaviour is to remove trailing whitespace and delimiters: see
 The optional `chars` argument specifies which characters to remove: it can be a single
 character, or a vector or set of characters.
 
-See also [`strip`](@ref) and [`lstrip`](@ref).
+See also [`strip`](@ref), [`lstrip`](@ref).
 
 # Examples
 ```jldoctest
@@ -462,10 +462,10 @@ The default behaviour is to remove leading and trailing whitespace and delimiter
 The optional `chars` argument specifies which characters to remove: it can be a single
 character, vector or set of characters.
 
-See also [`lstrip`](@ref) and [`rstrip`](@ref).
-
 !!! compat "Julia 1.2"
     The method which accepts a predicate function requires Julia 1.2 or later.
+
+See also [`lstrip`](@ref), [`rstrip`](@ref).
 
 # Examples
 ```jldoctest
@@ -487,13 +487,16 @@ Stringify `s` and pad the resulting string on the left with `p` to make it `n`
 characters (in [`textwidth`](@ref)) long. If `s` is already `n` characters long, an equal
 string is returned. Pad with spaces by default.
 
+!!! compat "Julia 1.7"
+    In Julia 1.7, this function was changed to use `textwidth` rather than a raw character (codepoint) count.
+
+See also [`rpad`](@ref).
+
 # Examples
 ```jldoctest
 julia> lpad("March", 10)
 "     March"
 ```
-!!! compat "Julia 1.7"
-    In Julia 1.7, this function was changed to use `textwidth` rather than a raw character (codepoint) count.
 """
 lpad(s, n::Integer, p::Union{AbstractChar,AbstractString}=' ') = lpad(string(s)::AbstractString, n, string(p))
 
@@ -524,13 +527,16 @@ Stringify `s` and pad the resulting string on the right with `p` to make it `n`
 characters (in [`textwidth`](@ref)) long. If `s` is already `n` characters long, an equal
 string is returned. Pad with spaces by default.
 
+!!! compat "Julia 1.7"
+    In Julia 1.7, this function was changed to use `textwidth` rather than a raw character (codepoint) count.
+
+See also [`lpad`](@ref).
+
 # Examples
 ```jldoctest
 julia> rpad("March", 20)
 "March               "
 ```
-!!! compat "Julia 1.7"
-    In Julia 1.7, this function was changed to use `textwidth` rather than a raw character (codepoint) count.
 """
 rpad(s, n::Integer, p::Union{AbstractChar,AbstractString}=' ') = rpad(string(s)::AbstractString, n, string(p))
 
@@ -560,6 +566,11 @@ end
 Truncate `str` to at most `maxwidth` columns (as estimated by [`textwidth`](@ref)), replacing the last characters
 with `replacement` if necessary. The default replacement string is "…".
 
+!!! compat "Julia 1.12"
+    This function was added in Julia 1.12.
+
+See also [`ltruncate`](@ref), [`ctruncate`](@ref).
+
 # Examples
 ```jldoctest
 julia> s = rtruncate("🍕🍕 I love 🍕", 10)
@@ -571,11 +582,6 @@ julia> textwidth(s)
 julia> rtruncate("foo", 3)
 "foo"
 ```
-
-!!! compat "Julia 1.12"
-    This function was added in Julia 1.12.
-
-See also [`ltruncate`](@ref) and [`ctruncate`](@ref).
 """
 function rtruncate(str::AbstractString, maxwidth::Integer, replacement::Union{AbstractString,AbstractChar} = '…')
     ret = string_truncate_boundaries(str, Int(maxwidth), replacement, Val(:right))
@@ -593,6 +599,11 @@ end
 Truncate `str` to at most `maxwidth` columns (as estimated by [`textwidth`](@ref)), replacing the first characters
 with `replacement` if necessary. The default replacement string is "…".
 
+!!! compat "Julia 1.12"
+    This function was added in Julia 1.12.
+
+See also [`rtruncate`](@ref), [`ctruncate`](@ref).
+
 # Examples
 ```jldoctest
 julia> s = ltruncate("🍕🍕 I love 🍕", 10)
@@ -604,11 +615,6 @@ julia> textwidth(s)
 julia> ltruncate("foo", 3)
 "foo"
 ```
-
-!!! compat "Julia 1.12"
-    This function was added in Julia 1.12.
-
-See also [`rtruncate`](@ref) and [`ctruncate`](@ref).
 """
 function ltruncate(str::AbstractString, maxwidth::Integer, replacement::Union{AbstractString,AbstractChar} = '…')
     ret = string_truncate_boundaries(str, Int(maxwidth), replacement, Val(:left))
@@ -627,6 +633,11 @@ Truncate `str` to at most `maxwidth` columns (as estimated by [`textwidth`](@ref
 with `replacement` if necessary. The default replacement string is "…". By default, the truncation
 prefers keeping chars on the left, but this can be changed by setting `prefer_left` to `false`.
 
+!!! compat "Julia 1.12"
+    This function was added in Julia 1.12.
+
+See also [`ltruncate`](@ref), [`rtruncate`](@ref).
+
 # Examples
 ```jldoctest
 julia> s = ctruncate("🍕🍕 I love 🍕", 10)
@@ -638,11 +649,6 @@ julia> textwidth(s)
 julia> ctruncate("foo", 3)
 "foo"
 ```
-
-!!! compat "Julia 1.12"
-    This function was added in Julia 1.12.
-
-See also [`ltruncate`](@ref) and [`rtruncate`](@ref).
 """
 function ctruncate(str::AbstractString, maxwidth::Integer, replacement::Union{AbstractString,AbstractChar} = '…'; prefer_left::Bool = true)
     ret = string_truncate_boundaries(str, Int(maxwidth), replacement, Val(:center), prefer_left)
@@ -721,10 +727,10 @@ The optional keyword arguments are:
  - `keepempty`: whether empty fields should be kept in the result. Default is `false` without
    a `dlm` argument, `true` with a `dlm` argument.
 
-See also [`split`](@ref).
-
 !!! compat "Julia 1.8"
     The `eachsplit` function requires at least Julia 1.8.
+
+See also [`split`](@ref).
 
 # Examples
 ```jldoctest
@@ -822,10 +828,10 @@ The optional keyword arguments are:
 Note that unlike [`split`](@ref), [`rsplit`](@ref) and [`eachsplit`](@ref), this
 function iterates the substrings right to left as they occur in the input.
 
-See also [`eachsplit`](@ref), [`rsplit`](@ref).
-
 !!! compat "Julia 1.11"
     This function requires Julia 1.11 or later.
+
+See also [`eachsplit`](@ref), [`rsplit`](@ref).
 
 # Examples
 ```jldoctest
@@ -1221,6 +1227,8 @@ to `dest`. The length of `dest` must be half the length of `itr`.
     Calling hex2bytes! with iterators producing UInt8 requires
     version 1.7. In earlier versions, you can collect the iterable
     before calling instead.
+
+See also [`hex2bytes`](@ref), [`bytes2hex`](@ref).
 """
 function hex2bytes!(dest::AbstractArray{UInt8}, itr)
     isodd(length(itr)) && throw(ArgumentError("length of iterable must be even"))
@@ -1259,6 +1267,8 @@ via `bytes2hex(io, itr)`.  The hexadecimal characters are all lowercase.
     Calling `bytes2hex` with arbitrary iterators producing `UInt8` values requires
     Julia 1.7 or later. In earlier versions, you can `collect` the iterator
     before calling `bytes2hex`.
+
+See also [`hex2bytes`](@ref), [`hex2bytes!`](@ref).
 
 # Examples
 ```jldoctest
@@ -1311,7 +1321,7 @@ end
 Convert a string to `String` type and check that it contains only ASCII data, otherwise
 throwing an `ArgumentError` indicating the position of the first non-ASCII byte.
 
-See also the [`isascii`](@ref) predicate to filter or replace non-ASCII characters.
+See also [`isascii`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -650,7 +650,7 @@ A macro to evaluate an expression, discard the resulting value, and instead retu
 total number of lock conflicts during evaluation, where a lock attempt on a [`ReentrantLock`](@ref)
 resulted in a wait because the lock was already held.
 
-See also [`@time`](@ref), [`@timev`](@ref) and [`@timed`](@ref).
+See also [`@time`](@ref), [`@timev`](@ref), [`@timed`](@ref).
 
 ```julia-repl
 julia> @lock_conflicts begin

--- a/stdlib/Random/src/Xoshiro.jl
+++ b/stdlib/Random/src/Xoshiro.jl
@@ -138,7 +138,7 @@ for (fname, sz) in ((:jump_128, 128), (:jump_192, 192))
 
         This can be used to generate `2^$($seq_pow)` non-overlapping subsequences for parallel computations.
 
-        See also: [`$($fname)`](@ref), [`$($see_other!)`](@ref)
+        See also [`$($fname)`](@ref), [`$($see_other!)`](@ref).
 
         # Examples
         ```julia-repl
@@ -159,7 +159,7 @@ for (fname, sz) in ((:jump_128, 128), (:jump_192, 192))
 
         This can be used to generate `2^$($seq_pow)` non-overlapping subsequences for parallel computations.
 
-        See also: [`$($fname!)`](@ref), [`$($see_other)`](@ref)
+        See also [`$($fname!)`](@ref), [`$($see_other)`](@ref).
 
         # Examples
         ```julia-repl


### PR DESCRIPTION
- Add or extend bunch of "See also" ref lists
- Replace 'and' in those list by a comma
- Drop colon in 'See also: '
- Add missing punctuation (trailing period, commas)
- Apply an informal ordering of the docstring content: first comes the general description, then any compat notices, then 'see also', then examples.