### PR TITLE
SharedArrays: Skip a `finally` step if we throw before the `shmmem_create_pid` local is defined

### DIFF
--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -154,7 +154,9 @@ function SharedArray{T,N}(dims::Dims{N}; init=false, pids=Int[]) where {T,N}
 
     finally
         if !isempty(shm_seg_name)
-            remotecall_fetch(shm_unlink, shmmem_create_pid, shm_seg_name)
+            if @isdefined shmmem_create_pid
+                remotecall_fetch(shm_unlink, shmmem_create_pid, shm_seg_name)
+            end
         end
     end
     S

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -153,10 +153,8 @@ function SharedArray{T,N}(dims::Dims{N}; init=false, pids=Int[]) where {T,N}
         shm_seg_name = ""
 
     finally
-        if !isempty(shm_seg_name)
-            if @isdefined shmmem_create_pid
-                remotecall_fetch(shm_unlink, shmmem_create_pid, shm_seg_name)
-            end
+        if !isempty(shm_seg_name) && @isdefined shmmem_create_pid
+            remotecall_fetch(shm_unlink, shmmem_create_pid, shm_seg_name)
         end
     end
     S


### PR DESCRIPTION
In theory, if we throw on line 116 (e.g. if `getpid()` or `randstring()` throws), then we'll enter the `finally` block before we ever define `shmmem_create_pid`. I think this case is unlikely, but if we do hit it, we can't perform the `remotecall_fetch` call in the `finally` block, because `shmmem_create_pid` won't be defined.

So this PR checks if `shmmem_create_pid` is defined before doing the `remotecall_fetch` call.

Alternatively, we could lift lines 116 and 117 out of the `try` block, at which point it will no longer be possible (as far as I can tell) for us to throw before defining `shmmem_create_pid`.

---

Detected by JET.