### PR TITLE
`make test-revise-*`: Initialize Revise fully on workers

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,7 @@ if use_revise
     push!(DEPOT_PATH, popfirst!(DEPOT_PATH))
     # Remote-eval the following to initialize Revise in workers
     const revise_init_expr = quote
+        ENV["JULIA_REVISE_WORKER_ONLY"] = "1"
         using Revise
         const STDLIBS = $STDLIBS
         union!(Revise.stdlib_names, Symbol.(STDLIBS))


### PR DESCRIPTION
Set `JULIA_REVISE_WORKER_ONLY` before loading `Revise` on `Distributed` workers in the revise test harness. This ensures worker-side Revise initialization assigns the Julia source paths before `revise_trackall()` calls `Revise.track` on `Base`, `Core.Compiler`, and stdlibs.

This fixes timholy/Revise.jl#1023.

🤖 Co-authored-by: Codex