### PR TITLE
nospecialize `InteractiveUtils._subtypes_in!`

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -253,7 +253,7 @@ function methodswith(@nospecialize(t::Type); supertypes::Bool=false)
 end
 
 # subtypes
-function _subtypes_in!(mods::Array, x::Type)
+function _subtypes_in!(mods::Array, @nospecialize(x::Type))
     xt = unwrap_unionall(x)
     if !isabstracttype(x) || !isa(xt, DataType)
         # Fast path


### PR DESCRIPTION
**NOTE**: this PR is against `backports-release-1.12`

On Julia 1.12, this leads to a ~20x speedup in Revise's fieldtype caching, which is essential for type revision.