### PR TITLE
Docs: note about `big(x::BigFloat)` being a no-op

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -487,7 +487,7 @@ information about some pitfalls with floating-point numbers.
 
 !!! note "big(x::BigFloat)"
     Unlike `BigFloat(x)`, `big(x)` is a no-op when `x` is already a `BigFloat`,
-    ie. when doing `x = big(x)`, the precision of `x` remains as is even if the
+    ie. when doing `x = big(x)`, the precision of `x` remains unchanged even if the
     current `BigFloat` precision is different.
     ```
 """

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -484,6 +484,12 @@ promote_rule(::Type{BigInt}, ::Type{<:Integer}) = BigInt
 Convert a number to a maximum precision representation (typically [`BigInt`](@ref) or
 `BigFloat`). See [`BigFloat`](@ref BigFloat(::Any, rounding::RoundingMode)) for
 information about some pitfalls with floating-point numbers.
+
+!!! note "big(x::BigFloat)"
+    Unlike `BigFloat(x)`, `big(x)` is a no-op when `x` is already a `BigFloat`,
+    ie. when doing `x = big(x)`, the precision of `x` remains as is even if the
+    current `BigFloat` precision is different.
+    ```
 """
 function big end
 


### PR DESCRIPTION
Emphasize that when doing `x = big(x)`, the precision of `x` remains as is even if the current `BigFloat` precision is different. 

Closes #60829.