### PR TITLE
make Iterators.take and Iterators.drop return views for vector input

### DIFF
--- a/base/views.jl
+++ b/base/views.jl
@@ -343,15 +343,16 @@ function Iterators.take(xs::AbstractVector, n::Integer)
     typ = promote_type(typ_f, typ_l, typeof(n))
     typ_wide = widen(typ)
     x = typ_wide(f) + n - 1  # avoid overflow in arithmetic
-    ran = if f <= x
+    y = if f <= x
         if l <= x
-            f:l
+            l
         else
-            f:(typ_l(x))
+            typ_l(x)
         end
     else
-        (typ_f(1)):(typ_l(0))  # empty range
+        typ_l(checked_sub(f, typ_f(1)))  # empty range
     end
+    ran = f:y
     view(xs, ran)
 end
 function Iterators.drop(xs::AbstractVector, n::Integer)
@@ -364,10 +365,11 @@ function Iterators.drop(xs::AbstractVector, n::Integer)
     typ = promote_type(typ_f, typeof(n))
     typ_wide = widen(typ)
     x = typ_wide(f) + n  # avoid overflow in arithmetic
-    ran = if x <= l
-        (typ_f(x)):l
+    y = if x <= l
+        typ_f(x)
     else
-        (typ_f(1)):(typ_l(0))  # empty range
+        typ_f(checked_add(l, typ_l(1)))  # empty range
     end
+    ran = y:l
     view(xs, ran)
 end

--- a/base/views.jl
+++ b/base/views.jl
@@ -338,17 +338,19 @@ function Iterators.take(xs::AbstractVector, n::Integer)
     Iterators.Take(xs, n)  # error handling
     f = firstindex(xs)
     l = lastindex(xs)
-    typ = promote_type(typeof(f), typeof(l), typeof(n))
+    typ_f = typeof(f)
+    typ_l = typeof(l)
+    typ = promote_type(typ_f, typ_l, typeof(n))
     typ_wide = widen(typ)
     x = typ_wide(f) + n - 1  # avoid overflow in arithmetic
     ran = if f <= x
         if l <= x
             f:l
         else
-            f:(typeof(l)(x))
+            f:(typ_l(x))
         end
     else
-        empty(f:l)
+        (typ_f(1)):(typ_l(0))  # empty range
     end
     view(xs, ran)
 end
@@ -357,13 +359,15 @@ function Iterators.drop(xs::AbstractVector, n::Integer)
     Iterators.Drop(xs, n)  # error handling
     f = firstindex(xs)
     l = lastindex(xs)
-    typ = promote_type(typeof(f), typeof(n))
+    typ_f = typeof(f)
+    typ_l = typeof(l)
+    typ = promote_type(typ_f, typeof(n))
     typ_wide = widen(typ)
     x = typ_wide(f) + n  # avoid overflow in arithmetic
     ran = if x <= l
-        (typeof(f)(x)):l
+        (typ_f(x)):l
     else
-        empty(f:l)
+        (typ_f(1)):(typ_l(0))  # empty range
     end
     view(xs, ran)
 end

--- a/base/views.jl
+++ b/base/views.jl
@@ -338,7 +338,18 @@ function Iterators.take(xs::AbstractVector, n::Integer)
     Iterators.Take(xs, n)  # error handling
     f = firstindex(xs)
     l = lastindex(xs)
-    ran = f:min(l, f + n - 1)
+    typ = promote_type(typeof(f), typeof(l), typeof(n))
+    typ_wide = widen(typ)
+    x = typ_wide(f) + n - 1  # avoid overflow in arithmetic
+    ran = if f <= x
+        if l <= x
+            f:l
+        else
+            f:(typeof(l)(x))
+        end
+    else
+        empty(f:l)
+    end
     view(xs, ran)
 end
 function Iterators.drop(xs::AbstractVector, n::Integer)
@@ -346,6 +357,13 @@ function Iterators.drop(xs::AbstractVector, n::Integer)
     Iterators.Drop(xs, n)  # error handling
     f = firstindex(xs)
     l = lastindex(xs)
-    ran = (f + n):l
+    typ = promote_type(typeof(f), typeof(n))
+    typ_wide = widen(typ)
+    x = typ_wide(f) + n  # avoid overflow in arithmetic
+    ran = if x <= l
+        (typeof(f)(x)):l
+    else
+        empty(f:l)
+    end
     view(xs, ran)
 end

--- a/base/views.jl
+++ b/base/views.jl
@@ -347,7 +347,7 @@ function Iterators.take(xs::AbstractVector, n::Integer)
         if l <= x
             l
         else
-            typ_l(x)
+            typ_l(x)  # has to be behind a branch to avoid a spurious throw
         end
     else
         typ_l(checked_sub(f, typ_f(1)))  # empty range
@@ -366,7 +366,7 @@ function Iterators.drop(xs::AbstractVector, n::Integer)
     typ_wide = widen(typ)
     x = typ_wide(f) + n  # avoid overflow in arithmetic
     y = if x <= l
-        typ_f(x)
+        typ_f(x)  # has to be behind a branch to avoid a spurious throw
     else
         typ_f(checked_add(l, typ_l(1)))  # empty range
     end

--- a/base/views.jl
+++ b/base/views.jl
@@ -332,3 +332,20 @@ julia> A
 macro views(x)
     esc(_views(replace_ref_begin_end!(__module__, x)))
 end
+
+function Iterators.take(xs::AbstractVector, n::Integer)
+    n = Int(n)::Int
+    Iterators.Take(xs, n)  # error handling
+    f = firstindex(xs)
+    l = lastindex(xs)
+    ran = f:min(l, f + n - 1)
+    view(xs, ran)
+end
+function Iterators.drop(xs::AbstractVector, n::Integer)
+    n = Int(n)::Int
+    Iterators.Drop(xs, n)  # error handling
+    f = firstindex(xs)
+    l = lastindex(xs)
+    ran = (f + n):l
+    view(xs, ran)
+end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -722,6 +722,17 @@ for T in (UInt8, UInt16, UInt32, UInt64, UInt128, Int8, Int16, Int128, BigInt)
     @test collect(partition(1:5, T(5)))[1] == 1:5
 end
 
+@testset "take, drop of an `AbstractVector` return an `AbstractVector`" begin
+    for typ in (UnitRange, Vector{Float32}, Memory{Float32})
+        for f in (take, drop)
+            for n in 0:5
+                v = typ(2:10)
+                @test (@inferred f(v, n)) isa AbstractVector
+            end
+        end
+    end
+end
+
 @testset "collect finite iterators issue #12009" begin
     @test (@inferred eltype(collect(enumerate(Iterators.Filter(x -> x>0, randn(10)))))) == Tuple{Int, Float64}
 end


### PR DESCRIPTION
Improvements:

* Make `Iterators.take` and `Iterators.drop` preserve the `Base.Fix2(isa, AbstractVector)` property of iterators.

* For `Iterators.drop`: improved iteration performance.