### PR TITLE
debugging: Add `jl__` utility for high-verbosity printing

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -2512,6 +2512,8 @@ JL_DLLEXPORT void jl_fprint_backtrace(ios_t *s) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jlbacktrace(void) JL_NOTSAFEPOINT; // deprecated
 // Mainly for debugging, use `void*` so that no type cast is needed in C++.
 JL_DLLEXPORT void jl_(void *jl_value) JL_NOTSAFEPOINT;
+// Mainly for debugging, a high-verbosity version of `jl_`
+JL_DLLEXPORT void jl__(void *jl_value) JL_NOTSAFEPOINT;
 
 // julia options -----------------------------------------------------------
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -674,7 +674,13 @@ void jl_gc_reset_alloc_count(void);
 uint32_t jl_get_gs_ctr(void);
 void jl_set_gs_ctr(uint32_t ctr);
 
-typedef struct _jl_static_show_config_t { uint8_t quiet; } jl_static_show_config_t;
+#define JL_STATIC_SHOW_VERBOSITY_MINIMAL 0
+#define JL_STATIC_SHOW_VERBOSITY_DEFAULT 1
+#define JL_STATIC_SHOW_VERBOSITY_FULL 2
+
+typedef struct _jl_static_show_config_t {
+    uint8_t verbosity;
+} jl_static_show_config_t;
 size_t jl_static_show_func_sig_(JL_STREAM *s, jl_value_t *type, jl_static_show_config_t ctx) JL_NOTSAFEPOINT;
 
 STATIC_INLINE jl_value_t *undefref_check(jl_datatype_t *dt, jl_value_t *v) JL_NOTSAFEPOINT

--- a/src/timing.c
+++ b/src/timing.c
@@ -605,7 +605,7 @@ JL_DLLEXPORT void jl_timing_show_func_sig(jl_value_t *v, jl_timing_block_t *cur_
     ios_mem(&buf, IOS_INLSIZE);
     buf.growable = 0; // Restrict to inline buffer to avoid allocation
 
-    jl_static_show_config_t config = { /* quiet */ 1 };
+    jl_static_show_config_t config = { /* verbosity */ JL_STATIC_SHOW_VERBOSITY_MINIMAL };
     jl_static_show_func_sig_((JL_STREAM*)&buf, v, config);
     _jl_timing_show_buf(cur_block, &buf);
 #endif


### PR DESCRIPTION
As seen on https://github.com/JuliaLang/julia/pull/60975, we don't have a very consistent "intent" when printing via `jl_`:

Some objects such as MethodInstances print almost none of their fields, while others such as CodeInstances print almost everything, even if it means flooding your terminal. This PR attempts to solve this problem by adding `jl__` which is high-verbosity and tries to print "all" data structurally accessible from an object.

This allows `jl_` printing to be tweaked to a more "reasonable" default for general inspection / printing of objects during runtime debugging, more analogous to `Base.show()` rather than `Base.dump()`.

(no actual printing differences are added in this PR, but hopefully this will make https://github.com/JuliaLang/julia/pull/60975 more straightforward to finish)