### PR TITLE
Allow JuliaOJIT::linkCallTarget to link to equivalent CodeInstance

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -614,15 +614,12 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_ci_equiv(jl_code_instance_t *ci JL_PROPA
     jl_method_instance_t *mi = jl_get_ci_mi(ci);
     jl_value_t *owner = ci->owner;
     jl_value_t *rettype = ci->rettype;
-    size_t min_world = jl_atomic_load_relaxed(&ci->min_world);
-    size_t max_world = jl_atomic_load_relaxed(&ci->max_world);
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
     while (codeinst) {
         if (codeinst != ci &&
             jl_atomic_load_relaxed(&codeinst->inferred) != NULL &&
-            (target_world ? 1 : jl_atomic_load_relaxed(&codeinst->invoke) != NULL) &&
-            jl_atomic_load_relaxed(&codeinst->min_world) <= (target_world ? target_world : min_world) &&
-            jl_atomic_load_relaxed(&codeinst->max_world) >= (target_world ? target_world : max_world) &&
+            jl_atomic_load_relaxed(&codeinst->min_world) <= target_world &&
+            jl_atomic_load_relaxed(&codeinst->max_world) >= target_world &&
             jl_egal(codeinst->def, def) &&
             jl_egal(codeinst->owner, owner) &&
             jl_egal(codeinst->rettype, rettype)) {

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2217,6 +2217,8 @@ orc::SymbolStringPtr JuliaOJIT::linkCallTarget(orc::MaterializationResponsibilit
                                                jl_code_instance_t *CI, jl_invoke_api_t API)
 {
     auto It = CISymbols.find(CI);
+    if (It == CISymbols.end())
+        It = CISymbols.find(findCompatibleCI(CI));
     if (It != CISymbols.end() && It->second.invoke_api == API)
         return It->second.specptr;
 
@@ -2247,6 +2249,32 @@ orc::SymbolStringPtr JuliaOJIT::linkCallTarget(orc::MaterializationResponsibilit
 
     assert(Sym->invoke_api == API);
     return Sym->specptr;
+}
+
+jl_code_instance_t *JuliaOJIT::findCompatibleCI(jl_code_instance_t *CI)
+{
+    // add_codeinsts_to_jit! may have added an equivalent CI to the JIT, but
+    // the invoke itself won't be updated.
+    auto MI = jl_get_ci_mi(CI);
+    jl_value_t *Def = CI->def;
+    jl_value_t *Owner = CI->owner;
+    jl_value_t *RetType = CI->rettype;
+    size_t MinWorld = jl_atomic_load_relaxed(&CI->min_world);
+    size_t MaxWorld = jl_atomic_load_relaxed(&CI->max_world);
+    auto IsCompatible = [=](jl_code_instance_t *CI2) {
+        return jl_atomic_load_relaxed(&CI2->min_world) <= MinWorld &&
+               jl_atomic_load_relaxed(&CI2->max_world) >= MaxWorld &&
+               jl_egal(CI2->def, Def) && jl_egal(CI2->owner, Owner) &&
+               jl_egal(CI2->rettype, RetType);
+    };
+    for (auto CI2 = jl_atomic_load_relaxed(&MI->cache); CI2;
+         CI2 = jl_atomic_load_relaxed(&CI2->next)) {
+        if (CI2 != CI && IsCompatible(CI) &&
+            (CISymbols.contains(CI2) || jl_atomic_load_relaxed(&CI2->invoke))) {
+            return CI2;
+        }
+    }
+    return CI;
 }
 
 CISymbolPtr *JuliaOJIT::linkCISymbol(jl_code_instance_t *CI)

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2261,7 +2261,7 @@ jl_code_instance_t *JuliaOJIT::findCompatibleCI(jl_code_instance_t *CI)
     jl_value_t *RetType = CI->rettype;
     size_t MinWorld = jl_atomic_load_relaxed(&CI->min_world);
     size_t MaxWorld = jl_atomic_load_relaxed(&CI->max_world);
-    auto IsCompatible = [=](jl_code_instance_t *CI2) {
+    auto IsCompatible = [=](jl_code_instance_t *CI2) JL_NOTSAFEPOINT {
         return jl_atomic_load_relaxed(&CI2->min_world) <= MinWorld &&
                jl_atomic_load_relaxed(&CI2->max_world) >= MaxWorld &&
                jl_egal(CI2->def, Def) && jl_egal(CI2->owner, Owner) &&

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -834,6 +834,11 @@ protected:
                                         jl_code_instance_t *CI,
                                         jl_invoke_api_t API) JL_NOTSAFEPOINT;
 
+    // If the provided CodeInstance is neither compiled nor has an ORC symbol in
+    // CISymbols, look for a compatible CodeInstance in the MethodInstance's
+    // cache that does.  Returns the original CodeInstance if none exists.
+    jl_code_instance_t *findCompatibleCI(jl_code_instance_t *CI);
+
     // Create an ORC symbol and entry in CISymbols for the CI's specptr,
     // returning a pointer into CISymbols or NULL if the CI is not compiled.
     CISymbolPtr *linkCISymbol(jl_code_instance_t *CI) JL_NOTSAFEPOINT;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -837,7 +837,7 @@ protected:
     // If the provided CodeInstance is neither compiled nor has an ORC symbol in
     // CISymbols, look for a compatible CodeInstance in the MethodInstance's
     // cache that does.  Returns the original CodeInstance if none exists.
-    jl_code_instance_t *findCompatibleCI(jl_code_instance_t *CI);
+    jl_code_instance_t *findCompatibleCI(jl_code_instance_t *CI) JL_NOTSAFEPOINT;
 
     // Create an ORC symbol and entry in CISymbols for the CI's specptr,
     // returning a pointer into CISymbols or NULL if the CI is not compiled.


### PR DESCRIPTION
When add_codeinsts_to_jit! finds an equivalent CodeInstance for an invoke with jl_get_ci_equiv, we add that CodeInstance to the JIT instead of the original, but leave the invoke statement pointing to the old one.  This results in the generation of unnecessary tojlinvoke trampolines, even with the jl_typeinf_lock in place.