### PR TITLE
Add docstrings for AbstractSerializer and Serializer

### DIFF
--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -15,8 +15,19 @@ using Core.IR
 
 export serialize, deserialize, AbstractSerializer, Serializer
 
+"""
+    AbstractSerializer
+
+Abstract type for serializer objects used by the `Serialization` standard library.
+"""
 abstract type AbstractSerializer end
 
+"""
+    Serializer(io::IO)
+
+Concrete serializer used by the `Serialization` standard library to write
+serialized data to an IO stream.
+"""
 mutable struct Serializer{I<:IO} <: AbstractSerializer
     io::I
     counter::Int

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -673,8 +673,7 @@ end
 
 @testset "Docstrings" begin
     undoc = Docs.undocumented_names(Serialization)
-    @test_broken isempty(undoc)
-    @test undoc == [:AbstractSerializer, :Serializer]
+    @test isempty(undoc)
 end
 
 # test method definitions from v1.11


### PR DESCRIPTION
Adds missing docstrings for `AbstractSerializer` and `Serializer`
in the Serialization stdlib, as listed in #52725.

Updates the docstring test accordingly.