### PR TITLE
subtype: isolate `Union` state in `subtype_ccheck` to prevent exponential hang

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -117,6 +117,7 @@ typedef struct jl_stenv_t {
     // Used to represent the length difference between 2 vararg.
     // intersect(X, Y) ==> X = Y + Loffset
     int Loffset;
+    int ccheck_merging;       // prevents re-entrant merge loops in subtype_ccheck
 } jl_stenv_t;
 
 // state manipulation utilities
@@ -176,6 +177,17 @@ static int next_union_state(jl_stenv_t *e, int8_t R) JL_NOTSAFEPOINT
 {
     jl_unionstate_t *state = R ? &e->Runions : &e->Lunions;
     if (state->more == 0)
+        return 0;
+    // reset `used` and let `pick_union_decision` clean the stack.
+    state->used = state->more;
+    statestack_set(state, state->used - 1, 1);
+    return 1;
+}
+
+static int next_union_state_from(jl_stenv_t *e, int8_t R, int16_t min_used) JL_NOTSAFEPOINT
+{
+    jl_unionstate_t *state = R ? &e->Runions : &e->Lunions;
+    if (state->more <= min_used)
         return 0;
     // reset `used` and let `pick_union_decision` clean the stack.
     state->used = state->more;
@@ -679,8 +691,97 @@ static jl_value_t *simple_meet(jl_value_t *a, jl_value_t *b, int overesi)
 static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param);
 
 static int local_forall_exists_subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param, int limit_slow);
+static int merge_env(jl_stenv_t *e, jl_savedenv_t *me, jl_savedenv_t *se, int count);
 
-// subtype for variable bounds consistency check. needs its own forall/exists environment.
+// After merge_env merges lb/ub/occurs/innervars/max_offset across all
+// successful ∃ branches, this overrides the metadata fields with values
+// from the original saved env. Only lb/ub (merged via simple_meet/
+// simple_join) are kept from the merge result.
+// merge_env's metadata merging (max for occurs, min for max_offset,
+// append for innervars) tightens constraints, which is the opposite of
+// what ccheck needs (widest valid constraints).
+static void ccheck_restore_metadata(jl_stenv_t *e, jl_savedenv_t *se) JL_NOTSAFEPOINT
+{
+    jl_value_t **roots = NULL;
+    int nroots = 0;
+    if (se->gcframe.nroots == JL_GC_ENCODE_PUSHARGS(1)) {
+        jl_svec_t *sv = (jl_svec_t*)se->roots[0];
+        assert(jl_is_svec(sv));
+        roots = jl_svec_data(sv);
+        nroots = jl_svec_len(sv);
+    }
+    else if (se->gcframe.nroots) {
+        roots = se->roots;
+        nroots = JL_GC_DECODE_NROOTS(se->gcframe.nroots);
+    }
+    jl_varbinding_t *v = e->vars;
+    int i = 0, j = 0;
+    while (v != NULL) {
+        if (roots)
+            v->innervars = (jl_array_t*)roots[i + 2];
+        i += 3;
+        v->occurs_inv = se->buf[j];
+        v->occurs_cov = se->buf[j + 1];
+        v->max_offset = se->buf[j + 2];
+        j += 3;
+        v = v->prev;
+    }
+    assert(!roots || i == nroots); (void)nroots;
+}
+
+// Merge successful right-side Union branches' environments.
+// Enumerates all ∃ branches via next_union_state_from, running a full
+// ∀∃ check (local_forall_exists_subtype) for each. Successful branches
+// are merged via merge_env (simple_meet for lb, simple_join for ub),
+// then metadata is restored from the original env.
+// Kept separate (noinline) to avoid bloating subtype_ccheck's stack frame.
+NOINLINE static void ccheck_merge_env(
+    jl_value_t *x, jl_value_t *y, jl_stenv_t *e,
+    jl_savedenv_t *se,
+    jl_saved_unionstate_t *oldLunions,
+    int16_t oldRunions_used,
+    jl_value_t **saved_envout, int envout_n)
+{
+    jl_savedenv_t me;
+    int nmerge = 0;
+    e->ccheck_merging = 1;
+    nmerge = merge_env(e, &me, se, nmerge);
+    while (next_union_state_from(e, 1, oldRunions_used)) {
+        restore_env(e, se, 1);
+        if (saved_envout)
+            memcpy(&e->envout[e->envidx], saved_envout,
+                   envout_n * sizeof(jl_value_t *));
+        pop_unionstate(&e->Lunions, oldLunions);
+        e->Runions.more = 0;
+        e->Lunions.more = 0;
+        if (local_forall_exists_subtype(x, y, e, 0, 1))
+            nmerge = merge_env(e, &me, se, nmerge);
+    }
+    e->ccheck_merging = 0;
+    if (nmerge > 0) {
+        restore_env(e, &me, 1);
+        ccheck_restore_metadata(e, se);
+        if (saved_envout)
+            memcpy(&e->envout[e->envidx], saved_envout,
+                   envout_n * sizeof(jl_value_t *));
+        free_env(&me);
+    }
+}
+
+// Subtype check for variable bounds consistency.
+// Union state (Lunions/Runions) is isolated via push/pop so that
+// right-side Union choices from bounds checks do not leak into
+// the shared Runions statestack, which would cause O(2^N)
+// iteration in exists_subtype when many Union-bounded parameters
+// are present.
+//
+// When right-side Union choices are made (detected via Runions.used
+// growth), env constraints from all successful ∃ branches are merged
+// (lb via simple_meet, ub via simple_join) to keep constraints valid
+// for any branch. Metadata (occurs, max_offset, innervars) is restored
+// from the original env. When no Union choices are involved, constraints
+// are deterministic and kept — restoring unconditionally causes false
+// negatives that break the obvious_subtype invariant.
 static int subtype_ccheck(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
 {
     if (jl_is_long(x) && jl_is_long(y))
@@ -695,8 +796,42 @@ static int subtype_ccheck(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
         return 1;
     if (x == (jl_value_t*)jl_any_type && jl_is_datatype(y))
         return 0;
+    if (obviously_in_union(y, x))
+        return 1;
     jl_saved_unionstate_t oldLunions; push_unionstate(&oldLunions, &e->Lunions);
+    jl_saved_unionstate_t oldRunions; push_unionstate(&oldRunions, &e->Runions);
+    jl_savedenv_t se;
+    save_env(e, &se, 1);
     int sub = local_forall_exists_subtype(x, y, e, 0, 1);
+    if (e->Runions.used > oldRunions.used) {
+        // Right-side Union choices were made. Preserve envout
+        // for subtype_unionall before any env restore.
+        int envout_n = 0;
+        jl_value_t **saved_envout = NULL;
+        if (e->envout && e->envidx < e->envsz) {
+            envout_n = e->envsz - e->envidx;
+            saved_envout = (jl_value_t **)alloca(
+                envout_n * sizeof(jl_value_t *));
+            memcpy(saved_envout, &e->envout[e->envidx],
+                   envout_n * sizeof(jl_value_t *));
+        }
+        if (sub && !e->ccheck_merging && !e->intersection) {
+            // Merge constraints across all successful ∃ branches
+            // (lb via simple_meet, ub via simple_join).
+            ccheck_merge_env(x, y, e, &se, &oldLunions, oldRunions.used,
+                             saved_envout, envout_n);
+        }
+        else {
+            // sub == 0 or re-entrance/intersection: restore env
+            // to clean up stale constraints from the check.
+            restore_env(e, &se, 1);
+            if (saved_envout)
+                memcpy(&e->envout[e->envidx], saved_envout,
+                       envout_n * sizeof(jl_value_t *));
+        }
+    }
+    free_env(&se);
+    pop_unionstate(&e->Runions, &oldRunions);
     pop_unionstate(&e->Lunions, &oldLunions);
     return sub;
 }
@@ -1891,6 +2026,7 @@ static void init_stenv(jl_stenv_t *e, jl_value_t **env, int envsz)
     e->emptiness_only = 0;
     e->triangular = 0;
     e->Loffset = 0;
+    e->ccheck_merging = 0;
     e->Lunions.depth = 0;      e->Runions.depth = 0;
     e->Lunions.more = 0;       e->Runions.more = 0;
     e->Lunions.used = 0;       e->Runions.used = 0;

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -173,17 +173,6 @@ static void statestack_set(jl_unionstate_t *st, int i, int val) JL_NOTSAFEPOINT
 
 #define has_next_union_state(e, R) ((((R) ? &(e)->Runions : &(e)->Lunions)->more) != 0)
 
-static int next_union_state(jl_stenv_t *e, int8_t R) JL_NOTSAFEPOINT
-{
-    jl_unionstate_t *state = R ? &e->Runions : &e->Lunions;
-    if (state->more == 0)
-        return 0;
-    // reset `used` and let `pick_union_decision` clean the stack.
-    state->used = state->more;
-    statestack_set(state, state->used - 1, 1);
-    return 1;
-}
-
 static int next_union_state_from(jl_stenv_t *e, int8_t R, int16_t min_used) JL_NOTSAFEPOINT
 {
     jl_unionstate_t *state = R ? &e->Runions : &e->Lunions;
@@ -193,6 +182,11 @@ static int next_union_state_from(jl_stenv_t *e, int8_t R, int16_t min_used) JL_N
     state->used = state->more;
     statestack_set(state, state->used - 1, 1);
     return 1;
+}
+
+static int next_union_state(jl_stenv_t *e, int8_t R) JL_NOTSAFEPOINT
+{
+    return next_union_state_from(e, R, 0);
 }
 
 static int pick_union_decision(jl_stenv_t *e, int8_t R) JL_NOTSAFEPOINT
@@ -754,11 +748,9 @@ NOINLINE static void ccheck_merge_env(
             nmerge = merge_env(e, &me, se, nmerge);
     }
     e->ccheck_merging = 0;
-    if (nmerge > 0) {
-        restore_env(e, &me, 1);
-        ccheck_restore_metadata(e, se);
-        free_env(&me);
-    }
+    restore_env(e, &me, 1);
+    ccheck_restore_metadata(e, se);
+    free_env(&me);
 }
 
 // Subtype check for variable bounds consistency.

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -117,7 +117,6 @@ typedef struct jl_stenv_t {
     // Used to represent the length difference between 2 vararg.
     // intersect(X, Y) ==> X = Y + Loffset
     int Loffset;
-    int ccheck_merging;       // prevents re-entrant merge loops in subtype_ccheck
 } jl_stenv_t;
 
 // state manipulation utilities
@@ -173,20 +172,15 @@ static void statestack_set(jl_unionstate_t *st, int i, int val) JL_NOTSAFEPOINT
 
 #define has_next_union_state(e, R) ((((R) ? &(e)->Runions : &(e)->Lunions)->more) != 0)
 
-static int next_union_state_from(jl_stenv_t *e, int8_t R, int16_t min_used) JL_NOTSAFEPOINT
+static int next_union_state(jl_stenv_t *e, int8_t R) JL_NOTSAFEPOINT
 {
     jl_unionstate_t *state = R ? &e->Runions : &e->Lunions;
-    if (state->more <= min_used)
+    if (state->more == 0)
         return 0;
     // reset `used` and let `pick_union_decision` clean the stack.
     state->used = state->more;
     statestack_set(state, state->used - 1, 1);
     return 1;
-}
-
-static int next_union_state(jl_stenv_t *e, int8_t R) JL_NOTSAFEPOINT
-{
-    return next_union_state_from(e, R, 0);
 }
 
 static int pick_union_decision(jl_stenv_t *e, int8_t R) JL_NOTSAFEPOINT
@@ -685,88 +679,42 @@ static jl_value_t *simple_meet(jl_value_t *a, jl_value_t *b, int overesi)
 static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param);
 
 static int local_forall_exists_subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param, int limit_slow);
-static int merge_env(jl_stenv_t *e, jl_savedenv_t *me, jl_savedenv_t *se, int count);
 
-// After merge_env merges lb/ub/occurs/innervars/max_offset across all
-// successful ∃ branches, this overrides the metadata fields with values
-// from the original saved env. Only lb/ub (merged via simple_meet/
-// simple_join) are kept from the merge result.
-// merge_env's metadata merging (max for occurs, min for max_offset,
-// append for innervars) tightens constraints, which is the opposite of
-// what ccheck needs (widest valid constraints).
-static void ccheck_restore_metadata(jl_stenv_t *e, jl_savedenv_t *se) JL_NOTSAFEPOINT
+// Check whether env (variable bounds: lb/ub) changed compared to saved env.
+static int env_unchanged(jl_stenv_t *e, jl_savedenv_t *se) JL_NOTSAFEPOINT
 {
     jl_value_t **roots = NULL;
-    int nroots = 0;
     if (se->gcframe.nroots == JL_GC_ENCODE_PUSHARGS(1)) {
         jl_svec_t *sv = (jl_svec_t*)se->roots[0];
         assert(jl_is_svec(sv));
         roots = jl_svec_data(sv);
-        nroots = jl_svec_len(sv);
     }
     else if (se->gcframe.nroots) {
         roots = se->roots;
-        nroots = JL_GC_DECODE_NROOTS(se->gcframe.nroots);
     }
+    if (!roots)
+        return 1; // no vars to compare
     jl_varbinding_t *v = e->vars;
-    int i = 0, j = 0;
+    int i = 0;
     while (v != NULL) {
-        if (roots)
-            v->innervars = (jl_array_t*)roots[i + 2];
-        i += 3;
-        v->occurs_inv = se->buf[j];
-        v->occurs_cov = se->buf[j + 1];
-        v->max_offset = se->buf[j + 2];
-        j += 3;
+        if (v->lb != roots[i] || v->ub != roots[i + 1])
+            return 0;
+        i += 3; // lb, ub, innervars
         v = v->prev;
     }
-    assert(!roots || i == nroots); (void)nroots;
-}
-
-// Merge successful right-side Union branches' environments.
-// Enumerates all ∃ branches via next_union_state_from, running a full
-// ∀∃ check (local_forall_exists_subtype) for each. Successful branches
-// are merged via merge_env (simple_meet for lb, simple_join for ub),
-// then metadata is restored from the original env.
-// Kept separate (noinline) to avoid bloating subtype_ccheck's stack frame.
-NOINLINE static void ccheck_merge_env(
-    jl_value_t *x, jl_value_t *y, jl_stenv_t *e,
-    jl_savedenv_t *se,
-    jl_saved_unionstate_t *oldLunions,
-    int16_t oldRunions_used)
-{
-    jl_savedenv_t me;
-    int nmerge = 0;
-    e->ccheck_merging = 1;
-    nmerge = merge_env(e, &me, se, nmerge);
-    while (next_union_state_from(e, 1, oldRunions_used)) {
-        restore_env(e, se, 1);
-        pop_unionstate(&e->Lunions, oldLunions);
-        e->Runions.more = 0;
-        e->Lunions.more = 0;
-        if (local_forall_exists_subtype(x, y, e, 0, 1))
-            nmerge = merge_env(e, &me, se, nmerge);
-    }
-    e->ccheck_merging = 0;
-    restore_env(e, &me, 1);
-    ccheck_restore_metadata(e, se);
-    free_env(&me);
+    return 1;
 }
 
 // Subtype check for variable bounds consistency.
-// Union state (Lunions/Runions) is isolated via push/pop so that
-// right-side Union choices from bounds checks do not leak into
-// the shared Runions statestack, which would cause O(2^N)
-// iteration in exists_subtype when many Union-bounded parameters
-// are present.
+// Needs its own forall/exists environment.
 //
-// When right-side Union choices are made (detected via Runions.used
-// growth), env constraints from all successful ∃ branches are merged
-// (lb via simple_meet, ub via simple_join) to keep constraints valid
-// for any branch. Metadata (occurs, max_offset, innervars) is restored
-// from the original env. When no Union choices are involved, constraints
-// are deterministic and kept — restoring unconditionally causes false
-// negatives that break the obvious_subtype invariant.
+// Right-side Union choices made during bounds checks can leak into
+// the shared Runions statestack, causing O(2^N) iteration in
+// exists_subtype when many Union-bounded parameters are present.
+// To prevent this, we monitor whether the env (variable bounds)
+// changes during the check. If it does not, the Union choices are
+// purely internal and we reset Runions.more to its previous value,
+// preventing the outer loop from iterating over those choices.
 static int subtype_ccheck(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
 {
     if (jl_is_long(x) && jl_is_long(y))
@@ -783,29 +731,14 @@ static int subtype_ccheck(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
         return 0;
     if (obviously_in_union(y, x))
         return 1;
-    // Bounds checks happen after all outer-chain right-side UnionAlls have
-    // been entered, so envidx >= envsz and restore_env cannot touch envout.
-    assert(e->envidx >= e->envsz);
     jl_saved_unionstate_t oldLunions; push_unionstate(&oldLunions, &e->Lunions);
-    jl_saved_unionstate_t oldRunions; push_unionstate(&oldRunions, &e->Runions);
+    int16_t oldRmore = e->Runions.more;
     jl_savedenv_t se;
     save_env(e, &se, 1);
     int sub = local_forall_exists_subtype(x, y, e, 0, 1);
-    if (e->Runions.used > oldRunions.used) {
-        // Right-side Union choices were made during the bounds check.
-        if (sub && !e->ccheck_merging && !e->intersection) {
-            // Merge constraints across all successful ∃ branches
-            // (lb via simple_meet, ub via simple_join).
-            ccheck_merge_env(x, y, e, &se, &oldLunions, oldRunions.used);
-        }
-        else {
-            // sub == 0 or re-entrance/intersection: restore env
-            // to clean up stale constraints from the check.
-            restore_env(e, &se, 1);
-        }
-    }
+    if (env_unchanged(e, &se))
+        e->Runions.more = oldRmore;
     free_env(&se);
-    pop_unionstate(&e->Runions, &oldRunions);
     pop_unionstate(&e->Lunions, &oldLunions);
     return sub;
 }
@@ -2000,7 +1933,6 @@ static void init_stenv(jl_stenv_t *e, jl_value_t **env, int envsz)
     e->emptiness_only = 0;
     e->triangular = 0;
     e->Loffset = 0;
-    e->ccheck_merging = 0;
     e->Lunions.depth = 0;      e->Runions.depth = 0;
     e->Lunions.more = 0;       e->Runions.more = 0;
     e->Lunions.used = 0;       e->Runions.used = 0;

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -739,8 +739,7 @@ NOINLINE static void ccheck_merge_env(
     jl_value_t *x, jl_value_t *y, jl_stenv_t *e,
     jl_savedenv_t *se,
     jl_saved_unionstate_t *oldLunions,
-    int16_t oldRunions_used,
-    jl_value_t **saved_envout, int envout_n)
+    int16_t oldRunions_used)
 {
     jl_savedenv_t me;
     int nmerge = 0;
@@ -748,9 +747,6 @@ NOINLINE static void ccheck_merge_env(
     nmerge = merge_env(e, &me, se, nmerge);
     while (next_union_state_from(e, 1, oldRunions_used)) {
         restore_env(e, se, 1);
-        if (saved_envout)
-            memcpy(&e->envout[e->envidx], saved_envout,
-                   envout_n * sizeof(jl_value_t *));
         pop_unionstate(&e->Lunions, oldLunions);
         e->Runions.more = 0;
         e->Lunions.more = 0;
@@ -761,9 +757,6 @@ NOINLINE static void ccheck_merge_env(
     if (nmerge > 0) {
         restore_env(e, &me, 1);
         ccheck_restore_metadata(e, se);
-        if (saved_envout)
-            memcpy(&e->envout[e->envidx], saved_envout,
-                   envout_n * sizeof(jl_value_t *));
         free_env(&me);
     }
 }
@@ -798,36 +791,25 @@ static int subtype_ccheck(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
         return 0;
     if (obviously_in_union(y, x))
         return 1;
+    // Bounds checks happen after all outer-chain right-side UnionAlls have
+    // been entered, so envidx >= envsz and restore_env cannot touch envout.
+    assert(e->envidx >= e->envsz);
     jl_saved_unionstate_t oldLunions; push_unionstate(&oldLunions, &e->Lunions);
     jl_saved_unionstate_t oldRunions; push_unionstate(&oldRunions, &e->Runions);
     jl_savedenv_t se;
     save_env(e, &se, 1);
     int sub = local_forall_exists_subtype(x, y, e, 0, 1);
     if (e->Runions.used > oldRunions.used) {
-        // Right-side Union choices were made. Preserve envout
-        // for subtype_unionall before any env restore.
-        int envout_n = 0;
-        jl_value_t **saved_envout = NULL;
-        if (e->envout && e->envidx < e->envsz) {
-            envout_n = e->envsz - e->envidx;
-            saved_envout = (jl_value_t **)alloca(
-                envout_n * sizeof(jl_value_t *));
-            memcpy(saved_envout, &e->envout[e->envidx],
-                   envout_n * sizeof(jl_value_t *));
-        }
+        // Right-side Union choices were made during the bounds check.
         if (sub && !e->ccheck_merging && !e->intersection) {
             // Merge constraints across all successful ∃ branches
             // (lb via simple_meet, ub via simple_join).
-            ccheck_merge_env(x, y, e, &se, &oldLunions, oldRunions.used,
-                             saved_envout, envout_n);
+            ccheck_merge_env(x, y, e, &se, &oldLunions, oldRunions.used);
         }
         else {
             // sub == 0 or re-entrance/intersection: restore env
             // to clean up stale constraints from the check.
             restore_env(e, &se, 1);
-            if (saved_envout)
-                memcpy(&e->envout[e->envidx], saved_envout,
-                       envout_n * sizeof(jl_value_t *));
         }
     }
     free_env(&se);

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2863,3 +2863,5 @@ let tt = Tuple{typeof(JETLS509f),
     } where F
     @test Base.code_typed_by_type(tt) isa Vector
 end
+@test !(Tuple{Union{Int16,Int8},Ref{Int16},Ref{Int16}} <: Tuple{<:Union{S,T},Ref{S},Ref{T}} where {S,T})
+@test !(Tuple{Ref{Int16},Ref{Int16},Union{Int16,Int8}} <: Tuple{Ref{S},Ref{T},<:Union{S,T}} where {S,T})

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2841,3 +2841,25 @@ let
     @test (r <: A) && (r <: B)
     @test r !== Union{}
 end
+
+# JETLS#509 — inference hang with Union-bounded parametric types
+# subtype_ccheck leaked right-side Union choices into the shared
+# Runions statestack, causing exponential state iteration when
+# multiple Union-bounded parameters share a common variable.
+struct JETLS509S{F, A<:Union{Ref{F},Val{F}}, B<:Union{Ref{F},Val{F}},
+                    C<:Union{Ref{F},Val{F}}, D<:Union{Ref{F},Val{F}},
+                    E<:Union{Ref{F},Val{F}}, G<:Union{Ref{F},Val{F}}}
+end
+JETLS509f(a::JETLS509S{F}, b::JETLS509S{F}, s::Union{Nothing,Ref{F}}=nothing) where {F} = 1
+let tt = Tuple{typeof(JETLS509f),
+        JETLS509S{F,A,B,C,D,E,G} where {
+            A<:Union{Ref{F},Val{F}}, B<:Union{Ref{F},Val{F}},
+            C<:Union{Ref{F},Val{F}}, D<:Union{Ref{F},Val{F}},
+            E<:Union{Ref{F},Val{F}}, G<:Union{Ref{F},Val{F}}},
+        JETLS509S{F,A,B,C,D,E,G} where {
+            A<:Union{Ref{F},Val{F}}, B<:Union{Ref{F},Val{F}},
+            C<:Union{Ref{F},Val{F}}, D<:Union{Ref{F},Val{F}},
+            E<:Union{Ref{F},Val{F}}, G<:Union{Ref{F},Val{F}}},
+    } where F
+    @test Base.code_typed_by_type(tt) isa Vector
+end


### PR DESCRIPTION
Investigation of aviatesk/JETLS.jl#509 revealed that the root cause is a hang in the subtyping algorithm. A minimal reproducer has been added to `test/subtype.jl`, which does not terminate in a reasonable time on the current master branch.

The fix was developed using Claude and Codex, with iterative cross-review between the two to arrive at what I believe is the most sound approach. However, I am not very familiar with the subtype algorithm implementation, so there may be implementation issues I have not caught. Note that the bulk of this patch was written by AI.

---

`subtype_ccheck` calls `local_forall_exists_subtype`, which leaks right-side Union choices (via `pick_union_decision`) into the shared `Runions` statestack. When many
Union-bounded type parameters share a common variable (e.g. 6 parameters all bounded by `Union{Ref{F},Val{F}}`), each bounds check adds decisions that `exists_subtype` must iterate over combinatorially, causing O(2^N) iterations.

Make `subtype_ccheck` save and restore both the `Runions` state and variable environment (`save_env`/`restore_env`).

When `pick_union_decision` added new entries during the check (detected via `Runions.used` growth) and the check succeeded, a merge loop (`ccheck_merge_env`) enumerates all successful right-side ∃ branches and merges their variable constraints via `simple_meet` (lb) / `simple_join` (ub). This yields the widest constraints valid across any successful branch, instead of discarding all constraints. A separate `ccheck_restore_metadata` step then overrides the metadata fields (`occurs_inv`, `occurs_cov`,
`max_offset`, `innervars`) with the original values, since `merge_env`'s metadata merging (max for occurs, min for max_offset) tightens constraints — the opposite of what `subtype_ccheck` needs.

The merge loop uses `next_union_state_from` to iterate only the ccheck's own ∃ decisions (starting from
`oldRunions.used`), avoiding interference with outer Union iteration. Each branch runs a full ∀∃ check via
`local_forall_exists_subtype`. The `ccheck_merging` flag prevents re-entrant merge loops from nested `subtype_ccheck` calls; the `!e->intersection` guard avoids conflicts with `intersect_all`'s own `merge_env` handling.

When no Union splitting occurred, the variable constraints are deterministic and safe to keep; restoring them unconditionally introduces false negatives that break the `obvious_subtype` invariant. The `envout` array is preserved across the restore because inner `subtype_unionall` calls may have already written inferred type-parameter values that must survive.

Known limitation: detection via `Runions.used` growth is imperfect — `local_forall_exists_subtype`'s exists-free path (path 1) internally pushes/pops its own `Runions`, so Union choices made there do not increase the outer `Runions.used`. Currently harmless because exists-free inputs have no exists-variable constraints to corrupt, but the detection mechanism has a structural gap.

Fixes aviatesk/JETLS.jl#509.