### PR TITLE
inference: Merge `bb_vartables`+`bb_slot_aliases` into `BBEntryState`

### DIFF
--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -209,6 +209,18 @@ to enable flow-sensitive analysis.
 """
 const VarTable = Vector{VarState}
 
+"""
+    BBEntryState
+
+Bundles the per-basic-block variable-type table ([`VarTable`](@ref)) and slot-alias table
+(`Vector{Int}`) into a single value. This ensures that both components are always present or
+absent together.
+"""
+struct BBEntryState
+    vartable::VarTable
+    aliases::Vector{Int}
+end
+
 struct StatementState
     vtypes::Union{VarTable,Nothing}
     saw_latestworld::Bool
@@ -275,22 +287,21 @@ mutable struct InferenceState
     ip::BitSet#=TODO BoundedMinPrioritySet=# # current active instruction pointers
     handler_info::Union{Nothing,HandlerInfo{TryCatchFrame}}
     ssavalue_uses::Vector{BitSet} # ssavalue sparsity and restart info
-    # TODO: Could keep this sparsely by doing structural liveness analysis ahead of time.
-    bb_vartables::Vector{Union{Nothing,VarTable}} # nothing if not analyzed yet
-
-    # Slot alias tracking
+    # Per-basic-block entry state. `nothing` if the BB has not been analyzed yet.
+    # Populated lazily during the main inference loop by `update_bbstate!`, which merges
+    # the current exit state into each successor. Both the variable-type table and the
+    # slot-alias table are bundled together in a `BBEntryState` so that the type system
+    # guarantees they are always in sync.
     #
-    # `slot_aliases[i] == j` means slot `i` currently holds the same value as slot `j`.
-    # `slot_aliases[i] == 0` means slot `i` is not known to be aliased to any other slot.
+    # Slot alias tracking:
+    # `aliases[i] == j` means slot `i` currently holds the same value as slot `j`.
+    # `aliases[i] == 0` means slot `i` is not known to be aliased to any other slot.
     # The table is always kept "flat": aliases always point directly to the root slot, not
     # through a chain, so a single lookup suffices to find all aliases of a given slot.
-    #
-    # `bb_slot_aliases[bb]` stores the alias state at the **entry** of BB `bb`. Like
-    # `bb_vartables`, it is populated lazily during the main inference loop by
-    # `update_bbstate!`, which intersects the current exit state into each successor.
     # The working alias table for the BB currently being analyzed is kept as a local
     # variable `slot_aliases` in `typeinf_local` (analogous to `currstate`).
-    bb_slot_aliases::Vector{Union{Nothing,Vector{Int}}}
+    # TODO: Could keep this sparsely by doing structural liveness analysis ahead of time.
+    bb_states::Vector{Union{Nothing,BBEntryState}}
 
     bb_saw_latestworld::Vector{Bool}
     ssavaluetypes::Vector{Any}
@@ -358,11 +369,10 @@ mutable struct InferenceState
 
         nslots = length(src.slotflags)
         slottypes = Vector{Any}(undef, nslots)
-        bb_slot_aliases = Union{Nothing,Vector{Int}}[nothing for _ = 1:length(cfg.blocks)]
-        bb_slot_aliases[1] = zeros(Int, nslots)  # entry BB: no aliases at function entry
         bb_saw_latestworld = Bool[false for _ = 1:length(cfg.blocks)]
-        bb_vartables = Union{Nothing,VarTable}[ nothing for _ = 1:length(cfg.blocks) ]
-        bb_vartable1 = bb_vartables[1] = VarTable(undef, nslots)
+        bb_vartable1 = VarTable(undef, nslots)
+        bb_states = Union{Nothing,BBEntryState}[nothing for _ = 1:length(cfg.blocks)]
+        bb_states[1] = BBEntryState(bb_vartable1, zeros(Int, nslots))
         argtypes = result.argtypes
 
         argtypes = va_process_argtypes(typeinf_lattice(interp), argtypes, src.nargs, src.isva, mi)
@@ -409,7 +419,7 @@ mutable struct InferenceState
 
         this = new(
             mi, valid_worlds, mod, sptypes, slottypes, src, cfg, spec_info,
-            currbb, currpc, ip, handler_info, ssavalue_uses, bb_vartables, bb_slot_aliases, bb_saw_latestworld, ssavaluetypes, ssaflags, edges, stmt_info,
+            currbb, currpc, ip, handler_info, ssavalue_uses, bb_states, bb_saw_latestworld, ssavaluetypes, ssaflags, edges, stmt_info,
             tasks, pclimitations, limitations, cycle_backedges, callstack, parentid, frameid, cycleid,
             result, unreachable, bestguess, exc_bestguess, ipo_effects,
             _time_ns(), 0.0, 0, 0,

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -924,13 +924,14 @@ function type_annotate!(::AbstractInterpreter, sv::InferenceState)
         end
     end
 
-    # widen slot wrappers (`Conditional` and `MustAlias`) in `bb_vartables`
-    for varstate in sv.bb_vartables
-        if varstate !== nothing
+    # widen slot wrappers (`Conditional` and `MustAlias`) in `bb_states`
+    for bbstate in sv.bb_states
+        if bbstate !== nothing
+            vartable = bbstate.vartable
             for slot in 1:nslots
-                vt = varstate[slot]
+                vt = vartable[slot]
                 widened_type = widenslotwrapper(ignorelimited(vt.typ))
-                varstate[slot] = VarState(widened_type, vt.ssadef, vt.undef)
+                vartable[slot] = VarState(widened_type, vt.ssadef, vt.undef)
             end
         end
     end

--- a/Compiler/test/irpasses.jl
+++ b/Compiler/test/irpasses.jl
@@ -1500,9 +1500,9 @@ let code = Any[
     interp = Compiler.NativeInterpreter()
     sv = Compiler.OptimizationState(mi, src, interp)
     # (_4 !== nothing) conditional narrows the type, triggering PiNodes
-    sv.bb_vartables[#= block_id =# 3][#= slot_id =# 4] = VarState(Bool, #= def =# 5, #= maybe_undef =# false)
-    sv.bb_vartables[#= block_id =# 4][#= slot_id =# 4] = VarState(Bool, #= def =# 7, #= maybe_undef =# false)
-    sv.bb_vartables[#= block_id =# 5][#= slot_id =# 4] = VarState(Bool, #= def =# 7, #= maybe_undef =# false)
+    sv.bb_states[#=block_id=#3].vartable[#=slot_id=#4] = VarState(Bool, #=def=#5, #=maybe_undef=#false)
+    sv.bb_states[#=block_id=#4].vartable[#=slot_id=#4] = VarState(Bool, #=def=#7, #=maybe_undef=#false)
+    sv.bb_states[#=block_id=#5].vartable[#=slot_id=#4] = VarState(Bool, #=def=#7, #=maybe_undef=#false)
 
     ir = Compiler.convert_to_ircode(src, sv)
     ir = Compiler.slot2reg(ir, src, sv)


### PR DESCRIPTION
Introduce `BBEntryState` that bundles the per-basic-block variable-type table (`VarTable`) and slot-alias table into a single place:

Previously, `update_bbstate!` set both arrays in the `if` branch but the type system had no way to express that invariant, forcing a runtime `typeassert` (`frame.bb_slot_aliases[bb]::Vector{Int}`) in the `else` branch. With `BBEntryState` the invariant is structural and a non-`nothing` entry always carries both components, so no assertion is needed.