### PR TITLE
Redact sensitive env vars when printing cmd errors.

### DIFF
--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -132,26 +132,48 @@ escape_microsoft_c_args(cmd::Cmd) =
 escape_microsoft_c_args(io::IO, cmd::Cmd) =
     escape_microsoft_c_args(io::IO, cmd.exec...)
 
-# Patterns that indicate a sensitive environment variable name (case-insensitive).
-const _SENSITIVE_ENV_PATTERNS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "PASSWD", "CREDENTIAL", "CRED", "AUTH", "PRIVATE")
+# Patterns that indicate a sensitive environment variable name.
+# Matched as whole components after splitting on non-alphanumeric characters,
+# so e.g. "PAT" matches "GITHUB_PAT" but not "PATH".
+const SENSITIVE_ENV_PATTERNS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "PASSWD",
+                                "CREDENTIAL", "CRED", "AUTH", "PRIVATE",
+                                "JWT", "PAT", "PASS", "PW")
 
-function _is_sensitive_env_name(name::AbstractString)
+function is_sensitive_env_name(name::AbstractString)
     uname = uppercase(name)
-    return any(p -> occursin(p, uname), _SENSITIVE_ENV_PATTERNS)
+    parts = eachsplit(uname, r"[^A-Za-z0-9]+")
+    return any(part -> part in SENSITIVE_ENV_PATTERNS, parts)
 end
 
-function _show_env(io::IO, env::Vector{String})
-    show_values = get(io, :show_env_values, false)::Bool
+function get_show_env_mode(io::IO)
+    val = get(io, :show_env, :_unset)
+    if val !== :_unset
+        return val::Symbol
+    end
+    envval = get(ENV, "JULIA_SHOW_ENV", nothing)
+    envval === nothing && return :redact
+    envval = lowercase(envval)
+    envval == "all" && return :all
+    envval == "none" && return :none
+    envval == "keys" && return :keys
+    return :redact
+end
+
+function show_env(io::IO, env::Vector{String})
+    mode = get_show_env_mode(io)
     print(io, "[")
     for (i, e) in enumerate(env)
         i > 1 && print(io, ", ")
         eqidx = findnext('=', e, 2)
-        if eqidx === nothing || show_values
+        if eqidx === nothing || mode === :all
             show(io, e)
-        else
+        elseif mode === :keys
             key = e[1:prevind(e, eqidx)]
-            if _is_sensitive_env_name(key)
-                show(io, string(key, "=***"))
+            show(io, key)
+        else  # :redact
+            key = e[1:prevind(e, eqidx)]
+            if is_sensitive_env_name(key)
+                show(io, key)
             else
                 show(io, e)
             end
@@ -161,7 +183,8 @@ function _show_env(io::IO, env::Vector{String})
 end
 
 function show(io::IO, cmd::Cmd)
-    print_env = cmd.env !== nothing
+    env_mode = cmd.env !== nothing ? get_show_env_mode(io) : nothing
+    print_env = cmd.env !== nothing && env_mode !== :none
     print_dir = !isempty(cmd.dir)
     print_uid = cmd.uid !== nothing
     print_gid = cmd.gid !== nothing
@@ -190,7 +213,7 @@ function show(io::IO, cmd::Cmd)
         print(io, ")")
     end
     if print_env || print_dir
-        print_env && (print(io, ","); _show_env(io, cmd.env))
+        print_env && (print(io, ","); show_env(io, cmd.env))
         print_dir && (print(io, "; dir="); show(io, cmd.dir))
         print(io, ")")
     end
@@ -315,10 +338,16 @@ The `dir` keyword argument can be used to specify a working directory for the co
 `dir` defaults to the currently set `dir` for `command` (which is the current working
 directory if not specified already).
 
-!!! note
-    When displaying a `Cmd`, environment variables whose names match sensitive patterns
-    (e.g. containing "KEY", "TOKEN", "SECRET", "PASSWORD", "AUTH") have their values
-    redacted. Use `repr(cmd, context=:show_env_values=>true)` to show all values.
+!!! warning
+    The display redaction behavior (including the `:show_env` IOContext key
+    and `JULIA_SHOW_ENV` environment variable) is experimental and may change
+    in a non-breaking release of Julia.
+
+When displaying a `Cmd`, environment variables whose names match sensitive patterns
+(e.g. containing "KEY", "TOKEN", "SECRET", "PASSWORD", "AUTH", "JWT", "PAT") have
+their values hidden. The display mode can be controlled via the `JULIA_SHOW_ENV`
+environment variable or the `:show_env` IOContext key (which takes precedence),
+with values `:none`, `:keys`, `:redact` (default), or `:all`.
 
 See also [`Cmd`](@ref), [`addenv`](@ref), [`ENV`](@ref), [`pwd`](@ref).
 """

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -132,6 +132,34 @@ escape_microsoft_c_args(cmd::Cmd) =
 escape_microsoft_c_args(io::IO, cmd::Cmd) =
     escape_microsoft_c_args(io::IO, cmd.exec...)
 
+# Patterns that indicate a sensitive environment variable name (case-insensitive).
+const _SENSITIVE_ENV_PATTERNS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "PASSWD", "CREDENTIAL", "CRED", "AUTH", "PRIVATE")
+
+function _is_sensitive_env_name(name::AbstractString)
+    uname = uppercase(name)
+    return any(p -> occursin(p, uname), _SENSITIVE_ENV_PATTERNS)
+end
+
+function _show_env(io::IO, env::Vector{String})
+    show_values = get(io, :show_env_values, false)::Bool
+    print(io, "[")
+    for (i, e) in enumerate(env)
+        i > 1 && print(io, ", ")
+        eqidx = findnext('=', e, 2)
+        if eqidx === nothing || show_values
+            show(io, e)
+        else
+            key = e[1:prevind(e, eqidx)]
+            if _is_sensitive_env_name(key)
+                show(io, string(key, "=***"))
+            else
+                show(io, e)
+            end
+        end
+    end
+    print(io, "]")
+end
+
 function show(io::IO, cmd::Cmd)
     print_env = cmd.env !== nothing
     print_dir = !isempty(cmd.dir)
@@ -162,7 +190,7 @@ function show(io::IO, cmd::Cmd)
         print(io, ")")
     end
     if print_env || print_dir
-        print_env && (print(io, ","); show(io, cmd.env))
+        print_env && (print(io, ","); _show_env(io, cmd.env))
         print_dir && (print(io, "; dir="); show(io, cmd.dir))
         print(io, ")")
     end
@@ -286,6 +314,11 @@ as desired, or use [`addenv`](@ref).
 The `dir` keyword argument can be used to specify a working directory for the command.
 `dir` defaults to the currently set `dir` for `command` (which is the current working
 directory if not specified already).
+
+!!! note
+    When displaying a `Cmd`, environment variables whose names match sensitive patterns
+    (e.g. containing "KEY", "TOKEN", "SECRET", "PASSWORD", "AUTH") have their values
+    redacted. Use `repr(cmd, context=:show_env_values=>true)` to show all values.
 
 See also [`Cmd`](@ref), [`addenv`](@ref), [`ENV`](@ref), [`pwd`](@ref).
 """

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -135,9 +135,9 @@ escape_microsoft_c_args(io::IO, cmd::Cmd) =
 # Patterns that indicate a sensitive environment variable name.
 # Matched as whole components after splitting on non-alphanumeric characters,
 # so e.g. "PAT" matches "GITHUB_PAT" but not "PATH".
-const SENSITIVE_ENV_PATTERNS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "PASSWD",
-                                "CREDENTIAL", "CRED", "AUTH", "PRIVATE",
-                                "JWT", "PAT", "PASS", "PW")
+const SENSITIVE_ENV_PATTERNS = ("KEY", "TOKEN", "SECRET", "JWT", "PAT",
+                                "PASSWORD", "PASSWD", "PASS", "PWD", "PW",
+                                "CREDENTIAL", "CRED", "AUTH", "PRIVATE", "PRIV")
 
 function is_sensitive_env_name(name::AbstractString)
     uname = uppercase(name)

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -606,6 +606,25 @@ if !Sys.iswindows()
     @test string(cmd_both) == "setgid(setuid(`echo test`, 1001), 1000)"
 end
 
+# test redaction of sensitive env vars in Cmd display
+@testset "Cmd env display redaction" begin
+    cmd = setenv(`echo`, "API_KEY" => "secret123", "PATH" => "/usr/bin", "DATABASE_PASSWORD" => "hunter2")
+    s = repr(cmd)
+    # Sensitive vars are redacted
+    @test contains(s, "API_KEY=***")
+    @test contains(s, "DATABASE_PASSWORD=***")
+    @test !contains(s, "secret123")
+    @test !contains(s, "hunter2")
+    # Non-sensitive vars show full values
+    @test contains(s, "PATH=/usr/bin")
+
+    # Opt-in to show all values
+    s_full = repr(cmd, context=:show_env_values=>true)
+    @test contains(s_full, "secret123")
+    @test contains(s_full, "hunter2")
+    @test contains(s_full, "/usr/bin")
+end
+
 # test for interpolation of Cmd
 let c = setenv(`x`, "A"=>true)
     @test (`$c a`).env == String["A=true"]

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -608,21 +608,80 @@ end
 
 # test redaction of sensitive env vars in Cmd display
 @testset "Cmd env display redaction" begin
-    cmd = setenv(`echo`, "API_KEY" => "secret123", "PATH" => "/usr/bin", "DATABASE_PASSWORD" => "hunter2")
+    cmd = setenv(`echo`, "API_KEY" => "secret123", "PATH" => "/usr/bin",
+                 "DATABASE_PASSWORD" => "hunter2", "GITHUB_PAT" => "ghp_abc",
+                 "DB_PW" => "pass", "MY_JWT" => "eyJ", "MONKEY" => "banana")
+
+    # default :redact mode — sensitive keys only, non-sensitive with values
     s = repr(cmd)
-    # Sensitive vars are redacted
-    @test contains(s, "API_KEY=***")
-    @test contains(s, "DATABASE_PASSWORD=***")
+    @test contains(s, "\"API_KEY\"")
+    @test contains(s, "\"DATABASE_PASSWORD\"")
+    @test contains(s, "\"GITHUB_PAT\"")
+    @test contains(s, "\"DB_PW\"")
+    @test contains(s, "\"MY_JWT\"")
     @test !contains(s, "secret123")
     @test !contains(s, "hunter2")
-    # Non-sensitive vars show full values
+    @test !contains(s, "ghp_abc")
     @test contains(s, "PATH=/usr/bin")
+    @test contains(s, "MONKEY=banana")
 
-    # Opt-in to show all values
-    s_full = repr(cmd, context=:show_env_values=>true)
-    @test contains(s_full, "secret123")
-    @test contains(s_full, "hunter2")
-    @test contains(s_full, "/usr/bin")
+    # component matching avoids false positives
+    @test !Base.is_sensitive_env_name("PATH")
+    @test !Base.is_sensitive_env_name("MONKEY")
+    @test !Base.is_sensitive_env_name("SPAWN")
+    @test Base.is_sensitive_env_name("API_KEY")
+    @test Base.is_sensitive_env_name("GITHUB_PAT")
+    @test Base.is_sensitive_env_name("DB_PW")
+    @test Base.is_sensitive_env_name("AUTH_TOKEN")
+
+    # :all mode — show all values
+    s_all = repr(cmd, context=:show_env=>:all)
+    @test contains(s_all, "secret123")
+    @test contains(s_all, "hunter2")
+    @test contains(s_all, "ghp_abc")
+    @test contains(s_all, "PATH=/usr/bin")
+
+    # :keys mode — all vars show key only
+    s_keys = repr(cmd, context=:show_env=>:keys)
+    @test contains(s_keys, "\"API_KEY\"")
+    @test contains(s_keys, "\"PATH\"")
+    @test !contains(s_keys, "/usr/bin")
+    @test !contains(s_keys, "secret123")
+
+    # :none mode — no env block
+    s_none = repr(cmd, context=:show_env=>:none)
+    @test !contains(s_none, "setenv")
+    @test contains(s_none, "`echo`")
+
+    # :none mode with dir still shows dir
+    cmd_dir = setenv(`echo`, "API_KEY" => "secret"; dir="/tmp")
+    s_none_dir = repr(cmd_dir, context=:show_env=>:none)
+    @test contains(s_none_dir, "setenv")
+    @test contains(s_none_dir, "dir=")
+    @test !contains(s_none_dir, "API_KEY")
+
+    # JULIA_SHOW_ENV env var
+    withenv("JULIA_SHOW_ENV" => "all") do
+        s = repr(cmd)
+        @test contains(s, "secret123")
+        @test contains(s, "hunter2")
+    end
+    withenv("JULIA_SHOW_ENV" => "none") do
+        s = repr(cmd)
+        @test !contains(s, "setenv")
+    end
+    withenv("JULIA_SHOW_ENV" => "keys") do
+        s = repr(cmd)
+        @test !contains(s, "/usr/bin")
+        @test contains(s, "\"PATH\"")
+    end
+
+    # IOContext overrides env var
+    withenv("JULIA_SHOW_ENV" => "all") do
+        s = repr(cmd, context=:show_env=>:redact)
+        @test !contains(s, "secret123")
+        @test contains(s, "PATH=/usr/bin")
+    end
 end
 
 # test for interpolation of Cmd


### PR DESCRIPTION
I yet again managed to get my API keys revoked because of sharing a Julia error message that included a dump of my entire environment. Although this is entirely a product of my stupidity, I figured we shouldn't have Julia enable this kind of behavior. This PR proposes a filter that replaces sensitive env vars with `***` to hopefully prevent this from happening to other people.

Quick vibe-coded PR. Will clean-up if deemed useful.

Before:
```
julia -e 'run(setenv(`false`, "API_KEY" => "hunter2"))'
ERROR: failed process: Process(setenv(`false`,["API_KEY=hunter2"]), ProcessExited(1)) [1]
```

After:
```
./julia -e 'run(setenv(`false`, "API_KEY" => "hunter2"))'
ERROR: failed process: Process(setenv(`false`,["API_KEY=***"]), ProcessExited(1)) [1]
```