### PR TITLE
method.c: fix typo in condition for backedge compaction

### DIFF
--- a/Compiler/test/invalidation.jl
+++ b/Compiler/test/invalidation.jl
@@ -361,3 +361,14 @@ end
     @test occursin("precompile(Tuple{typeof(Main.drop_cache_test_g), $Int})", err_before)
     @test occursin("precompile(Tuple{typeof(Main.drop_cache_test_g), $Int}) # recompile", err_after)
 end
+
+# Test that backedge compaction clears mi.backedges when all backedges are removed
+begin
+    pr61102_callee(x) = 2x
+    pr61102_caller(x) = pr61102_callee(x)
+    pr61102_caller(0)
+    callee_mi = Base.method_instance(pr61102_callee, (Int,))
+    @test isdefined(callee_mi, :backedges)
+    pr61102_callee(x::Int) = 3x
+    @test !isdefined(callee_mi, :backedges)
+end

--- a/src/method.c
+++ b/src/method.c
@@ -1158,7 +1158,7 @@ void jl_mi_done_backedges(jl_method_instance_t *mi JL_PROPAGATES_ROOT, uint8_t o
                     continue;
                 insb = set_next_edge(backedges, insb, invokesig, caller);
             }
-            if (insb == n) {
+            if (insb == 0) {
                 // All were deleted
                 mi->backedges = NULL;
             } else {


### PR DESCRIPTION
discovered via automated Claude audit for typos and other minor / obvious bugs. I manually reviewed each result

`insb` is the write cursor for kept entries after compaction, so `insb == 0` means all were deleted; the existing `insb == n` would mean none were deleted

I don't know how to add a test for the consequences of this