### PR TITLE
Generalized meta system for arguments

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -13,9 +13,7 @@ Adds `@nospecialize` annotation to non-annotated arguments of `def`.
                            x, ys
                        end
 :(function tfunc(\$(Expr(:meta, :specialize, :(𝕃::AbstractLattice))), x, y::Bool, zs...)
-      #= REPL[3]:1 =#
-      \$(Expr(:meta, :nospecialize, :x, :zs))
-      #= REPL[3]:2 =#
+      \$(Expr(:meta, :value, (:x, :zs), :nospecialize => true))
       (x, ys)
   end)
 ```

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2335,6 +2335,7 @@ function expand_function_arg(ctx, body_stmts, arg, is_last_arg, is_kw, arg_id)
         name = if is_kw
             @ast ctx ex ex=>K"Identifier"
         else
+            # TODO (vchuravy)
             new_local_binding(ctx, ex, "#arg$(string(arg_id))#"; kind=:argument,
                               is_nospecialize=is_nospecialize)
         end

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -246,7 +246,7 @@ function to_code_info(ex::SyntaxTree, slots::Vector{Slot}, meta::CompileHints)
         if slot.is_nospecialize
             # Ideally this should be a slot flag instead
             add_ir_debug_info!(current_codelocs_stack, ex)
-            push!(stmts, Expr(:meta, :nospecialize, Core.SlotNumber(i)))
+            push!(stmts, Expr(:meta, :value, Core.SlotNumber(i)), :nospecialize => true)
         end
     end
 

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -1159,6 +1159,7 @@ function compile_lambda(outer_ctx, ex)
     for arg in children(lambda_args)
         if kind(arg) == K"Placeholder"
             # Unused functions arguments like: `_` or `::T`
+            # TODO(vchuravy)
             push!(slots, Slot(arg.name_val, :argument, getmeta(arg, :nospecialize, false),
                               false, false, false, false))
         else

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -119,6 +119,7 @@ function maybe_declare_in_scope!(ctx, scope::ScopeInfo, ex, new_k::Symbol)
     old_k = isnothing(bid) ? nothing : get_binding(ctx, bid).kind
     if isnothing(old_k)
         if new_k === :argument
+            # TODO(vchuravy)
             declare_in_scope!(ctx, scope, ex, :argument;
                               is_nospecialize=getmeta(ex, :nospecialize, false))
         else

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -282,13 +282,13 @@ end
 function Typeof end
 ccall(:jl_toplevel_eval_in, Any, (Any, Any),
       Core, quote
-      (f::typeof(Typeof))(x) = ($(_expr(:meta,:nospecialize,:x)); isa(x,Type) ? Type{x} : typeof(x))
+      (f::typeof(Typeof))(x) = ($(_expr(:meta, :value, :x, :nospecialize => true)); isa(x,Type) ? Type{x} : typeof(x))
       end)
 
 function iterate end
 
 macro nospecialize(x)
-    _expr(:meta, :nospecialize, x)
+    _expr(:meta, :value, x, :nospecialize => true)
 end
 Expr(@nospecialize args...) = _expr(args...)
 

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -136,6 +136,7 @@ function argtype(expr::Expr)
     isexpr(expr, :(...)) && return :(Vararg{$(argtype(expr.args[1]))})
     if isexpr(expr, :meta) && length(expr.args) == 2
         a1 = expr.args[1]
+        # TODO(vchuravy)
         if a1 === :nospecialize || a1 === :specialize
             return argtype(expr.args[2])
         end

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -124,7 +124,7 @@ macro nospecialize(vars...)
             var.head = :kw
         end
     end
-    return Expr(:meta, :nospecialize, vars...)
+    return Expr(:meta, :value, vars, :nospecialize => true)
 end
 
 """


### PR DESCRIPTION
For some use-cases in GPUCompiler we would like to add annotations to arguments, similar in spirit to how `Expr(:meta, :nospecialize, x)` currently works.

I haven't found the energy yet to battle scheme to emit the new form.

cc: @maleadt

