### PR TITLE
Specialize `unsafe_view` for ranges instead of `view`

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -211,7 +211,7 @@ julia> view(2:5, 2:3) # returns a range as type is immutable
 ```
 """
 function view(A::AbstractArray, I::Vararg{Any,M}) where {M}
-    @inline
+    @_propagate_inbounds_meta
     J = map(i->unalias(A,i), to_indices(A, I))
     @boundscheck checkbounds(A, J...)
     J′ = rm_singleton_indices(ntuple(Returns(true), Val(ndims(A))), J...)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -241,6 +241,12 @@ function unsafe_view(r1::LinRange, r2::OrdinalRange{<:Integer})
     getindex(r1, r2)
 end
 
+# getindex(r::AbstractRange, ::Colon) returns a copy of the range, and we may do the same for a view
+function view(r1::AbstractRange, c::Colon)
+    @_propagate_inbounds_meta
+    getindex(r1, c)
+end
+
 function unsafe_view(A::AbstractArray, I::Vararg{ViewIndex,N}) where {N}
     @inline
     SubArray(A, I)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -219,31 +219,26 @@ function view(A::AbstractArray, I::Vararg{Any,M}) where {M}
 end
 
 # Ranges implement getindex to return recomputed ranges; use that for views, too (when possible)
-function view(r1::AbstractUnitRange, r2::AbstractUnitRange{<:Integer})
+# we specialize on unsafe_view to ensure that conversions from Colons or CartesainIndices have already taken place
+function unsafe_view(r1::AbstractUnitRange, r2::AbstractUnitRange{<:Integer})
     @_propagate_inbounds_meta
     getindex(r1, r2)
 end
-function view(r1::AbstractUnitRange, r2::StepRange{<:Integer})
+function unsafe_view(r1::AbstractUnitRange, r2::StepRange{<:Integer})
     @_propagate_inbounds_meta
     getindex(r1, r2)
 end
-function view(r1::StepRange, r2::AbstractRange{<:Integer})
+function unsafe_view(r1::StepRange, r2::AbstractRange{<:Integer})
     @_propagate_inbounds_meta
     getindex(r1, r2)
 end
-function view(r1::StepRangeLen, r2::OrdinalRange{<:Integer})
+function unsafe_view(r1::StepRangeLen, r2::OrdinalRange{<:Integer})
     @_propagate_inbounds_meta
     getindex(r1, r2)
 end
-function view(r1::LinRange, r2::OrdinalRange{<:Integer})
+function unsafe_view(r1::LinRange, r2::OrdinalRange{<:Integer})
     @_propagate_inbounds_meta
     getindex(r1, r2)
-end
-
-# getindex(r::AbstractRange, ::Colon) returns a copy of the range, and we may do the same for a view
-function view(r1::AbstractRange, c::Colon)
-    @_propagate_inbounds_meta
-    getindex(r1, c)
 end
 
 function unsafe_view(A::AbstractArray, I::Vararg{ViewIndex,N}) where {N}

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1887,6 +1887,17 @@ end
         vm = findfirst(sig->tt <: Base.tuple_type_tail(sig.sig), vmt)
         @test vmt[vm].sig != Tuple{typeof(view),AbstractArray,Vararg{Any,N}} where N
     end
+
+    struct MyRange{T,A<:AbstractRange{T}} <: AbstractRange{T}
+        r::A
+    end
+    Base.first(r::MyRange) = first(r.r)
+    Base.last(r::MyRange) = last(r.r)
+    Base.step(r::MyRange) = step(r.r)
+    Base.length(r::MyRange) = length(r.r)
+    Base.getindex(r::MyRange, i::Int) = getindex(r.r, i)
+
+    @test view(MyRange(1:10), :) === MyRange(1:10)
 end
 
 @testset "Issue #26608" begin

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1877,8 +1877,10 @@ end
     @test view(1:10, :) === 1:10
     @test view(1:2:9, :) === 1:2:9
 
+    @test view(1:10, CartesianIndices((1:5,))) === 1:5
+
     # Ensure we don't hit a fallback `view` if there's a better `getindex` implementation
-    vmt = collect(methods(view, Tuple{AbstractRange, AbstractRange}))
+    vmt = collect(methods(Base.unsafe_view, Tuple{AbstractRange, AbstractRange}))
     for m in methods(getindex, Tuple{AbstractRange, AbstractRange})
         tt = Base.tuple_type_tail(m.sig)
         tt == Tuple{AbstractArray,Vararg{Any,N}} where N && continue

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -626,7 +626,7 @@ end
         "Invalid use of @view macro: argument must be a reference expression A[...]."
     ) var"@view"(LineNumberNode(@__LINE__), @__MODULE__, 1)
 
-    X = reshape(1:24,2,3,4)
+    X = reshape(collect(1:24),2,3,4)
     Y = 4:-1:1
 
     @test isa(@view(X[1:3]), SubArray)


### PR DESCRIPTION
Currently, we define `view` for ranges in terms of `getindex`. This PR calls the `getindex` _after_ the index conversion through `to_indices` has taken place within `view`, which means, among other things, `CartesianIndices` behave the same as ranges. We also get `Colon`s for free.

```julia
julia> r = 1:4;

julia> view(r, eachindex(IndexLinear(), r))
1:4

julia> view(r, eachindex(IndexCartesian(), r))
1:4

julia> view(r, :)
1:4

julia> view(r, :, 1)
1:4
```
In comparison, currently, we have
```julia
julia> view(r, eachindex(IndexCartesian(), r))
4-element view(::UnitRange{Int64}, Base.OneTo(4)) with eltype Int64:
 1
 2
 3
 4

julia> view(r, :, 1)
4-element view(::UnitRange{Int64}, :) with eltype Int64:
 1
 2
 3
 4
```

This also helps avoid wrappers for reshaped ranges, since `view` may reshape the parent array to match the dimensions of the indices:
```julia
julia> s = reshape(r, 1, 4)
1×4 reshape(::UnitRange{Int64}, 1, 4) with eltype Int64:
 1  2  3  4

julia> view(s, :)
1:4
```
This will extend to `transpose`/`adjoint` as well if they are equivalent to `reshape`
```julia
julia> view(r', :)
1:4
```