### PR TITLE
[JuliaLowering] Better error messages, `jl_assert`

### DIFF
--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -1,50 +1,6 @@
 #-------------------------------------------------------------------------------
-# @chk: Basic AST structure checking tool
-#
-# Check a condition involving an expression, throwing a LoweringError if it
-# doesn't evaluate to true. Does some very simple pattern matching to attempt
-# to extract the expression variable from the left hand side.
-#
-# Forms:
-# @chk pred(ex)
-# @chk pred(ex) msg
-# @chk pred(ex) (msg_display_ex, msg)
-macro chk(cond, msg=nothing)
-    if Meta.isexpr(msg, :tuple)
-        ex = msg.args[1]
-        msg = msg.args[2]
-    else
-        ex = cond
-        while true
-            if ex isa Symbol
-                break
-            elseif ex.head == :call
-                ex = ex.args[2]
-            elseif ex.head == :ref
-                ex = ex.args[1]
-            elseif ex.head == :.
-                ex = ex.args[1]
-            elseif ex.head in (:(==), :(in), :<, :>)
-                ex = ex.args[1]
-            else
-                error("Can't analyze $cond")
-            end
-        end
-    end
-    quote
-        ex = $(esc(ex))
-        @assert ex isa SyntaxTree
-        ok = try
-            $(esc(cond))
-        catch
-            false
-        end
-        if !ok
-            throw(LoweringError(ex, $(isnothing(msg) ? "expected `$cond`" : esc(msg))))
-        end
-    end
-end
-
+# @jl_assert: Produce an internal error that surfaces one or more trees.
+# Example: `@jl_assert 1 === 1 (tree1, "message1"), tree2, (tree3, "message3")`
 if DEBUG
     macro jl_assert(cond, args...)
         usage = "usage: @jl_assert(condition, tree|(tree, message)...)"
@@ -478,8 +434,8 @@ end
 
 function extension_type(ex)
     @jl_assert kind(ex) == K"assert" ex
-    @chk numchildren(ex) >= 1
-    @chk kind(ex[1]) == K"Symbol"
+    @jl_assert numchildren(ex) >= 1 ex
+    @jl_assert kind(ex[1]) == K"Symbol" ex
     ex[1].name_val
 end
 

--- a/JuliaLowering/src/bindings.jl
+++ b/JuliaLowering/src/bindings.jl
@@ -136,7 +136,7 @@ end
 # Create a new local mutable binding or lambda argument
 function new_local_binding(ctx::AbstractLoweringContext, srcref, name;
                            kind=:local, kws...)
-    @assert kind === :local || kind === :argument
+    @jl_assert kind === :local || kind === :argument srcref
     nameref = newleaf(ctx, srcref, K"Identifier", name)
     b = _new_binding(ctx, nameref, name, kind; is_internal=true, kws...)
     lbindings = current_lambda_bindings(ctx)
@@ -183,7 +183,6 @@ LambdaBindings(self::IdTag = 0, scope_id::ScopeId = 0) =
     LambdaBindings(self, scope_id, Dict{IdTag,LambdaBindings}())
 
 function init_lambda_binding(bindings::LambdaBindings, b::BindingInfo, capt::Bool)
-    @assert !haskey(bindings.locals_capt, b.id)
     bindings.locals_capt[b.id] = capt
     b.lambda_id = bindings.scope_id
 end

--- a/JuliaLowering/src/bindings.jl
+++ b/JuliaLowering/src/bindings.jl
@@ -103,7 +103,7 @@ function _binding_id(id::Integer)
 end
 
 function _binding_id(ex::SyntaxTree)
-    @chk kind(ex) == K"BindingId"
+    @jl_assert kind(ex) == K"BindingId" ex
     ex.var_id
 end
 

--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -44,7 +44,7 @@ function captured_var_access(ctx, ex)
         ]
     else
         interpolations = cap_rewrite
-        @assert !isnothing(cap_rewrite)
+        @jl_assert !isnothing(cap_rewrite) ex
         if isempty(interpolations) || !is_same_identifier_like(interpolations[end], ex)
             push!(interpolations, ex)
         end
@@ -138,7 +138,7 @@ end
 
 function convert_global_assignment(ctx, ex, var, rhs0)
     binfo = get_binding(ctx, var)
-    @assert binfo.kind == :global
+    @jl_assert binfo.kind == :global ex var
     stmts = SyntaxList(ctx)
     decl = make_globaldecl(ctx, ex, binfo.mod, binfo.name, true)
     if kind(decl) !== K"TOMBSTONE"
@@ -191,7 +191,7 @@ function convert_assignment(ctx, ex)
     if binfo.kind == :global
         convert_global_assignment(ctx, ex, var, rhs0)
     else
-        @assert binfo.kind == :local || binfo.kind == :argument
+        @jl_assert binfo.kind == :local || binfo.kind == :argument ex
         boxed = is_boxed(binfo)
         if isnothing(binfo.type) && !boxed
             @ast ctx ex [K"=" var rhs0]
@@ -372,7 +372,7 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
             ex
         end
     elseif k == K"decl"
-        @assert kind(ex[1]) == K"BindingId"
+        @jl_assert kind(ex[1]) == K"BindingId" ex
         binfo = get_binding(ctx, ex[1])
         if binfo.kind == :global
             # flisp has this, but our K"assert" handling is in a previous pass
@@ -385,11 +385,11 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
         # Leftover `global` forms become weak globals.
         mod, name = if kind(ex[1]) == K"BindingId"
             binfo = get_binding(ctx, ex[1])
-            @assert binfo.kind == :global
+            @jl_assert binfo.kind == :global ex
             binfo.mod, binfo.name
         else
             # See note about using eval on Expr(:global/:const, GlobalRef(...))
-            @assert ex[1].value isa GlobalRef
+            @jl_assert ex[1].value isa GlobalRef ex[1]
             ex[1].value.mod, String(ex[1].value.name)
         end
         @ast ctx ex [K"unused_only" make_globaldecl(ctx, ex, mod, name, false)]
@@ -407,7 +407,7 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
         closure_convert_lambda(ctx, ex)
     elseif k == K"function_decl"
         func_name = ex[1]
-        @assert kind(func_name) == K"BindingId"
+        @jl_assert kind(func_name) == K"BindingId" ex
         func_name_id = func_name.var_id
         if haskey(ctx.closure_bindings, func_name_id)
             closure_info = get(ctx.closure_infos, func_name_id, nothing)
@@ -538,7 +538,7 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
 end
 
 function closure_convert_lambda(ctx, ex)
-    @assert kind(ex) == K"lambda"
+    @jl_assert kind(ex) == K"lambda" ex
     lambda_bindings = ex.lambda_bindings
     interpolations = nothing
     if isnothing(ctx.capture_rewriting)
@@ -577,7 +577,7 @@ function closure_convert_lambda(ctx, ex)
 
     if numchildren(ex) > 3
         # Convert return type
-        @assert numchildren(ex) == 4
+        @jl_assert numchildren(ex) == 4 ex
         push!(lambda_children, _convert_closures(ctx2, ex[4]))
     end
 

--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -186,7 +186,7 @@ function convert_assignment(ctx, ex)
     if kind(var) == K"Placeholder"
         return @ast ctx ex [K"=" var rhs0]
     end
-    @chk kind(var) == K"BindingId"
+    @jl_assert kind(var) == K"BindingId" ex
     binfo = get_binding(ctx, var)
     if binfo.kind == :global
         convert_global_assignment(ctx, ex, var, rhs0)

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -92,7 +92,7 @@ function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
         end
         setattr!(newleaf(graph, src, K"Value"), :value, e)
     end
-    @assert isa_lowering_ast_node(e) || is_expr_value(st)
+    @jl_assert isa_lowering_ast_node(e) || is_expr_value(st) st
 
     return st._id, src
 end
@@ -120,7 +120,7 @@ function est_to_expr(st::SyntaxTree, suppress_linenodes=false)
         QuoteNode(est_to_expr(st[1]))
     else
         # TODO: should handle post-lowering forms as well
-        @assert !is_leaf(st) "est_to_expr should only be used pre-desugaring"
+        @jl_assert !is_leaf(st) (st, "est_to_expr should only be used pre-desugaring")
         # In a partially-expanded or quoted AST, there may be heads with no
         # corresponding kind
         head = Symbol(k === K"unknown_head" ? st.name_val : untokenize(k))
@@ -176,7 +176,7 @@ function _dst_separate_dotop(st::SyntaxTree)
         return @ast st._graph st [K"." op_leaf]
     elseif k === K"Value" && st.value isa GlobalRef &&
         is_dotted_operator(string(st.value.name))
-        @assert false "TODO: handle dotted globalref"
+        @jl_assert false (st, "TODO: handle dotted globalref")
     else
         return est_to_dst(st)
     end
@@ -346,7 +346,7 @@ function est_to_dst(st::SyntaxTree; all_expanded=true)
                 push!(out_iters, _dst_iterspec(next, next[1][2:end]))
                 next = next[1][1]
             end
-            @assert kind(next) === K"generator"
+            @jl_assert kind(next) === K"generator" st next
             push!(out_iters, _dst_iterspec(next, next[2:end]))
             @ast g st [K"generator" rec(next[1]) out_iters...]
         end
@@ -468,9 +468,9 @@ function est_to_dst(st::SyntaxTree; all_expanded=true)
             if head === "latestworld-if-toplevel"
                 newleaf(g, st, K"latestworld_if_toplevel")
             else
-                @assert(false, string(
+                @jl_assert(false, (st, string(
                     "unknown expr head (corresponding to no kind) between",
-                    "macro-expansion and desugaring: ", st))
+                    "macro-expansion and desugaring: ")))
             end
         end
         [K"cfunction" typ fptr rt at sym] -> @ast g st [K"cfunction"

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -489,8 +489,8 @@ end
 function expand_compare_chain(ctx, ex)
     @jl_assert kind(ex) == K"comparison" ex
     terms = children(ex)
-    @chk numchildren(ex) >= 3
-    @chk isodd(numchildren(ex))
+    @jl_assert numchildren(ex) >= 3 ex
+    @jl_assert isodd(numchildren(ex)) ex
     i = 1
     comparisons = nothing
     # Combine any number of dotted comparisons
@@ -650,7 +650,7 @@ end
 function expand_ref_components(sctx::StatementListCtx, ex)
     check_no_parameters(ex, "unexpected semicolon in array expression")
     @jl_assert kind(ex) == K"ref" ex
-    @chk numchildren(ex) >= 1
+    @jl_assert numchildren(ex) >= 1 ex
     arr = ex[1]
     idxs = ex[2:end]
     if any(contains_identifier(e, "begin", "end") for e in idxs)
@@ -684,7 +684,7 @@ end
 function expand_dotcall(ctx, ex)
     k = kind(ex)
     if k == K"dotcall"
-        @chk numchildren(ex) >= 1
+        @jl_assert numchildren(ex) >= 1 ex
         farg = ex[1]
         args = SyntaxList(ctx)
         append!(args, ex[2:end])
@@ -714,7 +714,7 @@ end
 
 function expand_fuse_broadcast(ctx, ex)
     if kind(ex) == K".=" || kind(ex) == K".op="
-        @chk numchildren(ex) == 2
+        @jl_assert numchildren(ex) == 2 ex
         lhs = ex[1]
         kl = kind(lhs)
         rhs = expand_dotcall(ctx, ex[2])
@@ -816,7 +816,7 @@ function func_for_generator(ctx, body, iter_value_destructuring)
 end
 
 function expand_generator(ctx, ex)
-    @chk numchildren(ex) >= 2
+    @jl_assert numchildren(ex) >= 2 ex
     body = ex[1]
     check_no_return(body)
     if numchildren(ex) > 2
@@ -856,8 +856,8 @@ function expand_generator(ctx, ex)
         iter_ranges = SyntaxList(ctx)
         iter_lhss = SyntaxList(ctx)
         for iterspec in children(iterspecs)
-            @chk kind(iterspec) == K"in"
-            @chk numchildren(iterspec) == 2
+            @jl_assert kind(iterspec) == K"in" iterspec
+            @jl_assert numchildren(iterspec) == 2 iterspec
             push!(iter_lhss, iterspec[1])
             push!(iter_ranges, iterspec[2])
         end
@@ -1110,11 +1110,11 @@ function flatten_ncat_rows!(flat_elems, nrow_spans, row_major, parent_layout_dim
     k = kind(ex)
     if k == K"row"
         layout_dim = 1
-        @chk parent_layout_dim != 1 (ex,"Badly nested rows in `ncat`")
+        parent_layout_dim != 1 || throw(LoweringError(ex,"Badly nested rows in `ncat`"))
     elseif k == K"nrow"
         dim = JuliaSyntax.numeric_flags(ex)
-        @chk dim > 0                (ex,"Unsupported dimension $dim in ncat")
-        @chk !row_major || dim != 2 (ex,"2D `nrow` cannot be mixed with `row` in `ncat`")
+        dim > 0                || throw(LoweringError(ex,"Unsupported dimension $dim in ncat"))
+        !row_major || dim != 2 || throw(LoweringError(ex,"2D `nrow` cannot be mixed with `row` in `ncat`"))
         layout_dim = nrow_flipdim(row_major, dim)
     elseif kind(ex) == K"..."
         throw(LoweringError(ex, "Splatting ... in an `ncat` with multiple dimensions is not supported"))
@@ -1126,10 +1126,10 @@ function flatten_ncat_rows!(flat_elems, nrow_spans, row_major, parent_layout_dim
         return
     end
     row_start = length(flat_elems)
-    @chk parent_layout_dim > layout_dim (ex, "Badly nested rows in `ncat`")
+    parent_layout_dim > layout_dim || throw(LoweringError(ex, "Badly nested rows in `ncat`"))
     for e in children(ex)
         if layout_dim == 1
-            @chk kind(e) ∉ KSet"nrow row" (e,"Badly nested rows in `ncat`")
+            kind(e) ∉ KSet"nrow row" || throw(LoweringError(e,"Badly nested rows in `ncat`"))
         end
         flatten_ncat_rows!(flat_elems, nrow_spans, row_major, layout_dim, e)
     end
@@ -1146,7 +1146,7 @@ end
 function expand_ncat(ctx, ex)
     is_typed = kind(ex) == K"typed_ncat"
     outer_dim = JuliaSyntax.numeric_flags(ex)
-    @chk outer_dim > 0 (ex,"Unsupported dimension in ncat")
+    @jl_assert outer_dim > 0 (ex,"Unsupported dimension in ncat")
     eltype      = is_typed ? ex[1]     : nothing
     elements    = is_typed ? ex[2:end] : ex[1:end]
     hvncat_name = is_typed ? "typed_hvncat" : "hvncat"
@@ -1168,7 +1168,7 @@ function expand_ncat(ctx, ex)
     #   [a ; b ;;; c ; d]
     #   [a ; b ;;; c]
     row_major = any(ncat_contains_row, elements)
-    @chk !row_major || outer_dim != 2 (ex,"2D `nrow` cannot be mixed with `row` in `ncat`")
+    @jl_assert !row_major || outer_dim != 2 (ex,"2D `nrow` cannot be mixed with `row` in `ncat`")
     flat_elems = SyntaxList(ctx)
     # `ncat` syntax nests lower dimensional `nrow` inside higher dimensional
     # ones (with the exception of K"row" when `row_major` is true). Each nrow
@@ -1265,7 +1265,7 @@ end
 #   * Destructuring
 #   * Typed variable declarations
 function expand_assignment(ctx, ex, is_const=false)
-    @chk numchildren(ex) == 2
+    @jl_assert numchildren(ex) == 2 ex
     lhs = ex[1]
     rhs = ex[2]
     kl = kind(lhs)
@@ -1317,8 +1317,8 @@ function expand_assignment(ctx, ex, is_const=false)
         end
     elseif kl == K"."
         # a.b = rhs  ==>  setproperty!(a, :b, rhs)
-        @chk !is_const (ex, "cannot declare `.` form const")
-        @chk numchildren(lhs) == 2
+        @jl_assert !is_const (ex, "cannot declare `.` form const")
+        @jl_assert numchildren(lhs) == 2 lhs
         a = lhs[1]
         b = lhs[2]
         stmts = SyntaxList(ctx)
@@ -1345,7 +1345,7 @@ function expand_assignment(ctx, ex, is_const=false)
         end
     elseif kl == K"ref"
         # a[i1, i2] = rhs
-        @chk !is_const (ex, "cannot declare ref form const")
+        @jl_assert !is_const (ex, "cannot declare ref form const")
         expand_forms_2(ctx, expand_setindex(ctx, ex))
     elseif kl == K"::" && numchildren(lhs) == 2
         x = lhs[1]
@@ -1400,7 +1400,7 @@ function expand_update_operator(ctx, ex)
     k = kind(ex)
     dotted = k == K".op="
 
-    @chk numchildren(ex) == 3
+    @jl_assert numchildren(ex) == 3 ex
     lhs = ex[1]
     op = ex[2]
     rhs = ex[3]
@@ -1497,9 +1497,9 @@ end
 # Expand let blocks
 
 function expand_let(ctx, ex)
-    @chk numchildren(ex) == 2
+    @jl_assert numchildren(ex) == 2 ex
     bindings = ex[1]
-    @chk kind(bindings) == K"block"
+    @jl_assert kind(bindings) == K"block" bindings
     blk = ex[2]
     scope_type = get(ex, :scope_type, :hard)
     if numchildren(bindings) == 0
@@ -1774,7 +1774,7 @@ function expand_ccall(ctx, ex)
     if length(arg_types) >= 1
         va = arg_types[end]
         if kind(va) == K"..."
-            @chk numchildren(va) == 1
+            @jl_assert numchildren(va) == 1 va
             # Ok: vararg function
             vararg_type = expand_ccall_argtype(ctx, va[1])
             arg_types = arg_types[1:end-1]
@@ -1913,7 +1913,7 @@ function expand_call(ctx, ex)
     if is_core_ref(farg, "ccall")
         return expand_ccall(ctx, ex)
     elseif is_core_ref(farg, "cglobal")
-        @chk numchildren(ex) in 2:3  (ex, "cglobal must have one or two arguments")
+        @jl_assert numchildren(ex) in 2:3  (ex, "cglobal must have one or two arguments")
         return @ast ctx ex [K"call"
             ex[1]
             expand_forms_2(ctx, ex[2])
@@ -1952,7 +1952,7 @@ end
 #-------------------------------------------------------------------------------
 
 function expand_dot(ctx, ex)
-    @chk numchildren(ex) in (1,2)  (ex, "`.` form requires either one or two children")
+    @jl_assert numchildren(ex) in (1,2)  (ex, "`.` form requires either one or two children")
 
     if numchildren(ex) == 1
         # eg, `f = .+`
@@ -1986,7 +1986,7 @@ end
 function expand_for(ctx, ex)
     iterspecs = ex[1]
 
-    @chk kind(iterspecs) == K"iteration"
+    @jl_assert kind(iterspecs) == K"iteration" ex
 
     # Loop variables not declared `outer` are reassigned for each iteration of
     # the innermost loop in case the user assigns them to something else.
@@ -1995,7 +1995,7 @@ function expand_for(ctx, ex)
     # during desugaring.)
     copied_vars = SyntaxList(ctx)
     for iterspec in iterspecs[1:end-1]
-        @chk kind(iterspec) == K"in"
+        @jl_assert kind(iterspec) == K"in" iterspec
         lhs = iterspec[1]
         if kind(lhs) != K"outer"
             foreach_lhs_name(lhs) do var
@@ -2093,7 +2093,7 @@ end
 # Expand try/catch/finally
 
 function match_try(ex)
-    @chk numchildren(ex) > 1 "Invalid `try` form"
+    @jl_assert numchildren(ex) > 1 (ex, "Invalid `try` form")
     try_ = ex[1]
     catch_ = nothing
     finally_ = nothing
@@ -2101,13 +2101,13 @@ function match_try(ex)
     for e in ex[2:end]
         k = kind(e)
         if k == K"catch" && isnothing(catch_)
-            @chk numchildren(e) == 2 "Invalid `catch` form"
+            @jl_assert numchildren(e) == 2 (e, "Invalid `catch` form")
             catch_ = e
         elseif k == K"else" && isnothing(else_)
-            @chk numchildren(e) == 1
+            @jl_assert numchildren(e) == 1 e
             else_ = e[1]
         elseif k == K"finally" && isnothing(finally_)
-            @chk numchildren(e) == 1
+            @jl_assert numchildren(e) == 1 e
             finally_ = e[1]
         else
             throw(LoweringError(ex, "Invalid clause in `try` form"))
@@ -2256,7 +2256,7 @@ function expand_const_decl(ctx, ex)
     k = kind(ex[1])
     if k == K"global"
         asgn = ex[1][1]
-        @chk (kind(asgn) == K"=" || kind(asgn) == K"function") (ex, "expected assignment after `const`")
+        @jl_assert (kind(asgn) == K"=" || kind(asgn) == K"function") (ex, "expected assignment after `const`")
         globals = SyntaxList(ctx)
         foreach_lhs_name(asgn[1]) do x
             push!(globals, @ast ctx ex [K"global" x])
@@ -2274,7 +2274,7 @@ function expand_const_decl(ctx, ex)
         # remnant from the days when const-ness was a flag that could be set on
         # any global.  It creates a binding with kind PARTITION_KIND_UNDEF_CONST.
         # TODO: deprecate and delete this "feature"
-        @chk numchildren(ex) == 1
+        @jl_assert numchildren(ex) == 1 ex
         @ast ctx ex [K"constdecl" ex[1]]
     else
         throw(LoweringError(ex, "expected assignment after `const`"))
@@ -2323,7 +2323,7 @@ function expand_function_arg(ctx, body_stmts, arg, is_kw, arg_id)
                      :nospecialize, getmeta(arg_sym, :nospecialize, false))
         end
     else
-        @chk kind(arg_sym) in KSet"Identifier BindingId"
+        @jl_assert kind(arg_sym) in KSet"Identifier BindingId" arg_sym
         name = arg_sym
     end
 
@@ -2496,7 +2496,7 @@ function expand_function_generator(ctx, srcref, callex_srcref, func_name,
             # flisp lowering calls these unnamed arguments "#unused#", but JL does
             # not accept that as a repeated argument name
             return "#arg" * string(i) * "#"
-        else @jl_assert false ("Unexpected argument kind", n) end
+        else @jl_assert false (n, "Unexpected argument kind") end
     end
 
     # Extract non-generated body
@@ -2906,7 +2906,7 @@ function expand_function_def(ctx, ex, docs, rewrite_call=identity, rewrite_body=
     if kind(ex) === K"generated_function"
         @jl_assert numchildren(ex) === 3 && rewrite_body == identity ex
     else
-        @chk numchildren(ex) in (1,2)
+        @jl_assert numchildren(ex) in (1,2) ex
     end
     name = ex[1]
     if numchildren(ex) == 1 && is_identifier_like(name)
@@ -2936,7 +2936,7 @@ function expand_function_def(ctx, ex, docs, rewrite_call=identity, rewrite_body=
 
     return_type = nothing
     if kind(name) == K"::"
-        @chk numchildren(name) == 2
+        @jl_assert numchildren(name) == 2 name
         return_type = name[2]
         name = name[1]
     end
@@ -2980,13 +2980,13 @@ function expand_function_def(ctx, ex, docs, rewrite_call=identity, rewrite_body=
             self_type = name[1]
         else
             # function (f::T)() ...
-            @chk numchildren(name) == 2
+            @jl_assert numchildren(name) == 2 name
             self_name = name[1]
             self_type = name[2]
         end
         doc_obj = self_type
     elseif kind(name) == K"curly"
-        @chk numchildren(name) >= 2
+        @jl_assert numchildren(name) >= 2 name
         self_type = @ast ctx ex [K"function_type"
                                  expand_forms_2(ctx, expand_curly(ctx, name))]
         name = name[1]
@@ -3192,7 +3192,7 @@ function expand_arrow_args(ctx, arglist)
     # fixing this is extremely awkward when nested inside `where`. See
     # https://github.com/JuliaLang/JuliaSyntax.jl/pull/522
     if k == K"block"
-        @chk numchildren(arglist) == 2
+        @jl_assert numchildren(arglist) == 2 arglist
         kw = arglist[2]
         if kind(kw) === K"="
             kw = @ast ctx kw [K"kw" children(kw)...]
@@ -3225,7 +3225,7 @@ function expand_arrow_arglist(ctx, arglist, arrowname)
 end
 
 function expand_arrow(ctx, ex)
-    @chk numchildren(ex) == 2
+    @jl_assert numchildren(ex) == 2 ex
     expand_forms_2(ctx,
         @ast ctx ex [K"function"
             expand_arrow_arglist(ctx, ex[1], string(kind(ex)))
@@ -3240,10 +3240,10 @@ function expand_opaque_closure(ctx, ex)
     return_upper_bound = ex[3]
     allow_partial = ex[4]
     func_expr = ex[5]
-    @chk kind(func_expr) == K"->"
-    @chk numchildren(func_expr) == 2
+    @jl_assert kind(func_expr) == K"->" ex
+    @jl_assert numchildren(func_expr) == 2 ex
     args = expand_arrow_args(ctx, func_expr[1])
-    @chk kind(args) == K"tuple"
+    @jl_assert kind(args) == K"tuple" ex
     check_no_parameters(ex, args)
 
     arg_names = SyntaxList(ctx)
@@ -3301,7 +3301,7 @@ function _make_macro_name(ctx, ex)
         name.name_val = "@$(ex.name_val)"
         name
     elseif is_valid_modref(ex)
-        @chk numchildren(ex) == 2
+        @jl_assert numchildren(ex) == 2 ex
         @ast ctx ex [K"." ex[1] _make_macro_name(ctx, ex[2])]
     else
         throw(LoweringError(ex, "invalid macro name"))
@@ -3310,7 +3310,7 @@ end
 
 # flisp: expand-macro-def
 function expand_macro_def(ctx, ex)
-    @chk numchildren(ex) >= 1 (ex,"invalid macro definition")
+    @jl_assert numchildren(ex) >= 1 (ex,"invalid macro definition")
     if numchildren(ex) == 1
         name = ex[1]
         # macro with zero methods
@@ -3319,10 +3319,10 @@ function expand_macro_def(ctx, ex)
     end
     # TODO: Making this manual pattern matching robust is such a pain!!!
     sig = ex[1]
-    @chk (kind(sig) == K"call" && numchildren(sig) >= 1) (sig, "invalid macro signature")
+    @jl_assert (kind(sig) == K"call" && numchildren(sig) >= 1) (sig, "invalid macro signature")
     name = sig[1]
     args = remove_empty_parameters(children(sig))
-    @chk kind(args[end]) != K"parameters" (args[end], "macros cannot accept keyword arguments")
+    @jl_assert kind(args[end]) != K"parameters" (args[end], "macros cannot accept keyword arguments")
     scope_ref = kind(name) == K"." ? name[1] : name
     if ctx.expr_compat_mode
         @ast ctx ex [K"function"
@@ -3466,10 +3466,10 @@ end
 function expand_abstract_or_primitive_type(ctx, ex)
     is_abstract = kind(ex) == K"abstract"
     if is_abstract
-        @chk numchildren(ex) == 1
+        @jl_assert numchildren(ex) == 1 ex
     else
         @jl_assert kind(ex) == K"primitive" ex
-        @chk numchildren(ex) == 2
+        @jl_assert numchildren(ex) == 2 ex
     end
     nbits = is_abstract ? nothing : ex[2]
     name, type_params, supertype = analyze_type_sig(ctx, ex[1])
@@ -3957,7 +3957,7 @@ function insert_struct_shim(ctx, fieldtypes, name)
 end
 
 function expand_struct_def(ctx, ex, docs)
-    @chk numchildren(ex) == 2
+    @jl_assert numchildren(ex) == 2 ex
     type_sig = ex[1]
     type_body = ex[2]
     if kind(type_body) != K"block"
@@ -4154,7 +4154,7 @@ function expand_where(ctx, srcref, lhs, rhs)
 end
 
 function expand_wheres(ctx, ex)
-    @chk numchildren(ex) == 2
+    @jl_assert numchildren(ex) == 2 ex
     body = ex[1]
     rhs = ex[2]
     if kind(rhs) == K"braces"
@@ -4218,7 +4218,7 @@ end
 # Expand import / using / export
 
 function expand_importpath(path)
-    @chk kind(path) == K"importpath"
+    @jl_assert kind(path) == K"importpath" path
     path_spec = Expr(:.)
     prev_was_dot = true
     for component in children(path)
@@ -4228,7 +4228,7 @@ function expand_importpath(path)
             # import A.(:b).:c
             component = component[1]
         end
-        @chk kind(component) in (K"Identifier", K".")
+        @jl_assert kind(component) in (K"Identifier", K".") component
         name = component.name_val
         is_dot = kind(component) == K"."
         if is_dot && !prev_was_dot
@@ -4249,7 +4249,7 @@ function expand_import_or_using(ctx, ex)
         #  false
         #  (call core.svec "M")
         #  (call core.svec  2 "x" "y" "z"  1 "w" "w"))
-        @chk numchildren(ex[1]) >= 2
+        @jl_assert numchildren(ex[1]) >= 2 ex
         from = ex[1][1]
         from_path = @ast ctx from QuoteNode(expand_importpath(from))::K"Value"
         paths = ex[1][2:end]
@@ -4257,7 +4257,7 @@ function expand_import_or_using(ctx, ex)
         # import A.B
         # (using (importpath A B))
         # (call eval_import true nothing (call core.svec 1 "w"))
-        @chk numchildren(ex) >= 1
+        @jl_assert numchildren(ex) >= 1 ex
         from_path = nothing
         paths = children(ex)
     end
@@ -4266,8 +4266,8 @@ function expand_import_or_using(ctx, ex)
     for spec in paths
         as_name = nothing
         if kind(spec) == K"as"
-            @chk numchildren(spec) == 2
-            @chk kind(spec[2]) == K"Identifier"
+            @jl_assert numchildren(spec) == 2 spec
+            @jl_assert kind(spec[2]) == K"Identifier" spec
             as_name = Symbol(spec[2].name_val)
             path = QuoteNode(Expr(:as, expand_importpath(spec[1]), as_name))
         else
@@ -4323,7 +4323,7 @@ end
 function expand_public(ctx, ex)
     identifiers = String[]
     for e in children(ex)
-        @chk kind(e) == K"Identifier" (ex, "Expected identifier")
+        @jl_assert kind(e) == K"Identifier" (ex, "Expected identifier")
         push!(identifiers, e.name_val)
     end
     (e.name_val::K"String" for e in children(ex))
@@ -4393,10 +4393,10 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
     elseif k == K"."
         expand_forms_2(ctx, expand_dot(ctx, ex))
     elseif k == K"?"
-        @chk numchildren(ex) == 3
+        @jl_assert numchildren(ex) == 3 ex
         expand_forms_2(ctx, @ast ctx ex [K"if" children(ex)...])
     elseif k == K"&&" || k == K"||"
-        @chk numchildren(ex) > 1
+        @jl_assert numchildren(ex) > 1 ex
         cs = expand_cond_children(ctx, ex)
         # Attributing correct provenance for `cs[1:end-1]` is tricky in cases
         # like `a && (b && c)` because the expression constructed here arises
@@ -4413,7 +4413,7 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
             @ast ctx ex [K"if" cond true::K"Bool" cs[end]]
         end
     elseif k == K"::"
-        @chk numchildren(ex) == 2 "`::` must be written `value::type` outside function argument lists"
+        @jl_assert numchildren(ex) == 2 (ex, "`::` must be written `value::type` outside function argument lists")
         @ast ctx ex [K"call"
             "typeassert"::K"core"
             expand_forms_2(ctx, ex[1])
@@ -4457,20 +4457,20 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
     elseif k == K"comparison"
         expand_forms_2(ctx, expand_compare_chain(ctx, ex))
     elseif k == K"doc"
-        @chk numchildren(ex) == 2
+        @jl_assert numchildren(ex) == 2 ex
         expand_doc(ctx, ex[2], ex)
     elseif k == K"for"
         expand_forms_2(ctx, expand_for(ctx, ex))
     elseif k == K"comprehension"
-        @chk numchildren(ex) == 1
-        @chk kind(ex[1]) == K"generator"
+        @jl_assert numchildren(ex) == 1 ex
+        @jl_assert kind(ex[1]) == K"generator" ex
         @ast ctx ex [K"call"
             "collect"::K"top"
             expand_forms_2(ctx, ex[1])
         ]
     elseif k == K"typed_comprehension"
-        @chk numchildren(ex) == 2
-        @chk kind(ex[2]) == K"generator"
+        @jl_assert numchildren(ex) == 2 ex
+        @jl_assert kind(ex[2]) == K"generator" ex
         if numchildren(ex[2]) == 2 && kind(ex[2][2]) == K"iteration"
             # Hack to lower simple typed comprehensions to loops very early,
             # greatly reducing the number of functions and load on the compiler
@@ -4497,7 +4497,7 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
             expand_forms_2(ctx, expand_macro_def(ctx, ex))
         ]
     elseif k == K"if" || k == K"elseif"
-        @chk numchildren(ex) >= 2
+        @jl_assert numchildren(ex) >= 2 ex
         @ast ctx ex [k
             expand_condition(ctx, ex[1])
             expand_forms_2(ctx, ex[2:end])...
@@ -4601,7 +4601,7 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
     elseif k == K"ncat" || k == K"typed_ncat"
         expand_forms_2(ctx, expand_ncat(ctx, ex))
     elseif k == K"while"
-        @chk numchildren(ex) == 2
+        @jl_assert numchildren(ex) == 2 ex
         @ast ctx ex [K"symbolicblock" "loop-exit"::K"symboliclabel"
             [K"_while"
                 expand_condition(ctx, ex[1])

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -182,10 +182,10 @@ function add_ir_debug_info!(current_codelocs_stack, stmt)
             push!(current_codelocs_stack, (locstk[j][1], [], Vector{Int32}()))
         end
     end
-    @assert length(locstk) === length(current_codelocs_stack)
+    @jl_assert length(locstk) === length(current_codelocs_stack) stmt
     for (j, (file,line)) in enumerate(locstk)
         fn, edges, codelocs = current_codelocs_stack[j]
-        @assert fn == file
+        @jl_assert fn == file stmt
         if j < length(locstk)
             edge_index = length(edges) + 1
             edge_codeloc_index = fld1(length(current_codelocs_stack[j+1][3]) + 1, 3)
@@ -394,18 +394,18 @@ function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
         # opaque_closure_method has special non-evaluated semantics for the
         # `functionloc` line number node so we need to undo a level of quoting
         arg4 = args[4]
-        @assert arg4 isa QuoteNode
+        @jl_assert arg4 isa QuoteNode e
         args[4] = arg4.value
         Expr(:opaque_closure_method, args...)
     elseif k == K"meta"
         args = Any[_to_lowered_expr(e, stmt_offset) for e in children(ex)]
         # Unpack K"Symbol" QuoteNode as `Expr(:meta)` requires an identifier here.
         arg1 = args[1]
-        @assert arg1 isa QuoteNode
+        @jl_assert arg1 isa QuoteNode e
         args[1] = arg1.value
         Expr(:meta, args...)
     elseif k == K"static_eval"
-        @assert numchildren(ex) == 1
+        @jl_assert numchildren(ex) == 1 e
         @stm ex[1] begin
             # tuple should just be ccall library spec
             [K"tuple" s lib] -> Expr(:tuple,

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -238,7 +238,7 @@ end
 # An integer tag is created to identify the current code path and select the
 # on_exit action to be taken at finally handler exit.
 function enter_finally_block(ctx, srcref, on_exit, value)
-    @assert on_exit ∈ (:rethrow, :break, :return)
+    @jl_assert on_exit ∈ (:rethrow, :break, :return) srcref
     handler = last(ctx.finally_handlers)
     push!(handler.exit_actions, (on_exit, value))
     tag = length(handler.exit_actions)
@@ -590,7 +590,7 @@ function compile_try(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
             elseif on_exit === :rethrow
                 emit(ctx, @ast ctx srcref [K"call" "rethrow"::K"top"])
             else
-                @assert false
+                @jl_assert false finally_block
             end
             if !isnothing(next_action_label)
                 emit(ctx, next_action_label)
@@ -669,7 +669,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
                 binfo = get_binding(ctx, ex[1])
                 binfo.mod, binfo.name
             else
-                @assert kind(ex[1]) == K"Value" && typeof(ex[1].value) === GlobalRef
+                @jl_assert kind(ex[1]) == K"Value" && typeof(ex[1].value) === GlobalRef ex
                 gr = ex[1].value
                 gr.mod, String(gr.name)
             end
@@ -831,7 +831,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
     elseif k == K"trycatchelse" || k == K"tryfinally"
         compile_try(ctx, ex, needs_value, in_tail_pos)
     elseif k == K"method"
-        ctx.is_toplevel_thunk || internal_error(ex, "method not at top level")
+        @jl_assert ctx.is_toplevel_thunk (ex, "method not at top level")
         res = if numchildren(ex) == 1
             if in_tail_pos
                 emit_return(ctx, ex)
@@ -854,7 +854,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
                 lam = emit_assign_tmp(ctx, compile(ctx, lam, true, false))
             end
             emit(ctx, @ast ctx ex [K"method" fname sig lam])
-            @assert !needs_value && !in_tail_pos
+            @jl_assert !needs_value && !in_tail_pos ex
             nothing
         end
         emit_latestworld(ctx, ex)
@@ -932,7 +932,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
             ex
         end
     elseif k == K"newvar"
-        @assert !needs_value
+        @jl_assert !needs_value ex
         is_duplicate = !isempty(ctx.code) &&
             (e = last(ctx.code); kind(e) == K"newvar" && e[1].var_id == ex[1].var_id)
         if !is_duplicate
@@ -1023,18 +1023,18 @@ function compile_body(ctx::LinearIRContext, ex)
         pop_ex = compile_pop_exception(ctx, origin.goto, origin.catch_token_stack,
                                      target.catch_token_stack)
         if !isnothing(pop_ex)
-            @assert kind(ctx.code[i]) == K"TOMBSTONE"
+            @jl_assert kind(ctx.code[i]) == K"TOMBSTONE" ctx.code[i]
             ctx.code[i] = pop_ex
             i += 1
         end
         leave_ex = compile_leave_handler(ctx, origin.goto, origin.handler_token_stack,
                                          target.handler_token_stack)
         if !isnothing(leave_ex)
-            @assert kind(ctx.code[i]) == K"TOMBSTONE"
+            @jl_assert kind(ctx.code[i]) == K"TOMBSTONE" ctx.code[i]
             ctx.code[i] = leave_ex
             i += 1
         end
-        @assert kind(ctx.code[i]) == K"TOMBSTONE"
+        @jl_assert kind(ctx.code[i]) == K"TOMBSTONE" ctx.code[i]
         ctx.code[i] = @ast ctx origin.goto [K"goto" target.label]
     end
 
@@ -1152,11 +1152,11 @@ function compile_lambda(outer_ctx, ex)
                           lambda_bindings, ret_var)
     for arg in children(lambda_args)
         kind(arg) == K"Placeholder" && continue
-        @assert kind(arg) == K"BindingId"
+        @jl_assert kind(arg) == K"BindingId" ex
         id = arg.var_id
         binfo = get_binding(ctx, id)
         if binfo.is_assigned
-            @assert !haskey(ctx.argmap, binfo.id)
+            @jl_assert !haskey(ctx.argmap, binfo.id) ex arg
             ctx.argmap[binfo.id] = new_local_binding(ctx, binding_ex(ctx, binfo), binfo.name).var_id
         end
     end
@@ -1174,10 +1174,10 @@ function compile_lambda(outer_ctx, ex)
             push!(slots, Slot(arg.name_val, :argument, getmeta(arg, :nospecialize, false),
                               false, false, false, false))
         else
-            @assert kind(arg) == K"BindingId"
+            @jl_assert kind(arg) == K"BindingId" ex arg
             id = arg.var_id
             binfo = get_binding(ctx, id)
-            @assert binfo.kind == :local || binfo.kind == :argument
+            @jl_assert binfo.kind == :local || binfo.kind == :argument ex arg
             push!(slots, Slot(binfo.name, :argument, binfo.is_nospecialize,
                               binfo.is_read, binfo.is_assigned_once,
                               binfo.is_used_undef, binfo.is_called))
@@ -1197,10 +1197,10 @@ function compile_lambda(outer_ctx, ex)
         end
     end
     for (i,arg) in enumerate(children(static_parameters))
-        @assert kind(arg) == K"BindingId"
+        @jl_assert kind(arg) == K"BindingId" arg
         id = arg.var_id
         info = get_binding(ctx.bindings, id)
-        @assert info.kind == :static_parameter
+        @jl_assert info.kind == :static_parameter arg
         slot_rewrites[id] = i
     end
     code = renumber_body(ctx, ctx.code, slot_rewrites)

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -489,7 +489,6 @@ end
 #
 # See the devdocs for further discussion.
 function compile_try(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
-    @chk numchildren(ex) <= 3
     (try_block, catch_block, else_block, finally_block, catch_label, scope) = @stm ex begin
          [K"trycatchelse" t c] -> (t, c, nothing, nothing, make_label(ctx, c), nothing)
          [K"trycatchelse" t c e] -> (t, c, e, nothing, make_label(ctx, c), nothing)
@@ -646,7 +645,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         end
         nothing
     elseif k == K"TOMBSTONE"
-        @chk !needs_value (ex,"TOMBSTONE encountered in value position")
+        @jl_assert !needs_value (ex,"TOMBSTONE encountered in value position")
         nothing
     elseif k == K"call" || k == K"new" || k == K"splatnew" || k == K"foreigncall" ||
             k == K"new_opaque_closure" || k == K"cfunction"
@@ -789,7 +788,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
             nothing
         end
     elseif k == K"if" || k == K"elseif"
-        @chk numchildren(ex) <= 3
+        @jl_assert numchildren(ex) <= 3 ex
         has_else = numchildren(ex) > 2
         else_label = make_label(ctx, ex)
         compile_conditional(ctx, ex[1], else_label)
@@ -841,7 +840,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
                 emit(ctx, ex)
             end
         else
-            @chk numchildren(ex) == 3
+            @jl_assert numchildren(ex) == 3 ex
             fname = ex[1]
             sig = compile(ctx, ex[2], true, false)
             if !is_valid_ir_argument(ctx, sig)
@@ -885,7 +884,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         emit(ctx, ex)
         nothing
     elseif k == K"meta"
-        @chk numchildren(ex) >= 1
+        @jl_assert numchildren(ex) >= 1 ex
         if ex[1].name_val in ("inline", "noinline", "propagate_inbounds",
                               "nospecializeinfer", "aggressive_constprop", "no_constprop")
             for c in children(ex)

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -424,7 +424,9 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
         out = mkleaf(ex)
         setattr!(out, :scope_layer, scope_layer)
     elseif k == K"escape"
-        @chk numchildren(ex) === 1 "`escape` requires one argument"
+        if numchildren(ex) !== 1
+            throw(LoweringError(ex, "`escape` requires one argument"))
+        end
         if length(ctx.scope_layer_stack) === 1
             throw(MacroExpansionError(ex, "`escape` node in outer context"))
         end
@@ -433,8 +435,9 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
         push!(ctx.scope_layer_stack, top_layer)
         escaped_ex
     elseif k == K"hygienic-scope"
-        @chk(2 <= numchildren(ex) <= 3 && ex[2].value isa Module,
-             (ex,"`hygienic-scope` requires an AST and a module"))
+        if !(2 <= numchildren(ex) <= 3 && ex[2].value isa Module)
+            throw(LoweringError(ex,"`hygienic-scope` requires an AST and a module"))
+        end
         new_layer = ScopeLayer(length(ctx.scope_layers)+1, ex[2].value,
                                current_layer_id(ctx), true, false)
         push!(ctx.scope_layers, new_layer)
@@ -443,7 +446,9 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
         pop!(ctx.scope_layer_stack)
         hyg_ex
     elseif k == K"quote"
-        @chk numchildren(ex) == 1
+        if numchildren(ex) !== 1
+            throw(LoweringError(ex,"`quote` expects one argument"))
+        end
         expand_forms_1(ctx, expand_quote(ctx, ex[1]))
     elseif k == K"macrocall"
         expand_macro(ctx, ex)

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -270,7 +270,7 @@ function fix_toplevel_expansion(ctx, ex::SyntaxTree, mod::Module, lnn::LineNumbe
 end
 
 function expand_macro(ctx, ex)
-    @assert kind(ex) == K"macrocall"
+    @jl_assert kind(ex) == K"macrocall" ex
 
     macname = ex[1]
     mctx = MacroContext(ctx.graph, ex, current_layer(ctx), ctx.expr_compat_mode)

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -48,7 +48,7 @@ end
 function ScopeInfo(ctx, parent_id, ex::SyntaxTree)
     id = length(ctx.scopes) + 1
     if parent_id == 0
-        @assert kind(ex) === K"lambda"
+        @jl_assert kind(ex) === K"lambda" ex
         lambda_id = id
         is_permeable = ex.is_toplevel_thunk
         is_lifted = false
@@ -112,10 +112,8 @@ function maybe_declare_in_scope!(ctx, scope::ScopeInfo, ex, new_k::Symbol)
     if kind(ex) === K"BindingId"
         bid = ex.var_id
         b = get_binding(ctx, bid)
-        @assert b.kind === new_k
-        if b.lambda_id !== 0
-            internal_error(ex, "cannot declare a BindingId in multiple scopes")
-        end
+        @jl_assert b.kind === new_k ex
+        @jl_assert b.lambda_id !== 0 (ex, "cannot declare a BindingId in multiple scopes")
         add_lambda_local!(ctx, scope, b)
         return bid
     elseif kind(ex) === K"Placeholder"
@@ -167,7 +165,8 @@ function add_lambda_local!(ctx, scope::ScopeInfo, b)
         return
     end
     lam = scope.is_lifted ? top_scope(ctx) : enclosing_lambda(ctx, scope)
-    @assert !haskey(lam.locals_capt, b.id)
+    @jl_assert !haskey(lam.locals_capt, b.id) (
+        binding_ex(ctx, b), "adding lambda local twice")
     lam.locals_capt[b.id] = false
     b.lambda_id = lam.id
     nothing
@@ -182,7 +181,9 @@ function ensure_captured!(ctx, scope::ScopeInfo, b)
         b.is_captured = true
         lam.locals_capt[b.id] = true
         s2 = parent(ctx, lam)
-        @assert !isnothing(s2) "tried to capture local before declaration in any parent"
+        @jl_assert !isnothing(s2) (
+            binding_ex(ctx, b),
+            "tried to capture local before declaration in any parent")
         ensure_captured!(ctx, s2, b)
     end
     nothing
@@ -218,15 +219,15 @@ function _find_scope_decls!(ctx, scope, ex)
         if k1 === K"BindingId"
             b = get_binding(ctx, ex[1])
             if k === K"function_decl" && !b.is_ssa && b.kind !== :global
-                @assert false "allow local BindingId as function name?"
+                @jl_assert false (ex, "allow local BindingId as function name?")
             end
             get!(scope.binding_assignments, b.id, ex[1]._id)
         elseif k1 === K"Identifier"
             get!(scope.assignments, NameKey(ex[1]), ex[1]._id)
         elseif k1 === K"Placeholder"
-            @assert k !== K"function_decl"
+            @jl_assert k !== K"function_decl" ex
         else
-            @assert false "Unknown kind in assignment"
+            @jl_assert false (ex, "unknown kind in assignment")
         end
         if (k === K"=" || k === K"assign_or_constdecl_if_global" ||
             k === K"constdecl" && numchildren(ex) == 2)
@@ -243,7 +244,7 @@ end
 # means finding all variables declared and used in the scope `ex` and generating
 # the (identifier,layer)=>binding_id mapping `scope.vars`
 function enter_scope!(ctx, ex)
-    @assert kind(ex) in KSet"lambda scope_block method_defs"
+    @jl_assert kind(ex) in KSet"lambda scope_block method_defs" ex
     # Note that generated functions produce lambdas with this false
     is_toplevel_thunk = kind(ex) === K"lambda" && ex.is_toplevel_thunk
     parent_id = (is_toplevel_thunk || isempty(ctx.scope_stack)) ?
@@ -256,11 +257,11 @@ function enter_scope!(ctx, ex)
     # Find explicit decls that may influence assignment assignment resolution
     if kind(ex) === K"lambda"
         for c in children(ex[1])
-            @assert kind(c) in KSet"Identifier BindingId Placeholder"
+            @jl_assert kind(c) in KSet"Identifier BindingId Placeholder" c
             maybe_declare_in_scope!(ctx, scope, c, :argument)
         end
         for c in children(ex[2])
-            @assert kind(c) in KSet"Identifier BindingId Placeholder"
+            @jl_assert kind(c) in KSet"Identifier BindingId Placeholder" c
             maybe_declare_in_scope!(ctx, scope, c, :static_parameter)
         end
         for c in children(ex)[3:end]
@@ -336,7 +337,7 @@ end
 function _resolve_scopes(ctx, ex::SyntaxTree,
                          @nospecialize(scope::Union{Nothing, ScopeInfo}))
     k = kind(ex)
-    @assert scope isa ScopeInfo || k === K"lambda"
+    @jl_assert scope isa ScopeInfo || k === K"lambda" ex
     if k == K"Identifier"
         b = resolve_name(ctx, ex)
         # Unresolved names are assumed global
@@ -511,7 +512,7 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
                 throw(LoweringError(e, "this syntax is only allowed in top level code"))
             end
         else
-            internal_error(ex, "unknown syntax assertion")
+            @jl_assert false (ex, "unknown syntax assertion")
         end
         newleaf(ctx, ex, K"TOMBSTONE")
     elseif k == K"function_decl"
@@ -530,7 +531,7 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
         resolved
     elseif k == K"constdecl"
         resolved = mapchildren(e->_resolve_scopes(ctx, e, scope), ctx, ex)
-        @assert kind(resolved[1]) === K"BindingId"
+        @jl_assert kind(resolved[1]) === K"BindingId" resolved[1]
         if get_binding(ctx, resolved[1].var_id).kind === :local
             throw(LoweringError(ex, "unsupported `const` declaration on local variable"))
         elseif !is_top_scope(enclosing_lambda(ctx, scope))
@@ -540,7 +541,7 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
     elseif k == K"assign_or_constdecl_if_global"
         id = _resolve_scopes(ctx, ex[1], scope)
         bk = get_binding(ctx, id).kind
-        @assert numchildren(ex) === 2
+        @jl_assert numchildren(ex) === 2 ex
         assignment_kind = bk == :global ? K"constdecl" : K"="
         @ast ctx ex _resolve_scopes(ctx, [assignment_kind ex[1] ex[2]], scope)
     else
@@ -581,7 +582,7 @@ end
 
 function init_closure_bindings!(ctx, fname)
     func_name_id = fname.var_id
-    @assert get_binding(ctx, func_name_id).kind === :local
+    @jl_assert get_binding(ctx, func_name_id).kind === :local fname
     get!(ctx.closure_bindings, func_name_id) do
         name_stack = Vector{String}()
         for parentname in ctx.method_def_stack
@@ -627,9 +628,11 @@ function analyze_variables!(ctx, ex)
         # but is filled in here.
         scope = ctx.scopes[ctx.lambda_bindings.scope_id]
         ensure_captured!(ctx, scope, b)
-        @assert b.kind === :global || b.is_ssa || haskey(ctx.lambda_bindings.locals_capt, b.id)
+        @jl_assert (b.kind === :global ||
+            b.is_ssa ||
+            haskey(ctx.lambda_bindings.locals_capt, b.id)) ex binding_ex(ctx, b.id)
     elseif k == K"Identifier"
-        @assert false
+        @jl_assert false ex
     elseif k == K"break" && numchildren(ex) >= 2
         # For break with value, only analyze the value expression (second child), not the label
         # This must come BEFORE !needs_resolution check since K"break" is in is_quoted

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -13,7 +13,7 @@ function Base.isless(a::NameKey, b::NameKey)
 end
 
 function NameKey(ex::SyntaxTree)
-    @chk kind(ex) == K"Identifier"
+    @jl_assert kind(ex) === K"Identifier" ex
     NameKey(ex.name_val, ex.scope_layer)
 end
 

--- a/JuliaLowering/src/syntax_macros.jl
+++ b/JuliaLowering/src/syntax_macros.jl
@@ -46,14 +46,14 @@ end
 
 # TODO: support all forms that the original supports
 # function Base.var"@atomic"(__context__::MacroContext, ex)
-#     @chk kind(ex) == K"Identifier" || kind(ex) == K"::" (ex, "Expected identifier or declaration")
+#     @jl_assert kind(ex) == K"Identifier" || kind(ex) == K"::" (ex, "Expected identifier or declaration")
 #     @ast __context__ __context__.macrocall [K"atomic" ex]
 # end
 
 # TODO: @label
 
 function Base.var"@goto"(__context__::MacroContext, ex)
-    @chk kind(ex) == K"Identifier"
+    @jl_assert kind(ex) == K"Identifier" ex
     @ast __context__ ex [K"symbolicgoto" ex]
 end
 
@@ -238,7 +238,7 @@ function Base.GC.var"@preserve"(__context__::MacroContext, exs...)
 end
 
 function Base.Experimental.var"@opaque"(__context__::MacroContext, ex)
-    @chk kind(ex) == K"->"
+    @jl_assert kind(ex) == K"->" ex
     @ast __context__ __context__.macrocall [K"opaque_closure"
         "nothing"::K"core"
         "nothing"::K"core"
@@ -287,7 +287,7 @@ end
 #
 # For now we have our own versions
 function var"@islocal"(__context__::MacroContext, ex)
-    @chk kind(ex) == K"Identifier"
+    @jl_assert kind(ex) == K"Identifier" ex
     @ast __context__ __context__.macrocall [K"islocal" ex]
 end
 
@@ -345,6 +345,6 @@ etc. Needs careful thought - we should probably just copy what lisp does with
 quote+quasiquote 😅
 """
 function var"@inert"(__context__::MacroContext, ex)
-    @chk kind(ex) == K"quote"
+    @jl_assert kind(ex) == K"quote" ex
     @ast __context__ __context__.macrocall [K"inert" ex]
 end

--- a/JuliaLowering/src/utils.jl
+++ b/JuliaLowering/src/utils.jl
@@ -121,10 +121,11 @@ end
 LoweringError(ex::SyntaxTree, msg::String) =
     LoweringError(SyntaxList(ex), String[msg], false)
 
-# Collect some context for error printing.  >1 answer will only be produced with
-# a non-tree DAG.
-function _scan_parents(sts::SyntaxList, depth=3)
-    depth === 0 && return sts
+# Returns a set of ancestors within `depth` distance from the nodes in
+# `sts`. Slow, intended for error printing only.  >1 answer will only be
+# produced with a non-tree DAG.
+function _scan_parents(sts::SyntaxList; depth::Int=3)
+    depth <= 0 && return sts
     g = sts.graph
     out = SyntaxList(sts.graph)
     for st in sts
@@ -141,7 +142,7 @@ function _scan_parents(sts::SyntaxList, depth=3)
         end
         n_parents === 0 && push!(out, st)
     end
-    return _scan_parents(out, depth-1)
+    return _scan_parents(out; depth=depth-1)
 end
 
 function Base.showerror(io::IO, exc::LoweringError; show_detail=true)

--- a/JuliaLowering/src/utils.jl
+++ b/JuliaLowering/src/utils.jl
@@ -108,30 +108,74 @@ TODO(msg::AbstractString) = throw(ErrorException("Lowering TODO: $msg"))
 TODO(ex::SyntaxTree, msg="") = throw(LoweringError(ex, "Lowering TODO: $msg"))
 
 """
-An error generated while lowering user code `ex` (flisp: `Expr(:error, msg)`).
-For errors in lowering itself, use `@assert`.
+An error with detailed printing containing one or more SyntaxTrees and one
+message per tree.  If `!internal`, caused by bad user code in `syntax` (flisp:
+`Expr(:error, msg)`).
 """
 struct LoweringError <: Exception
-    ex::SyntaxTree
-    msg::String
+    sts::SyntaxList
+    msgs::Vector{String}
+    internal::Bool
 end
 
-internal_error(ex, msg) = throw(
-    LoweringError(ex, string("Internal lowering error: ", msg)))
+LoweringError(ex::SyntaxTree, msg::String) =
+    LoweringError(SyntaxList(ex), String[msg], false)
+
+# Collect some context for error printing.  >1 answer will only be produced with
+# a non-tree DAG.
+function _scan_parents(sts::SyntaxList, depth=3)
+    depth === 0 && return sts
+    g = sts.graph
+    out = SyntaxList(sts.graph)
+    for st in sts
+        n_parents = 0
+        for candidate_id in lastindex(g.edge_ranges):-1:firstindex(g.edge_ranges)
+            candidate = SyntaxTree(g, candidate_id)
+            if st in children(candidate)
+                push!(out, SyntaxTree(g, candidate_id))
+                n_parents += 1
+                # ideally we just want one; don't be spammy if we find many.
+                # iterating in reverse means get chronologically latest results.
+                n_parents >= 3 && break
+            end
+        end
+        n_parents === 0 && push!(out, st)
+    end
+    return _scan_parents(out, depth-1)
+end
 
 function Base.showerror(io::IO, exc::LoweringError; show_detail=true)
-    print(io, "LoweringError:\n")
-    src = sourceref(exc.ex)
-    highlight(io, src; note=exc.msg)
+    println(io, exc.internal ? "internal lowering bug:" : "LoweringError:")
+    for i in eachindex(exc.sts)
+        st = exc.sts[i]
+        msg = exc.msgs[i]
+        src = sourceref(st)
+        highlight(io, src; note=msg)
+        if exc.internal || src isa LineNumberNode
+            print(io, "\nExpression:\n  ")
+            show(io, MIME"text/x.sexpression"(), st)
+            parents = _scan_parents(SyntaxList(st))
+            print(io, "\nContaining expressions:")
+            for p in parents
+                print(io, "\n  ")
+                show(io, MIME"text/x.sexpression"(), p)
+            end
+        end
+        i !== lastindex(exc.sts) && print(io, "\n\n")
+    end
 
-    if show_detail
-        print(io, "\n\nDetailed provenance:\n")
-        showprov(io, exc.ex, tree=true)
+    if show_detail || exc.internal
+        print(io, "\n\nDetailed provenance:\n  ")
+        _show_provtree(io, exc.sts[1], "  ")
     end
 end
 
 function _show_provtree(io::IO, ex::SyntaxTree, indent)
-    print(io, ex, "\n")
+    print(io, ex)
+    if hasattr(ex, :jl_source)
+        printstyled(io, " @$(ex.jl_source)", color=:light_black)
+    end
+    print(io, "\n")
     prov = provenance(ex)
     for (i, e) in enumerate(prov)
         islast = i == length(prov)
@@ -169,16 +213,8 @@ function showprov(io::IO, exs::AbstractVector;
     end
 end
 
-function showprov(io::IO, ex::SyntaxTree; tree::Bool=false, showprov_kwargs...)
-    if tree
-        _show_provtree(io, ex, "")
-    else
-        showprov(io, flattened_provenance(ex); showprov_kwargs...)
-    end
-end
-
-function showprov(x; kws...)
-    showprov(stdout, x; kws...)
+function showprov(io::IO, ex::SyntaxTree; showprov_kwargs...)
+    showprov(io, flattened_provenance(ex); showprov_kwargs...)
 end
 
 function subscript_str(i)
@@ -195,16 +231,16 @@ function _deref_ssa(stmts, ex)
 end
 
 function _find_method_lambda(ex, name)
-    @assert kind(ex) == K"code_info"
+    @jl_assert kind(ex) == K"code_info" ex
     # Heuristic search through outer thunk for the method in question.
     method_found = false
     stmts = children(ex[1])
     for e in stmts
         if kind(e) == K"method" && numchildren(e) >= 2
             sig = _deref_ssa(stmts, e[2])
-            @assert kind(sig) == K"call"
+            @jl_assert kind(sig) == K"call" ex
             arg_types = _deref_ssa(stmts, sig[2])
-            @assert kind(arg_types) == K"call"
+            @jl_assert kind(arg_types) == K"call" ex
             self_type = _deref_ssa(stmts, arg_types[2])
             if kind(self_type) == K"globalref" && occursin(name, self_type.name_val)
                 return e[3]
@@ -214,7 +250,7 @@ function _find_method_lambda(ex, name)
 end
 
 function print_ir(io::IO, ex, method_filter=nothing)
-    @assert kind(ex) == K"code_info"
+    @jl_assert kind(ex) == K"code_info" ex
     if !isnothing(method_filter)
         filtered = _find_method_lambda(ex, method_filter)
         if isnothing(filtered)
@@ -229,7 +265,8 @@ end
 # TODO: JuliaLowering-the-module should always print the same way, ignoring parent modules
 function _print_ir(io::IO, ex, indent)
     added_indent = "    "
-    @assert (kind(ex) == K"lambda" || kind(ex) == K"code_info") && kind(ex[1]) == K"block"
+    @jl_assert ((kind(ex) == K"lambda" || kind(ex) == K"code_info")
+                && kind(ex[1]) == K"block") ex
     if !ex.is_toplevel_thunk && kind(ex) == K"code_info"
         slots = ex.slots
         print(io, indent, "slots: [")
@@ -262,7 +299,7 @@ function _print_ir(io::IO, ex, indent)
                 println(io, " ", string(e[3]))
             end
         elseif kind(e) == K"opaque_closure_method"
-            @assert numchildren(e) == 5
+            @jl_assert numchildren(e) == 5 e
             print(io, indent, lno, " --- opaque_closure_method ")
             for i=1:4
                 print(io, " ", e[i])
@@ -282,7 +319,8 @@ end
 # Wrap a function body in Base.Compiler.@zone for profiling
 if isdefined(Base.Compiler, Symbol("@zone"))
     macro fzone(str, f)
-        @assert f isa Expr && f.head === :function && length(f.args) === 2 && str isa String
+        @assert(f isa Expr && f.head === :function && length(f.args) === 2 && str isa String,
+                "usage: @fzone name_string <function expression>")
         esc(Expr(:function, f.args[1],
                  # Use source of our caller, not of this macro.
                  Expr(:macrocall, :(Base.Compiler.var"@zone"), __source__, str, f.args[2])))
@@ -297,7 +335,7 @@ end
 # @SyntaxTree(::Expr)
 
 function _find_SyntaxTree_macro(ex, line)
-    @assert !is_leaf(ex)
+    @jl_assert !is_leaf(ex) ex
     for c in children(ex)
         rng = byte_range(c)
         firstline = JuliaSyntax.source_line(sourcefile(c), first(rng))
@@ -311,13 +349,13 @@ function _find_SyntaxTree_macro(ex, line)
                     if kind(name) == K"."
                         name = name[2]
                     end
-                    @assert kind(name) == K"Identifier"
+                    @jl_assert kind(name) == K"Identifier" name
                     name.name_val == "@SyntaxTree"
                 end
             # We find the node we're looking for. NB: Currently assuming a max
             # of one @SyntaxTree invocation per line. Though we could relax
             # this with more heuristic matching of the Expr-AST...
-            @assert numchildren(c) == 2
+            @jl_assert numchildren(c) == 2 c
             return c[2]
         elseif !is_leaf(c)
             # Recurse
@@ -390,7 +428,7 @@ macro SyntaxTree(ex_old)
     # 4. Do the first step of JuliaLowering's syntax lowering to get
     # syntax interpolations to work
     _, ex1 = expand_forms_1(__module__, ex, false, Base.tls_world_age())
-    @assert kind(ex1) == K"call" && ex1[1].value == interpolate_ast
+    @jl_assert kind(ex1) == K"call" && ex1[1].value == interpolate_ast ex1
     Expr(:call, :interpolate_ast, SyntaxTree, ex1[3][1],
          map(e->_scope_layer_1_to_esc!(Expr(e)), ex1[4:end])...)
 end

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -527,6 +527,10 @@ vst1_ident(vcx, st; lhs=false) = @stm st begin
 end
 
 vst1_call(vcx, st) = @stm st begin
+    ([K"call" [K"Identifier"] args...], when=st[1].name_val==="cglobal") ->
+        (1 <= length(args) <= 2 ? pass() :
+            @fail(st, "cglobal must have one or two arguments")) &
+        all(vst1_call_arg, vcx, args)
     [K"call" f [K"parameters" kwargs...] args...] ->
         vst1(vcx, f) &
         all(vst1_call_arg, vcx, args) &

--- a/JuliaLowering/test/arrays_ir.jl
+++ b/JuliaLowering/test/arrays_ir.jl
@@ -269,6 +269,10 @@ LoweringError:
 #---------------------
 LoweringError:
 #= line 1 =# - invalid syntax: unknown form `nrow` or number of arguments 2
+Expression:
+  (nrow 1 1)
+Containing expressions:
+  (ncat 3 (nrow 1 (nrow 1 1)))
 
 ########################################
 # Error: bad nrow nesting
@@ -284,6 +288,10 @@ LoweringError:
 #---------------------
 LoweringError:
 #= line 1 =# - 2D `nrow` cannot be mixed with `row` in `ncat`
+Expression:
+  (nrow-2 (row 1))
+Containing expressions:
+  (ncat-3 (nrow-2 (row 1)))
 
 ########################################
 # Error: bad nrow nesting
@@ -298,6 +306,10 @@ LoweringError:
 #---------------------
 LoweringError:
 #= line 1 =# - Badly nested rows in `ncat`
+Expression:
+  (row 1)
+Containing expressions:
+  (ncat-3 (row (row 1)))
 
 ########################################
 # Simple getindex

--- a/JuliaLowering/test/branching_ir.jl
+++ b/JuliaLowering/test/branching_ir.jl
@@ -225,6 +225,12 @@ end
 #---------------------
 LoweringError:
 #= none:3 =# - Label `foo` defined multiple times
+Expression:
+  label:foo
+Containing expressions:
+  (lambda (block) (block) (block label:foo label:foo))
+  (lambda (block) (block) (block label:foo label:foo))
+  (lambda (block) (block) (block label:foo label:foo))
 
 ########################################
 # Error: using value of symbolic label
@@ -232,6 +238,13 @@ x = @label foo
 #---------------------
 LoweringError:
 #= none:1 =# - misplaced label in value position
+Expression:
+  label:foo
+Containing expressions:
+  (lambda (block) (block) (block (call core.declare_global Main.TestMod :x true) latestworld core.nothing (= #₂/tmp label:foo) (= #₃/binding_type (call core.get_binding_type Main.TestMod :x)) (= #₁/x (block (= #₅/type_tmp #₃/binding_type) (= #₄/tmp #₂/tmp) (if (call core.isa #₄/tmp #₅/type_tmp) core.nothing (= #₄/tmp (call top.convert #₅/type_tmp #₄/tmp))) #₄/tmp)) #₂/tmp))
+  (block (block (block (call core.declare_global Main.TestMod :x true) latestworld core.nothing) (= #₂/tmp label:foo) (= #₃/binding_type (call core.get_binding_type Main.TestMod :x)) (= #₁/x (block (= #₅/type_tmp #₃/binding_type) (= #₄/tmp #₂/tmp) (if (call core.isa #₄/tmp #₅/type_tmp) core.nothing (= #₄/tmp (call top.convert #₅/type_tmp #₄/tmp))) #₄/tmp)) #₂/tmp))
+  (lambda (block) (block) (block (= #₁/x label:foo)))
+  (lambda (block) (block) (= x label:foo))
 
 ########################################
 # Anonymous labeled block with valued break

--- a/JuliaLowering/test/closures_ir.jl
+++ b/JuliaLowering/test/closures_ir.jl
@@ -1109,3 +1109,7 @@ end
 #---------------------
 LoweringError:
 #= line 1 =# - Top level code was found outside any top level context. `@generated` functions may not contain closures, including `do` syntax and generators/comprehension
+Expression:
+  (call JuliaLowering.eval_closure_type Main.TestMod :#->##2 (call core.svec) (call core.svec))
+Containing expressions:
+  (call JuliaLowering.eval_closure_type Main.TestMod :#->##2 (call core.svec) (call core.svec))

--- a/JuliaLowering/test/function_calls_ir.jl
+++ b/JuliaLowering/test/function_calls_ir.jl
@@ -72,6 +72,10 @@ x^42.0
 #---------------------
 LoweringError:
 #= line 1 =# - malformed `call`
+Expression:
+  (call)
+Containing expressions:
+  (call)
 
 ########################################
 # Simple broadcast

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -421,4 +421,21 @@ emptyblock_result = JuliaLowering.eval(test_mod, Expr(:(=), :emptyblock_144, Exp
     """) == `cmdstrinnerstr123`
 end
 
+@testset "jl_assert" begin
+    st = @ast_ [K"function" "foo"::K"Identifier"]
+    err = try
+        JL.@jl_assert(1 == 2, (st, "error message 1"), (st, "error message 2"))
+        nothing
+    catch err
+        err
+    end
+    @test err isa LoweringError
+    @test err.internal === true
+    @test length(err.sts) == 2
+    @test length(err.msgs) == 2
+    shown = sprint(show, err)
+    @test contains(shown, "error message 1")
+    @test contains(shown, "error message 2")
+end
+
 end

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -424,7 +424,7 @@ end
 @testset "jl_assert" begin
     st = @ast_ [K"function" "foo"::K"Identifier"]
     err = try
-        JL.@jl_assert(1 == 2, (st, "error message 1"), (st, "error message 2"))
+        JuliaLowering.@jl_assert(1 == 2, (st, "error message 1"), (st, "error message 2"))
         nothing
     catch err
         err

--- a/JuliaLowering/test/misc_ir.jl
+++ b/JuliaLowering/test/misc_ir.jl
@@ -35,6 +35,10 @@ x."b"
 #---------------------
 LoweringError:
 #= line 1 =# - invalid syntax: unknown form `.` or number of arguments 3
+Expression:
+  (. x a 3)
+Containing expressions:
+  (. x a 3)
 
 ########################################
 # Error: Placeholder value used
@@ -253,6 +257,10 @@ LoweringError:
 #---------------------
 LoweringError:
 #= line 1 =# - expected (if cond body) or (if cond body else)
+Expression:
+  (if)
+Containing expressions:
+  (if)
 
 ########################################
 # Error: @atomic in wrong position
@@ -262,6 +270,10 @@ end
 #---------------------
 LoweringError:
 #= none:2 =# - unimplemented or unsupported `atomic` declaration
+Expression:
+  (atomic x)
+Containing expressions:
+  (let (block) (block (atomic x)))
 
 ########################################
 # GC.@preserve support

--- a/JuliaLowering/test/utils.jl
+++ b/JuliaLowering/test/utils.jl
@@ -28,7 +28,7 @@ end
 
 function _source_node(graph, src)
     id = new_id!(graph)
-    setattr!(graph, id, :kind, K"None")
+    setattr!(graph, id, :kind, K"TOMBSTONE")
     setattr!(graph, id, :source, src)
     SyntaxTree(graph, id)
 end


### PR DESCRIPTION
I'm still expecting lots of bugs on the way to proper integration, and I want
fixing them to be accessible to more than the current ~5 people.  We'll also
also be speeding through bootstrap and other large bodies of real-world code
where detailed printing is the only visibility we'll get.  This PR just improves
error output, especially in the case of internal errors from lowering.

- Allow multiple trees in one lowering error (a long-time TODO).  Printing is
  pretty basic, just (tree, message) pairs possibly followed by the provenance
  tree.
- Print jl_source (from #61006) in the provenance tree when DEBUG or from
  internal errors
- Show the offending form as an s-expression if we're limited to LineNumberNode
  provenance (previously we would just print the line number; see IR tests for
  differences)
- Show the containing expression(s) (see IR tests)
- Replace most `@assert`s with new `@jl_assert`, which can surface one or more
  trees in a verbose internal error, and can be easily disabled when
  !JuliaLowering.DEBUG.
- I've changed every `@chk` to `@jl_assert`, since the responsibility `@chk`
  once held is now that of the validator.  Most `@chk`s could probably be
  deleted, but it's not worth deciding which right now.
  - Note there are a few cases, corresponding to validator TODOS, where
    `chk`-turned-`jl_assert` may be hit from user code. This just means extra
    verbose output and an accidentally-correct label of "internal bug" until the
    check is implemented in the validator.

### TODO

Some errors are still somewhat noisy.  For example, I don't think the provenance
tree is meant to go in the final user-facing errors, but for now I'll keep it so
as to err on the side of printing too much.  I'd like to trim down the
"JuliaLowering threw given input" message given how large it is and how
imprecise the tree it prints is.
