### PR TITLE
[JuliaLowering] Recognize `(tryfinally _ _ scope)` form

### DIFF
--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -296,7 +296,8 @@ vst1(vcx::Validation1Context, st::SyntaxTree)::ValidationResult = @stm st begin
     [K"cconv" tup nreq] -> (get(tup, :value, nothing) isa Tuple &&
         get(nreq, :value, nothing) isa Int) ? pass() :
         @fail(st, "expected (cconv convention_tuple n_req_args)")
-    [K"tryfinally" t f _...] -> vst1(vcx, t) & vst1(vcx, f)
+    [K"tryfinally" t f] -> vst1(vcx, t) & vst1(vcx, f)
+    [K"tryfinally" t f scope] -> vst1(vcx, t) & vst1(vcx, f) & vst1(vcx, scope)
     [K"inline" _] -> pass()
     [K"noinline" _] -> pass()
     [K"inbounds" _] -> pass()

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -389,6 +389,18 @@ end
     """; expr_compat_mode=true)
     @test test_mod.SOME_ENUM <: Enum
     @test test_mod.X1 isa Enum
+
+    # @testset produces :tryfinally with secret third arg
+    @eval test_mod :(using Test)
+    @test JuliaLowering.include_string(test_mod, "@test true") isa Test.Pass
+    @testset let jltestset = JuliaLowering.include_string(test_mod, """
+    @testset begin
+        @test true
+    end
+    """; expr_compat_mode=true)
+        @test jltestset isa Test.AbstractTestSet
+        @test jltestset.n_passed == 1
+    end
 end
 
 @testset "macros producing meta forms" begin

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -282,3 +282,18 @@ end
 """; expr_compat_mode=true) === 1
 
 end
+
+@testset "tryfinally with scopedvalues" begin
+    @eval test_mod scopedval = Base.ScopedValues.ScopedValue(1)
+    @eval test_mod val_history = []
+    ex = Expr(:tryfinally,
+              :(push!(val_history, scopedval[])),
+              :(push!(val_history, scopedval[])),
+              :(Base.ScopedValues.Scope(Core.current_scope(),
+                                        $test_mod.scopedval => 2)))
+    JuliaLowering.eval(test_mod, JuliaLowering.expr_to_est(ex); expr_compat_mode=true)
+    # try block uses "inner" dynamic scope, finally does not
+    @test test_mod.val_history == [2, 1]
+    JuliaLowering.eval(test_mod, JuliaLowering.expr_to_est(ex))
+    @test test_mod.val_history == [2, 1, 2, 1]
+end

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -281,8 +281,6 @@ end
     end
 """; expr_compat_mode=true) === 1
 
-end
-
 @testset "tryfinally with scopedvalues" begin
     @eval test_mod scopedval = Base.ScopedValues.ScopedValue(1)
     @eval test_mod val_history = []
@@ -296,4 +294,6 @@ end
     @test test_mod.val_history == [2, 1]
     JuliaLowering.eval(test_mod, JuliaLowering.expr_to_est(ex))
     @test test_mod.val_history == [2, 1, 2, 1]
+end
+
 end


### PR DESCRIPTION
Fix `@testset` https://github.com/JuliaLang/JuliaLowering.jl/issues/79; we just weren't handling the secret third arg to the tryfinally form.  This argument appears to be used exclusively by Base.ScopedValues.