### PR TITLE
inference: implement `MustAlias` forwarding and `getproperty` support

### DIFF
--- a/Compiler/src/abstractlattice.jl
+++ b/Compiler/src/abstractlattice.jl
@@ -252,6 +252,10 @@ end
     isa(x, Const) && return true
     return is_forwardable_argtype(widenlattice(𝕃), x)
 end
+@nospecializeinfer function is_forwardable_argtype(𝕃::MustAliasesLattice, @nospecialize x)
+    isa(x, MustAlias) && return true
+    return is_forwardable_argtype(widenlattice(𝕃), x)
+end
 @nospecializeinfer is_forwardable_argtype(::JLTypeLattice, @nospecialize x) = false
 
 """

--- a/Compiler/src/inferenceresult.jl
+++ b/Compiler/src/inferenceresult.jl
@@ -100,6 +100,11 @@ function va_process_argtypes(𝕃::AbstractLattice, given_argtypes::Vector{Any},
                     newarg = widenconditional(newarg)
                 end
             end
+            if isva && has_mustalias(𝕃) && isa(newarg, MustAlias)
+                if newarg.slot > (nargs-isva)
+                    newarg = widenmustalias(newarg)
+                end
+            end
             isva_given_argtypes[i] = newarg
         end
         if isva
@@ -112,6 +117,14 @@ function va_process_argtypes(𝕃::AbstractLattice, given_argtypes::Vector{Any},
                         newarg = given_argtypes[i]
                         if isa(newarg, Conditional) && newarg.slot > (nargs-isva)
                             given_argtypes[i] = widenconditional(newarg)
+                        end
+                    end
+                end
+                if has_mustalias(𝕃)
+                    for i = last:length(given_argtypes)
+                        newarg = given_argtypes[i]
+                        if isa(newarg, MustAlias) && newarg.slot > (nargs-isva)
+                            given_argtypes[i] = widenmustalias(newarg)
                         end
                     end
                 end

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -980,6 +980,8 @@ is_effect_overridden(override::EffectsOverride, effect::Symbol) = getfield(overr
 
 has_conditional(𝕃::AbstractLattice, ::InferenceState) = has_conditional(𝕃)
 has_conditional(::AbstractLattice, ::IRInterpretationState) = false
+has_mustalias(𝕃::AbstractLattice, ::InferenceState) = has_mustalias(𝕃)
+has_mustalias(::AbstractLattice, ::IRInterpretationState) = false
 
 # work towards converging the valid age range for sv
 function update_valid_age!(sv::AbsIntState, world, valid_worlds::WorldRange)

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -888,10 +888,10 @@ end
 
 # annotate types of all symbols in AST, preparing for optimization
 function type_annotate!(::AbstractInterpreter, sv::InferenceState)
-    # widen `Conditional`s from `slottypes`
+    # widen slot wrappers from `slottypes`
     slottypes = sv.slottypes
     for i = 1:length(slottypes)
-        slottypes[i] = widenconditional(slottypes[i])
+        slottypes[i] = widenslotwrapper(slottypes[i])
     end
 
     # compute the required type for each slot

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -62,7 +62,7 @@ function setproperty!(x, f::Symbol, v)
     return setfield!(x, f, val)
 end
 
-typeof(function getproperty end).name.constprop_heuristic = Core.FORCE_CONST_PROP
+typeof(function getproperty end).name.constprop_heuristic = or_int(Core.FORCE_CONST_PROP, Core.DISABLE_SEMI_CONCRETE_EVAL)
 typeof(function setproperty! end).name.constprop_heuristic = Core.FORCE_CONST_PROP
 
 dotgetproperty(x, f) = getproperty(x, f)


### PR DESCRIPTION
Implement inter-procedural `MustAlias` forwarding through const-prop, enabling alias-aware union splitting when the base object and its field are both passed to a callee. Unify `ConditionalSimpleArgtypes` and the new `MustAlias` handling into a single `ForwardableArgtypes` type.

Also marks `getproperty` with `DISABLE_SEMI_CONCRETE_EVAL` so that const-prop runs instead of semi-concrete eval, allowing the `InterMustAlias` return type to be produced via the `widenreturn`/`from_intermustalias` pipeline.
I hope this does not impact the overall inference performance since `getproperty` is commonly simply implemented, but it's better to assert it with the nanosoldier inference performance benchmark.

Finally also widen all slot wrappers (including `MustAlias`, not only `Conditional`) in `type_annotate!` before optimization, preventing lattice elements from leaking into the optimizer which only supports `SimpleInferenceLattice`.

---

@nanosoldier `runbenchmarks("inference", vs=":master")`