### PR TITLE
[JuliaLowering] Pass "method expr name" into kw-function desugaring

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2372,7 +2372,7 @@ function method_def_expr(ctx, srcref, callex_srcref, method_table,
             ::K"SourceLocation"(callex_srcref)
         ]
         [K"method"
-            isnothing(method_table) ? "nothing"::K"core" : method_table
+            method_table
             method_metadata
             [K"lambda"(body, is_toplevel_thunk=false, toplevel_pure=false)
                 [K"block" arg_names...]
@@ -2483,7 +2483,7 @@ function expand_function_generator(ctx, srcref, callex_srcref, func_name,
         [K"method_defs"
             gen_name
             [K"block"
-                method_def_expr(ctx, srcref, callex_srcref, nothing, SyntaxList(ctx),
+                method_def_expr(ctx, srcref, callex_srcref, "nothing"::K"core", SyntaxList(ctx),
                                 gen_arg_names, gen_arg_types, gen_body, nothing)
             ]
         ]
@@ -2595,10 +2595,10 @@ function scope_nest(ctx, names, values, body)
 end
 
 # Generate body function and `Core.kwcall` overloads for functions taking keywords.
-function keyword_function_defs(ctx, srcref, callex_srcref, name_str, typevar_names,
-                               typevar_stmts, new_typevar_stmts, arg_names,
-                               arg_types, has_slurp, first_default, arg_defaults,
-                               keywords, body, ret_var)
+function keyword_function_defs(ctx, srcref, callex_srcref, orig_name, name_str,
+                               typevar_names, typevar_stmts, new_typevar_stmts,
+                               arg_names, arg_types, has_slurp, first_default,
+                               arg_defaults, keywords, body, ret_var)
     mangled_name = let n = isnothing(name_str) ? "_" : name_str
         reserve_module_binding_i(ctx.mod, string(startswith(n, '#') ? "" : "#", n, "#"))
     end
@@ -2623,7 +2623,7 @@ function keyword_function_defs(ctx, srcref, callex_srcref, name_str, typevar_nam
 
     body_arg_names = SyntaxList(ctx)
     body_arg_types = SyntaxList(ctx)
-    push!(body_arg_names, newsym(ctx, keywords, "#self#"))
+    push!(body_arg_names, body_func_name)
     push!(body_arg_types, @ast ctx body_func_name [K"function_type" body_func_name])
 
     non_positional_typevars = typevar_names[map(!,
@@ -2849,11 +2849,14 @@ function keyword_function_defs(ctx, srcref, callex_srcref, name_str, typevar_nam
                                 ret_var)
             ]
         ]
+        if is_identifier_like(orig_name)
+            [K"function_decl" orig_name]
+        end
         [K"method_defs"
-            # This should inherit the local / global status of the body func, so
-            # provide that here for closure conversion, even though this is
-            # really a method on Core.kwcall
-            body_func_name
+            # This should inherit the local / global status of the original
+            # func, so provide that here for closure conversion, even though
+            # this is really a method on Core.kwcall
+            is_identifier_like(orig_name) ? orig_name : "nothing"::K"core"
             [K"block"
                 new_typevar_stmts...
                 kwcall_method_defs...
@@ -3115,7 +3118,7 @@ function expand_function_def(ctx, ex, docs, rewrite_call=identity, rewrite_body=
     else
         # Rewrite `body` here so that the positional-only versions dispatch there.
         kw_func_method_defs, body =
-            keyword_function_defs(ctx, ex, callex, name_str, typevar_names, typevar_stmts,
+            keyword_function_defs(ctx, ex, callex, name, name_str, typevar_names, typevar_stmts,
                                   new_typevar_stmts, arg_names, arg_types, has_slurp,
                                   first_default, arg_defaults, keywords, body, ret_var)
         # The main function (but without keywords) needs its typevars trimmed,
@@ -3156,8 +3159,6 @@ function expand_function_def(ctx, ex, docs, rewrite_call=identity, rewrite_body=
 
     @ast ctx ex [K"block"
         if !isnothing(bare_func_name)
-            # Need the main function type created here before running any code
-            # in kw_func_method_defs
             [K"function_decl"(bare_func_name) bare_func_name]
         end
         gen_func_method_defs

--- a/JuliaLowering/test/closures_ir.jl
+++ b/JuliaLowering/test/closures_ir.jl
@@ -655,39 +655,38 @@ end
 9   slot₂/#f_kw_closure#0
 10  (new %₈ %₉)
 11  (= slot₃/f_kw_closure %₁₀)
-12  (call core.svec :#f_kw_closure#0 :y)
-13  (call core.svec true false)
+12  (call core.svec :y)
+13  (call core.svec false)
 14  (call JuliaLowering.eval_closure_type TestMod :##f_kw_closure#0##0 %₁₂ %₁₃)
 15  latestworld
 16  TestMod.##f_kw_closure#0##0
 17  (call core.typeof slot₁/y)
 18  (call core.apply_type %₁₆ %₁₇)
-19  slot₂/#f_kw_closure#0
-20  (new %₁₈ %₁₉ slot₁/y)
-21  slot₂/#f_kw_closure#0
-22  (call core.setfield! %₂₁ :contents %₂₀)
-23  TestMod.##f_kw_closure#0##0
-24  TestMod.X
-25  TestMod.#f_kw_closure##0
-26  (call core.svec %₂₃ %₂₄ %₂₅)
-27  (call core.svec)
-28  SourceLocation::2:14
-29  (call core.svec %₂₆ %₂₇ %₂₈)
-30  --- method core.nothing %₂₉
-    slots: [slot₁/#self#(!read) slot₂/x slot₃/#self#(!read)]
+19  (new %₁₈ slot₁/y)
+20  slot₂/#f_kw_closure#0
+21  (call core.setfield! %₂₀ :contents %₁₉)
+22  TestMod.##f_kw_closure#0##0
+23  TestMod.X
+24  TestMod.#f_kw_closure##0
+25  (call core.svec %₂₂ %₂₃ %₂₄)
+26  (call core.svec)
+27  SourceLocation::2:14
+28  (call core.svec %₂₅ %₂₆ %₂₇)
+29  --- method core.nothing %₂₈
+    slots: [slot₁/#f_kw_closure#0(!read) slot₂/x slot₃/#self#(!read)]
     1   (meta :nkw 1)
     2   TestMod.+
-    3   (call core.getfield slot₁/#self# :y)
+    3   (call core.getfield slot₁/#f_kw_closure#0 :y)
     4   (call %₂ slot₂/x %₃)
     5   (return %₄)
-31  latestworld
-32  (call core.typeof core.kwcall)
-33  TestMod.#f_kw_closure##0
-34  (call core.svec %₃₂ core.NamedTuple %₃₃)
-35  (call core.svec)
-36  SourceLocation::2:14
-37  (call core.svec %₃₄ %₃₅ %₃₆)
-38  --- method core.nothing %₃₇
+30  latestworld
+31  (call core.typeof core.kwcall)
+32  TestMod.#f_kw_closure##0
+33  (call core.svec %₃₁ core.NamedTuple %₃₂)
+34  (call core.svec)
+35  SourceLocation::2:14
+36  (call core.svec %₃₃ %₃₄ %₃₅)
+37  --- method core.nothing %₃₆
     slots: [slot₁/#kwcall_self#(!read) slot₂/kws slot₃/#self# slot₄/kwtmp slot₅/x(!read) slot₆/#f_kw_closure#0(!read,maybe_undef)]
     1   (newvar slot₅/x)
     2   (call core.isdefined slot₂/kws :x)
@@ -721,13 +720,13 @@ end
     30  (call core.getfield %₂₄ :contents)
     31  (call %₃₀ %₁₆ slot₃/#self#)
     32  (return %₃₁)
-39  latestworld
-40  TestMod.#f_kw_closure##0
-41  (call core.svec %₄₀)
-42  (call core.svec)
-43  SourceLocation::2:14
-44  (call core.svec %₄₁ %₄₂ %₄₃)
-45  --- method core.nothing %₄₄
+38  latestworld
+39  TestMod.#f_kw_closure##0
+40  (call core.svec %₃₉)
+41  (call core.svec)
+42  SourceLocation::2:14
+43  (call core.svec %₄₀ %₄₁ %₄₂)
+44  --- method core.nothing %₄₃
     slots: [slot₁/#self# slot₂/#f_kw_closure#0(!read,maybe_undef)]
     1   (call core.getfield slot₁/#self# :#f_kw_closure#0)
     2   (call core.isdefined %₁ :contents)
@@ -739,9 +738,9 @@ end
     8   TestMod.x_default
     9   (call %₇ %₈ slot₁/#self#)
     10  (return %₉)
-46  latestworld
-47  slot₃/f_kw_closure
-48  (return %₄₇)
+45  latestworld
+46  slot₃/f_kw_closure
+47  (return %₄₆)
 
 ########################################
 # Closure capturing a typed local must also capture the type expression

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -628,6 +628,16 @@ end
     @test f() isa Function
     @test f()() == (0, 1, 1)
     @test f(x=2)(y=3) == (0, 2, 3)
+
+    f = JuliaLowering.include_string(test_mod, """
+    function f_kw_anon(outervar)
+        (a,;kw=1)->a+kw+outervar
+    end
+    """)
+
+    @test f(100) isa Function
+    @test f(100)(2) == 103
+    @test f(100)(2;kw=2) == 104
 end
 
 @testset "pre-desugared arg::Vararg" begin

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -1265,46 +1265,48 @@ end
 15  SourceLocation::1:10
 16  (call core.svec %₁₃ %₁₄ %₁₅)
 17  --- method core.nothing %₁₆
-    slots: [slot₁/#self#(!read) slot₂/x slot₃/y slot₄/#self#(!read) slot₅/a slot₆/b]
+    slots: [slot₁/#f_kw_simple#0(!read) slot₂/x slot₃/y slot₄/#self#(!read) slot₅/a slot₆/b]
     1   (meta :nkw 2)
     2   (call core.tuple slot₅/a slot₆/b slot₂/x slot₃/y)
     3   (return %₂)
 18  latestworld
-19  (call core.typeof core.kwcall)
-20  TestMod.f_kw_simple
-21  (call core.Typeof %₂₀)
-22  (call core.svec %₁₉ core.NamedTuple %₂₁)
-23  (call core.svec)
-24  SourceLocation::1:10
-25  (call core.svec %₂₂ %₂₃ %₂₄)
-26  --- method core.nothing %₂₅
+19  (method TestMod.f_kw_simple)
+20  latestworld
+21  (call core.typeof core.kwcall)
+22  TestMod.f_kw_simple
+23  (call core.Typeof %₂₂)
+24  (call core.svec %₂₁ core.NamedTuple %₂₃)
+25  (call core.svec)
+26  SourceLocation::1:10
+27  (call core.svec %₂₄ %₂₅ %₂₆)
+28  --- method core.nothing %₂₇
     slots: [slot₁/#kwcall_self#(called) slot₂/kws slot₃/#self#]
     1   (call slot₁/#kwcall_self# slot₂/kws slot₃/#self# 1 1.0)
     2   (return %₁)
-27  latestworld
-28  (call core.typeof core.kwcall)
-29  TestMod.f_kw_simple
-30  (call core.Typeof %₂₉)
-31  TestMod.Int
-32  (call core.svec %₂₈ core.NamedTuple %₃₀ %₃₁)
-33  (call core.svec)
-34  SourceLocation::1:10
-35  (call core.svec %₃₂ %₃₃ %₃₄)
-36  --- method core.nothing %₃₅
+29  latestworld
+30  (call core.typeof core.kwcall)
+31  TestMod.f_kw_simple
+32  (call core.Typeof %₃₁)
+33  TestMod.Int
+34  (call core.svec %₃₀ core.NamedTuple %₃₂ %₃₃)
+35  (call core.svec)
+36  SourceLocation::1:10
+37  (call core.svec %₃₄ %₃₅ %₃₆)
+38  --- method core.nothing %₃₇
     slots: [slot₁/#kwcall_self#(called) slot₂/kws slot₃/#self# slot₄/a]
     1   (call slot₁/#kwcall_self# slot₂/kws slot₃/#self# slot₄/a 1.0)
     2   (return %₁)
-37  latestworld
-38  (call core.typeof core.kwcall)
-39  TestMod.f_kw_simple
-40  (call core.Typeof %₃₉)
-41  TestMod.Int
-42  TestMod.Float64
-43  (call core.svec %₃₈ core.NamedTuple %₄₀ %₄₁ %₄₂)
-44  (call core.svec)
-45  SourceLocation::1:10
-46  (call core.svec %₄₃ %₄₄ %₄₅)
-47  --- method core.nothing %₄₆
+39  latestworld
+40  (call core.typeof core.kwcall)
+41  TestMod.f_kw_simple
+42  (call core.Typeof %₄₁)
+43  TestMod.Int
+44  TestMod.Float64
+45  (call core.svec %₄₀ core.NamedTuple %₄₂ %₄₃ %₄₄)
+46  (call core.svec)
+47  SourceLocation::1:10
+48  (call core.svec %₄₅ %₄₆ %₄₇)
+49  --- method core.nothing %₄₈
     slots: [slot₁/#kwcall_self#(!read) slot₂/kws slot₃/#self# slot₄/a slot₅/b slot₆/kwtmp slot₇/x(!read) slot₈/y(!read)]
     1   (newvar slot₇/x)
     2   (newvar slot₈/y)
@@ -1346,46 +1348,46 @@ end
     38  TestMod.#f_kw_simple#0
     39  (call %₃₈ %₁₆ %₃₀ slot₃/#self# slot₄/a slot₅/b)
     40  (return %₃₉)
-48  latestworld
-49  TestMod.f_kw_simple
-50  (call core.Typeof %₄₉)
-51  (call core.svec %₅₀)
-52  (call core.svec)
-53  SourceLocation::1:10
-54  (call core.svec %₅₁ %₅₂ %₅₃)
-55  --- method core.nothing %₅₄
+50  latestworld
+51  TestMod.f_kw_simple
+52  (call core.Typeof %₅₁)
+53  (call core.svec %₅₂)
+54  (call core.svec)
+55  SourceLocation::1:10
+56  (call core.svec %₅₃ %₅₄ %₅₅)
+57  --- method core.nothing %₅₆
     slots: [slot₁/#self#(called)]
     1   (call slot₁/#self# 1 1.0)
     2   (return %₁)
-56  latestworld
-57  TestMod.f_kw_simple
-58  (call core.Typeof %₅₇)
-59  TestMod.Int
-60  (call core.svec %₅₈ %₅₉)
-61  (call core.svec)
-62  SourceLocation::1:10
-63  (call core.svec %₆₀ %₆₁ %₆₂)
-64  --- method core.nothing %₆₃
+58  latestworld
+59  TestMod.f_kw_simple
+60  (call core.Typeof %₅₉)
+61  TestMod.Int
+62  (call core.svec %₆₀ %₆₁)
+63  (call core.svec)
+64  SourceLocation::1:10
+65  (call core.svec %₆₂ %₆₃ %₆₄)
+66  --- method core.nothing %₆₅
     slots: [slot₁/#self#(called) slot₂/a]
     1   (call slot₁/#self# slot₂/a 1.0)
     2   (return %₁)
-65  latestworld
-66  TestMod.f_kw_simple
-67  (call core.Typeof %₆₆)
-68  TestMod.Int
-69  TestMod.Float64
-70  (call core.svec %₆₇ %₆₈ %₆₉)
-71  (call core.svec)
-72  SourceLocation::1:10
-73  (call core.svec %₇₀ %₇₁ %₇₂)
-74  --- method core.nothing %₇₃
+67  latestworld
+68  TestMod.f_kw_simple
+69  (call core.Typeof %₆₈)
+70  TestMod.Int
+71  TestMod.Float64
+72  (call core.svec %₆₉ %₇₀ %₇₁)
+73  (call core.svec)
+74  SourceLocation::1:10
+75  (call core.svec %₇₂ %₇₃ %₇₄)
+76  --- method core.nothing %₇₅
     slots: [slot₁/#self# slot₂/a slot₃/b]
     1   TestMod.#f_kw_simple#0
     2   (call %₁ 'a' true slot₁/#self# slot₂/a slot₃/b)
     3   (return %₂)
-75  latestworld
-76  TestMod.f_kw_simple
-77  (return %₇₆)
+77  latestworld
+78  TestMod.f_kw_simple
+79  (return %₇₈)
 
 ########################################
 # Error: Duplicate keyword placeholder name
@@ -1415,42 +1417,44 @@ end
 12  SourceLocation::1:10
 13  (call core.svec %₁₀ %₁₁ %₁₂)
 14  --- method core.nothing %₁₃
-    slots: [slot₁/#self#(!read) slot₂/all_kws slot₃/#self#(!read)]
+    slots: [slot₁/#f_kw_slurp_simple#0(!read) slot₂/all_kws slot₃/#self#(!read)]
     1   (meta :nkw 1)
     2   slot₂/all_kws
     3   (return %₂)
 15  latestworld
-16  (call core.typeof core.kwcall)
-17  TestMod.f_kw_slurp_simple
-18  (call core.Typeof %₁₇)
-19  (call core.svec %₁₆ core.NamedTuple %₁₈)
-20  (call core.svec)
-21  SourceLocation::1:10
-22  (call core.svec %₁₉ %₂₀ %₂₁)
-23  --- method core.nothing %₂₂
+16  (method TestMod.f_kw_slurp_simple)
+17  latestworld
+18  (call core.typeof core.kwcall)
+19  TestMod.f_kw_slurp_simple
+20  (call core.Typeof %₁₉)
+21  (call core.svec %₁₈ core.NamedTuple %₂₀)
+22  (call core.svec)
+23  SourceLocation::1:10
+24  (call core.svec %₂₁ %₂₂ %₂₃)
+25  --- method core.nothing %₂₄
     slots: [slot₁/#kwcall_self#(!read) slot₂/kws slot₃/#self# slot₄/all_kws(!read)]
     1   (newvar slot₄/all_kws)
     2   (call top.pairs slot₂/kws)
     3   TestMod.#f_kw_slurp_simple#0
     4   (call %₃ %₂ slot₃/#self#)
     5   (return %₄)
-24  latestworld
-25  TestMod.f_kw_slurp_simple
-26  (call core.Typeof %₂₅)
-27  (call core.svec %₂₆)
-28  (call core.svec)
-29  SourceLocation::1:10
-30  (call core.svec %₂₇ %₂₈ %₂₉)
-31  --- method core.nothing %₃₀
+26  latestworld
+27  TestMod.f_kw_slurp_simple
+28  (call core.Typeof %₂₇)
+29  (call core.svec %₂₈)
+30  (call core.svec)
+31  SourceLocation::1:10
+32  (call core.svec %₂₉ %₃₀ %₃₁)
+33  --- method core.nothing %₃₂
     slots: [slot₁/#self#]
     1   TestMod.#f_kw_slurp_simple#0
     2   (call core.NamedTuple)
     3   (call top.pairs %₂)
     4   (call %₁ %₃ slot₁/#self#)
     5   (return %₄)
-32  latestworld
-33  TestMod.f_kw_slurp_simple
-34  (return %₃₃)
+34  latestworld
+35  TestMod.f_kw_slurp_simple
+36  (return %₃₅)
 
 ########################################
 # Keyword slurping
@@ -1472,19 +1476,21 @@ end
 12  SourceLocation::1:10
 13  (call core.svec %₁₀ %₁₁ %₁₂)
 14  --- method core.nothing %₁₃
-    slots: [slot₁/#self#(!read) slot₂/x(!read) slot₃/non_x_kws(!read) slot₄/#self#(!read)]
+    slots: [slot₁/#f_kw_slurp#0(!read) slot₂/x(!read) slot₃/non_x_kws(!read) slot₄/#self#(!read)]
     1   (meta :nkw 2)
     2   TestMod.all_kws
     3   (return %₂)
 15  latestworld
-16  (call core.typeof core.kwcall)
-17  TestMod.f_kw_slurp
-18  (call core.Typeof %₁₇)
-19  (call core.svec %₁₆ core.NamedTuple %₁₈)
-20  (call core.svec)
-21  SourceLocation::1:10
-22  (call core.svec %₁₉ %₂₀ %₂₁)
-23  --- method core.nothing %₂₂
+16  (method TestMod.f_kw_slurp)
+17  latestworld
+18  (call core.typeof core.kwcall)
+19  TestMod.f_kw_slurp
+20  (call core.Typeof %₁₉)
+21  (call core.svec %₁₈ core.NamedTuple %₂₀)
+22  (call core.svec)
+23  SourceLocation::1:10
+24  (call core.svec %₂₁ %₂₂ %₂₃)
+25  --- method core.nothing %₂₄
     slots: [slot₁/#kwcall_self#(!read) slot₂/kws slot₃/#self# slot₄/kwtmp slot₅/x(!read) slot₆/non_x_kws(!read)]
     1   (newvar slot₅/x)
     2   (newvar slot₆/non_x_kws)
@@ -1503,14 +1509,14 @@ end
     15  TestMod.#f_kw_slurp#0
     16  (call %₁₅ %₁₀ %₁₄ slot₃/#self#)
     17  (return %₁₆)
-24  latestworld
-25  TestMod.f_kw_slurp
-26  (call core.Typeof %₂₅)
-27  (call core.svec %₂₆)
-28  (call core.svec)
-29  SourceLocation::1:10
-30  (call core.svec %₂₇ %₂₈ %₂₉)
-31  --- method core.nothing %₃₀
+26  latestworld
+27  TestMod.f_kw_slurp
+28  (call core.Typeof %₂₇)
+29  (call core.svec %₂₈)
+30  (call core.svec)
+31  SourceLocation::1:10
+32  (call core.svec %₂₉ %₃₀ %₃₁)
+33  --- method core.nothing %₃₂
     slots: [slot₁/#self#]
     1   TestMod.#f_kw_slurp#0
     2   TestMod.x_default
@@ -1518,9 +1524,9 @@ end
     4   (call top.pairs %₃)
     5   (call %₁ %₂ %₄ slot₁/#self#)
     6   (return %₅)
-32  latestworld
-33  TestMod.f_kw_slurp
-34  (return %₃₃)
+34  latestworld
+35  TestMod.f_kw_slurp
+36  (return %₃₅)
 
 ########################################
 # Keyword slurping with defaults depending on keyword names
@@ -1545,19 +1551,21 @@ end
 12  SourceLocation::1:10
 13  (call core.svec %₁₀ %₁₁ %₁₂)
 14  --- method core.nothing %₁₃
-    slots: [slot₁/#self#(!read) slot₂/a slot₃/b slot₄/kws slot₅/#self#(!read)]
+    slots: [slot₁/#f_kw_slurp_dep#0(!read) slot₂/a slot₃/b slot₄/kws slot₅/#self#(!read)]
     1   (meta :nkw 3)
     2   (call core.tuple slot₂/a slot₃/b slot₄/kws)
     3   (return %₂)
 15  latestworld
-16  (call core.typeof core.kwcall)
-17  TestMod.f_kw_slurp_dep
-18  (call core.Typeof %₁₇)
-19  (call core.svec %₁₆ core.NamedTuple %₁₈)
-20  (call core.svec)
-21  SourceLocation::1:10
-22  (call core.svec %₁₉ %₂₀ %₂₁)
-23  --- method core.nothing %₂₂
+16  (method TestMod.f_kw_slurp_dep)
+17  latestworld
+18  (call core.typeof core.kwcall)
+19  TestMod.f_kw_slurp_dep
+20  (call core.Typeof %₁₉)
+21  (call core.svec %₁₈ core.NamedTuple %₂₀)
+22  (call core.svec)
+23  SourceLocation::1:10
+24  (call core.svec %₂₁ %₂₂ %₂₃)
+25  --- method core.nothing %₂₄
     slots: [slot₁/#kwcall_self#(!read) slot₂/kws slot₃/#self# slot₄/kwtmp slot₅/a(single_assign) slot₆/b(single_assign)]
     1   (call core.isdefined slot₂/kws :a)
     2   (gotoifnot %₁ label₆)
@@ -1583,14 +1591,14 @@ end
     22  TestMod.#f_kw_slurp_dep#0
     23  (call %₂₂ slot₅/a slot₆/b %₂₁ slot₃/#self#)
     24  (return %₂₃)
-24  latestworld
-25  TestMod.f_kw_slurp_dep
-26  (call core.Typeof %₂₅)
-27  (call core.svec %₂₆)
-28  (call core.svec)
-29  SourceLocation::1:10
-30  (call core.svec %₂₇ %₂₈ %₂₉)
-31  --- method core.nothing %₃₀
+26  latestworld
+27  TestMod.f_kw_slurp_dep
+28  (call core.Typeof %₂₇)
+29  (call core.svec %₂₈)
+30  (call core.svec)
+31  SourceLocation::1:10
+32  (call core.svec %₂₉ %₃₀ %₃₁)
+33  --- method core.nothing %₃₂
     slots: [slot₁/#self# slot₂/a(single_assign) slot₃/b(single_assign) slot₄/kws(single_assign)]
     1   1
     2   (= slot₂/a %₁)
@@ -1602,9 +1610,9 @@ end
     8   TestMod.#f_kw_slurp_dep#0
     9   (call %₈ slot₂/a slot₃/b slot₄/kws slot₁/#self#)
     10  (return %₉)
-32  latestworld
-33  TestMod.f_kw_slurp_dep
-34  (return %₃₃)
+34  latestworld
+35  TestMod.f_kw_slurp_dep
+36  (return %₃₅)
 
 ########################################
 # Static parameters used in keywords, with and without the static parameter
@@ -1636,25 +1644,27 @@ end
 18  SourceLocation::1:10
 19  (call core.svec %₁₄ %₁₇ %₁₈)
 20  --- method core.nothing %₁₉
-    slots: [slot₁/#self#(!read) slot₂/a(!read) slot₃/b(!read) slot₄/#self#(!read) slot₅/x(!read)]
+    slots: [slot₁/#f_kw_sparams#0(!read) slot₂/a(!read) slot₃/b(!read) slot₄/#self#(!read) slot₅/x(!read)]
     1   (meta :nkw 2)
     2   static_parameter₁
     3   static_parameter₂
     4   (call core.tuple %₂ %₃)
     5   (return %₄)
 21  latestworld
-22  (= slot₃/X (call core.TypeVar :X))
-23  (= slot₄/A (call core.TypeVar :A))
-24  (call core.typeof core.kwcall)
-25  TestMod.f_kw_sparams
-26  (call core.Typeof %₂₅)
-27  slot₃/X
-28  (call core.svec %₂₄ core.NamedTuple %₂₆ %₂₇)
+22  (method TestMod.f_kw_sparams)
+23  latestworld
+24  (= slot₃/X (call core.TypeVar :X))
+25  (= slot₄/A (call core.TypeVar :A))
+26  (call core.typeof core.kwcall)
+27  TestMod.f_kw_sparams
+28  (call core.Typeof %₂₇)
 29  slot₃/X
-30  (call core.svec %₂₉)
-31  SourceLocation::1:10
-32  (call core.svec %₂₈ %₃₀ %₃₁)
-33  --- method core.nothing %₃₂
+30  (call core.svec %₂₆ core.NamedTuple %₂₈ %₂₉)
+31  slot₃/X
+32  (call core.svec %₃₁)
+33  SourceLocation::1:10
+34  (call core.svec %₃₀ %₃₂ %₃₃)
+35  --- method core.nothing %₃₄
     slots: [slot₁/#kwcall_self#(!read) slot₂/kws slot₃/#self# slot₄/x slot₅/kwtmp slot₆/a(!read) slot₇/b(!read)]
     1   (newvar slot₆/a)
     2   (newvar slot₇/b)
@@ -1691,27 +1701,27 @@ end
     33  TestMod.#f_kw_sparams#0
     34  (call %₃₃ %₁₀ %₂₅ slot₃/#self# slot₄/x)
     35  (return %₃₄)
-34  latestworld
-35  (= slot₅/X (call core.TypeVar :X))
-36  (= slot₆/A (call core.TypeVar :A))
-37  TestMod.f_kw_sparams
-38  (call core.Typeof %₃₇)
-39  slot₅/X
-40  (call core.svec %₃₈ %₃₉)
+36  latestworld
+37  (= slot₅/X (call core.TypeVar :X))
+38  (= slot₆/A (call core.TypeVar :A))
+39  TestMod.f_kw_sparams
+40  (call core.Typeof %₃₉)
 41  slot₅/X
-42  (call core.svec %₄₁)
-43  SourceLocation::1:10
-44  (call core.svec %₄₀ %₄₂ %₄₃)
-45  --- method core.nothing %₄₄
+42  (call core.svec %₄₀ %₄₁)
+43  slot₅/X
+44  (call core.svec %₄₃)
+45  SourceLocation::1:10
+46  (call core.svec %₄₂ %₄₄ %₄₅)
+47  --- method core.nothing %₄₆
     slots: [slot₁/#self# slot₂/x]
     1   TestMod.#f_kw_sparams#0
     2   TestMod.a_def
     3   TestMod.b_def
     4   (call %₁ %₂ %₃ slot₁/#self# slot₂/x)
     5   (return %₄)
-46  latestworld
-47  TestMod.f_kw_sparams
-48  (return %₄₇)
+48  latestworld
+49  TestMod.f_kw_sparams
+50  (return %₄₉)
 
 ########################################
 # Error: Static parameter which is unused in keyword body arg types

--- a/JuliaLowering/test/typedefs.jl
+++ b/JuliaLowering/test/typedefs.jl
@@ -367,4 +367,64 @@ let s = test_mod.ShadowTypeParam("hello")
     @test s.x === "hello"
 end
 
+# Inner kwarg constructor
+@test JuliaLowering.include_string(test_mod, """
+struct CheckConfig
+    field::Int
+    function CheckConfig(parg::String; kw::Int = 4)
+        new(length(parg) + kw)
+    end
+    function CheckConfig(optarg1=1, optarg2=10; kw1, kw2 = 1000)
+        new(optarg1+optarg2+kw1+kw2)
+    end
+    function CheckConfig(optarg1=1, optarg2=10; kw1, kw2 = 1000)
+        new(optarg1+optarg2+kw1+kw2)
+    end
+end
+""") === nothing
+
+@test isdefined(test_mod, :CheckConfig)
+
+let s = test_mod.CheckConfig("")
+    @test s isa test_mod.CheckConfig
+    @test s.field == 4
+end
+let s = test_mod.CheckConfig("";kw=5)
+    @test s isa test_mod.CheckConfig
+    @test s.field == 5
+end
+let s = test_mod.CheckConfig(;kw1=100)
+    @test s isa test_mod.CheckConfig
+    @test s.field == 1111
+end
+let s = test_mod.CheckConfig(;kw1=100, kw2=0)
+    @test s isa test_mod.CheckConfig
+    @test s.field == 111
+end
+let s = test_mod.CheckConfig(0;kw1=100, kw2=0)
+    @test s isa test_mod.CheckConfig
+    @test s.field == 110
+end
+let s = test_mod.CheckConfig(0,0;kw1=100)
+    @test s isa test_mod.CheckConfig
+    @test s.field == 1100
+end
+
+let s = test_mod.CheckConfig(;kw1=100)
+    @test s isa test_mod.CheckConfig
+    @test s.field == 1111
+end
+let s = test_mod.CheckConfig(;kw1=100, kw2=0)
+    @test s isa test_mod.CheckConfig
+    @test s.field == 111
+end
+let s = test_mod.CheckConfig(0;kw1=100, kw2=0)
+    @test s isa test_mod.CheckConfig
+    @test s.field == 110
+end
+let s = test_mod.CheckConfig(0,0;kw1=100)
+    @test s isa test_mod.CheckConfig
+    @test s.field == 1100
+end
+
 end


### PR DESCRIPTION
Fix https://github.com/JuliaLang/JuliaLowering.jl/issues/141.  I used the body
     method's name in a previous PR, but that isn't quite correct, since struct
     desugaring needs to make the non-body methods global with a signature
     rewrite, and the body method is local in a struct def.

Atop https://github.com/JuliaLang/julia/pull/61134