### PR TITLE
WIP: implement `ImmediateOrRef{T}` aka "tagged pointers"

### DIFF
--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -319,6 +319,7 @@ include("number.jl")
 include("int.jl")
 include("operators.jl")
 include("pointer.jl")
+include("immediateorref.jl")
 include("refvalue.jl")
 include("cmem.jl")
 

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -213,7 +213,7 @@ export
     Function, Method, Module, Symbol, Task, UndefInitializer, undef, WeakRef, VecElement,
     Array, Memory, MemoryRef, AtomicMemory, AtomicMemoryRef, GenericMemory, GenericMemoryRef,
     # numeric types
-    Number, Real, Integer, Bool, Ref, Ptr,
+    Number, Real, Integer, Bool, Ref, Ptr, ImmediateOrRef,
     AbstractFloat, Float16, Float32, Float64,
     Signed, Int, Int8, Int16, Int32, Int64, Int128,
     Unsigned, UInt, UInt8, UInt16, UInt32, UInt64, UInt128,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -10,7 +10,7 @@ export Core,
     Function, Method, Module, Symbol, Task, UndefInitializer, undef, WeakRef, VecElement,
     Array, Memory, MemoryRef, AtomicMemory, AtomicMemoryRef, GenericMemory, GenericMemoryRef,
     # numeric types
-    Number, Real, Integer, Bool, Ref, Ptr,
+    Number, Real, Integer, Bool, Ref, Ptr, ImmediateOrRef,
     AbstractFloat, Float16, Float32, Float64,
     Signed, Int, Int8, Int16, Int32, Int64, Int128,
     Unsigned, UInt, UInt8, UInt16, UInt32, UInt64, UInt128,

--- a/base/immediateorref.jl
+++ b/base/immediateorref.jl
@@ -1,0 +1,48 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# low-level helpers for the prototype ImmediateOrRef representation
+function _taggedptr_check_type(@nospecialize(T))
+    isa(T, Type) || error("ImmediateOrRef parameter must be a type in this prototype")
+    allocatedinline(T) &&
+        error("ImmediateOrRef parameter type must be represented as an ordinary boxed object in this prototype")
+    return T
+end
+_taggedptr_from_raw(::Type{ImmediateOrRef{T}}, raw::UInt) where {T} =
+    (_taggedptr_check_type(T);
+     Core.bitcast(ImmediateOrRef{T}, raw)::ImmediateOrRef{T})
+function _taggedptr_from_ref(::Type{ImmediateOrRef{T}}, @nospecialize(x)) where {T}
+    _taggedptr_check_type(T)
+    x isa T || throw(TypeError(:_taggedptr_from_ref, T, x))
+    raw = ccall(:jl_value_ptr, UInt, (Any,), x)
+    (raw == 0 || (raw & UInt(1)) != 0) &&
+        error("ImmediateOrRef reference encoding requires an aligned nonzero object pointer")
+    return _taggedptr_from_raw(ImmediateOrRef{T}, raw)
+end
+getindex(x::ImmediateOrRef{T}) where {T} = begin
+    raw = getrawvalue(x)
+    raw == 0 && throw(UndefRefError())
+    isimmediate(x) &&
+        error("ImmediateOrRef immediate payload does not contain a Julia object reference")
+    p = Core.bitcast(Ptr{Cvoid}, raw)
+    return ccall(:jl_value_ptr, Any, (Ptr{Cvoid},), p)::T
+end
+function _taggedptr_setref(x::ImmediateOrRef{T}, @nospecialize(y)) where {T}
+    return _taggedptr_from_ref(ImmediateOrRef{T}, y)
+end
+
+# isassigned(x) returns true if and only if x[] would work (not throw an error)
+function isassigned(x::ImmediateOrRef)
+    raw = getrawvalue(x)
+    return raw != 0 && (raw & UInt(1)) == 0
+end
+
+# isimmediate(x) returns true if and only if x is set to a genuine raw value
+# (so not to a pointer and not to NULL)
+isimmediate(x::ImmediateOrRef) = (getrawvalue(x) & UInt(1)) == UInt(1)
+
+getrawvalue(x::ImmediateOrRef) = Core.bitcast(UInt, x)::UInt
+setrawvalue(x::ImmediateOrRef{T}, raw::UInt) where {T} =
+    _taggedptr_from_raw(ImmediateOrRef{T}, raw)::ImmediateOrRef{T}
+
+ImmediateOrRef{T}() where {T} = _taggedptr_from_raw(ImmediateOrRef{T}, UInt(0))
+ImmediateOrRef{T}(x::T) where {T} = _taggedptr_from_ref(ImmediateOrRef{T}, x)

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -564,6 +564,7 @@ struct DataTypeLayout
     size::UInt32
     nfields::UInt32
     npointers::UInt32
+    ntaggedptrs::UInt32
     firstptr::Int32
     alignment::UInt16
     flags::UInt16
@@ -684,7 +685,10 @@ Can be called on any `isconcretetype`.
 """
 function datatype_pointerfree(dt::DataType)
     @_foldable_meta
-    return datatype_npointers(dt) == 0
+    layout_ptr = dt.layout::Ptr{Cvoid}
+    layout_ptr == C_NULL && throw(UndefRefError())
+    layout = unsafe_load(convert(Ptr{DataTypeLayout}, layout_ptr))
+    return layout.npointers == 0 && layout.ntaggedptrs == 0
 end
 
 """

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -244,6 +244,7 @@ DevDocs = [
         "devdocs/types.md",
         "devdocs/ub.md",
         "devdocs/object.md",
+        "devdocs/taggedptr.md",
         "devdocs/eval.md",
         "devdocs/callconv.md",
         "devdocs/compiler.md",

--- a/doc/src/devdocs/taggedptr.md
+++ b/doc/src/devdocs/taggedptr.md
@@ -1,0 +1,320 @@
+# Plan For ImmediateOrRef Support
+
+This note outlines a plan for implementing the feature discussed in
+[JuliaLang/julia#47735](https://github.com/JuliaLang/julia/issues/47735):
+a Julia-managed reference type that can hold either a normal heap reference
+or a small immediate value encoded in the reference bits.
+
+The issue discussion converges on a few points that should shape the work:
+
+- The feature should be a general runtime primitive, not a one-off `BigInt`
+  optimization.
+- For the prototype, the public name is `ImmediateOrRef`.
+- The runtime must participate directly. A pure Julia wrapper around `Ptr`
+  does not solve GC scanning, write barriers, or serialization.
+- The first implementation should focus on making the primitive correct and
+  usable. Follow-on consumers such as faster big integers, short strings, or
+  compact AST/source-location fields can come later.
+- The initial target is 64-bit Julia only, and the datatype should always
+  occupy 64 bits.
+
+## Goals
+
+- Add a first-class Julia type for storing either an immediate payload or a
+  Julia object reference in one machine word.
+- Preserve GC correctness, including tracing, remembered sets, and system
+  image serialization.
+- Expose a small API that lets user code test whether a value is immediate and
+  extract or install the raw payload cheaply.
+- Keep the design general enough that future optimizations for strings,
+  algebraic types, and compact unions can reuse the same machinery.
+
+## Non-goals for the first milestone
+
+- Replacing `BigInt`, `BigFloat`, or `String` in Base immediately.
+- Auto-optimizing arbitrary `Union{BitsType, RefType}` fields.
+- Designing a full tagged-union feature for all Julia aggregates.
+- Supporting every possible packed layout from day one.
+
+## Prototype decisions
+
+These choices are fixed for the first prototype unless implementation work
+shows that one of them is untenable:
+
+- `ImmediateOrRef{T}` is a dedicated primitive type with 64-bit storage.
+- The prototype is supported on 64-bit Julia only.
+- The first implementation targets struct fields and ordinary object
+  serialization on the stock GC. Tagged array / `Memory` elements and MMTK
+  support can come later.
+- The runtime distinguishes only two states at the representation level:
+  ordinary Julia reference and immediate payload. Higher-level payload schemes
+  are left to user code.
+
+### Proposed Core/Base shape
+
+The intended surface shape is:
+
+```julia
+primitive type ImmediateOrRef{T} <: Ref{T} 64 end
+```
+
+with Base methods layered on top for `getindex`, `isassigned`, `isimmediate`,
+`getrawvalue`, and `setrawvalue`.
+
+Subtyping `Ref{T}` keeps the user model close to the original issue and aligns
+with existing `Ref`-based APIs. The runtime representation is still special:
+it is not a raw native pointer and it cannot be modeled correctly as an
+ordinary `primitive type` without runtime support.
+
+### Proposed encoded representation
+
+At the machine level, an `ImmediateOrRef` slot stores one `UInt64`.
+
+- `0` means "unassigned".
+- a word with low bit `0` and nonzero value is a normal `jl_value_t*`
+  reference;
+- a word with low bit `1` is an immediate payload.
+
+This keeps the GC rule simple: only nonzero words with low bit `0` are traced.
+It also matches the original issue sketch.
+
+The prototype should assume that Julia object references stored in
+`ImmediateOrRef` have at least three low zero bits on supported 64-bit builds.
+However, only bit 0 needs to be interpreted by the runtime itself in v1.
+Bits 1 and 2 remain available to user-level encoding schemes.
+
+### Scope restriction for v1
+
+The first implementation should support `ImmediateOrRef` in struct fields before
+attempting to support it in `Memory`/array element layouts.
+
+The current prototype also targets the stock Julia GC only. Extending the
+design to MMTK is deferred until the core approach has been validated and the
+MMTK maintainers can coordinate the binding-side changes.
+
+That restriction keeps the initial runtime work bounded:
+
+- datatype layout changes are local to normal object fields;
+- GC scanning can be implemented as an extension of object scanning first;
+- serialization can piggyback on ordinary object field traversal;
+- codegen only needs field load/store support at first.
+
+If that lands cleanly, array-like storage can reuse the same slot semantics in
+a follow-up change.
+
+### Preferred layout-metadata strategy
+
+The existing object layout machinery mainly tracks two classes of embedded
+fields: unconditional pointers and everything else. Reusing the current
+`isptr` bit for tagged slots would force too many ambiguous special cases into
+the runtime.
+
+For the prototype, prefer extending `jl_datatype_layout_t` with explicit tagged
+slot metadata instead:
+
+- keep `npointers` / `first_ptr` / pointer offset tables for unconditional
+  references;
+- add `ntaggedptrs` and a parallel table of tagged-slot offsets;
+- treat `ImmediateOrRef` fields as 8-byte inline fields in the ordinary field
+  descriptors, but record their offsets again in the tagged-slot table.
+
+This keeps existing unconditional-pointer fast paths mostly intact while
+giving the GC, serializer, and code generator a precise way to find tagged
+slots.
+
+### First runtime touchpoints
+
+Given the strategy above, the first implementation steps should be:
+
+1. Add `ImmediateOrRef` to Core/Base as a built-in primitive type declaration in
+   `base/boot.jl`.
+2. Teach datatype layout construction in `src/datatype.c` to recognize fields
+   of type `ImmediateOrRef{T}` and populate the new tagged-slot metadata.
+3. Extend `jl_datatype_layout_t` and its helpers in `src/julia.h` so the
+   runtime can iterate tagged slots separately from unconditional pointers.
+4. Add one helper used by GC, serialization, and codegen to classify a stored
+   word as unassigned, reference, or immediate payload.
+
+## Proposed implementation stages
+
+### 1. Freeze the semantic model
+
+Before touching the runtime, decide the surface contract:
+
+- Use `ImmediateOrRef{T}` as the prototype and implementation name.
+- Implement it as a dedicated type first, rather than as field syntax or as a
+  general `Union` storage optimization.
+- Specify the invariants:
+  - the prototype only supports 64-bit runtimes;
+  - the representation is always 64 bits wide;
+  - object references stored in `ImmediateOrRef` have at least three low zero bits
+    on supported 64-bit Julia runtimes;
+  - whether v1 guarantees at least 3 tag bits, as suggested in the thread;
+  - v1 only permits payload types that are represented as ordinary boxed objects,
+    not inline/bits-like payload types such as `Int`;
+  - mutability is not the criterion: immutable non-inline object types remain valid.
+- Specify the minimal API: construction from a Julia value, `isassigned`,
+  `isimmediate`, `[]`, raw load/store of the encoded word,
+  conversion rules, and
+  pointer-conversion behavior for `ccall`.
+
+This stage should end with a short design section in this document being
+updated into a normative description.
+
+### 2. Extend object-layout metadata
+
+Current datatype layout metadata only distinguishes between "pointer" and
+"not a pointer". That is not enough for a field whose contents are scanned like
+a pointer only when a tag test succeeds.
+
+Expected touchpoints:
+
+- `src/julia.h`
+- `src/datatype.c`
+- `Compiler/src/Compiler.jl`
+- Base reflection helpers that expose `DataTypeFieldDesc`
+
+For the prototype, prefer explicit tagged-slot metadata in
+`jl_datatype_layout_t` instead of overloading the existing `isptr` bit in field
+descriptors. Concretely, keep the current unconditional pointer metadata and
+add a separate tagged-slot count plus offset table.
+
+### 3. Teach the stock GC how to scan tagged-reference slots
+
+Once layout metadata can identify tagged-reference fields, the collectors need
+to treat them as conditionally traced edges.
+
+Expected touchpoints:
+
+- `src/gc-stock.c`
+- `src/gc-wb-stock.h`
+
+Required work:
+
+- Add a helper for "load slot, test tag bits, recover `jl_value_t*` if this is
+  a real reference".
+- Update mark-stack traversal for objects and array-like storage if tagged
+  slots are allowed there.
+- Update remembered-set/write-barrier logic so that storing an immediate value
+  does not enqueue a fake edge, while storing a young object still preserves
+  generational invariants.
+- Audit debug assertions and heap verifiers that currently assume every pointer
+  slot is an untagged `jl_value_t*`.
+
+MMTK support is intentionally deferred for this prototype.
+
+### 4. Update serialization and system-image support
+
+The issue explicitly calls out serialization. Any object that contains a tagged
+reference field must serialize the heap reference case as a reference and the
+immediate case as raw bits.
+
+Expected touchpoints:
+
+- `src/staticdata.c`
+- Base-level serialization tests
+
+Required work:
+
+- Queue referenced objects only when the slot currently stores a real Julia
+  object.
+- Preserve the raw encoded word for immediate cases.
+- Ensure relocation logic never tries to relocate an immediate payload as if it
+  were a pointer.
+- Add round-trip tests for ordinary serialization and system-image generation.
+
+### 5. Add codegen and inference support
+
+Even with correct GC behavior, the feature is not useful unless loads, stores,
+and roots are modeled correctly by the compiler.
+
+Expected touchpoints:
+
+- `src/codegen.cpp`
+- `Compiler/src/abstractinterpretation.jl`
+- any builtins/intrinsics used to access the raw representation
+
+Required work:
+
+- Prevent "pointerfree" and "all pointers" fast paths from misclassifying
+  tagged-reference layouts.
+- Ensure inline-root extraction accounts for tagged-reference fields.
+- Decide whether `isimmediate`, raw-load, and raw-store operations are builtins,
+  intrinsics, or ordinary functions lowered to builtins.
+- Make field load/store lowering emit the correct tag test, write barrier, and
+  type information.
+
+This is also the right place to decide how much the optimizer should know about
+the new primitive. A minimal first version can treat it conservatively.
+
+### 6. Add the Base/Core surface API
+
+After the runtime path exists, wire up the user-visible type and operations.
+
+Expected touchpoints:
+
+- `base/boot.jl`
+- `base/refpointer.jl`
+
+Candidate API surface for v1:
+
+- `ImmediateOrRef{T}`
+- constructor from `T`
+- zero-argument constructor for an unassigned slot
+- `isassigned`
+- `getindex`
+- `isimmediate`
+- `getrawvalue`
+- `setrawvalue`
+
+Deferred for later:
+
+- nested `RefValue{ImmediateOrRef{T}}` mutation support
+
+The v1 API should stay intentionally small. Higher-level helpers for small
+integers, short strings, or compact rationals belong in follow-up work.
+
+### 7. Validation and bring-up
+
+The feature touches the object model, so validation needs to be broader than a
+normal Base API addition.
+
+Test areas:
+
+- runtime layout/reflection tests;
+- GC tests that exercise young/old edges, immediate writes, and stress
+  collection;
+- serialization and system-image round trips;
+- compiler/codegen tests for field access and rooting;
+- one end-to-end proof-of-concept type, likely a small `FastBigInt`-style
+  experiment kept in tests rather than in Base.
+
+## Recommended order of execution
+
+1. Finalize the semantic model and write down the invariants.
+2. Extend layout metadata so the runtime can distinguish tagged-reference
+   fields.
+3. Make GC scanning and barriers correct.
+4. Make serialization and system-image handling correct.
+5. Expose compiler hooks and the public API.
+6. Add a proof-of-concept consumer and benchmark it.
+
+This order keeps correctness work ahead of API expansion and avoids building a
+surface feature on top of ad hoc runtime checks.
+
+## Open design questions
+
+- Bit budget: whether the runtime should guarantee exactly 3 low zero bits for
+  stored references, or merely rely on current alignment and document it.
+- Exact constructor contract for non-reference-like values of type `T`,
+  especially boxed immutables.
+- Relation to existing `Union` optimizations: separate feature, or eventual
+  storage backend for some union fields.
+
+## Follow-up work after the primitive lands
+
+- Prototype a `FastBigInt`-style package or internal benchmark.
+- Explore short-string support.
+- Revisit compact `Expr` source-location storage.
+- Evaluate whether some `Union{bits, ref}` layouts should eventually lower to
+  the same runtime representation.

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2622,6 +2622,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("AddrSpace", (jl_value_t*)jl_addrspace_type);
     add_builtin("Ref", (jl_value_t*)jl_ref_type);
     add_builtin("Ptr", (jl_value_t*)jl_pointer_type);
+    add_builtin("ImmediateOrRef", (jl_value_t*)jl_taggedpointer_type);
     //add_builtin("GenericPtr", (jl_value_t*)jl_genericpointer_type);
     add_builtin("AbstractArray", (jl_value_t*)jl_abstractarray_type);
     add_builtin("DenseArray", (jl_value_t*)jl_densearray_type);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2282,6 +2282,7 @@ static void emit_write_barrier(jl_codectx_t&, Value*, ArrayRef<Value*>);
 static void emit_write_barrier(jl_codectx_t&, Value*, Value*);
 static void emit_write_multibarrier(jl_codectx_t&, Value*, Value*, jl_value_t*);
 static void emit_write_multibarrier(jl_codectx_t &ctx, Value *parent, const jl_cgval_t &x);
+static void emit_taggedptr_write_barrier(jl_codectx_t &ctx, Value *parent, Value *raw);
 
 SmallVector<unsigned, 0> first_ptr(Type *T)
 {
@@ -2559,6 +2560,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
     AllocaInst *intcast = nullptr;
     unsigned nb = 0;
     bool tracked_pointers = false;
+    bool tagged_ptr = !is_union && jl_is_taggedpointer_type(jltype);
     Value *r = nullptr;
     if (!is_union) {
         if (isboxed)
@@ -2968,34 +2970,44 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
         ctx.builder.SetInsertPoint(DoneBB);
     if (needlock)
         emit_lockstate_value(ctx, needlock, false);
-    if (parent != NULL && tracked_pointers && (!isboxed || !type_is_permalloc(rhs.typ))) {
+    if (parent != NULL && (tracked_pointers || tagged_ptr) && (!isboxed || !type_is_permalloc(rhs.typ))) {
         if (op == StoreKind::Replace || op == StoreKind::SetOnce) {
             BasicBlock *BB = BasicBlock::Create(ctx.builder.getContext(), "xchg_wb", ctx.f);
             DoneBB = BasicBlock::Create(ctx.builder.getContext(), "done_xchg_wb", ctx.f);
             ctx.builder.CreateCondBr(Success, BB, DoneBB);
             ctx.builder.SetInsertPoint(BB);
         }
-        if (r) {
-            if (realelty != elty)
-                r = ctx.builder.Insert(CastInst::Create(Instruction::Trunc, r, realelty));
-            if (intcast) {
-                ctx.builder.CreateStore(r, intcast);
-                r = ctx.builder.CreateLoad(intcast_eltyp, intcast);
+        if (tracked_pointers) {
+            if (r) {
+                if (realelty != elty)
+                    r = ctx.builder.Insert(CastInst::Create(Instruction::Trunc, r, realelty));
+                if (intcast) {
+                    ctx.builder.CreateStore(r, intcast);
+                    r = ctx.builder.CreateLoad(intcast_eltyp, intcast);
+                }
+                else if (!isboxed && intcast_eltyp) {
+                    assert(op == StoreKind::Set);
+                    // setfield doesn't use intcast, so need to reload rhs with the correct type
+                    r = emit_unbox(ctx, intcast_eltyp, rhs);
+                }
+                if (!isboxed)
+                    emit_write_multibarrier(ctx, parent, r, rhs.typ);
+                else
+                    emit_write_barrier(ctx, parent, r);
             }
-            else if (!isboxed && intcast_eltyp) {
-                assert(op == StoreKind::Set);
-                // setfield doesn't use intcast, so need to reload rhs with the correct type
-                r = emit_unbox(ctx, intcast_eltyp, rhs);
+            else {
+                assert(!isboxed);
+                assert(!rhs.inline_roots.empty());
+                emit_write_multibarrier(ctx, parent, rhs);
             }
-            if (!isboxed)
-                emit_write_multibarrier(ctx, parent, r, rhs.typ);
-            else
-                emit_write_barrier(ctx, parent, r);
         }
-        else {
-            assert(!isboxed);
-            assert(!rhs.inline_roots.empty());
-            emit_write_multibarrier(ctx, parent, rhs);
+        if (tagged_ptr) {
+            Value *raw = r;
+            if (raw == nullptr) {
+                Type *rawty = intcast_eltyp ? intcast_eltyp : realelty;
+                raw = emit_unbox(ctx, rawty, rhs);
+            }
+            emit_taggedptr_write_barrier(ctx, parent, raw);
         }
         if (op == StoreKind::Replace || op == StoreKind::SetOnce) {
             ctx.builder.CreateBr(DoneBB);
@@ -4364,6 +4376,36 @@ static void emit_write_multibarrier(jl_codectx_t &ctx, Value *parent, const jl_c
 {
     auto ptrs = get_gc_roots_for(ctx, x, true);
     emit_write_barrier(ctx, parent, ptrs);
+}
+
+static void emit_taggedptr_write_barrier(jl_codectx_t &ctx, Value *parent, Value *raw)
+{
+    Type *T_size = ctx.types().T_size;
+    if (raw->getType()->isPointerTy()) {
+        raw = ctx.builder.CreatePtrToInt(raw, T_size);
+    }
+    else {
+        assert(raw->getType()->isIntegerTy());
+        if (raw->getType() != T_size) {
+            if (raw->getType()->getIntegerBitWidth() > T_size->getIntegerBitWidth())
+                raw = ctx.builder.CreateTrunc(raw, T_size);
+            else
+                raw = ctx.builder.CreateZExt(raw, T_size);
+        }
+    }
+    Value *nonzero = ctx.builder.CreateICmpNE(raw, ConstantInt::get(T_size, 0));
+    Value *isptr = ctx.builder.CreateICmpEQ(
+        ctx.builder.CreateAnd(raw, ConstantInt::get(T_size, 1)),
+        ConstantInt::get(T_size, 0));
+    Value *isref = ctx.builder.CreateAnd(nonzero, isptr);
+
+    BasicBlock *wbBB = BasicBlock::Create(ctx.builder.getContext(), "taggedptr_wb", ctx.f);
+    BasicBlock *contBB = BasicBlock::Create(ctx.builder.getContext(), "taggedptr_wb_done", ctx.f);
+    ctx.builder.CreateCondBr(isref, wbBB, contBB);
+    ctx.builder.SetInsertPoint(wbBB);
+    emit_write_barrier(ctx, parent, ctx.builder.CreateIntToPtr(raw, ctx.types().T_pjlvalue));
+    ctx.builder.CreateBr(contBB);
+    ctx.builder.SetInsertPoint(contBB);
 }
 
 static jl_cgval_t emit_setfield(jl_codectx_t &ctx,

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -149,11 +149,15 @@ static uint32_t _hash_layout_djb2(uintptr_t _layout, void *unused) JL_NOTSAFEPOI
     const char *pointers = jl_dt_layout_ptrs(layout);
     assert(pointers);
     size_t pointers_size = layout->first_ptr < 0 ? 0 : (layout->npointers << layout->flags.fielddesc_type);
+    const char *taggedptrs = jl_dt_layout_taggedptrs(layout);
+    assert(taggedptrs);
+    size_t taggedptrs_size = layout->ntaggedptrs << layout->flags.fielddesc_type;
 
     uint_t hash = 5381;
     hash = _hash_djb2(hash, (char *)layout, own_size);
     hash = _hash_djb2(hash, fields, fields_size);
     hash = _hash_djb2(hash, pointers, pointers_size);
+    hash = _hash_djb2(hash, taggedptrs, taggedptrs_size);
     return hash;
 }
 
@@ -174,6 +178,11 @@ static int layout_eq(void *_l1, void *_l2, void *unused) JL_NOTSAFEPOINT
     size_t pointers_size = l1->first_ptr < 0 ? 0 : (l1->npointers << l1->flags.fielddesc_type);
     if (memcmp(p1, p2, pointers_size))
         return 0;
+    const char *tp1 = jl_dt_layout_taggedptrs(l1);
+    const char *tp2 = jl_dt_layout_taggedptrs(l2);
+    size_t taggedptrs_size = l1->ntaggedptrs << l1->flags.fielddesc_type;
+    if (memcmp(tp1, tp2, taggedptrs_size))
+        return 0;
     return 1;
 }
 
@@ -188,12 +197,14 @@ static int layoutcache_initialized = 0;
 static jl_datatype_layout_t *jl_get_layout(uint32_t sz,
                                            uint32_t nfields,
                                            uint32_t npointers,
+                                           uint32_t ntaggedptrs,
                                            uint32_t alignment,
                                            int haspadding,
                                            int isbitsegal,
                                            int arrayelem,
                                            jl_fielddesc32_t desc[],
-                                           uint32_t pointers[]) JL_NOTSAFEPOINT
+                                           uint32_t pointers[],
+                                           uint32_t taggedptrs[]) JL_NOTSAFEPOINT
 {
     assert(alignment); // should have been verified by caller
 
@@ -210,6 +221,8 @@ static jl_datatype_layout_t *jl_get_layout(uint32_t sz,
     }
     if (npointers > 0 && pointers[npointers - 1] > max_offset)
         max_offset = pointers[npointers - 1];
+    if (ntaggedptrs > 0 && taggedptrs[ntaggedptrs - 1] > max_offset)
+        max_offset = taggedptrs[ntaggedptrs - 1];
     jl_fielddesc8_t maxdesc8 = { 0, max_size, max_offset };
     jl_fielddesc16_t maxdesc16 = { 0, max_size, max_offset };
     jl_fielddesc32_t maxdesc32 = { 0, max_size, max_offset };
@@ -227,7 +240,8 @@ static jl_datatype_layout_t *jl_get_layout(uint32_t sz,
     // allocate a new descriptor, on the stack if possible.
     size_t fields_size = nfields * jl_fielddesc_size(fielddesc_type);
     size_t pointers_size = first_ptr < 0 ? 0 : (npointers << fielddesc_type);
-    size_t flddesc_sz = sizeof(jl_datatype_layout_t) + fields_size + pointers_size;
+    size_t taggedptrs_size = ntaggedptrs << fielddesc_type;
+    size_t flddesc_sz = sizeof(jl_datatype_layout_t) + fields_size + pointers_size + taggedptrs_size;
     int should_malloc = flddesc_sz >= jl_page_size;
     jl_datatype_layout_t *mallocmem = (jl_datatype_layout_t *)(should_malloc ? malloc(flddesc_sz) : NULL);
     jl_datatype_layout_t *allocamem = (jl_datatype_layout_t *)(should_malloc ? NULL : alloca(flddesc_sz));
@@ -245,6 +259,7 @@ static jl_datatype_layout_t *jl_get_layout(uint32_t sz,
     flddesc->flags.arrayelem_islocked = (arrayelem & 8) != 0;
     flddesc->flags.padding = 0;
     flddesc->npointers = npointers;
+    flddesc->ntaggedptrs = ntaggedptrs;
     flddesc->first_ptr = first_ptr;
 
     // fill out the fields of the new descriptor
@@ -281,6 +296,22 @@ static jl_datatype_layout_t *jl_get_layout(uint32_t sz,
             }
             else {
                 ptrs32[i] = pointers[i];
+            }
+        }
+    }
+    if (ntaggedptrs > 0) {
+        uint8_t *ptrs8 = (uint8_t *)jl_dt_layout_taggedptrs(flddesc);
+        uint16_t *ptrs16 = (uint16_t *)jl_dt_layout_taggedptrs(flddesc);
+        uint32_t *ptrs32 = (uint32_t *)jl_dt_layout_taggedptrs(flddesc);
+        for (size_t i = 0; i < ntaggedptrs; i++) {
+            if (fielddesc_type == 0) {
+                ptrs8[i] = taggedptrs[i];
+            }
+            else if (fielddesc_type == 1) {
+                ptrs16[i] = taggedptrs[i];
+            }
+            else {
+                ptrs32[i] = taggedptrs[i];
             }
         }
     }
@@ -509,6 +540,11 @@ static int is_type_identityfree(jl_value_t *t)
     return 0;
 }
 
+static int is_taggedptr_type(jl_value_t *t) JL_NOTSAFEPOINT
+{
+    return jl_is_taggedpointer_type(t);
+}
+
 // make a copy of the layout of st, but with nfields=0
 void jl_get_genericmemory_layout(jl_datatype_t *st)
 {
@@ -523,8 +559,12 @@ void jl_get_genericmemory_layout(jl_datatype_t *st)
     }
     if (!jl_is_type(eltype)) {
         // this is expected to have a layout, but since it is not constructable, we don't care too much what it is
-        static const jl_datatype_layout_t opaque_ptr_layout = {0, 0, 1, -1, sizeof(void*), {0}};
+        static const jl_datatype_layout_t opaque_ptr_layout = {0, 0, 1, 0, -1, sizeof(void*), {0}};
         st->layout = &opaque_ptr_layout;
+        st->has_concrete_subtype = 0;
+        return;
+    }
+    if (is_taggedptr_type(eltype)) {
         st->has_concrete_subtype = 0;
         return;
     }
@@ -557,6 +597,10 @@ void jl_get_genericmemory_layout(jl_datatype_t *st)
             assert(jl_is_datatype(eltype));
             zi = ((jl_datatype_t*)eltype)->zeroinit;
             el_layout = ((jl_datatype_t*)eltype)->layout;
+            if (el_layout->ntaggedptrs > 0) {
+                st->has_concrete_subtype = 0;
+                return;
+            }
             if (el_layout->first_ptr >= 0) {
                 first_ptr = el_layout->first_ptr;
                 npointers = el_layout->npointers;
@@ -609,7 +653,7 @@ void jl_get_genericmemory_layout(jl_datatype_t *st)
             arrayelem |= 8;  // arrayelem_islocked
     }
     assert(!st->layout);
-    st->layout = jl_get_layout(elsz, nfields, npointers, al, haspadding, isbitsegal, arrayelem, NULL, pointers);
+    st->layout = jl_get_layout(elsz, nfields, npointers, 0, al, haspadding, isbitsegal, arrayelem, NULL, pointers, NULL);
     st->zeroinit = zi;
     //st->has_concrete_subtype = 1;
     //st->isbitstype = 0;
@@ -669,17 +713,17 @@ void jl_compute_field_offsets(jl_datatype_t *st)
         // if we have no fields, we can trivially skip the rest
         if (st == jl_symbol_type || st == jl_string_type) {
             // opaque layout - heap-allocated blob
-            static const jl_datatype_layout_t opaque_byte_layout = {0, 0, 1, -1, 1, { .isbitsegal=1 }};
+            static const jl_datatype_layout_t opaque_byte_layout = {0, 0, 1, 0, -1, 1, { .isbitsegal=1 }};
             st->layout = &opaque_byte_layout;
             return;
         }
         else if (st == jl_simplevector_type || st == jl_module_type) {
-            static const jl_datatype_layout_t opaque_ptr_layout = {0, 0, 1, -1, sizeof(void*), { .isbitsegal=1 }};
+            static const jl_datatype_layout_t opaque_ptr_layout = {0, 0, 1, 0, -1, sizeof(void*), { .isbitsegal=1 }};
             st->layout = &opaque_ptr_layout;
             return;
         }
         else {
-            static const jl_datatype_layout_t singleton_layout = {0, 0, 0, -1, 1, { .isbitsegal=1 }};
+            static const jl_datatype_layout_t singleton_layout = {0, 0, 0, 0, -1, 1, { .isbitsegal=1 }};
             st->layout = &singleton_layout;
         }
     }
@@ -704,6 +748,12 @@ void jl_compute_field_offsets(jl_datatype_t *st)
 
     for (i = 0; (isbitstype || isidentityfree || ismutationfree) && i < nfields; i++) {
         jl_value_t *fld = jl_field_type(st, i);
+        if (is_taggedptr_type(fld)) {
+            isbitstype = 0;
+            ismutationfree = 0;
+            isidentityfree = 0;
+            continue;
+        }
         isbitstype &= jl_isbits(fld);
         ismutationfree &= (!st->name->mutabl || jl_field_isconst(st, i)) && is_type_mutationfree(fld);
         isidentityfree &= is_type_identityfree(fld);
@@ -714,6 +764,7 @@ void jl_compute_field_offsets(jl_datatype_t *st)
         size_t descsz = nfields * sizeof(jl_fielddesc32_t);
         jl_fielddesc32_t *desc;
         uint32_t *pointers;
+        uint32_t *taggedptrs;
         int should_malloc = descsz >= jl_page_size;
         if (should_malloc)
             desc = (jl_fielddesc32_t*)malloc_s(descsz);
@@ -727,6 +778,7 @@ void jl_compute_field_offsets(jl_datatype_t *st)
         int homogeneous = 1;
         int needlock = 0;
         uint32_t npointers = 0;
+        uint32_t ntaggedptrs = 0;
         jl_value_t *firstty = jl_field_type(st, 0);
         for (i = 0; i < nfields; i++) {
             jl_value_t *fld = jl_field_type(st, i);
@@ -745,12 +797,17 @@ void jl_compute_field_offsets(jl_datatype_t *st)
                     isbitsegal = 0;
                 }
                 else {
+                    if (is_taggedptr_type(fld)) {
+                        ntaggedptrs++;
+                        zeroinit = 1;
+                    }
                     if (fsz > jl_datatype_size(fld)) {
                         // We have to pad the size to integer size class, but it means this has some padding
                         isbitsegal = 0;
                         haspadding = 1;
                     }
                     uint32_t fld_npointers = ((jl_datatype_t*)fld)->layout->npointers;
+                    uint32_t fld_ntaggedptrs = ((jl_datatype_t*)fld)->layout->ntaggedptrs;
                     if (((jl_datatype_t*)fld)->layout->flags.haspadding)
                         haspadding = 1;
                     if (!((jl_datatype_t*)fld)->layout->flags.isbitsegal)
@@ -772,6 +829,7 @@ void jl_compute_field_offsets(jl_datatype_t *st)
                     if (!zeroinit)
                         zeroinit = ((jl_datatype_t*)fld)->zeroinit;
                     npointers += fld_npointers;
+                    ntaggedptrs += fld_ntaggedptrs;
                 }
             }
             else {
@@ -830,25 +888,40 @@ void jl_compute_field_offsets(jl_datatype_t *st)
             pointers = (uint32_t*)malloc_s(npointers * sizeof(uint32_t));
         else
             pointers = (uint32_t*)alloca(npointers * sizeof(uint32_t));
+        if (should_malloc && ntaggedptrs)
+            taggedptrs = (uint32_t*)malloc_s(ntaggedptrs * sizeof(uint32_t));
+        else
+            taggedptrs = (uint32_t*)alloca(ntaggedptrs * sizeof(uint32_t));
         size_t ptr_i = 0;
+        size_t tp_i = 0;
         for (i = 0; i < nfields; i++) {
             jl_value_t *fld = jl_field_type(st, i);
             uint32_t offset = desc[i].offset / sizeof(jl_value_t**);
-            if (desc[i].isptr)
+            if (desc[i].isptr) {
                 pointers[ptr_i++] = offset;
+            }
             else if (jl_is_datatype(fld)) {
+                if (is_taggedptr_type(fld))
+                    taggedptrs[tp_i++] = offset;
                 int j, npointers = ((jl_datatype_t*)fld)->layout->npointers;
                 for (j = 0; j < npointers; j++) {
                     pointers[ptr_i++] = offset + jl_ptr_offset((jl_datatype_t*)fld, j);
                 }
+                int ntaggedptrs = ((jl_datatype_t*)fld)->layout->ntaggedptrs;
+                for (j = 0; j < ntaggedptrs; j++) {
+                    taggedptrs[tp_i++] = offset + jl_taggedptr_offset((jl_datatype_t*)fld, j);
+                }
             }
         }
         assert(ptr_i == npointers);
-        st->layout = jl_get_layout(sz, nfields, npointers, alignm, haspadding, isbitsegal, 0, desc, pointers);
+        assert(tp_i == ntaggedptrs);
+        st->layout = jl_get_layout(sz, nfields, npointers, ntaggedptrs, alignm, haspadding, isbitsegal, 0, desc, pointers, taggedptrs);
         if (should_malloc) {
             free(desc);
             if (npointers)
                 free(pointers);
+            if (ntaggedptrs)
+                free(taggedptrs);
         }
         st->zeroinit = zeroinit;
     }
@@ -1024,7 +1097,7 @@ JL_DLLEXPORT jl_datatype_t *jl_new_primitivetype(jl_value_t *name, jl_module_t *
     bt->ismutationfree = 1;
     bt->isidentityfree = 1;
     bt->isbitstype = (parameters == jl_emptysvec);
-    bt->layout = jl_get_layout(nbytes, 0, 0, alignm, 0, 1, 0, NULL, NULL);
+    bt->layout = jl_get_layout(nbytes, 0, 0, 0, alignm, 0, 1, 0, NULL, NULL, NULL);
     bt->instance = NULL;
     return bt;
 }
@@ -1044,8 +1117,10 @@ JL_DLLEXPORT jl_datatype_t * jl_new_foreign_type(jl_sym_t *name,
         0, 4, 0);
     layout->size = large ? GC_MAX_SZCLASS+1 : 0;
     layout->nfields = 0;
-    layout->alignment = sizeof(void *);
     layout->npointers = haspointers;
+    layout->ntaggedptrs = 0;
+    layout->first_ptr = -1;
+    layout->alignment = sizeof(void *);
     layout->flags.haspadding = 1;
     layout->flags.isbitsegal = 0;
     layout->flags.fielddesc_type = 3;
@@ -1916,6 +1991,7 @@ inline void set_nth_field(jl_datatype_t *st, jl_value_t *v, size_t i, jl_value_t
     else {
         jl_value_t *ty = jl_field_type_concrete(st, i);
         jl_value_t *rty = jl_typeof(rhs);
+        int istagged = is_taggedptr_type(ty);
         int hasptr;
         int isunion = jl_is_uniontype(ty);
         if (isunion) {
@@ -1949,12 +2025,19 @@ inline void set_nth_field(jl_datatype_t *st, jl_value_t *v, size_t i, jl_value_t
         }
         if (hasptr)
             jl_gc_multi_wb(v, rhs); // rhs is immutable
+        if (istagged) {
+            uintptr_t raw = 0;
+            memcpy(&raw, rhs, sizeof(raw));
+            if (jl_taggedptr_is_reference(raw))
+                jl_gc_multi_wb(v, (jl_value_t*)raw);
+        }
     }
 }
 
 inline jl_value_t *swap_bits(jl_value_t *ty, char *v, uint8_t *psel, jl_value_t *parent, jl_value_t *rhs, enum atomic_kind isatomic)
 {
     jl_value_t *rty = jl_typeof(rhs);
+    int istagged = is_taggedptr_type(ty);
     int hasptr;
     int isunion = psel != NULL;
     if (isunion) {
@@ -1997,6 +2080,12 @@ inline jl_value_t *swap_bits(jl_value_t *ty, char *v, uint8_t *psel, jl_value_t 
         r = undefref_check((jl_datatype_t*)ty, r);
     if (hasptr)
         jl_gc_multi_wb(parent, rhs); // rhs is immutable
+    if (istagged) {
+        uintptr_t raw = 0;
+        memcpy(&raw, rhs, sizeof(raw));
+        if (jl_taggedptr_is_reference(raw))
+            jl_gc_multi_wb(parent, (jl_value_t*)raw);
+    }
     if (__unlikely(r == NULL))
         jl_throw(jl_undefref_exception);
     return r;
@@ -2063,6 +2152,7 @@ inline jl_value_t *modify_value(jl_value_t *ty, _Atomic(jl_value_t*) *p, jl_valu
 
 inline jl_value_t *modify_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value_t *parent, jl_value_t *op, jl_value_t *rhs, enum atomic_kind isatomic)
 {
+    int istagged = is_taggedptr_type(ty);
     int hasptr;
     int isunion = psel != NULL;
     if (isunion) {
@@ -2108,6 +2198,12 @@ inline jl_value_t *modify_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value_
             if (jl_atomic_bool_cmpswap_bits(p, r, y, fsz)) {
                 if (hasptr)
                     jl_gc_multi_wb(parent, y); // y is immutable
+                if (istagged) {
+                    uintptr_t raw = 0;
+                    memcpy(&raw, y, sizeof(raw));
+                    if (jl_taggedptr_is_reference(raw))
+                        jl_gc_multi_wb(parent, (jl_value_t*)raw);
+                }
                 break;
             }
         }
@@ -2138,6 +2234,12 @@ inline jl_value_t *modify_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value_
             if (success) {
                 if (hasptr)
                     jl_gc_multi_wb(parent, y); // y is immutable
+                if (istagged) {
+                    uintptr_t raw = 0;
+                    memcpy(&raw, y, sizeof(raw));
+                    if (jl_taggedptr_is_reference(raw))
+                        jl_gc_multi_wb(parent, (jl_value_t*)raw);
+                }
                 break;
             }
         }
@@ -2195,6 +2297,7 @@ inline jl_value_t *replace_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value
     jl_datatype_t *rettyp = jl_apply_cmpswap_type(ty);
     JL_GC_PROMISE_ROOTED(rettyp); // (JL_ALWAYS_LEAFTYPE)
     int hasptr;
+    int istagged = is_taggedptr_type(ty);
     int isunion = psel != NULL;
     size_t fsz = jl_field_size(rettyp, 0);
     int needlock = (isatomic && fsz > MAX_ATOMIC_SIZE);
@@ -2250,6 +2353,12 @@ inline jl_value_t *replace_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value
     }
     if (success && hasptr)
         jl_gc_multi_wb(parent, rhs); // rhs is immutable
+    if (success && istagged) {
+        uintptr_t raw = 0;
+        memcpy(&raw, rhs, sizeof(raw));
+        if (jl_taggedptr_is_reference(raw))
+            jl_gc_multi_wb(parent, (jl_value_t*)raw);
+    }
     if (!isunion) {
         r = undefref_check((jl_datatype_t*)rty, r);
         if (__unlikely(r == NULL))
@@ -2279,8 +2388,9 @@ jl_value_t *replace_nth_field(jl_datatype_t *st, jl_value_t *v, size_t i, jl_val
 inline int setonce_bits(jl_datatype_t *rty, char *p, jl_value_t *parent, jl_value_t *rhs, enum atomic_kind isatomic)
 {
     size_t fsz = jl_datatype_size((jl_datatype_t*)rty); // need to shrink-wrap the final copy
-    assert(rty->layout->first_ptr >= 0);
-    int hasptr = 1;
+    int hasptr = rty->layout->first_ptr >= 0;
+    int istagged = is_taggedptr_type((jl_value_t*)rty);
+    assert(hasptr || istagged);
     int needlock = (isatomic && fsz > MAX_ATOMIC_SIZE);
     int success;
     if (isatomic && !needlock) {
@@ -2293,8 +2403,14 @@ inline int setonce_bits(jl_datatype_t *rty, char *p, jl_value_t *parent, jl_valu
             memassign_safe(hasptr, px, rhs, fsz);
         unlock(p, parent, needlock, isatomic);
     }
-    if (success)
+    if (success && hasptr)
         jl_gc_multi_wb(parent, rhs); // rhs is immutable
+    if (success && istagged) {
+        uintptr_t raw = 0;
+        memcpy(&raw, rhs, sizeof(raw));
+        if (jl_taggedptr_is_reference(raw))
+            jl_gc_multi_wb(parent, (jl_value_t*)raw);
+    }
     return success;
 }
 
@@ -2318,7 +2434,8 @@ int set_nth_fieldonce(jl_datatype_t *st, jl_value_t *v, size_t i, jl_value_t *rh
         if (isunion)
             return 0;
         int hasptr = ((jl_datatype_t*)ty)->layout->first_ptr >= 0;
-        if (!hasptr)
+        int istagged = is_taggedptr_type(ty);
+        if (!hasptr && !istagged)
             return 0;
         assert(ty == jl_typeof(rhs));
         success = setonce_bits((jl_datatype_t*)ty, p, v, rhs, isatomic ? isatomic_object : isatomic_none);

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -1511,30 +1511,43 @@ void jl_gc_queue_multiroot(const jl_value_t *parent, const void *ptr, jl_datatyp
 {
     const jl_datatype_layout_t *ly = dt->layout;
     uint32_t npointers = ly->npointers;
-    //if (npointers == 0) // this was checked by the caller
-    //    return;
-    jl_value_t *ptrf = ((jl_value_t**)ptr)[ly->first_ptr];
-    if (ptrf && (jl_astaggedvalue(ptrf)->bits.gc & 1) == 0) {
-        // this pointer was young, move the barrier back now
-        jl_gc_wb_back(parent);
-        return;
+    if (npointers > 0) {
+        jl_value_t *ptrf = ((jl_value_t**)ptr)[ly->first_ptr];
+        if (ptrf && (jl_astaggedvalue(ptrf)->bits.gc & 1) == 0) {
+            // this pointer was young, move the barrier back now
+            jl_gc_wb_back(parent);
+            return;
+        }
+        const uint8_t *ptrs8 = (const uint8_t *)jl_dt_layout_ptrs(ly);
+        const uint16_t *ptrs16 = (const uint16_t *)jl_dt_layout_ptrs(ly);
+        const uint32_t *ptrs32 = (const uint32_t*)jl_dt_layout_ptrs(ly);
+        for (size_t i = 1; i < npointers; i++) {
+            uint32_t fld;
+            if (ly->flags.fielddesc_type == 0) {
+                fld = ptrs8[i];
+            }
+            else if (ly->flags.fielddesc_type == 1) {
+                fld = ptrs16[i];
+            }
+            else {
+                assert(ly->flags.fielddesc_type == 2);
+                fld = ptrs32[i];
+            }
+            jl_value_t *ptrf = ((jl_value_t**)ptr)[fld];
+            if (ptrf && (jl_astaggedvalue(ptrf)->bits.gc & 1) == 0) {
+                // this pointer was young, move the barrier back now
+                jl_gc_wb_back(parent);
+                return;
+            }
+        }
     }
-    const uint8_t *ptrs8 = (const uint8_t *)jl_dt_layout_ptrs(ly);
-    const uint16_t *ptrs16 = (const uint16_t *)jl_dt_layout_ptrs(ly);
-    const uint32_t *ptrs32 = (const uint32_t*)jl_dt_layout_ptrs(ly);
-    for (size_t i = 1; i < npointers; i++) {
-        uint32_t fld;
-        if (ly->flags.fielddesc_type == 0) {
-            fld = ptrs8[i];
-        }
-        else if (ly->flags.fielddesc_type == 1) {
-            fld = ptrs16[i];
-        }
-        else {
-            assert(ly->flags.fielddesc_type == 2);
-            fld = ptrs32[i];
-        }
-        jl_value_t *ptrf = ((jl_value_t**)ptr)[fld];
+    uint32_t ntagged = ly->ntaggedptrs;
+    for (size_t i = 0; i < ntagged; i++) {
+        uint32_t fld = jl_taggedptr_offset(dt, i);
+        uintptr_t raw = ((uintptr_t*)ptr)[fld];
+        if (!jl_taggedptr_is_reference(raw))
+            continue;
+        jl_value_t *ptrf = (jl_value_t*)raw;
         if (ptrf && (jl_astaggedvalue(ptrf)->bits.gc & 1) == 0) {
             // this pointer was young, move the barrier back now
             jl_gc_wb_back(parent);
@@ -1804,6 +1817,33 @@ STATIC_INLINE jl_value_t *gc_mark_obj32(jl_ptls_t ptls, char *obj32_parent, uint
     }
     gc_mark_push_remset(ptls, (jl_value_t *)obj32_parent, nptr);
     return new_obj;
+}
+
+// Mark object tagged-pointer slots
+STATIC_INLINE uintptr_t gc_mark_obj_taggedptr(jl_ptls_t ptls, char *obj_parent, jl_datatype_t *vt,
+                           uintptr_t nptr, int push_remset) JL_NOTSAFEPOINT
+{
+    jl_gc_markqueue_t *mq = &ptls->gc_tls.mark_queue;
+    const jl_datatype_layout_t *layout = vt->layout;
+    uint32_t nt = layout->ntaggedptrs;
+    for (size_t i = 0; i < nt; i++) {
+        uint32_t fld = jl_taggedptr_offset(vt, i);
+        uintptr_t *slot = &((uintptr_t*)obj_parent)[fld];
+        uintptr_t raw = *slot;
+        if (!jl_taggedptr_is_reference(raw))
+            continue;
+        jl_value_t *new_obj = (jl_value_t*)raw;
+        verify_parent2("object", obj_parent, slot, "field(%d)",
+                        gc_slot_to_fieldidx(obj_parent, slot, vt));
+        gc_assert_parent_validity((jl_value_t*)obj_parent, new_obj);
+        gc_try_claim_and_push(mq, new_obj, &nptr);
+        if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
+            _gc_heap_snapshot_record_object_edge((jl_value_t*)obj_parent, new_obj, slot);
+        }
+    }
+    if (push_remset)
+        gc_mark_push_remset(ptls, (jl_value_t *)obj_parent, nptr);
+    return nptr;
 }
 
 // Mark object array
@@ -2483,9 +2523,19 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
             return;
         const jl_datatype_layout_t *layout = vt->layout;
         uint32_t npointers = layout->npointers;
-        if (npointers == 0)
+        uint32_t ntaggedptrs = layout->ntaggedptrs;
+        int tagged_had_young = 0;
+        if (npointers == 0 && ntaggedptrs == 0)
             return;
-        uintptr_t nptr = (npointers << 2 | (bits & GC_OLD));
+        if (ntaggedptrs > 0) {
+            uintptr_t tagged_nptr = ((npointers + ntaggedptrs) << 2 | (bits & GC_OLD));
+            tagged_nptr = gc_mark_obj_taggedptr(ptls, (char*)new_obj, vt, tagged_nptr, npointers == 0);
+            if (npointers == 0)
+                return;
+            tagged_had_young = tagged_nptr & 0x1;
+        }
+        uintptr_t nptr = ((npointers + ntaggedptrs) << 2 | (bits & GC_OLD));
+        nptr |= tagged_had_young;
         assert((layout->nfields > 0 || layout->flags.fielddesc_type == 3) &&
                "opaque types should have been handled specially");
         if (layout->flags.fielddesc_type == 0) {

--- a/src/gc-wb-stock.h
+++ b/src/gc-wb-stock.h
@@ -37,7 +37,7 @@ STATIC_INLINE void jl_gc_multi_wb(const void *parent, const jl_value_t *ptr) JL_
         return; // ptr is old and not in remset (thus it does not point to young)
     jl_datatype_t *dt = (jl_datatype_t*)jl_typeof(ptr);
     const jl_datatype_layout_t *ly = dt->layout;
-    if (ly->npointers)
+    if (ly->npointers || ly->ntaggedptrs)
         jl_gc_queue_multiroot((jl_value_t*)parent, ptr, dt);
 }
 

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -108,6 +108,8 @@
     XX(pinode_type, jl_datatype_t*) \
     XX(pointer_type, jl_unionall_t*) \
     XX(pointer_typename, jl_typename_t*) \
+    XX(taggedpointer_type, jl_unionall_t*) \
+    XX(taggedpointer_typename, jl_typename_t*) \
     XX(precompilable_error, jl_value_t*) \
     XX(quotenode_type, jl_datatype_t*) \
     XX(readonlymemory_exception, jl_value_t*) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2403,10 +2403,26 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
                 jl_type_error_rt("GenericMemory", "isatomic parameter", (jl_value_t*)jl_symbol_type, isatomic);
             invalid = 1;
         }
+        jl_value_t *eltype = jl_svecref(p, 1);
+        if (jl_is_datatype(eltype) &&
+            (jl_is_taggedpointer_type(eltype) ||
+             (((jl_datatype_t*)eltype)->layout != NULL && ((jl_datatype_t*)eltype)->layout->ntaggedptrs > 0))) {
+            if (!nothrow)
+                jl_error("GenericMemory element type cannot contain ImmediateOrRef in this prototype");
+            invalid = 1;
+        }
         jl_value_t *addrspace = jl_svecref(p, 2);
         if (!jl_is_typevar(addrspace) && !jl_is_addrspace(addrspace)) {
             if (!nothrow)
                 jl_type_error_rt("GenericMemory", "addrspace parameter", (jl_value_t*)jl_addrspace_type, addrspace);
+            invalid = 1;
+        }
+    }
+    else if (tn == jl_taggedpointer_typename) {
+        jl_value_t *eltype = jl_svecref(p, 0);
+        if (jl_is_type(eltype) && jl_stored_inline(eltype)) {
+            if (!nothrow)
+                jl_error("ImmediateOrRef parameter type must be represented as an ordinary boxed object in this prototype");
             invalid = 1;
         }
     }
@@ -3368,6 +3384,14 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_pointer_type = (jl_unionall_t*)jl_pointer_typename->wrapper;
     jl_value_t *pointer_void = jl_apply_type1((jl_value_t*)jl_pointer_type, (jl_value_t*)jl_nothing_type);
     jl_voidpointer_type = (jl_datatype_t*)pointer_void;
+
+    tv = jl_svec1(tvar("T"));
+    jl_taggedpointer_typename =
+        jl_new_primitivetype((jl_value_t*)jl_symbol("ImmediateOrRef"), core,
+                             (jl_datatype_t*)jl_apply_type((jl_value_t*)jl_ref_type, jl_svec_data(tv), 1),
+                             tv,
+                             64)->name;
+    jl_taggedpointer_type = (jl_unionall_t*)jl_taggedpointer_typename->wrapper;
 
     tv = jl_svec2(tvar("T"), tvar("N"));
     jl_abstractarray_type = (jl_unionall_t*)

--- a/src/julia.h
+++ b/src/julia.h
@@ -593,6 +593,7 @@ typedef struct {
     uint32_t size;
     uint32_t nfields;
     uint32_t npointers; // number of pointers embedded inside
+    uint32_t ntaggedptrs; // number of TaggedPtr slots embedded inside
     int32_t first_ptr; // index of the first pointer (or -1)
     uint16_t alignment; // strictest alignment over all fields
     struct { // combine these fields into a struct so that we can take addressof them
@@ -1487,6 +1488,10 @@ static inline const char *jl_dt_layout_ptrs(const jl_datatype_layout_t *l) JL_NO
 {
     return jl_dt_layout_fields(l) + jl_fielddesc_size(l->flags.fielddesc_type) * l->nfields;
 }
+static inline const char *jl_dt_layout_taggedptrs(const jl_datatype_layout_t *l) JL_NOTSAFEPOINT
+{
+    return jl_dt_layout_ptrs(l) + (l->first_ptr < 0 ? 0 : (l->npointers << l->flags.fielddesc_type));
+}
 
 #define DEFINE_FIELD_ACCESSORS(f)                                             \
     static inline uint32_t jl_field_##f(jl_datatype_t *st,                    \
@@ -1532,6 +1537,28 @@ static inline uint32_t jl_ptr_offset(jl_datatype_t *st, int i) JL_NOTSAFEPOINT
         assert(ly->flags.fielddesc_type == 2);
         return ((const uint32_t*)ptrs)[i];
     }
+}
+
+static inline uint32_t jl_taggedptr_offset(jl_datatype_t *st, int i) JL_NOTSAFEPOINT
+{
+    const jl_datatype_layout_t *ly = st->layout; // NOT jl_datatype_layout(st)
+    assert(i >= 0 && (size_t)i < ly->ntaggedptrs);
+    const void *ptrs = jl_dt_layout_taggedptrs(ly);
+    if (ly->flags.fielddesc_type == 0) {
+        return ((const uint8_t*)ptrs)[i];
+    }
+    else if (ly->flags.fielddesc_type == 1) {
+        return ((const uint16_t*)ptrs)[i];
+    }
+    else {
+        assert(ly->flags.fielddesc_type == 2);
+        return ((const uint32_t*)ptrs)[i];
+    }
+}
+
+static inline int jl_taggedptr_is_reference(uintptr_t raw) JL_NOTSAFEPOINT
+{
+    return raw != 0 && (raw & 1) == 0;
 }
 
 static inline int jl_field_isatomic(jl_datatype_t *st, int i) JL_NOTSAFEPOINT
@@ -1744,6 +1771,12 @@ STATIC_INLINE int jl_is_llvmpointer_type(jl_value_t *t) JL_NOTSAFEPOINT
 {
     return (jl_is_datatype(t) &&
             ((jl_datatype_t*)(t))->name == jl_llvmpointer_typename);
+}
+
+STATIC_INLINE int jl_is_taggedpointer_type(jl_value_t *t) JL_NOTSAFEPOINT
+{
+    return (jl_is_datatype(t) &&
+            ((jl_datatype_t*)(t))->name == jl_taggedpointer_typename);
 }
 
 STATIC_INLINE int jl_is_abstract_ref_type(jl_value_t *t) JL_NOTSAFEPOINT

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -529,6 +529,14 @@ static jl_value_t *get_replaceable_field(jl_value_t **addr, int mutabl) JL_GC_DI
     return fld;
 }
 
+static jl_value_t *get_taggedptr_field(uintptr_t *addr) JL_NOTSAFEPOINT
+{
+    uintptr_t raw = *addr;
+    if (!jl_taggedptr_is_reference(raw))
+        return NULL;
+    return (jl_value_t*)raw;
+}
+
 static uintptr_t jl_fptr_id(void *fptr)
 {
     void **pbp = ptrhash_bp(&fptr_to_id, fptr);
@@ -834,7 +842,7 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
     if (immediate) // must be things that can be recursively handled, and valid as type parameters
         assert(jl_is_immutable(t) || jl_is_typevar(v) || jl_is_symbol(v) || jl_is_svec(v));
 
-    if (layout->npointers == 0) {
+    if (layout->npointers == 0 && layout->ntaggedptrs == 0) {
         // bitstypes do not require recursion
     }
     else if (jl_is_svec(v)) {
@@ -922,6 +930,17 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
             jl_value_t *fld = get_replaceable_field(&((jl_value_t**)data)[ptr], mutabl);
             jl_queue_for_serialization_(s, fld, 1, immediate);
         }
+        size_t nt = layout->ntaggedptrs;
+        fldidx = 1;
+        for (i = 0; i < nt; i++) {
+            uint32_t ptr = jl_taggedptr_offset(t, i);
+            size_t offset = ptr * sizeof(uintptr_t);
+            while (offset >= (fldidx == layout->nfields ? jl_datatype_size(t) : jl_field_offset(t, fldidx)))
+                fldidx++;
+            jl_value_t *fld = get_taggedptr_field(&((uintptr_t*)data)[ptr]);
+            if (fld != NULL)
+                jl_queue_for_serialization_(s, fld, 1, immediate);
+        }
     }
 
 done_fields: ;
@@ -955,6 +974,15 @@ done_fields: ;
             int mutabl = 1;
             jl_value_t *fld = get_replaceable_field(&((jl_value_t**)data)[ptr], mutabl);
             jl_queue_for_serialization_(s, fld, 1, immediate);
+        }
+        size_t nt = layout->ntaggedptrs;
+        for (i = 0; i < nt; i++) {
+            uint32_t ptr = jl_taggedptr_offset(t, i);
+            if (ptr * sizeof(uintptr_t) == offsetof(jl_datatype_t, super))
+                continue;
+            jl_value_t *fld = get_taggedptr_field(&((uintptr_t*)data)[ptr]);
+            if (fld != NULL)
+                jl_queue_for_serialization_(s, fld, 1, immediate);
         }
     }
 }
@@ -1353,7 +1381,7 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
         int mutabl = t->name->mutabl;
         ios_t *f = s->s;
         if (t->smalltag) {
-            if (t->layout->npointers == 0 || t == jl_string_type) {
+            if ((t->layout->npointers == 0 && t->layout->ntaggedptrs == 0) || t == jl_string_type) {
                 if (jl_datatype_nfields(t) == 0 || mutabl == 0 || t == jl_string_type) {
                     f = s->const_data;
                 }
@@ -1573,7 +1601,7 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
         }
         else if (jl_datatype_nfields(t) == 0) {
             // The object has no fields, so we just snapshot its byte representation
-            assert(t->layout->npointers == 0);
+            assert(t->layout->npointers == 0 && t->layout->ntaggedptrs == 0);
             ios_write(f, (char*)v, jl_datatype_size(t));
         }
         else if (jl_bigint_type && jl_typetagis(v, jl_bigint_type)) {
@@ -1634,6 +1662,7 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
             }
 
             size_t np = t->layout->npointers;
+            size_t nt = t->layout->ntaggedptrs;
             size_t fldidx = 1;
             for (i = 0; i < np; i++) {
                 size_t offset = jl_ptr_offset(t, i) * sizeof(jl_value_t*);
@@ -1648,6 +1677,20 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
                     record_uniquing(s, fld, fld_pos);
                 }
                 memset(&f->buf[fld_pos], 0, sizeof(fld)); // relocation offset (none)
+            }
+            fldidx = 1;
+            for (i = 0; i < nt; i++) {
+                size_t offset = jl_taggedptr_offset(t, i) * sizeof(uintptr_t);
+                while (offset >= (fldidx == nf ? jl_datatype_size(t) : jl_field_offset(t, fldidx)))
+                    fldidx++;
+                jl_value_t *fld = get_taggedptr_field((uintptr_t*)&data[offset]);
+                if (fld != NULL) {
+                    size_t fld_pos = offset + reloc_offset;
+                    arraylist_push(&s->relocs_list, (void*)(uintptr_t)(fld_pos)); // relocation location
+                    arraylist_push(&s->relocs_list, (void*)backref_id(s, fld, s->link_ids_relocs)); // relocation target
+                    record_uniquing(s, fld, fld_pos);
+                    memset(&f->buf[fld_pos], 0, sizeof(fld)); // relocation offset (none)
+                }
             }
 
             // Need do a tricky fieldtype walk an record all memoryref we find inlined in this value
@@ -1803,6 +1846,7 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
                 if (dt->layout != NULL) {
                     size_t nf = dt->layout->nfields;
                     size_t np = dt->layout->npointers;
+                    size_t ntp = dt->layout->ntaggedptrs;
                     size_t fieldsize = 0;
                     uint8_t is_foreign_type = dt->layout->flags.fielddesc_type == 3;
                     if (!is_foreign_type) {
@@ -1812,6 +1856,8 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
                     size_t fldsize = sizeof(jl_datatype_layout_t) + nf * fieldsize;
                     if (!is_foreign_type && dt->layout->first_ptr != -1)
                         fldsize += np << dt->layout->flags.fielddesc_type;
+                    if (!is_foreign_type)
+                        fldsize += ntp << dt->layout->flags.fielddesc_type;
                     uintptr_t layout = LLT_ALIGN(ios_pos(s->const_data), sizeof(void*));
                     write_padding(s->const_data, layout - ios_pos(s->const_data)); // realign stream
                     newdt->layout = NULL; // relocation offset
@@ -2906,6 +2952,14 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
                 for (j = 0; j < np; j++) {
                     uint32_t ptr = jl_ptr_offset(rty, j);
                     record_field_change((jl_value_t**)fldaddr + ptr, *(((jl_value_t**)newval) + ptr));
+                }
+                size_t nt = layout->ntaggedptrs;
+                for (j = 0; j < nt; j++) {
+                    uint32_t ptr = jl_taggedptr_offset(rty, j);
+                    uintptr_t raw = ((uintptr_t*)newval)[ptr];
+                    if (jl_taggedptr_is_reference(raw)) {
+                        record_field_change((jl_value_t**)fldaddr + ptr, (jl_value_t*)raw);
+                    }
                 }
             }
         }

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -696,6 +696,12 @@ function serialize(s::AbstractSerializer, x::Core.IntrinsicFunction)
     serialize(s, nameof(x))
 end
 
+function serialize(s::AbstractSerializer, x::ImmediateOrRef)
+    serialize_type(s, typeof(x))
+    write(s.io, Base.getrawvalue(x))
+    nothing
+end
+
 function serialize_any(s::AbstractSerializer, @nospecialize(x))
     tag = sertag(x)
     if tag > 0
@@ -1447,6 +1453,10 @@ function deserialize(s::AbstractSerializer, X::Type{MemoryRef{T}} where T)
     i = deserialize(s)::Int
     i == 2 || (x = Core.memoryrefnew(x, i, true))
     return x::X
+end
+
+function deserialize(s::AbstractSerializer, X::Type{ImmediateOrRef{T}}) where T
+    Base._taggedptr_from_raw(X, read(s.io, UInt))
 end
 
 function deserialize(s::AbstractSerializer, X::Type{Core.AddrSpace{M}} where M)

--- a/test/core.jl
+++ b/test/core.jl
@@ -6523,6 +6523,67 @@ t4 = vcat(A23567, t2, t3)
 
 using Serialization
 
+@testset "ImmediateOrRef serialization" begin
+    struct ImmediateOrRefImmutableHolder
+        x::ImmediateOrRef{Any}
+    end
+    mutable struct ImmediateOrRefSerializationHolder
+        x::ImmediateOrRef{Any}
+    end
+
+    for value in (
+        ImmediateOrRef{Any}(),
+        Base._taggedptr_from_raw(ImmediateOrRef{Any}, UInt(0x5)),
+        ImmediateOrRef{Any}(Int[1, 2, 3]),
+    )
+        holder = ImmediateOrRefSerializationHolder(value)
+        io = IOBuffer()
+        serialize(io, holder)
+        seekstart(io)
+        holder2 = deserialize(io)
+        @test holder2 isa ImmediateOrRefSerializationHolder
+        @test Base.getrawvalue(holder2.x) == Base.getrawvalue(holder.x)
+        if isassigned(holder.x)
+            @test holder2.x[] == holder.x[]
+            @test !Base.isimmediate(holder2.x)
+        elseif Base.isimmediate(holder.x)
+            @test !isassigned(holder2.x)
+            @test Base.isimmediate(holder2.x)
+            @test_throws ErrorException holder2.x[]
+        else
+            @test !isassigned(holder2.x)
+            @test !Base.isimmediate(holder2.x)
+            @test_throws UndefRefError holder2.x[]
+        end
+    end
+    for value in (
+        ImmediateOrRef{Any}(),
+        Base._taggedptr_from_raw(ImmediateOrRef{Any}, UInt(0x5)),
+        ImmediateOrRef{Any}(Int[4, 5, 6]),
+    )
+        holder = ImmediateOrRefImmutableHolder(value)
+        io = IOBuffer()
+        serialize(io, holder)
+        seekstart(io)
+        holder2 = deserialize(io)
+        @test holder2 isa ImmediateOrRefImmutableHolder
+        @test Base.getrawvalue(holder2.x) == Base.getrawvalue(holder.x)
+        if Base.isassigned(holder.x)
+            @test holder2.x[] == holder.x[]
+            @test isassigned(holder2.x)
+            @test !Base.isimmediate(holder2.x)
+        elseif Base.isimmediate(holder.x)
+            @test !isassigned(holder2.x)
+            @test Base.isimmediate(holder2.x)
+            @test_throws ErrorException holder2.x[]
+        else
+            @test !isassigned(holder2.x)
+            @test !Base.isimmediate(holder2.x)
+            @test_throws UndefRefError holder2.x[]
+        end
+    end
+end
+
 for U in unboxedunions
     local U
     for N in (1, 2, 3, 4)

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -7,6 +7,73 @@ b = parse(BigInt,"123456789012345678901234567891")
 c = parse(BigInt,"246913578024691357802469135780")
 d = parse(BigInt,"-246913578024691357802469135780")
 ee = typemax(Int64)
+
+# Exercise a test-only FastBigInt-style wrapper that inlines small signed values in ImmediateOrRef.
+@testset "ImmediateOrRef BigInt prototype" begin
+    taggedbigint_min = -(Int64(1) << 62)
+    taggedbigint_max = (Int64(1) << 62) - 1
+
+    taggedbigint_raw(n::Int64) = (reinterpret(UInt64, n) << 1) | UInt(1)
+    taggedbigint_decode(raw::UInt) = reinterpret(Int64, raw) >> 1
+    taggedbigint_can_inline(n::Integer) = taggedbigint_min <= n <= taggedbigint_max
+
+    struct TaggedBigInt
+        x::ImmediateOrRef{BigInt}
+    end
+
+    function TaggedBigInt(n::Integer)
+        if taggedbigint_can_inline(n)
+            raw = taggedbigint_raw(Int64(n))
+            return TaggedBigInt(Base._taggedptr_from_raw(ImmediateOrRef{BigInt}, raw))
+        end
+        return TaggedBigInt(ImmediateOrRef{BigInt}(BigInt(n)))
+    end
+
+    function taggedbigint_value(x::TaggedBigInt)
+        tp = x.x
+        if Base.isimmediate(tp)
+            return BigInt(taggedbigint_decode(Base.getrawvalue(tp)))
+        end
+        return tp[]
+    end
+
+    Base.:+(a::TaggedBigInt, b::TaggedBigInt) = TaggedBigInt(taggedbigint_value(a) + taggedbigint_value(b))
+
+    small = TaggedBigInt(123)
+    @test Base.isimmediate(small.x)
+    @test taggedbigint_value(small) == BigInt(123)
+
+    negsmall = TaggedBigInt(-123)
+    @test Base.isimmediate(negsmall.x)
+    @test taggedbigint_value(negsmall) == BigInt(-123)
+
+    @test taggedbigint_value(TaggedBigInt(taggedbigint_min)) == BigInt(taggedbigint_min)
+    @test taggedbigint_value(TaggedBigInt(taggedbigint_max)) == BigInt(taggedbigint_max)
+
+    large = TaggedBigInt(big(1) << 100)
+    @test !Base.isimmediate(large.x)
+    @test isassigned(large.x)
+    @test taggedbigint_value(large) == big(1) << 100
+
+    @test Base.isimmediate((TaggedBigInt(40) + TaggedBigInt(2)).x)
+    @test taggedbigint_value(TaggedBigInt(40) + TaggedBigInt(2)) == BigInt(42)
+
+    mixed = TaggedBigInt((big(1) << 100) + 7) + TaggedBigInt(5)
+    @test !Base.isimmediate(mixed.x)
+    @test taggedbigint_value(mixed) == (big(1) << 100) + 12
+
+    io = IOBuffer()
+    serialize(io, (small, negsmall, large))
+    seekstart(io)
+    small2, negsmall2, large2 = deserialize(io)
+    @test taggedbigint_value(small2) == taggedbigint_value(small)
+    @test taggedbigint_value(negsmall2) == taggedbigint_value(negsmall)
+    @test taggedbigint_value(large2) == taggedbigint_value(large)
+    @test Base.isimmediate(small2.x)
+    @test Base.isimmediate(negsmall2.x)
+    @test !Base.isimmediate(large2.x)
+end
+
 @testset "basics" begin
     @test BigInt <: Signed
     @test big(1) isa Signed

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -613,3 +613,107 @@ end
     end
     @test _pointerset_trigger(0) == (Int[1,2,3], 42, Int[1,2,3], 42)
 end
+
+# Ensure ImmediateOrRef can carry either references or tagged immediate words.
+@testset "ImmediateOrRef basic operations" begin
+    struct ImmediateOrRefInlineHolder
+        x::ImmediateOrRef{Any}
+    end
+    struct ImmediateOrRefPair
+        x::ImmediateOrRef{Any}
+        y::Int
+    end
+    mutable struct ImmediateOrRefMutablePair
+        x::ImmediateOrRef{Any}
+        y::Int
+    end
+
+    let tp = ImmediateOrRef{Any}(1)
+        @test isassigned(tp)
+        @test tp[] === 1
+        @test !Base.isimmediate(tp)
+        @test @inferred(isassigned(tp)) isa Bool
+        @test @inferred(Base.isimmediate(tp)) isa Bool
+        @test @inferred(Base.getrawvalue(tp)) isa UInt
+    end
+    let tp = ImmediateOrRef{String}("abc")
+        @test isassigned(tp)
+        @test !Base.isimmediate(tp)
+        @test tp[] === "abc"
+    end
+    let tp = Base._taggedptr_from_raw(ImmediateOrRef{Any}, UInt(0))
+        @test !isassigned(tp)
+        @test !Base.isimmediate(tp)
+        @test_throws UndefRefError tp[]
+    end
+    let tp = Base._taggedptr_from_raw(ImmediateOrRef{Any}, UInt(0x5))
+        @test !isassigned(tp)
+        @test Base.isimmediate(tp)
+        @test_throws ErrorException tp[]
+    end
+    let tp = ImmediateOrRef{Any}(1)
+        tp2 = Base.setrawvalue(tp, UInt(0x7))
+        @test @inferred(Base.setrawvalue(tp, UInt(0x7))) isa ImmediateOrRef{Any}
+        @test Base.isimmediate(tp2)
+        @test !isassigned(tp2)
+        tp3 = Base._taggedptr_setref(tp2, "abc")
+        @test isassigned(tp3)
+        @test !Base.isimmediate(tp3)
+        @test tp3[] === "abc"
+    end
+    @test sizeof(ImmediateOrRefPair) == 2sizeof(Int)
+    @test fieldoffset(ImmediateOrRefPair, 1) == 0
+    @test fieldoffset(ImmediateOrRefPair, 2) == sizeof(Int)
+    @test fieldoffset(ImmediateOrRefMutablePair, 1) == 0
+    @test fieldoffset(ImmediateOrRefMutablePair, 2) == sizeof(Int)
+    @test !Base.datatype_pointerfree(ImmediateOrRefPair)
+    @test !Base.datatype_pointerfree(ImmediateOrRefMutablePair)
+    let p = ImmediateOrRefPair(ImmediateOrRef{Any}(123), 7)
+        @test p.x[] === 123
+        @test p.y === 7
+    end
+    let p = ImmediateOrRefMutablePair(Base._taggedptr_from_raw(ImmediateOrRef{Any}, UInt(0x5)), 9)
+        @test Base.isimmediate(p.x)
+        @test p.y === 9
+    end
+    @test_throws ErrorException Memory{ImmediateOrRef{Any}}
+    @test_throws ErrorException Memory{ImmediateOrRef{Any}}(undef, 1)
+    @test_throws ErrorException Memory{ImmediateOrRefInlineHolder}
+    @test_throws ErrorException Memory{ImmediateOrRefInlineHolder}(undef, 1)
+    @test_throws ErrorException ImmediateOrRef{Int}
+    @test_throws ErrorException ImmediateOrRef{Int}(1)
+    @test_throws ErrorException Base._taggedptr_from_raw(ImmediateOrRef{Int}, UInt(0))
+    @test_throws ErrorException ImmediateOrRef{Tuple{Int,Int}}
+end
+
+# Check old->young barrier handling for ImmediateOrRef field stores.
+@testset "ImmediateOrRef field write barrier" begin
+    mutable struct ImmediateOrRefWBHolder
+        x::ImmediateOrRef{Any}
+    end
+    holder = ImmediateOrRefWBHolder(ImmediateOrRef{Any}())
+    GC.gc(true) # make holder old before writing young references into it
+
+    finalized = Ref(false)
+    obj = Int[1, 2, 3]
+    finalizer(obj) do _
+        finalized[] = true
+    end
+    holder.x = ImmediateOrRef{Any}(obj)
+    obj = nothing
+    for _ in 1:20
+        GC.gc(false)
+    end
+    @test !finalized[]
+    @test holder.x[] isa Vector{Int}
+    @test isassigned(holder.x)
+    @test !Base.isimmediate(holder.x)
+
+    holder.x = Base._taggedptr_from_raw(ImmediateOrRef{Any}, UInt(0x5))
+    for _ in 1:20
+        GC.gc(false)
+    end
+    @test !isassigned(holder.x)
+    @test Base.isimmediate(holder.x)
+    @test_throws ErrorException holder.x[]
+end


### PR DESCRIPTION
This is an attempt to resolve #47735. That is, in a nutshell: introduce a way to have way to have a 64bit  "object" that is either a GC-tracked pointer/ref to another Julia object, or a raw value. Which it is gets determined on certain bit patters (either high or low bits being set/cleared). For more details on why this might desirable, I refer back to #47735.

It is most definitely *not* ready for merging and in fact not entirely complete, in parts because I decided it make no sense to push this further without some feedback on certain design decisions.

Moreover, this PR was created with heavy use of Codex by OpenAI. And to be frank, I ended up quite a bit out of my depth. You've been warned.

But I decided to try this anyway, because
1. I really want this feature, and based on the discussions on #47735, there are plenty other people who are interested anyway
2. I figured that even if it ends up a failure, it might at least drive forward the discussion, reveal issues with possible designs, and perhaps trigger someone else to work on this ;-)
3. I wanted to see how far I can really push Codex (turns out quite far...)


To get started, I let Codex write up a plan (based on the issue and some further inputs from me), which is included in this PR (but I would not put this into the final version, rather there should be proper documentation). To get somewhere, I let it make certain assumptions to keep the scope down, in particular:

- 64-bit only (in the issue discussed that it would be valid to always use 64bit for these objects, even on 32bit systems, to keep things simple)
- stock-GC-only (no MMTK etc. adaption yet; I'll want help from the experts on that, but also it seemed too early to worry about that),
- a small low-level API
- separate tagged-slot layout metadata

But all of these can of course be changed.

What I hope for is some general feedback on the direction this is going.

---

Overall, this approach was instructive to me in that it revealed certain design issues that were not clear to me when I started out.



When I originally wrote my issue, I wanted to call this `TaggedRef{T}` or `TaggedPtr{T}` (I also used this initially for this PR). It was then pointed out that tagging is an implementation details, and the name `ImmediateOrRef{T}` suggested, which I quite like, and this PR uses for the "user facing" parts (the kernel code still mostly uses "taggedptr" which I think makes sense because that's what is is under the hood.


**Question: `ImmediateOrRef{T}` is a subtype of `Ref{T}` -- should it be?** It seemed natural because `Ptr{T}` is a subtype, but then there is issue #49004...

Even without this type relationship, the name `ImmediateOrRef{T}` has the drawback that it suggest that is kind of like "Ref but with extra features". But it really isn't: it is rather closer to a pointer and to `Ptr{T}`.

**Question: Keep the name, or use something different after all?**

Indeed, when `T` is a primitive or struct type, the current implementation falls a bit apart... To deal with that, I decided to for now restrict `ImmediateOrRef{T}` to types `T` which are "boxed", i.e., where we can take a pointer.

**Question: Is it sensible to restrict `ImmediateOrRef{T}` to types `T` where `Base.allocatedinline(T) == false`?** Or should this use a different criterion? Or even allow other types (but then I need help with the intended semantics).


Some more notes:
- this works currently by taking the lowest bit, as that should be more portable than high bit tagging, but of course we can have a debate of this as well if someone cares to (notable, the FLINT C library uses a high bit approach)
- we did not yet make any attempts to make `Memory{TaggedPtr{T}}` work
- we did not yet do any benchmarking, one could e.g. measure the `TaggedBigInt` demonstrator included in this PR


