### PR TITLE
REPL: add OSC 52 clipboard fallback and graceful degradation

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -11,8 +11,8 @@ Base.Experimental.@optlevel 1
 
 export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, varinfo,
     versioninfo, subtypes, supertypes, @which, @edit, @less, @functionloc, @code_warntype,
-    @code_typed, @code_lowered, @code_llvm, @code_native, @time_imports, clipboard, @trace_compile, @trace_dispatch,
-    @activate
+    @code_typed, @code_lowered, @code_llvm, @code_native, @time_imports, clipboard,
+    has_system_clipboard, @trace_compile, @trace_dispatch, @activate
 
 import Base.Docs.apropos
 

--- a/stdlib/InteractiveUtils/src/clipboard.jl
+++ b/stdlib/InteractiveUtils/src/clipboard.jl
@@ -2,7 +2,23 @@
 
 # clipboard copy and paste
 
+"""
+    has_system_clipboard() -> Bool
+
+Return `true` if the operating system has a clipboard mechanism available.
+On macOS and Windows this is always `true`. On Linux and FreeBSD, it checks
+for the presence of `xclip`, `xsel`, or `wl-copy` (from `wl-clipboard`).
+On other systems, returns `false`.
+
+!!! compat "Julia 1.14"
+    This function requires Julia 1.14 or later.
+
+See also [`clipboard`](@ref).
+"""
+function has_system_clipboard end
+
 if Sys.isapple()
+    has_system_clipboard() = true
     function clipboard(x)
         pbcopy_cmd = `pbcopy`
 
@@ -31,6 +47,14 @@ if Sys.isapple()
     end
 
 elseif Sys.islinux() || Sys.KERNEL === :FreeBSD
+    function has_system_clipboard()
+        try
+            clipboardcmd()
+            return true
+        catch
+            return false
+        end
+    end
     _clipboardcmd = nothing
     const _clipboard_copy = Dict(
             :xsel  => Sys.islinux() ?
@@ -76,6 +100,7 @@ elseif Sys.islinux() || Sys.KERNEL === :FreeBSD
     end
 
 elseif Sys.iswindows()
+    has_system_clipboard() = true
     function clipboard(x::AbstractString)
         if Base.containsnul(x)
             throw(ArgumentError("Windows clipboard strings cannot contain NUL character"))
@@ -142,6 +167,7 @@ elseif Sys.iswindows()
     end
 
 else
+    has_system_clipboard() = false
     clipboard(x="") = error("`clipboard` function not implemented for $(Sys.KERNEL)")
 end
 

--- a/stdlib/REPL/Project.toml
+++ b/stdlib/REPL/Project.toml
@@ -3,6 +3,7 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 version = "1.11.0"
 
 [deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/stdlib/REPL/src/History/History.jl
+++ b/stdlib/REPL/src/History/History.jl
@@ -8,7 +8,8 @@ using StyledStrings: @styled_str as @S_str, Face, addface!, face!, annotations, 
 using JuliaSyntaxHighlighting: highlight
 using Base.Threads
 using Dates
-using InteractiveUtils: clipboard
+using Base64: base64encode
+import InteractiveUtils
 
 export HistoryFile, HistEntry, update!, runsearch
 

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2758,7 +2758,12 @@ function history_search(mistate::MIState)
     else
         mimode.prompt_prefix
     end
-    result = histsearch(mimode.hist.history, term, prefix)
+    # Issue a DA1 query if we haven't received one yet, so that the
+    # terminal's OSC 52 clipboard capability can be detected.
+    if mistate.terminal_properties.da1 === nothing
+        write(term, "\e[c")
+    end
+    result = histsearch(mimode.hist.history, term, prefix, mistate.terminal_properties)
     mimode = if isnothing(result.mode)
         mistate.current_mode
     else


### PR DESCRIPTION
When pressing Ctrl-S → Clipboard in REPL history search on a system without clipboard tools (xsel, xclip, wl-clipboard), a TaskFailedException stack trace was thrown. This adds:

- `OncePerId{T}`: a new callable struct that caches `initializer(key)` per mutable key object via WeakKeyDict, for general-purpose per-object caching
- `has_system_clipboard()` in InteractiveUtils to detect native clipboard availability per platform
- OSC 52 terminal clipboard support as a fallback, with proper DA1 (Primary Device Attributes) query to detect terminal capability
- Graceful degradation: when neither clipboard mechanism is available, the Clipboard option is skipped and a friendly message is shown instead of a stack trace

Fixes #60145