### PR TITLE
inference: Cache tombstoned const-prop results to prevent non-termination

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -1312,7 +1312,6 @@ end
 function const_prop_call(interp::AbstractInterpreter,
     mi::MethodInstance, result::MethodCallResult, arginfo::ArgInfo, sv::AbsIntState,
     concrete_eval_result::Union{Nothing,ConstCallResult}=nothing)
-    inf_cache = get_inference_cache(interp)
     𝕃ᵢ = typeinf_lattice(interp)
     forwarded_argtypes = compute_forwarded_argtypes(interp, arginfo, sv)
     # use `cache_argtypes` that has been constructed for fresh regular inference if available
@@ -1323,8 +1322,13 @@ function const_prop_call(interp::AbstractInterpreter,
         cache_argtypes = matching_cache_argtypes(𝕃ᵢ, mi)
     end
     argtypes = matching_cache_argtypes(𝕃ᵢ, mi, forwarded_argtypes, cache_argtypes)
-    inf_result = constprop_cache_lookup(𝕃ᵢ, mi, argtypes, inf_cache)
-    if inf_result !== nothing
+    inf_result = constprop_cache_lookup(𝕃ᵢ, mi, argtypes, get_inference_cache(interp))
+    if inf_result === missing
+        # a previous const-prop attempt hit a cycle and produced a limited result;
+        # don't re-attempt the same work that would lead to the same limited outcome
+        add_remark!(interp, sv, "[constprop] Found cached but limited constant inference result")
+        return nothing
+    elseif inf_result isa InferenceResult
         # found the cache for this constant prop'
         if inf_result.result === nothing
             add_remark!(interp, sv, "[constprop] Found cached constant inference in a cycle")
@@ -1361,6 +1365,13 @@ function const_prop_call(interp::AbstractInterpreter,
         pop!(callstack)
         # add to the cache to record that this will always fail
         push!(get_inference_cache(interp), inf_result)
+        return nothing
+    end
+    if inf_result.tombstone
+        # This const-prop attempt resolved but hit a cycle and produced a limited result.
+        # The tombstoned entry is already cached by `promotecache!` via the normal local
+        # cache mechanism, so `constprop_cache_lookup` will find it on subsequent lookups.
+        add_remark!(interp, sv, "[constprop] Constant inference produced a limited result")
         return nothing
     end
     existing_edge = result.edge

--- a/Compiler/src/inferenceresult.jl
+++ b/Compiler/src/inferenceresult.jl
@@ -197,9 +197,9 @@ end
 function constprop_cache_lookup(𝕃::AbstractLattice, mi::MethodInstance, given_argtypes::Vector{Any}, cache::InferenceCache)
     nargtypes = length(given_argtypes)
     indices = get_indices(cache, mi)
+    found_tombstone = false
     for idx in indices
         cached_result = cache.results[idx]
-        cached_result.tombstone && continue # ignore deleted entries (due to LimitedAccuracy)
         cache_argtypes = cached_result.argtypes
         @assert length(cache_argtypes) == nargtypes "invalid `cache_argtypes` for `mi`"
         cache_overridden_by_const = cached_result.overridden_by_const
@@ -210,8 +210,15 @@ function constprop_cache_lookup(𝕃::AbstractLattice, mi::MethodInstance, given
                 @goto next_cache
             end
         end
+        # Don't return tombstoned entries as cache items: they represent rejected work
+        # (due to LimitedAccuracy). Instead, record that a tombstone was found so the
+        # caller can avoid re-attempting the same const-prop that would hit the same limit.
+        if cached_result.tombstone
+            found_tombstone = true
+            @goto next_cache
+        end
         return cached_result
         @label next_cache
     end
-    return nothing
+    return found_tombstone ? missing : nothing
 end

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -671,12 +671,14 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter, cycleid::
         # A parent may be cached still, but not this intermediate work:
         # we can throw everything else away now. Caching anything can confuse later
         # heuristics to consider it worth trying to pursue compiling this further and
-        # finding infinite work as a result. Avoiding caching helps to ensure there is only
-        # a finite amount of work that can be discovered later (although potentially still a
-        # large multiplier on it).
+        # finding infinite work as a result. Avoiding global caching helps to ensure there
+        # is only a finite amount of work that can be discovered later (although potentially
+        # still a large multiplier on it). We still allow local caching so that tombstoned
+        # entries can be found by `constprop_cache_lookup` to prevent re-attempting the same
+        # const-prop work that would hit the same limit.
         result.src = nothing
         result.tombstone = true
-        me.cache_mode = CACHE_MODE_NULL
+        me.cache_mode &= ~CACHE_MODE_GLOBAL
         set_inlineable!(src, false)
     else
         # annotate fulltree with type information,


### PR DESCRIPTION
When a const-prop frame encounters a cycle and gets poisoned, `finishinfer!` marks the result as tombstoned and sets `cache_mode = CACHE_MODE_NULL`, which prevents `promotecache!` from pushing the result to the local inference cache.
Meanwhile, `constprop_cache_lookup` (added in #57545) skips tombstoned entries entirely. This combination means the same const-prop is re-attempted on every cycle iteration, causing inference to never terminate when `aggressive_constant_propagation = true`.

Fix this by:
- In `const_prop_call`, explicitly pushing tombstoned results to the inference cache after a successful but limited `typeinf`, and returning `nothing` to fall back to the regular inference result.
- In `constprop_cache_lookup`, no longer skipping tombstoned entries so they can be found on subsequent lookups, preventing re-attempts.
- In `const_prop_call` cache-hit path, checking `inf_result.tombstone` and returning `nothing` (same as the existing cycle-hit handling).
- Removing the now-unnecessary tombstone check from `OverlayCodeCache.get`, where the subsequent `overridden_by_const` and `isdefined` checks already filter out such entries.

Note that #57545 added `tombstone && continue` to `cache_lookup` to prevent `LimitedAccuracy` results from propagating to callers via `const_prop_result`. This change removes that skip but achieves the same protection by explicitly checking `inf_result.tombstone` in `const_prop_call` and returning `nothing` instead of using the result.

Fixes #61257