### PR TITLE
Update documenter, add minimal docs for labeled break

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1190,6 +1190,23 @@ julia> while true
 4
 5
 ```
+
+Labeled break can be used to exit early from a labeled block created with [`@label`](@ref).
+
+```jldoctest
+julia> result = @label myblock begin
+           for i in 1:10
+               if i > 5
+                   break myblock i * 2
+               end
+           end
+           0
+       end
+12
+```
+
+!!! compat "Julia 1.14"
+    Labeled `break` requires Julia 1.14.
 """
 kw"break"
 
@@ -1208,6 +1225,28 @@ julia> for i = 1:6
 3
 5
 ```
+
+Labeled continue can be used to skip to the next iteration of a labeled loop created with [`@label`](@ref).
+
+```jldoctest
+julia> for i in 1:3
+           @label inner for j in 1:3
+               if j == 2
+                   continue inner
+               end
+               println((i, j))
+           end
+       end
+(1, 1)
+(1, 3)
+(2, 1)
+(2, 3)
+(3, 1)
+(3, 3)
+```
+
+!!! compat "Julia 1.14"
+    Labeled `continue` requires Julia 1.14.
 """
 kw"continue"
 

--- a/deps/jlutilities/documenter/Manifest.toml
+++ b/deps/jlutilities/documenter/Manifest.toml
@@ -10,23 +10,38 @@ registries = "General"
 uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
 version = "0.0.1"
 
+    [deps.ANSIColoredPrinters.syntax]
+    julia_version = "1.0.0"
+
 [[deps.AbstractTrees]]
 git-tree-sha1 = "2d9c9a55f9c93e8887ad391fbae72f8ef55e1177"
 registries = "General"
 uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 version = "0.4.5"
 
+    [deps.AbstractTrees.syntax]
+    julia_version = "1.0.0"
+
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 version = "1.1.2"
+
+    [deps.ArgTools.syntax]
+    julia_version = "1.3.0"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 version = "1.11.0"
 
+    [deps.Artifacts.syntax]
+    julia_version = "1.14.0-DEV.1669"
+
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 version = "1.11.0"
+
+    [deps.Base64.syntax]
+    julia_version = "1.14.0-DEV.1669"
 
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
@@ -35,15 +50,24 @@ registries = "General"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
 version = "0.7.8"
 
+    [deps.CodecZlib.syntax]
+    julia_version = "1.6.0"
+
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "1.3.0+1"
 
+    [deps.CompilerSupportLibraries_jll.syntax]
+    julia_version = "1.6.0"
+
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 version = "1.11.0"
+
+    [deps.Dates.syntax]
+    julia_version = "1.14.0-DEV.1669"
 
 [[deps.DocStringExtensions]]
 git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
@@ -51,17 +75,27 @@ registries = "General"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.9.5"
 
+    [deps.DocStringExtensions.syntax]
+    julia_version = "1.0.0"
+
 [[deps.Documenter]]
 deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
-git-tree-sha1 = "b37458ae37d8bdb643d763451585cd8d0e5b4a9e"
-registries = "General"
+git-tree-sha1 = "f964290a125b0f41d618731f626accbda841674e"
+repo-rev = "43d5602f451ecc69d15fa990a7c9df5644fe889b"
+repo-url = "https://github.com/JuliaDocs/Documenter.jl.git"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 version = "1.16.1"
+
+    [deps.Documenter.syntax]
+    julia_version = "1.6.0"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 version = "1.7.0"
+
+    [deps.Downloads.syntax]
+    julia_version = "1.10.0"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -70,9 +104,15 @@ registries = "General"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
 version = "2.7.3+0"
 
+    [deps.Expat_jll.syntax]
+    julia_version = "1.6.0"
+
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 version = "1.11.0"
+
+    [deps.FileWatching.syntax]
+    julia_version = "1.14.0-DEV.1669"
 
 [[deps.Git]]
 deps = ["Git_LFS_jll", "Git_jll", "JLLWrappers", "OpenSSH_jll"]
@@ -81,6 +121,9 @@ registries = "General"
 uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
 version = "1.5.0"
 
+    [deps.Git.syntax]
+    julia_version = "1.6.6"
+
 [[deps.Git_LFS_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
 git-tree-sha1 = "bb8471f313ed941f299aa53d32a94ab3bee08844"
@@ -88,12 +131,18 @@ registries = "General"
 uuid = "020c3dae-16b3-5ae5-87b3-4cb189e250b2"
 version = "3.7.0+0"
 
+    [deps.Git_LFS_jll.syntax]
+    julia_version = "1.6.0"
+
 [[deps.Git_jll]]
 deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
-git-tree-sha1 = "b6a684587ebe896d9f68ae777f648205940f0f70"
+git-tree-sha1 = "dc34a3e3d96b4ed305b641e626dc14c12b7824b8"
 registries = "General"
 uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
-version = "2.51.3+0"
+version = "2.53.0+0"
+
+    [deps.Git_jll.syntax]
+    julia_version = "1.6.0"
 
 [[deps.IOCapture]]
 deps = ["Logging", "Random"]
@@ -102,10 +151,16 @@ registries = "General"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 version = "1.0.0"
 
+    [deps.IOCapture.syntax]
+    julia_version = "1.0.0"
+
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 version = "1.11.0"
+
+    [deps.InteractiveUtils.syntax]
+    julia_version = "1.14.0-DEV.1669"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
@@ -114,15 +169,21 @@ registries = "General"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.7.1"
 
+    [deps.JLLWrappers.syntax]
+    julia_version = "1.0.0"
+
 [[deps.JSON]]
 deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
-git-tree-sha1 = "5b6bb73f555bc753a6153deec3717b8904f5551c"
+git-tree-sha1 = "b3ad4a0255688dcb895a52fafbaae3023b588a90"
 registries = "General"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "1.3.0"
+version = "1.4.0"
 
     [deps.JSON.extensions]
     JSONArrowExt = ["ArrowTypes"]
+
+    [deps.JSON.syntax]
+    julia_version = "1.9.0"
 
     [deps.JSON.weakdeps]
     ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
@@ -130,7 +191,10 @@ version = "1.3.0"
 [[deps.JuliaSyntaxHighlighting]]
 deps = ["StyledStrings"]
 uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
-version = "1.12.0"
+version = "1.13.0"
+
+    [deps.JuliaSyntaxHighlighting.syntax]
+    julia_version = "1.12.0"
 
 [[deps.LazilyInitializedFields]]
 git-tree-sha1 = "0f2da712350b020bc3957f269c9caad516383ee0"
@@ -138,34 +202,55 @@ registries = "General"
 uuid = "0e77f7df-68c5-4e49-93ce-4cd80f5598bf"
 version = "1.3.0"
 
+    [deps.LazilyInitializedFields.syntax]
+    julia_version = "1.6.0"
+
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 version = "1.0.0"
 
+    [deps.LibCURL.syntax]
+    julia_version = "1.3.0"
+
 [[deps.LibCURL_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "Zstd_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.17.0+0"
+version = "8.18.0+0"
+
+    [deps.LibCURL_jll.syntax]
+    julia_version = "1.11.0"
 
 [[deps.LibGit2]]
 deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 version = "1.11.0"
 
+    [deps.LibGit2.syntax]
+    julia_version = "1.14.0-DEV.1669"
+
 [[deps.LibGit2_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.9.1+0"
+version = "1.9.2+0"
+
+    [deps.LibGit2_jll.syntax]
+    julia_version = "1.9.0"
 
 [[deps.LibSSH2_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl", "OpenSSL_jll", "Zlib_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 version = "1.11.3+1"
 
+    [deps.LibSSH2_jll.syntax]
+    julia_version = "1.8.0"
+
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 version = "1.11.0"
+
+    [deps.Libdl.syntax]
+    julia_version = "1.14.0-DEV.1669"
 
 [[deps.Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -174,14 +259,23 @@ registries = "General"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
 version = "1.18.0+0"
 
+    [deps.Libiconv_jll.syntax]
+    julia_version = "1.6.0"
+
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 version = "1.11.0"
+
+    [deps.Logging.syntax]
+    julia_version = "1.14.0-DEV.1669"
 
 [[deps.Markdown]]
 deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 version = "1.11.0"
+
+    [deps.Markdown.syntax]
+    julia_version = "1.14.0-DEV.1669"
 
 [[deps.MarkdownAST]]
 deps = ["AbstractTrees", "Markdown"]
@@ -190,13 +284,22 @@ registries = "General"
 uuid = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
 version = "0.1.2"
 
+    [deps.MarkdownAST.syntax]
+    julia_version = "1.0.0"
+
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2025.11.4"
+version = "2025.12.2"
+
+    [deps.MozillaCACerts_jll.syntax]
+    julia_version = "1.14.0-DEV.1669"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.3.0"
+
+    [deps.NetworkOptions.syntax]
+    julia_version = "1.12.0"
 
 [[deps.OpenSSH_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "OpenSSL_jll", "Zlib_jll"]
@@ -205,15 +308,24 @@ registries = "General"
 uuid = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"
 version = "10.2.1+0"
 
+    [deps.OpenSSH_jll.syntax]
+    julia_version = "1.6.0"
+
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.5.4+0"
+version = "3.5.5+0"
+
+    [deps.OpenSSL_jll.syntax]
+    julia_version = "1.6.0"
 
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
 version = "10.47.0+0"
+
+    [deps.PCRE2_jll.syntax]
+    julia_version = "1.6.0"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
@@ -222,14 +334,20 @@ registries = "General"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "2.8.3"
 
+    [deps.Parsers.syntax]
+    julia_version = "1.6.0"
+
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "Zstd_jll", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.13.0"
+version = "1.14.0"
 weakdeps = ["REPL"]
 
     [deps.Pkg.extensions]
     REPLExt = "REPL"
+
+    [deps.Pkg.syntax]
+    julia_version = "1.12.0"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
@@ -238,27 +356,42 @@ registries = "General"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 version = "1.3.3"
 
+    [deps.PrecompileTools.syntax]
+    julia_version = "1.12.0"
+
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "0f27480397253da18fe2c12a4ba4eb9eb208bf3d"
+git-tree-sha1 = "522f093a29b31a93e34eaea17ba055d850edea28"
 registries = "General"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.5.0"
+version = "1.5.1"
+
+    [deps.Preferences.syntax]
+    julia_version = "1.0.0"
 
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 version = "1.11.0"
 
+    [deps.Printf.syntax]
+    julia_version = "1.14.0-DEV.1669"
+
 [[deps.REPL]]
 deps = ["Dates", "FileWatching", "InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 version = "1.11.0"
 
+    [deps.REPL.syntax]
+    julia_version = "1.14.0-DEV.1669"
+
 [[deps.Random]]
 deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 version = "1.11.0"
+
+    [deps.Random.syntax]
+    julia_version = "1.14.0-DEV.1669"
 
 [[deps.RegistryInstances]]
 deps = ["LazilyInitializedFields", "Pkg", "TOML", "Tar"]
@@ -267,28 +400,43 @@ registries = "General"
 uuid = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
 version = "0.1.0"
 
+    [deps.RegistryInstances.syntax]
+    julia_version = "1.6.0"
+
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 version = "1.0.0"
+
+    [deps.SHA.syntax]
+    julia_version = "1.0.0"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 version = "1.11.0"
 
+    [deps.Serialization.syntax]
+    julia_version = "1.14.0-DEV.1669"
+
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 version = "1.11.0"
 
+    [deps.Sockets.syntax]
+    julia_version = "1.14.0-DEV.1669"
+
 [[deps.StructUtils]]
 deps = ["Dates", "UUIDs"]
-git-tree-sha1 = "79529b493a44927dd5b13dde1c7ce957c2d049e4"
+git-tree-sha1 = "9297459be9e338e546f5c4bedb59b3b5674da7f1"
 registries = "General"
 uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
-version = "2.6.0"
+version = "2.6.2"
 
     [deps.StructUtils.extensions]
     StructUtilsMeasurementsExt = ["Measurements"]
     StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.syntax]
+    julia_version = "1.9.0"
 
     [deps.StructUtils.weakdeps]
     Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
@@ -296,22 +444,34 @@ version = "2.6.0"
 
 [[deps.StyledStrings]]
 uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
-version = "1.11.0"
+version = "1.13.0"
+
+    [deps.StyledStrings.syntax]
+    julia_version = "1.11.0"
 
 [[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 version = "1.0.3"
 
+    [deps.TOML.syntax]
+    julia_version = "1.6.0"
+
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 version = "1.10.0"
 
+    [deps.Tar.syntax]
+    julia_version = "1.3.0"
+
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 version = "1.11.0"
+
+    [deps.Test.syntax]
+    julia_version = "1.14.0-DEV.1669"
 
 [[deps.TranscodingStreams]]
 git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
@@ -319,34 +479,55 @@ registries = "General"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 version = "0.11.3"
 
+    [deps.TranscodingStreams.syntax]
+    julia_version = "1.6.0"
+
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 version = "1.11.0"
 
+    [deps.UUIDs.syntax]
+    julia_version = "1.14.0-DEV.1669"
+
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 version = "1.11.0"
+
+    [deps.Unicode.syntax]
+    julia_version = "1.14.0-DEV.1669"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 version = "1.3.1+2"
 
+    [deps.Zlib_jll.syntax]
+    julia_version = "1.6.0"
+
 [[deps.Zstd_jll]]
 deps = ["CompilerSupportLibraries_jll", "Libdl"]
 uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
 version = "1.5.7+1"
+
+    [deps.Zstd_jll.syntax]
+    julia_version = "1.6.0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
 version = "1.68.0+1"
 
+    [deps.nghttp2_jll.syntax]
+    julia_version = "1.11.0"
+
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 version = "17.7.0+0"
+
+    [deps.p7zip_jll.syntax]
+    julia_version = "1.6.0"
 
 [registries.General]
 url = "https://github.com/JuliaRegistries/General.git"

--- a/deps/jlutilities/documenter/Manifest.toml
+++ b/deps/jlutilities/documenter/Manifest.toml
@@ -80,8 +80,8 @@ version = "0.9.5"
 
 [[deps.Documenter]]
 deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
-git-tree-sha1 = "f964290a125b0f41d618731f626accbda841674e"
-repo-rev = "43d5602f451ecc69d15fa990a7c9df5644fe889b"
+git-tree-sha1 = "bb06f8b98c0ab8c91a32afc0783ce7d743ae582d"
+repo-rev = "31b1f17fdd1727106e26f9499ba1b5c14043b515"
 repo-url = "https://github.com/JuliaDocs/Documenter.jl.git"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 version = "1.16.1"

--- a/deps/jlutilities/documenter/Project.toml
+++ b/deps/jlutilities/documenter/Project.toml
@@ -1,2 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[sources]
+Documenter = {rev = "43d5602f451ecc69d15fa990a7c9df5644fe889b", url = "https://github.com/JuliaDocs/Documenter.jl.git"}

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -382,6 +382,19 @@ DocMeta.setdocmeta!(
     maybe_revise(:(;;));
     recursive=true,
 )
+# Use current Julia version's syntax for Base and Core doctests
+DocMeta.setdocmeta!(
+    Base,
+    :DocTestSyntax,
+    VERSION;
+    recursive=true, warn=false,
+)
+DocMeta.setdocmeta!(
+    Core,
+    :DocTestSyntax,
+    VERSION;
+    recursive=true, warn=false,
+)
 DocMeta.setdocmeta!(
     Base.BinaryPlatforms,
     :DocTestSetup,

--- a/doc/src/devdocs/contributing/jldoctests.md
+++ b/doc/src/devdocs/contributing/jldoctests.md
@@ -110,5 +110,42 @@ When a snippet needs to preserve its result for later examples, give it a label
 and reuse that label. This avoids repeating setup code and mirrors a REPL
 session more closely.
 
+## Syntax versioning
+
+When documenting features that use new Julia syntax, you can specify the required
+syntax version for a doctest block using the `syntax =` option:
+
+````
+```jldoctest; syntax = v"1.14"
+julia> result = @label myblock begin
+           for i in 1:10
+               i > 5 && break myblock i * 2
+           end
+           0
+       end
+12
+```
+````
+
+This ensures the code block is parsed using the specified Julia syntax version,
+allowing doctests for new language features to pass even when the documentation
+is built with an older default syntax.
+
+For modules that predominantly use new syntax, you can set a global default
+using `DocTestSyntax` in a meta block:
+
+````
+```@meta
+DocTestSyntax = v"1.14"
+```
+````
+
+Per-block `syntax =` settings override the global `DocTestSyntax` setting.
+
+!!! compat "Julia 1.14"
+    Syntax versioning for doctests requires Julia 1.14 or later.
+    When running doctests on older Julia versions, blocks with `syntax = v"1.14"`
+    or higher will be skipped with a warning.
+
 ## Further reading
 For a complete reference of doctest syntax, see the [corresponding Documenter.jl docs](https://documenter.juliadocs.org/stable/man/doctests/).


### PR DESCRIPTION
The primary purpose of this PR is to update documenter to enable doctests that use 1.14 syntax. To ensure everything is working, add some doctests that use labeled break.

Written by Claude.