### PR TITLE
codegen: represent Bool as i1 instead of i8 in LLVM IR

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4372,7 +4372,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         if (jl_is_type_type(ta.typ) && !jl_has_free_typevars(ta.typ) &&
             jl_is_type_type(tb.typ) && !jl_has_free_typevars(tb.typ)) {
             int issub = jl_subtype(jl_tparam0(ta.typ), jl_tparam0(tb.typ));
-            *ret = mark_julia_type(ctx, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), issub), false, jl_bool_type);
+            *ret = mark_julia_type(ctx, ConstantInt::get(getInt1Ty(ctx.builder.getContext()), issub), false, jl_bool_type);
             return true;
         }
     }


### PR DESCRIPTION
This PR is largely written with AI assistance in the codegen area, which I am not particularly proficient in. Therefore, it may contain unsatisfactory aspects.
I wrote this to replace #54731. The fundamental insight is that compared to when #21712 was reported, LLVM's handling of `i1` has been matured enough, and I believe we can now take advantage of it. A pkgeval may be necessary to ensure that this change does not impact the ecosystem.

This PR consists of the following two commits:

- [codegen: represent Bool as i1 instead of i8 in LLVM IR](https://github.com/JuliaLang/julia/commit/bffa57affba86dd93117012a30b921ede54713a8)

  Change Bool's LLVM IR representation from i8 to i1 for SSA values.
  Memory layout is unchanged (Bool is still 1 byte in memory).
  
  Previously, Bool was represented as i8 in LLVM IR (with i1 used only
  for llvmcall), requiring explicit truncation to i1 for branches and
  zero-extension back to i8 for storage. This led to missed optimizations
  since LLVM could not recognize identity patterns like `and_int(x, true)`
  or `or_int(x, false)` on i8 values without knowing the upper 7 bits
  are unused.
  
  With i1 as the native Bool type, LLVM can now fold these patterns
  automatically: `x AND 1` on i1 is identity, as is `x OR 0`.
  
  Key changes:
  - `bitstype_to_llvm` returns i1 unconditionally for Bool
  - Bool constants generated as i1 values
  - Atomic operations widen i1 to i8 (LLVM requires byte-minimum atomics)
  - Removed redundant i1↔i8 conversions (Success ZExt, typed_load trunc)
  - VecElement{Bool} keeps i8 in non-llvmcall mode since <N x i1> packs
    bits, which doesn't match Julia's 1-byte-per-Bool memory layout
  - `zext_struct` is retained to bridge the type mismatch between
    llvmcall (<N x i1>) and memory representation (<N x i8>) for
    VecElement{Bool} vectors
  
  Fixes https://github.com/JuliaLang/julia/issues/21712

- [codegen: remove Bool special case in emit_unbox](https://github.com/JuliaLang/julia/commit/1aafe8248494866ef03d3a12527c8482497cce67)

  Now that Bool is represented as i1 natively, the special case in
  emit_unbox that loaded as i8 with !range metadata and then truncated
  to i1 is no longer needed. The general load path handles Bool correctly:
  `load i1, ptr` internally loads a byte and masks to 1 bit, which is
  equivalent to the old manual approach.