### PR TITLE
REPL: Add OSC parsing to the keymap

### DIFF
--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -208,6 +208,7 @@ let
             precompile(Tuple{typeof(Base.setindex!), Base.Dict{Any, Any}, Any, Int})
             precompile(Tuple{typeof(Base.delete!), Base.Set{Any}, String})
             precompile(Tuple{typeof(Base.:(==)), Char, String})
+            precompile(Tuple{typeof(Base.convert), Type{Array{String, 1}}, Array{String, 1}})
         finally
             ccall(:jl_tag_newly_inferred_disable, Cvoid, ())
         end


### PR DESCRIPTION
This is prepratory work for #61151 and #59958. The key problem is that when we issue informational queries to the terminal emulator, we don't really have any way of knowing when they'll come back. There could be arbitrary amount of actual user input before or after. Thus, any code that would attempt to read from the terminal inline to read OSC responses faces the problem of accidentally getting user input and likewise, the REPL may see delayed OSC responses that are not inteded for it. To avoid all that complication, just put the REPL in charge of OSC response processing. The idea here is that at some point something issues the OSC query (possibly at startup) and whenever the response comes in, the REPL will just process it as if it was user input. This PR intentionally does not define a query interface, which is delagated to the follow on PRs that actually make use of this information.

Example:
```
julia> write(stdout, "\e[c")
3

julia> 52 in Base.active_repl.mistate.terminal_properties.da1
true
```

Written by Claude.