### PR TITLE
precompilation: fix show_progress crash when bar.current goes negative

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -350,8 +350,8 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing, carriagere
     end
     termwidth = @something termwidth (displaysize(io)::Tuple{Int,Int})[2]
     max_progress_width = max(0, min(termwidth - textwidth(p.header) - textwidth(progress_text) - 10 , p.width))
-    n_filled = floor(Int, max_progress_width * clamp(perc / 100, 0.0, 1.0))
-    partial_filled = (max_progress_width * perc_clamped / 100) - n_filled
+    filled = max_progress_width * clamp(perc / 100, 0.0, 1.0)
+    (partial_filled, n_filled::Int64) = modf(filled) # get fractional / integer part
     n_left = max_progress_width - n_filled
     headers = split(p.header, ' ')
     to_print = sprint(; context=io) do io

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -350,8 +350,7 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing, carriagere
     end
     termwidth = @something termwidth (displaysize(io)::Tuple{Int,Int})[2]
     max_progress_width = max(0, min(termwidth - textwidth(p.header) - textwidth(progress_text) - 10 , p.width))
-    perc_clamped = clamp(perc, 0.0, 100.0)
-    n_filled = floor(Int, max_progress_width * perc_clamped / 100)
+    n_filled = floor(Int, max_progress_width * clamp(perc / 100, 0.0, 1.0))
     partial_filled = (max_progress_width * perc_clamped / 100) - n_filled
     n_left = max_progress_width - n_filled
     headers = split(p.header, ' ')

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -350,8 +350,9 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing, carriagere
     end
     termwidth = @something termwidth (displaysize(io)::Tuple{Int,Int})[2]
     max_progress_width = max(0, min(termwidth - textwidth(p.header) - textwidth(progress_text) - 10 , p.width))
-    n_filled = floor(Int, max_progress_width * perc / 100)
-    partial_filled = (max_progress_width * perc / 100) - n_filled
+    perc_clamped = clamp(perc, 0.0, 100.0)
+    n_filled = floor(Int, max_progress_width * perc_clamped / 100)
+    partial_filled = (max_progress_width * perc_clamped / 100) - n_filled
     n_left = max_progress_width - n_filled
     headers = split(p.header, ' ')
     to_print = sprint(; context=io) do io

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -998,8 +998,11 @@ function _precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}},
                         if i_local > 1
                             print(iostr, ansi_cleartoend)
                         end
-                        bar.current = n_done[] - n_already_precomp[]
-                        bar.max = n_total - n_already_precomp[]
+                        # max(0,...) guards against a race where the print loop runs after
+                        # n_already_precomp is incremented but before n_done is incremented,
+                        # which would otherwise produce a negative value and crash repeat().
+                        bar.current = max(0, n_done[] - n_already_precomp[])
+                        bar.max = max(0, n_total - n_already_precomp[])
                         # when sizing to the terminal width subtract a little to give some tolerance to resizing the
                         # window between print cycles
                         termwidth = (displaysize(io)::Tuple{Int,Int})[2] - 4


### PR DESCRIPTION
Fixes #61333

There's likely a better fix for locking around incrementing these counters together, but I'd handle that after https://github.com/JuliaLang/julia/pull/60943

So just protect for now.

