### PR TITLE
[JuliaLowering] Several small bugfixes found in stdlib testing

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -97,6 +97,9 @@ function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
     return st._id, src
 end
 
+# `suppress_linenodes` is true if `st`'s parent knows `st` is an exception to
+# normal linenode rules.  It only applies to `st`, and not transitively to its
+# children.
 function est_to_expr(st::SyntaxTree, suppress_linenodes=false)
     k = kind(st)
     return if k === K"core" && numchildren(st) === 0 && st.name_val === "nothing"

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -97,7 +97,7 @@ function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
     return st._id, src
 end
 
-function est_to_expr(st::SyntaxTree)
+function est_to_expr(st::SyntaxTree, suppress_linenodes=false)
     k = kind(st)
     return if k === K"core" && numchildren(st) === 0 && st.name_val === "nothing"
         nothing
@@ -116,22 +116,45 @@ function est_to_expr(st::SyntaxTree)
     elseif k === K"inert"
         QuoteNode(est_to_expr(st[1]))
     else
-        # TODO: should handle post-desugaring forms as well
+        # TODO: should handle post-lowering forms as well
         @assert !is_leaf(st) "est_to_expr should only be used pre-desugaring"
         # In a partially-expanded or quoted AST, there may be heads with no
         # corresponding kind
         head = Symbol(k === K"unknown_head" ? st.name_val : untokenize(k))
-        need_lnns = head in (:block, :toplevel)
         out = Expr(head)
-        for c in children(st)
+
+        # (Move the following assumptions to the docs if they turn out accurate)
+        # The only mandatory LineNumberNode is the second macrocall argument.
+        # Other than that, optional linenodes may show up anywhere within:
+        # - `block`, unless the block is the first child of `for` or `let`
+        # - `toplevel`
+        # Macro authors are responsible for handling any linenodes that follow
+        # the rules above (but the presence of optional linenodes can't be
+        # counted upon).
+        need_lnns = head in (:block, :toplevel) && !suppress_linenodes
+        for (i, c) in enumerate(children(st))
             need_lnns && push!(out.args, source_location(LineNumberNode, c))
-            push!(out.args, est_to_expr(c))
+            let suppress_c = i == 1 && (k == K"for" || k == K"let")
+                push!(out.args, est_to_expr(c, suppress_c))
+            end
         end
-        # extra linenodes
-        n = length(out.args)
-        if (k === K"module" && 3 <= n <= 4 && kind(st[end]) === K"block") ||
-            (k in KSet"function macro" && n === 2 && kind(st[end]) === K"block")
-            pushfirst!(out.args[end].args, source_location(LineNumberNode, st))
+        # Add extra linenodes to some blocks for better provenance
+        @stm st begin
+            ([K"block"], when=!suppress_linenodes) ->
+                push!(out.args, source_location(LineNumberNode, st))
+            [K"module" _... [K"block" _...]] ->
+                pushfirst!(out.args[end].args, source_location(LineNumberNode, st))
+            [K"function" _ [K"block" _...]] ->
+                pushfirst!(out.args[end].args, source_location(LineNumberNode, st))
+            [K"macro" _ [K"block" _...]] ->
+                pushfirst!(out.args[end].args, source_location(LineNumberNode, st))
+            [K"for" _ [K"block" _...]] ->
+                push!(out.args[end].args, source_location(
+                    LineNumberNode, sourcefile(st), last_byte(st)))
+            [K"while" _ [K"block" _...]] ->
+                push!(out.args[end].args, source_location(
+                    LineNumberNode, sourcefile(st), last_byte(st)))
+            _ -> nothing
         end
         out
     end

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2179,7 +2179,8 @@ function make_lhs_decls(ctx, stmts, declkind, declmeta, ex, type_decls=true)
         ([K"Value"], when=ex.value isa GlobalRef) -> ex
         [K"Placeholder"] -> nothing
         ([K"::" [K"Identifier"] t], when=type_decls) -> let x = ex[1]
-            push!(stmts, newnode(ctx, ex, K"decl", tree_ids(x, t)))
+            t2 = expand_forms_2(ctx, t)
+            push!(stmts, newnode(ctx, ex, K"decl", tree_ids(x, t2)))
             make_lhs_decls(ctx, stmts, declkind, declmeta, x, type_decls)
         end
         ([K"::" [K"Placeholder"] t], when=type_decls) -> let

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -4524,10 +4524,10 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
         if numchildren(ex) == 1 && kind(ex[1]) == K"String"
             ex[1]
         else
-            @ast ctx ex [K"call"
+            expand_forms_2(ctx, @ast ctx ex [K"call"
                 "string"::K"top"
-                expand_forms_2(ctx, children(ex))...
-            ]
+                children(ex)...
+            ])
         end
     elseif k == K"try"
         expand_forms_2(ctx, expand_try(ctx, ex))

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -378,7 +378,7 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
         id = ex_out[1]
         if kind(id) != K"Placeholder"
             binfo = get_binding(ctx, id)
-            if !isnothing(binfo.type)
+            if !isnothing(binfo.type) && binfo.kind !== :global
                 throw(LoweringError(ex, "multiple type declarations found for `$(binfo.name)`"))
             end
             binfo.type = ex_out[2]._id

--- a/JuliaLowering/test/compat.jl
+++ b/JuliaLowering/test/compat.jl
@@ -481,6 +481,28 @@ test_toplevel_programs = [
         end
 
     end
+
+    @testset "test exceptions to blocks containing linenodes" begin
+        # Macro authors are otherwise expected to handle LineNumberNode in
+        # blocks, but since they were never emitted in `let` or `for` assignment
+        # blocks, test that we have the same behaviour.
+        @testset "linenodes equal in `let`" begin
+            s = """
+            let a=1, b=2, c=3
+                a,b,c
+            end
+            """
+            @test JL.est_to_expr(JS.parsestmt(SyntaxTree, s)) == JS.parsestmt(Expr, s)
+        end
+        @testset "linenodes equal in `for`" begin
+            s = """
+            for a in 1:2, b in 3:4, c in 5:6
+                a,b,c
+            end
+            """
+            @test JL.est_to_expr(JS.parsestmt(SyntaxTree, s)) == JS.parsestmt(Expr, s)
+        end
+    end
 end
 
 @testset "non-ASCII operator handling" begin

--- a/JuliaLowering/test/decls.jl
+++ b/JuliaLowering/test/decls.jl
@@ -68,7 +68,11 @@ global a_typed_global::Int = 10.0
 """) === 10.0
 @test Core.get_binding_type(test_mod, :a_typed_global) === Int
 @test test_mod.a_typed_global === 10
-
+@test JuliaLowering.include_string(test_mod, """
+global a_curly_typed_global::Union{Int, Float64} = 10.0
+""") === 10.0
+@test Core.get_binding_type(test_mod, :a_curly_typed_global) === Union{Int, Float64}
+@test test_mod.a_curly_typed_global === 10.0
 # Also allowed in nontrivial scopes in a top level thunk
 @test JuliaLowering.include_string(test_mod, """
 let
@@ -77,6 +81,13 @@ end
 """) === 10.0
 @test Core.get_binding_type(test_mod, :a_typed_global_2) === Int
 @test test_mod.a_typed_global_2 === 10
+@test JuliaLowering.include_string(test_mod, """
+let
+    global a_curly_typed_global_2::Union{Int, Float64} = 10.0
+end
+""") === 10.0
+@test Core.get_binding_type(test_mod, :a_curly_typed_global_2) === Union{Int, Float64}
+@test test_mod.a_curly_typed_global_2 === 10.0
 
 @test JuliaLowering.include_string(test_mod, "const x_c_T::Int = 9") === 9
 @test Base.isdefinedglobal(test_mod, :x_c_T)

--- a/JuliaLowering/test/decls.jl
+++ b/JuliaLowering/test/decls.jl
@@ -73,6 +73,21 @@ global a_curly_typed_global::Union{Int, Float64} = 10.0
 """) === 10.0
 @test Core.get_binding_type(test_mod, :a_curly_typed_global) === Union{Int, Float64}
 @test test_mod.a_curly_typed_global === 10.0
+@test JuliaLowering.include_string(test_mod, """
+begin
+    global opassign_global = 1
+    global opassign_global += 1
+end
+""") === 2
+@test test_mod.opassign_global === 2
+@test JuliaLowering.include_string(test_mod, """
+begin
+    global dotopassign_global = [1,2,3]
+    global dotopassign_global .+= 1
+end
+""") == [2,3,4]
+@test test_mod.dotopassign_global == [2,3,4]
+
 # Also allowed in nontrivial scopes in a top level thunk
 @test JuliaLowering.include_string(test_mod, """
 let
@@ -88,6 +103,22 @@ end
 """) === 10.0
 @test Core.get_binding_type(test_mod, :a_curly_typed_global_2) === Union{Int, Float64}
 @test test_mod.a_curly_typed_global_2 === 10.0
+@test JuliaLowering.include_string(test_mod, """
+begin
+    global opassign_global_t::Int = 1
+    global opassign_global_t::Int += 1.0
+end
+""") === 2.0
+@test Core.get_binding_type(test_mod, :opassign_global_t) === Int
+@test test_mod.opassign_global_t === 2
+@test JuliaLowering.include_string(test_mod, """
+begin
+    global dotopassign_global_t::Vector{Int} = [1,2,3]
+    global dotopassign_global_t::Vector{Int} .+= [1.0,2.0,3.0]
+end
+""") == [2.0,4.0,6.0]
+@test Core.get_binding_type(test_mod, :dotopassign_global_t) === Vector{Int}
+@test test_mod.dotopassign_global_t == [2,4,6]
 
 @test JuliaLowering.include_string(test_mod, "const x_c_T::Int = 9") === 9
 @test Base.isdefinedglobal(test_mod, :x_c_T)

--- a/JuliaLowering/test/decls_ir.jl
+++ b/JuliaLowering/test/decls_ir.jl
@@ -207,6 +207,33 @@ begin
 end
 
 ########################################
+# multiple type declarations is OK for globals
+begin
+    global x::Int
+    x::Int = 1
+end
+#---------------------
+1   TestMod.Int
+2   (call core.declare_global TestMod :x true %₁)
+3   latestworld
+4   (call core.declare_global TestMod :x false)
+5   latestworld
+6   TestMod.Int
+7   (call core.declare_global TestMod :x true %₆)
+8   latestworld
+9   (call core.declare_global TestMod :x true)
+10  latestworld
+11  (call core.get_binding_type TestMod :x)
+12  (= slot₁/tmp 1)
+13  (call core.isa slot₁/tmp %₁₁)
+14  (gotoifnot %₁₃ label₁₆)
+15  (goto label₁₇)
+16  (= slot₁/tmp (call top.convert %₁₁ slot₁/tmp))
+17  slot₁/tmp
+18  (call core.setglobal! TestMod :x %₁₇)
+19  (return 1)
+
+########################################
 # Error: Const not supported on locals
 const local x = 1
 #---------------------

--- a/JuliaLowering/test/decls_ir.jl
+++ b/JuliaLowering/test/decls_ir.jl
@@ -193,7 +193,7 @@ global xx::T = 10
 16  (return 10)
 
 ########################################
-# Error: x declared twice
+# Error: local with two type declarations
 begin
     local x::T = 1
     local x::S = 1
@@ -204,6 +204,20 @@ begin
     local x::T = 1
     local x::S = 1
 #        └───────┘ ── multiple type declarations found for `x`
+end
+
+########################################
+# Error: local with two type declarations, requiring scope resolution
+begin
+    local x::Int = 1
+    x::Int = 1
+end
+#---------------------
+LoweringError:
+begin
+    local x::Int = 1
+    x::Int = 1
+#   └────────┘ ── multiple type declarations found for `x`
 end
 
 ########################################
@@ -309,6 +323,18 @@ end
 ########################################
 # Error: global type decls only allowed at top level
 function f()
+    global x::Int
+end
+#---------------------
+LoweringError:
+function f()
+    global x::Int
+#          └────┘ ── type declarations for global variables must be at top level, not inside a function
+end
+
+########################################
+# Error: global type decls only allowed at top level (=)
+function f()
     global x::Int = 1
 end
 #---------------------
@@ -316,4 +342,125 @@ LoweringError:
 function f()
     global x::Int = 1
 #         └─────────┘ ── type declarations for global variables must be at top level, not inside a function
+end
+
+########################################
+# Error: global type decls only allowed at top level, requiring scope resolution
+function f()
+    global x
+    x::Int = 1
+end
+#---------------------
+LoweringError:
+function f()
+    global x
+    x::Int = 1
+#   └────────┘ ── type declarations for global variables must be at top level, not inside a function
+end
+
+########################################
+# FIXME: Error: global type decls only allowed at top level (.=)
+function f()
+    global x::Int .= 1
+end
+#---------------------
+1   (method TestMod.f)
+2   latestworld
+3   (call core.declare_global TestMod :x false)
+4   latestworld
+5   TestMod.f
+6   (call core.Typeof %₅)
+7   (call core.svec %₆)
+8   (call core.svec)
+9   SourceLocation::1:10
+10  (call core.svec %₇ %₈ %₉)
+11  --- method core.nothing %₁₀
+    slots: [slot₁/#self#(!read)]
+    1   TestMod.x
+    2   TestMod.Int
+    3   (call core.typeassert %₁ %₂)
+    4   (call top.broadcasted top.identity 1)
+    5   (call top.materialize! %₃ %₄)
+    6   (return %₅)
+12  latestworld
+13  TestMod.f
+14  (return %₁₃)
+
+########################################
+# FIXME: Error: global type decls only allowed at top level (+=)
+function f()
+    global x::Int += 1
+end
+#---------------------
+1   (method TestMod.f)
+2   latestworld
+3   (call core.declare_global TestMod :x false)
+4   latestworld
+5   (call core.declare_global TestMod :x true)
+6   latestworld
+7   TestMod.f
+8   (call core.Typeof %₇)
+9   (call core.svec %₈)
+10  (call core.svec)
+11  SourceLocation::1:10
+12  (call core.svec %₉ %₁₀ %₁₁)
+13  --- method core.nothing %₁₂
+    slots: [slot₁/#self#(!read) slot₂/tmp(!read)]
+    1   TestMod.+
+    2   TestMod.x
+    3   TestMod.Int
+    4   (call core.typeassert %₂ %₃)
+    5   (call %₁ %₄ 1)
+    6   (call core.get_binding_type TestMod :x)
+    7   (= slot₂/tmp %₅)
+    8   (call core.isa slot₂/tmp %₆)
+    9   (gotoifnot %₈ label₁₁)
+    10  (goto label₁₂)
+    11  (= slot₂/tmp (call top.convert %₆ slot₂/tmp))
+    12  slot₂/tmp
+    13  (call core.setglobal! TestMod :x %₁₂)
+    14  (return %₅)
+14  latestworld
+15  TestMod.f
+16  (return %₁₅)
+
+########################################
+# FIXME: Error: global type decls only allowed at top level (.+=)
+function f()
+    global x::Int .+= 1
+end
+#---------------------
+1   (method TestMod.f)
+2   latestworld
+3   (call core.declare_global TestMod :x false)
+4   latestworld
+5   TestMod.f
+6   (call core.Typeof %₅)
+7   (call core.svec %₆)
+8   (call core.svec)
+9   SourceLocation::1:10
+10  (call core.svec %₇ %₈ %₉)
+11  --- method core.nothing %₁₀
+    slots: [slot₁/#self#(!read)]
+    1   TestMod.x
+    2   TestMod.+
+    3   TestMod.Int
+    4   (call core.typeassert %₁ %₃)
+    5   (call top.broadcasted %₂ %₄ 1)
+    6   (call top.materialize! %₁ %₅)
+    7   (return %₆)
+12  latestworld
+13  TestMod.f
+14  (return %₁₃)
+
+########################################
+# Error: global type decls only allowed at top level (tuple)
+function f()
+    global (x::Int, y) = 1,2
+end
+#---------------------
+LoweringError:
+function f()
+    global (x::Int, y) = 1,2
+#         └────────────────┘ ── type declarations for global variables must be at top level, not inside a function
 end

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -350,4 +350,75 @@ end
 emptyblock_result = JuliaLowering.eval(test_mod, Expr(:(=), :emptyblock_144, Expr(:block)))
 @test emptyblock_result == nothing
 
+@testset "string forms" begin
+    @test JuliaLowering.include_string(test_mod, raw"""
+        "str"
+    """) == "str"
+    @test JuliaLowering.include_string(test_mod, raw"""
+    let x = 1
+        "str$x"
+    end
+    """) == "str1"
+    @test JuliaLowering.include_string(test_mod, raw"""
+    let x = 1
+        "str$(x)"
+    end
+    """) == "str1"
+    @test JuliaLowering.include_string(test_mod, raw"""
+    let x = [1,2,3]
+        "str$(x...)"
+    end
+    """) == "str123"
+    @test JuliaLowering.include_string(test_mod, raw"""
+    let x = [1,2,3]
+        "str$(x)"
+    end
+    """) == "str[1, 2, 3]"
+    @test JuliaLowering.include_string(test_mod, raw"""
+    let x = [1,2,3]
+        "str$("innerstr$(x...)")"
+    end
+    """) == "strinnerstr123"
+    @test JuliaLowering.include_string(test_mod, raw"""
+    let x = [1,2,3]
+        "str$(["innerstr$(x...)"]...)"
+    end
+    """) == "strinnerstr123"
+
+    # cmds
+    @test JuliaLowering.include_string(test_mod, raw"""
+        `cmdstr`
+    """) == `cmdstr`
+    @test JuliaLowering.include_string(test_mod, raw"""
+    let x = 1
+        `cmdstr$x`
+    end
+    """) == `cmdstr1`
+    @test JuliaLowering.include_string(test_mod, raw"""
+    let x = 1
+        `cmdstr$(x)`
+    end
+    """) == `cmdstr1`
+    @test JuliaLowering.include_string(test_mod, raw"""
+    let x = [1,2,3]
+        `cmdstr$(x...)`
+    end
+    """) == `cmdstr123`
+    @test JuliaLowering.include_string(test_mod, raw"""
+    let x = [1,2,3]
+        `cmdstr$(x)`
+    end
+    """) == `cmdstr1 cmdstr2 cmdstr3`
+    @test JuliaLowering.include_string(test_mod, raw"""
+    let x = [1,2,3]
+        `cmdstr$("innerstr$(x...)")`
+    end
+    """) == `cmdstrinnerstr123`
+    @test JuliaLowering.include_string(test_mod, raw"""
+    let x = [1,2,3]
+        `cmdstr$(["innerstr$(x...)"]...)`
+    end
+    """) == `cmdstrinnerstr123`
+end
+
 end


### PR DESCRIPTION
- Fix https://github.com/JuliaLang/JuliaLowering.jl/issues/143, simple missing
  desugaring on the rhs of a global type decl
- Fix https://github.com/JuliaLang/JuliaLowering.jl/issues/142, producing
  LineNumberNodes in the first argument to `for` when it is a block.  flisp and
  JuliaSyntax make an exception for this block (and the one in `let`, which I've
  also changed).  I wrote down what linenodes I expect macro authors to tolerate
  for future reference.
- Fix https://github.com/JuliaLang/JuliaLowering.jl/issues/146, which was just
  desugaring not knowing it had to handle `op=` (or `.op=`).
  - Fix the validator in the `global x .= y` case.  I missed this case expecting
    it to be part of `vst1_op_assign`.
  - Remove handling of non-top-level global type decls in the validator.  I 
    thought flisp was checking in desugaring, but it actually waits until scope 
    resolution.
- Remove checking for duplicate type decls on globals.  flisp only does this for
  locals (which only exist in one top-level expression, so the checking can be
  complete).
- Fix desugaring of `(string (... _))` form

All the changes above should be tested.  Suggestions for more are welcome!