### PR TITLE
Add `filterfirst(f,itr)`, returns first x in itr with `f(x)==true`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -457,8 +457,12 @@ firstindex(a, d) = (@inline; first(axes(a, d)))
 """
     first(coll)
 
-Get the first element of an iterable collection. Return the start point of an
-[`AbstractRange`](@ref) even if it is empty.
+Get the first element of an iterable collection.
+
+!!! note
+    For an [`AbstractRange`](@ref) the start point is always returned,
+    even if the range is empty. For other empty collections, an error
+    is thrown.
 
 See also [`only`](@ref), [`firstindex`](@ref), [`last`](@ref).
 
@@ -476,6 +480,30 @@ function first(itr)
     x === nothing && throw(ArgumentError("collection must be non-empty"))
     x[1]
 end
+
+
+"""
+    first(f, itr)
+
+Get the first element of an iterable collection `itr` for which the
+predicate `f` returns `true.`
+
+!!! compat "Julia 1.14"
+    This method requires at least Julia 1.14.
+
+# Examples
+```jldoctest
+julia> first(>=(5), 2:2:10)
+6
+
+julia> first(iseven, [1; 2; 3; 4])
+2
+
+julia> first(isodd, 2:2:10)
+ERROR: ArgumentError: collection must be non-empty
+```
+"""
+first(f, itr) = first(Iterators.filter(f, itr))
 
 """
     first(itr, n::Integer)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -481,9 +481,8 @@ function first(itr)
     x[1]
 end
 
-
 """
-    first(f, itr)
+    filterfirst(f, itr)
 
 Get the first element of an iterable collection `itr` for which the
 predicate `f` returns `true.`
@@ -493,17 +492,17 @@ predicate `f` returns `true.`
 
 # Examples
 ```jldoctest
-julia> first(>=(5), 2:2:10)
+julia> filterfirst(>=(5), 2:2:10)
 6
 
-julia> first(iseven, [1; 2; 3; 4])
+julia> filterfirst(iseven, [1; 2; 3; 4])
 2
 
-julia> first(isodd, 2:2:10)
+julia> filterfirst(isodd, 2:2:10)
 ERROR: ArgumentError: collection must be non-empty
 ```
 """
-first(f, itr) = first(Iterators.filter(f, itr))
+filterfirst(f, itr) = first(Iterators.filter(f, itr))
 
 """
     first(itr, n::Integer)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -482,29 +482,6 @@ function first(itr)
 end
 
 """
-    filterfirst(f, itr)
-
-Get the first element of an iterable collection `itr` for which the
-predicate `f` returns `true.`
-
-!!! compat "Julia 1.14"
-    This method requires at least Julia 1.14.
-
-# Examples
-```jldoctest
-julia> filterfirst(>=(5), 2:2:10)
-6
-
-julia> filterfirst(iseven, [1; 2; 3; 4])
-2
-
-julia> filterfirst(isodd, 2:2:10)
-ERROR: ArgumentError: collection must be non-empty
-```
-"""
-filterfirst(f, itr) = first(Iterators.filter(f, itr))
-
-"""
     first(itr, n::Integer)
 
 Get the first `n` elements of the iterable collection `itr`, or fewer elements if `itr` is not

--- a/base/array.jl
+++ b/base/array.jl
@@ -3049,6 +3049,29 @@ function filter!(f, a::AbstractVector)
 end
 
 """
+    filterfirst(f, itr)
+
+Get the first element of an iterable collection `itr` for which the
+predicate `f` returns `true.`
+
+!!! compat "Julia 1.14"
+    This method requires at least Julia 1.14.
+
+# Examples
+```jldoctest
+julia> filterfirst(>=(5), 2:2:10)
+6
+
+julia> filterfirst(iseven, [1; 2; 3; 4])
+2
+
+julia> filterfirst(isodd, 2:2:10)
+ERROR: ArgumentError: collection must be non-empty
+```
+"""
+filterfirst(f, itr) = first(Iterators.filter(f, itr))
+
+"""
     filter(f)
 
 Create a function that filters its arguments with function `f` using [`filter`](@ref), i.e.

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -571,6 +571,7 @@ export
     lastindex,
     filter!,
     filter,
+    filterfirst,
     foldl,
     foldr,
     foreach,

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -153,6 +153,7 @@ Base.collect(::Any)
 Base.collect(::Type, ::Any)
 Base.filter
 Base.filter!
+Base.filterfirst
 Base.replace(::Any, ::Pair...)
 Base.replace(::Base.Callable, ::Any)
 Base.replace!


### PR DESCRIPTION
This has been a long-standing feature request for me, and apparently also for others: Resolves #26287. Resolves #44996. First step towards resolving #54118 (as in: if we agree on this I can add the other features requested there, too).

I expect this to need some discussion, perhaps even triage. Perhaps a different name should be used. However, personally I find `find(f,itr)` very intuitive and in fact regularly try it and re-discover it doesn't work... So I'd be really sad if we don't go this way.

A past argument against this was the claim that `foo(f,itr)` "usually" stands for `foo(map(f,itr))`. I have not seen this claim backed up with actual data, but even if, I still don't find it very convincing, because `first(map(f,itr))` is simply not useful (it'd be a less efficient version of `f(first(itr))`). 

Other counterarguments I can think of:
- **shouldn't there also be a `last(f,itr)`?** -- fine by me, but I figured it is pointless to spend time on it if perhaps `first(f,itr)` is already rejected. If it accepted, I'll be happy to look into a `last` counterpart (probably based on `Iterators.reverse` and thus with a note that it may not work for all iterators)
- **shouldn't there also be `first(f,itr,n)` for full symmetry?** -- again, happy to do that but didn't want to spend time on it before knowing the general direction we want to go
- **there are not enough tests here** -- ditto
- **it is too trivial** -- I've seen this argument, and I find it confounding. Would you then also suggest we drop `isodd` (it is just `!iseven`, after all?) or in fact drop both `isodd` and `iseven`? Heck, even `first(itr)` is a one-liner (`iterate(itr)[1]`) if you don't care too much about optimized methods for specific input types (which of course `first(f,itr)` could also get).