### PR TITLE
RFC: Tweak Ctrl-R history position behavior

### DIFF
--- a/stdlib/REPL/src/History/display.jl
+++ b/stdlib/REPL/src/History/display.jl
@@ -19,7 +19,7 @@ STATES = Pair{SelectorState, SelectorState}[]
 
 const LABELS = (
     gatherdivider = S"{italic:carried over}",
-    preview_suggestion = S"Ctrl+S to save",
+    preview_suggestion = S"Alt+S to save",
     help_prompt = S"{REPL_History_search_hint,shadow:try {REPL_History_search_hint,(slant=normal):?} for help} ",
 )
 
@@ -38,9 +38,8 @@ Uses ANSI sync sequences to update only changed regions between
 function redisplay_all(io::IO, oldstate::SelectorState, newstate::SelectorState, pstate::REPL.LineEdit.PromptState;
                        buf::IOContext{IOBuffer} = IOContext(IOBuffer(), io),
                        dupcounts::Union{Nothing, Dict{Tuple{Symbol,String}, Int}} = nothing,
-                       expanded_key::Union{Nothing, Tuple{Symbol,String}} = nothing,
-                       expanded_entries::Vector{HistEntry} = HistEntry[],
-                       expanded_hover::Int = 0)
+                       instance_key::Union{Nothing, Tuple{Symbol,String}} = nothing,
+                       instance_offset::Int = 0)
     # Calculate dimensions
     oldrows = componentrows(oldstate)
     newrows = componentrows(newstate)
@@ -67,14 +66,13 @@ function redisplay_all(io::IO, oldstate::SelectorState, newstate::SelectorState,
             oldstate.scroll != newstate.scroll ||
             oldstate.selection.active != newstate.selection.active ||
             oldstate.hover != newstate.hover ||
-            oldstate.filter != newstate.filter ||
-            !isnothing(expanded_key)
+            oldstate.filter != newstate.filter
         refresh_preview = refresh_cands ||
             oldstate.selection.gathered != newstate.selection.gathered ||
             gethover(oldstate) != gethover(newstate)
         if refresh_cands
             redisplay_candidates(buf, oldstate, oldrows.candidates, newstate, newrows.candidates;
-                                 dupcounts, expanded_key, expanded_entries, expanded_hover)
+                                 dupcounts, instance_key, instance_offset)
             currentrow += newrows.candidates
         end
         if refresh_preview
@@ -374,9 +372,8 @@ unchanged lines remain.
 """
 function redisplay_candidates(io::IO, oldstate::SelectorState, oldrows::Int, newstate::SelectorState, newrows::Int;
                               dupcounts::Union{Nothing, Dict{Tuple{Symbol,String}, Int}} = nothing,
-                              expanded_key::Union{Nothing, Tuple{Symbol,String}} = nothing,
-                              expanded_entries::Vector{HistEntry} = HistEntry[],
-                              expanded_hover::Int = 0)
+                              instance_key::Union{Nothing, Tuple{Symbol,String}} = nothing,
+                              instance_offset::Int = 0)
     danglingdivider = false
     if oldstate.scroll < 0 && newstate.scroll == 0
         newrows -= 1
@@ -388,7 +385,7 @@ function redisplay_candidates(io::IO, oldstate::SelectorState, oldrows::Int, new
     # Redisplay active candidates
     update_candidates(io, oldcands.active, newcands.active,
                       !samefilter || oldstate.scroll == 0 && !isempty(oldstate.selection.gathered);
-                      dupcounts, expanded_key, expanded_entries, expanded_hover)
+                      dupcounts, instance_key, instance_offset)
     # Redisplay gathered candidates
     gathchange = oldrows != newrows || length(oldcands.gathered.entries) != length(newcands.gathered.entries)
     if isempty(newcands.gathered.entries) && !danglingdivider
@@ -412,9 +409,8 @@ Only changes are printed, and exactly `length(newcands.entries)` lines are print
 """
 function update_candidates(io::IO, oldcands::CandsState, newcands::CandsState, force::Bool = false;
                            dupcounts::Union{Nothing, Dict{Tuple{Symbol,String}, Int}} = nothing,
-                           expanded_key::Union{Nothing, Tuple{Symbol,String}} = nothing,
-                           expanded_entries::Vector{HistEntry} = HistEntry[],
-                           expanded_hover::Int = 0)
+                           instance_key::Union{Nothing, Tuple{Symbol,String}} = nothing,
+                           instance_offset::Int = 0)
     totalrows = newcands.rows
     thisline = 1
     for (i, (old, new)) in enumerate(zip(oldcands.entries, newcands.entries))
@@ -422,22 +418,18 @@ function update_candidates(io::IO, oldcands::CandsState, newcands::CandsState, f
         dc = if !isnothing(dupcounts)
             get(dupcounts, (new.mode, new.content), 1)
         else 1 end
+        inst = if !isnothing(instance_key) && (new.mode, new.content) == instance_key
+            instance_offset
+        else 0 end
         oldsel, newsel = i ∈ oldcands.selected, i ∈ newcands.selected
         oldhov, newhov = i == oldcands.hover, i == newcands.hover
-        if !force && old == new && oldsel == newsel && oldhov == newhov && oldcands.width == newcands.width && dc <= 1
+        if !force && old == new && oldsel == newsel && oldhov == newhov && oldcands.width == newcands.width && dc <= 1 && inst == 0
             println(io)
         else
             print_candidate(io, newcands.search, new, newcands.width;
-                            selected = newsel, hover = newhov, dupcount = dc)
+                            selected = newsel, hover = newhov, dupcount = dc, instance = inst)
         end
         thisline += 1
-        if !isnothing(expanded_key) && (new.mode, new.content) == expanded_key
-            for (j, sub) in enumerate(expanded_entries)
-                thisline > totalrows && break
-                print_expanded_entry(io, sub, newcands.width; hover = j == expanded_hover)
-                thisline += 1
-            end
-        end
     end
     for (i, new) in enumerate(newcands.entries)
         i <= length(oldcands.entries) && continue
@@ -445,17 +437,13 @@ function update_candidates(io::IO, oldcands::CandsState, newcands::CandsState, f
         dc = if !isnothing(dupcounts)
             get(dupcounts, (new.mode, new.content), 1)
         else 1 end
+        inst = if !isnothing(instance_key) && (new.mode, new.content) == instance_key
+            instance_offset
+        else 0 end
         print_candidate(io, newcands.search, new, newcands.width;
                         selected = i ∈ newcands.selected,
-                        hover = i == newcands.hover, dupcount = dc)
+                        hover = i == newcands.hover, dupcount = dc, instance = inst)
         thisline += 1
-        if !isnothing(expanded_key) && (new.mode, new.content) == expanded_key
-            for (j, sub) in enumerate(expanded_entries)
-                thisline > totalrows && break
-                print_expanded_entry(io, sub, newcands.width; hover = j == expanded_hover)
-                thisline += 1
-            end
-        end
     end
     for _ in thisline:totalrows
         print(io, "\e[K ", LIST_MARKERS.pending, '\n')
@@ -501,7 +489,7 @@ Render one history entry line with markers, mode hint, age, and highlighted cont
 Truncates and focuses on matches to fit `width`.
 """
 function print_candidate(io::IO, search::FilterSpec, cand::HistEntry, width::Int;
-                         selected::Bool, hover::Bool, dupcount::Int = 1)
+                         selected::Bool, hover::Bool, dupcount::Int = 1, instance::Int = 0)
     print(io, ' ', if selected
               LIST_MARKERS.selected
           elseif hover
@@ -511,7 +499,9 @@ function print_candidate(io::IO, search::FilterSpec, cand::HistEntry, width::Int
           end, ' ')
     age = humanage(floor(Int, ((now(UTC) - cand.date)::Millisecond).value ÷ 1000))
     agedec = S" {shadow,light,italic:$age}"
-    dupdec = if dupcount > 1
+    dupdec = if dupcount > 1 && instance > 0
+        S" {shadow:$(dupcount - instance)/$dupcount}"
+    elseif dupcount > 1
         S" {shadow:×$dupcount}"
     else
         S""
@@ -537,25 +527,6 @@ function print_candidate(io::IO, search::FilterSpec, cand::HistEntry, width::Int
         face!(dupdec, :region)
     end
     println(io, candstr, modehint, dupdec, agedec, ' ')
-end
-
-"""
-    print_expanded_entry(io::IO, entry::HistEntry, width::Int; hover::Bool)
-
-Render a single expanded sub-entry line showing its age and history index.
-"""
-function print_expanded_entry(io::IO, entry::HistEntry, width::Int; hover::Bool = false)
-    age = humanage(floor(Int, ((now(UTC) - entry.date)::Millisecond).value ÷ 1000))
-    marker = if hover
-        S" {REPL_History_search_selected:▸} "
-    else
-        S"   "
-    end
-    line = S"\e[K  $(marker){shadow,italic:$age ago} {shadow:│} {shadow:#$(entry.index)}"
-    if hover
-        face!(line, :region)
-    end
-    println(io, line)
 end
 
 """

--- a/stdlib/REPL/src/History/prompt.jl
+++ b/stdlib/REPL/src/History/prompt.jl
@@ -29,6 +29,27 @@ function select_keymap(events::Channel{Symbol})
             # Down Arrow
             "\e[B" => Event(events, :down),
             "^N" => Event(events, :down),
+            # Right Arrow (expand duplicates when at end of query)
+            "\e[C" => function(s, _...)
+                buf = REPL.LineEdit.buffer(s)
+                if position(buf) >= buf.size
+                    push!(events, :expand)
+                    :ignore
+                else
+                    REPL.LineEdit.edit_move_right(s)
+                    :ok
+                end
+            end,
+            "\eOC" => function(s, _...)
+                buf = REPL.LineEdit.buffer(s)
+                if position(buf) >= buf.size
+                    push!(events, :expand)
+                    :ignore
+                else
+                    REPL.LineEdit.edit_move_right(s)
+                    :ok
+                end
+            end,
             # Tab
             '\t' => Event(events, :tab),
             # Page up

--- a/stdlib/REPL/src/History/prompt.jl
+++ b/stdlib/REPL/src/History/prompt.jl
@@ -13,14 +13,14 @@ function (e::Event)(_...)
 end
 
 """
-    select_keymap(events::Channel{Symbol})
+    select_keymap(events::Channel{Symbol}, bounds::Channel{Bool})
 
 Build a REPL.LineEdit keymap that pushes symbols into `events`.
 
 Binds arrows, page keys, Tab, Ctrl-C/D/S, and meta-< / > to
 `Event` or `Returns` actions for driving the prompt loop.
 """
-function select_keymap(events::Channel{Symbol})
+function select_keymap(events::Channel{Symbol}, bounds::Channel{Bool})
     REPL.LineEdit.keymap([
         Dict{Any, Any}(
             # Up Arrow
@@ -29,26 +29,11 @@ function select_keymap(events::Channel{Symbol})
             # Down Arrow
             "\e[B" => Event(events, :down),
             "^N" => Event(events, :down),
-            # Right Arrow (expand duplicates when at end of query)
-            "\e[C" => function(s, _...)
-                buf = REPL.LineEdit.buffer(s)
-                if position(buf) >= buf.size
-                    push!(events, :expand)
-                    :ignore
-                else
-                    REPL.LineEdit.edit_move_right(s)
-                    :ok
-                end
-            end,
-            "\eOC" => function(s, _...)
-                buf = REPL.LineEdit.buffer(s)
-                if position(buf) >= buf.size
-                    push!(events, :expand)
-                    :ignore
-                else
-                    REPL.LineEdit.edit_move_right(s)
-                    :ok
-                end
+            # Ctrl-R: previous (older) duplicate instance
+            "^R" => function(s, _...)
+                push!(events, :previnstance)
+                take!(bounds) && REPL.LineEdit.beep(s)
+                :ignore
             end,
             # Tab
             '\t' => Event(events, :tab),
@@ -68,7 +53,14 @@ function select_keymap(events::Channel{Symbol})
             "^D" => Returns(:abort),
             "^G" => Returns(:abort),
             "\e\e" => Returns(:abort),
-            "^S" => Returns(:save),
+            # Ctrl-S: next (newer) duplicate instance
+            "^S" => function(s, _...)
+                push!(events, :nextinstance)
+                take!(bounds) && REPL.LineEdit.beep(s)
+                :ignore
+            end,
+            # Alt-S: save to clipboard/file
+            "\es" => Returns(:save),
             "^Y" => Returns(:copy),
         ),
         REPL.LineEdit.default_keymap,
@@ -76,19 +68,19 @@ function select_keymap(events::Channel{Symbol})
 end
 
 """
-    create_prompt(events::Channel{Symbol}, term)
+    create_prompt(events::Channel{Symbol}, bounds::Channel{Bool}, term)
 
 Initialize a custom REPL prompt tied to `events` using the existing `term`.
 
 Returns a tuple `(term, prompt, istate, pstate)` ready for
 input handling and display.
 """
-function create_prompt(events::Channel{Symbol}, term, prefix::String = "\e[90m")
+function create_prompt(events::Channel{Symbol}, bounds::Channel{Bool}, term, prefix::String = "\e[90m")
     prompt = REPL.LineEdit.Prompt(
         PROMPT_TEXT, # prompt
         prefix, "\e[0m", # prompt_prefix, prompt_suffix
         "", "", "", # output_prefix, output_prefix_prefix, output_prefix_suffix
-        select_keymap(events), # keymap_dict
+        select_keymap(events, bounds), # keymap_dict
         nothing, # repl
         REPL.LatexCompletions(), # complete
         _ -> true, # on_enter

--- a/stdlib/REPL/src/History/search.jl
+++ b/stdlib/REPL/src/History/search.jl
@@ -8,12 +8,13 @@ Launch the interactive REPL history search interface.
 Spawns prompt and display tasks, waits for user confirm or abort,
 and returns the final selection (if any).
 """
-function runsearch(histfile::HistoryFile, term, prefix::String = "\e[90m")
+function runsearch(histfile::HistoryFile, term, prefix::String = "\e[90m"; cur_idx::Int = 0)
     update!(histfile)
     events = Channel{Symbol}(Inf)
-    pspec = create_prompt(events, term, prefix)
+    bounds = Channel{Bool}(1)
+    pspec = create_prompt(events, bounds, term, prefix)
     ptask = @spawn runprompt!(pspec, events)
-    dtask = @spawn run_display!(pspec, events, histfile.records)
+    dtask = @spawn run_display!(pspec, events, bounds, histfile.records; cur_idx)
     wait(ptask)
     fullselection(fetch(dtask))
 end
@@ -49,7 +50,7 @@ Drive the display event loop until confirm or abort.
 Listens for navigation, edits, save, and abort events, re-filters history
 incrementally, and re-renders via `redisplay_all`.
 """
-function run_display!((; term, pstate), events::Channel{Symbol}, hist::Vector{HistEntry})
+function run_display!((; term, pstate), events::Channel{Symbol}, bounds::Channel{Bool}, hist::Vector{HistEntry}; cur_idx::Int = 0)
     # Output-related variables
     out = term.out_stream
     outsize = displaysize(out)
@@ -65,10 +66,10 @@ function run_display!((; term, pstate), events::Channel{Symbol}, hist::Vector{Hi
         key = (entry.mode, entry.content)
         hist_dupcounts[key] = get(hist_dupcounts, key, 0) + 1
     end
-    # Expand/collapse state for duplicate entries
-    expanded_key::Union{Nothing, Tuple{Symbol,String}} = nothing
-    expanded_entries = HistEntry[]
-    expanded_hover = 0
+    # Instance navigation state (for cycling through duplicates with Ctrl-R/Ctrl-S)
+    instance_offset = 0  # 0 = most recent instance, 1 = second most recent, etc.
+    instance_key::Union{Nothing, Tuple{Symbol,String}} = nothing
+    instance_entries = HistEntry[]  # all instances of the current key, sorted newest-first
     # Active duplicate counts for display (nothing when no filter, hist_dupcounts when filtering)
     active_dupcounts::Union{Nothing, Dict{Tuple{Symbol,String}, Int}} = nothing
     # Candidate cache
@@ -77,6 +78,21 @@ function run_display!((; term, pstate), events::Channel{Symbol}, hist::Vector{Hi
     cands_current = HistEntry[]
     cands_cond = ConditionSet{String}()
     cands_temp = HistEntry[]
+    # Position hover at cur_idx if provided, centered in the display
+    if cur_idx > 0
+        for (i, entry) in enumerate(hist)
+            if entry.index == cur_idx
+                newhover = length(hist) - i + 1
+                candrows = componentrows(state).candidates
+                newscroll = newhover - (candrows + 1) ÷ 2
+                newscroll = clamp(newscroll, max(0, newhover - candrows), newhover - 1)
+                state = SelectorState(
+                    state.area, state.query, state.filter, state.candidates,
+                    newscroll, state.selection, newhover)
+                break
+            end
+        end
+    end
     redisplay_all(out, EMPTY_STATE, state, pstate; buf)
     # Event loop
     while true
@@ -87,8 +103,9 @@ function run_display!((; term, pstate), events::Channel{Symbol}, hist::Vector{Hi
             return EMPTY_STATE
         elseif event === :confirm
             print(out, "\e[1G\e[J")
-            if expanded_hover > 0 && expanded_hover <= length(expanded_entries)
-                entry = expanded_entries[expanded_hover]
+            # If on a specific duplicate instance, return a state with that instance
+            if instance_offset > 0 && instance_offset < length(instance_entries)
+                entry = instance_entries[instance_offset + 1]
                 return SelectorState(state.area, state.query, state.filter,
                     [entry], 0, (active = Int[], gathered = HistEntry[]), 1)
             end
@@ -96,40 +113,18 @@ function run_display!((; term, pstate), events::Channel{Symbol}, hist::Vector{Hi
         elseif event === :clear
             print(out, "\e[H\e[2J")
             redisplay_all(out, EMPTY_STATE, state, pstate; buf,
-                          dupcounts=active_dupcounts, expanded_key, expanded_entries, expanded_hover)
+                          dupcounts=active_dupcounts, instance_key, instance_offset)
             continue
         elseif event === :redraw
             print(out, "\e[1G\e[J")
             redisplay_all(out, EMPTY_STATE, state, pstate; buf,
-                          dupcounts=active_dupcounts, expanded_key, expanded_entries, expanded_hover)
+                          dupcounts=active_dupcounts, instance_key, instance_offset)
             continue
         elseif event ∈ (:up, :down, :pageup, :pagedown)
-            # Handle navigation within expanded entries
-            if !isnothing(expanded_key) && expanded_hover > 0
-                if event ∈ (:up, :pageup)
-                    expanded_hover -= 1
-                    # expanded_hover=0 returns to the main entry
-                elseif expanded_hover < length(expanded_entries)
-                    expanded_hover += 1
-                else
-                    # Past the last expanded entry, exit and move down
-                    expanded_hover = 0
-                    prevstate, state = state, movehover(state, false, event === :pagedown)
-                end
-                redisplay_all(out, EMPTY_STATE, state, pstate; buf,
-                              dupcounts=active_dupcounts, expanded_key, expanded_entries, expanded_hover)
-                continue
-            end
-            # Check if we should enter expanded entries (on main entry, pressing down)
-            if !isnothing(expanded_key) && event ∈ (:down, :pagedown) && !isempty(expanded_entries)
-                hov = gethover(state)
-                if !isnothing(hov) && (hov.mode, hov.content) == expanded_key
-                    expanded_hover = 1
-                    redisplay_all(out, EMPTY_STATE, state, pstate; buf,
-                                  dupcounts=active_dupcounts, expanded_key, expanded_entries, expanded_hover)
-                    continue
-                end
-            end
+            # Reset instance offset when moving to a different entry
+            instance_offset = 0
+            instance_key = nothing
+            empty!(instance_entries)
             # Normal navigation
             prevstate, state = state, movehover(state, event ∈ (:up, :pageup), event ∈ (:pageup, :pagedown))
             @lock events begin
@@ -141,65 +136,104 @@ function run_display!((; term, pstate), events::Channel{Symbol}, hist::Vector{Hi
                 end
             end
             redisplay_all(out, prevstate, state, pstate; buf,
-                          dupcounts=active_dupcounts, expanded_key, expanded_entries, expanded_hover)
+                          dupcounts=active_dupcounts, instance_key, instance_offset)
             continue
         elseif event === :jumpfirst
+            instance_offset = 0
+            instance_key = nothing
+            empty!(instance_entries)
             prevstate = state
             state = SelectorState(
                 state.area, state.query, state.filter, state.candidates,
                 length(state.candidates) - componentrows(state).candidates,
                 state.selection, length(state.candidates))
             redisplay_all(out, prevstate, state, pstate; buf,
-                          dupcounts=active_dupcounts, expanded_key, expanded_entries, expanded_hover)
+                          dupcounts=active_dupcounts, instance_key, instance_offset)
             continue
         elseif event === :jumplast
+            instance_offset = 0
+            instance_key = nothing
+            empty!(instance_entries)
             prevstate = state
             state = SelectorState(
                 state.area, state.query, state.filter, state.candidates,
                 0, state.selection, 1)
             redisplay_all(out, prevstate, state, pstate; buf,
-                          dupcounts=active_dupcounts, expanded_key, expanded_entries, expanded_hover)
+                          dupcounts=active_dupcounts, instance_key, instance_offset)
             continue
         elseif event === :tab
             prevstate, state = state, toggleselection(state)
             redisplay_all(out, prevstate, state, pstate; buf,
-                          dupcounts=active_dupcounts, expanded_key, expanded_entries, expanded_hover)
+                          dupcounts=active_dupcounts, instance_key, instance_offset)
             continue
-        elseif event === :expand
-            # Only expand when dedup is active (non-empty query with filter)
-            if isnothing(active_dupcounts) || filter_idx != 0
-                continue
-            end
+        elseif event ∈ (:previnstance, :nextinstance)
             hovered = gethover(state)
-            if isnothing(hovered) || !isempty(state.selection.gathered)
+            if isnothing(hovered)
+                push!(bounds, true)
                 continue
             end
-            ekey = (hovered.mode, hovered.content)
-            dc = get(hist_dupcounts, ekey, 1)
-            if dc <= 1
-                continue
-            end
-            if expanded_key == ekey
-                # Collapse: already expanded, toggle off
-                expanded_key = nothing
-                empty!(expanded_entries)
-            else
-                # Expand: find all instances in hist, excluding the most recent
-                expanded_key = ekey
-                empty!(expanded_entries)
-                for entry in hist
-                    if entry.mode == ekey[1] && entry.content == ekey[2]
-                        push!(expanded_entries, entry)
+            hkey = (hovered.mode, hovered.content)
+            dc = get(hist_dupcounts, hkey, 1)
+            at_bounds = dc <= 1
+            if !at_bounds && isnothing(active_dupcounts)
+                # Non-dedup mode: physically navigate between duplicate entries
+                curpos = length(state.candidates) - state.hover + 1
+                target = nothing
+                if event === :previnstance
+                    for j in (curpos-1):-1:1
+                        cand = state.candidates[j]
+                        if cand.mode == hkey[1] && cand.content == hkey[2]
+                            target = j
+                            break
+                        end
+                    end
+                else
+                    for j in (curpos+1):length(state.candidates)
+                        cand = state.candidates[j]
+                        if cand.mode == hkey[1] && cand.content == hkey[2]
+                            target = j
+                            break
+                        end
                     end
                 end
-                if !isempty(expanded_entries)
-                    _, max_idx = findmax(e -> e.index, expanded_entries)
-                    deleteat!(expanded_entries, max_idx)
+                if isnothing(target)
+                    at_bounds = true
+                else
+                    newhover = length(state.candidates) - target + 1
+                    candrows = componentrows(state).candidates
+                    newscroll = newhover - (candrows + 1) ÷ 2
+                    newscroll = clamp(newscroll, max(0, newhover - candrows), newhover - 1)
+                    prevstate, state = state, SelectorState(
+                        state.area, state.query, state.filter, state.candidates,
+                        newscroll, state.selection, newhover)
+                    redisplay_all(out, prevstate, state, pstate; buf,
+                                  dupcounts=active_dupcounts, instance_key, instance_offset)
                 end
+            elseif !at_bounds
+                # Dedup mode: cycle through instance_offset
+                if instance_key != hkey
+                    instance_key = hkey
+                    empty!(instance_entries)
+                    for entry in Iterators.reverse(hist)  # newest first
+                        if entry.mode == hkey[1] && entry.content == hkey[2]
+                            push!(instance_entries, entry)
+                        end
+                    end
+                    instance_offset = 0
+                end
+                old_offset = instance_offset
+                if event === :previnstance
+                    instance_offset = min(instance_offset + 1, length(instance_entries) - 1)
+                else
+                    instance_offset = max(instance_offset - 1, 0)
+                end
+                if instance_offset == old_offset
+                    at_bounds = true
+                end
+                redisplay_all(out, EMPTY_STATE, state, pstate; buf,
+                              dupcounts=active_dupcounts, instance_key, instance_offset)
             end
-            expanded_hover = 0
-            redisplay_all(out, EMPTY_STATE, state, pstate; buf,
-                          dupcounts=active_dupcounts, expanded_key, expanded_entries, expanded_hover)
+            push!(bounds, at_bounds)
             continue
         elseif event === :edit
             @lock events begin
@@ -210,13 +244,25 @@ function run_display!((; term, pstate), events::Channel{Symbol}, hist::Vector{Hi
             query = REPL.LineEdit.input_string(pstate)
             if query === state.query
                 redisplay_all(out, state, state, pstate; buf,
-                              dupcounts=active_dupcounts, expanded_key, expanded_entries, expanded_hover)
+                              dupcounts=active_dupcounts, instance_key, instance_offset)
                 continue
             end
-            # Reset expanded state on query change
-            expanded_key = nothing
-            empty!(expanded_entries)
-            expanded_hover = 0
+            # Remember hovered entry and instance state before re-filtering.
+            prev_hovered = gethover(state)
+            prev_instance_key = instance_key
+            prev_instance_offset = instance_offset
+            prev_target_idx = if !isnothing(prev_hovered)
+                if instance_offset > 0 && prev_instance_key == (prev_hovered.mode, prev_hovered.content) &&
+                   instance_offset < length(instance_entries)
+                    instance_entries[instance_offset + 1].index
+                else
+                    prev_hovered.index
+                end
+            end
+            # Reset instance state on query change (restored below if same entry)
+            instance_offset = 0
+            instance_key = nothing
+            empty!(instance_entries)
             # Determine the conditions/filter spec
             cands_cond = ConditionSet(query)
             filter_spec = FilterSpec(cands_cond)
@@ -237,7 +283,7 @@ function run_display!((; term, pstate), events::Channel{Symbol}, hist::Vector{Hi
             # Show help?
             if query ∈ (FILTER_SHORTHELP_QUERY,FILTER_LONGHELP_QUERY)
                 redisplay_all(out, prevstate, state, pstate; buf,
-                          dupcounts=active_dupcounts, expanded_key, expanded_entries, expanded_hover)
+                          dupcounts=active_dupcounts, instance_key, instance_offset)
                 continue
             end
             # Parse the conditions and find a good candidate list
@@ -258,7 +304,7 @@ function run_display!((; term, pstate), events::Channel{Symbol}, hist::Vector{Hi
                 filter_idx = 0
                 active_dupcounts = nothing
             else
-                # Filtering needed, deduplicate results and show ×N badges
+                # Filtering needed, deduplicate results and show badges
                 active_dupcounts = hist_dupcounts
                 empty!(filter_seen)
                 filter_idx = filterchunkrev!(
@@ -270,8 +316,60 @@ function run_display!((; term, pstate), events::Channel{Symbol}, hist::Vector{Hi
                 cands_cachestate = addcache!(
                     cands_cache, cands_cachestate, cands_cond => state.candidates)
             end
+            # Preserve hover position.
+            # Try exact index match first (preserves position in non-dedup mode),
+            # then fall back to content match (for dedup where exact index may not exist).
+            if !isnothing(prev_hovered)
+                match_i = nothing
+                if !isnothing(prev_target_idx)
+                    for i in reverse(eachindex(state.candidates))
+                        if state.candidates[i].index == prev_target_idx
+                            match_i = i
+                            break
+                        end
+                    end
+                end
+                if isnothing(match_i)
+                    for i in reverse(eachindex(state.candidates))
+                        cand = state.candidates[i]
+                        if cand.mode == prev_hovered.mode && cand.content == prev_hovered.content
+                            match_i = i
+                            break
+                        end
+                    end
+                end
+                if !isnothing(match_i)
+                    matched = state.candidates[match_i]
+                    newhover = length(state.candidates) - match_i + 1
+                    new_candrows = componentrows(state).candidates
+                    newscroll = if length(state.candidates) == length(prevstate.candidates)
+                        # Same number of candidates: preserve visual row
+                        old_candrows = componentrows(prevstate).candidates
+                        old_visual = old_candrows + prevstate.scroll - prevstate.hover + 1
+                        old_visual - new_candrows + newhover - 1
+                    else
+                        # Candidate count changed: center the entry
+                        newhover - (new_candrows + 1) ÷ 2
+                    end
+                    newscroll = clamp(newscroll, max(0, newhover - new_candrows), newhover - 1)
+                    state = SelectorState(
+                        state.area, state.query, state.filter, state.candidates,
+                        newscroll, state.selection, newhover)
+                    # Restore instance cycling state if same entry is still hovered
+                    mkey = (matched.mode, matched.content)
+                    if prev_instance_key == mkey && prev_instance_offset > 0
+                        instance_key = mkey
+                        for entry in Iterators.reverse(hist)
+                            if entry.mode == mkey[1] && entry.content == mkey[2]
+                                push!(instance_entries, entry)
+                            end
+                        end
+                        instance_offset = min(prev_instance_offset, length(instance_entries) - 1)
+                    end
+                end
+            end
             redisplay_all(out, prevstate, state, pstate; buf,
-                          dupcounts=active_dupcounts, expanded_key, expanded_entries, expanded_hover)
+                          dupcounts=active_dupcounts, instance_key, instance_offset)
             continue
         elseif event === :copy
             content = strip(fullselection(state).text)
@@ -290,7 +388,7 @@ function run_display!((; term, pstate), events::Channel{Symbol}, hist::Vector{Hi
                 outsize, state.query, state.filter, state.candidates,
                 state.scroll, state.selection, state.hover)
             redisplay_all(out, prevstate, state, pstate; buf,
-                          dupcounts=active_dupcounts, expanded_key, expanded_entries, expanded_hover)
+                          dupcounts=active_dupcounts, instance_key, instance_offset)
         elseif filter_idx != 0
             append!(empty!(cands_temp), state.candidates)
             prevstate = SelectorState(
@@ -307,7 +405,7 @@ function run_display!((; term, pstate), events::Channel{Symbol}, hist::Vector{Hi
             length(state.candidates) != length(prevstate.candidates) &&
                 length(prevstate.candidates) - state.hover < outsize[1] &&
                 redisplay_all(out, prevstate, state, pstate; buf,
-                          dupcounts=active_dupcounts, expanded_key, expanded_entries, expanded_hover)
+                          dupcounts=active_dupcounts, instance_key, instance_offset)
         elseif isnothing(event)
             yield()
             sleep(0.01)

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2719,7 +2719,7 @@ function history_search(mistate::MIState)
     else
         mimode.prompt_prefix
     end
-    result = histsearch(hist.history, term, prefix)
+    result = histsearch(hist.history, term, prefix; cur_idx = hist.cur_idx)
     mimode = if isnothing(result.mode)
         mistate.current_mode
     else

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -102,7 +102,7 @@ include("docview.jl")
 include("History/History.jl")
 using .History
 
-histsearch(args...) = runsearch(args...)
+histsearch(args...; kwargs...) = runsearch(args...; kwargs...)
 
 include("Pkg_beforeload.jl")
 
@@ -999,7 +999,7 @@ function history_next(s::LineEdit.MIState, hist::REPLHistoryProvider,
     end
     m = history_move(s, hist, cur_idx+num, save_idx)
     if m === :ok
-        LineEdit.move_input_start(s)
+        LineEdit.move_input_end(s)
         return LineEdit.refresh_line(s)
     elseif m === :skip
         return history_next(s, hist, num+1, save_idx)

--- a/stdlib/REPL/test/history.jl
+++ b/stdlib/REPL/test/history.jl
@@ -281,7 +281,7 @@ end
                 empty!(results)
                 cset = ConditionSet("hello")
                 spec = FilterSpec(cset)
-                seen = Set{Tuple{Symbol,String}}()
+                seen = Dict{Tuple{Symbol,String}, Int}()
                 @test filterchunkrev!(results, entries, spec, seen) == 0
                 @test results == [entries[1], entries[7]]
                 empty!(results)
@@ -301,7 +301,7 @@ end
                 empty!(results)
                 cset = ConditionSet("=test")
                 spec = FilterSpec(cset)
-                seen = Set{Tuple{Symbol,String}}()
+                seen = Dict{Tuple{Symbol,String}, Int}()
                 @test filterchunkrev!(results, entries, spec, seen; maxresults = 2) == 5
                 @test results == [entries[6], entries[9]]
                 empty!(results)
@@ -315,7 +315,7 @@ end
                 empty!(results)
                 cset = ConditionSet("!hello ; !test;! cos")
                 spec = FilterSpec(cset)
-                seen = Set{Tuple{Symbol,String}}()
+                seen = Dict{Tuple{Symbol,String}, Int}()
                 @test filterchunkrev!(results, entries, spec, seen) == 0
                 @test results == [entries[2], entries[7], entries[8]]
             end
@@ -323,7 +323,7 @@ end
                 empty!(results)
                 cset = ConditionSet("`tc")
                 spec = FilterSpec(cset)
-                seen = Set{Tuple{Symbol,String}}()
+                seen = Dict{Tuple{Symbol,String}, Int}()
                 @test filterchunkrev!(results, entries, spec, seen) == 0
                 @test results == [entries[3]]
                 empty!(results)
@@ -337,7 +337,7 @@ end
                 empty!(results)
                 cset = ConditionSet("/^c.s\\b")
                 spec = FilterSpec(cset)
-                seen = Set{Tuple{Symbol,String}}()
+                seen = Dict{Tuple{Symbol,String}, Int}()
                 @test filterchunkrev!(results, entries, spec, seen) == 0
                 @test results == [entries[4], entries[5]]
             end
@@ -345,7 +345,7 @@ end
                 empty!(results)
                 cset = ConditionSet("shell>")
                 spec = FilterSpec(cset)
-                seen = Set{Tuple{Symbol,String}}()
+                seen = Dict{Tuple{Symbol,String}, Int}()
                 @test filterchunkrev!(results, entries, spec, seen) == 0
                 @test results == [entries[7]]
             end
@@ -353,7 +353,7 @@ end
                 empty!(results)
                 cset = ConditionSet("~cs")
                 spec = FilterSpec(cset)
-                seen = Set{Tuple{Symbol,String}}()
+                seen = Dict{Tuple{Symbol,String}, Int}()
                 @test filterchunkrev!(results, entries, spec, seen) == 0
                 @test results == entries[3:6]
             end
@@ -369,10 +369,10 @@ end
                     HistEntry(:julia, now(UTC), "println(\"hello\")", 6),  # duplicate
                     HistEntry(:julia, now(UTC), "tan(π/4)", 7),
                 ]
-                # When filtering with seen Set, duplicates are removed
+                # When filtering with seen Dict, duplicates are removed
                 cset = ConditionSet("cos")
                 spec = FilterSpec(cset)
-                seen = Set{Tuple{Symbol,String}}()
+                seen = Dict{Tuple{Symbol,String}, Int}()
                 @test filterchunkrev!(results, dup_entries, spec, seen) == 0
                 # Should only get unique entries matching the filter
                 # Since we iterate in reverse (7->1), we keep the most recent occurrence of each unique content


### PR DESCRIPTION
When we switched to the new ^R widget, we lost a very useful workflow of finding a particular history entry, going back to it and then executing the statements in order from that position by hitting the down key. There are three distinct issues:

1. The history searcher doesn't currently set the history index of the entry it restores at all.
2. Accepting an entry puts the cursor at the end, so UP is prefix search, not history navigation.
3. The searcher dedupllicates multiple entries, so you may not necessarily get the right one (this may seem niche, but it's not - I frequently want to go to the sequence *before* the last one, because I messed something up and had to restart the REPL and want to start clean).

This is a vibe-coded PR that tries to prototype solutions to all three. Since these things are a bit taste dependent, I have put no effort into implementation cleanup for the time being, while we decide on what we want the behavior to be.

Currently this PR does the following:

1. Fixes the lack of history entry restoration.
2. Always puts the cursor at the start of the line after accepting a history entry. For consistency, also put the cursor at the start of the line, when navigating to a previous history entry. We used to have a hidden modal that disabled prefix search if and only if the immediate previous thing you did was a history navigation. However, because this modal was invisible it was a frequent cause of confusion. This removes it. Fixes #24084.
3. Adds a xN tag for history entries with `N` duplicates. These can be expanded with RIGHT to select a particular entry in the history. If not selected, defaults to the most recent entry.

Fixes #60144