### PR TITLE
show context before for unexpected test passes

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -299,6 +299,9 @@ function Base.show(io::IO, t::Error)
         # A test that was expected to fail did not
         println(io, " Unexpected Pass")
         println(io, " Expression: ", t.orig_expr)
+        if t.context !== nothing
+            println(io, "     Context: ", t.context)
+        end
         print(io, " Got correct result, please change to @test if no longer broken.")
     elseif t.test_type === :nontest_error
         # we had an error outside of a @test
@@ -306,7 +309,7 @@ function Base.show(io::IO, t::Error)
         # Capture error message and indent to match
         join(io, ("  " * line for line in filter!(!isempty, split(t.backtrace, "\n"))), "\n")
     end
-    if t.context !== nothing
+    if t.context !== nothing && t.test_type !== :test_unbroken
         print(io, "\n     Context: ", t.context)
     end
 end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -300,7 +300,7 @@ function Base.show(io::IO, t::Error)
         println(io, " Unexpected Pass")
         println(io, " Expression: ", t.orig_expr)
         if t.context !== nothing
-            println(io, "     Context: ", t.context)
+            println(io, "    Context: ", t.context)
         end
         print(io, " Got correct result, please change to @test if no longer broken.")
     elseif t.test_type === :nontest_error

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -2402,6 +2402,30 @@ end
         @test recorded_error2.context !== nothing
         @test occursin("(x, y) = (42, \"hello\")", recorded_error2.context)
     end
+
+    # Unexpected pass (broken=true) should show context before "Got correct result" message
+    @testset "context shown for unexpected pass in context testset" begin
+        mock_parent4 = MockParentTestSet()
+        ctx_ts4 = Test.ContextTestSet(mock_parent4, :x, 42)
+
+        unbroken_result = Test.Error(:test_unbroken, "x != 99", "true", "", nothing, LineNumberNode(1, :test))
+        Test.record(ctx_ts4, unbroken_result)
+
+        @test length(mock_parent4.results) == 1
+        recorded = mock_parent4.results[1]
+        @test recorded isa Test.Error
+        @test recorded.context !== nothing
+        @test occursin("x = 42", recorded.context)
+
+        str = sprint(show, recorded)
+        @test occursin("Unexpected Pass", str)
+        @test occursin("Context:", str)
+        @test occursin("x = 42", str)
+        # Context should appear before "Got correct result"
+        ctx_pos = findfirst("Context:", str)
+        got_pos = findfirst("Got correct result", str)
+        @test first(ctx_pos) < first(got_pos)
+    end
 end
 
 @testset "io argument for Test output functions" begin


### PR DESCRIPTION
fixes #58972

moved the context display for unbroken errors to show the matching position for the let testset