### PR TITLE
Compiler: fix typo in can_propagate_conditional

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -22,7 +22,7 @@ function can_propagate_conditional(@nospecialize(rt), argtypes::Vector{Any})
         return false
     end
     return isa(argtypes[rt.slot], Conditional) &&
-        is_const_bool_or_bottom(rt.thentype) && is_const_bool_or_bottom(rt.thentype)
+        is_const_bool_or_bottom(rt.thentype) && is_const_bool_or_bottom(rt.elsetype)
 end
 
 function propagate_conditional(rt::InterConditional, cond::Conditional)

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -6544,4 +6544,18 @@ end
 @test Float64 <: Base.infer_return_type(issue55548, (Int,))
 @test issue55548(Int64(0)) === 1.0
 
+# issue #60883: conditional propagation through wrapper functions
+mutable struct A60883
+    a::Int
+end
+inner60883(a, b) = iszero(a.a) && !b
+outer60883(a, b) = inner60883(a, b)
+function issue60883()
+    a = A60883(0)
+    b = iszero(a.a)
+    if outer60883(a, b) else end
+    return b  # should not be narrowed to Const(false)
+end
+@test issue60883() === true
+
 end # module inference


### PR DESCRIPTION
The function was checking `rt.thentype` twice instead of checking both `rt.thentype` and `rt.elsetype`. This caused incorrect type narrowing when conditional types were propagated through wrapper functions.

Fixes #60883. Completely done by Claude.