### PR TITLE
Document Int(::AbstractChar)

### DIFF
--- a/base/char.jl
+++ b/base/char.jl
@@ -10,18 +10,6 @@ and characters can be converted to integer codepoint values via the [`codepoint`
 function, or can be constructed from the same integer.  At least for valid,
 properly encoded Unicode characters, these numerical codepoint values
 determine how characters are compared with `<` and `==`, for example.
-
-!!! note
-    Characters can also be converted to integers using `Int(c::AbstractChar)`,
-    which returns the Unicode code point of `c`.
-
-    # Examples
-        julia> Int('a')
-        97
-
-        julia> Int('é')
-        233
-
 New `T <: AbstractChar` types should define a `codepoint(::T)`
 method and a `T(::UInt32)` constructor, at minimum.
 
@@ -60,6 +48,15 @@ a `Char` value may store information that cannot be converted to a Unicode
 codepoint — converting such a `Char` to `UInt32` will throw an error.
 The [`isvalid(c::Char)`](@ref) function can be used to query whether `c`
 represents a valid Unicode character.
+
+*Note:* Characters can also be converted to integers using `Int(c::Char)`; 
+this returns the Unicode code point of `c`. Example:
+
+    julia> Int('a')
+    97
+
+    julia> Int('é')
+    233
 """
 Char
 

--- a/base/char.jl
+++ b/base/char.jl
@@ -10,6 +10,18 @@ and characters can be converted to integer codepoint values via the [`codepoint`
 function, or can be constructed from the same integer.  At least for valid,
 properly encoded Unicode characters, these numerical codepoint values
 determine how characters are compared with `<` and `==`, for example.
+
+!!! note
+    Characters can also be converted to integers using `Int(c::AbstractChar)`,
+    which returns the Unicode code point of `c`.
+
+    # Examples
+        julia> Int('a')
+        97
+
+        julia> Int('é')
+        233
+
 New `T <: AbstractChar` types should define a `codepoint(::T)`
 method and a `T(::UInt32)` constructor, at minimum.
 
@@ -50,20 +62,6 @@ The [`isvalid(c::Char)`](@ref) function can be used to query whether `c`
 represents a valid Unicode character.
 """
 Char
-
-"""
-    Int(c::AbstractChar)
-
-Convert a character `c` to its corresponding Unicode code point as an integer.
-
-# Examples
-
-    julia> Int('a')
-    97
-
-    julia> Int('é')
-    233
-"""
 
 @constprop :aggressive (::Type{T})(x::Number) where {T<:AbstractChar} = T(UInt32(x)::UInt32)
 @constprop :aggressive AbstractChar(x::Number) = Char(x)

--- a/base/char.jl
+++ b/base/char.jl
@@ -51,6 +51,20 @@ represents a valid Unicode character.
 """
 Char
 
+"""
+    Int(c::AbstractChar)
+
+Convert a character `c` to its corresponding Unicode code point as an integer.
+
+# Examples
+
+    julia> Int('a')
+    97
+
+    julia> Int('é')
+    233
+"""
+
 @constprop :aggressive (::Type{T})(x::Number) where {T<:AbstractChar} = T(UInt32(x)::UInt32)
 @constprop :aggressive AbstractChar(x::Number) = Char(x)
 @constprop :aggressive (::Type{T})(x::AbstractChar) where {T<:Union{Number,AbstractChar}} = T(codepoint(x))

--- a/base/char.jl
+++ b/base/char.jl
@@ -49,7 +49,7 @@ codepoint — converting such a `Char` to `UInt32` will throw an error.
 The [`isvalid(c::Char)`](@ref) function can be used to query whether `c`
 represents a valid Unicode character.
 
-*Note:* Characters can also be converted to integers using `Int(c::Char)`; 
+*Note:* Characters can also be converted to integers using `Int(c::Char)`;
 this returns the Unicode code point of `c`. Example:
 
     julia> Int('a')


### PR DESCRIPTION
This PR adds a docstring for `Int(::AbstractChar)` as requested in Issue #54000.

The docstring explains that a character `c` can be converted to its corresponding Unicode code point as an integer, with examples:

    julia> Int('a')
    97

    julia> Int('é')
    233

No code behavior is changed — this is purely documentation.

Closes #54000.