### PR TITLE
 Restore unary + for Array

### DIFF
--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -39,6 +39,7 @@ for f in (:+, :-)
     end
 end
 
++(A::Array) = broadcast_preserving_zero_d(+, A)
 function +(A::Array, B::Array, Cs::Array...)
     promote_shape(A, B)
     for C in Cs

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -100,6 +100,14 @@ using Dates
     @test Array{eltype(a)}(a) !== a
     @test Vector(a) !== a
 end
+
+@testset "issue #61046: unary +" begin
+    struct MyType61046 end
+    Base.:+(::MyType61046) = MyType61046()
+    A = fill(MyType61046(), 2, 2)
+    @test +A isa Matrix{MyType61046}
+    @test (+A)[1] isa MyType61046
+end
 @testset "effect inference for `reshape` for `Array`" begin
     for Arr ∈ (Array{<:Any, 0}, Vector, Matrix, Array{<:Any, 3})
         for Shape ∈ (Tuple{Int}, Tuple{Int, Int})


### PR DESCRIPTION
Restores support for unary + on Arrays with non-Number element types, which was regressed by a recent change to + method signatures.

Added +(A::Array) = broadcast_preserving_zero_d(+, A) to handle the unary case for all Arrays, restoring consistent behavior.

Also included a regression test in test/arrayops.jl.