### PR TITLE
Add API for non-native compiler caching of external methods

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -2183,6 +2183,8 @@ JL_DLLEXPORT jl_value_t *jl_object_top_module(jl_value_t* v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_set_newly_inferred(jl_value_t *newly_inferred);
 JL_DLLEXPORT jl_array_t* jl_compute_new_ext_cis(void);
 JL_DLLEXPORT void jl_push_newly_inferred(jl_value_t *ci);
+JL_DLLEXPORT void jl_set_newly_inferred_external(jl_value_t *newly_inferred_external);
+JL_DLLEXPORT void jl_push_newly_inferred_external(jl_value_t *ci);
 JL_DLLEXPORT void jl_set_inference_entrance_backtraces(jl_value_t *inference_entrance_backtraces);
 JL_DLLEXPORT void jl_push_inference_entrance_backtraces(jl_value_t *ci);
 JL_DLLEXPORT void jl_write_compiler_output(void);


### PR DESCRIPTION
Non-native compilers that use the AbstractInterpreter framework create CodeInstances with a non-nothing `owner` field to partition their compilation results from the native code cache. Since https://github.com/JuliaLang/julia/pull/54894, `queue_external_cis` filters CIs with `ci->owner == jl_nothing`, which sometimes means non-native CIs for external methods are silently dropped during serialization. @vchuravy This may explain the breakage seen in GPUCompiler.jl/CompilerCaching.jl for the test you added? I don't fully understand the whole mechanism for discovering/caching CIs though.

This PR adds an explicit `Base.precompile(ci::CodeInstance)` API to registers CIs into a separate `newly_inferred_external` array. During `jl_create_system_image`, these CIs are merged directly into `new_ext_cis` after the filtering step, bypassing the owner check entirely.

IIUC This would also be useful for compiling non-native workloads with JuliaC.jl, as a simpler alternative to `invoke_in_cache` or `invoke_with_absint`.

Corresponding CompilerCaching.jl PR: https://github.com/maleadt/CompilerCaching.jl/pull/3

cc @gbaraldi This resembles what we discussed yesterday.
cc @vchuravy You've worked on this before
cc @vtjnash Having authored https://github.com/JuliaLang/julia/pull/54894