### PR TITLE
Fix `Base.show(io::IO, b::Binding)` for e.g. `:(:)` or `:(==)`

### DIFF
--- a/base/docs/bindings.jl
+++ b/base/docs/bindings.jl
@@ -28,7 +28,14 @@ function Base.show(io::IO, b::Binding)
     if b.mod === Base.active_module()
         print(io, b.var)
     else
-        print(io, b.mod, '.', Base.isoperator(b.var) ? ":" : "", b.var)
+        print(io, b.mod, '.')
+        if Base.isoperator(b.var)
+            # ensures symbols are quoted right, so e.g.  :(==), :(:), :+ or :-
+            show(io, b.var)
+        else
+            # print ordinary identifiers without any quoting
+            print(io, b.var)
+        end
     end
 end
 

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1296,6 +1296,10 @@ let x = Binding(Main, :+)
     @test Meta.parse(string(x)) == :(Base.:+)
 end
 
+let x = Binding(Main, :(:))
+    @test Meta.parse(string(x)) == :(Base.:(:))
+end
+
 let x = Binding(Meta, :parse)
     @test Meta.parse(string(x)) == :(Base.Meta.parse)
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaDocs/Documenter.jl/issues/2844