### PR TITLE
Base: Set syntax version for `Base`

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -332,9 +332,11 @@ a_method_to_overwrite_in_test() = inferencebarrier(1)
 # Compiler frontend
 Core.println("JuliaSyntax/src/JuliaSyntax.jl")
 include(@__MODULE__, string(DATAROOT, "julia/JuliaSyntax/src/JuliaSyntax.jl"))
-
 # May be replaced in incremental sysimage build after-the-fact
 const JuliaLowering = nothing
+
+# Now that JuliaSyntax is bootstrapped and ready to use, set Base's syntax version.
+set_syntax_version(Base, VERSION)
 
 end_base_include = time_ns()
 


### PR DESCRIPTION
This allows tools like Revise to re-parse Base source files using the correct syntax version.

This (+ https://github.com/timholy/Revise.jl/pull/1016 / https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/711) is enough for `Revise.track(Base)` to work for me to revise local changes to `base/loading.jl`, etc. 

Co-authored-by: Claude \<noreply@anthropic.com\>