### PR TITLE
Enable trimming tests in cygwin

### DIFF
--- a/test/trimming/Makefile
+++ b/test/trimming/Makefile
@@ -74,7 +74,7 @@ check: $(BIN)/hello$(EXE) $(BIN)/trimmability$(EXE) $(BIN)/basic_jll$(EXE) $(BIN
 	$(JULIA) --startup-file=no --history-file=no --depwarn=error $(call maybe_windows_path,$(SRCDIR))/trimming.jl $(call maybe_windows_path,$<)
 
 clean:
-	-rm -f $(BIN)/hello$(EXE) $(BIN)/trimmability$(EXE) $(BIN)/basic_jll$(EXE) $(BIN)/hello-o.a $(BIN)/trimmability-o.a $(BIN)/basic_jll-o.a $(BIN)/libsimple-o.a $(BIN)/libsimple.$(SHLIB_EXT) $(BIN)/capplication$(EXE) $(call maybe_windows_path,$(BIN)/bindinginfo_libsimple.json) $(BIN)/Manifest.toml
+	-rm -f $(BIN)/hello$(EXE) $(BIN)/trimmability$(EXE) $(BIN)/basic_jll$(EXE) $(BIN)/hello-o.a $(BIN)/trimmability-o.a $(BIN)/basic_jll-o.a $(BIN)/libsimple-o.a $(BIN)/libsimple.$(SHLIB_EXT) $(BIN)/capplication$(EXE) $(BIN)/bindinginfo_libsimple.json $(BIN)/Manifest.toml
 
 .PHONY: release clean check
 

--- a/test/trimming/Makefile
+++ b/test/trimming/Makefile
@@ -14,7 +14,7 @@ endif
 
 # When made in cygwin, paths generated herein will start with /cygdrive/c/,
 # but when passed as arguments into julia, they must start with C:/. This function
-# shoulde be used on all paths that are passed to and are to be used within a julia session. 
+# should be used on all paths that are passed to and are to be used within a Julia session.
 define maybe_windows_path
 $(if $(filter CYGWIN%,$(shell uname -s)),$(shell cygpath -m $(1)),$(1))
 endef

--- a/test/trimming/Makefile
+++ b/test/trimming/Makefile
@@ -12,6 +12,13 @@ ifndef BIN
   $(error "Please pass BIN=[path of build directory], or set as environment variable!")
 endif
 
+# When made in cygwin, paths generated herein will start with /cygdrive/c/,
+# but when passed as arguments into julia, they must start with C:/. This function
+# shoulde be used on all paths that are passed to and are to be used within a julia session. 
+define maybe_windows_path
+$(if $(filter CYGWIN%,$(shell uname -s)),$(shell cygpath -m $(1)),$(1))
+endef
+
 #=============================================================================
 # location of test source
 SRCDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
@@ -37,19 +44,19 @@ release: $(BIN)/hello$(EXE) $(BIN)/trimmability$(EXE) $(BIN)/basic_jll$(EXE) $(B
 
 # Complete any needed Pkg operations before trimming (some Pkg code may not be trimmable)
 Manifest.toml: $(SRCDIR)/Project.toml
-	$(JULIA) --startup-file=no --history-file=no -e 'using Pkg; Pkg.activate("$(SRCDIR)"); Pkg.instantiate()'
+	$(JULIA) --startup-file=no --history-file=no -e 'using Pkg; Pkg.activate("$(call maybe_windows_path,$(SRCDIR))"); Pkg.instantiate()'
 
 $(BIN)/hello-o.a: $(SRCDIR)/hello.jl $(JULIAC_BUILDSCRIPT) Manifest.toml
-	$(JULIA) -t 1 -J $(JULIA_LIBDIR)/julia/sys.$(SHLIB_EXT) --startup-file=no --history-file=no --output-o $@ --output-incremental=no --strip-ir --strip-metadata --experimental --trim $(JULIAC_BUILDSCRIPT) $< --output-exe true
+	$(JULIA) -t 1 -J $(JULIA_LIBDIR)/julia/sys.$(SHLIB_EXT) --startup-file=no --history-file=no --output-o $(call maybe_windows_path,$@) --output-incremental=no --strip-ir --strip-metadata --experimental --trim $(JULIAC_BUILDSCRIPT) $(call maybe_windows_path,$<) --output-exe true
 
 $(BIN)/trimmability-o.a: $(SRCDIR)/trimmability.jl $(JULIAC_BUILDSCRIPT) Manifest.toml
-	$(JULIA) -t 1 -J $(JULIA_LIBDIR)/julia/sys.$(SHLIB_EXT) --startup-file=no --history-file=no --output-o $@ --output-incremental=no --strip-ir --strip-metadata --experimental --trim $(JULIAC_BUILDSCRIPT) $< --output-exe true
+	$(JULIA) -t 1 -J $(JULIA_LIBDIR)/julia/sys.$(SHLIB_EXT) --startup-file=no --history-file=no --output-o $(call maybe_windows_path,$@) --output-incremental=no --strip-ir --strip-metadata --experimental --trim $(JULIAC_BUILDSCRIPT) $(call maybe_windows_path,$<) --output-exe true
 
 $(BIN)/basic_jll-o.a: $(SRCDIR)/basic_jll.jl $(JULIAC_BUILDSCRIPT) Manifest.toml
-	$(JULIA) -t 1 -J $(JULIA_LIBDIR)/julia/sys.$(SHLIB_EXT) --startup-file=no --history-file=no --project=$(SRCDIR) --output-o $@ --output-incremental=no --strip-ir --strip-metadata --experimental --trim $(JULIAC_BUILDSCRIPT) $< --output-exe true
+	$(JULIA) -t 1 -J $(JULIA_LIBDIR)/julia/sys.$(SHLIB_EXT) --startup-file=no --history-file=no --project=$(SRCDIR) --output-o $(call maybe_windows_path,$@) --output-incremental=no --strip-ir --strip-metadata --experimental --trim $(JULIAC_BUILDSCRIPT) $(call maybe_windows_path,$<) --output-exe true
 
 $(BIN)/libsimple-o.a: $(SRCDIR)/libsimple.jl $(JULIAC_BUILDSCRIPT)
-	$(JULIA) -t 1 -J $(JULIA_LIBDIR)/julia/sys.$(SHLIB_EXT) --startup-file=no --history-file=no --output-o $@ --output-incremental=no --strip-ir --strip-metadata --experimental --trim $(JULIAC_BUILDSCRIPT) $< --output-lib true $(BIN)/bindinginfo_libsimple.json
+	$(JULIA) -t 1 -J $(JULIA_LIBDIR)/julia/sys.$(SHLIB_EXT) --startup-file=no --history-file=no --output-o $(call maybe_windows_path,$@) --output-incremental=no --strip-ir --strip-metadata --experimental --trim $(JULIAC_BUILDSCRIPT) $(call maybe_windows_path,$<) --output-lib true $(call maybe_windows_path,$(BIN)/bindinginfo_libsimple.json)
 
 $(BIN)/hello$(EXE): $(BIN)/hello-o.a
 	$(CC) -o $@ $(call whole_archive,$<) $(CPPFLAGS_ADD) $(CPPFLAGS) $(CFLAGS_ADD) $(CFLAGS) $(LDFLAGS_ADD) $(LDFLAGS)
@@ -64,10 +71,10 @@ $(BIN)/capplication$(EXE): $(SRCDIR)/capplication.c $(SRCDIR)/libsimple.h $(BIN)
 	$(CC) -I$(BIN) -I$(SRCDIR) -I$(JULIA_LIBDIR) -o $@ $< -Wl,--whole-archive $(BIN)/libsimple-o.a -Wl,--no-whole-archive $(LDFLAGS_ADD) $(LDFLAGS) $(CPPFLAGS_ADD) $(CPPFLAGS) $(CFLAGS_ADD) $(CFLAGS)
 
 check: $(BIN)/hello$(EXE) $(BIN)/trimmability$(EXE) $(BIN)/basic_jll$(EXE) $(BIN)/capplication$(EXE)
-	$(JULIA) --startup-file=no --history-file=no --depwarn=error $(SRCDIR)/trimming.jl $<
+	$(JULIA) --startup-file=no --history-file=no --depwarn=error $(call maybe_windows_path,$(SRCDIR))/trimming.jl $(call maybe_windows_path,$<)
 
 clean:
-	-rm -f $(BIN)/hello$(EXE) $(BIN)/trimmability$(EXE) $(BIN)/basic_jll$(EXE) $(BIN)/hello-o.a $(BIN)/trimmability-o.a $(BIN)/basic_jll-o.a $(BIN)/libsimple-o.a $(BIN)/libsimple.$(SHLIB_EXT) $(BIN)/capplication$(EXE) $(BIN)/bindinginfo_libsimple.json $(BIN)/Manifest.toml
+	-rm -f $(BIN)/hello$(EXE) $(BIN)/trimmability$(EXE) $(BIN)/basic_jll$(EXE) $(BIN)/hello-o.a $(BIN)/trimmability-o.a $(BIN)/basic_jll-o.a $(BIN)/libsimple-o.a $(BIN)/libsimple.$(SHLIB_EXT) $(BIN)/capplication$(EXE) $(call maybe_windows_path,$(BIN)/bindinginfo_libsimple.json) $(BIN)/Manifest.toml
 
 .PHONY: release clean check
 

--- a/test/trimming/trimming.jl
+++ b/test/trimming/trimming.jl
@@ -12,7 +12,11 @@ let exe_suffix = splitext(Base.julia_exename())[2]
 
     hello_exe = joinpath(bindir, "hello" * exe_suffix)
     @test readchomp(`$hello_exe arg1 arg2`) == "Hello, world!"
-    @test filesize(hello_exe) < 1_900_000
+    if Sys.iswindows()
+        @test filesize(hello_exe) < 2_000_000
+    else
+        @test filesize(hello_exe) < 1_900_000
+    end
 
     trimmability_exe = joinpath(bindir, "trimmability" * exe_suffix)
     @test readchomp(`$trimmability_exe arg1 arg2`) == "Hello, world!\n$trimmability_exe\narg1\narg2\n$(4.0+pi)"
@@ -26,7 +30,7 @@ let exe_suffix = splitext(Base.julia_exename())[2]
 
     # Test that the shared library can be used in a C application
     capplication_exe = joinpath(bindir, "capplication" * exe_suffix)
-    lines = split(readchomp(`$capplication_exe`), "\n")
+    lines = readlines(`$capplication_exe`)
     @test length(lines) == 2
     @test lines[1] == "Sum of copied values: 6.000000"
     @test lines[2] == "Count of same vectors: 1"

--- a/test/trimming/trimming.jl
+++ b/test/trimming/trimming.jl
@@ -13,7 +13,7 @@ let exe_suffix = splitext(Base.julia_exename())[2]
     hello_exe = joinpath(bindir, "hello" * exe_suffix)
     @test readchomp(`$hello_exe arg1 arg2`) == "Hello, world!"
     @test filesize(hello_exe) < 2_000_000
-    
+
     trimmability_exe = joinpath(bindir, "trimmability" * exe_suffix)
     @test readchomp(`$trimmability_exe arg1 arg2`) == "Hello, world!\n$trimmability_exe\narg1\narg2\n$(4.0+pi)"
 

--- a/test/trimming/trimming.jl
+++ b/test/trimming/trimming.jl
@@ -12,12 +12,8 @@ let exe_suffix = splitext(Base.julia_exename())[2]
 
     hello_exe = joinpath(bindir, "hello" * exe_suffix)
     @test readchomp(`$hello_exe arg1 arg2`) == "Hello, world!"
-    if Sys.iswindows()
-        @test filesize(hello_exe) < 2_000_000
-    else
-        @test filesize(hello_exe) < 1_900_000
-    end
-
+    @test filesize(hello_exe) < 2_000_000
+    
     trimmability_exe = joinpath(bindir, "trimmability" * exe_suffix)
     @test readchomp(`$trimmability_exe arg1 arg2`) == "Hello, world!\n$trimmability_exe\narg1\narg2\n$(4.0+pi)"
 


### PR DESCRIPTION
Allows running the trimming tests in cygwin (not implying that the tests also _pass_...). 

The primary issue was that paths must be converted from the format `/cygdrive/c/...` to `C:` when passed as arguments to the julia executable. 

Some windows compatibility to `trimming.jl` is also addeb, but bugs prevening the whole test suite from passing are reported in separate issues https://github.com/JuliaLang/julia/issues/61277 and https://github.com/JuliaLang/julia/issues/61276.