### PR TITLE
Local names linking fixes

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1984,11 +1984,8 @@ void JuliaOJIT::publishCIs(ArrayRef<jl_code_instance_t *> CIs, bool Wait)
         std::unique_lock Lock{LinkerMutex};
         for (auto CI : CIs) {
             auto It = CISymbols.find(CI);
-            if (It == CISymbols.end()) {
-                errs()
-                    << "Internal error: Attempted to publish code instance that was never successfully compiled.\n";
-                abort();
-            }
+            if (It == CISymbols.end())
+                return;
             auto CISym = It->second;
             if (CISym.invoke)
                 Exports.add(CISym.invoke);

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -369,12 +369,10 @@ void *jl_jit_abi_converter_impl(jl_task_t *ct, jl_abi_t from_abi,
             gf_thunk_name = emit_abi_dispatcher(*out, from_abi, codeinst, llvminvoke);
         }
     }
-    int8_t gc_state = jl_gc_safe_enter(ct->ptls);
     auto &ES = jl_ExecutionEngine->getExecutionSession();
     auto emitted = out->finish(*ES.getSymbolStringPool());
     jl_ExecutionEngine->addOutput(std::move(emitted));
     uintptr_t Addr = jl_ExecutionEngine->getFunctionAddress(gf_thunk_name);
-    jl_gc_safe_leave(ct->ptls, gc_state);
     assert(Addr);
     return (void*)Addr;
 }

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -784,7 +784,8 @@ protected:
     // void registerJITOutput(MemoryBufferRef Obj, const jl_linker_info_t &Info);
 
     // Rename LinkGraph symbols to match the previously chosen names and
-    // register debug info for defined symbols.
+    // register debug info for defined symbols.  Returns true on success, and
+    // false after calling MR.failMaterialization().
     bool linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferRef ObjBuf,
                     jitlink::LinkGraph &G,
                     std::unique_ptr<jl_linker_info_t> Info) JL_NOTSAFEPOINT;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -785,7 +785,7 @@ protected:
 
     // Rename LinkGraph symbols to match the previously chosen names and
     // register debug info for defined symbols.
-    void linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferRef ObjBuf,
+    bool linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferRef ObjBuf,
                     jitlink::LinkGraph &G,
                     std::unique_ptr<jl_linker_info_t> Info) JL_NOTSAFEPOINT;
 


### PR DESCRIPTION
The merging of #60031 revealed a few remaining multithreading issues with local names linking (https://buildkite.com/julialang/julia-master/builds/55081/steps/canvas?jid=019c9584-a2fa-4ddc-bc7e-95ee729211a0&tab=output).

This PR has a series of commits addressing these issues and making us a little more eager to crash with a useful message in situations that would otherwise result in a deadlock in `JuliaTaskDispatcher`:
- We return as soon as possible from `JLMaterializationUnit::materialize` after calling `MaterializationResponsibility::failMaterialization`.
- When an ORC lookup fails in `publishCIs`, call `abort()` instead of potentially deadlocking.

Two concurrency issues are fixed.  The first is that there was a window of time during which a CodeInstance added to the JIT via `jl_emit_codeinst_to_jit` had `invoke == jl_fptr_wait_for_compiled_addr`, but did not have ORC symbols set up in `JuliaOJIT::CISymbols`.  We solve this by taking the lock before setting up the ORC symbols, skipping any CodeInstances where another thread beat us to the punch in setting `invoke.`

I suspect the second issue is the one that was causing rare CI failures.  We had a data race on the `InFlight` counter for `JLJITLinkMemoryManager`, which, if decremented below zero, would cause the `FinalizedCallbacks` to never fire.  This manifests as deadlocks in `JuliaTaskDispatcher`, since those symbols will be stuck in the `SymbolState::Resolved` state forever.