### PR TITLE
prefer returning the loaded version from `pkgversion`

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -658,13 +658,15 @@ the form `pkgversion(@__MODULE__)` can be used.
     This function was introduced in Julia 1.9.
 """
 function pkgversion(m::Module)
-    path = pkgdir(m)
-    path === nothing && return nothing
     @lock require_lock begin
-        v = get_pkgversion_from_path(path)
         pkgorigin = get(pkgorigins, PkgId(moduleroot(m)), nothing)
-        # Cache the version
-        if pkgorigin !== nothing && pkgorigin.version === nothing
+        if pkgorigin !== nothing && pkgorigin.version !== nothing
+            return pkgorigin.version
+        end
+        path = pkgdir(m)
+        path === nothing && return nothing
+        v = get_pkgversion_from_path(path)
+        if pkgorigin !== nothing
             pkgorigin.version = v
         end
         return v

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -677,34 +677,6 @@ finally
 end
 @test pkgversion(TestPkg) == v"1.2.3"
 
-# pkgversion should return cached version even after source is deleted
-@testset "pkgversion after source deletion" begin
-    mktempdir() do tmp
-        pkg_dir = joinpath(tmp, "DeletedPkg")
-        src_dir = joinpath(pkg_dir, "src")
-        mkpath(src_dir)
-        write(joinpath(pkg_dir, "Project.toml"), """
-            name = "DeletedPkg"
-            uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-            version = "4.5.6"
-            """)
-        write(joinpath(src_dir, "DeletedPkg.jl"), "module DeletedPkg end")
-        old_act_proj = Base.ACTIVE_PROJECT[]
-        pushfirst!(LOAD_PATH, "@")
-        try
-            Base.set_active_project(pkg_dir)
-            @eval using DeletedPkg
-            m = @__MODULE__
-            @test pkgversion(@invokelatest(m.DeletedPkg)) == v"4.5.6"
-            rm(pkg_dir; recursive=true)
-            @test pkgversion(@invokelatest(m.DeletedPkg)) == v"4.5.6"
-        finally
-            Base.set_active_project(old_act_proj)
-            popfirst!(LOAD_PATH)
-        end
-    end
-end
-
 @testset "--project and JULIA_PROJECT paths should be absolutified" begin
     mktempdir() do dir; cd(dir) do
         mkdir("foo")
@@ -904,6 +876,34 @@ append!(empty!(DEPOT_PATH), saved_depot_path)
 pop!(Base.active_project_callbacks)
 Base.set_active_project(saved_active_project)
 @test watcher_counter[] == 3
+
+# pkgversion should return cached version even after source is deleted
+@testset "pkgversion after source deletion" begin
+    mktempdir() do tmp
+        pkg_dir = joinpath(tmp, "DeletedPkg")
+        src_dir = joinpath(pkg_dir, "src")
+        mkpath(src_dir)
+        write(joinpath(pkg_dir, "Project.toml"), """
+            name = "DeletedPkg"
+            uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            version = "4.5.6"
+            """)
+        write(joinpath(src_dir, "DeletedPkg.jl"), "module DeletedPkg end")
+        old_act_proj = Base.ACTIVE_PROJECT[]
+        pushfirst!(LOAD_PATH, "@")
+        try
+            Base.set_active_project(pkg_dir)
+            @eval using DeletedPkg
+            m = @__MODULE__
+            @test pkgversion(@invokelatest(m.DeletedPkg)) == v"4.5.6"
+            rm(pkg_dir; recursive=true)
+            @test pkgversion(@invokelatest(m.DeletedPkg)) == v"4.5.6"
+        finally
+            Base.set_active_project(old_act_proj)
+            popfirst!(LOAD_PATH)
+        end
+    end
+end
 
 # issue #28190
 module Foo28190; import Libdl; end


### PR DESCRIPTION
If we have already loaded the package we should return the loaded version (not what would be returned if we had not loaded the package and would load it now). As a side effect, this should allow `pkgversion` to work for packages that have been included in a custom sysimage.