### PR TITLE
disasm: guard against potential end-iterator dereference in `@code_native`

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -1038,7 +1038,10 @@ static void jl_dump_asm_internal(
                     if (!buf.empty()) {
                         Streamer->emitRawText(buf);
                     }
-                    nextLineAddr = (++di_lineIter)->first;
+                    if (++di_lineIter != di_lineEnd)
+                        nextLineAddr = di_lineIter->first;
+                    else
+                        nextLineAddr = (uint64_t)-1;
                 }
             }
 


### PR DESCRIPTION
discovered via automated Claude audit for typos and other minor / obvious bugs. I manually reviewed each result 

I guess this is very minor but may as well avoid a potential OOB read. I don't know how to add a test