### PR TITLE
inference: Alias-aware union splitting for identical arguments

### DIFF
--- a/Compiler/src/typeutils.jl
+++ b/Compiler/src/typeutils.jl
@@ -192,16 +192,88 @@ function tuple_tail_elem(𝕃::AbstractLattice, @nospecialize(init), ct::Vector{
     return Vararg{widenconst(t)}
 end
 
+# Given `fargs` from `ArgInfo` and optionally `argtypes`, compute alias groups
+# for argument positions. Returns `nothing` if `fargs === nothing`, otherwise a
+# `Vector{Int}` where `groups[i]` is the index of the leader for position `i`.
+# `groups[i] == i` means leader (or non-aliased); `groups[i] < i` means follower.
+#
+# Aliasing is detected from two sources:
+# 1. IR identity: same `SlotNumber`/`SSAValue` in `fargs`
+# 2. `MustAlias` in `argtypes`: same `(slot, ssadef, fldidx)` means same value
+function compute_alias_groups(
+        na::Int,
+        fargs::Union{Nothing,Vector{Any}},
+        argtypes::Union{Nothing,Vector{Any}}
+    )
+    groups = Vector{Int}(undef, na)
+    for i = 1:na
+        groups[i] = i
+    end
+    fargs !== nothing && merge_fargs_alias_groups!(groups, fargs)
+    argtypes !== nothing && merge_mustalias_groups!(groups, argtypes)
+    return groups
+end
+
+# Detect aliasing from IR identity: same `SlotNumber`/`SSAValue` in `fargs`.
+function merge_fargs_alias_groups!(groups::Vector{Int}, fargs::Vector{Any})
+    for i = 1:length(groups)
+        arg_i = fargs[i]
+        if arg_i isa SlotNumber || arg_i isa SSAValue
+            for j in 1:i-1
+                if fargs[j] === arg_i
+                    groups[i] = groups[j]
+                    break
+                end
+            end
+        end
+    end
+    return groups
+end
+
+# Detect additional aliasing from `MustAlias` lattice elements in `argtypes`:
+# two positions with the same `(slot, ssadef, fldidx)` must refer to the same value.
+function merge_mustalias_groups!(groups::Vector{Int}, argtypes::Vector{Any})
+    for i = 1:length(groups)
+        groups[i] == i || continue # already a follower
+        ti = argtypes[i]
+        ti isa MustAlias || continue
+        for j in 1:i-1
+            groups[j] == j || continue # only match against leaders
+            tj = argtypes[j]
+            tj isa MustAlias || continue
+            if ti.slot == tj.slot && ti.ssadef == tj.ssadef && ti.fldidx == tj.fldidx
+                # Merge: make j the leader for i, and re-point any
+                # existing followers of i to j as well
+                for k in i:length(groups)
+                    if groups[k] == i
+                        groups[k] = j
+                    end
+                end
+                break
+            end
+        end
+    end
+    return groups
+end
+
 # Gives a cost function over the effort to switch a tuple-union representation
 # as a cartesian product, relative to the size of the original representation.
 # Thus, we count the longest element as being roughly invariant to being inside
 # or outside of the Tuple/Union nesting, though somewhat more expensive to be
 # outside than inside because the representation is larger (because and it
 # informs the callee whether any splitting is possible).
-function unionsplitcost(𝕃::AbstractLattice, argtypes::Union{SimpleVector,Vector{Any}})
+function unionsplitcost(𝕃::AbstractLattice, argtypes::Union{SimpleVector,Vector{Any}};
+                        fargs::Union{Nothing,Vector{Any}}=nothing)
+    na = length(argtypes)
+    groups = compute_alias_groups(na, fargs, argtypes isa Vector{Any} ? argtypes : nothing)
     nu = 1
     max = 2
-    for ti in argtypes
+    for i in 1:na
+        # skip followers: their type is constrained by their leader
+        if groups !== nothing && groups[i] != i
+            continue
+        end
+        ti = argtypes[i]
         if has_extended_unionsplit(𝕃) && !isvarargtype(ti)
             ti = widenconst(ti)
         end
@@ -225,9 +297,15 @@ function switchtupleunion(@nospecialize(ty))
     return _switchtupleunion(JLTypeLattice(), Any[tparams...], length(tparams), [], ty)
 end
 
-switchtupleunion(𝕃::AbstractLattice, argtypes::Vector{Any}) = _switchtupleunion(𝕃, argtypes, length(argtypes), [], nothing)
+function switchtupleunion(𝕃::AbstractLattice, argtypes::Vector{Any};
+                          fargs::Union{Nothing,Vector{Any}}=nothing)
+    na = length(argtypes)
+    groups = compute_alias_groups(na, fargs, argtypes)
+    return _switchtupleunion(𝕃, argtypes, na, [], nothing, groups)
+end
 
-function _switchtupleunion(𝕃::AbstractLattice, t::Vector{Any}, i::Int, tunion::Vector{Any}, @nospecialize(origt))
+function _switchtupleunion(𝕃::AbstractLattice, t::Vector{Any}, i::Int, tunion::Vector{Any},
+                           @nospecialize(origt), groups::Union{Nothing,Vector{Int}}=nothing)
     if i == 0
         if origt === nothing
             push!(tunion, copy(t))
@@ -235,24 +313,53 @@ function _switchtupleunion(𝕃::AbstractLattice, t::Vector{Any}, i::Int, tunion
             tpl = rewrap_unionall(Tuple{t...}, origt)
             push!(tunion, tpl)
         end
+        return tunion
+    end
+
+    if groups !== nothing && groups[i] != i
+        # If this position is a follower (aliased to an earlier position),
+        # its type is already set by the leader — just recurse without iterating.
+        _switchtupleunion(𝕃, t, i - 1, tunion, origt, groups)
     else
         origti = ti = t[i]
-        # TODO remove this to implement callsite refinement of MustAlias
+        followers = Int[]
+        if groups !== nothing
+            for j in i+1:length(t)
+                if groups[j] == i # Collect follower indices for this leader
+                    push!(followers, j)
+                end
+            end
+        end
+        # TODO Generalize this to allow callsite union-splitting of MustAlias
         if isa(ti, Union)
+            origtypes = Any[t[j] for j in followers]
             for ty in uniontypes(ti)
                 t[i] = ty
-                _switchtupleunion(𝕃, t, i - 1, tunion, origt)
+                for j in followers
+                    t[j] = ty
+                end
+                _switchtupleunion(𝕃, t, i - 1, tunion, origt, groups)
             end
             t[i] = origti
+            for (k, j) in enumerate(followers)
+                t[j] = origtypes[k]
+            end
         elseif (has_extended_unionsplit(𝕃) && !isa(ti, Const) && !isvarargtype(ti) &&
             (wty = widenconst(ti); isa(wty, Union)))
+            origtypes = Any[t[j] for j in followers]
             for ty in uniontypes(wty)
                 t[i] = ty
-                _switchtupleunion(𝕃, t, i - 1, tunion, origt)
+                for j in followers
+                    t[j] = ty
+                end
+                _switchtupleunion(𝕃, t, i - 1, tunion, origt, groups)
             end
             t[i] = origti
+            for (k, j) in enumerate(followers)
+                t[j] = origtypes[k]
+            end
         else
-            _switchtupleunion(𝕃, t, i - 1, tunion, origt)
+            _switchtupleunion(𝕃, t, i - 1, tunion, origt, groups)
         end
     end
     return tunion

--- a/Compiler/src/typeutils.jl
+++ b/Compiler/src/typeutils.jl
@@ -324,7 +324,7 @@ function _switchtupleunion(𝕃::AbstractLattice, t::Vector{Any}, i::Int, tunion
         origti = ti = t[i]
         followers = Int[]
         if groups !== nothing
-            for j in i+1:length(t)
+            for j in 1:length(t)
                 if groups[j] == i # Collect follower indices for this leader
                     push!(followers, j)
                 end


### PR DESCRIPTION
When the same IR variable (`SlotNumber`/`SSAValue`) is passed to multiple argument positions of a call, the union-split algorithm previously generated the full cartesian product of `Union` types. For example, `f(a, a, a)` where `a::Union{A,B}` produced 8 splits when only 2 diagonal combinations are actually reachable, causing wasted inference on impossible type combinations.

This commit uses `fargs` from `ArgInfo` and `MustAlias` information from `argtypes` to detect argument aliasing via `compute_alias_groups`, which builds a leader/follower mapping. Aliasing is detected from two sources: IR identity (same `SlotNumber`/`SSAValue` in `fargs`) and `MustAlias` lattice elements with matching `(slot, ssadef, fldidx)`, which covers cases like `f(a.x, a.x)` where distinct SSAValues refer to the same field. In cost calculation, each alias group is counted once. In split generation, only leaders iterate over union types and propagate the chosen type to their followers.