### PR TITLE
Libdl: In `Libdl.dlpath`, throw an ArgumentError if the handle is `C_NULL`

### DIFF
--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -223,6 +223,7 @@ find_library(libname::Union{Symbol,AbstractString}, extrapaths=String[]) =
 Given a library `handle` from `dlopen`, return the full path.
 """
 function dlpath(handle::Ptr{Cvoid})
+    handle == C_NULL && throw(ArgumentError("NULL library handle"))
     p = ccall(:jl_pathname_for_handle, Cstring, (Ptr{Cvoid},), handle)
     s = unsafe_string(p)
     Sys.iswindows() && Libc.free(p)

--- a/stdlib/Libdl/test/runtests.jl
+++ b/stdlib/Libdl/test/runtests.jl
@@ -28,6 +28,7 @@ end
 # library handle pointer must not be NULL
 @test_throws ArgumentError Libdl.dlsym(C_NULL, :foo)
 @test_throws ArgumentError Libdl.dlsym_e(C_NULL, :foo)
+@test_throws ArgumentError Libdl.dlpath(C_NULL)
 
 # Find the library directory by finding the path of libjulia-internal (or libjulia-internal-debug,
 # as the case may be) to get the private library directory


### PR DESCRIPTION
🤖 Discovered by Codex during an audit.

Other functions in Libdl (such as `Libdl.dlsym`) already include a check for `C_NULL`. For example:

https://github.com/JuliaLang/julia/blob/bc4bb7ae9a49808a929917d921e597906a9f30cb/base/libdl.jl#L59-L60

So this PR adds a `C_NULL` check to `Libdl.dlpath`, and (similar to `Libdl.dlsym`), throws an `ArgumentError`.

🤖 Co-authored-by: Codex.