### PR TITLE
Add missing docstrings for public/exported symbols

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1364,6 +1364,18 @@ end
 
 @inline unsafe_getindex(A::AbstractArray, I...) = @inbounds getindex(A, I...)
 
+"""
+    CanonicalIndexError(func::String, type) <: Exception
+
+An exception thrown when a canonical indexing method for a custom `AbstractArray` subtype
+is not implemented. This is an internal mechanism to detect infinite recursion: when
+`getindex` or `setindex!` falls through to the canonical form without an actual
+implementation, this error is thrown instead of entering an infinite loop.
+
+Custom array types should implement the appropriate indexing method for their
+[`IndexStyle`](@ref) (either `getindex(A::MyArray, i::Int)` for [`IndexLinear`](@ref)
+or `getindex(A::MyArray, I::Vararg{Int,N})` for [`IndexCartesian`](@ref)) to avoid this error.
+"""
 struct CanonicalIndexError <: Exception
     func::String
     type::Any

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1246,6 +1246,18 @@ end
 # explicit calls to view.   (All of this can go away if slices
 # are changed to generate views by default.)
 
+"""
+    Broadcast.dotview(x, args...)
+
+Return the view of `x` that is used on the left-hand side of a fused broadcast assignment
+(`x[...] .= ...`). By default, `dotview` calls `Base.maybeview`, so that `x[i] .= rhs`
+uses a view for assignment.
+
+Custom array types can specialize `dotview` to control how broadcast assignment targets
+are created.
+
+See also [`Base.maybeview`](@ref), [`@views`](@ref).
+"""
 Base.@propagate_inbounds dotview(args...) = Base.maybeview(args...)
 
 ############################################################

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -375,6 +375,17 @@ function close_chnl_on_taskdone(t::Task, c::Channel)
     nothing
 end
 
+"""
+    InvalidStateException(msg::String, state::Symbol) <: Exception
+
+An exception thrown when an operation is attempted on an object that is in an invalid
+state for that operation. For example, this is thrown when trying to [`put!`](@ref) a
+value into a closed [`Channel`](@ref).
+
+# Fields
+- `msg::String`: A description of the error.
+- `state::Symbol`: The state of the object when the exception was thrown.
+"""
 struct InvalidStateException <: Exception
     msg::String
     state::Symbol

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -65,6 +65,26 @@ function.
 
 include("bindings.jl")
 
+"""
+    Docs.@var(x)
+
+Create a [`Docs.Binding`](@ref) object referencing the binding `x`. This is used to
+refer to a specific binding in a given module for documentation lookups, without
+evaluating the value of `x`.
+
+# Examples
+```jldoctest
+julia> using Base.Docs: @var
+
+julia> @var(sin)
+Base.sin
+
+julia> @var(Base.cos)
+Base.cos
+```
+"""
+:(@var)
+
 import .Base.Meta: quot, isexpr, unblock, unescape, uncurly
 import .Base: Callable, with_output_color
 using .Base: RefValue, mapany

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4044,6 +4044,42 @@ A non-exhaustive list of examples of when this is used include:
 """
 ConcurrencyViolationError
 
+"""
+    GenericMemoryRef{kind, T, addrspace}
+
+A reference (pointer with bounds-checking) into a [`GenericMemory`](@ref) object.
+`GenericMemoryRef` is parameterized by:
+- `kind::Symbol`: The atomicity kind (e.g. `:not_atomic` or `:atomic`).
+- `T`: The element type.
+- `addrspace`: The address space.
+
+The type aliases [`MemoryRef{T}`](@ref) and [`AtomicMemoryRef{T}`](@ref) are provided
+for the common cases.
+
+See also [`GenericMemory`](@ref), [`MemoryRef`](@ref), [`AtomicMemoryRef`](@ref).
+"""
+Core.GenericMemoryRef
+
+"""
+    MemoryRef{T}
+
+Type alias for `GenericMemoryRef{:not_atomic, T, Core.CPU}`, i.e. a reference into
+a non-atomic [`Memory{T}`](@ref).
+
+See also [`GenericMemoryRef`](@ref), [`Memory`](@ref).
+"""
+Core.MemoryRef
+
+"""
+    AtomicMemoryRef{T}
+
+Type alias for `GenericMemoryRef{:atomic, T, Core.CPU}`, i.e. a reference into
+an [`AtomicMemory{T}`](@ref).
+
+See also [`GenericMemoryRef`](@ref), [`AtomicMemory`](@ref).
+"""
+Core.AtomicMemoryRef
+
 Base.include(BaseDocs, "intrinsicsdocs.jl")
 
 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4044,6 +4044,25 @@ A non-exhaustive list of examples of when this is used include:
 """
 ConcurrencyViolationError
 
+"""
+    Exception
+
+Abstract type of all exceptions in Julia. New exception types should subtype `Exception`.
+
+# Examples
+```jldoctest
+julia> struct MyException <: Exception
+           msg::String
+       end
+
+julia> MyException("something went wrong") isa Exception
+true
+```
+
+See also [`throw`](@ref), [`error`](@ref), [`catch`](@ref).
+"""
+Core.Exception
+
 Base.include(BaseDocs, "intrinsicsdocs.jl")
 
 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4044,6 +4044,20 @@ A non-exhaustive list of examples of when this is used include:
 """
 ConcurrencyViolationError
 
+"""
+    IO
+
+The abstract type for all I/O streams. Every stream used for reading or writing data
+in Julia is a subtype of `IO`, including [`IOBuffer`](@ref), [`IOStream`](@ref),
+and network or file-based streams.
+
+Custom I/O types should subtype `IO` and implement methods such as
+[`read`](@ref), [`write`](@ref), and [`close`](@ref).
+
+See also [`IOBuffer`](@ref), [`IOStream`](@ref), [`open`](@ref).
+"""
+Core.IO
+
 Base.include(BaseDocs, "intrinsicsdocs.jl")
 
 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4044,6 +4044,16 @@ A non-exhaustive list of examples of when this is used include:
 """
 ConcurrencyViolationError
 
+"""
+    SegmentationFault() <: Exception
+
+An exception thrown when a segmentation fault (invalid memory access) occurs. These
+typically indicate a bug in native code called via [`ccall`](@ref) or a Julia runtime error.
+Unlike most exceptions, a `SegmentationFault` is automatically converted into a Julia
+exception by the runtime signal handler rather than being explicitly thrown by Julia code.
+"""
+Core.SegmentationFault
+
 Base.include(BaseDocs, "intrinsicsdocs.jl")
 
 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4044,6 +4044,32 @@ A non-exhaustive list of examples of when this is used include:
 """
 ConcurrencyViolationError
 
+"""
+    Method
+
+A type representing a single method definition in Julia's method table. A `Method` stores
+metadata about a specific method, including its source location, signature, and the
+module in which it was defined.
+
+Methods are created when a function is defined with a particular signature. Use
+[`methods`](@ref) to list the methods of a function, and [`which`](@ref) to find the specific
+method that would be called for given argument types.
+
+# Examples
+```jldoctest
+julia> m = which(+, (Int, Int));
+
+julia> m isa Method
+true
+
+julia> m.module
+Base
+```
+
+See also [`methods`](@ref), [`which`](@ref), [`Function`](@ref).
+"""
+Core.Method
+
 Base.include(BaseDocs, "intrinsicsdocs.jl")
 
 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4044,6 +4044,36 @@ A non-exhaustive list of examples of when this is used include:
 """
 ConcurrencyViolationError
 
+"""
+    TypeVar
+
+A type variable, representing a parameter in [`UnionAll`](@ref) types. `TypeVar`s are
+typically created by the `where` syntax in type declarations and method signatures.
+
+# Fields
+- `name::Symbol`: The name of the type variable.
+- `lb`: The lower bound of the type variable (default `Union{}`).
+- `ub`: The upper bound of the type variable (default `Any`).
+
+# Examples
+```jldoctest
+julia> T = TypeVar(:T)
+T
+
+julia> Vector{T} where T
+Vector{T} where T
+
+julia> TypeVar(:T, Integer)
+T<:Integer
+
+julia> TypeVar(:T, Int, Real)
+Int<:T<:Real
+```
+
+See also [`UnionAll`](@ref), [`where`](@ref).
+"""
+Core.TypeVar
+
 Base.include(BaseDocs, "intrinsicsdocs.jl")
 
 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4044,6 +4044,31 @@ A non-exhaustive list of examples of when this is used include:
 """
 ConcurrencyViolationError
 
+"""
+    GlobalRef
+
+A reference to a global variable in a specific module. This is a low-level representation
+used internally in Julia's intermediate representation (IR) and code generation to
+unambiguously identify module-level bindings.
+
+# Fields
+- `mod::Module`: The module containing the binding.
+- `name::Symbol`: The name of the binding.
+
+# Examples
+```jldoctest
+julia> gr = GlobalRef(Base, :sin)
+Base.sin
+
+julia> gr.mod
+Base
+
+julia> gr.name
+:sin
+```
+"""
+Core.GlobalRef
+
 Base.include(BaseDocs, "intrinsicsdocs.jl")
 
 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4044,6 +4044,30 @@ A non-exhaustive list of examples of when this is used include:
 """
 ConcurrencyViolationError
 
+"""
+    LineNumberNode
+
+A type representing a line number annotation in Julia's AST (abstract syntax tree).
+These nodes are used to track source locations for debugging and error reporting.
+
+# Fields
+- `line::Int`: The line number.
+- `file::Union{Symbol,Nothing}`: The source file name, or `nothing` if unknown.
+
+# Examples
+```jldoctest
+julia> ln = LineNumberNode(42, :myfile)
+:(#= myfile:42 =#)
+
+julia> ln.line
+42
+
+julia> ln.file
+:myfile
+```
+"""
+Core.LineNumberNode
+
 Base.include(BaseDocs, "intrinsicsdocs.jl")
 
 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -4044,6 +4044,49 @@ A non-exhaustive list of examples of when this is used include:
 """
 ConcurrencyViolationError
 
+"""
+    Core.arrayref(inbounds::Bool, A::Array, i::Int...)
+
+Legacy function to retrieve an element from an `Array` at the given indices. Equivalent
+to `Base.getindex(A, i...)`. The `inbounds` argument is ignored in current Julia versions.
+
+This function exists for backward compatibility. Use `getindex` or indexing syntax
+`A[i...]` instead.
+"""
+Core.arrayref
+
+"""
+    Core.const_arrayref(inbounds::Bool, A::Array, i::Int...)
+
+Legacy function identical to [`Core.arrayref`](@ref), retained for backward compatibility.
+Use `getindex` or indexing syntax `A[i...]` instead.
+"""
+Core.const_arrayref
+
+"""
+    Core.arrayset(inbounds::Bool, A::Array{T}, x, i::Int...) where T
+
+Legacy function to set an element of an `Array` at the given indices. Equivalent
+to `Base.setindex!(A, x, i...)`. The `inbounds` argument is ignored in current
+Julia versions.
+
+This function exists for backward compatibility. Use `setindex!` or indexing syntax
+`A[i...] = x` instead.
+"""
+Core.arrayset
+
+"""
+    Core.arraysize(a::Array)
+    Core.arraysize(a::Array, i::Int)
+
+Legacy function to get the dimensions of an `Array`. Called with one argument, returns
+a tuple of all dimensions. Called with two arguments, returns the size along dimension `i`
+(or 1 if `i` exceeds the number of dimensions).
+
+This function exists for backward compatibility. Use [`size`](@ref) instead.
+"""
+Core.arraysize
+
 Base.include(BaseDocs, "intrinsicsdocs.jl")
 
 end

--- a/base/file.jl
+++ b/base/file.jl
@@ -363,6 +363,19 @@ function checkfor_mv_cp_cptree(src::AbstractString, dst::AbstractString, txt::Ab
     end
 end
 
+"""
+    cptree(src::AbstractString, dst::AbstractString; force::Bool=false, follow_symlinks::Bool=false)
+
+Recursively copy a directory tree from `src` to `dst`. `src` must be an existing directory.
+
+If `force=true`, an existing `dst` will be removed before copying. If
+`follow_symlinks=false` (the default), symbolic links are copied as links; if
+`follow_symlinks=true`, the targets of symbolic links are copied instead.
+
+This is a lower-level function used by [`cp`](@ref) when copying directories.
+
+See also [`cp`](@ref), [`mv`](@ref).
+"""
 function cptree(src::String, dst::String; force::Bool=false,
                                           follow_symlinks::Bool=false)
     isdir(src) || throw(ArgumentError("'$src' is not a directory. Use `cp(src, dst)`"))

--- a/base/file.jl
+++ b/base/file.jl
@@ -1221,6 +1221,17 @@ function _walkdir(chnl, path, topdown, follow_symlinks, onerror)
     nothing
 end
 
+"""
+    unlink(p::AbstractString)
+
+Remove (delete) the file at path `p`. This is a low-level function that directly calls
+the POSIX `unlink` system call via libuv. It only works on files and symbolic links,
+not directories.
+
+Most users should prefer [`rm`](@ref) for removing files and directories.
+
+See also [`rm`](@ref).
+"""
 function unlink(p::AbstractString)
     err = ccall(:jl_fs_unlink, Int32, (Cstring,), p)
     err < 0 && uv_error("unlink($(repr(p)))", err)

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -215,6 +215,16 @@ end
 closewrite(f::File) = nothing
 
 # sendfile is the most efficient way to copy from a file descriptor
+"""
+    sendfile(dst::File, src::File, src_offset::Int64, bytes::Int)
+    sendfile(src::AbstractString, dst::AbstractString)
+
+Efficiently copy data between file descriptors or file paths using the OS-level
+`sendfile` mechanism when available. In the two-argument path form, copies the entire
+file from `src` to `dst`, preserving the file mode.
+
+This is used internally by [`cp`](@ref) for efficient file copying.
+"""
 function sendfile(dst::File, src::File, src_offset::Int64, bytes::Int)
     check_open(dst)
     check_open(src)

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -251,6 +251,15 @@ function truncate(f::File, n::Integer)
     return f
 end
 
+"""
+    futime(f::File, atime::Float64, mtime::Float64)
+
+Change the access time (`atime`) and modification time (`mtime`) of an open
+[`File`](@ref Base.Filesystem.File) `f`. Times are in seconds since the Unix epoch
+(1970-01-01 00:00:00 UTC). Returns `f`.
+
+See also [`stat`](@ref) for reading file timestamps.
+"""
 function futime(f::File, atime::Float64, mtime::Float64)
     check_open(f)
     req = Libc.malloc(_sizeof_uv_fs)

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -165,6 +165,18 @@ include(string(Base.BUILDROOT, "file_constants.jl"))  # include($BUILDROOT/base/
 
 abstract type AbstractFile <: IO end
 
+"""
+    Filesystem.File(fd::RawFD)
+    Filesystem.File(fd::OS_HANDLE)
+
+A low-level file handle wrapping an OS-level file descriptor, providing direct access to
+libuv file system operations. Unlike [`IOStream`](@ref), `File` does not perform buffering.
+
+Use [`Filesystem.open`](@ref) to open a file and obtain a `File` handle, then call
+[`read`](@ref), [`write`](@ref), [`seek`](@ref), and [`close`](@ref) as needed.
+
+Most users should prefer [`Base.open`](@ref) and [`IOStream`](@ref) for file I/O.
+"""
 mutable struct File <: AbstractFile
     open::Bool
     handle::OS_HANDLE

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -2,6 +2,17 @@
 
 ## File Operations (Libuv-based) ##
 
+"""
+    Filesystem
+
+Module providing low-level file system operations backed by libuv. This module contains
+the [`File`](@ref Base.Filesystem.File) type for direct file handle manipulation as well as
+file-system constants (e.g. `JL_O_RDONLY`, `S_IRUSR`) used with [`open`](@ref) and other system calls.
+
+Most users should prefer higher-level I/O functions such as [`open`](@ref), [`read`](@ref),
+[`write`](@ref), and file operations in `Base` (e.g. [`cp`](@ref), [`mv`](@ref), [`rm`](@ref))
+rather than using this module directly.
+"""
 module Filesystem
 
 """

--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -1,5 +1,16 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+"""n    Order
+
+Module providing ordering types and functions used by sorting algorithms. This module
+defines the [`Ordering`](@ref Base.Order.Ordering) abstract type and its subtypes
+([`ForwardOrdering`](@ref), [`ReverseOrdering`](@ref), [`By`](@ref Base.Order.By),
+[`Lt`](@ref Base.Order.Lt), [`Perm`](@ref Base.Order.Perm)), as well as the
+[`lt`](@ref Base.Order.lt) comparison function and the [`ord`](@ref Base.Order.ord)
+constructor.
+
+See also [`sort`](@ref), [`sort!`](@ref).
+"""
 module Order
 
 
@@ -28,6 +39,14 @@ Use [`Base.Order.lt`](@ref) to compare two elements according to the ordering.
 """
 abstract type Ordering end
 
+"""
+    ForwardOrdering <: Ordering
+
+A singleton ordering type that compares elements using [`isless`](@ref), which is the
+default ordering in Julia. The singleton instance is [`Base.Order.Forward`](@ref).
+
+See also [`ReverseOrdering`](@ref), [`DirectOrdering`](@ref).
+"""
 struct ForwardOrdering <: Ordering end
 
 """
@@ -55,6 +74,15 @@ reverses ordering specified by `o`.
 """
 reverse(o::Ordering) = ReverseOrdering(o)
 
+"""
+    DirectOrdering
+
+Type alias for `Union{ForwardOrdering, ReverseOrdering{ForwardOrdering}}`, i.e. orderings
+that compare elements directly using [`isless`](@ref) (either in forward or reverse order)
+without applying any transformation.
+
+See also [`ForwardOrdering`](@ref), [`ReverseOrdering`](@ref).
+"""
 const DirectOrdering = Union{ForwardOrdering,ReverseOrdering{ForwardOrdering}}
 
 """
@@ -167,6 +195,17 @@ end
 # The following clause means `if VERSION < v"2.0-"` but it also works during
 # bootstrap. For the same reason, we need to write `Int32` instead of `Cint`.
 if ccall(:jl_ver_major, Int32, ()) < 2
+    """
+        ordtype(o::Ordering, vs::AbstractArray)
+
+    Return the type of elements that would be compared by the ordering `o` when
+    sorting the array `vs`. For a plain `Ordering`, this is `eltype(vs)`. For
+    [`By`](@ref Base.Order.By) orderings it attempts to determine the return type
+    of the transformation function.
+
+    !!! compat "Julia 1.x"
+        This function is deprecated and may be removed in Julia 2.0.
+    """
     ordtype(o::ReverseOrdering, vs::AbstractArray) = ordtype(o.fwd, vs)
     ordtype(o::Perm,            vs::AbstractArray) = ordtype(o.order, o.data)
     # TODO: here, we really want the return type of o.by, without calling it

--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -1,5 +1,17 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+"""
+    ScopedValues
+
+Module providing dynamically-scoped values. A [`ScopedValue`](@ref) allows you to
+associate a value with a dynamic scope, so that code within that scope (and any code
+it calls) can read the value, without the need to pass it as a function argument.
+
+See [`ScopedValue`](@ref), [`with`](@ref), [`@with`](@ref).
+
+!!! compat "Julia 1.11"
+    Scoped values were introduced in Julia 1.11.
+"""
 module ScopedValues
 
 export ScopedValue, LazyScopedValue, with, @with, ScopedThunk

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1,5 +1,15 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+"""
+    Sort
+
+Module providing sorting algorithms and related functions. Contains the
+implementation of [`sort`](@ref), [`sort!`](@ref), [`sortperm`](@ref),
+[`issorted`](@ref), and related functions, as well as the sorting algorithm
+types ([`InsertionSort`](@ref), [`QuickSort`](@ref), [`MergeSort`](@ref), etc.).
+
+See also [`Base.Order`](@ref).
+"""
 module Sort
 
 using Base.Order
@@ -43,6 +53,15 @@ export # not exported by Base
     SMALL_ALGORITHM,
     SMALL_THRESHOLD
 
+"""
+    Algorithm
+
+Abstract supertype for all sorting algorithms. Concrete subtypes are used to select
+a sorting strategy when calling [`sort!`](@ref) with the `alg` keyword argument.
+
+Built-in algorithm types include [`InsertionSort`](@ref), [`QuickSort`](@ref),
+[`MergeSort`](@ref), and [`PartialQuickSort`](@ref).
+"""
 abstract type Algorithm end
 
 ## functions requiring only ordering ##
@@ -1594,6 +1613,15 @@ const _DEFAULT_ALGORITHMS_FOR_VECTORS = InitialOptimizations(
 _sort!(v::AbstractVector, ::Union{DefaultStable, DefaultUnstable}, o::Ordering, kw) =
     _sort!(v, _DEFAULT_ALGORITHMS_FOR_VECTORS, o, kw)
 
+"""
+    SMALL_THRESHOLD
+
+The maximum number of elements for which a sorting algorithm is considered
+"small" and may switch to a specialized small-array sorting strategy. Currently
+set to `$SMALL_THRESHOLD`.
+
+See also [`SMALL_ALGORITHM`](@ref).
+"""
 const SMALL_THRESHOLD  = 20
 
 function Base.show(io::IO, alg::Algorithm)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -166,6 +166,19 @@ function uv_status_string(x)
     return "invalid status"
 end
 
+"""
+    PipeEndpoint()
+    PipeEndpoint(fd::RawFD)
+
+A named pipe endpoint, implemented using libuv. `PipeEndpoint` provides a bidirectional
+byte-stream I/O object that can be used for inter-process communication.
+
+A `PipeEndpoint` can be created standalone (e.g. for connecting to a named pipe) or
+obtained from the `stdin`, `stdout`, or `stderr` fields of a [`Process`](@ref) launched
+with I/O redirection.
+
+See also [`PipeServer`], [`open_pipe!`].
+"""
 mutable struct PipeEndpoint <: LibuvStream
     handle::Ptr{Cvoid}
     status::Int

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1507,6 +1507,31 @@ function peek(s::LibuvStream, ::Type{T}) where T
 end
 
 # BufferStream's are non-OS streams, backed by a regular IOBuffer
+"""
+    BufferStream()
+
+An in-memory I/O stream backed by an [`IOBuffer`](@ref), implementing the
+[`LibuvStream`] interface. Unlike `IOBuffer`, a `BufferStream` supports blocking
+[`read`](@ref) operations that wait until data becomes available.
+
+`BufferStream` is useful as a pipe-like stream to connect producers and consumers
+of data within a single process. Writing to a `BufferStream` notifies any blocked
+readers that data is available, and closing the stream signals end-of-file.
+
+# Examples
+```jldoctest
+julia> bs = BufferStream();
+
+julia> write(bs, "hello");
+
+julia> close(bs);
+
+julia> String(read(bs))
+"hello"
+```
+
+See also [`IOBuffer`](@ref), [`PipeBuffer`](@ref).
+"""
 mutable struct BufferStream <: LibuvStream
     buffer::IOBuffer
     cond::Threads.Condition

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -12,6 +12,15 @@ end
 
 
 ## types ##
+"""
+    IOServer
+
+Abstract type for server-side I/O objects that listen for and accept incoming connections.
+Subtypes include [`LibuvServer`], and concrete implementations such as
+[`Sockets.TCPServer`] and [`PipeServer`].
+
+See also [`listen`](@ref), [`accept`](@ref).
+"""
 abstract type IOServer end
 """
     LibuvServer

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -209,6 +209,17 @@ if OS_HANDLE != RawFD
 end
 
 
+"""
+    TTY(fd::RawFD)
+    TTY(fd::OS_HANDLE)
+
+A stream type representing a terminal (tty) device, implemented using libuv. `TTY`
+objects are typically obtained from the global `stdin`, `stdout`, and `stderr` streams
+when Julia is run in an interactive terminal, but can also be constructed from a raw
+file descriptor.
+
+See also [`PipeEndpoint`](@ref), [`IOStream`](@ref).
+"""
 mutable struct TTY <: LibuvStream
     handle::Ptr{Cvoid}
     status::Int

--- a/base/task.jl
+++ b/base/task.jl
@@ -5,6 +5,20 @@
 Core.Task(@nospecialize(f), reserved_stack::Int=0) = Core._Task(f, reserved_stack, ThreadSynchronizer())
 
 # Container for a captured exception and its backtrace. Can be serialized.
+"""
+    CapturedException(ex, bt) <: Exception
+
+An exception type that wraps another exception `ex` together with a processed backtrace,
+making it safe to serialize and transport across processes. This is commonly used when
+an exception is caught in one context (such as a remote worker or async task) and needs
+to be rethrown or displayed elsewhere.
+
+# Fields
+- `ex`: The original exception.
+- `processed_bt::Vector{Any}`: The processed (serializable) backtrace.
+
+See also [`CompositeException`](@ref), [`TaskFailedException`](@ref).
+"""
 struct CapturedException <: Exception
     ex::Any
     processed_bt::Vector{Any}

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -1,3 +1,17 @@
+"""
+    Profile.Allocs
+
+Module for allocation profiling. Records allocation events with their types,
+sizes, and stack traces, allowing you to identify where memory is being allocated.
+
+Use [`Profile.Allocs.@profile`](@ref) to record allocations, [`Profile.Allocs.fetch`](@ref)
+to retrieve the results, and [`Profile.Allocs.clear`](@ref) to reset.
+
+!!! compat "Julia 1.8"
+    Allocation profiling was introduced in Julia 1.8.
+
+See also [`Profile`](@ref).
+"""
 module Allocs
 
 global print # Allocs.print is separate from both Base.print and Profile.print

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -437,7 +437,6 @@ include("allocs.jl")
 
 @testset "Docstrings" begin
     undoc = Docs.undocumented_names(Profile)
-    @test_broken isempty(undoc)
-    @test undoc == [:Allocs]
+    @test isempty(undoc)
 end
 include("heapsnapshot_reassemble.jl")

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -15,8 +15,24 @@ using Core.IR
 
 export serialize, deserialize, AbstractSerializer, Serializer
 
+"""
+    AbstractSerializer
+
+Abstract supertype for serializers. Subtypes should implement the serialization protocol
+to support [`serialize`](@ref) and [`deserialize`](@ref) operations. The built-in
+concrete implementation is [`Serializer`](@ref).
+"""
 abstract type AbstractSerializer end
 
+"""
+    Serializer{I<:IO}(io::IO)
+
+The default serializer implementation that reads from and writes to an `IO` stream.
+`Serializer` maintains internal state for tracking object references, enabling
+correct serialization of shared and circular data structures.
+
+See also [`serialize`](@ref), [`deserialize`](@ref), [`AbstractSerializer`](@ref).
+"""
 mutable struct Serializer{I<:IO} <: AbstractSerializer
     io::I
     counter::Int

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -661,8 +661,7 @@ end
 
 @testset "Docstrings" begin
     undoc = Docs.undocumented_names(Serialization)
-    @test_broken isempty(undoc)
-    @test undoc == [:AbstractSerializer, :Serializer]
+    @test isempty(undoc)
 end
 
 # test method definitions from v1.11

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1208,8 +1208,7 @@ f51129(v, x) = (1 .- (v ./ x) .^ 2)
 
 @testset "Docstrings" begin
     undoc = Docs.undocumented_names(Broadcast)
-    @test_broken isempty(undoc)
-    @test undoc == [:dotview]
+    @test isempty(undoc)
 end
 
 @testset "broadcast for `AbstractArray` without `CartesianIndex` support" begin

--- a/test/filesystem.jl
+++ b/test/filesystem.jl
@@ -43,8 +43,7 @@ end
 
 @testset "Base.Filesystem docstrings" begin
     undoc = Docs.undocumented_names(Base.Filesystem)
-    @test_broken isempty(undoc)
-    @test undoc == [:File, :Filesystem, :cptree, :futime, :sendfile, :unlink]
+    @test isempty(undoc)
 end
 
 @testset "write return type" begin

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1623,8 +1623,7 @@ end
 
 @testset "Base docstrings" begin
     undoc = Docs.undocumented_names(Base)
-    @test_broken isempty(undoc)
-    @test isempty(setdiff(undoc, [:BufferStream, :CanonicalIndexError, :CapturedException, :Filesystem, :IOServer, :InvalidStateException, :Order, :PipeEndpoint, :ScopedValues, :Sort, :TTY, :AtomicMemoryRef, :Exception, :GenericMemoryRef, :GlobalRef, :IO, :LineNumberNode, :MemoryRef, :Method, :SegmentationFault, :TypeVar, :arrayref, :arrayset, :arraysize, :const_arrayref]))
+    @test isempty(undoc)
 end
 
 exported_names(m) = filter(s -> Base.isexported(m, s), names(m))

--- a/test/ordering.jl
+++ b/test/ordering.jl
@@ -54,6 +54,5 @@ struct SomeOtherOrder <: Base.Order.Ordering end
 
 @testset "Base.Order docstrings" begin
     undoc = Docs.undocumented_names(Base.Order)
-    @test_broken isempty(undoc)
-    @test undoc == [:DirectOrdering, :ForwardOrdering, :Order, :ordtype]
+    @test isempty(undoc)
 end

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -11,8 +11,7 @@ using .Main.OffsetArrays
 
 @testset "Base.Sort docstrings" begin
     undoc = Docs.undocumented_names(Base.Sort)
-    @test_broken isempty(undoc)
-    @test undoc == [:Algorithm, :SMALL_THRESHOLD, :Sort]
+    @test isempty(undoc)
 end
 
 @testset "Order" begin


### PR DESCRIPTION
## Add missing docstrings for public/exported symbols

This PR adds docstrings for public and exported symbols that were previously undocumented, as tracked in #52725.

This PR was written with the assistance of generative AI (GitHub Copilot / Claude).

### Summary of changes

| Symbol | Module | File | Description |
|--------|--------|------|-------------|
| `Exception` | `Core` | `base/docs/basedocs.jl` | Abstract supertype of all exceptions |
| `IO` | `Core` | `base/docs/basedocs.jl` | Abstract type for all I/O streams |
| `TypeVar` | `Core` | `base/docs/basedocs.jl` | Representation of a type variable (e.g. `T` in `Vector{T}`) |
| `GlobalRef` | `Core` | `base/docs/basedocs.jl` | Reference to a global variable in a specific module (IR) |
| `LineNumberNode` | `Core` | `base/docs/basedocs.jl` | AST node representing source location information |
| `Method` | `Core` | `base/docs/basedocs.jl` | Method table entry for a specific method definition |
| `SegmentationFault` | `Core` | `base/docs/basedocs.jl` | Exception thrown on SIGSEGV/SIGBUS signals |
| `GenericMemoryRef` | `Core` | `base/docs/basedocs.jl` | Parametric reference type for `GenericMemory` elements |
| `MemoryRef` | `Core` | `base/docs/basedocs.jl` | Alias for `GenericMemoryRef{:not_atomic, T}` |
| `AtomicMemoryRef` | `Core` | `base/docs/basedocs.jl` | Alias for `GenericMemoryRef{:monotonic, T}` |
| `arrayref` | `Core` | `base/docs/basedocs.jl` | Legacy array element access function |
| `const_arrayref` | `Core` | `base/docs/basedocs.jl` | Legacy constant array element access function |
| `arrayset` | `Core` | `base/docs/basedocs.jl` | Legacy array element assignment function |
| `arraysize` | `Core` | `base/docs/basedocs.jl` | Legacy array size query function |
| `BufferStream` | `Base` | `base/stream.jl` | In-memory synchronous I/O buffer acting as a blocking stream |
| `IOServer` | `Base` | `base/stream.jl` | Abstract type for server-side I/O endpoints |
| `PipeEndpoint` | `Base` | `base/stream.jl` | libuv named pipe / IPC endpoint |
| `TTY` | `Base` | `base/stream.jl` | Terminal device I/O stream |
| `CanonicalIndexError` | `Base` | `base/abstractarray.jl` | Error for infinite recursion during custom array indexing |
| `CapturedException` | `Base` | `base/task.jl` | Wrapper holding an exception and its backtrace for rethrowing |
| `InvalidStateException` | `Base` | `base/channels.jl` | Error for operations on objects in an invalid state |
| `dotview` | `Base.Broadcast` | `base/broadcast.jl` | Customize the left-hand side view in fused `.=` broadcast |
| `@var` | `Base.Docs` | `base/docs/Docs.jl` | Refer to a binding (variable/constant) rather than its value in docs |
| `Filesystem` | `Base.Filesystem` | `base/filesystem.jl` | Module for low-level filesystem operations |
| `Filesystem.File` | `Base.Filesystem` | `base/filesystem.jl` | Low-level libuv file handle |
| `futime` | `Base.Filesystem` | `base/filesystem.jl` | Set access/modification times on an open file descriptor |
| `sendfile` | `Base.Filesystem` | `base/filesystem.jl` | OS-level zero-copy file transfer |
| `cptree` | `Base.Filesystem` | `base/file.jl` | Recursively copy a directory tree |
| `unlink` | `Base.Filesystem` | `base/file.jl` | POSIX file removal |
| `Order` | `Base.Order` | `base/ordering.jl` | Module defining ordering types for sorting |
| `ForwardOrdering` | `Base.Order` | `base/ordering.jl` | Singleton type for default ascending sort order |
| `DirectOrdering` | `Base.Order` | `base/ordering.jl` | Union type of `ForwardOrdering` and `ReverseOrdering{ForwardOrdering}` |
| `ordtype` | `Base.Order` | `base/ordering.jl` | Infer the return element type for ordering comparisons |
| `Sort` | `Base.Sort` | `base/sort.jl` | Module providing sorting algorithms and related utilities |
| `Algorithm` | `Base.Sort` | `base/sort.jl` | Abstract supertype for sorting algorithms |
| `SMALL_THRESHOLD` | `Base.Sort` | `base/sort.jl` | Threshold below which insertion sort is used |
| `ScopedValues` | `Base.ScopedValues` | `base/scopedvalues.jl` | Module for dynamically-scoped values |
| `AbstractSerializer` | `Serialization` | `stdlib/Serialization/src/Serialization.jl` | Abstract type for Julia serialization backends |
| `Serializer` | `Serialization` | `stdlib/Serialization/src/Serialization.jl` | Default `IO`-backed serialization implementation |
| `Allocs` | `Profile.Allocs` | `stdlib/Profile/src/Allocs.jl` | Submodule for memory allocation profiling |

### Files changed

- `base/docs/basedocs.jl` — Core type docstrings (+217 lines)
- `base/stream.jl` — `BufferStream`, `IOServer`, `PipeEndpoint`, `TTY` (+58 lines)
- `base/filesystem.jl` — `Filesystem` module, `File`, `futime`, `sendfile` (+42 lines)
- `base/ordering.jl` — `Order` module, `ForwardOrdering`, `DirectOrdering`, `ordtype` (+39 lines)
- `base/sort.jl` — `Sort` module, `Algorithm`, `SMALL_THRESHOLD` (+28 lines)
- `base/file.jl` — `cptree`, `unlink` (+24 lines)
- `base/docs/Docs.jl` — `@var` macro (+20 lines)
- `base/channels.jl` — `InvalidStateException` (+11 lines)
- `base/task.jl` — `CapturedException` (+14 lines)
- `base/broadcast.jl` — `dotview` (+12 lines)
- `base/abstractarray.jl` — `CanonicalIndexError` (+12 lines)
- `base/scopedvalues.jl` — `ScopedValues` module (+12 lines)
- `stdlib/Serialization/src/Serialization.jl` — `AbstractSerializer`, `Serializer` (+16 lines)
- `stdlib/Profile/src/Allocs.jl` — `Profile.Allocs` module (+14 lines)

Closes #52725 (partially — out-of-tree packages like REPL, Pkg, Distributed, StyledStrings are not addressed here).
