### PR TITLE
Support different subtypes of AbstractDict in merge()/mergewith()

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -406,10 +406,10 @@ promoteK(K) = K
 promoteV(V) = V
 promoteK(K, d, ds...) = promoteK(promote_type(K, keytype(d)), ds...)
 promoteV(V, d, ds...) = promoteV(promote_type(V, valtype(d)), ds...)
-function _typeddict(d::AbstractDict, others::AbstractDict...)
+function _typeddict(d::T, others::AbstractDict...) where {T <: AbstractDict}
     K = promoteK(keytype(d), others...)
     V = promoteV(valtype(d), others...)
-    Dict{K,V}(d)
+    T.name.wrapper{K, V}(d)
 end
 
 """

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1349,8 +1349,8 @@ end
     @test d == IdDict(1 => 6, 2 => 5, 3 => 10)
     @inferred mergewith(+, d1, d2, d3)
     d = mergewith(+, d1, d2, d3)
-    @test d isa Dict{Int, Float64}
-    @test d == Dict(1 => 6, 2 => 5, 3 => 10)
+    @test d isa IdDict{Int, Float64}
+    @test d == IdDict(1 => 6, 2 => 5, 3 => 10)
 end
 
 @testset "misc error/io" begin


### PR DESCRIPTION
The merge functions internally use the `_typeddict()` helper function, which returns a new `Dict` with the correct promoted key/value types. But the fact that it always returns a `Dict` means that the default implementations of `merge()`/`mergewith()` cannot be used for new `AbstractDict` subtypes that wish those functions to return their own custom type.

For example, OrderedDict: https://github.com/JuliaCollections/OrderedCollections.jl/blob/1eaa98084bd5c6e1f6519527c8f9e856a2fd2047/src/ordered_dict.jl#L488
And on 1.13 nightly that causes a ton of invalidations when loaded through CurveFit.jl:
```julia-repl
julia> using SnoopCompileCore

julia> invs, trees = begin
           invs = @snoop_invalidations using CurveFit
           using SnoopCompile, AbstractTrees
           trees = invalidation_trees(invs)
           invs, trees
       end;

julia> trees[end]
inserting merge(d::OrderedCollections.OrderedDict, others::AbstractDict...) @ OrderedCollections ~/.julia/dev/OrderedCollections/src/ordered_dict.jl:488 invalidated:
   mt_backedges: <38 invalidations I deleted because they have enormous types>
   backedges: 1: superseding merge(d::AbstractDict, others::AbstractDict...) @ Base abstractdict.jl:359 with MethodInstance for merge(::AbstractDict, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}) (21 children)
              2: superseding merge(d::AbstractDict, others::AbstractDict...) @ Base abstractdict.jl:359 with MethodInstance for merge(::AbstractDict, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}) (2489 children)
```

By allowing the Base functions to work with other dict types we could delete the methods from OrderedCollections and fix the invalidations. But, this is definitely breaking. A non-breaking alternative would be to just set `max_methods` for `merge()`/`mergewith()` to 1. I think the arguments for doing it anyway are:
1. Intuitively, `merge(::MyDict, ::MyDict) -> MyDict` is the behaviour I would expect with a custom dict. It's odd that this is supported for any `AbstractDict` but always returns a `Dict`, which is more like the behaviour of `collect()`.
1. The docstrings for `merge()`/`mergewith()` do not specify the type of the return value so it's kinda-sorta legal to change it. Admittedly this is a weak argument, we would probably need to do a PkgEval to see how breaking it actually is.
1. Supporting other dict types in Base allows more code reuse. Other packages currently need to implement their own type-promotion for keys/values to implement `merge()`/`mergewith()` properly.

Hardcoding `Dict` was done years ago, I suspect unintentionally: https://github.com/JuliaLang/julia/commit/ebbf1ddc99b240924bdef14b7a87500b5c4c989b
Calling `T.name.wrapper` to get the original type is to preserve this optimization: https://github.com/JuliaLang/julia/pull/22737

(CC @cstjean)