### PR TITLE
WIP : trying to resolve REPL property's completions UI

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -228,12 +228,20 @@ function complete_symbol!(suggestions::Vector{Completion},
         end
     elseif @isdefined(val) # looking for a property of an instance
         try
+            count = 0
+            truncated = false
             for property in propertynames(val, false)
                 # TODO: support integer arguments (#36872)
                 if property isa Symbol && startswith(string(property), name)
+                    count += 1
+                    if !shift && count > MAX_PROPERTY_COMPLETIONS
+                        truncated = true
+                        break
+                    end
                     push!(suggestions, PropertyCompletion(val, property))
                 end
             end
+            truncated && push!(suggestions, TextCompletion("( too many properties, use SHIFT-TAB to show )"))
         catch
         end
     elseif @isdefined(t) && field_completion_eligible(t)
@@ -728,6 +736,7 @@ function complete_methods(ex_org::Expr, context_module::Module=Main, shift::Bool
 end
 
 MAX_ANY_METHOD_COMPLETIONS::Int = 10
+MAX_PROPERTY_COMPLETIONS::Int = 200
 
 function accessible(mod::Module, private::Bool)
     bindings = IdSet{Any}(Core.Typeof(getglobal(mod, s)) for s in names(mod; all=private, imported=private, usings=private)

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -2270,6 +2270,23 @@ for s in ("WeirdNames().var\"oh ", "WeirdNames().var\"")
     @test c == Any["var\"oh no!\"", "var\"oh yes!\""]
 end
 
+@testset "Property completion limit" begin
+    struct LargeProps end
+    const LARGE_PROPS = [Symbol("col", i) for i in 1:7_000]
+    Base.propertynames(::LargeProps) = LARGE_PROPS
+
+    s = "LargeProps()."
+    c, r, res = test_complete_context(s; shift=false)
+    @test res
+    @test "( too many properties, use SHIFT-TAB to show )" in c
+    @test length(c) <= REPLCompletions.MAX_PROPERTY_COMPLETIONS + 1
+
+    c2, r2, res2 = test_complete_context(s; shift=true)
+    @test res2
+    @test "( too many properties, use SHIFT-TAB to show )" ∉ c2
+    @test length(c2) == length(LARGE_PROPS)
+end
+
 # Test completion of non-Expr literals
 let s = "\"abc\"."
     c, r = test_complete(s)


### PR DESCRIPTION
## Summary:

- Added a cap on property completions in `complete_symbol!` to avoid flooding the REPL when `propertynames `returns huge lists; when truncated, it appends a `TextCompletion` hint telling users to use SHIFT‑TAB to show all in [REPLCompletions.jl](https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/src/REPLCompletions.jl)

<img width="789" height="358" alt="image" src="https://github.com/user-attachments/assets/24a37a3a-fcc1-4f2a-9057-b565f60951da" />


- Introduced `MAX_PROPERTY_COMPLETIONS` to control that limit.

<img width="958" height="230" alt="image" src="https://github.com/user-attachments/assets/332ac9e5-ffe0-4d12-9532-d866e2366187" />

- Added a regression test in [replcompletions.jl](https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/test/replcompletions.jl) that defines a type with 7,000 properties and verifies: default completion is capped with the hint, while SHIFT‑TAB returns the full list.

Closes #60914