### PR TITLE
[JuliaLowering] Fix `@nospecialize` multi-arg and add 0-arg

### DIFF
--- a/JuliaLowering/Manifest.toml
+++ b/JuliaLowering/Manifest.toml
@@ -10,7 +10,13 @@ path = "."
 uuid = "f3c80556-a63f-4383-b822-37d64f81a311"
 version = "1.0.0-DEV"
 
+    [deps.JuliaLowering.syntax]
+    julia_version = "1.0.0"
+
 [[deps.JuliaSyntax]]
 path = "../JuliaSyntax"
 uuid = "70703baa-626e-46a2-a12c-08ffd08c73b4"
 version = "2.0.0-DEV"
+
+    [deps.JuliaSyntax.syntax]
+    julia_version = "1.0.0"

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -350,6 +350,11 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
             gid = declare_in_scope!(ctx, top_scope(ctx), ex, :global)
             b = get_binding(ctx, gid)
         end
+        # Body-level @nospecialize sets :nospecialize metadata on identifiers.
+        # Propagate this to the binding so the slot gets the nospecialize flag.
+        if getmeta(ex, :nospecialize, false) && b.kind === :argument
+            b.is_nospecialize = true
+        end
         newleaf(ctx, ex, K"BindingId", b.id)
     elseif k === K"BindingId"
         ex

--- a/JuliaLowering/src/syntax_macros.jl
+++ b/JuliaLowering/src/syntax_macros.jl
@@ -32,21 +32,16 @@ function _apply_nospecialize(ctx, ex)
     end
 end
 
-function Base.var"@nospecialize"(__context__::MacroContext)
-    @ast __context__ __context__.macrocall [K"meta" "nospecialize"::K"Symbol"]
-end
-
-function Base.var"@nospecialize"(__context__::MacroContext, ex::SyntaxTree)
-    _apply_nospecialize(__context__, ex)
-end
-
-function Base.var"@nospecialize"(
-        __context__::MacroContext,
-        ex1::SyntaxTree, ex2::SyntaxTree, exs::SyntaxTree...
-    )
-    to_nospecialize = SyntaxTree[ex1, ex2, exs...]
-    @ast __context__ __context__.macrocall [K"block"
-        map(st->_apply_nospecialize(__context__, st), to_nospecialize)...]
+function Base.var"@nospecialize"(__context__::MacroContext, exs::SyntaxTree...)
+    if length(exs) == 0
+        @ast __context__ __context__.macrocall [K"meta" "nospecialize"::K"Symbol"]
+    elseif length(exs) == 1
+        _apply_nospecialize(__context__, only(exs))
+    else
+        @ast __context__ __context__.macrocall [K"block"
+            map(ex->_apply_nospecialize(__context__, ex), exs)...
+        ]
+     end
 end
 
 # TODO: support all forms that the original supports

--- a/JuliaLowering/src/syntax_macros.jl
+++ b/JuliaLowering/src/syntax_macros.jl
@@ -32,9 +32,21 @@ function _apply_nospecialize(ctx, ex)
     end
 end
 
-function Base.var"@nospecialize"(__context__::MacroContext, ex, exs...)
-    # TODO support multi-arg version properly
+function Base.var"@nospecialize"(__context__::MacroContext)
+    @ast __context__ __context__.macrocall [K"meta" "nospecialize"::K"Symbol"]
+end
+
+function Base.var"@nospecialize"(__context__::MacroContext, ex::SyntaxTree)
     _apply_nospecialize(__context__, ex)
+end
+
+function Base.var"@nospecialize"(
+        __context__::MacroContext,
+        ex1::SyntaxTree, ex2::SyntaxTree, exs::SyntaxTree...
+    )
+    to_nospecialize = SyntaxTree[ex1, ex2, exs...]
+    @ast __context__ __context__.macrocall [K"block"
+        map(st->_apply_nospecialize(__context__, st), to_nospecialize)...]
 end
 
 # TODO: support all forms that the original supports

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -378,6 +378,90 @@ end
         (f_branch_meta(10, false), f_branch_meta(20, true))
     end
     """) == (12, 21)
+
+    # @nospecialize with multiple args in function body
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_nospecialize_multi_body(a, b, c, d)
+            @nospecialize a c d
+            (a, b, c, d)
+        end
+
+        f_nospecialize_multi_body(1, 2, 3, 4)
+    end
+    """) == (1, 2, 3, 4)
+    @test only(methods(test_mod.f_nospecialize_multi_body)).nospecialize == 0b1101
+
+    # @nospecialize with single arg in function body
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_nospecialize_single_body(a, b)
+            @nospecialize b
+            (a, b)
+        end
+
+        f_nospecialize_single_body(1, 2)
+    end
+    """) == (1, 2)
+    @test only(methods(test_mod.f_nospecialize_single_body)).nospecialize == 0b10
+
+    # @nospecialize with zero args in function body (blanket nospecialize)
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_nospecialize_zero_body(a, b, c)
+            @nospecialize
+            (a, b, c)
+        end
+
+        f_nospecialize_zero_body(1, 2, 3)
+    end
+    """) == (1, 2, 3)
+    # 0-arg @nospecialize sets all bits (-1 == typemax(Int32) for nospecialize)
+    @test only(methods(test_mod.f_nospecialize_zero_body)).nospecialize == -1
+
+    # @nospecialize with default value in signature
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_nospecialize_default(x, @nospecialize(y=1))
+            (x, y)
+        end
+
+        (f_nospecialize_default(10, 20), f_nospecialize_default(30))
+    end
+    """) == ((10, 20), (30, 1))
+    # The 2-arg method has nospecialize on y (bit 2), the 1-arg forwarding method has no y
+    ms = collect(methods(test_mod.f_nospecialize_default))
+    @test any(m -> m.nargs == 3 && m.nospecialize == 0b10, ms)
+    @test any(m -> m.nargs == 2 && m.nospecialize == 0b00, ms)
+
+    # Body-level @nospecialize with default value in signature
+    # See the TODO comment in `optional_positional_defs!`
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_body_nospecialize_default(x, y=1)
+            @nospecialize
+            (x, y)
+        end
+        (f_body_nospecialize_default(10, 20), f_body_nospecialize_default(30))
+    end
+    """) == ((10, 20), (30, 1))
+    # The 2-arg method has nospecialize on y (bit 2), the 1-arg forwarding method has no y
+    ms = collect(methods(test_mod.f_body_nospecialize_default))
+    @test count(m -> m.nargs == 3 && m.nospecialize == -1, ms) == 1
+    @test_broken count(m -> m.nargs == 2 && m.nospecialize == -1, ms) == 1
+
+    # Body-level @nospecialize for methods with keyword arguments
+    @test JuliaLowering.include_string(test_mod, """
+    function f_body_nospecialize_with_kwargs(a; kw=1)
+        @nospecialize a
+        (a, kw)
+    end
+    (f_body_nospecialize_with_kwargs(1; kw=2), f_body_nospecialize_with_kwargs(3))
+    """) == ((1,2), (3,1))
+    # Although not tested here, the keyword body method (`var"#f_body_nospecialize_with_kwargs#0"`)'s
+    # third argument (corresponding to `a`) should probably be nospecialized too.
+    @test_broken only(methods(test_mod.f_body_nospecialize_with_kwargs)).nospecialize == 1
+    @test_broken only(methods(Core.kwcall, (NamedTuple,typeof(test_mod.f_body_nospecialize_with_kwargs),Any))) == 1 << 2
 end
 
 @testset "Keyword functions" begin

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -461,7 +461,7 @@ end
     # Although not tested here, the keyword body method (`var"#f_body_nospecialize_with_kwargs#0"`)'s
     # third argument (corresponding to `a`) should probably be nospecialized too.
     @test_broken only(methods(test_mod.f_body_nospecialize_with_kwargs)).nospecialize == 1
-    @test_broken only(methods(Core.kwcall, (NamedTuple,typeof(test_mod.f_body_nospecialize_with_kwargs),Any))) == 1 << 2
+    @test_broken only(methods(Core.kwcall, (NamedTuple,typeof(test_mod.f_body_nospecialize_with_kwargs),Any))).nospecialize == 1 << 2
 end
 
 @testset "Keyword functions" begin

--- a/JuliaLowering/test/macros_ir.jl
+++ b/JuliaLowering/test/macros_ir.jl
@@ -208,3 +208,54 @@ end
 10  latestworld
 11  TestMod.foo
 12  (return %₁₁)
+
+########################################
+# @nospecialize (single arg in body)
+function foo(a, b)
+    @nospecialize a
+    a + b
+end
+#---------------------
+1   (method TestMod.foo)
+2   latestworld
+3   TestMod.foo
+4   (call core.Typeof %₃)
+5   (call core.svec %₄ core.Any core.Any)
+6   (call core.svec)
+7   SourceLocation::1:10
+8   (call core.svec %₅ %₆ %₇)
+9   --- method core.nothing %₈
+    slots: [slot₁/#self#(!read) slot₂/a(nospecialize) slot₃/b]
+    1   slot₂/a
+    2   TestMod.+
+    3   (call %₂ slot₂/a slot₃/b)
+    4   (return %₃)
+10  latestworld
+11  TestMod.foo
+12  (return %₁₁)
+
+########################################
+# @nospecialize (multi-arg in body)
+function foo(x, y, z)
+    @nospecialize x z
+    x + y + z
+end
+#---------------------
+1   (method TestMod.foo)
+2   latestworld
+3   TestMod.foo
+4   (call core.Typeof %₃)
+5   (call core.svec %₄ core.Any core.Any core.Any)
+6   (call core.svec)
+7   SourceLocation::1:10
+8   (call core.svec %₅ %₆ %₇)
+9   --- method core.nothing %₈
+    slots: [slot₁/#self#(!read) slot₂/x(nospecialize) slot₃/y slot₄/z(nospecialize)]
+    1   slot₂/x
+    2   slot₄/z
+    3   TestMod.+
+    4   (call %₃ slot₂/x slot₃/y slot₄/z)
+    5   (return %₄)
+10  latestworld
+11  TestMod.foo
+12  (return %₁₁)


### PR DESCRIPTION
Split the single `@nospecialize(ctx, ex, exs...)` method into properly typed variants:
- 0-arg: emits `[K"meta" "nospecialize"]` for blanket usage
- 1-arg: applies `_apply_nospecialize` to the argument
- 2+-arg: applies `_apply_nospecialize` to all arguments

The previous implementation only processed the first argument when multiple were given (the rest were silently ignored).