### PR TITLE
simplify and speed up `isdisjoint` for two `AbstractRange` values

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -581,17 +581,6 @@ function isdisjoint(a, b)
     _isdisjoint(a, b)
 end
 
-function isdisjoint(a::AbstractRange{T}, b::AbstractRange{T}) where T
-    (isempty(a) || isempty(b)) && return true
-    fa, la = extrema(a)
-    fb, lb = extrema(b)
-    if (la < fb) | (lb < fa)
-        return true
-    else
-        return _overlapping_range_isdisjoint(a, b)
-    end
-end
-
 """
     isdisjoint(x)
 
@@ -604,16 +593,6 @@ used to implement specialized methods.
     This functionality requires at least Julia 1.11.
 """
 isdisjoint(a) = Fix2(isdisjoint, a)
-
-_overlapping_range_isdisjoint(a::AbstractRange{T}, b::AbstractRange{T}) where T = invoke(isdisjoint, Tuple{Any,Any}, a, b)
-
-function _overlapping_range_isdisjoint(a::AbstractRange{T}, b::AbstractRange{T}) where T<:Integer
-    if abs(step(a)) == abs(step(b))
-        return mod(minimum(a), step(a)) != mod(minimum(b), step(a))
-    else
-        return invoke(isdisjoint, Tuple{Any,Any}, a, b)
-    end
-end
 
 ## partial ordering of sets by containment
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -1288,6 +1288,11 @@ function _findin(r::AbstractRange{<:Integer}, span::AbstractUnitRange{<:Integer}
     r isa AbstractUnitRange ? (ifirst:ilast) : (ifirst:1:ilast)
 end
 
+function isdisjoint(a::AbstractRange{T}, b::AbstractRange{T}) where {T}
+    c = intersect(a, b)
+    isempty(c)
+end
+
 issubset(r::OneTo, s::OneTo) = r.stop <= s.stop
 
 issubset(r::AbstractUnitRange{<:Integer}, s::AbstractUnitRange{<:Integer}) =


### PR DESCRIPTION
Ranges have optimized `intersect` implementations, so it is fastest in general to just rely on `isempty ∘ intersect`.

This removes the optimization for empty ranges, however that optimization only results in worse code (extra branching) for common cases such as `UnitRange{Int}`. Removing the optimization for empty ranges should result in a performance regression in special cases like `AbstractRange{BigInt}`, when the range is empty. But I suppose that is OK.