### PR TITLE
Speed up InteractiveUtils.subtypes by not performing an intermediary sort [NFC]

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -16,7 +16,7 @@ export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, 
 
 import Base.Docs.apropos
 
-using Base: unwrap_unionall, rewrap_unionall, isdeprecated, Bottom, summarysize,
+using Base: unsorted_names, unwrap_unionall, rewrap_unionall, isdeprecated, Bottom, summarysize,
     signature_type, format_bytes
 using Base.Libc
 using Markdown
@@ -263,7 +263,7 @@ function _subtypes_in!(mods::Array, @nospecialize(x::Type))
     while !isempty(mods)
         m = pop!(mods)
         xt = xt::DataType
-        for s in names(m, all = true)
+        for s in unsorted_names(m, all = true)
             if !isdeprecated(m, s) && isdefinedglobal(m, s)
                 t = getglobal(m, s)
                 dt = isa(t, UnionAll) ? unwrap_unionall(t) : t


### PR DESCRIPTION
`InteractiveUtils.subtypes` currently spends about half the time sorting names in environments where many modules are loaded and many types are present. Revise's new struct revision logic heavily relies on type enumeration and would benefit from some optimizations of this function.

~~While the output of `subtypes` must be sorted as per the docstring of that function,~~ We can avoid some intermediate sorting because we end up sorting at the bottom anyway. With this simple fix of using `unsorted_names` instead of `names`, I get a speed up from 20s to 14s in this example https://github.com/timholy/Revise.jl/issues/988#issuecomment-3965551279 .
Since this change doesn't affect the obervable behavior of the function beyond runtime, it seems like an easy win.

A variant that sidesteps the final `sortperm!` could shave off another 2s; which suggests we may want to expose an `unsorted_subtypes` variant as well. I'll leave that latter change up for discussion and a potential second PR.