### PR TITLE
nospecialize `fieldtypes` and `InteractiveUtils._subtypes_in!`

### DIFF
--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1366,7 +1366,7 @@ julia> fieldtypes(Foo)
 (Int64, String)
 ```
 """
-fieldtypes(T::Type) = (@_foldable_meta; ntupleany(i -> fieldtype(T, i), fieldcount(T)))
+fieldtypes(@nospecialize T::Type) = (@_foldable_meta; ntupleany(i -> fieldtype(T, i), fieldcount(T)))
 
 # return all instances, for types that can be enumerated
 

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -253,7 +253,7 @@ function methodswith(@nospecialize(t::Type); supertypes::Bool=false)
 end
 
 # subtypes
-function _subtypes_in!(mods::Array, x::Type)
+function _subtypes_in!(mods::Array, @nospecialize(x::Type))
     xt = unwrap_unionall(x)
     if !isabstracttype(x) || !isa(xt, DataType)
         # Fast path


### PR DESCRIPTION
These lead to 10-20x speedups in Revise's fieldtype-caching