### PR TITLE
REPL: make faces for current region and parentheses customizable

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -800,6 +800,14 @@ ENV["JULIA_WARN_COLOR"] = :yellow
 ENV["JULIA_INFO_COLOR"] = :cyan
 ```
 
+The default faces used for highlighting the current region and enclosing parentheses
+are as follows:
+```toml
+[REPL]
+region.inverse = true
+enclosing_paren = { weight = "bold", underline = true }
+```
+
 
 ## Changing the contextual module which is active at the REPL
 


### PR DESCRIPTION
Currently, the faces used for highlighting the current region and enclosing parentheses are hard-coded. This PR makes them customizable via the user's `config/faces.toml`.

Note that I have removed the `face` field of `EnclosingParenHighlightPass`. It always had the default value in the existing code. I first tried to keep the field with a method of the form
```
EnclosingParenHighlightPass() = EnclosingParenHighlightPass(StyledStrings.FACES.current[][:REPL_enclosing_paren])
```
However, this always picked the default value and never the one from `faces.toml`. This may be a precompilation issue. I would need help to fix that.

By the way, emacs uses some yellowish background color to indicate the region instead of `inverse=true`. I actually find this more attractive.