### PR TITLE
Markdown: fix text field of Link to be a Vector

### DIFF
--- a/stdlib/Markdown/src/Common/inline.jl
+++ b/stdlib/Markdown/src/Common/inline.jl
@@ -104,7 +104,7 @@ function image(stream::IO, md::MD)
 end
 
 mutable struct Link <: MarkdownElement
-    text
+    text::Vector
     url::String
 end
 
@@ -142,9 +142,9 @@ function autolink(stream::IO, md::MD)
         startswith(stream, '<') || return
         url = readuntil(stream, '>')
         url ≡ nothing && return
-        _is_link(url) && return Link(url, url)
-        _is_mailto(url) && return Link(url, url)
-        _is_email(url) && return Link(url, "mailto:" * url)
+        _is_link(url) && return Link([url], url)
+        _is_mailto(url) && return Link([url], url)
+        _is_email(url) && return Link([url], "mailto:" * url)
         return
     end
 end


### PR DESCRIPTION
Previously, a link created via <URL> would store a plain string in there, while one created via [URL](URL) would store a Vector containing a string. Removing this gratuitious difference makes it a little bit easier for others to consume Link objects.

Resolves #33438