### PR TITLE
codegen: Add NewSink LLVM pass for instruction sinking

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -84,6 +84,7 @@ CODEGEN_SRCS := codegen jitlayers aotcompile debuginfo disasm llvm-simdloop \
 	llvm-pass-helpers llvm-ptls llvm-propagate-addrspaces \
 	llvm-multiversioning llvm-alloc-opt llvm-alloc-helpers cgmemmgr llvm-remove-addrspaces \
 	llvm-remove-ni llvm-julia-licm llvm-demote-float16 llvm-cpufeatures llvm-expand-atomic-modify \
+	llvm-newsink \
 	pipeline llvm_api \
 	$(GC_CODEGEN_SRCS)
 FLAGS_COMMON += -I$(shell $(LLVM_CONFIG_HOST) --includedir)

--- a/src/llvm-julia-passes.inc
+++ b/src/llvm-julia-passes.inc
@@ -17,6 +17,7 @@ FUNCTION_PASS("PropagateJuliaAddrspaces", PropagateJuliaAddrspacesPass())
 FUNCTION_PASS("GCInvariantVerifier", GCInvariantVerifierPass())
 FUNCTION_PASS("FinalLowerGC", FinalLowerGCPass())
 FUNCTION_PASS("ExpandAtomicModify", ExpandAtomicModifyPass())
+FUNCTION_PASS("NewSink", NewSinkPass())
 #endif
 
 //Loop passes

--- a/src/llvm-newsink.cpp
+++ b/src/llvm-newsink.cpp
@@ -1,0 +1,877 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// NewSink - Sink instructions to paths where they are actually needed
+//
+// Useful for Julia's bounds checking where error message data is computed
+// eagerly but only needed when bounds checks fail.
+//
+// Algorithm:
+//   1. Pure values: sink to nearest common dominator of all use blocks
+//   2. Memory reads: sink to an immediate successor that dominates all uses
+//   3. Memory writes: sink to a successor verified safe by MemorySSA,
+//      splitting critical edges for multi-predecessor targets
+//   4. Iterate to fixed point (chains of sinkable instructions)
+//
+// Example:
+//   Before:                              After:
+//     store i64 %i, ptr %tuple             %cmp = icmp ult %i, %bound
+//     %cmp = icmp ult %i, %bound           br i1 %cmp, label %ok, label %error
+//     br i1 %cmp, label %ok, label %error  error:
+//   error:                                   store i64 %i, ptr %tuple
+//     call @throw(%tuple)                    call @throw(%tuple)
+//     unreachable                            unreachable
+
+#include "llvm-version.h"
+
+// GCC false positive about SmallDenseMap in BatchAAResults
+#ifdef _COMPILER_GCC_
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
+#include "passes.h"
+
+#include <llvm/ADT/PostOrderIterator.h>
+#include <llvm/ADT/SmallPtrSet.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/Statistic.h>
+#include <llvm/Analysis/AliasAnalysis.h>
+#include <llvm/Analysis/CaptureTracking.h>
+#include <llvm/Analysis/MemoryLocation.h>
+#include <llvm/Analysis/MemorySSA.h>
+#include <llvm/Analysis/MemorySSAUpdater.h>
+#include <llvm/Analysis/OptimizationRemarkEmitter.h>
+#include <llvm/Analysis/TargetLibraryInfo.h>
+#include <llvm/Analysis/ValueTracking.h>
+#include <llvm/Analysis/LoopInfo.h>
+#include <llvm/Analysis/PostDominators.h>
+#include <llvm/IR/Dominators.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/IntrinsicInst.h>
+#include <llvm/IR/Verifier.h>
+#include <llvm/Support/CommandLine.h>
+#include <llvm/Support/Debug.h>
+#include <llvm/Transforms/Utils/BasicBlockUtils.h>
+
+#include "julia.h"
+
+#define DEBUG_TYPE "new-sink"
+
+using namespace llvm;
+
+STATISTIC(NumSunk, "Number of instructions sunk");
+STATISTIC(NumSunkToNoReturn, "Number of instructions sunk to noreturn paths");
+STATISTIC(NumSunkGeneral, "Number of instructions sunk to general paths");
+STATISTIC(NumIterations, "Total sinking iterations across all functions");
+STATISTIC(NumAbortedMSSAWalk, "MSSA walks aborted due to limit");
+STATISTIC(NumAbortedIterations, "Functions where iteration limit reached");
+
+// Limits to bound worst-case complexity (similar to DSE)
+static cl::opt<unsigned> MemorySSAScanLimit(
+    "newsink-memoryssa-scanlimit", cl::init(150), cl::Hidden,
+    cl::desc("The number of memory accesses to scan for sinking (default = 150)"));
+
+static cl::opt<unsigned> MaxSinkingIterations(
+    "newsink-max-iterations", cl::init(32), cl::Hidden,
+    cl::desc("Maximum fixed-point iterations for sinking (default = 32)"));
+
+namespace {
+
+// Check if a memory write can be moved (not volatile, not ordered atomic).
+// Follows DSE's isRemovable pattern.
+static bool isSinkableMemoryWrite(Instruction *I)
+{
+    if (auto *SI = dyn_cast<StoreInst>(I))
+        return SI->isUnordered();
+
+    if (auto *CB = dyn_cast<CallBase>(I)) {
+        // Memory intrinsics: just check volatile
+        if (auto *MI = dyn_cast<MemIntrinsic>(CB))
+            return !MI->isVolatile();
+
+        // Other calls with a known write destination: must have no uses
+        // (can't sink a value producer via the write path), must return,
+        // and must not throw (sinking past a branch could skip the throw).
+        return CB->use_empty() && CB->willReturn() && CB->doesNotThrow() &&
+               !CB->isTerminator();
+    }
+
+    return false;
+}
+
+static bool isNoReturnBlock(const BasicBlock *BB)
+{
+    return isa<UnreachableInst>(BB->getTerminator());
+}
+
+// State struct holding all analysis dependencies, following DSE's pattern.
+struct NewSinkState {
+    Function &F;
+    DominatorTree &DT;
+    PostDominatorTree &PDT;
+    LoopInfo &LI;
+    AliasAnalysis &AA;
+    BatchAAResults BatchAA; // Caches AA queries
+    MemorySSA &MSSA;
+    MemorySSAUpdater MSSAUpdater; // Keeps MSSA consistent after modifications
+    const TargetLibraryInfo &TLI;
+    OptimizationRemarkEmitter &ORE;
+
+    // Precomputed: blocks where all paths lead to unreachable
+    SmallPtrSet<BasicBlock *, 16> NoReturnBlocks;
+
+    NewSinkState(Function &F, DominatorTree &DT, PostDominatorTree &PDT,
+                 LoopInfo &LI, AliasAnalysis &AA, MemorySSA &MSSA,
+                 const TargetLibraryInfo &TLI, OptimizationRemarkEmitter &ORE)
+      : F(F),
+        DT(DT),
+        PDT(PDT),
+        LI(LI),
+        AA(AA),
+        BatchAA(AA),
+        MSSA(MSSA),
+        MSSAUpdater(&MSSA),
+        TLI(TLI),
+        ORE(ORE)
+    {
+        collectNoReturnBlocks();
+    }
+
+    std::optional<MemoryLocation> getLocForWrite(Instruction *I) const
+    {
+        if (!I->mayWriteToMemory())
+            return std::nullopt;
+        if (auto *CB = dyn_cast<CallBase>(I))
+            return MemoryLocation::getForDest(CB, TLI);
+        return MemoryLocation::getOrNone(I);
+    }
+
+    bool isMemoryWrite(Instruction *I) const { return getLocForWrite(I).has_value(); }
+
+    Value *getWritePointer(Instruction *I) const
+    {
+        if (auto *SI = dyn_cast<StoreInst>(I))
+            return SI->getPointerOperand();
+
+        if (auto *CB = dyn_cast<CallBase>(I)) {
+            if (auto Loc = MemoryLocation::getForDest(CB, TLI))
+                return const_cast<Value *>(Loc->Ptr);
+            return nullptr;
+        }
+
+        return nullptr;
+    }
+
+    void collectNoReturnBlocks();
+    bool pointerEscapesOutsideTarget(const Value *Ptr, Instruction *WriteInst,
+                                     BasicBlock *CurrentBB,
+                                     BasicBlock *TargetSucc);
+    bool canSinkInstruction(Instruction *I) const;
+    BasicBlock *canSinkMemoryWriteToSuccessor(Instruction *WriteInst,
+                                              BasicBlock *TargetSucc);
+    BasicBlock *findSinkTargetForValue(Instruction *I);
+    BasicBlock *findSinkTargetForWrite(Instruction *I);
+    bool trySinkInstruction(Instruction *I);
+    bool run();
+};
+
+// Collect blocks where all paths lead to unreachable.
+// Uses a worklist to propagate backward from unreachable terminators in O(V+E).
+void NewSinkState::collectNoReturnBlocks()
+{
+    SmallVector<BasicBlock *, 8> Worklist;
+    for (BasicBlock &BB : F) {
+        if (!DT.isReachableFromEntry(&BB))
+            continue;
+        if (isNoReturnBlock(&BB)) {
+            NoReturnBlocks.insert(&BB);
+            Worklist.push_back(&BB);
+        }
+    }
+
+    while (!Worklist.empty()) {
+        BasicBlock *BB = Worklist.pop_back_val();
+        for (BasicBlock *Pred : predecessors(BB)) {
+            if (!DT.isReachableFromEntry(Pred))
+                continue;
+            if (NoReturnBlocks.count(Pred))
+                continue;
+            if (succ_empty(Pred))
+                continue;
+
+            if (llvm::all_of(successors(Pred), [&](BasicBlock *Succ) {
+                    return NoReturnBlocks.count(Succ);
+                })) {
+                NoReturnBlocks.insert(Pred);
+                Worklist.push_back(Pred);
+            }
+        }
+    }
+}
+
+// Path-sensitive CaptureTracker: ignores captures in blocks where
+// predicate returns true (target block or blocks dominated by it).
+template <typename BlockPredicate>
+struct PathSensitiveCaptureTracker : public CaptureTracker {
+    BlockPredicate IgnoreBlock;
+    bool Captured = false;
+
+    PathSensitiveCaptureTracker(BlockPredicate Pred) : IgnoreBlock(Pred) {}
+
+    void tooManyUses() override { Captured = true; }
+
+    bool captured(const Use *U) override
+    {
+        if (auto *I = dyn_cast<Instruction>(U->getUser())) {
+            if (IgnoreBlock(I->getParent()))
+                return false;
+        }
+        Captured = true;
+        return true;
+    }
+};
+
+// Check if pointer escapes outside where the sunk write will dominate.
+// When sinking to a single-predecessor target, the write dominates the
+// target and its subtree, so captures there are safe to ignore.
+// When splitting a critical edge to a multi-predecessor target, the new
+// block dominates the target only if all other predecessors are backedges
+// (SplitBlockDominatesTarget). If not, captures anywhere are unsafe
+// because the sunk write won't dominate the target.
+bool NewSinkState::pointerEscapesOutsideTarget(const Value *Ptr,
+                                                Instruction *WriteInst,
+                                                BasicBlock *CurrentBB,
+                                                BasicBlock *TargetSucc)
+{
+    const Value *UnderlyingObj = getUnderlyingObject(Ptr);
+
+    // After sinking (possibly via edge split), the write dominates the
+    // target only if the target has a single predecessor or all other
+    // predecessors are backedges. When this holds, we can safely ignore
+    // captures in the target's dominator subtree.
+    bool WriteDominatesTarget = true;
+    if (!TargetSucc->hasNPredecessors(1)) {
+        for (BasicBlock *Pred : predecessors(TargetSucc)) {
+            if (Pred != CurrentBB && !DT.dominates(TargetSucc, Pred)) {
+                WriteDominatesTarget = false;
+                break;
+            }
+        }
+    }
+
+    PathSensitiveCaptureTracker Tracker([&](BasicBlock *BB) {
+        // The write instruction itself will move to the target — ignore
+        // any capture through it (it will be in the target after sinking).
+        // We check this per-use inside captured(), but for block-level
+        // filtering we also ignore the target subtree when applicable.
+        if (!WriteDominatesTarget)
+            return false; // Can't ignore any captures
+        return BB == TargetSucc || DT.dominates(TargetSucc, BB);
+    });
+
+    // Override captured() to also skip uses by the write instruction itself
+    struct WriteAwareCaptureTracker : public CaptureTracker {
+        CaptureTracker &Inner;
+        const Instruction *WriteInst;
+        bool Captured = false;
+
+        WriteAwareCaptureTracker(CaptureTracker &Inner, const Instruction *WI)
+            : Inner(Inner), WriteInst(WI) {}
+
+        void tooManyUses() override { Captured = true; }
+
+        bool captured(const Use *U) override
+        {
+            // The write instruction will be sunk — its uses of the pointer
+            // will be in the target block after sinking, so ignore them.
+            if (U->getUser() == WriteInst)
+                return false;
+            if (Inner.captured(U)) {
+                Captured = true;
+                return true;
+            }
+            return false;
+        }
+    };
+
+    WriteAwareCaptureTracker OuterTracker(Tracker, WriteInst);
+    PointerMayBeCaptured(UnderlyingObj, &OuterTracker);
+    return OuterTracker.Captured;
+}
+
+// Check if a memory write can be safely sunk to target successor.
+// Uses MemorySSA to verify no reads observe the wrong value.
+BasicBlock *NewSinkState::canSinkMemoryWriteToSuccessor(Instruction *WriteInst,
+                                                        BasicBlock *TargetSucc)
+{
+    auto MaybeLoc = getLocForWrite(WriteInst);
+    if (!MaybeLoc)
+        return nullptr;
+    MemoryLocation WriteLoc = *MaybeLoc;
+
+    BasicBlock *CurrentBB = WriteInst->getParent();
+    assert(llvm::is_contained(successors(CurrentBB), TargetSucc) &&
+           "TargetSucc must be an immediate successor");
+
+    Value *WritePtr = getWritePointer(WriteInst);
+    if (!WritePtr)
+        return nullptr;
+
+    const Value *UnderlyingObj = getUnderlyingObject(WritePtr);
+    if (!isIdentifiedFunctionLocal(UnderlyingObj))
+        return nullptr;
+
+    // If the pointer escapes outside the target's dominator subtree,
+    // external code may read the field — MSSA can't see those reads.
+    if (pointerEscapesOutsideTarget(WritePtr, WriteInst, CurrentBB, TargetSucc))
+        return nullptr;
+
+    MemoryAccess *WriteDef = MSSA.getMemoryAccess(WriteInst);
+    if (!WriteDef)
+        return nullptr;
+
+    // Walk forward from our MemoryDef to check that no reader outside the
+    // target would observe the wrong value if we sink this write.
+    // Loop iteration safety is handled separately in findSinkTargetForWrite.
+    SmallVector<MemoryAccess *, 16> Worklist;
+    SmallPtrSet<MemoryAccess *, 16> Visited;
+
+    for (User *U : WriteDef->users())
+        if (auto *MA = dyn_cast<MemoryAccess>(U))
+            Worklist.push_back(MA);
+
+    // After splitting edge CurrentBB→TargetSucc, the new block dominates
+    // TargetSucc only if all other predecessors are dominated by TargetSucc
+    // (i.e. they are backedges). When this holds, reads in TargetSucc will
+    // see the sunk write and can be safely skipped in the MSSA walk.
+    bool SplitBlockDominatesTarget = true;
+    if (!TargetSucc->hasNPredecessors(1)) {
+        for (BasicBlock *Pred : predecessors(TargetSucc)) {
+            if (Pred != CurrentBB && !DT.dominates(TargetSucc, Pred)) {
+                SplitBlockDominatesTarget = false;
+                break;
+            }
+        }
+    }
+
+    LLVM_DEBUG(dbgs() << "NewSink:   MSSA walk for target "
+                      << TargetSucc->getName() << " (splitdom="
+                      << SplitBlockDominatesTarget << ")\n");
+
+    while (!Worklist.empty()) {
+        // Bail out if we've visited too many accesses
+        if (Visited.size() >= MemorySSAScanLimit) {
+            ++NumAbortedMSSAWalk;
+            LLVM_DEBUG(dbgs() << "NewSink:   MSSA scan limit reached ("
+                              << Visited.size() << " visited)\n");
+            return nullptr;
+        }
+
+        MemoryAccess *MA = Worklist.pop_back_val();
+        if (!Visited.insert(MA).second)
+            continue;
+
+        BasicBlock *MABB = MA->getBlock();
+
+        if (isa<MemoryPhi>(MA)) {
+            LLVM_DEBUG(dbgs() << "NewSink:   MSSA phi in "
+                              << MABB->getName() << "\n");
+            for (User *U : MA->users())
+                if (auto *UserMA = dyn_cast<MemoryAccess>(U))
+                    Worklist.push_back(UserMA);
+            continue;
+        }
+
+        Instruction *MemInst = nullptr;
+        if (auto *MU = dyn_cast<MemoryUseOrDef>(MA))
+            MemInst = MU->getMemoryInst();
+
+        if (!MemInst || MemInst == WriteInst)
+            continue;
+
+        // Reads in the target or blocks dominated by it will see the sunk
+        // write — but only when the split block will dominate the target.
+        // For single-predecessor targets, we sink directly and dominate.
+        // For multi-predecessor targets, the edge is split. The new block
+        // dominates the target only if all other predecessors are dominated
+        // by the target (i.e. they are backedges). This follows the same
+        // legality check as MachineSink::isLegalToBreakCriticalEdge.
+        if (SplitBlockDominatesTarget &&
+            (MABB == TargetSucc || DT.dominates(TargetSucc, MABB))) {
+            LLVM_DEBUG(dbgs() << "NewSink:   skip (in target/dominated): "
+                              << *MemInst << " in " << MABB->getName() << "\n");
+            continue;
+        }
+
+        // In the source block, any aliasing access blocks sinking.
+        if (MABB == CurrentBB) {
+            ModRefInfo MRI = BatchAA.getModRefInfo(MemInst, WriteLoc);
+            if (isModOrRefSet(MRI)) {
+                LLVM_DEBUG(dbgs() << "NewSink:   blocked by source-block access: "
+                                  << *MemInst << "\n");
+                return nullptr;
+            }
+            if (auto *UserDef = dyn_cast<MemoryDef>(MA)) {
+                for (User *U : UserDef->users())
+                    if (auto *UserMA = dyn_cast<MemoryAccess>(U))
+                        Worklist.push_back(UserMA);
+            }
+            continue;
+        }
+
+        ModRefInfo MRI = BatchAA.getModRefInfo(MemInst, WriteLoc);
+
+        if (!isRefSet(MRI)) {
+            // Doesn't read our location. Follow through MemoryDefs because
+            // MSSA chains all memory ops, not just aliasing ones.
+            LLVM_DEBUG(dbgs() << "NewSink:   no-ref (" << MABB->getName()
+                              << "): " << *MemInst << "\n");
+            if (auto *UserDef = dyn_cast<MemoryDef>(MA)) {
+                for (User *U : UserDef->users())
+                    if (auto *UserMA = dyn_cast<MemoryAccess>(U))
+                        Worklist.push_back(UserMA);
+            }
+            continue;
+        }
+
+        LLVM_DEBUG(dbgs() << "NewSink:   blocked by reader: "
+                          << *MemInst << " in " << MABB->getName() << "\n");
+        return nullptr;
+    }
+
+    LLVM_DEBUG(dbgs() << "NewSink:   MSSA walk succeeded ("
+                      << Visited.size() << " visited)\n");
+    return TargetSucc;
+}
+
+// Check that nothing clobbers a memory read between it and the block terminator.
+static bool canSinkMemoryRead(Instruction *I, AliasAnalysis &AA)
+{
+    BasicBlock *BB = I->getParent();
+    Instruction *Term = BB->getTerminator();
+
+    if (I->getNextNode() == Term)
+        return true;
+
+    // For loads, use the efficient MemoryLocation-based range query.
+    if (auto *LI = dyn_cast<LoadInst>(I)) {
+        MemoryLocation Loc = MemoryLocation::get(LI);
+        return !AA.canInstructionRangeModRef(*LI->getNextNode(), *Term, Loc,
+                                              ModRefInfo::Mod);
+    }
+
+    // For readonly calls, check each intervening instruction individually
+    // (no single MemoryLocation to use with canInstructionRangeModRef).
+    auto *CB = dyn_cast<CallBase>(I);
+    if (!CB)
+        return false;
+
+    for (Instruction *Cur = CB->getNextNode(); Cur != Term;
+         Cur = Cur->getNextNode()) {
+        if (!Cur->mayWriteToMemory())
+            continue;
+
+        if (auto *CurCB = dyn_cast<CallBase>(Cur)) {
+            if (isModSet(AA.getModRefInfo(CurCB, CB)))
+                return false;
+            continue;
+        }
+
+        if (auto Loc = MemoryLocation::getOrNone(Cur)) {
+            if (isRefSet(AA.getModRefInfo(CB, *Loc)))
+                return false;
+            continue;
+        }
+
+        // Unknown memory-writing instruction — conservatively block sinking.
+        return false;
+    }
+
+    return true;
+}
+
+// Check that nothing modifies the memcpy/memmove source between it and the terminator.
+static bool canSinkMemTransfer(MemTransferInst *MTI, AliasAnalysis &AA)
+{
+    BasicBlock *BB = MTI->getParent();
+    Instruction *Term = BB->getTerminator();
+
+    if (MTI->getNextNode() == Term)
+        return true;
+
+    // Check that nothing modifies (or terminates) the source location
+    MemoryLocation SourceLoc = MemoryLocation::getForSource(MTI);
+    return !AA.canInstructionRangeModRef(*MTI->getNextNode(), *Term, SourceLoc,
+                                         ModRefInfo::Mod);
+}
+
+static bool operandsDominateBlock(Instruction *I, BasicBlock *Target, DominatorTree &DT)
+{
+    for (Use &Op : I->operands()) {
+        if (auto *OpInst = dyn_cast<Instruction>(Op.get())) {
+            // The operand must dominate the target block
+            if (!DT.dominates(OpInst, Target))
+                return false;
+        }
+        // Arguments and constants always dominate
+    }
+    return true;
+}
+
+// Find sink target for value-producing instructions.
+// Memory reads sink to an immediate successor; pure values sink to the NCD.
+BasicBlock *NewSinkState::findSinkTargetForValue(Instruction *I)
+{
+    assert(!I->use_empty() && "Value must have uses");
+    BasicBlock *CurrentBB = I->getParent();
+
+    SmallPtrSet<BasicBlock *, 8> UserBlocks;
+    for (Use &U : I->uses()) {
+        auto *UserInst = cast<Instruction>(U.getUser());
+        BasicBlock *UseBlock = UserInst->getParent();
+        if (auto *PN = dyn_cast<PHINode>(UserInst))
+            UseBlock = PN->getIncomingBlock(
+                PHINode::getIncomingValueNumForOperand(U.getOperandNo()));
+        if (DT.isReachableFromEntry(UseBlock))
+            UserBlocks.insert(UseBlock);
+    }
+
+    if (UserBlocks.empty())
+        return nullptr;
+
+    // For memory reads, we can only check for clobbers in the source block,
+    // so the target must be an immediate successor. Find which successor
+    // dominates all uses instead of computing a potentially distant NCD.
+    // The target must also have a single predecessor (our block) to ensure
+    // no other incoming path can modify the read location.
+    if (I->mayReadFromMemory()) {
+        Loop *CurLoop = LI.getLoopFor(CurrentBB);
+        BasicBlock *Target = nullptr;
+        for (BasicBlock *Succ : successors(CurrentBB)) {
+            // Skip self-loops and backedges — sinking a load backward
+            // in the CFG could move it before a store it depends on.
+            if (Succ == CurrentBB || DT.dominates(Succ, CurrentBB))
+                continue;
+            // Don't sink reads deeper within the same loop. Moving loads
+            // from unconditional positions to conditional blocks causes
+            // the loop vectorizer to emit masked loads, which are slower
+            // on most targets. LLVM's standard Sink pass similarly avoids
+            // sinking into loops for this reason.
+            if (CurLoop && CurLoop == LI.getLoopFor(Succ))
+                continue;
+            // Multi-predecessor targets are unsafe: other incoming paths
+            // may write to the read location between our block and the
+            // target. We only check clobbers in the source block, not on
+            // other paths through the CFG.
+            if (!Succ->hasNPredecessors(1))
+                continue;
+            bool DominatesAll = llvm::all_of(UserBlocks, [&](BasicBlock *UB) {
+                return UB == Succ || DT.dominates(Succ, UB);
+            });
+            if (DominatesAll) {
+                if (Target)
+                    return nullptr; // ambiguous
+                Target = Succ;
+            }
+        }
+        if (!Target)
+            return nullptr;
+        if (!canSinkMemoryRead(I, AA))
+            return nullptr;
+        return Target;
+    }
+
+    // For non-memory instructions, sink to the NCD of all use blocks.
+    BasicBlock *Target = nullptr;
+    for (BasicBlock *UB : UserBlocks) {
+        if (Target)
+            Target = DT.findNearestCommonDominator(Target, UB);
+        else
+            Target = UB;
+    }
+    if (Target == CurrentBB)
+        Target = nullptr;
+
+    return Target;
+}
+
+// Find sink target for memory writes (stores, memset, memcpy, etc.)
+// Uses alias analysis (MemorySSA) to verify no reads observe the wrong value.
+BasicBlock *NewSinkState::findSinkTargetForWrite(Instruction *I)
+{
+    assert(I->use_empty() && "Sinkable memory writes should have no uses");
+
+    BasicBlock *CurrentBB = I->getParent();
+
+    if (succ_size(CurrentBB) <= 1)
+        return nullptr;
+
+    // For memcpy/memmove, verify the source isn't modified before the terminator.
+    if (auto *MTI = dyn_cast<MemTransferInst>(I)) {
+        if (!canSinkMemTransfer(MTI, AA))
+            return nullptr;
+    }
+
+    Loop *CurLoop = LI.getLoopFor(CurrentBB);
+
+    Value *WritePtr = getWritePointer(I);
+
+    BasicBlock *Target = nullptr;
+    for (BasicBlock *Succ : successors(CurrentBB)) {
+        if (Succ == CurrentBB)
+            continue;
+
+        Loop *SuccLoop = LI.getLoopFor(Succ);
+
+        if (CurLoop != SuccLoop) {
+            // Crossing a loop boundary. Sinking out of a loop is only safe
+            // when all iterations write to the same address (loop-invariant
+            // destination) — otherwise earlier iterations' writes are lost.
+            // Sinking into a different loop is never safe.
+            if (!CurLoop || !WritePtr || !CurLoop->isLoopInvariant(WritePtr))
+                continue;
+        }
+        else if (CurLoop) {
+            // Same loop: require post-dominance so the store executes on
+            // every iteration (can't sink to a conditional branch inside
+            // the loop body).
+            if (!PDT.dominates(Succ, CurrentBB))
+                continue;
+        }
+
+        if (canSinkMemoryWriteToSuccessor(I, Succ)) {
+            if (!Target) {
+                Target = Succ;
+            }
+            else {
+                // Ambiguous: both targets are valid, so neither reads
+                // the store (dead write). Don't bother sinking.
+                return nullptr;
+            }
+        }
+    }
+
+    if (!Target)
+        return nullptr;
+
+    // Split critical edges for multi-predecessor targets.
+    if (!Target->hasNPredecessors(1)) {
+        CriticalEdgeSplittingOptions Options(&DT, &LI, &MSSAUpdater, &PDT);
+        auto *NewBB = SplitCriticalEdge(CurrentBB, Target, Options);
+        if (!NewBB)
+            return nullptr;
+        LLVM_DEBUG(dbgs() << "NewSink:   Split critical edge: "
+                          << CurrentBB->getName() << " -> " << NewBB->getName()
+                          << " -> " << Target->getName() << "\n");
+        Target = NewBB;
+    }
+
+    return Target;
+}
+
+// Check if an instruction can be sunk (not a terminator, PHI, alloca, etc.).
+bool NewSinkState::canSinkInstruction(Instruction *I) const
+{
+    if (I->isTerminator() || isa<PHINode>(I) || I->isEHPad())
+        return false;
+
+    if (I->mayThrow())
+        return false;
+
+    // Instructions that might not return (e.g., infinite loops)
+    if (!I->willReturn())
+        return false;
+
+    if (isa<AllocaInst>(I))
+        return false;
+
+    // Don't sink lifetime intrinsics. They're markers for alloca liveness
+    // and moving them can cause issues with memory analysis.
+    if (auto *II = dyn_cast<IntrinsicInst>(I)) {
+        if (II->getIntrinsicID() == Intrinsic::lifetime_start ||
+            II->getIntrinsicID() == Intrinsic::lifetime_end)
+            return false;
+    }
+
+    // Token types are used for coroutines and other constructs that
+    // have strict placement requirements
+    if (I->getType()->isTokenTy())
+        return false;
+
+    if (auto *CB = dyn_cast<CallBase>(I)) {
+        // Convergent operations cannot be made control-dependent on additional values
+        if (CB->isConvergent())
+            return false;
+        // Inline asm constraints can break if moved
+        if (CB->isInlineAsm())
+            return false;
+        // nomerge attribute prevents code motion
+        if (CB->cannotMerge())
+            return false;
+        // returns_twice (setjmp) is a control-flow barrier — it returns once
+        // normally and once via longjmp with potentially different memory state.
+        // Must not be sunk or reordered.
+        if (CB->hasFnAttr(Attribute::ReturnsTwice))
+            return false;
+    }
+
+    if (I->mayHaveSideEffects() && !I->mayWriteToMemory())
+        return false;
+
+    if (isMemoryWrite(I))
+        return isSinkableMemoryWrite(I);
+
+    return !I->mayHaveSideEffects();
+}
+
+// Try to sink an instruction to a target block. Returns true if sunk.
+bool NewSinkState::trySinkInstruction(Instruction *I)
+{
+    // Skip debug output for trivially non-sinkable instructions
+    bool TriviallyNonSinkable =
+        I->isTerminator() || isa<PHINode>(I) || isa<AllocaInst>(I) || I->isEHPad();
+    if (!TriviallyNonSinkable) {
+        LLVM_DEBUG(dbgs() << "NewSink: Trying to sink: " << *I << "\n");
+    }
+
+    if (!canSinkInstruction(I)) {
+        if (!TriviallyNonSinkable) {
+            LLVM_DEBUG(dbgs() << "NewSink:   Failed: instruction not sinkable\n");
+        }
+        return false;
+    }
+
+    BasicBlock *BB = I->getParent();
+    BasicBlock *Target = nullptr;
+
+    if (isMemoryWrite(I)) {
+        // Alias analysis determines where memory writes can sink
+        Target = findSinkTargetForWrite(I);
+        if (!Target) {
+            LLVM_DEBUG(dbgs() << "NewSink:   Failed: no valid target for memory write\n");
+        }
+    }
+    else if (!I->use_empty()) {
+        // Dominance analysis determines where values can sink
+        Target = findSinkTargetForValue(I);
+        if (!Target) {
+            LLVM_DEBUG(dbgs() << "NewSink:   Failed: no valid target for value\n");
+        }
+    }
+    else {
+        LLVM_DEBUG(dbgs() << "NewSink:   Failed: unused non-memory instruction\n");
+        return false;
+    }
+
+    if (!Target)
+        return false;
+
+    if (!operandsDominateBlock(I, Target, DT)) {
+        LLVM_DEBUG(dbgs() << "NewSink:   Failed: operands don't dominate target\n");
+        return false;
+    }
+
+    bool IsNoReturnPath = NoReturnBlocks.count(Target);
+
+    LLVM_DEBUG(dbgs() << "NewSink:   Sunk to " << Target->getName()
+                      << (IsNoReturnPath ? " (noreturn path)" : " (general)") << "\n");
+
+    ORE.emit([&]() {
+        return OptimizationRemark(DEBUG_TYPE, "InstructionSunk", I)
+               << "sunk " << ore::NV("Instruction", I) << " from "
+               << ore::NV("FromBlock", BB) << " to " << ore::NV("ToBlock", Target)
+               << (IsNoReturnPath ? " (noreturn path)" : " (general path)");
+    });
+
+#if JL_LLVM_VERSION >= 200000
+    I->moveBefore(Target->getFirstInsertionPt());
+#else
+    I->moveBefore(&*Target->getFirstInsertionPt());
+#endif
+
+    // Update MemorySSA if this instruction has a MemoryAccess
+    if (MemoryUseOrDef *MA = dyn_cast_or_null<MemoryUseOrDef>(MSSA.getMemoryAccess(I)))
+        MSSAUpdater.moveToPlace(MA, Target, MemorySSA::Beginning);
+
+    ++NumSunk;
+    if (IsNoReturnPath)
+        ++NumSunkToNoReturn;
+    else
+        ++NumSunkGeneral;
+
+    return true;
+}
+
+// Fixed-point iteration: process blocks in RPO, instructions in reverse order.
+bool NewSinkState::run()
+{
+    LLVM_DEBUG(dbgs() << "NewSink: noreturn blocks in " << F.getName() << ":";
+               for (BasicBlock *BB
+                    : NoReturnBlocks) dbgs()
+               << " " << BB->getName();
+               dbgs() << "\n");
+
+    bool Changed = false;
+    bool MadeProgress = true;
+    unsigned Iterations = 0;
+
+    while (MadeProgress && Iterations < MaxSinkingIterations) {
+        MadeProgress = false;
+        ++Iterations;
+        ++NumIterations;
+        LLVM_DEBUG(dbgs() << "NEWSINK ITERATION #" << Iterations << " on " << F.getName()
+                          << "\n");
+        ReversePostOrderTraversal<Function *> RPOT(&F);
+
+        for (BasicBlock *BB : RPOT) {
+            // Skip blocks with no successors and blocks where all paths
+            // lead to unreachable — there's nowhere useful to sink to.
+            if (succ_empty(BB) || NoReturnBlocks.count(BB))
+                continue;
+
+            // Process in reverse order to allow chains to sink together
+            SmallVector<Instruction *, 16> Worklist;
+            for (Instruction &I : *BB)
+                Worklist.push_back(&I);
+
+            for (auto It = Worklist.rbegin(); It != Worklist.rend(); ++It) {
+                if (trySinkInstruction(*It)) {
+                    MadeProgress = true;
+                    Changed = true;
+                }
+            }
+        }
+    }
+
+    if (Iterations >= MaxSinkingIterations) {
+        ++NumAbortedIterations;
+        LLVM_DEBUG(dbgs() << "NewSink: iteration limit reached for " << F.getName()
+                          << "\n");
+    }
+
+    return Changed;
+}
+
+} // anonymous namespace
+
+PreservedAnalyses NewSinkPass::run(Function &F, FunctionAnalysisManager &AM)
+{
+    auto &DT = AM.getResult<DominatorTreeAnalysis>(F);
+    auto &PDT = AM.getResult<PostDominatorTreeAnalysis>(F);
+    auto &LI = AM.getResult<LoopAnalysis>(F);
+    auto &AA = AM.getResult<AAManager>(F);
+    auto &MSSA = AM.getResult<MemorySSAAnalysis>(F).getMSSA();
+    auto &TLI = AM.getResult<TargetLibraryAnalysis>(F);
+    auto &ORE = AM.getResult<OptimizationRemarkEmitterAnalysis>(F);
+
+    NewSinkState State(F, DT, PDT, LI, AA, MSSA, TLI, ORE);
+    if (!State.run())
+        return PreservedAnalyses::all();
+#ifdef JL_VERIFY_PASSES
+    assert(!verifyLLVMIR(F));
+#endif
+    PreservedAnalyses PA;
+    PA.preserveSet<CFGAnalyses>();
+    PA.preserve<MemorySSAAnalysis>();
+    return PA;
+}

--- a/src/llvm-newsink.cpp
+++ b/src/llvm-newsink.cpp
@@ -111,7 +111,6 @@ struct NewSinkState {
     PostDominatorTree &PDT;
     LoopInfo &LI;
     AliasAnalysis &AA;
-    BatchAAResults BatchAA; // Caches AA queries
     MemorySSA &MSSA;
     MemorySSAUpdater MSSAUpdater; // Keeps MSSA consistent after modifications
     const TargetLibraryInfo &TLI;
@@ -119,6 +118,9 @@ struct NewSinkState {
 
     // Precomputed: blocks where all paths lead to unreachable
     SmallPtrSet<BasicBlock *, 16> NoReturnBlocks;
+
+    // Set when SplitCriticalEdge is called during a run
+    bool SplitCriticalEdges = false;
 
     NewSinkState(Function &F, DominatorTree &DT, PostDominatorTree &PDT,
                  LoopInfo &LI, AliasAnalysis &AA, MemorySSA &MSSA,
@@ -128,7 +130,6 @@ struct NewSinkState {
         PDT(PDT),
         LI(LI),
         AA(AA),
-        BatchAA(AA),
         MSSA(MSSA),
         MSSAUpdater(&MSSA),
         TLI(TLI),
@@ -195,8 +196,6 @@ void NewSinkState::collectNoReturnBlocks()
             if (!DT.isReachableFromEntry(Pred))
                 continue;
             if (NoReturnBlocks.count(Pred))
-                continue;
-            if (succ_empty(Pred))
                 continue;
 
             if (llvm::all_of(successors(Pred), [&](BasicBlock *Succ) {
@@ -308,6 +307,9 @@ BasicBlock *NewSinkState::canSinkMemoryWriteToSuccessor(Instruction *WriteInst,
     if (!MaybeLoc)
         return nullptr;
     MemoryLocation WriteLoc = *MaybeLoc;
+
+    // Fresh BatchAA per query to avoid stale cached results across iterations
+    BatchAAResults BatchAA(AA);
 
     BasicBlock *CurrentBB = WriteInst->getParent();
     assert(llvm::is_contained(successors(CurrentBB), TargetSucc) &&
@@ -660,6 +662,7 @@ BasicBlock *NewSinkState::findSinkTargetForWrite(Instruction *I)
         auto *NewBB = SplitCriticalEdge(CurrentBB, Target, Options);
         if (!NewBB)
             return nullptr;
+        SplitCriticalEdges = true;
         LLVM_DEBUG(dbgs() << "NewSink:   Split critical edge: "
                           << CurrentBB->getName() << " -> " << NewBB->getName()
                           << " -> " << Target->getName() << "\n");
@@ -715,9 +718,14 @@ bool NewSinkState::canSinkInstruction(Instruction *I) const
             return false;
     }
 
+    // Side effects other than memory writes (e.g. volatile reads, traps)
+    // cannot be sunk since they have observable ordering constraints.
     if (I->mayHaveSideEffects() && !I->mayWriteToMemory())
         return false;
 
+    // Memory writes with a known destination go through the MSSA-based path.
+    // Writes without a known destination (e.g. calls writing to unknown
+    // locations) fall through to the final check and are rejected.
     if (isMemoryWrite(I))
         return isSinkableMemoryWrite(I);
 
@@ -871,7 +879,8 @@ PreservedAnalyses NewSinkPass::run(Function &F, FunctionAnalysisManager &AM)
     assert(!verifyLLVMIR(F));
 #endif
     PreservedAnalyses PA;
-    PA.preserveSet<CFGAnalyses>();
+    if (!State.SplitCriticalEdges)
+        PA.preserveSet<CFGAnalyses>();
     PA.preserve<MemorySSAAnalysis>();
     return PA;
 }

--- a/src/passes.h
+++ b/src/passes.h
@@ -47,6 +47,9 @@ struct ExpandAtomicModifyPass : PassInfoMixin<ExpandAtomicModifyPass> {
     PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM) JL_NOTSAFEPOINT;
 };
 
+struct NewSinkPass : PassInfoMixin<NewSinkPass> {
+    PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM) JL_NOTSAFEPOINT;
+};
 
 // Module Passes
 struct CPUFeaturesPass : PassInfoMixin<CPUFeaturesPass> {

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -490,6 +490,7 @@ static void buildScalarOptimizerPipeline(FunctionPassManager &FPM, PassBuilder *
             FPM.addPass(CorrelatedValuePropagationPass());
             FPM.addPass(ADCEPass());
             FPM.addPass(MemCpyOptPass());
+            JULIA_PASS(FPM.addPass(NewSinkPass()));
             FPM.addPass(DSEPass());
             FPM.addPass(IRCEPass());
             FPM.addPass(JumpThreadingPass());

--- a/test/llvmpasses/.gitignore
+++ b/test/llvmpasses/.gitignore
@@ -1,2 +1,3 @@
 /Output/
+**/Output/
 .lit_test_times.txt

--- a/test/llvmpasses/Makefile
+++ b/test/llvmpasses/Makefile
@@ -6,7 +6,10 @@ check: .
 
 TESTS_ll := $(filter-out update-%,$(patsubst $(SRCDIR)/%,%,$(wildcard $(SRCDIR)/*.ll)))
 TESTS_jl := $(patsubst $(SRCDIR)/%,%,$(wildcard $(SRCDIR)/*.jl))
-TESTS := $(TESTS_ll) $(TESTS_jl)
+# Include subdirectory tests (e.g., newsink/)
+SUBDIRS := $(patsubst $(SRCDIR)/%/,%,$(wildcard $(SRCDIR)/*/))
+TESTS_subdir_ll := $(foreach dir,$(SUBDIRS),$(patsubst $(SRCDIR)/%,%,$(wildcard $(SRCDIR)/$(dir)/*.ll)))
+TESTS := $(TESTS_ll) $(TESTS_jl) $(TESTS_subdir_ll) $(SUBDIRS)
 
 . $(TESTS):
 	$(MAKE) -C $(JULIAHOME)/deps install-llvm-tools

--- a/test/llvmpasses/NewSink/newsink-ambiguous-target.ll
+++ b/test/llvmpasses/NewSink/newsink-ambiguous-target.ll
@@ -1,0 +1,116 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; Test that the MSSA walk prevents incorrect sinking when both paths need
+; the store, and that ambiguity (both targets valid) only arises for dead writes.
+
+declare void @use(ptr)
+declare void @throw(ptr)
+
+; Both successors read the store's location. The MSSA walk finds the reader
+; on the OTHER path and blocks sinking to either. Store must stay in entry.
+; CHECK-LABEL: @test_both_paths_read
+; CHECK: entry:
+; CHECK: store i64 %a, ptr %buf
+; CHECK: br i1
+define void @test_both_paths_read(i64 %a, i1 %cond) {
+entry:
+  %buf = alloca i64, align 8
+  store i64 %a, ptr %buf, align 8
+  br i1 %cond, label %left, label %right
+
+left:
+  call void @use(ptr %buf)
+  ret void
+
+right:
+  call void @use(ptr %buf)
+  ret void
+}
+
+; Only one successor reads the store. The MSSA walk blocks sinking to the
+; non-reading path, so only one target is valid — no ambiguity.
+; CHECK-LABEL: @test_one_path_reads
+; CHECK: entry:
+; CHECK-NOT: store i64 %a, ptr %buf
+; CHECK: br i1
+; CHECK: left:
+; CHECK: store i64 %a, ptr %buf
+define void @test_one_path_reads(i64 %a, i1 %cond) {
+entry:
+  %buf = alloca i64, align 8
+  store i64 %a, ptr %buf, align 8
+  br i1 %cond, label %left, label %right
+
+left:
+  call void @use(ptr %buf)
+  ret void
+
+right:
+  ret void
+}
+
+; Neither successor reads the store (dead write). Both targets pass the MSSA
+; walk. When both are non-noreturn, this is ambiguous and the store stays put.
+; DSE can clean up dead stores later.
+; CHECK-LABEL: @test_dead_write_ambiguous
+; CHECK: entry:
+; CHECK: store i64 %a, ptr %buf
+; CHECK: br i1
+define void @test_dead_write_ambiguous(i64 %a, i1 %cond) {
+entry:
+  %buf = alloca i64, align 8
+  store i64 %a, ptr %buf, align 8
+  br i1 %cond, label %left, label %right
+
+left:
+  ret void
+
+right:
+  ret void
+}
+
+; Memory read with two successors that both dominate all uses: ambiguous,
+; load stays put.
+; CHECK-LABEL: @test_load_ambiguous_successor
+; CHECK: entry:
+; CHECK: %v = load i64, ptr %p
+define i64 @test_load_ambiguous_successor(ptr %p, i1 %cond) {
+entry:
+  %v = load i64, ptr %p, align 8
+  br i1 %cond, label %left, label %right
+
+left:
+  br label %merge
+
+right:
+  br label %merge
+
+merge:
+  call void @use(i64 %v)
+  ret i64 %v
+}
+
+; The store sinks to right; %val stays in entry (used on both paths).
+; CHECK-LABEL: @test_operands_dont_dominate
+; CHECK: entry:
+; CHECK: %val = add i64 %a, %b
+; CHECK-NOT: store
+; CHECK: br i1
+; CHECK: right:
+; CHECK: store i64 %val, ptr %p
+declare void @use_i64(i64) nounwind willreturn memory(none)
+define void @test_operands_dont_dominate(i64 %a, i64 %b, i1 %cond) {
+entry:
+  %p = alloca i64, align 8
+  %val = add i64 %a, %b
+  store i64 %val, ptr %p, align 8
+  br i1 %cond, label %left, label %right
+
+left:
+  call void @use_i64(i64 %val)
+  ret void
+
+right:
+  call void @throw(ptr %p)
+  unreachable
+}

--- a/test/llvmpasses/NewSink/newsink-basic.ll
+++ b/test/llvmpasses/NewSink/newsink-basic.ll
@@ -1,0 +1,58 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; Test basic store sinking to error path
+; The stores to %tuple should be sunk to the error block since they're only used there
+
+define double @test_sink_stores(ptr %array, i64 %i, i64 %j, i64 %bound1, i64 %bound2) {
+; CHECK-LABEL: @test_sink_stores
+entry:
+  %tuple = alloca [2 x i64], align 8
+  ; These stores should be sunk to the error block
+  ; CHECK-NOT: store i64 %i, ptr %tuple
+  store i64 %i, ptr %tuple, align 8
+  %ptr1 = getelementptr inbounds i8, ptr %tuple, i64 8
+  ; CHECK-NOT: store i64 %j, ptr %ptr1
+  store i64 %j, ptr %ptr1, align 8
+
+  ; Bounds checks
+  %cmp1 = icmp ult i64 %i, %bound1
+  %cmp2 = icmp ult i64 %j, %bound2
+  %inbounds = and i1 %cmp1, %cmp2
+  br i1 %inbounds, label %ok, label %error
+
+error:
+  ; CHECK: error:
+  ; CHECK: store i64 %i, ptr %tuple
+  ; CHECK: store i64 %j, ptr %ptr1
+  call void @throw_error(ptr %tuple)
+  unreachable
+
+ok:
+  ; Load from array (unrelated to tuple)
+  %val = load double, ptr %array, align 8
+  ret double %val
+}
+
+declare void @throw_error(ptr)
+
+; Stores to noalias arguments can be sunk (isIdentifiedFunctionLocal).
+define i64 @test_sink_noalias_arg(ptr noalias %buf, i64 %val, i64 %bound) {
+; CHECK-LABEL: @test_sink_noalias_arg
+entry:
+  ; CHECK: entry:
+  ; CHECK-NEXT: %cmp = icmp ult i64 %val, %bound
+  ; CHECK-NEXT: br i1 %cmp
+  store i64 %val, ptr %buf, align 8
+  %cmp = icmp ult i64 %val, %bound
+  br i1 %cmp, label %ok, label %error
+
+ok:
+  ret i64 %val
+
+error:
+  ; CHECK: error:
+  ; CHECK-NEXT: store i64 %val, ptr %buf
+  ; CHECK-NEXT: call void @throw_error
+  call void @throw_error(ptr %buf)
+  unreachable
+}

--- a/test/llvmpasses/NewSink/newsink-chain.ll
+++ b/test/llvmpasses/NewSink/newsink-chain.ll
@@ -1,0 +1,94 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; Test that chains of dependent instructions are all sunk together
+
+define i64 @test_sink_chain(i64 %a, i64 %b, i64 %c, i64 %bound) {
+; CHECK-LABEL: @test_sink_chain
+entry:
+  ; All these computations form a chain and should be sunk together
+  ; CHECK-NOT: %sum = add i64 %a, %b
+  ; CHECK-NOT: %prod = mul i64 %sum, %c
+  ; CHECK-NOT: %final = sub i64 %prod, 1
+  %sum = add i64 %a, %b
+  %prod = mul i64 %sum, %c
+  %final = sub i64 %prod, 1
+
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  ; CHECK: error:
+  ; CHECK-DAG: %sum = add i64 %a, %b
+  ; CHECK-DAG: %prod = mul i64 %sum, %c
+  ; CHECK-DAG: %final = sub i64 %prod, 1
+  call void @use(i64 %final)
+  unreachable
+
+ok:
+  ret i64 %b
+}
+
+; Test partial chain - only part of the chain is used in error path
+
+define i64 @test_sink_partial_chain(i64 %a, i64 %b, i64 %c, i64 %bound) {
+; CHECK-LABEL: @test_sink_partial_chain
+entry:
+  ; %sum is used in both paths, so it stays
+  ; CHECK: %sum = add i64 %a, %b
+  %sum = add i64 %a, %b
+
+  ; %prod is only used in error path, so it should be sunk
+  ; CHECK-NOT: %prod = mul i64 %sum, %c
+  %prod = mul i64 %sum, %c
+
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  ; CHECK: error:
+  ; CHECK: %prod = mul i64 %sum, %c
+  call void @use(i64 %prod)
+  unreachable
+
+ok:
+  ; %sum is used here too
+  ret i64 %sum
+}
+
+; Test arithmetic + GEP + store chain - all sunk together
+
+define i64 @test_sink_arith_gep_store_chain(i64 %a, i64 %b, i64 %bound) {
+; CHECK-LABEL: @test_sink_arith_gep_store_chain
+entry:
+  %tuple = alloca [4 x i64], align 8
+  ; Arithmetic and GEPs feeding stores should all sink together
+  ; CHECK: entry:
+  ; CHECK-NEXT: %tuple = alloca [4 x i64]
+  ; CHECK-NEXT: %cmp = icmp ult i64 %a, %bound
+  ; CHECK-NEXT: br i1 %cmp
+  %sum = add i64 %a, %b
+  %gep1 = getelementptr [4 x i64], ptr %tuple, i64 0, i64 0
+  store i64 %sum, ptr %gep1, align 8
+  %gep2 = getelementptr [4 x i64], ptr %tuple, i64 0, i64 1
+  store i64 %b, ptr %gep2, align 8
+
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  ; CHECK: error:
+  ; CHECK-DAG: %sum = add i64 %a, %b
+  ; CHECK-DAG: %gep1 = getelementptr
+  ; CHECK-DAG: store i64 %sum, ptr %gep1
+  ; CHECK-DAG: %gep2 = getelementptr
+  ; CHECK-DAG: store i64 %b, ptr %gep2
+  ; CHECK: call void @throw
+  call void @throw(ptr %tuple)
+  unreachable
+
+ok:
+  ret i64 %a
+}
+
+declare void @use(i64)
+declare void @throw(ptr)

--- a/test/llvmpasses/NewSink/newsink-ehpad.ll
+++ b/test/llvmpasses/NewSink/newsink-ehpad.ll
@@ -1,0 +1,103 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; Tests for exception handling - should NOT sink into or across EH pads
+; Based on LLVM Sink pass test patterns
+
+declare void @may_throw()
+declare i32 @__gxx_personality_v0(...)
+
+; Test: Don't sink into landing pad blocks
+define i64 @test_no_sink_into_landingpad(i64 %a, i64 %bound) personality ptr @__gxx_personality_v0 {
+; CHECK-LABEL: @test_no_sink_into_landingpad
+entry:
+  %tuple = alloca i64, align 8
+  ; This store should NOT be sunk into landing pad
+  ; CHECK: entry:
+  ; CHECK: store i64 %a, ptr %tuple
+  store i64 %a, ptr %tuple, align 8
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %try, label %error
+
+try:
+  invoke void @may_throw()
+    to label %ok unwind label %lpad
+
+lpad:
+  ; Landing pad is an EH pad - cannot sink into it
+  %lp = landingpad { ptr, i32 }
+          cleanup
+  %v = load i64, ptr %tuple, align 8
+  call void @use(i64 %v)
+  resume { ptr, i32 } %lp
+
+error:
+  call void @throw_error(ptr %tuple)
+  unreachable
+
+ok:
+  ret i64 %a
+}
+
+; Test: Don't sink EH pad instructions
+define i64 @test_no_sink_ehpad_inst(i64 %a, i64 %bound) personality ptr @__gxx_personality_v0 {
+; CHECK-LABEL: @test_no_sink_ehpad_inst
+entry:
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %try, label %exit
+
+try:
+  invoke void @may_throw()
+    to label %ok unwind label %lpad
+
+lpad:
+  ; EH pad instruction should never be moved
+  ; CHECK: lpad:
+  ; CHECK: %lp = landingpad
+  %lp = landingpad { ptr, i32 }
+          cleanup
+  br label %cleanup
+
+cleanup:
+  call void @use(i64 %a)
+  unreachable
+
+ok:
+  ret i64 %a
+
+exit:
+  ret i64 0
+}
+
+; Test: Store only used after invoke can still be sunk to normal destination
+; but NOT into the unwind destination
+define i64 @test_sink_past_invoke_to_normal(i64 %a, i64 %bound) personality ptr @__gxx_personality_v0 {
+; CHECK-LABEL: @test_sink_past_invoke_to_normal
+entry:
+  %tuple = alloca i64, align 8
+  ; Store used only in error (unwind) path
+  ; CHECK: entry:
+  ; Store should stay in entry because landing pad is involved
+  store i64 %a, ptr %tuple, align 8
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %try, label %direct_error
+
+try:
+  invoke void @may_throw()
+    to label %ok unwind label %lpad
+
+lpad:
+  %lp = landingpad { ptr, i32 }
+          cleanup
+  call void @throw_error(ptr %tuple)
+  unreachable
+
+direct_error:
+  call void @throw_error(ptr %tuple)
+  unreachable
+
+ok:
+  ret i64 %a
+}
+
+declare void @use(i64)
+declare void @throw_error(ptr)

--- a/test/llvmpasses/NewSink/newsink-escape.ll
+++ b/test/llvmpasses/NewSink/newsink-escape.ll
@@ -1,0 +1,108 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; Test that stores to escaping noalias allocations are not sunk.
+;
+; When a noalias-allocated object escapes the function (via return, store to
+; global, or call), sinking a field store to one branch makes the field
+; uninitialized on the other branch. Inter-procedural reads through the
+; escaped pointer would see the wrong value, but the intra-function MSSA
+; walk cannot detect those reads.
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare noalias nonnull ptr @alloc(ptr)
+declare void @use_val(i64)
+
+; The object escapes via return — stores must not be sunk because the
+; caller will read all fields of the returned object.
+; CHECK-LABEL: @test_escape_via_return
+; CHECK: entry:
+; CHECK: store i64 %size, ptr %size_ptr
+; CHECK: br i1 %is_empty
+define ptr @test_escape_via_return(ptr %ptls, i1 %is_empty, i64 %size, ptr %data_buf) {
+entry:
+  %obj = call noalias nonnull ptr @alloc(ptr %ptls)
+  store ptr %data_buf, ptr %obj, align 8
+  %size_ptr = getelementptr inbounds i8, ptr %obj, i64 16
+  store i64 %size, ptr %size_ptr, align 8
+  br i1 %is_empty, label %done, label %fill
+
+fill:
+  call void @llvm.memset.p0.i64(ptr %data_buf, i8 0, i64 %size, i1 false)
+  br label %done
+
+done:
+  ret ptr %obj
+}
+
+; The object escapes via store to a global — same issue.
+; CHECK-LABEL: @test_escape_via_store
+; CHECK: entry:
+; CHECK: store i64 %size, ptr %size_ptr
+; CHECK: br i1 %is_empty
+@global_slot = external global ptr
+define void @test_escape_via_store(ptr %ptls, i1 %is_empty, i64 %size, ptr %data_buf) {
+entry:
+  %obj = call noalias nonnull ptr @alloc(ptr %ptls)
+  store ptr %data_buf, ptr %obj, align 8
+  %size_ptr = getelementptr inbounds i8, ptr %obj, i64 16
+  store i64 %size, ptr %size_ptr, align 8
+  br i1 %is_empty, label %done, label %fill
+
+fill:
+  call void @llvm.memset.p0.i64(ptr %data_buf, i8 0, i64 %size, i1 false)
+  br label %done
+
+done:
+  store ptr %obj, ptr @global_slot, align 8
+  ret void
+}
+
+; The object escapes via call — same issue.
+; CHECK-LABEL: @test_escape_via_call
+; CHECK: entry:
+; CHECK: store i64 %size, ptr %size_ptr
+; CHECK: br i1 %is_empty
+declare void @consume(ptr)
+define void @test_escape_via_call(ptr %ptls, i1 %is_empty, i64 %size, ptr %data_buf) {
+entry:
+  %obj = call noalias nonnull ptr @alloc(ptr %ptls)
+  store ptr %data_buf, ptr %obj, align 8
+  %size_ptr = getelementptr inbounds i8, ptr %obj, i64 16
+  store i64 %size, ptr %size_ptr, align 8
+  br i1 %is_empty, label %done, label %fill
+
+fill:
+  call void @llvm.memset.p0.i64(ptr %data_buf, i8 0, i64 %size, i1 false)
+  br label %done
+
+done:
+  call void @consume(ptr %obj)
+  ret void
+}
+
+; Negative test: object does NOT escape — store CAN be sunk to the
+; noreturn error path where the tuple is consumed.
+; CHECK-LABEL: @test_no_escape
+; CHECK: entry:
+; CHECK-NOT: store i64 %size
+; CHECK: br i1 %cmp
+declare void @throw_error(ptr) noreturn
+define void @test_no_escape(ptr %ptls, i64 %size, i64 %bound) {
+entry:
+  %obj = call noalias nonnull ptr @alloc(ptr %ptls)
+  %size_ptr = getelementptr inbounds i8, ptr %obj, i64 16
+  store i64 %size, ptr %size_ptr, align 8
+  %cmp = icmp ult i64 %size, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  call void @throw_error(ptr %obj)
+  unreachable
+
+ok:
+  ret void
+}
+
+declare void @llvm.memset.p0.i64(ptr, i8, i64, i1)

--- a/test/llvmpasses/NewSink/newsink-gc-store.ll
+++ b/test/llvmpasses/NewSink/newsink-gc-store.ll
@@ -1,0 +1,53 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; Test that stores to noalias-allocated objects are not incorrectly sunk
+; through critical edge splits to multi-predecessor targets.
+;
+; Bug pattern: When the MSSA walk evaluates a multi-predecessor target, it
+; skips reads "in the target" assuming they'll see the sunk write. But after
+; splitting the critical edge, the write lands on only one incoming path,
+; so reads arriving from the other predecessor see uninitialized data.
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare noalias nonnull ptr @alloc(ptr)
+declare void @use(ptr)
+declare void @use_val(i64)
+
+; CHECK-LABEL: @test_no_sink_to_critical_edge
+; The size store must stay in entry, not be sunk to a critical edge split block.
+; CHECK: entry:
+; CHECK: store i64 %size, ptr %size_ptr
+; CHECK: br i1 %is_empty, label %merge, label %fill
+; CHECK-NOT: entry.merge_crit_edge:
+define void @test_no_sink_to_critical_edge(ptr %ptls, ptr noalias %other_arr, i1 %is_empty, i64 %size, ptr %data_buf) {
+entry:
+  %obj = call noalias nonnull ptr @alloc(ptr %ptls)
+  store ptr %data_buf, ptr %obj, align 8, !tbaa !3
+  %size_ptr = getelementptr inbounds i8, ptr %obj, i64 16
+  store i64 %size, ptr %size_ptr, align 8, !tbaa !5
+  br i1 %is_empty, label %merge, label %fill
+
+fill:
+  call void @llvm.memset.p0.i64(ptr %data_buf, i8 0, i64 %size, i1 false), !tbaa !7
+  br label %merge
+
+merge:
+  %other_size_ptr = getelementptr inbounds i8, ptr %other_arr, i64 16
+  %other_size = load i64, ptr %other_size_ptr, align 8, !tbaa !5
+  call void @use_val(i64 %other_size)
+  call void @use(ptr %obj)
+  ret void
+}
+
+declare void @llvm.memset.p0.i64(ptr, i8, i64, i1)
+
+!0 = !{!"root"}
+!1 = !{!"jtbaa", !0, i64 0}
+!2 = !{!"jtbaa_arrayptr", !1, i64 0}
+!3 = !{!2, !2, i64 0}
+!4 = !{!"jtbaa_arraysize", !1, i64 0}
+!5 = !{!4, !4, i64 0}
+!6 = !{!"jtbaa_arraybuf", !1, i64 0}
+!7 = !{!6, !6, i64 0}

--- a/test/llvmpasses/NewSink/newsink-lifetime.ll
+++ b/test/llvmpasses/NewSink/newsink-lifetime.ll
@@ -1,0 +1,52 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; Test sinking with lifetime intrinsics - stores should sink to paths that
+; actually read the memory, ignoring paths with lifetime.end
+
+declare void @llvm.lifetime.end.p0(i64, ptr)
+declare void @use(ptr)
+
+; Store doesn't sink: the MSSA walk finds readers on both paths
+; (load in slow, lifetime.end in fast), so neither is a unique target.
+; CHECK-LABEL: @test_sink_past_lifetime_end
+; CHECK: entry:
+; CHECK-NEXT: %buf = alloca i64
+; CHECK-NEXT: store i64 %a, ptr %buf
+; CHECK-NEXT: %cmp = icmp ult i64 %a, %bound
+define i64 @test_sink_past_lifetime_end(i64 %a, i64 %bound) {
+entry:
+  %buf = alloca i64, align 8
+  store i64 %a, ptr %buf, align 8
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %fast, label %slow
+
+fast:
+  call void @llvm.lifetime.end.p0(i64 8, ptr %buf)
+  ret i64 %a
+
+slow:
+  %v = load i64, ptr %buf, align 8
+  ret i64 %v
+}
+
+; Both paths access the alloca, so no unique target.
+; CHECK-LABEL: @test_sink_needs_lifetime_end_both
+; CHECK: entry:
+; CHECK:   %buf = alloca i64
+; CHECK-NEXT: store i64 %a, ptr %buf
+; CHECK-NEXT: %cmp = icmp ult i64 %a, %bound
+define i64 @test_sink_needs_lifetime_end_both(i64 %a, i64 %bound) {
+entry:
+  %buf = alloca i64, align 8
+  store i64 %a, ptr %buf, align 8
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %fast, label %slow
+
+fast:
+  call void @llvm.lifetime.end.p0(i64 8, ptr %buf)
+  ret i64 %a
+
+slow:
+  call void @use(ptr %buf)
+  ret i64 0
+}

--- a/test/llvmpasses/NewSink/newsink-limits.ll
+++ b/test/llvmpasses/NewSink/newsink-limits.ll
@@ -1,0 +1,38 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -newsink-memoryssa-scanlimit=2 -S %s | FileCheck %s --check-prefix=SCANLIMIT
+
+declare void @throw(ptr)
+
+; MSSA scan limit: with scanlimit=2, the walk aborts and conservatively
+; keeps the store. With default limit it would sink.
+; SCANLIMIT-LABEL: @test_mssa_scan_limit
+; SCANLIMIT: entry:
+; SCANLIMIT: store i64 %a, ptr %p
+define void @test_mssa_scan_limit(i64 %a, i1 %c1, i1 %c2, i1 %c3) {
+entry:
+  %p = alloca i64, align 8
+  store i64 %a, ptr %p, align 8
+  br i1 %c1, label %b1, label %error
+
+b1:
+  br i1 %c2, label %b2, label %exit1
+
+b2:
+  br i1 %c3, label %b3, label %exit2
+
+b3:
+  br label %exit3
+
+exit1:
+  ret void
+
+exit2:
+  ret void
+
+exit3:
+  ret void
+
+error:
+  call void @throw(ptr %p)
+  unreachable
+}
+

--- a/test/llvmpasses/NewSink/newsink-llvm-patterns.ll
+++ b/test/llvmpasses/NewSink/newsink-llvm-patterns.ll
@@ -1,0 +1,138 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; Tests adapted from LLVM Sink and DSE pass test suites
+; These cover interesting edge cases from the official LLVM test infrastructure
+
+;; ============================================================================
+;; From LLVM Sink/dead-user.ll - Dead blocks with no predecessors
+;; ============================================================================
+
+; Test: Dead block (unreachable infinite loop) should not crash the pass
+; The pass should complete without error and preserve the CFG structure
+define void @test_dead_block_no_predecessors(i16 %p1, i1 %arg) {
+; CHECK-LABEL: @test_dead_block_no_predecessors
+; CHECK: bb.0:
+; CHECK: %conv = sext i16 %p1 to i32
+; CHECK: br i1 %arg, label %bb.1, label %bb.3
+bb.0:
+  %conv = sext i16 %p1 to i32
+  br i1 %arg, label %bb.1, label %bb.3
+
+bb.1:
+  br label %bb.2
+
+bb.2:
+  %and.2 = and i32 undef, %conv
+  br label %bb.2
+
+bb.3:
+  %and.3 = and i32 undef, %conv
+  br label %bb.3
+
+dead:
+  ; No predecessors - this block is unreachable
+  %and.dead = and i32 undef, %conv
+  br label %dead
+}
+
+; Test: Dead block referenced in PHI node (from dead_from_phi)
+; The pass should complete without error and preserve the CFG structure
+define i32 @test_dead_block_phi(i32 %a) {
+; CHECK-LABEL: @test_dead_block_phi
+; CHECK: entry:
+; CHECK: br i1 %.not, label %if.end, label %if.then
+; CHECK: if.end:
+; CHECK: phi i32
+; CHECK: ret i32
+entry:
+  %.not = icmp eq i32 %a, 0
+  br i1 %.not, label %if.end, label %if.then
+
+if.then:
+  %b = and i32 undef, 65535
+  br label %if.end
+
+dead:
+  ; No predecessors but referenced in PHI
+  br label %if.end
+
+if.end:
+  %.0 = phi i32 [ %a, %entry ], [ %b, %if.then ], [ %b, %dead ]
+  ret i32 %.0
+}
+
+;; ============================================================================
+;; From LLVM DSE/multiblock-unreachable.ll - Unreachable exits
+;; ============================================================================
+
+; Store sinks to if.then (only read there). The store in if.end writes a
+; different value and doesn't depend on the first store.
+define void @unreachable_exit_with_no_call(ptr %ptr, i1 %c.1) {
+; CHECK-LABEL: @unreachable_exit_with_no_call
+; CHECK: entry:
+; CHECK-NOT: store
+; CHECK: br i1
+; CHECK: if.then:
+; CHECK-NEXT: store i64 1, ptr %loc
+entry:
+  %loc = alloca i64, align 8
+  store i64 1, ptr %loc, align 8
+  br i1 %c.1, label %if.then, label %if.end
+
+if.then:
+  call void @throw(ptr %loc)
+  unreachable
+
+if.end:
+  store i64 0, ptr %loc, align 8
+  ret void
+}
+
+;; ============================================================================
+;; Complex CFG patterns
+;; ============================================================================
+
+; Test: Complex CFG with unreachable blocks and no predecessors
+; From DSE multiblock-unreachable.ll @test
+; The pass should complete without error on this complex CFG
+define void @test_complex_cfg_with_unreachable(ptr %ptr, i1 %c.1, i1 %c.2, i1 %c.3) {
+; CHECK-LABEL: @test_complex_cfg_with_unreachable
+; CHECK: bb:
+; CHECK: br i1 %c.1
+; CHECK: bb27:
+; CHECK: br i1 %c.3
+bb:
+  br i1 %c.1, label %bb27, label %bb53
+
+bb10:
+  ; No predecessors - dead block
+  br label %bb43
+
+bb22:
+  ; Self-loop
+  br i1 %c.2, label %bb22, label %bb53
+
+bb27:
+  br i1 %c.3, label %bb38, label %bb39
+
+bb38:
+  ; Infinite loop
+  store float 0.000000e+00, ptr %ptr, align 4
+  br label %bb38
+
+bb39:
+  br i1 %c.2, label %bb43, label %bb38
+
+bb43:
+  store float 0.000000e+00, ptr %ptr, align 4
+  br label %bb50
+
+bb50:
+  br i1 %c.3, label %bb27, label %bb53
+
+bb53:
+  ; Unreachable infinite loop
+  br label %bb53
+}
+
+declare void @throw(ptr)

--- a/test/llvmpasses/NewSink/newsink-loop-complex.ll
+++ b/test/llvmpasses/NewSink/newsink-loop-complex.ll
@@ -1,0 +1,359 @@
+; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='function(NewSink)' -S %s | FileCheck %s
+
+; Complex loop tests: multiple exits, nested loops, post-dominance cases
+; Note: We avoid calls between stores and branches because unknown calls
+; are conservatively assumed to read memory, which blocks sinking.
+
+
+declare void @use(ptr)
+declare void @throw(ptr)
+
+; =============================================================================
+; Multiple loop exits
+; =============================================================================
+
+; Test: Loop with two normal exits - store used on one exit path
+; Store should NOT be sunk because we're in a loop and target doesn't post-dominate
+; CHECK-LABEL: @test_loop_multiple_exits
+; CHECK: loop_header:
+; CHECK: store i64 %i, ptr %buf
+define void @test_loop_multiple_exits(i64 %n, i1 %c1, i1 %c2) {
+entry:
+  %buf = alloca i64, align 8
+  br label %loop_header
+
+loop_header:
+  %i = phi i64 [ 0, %entry ], [ %next, %loop_latch ]
+  store i64 %i, ptr %buf, align 8
+  br i1 %c1, label %exit_a, label %check_b
+
+check_b:
+  br i1 %c2, label %exit_b, label %loop_latch
+
+loop_latch:
+  %next = add i64 %i, 1
+  %done = icmp eq i64 %next, %n
+  br i1 %done, label %exit_c, label %loop_header
+
+exit_a:
+  call void @use(ptr %buf)
+  ret void
+
+exit_b:
+  ret void
+
+exit_c:
+  ret void
+}
+
+; Test: Loop with error exit (unreachable) - CAN sink to error path
+; CHECK-LABEL: @test_loop_error_exit
+; CHECK: loop_header:
+; CHECK-NOT: store i64 %i, ptr %buf
+; CHECK: error_exit:
+; CHECK: store i64 %i, ptr %buf
+define void @test_loop_error_exit(i64 %n, i1 %c1) {
+entry:
+  %buf = alloca i64, align 8
+  br label %loop_header
+
+loop_header:
+  %i = phi i64 [ 0, %entry ], [ %next, %loop_latch ]
+  store i64 %i, ptr %buf, align 8
+  br i1 %c1, label %error_exit, label %loop_latch
+
+loop_latch:
+  %next = add i64 %i, 1
+  %done = icmp eq i64 %next, %n
+  br i1 %done, label %normal_exit, label %loop_header
+
+error_exit:
+  call void @throw(ptr %buf)
+  unreachable
+
+normal_exit:
+  ret void
+}
+
+; =============================================================================
+; Nested loops - various sinking scenarios
+; =============================================================================
+
+; Test: Store in outer loop header, read in inner loop
+; Should NOT sink - inner loop iterations need the store
+; CHECK-LABEL: @test_nested_outer_to_inner
+; CHECK: outer_header:
+; CHECK: store i64 %i, ptr %buf
+define void @test_nested_outer_to_inner(i64 %n, i64 %m, i1 %c) {
+entry:
+  %buf = alloca i64, align 8
+  br label %outer_header
+
+outer_header:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %outer_latch ]
+  store i64 %i, ptr %buf, align 8
+  br label %inner_header
+
+inner_header:
+  %j = phi i64 [ 0, %outer_header ], [ %j.next, %inner_latch ]
+  %v = load i64, ptr %buf, align 8
+  br i1 %c, label %inner_latch, label %outer_latch
+
+inner_latch:
+  %j.next = add i64 %j, 1
+  %inner_done = icmp eq i64 %j.next, %m
+  br i1 %inner_done, label %outer_latch, label %inner_header
+
+outer_latch:
+  %i.next = add i64 %i, 1
+  %outer_done = icmp eq i64 %i.next, %n
+  br i1 %outer_done, label %exit, label %outer_header
+
+exit:
+  ret void
+}
+
+; Test: Store in inner loop header, read only on one path
+; Should NOT sink - other inner iterations need the store
+; CHECK-LABEL: @test_nested_inner_header_store
+; CHECK: inner_header:
+; CHECK: store i64 %j, ptr %buf
+define void @test_nested_inner_header_store(i64 %n, i64 %m, i1 %c) {
+entry:
+  %buf = alloca i64, align 8
+  br label %outer_header
+
+outer_header:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %outer_latch ]
+  br label %inner_header
+
+inner_header:
+  %j = phi i64 [ 0, %outer_header ], [ %j.next, %inner_latch ]
+  store i64 %j, ptr %buf, align 8
+  br i1 %c, label %use_path, label %skip_path
+
+use_path:
+  call void @use(ptr %buf)
+  br label %inner_latch
+
+skip_path:
+  br label %inner_latch
+
+inner_latch:
+  %j.next = add i64 %j, 1
+  %inner_done = icmp eq i64 %j.next, %m
+  br i1 %inner_done, label %outer_latch, label %inner_header
+
+outer_latch:
+  %i.next = add i64 %i, 1
+  %outer_done = icmp eq i64 %i.next, %n
+  br i1 %outer_done, label %exit, label %outer_header
+
+exit:
+  ret void
+}
+
+; Store in inner loop sinks to inner error exit.
+; CHECK-LABEL: @test_nested_inner_error_exit
+; CHECK: inner_header:
+; CHECK-NOT: store i64 %j, ptr %buf
+; CHECK: inner_error:
+; CHECK: store i64 %j, ptr %buf
+define void @test_nested_inner_error_exit(i64 %n, i64 %m, i1 %c) {
+entry:
+  %buf = alloca i64, align 8
+  br label %outer_header
+
+outer_header:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %outer_latch ]
+  br label %inner_header
+
+inner_header:
+  %j = phi i64 [ 0, %outer_header ], [ %j.next, %inner_latch ]
+  store i64 %j, ptr %buf, align 8
+  br i1 %c, label %inner_error, label %inner_latch
+
+inner_latch:
+  %j.next = add i64 %j, 1
+  %inner_done = icmp eq i64 %j.next, %m
+  br i1 %inner_done, label %outer_latch, label %inner_header
+
+inner_error:
+  call void @throw(ptr %buf)
+  unreachable
+
+outer_latch:
+  %i.next = add i64 %i, 1
+  %outer_done = icmp eq i64 %i.next, %n
+  br i1 %outer_done, label %exit, label %outer_header
+
+exit:
+  ret void
+}
+
+; Test: Early exit from nested loop to outer error
+; Store in outer, error exit from inner - CANNOT sink
+; (outer_error is not a direct successor of outer_header, only inner_header is)
+; CHECK-LABEL: @test_nested_early_exit_error
+; CHECK: outer_header:
+; CHECK: store i64 %i, ptr %buf
+define void @test_nested_early_exit_error(i64 %n, i64 %m, i1 %c) {
+entry:
+  %buf = alloca i64, align 8
+  br label %outer_header
+
+outer_header:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %outer_latch ]
+  store i64 %i, ptr %buf, align 8
+  br label %inner_header
+
+inner_header:
+  %j = phi i64 [ 0, %outer_header ], [ %j.next, %inner_latch ]
+  br i1 %c, label %outer_error, label %inner_latch
+
+inner_latch:
+  %j.next = add i64 %j, 1
+  %inner_done = icmp eq i64 %j.next, %m
+  br i1 %inner_done, label %outer_latch, label %inner_header
+
+outer_error:
+  call void @throw(ptr %buf)
+  unreachable
+
+outer_latch:
+  %i.next = add i64 %i, 1
+  %outer_done = icmp eq i64 %i.next, %n
+  br i1 %outer_done, label %exit, label %outer_header
+
+exit:
+  ret void
+}
+
+; =============================================================================
+; Don't sink INTO a different loop
+; =============================================================================
+
+; Test: Store before loop, target is inside loop - should NOT sink
+; CHECK-LABEL: @test_no_sink_into_loop
+; CHECK: entry:
+; CHECK: store i64 %a, ptr %buf
+define void @test_no_sink_into_loop(i64 %a, i64 %n, i1 %enter) {
+entry:
+  %buf = alloca i64, align 8
+  store i64 %a, ptr %buf, align 8
+  br i1 %enter, label %loop_header, label %skip
+
+loop_header:
+  %i = phi i64 [ 0, %entry ], [ %next, %loop_latch ]
+  call void @use(ptr %buf)
+  br label %loop_latch
+
+loop_latch:
+  %next = add i64 %i, 1
+  %done = icmp eq i64 %next, %n
+  br i1 %done, label %exit, label %loop_header
+
+skip:
+  ret void
+
+exit:
+  ret void
+}
+
+; =============================================================================
+; Post-dominance cases - when sinking IS allowed in loops
+; =============================================================================
+
+; Test: Linear loop body - single successor, no benefit to sinking
+; (We skip sinking when there's only one successor since it doesn't reduce work)
+; CHECK-LABEL: @test_loop_linear_body
+; CHECK: loop_header:
+; CHECK: store i64 %i, ptr %buf
+define void @test_loop_linear_body(i64 %n) {
+entry:
+  %buf = alloca i64, align 8
+  br label %loop_header
+
+loop_header:
+  %i = phi i64 [ 0, %entry ], [ %next, %loop_body ]
+  store i64 %i, ptr %buf, align 8
+  br label %loop_body
+
+loop_body:
+  call void @use(ptr %buf)
+  %next = add i64 %i, 1
+  %done = icmp eq i64 %next, %n
+  br i1 %done, label %exit, label %loop_header
+
+exit:
+  ret void
+}
+
+; =============================================================================
+; Loop with multiple back-edges
+; =============================================================================
+
+; Test: Loop with two back-edges (continue from two places)
+; Store should NOT be sunk (neither path post-dominates)
+; CHECK-LABEL: @test_loop_multiple_backedges
+; CHECK: loop_header:
+; CHECK: store i64 %i, ptr %buf
+define void @test_loop_multiple_backedges(i64 %n, i1 %c1, i1 %c2) {
+entry:
+  %buf = alloca i64, align 8
+  br label %loop_header
+
+loop_header:
+  %i = phi i64 [ 0, %entry ], [ %next1, %continue1 ], [ %next2, %continue2 ]
+  store i64 %i, ptr %buf, align 8
+  br i1 %c1, label %path_a, label %path_b
+
+path_a:
+  br i1 %c2, label %use_and_exit, label %continue1
+
+path_b:
+  br label %continue2
+
+use_and_exit:
+  call void @use(ptr %buf)
+  ret void
+
+continue1:
+  %next1 = add i64 %i, 1
+  br label %loop_header
+
+continue2:
+  %next2 = add i64 %i, 2
+  br label %loop_header
+}
+
+; Store must not be sunk into a different loop.
+; CHECK-LABEL: @test_no_sink_into_different_loop
+; CHECK: between_loops:
+; CHECK: store i64 42, ptr %buf
+define void @test_no_sink_into_different_loop(i64 %n) {
+entry:
+  %buf = alloca i64, align 8
+  br label %loop1
+
+loop1:
+  %i = phi i64 [ 0, %entry ], [ %next1, %loop1 ]
+  %next1 = add nuw nsw i64 %i, 1
+  %done1 = icmp eq i64 %next1, %n
+  br i1 %done1, label %between_loops, label %loop1
+
+between_loops:
+  store i64 42, ptr %buf, align 8
+  br i1 true, label %loop2, label %exit
+
+loop2:
+  %j = phi i64 [ 0, %between_loops ], [ %next2, %loop2 ]
+  %v = load i64, ptr %buf, align 8
+  %next2 = add nuw nsw i64 %j, 1
+  %done2 = icmp eq i64 %next2, %n
+  br i1 %done2, label %exit, label %loop2
+
+exit:
+  call void @use(ptr %buf)
+  ret void
+}

--- a/test/llvmpasses/NewSink/newsink-loop.ll
+++ b/test/llvmpasses/NewSink/newsink-loop.ll
@@ -1,0 +1,429 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; ============================================================================
+; Sinking TO error blocks inside loops
+; ============================================================================
+
+; Store to loop-invariant alloca sinks to error exit.
+define i64 @test_loop_with_error_block(ptr %array, i64 %n) {
+; CHECK-LABEL: @test_loop_with_error_block
+entry:
+  %tuple = alloca i64, align 8
+  br label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %loop.latch ]
+  ; CHECK: loop:
+  ; CHECK-NOT: store i64 %i, ptr %tuple
+  store i64 %i, ptr %tuple, align 8
+
+  %cmp = icmp ult i64 %i, %n
+  br i1 %cmp, label %loop.latch, label %error
+
+loop.latch:
+  %ptr = getelementptr i64, ptr %array, i64 %i
+  %val = load i64, ptr %ptr, align 8
+  %i.next = add i64 %i, 1
+  %done = icmp eq i64 %i.next, %n
+  br i1 %done, label %exit, label %loop
+
+error:
+  ; CHECK: error:
+  ; CHECK: store i64 %i, ptr %tuple
+  call void @throw_bounds_error(ptr %tuple)
+  unreachable
+
+exit:
+  ret i64 0
+}
+
+; Self-loop: store sinks to error exit.
+define void @test_infinite_loop_with_error(ptr %array, i64 %n) {
+; CHECK-LABEL: @test_infinite_loop_with_error
+entry:
+  %tuple = alloca i64, align 8
+  br label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %loop ]
+  ; CHECK: loop:
+  ; CHECK-NOT: store i64 %i, ptr %tuple
+  store i64 %i, ptr %tuple, align 8
+
+  %cmp = icmp ult i64 %i, %n
+  %i.next = add i64 %i, 1
+  br i1 %cmp, label %loop, label %error
+
+error:
+  ; CHECK: error:
+  ; CHECK: store i64 %i, ptr %tuple
+  call void @throw_bounds_error(ptr %tuple)
+  unreachable
+}
+
+; Store must NOT sink: the latch reads the stored value.
+define i64 @test_loop_value_used_in_latch(ptr %array, i64 %n) {
+; CHECK-LABEL: @test_loop_value_used_in_latch
+entry:
+  %tuple = alloca i64, align 8
+  br label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %loop.latch ]
+  ; CHECK: loop:
+  ; CHECK: store i64 %i, ptr %tuple
+  store i64 %i, ptr %tuple, align 8
+
+  %cmp = icmp ult i64 %i, %n
+  br i1 %cmp, label %loop.latch, label %error
+
+loop.latch:
+  %loaded = load i64, ptr %tuple, align 8
+  %i.next = add i64 %loaded, 1
+  %done = icmp eq i64 %i.next, %n
+  br i1 %done, label %exit, label %loop
+
+error:
+  call void @throw_bounds_error(ptr %tuple)
+  unreachable
+
+exit:
+  ret i64 0
+}
+
+; ============================================================================
+; Cross-loop sinking: loop-invariant vs loop-variant destinations
+; ============================================================================
+
+; Loop-invariant destination: CAN sink out of loop (all iterations write
+; to the same address, only the last write matters).
+; CHECK-LABEL: @test_sink_loop_invariant_dest_to_exit
+; CHECK: loop:
+; CHECK-NOT: store i64 %i, ptr %buf
+; CHECK: br i1
+; CHECK: exit:
+; CHECK: store i64 %i, ptr %buf
+; CHECK: call void @use_value
+define void @test_sink_loop_invariant_dest_to_exit(i64 %n) {
+entry:
+  %buf = alloca i64, align 8
+  br label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %next, %latch ]
+  store i64 %i, ptr %buf, align 8
+  %cmp = icmp ult i64 %i, %n
+  br i1 %cmp, label %latch, label %exit
+
+latch:
+  %next = add nuw nsw i64 %i, 1
+  br label %loop
+
+exit:
+  call void @use_value(ptr %buf)
+  ret void
+}
+
+; Loop-variant destination: must NOT sink (earlier iterations' writes lost).
+; CHECK-LABEL: @test_no_sink_loop_variant_dest
+; CHECK: loop:
+; CHECK: store i64 42, ptr %dest
+; CHECK: br i1
+define void @test_no_sink_loop_variant_dest(i64 %n) {
+entry:
+  %buf = alloca [8 x i64], align 8
+  br label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %next, %latch ]
+  %dest = getelementptr inbounds i64, ptr %buf, i64 %i
+  store i64 42, ptr %dest, align 8
+  %cmp = icmp ult i64 %i, %n
+  br i1 %cmp, label %latch, label %exit
+
+latch:
+  %next = add nuw nsw i64 %i, 1
+  br label %loop
+
+exit:
+  call void @use_value(ptr %buf)
+  ret void
+}
+
+; Loop-variant memcpy destination: must NOT sink.
+define void @test_no_sink_memcpy_out_of_loop() {
+; CHECK-LABEL: @test_no_sink_memcpy_out_of_loop
+entry:
+  %buf = alloca [32 x i8], align 16
+  %tmp = alloca [16 x i8], align 16
+  call void @llvm.memset.p0.i64(ptr %buf, i8 0, i64 32, i1 false)
+  br label %loop
+
+; CHECK: loop:
+; CHECK: call void @compute_result
+; CHECK: call void @llvm.memcpy
+; CHECK: br i1
+loop:
+  %i = phi i64 [ 0, %entry ], [ %next, %loop ]
+  call void @compute_result(ptr sret([16 x i8]) %tmp, i64 %i)
+  %offset = shl i64 %i, 4
+  %dest = getelementptr inbounds i8, ptr %buf, i64 %offset
+  call void @llvm.memcpy.p0.p0.i64(ptr %dest, ptr %tmp, i64 16, i1 false)
+  %next = add nuw nsw i64 %i, 1
+  %done = icmp eq i64 %next, 2
+  br i1 %done, label %exit, label %loop
+
+; CHECK: exit:
+; CHECK-NOT: call void @llvm.memcpy
+; CHECK: call void @use_buffer
+exit:
+  call void @use_buffer(ptr %buf)
+  ret void
+}
+
+; Loop-invariant destination with a load on the backedge.
+; The load must NOT be sunk within the loop — sinking reads deeper
+; within a loop causes the loop vectorizer to emit masked loads.
+; CHECK-LABEL: @test_no_sink_loop_invariant_with_backedge_reader
+; CHECK: loop:
+; CHECK: store i64 %i, ptr %buf
+; CHECK: %val = load i64, ptr %buf
+define i64 @test_no_sink_loop_invariant_with_backedge_reader(i64 %n) {
+entry:
+  %buf = alloca i64, align 8
+  store i64 0, ptr %buf, align 8
+  br label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %next, %latch ]
+  store i64 %i, ptr %buf, align 8
+  %val = load i64, ptr %buf, align 8
+  %cmp = icmp ult i64 %i, %n
+  br i1 %cmp, label %latch, label %exit
+
+latch:
+  %next = add nuw nsw i64 %val, 1
+  br label %loop
+
+exit:
+  %result = load i64, ptr %buf, align 8
+  ret i64 %result
+}
+
+; ============================================================================
+; Must NOT sink INTO loops
+; ============================================================================
+
+; Store before loop, read in loop body — must not sink.
+define i64 @test_no_sink_store_into_loop(i64 %a, i64 %n) {
+; CHECK-LABEL: @test_no_sink_store_into_loop
+entry:
+  %p = alloca i64, align 8
+  ; CHECK: entry:
+  ; CHECK: store i64 %a, ptr %p
+  store i64 %a, ptr %p, align 8
+  br label %loop.header
+
+loop.header:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %loop.latch ]
+  %cmp = icmp ult i64 %i, %n
+  br i1 %cmp, label %loop.body, label %exit
+
+loop.body:
+  %v = load i64, ptr %p, align 8
+  %result = add i64 %v, %i
+  br label %loop.latch
+
+loop.latch:
+  %i.next = add i64 %i, 1
+  br label %loop.header
+
+exit:
+  %final = load i64, ptr %p, align 8
+  ret i64 %final
+}
+
+; ============================================================================
+; Post-dominance and backedge safety
+; ============================================================================
+
+; Stores must not sink when target doesn't post-dominate source in a loop.
+; Sinking to use_state_path would skip stores on iterations taking skip_state_path.
+
+; CHECK-LABEL: @test_loop_backedge_sink
+; CHECK: loop_header:
+; CHECK-NEXT: phi i64
+; CHECK-NEXT: phi i64
+; CHECK: store i64 %iter_val
+; CHECK: store i64 %state_val
+define void @test_loop_backedge_sink() {
+entry:
+  %state = alloca [7 x i64], align 8
+  %flag = call i1 @get_flag()
+  br i1 %flag, label %setup_path, label %direct_path
+
+setup_path:
+  %v1 = call i64 @get_value()
+  %v2 = call i64 @get_value()
+  br label %loop_header
+
+direct_path:
+  br label %loop_header
+
+loop_header:
+  %iter_val = phi i64 [ %v1, %setup_path ], [ 0, %direct_path ], [ %next_val, %loop_latch ]
+  %state_val = phi i64 [ %v2, %setup_path ], [ 0, %direct_path ], [ %new_state, %loop_latch ]
+  store i64 %iter_val, ptr %state, align 8
+  %ptr2 = getelementptr i8, ptr %state, i64 8
+  store i64 %state_val, ptr %ptr2, align 8
+  br i1 %flag, label %use_state_path, label %skip_state_path
+
+use_state_path:
+  %as11 = addrspacecast ptr %state to ptr addrspace(11)
+  call void @use_state(ptr addrspace(11) %as11)
+  br label %loop_latch
+
+skip_state_path:
+  br label %loop_latch
+
+loop_latch:
+  %next_val = add i64 %iter_val, 1
+  %new_state = add i64 %state_val, 1
+  %done = icmp eq i64 %next_val, 10
+  br i1 %done, label %exit, label %loop_header
+
+exit:
+  ret void
+}
+
+; Stores in loop header must not sink to a successor (the successor
+; doesn't post-dominate the header due to the backedge).
+; CHECK-LABEL: @test_loop_header_store
+define void @test_loop_header_store() {
+entry:
+  %state = alloca [2 x i64], align 8
+  br label %loop_header
+
+; CHECK-LABEL: loop_header:
+; CHECK: phi i64
+; CHECK: store i64 %i, ptr %state
+; CHECK: store i64 42, ptr %ptr2
+loop_header:
+  %i = phi i64 [ 0, %entry ], [ %next, %loop_latch ]
+  store i64 %i, ptr %state, align 8
+  %ptr2 = getelementptr i8, ptr %state, i64 8
+  store i64 42, ptr %ptr2, align 8
+  %cond = call i1 @get_cond()
+  br i1 %cond, label %loop_latch, label %exit_path
+
+loop_latch:
+  %next = add i64 %i, 1
+  br label %loop_header
+
+exit_path:
+  call void @use_state_p(ptr %state)
+  ret void
+}
+
+; Same with memcpy in loop header.
+; CHECK-LABEL: @test_loop_header_memcpy
+define void @test_loop_header_memcpy(ptr %src) {
+entry:
+  %state = alloca [16 x i8], align 8
+  br label %loop_header
+
+; CHECK-LABEL: loop_header:
+; CHECK: phi i64
+; CHECK: call void @llvm.memcpy
+loop_header:
+  %i = phi i64 [ 0, %entry ], [ %next, %loop_latch ]
+  call void @llvm.memcpy.p0.p0.i64(ptr %state, ptr %src, i64 16, i1 false)
+  %cond = call i1 @get_cond()
+  br i1 %cond, label %loop_latch, label %exit_path
+
+loop_latch:
+  %next = add i64 %i, 1
+  br label %loop_header
+
+exit_path:
+  call void @use_state_p(ptr %state)
+  ret void
+}
+
+; ============================================================================
+; Must NOT sink reads deeper within the same loop (vectorization hazard)
+; ============================================================================
+
+; Sinking loads from the loop header to a conditional block within the
+; loop causes the loop vectorizer to emit masked loads instead of
+; unconditional vector loads. This is the perf_countequals pattern:
+; the union type tag is checked first, and the value load is only needed
+; in one branch — but keeping it unconditional enables full vectorization.
+; CHECK-LABEL: @test_no_sink_read_within_loop
+define i64 @test_no_sink_read_within_loop(ptr %tags, ptr %vals, i64 %n) {
+entry:
+  br label %loop
+
+; CHECK: loop:
+; CHECK: %tag = load i8, ptr %tag_ptr
+; CHECK: %val = load i64, ptr %val_ptr
+; CHECK: br i1 %is_valid
+loop:
+  %i = phi i64 [ 0, %entry ], [ %next, %merge ]
+  %sum = phi i64 [ 0, %entry ], [ %new_sum, %merge ]
+  %tag_ptr = getelementptr i8, ptr %tags, i64 %i
+  %tag = load i8, ptr %tag_ptr, align 1
+  %val_ptr = getelementptr i64, ptr %vals, i64 %i
+  %val = load i64, ptr %val_ptr, align 8
+  %is_valid = icmp ne i8 %tag, 0
+  br i1 %is_valid, label %use_val, label %merge
+
+use_val:
+  %add = add i64 %sum, %val
+  br label %merge
+
+merge:
+  %new_sum = phi i64 [ %add, %use_val ], [ %sum, %loop ]
+  %next = add nuw i64 %i, 1
+  %done = icmp eq i64 %next, %n
+  br i1 %done, label %exit, label %loop
+
+exit:
+  ret i64 %new_sum
+}
+
+; Negative test: sinking a read OUT of a loop to an exit block IS allowed.
+; The load reads from %other (not clobbered by the store to %buf).
+; CHECK-LABEL: @test_sink_read_to_loop_exit
+define i64 @test_sink_read_to_loop_exit(ptr noalias %buf, ptr noalias %other, i64 %n) {
+entry:
+  br label %loop
+
+; CHECK: loop:
+; CHECK-NOT: %result = load
+; CHECK: br i1 %done
+loop:
+  %i = phi i64 [ 0, %entry ], [ %next, %loop ]
+  %result = load i64, ptr %other, align 8
+  store i64 %i, ptr %buf, align 8
+  %next = add nuw i64 %i, 1
+  %done = icmp eq i64 %next, %n
+  br i1 %done, label %exit, label %loop
+
+; CHECK: exit:
+; CHECK: %result = load i64, ptr %other
+exit:
+  ret i64 %result
+}
+
+declare void @throw_bounds_error(ptr)
+declare void @use_value(ptr)
+declare void @use_buffer(ptr)
+declare void @compute_result(ptr noalias sret([16 x i8]), i64)
+declare void @use_state(ptr addrspace(11) nocapture readonly)
+declare void @use_state_p(ptr)
+declare i1 @get_flag()
+declare i1 @get_cond()
+declare i64 @get_value()
+declare void @llvm.memset.p0.i64(ptr, i8, i64, i1)
+declare void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)

--- a/test/llvmpasses/NewSink/newsink-memintrinsic.ll
+++ b/test/llvmpasses/NewSink/newsink-memintrinsic.ll
@@ -1,0 +1,152 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; Test sinking of memory intrinsics (memset, memcpy, memmove).
+
+declare void @throw(ptr)
+declare void @llvm.memset.p0.i64(ptr, i8, i64, i1)
+declare void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
+declare void @llvm.lifetime.end.p0(i64, ptr)
+declare ptr @strcpy(ptr, ptr) nounwind willreturn
+
+; Basic memset sinks to error path.
+; CHECK-LABEL: @test_memset_sink_to_error
+; CHECK: entry:
+; CHECK:   %buf = alloca [64 x i8]
+; CHECK-NEXT: %cmp = icmp
+; CHECK: error:
+; CHECK-NEXT: call void @llvm.memset
+define i64 @test_memset_sink_to_error(i64 %a, i64 %bound) {
+entry:
+  %buf = alloca [64 x i8], align 8
+  call void @llvm.memset.p0.i64(ptr %buf, i8 0, i64 64, i1 false)
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+ok:
+  ret i64 %a
+error:
+  call void @throw(ptr %buf)
+  unreachable
+}
+
+; Volatile memset should NOT be sunk.
+; CHECK-LABEL: @test_volatile_memset_no_sink
+; CHECK: entry:
+; CHECK-NEXT: %buf = alloca [64 x i8]
+; CHECK-NEXT: call void @llvm.memset{{.*}}i1 true
+define i64 @test_volatile_memset_no_sink(i64 %a, i64 %bound) {
+entry:
+  %buf = alloca [64 x i8], align 8
+  call void @llvm.memset.p0.i64(ptr %buf, i8 0, i64 64, i1 true)
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+ok:
+  ret i64 %a
+error:
+  call void @throw(ptr %buf)
+  unreachable
+}
+
+; strcpy with return value used — not sinkable (use_empty check).
+; CHECK-LABEL: @test_strcpy_with_uses_no_sink
+; CHECK: entry:
+; CHECK:   %buf = alloca [64 x i8]
+; CHECK-NEXT: %p = call ptr @strcpy
+define i64 @test_strcpy_with_uses_no_sink(i64 %a, i64 %bound, ptr %src) {
+entry:
+  %buf = alloca [64 x i8], align 8
+  %p = call ptr @strcpy(ptr %buf, ptr %src)
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+ok:
+  ret i64 %a
+error:
+  call void @throw(ptr %p)
+  unreachable
+}
+
+; canSinkMemTransfer: source modified by volatile store blocks memcpy.
+; CHECK-LABEL: @test_memcpy_source_volatile_store_no_sink
+; CHECK: entry:
+; CHECK:   call void @llvm.memcpy
+; CHECK-NEXT: store volatile i8 99, ptr %src
+define i64 @test_memcpy_source_volatile_store_no_sink(i64 %a, i64 %bound) {
+entry:
+  %src = alloca [64 x i8], align 8
+  %dest = alloca [64 x i8], align 8
+  call void @llvm.memcpy.p0.p0.i64(ptr %dest, ptr %src, i64 64, i1 false)
+  store volatile i8 99, ptr %src, align 1
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+ok:
+  ret i64 %a
+error:
+  call void @throw(ptr %dest)
+  unreachable
+}
+
+; canSinkMemTransfer: source lifetime.end blocks memcpy.
+; CHECK-LABEL: @test_memcpy_source_lifetime_end_no_sink
+; CHECK: entry:
+; CHECK:   call void @llvm.memcpy
+; CHECK-NEXT: call void @llvm.lifetime.end
+define i64 @test_memcpy_source_lifetime_end_no_sink(i64 %a, i64 %bound) {
+entry:
+  %src = alloca [64 x i8], align 8
+  %dest = alloca [64 x i8], align 8
+  call void @llvm.memcpy.p0.p0.i64(ptr %dest, ptr %src, i64 64, i1 false)
+  call void @llvm.lifetime.end.p0(i64 64, ptr %src)
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+ok:
+  ret i64 %a
+error:
+  call void @throw(ptr %dest)
+  unreachable
+}
+
+; Dead store blocks memcpy (store modifies source between memcpy and terminator).
+; CHECK-LABEL: @test_memcpy_dead_store_blocks_both
+; CHECK: entry:
+; CHECK:   call void @llvm.memcpy
+; CHECK-NEXT: store i8 99, ptr %src
+define i64 @test_memcpy_dead_store_blocks_both(i64 %a, i64 %bound) {
+entry:
+  %src = alloca [64 x i8], align 8
+  %dest = alloca [64 x i8], align 8
+  call void @llvm.memcpy.p0.p0.i64(ptr %dest, ptr %src, i64 64, i1 false)
+  store i8 99, ptr %src, align 1
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+ok:
+  ret i64 %a
+error:
+  call void @throw(ptr %dest)
+  unreachable
+}
+
+; Memcpy and unrelated store/load sink to different paths.
+; CHECK-LABEL: @test_memcpy_store_load_all_sink
+; CHECK: entry:
+; CHECK:   %dest = alloca [64 x i8]
+; CHECK-NEXT: %cmp = icmp
+; CHECK: ok:
+; CHECK-NEXT: store i8 99, ptr %src
+; CHECK-NEXT: %v = load i8, ptr %src
+; CHECK: error:
+; CHECK-NEXT: call void @llvm.memcpy
+define i64 @test_memcpy_store_load_all_sink(i64 %a, i64 %bound) {
+entry:
+  %src = alloca [64 x i8], align 8
+  %dest = alloca [64 x i8], align 8
+  call void @llvm.memcpy.p0.p0.i64(ptr %dest, ptr %src, i64 64, i1 false)
+  store i8 99, ptr %src, align 1
+  %v = load i8, ptr %src, align 1
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+ok:
+  %ext = zext i8 %v to i64
+  ret i64 %ext
+error:
+  call void @throw(ptr %dest)
+  unreachable
+}

--- a/test/llvmpasses/NewSink/newsink-multipred.ll
+++ b/test/llvmpasses/NewSink/newsink-multipred.ll
@@ -1,0 +1,166 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; Test cases with multiple predecessors to error blocks
+; Adapted from D136218 multiblock-sink.ll patterns
+
+; Test: Error block has multiple predecessors, stores from different blocks.
+; Stores are NOT sunk to multi-predecessor targets because the MSSA walk
+; cannot guarantee reads in the target see correct values from all incoming
+; edges after a critical edge split. This is a conservative restriction
+; that prevents miscompilation when an object escapes and is read later.
+define i64 @test_multi_pred_error_block(i64 %a, i64 %b, i64 %bound1, i64 %bound2) {
+; CHECK-LABEL: @test_multi_pred_error_block
+entry:
+  %tuple = alloca i64, align 8
+  ; CHECK: entry:
+  ; CHECK: store i64 %a, ptr %tuple
+  ; CHECK: br i1 %cmp1
+  store i64 %a, ptr %tuple, align 8
+  %cmp1 = icmp ult i64 %a, %bound1
+  br i1 %cmp1, label %check2, label %error
+
+check2:
+  ; CHECK: check2:
+  ; CHECK: store i64 %b, ptr %tuple
+  ; CHECK: br i1 %cmp2
+  store i64 %b, ptr %tuple, align 8
+  %cmp2 = icmp ult i64 %b, %bound2
+  br i1 %cmp2, label %ok, label %error
+
+error:
+  call void @throw_bounds_error(ptr %tuple)
+  unreachable
+
+ok:
+  ret i64 %a
+}
+
+declare void @throw_bounds_error(ptr)
+declare void @use(i64)
+
+;; ============================================================================
+;; PHI node handling
+;; ============================================================================
+
+; Test: PHI nodes in error blocks - values used by PHI should sink to incoming blocks
+define i64 @test_phi_in_error_block(i64 %a, i64 %b, i64 %bound, i1 %cond) {
+; CHECK-LABEL: @test_phi_in_error_block
+entry:
+  ; These should be sunk since PHI uses are in error block
+  ; CHECK-NOT: %sum1 = add i64 %a, 1
+  ; CHECK-NOT: %sum2 = add i64 %b, 2
+  %sum1 = add i64 %a, 1
+  %sum2 = add i64 %b, 2
+
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error_entry
+
+error_entry:
+  br i1 %cond, label %error1, label %error2
+
+error1:
+  ; CHECK: error1:
+  ; CHECK: %sum1 = add i64 %a, 1
+  br label %error_merge
+
+error2:
+  ; CHECK: error2:
+  ; CHECK: %sum2 = add i64 %b, 2
+  br label %error_merge
+
+error_merge:
+  %phi = phi i64 [ %sum1, %error1 ], [ %sum2, %error2 ]
+  call void @use(i64 %phi)
+  unreachable
+
+ok:
+  ret i64 %a
+}
+
+; Test: PHI node with use from non-error block - should NOT sink
+define i64 @test_phi_mixed_sources(i64 %a, i64 %b, i64 %bound, i1 %cond) {
+; CHECK-LABEL: @test_phi_mixed_sources
+entry:
+  ; This should NOT be sunk because PHI has incoming from non-error block
+  ; CHECK: entry:
+  ; CHECK: %sum = add i64 %a, %b
+  %sum = add i64 %a, %b
+
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %maybe_ok, label %error
+
+maybe_ok:
+  br i1 %cond, label %ok, label %also_error
+
+also_error:
+  br label %merge
+
+error:
+  br label %merge
+
+merge:
+  %phi = phi i64 [ %sum, %also_error ], [ %sum, %error ]
+  call void @use(i64 %phi)
+  unreachable
+
+ok:
+  ret i64 %b
+}
+
+;; ============================================================================
+;; Common error dominator patterns
+;; ============================================================================
+
+; Value sinks to common dominator of all use blocks.
+define i64 @test_sink_common_error_dominator(i64 %a, i64 %b, i64 %bound, i1 %cond) {
+; CHECK-LABEL: @test_sink_common_error_dominator
+; CHECK: entry:
+; CHECK-NEXT: %cmp = icmp
+; CHECK-NEXT: br i1 %cmp
+entry:
+  %sum = add i64 %a, %b
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error_dispatch
+
+error_dispatch:
+  ; CHECK: error_dispatch:
+  ; CHECK: %sum = add i64 %a, %b
+  br i1 %cond, label %error1, label %error2
+
+error1:
+  call void @use(i64 %sum)
+  unreachable
+
+error2:
+  call void @use(i64 %sum)
+  unreachable
+
+ok:
+  ret i64 %b
+}
+
+; NCD of use blocks is entry (CurrentBB) — stays put.
+define i64 @test_no_sink_no_common_error_dominator(i64 %a, i64 %b, i64 %bound1, i64 %bound2) {
+; CHECK-LABEL: @test_no_sink_no_common_error_dominator
+entry:
+  ; CHECK: entry:
+  ; CHECK: %sum = add i64 %a, %b
+  %sum = add i64 %a, %b
+  %cmp1 = icmp ult i64 %a, %bound1
+  br i1 %cmp1, label %check2, label %error1
+
+check2:
+  %cmp2 = icmp ult i64 %b, %bound2
+  br i1 %cmp2, label %ok, label %error2
+
+error1:
+  call void @use(i64 %sum)
+  unreachable
+
+error2:
+  call void @use(i64 %sum)
+  unreachable
+
+ok:
+  ret i64 %b
+}

--- a/test/llvmpasses/NewSink/newsink-nosink.ll
+++ b/test/llvmpasses/NewSink/newsink-nosink.ll
@@ -1,0 +1,353 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; Tests for instructions that should NOT be sunk
+
+declare void @throw_error(ptr)
+declare void @use(i64)
+declare void @use_ptr(ptr)
+declare token @llvm.coro.id(i32, ptr, ptr, ptr)
+declare i1 @llvm.coro.alloc(token)
+declare i64 @may_not_return(i64) memory(none)
+
+; Test: Convergent calls should not be sunk
+define i64 @test_convergent(i64 %val, i64 %bound) {
+; CHECK-LABEL: @test_convergent
+; CHECK: entry:
+; CHECK-NEXT: %result = call i64 @convergent_op(i64 %val)
+; CHECK-NEXT: %cmp = icmp
+entry:
+  %result = call i64 @convergent_op(i64 %val)
+  %cmp = icmp ult i64 %val, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  call void @use(i64 %result)
+  call void @throw_error(ptr null)
+  unreachable
+
+ok:
+  ret i64 %val
+}
+
+declare i64 @convergent_op(i64) convergent
+
+; Test: Inline asm should not be sunk
+define i64 @test_inline_asm(i64 %val, i64 %bound) {
+; CHECK-LABEL: @test_inline_asm
+; CHECK: entry:
+; CHECK-NEXT: %result = call i64 asm
+; CHECK-NEXT: %cmp = icmp
+entry:
+  %result = call i64 asm "mov $1, $0", "=r,r"(i64 %val)
+  %cmp = icmp ult i64 %val, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  call void @use(i64 %result)
+  call void @throw_error(ptr null)
+  unreachable
+
+ok:
+  ret i64 %val
+}
+
+; Test: nomerge calls should not be sunk
+define i64 @test_nomerge(i64 %val, i64 %bound) {
+; CHECK-LABEL: @test_nomerge
+; CHECK: entry:
+; CHECK-NEXT: %result = call i64 @nomerge_op(i64 %val)
+; CHECK-NEXT: %cmp = icmp
+entry:
+  %result = call i64 @nomerge_op(i64 %val) nomerge
+  %cmp = icmp ult i64 %val, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  call void @use(i64 %result)
+  call void @throw_error(ptr null)
+  unreachable
+
+ok:
+  ret i64 %val
+}
+
+declare i64 @nomerge_op(i64)
+
+; Test: Volatile loads should not be sunk
+define i64 @test_volatile_load(ptr %p, i64 %bound) {
+; CHECK-LABEL: @test_volatile_load
+; CHECK: entry:
+; CHECK-NEXT: %val = load volatile i64, ptr %p
+; CHECK-NEXT: %cmp = icmp
+entry:
+  %val = load volatile i64, ptr %p
+  %cmp = icmp ult i64 %val, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  call void @use(i64 %val)
+  call void @throw_error(ptr null)
+  unreachable
+
+ok:
+  ret i64 0
+}
+
+; Test: Atomic loads with ordering should not be sunk
+define i64 @test_atomic_load(ptr %p, i64 %bound) {
+; CHECK-LABEL: @test_atomic_load
+; CHECK: entry:
+; CHECK-NEXT: %val = load atomic i64, ptr %p seq_cst
+; CHECK-NEXT: %cmp = icmp
+entry:
+  %val = load atomic i64, ptr %p seq_cst, align 8
+  %cmp = icmp ult i64 %val, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  call void @use(i64 %val)
+  call void @throw_error(ptr null)
+  unreachable
+
+ok:
+  ret i64 0
+}
+
+; Test: Volatile stores should not be sunk
+define i64 @test_volatile_store(ptr %p, i64 %val, i64 %bound) {
+; CHECK-LABEL: @test_volatile_store
+; CHECK: entry:
+; CHECK-NEXT: store volatile i64 %val, ptr %p
+; CHECK-NEXT: %cmp = icmp
+entry:
+  store volatile i64 %val, ptr %p
+  %cmp = icmp ult i64 %val, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  call void @throw_error(ptr %p)
+  unreachable
+
+ok:
+  ret i64 %val
+}
+
+; Test: Fence should not be sunk
+define i64 @test_fence(i64 %val, i64 %bound) {
+; CHECK-LABEL: @test_fence
+; CHECK: entry:
+; CHECK-NEXT: fence seq_cst
+; CHECK-NEXT: %cmp = icmp
+entry:
+  fence seq_cst
+  %cmp = icmp ult i64 %val, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  call void @throw_error(ptr null)
+  unreachable
+
+ok:
+  ret i64 %val
+}
+
+; Test: AtomicRMW should not be sunk
+define i64 @test_atomicrmw(ptr %p, i64 %val, i64 %bound) {
+; CHECK-LABEL: @test_atomicrmw
+; CHECK: entry:
+; CHECK-NEXT: %old = atomicrmw add ptr %p, i64 %val seq_cst
+; CHECK-NEXT: %cmp = icmp
+entry:
+  %old = atomicrmw add ptr %p, i64 %val seq_cst
+  %cmp = icmp ult i64 %val, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  call void @use(i64 %old)
+  call void @throw_error(ptr null)
+  unreachable
+
+ok:
+  ret i64 %val
+}
+
+; Test: AtomicCmpXchg should not be sunk
+define i64 @test_cmpxchg(ptr %p, i64 %expected, i64 %new, i64 %bound) {
+; CHECK-LABEL: @test_cmpxchg
+; CHECK: entry:
+; CHECK-NEXT: %result = cmpxchg ptr %p, i64 %expected, i64 %new seq_cst seq_cst
+; CHECK-NEXT: %val = extractvalue
+; CHECK-NEXT: %cmp = icmp
+entry:
+  %result = cmpxchg ptr %p, i64 %expected, i64 %new seq_cst seq_cst
+  %val = extractvalue { i64, i1 } %result, 0
+  %cmp = icmp ult i64 %val, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  call void @use(i64 %val)
+  call void @throw_error(ptr null)
+  unreachable
+
+ok:
+  ret i64 %val
+}
+
+; Test: Calls that may throw should not be sunk
+define i64 @test_maythrow(i64 %val, i64 %bound) {
+; CHECK-LABEL: @test_maythrow
+; CHECK: entry:
+; CHECK-NEXT: %result = call i64 @may_throw_op(i64 %val)
+; CHECK-NEXT: %cmp = icmp
+entry:
+  %result = call i64 @may_throw_op(i64 %val)
+  %cmp = icmp ult i64 %val, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  call void @use(i64 %result)
+  call void @throw_error(ptr null)
+  unreachable
+
+ok:
+  ret i64 %val
+}
+
+declare i64 @may_throw_op(i64)
+
+
+; Test: Store to local alloca NOT sunk past fence (conservative)
+define i64 @test_no_sink_store_past_fence(i64 %a, i64 %bound) {
+; CHECK-LABEL: @test_no_sink_store_past_fence
+entry:
+  %loc = alloca i64, align 8
+  ; Store is NOT sunk past fence
+  ; CHECK: entry:
+  ; CHECK: store i64 %a, ptr %loc
+  ; CHECK: fence seq_cst
+  store i64 %a, ptr %loc, align 8
+  fence seq_cst
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  %v = load i64, ptr %loc, align 8
+  call void @use(i64 %v)
+  unreachable
+
+ok:
+  ret i64 %a
+}
+
+; Test: Store used on both paths should NOT be sunk
+define double @test_store_used_both_paths(ptr %array, i64 %i, i64 %bound) {
+; CHECK-LABEL: @test_store_used_both_paths
+entry:
+  %shared = alloca i64, align 8
+  ; This store should NOT be sunk because %shared is loaded on the ok path
+  ; CHECK: entry:
+  ; CHECK: store i64 %i, ptr %shared
+  store i64 %i, ptr %shared, align 8
+
+  %cmp = icmp ult i64 %i, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  call void @throw_error(ptr %shared)
+  unreachable
+
+ok:
+  ; Also used here - prevents sinking
+  %loaded = load i64, ptr %shared, align 8
+  %arrayptr = getelementptr double, ptr %array, i64 %loaded
+  %val = load double, ptr %arrayptr, align 8
+  ret double %val
+}
+
+; Test: Calls without willreturn should not be sunk
+; CHECK-LABEL: @test_no_willreturn
+; CHECK: entry:
+; CHECK: call i64 @may_not_return
+define i64 @test_no_willreturn(i64 %a, i1 %cond) {
+entry:
+  %v = call i64 @may_not_return(i64 %a)
+  br i1 %cond, label %use_it, label %skip
+
+use_it:
+  call void @use(i64 %v)
+  unreachable
+
+skip:
+  ret i64 0
+}
+
+; Test: Token-typed instructions should not be sunk
+; CHECK-LABEL: @test_token_type
+; CHECK: entry:
+; CHECK: call token @llvm.coro.id
+define void @test_token_type(i1 %cond) {
+entry:
+  %tok = call token @llvm.coro.id(i32 0, ptr null, ptr null, ptr null)
+  %alloc = call i1 @llvm.coro.alloc(token %tok)
+  br i1 %cond, label %use_it, label %skip
+
+use_it:
+  br label %skip
+
+skip:
+  ret void
+}
+
+; Test: Store in a block with one successor stays (no benefit from sinking)
+; CHECK-LABEL: @test_single_successor_store
+; CHECK: entry:
+; CHECK: store i64 42, ptr %p
+define void @test_single_successor_store() {
+entry:
+  %p = alloca i64, align 8
+  store i64 42, ptr %p, align 8
+  br label %next
+
+next:
+  call void @use_ptr(ptr %p)
+  ret void
+}
+
+; Test: Stores to global pointers are not sunk (not function-local)
+@global = external global i64
+; CHECK-LABEL: @test_no_sink_global_store
+; CHECK: entry:
+; CHECK: store i64 %a, ptr @global
+define i64 @test_no_sink_global_store(i64 %a, i64 %bound) {
+entry:
+  store i64 %a, ptr @global, align 8
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  %v = load i64, ptr @global, align 8
+  call void @use(i64 %v)
+  unreachable
+
+ok:
+  ret i64 %a
+}
+
+; Test: Stores to external pointers are not sunk (not function-local)
+; CHECK-LABEL: @test_no_sink_external_ptr_store
+; CHECK: entry:
+; CHECK: store i64 %a, ptr %p
+define i64 @test_no_sink_external_ptr_store(ptr %p, i64 %a, i64 %bound) {
+entry:
+  store i64 %a, ptr %p, align 8
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  %v = load i64, ptr %p, align 8
+  call void @use(i64 %v)
+  unreachable
+
+ok:
+  ret i64 %a
+}

--- a/test/llvmpasses/NewSink/newsink-pure.ll
+++ b/test/llvmpasses/NewSink/newsink-pure.ll
@@ -1,0 +1,81 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; Test sinking of calls with various memory attributes.
+
+declare void @report_error(i64)
+declare void @use_buffer(ptr)
+
+; Readnone call sinks (doesNotAccessMemory — no clobber check needed).
+; CHECK-LABEL: @test_sink_pure_call
+; CHECK: entry:
+; CHECK-NOT: call i64 @pure_compute
+; CHECK: error:
+; CHECK-NEXT: %result = call i64 @pure_compute
+declare i64 @pure_compute(i64, i64) readnone nounwind willreturn
+define i64 @test_sink_pure_call(i64 %a, i64 %b, i64 %bound) {
+entry:
+  %result = call i64 @pure_compute(i64 %a, i64 %b)
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+error:
+  call void @report_error(i64 %result)
+  unreachable
+ok:
+  ret i64 %b
+}
+
+; Readonly call sinks (canSinkMemoryRead verifies no intervening clobber).
+; CHECK-LABEL: @test_sink_readonly_call
+; CHECK: entry:
+; CHECK-NOT: call i64 @readonly_compute
+; CHECK: error:
+; CHECK-NEXT: %result = call i64 @readonly_compute
+declare i64 @readonly_compute(ptr) readonly nounwind willreturn
+define i64 @test_sink_readonly_call(i64 %a, ptr %p, i64 %bound) {
+entry:
+  %result = call i64 @readonly_compute(ptr %p)
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+error:
+  call void @report_error(i64 %result)
+  unreachable
+ok:
+  ret i64 %a
+}
+
+; Writing call with return value — not sinkable (mayHaveSideEffects).
+; CHECK-LABEL: @test_no_sink_argmem_write_with_retval
+; CHECK: entry:
+; CHECK-NEXT: %result = call i64 @argmem_write_fn
+declare i64 @argmem_write_fn(ptr, i64) nounwind willreturn memory(argmem: write)
+define i64 @test_no_sink_argmem_write_with_retval(i64 %a, ptr %p, i64 %bound) {
+entry:
+  %result = call i64 @argmem_write_fn(ptr %p, i64 %a)
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+error:
+  call void @report_error(i64 %result)
+  unreachable
+ok:
+  ret i64 %a
+}
+
+; Writing call with no return value sinks via the write path.
+; CHECK-LABEL: @test_sink_argmem_write_void
+; CHECK: entry:
+; CHECK-NOT: call void @argmem_write_void_fn
+; CHECK: error:
+; CHECK-NEXT: call void @argmem_write_void_fn
+declare void @argmem_write_void_fn(ptr, i64) nounwind willreturn memory(argmem: write)
+define i64 @test_sink_argmem_write_void(i64 %a, i64 %bound) {
+entry:
+  %buf = alloca i64, align 8
+  call void @argmem_write_void_fn(ptr %buf, i64 %a)
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+error:
+  call void @use_buffer(ptr %buf)
+  unreachable
+ok:
+  ret i64 %a
+}

--- a/test/llvmpasses/NewSink/newsink-read-multipred.ll
+++ b/test/llvmpasses/NewSink/newsink-read-multipred.ll
@@ -1,0 +1,53 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; Test that memory reads are not sunk to multi-predecessor targets.
+;
+; When a load is sunk from block A to a merge block M that also has
+; predecessor B, writes on the A→B→M path can modify the loaded location.
+; Since we only check for clobbers in the source block, sinking to a
+; multi-predecessor target is unsafe.
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare void @modify(ptr)
+
+; The load of %val must NOT be sunk to %merge because the modify→merge
+; path writes to %ptr (via @modify), changing what the load would read.
+; This is the heappop! pattern: x = xs[1] is sunk past percolate_down!
+; which overwrites xs[1].
+; CHECK-LABEL: @test_no_sink_read_to_multipred
+; CHECK: entry:
+; CHECK: %val = load i64, ptr %ptr
+; CHECK: br i1 %cond
+define i64 @test_no_sink_read_to_multipred(ptr %ptr, i1 %cond) {
+entry:
+  %val = load i64, ptr %ptr, align 8
+  br i1 %cond, label %merge, label %modify_path
+
+modify_path:
+  call void @modify(ptr %ptr)
+  br label %merge
+
+merge:
+  ret i64 %val
+}
+
+; Negative test: single-predecessor target is fine for read sinking.
+; CHECK-LABEL: @test_sink_read_to_single_pred
+; CHECK: entry:
+; CHECK-NOT: load i64, ptr %ptr
+; CHECK: br i1 %cond
+; CHECK: single_pred:
+; CHECK: %val = load i64, ptr %ptr
+define i64 @test_sink_read_to_single_pred(ptr %ptr, i1 %cond) {
+entry:
+  %val = load i64, ptr %ptr, align 8
+  br i1 %cond, label %other, label %single_pred
+
+single_pred:
+  ret i64 %val
+
+other:
+  ret i64 0
+}

--- a/test/llvmpasses/NewSink/newsink-readclobber.ll
+++ b/test/llvmpasses/NewSink/newsink-readclobber.ll
@@ -1,0 +1,288 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; Tests for read clobber scenarios
+; Adapted from D136218 multiblock-sink.ll patterns
+
+; Test: Read from location happens in same block before branch
+; Store should NOT be sunk
+define i64 @test_read_before_branch(i64 %a, i64 %bound) {
+; CHECK-LABEL: @test_read_before_branch
+entry:
+  %loc = alloca i64, align 8
+  ; Store happens
+  ; CHECK: entry:
+  ; CHECK: store i64 %a, ptr %loc
+  store i64 %a, ptr %loc, align 8
+  ; Read happens before branch - store cannot be sunk
+  %v = load i64, ptr %loc, align 8
+  %cmp = icmp ult i64 %v, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  call void @use(i64 %v)
+  unreachable
+
+ok:
+  ret i64 %v
+}
+
+; Test: Read is only in the other (non-error) successor
+; Store CAN be sunk since the read is only on the non-error path
+define i64 @test_read_in_ok_path_only(i64 %a, i64 %bound) {
+; CHECK-LABEL: @test_read_in_ok_path_only
+entry:
+  %loc = alloca i64, align 8
+  ; Store can be sunk - read is only in ok path, not error path
+  ; CHECK: entry:
+  ; CHECK-NOT: store i64 %a, ptr %loc
+  store i64 %a, ptr %loc, align 8
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  ; CHECK: error:
+  ; CHECK: store i64 %a, ptr %loc
+  %errv = load i64, ptr %loc, align 8
+  call void @use(i64 %errv)
+  unreachable
+
+ok:
+  ; No read from %loc on this path.
+  ret i64 %a
+}
+
+; Test: Callable that might read memory before branch
+; Store should NOT be sunk
+declare void @readonly_fn() readonly
+
+define i64 @test_call_might_read_before_branch(i64 %a, i64 %bound) {
+; CHECK-LABEL: @test_call_might_read_before_branch
+entry:
+  %loc = alloca i64, align 8
+  ; CHECK: entry:
+  ; CHECK: store i64 %a, ptr %loc
+  store i64 %a, ptr %loc, align 8
+  ; This call might read from loc
+  call void @readonly_fn()
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  %v = load i64, ptr %loc, align 8
+  call void @use(i64 %v)
+  unreachable
+
+ok:
+  ret i64 %a
+}
+
+; Test: Store then store - second store kills first, so first can potentially be removed
+; but our pass just sinks, so both stores would be sunk (second kills first)
+define i64 @test_store_after_store(i64 %a, i64 %b, i64 %bound) {
+; CHECK-LABEL: @test_store_after_store
+entry:
+  %loc = alloca i64, align 8
+  ; Both stores should be sunk, second overwrites first
+  ; CHECK: entry:
+  ; CHECK-NOT: store i64 %a, ptr %loc
+  ; CHECK-NOT: store i64 %b, ptr %loc
+  store i64 %a, ptr %loc, align 8
+  store i64 %b, ptr %loc, align 8
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  ; CHECK: error:
+  ; CHECK: store i64 %a, ptr %loc
+  ; CHECK: store i64 %b, ptr %loc
+  %v = load i64, ptr %loc, align 8
+  call void @use(i64 %v)
+  unreachable
+
+ok:
+  ret i64 %a
+}
+
+; Test: Specific case - store to different offsets of same alloca
+; Both stores should be sunk independently
+define i64 @test_stores_different_offsets(i64 %a, i64 %b, i64 %bound) {
+; CHECK-LABEL: @test_stores_different_offsets
+entry:
+  %tuple = alloca [2 x i64], align 8
+  %ptr0 = getelementptr [2 x i64], ptr %tuple, i64 0, i64 0
+  %ptr1 = getelementptr [2 x i64], ptr %tuple, i64 0, i64 1
+  ; Both stores should be sunk
+  ; CHECK: entry:
+  ; CHECK-NOT: store i64 %a, ptr %ptr0
+  ; CHECK-NOT: store i64 %b, ptr %ptr1
+  store i64 %a, ptr %ptr0, align 8
+  store i64 %b, ptr %ptr1, align 8
+  %cmp = icmp ult i64 %a, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  ; CHECK: error:
+  ; CHECK-DAG: store i64 %a, ptr %ptr0
+  ; CHECK-DAG: store i64 %b, ptr %ptr1
+  ; CHECK: call void @throw_error
+  call void @throw_error(ptr %tuple)
+  unreachable
+
+ok:
+  ret i64 %a
+}
+
+; Intervening non-aliasing write followed by a read from %a.
+define i64 @test_intervening_nonaliasing_write(i64 %x, i64 %y, i64 %bound) {
+; CHECK-LABEL: @test_intervening_nonaliasing_write
+entry:
+  %a = alloca i64, align 8
+  %b = alloca i64, align 8
+  ; CHECK: entry:
+  ; CHECK: store i64 %x, ptr %a
+  store i64 %x, ptr %a, align 8       ; Our write to %a
+  store i64 %y, ptr %b, align 8       ; Non-aliasing write to %b
+  %v = load i64, ptr %a, align 8      ; Read from %a - blocks sinking!
+  %cmp = icmp ult i64 %v, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  call void @use(i64 %v)
+  unreachable
+
+ok:
+  ret i64 %v
+}
+
+; Test: Same scenario but read is only on error path - CAN sink
+define i64 @test_intervening_nonaliasing_write_error_only(i64 %x, i64 %y, i64 %bound) {
+; CHECK-LABEL: @test_intervening_nonaliasing_write_error_only
+entry:
+  %a = alloca i64, align 8
+  %b = alloca i64, align 8
+  ; CHECK: entry:
+  ; CHECK-NOT: store i64 %x, ptr %a
+  store i64 %x, ptr %a, align 8       ; Our write to %a
+  store i64 %y, ptr %b, align 8       ; Non-aliasing write to %b
+  %cmp = icmp ult i64 %x, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  ; CHECK: error:
+  ; CHECK: store i64 %x, ptr %a
+  %v = load i64, ptr %a, align 8      ; Read only on error path
+  call void @use(i64 %v)
+  unreachable
+
+ok:
+  ret i64 %x
+}
+
+; Regression: clobbering source-block write blocks sinking.
+define i64 @test_intervening_volatile_clobber_blocks_sink(i64 %x, i64 %y, i64 %bound) {
+; CHECK-LABEL: @test_intervening_volatile_clobber_blocks_sink
+entry:
+  %a = alloca i64, align 8
+  ; CHECK: entry:
+  ; CHECK-NEXT: %a = alloca i64, align 8
+  ; CHECK-NEXT: store i64 %x, ptr %a, align 8
+  ; CHECK-NEXT: store volatile i64 %y, ptr %a, align 8
+  store i64 %x, ptr %a, align 8
+  store volatile i64 %y, ptr %a, align 8
+  %cmp = icmp ult i64 %x, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  %v = load i64, ptr %a, align 8
+  call void @use(i64 %v)
+  unreachable
+
+ok:
+  ret i64 %x
+}
+
+; Regression: same pattern with ordered atomic clobber.
+define i64 @test_intervening_atomic_clobber_blocks_sink(i64 %x, i64 %y, i64 %bound) {
+; CHECK-LABEL: @test_intervening_atomic_clobber_blocks_sink
+entry:
+  %a = alloca i64, align 8
+  ; CHECK: entry:
+  ; CHECK-NEXT: %a = alloca i64, align 8
+  ; CHECK-NEXT: store i64 %x, ptr %a, align 8
+  ; CHECK-NEXT: store atomic i64 %y, ptr %a seq_cst, align 8
+  store i64 %x, ptr %a, align 8
+  store atomic i64 %y, ptr %a seq_cst, align 8
+  %cmp = icmp ult i64 %x, %bound
+  br i1 %cmp, label %ok, label %error
+
+error:
+  %v = load i64, ptr %a, align 8
+  call void @use(i64 %v)
+  unreachable
+
+ok:
+  ret i64 %x
+}
+
+declare void @use(i64)
+declare void @throw_error(ptr)
+
+; Load and store to the same alloca sink independently to different paths.
+; CHECK-LABEL: @test_sink_read_before_store
+; CHECK: entry:
+; CHECK-NOT: load
+; CHECK-NOT: store
+; CHECK: br i1 %cond
+; CHECK: then:
+; CHECK: store i64 %a, ptr %loc
+; CHECK: else:
+; CHECK: %early_read = load i64, ptr %loc
+define i64 @test_sink_read_before_store(i64 %a, i64 %b, i1 %cond) {
+entry:
+  %loc = alloca i64, align 8
+  %early_read = load i64, ptr %loc, align 8
+  store i64 %a, ptr %loc, align 8
+  br i1 %cond, label %then, label %else
+
+then:
+  %v = load i64, ptr %loc, align 8
+  ret i64 %v
+
+else:
+  ret i64 %early_read
+}
+
+; Both the initial store and load sink to %then. The load executes before
+; the clobbering store so it still reads the correct value (0).
+; CHECK-LABEL: @test_load_sunk_before_clobber
+define void @test_load_sunk_before_clobber(i1 %cond) {
+entry:
+  %p = alloca i64, align 8
+  store i64 0, ptr %p, align 8
+; CHECK: entry:
+; CHECK-NOT: store
+; CHECK-NOT: load
+; CHECK: br i1 %cond
+  %v = load i64, ptr %p, align 8
+  br i1 %cond, label %then, label %error
+
+then:
+; CHECK: then:
+; CHECK: store i64 0, ptr %p
+; CHECK-NEXT: %v = load i64, ptr %p
+; CHECK-NEXT: store i64 42, ptr %p
+  store i64 42, ptr %p, align 8
+  br label %use_block
+
+use_block:
+; CHECK: use_block:
+; CHECK-NOT: load
+; CHECK: call void @use_val(i64 %v)
+  call void @use_val(i64 %v)
+  ret void
+
+error:
+  unreachable
+}
+
+declare void @use_val(i64)

--- a/test/llvmpasses/NewSink/newsink-returns-twice.ll
+++ b/test/llvmpasses/NewSink/newsink-returns-twice.ll
@@ -1,0 +1,110 @@
+; RUN: opt -load-pass-plugin=libjulia-codegen%shlibext -passes='NewSink' -S %s | FileCheck %s
+
+; Tests for returns_twice (setjmp) barriers and memory(read) call clobber checking.
+
+; --- Function declarations with real Julia attributes ---
+
+; ijl_excstack_state: captures exception stack state (pure read)
+declare i64 @ijl_excstack_state(ptr) #0
+
+; ijl_enter_handler: sets up exception handler (readwrite, no special attrs)
+declare void @ijl_enter_handler(ptr, ptr)
+
+; __sigsetjmp: returns 0 normally, non-zero on longjmp (returns_twice)
+declare i32 @__sigsetjmp(ptr, i32) #1
+
+; ijl_pop_handler / ijl_restore_excstack: exception cleanup
+declare void @ijl_pop_handler(ptr, i32) #2
+declare void @ijl_restore_excstack(ptr, i64)
+
+; Generic helpers
+declare void @try_body()
+declare void @use(i64)
+
+; Attribute groups matching real Julia LLVM IR
+attributes #0 = { mustprogress nofree nounwind willreturn memory(read) }
+attributes #1 = { returns_twice }
+attributes #2 = { mustprogress nounwind willreturn }
+
+; ijl_excstack_state must stay before sigsetjmp — sinking it into catch
+; would capture the wrong exception stack state.
+
+define void @test_julia_eh_pattern(ptr %task, ptr %handler) {
+; CHECK-LABEL: @test_julia_eh_pattern
+; excstack_state must stay in entry, before sigsetjmp
+; CHECK: entry:
+; CHECK: %state = call i64 @ijl_excstack_state(ptr %task)
+; CHECK: call void @ijl_enter_handler(ptr %task, ptr %handler)
+; CHECK: call i32 @__sigsetjmp(ptr %handler, i32 0)
+entry:
+  %state = call i64 @ijl_excstack_state(ptr %task)
+  call void @ijl_enter_handler(ptr %task, ptr %handler)
+  %r = call i32 @__sigsetjmp(ptr %handler, i32 0) #1
+  %is_try = icmp eq i32 %r, 0
+  br i1 %is_try, label %try, label %catch
+
+try:
+  call void @try_body()
+  call void @ijl_pop_handler(ptr %task, i32 1)
+  br label %done
+
+catch:
+  call void @ijl_pop_handler(ptr %task, i32 1)
+  call void @ijl_restore_excstack(ptr %task, i64 %state)
+  br label %done
+
+done:
+  ret void
+}
+
+; memory(read) call must not be sunk past a returns_twice call.
+
+declare i64 @read_global_state() #0
+declare i32 @pure_setjmp(ptr) #3
+
+; returns_twice + only writes to its argument
+attributes #3 = { returns_twice nounwind memory(argmem: readwrite) }
+
+define i64 @test_no_sink_past_returns_twice(ptr %buf) {
+; CHECK-LABEL: @test_no_sink_past_returns_twice
+; read_global_state must stay before pure_setjmp
+; CHECK: entry:
+; CHECK: %state = call i64 @read_global_state()
+; CHECK: call i32 @pure_setjmp(ptr %buf)
+entry:
+  %state = call i64 @read_global_state()
+  %r = call i32 @pure_setjmp(ptr %buf) #3
+  %cmp = icmp eq i32 %r, 0
+  br i1 %cmp, label %normal, label %handler
+
+normal:
+  ret i64 0
+
+handler:
+  call void @use(i64 %state)
+  ret i64 %state
+}
+
+; memory(read) call must not be sunk past a readwrite call.
+
+declare void @modify_state(ptr)
+
+define i64 @test_no_sink_readonly_call_past_write(ptr %p) {
+; CHECK-LABEL: @test_no_sink_readonly_call_past_write
+; read_global_state must not be sunk past modify_state
+; CHECK: entry:
+; CHECK: %state = call i64 @read_global_state()
+; CHECK: call void @modify_state(ptr %p)
+entry:
+  %state = call i64 @read_global_state()
+  call void @modify_state(ptr %p)
+  %cmp = icmp eq i64 %state, 0
+  br i1 %cmp, label %ok, label %error
+
+error:
+  call void @use(i64 %state)
+  unreachable
+
+ok:
+  ret i64 0
+}

--- a/test/llvmpasses/NewSink/newsink-returns-twice.ll
+++ b/test/llvmpasses/NewSink/newsink-returns-twice.ll
@@ -85,6 +85,26 @@ handler:
   ret i64 %state
 }
 
+; A plain load must also not sink past a returns_twice call.
+define i64 @test_no_sink_load_past_returns_twice(ptr %buf, ptr %p) {
+; CHECK-LABEL: @test_no_sink_load_past_returns_twice
+; CHECK: entry:
+; CHECK: %state = load i64, ptr %p, align 8
+; CHECK: call i32 @pure_setjmp(ptr %buf)
+entry:
+  %state = load i64, ptr %p, align 8
+  %r = call i32 @pure_setjmp(ptr %buf) #3
+  %cmp = icmp eq i32 %r, 0
+  br i1 %cmp, label %normal, label %handler
+
+normal:
+  ret i64 0
+
+handler:
+  call void @use(i64 %state)
+  ret i64 %state
+}
+
 ; memory(read) call must not be sunk past a readwrite call.
 
 declare void @modify_state(ptr)

--- a/test/llvmpasses/NewSink/newsink-unreachable-use.ll
+++ b/test/llvmpasses/NewSink/newsink-unreachable-use.ll
@@ -1,0 +1,25 @@
+; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='function(NewSink)' -S %s | FileCheck %s
+
+; Test that values used in unreachable blocks (blocks with no predecessors)
+; don't cause the pass to crash. These blocks are not in the dominator tree.
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128-ni:10:11:12:13"
+target triple = "x86_64-unknown-linux-gnu"
+
+; CHECK-LABEL: @test_unreachable_use_blocks
+; CHECK: entry:
+; CHECK: %gep = getelementptr i8, ptr %p, i64 -152
+; CHECK: ret void
+define swiftcc void @test_unreachable_use_blocks(ptr %p) {
+entry:
+  %gep = getelementptr i8, ptr %p, i64 -152
+  ret void
+
+unreachable1:                                     ; No predecessors!
+  %call1 = call ptr addrspace(10) null(ptr %gep, i64 0, ptr addrspace(10) null)
+  unreachable
+
+unreachable2:                                     ; No predecessors!
+  %call2 = call ptr addrspace(10) null(ptr %gep, i64 0, ptr addrspace(10) null)
+  unreachable
+}

--- a/test/llvmpasses/NewSink/run-alive-tests.sh
+++ b/test/llvmpasses/NewSink/run-alive-tests.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Run alive-tv validation on all newsink tests in parallel
+#
+# Usage: ./run-alive-tests.sh
+#
+# Requires alive-tv on PATH or set ALIVE_TV to its location.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+JULIA_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+OPT="$JULIA_ROOT/usr/tools/opt"
+PLUGIN="$JULIA_ROOT/usr/lib/libjulia-codegen.so"
+ALIVE_TV="${ALIVE_TV:-$(command -v alive-tv 2>/dev/null || true)}"
+TMPDIR="${TMPDIR:-/tmp}/newsink-alive-$$"
+
+if [ -z "$ALIVE_TV" ] || [ ! -x "$ALIVE_TV" ]; then
+    echo "alive-tv not found. Set ALIVE_TV or add it to PATH."
+    exit 1
+fi
+
+mkdir -p "$TMPDIR"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+run_test() {
+    local f="$1"
+    local base=$(basename "$f" .ll)
+    local transformed="$TMPDIR/${base}-transformed.ll"
+
+    "$OPT" -load-pass-plugin="$PLUGIN" -passes='NewSink' -S "$f" -o "$transformed" 2>/dev/null
+
+    local output=$("$ALIVE_TV" "$f" "$transformed" 2>&1)
+    local incorrect=$(echo "$output" | grep -E "^\s*[1-9][0-9]* incorrect" || true)
+
+    if [ -n "$incorrect" ]; then
+        echo -e "${RED}FAILED${NC}: $base"
+        echo "$output" | grep -E "incorrect|error" | head -5
+        return 1
+    else
+        local correct=$(echo "$output" | grep -oP '\d+ correct' | head -1)
+        echo -e "${GREEN}OK${NC}: $base ($correct)"
+        return 0
+    fi
+}
+
+export -f run_test
+export OPT ALIVE_TV PLUGIN TMPDIR RED GREEN NC
+
+failed=0
+for f in "$SCRIPT_DIR"/*.ll; do
+    run_test "$f" &
+done
+
+for job in $(jobs -p); do
+    wait "$job" || ((failed++))
+done
+
+rm -rf "$TMPDIR"
+
+echo ""
+if [ $failed -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}$failed test(s) failed${NC}"
+    exit 1
+fi


### PR DESCRIPTION
This is very vibe coded, but also has lots of tests and I have gone through it and haven't seen anything at that glance.

This fixes some of the issues we have in code like by sinking the stores into the error path
```julia
 array = rand(5,5,5,5,5)
 @code_llvm raw=true dump_module=true array[1,2,3,4,5]
```
new
```llvm
  store i64 %"i1::Int64", ptr %"new::Tuple1", align 8, !dbg !43
  %12 = getelementptr inbounds nuw i8, ptr %"new::Tuple1", i64 8, !dbg !43
  store i64 %"i2::Int64", ptr %12, align 8, !dbg !43
  %13 = getelementptr inbounds nuw i8, ptr %"new::Tuple1", i64 16, !dbg !43
  store i64 %"I[1]::Int64", ptr %13, align 8, !dbg !43, !tbaa !83, !alias.scope !85, !noalias !86
  %14 = getelementptr inbounds nuw i8, ptr %"new::Tuple1", i64 24, !dbg !43
  store i64 %"I[2]::Int64", ptr %14, align 8, !dbg !43, !tbaa !83, !alias.scope !85, !noalias !86
  %15 = getelementptr inbounds nuw i8, ptr %"new::Tuple1", i64 32, !dbg !43
  store i64 %"I[3]::Int64", ptr %15, align 8, !dbg !43, !tbaa !83, !alias.scope !85, !noalias !86
; ┌ @ abstractarray.jl:702 within `checkbounds`
   call swiftcc void @j_throw_boundserror_3105(ptr nonnull swiftself "gcstack" %pgcstack_arg, ptr nonnull %"A::Array", ptr nocapture nonnull readonly %"new::Tuple1") #10, !dbg !42
   unreachable, !dbg !42
```
old
```llvm
  %"new::Tuple1" = alloca [5 x i64], align 8
  %ptls_field = getelementptr inbounds nuw i8, ptr %pgcstack_arg, i64 16
  %ptls_load = load ptr, ptr %ptls_field, align 8, !tbaa !25
  %0 = getelementptr inbounds nuw i8, ptr %ptls_load, i64 16
  %safepoint = load atomic ptr, ptr %0 monotonic, align 8, !tbaa !29, !invariant.load !0
  fence syncscope("singlethread") seq_cst
  %1 = load volatile i64, ptr %safepoint, align 8
  fence syncscope("singlethread") seq_cst
    #dbg_declare(ptr %"A::Array", !19, !DIExpression(), !31)
    #dbg_value(i64 %"i1::Int64", !20, !DIExpression(), !31)
    #dbg_value(i64 %"i2::Int64", !21, !DIExpression(), !31)
    #dbg_value(i64 %"I[1]::Int64", !22, !DIExpression(DW_OP_LLVM_fragment, 0, 64), !32)
    #dbg_value(i64 %"I[2]::Int64", !22, !DIExpression(DW_OP_LLVM_fragment, 64, 64), !32)
    #dbg_value(i64 %"I[3]::Int64", !22, !DIExpression(DW_OP_LLVM_fragment, 128, 64), !32)
;  @ array.jl:962 within `getindex`
  store i64 %"i1::Int64", ptr %"new::Tuple1", align 8, !dbg !33
  %2 = getelementptr inbounds nuw i8, ptr %"new::Tuple1", i64 8, !dbg !33
  store i64 %"i2::Int64", ptr %2, align 8, !dbg !33
  %3 = getelementptr inbounds nuw i8, ptr %"new::Tuple1", i64 16, !dbg !33
  store i64 %"I[1]::Int64", ptr %3, align 8, !dbg !33, !tbaa !34, !alias.scope !36, !noalias !39
  %4 = getelementptr inbounds nuw i8, ptr %"new::Tuple1", i64 24, !dbg !33
  store i64 %"I[2]::Int64", ptr %4, align 8, !dbg !33, !tbaa !34, !alias.scope !36, !noalias !39
  %5 = getelementptr inbounds nuw i8, ptr %"new::Tuple1", i64 32, !dbg !33
  store i64 %"I[3]::Int64", ptr %5, align 8, !dbg !33, !tbaa !34, !alias.scope !36, !noalias !39
```
Adds a new LLVM pass that sinks instructions to paths where they are actually needed. This is useful for Julia's bounds checking where error message data is computed eagerly but only needed when bounds checks fail.

The pass uses MemorySSA to track memory dependencies and verify that sinking writes doesn't change observable behavior. It handles:

- Sinking to single-predecessor successors (D136218-style)
- Sinking to noreturn/error blocks
- Memory intrinsics (memset, memcpy, memmove)
- Pointer captures in dominated blocks
- Loop boundaries (won't sink into loops)

All transformations validated with alive-tv.


Fixes https://github.com/JuliaLang/julia/issues/55009
