### PR TITLE
[JuliaLowering] Fix and test `cglobal`

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -1724,13 +1724,16 @@ function expand_ccall_argtype(ctx, ex)
 end
 
 # Expand the (sym,lib) argument to ccall/cglobal
-function expand_C_library_symbol(ctx, ex)
-    if kind(ex) == K"tuple"
-        return @ast ctx ex [K"static_eval"(meta=name_hint("function name and library expression"))
-            mapchildren(e->expand_forms_2(ctx,e), ctx, ex)
+function expand_C_library_symbol(ctx, ex, desugar_tuple)
+    @stm ex begin
+        [K"tuple" _...] -> @ast ctx ex [K"static_eval"(
+            meta=name_hint("function name and library expression"))
+            desugar_tuple ? expand_forms_2(ctx, ex) :
+                mapchildren(e->expand_forms_2(ctx,e), ctx, ex)
         ]
+        [K"static_eval" _] -> ex # already done
+        _ -> expand_forms_2(ctx, ex)
     end
-    return expand_forms_2(ctx, ex)
 end
 
 function expand_ccall(ctx, ex)
@@ -1846,7 +1849,7 @@ function expand_ccall(ctx, ex)
     @ast ctx ex [K"block"
         sctx.stmts...
         [K"foreigncall"
-            expand_C_library_symbol(ctx, cfunc_name)
+            expand_C_library_symbol(ctx, cfunc_name, false)
             [K"static_eval"(meta=name_hint("ccall return type"))
                 expand_forms_2(ctx, return_type)
             ]
@@ -1915,7 +1918,7 @@ function expand_call(ctx, ex)
         @chk numchildren(ex) in 2:3  (ex, "cglobal must have one or two arguments")
         return @ast ctx ex [K"call"
             ex[1]
-            expand_C_library_symbol(ctx, ex[2])
+            expand_C_library_symbol(ctx, ex[2], true)
             if numchildren(ex) == 3
                 expand_forms_2(ctx, ex[3])
             end
@@ -4506,7 +4509,7 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
     elseif k == K"generator"
         expand_forms_2(ctx, expand_generator(ctx, ex))
     elseif k == K"->" || k == K"do"
-        expand_forms_2(ctx, expand_arrow(ctx, ex))
+        expand_arrow(ctx, ex)
     elseif k == K"function" || k == K"generated_function"
         expand_forms_2(ctx, expand_function_def(ctx, ex, docs))
     elseif k == K"macro"
@@ -4635,6 +4638,11 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
         ]
     elseif k == K"inert" || k == K"inert_syntaxtree"
         ex
+    elseif k == K"foreigncall"
+        @ast ctx ex [K"foreigncall"
+            expand_C_library_symbol(ctx, ex[1], false)
+            map(c->expand_forms_2(ctx, c), ex[2:end])...
+        ]
     elseif k == K"symbolicblock"
         # @label name body -> (symbolicblock name expanded_body)
         # The @label macro inserts the continue block for loops, so we just expand the body

--- a/JuliaLowering/test/function_calls_ir.jl
+++ b/JuliaLowering/test/function_calls_ir.jl
@@ -503,7 +503,7 @@ ccall(:foo, Csize_t, (Cstring..., Cstring...), "asdfg", "blah")
 cglobal((:sym, lib), Int)
 #---------------------
 1   TestMod.Int
-2   (call core.cglobal (static_eval (tuple :sym TestMod.lib)) %₁)
+2   (call core.cglobal (static_eval (call core.tuple :sym TestMod.lib)) %₁)
 3   (return %₂)
 
 ########################################

--- a/JuliaLowering/test/function_calls_ir.jl
+++ b/JuliaLowering/test/function_calls_ir.jl
@@ -502,9 +502,11 @@ ccall(:foo, Csize_t, (Cstring..., Cstring...), "asdfg", "blah")
 # cglobal special support for (sym, lib) tuple
 cglobal((:sym, lib), Int)
 #---------------------
-1   TestMod.Int
-2   (call core.cglobal (static_eval (call core.tuple :sym TestMod.lib)) %₁)
-3   (return %₂)
+1   TestMod.lib
+2   (call core.tuple :sym %₁)
+3   TestMod.Int
+4   (call core.cglobal %₂ %₃)
+5   (return %₄)
 
 ########################################
 # cglobal - non-tuple expressions in first arg are lowered as normal
@@ -515,18 +517,6 @@ cglobal(f(), Int)
 3   TestMod.Int
 4   (call core.cglobal %₂ %₃)
 5   (return %₄)
-
-########################################
-# Error: cglobal with library name referencing local variable
-let func="myfunc"
-    cglobal((func, "somelib"), Int)
-end
-#---------------------
-LoweringError:
-let func="myfunc"
-    cglobal((func, "somelib"), Int)
-#            └──┘ ── function name and library expression cannot reference local variable
-end
 
 ########################################
 # Error: cglobal too many arguments

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -66,6 +66,14 @@ end
     @test cg isa Ptr{Cint}
     @test cg !== C_NULL
     @test unsafe_load(cg) == 1
+    cg = JuliaLowering.include_string(test_mod, """
+        let local_tuple = (:global_var, libccalltest_var)
+            cglobal(local_tuple, Cint)
+        end
+    """)
+    @test cg isa Ptr{Cint}
+    @test cg !== C_NULL
+    @test unsafe_load(cg) == 1
 end
 
 # ccall

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -43,6 +43,31 @@ let x=11
 end
 """) == 220
 
+@eval test_mod libccalltest_var = "libccalltest"
+
+@testset "cglobal" begin
+    cg = JuliaLowering.include_string(test_mod, """
+        cglobal(:jl_, Any)
+    """)
+    @test cg isa Ptr{Any}
+    @test cg !== C_NULL
+
+    cg = JuliaLowering.include_string(test_mod, """
+        cglobal((:global_var, libccalltest_var), Cint)
+    """)
+    @test cg isa Ptr{Cint}
+    @test cg !== C_NULL
+    @test unsafe_load(cg) == 1
+
+    @eval test_mod global cglobal_tuple = (:global_var, libccalltest_var)
+    cg = JuliaLowering.include_string(test_mod, """
+        cglobal(cglobal_tuple, Cint)
+    """)
+    @test cg isa Ptr{Cint}
+    @test cg !== C_NULL
+    @test unsafe_load(cg) == 1
+end
+
 # ccall
 @test JuliaLowering.include_string(test_mod, """
 ccall(:strlen, Csize_t, (Cstring,), "asdfg")
@@ -74,7 +99,6 @@ end
     ccall((:ctest, :libccalltest), Complex{Int}, (Complex{Int},), 10 + 20im)
 """) === 11 + 18im
 # (function, library): library is a global
-@eval test_mod libccalltest_var = "libccalltest"
 @test JuliaLowering.include_string(test_mod, """
     ccall((:ctest, libccalltest_var), Complex{Int}, (Complex{Int},), 10 + 20im)
 """) === 11 + 18im

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -4891,7 +4891,8 @@ f(x) = yt(x)
                                (compile-args (list-head (cdr e) 4) break-labels)
                                (list (append (butlast oc_method) (list lambda)))
                                (compile-args (list-tail (cdr e) 5) break-labels))))
-                           ;; NOTE: 1st argument to cglobal treated same as for ccall
+                           ;; NOTE: 1st argument to cglobal is similar to ccall,
+                           ;; but tuple should be a value, not literal expr
                            ((and (length> e 2)
                                  (or (eq? (cadr e) 'cglobal)
                                      (equal? (cadr e) '(globalref (thismodule) cglobal))))


### PR DESCRIPTION
Noticed on the asserts build in https://github.com/JuliaLang/julia/pull/60942.  The output of `(call cglobal _...)` lowering is an ordinary call which expects a `(call Core.tuple sym lib)` arg,  and not a special form like `foreigncall` that expects `(tuple sym lib)`. Fix this and add tests.

The specific failure was `do` and `->` forms getting desugared twice, causing a foreigncall to contain `(call Core.tuple _...)` instead of the Expr-`tuple` it expected.  This PR fixes the double-desugaring, but also makes the desugaring idempotent.