### PR TITLE
Deduplicate method tables in jl_foreach_reachable_mtable

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -980,6 +980,8 @@ int jl_foreach_reachable_mtable(int (*visit)(jl_methtable_t *mt, void *env), jl_
 
     arraylist_t workqueue;
     arraylist_new(&workqueue, 0);
+    htable_t visited_mts;
+    htable_new(&visited_mts, 0);
 
     // Add initial toplevel modules to workqueue
     for (size_t i = 0; i < jl_array_nrows(mod_array); i++) {
@@ -1012,7 +1014,8 @@ int jl_foreach_reachable_mtable(int (*visit)(jl_methtable_t *mt, void *env), jl_
                 }
                 else if (jl_is_mtable(v)) {
                     jl_methtable_t *mt = (jl_methtable_t*)v;
-                    if (mt && mt != jl_method_table) {
+                    if (mt && mt != jl_method_table && !ptrhash_has(&visited_mts, mt)) {
+                        ptrhash_put(&visited_mts, mt, mt);
                         if (!visit(mt, env)) {
                             result = 0;
                             goto cleanup;
@@ -1026,6 +1029,7 @@ int jl_foreach_reachable_mtable(int (*visit)(jl_methtable_t *mt, void *env), jl_
 
 cleanup:
     arraylist_free(&workqueue);
+    htable_free(&visited_mts);
     return result;
 }
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -980,8 +980,6 @@ int jl_foreach_reachable_mtable(int (*visit)(jl_methtable_t *mt, void *env), jl_
 
     arraylist_t workqueue;
     arraylist_new(&workqueue, 0);
-    htable_t visited_mts;
-    htable_new(&visited_mts, 0);
 
     // Add initial toplevel modules to workqueue
     for (size_t i = 0; i < jl_array_nrows(mod_array); i++) {
@@ -1014,8 +1012,7 @@ int jl_foreach_reachable_mtable(int (*visit)(jl_methtable_t *mt, void *env), jl_
                 }
                 else if (jl_is_mtable(v)) {
                     jl_methtable_t *mt = (jl_methtable_t*)v;
-                    if (mt && mt != jl_method_table && !ptrhash_has(&visited_mts, mt)) {
-                        ptrhash_put(&visited_mts, mt, mt);
+                    if (mt && mt != jl_method_table && mt->module == current_m && mt->name == name) {
                         if (!visit(mt, env)) {
                             result = 0;
                             goto cleanup;
@@ -1029,7 +1026,6 @@ int jl_foreach_reachable_mtable(int (*visit)(jl_methtable_t *mt, void *env), jl_
 
 cleanup:
     arraylist_free(&workqueue);
-    htable_free(&visited_mts);
     return result;
 }
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -8559,6 +8559,45 @@ let load_path = mktempdir()
     end
 end
 
+# Deduplication of method tables in jl_foreach_reachable_mtable:
+# when a method table is imported, it should not be visited multiple times.
+let load_path = mktempdir()
+    depot_path = mkdepottempdir()
+    try
+        pushfirst!(LOAD_PATH, load_path)
+        pushfirst!(DEPOT_PATH, depot_path)
+
+        write(joinpath(load_path, "MtDef.jl"),
+            """
+            module MtDef
+            Base.Experimental.@MethodTable(mt)
+            end
+            """)
+
+        MtDef = Base.require(Main, :MtDef)
+        @test length(MtDef.mt) == 0
+
+        write(joinpath(load_path, "MtUser.jl"),
+            """
+            module MtUser
+            using MtDef: mt
+            Base.Experimental.@overlay mt sin(x::Int) = 42
+            end
+            """)
+
+        # MtUser imports mt from MtDef, making it reachable from both modules'
+        # bindings during precompilation. Without deduplication in
+        # jl_foreach_reachable_mtable, the overlay method would be serialized
+        # twice, causing an assertion failure when activating methods on load.
+        MtUser = Base.require(Main, :MtUser)
+        @test length(MtDef.mt) == 1
+    finally
+        filter!((≠)(load_path), LOAD_PATH)
+        filter!((≠)(depot_path), DEPOT_PATH)
+        rm(load_path, recursive=true, force=true)
+    end
+end
+
 # merging va tuple unions
 @test Tuple === Union{Tuple{},Tuple{Any,Vararg}}
 @test Tuple{Any,Vararg} === Union{Tuple{Any},Tuple{Any,Any,Vararg}}


### PR DESCRIPTION
When a custom method table is defined in one package and imported by another, jl_foreach_reachable_mtable visits the same table twice (once per module binding). This causes extext methods to be collected and serialized twice, and on loading, jl_method_table_activate asserts because dispatch_status was already set by the first activation.

Add an htable to track visited method tables and skip duplicates.