### PR TITLE
Move InterMustAlias to Core

### DIFF
--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -4,9 +4,9 @@
 # structs/constants #
 #####################
 
-# N.B.: Const/PartialStruct/InterConditional are defined in Core, to allow them to be used
-# inside the global code cache.
-import Core: Const, InterConditional, PartialStruct
+# N.B.: Const/PartialStruct/InterConditional/InterMustAlias are defined in Core,
+# to allow them to be used inside the global code cache.
+import Core: Const, InterConditional, PartialStruct, InterMustAlias
 
 function may_form_limited_typ(@nospecialize(aty), @nospecialize(bty), @nospecialize(xty))
     if aty isa LimitedAccuracy
@@ -110,32 +110,11 @@ end
 MustAlias(var::SlotNumber, ssadef::Int, @nospecialize(vartyp), fldidx::Int, @nospecialize(fldtyp)) =
     MustAlias(slot_id(var), ssadef, vartyp, fldidx, fldtyp)
 
-"""
-    alias::InterMustAlias
-
-This lattice element used in a very similar way as `InterConditional`, but corresponds to `MustAlias`.
-"""
-struct InterMustAlias
-    slot::Int
-    vartyp::Any
-    fldidx::Int
-    fldtyp::Any
-    function InterMustAlias(slot::Int, @nospecialize(vartyp), fldidx::Int, @nospecialize(fldtyp))
-        assert_nested_slotwrapper(vartyp)
-        assert_nested_slotwrapper(fldtyp)
-        # @assert !isalreadyconst(vartyp) "vartyp is already const"
-        # @assert !isalreadyconst(fldtyp) "fldtyp is already const"
-        limited = may_form_limited_typ(vartyp, fldtyp, fldtyp)
-        limited !== nothing && return limited
-        return new(slot, vartyp, fldidx, fldtyp)
-    end
-end
-InterMustAlias(var::SlotNumber, @nospecialize(vartyp), fldidx::Int, @nospecialize(fldtyp)) =
-    InterMustAlias(slot_id(var), vartyp, fldidx, fldtyp)
-
 const AnyMustAlias = Union{MustAlias,InterMustAlias}
 function InterMustAlias(alias::MustAlias)
     @assert alias.ssadef == 0
+    limited = may_form_limited_typ(alias.vartyp, alias.fldtyp, alias.fldtyp)
+    limited !== nothing && return limited
     InterMustAlias(alias.slot, alias.vartyp, alias.fldidx, alias.fldtyp)
 end
 

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -568,6 +568,14 @@ struct InterConditional
     InterConditional(slot::Int, @nospecialize(thentype), @nospecialize(elsetype)) = new(slot, thentype, elsetype)
 end
 
+struct InterMustAlias
+    slot::Int
+    vartyp::Any
+    fldidx::Int
+    fldtyp::Any
+    InterMustAlias(slot::Int, @nospecialize(vartyp), fldidx::Int, @nospecialize(fldtyp)) = new(slot, vartyp, fldidx, fldtyp)
+end
+
 struct PartialOpaque
     typ::Type
     env

--- a/base/coreir.jl
+++ b/base/coreir.jl
@@ -114,3 +114,13 @@ Core.InterConditional
 
 Core.InterConditional(var::SlotNumber, @nospecialize(thentype), @nospecialize(elsetype)) =
     InterConditional(slot_id(var), thentype, elsetype)
+
+"""
+    alias::InterMustAlias
+
+This lattice element used in a very similar way as `InterConditional`, but corresponds to `MustAlias`.
+"""
+Core.InterMustAlias
+
+InterMustAlias(var::SlotNumber, @nospecialize(vartyp), fldidx::Int, @nospecialize(fldtyp)) =
+    InterMustAlias(slot_id(var), vartyp, fldidx, fldtyp)

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -61,6 +61,7 @@
     XX(int32_type, jl_datatype_t*) \
     XX(int64_type, jl_datatype_t*) \
     XX(int8_type, jl_datatype_t*) \
+    XX(inter_must_alias_type, jl_datatype_t*) \
     XX(interconditional_type, jl_datatype_t*) \
     XX(interrupt_exception, jl_value_t*) \
     XX(intrinsic_type, jl_datatype_t*) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3989,6 +3989,7 @@ void post_boot_hooks(void)
     jl_partial_struct_type = (jl_datatype_t*)core("PartialStruct");
     jl_interconditional_type = (jl_datatype_t*)core("InterConditional");
     jl_partial_opaque_type = (jl_datatype_t*)core("PartialOpaque");
+    jl_inter_must_alias_type = (jl_datatype_t*)core("InterMustAlias");
 
     export_jl_small_typeof();
     export_jl_sysimg_globals();


### PR DESCRIPTION
Since we publish InterMustAlias to the global cache in rettype_const, it should live in Core.  Loading the Compiler package when it's defined there results in silent incorrect type inference, since the new compiler wraps Core.Compiler.InterMustAlias in a Core.Const when it's found in rettype_const.