### PR TITLE
fix some typos in passing kwargs to code_typed_opaque_closure

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -596,7 +596,7 @@ function return_types(@nospecialize(f), @nospecialize(types=default_tt(f));
     interp = passed_interp === nothing ? invoke_default_compiler(:_default_interp, world) : interp
     check_generated_context(world)
     if isa(f, Core.OpaqueClosure)
-        _, rt = only(code_typed_opaque_closure(f, types; Compiler))
+        _, rt = only(code_typed_opaque_closure(f, types; interp=passed_interp))
         return Any[rt]
     elseif isa(f, Core.Builtin)
         return Any[_builtin_return_type(passed_interp, interp, f, types)]

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -166,7 +166,7 @@ function code_warntype(io::IO, arginfo::ArgInfo;
     if arginfo.oc !== nothing
         (; oc, tt) = arginfo
         isa(oc.source, Method) && (nargs = oc.source.nargs)
-        print_warntype_codeinfo(io, Base.code_typed_opaque_closure(oc, tt)[1]..., nargs;
+        print_warntype_codeinfo(io, Base.code_typed_opaque_closure(oc, tt; optimize, interp)[1]..., nargs;
                                 lineprinter, label_dynamic_calls = optimize)
         return nothing
     end

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -257,6 +257,15 @@ let oc = @opaque a->sin(a)
     end
 end
 
+let oc = @opaque (a::Int) -> identity(a)
+    buf = IOBuffer()
+    code_warntype(buf, oc, (Int,); optimize=true)
+    opt = takestring!(buf)
+    code_warntype(buf, oc, (Int,); optimize=false)
+    unopt = takestring!(buf)
+    @test opt != unopt
+end
+
 # constructing an opaque closure from IRCode
 let src = first(only(code_typed(+, (Int, Int))))
     ir = Core.Compiler.inflate_ir(src, Core.Compiler.VarState[], src.slottypes)


### PR DESCRIPTION
pretty sure these are just typos. the first was found via manual inspection while trying to investigate something else, the second was a follow-up search.