### PR TITLE
Preferences: Fully serialize compile-time preferences

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -280,7 +280,7 @@ include("threadcall.jl")
 # code loading
 include("uuid.jl")
 include("pkgid.jl")
-include("toml_parser.jl")
+include("toml/toml.jl")
 include("linking.jl")
 include("loading.jl")
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1391,7 +1391,7 @@ function find_all_in_cache_path(pkg::PkgId, DEPOT_PATH::typeof(DEPOT_PATH)=DEPOT
                     if iszero(isvalid_cache_header(io))
                         false
                     else
-                        _, _, _, _, _, _, _, flags = parse_cache_header(io, path)
+                        _, _, _, _, _, _, flags = parse_cache_header(io, path)
                         CacheFlags(flags).use_pkgimages
                     end
                 finally
@@ -2163,7 +2163,7 @@ function _tryrequire_from_serialized(pkg::PkgId, path::String, ocachepath::Union
     io = open(path, "r")
     try
         iszero(isvalid_cache_header(io)) && return ArgumentError("Incompatible header in cache file $path.")
-        _, (includes, _, _), depmodnames, _, _, _, clone_targets, _ = parse_cache_header(io, path)
+        _, (includes, _, _), depmodnames, _, _, clone_targets, _ = parse_cache_header(io, path)
 
 
         pkgimage = !isempty(clone_targets)
@@ -3409,7 +3409,7 @@ function compilecache_dir(pkg::PkgId)
     return joinpath(DEPOT_PATH[1], entrypath)
 end
 
-function compilecache_path(pkg::PkgId, prefs_hash::UInt64; flags::CacheFlags=CacheFlags(), project::String=something(Base.active_project(), ""))::String
+function compilecache_path(pkg::PkgId, prefs_blob::String; flags::CacheFlags=CacheFlags(), project::String=something(Base.active_project(), ""))::String
     entrypath, entryfile = cache_file_entry(pkg)
     cachepath = joinpath(DEPOT_PATH[1], entrypath)
     isdir(cachepath) || mkpath(cachepath)
@@ -3426,8 +3426,7 @@ function compilecache_path(pkg::PkgId, prefs_hash::UInt64; flags::CacheFlags=Cac
             cpu_target = unsafe_string(JLOptions().cpu_target)
         end
         crc = _crc32c(cpu_target, crc)
-
-        crc = _crc32c(prefs_hash, crc)
+        crc = _crc32c(prefs_blob, crc)
         project_precompile_slug = slug(crc, 5)
         abspath(cachepath, string(entryfile, "_", project_precompile_slug, ".ji"))
     end
@@ -3498,10 +3497,10 @@ function compilecache(pkg::PkgId, spec::PkgLoadSpec, internal_stderr::IO = stder
                 Linking.link_image(tmppath_o, tmppath_so)
             end
 
-            # Read preferences hash back from .ji file (we can't precompute because
-            # we don't actually know what the list of compile-time preferences are without compiling)
-            prefs_hash = preferences_hash(tmppath)
-            cachefile = compilecache_path(pkg, prefs_hash; flags=cacheflags)
+            # Read preferences blob back from .ji file (we can't precompute because we don't
+            # actually know what the list of compile-time preferences are without compiling)
+            prefs_blob = preferences_blob(tmppath)
+            cachefile = compilecache_path(pkg, prefs_blob; flags=cacheflags)
             ocachefile = cache_objects ? ocachefile_from_cachefile(cachefile) : nothing
 
             # append checksum for so to the end of the .ji file:
@@ -3732,18 +3731,10 @@ function _parse_cache_header(f::IO, cachefile::AbstractString)
             push!(includes, CacheHeaderIncludes(modkey, depname, fsize, hash, mtime, modpath))
         end
     end
-    prefs = String[]
-    while true
-        n2 = read(f, Int32)
-        totbytes -= 4
-        if n2 == 0
-            break
-        end
-        push!(prefs, String(read(f, n2)))
-        totbytes -= n2
-    end
-    prefs_hash = read(f, UInt64)
-    totbytes -= 8
+    n2 = read(f, Int32)
+    totbytes -= 4
+    prefs_blob = String(read(f, n2))
+    totbytes -= n2
     srctextpos = read(f, Int64)
     totbytes -= 8
     @assert totbytes == 0 "header of cache file appears to be corrupt (totbytes == $(totbytes))"
@@ -3754,12 +3745,12 @@ function _parse_cache_header(f::IO, cachefile::AbstractString)
 
     srcfiles = srctext_files(f, srctextpos, includes)
 
-    return modules, (includes, srcfiles, requires), required_modules, srctextpos, prefs, prefs_hash, clone_targets, flags, syntax_version
+    return modules, (includes, srcfiles, requires), required_modules, srctextpos, prefs_blob, clone_targets, flags, syntax_version
 end
 
 function parse_cache_header(f::IO, cachefile::AbstractString)
     modules, (includes, srcfiles, requires), required_modules,
-        srctextpos, prefs, prefs_hash, clone_targets, flags, syntax_version = _parse_cache_header(f, cachefile)
+        srctextpos, prefs_blob, clone_targets, flags, syntax_version = _parse_cache_header(f, cachefile)
 
     includes_srcfiles = CacheHeaderIncludes[]
     includes_depfiles = CacheHeaderIncludes[]
@@ -3833,7 +3824,7 @@ function parse_cache_header(f::IO, cachefile::AbstractString)
         end
     end
 
-    return modules, (includes, includes_srcfiles, requires), required_modules, srctextpos, prefs, prefs_hash, clone_targets, flags, syntax_version
+    return modules, (includes, includes_srcfiles, requires), required_modules, srctextpos, prefs_blob, clone_targets, flags, syntax_version
 end
 
 function parse_cache_header(cachefile::String)
@@ -3847,14 +3838,14 @@ function parse_cache_header(cachefile::String)
     end
 end
 
-preferences_hash(f::IO, cachefile::AbstractString) = parse_cache_header(f, cachefile)[6]
-function preferences_hash(cachefile::String)
+preferences_blob(f::IO, cachefile::AbstractString) = parse_cache_header(f, cachefile)[5]
+function preferences_blob(cachefile::String)
     io = open(cachefile, "r")
     try
         if iszero(isvalid_cache_header(io))
             throw(ArgumentError("Incompatible header in cache file $cachefile."))
         end
-        return preferences_hash(io, cachefile)
+        return preferences_blob(io, cachefile)
     finally
         close(io)
     end
@@ -3876,7 +3867,7 @@ function cache_dependencies(cachefile::String)
 end
 
 function read_dependency_src(io::IO, cachefile::AbstractString, filename::AbstractString)
-    _, (includes, _, _), _, srctextpos, _, _, _, _ = parse_cache_header(io, cachefile)
+    _, (includes, _, _), _, srctextpos, _, _, _ = parse_cache_header(io, cachefile)
     srctextpos == 0 && error("no source-text stored in cache file")
     seek(io, srctextpos)
     return _read_dependency_src(io, filename, includes)
@@ -4076,42 +4067,48 @@ function get_preferences(uuid::Union{UUID,Nothing} = nothing)
     return merged_prefs
 end
 
-function get_preferences_hash(uuid::Union{UUID, Nothing}, prefs_list::Vector{String})
-    # Start from a predictable hash point to ensure that the same preferences always
-    # hash to the same value, modulo changes in how Dictionaries are hashed.
-    h = UInt(0)
-    uuid === nothing && return UInt64(h)
-
-    # Load the preferences
-    prefs = get_preferences(uuid)
-
-    # Walk through each name that's called out as a compile-time preference
-    for name in prefs_list
-        prefs_value = get(prefs, name, nothing)
-        if prefs_value !== nothing
-            h = hash(prefs_value, h)::UInt
-        end
-    end
-    # We always return a `UInt64` so that our serialization format is stable
-    return UInt64(h)
-end
-
-get_preferences_hash(m::Module, prefs_list::Vector{String}) = get_preferences_hash(PkgId(m).uuid, prefs_list)
-
 # This is how we keep track of who is using what preferences at compile-time
 const COMPILETIME_PREFERENCES = Dict{UUID,Set{String}}()
 
-# In `Preferences.jl`, if someone calls `load_preference(@__MODULE__, key)` while we're precompiling,
-# we mark that usage as a usage at compile-time and call this method, so that at the end of `.ji` generation,
-# we can record the list of compile-time preferences and embed that into the `.ji` header
+# This is used by `Preferences.load_preference` to record any (pre)compile-time preference
+# queries, which the resulting pkgimage will be keyed on to detect preference changes.
 function record_compiletime_preference(uuid::UUID, key::String)
     pref = get!(Set{String}, COMPILETIME_PREFERENCES, uuid)
     push!(pref, key)
     return nothing
 end
-get_compiletime_preferences(uuid::UUID) = collect(get(Vector{String}, COMPILETIME_PREFERENCES, uuid))
-get_compiletime_preferences(m::Module) = get_compiletime_preferences(PkgId(m).uuid)
-get_compiletime_preferences(::Nothing) = String[]
+
+# Return a serialized "blob" of all observed (at compile-time) preferences.
+# This is called at pkgimage write time (.ji generation).
+function get_preferences_blob()
+    isempty(COMPILETIME_PREFERENCES) && return ""
+    observed = Dict{String, Any}()
+    unset = Dict{String, Any}()
+    for (uuid, pref_keys) in COMPILETIME_PREFERENCES
+        uuid_prefs = get_preferences(uuid)
+        uuid_str = string(uuid)
+        for key in pref_keys
+            if haskey(uuid_prefs, key)
+                uuid_observed = get!(Dict{String, Any}, observed, uuid_str)
+                uuid_observed[key] = uuid_prefs[key]
+            else
+                # preferences that were not set are tracked in a
+                # separate table to prevent name / value collisions
+                uuid_unset = get!(Set{Any}, unset, uuid_str)
+                push!(uuid_unset, key)
+            end
+        end
+    end
+    for (uuid, uuid_unset) in pairs(unset)
+        unset[uuid] = sort!(collect(uuid_unset))
+    end
+    if !isempty(unset)
+        observed["unset"] = unset
+    end
+    buf = IOBuffer()
+    TOML.Printer.print(buf, observed; sorted=true)
+    return String(take!(buf))
+end
 
 function check_clone_targets(clone_targets)
     rejection_reason = ccall(:jl_check_pkgimage_clones, Any, (Ptr{Cchar},), clone_targets)
@@ -4125,10 +4122,10 @@ global mkpidlock_hook::Any
 global trymkpidlock_hook::Any
 global parse_pidfile_hook::Any
 
-# The preferences hash is only known after precompilation so just assume no preferences.
+# The preferences blob is only known after precompilation so just assume no preferences.
 # Also ignore the active project, which means that if all other conditions are equal,
 # the same package cannot be precompiled from different projects and/or different preferences at the same time.
-compilecache_pidfile_path(pkg::PkgId; flags::CacheFlags=CacheFlags()) = compilecache_path(pkg, UInt64(0); project="", flags) * ".pidfile"
+compilecache_pidfile_path(pkg::PkgId; flags::CacheFlags=CacheFlags()) = compilecache_path(pkg, ""; project="", flags) * ".pidfile"
 
 const compilecache_pidlock_stale_age = 10
 
@@ -4227,6 +4224,54 @@ function cache_syntax_version(ver::VersionNumber)
     UInt8(clamp(ver.minor - 13, 0, 255))
 end
 
+# This custom equality predicate is analogous to `===`, except that it also
+# compares mutable containers structurally. This allows us to differentiate
+# `1.0` / `1` / `true` in Preferences, despite these being normally `isequal`
+toml_egal(@nospecialize(A), @nospecialize(B)) = A === B
+
+function toml_egal(A::AbstractArray, B::AbstractArray)
+    axes(A) != axes(B) && return false
+    for (a, b) in zip(A, B)
+        !toml_egal(a, b) && return false
+    end
+    return true
+end
+
+function toml_egal(A::AbstractDict, B::AbstractDict)
+    isa(A,IdDict) != isa(B,IdDict) && return false
+    length(A) != length(B) && return false
+    for pair in A
+        !in(pair, B, toml_egal) && return false
+    end
+    return true
+end
+
+function stale_prefs(prefs_blob::String)
+    # ensure any preferences observed match their precompile-time values
+    prefs_blob == "" && return false # no observed preferences (fast-path)
+    prefs_data = TOML.parse(TOML.Parser{nothing}(prefs_blob))
+
+    for (uuid, observed) in prefs_data
+        uuid == "unset" && continue
+        curr = get_preferences(UUID(uuid))
+        for (key, val) in observed
+            # any set preferences should have the same value
+            !haskey(curr, key) && return true
+            !toml_egal(curr[key], val) && return true
+        end
+    end
+    if haskey(prefs_data, "unset")
+        for (uuid, observed) in prefs_data["unset"]
+            curr = get_preferences(UUID(uuid))
+            for key in observed
+                # any unset preferences should still be unset
+                haskey(curr, key) && return true
+            end
+        end
+    end
+    return false
+end
+
 # returns true if it "cachefile.ji" is stale relative to "modpath.jl" and build_id for modkey
 # otherwise returns the list of dependencies to also check
 @constprop :none function stale_cachefile(modpath::String, cachefile::String; kwargs...)
@@ -4253,7 +4298,7 @@ end
             record_reason(reasons, "different Julia build configuration")
             return true # incompatible cache file
         end
-        modules, (includes, _, requires), required_modules, srctextpos, prefs, prefs_hash, clone_targets, actual_flags, syntax_version = parse_cache_header(io, cachefile)
+        modules, (includes, _, requires), required_modules, srctextpos, prefs_blob, clone_targets, actual_flags, syntax_version = parse_cache_header(io, cachefile)
         if isempty(modules)
             return true # ignore empty file
         end
@@ -4413,9 +4458,8 @@ end
             end
         end
 
-        curr_prefs_hash = get_preferences_hash(id.uuid, prefs)
-        if prefs_hash != curr_prefs_hash
-            @debug "Rejecting cache file $cachefile because preferences hash does not match 0x$(string(prefs_hash, base=16)) != 0x$(string(curr_prefs_hash, base=16))"
+        if stale_prefs(prefs_blob)
+            @debug "Rejecting cache file $cachefile because preferences have changed"
             record_reason(reasons, "package preferences changed")
             return true
         end

--- a/base/toml/parser.jl
+++ b/base/toml/parser.jl
@@ -1,12 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-"""
-`Base.TOML` is an undocumented internal part of Julia's TOML parser
-implementation.  Users should call the documented interface in the
-TOML.jl standard library instead (by `import TOML` or `using TOML`).
-"""
-module TOML
-
 using Base: IdSet
 
 # we parse DateTime into these internal structs,
@@ -1232,6 +1225,4 @@ function take_chunks(l::Parser, unescape::Bool)::String
     end
     empty!(l.chunks)
     return unescape ? unescape_string(str) : str
-end
-
 end

--- a/base/toml/printer.jl
+++ b/base/toml/printer.jl
@@ -1,9 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-import Dates
-
 import Base: @invokelatest
-import ..isvalid_barekey_char
+import ..isvalid_barekey_char # from Parser
 
 function print_toml_escaped(io::IO, s::AbstractString)
     for c::AbstractChar in s
@@ -33,9 +31,11 @@ function print_toml_escaped(io::IO, s::AbstractString)
     end
 end
 
-const TOMLValue = Union{AbstractVector, AbstractDict, Bool, Integer, AbstractFloat, AbstractString,
-                        Dates.DateTime, Dates.Time, Dates.Date, Base.TOML.DateTime, Base.TOML.Time, Base.TOML.Date}
+const BaseTOMLValue = Union{AbstractVector, AbstractDict, Bool, Integer, AbstractFloat, AbstractString,
+                            Base.TOML.DateTime, Base.TOML.Time, Base.TOML.Date}
 
+is_valid_toml_value(@nospecialize(::Any)) = false
+is_valid_toml_value(@nospecialize(::BaseTOMLValue)) = true
 
 ########
 # Keys #
@@ -63,7 +63,7 @@ function to_toml_value(@nospecialize(f::Function), value)
         error("type `$(typeof(value))` is not a valid TOML type, pass a conversion function to `TOML.print`")
     end
     toml_value = f(value)
-    if !(toml_value isa TOMLValue)
+    if !is_valid_toml_value(toml_value)
         error("TOML syntax function for type `$(typeof(value))` did not return a valid TOML type but a `$(typeof(toml_value))`")
     end
     return toml_value
@@ -88,32 +88,64 @@ function printvalue(f::Function, io::IO, value::AbstractVector, sorted::Bool)
     Base.print(io, "]")
 end
 
-function printvalue(f::Function, io::IO, value::TOMLValue, sorted::Bool)
-    value isa Base.TOML.DateTime && (value = Dates.DateTime(value))
-    value isa Base.TOML.Time && (value = Dates.Time(value))
-    value isa Base.TOML.Date && (value = Dates.Date(value))
-    value isa Dates.DateTime ? Base.print(io, Dates.format(value, Dates.dateformat"YYYY-mm-dd\THH:MM:SS.sss\Z")) :
-    value isa Dates.Time     ? Base.print(io, Dates.format(value, Dates.dateformat"HH:MM:SS.sss")) :
-    value isa Dates.Date     ? Base.print(io, Dates.format(value, Dates.dateformat"YYYY-mm-dd")) :
-    value isa Bool           ? Base.print(io, value ? "true" : "false") :
-    value isa Integer        ? print_integer(io, value) :  # Julia's own printing should be compatible with TOML on integers
-    value isa AbstractFloat  ? Base.print(io, isnan(value) ? "nan" :
-                                              isinf(value) ? string(value > 0 ? "+" : "-", "inf") :
-                                              Float64(value)) :  # TOML specifies IEEE 754 binary64 for float
-    value isa AbstractString ? (qmark = Base.contains(value, "\n") ? "\"\"\"" : "\"";
-                                Base.print(io, qmark);
-                                print_toml_escaped(io, value);
-                                Base.print(io, qmark)) :
-    value isa AbstractDict ? print_inline_table(f, io, value, sorted) :
-    error("internal error in TOML printing, unhandled value")
+function printvalue(f::Function, io::IO, value::Base.TOML.DateTime, sorted::Bool)
+    printvalue(f, io, value.date, sorted)
+    Base.print(io, "T")
+    printvalue(f, io, value.time, sorted)
+    Base.print(io, "Z")
 end
 
-function print_integer(io::IO, value::Integer)
+function printvalue(f::Function, io::IO, value::Base.TOML.Time, sorted::Bool)
+    Base.print(io, string(value.hour, pad=2))
+    Base.print(io, ":")
+    Base.print(io, string(value.minute, pad=2))
+    Base.print(io, ":")
+    Base.print(io, string(value.second, pad=2))
+    if value.ms != 0
+        Base.print(io, ".")
+        Base.print(io, string(value.ms, pad=3))
+    end
+end
+
+function printvalue(f::Function, io::IO, value::Base.TOML.Date, sorted::Bool)
+    Base.print(io, string(value.year, pad=4))
+    Base.print(io, "-")
+    Base.print(io, string(value.month, pad=2))
+    Base.print(io, "-")
+    Base.print(io, string(value.day, pad=2))
+end
+
+function printvalue(f::Function, io::IO, value::Bool, sorted::Bool)
+    Base.print(io, value ? "true" : "false")
+end
+
+function printvalue(f::Function, io::IO, value::Integer, sorted::Bool)
     value isa Signed && return Base.show(io, value)
     # unsigned integers are printed as hex
     n = 2 * ndigits(value, base=256)
     Base.print(io, "0x", string(value, base=16, pad=n))
     return
+end
+
+function printvalue(f::Function, io::IO, value::AbstractFloat, sorted::Bool)
+    if isnan(value)
+        Base.print(io, "nan")
+    elseif isinf(value)
+        Base.print(io, value > 0 ? "+inf" : "-inf")
+    else
+        Base.print(io, Float64(value)) # TOML specifies IEEE 754 binary64 for float
+    end
+end
+
+function printvalue(f::Function, io::IO, value::AbstractString, sorted::Bool)
+    qmark = Base.contains(value, "\n") ? "\"\"\"" : "\""
+    Base.print(io, qmark)
+    print_toml_escaped(io, value)
+    Base.print(io, qmark)
+end
+
+function printvalue(f::Function, io::IO, value::AbstractDict, sorted::Bool)
+    print_inline_table(f, io, value, sorted)
 end
 
 function print_inline_table(f::Function, io::IO, value::AbstractDict, sorted::Bool)
@@ -166,7 +198,7 @@ function print_table(f::Function, io::IO, a::AbstractDict,
     # First print non-tabular entries
     for key in akeys
         value = a[key]
-        if !isa(value, TOMLValue)
+        if !is_valid_toml_value(value)
             value = to_toml_value(f, value)
         end
         if is_tabular(value) && !(value in inline_tables)
@@ -183,7 +215,7 @@ function print_table(f::Function, io::IO, a::AbstractDict,
 
     for key in akeys
         value = a[key]
-        if !isa(value, TOMLValue)
+        if !is_valid_toml_value(value)
             value = to_toml_value(f, value)
         end
         if is_table(value) && !(value in inline_tables)

--- a/base/toml/toml.jl
+++ b/base/toml/toml.jl
@@ -1,0 +1,19 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+"""
+`Base.TOML` is an undocumented internal part of Julia's TOML implementation.
+Users should call the documented interface in the TOML.jl standard library
+instead (by `import TOML` or `using TOML`).
+"""
+module TOML
+
+include("parser.jl")
+
+# We put the printing functionality in a separate module since it
+# defines a function `print` and we don't want that to collide with normal
+# usage of `(Base.)print` in other files
+module Printer
+    include("printer.jl")
+end
+
+end

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -720,14 +720,11 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
     jl_task_t *ct = jl_current_task;
     size_t last_age = ct->world_age;
     ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
-    jl_value_t *depots = NULL, *prefs_hash = NULL, *prefs_list = NULL;
+    jl_value_t *depots = NULL, *prefs_blob = NULL;
     jl_value_t *unique_func = NULL;
     jl_value_t *replace_depot_func = NULL;
     jl_value_t *normalize_depots_func = NULL;
-    jl_value_t *toplevel = NULL;
-    jl_value_t *prefs_hash_func = NULL;
-    jl_value_t *get_compiletime_prefs_func = NULL;
-    JL_GC_PUSH8(&depots, &prefs_list, &unique_func, &replace_depot_func, &normalize_depots_func, &toplevel, &prefs_hash_func, &get_compiletime_prefs_func);
+    JL_GC_PUSH5(&depots, &prefs_blob, &unique_func, &replace_depot_func, &normalize_depots_func);
 
     jl_array_t *udeps = (jl_array_t*)jl_get_global_value(jl_base_module, jl_symbol("_require_dependencies"), ct->world_age);
     *udepsp = udeps;
@@ -798,51 +795,22 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
     }
     write_int32(s, 0); // terminator, for ease of reading
 
-    // Calculate Preferences hash for current package.
-    if (jl_base_module) {
-        // Toplevel module is the module we're currently compiling, use it to get our preferences hash
-        toplevel = jl_get_global_value(jl_base_module, jl_symbol("__toplevel__"), ct->world_age);
-        prefs_hash_func = jl_eval_global_var(jl_base_module, jl_symbol("get_preferences_hash"), ct->world_age);
-        get_compiletime_prefs_func = jl_eval_global_var(jl_base_module, jl_symbol("get_compiletime_preferences"), ct->world_age);
-
-        if (toplevel) {
-            // call get_compiletime_prefs(__toplevel__)
-            jl_value_t *args[3] = {get_compiletime_prefs_func, (jl_value_t*)toplevel, NULL};
-            prefs_list = (jl_value_t*)jl_apply(args, 2);
-            JL_TYPECHK(write_dependency_list, array, prefs_list);
-
-            // Call get_preferences_hash(__toplevel__, prefs_list)
-            args[0] = prefs_hash_func;
-            args[2] = prefs_list;
-            prefs_hash = (jl_value_t*)jl_apply(args, 3);
-            JL_TYPECHK(write_dependency_list, uint64, prefs_hash);
-        }
-    }
+    // Serialize any compile-time dependencies on preferences.
+    assert(jl_base_module);
+    jl_value_t *get_preferences_blob = jl_eval_global_var(
+        jl_base_module, jl_symbol("get_preferences_blob"), ct->world_age);
+    assert(get_preferences_blob);
+    jl_value_t *args[1] = { get_preferences_blob };
+    prefs_blob = jl_apply(args, 1);
+    JL_TYPECHK(write_dependency_list, string, prefs_blob);
     ct->world_age = last_age;
 
-    // If we successfully got the preferences, write it out, otherwise write `0` for this `.ji` file.
-    if (prefs_hash != NULL && prefs_list != NULL) {
-        size_t i, l = jl_array_nrows(prefs_list);
-        for (i = 0; i < l; i++) {
-            jl_value_t *pref_name = jl_array_ptr_ref(prefs_list, i);
-            JL_TYPECHK(write_dependency_list, string, pref_name);
-            size_t slen = jl_string_len(pref_name);
-            write_int32(s, slen);
-            ios_write(s, jl_string_data(pref_name), slen);
-        }
-        write_int32(s, 0); // terminator
-        write_uint64(s, jl_unbox_uint64(prefs_hash));
-    }
-    else {
-        // This is an error path, but let's at least generate a valid `.ji` file.
-        // We declare an empty list of preference names, followed by a zero-hash.
-        // The zero-hash is not what would be generated for an empty set of preferences,
-        // and so this `.ji` file will be invalidated by a future non-erroring pass
-        // through this function.
-        write_int32(s, 0);
-        write_uint64(s, 0);
-    }
-    JL_GC_POP(); // for depots, prefs_list
+    // Write out the serialized preferences "blob"
+    size_t slen = jl_string_len(prefs_blob);
+    write_int32(s, slen);
+    ios_write(s, jl_string_data(prefs_blob), slen);
+
+    JL_GC_POP(); // for depots, prefs_blob
 #undef jl_is_deptuple
 
     // write a dummy file position to indicate the beginning of the source-text

--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -747,3 +747,12 @@ for date_type in (:Date, :DateTime)
     # Parsable output will have type info displayed, thus it is implied
     @eval Base.typeinfo_implicit(::Type{$date_type}) = true
 end
+
+# minimal Base.TOML support
+Base.TOML.Printer.printvalue(f::Function, io::IO, value::Date, sorted::Bool) =
+    Base.print(io, Dates.format(value, dateformat"YYYY-mm-dd"))
+Base.TOML.Printer.printvalue(f::Function, io::IO, value::Time, sorted::Bool) =
+    Base.print(io, Dates.format(value, dateformat"HH:MM:SS.sss"))
+Base.TOML.Printer.printvalue(f::Function, io::IO, value::DateTime, sorted::Bool) =
+    Base.print(io, Dates.format(value, dateformat"YYYY-mm-dd\THH:MM:SS.sss\Z"))
+Base.TOML.Printer.is_valid_toml_value(@nospecialize(::Union{Date,Time,DateTime})) = true

--- a/stdlib/TOML/src/TOML.jl
+++ b/stdlib/TOML/src/TOML.jl
@@ -11,16 +11,10 @@ using Dates
 
 module Internals
     # The parser is defined in Base
-    using Base.TOML: Parser, parse, tryparse, ParserError, isvalid_barekey_char, reinit!
+    using Base.TOML: Parser, Printer, parse, tryparse, ParserError, reinit!
     # Put the error instances in this module
     for errtype in instances(Base.TOML.ErrorType)
         @eval using Base.TOML: $(Symbol(errtype))
-    end
-    # We put the printing functionality in a separate module since It
-    # defines a function `print` and we don't want that to collide with normal
-    # usage of `(Base.)print` in other files
-    module Printer
-        include("print.jl")
     end
 end
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -275,7 +275,7 @@ end
         pkg = recurse_package(n...)
         @test pkg == PkgId(UUID(uuid), n[end])
         @test joinpath(@__DIR__, normpath(path)) == locate_package(pkg)
-        @test Base.compilecache_path(pkg, UInt64(0)) == Base.compilecache_path(pkg, UInt64(0))
+        @test Base.compilecache_path(pkg, "") == Base.compilecache_path(pkg, "")
     end
     @test identify_package("Baz") === nothing
     @test identify_package("Qux") === nothing
@@ -1080,6 +1080,190 @@ end
     end
 end
 
+@testset "Preferences blob" begin
+    # Tests for get_preferences_blob() and stale_prefs() - the serialization of
+    # compile-time preference observations into a TOML blob embedded in cache files.
+    pkg_uuid = uuid4()
+    pkg2_uuid = uuid4()
+    mktempdir() do dir
+        # Set up a project with preferences for two packages
+        write(joinpath(dir, "Project.toml"), """
+        [deps]
+        PkgA = "$(pkg_uuid)"
+        PkgB = "$(pkg2_uuid)"
+
+        [preferences.PkgA]
+        key1 = "val1"
+        key2 = 42
+
+        [preferences.PkgB]
+        flag = true
+        """)
+
+        old_load_path = copy(LOAD_PATH)
+        old_compiletime_prefs = Dict(k => copy(v) for (k, v) in Base.COMPILETIME_PREFERENCES)
+        try
+            copy!(LOAD_PATH, [joinpath(dir, "Project.toml")])
+            empty!(Base.COMPILETIME_PREFERENCES)
+
+            # Empty COMPILETIME_PREFERENCES → empty blob (fast-path)
+            @test Base.get_preferences_blob() == ""
+
+            # A queried+set preference appears in the main table
+            Base.record_compiletime_preference(pkg_uuid, "key1")
+            blob = Base.get_preferences_blob()
+            @test !isempty(blob)
+            parsed = Base.TOML.parse(Base.TOML.Parser{nothing}(blob))
+            @test parsed[string(pkg_uuid)]["key1"] == "val1"
+            @test !haskey(parsed, "unset")
+
+            # A queried+unset preference appears in the [unset] table
+            empty!(Base.COMPILETIME_PREFERENCES)
+            Base.record_compiletime_preference(pkg_uuid, "missing_key")
+            blob = Base.get_preferences_blob()
+            parsed = Base.TOML.parse(Base.TOML.Parser{nothing}(blob))
+            @test haskey(parsed, "unset")
+            @test "missing_key" in parsed["unset"][string(pkg_uuid)]
+            @test !haskey(get(parsed, string(pkg_uuid), Dict()), "missing_key")
+
+            # Mix of set and unset preferences for the same UUID
+            empty!(Base.COMPILETIME_PREFERENCES)
+            Base.record_compiletime_preference(pkg_uuid, "key1")
+            Base.record_compiletime_preference(pkg_uuid, "missing_key")
+            blob = Base.get_preferences_blob()
+            parsed = Base.TOML.parse(Base.TOML.Parser{nothing}(blob))
+            @test parsed[string(pkg_uuid)]["key1"] == "val1"
+            @test "missing_key" in parsed["unset"][string(pkg_uuid)]
+
+            # Multiple UUIDs are tracked independently
+            empty!(Base.COMPILETIME_PREFERENCES)
+            Base.record_compiletime_preference(pkg_uuid, "key1")
+            Base.record_compiletime_preference(pkg2_uuid, "flag")
+            blob = Base.get_preferences_blob()
+            parsed = Base.TOML.parse(Base.TOML.Parser{nothing}(blob))
+            @test parsed[string(pkg_uuid)]["key1"] == "val1"
+            @test parsed[string(pkg2_uuid)]["flag"] == true
+
+            # stale_prefs: empty blob is never stale
+            @test !Base.stale_prefs("")
+
+            # stale_prefs: set preference unchanged → not stale
+            empty!(Base.COMPILETIME_PREFERENCES)
+            Base.record_compiletime_preference(pkg_uuid, "key1")
+            blob = Base.get_preferences_blob()
+            @test !Base.stale_prefs(blob)
+
+            # stale_prefs: set preference value changed → stale
+            mktempdir() do dir2
+                write(joinpath(dir2, "Project.toml"), """
+                [deps]
+                PkgA = "$(pkg_uuid)"
+
+                [preferences.PkgA]
+                key1 = "different"
+                """)
+                copy!(LOAD_PATH, [joinpath(dir2, "Project.toml")])
+                @test Base.stale_prefs(blob)
+                copy!(LOAD_PATH, [joinpath(dir, "Project.toml")])
+            end
+
+            # stale_prefs: set preference becomes unset → stale
+            mktempdir() do dir2
+                write(joinpath(dir2, "Project.toml"), """
+                [deps]
+                PkgA = "$(pkg_uuid)"
+                """)
+                copy!(LOAD_PATH, [joinpath(dir2, "Project.toml")])
+                @test Base.stale_prefs(blob)
+                copy!(LOAD_PATH, [joinpath(dir, "Project.toml")])
+            end
+
+            # stale_prefs: unset preference still unset → not stale
+            empty!(Base.COMPILETIME_PREFERENCES)
+            Base.record_compiletime_preference(pkg_uuid, "missing_key")
+            blob_unset = Base.get_preferences_blob()
+            @test !Base.stale_prefs(blob_unset)
+
+            # stale_prefs: unset preference becomes set → stale
+            mktempdir() do dir2
+                write(joinpath(dir2, "Project.toml"), """
+                [deps]
+                PkgA = "$(pkg_uuid)"
+
+                [preferences.PkgA]
+                missing_key = "now_set"
+                """)
+                copy!(LOAD_PATH, [joinpath(dir2, "Project.toml")])
+                @test Base.stale_prefs(blob_unset)
+                copy!(LOAD_PATH, [joinpath(dir, "Project.toml")])
+            end
+
+            # hash collision test:
+            #   https://github.com/JuliaLang/julia/issues/59345#issue-3338450603
+            #
+            # `1`, `1.0`, and `true` are all `isequal` in Julia, so == / isequal / hash
+            # cannot distinguish these semantically distinct values, but the preferences
+            # system should distinguish them since they are clearly different objects
+            mktempdir() do dir_bool
+                write(joinpath(dir_bool, "Project.toml"), """
+                [deps]
+                PkgA = "$(pkg_uuid)"
+
+                [preferences.PkgA]
+                flag = true
+                """)
+                copy!(LOAD_PATH, [joinpath(dir_bool, "Project.toml")])
+                empty!(Base.COMPILETIME_PREFERENCES)
+                Base.record_compiletime_preference(pkg_uuid, "flag")
+                blob_bool = Base.get_preferences_blob()
+
+                mktempdir() do dir_int
+                    write(joinpath(dir_int, "Project.toml"), """
+                    [deps]
+                    PkgA = "$(pkg_uuid)"
+
+                    [preferences.PkgA]
+                    flag = 1
+                    """)
+                    copy!(LOAD_PATH, [joinpath(dir_int, "Project.toml")])
+                    @test Base.stale_prefs(blob_bool)
+                end
+                copy!(LOAD_PATH, [joinpath(dir, "Project.toml")])
+            end
+
+            # hash collision test (on ≥1.13, where hash(false, UInt(0)) == UInt(0))
+            #
+            # the old hash-based approach for preference invalidation would fail to detect
+            # the difference between `pref = false` and "no preference".
+            mktempdir() do dir2
+                write(joinpath(dir2, "Project.toml"), """
+                [deps]
+                PkgA = "$(pkg_uuid)"
+
+                [preferences.PkgA]
+                key1 = false
+                """)
+                copy!(LOAD_PATH, [joinpath(dir2, "Project.toml")])
+                empty!(Base.COMPILETIME_PREFERENCES)
+                Base.record_compiletime_preference(pkg_uuid, "key1")
+                blob_false = Base.get_preferences_blob()
+                mktempdir() do dir3
+                    write(joinpath(dir3, "Project.toml"), """
+                    [deps]
+                    PkgA = "$(pkg_uuid)"
+                    """)
+                    copy!(LOAD_PATH, [joinpath(dir3, "Project.toml")])
+                    @test Base.stale_prefs(blob_false)
+                end
+                copy!(LOAD_PATH, [joinpath(dir, "Project.toml")])
+            end
+        finally
+            copy!(LOAD_PATH, old_load_path)
+            empty!(Base.COMPILETIME_PREFERENCES)
+            merge!(Base.COMPILETIME_PREFERENCES, old_compiletime_prefs)
+        end
+    end
+end
 
 @testset "Loading with incomplete manifest/depot #45977" begin
     mktempdir() do tmp

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -643,8 +643,7 @@ precompile_test_harness(false) do dir
           """)
 
     cachefile, _ = @test_logs (:debug, r"Generating object cache file for FooBar") min_level=Logging.Debug match_mode=:any Base.compilecache(Base.PkgId("FooBar"))
-    empty_prefs_hash = Base.get_preferences_hash(nothing, String[])
-    @test cachefile == Base.compilecache_path(Base.PkgId("FooBar"), empty_prefs_hash)
+    @test cachefile == Base.compilecache_path(Base.PkgId("FooBar"), "")
     @test isfile(joinpath(cachedir, "FooBar.ji"))
     Tsc = Bool(Base.JLOptions().use_pkgimages) ? Tuple{<:Vector, String, UInt128} : Tuple{<:Vector, Nothing, UInt128}
     @test Base.stale_cachefile(FooBar_file, joinpath(cachedir, "FooBar.ji")) isa Tsc
@@ -2124,7 +2123,7 @@ precompile_test_harness("Test flags") do load_path
     ji, ofile = Base.compilecache(Base.PkgId("TestFlags"); flags=`--check-bounds=no -O3`)
     open(ji, "r") do io
         Base.isvalid_cache_header(io)
-        _, _, _, _, _, _, _, flags = Base.parse_cache_header(io, ji)
+        _, _, _, _, _, _, flags = Base.parse_cache_header(io, ji)
         cacheflags = Base.CacheFlags(flags)
         @test cacheflags.check_bounds == 2
         @test cacheflags.opt_level == 3
@@ -2139,7 +2138,7 @@ if Base.get_bool_env("CI", false) && (Sys.ARCH === :x86_64 || Sys.ARCH === :aarc
         idx = findfirst(cachefiles) do cf
             Base.stale_cachefile(pkgpath, cf) !== true
         end
-        targets = Base.parse_image_targets(Base.parse_cache_header(cachefiles[idx])[7])
+        targets = Base.parse_image_targets(Base.parse_cache_header(cachefiles[idx])[6])
         @test length(targets) > 1
     end
 end
@@ -2684,6 +2683,184 @@ end
         @test count("Precompiling DependsOnly finished.", output) == 1
         @test count("Now FailPkg is running.", output) == 0
         @test count("Now DependsOnly is running.", output) == 1
+    end
+end
+
+precompile_test_harness("invalidation for 'foreign-keyed' Preferences") do load_path
+    # Test that compile-time preferences invalidate, even when queried from a
+    # "foreign" UUID / package namespace
+    foreign_uuid_str = "b5f1a95c-d45e-4b9e-84c6-b7ea3b5e5f22"
+    foreign_uuid = Base.UUID(foreign_uuid_str)
+
+    # Package that records compile-time preferences for a "foreign" UUID
+    write(joinpath(load_path, "PkgCrossPrefs.jl"),
+          """
+          module PkgCrossPrefs
+              # Query preferences for a foreign package UUID (cross-UUID tracking)
+              Base.record_compiletime_preference(Base.UUID("$foreign_uuid_str"), "debug")
+              # Also query a preference that won't be set
+              Base.record_compiletime_preference(Base.UUID("$foreign_uuid_str"), "unset_opt")
+          end
+          """)
+
+    env_base_dir    = mkpath(joinpath(load_path, "env_base"))
+    env_changed_dir = mkpath(joinpath(load_path, "env_changed"))
+    env_unset_dir   = mkpath(joinpath(load_path, "env_unset_set"))
+
+    env_base      = joinpath(env_base_dir, "Project.toml")
+    env_changed   = joinpath(env_changed_dir, "Project.toml")
+    env_unset_set = joinpath(env_unset_dir, "Project.toml")
+
+    write(env_base, """
+    [deps]
+    PkgForeign = "$foreign_uuid_str"
+
+    [preferences.PkgForeign]
+    debug = false
+    """)
+    write(env_changed, """
+    [deps]
+    PkgForeign = "$foreign_uuid_str"
+
+    [preferences.PkgForeign]
+    debug = true
+    """)
+    write(env_unset_set, """
+    [deps]
+    PkgForeign = "$foreign_uuid_str"
+
+    [preferences.PkgForeign]
+    debug = false
+    unset_opt = "now_set"
+    """)
+
+    old_proj = Base.active_project()
+    try
+        Base.set_active_project(env_base)
+        cachefile, _ = Base.compilecache(Base.PkgId("PkgCrossPrefs"))
+        pkg_file = joinpath(load_path, "PkgCrossPrefs.jl")
+
+        # Cache is not stale with the original preferences
+        @test Base.stale_cachefile(pkg_file, cachefile) !== true
+        # Changing the (foreign) preferences makes the cache stale
+        Base.set_active_project(env_changed)
+        @test Base.stale_cachefile(pkg_file, cachefile) === true
+        # Restoring the original preferences makes it not stale again
+        Base.set_active_project(env_base)
+        @test Base.stale_cachefile(pkg_file, cachefile) !== true
+        # Setting a previously-unset preference also causes staleness
+        Base.set_active_project(env_unset_set)
+        @test Base.stale_cachefile(pkg_file, cachefile) === true
+    finally
+        Base.set_active_project(old_proj)
+    end
+end
+
+precompile_test_harness("Preferences hash collision (issue #59344), part 1") do load_path
+    # Test for the preference hash collision bug (https://github.com/JuliaLang/julia/issues/59344)
+    # related to skipping unset preferences in preference hash
+    pkg_uuid_str = "c9de8a70-0fad-4996-b3e2-f9c45bce31af"
+    pkg_uuid = Base.UUID(pkg_uuid_str)
+
+    pkg_src_dir = mkpath(joinpath(load_path, "PkgHashCollision", "src"))
+    write(joinpath(pkg_src_dir, "PkgHashCollision.jl"),
+          """
+          module PkgHashCollision
+              Base.record_compiletime_preference(Base.UUID("$pkg_uuid_str"), "xyz")
+              Base.record_compiletime_preference(Base.UUID("$pkg_uuid_str"), "abc")
+          end
+          """)
+    write(joinpath(load_path, "PkgHashCollision", "Project.toml"), """
+          name = "PkgHashCollision"
+          uuid = "$pkg_uuid_str"
+          """)
+
+    env_xyz_dir = mkpath(joinpath(load_path, "env_xyz"))
+    env_abc_dir = mkpath(joinpath(load_path, "env_abc"))
+
+    env_xyz = joinpath(env_xyz_dir, "Project.toml")
+    env_abc = joinpath(env_abc_dir, "Project.toml")
+
+    # First config: xyz has the value, abc is unset
+    write(env_xyz, """
+    [deps]
+    PkgHashCollision = "$pkg_uuid_str"
+
+    [preferences.PkgHashCollision]
+    xyz = "same_value"
+    """)
+    # Second config: abc has the same value, xyz is unset
+    write(env_abc, """
+    [deps]
+    PkgHashCollision = "$pkg_uuid_str"
+
+    [preferences.PkgHashCollision]
+    abc = "same_value"
+    """)
+
+    old_proj = Base.active_project()
+    try
+        Base.set_active_project(env_xyz)
+        cachefile, _ = Base.compilecache(Base.PkgId(pkg_uuid, "PkgHashCollision"))
+        pkg_file = joinpath(load_path, "PkgHashCollision", "src", "PkgHashCollision.jl")
+
+        @test Base.stale_cachefile(pkg_file, cachefile) !== true
+        Base.set_active_project(env_abc)
+        @test Base.stale_cachefile(pkg_file, cachefile) === true
+    finally
+        Base.set_active_project(old_proj)
+    end
+end
+
+precompile_test_harness("Preferences hash collision (issue #59344), part 2") do load_path
+    # On Julia ≥1.13, `pref = false` and an unset preference triggered a hash collision,
+    # causing preference changes not to invalidate. Test that this invalidates as expected.
+    pkg_uuid_str = "d2e8c371-1b3f-4f5a-8c7e-9a2b1d4e6f8c"
+    pkg_uuid = Base.UUID(pkg_uuid_str)
+
+    pkg_src_dir = mkpath(joinpath(load_path, "PkgFalsePrefs", "src"))
+    write(joinpath(pkg_src_dir, "PkgFalsePrefs.jl"),
+          """
+          module PkgFalsePrefs
+              Base.record_compiletime_preference(Base.UUID("$pkg_uuid_str"), "flag")
+          end
+          """)
+    write(joinpath(load_path, "PkgFalsePrefs", "Project.toml"), """
+          name = "PkgFalsePrefs"
+          uuid = "$pkg_uuid_str"
+          """)
+
+    env_false_dir = mkpath(joinpath(load_path, "env_false"))
+    env_none_dir  = mkpath(joinpath(load_path, "env_none"))
+
+    env_false = joinpath(env_false_dir, "Project.toml")
+    env_none  = joinpath(env_none_dir,  "Project.toml")
+
+    # Compiled with flag = false
+    write(env_false, """
+    [deps]
+    PkgFalsePrefs = "$pkg_uuid_str"
+
+    [preferences.PkgFalsePrefs]
+    flag = false
+    """)
+    # Preference removed entirely
+    write(env_none, """
+    [deps]
+    PkgFalsePrefs = "$pkg_uuid_str"
+    """)
+
+    old_proj = Base.active_project()
+    try
+        Base.set_active_project(env_false)
+        cachefile, _ = Base.compilecache(Base.PkgId(pkg_uuid, "PkgFalsePrefs"))
+        pkg_file = joinpath(load_path, "PkgFalsePrefs", "src", "PkgFalsePrefs.jl")
+
+        @test Base.stale_cachefile(pkg_file, cachefile) !== true
+        Base.set_active_project(env_none)
+        @test Base.stale_cachefile(pkg_file, cachefile) === true
+    finally
+        Base.set_active_project(old_proj)
     end
 end
 


### PR DESCRIPTION
Dependent on https://github.com/JuliaLang/julia/pull/61210.

This change resolves some notable gaps in Preferences' tracking of compile-time dependencies:

 1. Preferences tracks only preferences keyed on the active `__toplevel__` module, despite allowing you to query preferences keyed on any module / package.
 2. Preference changes are checked for by comparing a hash, without a full value comparison.

This hash comparison was probably something of a premature optimization, since it is done very rarely and it is impossible to compute the hash before asking the pkgimage what preferences it depended upon anyway. It has also led to a few serious bugs.

Resolve this by storing a serialized (TOML) representation of the compile-time dependencies used in any Module and de-serializing this upon loading instead.

Fixes https://github.com/JuliaPackaging/Preferences.jl/issues/86. Fixes https://github.com/JuliaLang/julia/issues/59344. Fixes https://github.com/JuliaLang/julia/issues/59257.

Co-written with Claude.
