### PR TITLE
Make.inc: fix xcrun invocation

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1716,7 +1716,7 @@ endif
 CLANGSA_FLAGS :=
 CLANGSA_CXXFLAGS :=
 ifeq ($(OS), Darwin) # on new XCode, the files are hidden
- CLANGSA_FLAGS += -isysroot $(shell xcrun --show-sdk-path -sdk macosx)
+ CLANGSA_FLAGS += -isysroot $(shell xcrun --show-sdk-path --sdk macosx)
 endif
 ifeq ($(USEGCC),1)
 # try to help clang find the c++ files for CC by guessing the value for --prefix


### PR DESCRIPTION
The officially supported argument is --sdk, not -sdk, though it seems the later also works in practice. But with BinaryBuilder, we use a 'fake' xcrun script which only supports the officially documented argument name.

I've also submitted a [PR to let BinaryBuilderBase.jl accept this](https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/464); but I think it's wise for us to stick to the officially documented options.