### PR TITLE
SyntaxTree: Add `jl_source` attribute for debugging JuliaLowering

### DIFF
--- a/JuliaLowering/src/JuliaLowering.jl
+++ b/JuliaLowering/src/JuliaLowering.jl
@@ -19,7 +19,7 @@ using .JuliaSyntax: highlight, Kind, @KSet_str, is_leaf, children, numchildren,
     is_contextual_keyword,
     SyntaxGraph, SyntaxTree, SyntaxList, NodeId, SourceRef, SourceAttrType,
     ensure_attributes, ensure_attributes!, delete_attributes, new_id!, hasattr,
-    setattr, setattr!, syntax_graph, is_compatible_graph,
+    copy_attrs, setattr, setattr!, syntax_graph, is_compatible_graph,
     check_compatible_graph, copy_node, copy_ast, provenance, sourceref,
     reparent, mapchildren, flattened_provenance, mkleaf, mknode, newleaf,
     newnode, tree_ids, @stm, mapsyntax

--- a/JuliaLowering/src/JuliaLowering.jl
+++ b/JuliaLowering/src/JuliaLowering.jl
@@ -24,6 +24,8 @@ using .JuliaSyntax: highlight, Kind, @KSet_str, is_leaf, children, numchildren,
     reparent, mapchildren, flattened_provenance, mkleaf, mknode, newleaf,
     newnode, tree_ids, @stm, mapsyntax
 
+const DEBUG = true
+
 _include("kinds.jl")
 _register_kinds()
 

--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -28,15 +28,6 @@ struct ClosureConversionCtx{Attrs} <: AbstractLoweringContext
     closure_infos::Dict{IdTag,ClosureInfo{Attrs}}
 end
 
-function ClosureConversionCtx(graph::SyntaxGraph{Attrs}, bindings::Bindings,
-                              mod::Module, closure_bindings::Dict{IdTag,ClosureBindings},
-                              lambda_bindings::LambdaBindings) where {Attrs}
-    ClosureConversionCtx{Attrs}(
-        graph, bindings, mod, closure_bindings, nothing,
-        lambda_bindings, false, true, SyntaxList(graph),
-        Dict{IdTag,ClosureInfo{Attrs}}())
-end
-
 function current_lambda_bindings(ctx::ClosureConversionCtx)
     ctx.lambda_bindings
 end
@@ -628,12 +619,17 @@ Invariants:
 * This pass must not introduce new K"Identifier" - only K"BindingId".
 * Any new binding IDs must be added to the enclosing lambda locals
 """
-@fzone "JL: closures" function convert_closures(ctx::VariableAnalysisContext, ex)
-    ctx = ClosureConversionCtx(ctx.graph, ctx.bindings, ctx.mod,
-                               ctx.closure_bindings, ex.lambda_bindings)
-    ex1 = closure_convert_lambda(ctx, ex)
-    if !isempty(ctx.toplevel_stmts)
-        throw(LoweringError(first(ctx.toplevel_stmts), "Top level code was found outside any top level context. `@generated` functions may not contain closures, including `do` syntax and generators/comprehension"))
+@fzone "JL: closures" function convert_closures(
+    ctx::VariableAnalysisContext, ex::SyntaxTree{Attrs}
+) where Attrs
+    ctx_out = ClosureConversionCtx(ctx.graph, ctx.bindings, ctx.mod,
+                                   ctx.closure_bindings, nothing,
+                                   ex.lambda_bindings,
+                                   false, true, SyntaxList(ctx.graph),
+                                   Dict{IdTag,ClosureInfo{Attrs}}())
+    ex_out = closure_convert_lambda(ctx_out, ex)
+    if !isempty(ctx_out.toplevel_stmts)
+        throw(LoweringError(first(ctx_out.toplevel_stmts), "Top level code was found outside any top level context. `@generated` functions may not contain closures, including `do` syntax and generators/comprehension"))
     end
-    ctx, ex1
+    ctx_out, ex_out
 end

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -18,13 +18,7 @@ end
 
 function expr_to_est(@nospecialize(e),
                      lnn::LineNumberNode=LineNumberNode(0, :none))
-    graph = ensure_attributes!(
-        SyntaxGraph(),
-        kind=Kind, syntax_flags=UInt16,
-        source=SourceAttrType, var_id=Int, value=Any,
-        name_val=String, is_toplevel_thunk=Bool,
-        scope_layer=LayerId, meta=CompileHints,
-        toplevel_pure=Bool)
+    graph = ensure_macro_attributes!(SyntaxGraph())
     expr_to_est(graph, e, lnn)
 end
 

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -8,20 +8,12 @@ struct DesugaringContext{Attrs} <: AbstractLoweringContext
     expr_compat_mode::Bool
 end
 
-function DesugaringContext(ctx, expr_compat_mode::Bool)
-    graph = ensure_attributes(syntax_graph(ctx),
-                              kind=Kind, syntax_flags=UInt16,
-                              source=SourceAttrType,
-                              value=Any, name_val=String,
-                              scope_type=Symbol, # :hard or :soft
-                              var_id=IdTag,
-                              is_toplevel_thunk=Bool,
-                              toplevel_pure=Bool)
+function DesugaringContext(graph, ctx)
     DesugaringContext(graph,
                       ctx.bindings,
                       ctx.scope_layers,
                       current_layer(ctx).mod,
-                      expr_compat_mode)
+                      ctx.expr_compat_mode)
 end
 
 #-------------------------------------------------------------------------------
@@ -4680,15 +4672,23 @@ function expand_forms_2(ctx::StatementListCtx, args...)
     expand_forms_2(ctx.ctx, args...)
 end
 
+ensure_desugaring_attributes!(graph) = ensure_attributes!(
+    ensure_macro_attributes!(graph),
+    is_toplevel_thunk=Bool,
+    toplevel_pure=Bool,
+    scope_type=Symbol)
+
 @fzone "JL: desugar" function expand_forms_2(ctx::MacroExpansionContext, ex::SyntaxTree)
-    ctx1 = DesugaringContext(ctx, ctx.expr_compat_mode)
+    graph = ensure_desugaring_attributes!(copy_attrs(ctx.graph))
+    ex = reparent(graph, ex)
+    ctx_out = DesugaringContext(graph, ctx.bindings, ctx.scope_layers,
+                                current_layer(ctx).mod, ctx.expr_compat_mode)
     vr = valid_st1(ex)
     # surface only one error until we have pretty-printing for multiple
     if !vr.ok
         # showerrors(vr)
         throw(LoweringError(vr.errors[1].sts[1], vr.errors[1].msg))
     end
-    ex = est_to_dst(ex)
-    ex1 = expand_forms_2(ctx1, reparent(ctx1, ex))
-    ctx1, ex1
+    ex_out = expand_forms_2(ctx_out, est_to_dst(ex))
+    ctx_out, ex_out
 end

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -85,8 +85,7 @@ struct LinearIRContext{Attrs} <: AbstractLoweringContext
     mod::Module
 end
 
-function LinearIRContext(ctx, is_toplevel_thunk, lambda_bindings, return_type)
-    graph = syntax_graph(ctx)
+function LinearIRContext(graph, ctx, is_toplevel_thunk, lambda_bindings, return_type)
     rett = isnothing(return_type) ? nothing : reparent(graph, return_type)
     Attrs = typeof(graph.attributes)
     LinearIRContext(graph, SyntaxList(ctx), ctx.bindings, Ref(0),
@@ -1137,7 +1136,8 @@ function compile_lambda(outer_ctx, ex)
     static_parameters = ex[2]
     ret_var = numchildren(ex) == 4 ? ex[4] : nothing
     lambda_bindings = ex.lambda_bindings
-    ctx = LinearIRContext(outer_ctx, ex.is_toplevel_thunk, lambda_bindings, ret_var)
+    ctx = LinearIRContext(outer_ctx.graph, outer_ctx, ex.is_toplevel_thunk,
+                          lambda_bindings, ret_var)
     for arg in children(lambda_args)
         kind(arg) == K"Placeholder" && continue
         @assert kind(arg) == K"BindingId"
@@ -1204,6 +1204,12 @@ function compile_lambda(outer_ctx, ex)
     ]
 end
 
+ensure_linearization_attributes!(graph) = ensure_attributes!(
+    ensure_scope_attributes!(graph),
+    slots=Vector{Slot},
+    mod=Module,
+    id=Int)
+
 """
 This pass converts nested ASTs in the body of a lambda into a list of
 statements (ie, Julia's linear/untyped IR).
@@ -1212,23 +1218,10 @@ Most of the compliexty of this pass is in lowering structured control flow (if,
 loops, etc) to gotos and exception handling to enter/leave. We also convert
 `K"BindingId"` into K"slot", `K"globalref"` or `K"SSAValue` as appropriate.
 """
-@fzone "JL: linearize" function linearize_ir(ctx, ex)
-    graph = ensure_attributes(ctx.graph,
-                              slots=Vector{Slot},
-                              mod=Module,
-                              id=Int)
-    # TODO: Cleanup needed - `_ctx` is just a dummy context here. But currently
-    # required to call reparent() ...
-    Attrs = typeof(graph.attributes)
-    _ctx = LinearIRContext(graph, SyntaxList(graph), ctx.bindings,
-                           Ref(0), false, LambdaBindings(),
-                           Dict{IdTag,IdTag}(), nothing,
-                           Dict{String,JumpTarget{Attrs}}(),
-                           SyntaxList(graph), SyntaxList(graph),
-                           Vector{FinallyHandler{Attrs}}(),
-                           Dict{String, JumpTarget{Attrs}}(),
-                           Vector{JumpOrigin{Attrs}}(),
-                           Set{String}(), Dict{Symbol, Any}(), ctx.mod)
-    res = compile_lambda(_ctx, reparent(_ctx, ex))
-    _ctx, res
+@fzone "JL: linearize" function linearize_ir(ctx::ClosureConversionCtx, ex)
+    graph = ensure_linearization_attributes!(copy_attrs(ctx.graph))
+    ex = reparent(graph, ex)
+    ctx_out = LinearIRContext(graph, ctx, false, LambdaBindings(), nothing)
+    ex_out = compile_lambda(ctx_out, ex)
+    ctx_out, ex_out
 end

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -494,7 +494,8 @@ ensure_macro_attributes!(graph) = ensure_attributes!(
     var_id=IdTag,
     scope_layer=LayerId,
     __macro_ctx__=Nothing,
-    meta=CompileHints)
+    meta=CompileHints,
+    jl_source=LineNumberNode)
 
 @fzone "JL: macroexpand" function expand_forms_1(mod::Module, ex::SyntaxTree, expr_compat_mode::Bool, macro_world::UInt)
     if kind(ex) == K"local"

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -489,13 +489,12 @@ split_generated(st::SyntaxTree, gen_part) = JuliaSyntax.@stm st begin
     _ -> mapchildren(x->split_generated(x, gen_part), st._graph, st)
 end
 
-function ensure_macro_attributes(graph)
-    ensure_attributes(graph,
-                      var_id=IdTag,
-                      scope_layer=LayerId,
-                      __macro_ctx__=Nothing,
-                      meta=CompileHints)
-end
+ensure_macro_attributes!(graph) = ensure_attributes!(
+    graph,
+    var_id=IdTag,
+    scope_layer=LayerId,
+    __macro_ctx__=Nothing,
+    meta=CompileHints)
 
 @fzone "JL: macroexpand" function expand_forms_1(mod::Module, ex::SyntaxTree, expr_compat_mode::Bool, macro_world::UInt)
     if kind(ex) == K"local"
@@ -503,14 +502,16 @@ end
         # we might want to make that more explicit in the pass system.
         throw(LoweringError(ex, "local declarations have no effect outside a scope"))
     end
-    graph = ensure_macro_attributes(syntax_graph(ex))
-    ctx = MacroExpansionContext(graph, mod, expr_compat_mode, macro_world)
-    ex2 = expand_forms_1(ctx, reparent(ctx, ex))
-    graph2 = delete_attributes(graph, :__macro_ctx__)
+    graph = ensure_macro_attributes!(copy_attrs(syntax_graph(ex)))
+    ex = reparent(graph, ex)
+    ctx_out = MacroExpansionContext(graph, mod, expr_compat_mode, macro_world)
+    ex_out = expand_forms_1(ctx_out, ex)
+    graph2 = delete_attributes(ex._graph, :__macro_ctx__)
     # TODO: Returning the context with pass-specific mutable data is a bad way
     # to carry state into the next pass. We might fix this by attaching such
     # data to the graph itself as global attributes?
-    ctx2 = MacroExpansionContext(graph2, ctx.bindings, ctx.scope_layers, ctx.scope_layer_stack,
+    ctx2 = MacroExpansionContext(graph2, ctx_out.bindings, ctx_out.scope_layers,
+                                 ctx_out.scope_layer_stack,
                                  expr_compat_mode, macro_world)
-    return ctx2, reparent(ctx2, ex2)
+    return ctx2, reparent(ctx2.graph, ex_out)
 end

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -490,12 +490,12 @@ split_generated(st::SyntaxTree, gen_part) = JuliaSyntax.@stm st begin
 end
 
 ensure_macro_attributes!(graph) = ensure_attributes!(
-    graph,
+    graph;
     var_id=IdTag,
     scope_layer=LayerId,
     __macro_ctx__=Nothing,
     meta=CompileHints,
-    jl_source=LineNumberNode)
+    (DEBUG ? (:jl_source=>LineNumberNode,) : ())...)
 
 @fzone "JL: macroexpand" function expand_forms_1(mod::Module, ex::SyntaxTree, expr_compat_mode::Bool, macro_world::UInt)
     if kind(ex) == K"local"

--- a/JuliaLowering/src/runtime.jl
+++ b/JuliaLowering/src/runtime.jl
@@ -122,9 +122,7 @@ function interpolate_ast(::Type{SyntaxTree}, ex::SyntaxTree, values...)
         end
     end
     if isnothing(graph)
-        graph = ensure_attributes(
-            SyntaxGraph(), kind=Kind, syntax_flags=UInt16, source=SourceAttrType,
-            value=Any, name_val=String, scope_layer=LayerId)
+        graph = ensure_macro_attributes!(SyntaxGraph())
     end
     ctx = InterpolationContext(graph, values, Ref(1))
 
@@ -308,17 +306,7 @@ function (g::GeneratedFunctionStub)(world::UInt, source::Method, @nospecialize a
     #
     # TODO: Reduce duplication where possible.
 
-    # Attributes from parsing
-    graph = ensure_attributes(SyntaxGraph(), kind=Kind, syntax_flags=UInt16, source=SourceAttrType,
-                              value=Any, name_val=String)
-    # Attributes for macro expansion
-    graph = ensure_attributes(ensure_macro_attributes(graph),
-                              # Additional attribute for resolve_scopes, for
-                              # adding our custom lambda below
-                              is_toplevel_thunk=Bool,
-                              toplevel_pure=Bool,
-                              )
-
+    graph = ensure_desugaring_attributes!(SyntaxGraph())
     __module__ = source.module
 
     # Macro expansion. Note that we expand in `tls_world_age()` (see

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -86,20 +86,6 @@ struct ScopeResolutionContext{Attrs} <: AbstractLoweringContext
     expr_compat_mode::Bool
 end
 
-function ScopeResolutionContext(ctx, ex)
-    graph = ensure_attributes(ctx.graph, lambda_bindings=LambdaBindings)
-    ScopeResolutionContext(
-        graph,
-        ctx.bindings,
-        ctx.mod,
-        Vector{ScopeInfo}(),
-        Vector{ScopeId}(),
-        ctx.scope_layers,
-        Set{NameKey}(),
-        contains_softscope_marker(ex),
-        ctx.expr_compat_mode)
-end
-
 function contains_softscope_marker(ex)
     kind(ex) == K"softscope" ||
         needs_resolution(ex) && any(contains_softscope_marker, children(ex))
@@ -589,12 +575,6 @@ struct VariableAnalysisContext{Attrs} <: AbstractLoweringContext
     closure_bindings::Dict{IdTag,ClosureBindings}
 end
 
-function VariableAnalysisContext(graph, bindings, mod, scopes, lambda_bindings)
-    graph = ensure_attributes(graph, lambda_bindings=LambdaBindings)
-    VariableAnalysisContext(graph, bindings, mod, scopes, lambda_bindings,
-                            SyntaxList(graph), Dict{IdTag,ClosureBindings}())
-end
-
 function init_closure_bindings!(ctx, fname)
     func_name_id = fname.var_id
     @assert get_binding(ctx, func_name_id).kind === :local
@@ -749,6 +729,10 @@ function resolve_scopes(ctx::ScopeResolutionContext, ex)
     _resolve_scopes(ctx, ex, nothing)
 end
 
+ensure_scope_attributes!(graph) = ensure_attributes!(
+    ensure_desugaring_attributes!(graph),
+    lambda_bindings=LambdaBindings)
+
 """
 This pass analyzes scopes and the names (locals/globals etc) used within them.
 
@@ -760,10 +744,18 @@ This pass also records the set of binding IDs used locally within the
 enclosing lambda form and information about variables captured by closures.
 """
 @fzone "JL: resolve_scopes" function resolve_scopes(ctx::DesugaringContext, ex)
-    ctx2 = ScopeResolutionContext(ctx, ex)
-    ex2 = resolve_scopes(ctx2, reparent(ctx2, ex))
-    ctx3 = VariableAnalysisContext(
-        ctx2.graph, ctx2.bindings, ctx2.mod, ctx2.scopes, ex2.lambda_bindings)
+    graph = ensure_scope_attributes!(copy_attrs(ctx.graph))
+    ex = reparent(graph, ex)
+    ctx2 = ScopeResolutionContext(graph, ctx.bindings, ctx.mod,
+                                  Vector{ScopeInfo}(), Vector{ScopeId}(),
+                                  ctx.scope_layers, Set{NameKey}(),
+                                  contains_softscope_marker(ex),
+                                  ctx.expr_compat_mode)
+    ex2 = resolve_scopes(ctx2, ex)
+    ctx3 = VariableAnalysisContext(graph, ctx2.bindings, ctx2.mod,
+                                   ctx2.scopes, ex2.lambda_bindings,
+                                   SyntaxList(graph),
+                                   Dict{IdTag,ClosureBindings}())
     analyze_variables!(ctx3, ex2)
     analyze_def_and_use!(ctx3, ex2)
     ctx3, ex2

--- a/JuliaLowering/src/utils.jl
+++ b/JuliaLowering/src/utils.jl
@@ -1,5 +1,6 @@
 attrsummary(name, value) = string(name)
 attrsummary(name, value::Number) = "$name=$value"
+attrsummary(name, value::LineNumberNode) = "$name=L$(value.line)"
 
 function _value_string(ex)
     k = kind(ex)

--- a/JuliaLowering/test/compat.jl
+++ b/JuliaLowering/test/compat.jl
@@ -102,6 +102,7 @@ end
 
     # TODO: `@ast_` escaping is broken
     unused = JuliaSyntax.parsestmt(JuliaSyntax.SyntaxTree, "foo")
+    JuliaLowering.ensure_macro_attributes!(unused._graph)
     local st_wrappers = Function[
         x->(@assert(!isnothing(x)); @ast unused._graph unused (x::K"Value"))
         x->(@assert(!isnothing(x)); @ast unused._graph unused [K"inert" x::K"Value"])

--- a/JuliaLowering/test/utils.jl
+++ b/JuliaLowering/test/utils.jl
@@ -15,19 +15,15 @@ import REPL
 using .JuliaSyntax: SourceAttrType, sourcetext, set_numeric_flags
 
 using .JuliaLowering:
-    SyntaxGraph, new_id!, ensure_attributes!,
+    SyntaxGraph, new_id!,
     Kind, SourceRef, SyntaxTree, NodeId,
     setattr!, is_leaf, numchildren, children,
     @ast, flattened_provenance, showprov, LoweringError, MacroExpansionError,
     syntax_graph, Bindings, ScopeLayer, mapchildren
 
 function _ast_test_graph()
-    graph = SyntaxGraph()
-    ensure_attributes!(graph,
-                       kind=Kind, syntax_flags=UInt16,
-                       source=SourceAttrType,
-                       var_id=Int, value=Any, name_val=String, is_toplevel_thunk=Bool,
-                       toplevel_pure=Bool)
+    graph = JuliaLowering.ensure_desugaring_attributes!(
+        JuliaLowering.ensure_macro_attributes!(SyntaxGraph()))
 end
 
 function _source_node(graph, src)


### PR DESCRIPTION
Given that `@ast` is the main way we build trees, we can do a neat trick: store the calling line in the tree it created.  I've been using this locally, and it's been helpful for debugging.

Also refactor our use of `ensure_attributes` so new ones don't need to be added in many separate places.