### PR TITLE
Remove undocumented internal method `Markdown.tohtml(::IO, ::MIME"image/svg+xml", ::Any)`

### DIFF
--- a/stdlib/Markdown/src/render/rich.jl
+++ b/stdlib/Markdown/src/render/rich.jl
@@ -14,10 +14,6 @@ function tohtml(io::IO, m::MIME"image/png", img)
     print(io, "\" />")
 end
 
-function tohtml(io::IO, m::MIME"image/svg+xml", img)
-    show(io, m, img)
-end
-
 # AbstractDisplay infrastructure
 
 function bestmime(val)


### PR DESCRIPTION
Fixes #61139 