### PR TITLE
[JuliaLowering] Fix use-and-def analysis for `[function_decl]`

### DIFF
--- a/JuliaLowering/src/binding_analysis.jl
+++ b/JuliaLowering/src/binding_analysis.jl
@@ -73,7 +73,7 @@ mutable struct DefUseState
     const args::Set{IdTag}
 
     function DefUseState(ctx, candidates)
-        unused = candidates
+        unused = copy(candidates)
         live = Set{IdTag}()
         seen = Set{IdTag}()
         decl = Set{IdTag}()
@@ -345,6 +345,21 @@ function _analyze_lambda_vars!(ctx, ex)
             b = get_binding(ctx, id)
             b.unboxed = true
             b.is_always_defined = true
+        end
+    end
+
+    # A single (scope-dominating) assignment implies unboxed even if we gave up above
+    for id in candidates
+        b = get_binding(ctx, id)
+        # XXX: This uses is-always-defined to imply that the assignment is defined
+        #      everywhere in its scope, which then implies that the one definition
+        #      executes only once dynamically.
+        #      (i.e. it forbids single-assignment to `x` in an inner loop)
+        #
+        #      If this flag becomes broader and only considers definedness-at-use
+        #      then this check (taken from `julia-syntax.scm`) becomes unsound.
+        if b.kind === :local && b.is_always_defined && b.is_assigned_once
+            b.unboxed = true
         end
     end
 end

--- a/JuliaLowering/src/binding_analysis.jl
+++ b/JuliaLowering/src/binding_analysis.jl
@@ -300,9 +300,9 @@ function du_visit!(ctx, state::DefUseState, e)
         return has_label
 
     elseif is_leaf(e) || is_quoted(e) ||
-        k in KSet"local meta inbounds boundscheck noinline loopinfo decl
-            with_static_parameters toplevel_butfirst global globalref
-            constdecl atomic isdefined toplevel module error
+        k in KSet"local always_defined meta inbounds boundscheck noinline
+            loopinfo decl with_static_parameters toplevel_butfirst global
+            globalref constdecl atomic isdefined toplevel module error
             gc_preserve_begin gc_preserve_end export public inline"
 
         # Forms that don't interact with locals or affect control flow (likely more than is necessary).

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2757,8 +2757,8 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
         end
     end
     @ast ctx src [K"block"
-        is_core_nothing(mtable) ? nothing : [K"function_decl" mtable]
         [K"function_decl" m1_name]
+        is_core_nothing(mtable) ? nothing : [K"function_decl" mtable]
         [K"method_defs" m1_name mdefs1]
         [K"method_defs" mtable mdefs2]
         [K"method_defs" mtable mdefs3]

--- a/JuliaLowering/test/closures.jl
+++ b/JuliaLowering/test/closures.jl
@@ -576,3 +576,42 @@ let (f, foo) = test_mod.f_box_regression147()
     @test !(f.foo isa Core.Box)
     @test f.foo === foo
 end
+
+# Any `let` variables marked always-defined && assigned-once are known to
+# dominate their scope, so they should not be boxed even in the presence
+# of `@label`
+JuliaLowering.include_string(test_mod, """
+function f_let_capture_with_label()
+    for x in [1,2,3]
+        let x = x
+            if false
+                @goto done
+                @label done # force the binding analysis to give up
+            else
+                return (() -> x,)
+            end
+        end
+    end
+end
+""")
+let (f,) = test_mod.f_let_capture_with_label()
+    @test !(f.x isa Core.Box)
+    @test f.x == 1
+end
+
+JuliaLowering.include_string(test_mod, """
+function f_arg_reassign_with_label(x)
+    g() = x
+    if false
+        @goto done
+        @label done
+    end
+    x = 1
+    return (g, x)
+end
+""")
+let (g, x) = test_mod.f_arg_reassign_with_label(42)
+    @test g.x isa Core.Box
+    @test g() == 1
+    @test x == 1
+end

--- a/JuliaLowering/test/closures.jl
+++ b/JuliaLowering/test/closures.jl
@@ -577,6 +577,22 @@ let (f, foo) = test_mod.f_box_regression147()
     @test f.foo === foo
 end
 
+# The internal "helper" of an (inner) kwargs function should not be boxed.
+JuliaLowering.include_string(test_mod, """
+function f_kwbody_box()
+    function inner(x; verbose=false)
+        return verbose ? x : nothing
+    end
+    return (inner, inner(1; verbose=true))
+end
+""")
+let (inner, result) = test_mod.f_kwbody_box()
+    @test result == 1
+    # The kw body closure should be captured directly, not through a Box
+    kw_body_field = only(filter(f -> startswith(string(f), "#kw_body#"), fieldnames(typeof(inner))))
+    @test !(getfield(inner, kw_body_field) isa Core.Box)
+end
+
 # Any `let` variables marked always-defined && assigned-once are known to
 # dominate their scope, so they should not be boxed even in the presence
 # of `@label`

--- a/JuliaLowering/test/closures.jl
+++ b/JuliaLowering/test/closures.jl
@@ -562,3 +562,17 @@ let (f, response) = test_mod.f_update_outer_capture()
     @test f.response isa Core.Box
     @test response == 1
 end
+
+# https://github.com/JuliaLang/JuliaLowering.jl/issues/147
+JuliaLowering.include_string(test_mod, """
+function f_box_regression147()
+    function foo()
+        return true
+    end
+    return (()->foo, foo)
+end
+""")
+let (f, foo) = test_mod.f_box_regression147()
+    @test !(f.foo isa Core.Box)
+    @test f.foo === foo
+end

--- a/JuliaLowering/test/closures_ir.jl
+++ b/JuliaLowering/test/closures_ir.jl
@@ -582,23 +582,21 @@ let
     end
 end
 #---------------------
-1   (= slot₁/recursive_a (call core.Box))
-2   (= slot₂/recursive_b (call core.Box))
-3   (call core.svec :recursive_b)
-4   (call core.svec true)
-5   (call JuliaLowering.eval_closure_type TestMod :#recursive_a##0 %₃ %₄)
-6   latestworld
-7   TestMod.#recursive_a##0
-8   slot₂/recursive_b
-9   (new %₇ %₈)
-10  slot₁/recursive_a
-11  (call core.setfield! %₁₀ :contents %₉)
-12  TestMod.#recursive_a##0
-13  (call core.svec %₁₂)
-14  (call core.svec)
-15  SourceLocation::2:14
-16  (call core.svec %₁₃ %₁₄ %₁₅)
-17  --- method core.nothing %₁₆
+1   (= slot₂/recursive_b (call core.Box))
+2   (call core.svec :recursive_b)
+3   (call core.svec true)
+4   (call JuliaLowering.eval_closure_type TestMod :#recursive_a##0 %₂ %₃)
+5   latestworld
+6   TestMod.#recursive_a##0
+7   slot₂/recursive_b
+8   (new %₆ %₇)
+9   (= slot₁/recursive_a %₈)
+10  TestMod.#recursive_a##0
+11  (call core.svec %₁₀)
+12  (call core.svec)
+13  SourceLocation::2:14
+14  (call core.svec %₁₁ %₁₂ %₁₃)
+15  --- method core.nothing %₁₄
     slots: [slot₁/#self#(!read) slot₂/recursive_b(!read,maybe_undef)]
     1   (call core.getfield slot₁/#self# :recursive_b)
     2   (call core.isdefined %₁ :contents)
@@ -609,41 +607,36 @@ end
     7   (call core.getfield %₁ :contents)
     8   (call %₇)
     9   (return %₈)
-18  latestworld
-19  (call core.svec :recursive_a)
-20  (call core.svec true)
-21  (call JuliaLowering.eval_closure_type TestMod :#recursive_b##0 %₁₉ %₂₀)
-22  latestworld
-23  TestMod.#recursive_b##0
-24  slot₁/recursive_a
-25  (new %₂₃ %₂₄)
-26  slot₂/recursive_b
-27  (call core.setfield! %₂₆ :contents %₂₅)
-28  TestMod.#recursive_b##0
-29  (call core.svec %₂₈)
-30  (call core.svec)
-31  SourceLocation::5:14
-32  (call core.svec %₂₉ %₃₀ %₃₁)
-33  --- method core.nothing %₃₂
-    slots: [slot₁/#self#(!read) slot₂/recursive_a(!read,maybe_undef)]
+16  latestworld
+17  (call core.svec :recursive_a)
+18  (call core.svec false)
+19  (call JuliaLowering.eval_closure_type TestMod :#recursive_b##0 %₁₇ %₁₈)
+20  latestworld
+21  TestMod.#recursive_b##0
+22  (call core._typeof_captured_variable slot₁/recursive_a)
+23  (call core.apply_type %₂₁ %₂₂)
+24  (new %₂₃ slot₁/recursive_a)
+25  slot₂/recursive_b
+26  (call core.setfield! %₂₅ :contents %₂₄)
+27  TestMod.#recursive_b##0
+28  (call core.svec %₂₇)
+29  (call core.svec)
+30  SourceLocation::5:14
+31  (call core.svec %₂₈ %₂₉ %₃₀)
+32  --- method core.nothing %₃₁
+    slots: [slot₁/#self#(!read)]
     1   (call core.getfield slot₁/#self# :recursive_a)
-    2   (call core.isdefined %₁ :contents)
-    3   (gotoifnot %₂ label₅)
-    4   (goto label₇)
-    5   (newvar slot₂/recursive_a)
-    6   slot₂/recursive_a
-    7   (call core.getfield %₁ :contents)
-    8   (call %₇)
-    9   (return %₈)
-34  latestworld
-35  slot₂/recursive_b
-36  (call core.isdefined %₃₅ :contents)
-37  (gotoifnot %₃₆ label₃₉)
-38  (goto label₄₁)
-39  (newvar slot₄/recursive_b)
-40  slot₄/recursive_b
-41  (call core.getfield %₃₅ :contents)
-42  (return %₄₁)
+    2   (call %₁)
+    3   (return %₂)
+33  latestworld
+34  slot₂/recursive_b
+35  (call core.isdefined %₃₄ :contents)
+36  (gotoifnot %₃₅ label₃₈)
+37  (goto label₄₀)
+38  (newvar slot₃/recursive_b)
+39  slot₃/recursive_b
+40  (call core.getfield %₃₄ :contents)
+41  (return %₄₀)
 
 ########################################
 # Closure with keywords
@@ -654,67 +647,60 @@ let y = y_init
 end
 #---------------------
 1   TestMod.y_init
-2   (= slot₂/#kw_body#f_kw_closure#0 (call core.Box))
-3   (= slot₁/y %₁)
-4   (call core.svec :#kw_body#f_kw_closure#0)
-5   (call core.svec true)
-6   (call JuliaLowering.eval_closure_type TestMod :#f_kw_closure##0 %₄ %₅)
-7   latestworld
-8   TestMod.#f_kw_closure##0
-9   slot₂/#kw_body#f_kw_closure#0
-10  (new %₈ %₉)
-11  (= slot₃/f_kw_closure %₁₀)
-12  (call core.svec :y)
+2   (= slot₁/y %₁)
+3   (call core.svec :y)
+4   (call core.svec false)
+5   (call JuliaLowering.eval_closure_type TestMod :##kw_body#f_kw_closure#0##0 %₃ %₄)
+6   latestworld
+7   TestMod.##kw_body#f_kw_closure#0##0
+8   (call core._typeof_captured_variable slot₁/y)
+9   (call core.apply_type %₇ %₈)
+10  (new %₉ slot₁/y)
+11  (= slot₂/#kw_body#f_kw_closure#0 %₁₀)
+12  (call core.svec :#kw_body#f_kw_closure#0)
 13  (call core.svec false)
-14  (call JuliaLowering.eval_closure_type TestMod :##kw_body#f_kw_closure#0##0 %₁₂ %₁₃)
+14  (call JuliaLowering.eval_closure_type TestMod :#f_kw_closure##0 %₁₂ %₁₃)
 15  latestworld
-16  TestMod.##kw_body#f_kw_closure#0##0
-17  (call core._typeof_captured_variable slot₁/y)
+16  TestMod.#f_kw_closure##0
+17  (call core._typeof_captured_variable slot₂/#kw_body#f_kw_closure#0)
 18  (call core.apply_type %₁₆ %₁₇)
-19  (new %₁₈ slot₁/y)
-20  slot₂/#kw_body#f_kw_closure#0
-21  (call core.setfield! %₂₀ :contents %₁₉)
-22  TestMod.##kw_body#f_kw_closure#0##0
-23  TestMod.X
-24  TestMod.#f_kw_closure##0
-25  (call core.svec %₂₂ %₂₃ %₂₄)
-26  (call core.svec)
-27  SourceLocation::2:14
-28  (call core.svec %₂₅ %₂₆ %₂₇)
-29  --- method core.nothing %₂₈
+19  (new %₁₈ slot₂/#kw_body#f_kw_closure#0)
+20  (= slot₃/f_kw_closure %₁₉)
+21  TestMod.##kw_body#f_kw_closure#0##0
+22  TestMod.X
+23  TestMod.#f_kw_closure##0
+24  (call core.svec %₂₁ %₂₂ %₂₃)
+25  (call core.svec)
+26  SourceLocation::2:14
+27  (call core.svec %₂₄ %₂₅ %₂₆)
+28  --- method core.nothing %₂₇
     slots: [slot₁/#kw_body#f_kw_closure#0(!read) slot₂/x slot₃/#self#(!read)]
     1   (meta :nkw 1)
     2   TestMod.+
     3   (call core.getfield slot₁/#kw_body#f_kw_closure#0 :y)
     4   (call %₂ slot₂/x %₃)
     5   (return %₄)
-30  latestworld
-31  TestMod.#f_kw_closure##0
-32  (call core.svec %₃₁)
-33  (call core.svec)
-34  SourceLocation::2:14
-35  (call core.svec %₃₂ %₃₃ %₃₄)
-36  --- method core.nothing %₃₅
-    slots: [slot₁/#self# slot₂/#kw_body#f_kw_closure#0(!read,maybe_undef)]
+29  latestworld
+30  TestMod.#f_kw_closure##0
+31  (call core.svec %₃₀)
+32  (call core.svec)
+33  SourceLocation::2:14
+34  (call core.svec %₃₁ %₃₂ %₃₃)
+35  --- method core.nothing %₃₄
+    slots: [slot₁/#self#]
     1   (call core.getfield slot₁/#self# :#kw_body#f_kw_closure#0)
-    2   (call core.isdefined %₁ :contents)
-    3   (gotoifnot %₂ label₅)
-    4   (goto label₇)
-    5   (newvar slot₂/#kw_body#f_kw_closure#0)
-    6   slot₂/#kw_body#f_kw_closure#0
-    7   (call core.getfield %₁ :contents)
-    8   TestMod.x_default
-    9   (call %₇ %₈ slot₁/#self#)
-    10  (return %₉)
-37  latestworld
-38  (call core.typeof core.kwcall)
-39  TestMod.#f_kw_closure##0
-40  (call core.svec %₃₈ core.NamedTuple %₃₉)
-41  (call core.svec)
-42  SourceLocation::2:14
-43  (call core.svec %₄₀ %₄₁ %₄₂)
-44  --- method core.nothing %₄₃
-    slots: [slot₁/#unused#(!read) slot₂/kws slot₃/#self# slot₄/x(!read) slot₅/kwtmp slot₆/#kw_body#f_kw_closure#0(!read,maybe_undef)]
+    2   TestMod.x_default
+    3   (call %₁ %₂ slot₁/#self#)
+    4   (return %₃)
+36  latestworld
+37  (call core.typeof core.kwcall)
+38  TestMod.#f_kw_closure##0
+39  (call core.svec %₃₇ core.NamedTuple %₃₈)
+40  (call core.svec)
+41  SourceLocation::2:14
+42  (call core.svec %₃₉ %₄₀ %₄₁)
+43  --- method core.nothing %₄₂
+    slots: [slot₁/#unused#(!read) slot₂/kws slot₃/#self# slot₄/x(!read) slot₅/kwtmp]
     1   (newvar slot₄/x)
     2   (newvar slot₅/kwtmp)
     3   (call core.isdefined slot₂/kws :x)
@@ -740,17 +726,11 @@ end
     23  (goto label₂₅)
     24  (call top.kwerr slot₂/kws slot₃/#self#)
     25  (call core.getfield slot₃/#self# :#kw_body#f_kw_closure#0)
-    26  (call core.isdefined %₂₅ :contents)
-    27  (gotoifnot %₂₆ label₂₉)
-    28  (goto label₃₁)
-    29  (newvar slot₆/#kw_body#f_kw_closure#0)
-    30  slot₆/#kw_body#f_kw_closure#0
-    31  (call core.getfield %₂₅ :contents)
-    32  (call %₃₁ %₁₇ slot₃/#self#)
-    33  (return %₃₂)
-45  latestworld
-46  slot₃/f_kw_closure
-47  (return %₄₆)
+    26  (call %₂₅ %₁₇ slot₃/#self#)
+    27  (return %₂₆)
+44  latestworld
+45  slot₃/f_kw_closure
+46  (return %₄₅)
 
 ########################################
 # Closure capturing a typed local must also capture the type expression

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -1344,9 +1344,9 @@ function f_kw_simple(a::Int=1, b::Float64=1.0; x::Char='a', y::Bool=true)
     (a, b, x, y)
 end
 #---------------------
-1   (method TestMod.f_kw_simple)
+1   (method TestMod.#kw_body#f_kw_simple#0)
 2   latestworld
-3   (method TestMod.#kw_body#f_kw_simple#0)
+3   (method TestMod.f_kw_simple)
 4   latestworld
 5   TestMod.#kw_body#f_kw_simple#0
 6   (call core.Typeof %₅)
@@ -1493,9 +1493,9 @@ end
 # underscore kwargs apart from `_...` are probably not intended to work anyway
 function f_kw_placeholders(; _=1, _=2); end
 #---------------------
-1   (method TestMod.f_kw_placeholders)
+1   (method TestMod.#kw_body#f_kw_placeholders#0)
 2   latestworld
-3   (method TestMod.#kw_body#f_kw_placeholders#0)
+3   (method TestMod.f_kw_placeholders)
 4   latestworld
 5   TestMod.#kw_body#f_kw_placeholders#0
 6   (call core.Typeof %₅)
@@ -1564,9 +1564,9 @@ function f_kw_slurp_simple(; all_kws...)
     all_kws
 end
 #---------------------
-1   (method TestMod.f_kw_slurp_simple)
+1   (method TestMod.#kw_body#f_kw_slurp_simple#0)
 2   latestworld
-3   (method TestMod.#kw_body#f_kw_slurp_simple#0)
+3   (method TestMod.f_kw_slurp_simple)
 4   latestworld
 5   TestMod.#kw_body#f_kw_slurp_simple#0
 6   (call core.Typeof %₅)
@@ -1620,9 +1620,9 @@ function f_kw_slurp(; x=x_default, non_x_kws...)
     all_kws
 end
 #---------------------
-1   (method TestMod.f_kw_slurp)
+1   (method TestMod.#kw_body#f_kw_slurp#0)
 2   latestworld
-3   (method TestMod.#kw_body#f_kw_slurp#0)
+3   (method TestMod.f_kw_slurp)
 4   latestworld
 5   TestMod.#kw_body#f_kw_slurp#0
 6   (call core.Typeof %₅)
@@ -1692,9 +1692,9 @@ function f_kw_slurp_dep(; a=1, b=a, kws...)
     (a, b, kws)
 end
 #---------------------
-1   (method TestMod.f_kw_slurp_dep)
+1   (method TestMod.#kw_body#f_kw_slurp_dep#0)
 2   latestworld
-3   (method TestMod.#kw_body#f_kw_slurp_dep#0)
+3   (method TestMod.f_kw_slurp_dep)
 4   latestworld
 5   TestMod.#kw_body#f_kw_slurp_dep#0
 6   (call core.Typeof %₅)
@@ -1775,9 +1775,9 @@ function f_kw_sparams(x::X; a::A=a_def, b::X=b_def) where {X,A}
     (X,A)
 end
 #---------------------
-1   (method TestMod.f_kw_sparams)
+1   (method TestMod.#kw_body#f_kw_sparams#0)
 2   latestworld
-3   (method TestMod.#kw_body#f_kw_sparams#0)
+3   (method TestMod.f_kw_sparams)
 4   latestworld
 5   (= slot₁/X (call core.TypeVar :X))
 6   (= slot₂/A (call core.TypeVar :A))
@@ -1888,9 +1888,9 @@ function f_kw_slurp(a,;kw1,kw2=2,restkw...)
     @nospecialize
 end
 #---------------------
-1   (method TestMod.f_kw_slurp)
+1   (method TestMod.#kw_body#f_kw_slurp#1)
 2   latestworld
-3   (method TestMod.#kw_body#f_kw_slurp#1)
+3   (method TestMod.f_kw_slurp)
 4   latestworld
 5   TestMod.#kw_body#f_kw_slurp#1
 6   (call core.Typeof %₅)

--- a/JuliaLowering/test/typedefs_ir.jl
+++ b/JuliaLowering/test/typedefs_ir.jl
@@ -749,82 +749,73 @@ end
 9   (call core.isdefinedglobal TestMod :X false)
 10  (gotoifnot %₉ label₁₄)
 11  TestMod.X
-12  (= slot₄/if_val (call core._equiv_typedef %₁₁ %₆))
+12  (= slot₃/if_val (call core._equiv_typedef %₁₁ %₆))
 13  (goto label₁₅)
-14  (= slot₄/if_val false)
-15  slot₄/if_val
+14  (= slot₃/if_val false)
+15  slot₃/if_val
 16  (gotoifnot %₁₅ label₂₀)
 17  TestMod.X
-18  (= slot₅/if_val %₁₇)
+18  (= slot₄/if_val %₁₇)
 19  (goto label₂₁)
-20  (= slot₅/if_val false)
-21  slot₅/if_val
+20  (= slot₄/if_val false)
+21  slot₄/if_val
 22  (gotoifnot %₁₅ label₂₃)
 23  (call core.svec core.Any)
 24  (call core._typebody! %₂₁ %₆ %₂₃)
 25  (call core.declare_const TestMod :X %₂₄)
 26  latestworld
-27  (= slot₂/f (call core.Box))
+27  (call core.svec)
 28  (call core.svec)
-29  (call core.svec)
-30  (call JuliaLowering.eval_closure_type TestMod :#f##0 %₂₈ %₂₉)
-31  latestworld
-32  TestMod.#f##0
-33  (new %₃₂)
-34  slot₂/f
-35  (call core.setfield! %₃₄ :contents %₃₃)
-36  TestMod.#f##0
-37  (call core.svec %₃₆)
-38  (call core.svec)
-39  SourceLocation::3:5
-40  (call core.svec %₃₇ %₃₈ %₃₉)
-41  --- method core.nothing %₄₀
+29  (call JuliaLowering.eval_closure_type TestMod :#f##0 %₂₇ %₂₈)
+30  latestworld
+31  TestMod.#f##0
+32  (new %₃₁)
+33  (= slot₂/f %₃₂)
+34  TestMod.#f##0
+35  (call core.svec %₃₄)
+36  (call core.svec)
+37  SourceLocation::3:5
+38  (call core.svec %₃₅ %₃₆ %₃₇)
+39  --- method core.nothing %₃₈
     slots: [slot₁/#self#(!read)]
     1   TestMod.X
     2   (new %₁ 1)
     3   (return %₂)
-42  latestworld
-43  TestMod.X
-44  (call core.apply_type core.Type %₄₃)
-45  (call core.svec %₄₄)
-46  (call core.svec)
-47  SourceLocation::4:5
-48  (call core.svec %₄₅ %₄₆ %₄₇)
-49  --- code_info
-    slots: [slot₁/#ctor-self#(!read) slot₂/f(!read,maybe_undef)]
+40  latestworld
+41  TestMod.X
+42  (call core.apply_type core.Type %₄₁)
+43  (call core.svec %₄₂)
+44  (call core.svec)
+45  SourceLocation::4:5
+46  (call core.svec %₄₃ %₄₄ %₄₅)
+47  --- code_info
+    slots: [slot₁/#ctor-self#(!read)]
     1   (captured_local 1)
-    2   (call core.isdefined %₁ :contents)
-    3   (gotoifnot %₂ label₅)
-    4   (goto label₇)
-    5   (newvar slot₂/f)
-    6   slot₂/f
-    7   (call core.getfield %₁ :contents)
-    8   (call %₇)
-    9   (return %₈)
-50  slot₂/f
-51  (call core.svec %₅₀)
-52  (call JuliaLowering.replace_captured_locals! %₄₉ %₅₁)
-53  --- method core.nothing %₄₈ %₅₂
-54  latestworld
-55  TestMod.X
-56  (call core.apply_type core.Type %₅₅)
-57  (call core.svec %₅₆ core.Any)
-58  (call core.svec)
-59  SourceLocation::5:5
-60  (call core.svec %₅₇ %₅₈ %₅₉)
-61  --- method core.nothing %₆₀
+    2   (call %₁)
+    3   (return %₂)
+48  (call core.svec slot₂/f)
+49  (call JuliaLowering.replace_captured_locals! %₄₇ %₄₈)
+50  --- method core.nothing %₄₆ %₄₉
+51  latestworld
+52  TestMod.X
+53  (call core.apply_type core.Type %₅₂)
+54  (call core.svec %₅₃ core.Any)
+55  (call core.svec)
+56  SourceLocation::5:5
+57  (call core.svec %₅₄ %₅₅ %₅₆)
+58  --- method core.nothing %₅₇
     slots: [slot₁/#ctor-self# slot₂/x]
     1   slot₁/#ctor-self#
     2   (new %₁ slot₂/x)
     3   (return %₂)
-62  latestworld
-63  TestMod.X
-64  (call core.apply_type core.Type %₆₃)
-65  (call core.svec %₆₄ core.Any core.Any)
-66  (call core.svec)
-67  SourceLocation::6:5
-68  (call core.svec %₆₅ %₆₆ %₆₇)
-69  --- method core.nothing %₆₈
+59  latestworld
+60  TestMod.X
+61  (call core.apply_type core.Type %₆₀)
+62  (call core.svec %₆₁ core.Any core.Any)
+63  (call core.svec)
+64  SourceLocation::6:5
+65  (call core.svec %₆₂ %₆₃ %₆₄)
+66  --- method core.nothing %₆₅
     slots: [slot₁/#ctor-self# slot₂/y slot₃/z slot₄/tmp(!read)]
     1   slot₁/#ctor-self#
     2   TestMod.+
@@ -838,20 +829,20 @@ end
     10  (= slot₄/tmp (call core.typeassert %₉ %₄))
     11  slot₄/tmp
     12  (return %₁₁)
-70  latestworld
-71  TestMod.X
-72  (call core.apply_type core.Type %₇₁)
-73  (call core.svec %₇₂ core.Any core.Any core.Any)
-74  (call core.svec)
-75  SourceLocation::10:5
-76  (call core.svec %₇₃ %₇₄ %₇₅)
-77  --- method core.nothing %₇₆
+67  latestworld
+68  TestMod.X
+69  (call core.apply_type core.Type %₆₈)
+70  (call core.svec %₆₉ core.Any core.Any core.Any)
+71  (call core.svec)
+72  SourceLocation::10:5
+73  (call core.svec %₇₀ %₇₁ %₇₂)
+74  --- method core.nothing %₇₃
     slots: [slot₁/#ctor-self# slot₂/a slot₃/b(!read) slot₄/c(!read)]
     1   slot₁/#ctor-self#
     2   (new %₁ slot₂/a)
     3   (return %₂)
-78  latestworld
-79  (return core.nothing)
+75  latestworld
+76  (return core.nothing)
 
 ########################################
 # User defined inner constructors and helper functions for structs with type params


### PR DESCRIPTION
This form is an implicit assignment to its argument, so the use-and-def analysis needs to take this into account. Otherwise it's both a correctness and optimization problem.

Resolves https://github.com/JuliaLang/JuliaLowering.jl/issues/147.