### PR TITLE
inference: Widen slot wrappers in `update_exc_bestguess!`

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -4145,6 +4145,7 @@ end
 function update_exc_bestguess!(interp::AbstractInterpreter, @nospecialize(exct), frame::InferenceState)
     𝕃ₚ = ipo_lattice(interp)
     handler = gethandler(frame)
+    exct = widenslotwrapper(exct)
     if handler === nothing
         if !⊑(𝕃ₚ, exct, frame.exc_bestguess)
             frame.exc_bestguess = tmerge(𝕃ₚ, frame.exc_bestguess, exct)

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -6558,4 +6558,9 @@ function issue60883()
 end
 @test issue60883() === true
 
+throwconditional(c, x) = c ? throw(x isa Int) : throw(x isa Float64)
+@test Base.infer_exception_type((Bool, Any)) do c, x
+    throwconditional(c, x)
+end == Bool
+
 end # module inference


### PR DESCRIPTION
Widen slot wrappers in `exct` before merging into `exc_bestguess`, so that the merged types are simple enough to be handled by the ipo lattice without needing complex lattice element merging.