### PR TITLE
fix typo in GC thrashing detection condition

### DIFF
--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -3243,7 +3243,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
         old_freed_diff = gc_mem;
         old_pause_time = gc_time;
         // thrashing estimator: if GC time more than 50% of the runtime
-        if (pause > mutator_time && !(thrash_counter < 4))
+        if (pause > mutator_time && thrash_counter <= 4)
             thrash_counter += 1;
         else if (thrash_counter > 0)
             thrash_counter -= 1;


### PR DESCRIPTION
discovered via automated Claude audit for typos and other minor / obvious bugs. I manually reviewed each result 

`thrash_counter` is initialized to `0` but only ever incremented under this branch, which was checking `!(thrash_counter < 4)`, making the entire mechanism effectively dead code

here was something that can demonstrate the difference but I don't know how to add a unit test

```
# gc_thrash_mwe.jl
mutable struct Node; l::Any; r::Any; d::Vector{UInt8}; end
tree(n) = n <= 0 ? Node(nothing,nothing,rand(UInt8,64)) : Node(tree(n-1),tree(n-1),rand(UInt8,64))

const SHED = Ref(false)
const CB = @cfunction(() -> (SHED[] = true; nothing), Cvoid, ())
ccall(:jl_gc_set_cb_notify_gc_pressure, Cvoid, (Ptr{Cvoid}, Cint), CB, 1)

trees = Any[tree(18) for _ in 1:8]                       # ~640 MB scattered pointers
cache = Ref{Any}([rand(UInt8, 200) for _ in 1:1_000_000]) # ~200 MB droppable cache
GC.gc()

@time for i in 1:200
    if SHED[]; cache[] = nothing; SHED[] = false; end
    [rand(UInt8, 48) for _ in 1:50_000]
end
println(cache[] === nothing ? "PASS: cache shed under pressure" : "FAIL: pressure callback never fired")
```

```
➜  (adienes) ./julia --heap-size-hint=1500M gc_thrash_mwe.jl
  0.449891 seconds (20.03 M allocations: 1.121 GiB, 64.03% gc time, 4.14% compilation time)
PASS: cache shed under pressure

➜  (adienes) julia +nightly --heap-size-hint=1500M gc_thrash_mwe.jl
  0.619595 seconds (20.03 M allocations: 1.121 GiB, 75.61% gc time, 2.99% compilation time)
FAIL: pressure callback never fired
```