### PR TITLE
Handle non-dispatch tuples in `Base.method_instance`

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -75,10 +75,19 @@ end
 function method_instance(@nospecialize(argtypes::Union{Tuple,Type{<:Tuple}});
                          world=Base.get_world_counter(), method_table=nothing)
     tt = to_tuple_type(argtypes)
-    mi = ccall(:jl_method_lookup_by_tt, Any,
-                (Any, Csize_t, Any),
-                tt, world, method_table)
-    return mi::Union{Nothing, MethodInstance}
+    if isdispatchtuple(tt)
+        # Fast path: use the dispatch cache
+        mi = ccall(:jl_method_lookup_by_tt, Any,
+                    (Any, Csize_t, Any),
+                    tt, world, method_table)
+        return mi::Union{Nothing, MethodInstance}
+    else
+        # Non-dispatch tuple (abstract types, free typevars): uncached lookup
+        matches = _methods_by_ftype(tt, method_table, 1, world)
+        matches === nothing && return nothing
+        length(matches) != 1 && return nothing
+        return specialize_method(matches[1]::Core.MethodMatch)
+    end
 end
 
 function method_instance(@nospecialize(f), @nospecialize(t);

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1231,6 +1231,17 @@ end
     mi3 = @ccall jl_method_lookup(Any[+, 1, 1]::Ptr{Any}, 3::Csize_t, Base.get_world_counter()::Csize_t)::Ref{Core.MethodInstance}
     @test mi1 == mi3
     @test mi2 == mi3
+
+    # Non-dispatch tuples (abstract argument types) should work via uncached fallback
+    mi4 = Base.method_instance(+, (Any, Int))
+    @test mi4 isa Core.MethodInstance
+    @test mi4.def.name == :+
+    mi5 = Base.method_instance(+, (Integer, Integer))
+    @test mi5 isa Core.MethodInstance
+    @test mi5.def.name == :+
+    # No matching method returns nothing
+    mi_test_f(::Int) = 1
+    @test Base.method_instance(mi_test_f, (String,)) === nothing
 end
 
 Base.@assume_effects :terminates_locally function issue41694(x::Int)


### PR DESCRIPTION
`method_instance` conceptually does the same thing as `method_instances` (finding a matching method and specializing it), but uses the dispatch cache when possible. Previously it always went through `jl_method_lookup_by_tt`, which calls `jl_mt_assoc_by_type` — a function that asserts its input is a dispatch tuple. For non-dispatch tuples (e.g. abstract argument types like
`Tuple{typeof(+), Any, Int64}`), fall back to the same uncached `_methods_by_ftype` + `specialize_method` path that `method_instances` uses.