### PR TITLE
Unify prefix layouts, always installing to private libdir

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -349,12 +349,16 @@ build_libdir := $(build_prefix)/lib/$(MULTIARCH)
 endif
 
 # Private library directories
+# Note: build_private_libdir is unified with private_libdir so that
+# dependencies are unpacked/built directly into their final private locations
+# at make time, eliminating the need for rearrangement at install time.
 ifeq ($(DARWIN_FRAMEWORK), 1)
 private_libdir := $(prefix)/$(framework_frameworks)
+build_private_libdir := $(build_prefix)/$(framework_frameworks)
 else
 private_libdir := $(libdir)/julia
-endif
 build_private_libdir := $(build_libdir)/julia
+endif
 
 private_libexecdir := $(libexecdir)/julia
 build_private_libexecdir := $(build_libexecdir)/julia
@@ -391,8 +395,10 @@ reverse_private_libdir_rel_eval = $(call rel_path,$(private_libdir),$(libdir))
 reverse_private_libdir_rel = $(call hit_cache,reverse_private_libdir_rel_eval)
 reverse_private_libexecdir_rel_eval = $(call rel_path,$(private_libexecdir),$(private_libdir))
 reverse_private_libexecdir_rel = $(call hit_cache,reverse_private_libexecdir_rel_eval)
-reverse_build_private_libexecdir_rel_eval = $(call rel_path,$(build_private_libexecdir),$(build_libdir))
+reverse_build_private_libexecdir_rel_eval = $(call rel_path,$(build_private_libexecdir),$(build_private_libdir))
 reverse_build_private_libexecdir_rel = $(call hit_cache,reverse_build_private_libexecdir_rel_eval)
+reverse_build_depsbindir_rel_eval = $(call rel_path,$(build_depsbindir),$(build_private_libdir))
+reverse_build_depsbindir_rel = $(call hit_cache,reverse_build_depsbindir_rel_eval)
 
 INSTALL_F := $(JULIAHOME)/contrib/install.sh 644
 INSTALL_M := $(JULIAHOME)/contrib/install.sh 755
@@ -852,6 +858,39 @@ endif
 
 # Do not try to extract owner uids, even if we're root (e.g. in sandboxes)
 TAR += --no-same-owner
+# Transform rules for unpacking dependencies directly into private locations
+# This eliminates the need for layout rearrangement at install time.
+# GNU tar uses --transform, BSD tar (macOS) uses -s.
+# We detect which to use based on whether 'strip-components' is supported (GNU tar feature).
+# Note: Syntax differs between the two:
+#   GNU tar:  --transform 's|pattern|replacement|'  (with 's' prefix, like sed)
+#   BSD tar:           -s  '|pattern|replacement|'  (without 's' prefix)
+TAR_TRANSFORM_CMD :=
+ifeq (,$(findstring components,$(TAR_TEST)))
+    # BSD tar (macOS)
+    IS_BSD_TAR := true
+    TAR_TRANSFORM_CMD := -s
+else
+    # GNU tar
+    TAR_TRANSFORM_CMD := --transform
+endif
+
+# Transform all files with extensions directly in `lib/` to `lib/julia/`
+# Files in lib/ subdirectories (lib/pkgconfig/, lib/cmake/, etc.) remain in place
+# Pattern explanation:
+#   ^\(\./\)\{0,1\}      - Optional `./` prefix (BRE syntax)
+#   lib/\([^/]*\.[^/]*\) - `lib/` followed by: filename, dot, extension (matches files, not dirs)
+#   lib/julia/\2         - Move to `lib/julia/` preserving the filename (second capture group)
+ifeq ($(IS_BSD_TAR),true)
+    # BSD tar: -s '|pattern|replacement|' (no 's' prefix)
+    TAR_TRANSFORM_PRIVATE := -s '|^\(\./\)\{0,1\}lib/\([^/]*\.[^/]*\)|lib/julia/\2|'
+else
+    # GNU tar: --transform 's|pattern|replacement|' (with 's' prefix)
+    TAR_TRANSFORM_PRIVATE := --transform 's|^\(\./\)\{0,1\}lib/\([^/]*\.[^/]*\)|lib/julia/\2|'
+endif
+
+# Equivalent sed expression for transforming file listings (e.g. for mkdir pre-pass and uninstaller)
+SED_TRANSFORM_PRIVATE := -e 's|^\(\./\)\{0,1\}lib/\([^/]*\.[^/]*\)|lib/julia/\2|'
 
 ifeq ($(WITH_GC_VERIFY), 1)
 JCXXFLAGS += -DGC_VERIFY
@@ -1361,14 +1400,14 @@ ifeq ($(USE_SYSTEM_BLAS), 1)
 ifeq ($(OS), Darwin)
 USE_BLAS64 := 0
 USE_SYSTEM_LAPACK := 0
-LIBBLAS := -L$(build_libdir) -lgfortblas
+LIBBLAS := -L$(build_private_libdir) -lgfortblas
 LIBBLASNAME := libgfortblas
 else
 LIBBLAS ?= -lblas
 LIBBLASNAME ?= libblas
 endif
 else
-LIBBLAS := -L$(build_shlibdir) -lopenblas
+LIBBLAS := -L$(build_private_shlibdir) -lopenblas
 LIBBLASNAME := libopenblas
 endif
 
@@ -1382,7 +1421,7 @@ ifeq ($(USE_SYSTEM_LAPACK), 1)
 LIBLAPACK ?= -llapack
 LIBLAPACKNAME ?= liblapack
 else
-LIBLAPACK := -L$(build_shlibdir) -llapack $(LIBBLAS)
+LIBLAPACK := -L$(build_private_shlibdir) -llapack $(LIBBLAS)
 LIBLAPACKNAME := liblapack
 endif
 endif
@@ -1399,7 +1438,7 @@ ifeq ($(USE_SYSTEM_LIBUV), 1)
   LIBUV := $(LOCALBASE)/lib/libuv-julia.a
   LIBUV_INC := $(LOCALBASE)/include
 else
-  LIBUV := $(build_libdir)/libuv.a
+  LIBUV := $(build_private_libdir)/libuv.a
   LIBUV_INC := $(build_includedir)
 endif
 
@@ -1407,7 +1446,7 @@ ifeq ($(USE_SYSTEM_UTF8PROC), 1)
   LIBUTF8PROC := -lutf8proc
   UTF8PROC_INC := $(LOCALBASE)/include
 else
-  LIBUTF8PROC := $(build_libdir)/libutf8proc.a
+  LIBUTF8PROC := $(build_private_libdir)/libutf8proc.a
   UTF8PROC_INC := $(build_includedir)
 endif
 
@@ -1536,13 +1575,13 @@ ifneq (,$(filter $(OS),WINNT emscripten))
   RPATH_ORIGIN :=
   RPATH_ESCAPED_ORIGIN :=
 else ifeq ($(OS), Darwin)
-  RPATH := -Wl,-rpath,'@executable_path/$(build_libdir_rel)'
+  RPATH := -Wl,-rpath,'@executable_path/$(build_libdir_rel)' -Wl,-rpath,'@executable_path/$(build_private_libdir_rel)'
   RPATH_ORIGIN := -Wl,-rpath,'@loader_path/'
   RPATH_ESCAPED_ORIGIN := $(RPATH_ORIGIN)
 else
-  RPATH := -Wl,-rpath,'$$ORIGIN/$(build_libdir_rel)' -Wl,-rpath,'$$ORIGIN/$(build_private_libdir_rel)' -Wl,-rpath-link,$(build_shlibdir) -Wl,-z,origin -Wl,--enable-new-dtags
+  RPATH := -Wl,-rpath,'$$ORIGIN/$(build_libdir_rel)' -Wl,-rpath,'$$ORIGIN/$(build_private_libdir_rel)' -Wl,-rpath-link,$(build_private_shlibdir) -Wl,-rpath-link,$(build_shlibdir) -Wl,-z,origin -Wl,--enable-new-dtags
   RPATH_ORIGIN := -Wl,-rpath,'$$ORIGIN' -Wl,-z,origin -Wl,--enable-new-dtags
-  RPATH_ESCAPED_ORIGIN := -Wl,-rpath,'\$$\$$ORIGIN' -Wl,-z,origin -Wl,-rpath-link,$(build_shlibdir) -Wl,--enable-new-dtags
+  RPATH_ESCAPED_ORIGIN := -Wl,-rpath,'\$$\$$ORIGIN' -Wl,-z,origin -Wl,-rpath-link,$(build_private_shlibdir) -Wl,-rpath-link,$(build_shlibdir) -Wl,--enable-new-dtags
 endif
 RPATH_LIB := $(RPATH_ORIGIN)
 
@@ -1676,7 +1715,7 @@ ifeq ($(USE_SYSTEM_BLAS), 0)
 ifeq ($(USE_BLAS64), 1)
 OPENBLAS_SYMBOLSUFFIX := 64_
 OPENBLAS_LIBNAMESUFFIX := 64_
-LIBBLAS := -L$(build_shlibdir) -lopenblas$(OPENBLAS_LIBNAMESUFFIX)
+LIBBLAS := -L$(build_private_shlibdir) -lopenblas$(OPENBLAS_LIBNAMESUFFIX)
 LIBLAPACK := $(LIBBLAS)
 LIBBLASNAME := $(LIBBLASNAME)$(OPENBLAS_LIBNAMESUFFIX)
 LIBLAPACKNAME := $(LIBBLASNAME)
@@ -1832,17 +1871,17 @@ define dep_lib_path
 $(call normalize_path,$(shell $(PYTHON) $(call python_cygpath,$(JULIAHOME)/contrib/relative_path.py) $(1) $(2)))
 endef
 
-LIBJULIAINTERNAL_BUILD_DEPLIB := $(call dep_lib_path,$(build_shlibdir),$(build_shlibdir)/libjulia-internal.$(JL_MAJOR_SHLIB_EXT))
-LIBJULIAINTERNAL_INSTALL_DEPLIB := $(call dep_lib_path,$(shlibdir),$(private_shlibdir)/libjulia-internal.$(JL_MAJOR_SHLIB_EXT))
+LIBJULIAINTERNAL_BUILD_DEPLIB         := $(call dep_lib_path,$(build_shlibdir),$(build_private_shlibdir)/libjulia-internal.$(JL_MAJOR_SHLIB_EXT))
+LIBJULIAINTERNAL_INSTALL_DEPLIB       := $(call dep_lib_path,      $(shlibdir),      $(private_shlibdir)/libjulia-internal.$(JL_MAJOR_SHLIB_EXT))
 
-LIBJULIAINTERNAL_DEBUG_BUILD_DEPLIB := $(call dep_lib_path,$(build_shlibdir),$(build_shlibdir)/libjulia-internal-debug.$(JL_MAJOR_SHLIB_EXT))
-LIBJULIAINTERNAL_DEBUG_INSTALL_DEPLIB := $(call dep_lib_path,$(shlibdir),$(private_shlibdir)/libjulia-internal-debug.$(JL_MAJOR_SHLIB_EXT))
+LIBJULIAINTERNAL_DEBUG_BUILD_DEPLIB   := $(call dep_lib_path,$(build_shlibdir),$(build_private_shlibdir)/libjulia-internal-debug.$(JL_MAJOR_SHLIB_EXT))
+LIBJULIAINTERNAL_DEBUG_INSTALL_DEPLIB := $(call dep_lib_path,      $(shlibdir),      $(private_shlibdir)/libjulia-internal-debug.$(JL_MAJOR_SHLIB_EXT))
 
-LIBJULIACODEGEN_BUILD_DEPLIB := $(call dep_lib_path,$(build_shlibdir),$(build_shlibdir)/libjulia-codegen.$(JL_MAJOR_SHLIB_EXT))
-LIBJULIACODEGEN_INSTALL_DEPLIB := $(call dep_lib_path,$(shlibdir),$(private_shlibdir)/libjulia-codegen.$(JL_MAJOR_SHLIB_EXT))
+LIBJULIACODEGEN_BUILD_DEPLIB          := $(call dep_lib_path,$(build_shlibdir),$(build_private_shlibdir)/libjulia-codegen.$(JL_MAJOR_SHLIB_EXT))
+LIBJULIACODEGEN_INSTALL_DEPLIB        := $(call dep_lib_path,      $(shlibdir),      $(private_shlibdir)/libjulia-codegen.$(JL_MAJOR_SHLIB_EXT))
 
-LIBJULIACODEGEN_DEBUG_BUILD_DEPLIB := $(call dep_lib_path,$(build_shlibdir),$(build_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_SHLIB_EXT))
-LIBJULIACODEGEN_DEBUG_INSTALL_DEPLIB := $(call dep_lib_path,$(shlibdir),$(private_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_SHLIB_EXT))
+LIBJULIACODEGEN_DEBUG_BUILD_DEPLIB    := $(call dep_lib_path,$(build_shlibdir),$(build_private_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_SHLIB_EXT))
+LIBJULIACODEGEN_DEBUG_INSTALL_DEPLIB  := $(call dep_lib_path,      $(shlibdir),      $(private_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_SHLIB_EXT))
 
 ifeq ($(OS),WINNT)
 ifeq ($(BINARY),32)
@@ -1872,7 +1911,7 @@ endif
 ifeq ($(USE_SYSTEM_CSL),1)
 LIBGCC_BUILD_DEPLIB := $(call dep_lib_path,$(build_shlibdir),$(build_private_shlibdir)/$(LIBGCC_NAME))
 else
-LIBGCC_BUILD_DEPLIB := $(call dep_lib_path,$(build_shlibdir),$(build_shlibdir)/$(LIBGCC_NAME))
+LIBGCC_BUILD_DEPLIB := $(call dep_lib_path,$(build_shlibdir),$(build_private_shlibdir)/$(LIBGCC_NAME))
 endif
 LIBGCC_INSTALL_DEPLIB := $(call dep_lib_path,$(shlibdir),$(private_shlibdir)/$(LIBGCC_NAME))
 
@@ -1883,7 +1922,7 @@ LIBSTDCXX_NAME := libstdc++.so.6
 ifeq ($(USE_SYSTEM_CSL),1)
 LIBSTDCXX_BUILD_DEPLIB := $(call dep_lib_path,$(build_shlibdir),$(build_private_shlibdir)/$(LIBSTDCXX_NAME))
 else
-LIBSTDCXX_BUILD_DEPLIB := $(call dep_lib_path,$(build_shlibdir),$(build_shlibdir)/$(LIBSTDCXX_NAME))
+LIBSTDCXX_BUILD_DEPLIB := $(call dep_lib_path,$(build_shlibdir),$(build_private_shlibdir)/$(LIBSTDCXX_NAME))
 endif
 LIBSTDCXX_INSTALL_DEPLIB := $(call dep_lib_path,$(shlibdir),$(private_shlibdir)/$(LIBSTDCXX_NAME))
 endif
@@ -1895,7 +1934,7 @@ LIBM_BUILD_DEPLIB := $(call dep_lib_path,$(build_shlibdir),$(build_private_shlib
 else ifeq ($(USE_SYSTEM_OPENLIBM),1)
 LIBM_BUILD_DEPLIB := $(call dep_lib_path,$(build_shlibdir),$(build_private_shlibdir)/$(LIBMNAME).$(SHLIB_EXT))
 else
-LIBM_BUILD_DEPLIB := $(call dep_lib_path,$(build_shlibdir),$(build_shlibdir)/$(LIBMNAME).$(SHLIB_EXT))
+LIBM_BUILD_DEPLIB := $(call dep_lib_path,$(build_shlibdir),$(build_private_shlibdir)/$(LIBMNAME).$(SHLIB_EXT))
 endif
 LIBM_INSTALL_DEPLIB := $(call dep_lib_path,$(shlibdir),$(private_shlibdir)/$(LIBMNAME).$(SHLIB_EXT))
 

--- a/Make.inc
+++ b/Make.inc
@@ -799,10 +799,10 @@ endif
 # Allow the user to specify this in Make.user
 GCCPATH ?= $(LOCALBASE)/lib/gcc$(_GCCVER)
 
-# We're going to copy over the libraries we need from GCCPATH into build_libdir, then
-# tell everyone to look for them there. At install time, the build_libdir added into
+# We're going to copy over the libraries we need from GCCPATH into build_private_libdir, then
+# tell everyone to look for them there. At install time, the build_private_libdir added into
 # the RPATH here is removed by patchelf.
-LDFLAGS += -L$(build_libdir) -Wl,-rpath,$(build_libdir)
+LDFLAGS += -L$(build_private_libdir) -Wl,-rpath,$(build_private_libdir)
 
 endif # gfortran
 endif # FreeBSD

--- a/Makefile
+++ b/Makefile
@@ -375,13 +375,13 @@ ifneq ($(DARWIN_FRAMEWORK),1)
 ifeq ($(OS),Darwin)
 ifeq ($(JULIA_BUILD_MODE),release)
 	cp -a $(build_libdir)/libjulia.*.dSYM $(DESTDIR)$(libdir)
-	cp -a $(build_libdir)/libjulia-internal.*.dSYM $(DESTDIR)$(private_libdir)
-	cp -a $(build_libdir)/libjulia-codegen.*.dSYM $(DESTDIR)$(private_libdir)
+	cp -a $(build_private_libdir)/libjulia-internal.*.dSYM $(DESTDIR)$(private_libdir)
+	cp -a $(build_private_libdir)/libjulia-codegen.*.dSYM $(DESTDIR)$(private_libdir)
 	cp -a $(build_private_libdir)/sys.dylib.dSYM $(DESTDIR)$(private_libdir)
 else ifeq ($(JULIA_BUILD_MODE),debug)
 	cp -a $(build_libdir)/libjulia-debug.*.dSYM $(DESTDIR)$(libdir)
-	cp -a $(build_libdir)/libjulia-internal-debug.*.dSYM $(DESTDIR)$(private_libdir)
-	cp -a $(build_libdir)/libjulia-codegen-debug.*.dSYM $(DESTDIR)$(private_libdir)
+	cp -a $(build_private_libdir)/libjulia-internal-debug.*.dSYM $(DESTDIR)$(private_libdir)
+	cp -a $(build_private_libdir)/libjulia-codegen-debug.*.dSYM $(DESTDIR)$(private_libdir)
 	cp -a $(build_private_libdir)/sys-debug.dylib.dSYM $(DESTDIR)$(private_libdir)
 endif
 endif
@@ -408,7 +408,7 @@ endif
 endif
 
 	for suffix in $(JL_PRIVATE_LIBS-0) ; do \
-		for lib in $(build_libdir)/$${suffix}.*$(SHLIB_EXT)*; do \
+		for lib in $(build_private_libdir)/$${suffix}.*$(SHLIB_EXT)*; do \
 			if [ "$${lib##*.}" != "dSYM" ]; then \
 				$(INSTALL_M) $$lib $(DESTDIR)$(private_libdir) || exit 1; \
 			fi \
@@ -496,11 +496,6 @@ endif
 	else \
 		RELEASE_TARGET=$(DESTDIR)$(prefix)/$(framework_dylib); \
 		DEBUG_TARGET=$(DESTDIR)$(prefix)/$(framework_dylib)_debug; \
-	fi; \
-	if [ "$(JULIA_BUILD_MODE)" = "release" ]; then \
-		$(call stringreplace,$${RELEASE_TARGET},sys.$(SHLIB_EXT)$$,$(private_libdir_rel)/sys.$(SHLIB_EXT)); \
-	elif [ "$(JULIA_BUILD_MODE)" = "debug" ]; then \
-		$(call stringreplace,$${DEBUG_TARGET},sys-debug.$(SHLIB_EXT)$$,$(private_libdir_rel)/sys-debug.$(SHLIB_EXT)); \
 	fi;
 endif
 
@@ -781,13 +776,13 @@ endif
 	@printf $(JULCOLOR)' ==> ./julia binary sizes\n'$(ENDCOLOR)
 	$(call spawn,$(LLVM_SIZE) -A $(call cygpath_w,$(build_private_libdir)/sys.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia.$(SHLIB_EXT)) \
-		$(call cygpath_w,$(build_shlibdir)/libjulia-internal.$(SHLIB_EXT)) \
-		$(call cygpath_w,$(build_shlibdir)/libjulia-codegen.$(SHLIB_EXT)) \
+		$(call cygpath_w,$(build_private_shlibdir)/libjulia-internal.$(SHLIB_EXT)) \
+		$(call cygpath_w,$(build_private_shlibdir)/libjulia-codegen.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_bindir)/julia$(EXE)))
 ifeq ($(OS),Darwin)
-	$(call spawn,$(LLVM_SIZE) -A $(call cygpath_w,$(build_shlibdir)/libLLVM.$(SHLIB_EXT)))
+	$(call spawn,$(LLVM_SIZE) -A $(call cygpath_w,$(build_private_shlibdir)/libLLVM.$(SHLIB_EXT)))
 else
-	$(call spawn,$(LLVM_SIZE) -A $(call cygpath_w,$(build_shlibdir)/$(LLVM_SHARED_LIB_NAME).$(SHLIB_EXT)))
+	$(call spawn,$(LLVM_SIZE) -A $(call cygpath_w,$(build_private_shlibdir)/$(LLVM_SHARED_LIB_NAME).$(SHLIB_EXT)))
 endif
 	@printf $(JULCOLOR)' ==> ./julia launch speedtest\n'$(ENDCOLOR)
 	@time $(call spawn,$(build_bindir)/julia$(EXE) -e '')

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -8,7 +8,7 @@ include $(JULIAHOME)/deps/llvm-ver.make
 HEADERS := $(addprefix $(SRCDIR)/,jl_exports.h loader.h dl-cache.h) $(addprefix $(JULIAHOME)/src/,julia_fasttls.h support/platform.h support/dirpath.h jl_exported_data.inc jl_exported_funcs.inc)
 
 LOADER_CFLAGS = $(JCFLAGS) -I$(BUILDROOT)/src -I$(JULIAHOME)/src -I$(JULIAHOME)/src/support -I$(build_includedir) -ffreestanding
-LOADER_LDFLAGS = $(JLDFLAGS) -ffreestanding -L$(build_shlibdir) -L$(build_libdir)
+LOADER_LDFLAGS = $(JLDFLAGS) -ffreestanding -L$(build_private_libdir) -L$(build_shlibdir) -L$(build_libdir)
 
 ifeq ($(OS),WINNT)
 LOADER_CFLAGS += -municode -mconsole -nostdlib -fno-stack-check -fno-stack-protector -mno-stack-arg-probe

--- a/deps/blastrampoline.mk
+++ b/deps/blastrampoline.mk
@@ -30,7 +30,7 @@ $(eval $(call staged-install, \
 	blastrampoline,$(BLASTRAMPOLINE_SRC_DIR), \
 	BLASTRAMPOLINE_INSTALL,, \
 	$$(BLASTRAMPOLINE_OBJ_TARGET), \
-	$$(INSTALL_NAME_CMD)libblastrampoline.$$(SHLIB_EXT) $$(build_shlibdir)/libblastrampoline.$$(SHLIB_EXT)))
+	$$(INSTALL_NAME_CMD)libblastrampoline.$$(SHLIB_EXT) $$(build_private_shlibdir)/libblastrampoline.$$(SHLIB_EXT)))
 
 clean-blastrampoline:
 	-if [ -d $(BLASTRAMPOLINE_BUILD_ROOT) ]; then $(MAKE) -C $(BLASTRAMPOLINE_BUILD_ROOT) clean; fi

--- a/deps/csl.mk
+++ b/deps/csl.mk
@@ -48,10 +48,10 @@ endif
 
 ifeq ($(USE_BINARYBUILDER_CSL),0)
 define copy_csl
-install-csl: | $$(build_shlibdir) $$(build_shlibdir)/$(1)
-$$(build_shlibdir)/$(1): | $$(build_shlibdir)
+install-csl: | $$(build_private_shlibdir) $$(build_private_shlibdir)/$(1)
+$$(build_private_shlibdir)/$(1): | $$(build_private_shlibdir)
 	-@SRC_LIB='$$(call pathsearch,$(1),$$(STD_LIB_PATH))'; \
-	[ -n "$$$${SRC_LIB}" ] && cp "$$$${SRC_LIB}" '$$(build_shlibdir)'
+	[ -n "$$$${SRC_LIB}" ] && cp "$$$${SRC_LIB}" '$$(build_private_shlibdir)'
 endef
 
 define copy_csl_static_lib
@@ -118,16 +118,16 @@ endif
 
 get-csl:
 clean-csl:
-	-rm -f $(build_shlibdir)/libgfortran*$(SHLIB_EXT)*
-	-rm -f $(build_shlibdir)/libquadmath*$(SHLIB_EXT)*
-	-rm -f $(build_shlibdir)/libstdc++*$(SHLIB_EXT)*
-	-rm -f $(build_shlibdir)/libc++*$(SHLIB_EXT)*
-	-rm -f $(build_shlibdir)/libgcc_s*$(SHLIB_EXT)*
-	-rm -f $(build_shlibdir)/libssp*$(SHLIB_EXT)*
-	-rm -f $(build_shlibdir)/libpthread*$(SHLIB_EXT)*
-	-rm -f $(build_shlibdir)/libwinpthread*$(SHLIB_EXT)*
-	-rm -f $(build_shlibdir)/libatomic*$(SHLIB_EXT)*
-	-rm -f $(build_shlibdir)/libgomp*$(SHLIB_EXT)*
+	-rm -f $(build_private_shlibdir)/libgfortran*$(SHLIB_EXT)*
+	-rm -f $(build_private_shlibdir)/libquadmath*$(SHLIB_EXT)*
+	-rm -f $(build_private_shlibdir)/libstdc++*$(SHLIB_EXT)*
+	-rm -f $(build_private_shlibdir)/libc++*$(SHLIB_EXT)*
+	-rm -f $(build_private_shlibdir)/libgcc_s*$(SHLIB_EXT)*
+	-rm -f $(build_private_shlibdir)/libssp*$(SHLIB_EXT)*
+	-rm -f $(build_private_shlibdir)/libpthread*$(SHLIB_EXT)*
+	-rm -f $(build_private_shlibdir)/libwinpthread*$(SHLIB_EXT)*
+	-rm -f $(build_private_shlibdir)/libatomic*$(SHLIB_EXT)*
+	-rm -f $(build_private_shlibdir)/libgomp*$(SHLIB_EXT)*
 distclean-csl: clean-csl
 
 else

--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -22,7 +22,7 @@ $(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/nghttp
 endif
 
 ifneq ($(USE_BINARYBUILDER_CURL),1)
-CURL_LDFLAGS := $(RPATH_ESCAPED_ORIGIN) -Wl,-rpath,$(build_shlibdir)
+CURL_LDFLAGS := -L$(build_private_shlibdir) $(RPATH_ESCAPED_ORIGIN) -Wl,-rpath,$(build_private_shlibdir)
 
 # On older Linuces (those that use OpenSSL < 1.1) we include `libpthread` explicitly.
 # It doesn't hurt to include it explicitly elsewhere, so we do so.
@@ -90,7 +90,7 @@ endif
 $(eval $(call staged-install, \
 	curl,curl-$$(CURL_VER), \
 	MAKE_INSTALL,,, \
-	$$(INSTALL_NAME_CMD)libcurl.$$(SHLIB_EXT) $$(build_shlibdir)/libcurl.$$(SHLIB_EXT)))
+	$$(INSTALL_NAME_CMD)libcurl.$$(SHLIB_EXT) $$(build_private_shlibdir)/libcurl.$$(SHLIB_EXT)))
 
 clean-curl:
 	-rm -f $(BUILDDIR)/curl-$(CURL_VER)/build-configured $(BUILDDIR)/curl-$(CURL_VER)/build-compiled

--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -13,6 +13,10 @@ ifeq ($(USE_SYSTEM_ZLIB), 0)
 $(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/zlib
 endif
 
+ifeq ($(USE_SYSTEM_ZSTD), 0)
+$(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/zstd
+endif
+
 ifeq ($(USE_SYSTEM_NGHTTP2), 0)
 $(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/nghttp2
 endif

--- a/deps/dsfmt.mk
+++ b/deps/dsfmt.mk
@@ -48,7 +48,7 @@ $(eval $(call staged-install, \
 	dsfmt,dsfmt-$(DSFMT_VER), \
 	DSFMT_INSTALL,, \
 	$$(DSFMT_OBJ_TARGET), \
-	$$(INSTALL_NAME_CMD)libdSFMT.$$(SHLIB_EXT) $$(build_shlibdir)/libdSFMT.$$(SHLIB_EXT)))
+	$$(INSTALL_NAME_CMD)libdSFMT.$$(SHLIB_EXT) $$(build_private_shlibdir)/libdSFMT.$$(SHLIB_EXT)))
 
 clean-dsfmt:
 	-rm -f $(BUILDDIR)/dsfmt-$(DSFMT_VER)/build-compiled

--- a/deps/gmp.mk
+++ b/deps/gmp.mk
@@ -68,7 +68,7 @@ $(eval $(call staged-install, \
 	gmp,gmp-$(GMP_VER), \
 	MAKE_INSTALL,,, \
 	$$(WIN_MAKE_HARD_LINK) $(build_bindir)/libgmp-*.dll $(build_bindir)/libgmp.dll && \
-		$$(INSTALL_NAME_CMD)libgmp.$$(SHLIB_EXT) $$(build_shlibdir)/libgmp.$$(SHLIB_EXT)))
+		$$(INSTALL_NAME_CMD)libgmp.$$(SHLIB_EXT) $$(build_private_shlibdir)/libgmp.$$(SHLIB_EXT)))
 
 clean-gmp:
 	-rm -f $(BUILDDIR)/gmp-$(GMP_VER)/build-configured $(BUILDDIR)/gmp-$(GMP_VER)/build-compiled

--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -49,6 +49,7 @@ endif
 
 ifneq (,$(findstring $(OS),Linux FreeBSD OpenBSD))
 LIBGIT2_OPTS += -DUSE_HTTPS="OpenSSL" -DUSE_SHA1="CollisionDetection" -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
+LIBGIT2_OPTS += -DOPENSSL_ROOT_DIR=$(build_prefix) -D_OPENSSL_LIBDIR=$(build_private_shlibdir)
 endif
 
 LIBGIT2_SRC_PATH := $(SRCCACHE)/$(LIBGIT2_SRC_DIR)
@@ -81,7 +82,7 @@ endef
 $(eval $(call staged-install, \
 	libgit2,$(LIBGIT2_SRC_DIR), \
 	LIBGIT2_INSTALL,,, \
-	$$(INSTALL_NAME_CMD)libgit2.$$(SHLIB_EXT) $$(build_shlibdir)/libgit2.$$(SHLIB_EXT)))
+	$$(INSTALL_NAME_CMD)libgit2.$$(SHLIB_EXT) $$(build_private_shlibdir)/libgit2.$$(SHLIB_EXT)))
 
 clean-libgit2:
 	-rm -f $(build_datarootdir)/julia/cert.pem

--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -19,7 +19,7 @@ ifeq ($(OS),WINNT)
 LIBSSH2_OPTS += -DCRYPTO_BACKEND=WinCNG -DENABLE_ZLIB_COMPRESSION=OFF
 else
 LIBSSH2_OPTS += -DCRYPTO_BACKEND=OpenSSL -DENABLE_ZLIB_COMPRESSION=OFF
-LIBSSH2_OPTS += -DOPENSSL_ROOT_DIR=$(build_prefix)
+LIBSSH2_OPTS += -DOPENSSL_ROOT_DIR=$(build_prefix) -D_OPENSSL_LIBDIR=$(build_private_shlibdir)
 endif
 
 ifneq (,$(findstring $(OS),Linux FreeBSD OpenBSD))
@@ -51,7 +51,7 @@ endif
 $(eval $(call staged-install, \
 	libssh2,$(LIBSSH2_SRC_DIR), \
 	MAKE_INSTALL,,, \
-	$$(INSTALL_NAME_CMD)libssh2.$$(SHLIB_EXT) $$(build_shlibdir)/libssh2.$$(SHLIB_EXT)))
+	$$(INSTALL_NAME_CMD)libssh2.$$(SHLIB_EXT) $$(build_private_shlibdir)/libssh2.$$(SHLIB_EXT)))
 
 clean-libssh2:
 	-rm -f $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-compiled

--- a/deps/libsuitesparse.mk
+++ b/deps/libsuitesparse.mk
@@ -4,7 +4,6 @@ include $(SRCDIR)/libsuitesparse.version
 ifneq ($(USE_BINARYBUILDER_LIBSUITESPARSE), 1)
 
 LIBSUITESPARSE_PROJECTS := "suitesparse_config;amd;btf;camd;ccolamd;colamd;cholmod;klu;ldl;umfpack;rbio;spqr"
-LIBSUITESPARSE_LIBS := $(addsuffix .*$(SHLIB_EXT)*,suitesparseconfig $(subst ;, ,$(LIBSUITESPARSE_PROJECTS)))
 
 ifeq ($(OS),WINNT)
 BLAS_LIB_NAME_NO_EXT:=blastrampoline-5
@@ -55,12 +54,14 @@ checksum-libsuitesparse: $(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER).tar.gz
 $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/source-patched: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/source-extracted
 	echo 1 > $@
 
+$(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-configured: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/source-patched
+	cd $(dir $<) && $(CMAKE) -G"Unix Makefiles" . $(LIBSUITESPARSE_CMAKE_FLAGS)
+	echo 1 > $@
+
 $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled: | $(build_prefix)/manifest/blastrampoline
 
-$(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/source-patched
-	cd $(dir $<) && $(CMAKE) -G"Unix Makefiles" . $(LIBSUITESPARSE_CMAKE_FLAGS)
+$(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-configured
 	$(MAKE) -C $(dir $<)
-	$(MAKE) -C $(dir $<) install
 	echo 1 > $@
 
 ifeq ($(OS),WINNT)
@@ -74,15 +75,12 @@ $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-checked: $(BUILDDIR)/SuiteSp
 	done
 	echo 1 > $@
 
-UNINSTALL_libsuitesparse := $(LIBSUITESPARSE_VER) manual_libsuitesparse $(LIBSUITESPARSE_LIBS)
+$(eval $(call staged-install, \
+	libsuitesparse,SuiteSparse-$$(LIBSUITESPARSE_VER), \
+	MAKE_INSTALL,,,))
 
-$(build_prefix)/manifest/libsuitesparse: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled | $(build_prefix)/manifest $(build_shlibdir)
-	echo $(UNINSTALL_libsuitesparse) > $@
-
-clean-libsuitesparse: uninstall-libsuitesparse
-	-rm -f $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled
-	-rm -fr $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/lib
-	-rm -fr $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/include
+clean-libsuitesparse:
+	-rm -f $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-configured $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled
 	-if [ -d $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER) ]; then $(MAKE) -C $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER) clean; fi
 
 distclean-libsuitesparse:
@@ -91,11 +89,11 @@ distclean-libsuitesparse:
 
 get-libsuitesparse: $(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER).tar.gz
 extract-libsuitesparse: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/source-extracted
-configure-libsuitesparse: extract-libsuitesparse
+configure-libsuitesparse: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-configured
 compile-libsuitesparse: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled
 fastcheck-libsuitesparse: #none
 check-libsuitesparse: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-checked
-install-libsuitesparse: $(build_prefix)/manifest/libsuitesparse remove-libsuitesparse-gpl-lib
+install-libsuitesparse: | remove-libsuitesparse-gpl-lib
 
 else # USE_BINARYBUILDER_LIBSUITESPARSE
 
@@ -105,12 +103,6 @@ $(eval $(call bb-install,libsuitesparse,LIBSUITESPARSE,false))
 compile-libsuitesparse: | $(build_prefix)/manifest/blastrampoline
 install-libsuitesparse: | remove-libsuitesparse-gpl-lib
 endif
-
-define manual_libsuitesparse
-uninstall-libsuitesparse:
-	-rm -f $(build_prefix)/manifest/libsuitesparse
-	-rm -f $(addprefix $(build_shlibdir)/lib,$3)
-endef
 
 remove-libsuitesparse-gpl-lib:
 ifeq ($(USE_GPL_LIBS),0)

--- a/deps/libsuitesparse.mk
+++ b/deps/libsuitesparse.mk
@@ -23,10 +23,10 @@ LIBSUITESPARSE_CMAKE_FLAGS := $(CMAKE_COMMON) \
 	  -DSUITESPARSE_USE_OPENMP=OFF \
 	  -DCHOLMOD_PARTITION=ON \
 	  -DBLAS_FOUND=1 \
-	  -DBLAS_LIBRARIES="$(build_shlibdir)/lib$(BLAS_LIB_NAME_NO_EXT).$(SHLIB_EXT)" \
+	  -DBLAS_LIBRARIES="$(build_private_shlibdir)/lib$(BLAS_LIB_NAME_NO_EXT).$(SHLIB_EXT)" \
 	  -DBLAS_LINKER_FLAGS="$(BLAS_LIB_NAME_NO_EXT)" \
 	  -DBLA_VENDOR="$(BLAS_LIB_NAME_NO_EXT)" \
-	  -DLAPACK_LIBRARIES="$(build_shlibdir)/lib$(BLAS_LIB_NAME_NO_EXT).$(SHLIB_EXT)" \
+	  -DLAPACK_LIBRARIES="$(build_private_shlibdir)/lib$(BLAS_LIB_NAME_NO_EXT).$(SHLIB_EXT)" \
 	  -DLAPACK_LINKER_FLAGS="${BLAS_LIB_NAME_NO_EXT}"
 
 ifeq ($(BINARY),64)
@@ -67,7 +67,7 @@ $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled: $(BUILDDIR)/SuiteS
 ifeq ($(OS),WINNT)
 LIBSUITESPARSE_SHLIB_ENV:=PATH="$(abspath $(dir $<))lib:$(build_bindir):$(PATH)"
 else
-LIBSUITESPARSE_SHLIB_ENV:=LD_LIBRARY_PATH="$(build_shlibdir)"
+LIBSUITESPARSE_SHLIB_ENV:=LD_LIBRARY_PATH="$(build_private_shlibdir)"
 endif
 $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-checked: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled
 	for PROJ in $(shell echo $(subst ;, ,$(LIBSUITESPARSE_PROJECTS))); do \

--- a/deps/libtracyclient.mk
+++ b/deps/libtracyclient.mk
@@ -63,7 +63,7 @@ $(LIBTRACYCLIENT_BUILDDIR)/build-compiled: $(LIBTRACYCLIENT_BUILDDIR)/build-conf
 $(eval $(call staged-install, \
 	libtracyclient,$$(LIBTRACYCLIENT_SRC_DIR), \
 	MAKE_INSTALL,,, \
-	$$(INSTALL_NAME_CMD)libtracyclient.$$(SHLIB_EXT) $$(build_shlibdir)/libtracyclient.$$(SHLIB_EXT)))
+	$$(INSTALL_NAME_CMD)libtracyclient.$$(SHLIB_EXT) $$(build_private_shlibdir)/libtracyclient.$$(SHLIB_EXT)))
 
 clean-libtracyclient:
 	rm -rf $(LIBTRACYCLIENT_BUILDDIR)/build-configured $(LIBTRACYCLIENT_BUILDDIR)/build-compiled

--- a/deps/libuv.mk
+++ b/deps/libuv.mk
@@ -56,7 +56,7 @@ endif
 $(eval $(call staged-install, \
 	libuv,$$(LIBUV_SRC_DIR), \
 	MAKE_INSTALL,,, \
-	$$(INSTALL_NAME_CMD)libuv.$$(SHLIB_EXT) $$(build_shlibdir)/libuv.$$(SHLIB_EXT)))
+	$$(INSTALL_NAME_CMD)libuv.$$(SHLIB_EXT) $$(build_private_shlibdir)/libuv.$$(SHLIB_EXT)))
 
 clean-libuv:
 	rm -rf $(LIBUV_BUILDDIR)/build-configured $(LIBUV_BUILDDIR)/build-compiled

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -82,7 +82,7 @@ LLVM_EXPERIMENTAL_TARGETS :=
 LLVM_CFLAGS :=
 LLVM_CXXFLAGS :=
 LLVM_CPPFLAGS :=
-LLVM_LDFLAGS := "-L$(build_shlibdir)" # hacky way to force zlib to be found when linking against libLLVM and sysroot is set
+LLVM_LDFLAGS := -L$(build_shlibdir) # hacky way to force zlib to be found when linking against libLLVM and sysroot is set
 LLVM_CMAKE :=
 
 LLVM_CMAKE += -DLLVM_ENABLE_PROJECTS="$(LLVM_ENABLE_PROJECTS)"

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -82,7 +82,7 @@ LLVM_EXPERIMENTAL_TARGETS :=
 LLVM_CFLAGS :=
 LLVM_CXXFLAGS :=
 LLVM_CPPFLAGS :=
-LLVM_LDFLAGS := -L$(build_shlibdir) # hacky way to force zlib to be found when linking against libLLVM and sysroot is set
+LLVM_LDFLAGS := -L$(build_shlibdir) -L$(build_private_shlibdir) # hacky way to force zlib to be found when linking against libLLVM and sysroot is set
 LLVM_CMAKE :=
 
 LLVM_CMAKE += -DLLVM_ENABLE_PROJECTS="$(LLVM_ENABLE_PROJECTS)"
@@ -163,7 +163,7 @@ endif
 ifeq ($(LLVM_SANITIZE),1)
 ifeq ($(SANITIZE_MEMORY),1)
 LLVM_CFLAGS += -fsanitize=memory -fsanitize-memory-track-origins
-LLVM_LDFLAGS += -fsanitize=memory -fsanitize-memory-track-origins -rpath $(build_shlibdir)
+LLVM_LDFLAGS += -fsanitize=memory -fsanitize-memory-track-origins -rpath $(build_private_shlibdir)
 LLVM_CXXFLAGS += -fsanitize=memory -fsanitize-memory-track-origins
 LLVM_CMAKE += -DLLVM_USE_SANITIZER="MemoryWithOrigins"
 endif
@@ -378,6 +378,47 @@ $(build_prefix)/manifest/llvm-tools uninstall-llvm-tools: \
 	TAR:=$(TAR) --exclude=llvm-config.exe
 
 endif # USE_BINARYBUILDER_LLVM
+
+
+
+# work-around for llvm-config not knowing how to find its libraries after we've
+# moved them around with the `TAR_TRANSFORM_CMD`.  We use `libLLVMAnalysis.a` as
+# a canary for whether or not this has happened.
+install-llvm: $(build_libdir)/libLLVMAnalysis.a
+uninstall-llvm: pre-uninstall-llvm
+$(build_libdir)/libLLVMAnalysis.a: $(build_prefix)/manifest/llvm
+	@for lib in $(build_private_libdir)/libLLVM*.a; do \
+		ln -svf "julia/$$(basename "$${lib}")" "$(build_libdir)/$$(basename "$${lib}")" ; \
+	done
+	touch $@
+
+pre-uninstall-llvm:
+	@for lib in $(build_private_libdir)/libLLVM*.a; do \
+		rm -f "$(build_libdir)/$$(basename "$${lib}")" ; \
+	done
+
+# Rewrite llvm-size's RPATH entry to point to the private libdir
+install-llvm-tools: post-install-llvm-tools
+post-install-llvm-tools: $(build_prefix)/manifest/llvm-tools $(PATCHELF_MANIFEST)
+ifeq ($(OS), Darwin)
+	install_name_tool -rpath @loader_path/$(build_libdir_rel) @loader_path/$(reverse_build_depsbindir_rel) $(build_depsbindir)/llvm-size 2>/dev/null
+else ifneq (,$(findstring $(OS),Linux FreeBSD))
+	-$(PATCHELF) $(PATCHELF_SET_RPATH_ARG) '$$ORIGIN/$(reverse_build_depsbindir_rel)' $(build_depsbindir)/llvm-size
+endif
+
+install-clang: post-install-clang
+post-install-clang: $(build_prefix)/manifest/clang $(PATCHELF_MANIFEST)
+ifeq ($(OS), Darwin)
+	-for exe in clang clang-tidy lld; do \
+		install_name_tool -rpath @loader_path/$(build_libdir_rel) @loader_path/$(reverse_build_depsbindir_rel) $(build_depsbindir)/$$exe 2>/dev/null ; \
+	done
+else ifneq (,$(findstring $(OS),Linux FreeBSD))
+	-for exe in clang clang-tidy lld; do \
+		$(PATCHELF) $(PATCHELF_SET_RPATH_ARG) '$$ORIGIN/$(reverse_build_depsbindir_rel)' $(build_depsbindir)/$$exe ; \
+	done
+endif
+
+
 
 get-lld: get-llvm
 install-lld install-clang install-llvm-tools: install-llvm

--- a/deps/mpfr.mk
+++ b/deps/mpfr.mk
@@ -56,7 +56,7 @@ $(eval $(call staged-install, \
 	mpfr,mpfr-$(MPFR_VER), \
 	MAKE_INSTALL,,, \
 	$$(WIN_MAKE_HARD_LINK) $(build_bindir)/libmpfr-*.dll $(build_bindir)/libmpfr.dll && \
-		$$(INSTALL_NAME_CMD)libmpfr.$$(SHLIB_EXT) $$(build_shlibdir)/libmpfr.$$(SHLIB_EXT)))
+		$$(INSTALL_NAME_CMD)libmpfr.$$(SHLIB_EXT) $$(build_private_shlibdir)/libmpfr.$$(SHLIB_EXT)))
 
 clean-mpfr:
 	-rm -f $(BUILDDIR)/mpfr-$(MPFR_VER)/build-configured $(BUILDDIR)/mpfr-$(MPFR_VER)/build-compiled

--- a/deps/nghttp2.mk
+++ b/deps/nghttp2.mk
@@ -34,7 +34,7 @@ endif
 $(eval $(call staged-install, \
 	nghttp2,nghttp2-$(NGHTTP2_VER), \
 	MAKE_INSTALL,,, \
-	$$(INSTALL_NAME_CMD)libnghttp2.$$(SHLIB_EXT) $$(build_shlibdir)/libnghttp2.$$(SHLIB_EXT)))
+	$$(INSTALL_NAME_CMD)libnghttp2.$$(SHLIB_EXT) $$(build_private_shlibdir)/libnghttp2.$$(SHLIB_EXT)))
 
 clean-nghttp2:
 	-rm -f $(BUILDDIR)/nghttp2-$(NGHTTP2_VER)/build-configured $(BUILDDIR)/nghttp2-$(NGHTTP2_VER)/build-compiled

--- a/deps/openblas.mk
+++ b/deps/openblas.mk
@@ -112,7 +112,7 @@ endef
 $(eval $(call staged-install, \
 	openblas,$(OPENBLAS_SRC_DIR), \
 	OPENBLAS_INSTALL,$(BUILDDIR)/$(OPENBLAS_SRC_DIR)/$(LIBBLASNAME).$(SHLIB_EXT),, \
-	$$(INSTALL_NAME_CMD)libopenblas$$(OPENBLAS_LIBNAMESUFFIX).$$(SHLIB_EXT) $$(build_shlibdir)/libopenblas$$(OPENBLAS_LIBNAMESUFFIX).$$(SHLIB_EXT)))
+	$$(INSTALL_NAME_CMD)libopenblas$$(OPENBLAS_LIBNAMESUFFIX).$$(SHLIB_EXT) $$(build_private_shlibdir)/libopenblas$$(OPENBLAS_LIBNAMESUFFIX).$$(SHLIB_EXT)))
 
 clean-openblas:
 	-rm -f $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-compiled
@@ -133,7 +133,7 @@ $(BUILDDIR)/libgfortblas.$(SHLIB_EXT): $(SRCDIR)/gfortblas.c $(SRCDIR)/gfortblas
 	$(CC) -Wall -O3 $(CPPFLAGS) $(CFLAGS) $(fPIC) -shared $< -o $@ -pipe \
 				-Wl,-reexport_framework,Accelerate -Wl,-alias_list,$(SRCDIR)/gfortblas.alias
 
-$(build_shlibdir)/libgfortblas.$(SHLIB_EXT): $(BUILDDIR)/libgfortblas.$(SHLIB_EXT)
+$(build_private_shlibdir)/libgfortblas.$(SHLIB_EXT): $(BUILDDIR)/libgfortblas.$(SHLIB_EXT)
 	cp -f $< $@
 	$(INSTALL_NAME_CMD)libgfortblas.$(SHLIB_EXT) $@
 endif
@@ -161,7 +161,7 @@ checksum-lapack: $(SRCCACHE)/lapack-$(LAPACK_VER).tgz
 ifeq ($(USE_SYSTEM_BLAS), 0)
 $(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled0: | $(build_prefix)/manifest/openblas
 else ifeq ($(OS),Darwin)
-$(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled0: | $(build_shlibdir)/libgfortblas.$(SHLIB_EXT)
+$(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled0: | $(build_private_shlibdir)/libgfortblas.$(SHLIB_EXT)
 endif
 $(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled0: $(BUILDDIR)/lapack-$(LAPACK_VER)/source-extracted
 	$(MAKE) -C $(dir $@) lapacklib $(LAPACK_MFLAGS)
@@ -183,7 +183,7 @@ $(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled: $(BUILDDIR)/lapack-$(LAPACK_VER
 $(eval $(call staged-install, \
 	lapack,lapack-$(LAPACK_VER), \
 	SHLIBFILE_INSTALL,$(BUILDDIR)/lapack-$(LAPACK_VER)/liblapack.$(SHLIB_EXT),, \
-	$$(INSTALL_NAME_CMD)liblapack.$$(SHLIB_EXT) $$(build_shlibdir)/liblapack.$$(SHLIB_EXT)))
+	$$(INSTALL_NAME_CMD)liblapack.$$(SHLIB_EXT) $$(build_private_shlibdir)/liblapack.$$(SHLIB_EXT)))
 
 clean-lapack:
 	-rm -f $(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled0 $(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled

--- a/deps/openlibm.mk
+++ b/deps/openlibm.mk
@@ -13,7 +13,7 @@ $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/build-compiled: $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/
 $(eval $(call staged-install, \
 	openlibm,$$(OPENLIBM_SRC_DIR), \
 	MAKE_INSTALL,$$(OPENLIBM_FLAGS),, \
-	$(INSTALL_NAME_CMD)libopenlibm.$(SHLIB_EXT) $(build_shlibdir)/libopenlibm.$(SHLIB_EXT)))
+	$(INSTALL_NAME_CMD)libopenlibm.$(SHLIB_EXT) $(build_private_shlibdir)/libopenlibm.$(SHLIB_EXT)))
 
 clean-openlibm:
 	-rm -f $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/build-compiled $(build_libdir)/libopenlibm.a

--- a/deps/openssl.mk
+++ b/deps/openssl.mk
@@ -80,9 +80,9 @@ OPENSSL_INSTALL = \
 OPENSSL_POST_INSTALL := \
 	$(WIN_MAKE_HARD_LINK) $(build_bindir)/libcrypto-*.dll $(build_bindir)/libcrypto.dll && \
 	$(WIN_MAKE_HARD_LINK) $(build_bindir)/libssl-*.dll $(build_bindir)/libssl.dll && \
-	$(INSTALL_NAME_CMD)libcrypto.$(SHLIB_EXT) $(build_shlibdir)/libcrypto.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libssl.$(SHLIB_EXT) $(build_shlibdir)/libssl.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CHANGE_CMD) $(build_shlibdir)/libcrypto.3.dylib @rpath/libcrypto.$(SHLIB_EXT) $(build_shlibdir)/libssl.$(SHLIB_EXT)
+	$(INSTALL_NAME_CMD)libcrypto.$(SHLIB_EXT) $(build_private_shlibdir)/libcrypto.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libssl.$(SHLIB_EXT) $(build_private_shlibdir)/libssl.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CHANGE_CMD) $(build_private_shlibdir)/libcrypto.3.dylib @rpath/libcrypto.$(SHLIB_EXT) $(build_private_shlibdir)/libssl.$(SHLIB_EXT)
 
 $(eval $(call staged-install, \
 	openssl,openssl-$(OPENSSL_VER), \

--- a/deps/pcre.mk
+++ b/deps/pcre.mk
@@ -48,8 +48,8 @@ endif
 $(eval $(call staged-install, \
 	pcre,pcre2-$$(PCRE_VER), \
 	MAKE_INSTALL,$$(LIBTOOL_CCLD),, \
-	rm -f $$(build_shlibdir)/libpcre2-posix.* && \
-	$$(INSTALL_NAME_CMD)libpcre2-8.$$(SHLIB_EXT) $$(build_shlibdir)/libpcre2-8.$$(SHLIB_EXT)))
+	rm -f $$(build_private_shlibdir)/libpcre2-posix.* && \
+	$$(INSTALL_NAME_CMD)libpcre2-8.$$(SHLIB_EXT) $$(build_private_shlibdir)/libpcre2-8.$$(SHLIB_EXT)))
 
 clean-pcre:
 	-rm -f $(BUILDDIR)/pcre2-$(PCRE_VER)/build-configured $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled

--- a/deps/sanitizers.mk
+++ b/deps/sanitizers.mk
@@ -11,13 +11,13 @@ $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(2)))))
 endef
 
 define copy_sanitizer_lib
-install-sanitizers: $$(addprefix $$(build_libdir)/, $$(notdir $$(call pathsearch_all,$(1),$$(SANITIZER_LIB_PATH)))) | $$(build_shlibdir)
+install-sanitizers: $$(addprefix $$(build_private_shlibdir)/, $$(notdir $$(call pathsearch_all,$(1),$$(SANITIZER_LIB_PATH)))) | $$(build_private_shlibdir)
 	@result=$$(call pathsearch_all,$(1),$$(SANITIZER_LIB_PATH)); \
 	if [ -z "$$$$result" ]; then \
 		echo "Sanitizer library $(1) not found in $$(SANITIZER_LIB_PATH)"; \
 		exit 1; \
 	fi
-$$(addprefix $$(build_shlibdir)/,$(2)): $$(addprefix $$(dir $$(call pathsearch_all,$(1),$$(SANITIZER_LIB_PATH))),$(2)) $$(PATCHELF_MANIFEST) | $$(build_shlibdir)
+$$(addprefix $$(build_private_shlibdir)/,$(2)): $$(addprefix $$(dir $$(call pathsearch_all,$(1),$$(SANITIZER_LIB_PATH))),$(2)) $$(PATCHELF_MANIFEST) | $$(build_private_shlibdir)
 	-cp $$< $$@
 ifneq (,$(findstring $(OS),Linux))
 	-$(PATCHELF) $(PATCHELF_SET_RPATH_ARG) '$$$$ORIGIN' $$@
@@ -33,5 +33,5 @@ endif
 
 get-sanitizers:
 clean-sanitizers:
-	-rm -f $(build_shlibdir)/libclang_rt.asan*$(SHLIB_EXT)*
+	-rm -f $(build_private_shlibdir)/libclang_rt.asan*$(SHLIB_EXT)*
 distclean-sanitizers: clean-sanitizers

--- a/deps/tools/bb-install.mk
+++ b/deps/tools/bb-install.mk
@@ -54,10 +54,13 @@ $$(build_prefix)/manifest/$(strip $1): $$(SRCCACHE)/$$($(2)_JLL_BASENAME) | $(bu
 ifneq (bsdtar,$(findstring bsdtar,$(TAR_TEST)))
 	@# work-around a gtar bug: they do some complicated work to avoid the mkdir
 	@# syscall, which is buggy when working with Tar.jl files so we manually do
-	@# the mkdir calls first in a pre-pass
-	$$(TAR) -tzf $$< | xargs -n 1 dirname | sort -u | (cd $$(build_prefix) && xargs -t mkdir -p)
+	@# the mkdir calls first in a pre-pass (with transforms applied to match extraction)
+	$$(TAR) -tzf $$< | sed $(SED_TRANSFORM_PRIVATE) | xargs -n 1 dirname | sort -u | (cd $$(build_prefix) && xargs -t mkdir -p)
 endif
-	$$(UNTAR) $$< -C $$(build_prefix)
+	# Extract with transform to unpack directly into private locations
+	# lib/* → lib/julia/*, libexec/* → libexec/julia/*, bin/* stays in place
+	$$(TAR) $(TAR_TRANSFORM_PRIVATE) -xzf $$< -C $$(build_prefix)
+	$$(call REWRITE_PKGCONFIG_LIBDIR,-tzf)
 	echo '$$(UNINSTALL_$(strip $1))' > $$@
 
 # Special "checksum-foo" target to speed up `contrib/refresh_checksums.sh`
@@ -82,6 +85,6 @@ endef
 
 define bb-uninstaller
 uninstall-$(strip $1):
-	-cd $$(build_prefix) && rm -fv -- $$$$($$(TAR) -tzf $$(SRCCACHE)/$2.tar.gz | grep -v '/$$$$')
+	-cd $$(build_prefix) && rm -fv -- $$$$($$(TAR) -tzf $$(SRCCACHE)/$2.tar.gz | sed $(SED_TRANSFORM_PRIVATE) | grep -v '/$$$$')
 	-rm -f $$(build_prefix)/manifest/$(strip $1)
 endef

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -18,13 +18,14 @@ endif
 ifeq ($(OS),WINNT)
 CONFIGURE_COMMON += LDFLAGS="$(LDFLAGS) -Wl,--stack,8388608"
 else
-CONFIGURE_COMMON += LDFLAGS="$(LDFLAGS) $(RPATH_ESCAPED_ORIGIN) $(SANITIZE_LDFLAGS)"
+CONFIGURE_COMMON += LDFLAGS="$(LDFLAGS) -L$(build_private_shlibdir) $(RPATH_ESCAPED_ORIGIN) $(SANITIZE_LDFLAGS)"
 endif
 CONFIGURE_COMMON += F77="$(FC)" CC="$(CC) $(SANITIZE_OPTS)" CXX="$(CXX) $(SANITIZE_OPTS)" LD="$(LD)"
 
 ifneq ($(OS),WINNT)
 CMAKE_COMMON += -DCMAKE_INSTALL_LIBDIR=$(build_libdir)
 endif
+CMAKE_COMMON += -DCMAKE_LIBRARY_PATH=$(build_private_shlibdir)
 
 ifeq ($(OS), Darwin)
 CMAKE_COMMON += -DCMAKE_MACOSX_RPATH=1
@@ -156,7 +157,7 @@ endif
 
 ## PATHS ##
 # sort is used to remove potential duplicates
-DIRS := $(sort $(build_bindir) $(build_depsbindir) $(build_libdir) $(build_includedir) $(build_sysconfdir) $(build_datarootdir) $(build_staging) $(build_prefix)/manifest)
+DIRS := $(sort $(build_bindir) $(build_depsbindir) $(build_libdir) $(build_private_shlibdir) $(build_includedir) $(build_sysconfdir) $(build_datarootdir) $(build_staging) $(build_prefix)/manifest)
 
 $(foreach dir,$(DIRS),$(eval $(call dir_target,$(dir))))
 $(build_prefix): | $(DIRS)
@@ -192,6 +193,18 @@ define BINFILE_INSTALL
 	cp $3 $2/$$(build_depsbindir)
 endef
 
+# Rewrite libdir in pkgconfig files from lib/ to lib/julia/ to match the
+# private shared library layout. Operates only on .pc files listed in the tarball.
+# $1 = tar listing flags (e.g. -tf or -tzf)
+# Called via $$(call ...) from within recipe lines of staged-install / bb-install.
+define REWRITE_PKGCONFIG_LIBDIR
+	$(TAR) $1 $< | sed -n 's,^./,,;s,^\(lib/pkgconfig/[^/]*\.pc\)$$,\1,p' | while read pc; do \
+		pc="$(build_prefix)/$$pc"; \
+		sed 's|libdir=\$${exec_prefix}/lib$$|libdir=\$${exec_prefix}/lib/julia|' "$$pc" > "$$pc.tmp" && \
+		mv "$$pc.tmp" "$$pc"; \
+	done
+endef
+
 define staged-install
 stage-$(strip $1): $$(build_staging)/$2.tar
 install-$(strip $1): $$(build_prefix)/manifest/$(strip $1)
@@ -223,7 +236,11 @@ UNINSTALL_$(strip $1) := $2 staged-uninstaller
 
 $$(build_prefix)/manifest/$(strip $1): $$(build_staging)/$2.tar | $(build_prefix)/manifest
 	-+[ ! -e $$@ ] || $$(MAKE) uninstall-$(strip $1)
-	$$(UNTAR) $$< -C $$(build_prefix)
+ifneq (bsdtar,$(findstring bsdtar,$(TAR_TEST)))
+	$$(TAR) -tf $$< | sed $(SED_TRANSFORM_PRIVATE) | xargs -n 1 dirname | sort -u | (cd $$(build_prefix) && xargs -t mkdir -p)
+endif
+	$$(UNTAR_PRIVATE) $$< -C $$(build_prefix)
+	$$(call REWRITE_PKGCONFIG_LIBDIR,-tf)
 	$6
 	echo '$$(UNINSTALL_$(strip $1))' > $$@
 .PHONY: $(addsuffix -$(strip $1),stage install distclean uninstall reinstall)
@@ -231,7 +248,7 @@ endef
 
 define staged-uninstaller
 uninstall-$(strip $1):
-	-cd $$(build_prefix) && rm -fv -- $$$$($$(TAR) -tf $$(build_staging)/$2.tar | grep -v '/$$$$')
+	-cd $$(build_prefix) && rm -fv -- $$$$($$(TAR) -tf $$(build_staging)/$2.tar | sed $(SED_TRANSFORM_PRIVATE) | grep -v '/$$$$')
 	-rm -f $$(build_prefix)/manifest/$(strip $1)
 endef
 
@@ -281,9 +298,11 @@ endef
 ifneq (bsdtar,$(findstring bsdtar,$(TAR_TEST)))
 #gnu tar
 UNTAR = $(TAR) -xmf
+UNTAR_PRIVATE = $(TAR) $(TAR_TRANSFORM_PRIVATE) -xmf
 else
 #bsd tar
 UNTAR = $(TAR) -xmUf
+UNTAR_PRIVATE = $(TAR) $(TAR_TRANSFORM_PRIVATE) -xmUf
 endif
 
 

--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -5,7 +5,7 @@ include $(SRCDIR)/llvmunwind.version
 ifneq ($(USE_BINARYBUILDER_LIBUNWIND),1)
 LIBUNWIND_CFLAGS := -U_FORTIFY_SOURCE $(fPIC) $(SANITIZE_OPTS)
 LIBUNWIND_CPPFLAGS := -I$(build_includedir)
-LIBUNWIND_LDFLAGS := -L$(build_shlibdir)
+LIBUNWIND_LDFLAGS := -L$(build_private_shlibdir)
 
 ifeq ($(USE_SYSTEM_ZLIB),0)
 $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured: | $(build_prefix)/manifest/zlib

--- a/deps/zlib.mk
+++ b/deps/zlib.mk
@@ -20,7 +20,7 @@ $(BUILDDIR)/$(ZLIB_SRC_DIR)/build-compiled: $(BUILDDIR)/$(ZLIB_SRC_DIR)/build-co
 $(eval $(call staged-install, \
 	zlib,$(ZLIB_SRC_DIR), \
 	MAKE_INSTALL,,, \
-	$(INSTALL_NAME_CMD)libz.$(SHLIB_EXT) $(build_shlibdir)/libz.$(SHLIB_EXT)))
+	$(INSTALL_NAME_CMD)libz.$(SHLIB_EXT) $(build_private_shlibdir)/libz.$(SHLIB_EXT)))
 
 clean-zlib:
 	-rm -f $(BUILDDIR)/$(ZLIB_SRC_DIR)/build-configured $(BUILDDIR)/$(ZLIB_SRC_DIR)/build-compiled

--- a/src/Makefile
+++ b/src/Makefile
@@ -202,7 +202,7 @@ else
 LIBJULIA_PATH_REL := libjulia
 endif
 
-COMMON_LIBPATHS := -L$(build_libdir) -L$(build_shlibdir)
+COMMON_LIBPATHS := -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir)
 RT_LIBS := $(call whole_archive,$(LIBUV)) $(call whole_archive,$(LIBUTF8PROC)) $(LIBUNWIND) $(RT_LLVMLINK) $(OSLIBS) $(LIBTRACYCLIENT) $(LIBITTAPI) -lzstd
 # NB: CG needs uv_mutex_* symbols, but we expect to export them from libjulia-internal
 CG_LIBS := $(LIBUNWIND) $(CG_LLVMLINK) $(OSLIBS) $(LIBTRACYCLIENT) $(LIBITTAPI)
@@ -331,20 +331,20 @@ $(build_includedir)/julia/uv/*.h: $(LIBUV_INC)/uv/*.h | $(build_includedir)/juli
 	$(INSTALL_F) $^ $(build_includedir)/julia/uv
 
 .PHONY: libccalltest
-libccalltest: $(build_shlibdir)/libccalltest.$(SHLIB_EXT)
+libccalltest: $(build_private_shlibdir)/libccalltest.$(SHLIB_EXT)
 .PHONY: libccalllazyfoo
-libccalllazyfoo: $(build_shlibdir)/libccalllazyfoo.$(SHLIB_EXT)
+libccalllazyfoo: $(build_private_shlibdir)/libccalllazyfoo.$(SHLIB_EXT)
 .PHONY: libccalllazybar
-libccalllazybar: $(build_shlibdir)/libccalllazybar.$(SHLIB_EXT)
+libccalllazybar: $(build_private_shlibdir)/libccalllazybar.$(SHLIB_EXT)
 .PHONY: libllvmcalltest
-libllvmcalltest: $(build_shlibdir)/libllvmcalltest.$(SHLIB_EXT)
+libllvmcalltest: $(build_private_shlibdir)/libllvmcalltest.$(SHLIB_EXT)
 
 ifeq ($(OS), Linux)
 JULIA_SPLITDEBUG := 1
 else
 JULIA_SPLITDEBUG := 0
 endif
-$(build_shlibdir)/libccalltest.$(SHLIB_EXT): $(SRCDIR)/ccalltest.c
+$(build_private_shlibdir)/libccalltest.$(SHLIB_EXT): $(SRCDIR)/ccalltest.c
 	@$(call PRINT_CC, $(CC) $(JCFLAGS) $(JCPPFLAGS) $(FLAGS_COMMON) -O3 $< $(fPIC) -shared -o $@.tmp $(LDFLAGS))
 	$(INSTALL_NAME_CMD)libccalltest.$(SHLIB_EXT) $@.tmp
 ifeq ($(JULIA_SPLITDEBUG),1)
@@ -361,13 +361,13 @@ endif
 	mv $@.tmp $@
 	$(INSTALL_NAME_CMD)libccalltest.$(SHLIB_EXT) $@
 
-$(build_shlibdir)/libccalllazyfoo.$(SHLIB_EXT): $(SRCDIR)/ccalllazyfoo.c
+$(build_private_shlibdir)/libccalllazyfoo.$(SHLIB_EXT): $(SRCDIR)/ccalllazyfoo.c
 	@$(call PRINT_CC, $(CC) $(JCFLAGS) $(JCPPFLAGS) $(FLAGS_COMMON) -O3 $< $(fPIC) -shared -o $@ $(LDFLAGS) $(COMMON_LIBPATHS) $(call SONAME_FLAGS,libccalllazyfoo.$(SHLIB_EXT)))
 
-$(build_shlibdir)/libccalllazybar.$(SHLIB_EXT): $(SRCDIR)/ccalllazybar.c $(build_shlibdir)/libccalllazyfoo.$(SHLIB_EXT)
+$(build_private_shlibdir)/libccalllazybar.$(SHLIB_EXT): $(SRCDIR)/ccalllazybar.c $(build_private_shlibdir)/libccalllazyfoo.$(SHLIB_EXT)
 	@$(call PRINT_CC, $(CC) $(JCFLAGS) $(JCPPFLAGS) $(FLAGS_COMMON) -O3 $< $(fPIC) -shared -o $@ $(LDFLAGS) $(COMMON_LIBPATHS) $(call SONAME_FLAGS,libccalllazybar.$(SHLIB_EXT)) -lccalllazyfoo)
 
-$(build_shlibdir)/libllvmcalltest.$(SHLIB_EXT): $(SRCDIR)/llvmcalltest.cpp $(LLVM_CONFIG_ABSOLUTE)
+$(build_private_shlibdir)/libllvmcalltest.$(SHLIB_EXT): $(SRCDIR)/llvmcalltest.cpp $(LLVM_CONFIG_ABSOLUTE)
 	@$(call PRINT_CC, $(CXX) $(JCXXFLAGS) $(LLVM_CXXFLAGS) $(FLAGS_COMMON) $(CPPFLAGS) $(CXXFLAGS) -O3 $< $(fPIC) -shared -o $@ $(LDFLAGS) $(COMMON_LIBPATHS) $(CG_LLVMLINK)) -lpthread
 
 .PHONY: julia_flisp.boot.inc.phony
@@ -408,7 +408,7 @@ $(BUILDDIR)/init.o $(BUILDDIR)/init.dbg.obj: $(SRCDIR)/builtin_proto.h
 $(BUILDDIR)/interpreter.o $(BUILDDIR)/interpreter.dbg.obj: $(SRCDIR)/builtin_proto.h
 $(BUILDDIR)/jitlayers.o $(BUILDDIR)/jitlayers.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/llvm-codegen-shared.h $(SRCDIR)/julia-task-dispatcher.h
 $(BUILDDIR)/jltypes.o $(BUILDDIR)/jltypes.dbg.obj: $(SRCDIR)/builtin_proto.h
-$(build_shlibdir)/libllvmcalltest.$(SHLIB_EXT): $(SRCDIR)/llvm-codegen-shared.h $(BUILDDIR)/julia_version.h
+$(build_private_shlibdir)/libllvmcalltest.$(SHLIB_EXT): $(SRCDIR)/llvm-codegen-shared.h $(BUILDDIR)/julia_version.h
 $(BUILDDIR)/llvm-alloc-helpers.o $(BUILDDIR)/llvm-alloc-helpers.dbg.obj: $(SRCDIR)/llvm-codegen-shared.h $(SRCDIR)/llvm-pass-helpers.h $(SRCDIR)/llvm-alloc-helpers.h
 $(BUILDDIR)/llvm-alloc-opt.o $(BUILDDIR)/llvm-alloc-opt.dbg.obj: $(SRCDIR)/llvm-codegen-shared.h $(SRCDIR)/llvm-pass-helpers.h $(SRCDIR)/llvm-alloc-helpers.h
 $(BUILDDIR)/llvm-cpufeatures.o $(BUILDDIR)/llvm-cpufeatures.dbg.obj: $(SRCDIR)/jitlayers.h
@@ -476,58 +476,58 @@ $(BUILDDIR)/julia.expmap: $(SRCDIR)/julia.expmap.in $(JULIAHOME)/VERSION $(LLVM_
 		        -e "s/@LLVM_SHLIB_SYMBOL_VERSION@/$(LLVM_SHLIB_SYMBOL_VERSION)/"; \
 	mv $$TMPFILE $@
 
-$(build_shlibdir)/libjulia-internal.$(JL_MAJOR_MINOR_SHLIB_EXT): $(BUILDDIR)/julia.expmap $(OBJS) $(BUILDDIR)/flisp/libflisp.a $(BUILDDIR)/support/libsupport.a $(LIBUV)
+$(build_private_shlibdir)/libjulia-internal.$(JL_MAJOR_MINOR_SHLIB_EXT): $(BUILDDIR)/julia.expmap $(OBJS) $(BUILDDIR)/flisp/libflisp.a $(BUILDDIR)/support/libsupport.a $(LIBUV)
 	@$(call PRINT_LINK, $(CXXLD) $(call IMPLIB_FLAGS,$@) $(SHIPFLAGS) $(JCXXFLAGS) $(CXXLDFLAGS) $(OBJS) $(RPATH_LIB) -o $@ \
 		$(JLDFLAGS) $(BOLT_LDFLAGS) $(JLIBLDFLAGS) $(RT_RELEASE_LIBS) $(call SONAME_FLAGS,libjulia-internal.$(JL_MAJOR_SHLIB_EXT)))
 	@$(INSTALL_NAME_CMD)libjulia-internal.$(SHLIB_EXT) $@
 	$(DSYMUTIL) $@
 
-$(build_shlibdir)/libjulia-internal-debug.$(JL_MAJOR_MINOR_SHLIB_EXT): $(BUILDDIR)/julia.expmap $(DOBJS) $(BUILDDIR)/flisp/libflisp-debug.a $(BUILDDIR)/support/libsupport-debug.a $(LIBUV)
+$(build_private_shlibdir)/libjulia-internal-debug.$(JL_MAJOR_MINOR_SHLIB_EXT): $(BUILDDIR)/julia.expmap $(DOBJS) $(BUILDDIR)/flisp/libflisp-debug.a $(BUILDDIR)/support/libsupport-debug.a $(LIBUV)
 	@$(call PRINT_LINK, $(CXXLD) $(call IMPLIB_FLAGS,$@) $(DEBUGFLAGS) $(JCXXFLAGS) $(CXXLDFLAGS) $(DOBJS) $(RPATH_LIB) -o $@ \
 		$(JLDFLAGS) $(JLIBLDFLAGS) $(RT_DEBUG_LIBS) $(call SONAME_FLAGS,libjulia-internal-debug.$(JL_MAJOR_SHLIB_EXT)))
 	@$(INSTALL_NAME_CMD)libjulia-internal-debug.$(SHLIB_EXT) $@
 	$(DSYMUTIL) $@
 
 ifneq ($(OS), WINNT)
-$(build_shlibdir)/libjulia-internal.$(JL_MAJOR_SHLIB_EXT) $(build_shlibdir)/libjulia-internal-debug.$(JL_MAJOR_SHLIB_EXT): $(build_shlibdir)/libjulia-internal%.$(JL_MAJOR_SHLIB_EXT): \
-		$(build_shlibdir)/libjulia-internal%.$(JL_MAJOR_MINOR_SHLIB_EXT)
+$(build_private_shlibdir)/libjulia-internal.$(JL_MAJOR_SHLIB_EXT) $(build_private_shlibdir)/libjulia-internal-debug.$(JL_MAJOR_SHLIB_EXT): $(build_private_shlibdir)/libjulia-internal%.$(JL_MAJOR_SHLIB_EXT): \
+		$(build_private_shlibdir)/libjulia-internal%.$(JL_MAJOR_MINOR_SHLIB_EXT)
 	@$(call PRINT_LINK, ln -sf $(notdir $<) $@)
-$(build_shlibdir)/libjulia-internal.$(SHLIB_EXT) $(build_shlibdir)/libjulia-internal-debug.$(SHLIB_EXT): $(build_shlibdir)/libjulia-internal%.$(SHLIB_EXT): \
-		$(build_shlibdir)/libjulia-internal%.$(JL_MAJOR_MINOR_SHLIB_EXT)
+$(build_private_shlibdir)/libjulia-internal.$(SHLIB_EXT) $(build_private_shlibdir)/libjulia-internal-debug.$(SHLIB_EXT): $(build_private_shlibdir)/libjulia-internal%.$(SHLIB_EXT): \
+		$(build_private_shlibdir)/libjulia-internal%.$(JL_MAJOR_MINOR_SHLIB_EXT)
 	@$(call PRINT_LINK, ln -sf $(notdir $<) $@)
-$(build_shlibdir)/libjulia-codegen.$(JL_MAJOR_MINOR_SHLIB_EXT): $(build_shlibdir)/libjulia-internal.$(SHLIB_EXT)
-$(build_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_MINOR_SHLIB_EXT): $(build_shlibdir)/libjulia-internal-debug.$(SHLIB_EXT)
-libjulia-internal-release: $(build_shlibdir)/libjulia-internal.$(JL_MAJOR_SHLIB_EXT) $(build_shlibdir)/libjulia-internal.$(SHLIB_EXT)
-libjulia-internal-debug: $(build_shlibdir)/libjulia-internal-debug.$(JL_MAJOR_SHLIB_EXT) $(build_shlibdir)/libjulia-internal-debug.$(SHLIB_EXT)
+$(build_private_shlibdir)/libjulia-codegen.$(JL_MAJOR_MINOR_SHLIB_EXT): $(build_private_shlibdir)/libjulia-internal.$(SHLIB_EXT)
+$(build_private_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_MINOR_SHLIB_EXT): $(build_private_shlibdir)/libjulia-internal-debug.$(SHLIB_EXT)
+libjulia-internal-release: $(build_private_shlibdir)/libjulia-internal.$(JL_MAJOR_SHLIB_EXT) $(build_private_shlibdir)/libjulia-internal.$(SHLIB_EXT)
+libjulia-internal-debug: $(build_private_shlibdir)/libjulia-internal-debug.$(JL_MAJOR_SHLIB_EXT) $(build_private_shlibdir)/libjulia-internal-debug.$(SHLIB_EXT)
 endif
-libjulia-internal-release: $(build_shlibdir)/libjulia-internal.$(JL_MAJOR_MINOR_SHLIB_EXT)
-libjulia-internal-debug: $(build_shlibdir)/libjulia-internal-debug.$(JL_MAJOR_MINOR_SHLIB_EXT)
+libjulia-internal-release: $(build_private_shlibdir)/libjulia-internal.$(JL_MAJOR_MINOR_SHLIB_EXT)
+libjulia-internal-debug: $(build_private_shlibdir)/libjulia-internal-debug.$(JL_MAJOR_MINOR_SHLIB_EXT)
 libjulia-internal-debug libjulia-internal-release: $(PUBLIC_HEADER_TARGETS)
 
-$(build_shlibdir)/libjulia-codegen.$(JL_MAJOR_MINOR_SHLIB_EXT): $(BUILDDIR)/julia.expmap $(CODEGEN_OBJS) $(BUILDDIR)/support/libsupport.a $(build_shlibdir)/libjulia-internal.$(JL_MAJOR_MINOR_SHLIB_EXT)
+$(build_private_shlibdir)/libjulia-codegen.$(JL_MAJOR_MINOR_SHLIB_EXT): $(BUILDDIR)/julia.expmap $(CODEGEN_OBJS) $(BUILDDIR)/support/libsupport.a $(build_private_shlibdir)/libjulia-internal.$(JL_MAJOR_MINOR_SHLIB_EXT)
 	@$(call PRINT_LINK, $(CXXLD) $(call IMPLIB_FLAGS,$@) $(SHIPFLAGS) $(JCXXFLAGS) $(CXXLDFLAGS) $(CODEGEN_OBJS) $(RPATH_LIB) -o $@ \
 		$(JLDFLAGS) $(BOLT_LDFLAGS) $(JLIBLDFLAGS) $(CG_RELEASE_LIBS) $(call SONAME_FLAGS,libjulia-codegen.$(JL_MAJOR_SHLIB_EXT)))
 	@$(INSTALL_NAME_CMD)libjulia-codegen.$(SHLIB_EXT) $@
 	$(DSYMUTIL) $@
 
-$(build_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_MINOR_SHLIB_EXT): $(BUILDDIR)/julia.expmap $(CODEGEN_DOBJS) $(BUILDDIR)/support/libsupport-debug.a $(build_shlibdir)/libjulia-internal-debug.$(JL_MAJOR_MINOR_SHLIB_EXT)
+$(build_private_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_MINOR_SHLIB_EXT): $(BUILDDIR)/julia.expmap $(CODEGEN_DOBJS) $(BUILDDIR)/support/libsupport-debug.a $(build_private_shlibdir)/libjulia-internal-debug.$(JL_MAJOR_MINOR_SHLIB_EXT)
 	@$(call PRINT_LINK, $(CXXLD) $(call IMPLIB_FLAGS,$@) $(DEBUGFLAGS) $(JCXXFLAGS) $(CXXLDFLAGS) $(CODEGEN_DOBJS) $(RPATH_LIB) -o $@ \
 		$(JLDFLAGS) $(JLIBLDFLAGS) $(CG_DEBUG_LIBS) $(call SONAME_FLAGS,libjulia-codegen-debug.$(JL_MAJOR_SHLIB_EXT)))
 	@$(INSTALL_NAME_CMD)libjulia-codegen-debug.$(SHLIB_EXT) $@
 	$(DSYMUTIL) $@
 
 ifneq ($(OS), WINNT)
-$(build_shlibdir)/libjulia-codegen.$(JL_MAJOR_SHLIB_EXT) $(build_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_SHLIB_EXT): $(build_shlibdir)/libjulia-codegen%.$(JL_MAJOR_SHLIB_EXT): \
-		$(build_shlibdir)/libjulia-codegen%.$(JL_MAJOR_MINOR_SHLIB_EXT)
+$(build_private_shlibdir)/libjulia-codegen.$(JL_MAJOR_SHLIB_EXT) $(build_private_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_SHLIB_EXT): $(build_private_shlibdir)/libjulia-codegen%.$(JL_MAJOR_SHLIB_EXT): \
+		$(build_private_shlibdir)/libjulia-codegen%.$(JL_MAJOR_MINOR_SHLIB_EXT)
 	@$(call PRINT_LINK, ln -sf $(notdir $<) $@)
-$(build_shlibdir)/libjulia-codegen.$(SHLIB_EXT) $(build_shlibdir)/libjulia-codegen-debug.$(SHLIB_EXT): $(build_shlibdir)/libjulia-codegen%.$(SHLIB_EXT): \
-		$(build_shlibdir)/libjulia-codegen%.$(JL_MAJOR_MINOR_SHLIB_EXT)
+$(build_private_shlibdir)/libjulia-codegen.$(SHLIB_EXT) $(build_private_shlibdir)/libjulia-codegen-debug.$(SHLIB_EXT): $(build_private_shlibdir)/libjulia-codegen%.$(SHLIB_EXT): \
+		$(build_private_shlibdir)/libjulia-codegen%.$(JL_MAJOR_MINOR_SHLIB_EXT)
 	@$(call PRINT_LINK, ln -sf $(notdir $<) $@)
-libjulia-codegen-release: $(build_shlibdir)/libjulia-codegen.$(JL_MAJOR_SHLIB_EXT) $(build_shlibdir)/libjulia-codegen.$(SHLIB_EXT)
-libjulia-codegen-debug: $(build_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_SHLIB_EXT) $(build_shlibdir)/libjulia-codegen-debug.$(SHLIB_EXT)
+libjulia-codegen-release: $(build_private_shlibdir)/libjulia-codegen.$(JL_MAJOR_SHLIB_EXT) $(build_private_shlibdir)/libjulia-codegen.$(SHLIB_EXT)
+libjulia-codegen-debug: $(build_private_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_SHLIB_EXT) $(build_private_shlibdir)/libjulia-codegen-debug.$(SHLIB_EXT)
 endif
-libjulia-codegen-release: $(build_shlibdir)/libjulia-codegen.$(JL_MAJOR_MINOR_SHLIB_EXT)
-libjulia-codegen-debug: $(build_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_MINOR_SHLIB_EXT)
+libjulia-codegen-release: $(build_private_shlibdir)/libjulia-codegen.$(JL_MAJOR_MINOR_SHLIB_EXT)
+libjulia-codegen-debug: $(build_private_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_MINOR_SHLIB_EXT)
 libjulia-codegen-debug libjulia-codegen-release: $(PUBLIC_HEADER_TARGETS)
 
 # set the exports for the source files based on where they are getting linked
@@ -584,8 +584,8 @@ INCLUDED_CXX_FILES := \
 
 .PHONY: clean
 clean:
-	-rm -fr $(build_shlibdir)/libjulia-internal* $(build_shlibdir)/libjulia-codegen*
-	-rm -rf $(build_shlibdir)/libccalltest* $(build_shlibdir)/libllvmcalltest* $(build_shlibdir)/libccalllazyfoo* $(build_shlibdir)/libccalllazybar*
+	-rm -fr $(build_private_shlibdir)/libjulia-internal* $(build_private_shlibdir)/libjulia-codegen*
+	-rm -rf $(build_private_shlibdir)/libccalltest* $(build_private_shlibdir)/libllvmcalltest* $(build_private_shlibdir)/libccalllazyfoo* $(build_private_shlibdir)/libccalllazybar*
 	-rm -f $(BUILDDIR)/julia_flisp.boot* $(BUILDDIR)/julia_flisp.boot.inc* $(BUILDDIR)/jl_internal_funcs.inc* $(BUILDDIR)/jl_data_globals_defs.inc*
 	-rm -f $(BUILDDIR)/*.dbg.obj $(BUILDDIR)/*.o $(BUILDDIR)/*.dwo $(BUILDDIR)/*.$(SHLIB_EXT) $(BUILDDIR)/*.a $(BUILDDIR)/*.h.gen
 	-rm -f $(BUILDDIR)/julia.expmap
@@ -603,8 +603,8 @@ clean-support:
 .PHONY: cleanall
 cleanall: clean clean-flisp clean-support clean-analyzegc
 
-$(build_shlibdir)/lib%Plugin.$(SHLIB_EXT): $(SRCDIR)/clangsa/%.cpp $(LLVM_CONFIG_ABSOLUTE)
-	@$(call PRINT_CC, $(CXX) -g $(fPIC) -shared -o $@ -DCLANG_PLUGIN -I$(build_includedir) -L$(build_libdir) \
+$(build_private_shlibdir)/lib%Plugin.$(SHLIB_EXT): $(SRCDIR)/clangsa/%.cpp $(LLVM_CONFIG_ABSOLUTE)
+	@$(call PRINT_CC, $(CXX) -g $(fPIC) -shared -o $@ -DCLANG_PLUGIN -I$(build_includedir) -L$(build_private_libdir) \
 		$(LLVM_CXXFLAGS) $(CLANG_LDFLAGS) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(CXXLDFLAGS) $<)
 
 # Throw an error if a proper version of `clang` is not available.
@@ -632,8 +632,8 @@ ifneq ($(BUILD_LLVM_CLANG),1)
 endif
 endif
 
-clangsa: $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)
-clangsa: $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT)
+clangsa: $(build_private_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)
+clangsa: $(build_private_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT)
 
 # optarg is a required_argument for these
 SA_EXCEPTIONS-jloptions.c                   := -Xanalyzer -analyzer-config -Xanalyzer silence-checkers="core.NonNullParamChecker;unix.cstring.NullArg"
@@ -645,14 +645,14 @@ SKIP_GC_CHECK := codegen.cpp rtutils.c
 
 # make sure LLVM's invariant information is not discarded with -DNDEBUG
 clang-sagc-%: JCXXFLAGS_COMMON += -UNDEBUG
-clang-sagc-%: $(SRCDIR)/%.c $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
+clang-sagc-%: $(SRCDIR)/%.c $(build_private_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
 	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang -D__clang_gcanalyzer__ --analyze -Xanalyzer -analyzer-werror -Xanalyzer -analyzer-output=text --analyzer-no-default-checks \
-		-Xclang -load -Xclang $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) -Xclang -analyzer-checker=core$(COMMA)julia.GCChecker \
+		-Xclang -load -Xclang $(build_private_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) -Xclang -analyzer-checker=core$(COMMA)julia.GCChecker \
 		$(SA_EXCEPTIONS-$(notdir $<)) \
 		$(CLANG_TOOLING_C_FLAGS) -fcolor-diagnostics -x c $<)
-clang-sagc-%: $(SRCDIR)/%.cpp $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
+clang-sagc-%: $(SRCDIR)/%.cpp $(build_private_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
 	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang -D__clang_gcanalyzer__ --analyze -Xanalyzer -analyzer-werror -Xanalyzer -analyzer-output=text --analyzer-no-default-checks \
-		-Xclang -load -Xclang $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) -Xclang -analyzer-checker=core$(COMMA)julia.GCChecker \
+		-Xclang -load -Xclang $(build_private_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) -Xclang -analyzer-checker=core$(COMMA)julia.GCChecker \
 		$(SA_EXCEPTIONS-$(notdir $<)) \
 		$(CLANG_TOOLING_CXX_FLAGS) -fcolor-diagnostics -x c++ $<)
 
@@ -668,13 +668,13 @@ clang-sa-%: $(SRCDIR)/%.cpp .FORCE | analyzegc-deps-check
 		$(SA_EXCEPTIONS-$(notdir $<)) \
 		$(CLANG_TOOLING_CXX_FLAGS) -fcolor-diagnostics -Werror -x c++ $<)
 
-clang-tidy-%: $(SRCDIR)/%.c $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
+clang-tidy-%: $(SRCDIR)/%.c $(build_private_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
 	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang-tidy $< -header-filter='.*' --quiet \
-		-load $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) --checks='-clang-analyzer-*$(COMMA)-clang-diagnostic-*$(COMMA)concurrency-implicit-atomics' --warnings-as-errors='*' \
+		-load $(build_private_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) --checks='-clang-analyzer-*$(COMMA)-clang-diagnostic-*$(COMMA)concurrency-implicit-atomics' --warnings-as-errors='*' \
 		-- $(CLANG_TOOLING_C_FLAGS) -fcolor-diagnostics -fno-caret-diagnostics -x c)
-clang-tidy-%: $(SRCDIR)/%.cpp $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
+clang-tidy-%: $(SRCDIR)/%.cpp $(build_private_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
 	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang-tidy $< -header-filter='.*' --quiet \
-		-load $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) --checks='-clang-analyzer-*$(COMMA)-clang-diagnostic-*$(COMMA)concurrency-implicit-atomics' --warnings-as-errors='*' \
+		-load $(build_private_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) --checks='-clang-analyzer-*$(COMMA)-clang-diagnostic-*$(COMMA)concurrency-implicit-atomics' --warnings-as-errors='*' \
 		-- $(CLANG_TOOLING_CXX_FLAGS) -fcolor-diagnostics --system-header-prefix=llvm -Wno-deprecated-declarations -fno-caret-diagnostics -x c++)
 
 # Add C files as a target of `analyzesrc` and `analyzegc` and `tidysrc`
@@ -693,8 +693,8 @@ $(addprefix analyze-,$(filter-out $(basename $(SKIP_GC_CHECK)),$(CODEGEN_SRCS) $
 
 .PHONY: clean-analyzegc
 clean-analyzegc:
-	rm -f $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)
-	rm -f $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT)
+	rm -f $(build_private_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)
+	rm -f $(build_private_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT)
 
 # Compilation database generation using existing clang infrastructure
 .PHONY: regenerate-compile_commands

--- a/test/clangsa/Makefile
+++ b/test/clangsa/Makefile
@@ -11,7 +11,7 @@ TESTS = $(patsubst $(SRCDIR)/%,%,$(wildcard $(SRCDIR)/*.c) $(wildcard $(SRCDIR)/
 	@$(MAKE) -C $(BUILDDIR)/../../src $(build_includedir)/julia/julia_version.h
 	@$(MAKE) -C $(BUILDDIR)/../../src clangsa
 	PATH=$(build_bindir):$(build_depsbindir):$$PATH \
-	LD_LIBRARY_PATH="${build_libdir}:$$LD_LIBRARY_PATH" \
+	LD_LIBRARY_PATH="${build_private_libdir}:${build_libdir}:$$LD_LIBRARY_PATH" \
 	CLANGSA_FLAGS="${CLANGSA_FLAGS}" \
 	CLANGSA_CXXFLAGS="${CLANGSA_CXXFLAGS}" \
 	CPPFLAGS_FLAGS="${CPPFLAGS_FLAGS}" \

--- a/test/llvmpasses/Makefile
+++ b/test/llvmpasses/Makefile
@@ -11,7 +11,7 @@ TESTS := $(TESTS_ll) $(TESTS_jl)
 . $(TESTS):
 	$(MAKE) -C $(JULIAHOME)/deps install-llvm-tools
 	PATH=$(build_bindir):$(build_depsbindir):$$PATH \
-	LD_LIBRARY_PATH=${build_libdir}:$$LD_LIBRARY_PATH \
+	LD_LIBRARY_PATH=${build_private_libdir}:${build_libdir}:$$LD_LIBRARY_PATH \
 	$(build_depsbindir)/lit/lit.py -v "$(addprefix $(SRCDIR)/,$@)"
 
 $(addprefix update-,$(TESTS_ll)):
@@ -19,14 +19,14 @@ $(addprefix update-,$(TESTS_ll)):
 	@read -p "$$(printf $(WARNCOLOR)'This will directly modify %s, are you sure you want to proceed? '$(ENDCOLOR) '$@')" REPLY && [ yy = "y$$REPLY" ]
 	sed -e 's/%shlibext/.$(SHLIB_EXT)/g' < "$(@:update-%=$(SRCDIR)/%)" > "$@"
 	PATH=$(build_bindir):$(build_depsbindir):$$PATH \
-	LD_LIBRARY_PATH=${build_libdir}:$$LD_LIBRARY_PATH \
+	LD_LIBRARY_PATH=${build_private_libdir}:${build_libdir}:$$LD_LIBRARY_PATH \
 	$(JULIAHOME)/deps/srccache/llvm/llvm/utils/update_test_checks.py "$@" \
 	--preserve-names
 	mv "$@" "$(@:update-%=$(SRCDIR)/%)"
 
 update-help:
 	PATH=$(build_bindir):$(build_depsbindir):$$PATH \
-	LD_LIBRARY_PATH=${build_libdir}:$$LD_LIBRARY_PATH \
+	LD_LIBRARY_PATH=${build_private_libdir}:${build_libdir}:$$LD_LIBRARY_PATH \
 	$(JULIAHOME)/deps/srccache/llvm/llvm/utils/update_test_checks.py \
 	--help
 


### PR DESCRIPTION
Unify the Julia library installation directory so that dependencies are extracted directly into `usr/lib/julia` at build time, matching the install-time layout. This eliminates the need for layout rearrangement at `make install` time.

This has been a consistent source of pain for people who want to work with libraries with a julia installation as well as a build tree version of Julia.  Note that we can't completely eliminate all of our logic for re-arranging, as e.g. debian sets multilib libdir paths which will be different than our default layout, but this at least makes the most common case the smoothest.  I've tested this with `USE_BINARYBUILDER_XXX=0` for all relevant dependencies, as well as `USE_SYSTEM_XXX=1` for as many as work (looks like some of those are broken, but no more broken with these changes).

The basic idea here is to use the fact that all our dependencies pass through the `staged-install` mechanism and use `tar`'s `--transform` argument to relocate `.so`, `.dylib`, `.a` files from `/lib` to `/lib/julia` at unpack time.  We also do a quick `sed` on `.pc` files to rewrite their paths as well.

## TODO

- [ ] One big annoyance is that `llvm-config` isn't easily fooled, so I've had to symlink in all the `.a` files for LLVM to find its own files.  One path forward is to just teach `llvm-config` to take in an environment variable or argument that says "trust me, your libdir is actually at `usr/lib/julia`", which should be a relatively small patch.
- [ ] I've only tested on Linux, there's probably some brokenness on Windows or macOS.

AI was used in the creation of this PR.