### PR TITLE
Tweak SyntaxList constructor to accept tree elements

### DIFF
--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -91,6 +91,8 @@ Lexical scope ID
 """
 const ScopeId = Int
 
+JuliaSyntax.SyntaxList(ctx::AbstractLoweringContext) = SyntaxList(syntax_graph(ctx))
+
 function JuliaSyntax.newleaf(ctx::AbstractLoweringContext,
                     prov::Union{SyntaxTree, SourceAttrType},
                     k::Kind)

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -340,7 +340,7 @@ function est_to_dst(st::SyntaxTree; all_expanded=true)
             ]
         end
         [K"flatten" _] -> let
-            out_iters = SyntaxList(st)
+            out_iters = SyntaxList(g)
             next = st
             while kind(next) === K"flatten"
                 push!(out_iters, _dst_iterspec(next, next[1][2:end]))
@@ -415,7 +415,7 @@ function est_to_dst(st::SyntaxTree; all_expanded=true)
             out_cs = mapsyntax(_dst_importpath, paths)
             if !isnothing(maybe_colon)
                 out_c1 = @ast g maybe_colon [K":" out_cs...]
-                out_cs = SyntaxList(g, tree_ids(out_c1))
+                out_cs = SyntaxList(out_c1)
             end
             mknode(st, out_cs)
         end

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -594,7 +594,7 @@ vst1_lam_lhs(vcx, st) = @stm st begin
     # syntax TODO: This is handled badly in the parser
     [K"block" p1 p2] -> pass()
     # unwrapped single arg
-    _ -> let ps = SyntaxList(st._graph, tree_ids(st))
+    _ -> let ps = SyntaxList(st)
         _calldecl_positionals(vcx, ps, K"=")
     end
 end

--- a/JuliaLowering/test/scopes.jl
+++ b/JuliaLowering/test/scopes.jl
@@ -98,6 +98,7 @@ end
     # worth replicating this behaviour.  We would likely need to copy the way
     # flisp nests an extra scope block in every lambda.
     @testset "arg,global" begin
+        local f
         s = "function (a); global a = 1; a; end"
         @test_broken f = JuliaLowering.include_string(test_mod, s)
         @test_broken f isa Function
@@ -105,6 +106,7 @@ end
         @test_broken isdefinedglobal(test_mod, :a)
     end
     @testset "sparam,global" begin
+        local f
         s = "function (a::s) where {s}; global s = 1; s; end"
         @test_broken f = JuliaLowering.include_string(test_mod, s)
         @test_broken f isa Function

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -410,7 +410,7 @@ function _flattened_provenance(refs, graph, sources, id)
 end
 
 function flattened_provenance(ex::SyntaxTree)
-    refs = SyntaxList(ex)
+    refs = SyntaxList(ex._graph)
     _flattened_provenance(refs, ex._graph, ex._graph.source, ex._id)
     return reverse(refs)
 end
@@ -468,7 +468,8 @@ function SyntaxList(graph::SyntaxGraph{T}, ids::AbstractVector{NodeId}) where {T
 end
 
 SyntaxList(graph::SyntaxGraph) = SyntaxList(graph, Vector{NodeId}())
-SyntaxList(ctx) = SyntaxList(syntax_graph(ctx))
+SyntaxList(st::SyntaxTree, rest::SyntaxTree...) =
+    SyntaxList(st._graph, tree_ids(st, rest...))
 
 tree_ids(sts::SyntaxTree...) = NodeId[st._id for st in sts]
 
@@ -669,7 +670,7 @@ function mapchildren(f::Function, ctx, ex::SyntaxTree, do_map_child::Function)
             if newchild == e
                 continue
             else
-                cs = SyntaxList(ctx)
+                cs = SyntaxList(syntax_graph(ctx))
                 append!(cs, orig_children[1:i-1])
             end
         end
@@ -1494,7 +1495,7 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
         g_out = _green_to_est(st, 1, popfirst!(cs))
         for c in Iterators.reverse(cs)
             gen_cs = let rest = kind(c) === K"iteration" ?
-                preprocessed_green_children(c) : SyntaxList(graph, tree_ids(c))
+                preprocessed_green_children(c) : SyntaxList(c)
                 rest = _map_green_to_est(st, rest; undef_parent=true)
                 pushfirst!(rest, g_out)
             end
@@ -1558,7 +1559,7 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
             return kind(out) in KSet"Identifier = ::" ? out :
                 mknode(st, tree_ids(out))
         elseif kind(parent) === K"struct" && parent_i === 3
-            cs_tmp = SyntaxList(cs)
+            cs_tmp = SyntaxList(graph)
             for c in cs
                 kind(c) === K"doc" ?
                     append!(cs_tmp, preprocessed_green_children(c)) :
@@ -1679,7 +1680,7 @@ end
 # Converting children-first (as _string_to_Expr does) would make this much
 # harder by converting literal strings without the parent's knowledge
 function _string_to_est(st::SyntaxTree, cs::SyntaxList; unwrap_literal)
-    ret_cs = SyntaxList(st)
+    ret_cs = SyntaxList(st._graph)
     literal_k = kind(st) === K"cmdstring" ? K"CmdString" : K"String"
     prev_str = cur_str = false
     next_str = length(cs) > 0 && kind(cs[1]) === literal_k

--- a/JuliaSyntax/test/syntax_graph.jl
+++ b/JuliaSyntax/test/syntax_graph.jl
@@ -1,4 +1,4 @@
-using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, freeze_attrs, unfreeze_attrs, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind
+using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, freeze_attrs, unfreeze_attrs, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind, syntax_graph
 
 @testset "SyntaxGraph attrs" begin
     st = parsestmt(SyntaxTree, "function foo end")
@@ -286,6 +286,35 @@ end
         st = JuliaSyntax.annotate_parent!(SyntaxTree(g, 1))
         @test chk_parent(st, nothing)
     end
+end
+
+@testset "SyntaxList" begin
+    st = parsestmt(SyntaxTree, "function foo end")
+    g = st._graph
+
+    # constructors
+    sl0 = SyntaxList(g)
+    @test sl0 isa SyntaxList
+    @test length(sl0) == 0
+    @test syntax_graph(sl0) == g
+
+    sl1_id = SyntaxList(g, st._id)
+    @test sl1_id isa SyntaxList
+    @test length(sl1_id) == 1
+    @test sl1_id[1] == st
+    @test syntax_graph(sl1_id) == g
+
+    sl1 = SyntaxList(st)
+    @test sl1 isa SyntaxList
+    @test length(sl1) == 1
+    @test sl1[1] == st
+    @test syntax_graph(sl1) == g
+
+    sl2 = SyntaxList(st, st)
+    @test sl2 isa SyntaxList
+    @test length(sl2) == 2
+    @test sl2[2] == st
+    @test syntax_graph(sl2) == g
 end
 
 @testset "@stm SyntaxTree pattern-matching" begin


### PR DESCRIPTION
It should be easy to create known-length lists of trees without repeated
`push!`ing, but it isn't, and desugaring is full of `x = SyntaxList(ctx);
push!(x, st1); push!(x, st2)`.  This change adds a `SyntaxList(::SyntaxTree...)`
method.  Previously, we had `SyntaxList(::SyntaxTree)` create an empty list in
that tree's graph (but that method was mostly unused).

This also matches other utilities where we'll often have one function taking
SyntaxGraph+NodeId(s) and one taking SyntaxTree(s).

We could also consider using `Vector{SyntaxTree}` instead (I'm not sure how much
performance benefit there is to `SyntaxList` in the first place), though that
would require some refactoring of all the existing stuff that takes SyntaxList.