### PR TITLE
fix `detect_closure_boxes` to only consider active methods

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2686,7 +2686,12 @@ function detect_closure_boxes(mods::Module...)
         return is_in_mods(mod, true, mods)
     end
 
+    function is_active_method(m::Method)
+        return !iszero(m.dispatch_status & Core.Compiler.ReinferUtils.METHOD_SIG_LATEST_WHICH)
+    end
+
     function scan_method!(m::Method)
+        is_active_method(m) || return
         matches_module(parentmodule(m)) || return
         ci = try
             Base.uncompressed_ast(m)

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2686,8 +2686,11 @@ function detect_closure_boxes(mods::Module...)
         return is_in_mods(mod, true, mods)
     end
 
+    world = Base.get_world_counter()
+    matches = Any[]
     function is_active_method(m::Method)
-        return !iszero(m.dispatch_status & Core.Compiler.ReinferUtils.METHOD_SIG_LATEST_WHICH)
+        minworld, maxworld = Core.Compiler.ReinferUtils.verify_invokesig(m.sig, m, world, matches)
+        return minworld <= world <= maxworld
     end
 
     function scan_method!(m::Method)

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -70,7 +70,7 @@ end
     all_boxes = Test.detect_closure_boxes_all_modules()
     @test any(p -> p.first.name === :boxed, all_boxes)
 
-    # Redefinition should drop closure boxes from deleted methods.
+    # Redefinition should drop closure boxes from shadowed methods.
     @test !isempty(Test.detect_closure_boxes(ClosureBoxRedefTest))
     @eval ClosureBoxRedefTest begin
         function boxed()

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -47,6 +47,14 @@ module ClosureBoxTest
     end
 end
 
+module ClosureBoxRedefTest
+    function boxed()
+        x = 1
+        inner() = (x += 1)
+        inner()
+    end
+end
+
 @testset "detect_closure_boxes" begin
     boxes = Test.detect_closure_boxes(ClosureBoxTest)
     @test any(p -> p.first.name === :boxed, boxes)
@@ -61,6 +69,17 @@ end
     # _all version checks all loaded modules
     all_boxes = Test.detect_closure_boxes_all_modules()
     @test any(p -> p.first.name === :boxed, all_boxes)
+
+    # Redefinition should drop closure boxes from deleted methods.
+    @test !isempty(Test.detect_closure_boxes(ClosureBoxRedefTest))
+    @eval ClosureBoxRedefTest begin
+        function boxed()
+            x = 1
+            inner() = x + 1
+            inner()
+        end
+    end
+    @test isempty(Test.detect_closure_boxes(ClosureBoxRedefTest))
 end
 
 @testset "@test with skip/broken kwargs" begin


### PR DESCRIPTION
Fixes #https://github.com/JuliaLang/julia/issues/60922

@vtjnash, could you look at this (considering e4d859d8d9d305cee699aa68dc2)