### PR TITLE
optimizer: Switch to `Some{}` in PersistentDict optimized generics

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -1006,7 +1006,7 @@ function in(key_val::Pair{K,V}, dict::PersistentDict{K,V}, valcmp=(==)) where {K
     key, val = key_val
     found = KeyValue.get(dict, key)
     found === nothing && return false
-    return valcmp(val, only(found))
+    return valcmp(val, something(found))
 end
 
 function haskey(dict::PersistentDict{K}, key::K) where K
@@ -1016,13 +1016,13 @@ end
 function getindex(dict::PersistentDict{K,V}, key::K) where {K,V}
     found = KeyValue.get(dict, key)
     found === nothing && throw(KeyError(key))
-    return only(found)
+    return something(found)
 end
 
 function get(dict::PersistentDict{K,V}, key::K, default) where {K,V}
     found = KeyValue.get(dict, key)
     found === nothing && return default
-    return only(found)
+    return something(found)
 end
 
 @noinline function KeyValue.get(dict::PersistentDict{K, V}, key) where {K, V}
@@ -1034,7 +1034,7 @@ end
     found, present, trie, i, _, _, _ = HAMT.path(trie, key, h)
     if found && present
         leaf = @inbounds trie.data[i]::HAMT.Leaf{K,V}
-        return (leaf.val,)
+        return Some{V}(leaf.val)
     end
     return nothing
 end
@@ -1042,13 +1042,13 @@ end
 @noinline function KeyValue.get(default, dict::PersistentDict, key)
     found = KeyValue.get(dict, key)
     found === nothing && return default()
-    return only(found)
+    return something(found)
 end
 
 function get(default::Callable, dict::PersistentDict{K,V}, key::K) where {K,V}
     found = KeyValue.get(dict, key)
     found === nothing && return default()
-    return only(found)
+    return something(found)
 end
 
 function delete(dict::PersistentDict{K}, key::K) where K

--- a/base/optimized_generics.jl
+++ b/base/optimized_generics.jl
@@ -23,7 +23,7 @@ Implements a key-value like interface where the compiler has liberty to perform
 the following transformations. The core optimization semantically allowed for
 the compiler is:
 
-    get(set(x, key, val), key) -> (val,)
+    get(set(x, key, val), key) -> Some(val)
 
 where the compiler will recursively look through `x`. Keys are compared by
 egality.
@@ -47,8 +47,8 @@ module KeyValue
     """
         get(collection, key)
 
-    Retrieve the value corresponding to `key` in `collection` as a single
-    element tuple or `nothing` if no value corresponding to the key was found.
+    Retrieve the value corresponding to `key` in `collection` wrapped in
+    `Some` or return `nothing` if no value corresponding to the key was found.
     `key`s are compared by egal.
     """
     function get end

--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -212,7 +212,7 @@ function get(val::AbstractScopedValue{T}) where {T}
     else
         v = Base.KeyValue.get(scope.values, val)
         v === nothing && return nothing
-        return Some{T}(only(v)::T)
+        return Some{T}(something(v)::T)
     end
     return nothing
 end

--- a/test/scopedvalues.jl
+++ b/test/scopedvalues.jl
@@ -268,3 +268,20 @@ end
 @testset "issue 59483" begin
     test_59483()
 end
+
+# issue #53584 - ScopedValue should not allocate when accessed
+const sv_53584 = ScopedValue([0])
+@noinline function access_scoped_53584()
+    v = sv_53584[]
+    v[1] += 1
+    return nothing
+end
+function run_53584()
+    @with sv_53584=>[0] for _ in 1:100_000
+        access_scoped_53584()
+    end
+end
+@testset "issue #53584" begin
+    run_53584() # warmup
+    @test (@allocated run_53584()) < 10_000
+end


### PR DESCRIPTION
This fixes #53584 by switching the return type of the KeyValue optimized generics interface to allow any one-field struct, not just `Tuple`. In particular, the persistent dict implementation uses `Some{V}`. This makes a material difference because Tuple{Any} does not (currently) have special ABI support, while Some{Any} does.

Written by Claude