### PR TITLE
add public callable `Iterators.cat`, use it to concatenate iterators

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,8 @@ Build system changes
 New library functions
 ---------------------
 
+* `Iterators.cat(iterators...)` concatenates several iterators ([XXX]).
+
 New library features
 --------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,7 +37,7 @@ Build system changes
 New library functions
 ---------------------
 
-* `Iterators.cat(iterators...)` concatenates several iterators ([XXX]).
+* `Iterators.cat(iterators...)` concatenates several iterators ([#60965]).
 
 New library features
 --------------------

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -33,7 +33,46 @@ import Base:
     popfirst!, isdone, peek, intersect
 
 export enumerate, zip, rest, countfrom, take, drop, takewhile, dropwhile, cycle, repeated, product, flatten, flatmap, partition, nth, findeach
-public accumulate, filter, map, peel, reverse, Stateful
+public accumulate, filter, map, peel, reverse, Stateful, cat
+
+"""
+    Iterators.cat(iterators...)
+
+Concatenate several iterators.
+
+Currently just defined as `Iterators.flatten ∘ tuple`.
+
+!!! compat "Julia 1.14"
+
+    This function requires at least Julia 1.14.
+
+# Examples
+
+```jldoctest
+julia> collect(Int, Iterators.cat())
+Int64[]
+
+julia> collect(Int, Iterators.cat([]))
+Int64[]
+
+julia> collect(Int, Iterators.cat([], []))
+Int64[]
+
+julia> collect(Iterators.cat([1, 2, 3]))
+3-element Vector{Int64}:
+ 1
+ 2
+ 3
+
+julia> collect(Iterators.cat([1, 2, 3], [10]))
+4-element Vector{Int64}:
+  1
+  2
+  3
+ 10
+```
+"""
+const cat = Iterators.flatten ∘ tuple
 
 """
     Iterators.map(f, iterators...)

--- a/base/terminfo.jl
+++ b/base/terminfo.jl
@@ -138,7 +138,7 @@ function extendedterminfo(data::IO, NumInt::Union{Type{Int16}, Type{Int32}})
     end
     labels = map(Symbol, _terminfo_read_strings(table_data, table_indices[string_count+1:end]))
     Dict{Symbol, Union{Bool, Int, String, Nothing}}(
-        zip(labels, Iterators.flatten((flags, numbers, strings))))
+        zip(labels, Iterators.cat(flags, numbers, strings)))
 end
 
 """

--- a/doc/src/base/iterators.md
+++ b/doc/src/base/iterators.md
@@ -15,6 +15,7 @@ Base.Iterators.cycle
 Base.Iterators.repeated
 Base.Iterators.product
 Base.Iterators.flatten
+Base.Iterators.cat
 Base.Iterators.flatmap
 Base.Iterators.partition
 Base.Iterators.map

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -497,8 +497,8 @@ repl_corrections(s) = repl_corrections(stdout, s)
 const symbols_latex = Dict{String,String}()
 function symbol_latex(s::String)
     if isempty(symbols_latex)
-        for (k,v) in Iterators.flatten((REPLCompletions.latex_symbols,
-                                        REPLCompletions.emoji_symbols))
+        for (k,v) in Iterators.cat(REPLCompletions.latex_symbols,
+                                   REPLCompletions.emoji_symbols)
             symbols_latex[v] = k
         end
 

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -556,6 +556,13 @@ end
     @test (@inferred Base.IteratorSize(Base.Flatten(1:2:4))) == Base.HasLength()
 end
 
+@testset "`Iterators.cat`" begin
+    f = collect ∘ Iterators.cat
+    @test [] == f() == f([]) == f([], []) == f(()) == f([], ())
+    @test [3] == f([], [3]) == f([3], []) == f([], (), [3])
+    @test [10, 1, 2] == f((10,), [1, 2]) == f([10, 1], (2,))
+end
+
 @test (@inferred Base.IteratorEltype(Base.Flatten((i for i=1:2) for j=1:1))) == Base.EltypeUnknown()
 # see #29112, #29464, #29548
 @test Base.return_types(Base.IteratorEltype, Tuple{Array}) == [Base.HasEltype]


### PR DESCRIPTION
I feel it is common to want to concatenate several iterators. While the implementation is extremely simple, the approach is not completely obvious. A newcomer, especially, might choose to use the more verbose `Iterators.flatten((i, j))` instead of cooking up their own `Iterators.cat`.

Fixes #36760