### PR TITLE
REPL: fix highlighting of the region and of enclosing parentheses

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -635,7 +635,7 @@ function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf
         full_input = String(buf.data[1:buf.size])
         if !isempty(full_input)
             passes = StylingPass[]
-            context = StylingContext(buf_pos, regstart, regstop)
+            context = StylingContext(buf_pos, regstart + 1, regstop) # region positions are 1-based
 
             # Add prompt-specific styling passes if the prompt has them and styling is enabled
             enable_style_input = prompt_obj === nothing ? false :

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -635,7 +635,7 @@ function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf
         full_input = String(buf.data[1:buf.size])
         if !isempty(full_input)
             passes = StylingPass[]
-            context = StylingContext(buf_pos, regstart + 1, regstop) # region positions are 1-based
+            context = StylingContext(buf_pos + 1, regstart + 1, regstop) # StylingContext positions are 1-based
 
             # Add prompt-specific styling passes if the prompt has them and styling is enabled
             enable_style_input = prompt_obj === nothing ? false :

--- a/stdlib/REPL/src/StylingPasses.jl
+++ b/stdlib/REPL/src/StylingPasses.jl
@@ -137,7 +137,7 @@ function find_enclosing_parens(content::String, ast, cursor_pos::Int)
             elseif depthchange < 0 && !isempty(paren_stack)
                 # Closing paren - pop from stack and check if cursor is inside
                 open_pos, depth, open_ptype = pop!(paren_stack)
-                if open_ptype == ptype && open_pos <= cursor_pos < pos
+                if open_ptype == ptype && open_pos <= cursor_pos <= pos
                     # Cursor is inside this paren pair - keep only innermost per type
                     # Only update if this is the first pair or if it's smaller (more inner) than existing
                     if !haskey(innermost_pairs, ptype) || (pos - open_pos) < (innermost_pairs[ptype][2] - innermost_pairs[ptype][1])


### PR DESCRIPTION
fixes #60762

In the syntax highlighting introduced in #59778 for Julia 1.13, the region highlighting is off by 1. This PR fixed this. I believe that the region highlighting is now as in 1.12, up to the added colors.

@KristofferC Could you have a look at it?