### PR TITLE
Fix similar, but wrong word in modules documentation

### DIFF
--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -637,7 +637,7 @@ Other known potential failure scenarios include:
    Note that `objectid` (which works by hashing the memory pointer) has similar issues (see notes
    on `Dict` usage below).
 
-   One alternative is to use a macro to capture [`@__MODULE__`](@ref) and store it alone with the current `counter` value,
+   One alternative is to use a macro to capture [`@__MODULE__`](@ref) and store it along with the current `counter` value,
    however, it may be better to redesign the code to not depend on this global state.
 2. Associative collections (such as `Dict` and `Set`) need to be re-hashed in `__init__`. (In the
    future, a mechanism may be provided to register an initializer function.)


### PR DESCRIPTION
The global state is not unique. The global state together with the package name (or the module name as a possibly finer-grained substitute) is unique. Therefore, it should be "along", not "alone".