### PR TITLE
precompilation: improve warn_loaded messaging for transitive deps

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -931,6 +931,7 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
     n_done = Ref(0)
     n_already_precomp = Ref(0)
     n_loaded = Ref(0)
+    loaded_pkgs = Base.PkgId[]
     interrupted = Ref(false)
     t_print = Ref{Task}()
 
@@ -1194,7 +1195,10 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
                                     stale_cache[stale_cache_key] = false
                                 end
                             end
-                            loaded && (n_loaded[] += 1)
+                            if loaded
+                                n_loaded[] += 1
+                                @lock print_lock push!(loaded_pkgs, pkg)
+                            end
                         catch err
                             close(std_pipe.in) # close pipe to end the std output monitor
                             wait(t_monitor)
@@ -1212,7 +1216,13 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
                             Base.release(parallel_limiter)
                         end
                     else
-                        is_stale || (n_already_precomp[] += 1)
+                        if !is_stale
+                            n_already_precomp[] += 1
+                            if loaded
+                                n_loaded[] += 1
+                                @lock print_lock push!(loaded_pkgs, pkg)
+                            end
+                        end
                     end
                     n_done[] += 1
                     notify(was_processed[pkg_config])
@@ -1283,14 +1293,44 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
                     local plural1 = length(configs) > 1 ? "dependency configurations" : n_loaded[] == 1 ? "dependency" : "dependencies"
                     local plural2 = n_loaded[] == 1 ? "a different version is" : "different versions are"
                     local plural3 = n_loaded[] == 1 ? "" : "s"
-                    local plural4 = n_loaded[] == 1 ? "this package" : "these packages"
+                    local loaded_names = join(sort!([full_name(ext_to_parent, p) for p in loaded_pkgs]), ", ", " and ")
+                    # compute how many precompiled packages transitively depend on the loaded packages
+                    local n_affected = 0
+                    local loaded_set = Set{Base.PkgId}(loaded_pkgs)
+                    let reverse_deps = Dict{Base.PkgId, Vector{Base.PkgId}}()
+                        for (p, deps) in direct_deps
+                            for d in deps
+                                push!(get!(Vector{Base.PkgId}, reverse_deps, d), p)
+                            end
+                        end
+                        affected = Set{Base.PkgId}()
+                        frontier = Base.PkgId[p for p in loaded_set]
+                        while !isempty(frontier)
+                            p = pop!(frontier)
+                            for rdep in get(reverse_deps, p, Base.PkgId[])
+                                if rdep ∉ affected && rdep ∉ loaded_set
+                                    push!(affected, rdep)
+                                    push!(frontier, rdep)
+                                end
+                            end
+                        end
+                        n_affected = length(affected)
+                    end
                     print(iostr, "\n  ",
                         color_string(string(n_loaded[]), Base.warn_color()),
                         " $(plural1) precompiled but ",
                         color_string("$(plural2) currently loaded", Base.warn_color()),
-                        ". Restart julia to access the new version$(plural3). \
-                        Otherwise, loading dependents of $(plural4) may trigger further precompilation to work with the unexpected version$(plural3)."
+                        " (", loaded_names, ")",
+                        ". Restart julia to access the new version$(plural3)."
                     )
+                    if n_affected > 0
+                        local affected_plural = length(configs) > 1 ? "dependency configurations" : n_affected == 1 ? "dependent" : "dependents"
+                        print(iostr,
+                            " Otherwise, $(n_affected) $(affected_plural) of ",
+                            n_loaded[] == 1 ? "this package" : "these packages",
+                            " may trigger further precompilation to work with the unexpected version$(plural3)."
+                        )
+                    end
                 end
                 if !isempty(precomperr_deps)
                     pluralpc = length(configs) > 1 ? "dependency configurations" : precomperr_deps == 1 ? "dependency" : "dependencies"

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2893,4 +2893,89 @@ end
     end
 end
 
+# Test that warn_loaded names loaded packages and counts affected dependents
+@testset "warn_loaded names packages and counts dependents" begin
+    mkdepottempdir() do depot; mktempdir() do dir
+        # Create LoadedDep — will be loaded before precompilepkgs runs
+        loaded_dep_path = joinpath(dir, "dev", "LoadedDep")
+        mkpath(joinpath(loaded_dep_path, "src"))
+        write(joinpath(loaded_dep_path, "Project.toml"),
+              """
+              name = "LoadedDep"
+              uuid = "a1a1a1a1-0000-0000-0000-000000000001"
+              version = "0.1.0"
+              """)
+        write(joinpath(loaded_dep_path, "src", "LoadedDep.jl"),
+              """
+              module LoadedDep
+              end
+              """)
+
+        # Create DepUser — depends on LoadedDep
+        depuser_path = joinpath(dir, "dev", "DepUser")
+        mkpath(joinpath(depuser_path, "src"))
+        write(joinpath(depuser_path, "Project.toml"),
+              """
+              name = "DepUser"
+              uuid = "b2b2b2b2-0000-0000-0000-000000000002"
+              version = "0.1.0"
+
+              [deps]
+              LoadedDep = "a1a1a1a1-0000-0000-0000-000000000001"
+              """)
+        write(joinpath(depuser_path, "src", "DepUser.jl"),
+              """
+              module DepUser
+              import LoadedDep
+              end
+              """)
+
+        # Create project environment referencing both packages
+        project_path = joinpath(dir, "project")
+        mkpath(project_path)
+        write(joinpath(project_path, "Project.toml"),
+              """
+              [deps]
+              DepUser = "b2b2b2b2-0000-0000-0000-000000000002"
+              LoadedDep = "a1a1a1a1-0000-0000-0000-000000000001"
+              """)
+        write(joinpath(project_path, "Manifest.toml"),
+              """
+              manifest_format = "2.0"
+
+              [[deps.DepUser]]
+              deps = ["LoadedDep"]
+              path = "../dev/DepUser/"
+              uuid = "b2b2b2b2-0000-0000-0000-000000000002"
+              version = "0.1.0"
+
+              [[deps.LoadedDep]]
+              path = "../dev/LoadedDep/"
+              uuid = "a1a1a1a1-0000-0000-0000-000000000001"
+              version = "0.1.0"
+              """)
+
+        script = """
+            using LoadedDep
+            Base.Precompilation.precompilepkgs(; fancyprint=false, warn_loaded=true)
+            """
+
+        cmd = addenv(`$(Base.julia_cmd()) --startup-file=no --project=$(project_path) -e $script`,
+                     "JULIA_DEPOT_PATH" => depot)
+
+        out = Base.PipeEndpoint()
+        log = @async read(out, String)
+        try
+            proc = run(pipeline(cmd, stdout=out, stderr=out))
+            @test success(proc)
+        catch
+            @show fetch(log)
+            rethrow()
+        end
+        output = fetch(log)
+        @test occursin("currently loaded", output)
+        @test occursin("LoadedDep", output)
+    end end
+end
+
 finish_precompile_test!()


### PR DESCRIPTION
The existing warning was brittle and wasn't shown when the package with a different version loaded wasn't actually precompiled by this session. i.e. `[21216c6a] + Preferences v1.5.2 [loaded: v1.5.1]` but v1.5.2 was actually already precompiled on the system.

Developed with Claude.

---

Name the loaded packages and count their affected dependents in the warning shown after Pkg.precompile. This helps users understand why a subsequent `using` triggers re-precompilation: a transitive dependency (e.g. Preferences) was loaded at one version but the manifest resolved a different version, so caches built by Pkg.precompile (ignore_loaded=true) are rejected at load time (ignore_loaded=false).

The message now shows which packages are loaded at a different version and how many dependents will be affected, making the restart suggestion more actionable.

```
(@v1.14) pkg> st
Status `~/.julia/environments/v1.14/Project.toml`
  [336ed68f] CSV v0.10.16
  [0ca39b1e] Chairmarks v1.3.1
  [a93c6f00] DataFrames v1.8.1
  [7876af07] Example v0.5.5
⌃ [21216c6a] Preferences v1.5.1
  [295af30f] Revise v3.13.2
Info Packages marked with ⌃ have new versions available and may be upgradable.

julia> using Preferences

(@v1.14) pkg> activate --temp
  Activating new project at `/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_PgrklO`

(jl_PgrklO) pkg> add CSV
   Resolving package versions...
    Updating `/private/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_PgrklO/Project.toml`
  [336ed68f] + CSV v0.10.16
    Updating `/private/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_PgrklO/Manifest.toml`
  [336ed68f] + CSV v0.10.16
  [944b1d66] + CodecZlib v0.7.8
  [34da2185] + Compat v4.18.1
  [9a962f9c] + DataAPI v1.16.0
  [e2d170a0] + DataValueInterfaces v1.0.0
  [48062228] + FilePathsBase v0.9.24
  [842dd82b] + InlineStrings v1.4.5
  [82899510] + IteratorInterfaceExtensions v1.0.0
  [bac558e1] + OrderedCollections v1.8.1
  [69de0a69] + Parsers v2.8.3
  [2dfb63ee] + PooledArrays v1.4.3
  [aea7be01] + PrecompileTools v1.3.3
  [21216c6a] + Preferences v1.5.2 [loaded: v1.5.1]
  [91c51154] + SentinelArrays v1.4.9
  [3783bdb8] + TableTraits v1.0.1
  [bd369af6] + Tables v1.12.1
  [3bb67fe8] + TranscodingStreams v0.11.3
  [ea10d353] + WeakRefStrings v1.4.2
  [76eceee3] + WorkerUtilities v1.6.1
  [ade2ca70] + Dates v1.11.0
  [9fa8497b] + Future v1.11.0
  [8f399da3] + Libdl v1.11.0
  [a63ad114] + Mmap v1.11.0
  [de0858da] + Printf v1.11.0
  [9a3f8284] + Random v1.11.0
  [ea8e919c] + SHA v1.0.0
  [fa267f1f] + TOML v1.0.3
  [cf7118a7] + UUIDs v1.11.0
  [4ec0a83e] + Unicode v1.11.0
  [83775a58] + Zlib_jll v1.3.2+0
Precompiling CSV finished.
  1 dependency successfully precompiled in 9 seconds. 29 already precompiled.
  1 dependency precompiled but a different version is currently loaded (Preferences). Restart julia to access the new version. Otherwise, 5 dependents of this package may trigger further precompilation to work with the unexpected version.

```