### PR TITLE
jitlayers: Fix findCompatibleCI checking wrong CodeInstance

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2269,7 +2269,7 @@ jl_code_instance_t *JuliaOJIT::findCompatibleCI(jl_code_instance_t *CI)
     };
     for (auto CI2 = jl_atomic_load_relaxed(&MI->cache); CI2;
          CI2 = jl_atomic_load_relaxed(&CI2->next)) {
-        if (CI2 != CI && IsCompatible(CI) &&
+        if (CI2 != CI && IsCompatible(CI2) &&
             (CISymbols.contains(CI2) || jl_atomic_load_relaxed(&CI2->invoke))) {
             return CI2;
         }


### PR DESCRIPTION
`findCompatibleCI` was calling `IsCompatible(CI)` instead of `IsCompatible(CI2)`, comparing the input CI against its own captured values (always true) rather than checking the candidate CI2. This caused it to return any compiled CI for the same MethodInstance, regardless of whether the rettype matched, which resulted in memory corruptions / segfaults due to ABI mismatches.