### PR TITLE
inference: Extend signature constraint propagation to `MustAlias`

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -582,6 +582,34 @@ function collect_slot_refinements(𝕃ᵢ::AbstractLattice, applicable::Vector{M
                 end
                 slotrefinements[fidx] = sigt
             end
+        elseif argtypes[i] isa MustAlias
+            alias = argtypes[i]::MustAlias
+            argt = alias.fldtyp
+            if isvarargtype(argt)
+                argt = unwrapva(argt)
+            end
+            sigt = Bottom
+            for j = 1:length(applicable)
+                (;match) = applicable[j]
+                valid_as_lattice(match.spec_types, true) || continue
+                sigt = sigt ⊔ fieldtype(match.spec_types, i)
+            end
+            if sigt ⊏ argt # i.e. signature type is strictly more specific than the field type
+                newtyp = form_mustalias_refinement(alias, sigt)
+                if newtyp !== nothing
+                    aidx = alias.slot
+                    if slotrefinements === nothing
+                        slotrefinements = fill!(Vector{Any}(undef, length(sv.slottypes)), nothing)
+                    end
+                    # TODO: if multiple MustAlias arguments refer to different fields
+                    # of the same slot, we only apply the first refinement. Merging
+                    # multiple PartialStruct refinements would require a meet operation
+                    # on PartialStruct, which is not currently implemented.
+                    if slotrefinements[aidx] === nothing
+                        slotrefinements[aidx] = newtyp
+                    end
+                end
+            end
         end
     end
     return slotrefinements

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -322,45 +322,35 @@ end
     return fldidx
 end
 
-@nospecializeinfer function form_mustalias_conditional(alias::MustAlias, @nospecialize(thentype), @nospecialize(elsetype))
-    (; slot, ssadef, vartyp, fldidx) = alias
+@nospecializeinfer function form_mustalias_refinement(alias::MustAlias, @nospecialize(newtyp))
+    newtyp === Union{} && return nothing
+    (; vartyp, fldidx) = alias
     if isa(vartyp, PartialStruct)
-        fields = vartyp.fields
-        thenfields = thentype === Bottom ? nothing : copy(fields)
-        elsefields = elsetype === Bottom ? nothing : copy(fields)
+        fields = copy(vartyp.fields)
         undefs = copy(_getundefs(vartyp))
         if 1 ≤ fldidx ≤ length(fields)
-            thenfields === nothing || (thenfields[fldidx] = thentype)
-            elsefields === nothing || (elsefields[fldidx] = elsetype)
+            fields[fldidx] = newtyp
             undefs[fldidx] = false
         end
-        return Conditional(slot, ssadef,
-            thenfields === nothing ? Bottom : PartialStruct(fallback_lattice, vartyp.typ, undefs, thenfields),
-            elsefields === nothing ? Bottom : PartialStruct(fallback_lattice, vartyp.typ, undefs, elsefields))
+        return PartialStruct(fallback_lattice, vartyp.typ, undefs, fields)
     else
         vartyp_widened = widenconst(vartyp)
-        thenfields = thentype === Bottom ? nothing : Any[]
-        elsefields = elsetype === Bottom ? nothing : Any[]
+        fields = Any[]
         for i in 1:fieldcount(vartyp_widened)
-            if i == fldidx
-                thenfields === nothing || push!(thenfields, thentype)
-                elsefields === nothing || push!(elsefields, elsetype)
-            else
-                t = fieldtype(vartyp_widened, i)
-                thenfields === nothing || push!(thenfields, t)
-                elsefields === nothing || push!(elsefields, t)
-            end
+            push!(fields, i == fldidx ? newtyp : fieldtype(vartyp_widened, i))
         end
-        thentype_r = thenfields === nothing ? Bottom : begin
-            undefs = partialstruct_init_undefs(vartyp_widened, thenfields)
-            undefs === nothing ? Bottom : PartialStruct(fallback_lattice, vartyp_widened, undefs, thenfields)
-        end
-        elsetype_r = elsefields === nothing ? Bottom : begin
-            undefs = partialstruct_init_undefs(vartyp_widened, elsefields)
-            undefs === nothing ? Bottom : PartialStruct(fallback_lattice, vartyp_widened, undefs, elsefields)
-        end
-        return Conditional(slot, ssadef, thentype_r, elsetype_r)
+        undefs = partialstruct_init_undefs(vartyp_widened, fields)
+        undefs === nothing && return nothing
+        return PartialStruct(fallback_lattice, vartyp_widened, undefs, fields)
     end
+end
+
+@nospecializeinfer function form_mustalias_conditional(alias::MustAlias, @nospecialize(thentype), @nospecialize(elsetype))
+    thentype_r = thentype === Bottom ? Bottom : form_mustalias_refinement(alias, thentype)
+    elsetype_r = elsetype === Bottom ? Bottom : form_mustalias_refinement(alias, elsetype)
+    thentype_r === nothing && (thentype_r = Bottom)
+    elsetype_r === nothing && (elsetype_r = Bottom)
+    return Conditional(alias.slot, alias.ssadef, thentype_r, elsetype_r)
 end
 
 function issubalias(a::AnyMustAlias, b::AnyMustAlias)

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -4420,6 +4420,16 @@ end == Int
     callsig_backprop_invalidation_outer(a)
 end ≠ Int
 
+# MustAlias signature constraint propagation:
+# when a call like `f(x.value)` constrains `x.value` via the method signature,
+# the refinement should propagate back to the slot `x` as a PartialStruct
+check_int_positive(x::Int) = x > 0 || error("x must be positive")
+# basic case: field type should be narrowed after the call
+@test Base.infer_return_type((Some{Any},)) do x
+    check_int_positive(x.value)
+    return sin(x.value)
+end == Float64
+
 # https://github.com/JuliaLang/julia/issues/37866
 function issue37866(v::Vector{Union{Nothing,Float64}})
     for x in v


### PR DESCRIPTION
Previously, `collect_slot_refinements` only narrowed slot types when a slot was passed directly as a call argument (the `SlotNumber` case). This meant that field accesses like `x.value` passed to a call did not benefit from signature constraint propagation.

For example, in code like:

```julia
code_typed((Some{Any},); optimize=false) do x
    only_accepts_int(x.value)
    return sin(x.value) # x.value was not narrowed to Int
end
```

the call to `only_accepts_int(::Int)` constrains `x.value` to `Int`, but this information was not propagated back to the slot `x`. After this change, the slot is refined to `PartialStruct(Some{Any}, [Int])`, allowing subsequent uses of `x.value` to be inferred as `Int`.

The implementation extracts the `PartialStruct` construction logic from `form_mustalias_conditional` into a shared `form_mustalias_refinement` helper and reuses it in `collect_slot_refinements`.