### PR TITLE
Handle non-standard Method.source in jl_ir_flag_has_image_globalref

### DIFF
--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1239,8 +1239,10 @@ JL_DLLEXPORT uint8_t jl_ir_flag_has_image_globalref(jl_string_t *data)
 {
     if (jl_is_code_info(data))
         return ((jl_code_info_t*)data)->has_image_globalref;
-    if (!jl_is_string(data))
-        return 0; // foreign CodeInstance with custom source / IR, doesn't track GlobalRef edges 
+    if (!jl_is_string(data)) {
+        // foreign CodeInstance with custom source/IR, doesn't track GlobalRef edges
+        return 0;
+    }
     jl_code_info_flags_t flags;
     flags.packed = jl_string_data(data)[ir_offset_flags];
     return flags.bits.has_image_globalref;

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1239,7 +1239,8 @@ JL_DLLEXPORT uint8_t jl_ir_flag_has_image_globalref(jl_string_t *data)
 {
     if (jl_is_code_info(data))
         return ((jl_code_info_t*)data)->has_image_globalref;
-    assert(jl_is_string(data));
+    if (!jl_is_string(data))
+        return 0;
     jl_code_info_flags_t flags;
     flags.packed = jl_string_data(data)[ir_offset_flags];
     return flags.bits.has_image_globalref;

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1240,7 +1240,7 @@ JL_DLLEXPORT uint8_t jl_ir_flag_has_image_globalref(jl_string_t *data)
     if (jl_is_code_info(data))
         return ((jl_code_info_t*)data)->has_image_globalref;
     if (!jl_is_string(data))
-        return 0;
+        return 0; // foreign CodeInstance with custom source / IR, doesn't track GlobalRef edges 
     jl_code_info_flags_t flags;
     flags.packed = jl_string_data(data)[ir_offset_flags];
     return flags.bits.has_image_globalref;

--- a/test/precompile_extmi.jl
+++ b/test/precompile_extmi.jl
@@ -72,4 +72,29 @@ precompile_test_harness() do load_path
     end
 end
 
+# Test that methods with non-standard (foreign) source survive precompilation round-trip
+precompile_test_harness() do load_path
+    write(joinpath(load_path, "ForeignIR.jl"), """
+    module ForeignIR
+        struct MyIR
+            data::Vector{UInt8}
+        end
+        function foreign_func(x)
+            return x + 1
+        end
+        let m = first(methods(foreign_func))
+            m.source = MyIR(UInt8[1,2,3])
+        end
+    end
+    """)
+    Base.compilecache(Base.PkgId("ForeignIR"))
+
+    @eval let
+        using ForeignIR
+        m = first(methods(ForeignIR.foreign_func))
+        @test m.source isa ForeignIR.MyIR
+        @test !Base.has_image_globalref(m)
+    end
+end
+
 finish_precompile_test!()


### PR DESCRIPTION
Methods created with custom source data (e.g. via CompilerCaching's add_method which stores domain-specific IR) are neither CodeInfo nor compressed String. Return 0 instead of asserting, since such methods cannot have image globalrefs.