### PR TITLE
Artifacts: remove undocumented `pkg_uuid` kwarg from `artifact_hash`

### DIFF
--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -443,8 +443,7 @@ collapsed artifact.  Returns `nothing` if no mapping can be found.
     This function requires at least Julia 1.3.
 """
 function artifact_hash(name::String, artifacts_toml::String;
-                       platform::AbstractPlatform = HostPlatform(),
-                       pkg_uuid::Union{Base.UUID,Nothing}=nothing)::Union{Nothing, SHA1}
+                       platform::AbstractPlatform = HostPlatform())::Union{Nothing, SHA1}
     meta = artifact_meta(name, artifacts_toml; platform=platform)
     if meta === nothing
         return nothing


### PR DESCRIPTION
🤖 Discovered via automated Codex audit.

`artifact_hash` accepts a `pkg_uuid` keyword argument, but that keyword is undocumented and not part of the behavior we want to expose.

This PR removes the `pkg_uuid` keyword from `artifact_hash` so the public API matches the implementation and documentation.

🤖 Co-authored-by: Codex.