### PR TITLE
codegen: Mark resolved `const` `GlobalRef` as method root

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3505,6 +3505,10 @@ static jl_cgval_t emit_globalref(jl_codectx_t &ctx, jl_module_t *mod, jl_sym_t *
             undef_var_error_ifnot(ctx, ConstantInt::get(getInt1Ty(ctx.builder.getContext()), 0), name, (jl_value_t*)mod);
             return jl_cgval_t();
         }
+        if (jl_generating_output()) {
+            // root is required to allow bindings to be pruned, especially by `--trim`
+            jl_temporary_root(ctx, constval);
+        }
         return mark_julia_const(ctx, constval);
     }
     if (rkp.kind != PARTITION_KIND_GLOBAL) {

--- a/test/trimming/trimmability.jl
+++ b/test/trimming/trimmability.jl
@@ -19,6 +19,13 @@ area(c::Circle) = pi*c.radius^2
 
 sum_areas(v::Vector{Shape}) = sum(area, v)
 
+mutable struct Foo; x::Int; end
+const storage = Foo[]
+function add_one(x::Cint)::Cint
+    push!(storage, Foo(x))
+    return x + 1
+end
+
 function @main(args::Vector{String})::Cint
     println(Core.stdout, str())
     println(Core.stdout, PROGRAM_FILE)
@@ -37,6 +44,12 @@ function @main(args::Vector{String})::Cint
     c = map(x -> x^2, sorted_arr)
     d = mapreduce(x -> x^2, +, sorted_arr)
     # e = reduce(xor, rand(Int, 10))
+
+    for i = 1:10
+        # https://github.com/JuliaLang/julia/issues/60846
+        add_one(Cint(i))
+        GC.gc()
+    end
 
     try
         sock = connect("localhost", 4900)


### PR DESCRIPTION
This allows `--trim` to safely* prune bindings without dropping the root required for the generated machine code.

Opening this PR with a "simple" solution to get numbers / opinions on the overhead of these extra roots.

The (significantly more complex) alternative will be to examine the bindings (back)edges during `--trim` serialization and reconstruct the relevant binding dependency edges at that time. I'll update this PR in-place with that solution if it seems like the right direction to go instead.

Resolves https://github.com/JuliaLang/julia/issues/60846.

\* As a caveat, uninferred GlobalRefs can lead to missing bindings at runtime, but this is out-of-scope for --trim.