### PR TITLE
[JuliaLowering] Use `var"#self#"` instead of `@__FUNCTION__` for v1.12 compat

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -235,7 +235,7 @@ We can assume `st` has passed `valid_st1`.  Errors arising from invalid AST
 """
 function est_to_dst(st::SyntaxTree; all_expanded=true)
     g = st._graph
-    rec = @__FUNCTION__()
+    rec = var"#self#"
 
     return @stm st begin
         [K"Identifier"] -> let s = st.name_val


### PR DESCRIPTION
`@__FUNCTION__` is only available on v1.13+. Since JETLS, currently the primary consumer of JuliaLowering, only supports v1.12, use `var"#self#"` to allow JETLS to use the latest JuliaLowering version until it gains v1.13+ compatibility.