### PR TITLE
build: defer libwhich lookup in symlink_system_library

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -160,12 +160,11 @@ endif
 #	printf "%s\n" "$$P"
 
 define symlink_system_library
-libname_$2 = $$(notdir $(call versioned_libname,$2,$3))
-libpath_$2 = $$(shell $$(call spawn,$$(LIBWHICH)) -p $$(libname_$2) 2>/dev/null)
+libname_$2 := $$(notdir $(call versioned_libname,$2,$3))
 symlink_$2: $$(build_private_libdir)/$$(libname_$2)
 $$(build_private_libdir)/$$(libname_$2):
-	@if [ -e "$$(libpath_$2)" ]; then \
-		REALPATH=$$(libpath_$2); \
+	@REALPATH=`$$(call spawn,$$(LIBWHICH)) -p $$(libname_$2) 2>/dev/null`; \
+	if [ -e "$$$$REALPATH" ]; then \
 		$$(call resolve_path,REALPATH) && \
 		[ -e "$$$$REALPATH" ] && \
 		rm -f "$$@" && \

--- a/base/Makefile
+++ b/base/Makefile
@@ -160,8 +160,8 @@ endif
 #	printf "%s\n" "$$P"
 
 define symlink_system_library
-libname_$2 := $$(notdir $(call versioned_libname,$2,$3))
-libpath_$2 := $$(shell $$(call spawn,$$(LIBWHICH)) -p $$(libname_$2) 2>/dev/null)
+libname_$2 = $$(notdir $(call versioned_libname,$2,$3))
+libpath_$2 = $$(shell $$(call spawn,$$(LIBWHICH)) -p $$(libname_$2) 2>/dev/null)
 symlink_$2: $$(build_private_libdir)/$$(libname_$2)
 $$(build_private_libdir)/$$(libname_$2):
 	@if [ -e "$$(libpath_$2)" ]; then \


### PR DESCRIPTION
Run `libwhich -p` inside the symlink recipe shell instead of
using `$(shell ...)` in a recursively expanded make variable.

This keeps evaluation timing explicit and avoids unpredictable
expansion behavior from recursive `$(shell ...)`.

The lookup still happens only when the symlink target is built,
so default builds and clean targets do not trigger unnecessary
probes.

This fixes in particular annoying segfaults in libwhich on macOS when
it tries to inspect libcrypto or libssl. Since USE_SYSTEM_OPENSSL=0
by default, the failed lookups don't matter but they look scary and
if CrashReporter is active, can be also rather annoying.

Resolves #57670

Co-authored-by: Codex <codex@openai.com>
