### PR TITLE
docs: Fix `Cmd` doc typo

### DIFF
--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -393,7 +393,7 @@ an existing `Cmd` or list of arguments:
 
 ```julia
 run(Cmd(`pwd`, dir=".."))
-run(Cmd(["pwd"], detach=true, ignorestatus=true))
+run(Cmd(Cmd(["pwd"]), detach=true, ignorestatus=true))
 ```
 
 This allows you to specify several aspects of the `Cmd`'s execution environment via keyword arguments. For


### PR DESCRIPTION
The previous example:

```julia
run(Cmd(["pwd"], detach=true, ignorestatus=true))
```

errors.