### PR TITLE
REPL: Add option to show active environment in prompt

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -900,6 +900,31 @@ Out[3]: Dict{Int64, Any} with 2 entries:
     an individual entry with `Out[n] = nothing`.
 
 
+## Environment in prompt
+
+By default, the active project/environment is only shown in the `pkg>` prompt. You can also
+display it in the `julia>` prompt (and other modes like `help?>` and `shell>`) by enabling
+the `show_project_in_prompt` option. To enable this on startup, add the following to your
+`~/.julia/config/startup.jl` file:
+
+```julia
+atreplinit() do repl
+    repl.options.show_project_in_prompt = true
+end
+```
+
+This will show prompts like:
+
+```julia-repl
+(@v1.12) julia>
+```
+
+or, when using a named project:
+
+```julia-repl
+(MyProject) julia>
+```
+
 ## TerminalMenus
 
 TerminalMenus is a submodule of the Julia REPL and enables small, low-profile interactive menus in the terminal.

--- a/stdlib/REPL/src/Pkg_beforeload.jl
+++ b/stdlib/REPL/src/Pkg_beforeload.jl
@@ -90,7 +90,7 @@ prev_project_file = nothing
 prev_project_timestamp = nothing
 prev_prefix = ""
 
-function Pkg_promptf()
+function project_prefix()
     global prev_project_timestamp, prev_prefix, prev_project_file
     project_file = find_project_file()
     prefix = ""
@@ -117,6 +117,10 @@ function Pkg_promptf()
             end
         end
     end
+    return prefix
+end
+
+function Pkg_promptf()
     # Note no handling of Pkg.offline, as the Pkg version does here
-    return "$(prefix)$(PKG_PROMPT)"
+    return "$(project_prefix())$(PKG_PROMPT)"
 end

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1236,9 +1236,10 @@ enable_promptpaste(v::Bool) = JL_PROMPT_PASTE[] = v
 function contextual_prompt(repl::LineEditREPL, prompt::Union{String,Function})
     function ()
         mod = Base.active_module(repl)
-        prefix = mod == Main ? "" : string('(', mod, ") ")
+        mod_prefix = mod == Main ? "" : string('(', mod, ") ")
+        env_prefix = repl.options.show_project_in_prompt ? project_prefix() : ""
         pr = prompt isa String ? prompt : prompt()
-        prefix * pr
+        env_prefix * mod_prefix * pr
     end
 end
 

--- a/stdlib/REPL/src/options.jl
+++ b/stdlib/REPL/src/options.jl
@@ -32,6 +32,7 @@ mutable struct Options
     style_input::Bool # enable syntax highlighting for input
     # default IOContext settings at the REPL
     iocontext::Dict{Symbol,Any}
+    show_project_in_prompt::Bool # show active project/environment in prompt
 end
 
 Options(;
@@ -53,7 +54,8 @@ Options(;
         hint_tab_completes = true,
         auto_insert_closing_bracket = true,
         style_input = true,
-        iocontext = Dict{Symbol,Any}()) =
+        iocontext = Dict{Symbol,Any}(),
+        show_project_in_prompt = false) =
             Options(hascolor, extra_keymap, tabwidth,
                     kill_ring_max, region_animation_duration,
                     beep_duration, beep_blink, beep_maxduration,
@@ -62,7 +64,7 @@ Options(;
                     auto_indent, auto_indent_tmp_off, auto_indent_bracketed_paste,
                     auto_indent_time_threshold, auto_refresh_time_delay,
                     hint_tab_completes, auto_insert_closing_bracket, style_input,
-                    iocontext)
+                    iocontext, show_project_in_prompt)
 
 # for use by REPLs not having an options field
 const GlobalOptions = Options()

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1891,6 +1891,22 @@ end
     @test get_prompt("--project=$proj_file") == "(Bar) pkg> "
 end
 
+@testset "show_project_in_prompt option" begin
+    # Test project_prefix() directly
+    get_prefix(proj::String) = readchomp(`$(Base.julia_cmd()[1]) --startup-file=no $(proj) -e "using REPL; print(REPL.project_prefix())"`)
+    @test get_prefix("--project=$(pkgdir(REPL))") == "(REPL) "
+
+    tdir = mkpath(joinpath(mktempdir(), "baz"))
+    @test get_prefix("--project=$tdir") == "(baz) "
+
+    # Pkg_promptf still works after refactor
+    get_pkg(proj::String) = readchomp(`$(Base.julia_cmd()[1]) --startup-file=no $(proj) -e "using REPL; print(REPL.Pkg_promptf())"`)
+    @test get_pkg("--project=$tdir") == "(baz) pkg> "
+
+    # Test that the option defaults to false
+    @test REPL.Options().show_project_in_prompt == false
+end
+
 # Issue #58158 add alias for Char display in REPL
 @testset "REPL show_repl Char alias" begin
     # Test character with a known emoji alias


### PR DESCRIPTION
Add a `show_project_in_prompt` option to `REPL.Options` that,  
  when                                           
  enabled, displays the active project/environment name in the   
  julia>                                                       
  prompt (and other mode prompts), similar to how the pkg> prompt
  already shows it.

  Users can enable this in their startup.jl:

      atreplinit() do repl
          repl.options.show_project_in_prompt = true
      end

  The implementation refactors `Pkg_promptf()` to extract a
  shared
  `project_prefix()` function, avoiding code duplication between
  the
  Pkg prompt and the new julia prompt prefix.

  Fixes #35876