### PR TITLE
Fix hang with invalid `.` expression

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2655,11 +2655,11 @@
 
    '|.|
    (lambda (e)
-     (if (length= e 2)
-         ;; e = (|.| op)
-         `(call (top BroadcastFunction) ,(cadr e))
-         ;; e = (|.| f x)
-         (expand-fuse-broadcast '() e)))
+     (cond  ;; e = (|.| op)
+      ((length= e 2) `(call (top BroadcastFunction) ,(cadr e)))
+      ;; e = (|.| f x)
+      ((length= e 3) (expand-fuse-broadcast '() e))
+      (else (error "wrong number of arguments in `.` expression"))))
 
    '.&&
    (lambda (e) (expand-fuse-broadcast '() e))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -358,6 +358,14 @@ end
 @test_loweringerror(:(identity($(Expr(:(...), 1, 2, 3)))),
                     "wrong number of expressions following \"...\"")
 
+# issue #57733 - malformed "." expr
+@test_loweringerror(Expr(:.),
+                    "wrong number of arguments in `.` expression")
+@test_loweringerror(Expr(:., :a, :b, :c),
+                    "wrong number of arguments in `.` expression")
+@test_loweringerror(Expr(:., :a, :b, :c, :d),
+                    "wrong number of arguments in `.` expression")
+
 # issue #15830
 @test_loweringerror(Meta.parse("foo(y = (global x)) = y"), "misplaced \"global\" declaration")
 


### PR DESCRIPTION
Fix https://github.com/JuliaLang/julia/issues/57733.  Clearly not a common bug to encounter in practice, but one that's difficult to deal with while fuzzing, since flisp's wonderful tail-call elimination means a real infinite hang with no stack overflow to stop it, and it happens with expressions as small as `Meta.lower(Main, Expr(:.))`.