### PR TITLE
Serialization stdlib: Replace a call to `Core.memoryref` with `Core.memoryrefnew`

### DIFF
--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1445,7 +1445,7 @@ end
 function deserialize(s::AbstractSerializer, X::Type{MemoryRef{T}} where T)
     x = Core.memoryref(deserialize(s))::X
     i = deserialize(s)::Int
-    i == 2 || (x = Core.memoryref(x, i, true))
+    i == 2 || (x = Core.memoryrefnew(x, i, true))
     return x::X
 end
 

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -687,3 +687,34 @@ if Int === Int64
         @test @invokelatest(Main.f111_to_112(16)) == 256
     end
 end
+
+@testset "MemoryRef" begin
+    old_m = Memory{Int}(undef, 10)
+    for i in 1:10
+        old_m[i] = i^2
+    end
+    old_x = memoryref(old_m, 5)
+    @test old_x[] == 25
+    old_d = Dict(:x => old_x)
+
+    old_str = sprint(serialize, old_d)
+    new_d = deserialize(IOBuffer(old_str))
+
+    @test new_d[:x] isa MemoryRef
+    @test new_d[:x][] == 25
+end
+
+@testset "Memory" begin
+    old_m = Memory{Int}(undef, 10)
+    for i in 1:10
+        old_m[i] = i^3
+    end
+    @test old_m[5] == 125
+    old_d = Dict(:m => old_m)
+
+    old_str = sprint(serialize, old_d)
+    new_d = deserialize(IOBuffer(old_str))
+
+    @test new_d[:m] isa Memory
+    @test new_d[:m][5] == 125
+end


### PR DESCRIPTION
The Serialization stdlib has the following function:

https://github.com/JuliaLang/julia/blob/e46125f569f43e28261d1b55a0d85aacceee499a/stdlib/Serialization/src/Serialization.jl#L1445-L1450

As far as I can tell, there is no method matching `Core.memoryref(x::MemoryRef, i::Int, true::Bool)` (called on line 1448).[^1]

[^1]: This issue was detected by JET.

I think this should be a call to `Core.memoryrefnew(x::MemoryRef, i::Int, true::Bool)` instead, which is what this PR does.