### PR TITLE
test/Artifacts: add missing test deps for Artifacts

### DIFF
--- a/stdlib/Artifacts/Project.toml
+++ b/stdlib/Artifacts/Project.toml
@@ -3,7 +3,9 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 version = "1.11.0"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [targets]
-test = ["Test"]
+test = ["Pkg", "Test", "TOML"]


### PR DESCRIPTION
I'm not sure if this is really a issue/bug?
And why only PkgEval find this issue.

[nanosoldier/pkgeval/by_date/2026-01/26/Artifacts.primary.log](https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_date/2026-01/26/Artifacts.primary.log)

Maybe we need some backport.