### PR TITLE
Tweak labeled break - Provide `@label block` for default break scope

### DIFF
--- a/JuliaLowering/src/binding_analysis.jl
+++ b/JuliaLowering/src/binding_analysis.jl
@@ -285,7 +285,7 @@ function du_visit!(ctx, state::DefUseState, e)
             return false
         end
 
-    elseif k == K"break_block"
+    elseif k == K"symbolicblock"
         # Skip the first child (break target label) - it's not a @goto target
         # No save/restore needed: the body always executes (break just exits early)
         has_label = false

--- a/JuliaLowering/src/kinds.jl
+++ b/JuliaLowering/src/kinds.jl
@@ -76,7 +76,6 @@ function _register_kinds()
             "BindingId"
             # Various heads harvested from flisp lowering.
             # (TODO: May or may not need all these - assess later)
-            "break_block"
             # Like block, but introduces a lexical scope; used during scope resolution.
             "scope_block"
             # Equivalent to Expr(:softscope).  If found in the top-level thunk,

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -75,6 +75,7 @@ struct LinearIRContext{Attrs} <: AbstractLoweringContext
     argmap::Dict{IdTag, IdTag}
     return_type::Union{Nothing, SyntaxTree{Attrs}}
     break_targets::Dict{String, JumpTarget{Attrs}}
+    break_label_stack::Vector{String}  # tracks nesting order of symbolicblock labels
     handler_token_stack::SyntaxList{Attrs, Vector{NodeId}}
     catch_token_stack::SyntaxList{Attrs, Vector{NodeId}}
     finally_handlers::Vector{FinallyHandler{Attrs}}
@@ -90,7 +91,8 @@ function LinearIRContext(graph, ctx, is_toplevel_thunk, lambda_bindings, return_
     Attrs = typeof(graph.attributes)
     LinearIRContext(graph, SyntaxList(ctx), ctx.bindings, Ref(0),
                     is_toplevel_thunk, lambda_bindings, Dict{IdTag,IdTag}(), rett,
-                    Dict{String,JumpTarget{Attrs}}(), SyntaxList(ctx), SyntaxList(ctx),
+                    Dict{String,JumpTarget{Attrs}}(), String[],
+                    SyntaxList(ctx), SyntaxList(ctx),
                     Vector{FinallyHandler{Attrs}}(), Dict{String,JumpTarget{Attrs}}(),
                     Vector{JumpOrigin{Attrs}}(), Set{String}(), Dict{Symbol, Any}(), ctx.mod)
 end
@@ -308,7 +310,7 @@ function emit_break(ctx, ex)
     target = get(ctx.break_targets, name, nothing)
     if isnothing(target)
         if name == "loop_exit"
-            throw(LoweringError(ex, "`break` must be used inside a `while` or `for` loop"))
+            throw(LoweringError(ex, "`break` must be used inside a `while`, `for` loop, or `@label` block"))
         elseif name == "loop_cont"
             throw(LoweringError(ex, "`continue` must be used inside a `while` or `for` loop"))
         elseif endswith(name, "#cont")
@@ -316,6 +318,27 @@ function emit_break(ctx, ex)
             throw(LoweringError(ex, "`continue $label` is not inside a `@label $label` loop"))
         else
             throw(LoweringError(ex, "`break $name` is not inside a `@label $name` block"))
+        end
+    end
+    # If targeting loop_exit, check for intervening named @label blocks
+    if name == "loop_exit"
+        for i in lastindex(ctx.break_label_stack):-1:1
+            lbl = ctx.break_label_stack[i]
+            lbl == "loop_exit" && break
+            if lbl != "loop_cont" && !contains(lbl, '#')
+                throw(LoweringError(ex,
+                    "plain `break` inside `@label $lbl` block is disallowed; use `break $lbl` to exit the block"))
+            end
+        end
+    end
+    # If targeting loop_cont, check for intervening loop_exit (@label block)
+    if name == "loop_cont"
+        for i in lastindex(ctx.break_label_stack):-1:1
+            lbl = ctx.break_label_stack[i]
+            lbl == "loop_cont" && break
+            if lbl == "loop_exit"
+                throw(LoweringError(ex, "`continue` inside an anonymous `@label` block is not allowed"))
+            end
         end
     end
     # Handle valued break (break name val)
@@ -696,40 +719,26 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
             end
             res
         end
-    elseif k == K"break_block"
-        end_label = make_label(ctx, ex)
-        name = ex[1].name_val
-        outer_target = get(ctx.break_targets, name, nothing)
-        # Inherit result_var from outer symbolicblock if present
-        outer_result_var = isnothing(outer_target) ? nothing : outer_target.result_var
-        ctx.break_targets[name] = JumpTarget(end_label, ctx, outer_result_var)
-        compile(ctx, ex[2], false, false)
-        if isnothing(outer_target)
-            delete!(ctx.break_targets, name)
-        else
-            ctx.break_targets[name] = outer_target
-        end
-        emit(ctx, end_label)
-        if needs_value
-            compile(ctx, nothing_(ctx, ex), needs_value, in_tail_pos)
-        end
     elseif k == K"symbolicblock"
         name = ex[1].name_val
-        if haskey(ctx.symbolic_jump_targets, name) || name in ctx.symbolic_block_labels
-            throw(LoweringError(ex, "Label `$name` defined multiple times"))
+        # Skip duplicate check for default-scope labels (loop_exit, loop_cont) which allow nesting
+        if name != "loop_exit" && name != "loop_cont"
+            if haskey(ctx.symbolic_jump_targets, name) || name in ctx.symbolic_block_labels
+                throw(LoweringError(ex, "Label `$name` defined multiple times"))
+            end
+            push!(ctx.symbolic_block_labels, name)
         end
-        push!(ctx.symbolic_block_labels, name)
         end_label = make_label(ctx, ex)
-        result_var = if needs_value || in_tail_pos
-            rv = new_local_binding(ctx, ex, "$(name)_result")
-            emit_assignment(ctx, ex, rv, nothing_(ctx, ex))
-            rv
-        else
-            nothing
+        need_value = needs_value || in_tail_pos
+        result_var = need_value ? new_local_binding(ctx, ex, "$(name)_result") : nothing
+        if !isnothing(result_var)
+            emit_assignment(ctx, ex, result_var, nothing_(ctx, ex))
         end
         outer_target = get(ctx.break_targets, name, nothing)
         ctx.break_targets[name] = JumpTarget(end_label, ctx, result_var)
-        body_val = compile(ctx, ex[2], !isnothing(result_var), false)
+        push!(ctx.break_label_stack, name)
+        body_val = compile(ctx, ex[2], need_value, false)
+        pop!(ctx.break_label_stack)
         if !isnothing(result_var) && !isnothing(body_val)
             emit_assignment(ctx, ex, result_var, body_val)
         end
@@ -742,7 +751,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         if in_tail_pos
             emit_return(ctx, ex, result_var)
             nothing
-        else
+        elseif needs_value
             result_var
         end
     elseif k == K"break"

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -275,7 +275,8 @@ vst1(vcx::Validation1Context, st::SyntaxTree)::ValidationResult = @stm st begin
     [K"symboliclabel" lab] -> vst1_ident(vcx, lab; lhs=true)
     [K"symbolicgoto" lab] -> vst1_ident(vcx, lab; lhs=true)
     [K"symbolicblock" lab body] ->
-        vst1_ident(vcx, lab; lhs=true) & vst1(with(vcx; in_symblock=true), body)
+        (kind(lab) == K"symboliclabel" ? pass() : vst1_ident(vcx, lab; lhs=true)) &
+        vst1(with(vcx; in_symblock=true), body)
     [K"gc_preserve" x ids...] -> vst1(vcx, x) & all(vst1_ident, vcx, ids)
     [K"gc_preserve_begin" ids...] -> all(vst1_ident, vcx, ids)
     [K"gc_preserve_end" ids...] -> all(vst1_ident, vcx, ids)

--- a/JuliaLowering/test/branching_ir.jl
+++ b/JuliaLowering/test/branching_ir.jl
@@ -239,18 +239,18 @@ x = @label foo
 #          └─┘ ── misplaced label in value position
 
 ########################################
-# Labeled block with underscore label and valued break
-@label _ begin
+# Anonymous labeled block with valued break
+@label begin
     a
     break _ 42
     b
 end
 #---------------------
-1   (= slot₁/__result core.nothing)
+1   (= slot₁/loop_exit_result core.nothing)
 2   TestMod.a
-3   (= slot₁/__result 42)
+3   (= slot₁/loop_exit_result 42)
 4   (goto label₇)
 5   TestMod.b
-6   (= slot₁/__result %₅)
-7   slot₁/__result
+6   (= slot₁/loop_exit_result %₅)
+7   slot₁/loop_exit_result
 8   (return %₇)

--- a/JuliaLowering/test/exceptions_ir.jl
+++ b/JuliaLowering/test/exceptions_ir.jl
@@ -235,21 +235,24 @@ while true
     end
 end
 #---------------------
-1   (gotoifnot true label₁₅)
-2   (enter label₉)
-3   (= slot₁/finally_tag -1)
-4   TestMod.a
-5   (leave %₂)
-6   (goto label₁₅)
-7   (leave %₂)
-8   (goto label₁₀)
-9   (= slot₁/finally_tag 1)
-10  TestMod.b
-11  (call core.=== slot₁/finally_tag 1)
-12  (gotoifnot %₁₁ label₁₄)
-13  (call top.rethrow)
-14  (goto label₁)
-15  (return core.nothing)
+1   (= slot₁/loop_exit_result core.nothing)
+2   (gotoifnot true label₁₆)
+3   (enter label₁₀)
+4   (= slot₂/finally_tag -1)
+5   TestMod.a
+6   (leave %₃)
+7   (goto label₁₇)
+8   (leave %₃)
+9   (goto label₁₁)
+10  (= slot₂/finally_tag 1)
+11  TestMod.b
+12  (call core.=== slot₂/finally_tag 1)
+13  (gotoifnot %₁₂ label₁₅)
+14  (call top.rethrow)
+15  (goto label₂)
+16  (= slot₁/loop_exit_result core.nothing)
+17  slot₁/loop_exit_result
+18  (return %₁₇)
 
 ########################################
 # try/catch/finally

--- a/JuliaLowering/test/loops_ir.jl
+++ b/JuliaLowering/test/loops_ir.jl
@@ -5,14 +5,17 @@ while f(a)
     body2
 end
 #---------------------
-1   TestMod.f
-2   TestMod.a
-3   (call %₁ %₂)
-4   (gotoifnot %₃ label₈)
-5   TestMod.body1
-6   TestMod.body2
-7   (goto label₁)
-8   (return core.nothing)
+1   (= slot₁/loop_exit_result core.nothing)
+2   TestMod.f
+3   TestMod.a
+4   (call %₂ %₃)
+5   (gotoifnot %₄ label₉)
+6   TestMod.body1
+7   TestMod.body2
+8   (goto label₂)
+9   (= slot₁/loop_exit_result core.nothing)
+10  slot₁/loop_exit_result
+11  (return %₁₀)
 
 ########################################
 # While loop with short circuit condition
@@ -20,13 +23,16 @@ while a && b
     body
 end
 #---------------------
-1   TestMod.a
-2   (gotoifnot %₁ label₇)
-3   TestMod.b
-4   (gotoifnot %₃ label₇)
-5   TestMod.body
-6   (goto label₁)
-7   (return core.nothing)
+1   (= slot₁/loop_exit_result core.nothing)
+2   TestMod.a
+3   (gotoifnot %₂ label₈)
+4   TestMod.b
+5   (gotoifnot %₄ label₈)
+6   TestMod.body
+7   (goto label₂)
+8   (= slot₁/loop_exit_result core.nothing)
+9   slot₁/loop_exit_result
+10  (return %₉)
 
 ########################################
 # While loop with with break and continue
@@ -38,15 +44,18 @@ while cond
     body3
 end
 #---------------------
-1   TestMod.cond
-2   (gotoifnot %₁ label₉)
-3   TestMod.body1
-4   (goto label₉)
-5   TestMod.body2
-6   (goto label₈)
-7   TestMod.body3
-8   (goto label₁)
-9   (return core.nothing)
+1   (= slot₁/loop_exit_result core.nothing)
+2   TestMod.cond
+3   (gotoifnot %₂ label₁₀)
+4   TestMod.body1
+5   (goto label₁₁)
+6   TestMod.body2
+7   (goto label₉)
+8   TestMod.body3
+9   (goto label₂)
+10  (= slot₁/loop_exit_result core.nothing)
+11  slot₁/loop_exit_result
+12  (return %₁₁)
 
 ########################################
 # Basic for loop
@@ -54,23 +63,30 @@ for x in xs
     body
 end
 #---------------------
-1   TestMod.xs
-2   (= slot₁/next (call top.iterate %₁))
-3   slot₁/next
-4   (call core.=== %₃ core.nothing)
-5   (call top.not_int %₄)
-6   (gotoifnot %₅ label₁₇)
-7   slot₁/next
-8   (= slot₂/x (call core.getfield %₇ 1))
-9   (call core.getfield %₇ 2)
-10  TestMod.body
-11  (= slot₁/next (call top.iterate %₁ %₉))
-12  slot₁/next
-13  (call core.=== %₁₂ core.nothing)
-14  (call top.not_int %₁₃)
-15  (gotoifnot %₁₄ label₁₇)
-16  (goto label₇)
-17  (return core.nothing)
+1   (= slot₃/loop_exit_result core.nothing)
+2   TestMod.xs
+3   (= slot₁/next (call top.iterate %₂))
+4   slot₁/next
+5   (call core.=== %₄ core.nothing)
+6   (call top.not_int %₅)
+7   (gotoifnot %₆ label₂₀)
+8   slot₁/next
+9   (= slot₂/x (call core.getfield %₈ 1))
+10  (call core.getfield %₈ 2)
+11  TestMod.body
+12  (= slot₁/next (call top.iterate %₂ %₁₀))
+13  slot₁/next
+14  (call core.=== %₁₃ core.nothing)
+15  (call top.not_int %₁₄)
+16  (gotoifnot %₁₅ label₁₈)
+17  (goto label₈)
+18  (= slot₄/if_val core.nothing)
+19  (goto label₂₁)
+20  (= slot₄/if_val core.nothing)
+21  slot₄/if_val
+22  (= slot₃/loop_exit_result %₂₁)
+23  slot₃/loop_exit_result
+24  (return %₂₃)
 
 ########################################
 # Syntax sugar for nested for loop
@@ -78,40 +94,47 @@ for x in xs, y in ys
     x = 10 # Copy of x; does not overwrite x iteration var
 end
 #---------------------
-1   TestMod.xs
-2   (= slot₂/next (call top.iterate %₁))
-3   slot₂/next
-4   (call core.=== %₃ core.nothing)
-5   (call top.not_int %₄)
-6   (gotoifnot %₅ label₃₄)
-7   slot₂/next
-8   (= slot₃/x (call core.getfield %₇ 1))
-9   (call core.getfield %₇ 2)
-10  TestMod.ys
-11  (= slot₁/next (call top.iterate %₁₀))
-12  slot₁/next
-13  (call core.=== %₁₂ core.nothing)
-14  (call top.not_int %₁₃)
-15  (gotoifnot %₁₄ label₂₈)
-16  slot₃/x
-17  (= slot₄/x %₁₆)
-18  slot₁/next
-19  (= slot₅/y (call core.getfield %₁₈ 1))
-20  (call core.getfield %₁₈ 2)
-21  (= slot₄/x 10)
-22  (= slot₁/next (call top.iterate %₁₀ %₂₀))
-23  slot₁/next
-24  (call core.=== %₂₃ core.nothing)
-25  (call top.not_int %₂₄)
-26  (gotoifnot %₂₅ label₂₈)
-27  (goto label₁₆)
-28  (= slot₂/next (call top.iterate %₁ %₉))
-29  slot₂/next
-30  (call core.=== %₂₉ core.nothing)
-31  (call top.not_int %₃₀)
-32  (gotoifnot %₃₁ label₃₄)
-33  (goto label₇)
-34  (return core.nothing)
+1   (= slot₆/loop_exit_result core.nothing)
+2   TestMod.xs
+3   (= slot₂/next (call top.iterate %₂))
+4   slot₂/next
+5   (call core.=== %₄ core.nothing)
+6   (call top.not_int %₅)
+7   (gotoifnot %₆ label₃₇)
+8   slot₂/next
+9   (= slot₃/x (call core.getfield %₈ 1))
+10  (call core.getfield %₈ 2)
+11  TestMod.ys
+12  (= slot₁/next (call top.iterate %₁₁))
+13  slot₁/next
+14  (call core.=== %₁₃ core.nothing)
+15  (call top.not_int %₁₄)
+16  (gotoifnot %₁₅ label₂₉)
+17  slot₃/x
+18  (= slot₄/x %₁₇)
+19  slot₁/next
+20  (= slot₅/y (call core.getfield %₁₉ 1))
+21  (call core.getfield %₁₉ 2)
+22  (= slot₄/x 10)
+23  (= slot₁/next (call top.iterate %₁₁ %₂₁))
+24  slot₁/next
+25  (call core.=== %₂₄ core.nothing)
+26  (call top.not_int %₂₅)
+27  (gotoifnot %₂₆ label₂₉)
+28  (goto label₁₇)
+29  (= slot₂/next (call top.iterate %₂ %₁₀))
+30  slot₂/next
+31  (call core.=== %₃₀ core.nothing)
+32  (call top.not_int %₃₁)
+33  (gotoifnot %₃₂ label₃₅)
+34  (goto label₈)
+35  (= slot₇/if_val core.nothing)
+36  (goto label₃₈)
+37  (= slot₇/if_val core.nothing)
+38  slot₇/if_val
+39  (= slot₆/loop_exit_result %₃₈)
+40  slot₆/loop_exit_result
+41  (return %₄₀)
 
 ########################################
 # Error: break outside for/while

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,8 +12,10 @@ New language features
     operator suffixes, accessible as `\^alpha`, `\^epsilon`, `\^ltphi`, `\_<`, `\_>`, and `\_schwa` at the REPL
     ([#60285]).
   - The `@label` macro can now create labeled blocks that can be exited early with `break name [value]`. Use
-    `@label name expr` for named blocks or `@label _ expr` for anonymous blocks. The `continue` statement also
-    supports labels with `continue name` to continue a labeled loop ([#60481]).
+    `@label name expr` for named blocks or `@label expr` for anonymous blocks. Anonymous `@label` blocks
+    participate in the default break scope: a plain `break` or `break _` exits the innermost breakable scope,
+    whether it is a loop or an `@label` block. The `continue` statement also supports labels with
+    `continue name` to continue a labeled loop ([#60481]).
 
 Language changes
 ----------------

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -290,7 +290,7 @@ function _show_nd(io::IO, @nospecialize(a::AbstractArray), print_matrix::Functio
     reached_last_d = false
     for I in Is
         idxs = I.I
-        @label _ begin
+        @label entry begin
             if limit
                 for i = 1:nd
                     ii = idxs[i]
@@ -308,16 +308,16 @@ function _show_nd(io::IO, @nospecialize(a::AbstractArray), print_matrix::Functio
                                 szj = length(axs[j+2])
                                 indj = tailinds[j]
                                 if szj>10 && first(indj)+2 < idxs[j] <= last(indj)-3
-                                    break _
+                                    break entry
                                 end
                             end
                             print(io, ";"^(i+2))
                             print(io, " \u2026 ")
                             show_full && print(io, "\n\n")
-                            break _
+                            break entry
                         end
                         if ind[firstindex(ind)+2] < ii <= ind[end-3]
-                            break _
+                            break entry
                         end
                     end
                 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1172,7 +1172,10 @@ kw"finally"
 """
     break
 
-Break out of a loop immediately.
+Break out of the innermost loop or [`@label`](@ref) block immediately.
+
+`break` exits the innermost breakable scope, which may be a `for` or `while` loop, or
+an `@label` block.
 
 # Examples
 ```jldoctest

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -481,7 +481,7 @@ function locate_package_env(pkg::PkgId, stopenv::Union{String, Nothing}=nothing)
         specenv = get(cache.located, (pkg, stopenv), missing)
         specenv === missing || return specenv
     end
-    (env′, spec) = @label _ begin
+    (env′, spec) = @label found begin
         if pkg.uuid === nothing
             # The project we're looking for does not have a Project.toml (n.b. - present
             # `Project.toml` without UUID gets a path-based dummy UUID). It must have
@@ -493,10 +493,10 @@ function locate_package_env(pkg::PkgId, stopenv::Union{String, Nothing}=nothing)
                 found = implicit_manifest_pkgid(env, pkg.name)
                 if found !== nothing && found.uuid === nothing
                     @assert found.name == pkg.name
-                    break _ (env, implicit_manifest_uuid_load_spec(env, pkg))
+                    break found (env, implicit_manifest_uuid_load_spec(env, pkg))
                 end
                 if !(loading_extension || precompiling_extension)
-                    stopenv == env && break _ (nothing, nothing)
+                    stopenv == env && break found (nothing, nothing)
                 end
             end
         else
@@ -505,10 +505,10 @@ function locate_package_env(pkg::PkgId, stopenv::Union{String, Nothing}=nothing)
                 # missing is used as a sentinel to stop looking further down in envs
                 if spec === missing
                     is_stdlib(pkg) && break
-                    break _ (nothing, nothing)
+                    break found (nothing, nothing)
                 end
                 if spec !== nothing
-                    break _ (env, spec)
+                    break found (env, spec)
                 end
                 if !(loading_extension || precompiling_extension)
                     stopenv == env && break
@@ -518,7 +518,7 @@ function locate_package_env(pkg::PkgId, stopenv::Union{String, Nothing}=nothing)
             # e.g. if they have been explicitly added to the project/manifest
             mbyspec = manifest_uuid_load_spec(Sys.STDLIB, pkg)
             if mbyspec isa PkgLoadSpec
-                break _ (Sys.STDLIB, mbyspec)
+                break found (Sys.STDLIB, mbyspec)
             end
         end
         (nothing, nothing)
@@ -1169,7 +1169,7 @@ function explicit_manifest_deps_get(project_file::String, where::PkgId, name::St
             # a table of entries (deps = {"DepA" = "6ea...", "DepB" = "55d..."}
             deps = get(entry, "deps", nothing)::Union{Vector{String}, Dict{String, Any}, Nothing}
             local dep::Union{Nothing, PkgId}
-            @label _ begin
+            @label resolved begin
                 if UUID(uuid) === where.uuid
                     dep = dep_stanza_get(deps, name)
 
@@ -1197,7 +1197,7 @@ function explicit_manifest_deps_get(project_file::String, where::PkgId, name::St
                                     (deps,))
                                 dep = dep_stanza_get(deps′, name)
                                 dep === nothing && continue
-                                break _
+                                break resolved
                             end
                             return PkgId(name)
                         end
@@ -2635,13 +2635,13 @@ function find_unsuitable_manifests_versions()
         manifest_file isa String || continue # no manifest file
         m = parsed_toml(manifest_file)
         man_julia_version = get(m, "julia_version", nothing)
-        @label _ begin
-            man_julia_version isa String || break _
+        @label check begin
+            man_julia_version isa String || break check
             man_julia_version = VersionNumber(man_julia_version)
-            thispatch(man_julia_version) != thispatch(VERSION) && break _
-            isempty(man_julia_version.prerelease) != isempty(VERSION.prerelease) && break _
+            thispatch(man_julia_version) != thispatch(VERSION) && break check
+            isempty(man_julia_version.prerelease) != isempty(VERSION.prerelease) && break check
             isempty(man_julia_version.prerelease) && continue
-            man_julia_version.prerelease[1] != VERSION.prerelease[1] && break _
+            man_julia_version.prerelease[1] != VERSION.prerelease[1] && break check
             if VERSION.prerelease[1] == "DEV"
                 # manifests don't store the 2nd part of prerelease, so cannot check further
                 # so treat them specially in the warning

--- a/base/strings/annotated_io.jl
+++ b/base/strings/annotated_io.jl
@@ -165,7 +165,7 @@ This is implemented so that one can say write an `AnnotatedString` to an
 new annotation for each character.
 """
 function _insert_annotations!(annots::Vector{RegionAnnotation}, newannots::Vector{RegionAnnotation}, offset::Int = 0)
-    run = @label _ begin
+    run = @label search begin
         if !isempty(annots) && last(last(annots).region) == offset
             for i in reverse(axes(newannots, 1))
                 annot = newannots[i]
@@ -181,10 +181,10 @@ function _insert_annotations!(annots::Vector{RegionAnnotation}, newannots::Vecto
                     old.label != new.label ||
                     old.value != new.value)
                 end || continue
-                break _ i
+                break search i
             end
         end
-        break _ 0
+        0
     end
     for runindex in 0:run-1
         old_index = lastindex(annots) - run + 1 + runindex

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -461,23 +461,23 @@ end
 
 # duck-type s so that external UTF-8 string packages like StringViews can hook in
 function iterate_continued(s, i::Int, u::UInt32)
-    @label _ begin
-        u < 0xc0000000 && (i += 1; break _)
+    @label begin
+        u < 0xc0000000 && (i += 1; break)
         n = ncodeunits(s)
         # first continuation byte
-        (i += 1) > n && break _
+        (i += 1) > n && break
         @inbounds b = codeunit(s, i)
-        b & 0xc0 == 0x80 || break _
+        b & 0xc0 == 0x80 || break
         u |= UInt32(b) << 16
         # second continuation byte
-        ((i += 1) > n) | (u < 0xe0000000) && break _
+        ((i += 1) > n) | (u < 0xe0000000) && break
         @inbounds b = codeunit(s, i)
-        b & 0xc0 == 0x80 || break _
+        b & 0xc0 == 0x80 || break
         u |= UInt32(b) << 8
         # third continuation byte
-        ((i += 1) > n) | (u < 0xf0000000) && break _
+        ((i += 1) > n) | (u < 0xf0000000) && break
         @inbounds b = codeunit(s, i)
-        b & 0xc0 == 0x80 || break _
+        b & 0xc0 == 0x80 || break
         u |= UInt32(b); i += 1
     end
     return reinterpret(Char, u), i
@@ -492,27 +492,27 @@ end
 
 # duck-type s so that external UTF-8 string packages like StringViews can hook in
 function getindex_continued(s, i::Int, u::UInt32)
-    @label _ begin
+    @label begin
         if u < 0xc0000000
             # called from `getindex` which checks bounds
-            @inbounds isvalid(s, i) && break _
+            @inbounds isvalid(s, i) && break
             string_index_err(s, i)
         end
         n = ncodeunits(s)
 
-        (i += 1) > n && break _
+        (i += 1) > n && break
         @inbounds b = codeunit(s, i) # cont byte 1
-        b & 0xc0 == 0x80 || break _
+        b & 0xc0 == 0x80 || break
         u |= UInt32(b) << 16
 
-        ((i += 1) > n) | (u < 0xe0000000) && break _
+        ((i += 1) > n) | (u < 0xe0000000) && break
         @inbounds b = codeunit(s, i) # cont byte 2
-        b & 0xc0 == 0x80 || break _
+        b & 0xc0 == 0x80 || break
         u |= UInt32(b) << 8
 
-        ((i += 1) > n) | (u < 0xf0000000) && break _
+        ((i += 1) > n) | (u < 0xf0000000) && break
         @inbounds b = codeunit(s, i) # cont byte 3
-        b & 0xc0 == 0x80 || break _
+        b & 0xc0 == 0x80 || break
         u |= UInt32(b)
     end
     return reinterpret(Char, u)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1531,10 +1531,10 @@ catch e
     @test e.error isa MethodError
 end
 
-@test_loweringerror(:(if true; break; end for i = 1:1), "break or continue outside loop")
-@test_loweringerror(:([if true; break; end for i = 1:1]), "break or continue outside loop")
+@test_loweringerror(:(if true; break; end for i = 1:1), "`break` must be used inside a `while`, `for` loop, or `@label` block")
+@test_loweringerror(:([if true; break; end for i = 1:1]), "`break` must be used inside a `while`, `for` loop, or `@label` block")
 @test_loweringerror(:(Int[if true; break; end for i = 1:1]), "break or continue outside loop")
-@test_loweringerror(:([if true; continue; end for i = 1:1]), "break or continue outside loop")
+@test_loweringerror(:([if true; continue; end for i = 1:1]), "`continue` must be used inside a `while` or `for` loop")
 @test_loweringerror(:(Int[if true; continue; end for i = 1:1]), "break or continue outside loop")
 
 @test_loweringerror(:(return 0 for i=1:2), "\"return\" not allowed inside comprehension or generator")


### PR DESCRIPTION
For reasons outlined in #60980, tweak the labeled break design to:

1. Disallow `@label _ begin; end`, instead introduce `@label begin; end` which introduce a default break label (i.e. the same break label used by while/for).

2. Change `break _ [val]` to target the default break label

This is breaking vs master, but of course not vs 1.13 since the feature is new.

Closes #60980. Written by Claude.