### PR TITLE
[JuliaLowering] Support new `@__FUNCTION__`/`thisfunction`

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2710,6 +2710,11 @@ function keyword_function_defs(ctx, srcref, callex_srcref, name_str, typevar_nam
 
         push!(kw_name_syms, name_sym)
     end
+    # Mark the wrapper, not the body function, as the "self" arg to
+    # @__FUNCTION__.  TODO: We could probably unify this with is_kwcall_self
+    # with a generic "closure not on first arg" flag if we're willing to pass
+    # the closure to the body function through this arg instead of the first.
+    arg_names[1] = setmeta(arg_names[1], :thisfunction_original, true)
     append!(body_arg_names, arg_names)
     append!(body_arg_types, arg_types)
 

--- a/JuliaLowering/src/kinds.jl
+++ b/JuliaLowering/src/kinds.jl
@@ -65,6 +65,7 @@ function _register_kinds()
             "islocal"
             "isglobal"
             "locals"
+            "thisfunction"
         "END_EXTENSION_KINDS"
 
         # The following kinds are internal to lowering

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -494,6 +494,13 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
         end
         push!(stmts, locals_dict)
         newnode(ctx, ex, K"block", stmts)
+    elseif k == K"thisfunction"
+        lam = SyntaxTree(ex._graph, enclosing_lambda(ctx, scope::ScopeInfo).node_id)
+        self_arg = lam[1][1]
+        for a in children(lam[1])
+            getmeta(a, :thisfunction_original, false) && (self_arg = a)
+        end
+        return _resolve_scopes(ctx, self_arg, scope)
     elseif k == K"assert"
         etype = extension_type(ex)
         if etype == "require_existing_locals"

--- a/JuliaLowering/src/syntax_macros.jl
+++ b/JuliaLowering/src/syntax_macros.jl
@@ -103,6 +103,10 @@ function Base.var"@locals"(__context__::MacroContext)
     @ast __context__ __context__.macrocall [K"locals"]
 end
 
+function Base.var"@__FUNCTION__"(__context__::MacroContext)
+    @ast __context__ __context__.macrocall [K"thisfunction"]
+end
+
 function Base.var"@isdefined"(__context__::MacroContext, ex)
     @ast __context__ __context__.macrocall [K"isdefined" ex]
 end

--- a/JuliaLowering/test/macros_ir.jl
+++ b/JuliaLowering/test/macros_ir.jl
@@ -259,3 +259,31 @@ end
 10  latestworld
 11  TestMod.foo
 12  (return %₁₁)
+
+########################################
+# Error: thisfunction disallowed in comprehension/generator
+[@__FUNCTION__() for x in 1:2]
+#---------------------
+LoweringError:
+[@__FUNCTION__() for x in 1:2]
+#└─────────────┘ ── current function not defined in comprehension or generator
+
+########################################
+# Error: thisfunction disallowed in comprehension/generator
+f(@__FUNCTION__() for x in 1:2)
+#---------------------
+LoweringError:
+f(@__FUNCTION__() for x in 1:2)
+# └─────────────┘ ── current function not defined in comprehension or generator
+
+########################################
+# Error: thisfunction disallowed outside of function
+let
+    @__FUNCTION__()
+end
+#---------------------
+LoweringError:
+let
+    @__FUNCTION__()
+#   └─────────────┘ ── can only be used inside a function
+end


### PR DESCRIPTION
Became an issue in https://github.com/JuliaLang/julia/pull/45399 (cc @BioTurboNick).  

- Port https://github.com/JuliaLang/julia/pull/58940 and steal most tests (we should figure out how to just run the existing tests soon)
- Add a version of `@__FUNCTION__` that preserves provenance
- Catch misuse in the validator
  - Fix a bug where generated functions weren't being counted as functions