### PR TITLE
Make jl_assume, jl_assume_aligned, jl_unreachable asserts in debug

### DIFF
--- a/src/julia_assert.h
+++ b/src/julia_assert.h
@@ -1,5 +1,8 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
+#ifndef JL_ASSERT_H
+#define JL_ASSERT_H
+
 // Include this file instead of `assert.h` directly.
 // This is necessary because LLVM sometimes has bugs that cause runtime assertion if
 // the `NDEBUG` setting is different from the one used to compile LLVM.
@@ -10,7 +13,10 @@
 // Files that need `assert` should include this file after all other includes.
 // All files should also check `JL_NDEBUG` instead of `NDEBUG`.
 
+#include "support/platform.h"
+
 #pragma GCC visibility push(default)
+
 #ifdef NDEBUG
 #  ifndef JL_NDEBUG
 #    undef NDEBUG
@@ -29,4 +35,100 @@
 #    include <assert.h>
 #  endif
 #endif
+
+#if defined __has_builtin
+#  define jl_has_builtin(x) __has_builtin(x)
+#else
+#  define jl_has_builtin(x) 0
+#endif
+
+#ifdef JL_NDEBUG
+# if jl_has_builtin(__builtin_assume)
+#define jl_assume(cond)                  \
+    (__extension__({                     \
+        __typeof__(cond) cond_ = (cond); \
+        __builtin_assume(!!(cond_));     \
+        cond_;                           \
+    }))
+#elif defined(__GNUC__)
+static inline void jl_assume_(int cond)
+{
+    if (!cond) {
+        __builtin_unreachable();
+    }
+}
+#define jl_assume(cond)                  \
+    (__extension__({                     \
+        __typeof__(cond) cond_ = (cond); \
+        jl_assume_(!!(cond_));           \
+        cond_;                           \
+    }))
+#else
+#  define jl_assume(cond) (cond)
+# endif
+# if jl_has_builtin(__builtin_assume_aligned) || defined(_COMPILER_GCC_)
+#  define jl_assume_aligned(ptr, align) __builtin_assume_aligned(ptr, align)
+# elif defined(__GNUC__)
+#define jl_assume_aligned(ptr, align)               \
+    (__extension__({                                \
+        __typeof__(ptr) ptr_ = (ptr);               \
+        jl_assume(((uintptr_t)ptr_) % (align) == 0); \
+        ptr_;                                       \
+    }))
+#elif defined(__cplusplus)
+template<typename T>
+static inline T
+jl_assume_aligned(T ptr, unsigned align)
+{
+    (void)jl_assume(((uintptr_t)ptr) % align == 0);
+    return ptr;
+}
+# else
+#  define jl_assume_aligned(ptr, align) (ptr)
+# endif
+#else
+# if defined(__GNUC__)
+#define jl_assume(cond)                  \
+    (__extension__({                     \
+        __typeof__(cond) cond_ = (cond); \
+        assert(!!(cond_));               \
+        cond_;                           \
+    }))
+#define jl_assume_aligned(ptr, align)             \
+    (__extension__({                              \
+        __typeof__(ptr) ptr_ = (ptr);             \
+        assert(((uintptr_t)ptr_) % (align) == 0); \
+        ptr_;                                     \
+    }))
+# elif defined(__cplusplus)
+#define jl_assume(cond)      \
+    (([&]() {                \
+        auto cond_ = (cond); \
+        assert(!!(cond_));   \
+        return cond_;        \
+    })())
+#define jl_assume_aligned(ptr, align)             \
+    (([&]() {                                     \
+        auto ptr_ = (ptr);                        \
+        assert(((uintptr_t)ptr_) % (align) == 0); \
+        return ptr_;                              \
+    })())
+#else
+#  define jl_assume(cond) (cond)
+#  define jl_assume_aligned(ptr, align) (ptr)
+# endif
+#endif
+
+#ifdef JL_NDEBUG
+# if jl_has_builtin(__builtin_unreachable) || defined(_COMPILER_GCC_) || defined(_COMPILER_INTEL_)
+#   define jl_unreachable() __builtin_unreachable()
+# else
+#   define jl_unreachable() ((void)jl_assume(0))
+# endif
+#else
+# define jl_unreachable() assert(0 && "unreachable")
+#endif
+
 #pragma GCC visibility pop
+
+#endif /* JL_ASSERT_H */

--- a/src/julia_assert.h
+++ b/src/julia_assert.h
@@ -1,8 +1,5 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
-#ifndef JL_ASSERT_H
-#define JL_ASSERT_H
-
 // Include this file instead of `assert.h` directly.
 // This is necessary because LLVM sometimes has bugs that cause runtime assertion if
 // the `NDEBUG` setting is different from the one used to compile LLVM.
@@ -13,10 +10,7 @@
 // Files that need `assert` should include this file after all other includes.
 // All files should also check `JL_NDEBUG` instead of `NDEBUG`.
 
-#include "support/platform.h"
-
 #pragma GCC visibility push(default)
-
 #ifdef NDEBUG
 #  ifndef JL_NDEBUG
 #    undef NDEBUG
@@ -35,100 +29,4 @@
 #    include <assert.h>
 #  endif
 #endif
-
-#if defined __has_builtin
-#  define jl_has_builtin(x) __has_builtin(x)
-#else
-#  define jl_has_builtin(x) 0
-#endif
-
-#ifdef JL_NDEBUG
-# if jl_has_builtin(__builtin_assume)
-#define jl_assume(cond)                  \
-    (__extension__({                     \
-        __typeof__(cond) cond_ = (cond); \
-        __builtin_assume(!!(cond_));     \
-        cond_;                           \
-    }))
-#elif defined(__GNUC__)
-static inline void jl_assume_(int cond)
-{
-    if (!cond) {
-        __builtin_unreachable();
-    }
-}
-#define jl_assume(cond)                  \
-    (__extension__({                     \
-        __typeof__(cond) cond_ = (cond); \
-        jl_assume_(!!(cond_));           \
-        cond_;                           \
-    }))
-#else
-#  define jl_assume(cond) (cond)
-# endif
-# if jl_has_builtin(__builtin_assume_aligned) || defined(_COMPILER_GCC_)
-#  define jl_assume_aligned(ptr, align) __builtin_assume_aligned(ptr, align)
-# elif defined(__GNUC__)
-#define jl_assume_aligned(ptr, align)               \
-    (__extension__({                                \
-        __typeof__(ptr) ptr_ = (ptr);               \
-        jl_assume(((uintptr_t)ptr_) % (align) == 0); \
-        ptr_;                                       \
-    }))
-#elif defined(__cplusplus)
-template<typename T>
-static inline T
-jl_assume_aligned(T ptr, unsigned align)
-{
-    (void)jl_assume(((uintptr_t)ptr) % align == 0);
-    return ptr;
-}
-# else
-#  define jl_assume_aligned(ptr, align) (ptr)
-# endif
-#else
-# if defined(__GNUC__)
-#define jl_assume(cond)                  \
-    (__extension__({                     \
-        __typeof__(cond) cond_ = (cond); \
-        assert(!!(cond_));               \
-        cond_;                           \
-    }))
-#define jl_assume_aligned(ptr, align)             \
-    (__extension__({                              \
-        __typeof__(ptr) ptr_ = (ptr);             \
-        assert(((uintptr_t)ptr_) % (align) == 0); \
-        ptr_;                                     \
-    }))
-# elif defined(__cplusplus)
-#define jl_assume(cond)      \
-    (([&]() {                \
-        auto cond_ = (cond); \
-        assert(!!(cond_));   \
-        return cond_;        \
-    })())
-#define jl_assume_aligned(ptr, align)             \
-    (([&]() {                                     \
-        auto ptr_ = (ptr);                        \
-        assert(((uintptr_t)ptr_) % (align) == 0); \
-        return ptr_;                              \
-    })())
-#else
-#  define jl_assume(cond) (cond)
-#  define jl_assume_aligned(ptr, align) (ptr)
-# endif
-#endif
-
-#ifdef JL_NDEBUG
-# if jl_has_builtin(__builtin_unreachable) || defined(_COMPILER_GCC_) || defined(_COMPILER_INTEL_)
-#   define jl_unreachable() __builtin_unreachable()
-# else
-#   define jl_unreachable() ((void)jl_assume(0))
-# endif
-#else
-# define jl_unreachable() assert(0 && "unreachable")
-#endif
-
 #pragma GCC visibility pop
-
-#endif /* JL_ASSERT_H */

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2021,6 +2021,16 @@ struct _jl_image_fptrs_t;
 JL_DLLEXPORT void jl_write_coverage_data(const char*);
 void jl_write_malloc_log(void);
 
+#ifdef JL_NDEBUG
+# if jl_has_builtin(__builtin_unreachable) || defined(_COMPILER_GCC_) || defined(_COMPILER_INTEL_)
+#   define jl_unreachable() __builtin_unreachable()
+# else
+#   define jl_unreachable() ((void)jl_assume(0))
+# endif
+#else
+# define jl_unreachable() assert(0 && "unreachable")
+#endif
+
 extern uv_mutex_t symtab_lock;
 jl_sym_t *_jl_symbol(const char *str, size_t len) JL_NOTSAFEPOINT;
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2021,12 +2021,6 @@ struct _jl_image_fptrs_t;
 JL_DLLEXPORT void jl_write_coverage_data(const char*);
 void jl_write_malloc_log(void);
 
-#if jl_has_builtin(__builtin_unreachable) || defined(_COMPILER_GCC_) || defined(_COMPILER_INTEL_)
-#  define jl_unreachable() __builtin_unreachable()
-#else
-#  define jl_unreachable() ((void)jl_assume(0))
-#endif
-
 extern uv_mutex_t symtab_lock;
 jl_sym_t *_jl_symbol(const char *str, size_t len) JL_NOTSAFEPOINT;
 

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -143,7 +143,7 @@ typedef intptr_t ssize_t;
 #  define JL_ATTRIBUTE_ALIGN_PTRSIZE(x)
 #endif
 
-#if defined __has_builtin
+#if defined(__has_builtin)
 #  define jl_has_builtin(x) __has_builtin(x)
 #else
 #  define jl_has_builtin(x) 0

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -3,6 +3,7 @@
 #ifndef JL_DTYPES_H
 #define JL_DTYPES_H
 
+#include <assert.h>
 #include <stddef.h>
 #include <stddef.h> // double include of stddef.h fixes #3421
 #include <stdint.h>
@@ -14,7 +15,6 @@
 
 #include "platform.h"
 #include "analyzer_annotations.h"
-#include "../julia_assert.h"
 
 #if !defined(_OS_WINDOWS_)
 #include <inttypes.h>
@@ -141,6 +141,89 @@ typedef intptr_t ssize_t;
 #  define JL_ATTRIBUTE_ALIGN_PTRSIZE(x) x __attribute__ ((aligned (sizeof(void*))))
 #else
 #  define JL_ATTRIBUTE_ALIGN_PTRSIZE(x)
+#endif
+
+#if defined __has_builtin
+#  define jl_has_builtin(x) __has_builtin(x)
+#else
+#  define jl_has_builtin(x) 0
+#endif
+
+#ifdef JL_NDEBUG
+# if jl_has_builtin(__builtin_assume)
+#define jl_assume(cond)                  \
+    (__extension__({                     \
+        __typeof__(cond) cond_ = (cond); \
+        __builtin_assume(!!(cond_));     \
+        cond_;                           \
+    }))
+#elif defined(__GNUC__)
+static inline void jl_assume_(int cond)
+{
+    if (!cond) {
+        __builtin_unreachable();
+    }
+}
+#define jl_assume(cond)                  \
+    (__extension__({                     \
+        __typeof__(cond) cond_ = (cond); \
+        jl_assume_(!!(cond_));           \
+        cond_;                           \
+    }))
+#else
+#  define jl_assume(cond) (cond)
+# endif
+# if jl_has_builtin(__builtin_assume_aligned) || defined(_COMPILER_GCC_)
+#  define jl_assume_aligned(ptr, align) __builtin_assume_aligned(ptr, align)
+# elif defined(__GNUC__)
+#define jl_assume_aligned(ptr, align)               \
+    (__extension__({                                \
+        __typeof__(ptr) ptr_ = (ptr);               \
+        jl_assume(((uintptr_t)ptr_) % (align) == 0); \
+        ptr_;                                       \
+    }))
+#elif defined(__cplusplus)
+template<typename T>
+static inline T
+jl_assume_aligned(T ptr, unsigned align)
+{
+    (void)jl_assume(((uintptr_t)ptr) % align == 0);
+    return ptr;
+}
+# else
+#  define jl_assume_aligned(ptr, align) (ptr)
+# endif
+#else
+# if defined(__GNUC__)
+#define jl_assume(cond)                  \
+    (__extension__({                     \
+        __typeof__(cond) cond_ = (cond); \
+        assert(!!(cond_));               \
+        cond_;                           \
+    }))
+#define jl_assume_aligned(ptr, align)             \
+    (__extension__({                              \
+        __typeof__(ptr) ptr_ = (ptr);             \
+        assert(((uintptr_t)ptr_) % (align) == 0); \
+        ptr_;                                     \
+    }))
+# elif defined(__cplusplus)
+#define jl_assume(cond)      \
+    (([&]() {                \
+        auto cond_ = (cond); \
+        assert(!!(cond_));   \
+        return cond_;        \
+    })())
+#define jl_assume_aligned(ptr, align)             \
+    (([&]() {                                     \
+        auto ptr_ = (ptr);                        \
+        assert(((uintptr_t)ptr_) % (align) == 0); \
+        return ptr_;                              \
+    })())
+#else
+#  define jl_assume(cond) (cond)
+#  define jl_assume_aligned(ptr, align) (ptr)
+# endif
 #endif
 
 typedef int bool_t;

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -150,39 +150,39 @@ typedef intptr_t ssize_t;
 #endif
 
 #ifdef JL_NDEBUG
-# if jl_has_builtin(__builtin_assume)
-#define jl_assume(cond)                  \
-    (__extension__({                     \
-        __typeof__(cond) cond_ = (cond); \
-        __builtin_assume(!!(cond_));     \
-        cond_;                           \
-    }))
-#elif defined(__GNUC__)
+#  if jl_has_builtin(__builtin_assume)
+#    define jl_assume(cond)                     \
+       (__extension__({                         \
+           __typeof__(cond) cond_ = (cond);     \
+           __builtin_assume(!!(cond_));         \
+           cond_;                               \
+       }))
+#  elif defined(__GNUC__)
 static inline void jl_assume_(int cond)
 {
     if (!cond) {
         __builtin_unreachable();
     }
 }
-#define jl_assume(cond)                  \
-    (__extension__({                     \
-        __typeof__(cond) cond_ = (cond); \
-        jl_assume_(!!(cond_));           \
-        cond_;                           \
-    }))
-#else
-#  define jl_assume(cond) (cond)
-# endif
-# if jl_has_builtin(__builtin_assume_aligned) || defined(_COMPILER_GCC_)
-#  define jl_assume_aligned(ptr, align) __builtin_assume_aligned(ptr, align)
-# elif defined(__GNUC__)
-#define jl_assume_aligned(ptr, align)               \
-    (__extension__({                                \
-        __typeof__(ptr) ptr_ = (ptr);               \
-        jl_assume(((uintptr_t)ptr_) % (align) == 0); \
-        ptr_;                                       \
-    }))
-#elif defined(__cplusplus)
+#    define jl_assume(cond)                     \
+       (__extension__({                         \
+           __typeof__(cond) cond_ = (cond);     \
+           jl_assume_(!!(cond_));               \
+           cond_;                               \
+       }))
+#  else
+#    define jl_assume(cond) (cond)
+#  endif
+#  if jl_has_builtin(__builtin_assume_aligned) || defined(_COMPILER_GCC_)
+#    define jl_assume_aligned(ptr, align) __builtin_assume_aligned(ptr, align)
+#  elif defined(__GNUC__)
+#    define jl_assume_aligned(ptr, align)               \
+       (__extension__({                                 \
+           __typeof__(ptr) ptr_ = (ptr);                \
+           jl_assume(((uintptr_t)ptr_) % (align) == 0); \
+           ptr_;                                        \
+       }))
+#  elif defined(__cplusplus)
 template<typename T>
 static inline T
 jl_assume_aligned(T ptr, unsigned align)
@@ -190,40 +190,40 @@ jl_assume_aligned(T ptr, unsigned align)
     (void)jl_assume(((uintptr_t)ptr) % align == 0);
     return ptr;
 }
-# else
-#  define jl_assume_aligned(ptr, align) (ptr)
-# endif
+#  else
+#    define jl_assume_aligned(ptr, align) (ptr)
+#  endif
 #else
-# if defined(__GNUC__)
-#define jl_assume(cond)                  \
-    (__extension__({                     \
-        __typeof__(cond) cond_ = (cond); \
-        assert(!!(cond_));               \
-        cond_;                           \
-    }))
-#define jl_assume_aligned(ptr, align)             \
-    (__extension__({                              \
-        __typeof__(ptr) ptr_ = (ptr);             \
-        assert(((uintptr_t)ptr_) % (align) == 0); \
-        ptr_;                                     \
-    }))
-# elif defined(__cplusplus)
-#define jl_assume(cond)      \
-    (([&]() {                \
-        auto cond_ = (cond); \
-        assert(!!(cond_));   \
-        return cond_;        \
-    })())
-#define jl_assume_aligned(ptr, align)             \
-    (([&]() {                                     \
-        auto ptr_ = (ptr);                        \
-        assert(((uintptr_t)ptr_) % (align) == 0); \
-        return ptr_;                              \
-    })())
-#else
-#  define jl_assume(cond) (cond)
-#  define jl_assume_aligned(ptr, align) (ptr)
-# endif
+#  if defined(__GNUC__)
+#    define jl_assume(cond)                     \
+       (__extension__({                         \
+           __typeof__(cond) cond_ = (cond);     \
+           assert(!!(cond_));                   \
+           cond_;                               \
+       }))
+#    define jl_assume_aligned(ptr, align)               \
+       (__extension__({                                 \
+           __typeof__(ptr) ptr_ = (ptr);                \
+           assert(((uintptr_t)ptr_) % (align) == 0);    \
+           ptr_;                                        \
+       }))
+#  elif defined(__cplusplus)
+#    define jl_assume(cond)                     \
+       (([&]() {                                \
+           auto cond_ = (cond);                 \
+           assert(!!(cond_));                   \
+           return cond_;                        \
+       })())
+#    define jl_assume_aligned(ptr, align)               \
+       (([&]() {                                        \
+           auto ptr_ = (ptr);                           \
+           assert(((uintptr_t)ptr_) % (align) == 0);    \
+           return ptr_;                                 \
+       })())
+#  else
+#    define jl_assume(cond) (cond)
+#    define jl_assume_aligned(ptr, align) (ptr)
+#  endif
 #endif
 
 typedef int bool_t;

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -14,6 +14,7 @@
 
 #include "platform.h"
 #include "analyzer_annotations.h"
+#include "../julia_assert.h"
 
 #if !defined(_OS_WINDOWS_)
 #include <inttypes.h>
@@ -140,54 +141,6 @@ typedef intptr_t ssize_t;
 #  define JL_ATTRIBUTE_ALIGN_PTRSIZE(x) x __attribute__ ((aligned (sizeof(void*))))
 #else
 #  define JL_ATTRIBUTE_ALIGN_PTRSIZE(x)
-#endif
-
-#ifdef __has_builtin
-#  define jl_has_builtin(x) __has_builtin(x)
-#else
-#  define jl_has_builtin(x) 0
-#endif
-
-#if jl_has_builtin(__builtin_assume)
-#define jl_assume(cond) (__extension__ ({               \
-                __typeof__(cond) cond_ = (cond);        \
-                __builtin_assume(!!(cond_));            \
-                cond_;                                  \
-            }))
-#elif defined(__GNUC__)
-static inline void jl_assume_(int cond)
-{
-    if (!cond) {
-        __builtin_unreachable();
-    }
-}
-#define jl_assume(cond) (__extension__ ({               \
-                __typeof__(cond) cond_ = (cond);        \
-                jl_assume_(!!(cond_));                  \
-                cond_;                                  \
-            }))
-#else
-#define jl_assume(cond) (cond)
-#endif
-
-#if jl_has_builtin(__builtin_assume_aligned) || defined(_COMPILER_GCC_)
-#define jl_assume_aligned(ptr, align) __builtin_assume_aligned(ptr, align)
-#elif defined(__GNUC__)
-#define jl_assume_aligned(ptr, align) (__extension__ ({         \
-                __typeof__(ptr) ptr_ = (ptr);                   \
-                jl_assume(((uintptr_t)ptr) % (align) == 0);     \
-                ptr_;                                           \
-            }))
-#elif defined(__cplusplus)
-template<typename T>
-static inline T
-jl_assume_aligned(T ptr, unsigned align)
-{
-    (void)jl_assume(((uintptr_t)ptr) % align == 0);
-    return ptr;
-}
-#else
-#define jl_assume_aligned(ptr, align) (ptr)
 #endif
 
 typedef int bool_t;


### PR DESCRIPTION
When JL_NDEBUG is undefined, we should use these as assertions. Suggested by @topolarity in
https://github.com/JuliaLang/julia/pull/60031#discussion_r2799620544.