### PR TITLE
docs: put all bit operations together in one place

### DIFF
--- a/doc/src/base/math.md
+++ b/doc/src/base/math.md
@@ -47,21 +47,6 @@ Base.cmp
 Base.isapprox
 ```
 
-## Bit Operators
-
-```@docs
-Base.:(<<)
-Base.:(>>)
-Base.:(>>>)
-Base.bitrotate
-Base.:(~)
-Base.:(&)
-Base.:(|)
-Base.xor
-Base.nand
-Base.nor
-```
-
 ## Logical Operators
 
 ```@docs

--- a/doc/src/base/numbers.md
+++ b/doc/src/base/numbers.md
@@ -33,7 +33,7 @@ Number  (Abstract Type)
       └─ Irrational
 ```
 
-### Abstract number types
+### Abstract Number Types
 
 ```@docs
 Core.Number
@@ -45,7 +45,7 @@ Core.Unsigned
 Base.AbstractIrrational
 ```
 
-### Concrete number types
+### Concrete Number Types
 
 ```@docs
 Core.Float16
@@ -134,7 +134,20 @@ Base.Rounding.get_zero_subnormals
 Base.Rounding.set_zero_subnormals
 ```
 
-### Integers
+## Bit Operations
+
+```@docs
+Base.:(<<)
+Base.:(>>)
+Base.:(>>>)
+Base.bitrotate
+Base.:(~)
+Base.:(&)
+Base.:(|)
+Base.xor
+Base.nand
+Base.nor
+```
 
 ```@docs
 Base.count_ones
@@ -143,6 +156,11 @@ Base.leading_zeros
 Base.leading_ones
 Base.trailing_zeros
 Base.trailing_ones
+```
+
+### Integers
+
+```@docs
 Base.isodd
 Base.iseven
 Base.@int128_str


### PR DESCRIPTION
Bit shifts, bit rotations, etc. are not classical "mathematical" operations, so did not fit very well in the "mathematics" chapter. But they do fit well together with functions like `count_ones` etc.