### PR TITLE
module: add missing GC write barriers for bpart->restriction stores

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -393,6 +393,8 @@ JL_DLLEXPORT void jl_update_loaded_bpart(jl_binding_t *b, jl_binding_partition_t
     jl_atomic_store_relaxed(&bpart->min_world, resolution.min_world);
     jl_atomic_store_relaxed(&bpart->max_world, resolution.max_world);
     bpart->restriction = resolution.binding_or_const;
+    if (resolution.binding_or_const)
+        jl_gc_wb(bpart, resolution.binding_or_const);
     bpart->kind = resolution.ultimate_kind;
 }
 
@@ -1792,6 +1794,7 @@ JL_DLLEXPORT jl_binding_partition_t *jl_replace_binding_locked2(jl_binding_t *b,
             new_bpart->kind |= PARTITION_FLAG_IMPLICITLY_EXPORTED;
         }
         new_bpart->restriction = resolution.binding_or_const;
+        jl_gc_wb_fresh(new_bpart, resolution.binding_or_const);
         assert(resolution.min_world <= new_world && resolution.max_world == ~(size_t)0);
         if (new_bpart->kind == old_bpart->kind && new_bpart->restriction == old_bpart->restriction) {
             JL_GC_POP();


### PR DESCRIPTION
discovered via automated Claude audit for typos and other minor / obvious bugs. I manually reviewed each result

I was less sure about this one but robot seems confident so I'm pasting the message it gave as-is

Add a `jl_gc_wb` in `jl_update_loaded_bpart` after storing `resolution.binding_or_const` into an existing (potentially old-generation) binding partition's restriction field, matching every other non-fresh store to this field.

Add a `jl_gc_wb_fresh` in `jl_replace_binding_locked2`'s `IMPLICIT_RECOMPUTE` path, where `jl_resolve_implicit_import` can trigger GC between the allocation of `new_bpart` and the store, potentially promoting the fresh partition to an older generation. The else branch already had the corresponding `jl_gc_wb_fresh`.

Neither bug is currently triggerable because the stored values are always independently rooted through the module binding table, but the barriers are needed to maintain GC invariants and guard against future code changes.