### PR TITLE
AGENTS.md: Add instructions regarding backticks inside commit messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,11 @@ of the purpose of the changes made. Do not specifically mention added tests, com
 documentation, etc., unless this is the main purpose of the change. Do not mention
 the test plan, unless it differs from what you were instructed to do in AGENTS.md.
 If your change fixes one or more issues, use the syntax "Fixes #" at the end of the commit message, but do not include it in the title.
+When invoking `git commit` from the shell, avoid shell-sensitive formatting in inline
+`-m` arguments. In particular, do not use backticks inside double-quoted commit
+message text, since the shell will treat them as command substitution. Prefer plain
+text in inline commit bodies, or use a message file / other mechanism that bypasses
+shell interpolation when exact formatting is required.
 
 When referencing external GitHub PRs or issues, use proper GitHub interlinking format (e.g., `owner/repo#123` for PRs/issues).
 When fixing CI failures, include the link to the specific CI failure in the commit message.


### PR DESCRIPTION
I'm not sure if this is Codex-specific or not, but Codex keeps trying to run `git commit -m` with backticks inside the commit message, and the shell eats up the backticks before it gets to Git. So I thought it might be useful to have something in `AGENTS.md` to address this.

Alternatively, folks could instead add this content to their global `~/.claude/CLAUDE.md` or `~/.codex/AGENTS.md`, but I thought it'd be convenient to have it in the repo.

🤖 Co-authored-by: Codex.
