### PR TITLE
Support IJulia in `artifact_str`

### DIFF
--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -678,7 +678,7 @@ If `name` contains a forward or backward slash, all elements after the first sla
 be taken to be path names indexing into the artifact, allowing for an easy one-liner to
 access a single file/directory within an artifact.  Example:
 
-    ffmpeg_path = @artifact"FFMPEG/bin/ffmpeg"
+    ffmpeg_path = artifact"FFMPEG/bin/ffmpeg"
 
 !!! compat "Julia 1.3"
     This macro requires at least Julia 1.3.
@@ -689,7 +689,8 @@ access a single file/directory within an artifact.  Example:
 macro artifact_str(name, platform=nothing)
     # Find Artifacts.toml file we're going to load from
     srcfile = string(__source__.file)
-    if ((isinteractive() && startswith(srcfile, "REPL[")) || (!isinteractive() && srcfile == "none")) && !isfile(srcfile)
+    is_repl_or_ijulia = isinteractive() && (startswith(srcfile, "REPL[") || startswith(srcfile, "In["))
+    if (is_repl_or_ijulia || (!isinteractive() && srcfile == "none")) && !isfile(srcfile)
         srcfile = pwd()
     end
     local artifacts_toml = find_artifacts_toml(srcfile)


### PR DESCRIPTION
IJulia evaluates cells with the source file set to e.g. `In[3]`. `artifact_str` only supports the REPL prefix so calling `artifact"foo"` in a notebook would fail. Also fixed a wee typo in the docstring.

Disclaimer: I'm not sure this is the best way to fix it. Hardcoding support for an external package (even one as important as IJulia) into a stdlib feels a bit wack. But I'm also not aware of any API to get the prefix, and I don't know of any other package that needs such support.

Fixes https://github.com/JuliaLang/IJulia.jl/issues/1060.