### PR TITLE
[JuliaLowering] Fix soft scope semantics leaking through hard scope

### DIFF
--- a/JuliaLowering/test/utils.jl
+++ b/JuliaLowering/test/utils.jl
@@ -378,3 +378,7 @@ end
 function reference_lower(mod::Module, x)
     Base.fl_lower(x, mod, @__FILE__, @__LINE__, Base.get_world_counter())[1]
 end
+
+function reference_eval(mod::Module, x)
+    Core.eval(mod, reference_lower(mod, x))
+end


### PR DESCRIPTION
Fix a silly mistake in https://github.com/JuliaLang/julia/pull/60316 I noticed while doing something else.  I had managed to describe the correct behaviour in a comment:

```
struct ScopeInfo
    ...
    # True in the top-level scope, and any neutral scope nested within it not
    # protected by a hard scope.  Becomes soft if `ctx.enable_soft_scopes`.
    is_permeable::Bool
    ...
end
```

but wasn't checking the parent scope at all.  

Also move some code for a future change and make tests more thorough.