### PR TITLE
[JuliaLowering][CI] Run `Pkg.test()` for stdlibs

### DIFF
--- a/test/JuliaLowering_stdlibs.jl
+++ b/test/JuliaLowering_stdlibs.jl
@@ -1,7 +1,24 @@
 import Libdl
 
-# known precompilation failures under JL
-const INCOMPATIBLE_STDLIBS = String[]
+# known test failures under JL
+const INCOMPATIBLE_STDLIBS = String[
+
+    # root-caused / minimized failures
+    "Distributed",      # uses post-lowering `Expr(:const, ...)` form  (JuliaLang/JuliaLowering.jl#149)
+    "InteractiveUtils", # highlighting test failure                    (JuliaLang/JuliaLowering.jl#155)
+    "Logging",          # `@noinline` modifies stack trace             (JuliaLang/JuliaLowering.jl#159)
+    "Mmap",             # static parameters + default args failure     (JuliaLang/JuliaLowering.jl#158)
+    "Profile",          # unexpected kwarg syntax                      (JuliaLang/JuliaLowering.jl#151)
+    "SparseArrays",     # broadcasted type regression                  (JuliaLang/JuliaLowering.jl#152)
+    "Test",             # overloading `..`                             (JuliaLang/JuliaLowering.jl#154) 
+
+    # undiagnosed failures
+    "REPL",  # inference failures (4 items pre-compiled, but expected 0)
+    "Pkg",   # box failures (TBD)
+
+    # these take too long to run, even if they did pass
+    "LinearAlgebra", # fails due to @inferred regressions
+]
 
 const JULIA_EXECUTABLE = Base.unsafe_string(Base.JLOptions().julia_bin)
 const JULIA_CPU_TARGET = get(ENV, "JULIA_CPU_TARGET", Base.unsafe_string(Base.JLOptions().cpu_target))
@@ -42,17 +59,21 @@ else
     # Standalone test run (CI), compile every time
     compile_JL_sysimage(JL_sysimage)
 end
-stdlibs_to_test = filter(name -> !in(name, INCOMPATIBLE_STDLIBS), readdir(Sys.STDLIB))
+stdlibs = readdir(Sys.STDLIB)
+stdlibs_to_test = filter(name -> !in(name, INCOMPATIBLE_STDLIBS), stdlibs)
 
 configs = [
     ``=>Base.CacheFlags(check_bounds=0, debug_level=2, opt_level=3),
     ``=>Base.CacheFlags(check_bounds=1, debug_level=2, opt_level=3),
 ]
-setupproject_command = "using Pkg; Pkg.add($(stdlibs_to_test))"
-compilecache_command = "using Base: CacheFlags; Base.Precompilation.precompilepkgs($(stdlibs_to_test); configs=$(configs))"
+setupproject_command = "using Pkg; Pkg.add($(stdlibs))"
+compilecache_command = "using Base: CacheFlags; Base.Precompilation.precompilepkgs($(stdlibs); configs=$(configs))"
+testpkgs_command = "using Pkg; Pkg.test($(stdlibs_to_test))"
 
 # pre-compile stdlibs (into temporary depot)
 mktempdir() do tmp_depot
+    tmp_depot = abspath("./JuliaLowering_depot")
+
     # first setup the project / environment
     env_dir = joinpath(tmp_depot, "environments", "v$(VERSION.major).$(VERSION.minor)")
     cmd = addenv(
@@ -64,6 +85,18 @@ mktempdir() do tmp_depot
     # now actually perform the precompilation
     cmd = addenv(
         `$(JULIA_EXECUTABLE) --sysimage $(JL_sysimage) --startup-file=no -e $compilecache_command`,
+        "JULIA_LOAD_PATH" => "@stdlib$(Base.Linking.pathsep)$(env_dir)",
+        "JULIA_CPU_TARGET" => "sysimage",
+        "JULIA_USE_FLISP_LOWERING" => "0",
+        "JULIA_USE_FALLBACK_REPL" => "0",
+        "JULIA_DEPOT_PATH" => tmp_depot,
+        ; inherit = true
+    )
+    success(run(cmd))
+
+    # and then run the stdlib tests
+    cmd = addenv(
+        `$(JULIA_EXECUTABLE) --sysimage $(JL_sysimage) --startup-file=no -e $testpkgs_command`,
         "JULIA_LOAD_PATH" => "@stdlib$(Base.Linking.pathsep)$(env_dir)",
         "JULIA_CPU_TARGET" => "sysimage",
         "JULIA_USE_FLISP_LOWERING" => "0",


### PR DESCRIPTION
As of b35bcd7688acee5ec0871735fe090d33bb1624cd, JuliaLowering can successfully lower and pre-compile all stdlibs! 🎉 

The next step is to get all their tests passing. There are plenty of failures to investigate:
```console
Packages errored during testing: Artifacts, CRC32c, Distributed, Downloads, FileWatching, InteractiveUtils, LibCURL (received signal: 6), LibGit2, LinearAlgebra, Logging, Mmap, Pkg, Profile, REPL, Random, SharedArrays, SparseArrays, Statistics, StyledStrings, Tar, Test
```

Draft while some early bugfixes are landed / CI time is evaluated.