### PR TITLE
Serialization: support Core.IntrinsicFunction serialize/deserialize

### DIFF
--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -691,6 +691,11 @@ function serialize(s::AbstractSerializer, x::Core.AddrSpace)
     write(s.io, Core.bitcast(UInt8, x))
 end
 
+function serialize(s::AbstractSerializer, x::Core.IntrinsicFunction)
+    serialize_type(s, typeof(x))
+    serialize(s, nameof(x))
+end
+
 function serialize_any(s::AbstractSerializer, @nospecialize(x))
     tag = sertag(x)
     if tag > 0
@@ -1446,6 +1451,11 @@ end
 
 function deserialize(s::AbstractSerializer, X::Type{Core.AddrSpace{M}} where M)
     Core.bitcast(X, read(s.io, UInt8))
+end
+
+function deserialize(s::AbstractSerializer, ::Type{Core.IntrinsicFunction})
+    name = deserialize(s)::Symbol
+    return getfield(Core.Intrinsics, name)::Core.IntrinsicFunction
 end
 
 function deserialize_expr(s::AbstractSerializer, len)

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -659,6 +659,18 @@ end
     @test l2.parts === ()
 end
 
+@testset "Core.IntrinsicFunction" begin
+    create_serialization_stream() do s
+        serialize(s, Core.Intrinsics.add_int)
+        serialize(s, Core.Intrinsics.xor_int)
+        serialize(s, Core.Intrinsics.sub_float)
+        seekstart(s)
+        @test deserialize(s) === Core.Intrinsics.add_int
+        @test deserialize(s) === Core.Intrinsics.xor_int
+        @test deserialize(s) === Core.Intrinsics.sub_float
+    end
+end
+
 @testset "Docstrings" begin
     undoc = Docs.undocumented_names(Serialization)
     @test_broken isempty(undoc)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/61011

added serialize and deserialize methods for Core.IntrinsicFunction values as before this serializing would throw a method error because the generic serialize_any path calls write() and there was no method for intrinsic function.

do follow up on this if any more / different changes are expected