### PR TITLE
Make Base.generating_output() public

### DIFF
--- a/base/public.jl
+++ b/base/public.jl
@@ -69,6 +69,7 @@ public
     isexported,
     ispublic,
     remove_linenums!,
+    generating_output,
 
 # AST handling
     IR,

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -547,6 +547,7 @@ Base.code_lowered
 Base.code_typed
 Base.precompile
 Base.jit_total_bytes
+Base.generating_output
 ```
 
 ## Meta


### PR DESCRIPTION
Doing different things during precompilation is sometimes necessary, and right now most packages do that using `jl_generating_output()`: https://juliahub.com/ui/Search?type=code&q=jl_generating_output

`Base.generating_output()` seems like a better option, and a few external packages already use it: https://juliahub.com/ui/Search?type=code&q=Base.generating_output