### PR TITLE
Fix irrational raised to a non-literal negative integer power

### DIFF
--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -200,7 +200,7 @@ for op in Symbol[:+, :-, :*, :/, :^]
 end
 *(x::Bool, y::AbstractIrrational) = ifelse(x, Float64(y), 0.0)
 
-^(x::AbstractIrrational, y::Integer) = ^(promote(x,y)...)
+^(x::AbstractIrrational, y::Integer) = float(x)^y
 
 round(x::Irrational, r::RoundingMode) = round(float(x), r)
 

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -200,6 +200,8 @@ for op in Symbol[:+, :-, :*, :/, :^]
 end
 *(x::Bool, y::AbstractIrrational) = ifelse(x, Float64(y), 0.0)
 
+^(x::AbstractIrrational, y::Integer) = ^(promote(x,y)...)
+
 round(x::Irrational, r::RoundingMode) = round(float(x), r)
 
 """

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -3353,9 +3353,9 @@ end
     end
 end
 
-@testset "irrational negative integer power" begin
+@testset "irrational negative integer power (#61284)" begin
     p = -2 # test non literal power
     for x in (π, ℯ, γ, catalan, φ)
-        @test x^p == ^(promote(x,p)...)
+        @test x^p == float(x)^p
     end
 end

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -3352,3 +3352,10 @@ end
         @test v === typemin(v) === typemax(v)
     end
 end
+
+@testset "irrational negative integer power" begin
+    p = -2 # test non literal power
+    for x in (π, ℯ, γ, catalan, φ)
+        @test x^p == ^(promote(x,p)...)
+    end
+end


### PR DESCRIPTION
Fixes #61284.

`^(x::AbstractIrrational, y::Integer)` was hitting (non-explicitly) `^(x::Number, p::Integer) = power_by_squaring(x,p)`.
Use `float(x)^p` which has a specialized method `^(x::Float64, n::Integer)`.