### PR TITLE
Compiler: Replace any() closure in compileable_specialization with explicit loop to avoid invalidation

### DIFF
--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -770,7 +770,7 @@ end
 function compileable_specialization(code::Union{MethodInstance,CodeInstance}, effects::Effects,
     et::InliningEdgeTracker, @nospecialize(info::CallInfo), state::InliningState)
     mi = code isa CodeInstance ? code.def : code
-    mi_invoke = mi
+    mi_invoke = mi::MethodInstance
     method, atype, sparams = mi.def::Method, mi.specTypes, mi.sparam_vals
     if OptimizationParams(state.interp).compilesig_invokes
         new_atype = get_compileable_sig(method, atype, sparams)

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -786,7 +786,7 @@ function compileable_specialization(code::Union{MethodInstance,CodeInstance}, ef
         # If this caller does not want us to optimize calls to use their
         # declared compilesig, then it is also likely they would handle sparams
         # incorrectly if there were any unknown typevars, so we conservatively return nothing
-        if any(@nospecialize(t)->isa(t, TypeVar), mi.sparam_vals)
+        if _svec_any_typevar(mi.sparam_vals)
             return nothing
         end
     end
@@ -800,6 +800,13 @@ function compileable_specialization(code::Union{MethodInstance,CodeInstance}, ef
     end
     add_inlining_edge!(et, code) # to the code and edges
     return InvokeCase(code, effects, info)
+end
+
+function _svec_any_typevar(sv::SimpleVector)
+    for i in 1:length(sv)
+        isa(sv[i], TypeVar) && return true
+    end
+    return false
 end
 
 struct InferredCode


### PR DESCRIPTION
## Summary

Replace `any(@nospecialize(t)->isa(t, TypeVar), mi.sparam_vals)` in
`compileable_specialization` with an explicit `_svec_any_typevar` helper
to eliminate 531 downstream invalidations.

## Problem

The closure-based `any` call creates a MethodInstance
`any(::compileable_specialization##0##1, ::AbstractArray)` in the sysimage
with a widened `::AbstractArray` type parameter. Because `compileable_specialization`
is compiled with abstract `CallInfo` types, inference widens the array argument.

This MI gets invalidated whenever **any** package defines `any(f, ::AbstractArraySubtype)`,
causing a cascade of **531 downstream invalidations** through the Compiler's inlining
system. This is the single largest source of `any`-related invalidation in the sysimage.

### How I found this

```julia
using SnoopCompile.SnoopCompileCore
invs = @snoop_invalidations using RecursiveArrayTools
using SnoopCompile, AbstractTrees
trees = invalidation_trees(invs)
# 531 children from: any(::Compiler.compileable_specialization##0##1, ::AbstractArray)
```

Tracing the widened MI:
```julia
m = which(any, Tuple{Function, AbstractArray})
for spec in Base.specializations(m)
    if !isnothing(spec) && spec.specTypes.parameters[3] === AbstractArray
        println(spec)
        # → any(::Compiler.compileable_specialization##0##1, ::AbstractArray)
        # Backedges: compileable_specialization with 4 CallInfo specializations
    end
end
```

## Fix

```diff
-        if any(@nospecialize(t)->isa(t, TypeVar), mi.sparam_vals)
+        if _svec_any_typevar(mi.sparam_vals)

+function _svec_any_typevar(sv::SimpleVector)
+    for i in 1:length(sv)
+        isa(sv[i], TypeVar) && return true
+    end
+    return false
+end
```

The explicit loop is functionally identical but avoids the `any` dispatch path,
so no closure type is created and no widened MI appears in the sysimage.

## Test plan

- [x] `make fix-whitespace` passes
- [ ] CI: Compiler tests pass (change is behaviorally equivalent)

This PR was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)