### PR TITLE
Artifacts stdlib: Add `TOML` and `Pkg` as test dependencies

### DIFF
--- a/stdlib/Artifacts/Project.toml
+++ b/stdlib/Artifacts/Project.toml
@@ -3,8 +3,9 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 version = "1.11.0"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "TOML"]
+test = ["Test", "Pkg", "TOML"]

--- a/stdlib/Artifacts/Project.toml
+++ b/stdlib/Artifacts/Project.toml
@@ -3,7 +3,8 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 version = "1.11.0"
 
 [extras]
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "TOML"]


### PR DESCRIPTION
Because `TOML` is used in the tests:

https://github.com/JuliaLang/julia/blob/b51d41ac753f46a3529f47fe3c6638895cf97c6d/stdlib/Artifacts/test/runtests.jl#L6-L6

Noticed in PkgEval ([log](https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/a6a3237_vs_63406df/Artifacts.primary.log))