### PR TITLE
REPL: Fix call to correct `hascolor` function

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -710,7 +710,7 @@ mutable struct BasicREPL <: AbstractREPL
 end
 
 outstream(r::BasicREPL) = r.terminal
-hascolor(r::BasicREPL) = hascolor(r.terminal)
+hascolor(r::BasicREPL) = Terminals.hascolor(r.terminal)
 
 function run_frontend(repl::BasicREPL, backend::REPLBackendRef)
     repl.frontend_task = current_task()

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -2093,3 +2093,9 @@ end
         @test found_114
     end
 end
+
+@testset "REPL.hascolor(::BasicREPL)" begin
+    term = REPL.Terminals.TTYTerminal("dumb",IOBuffer("1+2\n"),IOContext(IOBuffer(),:foo=>true),IOBuffer())
+    r = REPL.BasicREPL(term)
+    @test !REPL.hascolor(r)
+end


### PR DESCRIPTION
`REPL.hascolor` and `Base.Terminals.hascolor` are two different generic functions. The method for `::TextTerminal` is a method of the latter.

Detected by JET.