### PR TITLE
add error handling for ghost types in llvmcall

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -931,6 +931,11 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
         jl_value_t *tti = jl_svecref(tt,i);
         bool toboxed;
         Type *t = julia_type_to_llvm(ctx, tti, &toboxed);
+        if (type_is_ghost(t)) {
+            emit_error(ctx, make_errmsg("llvmcall", i + 1, " type doesn't correspond to a C type"));
+            JL_GC_POP();
+            return jl_cgval_t();
+        }
         argtypes.push_back(t);
         jl_value_t *argi = args[4 + i];
         jl_cgval_t arg = emit_expr(ctx, argi);

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -236,3 +236,7 @@ function too_many_args(x::Int32, y::Int32)
         x,y,x)
 end
 @test_throws ErrorException too_many_args(Int32(1), Int32(1))
+
+llvmcall_parametric_nothing_arg(x::T) where T = Core.Intrinsics.llvmcall("ret i8 0", Int8, Tuple{T}, x)
+@test_throws ErrorException llvmcall_parametric_nothing_arg(nothing)
+@test_throws ErrorException llvmcall_parametric_nothing_arg(missing)

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -237,6 +237,5 @@ function too_many_args(x::Int32, y::Int32)
 end
 @test_throws ErrorException too_many_args(Int32(1), Int32(1))
 
-llvmcall_parametric_nothing_arg(x::T) where T = Core.Intrinsics.llvmcall("ret i8 0", Int8, Tuple{T}, x)
-@test_throws ErrorException llvmcall_parametric_nothing_arg(nothing)
-@test_throws ErrorException llvmcall_parametric_nothing_arg(missing)
+llvmcall_nothing_arg() = Core.Intrinsics.llvmcall("ret i8 0", Int8, Tuple{Nothing}, nothing)
+@test_throws ErrorException llvmcall_nothing_arg()


### PR DESCRIPTION
AI Use Acknowledgement: I used GitHub Copilot (GPT-5.3-Codex) to help me identify issues and make changes to code. I reviewed its output and take responsibility for the code changes. 

I created a check for ghost types that are being passed as arguments to llvmcall. 
I read the pull request created by [raym293](https://github.com/raym293)  (https://github.com/JuliaLang/julia/pull/60630), and the response by reviewers. It seems that adding a guard that checks for ghost types using `type_is_ghost` is sufficient to allow Julia to fail gracefully instead of segfaulting, in cases where the user passes an argument such as `nothing` or `missing` to llvmcall. 
I tested this contribution on my ubuntu machine, and to my knowledge the change fixes the reported issue without adding unexpected behavior. 

If there are any errors or mistakes in this PR, I apologize, it's also my first attempt to contribute to an open-source project. If there are issues I will try to address them. Thank you for your understanding. 