### PR TITLE
`Base.ssqs`: fix small type instability

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -513,7 +513,7 @@ function ssqs(x::T, y::T) where T<:Real
         ρ = convert(T, Inf)
     elseif isinf(ρ) || (ρ==0 && (x!=0 || y!=0)) || ρ<nextfloat(zero(T))/(2*eps(T)^2)
         m::T = max(abs(x), abs(y))
-        k = m==0 ? m : exponent(m)
+        k = m==0 ? 0 : exponent(m)
         xk, yk = ldexp(x,-k), ldexp(y,-k)
         ρ = xk*xk + yk*yk
     end


### PR DESCRIPTION
`m` is of floating-point type, while `k` is an integer.

This change makes the type of the branch expression always be a subtype of `Integer`, and indeed, a concrete `Int` in practically important cases.

This fixes a tiny type instability. It is of the small union kind, usually addressed well by union splitting in the Julia compiler. However, it seems that this type instability had caused issues for some GPU targets in the past, see discussion on linked PR.

This PR is a simplification of the PR #54869.