### PR TITLE
[JuliaLowering] Fix `BoundsError` in `sink_assignment`

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -232,7 +232,7 @@ end
 # flisp: sink-assignment
 function sink_assignment(ctx, srcref, lhs, rhs)
     @assert is_identifier_like(lhs)
-    if kind(rhs) == K"block"
+    if kind(rhs) == K"block" && numchildren(rhs) > 0
         @ast ctx srcref [K"block"
             rhs[1:end-1]...
             [K"=" lhs rhs[end]]

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -346,4 +346,8 @@ end
     @test test_mod.val_history == [2, 1, 2, 1]
 end
 
+# JuliaLowering/issues/144
+emptyblock_result = JuliaLowering.eval(test_mod, Expr(:(=), :emptyblock_144, Expr(:block)))
+@test emptyblock_result == nothing
+
 end


### PR DESCRIPTION
We had missed this `is-pair?` check in flisp: https://github.com/JuliaLang/julia/blob/df1fb13dc371c059218cc48b402730489dbc4963/src/julia-syntax.scm#L2553

Resolves https://github.com/JuliaLang/JuliaLowering.jl/issues/144.