### PR TITLE
[JuliaLowering] Fix closure-conversion of keyword functions

### DIFF
--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -502,14 +502,12 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
                                     ctx.is_toplevel_seq_point, ctx.toplevel_pure, ctx.toplevel_stmts,
                                     ctx.closure_infos)
         body = map_cl_convert(ctx2, ex[2], false)
-        if is_closure
-            if ctx.is_toplevel_seq_point
-                body
-            else
-                # Move methods out to a top-level sequence point.
-                push!(ctx.toplevel_stmts, body)
-                @ast ctx ex (::K"TOMBSTONE")
-            end
+        if !ctx.is_toplevel_seq_point
+            # Move methods out to a top-level sequence point.
+            push!(ctx.toplevel_stmts, body)
+            @ast ctx ex (::K"TOMBSTONE")
+        elseif is_closure
+            body
         else
             @ast ctx ex [K"block"
                 body

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2612,8 +2612,6 @@ function keyword_function_defs(ctx, srcref, callex_srcref, name_str, typevar_nam
     mangled_name = let n = isnothing(name_str) ? "_" : name_str
         reserve_module_binding_i(ctx.mod, string(startswith(n, '#') ? "" : "#", n, "#"))
     end
-    # TODO: Is the layer correct here? Which module should be the parent module
-    # of this body function?
     body_func_name = newsym(ctx, callex_srcref, mangled_name)
 
     kwcall_arg_names = SyntaxList(ctx)
@@ -2862,8 +2860,9 @@ function keyword_function_defs(ctx, srcref, callex_srcref, name_str, typevar_nam
             ]
         ]
         [K"method_defs"
-            # We want this method to be local or global at the same time as the
-            # body func, but it's really a method on Core.kwcall
+            # This should inherit the local / global status of the body func, so
+            # provide that here for closure conversion, even though this is
+            # really a method on Core.kwcall
             body_func_name
             [K"block"
                 new_typevar_stmts...

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -818,9 +818,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
     elseif k == K"trycatchelse" || k == K"tryfinally"
         compile_try(ctx, ex, needs_value, in_tail_pos)
     elseif k == K"method"
-        # TODO
-        # throw(LoweringError(ex,
-        #     "Global method definition needs to be placed at the top level, or use `eval`"))
+        ctx.is_toplevel_thunk || internal_error(ex, "method not at top level")
         res = if numchildren(ex) == 1
             if in_tail_pos
                 emit_return(ctx, ex)

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -405,8 +405,13 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
         newscope = enter_scope!(ctx, ex)
         arg_bindings = _resolve_scopes(ctx, ex[1], newscope)
         sparam_bindings = _resolve_scopes(ctx, ex[2], newscope)
-
-        self_id = numchildren(arg_bindings) === 0 ? 0 : arg_bindings[1].var_id
+        self_id = if numchildren(arg_bindings) === 0
+            0
+        elseif getmeta(ex[1][1], :is_kwcall_self, false)
+            arg_bindings[3].var_id
+        else
+            arg_bindings[1].var_id
+        end
         lambda_bindings = LambdaBindings(self_id, newscope.id, newscope.locals_capt)
         body_stmts = SyntaxList(ctx)
         add_local_decls!(ctx, body_stmts, ex, newscope)

--- a/JuliaLowering/test/closures_ir.jl
+++ b/JuliaLowering/test/closures_ir.jl
@@ -656,39 +656,40 @@ end
 9   slot₂/#f_kw_closure#0
 10  (new %₈ %₉)
 11  (= slot₃/f_kw_closure %₁₀)
-12  (call core.svec :y)
-13  (call core.svec false)
+12  (call core.svec :#f_kw_closure#0 :y)
+13  (call core.svec true false)
 14  (call JuliaLowering.eval_closure_type TestMod :##f_kw_closure#0##0 %₁₂ %₁₃)
 15  latestworld
 16  TestMod.##f_kw_closure#0##0
 17  (call core.typeof slot₁/y)
 18  (call core.apply_type %₁₆ %₁₇)
-19  (new %₁₈ slot₁/y)
-20  slot₂/#f_kw_closure#0
-21  (call core.setfield! %₂₀ :contents %₁₉)
-22  TestMod.##f_kw_closure#0##0
-23  TestMod.X
-24  TestMod.#f_kw_closure##0
-25  (call core.svec %₂₂ %₂₃ %₂₄)
-26  (call core.svec)
-27  SourceLocation::2:14
-28  (call core.svec %₂₅ %₂₆ %₂₇)
-29  --- method core.nothing %₂₈
+19  slot₂/#f_kw_closure#0
+20  (new %₁₈ %₁₉ slot₁/y)
+21  slot₂/#f_kw_closure#0
+22  (call core.setfield! %₂₁ :contents %₂₀)
+23  TestMod.##f_kw_closure#0##0
+24  TestMod.X
+25  TestMod.#f_kw_closure##0
+26  (call core.svec %₂₃ %₂₄ %₂₅)
+27  (call core.svec)
+28  SourceLocation::2:14
+29  (call core.svec %₂₆ %₂₇ %₂₈)
+30  --- method core.nothing %₂₉
     slots: [slot₁/#self#(!read) slot₂/x slot₃/#self#(!read)]
     1   (meta :nkw 1)
     2   TestMod.+
     3   (call core.getfield slot₁/#self# :y)
     4   (call %₂ slot₂/x %₃)
     5   (return %₄)
-30  latestworld
-31  (call core.typeof core.kwcall)
-32  TestMod.#f_kw_closure##0
-33  (call core.svec %₃₁ core.NamedTuple %₃₂)
-34  (call core.svec)
-35  SourceLocation::2:14
-36  (call core.svec %₃₃ %₃₄ %₃₅)
-37  --- code_info
-    slots: [slot₁/#self#(!read) slot₂/kws slot₃/#self# slot₄/kwtmp slot₅/x(!read) slot₆/#f_kw_closure#0(!read,maybe_undef)]
+31  latestworld
+32  (call core.typeof core.kwcall)
+33  TestMod.#f_kw_closure##0
+34  (call core.svec %₃₂ core.NamedTuple %₃₃)
+35  (call core.svec)
+36  SourceLocation::2:14
+37  (call core.svec %₃₄ %₃₅ %₃₆)
+38  --- method core.nothing %₃₇
+    slots: [slot₁/#kwcall_self#(!read) slot₂/kws slot₃/#self# slot₄/kwtmp slot₅/x(!read) slot₆/#f_kw_closure#0(!read,maybe_undef)]
     1   (newvar slot₅/x)
     2   (call core.isdefined slot₂/kws :x)
     3   (gotoifnot %₂ label₁₄)
@@ -712,7 +713,7 @@ end
     21  (gotoifnot %₂₀ label₂₃)
     22  (goto label₂₄)
     23  (call top.kwerr slot₂/kws slot₃/#self#)
-    24  (captured_local 1)
+    24  (call core.getfield slot₃/#self# :#f_kw_closure#0)
     25  (call core.isdefined %₂₄ :contents)
     26  (gotoifnot %₂₅ label₂₈)
     27  (goto label₃₀)
@@ -721,17 +722,13 @@ end
     30  (call core.getfield %₂₄ :contents)
     31  (call %₃₀ %₁₆ slot₃/#self#)
     32  (return %₃₁)
-38  slot₂/#f_kw_closure#0
-39  (call core.svec %₃₈)
-40  (call JuliaLowering.replace_captured_locals! %₃₇ %₃₉)
-41  --- method core.nothing %₃₆ %₄₀
-42  latestworld
-43  TestMod.#f_kw_closure##0
-44  (call core.svec %₄₃)
-45  (call core.svec)
-46  SourceLocation::2:14
-47  (call core.svec %₄₄ %₄₅ %₄₆)
-48  --- method core.nothing %₄₇
+39  latestworld
+40  TestMod.#f_kw_closure##0
+41  (call core.svec %₄₀)
+42  (call core.svec)
+43  SourceLocation::2:14
+44  (call core.svec %₄₁ %₄₂ %₄₃)
+45  --- method core.nothing %₄₄
     slots: [slot₁/#self# slot₂/#f_kw_closure#0(!read,maybe_undef)]
     1   (call core.getfield slot₁/#self# :#f_kw_closure#0)
     2   (call core.isdefined %₁ :contents)
@@ -743,9 +740,9 @@ end
     8   TestMod.x_default
     9   (call %₇ %₈ slot₁/#self#)
     10  (return %₉)
-49  latestworld
-50  slot₃/f_kw_closure
-51  (return %₅₀)
+46  latestworld
+47  slot₃/f_kw_closure
+48  (return %₄₇)
 
 ########################################
 # Closure capturing a typed local must also capture the type expression

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -510,6 +510,40 @@ end
     """)
     @test cl() == 11
     @test cl(x = 20) == 21
+    f = JuliaLowering.include_string(test_mod, """
+    function f_kw_closure_outer(; x=1)
+        function f_kw_closure(; y=2)
+            (x, y)
+        end
+    end
+    """)
+    @test f() isa Function
+    @test f()() == (1, 2)
+    @test f()(y = 3) == (1, 3)
+    @test f(x = 10) isa Function
+    @test f(x = 10)(y = 10) == (10, 10)
+    f = JuliaLowering.include_string(test_mod, """
+    function f_kw_closure_capt_default(; x=1)
+        function f_kw_closure(; y=x)
+            (x, y)
+        end
+    end
+    """)
+    @test f() isa Function
+    @test f()() == (1, 1)
+    @test f(x=2)(y=3) == (2, 3)
+    f = JuliaLowering.include_string(test_mod, """
+    let outer_capt = 0
+    function f_kw_closure_capt_default(; x=1)
+        function f_kw_closure(; y=x)
+            (outer_capt, x, y)
+        end
+    end
+    end
+    """)
+    @test f() isa Function
+    @test f()() == (0, 1, 1)
+    @test f(x=2)(y=3) == (0, 2, 3)
 end
 
 @testset "pre-desugared arg::Vararg" begin

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -1278,8 +1278,8 @@ end
 24  SourceLocation::1:10
 25  (call core.svec %₂₂ %₂₃ %₂₄)
 26  --- method core.nothing %₂₅
-    slots: [slot₁/#self#(called) slot₂/kws slot₃/#self#]
-    1   (call slot₁/#self# slot₂/kws slot₃/#self# 1 1.0)
+    slots: [slot₁/#kwcall_self#(called) slot₂/kws slot₃/#self#]
+    1   (call slot₁/#kwcall_self# slot₂/kws slot₃/#self# 1 1.0)
     2   (return %₁)
 27  latestworld
 28  (call core.typeof core.kwcall)
@@ -1291,8 +1291,8 @@ end
 34  SourceLocation::1:10
 35  (call core.svec %₃₂ %₃₃ %₃₄)
 36  --- method core.nothing %₃₅
-    slots: [slot₁/#self#(called) slot₂/kws slot₃/#self# slot₄/a]
-    1   (call slot₁/#self# slot₂/kws slot₃/#self# slot₄/a 1.0)
+    slots: [slot₁/#kwcall_self#(called) slot₂/kws slot₃/#self# slot₄/a]
+    1   (call slot₁/#kwcall_self# slot₂/kws slot₃/#self# slot₄/a 1.0)
     2   (return %₁)
 37  latestworld
 38  (call core.typeof core.kwcall)
@@ -1305,7 +1305,7 @@ end
 45  SourceLocation::1:10
 46  (call core.svec %₄₃ %₄₄ %₄₅)
 47  --- method core.nothing %₄₆
-    slots: [slot₁/#self#(!read) slot₂/kws slot₃/#self# slot₄/a slot₅/b slot₆/kwtmp slot₇/x(!read) slot₈/y(!read)]
+    slots: [slot₁/#kwcall_self#(!read) slot₂/kws slot₃/#self# slot₄/a slot₅/b slot₆/kwtmp slot₇/x(!read) slot₈/y(!read)]
     1   (newvar slot₇/x)
     2   (newvar slot₈/y)
     3   (call core.isdefined slot₂/kws :x)
@@ -1428,7 +1428,7 @@ end
 21  SourceLocation::1:10
 22  (call core.svec %₁₉ %₂₀ %₂₁)
 23  --- method core.nothing %₂₂
-    slots: [slot₁/#self#(!read) slot₂/kws slot₃/#self# slot₄/all_kws(!read)]
+    slots: [slot₁/#kwcall_self#(!read) slot₂/kws slot₃/#self# slot₄/all_kws(!read)]
     1   (newvar slot₄/all_kws)
     2   (call top.pairs slot₂/kws)
     3   TestMod.#f_kw_slurp_simple#0
@@ -1485,7 +1485,7 @@ end
 21  SourceLocation::1:10
 22  (call core.svec %₁₉ %₂₀ %₂₁)
 23  --- method core.nothing %₂₂
-    slots: [slot₁/#self#(!read) slot₂/kws slot₃/#self# slot₄/kwtmp slot₅/x(!read) slot₆/non_x_kws(!read)]
+    slots: [slot₁/#kwcall_self#(!read) slot₂/kws slot₃/#self# slot₄/kwtmp slot₅/x(!read) slot₆/non_x_kws(!read)]
     1   (newvar slot₅/x)
     2   (newvar slot₆/non_x_kws)
     3   (call core.isdefined slot₂/kws :x)
@@ -1558,7 +1558,7 @@ end
 21  SourceLocation::1:10
 22  (call core.svec %₁₉ %₂₀ %₂₁)
 23  --- method core.nothing %₂₂
-    slots: [slot₁/#self#(!read) slot₂/kws slot₃/#self# slot₄/kwtmp slot₅/a(single_assign) slot₆/b(single_assign)]
+    slots: [slot₁/#kwcall_self#(!read) slot₂/kws slot₃/#self# slot₄/kwtmp slot₅/a(single_assign) slot₆/b(single_assign)]
     1   (call core.isdefined slot₂/kws :a)
     2   (gotoifnot %₁ label₆)
     3   (call core.getfield slot₂/kws :a)
@@ -1655,7 +1655,7 @@ end
 31  SourceLocation::1:10
 32  (call core.svec %₂₈ %₃₀ %₃₁)
 33  --- method core.nothing %₃₂
-    slots: [slot₁/#self#(!read) slot₂/kws slot₃/#self# slot₄/x slot₅/kwtmp slot₆/a(!read) slot₇/b(!read)]
+    slots: [slot₁/#kwcall_self#(!read) slot₂/kws slot₃/#self# slot₄/x slot₅/kwtmp slot₆/a(!read) slot₇/b(!read)]
     1   (newvar slot₆/a)
     2   (newvar slot₇/b)
     3   (call core.isdefined slot₂/kws :a)

--- a/test/JuliaLowering_stdlibs.jl
+++ b/test/JuliaLowering_stdlibs.jl
@@ -1,10 +1,7 @@
 import Libdl
 
 # known precompilation failures under JL
-const INCOMPATIBLE_STDLIBS = String[
-    "Pkg", # closure w/ kwarg bug (JuliaLang/JuliaLowering.jl#139)
-    "LazyArtifacts", # depends on Pkg
-]
+const INCOMPATIBLE_STDLIBS = String[]
 
 const JULIA_EXECUTABLE = Base.unsafe_string(Base.JLOptions().julia_bin)
 const JULIA_CPU_TARGET = get(ENV, "JULIA_CPU_TARGET", Base.unsafe_string(Base.JLOptions().cpu_target))


### PR DESCRIPTION
The `Core.kwcall` `method` expression from desugaring is expected to be as local or global (according to closure conversion) as the other methods produced.  We were (1) always considering it global, and so (2) not lifting the `method` form for it, which just meant invalid IR.  This PR makes a few tweaks:
1. Allow that method to be local
2. Lift `method` expressions to top-level regardless of whether they're local or global.  Debatable, but I think it's simpler to expect closure conversion always do the simple mechanical thing, and not have it depend on the scope resolution of the first argument of `K"method_defs"`.  This form doesn't exist in flisp, and I don't think we've written down or decided on the full purpose of the first argument yet.
3. Throw an internal error if `method` is found not at top level (commented out before).  The user-facing "global function should go at top level" is thrown from the validator.
4. A small hack to get the closure argument passed to `Core.kwcall` in the third position instead of the first (don't think there's a good way around this; flisp does `(contains (lambda (x) (eq? x 'kwftype)) sig)`)

Fix https://github.com/JuliaLang/JuliaLowering.jl/issues/139. Pkg and LazyArtifacts should now precompile, meaning all stdlibs precompile under JuliaLowering now!