### PR TITLE
Test suite: Don't allow `Distributed.cluster_manager` to be undefined

### DIFF
--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -98,14 +98,6 @@ ambig(x::Union{Char, Int16}) = 's'
 
 const allowed_undefineds = Set([GlobalRef(Base, :active_repl)])
 
-let Distributed = get(Base.loaded_modules,
-                      Base.PkgId(Base.UUID("8ba89e20-285c-5b6f-9357-94700520ee1b"), "Distributed"),
-                      nothing)
-    if Distributed !== nothing
-        push!(allowed_undefineds, GlobalRef(Distributed, :cluster_manager))
-    end
-end
-
 module Ambig1
 ambig(x, y) = 1
 ambig(x::Integer, y) = 2


### PR DESCRIPTION
Depends on:
- [x] https://github.com/JuliaLang/Distributed.jl/pull/177
    - [x] Which will land on master in: #61109