### PR TITLE
REPL precompilation on Windows, fix warning due to double-deletion of temp files

### DIFF
--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -96,7 +96,7 @@ function repl_workload()
     println("done")
     """
 
-    tmphistfile = tempname()
+    tmphistfile = tempname(; cleanup = false)
     write(tmphistfile, """
     # time: 2020-10-31 13:16:39 AWST
     # mode: julia


### PR DESCRIPTION
These warnings have been occuring on Windows builds:

<img width="855" height="314" alt="image" src="https://github.com/user-attachments/assets/2077c452-2ab8-4ed9-a158-2640d2d8f5e8" />

It's because a temp file is created and registered for automatic cleanup, but the file is explicitly deleted. I've undone the automatic cleanup in favor of the explicit deletion, but could go the other way. Both fix the issue.