### PR TITLE
make `checkbounds(collection, indices...)` return `nothing` when returning

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -696,6 +696,8 @@ end
     checkbounds(A, I...)
 
 Throw an error if the specified indices `I` are not in bounds for the given array `A`.
+
+In case there is no throw, it is recommended to return [`nothing`](@ref).
 """
 function checkbounds(A::AbstractArray, I...)
     @inline

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -696,8 +696,6 @@ end
     checkbounds(A, I...)
 
 Throw an error if the specified indices `I` are not in bounds for the given array `A`.
-
-In case there is no throw, it is recommended to return [`nothing`](@ref).
 """
 function checkbounds(A::AbstractArray, I...)
     @inline

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -630,11 +630,15 @@ to_index(::Tuple{}) = CartesianIndex()
 to_index(Is::Tuple{Any}) = Is[1]
 to_index(Is::Tuple) = CartesianIndex(Is)
 
-@inline Base.checkbounds(bc::Broadcasted, I::CartesianIndex) =
+@inline function Base.checkbounds(bc::Broadcasted, I::CartesianIndex)
     Base.checkbounds_indices(Bool, axes(bc), (I,)) || Base.throw_boundserror(bc, (I,))
+    nothing
+end
 
-@inline Base.checkbounds(bc::Broadcasted, I::Integer) =
+@inline function Base.checkbounds(bc::Broadcasted, I::Integer)
     Base.checkindex(Bool, eachindex(IndexLinear(), bc), I) || Base.throw_boundserror(bc, (I,))
+    nothing
+end
 
 
 """

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -383,6 +383,7 @@ end
 function checkbounds(A::Union{Array, GenericMemory}, i::Int)
     @inline
     checkbounds(Bool, A, i) || throw_boundserror(A, (i,))
+    nothing
 end
 
 default_access_order(::GenericMemory{:not_atomic}) = :not_atomic

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3258,7 +3258,7 @@ end
 
 @testset "conditionally-throwing version of `checkbounds` should return `nothing` if it returns" begin
     for typ in (AbstractString, DenseArray, Base.AbstractBroadcasted)
-        @test Base.infer_return_type(checkbounds, Tuple{typ, Any}) <: Nothing
+        @test Base.infer_return_type(checkbounds, Tuple{typ, Vararg}) <: Nothing
     end
 end
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3258,7 +3258,7 @@ end
 
 @testset "conditionally-throwing version of `checkbounds` should return `nothing` if it returns" begin
     for typ in (AbstractString, DenseArray, Base.AbstractBroadcasted)
-        @test Base.infer_return_type(checkbounds, Tuple{typ, Any})
+        @test Base.infer_return_type(checkbounds, Tuple{typ, Any}) <: Nothing
     end
 end
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3257,7 +3257,7 @@ end
 end
 
 @testset "conditionally-throwing version of `checkbounds` should return `nothing` if it returns" begin
-    for typ in (AbstractString, DenseArray, Base.AbstractBroadcasted)
+    for typ in (AbstractString, AbstractArray, Base.AbstractBroadcasted)
         @test Base.infer_return_type(checkbounds, Tuple{typ, Vararg}) <: Nothing
     end
 end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3256,6 +3256,12 @@ end
     @test setindex!(zeros(2,2), fill(1.0), CI0, 1, 1) == [1.0 0.0; 0.0 0.0]
 end
 
+@testset "conditionally-throwing version of `checkbounds` should return `nothing` if it returns" begin
+    for typ in (AbstractString, DenseArray, Base.AbstractBroadcasted)
+        @test Base.infer_return_type(checkbounds, Tuple{typ, Any})
+    end
+end
+
 # Throws ArgumentError for negative dimensions in Array
 @test_throws ArgumentError fill('a', -10)
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3257,6 +3257,7 @@ end
 end
 
 @testset "conditionally-throwing version of `checkbounds` should return `nothing` if it returns" begin
+    # can not just set `typ = Any` because that would include the predicate (non-throwing) methods of `checkbounds`, because `Type{Bool} <: Any`
     for typ in (AbstractString, AbstractArray, Base.AbstractBroadcasted)
         @test Base.infer_return_type(checkbounds, Tuple{typ, Vararg}) <: Nothing
     end


### PR DESCRIPTION
Before this change `checkbounds(collection, indices...)` has various possible return types depending on `typeof(collection)`. It would be more consistent and just as useful to always return `nothing`.