### PR TITLE
shell: escape backslashes in double-quote path of shell_escape

### DIFF
--- a/base/shell.jl
+++ b/base/shell.jl
@@ -200,7 +200,7 @@ function print_shell_word(io::IO, word::AbstractString, special::AbstractString 
     else
         print(io, '"')
         for c in word
-            if c == '"' || c == '$'
+            if c == '"' || c == '$' || c == '\\'
                 print(io, '\\')
             end
             print(io, c)

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -544,6 +544,13 @@ end
 
 @test Base.shell_split("\"\\\\\"") == ["\\"]
 
+let roundtrip(s) = first(Base.shell_split(Base.shell_escape(s))) == s
+    @test roundtrip("foo'bar\\\$baz")
+    @test roundtrip("foo'bar\\\"baz")
+    @test roundtrip("foo'bar\\\\baz")
+    @test roundtrip("foo'bar\\\\")
+end
+
 # Test failing commands
 failing_cmd = `$catcmd _doesnt_exist__111_`
 failing_pipeline = pipeline(failing_cmd, stderr=devnull) # make quiet for tests


### PR DESCRIPTION
discovered via automated Claude audit for typos and other minor / obvious bugs. I manually reviewed each result

When `print_shell_word` uses the double-quote escaping path (for strings containing single quotes), backslashes before `"`, `$`, or `\` were not being escaped, but `shell_parse` treats `\"`, `\$`, and `\\` inside double quotes as escape sequences