### PR TITLE
builtins: fix off-by-one nargs in jl_f_invoke CodeInstance fallback

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1721,7 +1721,7 @@ JL_CALLABLE(jl_f_invoke)
             if (codeinst->owner != jl_nothing) {
                 jl_error("Failed to invoke or compile external codeinst");
             }
-            return jl_invoke(args[0], &args[2], nargs - 1, mi);
+            return jl_invoke(args[0], &args[2], nargs - 2, mi);
         }
     }
     if (!jl_is_tuple_type(jl_unwrap_unionall(argtypes)))


### PR DESCRIPTION
discovered via automated Claude audit for typos and other minor / obvious bugs. I manually reviewed each result 

compare to https://github.com/JuliaLang/julia/blob/a17503f9d940acc236b0fcd1e979242069df9f9b/src/builtins.c#L1719 which uses the correct `nargs`

the test only fails when run with `--compile=min` hence why I put it in `interpreter.jl` and not `builtins.jl`