### PR TITLE
inference: make `constprop_heuristic` a bitfield

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -952,13 +952,19 @@ function concrete_eval_eligible(interp::AbstractInterpreter,
             # method since currently there is no easy way to execute overlayed methods
             add_remark!(interp, sv, "[constprop] Concrete eval disabled for overlayed methods")
         end
-        if !any_conditional(arginfo)
-            if may_optimize(interp)
-                return :semi_concrete_eval
+        if may_optimize(interp)
+            if any_conditional(arginfo)
+                # N.B. semi-concrete eval uses `IRInterpretationState` which does not support
+                # `Conditional`, so skip it when these lattice elements are present in argtypes
+                add_remark!(interp, sv, "[constprop] Semi-concrete interpretation disabled due to conditional")
+            elseif !iszero(typename(typeof(f)).constprop_heuristic & Core.DISABLE_SEMI_CONCRETE_EVAL)
+                add_remark!(interp, sv, "[constprop] Semi-concrete interpretation disabled due to constprop_heuristic")
             else
-                # disable irinterp if optimization is disabled, since it requires optimized IR
-                add_remark!(interp, sv, "[constprop] Semi-concrete interpretation disabled for non-optimizing interpreter")
+                return :semi_concrete_eval
             end
+        else
+            # disable irinterp if optimization is disabled, since it requires optimized IR
+            add_remark!(interp, sv, "[constprop] Semi-concrete interpretation disabled for non-optimizing interpreter")
         end
     end
     return :none
@@ -1157,7 +1163,7 @@ end
 function force_const_prop(interp::AbstractInterpreter, @nospecialize(f), method::Method)
     return is_aggressive_constprop(method) ||
            InferenceParams(interp).aggressive_constant_propagation ||
-           typename(typeof(f)).constprop_heuristic === Core.FORCE_CONST_PROP
+           !iszero(typename(typeof(f)).constprop_heuristic & Core.FORCE_CONST_PROP)
 end
 
 function const_prop_function_heuristic(interp::AbstractInterpreter, @nospecialize(f),
@@ -1166,7 +1172,7 @@ function const_prop_function_heuristic(interp::AbstractInterpreter, @nospecializ
     heuristic = typename(typeof(f)).constprop_heuristic
     if length(argtypes) > 1
         𝕃ᵢ = typeinf_lattice(interp)
-        if heuristic === Core.ARRAY_INDEX_HEURISTIC
+        if !iszero(heuristic & Core.ARRAY_INDEX_HEURISTIC)
             arrty = argtypes[2]
             # don't propagate constant index into indexing of non-constant array
             if arrty isa Type && arrty <: AbstractArray && !issingletontype(arrty)
@@ -1179,14 +1185,14 @@ function const_prop_function_heuristic(interp::AbstractInterpreter, @nospecializ
             elseif ⊑(𝕃ᵢ, arrty, Array) || ⊑(𝕃ᵢ, arrty, GenericMemory)
                 return false
             end
-        elseif heuristic === Core.ITERATE_HEURISTIC
+        elseif !iszero(heuristic & Core.ITERATE_HEURISTIC)
             itrty = argtypes[2]
             if ⊑(𝕃ᵢ, itrty, Array) || ⊑(𝕃ᵢ, itrty, GenericMemory)
                 return false
             end
         end
     end
-    if !all_overridden && heuristic === Core.SAMETYPE_HEURISTIC
+    if !all_overridden && !iszero(heuristic & Core.SAMETYPE_HEURISTIC)
         # it is almost useless to inline the op when all the same type,
         # but highly worthwhile to inline promote of a constant
         length(argtypes) > 2 || return false

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -1185,7 +1185,8 @@ function const_prop_function_heuristic(interp::AbstractInterpreter, @nospecializ
             elseif ⊑(𝕃ᵢ, arrty, Array) || ⊑(𝕃ᵢ, arrty, GenericMemory)
                 return false
             end
-        elseif !iszero(heuristic & Core.ITERATE_HEURISTIC)
+        end
+        if !iszero(heuristic & Core.ITERATE_HEURISTIC)
             itrty = argtypes[2]
             if ⊑(𝕃ᵢ, itrty, Array) || ⊑(𝕃ᵢ, itrty, GenericMemory)
                 return false

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -1138,10 +1138,11 @@ EnterNode(old::EnterNode, new_dest::Int) = isdefined(old, :scope) ?
     EnterNode(new_dest, old.scope) : EnterNode(new_dest)
 
 # typename(_).constprop_heuristic
-const FORCE_CONST_PROP      = 0x1
-const ARRAY_INDEX_HEURISTIC = 0x2
-const ITERATE_HEURISTIC     = 0x3
-const SAMETYPE_HEURISTIC    = 0x4
+const FORCE_CONST_PROP           = shl_int(0x1, 0)
+const ARRAY_INDEX_HEURISTIC      = shl_int(0x1, 1)
+const ITERATE_HEURISTIC          = shl_int(0x1, 2)
+const SAMETYPE_HEURISTIC         = shl_int(0x1, 3)
+const DISABLE_SEMI_CONCRETE_EVAL = shl_int(0x1, 4)
 
 # `typename` has special tfunc support in inference to improve
 # the result for `Type{Union{...}}`. It is defined here, so that the Compiler

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -1138,11 +1138,11 @@ EnterNode(old::EnterNode, new_dest::Int) = isdefined(old, :scope) ?
     EnterNode(new_dest, old.scope) : EnterNode(new_dest)
 
 # typename(_).constprop_heuristic
-const FORCE_CONST_PROP           = shl_int(0x1, 0)
-const ARRAY_INDEX_HEURISTIC      = shl_int(0x1, 1)
-const ITERATE_HEURISTIC          = shl_int(0x1, 2)
-const SAMETYPE_HEURISTIC         = shl_int(0x1, 3)
-const DISABLE_SEMI_CONCRETE_EVAL = shl_int(0x1, 4)
+const FORCE_CONST_PROP           = 0x01
+const ARRAY_INDEX_HEURISTIC      = 0x02
+const ITERATE_HEURISTIC          = 0x04
+const SAMETYPE_HEURISTIC         = 0x08
+const DISABLE_SEMI_CONCRETE_EVAL = 0x10
 
 # `typename` has special tfunc support in inference to improve
 # the result for `Type{Union{...}}`. It is defined here, so that the Compiler


### PR DESCRIPTION
Change `constprop_heuristic` from enum-style values to proper bitflags (powers of 2), enabling functions to combine multiple heuristic behaviors.

Also adds `DISABLE_SEMI_CONCRETE_EVAL` flag that allows specific functions to opt out of semi-concrete evaluation where necessary (I plan to add this bit to `getproperty` in another PR).