### PR TITLE
bugfix for -Dates.CompoundPeriod()

### DIFF
--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -336,7 +336,7 @@ Base.convert(::Type{T}, x::CompoundPeriod) where T<:Period =
 # E.g. Year(1) - Month(1)
 (-)(x::Period, y::Period) = CompoundPeriod(Period[x, -y])
 (-)(x::CompoundPeriod, y::Period) = CompoundPeriod(vcat(x.periods, -y))
-(-)(x::CompoundPeriod) = CompoundPeriod(-x.periods)
+(-)(x::CompoundPeriod) = CompoundPeriod(Period[-p for p in x.periods])
 (-)(y::Union{Period, CompoundPeriod}, x::CompoundPeriod) = (-x) + y
 
 GeneralPeriod = Union{Period, CompoundPeriod}

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -385,6 +385,7 @@ end
     @test sprint(show, y + m) == string(y + m)
     @test convert(Dates.CompoundPeriod, y) + m == y + m
     @test Dates.periods(convert(Dates.CompoundPeriod, y)) == convert(Dates.CompoundPeriod, y).periods
+    @test -Dates.CompoundPeriod() == Dates.CompoundPeriod()
 end
 @testset "compound period simplification" begin
     # reduce compound periods into the most basic form

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -386,6 +386,8 @@ end
     @test convert(Dates.CompoundPeriod, y) + m == y + m
     @test Dates.periods(convert(Dates.CompoundPeriod, y)) == convert(Dates.CompoundPeriod, y).periods
     @test -Dates.CompoundPeriod() == Dates.CompoundPeriod()
+    @test -(d - h) == -23h
+    @test (d - h) - (d - h) == Dates.CompoundPeriod()
 end
 @testset "compound period simplification" begin
     # reduce compound periods into the most basic form


### PR DESCRIPTION
This fixes a bug where `-Dates.CompoundPeriod()` threw an error, which occurred because `-Period[]` returns `Any[]` (which happens because `Period` is an abstract type):
```jl
julia> -Dates.CompoundPeriod()
ERROR: MethodError: no method matching Dates.CompoundPeriod(::Vector{Any})
The type `Dates.CompoundPeriod` exists, but no method is defined for this combination of argument types when trying to construct it.
```
(This also causes subtraction to fail.)

The PR uses a comprehension instead of `-x.periods` to ensure that a `Vector{Period}` array is created.

(I noticed this when looking at #61280 by @yakir12, to make sure `CompoundPeriod()` is an additive identity.)