### PR TITLE
`jl_static_show`: don't recurse on CodeInstance edges

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1399,6 +1399,9 @@ function show(io::IO, codeinst::Core.CodeInstance)
     else
         show_mi(io, def::MethodInstance)
     end
+    if codeinst.owner !== nothing
+        print(io, " (foreign)")
+    end
 end
 
 function show_mi(io::IO, mi::Core.MethodInstance, from_stackframe::Bool=false)

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -921,6 +921,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         n += jl_static_show_func_sig(out, m->sig);
     }
     else if (vt == jl_method_instance_type) {
+        n += jl_printf(out, "MethodInstance ");
         jl_method_instance_t *li = (jl_method_instance_t*)v;
         if (jl_is_method(li->def.method)) {
             n += jl_static_show_func_sig(out, li->specTypes);
@@ -932,6 +933,24 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
             n += jl_printf(out, ".<toplevel thunk> -> ");
             n += jl_static_show_x(out, jl_atomic_load_relaxed(&jl_cached_uninferred(
                 jl_atomic_load_relaxed(&li->cache), 1)->inferred), depth, ctx);
+        }
+    }
+    else if (vt == jl_code_instance_type && ctx.verbosity < JL_STATIC_SHOW_VERBOSITY_FULL) {
+        jl_code_instance_t *ci = (jl_code_instance_t*)v;
+        n += jl_printf(
+            out, "CodeInstance(min_world=0x%zx, max_world=0x%zx) for ",
+            jl_atomic_load_relaxed(&ci->min_world),
+            jl_atomic_load_relaxed(&ci->max_world));
+        if (jl_is_method_instance(ci->def)) {
+            n += jl_static_show_x(out, ci->def, depth, ctx);
+        }
+        else if (jl_is_abioverride(ci->def)) {
+            jl_abi_override_t* def = (jl_abi_override_t*)ci->def;
+            n += jl_static_show_x(out, (jl_value_t*)def->def, depth, ctx);
+            n += jl_printf(out, " (ABI overridden)");
+        }
+        if (ci->owner != jl_nothing) {
+            n += jl_printf(out, " (foreign)");
         }
     }
     else if (vt == jl_typename_type) {

--- a/test/show.jl
+++ b/test/show.jl
@@ -1648,6 +1648,24 @@ end
 # Test that static show prints something reasonable for `<:Function` types
 @test static_shown(:) == "Base.Colon()"
 
+# Test basic CodeInstance, MethodInstance printing in jl_static_show
+f_test_static_show_mi_ci() = nothing
+let
+    f = f_test_static_show_mi_ci
+    m = first(methods(f, Tuple{}))
+    mi = Base.specialize_method(m, Tuple{typeof(f)}, Core.svec())
+    Base.return_types(f, Tuple{}) # populate .cache
+    @test mi.cache isa Core.CodeInstance
+    ci = mi.cache
+
+    mi_s = static_shown(mi)
+    ci_s = static_shown(ci)
+    @test occursin("MethodInstance", mi_s)
+    @test occursin("CodeInstance", ci_s)
+    @test occursin("f_test_static_show_mi_ci", mi_s)
+    @test occursin("f_test_static_show_mi_ci", ci_s)
+end
+
 # Test @show
 let fname = tempname()
     try


### PR DESCRIPTION
Before:
```
julia> mi = Base.method_instance(Tuple{typeof(Base.push!), Vector{Int}, Int});

julia> @ccall jl_(mi::Any)::Int;
push!(Array{Int64, 1}, Int64) from push!(Array{T, 1}, Any) where {T}

julia> @ccall jl_(mi.cache::Any)::Int
Core.CodeInstance(...... # stack overflow
```

After:
```
julia> @ccall jl_(mi::Any)::Int;
MethodInstance push!(Array{Int64, 1}, Int64) from push!(Array{T, 1}, Any) where {T}

julia> @ccall jl_(mi.cache::Any)::Int;
CodeInstance(min_world=0x1166, max_world=0xffffffffffffffff) for MethodInstance push!(Array{Int64, 1}, Int64) from push!(Array{T, 1}, Any) where {T}
```

Also tweaks MethodInstance printing slightly just to say MethodInstance.