### PR TITLE
Fixes for `break label` and `continue label` parsing

### DIFF
--- a/JuliaSyntax/src/julia/parser.jl
+++ b/JuliaSyntax/src/julia/parser.jl
@@ -44,7 +44,7 @@ end
 # Functions to change parse state
 
 function normal_context(ps::ParseState)
-    ParseState(ps,
+    ParseState(ps;
                range_colon_enabled=true,
                space_sensitive=false,
                where_enabled=true,
@@ -239,10 +239,10 @@ function is_closer_or_newline(ps::ParseState, k)
     is_closing_token(ps,k) || k == K"NewlineWs"
 end
 
-function is_break_cont_closer(ps::ParseState, k)
-    return k in KSet"NewlineWs ; ) EndMarker" ||
-           (k == K"end" && !ps.end_symbol) ||
-           (k == K":"   && ps.range_colon_enabled)
+# Closer for "Non-delimited reserved words" like `return` which aren't closed with an `end`
+function is_nd_resword_closer(ps::ParseState, k)
+    return is_closer_or_newline(ps, k) ||
+           (k == K":"   && !ps.range_colon_enabled)
 end
 
 function is_initial_reserved_word(ps::ParseState, k)
@@ -1873,12 +1873,22 @@ end
 #
 # flisp: parse-resword
 function parse_resword(ps::ParseState)
-    # In normal_context
-    # begin f() where T = x end  ==>  (block (= (where (call f) T) x))
-    ps = normal_context(ps)
-    bump_trivia(ps)
-    mark = position(ps)
+    bump_trivia(ps, skip_newlines=true)
     word = peek(ps)
+    v_1_14_break_cont_ret = ps.stream.version >= (1,14)
+    if v_1_14_break_cont_ret && (word == K"break" || word == K"continue" || word == K"return")
+        # "Non-delimited" reserved words don't have an `end` delimiter and
+        # should preserve end_symbol and range_colon_enabled.
+        ps = ParseState(ps;
+                        space_sensitive=false,
+                        where_enabled=true,
+                        for_generator=false,
+                        whitespace_newline=false)
+    else
+        ps = normal_context(ps)
+    end
+
+    mark = position(ps)
     if word in KSet"begin quote"
         # begin end         ==>  (block)
         # begin a ; b end   ==>  (block a b)
@@ -2055,9 +2065,10 @@ function parse_resword(ps::ParseState)
     elseif word == K"return"
         bump(ps, TRIVIA_FLAG)
         k = peek(ps)
-        if k == K"NewlineWs" || is_closing_token(ps, k)
-            # return\nx   ==>  (return)
-            # return)     ==>  (return)
+        if v_1_14_break_cont_ret ? is_nd_resword_closer(ps, k) :
+                                   (k == K"NewlineWs" || is_closing_token(ps, k))
+            # return\nx   ==> (return)
+            # (return)    ==> (parens (return))
         else
             # return x    ==>  (return x)
             # return x,y  ==>  (return (tuple x y))
@@ -2065,40 +2076,57 @@ function parse_resword(ps::ParseState)
         end
         emit(ps, mark, K"return")
     elseif word == K"break" || word == K"continue"
-        # break            ==>  (break)
-        # break _          ==>  (break _)               [1.14+]
-        # break _ val      ==>  (break _ val)           [1.14+]
-        # break label      ==>  (break label)           [1.14+]
-        # break label val  ==>  (break label val)       [1.14+]
-        #
-        # continue         ==>  (continue)
-        # continue _       ==>  (continue _)        [1.14+]
-        # continue label   ==>  (continue label)    [1.14+]
         bump(ps, TRIVIA_FLAG)
         k = peek(ps)
-        if is_break_cont_closer(ps, k)
-            emit(ps, mark, word)
-        elseif k == K"Identifier" || is_contextual_keyword(k)
-            # break label
-            bump(ps, remap_kind=K"Identifier")
-            if word == K"break"
-                t2 = peek_token(ps)
-                if !is_break_cont_closer(ps, kind(t2))
-                    # break label value
-                    if !preceding_whitespace(t2)
-                        bump_invisible(ps, K"error", TRIVIA_FLAG,
-                                       error="expected space after break label")
+        if v_1_14_break_cont_ret
+            if is_nd_resword_closer(ps, k)
+                # break            ==>  (break)
+                # continue         ==>  (continue)
+                emit(ps, mark, word)
+            else
+                # break label      ==>  (break label)           [1.14+]
+                # continue label   ==>  (continue label)        [1.14+]
+                bump_trivia(ps)
+                emark = position(ps)
+                parse_unary_prefix(ps)
+                b = peek_behind(ps)
+                if b.orig_kind == K"Identifier" || is_contextual_keyword(b.orig_kind) ||
+                        b.kind == K"$" || b.kind == K"var"
+                    # Label ok. Check for `break label value` syntax
+                    if word == K"break"
+                        t2 = peek_token(ps)
+                        if !is_nd_resword_closer(ps, kind(t2))
+                            # break label val  ==>  (break label val)       [1.14+]
+                            if !preceding_whitespace(t2)
+                                bump_invisible(ps, K"error", TRIVIA_FLAG,
+                                               error="expected space after break label")
+                            end
+                            parse_eq(ps)
+                        end
                     end
-                    parse_eq(ps)
+                else
+                    emit(ps, emark, K"error", TRIVIA_FLAG,
+                         error="expected identifier for break label")
+                end
+                emit(ps, mark, word)
+                if !is_nd_resword_closer(ps, peek(ps))
+                    recover(is_nd_resword_closer, ps, TRIVIA_FLAG,
+                            error="unexpected token after $(untokenize(word))")
                 end
             end
-            emit(ps, mark, word)
-            min_supported_version(v"1.14", ps, mark,
-                                  word == K"break" ? "labeled `break`" : "labeled `continue`")
         else
-            recover(is_closer_or_newline, ps, TRIVIA_FLAG,
-                    error="unexpected token after $(untokenize(word))")
-            emit(ps, mark, word)
+            if k in KSet"NewlineWs ; ) : EndMarker" || (k == K"end" && !ps.end_symbol)
+                # break  ==>  (break)
+                emit(ps, mark, word)
+            else
+                # break label ==> ERROR
+                recover(is_closer_or_newline, ps, TRIVIA_FLAG,
+                        error="unexpected token after $(untokenize(word))")
+                emit(ps, mark, word)
+                if k == K"Identifier" || is_contextual_keyword(k) || k == K"$" || k == K"var"
+                    min_supported_version(v"1.14", ps, mark, "labeled `break` and `continue`")
+                end
+            end
         end
     elseif word in KSet"module baremodule"
         # module A end  ==> (module A (block))

--- a/JuliaSyntax/test/diagnostics.jl
+++ b/JuliaSyntax/test/diagnostics.jl
@@ -144,21 +144,25 @@ end
         diagnostic("public() = 6", version=v"1.11") ==
         Diagnostic(1, 6, :warning, "using public as an identifier is deprecated")
 
-    @testset "break/continue version=$ver" for ver in [v"1.13", v"1.14"]
-        @test diagnostic("break +", only_first=true, version=ver) ==
-            Diagnostic(6, 7, :error, "unexpected token after break")
-        @test diagnostic("break ()", only_first=true, version=ver) ==
-            Diagnostic(6, 7, :error, "unexpected token after break")
+    @test diagnostic("break +", only_first=true, version=v"1.13") ==
+        Diagnostic(6, 7, :error, "unexpected token after break")
+    @test diagnostic("break ()", only_first=true, version=v"1.13") ==
+        Diagnostic(6, 7, :error, "unexpected token after break")
+    @test diagnostic("continue +", only_first=true, version=v"1.13") ==
+        Diagnostic(9, 10, :error, "unexpected token after continue")
+    @test diagnostic("break label", only_first=true, version=v"1.13") ==
+        Diagnostic(1, 11, :error, "labeled `break` and `continue` not supported in Julia version 1.13 < 1.14")
 
-        @test diagnostic("continue +", only_first=true, version=ver) ==
-            Diagnostic(9, 10, :error, "unexpected token after continue")
-    end
+    @test diagnostic("break +", only_first=true, version=v"1.14") ==
+        Diagnostic(7, 7, :error, "expected identifier for break label")
+    @test diagnostic("continue +", only_first=true, version=v"1.14") ==
+        Diagnostic(10, 10, :error, "expected identifier for break label")
 
-    @test diagnostic("break f()", version=v"1.14") ==
+    @test diagnostic("break f()", only_first=true, version=v"1.14") ==
         Diagnostic(8, 7, :error, "expected space after break label")
 
-    @test diagnostic("continue f val", version=v"1.14") ==
-        Diagnostic(11, 14, :error, "extra tokens after end of expression")
+    @test diagnostic("continue f val", only_first=true, version=v"1.14") ==
+        Diagnostic(11, 14, :error, "unexpected token after continue")
 end
 
 @testset "diagnostics for literal parsing" begin

--- a/JuliaSyntax/test/diagnostics.jl
+++ b/JuliaSyntax/test/diagnostics.jl
@@ -143,6 +143,22 @@ end
         diagnostic("public[7] = 5", version=v"1.11") ==
         diagnostic("public() = 6", version=v"1.11") ==
         Diagnostic(1, 6, :warning, "using public as an identifier is deprecated")
+
+    @testset "break/continue version=$ver" for ver in [v"1.13", v"1.14"]
+        @test diagnostic("break +", only_first=true, version=ver) ==
+            Diagnostic(6, 7, :error, "unexpected token after break")
+        @test diagnostic("break ()", only_first=true, version=ver) ==
+            Diagnostic(6, 7, :error, "unexpected token after break")
+
+        @test diagnostic("continue +", only_first=true, version=ver) ==
+            Diagnostic(9, 10, :error, "unexpected token after continue")
+    end
+
+    @test diagnostic("break f()", version=v"1.14") ==
+        Diagnostic(8, 7, :error, "expected space after break label")
+
+    @test diagnostic("continue f val", version=v"1.14") ==
+        Diagnostic(11, 14, :error, "extra tokens after end of expression")
 end
 
 @testset "diagnostics for literal parsing" begin

--- a/JuliaSyntax/test/parser.jl
+++ b/JuliaSyntax/test/parser.jl
@@ -9,13 +9,13 @@ function parse_to_sexpr_str(production, code::AbstractString; v=v"1.6", show_kws
     return sprint(io->show(io, MIME("text/x.sexpression"), s; show_kws...))
 end
 
-function test_parse(production, input, expected)
+function test_parse(production, input, expected; show_kws...)
     if !(input isa AbstractString)
         opts, input = input
     else
         opts = NamedTuple()
     end
-    parsed = parse_to_sexpr_str(production, input; opts...)
+    parsed = parse_to_sexpr_str(production, input; show_kws..., opts...)
     if expected isa Regex # Could be AbstractPattern, but that type was added in Julia 1.6.
         @test match(expected, parsed) !== nothing
     else
@@ -556,8 +556,14 @@ tests = [
         ((v=v"1.14",), "break _ x") => "(break _ x)"
         ((v=v"1.14",), "break label") => "(break label)"
         ((v=v"1.14",), "break label x") => "(break label x)"
+        ((v=v"1.14",), "break f ()") => "(break f (tuple-p))"
+        ((v=v"1.14",), "break f()") => "(break f (error-t) (tuple-p))"
         ((v=v"1.14",), "continue _") => "(continue _)"
         ((v=v"1.14",), "continue label") => "(continue label)"
+        ((v=v"1.14",), "break +")  => "(break (error-t + (error-t)))"
+        ((v=v"1.13",), "break label") => "(error (break label))"
+        ((v=v"1.13",), "continue label") => "(error (continue label))"
+        ((v=v"1.13",), "break +")  => "(break (error-t + (error-t)))"
         # module/baremodule
         "module A end"      =>  "(module A (block))"
         "baremodule A end"  =>  "(module-bare A (block))"
@@ -1127,6 +1133,13 @@ parsestmt_test_specs = [
     # unit tests there.
     "''" => "(char (error))"
 
+    # break / continue with trailing tokens are legal in some cases
+    "a ? break : c"    => "(? a (break) c)"
+    "begin break end"  => "(block (break))"
+    "a ? continue : c"   => "(? a (continue) c)"
+    "begin continue end" => "(block (continue))"
+    "break:x"  => "(call-i (break) : x)" # range colon allowed
+
     # The following may not be ideal error recovery! But at least the parser
     # shouldn't crash
     "@(x y)" => "(macrocall (macro_name (parens x (error-t y))))"
@@ -1152,7 +1165,7 @@ parsestmt_test_specs = [
     "f(x for x = xs a)"     =>  "(call f (generator x (iteration (in x xs))) (error-t a))"
 ]
 
-@testset "Parser does not crash on broken code" begin
+@testset "Parsestmt tests" begin
     @testset "$(repr(input))" for (input, output) in parsestmt_test_specs
         test_parse(JuliaSyntax.parse_stmts, input, output)
     end
@@ -1179,6 +1192,11 @@ parsestmt_with_kind_tests = [
     "a^b"    => "(call-i a::Identifier ^::Identifier b::Identifier)"
     "f.'"    => "(dotcall-post f::Identifier (error '::Identifier))"
     "f'"     => "(call-post f::Identifier '::Identifier)"
+    # break/continue labels (contextual keywords allowed)
+    ((v=v"1.14",), "break label") => "(break label::Identifier)"
+    ((v=v"1.14",), "continue label") => "(continue label::Identifier)"
+    ((v=v"1.14",), "break outer") => "(break outer::Identifier)"
+    ((v=v"1.14",), "continue outer") => "(continue outer::Identifier)"
     # Standalone syntactic ops which keep their kind - they can't really be
     # used in a sane way as identifiers or interpolated into expressions
     # because they have their own syntactic forms.
@@ -1200,8 +1218,7 @@ parsestmt_with_kind_tests = [
 
 @testset "parser `Kind` remapping" begin
     @testset "$(repr(input))" for (input, output) in parsestmt_with_kind_tests
-        input = ((show_kind=true,), input)
-        test_parse(JuliaSyntax.parse_stmts, input, output)
+        test_parse(JuliaSyntax.parse_stmts, input, output; show_kind=true)
     end
 end
 


### PR DESCRIPTION
Fixes for the new parsing for labeled `break` / `continue` which is broken or surprising in a few ways:

* The syntax `break f()` was allowed but parsed as `(break f (tuple))` rather than `(break (call f))`. This is very surprising, so introduce a condition forcing the label to be followed by whitespace.
* The trailing token error handling was somehow deleted (but replaced with a comment yay AI slop :-/ ?), allowing things like `break + x` to parse as `(call-i (break) + x)`. We didn't have tests for this, so fix this bug and beef up the tests.
* It doesn't use `bump()` with `remap_kind=K"Identifier"` so the label can be a contextual keyword. This is inconsistent with the rest of the parser's treatment of identifier-like things in identifier position.

Also clean up other AI slop written by Claude in #60481: delete redundant comments and factoring break and continue parsing back into a single block as they share the same logic for label validity and error recovery.

Currently this parsing doesn't allow a few things as labels that we allow in other locations as plain identifiers. For consistency we might want to consider allowing the following as labels which are currently allowed in macros like `@label`

* Operator symbols like `+`
* Word operators `where` `in`, `as`
* `var""` identifiers (?)

I didn't change these yet, however.