### PR TITLE
precompilation: scope workspace sub-environment precompilation to project deps

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -705,6 +705,57 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
         for (name, uuid) in env.project_deps if !Base.in_sysimage(Base.PkgId(uuid, name))
     ]
 
+    # If not precompiling the full workspace manifest, prune the dependency graph
+    # to only packages reachable from the active project's dependencies.
+    # In a workspace with a shared Manifest.toml, env.deps contains packages from
+    # all sub-environments. Without this pruning, extensions with cross-environment
+    # triggers would be included in project_deps and pull in unrelated packages.
+    # This is done before extension edge injection so that the expensive indirect
+    # dependency expansion and extension logic only runs on the relevant subgraph.
+    if !manifest
+        if isempty(pkg_names)
+            pkg_names = [pkg.name for pkg in project_deps]
+        end
+        keep = Set{Base.PkgId}()
+        for dep_pkgid in keys(direct_deps)
+            if dep_pkgid.name in pkg_names
+                push!(keep, dep_pkgid)
+                collect_all_deps(direct_deps, dep_pkgid, keep)
+            end
+        end
+        # Also keep packages that were explicitly requested as PkgIds (for extensions)
+        if pkgs isa Vector{PkgId}
+            for requested_pkgid in requested_pkgids
+                if haskey(direct_deps, requested_pkgid)
+                    push!(keep, requested_pkgid)
+                    collect_all_deps(direct_deps, requested_pkgid, keep)
+                end
+            end
+        end
+        for ext in keys(ext_to_parent)
+            if haskey(direct_deps, ext) && all(d -> d in keep, direct_deps[ext])
+                push!(keep, ext)
+            end
+        end
+        filter!(d -> first(d) in keep, direct_deps)
+        filter!(d -> first(d) in keep, ext_to_parent)
+        filter!(d -> first(d) in keep, triggers)
+        for (_, exts) in parent_to_exts
+            filter!(ext -> ext in keep, exts)
+        end
+        filter!(d -> !isempty(last(d)), parent_to_exts)
+        if isempty(direct_deps)
+            if _from_loading
+                # if called from loading precompilation it may be a package from another environment stack so
+                # don't error and allow serial precompilation to try
+                # TODO: actually handle packages from other envs in the stack
+                return
+            else
+                return
+            end
+        end
+    end
+
     # consider exts of project deps to be project deps so that errors are reported
     append!(project_deps, keys(filter(d->last(d).name in keys(env.project_deps), ext_to_parent)))
 
@@ -815,48 +866,6 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
     end
     if !isempty(circular_deps)
         @warn excluded_circular_deps_explanation(io, ext_to_parent, circular_deps, cycles)
-    end
-
-    # If you have a workspace and want to precompile all projects in it, look through all packages in the manifest
-    # instead of collecting from a project i.e. not filter out packages that are in the current project.
-    # i.e. Pkg sets manifest to true for workspace precompile requests
-    # TODO: rename `manifest`?
-    if !manifest
-        if isempty(pkg_names)
-            pkg_names = [pkg.name for pkg in project_deps]
-        end
-        keep = Set{Base.PkgId}()
-        for dep_pkgid in keys(direct_deps)
-            if dep_pkgid.name in pkg_names
-                push!(keep, dep_pkgid)
-                collect_all_deps(direct_deps, dep_pkgid, keep)
-            end
-        end
-        # Also keep packages that were explicitly requested as PkgIds (for extensions)
-        if pkgs isa Vector{PkgId}
-            for requested_pkgid in requested_pkgids
-                if haskey(direct_deps, requested_pkgid)
-                    push!(keep, requested_pkgid)
-                    collect_all_deps(direct_deps, requested_pkgid, keep)
-                end
-            end
-        end
-        for ext in keys(ext_to_parent)
-            if issubset(collect_all_deps(direct_deps, ext), keep) # if all extension deps are kept
-                push!(keep, ext)
-            end
-        end
-        filter!(d->in(first(d), keep), direct_deps)
-        if isempty(direct_deps)
-            if _from_loading
-                # if called from loading precompilation it may be a package from another environment stack so
-                # don't error and allow serial precompilation to try
-                # TODO: actually handle packages from other envs in the stack
-                return
-            else
-                return
-            end
-        end
     end
 
     target = Ref{Union{Nothing, String}}(nothing)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2864,4 +2864,125 @@ precompile_test_harness("Preferences hash collision (issue #59344), part 2") do 
     end
 end
 
+# Workspace sub-environment precompilation should not precompile packages from other sub-environments
+@testset "workspace sub-environment precompilation scoping" begin
+    mkdepottempdir() do depot
+        workspace_path = joinpath(depot, "workspace")
+        mkpath(workspace_path)
+
+        # Foo: a package with an extension triggered by Bar
+        foo_path = joinpath(workspace_path, "Foo")
+        mkpath(joinpath(foo_path, "src"))
+        mkpath(joinpath(foo_path, "ext"))
+        write(joinpath(foo_path, "Project.toml"),
+              """
+              name = "Foo"
+              uuid = "ab000000-0000-0000-0000-000000000001"
+              version = "0.1.0"
+
+              [weakdeps]
+              Bar = "ab000000-0000-0000-0000-000000000002"
+
+              [extensions]
+              FooBarExt = "Bar"
+              """)
+        write(joinpath(foo_path, "src", "Foo.jl"),
+              """
+              module Foo
+              greet() = "hello from Foo"
+              end
+              """)
+        write(joinpath(foo_path, "ext", "FooBarExt.jl"),
+              """
+              module FooBarExt
+              using Foo, Bar
+              end
+              """)
+
+        # Bar: a package that only the BarEnv sub-environment depends on
+        bar_path = joinpath(workspace_path, "Bar")
+        mkpath(joinpath(bar_path, "src"))
+        write(joinpath(bar_path, "Project.toml"),
+              """
+              name = "Bar"
+              uuid = "ab000000-0000-0000-0000-000000000002"
+              version = "0.1.0"
+              """)
+        write(joinpath(bar_path, "src", "Bar.jl"),
+              """
+              module Bar
+              greet() = "hello from Bar"
+              end
+              """)
+
+        # FooEnv: a sub-environment that only depends on Foo
+        fooenv_path = joinpath(workspace_path, "FooEnv")
+        mkpath(fooenv_path)
+        write(joinpath(fooenv_path, "Project.toml"),
+              """
+              [deps]
+              Foo = "ab000000-0000-0000-0000-000000000001"
+              """)
+
+        # BarEnv: a sub-environment that depends on both Foo and Bar
+        barenv_path = joinpath(workspace_path, "BarEnv")
+        mkpath(barenv_path)
+        write(joinpath(barenv_path, "Project.toml"),
+              """
+              [deps]
+              Foo = "ab000000-0000-0000-0000-000000000001"
+              Bar = "ab000000-0000-0000-0000-000000000002"
+              """)
+
+        # Workspace root Project.toml
+        write(joinpath(workspace_path, "Project.toml"),
+              """
+              [workspace]
+              projects = ["FooEnv", "BarEnv"]
+              """)
+
+        # Shared Manifest.toml at workspace root (contains all packages)
+        write(joinpath(workspace_path, "Manifest.toml"),
+              """
+              manifest_format = "2.0"
+
+              [[deps.Bar]]
+              path = "Bar"
+              uuid = "ab000000-0000-0000-0000-000000000002"
+              version = "0.1.0"
+
+              [[deps.Foo]]
+              deps = ["Bar"]
+              weakdeps = ["Bar"]
+              path = "Foo"
+              uuid = "ab000000-0000-0000-0000-000000000001"
+              version = "0.1.0"
+
+              [deps.Foo.extensions]
+              FooBarExt = "Bar"
+              """)
+
+        original_depot_path = copy(Base.DEPOT_PATH)
+        old_proj = Base.active_project()
+        try
+            push!(empty!(DEPOT_PATH), depot)
+            # Activate FooEnv (only depends on Foo, not Bar)
+            Base.set_active_project(fooenv_path)
+
+            io = IOBuffer()
+            ioc = IOContext(io, :color => false)
+            Base.Precompilation.precompilepkgs(; io=ioc, fancyprint=false)
+            output = String(take!(io))
+
+            # Foo should be precompiled
+            @test occursin("Foo", output)
+            # Bar should NOT be precompiled (it's in another sub-environment)
+            @test !occursin("Bar", output)
+        finally
+            Base.set_active_project(old_proj)
+            append!(empty!(DEPOT_PATH), original_depot_path)
+        end
+    end
+end
+
 finish_precompile_test!()


### PR DESCRIPTION
@giordano reported:
> check out https://github.com/NumericalEarth/Breeze.jl, activate and precompile the benchmarking environment, then wait for Makie and Reactant to be precompiled even if they aren't in [that environment](https://github.com/NumericalEarth/Breeze.jl/blob/ed4f42e188c715344b06e582bfa696fd6c3d5826/benchmarking/Project.toml) (they are in the docs and test environments, respectively)

> notably, it's not all the workspace dependencies, just a bunch of them.  CairoMakie isn't precompiled, but Makie is (of course it's Makie the more expensive one)

## The issue & Fix

In a workspace with a shared Manifest.toml, ExplicitEnv().deps contains packages from all sub-environments. When precompiling from a specific sub-environment, extensions with triggers from other sub-environments would be included and pull in unrelated packages.

Move the dependency graph pruning to happen before extension edge injection rather than after. This ensures the expensive indirect dependency expansion and extension logic only runs on the relevant subgraph, and prevents cross-environment extensions from dragging in packages that belong to other sub-environments.

Developed with Claude