### PR TITLE
Update Revise manifest

### DIFF
--- a/deps/jlutilities/revise/Manifest.toml
+++ b/deps/jlutilities/revise/Manifest.toml
@@ -1,159 +1,275 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.13.0-DEV"
-manifest_format = "2.0"
+julia_version = "1.14.0-DEV"
+manifest_format = "2.1"
 project_hash = "6de5e8b1c4d9b467a5c126490dbc755dc0575a9c"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 version = "1.11.0"
 
+    [deps.Artifacts.syntax]
+    julia_version = "1.14.0-DEV.1492"
+
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 version = "1.11.0"
 
+    [deps.Base64.syntax]
+    julia_version = "1.14.0-DEV.1492"
+
 [[deps.CodeTracking]]
 deps = ["InteractiveUtils", "UUIDs"]
-git-tree-sha1 = "062c5e1a5bf6ada13db96a4ae4749a4c2234f521"
+git-tree-sha1 = "b7231a755812695b8046e8471ddc34c8268cbad5"
+registries = "General"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
-version = "1.3.9"
+version = "3.0.0"
+
+    [deps.CodeTracking.syntax]
+    julia_version = "1.10.0"
 
 [[deps.Compiler]]
 git-tree-sha1 = "382d79bfe72a406294faca39ef0c3cef6e6ce1f1"
+registries = "General"
 uuid = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
 version = "0.1.1"
+
+    [deps.Compiler.syntax]
+    julia_version = "1.10.0"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "1.3.0+1"
 
+    [deps.CompilerSupportLibraries_jll.syntax]
+    julia_version = "1.6.0"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+    [deps.Dates.syntax]
+    julia_version = "1.14.0-DEV.1492"
+
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 version = "1.11.0"
+
+    [deps.FileWatching.syntax]
+    julia_version = "1.14.0-DEV.1492"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 version = "1.11.0"
 
+    [deps.InteractiveUtils.syntax]
+    julia_version = "1.14.0-DEV.1492"
+
 [[deps.JuliaInterpreter]]
 deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
-git-tree-sha1 = "6ac9e4acc417a5b534ace12690bc6973c25b862f"
+git-tree-sha1 = "80580012d4ed5a3e8b18c7cd86cebe4b816d17a6"
+registries = "General"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.10.3"
+version = "0.10.9"
+
+    [deps.JuliaInterpreter.syntax]
+    julia_version = "1.10.0"
 
 [[deps.JuliaSyntaxHighlighting]]
 deps = ["StyledStrings"]
 uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
-version = "1.12.0"
+version = "1.13.0"
+
+    [deps.JuliaSyntaxHighlighting.syntax]
+    julia_version = "1.12.0"
 
 [[deps.LibGit2]]
 deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 version = "1.11.0"
 
+    [deps.LibGit2.syntax]
+    julia_version = "1.14.0-DEV.1492"
+
 [[deps.LibGit2_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.9.1+0"
+version = "1.9.2+0"
+
+    [deps.LibGit2_jll.syntax]
+    julia_version = "1.9.0"
 
 [[deps.LibSSH2_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl", "OpenSSL_jll", "Zlib_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 version = "1.11.3+1"
 
+    [deps.LibSSH2_jll.syntax]
+    julia_version = "1.8.0"
+
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 version = "1.11.0"
 
+    [deps.Libdl.syntax]
+    julia_version = "1.14.0-DEV.1492"
+
 [[deps.LoweredCodeUtils]]
-deps = ["Compiler", "JuliaInterpreter"]
-git-tree-sha1 = "b882a7dd7ef37643066ae8f9380beea8fdd89cae"
+deps = ["CodeTracking", "Compiler", "JuliaInterpreter"]
+git-tree-sha1 = "65ae3db6ab0e5b1b5f217043c558d9d1d33cc88d"
+registries = "General"
 uuid = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
-version = "3.4.2"
+version = "3.5.0"
+
+    [deps.LoweredCodeUtils.syntax]
+    julia_version = "1.10.0"
 
 [[deps.Markdown]]
 deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 version = "1.11.0"
 
+    [deps.Markdown.syntax]
+    julia_version = "1.14.0-DEV.1492"
+
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.3.0"
 
+    [deps.NetworkOptions.syntax]
+    julia_version = "1.12.0"
+
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.5.1+0"
+version = "3.5.4+0"
+
+    [deps.OpenSSL_jll.syntax]
+    julia_version = "1.6.0"
 
 [[deps.OrderedCollections]]
 git-tree-sha1 = "05868e21324cede2207c6f0f466b4bfef6d5e7ee"
+registries = "General"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.8.1"
+
+    [deps.OrderedCollections.syntax]
+    julia_version = "1.7.1"
 
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
-version = "10.45.0+0"
+version = "10.47.0+0"
+
+    [deps.PCRE2_jll.syntax]
+    julia_version = "1.6.0"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "522f093a29b31a93e34eaea17ba055d850edea28"
+registries = "General"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.1"
+
+    [deps.Preferences.syntax]
+    julia_version = "1.0.0"
 
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 version = "1.11.0"
 
+    [deps.Printf.syntax]
+    julia_version = "1.14.0-DEV.1492"
+
 [[deps.REPL]]
-deps = ["FileWatching", "InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+deps = ["Dates", "FileWatching", "InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 version = "1.11.0"
+
+    [deps.REPL.syntax]
+    julia_version = "1.14.0-DEV.1492"
 
 [[deps.Random]]
 deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 version = "1.11.0"
 
-[[deps.Requires]]
-deps = ["UUIDs"]
-git-tree-sha1 = "62389eeff14780bfe55195b7204c0d8738436d64"
-uuid = "ae029012-a4dd-5104-9daa-d747884805df"
-version = "1.3.1"
+    [deps.Random.syntax]
+    julia_version = "1.14.0-DEV.1492"
 
 [[deps.Revise]]
-deps = ["CodeTracking", "FileWatching", "JuliaInterpreter", "LibGit2", "LoweredCodeUtils", "OrderedCollections", "REPL", "Requires", "UUIDs", "Unicode"]
-git-tree-sha1 = "82dc140c7f52e4daeeec3675a411d48167a85a87"
+deps = ["CodeTracking", "FileWatching", "InteractiveUtils", "JuliaInterpreter", "LibGit2", "LoweredCodeUtils", "OrderedCollections", "Preferences", "REPL", "UUIDs"]
+git-tree-sha1 = "c123d83838e2cf3ae4799ebec6e4331bdb0b703a"
 repo-rev = "master"
 repo-url = "https://github.com/timholy/Revise.jl.git"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.8.0"
+version = "3.13.2"
 
     [deps.Revise.extensions]
     DistributedExt = "Distributed"
+
+    [deps.Revise.syntax]
+    julia_version = "1.10.0"
 
     [deps.Revise.weakdeps]
     Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
-version = "0.7.0"
+version = "1.0.0"
+
+    [deps.SHA.syntax]
+    julia_version = "1.0.0"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 version = "1.11.0"
 
+    [deps.Sockets.syntax]
+    julia_version = "1.14.0-DEV.1492"
+
 [[deps.StyledStrings]]
 uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
-version = "1.11.0"
+version = "1.13.0"
+
+    [deps.StyledStrings.syntax]
+    julia_version = "1.11.0"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+    [deps.TOML.syntax]
+    julia_version = "1.6.0"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 version = "1.11.0"
 
+    [deps.UUIDs.syntax]
+    julia_version = "1.14.0-DEV.1492"
+
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 version = "1.11.0"
+
+    [deps.Unicode.syntax]
+    julia_version = "1.14.0-DEV.1492"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 version = "1.3.1+2"
+
+    [deps.Zlib_jll.syntax]
+    julia_version = "1.6.0"
+
+[registries.General]
+url = "https://github.com/JuliaRegistries/General.git"
+uuid = "23338594-aafe-5451-b93e-139f81909106"


### PR DESCRIPTION
Currently the Revise we use for `make test-revise-*` (from deps/jlutilities) and the test_revise buildkite job are not the same (the latter always uses Revise master). This has two problems

1. It is impossible for us to test concurrent Revise changes in a PR; and
2. The `make test-revise-*` target may use an outdated Revise since we don't check the Manifest version against the current version of julia

https://github.com/JuliaCI/julia-buildkite/pull/518 fixes both of those by making the CI job use the Manifest from the source tree, but turns out that Manifest is actually currently broken (ref point 2 above), so bump that now, so that we can switch over CI after.