### PR TITLE
Markdown: special case hack for <br>

### DIFF
--- a/stdlib/Markdown/src/Common/inline.jl
+++ b/stdlib/Markdown/src/Common/inline.jl
@@ -444,6 +444,8 @@ function skip_cdata_section(io::IO)
     end
 end
 
+const HTML_BREAK_REGEX = r"^<br\s*/?>"i
+
 @trigger '<' ->
 function html_inline(stream::IO, md::MD)
     pos = position(stream)
@@ -451,7 +453,7 @@ function html_inline(stream::IO, md::MD)
     # special case for <br>: this is of course not part of CommonMark,
     # but it is the only way to get linebreaks into tables, and by handling
     # this here, it will also work in LaTeX / PDF output.
-    startswith(stream, "<br>") && return LineBreak()
+    startswith(stream, HTML_BREAK_REGEX) && return LineBreak()
 
     # An HTML tag consists of an open tag, a closing tag, an HTML comment, a
     # processing instruction, a declaration, or a CDATA section.

--- a/stdlib/Markdown/src/Common/inline.jl
+++ b/stdlib/Markdown/src/Common/inline.jl
@@ -448,6 +448,11 @@ end
 function html_inline(stream::IO, md::MD)
     pos = position(stream)
 
+    # special case for <br>: this is of course not part of CommonMark,
+    # but it is the only way to get linebreaks into tables, and by handling
+    # this here, it will also work in LaTeX / PDF output.
+    startswith(stream, "<br>") && return LineBreak()
+
     # An HTML tag consists of an open tag, a closing tag, an HTML comment, a
     # processing instruction, a declaration, or a CDATA section.
     skip_open_tag(stream) ||

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1740,6 +1740,24 @@ end
     @test str_nbsp == "  abc\n  $nbsp| def"
 end
 
+@testset "Hack for handling <br>" begin
+    md = Markdown.parse("""
+    1<br>
+    2<br >
+    3<br/>
+    4<br />
+    5<BR>
+    6<BR >
+    7<BR/>
+    8<BR />
+    """)
+
+    @test length(md[1].content) == 16
+    @test all(i -> md[1].content[i] isa LineBreak, 2:2:16)
+    @test all(i -> md[1].content[i] isa String, 1:2:15)
+
+end
+
 include("test_spec_roundtrip_common.jl")
 include("test_spec_roundtrip_github.jl")
 include("test_spec_roundtrip_julia.jl")


### PR DESCRIPTION
This is of course not part of CommonMark. But it is a pragmatic hack to allow users to insert linebreaks into table cells in way that also works in LaTeX / PDF output.

This is for example already now used in effect in the file doc/src/manual/noteworthy-differences.md for the table in section "Julia ⇔ C/C++: Quick reference". However, in Julia versions before 1.14, this ended up as being displayed as literal `<br>` in both the [HTML](https://docs.julialang.org/en/v1.12/manual/noteworthy-differences/#Julia-C/C:-Quick-reference) and PDF versions.

With the recent addition of support inline HTML, the table would already work right when producing HTML (and using Documenter 1.17+), but still not in PDFs.

Unfortunately there is no other generally accepted way of inserting line breaks into table cells (note that tables are an extensions beyond base CommonMark).

Fixes #49991.