### PR TITLE
Fix an `UndefVarError` in the Random tests

### DIFF
--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -3,13 +3,14 @@
 using Test, SparseArrays
 using Test: guardseed
 
+using Random
+
 @test isempty(Test.detect_closure_boxes(Random))
 
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "test")
 isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "OffsetArrays.jl"))
 using .Main.OffsetArrays
 
-using Random
 using Random.DSFMT
 
 using Random: default_rng, Sampler, SamplerRangeFast, SamplerRangeInt, SamplerRangeNDL, MT_CACHE_F, MT_CACHE_I


### PR DESCRIPTION
Spotted in PkgEval: https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/45b2a06_vs_ee63552/Random.primary.log