### PR TITLE
REPL: Convert char to string before calling `escape_string`

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1833,7 +1833,7 @@ function add_nested_key!(keymap::Dict{Char, Any}, key::Union{String, Char}, valu
         c, i = y
         y = iterate(key, i)
         if !override && c in keys(keymap) && (y === nothing || !isa(keymap[c], Dict))
-            error("Conflicting definitions for keyseq " * escape_string(key) *
+            error("Conflicting definitions for keyseq " * escape_string(string(key)) *
                   " within one keymap")
         end
         if y === nothing

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -1166,3 +1166,22 @@ end
     @test content(s) == "\"()\""
     @test position(buffer(s)) == 2
 end
+
+@testset "Conflicting definitions for keyseq" begin
+    @testset "string" begin
+        keymap = Dict{Char, Any}()
+        REPL.LineEdit.add_nested_key!(keymap, "a", "abc")
+        @test keymap == Dict('a' => "abc")
+        expected_msg = "Conflicting definitions for keyseq a within one keymap"
+        @test_throws ErrorException(expected_msg) REPL.LineEdit.add_nested_key!(keymap, "a", "abdef")
+        @test keymap == Dict('a' => "abc")
+    end
+    @testset "char" begin
+        keymap = Dict{Char, Any}()
+        REPL.LineEdit.add_nested_key!(keymap, 'a', "abc")
+        @test keymap == Dict('a' => "abc")
+        expected_msg = "Conflicting definitions for keyseq a within one keymap"
+        @test_throws ErrorException(expected_msg) REPL.LineEdit.add_nested_key!(keymap, 'a', "abdef")
+        @test keymap == Dict('a' => "abc")
+    end
+end


### PR DESCRIPTION
In this function, `key` is allowed to be either `String` or `Char`, but there is no method matching `escape_string(::Char)`. So convert `key` to a string before calling `escape_string`.

MWE:

```
import REPL

keymap = Dict{Char, Any}()
REPL.LineEdit.add_nested_key!(keymap, 'a', "foo")
REPL.LineEdit.add_nested_key!(keymap, 'a', "bar")
```

Which throws this error:

```
julia> REPL.LineEdit.add_nested_key!(keymap, 'a', "bar")
ERROR: MethodError: no method matching escape_string(::Char)
The function `escape_string` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  escape_string(::IO, ::Union{Base.AnnotatedString, SubString{<:Base.AnnotatedString}}, ::Any; keep, ascii, fullhex)
   @ Base strings/annotated_io.jl:266
  escape_string(::IO, ::Union{Base.AnnotatedString, SubString{<:Base.AnnotatedString}}; ...)
   @ Base strings/annotated_io.jl:266
  escape_string(::AbstractString, ::Any; keep, ascii, fullhex)
   @ Base strings/io.jl:467
  ...

Stacktrace:
 [1] add_nested_key!(keymap::Dict{Char, Any}, key::Union{Char, String}, value::Any; override::Bool)
   @ REPL.LineEdit ~/juliaup.depot/juliaup/julia-1.12.5+0.aarch64.apple.darwin14/Julia-1.12.app/Contents/Resources/julia/share/julia/stdlib/v1.12/REPL/src/LineEdit.jl:1785
 [2] add_nested_key!(keymap::Dict{Char, Any}, key::Union{Char, String}, value::Any)
   @ REPL.LineEdit ~/juliaup.depot/juliaup/julia-1.12.5+0.aarch64.apple.darwin14/Julia-1.12.app/Contents/Resources/julia/share/julia/stdlib/v1.12/REPL/src/LineEdit.jl:1779
 [3] top-level scope
   @ REPL[3]:1
```

But we want it to throw this instead:

```
ERROR: Conflicting definitions for keyseq a within one keymap
```

---

Detected by JET.