### PR TITLE
CI: Add concurrency group to LabelCheck

### DIFF
--- a/.github/workflows/LabelCheck.yml
+++ b/.github/workflows/LabelCheck.yml
@@ -5,6 +5,9 @@ permissions:
 on:
   pull_request:
     types: [labeled, unlabeled, opened, reopened, edited, synchronize]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 jobs:
   enforce-labels:
     name: Check for blocking labels


### PR DESCRIPTION
Trying to prevent the buggy looking repeat CI runs


<img width="1300" height="275" alt="image" src="https://github.com/user-attachments/assets/7afabda0-6a43-43f5-80c4-c735bdb02f10" />


Note: I tried using `ubuntu-slim` but apparently it doesn't have docker, which this actions requires.