### PR TITLE
extend `dataids` semantics, with the goal of obviating non-generic methods of `mightalias`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1649,7 +1649,7 @@ function _isdisjoint_dataids(as::Tuple{Vararg{DataID}}, bs::Tuple{Vararg{DataID}
     _isdisjoint_dataids(t, bs)
 end
 
-function _canonicalize_dataid(x)
+function _canonicalize_dataid(x; read_write_status::Union{IsReadOnly, IsReadWrite} = IsReadWrite())
     let y
         if x isa UInt
             y = DataID{Core.CPU}(; owner = x)
@@ -1658,6 +1658,11 @@ function _canonicalize_dataid(x)
         end
         y
     end
+end
+
+function _canonicalize_dataid_as_readonly(x)
+    read_write_status = IsReadOnly()
+    _canonicalize_dataid(x; read_write_status)
 end
 
 function _isdisjoint(a::Tuple, b::Tuple)

--- a/base/range.jl
+++ b/base/range.jl
@@ -1184,6 +1184,11 @@ union(r::OneTo, s::OneTo) = OneTo(max(r.stop,s.stop))
 
 intersect(r::AbstractUnitRange{<:Integer}, s::AbstractUnitRange{<:Integer}) = max(first(r),first(s)):min(last(r),last(s))
 
+function isdisjoint(r::AbstractUnitRange{T}, s::AbstractUnitRange{T}) where {T <: Integer}
+    p = intersect(r, s)
+    isempty(p)
+end
+
 intersect(i::Integer, r::AbstractUnitRange{<:Integer}) = range(max(i, first(r)), length=in(i, r))
 
 intersect(r::AbstractUnitRange{<:Integer}, i::Integer) = intersect(i, r)

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -261,11 +261,6 @@ elsize(::Type{<:ReshapedArray{<:Any,<:Any,P}}) where {P} = elsize(P)
 
 unaliascopy(A::ReshapedArray) = typeof(A)(unaliascopy(A.parent), A.dims, A.mi)
 dataids(A::ReshapedArray) = dataids(A.parent)
-# forward the aliasing check the parent in case there are specializations
-mightalias(A::ReshapedArray, B::ReshapedArray) = mightalias(parent(A), parent(B))
-# special handling for reshaped SubArrays that dispatches to the subarray aliasing check
-mightalias(A::ReshapedArray, B::SubArray) = mightalias(parent(A), B)
-mightalias(A::SubArray, B::ReshapedArray) = mightalias(A, parent(B))
 
 @inline ind2sub_rs(ax, ::Tuple{}, i::Int) = (i,)
 @inline ind2sub_rs(ax, szs, i) = _ind2sub_rs(ax, szs, i - 1)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -104,7 +104,12 @@ function parentindices end
 parentindices(a::AbstractArray) = map(oneto, size(a))
 
 ## Aliasing detection
-dataids(A::SubArray) = (dataids(A.parent)..., _splatmap(dataids, A.indices)...)
+function dataids(A::SubArray)
+    read_write_dataids = dataids(A.parent)
+    read_only_dataids_1 = _splatmap(dataids, A.indices)
+    read_only_dataids_2 = map(_canonicalize_dataid_as_readonly, read_only_dataids_1)
+    (read_write_dataids..., read_only_dataids_2...)
+end
 _splatmap(f, ::Tuple{}) = ()
 _splatmap(f, t::Tuple) = (f(t[1])..., _splatmap(f, tail(t))...)
 unaliascopy(A::SubArray) = typeof(A)(unaliascopy(A.parent), map(unaliascopy, A.indices), A.offset1, A.stride1)


### PR DESCRIPTION
* Very WIP.

* There are multiple issues with the aliasing detection machinery. This PR only attempts to make `dataids` more expressive, to make special methods of `mightalias` unnecessary. It attempts complete backwards compatibility, even though `dataids` is not public API yet. Other PRs might follow, for example to replace the current unsafe defaults of `dataids` or `mightalias` with something safer and more consistent.

* Some issues to cross-reference:

    * https://github.com/JuliaLang/julia/issues/8087

    * https://github.com/JuliaLang/julia/issues/26865

    * Not directly relevant, perhaps for a future PR: https://github.com/JuliaLang/julia/issues/50820

    * https://github.com/JuliaLang/julia/issues/51753