### PR TITLE
fix Dates.canonicalize docstring: Period arguments are accepted

### DIFF
--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -227,6 +227,9 @@ julia> canonicalize(Dates.CompoundPeriod(Dates.Month(1), Dates.Week(-2)))
 julia> canonicalize(Dates.Minute(50000))
 4 weeks, 6 days, 17 hours, 20 minutes
 ```
+
+!!! compat "Julia 1.6"
+    Prior to Julia 1.6, the argument of `canonicalize` could only be a `CompoundPeriod`.
 """
 canonicalize(x::Period) = canonicalize(CompoundPeriod(x))
 function canonicalize(x::CompoundPeriod)

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -204,9 +204,9 @@ CompoundPeriod(p::Period...) = CompoundPeriod(Period[p...])
 
 
 """
-    canonicalize(::CompoundPeriod)::CompoundPeriod
+    canonicalize(::Period)::CompoundPeriod
 
-Reduces the `CompoundPeriod` into its canonical form by applying the following rules:
+Reduces the `Period` into its canonical form by applying the following rules:
 
 * Any `Period` large enough be partially representable by a coarser `Period` will be broken
   into multiple `Period`s (eg. `Hour(30)` becomes `Day(1) + Hour(6)`)
@@ -215,7 +215,7 @@ Reduces the `CompoundPeriod` into its canonical form by applying the following r
 
 # Examples
 ```jldoctest
-julia> canonicalize(Dates.CompoundPeriod(Dates.Hour(12), Dates.Hour(13)))
+julia> canonicalize(Dates.Hour(25))
 1 day, 1 hour
 
 julia> canonicalize(Dates.CompoundPeriod(Dates.Hour(-1), Dates.Minute(1)))
@@ -224,7 +224,7 @@ julia> canonicalize(Dates.CompoundPeriod(Dates.Hour(-1), Dates.Minute(1)))
 julia> canonicalize(Dates.CompoundPeriod(Dates.Month(1), Dates.Week(-2)))
 1 month, -2 weeks
 
-julia> canonicalize(Dates.CompoundPeriod(Dates.Minute(50000)))
+julia> canonicalize(Dates.Minute(50000))
 4 weeks, 6 days, 17 hours, 20 minutes
 ```
 """


### PR DESCRIPTION
I noticed that the `Dates.canonicalize` docstring incorrectly said that the argument had to be a `CompoundPeriod`, when in fact it can be any `Period`.