### PR TITLE
PCRE2_jll: Fix Windows DLL name to use versioned filename

### DIFF
--- a/stdlib/PCRE2_jll/src/PCRE2_jll.jl
+++ b/stdlib/PCRE2_jll/src/PCRE2_jll.jl
@@ -16,7 +16,7 @@ artifact_dir::String = ""
 libpcre2_8_path::String = ""
 const libpcre2_8 = LazyLibrary(
     if Sys.iswindows()
-        BundledLazyLibraryPath("libpcre2-8.dll")
+        BundledLazyLibraryPath("libpcre2-8-0.dll")
     elseif Sys.isapple()
         BundledLazyLibraryPath("libpcre2-8.0.dylib")
     elseif Sys.islinux() || Sys.isfreebsd()


### PR DESCRIPTION
Restore the versioned DLL name libpcre2-8-0.dll on Windows, which was inadvertently changed to the unversioned libpcre2-8.dll in #58560.

External JLL packages (e.g. Glib_jll) link against the versioned name libpcre2-8-0.dll. When PCRE2_jll only loaded the unversioned name, Windows could not resolve that dependency, causing DLL load failures.

Fixes #61004

Found/fixed by Claude

Untested. @nhz2 @jaakkor2 can you try this out.