### PR TITLE
[JuliaLowering] compat: Fix catch scope provenance

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -352,7 +352,7 @@ function est_to_dst(st::SyntaxTree; all_expanded=true)
             has_finally = length(rest) >= 1 && !_is_false(rest[1])
             has_else = length(rest) === 2
             @ast g st [K"try" rec(tryb)
-                has_catch ? [K"catch" cvar_out rec(catchb)] : nothing
+                has_catch ? [K"catch"(catchb) cvar_out rec(catchb)] : nothing
                 has_else ? [K"else" rec(rest[2])] : nothing
                 has_finally ? [K"finally" rec(rest[1])] : nothing
             ]

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -320,10 +320,10 @@ function est_to_dst(st::SyntaxTree; all_expanded=true)
         [K"module" _...] -> st
         [K"toplevel" _...] -> st
         [K"for" [K"=" _ _] body] ->
-            @ast g st [K"for" [K"iteration" _dst_eq_to_in(st[1])] rec(body)]
+            @ast g st [K"for" [K"iteration"(st[1]) _dst_eq_to_in(st[1])] rec(body)]
         [K"for" [K"block" iters...] body] ->
             @ast g st [K"for"
-                [K"iteration" mapsyntax(_dst_eq_to_in, iters)...]
+                [K"iteration"(st[1]) mapsyntax(_dst_eq_to_in, iters)...]
                 rec(body)
             ]
         ([K"where" t tds...],
@@ -353,8 +353,8 @@ function est_to_dst(st::SyntaxTree; all_expanded=true)
             has_else = length(rest) === 2
             @ast g st [K"try" rec(tryb)
                 has_catch ? [K"catch"(catchb) cvar_out rec(catchb)] : nothing
-                has_else ? [K"else" rec(rest[2])] : nothing
-                has_finally ? [K"finally" rec(rest[1])] : nothing
+                has_else ? [K"else"(rest[2]) rec(rest[2])] : nothing
+                has_finally ? [K"finally"(rest[1]) rec(rest[1])] : nothing
             ]
         end
         [K"flatten" _] -> let
@@ -412,7 +412,7 @@ function est_to_dst(st::SyntaxTree; all_expanded=true)
             ]
         end
         ([K"let" binds body], when=(kind(binds) !== K"block")) ->
-            @ast g st [K"let" [K"block" rec(binds)] rec(body)]
+            @ast g st [K"let" [K"block"(binds) rec(binds)] rec(body)]
         [K"struct" mut sig body] -> let
             flags = JS.flags(st) | (_is_false(mut) ? 0 : JS.MUTABLE_FLAG)
             @ast g st [K"struct"(syntax_flags=flags)
@@ -473,7 +473,7 @@ function est_to_dst(st::SyntaxTree; all_expanded=true)
         [K"copyast" [K"inert" ex]] -> @ast g st [K"call"
             interpolate_ast::K"Value"
             Expr::K"Value"
-            [K"inert" ex]
+            [K"inert"(st[1]) ex]
         ]
         [K"symbolicgoto" lab] -> setattr!(mkleaf(st), :name_val, lab.name_val)
         [K"symboliclabel" lab] -> setattr!(mkleaf(st), :name_val, lab.name_val)
@@ -493,8 +493,8 @@ function est_to_dst(st::SyntaxTree; all_expanded=true)
         end
         [K"cfunction" typ fptr rt at sym] -> @ast g st [K"cfunction"
             rec(typ) rec(fptr)
-            [K"static_eval"(meta=name_hint("cfunction return type")) rec(rt)]
-            [K"static_eval"(meta=name_hint("cfunction argument type")) rec(at)]
+            [K"static_eval"(rt, meta=name_hint("cfunction return type")) rec(rt)]
+            [K"static_eval"(at, meta=name_hint("cfunction argument type")) rec(at)]
             rec(sym)
         ]
 


### PR DESCRIPTION
Set explicit `srcref` for the `K"catch"` node in `est_to_dst` try reconstruction. Previously, `[K"catch" ...]` inherited the parent `st` (the EST `K"try"` node) as its source, causing the catch `scope_block`'s `flattened_provenance` to resolve to `K"try"` rather than the catch body. This made it impossible for external consumers to distinguish catch scopes from try scopes using provenance alone.