### PR TITLE
Preserve creation world age in binding partition lists

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -66,7 +66,7 @@ using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospeciali
     _uncompressed_ir, datatype_min_ninitialized,
     partialstruct_init_undefs, fieldcount_noerror, _eval_import, _eval_using,
     get_ci_mi, get_methodtable, morespecific, specializations, has_image_globalref,
-    PARTITION_MASK_KIND, PARTITION_KIND_GUARD, PARTITION_FLAG_EXPORTED, PARTITION_FLAG_DEPRECATED,
+    PARTITION_MASK_KIND, PARTITION_KIND_GUARD, PARTITION_KIND_DECLARED_GUARD, PARTITION_FLAG_EXPORTED, PARTITION_FLAG_DEPRECATED,
     BINDING_FLAG_ANY_IMPLICIT_EDGES, is_some_implicit, IteratorSize, SizeUnknown, get_require_world, JLOptions,
     devnull, devnull as stdin
 

--- a/Compiler/src/bindinginvalidations.jl
+++ b/Compiler/src/bindinginvalidations.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using ..Compiler: _uncompressed_ir, specializations, get_ci_mi, convert, unsafe_load, cglobal, generating_output, has_image_globalref,
-    PARTITION_MASK_KIND, PARTITION_KIND_GUARD, PARTITION_FLAG_EXPORTED, PARTITION_FLAG_DEPRECATED,
+    PARTITION_MASK_KIND, PARTITION_KIND_GUARD, PARTITION_KIND_DECLARED_GUARD, PARTITION_FLAG_EXPORTED, PARTITION_FLAG_DEPRECATED,
     BINDING_FLAG_ANY_IMPLICIT_EDGES, binding_kind, partition_restriction, is_some_imported,
     is_some_binding_imported, is_some_implicit, SizeUnknown, maybe_add_binding_backedge!, walk_binding_partition, abstract_eval_partition_load, userefs
 using .Core: SimpleVector, CodeInfo
@@ -83,7 +83,7 @@ function invalidate_method_for_globalref!(gr::GlobalRef, method::Method, invalid
 end
 
 export_affecting_partition_flags(bpart::Core.BindingPartition) =
-    ((bpart.kind & PARTITION_MASK_KIND) == PARTITION_KIND_GUARD,
+    (let k = bpart.kind & PARTITION_MASK_KIND; k == PARTITION_KIND_GUARD || k == PARTITION_KIND_DECLARED_GUARD end,
      (bpart.kind & PARTITION_FLAG_EXPORTED) != 0,
      (bpart.kind & PARTITION_FLAG_DEPRECATED) != 0)
 

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -1265,7 +1265,7 @@ function UndefVarError_hint(io::IO, ex::UndefVarError)
                 else
                     print(io, "\nSuggestion: check for spelling errors or missing imports.")
                 end
-            elseif kind === PARTITION_KIND_GLOBAL || kind === PARTITION_KIND_UNDEF_CONST || kind == PARTITION_KIND_DECLARED
+            elseif kind === PARTITION_KIND_GLOBAL || kind === PARTITION_KIND_UNDEF_CONST || kind == PARTITION_KIND_DECLARED || kind == PARTITION_KIND_DECLARED_GUARD
                 print(io, "\nSuggestion: add an appropriate import or assignment. This global was declared but not assigned.")
             elseif kind === PARTITION_KIND_FAILED
                 print(io, "\nHint: It looks like two or more modules export different ",

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -249,6 +249,7 @@ const PARTITION_KIND_DECLARED           = 0x8
 const PARTITION_KIND_GUARD              = 0x9
 const PARTITION_KIND_UNDEF_CONST        = 0xa
 const PARTITION_KIND_BACKDATED_CONST    = 0xb
+const PARTITION_KIND_DECLARED_GUARD     = 0xe
 
 const PARTITION_FLAG_EXPORTED     = 0x10
 const PARTITION_FLAG_DEPRECATED   = 0x20
@@ -265,10 +266,10 @@ const JL_MODULE_USING_REEXPORT = 0x1
 is_defined_const_binding(kind::UInt8) = (kind == PARTITION_KIND_CONST || kind == PARTITION_KIND_CONST_IMPORT || kind == PARTITION_KIND_IMPLICIT_CONST || kind == PARTITION_KIND_BACKDATED_CONST)
 is_some_const_binding(kind::UInt8) = (is_defined_const_binding(kind) || kind == PARTITION_KIND_UNDEF_CONST)
 is_some_imported(kind::UInt8) = (kind == PARTITION_KIND_IMPLICIT_GLOBAL || kind == PARTITION_KIND_IMPLICIT_CONST || kind == PARTITION_KIND_EXPLICIT || kind == PARTITION_KIND_IMPORTED)
-is_some_implicit(kind::UInt8) = (kind == PARTITION_KIND_IMPLICIT_GLOBAL || kind == PARTITION_KIND_IMPLICIT_CONST || kind == PARTITION_KIND_GUARD || kind == PARTITION_KIND_FAILED)
+is_some_implicit(kind::UInt8) = (kind == PARTITION_KIND_IMPLICIT_GLOBAL || kind == PARTITION_KIND_IMPLICIT_CONST || kind == PARTITION_KIND_GUARD || kind == PARTITION_KIND_FAILED || kind == PARTITION_KIND_DECLARED_GUARD)
 is_some_explicit_imported(kind::UInt8) = (kind == PARTITION_KIND_EXPLICIT || kind == PARTITION_KIND_IMPORTED)
 is_some_binding_imported(kind::UInt8) = is_some_explicit_imported(kind) || kind == PARTITION_KIND_IMPLICIT_GLOBAL
-is_some_guard(kind::UInt8) = (kind == PARTITION_KIND_GUARD || kind == PARTITION_KIND_FAILED || kind == PARTITION_KIND_UNDEF_CONST)
+is_some_guard(kind::UInt8) = (kind == PARTITION_KIND_GUARD || kind == PARTITION_KIND_FAILED || kind == PARTITION_KIND_UNDEF_CONST || kind == PARTITION_KIND_DECLARED_GUARD)
 
 function lookup_binding_partition(world::UInt, b::Core.Binding)
     ccall(:jl_get_binding_partition, Ref{Core.BindingPartition}, (Any, UInt), b, world)

--- a/base/show.jl
+++ b/base/show.jl
@@ -3356,6 +3356,8 @@ function print_partition(io::IO, partition::Core.BindingPartition)
         print(io, "undefined const binding")
     elseif kind == PARTITION_KIND_GUARD
         print(io, "undefined binding - guard entry")
+    elseif kind == PARTITION_KIND_DECLARED_GUARD
+        print(io, "undefined binding - explicitly declared with `public` or `export`")
     elseif kind == PARTITION_KIND_FAILED
         print(io, "ambiguous binding - guard entry")
     elseif kind == PARTITION_KIND_DECLARED

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1098,7 +1098,7 @@ STATIC_INLINE int jl_bkind_is_some_explicit_import(enum jl_partition_kind kind) 
 }
 
 STATIC_INLINE int jl_bkind_is_some_guard(enum jl_partition_kind kind) JL_NOTSAFEPOINT {
-    return kind == PARTITION_KIND_FAILED || kind == PARTITION_KIND_GUARD;
+    return kind == PARTITION_KIND_FAILED || kind == PARTITION_KIND_GUARD || kind == PARTITION_KIND_DECLARED_GUARD;
 }
 
 STATIC_INLINE int jl_bkind_is_some_implicit(enum jl_partition_kind kind) JL_NOTSAFEPOINT {

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -316,7 +316,7 @@ void jl_declare_global(jl_module_t *m, jl_value_t *arg, jl_value_t *set_type, in
         bpart = jl_get_binding_partition(b, new_world);
         enum jl_partition_kind kind = jl_binding_kind(bpart);
         if (kind != PARTITION_KIND_GLOBAL) {
-            if (jl_bkind_is_some_implicit(kind) || kind == PARTITION_KIND_DECLARED) {
+            if (jl_bkind_is_some_implicit(kind) || kind == PARTITION_KIND_DECLARED || kind == PARTITION_KIND_DECLARED_GUARD) {
                 if (kind == new_kind) {
                     if (!set_type)
                         goto done;


### PR DESCRIPTION
This has two commits which should perhaps be merged without squashing. The first commit fixes two cases in which `master` may backdate a binding to before the world age of the corresponding module. The second commit introduces a new kind of guard partition, `PARTITION_KIND_DECLARED_GUARD`, whose purpose is to record the world age of creation for bindings that do not yet have an assigned value (e.g., `export x` or `public y`).

This should resolve the challenges facing #60736 but is kept independent of that work. I am uneasy about declaring this backport-worthy, at least for 1.12. Soliciting the thoughts of others on this point, as #60736 will not be backportable without this.

Co-written with Claude.