### PR TITLE
APInt-C: fix MutableArrayRef element count in LLVMFPtoInt

### DIFF
--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -355,7 +355,7 @@ void LLVMFPtoInt(jl_datatype_t *ty, void *pa, jl_datatype_t *oty, integerPart *p
         APFloat::roundingMode rounding_mode = RoundingMode::TowardZero;
         unsigned nbytes = alignTo(onumbits, integerPartWidth) / host_char_bit;
         integerPart *parts = (integerPart*)alloca(nbytes);
-        APFloat::opStatus status = a.convertToInteger(MutableArrayRef<integerPart>(parts, nbytes), onumbits, isSigned, rounding_mode, &isVeryExact);
+        APFloat::opStatus status = a.convertToInteger(MutableArrayRef<integerPart>(parts, nbytes / sizeof(integerPart)), onumbits, isSigned, rounding_mode, &isVeryExact);
         memcpy(pr, parts, onumbytes);
         if (isExact)
             *isExact = (status == APFloat::opOK);


### PR DESCRIPTION
discovered via automated Claude audit for typos and other minor / obvious bugs. I manually reviewed each result

Pass the number of `integerPart` elements rather than the byte count to `MutableArrayRef` in `convertToInteger`, which was  overstating the array size by a factor of `sizeof(integerPart)`

compare to https://github.com/JuliaLang/julia/blob/2ba9b37b3f8074106e21b621fe58a9518ae07cd8/src/APInt-C.cpp#L28