### PR TITLE
RFC/WIP: Split `Union` to memoize hasuniquerep

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1346,14 +1346,14 @@ end
 end
 @nospecs function modifyfield!_tfunc(𝕃::AbstractLattice, o, f, op, v, order=Symbol)
     o′ = widenconst(o)
-    T = _fieldtype_tfunc(𝕃, o′, f, isconcretetype(o′))
+    T = _fieldtype_tfunc(𝕃, o′, f, isconcretetype(o′), isa(o, Const) || hasuniquerep(o′))
     T === Bottom && return Bottom
     PT = Const(Pair)
     return instanceof_tfunc(apply_type_tfunc(𝕃, Any[PT, T, T]), true)[1]
 end
 @nospecs function replacefield!_tfunc(𝕃::AbstractLattice, o, f, x, v, success_order=Symbol, failure_order=Symbol)
     o′ = widenconst(o)
-    T = _fieldtype_tfunc(𝕃, o′, f, isconcretetype(o′))
+    T = _fieldtype_tfunc(𝕃, o′, f, isconcretetype(o′), isa(o, Const) || hasuniquerep(o′))
     T === Bottom && return Bottom
     PT = Const(ccall(:jl_apply_cmpswap_type, Any, (Any,), T) where T)
     return instanceof_tfunc(apply_type_tfunc(𝕃, Any[PT, T]), true)[1]
@@ -1540,17 +1540,17 @@ end
 
     s, exact = instanceof_tfunc(s0, false)
     s === Bottom && return Bottom
-    return _fieldtype_tfunc(𝕃, s, name, exact)
+    return _fieldtype_tfunc(𝕃, s, name, exact, isa(s0, Const) || hasuniquerep(s0))
 end
 
-@nospecs function _fieldtype_tfunc(𝕃::AbstractLattice, s, name, exact::Bool)
+@nospecs function _fieldtype_tfunc(𝕃::AbstractLattice, s, name, exact::Bool, s_uniquerep::Bool=false)
     exact = exact && !has_free_typevars(s)
     u = unwrap_unionall(s)
     if isa(u, Union)
-        ta0 = _fieldtype_tfunc(𝕃, rewrap_unionall(u.a, s), name, exact)
-        tb0 = _fieldtype_tfunc(𝕃, rewrap_unionall(u.b, s), name, exact)
-        ta0 ⊑ tb0 && return tb0
-        tb0 ⊑ ta0 && return ta0
+        ta0 = _fieldtype_tfunc(𝕃, rewrap_unionall(u.a, s), name, exact, s_uniquerep)
+        tb0 = _fieldtype_tfunc(𝕃, rewrap_unionall(u.b, s), name, exact, s_uniquerep)
+        ⊑(𝕃, ta0, tb0) && return tb0
+        ⊑(𝕃, tb0, ta0) && return ta0
         ta, exacta, _, istypea = instanceof_tfunc(ta0, false)
         tb, exactb, _, istypeb = instanceof_tfunc(tb0, false)
         if exact && exacta && exactb
@@ -1630,15 +1630,16 @@ end
         return Const(ft)
     end
 
-    exactft = exact || (!has_free_typevars(ft) && u.name !== Tuple.name)
+    exactft = !has_free_typevars(ft)
     ft = rewrap_unionall(ft, s)
-    if exactft
+    if exact && s_uniquerep
+        return Const(ft)
+    elseif exact || (exactft && u.name !== Tuple.name)
         if hasuniquerep(ft)
             return Const(ft) # ft unique via type cache
         end
         return Type{ft}
-    end
-    if u.name === Tuple.name && ft === Any
+    elseif u.name === Tuple.name && ft === Any
         # Tuple{:x} is possible
         return Any
     end

--- a/Compiler/src/typeutils.jl
+++ b/Compiler/src/typeutils.jl
@@ -17,6 +17,9 @@ function hasuniquerep(@nospecialize t)
     isa(t, TypeVar) && return false # TypeVars are identified by address, not equality
     iskindtype(typeof(t)) || return true # non-types are always compared by egal in the type system
     isconcretetype(t) && return true # these are also interned and pointer comparable
+    if isa(t, Union)
+        return ccall(:jl_union_hasuniquerep, Int32, (Any,), t) != 0
+    end
     if isa(t, DataType) && t.name !== Tuple.name && !isvarargtype(t) # invariant DataTypes
         return all(hasuniquerep, t.parameters)
     end

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -655,6 +655,19 @@ f18450() = ifelse(true, Tuple{Vararg{Int}}, Tuple{Vararg})
 # issue #18569
 @test !Compiler.isconstType(Type{Tuple})
 
+# hasuniquerep: Union types with canonicalizable components
+@test Compiler.hasuniquerep(Union{Int64, Float64})
+@test Compiler.hasuniquerep(Union{Int8, Int16, Int32})
+@test Compiler.hasuniquerep(Union{Vector{Int}, Vector{Float64}})
+# Union sort comparator (datatype_name_cmp) gives up on non-DataType parameters,
+# so types like Val{1} vs Val{2} are not distinguishable and the sort does not
+# canonicalize them — Union{Val{1},Val{2}} and Union{Val{2},Val{1}} are
+# typeequal but not egal.
+@test !Compiler.hasuniquerep(Union{Val{1}, Val{2}})
+@test !Compiler.hasuniquerep(Union{Val{:a}, Val{:b}})
+# Wrapper UnionAlls are not uniquerep: Ref == Union{Ref{T}, Ref{S}} where {S, S<:T<:S}
+@test !Compiler.hasuniquerep(Ref)
+
 # issue #10880
 function cat10880(a, b)
     Tuple{a.parameters..., b.parameters...}
@@ -795,6 +808,8 @@ let fieldtype_tfunc(@nospecialize args...) =
     @test fieldtype_tfunc(Union{Type{Base.RefValue{<:Real}}, Type{Int32}}, Const(:x)) == Const(Real)
     @test fieldtype_tfunc(Const(Union{Base.RefValue{<:Real}, Type{Int32}}), Const(:x)) == Const(Real)
     @test fieldtype_tfunc(Type{Union{Base.RefValue{T}, Type{Int32}}} where {T<:Real}, Const(:x)) == Type{<:Real}
+    @test fieldtype_tfunc(Const(Base.RefValue{Union{Int64, Float64}}), Const(:x)) == Const(Union{Int64, Float64})
+    @test fieldtype_tfunc(Const(Base.RefValue{Vector{<:Integer}}), Const(:x)) isa Const
     @test fieldtype_tfunc(Type{<:Tuple}, Const(1)) == Any
     @test fieldtype_tfunc(Type{<:Tuple}, Any) == Any
     @test fieldtype_nothrow(Type{Base.RefValue{<:Real}}, Const(:x))
@@ -1374,7 +1389,7 @@ let isa_tfunc(@nospecialize xs...) =
     @test isa_tfunc(DataType, Const(Type{Array})) === Bool
     @test isa_tfunc(UnionAll, Const(Type{Int})) === Bool # could be improved
     @test isa_tfunc(UnionAll, Const(Type{Array})) === Bool
-    @test isa_tfunc(Union, Const(Union{Float32, Float64})) === Bool
+    @test isa_tfunc(Union, Const(Union{Float32, Float64})) === Const(false)
     @test isa_tfunc(Union, Type{Union}) === Const(true)
     @test isa_tfunc(typeof(Union{}), Const(Int)) === Const(false)
     @test isa_tfunc(typeof(Union{}), Const(Union{})) === Const(false)
@@ -2823,11 +2838,11 @@ end |> only === Int
 @test (() -> NamedTuple{(), <:Any})() isa UnionAll
 
 # Don't pessimize apply_type to anything worse than Type (or TypeVar) and yield Bottom for invalid Unions
-@test only(Base.return_types(Core.apply_type, Tuple{Type{Union}})) == Type{Union{}}
-@test only(Base.return_types(Core.apply_type, Tuple{Type{Union},Any})) == Union{Type,TypeVar}
-@test only(Base.return_types(Core.apply_type, Tuple{Type{Union},Any,Any})) == Type
-@test only(Base.return_types(Core.apply_type, Tuple{Type{Union},Int})) == Union{}
-@test only(Base.return_types(Core.apply_type, Tuple{Type{Union},Any,Int})) == Union{}
+@test only(Base.return_types(Core.apply_type, Tuple{Type{Union}})) == Any
+@test only(Base.return_types(Core.apply_type, Tuple{Type{Union},Any})) == Any
+@test only(Base.return_types(Core.apply_type, Tuple{Type{Union},Any,Any})) == Any
+@test only(Base.return_types(Core.apply_type, Tuple{Type{Union},Int})) == Any
+@test only(Base.return_types(Core.apply_type, Tuple{Type{Union},Any,Int})) == Any
 @test only(Base.return_types(Core.apply_type, Tuple{Any})) == Any
 @test only(Base.return_types(Core.apply_type, Tuple{Any,Any})) == Any
 

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -993,7 +993,8 @@ or [`Core.TypeofBottom`](@ref).
 
 All kinds are [concrete](@ref isconcretetype) because types are Julia values.
 """
-iskindtype(@nospecialize t) = (t === DataType || t === UnionAll || t === Union || t === typeof(Bottom))
+iskindtype(@nospecialize t) = (t === DataType || t === UnionAll || t === typeof(Bottom) ||
+                              (t isa DataType && t.name === Union.body.name))
 
 """
     Base.isconcretedispatch(T)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1138,6 +1138,14 @@ function maybe_kws_nt(x::DataType)
 end
 
 function show_datatype(io::IO, x::DataType, wheres::Vector{TypeVar}=TypeVar[])
+    # Display concrete Union specializations by their canonical Core binding names
+    if x === Core.UniqueUnion
+        print(io, "UniqueUnion")
+        return
+    elseif x === Core.NonUniqueUnion
+        print(io, "NonUniqueUnion")
+        return
+    end
     parameters = x.parameters::SimpleVector
     istuple = x.name === Tuple.name
     isnamedtuple = x.name === typename(NamedTuple)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -206,7 +206,7 @@ static int egal_types(const jl_value_t *a, const jl_value_t *b, jl_typeenv_t *en
         jl_typeenv_t e = { ua->var, (jl_value_t*)ub->var, env };
         return egal_types(ua->body, ub->body, &e, tvar_names);
     }
-    if (dtag == jl_uniontype_tag << 4) {
+    if (dtag == jl_uniontype_tag << 4 || dtag == jl_unique_uniontype_tag << 4) {
         return egal_types(((jl_uniontype_t*)a)->a, ((jl_uniontype_t*)b)->a, env, tvar_names) &&
             egal_types(((jl_uniontype_t*)a)->b, ((jl_uniontype_t*)b)->b, env, tvar_names);
     }
@@ -288,7 +288,8 @@ JL_DLLEXPORT int jl_egal__bitstag(const jl_value_t *a JL_MAYBE_UNROOTED, const j
         case jl_unionall_tag:
             return egal_types(a, b, NULL, 1);
         case jl_uniontype_tag:
-            return compare_fields(a, b, jl_uniontype_type);
+        case jl_unique_uniontype_tag:
+            return compare_fields(a, b, jl_nonunique_uniontype_type);
         case jl_vararg_tag:
             return compare_fields(a, b, jl_vararg_type);
         case jl_task_tag:
@@ -399,7 +400,7 @@ static uintptr_t type_object_id_(jl_value_t *v, jl_varidx_t *env) JL_NOTSAFEPOIN
             return ((uintptr_t*)v)[-2];
         return inthash((uintptr_t)v);
     }
-    if (tv == jl_uniontype_type) {
+    if (tv == jl_nonunique_uniontype_type || tv == jl_unique_uniontype_type) {
         return bitmix(bitmix(jl_object_id((jl_value_t*)tv),
                              type_object_id_(((jl_uniontype_t*)v)->a, env)),
                       type_object_id_(((jl_uniontype_t*)v)->b, env));
@@ -512,6 +513,8 @@ static uintptr_t NOINLINE jl_object_id__cold(uintptr_t tv, jl_value_t *v) JL_NOT
             return ((uintptr_t*)v)[-2];
         return inthash((uintptr_t)v);
     }
+    if (dt == jl_nonunique_uniontype_type || dt == jl_unique_uniontype_type)
+        return type_object_id_(v, NULL);
     return immut_id_(dt, v, dt->hash);
 }
 
@@ -1663,7 +1666,9 @@ JL_CALLABLE(jl_f_apply_type)
         }
         return jl_apply_tuple_type_v(&args[1], nargs-1);
     }
-    else if (args[0] == (jl_value_t*)jl_uniontype_type) {
+    else if (args[0] == (jl_value_t*)jl_uniontype_type ||
+             args[0] == (jl_value_t*)jl_nonunique_uniontype_type ||
+             args[0] == (jl_value_t*)jl_unique_uniontype_type) {
         // Union{} has extra restrictions, so it needs to be checked after
         // substituting typevars (a valid_type_param check here isn't sufficient).
         return (jl_value_t*)jl_type_union(&args[1], nargs-1);
@@ -2593,6 +2598,8 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("TypeVar", (jl_value_t*)jl_tvar_type);
     add_builtin("UnionAll", (jl_value_t*)jl_unionall_type);
     add_builtin("Union", (jl_value_t*)jl_uniontype_type);
+    add_builtin("UniqueUnion", (jl_value_t*)jl_unique_uniontype_type);
+    add_builtin("NonUniqueUnion", (jl_value_t*)jl_nonunique_uniontype_type);
     add_builtin("TypeofBottom", (jl_value_t*)jl_typeofbottom_type);
     add_builtin("Tuple", (jl_value_t*)jl_anytuple_type);
     add_builtin("TypeofVararg", (jl_value_t*)jl_vararg_type);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2101,7 +2101,9 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
         Value *typ = emit_typeof(ctx, x, false, true);
         auto val = ctx.builder.CreateOr(
             ctx.builder.CreateOr(
-                ctx.builder.CreateICmpEQ(typ, emit_tagfrom(ctx, jl_uniontype_type)),
+                ctx.builder.CreateOr(
+                    ctx.builder.CreateICmpEQ(typ, emit_tagfrom(ctx, jl_nonunique_uniontype_type)),
+                    ctx.builder.CreateICmpEQ(typ, emit_tagfrom(ctx, jl_unique_uniontype_type))),
                 ctx.builder.CreateICmpEQ(typ, emit_tagfrom(ctx, jl_datatype_type))),
             ctx.builder.CreateOr(
                 ctx.builder.CreateICmpEQ(typ, emit_tagfrom(ctx, jl_unionall_type)),

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3626,7 +3626,8 @@ static Value *emit_box_compare(jl_codectx_t &ctx, const jl_cgval_t &arg1, const 
         Value *neq = ctx.builder.CreateICmpNE(varg1, varg2);
         return emit_guarded_test(ctx, neq, true, [&] {
             Value *dtarg = emit_typeof(ctx, arg1, false, true);
-            Value *dt_eq = ctx.builder.CreateICmpEQ(dtarg, emit_typeof(ctx, arg2, false, true));
+            Value *dtarg2 = emit_typeof(ctx, arg2, false, true);
+            Value *dt_eq = ctx.builder.CreateICmpEQ(dtarg, dtarg2);
             return emit_guarded_test(ctx, dt_eq, false, [&] {
                 return ctx.builder.CreateTrunc(ctx.builder.CreateCall(prepare_call(jlegalx_func),
                                                                       {varg1, varg2, dtarg}), getInt1Ty(ctx.builder.getContext()));

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -1575,6 +1575,7 @@ STATIC_INLINE void gc_assert_parent_validity(jl_value_t *parent, jl_value_t *chi
     if (child_vt == (jl_datatype_tag << 4) ||
         child_vt == (jl_unionall_tag << 4) ||
         child_vt == (jl_uniontype_tag << 4) ||
+        child_vt == (jl_unique_uniontype_tag << 4) ||
         child_vt == (jl_tvar_tag << 4) ||
         child_vt == (jl_vararg_tag << 4)) {
         // Skip, since these wouldn't hit the object assert anyway
@@ -2275,6 +2276,7 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
         if (vtag == (jl_datatype_tag << 4) ||
             vtag == (jl_unionall_tag << 4) ||
             vtag == (jl_uniontype_tag << 4) ||
+            vtag == (jl_unique_uniontype_tag << 4) ||
             vtag == (jl_tvar_tag << 4) ||
             vtag == (jl_vararg_tag << 4) ||
             vtag == (jl_globalref_tag << 4) ||
@@ -2872,6 +2874,10 @@ static void gc_mark_roots(jl_gc_markqueue_t *mq) JL_NOTSAFEPOINT
     // constants
     gc_try_claim_and_push(mq, jl_emptytuple_type, NULL);
     gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_emptytuple_type, "emptytuple_type");
+    gc_try_claim_and_push(mq, jl_nonunique_uniontype_type, NULL);
+    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_nonunique_uniontype_type, "nonunique_uniontype_type");
+    gc_try_claim_and_push(mq, jl_unique_uniontype_type, NULL);
+    gc_heap_snapshot_record_gc_roots((jl_value_t*)jl_unique_uniontype_type, "unique_uniontype_type");
     gc_try_claim_and_push(mq, cmpswap_names, NULL);
     gc_heap_snapshot_record_gc_roots((jl_value_t*)cmpswap_names, "cmpswap_names");
     gc_try_claim_and_push(mq, jl_global_roots_list, NULL);

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1658,6 +1658,7 @@ void jl_init_serializer(void)
                      jl_vararg_type,
                      jl_densearray_type, jl_function_type, jl_typename_type,
                      jl_builtin_type, jl_task_type, jl_uniontype_type,
+                     jl_unique_uniontype_type, jl_nonunique_uniontype_type,
                      jl_array_any_type, jl_intrinsic_type,
                      jl_voidpointer_type, jl_newvarnode_type, jl_abstractstring_type,
                      jl_array_symbol_type, jl_anytuple_type, jl_tparam0(jl_anytuple_type),

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -141,7 +141,9 @@
     XX(undefvarerror_type, jl_datatype_t*) \
     XX(fielderror_type, jl_datatype_t*) \
     XX(unionall_type, jl_datatype_t*) \
-    XX(uniontype_type, jl_datatype_t*) \
+    XX(uniontype_type, jl_unionall_t*) \
+    XX(unique_uniontype_type, jl_datatype_t*) \
+    XX(nonunique_uniontype_type, jl_datatype_t*) \
     XX(upsilonnode_type, jl_datatype_t*) \
     XX(vararg_type, jl_datatype_t*) \
     XX(vecelement_typename, jl_typename_t*) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -479,6 +479,7 @@
     XX(jl_method_morespecific) \
     XX(jl_type_union) \
     XX(jl_type_unionall) \
+    XX(jl_union_hasuniquerep) \
     XX(jl_unbox_bool) \
     XX(jl_unbox_float32) \
     XX(jl_unbox_float64) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -566,19 +566,75 @@ static void flatten_type_union(jl_value_t **types, size_t n, jl_value_t **out, s
 }
 
 
-static void isort_union(jl_value_t **a, size_t len) JL_NOTSAFEPOINT
+// Sort union components and report whether the ordering is fully deterministic.
+// Returns 1 if all distinct non-NULL pairs were distinguishable by the comparator
+// (i.e. no ties between non-identical elements), 0 otherwise.
+static int isort_union(jl_value_t **a, size_t len) JL_NOTSAFEPOINT
 {
+    int deterministic = 1;
     size_t i, j;
     for (i = 1; i < len; i++) {
         jl_value_t *x = a[i];
         for (j = i; j > 0; j--) {
             jl_value_t *y = a[j - 1];
-            if (!(union_sort_cmp(x, y) < 0))
+            int cmp = union_sort_cmp(x, y);
+            if (cmp == 0 && x != NULL && y != NULL && x != y)
+                deterministic = 0;
+            if (!(cmp < 0))
                 break;
             a[j] = y;
         }
         a[j] = x;
     }
+    return deterministic;
+}
+
+// Allocate a union node with the given small tag (jl_uniontype_tag or jl_unique_uniontype_tag).
+static jl_value_t *jl_new_union_node(int smalltag, jl_value_t *a, jl_value_t *b)
+{
+    jl_task_t *ct = jl_current_task;
+    jl_datatype_t *dt = (smalltag == jl_unique_uniontype_tag) ?
+        jl_unique_uniontype_type : jl_nonunique_uniontype_type;
+    jl_value_t *u = jl_gc_alloc(ct->ptls, sizeof(jl_uniontype_t), dt);
+    jl_set_typetagof(u, smalltag, 0);
+    ((jl_uniontype_t*)u)->a = a;
+    jl_gc_wb(u, a);
+    ((jl_uniontype_t*)u)->b = b;
+    jl_gc_wb(u, b);
+    return u;
+}
+
+// Test whether type t has a unique representation, s.t. T == S implies T === S.
+// This mirrors the Julia-level hasuniquerep (Compiler/src/typeutils.jl).
+int type_has_uniquerep(jl_value_t *t) JL_NOTSAFEPOINT
+{
+    if (t == (jl_value_t*)jl_typeofbottom_type)
+        return 0; // typeof(Union{}) is special
+    if (t == jl_bottom_type)
+        return 1;
+    if (jl_is_typevar(t))
+        return 0; // TypeVars are identified by address
+    if (!jl_is_type(t))
+        return 1; // non-types are always compared by egal
+    if (jl_is_concrete_type(t))
+        return 1; // concrete types are interned
+    if (jl_is_uniontype(t)) {
+        // For unions, the tag tells us: unique_uniontype means uniquerep
+        return jl_typetagof(t) == (jl_unique_uniontype_tag << 4);
+    }
+    if (jl_is_datatype(t)) {
+        jl_datatype_t *dt = (jl_datatype_t*)t;
+        if (dt->name == jl_tuple_typename || jl_is_vararg((jl_value_t*)dt))
+            return 0;
+        // invariant DataTypes: check all parameters
+        size_t i, l = jl_nparams(dt);
+        for (i = 0; i < l; i++) {
+            if (!type_has_uniquerep(jl_tparam(dt, i)))
+                return 0;
+        }
+        return 1;
+    }
+    return 0;
 }
 
 static int simple_subtype(jl_value_t *a, jl_value_t *b, int hasfree, int isUnion)
@@ -665,6 +721,13 @@ STATIC_INLINE void merge_vararg_unions(jl_value_t **temp, size_t nt)
     }
 }
 
+// Returns 1 if the union type has unique representation (tagged as unique_uniontype),
+// meaning T == S implies T === S for this union type.
+JL_DLLEXPORT int jl_union_hasuniquerep(jl_value_t *v) JL_NOTSAFEPOINT
+{
+    return jl_is_uniontype(v) && jl_typetagof(v) == (jl_unique_uniontype_tag << 4);
+}
+
 JL_DLLEXPORT jl_value_t *jl_type_union(jl_value_t **ts, size_t n)
 {
     if (n == 0)
@@ -695,8 +758,30 @@ JL_DLLEXPORT jl_value_t *jl_type_union(jl_value_t **ts, size_t n)
             }
         }
     }
-    isort_union(temp, nt);
+    int deterministic = isort_union(temp, nt);
     merge_vararg_unions(temp, nt);
+    // Determine if the union has unique representation:
+    // sort must be deterministic AND all components must have uniquerep.
+    int uniquerep = deterministic;
+    if (uniquerep) {
+        int ntuples = 0;
+        for (i = 0; i < nt; i++) {
+            if (temp[i] != NULL) {
+                if (!type_has_uniquerep(temp[i])) {
+                    uniquerep = 0;
+                    break;
+                }
+                // Tuples are covariant, so Union{Tuple{A,...}, Tuple{B,...}} can be type-equal
+                // to Tuple{Union{A,B},...} (a non-Union). Limit to at most one tuple to preserve
+                // the UniqueUnion invariant that type-equal implies egal.
+                if (jl_is_datatype(temp[i]) && ((jl_datatype_t*)temp[i])->name == jl_tuple_typename)
+                    ntuples++;
+            }
+        }
+        if (ntuples > 1)
+            uniquerep = 0;
+    }
+    int tag = uniquerep ? jl_unique_uniontype_tag : jl_uniontype_tag;
     jl_value_t **ptu = &temp[nt];
     *ptu = jl_bottom_type;
     int k;
@@ -705,7 +790,7 @@ JL_DLLEXPORT jl_value_t *jl_type_union(jl_value_t **ts, size_t n)
             if (*ptu == jl_bottom_type)
                 *ptu = temp[k];
             else
-                *ptu = jl_new_struct(jl_uniontype_type, temp[k], *ptu);
+                *ptu = jl_new_union_node(tag, temp[k], *ptu);
         }
     }
     assert(*ptu != NULL);
@@ -801,8 +886,25 @@ jl_value_t *simple_union(jl_value_t *a, jl_value_t *b)
             }
         }
     }
-    isort_union(temp, nt);
+    int deterministic = isort_union(temp, nt);
     merge_vararg_unions(temp, nt);
+    int uniquerep = deterministic;
+    if (uniquerep) {
+        int ntuples = 0;
+        for (i = 0; i < nt; i++) {
+            if (temp[i] != NULL) {
+                if (!type_has_uniquerep(temp[i])) {
+                    uniquerep = 0;
+                    break;
+                }
+                if (jl_is_datatype(temp[i]) && ((jl_datatype_t*)temp[i])->name == jl_tuple_typename)
+                    ntuples++;
+            }
+        }
+        if (ntuples > 1)
+            uniquerep = 0;
+    }
+    int tag = uniquerep ? jl_unique_uniontype_tag : jl_uniontype_tag;
     temp[nt] = jl_bottom_type;
     size_t k;
     for (k = nt; k-- > 0; ) {
@@ -810,7 +912,7 @@ jl_value_t *simple_union(jl_value_t *a, jl_value_t *b)
             if (temp[nt] == jl_bottom_type)
                 temp[nt] = temp[k];
             else
-                temp[nt] = jl_new_struct(jl_uniontype_type, temp[k], temp[nt]);
+                temp[nt] = jl_new_union_node(tag, temp[k], temp[nt]);
         }
     }
     assert(temp[nt] != NULL);
@@ -910,7 +1012,25 @@ jl_value_t *simple_intersect(jl_value_t *a, jl_value_t *b, int overesi)
                 temp[j] = NULL;
         }
     }
-    isort_union(&temp[i], count);
+    int deterministic = isort_union(&temp[i], count);
+    int uniquerep = deterministic;
+    if (uniquerep) {
+        int ntuples = 0;
+        size_t ki;
+        for (ki = i; ki < nt; ki++) {
+            if (temp[ki] != NULL) {
+                if (!type_has_uniquerep(temp[ki])) {
+                    uniquerep = 0;
+                    break;
+                }
+                if (jl_is_datatype(temp[ki]) && ((jl_datatype_t*)temp[ki])->name == jl_tuple_typename)
+                    ntuples++;
+            }
+        }
+        if (ntuples > 1)
+            uniquerep = 0;
+    }
+    int tag = uniquerep ? jl_unique_uniontype_tag : jl_uniontype_tag;
     temp[nt] = jl_bottom_type;
     size_t k;
     for (k = nt; k-- > i; ) {
@@ -918,7 +1038,7 @@ jl_value_t *simple_intersect(jl_value_t *a, jl_value_t *b, int overesi)
             if (temp[nt] == jl_bottom_type)
                 temp[nt] = temp[k];
             else
-                temp[nt] = jl_new_struct(jl_uniontype_type, temp[k], temp[nt]);
+                temp[nt] = jl_new_union_node(tag, temp[k], temp[nt]);
         }
     }
     assert(temp[nt] != NULL);
@@ -1438,7 +1558,9 @@ jl_value_t *jl_apply_type(jl_value_t *tc, jl_value_t **params, size_t n)
 {
     if (tc == (jl_value_t*)jl_anytuple_type)
         return jl_apply_tuple_type_v(params, n);
-    if (tc == (jl_value_t*)jl_uniontype_type)
+    if (tc == (jl_value_t*)jl_uniontype_type ||
+        tc == (jl_value_t*)jl_nonunique_uniontype_type ||
+        tc == (jl_value_t*)jl_unique_uniontype_type)
         return (jl_value_t*)jl_type_union(params, n);
     size_t i;
     if (n > 1) {
@@ -1714,6 +1836,10 @@ jl_value_t *jl_substitute_datatype(jl_value_t *t, jl_datatype_t * x, jl_datatype
         JL_GC_POP();
     }
     else if jl_is_uniontype(t) { // recursively call itself on a and b
+        // UniqueUnion components all have uniquerep and thus no free TypeVars,
+        // so substitution cannot change them.
+        if (jl_typetagof(t) == (jl_unique_uniontype_tag << 4))
+            return t;
         jl_uniontype_t *u = (jl_uniontype_t*)t;
         jl_value_t *a = NULL;
         jl_value_t *b = NULL;
@@ -1721,7 +1847,7 @@ jl_value_t *jl_substitute_datatype(jl_value_t *t, jl_datatype_t * x, jl_datatype
         a = jl_substitute_datatype(u->a, x, y);
         b = jl_substitute_datatype(u->b, x, y);
         if (a != u->a || b != u->b) {
-            t = jl_new_struct(jl_uniontype_type, a, b);
+            t = jl_new_union_node(jl_uniontype_tag, a, b);
         }
         JL_GC_POP();
     }
@@ -2051,7 +2177,7 @@ static jl_value_t *normalize_unionalls(jl_value_t *t)
         a = normalize_unionalls(u->a);
         b = normalize_unionalls(u->b);
         if (a != u->a || b != u->b) {
-            t = jl_new_struct(jl_uniontype_type, a, b);
+            t = jl_new_union_node(jl_typetagof(u) >> 4, a, b);
         }
         JL_GC_POP();
     }
@@ -2699,9 +2825,9 @@ static jl_value_t *inst_type_w_(jl_value_t *t, jl_typeenv_t *env, jl_typestack_t
                 b = NULL;
         }
         if (a != u->a || b != u->b) {
-            if (!check) {
-                // fast path for `jl_rename_unionall`.
-                t = jl_new_struct(jl_uniontype_type, a, b);
+            if (!check && a != NULL && b != NULL) {
+                // fast path for `jl_rename_unionall` (check==0 implies nothrow==0 so a,b are non-NULL).
+                t = jl_new_union_node(jl_typetagof(u) >> 4, a, b);
             }
             else if (a == NULL || b == NULL) {
                 assert(nothrow);
@@ -3156,13 +3282,28 @@ void jl_init_types(void) JL_GC_DISABLED
     // It seems like we probably usually end up needing the box for kinds (often used in an Any context), so force it to exist
     jl_unionall_type->name->mayinlinealloc = 0;
 
-    jl_uniontype_type = jl_new_datatype(jl_symbol("Union"), core, type_type, jl_emptysvec,
-                                        jl_perm_symsvec(2, "a", "b"),
-                                        jl_svec(2, jl_any_type, jl_any_type),
-                                        jl_emptysvec, 0, 0, 2);
-    XX(uniontype);
-    // It seems like we probably usually end up needing the box for kinds (often used in an Any context), so force it to exist
-    jl_uniontype_type->name->mayinlinealloc = 0;
+    // Create the body DataType for the parametric Union{uniquerep} type.
+    // Union{uniquerep} where uniquerep is a UnionAll with Bool-valued parameter.
+    // Union{false} = non-unique unions, Union{true} = unique unions.
+    {
+        jl_tvar_t *ur_tvar = tvar("uniquerep");
+        jl_datatype_t *union_body = jl_new_datatype(jl_symbol("Union"), core, type_type,
+                                            jl_svec1(ur_tvar),
+                                            jl_perm_symsvec(2, "a", "b"),
+                                            jl_svec(2, jl_any_type, jl_any_type),
+                                            jl_emptysvec, 0, 0, 2);
+        union_body->name->mayinlinealloc = 0;
+        // Create the UnionAll wrapper: Union{uniquerep} where uniquerep
+        jl_uniontype_type = (jl_unionall_t*)jl_new_struct(jl_unionall_type, ur_tvar, (jl_value_t*)union_body);
+        union_body->name->wrapper = (jl_value_t*)jl_uniontype_type;
+        // Temporarily use the body as both union type variants for early bootstrap.
+        // Phase 2 (after Bool) will replace these with proper specializations.
+        jl_nonunique_uniontype_type = union_body;
+        jl_unique_uniontype_type = union_body;
+        union_body->smalltag = jl_uniontype_tag;
+        ijl_small_typeof[(jl_uniontype_tag << 4) / sizeof(*ijl_small_typeof)] = union_body;
+        ijl_small_typeof[(jl_unique_uniontype_tag << 4) / sizeof(*ijl_small_typeof)] = union_body;
+    }
 
     jl_tvar_t *tttvar = tvar("T");
     type_type->parameters = jl_svec(1, tttvar);
@@ -3241,6 +3382,20 @@ void jl_init_types(void) JL_GC_DISABLED
     XX(bool);
     jl_false = jl_permbox8(jl_bool_type, jl_bool_tag, 0);
     jl_true  = jl_permbox8(jl_bool_type, jl_bool_tag, 1);
+
+    // Phase 2: Now that Bool is available, create the proper Union{false} and Union{true}
+    // specializations of the Union{uniquerep} UnionAll.
+    {
+        jl_nonunique_uniontype_type = (jl_datatype_t*)jl_instantiate_unionall(jl_uniontype_type, (jl_value_t*)jl_false);
+        jl_nonunique_uniontype_type->smalltag = jl_uniontype_tag;
+        jl_nonunique_uniontype_type->ismutationfree = 1;
+        ijl_small_typeof[(jl_uniontype_tag << 4) / sizeof(*ijl_small_typeof)] = jl_nonunique_uniontype_type;
+
+        jl_unique_uniontype_type = (jl_datatype_t*)jl_instantiate_unionall(jl_uniontype_type, (jl_value_t*)jl_true);
+        jl_unique_uniontype_type->smalltag = jl_unique_uniontype_tag;
+        jl_unique_uniontype_type->ismutationfree = 1;
+        ijl_small_typeof[(jl_unique_uniontype_tag << 4) / sizeof(*ijl_small_typeof)] = jl_unique_uniontype_type;
+    }
 
     jl_abstractstring_type = jl_new_abstracttype((jl_value_t*)jl_symbol("AbstractString"), core, jl_any_type, jl_emptysvec);
     jl_string_type = jl_new_datatype(jl_symbol("String"), core, jl_abstractstring_type, jl_emptysvec,
@@ -3692,7 +3847,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             "flags",
                             "dispatch_status"),
                         jl_svec(8,
-                            jl_new_struct(jl_uniontype_type, jl_method_type, jl_module_type),
+                            jl_new_union_node(jl_unique_uniontype_tag, (jl_value_t*)jl_method_type, (jl_value_t*)jl_module_type),
                             jl_any_type,
                             jl_simplevector_type,
                             jl_array_any_type,
@@ -3865,7 +4020,7 @@ void jl_init_types(void) JL_GC_DISABLED
                         jl_emptysvec,
                         0, 1, 6);
     XX(task);
-    jl_value_t *listt = jl_new_struct(jl_uniontype_type, jl_task_type, jl_nothing_type);
+    jl_value_t *listt = jl_new_union_node(jl_unique_uniontype_tag, (jl_value_t*)jl_task_type, (jl_value_t*)jl_nothing_type);
     jl_svecset(jl_task_type->types, 0, listt);
     // Set field 20 (metrics_enabled) as const
     // Set fields 8 (_state) and 24-27 (metric counters) as atomic
@@ -3915,7 +4070,8 @@ void jl_init_types(void) JL_GC_DISABLED
 
     jl_compute_field_offsets(jl_datatype_type);
     jl_compute_field_offsets(jl_typename_type);
-    jl_compute_field_offsets(jl_uniontype_type);
+    jl_compute_field_offsets(jl_nonunique_uniontype_type);
+    jl_compute_field_offsets(jl_unique_uniontype_type);
     jl_compute_field_offsets(jl_tvar_type);
     jl_compute_field_offsets(jl_methtable_type);
     jl_compute_field_offsets(jl_methcache_type);
@@ -3932,7 +4088,8 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_simplevector_type->isidentityfree = 1;
     jl_typename_type->ismutationfree = 1;
     jl_datatype_type->ismutationfree = 1;
-    jl_uniontype_type->ismutationfree = 1;
+    jl_nonunique_uniontype_type->ismutationfree = 1;
+    jl_unique_uniontype_type->ismutationfree = 1;
     jl_unionall_type->ismutationfree = 1;
     assert(((jl_datatype_t*)jl_array_any_type)->ismutationfree == 0);
     assert(((jl_datatype_t*)jl_array_uint8_type)->ismutationfree == 0);

--- a/src/julia.h
+++ b/src/julia.h
@@ -964,6 +964,7 @@ typedef struct {
     XX(datatype) \
     XX(unionall) \
     XX(uniontype) \
+    XX(unique_uniontype) \
     /* type parameter objects */ \
     XX(vararg) \
     XX(tvar) \
@@ -1569,7 +1570,8 @@ static inline int jl_field_isconst(jl_datatype_t *st, int i) JL_NOTSAFEPOINT
 #define jl_is_mutable_datatype(t) (jl_is_datatype(t) && (((jl_datatype_t*)t)->name->mutabl))
 #define jl_is_immutable(t)   (!((jl_datatype_t*)t)->name->mutabl)
 #define jl_may_be_immutable_datatype(t) (jl_is_datatype(t) && (!((jl_datatype_t*)t)->name->mutabl))
-#define jl_is_uniontype(v)   jl_typetagis(v,jl_uniontype_tag<<4)
+// uniontype and unique_uniontype tags are consecutive; range-check covers both
+#define jl_is_uniontype(v)   ((uintptr_t)(jl_typetagof(v) - (jl_uniontype_tag<<4)) <= (uintptr_t)(1<<4))
 #define jl_is_typevar(v)     jl_typetagis(v,jl_tvar_tag<<4)
 #define jl_is_unionall(v)    jl_typetagis(v,jl_unionall_tag<<4)
 #define jl_is_vararg(v)      jl_typetagis(v,jl_vararg_tag<<4)
@@ -1630,14 +1632,19 @@ int is_leaf_bound(jl_value_t *v) JL_NOTSAFEPOINT;
 
 STATIC_INLINE int jl_is_kind(jl_value_t *v) JL_NOTSAFEPOINT
 {
-    return (v==(jl_value_t*)jl_uniontype_type || v==(jl_value_t*)jl_datatype_type ||
-            v==(jl_value_t*)jl_unionall_type || v==(jl_value_t*)jl_typeofbottom_type);
+    // Union has multiple DataType variants (unique/non-unique) sharing the same TypeName,
+    // plus a body DataType for the UnionAll. Check via TypeName to cover all of them.
+    return (v==(jl_value_t*)jl_datatype_type ||
+            v==(jl_value_t*)jl_unionall_type || v==(jl_value_t*)jl_typeofbottom_type ||
+            (jl_nonunique_uniontype_type && jl_is_datatype(v) &&
+             ((jl_datatype_t*)v)->name == jl_nonunique_uniontype_type->name));
 }
 
 STATIC_INLINE int jl_is_kindtag(uintptr_t t) JL_NOTSAFEPOINT
 {
     t >>= 4;
-    return (t==(uintptr_t)jl_uniontype_tag || t==(uintptr_t)jl_datatype_tag ||
+    return (t==(uintptr_t)jl_uniontype_tag || t==(uintptr_t)jl_unique_uniontype_tag ||
+            t==(uintptr_t)jl_datatype_tag ||
             t==(uintptr_t)jl_unionall_tag || t==(uintptr_t)jl_typeofbottom_tag);
 }
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -934,6 +934,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry);
 jl_typemap_entry_t *jl_method_table_add(jl_methtable_t *mt, jl_method_t *method, jl_tupletype_t *simpletype);
 jl_method_t *jl_mk_builtin_func(jl_datatype_t *dt, jl_sym_t *name, jl_fptr_args_t fptr) JL_GC_DISABLED;
 int jl_obviously_unequal(jl_value_t *a, jl_value_t *b);
+int type_has_uniquerep(jl_value_t *t) JL_NOTSAFEPOINT;
 int jl_has_bound_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_array_t *jl_find_free_typevars(jl_value_t *v);
 int jl_has_fixed_layout(jl_datatype_t *t);

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -966,9 +966,9 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         // Print concrete Union specializations by their canonical names,
         // since Union{true}/Union{false} is not valid syntax.
         if (dv == jl_unique_uniontype_type)
-            return jl_printf(out, "UniqueUnion");
+            return jl_printf(out, "Core.UniqueUnion");
         if (dv == jl_nonunique_uniontype_type)
-            return jl_printf(out, "NonUniqueUnion");
+            return jl_printf(out, "Core.NonUniqueUnion");
         if (dv->name == jl_tuple_typename) {
             if (dv == jl_tuple_type)
                 return jl_printf(out, "Tuple");

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -963,6 +963,12 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         // Types are printed as a fully qualified name, with parameters, e.g.
         // `Base.Set{Int}`, and function types are printed as e.g. `typeof(Main.f)`
         jl_datatype_t *dv = (jl_datatype_t*)v;
+        // Print concrete Union specializations by their canonical names,
+        // since Union{true}/Union{false} is not valid syntax.
+        if (dv == jl_unique_uniontype_type)
+            return jl_printf(out, "UniqueUnion");
+        if (dv == jl_nonunique_uniontype_type)
+            return jl_printf(out, "NonUniqueUnion");
         if (dv->name == jl_tuple_typename) {
             if (dv == jl_tuple_type)
                 return jl_printf(out, "Tuple");
@@ -1102,7 +1108,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
     else if (v == jl_bottom_type) {
         n += jl_printf(out, "Union{}");
     }
-    else if (vt == jl_uniontype_type) {
+    else if (vt == jl_nonunique_uniontype_type || vt == jl_unique_uniontype_type) {
         n += jl_printf(out, "Union{");
         while (jl_is_uniontype(v)) {
             // tail-recurse on b to flatten the printing of the Union structure in the common case

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3857,8 +3857,11 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         JL_CONST_GLOBAL_VARS(XX)
 #undef XX
 #define XX(name) \
-        ijl_small_typeof[(jl_##name##_tag << 4) / sizeof(*ijl_small_typeof)] = jl_##name##_type;
+        ijl_small_typeof[(jl_##name##_tag << 4) / sizeof(*ijl_small_typeof)] = (jl_datatype_t*)jl_##name##_type;
         JL_SMALL_TYPEOF(XX)
+        // jl_uniontype_type is a UnionAll; override with the concrete DataType variants.
+        ijl_small_typeof[(jl_uniontype_tag << 4) / sizeof(*ijl_small_typeof)] = jl_nonunique_uniontype_type;
+        ijl_small_typeof[(jl_unique_uniontype_tag << 4) / sizeof(*ijl_small_typeof)] = jl_unique_uniontype_type;
 #undef XX
         export_jl_small_typeof();
         export_jl_sysimg_globals();

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -434,12 +434,13 @@ static int obviously_egal(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT
     return !jl_is_type(a) && jl_egal(a,b);
 }
 
-static int obviously_unequal(jl_value_t *a, jl_value_t *b)
+static int obviously_unequal(jl_value_t *aarg, jl_value_t *barg)
 {
-    if (a == (jl_value_t*)jl_typeofbottom_type->super)
-        a = (jl_value_t*)jl_typeofbottom_type; // supertype(typeof(Union{})) is equal to, although distinct from, itself
-    if (b == (jl_value_t*)jl_typeofbottom_type->super)
-        b = (jl_value_t*)jl_typeofbottom_type; // supertype(typeof(Union{})) is equal to, although distinct from, itself
+    if (aarg == (jl_value_t*)jl_typeofbottom_type->super)
+        aarg = (jl_value_t*)jl_typeofbottom_type; // supertype(typeof(Union{})) is equal to, although distinct from, itself
+    if (barg == (jl_value_t*)jl_typeofbottom_type->super)
+        barg = (jl_value_t*)jl_typeofbottom_type; // supertype(typeof(Union{})) is equal to, although distinct from, itself
+    jl_value_t *a = aarg, *b = barg;
     if (a == b)
         return 0;
     if (jl_is_unionall(a))
@@ -486,10 +487,40 @@ static int obviously_unequal(jl_value_t *a, jl_value_t *b)
                 if (obviously_unequal(jl_tparam(ad, i), jl_tparam(bd, i)))
                     return 1;
             }
+        } else if (((jl_datatype_t*)a)->name != jl_tuple_typename && jl_is_uniontype(b)) {
+            // A non-Tuple DataType is never type-equal to a Union, unless the union
+            // has free typevars that might cause it to collapse, e.g.
+            // Ref == Union{Ref{T}, Ref{S}} where {S, S<:T<:S}
+            // (Tuples are covariant, so Union{Tuple{A,...}, Tuple{B,...}} can equal Tuple{Union{A,B},...})
+            if (!jl_has_free_typevars(b))
+                return 1;
         }
     }
     else if (a == jl_bottom_type && jl_is_datatype(b)) {
         return 1;
+    }
+    else if (jl_is_uniontype(a)) {
+        if (jl_is_datatype(b) && ((jl_datatype_t*)b)->name != jl_tuple_typename) {
+            if (!jl_has_free_typevars(a))
+                return 1;
+        }
+        if (jl_is_uniontype(b)) {
+            if (jl_typetagof(a) == (jl_unique_uniontype_tag << 4)) {
+                if (jl_typetagof(b) == (jl_unique_uniontype_tag << 4))
+                    // UniqueUnion vs UniqueUnion: canonical ordering means componentwise comparison works
+                    return obviously_unequal(((jl_uniontype_t*)a)->a, ((jl_uniontype_t*)b)->a) ||
+                        obviously_unequal(((jl_uniontype_t*)a)->b, ((jl_uniontype_t*)b)->b);
+                // UniqueUnion vs NonUniqueUnion: type-equal unions must have the same tag
+                // (unless b has free typevars that could collapse to match a's structure)
+                if (!jl_has_free_typevars(b))
+                    return 1;
+            }
+            else if (jl_typetagof(b) == (jl_unique_uniontype_tag << 4)) {
+                // NonUniqueUnion vs UniqueUnion: same logic, symmetric
+                if (!jl_has_free_typevars(a))
+                    return 1;
+            }
+        }
     }
     if (jl_is_typevar(a) && jl_is_typevar(b) && obviously_unequal(((jl_tvar_t*)a)->ub, ((jl_tvar_t*)b)->ub))
         return 1;
@@ -1569,7 +1600,15 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param)
                 // Int isa DataType, Int isa Type{Int}, Type{Int} more specific than DataType,
                 // !(Type{Int} <: DataType), !isleaftype(Type{Int}), because non-DataTypes can
                 // be type-equal to `Int`.
-                return jl_typeof(tp0) == (jl_value_t*)yd;
+                jl_value_t *tw = jl_typeof(tp0);
+                if (tw == (jl_value_t*)yd)
+                    return 1;
+                // For parameterized kind types (e.g. Union{uniquerep}), typeof(tp0) is
+                // a concrete specialization, not the body type. Use full subtype check
+                // to properly handle TypeVar matching.
+                if (jl_is_datatype(tw) && ((jl_datatype_t*)tw)->name == yd->name)
+                    return subtype(tw, (jl_value_t*)yd, e, param);
+                return 0;
             }
             return 0;
         }
@@ -1801,6 +1840,13 @@ static int forall_exists_equal(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
     }
 
     if ((jl_is_uniontype(x) && jl_is_uniontype(y))) {
+        // For UniqueUnion, type-equal implies egal, and obviously_egal (line 1787) is a
+        // complete egal check for UniqueUnion types (all components have unique rep and
+        // are pointer-comparable at the leaves). So if obviously_egal returned 0, these
+        // unions are not type-equal; skip the expensive componentwise/full algorithm.
+        if (jl_typetagof(x) == (jl_unique_uniontype_tag << 4) &&
+            jl_typetagof(y) == (jl_unique_uniontype_tag << 4))
+            return 0;
         // For 2 unions, first try a more efficient greedy algorithm that compares the unions
         // componentwise. If failed, `exists_subtype` would memorize that this branch should be skipped.
         // Note: this is valid because the normal path checks `>:` locally.
@@ -2094,7 +2140,16 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
                     jl_value_t *t0 = jl_tparam0(x);
                     if (jl_is_typevar(t0))
                         return 0;
-                    *subtype = jl_typeof(t0) == y;
+                    jl_value_t *tw = jl_typeof(t0);
+                    if (tw == y) {
+                        *subtype = 1;
+                        return 1;
+                    }
+                    // For parameterized kind types (e.g. Union{T} where T),
+                    // typeof(t0) may be a specialization, not pointer-equal to y.
+                    if (((jl_datatype_t*)y)->hasfreetypevars)
+                        return 0; // uncertain, let full algorithm handle it
+                    *subtype = 0;
                     return 1;
                 }
                 if (jl_is_type_type(y)) {
@@ -2370,8 +2425,13 @@ JL_DLLEXPORT int jl_types_equal(jl_value_t *a, jl_value_t *b)
 {
     if (a == b)
         return 1;
-    if (jl_typeof(a) == jl_typeof(b) && jl_types_egal(a, b))
-        return 1;
+    jl_value_t *atyp = jl_typeof(a);
+    if (atyp == jl_typeof(b)) {
+        if (jl_types_egal(a, b))
+            return 1;
+        if (type_has_uniquerep(a))
+            return 0;
+    }
     if (obviously_unequal(a, b))
         return 0;
     // the following is an interleaved version of:
@@ -2559,7 +2619,9 @@ JL_DLLEXPORT int jl_isa(jl_value_t *x, jl_value_t *t)
                         }
                     }
                 }
-                else {
+                else if (!jl_is_kind((jl_value_t*)t2)) {
+                    // For non-kind parametric types, a type value can't be an instance.
+                    // Kind types (like Union{uniquerep}) need the general jl_subtype check below.
                     return 0;
                 }
             }
@@ -3929,8 +3991,15 @@ static jl_value_t *intersect_type_type(jl_value_t *x, jl_value_t *y, jl_stenv_t 
 {
     assert(e->Loffset == 0);
     jl_value_t *p0 = jl_tparam0(x);
-    if (!jl_is_typevar(p0))
-        return (jl_typeof(p0) == y) ? x : jl_bottom_type;
+    if (!jl_is_typevar(p0)) {
+        jl_value_t *tw = jl_typeof(p0);
+        if (tw == y) return x;
+        // For parameterized kind types, check if typeof is a specialization of y
+        if (jl_is_datatype(tw) && jl_is_datatype(y) &&
+                ((jl_datatype_t*)tw)->name == ((jl_datatype_t*)y)->name)
+            return x;
+        return jl_bottom_type;
+    }
     if (!jl_is_kind(y)) return jl_bottom_type;
     if (y == (jl_value_t*)jl_typeofbottom_type && ((jl_tvar_t*)p0)->lb == jl_bottom_type)
         return (jl_value_t*)jl_wrap_Type(jl_bottom_type);
@@ -5453,7 +5522,9 @@ static int type_morespecific_(jl_value_t *a, jl_value_t *b, jl_value_t *a0, jl_v
                 return 1;
         }
         else if (b == (jl_value_t*)jl_datatype_type || b == (jl_value_t*)jl_unionall_type ||
-                 b == (jl_value_t*)jl_uniontype_type) {
+                 b == (jl_value_t*)jl_uniontype_type ||
+                 b == (jl_value_t*)jl_nonunique_uniontype_type ||
+                 b == (jl_value_t*)jl_unique_uniontype_type) {
             return 1;
         }
     }

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1571,6 +1571,13 @@ function deserialize_datatype(s::AbstractSerializer, full::Bool)
             else
                 t = Tuple{Any[ deserialize(s) for i=1:np ]...}
             end
+        elseif ty === Union
+            # Union is a UnionAll parameterized by uniquerep (Bool).
+            # Cannot use t{param} since Union{x} syntax means type union.
+            # Instantiate via Core bindings instead.
+            @assert np == 1
+            param = deserialize(s)
+            t = param === true ? Core.UniqueUnion : Core.NonUniqueUnion
         else
             t = ty
             for i = 1:np


### PR DESCRIPTION
This attempts to revisit the issue that gave rise to #44400 more comprehensively. The core issue is that having `Union` typed fields forced inference to deal with these as `Type{}`, which can be substantially slower than dealing with unions as concrete objects.

The patch in #44400 attempted to improve this by returning the correct `Const` object when the object being queried was `Const` or `hasuniquerep`. However, we can actually do substantially better by recognizing that most `Union`s that we encounter in practice themselves are actually `hasuniquerep`, because we normalize them on construction.

This allows us to use `Const` for these unions significantly more often. The only issue is that computing whether the normalization succeeded is non-trivial and would in general require an O(n log n) (in the number of Union components) sort. This is ok on construction, but not great in the tfuncs, where this is supposed to be a fast check and having to do the query would defeat the performance advantage.

Thus, we main meat of this PR is to attemtp to memoize the `hasuniquerep` bit for `Union` without being breaking to existing code that deals with `Union`s. This is accomplished as follows:

1. The Union DataType is split into (semantically) `Union{true}` and `Union{false}`. Since these types are not constructable with apply_type, there are canonical UniqueUnion and NonuniqueUnion aliases.
2. `Union` is now the UnionAll of these two.
3. The code from #44400 is still incorporated in addition to handle NonuniqueUnion cases, but the basic test set from that issue is already addressed by just the `hasuniquerep` memoization.