### PR TITLE
[JuliaLowering] Misc. cleanup: `symboliclabel`, `flatten_blocks`

### DIFF
--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -224,14 +224,14 @@ end
 
 # Compute fields for a closure type, one field for each captured variable.
 function closure_type_fields(ctx, srcref, closure_binds, is_opaque)
-    capture_ids = Vector{IdTag}()
+    capture_ids = Set{IdTag}()
     for lambda_bindings in closure_binds.lambdas
         for (id, is_capt) in lambda_bindings.locals_capt
             is_capt && push!(capture_ids, id)
         end
     end
-    # sort here to avoid depending on undefined Dict iteration order.
-    capture_ids = sort!(unique(capture_ids))
+    # sort here to avoid depending on undefined Set iteration order
+    capture_ids = sort!(collect(capture_ids))
 
     field_syms = SyntaxList(ctx)
     if is_opaque
@@ -440,9 +440,7 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
                     push!(init_closure_args, field_val)
                     if !boxed
                         push!(type_params, @ast ctx ex [K"call"
-                              # TODO: Update to use _typeof_captured_variable (#40985)
-                              #"_typeof_captured_variable"::K"core"
-                              "typeof"::K"core"
+                              "_typeof_captured_variable"::K"core"
                               field_val])
                     end
                 end
@@ -624,5 +622,5 @@ Invariants:
     if !isempty(ctx_out.toplevel_stmts)
         throw(LoweringError(first(ctx_out.toplevel_stmts), "Top level code was found outside any top level context. `@generated` functions may not contain closures, including `do` syntax and generators/comprehension"))
     end
-    ctx_out, ex_out
+    ctx_out, flatten_blocks(ex_out)
 end

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -477,6 +477,11 @@ function est_to_dst(st::SyntaxTree; all_expanded=true)
         ]
         [K"symbolicgoto" lab] -> setattr!(mkleaf(st), :name_val, lab.name_val)
         [K"symboliclabel" lab] -> setattr!(mkleaf(st), :name_val, lab.name_val)
+        [K"symbolicblock" id body] -> if all(==('_'), id.name_val)
+            @ast g st [K"symbolicblock" id=>K"Placeholder" rec(body)]
+        else
+            @ast g st [K"symbolicblock" id=>K"symboliclabel" rec(body)]
+        end
         [K"unknown_head" cs...] -> let head = st.name_val
             if head === "latestworld-if-toplevel"
                 newleaf(g, st, K"latestworld_if_toplevel")

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2038,7 +2038,7 @@ function expand_for(ctx, ex)
         body = if i == numchildren(iterspecs)
             # Innermost loop gets the continue label and copied vars
             @ast ctx ex [K"symbolicblock"
-                "loop_cont"::K"symboliclabel"
+                "loop-cont"::K"symboliclabel"
                 [K"let"(scope_type=:neutral)
                      [K"block"
                          copied_vars...
@@ -2084,7 +2084,7 @@ function expand_for(ctx, ex)
         ]
     end
 
-    @ast ctx ex [K"symbolicblock" "loop_exit"::K"symboliclabel"
+    @ast ctx ex [K"symbolicblock" "loop-exit"::K"symboliclabel"
         loop
     ]
 end
@@ -4429,47 +4429,30 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
     elseif k == K"="
         expand_assignment(ctx, ex)
     elseif k == K"break"
-        nc = numchildren(ex)
-        if nc == 0
-            @ast ctx ex [K"break" "loop_exit"::K"symboliclabel"]
-        else
-            @chk nc <= 2 (ex, "Too many arguments to break")
-            label = ex[1]
-            label_kind = kind(label)
-            # Convert Symbol (from Expr conversion) to symboliclabel
-            if label_kind == K"Symbol"
-                label = @ast ctx label label.name_val::K"symboliclabel"
-            elseif label_kind == K"Placeholder"
-                # `break _` maps to the default break scope (loop_exit)
-                label = @ast ctx label "loop_exit"::K"symboliclabel"
-            elseif !(label_kind == K"Identifier" ||
-                     label_kind == K"symboliclabel" || is_contextual_keyword(label_kind))
-                throw(LoweringError(label, "Invalid break label: expected identifier"))
+        @stm ex begin
+            [K"break"] ->
+                @ast ctx ex [K"break" "loop-exit"::K"symboliclabel"]
+            [K"break" [K"Placeholder"]] ->
+                @ast ctx ex [K"break" "loop-exit"::K"symboliclabel"]
+            [K"break" [K"Identifier"]] -> begin
+                @ast ctx ex [K"break" ex[1]=>K"symboliclabel"]
             end
-            if nc == 2
-                @ast ctx ex [K"break" label expand_forms_2(ctx, ex[2])]
-            else
-                @ast ctx ex [K"break" label]
+            [K"break" [K"Placeholder"] val] ->
+                @ast ctx ex [K"break" "loop-exit"::K"symboliclabel"
+                             expand_forms_2(ctx, val)]
+            [K"break" [K"Identifier"] val] -> begin
+                @ast ctx ex [K"break" ex[1]=>K"symboliclabel"
+                             expand_forms_2(ctx, val)]
             end
         end
     elseif k == K"continue"
-        nc = numchildren(ex)
-        if nc == 0
-            @ast ctx ex [K"break" "loop_cont"::K"symboliclabel"]
-        else
-            @chk nc == 1 (ex, "Too many arguments to continue")
-            label = ex[1]
-            label_kind = kind(label)
-            if label_kind == K"Placeholder"
-                # `continue _` maps to the default continue scope (loop_cont)
-                cont_label = @ast ctx label "loop_cont"::K"symboliclabel"
-            elseif !(label_kind == K"Identifier" ||
-                     label_kind == K"Symbol" || is_contextual_keyword(label_kind))
-                throw(LoweringError(label, "Invalid continue label: expected identifier"))
-            else
-                cont_label = @ast ctx label string(label.name_val, "#cont")::K"symboliclabel"
-            end
-            @ast ctx ex [K"break" cont_label]
+        @stm ex begin
+            [K"continue"] ->
+                @ast ctx ex [K"break" "loop-cont"::K"symboliclabel"]
+            [K"continue" [K"Placeholder"]] ->
+                @ast ctx ex [K"break" "loop-cont"::K"symboliclabel"]
+            [K"continue" [K"Identifier"]] ->
+                @ast ctx ex [K"break" string(label.name_val, "#cont")::K"symboliclabel"]
         end
     elseif k == K"comparison"
         expand_forms_2(ctx, expand_compare_chain(ctx, ex))
@@ -4619,10 +4602,10 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
         expand_forms_2(ctx, expand_ncat(ctx, ex))
     elseif k == K"while"
         @chk numchildren(ex) == 2
-        @ast ctx ex [K"symbolicblock" "loop_exit"::K"symboliclabel"
+        @ast ctx ex [K"symbolicblock" "loop-exit"::K"symboliclabel"
             [K"_while"
                 expand_condition(ctx, ex[1])
-                [K"symbolicblock" "loop_cont"::K"symboliclabel"
+                [K"symbolicblock" "loop-cont"::K"symboliclabel"
                     [K"scope_block"(scope_type=:neutral)
                          expand_forms_2(ctx, ex[2])
                     ]
@@ -4640,11 +4623,6 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
                 @ast ctx ex [K"static_eval" expand_forms_2(ctx, c)])
         end
         @ast ctx ex [K"foreigncall" expand_C_library_symbol(ctx, ex[1]) args...]
-    elseif k == K"symbolicblock"
-        # @label name body -> (symbolicblock name expanded_body)
-        # The @label macro inserts the continue block for loops, so we just expand the body
-        @chk numchildren(ex) == 2
-        @ast ctx ex [K"symbolicblock" ex[1] expand_forms_2(ctx, ex[2])]
     elseif k == K"gc_preserve"
         s = ssavar(ctx, ex)
         r = ssavar(ctx, ex)

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -305,9 +305,9 @@ function emit_break(ctx, ex)
     name = ex[1].name_val
     target = get(ctx.break_targets, name, nothing)
     if isnothing(target)
-        if name == "loop_exit"
+        if name == "loop-exit"
             throw(LoweringError(ex, "`break` must be used inside a `while`, `for` loop, or `@label` block"))
-        elseif name == "loop_cont"
+        elseif name == "loop-cont"
             throw(LoweringError(ex, "`continue` must be used inside a `while` or `for` loop"))
         elseif endswith(name, "#cont")
             label = name[1:end-5]
@@ -316,23 +316,23 @@ function emit_break(ctx, ex)
             throw(LoweringError(ex, "`break $name` is not inside a `@label $name` block"))
         end
     end
-    # If targeting loop_exit, check for intervening named @label blocks
-    if name == "loop_exit"
+    # If targeting loop-exit, check for intervening named @label blocks
+    if name == "loop-exit"
         for i in lastindex(ctx.break_label_stack):-1:1
             lbl = ctx.break_label_stack[i]
-            lbl == "loop_exit" && break
-            if lbl != "loop_cont" && !contains(lbl, '#')
+            lbl == "loop-exit" && break
+            if lbl != "loop-cont" && !contains(lbl, '#')
                 throw(LoweringError(ex,
                     "plain `break` inside `@label $lbl` block is disallowed; use `break $lbl` to exit the block"))
             end
         end
     end
-    # If targeting loop_cont, check for intervening loop_exit (@label block)
-    if name == "loop_cont"
+    # If targeting loop-cont, check for intervening loop-exit (@label block)
+    if name == "loop-cont"
         for i in lastindex(ctx.break_label_stack):-1:1
             lbl = ctx.break_label_stack[i]
-            lbl == "loop_cont" && break
-            if lbl == "loop_exit"
+            lbl == "loop-cont" && break
+            if lbl == "loop-exit"
                 throw(LoweringError(ex, "`continue` inside an anonymous `@label` block is not allowed"))
             end
         end
@@ -717,8 +717,8 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         end
     elseif k == K"symbolicblock"
         name = ex[1].name_val
-        # Skip duplicate check for default-scope labels (loop_exit, loop_cont) which allow nesting
-        if name != "loop_exit" && name != "loop_cont"
+        # Skip duplicate check for default-scope labels (loop-exit, loop-cont) which allow nesting
+        if name != "loop-exit" && name != "loop-cont"
             if haskey(ctx.symbolic_jump_targets, name) || name in ctx.symbolic_block_labels
                 throw(LoweringError(ex, "Label `$name` defined multiple times"))
             end

--- a/JuliaLowering/src/utils.jl
+++ b/JuliaLowering/src/utils.jl
@@ -416,6 +416,8 @@ end
 function flatten_blocks(st::SyntaxTree)
     if kind(st) === K"block"
         mknode(st, _flatten_blocks(st))
+    elseif is_quoted(st)
+        st
     else
         mapchildren(flatten_blocks, st._graph, st)
     end

--- a/JuliaLowering/src/utils.jl
+++ b/JuliaLowering/src/utils.jl
@@ -394,3 +394,29 @@ macro SyntaxTree(ex_old)
     Expr(:call, :interpolate_ast, SyntaxTree, ex1[3][1],
          map(e->_scope_layer_1_to_esc!(Expr(e)), ex1[4:end])...)
 end
+
+function _flatten_blocks(st::SyntaxTree)
+    if kind(st) === K"block"
+        out = SyntaxList(st._graph)
+        for c in children(st)
+            append!(out, _flatten_blocks(c))
+        end
+        # special case: an empty final block has value nothing
+        if (length(children(st)) > 0 && kind(st[end]) === K"block" &&
+            numchildren(st[end]) == 0)
+            push!(out, @ast st._graph st[end] "nothing"::K"core")
+        end
+        return out
+    else
+        SyntaxList(mapchildren(flatten_blocks, st._graph, st))
+    end
+end
+
+# Splat the contents of any block whose parent is also a block
+function flatten_blocks(st::SyntaxTree)
+    if kind(st) === K"block"
+        mknode(st, _flatten_blocks(st))
+    else
+        mapchildren(flatten_blocks, st._graph, st)
+    end
+end

--- a/JuliaLowering/src/utils.jl
+++ b/JuliaLowering/src/utils.jl
@@ -407,6 +407,8 @@ function _flatten_blocks(st::SyntaxTree)
             push!(out, @ast st._graph st[end] "nothing"::K"core")
         end
         return out
+    elseif is_quoted(st)
+        SyntaxList(st)
     else
         SyntaxList(mapchildren(flatten_blocks, st._graph, st))
     end

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -194,8 +194,6 @@ vst1(vcx::Validation1Context, st::SyntaxTree)::ValidationResult = @stm st begin
     [K"return" val] -> vcx.return_ok ?
         vst1(vcx, val) :
         @fail(st, "`return` not allowed inside comprehension or generator")
-    [K"return"] -> vcx.return_ok ? pass() :
-        @fail(st, "`return` not allowed inside comprehension or generator")
     ([K"continue"], when=vcx.in_loop) -> pass()
     ([K"continue" lab], when=vcx.in_loop) -> vst1_ident(vcx, lab; lhs=true)
     ([K"break"], when=vcx.in_loop) -> pass()
@@ -275,8 +273,7 @@ vst1(vcx::Validation1Context, st::SyntaxTree)::ValidationResult = @stm st begin
     [K"symboliclabel" lab] -> vst1_ident(vcx, lab; lhs=true)
     [K"symbolicgoto" lab] -> vst1_ident(vcx, lab; lhs=true)
     [K"symbolicblock" lab body] ->
-        (kind(lab) == K"symboliclabel" ? pass() : vst1_ident(vcx, lab; lhs=true)) &
-        vst1(with(vcx; in_symblock=true), body)
+        vst1_ident(vcx, lab; lhs=true) & vst1(with(vcx; in_symblock=true), body)
     [K"gc_preserve" x ids...] -> vst1(vcx, x) & all(vst1_ident, vcx, ids)
     [K"gc_preserve_begin" ids...] -> all(vst1_ident, vcx, ids)
     [K"gc_preserve_end" ids...] -> all(vst1_ident, vcx, ids)
@@ -1059,6 +1056,7 @@ function _assert_syntaxtree(st::SyntaxTree, parents::Vector{NodeId}, vr)
         vr &= hasattr(st, a) ? pass() : @fail(st, string("needs attribute ", a))
     end
     if is_leaf(st)
+        # Note some kinds can show up in non-leaves too
         required_attrs = @stm st begin
             [K"Identifier"] -> (:name_val,)
             [K"core"] -> (:name_val,)

--- a/JuliaLowering/test/ast.jl
+++ b/JuliaLowering/test/ast.jl
@@ -22,3 +22,56 @@
     @test_throws "cycle detected" JuliaLowering.assert_syntaxtree(cyc_1)
     @test_throws "cycle detected" JuliaLowering.assert_syntaxtree(cyc_2)
 end
+
+@testset "flatten_blocks" begin
+    let
+        st = @ast_ [K"block"]
+        @test JuliaLowering.flatten_blocks(st) ≈
+            @ast_ [K"block"]
+
+        st = @ast_ [K"block" 1::K"Value"]
+        @test JuliaLowering.flatten_blocks(st) ≈
+            @ast_ [K"block" 1::K"Value"]
+
+        st = @ast_ [K"block" 1::K"Value" [K"block" 1::K"Value"]]
+        @test JuliaLowering.flatten_blocks(st) ≈
+            @ast_ [K"block" 1::K"Value" 1::K"Value"]
+
+        st = @ast_ [K"inert" [K"block" 1::K"Value" [K"block" 1::K"Value"]]]
+        @test JuliaLowering.flatten_blocks(st) ≈
+            @ast_ [K"inert" [K"block" 1::K"Value" [K"block" 1::K"Value"]]]
+
+        st = @ast_ [K"block" 1::K"Value" [K"block"]]
+        @test JuliaLowering.flatten_blocks(st) ≈
+            @ast_ [K"block" 1::K"Value" "nothing"::K"core"]
+
+        st = @ast_ [K"block" 1::K"Value" [K"block"] 1::K"Value"]
+        @test JuliaLowering.flatten_blocks(st) ≈
+            @ast_ [K"block" 1::K"Value" 1::K"Value"]
+
+        # repeat with call wrapper
+        st = @ast_ [K"call" [K"block"]]
+        @test JuliaLowering.flatten_blocks(st) ≈
+            @ast_ [K"call" [K"block"]]
+
+        st = @ast_ [K"call" [K"block" 1::K"Value"]]
+        @test JuliaLowering.flatten_blocks(st) ≈
+            @ast_ [K"call" [K"block" 1::K"Value"]]
+
+        st = @ast_ [K"call" [K"block" 1::K"Value" [K"block" 1::K"Value"]]]
+        @test JuliaLowering.flatten_blocks(st) ≈
+            @ast_ [K"call" [K"block" 1::K"Value" 1::K"Value"]]
+
+        st = @ast_ [K"call" [K"inert" [K"block" 1::K"Value" [K"block" 1::K"Value"]]]]
+        @test JuliaLowering.flatten_blocks(st) ≈
+            @ast_ [K"call" [K"inert" [K"block" 1::K"Value" [K"block" 1::K"Value"]]]]
+
+        st = @ast_ [K"call" [K"block" 1::K"Value" [K"block"]]]
+        @test JuliaLowering.flatten_blocks(st) ≈
+            @ast_ [K"call" [K"block" 1::K"Value" "nothing"::K"core"]]
+
+        st = @ast_ [K"call" [K"block" 1::K"Value" [K"block"] 1::K"Value"]]
+        @test JuliaLowering.flatten_blocks(st) ≈
+            @ast_ [K"call" [K"block" 1::K"Value" 1::K"Value"]]
+    end
+end

--- a/JuliaLowering/test/ast.jl
+++ b/JuliaLowering/test/ast.jl
@@ -49,6 +49,10 @@ end
         @test JuliaLowering.flatten_blocks(st) ≈
             @ast_ [K"block" 1::K"Value" 1::K"Value"]
 
+        st = @ast_ [K"block" [K"inert" [K"block" 1::K"Value" [K"block" 1::K"Value"]]]]
+        @test JuliaLowering.flatten_blocks(st) ≈
+            @ast_ [K"block" [K"inert" [K"block" 1::K"Value" [K"block" 1::K"Value"]]]]
+
         # repeat with call wrapper
         st = @ast_ [K"call" [K"block"]]
         @test JuliaLowering.flatten_blocks(st) ≈
@@ -73,5 +77,9 @@ end
         st = @ast_ [K"call" [K"block" 1::K"Value" [K"block"] 1::K"Value"]]
         @test JuliaLowering.flatten_blocks(st) ≈
             @ast_ [K"call" [K"block" 1::K"Value" 1::K"Value"]]
+
+        st = @ast_ [K"call" [K"block" [K"inert" [K"block" 1::K"Value" [K"block" 1::K"Value"]]]]]
+        @test JuliaLowering.flatten_blocks(st) ≈
+            @ast_ [K"call" [K"block" [K"inert" [K"block" 1::K"Value" [K"block" 1::K"Value"]]]]]
     end
 end

--- a/JuliaLowering/test/branching_ir.jl
+++ b/JuliaLowering/test/branching_ir.jl
@@ -224,19 +224,14 @@ begin
 end
 #---------------------
 LoweringError:
-begin
-    @label foo
-    @label foo
-#          └─┘ ── Label `foo` defined multiple times
-end
+#= none:3 =# - Label `foo` defined multiple times
 
 ########################################
 # Error: using value of symbolic label
 x = @label foo
 #---------------------
 LoweringError:
-x = @label foo
-#          └─┘ ── misplaced label in value position
+#= none:1 =# - misplaced label in value position
 
 ########################################
 # Anonymous labeled block with valued break
@@ -247,13 +242,13 @@ x = @label foo
 end
 #---------------------
 1   TestMod.a
-2   (= slot₁/loop_exit_result 42)
+2   (= slot₁/loop-exit_result 42)
 3   (goto label₆)
 4   TestMod.b
-5   (= slot₁/loop_exit_result %₄)
-6   (isdefined slot₁/loop_exit_result)
+5   (= slot₁/loop-exit_result %₄)
+6   (isdefined slot₁/loop-exit_result)
 7   (gotoifnot %₆ label₉)
 8   (goto label₁₀)
-9   (= slot₁/loop_exit_result core.nothing)
-10  slot₁/loop_exit_result
+9   (= slot₁/loop-exit_result core.nothing)
+10  slot₁/loop-exit_result
 11  (return %₁₀)

--- a/JuliaLowering/test/closures_ir.jl
+++ b/JuliaLowering/test/closures_ir.jl
@@ -13,7 +13,7 @@ end
 4   (call JuliaLowering.eval_closure_type TestMod :#f##0 %₂ %₃)
 5   latestworld
 6   TestMod.#f##0
-7   (call core.typeof slot₂/x)
+7   (call core._typeof_captured_variable slot₂/x)
 8   (call core.apply_type %₆ %₇)
 9   (new %₈ slot₂/x)
 10  (= slot₁/f %₉)
@@ -186,7 +186,7 @@ end
     6   (= slot₃/x 5)
     7   TestMod.#foo#->##0
     8   slot₃/x
-    9   (call core.typeof %₈)
+    9   (call core._typeof_captured_variable %₈)
     10  (call core.apply_type %₇ %₉)
     11  slot₃/x
     12  (new %₁₀ %₁₁)
@@ -232,7 +232,7 @@ end
 20  --- method core.nothing %₁₉
     slots: [slot₁/#self#(!read) slot₂/x slot₃/g(single_assign) slot₄/z(!read,single_assign)]
     1   TestMod.#f#g##1
-    2   (call core.typeof slot₂/x)
+    2   (call core._typeof_captured_variable slot₂/x)
     3   (call core.apply_type %₁ %₂)
     4   (new %₃ slot₂/x)
     5   (= slot₃/g %₄)
@@ -282,7 +282,7 @@ end
     slots: [slot₁/#self#(!read) slot₂/#arg1#(!read) slot₃/g(single_assign)]
     1   TestMod.#f#g##2
     2   static_parameter₁
-    3   (call core.typeof %₂)
+    3   (call core._typeof_captured_variable %₂)
     4   (call core.apply_type %₁ %₃)
     5   static_parameter₁
     6   (new %₄ %₅)
@@ -337,7 +337,7 @@ end
     slots: [slot₁/#self#(!read) slot₂/x slot₃/g(single_assign) slot₄/y(single_assign)]
     1   (= slot₄/y (call core.Box))
     2   TestMod.#f#g##3
-    3   (call core.typeof slot₂/x)
+    3   (call core._typeof_captured_variable slot₂/x)
     4   (call core.apply_type %₂ %₃)
     5   slot₄/y
     6   (new %₄ slot₂/x %₅)
@@ -368,8 +368,8 @@ end
 slots: [slot₁/#self#(!read) slot₂/y slot₃/h_nest(single_assign)]
 1   TestMod.#f_nest#g_nest#h_nest##0
 2   (call core.getfield slot₁/#self# :x)
-3   (call core.typeof %₂)
-4   (call core.typeof slot₂/y)
+3   (call core._typeof_captured_variable %₂)
+4   (call core._typeof_captured_variable slot₂/y)
 5   (call core.apply_type %₁ %₃ %₄)
 6   (call core.getfield slot₁/#self# :x)
 7   (new %₅ %₆ slot₂/y)
@@ -660,7 +660,7 @@ end
 14  (call JuliaLowering.eval_closure_type TestMod :##f_kw_closure#0##0 %₁₂ %₁₃)
 15  latestworld
 16  TestMod.##f_kw_closure#0##0
-17  (call core.typeof slot₁/y)
+17  (call core._typeof_captured_variable slot₁/y)
 18  (call core.apply_type %₁₆ %₁₇)
 19  (new %₁₈ slot₁/y)
 20  slot₂/#f_kw_closure#0
@@ -807,7 +807,7 @@ end
     3   (call %₂ "hello")
     4   (= slot₃/y 1)
     5   TestMod.#f_after_if#->##0
-    6   (call core.typeof slot₃/y)
+    6   (call core._typeof_captured_variable slot₃/y)
     7   (call core.apply_type %₅ %₆)
     8   (new %₇ slot₃/y)
     9   (return %₈)
@@ -856,7 +856,7 @@ end
     8   slot₄/if_val
     9   (= slot₃/y %₈)
     10  TestMod.#f_ternary#->##0
-    11  (call core.typeof slot₃/y)
+    11  (call core._typeof_captured_variable slot₃/y)
     12  (call core.apply_type %₁₀ %₁₁)
     13  (new %₁₂ slot₃/y)
     14  (return %₁₃)
@@ -913,7 +913,7 @@ end
     15  slot₂/x
     16  (= slot₃/y %₁₅)
     17  TestMod.#f_or_guard#->##0
-    18  (call core.typeof slot₃/y)
+    18  (call core._typeof_captured_variable slot₃/y)
     19  (call core.apply_type %₁₇ %₁₈)
     20  (new %₁₉ slot₃/y)
     21  (return %₂₀)
@@ -956,7 +956,7 @@ end
     2   (= slot₃/x 1)
     3   TestMod.#f_arg_reassign#->##0
     4   slot₃/x
-    5   (call core.typeof %₄)
+    5   (call core._typeof_captured_variable %₄)
     6   (call core.apply_type %₃ %₅)
     7   slot₃/x
     8   (new %₆ %₇)
@@ -1038,7 +1038,7 @@ end
     slots: [slot₁/#self#(!read) slot₂/x(single_assign)]
     1   (= slot₂/x 1)
     2   TestMod.#f_local_no_box#->##0
-    3   (call core.typeof slot₂/x)
+    3   (call core._typeof_captured_variable slot₂/x)
     4   (call core.apply_type %₂ %₃)
     5   (new %₄ slot₂/x)
     6   (return %₅)
@@ -1089,7 +1089,7 @@ end
     9   slot₃/tmp
     10  (= slot₂/x %₉)
     11  TestMod.#f_typed_local_no_box#->##0
-    12  (call core.typeof slot₂/x)
+    12  (call core._typeof_captured_variable slot₂/x)
     13  (call core.apply_type %₁₁ %₁₂)
     14  (new %₁₃ slot₂/x)
     15  (return %₁₄)

--- a/JuliaLowering/test/exceptions_ir.jl
+++ b/JuliaLowering/test/exceptions_ir.jl
@@ -249,12 +249,12 @@ end
 12  (gotoifnot %₁₁ label₁₄)
 13  (call top.rethrow)
 14  (goto label₁)
-15  (= slot₁/loop_exit_result core.nothing)
-16  (isdefined slot₁/loop_exit_result)
+15  (= slot₁/loop-exit_result core.nothing)
+16  (isdefined slot₁/loop-exit_result)
 17  (gotoifnot %₁₆ label₁₉)
 18  (goto label₂₀)
-19  (= slot₁/loop_exit_result core.nothing)
-20  slot₁/loop_exit_result
+19  (= slot₁/loop-exit_result core.nothing)
+20  slot₁/loop-exit_result
 21  (return %₂₀)
 
 ########################################

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -1842,7 +1842,7 @@ end
     slots: [slot₁/#self#(!read) slot₂/__context__(!read) slot₃/#self#(nospecialize,!read) slot₄/x(nospecialize,!read) slot₅/y(nospecialize,!read)]
     1   (call JuliaLowering.interpolate_ast SyntaxTree (inert_syntaxtree (block (= maybe_gen_stuff (call some_gen_stuff x y)))))
     2   (call core.tuple %₁)
-    3   (call JuliaLowering.interpolate_ast SyntaxTree (inert_syntaxtree (block (block (= nongen_stuff (call bothgen x y)) ($ (block (call JuliaLowering.interpolate_ast SyntaxTree (inert_syntaxtree (block (= maybe_gen_stuff (call some_gen_stuff x y))))))) (tuple-p nongen_stuff maybe_gen_stuff)))) %₂)
+    3   (call JuliaLowering.interpolate_ast SyntaxTree (inert_syntaxtree (block (= nongen_stuff (call bothgen x y)) ($ (block (call JuliaLowering.interpolate_ast SyntaxTree (inert_syntaxtree (block (= maybe_gen_stuff (call some_gen_stuff x y))))))) (tuple-p nongen_stuff maybe_gen_stuff))) %₂)
     4   (return %₃)
 12  latestworld
 13  TestMod.f_partially_generated

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -1842,7 +1842,7 @@ end
     slots: [slot₁/#self#(!read) slot₂/__context__(!read) slot₃/#self#(nospecialize,!read) slot₄/x(nospecialize,!read) slot₅/y(nospecialize,!read)]
     1   (call JuliaLowering.interpolate_ast SyntaxTree (inert_syntaxtree (block (= maybe_gen_stuff (call some_gen_stuff x y)))))
     2   (call core.tuple %₁)
-    3   (call JuliaLowering.interpolate_ast SyntaxTree (inert_syntaxtree (block (= nongen_stuff (call bothgen x y)) ($ (block (call JuliaLowering.interpolate_ast SyntaxTree (inert_syntaxtree (block (= maybe_gen_stuff (call some_gen_stuff x y))))))) (tuple-p nongen_stuff maybe_gen_stuff))) %₂)
+    3   (call JuliaLowering.interpolate_ast SyntaxTree (inert_syntaxtree (block (block (= nongen_stuff (call bothgen x y)) ($ (block (call JuliaLowering.interpolate_ast SyntaxTree (inert_syntaxtree (block (= maybe_gen_stuff (call some_gen_stuff x y))))))) (tuple-p nongen_stuff maybe_gen_stuff)))) %₂)
     4   (return %₃)
 12  latestworld
 13  TestMod.f_partially_generated

--- a/JuliaLowering/test/loops_ir.jl
+++ b/JuliaLowering/test/loops_ir.jl
@@ -12,12 +12,12 @@ end
 5   TestMod.body1
 6   TestMod.body2
 7   (goto label₁)
-8   (= slot₁/loop_exit_result core.nothing)
-9   (isdefined slot₁/loop_exit_result)
+8   (= slot₁/loop-exit_result core.nothing)
+9   (isdefined slot₁/loop-exit_result)
 10  (gotoifnot %₉ label₁₂)
 11  (goto label₁₃)
-12  (= slot₁/loop_exit_result core.nothing)
-13  slot₁/loop_exit_result
+12  (= slot₁/loop-exit_result core.nothing)
+13  slot₁/loop-exit_result
 14  (return %₁₃)
 
 ########################################
@@ -32,12 +32,12 @@ end
 4   (gotoifnot %₃ label₇)
 5   TestMod.body
 6   (goto label₁)
-7   (= slot₁/loop_exit_result core.nothing)
-8   (isdefined slot₁/loop_exit_result)
+7   (= slot₁/loop-exit_result core.nothing)
+8   (isdefined slot₁/loop-exit_result)
 9   (gotoifnot %₈ label₁₁)
 10  (goto label₁₂)
-11  (= slot₁/loop_exit_result core.nothing)
-12  slot₁/loop_exit_result
+11  (= slot₁/loop-exit_result core.nothing)
+12  slot₁/loop-exit_result
 13  (return %₁₂)
 
 ########################################
@@ -58,12 +58,12 @@ end
 6   (goto label₈)
 7   TestMod.body3
 8   (goto label₁)
-9   (= slot₁/loop_exit_result core.nothing)
-10  (isdefined slot₁/loop_exit_result)
+9   (= slot₁/loop-exit_result core.nothing)
+10  (isdefined slot₁/loop-exit_result)
 11  (gotoifnot %₁₀ label₁₃)
 12  (goto label₁₄)
-13  (= slot₁/loop_exit_result core.nothing)
-14  slot₁/loop_exit_result
+13  (= slot₁/loop-exit_result core.nothing)
+14  slot₁/loop-exit_result
 15  (return %₁₄)
 
 ########################################
@@ -92,12 +92,12 @@ end
 18  (goto label₂₀)
 19  (= slot₄/if_val core.nothing)
 20  slot₄/if_val
-21  (= slot₃/loop_exit_result %₂₀)
-22  (isdefined slot₃/loop_exit_result)
+21  (= slot₃/loop-exit_result %₂₀)
+22  (isdefined slot₃/loop-exit_result)
 23  (gotoifnot %₂₂ label₂₅)
 24  (goto label₂₆)
-25  (= slot₃/loop_exit_result core.nothing)
-26  slot₃/loop_exit_result
+25  (= slot₃/loop-exit_result core.nothing)
+26  slot₃/loop-exit_result
 27  (return %₂₆)
 
 ########################################
@@ -143,12 +143,12 @@ end
 35  (goto label₃₇)
 36  (= slot₇/if_val core.nothing)
 37  slot₇/if_val
-38  (= slot₆/loop_exit_result %₃₇)
-39  (isdefined slot₆/loop_exit_result)
+38  (= slot₆/loop-exit_result %₃₇)
+39  (isdefined slot₆/loop-exit_result)
 40  (gotoifnot %₃₉ label₄₂)
 41  (goto label₄₃)
-42  (= slot₆/loop_exit_result core.nothing)
-43  slot₆/loop_exit_result
+42  (= slot₆/loop-exit_result core.nothing)
+43  slot₆/loop-exit_result
 44  (return %₄₃)
 
 ########################################


### PR DESCRIPTION
Misc:
- Use `_typeof_captured_variable` in closure conversion
- Don't erase `ex.toplevel_pure` in scope resolution
- Add and use `flatten_blocks` to make debug output more readable.
- Remove zero-argument return from the validator and a new macro (has never been
  an accepted form in flisp lowering).

Fixups to #60481 and #61016
- Consistently use symbolic labels in break/continue instead of identifiers
- Symbolic labels don't participate in scope resolution, so don't need to be
  special-cased
- Clean up break/continue desugaring.  Claude seems quite confused as to what
  forms can show up where.  I can sympathize, and will hopefully have that
  written down sometime this week.
- Remove provenance-preserving `@label` macro---I could fix the mistakes, it's
  just certain that we need everything to work without them, and having them was
  masking some problems.
  - Naming it `loop-cont`/`loop-exit` in the normal macro and
    `loop_cont`/`loop_exit` was pretty devious

For future reference, these are the invariants we have and want to maintain:
- The expansion of any macro in syntax_macros.jl should be equal to
  `expr_to_est(equivalent_old_expansion)` (modulo scope layer nonsense)
- The result of Expr-macro expansion should always be lowerable by
  JuliaLowering
  - The reverse is nearly true, but requires implementation of
    scope_layer/name-mangling equivalence
- If we see a tree in desugaring, we know it passed `valid_st1` and went through
  `est_to_dst`; no other forms are possible
