### PR TITLE
Change GMP download link

### DIFF
--- a/deps/gmp.mk
+++ b/deps/gmp.mk
@@ -24,7 +24,7 @@ GMP_CONFIGURE_OPTS += CFLAGS="-fPIC"
 endif
 
 $(SRCCACHE)/gmp-$(GMP_VER).tar.bz2: | $(SRCCACHE)
-	$(JLDOWNLOAD) $@ https://gmplib.org/download/gmp/$(notdir $@)
+	$(JLDOWNLOAD) $@ https://ftp.gnu.org/gnu/gmp/$(notdir $@)
 
 $(SRCCACHE)/gmp-$(GMP_VER)/source-extracted: $(SRCCACHE)/gmp-$(GMP_VER).tar.bz2
 	$(JLCHECKSUM) $<


### PR DESCRIPTION
Fix Julia builds on GHA ([GMP has blocked GHA](https://github.com/actions/runner-images/issues/7901)).

Closes #60999.