### PR TITLE
codegen: Move GC pointer zeroing to late-gc-lowering

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2317,15 +2317,11 @@ static void undef_derived_strct(jl_codectx_t &ctx, Value *ptr, jl_datatype_t *st
     size_t first_offset = sty->layout->nfields ? jl_field_offset(sty, 0) : 0;
     if (first_offset != 0)
         ctx.builder.CreateMemSet(ptr, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0), first_offset, MaybeAlign(0));
-    if (sty->layout->first_ptr < 0)
-        return;
-    size_t i, np = sty->layout->npointers;
-    auto T_prjlvalue = JuliaType::get_prjlvalue_ty(ctx.builder.getContext());
-    for (i = 0; i < np; i++) {
-        Value *fld = emit_ptrgep(ctx, ptr, jl_ptr_offset(sty, i) * sizeof(jl_value_t*));
-        jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, tbaa);
-        ai.decorateInst(ctx.builder.CreateStore(Constant::getNullValue(T_prjlvalue), fld));
-    }
+    // GC pointer fields are now zeroed by LateLowerGCFrame based on the
+    // julia.gc_alloc_ptr_offsets operand bundle on the allocation call.
+    // This ensures zeroing happens after allocation lowering, preventing
+    // optimization passes from sinking it past safepoints.
+    (void)tbaa;
 }
 
 static Value *emit_inttoptr(jl_codectx_t &ctx, Value *v, Type *ty)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4406,10 +4406,10 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             *ret = mark_julia_const(ctx, (jl_value_t*)jl_emptysvec);
             return true;
         }
-        // Svec layout: [length (sizeof_ptr)] [ptr0] [ptr1] ... [ptr_n-1]
+        // Svec layout: [length] [ptr0] [ptr1] ... [ptr_n-1]
         // Use zeroinit_region to zero the pointer array - this must happen before
         // any safepoint (e.g., boxed() below) to prevent GC from seeing uninitialized pointers
-        AllocZeroinitRegion zeroinit(ctx.types().sizeof_ptr, ctx.types().sizeof_ptr * nargs);
+        AllocZeroinitRegion zeroinit(sizeof(jl_svec_t), ctx.types().sizeof_ptr * nargs);
         Value *svec = emit_allocobj(ctx, ctx.types().sizeof_ptr * (nargs + 1),
                                     ctx.builder.CreateIntToPtr(emit_tagfrom(ctx, jl_simplevector_type), ctx.types().T_pjlvalue),
                                     true, julia_alignment((jl_value_t*)jl_simplevector_type),

--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -40,6 +40,7 @@ JL_DLLEXPORT jl_genericmemory_t *jl_alloc_genericmemory_unchecked(jl_ptls_t ptls
     }
     m = (jl_genericmemory_t*)jl_gc_alloc(ptls, tot, mtype);
     if (pooled) {
+        // N.B. if this offset changes, also update emit_const_len_memorynew in cgutils.cpp
         data = (char*)m + JL_SMALL_BYTE_ALIGNMENT;
     }
     else {

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -318,8 +318,7 @@ if bc_opt == bc_default
     for T in [Memory] # This requires changing the pointer_from_objref to something llvm sees through
         for ET in [Int, Float32, Union{Int, Float64}]
             no_allocate(T{ET}) #compile
-            # allocations aren't removed for Union eltypes which they theoretically could be eventually
-            test_alloc(T{ET}, broken=(ET==Union{Int, Float64}))
+            test_alloc(T{ET})
         end
     end
     function f() # this was causing a bug on an in progress version of #55913.

--- a/test/llvmpasses/codegen-alloc-zeroing.jl
+++ b/test/llvmpasses/codegen-alloc-zeroing.jl
@@ -1,0 +1,100 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Tests for GC pointer zeroing operand bundles on allocation calls
+# These bundles inform late-gc-lowering about which fields need to be zeroed
+
+using Test, InteractiveUtils
+
+# Helper to get raw LLVM IR (before late-gc-lowering)
+function get_raw_llvm(@nospecialize(f), @nospecialize(tt))
+    sprint((io, f, tt) -> code_llvm(io, f, tt; raw=true, optimize=false, debuginfo=:none), f, tt)
+end
+
+# Helper to get optimized LLVM IR (after late-gc-lowering)
+function get_opt_llvm(@nospecialize(f), @nospecialize(tt))
+    sprint((io, f, tt) -> code_llvm(io, f, tt; optimize=true, debuginfo=:none), f, tt)
+end
+
+@testset "GC allocation zeroing bundles" begin
+    # Test 1: Mutable struct with pointer fields should emit julia.gc_alloc_ptr_offsets bundle
+    @testset "Struct with pointer fields" begin
+        mutable struct TestStructPtrs
+            a::Any      # GC pointer at offset 0
+            b::Int64    # Non-pointer at offset 8
+            c::Any      # GC pointer at offset 16
+        end
+
+        function make_struct_ptrs(x, y, z)
+            TestStructPtrs(x, y, z)
+        end
+
+        # Check raw IR has the bundle
+        raw_ir = get_raw_llvm(make_struct_ptrs, Tuple{Any, Int64, Any})
+        @test occursin("julia.gc_alloc_ptr_offsets", raw_ir)
+        @test occursin("i64 0", raw_ir) && occursin("i64 16", raw_ir)  # offsets for 'a' and 'c'
+
+        # Check optimized IR has null stores after allocation
+        opt_ir = get_opt_llvm(make_struct_ptrs, Tuple{Any, Int64, Any})
+        @test occursin("store ptr null", opt_ir) || occursin("store ptr addrspace(10) null", opt_ir)
+    end
+
+    # Test 2: Struct with only non-pointer fields should NOT have the bundle
+    @testset "Struct without pointer fields" begin
+        mutable struct TestStructNoPtrs
+            a::Int64
+            b::Int64
+        end
+
+        function make_struct_no_ptrs(x, y)
+            TestStructNoPtrs(x, y)
+        end
+
+        raw_ir = get_raw_llvm(make_struct_no_ptrs, Tuple{Int64, Int64})
+        # Should have allocation but NO ptr_offsets bundle
+        @test occursin("julia.gc_alloc_obj", raw_ir)
+        @test !occursin("julia.gc_alloc_ptr_offsets", raw_ir)
+    end
+
+    # Test 3: Memory{Any} should emit julia.gc_alloc_zeroinit bundle
+    @testset "Memory with boxed elements" begin
+        function make_memory_any()
+            Memory{Any}(undef, 4)
+        end
+
+        # Check raw IR has the zeroinit bundle
+        raw_ir = get_raw_llvm(make_memory_any, Tuple{})
+        @test occursin("julia.gc_alloc_zeroinit", raw_ir)
+        # Should specify offset 16 (after header) and size 32 (4 * 8 bytes)
+        @test occursin("i64 16", raw_ir) && occursin("i64 32", raw_ir)
+
+        # Check optimized IR has memset
+        opt_ir = get_opt_llvm(make_memory_any, Tuple{})
+        @test occursin("llvm.memset", opt_ir)
+    end
+
+    # Test 4: Memory{Int64} (non-boxed) should NOT have zeroinit bundle
+    @testset "Memory with non-boxed elements" begin
+        function make_memory_int()
+            Memory{Int64}(undef, 4)
+        end
+
+        raw_ir = get_raw_llvm(make_memory_int, Tuple{})
+        # Int64 doesn't need zeroing, so no zeroinit bundle
+        @test !occursin("julia.gc_alloc_zeroinit", raw_ir)
+    end
+
+    # Test 5: Single pointer field struct
+    @testset "Single pointer field" begin
+        mutable struct SinglePtr
+            x::Any
+        end
+
+        function make_single_ptr(x)
+            SinglePtr(x)
+        end
+
+        raw_ir = get_raw_llvm(make_single_ptr, Tuple{Any})
+        @test occursin("julia.gc_alloc_ptr_offsets", raw_ir)
+        @test occursin("i64 0", raw_ir)  # pointer at offset 0
+    end
+end

--- a/test/llvmpasses/codegen-alloc-zeroing.jl
+++ b/test/llvmpasses/codegen-alloc-zeroing.jl
@@ -3,128 +3,104 @@
 # Tests for GC pointer zeroing operand bundles on allocation calls
 # These bundles inform late-gc-lowering about which fields need to be zeroed
 
-using Test, InteractiveUtils
+# RUN: julia --startup-file=no %s %t && llvm-link -S %t/* -o %t/module.ll
+# RUN: cat %t/module.ll | FileCheck %s
 
-# Helper to get raw LLVM IR (before late-gc-lowering)
-function get_raw_llvm(@nospecialize(f), @nospecialize(tt))
-    sprint((io, f, tt) -> code_llvm(io, f, tt; raw=true, optimize=false, debuginfo=:none), f, tt)
+include(joinpath("..", "testhelpers", "llvmpasses.jl"))
+
+# COM: Test 1: Mutable struct with pointer fields should emit julia.gc_alloc_ptr_offsets bundle
+mutable struct TestStructPtrs
+    a::Any      # GC pointer at offset 0
+    b::Int64    # Non-pointer at offset 8
+    c::Any      # GC pointer at offset 16
 end
 
-# Helper to get optimized LLVM IR (after late-gc-lowering)
-function get_opt_llvm(@nospecialize(f), @nospecialize(tt))
-    sprint((io, f, tt) -> code_llvm(io, f, tt; optimize=true, debuginfo=:none), f, tt)
+function make_struct_ptrs(x, y, z)
+    TestStructPtrs(x, y, z)
 end
 
-@testset "GC allocation zeroing bundles" begin
-    # Test 1: Mutable struct with pointer fields should emit julia.gc_alloc_ptr_offsets bundle
-    @testset "Struct with pointer fields" begin
-        mutable struct TestStructPtrs
-            a::Any      # GC pointer at offset 0
-            b::Int64    # Non-pointer at offset 8
-            c::Any      # GC pointer at offset 16
-        end
+# CHECK: define {{.*}} @julia_make_struct_ptrs
+# CHECK: julia.gc_alloc_obj
+# CHECK-SAME: [ "julia.gc_alloc_ptr_offsets"(i64 0, i64 16) ]
+emit(make_struct_ptrs, Any, Int64, Any)
 
-        function make_struct_ptrs(x, y, z)
-            TestStructPtrs(x, y, z)
-        end
-
-        # Check raw IR has the bundle
-        raw_ir = get_raw_llvm(make_struct_ptrs, Tuple{Any, Int64, Any})
-        @test occursin("julia.gc_alloc_ptr_offsets", raw_ir)
-        @test occursin("i64 0", raw_ir) && occursin("i64 16", raw_ir)  # offsets for 'a' and 'c'
-
-        # Check optimized IR has null stores after allocation
-        opt_ir = get_opt_llvm(make_struct_ptrs, Tuple{Any, Int64, Any})
-        @test occursin("store ptr null", opt_ir) || occursin("store ptr addrspace(10) null", opt_ir)
-    end
-
-    # Test 2: Struct with only non-pointer fields should NOT have the bundle
-    @testset "Struct without pointer fields" begin
-        mutable struct TestStructNoPtrs
-            a::Int64
-            b::Int64
-        end
-
-        function make_struct_no_ptrs(x, y)
-            TestStructNoPtrs(x, y)
-        end
-
-        raw_ir = get_raw_llvm(make_struct_no_ptrs, Tuple{Int64, Int64})
-        # Should have allocation but NO ptr_offsets bundle
-        @test occursin("julia.gc_alloc_obj", raw_ir)
-        @test !occursin("julia.gc_alloc_ptr_offsets", raw_ir)
-    end
-
-    # Test 3: Memory{Any} should emit julia.gc_alloc_zeroinit bundle
-    @testset "Memory with boxed elements" begin
-        function make_memory_any()
-            Memory{Any}(undef, 4)
-        end
-
-        # Check raw IR has the zeroinit bundle
-        raw_ir = get_raw_llvm(make_memory_any, Tuple{})
-        @test occursin("julia.gc_alloc_zeroinit", raw_ir)
-        # Should specify offset 16 (after header) and size 32 (4 * 8 bytes)
-        @test occursin("i64 16", raw_ir) && occursin("i64 32", raw_ir)
-
-        # Check optimized IR has memset
-        opt_ir = get_opt_llvm(make_memory_any, Tuple{})
-        @test occursin("llvm.memset", opt_ir)
-    end
-
-    # Test 4: Memory{Int64} (non-boxed) should NOT have zeroinit bundle
-    @testset "Memory with non-boxed elements" begin
-        function make_memory_int()
-            Memory{Int64}(undef, 4)
-        end
-
-        raw_ir = get_raw_llvm(make_memory_int, Tuple{})
-        # Int64 doesn't need zeroing, so no zeroinit bundle
-        @test !occursin("julia.gc_alloc_zeroinit", raw_ir)
-    end
-
-    # Test 5: Single pointer field struct
-    @testset "Single pointer field" begin
-        mutable struct SinglePtr
-            x::Any
-        end
-
-        function make_single_ptr(x)
-            SinglePtr(x)
-        end
-
-        raw_ir = get_raw_llvm(make_single_ptr, Tuple{Any})
-        @test occursin("julia.gc_alloc_ptr_offsets", raw_ir)
-        @test occursin("i64 0", raw_ir)  # pointer at offset 0
-    end
-
-    # Test 6: Variable-length Memory{Any} uses zeroinit_indirect bundle
-    @testset "Variable-length Memory with boxed elements" begin
-        function make_memory_any_dynamic(n::Int)
-            Memory{Any}(undef, n)
-        end
-
-        raw_ir = get_raw_llvm(make_memory_any_dynamic, Tuple{Int})
-        # Variable-length uses jl_alloc_genericmemory_unchecked with zeroinit_indirect bundle
-        @test occursin("jl_alloc_genericmemory_unchecked", raw_ir)
-        @test occursin("julia.gc_alloc_zeroinit_indirect", raw_ir)
-        # Data pointer offset is 8 (sizeof(size_t) for length field)
-        @test occursin("i64 8", raw_ir)
-
-        # Optimized IR should have memset (emitted by late-gc-lowering)
-        opt_ir = get_opt_llvm(make_memory_any_dynamic, Tuple{Int})
-        @test occursin("llvm.memset", opt_ir)
-    end
-
-    # Test 7: Variable-length Memory{Int64} should NOT have zeroinit bundle
-    @testset "Variable-length Memory with non-boxed elements" begin
-        function make_memory_int_dynamic(n::Int)
-            Memory{Int64}(undef, n)
-        end
-
-        raw_ir = get_raw_llvm(make_memory_int_dynamic, Tuple{Int})
-        @test occursin("jl_alloc_genericmemory_unchecked", raw_ir)
-        # Int64 doesn't need zeroing, so no zeroinit bundle
-        @test !occursin("julia.gc_alloc_zeroinit_indirect", raw_ir)
-    end
+# COM: Test 2: Struct with only non-pointer fields should NOT have the bundle
+mutable struct TestStructNoPtrs
+    a::Int64
+    b::Int64
 end
+
+function make_struct_no_ptrs(x, y)
+    TestStructNoPtrs(x, y)
+end
+
+# CHECK: define {{.*}} @julia_make_struct_no_ptrs
+# CHECK: julia.gc_alloc_obj
+# CHECK-NOT: julia.gc_alloc_ptr_offsets
+# CHECK: ret
+emit(make_struct_no_ptrs, Int64, Int64)
+
+# COM: Test 3: Memory{Any} (constant length) should emit julia.gc_alloc_zeroinit bundle
+function make_memory_any()
+    Memory{Any}(undef, 4)
+end
+
+# CHECK: define {{.*}} @julia_make_memory_any
+# CHECK: julia.gc_alloc_obj
+# CHECK-SAME: [ "julia.gc_alloc_zeroinit"(i64 16, i64 32) ]
+emit(make_memory_any)
+
+# COM: Test 4: Memory{Int64} (non-boxed) should NOT have zeroinit bundle
+function make_memory_int()
+    Memory{Int64}(undef, 4)
+end
+
+# CHECK: define {{.*}} @julia_make_memory_int
+# CHECK-NOT: julia.gc_alloc_zeroinit
+# CHECK: ret
+emit(make_memory_int)
+
+# COM: Test 5: Single pointer field struct
+mutable struct SinglePtr
+    x::Any
+end
+
+function make_single_ptr(x)
+    SinglePtr(x)
+end
+
+# CHECK: define {{.*}} @julia_make_single_ptr
+# CHECK: julia.gc_alloc_obj
+# CHECK-SAME: [ "julia.gc_alloc_ptr_offsets"(i64 0) ]
+emit(make_single_ptr, Any)
+
+# COM: Test 6: Variable-length Memory{Any} uses zeroinit_indirect bundle
+function make_memory_any_dynamic(n::Int)
+    Memory{Any}(undef, n)
+end
+
+# CHECK: define {{.*}} @julia_make_memory_any_dynamic
+# CHECK: jl_alloc_genericmemory_unchecked
+# CHECK-SAME: [ "julia.gc_alloc_zeroinit_indirect"(i64 8,
+emit(make_memory_any_dynamic, Int)
+
+# COM: Test 7: Variable-length Memory{Int64} should NOT have zeroinit bundle
+function make_memory_int_dynamic(n::Int)
+    Memory{Int64}(undef, n)
+end
+
+# CHECK: define {{.*}} @julia_make_memory_int_dynamic
+# CHECK: jl_alloc_genericmemory_unchecked
+# CHECK-NOT: julia.gc_alloc_zeroinit_indirect
+# CHECK: ret
+emit(make_memory_int_dynamic, Int)
+
+# COM: Test 8: SimpleVector (svec) should emit julia.gc_alloc_zeroinit bundle
+function make_svec(a, b, c)
+    Core.svec(a, b, c)
+end
+
+# CHECK: define {{.*}} @{{(julia_make_svec|japi1_make_svec)}}
+# CHECK: julia.gc_alloc_obj
+# CHECK-SAME: [ "julia.gc_alloc_zeroinit"(i64 8, i64 24) ]
+emit(make_svec, Any, Any, Any)

--- a/test/llvmpasses/late-lower-gc-alloc-zeroing.ll
+++ b/test/llvmpasses/late-lower-gc-alloc-zeroing.ll
@@ -112,7 +112,7 @@ define {} addrspace(10)* @gc_alloc_no_bundles({}** %current_task) {
 ; This loads the data pointer from offset 8 and zeros via that pointer
 define {} addrspace(10)* @gc_alloc_zeroinit_indirect({}* %ptls, i64 %nbytes) {
 ; CHECK-LABEL: @gc_alloc_zeroinit_indirect
-; CHECK: %v = call noalias nonnull ptr addrspace(10) @jl_alloc_genericmemory_unchecked
+; CHECK: %v = call noalias ptr addrspace(10) @jl_alloc_genericmemory_unchecked
 ; CHECK: [[DERIVED:%.*]] = addrspacecast ptr addrspace(10) %v to ptr addrspace(11)
 ; CHECK: [[PTR_FIELD:%.*]] = getelementptr inbounds i8, ptr addrspace(11) [[DERIVED]], i64 8
 ; CHECK: [[DATA_PTR:%.*]] = load ptr, ptr addrspace(11) [[PTR_FIELD]], align 8
@@ -125,7 +125,7 @@ define {} addrspace(10)* @gc_alloc_zeroinit_indirect({}* %ptls, i64 %nbytes) {
 ; Test zeroinit_indirect with constant size
 define {} addrspace(10)* @gc_alloc_zeroinit_indirect_const({}* %ptls) {
 ; CHECK-LABEL: @gc_alloc_zeroinit_indirect_const
-; CHECK: %v = call noalias nonnull ptr addrspace(10) @jl_alloc_genericmemory_unchecked
+; CHECK: %v = call noalias ptr addrspace(10) @jl_alloc_genericmemory_unchecked
 ; CHECK: [[DERIVED:%.*]] = addrspacecast ptr addrspace(10) %v to ptr addrspace(11)
 ; CHECK: [[PTR_FIELD:%.*]] = getelementptr inbounds i8, ptr addrspace(11) [[DERIVED]], i64 8
 ; CHECK: [[DATA_PTR:%.*]] = load ptr, ptr addrspace(11) [[PTR_FIELD]], align 8
@@ -138,7 +138,7 @@ define {} addrspace(10)* @gc_alloc_zeroinit_indirect_const({}* %ptls) {
 ; Test zeroinit_indirect with zero size (should not emit memset)
 define {} addrspace(10)* @gc_alloc_zeroinit_indirect_zero_size({}* %ptls) {
 ; CHECK-LABEL: @gc_alloc_zeroinit_indirect_zero_size
-; CHECK: %v = call noalias nonnull ptr addrspace(10) @jl_alloc_genericmemory_unchecked
+; CHECK: %v = call noalias ptr addrspace(10) @jl_alloc_genericmemory_unchecked
 ; CHECK-NOT: call void @llvm.memset
 ; CHECK: ret ptr addrspace(10) %v
     %v = call noalias {} addrspace(10)* @jl_alloc_genericmemory_unchecked({}* %ptls, i64 0, {} addrspace(10)* @tag) [ "julia.gc_alloc_zeroinit_indirect"(i64 8, i64 0) ]

--- a/test/llvmpasses/late-lower-gc-alloc-zeroing.ll
+++ b/test/llvmpasses/late-lower-gc-alloc-zeroing.ll
@@ -1,0 +1,108 @@
+; This file is a part of Julia. License is MIT: https://julialang.org/license
+
+; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -passes='function(LateLowerGCFrame)' -S %s | FileCheck %s
+
+@tag = external addrspace(10) global {}, align 16
+
+declare {}*** @julia.get_pgcstack()
+declare noalias nonnull {} addrspace(10)* @julia.gc_alloc_obj({}**, i64, {} addrspace(10)*)
+declare i64 @external_call({} addrspace(10)*)
+
+; Test that julia.gc_alloc_ptr_offsets bundle causes null stores to be emitted
+define {} addrspace(10)* @gc_alloc_ptr_offsets_single({}** %current_task) {
+; CHECK-LABEL: @gc_alloc_ptr_offsets_single
+; CHECK: %v = call noalias nonnull ptr addrspace(10) @julia.gc_alloc_bytes
+; CHECK: store atomic ptr addrspace(10) @tag
+; CHECK: [[DERIVED:%.*]] = addrspacecast ptr addrspace(10) %v to ptr addrspace(11)
+; CHECK: [[PTR:%.*]] = getelementptr inbounds i8, ptr addrspace(11) [[DERIVED]], i64 8
+; CHECK: store ptr addrspace(10) null, ptr addrspace(11) [[PTR]], align 8
+; CHECK: ret ptr addrspace(10) %v
+    %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, i64 24, {} addrspace(10)* @tag) [ "julia.gc_alloc_ptr_offsets"(i64 8) ]
+    ret {} addrspace(10)* %v
+}
+
+; Test multiple pointer offsets
+define {} addrspace(10)* @gc_alloc_ptr_offsets_multiple({}** %current_task) {
+; CHECK-LABEL: @gc_alloc_ptr_offsets_multiple
+; CHECK: %v = call noalias nonnull ptr addrspace(10) @julia.gc_alloc_bytes
+; CHECK: store atomic ptr addrspace(10) @tag
+; CHECK: [[DERIVED:%.*]] = addrspacecast ptr addrspace(10) %v to ptr addrspace(11)
+; CHECK: [[PTR0:%.*]] = getelementptr inbounds i8, ptr addrspace(11) [[DERIVED]], i64 0
+; CHECK: store ptr addrspace(10) null, ptr addrspace(11) [[PTR0]], align 8
+; CHECK: [[PTR8:%.*]] = getelementptr inbounds i8, ptr addrspace(11) [[DERIVED]], i64 8
+; CHECK: store ptr addrspace(10) null, ptr addrspace(11) [[PTR8]], align 8
+; CHECK: [[PTR16:%.*]] = getelementptr inbounds i8, ptr addrspace(11) [[DERIVED]], i64 16
+; CHECK: store ptr addrspace(10) null, ptr addrspace(11) [[PTR16]], align 8
+; CHECK: ret ptr addrspace(10) %v
+    %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, i64 24, {} addrspace(10)* @tag) [ "julia.gc_alloc_ptr_offsets"(i64 0, i64 8, i64 16) ]
+    ret {} addrspace(10)* %v
+}
+
+; Test julia.gc_alloc_zeroinit bundle causes memset to be emitted
+define {} addrspace(10)* @gc_alloc_zeroinit({}** %current_task) {
+; CHECK-LABEL: @gc_alloc_zeroinit
+; CHECK: %v = call noalias nonnull ptr addrspace(10) @julia.gc_alloc_bytes
+; CHECK: store atomic ptr addrspace(10) @tag
+; CHECK: [[DERIVED:%.*]] = addrspacecast ptr addrspace(10) %v to ptr addrspace(11)
+; CHECK: [[PTR:%.*]] = getelementptr inbounds i8, ptr addrspace(11) [[DERIVED]], i64 16
+; CHECK: call void @llvm.memset.p11.i64(ptr addrspace(11) align 8 [[PTR]], i8 0, i64 32, i1 false)
+; CHECK: ret ptr addrspace(10) %v
+    %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, i64 48, {} addrspace(10)* @tag) [ "julia.gc_alloc_zeroinit"(i64 16, i64 32) ]
+    ret {} addrspace(10)* %v
+}
+
+; Test both bundles together
+define {} addrspace(10)* @gc_alloc_both_bundles({}** %current_task) {
+; CHECK-LABEL: @gc_alloc_both_bundles
+; CHECK: %v = call noalias nonnull ptr addrspace(10) @julia.gc_alloc_bytes
+; CHECK: store atomic ptr addrspace(10) @tag
+; ptr_offsets bundle: null store at offset 8
+; CHECK: [[DERIVED1:%.*]] = addrspacecast ptr addrspace(10) %v to ptr addrspace(11)
+; CHECK: [[PTR8:%.*]] = getelementptr inbounds i8, ptr addrspace(11) [[DERIVED1]], i64 8
+; CHECK: store ptr addrspace(10) null, ptr addrspace(11) [[PTR8]], align 8
+; zeroinit bundle: memset at offset 24 for 16 bytes
+; CHECK: [[DERIVED2:%.*]] = addrspacecast ptr addrspace(10) %v to ptr addrspace(11)
+; CHECK: [[PTR24:%.*]] = getelementptr inbounds i8, ptr addrspace(11) [[DERIVED2]], i64 24
+; CHECK: call void @llvm.memset.p11.i64(ptr addrspace(11) align 8 [[PTR24]], i8 0, i64 16, i1 false)
+; CHECK: ret ptr addrspace(10) %v
+    %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, i64 48, {} addrspace(10)* @tag) [ "julia.gc_alloc_ptr_offsets"(i64 8), "julia.gc_alloc_zeroinit"(i64 24, i64 16) ]
+    ret {} addrspace(10)* %v
+}
+
+; Test that zeroing happens before any potential safepoint
+define {} addrspace(10)* @gc_alloc_zeroing_before_safepoint({}** %current_task, {} addrspace(10)* %input) {
+; CHECK-LABEL: @gc_alloc_zeroing_before_safepoint
+; CHECK: %v = call noalias nonnull ptr addrspace(10) @julia.gc_alloc_bytes
+; CHECK: store atomic ptr addrspace(10) @tag
+; CHECK: [[DERIVED:%.*]] = addrspacecast ptr addrspace(10) %v to ptr addrspace(11)
+; CHECK: [[PTR:%.*]] = getelementptr inbounds i8, ptr addrspace(11) [[DERIVED]], i64 8
+; CHECK: store ptr addrspace(10) null, ptr addrspace(11) [[PTR]], align 8
+; CHECK: call i64 @external_call
+    %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, i64 24, {} addrspace(10)* @tag) [ "julia.gc_alloc_ptr_offsets"(i64 8) ]
+    ; This call could be a safepoint - the null store must happen before it
+    %len = call i64 @external_call({} addrspace(10)* %input)
+    ret {} addrspace(10)* %v
+}
+
+; Test zero-size zeroinit region is handled (no memset emitted)
+define {} addrspace(10)* @gc_alloc_zeroinit_zero_size({}** %current_task) {
+; CHECK-LABEL: @gc_alloc_zeroinit_zero_size
+; CHECK: %v = call noalias nonnull ptr addrspace(10) @julia.gc_alloc_bytes
+; CHECK: store atomic ptr addrspace(10) @tag
+; CHECK-NOT: call void @llvm.memset
+; CHECK: ret ptr addrspace(10) %v
+    %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, i64 16, {} addrspace(10)* @tag) [ "julia.gc_alloc_zeroinit"(i64 16, i64 0) ]
+    ret {} addrspace(10)* %v
+}
+
+; Test allocation without bundles still works
+define {} addrspace(10)* @gc_alloc_no_bundles({}** %current_task) {
+; CHECK-LABEL: @gc_alloc_no_bundles
+; CHECK: %v = call noalias nonnull ptr addrspace(10) @julia.gc_alloc_bytes
+; CHECK: store atomic ptr addrspace(10) @tag
+; CHECK-NOT: store ptr addrspace(10) null
+; CHECK-NOT: call void @llvm.memset
+; CHECK: ret ptr addrspace(10) %v
+    %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, i64 24, {} addrspace(10)* @tag)
+    ret {} addrspace(10)* %v
+}

--- a/test/llvmpasses/late-lower-gc-alloc-zeroing.ll
+++ b/test/llvmpasses/late-lower-gc-alloc-zeroing.ll
@@ -52,24 +52,6 @@ define {} addrspace(10)* @gc_alloc_zeroinit({}** %current_task) {
     ret {} addrspace(10)* %v
 }
 
-; Test both bundles together
-define {} addrspace(10)* @gc_alloc_both_bundles({}** %current_task) {
-; CHECK-LABEL: @gc_alloc_both_bundles
-; CHECK: %v = call noalias nonnull ptr addrspace(10) @julia.gc_alloc_bytes
-; CHECK: store atomic ptr addrspace(10) @tag
-; ptr_offsets bundle: null store at offset 8
-; CHECK: [[DERIVED1:%.*]] = addrspacecast ptr addrspace(10) %v to ptr addrspace(11)
-; CHECK: [[PTR8:%.*]] = getelementptr inbounds i8, ptr addrspace(11) [[DERIVED1]], i64 8
-; CHECK: store ptr addrspace(10) null, ptr addrspace(11) [[PTR8]], align 8
-; zeroinit bundle: memset at offset 24 for 16 bytes
-; CHECK: [[DERIVED2:%.*]] = addrspacecast ptr addrspace(10) %v to ptr addrspace(11)
-; CHECK: [[PTR24:%.*]] = getelementptr inbounds i8, ptr addrspace(11) [[DERIVED2]], i64 24
-; CHECK: call void @llvm.memset.p11.i64(ptr addrspace(11) align 8 [[PTR24]], i8 0, i64 16, i1 false)
-; CHECK: ret ptr addrspace(10) %v
-    %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, i64 48, {} addrspace(10)* @tag) [ "julia.gc_alloc_ptr_offsets"(i64 8), "julia.gc_alloc_zeroinit"(i64 24, i64 16) ]
-    ret {} addrspace(10)* %v
-}
-
 ; Test that zeroing happens before any potential safepoint
 define {} addrspace(10)* @gc_alloc_zeroing_before_safepoint({}** %current_task, {} addrspace(10)* %input) {
 ; CHECK-LABEL: @gc_alloc_zeroing_before_safepoint


### PR DESCRIPTION
This still needs some cleanup, but after a lot of discussion and some experimentation it dawned on me that if we always initialize after late gc lowering runs then there's no need for tricks to hide this from LLVM. 
There are some caveats (that exist today so this is not a regression). Codegen currently always emits stores of GC tracked fields as release atomics, but doesn't do that for any of it's null initialization. For reasons of LLVM never touching atomics, that stops all optimizations of the null pointer stores.

This causes things like
```llvm
   %"new::RefValue" = call noalias nonnull align 8 dereferenceable(16) ptr @ijl_gc_small_alloc(ptr %ptls_load3, i32 360, i32 16, i64 140078842429264) #5, !dbg !25
   %"new::RefValue.tag_addr" = getelementptr inbounds i8, ptr %"new::RefValue", i64 -8, !dbg !25
   store atomic i64 140078842429264, ptr %"new::RefValue.tag_addr" unordered, align 8, !dbg !25, !tbaa !30
   store ptr null, ptr %"new::RefValue", align 8, !dbg !25, !tbaa !33, !alias.scope !36, !noalias !39
   store atomic ptr %"x::Array", ptr %"new::RefValue" release, align 8, !dbg !25, !tbaa !33, !alias.scope !36, !noalias !39
   ret ptr %"new::RefValue", !dbg !25
```
for something like ` @code_llvm raw=true dump_module=true Ref([])`


AI PART
Move GC pointer field zeroing from codegen to late-gc-lowering to prevent
optimization passes from sinking the null stores past safepoints. This
ensures the GC never sees uninitialized pointer values.

The implementation uses LLVM operand bundles on the gc_alloc_obj call:
- `julia.gc_alloc_ptr_offsets(i64 off1, i64 off2, ...)`: specifies byte
  offsets of GC pointer fields that need null initialization
- `julia.gc_alloc_zeroinit(i64 offset, i64 size)`: specifies a contiguous
  region to zero (for GenericMemory with boxed elements)

Late-gc-lowering processes these bundles after lowering the allocation
to gc_alloc_bytes and emits the appropriate null stores or memset calls.
Since this happens after optimization passes, the zeroing cannot be
incorrectly sunk past safepoints.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
