### PR TITLE
docs: move ispositive/isnegative to math chapter

### DIFF
--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -141,8 +141,6 @@ Core.:(===)
 Core.isa
 Base.isequal
 Base.isless
-Base.ispositive
-Base.isnegative
 Base.isunordered
 Base.ifelse
 Core.typeassert

--- a/doc/src/base/math.md
+++ b/doc/src/base/math.md
@@ -260,6 +260,11 @@ Base.signbit
 Base.flipsign
 ```
 
+```@docs
+Base.ispositive
+Base.isnegative
+```
+
 ## Roots
 
 ```@docs


### PR DESCRIPTION
They were in the section for function applicable to Any, but in reality they are really meant for Number types. So they couuld also go into numbers.md; but logically they seem to fit best next to other sign related functions.