### PR TITLE
[JuliaLowering] Fix destructured arg handling, improve error messages

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -353,11 +353,16 @@ function est_to_dst(st::SyntaxTree; all_expanded=true)
         else
             @ast g st [K"function" rec(l) rec(r)]
         end
-        [K"function" l r] -> if has_if_generated(r)
-            gen, nongen = split_generated(r, true), split_generated(r, false)
-            @ast g st [K"generated_function" rec(l) gen nongen]
-        else
-            @ast g st [K"function" rec(l) rec(r)]
+        [K"function" l r] -> let
+            if kind(l) === K"..."
+                l = @ast g l [K"tuple" l]
+            end
+            if has_if_generated(r)
+                gen, nongen = split_generated(r, true), split_generated(r, false)
+                @ast g st [K"generated_function" rec(l) gen nongen]
+            else
+                @ast g st [K"function" rec(l) rec(r)]
+            end
         end
         [K"do" [K"call" f args...] [K"->" do_args do_body]] -> let
             # Note desugaring expects first-arg do-expression, unlike RawGreenNode

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -438,7 +438,7 @@ end
 vst1_tuple(vcx, st) = @stm st begin
     [K"tuple" [K"parameters" kws...]] -> all(vst1_call_kwarg, vcx, kws)
     [K"tuple" [K"parameters" _ _...] _ _...] -> @fail(
-        st[end], "cannot mix tuple `(a,b,c)` and named tuple `(;a,b,c)` syntax")
+        st[1], "cannot mix tuple `(a,b,c)` and named tuple `(;a,b,c)` syntax")
     ([K"tuple" args...], when=any(x->kind(x)===K"=", args)) ->
         all(vst1_call_arg, vcx, args)
     [K"tuple" xs...] -> all(vst1_splat_or_val, vcx, xs)
@@ -519,7 +519,7 @@ end
 vst1_symdecl(vcx, st) = @stm st begin
     [K"Identifier"] -> pass()
     [K"::" [K"Identifier"] t] -> vst1(vcx, t)
-    _ -> @fail(st, "expected identifier or `::`")
+    _ -> @fail(st, "expected identifier or `identifier::type`")
 end
 
 # TODO: globalref might not be valid everywhere; check usage of this function
@@ -640,9 +640,9 @@ vst1_simple_calldecl(vcx, st; in_macro=false) = @stm st begin
         vst1_calldecl_kws(vcx, st[2])
     [K"call" f ps...] -> vst1_calldecl_name(vcx, f) &
         _calldecl_positionals(vcx, ps, K"kw")
-    # anonymous function syntax `function (x)`
-    [K"tuple" _...] ->
-        vst1_lam_lhs(vcx, st)
+    # anonymous function syntax `function (x); end`  or `function (x...); end`
+    [K"tuple" _...] -> vst1_lam_lhs(vcx, st)
+    [K"..." va] -> vst1_pparam_typed_tuple(vcx, va)
     _ -> @fail(st, "malformed `call` in function decl")
 end
 
@@ -679,7 +679,7 @@ vst1_calldecl_name(vcx, st) = @stm st begin
     [K"::" t] ->
         vst1(vcx, t)
     [K"::" x t] ->
-        vst1_param_simple_tuple(vcx, x) & vst1(vcx, t)
+        vst1_pparam_simple_tuple(vcx, x) & vst1(vcx, t)
 
     [K"where" t tds...] ->
         vst1(vcx, t) & all(vst1_typevar_decl, vcx, tds)
@@ -687,7 +687,7 @@ vst1_calldecl_name(vcx, st) = @stm st begin
 end
 
 # Check mandatory and optional positional params:
-# `[param* param_and_default* (kw (... param) val)|(... param)?]`
+# `[pparam* pparam_and_default* pparam_va?]`
 # TODO: add list matching to @stm
 function _calldecl_positionals(vcx, params_meta, kw_kind)
     isempty(params_meta) && return pass()
@@ -703,15 +703,8 @@ function _calldecl_positionals(vcx, params_meta, kw_kind)
             p -> p
         end
     end
-    va_ok = @stm params[end] begin
-        ([K"kw" [K"..." va] val], when=kw_kind===K"kw") ->
-            vst1_param_typed_tuple(vcx, va) & vst1_splat_or_val(vcx, val)
-        ([K"=" [K"..." va] val], when=kw_kind===K"=") ->
-            vst1_param_typed_tuple(vcx, va) & vst1_splat_or_val(vcx, val)
-        [K"..." va] -> vst1_param_typed_tuple(vcx, va)
-        _ -> nothing
-    end
-    if !isnothing(va_ok)
+    va_ok = vst1_pparam_va(vcx, params[end]; kw_kind)
+    if is_known(va_ok)
         params = params[1:end-1]
         ok[] &= va_ok
     end
@@ -719,57 +712,76 @@ function _calldecl_positionals(vcx, params_meta, kw_kind)
     for p in params
         if kind(p) === kw_kind
             require_assign = true
-            ok[] &= vst1_param_and_default(vcx, p; kw_kind)
+            ok[] &= vst1_pparam_and_default(vcx, p; kw_kind)
         elseif kind(p) === K"..."
             ok[] &= @fail(p, "`...` may only be used on the final parameter")
         elseif require_assign # TODO: multi-syntaxtree error
             ok[] &= @fail(p, "all function parameters after an optional parameter must also be optional")
         else
-            ok[] &= vst1_param_typed_tuple(vcx, p)
+            ok[] &= vst1_pparam_typed_tuple(vcx, p)
         end
     end
     return ok[]
 end
 
+vst1_pparam_va(vcx, st; kw_kind) = @stm st begin
+    ([K"kw" [K"..." va] val], when=kw_kind===K"kw") ->
+        vst1_pparam_typed_tuple(vcx, va) & vst1_splat_or_val(vcx, val)
+    ([K"=" [K"..." va] val], when=kw_kind===K"=") ->
+        vst1_pparam_typed_tuple(vcx, va) & vst1_splat_or_val(vcx, val)
+    [K"..." va] -> vst1_pparam_typed_tuple(vcx, va)
+    _ -> unknown()
+end
+
 # destructuring args: function f(a, (x, y)) ...
-vst1_param_typed_tuple(vcx, st) = @stm st begin
+vst1_pparam_typed_tuple(vcx, st) = @stm st begin
     [K"::" [K"tuple" _...] t] ->
-        vst1_param_simple_tuple(vcx, st[1]) &
+        vst1_pparam_simple_tuple(vcx, st[1]) &
         vst1(with(vcx; in_param_t=true), t)
-    [K"tuple" _...] -> vst1_param_simple_tuple(vcx, st)
+    [K"tuple" _...] -> vst1_pparam_simple_tuple(vcx, st)
     _ -> vst1_param(vcx, st)
 end
-
-vst1_param_simple_tuple_or_splat(vcx, st) = @stm st begin
-    [K"..." t] -> vst1_param_simple_tuple(vcx, t)
-    t -> vst1_param_simple_tuple(vcx, t)
+vst1_pparam_simple_tuple_or_splat(vcx, st) = @stm st begin
+    [K"..." t] -> vst1_pparam_simple_tuple(vcx, t)
+    t -> vst1_pparam_simple_tuple(vcx, t)
 end
-
-vst1_param_simple_tuple(vcx, st) = @stm st begin
+# Similar to an assignment to a tuple LHS, but does not allow `::`.  Also should
+# not allow ref, curly, or call, but flisp does, so we may need to change this.
+vst1_pparam_simple_tuple(vcx, st) = @stm st begin
     [K"Identifier"] -> pass()
+    [K"tuple" [K"parameters" _ _...] _ _...] -> @fail(
+        st[1], "cannot mix tuple `(a,b,c)` and named tuple `(;a,b,c)` syntax")
     [K"tuple" [K"parameters" kws...]] -> all(vst1_ident, vcx, kws; lhs=true)
-    [K"tuple" xs...] -> all(vst1_param_simple_tuple_or_splat, vcx, xs)
-    _ -> unknown()
+    [K"tuple" xs...] ->
+        all(vst1_pparam_simple_tuple_or_splat, vcx, xs) &
+        (count(kind(x)===K"..." for x in xs) <= 1 ? pass() :
+        @fail(st, "multiple `...` in destructured parameter is ambiguous"))
+    [K"::" _...] -> @fail(st, "cannot have type in destructured argument")
+    _ -> @fail(st, "expected identifier or tuple")
 end
 
 vst1_param(vcx, st) = @stm st begin
     [K"Identifier"] -> pass()
     [K"::" [K"Identifier"] t] -> vst1(with(vcx; in_param_t=true), t)
     [K"::" t] -> vst1(with(vcx; in_param_t=true), t)
-    _ -> @fail(st, "expected identifier or `::`")
+    _ -> @fail(st, "expected identifier or `identifier::type`")
 end
 
-vst1_param_and_default(vcx, st; kw_kind) = @stm st begin
+vst1_pparam_and_default(vcx, st; kw_kind) = @stm st begin
     ([K"kw" id val], when=(kw_kind===K"kw")) ->
-        vst1_param_typed_tuple(vcx, id) & vst1(vcx, val)
+        vst1_pparam_typed_tuple(vcx, id) & vst1(vcx, val)
     ([K"=" id val], when=(kw_kind===K"=")) ->
-        vst1_param_typed_tuple(vcx, id) & vst1(vcx, val)
+        vst1_pparam_typed_tuple(vcx, id) & vst1(vcx, val)
     _ -> @fail(st, "malformed optional positional parameter; expected `=`")
 end
 
 vst1_calldecl_kws(vcx, st) = @stm st begin
     [K"parameters" kws... [K"..." varkw]] ->
-        all(vst1_param_kw, vcx, kws) & vst1_param(vcx, varkw)
+        all(vst1_param_kw, vcx, kws) & @stm varkw begin
+            [K"Identifier"] -> pass()
+            [K"::" _...] ->
+                @fail(varkw, "keyword parameter with `...` may not be given a type")
+        end
     [K"parameters" kws...] -> all(vst1_param_kw, vcx, kws)
     _ -> unknown()
 end
@@ -778,7 +790,7 @@ vst1_param_kw(vcx, st) = @stm st begin
     [K"kw" id val] ->
         vst1_param(vcx, id) & vst1(vcx, val)
     [K"..." _...] ->
-        @fail(st, "`...` may only be used for the last keyword parameter")
+        @fail(st, "`...` may only be used for the final keyword parameter")
     _ -> vst1_param(vcx, st) |
         @fail(st, "malformed keyword parameter; expected identifier, `=`, or `::`")
 end

--- a/JuliaLowering/test/destructuring_ir.jl
+++ b/JuliaLowering/test/destructuring_ir.jl
@@ -382,4 +382,4 @@ LoweringError:
 #---------------------
 LoweringError:
 (; a=1, b) = rhs
-#  └─┘ ── expected identifier or `::`
+#  └─┘ ── expected identifier or `identifier::type`

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -512,13 +512,153 @@ end
     @test cl(x = 20) == 21
 end
 
+@testset "all known valid positional argument forms" begin
+    make_defaults(x) = let (ps, vals) = x
+        # (p1,p2,p3) => (v1,v2,v3) to
+        # ((kw p1 v1),(kw p2 v2),(kw p3 v3)) => (v1,v2,v3)
+        map(zip(ps, vals)) do pv
+            Expr(:kw, pv[1], pv[2])
+        end => vals
+    end
+    make_typed(pv) = let (ps, vals) = pv
+        new_ps = map(ps) do p
+            # types go under `...`
+            if Meta.isexpr(p, :...)
+                Expr(:..., Expr(:(::), p.args[1], Any))
+            else
+                Expr(:(::), p, Any)
+            end
+        end
+        new_ps => vals
+    end
+
+    pparams_req = let
+        # tuple of params => tuple of acceptable values
+        pparams_untyped = [
+            # x,y,z must be defined for testing
+            (:x,
+             :y,
+             :z) =>
+                 (1,2,3),
+            (:x,
+             Expr(:tuple, :y, :z)) =>
+                 (1,(2,3)),
+            (:x,
+             Expr(:tuple, Expr(:parameters, :y, :z))) =>
+                 (1,(;y=2,z=3)),
+            (:x,
+             Expr(:tuple, Expr(:..., :y), :z)) =>
+                (1,(2,3,4)),
+            (Expr(:tuple, Expr(:tuple, :x, :y), :z),) =>
+                (((1,2),3),),
+            (Expr(:tuple, Expr(:..., Expr(:tuple, :x, :y)), :z),) =>
+                ((1,2,3),),
+            (:x,
+             :y,
+             Expr(:..., :z)) =>
+                 (1,2,3),
+        ]
+        pparams_typed = map(make_typed, pparams_untyped)
+        vcat(pparams_untyped, pparams_typed)
+    end
+
+    @testset "required args" for (params_i, args_i) in pparams_req
+        @testset let f_expr = Expr(:function,
+                                   Expr(:call, gensym(), params_i...),
+                                   Expr(:tuple, :x, :y, :z)),
+                f_st = JuliaLowering.expr_to_est(f_expr)
+
+            local func_ref, func_test
+            @test ((func_ref = Core.eval(test_mod, reference_lower(test_mod, f_expr))) isa Function)
+            @test ((func_test = JuliaLowering.eval(test_mod, f_st)) isa Function)
+            Core.@latestworld
+            @test func_ref(args_i...) == func_test(args_i...)
+        end
+    end
+
+    pparams_default = map(make_defaults, pparams_req)
+
+    @testset "default args" for (params_i, args_i) in pparams_default
+        @testset let f_expr = Expr(:function,
+                                   Expr(:call, gensym(), params_i...),
+                                   Expr(:tuple, :x, :y, :z)),
+                    f_st = JuliaLowering.expr_to_est(f_expr)
+
+            local func_ref, func_test
+            @test ((func_ref = Core.eval(test_mod, reference_lower(test_mod, f_expr))) isa Function)
+            @test ((func_test = JuliaLowering.eval(test_mod, f_st)) isa Function)
+            Core.@latestworld
+            @test func_ref(args_i...) == func_test(args_i...)
+            @test func_ref() == func_test()
+        end
+    end
+
+    # test vararg-tuples separately, as providing defaults must be done with a
+    # syntactic splat, and some variants are valid syntax but not callable (may
+    # later be disallowed)
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        f_vararg_tuple = function ((x,y,z)...)
+            (x,y,z)
+        end
+        f_vararg_tuple(1,2,3), f_vararg_tuple(1,2,3,4,5)
+    end
+    """) === ((1,2,3), (1,2,3))
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        f_vararg_tuple = function ((x,y,z)...=(1,2,3)...)
+            (x,y,z)
+        end
+        f_vararg_tuple(4,5,6,7), f_vararg_tuple()
+    end
+    """) === ((4,5,6), (1,2,3))
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        f_vararg_tuple = function ((x,(y,z))...=(1,(2,3))...)
+            (x,y,z)
+        end
+        f_vararg_tuple(4,(5,6),7), f_vararg_tuple()
+    end
+    """) === ((4,5,6), (1,2,3))
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        f_vararg_tuple = function ((x,(y,z)...)...=(1,(2,3)...)...)
+            (x,y,z)
+        end
+        f_vararg_tuple(4,5,6,7), f_vararg_tuple()
+    end
+    """) === ((4,5,6), (1,2,3))
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        f_vararg_tuple = function ((x,y,z)::Tuple...)
+            (x,y,z)
+        end
+    end
+    """) isa Function
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        f_vararg_tuple = function ((;x,y,z)...)
+            (x,y,z)
+        end
+    end
+    """) isa Function
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        f_vararg_tuple = function ((;x,y,z)::NamedTuple...)
+            (x,y,z)
+        end
+    end
+    """) isa Function
+end
+
 @testset "Write-only placeholder function arguments" begin
     # positional arguments may be duplicate placeholders.  keyword arguments can
     # contain placeholders, but they must be unique
     params_req = [""
                   "_"
                   "::Int"
-                  "_, _"]
+                  "_, _"
+                  "(_, _)"]
     params_opt = [""
                   "::Int=2"
                   "_=2"]
@@ -530,13 +670,15 @@ end
                   "; _=1, __=2"
                   "; _..."
                   "; _=1, __..."]
-    local i = 0
     for req in params_req, opt in params_opt, va in params_va, kw in params_kw
         arg_str = join(filter(!isempty, (req, opt, va, kw)), ", ")
-        f_str = "function f_placeholders$i($arg_str); end"
-        i += 1
+        f_str = "function ($arg_str); end"
         @testset "$f_str" begin
             @test JuliaLowering.include_string(test_mod, f_str) isa Function
+        end
+        f_lam_str = "($arg_str)->nothing"
+        @testset "$f_lam_str" begin
+            @test JuliaLowering.include_string(test_mod, f_lam_str) isa Function
         end
     end
 end

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -1000,6 +1000,22 @@ function f(_,(_,x{y})); end
 #               └──┘ ── expected identifier or tuple
 
 ########################################
+# Error: splat on non-final default positional arg
+function f(x=1...,y=2); end
+#---------------------
+LoweringError:
+function f(x=1...,y=2); end
+#            └──┘ ── splat only allowed on final positional default arg
+
+########################################
+# Error: splat on non-final default positional arg 2
+function f(x=(1,2)...,y=(3,4)...); end
+#---------------------
+LoweringError:
+function f(x=(1,2)...,y=(3,4)...); end
+#            └──────┘ ── splat only allowed on final positional default arg
+
+########################################
 # Function argument destructuring combined with splats, types and and defaults
 function f(x=default_x)::T
 end

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -880,6 +880,126 @@ end
 22  (return %₂₁)
 
 ########################################
+# Error: multiple destructuring in destructured arg
+function f(_,(x...,y...)); end
+#---------------------
+LoweringError:
+function f(_,(x...,y...)); end
+#            └─────────┘ ── multiple `...` in destructured parameter is ambiguous
+
+########################################
+# Error: multiple destructuring in var-destructured arg
+function f(_,(x...,y...)...); end
+#---------------------
+LoweringError:
+function f(_,(x...,y...)...); end
+#            └─────────┘ ── multiple `...` in destructured parameter is ambiguous
+
+########################################
+# Error: type in destructured arg
+function f(_,(x,y::Int)); end
+#---------------------
+LoweringError:
+function f(_,(x,y::Int)); end
+#               └────┘ ── cannot have type in destructured argument
+
+########################################
+# Error: type in destructured arg, nested
+function f(_,(x,(y,(z::Int,)))...); end
+#---------------------
+LoweringError:
+function f(_,(x,(y,(z::Int,)))...); end
+#                   └────┘ ── cannot have type in destructured argument
+
+########################################
+# Error: type on splat
+function (_,((a,b)...)::Int); end
+#---------------------
+LoweringError:
+function (_,((a,b)...)::Int); end
+#           └─────────────┘ ── expected identifier or `identifier::type`
+
+########################################
+# Error: destructured arg with kw
+function f(_,(x,y=1)); end
+#---------------------
+LoweringError:
+function f(_,(x,y=1)); end
+#               └─┘ ── expected identifier or tuple
+
+########################################
+# Error: destructured arg with ;kw
+function f(_,(;x,y=1)); end
+#---------------------
+LoweringError:
+function f(_,(;x,y=1)); end
+#                └─┘ ── expected identifier
+
+########################################
+# Error: destructured arg with other lhs-likes after ; (call)
+function f(_,(;x,y())); end
+#---------------------
+LoweringError:
+function f(_,(;x,y())); end
+#                └─┘ ── expected identifier
+
+########################################
+# Error: destructured arg with other lhs-likes after ; (ref)
+function f(_,(;x,y())); end
+#---------------------
+LoweringError:
+function f(_,(;x,y())); end
+#                └─┘ ── expected identifier
+
+########################################
+# Error: destructured arg with other lhs-likes after ; (tuple)
+function f(_,(;x,(y,z))); end
+#---------------------
+LoweringError:
+function f(_,(;x,(y,z))); end
+#                └───┘ ── expected identifier
+
+########################################
+# Error: destructured arg with other lhs-likes after ; (...)
+function f(_,(;x,y...)); end
+#---------------------
+LoweringError:
+function f(_,(;x,y...)); end
+#                └──┘ ── expected identifier
+
+########################################
+# Error: destructuring mixed tuple
+function f(_,(x,;y=1)); end
+#---------------------
+LoweringError:
+function f(_,(x,;y=1)); end
+#               └──┘ ── cannot mix tuple `(a,b,c)` and named tuple `(;a,b,c)` syntax
+
+########################################
+# Error: ref in arg tuple (flisp allows this)
+function f(_,(_,x[])); end
+#---------------------
+LoweringError:
+function f(_,(_,x[])); end
+#               └─┘ ── expected identifier or tuple
+
+########################################
+# Error: call in arg tuple (flisp allows this; args ignored)
+function f(_,(_,x(y))); end
+#---------------------
+LoweringError:
+function f(_,(_,x(y))); end
+#               └──┘ ── expected identifier or tuple
+
+########################################
+# Error: curly in arg tuple (flisp allows this)
+function f(_,(_,x{y})); end
+#---------------------
+LoweringError:
+function f(_,(_,x{y})); end
+#               └──┘ ── expected identifier or tuple
+
+########################################
 # Function argument destructuring combined with splats, types and and defaults
 function f(x=default_x)::T
 end

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -1596,7 +1596,7 @@ end
 #---------------------
 LoweringError:
 function f_kw_destruct(; (x,y)=10)
-#                        └───┘ ── expected identifier or `::`
+#                        └───┘ ── expected identifier or `identifier::type`
 end
 
 ########################################
@@ -1606,7 +1606,7 @@ end
 #---------------------
 LoweringError:
 function f_kw_slurp_default(; kws...=def)
-#                             └────┘ ── expected identifier or `::`
+#                             └────┘ ── expected identifier or `identifier::type`
 end
 
 ########################################
@@ -1616,7 +1616,7 @@ end
 #---------------------
 LoweringError:
 function f_kw_slurp_type(; kws::T...)
-#                          └───────┘ ── keyword argument with `...` may not be given a type
+#                          └────┘ ── keyword parameter with `...` may not be given a type
 end
 
 ########################################
@@ -1626,7 +1626,7 @@ end
 #---------------------
 LoweringError:
 function f_kw_slurp_not_last(; kws..., x=1)
-#                              └────┘ ── `...` may only be used for the last keyword parameter
+#                              └────┘ ── `...` may only be used for the final keyword parameter
 end
 
 ########################################

--- a/JuliaLowering/test/misc_ir.jl
+++ b/JuliaLowering/test/misc_ir.jl
@@ -148,7 +148,7 @@ LoweringError:
 #---------------------
 LoweringError:
 (a=1; b=2, c=3)
-#└─┘ ── cannot mix tuple `(a,b,c)` and named tuple `(;a,b,c)` syntax
+#   └────────┘ ── cannot mix tuple `(a,b,c)` and named tuple `(;a,b,c)` syntax
 
 ########################################
 # Error: Named tuple field dots in rhs

--- a/JuliaLowering/test/utils.jl
+++ b/JuliaLowering/test/utils.jl
@@ -374,3 +374,7 @@ function reduce_any_failing_toplevel(mod::Module, filename::AbstractString; do_e
     end
     nothing
 end
+
+function reference_lower(mod::Module, x)
+    Base.fl_lower(x, mod, @__FILE__, @__LINE__, Base.get_world_counter())[1]
+end

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -1622,6 +1622,8 @@ function preprocessed_green_children(st::SyntaxTree)
             inner_cs = preprocessed_green_children(cs[i])
             if length(inner_cs) === 1
                 cs[i] = inner_cs[1]
+            else
+                break
             end
         end
     end

--- a/test/JuliaLowering_stdlibs.jl
+++ b/test/JuliaLowering_stdlibs.jl
@@ -3,7 +3,6 @@ import Libdl
 # known precompilation failures under JL
 const INCOMPATIBLE_STDLIBS = String[
     "SparseArrays", # closure static parameter bug (JuliaLang/JuliaLowering.jl#134)
-    "Test", # nested + destructured args splat (JuliaLang/JuliaLowering.jl#133)
     "Pkg", # closure w/ kwarg bug (JuliaLang/JuliaLowering.jl#139)
     "SuiteSparse", # depends on SparseArrays
     "LazyArtifacts", # depends on Pkg


### PR DESCRIPTION
- Take this opportunity to clean up a couple pieces of desugaring given invariants from the validator
- Fix https://github.com/JuliaLang/JuliaLowering.jl/issues/133, which I think was just a simple failure to recurse.  Test.jl now precompiles!
- Test every function arg form that I know flisp accepts
- Test error messages for function arg forms that the validator rejects