### PR TITLE
[backports-release-1.10] Allow ext → ext dependency if triggers are a strict superset (#56368)

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1165,6 +1165,86 @@ end
             @test occursin("Hello parent!", String(read(cmd)))
         end
 
+        # Extension with cycles in dependencies
+        code = """
+        using CyclicExtensions
+        Base.get_extension(CyclicExtensions, :ExtA) isa Module || error("expected extension to load")
+        Base.get_extension(CyclicExtensions, :ExtB) isa Module || error("expected extension to load")
+        CyclicExtensions.greet()
+        """
+        proj = joinpath(@__DIR__, "project", "Extensions", "CyclicExtensions")
+        cmd =  `$(Base.julia_cmd()) --startup-file=no -e $code`
+        cmd = addenv(cmd, "JULIA_LOAD_PATH" => proj)
+        @test occursin("Hello Cycles!", String(read(cmd)))
+
+        # Extension-to-extension dependencies
+
+        mktempdir() do depot # Parallel pre-compilation
+            code = """
+            Base.disable_parallel_precompile = false
+            using ExtToExtDependency
+            Base.get_extension(ExtToExtDependency, :ExtA) isa Module || error("expected extension to load")
+            Base.get_extension(ExtToExtDependency, :ExtAB) isa Module || error("expected extension to load")
+            ExtToExtDependency.greet()
+            """
+            proj = joinpath(@__DIR__, "project", "Extensions", "ExtToExtDependency")
+            cmd =  `$(Base.julia_cmd()) --startup-file=no -e $code`
+            cmd = addenv(cmd,
+                "JULIA_LOAD_PATH" => proj,
+                "JULIA_DEPOT_PATH" => depot * Base.Filesystem.pathsep(),
+            )
+            @test occursin("Hello ext-to-ext!", String(read(cmd)))
+        end
+        mktempdir() do depot # Serial pre-compilation
+            code = """
+            Base.disable_parallel_precompile = true
+            using ExtToExtDependency
+            Base.get_extension(ExtToExtDependency, :ExtA) isa Module || error("expected extension to load")
+            Base.get_extension(ExtToExtDependency, :ExtAB) isa Module || error("expected extension to load")
+            ExtToExtDependency.greet()
+            """
+            proj = joinpath(@__DIR__, "project", "Extensions", "ExtToExtDependency")
+            cmd =  `$(Base.julia_cmd()) --startup-file=no -e $code`
+            cmd = addenv(cmd,
+                "JULIA_LOAD_PATH" => proj,
+                "JULIA_DEPOT_PATH" => depot * Base.Filesystem.pathsep(),
+            )
+            @test occursin("Hello ext-to-ext!", String(read(cmd)))
+        end
+
+        mktempdir() do depot # Parallel pre-compilation
+            code = """
+            Base.disable_parallel_precompile = false
+            using CrossPackageExtToExtDependency
+            Base.get_extension(CrossPackageExtToExtDependency.CyclicExtensions, :ExtA) isa Module || error("expected extension to load")
+            Base.get_extension(CrossPackageExtToExtDependency, :ExtAB) isa Module || error("expected extension to load")
+            CrossPackageExtToExtDependency.greet()
+            """
+            proj = joinpath(@__DIR__, "project", "Extensions", "CrossPackageExtToExtDependency")
+            cmd =  `$(Base.julia_cmd()) --startup-file=no -e $code`
+            cmd = addenv(cmd,
+                "JULIA_LOAD_PATH" => proj,
+                "JULIA_DEPOT_PATH" => depot * Base.Filesystem.pathsep(),
+            )
+            @test occursin("Hello x-package ext-to-ext!", String(read(cmd)))
+        end
+        mktempdir() do depot # Serial pre-compilation
+            code = """
+            Base.disable_parallel_precompile = true
+            using CrossPackageExtToExtDependency
+            Base.get_extension(CrossPackageExtToExtDependency.CyclicExtensions, :ExtA) isa Module || error("expected extension to load")
+            Base.get_extension(CrossPackageExtToExtDependency, :ExtAB) isa Module || error("expected extension to load")
+            CrossPackageExtToExtDependency.greet()
+            """
+            proj = joinpath(@__DIR__, "project", "Extensions", "CrossPackageExtToExtDependency")
+            cmd =  `$(Base.julia_cmd()) --startup-file=no -e $code`
+            cmd = addenv(cmd,
+                "JULIA_LOAD_PATH" => proj,
+                "JULIA_DEPOT_PATH" => depot * Base.Filesystem.pathsep(),
+            )
+            @test occursin("Hello x-package ext-to-ext!", String(read(cmd)))
+        end
+
     finally
         try
             rm(depot_path, force=true, recursive=true)

--- a/test/project/Extensions/CrossPackageExtToExtDependency/Manifest.toml
+++ b/test/project/Extensions/CrossPackageExtToExtDependency/Manifest.toml
@@ -1,18 +1,24 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.9.0-rc3"
+julia_version = "1.11.1"
 manifest_format = "2.0"
-project_hash = "ec25ff8df3a5e2212a173c3de2c7d716cc47cd36"
+project_hash = "dc35c2cf8c6b82fb5b9624c9713c2df34ca30499"
+
+[[deps.CyclicExtensions]]
+deps = ["ExtDep"]
+path = "../CyclicExtensions"
+uuid = "17d4f0df-b55c-4714-ac4b-55fa23f7355c"
+version = "0.1.0"
+weakdeps = ["SomePackage"]
+
+    [deps.CyclicExtensions.extensions]
+    ExtA = ["SomePackage"]
+    ExtB = ["SomePackage"]
 
 [[deps.ExtDep]]
-deps = ["SomePackage", "SomeOtherPackage"]
+deps = ["SomeOtherPackage", "SomePackage"]
 path = "../ExtDep.jl"
 uuid = "fa069be4-f60b-4d4c-8b95-f8008775090c"
-version = "0.1.0"
-
-[[deps.ExtDep2]]
-path = "../ExtDep2"
-uuid = "55982ee5-2ad5-4c40-8cfe-5e9e1b01500d"
 version = "0.1.0"
 
 [[deps.SomeOtherPackage]]

--- a/test/project/Extensions/CrossPackageExtToExtDependency/Project.toml
+++ b/test/project/Extensions/CrossPackageExtToExtDependency/Project.toml
@@ -1,0 +1,12 @@
+name = "CrossPackageExtToExtDependency"
+uuid = "30f07f2e-c47e-40db-93a2-cbc4d1b301cc"
+version = "0.1.0"
+
+[deps]
+CyclicExtensions = "17d4f0df-b55c-4714-ac4b-55fa23f7355c"
+
+[weakdeps]
+SomePackage = "678608ae-7bb3-42c7-98b1-82102067a3d8"
+
+[extensions]
+ExtAB = ["CyclicExtensions", "SomePackage"]

--- a/test/project/Extensions/CrossPackageExtToExtDependency/ext/ExtAB.jl
+++ b/test/project/Extensions/CrossPackageExtToExtDependency/ext/ExtAB.jl
@@ -1,0 +1,12 @@
+module ExtAB
+
+using CrossPackageExtToExtDependency
+using SomePackage
+using CyclicExtensions
+
+const ExtA = Base.get_extension(CyclicExtensions, :ExtA)
+if !(ExtA isa Module)
+    error("expected extension to load")
+end
+
+end

--- a/test/project/Extensions/CrossPackageExtToExtDependency/src/CrossPackageExtToExtDependency.jl
+++ b/test/project/Extensions/CrossPackageExtToExtDependency/src/CrossPackageExtToExtDependency.jl
@@ -1,0 +1,7 @@
+module CrossPackageExtToExtDependency
+
+using CyclicExtensions
+
+greet() = print("Hello x-package ext-to-ext!")
+
+end # module CrossPackageExtToTextDependency

--- a/test/project/Extensions/CyclicExtensions/Manifest.toml
+++ b/test/project/Extensions/CyclicExtensions/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.6"
+julia_version = "1.10.4"
 manifest_format = "2.0"
-project_hash = "eed4f16fdd2e22799229e480394c255a569eb19c"
+project_hash = "ec25ff8df3a5e2212a173c3de2c7d716cc47cd36"
 
 [[deps.ExtDep]]
 deps = ["SomePackage", "SomeOtherPackage"]
@@ -14,23 +14,6 @@ version = "0.1.0"
 path = "../ExtDep2"
 uuid = "55982ee5-2ad5-4c40-8cfe-5e9e1b01500d"
 version = "0.1.0"
-
-[[deps.ExtDep3]]
-path = "../ExtDep3.jl"
-uuid = "a5541f1e-a556-4fdc-af15-097880d743a1"
-version = "0.1.0"
-
-[[deps.HasExtensions]]
-deps = ["ExtDep3"]
-path = "../HasExtensions.jl"
-uuid = "4d3288b3-3afc-4bb6-85f3-489fffe514c8"
-version = "0.1.0"
-weakdeps = ["ExtDep", "ExtDep2"]
-
-    [deps.HasExtensions.extensions]
-    Extension = "ExtDep"
-    ExtensionDep = "ExtDep3"
-    ExtensionFolder = ["ExtDep", "ExtDep2"]
 
 [[deps.SomeOtherPackage]]
 path = "../SomeOtherPackage"

--- a/test/project/Extensions/CyclicExtensions/Project.toml
+++ b/test/project/Extensions/CyclicExtensions/Project.toml
@@ -1,0 +1,13 @@
+name = "CyclicExtensions"
+uuid = "17d4f0df-b55c-4714-ac4b-55fa23f7355c"
+version = "0.1.0"
+
+[deps]
+ExtDep = "fa069be4-f60b-4d4c-8b95-f8008775090c"
+
+[weakdeps]
+SomePackage = "678608ae-7bb3-42c7-98b1-82102067a3d8"
+
+[extensions]
+ExtA = ["SomePackage"]
+ExtB = ["SomePackage"]

--- a/test/project/Extensions/CyclicExtensions/ext/ExtA.jl
+++ b/test/project/Extensions/CyclicExtensions/ext/ExtA.jl
@@ -1,0 +1,6 @@
+module ExtA
+
+using CyclicExtensions
+using SomePackage
+
+end

--- a/test/project/Extensions/CyclicExtensions/ext/ExtB.jl
+++ b/test/project/Extensions/CyclicExtensions/ext/ExtB.jl
@@ -1,0 +1,6 @@
+module ExtB
+
+using CyclicExtensions
+using SomePackage
+
+end

--- a/test/project/Extensions/CyclicExtensions/src/CyclicExtensions.jl
+++ b/test/project/Extensions/CyclicExtensions/src/CyclicExtensions.jl
@@ -1,0 +1,7 @@
+module CyclicExtensions
+
+using ExtDep
+
+greet() = print("Hello Cycles!")
+
+end # module CyclicExtensions

--- a/test/project/Extensions/EnvWithHasExtensions/Manifest.toml
+++ b/test/project/Extensions/EnvWithHasExtensions/Manifest.toml
@@ -5,7 +5,7 @@ manifest_format = "2.0"
 project_hash = "caa716752e6dff3d77c3de929ebbb5d2024d04ef"
 
 [[deps.ExtDep]]
-deps = ["SomePackage"]
+deps = ["SomePackage", "SomeOtherPackage"]
 path = "../ExtDep.jl"
 uuid = "fa069be4-f60b-4d4c-8b95-f8008775090c"
 version = "0.1.0"
@@ -29,6 +29,11 @@ version = "0.1.0"
     [deps.HasExtensions.weakdeps]
     ExtDep = "fa069be4-f60b-4d4c-8b95-f8008775090c"
     ExtDep2 = "55982ee5-2ad5-4c40-8cfe-5e9e1b01500d"
+
+[[deps.SomeOtherPackage]]
+path = "../SomeOtherPackage"
+uuid = "178f68a2-4498-45ee-a775-452b36359b63"
+version = "0.1.0"
 
 [[deps.SomePackage]]
 path = "../SomePackage"

--- a/test/project/Extensions/EnvWithHasExtensionsv2/Manifest.toml
+++ b/test/project/Extensions/EnvWithHasExtensionsv2/Manifest.toml
@@ -5,7 +5,7 @@ manifest_format = "2.0"
 project_hash = "caa716752e6dff3d77c3de929ebbb5d2024d04ef"
 
 [[deps.ExtDep]]
-deps = ["SomePackage"]
+deps = ["SomePackage", "SomeOtherPackage"]
 path = "../ExtDep.jl"
 uuid = "fa069be4-f60b-4d4c-8b95-f8008775090c"
 version = "0.1.0"
@@ -18,6 +18,11 @@ weakdeps = ["ExtDep"]
 
     [deps.HasExtensions.extensions]
     Extension2 = "ExtDep"
+
+[[deps.SomeOtherPackage]]
+path = "../SomeOtherPackage"
+uuid = "178f68a2-4498-45ee-a775-452b36359b63"
+version = "0.1.0"
 
 [[deps.SomePackage]]
 path = "../SomePackage"

--- a/test/project/Extensions/ExtDep.jl/Project.toml
+++ b/test/project/Extensions/ExtDep.jl/Project.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 
 [deps]
 SomePackage = "678608ae-7bb3-42c7-98b1-82102067a3d8"
+SomeOtherPackage = "178f68a2-4498-45ee-a775-452b36359b63"

--- a/test/project/Extensions/ExtDep.jl/src/ExtDep.jl
+++ b/test/project/Extensions/ExtDep.jl/src/ExtDep.jl
@@ -2,6 +2,7 @@ module ExtDep
 
 # loading this package makes the check for loading extensions trigger
 # which tests #47921
+using SomeOtherPackage
 using SomePackage
 
 struct ExtDepStruct end

--- a/test/project/Extensions/ExtToExtDependency/Manifest.toml
+++ b/test/project/Extensions/ExtToExtDependency/Manifest.toml
@@ -1,18 +1,13 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.9.0-rc3"
+julia_version = "1.11.1"
 manifest_format = "2.0"
-project_hash = "ec25ff8df3a5e2212a173c3de2c7d716cc47cd36"
+project_hash = "90b427e837c654fabb1434527ea698dabad46d29"
 
 [[deps.ExtDep]]
-deps = ["SomePackage", "SomeOtherPackage"]
+deps = ["SomeOtherPackage", "SomePackage"]
 path = "../ExtDep.jl"
 uuid = "fa069be4-f60b-4d4c-8b95-f8008775090c"
-version = "0.1.0"
-
-[[deps.ExtDep2]]
-path = "../ExtDep2"
-uuid = "55982ee5-2ad5-4c40-8cfe-5e9e1b01500d"
 version = "0.1.0"
 
 [[deps.SomeOtherPackage]]

--- a/test/project/Extensions/ExtToExtDependency/Project.toml
+++ b/test/project/Extensions/ExtToExtDependency/Project.toml
@@ -1,0 +1,14 @@
+name = "ExtToExtDependency"
+uuid = "594ddb71-72fb-4cfe-9471-775d48a5b70b"
+version = "0.1.0"
+
+[deps]
+ExtDep = "fa069be4-f60b-4d4c-8b95-f8008775090c"
+
+[weakdeps]
+SomeOtherPackage = "178f68a2-4498-45ee-a775-452b36359b63"
+SomePackage = "678608ae-7bb3-42c7-98b1-82102067a3d8"
+
+[extensions]
+ExtA = ["SomePackage"]
+ExtAB = ["SomePackage", "SomeOtherPackage"]

--- a/test/project/Extensions/ExtToExtDependency/ext/ExtA.jl
+++ b/test/project/Extensions/ExtToExtDependency/ext/ExtA.jl
@@ -1,0 +1,6 @@
+module ExtA
+
+using ExtToExtDependency
+using SomePackage
+
+end

--- a/test/project/Extensions/ExtToExtDependency/ext/ExtAB.jl
+++ b/test/project/Extensions/ExtToExtDependency/ext/ExtAB.jl
@@ -1,0 +1,12 @@
+module ExtAB
+
+using ExtToExtDependency
+using SomePackage
+using SomeOtherPackage
+
+const ExtA = Base.get_extension(ExtToExtDependency, :ExtA)
+if !(ExtA isa Module)
+    error("expected extension to load")
+end
+
+end

--- a/test/project/Extensions/ExtToExtDependency/src/ExtToExtDependency.jl
+++ b/test/project/Extensions/ExtToExtDependency/src/ExtToExtDependency.jl
@@ -1,0 +1,7 @@
+module ExtToExtDependency
+
+using ExtDep
+
+greet() = print("Hello ext-to-ext!")
+
+end # module ExtToExtDependency

--- a/test/project/Extensions/SomeOtherPackage/Project.toml
+++ b/test/project/Extensions/SomeOtherPackage/Project.toml
@@ -1,0 +1,4 @@
+name = "SomeOtherPackage"
+uuid = "178f68a2-4498-45ee-a775-452b36359b63"
+authors = ["Cody Tapscott <topolarity@tapscott.me>"]
+version = "0.1.0"

--- a/test/project/Extensions/SomeOtherPackage/src/SomeOtherPackage.jl
+++ b/test/project/Extensions/SomeOtherPackage/src/SomeOtherPackage.jl
@@ -1,0 +1,5 @@
+module SomeOtherPackage
+
+greet() = print("Hello World!")
+
+end # module SomeOtherPackage


### PR DESCRIPTION
Also includes https://github.com/JuliaLang/julia/pull/55589.

Resolves the lingering extension dependency cycles that we have on 1.10.

This is a breaking change (see issue https://github.com/JuliaLang/julia/issues/56204), since it makes ext → ext
 loading edges stricter than they are today to align with 1.11 / 1.12
 behavior.

~~Draft due to dependency on https://github.com/JuliaLang/Pkg.jl/pull/4619 and https://github.com/JuliaLang/julia/pull/60996.~~