### PR TITLE
allow transform function as first argument to `replace`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,9 @@ New library functions
 New library features
 --------------------
 
+* `replace` for strings now supports passing the replacement function as the first argument,
+  enabling `do`-block syntax: `replace(f, s, pat)` is equivalent to `replace(s, pat => f)` ([#24598]).
+
 * `IOContext` supports a new boolean `hexunsigned` option that allows for
   printing unsigned integers in decimal instead of hexadecimal ([#60267]).
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -1105,6 +1105,7 @@ end
 
 """
     replace([io::IO], s::AbstractString, pat=>r, [pat2=>r2, ...]; [count::Integer])
+    replace(f, [io::IO], s::AbstractString, pat; [count::Integer])
 
 Search for the given pattern `pat` in `s`, and replace each occurrence with `r`.
 If `count` is provided, replace at most `count` occurrences.
@@ -1152,6 +1153,22 @@ julia> replace("The quick foxes run quickly.", r"fox(es)?" => s"bus\\1")
 julia> replace("abcabc", "a" => "b", "b" => "c", r".+" => "a")
 "bca"
 ```
+
+The replacement `r` can also be passed as a function as the first argument to
+enable `do`-block syntax:
+
+```jldoctest
+julia> replace(uppercase, "hello world", r"\\w+")
+"HELLO WORLD"
+
+julia> replace("Hello, world.", r"\\w+") do word
+           string(length(word))
+       end
+"5, 6."
+```
+
+!!! compat "Julia 1.14"
+    The `replace(f, s, pat)` form requires Julia 1.14.
 """
 replace(io::IO, s::AbstractString, pat_f::Pair...; count=typemax(Int)) =
     _replace_(io, String(s), pat_f, Int(count))
@@ -1160,7 +1177,11 @@ replace(s::AbstractString, pat_f::Pair...; count=typemax(Int)) =
     _replace_(String(s), pat_f, Int(count))
 
 
-# TODO: allow transform as the first argument to replace?
+replace(f::Callable, s::AbstractString, pat; count::Integer=typemax(Int)) =
+    replace(s, pat => f; count)
+
+replace(f::Callable, io::IO, s::AbstractString, pat; count::Integer=typemax(Int)) =
+    replace(io, s, pat => f; count)
 
 # hex <-> bytes conversion
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -1164,7 +1164,7 @@ julia> replace(uppercase, "hello world", r"\\w+")
 julia> replace("Hello, world.", r"\\w+") do word
            string(length(word))
        end
-"5, 6."
+"5, 5."
 ```
 
 !!! compat "Julia 1.14"

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -1177,10 +1177,10 @@ replace(s::AbstractString, pat_f::Pair...; count=typemax(Int)) =
     _replace_(String(s), pat_f, Int(count))
 
 
-replace(f::Callable, s::AbstractString, pat; count::Integer=typemax(Int)) =
+replace(f, s::AbstractString, pat; count::Integer=typemax(Int)) =
     replace(s, pat => f; count)
 
-replace(f::Callable, io::IO, s::AbstractString, pat; count::Integer=typemax(Int)) =
+replace(f, io::IO, s::AbstractString, pat; count::Integer=typemax(Int)) =
     replace(io, s, pat => f; count)
 
 # hex <-> bytes conversion

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -450,6 +450,18 @@ end
             rm(tempfile, force=true)
         end
     end
+
+    # Issue #24598: function-first replace for do-block syntax
+    @test replace(uppercase, "foo bar", r"\w+") == "FOO BAR"
+    @test replace(uppercase, "foo bar", r"\w+", count=1) == "FOO bar"
+    @test replace(uppercase, "abc", 'b') == "aBc"
+    @test replace("Hello, world.", r"\w+") do word
+        string(length(word))
+    end == "5, 6."
+    let buf = IOBuffer()
+        replace(uppercase, buf, "foo bar", r"\w+")
+        @test String(take!(buf)) == "FOO BAR"
+    end
 end
 
 @testset "replace many" begin

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -457,7 +457,7 @@ end
     @test replace(uppercase, "abc", 'b') == "aBc"
     @test replace("Hello, world.", r"\w+") do word
         string(length(word))
-    end == "5, 6."
+    end == "5, 5."
     let buf = IOBuffer()
         replace(uppercase, buf, "foo bar", r"\w+")
         @test String(take!(buf)) == "FOO BAR"


### PR DESCRIPTION
Adds `replace(f, s, pat; count)` and `replace(f, io, s, pat; count)` methods that enable `do`-block syntax for string replacement.
Fixes #24598