### PR TITLE
lowering: fix @goto into while loop causing UndefVarError

### DIFF
--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -731,9 +731,6 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         end_label = make_label(ctx, ex)
         need_value = needs_value || in_tail_pos
         result_var = need_value ? new_local_binding(ctx, ex, "$(name)_result") : nothing
-        if !isnothing(result_var)
-            emit_assignment(ctx, ex, result_var, nothing_(ctx, ex))
-        end
         outer_target = get(ctx.break_targets, name, nothing)
         ctx.break_targets[name] = JumpTarget(end_label, ctx, result_var)
         push!(ctx.break_label_stack, name)
@@ -748,6 +745,18 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
             ctx.break_targets[name] = outer_target
         end
         emit(ctx, end_label)
+        # Use isdefined to handle the case where initialization was
+        # skipped (e.g., by @goto jumping into a loop body).
+        if !isnothing(result_var)
+            defined_label = make_label(ctx, ex)
+            done_label = make_label(ctx, ex)
+            isdef = emit_assign_tmp(ctx, @ast ctx ex [K"isdefined" result_var])
+            emit(ctx, @ast ctx ex [K"gotoifnot" isdef defined_label])
+            emit(ctx, @ast ctx ex [K"goto" done_label])
+            emit(ctx, defined_label)
+            emit_assignment(ctx, ex, result_var, nothing_(ctx, ex))
+            emit(ctx, done_label)
+        end
         if in_tail_pos
             emit_return(ctx, ex, result_var)
             nothing

--- a/JuliaLowering/test/branching_ir.jl
+++ b/JuliaLowering/test/branching_ir.jl
@@ -246,11 +246,14 @@ x = @label foo
     b
 end
 #---------------------
-1   (= slot₁/loop_exit_result core.nothing)
-2   TestMod.a
-3   (= slot₁/loop_exit_result 42)
-4   (goto label₇)
-5   TestMod.b
-6   (= slot₁/loop_exit_result %₅)
-7   slot₁/loop_exit_result
-8   (return %₇)
+1   TestMod.a
+2   (= slot₁/loop_exit_result 42)
+3   (goto label₆)
+4   TestMod.b
+5   (= slot₁/loop_exit_result %₄)
+6   (isdefined slot₁/loop_exit_result)
+7   (gotoifnot %₆ label₉)
+8   (goto label₁₀)
+9   (= slot₁/loop_exit_result core.nothing)
+10  slot₁/loop_exit_result
+11  (return %₁₀)

--- a/JuliaLowering/test/exceptions_ir.jl
+++ b/JuliaLowering/test/exceptions_ir.jl
@@ -235,24 +235,27 @@ while true
     end
 end
 #---------------------
-1   (= slot₁/loop_exit_result core.nothing)
-2   (gotoifnot true label₁₆)
-3   (enter label₁₀)
-4   (= slot₂/finally_tag -1)
-5   TestMod.a
-6   (leave %₃)
-7   (goto label₁₇)
-8   (leave %₃)
-9   (goto label₁₁)
-10  (= slot₂/finally_tag 1)
-11  TestMod.b
-12  (call core.=== slot₂/finally_tag 1)
-13  (gotoifnot %₁₂ label₁₅)
-14  (call top.rethrow)
-15  (goto label₂)
-16  (= slot₁/loop_exit_result core.nothing)
-17  slot₁/loop_exit_result
-18  (return %₁₇)
+1   (gotoifnot true label₁₅)
+2   (enter label₉)
+3   (= slot₂/finally_tag -1)
+4   TestMod.a
+5   (leave %₂)
+6   (goto label₁₆)
+7   (leave %₂)
+8   (goto label₁₀)
+9   (= slot₂/finally_tag 1)
+10  TestMod.b
+11  (call core.=== slot₂/finally_tag 1)
+12  (gotoifnot %₁₁ label₁₄)
+13  (call top.rethrow)
+14  (goto label₁)
+15  (= slot₁/loop_exit_result core.nothing)
+16  (isdefined slot₁/loop_exit_result)
+17  (gotoifnot %₁₆ label₁₉)
+18  (goto label₂₀)
+19  (= slot₁/loop_exit_result core.nothing)
+20  slot₁/loop_exit_result
+21  (return %₂₀)
 
 ########################################
 # try/catch/finally

--- a/JuliaLowering/test/loops_ir.jl
+++ b/JuliaLowering/test/loops_ir.jl
@@ -5,17 +5,20 @@ while f(a)
     body2
 end
 #---------------------
-1   (= slot₁/loop_exit_result core.nothing)
-2   TestMod.f
-3   TestMod.a
-4   (call %₂ %₃)
-5   (gotoifnot %₄ label₉)
-6   TestMod.body1
-7   TestMod.body2
-8   (goto label₂)
-9   (= slot₁/loop_exit_result core.nothing)
-10  slot₁/loop_exit_result
-11  (return %₁₀)
+1   TestMod.f
+2   TestMod.a
+3   (call %₁ %₂)
+4   (gotoifnot %₃ label₈)
+5   TestMod.body1
+6   TestMod.body2
+7   (goto label₁)
+8   (= slot₁/loop_exit_result core.nothing)
+9   (isdefined slot₁/loop_exit_result)
+10  (gotoifnot %₉ label₁₂)
+11  (goto label₁₃)
+12  (= slot₁/loop_exit_result core.nothing)
+13  slot₁/loop_exit_result
+14  (return %₁₃)
 
 ########################################
 # While loop with short circuit condition
@@ -23,16 +26,19 @@ while a && b
     body
 end
 #---------------------
-1   (= slot₁/loop_exit_result core.nothing)
-2   TestMod.a
-3   (gotoifnot %₂ label₈)
-4   TestMod.b
-5   (gotoifnot %₄ label₈)
-6   TestMod.body
-7   (goto label₂)
-8   (= slot₁/loop_exit_result core.nothing)
-9   slot₁/loop_exit_result
-10  (return %₉)
+1   TestMod.a
+2   (gotoifnot %₁ label₇)
+3   TestMod.b
+4   (gotoifnot %₃ label₇)
+5   TestMod.body
+6   (goto label₁)
+7   (= slot₁/loop_exit_result core.nothing)
+8   (isdefined slot₁/loop_exit_result)
+9   (gotoifnot %₈ label₁₁)
+10  (goto label₁₂)
+11  (= slot₁/loop_exit_result core.nothing)
+12  slot₁/loop_exit_result
+13  (return %₁₂)
 
 ########################################
 # While loop with with break and continue
@@ -44,18 +50,21 @@ while cond
     body3
 end
 #---------------------
-1   (= slot₁/loop_exit_result core.nothing)
-2   TestMod.cond
-3   (gotoifnot %₂ label₁₀)
-4   TestMod.body1
-5   (goto label₁₁)
-6   TestMod.body2
-7   (goto label₉)
-8   TestMod.body3
-9   (goto label₂)
-10  (= slot₁/loop_exit_result core.nothing)
-11  slot₁/loop_exit_result
-12  (return %₁₁)
+1   TestMod.cond
+2   (gotoifnot %₁ label₉)
+3   TestMod.body1
+4   (goto label₁₀)
+5   TestMod.body2
+6   (goto label₈)
+7   TestMod.body3
+8   (goto label₁)
+9   (= slot₁/loop_exit_result core.nothing)
+10  (isdefined slot₁/loop_exit_result)
+11  (gotoifnot %₁₀ label₁₃)
+12  (goto label₁₄)
+13  (= slot₁/loop_exit_result core.nothing)
+14  slot₁/loop_exit_result
+15  (return %₁₄)
 
 ########################################
 # Basic for loop
@@ -63,30 +72,33 @@ for x in xs
     body
 end
 #---------------------
-1   (= slot₃/loop_exit_result core.nothing)
-2   TestMod.xs
-3   (= slot₁/next (call top.iterate %₂))
-4   slot₁/next
-5   (call core.=== %₄ core.nothing)
-6   (call top.not_int %₅)
-7   (gotoifnot %₆ label₂₀)
-8   slot₁/next
-9   (= slot₂/x (call core.getfield %₈ 1))
-10  (call core.getfield %₈ 2)
-11  TestMod.body
-12  (= slot₁/next (call top.iterate %₂ %₁₀))
-13  slot₁/next
-14  (call core.=== %₁₃ core.nothing)
-15  (call top.not_int %₁₄)
-16  (gotoifnot %₁₅ label₁₈)
-17  (goto label₈)
-18  (= slot₄/if_val core.nothing)
-19  (goto label₂₁)
-20  (= slot₄/if_val core.nothing)
-21  slot₄/if_val
-22  (= slot₃/loop_exit_result %₂₁)
-23  slot₃/loop_exit_result
-24  (return %₂₃)
+1   TestMod.xs
+2   (= slot₁/next (call top.iterate %₁))
+3   slot₁/next
+4   (call core.=== %₃ core.nothing)
+5   (call top.not_int %₄)
+6   (gotoifnot %₅ label₁₉)
+7   slot₁/next
+8   (= slot₂/x (call core.getfield %₇ 1))
+9   (call core.getfield %₇ 2)
+10  TestMod.body
+11  (= slot₁/next (call top.iterate %₁ %₉))
+12  slot₁/next
+13  (call core.=== %₁₂ core.nothing)
+14  (call top.not_int %₁₃)
+15  (gotoifnot %₁₄ label₁₇)
+16  (goto label₇)
+17  (= slot₄/if_val core.nothing)
+18  (goto label₂₀)
+19  (= slot₄/if_val core.nothing)
+20  slot₄/if_val
+21  (= slot₃/loop_exit_result %₂₀)
+22  (isdefined slot₃/loop_exit_result)
+23  (gotoifnot %₂₂ label₂₅)
+24  (goto label₂₆)
+25  (= slot₃/loop_exit_result core.nothing)
+26  slot₃/loop_exit_result
+27  (return %₂₆)
 
 ########################################
 # Syntax sugar for nested for loop
@@ -94,47 +106,50 @@ for x in xs, y in ys
     x = 10 # Copy of x; does not overwrite x iteration var
 end
 #---------------------
-1   (= slot₆/loop_exit_result core.nothing)
-2   TestMod.xs
-3   (= slot₂/next (call top.iterate %₂))
-4   slot₂/next
-5   (call core.=== %₄ core.nothing)
-6   (call top.not_int %₅)
-7   (gotoifnot %₆ label₃₇)
-8   slot₂/next
-9   (= slot₃/x (call core.getfield %₈ 1))
-10  (call core.getfield %₈ 2)
-11  TestMod.ys
-12  (= slot₁/next (call top.iterate %₁₁))
-13  slot₁/next
-14  (call core.=== %₁₃ core.nothing)
-15  (call top.not_int %₁₄)
-16  (gotoifnot %₁₅ label₂₉)
-17  slot₃/x
-18  (= slot₄/x %₁₇)
-19  slot₁/next
-20  (= slot₅/y (call core.getfield %₁₉ 1))
-21  (call core.getfield %₁₉ 2)
-22  (= slot₄/x 10)
-23  (= slot₁/next (call top.iterate %₁₁ %₂₁))
-24  slot₁/next
-25  (call core.=== %₂₄ core.nothing)
-26  (call top.not_int %₂₅)
-27  (gotoifnot %₂₆ label₂₉)
-28  (goto label₁₇)
-29  (= slot₂/next (call top.iterate %₂ %₁₀))
-30  slot₂/next
-31  (call core.=== %₃₀ core.nothing)
-32  (call top.not_int %₃₁)
-33  (gotoifnot %₃₂ label₃₅)
-34  (goto label₈)
-35  (= slot₇/if_val core.nothing)
-36  (goto label₃₈)
-37  (= slot₇/if_val core.nothing)
-38  slot₇/if_val
-39  (= slot₆/loop_exit_result %₃₈)
-40  slot₆/loop_exit_result
-41  (return %₄₀)
+1   TestMod.xs
+2   (= slot₂/next (call top.iterate %₁))
+3   slot₂/next
+4   (call core.=== %₃ core.nothing)
+5   (call top.not_int %₄)
+6   (gotoifnot %₅ label₃₆)
+7   slot₂/next
+8   (= slot₃/x (call core.getfield %₇ 1))
+9   (call core.getfield %₇ 2)
+10  TestMod.ys
+11  (= slot₁/next (call top.iterate %₁₀))
+12  slot₁/next
+13  (call core.=== %₁₂ core.nothing)
+14  (call top.not_int %₁₃)
+15  (gotoifnot %₁₄ label₂₈)
+16  slot₃/x
+17  (= slot₄/x %₁₆)
+18  slot₁/next
+19  (= slot₅/y (call core.getfield %₁₈ 1))
+20  (call core.getfield %₁₈ 2)
+21  (= slot₄/x 10)
+22  (= slot₁/next (call top.iterate %₁₀ %₂₀))
+23  slot₁/next
+24  (call core.=== %₂₃ core.nothing)
+25  (call top.not_int %₂₄)
+26  (gotoifnot %₂₅ label₂₈)
+27  (goto label₁₆)
+28  (= slot₂/next (call top.iterate %₁ %₉))
+29  slot₂/next
+30  (call core.=== %₂₉ core.nothing)
+31  (call top.not_int %₃₀)
+32  (gotoifnot %₃₁ label₃₄)
+33  (goto label₇)
+34  (= slot₇/if_val core.nothing)
+35  (goto label₃₇)
+36  (= slot₇/if_val core.nothing)
+37  slot₇/if_val
+38  (= slot₆/loop_exit_result %₃₇)
+39  (isdefined slot₆/loop_exit_result)
+40  (gotoifnot %₃₉ label₄₂)
+41  (goto label₄₃)
+42  (= slot₆/loop_exit_result core.nothing)
+43  slot₆/loop_exit_result
+44  (return %₄₃)
 
 ########################################
 # Error: break outside for/while

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -599,3 +599,13 @@ end
             end
         end
     end)
+
+# issue #61129 - @goto into a while loop with break should not error
+function goto_into_while_break()
+    @goto foo
+    while true
+        @label foo
+        break
+    end
+end
+@test goto_into_while_break() === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,8 +91,10 @@ move_to_node1("stress")
 limited_worker_rss && move_to_node1("Distributed")
 
 # Move LinearAlgebra and Pkg tests to the front, because they take a while, so we might
-# as well get them all started early.
-for prependme in ["LinearAlgebra", "Pkg"]
+# as well get them all started early. JuliaLowering_stdlibs both takes a while and
+# uses a lot of a memory at the beginning so try to run it early to keep total memory
+# use flatter.
+for prependme in ["LinearAlgebra", "Pkg", "JuliaLowering_stdlibs"]
     prependme_test_ids = findall(x->occursin(prependme, x), tests)
     prependme_tests = tests[prependme_test_ids]
     deleteat!(tests, prependme_test_ids)


### PR DESCRIPTION
When `@goto` jumps into a while loop body, the initialization of the `loop_exit_result` variable at the top of the symbolicblock is skipped. When `break` then jumps to the end of the symbolicblock, the uninitialized variable is read, causing an UndefVarError.

Fix this by replacing the upfront initialization with an `isdefined` check at the symbolicblock exit. If the result variable was never assigned (because the entry was skipped via `@goto`), it falls back to `nothing`.

Fixes #61129