### PR TITLE
Add support for atomic fields with default values to @kwdef

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -582,6 +582,11 @@ Stacktrace:
 ```
 """
 macro kwdef(expr)
+    if isexpr(expr, :struct)
+        fieldsblock = expr.args[3]
+        kwdef_preprocess_atomic_fields!(fieldsblock)
+    end
+
     expr = macroexpand(__module__, expr) # to expand @static
     isexpr(expr, :struct) || error("Invalid usage of @kwdef")
     _, T, fieldsblock = expr.args
@@ -632,6 +637,26 @@ macro kwdef(expr)
     return quote
         $(esc(:($Base.@__doc__ $expr)))
         $kwdefs
+    end
+end
+
+# Pre-process @atomic field definitions in @kwdef structs to move default values
+# outside the @atomic macrocall. This transforms `@atomic x::Int = 1` (parsed as
+# `@atomic (x::Int = 1)`) into `(@atomic x::Int) = 1`, preventing @atomic from
+# misinterpreting the `=` as an atomic modify operation during macroexpand.
+function kwdef_preprocess_atomic_fields!(ex)
+    ex isa Expr || return
+    for (i, item) in pairs(ex.args)
+        if isexpr(item, :macrocall) &&
+               item.args[1] === Symbol("@atomic") && isexpr(item.args[end], :(=))
+            eq_expr = item.args[end]
+            lhs, rhs = eq_expr.args
+            # Replace @atomic (field = default) with (@atomic field) = default
+            atomic_call = Expr(:macrocall, item.args[1:end-1]..., lhs)
+            ex.args[i] = Expr(:(=), atomic_call, rhs)
+        else
+            kwdef_preprocess_atomic_fields!(item)
+        end
     end
 end
 

--- a/base/util.jl
+++ b/base/util.jl
@@ -584,10 +584,13 @@ Stacktrace:
 macro kwdef(expr)
     if isexpr(expr, :struct)
         fieldsblock = expr.args[3]
-        kwdef_preprocess_atomic_fields!(fieldsblock)
+        # Handle top-level @atomic fields
+        for (i, item) in pairs(fieldsblock.args)
+            fieldsblock.args[i] = kwdef_restructure_atomic_default(item)
+        end
     end
 
-    expr = macroexpand(__module__, expr) # to expand @static
+    expr = macroexpand(__module__, expr; recursive=false, legacyscope=false) # to expand @static
     isexpr(expr, :struct) || error("Invalid usage of @kwdef")
     _, T, fieldsblock = expr.args
     if T isa Expr && T.head === :<:
@@ -640,24 +643,14 @@ macro kwdef(expr)
     end
 end
 
-# Pre-process @atomic field definitions in @kwdef structs to move default values
-# outside the @atomic macrocall. This transforms `@atomic x::Int = 1` (parsed as
-# `@atomic (x::Int = 1)`) into `(@atomic x::Int) = 1`, preventing @atomic from
-# misinterpreting the `=` as an atomic modify operation during macroexpand.
-function kwdef_preprocess_atomic_fields!(ex)
-    ex isa Expr || return
-    for (i, item) in pairs(ex.args)
-        if isexpr(item, :macrocall) &&
-               item.args[1] === Symbol("@atomic") && isexpr(item.args[end], :(=))
-            eq_expr = item.args[end]
-            lhs, rhs = eq_expr.args
-            # Replace @atomic (field = default) with (@atomic field) = default
-            atomic_call = Expr(:macrocall, item.args[1:end-1]..., lhs)
-            ex.args[i] = Expr(:(=), atomic_call, rhs)
-        else
-            kwdef_preprocess_atomic_fields!(item)
-        end
+# Transform `@atomic (x::Int = 1)` into `(@atomic x::Int) = 1`, so that @atomic
+# doesn't misinterpret the `=` as an atomic modify operation during macroexpand.
+function kwdef_restructure_atomic_default(ex)
+    if isexpr(ex, :macrocall) && ex.args[1] === Symbol("@atomic") && isexpr(ex.args[end], :(=))
+        lhs, rhs = ex.args[end].args
+        return Expr(:(=), Expr(:macrocall, ex.args[1:end-1]..., lhs), rhs)
     end
+    return ex
 end
 
 # @kwdef helper function
@@ -684,6 +677,11 @@ function extract_names_and_defvals_from_kwdef_fieldblock!(block, names, defvals)
 end
 
 function def_name_defval_from_kwdef_fielddef(kwdef)
+    # Normalize @atomic macrocalls with defaults before processing, so the :(=) branch
+    # handles the default extraction. This covers unexpanded @atomic macrocalls from
+    # inside @static blocks that were not expanded due to recursive=false.
+    kwdef = kwdef_restructure_atomic_default(kwdef)
+
     if kwdef isa Symbol
         return kwdef, kwdef, nothing
     elseif isexpr(kwdef, :(::))
@@ -696,6 +694,9 @@ function def_name_defval_from_kwdef_fielddef(kwdef)
     elseif kwdef isa Expr && kwdef.head in (:const, :atomic)
         def, name, defval = @something(def_name_defval_from_kwdef_fielddef(kwdef.args[1]), return nothing)
         return Expr(kwdef.head, def), name, defval
+    elseif isexpr(kwdef, :macrocall) && kwdef.args[1] === Symbol("@atomic")
+        def, name, defval = @something(def_name_defval_from_kwdef_fielddef(kwdef.args[end]), return nothing)
+        return Expr(:macrocall, kwdef.args[1:end-1]..., def), name, defval
     elseif kwdef isa Expr && kwdef.head in (:escape, :var"hygienic-scope")
         def, name, defval = @something(def_name_defval_from_kwdef_fielddef(kwdef.args[1]), return nothing)
         return Expr(kwdef.head, def), name, isnothing(defval) ? defval : Expr(kwdef.head, defval)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1346,6 +1346,13 @@ end
     const f = 1
     const g::Int = 1
     @atomic h::Int
+    @atomic i::Int = 1
+    @static if true
+        @atomic j::Int = 1
+    end
+    @static if false
+        @atomic k::Int = 3
+    end
 end
 
 @testset "const and @atomic fields in @kwdef" begin
@@ -1366,6 +1373,14 @@ end
         @test @atomic(x.h) == 1
         @atomic x.h = 2
         @test @atomic(x.h) == 2
+    end
+    @testset "@atomic fields with default values" begin
+        @test @atomic(x.i) == 1
+        @test @atomic(x.j) == 1
+        @test :k ∉ fieldnames(Test_kwdef_const_atomic)
+        @test_throws ConcurrencyViolationError x.i = 1
+        @atomic x.i = 42
+        @test @atomic(x.i) == 42
     end
 end
 


### PR DESCRIPTION
Fixes #56932. I didn't realize when I wrote the issue but this form works already:
```julia-repl
julia> @kwdef mutable struct Bar
           (@atomic x::Int) = 1
       end
```

So the PR implements transforming `@atomic x::Int = 1` to `(@atomic x::Int) = 1`.

Written with help from Claude :robot: 