### PR TITLE
JuliaSyntax: parse `typegroup` as identifier on older Julia versions

### DIFF
--- a/JuliaSyntax/src/julia/parser.jl
+++ b/JuliaSyntax/src/julia/parser.jl
@@ -251,7 +251,15 @@ function is_initial_reserved_word(ps::ParseState, k)
                             macro quote let local global const do struct typegroup module
                             baremodule using import export"
     # `begin` means firstindex(a) inside a[...]
-    return is_iresword && !(k == K"begin" && ps.end_symbol)
+    if k == K"begin" && ps.end_symbol
+        return false
+    end
+    # `typegroup` is only a keyword in Julia >= 1.14
+    # N.B: In some cases, we parse as typegroup anyway for error recovery - see below
+    if k == K"typegroup" && ps.stream.version < (1, 14)
+        return false
+    end
+    return is_iresword
 end
 
 function is_reserved_word(k)
@@ -270,6 +278,12 @@ function peek_initial_reserved_words(ps::ParseState)
         return (k == K"mutable"   && k2 == K"struct") ||
                (k == K"primitive" && k2 == K"type")   ||
                (k == K"abstract"  && k2 == K"type")
+    elseif k == K"typegroup" && ps.stream.version < (1, 14)
+        # On older versions, typegroup is an identifier. But if followed by
+        # a type definition keyword (which would be a syntax error in old
+        # Julia due to juxtaposition), parse as typegroup for error recovery.
+        k2 = peek(ps, 2, skip_newlines=false)
+        return k2 in KSet"struct mutable abstract primitive @ \" \"\"\""
     else
         return false
     end

--- a/JuliaSyntax/test/parser.jl
+++ b/JuliaSyntax/test/parser.jl
@@ -1201,6 +1201,12 @@ parsestmt_test_specs = [
     "(x for x = xs a)"      =>  "(parens (generator x (iteration (in x xs))) (error-t a))"
     "(x for x = xs a, b)"   =>  "(parens (generator x (iteration (in x xs))) (error-t a ✘ b))"
     "f(x for x = xs a)"     =>  "(call f (generator x (iteration (in x xs))) (error-t a))"
+
+    # typegroup as identifier on older versions
+    ((v=v"1.12",), "typegroup = 3")  =>  "(= typegroup 3)"
+    ((v=v"1.12",), "let typegroup = 3 end")  =>  "(let (block (= typegroup 3)) (block))"
+    # typegroup error recovery on older versions (would be a syntax error anyway)
+    ((v=v"1.12",), "typegroup struct A end end")  =>  "(error (typegroup (block (struct A (block)))))"
 ]
 
 @testset "Parsestmt tests" begin


### PR DESCRIPTION
On Julia versions < 1.14, `typegroup` is treated as an ordinary identifier rather than a reserved keyword. This fixes parsing of code like `let typegroup = 3 end` when targeting older versions.

We had not previously defined our syntax evolution policies for addition for new keywords. My proposal, implemented in this PR is as follows:

- Where the old syntax parsed, keep providing the same parse result
- Where the new syntax would be a syntax error in the old syntax version, attempt to parse as the new syntax (and then wrap it in the version error). This provides better error messages and error recovery when attempting to use new syntax in an old syntax version.

Implements post-commit review from https://github.com/JuliaLang/julia/pull/60569#discussion_r2925201976