### PR TITLE
Fix precompilation error logging

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -4377,10 +4377,10 @@ end
             if !samefile(includes[1].filename, modspec.path)
                 # In certain cases the path rewritten by `fixup_stdlib_path` may
                 # point to an unreadable directory, make sure we can `stat` the
-                # file before comparing it with `modpath`.
+                # file before comparing it with `modspec.path`.
                 stdlib_path = fixup_stdlib_path(includes[1].filename)
                 if !(isreadable(stdlib_path) && samefile(stdlib_path, modspec.path))
-                    @debug "Rejecting cache file $cachefile because it is for file $(includes[1].filename) not file $modpath"
+                    @debug "Rejecting cache file $cachefile because it is for file $(includes[1].filename) not file $(modspec.path)"
                     record_reason(reasons, "different source file path")
                     return true # cache file was compiled from a different path
                 end


### PR DESCRIPTION
Fix for the modpath -> modspec change

This only cause an error when logging is enabled.