### PR TITLE
make `Meta-e` work for editors defined with `wait=false`

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1565,7 +1565,7 @@ function guess_current_mode_name(s)
 end
 
 # edit current input in editor
-function edit_input(s, f = (filename, line, column) -> InteractiveUtils.edit(filename, line, column))
+function edit_input(s, f = (filename, line, column) -> InteractiveUtils.edit(filename, line, column; wait=true))
     mode_name = guess_current_mode_name(s)
     filename = tempname()
     if mode_name === :julia


### PR DESCRIPTION
If in `define_editor` the keyword argument `wait=false` is used (the default value), then the `edit` function always returns immediately, without waiting for the editor to be closed. As a result, one cannot use `Meta-e` anymore to edit the current input in an external editor. For this to work, the `edit` call used under the hood would have to wait for the editor. This PR fixed this.

The solution I propose is to add a keyword argument `wait` to `edit` (for the filename-line-column version only). If it is set to `true`, then `edit` will wait for the editor to close, no matter which `wait` value was used in `define_editor`. If the `wait` argument for `edit` is `false`, then the value used for `define_editor` is taken.
