### PR TITLE
Add `--output-heap-snapshot` CLI option

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -51,6 +51,7 @@ struct JLOptions
     outputasm::Ptr{UInt8}
     outputji::Ptr{UInt8}
     output_code_coverage::Ptr{UInt8}
+    output_heap_snapshot::Ptr{UInt8}
     incremental::Int8
     image_file_specified::Int8
     warn_scope::Int8

--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -625,6 +625,11 @@ int gc_slot_to_arrayidx(void *obj, void *_slot) JL_NOTSAFEPOINT
         start = (char*)jl_svec_data(obj);
         len = jl_svec_len(obj);
     }
+    else if (vt->name == jl_genericmemory_typename) {
+        jl_genericmemory_t *mem = (jl_genericmemory_t*)obj;
+        start = (char*)mem->ptr;
+        len = mem->length;
+    }
     if (slot < start || slot >= start + elsize * len)
         return -1;
     return (slot - start) / elsize;

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -152,6 +152,8 @@ struct HeapSnapshot {
     StringTable edge_types;
     DenseMap<void *, size_t> node_ptr_to_index_map;
 
+    bool redact_data;
+
     size_t num_nodes = 0; // Since we stream out to files,
     size_t num_edges = 0; // we need to track the counts here.
 
@@ -173,37 +175,32 @@ struct HeapSnapshot {
     size_t _gc_finlist_root_idx = 2; // node index of the GC finlist roots node
 };
 
-// global heap snapshot, mutated by garbage collector
-// when snapshotting is on.
-int gc_heap_snapshot_enabled = 0;
-int gc_heap_snapshot_redact_data = 0;
-HeapSnapshot *g_snapshot = nullptr;
 // mutex for gc-heap-snapshot.
 jl_mutex_t heapsnapshot_lock;
 
-void final_serialize_heap_snapshot(ios_t *json, ios_t *strings, HeapSnapshot &snapshot, char all_one);
-void serialize_heap_snapshot(ios_t *stream, HeapSnapshot &snapshot, char all_one);
-static inline void _record_gc_edge(const char *edge_type,
+void final_serialize_heap_snapshot(HeapSnapshot  *snapshot);
+static inline void _record_gc_edge(HeapSnapshot *snapshot, const char *edge_type,
                                    jl_value_t *a, jl_value_t *b, size_t name_or_index) JL_NOTSAFEPOINT;
-void _record_gc_just_edge(const char *edge_type, size_t from_idx, size_t to_idx, size_t name_or_idx) JL_NOTSAFEPOINT;
+void _record_gc_just_edge(HeapSnapshot *snapshot, const char *edge_type,
+                          size_t from_idx, size_t to_idx, size_t name_or_idx) JL_NOTSAFEPOINT;
 void _add_synthetic_root_entries(HeapSnapshot *snapshot) JL_NOTSAFEPOINT;
 
 
 JL_DLLEXPORT void jl_gc_take_heap_snapshot(ios_t *nodes, ios_t *edges,
-    ios_t *strings, ios_t *json, char all_one, char redact_data)
+    ios_t *strings, ios_t *json, char redact_data)
 {
     HeapSnapshot snapshot;
     snapshot.nodes = nodes;
     snapshot.edges = edges;
     snapshot.strings = strings;
     snapshot.json = json;
+    snapshot.redact_data = redact_data;
 
     jl_mutex_lock(&heapsnapshot_lock);
 
     // Enable snapshotting
+    extern void *g_snapshot;
     g_snapshot = &snapshot;
-    gc_heap_snapshot_redact_data = redact_data;
-    gc_heap_snapshot_enabled = true;
 
     _add_synthetic_root_entries(&snapshot);
 
@@ -211,45 +208,35 @@ JL_DLLEXPORT void jl_gc_take_heap_snapshot(ios_t *nodes, ios_t *edges,
     jl_gc_collect(JL_GC_FULL);
 
     // Disable snapshotting
-    gc_heap_snapshot_enabled = false;
-    gc_heap_snapshot_redact_data = 0;
     g_snapshot = nullptr;
 
     jl_mutex_unlock(&heapsnapshot_lock);
 
     // When we return, the snapshot is full
     // Dump the snapshot
-    final_serialize_heap_snapshot((ios_t*)json, (ios_t*)strings, snapshot, all_one);
+    final_serialize_heap_snapshot(&snapshot);
 }
 
-void _gc_start_custom_heap_snapshot(ios_t *nodes, ios_t *edges,
+void *_gc_start_custom_heap_snapshot(ios_t *nodes, ios_t *edges,
     ios_t *strings, ios_t *json, char redact_data)
 {
-    jl_mutex_lock(&heapsnapshot_lock);
+    HeapSnapshot *snapshot = new HeapSnapshot;
 
-    g_snapshot = new HeapSnapshot;
-    g_snapshot->nodes = nodes;
-    g_snapshot->edges = edges;
-    g_snapshot->strings = strings;
-    g_snapshot->json = json;
+    snapshot->nodes = nodes;
+    snapshot->edges = edges;
+    snapshot->strings = strings;
+    snapshot->json = json;
+    snapshot->redact_data = redact_data;
 
-    // Enable snapshotting
-    gc_heap_snapshot_redact_data = redact_data;
-    gc_heap_snapshot_enabled = true;
+    _add_synthetic_root_entries(snapshot);
 
-    _add_synthetic_root_entries(g_snapshot);
+    return snapshot;
 }
 
-void _gc_finish_custom_heap_snapshot(char all_one)
+void _gc_finish_custom_heap_snapshot(void *ctx)
 {
-    HeapSnapshot *snapshot = g_snapshot;
-
-    gc_heap_snapshot_enabled = false;
-    gc_heap_snapshot_redact_data = 0;
-    g_snapshot = nullptr;
-    jl_mutex_unlock(&heapsnapshot_lock);
-
-    final_serialize_heap_snapshot((ios_t*)snapshot->json, (ios_t*)snapshot->strings, *snapshot, all_one);
+    HeapSnapshot *snapshot = (HeapSnapshot*)ctx;
+    final_serialize_heap_snapshot(snapshot);
     delete snapshot;
 }
 
@@ -265,7 +252,7 @@ void serialize_node(HeapSnapshot *snapshot, const Node &node) JL_NOTSAFEPOINT
     ios_write(snapshot->nodes, (char*)&node.trace_node_id, sizeof(node.trace_node_id));
     ios_write(snapshot->nodes, (char*)&node.detachedness, sizeof(node.detachedness));
 
-    g_snapshot->num_nodes += 1;
+    snapshot->num_nodes += 1;
 }
 
 void serialize_edge(HeapSnapshot *snapshot, const Edge &edge) JL_NOTSAFEPOINT
@@ -277,7 +264,7 @@ void serialize_edge(HeapSnapshot *snapshot, const Edge &edge) JL_NOTSAFEPOINT
     ios_write(snapshot->edges, (char*)&edge.from_node, sizeof(edge.from_node));
     ios_write(snapshot->edges, (char*)&edge.to_node, sizeof(edge.to_node));
 
-    g_snapshot->num_edges += 1;
+    snapshot->num_edges += 1;
 }
 
 // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L212
@@ -337,9 +324,9 @@ void _add_synthetic_root_entries(HeapSnapshot *snapshot) JL_NOTSAFEPOINT
 
 // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L597-L597
 // returns the index of the new node
-size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
+size_t record_node_to_gc_snapshot(HeapSnapshot *snapshot, jl_value_t *a) JL_NOTSAFEPOINT
 {
-    auto val = g_snapshot->node_ptr_to_index_map.insert(make_pair(a, g_snapshot->num_nodes));
+    auto val = snapshot->node_ptr_to_index_map.insert(make_pair(a, snapshot->num_nodes));
     if (!val.second) {
         return val.first->second;
     }
@@ -356,7 +343,7 @@ size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
 
     if (jl_is_string(a)) {
         node_type = "String";
-        name = gc_heap_snapshot_redact_data ? "<redacted>" : jl_string_data(a);
+        name = snapshot->redact_data ? "<redacted>" : jl_string_data(a);
         self_size = jl_string_len(a);
     }
     else if (jl_is_symbol(a)) {
@@ -420,8 +407,8 @@ size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
     }
 
     auto node = Node{
-        (uint8_t)g_snapshot->node_types.find_or_create_string_id(node_type), // size_t type;
-        g_snapshot->names.serialize(g_snapshot->strings, name), // size_t name;
+        (uint8_t)snapshot->node_types.find_or_create_string_id(node_type), // size_t type;
+        snapshot->names.serialize(snapshot->strings, name), // size_t name;
         (size_t)a,     // size_t id;
         // We add 1 to self-size for the type tag that all heap-allocated objects have.
         // Also because the Chrome Snapshot viewer ignores size-0 leaves!
@@ -429,7 +416,7 @@ size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
         0,             // size_t trace_node_id (unused)
         0,             // int detachedness;  // 0 - unknown,  1 - attached;  2 - detached
     };
-    serialize_node(g_snapshot, node);
+    serialize_node(snapshot, node);
 
     if (ios_need_close)
         ios_close(&str_);
@@ -437,22 +424,22 @@ size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
     return val.first->second;
 }
 
-static size_t record_pointer_to_gc_snapshot(void *a, size_t bytes, StringRef name) JL_NOTSAFEPOINT
+static size_t record_pointer_to_gc_snapshot(HeapSnapshot *snapshot, void *a, size_t bytes, StringRef name) JL_NOTSAFEPOINT
 {
-    auto val = g_snapshot->node_ptr_to_index_map.insert(make_pair(a, g_snapshot->num_nodes));
+    auto val = snapshot->node_ptr_to_index_map.insert(make_pair(a, snapshot->num_nodes));
     if (!val.second) {
         return val.first->second;
     }
 
     auto node = Node{
-        (uint8_t)g_snapshot->node_types.find_or_create_string_id( "object"), // size_t type;
-        g_snapshot->names.serialize(g_snapshot->strings, name), // size_t name;
+        (uint8_t)snapshot->node_types.find_or_create_string_id( "object"), // size_t type;
+        snapshot->names.serialize(snapshot->strings, name), // size_t name;
         (size_t)a,     // size_t id;
         bytes,         // size_t self_size;
         0,             // size_t trace_node_id (unused)
         0,             // int detachedness;  // 0 - unknown,  1 - attached;  2 - detached
     };
-    serialize_node(g_snapshot, node);
+    serialize_node(snapshot, node);
 
     return val.first->second;
 }
@@ -486,28 +473,31 @@ static SmallString<128> _fieldpath_for_slot(void *obj, void *slot) JL_NOTSAFEPOI
     }
 }
 
-void _gc_heap_snapshot_record_root(jl_value_t *root, char *name) JL_NOTSAFEPOINT
+void _gc_heap_snapshot_record_root(void *ctx, jl_value_t *root, char *name) JL_NOTSAFEPOINT
 {
-    size_t to_node_idx = record_node_to_gc_snapshot(root);
-    auto edge_label = g_snapshot->names.serialize(g_snapshot->strings, name);
+    HeapSnapshot *snapshot = (HeapSnapshot*)ctx;
+    size_t to_node_idx = record_node_to_gc_snapshot(snapshot, root);
+    auto edge_label = snapshot->names.serialize(snapshot->strings, name);
 
-    _record_gc_just_edge("internal", g_snapshot->internal_root_idx, to_node_idx, edge_label);
+    _record_gc_just_edge(snapshot, "internal", snapshot->internal_root_idx, to_node_idx, edge_label);
 }
 
-void _gc_heap_snapshot_record_gc_roots(jl_value_t *root, char *name) JL_NOTSAFEPOINT
+void _gc_heap_snapshot_record_gc_roots(void *ctx, jl_value_t *root, char *name) JL_NOTSAFEPOINT
 {
-    auto to_node_idx = record_node_to_gc_snapshot(root);
-    auto edge_label = g_snapshot->names.serialize(g_snapshot->strings, name);
+    HeapSnapshot *snapshot = (HeapSnapshot*)ctx;
+    auto to_node_idx = record_node_to_gc_snapshot(snapshot, root);
+    auto edge_label = snapshot->names.serialize(snapshot->strings, name);
 
-    _record_gc_just_edge("internal", g_snapshot->_gc_root_idx, to_node_idx, edge_label);
+    _record_gc_just_edge(snapshot, "internal", snapshot->_gc_root_idx, to_node_idx, edge_label);
 }
 
-void _gc_heap_snapshot_record_finlist(jl_value_t *obj, size_t index) JL_NOTSAFEPOINT
+void _gc_heap_snapshot_record_finlist(void *ctx, jl_value_t *obj, size_t index) JL_NOTSAFEPOINT
 {
-    auto to_node_idx = record_node_to_gc_snapshot(obj);
+    HeapSnapshot *snapshot = (HeapSnapshot*)ctx;
+    auto to_node_idx = record_node_to_gc_snapshot(snapshot, obj);
     SmallString<16> ss = formatv("finlist-{0}", index);
-    auto edge_label = g_snapshot->names.serialize_if_necessary(g_snapshot->strings, ss);
-    _record_gc_just_edge("internal", g_snapshot->_gc_finlist_root_idx, to_node_idx, edge_label);
+    auto edge_label = snapshot->names.serialize_if_necessary(snapshot->strings, ss);
+    _record_gc_just_edge(snapshot, "internal", snapshot->_gc_finlist_root_idx, to_node_idx, edge_label);
 }
 
 // Add a node to the heap snapshot representing a Julia stack frame.
@@ -516,7 +506,7 @@ void _gc_heap_snapshot_record_finlist(jl_value_t *obj, size_t index) JL_NOTSAFEP
 // Stack frame nodes point at the objects they have as local variables.
 size_t _record_stack_frame_node(HeapSnapshot *snapshot, void *frame) JL_NOTSAFEPOINT
 {
-    auto val = g_snapshot->node_ptr_to_index_map.insert(make_pair(frame, g_snapshot->num_nodes));
+    auto val = snapshot->node_ptr_to_index_map.insert(make_pair(frame, snapshot->num_nodes));
     if (!val.second) {
         return val.first->second;
     }
@@ -534,125 +524,138 @@ size_t _record_stack_frame_node(HeapSnapshot *snapshot, void *frame) JL_NOTSAFEP
     return val.first->second;
 }
 
-void _gc_heap_snapshot_record_frame_to_object_edge(void *from, jl_value_t *to) JL_NOTSAFEPOINT
+void _gc_heap_snapshot_record_frame_to_object_edge(void *ctx, void *from, jl_value_t *to) JL_NOTSAFEPOINT
 {
-    auto from_node_idx = _record_stack_frame_node(g_snapshot, (jl_gcframe_t*)from);
-    auto to_idx = record_node_to_gc_snapshot(to);
+    HeapSnapshot *snapshot = (HeapSnapshot*)ctx;
+    auto from_node_idx = _record_stack_frame_node(snapshot, (jl_gcframe_t*)from);
+    auto to_idx = record_node_to_gc_snapshot(snapshot, to);
 
-    auto name_idx = g_snapshot->names.serialize_if_necessary(g_snapshot->strings, "local var");
-    _record_gc_just_edge("internal", from_node_idx, to_idx, name_idx);
+    auto name_idx = snapshot->names.serialize_if_necessary(snapshot->strings, "local var");
+    _record_gc_just_edge(snapshot, "internal", from_node_idx, to_idx, name_idx);
 }
 
-void _gc_heap_snapshot_record_task_to_frame_edge(jl_task_t *from, void *to) JL_NOTSAFEPOINT
+void _gc_heap_snapshot_record_task_to_frame_edge(void *ctx, jl_task_t *from, void *to) JL_NOTSAFEPOINT
 {
-    auto from_node_idx = record_node_to_gc_snapshot((jl_value_t*)from);
-    auto to_node_idx = _record_stack_frame_node(g_snapshot, to);
+    HeapSnapshot *snapshot = (HeapSnapshot*)ctx;
+    auto from_node_idx = record_node_to_gc_snapshot(snapshot, (jl_value_t*)from);
+    auto to_node_idx = _record_stack_frame_node(snapshot, to);
 
-    auto name_idx = g_snapshot->names.serialize_if_necessary(g_snapshot->strings, "stack");
-    _record_gc_just_edge("internal", from_node_idx, to_node_idx, name_idx);
+    auto name_idx = snapshot->names.serialize_if_necessary(snapshot->strings, "stack");
+    _record_gc_just_edge(snapshot, "internal", from_node_idx, to_node_idx, name_idx);
 }
 
-void _gc_heap_snapshot_record_frame_to_frame_edge(jl_gcframe_t *from, jl_gcframe_t *to) JL_NOTSAFEPOINT
+void _gc_heap_snapshot_record_frame_to_frame_edge(void *ctx, jl_gcframe_t *from, jl_gcframe_t *to) JL_NOTSAFEPOINT
 {
-    auto from_node_idx = _record_stack_frame_node(g_snapshot, from);
-    auto to_node_idx = _record_stack_frame_node(g_snapshot, to);
+    HeapSnapshot *snapshot = (HeapSnapshot*)ctx;
+    auto from_node_idx = _record_stack_frame_node(snapshot, from);
+    auto to_node_idx = _record_stack_frame_node(snapshot, to);
 
-    auto name_idx = g_snapshot->names.serialize_if_necessary(g_snapshot->strings, "next frame");
-    _record_gc_just_edge("internal", from_node_idx, to_node_idx, name_idx);
+    auto name_idx = snapshot->names.serialize_if_necessary(snapshot->strings, "next frame");
+    _record_gc_just_edge(snapshot, "internal", from_node_idx, to_node_idx, name_idx);
 }
 
-void _gc_heap_snapshot_record_array_edge(jl_value_t *from, jl_value_t *to, size_t index) JL_NOTSAFEPOINT
+void _gc_heap_snapshot_record_array_edge(void *ctx, jl_value_t *from, jl_value_t *to, size_t index) JL_NOTSAFEPOINT
 {
-    _record_gc_edge("element", from, to, index);
+    HeapSnapshot *snapshot = (HeapSnapshot*)ctx;
+    _record_gc_edge(snapshot, "element", from, to, index);
 }
 
-void _gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, void *slot) JL_NOTSAFEPOINT
+void _gc_heap_snapshot_record_object_edge(void *ctx, jl_value_t *from, jl_value_t *to, void *slot) JL_NOTSAFEPOINT
 {
     SmallString<128> path = _fieldpath_for_slot(from, slot);
-    _record_gc_edge("property", from, to,
-                    g_snapshot->names.serialize_if_necessary(g_snapshot->strings, path));
+    HeapSnapshot *snapshot = (HeapSnapshot*)ctx;
+    _record_gc_edge(snapshot, "property", from, to,
+                    snapshot->names.serialize_if_necessary(snapshot->strings, path));
 }
 
-void _gc_heap_snapshot_record_property_edge(jl_value_t *from, jl_value_t *to, const char *path) JL_NOTSAFEPOINT
+void _gc_heap_snapshot_record_property_edge(void *ctx, jl_value_t *from, jl_value_t *to, const char *path) JL_NOTSAFEPOINT
 {
-    _record_gc_edge("property", from, to,
-                    g_snapshot->names.serialize_if_necessary(g_snapshot->strings, path));
+    HeapSnapshot *snapshot = (HeapSnapshot*)ctx;
+    _record_gc_edge(snapshot, "property", from, to,
+                    snapshot->names.serialize_if_necessary(snapshot->strings, path));
 }
 
-void _gc_heap_snapshot_record_module_to_binding(jl_module_t *module, jl_value_t *bindings, jl_value_t *bindingkeyset) JL_NOTSAFEPOINT
+void _gc_heap_snapshot_record_module_to_binding(void *ctx, jl_module_t *module, jl_value_t *bindings, jl_value_t *bindingkeyset) JL_NOTSAFEPOINT
 {
-    auto from_node_idx = record_node_to_gc_snapshot((jl_value_t*)module);
-    auto to_bindings_idx = record_node_to_gc_snapshot(bindings);
-    auto to_bindingkeyset_idx = record_node_to_gc_snapshot(bindingkeyset);
+    HeapSnapshot *snapshot = (HeapSnapshot*)ctx;
+    auto from_node_idx = record_node_to_gc_snapshot(snapshot, (jl_value_t*)module);
+    auto to_bindings_idx = record_node_to_gc_snapshot(snapshot, bindings);
+    auto to_bindingkeyset_idx = record_node_to_gc_snapshot(snapshot, bindingkeyset);
 
     if (to_bindings_idx > 0) {
-        _record_gc_just_edge("internal", from_node_idx, to_bindings_idx, g_snapshot->names.serialize_if_necessary(g_snapshot->strings, "bindings"));
+        _record_gc_just_edge(snapshot, "internal", from_node_idx, to_bindings_idx,
+                             snapshot->names.serialize_if_necessary(snapshot->strings, "bindings"));
     }
     if (to_bindingkeyset_idx > 0) {
-        _record_gc_just_edge("internal", from_node_idx, to_bindingkeyset_idx, g_snapshot->names.serialize_if_necessary(g_snapshot->strings, "bindingkeyset"));
+        _record_gc_just_edge(snapshot, "internal", from_node_idx, to_bindingkeyset_idx,
+                             snapshot->names.serialize_if_necessary(snapshot->strings, "bindingkeyset"));
     }
  }
 
-void _gc_heap_snapshot_record_internal_array_edge(jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT
+void _gc_heap_snapshot_record_internal_array_edge(void *ctx, jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT
 {
-    _record_gc_edge("internal", from, to,
-                    g_snapshot->names.serialize_if_necessary(g_snapshot->strings, "<internal>"));
+    HeapSnapshot *snapshot = (HeapSnapshot*)ctx;
+    _record_gc_edge(snapshot, "internal", from, to,
+                    snapshot->names.serialize_if_necessary(snapshot->strings, "<internal>"));
 }
 
-void _gc_heap_snapshot_record_binding_partition_edge(jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT
+void _gc_heap_snapshot_record_binding_partition_edge(void *ctx, jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT
 {
-    _record_gc_edge("binding", from, to,
-                    g_snapshot->names.serialize_if_necessary(g_snapshot->strings, "<binding>"));
+    HeapSnapshot *snapshot = (HeapSnapshot*)ctx;
+    _record_gc_edge(snapshot, "binding", from, to,
+                    snapshot->names.serialize_if_necessary(snapshot->strings, "<binding>"));
 }
 
 
-void _gc_heap_snapshot_record_foreign_memory_edge(jl_value_t *from, void* to, size_t bytes) JL_NOTSAFEPOINT
+void _gc_heap_snapshot_record_foreign_memory_edge(void *ctx, jl_value_t *from, void* to, size_t bytes) JL_NOTSAFEPOINT
 {
-    size_t name_or_idx = g_snapshot->names.serialize_if_necessary(g_snapshot->strings, "<native>");
+    HeapSnapshot *snapshot = (HeapSnapshot*)ctx;
+    size_t name_or_idx = snapshot->names.serialize_if_necessary(snapshot->strings, "<native>");
 
-    auto from_node_idx = record_node_to_gc_snapshot(from);
+    auto from_node_idx = record_node_to_gc_snapshot(snapshot, from);
     const char *alloc_kind = "<foreign memory - malloc>";
-    auto to_node_idx = record_pointer_to_gc_snapshot(to, bytes, alloc_kind);
+    auto to_node_idx = record_pointer_to_gc_snapshot(snapshot, to, bytes, alloc_kind);
 
-    _record_gc_just_edge("hidden", from_node_idx, to_node_idx, name_or_idx);
+    _record_gc_just_edge(snapshot, "hidden", from_node_idx, to_node_idx, name_or_idx);
 }
 
-static inline void _record_gc_edge(const char *edge_type, jl_value_t *a,
+static inline void _record_gc_edge(HeapSnapshot *snapshot, const char *edge_type, jl_value_t *a,
                                   jl_value_t *b, size_t name_or_idx) JL_NOTSAFEPOINT
 {
-    auto from_node_idx = record_node_to_gc_snapshot(a);
-    auto to_node_idx = record_node_to_gc_snapshot(b);
+    auto from_node_idx = record_node_to_gc_snapshot(snapshot, a);
+    auto to_node_idx = record_node_to_gc_snapshot(snapshot, b);
 
-    _record_gc_just_edge(edge_type, from_node_idx, to_node_idx, name_or_idx);
+    _record_gc_just_edge(snapshot, edge_type, from_node_idx, to_node_idx, name_or_idx);
 }
 
-void _record_gc_just_edge(const char *edge_type, size_t from_idx, size_t to_idx, size_t name_or_idx) JL_NOTSAFEPOINT
+void _record_gc_just_edge(HeapSnapshot *snapshot, const char *edge_type, size_t from_idx, size_t to_idx, size_t name_or_idx) JL_NOTSAFEPOINT
 {
     auto edge = Edge{
-        (uint8_t)g_snapshot->edge_types.find_or_create_string_id(edge_type),
+        (uint8_t)snapshot->edge_types.find_or_create_string_id(edge_type),
         name_or_idx, // edge label
         from_idx, // from
         to_idx // to
     };
 
-    serialize_edge(g_snapshot, edge);
+    serialize_edge(snapshot, edge);
 }
 
-void final_serialize_heap_snapshot(ios_t *json, ios_t *strings, HeapSnapshot &snapshot, char all_one)
+void final_serialize_heap_snapshot(HeapSnapshot *snapshot)
 {
     // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L2567-L2567
     // also https://github.com/microsoft/vscode-v8-heap-tools/blob/c5b34396392397925ecbb4ecb904a27a2754f2c1/v8-heap-parser/src/decoder.rs#L43-L51
+    ios_t *json = snapshot->json;
     ios_printf(json, "{\"snapshot\":{\n");
 
     ios_printf(json, "  \"meta\":{\n");
     ios_printf(json, "    \"node_fields\":[\"type\",\"name\",\"id\",\"self_size\",\"edge_count\",\"trace_node_id\",\"detachedness\"],\n");
     ios_printf(json, "    \"node_types\":[");
-    snapshot.node_types.print_json_array(json, false);
+    snapshot->node_types.print_json_array(json, false);
     ios_printf(json, ",");
     ios_printf(json, "\"string\", \"number\", \"number\", \"number\", \"number\", \"number\"],\n");
     ios_printf(json, "    \"edge_fields\":[\"type\",\"name_or_index\",\"to_node\"],\n");
     ios_printf(json, "    \"edge_types\":[");
-    snapshot.edge_types.print_json_array(json, false);
+    snapshot->edge_types.print_json_array(json, false);
     ios_printf(json, ",");
     ios_printf(json, "\"string_or_number\",\"from_node\"],\n");
     // not used. Required by microsoft/vscode-v8-heap-tools
@@ -663,8 +666,8 @@ void final_serialize_heap_snapshot(ios_t *json, ios_t *strings, HeapSnapshot &sn
     // end not used
     ios_printf(json, "  },\n"); // end "meta"
 
-    ios_printf(json, "  \"node_count\":%zu,\n", snapshot.num_nodes);
-    ios_printf(json, "  \"edge_count\":%zu,\n", snapshot.num_edges);
+    ios_printf(json, "  \"node_count\":%zu,\n", snapshot->num_nodes);
+    ios_printf(json, "  \"edge_count\":%zu,\n", snapshot->num_edges);
     ios_printf(json, "  \"trace_function_count\":0\n"); // not used. Required by microsoft/vscode-v8-heap-tools
     ios_printf(json, "}\n"); // end "snapshot"
 

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -27,7 +27,7 @@ void _gc_heap_snapshot_record_module_to_binding(jl_module_t* module, jl_value_t 
 void _gc_heap_snapshot_record_internal_array_edge(jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT;
 // Used for objects manually allocated in C (outside julia GC), to still tell the heap snapshot about the
 // size of the object, even though we're never going to mark that object.
-void _gc_heap_snapshot_record_hidden_edge(jl_value_t *from, void* to, size_t bytes, uint16_t alloc_type) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_foreign_memory_edge(jl_value_t *from, void* to, size_t bytes) JL_NOTSAFEPOINT;
 // Used for objects that are reachable from the GC roots
 void _gc_heap_snapshot_record_gc_roots(jl_value_t *root, char *name) JL_NOTSAFEPOINT;
 // Used for objects that are reachable from the finalizer list
@@ -106,10 +106,10 @@ static inline void gc_heap_snapshot_record_binding_partition_edge(jl_value_t *fr
     }
 }
 
-static inline void gc_heap_snapshot_record_hidden_edge(jl_value_t *from, void* to, size_t bytes, uint16_t alloc_type) JL_NOTSAFEPOINT
+static inline void gc_heap_snapshot_record_foreign_memory_edge(jl_value_t *from, void* to, size_t bytes) JL_NOTSAFEPOINT
 {
     if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
-        _gc_heap_snapshot_record_hidden_edge(from, to, bytes, alloc_type);
+        _gc_heap_snapshot_record_foreign_memory_edge(from, to, bytes);
     }
 }
 

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -14,30 +14,30 @@ extern "C" {
 // ---------------------------------------------------------------------
 // Functions to call from GC when heap snapshot is enabled
 // ---------------------------------------------------------------------
-void _gc_heap_snapshot_record_root(jl_value_t *root, char *name) JL_NOTSAFEPOINT;
-void _gc_heap_snapshot_record_frame_to_object_edge(void *from, jl_value_t *to) JL_NOTSAFEPOINT;
-void _gc_heap_snapshot_record_task_to_frame_edge(jl_task_t *from, void *to) JL_NOTSAFEPOINT;
-void _gc_heap_snapshot_record_frame_to_frame_edge(jl_gcframe_t *from, jl_gcframe_t *to) JL_NOTSAFEPOINT;
-void _gc_heap_snapshot_record_array_edge(jl_value_t *from, jl_value_t *to, size_t index) JL_NOTSAFEPOINT;
-void _gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, void* slot) JL_NOTSAFEPOINT;
-void _gc_heap_snapshot_record_property_edge(jl_value_t *from, jl_value_t *to, const char *property) JL_NOTSAFEPOINT;
-void _gc_heap_snapshot_record_module_to_binding(jl_module_t* module, jl_value_t *bindings, jl_value_t *bindingkeyset) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_root(void *snapshot, jl_value_t *root, char *name) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_frame_to_object_edge(void *snapshot, void *from, jl_value_t *to) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_task_to_frame_edge(void *snapshot, jl_task_t *from, void *to) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_frame_to_frame_edge(void *snapshot, jl_gcframe_t *from, jl_gcframe_t *to) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_array_edge(void *snapshot, jl_value_t *from, jl_value_t *to, size_t index) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_object_edge(void *snapshot, jl_value_t *from, jl_value_t *to, void* slot) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_property_edge(void *snapshot, jl_value_t *from, jl_value_t *to, const char *property) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_module_to_binding(void *snapshot, jl_module_t* module, jl_value_t *bindings, jl_value_t *bindingkeyset) JL_NOTSAFEPOINT;
 // Used for objects managed by GC, but which aren't exposed in the julia object, so have no
 // field or index.  i.e. they're not reachable from julia code, but we _will_ hit them in
 // the GC mark phase (so we can check their type tag to get the size).
-void _gc_heap_snapshot_record_internal_array_edge(jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_internal_array_edge(void *snapshot, jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT;
 // Used for objects manually allocated in C (outside julia GC), to still tell the heap snapshot about the
 // size of the object, even though we're never going to mark that object.
-void _gc_heap_snapshot_record_foreign_memory_edge(jl_value_t *from, void* to, size_t bytes) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_foreign_memory_edge(void *snapshot, jl_value_t *from, void* to, size_t bytes) JL_NOTSAFEPOINT;
 // Used for objects that are reachable from the GC roots
-void _gc_heap_snapshot_record_gc_roots(jl_value_t *root, char *name) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_gc_roots(void *snapshot, jl_value_t *root, char *name) JL_NOTSAFEPOINT;
 // Used for objects that are reachable from the finalizer list
-void _gc_heap_snapshot_record_finlist(jl_value_t *finlist, size_t index) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_finlist(void *snapshot, jl_value_t *finlist, size_t index) JL_NOTSAFEPOINT;
 // Used for objects reachable from the binding partition pointer union
-void _gc_heap_snapshot_record_binding_partition_edge(jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT;
-void _gc_start_custom_heap_snapshot(ios_t *nodes, ios_t *edges,
+void _gc_heap_snapshot_record_binding_partition_edge(void *snapshot, jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT;
+void *_gc_start_custom_heap_snapshot(ios_t *nodes, ios_t *edges,
     ios_t *strings, ios_t *json, char redact_data);
-void _gc_finish_custom_heap_snapshot(char all_one);
+void _gc_finish_custom_heap_snapshot(void *snapshot);
 
 extern int gc_heap_snapshot_enabled;
 extern int prev_sweep_full;
@@ -46,94 +46,94 @@ extern jl_mutex_t heapsnapshot_lock;
 int gc_slot_to_fieldidx(void *_obj, void *slot, jl_datatype_t *vt) JL_NOTSAFEPOINT;
 int gc_slot_to_arrayidx(void *_obj, void *begin) JL_NOTSAFEPOINT;
 
-static inline void gc_heap_snapshot_record_frame_to_object_edge(void *from, jl_value_t *to) JL_NOTSAFEPOINT
+static inline void gc_heap_snapshot_record_frame_to_object_edge(void *snapshot, void *from, jl_value_t *to) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
-        _gc_heap_snapshot_record_frame_to_object_edge(from, to);
+    if (__unlikely(snapshot)) {
+        _gc_heap_snapshot_record_frame_to_object_edge(snapshot, from, to);
     }
 }
-static inline void gc_heap_snapshot_record_task_to_frame_edge(jl_task_t *from, void *to) JL_NOTSAFEPOINT
+static inline void gc_heap_snapshot_record_task_to_frame_edge(void *snapshot, jl_task_t *from, void *to) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
-        _gc_heap_snapshot_record_task_to_frame_edge(from, to);
+    if (__unlikely(snapshot)) {
+        _gc_heap_snapshot_record_task_to_frame_edge(snapshot, from, to);
     }
 }
-static inline void gc_heap_snapshot_record_frame_to_frame_edge(jl_gcframe_t *from, jl_gcframe_t *to) JL_NOTSAFEPOINT
+static inline void gc_heap_snapshot_record_frame_to_frame_edge(void *snapshot, jl_gcframe_t *from, jl_gcframe_t *to) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
-        _gc_heap_snapshot_record_frame_to_frame_edge(from, to);
+    if (__unlikely(snapshot)) {
+        _gc_heap_snapshot_record_frame_to_frame_edge(snapshot, from, to);
     }
 }
-static inline void gc_heap_snapshot_record_root(jl_value_t *root, char *name) JL_NOTSAFEPOINT
+static inline void gc_heap_snapshot_record_root(void *snapshot, jl_value_t *root, char *name) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
-        _gc_heap_snapshot_record_root(root, name);
+    if (__unlikely(snapshot)) {
+        _gc_heap_snapshot_record_root(snapshot, root, name);
     }
 }
-static inline void gc_heap_snapshot_record_array_edge_index(jl_value_t *from, jl_value_t *to, size_t index) JL_NOTSAFEPOINT
+static inline void gc_heap_snapshot_record_array_edge_index(void *snapshot, jl_value_t *from, jl_value_t *to, size_t index) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full && from != NULL && to != NULL)) {
-        _gc_heap_snapshot_record_array_edge(from, to, index);
+    if (__unlikely(snapshot && from != NULL && to != NULL)) {
+        _gc_heap_snapshot_record_array_edge(snapshot, from, to, index);
     }
 }
-static inline void gc_heap_snapshot_record_array_edge(jl_value_t *from, jl_value_t **to) JL_NOTSAFEPOINT
+static inline void gc_heap_snapshot_record_array_edge(void *snapshot, jl_value_t *from, jl_value_t **to) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
-        _gc_heap_snapshot_record_array_edge(from, *to, gc_slot_to_arrayidx(from, to));
+    if (__unlikely(snapshot)) {
+        _gc_heap_snapshot_record_array_edge(snapshot, from, *to, gc_slot_to_arrayidx(from, to));
     }
 }
-static inline void gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t **to) JL_NOTSAFEPOINT
+static inline void gc_heap_snapshot_record_object_edge(void *snapshot, jl_value_t *from, jl_value_t **to) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
-        _gc_heap_snapshot_record_object_edge(from, *to, to);
+    if (__unlikely(snapshot)) {
+        _gc_heap_snapshot_record_object_edge(snapshot, from, *to, to);
     }
 }
-static inline void gc_heap_snapshot_record_property_edge(jl_value_t *from, jl_value_t *to, const char *property) JL_NOTSAFEPOINT
+static inline void gc_heap_snapshot_record_property_edge(void *snapshot, jl_value_t *from, jl_value_t *to, const char *property) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
-        _gc_heap_snapshot_record_property_edge(from, to, property);
-    }
-}
-
-static inline void gc_heap_snapshot_record_module_to_binding(jl_module_t* module, jl_value_t *bindings, jl_value_t *bindingkeyset) JL_NOTSAFEPOINT
-{
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full) && bindings != NULL && bindingkeyset != NULL) {
-        _gc_heap_snapshot_record_module_to_binding(module, bindings, bindingkeyset);
+    if (__unlikely(snapshot)) {
+        _gc_heap_snapshot_record_property_edge(snapshot, from, to, property);
     }
 }
 
-static inline void gc_heap_snapshot_record_internal_array_edge(jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT
+static inline void gc_heap_snapshot_record_module_to_binding(void *snapshot, jl_module_t* module, jl_value_t *bindings, jl_value_t *bindingkeyset) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
-        _gc_heap_snapshot_record_internal_array_edge(from, to);
+    if (__unlikely(snapshot && bindings != NULL && bindingkeyset != NULL)) {
+        _gc_heap_snapshot_record_module_to_binding(snapshot, module, bindings, bindingkeyset);
     }
 }
 
-static inline void gc_heap_snapshot_record_binding_partition_edge(jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT
+static inline void gc_heap_snapshot_record_internal_array_edge(void *snapshot, jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
-        _gc_heap_snapshot_record_binding_partition_edge(from, to);
+    if (__unlikely(snapshot)) {
+        _gc_heap_snapshot_record_internal_array_edge(snapshot, from, to);
     }
 }
 
-static inline void gc_heap_snapshot_record_foreign_memory_edge(jl_value_t *from, void* to, size_t bytes) JL_NOTSAFEPOINT
+static inline void gc_heap_snapshot_record_binding_partition_edge(void *snapshot, jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
-        _gc_heap_snapshot_record_foreign_memory_edge(from, to, bytes);
+    if (__unlikely(snapshot)) {
+        _gc_heap_snapshot_record_binding_partition_edge(snapshot, from, to);
     }
 }
 
-static inline void gc_heap_snapshot_record_gc_roots(jl_value_t *root, char *name) JL_NOTSAFEPOINT
+static inline void gc_heap_snapshot_record_foreign_memory_edge(void *snapshot, jl_value_t *from, void* to, size_t bytes) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full && root != NULL)) {
-        _gc_heap_snapshot_record_gc_roots(root, name);
+    if (__unlikely(snapshot)) {
+        _gc_heap_snapshot_record_foreign_memory_edge(snapshot, from, to, bytes);
     }
 }
 
-static inline void gc_heap_snapshot_record_finlist(jl_value_t *finlist, size_t index) JL_NOTSAFEPOINT
+static inline void gc_heap_snapshot_record_gc_roots(void *snapshot, jl_value_t *root, char *name) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full && finlist != NULL)) {
-        _gc_heap_snapshot_record_finlist(finlist, index);
+    if (__unlikely(snapshot && root != NULL)) {
+        _gc_heap_snapshot_record_gc_roots(snapshot, root, name);
+    }
+}
+
+static inline void gc_heap_snapshot_record_finlist(void *snapshot, jl_value_t *finlist, size_t index) JL_NOTSAFEPOINT
+{
+    if (__unlikely(snapshot && finlist != NULL)) {
+        _gc_heap_snapshot_record_finlist(snapshot, finlist, index);
     }
 }
 
@@ -141,7 +141,7 @@ static inline void gc_heap_snapshot_record_finlist(jl_value_t *finlist, size_t i
 // Functions to call from Julia to take heap snapshot
 // ---------------------------------------------------------------------
 JL_DLLEXPORT void jl_gc_take_heap_snapshot(ios_t *nodes, ios_t *edges,
-    ios_t *strings, ios_t *json, char all_one, char redact_data);
+    ios_t *strings, ios_t *json, char redact_data);
 
 
 #ifdef __cplusplus

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -20,6 +20,7 @@ void _gc_heap_snapshot_record_task_to_frame_edge(jl_task_t *from, void *to) JL_N
 void _gc_heap_snapshot_record_frame_to_frame_edge(jl_gcframe_t *from, jl_gcframe_t *to) JL_NOTSAFEPOINT;
 void _gc_heap_snapshot_record_array_edge(jl_value_t *from, jl_value_t *to, size_t index) JL_NOTSAFEPOINT;
 void _gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, void* slot) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_property_edge(jl_value_t *from, jl_value_t *to, const char *property) JL_NOTSAFEPOINT;
 void _gc_heap_snapshot_record_module_to_binding(jl_module_t* module, jl_value_t *bindings, jl_value_t *bindingkeyset) JL_NOTSAFEPOINT;
 // Used for objects managed by GC, but which aren't exposed in the julia object, so have no
 // field or index.  i.e. they're not reachable from julia code, but we _will_ hit them in
@@ -34,6 +35,9 @@ void _gc_heap_snapshot_record_gc_roots(jl_value_t *root, char *name) JL_NOTSAFEP
 void _gc_heap_snapshot_record_finlist(jl_value_t *finlist, size_t index) JL_NOTSAFEPOINT;
 // Used for objects reachable from the binding partition pointer union
 void _gc_heap_snapshot_record_binding_partition_edge(jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT;
+void _gc_start_custom_heap_snapshot(ios_t *nodes, ios_t *edges,
+    ios_t *strings, ios_t *json, char redact_data);
+void _gc_finish_custom_heap_snapshot(char all_one);
 
 extern int gc_heap_snapshot_enabled;
 extern int prev_sweep_full;
@@ -82,6 +86,12 @@ static inline void gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_valu
 {
     if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
         _gc_heap_snapshot_record_object_edge(from, *to, to);
+    }
+}
+static inline void gc_heap_snapshot_record_property_edge(jl_value_t *from, jl_value_t *to, const char *property) JL_NOTSAFEPOINT
+{
+    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
+        _gc_heap_snapshot_record_property_edge(from, to, property);
     }
 }
 

--- a/src/gc-mmtk.c
+++ b/src/gc-mmtk.c
@@ -590,7 +590,8 @@ JL_DLLEXPORT void jl_gc_scan_julia_exc_obj(void* obj_raw, void* closure, Process
 static void jl_gc_free_memory(jl_genericmemory_t *m, int isaligned) JL_NOTSAFEPOINT
 {
     assert(jl_is_genericmemory(m));
-    assert(jl_genericmemory_how(m) == 1 || jl_genericmemory_how(m) == 2);
+    assert(jl_genericmemory_how(m) == JL_GENERICMEMORY_GCMANAGED ||
+           jl_genericmemory_how(m) == JL_GENERICMEMORY_MALLOCD);
     char *d = (char*)m->ptr;
     size_t freed_bytes = memory_block_usable_size(d, isaligned);
     assert(freed_bytes != 0);
@@ -644,7 +645,7 @@ JL_DLLEXPORT void jl_gc_update_inlined_array(void* from, void* to) {
         jl_genericmemory_t *b = (jl_genericmemory_t*)jl_to;
         int how = jl_genericmemory_how(a);
 
-        if (how == 0 && mmtk_object_is_managed_by_mmtk(a->ptr)) { // a is inlined (a->ptr points into the mmtk object)
+        if (how == JL_GENERICMEMORY_INLINED && mmtk_object_is_managed_by_mmtk(a->ptr)) { // a is inlined (a->ptr points into the mmtk object)
             size_t offset_of_data = ((size_t)a->ptr - (size_t)a);
             if (offset_of_data > 0) {
                 b->ptr = (void*)((size_t) b + offset_of_data);
@@ -776,13 +777,13 @@ JL_DLLEXPORT size_t jl_gc_genericmemory_how(void *arg) JL_NOTSAFEPOINT
 {
     jl_genericmemory_t* m = (jl_genericmemory_t*)arg;
     if (m->ptr == (void*)((char*)m + 16)) // JL_SMALL_BYTE_ALIGNMENT (from julia_internal.h)
-        return 0;
+        return JL_GENERICMEMORY_INLINED;
     jl_value_t *owner = jl_genericmemory_data_owner_field(m);
     if (owner == (jl_value_t*)m)
-        return 1;
+        return JL_GENERICMEMORY_GCMANAGED;
     if (owner == NULL)
-        return 2;
-    return 3;
+        return JL_GENERICMEMORY_MALLOCD;
+    return JL_GENERICMEMORY_STRINGOWNED;
 }
 
 // ========================================================================= //

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -636,7 +636,7 @@ void jl_gc_reset_alloc_count(void) JL_NOTSAFEPOINT
 static void jl_gc_free_memory(jl_genericmemory_t *m, int isaligned) JL_NOTSAFEPOINT
 {
     assert(jl_is_genericmemory(m));
-    assert(jl_genericmemory_how(m) == 1);
+    assert(jl_genericmemory_how(m) == JL_GENERICMEMORY_GCMANAGED);
     char *d = (char*)m->ptr;
     size_t freed_bytes = memory_block_usable_size(d, isaligned);
     assert(freed_bytes != 0);
@@ -2398,13 +2398,13 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
                     gc_setmark_big(ptls, o, bits);
             }
             int how = jl_genericmemory_how(m);
-            if (how == 0 || how == 2) {
-                gc_heap_snapshot_record_hidden_edge(new_obj, m->ptr, jl_genericmemory_nbytes(m), how == 0 ? 2 : 0);
+            if (how == JL_GENERICMEMORY_MALLOCD) {
+                gc_heap_snapshot_record_foreign_memory_edge(
+                    new_obj, m->ptr, jl_genericmemory_nbytes(m));
             }
-            else if (how == 1) {
+            else if (how == JL_GENERICMEMORY_GCMANAGED) {
                 if (update_meta || foreign_alloc) {
                     size_t nb = jl_genericmemory_nbytes(m);
-                    gc_heap_snapshot_record_hidden_edge(new_obj, m->ptr, nb, 0);
                     if (bits == GC_OLD_MARKED) {
                         ptls->gc_tls.gc_cache.perm_scanned_bytes += nb;
                     }
@@ -2413,7 +2413,7 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
                     }
                 }
             }
-            else if (how == 3) {
+            else if (how == JL_GENERICMEMORY_STRINGOWNED) {
                 jl_value_t *owner = jl_genericmemory_data_owner_field(m);
                 uintptr_t nptr = (1 << 2) | (bits & GC_OLD);
                 gc_try_claim_and_push(mq, owner, &nptr);

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -17,6 +17,9 @@ extern "C" {
 // System-wide heap statistics
 gc_heapstatus_t gc_heap_stats = {0};
 
+// Currently active heap snapshot
+void *g_snapshot = NULL; // TODO: handle prev_sweep_full condition
+
 // Memory upper bound on 32-bit systems
 const uint64_t max_mem_32bit_systems = 1536 * 1024 * 1024; // 1.5 GiB
 // Julia's GC heuristics will try to keep the heap size below the `max_total_memory` soft limit,
@@ -1734,7 +1737,7 @@ STATIC_INLINE jl_value_t *gc_mark_obj8(jl_ptls_t ptls, char *obj8_parent, uint8_
                 nptr |= !gc_old(o->header);
                 if (!gc_try_setmark_tag(o, GC_MARKED)) new_obj = NULL;
             }
-            gc_heap_snapshot_record_object_edge((jl_value_t*)obj8_parent, slot);
+            gc_heap_snapshot_record_object_edge(g_snapshot, (jl_value_t*)obj8_parent, slot);
         }
     }
     gc_mark_push_remset(ptls, (jl_value_t *)obj8_parent, nptr);
@@ -1766,7 +1769,7 @@ STATIC_INLINE jl_value_t *gc_mark_obj16(jl_ptls_t ptls, char *obj16_parent, uint
                 nptr |= !gc_old(o->header);
                 if (!gc_try_setmark_tag(o, GC_MARKED)) new_obj = NULL;
             }
-            gc_heap_snapshot_record_object_edge((jl_value_t*)obj16_parent, slot);
+            gc_heap_snapshot_record_object_edge(g_snapshot, (jl_value_t*)obj16_parent, slot);
         }
     }
     gc_mark_push_remset(ptls, (jl_value_t *)obj16_parent, nptr);
@@ -1798,7 +1801,7 @@ STATIC_INLINE jl_value_t *gc_mark_obj32(jl_ptls_t ptls, char *obj32_parent, uint
                 nptr |= !gc_old(o->header);
                 if (!gc_try_setmark_tag(o, GC_MARKED)) new_obj = NULL;
             }
-            gc_heap_snapshot_record_object_edge((jl_value_t*)obj32_parent, slot);
+            gc_heap_snapshot_record_object_edge(g_snapshot, (jl_value_t*)obj32_parent, slot);
         }
     }
     gc_mark_push_remset(ptls, (jl_value_t *)obj32_parent, nptr);
@@ -1829,7 +1832,7 @@ STATIC_INLINE void gc_mark_objarray(jl_ptls_t ptls, jl_value_t *obj_parent, jl_v
                     nptr |= 1;
                 if (!gc_marked(o->header))
                     break;
-                gc_heap_snapshot_record_array_edge(obj_parent, slot);
+                gc_heap_snapshot_record_array_edge(g_snapshot, obj_parent, slot);
             }
         }
     }
@@ -1858,7 +1861,7 @@ STATIC_INLINE void gc_mark_objarray(jl_ptls_t ptls, jl_value_t *obj_parent, jl_v
                         gc_slot_to_arrayidx(obj_parent, obj_begin));
             gc_assert_parent_validity(obj_parent, new_obj);
             gc_try_claim_and_push(mq, new_obj, &nptr);
-            gc_heap_snapshot_record_array_edge(obj_parent, slot);
+            gc_heap_snapshot_record_array_edge(g_snapshot, obj_parent, slot);
         }
     }
     if (too_big) {
@@ -1901,7 +1904,7 @@ STATIC_INLINE void gc_mark_memory8(jl_ptls_t ptls, jl_value_t *ary8_parent, jl_v
                         early_end = 1;
                         break;
                     }
-                    gc_heap_snapshot_record_array_edge(ary8_parent, slot);
+                    gc_heap_snapshot_record_array_edge(g_snapshot, ary8_parent, slot);
                 }
             }
             if (early_end)
@@ -1934,7 +1937,7 @@ STATIC_INLINE void gc_mark_memory8(jl_ptls_t ptls, jl_value_t *ary8_parent, jl_v
                                gc_slot_to_arrayidx(ary8_parent, ary8_begin));
                 gc_assert_parent_validity(ary8_parent, new_obj);
                 gc_try_claim_and_push(mq, new_obj, &nptr);
-                gc_heap_snapshot_record_array_edge(ary8_parent, slot);
+                gc_heap_snapshot_record_array_edge(g_snapshot, ary8_parent, slot);
             }
         }
     }
@@ -1978,7 +1981,7 @@ STATIC_INLINE void gc_mark_memory16(jl_ptls_t ptls, jl_value_t *ary16_parent, jl
                         early_end = 1;
                         break;
                     }
-                    gc_heap_snapshot_record_array_edge(ary16_parent, slot);
+                    gc_heap_snapshot_record_array_edge(g_snapshot, ary16_parent, slot);
                 }
             }
             if (early_end)
@@ -2011,7 +2014,7 @@ STATIC_INLINE void gc_mark_memory16(jl_ptls_t ptls, jl_value_t *ary16_parent, jl
                                gc_slot_to_arrayidx(ary16_parent, ary16_begin));
                 gc_assert_parent_validity(ary16_parent, new_obj);
                 gc_try_claim_and_push(mq, new_obj, &nptr);
-                gc_heap_snapshot_record_array_edge(ary16_parent, slot);
+                gc_heap_snapshot_record_array_edge(g_snapshot, ary16_parent, slot);
             }
         }
     }
@@ -2058,12 +2061,12 @@ STATIC_INLINE void gc_mark_stack(jl_ptls_t ptls, jl_gcframe_t *s, uint32_t nroot
                     continue;
             }
             gc_try_claim_and_push(mq, new_obj, NULL);
-            gc_heap_snapshot_record_frame_to_object_edge(s, new_obj);
+            gc_heap_snapshot_record_frame_to_object_edge(g_snapshot, s, new_obj);
         }
         jl_gcframe_t *sprev = (jl_gcframe_t *)gc_read_stack(&s->prev, offset, lb, ub);
         if (sprev == NULL)
             break;
-        gc_heap_snapshot_record_frame_to_frame_edge(s, sprev);
+        gc_heap_snapshot_record_frame_to_frame_edge(g_snapshot, s, sprev);
         s = sprev;
         uintptr_t new_nroots = gc_read_stack(&s->nroots, offset, lb, ub);
         assert(new_nroots <= UINT32_MAX);
@@ -2091,14 +2094,14 @@ STATIC_INLINE void gc_mark_excstack(jl_ptls_t ptls, jl_excstack_t *excstack, siz
             for (size_t jlval_index = 0; jlval_index < njlvals; jlval_index++) {
                 new_obj = jl_bt_entry_jlvalue(bt_entry, jlval_index);
                 gc_try_claim_and_push(mq, new_obj, NULL);
-                gc_heap_snapshot_record_frame_to_object_edge(bt_entry, new_obj);
+                gc_heap_snapshot_record_frame_to_object_edge(g_snapshot, bt_entry, new_obj);
             }
         }
         // The exception comes last - mark it
         new_obj = jl_excstack_exception(excstack, itr);
         itr = jl_excstack_next(excstack, itr);
         gc_try_claim_and_push(mq, new_obj, NULL);
-        gc_heap_snapshot_record_frame_to_object_edge(excstack, new_obj);
+        gc_heap_snapshot_record_frame_to_object_edge(g_snapshot, excstack, new_obj);
     }
 }
 
@@ -2113,15 +2116,15 @@ STATIC_INLINE void gc_mark_module_binding(jl_ptls_t ptls, jl_module_t *mb_parent
     jl_value_t *bindingkeyset = (jl_value_t *)jl_atomic_load_relaxed(&mb_parent->bindingkeyset);
     gc_assert_parent_validity((jl_value_t *)mb_parent, bindingkeyset);
     gc_try_claim_and_push(mq, bindingkeyset, &nptr);
-    gc_heap_snapshot_record_module_to_binding(mb_parent, bindings, bindingkeyset);
+    gc_heap_snapshot_record_module_to_binding(g_snapshot, mb_parent, bindings, bindingkeyset);
     gc_assert_parent_validity((jl_value_t *)mb_parent, (jl_value_t *)mb_parent->parent);
     gc_try_claim_and_push(mq, (jl_value_t *)mb_parent->parent, &nptr);
     gc_assert_parent_validity((jl_value_t *)mb_parent, (jl_value_t *)mb_parent->usings_backedges);
     gc_try_claim_and_push(mq, (jl_value_t *)mb_parent->usings_backedges, &nptr);
-    gc_heap_snapshot_record_binding_partition_edge((jl_value_t*)mb_parent, mb_parent->usings_backedges);
+    gc_heap_snapshot_record_binding_partition_edge(g_snapshot, (jl_value_t*)mb_parent, mb_parent->usings_backedges);
     gc_assert_parent_validity((jl_value_t *)mb_parent, (jl_value_t *)mb_parent->scanned_methods);
     gc_try_claim_and_push(mq, (jl_value_t *)mb_parent->scanned_methods, &nptr);
-    gc_heap_snapshot_record_binding_partition_edge((jl_value_t*)mb_parent, mb_parent->scanned_methods);
+    gc_heap_snapshot_record_binding_partition_edge(g_snapshot, (jl_value_t*)mb_parent, mb_parent->scanned_methods);
     size_t nusings = module_usings_length(mb_parent);
     if (nusings > 0) {
         // this is only necessary because bindings for "using" modules
@@ -2165,11 +2168,11 @@ void gc_mark_finlist_(jl_gc_markqueue_t *mq, jl_value_t *fl_parent, jl_value_t *
             continue;
         gc_try_claim_and_push(mq, new_obj, NULL);
         if (fl_parent != NULL) {
-            gc_heap_snapshot_record_array_edge(fl_parent, slot);
+            gc_heap_snapshot_record_array_edge(g_snapshot, fl_parent, slot);
         } else {
             // This is a list of objects following the same format as a finlist
             // if `fl_parent` is NULL
-            gc_heap_snapshot_record_finlist(new_obj, ++i);
+            gc_heap_snapshot_record_finlist(g_snapshot, new_obj, ++i);
         }
     }
 }
@@ -2339,13 +2342,13 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
         #endif
                 if (s != NULL) {
                     nroots = gc_read_stack(&s->nroots, offset, lb, ub);
-                    gc_heap_snapshot_record_task_to_frame_edge(ta, s);
+                    gc_heap_snapshot_record_task_to_frame_edge(g_snapshot, ta, s);
                     assert(nroots <= UINT32_MAX);
                     gc_mark_stack(ptls, s, (uint32_t)nroots, offset, lb, ub);
                 }
                 if (ta->excstack) {
                     jl_excstack_t *excstack = ta->excstack;
-                    gc_heap_snapshot_record_task_to_frame_edge(ta, excstack);
+                    gc_heap_snapshot_record_task_to_frame_edge(g_snapshot, ta, excstack);
                     size_t itr = ta->excstack->top;
                     gc_setmark_buf_(ptls, excstack, bits,
                                     sizeof(jl_excstack_t) +
@@ -2399,7 +2402,7 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
             }
             int how = jl_genericmemory_how(m);
             if (how == JL_GENERICMEMORY_MALLOCD) {
-                gc_heap_snapshot_record_foreign_memory_edge(
+                gc_heap_snapshot_record_foreign_memory_edge(g_snapshot,
                     new_obj, m->ptr, jl_genericmemory_nbytes(m));
             }
             else if (how == JL_GENERICMEMORY_GCMANAGED) {
@@ -2417,7 +2420,7 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
                 jl_value_t *owner = jl_genericmemory_data_owner_field(m);
                 uintptr_t nptr = (1 << 2) | (bits & GC_OLD);
                 gc_try_claim_and_push(mq, owner, &nptr);
-                gc_heap_snapshot_record_internal_array_edge(new_obj, owner);
+                gc_heap_snapshot_record_internal_array_edge(g_snapshot, new_obj, owner);
                 gc_mark_push_remset(ptls, new_obj, nptr);
                 return;
             }
@@ -2765,26 +2768,26 @@ static void gc_queue_thread_local(jl_gc_markqueue_t *mq, jl_ptls_t ptls2) JL_NOT
     task = ptls2->root_task;
     if (task != NULL) {
         gc_try_claim_and_push(mq, task, NULL);
-        gc_heap_snapshot_record_root((jl_value_t*)task, "root task");
+        gc_heap_snapshot_record_root(g_snapshot, (jl_value_t*)task, "root task");
     }
     task = jl_atomic_load_relaxed(&ptls2->current_task);
     if (task != NULL) {
         gc_try_claim_and_push(mq, task, NULL);
-        gc_heap_snapshot_record_root((jl_value_t*)task, "current task");
+        gc_heap_snapshot_record_root(g_snapshot, (jl_value_t*)task, "current task");
     }
     task = ptls2->next_task;
     if (task != NULL) {
         gc_try_claim_and_push(mq, task, NULL);
-        gc_heap_snapshot_record_root((jl_value_t*)task, "next task");
+        gc_heap_snapshot_record_root(g_snapshot, (jl_value_t*)task, "next task");
     }
     task = ptls2->previous_task;
     if (task != NULL) {
         gc_try_claim_and_push(mq, task, NULL);
-        gc_heap_snapshot_record_root((jl_value_t*)task, "previous task");
+        gc_heap_snapshot_record_root(g_snapshot, (jl_value_t*)task, "previous task");
     }
     if (ptls2->previous_exception) {
         gc_try_claim_and_push(mq, ptls2->previous_exception, NULL);
-        gc_heap_snapshot_record_root((jl_value_t*)ptls2->previous_exception, "previous exception");
+        gc_heap_snapshot_record_root(g_snapshot, (jl_value_t*)ptls2->previous_exception, "previous exception");
     }
 }
 
@@ -2836,40 +2839,40 @@ static void gc_mark_roots(jl_gc_markqueue_t *mq) JL_NOTSAFEPOINT
 {
     // modules
     gc_try_claim_and_push(mq, jl_main_module, NULL);
-    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_main_module, "main_module");
+    gc_heap_snapshot_record_gc_roots(g_snapshot, (jl_value_t*)jl_main_module, "main_module");
     // invisible builtin values
     gc_try_claim_and_push(mq, jl_method_table, NULL);
-    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_method_table, "global_method_table");
+    gc_heap_snapshot_record_gc_roots(g_snapshot, (jl_value_t*)jl_method_table, "global_method_table");
     gc_try_claim_and_push(mq, jl_an_empty_vec_any, NULL);
-    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_an_empty_vec_any, "an_empty_vec_any");
+    gc_heap_snapshot_record_gc_roots(g_snapshot, (jl_value_t*)jl_an_empty_vec_any, "an_empty_vec_any");
     gc_try_claim_and_push(mq, jl_module_init_order, NULL);
-    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_module_init_order, "module_init_order");
+    gc_heap_snapshot_record_gc_roots(g_snapshot, (jl_value_t*)jl_module_init_order, "module_init_order");
     for (size_t i = 0; i < jl_current_modules.size; i += 2) {
         if (jl_current_modules.table[i + 1] != HT_NOTFOUND) {
             gc_try_claim_and_push(mq, jl_current_modules.table[i], NULL);
-            gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_current_modules.table[i], "top level module");
+            gc_heap_snapshot_record_gc_roots(g_snapshot, (jl_value_t*)jl_current_modules.table[i], "top level module");
         }
     }
     gc_try_claim_and_push(mq, jl_anytuple_type_type, NULL);
-    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_anytuple_type_type, "anytuple_type_type");
+    gc_heap_snapshot_record_gc_roots(g_snapshot, (jl_value_t*)jl_anytuple_type_type, "anytuple_type_type");
     for (size_t i = 0; i < N_CALL_CACHE; i++) {
         jl_typemap_entry_t *v = jl_atomic_load_relaxed(&call_cache[i]);
         gc_try_claim_and_push(mq, v, NULL);
-        gc_heap_snapshot_record_array_edge_index((jl_value_t*)jl_anytuple_type_type, (jl_value_t*)v, i);
+        gc_heap_snapshot_record_array_edge_index(g_snapshot, (jl_value_t*)jl_anytuple_type_type, (jl_value_t*)v, i);
     }
     gc_try_claim_and_push(mq, _jl_debug_method_invalidation, NULL);
-    gc_heap_snapshot_record_gc_roots((jl_value_t*)_jl_debug_method_invalidation, "debug_method_invalidation");
+    gc_heap_snapshot_record_gc_roots(g_snapshot, (jl_value_t*)_jl_debug_method_invalidation, "debug_method_invalidation");
     // constants
     gc_try_claim_and_push(mq, jl_emptytuple_type, NULL);
-    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_emptytuple_type, "emptytuple_type");
+    gc_heap_snapshot_record_gc_roots(g_snapshot, (jl_value_t*)jl_emptytuple_type, "emptytuple_type");
     gc_try_claim_and_push(mq, cmpswap_names, NULL);
-    gc_heap_snapshot_record_gc_roots((jl_value_t*)cmpswap_names, "cmpswap_names");
+    gc_heap_snapshot_record_gc_roots(g_snapshot, (jl_value_t*)cmpswap_names, "cmpswap_names");
     gc_try_claim_and_push(mq, jl_global_roots_list, NULL);
-    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_global_roots_list, "global_roots_list");
+    gc_heap_snapshot_record_gc_roots(g_snapshot, (jl_value_t*)jl_global_roots_list, "global_roots_list");
     gc_try_claim_and_push(mq, jl_global_roots_keyset, NULL);
-    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_global_roots_keyset, "global_roots_keyset");
+    gc_heap_snapshot_record_gc_roots(g_snapshot, (jl_value_t*)jl_global_roots_keyset, "global_roots_keyset");
     gc_try_claim_and_push(mq, precompile_field_replace, NULL);
-    gc_heap_snapshot_record_gc_roots((jl_value_t*)precompile_field_replace, "precompile_field_replace");
+    gc_heap_snapshot_record_gc_roots(g_snapshot, (jl_value_t*)precompile_field_replace, "precompile_field_replace");
 }
 
 // find unmarked objects that need to be finalized from the finalizer list "list".
@@ -3055,7 +3058,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
     {
         JL_TIMING(GC, GC_Mark);
         assert(gc_n_threads != 0);
-        int single_threaded_mark = (jl_n_markthreads == 0 || gc_heap_snapshot_enabled);
+        int single_threaded_mark = (jl_n_markthreads == 0 || g_snapshot);
         for (int t_i = 0; t_i < gc_n_threads; t_i++) {
             jl_ptls_t ptls2 = gc_all_tls_states[t_i];
             jl_ptls_t ptls_dest = ptls;

--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -197,9 +197,9 @@ JL_DLLEXPORT jl_value_t *jl_genericmemory_to_string(jl_genericmemory_t *m, size_
     }
     int how = jl_genericmemory_how(m);
     size_t mlength = m->length;
-    if (how != 0) {
+    if (how != JL_GENERICMEMORY_INLINED) {
         jl_value_t *o = jl_genericmemory_data_owner_field(m);
-        if (how == 3 && // implies jl_is_string(o)
+        if (how == JL_GENERICMEMORY_STRINGOWNED && // implies jl_is_string(o)
              ((mlength + sizeof(void*) + 1 <= GC_MAX_SZCLASS) == (len + sizeof(void*) + 1 <= GC_MAX_SZCLASS))) {
             if (jl_string_data(o)[len] != '\0')
                 jl_string_data(o)[len] = '\0';
@@ -212,7 +212,7 @@ JL_DLLEXPORT jl_value_t *jl_genericmemory_to_string(jl_genericmemory_t *m, size_
         JL_GC_POP();
         return str;
     }
-    // n.b. how == 0 is always pool-allocated, so the freed bytes are computed from the pool not the object
+    // n.b. how == JL_GENERICMEMORY_INLINED is always pool-allocated, so the freed bytes are computed from the pool not the object
     return jl_pchar_to_string((const char*)m->ptr, len);
 }
 

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -144,6 +144,7 @@ JL_DLLEXPORT void jl_init_options(void)
                         NULL, // output-asm
                         NULL, // output-ji
                         NULL, // output-code_coverage
+                        NULL, // output-heap-snapshot
                         0, // incremental
                         0, // image_file_specified
                         JL_OPTIONS_WARN_SCOPE_ON,  // ambiguous scope warning
@@ -401,6 +402,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_output_o,
            opt_output_asm,
            opt_output_ji,
+           opt_output_heap_snapshot,
            opt_use_precompiled,
            opt_use_compilecache,
            opt_incremental,
@@ -470,6 +472,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "output-o",        required_argument, 0, opt_output_o },
         { "output-asm",      required_argument, 0, opt_output_asm },
         { "output-ji",       required_argument, 0, opt_output_ji },
+        { "output-heap-snapshot",required_argument, 0, opt_output_heap_snapshot },
         { "output-incremental",required_argument, 0, opt_incremental },
         { "depwarn",         required_argument, 0, opt_depwarn },
         { "warn-overwrite",  required_argument, 0, opt_warn_overwrite },
@@ -905,6 +908,9 @@ restart_switch:
         case opt_output_ji:
             jl_options.outputji = optarg;
             if (!jl_options.image_file_specified) jl_options.image_file = NULL;
+            break;
+        case opt_output_heap_snapshot:
+            jl_options.output_heap_snapshot = optarg;
             break;
         case opt_incremental:
             if (!strcmp(optarg,"yes"))

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -55,6 +55,7 @@ typedef struct {
     const char *outputasm;
     const char *outputji;
     const char *output_code_coverage;
+    const char *output_heap_snapshot;
     int8_t incremental;
     int8_t image_file_specified;
     int8_t warn_scope;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1254,16 +1254,21 @@ STATIC_INLINE jl_value_t *jl_genericmemory_owner(jl_genericmemory_t *m JL_PROPAG
   2 = malloc-allocated pointer (does not own it)
   3 = has a pointer to the String object that owns the data pointer (m must be isbits)
 */
+#define JL_GENERICMEMORY_INLINED     0
+#define JL_GENERICMEMORY_GCMANAGED   1
+#define JL_GENERICMEMORY_MALLOCD     2
+#define JL_GENERICMEMORY_STRINGOWNED 3
+
 STATIC_INLINE int jl_genericmemory_how(jl_genericmemory_t *m) JL_NOTSAFEPOINT
 {
     if (m->ptr == (void*)((char*)m + 16)) // JL_SMALL_BYTE_ALIGNMENT (from julia_internal.h)
-        return 0;
+        return JL_GENERICMEMORY_INLINED;
     jl_value_t *owner = jl_genericmemory_data_owner_field(m);
     if (owner == (jl_value_t*)m)
-        return 1;
+        return JL_GENERICMEMORY_GCMANAGED;
     if (owner == NULL)
-        return 2;
-    return 3;
+        return JL_GENERICMEMORY_MALLOCD;
+    return JL_GENERICMEMORY_STRINGOWNED;
 }
 
 STATIC_INLINE jl_value_t *jl_genericmemory_owner(jl_genericmemory_t *m JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -862,7 +862,7 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
     else if (jl_is_genericmemory(v)) {
         jl_genericmemory_t *m = (jl_genericmemory_t*)v;
         const char *data = (const char*)m->ptr;
-        if (jl_genericmemory_how(m) == 3) {
+        if (jl_genericmemory_how(m) == JL_GENERICMEMORY_STRINGOWNED) {
             assert(jl_is_string(jl_genericmemory_data_owner_field(m)));
         }
         else if (layout->flags.arrayelem_isboxed) {
@@ -1450,7 +1450,7 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
             jl_genericmemory_t *m = (jl_genericmemory_t*)v;
             const jl_datatype_layout_t *layout = t->layout;
             size_t len = m->length;
-            // if (jl_genericmemory_how(m) == 3) {
+            // if (jl_genericmemory_how(m) == JL_GENERICMEMORY_STRINGOWNED) {
             //     jl_value_t *owner = jl_genericmemory_data_owner_field(m);
             //     write_uint(f, len);
             //     write_pointerfield(s, owner);
@@ -1510,7 +1510,7 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
                     if (len == 0) { // TODO: should we have a zero-page, instead of writing each type's fragment separately?
                         write_padding(s->const_data, layout->size ? layout->size : isbitsunion);
                     }
-                    else if (jl_genericmemory_how(m) == 3) {
+                    else if (jl_genericmemory_how(m) == JL_GENERICMEMORY_STRINGOWNED) {
                         assert(jl_is_string(jl_genericmemory_data_owner_field(m)));
                         write_padding(s->const_data, 1);
                     }

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -74,6 +74,7 @@ External links:
 
 #include <zstd.h>
 
+#include "gc-heap-snapshot.h"
 #include "julia.h"
 #include "julia_internal.h"
 #include "julia_gcext.h"
@@ -353,6 +354,7 @@ typedef struct {
     jl_query_cache *query_cache;
     jl_ptls_t ptls;
     jl_image_t *image;
+    int8_t heap_snapshot;
     int8_t incremental;
 } jl_serializer_state;
 
@@ -595,8 +597,23 @@ static void jl_queue_module_for_serialization(jl_serializer_state *s, jl_module_
         jl_queue_for_serialization(s, jl_atomic_load_relaxed(&m->bindings));
     }
 
+    if (s->heap_snapshot) {
+        gc_heap_snapshot_record_property_edge((jl_value_t*)m, (jl_value_t*)m->name, "name");
+        gc_heap_snapshot_record_property_edge((jl_value_t*)m, (jl_value_t*)m->parent, "parent");
+        gc_heap_snapshot_record_property_edge((jl_value_t*)m,
+            (jl_value_t*)jl_atomic_load_relaxed(&m->bindings), "bindings");
+        gc_heap_snapshot_record_property_edge((jl_value_t*)m,
+            (jl_value_t*)jl_atomic_load_relaxed(&m->bindingkeyset), "bindingkeyset");
+        if (!jl_options.strip_metadata)
+            gc_heap_snapshot_record_property_edge((jl_value_t*)m, (jl_value_t*)m->file, "file");
+    }
+
     for (size_t i = 0; i < module_usings_length(m); i++) {
-        jl_queue_for_serialization(s, module_usings_getmod(m, i));
+        struct _jl_module_using *data = module_usings_getidx(m, i);
+        jl_queue_for_serialization(s, data->mod);
+        if (s->heap_snapshot) {
+            gc_heap_snapshot_record_array_edge((jl_value_t *)m, (jl_value_t **)&data->mod);
+        }
     }
 
     if (jl_options.trim || jl_options.strip_ir) {
@@ -606,6 +623,10 @@ static void jl_queue_module_for_serialization(jl_serializer_state *s, jl_module_
     else {
         jl_queue_for_serialization(s, m->usings_backedges);
         jl_queue_for_serialization(s, m->scanned_methods);
+        if (s->heap_snapshot) {
+            gc_heap_snapshot_record_binding_partition_edge((jl_value_t*)m, m->usings_backedges);
+            gc_heap_snapshot_record_binding_partition_edge((jl_value_t*)m, m->scanned_methods);
+        }
     }
 }
 
@@ -632,6 +653,10 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
     jl_queue_for_serialization_(s, (jl_value_t*)t, 1, immediate);
     const jl_datatype_layout_t *layout = t->layout;
 
+    if (s->heap_snapshot && jl_needs_serialization(s, (jl_value_t*)t)) {
+        gc_heap_snapshot_record_property_edge(v, (jl_value_t*)t, "typeof(...)");
+    }
+
     if (!recursive)
         goto done_fields;
 
@@ -656,6 +681,11 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
                 jl_queue_for_serialization(s, mi->def.value);
                 jl_queue_for_serialization(s, mi->specTypes);
                 jl_queue_for_serialization(s, (jl_value_t*)mi->sparam_vals);
+                if (s->heap_snapshot) {
+                    gc_heap_snapshot_record_object_edge((jl_value_t*)mi, &mi->def.value);
+                    gc_heap_snapshot_record_object_edge((jl_value_t*)mi, &mi->specTypes);
+                    gc_heap_snapshot_record_object_edge((jl_value_t*)mi, (jl_value_t**)&mi->sparam_vals);
+                }
                 goto done_fields;
             }
             else if (jl_is_method(def) && jl_object_in_image(def)) {
@@ -697,6 +727,10 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
         if (s->incremental && needs_uniquing(v, s->query_cache)) {
             jl_queue_for_serialization(s, b->globalref->mod);
             jl_queue_for_serialization(s, b->globalref->name);
+            if (s->heap_snapshot) {
+                gc_heap_snapshot_record_property_edge((jl_value_t*)b, (jl_value_t*)b->globalref->mod, "module");
+                gc_heap_snapshot_record_property_edge((jl_value_t*)b, (jl_value_t*)b->globalref->name, "name");
+            }
             goto done_fields;
         }
         if (jl_options.trim || jl_options.strip_ir) {
@@ -851,25 +885,41 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
         size_t i, l = jl_svec_len(v);
         jl_value_t **data = jl_svec_data(v);
         for (i = 0; i < l; i++) {
-            jl_queue_for_serialization_(s, data[i], 1, immediate);
+            jl_value_t **item = &data[i];
+            jl_queue_for_serialization_(s, *item, 1, immediate);
+            if (s->heap_snapshot && jl_needs_serialization(s, *item)) {
+                gc_heap_snapshot_record_array_edge(v, item);
+            }
         }
     }
     else if (jl_is_array(v)) {
         jl_array_t *ar = (jl_array_t*)v;
-        jl_value_t *mem = get_replaceable_field((jl_value_t**)&ar->ref.mem, 1);
+        jl_value_t **mem_ptr = (jl_value_t**)&ar->ref.mem;
+        jl_value_t *mem = get_replaceable_field(mem_ptr, 1);
         jl_queue_for_serialization_(s, mem, 1, immediate);
+        if (s->heap_snapshot && jl_needs_serialization(s, mem)) {
+            _gc_heap_snapshot_record_object_edge(v, mem, (void*)mem_ptr);
+        }
     }
     else if (jl_is_genericmemory(v)) {
         jl_genericmemory_t *m = (jl_genericmemory_t*)v;
         const char *data = (const char*)m->ptr;
         if (jl_genericmemory_how(m) == JL_GENERICMEMORY_STRINGOWNED) {
-            assert(jl_is_string(jl_genericmemory_data_owner_field(m)));
+            jl_value_t *owner = jl_genericmemory_data_owner_field(m);
+            assert(jl_is_string(owner));
+            if (s->heap_snapshot && jl_needs_serialization(s, owner)) {
+                gc_heap_snapshot_record_internal_array_edge(v, owner);
+            }
         }
         else if (layout->flags.arrayelem_isboxed) {
             size_t i, l = m->length;
             for (i = 0; i < l; i++) {
-                jl_value_t *fld = get_replaceable_field(&((jl_value_t**)data)[i], 1);
+                jl_value_t **fld_ptr = &((jl_value_t**)data)[i];
+                jl_value_t *fld = get_replaceable_field(fld_ptr, 1);
                 jl_queue_for_serialization_(s, fld, 1, immediate);
+                if (s->heap_snapshot && fld && jl_needs_serialization(s, fld)) {
+                    _gc_heap_snapshot_record_array_edge(v, fld, i);
+                }
             }
         }
         else if (layout->first_ptr >= 0) {
@@ -878,9 +928,12 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
             size_t j, np = layout->npointers;
             for (i = 0; i < l; i++) {
                 for (j = 0; j < np; j++) {
-                    uint32_t ptr = jl_ptr_offset(t, j);
-                    jl_value_t *fld = get_replaceable_field(&((jl_value_t**)data)[ptr], 1);
+                    jl_value_t **fld_ptr = &((jl_value_t**)data)[jl_ptr_offset(t, j)];
+                    jl_value_t *fld = get_replaceable_field(fld_ptr, 1);
                     jl_queue_for_serialization_(s, fld, 1, immediate);
+                    if (s->heap_snapshot && fld && jl_needs_serialization(s, fld)) {
+                        _gc_heap_snapshot_record_array_edge(v, fld, i);
+                    }
                 }
                 data += elsz;
             }
@@ -929,8 +982,12 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
             while (offset >= (fldidx == layout->nfields ? jl_datatype_size(t) : jl_field_offset(t, fldidx)))
                 fldidx++;
             int mutabl = !jl_field_isconst(t, fldidx - 1);
-            jl_value_t *fld = get_replaceable_field(&((jl_value_t**)data)[ptr], mutabl);
+            jl_value_t **fld_ptr = &((jl_value_t**)data)[ptr];
+            jl_value_t *fld = get_replaceable_field(fld_ptr, mutabl);
             jl_queue_for_serialization_(s, fld, 1, immediate);
+            if (s->heap_snapshot && fld && jl_needs_serialization(s, fld)) {
+                _gc_heap_snapshot_record_object_edge(v, fld, (void *)fld_ptr);
+            }
         }
     }
 
@@ -954,6 +1011,9 @@ done_fields: ;
             // if super is already on the stack of things to handle when this returns, do
             // not try to handle it now
             jl_queue_for_serialization_(s, (jl_value_t*)dt->super, 1, immediate);
+            if (s->heap_snapshot) {
+                _gc_heap_snapshot_record_object_edge(v, (jl_value_t*)dt->super, (void *)&dt->super);
+            }
         }
         immediate = 0;
         char *data = (char*)jl_data_ptr(v);
@@ -963,8 +1023,12 @@ done_fields: ;
             if (ptr * sizeof(jl_value_t*) == offsetof(jl_datatype_t, super))
                 continue; // skip the super field, since it might not be quite validly ordered
             int mutabl = 1;
-            jl_value_t *fld = get_replaceable_field(&((jl_value_t**)data)[ptr], mutabl);
+            jl_value_t **fld_ptr = &((jl_value_t**)data)[ptr];
+            jl_value_t *fld = get_replaceable_field(fld_ptr, mutabl);
             jl_queue_for_serialization_(s, fld, 1, immediate);
+            if (s->heap_snapshot && fld && jl_needs_serialization(s, fld)) {
+                _gc_heap_snapshot_record_object_edge(v, fld, (void *)fld_ptr);
+            }
         }
     }
 }
@@ -1319,8 +1383,12 @@ static void record_memoryrefs_inside(jl_serializer_state *s, jl_datatype_t *t, s
 
 static void record_gvars(jl_serializer_state *s, arraylist_t *globals) JL_GC_DISABLED
 {
-    for (size_t i = 0; i < globals->len; i++)
+    for (size_t i = 0; i < globals->len; i++) {
         jl_queue_for_serialization(s, globals->items[i]);
+        if (s->heap_snapshot) {
+            gc_heap_snapshot_record_root((jl_value_t*)globals->items[i], "gvar");
+        }
+    }
 }
 
 static void record_external_fns(jl_serializer_state *s, arraylist_t *external_fns) JL_NOTSAFEPOINT
@@ -2979,6 +3047,7 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
     arraylist_new(&object_worklist, 0);
     arraylist_new(&serialization_queue, 0);
     ios_t sysimg, const_data, symbols, relocs, gvar_record, fptr_record;
+    ios_t snapshot_nodes, snapshot_edges, snapshot_strings, snapshot_json;
     ios_mem(&sysimg, 0);
     ios_mem(&const_data, 0);
     ios_mem(&symbols, 0);
@@ -2995,6 +3064,40 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
     s.gvar_record = &gvar_record;
     s.fptr_record = &fptr_record;
     s.ptls = jl_current_task->ptls;
+    if (jl_options.output_heap_snapshot != NULL) {
+        char buf[JL_PATH_MAX];
+        snprintf(buf, sizeof(buf), "%s.nodes", jl_options.output_heap_snapshot);
+        if (ios_file(&snapshot_nodes, buf, /*rd*/0, /*wr*/1, /*create*/1, /*trunc*/1) == NULL) {
+            jl_printf(JL_STDERR, "ERROR: could not open file \"%s\" for writing\n", buf);
+            jl_exit(1);
+        }
+        snprintf(buf, sizeof(buf), "%s.edges", jl_options.output_heap_snapshot);
+        if (ios_file(&snapshot_edges, buf, /*rd*/0, /*wr*/1, /*create*/1, /*trunc*/1) == NULL) {
+            jl_printf(JL_STDERR, "ERROR: could not open file \"%s\" for writing\n", buf);
+            jl_exit(1);
+        }
+        snprintf(buf, sizeof(buf), "%s.strings", jl_options.output_heap_snapshot);
+        if (ios_file(&snapshot_strings, buf, /*rd*/0, /*wr*/1, /*create*/1, /*trunc*/1) == NULL) {
+            jl_printf(JL_STDERR, "ERROR: could not open file \"%s\" for writing\n", buf);
+            jl_exit(1);
+        }
+        snprintf(buf, sizeof(buf), "%s.metadata.json", jl_options.output_heap_snapshot);
+        if (ios_file(&snapshot_json, buf, /*rd*/0, /*wr*/1, /*create*/1, /*trunc*/1) == NULL) {
+            jl_printf(JL_STDERR, "ERROR: could not open file \"%s\" for writing\n", buf);
+            jl_exit(1);
+        }
+        // FIXME: adapt GC heap snapshot interface to make this unnecessary
+        extern int prev_sweep_full;
+        prev_sweep_full = 1;
+        _gc_start_custom_heap_snapshot(
+            &snapshot_nodes,
+            &snapshot_edges,
+            &snapshot_strings,
+            &snapshot_json,
+            /* redact_data */ 0
+        );
+        s.heap_snapshot = 1;
+    }
     arraylist_new(&s.memowner_list, 0);
     arraylist_new(&s.memref_list, 0);
     arraylist_new(&s.relocs_list, 0);
@@ -3044,21 +3147,41 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
             for (i = 0; tags[i] != NULL; i++) {
                 jl_value_t *tag = *tags[i];
                 jl_queue_for_serialization(&s, tag);
+                if (s.heap_snapshot) {
+                    gc_heap_snapshot_record_root(tag, "tag");
+                }
             }
-            for (i = 0; i < jl_n_builtins; i++)
+            for (i = 0; i < jl_n_builtins; i++) {
                 jl_queue_for_serialization(&s, jl_builtin_instances[i]);
-#define XX(name, type) jl_queue_for_serialization(&s, (jl_value_t*)jl_##name);
+                if (s.heap_snapshot) {
+                    gc_heap_snapshot_record_root(jl_builtin_instances[i], "builtin");
+                }
+            }
+#define XX(name, type) jl_queue_for_serialization(&s, (jl_value_t*)jl_##name); \
+                       if (s.heap_snapshot) { \
+                           gc_heap_snapshot_record_root((jl_value_t*)jl_##name, "exported"); \
+                       }
             JL_EXPORTED_DATA_POINTERS(XX)
 #undef XX
-#define XX(name, type) jl_queue_for_serialization(&s, (jl_value_t*)jl_##name);
+#define XX(name, type) jl_queue_for_serialization(&s, (jl_value_t*)jl_##name); \
+                       if (s.heap_snapshot) { \
+                           gc_heap_snapshot_record_root((jl_value_t*)jl_##name, "const_global"); \
+                       }
             JL_CONST_GLOBAL_VARS(XX)
 #undef XX
             jl_queue_for_serialization(&s, s.ptls->root_task->tls);
+            if (s.heap_snapshot) {
+                gc_heap_snapshot_record_root(s.ptls->root_task->tls, "root_task_tls");
+            }
         }
         else {
             // Queue the worklist itself as the first item we serialize
             jl_queue_for_serialization(&s, worklist);
             jl_queue_for_serialization(&s, module_init_order);
+            if (s.heap_snapshot) {
+                gc_heap_snapshot_record_root((jl_value_t*)worklist, "worklist");
+                gc_heap_snapshot_record_root((jl_value_t*)module_init_order, "module_init_order");
+            }
         }
         // step 1.1: as needed, serialize the data needed for insertion into the running system
         if (extext_methods) {
@@ -3066,6 +3189,10 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
             jl_queue_for_serialization(&s, extext_methods);
             // Queue the new specializations
             jl_queue_for_serialization(&s, new_ext_cis);
+            if (s.heap_snapshot) {
+                gc_heap_snapshot_record_root((jl_value_t*)extext_methods, "extext_methods");
+                gc_heap_snapshot_record_root((jl_value_t*)new_ext_cis, "new_ext_cis");
+            }
         }
         jl_serialize_reachable(&s);
         // step 1.2: ensure all gvars are part of the sysimage too
@@ -3080,6 +3207,9 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
         if (s.incremental) {
             // Queue the new roots array
             jl_queue_for_serialization(&s, s.method_roots_list);
+            if (s.heap_snapshot) {
+                gc_heap_snapshot_record_gc_roots((jl_value_t*)s.method_roots_list, "method_roots_list");
+            }
             jl_serialize_reachable(&s);
         }
         // step 1.4: prune (garbage collect) special weak references from the jl_global_roots_list
@@ -3096,6 +3226,10 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
             }
             jl_queue_for_serialization(&s, global_roots_list);
             jl_queue_for_serialization(&s, global_roots_keyset);
+            if (s.heap_snapshot) {
+                gc_heap_snapshot_record_gc_roots((jl_value_t*)global_roots_list, "global_roots_list");
+                gc_heap_snapshot_record_gc_roots((jl_value_t*)global_roots_keyset, "global_roots_keyset");
+            }
             jl_serialize_reachable(&s);
         }
         // step 1.5: prune (garbage collect) some special weak references known caches
@@ -3268,6 +3402,16 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
         write_uint32(f, jl_array_len(s.link_ids_external_fnvars));
         ios_write(f, (char*)jl_array_data(s.link_ids_external_fnvars, uint32_t), jl_array_len(s.link_ids_external_fnvars) * sizeof(uint32_t));
         write_uint32(f, external_fns_begin);
+    }
+
+    if (jl_options.output_heap_snapshot != NULL) {
+        _gc_finish_custom_heap_snapshot(
+            /* all_one */ 0
+        );
+        ios_close(&snapshot_nodes);
+        ios_close(&snapshot_edges);
+        ios_close(&snapshot_strings);
+        ios_close(&snapshot_json);
     }
 
     assert(object_worklist.len == 0);

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1438,9 +1438,9 @@ function _stream_heap_snapshot(prefix::AbstractString, all_one::Bool, redact_dat
                     Base.@_lock_ios(json,
                         ccall(:jl_gc_take_heap_snapshot,
                             Cvoid,
-                            (Ptr{Cvoid},Ptr{Cvoid},Ptr{Cvoid},Ptr{Cvoid}, Cchar, Cchar),
+                            (Ptr{Cvoid},Ptr{Cvoid},Ptr{Cvoid},Ptr{Cvoid}, Cchar),
                             nodes.handle, edges.handle, strings.handle, json.handle,
-                            Cchar(all_one), Cchar(redact_data))
+                            Cchar(redact_data))
                     )
                     )
                     )

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 import Libdl
+import Profile
 
 # helper function for passing input to stdin
 # and returning the stdout result
@@ -1477,6 +1478,15 @@ end
             Base.Linking.link_image(joinpath(dir, "sys.o.a"), joinpath(dir, "sys.so"))
             @test readchomp(`$(Base.julia_cmd()) -t1,0 -J $(dir)/sys.so -E 'hasmethod(sort, (Vector{Int},), (:dims,))'`) == "true"
         end
+    end
+end
+
+@testset "--output-heap-snapshot" begin
+    mktempdir() do dir
+        Base.compilecache(Base.PkgId(Base.UUID("3161d3a3-bdf6-5164-811a-617609db77b4"), "Zstd_jll");
+                          flags=`--output-heap-snapshot=Zstd_jll.heapsnapshot`)
+        Profile.HeapSnapshot.assemble_snapshot("Zstd_jll.heapsnapshot")
+        @test isfile("Zstd_jll.heapsnapshot")
     end
 end
 


### PR DESCRIPTION
This (undocumented) CLI option lets you take a snapshot of the graph of Julia objects serialized into a sysimage or pkgimage.

For pkgimages with a large `.ldata` section, this can be useful to help you shrink down the generated image.

```julia
julia> Base.compilecache(Base.PkgId(Base.UUID("3161d3a3-bdf6-5164-811a-617609db77b4"), "Zstd_jll");
                         flags=`--output-heap-snapshot=Zstd_jll.heapsnapshot`)
julia> using Profile; Profile.HeapSnapshot.assemble_snapshot("Zstd_jll.heapsnapshot")
julia> isfile("Zstd_jll.heapsnapshot")
true
```

Like with a GC heap snapshot, you can inspect the resulting `.heapsnapshot` file in Chrome Web Tools (or another viewer) and inspect the objects contained in a sysimage or pkgimage and see what caused various objects to be included.

TODO list:
  - [x] needs tests
  - [ ] `gc-heap-snapshot` interface needs re-factoring