### PR TITLE
use `splat` instead of a local function in `Generator` constructors

### DIFF
--- a/base/generator.jl
+++ b/base/generator.jl
@@ -34,11 +34,11 @@ struct Generator{I,F}
     iter::I
 end
 
-Generator(f, I1, I2, Is...) = Generator(a->f(a...), zip(I1, I2, Is...))
+Generator(f, I1, I2, Is...) = Generator(splat(f), zip(I1, I2, Is...))
 
 Generator(::Type{T}, iter::I) where {T,I} = Generator{I,Type{T}}(T, iter)
 
-Generator(::Type{T}, I1, I2, Is...) where {T} = Generator(a->T(a...), zip(I1, I2, Is...))
+Generator(::Type{T}, I1, I2, Is...) where {T} = Generator(splat(T), zip(I1, I2, Is...))
 
 function iterate(g::Generator, s...)
     @inline

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -121,6 +121,14 @@ let gen = Base.Generator(+, 1:10, 1:10, 1:10)
     @test collect(gen) == 3:3:30
 end
 
+@testset "`Generator` constructor for multiple iterators uses `zip` and `splat`" begin
+    for f in (hypot, Pair)
+        for typ in (Base.Generator{<:Iterators.Zip, <:Base.Splat}, Base.Generator{typeof(zip(1:3, 2:4)), typeof(splat(f))})
+            @test (@inferred Base.Generator(f, 1:3, 2:4)) isa typ
+        end
+    end
+end
+
 let gen = (x for x in 1:10 if x % 2 == 0), gen2 = Iterators.filter(x->x % 2 == 0, x for x in 1:10)
     @test collect(gen) == collect(gen2)
     @test collect(gen) == 2:2:10


### PR DESCRIPTION
One benefit is more succinct showing of iterators created with the generator syntax or with `Iterators.map`.