### PR TITLE
RFC: [macOS] Use POSIX-style signals for `segv_handler`

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1398,6 +1398,9 @@ int jl_safepoint_consume_sigint(void);
 void jl_wake_libuv(void) JL_NOTSAFEPOINT;
 
 void jl_set_pgcstack(jl_gcframe_t **) JL_NOTSAFEPOINT;
+#ifndef _OS_WINDOWS_
+jl_ptls_t jl_get_task_exit_ptls(void) JL_NOTSAFEPOINT;
+#endif
 #if defined(_OS_WINDOWS_)
 typedef DWORD jl_pgcstack_key_t;
 #else

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1409,7 +1409,7 @@ JL_DLLEXPORT void jl_pgcstack_getkey(jl_get_pgcstack_func **f, jl_pgcstack_key_t
 extern pthread_mutex_t in_signal_lock;
 #endif
 
-void jl_set_gc_and_wait(jl_task_t *ct); // n.b. not used on _OS_DARWIN_
+void jl_set_gc_and_wait(jl_task_t *ct);
 
 // Query if a Julia object is if a permalloc region (due to part of a sys- pkg-image)
 STATIC_INLINE size_t n_linkage_blobs(void) JL_NOTSAFEPOINT
@@ -1892,10 +1892,6 @@ JL_DLLEXPORT float julia_half_to_float(uint16_t param) JL_NOTSAFEPOINT;
 extern jl_mutex_t typecache_lock;
 extern jl_mutex_t world_counter_lock;
 
-#if defined(__APPLE__)
-void jl_mach_gc_end(void) JL_NOTSAFEPOINT;
-void jl_safepoint_resume_thread_mach(jl_ptls_t ptls2, int16_t tid2) JL_NOTSAFEPOINT;
-#endif
 
 // -- smallintset.c -- //
 

--- a/src/safepoint.c
+++ b/src/safepoint.c
@@ -227,15 +227,11 @@ void jl_safepoint_end_gc(void)
     jl_safepoint_disable(2);
     jl_safepoint_disable(1);
     jl_atomic_store_release(&jl_gc_running, 0);
-#  ifdef _OS_DARWIN_
-    // This wakes up other threads on mac.
-    jl_mach_gc_end();
-#  endif
     uv_mutex_unlock(&safepoint_lock);
     uv_cond_broadcast(&safepoint_cond_end);
 }
 
-void jl_set_gc_and_wait(jl_task_t *ct) // n.b. not used on _OS_DARWIN_
+void jl_set_gc_and_wait(jl_task_t *ct)
 {
     // reading own gc state doesn't need atomic ops since no one else
     // should store to it.
@@ -391,9 +387,6 @@ int jl_safepoint_resume_thread(int tid) JL_NOTSAFEPOINT
         else
             jl_atomic_store_relaxed(&ptls2->safepoint, (size_t*)(jl_safepoint_pages + jl_page_size * 2 + sizeof(void*)));
         uv_cond_signal(&ptls2->wake_signal);
-#ifdef _OS_DARWIN_
-        jl_safepoint_resume_thread_mach(ptls2, tid);
-#endif
         uv_cond_broadcast(&safepoint_cond_begin);
     }
     if (suspend_count != 0) {

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -42,108 +42,7 @@ extern void _dyld_dlopen_atfork_prepare(void) __attribute__((weak_import));
 extern void _dyld_dlopen_atfork_parent(void) __attribute__((weak_import));
 //extern void _dyld_dlopen_atfork_child(void) __attribute__((weak_import));
 
-static void attach_exception_port(thread_port_t thread, int segv_only);
-
-// low 16 bits are the thread id, the next 8 bits are the original gc_state
-static arraylist_t suspended_threads;
-extern uv_cond_t safepoint_cond_begin;
-
-#define GC_STATE_SHIFT 8*sizeof(int16_t)
-static inline int8_t decode_gc_state(uintptr_t item)
-{
-    return (int8_t)(item >> GC_STATE_SHIFT);
-}
-
-static inline int16_t decode_tid(uintptr_t item)
-{
-    return (int16_t)item;
-}
-
-static inline uintptr_t encode_item(int16_t tid, int8_t gc_state)
-{
-    return (uintptr_t)tid | ((uintptr_t)gc_state << GC_STATE_SHIFT);
-}
-
-// see jl_safepoint_wait_thread_resume
-void jl_safepoint_resume_thread_mach(jl_ptls_t ptls2, int16_t tid2)
-{
-    // must be called with uv_mutex_lock(&safepoint_lock) and uv_mutex_lock(&ptls2->sleep_lock) held (in that order)
-    for (size_t i = 0; i < suspended_threads.len; i++) {
-        uintptr_t item = (uintptr_t)suspended_threads.items[i];
-
-        int16_t tid = decode_tid(item);
-        int8_t gc_state = decode_gc_state(item);
-        if (tid != tid2)
-            continue;
-        jl_atomic_store_release(&ptls2->gc_state, gc_state);
-        thread_resume(pthread_mach_thread_np(ptls2->system_id));
-        suspended_threads.items[i] = suspended_threads.items[--suspended_threads.len];
-        break;
-    }
-    // thread hadn't actually reached a jl_mach_gc_wait call where we suspended it
-}
-
-void jl_mach_gc_end(void)
-{
-    // must be called with uv_mutex_lock(&safepoint_lock) held
-    size_t j = 0;
-    for (size_t i = 0; i < suspended_threads.len; i++) {
-        uintptr_t item = (uintptr_t)suspended_threads.items[i];
-        int16_t tid = decode_tid(item);
-        int8_t gc_state = decode_gc_state(item);
-        jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
-        uv_mutex_lock(&ptls2->sleep_lock);
-        if (jl_atomic_load_relaxed(&ptls2->suspend_count) == 0) {
-            jl_atomic_store_release(&ptls2->gc_state, gc_state);
-            thread_resume(pthread_mach_thread_np(ptls2->system_id));
-        }
-        else {
-            // this is the check for jl_safepoint_wait_thread_resume
-            suspended_threads.items[j++] = (void*)item;
-        }
-        uv_mutex_unlock(&ptls2->sleep_lock);
-    }
-    suspended_threads.len = j;
-}
-
-// implement jl_set_gc_and_wait from a different thread
-static void jl_mach_gc_wait(jl_ptls_t ptls2, mach_port_t thread, int16_t tid)
-{
-    // relaxed, since we don't mind missing one--we will hit another soon (immediately probably)
-    uv_mutex_lock(&safepoint_lock);
-    // Since this gets set to zero only while the safepoint_lock was held this
-    // means we can tell for sure if GC is done before we got the message or
-    // the safepoint was enabled for SIGINT instead.
-    int doing_gc = jl_atomic_load_relaxed(&jl_gc_running);
-    int do_suspend = doing_gc;
-    int relaxed_suspend_count = !doing_gc && jl_atomic_load_relaxed(&ptls2->suspend_count) != 0;
-    if (relaxed_suspend_count) {
-        uv_mutex_lock(&ptls2->sleep_lock);
-        do_suspend = jl_atomic_load_relaxed(&ptls2->suspend_count) != 0;
-        // only do_suspend while holding the sleep_lock, otherwise we might miss a resume
-    }
-    if (do_suspend) {
-        // Set the gc state of the thread, suspend and record it
-        //
-        // TODO: TSAN will complain that it never saw the faulting task do an
-        // atomic release (it was in the kernel). And our attempt here does
-        // nothing, since we are a different thread, and it is not transitive).
-        //
-        // This also means we are not making this thread available for GC work.
-        // Eventually, we should probably release this signal to the original
-        // thread, (return KERN_FAILURE instead of KERN_SUCCESS) so that it
-        // triggers a SIGSEGV and gets handled by the usual codepath for unix.
-        int8_t gc_state = jl_atomic_load_acquire(&ptls2->gc_state);
-        jl_atomic_store_release(&ptls2->gc_state, JL_GC_STATE_WAITING);
-        uintptr_t item = encode_item(tid, gc_state);
-        arraylist_push(&suspended_threads, (void*)item);
-        thread_suspend(thread);
-    }
-    if (relaxed_suspend_count)
-        uv_mutex_unlock(&ptls2->sleep_lock);
-    uv_cond_broadcast(&safepoint_cond_begin);
-    uv_mutex_unlock(&safepoint_lock);
-}
+static void attach_exception_port(thread_port_t thread);
 
 static mach_port_t segv_port = 0;
 
@@ -172,8 +71,6 @@ static void allocate_mach_handler(void)
     if (_keymgr_set_lockmode_processwide_ptr(KEYMGR_GCC3_DW2_OBJ_LIST, NM_ALLOW_RECURSION))
         jl_error("_keymgr_set_lockmode_processwide_ptr failed");
 
-    int16_t nthreads = jl_atomic_load_acquire(&jl_n_threads);
-    arraylist_new(&suspended_threads, nthreads); // we will resize later (inside safepoint_lock), if needed
     pthread_t thread;
     pthread_attr_t attr;
     kern_return_t ret;
@@ -315,21 +212,6 @@ static void jl_longjmp_in_state(host_thread_state_t *state, jl_jmp_buf jmpbuf)
     }
 }
 
-#ifdef _CPU_X86_64_
-int is_write_fault(host_exception_state_t exc_state) {
-    return exc_reg_is_write_fault(exc_state.__err);
-}
-#elif defined(_CPU_AARCH64_)
-int is_write_fault(host_exception_state_t exc_state) {
-    return exc_reg_is_write_fault(exc_state.__esr);
-}
-#else
-#warning Implement this query for consistent PROT_NONE handling
-int is_write_fault(host_exception_state_t exc_state) {
-    return 0;
-}
-#endif
-
 static void jl_throw_in_thread(jl_ptls_t ptls2, mach_port_t thread, jl_value_t *exception)
 {
     unsigned int count = MACH_THREAD_STATE_COUNT;
@@ -360,23 +242,6 @@ static void jl_throw_in_thread(jl_ptls_t ptls2, mach_port_t thread, jl_value_t *
     HANDLE_MACH_ERROR("thread_set_state", ret);
 }
 
-static void segv_handler(int sig, siginfo_t *info, void *context)
-{
-    assert(sig == SIGSEGV || sig == SIGBUS);
-    jl_jmp_buf *saferestore = jl_get_safe_restore();
-    if (saferestore) { // restarting jl_ or jl_unwind_stepn
-        jl_longjmp_in_state((host_thread_state_t*)jl_to_bt_context(context), *saferestore);
-        return;
-    }
-    jl_task_t *ct = jl_get_current_task();
-    if ((sig != SIGBUS || info->si_code == BUS_ADRERR) &&
-    !(ct == NULL || ct->ptls == NULL || jl_atomic_load_relaxed(&ct->ptls->gc_state) == JL_GC_STATE_WAITING || ct->eh == NULL)
-    && is_addr_on_stack(ct, info->si_addr)) { // stack overflow and not a BUS_ADRALN (alignment error)
-        stack_overflow_warning();
-    }
-    sigdie_handler(sig, info, context);
-}
-
 // n.b. mach_exc_server expects us to define this symbol locally
 /* The documentation for catch_exception_raise says: A return value of
  * KERN_SUCCESS indicates that the thread is to continue from the point of
@@ -398,76 +263,16 @@ kern_return_t catch_mach_exception_raise(
     mach_exception_data_t code,
     mach_msg_type_number_t codeCnt)
 {
-    unsigned int exc_count = HOST_EXCEPTION_STATE_COUNT;
-    host_exception_state_t exc_state;
 #ifdef LLVMLIBUNWIND
     if (thread == mach_profiler_thread) {
         return profiler_segv_handler(exception_port, thread, task, exception, code, codeCnt);
     }
 #endif
-    int16_t tid;
-    jl_ptls_t ptls2 = NULL;
-    int nthreads = jl_atomic_load_acquire(&jl_n_threads);
-    for (tid = 0; tid < nthreads; tid++) {
-        jl_ptls_t _ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
-        if (jl_atomic_load_relaxed(&_ptls2->current_task) == NULL) {
-            // this thread is dead
-            continue;
-        }
-        if (pthread_mach_thread_np(_ptls2->system_id) == thread) {
-            ptls2 = _ptls2;
-            break;
-        }
-    }
-    if (!ptls2) {
-        // We don't know about this thread, let the kernel try another handler
-        // instead. This shouldn't actually happen since we only register the
-        // handler for the threads we know about.
-        jl_safe_printf("ERROR: Exception handler triggered on unmanaged thread.\n");
-        return KERN_INVALID_ARGUMENT;
-    }
-    if (ptls2->safe_restore) {
-        jl_throw_in_thread(ptls2, thread, NULL);
-        return KERN_SUCCESS;
-    }
-    if (jl_atomic_load_acquire(&ptls2->gc_state) == JL_GC_STATE_WAITING)
-        return KERN_FAILURE;
-    if (exception == EXC_ARITHMETIC) {
-        jl_throw_in_thread(ptls2, thread, jl_diverror_exception);
-        return KERN_SUCCESS;
-    }
-    assert(exception == EXC_BAD_ACCESS); // SIGSEGV or SIGBUS
-    if (codeCnt < 2 || code[0] != KERN_PROTECTION_FAILURE) // SEGV_ACCERR or BUS_ADRERR or BUS_ADRALN
-        return KERN_FAILURE;
-    uint64_t fault_addr = code[1];
-    kern_return_t ret = thread_get_state(thread, HOST_EXCEPTION_STATE, (thread_state_t)&exc_state, &exc_count);
-    HANDLE_MACH_ERROR("thread_get_state", ret);
-    if (jl_addr_is_safepoint(fault_addr) && !is_write_fault(exc_state)) {
-        jl_mach_gc_wait(ptls2, thread, tid);
-        if (ptls2->tid != 0)
-            return KERN_SUCCESS;
-        if (ptls2->defer_signal) {
-            jl_safepoint_defer_sigint();
-        }
-        else if (jl_safepoint_consume_sigint()) {
-            jl_clear_force_sigint();
-            jl_throw_in_thread(ptls2, thread, jl_interrupt_exception);
-        }
-        return KERN_SUCCESS;
-    }
-    if (jl_atomic_load_relaxed(&ptls2->current_task)->eh == NULL)
-        return KERN_FAILURE;
-    jl_value_t *excpt;
-    if (is_addr_on_stack(jl_atomic_load_relaxed(&ptls2->current_task), (void*)fault_addr)) {
-        stack_overflow_warning();
-        excpt = jl_stackovf_exception;
-    }
-    else if (is_write_fault(exc_state)) // false for alignment errors
-        excpt = jl_readonlymemory_exception;
-    else
-        return KERN_FAILURE;
-    jl_throw_in_thread(ptls2, thread, excpt);
-    return KERN_SUCCESS;
+    // All exceptions (EXC_BAD_ACCESS, EXC_ARITHMETIC, EXC_BAD_INSTRUCTION,
+    // EXC_BREAKPOINT) are handled by POSIX signal handlers. Return
+    // KERN_FAILURE so the kernel delivers them as signals (SIGSEGV/SIGBUS,
+    // SIGFPE, SIGILL, SIGTRAP) to the faulting thread.
+    return KERN_FAILURE;
 }
 
 //mach_exc_server expects us to define this symbol locally
@@ -502,13 +307,12 @@ kern_return_t catch_mach_exception_raise_state_identity(
     return KERN_INVALID_ARGUMENT; // we only use EXCEPTION_DEFAULT
 }
 
-static void attach_exception_port(thread_port_t thread, int segv_only)
+static void attach_exception_port(thread_port_t thread)
 {
     kern_return_t ret;
     // https://www.opensource.apple.com/source/xnu/xnu-2782.1.97/osfmk/man/thread_set_exception_ports.html
+    // The profiler thread needs EXC_MASK_BAD_ACCESS for crash recovery during unwinding with compact unwind info.
     exception_mask_t mask = EXC_MASK_BAD_ACCESS;
-    if (!segv_only)
-        mask |= EXC_MASK_ARITHMETIC;
     ret = thread_set_exception_ports(thread, mask, segv_port, EXCEPTION_DEFAULT | MACH_EXCEPTION_CODES, MACH_THREAD_STATE);
     HANDLE_MACH_ERROR("thread_set_exception_ports", ret);
 }
@@ -810,7 +614,7 @@ void *mach_profile_listener(void *arg)
 {
     (void)arg;
     const int max_size = 512;
-    attach_exception_port(mach_thread_self(), 1);
+    attach_exception_port(mach_thread_self());
 #ifdef LLVMLIBUNWIND
     mach_profiler_thread = mach_thread_self();
 #endif

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -511,6 +511,14 @@ JL_NO_ASAN static void segv_handler(int sig, siginfo_t *info, void *context)
         return;
     }
     jl_task_t *ct = jl_get_current_task();
+    if (ct == NULL) {
+        // On macOS, __thread TLV storage is cleaned up before pthread TSD
+        // destructors run, so jl_get_current_task() returns NULL during
+        // jl_delete_thread. Use the TSD key to recover ptls directly.
+        jl_ptls_t ptls = jl_get_task_exit_ptls();
+        if (ptls != NULL)
+            ct = jl_atomic_load_relaxed(&ptls->current_task);
+    }
     if (ct == NULL || ct->ptls == NULL || jl_atomic_load_relaxed(&ct->ptls->gc_state) == JL_GC_STATE_WAITING) {
         sigdie_handler(sig, info, context);
         return;

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -158,10 +158,17 @@ extern void JL_NORETURN jl_fake_signal_return(void)
     abort();
 }
 #endif
+#endif // !defined(_OS_DARWIN_)
 
 static inline uintptr_t jl_get_rsp_from_ctx(const void *_ctx)
 {
-#if defined(_OS_LINUX_) && defined(_CPU_X86_64_)
+#if defined(_OS_DARWIN_) && defined(_CPU_X86_64_)
+    const ucontext64_t *ctx = (const ucontext64_t*)_ctx;
+    return ctx->uc_mcontext64->__ss.__rsp;
+#elif defined(_OS_DARWIN_) && defined(_CPU_AARCH64_)
+    const ucontext64_t *ctx = (const ucontext64_t*)_ctx;
+    return ctx->uc_mcontext64->__ss.__sp;
+#elif defined(_OS_LINUX_) && defined(_CPU_X86_64_)
     const ucontext_t *ctx = (const ucontext_t*)_ctx;
     return ctx->uc_mcontext.gregs[REG_RSP];
 #elif defined(_OS_LINUX_) && defined(_CPU_X86_)
@@ -199,6 +206,7 @@ static int is_addr_on_sigstack(jl_ptls_t ptls, void *ptr) JL_NOTSAFEPOINT
             (char*)ptr <= (char*)ptls->signal_stack + (ptls->signal_stack_size ? ptls->signal_stack_size : sig_stack_size));
 }
 
+#if !defined(_OS_DARWIN_)
 // Modify signal context `_ctx` so that `fptr` will execute when the signal returns
 // The function `fptr` itself must not return.
 JL_NO_ASAN static void jl_call_in_ctx(jl_ptls_t ptls, void (*fptr)(void), int sig, void *_ctx)
@@ -427,35 +435,18 @@ int exc_reg_is_write_fault(uintptr_t esr) {
 
 static int jl_thread_suspend_and_get_state(int tid, int timeout, bt_context_t *ctx);
 
-#if defined(HAVE_MACH)
-#include "signals-mach.c"
-#else
-#include <poll.h>
-#include <sys/eventfd.h>
-#include <link.h>
-
-typedef struct {
-    int16_t tid;
-    bt_context_t *ctx;
-    int success;
-} callback_data_t;
-static int with_dl_iterate_phdr_lock(struct dl_phdr_info *info, size_t size, void *data)
-{
-    jl_lock_profile();
-    callback_data_t *cb_data = (callback_data_t*)data;
-    cb_data->success = jl_thread_suspend_and_get_state(cb_data->tid, 1, cb_data->ctx);
-    jl_unlock_profile();
-    return 1; // only call this once
+// is_write_fault: determine from signal context whether this was a write fault
+#if defined(_OS_DARWIN_) && defined(_CPU_X86_64_)
+int is_write_fault(void *context) {
+    ucontext64_t *ctx = (ucontext64_t*)context;
+    return exc_reg_is_write_fault(ctx->uc_mcontext64->__es.__err);
 }
-
-int jl_thread_suspend(int16_t tid, bt_context_t *ctx)
-{
-    callback_data_t cb_data = {tid, ctx, 0};
-    dl_iterate_phdr(with_dl_iterate_phdr_lock, &cb_data);
-    return cb_data.success;
+#elif defined(_OS_DARWIN_) && defined(_CPU_AARCH64_)
+int is_write_fault(void *context) {
+    ucontext64_t *ctx = (ucontext64_t*)context;
+    return exc_reg_is_write_fault(ctx->uc_mcontext64->__es.__esr);
 }
-
-#if defined(_OS_LINUX_) && (defined(_CPU_X86_64_) || defined(_CPU_X86_))
+#elif defined(_OS_LINUX_) && (defined(_CPU_X86_64_) || defined(_CPU_X86_))
 int is_write_fault(void *context) {
     ucontext_t *ctx = (ucontext_t*)context;
     return exc_reg_is_write_fault(ctx->uc_mcontext.gregs[REG_ERR]);
@@ -524,7 +515,14 @@ JL_NO_ASAN static void segv_handler(int sig, siginfo_t *info, void *context)
         sigdie_handler(sig, info, context);
         return;
     }
-    if (sig == SIGSEGV && info->si_code == SEGV_ACCERR && jl_addr_is_safepoint((uintptr_t)info->si_addr) && !is_write_fault(context)) {
+    // On Linux, protection faults (e.g. safepoint PROT_NONE) arrive as SIGSEGV/SEGV_ACCERR.
+    // On macOS, they arrive as SIGBUS (XNU maps KERN_PROTECTION_FAILURE to SIGBUS).
+    int is_protection_fault =
+#if defined(_OS_DARWIN_)
+        (sig == SIGBUS) ||
+#endif
+        (sig == SIGSEGV && info->si_code == SEGV_ACCERR);
+    if (is_protection_fault && jl_addr_is_safepoint((uintptr_t)info->si_addr) && !is_write_fault(context)) {
         jl_set_gc_and_wait(ct);
         // Do not raise sigint on worker thread
         if (jl_atomic_load_relaxed(&ct->tid) != 0)
@@ -559,12 +557,40 @@ JL_NO_ASAN static void segv_handler(int sig, siginfo_t *info, void *context)
         jl_safe_printf("ERROR: Signal stack overflow, exit\n");
         jl_raise(sig);
     }
-    else if (sig == SIGSEGV && info->si_code == SEGV_ACCERR && is_write_fault(context)) {  // writing to read-only memory (e.g., mmap)
+    else if (is_protection_fault && is_write_fault(context)) {  // writing to read-only memory (e.g., mmap)
         jl_throw_in_ctx(ct, jl_readonlymemory_exception, sig, context);
     }
     else {
         sigdie_handler(sig, info, context);
     }
+}
+
+#if defined(HAVE_MACH)
+#include "signals-mach.c"
+#else
+#include <poll.h>
+#include <sys/eventfd.h>
+#include <link.h>
+
+typedef struct {
+    int16_t tid;
+    bt_context_t *ctx;
+    int success;
+} callback_data_t;
+static int with_dl_iterate_phdr_lock(struct dl_phdr_info *info, size_t size, void *data)
+{
+    jl_lock_profile();
+    callback_data_t *cb_data = (callback_data_t*)data;
+    cb_data->success = jl_thread_suspend_and_get_state(cb_data->tid, 1, cb_data->ctx);
+    jl_unlock_profile();
+    return 1; // only call this once
+}
+
+int jl_thread_suspend(int16_t tid, bt_context_t *ctx)
+{
+    callback_data_t cb_data = {tid, ctx, 0};
+    dl_iterate_phdr(with_dl_iterate_phdr_lock, &cb_data);
+    return cb_data.success;
 }
 
 pthread_mutex_t in_signal_lock; // shared with jl_delete_thread
@@ -861,9 +887,6 @@ static void allocate_segv_handler(void)
 
 void jl_install_thread_signal_handler(jl_ptls_t ptls)
 {
-#ifdef HAVE_MACH
-    attach_exception_port(pthread_mach_thread_np(ptls->system_id), 0);
-#endif
     stack_t ss;
     if (sigaltstack(NULL, &ss) < 0)
         jl_errorf("fatal error: sigaltstack: %s", strerror(errno));

--- a/src/threading.c
+++ b/src/threading.c
@@ -80,13 +80,8 @@ JL_DLLEXPORT void jl_set_safe_restore(jl_jmp_buf *sr)
 {
 #ifdef _OS_DARWIN_
     jl_task_t *ct = jl_get_current_task();
-    if (ct != NULL && ct->ptls) {
-        if (sr == NULL)
-            pthread_setspecific(jl_safe_restore_key, (void*)sr);
+    if (ct != NULL && ct->ptls)
         ct->ptls->safe_restore = sr;
-        if (sr == NULL)
-            return;
-    }
 #endif
     pthread_setspecific(jl_safe_restore_key, (void*)sr);
 }

--- a/src/threading.c
+++ b/src/threading.c
@@ -76,6 +76,11 @@ JL_DLLEXPORT jl_jmp_buf *jl_get_safe_restore(void)
     return (jl_jmp_buf*)pthread_getspecific(jl_safe_restore_key);
 }
 
+jl_ptls_t jl_get_task_exit_ptls(void) JL_NOTSAFEPOINT
+{
+    return (jl_ptls_t)pthread_getspecific(jl_task_exit_key);
+}
+
 JL_DLLEXPORT void jl_set_safe_restore(jl_jmp_buf *sr)
 {
 #ifdef _OS_DARWIN_
@@ -492,10 +497,13 @@ void _jl_free_stack(jl_ptls_t ptls, void *stkbuf, size_t bufsz) JL_NOTSAFEPOINT;
 
 static void jl_delete_thread(void *value) JL_NOTSAFEPOINT_ENTER
 {
-#ifndef _OS_WINDOWS_
-    pthread_setspecific(jl_task_exit_key, NULL);
-#endif
     jl_ptls_t ptls = (jl_ptls_t)value;
+#ifndef _OS_WINDOWS_
+    // On macOS __thread values like `jl_current_task` have already been cleaned
+    // up by now, so forward the PTLS to the GC safepoint logic (`jl_gc_*_enter`)
+    // via the task exit pthread key.
+    pthread_setspecific(jl_task_exit_key, value);
+#endif
     // safepoint until GC exit, in case GC was running concurrently while in
     // prior unsafe-region (before we let it release the stack memory)
     (void)jl_gc_unsafe_enter(ptls);
@@ -524,6 +532,10 @@ static void jl_delete_thread(void *value) JL_NOTSAFEPOINT_ENTER
     jl_free_thread_gc_state(ptls);
     // park in safe-region from here on (this may run GC again)
     (void)jl_gc_safe_enter(ptls);
+#ifndef _OS_WINDOWS_
+    // Clear the TSD key after the last safepoint operation.
+    pthread_setspecific(jl_task_exit_key, NULL);
+#endif
     // try to free some state we do not need anymore
 #ifndef _OS_WINDOWS_
     void *signal_stack = ptls->signal_stack;


### PR DESCRIPTION
This is a lot of extra code to use these ports as a special case on macOS (which we get to delete here).

Resolves this note in the previous design:
```
         // This also means we are not making this thread available for GC work. 
         // Eventually, we should probably release this signal to the original 
         // thread, (return KERN_FAILURE instead of KERN_SUCCESS) so that it 
         // triggers a SIGSEGV and gets handled by the usual codepath for unix.
```

However, the real motivation is https://github.com/JuliaLang/julia/pull/61294.

Since these exception ports are registered per-thread there is quite a bit of state to manage when chaining signal handlers together. It is not infeasible to do that chaining (we can implement it if we like), but the better choice here may be to make the signal handling on all Unix platforms uniform, which is what Java's Hotspot VM does as well.