### PR TITLE
avoid unnecessary method of `checkbounds` for `Union{Array,GenericMemory}`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -697,11 +697,7 @@ end
 
 Throw an error if the specified indices `I` are not in bounds for the given array `A`.
 """
-function checkbounds(A::AbstractArray, I...)
-    @inline
-    checkbounds(Bool, A, I...) || throw_boundserror(A, I)
-    nothing
-end
+checkbounds(A::AbstractArray, I...)
 
 """
     checkbounds_indices(Bool, IA, I)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -375,14 +375,14 @@ macro _nospecializeinfer_meta()
     return Expr(:meta, :nospecializeinfer)
 end
 
-# These special checkbounds methods are defined early for bootstrapping
+# These checkbounds methods are defined early for bootstrapping
 function checkbounds(::Type{Bool}, A::Union{Array, Memory}, i::Int)
     @inline
     ult_int(bitcast(UInt, sub_int(i, 1)), bitcast(UInt, length(A)))
 end
-function checkbounds(A::Union{Array, GenericMemory}, i::Int)
+function checkbounds(A::AbstractArray, I...)
     @inline
-    checkbounds(Bool, A, i) || throw_boundserror(A, (i,))
+    checkbounds(Bool, A, I...) || throw_boundserror(A, I)
     nothing
 end
 


### PR DESCRIPTION
Simplification: after moving the generic method to earlier in bootstrap, the method specific to `Union{Array,GenericMemory}` is not necessary any more.

Reduce `length(methods(checkbounds, Tuple{AbstractArray, Vararg}))` from `2` to `1`.