### PR TITLE
[jitlayers] add missing JD parameter to remaining external API call

### DIFF
--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -148,13 +148,13 @@ JL_DLLEXPORT void* JLJITGetLLVMOrcExecutionSession_fallback(void* JIT) UNAVAILAB
 
 JL_DLLEXPORT void* JLJITGetJuliaOJIT_fallback(void) UNAVAILABLE
 
-JL_DLLEXPORT void* JLJITGetExternalJITDylib_fallback(void* JIT) UNAVAILABLE
+JL_DLLEXPORT void* JLJITCreateJITDylib_fallback(void* JIT, const char *Name) UNAVAILABLE
 
 JL_DLLEXPORT void* JLJITAddObjectFile_fallback(void* JIT, void* JD, void* ObjBuffer) UNAVAILABLE
 
 JL_DLLEXPORT void* JLJITAddLLVMIRModule_fallback(void* JIT, void* JD, void* TSM) UNAVAILABLE
 
-JL_DLLEXPORT void* JLJITLookup_fallback(void* JIT, void* Result, const char *Name) UNAVAILABLE
+JL_DLLEXPORT void* JLJITJDLookup_fallback(void* JIT, void* JD, void* Result, const char *Name, int ExternalJDOnly) UNAVAILABLE
 
 JL_DLLEXPORT void* JLJITMangleAndIntern_fallback(void* JIT, const char *Name) UNAVAILABLE
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1703,9 +1703,9 @@ JuliaOJIT::JuliaOJIT()
   : TM(createTargetMachine()),
     DL(jl_create_datalayout(*TM)),
     ES(cantFail(orc::SelfExecutorProcessControl::Create(nullptr, std::make_unique<::JuliaTaskDispatcher>()))),
+    SessionJD(ES.createBareJITDylib("JuliaSession")),
     GlobalJD(ES.createBareJITDylib("JuliaGlobals")),
     JD(ES.createBareJITDylib("JuliaOJIT")),
-    ExternalJD(ES.createBareJITDylib("JuliaExternal")),
     DLSymOpt(std::make_unique<DLSymOptimizer>(false)),
     MemMgr(createJITLinkMemoryManager()),
     ObjectLayer(ES, *MemMgr),
@@ -1740,39 +1740,43 @@ JuliaOJIT::JuliaOJIT()
     ObjectLayer.addPlugin(DebuginfoPlugin);
     ObjectLayer.addPlugin(std::make_unique<JLMemoryUsagePlugin>(&jit_bytes_size));
 
-    std::string ErrorStr;
-
+    SetVector<void*> libhandles;
     // Make sure that libjulia-internal is loaded and placed first in the
     // DynamicLibrary order so that calls to runtime intrinsics are resolved
     // to the correct library when multiple libjulia-*'s have been loaded
     // (e.g. when we `ccall` into a PackageCompiler.jl-created shared library)
-    sys::DynamicLibrary libjulia_internal_dylib = sys::DynamicLibrary::addPermanentLibrary(
-      jl_libjulia_internal_handle, &ErrorStr);
-    if(!ErrorStr.empty())
-        report_fatal_error(llvm::Twine("FATAL: unable to dlopen libjulia-internal\n") + ErrorStr);
-
+    libhandles.insert(jl_libjulia_internal_handle);
+    libhandles.insert(jl_libjulia_handle);
     // Make sure SectionMemoryManager::getSymbolAddressInProcess can resolve
     // symbols in the program as well. The nullptr argument to the function
-    // tells DynamicLibrary to load the program, not a library.
-    if (sys::DynamicLibrary::LoadLibraryPermanently(nullptr, &ErrorStr))
-        report_fatal_error(llvm::Twine("FATAL: unable to dlopen self\n") + ErrorStr);
-
-    GlobalJD.addGenerator(
-      std::make_unique<orc::DynamicLibrarySearchGenerator>(
-        libjulia_internal_dylib,
-        DL.getGlobalPrefix(),
-        orc::DynamicLibrarySearchGenerator::SymbolPredicate()));
-
-#if defined(_COMPILER_GCC_) && __GNUC__ < 14
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+    // tells DynamicLibrary to load the program); not a library.
+    libhandles.insert(jl_exe_handle);
+#ifdef _OS_WINDOWS_
+    // Find where compiler symbols (assumed by LLVM) are linked from
+    // by looking for an exported data symbol, or by typical name.
+    // libgcc_s_seh-1 doesn't export any data, so we have to hard-code a name.
+    // libwinpthreads-1 exports a single symbol: the pthread_key_dest table.
+    libhandles.insert(jl_dlopen("libgcc_s_seh-1.dll", JL_RTLD_NOLOAD));
+    libhandles.insert(jl_find_dynamic_library_by_addr((void*)&_pthread_key_dest, /* throw_err */ 1, 0));
+    // Add system C libraries explicitly too.
+    // Unlike posix, these aren't automatically handled by recursive search from libjulia-internal.
+    libhandles.insert(jl_ntdll_handle);
+    libhandles.insert(jl_kernel32_handle);
+    libhandles.insert(jl_crtdll_handle);
+    libhandles.insert(jl_winsock_handle);
 #endif
-    GlobalJD.addGenerator(
-      cantFail(orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(
-        DL.getGlobalPrefix())));
-#if defined(_COMPILER_GCC_) && __GNUC__ < 14
-#pragma GCC diagnostic pop
-#endif
+    for (void *h : libhandles) {
+        if (h == nullptr)
+            continue;
+        std::string ErrorStr;
+        sys::DynamicLibrary dylib = sys::DynamicLibrary::addPermanentLibrary(h, &ErrorStr);
+        if (!ErrorStr.empty())
+            report_fatal_error(llvm::Twine("FATAL: unable to dlopen libjulia dependency\n") + ErrorStr);
+        GlobalJD.addGenerator(
+            std::make_unique<orc::DynamicLibrarySearchGenerator>(
+            dylib,
+            DL.getGlobalPrefix()));
+    }
 
     // Resolve non-lock free atomic functions in the libatomic1 library.
     // This is the library that provides support for c11/c++11 atomic operations.
@@ -1783,21 +1787,26 @@ JuliaOJIT::JuliaOJIT()
     if (libatomic) {
         static void *atomic_hdl = jl_load_dynamic_library(libatomic, JL_RTLD_LOCAL, 0);
         if (atomic_hdl != NULL) {
+            std::string ErrorStr;
+            sys::DynamicLibrary dylib = sys::DynamicLibrary::addPermanentLibrary(atomic_hdl, &ErrorStr);
+            if (!ErrorStr.empty())
+                report_fatal_error(llvm::Twine("FATAL: unable to dlopen libjulia dependency\n") + ErrorStr);
             GlobalJD.addGenerator(
-              cantFail(orc::DynamicLibrarySearchGenerator::Load(
-                  libatomic,
+              std::make_unique<orc::DynamicLibrarySearchGenerator>(
+                  dylib,
                   DL.getGlobalPrefix(),
                   [&](const orc::SymbolStringPtr &S) {
                         const char *const atomic_prefix = "__atomic_";
                         return (*S).starts_with(atomic_prefix);
-                  })));
+                  }));
         }
     }
 
     JD.addToLinkOrder(GlobalJD, orc::JITDylibLookupFlags::MatchExportedSymbolsOnly);
-    JD.addToLinkOrder(ExternalJD, orc::JITDylibLookupFlags::MatchExportedSymbolsOnly);
-    ExternalJD.addToLinkOrder(GlobalJD, orc::JITDylibLookupFlags::MatchExportedSymbolsOnly);
-    ExternalJD.addToLinkOrder(JD, orc::JITDylibLookupFlags::MatchExportedSymbolsOnly);
+#if defined(_OS_WINDOWS_)
+    // TODO: why does Windows CI hang without this?
+    JD.addToLinkOrder(SessionJD, orc::JITDylibLookupFlags::MatchExportedSymbolsOnly);
+#endif
 
     orc::SymbolAliasMap jl_crt = {
         // Float16 conversion routines
@@ -1863,6 +1872,17 @@ JuliaOJIT::JuliaOJIT()
     cantFail(JD.define(orc::absoluteSymbols(asan_crt)));
 #endif
 
+#if defined(_COMPILER_GCC_) && __GNUC__ < 14
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    SessionJD.addGenerator(
+      cantFail(orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(
+        DL.getGlobalPrefix())));
+#if defined(_COMPILER_GCC_) && __GNUC__ < 14
+#pragma GCC diagnostic pop
+#endif
+
     if (jl_is_timing_trace) {
         PrintLLVMTimers.push_back([]() JL_NOTSAFEPOINT {
             if (timeTraceProfilerEnabled()) {
@@ -1925,6 +1945,16 @@ void JuliaOJIT::addOutput(jl_emitted_output_t O)
     check(JD.define(MU, JD.getDefaultResourceTracker()));
 }
 
+orc::JITDylib& JuliaOJIT::createJITDylib(StringRef NamePrefix)
+{
+    // Create a new JITDylib with unique name
+    std::string dylib_name = (NamePrefix + "_" + Twine(jl_atomic_fetch_add_relaxed(&jitcounter, 1))).str();
+    JITDylib &NewJD = ES.createBareJITDylib(dylib_name);
+    NewJD.addToLinkOrder(GlobalJD, orc::JITDylibLookupFlags::MatchExportedSymbolsOnly);
+    NewJD.addToLinkOrder(SessionJD, orc::JITDylibLookupFlags::MatchExportedSymbolsOnly);
+    return NewJD;
+}
+
 Error JuliaOJIT::addExternalModule(orc::JITDylib &JD, orc::ThreadSafeModule TSM, bool ShouldOptimize)
 {
     if (auto Err = TSM.withModuleDo([&](Module &M) JL_NOTSAFEPOINT -> Error {
@@ -1942,6 +1972,7 @@ Error JuliaOJIT::addExternalModule(orc::JITDylib &JD, orc::ThreadSafeModule TSM,
             return Error::success();
         }))
         return Err;
+
     //if (ShouldOptimize)
     //    return OptimizeLayer.add(JD, std::move(TSM));
     return CompileLayer.add(JD.getDefaultResourceTracker(), std::move(TSM));
@@ -1970,30 +2001,17 @@ SmallVector<uint64_t> JuliaOJIT::findSymbols(ArrayRef<StringRef> Names)
     return Addrs;
 }
 
-Expected<ExecutorSymbolDef> JuliaOJIT::findSymbol(StringRef Name, bool ExportedSymbolsOnly)
+Expected<ExecutorSymbolDef> JuliaOJIT::findJDSymbol(JITDylib &JD, StringRef Name, bool ExternalJDOnly)
 {
-    orc::JITDylib* SearchOrders[3] = {&JD, &GlobalJD, &ExternalJD};
-    ArrayRef<orc::JITDylib*> SearchOrder = ArrayRef<orc::JITDylib*>(&SearchOrders[0], ExportedSymbolsOnly ? 3 : 1);
-    auto Sym = ::safelookup(ES, SearchOrder, Name);
-    return Sym;
-}
-
-Expected<ExecutorSymbolDef> JuliaOJIT::findUnmangledSymbol(StringRef Name)
-{
-    return findSymbol(getMangledName(Name), true);
-}
-
-Expected<ExecutorSymbolDef> JuliaOJIT::findExternalJDSymbol(StringRef Name, bool ExternalJDOnly)
-{
-    orc::JITDylib* SearchOrders[3] = {&ExternalJD, &GlobalJD, &JD};
-    ArrayRef<orc::JITDylib*> SearchOrder = ArrayRef<orc::JITDylib*>(&SearchOrders[0], ExternalJDOnly ? 1 : 3);
+    orc::JITDylib *SearchOrders[2] = {&JD, &GlobalJD};
+    ArrayRef<orc::JITDylib*> SearchOrder = ArrayRef<orc::JITDylib*>(&SearchOrders[0], ExternalJDOnly ? 1 : 2);
     auto Sym = ::safelookup(ES, SearchOrder, getMangledName(Name));
     return Sym;
 }
 
 uint64_t JuliaOJIT::getGlobalValueAddress(StringRef Name)
 {
-    auto addr = findSymbol(getMangledName(Name), false);
+    auto addr = findJDSymbol(JD, Name, true);
     if (!addr) {
         consumeError(addr.takeError());
         return 0;
@@ -2003,7 +2021,7 @@ uint64_t JuliaOJIT::getGlobalValueAddress(StringRef Name)
 
 uint64_t JuliaOJIT::getFunctionAddress(StringRef Name)
 {
-    auto addr = findSymbol(getMangledName(Name), false);
+    auto addr = findJDSymbol(JD, Name, true);
     if (!addr) {
         consumeError(addr.takeError());
         return 0;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -797,18 +797,14 @@ public:
     void addGlobalMapping(StringRef Name, uint64_t Addr) JL_NOTSAFEPOINT;
     void addOutput(jl_emitted_output_t O) JL_NOTSAFEPOINT;
 
-    //Methods for the C API
-    Error addExternalModule(orc::JITDylib &JD, orc::ThreadSafeModule TSM,
-                            bool ShouldOptimize = false) JL_NOTSAFEPOINT;
-    Error addObjectFile(orc::JITDylib &JD,
-                        std::unique_ptr<MemoryBuffer> Obj) JL_NOTSAFEPOINT;
+    // Methods mainly for the C API
+    Error addExternalModule(orc::JITDylib &JD, orc::ThreadSafeModule TSM, bool ShouldOptimize = false) JL_NOTSAFEPOINT;
+    Error addObjectFile(orc::JITDylib &JD, std::unique_ptr<MemoryBuffer> Obj) JL_NOTSAFEPOINT;
     orc::IRCompileLayer &getIRCompileLayer() JL_NOTSAFEPOINT { return CompileLayer; };
     orc::ExecutionSession &getExecutionSession() JL_NOTSAFEPOINT { return ES; }
-    orc::JITDylib &getExternalJITDylib() JL_NOTSAFEPOINT { return ExternalJD; }
+    orc::JITDylib &createJITDylib(StringRef NamePrefix) JL_NOTSAFEPOINT;
 
-    Expected<llvm::orc::ExecutorSymbolDef> findSymbol(StringRef Name, bool ExportedSymbolsOnly);
-    Expected<llvm::orc::ExecutorSymbolDef> findUnmangledSymbol(StringRef Name);
-    Expected<llvm::orc::ExecutorSymbolDef> findExternalJDSymbol(StringRef Name, bool ExternalJDOnly);
+    Expected<llvm::orc::ExecutorSymbolDef> findJDSymbol(orc::JITDylib &JD, StringRef Name, bool ExportedSymbolsOnly);
     SmallVector<uint64_t> findSymbols(ArrayRef<StringRef> Names);
     uint64_t getGlobalValueAddress(StringRef Name);
     uint64_t getFunctionAddress(StringRef Name);
@@ -900,9 +896,9 @@ private:
     const DataLayout DL;
 
     orc::ExecutionSession ES;
+    orc::JITDylib &SessionJD;
     orc::JITDylib &GlobalJD;
     orc::JITDylib &JD;
-    orc::JITDylib &ExternalJD;
     std::mutex SharedBytesMutex{};
     SharedBytesT SharedBytes;
 

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -554,10 +554,10 @@
     YY(jl_jit_unregister_ci) \
     YY(JLJITGetLLVMOrcExecutionSession) \
     YY(JLJITGetJuliaOJIT) \
-    YY(JLJITGetExternalJITDylib) \
+    YY(JLJITCreateJITDylib) \
     YY(JLJITAddObjectFile) \
     YY(JLJITAddLLVMIRModule) \
-    YY(JLJITLookup) \
+    YY(JLJITJDLookup) \
     YY(JLJITMangleAndIntern) \
     YY(JLJITGetTripleString) \
     YY(JLJITGetGlobalPrefix) \

--- a/src/llvm_api.cpp
+++ b/src/llvm_api.cpp
@@ -71,9 +71,9 @@ JLJITGetLLVMOrcExecutionSession_impl(JuliaOJITRef JIT)
 }
 
 JL_DLLEXPORT_CODEGEN LLVMOrcJITDylibRef
-JLJITGetExternalJITDylib_impl(JuliaOJITRef JIT)
+JLJITCreateJITDylib_impl(JuliaOJITRef JIT, const char *Name)
 {
-    return wrap(&unwrap(JIT)->getExternalJITDylib());
+    return wrap(&unwrap(JIT)->createJITDylib(Name));
 }
 
 JL_DLLEXPORT_CODEGEN LLVMErrorRef JLJITAddObjectFile_impl(
@@ -91,10 +91,9 @@ JL_DLLEXPORT_CODEGEN LLVMErrorRef JLJITAddLLVMIRModule_impl(
 }
 
 JL_DLLEXPORT_CODEGEN LLVMErrorRef
-JLJITLookup_impl(JuliaOJITRef JIT, LLVMOrcExecutorAddress *Result,
-                                   const char *Name, int ExternalJDOnly)
+JLJITJDLookup_impl(JuliaOJITRef JIT, LLVMOrcJITDylibRef JD, LLVMOrcExecutorAddress *Result, const char *Name, int ExternalJDOnly)
 {
-    auto Sym = unwrap(JIT)->findExternalJDSymbol(Name, ExternalJDOnly);
+    auto Sym = unwrap(JIT)->findJDSymbol(*unwrap(JD), Name, ExternalJDOnly);
     if (Sym) {
         auto addr = Sym->getAddress();
         *Result = orc::ExecutorAddr(addr).getValue();
@@ -107,8 +106,7 @@ JLJITLookup_impl(JuliaOJITRef JIT, LLVMOrcExecutorAddress *Result,
 }
 
 JL_DLLEXPORT_CODEGEN LLVMOrcSymbolStringPoolEntryRef
-JLJITMangleAndIntern_impl(JuliaOJITRef JIT,
-                                            const char *Name)
+JLJITMangleAndIntern_impl(JuliaOJITRef JIT, const char *Name)
 {
 #if JL_LLVM_VERSION >= 180000
     return wrap(orc::SymbolStringPoolEntryUnsafe::take(unwrap(JIT)->mangle(Name)).rawPtr());

--- a/test/llvmcall2.jl
+++ b/test/llvmcall2.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using InteractiveUtils: code_llvm
+using libLLVM_jll
 
 function declared_floor(x::Float64)
     return ccall("llvm.floor.f64", llvmcall, Float64, (Float64,), x)
@@ -61,6 +62,7 @@ let err = ErrorException("llvmcall only supports intrinsic calls")
     @test_throws err (@eval ccall("llvm.floor", llvmcall, Float64, (Float64, Float64...,), 0.0)) === 0.0
 end
 
+# Test basic JIT access and info functions
 @testset "JLJIT API" begin
     function JLJITGetJuliaOJIT()
         ccall(:JLJITGetJuliaOJIT, Ptr{Cvoid}, ())
@@ -68,10 +70,61 @@ end
     function JLJITGetTripleString(JIT)
         ccall(:JLJITGetTripleString, Cstring, (Ptr{Cvoid},), JIT)
     end
+    function JLJITGetDataLayoutString(JIT)
+        ccall(:JLJITGetDataLayoutString, Cstring, (Ptr{Cvoid},), JIT)
+    end
+    function JLJITGetGlobalPrefix(JIT)
+        ccall(:JLJITGetGlobalPrefix, Cchar, (Ptr{Cvoid},), JIT)
+    end
+    function JLJITMangleAndIntern(JIT, name)
+        ccall(:JLJITMangleAndIntern, Ptr{Cvoid}, (Ptr{Cvoid}, Cstring), JIT, name)
+    end
+    function JLJITCreateJITDylib(JIT, name)
+        ccall(:JLJITCreateJITDylib, Ptr{Cvoid}, (Ptr{Cvoid}, Cstring), JIT, name)
+    end
+    function JLJITJDLookup(JIT, JD, result_ptr, name, external_jd_only)
+        ccall(:JLJITJDLookup, Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{UInt64}, Cstring, Cint),
+              JIT, JD, result_ptr, name, external_jd_only)
+    end
+    function LLVMGetErrorMessage(err)
+        errp = ccall((:LLVMGetErrorMessage, libLLVM_jll.libLLVM), Cstring, (Ptr{Cvoid},), err)
+        errs = unsafe_string(errp)
+        ccall((:LLVMDisposeErrorMessage, libLLVM_jll.libLLVM), Cvoid, (Cstring,), errp)
+        return errs
+    end
+
     jit = JLJITGetJuliaOJIT()
+    @test jit != C_NULL
+
     str = JLJITGetTripleString(jit)
     jl_str = unsafe_string(str)
     @test length(jl_str) > 4
+    @test 2 <= count("-", jl_str) <= 4
+
+    dl_str = JLJITGetDataLayoutString(jit)
+    jl_dl_str = unsafe_string(dl_str)
+    @test length(jl_dl_str) > 1
+    @test occursin("-", jl_dl_str)
+    @test occursin(":", jl_dl_str)
+
+    prefix = Char(JLJITGetGlobalPrefix(jit))
+    @test prefix == '\0' || prefix == '_'  # Common prefixes are no prefix or underscore
+
+    mangled = JLJITMangleAndIntern(jit, "my_symbol")
+    @test mangled != C_NULL
+
+    jd = JLJITCreateJITDylib(jit, "TestJITDylib")
+    @test jd != C_NULL
+
+    # look up a symbol from GlobalJD via JD
+    result = Ref{UInt64}(0)
+    err = JLJITJDLookup(jit, jd, result, "jl_get_ptls_states", 0)
+    @test err == C_NULL
+    @test result[] != 0  # Should find the symbol
+    err = JLJITJDLookup(jit, jd, result, "jl_get_ptls_states", 1)
+    @test err != C_NULL
+    @test LLVMGetErrorMessage(err) ∈ ("Symbols not found: [ jl_get_ptls_states ]",
+                                      "Symbols not found: [ _jl_get_ptls_states ]")
 end
 
 


### PR DESCRIPTION
This previously relied on the user making all symbol names globally unique, despite that being essentially impossible to query or satisfy, and despite the API also requiring the user to provide a private namespace to track it in anyways. Also have claude add a few tests.