### PR TITLE
[JuliaSyntax] Fix `sourcetext` for `SyntaxTree` with `LineNumberNode` provenance

### DIFF
--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -472,6 +472,12 @@ syntax_graph(ex::SyntaxTree) = ex._graph
 sourcefile(ex::SyntaxTree) = sourcefile(sourceref(ex))
 byte_range(ex::SyntaxTree) = byte_range(sourceref(ex))
 
+function sourcetext(ex::SyntaxTree)
+    sf = sourcefile(ex)
+    sf isa LineNumberNode && return SubString("")
+    view(sf, byte_range(ex))
+end
+
 #-------------------------------------------------------------------------------
 # Lightweight vector of nodes ids with associated pointer to graph stored separately.
 mutable struct SyntaxList{Attrs, NodeIdVecType} <: AbstractVector{SyntaxTree}


### PR DESCRIPTION
When a `SyntaxTree` node has `LineNumberNode` as its source provenance (which happens for nodes created via `expr_to_est` during old-style macro expansion), the generic `sourcetext(x)` would call `view(sourcefile(x), byte_range(x))` which fails with `MethodError` because `view(::LineNumberNode, ::UnitRange)` is not defined.

Add a specialized `sourcetext(::SyntaxTree)` method that checks for `LineNumberNode` and returns `SubString("")`, consistent with the existing `sourcetext(::LineNumberNode)` method.

Fixes aviatesk/JETLS.jl#583