### PR TITLE
Hint about workspaces when it might fix loading issue

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2574,6 +2574,63 @@ function check_for_hint(into, mod)
     end
 end
 
+# Check if a parent Project.toml knows about `mod` but hasn't set up a workspace
+# to include the current active project, and return a hint if so.
+function workspace_setup_hint(mod::Symbol)
+    project_file = active_project()
+    project_file === nothing && return ""
+    isfile(project_file) || return ""
+    project_dir = abspath(dirname(project_file))
+    home_dir = abspath(homedir())
+    started_in_home = startswith(project_dir, home_dir)
+    mod_str = String(mod)
+    current_dir = project_dir
+    while true
+        parent_dir = dirname(current_dir)
+        parent_dir == current_dir && return ""
+        if started_in_home && !startswith(parent_dir, home_dir)
+            return ""
+        end
+        parent_project_file = env_project_file(parent_dir)
+        if parent_project_file isa String
+            d = parsed_toml(parent_project_file)
+            parent_name = get(d, "name", nothing)
+            parent_deps = get(d, "deps", nothing)
+            if parent_name == mod_str || (parent_deps isa Dict && haskey(parent_deps, mod_str))
+                rel = relpath(project_dir, parent_dir)
+                workspace = get(d, "workspace", nothing)
+                if workspace isa Dict
+                    # Workspace exists but may not include our active project dir
+                    projects = get(workspace, "projects", nothing)
+                    if projects isa Vector
+                        workspace_root = dirname(parent_project_file)
+                        for proj in projects
+                            proj_path = joinpath(workspace_root, proj)
+                            if isdir(proj_path) && samefile(proj_path, project_dir)
+                                return ""  # workspace already set up correctly
+                            end
+                        end
+                    end
+                    existing = projects isa Vector ? projects : String[]
+                    new_projects = vcat(existing, rel)
+                    projects_str = join([repr(p) for p in new_projects], ", ")
+                    return "\n- Tip: Package `$mod_str` was found in the parent project at" *
+                           " `$parent_project_file`, but the `[workspace]` there does not include" *
+                           " the current project.\n" *
+                           "  Consider updating `$parent_project_file`:\n" *
+                           "    [workspace]\n      projects = [$projects_str]"
+                else
+                    return "\n- Tip: Package `$mod_str` was found in the parent project at" *
+                           " `$parent_project_file`, but that project has no `[workspace]` configured.\n" *
+                           "  Consider adding to `$parent_project_file`:\n" *
+                           "    [workspace]\n      projects = [$(repr(rel))]"
+                end
+            end
+        end
+        current_dir = parent_dir
+    end
+end
+
 function __require(into::Module, mod::Symbol)
     if into === __toplevel__ && generating_output(#=incremental=#true)
         error("`using/import $mod` outside of a Module detected. Importing a package outside of a module \
@@ -2599,8 +2656,9 @@ function __require(into::Module, mod::Symbol)
                 else  # for some reason Pkg itself isn't availability so do not tell them to use Pkg to install it.
                     ""
                 end
+                workspace_message = workspace_setup_hint(mod)
 
-                throw(ArgumentError("Package $mod not found in current path$hint_message.$install_message"))
+                throw(ArgumentError("Package $mod not found in current path$hint_message.$install_message$workspace_message"))
             else
                 manifest_warnings = collect_manifest_warnings()
                 throw(ArgumentError("""

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2617,13 +2617,13 @@ function workspace_setup_hint(mod::Symbol)
                     return "\n- Tip: Package `$mod_str` was found in the parent project at" *
                            " `$parent_project_file`, but the `[workspace]` there does not include" *
                            " the current project.\n" *
-                           "  Consider updating `$parent_project_file`:\n" *
-                           "    [workspace]\n      projects = [$projects_str]"
+                           "  Consider updating `$parent_project_file` to:\n" *
+                           "    [workspace]\n    projects = [$projects_str]"
                 else
                     return "\n- Tip: Package `$mod_str` was found in the parent project at" *
                            " `$parent_project_file`, but that project has no `[workspace]` configured.\n" *
-                           "  Consider adding to `$parent_project_file`:\n" *
-                           "    [workspace]\n      projects = [$(repr(rel))]"
+                           "  Consider adding the following to `$parent_project_file`:\n" *
+                           "    [workspace]\n    projects = [$(repr(rel))]"
                 end
             end
         end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -2016,6 +2016,55 @@ end
     end
 end
 
+@testset "workspace_setup_hint" begin
+    # Test the hint shown when `using Pkg` fails because a parent project knows about
+    # the package but the workspace isn't configured to include the current project.
+    old_active = Base.active_project()
+    try
+        d = mktempdir()
+
+        # Case 1: workspace already set up correctly -> no hint
+        pkgdir = joinpath(d, "MyPkg")
+        testdir = joinpath(pkgdir, "test")
+        mkpath(testdir)
+        write(joinpath(pkgdir, "Project.toml"),
+              "name = \"MyPkg\"\nuuid = \"12345678-1234-1234-1234-1234567890ab\"\n\n[workspace]\nprojects = [\"test\"]\n")
+        write(joinpath(testdir, "Project.toml"),
+              "[deps]\nTest = \"8dfed614-e22c-5e08-85e1-65c5234f0b40\"\n")
+        Base.set_active_project(joinpath(testdir, "Project.toml"))
+        @test Base.workspace_setup_hint(:MyPkg) == ""
+
+        # Case 2: [workspace] exists but current project not in it
+        pkgdir = joinpath(d, "MyPkg2")
+        testdir = joinpath(pkgdir, "test")
+        mkpath(testdir)
+        write(joinpath(pkgdir, "Project.toml"),
+              "name = \"MyPkg2\"\nuuid = \"22345678-1234-1234-1234-1234567890ab\"\n\n[workspace]\nprojects = [\"docs\"]\n")
+        write(joinpath(testdir, "Project.toml"),
+              "[deps]\nTest = \"8dfed614-e22c-5e08-85e1-65c5234f0b40\"\n")
+        Base.set_active_project(joinpath(testdir, "Project.toml"))
+        h = Base.workspace_setup_hint(:MyPkg2)
+        @test occursin("[workspace]", h)
+        @test occursin("does not include", h)
+        @test occursin("docs", h)  # existing projects preserved in suggestion
+
+        # Case 3: no [workspace] at all
+        pkgdir = joinpath(d, "MyPkg3")
+        testdir = joinpath(pkgdir, "test")
+        mkpath(testdir)
+        write(joinpath(pkgdir, "Project.toml"),
+              "name = \"MyPkg3\"\nuuid = \"32345678-1234-1234-1234-1234567890ab\"\n")
+        write(joinpath(testdir, "Project.toml"),
+              "[deps]\nTest = \"8dfed614-e22c-5e08-85e1-65c5234f0b40\"\n")
+        Base.set_active_project(joinpath(testdir, "Project.toml"))
+        h = Base.workspace_setup_hint(:MyPkg3)
+        @test occursin("[workspace]", h)
+        @test occursin("no `[workspace]`", h)
+    finally
+        Base.set_active_project(old_active)
+    end
+end
+
 @testset "project path handling" begin
     old_load_path = copy(LOAD_PATH)
     try


### PR DESCRIPTION
Claude expects this to work from a package root
```
julia --project=test -e "test/file.jl"
```
where `test/file.jl` might include deps from the main project, because of how Pkg merges the test env in.

That works when a workspace is set up, so add a tip if it would've worked:

```julia
VideoIO.jl % julia --project=test -e "using FFMPEG"             
ERROR: ArgumentError: Package FFMPEG not found in current path.
- Run `import Pkg; Pkg.add("FFMPEG")` to install the FFMPEG package.
- Tip: Package `FFMPEG` was found in the parent project at `/Users/ian/Documents/GitHub/VideoIO.jl/Project.toml`, but that project has no `[workspace]` configured. 
  Consider adding the following to `/Users/ian/Documents/GitHub/VideoIO.jl/Project.toml`:
    [workspace]
    projects = ["test"]
Stacktrace:
  [1] macro expansion
    @ ./loading.jl:2660 [inlined]
  [2] macro expansion
    @ ./lock.jl:376 [inlined]
  [3] __require(into::Module, mod::Symbol)
    @ Base ./loading.jl:2642
  [4] require
    @ ./loading.jl:2562 [inlined]
  [5] eval_import_path
    @ ./module.jl:36 [inlined]
  [6] eval_import_path_all(at::Module, path::Expr, keyword::String)
    @ Base ./module.jl:60
  [7] _eval_using
    @ ./module.jl:137 [inlined]
  [8] _eval_using(to::Module, path::Expr)
    @ Base ./module.jl:137
  [9] top-level scope
    @ none:1
 [10] eval(m::Module, e::Any)
    @ Core ./boot.jl:517
 [11] exec_options(opts::Base.JLOptions)
    @ Base ./client.jl:310
 [12] _start()
    @ Base ./client.jl:585
```