### PR TITLE
Use `T::Type` rather than `::Type{T}` to prevent cache poisoning

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -17,9 +17,9 @@ abstract type Enum{T<:Integer} end
 basetype(::Type{<:Enum{T}}) where {T<:Integer} = T
 
 (::Type{T})(x::Enum{T2}) where {T<:Integer,T2<:Integer} = T(bitcast(T2, x))::T
-Base.cconvert(::Type{T}, x::Enum{T2}) where {T<:Integer,T2<:Integer} = T(x)::T
+Base.cconvert(T::Type{<:Integer}, x::Enum{T2}) where {T2<:Integer} = T(x)::T
 Base.write(io::IO, x::Enum{T}) where {T<:Integer} = write(io, T(x))
-Base.read(io::IO, ::Type{T}) where {T<:Enum} = T(read(io, basetype(T)))
+Base.read(io::IO, T::Type{<:Enum}) = T(read(io, basetype(T)))
 
 """
     _enum_hash(x::Enum, h::UInt)

--- a/base/Terminals.jl
+++ b/base/Terminals.jl
@@ -165,6 +165,6 @@ Base.haskey(t::TTYTerminal, key) = haskey(pipe_writer(t), key)
 Base.getindex(t::TTYTerminal, key) = getindex(pipe_writer(t), key)
 Base.get(t::TTYTerminal, key, default) = get(pipe_writer(t), key, default)
 
-Base.peek(t::TTYTerminal, ::Type{T}) where {T} = peek(t.in_stream, T)::T
+Base.peek(t::TTYTerminal, T::Type) = peek(t.in_stream, T)::T
 
 end # module

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -817,21 +817,21 @@ julia> similar(falses(10), Float64, 2, 4)
 See also [`undef`](@ref), [`isassigned`](@ref).
 """
 similar(a::AbstractArray{T}) where {T}                             = similar(a, T)
-similar(a::AbstractArray, ::Type{T}) where {T}                     = similar(a, T, axes(a))
+similar(a::AbstractArray, T::Type)                                 = similar(a, T, axes(a))
 similar(a::AbstractArray{T}, dims::Tuple) where {T}                = similar(a, T, dims)
 similar(a::AbstractArray{T}, dims::DimOrInd...) where {T}          = similar(a, T, dims)
-similar(a::AbstractArray, ::Type{T}, dims::DimOrInd...) where {T}  = similar(a, T, dims)
+similar(a::AbstractArray, T::Type, dims::DimOrInd...)              = similar(a, T, dims)
 # Similar supports specifying dims as either Integers or AbstractUnitRanges or any mixed combination
 # thereof. Ideally, we'd just convert Integers to OneTos and then call a canonical method with the axes,
 # but we don't want to require all AbstractArray subtypes to dispatch on Base.OneTo. So instead we
 # define this method to convert supported axes to Ints, with the expectation that an offset array
 # package will define a method with dims::Tuple{Union{Integer, UnitRange}, Vararg{Union{Integer, UnitRange}}}
-similar(a::AbstractArray, ::Type{T}, dims::Tuple{Union{Integer, AbstractOneTo}, Vararg{Union{Integer, AbstractOneTo}}}) where {T} = similar(a, T, to_shape(dims))
+similar(a::AbstractArray, T::Type, dims::Tuple{Union{Integer, AbstractOneTo}, Vararg{Union{Integer, AbstractOneTo}}}) = similar(a, T, to_shape(dims))
 # legacy method for packages that specialize similar(A::AbstractArray, ::Type{T}, dims::Tuple{Union{Integer, OneTo, CustomAxis}, Vararg{Union{Integer, OneTo, CustomAxis}}}
 # leaving this method in ensures that Base owns the more specific method
-similar(a::AbstractArray, ::Type{T}, dims::Tuple{Union{Integer, OneTo}, Vararg{Union{Integer, OneTo}}}) where {T} = similar(a, T, to_shape(dims))
+similar(a::AbstractArray, T::Type, dims::Tuple{Union{Integer, OneTo}, Vararg{Union{Integer, OneTo}}}) = similar(a, T, to_shape(dims))
 # similar creates an Array by default
-similar(a::AbstractArray, ::Type{T}, dims::Dims{N}) where {T,N}    = Array{T,N}(undef, dims)
+similar(a::AbstractArray, T::Type, dims::Dims{N}) where {N}        = Array{T,N}(undef, dims)
 
 to_shape(::Tuple{}) = ()
 to_shape(dims::Dims) = dims
@@ -866,11 +866,11 @@ indices of the result will match `A`.
 would create a 1-dimensional logical array whose indices match those
 of the columns of `A`.
 """
-similar(::Type{T}, dims::DimOrInd...) where {T<:AbstractArray} = similar(T, dims)
-similar(::Type{T}, shape::Tuple{Union{Integer, AbstractOneTo}, Vararg{Union{Integer, AbstractOneTo}}}) where {T<:AbstractArray} = similar(T, to_shape(shape))
+similar(T::Type{<:AbstractArray}, dims::DimOrInd...) = similar(T, dims)
+similar(T::Type{<:AbstractArray}, shape::Tuple{Union{Integer, AbstractOneTo}, Vararg{Union{Integer, AbstractOneTo}}}) = similar(T, to_shape(shape))
 # legacy method for packages that specialize similar(::Type{T}, dims::Tuple{Union{Integer, OneTo, CustomAxis}, Vararg{Union{Integer, OneTo, CustomAxis}})
-similar(::Type{T}, shape::Tuple{Union{Integer, OneTo}, Vararg{Union{Integer, OneTo}}}) where {T<:AbstractArray} = similar(T, to_shape(shape))
-similar(::Type{T}, dims::Dims) where {T<:AbstractArray} = T(undef, dims)
+similar(T::Type{<:AbstractArray}, shape::Tuple{Union{Integer, OneTo}, Vararg{Union{Integer, OneTo}}}) = similar(T, to_shape(shape))
+similar(T::Type{<:AbstractArray}, dims::Dims) = T(undef, dims)
 
 """
     empty(v::AbstractVector, [eltype])
@@ -893,7 +893,7 @@ empty(a::AbstractVector{T}, ::Type{U}=T) where {T,U} = similar(a, U, 0)
 
 # like empty, but should return a mutable collection, a Vector by default
 emptymutable(a::AbstractVector{T}, ::Type{U}=T) where {T,U} = Vector{U}()
-emptymutable(itr, ::Type{U}) where {U} = Vector{U}()
+emptymutable(itr, U::Type) = Vector{U}()
 
 """
     copy!(dst, src) -> dst
@@ -1254,10 +1254,10 @@ isempty(a::AbstractArray) = (length(a) == 0)
 
 ## range conversions ##
 
-map(::Type{T}, r::StepRange) where {T<:Real} = T(r.start):T(r.step):T(last(r))
-map(::Type{T}, r::UnitRange) where {T<:Real} = T(r.start):T(last(r))
-map(::Type{T}, r::StepRangeLen) where {T<:AbstractFloat} = convert(StepRangeLen{T}, r)
-function map(::Type{T}, r::LinRange) where T<:AbstractFloat
+map(T::Type{<:Real}, r::StepRange) = T(r.start):T(r.step):T(last(r))
+map(T::Type{<:Real}, r::UnitRange) = T(r.start):T(last(r))
+map(T::Type{<:AbstractFloat}, r::StepRangeLen) = convert(StepRangeLen{T}, r)
+function map(T::Type{<:AbstractFloat}, r::LinRange)
     LinRange(T(r.start), T(r.stop), length(r))
 end
 
@@ -1660,22 +1660,22 @@ eltypeof(x::AbstractArray) = eltype(x)
 promote_eltypeof() = error()
 promote_eltypeof(v1) = eltypeof(v1)
 promote_eltypeof(v1, v2) = promote_type(eltypeof(v1), eltypeof(v2))
-promote_eltypeof(v1, v2, vs...) = (@inline; afoldl(((::Type{T}, y) where {T}) -> promote_type(T, eltypeof(y)), promote_eltypeof(v1, v2), vs...))
+promote_eltypeof(v1, v2, vs...) = (@inline; afoldl((T::Type, y) -> promote_type(T, eltypeof(y)), promote_eltypeof(v1, v2), vs...))
 promote_eltypeof(v1::T, vs::T...) where {T} = eltypeof(v1)
 promote_eltypeof(v1::AbstractArray{T}, vs::AbstractArray{T}...) where {T} = T
 
 promote_eltype() = error()
 promote_eltype(v1) = eltype(v1)
 promote_eltype(v1, v2) = promote_type(eltype(v1), eltype(v2))
-promote_eltype(v1, v2, vs...) = (@inline; afoldl(((::Type{T}, y) where {T}) -> promote_type(T, eltype(y)), promote_eltype(v1, v2), vs...))
+promote_eltype(v1, v2, vs...) = (@inline; afoldl((T::Type, y) -> promote_type(T, eltype(y)), promote_eltype(v1, v2), vs...))
 promote_eltype(v1::T, vs::T...) where {T} = eltype(T)
 promote_eltype(v1::AbstractArray{T}, vs::AbstractArray{T}...) where {T} = T
 
 #TODO: ERROR CHECK
 _cat(catdim::Int) = Vector{Any}()
 
-typed_vcat(::Type{T}) where {T} = Vector{T}()
-typed_hcat(::Type{T}) where {T} = Vector{T}()
+typed_vcat(T::Type) = Vector{T}()
+typed_hcat(T::Type) = Vector{T}()
 
 ## cat: special cases
 vcat(X::T...) where {T}         = T[ X[i] for i=eachindex(X) ]
@@ -1685,8 +1685,8 @@ hcat(X::T...) where {T<:Number} = T[ X[j] for _=1:1, j=eachindex(X) ]
 
 vcat(X::Number...) = hvcat_fill!(Vector{promote_typeof(X...)}(undef, length(X)), X)
 hcat(X::Number...) = hvcat_fill!(Matrix{promote_typeof(X...)}(undef, 1,length(X)), X)
-typed_vcat(::Type{T}, X::Number...) where {T} = hvcat_fill!(Vector{T}(undef, length(X)), X)
-typed_hcat(::Type{T}, X::Number...) where {T} = hvcat_fill!(Matrix{T}(undef, 1,length(X)), X)
+typed_vcat(T::Type, X::Number...) = hvcat_fill!(Vector{T}(undef, length(X)), X)
+typed_hcat(T::Type, X::Number...) = hvcat_fill!(Matrix{T}(undef, 1,length(X)), X)
 
 vcat(V::AbstractVector...) = typed_vcat(promote_eltype(V...), V...)
 vcat(V::AbstractVector{T}...) where {T} = typed_vcat(T, V...)
@@ -1696,8 +1696,8 @@ vcat(V::AbstractVector{T}...) where {T} = typed_vcat(T, V...)
 # but that solution currently fails (see #27188 and #27224)
 AbstractVecOrTuple{T} = Union{AbstractVector{<:T}, Tuple{Vararg{T}}}
 
-_typed_vcat_similar(V, ::Type{T}, n) where T = similar(V[1], T, n)
-_typed_vcat(::Type{T}, V::AbstractVecOrTuple{AbstractVector}) where T =
+_typed_vcat_similar(V, T::Type, n) = similar(V[1], T, n)
+_typed_vcat(T::Type, V::AbstractVecOrTuple{AbstractVector}) =
     _typed_vcat!(_typed_vcat_similar(V, T, sum(map(length, V))), V)
 
 function _typed_vcat!(a::AbstractVector{T}, V::AbstractVecOrTuple{AbstractVector}) where T
@@ -1711,7 +1711,7 @@ function _typed_vcat!(a::AbstractVector{T}, V::AbstractVecOrTuple{AbstractVector
     a
 end
 
-typed_hcat(::Type{T}, A::AbstractVecOrMat...) where {T} = _typed_hcat(T, A)
+typed_hcat(T::Type, A::AbstractVecOrMat...) = _typed_hcat(T, A)
 
 # Catch indexing errors like v[i +1] (instead of v[i+1] or v[i + 1]), where indexing is
 # interpreted as a typed concatenation. (issue #49676)
@@ -1724,7 +1724,7 @@ typed_hcat(::AbstractArray, other...) = throw(ArgumentError("It is unclear wheth
 hcat(A::AbstractVecOrMat...) = typed_hcat(promote_eltype(A...), A...)
 hcat(A::AbstractVecOrMat{T}...) where {T} = typed_hcat(T, A...)
 
-function _typed_hcat(::Type{T}, A::AbstractVecOrTuple{AbstractVecOrMat}) where T
+function _typed_hcat(T::Type, A::AbstractVecOrTuple{AbstractVecOrMat})
     nargs = length(A)
     nrows = size(A[1], 1)
     ncols = 0
@@ -1761,7 +1761,7 @@ end
 vcat(A::AbstractVecOrMat...) = typed_vcat(promote_eltype(A...), A...)
 vcat(A::AbstractVecOrMat{T}...) where {T} = typed_vcat(T, A...)
 
-function _typed_vcat(::Type{T}, A::AbstractVecOrTuple{AbstractVecOrMat}) where T
+function _typed_vcat(T::Type, A::AbstractVecOrTuple{AbstractVecOrMat})
     nargs = length(A)
     nrows = sum(a->size(a, 1), A)::Int
     ncols = size(A[1], 2)
@@ -1781,7 +1781,7 @@ function _typed_vcat(::Type{T}, A::AbstractVecOrTuple{AbstractVecOrMat}) where T
     return B
 end
 
-typed_vcat(::Type{T}, A::AbstractVecOrMat...) where {T} = _typed_vcat(T, A)
+typed_vcat(T::Type, A::AbstractVecOrMat...) = _typed_vcat(T, A)
 
 reduce(::typeof(vcat), A::AbstractVector{<:AbstractVecOrMat}) =
     _typed_vcat(mapreduce(eltype, promote_type, A), A)
@@ -1806,10 +1806,10 @@ cat_ndims(a::AbstractArray) = ndims(a)
 cat_indices(A, d) = OneTo(1)
 cat_indices(A::AbstractArray, d) = axes(A, d)
 
-cat_similar(A, ::Type{T}, shape::Tuple) where T = Array{T}(undef, shape)
-cat_similar(A, ::Type{T}, shape::Vector) where T = Array{T}(undef, shape...)
-cat_similar(A::Array, ::Type{T}, shape::Tuple) where T = Array{T}(undef, shape)
-cat_similar(A::Array, ::Type{T}, shape::Vector) where T = Array{T}(undef, shape...)
+cat_similar(A, T::Type, shape::Tuple) = Array{T}(undef, shape)
+cat_similar(A, T::Type, shape::Vector) = Array{T}(undef, shape...)
+cat_similar(A::Array, T::Type, shape::Tuple) = Array{T}(undef, shape)
+cat_similar(A::Array, T::Type, shape::Vector) = Array{T}(undef, shape...)
 cat_similar(A::AbstractArray, T::Type, shape::Tuple) = similar(A, T, shape)
 cat_similar(A::AbstractArray, T::Type, shape::Vector) = similar(A, T, shape...)
 
@@ -1863,7 +1863,7 @@ end
 
 _cat(dims, X...) = _cat_t(dims, promote_eltypeof(X...), X...)
 
-@inline function _cat_t(dims, ::Type{T}, X...) where {T}
+@inline function _cat_t(dims, T::Type, X...)
     catdims = dims2cat(dims)
     shape = cat_size_shape(catdims, X...)
     A = cat_similar(X[1], T, shape)
@@ -1874,7 +1874,7 @@ _cat(dims, X...) = _cat_t(dims, promote_eltypeof(X...), X...)
 end
 # this version of `cat_t` is not very kind for inference and so its usage should be avoided,
 # nevertheless it is here just for compat after https://github.com/JuliaLang/julia/pull/45028
-@inline cat_t(::Type{T}, X...; dims) where {T} = _cat_t(dims, T, X...)
+@inline cat_t(T::Type, X...; dims) = _cat_t(dims, T, X...)
 
 # Why isn't this called `__cat!`?
 __cat(A, shape, catdims, X...) = __cat_offset!(A, shape, catdims, ntuple(Returns(0), length(shape)), X...)
@@ -2011,8 +2011,8 @@ julia> hcat([1.1, 9.9], Matrix(undef, 2, 0))  # hcat with empty 2×0 Matrix
 """
 hcat(X...) = cat(X...; dims=Val(2))
 
-typed_vcat(::Type{T}, X...) where T = _cat_t(Val(1), T, X...)
-typed_hcat(::Type{T}, X...) where T = _cat_t(Val(2), T, X...)
+typed_vcat(T::Type, X...) = _cat_t(Val(1), T, X...)
+typed_hcat(T::Type, X...) = _cat_t(Val(2), T, X...)
 
 """
     cat(A...; dims)
@@ -2204,10 +2204,10 @@ hvcat(rows::Tuple{Vararg{Int}}, xs::AbstractArray...) = typed_hvcat(promote_elty
 hvcat(rows::Tuple{Vararg{Int}}, xs::AbstractArray{T}...) where {T} = typed_hvcat(T, rows, xs...)
 
 rows_to_dimshape(rows::Tuple{Vararg{Int}}) = all(==(rows[1]), rows) ? (length(rows), rows[1]) : (rows, (sum(rows),))
-typed_hvcat(::Type{T}, rows::Tuple{Vararg{Int}}, as::AbstractVecOrMat...) where T = typed_hvncat(T, rows_to_dimshape(rows), true, as...)
+typed_hvcat(T::Type, rows::Tuple{Vararg{Int}}, as::AbstractVecOrMat...) = typed_hvncat(T, rows_to_dimshape(rows), true, as...)
 
 hvcat(rows::Tuple{Vararg{Int}}) = []
-typed_hvcat(::Type{T}, rows::Tuple{Vararg{Int}}) where {T} = Vector{T}()
+typed_hvcat(T::Type, rows::Tuple{Vararg{Int}}) = Vector{T}()
 
 function hvcat(rows::Tuple{Vararg{Int}}, xs::T...) where T<:Number
     nr = length(rows)
@@ -2251,7 +2251,7 @@ hvcat(rows::Tuple{Vararg{Int}}, xs...) = typed_hvcat(promote_eltypeof(xs...), ro
 # the following method is needed to provide a more specific one compared to LinearAlgebra/uniformscaling.jl
 hvcat(rows::Tuple{Vararg{Int}}, xs::Union{AbstractArray,Number}...) = typed_hvcat(promote_eltypeof(xs...), rows, xs...)
 
-function typed_hvcat(::Type{T}, rows::Tuple{Vararg{Int}}, xs::Number...) where T
+function typed_hvcat(T::Type, rows::Tuple{Vararg{Int}}, xs::Number...)
     nr = length(rows)
     nc = rows[1]
     for i = 2:nr
@@ -2262,7 +2262,7 @@ function typed_hvcat(::Type{T}, rows::Tuple{Vararg{Int}}, xs::Number...) where T
     hvcat_fill!(Matrix{T}(undef, nr, nc), xs)
 end
 
-typed_hvcat(::Type{T}, rows::Tuple{Vararg{Int}}, as...) where T = typed_hvncat(T, rows_to_dimshape(rows), true, as...)
+typed_hvcat(T::Type, rows::Tuple{Vararg{Int}}, as...) = typed_hvncat(T, rows_to_dimshape(rows), true, as...)
 
 ## N-dimensional concatenation ##
 
@@ -2381,7 +2381,7 @@ _typed_hvncat_0d_only_one() =
 # `@constprop :aggressive` here to form constant `Val(dim)` type to get type stability
 @constprop :aggressive _typed_hvncat(T::Type, dim::Int, ::Bool, xs...) = _typed_hvncat(T, Val(dim), xs...) # catches from _hvncat type promoters
 
-function _typed_hvncat(::Type{T}, ::Val{N}) where {T, N}
+function _typed_hvncat(T::Type, ::Val{N}) where {N}
     N < 0 &&
         throw(ArgumentError("concatenation dimension must be non-negative"))
     return Array{T, N}(undef, ntuple(Returns(0), Val(N)))
@@ -2395,7 +2395,7 @@ function _typed_hvncat(T::Type, ::Val{N}, xs::Number...) where N
     return A
 end
 
-function _typed_hvncat(::Type{T}, ::Val{N}, as::AbstractArray...) where {T, N}
+function _typed_hvncat(T::Type, ::Val{N}, as::AbstractArray...) where {N}
     # optimization for arrays that can be concatenated by copying them linearly into the destination
     # conditions: the elements must all have 1-length dimensions above N
     length(as) > 0 ||
@@ -2430,7 +2430,7 @@ function _typed_hvncat(::Type{T}, ::Val{N}, as::AbstractArray...) where {T, N}
     return A
 end
 
-function _typed_hvncat(::Type{T}, ::Val{N}, as...) where {T, N}
+function _typed_hvncat(T::Type, ::Val{N}, as...) where {N}
     length(as) > 0 ||
         throw(ArgumentError("must have at least one element"))
     N < 0 &&
@@ -2473,7 +2473,7 @@ _typed_hvncat(T::Type, ::Tuple{}, ::Bool, x::Number...) = _typed_hvncat(T, Val(0
 _typed_hvncat(T::Type, dims::Tuple{Int}, ::Bool, as...) = _typed_hvncat_1d(T, dims[1], Val(false), as...)
 _typed_hvncat(T::Type, dims::Tuple{Int}, ::Bool, as::Number...) = _typed_hvncat_1d(T, dims[1], Val(false), as...)
 
-function _typed_hvncat_1d(::Type{T}, ds::Int, ::Val{row_first}, as...) where {T, row_first}
+function _typed_hvncat_1d(T::Type, ds::Int, ::Val{row_first}, as...) where {row_first}
     lengthas = length(as)
     ds > 0 ||
         throw(ArgumentError("`dimsshape` argument must consist of positive integers"))
@@ -2486,7 +2486,7 @@ function _typed_hvncat_1d(::Type{T}, ds::Int, ::Val{row_first}, as...) where {T,
     end
 end
 
-function _typed_hvncat(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, xs::Number...) where {T, N}
+function _typed_hvncat(T::Type, dims::NTuple{N, Int}, row_first::Bool, xs::Number...) where {N}
     all(>(0), dims) ||
         throw(ArgumentError("`dims` argument must contain positive integers"))
     A = Array{T, N}(undef, dims...)
@@ -2534,7 +2534,7 @@ function _typed_hvncat(T::Type, dims::NTuple{N, Int}, row_first::Bool, as...) wh
     return _typed_hvncat_dims(T, (dims..., ntuple(Returns(1), nd - N)...), row_first, as)
 end
 
-function _typed_hvncat_dims(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, as::Tuple) where {T, N}
+function _typed_hvncat_dims(T::Type, dims::NTuple{N, Int}, row_first::Bool, as::Tuple) where {N}
     length(as) > 0 ||
         throw(ArgumentError("must have at least one element"))
     all(>(0), dims) ||
@@ -2643,7 +2643,7 @@ function _typed_hvncat(T::Type, shape::NTuple{N, Tuple}, row_first::Bool, as...)
     return _typed_hvncat_shape(T, (shape..., ntuple(Returns(shape[end]), nd - N)...), row_first, as)
 end
 
-function _typed_hvncat_shape(::Type{T}, shape::NTuple{N, Tuple}, row_first, as::Tuple) where {T, N}
+function _typed_hvncat_shape(T::Type, shape::NTuple{N, Tuple}, row_first, as::Tuple) where {N}
     length(as) > 0 ||
         throw(ArgumentError("must have at least one element"))
     all(>(0), tuple((shape...)...)) ||
@@ -2910,7 +2910,7 @@ function _stack(dims::D, ::Union{HasShape, HasLength}, iter) where {D}
     end
 end
 
-function _typed_stack(::Colon, ::Type{T}, ::Type{S}, A, Aax=_iterator_axes(A)) where {T, S}
+function _typed_stack(::Colon, T::Type, S::Type, A, Aax=_iterator_axes(A))
     xit = iterate(A)
     nothing === xit && return _empty_stack(:, T, S, A)
     x1, _ = xit
@@ -2933,21 +2933,21 @@ _iterator_axes(x, ::HasLength) = (OneTo(length(x)),)
 _iterator_axes(x, ::IteratorSize) = axes(x)
 
 # For some dims values, stack(A; dims) == stack(vec(A)), and the : path will be faster
-_typed_stack(dims::Integer, ::Type{T}, ::Type{S}, A) where {T,S} =
+_typed_stack(dims::Integer, T::Type, S::Type, A) =
     _typed_stack(dims, T, S, IteratorSize(S), A)
-function _typed_stack(dims::Integer, ::Type{T}, ::Type{S}, ::HasShape{N}, A) where {T,S,N}
+function _typed_stack(dims::Integer, T::Type, S::Type, ::HasShape{N}, A) where {N}
     if dims == N+1
         _typed_stack(:, T, S, A, (_vec_axis(A),))
     else
         _dim_stack(dims, T, S, A)
     end
 end
-_typed_stack(dims::Integer, ::Type{T}, ::Type{S}, ::IteratorSize, A) where {T,S} =
+_typed_stack(dims::Integer, T::Type, S::Type, ::IteratorSize, A) =
     _dim_stack(dims, T, S, A)
 
 _vec_axis(A, ax=_iterator_axes(A)) = length(ax) == 1 ? only(ax) : OneTo(prod(length, ax; init=1))
 
-@constprop :aggressive function _dim_stack(dims::Integer, ::Type{T}, ::Type{S}, A) where {T,S}
+@constprop :aggressive function _dim_stack(dims::Integer, T::Type, S::Type, A)
     xit = Iterators.peel(A)
     nothing === xit && return _empty_stack(dims, T, S, A)
     x1, xrest = xit

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -192,7 +192,7 @@ return for the given index and value types, by specializing on the three-argumen
 The default is to return an empty `Dict`.
 """
 empty(a::AbstractDict) = empty(a, keytype(a), valtype(a))
-empty(a::AbstractDict, ::Type{V}) where {V} = empty(a, keytype(a), V) # Note: this is the form which makes sense for `Vector`.
+empty(a::AbstractDict, V::Type) = empty(a, keytype(a), V) # Note: this is the form which makes sense for `Vector`.
 
 copy(a::AbstractDict) = merge!(empty(a), a)
 function copy!(dst::AbstractDict, src::AbstractDict)
@@ -568,7 +568,7 @@ push!(t::AbstractDict, p::Pair) = setindex!(t, p.second, p.first)
 # AbstractDicts are convertible
 convert(::Type{T}, x::T) where {T<:AbstractDict} = x
 
-function convert(::Type{T}, x::AbstractDict) where T<:AbstractDict
+function convert(T::Type{<:AbstractDict}, x::AbstractDict)
     h = T(x)::T
     if length(h) != length(x)
         error("key collision during dictionary conversion")

--- a/base/array.jl
+++ b/base/array.jl
@@ -430,7 +430,7 @@ julia> getindex(Int8, 1, 2, 3)
  3
 ```
 """
-function getindex(::Type{T}, vals...) where T
+function getindex(T::Type, vals...)
     @inline
     @_effect_free_terminates_locally_meta
     a = Vector{T}(undef, length(vals))
@@ -619,20 +619,20 @@ function ones end
 for (fname, felt) in ((:zeros, :zero), (:ones, :one))
     @eval begin
         $fname(dims::DimOrInd...) = $fname(dims)
-        $fname(::Type{T}, dims::DimOrInd...) where {T} = $fname(T, dims)
+        $fname(T::Type, dims::DimOrInd...) = $fname(T, dims)
         $fname(dims::Tuple{Vararg{DimOrInd}}) = $fname(Float64, dims)
-        $fname(::Type{T}, dims::NTuple{N, Union{Integer, OneTo}}) where {T,N} = $fname(T, map(to_dim, dims))
-        function $fname(::Type{T}, dims::NTuple{N, Integer}) where {T,N}
+        $fname(T::Type, dims::NTuple{N, Union{Integer, OneTo}}) where {N} = $fname(T, map(to_dim, dims))
+        function $fname(T::Type, dims::NTuple{N, Integer}) where {N}
             a = Array{T,N}(undef, dims)
             fill!(a, $felt(T))
             return a
         end
-        function $fname(::Type{T}, dims::Tuple{}) where {T}
+        function $fname(T::Type, dims::Tuple{})
             a = Array{T}(undef)
             fill!(a, $felt(T))
             return a
         end
-        function $fname(::Type{T}, dims::NTuple{N, DimOrInd}) where {T,N}
+        function $fname(T::Type, dims::NTuple{N, DimOrInd}) where {N}
             a = similar(Array{T,N}, dims)
             fill!(a, $felt(T))
             return a
@@ -642,7 +642,7 @@ end
 
 ## Conversions ##
 
-convert(::Type{T}, a::AbstractArray) where {T<:Array} = a isa T ? a : T(a)::T
+convert(T::Type{<:Array}, a::AbstractArray) = a isa T ? a : T(a)::T
 
 promote_rule(a::Type{Array{T,n}}, b::Type{Array{S,n}}) where {T,n,S} = el_same(promote_type(T,S), a, b)
 
@@ -669,11 +669,11 @@ julia> collect(Float64, 1:2:5)
  5.0
 ```
 """
-collect(::Type{T}, itr) where {T} = _collect(T, itr, IteratorSize(itr))
+collect(T::Type, itr) = _collect(T, itr, IteratorSize(itr))
 
-_collect(::Type{T}, itr, isz::Union{HasLength,HasShape}) where {T} =
+_collect(T::Type, itr, isz::Union{HasLength,HasShape}) =
     copyto!(_array_for_inner(T, isz, _similar_shape(itr, isz)), itr)
-function _collect(::Type{T}, itr, isz::SizeUnknown) where T
+function _collect(T::Type, itr, isz::SizeUnknown)
     a = Vector{T}()
     for x in itr
         push!(a, x)
@@ -682,26 +682,26 @@ function _collect(::Type{T}, itr, isz::SizeUnknown) where T
 end
 
 # make a collection similar to `c` and appropriate for collecting `itr`
-_similar_for(c, ::Type{T}, itr, isz, shp) where {T} = similar(c, T)
+_similar_for(c, T::Type, itr, isz, shp) = similar(c, T)
 
 _similar_shape(itr, ::SizeUnknown) = nothing
 _similar_shape(itr, ::HasLength) = length(itr)::Integer
 _similar_shape(itr, ::HasShape) = axes(itr)
 
-_similar_for(c::AbstractArray, ::Type{T}, itr, ::SizeUnknown, ::Nothing) where {T} =
+_similar_for(c::AbstractArray, T::Type, itr, ::SizeUnknown, ::Nothing) =
     similar(c, T, 0)
-_similar_for(c::AbstractArray, ::Type{T}, itr, ::HasLength, len::Integer) where {T} =
+_similar_for(c::AbstractArray, T::Type, itr, ::HasLength, len::Integer) =
     similar(c, T, len)
-_similar_for(c::AbstractArray, ::Type{T}, itr, ::HasShape, axs) where {T} =
+_similar_for(c::AbstractArray, T::Type, itr, ::HasShape, axs) =
     similar(c, T, axs)
 
 # make a collection appropriate for collecting `itr::Generator`
-_array_for_inner(::Type{T}, ::SizeUnknown, ::Nothing) where {T} = Vector{T}(undef, 0)
-_array_for_inner(::Type{T}, ::HasLength, len::Integer) where {T} = Vector{T}(undef, Int(len))
-_array_for_inner(::Type{T}, ::HasShape{N}, axs) where {T,N} = similar(Array{T,N}, axs)
+_array_for_inner(T::Type, ::SizeUnknown, ::Nothing) = Vector{T}(undef, 0)
+_array_for_inner(T::Type, ::HasLength, len::Integer) = Vector{T}(undef, Int(len))
+_array_for_inner(T::Type, ::HasShape{N}, axs) where {N} = similar(Array{T,N}, axs)
 
 # used by syntax lowering for simple typed comprehensions
-_array_for(::Type{T}, itr, isz) where {T} = _array_for_inner(T, isz, _similar_shape(itr, isz))
+_array_for(T::Type, itr, isz) = _array_for_inner(T, isz, _similar_shape(itr, isz))
 
 
 """

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -564,7 +564,7 @@ julia> BitArray(x+y == 3 for x = 1:2 for y = 1:3)
 BitArray(itr) = gen_bitarray(IteratorSize(itr), itr)
 BitArray{N}(itr) where N = gen_bitarrayN(BitArray{N}, IteratorSize(itr), itr)
 
-convert(::Type{T}, a::AbstractArray) where {T<:BitArray} = a isa T ? a : T(a)::T
+convert(T::Type{<:BitArray}, a::AbstractArray) = a isa T ? a : T(a)::T
 
 # generic constructor from an iterable without compile-time info
 # (we pass start(itr) explicitly to avoid a type-instability with filters)

--- a/base/bool.jl
+++ b/base/bool.jl
@@ -3,7 +3,7 @@
 import Core: Bool
 
 # promote Bool to any other numeric type
-promote_rule(::Type{Bool}, ::Type{T}) where {T<:Number} = T
+promote_rule(::Type{Bool}, T::Type{<:Number}) = T
 
 typemin(::Type{Bool}) = false
 typemax(::Type{Bool}) = true

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -345,7 +345,7 @@ const MemoryRef{T} = GenericMemoryRef{:not_atomic, T, CPU}
 # so the methods and ccall's in Core aren't permitted to use convert
 convert(::Type{Any}, @nospecialize(x)) = x
 convert(::Type{T}, x::T) where {T} = x
-cconvert(::Type{T}, x) where {T} = convert(T, x)
+cconvert(T::Type, x) = convert(T, x)
 unsafe_convert(::Type{T}, x::T) where {T} = x
 
 # will be inserted by the frontend for closures
@@ -936,7 +936,7 @@ end
 # n.b. This function exists for CUDA to overload to configure error behavior (see #48097)
 throw_inexacterror(func::Symbol, to, val) = throw(InexactError(func, to, val))
 
-function check_sign_bit(::Type{To}, x) where {To}
+function check_sign_bit(To::Type, x)
     @inline
     # the top bit is the sign bit of x but "sign bit" sounds better in stacktraces
     # n.b. if x is signed, then sizeof(x) === sizeof(To), otherwise sizeof(x) >= sizeof(To)
@@ -944,7 +944,7 @@ function check_sign_bit(::Type{To}, x) where {To}
     x
 end
 
-function checked_trunc_sint(::Type{To}, x::From) where {To,From}
+function checked_trunc_sint(To::Type, x::From) where {From}
     @inline
     y = trunc_int(To, x)
     back = sext_int(From, y)
@@ -952,7 +952,7 @@ function checked_trunc_sint(::Type{To}, x::From) where {To,From}
     y
 end
 
-function checked_trunc_uint(::Type{To}, x::From) where {To,From}
+function checked_trunc_uint(To::Type, x::From) where {From}
     @inline
     y = trunc_int(To, x)
     back = zext_int(From, y)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -100,7 +100,7 @@ DefaultArrayStyle{M}(::Val{N}) where {N,M} = DefaultArrayStyle{N}()
 const DefaultVectorStyle = DefaultArrayStyle{1}
 const DefaultMatrixStyle = DefaultArrayStyle{2}
 BroadcastStyle(::Type{<:AbstractArray{T,N}}) where {T,N} = DefaultArrayStyle{N}()
-BroadcastStyle(::Type{T}) where {T} = DefaultArrayStyle{ndims(T)}()
+BroadcastStyle(T::Type) = DefaultArrayStyle{ndims(T)}()
 
 # `ArrayConflict` is an internal type signaling that two or more different `AbstractArrayStyle`
 # objects were supplied as arguments, and that no rule was defined for resolving the
@@ -224,13 +224,13 @@ function Base.show(io::IO, bc::Broadcasted{Style}) where {Style}
 end
 
 ## Allocating the output container
-Base.similar(bc::Broadcasted, ::Type{T}) where {T} = similar(bc, T, axes(bc))
-Base.similar(::Broadcasted{DefaultArrayStyle{N}}, ::Type{ElType}, dims) where {N,ElType} =
+Base.similar(bc::Broadcasted, T::Type) = similar(bc, T, axes(bc))
+Base.similar(::Broadcasted{DefaultArrayStyle{N}}, ElType::Type, dims) where {N} =
     similar(Array{ElType, length(dims)}, dims)
 Base.similar(::Broadcasted{DefaultArrayStyle{N}}, ::Type{Bool}, dims) where N =
     similar(BitArray, dims)
 # In cases of conflict we fall back on Array
-Base.similar(::Broadcasted{ArrayConflict}, ::Type{ElType}, dims) where ElType =
+Base.similar(::Broadcasted{ArrayConflict}, ElType::Type, dims) =
     similar(Array{ElType, length(dims)}, dims)
 Base.similar(::Broadcasted{ArrayConflict}, ::Type{Bool}, dims) =
     similar(BitArray, dims)
@@ -247,7 +247,7 @@ BroadcastStyle(::Type{<:Broadcasted{Style}}) where {Style} = Style()
 BroadcastStyle(::Type{<:Broadcasted{S}}) where {S<:Union{Nothing,Unknown}} =
     throw(ArgumentError("Broadcasted{Unknown} wrappers do not have a style assigned"))
 
-argtype(::Type{BC}) where {BC<:Broadcasted} = fieldtype(BC, :args)
+argtype(BC::Type{<:Broadcasted}) = fieldtype(BC, :args)
 argtype(bc::Broadcasted) = argtype(typeof(bc))
 
 @inline Base.eachindex(bc::Broadcasted) = eachindex(IndexStyle(bc), bc)
@@ -290,7 +290,7 @@ Base.@propagate_inbounds function Base.iterate(bc::Broadcasted, s)
     return (bc[i], (s[1], newstate))
 end
 
-Base.IteratorSize(::Type{T}) where {T<:Broadcasted} = Base.HasShape{ndims(T)}()
+Base.IteratorSize(T::Type{<:Broadcasted}) = Base.HasShape{ndims(T)}()
 Base.IteratorEltype(::Type{<:Broadcasted}) = Base.EltypeUnknown()
 
 ## Instantiation fills in the "missing" fields in Broadcasted.
@@ -730,7 +730,7 @@ Base.RefValue{String}("hello")
 ```
 """
 broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,AbstractPattern,Pair,IO,CartesianIndex}) = Ref(x)
-broadcastable(::Type{T}) where {T} = Ref{Type{T}}(T)
+broadcastable(T::Type) = Ref{Type{T}}(T)
 broadcastable(x::Union{AbstractArray,Number,AbstractChar,Ref,Tuple,Broadcasted}) = x
 # Default to collecting iterables — which will error for non-iterables
 broadcastable(x) = collect(x)

--- a/base/char.jl
+++ b/base/char.jl
@@ -210,12 +210,12 @@ end
 end
 
 convert(::Type{AbstractChar}, x::Number) = Char(x) # default to Char
-convert(::Type{T}, x::Number) where {T<:AbstractChar} = T(x)::T
-convert(::Type{T}, x::AbstractChar) where {T<:Number} = T(x)::T
-convert(::Type{T}, c::AbstractChar) where {T<:AbstractChar} = T(c)::T
+convert(T::Type{<:AbstractChar}, x::Number) = T(x)::T
+convert(T::Type{<:Number}, x::AbstractChar) = T(x)::T
+convert(T::Type{<:AbstractChar}, c::AbstractChar) = T(c)::T
 convert(::Type{T}, c::T) where {T<:AbstractChar} = c
 
-rem(x::AbstractChar, ::Type{T}) where {T<:Number} = rem(codepoint(x), T)
+rem(x::AbstractChar, T::Type{<:Number}) = rem(codepoint(x), T)
 
 typemax(::Type{Char}) = bitcast(Char, typemax(UInt32))
 typemin(::Type{Char}) = bitcast(Char, typemin(UInt32))
@@ -233,7 +233,7 @@ getindex(c::AbstractChar, i::Integer) = i == 1 ? c : throw(BoundsError())
 getindex(c::AbstractChar, I::Integer...) = all(x -> x == 1, I) ? c : throw(BoundsError())
 first(c::AbstractChar) = c
 last(c::AbstractChar) = c
-eltype(::Type{T}) where {T<:AbstractChar} = T
+eltype(T::Type{<:AbstractChar}) = T
 
 iterate(c::AbstractChar, done=false) = done ? nothing : (c, true)
 isempty(c::AbstractChar) = false
@@ -248,7 +248,7 @@ hash(x::Char, h::UInt) =
 isless(x::AbstractChar, y::AbstractChar) = isless(Char(x)::Char, Char(y)::Char)
 ==(x::AbstractChar, y::AbstractChar) = Char(x)::Char == Char(y)::Char
 hash(x::AbstractChar, h::UInt) = hash(Char(x)::Char, h)
-widen(::Type{T}) where {T<:AbstractChar} = T
+widen(T::Type{<:AbstractChar}) = T
 
 @inline -(x::AbstractChar, y::AbstractChar) = Int(x) - Int(y)
 @inline function -(x::T, y::Integer) where {T<:AbstractChar}

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -118,7 +118,7 @@ Float64
 ```
 """
 real(T::Type) = typeof(real(zero(T)))
-real(::Type{T}) where {T<:Real} = T
+real(T::Type{<:Real}) = T
 real(C::Type{<:Complex}) = fieldtype(C, 1)
 real(::Type{Union{}}, slurp...) = Union{}
 
@@ -186,7 +186,7 @@ julia> complex(Union{Int, Missing})
 Union{Missing, Complex{Int64}}
 ```
 """
-complex(::Type{T}) where {T<:Real} = Complex{T}
+complex(T::Type{<:Real}) = Complex{T}
 complex(::Type{Complex{T}}) where {T<:Real} = Complex{T}
 complex(::Type{Union{}}, slurp...) = Union{}
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -411,7 +411,7 @@ getindex(match::Core.MethodMatch, field::Int) =
 # these were internal functions, but some packages seem to be relying on them
 tuple_type_head(T::Type) = fieldtype(T, 1)
 tuple_type_cons(::Type, ::Type{Union{}}) = Union{}
-@assume_effects :foldable tuple_type_cons(::Type{S}, ::Type{T}) where T<:Tuple where S =
+@assume_effects :foldable tuple_type_cons(S::Type, T::Type{<:Tuple}) =
     Tuple{S, T.parameters...}
 @assume_effects :foldable parameter_upper_bound(t::UnionAll, idx) =
     rewrap_unionall((unwrap_unionall(t)::DataType).parameters[idx], t)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -116,7 +116,7 @@ Dict(ps::Pair...)                  = Dict(ps)
 
 Dict(kv) = dict_with_eltype((K, V) -> Dict{K, V}, kv, eltype(kv))
 
-empty(a::AbstractDict, ::Type{K}, ::Type{V}) where {K, V} = Dict{K, V}()
+empty(a::AbstractDict, K::Type, V::Type) = Dict{K, V}()
 
 # Gets 7 most significant bits from the hash (hsh), first bit is 1
 _shorthash7(hsh::UInt) = (hsh >> (8sizeof(UInt)-7))%UInt8 | 0x80
@@ -858,7 +858,7 @@ function iterate(d::ImmutableDict{K,V}, t=d) where {K, V}
 end
 length(t::ImmutableDict) = count(Returns(true), t)
 isempty(t::ImmutableDict) = !isdefined(t, :parent)
-empty(::ImmutableDict, ::Type{K}, ::Type{V}) where {K, V} = ImmutableDict{K,V}()
+empty(::ImmutableDict, K::Type, V::Type) = ImmutableDict{K,V}()
 
 """
     setindex(d::ImmutableDict, value, key)
@@ -883,7 +883,7 @@ function setindex(d::ImmutableDict, value, key)
 end
 
 _similar_for(c::AbstractDict, ::Type{Pair{K,V}}, itr, isz, len) where {K, V} = empty(c, K, V)
-_similar_for(c::AbstractDict, ::Type{T}, itr, isz, len) where {T} =
+_similar_for(c::AbstractDict, T::Type, itr, isz, len) =
     throw(ArgumentError("for AbstractDicts, similar requires an element type of Pair;\n  if calling map, consider a comprehension instead"))
 
 
@@ -1059,6 +1059,6 @@ iterate(dict::PersistentDict, state=nothing) = HAMT.iterate(dict.trie, state)
 
 length(dict::PersistentDict) = HAMT.length(dict.trie)
 isempty(dict::PersistentDict) = HAMT.isempty(dict.trie)
-empty(::PersistentDict, ::Type{K}, ::Type{V}) where {K, V} = PersistentDict{K, V}()
+empty(::PersistentDict, K::Type, V::Type) = PersistentDict{K, V}()
 
 @propagate_inbounds Iterators.only(dict::PersistentDict) = Iterators._only(dict, first)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -409,7 +409,7 @@ function showerror(io::IO, exc::FieldError)
     Base.Experimental.show_error_hints(io, exc)
 end
 
-striptype(::Type{T}) where {T} = T
+striptype(T::Type) = T
 striptype(::Any) = nothing
 
 function showerror_ambiguous(io::IO, meths, f, args::Type)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -644,7 +644,7 @@ import Core: typename
 _tuple_error(T::Type, x) = (@noinline; throw(MethodError(convert, (T, x))))
 
 convert(::Type{T}, x::T) where {T<:Tuple} = x
-function convert(::Type{T}, x::NTuple{N,Any}) where {N, T<:Tuple}
+function convert(T::Type{<:Tuple}, x::NTuple{N,Any}) where {N}
     # First see if there could be any conversion of the input type that'd be a subtype of the output.
     # If not, we'll throw an explicit MethodError (otherwise, it might throw a typeassert).
     if typeintersect(NTuple{N,Any}, T) === Union{}
@@ -730,12 +730,12 @@ Neither `convert` nor `cconvert` should take a Julia object and turn it into a `
 """
 function cconvert end
 
-cconvert(::Type{T}, x) where {T} = x isa T ? x : convert(T, x) # do the conversion eagerly in most cases
+cconvert(T::Type, x) = x isa T ? x : convert(T, x) # do the conversion eagerly in most cases
 cconvert(::Type{Union{}}, x...) = convert(Union{}, x...)
 cconvert(::Type{<:Ptr}, x) = x # but defer the conversion to Ptr to unsafe_convert
 unsafe_convert(::Type{T}, x::T) where {T} = x # unsafe_convert (like convert) defaults to assuming the convert occurred
 unsafe_convert(::Type{T}, x::T) where {T<:Ptr} = x  # to resolve ambiguity with the next method
-unsafe_convert(::Type{P}, x::Ptr) where {P<:Ptr} = convert(P, x)
+unsafe_convert(P::Type{<:Ptr}, x::Ptr) = convert(P, x)
 unsafe_convert(::Type{Ptr{UInt8}}, s::String) = ccall(:jl_string_ptr, Ptr{UInt8}, (Any,), s)
 unsafe_convert(::Type{Ptr{Int8}}, s::String) = ccall(:jl_string_ptr, Ptr{Int8}, (Any,), s)
 
@@ -773,7 +773,7 @@ julia> reinterpret(Tuple{UInt16, UInt8}, (0x01, 0x0203))
     may result without additional validation.
 
 """
-function reinterpret(::Type{Out}, x) where {Out}
+function reinterpret(Out::Type, x)
     @inline
     if isprimitivetype(Out) && isprimitivetype(typeof(x))
         return bitcast(Out, x)

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -295,7 +295,7 @@ function read(f::File, ::Type{Char})
     return reinterpret(Char, c)
 end
 
-read(f::File, ::Type{T}) where {T<:AbstractChar} = T(read(f, Char)) # fallback
+read(f::File, T::Type{<:AbstractChar}) = T(read(f, Char)) # fallback
 
 function unsafe_read(f::File, p::Ptr{UInt8}, nel::UInt)
     check_open(f)

--- a/base/float.jl
+++ b/base/float.jl
@@ -164,7 +164,7 @@ function exponent_raw_max end
 """
 IEEE 754 definition of the minimum exponent.
 """
-ieee754_exponent_min(::Type{T}) where {T<:IEEEFloat} = Int(1 - exponent_max(T))::Int
+ieee754_exponent_min(T::Type{<:IEEEFloat}) = Int(1 - exponent_max(T))::Int
 
 exponent_min(::Type{Float16}) = ieee754_exponent_min(Float16)
 exponent_min(::Type{Float32}) = ieee754_exponent_min(Float32)
@@ -389,8 +389,8 @@ julia> float(Int)
 Float64
 ```
 """
-float(::Type{T}) where {T<:Number} = typeof(float(zero(T)))
-float(::Type{T}) where {T<:AbstractFloat} = T
+float(T::Type{<:Number}) = typeof(float(zero(T)))
+float(T::Type{<:AbstractFloat}) = T
 float(::Type{Union{}}, slurp...) = Union{}
 
 """
@@ -469,7 +469,7 @@ rounds_up(x, ::RoundingMode{:Down}) = false
 rounds_up(x, ::RoundingMode{:Up}) = true
 rounds_up(x, ::RoundingMode{:ToZero}) = signbit(x)
 rounds_up(x, ::RoundingMode{:FromZero}) = !signbit(x)
-function _round_convert(::Type{T}, x_integer, x, r::Union{RoundingMode{:ToZero}, RoundingMode{:FromZero}, RoundingMode{:Up}, RoundingMode{:Down}}) where {T<:AbstractFloat}
+function _round_convert(T::Type{<:AbstractFloat}, x_integer, x, r::Union{RoundingMode{:ToZero}, RoundingMode{:FromZero}, RoundingMode{:Up}, RoundingMode{:Down}})
     x_t = convert(T, x_integer)
     if rounds_up(x, r)
         x_t < x ? nextfloat(x_t) : x_t
@@ -803,7 +803,7 @@ function _precision(x, base::Integer)
     p = _precision_with_base_2(x)
     return base == 2 ? Int(p) : floor(Int, p / log2(base))
 end
-precision(::Type{T}; base::Integer=2) where {T<:AbstractFloat} = _precision(T, base)
+precision(T::Type{<:AbstractFloat}; base::Integer=2) = _precision(T, base)
 precision(::T; base::Integer=2) where {T<:AbstractFloat} = precision(T; base)
 
 

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -41,7 +41,7 @@ The largest consecutive integer representable in the given floating-point type `
 also does not exceed the maximum integer representable by the integer type `S`.  Equivalently,
 it is the minimum of `maxintfloat(T)` and [`typemax(S)`](@ref).
 """
-maxintfloat(::Type{S}, ::Type{T}) where {S<:AbstractFloat, T<:Integer} = min(maxintfloat(S), S(typemax(T)))
+maxintfloat(S::Type{<:AbstractFloat}, T::Type{<:Integer}) = min(maxintfloat(S), S(typemax(T)))
 maxintfloat() = maxintfloat(Float64)
 
 isinteger(x::AbstractFloat) = iszero(x - trunc(x)) # note: x == trunc(x) would be incorrect for x=Inf
@@ -261,7 +261,7 @@ This is equivalent to `!isapprox(x,y)` (see [`isapprox`](@ref)).
 ≉(args...; kws...) = !≈(args...; kws...)
 
 # default tolerance arguments
-rtoldefault(::Type{T}) where {T<:AbstractFloat} = sqrt(eps(T))
+rtoldefault(T::Type{<:AbstractFloat}) = sqrt(eps(T))
 rtoldefault(::Type{<:Real}) = 0
 function rtoldefault(x::Union{T,Type{T}}, y::Union{S,Type{S}}, atol::Real) where {T<:Number,S<:Number}
     rtol = max(rtoldefault(real(T)),rtoldefault(real(S)))

--- a/base/generator.jl
+++ b/base/generator.jl
@@ -36,9 +36,9 @@ end
 
 Generator(f, I1, I2, Is...) = Generator(splat(f), zip(I1, I2, Is...))
 
-Generator(::Type{T}, iter::I) where {T,I} = Generator{I,Type{T}}(T, iter)
+Generator(T::Type, iter::I) where {I} = Generator{I,Type{T}}(T, iter)
 
-Generator(::Type{T}, I1, I2, Is...) where {T} = Generator(splat(T), zip(I1, I2, Is...))
+Generator(T::Type, I1, I2, Is...) = Generator(splat(T), zip(I1, I2, Is...))
 
 function iterate(g::Generator, s...)
     @inline

--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -226,7 +226,7 @@ end
 
 ## Conversions ##
 
-convert(::Type{T}, a::AbstractArray) where {T<:Memory} = a isa T ? a : T(a)::T
+convert(T::Type{<:Memory}, a::AbstractArray) = a isa T ? a : T(a)::T
 
 promote_rule(a::Type{Memory{T}}, b::Type{Memory{S}}) where {T,S} = el_same(promote_type(T,S), a, b)
 

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -348,10 +348,10 @@ end
 
 rem(x::BigInt, ::Type{Bool}) = !iszero(x) & unsafe_load(x.d) % Bool # never unsafe here
 
-rem(x::BigInt, ::Type{T}) where T<:Union{SLimbMax,ULimbMax} =
+rem(x::BigInt, T::Type{<:Union{SLimbMax,ULimbMax}}) =
     iszero(x) ? zero(T) : flipsign(unsafe_load(x.d) % T, x.size)
 
-function rem(x::BigInt, ::Type{T}) where T<:Union{Base.BitUnsigned,Base.BitSigned}
+function rem(x::BigInt, T::Type{<:Union{Base.BitUnsigned,Base.BitSigned}})
     u = zero(T)
     for l = 1:min(abs(x.size), cld(sizeof(T), sizeof(Limb)))
         u += (unsafe_load(x.d, l) % T) << ((sizeof(Limb)<<3)*(l-1))

--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -282,7 +282,7 @@ end
 hash(x::Symbol) = objectid(x)
 
 
-load_le(::Type{T}, ptr::Ptr{UInt8}, i) where {T <: Union{UInt32, UInt64}} =
+load_le(T::Type{<:Union{UInt32, UInt64}}, ptr::Ptr{UInt8}, i) =
     unsafe_load(convert(Ptr{T}, ptr + i - 1))
 
 @assume_effects :terminates_globally function hash_bytes(

--- a/base/iddict.jl
+++ b/base/iddict.jl
@@ -56,7 +56,7 @@ IdDict(ps::Pair...)                            = IdDict{Any,Any}(ps)
 
 IdDict(kv) = dict_with_eltype((K, V) -> IdDict{K, V}, kv, eltype(kv))
 
-empty(d::IdDict, ::Type{K}, ::Type{V}) where {K, V} = IdDict{K,V}()
+empty(d::IdDict, K::Type, V::Type) = IdDict{K,V}()
 
 function rehash!(d::IdDict, newsz::Integer = length(d.ht)%UInt)
     d.ht = ccall(:jl_idtable_rehash, Memory{Any}, (Any, Csize_t), d.ht, newsz)

--- a/base/idset.jl
+++ b/base/idset.jl
@@ -38,7 +38,7 @@ IdSet{T}(itr) where {T} = union!(IdSet{T}(), itr)
 IdSet() = IdSet{Any}()
 
 copymutable(s::IdSet) = typeof(s)(s)
-emptymutable(s::IdSet{T}, ::Type{U}=T) where {T,U} = IdSet{U}()
+emptymutable(s::IdSet{T}, U::Type=T) where {T} = IdSet{U}()
 copy(s::IdSet) = typeof(s)(s)
 
 haskey(s::IdSet, @nospecialize(key)) = ccall(:jl_idset_peek_bp, Int, (Any, Any, Any), s.list, s.idxs, key) != -1

--- a/base/int.jl
+++ b/base/int.jl
@@ -76,7 +76,7 @@ signed(::Type{UInt16}) = Int16
 signed(::Type{UInt32}) = Int32
 signed(::Type{UInt64}) = Int64
 signed(::Type{UInt128}) = Int128
-signed(::Type{T}) where {T<:Signed} = T
+signed(T::Type{<:Signed}) = T
 
 ## integer comparisons ##
 
@@ -666,9 +666,9 @@ rem(x::Signed, ::Type{Unsigned}) = x % unsigned(typeof(x))
 rem(x::Unsigned, ::Type{Signed}) = x % signed(typeof(x))
 rem(x::Integer, T::Type{<:Integer}) = convert(T, x)  # `x % T` falls back to `convert`
 rem(x::Integer, ::Type{Bool}) = ((x & 1) != 0)
-mod(x::Integer, ::Type{T}) where {T<:Integer} = rem(x, T)
+mod(x::Integer, T::Type{<:Integer}) = rem(x, T)
 
-unsafe_trunc(::Type{T}, x::Integer) where {T<:Integer} = rem(x, T)
+unsafe_trunc(T::Type{<:Integer}, x::Integer) = rem(x, T)
 
 ## integer construction ##
 

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -364,7 +364,7 @@ Inverse (modulo ``2^w``)* by Jeffrey Hurchalla](https://arxiv.org/abs/2204.04342
 !!! compat "Julia 1.11"
     The `invmod(n)` and `invmod(n, T)` methods require Julia 1.11 or later.
 """
-invmod(n::Integer, ::Type{T}) where {T<:BitInteger} = invmod(n % T)
+invmod(n::Integer, T::Type{<:BitInteger}) = invmod(n % T)
 
 function invmod(n::T) where {T<:BitInteger}
     isodd(n) || throw(DomainError(n, "Argument must be odd."))
@@ -1202,7 +1202,7 @@ end
 
 Return `true` if and only if the extrema `typemax(T)` and `typemin(T)` are defined.
 """
-hastypemax(::Type{T}) where {T} = applicable(typemax, T) && applicable(typemin, T)
+hastypemax(T::Type) = applicable(typemax, T) && applicable(typemin, T)
 
 """
     digits!(array, n::Integer; base::Integer = 10)
@@ -1466,7 +1466,7 @@ julia> trunc(Int, 4pi^2)
 39
 ```
 """
-function clamp(x, ::Type{T}) where {T<:Integer}
+function clamp(x, T::Type{<:Integer})
     # delegating to clamp(x, typemin(T), typemax(T)) would promote types
     # this way, we avoid unnecessary conversions
     # think of, e.g., clamp(big(2) ^ 200, Int16)

--- a/base/io.jl
+++ b/base/io.jl
@@ -357,7 +357,7 @@ function unsafe_read(s::IO, p::Ptr{UInt8}, n::UInt)
     nothing
 end
 
-function peek(s::IO, ::Type{T}) where T
+function peek(s::IO, T::Type)
     mark(s)
     try read(s, T)::T
     finally
@@ -486,7 +486,7 @@ copyuntil(out::IO, io::AbstractPipe, arg::AbstractString; kw...) = copyuntil(out
 copyuntil(out::IO, io::AbstractPipe, arg::AbstractVector; kw...) = copyuntil(out, pipe_reader(io)::IO, arg; kw...)
 readuntil_vector!(io::AbstractPipe, target::AbstractVector, keep::Bool, out) = readuntil_vector!(pipe_reader(io)::IO, target, keep, out)
 readbytes!(io::AbstractPipe, target::AbstractVector{UInt8}, n=length(target)) = readbytes!(pipe_reader(io)::IO, target, n)
-peek(io::AbstractPipe, ::Type{T}) where {T} = peek(pipe_reader(io)::IO, T)::T
+peek(io::AbstractPipe, T::Type) = peek(pipe_reader(io)::IO, T)::T
 wait_readnb(io::AbstractPipe, nb::Int) = wait_readnb(pipe_reader(io)::IO, nb)
 eof(io::AbstractPipe) = eof(pipe_reader(io)::IO)::Bool
 
@@ -523,7 +523,7 @@ Open a file and read its contents. `args` is passed to `read`: this is equivalen
 """
 read(filename::AbstractString, args...) = open(io->read(io, args...), convert(String, filename)::String)
 
-read(filename::AbstractString, ::Type{T}) where {T} = open(io->read(io, T), convert(String, filename)::String)
+read(filename::AbstractString, T::Type) = open(io->read(io, T), convert(String, filename)::String)
 
 """
     read!(stream::IO, array::AbstractArray)

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -28,8 +28,8 @@ See also [`AbstractIrrational`](@ref).
 """
 struct Irrational{sym} <: AbstractIrrational end
 
-typemin(::Type{T}) where {T<:Irrational} = T()
-typemax(::Type{T}) where {T<:Irrational} = T()
+typemin(T::Type{<:Irrational}) = T()
+typemax(T::Type{<:Irrational}) = T()
 
 show(io::IO, x::Irrational{sym}) where {sym} = print(io, sym)
 
@@ -44,9 +44,9 @@ end
 promote_rule(::Type{<:AbstractIrrational}, ::Type{Float16}) = Float16
 promote_rule(::Type{<:AbstractIrrational}, ::Type{Float32}) = Float32
 promote_rule(::Type{<:AbstractIrrational}, ::Type{<:AbstractIrrational}) = Float64
-promote_rule(::Type{<:AbstractIrrational}, ::Type{T}) where {T<:Real} = promote_type(Float64, T)
+promote_rule(::Type{<:AbstractIrrational}, T::Type{<:Real}) = promote_type(Float64, T)
 
-function promote_rule(::Type{S}, ::Type{T}) where {S<:AbstractIrrational,T<:Number}
+function promote_rule(S::Type{<:AbstractIrrational}, T::Type{<:Number})
     U = promote_type(S, real(T))
     if S <: U
         # prevent infinite recursion
@@ -60,7 +60,7 @@ AbstractFloat(x::AbstractIrrational) = Float64(x)::Float64
 Float16(x::AbstractIrrational) = Float16(Float32(x)::Float32)
 Complex{T}(x::AbstractIrrational) where {T<:Real} = Complex{T}(T(x))
 
-function _irrational_to_rational_at_current_precision(::Type{T}, x::AbstractIrrational) where {T <: Integer}
+function _irrational_to_rational_at_current_precision(T::Type{<:Integer}, x::AbstractIrrational)
     bx = BigFloat(x)
     r = rationalize(T, bx, tol = 0)
     if abs(BigFloat(r) - bx) > eps(bx)
@@ -69,13 +69,13 @@ function _irrational_to_rational_at_current_precision(::Type{T}, x::AbstractIrra
         nothing  # Error is too small, repeat with greater precision.
     end
 end
-function _irrational_to_rational_at_precision(::Type{T}, x::AbstractIrrational, p::Int) where {T <: Integer}
+function _irrational_to_rational_at_precision(T::Type{<:Integer}, x::AbstractIrrational, p::Int)
     f = let x = x
         () -> _irrational_to_rational_at_current_precision(T, x)
     end
     setprecision(f, BigFloat, p)
 end
-function _irrational_to_rational_at_current_rounding_mode(::Type{T}, x::AbstractIrrational) where {T <: Integer}
+function _irrational_to_rational_at_current_rounding_mode(T::Type{<:Integer}, x::AbstractIrrational)
     if T <: BigInt
         _throw_argument_error_irrational_to_rational_bigint()  # avoid infinite loop
     end
@@ -88,7 +88,7 @@ function _irrational_to_rational_at_current_rounding_mode(::Type{T}, x::Abstract
         p += 32
     end
 end
-function _irrational_to_rational(::Type{T}, x::AbstractIrrational) where {T <: Integer}
+function _irrational_to_rational(T::Type{<:Integer}, x::AbstractIrrational)
     f = let x = x
         () -> _irrational_to_rational_at_current_rounding_mode(T, x)
     end
@@ -98,7 +98,7 @@ Rational{T}(x::AbstractIrrational) where {T<:Integer} = _irrational_to_rational(
 _throw_argument_error_irrational_to_rational_bigint() = throw(ArgumentError("Cannot convert an AbstractIrrational to a Rational{BigInt}: use rationalize(BigInt, x) instead"))
 Rational{BigInt}(::AbstractIrrational) = _throw_argument_error_irrational_to_rational_bigint()
 
-function _irrational_to_float(::Type{T}, x::AbstractIrrational, r::RoundingMode) where T<:Union{Float32,Float64}
+function _irrational_to_float(T::Type{<:Union{Float32,Float64}}, x::AbstractIrrational, r::RoundingMode)
     setprecision(BigFloat, 256) do
         T(BigFloat(x)::BigFloat, r)
     end
@@ -141,10 +141,10 @@ end
 <=(x::AbstractFloat, y::AbstractIrrational) = x < y
 
 # Irrational vs Rational
-function _rationalize_irrational(::Type{T}, x::AbstractIrrational, tol::Real) where {T<:Integer}
+function _rationalize_irrational(T::Type{<:Integer}, x::AbstractIrrational, tol::Real)
     return rationalize(T, big(x), tol=tol)
 end
-function rationalize(::Type{T}, x::AbstractIrrational; tol::Real=0) where {T<:Integer}
+function rationalize(T::Type{<:Integer}, x::AbstractIrrational; tol::Real=0)
     return _rationalize_irrational(T, x, tol)
 end
 function _lessrational(rx::Rational, x::AbstractIrrational)
@@ -184,7 +184,7 @@ isone(::AbstractIrrational) = false
 
 hash(x::Irrational, h::UInt) = 3h - objectid(x)
 
-widen(::Type{T}) where {T<:Irrational} = T
+widen(T::Type{<:Irrational}) = T
 
 zero(::AbstractIrrational) = false
 zero(::Type{<:AbstractIrrational}) = false

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1153,7 +1153,7 @@ end
 
 eltype(::Type{ProductIterator{I}}) where {I} = _prod_eltype(I)
 _prod_eltype(::Type{Tuple{}}) = Tuple{}
-_prod_eltype(::Type{I}) where {I<:Tuple} = TupleOrBottom(ntuple(n -> eltype(fieldtype(I, n)), _counttuple(I)::Int)...)
+_prod_eltype(I::Type{<:Tuple}) = TupleOrBottom(ntuple(n -> eltype(fieldtype(I, n)), _counttuple(I)::Int)...)
 
 iterate(::ProductIterator{Tuple{}}) = (), true
 iterate(::ProductIterator{Tuple{}}, state) = nothing

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -738,9 +738,9 @@ mutable struct OncePerProcess{T, F} <: Function
         return once
     end
 end
-OncePerProcess{T}(initializer::Type{U}) where {T, U} = OncePerProcess{T, Type{U}}(initializer)
+OncePerProcess{T}(initializer::Type) where {T} = OncePerProcess{T, Type{initializer}}(initializer)
 OncePerProcess{T}(initializer::F) where {T, F} = OncePerProcess{T, F}(initializer)
-OncePerProcess(initializer::Type{U}) where U = OncePerProcess{Base.promote_op(initializer), Type{U}}(initializer)
+OncePerProcess(initializer::Type) = OncePerProcess{Base.promote_op(initializer), Type{initializer}}(initializer)
 OncePerProcess(initializer) = OncePerProcess{Base.promote_op(initializer), typeof(initializer)}(initializer)
 @inline function (once::OncePerProcess{T,F})() where {T,F}
     state = (@atomic :acquire once.state)
@@ -850,9 +850,9 @@ mutable struct OncePerThread{T, F} <: Function
         return once
     end
 end
-OncePerThread{T}(initializer::Type{U}) where {T, U} = OncePerThread{T,Type{U}}(initializer)
+OncePerThread{T}(initializer::Type) where {T} = OncePerThread{T,Type{initializer}}(initializer)
 OncePerThread{T}(initializer::F) where {T, F} = OncePerThread{T,F}(initializer)
-OncePerThread(initializer::Type{U}) where U = OncePerThread{Base.promote_op(initializer), Type{U}}(initializer)
+OncePerThread(initializer::Type) = OncePerThread{Base.promote_op(initializer), Type{initializer}}(initializer)
 OncePerThread(initializer) = OncePerThread{Base.promote_op(initializer), typeof(initializer)}(initializer)
 @inline (once::OncePerThread{T,F})() where {T,F} = once[Threads.threadid()]
 @inline function getindex(once::OncePerThread{T,F}, tid::Integer) where {T,F}
@@ -980,10 +980,10 @@ false
 mutable struct OncePerTask{T, F} <: Function
     const initializer::F
 
-    OncePerTask{T}(initializer::Type{U}) where {T, U} = new{T,Type{U}}(initializer)
+    OncePerTask{T}(initializer::Type) where {T} = new{T,Type{initializer}}(initializer)
     OncePerTask{T}(initializer::F) where {T, F} = new{T,F}(initializer)
     OncePerTask{T,F}(initializer::F) where {T, F} = new{T,F}(initializer)
-    OncePerTask(initializer::Type{U}) where U = new{Base.promote_op(initializer), Type{U}}(initializer)
+    OncePerTask(initializer::Type) = new{Base.promote_op(initializer), Type{initializer}}(initializer)
     OncePerTask(initializer) = new{Base.promote_op(initializer), typeof(initializer)}(initializer)
 end
 @inline function (once::OncePerTask{T,F})() where {T,F}

--- a/base/mathconstants.jl
+++ b/base/mathconstants.jl
@@ -29,7 +29,7 @@ end
 Base.@assume_effects :foldable function (::Type{T})(x::_KnownIrrational, r::RoundingMode) where {T<:Union{Float32,Float64}}
     Base._irrational_to_float(T, x, r)
 end
-Base.@assume_effects :foldable function Base.rationalize(::Type{T}, x::_KnownIrrational; tol::Real=0) where {T<:Integer}
+Base.@assume_effects :foldable function Base.rationalize(T::Type{<:Integer}, x::_KnownIrrational; tol::Real=0)
     Base._rationalize_irrational(T, x, tol)
 end
 Base.@assume_effects :foldable function Base.lessrational(rx::Rational, x::_KnownIrrational)

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -67,8 +67,8 @@ end
 
 convert(::Type{T}, x::T) where {T>:Missing} = x
 convert(::Type{T}, x::T) where {T>:Union{Missing, Nothing}} = x
-convert(::Type{T}, x) where {T>:Missing} = convert(nonmissingtype_checked(T), x)
-convert(::Type{T}, x) where {T>:Union{Missing, Nothing}} = convert(nonmissingtype_checked(nonnothingtype_checked(T)), x)
+convert(T::Type{>:Missing}, x) = convert(nonmissingtype_checked(T), x)
+convert(T::Type{>:Union{Missing, Nothing}}, x) = convert(nonmissingtype_checked(nonnothingtype_checked(T)), x)
 
 # Comparison operators
 ==(::Missing, ::Missing) = missing
@@ -105,11 +105,11 @@ end
 for f in (:zero, :one, :oneunit)
     @eval ($f)(::Type{Any}) = throw(MethodError($f, (Any,)))  # To prevent StackOverflowError
     @eval ($f)(::Type{Missing}) = missing
-    @eval ($f)(::Type{T}) where {T>:Missing} = $f(nonmissingtype_checked(T))
+    @eval ($f)(T::Type{>:Missing}) = $f(nonmissingtype_checked(T))
 end
 for f in (:float, :real, :complex)
     @eval ($f)(::Type{Any}) = throw(MethodError($f, (Any,)))  # To prevent StackOverflowError
-    @eval ($f)(::Type{T}) where {T>:Missing} = Union{$f(nonmissingtype(T)), Missing}
+    @eval ($f)(T::Type{>:Missing}) = Union{$f(nonmissingtype(T)), Missing}
 end
 
 # Binary operators/functions
@@ -140,13 +140,13 @@ missing_conversion_msg(@nospecialize T) =
 # Rounding and related functions
 round(::Missing, ::RoundingMode=RoundNearest; sigdigits::Integer=0, digits::Integer=0, base::Integer=0) = missing
 round(::Type{>:Missing}, ::Missing, ::RoundingMode=RoundNearest) = missing
-round(::Type{T}, ::Missing, ::RoundingMode=RoundNearest) where {T} =
+round(T::Type, ::Missing, ::RoundingMode=RoundNearest) =
     throw(MissingException(missing_conversion_msg(T)))
-round(::Type{T}, x::Any, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype_checked(T), x, r)
+round(T::Type{>:Missing}, x::Any, r::RoundingMode=RoundNearest) = round(nonmissingtype_checked(T), x, r)
 # to fix ambiguities
-round(::Type{T}, x::Real, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype_checked(T), x, r)
-round(::Type{T}, x::Rational{Tr}, r::RoundingMode=RoundNearest) where {T>:Missing,Tr} = round(nonmissingtype_checked(T), x, r)
-round(::Type{T}, x::Rational{Bool}, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype_checked(T), x, r)
+round(T::Type{>:Missing}, x::Real, r::RoundingMode=RoundNearest) = round(nonmissingtype_checked(T), x, r)
+round(T::Type{>:Missing}, x::Rational{Tr}, r::RoundingMode=RoundNearest) where {Tr} = round(nonmissingtype_checked(T), x, r)
+round(T::Type{>:Missing}, x::Rational{Bool}, r::RoundingMode=RoundNearest) = round(nonmissingtype_checked(T), x, r)
 
 # to avoid ambiguity warnings
 (^)(::Missing, ::Integer) = missing

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -442,12 +442,12 @@ function _unchecked_cast(::Type{BigInt}, x::BigFloat, r::MPFRRoundingMode)
     return z
 end
 
-function _unchecked_cast(::Type{T}, x::BigFloat, r::MPFRRoundingMode) where T<:Union{Signed, Unsigned}
+function _unchecked_cast(T::Type{<:Union{Signed, Unsigned}}, x::BigFloat, r::MPFRRoundingMode)
     CT = T <: Signed ? Int64 : UInt64
     typemax(T) < typemax(CT) ? _unchecked_cast(CT, x, r) : _unchecked_cast(BigInt, x, r)
 end
 
-function round(::Type{T}, x::BigFloat, r::Union{RoundingMode, MPFRRoundingMode}) where T<:Union{Signed, Unsigned}
+function round(T::Type{<:Union{Signed, Unsigned}}, x::BigFloat, r::Union{RoundingMode, MPFRRoundingMode})
     clear_flags()
     res = _unchecked_cast(T, x, r)
     if had_range_exception() || !(typemin(T) <= res <= typemax(T))
@@ -463,16 +463,16 @@ function round(::Type{BigInt}, x::BigFloat, r::Union{RoundingMode, MPFRRoundingM
     return res
 end
 
-round(::Type{T}, x::BigFloat, r::RoundingMode) where T<:Union{Signed, Unsigned} =
+round(T::Type{<:Union{Signed, Unsigned}}, x::BigFloat, r::RoundingMode) =
     invoke(round, Tuple{Type{<:Union{Signed, Unsigned}}, BigFloat, Union{RoundingMode, MPFRRoundingMode}}, T, x, r)
 round(::Type{BigInt}, x::BigFloat, r::RoundingMode) =
     invoke(round, Tuple{Type{BigInt}, BigFloat, Union{RoundingMode, MPFRRoundingMode}}, BigInt, x, r)
 
 
-unsafe_trunc(::Type{T}, x::BigFloat) where {T<:Integer} = unsafe_trunc(T, _unchecked_cast(T, x, RoundToZero))
+unsafe_trunc(T::Type{<:Integer}, x::BigFloat) = unsafe_trunc(T, _unchecked_cast(T, x, RoundToZero))
 unsafe_trunc(::Type{BigInt}, x::BigFloat) = _unchecked_cast(BigInt, x, RoundToZero)
 
-round(::Type{T}, x::BigFloat) where T<:Integer = round(T, x, rounding_raw(BigFloat))
+round(T::Type{<:Integer}, x::BigFloat) = round(T, x, rounding_raw(BigFloat))
 # these two methods are split to increase their precedence in disambiguation:
 round(::Type{Integer}, x::BigFloat, r::RoundingMode) = round(BigInt, x, r)
 round(::Type{Integer}, x::BigFloat, r::MPFRRoundingMode) = round(BigInt, x, r)
@@ -492,7 +492,7 @@ function (::Type{T})(x::BigFloat) where T<:Integer
     trunc(T,x)
 end
 
-function to_ieee754(::Type{T}, x::BigFloat, rm) where {T<:AbstractFloat}
+function to_ieee754(T::Type{<:AbstractFloat}, x::BigFloat, rm)
     sb = signbit(x)
     is_zero = iszero(x)
     is_inf = isinf(x)
@@ -1196,7 +1196,7 @@ Note: `nextfloat()`, `prevfloat()` do not use the precision mentioned by
 !!! compat "Julia 1.8"
     The `base` keyword requires at least Julia 1.8.
 """
-function setprecision(f::Function, ::Type{T}, prec::Integer; kws...) where T
+function setprecision(f::Function, T::Type, prec::Integer; kws...)
     depwarn("""
             The fallback `setprecision(::Function, ...)` method is deprecated. Packages overloading this method should
             implement their own specialization using `ScopedValue` instead.

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -106,7 +106,7 @@ module IteratorsMD
     firstindex(index::CartesianIndex) = firstindex(index.I)
     lastindex(index::CartesianIndex) = lastindex(index.I)
     Base.get(A::AbstractArray, I::CartesianIndex, default) = get(A, I.I, default)
-    eltype(::Type{T}) where {T<:CartesianIndex} = eltype(fieldtype(T, :I))
+    eltype(T::Type{<:CartesianIndex}) = eltype(fieldtype(T, :I))
 
     # access to index tuple
     Tuple(index::CartesianIndex) = index.I
@@ -142,8 +142,8 @@ module IteratorsMD
     isless(I1::CartesianIndex{N}, I2::CartesianIndex{N}) where {N} = isless(reverse(I1.I), reverse(I2.I))
 
     # conversions
-    convert(::Type{T}, index::CartesianIndex{1}) where {T<:Number} = convert(T, index[1])
-    convert(::Type{T}, index::CartesianIndex) where {T<:Tuple} = convert(T, index.I)
+    convert(T::Type{<:Number}, index::CartesianIndex{1}) = convert(T, index[1])
+    convert(T::Type{<:Tuple}, index::CartesianIndex) = convert(T, index.I)
 
     # hashing
     const cartindexhash_seed = UInt == UInt64 ? 0xd60ca92f8284b8b0 : 0xf2ea7c2e

--- a/base/multinverses.jl
+++ b/base/multinverses.jl
@@ -12,7 +12,7 @@ unsigned(::Type{Int16}) = UInt16
 unsigned(::Type{Int32}) = UInt32
 unsigned(::Type{Int64}) = UInt64
 unsigned(::Type{Int128}) = UInt128
-unsigned(::Type{T}) where {T<:Unsigned} = T
+unsigned(T::Type{<:Unsigned}) = T
 
 abstract type  MultiplicativeInverse{T} <: Number end
 

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -177,7 +177,7 @@ nextind(@nospecialize(t::NamedTuple), i::Integer) = Int(i)+1
 
 convert(::Type{NT}, nt::NT) where {names, NT<:NamedTuple{names}} = nt
 convert(::Type{NT}, nt::NT) where {names, T<:Tuple, NT<:NamedTuple{names,T}} = nt
-convert(::Type{NT}, t::Tuple) where {NT<:NamedTuple} = (@inline NT(t))::NT
+convert(NT::Type{<:NamedTuple}, t::Tuple) = (@inline NT(t))::NT
 
 function convert(::Type{NamedTuple{names,T}}, nt::NamedTuple{names}) where {names,T<:Tuple}
     NT = NamedTuple{names,T}
@@ -228,7 +228,7 @@ function show(io::IO, t::NamedTuple)
     end
 end
 
-eltype(::Type{T}) where T<:NamedTuple = nteltype(T)
+eltype(T::Type{<:NamedTuple}) = nteltype(T)
 nteltype(::Type) = Any
 nteltype(::Type{NamedTuple{names,T}} where names) where {T} = eltype(T)
 

--- a/base/number.jl
+++ b/base/number.jl
@@ -4,7 +4,7 @@
 
 # Numbers are convertible
 convert(::Type{T}, x::T)      where {T<:Number} = x
-convert(::Type{T}, x::Number) where {T<:Number} = T(x)::T
+convert(T::Type{<:Number}, x::Number) = T(x)::T
 
 """
     isinteger(x)::Bool
@@ -87,7 +87,7 @@ size(x::Number) = ()
 size(x::Number, d::Integer) = d < 1 ? throw(BoundsError()) : 1
 axes(x::Number) = ()
 axes(x::Number, d::Integer) = d < 1 ? throw(BoundsError()) : OneTo(1)
-eltype(::Type{T}) where {T<:Number} = T
+eltype(T::Type{<:Number}) = T
 ndims(x::Number) = 0
 ndims(::Type{<:Number}) = 0
 length(x::Number) = 1
@@ -361,7 +361,7 @@ julia> zero(rand(2,2))
 ```
 """
 zero(x::Number) = oftype(x,0)
-zero(::Type{T}) where {T<:Number} = convert(T,0)
+zero(T::Type{<:Number}) = convert(T,0)
 zero(::Type{Union{}}, slurp...) = Union{}(0)
 
 """
@@ -402,7 +402,7 @@ julia> import Dates; one(Dates.Day(1))
 1
 ```
 """
-one(::Type{T}) where {T<:Number} = convert(T,1)
+one(T::Type{<:Number}) = convert(T,1)
 one(x::T) where {T<:Number} = one(T)
 one(::Type{Union{}}, slurp...) = Union{}(1)
 # note that convert(T, 1) should throw an error if T is dimensionful,
@@ -428,7 +428,7 @@ julia> import Dates; oneunit(Dates.Day)
 ```
 """
 oneunit(x::T) where {T} = T(one(x))
-oneunit(::Type{T}) where {T} = T(one(T))
+oneunit(T::Type) = T(one(T))
 oneunit(::Type{Union{}}, slurp...) = Union{}(1)
 
 """
@@ -449,5 +449,5 @@ julia> big(Complex{Int})
 Complex{BigInt}
 ```
 """
-big(::Type{T}) where {T<:Number} = typeof(big(zero(T)))
+big(T::Type{<:Number}) = typeof(big(zero(T)))
 big(::Type{Union{}}, slurp...) = Union{}(0)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -952,7 +952,7 @@ julia> widen(1.5f0)
 ```
 """
 widen(x::T) where {T} = convert(widen(T), x)
-widen(x::Type{T}) where {T} = throw(MethodError(widen, (T,)))
+widen(x::Type) = throw(MethodError(widen, (x,)))
 widen(x::Type{Union{}}, slurp...) = throw(MethodError(widen, (Union{},)))
 
 # function pipelining
@@ -980,7 +980,7 @@ julia> [0 1; 2 3] .|> (x -> x^2) |> sum
 |>(x, f) = f(x)
 
 _stable_typeof(x) = typeof(x)
-_stable_typeof(::Type{T}) where {T} = @isdefined(T) ? Type{T} : DataType
+_stable_typeof(T::Type) = Type{T}
 
 """
     f = Returns(value)
@@ -1109,7 +1109,7 @@ call_composed(fs::Tuple{Any}, x, kw) = fs[1](x...; kw...)
 
 struct Constructor{F} <: Function end
 (::Constructor{F})(args...; kw...) where {F} = (@inline; F(args...; kw...))
-maybeconstructor(::Type{F}) where {F} = Constructor{F}()
+maybeconstructor(F::Type) = Constructor{F}()
 maybeconstructor(f) = f
 
 ∘(f) = f

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -38,7 +38,7 @@ julia> parse(Complex{Float64}, "3.2e-1 + 4.5im")
 parse(T::Type, str; base = Int)
 parse(::Type{Union{}}, slurp...; kwargs...) = error("cannot parse a value as Union{}")
 
-function parse(::Type{T}, c::AbstractChar; base::Integer = 10) where T<:Integer
+function parse(T::Type{<:Integer}, c::AbstractChar; base::Integer = 10)
     a::Int = (base <= 36 ? 10 : 36)
     2 <= base <= 62 || throw(ArgumentError("invalid base: base must be 2 ≤ base ≤ 62, got $base"))
     d = '0' <= c <= '9' ? c-'0'    :
@@ -109,7 +109,7 @@ end
 end
 
 
-function tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::Int, base_::Integer, raise::Bool) where T<:Integer
+function tryparse_internal(T::Type{<:Integer}, s::AbstractString, startpos::Int, endpos::Int, base_::Integer, raise::Bool)
     sgn, base, i = parseint_preamble(T<:Signed, Int(base_), s, startpos, endpos)
     if sgn == 0 && base == 0 && i == 0
         raise && throw(ArgumentError("input string is empty or only contains whitespace"))
@@ -245,12 +245,12 @@ end
 Like [`parse`](@ref), but returns either a value of the requested type,
 or [`nothing`](@ref) if the string does not contain a valid number.
 """
-function tryparse(::Type{T}, s::AbstractString; base::Union{Nothing,Integer} = nothing) where {T<:Integer}
+function tryparse(T::Type{<:Integer}, s::AbstractString; base::Union{Nothing,Integer} = nothing)
     # Zero base means, "figure it out"
     tryparse_internal(T, s, firstindex(s), lastindex(s), base===nothing ? 0 : check_valid_base(base), false)
 end
 
-function parse(::Type{T}, s::AbstractString; base::Union{Nothing,Integer} = nothing) where {T<:Integer}
+function parse(T::Type{<:Integer}, s::AbstractString; base::Union{Nothing,Integer} = nothing)
     v = tryparse_internal(T, s, firstindex(s), lastindex(s), base===nothing ? 0 : check_valid_base(base), true)
     v === nothing && error("should not happoen")
     convert(T, v)
@@ -299,7 +299,7 @@ function tryparse_internal(::Type{Float32}, s::SubString{String}, startpos::Int,
                           (Ptr{UInt8},Csize_t,Csize_t), s.string, s.offset+startpos-1, endpos-startpos+1)
     hasvalue ? val : nothing
 end
-tryparse(::Type{T}, s::AbstractString) where {T<:Union{Float32,Float64}} = tryparse(T, String(s)::String)
+tryparse(T::Type{<:Union{Float32,Float64}}, s::AbstractString) = tryparse(T, String(s)::String)
 tryparse(::Type{Float16}, s::AbstractString) =
     convert(Union{Float16, Nothing}, tryparse(Float32, s))
 tryparse_internal(::Type{Float16}, s::AbstractString, startpos::Int, endpos::Int) =
@@ -369,16 +369,16 @@ tryparse_internal(T::Type{Complex{S}}, s::AbstractString, i::Int, e::Int, raise:
     tryparse_internal(T, String(s), i, e, raise)
 
 # fallback methods for tryparse_internal
-tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::Int) where T<:Real =
+tryparse_internal(T::Type{<:Real}, s::AbstractString, startpos::Int, endpos::Int) =
     startpos == firstindex(s) && endpos == lastindex(s) ? tryparse(T, s) : tryparse(T, SubString(s, startpos, endpos))
-function tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::Int, raise::Bool) where T<:Real
+function tryparse_internal(T::Type{<:Real}, s::AbstractString, startpos::Int, endpos::Int, raise::Bool)
     result = tryparse_internal(T, s, startpos, endpos)
     if raise && result === nothing
         _parse_failure(T, s, startpos, endpos)
     end
     return result
 end
-function tryparse_internal(::Type{T}, s::AbstractString, raise::Bool; kwargs...) where T<:Real
+function tryparse_internal(T::Type{<:Real}, s::AbstractString, raise::Bool; kwargs...)
     result = tryparse(T, s; kwargs...)
     if raise && result === nothing
         _parse_failure(T, s)
@@ -388,12 +388,12 @@ end
 @noinline _parse_failure(T, s::AbstractString, startpos = firstindex(s), endpos = lastindex(s)) =
     throw(ArgumentError(LazyString("cannot parse ", repr(s[startpos:endpos]), " as ", T)))
 
-tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::Int, raise::Bool) where T<:Integer =
+tryparse_internal(T::Type{<:Integer}, s::AbstractString, startpos::Int, endpos::Int, raise::Bool) =
     tryparse_internal(T, s, startpos, endpos, 10, raise)
 
-parse(::Type{T}, s::AbstractString; kwargs...) where T<:Real =
+parse(T::Type{<:Real}, s::AbstractString; kwargs...) =
     convert(T, tryparse_internal(T, s, true; kwargs...))
-parse(::Type{T}, s::AbstractString) where T<:Complex =
+parse(T::Type{<:Complex}, s::AbstractString) =
     convert(T, tryparse_internal(T, s, firstindex(s), lastindex(s), true))
 
 tryparse(T::Type{Complex{S}}, s::AbstractString) where S<:Real =

--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -126,7 +126,7 @@ const EXECUTE_MASK      =
 
 const UNSET = ~Csize_t(0)  # Indicates that an output vector element is unset
 
-function info(regex::Ptr{Cvoid}, what::Integer, ::Type{T}) where T
+function info(regex::Ptr{Cvoid}, what::Integer, T::Type)
     buf = RefValue{T}()
     ret = ccall((:pcre2_pattern_info_8, PCRE_LIB), Cint,
                 (Ptr{Cvoid}, UInt32, Ptr{Cvoid}),

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -20,7 +20,7 @@ const C_NULL = bitcast(Ptr{Cvoid}, 0)
 # TODO: deprecate these conversions. C doesn't even allow them.
 
 # pointer to integer
-convert(::Type{T}, x::Ptr) where {T<:Integer} = T(UInt(x))::T
+convert(T::Type{<:Integer}, x::Ptr) = T(UInt(x))::T
 
 # integer to pointer
 convert(::Type{Ptr{T}}, x::Union{Int,UInt}) where {T} = Ptr{T}(x)

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -187,7 +187,7 @@ _promote_typesubtract(@nospecialize(a)) =
     a >: Missing ? typesplit(a, Missing) :
     a
 
-function promote_typejoin_union(::Type{T}) where T
+function promote_typejoin_union(T::Type)
     if T === Union{}
         return Union{}
     elseif T isa UnionAll
@@ -309,10 +309,10 @@ promote_type(T, S, U, V...) = (@inline; afoldl(promote_type, promote_type(T, S, 
 
 promote_type(::Type{Bottom}, ::Type{Bottom}) = Bottom
 promote_type(::Type{T}, ::Type{T}) where {T} = T
-promote_type(::Type{T}, ::Type{Bottom}) where {T} = T
-promote_type(::Type{Bottom}, ::Type{T}) where {T} = T
+promote_type(T::Type, ::Type{Bottom}) = T
+promote_type(::Type{Bottom}, T::Type) = T
 
-function promote_type(::Type{T}, ::Type{S}) where {T,S}
+function promote_type(T::Type, S::Type)
     @inline
     # Try promote_rule in both orders. Typically only one is defined,
     # and there is a fallback returning Bottom below, so the common case is
@@ -336,13 +336,13 @@ promote_rule(::Type, ::Type) = Bottom
 # with Type{<:T}, and return a value in general accordance with the result given by promote_type
 promote_rule(::Type{Bottom}, slurp...) = Bottom
 promote_rule(::Type{Bottom}, ::Type{Bottom}, slurp...) = Bottom # not strictly necessary, since the next method would match unambiguously anyways
-promote_rule(::Type{Bottom}, ::Type{T}, slurp...) where {T} = T
-promote_rule(::Type{T}, ::Type{Bottom}, slurp...) where {T} = T
+promote_rule(::Type{Bottom}, T::Type, slurp...) = T
+promote_rule(T::Type, ::Type{Bottom}, slurp...) = T
 
-promote_result(::Type,::Type,::Type{T},::Type{S}) where {T,S} = (@inline; promote_type(T,S))
+promote_result(::Type,::Type,T::Type,S::Type) = (@inline; promote_type(T,S))
 # If no promote_rule is defined, both directions give Bottom. In that
 # case use typejoin on the original types instead.
-promote_result(::Type{T},::Type{S},::Type{Bottom},::Type{Bottom}) where {T,S} = (@inline; typejoin(T, S))
+promote_result(T::Type,S::Type,::Type{Bottom},::Type{Bottom}) = (@inline; typejoin(T, S))
 
 """
     promote(xs...)
@@ -381,7 +381,7 @@ end
 promote_typeof(x) = typeof(x)
 promote_typeof(x, y) = (@inline; promote_type(typeof(x), typeof(y)))
 promote_typeof(x, y, z) = (@inline; promote_type(typeof(x), typeof(y), typeof(z)))
-promote_typeof(x, y, z, a...) = (@inline; afoldl(((::Type{T}, y) where {T}) -> promote_type(T, typeof(y)), promote_typeof(x, y, z), a...))
+promote_typeof(x, y, z, a...) = (@inline; afoldl((T::Type, y) -> promote_type(T, typeof(y)), promote_typeof(x, y, z), a...))
 function _promote(x, y, z)
     @inline
     R = promote_typeof(x, y, z)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -11,7 +11,7 @@ struct Rational{T<:Integer} <: Real
     den::T
 
     # Unexported inner constructor of Rational that bypasses all checks
-    global unsafe_rational(::Type{T}, num, den) where {T} = new{T}(num, den)
+    global unsafe_rational(T::Type, num, den) = new{T}(num, den)
 end
 
 unsafe_rational(num::T, den::T) where {T<:Integer} = unsafe_rational(T, num, den)
@@ -218,9 +218,9 @@ big(q::Rational) = unsafe_rational(big(numerator(q)), big(denominator(q)))
 
 big(z::Complex{<:Rational{<:Integer}}) = Complex{Rational{BigInt}}(z)
 
-promote_rule(::Type{Rational{T}}, ::Type{S}) where {T<:Integer,S<:Integer} = Rational{promote_type(T,S)}
+promote_rule(::Type{Rational{T}}, S::Type{<:Integer}) where {T<:Integer} = Rational{promote_type(T,S)}
 promote_rule(::Type{Rational{T}}, ::Type{Rational{S}}) where {T<:Integer,S<:Integer} = Rational{promote_type(T,S)}
-promote_rule(::Type{Rational{T}}, ::Type{S}) where {T<:Integer,S<:AbstractFloat} = promote_type(T,S)
+promote_rule(::Type{Rational{T}}, S::Type{<:AbstractFloat}) where {T<:Integer} = promote_type(T,S)
 
 widen(::Type{Rational{T}}) where {T} = Rational{widen(T)}
 
@@ -244,7 +244,7 @@ julia> typeof(numerator(a))
 BigInt
 ```
 """
-function rationalize(::Type{T}, x::Union{AbstractFloat, Rational}, tol::Real) where T<:Integer
+function rationalize(T::Type{<:Integer}, x::Union{AbstractFloat, Rational}, tol::Real)
     if tol < 0
         throw(ArgumentError("negative tolerance $tol"))
     end
@@ -304,14 +304,14 @@ function rationalize(::Type{T}, x::Union{AbstractFloat, Rational}, tol::Real) wh
         return p // q
     end
 end
-rationalize(::Type{T}, x::AbstractFloat; tol::Real = eps(x)) where {T<:Integer} = rationalize(T, x, tol)
+rationalize(T::Type{<:Integer}, x::AbstractFloat; tol::Real = eps(x)) = rationalize(T, x, tol)
 rationalize(x::Real; kvs...) = rationalize(Int, x; kvs...)
-rationalize(::Type{T}, x::Complex; kvs...) where {T<:Integer} = Complex(rationalize(T, x.re; kvs...), rationalize(T, x.im; kvs...))
+rationalize(T::Type{<:Integer}, x::Complex; kvs...) = Complex(rationalize(T, x.re; kvs...), rationalize(T, x.im; kvs...))
 rationalize(x::Complex; kvs...) = Complex(rationalize(Int, x.re; kvs...), rationalize(Int, x.im; kvs...))
-rationalize(::Type{T}, x::Rational; tol::Real = 0) where {T<:Integer} = rationalize(T, x, tol)
+rationalize(T::Type{<:Integer}, x::Rational; tol::Real = 0) = rationalize(T, x, tol)
 rationalize(x::Rational; kvs...) = x
 rationalize(x::Integer; kvs...) = Rational(x)
-function rationalize(::Type{T}, x::Integer; kvs...) where {T<:Integer}
+function rationalize(T::Type{<:Integer}, x::Integer; kvs...)
     T<:Unsigned && x < 0 && __throw_negate_unsigned()
     if Base.hastypemax(T) # BigInt doesn't
         x < typemin(T) && return unsafe_rational(-one(T), zero(T))
@@ -569,14 +569,14 @@ end
 
 round(x::Rational, r::RoundingMode=RoundNearest) = round(typeof(x), x, r)
 
-function round(::Type{T}, x::Rational{Tr}, r::RoundingMode=RoundNearest) where {T,Tr}
+function round(T::Type, x::Rational{Tr}, r::RoundingMode=RoundNearest) where {Tr}
     if iszero(denominator(x)) && !(T <: Integer)
         return convert(T, copysign(unsafe_rational(one(Tr), zero(Tr)), numerator(x)))
     end
     convert(T, div(numerator(x), denominator(x), r))
 end
 
-function round(::Type{T}, x::Rational{Bool}, ::RoundingMode=RoundNearest) where T
+function round(T::Type, x::Rational{Bool}, ::RoundingMode=RoundNearest)
     if denominator(x) == false && (T <: Integer)
         throw(DivideError())
     end

--- a/base/rawbigfloats.jl
+++ b/base/rawbigfloats.jl
@@ -86,7 +86,7 @@ Return an integer of type `R`, consisting of the `len` most
 significant bits of `x`. If there are less than `len` bits in `x`,
 the least significant bits are zeroed.
 """
-function truncated(::Type{R}, x::BigFloatData, len::Int) where {R<:Integer}
+function truncated(R::Type{<:Integer}, x::BigFloatData, len::Int)
     ret = zero(R)
     if 0 < len
         word_count, bit_count_in_word = split_bit_index(x, len)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -329,7 +329,7 @@ with reduction `op` over an empty array with element type of `T`.
 This should only be defined in unambiguous cases; for example,
 
 ```julia
-Base.reduce_empty(::typeof(+), ::Type{T}) where T = zero(T)
+Base.reduce_empty(::typeof(+), T::Type) = zero(T)
 ```
 
 is justified (the sum of zero elements is zero), whereas
@@ -338,26 +338,26 @@ is generally ambiguous, and especially so when the element type is unknown).
 
 As an alternative, consider supplying an `init` value to the reducer.
 """
-reduce_empty(::typeof(+), ::Type{T}) where {T} = zero(T)
+reduce_empty(::typeof(+), T::Type) = zero(T)
 reduce_empty(::typeof(+), ::Type{Bool}) = zero(Int)
-reduce_empty(::typeof(*), ::Type{T}) where {T} = one(T)
+reduce_empty(::typeof(*), T::Type) = one(T)
 reduce_empty(::typeof(*), ::Type{<:AbstractChar}) = ""
 reduce_empty(::typeof(&), ::Type{Bool}) = true
 reduce_empty(::typeof(|), ::Type{Bool}) = false
-reduce_empty(::typeof(and_all), ::Type{T}) where {T} = true
-reduce_empty(::typeof(or_any), ::Type{T}) where {T} = false
+reduce_empty(::typeof(and_all), ::Type) = true
+reduce_empty(::typeof(or_any), ::Type) = false
 
-reduce_empty(::typeof(add_sum), ::Type{T}) where {T} = reduce_empty(+, T)
-reduce_empty(::typeof(add_sum), ::Type{T}) where {T<:BitSignedSmall}  = zero(Int)
-reduce_empty(::typeof(add_sum), ::Type{T}) where {T<:BitUnsignedSmall} = zero(UInt)
-reduce_empty(::typeof(mul_prod), ::Type{T}) where {T} = reduce_empty(*, T)
-reduce_empty(::typeof(mul_prod), ::Type{T}) where {T<:BitSignedSmall}  = one(Int)
-reduce_empty(::typeof(mul_prod), ::Type{T}) where {T<:BitUnsignedSmall} = one(UInt)
+reduce_empty(::typeof(add_sum), T::Type) = reduce_empty(+, T)
+reduce_empty(::typeof(add_sum), ::Type{<:BitSignedSmall})  = zero(Int)
+reduce_empty(::typeof(add_sum), ::Type{<:BitUnsignedSmall}) = zero(UInt)
+reduce_empty(::typeof(mul_prod), T::Type) = reduce_empty(*, T)
+reduce_empty(::typeof(mul_prod), ::Type{<:BitSignedSmall})  = one(Int)
+reduce_empty(::typeof(mul_prod), ::Type{<:BitUnsignedSmall}) = one(UInt)
 
-reduce_empty(op::BottomRF, ::Type{T}) where {T} = reduce_empty(op.rf, T)
-reduce_empty(op::MappingRF, ::Type{T}) where {T} = mapreduce_empty(op.f, op.rf, T)
-reduce_empty(op::FilteringRF, ::Type{T}) where {T} = reduce_empty(op.rf, T)
-reduce_empty(op::FlipArgs, ::Type{T}) where {T} = reduce_empty(op.f, T)
+reduce_empty(op::BottomRF, T::Type) = reduce_empty(op.rf, T)
+reduce_empty(op::MappingRF, T::Type) = mapreduce_empty(op.f, op.rf, T)
+reduce_empty(op::FilteringRF, T::Type) = reduce_empty(op.rf, T)
+reduce_empty(op::FlipArgs, T::Type) = reduce_empty(op.f, T)
 
 """
     Base.mapreduce_empty(f, op, T)
@@ -801,7 +801,7 @@ extrema(f, itr; kw...) = mapreduce(ExtremaMap(f), _extrema_rf, itr; kw...)
 struct ExtremaMap{F} <: Function
     f::F
 end
-ExtremaMap(::Type{T}) where {T} = ExtremaMap{Type{T}}(T)
+ExtremaMap(T::Type) = ExtremaMap{Type{T}}(T)
 @inline (f::ExtremaMap)(x) = (y = f.f(x); (y, y))
 
 @inline _extrema_rf((min1, max1), (min2, max2)) = (min(min1, min2), max(max1, max2))

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -50,7 +50,7 @@ for (Op, initval) in ((:(typeof(and_all)), true), (:(typeof(or_any)), false))
 end
 
 # reducedim_initarray is called by
-reducedim_initarray(A::AbstractArrayOrBroadcasted, region, init, ::Type{R}) where {R} = fill!(similar(A,R,reduced_indices(A,region)), init)
+reducedim_initarray(A::AbstractArrayOrBroadcasted, region, init, R::Type) = fill!(similar(A,R,reduced_indices(A,region)), init)
 reducedim_initarray(A::AbstractArrayOrBroadcasted, region, init::T) where {T} = reducedim_initarray(A, region, init, T)
 
 # TODO: better way to handle reducedim initialization

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -178,8 +178,8 @@ julia> reinterpret(reshape, Int, a)             # the result is a matrix
 """
 reinterpret(::typeof(reshape), T::Type, a::AbstractArray)
 
-reinterpret(::Type{T}, a::NonReshapedReinterpretArray) where {T} = reinterpret(T, a.parent)
-reinterpret(::typeof(reshape), ::Type{T}, a::ReshapedReinterpretArray) where {T} = reinterpret(reshape, T, a.parent)
+reinterpret(T::Type, a::NonReshapedReinterpretArray) = reinterpret(T, a.parent)
+reinterpret(::typeof(reshape), T::Type, a::ReshapedReinterpretArray) = reinterpret(reshape, T, a.parent)
 
 # Definition of StridedArray
 StridedFastContiguousSubArray{T,N,A<:DenseArray} = FastContiguousSubArray{T,N,A}
@@ -828,12 +828,12 @@ end
     padding(Out) == padding(In)
 end
 
-@assume_effects :foldable function packedsize(::Type{T}) where T
+@assume_effects :foldable function packedsize(T::Type)
     pads = padding(T)
     return sizeof(T) - sum((p.size for p ∈ pads), init = 0)
 end
 
-@assume_effects :foldable ispacked(::Type{T}) where T = isempty(padding(T))
+@assume_effects :foldable ispacked(T::Type) = isempty(padding(T))
 
 function _copytopacked!(ptr_out::Ptr{Out}, ptr_in::Ptr{In}) where {Out, In}
     writeoffset = 0

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -253,7 +253,7 @@ end
 size(A::ReshapedArray) = A.dims
 length(A::ReshapedArray) = length(parent(A))
 similar(A::ReshapedArray, eltype::Type, dims::Dims) = similar(parent(A), eltype, dims)
-similar(::Type{TA}, dims::Dims) where {T,N,P,TA<:ReshapedArray{T,N,P}} = similar(P, dims)
+similar(TA::Type{<:ReshapedArray{<:Any,<:Any,P}}, dims::Dims) where {P} = similar(P, dims)
 IndexStyle(::Type{<:ReshapedArrayLF}) = IndexLinear()
 parent(A::ReshapedArray) = A.parent
 parentindices(A::ReshapedArray) = map(oneto, size(parent(A)))

--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -219,7 +219,7 @@ See [`RoundingMode`](@ref) for available modes.
 setrounding_raw(::Type{<:Union{Float32,Float64}}, i::Integer) = ccall(:jl_set_fenv_rounding, Int32, (Int32,), i)
 rounding_raw(::Type{<:Union{Float32,Float64}}) = ccall(:jl_get_fenv_rounding, Int32, ())
 
-rounding(::Type{T}) where {T<:Union{Float32,Float64}} = from_fenv(rounding_raw(T))
+rounding(T::Type{<:Union{Float32,Float64}}) = from_fenv(rounding_raw(T))
 
 """
     setrounding(f::Function, T, mode)
@@ -234,7 +234,7 @@ equivalent to:
 
 See [`RoundingMode`](@ref) for available rounding modes.
 """
-function setrounding(f::Function, ::Type{T}, rounding::RoundingMode) where T
+function setrounding(f::Function, T::Type, rounding::RoundingMode)
     old_rounding_raw = rounding_raw(T)
     setrounding(T,rounding)
     try
@@ -243,7 +243,7 @@ function setrounding(f::Function, ::Type{T}, rounding::RoundingMode) where T
         setrounding_raw(T,old_rounding_raw)
     end
 end
-function setrounding_raw(f::Function, ::Type{T}, rounding) where T
+function setrounding_raw(f::Function, T::Type, rounding)
     old_rounding_raw = rounding_raw(T)
     setrounding_raw(T,rounding)
     try
@@ -264,16 +264,16 @@ end
 # To avoid ambiguous dispatch with methods in mpfr.jl:
 (::Type{T})(x::Real, r::RoundingMode) where {T<:AbstractFloat} = _convert_rounding(T,x,r)::T
 
-_convert_rounding(::Type{T}, x::Real, r::RoundingMode{:Nearest}) where {T<:AbstractFloat} = convert(T,x)::T
-function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:Down}) where T<:AbstractFloat
+_convert_rounding(T::Type{<:AbstractFloat}, x::Real, r::RoundingMode{:Nearest}) = convert(T,x)::T
+function _convert_rounding(T::Type{<:AbstractFloat}, x::Real, r::RoundingMode{:Down})
     y = convert(T,x)::T
     y > x ? prevfloat(y) : y
 end
-function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:Up}) where T<:AbstractFloat
+function _convert_rounding(T::Type{<:AbstractFloat}, x::Real, r::RoundingMode{:Up})
     y = convert(T,x)::T
     y < x ? nextfloat(y) : y
 end
-function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:ToZero}) where T<:AbstractFloat
+function _convert_rounding(T::Type{<:AbstractFloat}, x::Real, r::RoundingMode{:ToZero})
     y = convert(T,x)::T
     if x > 0.0
         y > x ? prevfloat(y) : y
@@ -281,7 +281,7 @@ function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:ToZero}) where T
         y < x ? nextfloat(y) : y
     end
 end
-function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:FromZero}) where T<:AbstractFloat
+function _convert_rounding(T::Type{<:AbstractFloat}, x::Real, r::RoundingMode{:FromZero})
     y = convert(T,x)::T
     if x < 0.0
         y > x ? prevfloat(y) : y
@@ -480,12 +480,12 @@ floor(x; kws...) = round(x, RoundDown; kws...)
  ceil(x; kws...) = round(x, RoundUp; kws...)
 round(x; kws...) = round(x, RoundNearest; kws...)
 
-trunc(::Type{T}, x) where T = round(T, x, RoundToZero)
-floor(::Type{T}, x) where T = round(T, x, RoundDown)
- ceil(::Type{T}, x) where T = round(T, x, RoundUp)
-round(::Type{T}, x) where T = round(T, x, RoundNearest)
+trunc(T::Type, x) = round(T, x, RoundToZero)
+floor(T::Type, x) = round(T, x, RoundDown)
+ ceil(T::Type, x) = round(T, x, RoundUp)
+round(T::Type, x) = round(T, x, RoundNearest)
 
-round(::Type{T}, x, r::RoundingMode) where T = _round_convert(T, round(x, r), x, r)
-_round_convert(::Type{T}, x_integer, x, r) where T = convert(T, x_integer)
+round(T::Type, x, r::RoundingMode) = _round_convert(T, round(x, r), x, r)
+_round_convert(T::Type, x_integer, x, r) = convert(T, x_integer)
 
 round(x::Integer, r::RoundingMode) = x

--- a/base/ryu/utils.jl
+++ b/base/ryu/utils.jl
@@ -113,7 +113,7 @@ function decimallength(v::UInt16)
     return 1
 end
 
-function mulshiftinvsplit(::Type{T}, mv, mp, mm, i, j) where {T}
+function mulshiftinvsplit(T::Type, mv, mp, mm, i, j)
     mul = pow5invsplit_lookup(T, i)
     vr = mulshift(mv, mul, j)
     vp = mulshift(mp, mul, j)
@@ -121,7 +121,7 @@ function mulshiftinvsplit(::Type{T}, mv, mp, mm, i, j) where {T}
     return vr, vp, vm
 end
 
-function mulshiftsplit(::Type{T}, mv, mp, mm, i, j) where {T}
+function mulshiftsplit(T::Type, mv, mp, mm, i, j)
     mul = pow5split_lookup(T, i)
     vr = mulshift(mv, mul, j)
     vp = mulshift(mp, mul, j)
@@ -254,7 +254,7 @@ Compute `floor(2^k/5^i)+1`, where `k = pow5bits(i) - 1 + pow5_inv_bitcount(T)`. 
 is an unsigned integer twice as wide as `T` (i.e. a `UInt128` if `T == Float64`), with
 `pow5_inv_bitcount(T)` significant bits.
 """
-function pow5invsplit(::Type{T}, i) where {T<:AbstractFloat}
+function pow5invsplit(T::Type{<:AbstractFloat}, i)
     W = widen(uinttype(T))
     pow = big(5)^i
     inv = div(big(1) << (ndigits(pow, base=2) - 1 + pow5_inv_bitcount(T)), pow) + 1
@@ -283,7 +283,7 @@ Compute `floor(5^i/2^k)`, where `k = pow5bits(i) - pow5_bitcount(T)`. The result
 unsigned integer twice as wide as `T` (i.e. a `UInt128` if `T == Float64`), with
 `pow5_bitcount(T)` significant bits.
 """
-function pow5split(::Type{T}, i) where {T<:AbstractFloat}
+function pow5split(T::Type{<:AbstractFloat}, i)
     W = widen(uinttype(T))
     pow = big(5)^i
     return W(pow >> (ndigits(pow, base=2) - pow5_bitcount(T)))

--- a/base/set.jl
+++ b/base/set.jl
@@ -70,7 +70,7 @@ empty(s::AbstractSet{T}, ::Type{U}=T) where {T,U} = Set{U}()
 # by default, a Set is returned
 emptymutable(s::AbstractSet{T}, ::Type{U}=T) where {T,U} = Set{U}()
 
-_similar_for(c::AbstractSet, ::Type{T}, itr, isz, len) where {T} = empty(c, T)
+_similar_for(c::AbstractSet, T::Type, itr, isz, len) = empty(c, T)
 
 function show(io::IO, s::Set)
     if isempty(s)
@@ -677,7 +677,7 @@ function hash(s::AbstractSet, h::UInt)
 end
 
 convert(::Type{T}, s::T) where {T<:AbstractSet} = s
-convert(::Type{T}, s::AbstractSet) where {T<:AbstractSet} = T(s)::T
+convert(T::Type{<:AbstractSet}, s::AbstractSet) = T(s)::T
 
 
 ## replace/replace! ##
@@ -688,20 +688,20 @@ function check_count(count::Integer)
 end
 
 # TODO: use copy!, which is currently unavailable from here since it is defined in Future
-_copy_oftype(x, ::Type{T}) where {T} = copyto!(similar(x, T), x)
+_copy_oftype(x, T::Type) = copyto!(similar(x, T), x)
 # TODO: use similar() once deprecation is removed and it preserves keys
 _copy_oftype(x::AbstractDict, ::Type{Pair{K,V}}) where {K,V} = merge!(empty(x, K, V), x)
-_copy_oftype(x::AbstractSet, ::Type{T}) where {T} = union!(empty(x, T), x)
+_copy_oftype(x::AbstractSet, T::Type) = union!(empty(x, T), x)
 
 _copy_oftype(x::AbstractArray{T}, ::Type{T}) where {T} = copy(x)
 _copy_oftype(x::AbstractDict{K,V}, ::Type{Pair{K,V}}) where {K,V} = copy(x)
 _copy_oftype(x::AbstractSet{T}, ::Type{T}) where {T} = copy(x)
 
 _similar_or_copy(x::Any) = similar(x)
-_similar_or_copy(x::Any, ::Type{T}) where {T} = similar(x, T)
+_similar_or_copy(x::Any, T::Type) = similar(x, T)
 # Make a copy on construction since it is faster than inserting elements separately
 _similar_or_copy(x::Union{AbstractDict,AbstractSet}) = copy(x)
-_similar_or_copy(x::Union{AbstractDict,AbstractSet}, ::Type{T}) where {T} = _copy_oftype(x, T)
+_similar_or_copy(x::Union{AbstractDict,AbstractSet}, T::Type) = _copy_oftype(x, T)
 
 # to make replace/replace! work for a new container type Cont, only
 # _replace!(new::Callable, res::Cont, A::Cont, count::Int)
@@ -828,14 +828,14 @@ promote_valuetype(x::Pair{K, V}, y::Pair...) where {K, V} =
     promote_type(V, promote_valuetype(y...))
 
 # Subtract singleton types which are going to be replaced
-function subtract_singletontype(::Type{T}, x::Pair{K}) where {T, K}
+function subtract_singletontype(T::Type, x::Pair{K}) where {K}
     if issingletontype(K)
         typesplit(T, K)
     else
         T
     end
 end
-subtract_singletontype(::Type{T}, x::Pair{K}, y::Pair...) where {T, K} =
+subtract_singletontype(T::Type, x::Pair{K}, y::Pair...) where {K} =
     subtract_singletontype(subtract_singletontype(T, y...), x)
 
 """

--- a/base/some.jl
+++ b/base/some.jl
@@ -12,7 +12,7 @@ struct Some{T}
     value::T
 end
 
-Some(::Type{T}) where {T} = Some{Type{T}}(T)
+Some(T::Type) = Some{Type{T}}(T)
 
 nonnothingtype(@nospecialize(T::Type)) = typesplit(T, Nothing)
 promote_rule(T::Type{Nothing}, S::Type) = Union{S, Nothing}
@@ -32,7 +32,7 @@ function nonnothingtype_checked(T::Type)
 end
 
 convert(::Type{T}, x::T) where {T>:Nothing} = x
-convert(::Type{T}, x) where {T>:Nothing} = convert(nonnothingtype_checked(T), x)
+convert(T::Type{>:Nothing}, x) = convert(nonnothingtype_checked(T), x)
 convert(::Type{Some{T}}, x::Some{T}) where {T} = x
 convert(::Type{Some{T}}, x::Some) where {T} = Some{T}(convert(T, x.value))::Some{T}
 

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -2271,7 +2271,7 @@ uint_unmap(::Type{T}, u::T, ::ForwardOrdering) where T <: Unsigned = u
 
 uint_map(x::Signed, ::ForwardOrdering) =
     unsigned(xor(x, typemin(x)))
-uint_unmap(::Type{T}, u::Unsigned, ::ForwardOrdering) where T <: Signed =
+uint_unmap(T::Type{<:Signed}, u::Unsigned, ::ForwardOrdering) =
     xor(signed(u), typemin(T))
 
 UIntMappable(T::BitIntegerType, ::ForwardOrdering) = unsigned(T)

--- a/base/special/hyperbolic.jl
+++ b/base/special/hyperbolic.jl
@@ -87,7 +87,7 @@ function Base.sinh(a::Float16)
     return Float16(copysign(.5f0*(E - 1/E),x))
 end
 
-COSH_SMALL_X(::Type{T}) where T= one(T)
+COSH_SMALL_X(T::Type) = one(T)
 
 function cosh_kernel(x2::Float32)
     return evalpoly(x2, (1.0f0, 0.49999997f0, 0.041666888f0, 0.0013882756f0, 2.549933f-5))

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1498,7 +1498,7 @@ unmark(x::LibuvStream)   = unmark(x.buffer)
 reset(x::LibuvStream)    = reset(x.buffer)
 ismarked(x::LibuvStream) = ismarked(x.buffer)
 
-function peek(s::LibuvStream, ::Type{T}) where T
+function peek(s::LibuvStream, T::Type)
     mark(s)
     try read(s, T)
     finally

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -225,7 +225,7 @@ Symbol(s::AbstractString) = Symbol(String(s)::String)
 Symbol(x...) = Symbol(string(x...))
 
 convert(::Type{T}, s::T) where {T<:AbstractString} = s
-convert(::Type{T}, s::AbstractString) where {T<:AbstractString} = T(s)::T
+convert(T::Type{<:AbstractString}, s::AbstractString) = T(s)::T
 
 ## summary ##
 

--- a/base/strings/cstring.jl
+++ b/base/strings/cstring.jl
@@ -161,10 +161,10 @@ julia> transcode(String, transcode(UInt16, str))
 function transcode end
 
 transcode(::Type{T}, src::AbstractVector{T}) where {T<:Union{UInt8,UInt16,UInt32,Int32}} = src
-transcode(::Type{T}, src::String) where {T<:Union{Int32,UInt32}} = T[T(c) for c in src]
-transcode(::Type{T}, src::AbstractVector{UInt8}) where {T<:Union{Int32,UInt32}} =
+transcode(T::Type{<:Union{Int32,UInt32}}, src::String) = T[T(c) for c in src]
+transcode(T::Type{<:Union{Int32,UInt32}}, src::AbstractVector{UInt8}) =
     transcode(T, String(Vector(src)))
-transcode(::Type{T}, src::CodeUnits{UInt8,String}) where {T<:Union{Int32,UInt32}} =
+transcode(T::Type{<:Union{Int32,UInt32}}, src::CodeUnits{UInt8,String}) =
     transcode(T, String(src))
 
 function transcode(::Type{UInt8}, src::Vector{<:Union{Int32,UInt32}})

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -57,7 +57,7 @@ isvalid(T,value)
 
 isvalid(c::AbstractChar) = !ismalformed(c) & !isoverlong(c) & ((c ≤ '\ud7ff') | ('\ue000' ≤ c) & (c ≤ '\U10ffff'))
 isvalid(::Type{<:AbstractChar}, c::Unsigned) = ((c ≤  0xd7ff ) | ( 0xe000  ≤ c) & (c ≤  0x10ffff ))
-isvalid(::Type{T}, c::Integer) where {T<:AbstractChar}  = isvalid(T, Unsigned(c))
+isvalid(T::Type{<:AbstractChar}, c::Integer)  = isvalid(T, Unsigned(c))
 isvalid(::Type{<:AbstractChar}, c::AbstractChar)     = isvalid(c)
 
 # utf8 category constants

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -65,7 +65,7 @@ viewindexing(I::Tuple{AbstractArray, Vararg{Any}}) = IndexCartesian()
 size(V::SubArray) = (@inline; map(length, axes(V)))
 
 similar(V::SubArray, T::Type, dims::Dims) = similar(V.parent, T, dims)
-similar(::Type{TA}, dims::Dims) where {T,N,P,TA<:SubArray{T,N,P}} = similar(P, dims)
+similar(TA::Type{<:SubArray{<:Any,<:Any,P}}, dims::Dims) where {P} = similar(P, dims)
 
 sizeof(V::SubArray) = length(V) * sizeof(eltype(V))
 sizeof(V::SubArray{<:Any,<:Any,<:Array}) = length(V) * elsize(V.parent)

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -772,7 +772,7 @@ end
 # This version of lcm does not check for overflows
 lcm_unchecked(a::T, b::T) where T<:Integer = a * div(b, gcd(a, b))
 
-narrow(::Type{T}) where {T<:AbstractFloat} = Float64
+narrow(::Type{<:AbstractFloat}) = Float64
 narrow(::Type{Float64}) = Float32
 narrow(::Type{Float32}) = Float16
 narrow(::Type{Float16}) = Float16

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -77,7 +77,7 @@ function _cleanup_locked(h::WeakKeyDict)
 end
 
 sizehint!(d::WeakKeyDict, newsz::Integer; shrink::Bool = true) = @lock d sizehint!(d.ht, newsz; shrink = shrink)
-empty(d::WeakKeyDict, ::Type{K}, ::Type{V}) where {K, V} = WeakKeyDict{K, V}()
+empty(d::WeakKeyDict, K::Type, V::Type) = WeakKeyDict{K, V}()
 
 IteratorSize(::Type{<:WeakKeyDict}) = SizeUnknown()
 

--- a/stdlib/Dates/src/parse.jl
+++ b/stdlib/Dates/src/parse.jl
@@ -298,7 +298,7 @@ function Base.parse(::Type{DateTime}, s::AbstractString, df::typeof(ISODateTimeF
     throw(ArgumentError("Invalid DateTime string"))
 end
 
-function Base.parse(::Type{T}, str::AbstractString, df::DateFormat=default_format(T)) where T<:TimeType
+function Base.parse(T::Type{<:TimeType}, str::AbstractString, df::DateFormat=default_format(T))
     pos, len = firstindex(str), lastindex(str)
     pos > len && throw(ArgumentError("Cannot parse an empty string as a Date or Time"))
     val = tryparsenext_internal(T, str, pos, len, df, true)
@@ -307,7 +307,7 @@ function Base.parse(::Type{T}, str::AbstractString, df::DateFormat=default_forma
     return T(values...)::T
 end
 
-function Base.tryparse(::Type{T}, str::AbstractString, df::DateFormat=default_format(T)) where T<:TimeType
+function Base.tryparse(T::Type{<:TimeType}, str::AbstractString, df::DateFormat=default_format(T))
     pos, len = firstindex(str), lastindex(str)
     pos > len && return nothing
     res = tryparsenext_internal(T, str, pos, len, df, false)

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -50,8 +50,8 @@ Base.show(io::IO, ::MIME"text/plain", x::Period) = print(io, x)
 Base.show(io::IO, p::P) where {P<:Period} = print(io, P, '(', value(p), ')')
 Base.zero(::Union{Type{P},P}) where {P<:Period} = P(0)
 Base.one(::Union{Type{P},P}) where {P<:Period} = 1  # see #16116
-Base.typemin(::Type{P}) where {P<:Period} = P(typemin(Int64))
-Base.typemax(::Type{P}) where {P<:Period} = P(typemax(Int64))
+Base.typemin(P::Type{<:Period}) = P(typemin(Int64))
+Base.typemax(P::Type{<:Period}) = P(typemax(Int64))
 Base.isfinite(::Union{Type{P}, P}) where {P<:Period} = true
 
 # Default values (as used by TimeTypes)
@@ -105,7 +105,7 @@ Base.sign(x::Period) = sign(value(x))
 Base.signbit(x::Period) = signbit(value(x))
 
 # return (next coarser period, conversion factor):
-coarserperiod(::Type{P}) where {P<:Period} = (P, 1)
+coarserperiod(P::Type{<:Period}) = (P, 1)
 coarserperiod(::Type{Nanosecond})  = (Microsecond, 1000)
 coarserperiod(::Type{Microsecond}) = (Millisecond, 1000)
 coarserperiod(::Type{Millisecond}) = (Second, 1000)
@@ -325,7 +325,7 @@ function Base.string(x::CompoundPeriod)
 end
 Base.show(io::IO,x::CompoundPeriod) = print(io, string(x))
 
-Base.convert(::Type{T}, x::CompoundPeriod) where T<:Period =
+Base.convert(T::Type{<:Period}, x::CompoundPeriod) =
     isconcretetype(T) ? sum(T, x.periods; init = zero(T)) : throw(MethodError(convert,(T,x)))
 
 # E.g. Year(1) + Day(1)

--- a/stdlib/Dates/src/rounding.jl
+++ b/stdlib/Dates/src/rounding.jl
@@ -288,15 +288,15 @@ Base.round(::TimeTypeOrPeriod, p::Period, ::RoundingMode) = throw(DomainError(p)
 Base.round(x::TimeTypeOrPeriod, p::Period) = Base.round(x, p, RoundNearestTiesUp)
 
 # Make rounding functions callable using Period types in addition to values.
-Base.floor(x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.floor(x, oneunit(P))
-Base.ceil(x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.ceil(x, oneunit(P))
-Base.floor(::Type{Date}, x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.floor(Date(x), oneunit(P))
-Base.ceil(::Type{Date}, x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.ceil(Date(x), oneunit(P))
+Base.floor(x::TimeTypeOrPeriod, P::Type{<:Period}) = Base.floor(x, oneunit(P))
+Base.ceil(x::TimeTypeOrPeriod, P::Type{<:Period}) = Base.ceil(x, oneunit(P))
+Base.floor(::Type{Date}, x::TimeTypeOrPeriod, P::Type{<:Period}) = Base.floor(Date(x), oneunit(P))
+Base.ceil(::Type{Date}, x::TimeTypeOrPeriod, P::Type{<:Period}) = Base.ceil(Date(x), oneunit(P))
 
-function Base.round(x::TimeTypeOrPeriod, ::Type{P}, r::RoundingMode=RoundNearestTiesUp) where P <: Period
+function Base.round(x::TimeTypeOrPeriod, P::Type{<:Period}, r::RoundingMode=RoundNearestTiesUp)
     return Base.round(x, oneunit(P), r)
 end
 
-function Base.round(::Type{Date}, x::TimeTypeOrPeriod, ::Type{P}, r::RoundingMode=RoundNearestTiesUp) where P <: Period
+function Base.round(::Type{Date}, x::TimeTypeOrPeriod, P::Type{<:Period}, r::RoundingMode=RoundNearestTiesUp)
     return Base.round(Date(x), oneunit(P), r)
 end

--- a/stdlib/LibGit2/src/reference.jl
+++ b/stdlib/LibGit2/src/reference.jl
@@ -196,7 +196,7 @@ then `ref` will be peeled until an object other than a [`GitTag`](@ref) is obtai
     Only annotated tags can be peeled to `GitTag` objects. Lightweight tags (the default)
     are references under `refs/tags/` which point directly to `GitCommit` objects.
 """
-function peel(::Type{T}, ref::GitReference) where T<:GitObject
+function peel(T::Type{<:GitObject}, ref::GitReference)
     ensure_initialized()
     obj_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_reference_peel, libgit2), Cint,

--- a/stdlib/LibGit2/src/repository.jl
+++ b/stdlib/LibGit2/src/repository.jl
@@ -283,7 +283,7 @@ then `obj` will be peeled until the type changes.
 - A `GitTag` will be peeled to the object it references.
 - A `GitCommit` will be peeled to a `GitTree`.
 """
-function peel(::Type{T}, obj::GitObject) where T<:GitObject
+function peel(T::Type{<:GitObject}, obj::GitObject)
     ensure_initialized()
     new_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
 

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -1233,10 +1233,10 @@ function with(f::Function, obj)
     end
 end
 
-with(f::Function, ::Type{T}, args...) where {T} = with(f, T(args...))
+with(f::Function, T::Type, args...) = with(f, T(args...))
 
 """
-    with_warn(f::Function, ::Type{T}, args...)
+    with_warn(f::Function, T::Type, args...)
 
 Resource management helper function. Apply `f` to `args`, first constructing
 an instance of type `T` from `args`. Makes sure to call `close` on the resulting
@@ -1244,7 +1244,7 @@ object after `f` successfully returns or throws an error. Ensures that
 allocated git resources are finalized as soon as they are no longer needed. If an
 error is thrown by `f`, a warning is shown containing the error.
 """
-function with_warn(f::Function, ::Type{T}, args...) where T
+function with_warn(f::Function, T::Type, args...)
     obj = T(args...)
     try
         with(f, obj)
@@ -1254,7 +1254,7 @@ function with_warn(f::Function, ::Type{T}, args...) where T
 end
 
 """
-    LibGit2.Consts.OBJECT(::Type{T}) where T<:GitObject
+    LibGit2.Consts.OBJECT(T::Type{<:GitObject})
 
 The `OBJECT` enum value corresponding to type `T`.
 """

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -271,14 +271,14 @@ mmap(file::AbstractString,
     open(io->mmap(io, T, dims, offset; grow=grow, shared=shared), file, isfile(file) ? "r" : "w+")::Array{eltype(T),N}
 
 # using a length argument instead of dims
-mmap(io::IO, ::Type{T}, len::Integer, offset::Integer=position(io); grow::Bool=true, shared::Bool=true) where {T<:Array} =
+mmap(io::IO, T::Type{<:Array}, len::Integer, offset::Integer=position(io); grow::Bool=true, shared::Bool=true) =
     mmap(io, T, (len,), offset; grow=grow, shared=shared)
-mmap(file::AbstractString, ::Type{T}, len::Integer, offset::Integer=Int64(0); grow::Bool=true, shared::Bool=true) where {T<:Array} =
+mmap(file::AbstractString, T::Type{<:Array}, len::Integer, offset::Integer=Int64(0); grow::Bool=true, shared::Bool=true) =
     open(io->mmap(io, T, (len,), offset; grow=grow, shared=shared), file, isfile(file) ? "r" : "w+")::Vector{eltype(T)}
 
 # constructors for non-file-backed (anonymous) mmaps
-mmap(::Type{T}, dims::NTuple{N,Integer}; shared::Bool=true) where {T<:Array,N} = mmap(Anonymous(), T, dims, Int64(0); shared=shared)
-mmap(::Type{T}, i::Integer...; shared::Bool=true) where {T<:Array} = mmap(Anonymous(), T, convert(Tuple{Vararg{Int}},i), Int64(0); shared=shared)
+mmap(T::Type{<:Array}, dims::NTuple{N,Integer}; shared::Bool=true) where {N} = mmap(Anonymous(), T, dims, Int64(0); shared=shared)
+mmap(T::Type{<:Array}, i::Integer...; shared::Bool=true) = mmap(Anonymous(), T, convert(Tuple{Vararg{Int}},i), Int64(0); shared=shared)
 
 """
     mmap(io, BitArray, [dims, offset])
@@ -338,18 +338,18 @@ function mmap(io::IOStream, ::Type{<:BitArray}, dims::NTuple{N,Integer},
     return B
 end
 
-mmap(file::AbstractString, ::Type{T}, dims::NTuple{N,Integer}, offset::Integer=Int64(0);grow::Bool=true, shared::Bool=true) where {T<:BitArray,N} =
+mmap(file::AbstractString, T::Type{<:BitArray}, dims::NTuple{N,Integer}, offset::Integer=Int64(0);grow::Bool=true, shared::Bool=true) where {N} =
     open(io->mmap(io, T, dims, offset; grow=grow, shared=shared), file, isfile(file) ? "r" : "w+")::BitArray{N}
 
 # using a length argument instead of dims
-mmap(io::IO, ::Type{T}, len::Integer, offset::Integer=position(io); grow::Bool=true, shared::Bool=true) where {T<:BitArray} =
+mmap(io::IO, T::Type{<:BitArray}, len::Integer, offset::Integer=position(io); grow::Bool=true, shared::Bool=true) =
     mmap(io, T, (len,), offset; grow=grow, shared=shared)
-mmap(file::AbstractString, ::Type{T}, len::Integer, offset::Integer=Int64(0); grow::Bool=true, shared::Bool=true) where {T<:BitArray} =
+mmap(file::AbstractString, T::Type{<:BitArray}, len::Integer, offset::Integer=Int64(0); grow::Bool=true, shared::Bool=true) =
     open(io->mmap(io, T, (len,), offset; grow=grow, shared=shared), file, isfile(file) ? "r" : "w+")::BitVector
 
 # constructors for non-file-backed (anonymous) mmaps
-mmap(::Type{T}, dims::NTuple{N,Integer}; shared::Bool=true) where {T<:BitArray,N} = mmap(Anonymous(), T, dims, Int64(0); shared=shared)
-mmap(::Type{T}, i::Integer...; shared::Bool=true) where {T<:BitArray} = mmap(Anonymous(), T, convert(Tuple{Vararg{Int}},i), Int64(0); shared=shared)
+mmap(T::Type{<:BitArray}, dims::NTuple{N,Integer}; shared::Bool=true) where {N} = mmap(Anonymous(), T, dims, Int64(0); shared=shared)
+mmap(T::Type{<:BitArray}, i::Integer...; shared::Bool=true) = mmap(Anonymous(), T, convert(Tuple{Vararg{Int}},i), Int64(0); shared=shared)
 
 # msync flags for unix
 const MS_ASYNC = 1

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -283,7 +283,7 @@ function Profile.print(io::IO, data::AllocResults, fmt::ProfileFormat, format::S
 end
 
 
-function parse_flat(::Type{T}, data::Vector{Alloc}, C::Bool) where T
+function parse_flat(T::Type, data::Vector{Alloc}, C::Bool)
     lilist = StackFrame[]
     n = Int[]
     m = Int[]

--- a/stdlib/Random/src/MersenneTwister.jl
+++ b/stdlib/Random/src/MersenneTwister.jl
@@ -158,7 +158,7 @@ idxmask(::Type{<:Union{Int64,UInt64}}) = 1
 idxmask(::Type{<:Union{Int128,UInt128}}) = 0
 
 
-mt_avail(r::MersenneTwister, ::Type{T}) where {T<:BitInteger} =
+mt_avail(r::MersenneTwister, T::Type{<:BitInteger}) =
     r.idxI >> logsizeof(T)
 
 function mt_setfull!(r::MersenneTwister, ::Type{<:BitInteger})
@@ -195,12 +195,12 @@ end
 
 mt_setempty!(r::MersenneTwister, ::Type{<:BitInteger}) = r.idxI = 0
 
-function reserve1(r::MersenneTwister, ::Type{T}) where T<:BitInteger
+function reserve1(r::MersenneTwister, T::Type{<:BitInteger})
     r.idxI < sizeof(T) && mt_setfull!(r, T)
     nothing
 end
 
-function mt_pop!(r::MersenneTwister, ::Type{T}) where T<:BitInteger
+function mt_pop!(r::MersenneTwister, T::Type{<:BitInteger})
     reserve1(r, T)
     r.idxI -= sizeof(T)
     i = r.idxI
@@ -209,7 +209,7 @@ function mt_pop!(r::MersenneTwister, ::Type{T}) where T<:BitInteger
     (x128 >> (i128 * (sizeof(T) << 3))) % T
 end
 
-function mt_pop!(r::MersenneTwister, ::Type{T}) where {T<:Union{Int128,UInt128}}
+function mt_pop!(r::MersenneTwister, T::Type{<:Union{Int128,UInt128}})
     reserve1(r, T)
     idx = r.idxI >> 4
     r.idxI = idx << 4 - 16

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -44,7 +44,7 @@ abstract type AbstractRNG end
 
 Base.broadcastable(x::AbstractRNG) = Ref(x)
 
-gentype(::Type{X}) where {X} = eltype(X)
+gentype(X::Type) = eltype(X)
 gentype(x) = gentype(typeof(x))
 
 
@@ -79,7 +79,7 @@ uint_sup(::Type{<:Union{UInt2x52,UInt2x52Raw}}) = UInt128
 for UI = (:UInt10, :UInt10Raw, :UInt23, :UInt23Raw, :UInt52, :UInt52Raw,
           :UInt104, :UInt104Raw, :UInt2x52, :UInt2x52Raw)
     @eval begin
-        $UI(::Type{T}=uint_sup($UI)) where {T} = $UI{T}()
+        $UI(T::Type=uint_sup($UI)) = $UI{T}()
         # useful for defining rand generically:
         uint_default(::$UI) = $UI{uint_sup($UI)}()
     end
@@ -98,8 +98,8 @@ const FloatInterval_64 = FloatInterval{Float64}
 const CloseOpen01_64   = CloseOpen01{Float64}
 const CloseOpen12_64   = CloseOpen12{Float64}
 
-CloseOpen01(::Type{T}=Float64) where {T<:AbstractFloat} = CloseOpen01{T}()
-CloseOpen12(::Type{T}=Float64) where {T<:AbstractFloat} = CloseOpen12{T}()
+CloseOpen01(T::Type{<:AbstractFloat}=Float64) = CloseOpen01{T}()
+CloseOpen12(T::Type{<:AbstractFloat}=Float64) = CloseOpen12{T}()
 
 gentype(::Type{<:FloatInterval{T}}) where {T<:AbstractFloat} = T
 
@@ -141,7 +141,7 @@ the amount of precomputation, if applicable.
 pre-computed values without defining extra types for only this purpose.
 """
 Sampler(rng::AbstractRNG, x, r::Repetition=Val(Inf)) = Sampler(typeof(rng), x, r)
-Sampler(rng::AbstractRNG, ::Type{X}, r::Repetition=Val(Inf)) where {X} =
+Sampler(rng::AbstractRNG, X::Type, r::Repetition=Val(Inf)) =
     Sampler(typeof(rng), X, r)
 
 # this method is necessary to prevent rand(rng::AbstractRNG, X) from
@@ -150,8 +150,8 @@ Sampler(T::Type{<:AbstractRNG}, sp::Sampler, r::Repetition) =
     throw(MethodError(Sampler, (T, sp, r)))
 
 # default shortcut for the general case
-Sampler(::Type{RNG}, X) where {RNG<:AbstractRNG} = Sampler(RNG, X, Val(Inf))
-Sampler(::Type{RNG}, ::Type{X}) where {RNG<:AbstractRNG,X} = Sampler(RNG, X, Val(Inf))
+Sampler(RNG::Type{<:AbstractRNG}, X) = Sampler(RNG, X, Val(Inf))
+Sampler(RNG::Type{<:AbstractRNG}, X::Type) = Sampler(RNG, X, Val(Inf))
 
 #### pre-defined useful Sampler types
 
@@ -163,7 +163,7 @@ when called with types.
 """
 struct SamplerType{T} <: Sampler{T} end
 
-Sampler(::Type{<:AbstractRNG}, ::Type{T}, ::Repetition) where {T} = SamplerType{T}()
+Sampler(::Type{<:AbstractRNG}, T::Type, ::Repetition) = SamplerType{T}()
 
 Base.getindex(::SamplerType{T}) where {T} = T
 
@@ -246,7 +246,7 @@ rand(rng::AbstractRNG, sp::Masked) = rand(rng, sp.s) & sp.mask
 
 struct UniformT{T} <: Sampler{T} end
 
-uniform(::Type{T}) where {T} = UniformT{T}()
+uniform(T::Type) = UniformT{T}()
 
 rand(rng::AbstractRNG, ::UniformT{T}) where {T} = rand(rng, T)
 
@@ -262,18 +262,18 @@ rand(rng::AbstractRNG, ::UniformT{T}) where {T} = rand(rng, T)
 rand(rng::AbstractRNG, X)                                           = rand(rng, Sampler(rng, X, Val(1)))
 # this is needed to disambiguate
 rand(rng::AbstractRNG, X::Dims)                                     = rand(rng, Sampler(rng, X, Val(1)))
-rand(rng::AbstractRNG=default_rng(), ::Type{X}=Float64) where {X}   = rand(rng, Sampler(rng, X, Val(1)))::X
+rand(rng::AbstractRNG=default_rng(), X::Type=Float64)               = rand(rng, Sampler(rng, X, Val(1)))::X
 
 rand(X)                   = rand(default_rng(), X)
-rand(::Type{X}) where {X} = rand(default_rng(), X)
+rand(X::Type) = rand(default_rng(), X)
 
 #### arrays
 
 rand!(A::AbstractArray{T}, X) where {T}             = rand!(default_rng(), A, X)
-rand!(A::AbstractArray{T}, ::Type{X}=T) where {T,X} = rand!(default_rng(), A, X)
+rand!(A::AbstractArray{T}, X::Type=T) where {T} = rand!(default_rng(), A, X)
 
 rand!(rng::AbstractRNG, A::AbstractArray{T}, X) where {T}             = rand!(rng, A, Sampler(rng, X))
-rand!(rng::AbstractRNG, A::AbstractArray{T}, ::Type{X}=T) where {T,X} = rand!(rng, A, Sampler(rng, X))
+rand!(rng::AbstractRNG, A::AbstractArray{T}, X::Type=T) where {T} = rand!(rng, A, Sampler(rng, X))
 
 function rand!(rng::AbstractRNG, A::AbstractArray{T}, sp::Sampler) where T
     for i in eachindex(A)
@@ -294,11 +294,11 @@ rand(                X, d::Integer, dims::Integer...) = rand(X, Dims((d, dims...
 # rand(r, ()) would match both this method and rand(r, dims::Dims)
 # moreover, a call like rand(r, NotImplementedType()) would be an infinite loop
 
-rand(r::AbstractRNG, ::Type{X}, dims::Dims) where {X} = rand!(r, Array{X}(undef, dims), X)
-rand(                ::Type{X}, dims::Dims) where {X} = rand(default_rng(), X, dims)
+rand(r::AbstractRNG, X::Type, dims::Dims) = rand!(r, Array{X}(undef, dims), X)
+rand(                X::Type, dims::Dims) = rand(default_rng(), X, dims)
 
-rand(r::AbstractRNG, ::Type{X}, d::Integer, dims::Integer...) where {X} = rand(r, X, Dims((d, dims...)))
-rand(                ::Type{X}, d::Integer, dims::Integer...) where {X} = rand(X, Dims((d, dims...)))
+rand(r::AbstractRNG, X::Type, d::Integer, dims::Integer...) = rand(r, X, Dims((d, dims...)))
+rand(                X::Type, d::Integer, dims::Integer...) = rand(X, Dims((d, dims...)))
 
 
 ### UnsafeView

--- a/stdlib/Random/src/XoshiroSimd.jl
+++ b/stdlib/Random/src/XoshiroSimd.jl
@@ -11,7 +11,7 @@ using Core.Intrinsics: llvmcall
 # Vector-width. Influences random stream.
 xoshiroWidth() = Val(8)
 # Simd threshold. Influences random stream.
-simdThreshold(::Type{T}) where T = 64
+simdThreshold(::Type) = 64
 simdThreshold(::Type{Bool}) = 640
 
 @inline _rotl45(x::UInt64) = (x<<45)|(x>>19)
@@ -250,7 +250,7 @@ end
 end
 
 
-@noinline function xoshiro_bulk_simd(rng::Union{TaskLocalRNG, Xoshiro}, dst::Ptr{UInt8}, len::Int, ::Type{T}, ::Val{N}, f::F) where {T,N,F}
+@noinline function xoshiro_bulk_simd(rng::Union{TaskLocalRNG, Xoshiro}, dst::Ptr{UInt8}, len::Int, T::Type, ::Val{N}, f::F) where {N,F}
     s0, s1, s2, s3 = forkRand(rng, Val(N))
 
     i = 0

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -16,7 +16,7 @@
 
 ### random floats
 
-Sampler(::Type{RNG}, ::Type{T}, n::Repetition) where {RNG<:AbstractRNG,T<:AbstractFloat} =
+Sampler(RNG::Type{<:AbstractRNG}, T::Type{<:AbstractFloat}, n::Repetition) =
     Sampler(RNG, CloseOpen01(T), n)
 
 # generic random generation function which can be used by RNG implementers
@@ -169,13 +169,13 @@ end
 
 ### random tuples
 
-function Sampler(::Type{RNG}, ::Type{T}, n::Repetition) where {T<:Tuple, RNG<:AbstractRNG}
+function Sampler(RNG::Type{<:AbstractRNG}, T::Type{<:Tuple}, n::Repetition)
     tail_sp_ = Sampler(RNG, Tuple{Base.tail(fieldtypes(T))...}, n)
     SamplerTag{Ref{T}}((Sampler(RNG, fieldtype(T, 1), n), tail_sp_.data...))
     # Ref so that the gentype is `T` in SamplerTag's constructor
 end
 
-function Sampler(::Type{RNG}, ::Type{Tuple{Vararg{T, N}}}, n::Repetition) where {T, N, RNG<:AbstractRNG}
+function Sampler(RNG::Type{<:AbstractRNG}, ::Type{Tuple{Vararg{T, N}}}, n::Repetition) where {T, N}
     if N > 0
         SamplerTag{Ref{Tuple{Vararg{T, N}}}}((Sampler(RNG, T, n),))
     else
@@ -189,7 +189,7 @@ end
 
 ### random pairs
 
-function Sampler(::Type{RNG}, ::Type{Pair{A, B}}, n::Repetition) where {RNG<:AbstractRNG, A, B}
+function Sampler(RNG::Type{<:AbstractRNG}, ::Type{Pair{A, B}}, n::Repetition) where {A, B}
     sp1 = Sampler(RNG, A, n)
     sp2 = A === B ? sp1 : Sampler(RNG, B, n)
     SamplerTag{Ref{Pair{A,B}}}(sp1 => sp2) # Ref so that the gentype is Pair{A, B}
@@ -244,7 +244,7 @@ end
 SamplerRangeFast(r::AbstractUnitRange{T}) where T<:BitInteger =
     SamplerRangeFast(r, uint_sup(T))
 
-function SamplerRangeFast(r::AbstractUnitRange{T}, ::Type{U}) where {T,U}
+function SamplerRangeFast(r::AbstractUnitRange{T}, U::Type) where {T}
     isempty(r) && empty_collection_error()
     m = (last(r) - first(r)) % unsigned(T) % U # % unsigned(T) to not propagate sign bit
     bw = (Base.top_set_bit(m)) % UInt # bit-width
@@ -318,7 +318,7 @@ end
 SamplerRangeInt(r::AbstractUnitRange{T}) where T<:BitInteger =
     SamplerRangeInt(r, uint_sup(T))
 
-function SamplerRangeInt(r::AbstractUnitRange{T}, ::Type{U}) where {T,U}
+function SamplerRangeInt(r::AbstractUnitRange{T}, U::Type) where {T}
     isempty(r) && empty_collection_error()
     a = first(r)
     m = (last(r) - first(r)) % unsigned(T) % U
@@ -416,7 +416,7 @@ function SamplerBigInt(::Type{RNG}, r::AbstractUnitRange{BigInt}, N::Repetition=
     return SamplerBigInt(first(r), m, nlimbs, nlimbsmax, highsp)
 end
 
-Sampler(::Type{RNG}, r::AbstractUnitRange{BigInt}, N::Repetition) where {RNG<:AbstractRNG} =
+Sampler(RNG::Type{<:AbstractRNG}, r::AbstractUnitRange{BigInt}, N::Repetition) =
     SamplerBigInt(RNG, r, N)
 
 rand(rng::AbstractRNG, sp::SamplerBigInt) =
@@ -454,7 +454,7 @@ end
 
 ## random values from AbstractArray
 
-Sampler(::Type{RNG}, r::AbstractArray, n::Repetition) where {RNG<:AbstractRNG} =
+Sampler(RNG::Type{<:AbstractRNG}, r::AbstractArray, n::Repetition) =
     SamplerSimple(r, Sampler(RNG, firstindex(r):lastindex(r), n))
 
 rand(rng::AbstractRNG, sp::SamplerSimple{<:AbstractArray,<:Sampler}) =
@@ -463,7 +463,7 @@ rand(rng::AbstractRNG, sp::SamplerSimple{<:AbstractArray,<:Sampler}) =
 
 ## random values from Dict
 
-function Sampler(::Type{RNG}, t::Dict, ::Repetition) where RNG<:AbstractRNG
+function Sampler(RNG::Type{<:AbstractRNG}, t::Dict, ::Repetition)
     isempty(t) && empty_collection_error()
     # we use Val(Inf) below as rand is called repeatedly internally
     # even for generating only one random value from t
@@ -485,7 +485,7 @@ rand(rng::AbstractRNG, sp::SamplerTrivial{<:Base.ValueIterator{<:Dict}}) =
 
 ## random values from Set
 
-Sampler(::Type{RNG}, t::Set{T}, n::Repetition) where {RNG<:AbstractRNG,T} =
+Sampler(RNG::Type{<:AbstractRNG}, t::Set{T}, n::Repetition) where {T} =
     SamplerTag{Set{T}}(Sampler(RNG, t.dict, n))
 
 rand(rng::AbstractRNG, sp::SamplerTag{<:Set,<:Sampler}) = rand(rng, sp.data).first

--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -117,7 +117,7 @@ randn(rng::AbstractRNG, ::Type{Complex{T}}) where {T<:AbstractFloat} =
 
 
 ### fallback randn for float types defining rand:
-function randn(rng::AbstractRNG, ::Type{T}) where {T<:AbstractFloat}
+function randn(rng::AbstractRNG, T::Type{<:AbstractFloat})
     # Marsaglia polar variant of Box–Muller transform:
     while true
         x, y = 2rand(rng, T)-1, 2rand(rng, T)-1
@@ -173,7 +173,7 @@ end
 end
 
 ### fallback randexp for float types defining rand:
-randexp(rng::AbstractRNG, ::Type{T}) where {T<:AbstractFloat} =
+randexp(rng::AbstractRNG, T::Type{<:AbstractFloat}) =
     -log1p(-rand(rng, T))
 
 ## arrays & other scalar methods
@@ -222,7 +222,7 @@ for randfun in [:randn, :randexp]
     @eval begin
         # scalars
         $randfun(rng::AbstractRNG, T::BitFloatType) = convert(T, $randfun(rng))
-        $randfun(::Type{T}) where {T} = $randfun(default_rng(), T)
+        $randfun(T::Type) = $randfun(default_rng(), T)
 
         # filling arrays
         function $randfun!(rng::AbstractRNG, A::AbstractArray{T}) where T
@@ -266,12 +266,12 @@ for randfun in [:randn, :randexp]
         $randfun!(A::AbstractArray) = $randfun!(default_rng(), A)
 
         # generating arrays
-        $randfun(rng::AbstractRNG, ::Type{T}, dims::Dims                     ) where {T} = $randfun!(rng, Array{T}(undef, dims))
+        $randfun(rng::AbstractRNG, T::Type, dims::Dims                     ) = $randfun!(rng, Array{T}(undef, dims))
         # Note that this method explicitly does not define $randfun(rng, T),
         # in order to prevent an infinite recursion.
-        $randfun(rng::AbstractRNG, ::Type{T}, dim1::Integer, dims::Integer...) where {T} = $randfun!(rng, Array{T}(undef, dim1, dims...))
-        $randfun(                  ::Type{T}, dims::Dims                     ) where {T} = $randfun(default_rng(), T, dims)
-        $randfun(                  ::Type{T}, dims::Integer...               ) where {T} = $randfun(default_rng(), T, dims...)
+        $randfun(rng::AbstractRNG, T::Type, dim1::Integer, dims::Integer...) = $randfun!(rng, Array{T}(undef, dim1, dims...))
+        $randfun(                  T::Type, dims::Dims                     ) = $randfun(default_rng(), T, dims)
+        $randfun(                  T::Type, dims::Integer...               ) = $randfun(default_rng(), T, dims...)
         $randfun(rng::AbstractRNG,            dims::Dims                     )           = $randfun(rng, Float64, dims)
         $randfun(rng::AbstractRNG,            dims::Integer...               )           = $randfun(rng, Float64, dims...)
         $randfun(                             dims::Dims                     )           = $randfun(default_rng(), Float64, dims)

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1731,7 +1731,7 @@ function serialize(s::AbstractSerializer, lock::Base.AbstractLock)
     nothing
 end
 
-function deserialize(s::AbstractSerializer, ::Type{T}) where T<:Base.AbstractLock
+function deserialize(s::AbstractSerializer, T::Type{<:Base.AbstractLock})
     lock = T()
     deserialize_cycle(s, lock)
     return lock
@@ -1743,7 +1743,7 @@ function serialize(s::AbstractSerializer, cond::Base.GenericCondition)
     nothing
 end
 
-function deserialize(s::AbstractSerializer, ::Type{T}) where T<:Base.GenericCondition
+function deserialize(s::AbstractSerializer, T::Type{<:Base.GenericCondition})
     lock = deserialize(s)
     cond = T(lock)
     deserialize_cycle(s, cond)

--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -261,7 +261,7 @@ const _sizeof_uv_interface_address = ccall(:jl_uv_sizeof_interface_address,Int32
 Get an IP address of the local machine, preferring IPv4 over IPv6. Throws if no
 addresses are available.
 
-    getipaddr(addr_type::Type{T}) where T<:IPAddr -> T
+    getipaddr(addr_type::Type{<:IPAddr}) -> IPAddr
 
 Get an IP address of the local machine of the specified type. Throws if no
 addresses of the specified type are available.
@@ -280,7 +280,7 @@ ip"fe80::9731:35af:e1c5:6e49"
 
 See also [`getipaddrs`](@ref).
 """
-function getipaddr(addr_type::Type{T}) where T<:IPAddr
+function getipaddr(addr_type::Type{<:IPAddr})
     addrs = getipaddrs(addr_type)
     isempty(addrs) && error("No networking interface available")
 
@@ -293,7 +293,7 @@ getipaddr() = getipaddr(IPAddr)
 
 
 """
-    getipaddrs(addr_type::Type{T}=IPAddr; loopback::Bool=false) where T<:IPAddr -> Vector{T}
+    getipaddrs(addr_type::Type{<:IPAddr}=IPAddr; loopback::Bool=false) -> Vector{<:IPAddr}
 
 Get the IP addresses of the local machine.
 
@@ -323,8 +323,8 @@ julia> getipaddrs(IPv6)
 
 See also [`islinklocaladdr`](@ref).
 """
-function getipaddrs(addr_type::Type{T}=IPAddr; loopback::Bool=false) where T<:IPAddr
-    addresses = T[]
+function getipaddrs(addr_type::Type{<:IPAddr}=IPAddr; loopback::Bool=false)
+    addresses = addr_type[]
     addr_ref = Ref{Ptr{UInt8}}(C_NULL)
     count_ref = Ref{Int32}(1)
     lo_present = false
@@ -340,9 +340,9 @@ function getipaddrs(addr_type::Type{T}=IPAddr; loopback::Bool=false) where T<:IP
             end
         end
         sockaddr = ccall(:jl_uv_interface_address_sockaddr, Ptr{Cvoid}, (Ptr{UInt8},), current_addr)
-        if IPv4 <: T && ccall(:jl_sockaddr_is_ip4, Int32, (Ptr{Cvoid},), sockaddr) == 1
+        if IPv4 <: addr_type && ccall(:jl_sockaddr_is_ip4, Int32, (Ptr{Cvoid},), sockaddr) == 1
             push!(addresses, IPv4(ntoh(ccall(:jl_sockaddr_host4, UInt32, (Ptr{Cvoid},), sockaddr))))
-        elseif IPv6 <: T && ccall(:jl_sockaddr_is_ip6, Int32, (Ptr{Cvoid},), sockaddr) == 1
+        elseif IPv6 <: addr_type && ccall(:jl_sockaddr_is_ip6, Int32, (Ptr{Cvoid},), sockaddr) == 1
             addr6 = Ref{UInt128}()
             scope_id = ccall(:jl_sockaddr_host6, UInt32, (Ptr{Cvoid}, Ref{UInt128},), sockaddr, addr6)
             push!(addresses, IPv6(ntoh(addr6[])))


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/issues/61325, this can cause crashes if the first call is with a non-canonical type. Try to be slightly more robust by not using type parameters here. I do want to fix this properly, but I think the `T::Type` version is close to what's actually wanted anyway, so might as well do this for now.

Written by Claude