### PR TITLE
`make check-whitespace`: Prefer the locally-built Julia over other Julias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ WS_CHECK_PATTERNS = *.1 *.c *.cpp *.h *.inc *.jl *.lsp *.make *.md *.mk *.rst *.
 .PHONY: check-whitespace
 check-whitespace:
 ifneq ($(NO_GIT), 1)
-	@git ls-files -- $(WS_CHECK_PATTERNS:%='%') | PATH="$(PATH):$(dir $(JULIA_EXECUTABLE))" julia $(call cygpath_w,$(JULIAHOME)/contrib/check-whitespace.jl) --stdin
+	@git ls-files -- $(WS_CHECK_PATTERNS:%='%') | PATH="$(dir $(JULIA_EXECUTABLE)):$(PATH)" julia $(call cygpath_w,$(JULIAHOME)/contrib/check-whitespace.jl) --stdin
 else
 	$(warn "Skipping whitespace check because git is unavailable")
 endif
@@ -164,7 +164,7 @@ endif
 .PHONY: fix-whitespace
 fix-whitespace:
 ifneq ($(NO_GIT), 1)
-	@git ls-files -- $(WS_CHECK_PATTERNS:%='%') | PATH="$(PATH):$(dir $(JULIA_EXECUTABLE))" julia $(call cygpath_w,$(JULIAHOME)/contrib/check-whitespace.jl) --stdin --fix
+	@git ls-files -- $(WS_CHECK_PATTERNS:%='%') | PATH="$(dir $(JULIA_EXECUTABLE)):$(PATH)" julia $(call cygpath_w,$(JULIAHOME)/contrib/check-whitespace.jl) --stdin --fix
 else
 	$(warn "Skipping whitespace fix because git is unavailable")
 endif


### PR DESCRIPTION
If Codex tries to run `make check-whitespace` inside a sandbox, it will try to use Juliaup, because Juliaup is first in my `PATH`[^1]. This fails because Juliaup can't lock its configuration file, because the sandbox prevents it.

But this all seems moot to me, because I just built Julia from source, so shouldn't `make check-whitespace` prefer that Julia, if it's available? So that's what this PR does.

[^1]: Which I suspect is true for many other users as well.

🤖 Co-authored-by: Codex