### PR TITLE
fix pkg loading from read-only filesystems on unix

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2058,9 +2058,8 @@ function compilecache_freshest_path(pkg::PkgId;
             try
                 # update timestamp of precompilation file so that it is the first to be tried by code loading
                 touch(path_to_try)
-            catch ex
+            catch
                 # file might be read-only and then we fail to update timestamp, which is fine
-                ex isa IOError || rethrow()
             end
             return path_to_try
         end
@@ -2280,8 +2279,8 @@ end
                 if stalecheck
                     try
                         touch(path_to_try) # update timestamp of precompilation file
-                    catch ex # file might be read-only and then we fail to update timestamp, which is fine
-                        ex isa IOError || rethrow()
+                    catch
+                        # file might be read-only and then we fail to update timestamp, which is fine
                     end
                 end
                 # finish loading module graph into staledeps


### PR DESCRIPTION
On our HPC systems `/home` is mounted read-only on the compute nodes, and if you load a precompiled pkg you'll see errors like the following:

```
julia> using DataFrames
ERROR: SystemError: futimes: Permission denied
Stacktrace:
  [1] systemerror(p::Symbol, errno::Int32; extrainfo::Nothing)
    @ Base ./error.jl:186
  [2] systemerror
    @ ./error.jl:185 [inlined]
  [3] touch
    @ ./filesystem.jl:361 [inlined]
  [4] touch(path::String)
    @ Base.Filesystem ./file.jl:546
  [5] _require_search_from_serialized(pkg::Base.PkgId, sourcepath::String, build_id::UInt128, stalecheck::Bool; reasons::Dict{String, Int64}, DEPOT_PATH::Vector{String})
    @ Base ./loading.jl:2090
...
```

But touching read-only files is supposed to be fine, according to the code comments:

https://github.com/JuliaLang/julia/blob/74d12302d74928dbe8c8883bdd395cd3e35481b9/base/loading.jl#L2058-L2064

However, only `IOError`s are ignored. On unix `touch()` calls `futimes` in the C stdlib and throws `SystemError`:

https://github.com/JuliaLang/julia/blob/74d12302d74928dbe8c8883bdd395cd3e35481b9/base/filesystem.jl#L359-L368

This patch ignores all exceptions thrown when touching precompilation files.