### PR TITLE
Document more features of local and global

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -283,10 +283,11 @@ kw"__source__"
 """
     local
 
-`local` introduces a new local variable.
+`local` introduces one or more new local variables.
 See the [manual section on variable scoping](@ref scope-of-variables) for more information.
 
 # Examples
+
 ```jldoctest
 julia> function foo(n)
            x = 0
@@ -301,6 +302,23 @@ foo (generic function with 1 method)
 julia> foo(10)
 0
 ```
+
+`local` may be combined with assignment and destructuring.
+```jldoctest
+julia> function foo()
+           x = 0
+           y = 0
+           function bar(values)
+               local (; x, y) = values
+               x, y
+           end
+           (x, y), bar((; x= 1, y = 2))
+       end
+foo (generic function with 1 method)
+
+julia> foo()
+((0, 0), (1, 2))
+```
 """
 kw"local"
 
@@ -312,6 +330,7 @@ variable of that name.
 See the [manual section on variable scoping](@ref scope-of-variables) for more information.
 
 # Examples
+
 ```jldoctest
 julia> z = 3
 3
@@ -326,6 +345,24 @@ julia> foo()
 
 julia> z
 6
+```
+
+`global` may be used with multiple names and may also be combined with
+assignment and destructuring.
+```jldoctest
+julia> x, y = 1, 2
+(1, 2)
+
+julia> function foo(values)
+           global (; x, y) = values
+       end
+foo (generic function with 1 method)
+
+julia> foo((; x = 2, y = 3))
+(2, 3)
+
+julia> x, y
+(2, 3)
 ```
 """
 kw"global"


### PR DESCRIPTION
I couldn't find clear statements about the ability of `local` and `global` to work with multiple names. So, first, I tried to clarify that in the doc strings and examples.

I also noticed that `local` and `global` both work with destructuring, so I documented that as well.

I'm worried that I've made those doc strings a bit too long. Would some of the examples be better in an extended help section instead?