### PR TITLE
support column argument for micro and kakoune editors

### DIFF
--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -153,7 +153,8 @@ function define_default_editors()
         `$cmd +$line:$column $path`
     end
     define_editor(["micro", "kak"]; wait=true) do cmd, path, line, column
-        `$cmd +$line $path`
+        # micro ignores "+line:column" if column == 0
+        iszero(column) ? `$cmd +$line $path` : `$cmd +$line:$column $path`
     end
     define_editor(["hx", "helix"]; wait=true) do cmd, path, line, column
         `$cmd $path:$line:$column`


### PR DESCRIPTION
The editor definitions for micro and kakoune ignore the `column` argument although both editors accept a command line argument of the form `+line:column` besides `+line`. For micro, however, the column must not be zero, otherwise also `line` is ignored. So in this case we drop the column. (I wonder why the default values for `line` and `column` are `0` and not `1`.)