### PR TITLE
Base: Replace many 1-arg `@assert`s with 2-arg

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3486,7 +3486,7 @@ julia> map!(+, zeros(Int, 5), 100:999, 1:3)
 ```
 """
 function map!(f::F, dest::AbstractArray, As::AbstractArray...) where {F}
-    @assert !isempty(As) # should dispatch to map!(f, A)
+    @assert !isempty(As) "should dispatch to map!(f, A)"
     map_n!(f, dest, As)
 end
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -2326,7 +2326,7 @@ function vcat(arrays::Vector{T}...) where T
     nd = 1
     for a in arrays
         na = length(a)
-        @assert nd + na <= 1 + length(arr) # Concurrent modification of arrays?
+        @assert nd + na <= 1 + length(arr) "Concurrent modification of arrays?"
         unsafe_copyto!(arr, nd, a, 1, na)
         nd += na
     end

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -183,7 +183,7 @@ function _print_matrix(io, @nospecialize(X::AbstractVecOrMat), pre, sep, post, h
     screenwidth -= length(pre)::Int + length(post)::Int
     presp = repeat(" ", length(pre)::Int)  # indent each row to match pre string
     postsp = ""
-    @assert textwidth(hdots) == textwidth(ddots)
+    @assert textwidth(hdots) == textwidth(ddots) "hdots and ddots must have same textwidth"
     sepsize = length(sep)::Int
     m, n = length(rowsA), length(colsA)
     # To figure out alignments, only need to look at as many rows as could
@@ -422,7 +422,7 @@ _show_nonempty(io::IO, X::AbstractMatrix, prefix::String) =
     _show_nonempty(io, inferencebarrier(X), prefix, false, axes(X))
 
 function _show_nonempty(io::IO, @nospecialize(X::AbstractMatrix), prefix::String, drop_brackets::Bool, axs::Tuple{AbstractUnitRange,AbstractUnitRange})
-    @assert !isempty(X)
+    @assert !isempty(X) "X should be non-empty"
     limit = get(io, :limit, false)::Bool
     indr, indc = axs
     nr, nc = length(indr), length(indc)

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -126,13 +126,13 @@ mutable struct Timer
         associate_julia_struct(this.handle, this)
         iolock_begin()
         err = ccall(:uv_timer_init, Cint, (Ptr{Cvoid}, Ptr{Cvoid}), loop, this)
-        @assert err == 0
+        @assert err == 0 "failed to initialize timer"
         finalizer(uvfinalize, this)
         ccall(:uv_update_time, Cvoid, (Ptr{Cvoid},), loop)
         err = ccall(:uv_timer_start, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, UInt64, UInt64),
             this, @cfunction(uv_timercb, Cvoid, (Ptr{Cvoid},)),
             timeoutms, intervalms)
-        @assert err == 0
+        @assert err == 0 "failed to start timer"
         iolock_end()
         return this
     end

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -325,7 +325,7 @@ function copy_to_bitarray_chunks!(Bc::Vector{UInt64}, pos_d::Int, C::Array{Bool}
         bind += 1
     end
     @inbounds if bind ≤ kd1
-        @assert bind == kd1
+        @assert bind == kd1 "bind != kd1"
         c = UInt64(0)
         for j = 0:ld1
             c |= (UInt64(C[ind]) << j)

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -345,8 +345,8 @@ of type `Channel{Any}(0)`.
 Returns a tuple, `(Array{Channel}, Array{Task})`, of the created channels and tasks.
 """
 function channeled_tasks(n::Int, funcs...; ctypes=fill(Any,n), csizes=fill(0,n))
-    @assert length(csizes) == n
-    @assert length(ctypes) == n
+    @assert length(csizes) == n "length(csizes) != n"
+    @assert length(ctypes) == n "length(ctypes) != n"
 
     chnls = map(i -> Channel{ctypes[i]}(csizes[i]), 1:n)
     tasks = Task[ Task(() -> f(chnls...)) for f in funcs ]

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -44,7 +44,7 @@ end
 # Basic functions for working with permutations
 
 @inline function _foldoneto(op, acc, ::Val{N}) where N
-    @assert N::Integer > 0
+    @assert N::Integer > 0 "N must be positive"
     if @generated
         quote
             acc_0 = acc

--- a/base/file.jl
+++ b/base/file.jl
@@ -769,7 +769,7 @@ function _win_mkstemp(temppath::AbstractString)
                     tempp, temppfx, UInt32(0), tname)
     windowserror("GetTempFileName", uunique == 0)
     lentname = something(findfirst(iszero, tname))
-    @assert lentname > 0
+    @assert lentname > 0 "unexpected index"
     resize!(tname, lentname - 1)
     return transcode(String, tname)
 end
@@ -1396,7 +1396,7 @@ function readlink(path::AbstractString)
         if ret < 0
             uv_fs_req_cleanup(req)
             uv_error("readlink($(repr(path)))", ret)
-            @assert false
+            @assert false "unexpected uv readlink error"
         end
         tgt = unsafe_string(ccall(:jl_uv_fs_t_ptr, Cstring, (Ptr{Cvoid},), req))
         uv_fs_req_cleanup(req)

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -269,7 +269,7 @@ function read(f::File, ::Type{UInt8})
     ret = ccall(:jl_fs_read, Int32, (OS_HANDLE, Ptr{Cvoid}, Csize_t),
                 f.handle, p, 1)
     uv_error("read", ret)
-    @assert ret <= sizeof(p) == 1
+    @assert ret <= sizeof(p) == 1 "unexpected read size"
     ret < 1 && throw(EOFError())
     return p[] % UInt8
 end

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -261,7 +261,7 @@ function export!(a::AbstractVector{T}, n::BigInt; order::Integer=-1, nails::Inte
     count = Ref{Csize_t}()
     ccall((:__gmpz_export, libgmp), Ptr{T}, (Ptr{T}, Ref{Csize_t}, Cint, Csize_t, Cint, Csize_t, mpz_t),
         a, count, order, sizeof(T), endian, nails, n)
-    @assert count[] ≤ length(a)
+    @assert count[] ≤ length(a) "count[] > length(a)"
     return a, Int(count[])
 end
 

--- a/base/hamt.jl
+++ b/base/hamt.jl
@@ -199,7 +199,7 @@ or grows the HAMT by inserting a new trie instead.
         end
         set!(trie, bi)
     else
-        @assert present
+        @assert present "!found && !present"
         # collision -> grow
         leaf = @inbounds trie.data[i]::Leaf{K,V}
         leaf_h = HashState(h, leaf.key)

--- a/base/idset.jl
+++ b/base/idset.jl
@@ -52,7 +52,7 @@ function push!(s::IdSet, @nospecialize(x))
     else
         if s.max < length(s.list)
             idx = s.max
-            @assert !isassigned(s.list, idx + 1)
+            @assert !isassigned(s.list, idx + 1) "bucket is already occupied"
             s.list[idx + 1] = x
             s.max = idx + 1
         else
@@ -61,7 +61,7 @@ function push!(s::IdSet, @nospecialize(x))
             idx = newidx[]
             s.max = idx < 0 ? -idx : idx + 1
         end
-        @assert s.list[s.max] === x
+        @assert s.list[s.max] === x "unexpected object in bucket"
         setfield!(s, :idxs, ccall(:jl_idset_put_idx, Any, (Any, Any, Int), s.list, s.idxs, idx))
         s.count += 1
     end

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -504,7 +504,7 @@ function copyuntil(out::IOBuffer, s::IOStream, delim::UInt8; keep::Bool=false)
         (eof(s) || len == out.maxsize) && break
         len = min(2len + 64, out.maxsize)
         ensureroom(out, len)
-        @assert length(out.data) >= len
+        @assert length(out.data) >= len "length(out.data) < len"
     end
     return out
 end

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -1254,7 +1254,7 @@ function _prettify_bigfloat(s::String)::String
         else
             neg = startswith(int, '-')
             neg == true && (int = lstrip(int, '-'))
-            @assert length(int) == 1
+            @assert length(int) == 1 "length(int) != 1"
             string(neg ? '-' : "", '0', '.', '0'^(-expo-1), int, frac == "0" ? "" : frac)
         end
     else

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1488,7 +1488,7 @@ function copy_to_bitarray_chunks!(Bc::Vector{UInt64}, pos_d::Int, C::StridedArra
     end
 
     @inbounds if bind ≤ kd1
-        @assert bind == kd1
+        @assert bind == kd1 "bind != kd1"
         c = UInt64(0)
         for j = 0:ld1
             c |= (UInt64(unchecked_bool_convert(C[ind])) << j)

--- a/base/partr.jl
+++ b/base/partr.jl
@@ -139,7 +139,7 @@ end
 
 function multiq_insert(task::Task, priority::UInt16)
     tpid = ccall(:jl_get_task_threadpoolid, Int8, (Any,), task)
-    @assert tpid > -1
+    @assert tpid > -1 "invalid tpid"
     heap_p = multiq_size(tpid)
     tp = tpid + 1
 

--- a/base/pkgid.jl
+++ b/base/pkgid.jl
@@ -38,7 +38,7 @@ end
 function binunpack(s::String)
     io = IOBuffer(s)
     z = read(io, UInt8)
-    @assert z === 0x00
+    @assert z === 0x00 "unexpected data"
     uuid = read(io, UInt128)
     name = read(io, String)
     return PkgId(UUID(uuid), name)

--- a/base/process.jl
+++ b/base/process.jl
@@ -556,7 +556,7 @@ const SIGPIPE = 13 # !windows
 const SIGTERM = 15
 
 function test_success(proc::Process)
-    @assert process_exited(proc)
+    @assert process_exited(proc) "process did not exit successfully"
     if proc.exitcode < 0
         #TODO: this codepath is not currently tested
         throw(_UVError("could not start process " * repr(proc.cmd), proc.exitcode))
@@ -634,7 +634,7 @@ permissions).
 function kill(p::Process, signum::Integer=SIGTERM)
     iolock_begin()
     if process_running(p)
-        @assert p.handle != C_NULL
+        @assert p.handle != C_NULL "invalid handle"
         err = ccall(:uv_process_kill, Int32, (Ptr{Cvoid}, Int32), p.handle, signum)
         if err != 0 && err != UV_ESRCH
             throw(_UVError("kill", err))

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -267,7 +267,7 @@ to_index(i::SCartesianIndex2) = i
 struct SCartesianIndices2{K,R<:AbstractUnitRange{Int}} <: AbstractMatrix{SCartesianIndex2{K}}
     indices2::R
 end
-SCartesianIndices2{K}(indices2::AbstractUnitRange{Int}) where {K} = (@assert K::Int > 1; SCartesianIndices2{K,typeof(indices2)}(indices2))
+SCartesianIndices2{K}(indices2::AbstractUnitRange{Int}) where {K} = (@assert K::Int > 1 "invalid index"; SCartesianIndices2{K,typeof(indices2)}(indices2))
 
 eachindex(::IndexSCartesian2{K}, A::ReshapedReinterpretArray) where {K} = SCartesianIndices2{K}(eachindex(IndexLinear(), parent(A)))
 @inline function eachindex(style::IndexSCartesian2{K}, A::AbstractArray, B::AbstractArray...) where {K}

--- a/base/ryu/exp.jl
+++ b/base/ryu/exp.jl
@@ -1,7 +1,7 @@
 function writeexp(buf, pos, v::T,
     precision=-1, plus=false, space=false, hash=false,
     expchar=UInt8('e'), decchar=UInt8('.'), trimtrailingzeros=false) where {T <: Base.IEEEFloat}
-    @assert 0 < pos <= length(buf)
+    @assert 0 < pos <= length(buf) "invalid pos"
     startpos = pos
     x = Float64(v)
     pos = append_sign(x, plus, space, buf, pos)

--- a/base/ryu/fixed.jl
+++ b/base/ryu/fixed.jl
@@ -1,7 +1,7 @@
 function writefixed(buf, pos, v::T,
     precision=-1, plus=false, space=false, hash=false,
     decchar=UInt8('.'), trimtrailingzeros=false) where {T <: Base.IEEEFloat}
-    @assert 0 < pos <= length(buf)
+    @assert 0 < pos <= length(buf) "invalid pos"
     startpos = pos
     x = Float64(v)
     pos = append_sign(x, plus, space, buf, pos)

--- a/base/ryu/shortest.jl
+++ b/base/ryu/shortest.jl
@@ -229,7 +229,7 @@ function writeshortest(buf::AbstractVector{UInt8}, pos, x::T,
                        plus=false, space=false, hash=true,
                        precision=-1, expchar=UInt8('e'), padexp=false, decchar=UInt8('.'),
                        typed=false, compact=false) where {T}
-    @assert 0 < pos <= length(buf)
+    @assert 0 < pos <= length(buf) "invalid pos"
     # special cases
     if x == 0
         if typed && x isa Float16

--- a/base/set.jl
+++ b/base/set.jl
@@ -881,8 +881,8 @@ askey(k, ::AbstractSet) = k
 
 function _replace!(new::Callable, res::Union{AbstractDict,AbstractSet},
                    A::Union{AbstractDict,AbstractSet}, count::Int)
-    @assert res isa AbstractDict && A isa AbstractDict ||
-        res isa AbstractSet && A isa AbstractSet
+    @assert (res isa AbstractDict && A isa AbstractDict ||
+             res isa AbstractSet && A isa AbstractSet) "type mismatch"
     count == 0 && return res
     c = 0
     if res === A # cannot replace elements while iterating over A

--- a/base/show.jl
+++ b/base/show.jl
@@ -3373,7 +3373,7 @@ function print_partition(io::IO, partition::Core.BindingPartition)
         print(io, "explicit `import` from ")
         print(io, partition_restriction(partition).globalref)
     else
-        @assert kind == PARTITION_KIND_GLOBAL
+        @assert kind == PARTITION_KIND_GLOBAL "unexpected partition kind"
         print(io, "global variable with type ")
         print(io, partition_restriction(partition))
     end

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -599,7 +599,7 @@ struct WithoutMissingVector{T, U} <: AbstractVector{T}
 end
 Base.@propagate_inbounds function Base.getindex(v::WithoutMissingVector, i::Integer)
     out = v.data[i]
-    @assert !(out isa Missing)
+    @assert !(out isa Missing) "encountered `missing` in WithoutMissingVector"
     out::eltype(v)
 end
 Base.@propagate_inbounds function Base.setindex!(v::WithoutMissingVector, x, i::Integer)
@@ -1251,13 +1251,13 @@ function move!(v, target, source)
     # This function never dominates runtime—only add `@inbounds` if you can demonstrate a
     # performance improvement. And if you do, also double check behavior when `target`
     # is out of bounds.
-    @assert length(target) == length(source)
+    @assert length(target) == length(source) "length mismatch"
     if length(target) == 1 || isdisjoint(target, source)
         for (i, j) in zip(target, source)
             v[i], v[j] = v[j], v[i]
         end
     else
-        @assert minimum(source) <= minimum(target)
+        @assert minimum(source) <= minimum(target) "range mismatch"
         reverse!(v, minimum(source), maximum(target))
         reverse!(v, minimum(target), maximum(target))
     end
@@ -1328,7 +1328,7 @@ function _sort!(v::AbstractVector, a::BracketedSort, o::Ordering, kw)
             # Specifically, this means that expected_middle_ln == ln, so
             # ln <= ... + 2.0expected_middle_ln && return ...
             # will trigger.
-            @assert false
+            @assert false "this should never happen"
             # But if it does happen, the kernel reduces to
             0, hi
         elseif lo_signpost_i <= lo

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -918,8 +918,8 @@ readbytes!(s::LibuvStream, a::Vector{UInt8}, nb = length(a)) = readbytes!(s, a, 
 function readbytes!(s::LibuvStream, a::Vector{UInt8}, nb::Int)
     iolock_begin()
     sbuf = s.buffer
-    @assert sbuf.seekable == false
-    @assert sbuf.maxsize >= nb
+    @assert sbuf.seekable == false "buffer should not be seekable"
+    @assert sbuf.maxsize >= nb "insufficient buffer size"
 
     function wait_locked(s, buf, nb)
         while bytesavailable(buf) < nb
@@ -966,8 +966,8 @@ end
 function unsafe_read(s::LibuvStream, p::Ptr{UInt8}, nb::UInt)
     iolock_begin()
     sbuf = s.buffer
-    @assert sbuf.seekable == false
-    @assert sbuf.maxsize >= nb
+    @assert sbuf.seekable == false "buffer should not be seekable"
+    @assert sbuf.maxsize >= nb "insufficient buffer size"
 
     function wait_locked(s, buf, nb)
         while bytesavailable(buf) < nb
@@ -1002,7 +1002,7 @@ end
 function read(this::LibuvStream, ::Type{UInt8})
     iolock_begin()
     sbuf = this.buffer
-    @assert sbuf.seekable == false
+    @assert sbuf.seekable == false "buffer should not be seekable"
     while bytesavailable(sbuf) < 1
         iolock_end()
         eof(this) && throw(EOFError())
@@ -1017,7 +1017,7 @@ function readavailable(this::LibuvStream)
     wait_readnb(this, 1) # unlike the other `read` family of functions, this one doesn't guarantee error reporting
     iolock_begin()
     buf = this.buffer
-    @assert buf.seekable == false
+    @assert buf.seekable == false "buffer should not be seekable"
     bytes = take!(buf)
     iolock_end()
     return bytes
@@ -1026,7 +1026,7 @@ end
 function copyuntil(out::IO, x::LibuvStream, c::UInt8; keep::Bool=false)
     iolock_begin()
     buf = x.buffer
-    @assert buf.seekable == false
+    @assert buf.seekable == false "buffer should not be seekable"
     if !occursin(c, buf) # fast path checks first
         x.readerror === nothing || throw(x.readerror)
         if isopen(x) && x.status != StatusEOF
@@ -1563,7 +1563,7 @@ function readavailable(this::BufferStream)
     bytes = lock(this.cond) do
         wait_readnb(this, 1)
         buf = this.buffer
-        @assert buf.seekable == false
+        @assert buf.seekable == false "buffer should not be seekable"
         take!(buf)
     end
     return bytes
@@ -1579,8 +1579,8 @@ end
 
 function readbytes!(s::BufferStream, a::Vector{UInt8}, nb::Int)
     sbuf = s.buffer
-    @assert sbuf.seekable == false
-    @assert sbuf.maxsize >= nb
+    @assert sbuf.seekable == false "buffer should not be seekable"
+    @assert sbuf.maxsize >= nb "insufficient buffer size"
 
     function wait_locked(s, buf, nb)
         while bytesavailable(buf) < nb

--- a/base/task.jl
+++ b/base/task.jl
@@ -160,7 +160,7 @@ const task_state_failed   = UInt8(2)
         elseif st === task_state_failed
             return :failed
         else
-            @assert false
+            @assert false "unexpected state"
         end
     elseif field === :backtrace
         # TODO: this field name should be deprecated in 2.0

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -183,7 +183,7 @@ function threading_run(fun, static)
                 # TODO: this should be the current pool (except interactive) if there
                 # are ever more than two pools.
                 _result = ccall(:jl_set_task_threadpoolid, Cint, (Any, Int8), t, _sym_to_tpid(:default))
-                @assert _result == 1
+                @assert _result == 1 "_result != 1"
             end
             tasks[i] = t
             schedule(t)
@@ -444,7 +444,7 @@ function _spawn_set_thrpool(t::Task, tp::Symbol)
         tpid = _sym_to_tpid(:default)
     end
     _result = ccall(:jl_set_task_threadpoolid, Cint, (Any, Int8), t, tpid)
-    @assert _result == 1
+    @assert _result == 1 "_result != 1"
     nothing
 end
 

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -573,7 +573,7 @@ function _gen_allocation_measurer(ex, fname::Symbol)
             b1[] - b0[]
         end
     else
-        @assert fname === :allocations
+        @assert fname === :allocations "unexpected fname"
         return quote
             Experimental.@force_compile
             # Note this value is unused, but without it `allocated` and `allocations`

--- a/base/toml_parser.jl
+++ b/base/toml_parser.jl
@@ -297,7 +297,7 @@ end
 # used to show the interval where an error happened
 # Right now, it is only called with a == b
 function point_to_line(str::AbstractString, a::Int, b::Int, context)
-    @assert b >= a
+    @assert b >= a "invalid range"
     a = thisind(str, a)
     b = thisind(str, b)
     pos = something(findprev('\n', str, prevind(str, a)), 0) + 1
@@ -720,7 +720,7 @@ function parse_array(l::Parser{Dates})::Err{Vector} where Dates
         (Dates !== nothing && ((T === Dates.Date) || (T === Dates.Time) || (T === Dates.DateTime)))
         # do nothing, leave as Vector{Any}
         new = array
-    else @assert false end
+    else @assert false "unexpected type" end
     push!(l.static_arrays, new)
     return new
 end

--- a/base/version.jl
+++ b/base/version.jl
@@ -472,7 +472,7 @@ function Base.union!(ranges::Vector{<:VersionRange})
             continue
         end
         vr = VersionRange(lo, up)
-        @assert !isempty(vr)
+        @assert !isempty(vr) "empty VersionRange"
         ranges[k0] = vr
         k0 += 1
         lo, up = lo1, up1
@@ -517,8 +517,8 @@ end
 # Optimized for sorted version lists (but works correctly even if unsorted)
 # Note: Only fills indices 1:n, leaves rest of dest unchanged
 function matches_spec_range!(dest::BitVector, versions::AbstractVector{VersionNumber}, spec::VersionSpec, n::Int)
-    @assert length(versions) == n
-    @assert length(dest) >= n
+    @assert length(versions) == n "invalid version list"
+    @assert length(dest) >= n "invalid dest length"
 
     # Initialize to false
     dest[1:n] .= false
@@ -633,7 +633,7 @@ function semver_spec(s::String; throw = true)
 end
 
 function semver_interval(m::RegexMatch)
-    @assert length(m.captures) == 4
+    @assert length(m.captures) == 4 "invalid match"
     n_significant = count(x -> x !== nothing, m.captures) - 1
     typ, _major, _minor, _patch = m.captures
     major = parse(Int, _major)
@@ -670,7 +670,7 @@ end
 
 const _inf = VersionBound("*")
 function inequality_interval(m::RegexMatch)
-    @assert length(m.captures) == 4
+    @assert length(m.captures) == 4 "invalid match"
     typ, _major, _minor, _patch = m.captures
     n_significant = count(x -> x !== nothing, m.captures) - 1
     major = parse(Int, _major)
@@ -702,7 +702,7 @@ function inequality_interval(m::RegexMatch)
 end
 
 function hyphen_interval(m::RegexMatch)
-    @assert length(m.captures) == 6
+    @assert length(m.captures) == 6 "invalid match"
     _lower_major, _lower_minor, _lower_patch, _upper_major, _upper_minor, _upper_patch = m.captures
     if isnothing(_lower_minor)
         lower_bound = VersionBound(parse(Int, _lower_major))

--- a/base/views.jl
+++ b/base/views.jl
@@ -26,7 +26,7 @@ function replace_ref_begin_end_!(__module__::Module, ex, withex, in_quote_contex
         return ex
     end
     function handle_refexpr!(__module__::Module, ref_ex::Expr, main_ex::Expr, withex, in_quote_context, escs::Int)
-        @assert !in_quote_context
+        @assert !in_quote_context "handle_refexpr! should not be called in quote context"
         local used_withex
         ref_ex.args[1], used_withex = replace_ref_begin_end_!(__module__, ref_ex.args[1], withex, in_quote_context, escs)
         S = gensym(:S) # temp var to cache ex.args[1] if needed. if S is a global or expression, then it has side effects to use


### PR DESCRIPTION
These `@assert`s are not directly problematic for `--trim` (thanks to an overload / monkey patch it does), but they can cause false positives for dynamic dispatches in JET and similar tools so it's probably best to replace them with the 2-arg variant (which just needs to print a String, rather than an `Expr` containing arbitrary Julia objects)