### PR TITLE
fix TypeofBottom subtyping of Type{T} for non typevar T (e.g. Union)

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1997,9 +1997,9 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
     if (jl_is_unionall(y))
         y = jl_unwrap_unionall(y);
     if (x == (jl_value_t*)jl_typeofbottom_type->super)
-        x = (jl_value_t*)jl_typeofbottom_type; // supertype(typeof(Union{})) is equal to, although distinct from, itself
+        x = (jl_value_t*)jl_typeofbottom_type; // supertype(typeof(Union{})) is equal to, although distinct from, typeof(Union{})
     if (y == (jl_value_t*)jl_typeofbottom_type->super)
-        y = (jl_value_t*)jl_typeofbottom_type; // supertype(typeof(Union{})) is equal to, although distinct from, itself
+        y = (jl_value_t*)jl_typeofbottom_type; // supertype(typeof(Union{})) is equal to, although distinct from, typeof(Union{})
     if (x == y || y == (jl_value_t*)jl_any_type) {
         *subtype = 1;
         return 1;
@@ -2100,7 +2100,7 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
                 if (jl_is_type_type(y)) {
                     jl_value_t *t0 = jl_tparam0(y);
                     assert(!jl_is_type_type(x));
-                    if (jl_is_kind(x) && jl_is_typevar(t0))
+                    if ((jl_is_kind(x) && jl_is_typevar(t0)) || (x == (jl_value_t*)jl_typeofbottom_type))
                         return 0;
                     *subtype = 0;
                     return 1;

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -554,6 +554,13 @@ function test_Type()
 
     @test isequal_type(Core.TypeofBottom, Type{Union{}})
     @test issub(Core.TypeofBottom, Type{T} where T<:Real)
+
+    for b in (Type{T} where T, Type{Union{T,S}} where {T,S})
+        for a in (Type{Union{}}, Core.TypeofBottom)
+            @test issub(a, b)
+        end
+        @test isa(Union{}, b)
+    end
 end
 
 # old subtyping tests from test/core.jl


### PR DESCRIPTION
closes https://github.com/JuliaLang/julia/issues/49358, which was caused by the fast path `obvious_subtype` normalizing `Type{Union{}}` to `TypeofBottom` and one of the branches not accounting for that normalization

I believe it's acceptable to special-case `TypeofBottom` here since if I understand correctly that is the only `DataType` which subtypes a `Type{X}` where `X` can match `Union{}`, but does not have `name == Type`