### PR TITLE
InteractiveUtils: In `edit(m::Module)`, throw a more informative error when `pathof(m)` is nothing

### DIFF
--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -272,7 +272,11 @@ edit(@nospecialize(f), idx::Integer) = edit(methods(f).ms[idx])
 edit(f, t) = (@nospecialize; edit(functionloc(f, t)...))
 edit(@nospecialize argtypes::Union{Tuple, Type{<:Tuple}}) = edit(functionloc(argtypes)...)
 edit(file::Nothing, line::Integer) = error("could not find source file for function")
-edit(m::Module) = edit(pathof(m))
+function edit(m::Module)
+    path = pathof(m)
+    path === nothing && error("could not find source file for module: $m")
+    edit(path)
+end
 
 # terminal pager
 

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -837,6 +837,10 @@ file, ln = functionloc(versioninfo, Tuple{})
 @test isfile(pathof(InteractiveUtils))
 @test isdir(pkgdir(InteractiveUtils))
 
+module ModuleWithoutPathForEdit
+end
+@test_throws ErrorException("could not find source file for module: $(ModuleWithoutPathForEdit)") edit(ModuleWithoutPathForEdit)
+
 # compiler stdlib path updating
 file, ln = functionloc(Core.Compiler.tmeet, Tuple{Int, Float64})
 @test isfile(file)


### PR DESCRIPTION
🤖 Discovered via automated Codex audit.

Before this PR, `edit(m::Module)` will throw a relatively unhelpful error if `pathof(m)` is nothing:

```julia
julia> module MyModule end

julia> InteractiveUtils.edit(MyModule)
ERROR: object is not callable
Stacktrace:
```

After this PR, it throws a more useful error.

🤖 Co-authored-by: Codex