### PR TITLE
Test: Add test_call mechanism for extra @test failure context

### DIFF
--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -1352,14 +1352,14 @@ end
     x, y = 0.9, 0.1
     @test x ≈ y atol=0.01
     """)
-    @test occursin("Evaluated: 0.9 ≈ 0.1 (atol=0.01)", msg)
+    @test occursin("Evaluated: ≈(0.9, 0.1; atol = 0.01)", msg)
 
     msg = f("""
     using Test
     x, y = 0.9, 0.1
     @test x ≈ y nans=true atol=0.01
     """)
-    @test occursin("Evaluated: 0.9 ≈ 0.1 (nans=true, atol=0.01)", msg)
+    @test occursin("Evaluated: ≈(0.9, 0.1; nans = true, atol = 0.01)", msg)
 end
 
 erronce() = @error "an error" maxlog=1

--- a/test/JuliaLowering_stdlibs.jl
+++ b/test/JuliaLowering_stdlibs.jl
@@ -26,10 +26,10 @@ function compile_JL_sysimage(output_filepath)
         "JULIA_NUM_THREADS" => "1",
     )
     println("Compiling incremental sysimage with JuliaLowering...")
-    success(run(cmd))
+    @test success(cmd)
 
     cmd = Base.Linking.link_image_cmd(output_object, output_sysimage)
-    success(run(cmd))
+    @test success(cmd)
 
     return nothing
 end
@@ -59,7 +59,7 @@ mktempdir() do tmp_depot
         `$(JULIA_EXECUTABLE) --startup-file=no --project=$env_dir -e $setupproject_command`,
         ; inherit = true
     )
-    success(run(cmd))
+    @test success(cmd)
 
     # now actually perform the precompilation
     cmd = addenv(
@@ -71,5 +71,5 @@ mktempdir() do tmp_depot
         "JULIA_DEPOT_PATH" => tmp_depot,
         ; inherit = true
     )
-    success(run(cmd))
+    @test success(cmd)
 end


### PR DESCRIPTION
Add `Test.test_call`, an overloadable function that lets specific
predicates provide extra context when `@test` fails. For example,
`@test success(cmd)` now reports the exit code and term signal of the
failing process, rather than just showing `false`.

The old `≈` kwargs display hack (https://github.com/JuliaLang/julia/commit/1046736ab0c2d4591972885179a9c4ea57246481, https://github.com/JuliaLang/julia/pull/24926) is removed as part
of this change. That hack predates https://github.com/JuliaLang/julia/pull/57825 which made all function calls
show evaluated arguments. Before https://github.com/JuliaLang/julia/pull/57825, `@test x ≈ y atol=z` would
only show `Expression:` with no evaluated form, so the hack constructed
a synthetic `Evaluated: 0.9 ≈ 0.1 (atol=0.01)` to surface the kwargs.
Now that all calls already produce an `Evaluated:` line, the hack is
redundant. The kwargs display in the standard `; key = val` syntax.

Written by Claude.