### PR TITLE
More unique name for shared array memory

### DIFF
--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -113,7 +113,7 @@ function SharedArray{T,N}(dims::Dims{N}; init=false, pids=Int[]) where {T,N}
     local shmmem_create_pid
     try
         # On OSX, the shm_seg_name length must be <= 31 characters (including the terminating NULL character)
-        seg_name = "/jl$(lpad(string(getpid() % 10^6), 6, "0"))$(randstring(20))"
+        seg_name = "/jl$(lpad(string(getpid() % 10^6), 6, "0"))$(repr(time_ns())[3:end])$(randstring(4))"
         shm_seg_name = seg_name
         if onlocalhost
             shmmem_create_pid = myid()


### PR DESCRIPTION
Fixes #42936 

The issue, investigated in #60937, is from multiple factors:
* RNG resetting during testing results in duplicated names for the shared memory object
* On Linux, the file descriptor can be reopened and truncated freely without error; the comparable calls in Windows can only resize up to the next memory page boundary; also on Linux, SharedArrays uses `shm_unlink` to release the name created by `shm_open`.
* Inconsistent API for Mmap between Linux and Windows.

This PR resolves the immediate issue, which is to make the name more unique by using the hex string encoding of `time_ns()` with a four-character random string concatenated, instead of merely a 20-character random string.