### PR TITLE
Fix sret alloca alignment to match callee's preferred type alignment

### DIFF
--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -1102,3 +1102,15 @@ function loop_preserve_any_ea(n)
 end
 loop_preserve_any_ea(10)
 @test (@allocated loop_preserve_any_ea(10)) == 0
+
+# sret parameters must have an alignment attribute (required by LLVM LangRef).
+@testset "sret alignment attribute" begin
+    struct SretAlignTest
+        a::Float32
+        b::Float32
+        c::Float32
+    end
+    @noinline f_srettest(x::Float32) = SretAlignTest(x, x+1, x+2)
+    ir = get_llvm(f_srettest, Tuple{Float32}, true, true, true)
+    @test occursin(r"sret\([^)]+\) align \d+", ir)
+end

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1311,6 +1311,7 @@ std::string generate_func_sig(const char *fname)
             if (!ctx->TargetTriple.isOSWindows()) {
                 // llvm used to use the old mingw ABI, skipping this marking works around that difference
                 retattrs.addStructRetAttr(lrt);
+                retattrs.addAlignmentAttr(Align(julia_alignment(rt)));
             }
             retattrs.addAttribute(Attribute::NoAlias);
             paramattrs.push_back(AttributeSet::get(LLVMCtx, retattrs));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8232,6 +8232,7 @@ jl_returninfo_t get_specsig_function(jl_codegen_output_t &out, Module *M, Value 
         param.addAttribute(Attribute::NoAlias);
         addNoCaptureAttr(param);
         param.addAttribute(Attribute::NoUndef);
+        param.addAlignmentAttr(Align(props.union_align));
         attrs.push_back(AttributeSet::get(M->getContext(), param));
         assert(fsig.size() == 1);
     }
@@ -8837,13 +8838,10 @@ static jl_llvm_functions_t
             const DataLayout &DL = jl_Module->getDataLayout();
             Type *RT = Arg->getParamStructRetType();
             TypeSize sz = DL.getTypeAllocSize(RT);
-            Align al = DL.getPrefTypeAlign(RT);
-            if (al > MAX_ALIGN)
-                al = Align(MAX_ALIGN);
             param.addAttribute(Attribute::NonNull);
             // The `dereferenceable` below does not imply `nonnull` for non addrspace(0) pointers.
             param.addDereferenceableAttr(sz);
-            param.addAlignmentAttr(al);
+            // Alignment is already set by get_specsig_function.
         }
         attrs[Arg->getArgNo()] = AttributeSet::get(Arg->getContext(), param); // function declaration attributes
     }


### PR DESCRIPTION
The caller's sret alloca used julia_alignment (union_align) which can be smaller than the LLVM preferred type alignment that the callee uses for its loads/stores. For example, a struct of floats gets julia_alignment=4 but the callee uses DL.getPrefTypeAlign()=8, generating 8-byte-aligned memcpy operations. On strict-alignment targets (NVPTX), the resulting misaligned access causes CUDA_ERROR_MISALIGNED_ADDRESS.

Fix by computing the sret type's preferred alignment from the callee's StructRet attribute and taking the max with union_align, matching the alignment the callee computes for its sret parameter.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/3034
Regression introduced in 1.12 by #55730