### PR TITLE
Fix `rationalize(T, x::Integer)` with `x` negative and `T` unsigned

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -312,6 +312,7 @@ rationalize(::Type{T}, x::Rational; tol::Real = 0) where {T<:Integer} = rational
 rationalize(x::Rational; kvs...) = x
 rationalize(x::Integer; kvs...) = Rational(x)
 function rationalize(::Type{T}, x::Integer; kvs...) where {T<:Integer}
+    T<:Unsigned && x < 0 && __throw_negate_unsigned()
     if Base.hastypemax(T) # BigInt doesn't
         x < typemin(T) && return unsafe_rational(-one(T), zero(T))
         x > typemax(T) && return unsafe_rational(one(T), zero(T))

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -39,6 +39,7 @@ using Test
     @test @inferred(rationalize(Int8, 1000//3)) === Rational{Int8}(1//0)
     @test @inferred(rationalize(Int8, 1000)) === Rational{Int8}(1//0)
     @test_throws OverflowError rationalize(UInt, -2.0)
+    @test_throws OverflowError rationalize(UInt, -2)
     @test_throws ArgumentError rationalize(Int, big(3.0), -1.)
     # issue 26823
     @test_throws InexactError rationalize(Int, NaN)


### PR DESCRIPTION
Was overflowing silently. Throw instead to make the function behavior consistent regardless of the typeof x.