### PR TITLE
[JuliaLowering] Fix-up implementation of `GC.@preserve`

### DIFF
--- a/JuliaLowering/src/syntax_macros.jl
+++ b/JuliaLowering/src/syntax_macros.jl
@@ -253,20 +253,7 @@ function Base.GC.var"@preserve"(__context__::MacroContext, exs...)
             throw(MacroExpansionError(e, "Preserved variable must be a symbol"))
         end
     end
-    @ast __context__ __context__.macrocall [K"block"
-        [K"="
-            "s"::K"Identifier"
-            [K"gc_preserve_begin"
-                idents...
-            ]
-        ]
-        [K"="
-            "r"::K"Identifier"
-            exs[end]
-        ]
-        [K"gc_preserve_end" "s"::K"Identifier"]
-        "r"::K"Identifier"
-    ]
+    @ast __context__ __context__.macrocall [K"gc_preserve" exs[end] exs[1:end-1]...]
 end
 
 function Base.Experimental.var"@opaque"(__context__::MacroContext, ex)

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -356,6 +356,25 @@ end
     GC.@preserve @static if true v"1.14" else end
     """) isa VersionNumber
 
+    # JuliaLowering.jl/issues/144
+    @test JuliaLowering.include_string(test_mod, """
+    f_preserve144() = let
+        val = Any[]
+        GC.@preserve val begin; end
+    end
+    f_preserve144()
+    """) == nothing
+
+    # JuliaLowering.jl/issues/145
+    @test JuliaLowering.include_string(test_mod, """
+    f_preserve145() = let
+        debug_buffer = IOBuffer()
+        # inside function to force compilation
+        GC.@preserve debug_buffer 1
+    end
+    f_preserve145()
+    """) == 1
+
     # only invokelatest produces :isglobal now, so MWE here
     Base.eval(test_mod, :(macro isglobal(x); esc(Expr(:isglobal, x)); end))
     @test JuliaLowering.include_string(test_mod, """

--- a/JuliaLowering/test/misc_ir.jl
+++ b/JuliaLowering/test/misc_ir.jl
@@ -271,14 +271,13 @@ end
 #---------------------
 1   TestMod.a
 2   TestMod.b
-3   (= slot₂/s (gc_preserve_begin %₁ %₂))
+3   (gc_preserve_begin %₁ %₂)
 4   TestMod.f
 5   TestMod.a
 6   TestMod.b
-7   (= slot₁/r (call %₄ %₅ %₆))
-8   (gc_preserve_end slot₂/s)
-9   slot₁/r
-10  (return %₉)
+7   (call %₄ %₅ %₆)
+8   (gc_preserve_end %₃)
+9   (return %₇)
 
 ########################################
 # Error: GC.@preserve bad args


### PR DESCRIPTION
Trying to emulate the scope token by introducing an identifier / local doesn't work when the result is compiled:
```julia
julia> JuliaLowering.include_string(Main, raw"""
       foo() = let
           debug_buffer = IOBuffer()
           GC.@preserve debug_buffer try; println(); catch; end
       end
       foo()
       """; expr_compat_mode=true)
julia: /home/topolarity/repos/julia/src/codegen.cpp:6999: jl_cgval_t emit_expr(jl_codectx_t&, jl_value_t*, ssize_t):
Assertion `token.V->getType()->isTokenTy()' failed.
```

As far as I can tell, this must be implemented via `Expr(:gc_preserve, ...)` since the `gc_preserve_begin` token must end up ultimately as an `SSAValue`.

Resolves https://github.com/JuliaLang/JuliaLowering.jl/issues/145.

P.S. @mlechu this is fairly barebones test coverage, so let me know if you'd like me to add some more.