### PR TITLE
doc: Apply VERSION to all doc pages

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -382,19 +382,6 @@ DocMeta.setdocmeta!(
     maybe_revise(:(;;));
     recursive=true,
 )
-# Use current Julia version's syntax for Base and Core doctests
-DocMeta.setdocmeta!(
-    Base,
-    :DocTestSyntax,
-    VERSION;
-    recursive=true, warn=false,
-)
-DocMeta.setdocmeta!(
-    Core,
-    :DocTestSyntax,
-    VERSION;
-    recursive=true, warn=false,
-)
 DocMeta.setdocmeta!(
     Base.BinaryPlatforms,
     :DocTestSetup,
@@ -439,6 +426,7 @@ makedocs(
     authors   = "The Julia Project",
     pages     = PAGES,
     remotes   = documenter_stdlib_remotes,
+    meta      = Dict(:DocTestSyntax => VERSION),
 )
 
 # Update URLs to external stdlibs (JuliaLang/julia#43199)


### PR DESCRIPTION
When documenting a package, Documenter will pick up the syntax version using the ordinary mechanism, but Base is special of course. Claude had manually set the VERSION for Base/Core, but this doesn't apply to man pages. Instead, just set the version for the whole build.