### PR TITLE
add zero and iszero to Dates.CompoundPeriod

### DIFF
--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -370,7 +370,7 @@ function (-)(x::TimeType, y::CompoundPeriod)
 end
 
 Base.iszero(x::CompoundPeriod) = isempty(canonicalize(x).periods)
-Base.zero(::Type{CompoundPeriod}) = CompoundPeriod()
+Base.zero(::Union{CompoundPeriod,Type{CompoundPeriod}}) = CompoundPeriod()
 
 # Fixed-value Periods (periods corresponding to a well-defined time interval,
 # as opposed to variable calendar intervals like Year).

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -369,6 +369,9 @@ function (-)(x::TimeType, y::CompoundPeriod)
     return x
 end
 
+Base.iszero(x::CompoundPeriod) = isempty(x.periods)
+Base.zero(::Type{CompoundPeriod}) = CompoundPeriod()
+
 # Fixed-value Periods (periods corresponding to a well-defined time interval,
 # as opposed to variable calendar intervals like Year).
 const FixedPeriod = Union{Week, Day, Hour, Minute, Second, Millisecond, Microsecond, Nanosecond}

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -369,7 +369,7 @@ function (-)(x::TimeType, y::CompoundPeriod)
     return x
 end
 
-Base.iszero(x::CompoundPeriod) = isempty(x.periods)
+Base.iszero(x::CompoundPeriod) = isempty(canonicalize(x).periods)
 Base.zero(::Type{CompoundPeriod}) = CompoundPeriod()
 
 # Fixed-value Periods (periods corresponding to a well-defined time interval,

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -157,6 +157,7 @@ emptyperiod = ((y + d) - d) - y
     @test typeof(y + ns) <: Dates.CompoundPeriod
     @test zero(Dates.CompoundPeriod) == Dates.CompoundPeriod()
     @test iszero(Dates.CompoundPeriod())
+    @test iszero(Minute(1) - Second(60))
     @test y > m
     @test d < w
     @test mi < h

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -155,7 +155,7 @@ emptyperiod = ((y + d) - d) - y
     @test typeof(y + ms) <: Dates.CompoundPeriod
     @test typeof(y + us) <: Dates.CompoundPeriod
     @test typeof(y + ns) <: Dates.CompoundPeriod
-    @test zero(Dates.CompoundPeriod) == Dates.CompoundPeriod()
+    @test zero(Dates.CompoundPeriod) == Dates.CompoundPeriod() == zero(y + ns)
     @test iszero(Dates.CompoundPeriod())
     @test iszero(Minute(1) - Second(60))
     @test y > m

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -155,6 +155,8 @@ emptyperiod = ((y + d) - d) - y
     @test typeof(y + ms) <: Dates.CompoundPeriod
     @test typeof(y + us) <: Dates.CompoundPeriod
     @test typeof(y + ns) <: Dates.CompoundPeriod
+    @test zero(Dates.CompoundPeriod) == Dates.CompoundPeriod()
+    @test iszero(Dates.CompoundPeriod())
     @test y > m
     @test d < w
     @test mi < h


### PR DESCRIPTION
Adds a `zero` and `iszero` to `Dates.CompoundPeriod`. Solves issue #61268 