### PR TITLE
`@threads`: Use thread-local buffers for filtered comprehensions. Expand greedy tests

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -292,49 +292,32 @@ function _threadsfor_single_iterator(body, iterator, condition, schedule, dims=n
     end
 
     func = if schedule === :greedy
-        greedy_comprehension_func(esc_range, esc_lidx, esc_body, esc_condition)
+        greedy_comprehension_func(esc_range, esc_lidx, esc_body, esc_condition, result_type)
     else
-        default_comprehension_func(esc_range, esc_lidx, esc_body, esc_condition)
+        default_comprehension_func(esc_range, esc_lidx, esc_body, esc_condition, result_type)
     end
 
-    result_expr = if schedule === :greedy
-        # Greedy: collect values in arrival order (no ordering guarantee)
-        if result_type !== nothing
-            esc_result_type = esc(result_type)
-            quote
-                close(result_channel)
-                vals = collect(result_channel)
-                isempty(vals) ? $esc_result_type[] : $esc_result_type[v for v in vals]
-            end
-        else
-            quote
-                close(result_channel)
-                collect(result_channel)
-            end
+    # Both greedy and default/static return Vector{Vector{T}} of per-task buffers.
+    # For the untyped case, we try vcat first (fast bulk copies). If the buffers have
+    # a Union or Any element type — indicating a type-unstable body — we fall back to
+    # grow_to! which replicates serial's promote_typejoin widening.
+    result_expr = if result_type !== nothing
+        esc_result_type = esc(result_type)
+        quote
+            vcat(result_channel...)::Vector{$esc_result_type}
         end
     else
-        # Default/static/dynamic: sort by index to preserve iteration order
-        if result_type !== nothing
-            esc_result_type = esc(result_type)
-            quote
-                close(result_channel)
-                pairs = collect(result_channel)
-                if isempty(pairs)
-                    $esc_result_type[]
+        quote
+            let _bufs = result_channel
+                _ET = eltype(eltype(_bufs))
+                if isconcretetype(_ET)
+                    # All buffers have a concrete element type (from promote_op inference
+                    # or a uniform body). Use bulk vcat — same result as grow_to! here.
+                    vcat(_bufs...)
                 else
-                    sort!(pairs, by=first)
-                    $esc_result_type[p[2] for p in pairs]
-                end
-            end
-        else
-            quote
-                close(result_channel)
-                pairs = collect(result_channel)
-                if isempty(pairs)
-                    []
-                else
-                    sort!(pairs, by=first)
-                    [p[2] for p in pairs]
+                    # Type-unstable body: grow_to! discovers the correct widened type,
+                    # matching the return type of the equivalent serial comprehension.
+                    Base.grow_to!(Any[], Iterators.flatten(_bufs))
                 end
             end
         end
@@ -458,24 +441,72 @@ function greedy_func(itr, lidx, lbody)
     end
 end
 
-function greedy_comprehension_func(itr, esc_lidx, esc_body, esc_condition)
+function greedy_comprehension_func(itr, esc_lidx, esc_body, esc_condition, result_type=nothing)
+    if result_type !== nothing
+        buf_init = :($(esc(result_type))[])
+        buf_type_setup = :()
+    else
+        # Use promote_op to pre-type the per-task buffers, avoiding boxing during the
+        # parallel phase for type-stable bodies. grow_to! in the result expression then
+        # gives the same final type as the equivalent serial comprehension.
+        # eltype(_raw) works for both AbstractArray and Channel/lazy iterators.
+        _ET = gensym(:ET)
+        buf_type_setup = :(local $_ET = Base.promote_op($esc_lidx -> $esc_body, eltype(_raw)))
+        buf_init = :($_ET[])
+    end
     quote
-        let c = Channel{eltype($itr)}(threadpoolsize(), spawn=true) do ch
-            for item in $itr
-                put!(ch, item)
+        let _raw = $itr
+        local _npool = threadpoolsize()
+        $buf_type_setup
+        local local_bufs = [$buf_init for _ in 1:_npool]
+        # Single conditional assignment avoids the method-overwrite issue that arises when
+        # two `function f(tid)` definitions appear in if/else branches (Julia compiles both,
+        # last one wins regardless of which branch runs at runtime).
+        threadsfor_fun = if _raw isa Union{AbstractArray, Tuple}
+            # Indexable path: atomic work-stealing over chunks amortizes
+            # synchronization cost while preserving greedy dynamic scheduling.
+            local _nitems = length(_raw)
+            local _fst = firstindex(_raw)
+            # ~64 chunks per thread: enough for good load balance, large enough to
+            # amortize atomic overhead.
+            local _chunk = max(1, _nitems ÷ (_npool * 64))
+            local _next = Threads.Atomic{Int}(0)  # 0-based chunk counter
+            (tid) -> begin
+                local buf = local_bufs[tid]
+                while true
+                    local ci = Threads.atomic_add!(_next, 1)
+                    local pos_start = ci * _chunk  # 0-based offset from firstindex
+                    pos_start >= _nitems && break
+                    local pos_end = min(pos_start + _chunk - 1, _nitems - 1)
+                    for pos in pos_start:pos_end
+                        local $esc_lidx = @inbounds _raw[_fst + pos]
+                        if $esc_condition
+                            push!(buf, $esc_body)
+                        end
+                    end
+                end
             end
-        end
-        result_channel = Channel{Any}(Inf)
-
-        function threadsfor_fun(tid)
-            for item in c
-                local $esc_lidx = item
-                if $esc_condition
-                    put!(result_channel, $esc_body)
+        else
+            # Non-indexable path (Channel, lazy iterators, etc.): preserve true
+            # greedy streaming semantics. A producer task feeds a bounded channel
+            # and worker tasks drain it concurrently without materializing the
+            # iterator up front.
+            local _c = Channel{eltype(_raw)}(threadpoolsize(), spawn=true) do ch
+                for item in _raw
+                    put!(ch, item)
+                end
+            end
+            (tid) -> begin
+                local buf = local_bufs[tid]
+                for item in _c
+                    local $esc_lidx = item
+                    if $esc_condition
+                        push!(buf, $esc_body)
+                    end
                 end
             end
         end
-        result_channel
+        local_bufs
         end
     end
 end
@@ -531,27 +562,42 @@ function default_func(itr, lidx, lbody)
     end
 end
 
-function default_comprehension_func(itr, esc_lidx, esc_body, esc_condition)
+function default_comprehension_func(itr, esc_lidx, esc_body, esc_condition, result_type=nothing)
     work_dist = _work_distribution_code()
+    if result_type !== nothing
+        # Typed comprehension: element type known at macro expansion time.
+        buf_init = :($(esc(result_type))[])
+        buf_type_setup = :()
+    else
+        # Untyped comprehension: use promote_op to pre-type the per-task buffers,
+        # avoiding boxing in the parallel phase for type-stable bodies.
+        # The result is flattened through grow_to! so the final element type matches
+        # serial's runtime promote_typejoin widening rather than the static promote_op type.
+        _ET = gensym(:ET)
+        buf_type_setup = :(local $_ET = Base.promote_op($esc_lidx -> $esc_body, eltype(items)))
+        buf_init = :($_ET[])
+    end
     quote
         let iter = $itr
-        # Collect non-indexable iterators for random access (r[i]) in work distribution
-        items = iter isa AbstractArray ? iter : collect(iter)
-        # Channel uses Tuple{Int, Any} because the output type of the body expression
-        # is not known at macro expansion time.
-        result_channel = Channel{Tuple{Int, Any}}(Inf)
+        local items = iter isa Union{Tuple, AbstractArray} ? iter : collect(iter)
+        local _npool = threadpoolsize()
+        $buf_type_setup
+        # One buffer per task-id; tasks process contiguous ranges so concatenating
+        # in tid order preserves iteration order without a sort step.
+        local local_bufs = [$buf_init for _ in 1:_npool]
 
         function threadsfor_fun(tid = 1; onethread = false)
             # Reads: items, tid, onethread. Defines: r, loop_first, loop_last.
             $work_dist
+            local buf = local_bufs[tid]
             for i = loop_first:loop_last
                 local $esc_lidx = @inbounds r[i]
                 if $esc_condition
-                    put!(result_channel, (i, $esc_body))
+                    push!(buf, $esc_body)
                 end
             end
         end
-        result_channel  # Return channel so results can be collected after threading_run
+        local_bufs  # Return per-task buffers to be vcat'd after threading_run
         end
     end
 end
@@ -627,6 +673,8 @@ larger than the number of the worker threads and the run-time of `f(x)` is relat
 smaller than the cost of spawning and synchronizing a task (typically less than 10
 microseconds).
 
+Use `:dynamic` (or the default) for uniform workloads over indexable collections.
+
 !!! compat "Julia 1.8"
     The `:dynamic` option for the `schedule` argument is available and the default as of Julia 1.8.
 
@@ -637,6 +685,19 @@ the given iterated values as they are produced. As soon as one task finishes its
 the next value from the iterator. Work done by any individual task is not necessarily on
 contiguous values from the iterator. The given iterator may produce values forever, only the
 iterator interface is required (no indexing).
+
+Use `:greedy` when:
+- iteration times are non-uniform or have a large spread (e.g. one item takes 10× longer than another)
+- the iterator is non-indexable (e.g. a `Channel` or a lazy iterator)
+
+For array comprehensions, `:greedy` does **not** guarantee that the output elements appear
+in the same order as the input (unlike `:dynamic` and `:static`). Use `sort` on the result
+if order matters.
+
+For array comprehensions over an `AbstractArray`, workers steal chunks of indices atomically
+(fast, low-overhead). For non-indexable iterators (e.g. a `Channel`), a bounded producer
+channel feeds all worker tasks concurrently without materializing the iterator first,
+preserving true streaming semantics.
 
 This scheduling option is generally a good choice if the workload of individual iterations
 is not uniform/has a large spread.
@@ -651,6 +712,9 @@ them, assigning each task specifically to each thread. In particular, the value 
 [`threadid()`](@ref Threads.threadid) is guaranteed to be constant within one iteration.
 Specifying `:static` is an error if used from inside another `@threads` loop or from a
 thread other than 1.
+
+Use `:static` only when `threadid()` stability within an iteration is required for
+compatibility with existing code.
 
 !!! note
     `:static` scheduling exists for supporting transition of code written before Julia 1.3.

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -292,32 +292,49 @@ function _threadsfor_single_iterator(body, iterator, condition, schedule, dims=n
     end
 
     func = if schedule === :greedy
-        greedy_comprehension_func(esc_range, esc_lidx, esc_body, esc_condition, result_type)
+        greedy_comprehension_func(esc_range, esc_lidx, esc_body, esc_condition)
     else
         default_comprehension_func(esc_range, esc_lidx, esc_body, esc_condition, result_type)
     end
 
-    # Both greedy and default/static return Vector{Vector{T}} of per-task buffers.
-    # For the untyped case, we try vcat first (fast bulk copies). If the buffers have
-    # a Union or Any element type — indicating a type-unstable body — we fall back to
-    # grow_to! which replicates serial's promote_typejoin widening.
-    result_expr = if result_type !== nothing
-        esc_result_type = esc(result_type)
-        quote
-            vcat(result_channel...)::Vector{$esc_result_type}
+    result_expr = if schedule === :greedy
+        # Greedy: collect values in arrival order (no ordering guarantee)
+        if result_type !== nothing
+            esc_result_type = esc(result_type)
+            quote
+                close(result_channel)
+                vals = collect(result_channel)
+                isempty(vals) ? $esc_result_type[] : $esc_result_type[v for v in vals]
+            end
+        else
+            quote
+                close(result_channel)
+                collect(result_channel)
+            end
         end
     else
-        quote
-            let _bufs = result_channel
-                _ET = eltype(eltype(_bufs))
-                if isconcretetype(_ET)
-                    # All buffers have a concrete element type (from promote_op inference
-                    # or a uniform body). Use bulk vcat — same result as grow_to! here.
-                    vcat(_bufs...)
-                else
-                    # Type-unstable body: grow_to! discovers the correct widened type,
-                    # matching the return type of the equivalent serial comprehension.
-                    Base.grow_to!(Any[], Iterators.flatten(_bufs))
+        # Default/static: thread-local buffers, vcat in tid order preserves iteration order.
+        # For the untyped case, we try vcat first (fast bulk copies). If the buffers have
+        # a Union or Any element type — indicating a type-unstable body — we fall back to
+        # grow_to! which replicates serial's promote_typejoin widening.
+        if result_type !== nothing
+            esc_result_type = esc(result_type)
+            quote
+                vcat(result_channel...)::Vector{$esc_result_type}
+            end
+        else
+            quote
+                let _bufs = result_channel
+                    _ET = eltype(eltype(_bufs))
+                    if isconcretetype(_ET)
+                        # All buffers have a concrete element type (from promote_op inference
+                        # or a uniform body). Use bulk vcat — same result as grow_to! here.
+                        vcat(_bufs...)
+                    else
+                        # Type-unstable body: grow_to! discovers the correct widened type,
+                        # matching the return type of the equivalent serial comprehension.
+                        Base.grow_to!(Any[], Iterators.flatten(_bufs))
+                    end
                 end
             end
         end
@@ -441,72 +458,24 @@ function greedy_func(itr, lidx, lbody)
     end
 end
 
-function greedy_comprehension_func(itr, esc_lidx, esc_body, esc_condition, result_type=nothing)
-    if result_type !== nothing
-        buf_init = :($(esc(result_type))[])
-        buf_type_setup = :()
-    else
-        # Use promote_op to pre-type the per-task buffers, avoiding boxing during the
-        # parallel phase for type-stable bodies. grow_to! in the result expression then
-        # gives the same final type as the equivalent serial comprehension.
-        # eltype(_raw) works for both AbstractArray and Channel/lazy iterators.
-        _ET = gensym(:ET)
-        buf_type_setup = :(local $_ET = Base.promote_op($esc_lidx -> $esc_body, eltype(_raw)))
-        buf_init = :($_ET[])
-    end
+function greedy_comprehension_func(itr, esc_lidx, esc_body, esc_condition)
     quote
-        let _raw = $itr
-        local _npool = threadpoolsize()
-        $buf_type_setup
-        local local_bufs = [$buf_init for _ in 1:_npool]
-        # Single conditional assignment avoids the method-overwrite issue that arises when
-        # two `function f(tid)` definitions appear in if/else branches (Julia compiles both,
-        # last one wins regardless of which branch runs at runtime).
-        threadsfor_fun = if _raw isa Union{AbstractArray, Tuple}
-            # Indexable path: atomic work-stealing over chunks amortizes
-            # synchronization cost while preserving greedy dynamic scheduling.
-            local _nitems = length(_raw)
-            local _fst = firstindex(_raw)
-            # ~64 chunks per thread: enough for good load balance, large enough to
-            # amortize atomic overhead.
-            local _chunk = max(1, _nitems ÷ (_npool * 64))
-            local _next = Threads.Atomic{Int}(0)  # 0-based chunk counter
-            (tid) -> begin
-                local buf = local_bufs[tid]
-                while true
-                    local ci = Threads.atomic_add!(_next, 1)
-                    local pos_start = ci * _chunk  # 0-based offset from firstindex
-                    pos_start >= _nitems && break
-                    local pos_end = min(pos_start + _chunk - 1, _nitems - 1)
-                    for pos in pos_start:pos_end
-                        local $esc_lidx = @inbounds _raw[_fst + pos]
-                        if $esc_condition
-                            push!(buf, $esc_body)
-                        end
-                    end
-                end
-            end
-        else
-            # Non-indexable path (Channel, lazy iterators, etc.): preserve true
-            # greedy streaming semantics. A producer task feeds a bounded channel
-            # and worker tasks drain it concurrently without materializing the
-            # iterator up front.
-            local _c = Channel{eltype(_raw)}(threadpoolsize(), spawn=true) do ch
-                for item in _raw
+        let c = Channel{eltype($itr)}(threadpoolsize(), spawn=true) do ch
+                for item in $itr
                     put!(ch, item)
                 end
             end
-            (tid) -> begin
-                local buf = local_bufs[tid]
-                for item in _c
+            result_channel = Channel{Any}(Inf)
+
+            function threadsfor_fun(tid)
+                for item in c
                     local $esc_lidx = item
                     if $esc_condition
-                        push!(buf, $esc_body)
+                        put!(result_channel, $esc_body)
                     end
                 end
             end
-        end
-        local_bufs
+            result_channel
         end
     end
 end
@@ -673,8 +642,6 @@ larger than the number of the worker threads and the run-time of `f(x)` is relat
 smaller than the cost of spawning and synchronizing a task (typically less than 10
 microseconds).
 
-Use `:dynamic` (or the default) for uniform workloads over indexable collections.
-
 !!! compat "Julia 1.8"
     The `:dynamic` option for the `schedule` argument is available and the default as of Julia 1.8.
 
@@ -685,19 +652,6 @@ the given iterated values as they are produced. As soon as one task finishes its
 the next value from the iterator. Work done by any individual task is not necessarily on
 contiguous values from the iterator. The given iterator may produce values forever, only the
 iterator interface is required (no indexing).
-
-Use `:greedy` when:
-- iteration times are non-uniform or have a large spread (e.g. one item takes 10× longer than another)
-- the iterator is non-indexable (e.g. a `Channel` or a lazy iterator)
-
-For array comprehensions, `:greedy` does **not** guarantee that the output elements appear
-in the same order as the input (unlike `:dynamic` and `:static`). Use `sort` on the result
-if order matters.
-
-For array comprehensions over an `AbstractArray`, workers steal chunks of indices atomically
-(fast, low-overhead). For non-indexable iterators (e.g. a `Channel`), a bounded producer
-channel feeds all worker tasks concurrently without materializing the iterator first,
-preserving true streaming semantics.
 
 This scheduling option is generally a good choice if the workload of individual iterations
 is not uniform/has a large spread.
@@ -712,9 +666,6 @@ them, assigning each task specifically to each thread. In particular, the value 
 [`threadid()`](@ref Threads.threadid) is guaranteed to be constant within one iteration.
 Specifying `:static` is an error if used from inside another `@threads` loop or from a
 thread other than 1.
-
-Use `:static` only when `threadid()` stability within an iteration is required for
-compatibility with existing code.
 
 !!! note
     `:static` scheduling exists for supporting transition of code written before Julia 1.3.

--- a/test/threads_comprehensions.jl
+++ b/test/threads_comprehensions.jl
@@ -47,12 +47,12 @@ using .Main.OffsetArrays
         # Test greedy scheduling with filter (does not guarantee element order)
         result_greedy = @threads :greedy [i^2 for i in 1:n if iseven(i)]
         @test sort(result_greedy) == expected
-        @test typeof(result_greedy) == typeof(expected)
+        @test_broken typeof(result_greedy) == typeof(expected)
         g_untyped(m) = Threads.@threads :greedy [i for i in 1:m if iseven(i)]
         g_typed(m)   = Threads.@threads :greedy Int[i for i in 1:m if iseven(i)]
         g_untyped(10); g_typed(10)
-        @test @allocations(g_untyped(1_000_000)) < 1_000
-        @test @allocations(g_typed(1_000_000)) < 1_000
+        @test_broken @allocations(g_untyped(1_000_000)) < 1_000
+        @test_broken @allocations(g_typed(1_000_000)) < 1_000
 
         # Test with more complex filter
         expected_complex = [i for i in 1:100 if i % 3 == 0 && i > 20]
@@ -174,13 +174,13 @@ using .Main.OffsetArrays
 
         result_greedy = @threads :greedy [x for x in t]
         @test sort(result_greedy) == sort(collect(t))
-        @test typeof(result_greedy) == typeof([x for x in t])
+        @test_broken typeof(result_greedy) == typeof([x for x in t])
 
         # :greedy with filter over Tuple (uses atomic work-stealing path)
         result_greedy_filt = @threads :greedy [x for x in t if x > 25]
         expected_greedy_filt = [x for x in t if x > 25]
         @test sort(result_greedy_filt) == expected_greedy_filt
-        @test typeof(result_greedy_filt) == typeof(expected_greedy_filt)
+        @test_broken typeof(result_greedy_filt) == typeof(expected_greedy_filt)
 
         result_filter = @threads [x for x in t if x > 25]
         @test result_filter == [x for x in t if x > 25]
@@ -202,7 +202,7 @@ using .Main.OffsetArrays
         result_ch_filter = @threads :greedy [i for i in ch2 if iseven(i)]
         expected_ch_filter = [i for i in 1:10 if iseven(i)]
         @test sort(result_ch_filter) == expected_ch_filter
-        @test typeof(result_ch_filter) == typeof(expected_ch_filter)
+        @test_broken typeof(result_ch_filter) == typeof(expected_ch_filter)
     end
 
     # Test mixed element types
@@ -223,7 +223,7 @@ using .Main.OffsetArrays
         result_greedy_filt = @threads :greedy [x for x in [1, 2.0, "3", 4, 5.0] if x isa Number]
         expected_greedy_filt = [x for x in [1, 2.0, "3", 4, 5.0] if x isa Number]
         @test sort(result_greedy_filt, by=string) == sort(expected_greedy_filt, by=string)
-        @test typeof(result_greedy_filt) == typeof(expected_greedy_filt)
+        @test_broken typeof(result_greedy_filt) == typeof(expected_greedy_filt)
 
         # Test with :static scheduler
         result_static = @threads :static [x for x in [1, 2.0, "3"]]
@@ -250,7 +250,7 @@ using .Main.OffsetArrays
         # :greedy with type-widening body — must match serial's promote_typejoin result (does not guarantee order)
         result_greedy = @threads :greedy [i == 50 ? 1.0 : i for i in 1:100]
         @test sort(result_greedy) == sort(expected)
-        @test typeof(result_greedy) == typeof(expected)
+        @test_broken typeof(result_greedy) == typeof(expected)
 
         # Verify widening allocations aren't significantly worse than serial
         widen_threaded() = @threads [i == 100 ? 1.0 : i for i in 1:100_000]

--- a/test/threads_comprehensions.jl
+++ b/test/threads_comprehensions.jl
@@ -34,22 +34,40 @@ using .Main.OffsetArrays
         n = 100
 
         # Test default scheduling with filter
-        result = @threads [i^2 for i in 1:n if iseven(i)]
         expected = [i^2 for i in 1:n if iseven(i)]
+        result = @threads [i^2 for i in 1:n if iseven(i)]
         @test result == expected
+        @test typeof(result) == typeof(expected)
 
         # Test static scheduling with filter
         result_static = @threads :static [i^2 for i in 1:n if iseven(i)]
         @test result_static == expected
+        @test typeof(result_static) == typeof(expected)
 
-        # Test greedy scheduling with filter (does not guarantee order)
+        # Test greedy scheduling with filter (does not guarantee element order)
         result_greedy = @threads :greedy [i^2 for i in 1:n if iseven(i)]
         @test sort(result_greedy) == expected
+        @test typeof(result_greedy) == typeof(expected)
+        g_untyped(m) = Threads.@threads :greedy [i for i in 1:m if iseven(i)]
+        g_typed(m)   = Threads.@threads :greedy Int[i for i in 1:m if iseven(i)]
+        g_untyped(10); g_typed(10)
+        @test @allocations(g_untyped(1_000_000)) < 1_000
+        @test @allocations(g_typed(1_000_000)) < 1_000
 
         # Test with more complex filter
-        result_complex = @threads [i for i in 1:100 if i % 3 == 0 && i > 20]
         expected_complex = [i for i in 1:100 if i % 3 == 0 && i > 20]
+        result_complex = @threads [i for i in 1:100 if i % 3 == 0 && i > 20]
         @test result_complex == expected_complex
+        @test typeof(result_complex) == typeof(expected_complex)
+
+        # Allocations must be O(nthreads), not O(n): thread-local buffers mean one
+        # push! per passing element with no per-element heap tuple or channel put!.
+        f_untyped(m) = Threads.@threads [i for i in 1:m if iseven(i)]
+        f_typed(m)   = Threads.@threads Int[i for i in 1:m if iseven(i)]
+        f_untyped(10); f_typed(10)  # warm up
+        for f in (f_untyped, f_typed)
+            @test @allocations(f(1_000_000)) < 1_000
+        end
     end
 
     # Test edge cases
@@ -92,8 +110,8 @@ using .Main.OffsetArrays
     # Test multiple loops comprehensions
     @testset "multiple loops comprehensions" begin
         # Test simple multiple loops
-        result = @threads [i + j for i in 1:3, j in 1:3]
         expected = [i + j for i in 1:3, j in 1:3]
+        result = @threads [i + j for i in 1:3, j in 1:3]
         @test size(result) == size(expected)
         @test result == expected  # default scheduling preserves order and dimensions
 
@@ -125,8 +143,8 @@ using .Main.OffsetArrays
     @testset "non-indexable iterators" begin
         # Test with Iterators.flatten
         flat_iter = Iterators.flatten([1:3, 4:6])
+        expected = [i^2 for i in flat_iter]
         result = @threads [i^2 for i in flat_iter]
-        expected = [i^2 for i in 1:6]
         @test result == expected
 
         # Test with greedy scheduling for non-indexable (does not guarantee order)
@@ -156,6 +174,13 @@ using .Main.OffsetArrays
 
         result_greedy = @threads :greedy [x for x in t]
         @test sort(result_greedy) == sort(collect(t))
+        @test typeof(result_greedy) == typeof([x for x in t])
+
+        # :greedy with filter over Tuple (uses atomic work-stealing path)
+        result_greedy_filt = @threads :greedy [x for x in t if x > 25]
+        expected_greedy_filt = [x for x in t if x > 25]
+        @test sort(result_greedy_filt) == expected_greedy_filt
+        @test typeof(result_greedy_filt) == typeof(expected_greedy_filt)
 
         result_filter = @threads [x for x in t if x > 25]
         @test result_filter == [x for x in t if x > 25]
@@ -175,34 +200,57 @@ using .Main.OffsetArrays
         foreach(i -> put!(ch2, i), 1:10)
         close(ch2)
         result_ch_filter = @threads :greedy [i for i in ch2 if iseven(i)]
-        @test sort(result_ch_filter) == [2, 4, 6, 8, 10]
+        expected_ch_filter = [i for i in 1:10 if iseven(i)]
+        @test sort(result_ch_filter) == expected_ch_filter
+        @test typeof(result_ch_filter) == typeof(expected_ch_filter)
     end
 
     # Test mixed element types
     @testset "mixed element types" begin
-        # Test that mixed types return Vector{Any} like normal comprehensions
-        result = @threads [x for x in [1, 2.0, "3"]]
+        # Test that mixed types return the same eltype as the serial comprehension
         expected = [x for x in [1, 2.0, "3"]]
+        result = @threads [x for x in [1, 2.0, "3"]]
         @test result == expected
-        @test eltype(result) == eltype(expected)
+        @test typeof(result) == typeof(expected)
 
         # Test with :greedy scheduler (does not guarantee order)
+        # :greedy with heterogeneous body — eltype must match serial
         result_greedy = @threads :greedy [x for x in [1, 2.0, "3"]]
         @test sort(result_greedy, by=string) == sort(expected, by=string)
-        @test result_greedy isa Vector{Any}
+        @test typeof(result_greedy) == typeof(expected)
+
+        # :greedy with filter and heterogeneous body
+        result_greedy_filt = @threads :greedy [x for x in [1, 2.0, "3", 4, 5.0] if x isa Number]
+        expected_greedy_filt = [x for x in [1, 2.0, "3", 4, 5.0] if x isa Number]
+        @test sort(result_greedy_filt, by=string) == sort(expected_greedy_filt, by=string)
+        @test typeof(result_greedy_filt) == typeof(expected_greedy_filt)
 
         # Test with :static scheduler
         result_static = @threads :static [x for x in [1, 2.0, "3"]]
         @test result_static == expected
-        @test eltype(result_static) == eltype(expected)
+        @test typeof(result_static) == typeof(expected)
     end
 
     # Test type widening when body expression produces heterogeneous types
     @testset "body expression type widening" begin
-        result = @threads [i == 50 ? 1.0 : i for i in 1:100]
         expected = [i == 50 ? 1.0 : i for i in 1:100]
+        result = @threads [i == 50 ? 1.0 : i for i in 1:100]
         @test result == expected
-        @test eltype(result) == eltype(expected)
+        @test typeof(result) == typeof(expected)
+
+        # Filtered body with type widening: must match serial's promote_typejoin result
+        expected_filt = [i == 50 ? 1.0 : i for i in 1:100 if iseven(i)]
+        result_filt = @threads [i == 50 ? 1.0 : i for i in 1:100 if iseven(i)]
+        result_filt_static = @threads :static [i == 50 ? 1.0 : i for i in 1:100 if iseven(i)]
+        @test result_filt == expected_filt
+        @test typeof(result_filt) == typeof(expected_filt)
+        @test result_filt_static == expected_filt
+        @test typeof(result_filt_static) == typeof(expected_filt)
+
+        # :greedy with type-widening body — must match serial's promote_typejoin result (does not guarantee order)
+        result_greedy = @threads :greedy [i == 50 ? 1.0 : i for i in 1:100]
+        @test sort(result_greedy) == sort(expected)
+        @test typeof(result_greedy) == typeof(expected)
 
         # Verify widening allocations aren't significantly worse than serial
         widen_threaded() = @threads [i == 100 ? 1.0 : i for i in 1:100_000]
@@ -233,13 +281,14 @@ using .Main.OffsetArrays
         # Typed comprehension with filter
         result_filtered = @threads Int[i^2 for i in 1:20 if iseven(i)]
         expected_filtered = Int[i^2 for i in 1:20 if iseven(i)]
-        @test result_filtered isa Vector{Int}
         @test result_filtered == expected_filtered
+        @test typeof(result_filtered) == typeof(expected_filtered)
 
         # Typed comprehension with filter and greedy (does not guarantee order)
         result_greedy_filt = @threads :greedy Float64[i for i in 1:20 if i > 10]
-        @test result_greedy_filt isa Vector{Float64}
-        @test sort(result_greedy_filt) == Float64.(11:20)
+        expected_greedy_filt = Float64[i for i in 1:20 if i > 10]
+        @test typeof(result_greedy_filt) == typeof(expected_greedy_filt)
+        @test sort(result_greedy_filt) == expected_greedy_filt
 
         # Typed multi-dimensional comprehension
         result_2d = @threads Float64[i + j for i in 1:3, j in 1:4]
@@ -273,8 +322,8 @@ using .Main.OffsetArrays
     # Test non-1-based indexing preserves axes
     @testset "non-1-based indexing" begin
         r = OffsetArray(1:5, -2:2)
-        result = @threads [x^2 for x in r]
         expected = [x^2 for x in r]
+        result = @threads [x^2 for x in r]
         @test result == expected
         @test axes(result) == axes(expected)
 


### PR DESCRIPTION
Continuation of #59019

- The filtered array comprehensions performance had some significant room for improvement. See benchmarks below.
- The greedy schedule option doesn't perform as well as the others and returns `Any[]` in the untyped case, so tests added and marked as broken as appropriate. @Seelengrab you may have views/ideas on that. I'm not sure what to optimize it for.

Developed with Claude

<details>
<summary>Benchmark script</summary>

```julia
using Chairmarks, Printf

f(i::Int) = rand(Int)

# --- Serial comprehensions ---
serial_untyped(n::Int)        = [f(i) for i in 1:n]
serial_typed(n::Int)          = Int[f(i) for i in 1:n]
serial_filtered(n::Int)       = [f(i) for i in 1:n if iseven(i)]
serial_filtered_typed(n::Int) = Int[f(i) for i in 1:n if iseven(i)]

# --- Threaded comprehensions ---
threaded_untyped(n::Int)        = Threads.@threads [f(i) for i in 1:n]
threaded_typed(n::Int)          = Threads.@threads Int[f(i) for i in 1:n]
threaded_filtered(n::Int)       = Threads.@threads [f(i) for i in 1:n if iseven(i)]
threaded_filtered_typed(n::Int) = Threads.@threads Int[f(i) for i in 1:n if iseven(i)]

function fmt_time(t)
    t < 1e-6 && return @sprintf("%9.2f ns", t * 1e9)
    t < 1e-3 && return @sprintf("%9.2f μs", t * 1e6)
    t < 1.0  && return @sprintf("%9.2f ms", t * 1e3)
    return         @sprintf("%9.2f s",  t)
end

const BENCHMARKS = [
    ("[i for i in 1:n]",                 serial_untyped,        threaded_untyped),
    ("Int[i for i in 1:n]",              serial_typed,          threaded_typed),
    ("[i for i in 1:n if iseven(i)]",    serial_filtered,       threaded_filtered),
    ("Int[i for i in 1:n if iseven(i)]", serial_filtered_typed, threaded_filtered_typed),
]

const COL   = 40   # expression label width
const TYCOL = 16   # array type column width
const TCOL  = 12   # time column (fmt_time always returns 12 chars)
const BCOL  = 13   # bytes column (up to ~10-digit numbers)
const ACOL  = 11   # allocs column (up to ~9-digit numbers)
# total row width: 1 + COL + (3 + TYCOL + 1 + TCOL + 1 + BCOL + 1 + ACOL) * 2
const RULEWIDTH = 1 + COL + 2*(3 + TYCOL + 1 + TCOL + 1 + BCOL + 1 + ACOL)
const RULE = repeat('─', RULEWIDTH)

function run_benchmarks()
    println("\nArray Comprehension Benchmark: Serial vs Threads.@threads")
    @printf("Julia %s | %d thread(s)\n", VERSION, Threads.nthreads())

    for n in (1_000, 1_000_000, 10_000_000)
        println("\n", "═"^RULEWIDTH)
        @printf(" N = %d\n", n)
        println(RULE)
        @printf(" %-*s │ %-*s %*s %*s %*s │ %-*s %*s %*s %*s\n",
            COL, "Expression",
            TYCOL, "Type",    TCOL, "Serial",   BCOL, "Bytes",  ACOL, "Allocs",
            TYCOL, "Type",    TCOL, "@threads", BCOL, "Bytes",  ACOL, "Allocs")
        println(RULE)

        for (label, sfn, tfn) in BENCHMARKS
            s_type = string(typeof(sfn(n)))
            t_type = string(typeof(tfn(n)))
            s = @b sfn(n)
            t = @b tfn(n)
            @printf(" %-*s │ %-*s %*s %*d %*d │ %-*s %*s %*d %*d\n",
                COL, label,
                TYCOL, s_type, TCOL, fmt_time(s.time), BCOL, s.bytes, ACOL, s.allocs,
                TYCOL, t_type, TCOL, fmt_time(t.time), BCOL, t.bytes, ACOL, t.allocs)
        end

        println(RULE)
    end
end

run_benchmarks()
```

</details>

Master
```
Array Comprehension Benchmark: Serial vs Threads.@threads
Julia 1.14.0-DEV.1903 | 6 thread(s)

═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 N = 1000
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Expression                               │ Type                   Serial         Bytes      Allocs │ Type                 @threads         Bytes      Allocs
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 [i for i in 1:n]                         │ Vector{Int64}         1.10 μs          8256           3 │ Vector{Int64}         7.08 μs         11200          50
 Int[i for i in 1:n]                      │ Vector{Int64}         1.10 μs          8256           3 │ Vector{Int64}         6.75 μs         10576          35
 [i for i in 1:n if iseven(i)]            │ Vector{Int64}         1.50 μs          6832           8 │ Vector{Int64}       209.29 μs        163568        6248
 Int[i for i in 1:n if iseven(i)]         │ Vector{Int64}         1.49 μs          6800           7 │ Vector{Int64}       322.33 μs        194992        7212
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 N = 1000000
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Expression                               │ Type                   Serial         Bytes      Allocs │ Type                 @threads         Bytes      Allocs
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 [i for i in 1:n]                         │ Vector{Int64}         1.07 ms       8011840           3 │ Vector{Int64}       574.54 μs       8014784          50
 Int[i for i in 1:n]                      │ Vector{Int64}         1.02 ms       8011840           3 │ Vector{Int64}       255.58 μs       8014160          35
 [i for i in 1:n if iseven(i)]            │ Vector{Int64}         1.59 ms      13597680          28 │ Vector{Int64}       401.30 ms     474654688    24464667
 Int[i for i in 1:n if iseven(i)]         │ Vector{Int64}         1.59 ms      13597648          27 │ Vector{Int64}       535.28 ms     519276448    26253527
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 N = 10000000
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Expression                               │ Type                   Serial         Bytes      Allocs │ Type                 @threads         Bytes      Allocs
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 [i for i in 1:n]                         │ Vector{Int64}        11.00 ms      80003136           3 │ Vector{Int64}         5.39 ms      80006080          50
 Int[i for i in 1:n]                      │ Vector{Int64}        10.97 ms      80003136           3 │ Vector{Int64}         2.19 ms      80005456          35
 [i for i in 1:n if iseven(i)]            │ Vector{Int64}        21.88 ms     152812688          38 │ Vector{Int64}          4.68 s    5563294480   295129646
 Int[i for i in 1:n if iseven(i)]         │ Vector{Int64}        45.28 ms     152812656          37 │ Vector{Int64}          6.10 s    6070076960   316484063
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

```


PR

```
Array Comprehension Benchmark: Serial vs Threads.@threads
Julia 1.14.0-DEV.1903 | 6 thread(s)

═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 N = 1000
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Expression                               │ Type                   Serial         Bytes      Allocs │ Type                 @threads         Bytes      Allocs
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 [i for i in 1:n]                         │ Vector{Int64}         1.08 μs          8256           3 │ Vector{Int64}         7.33 μs         11200          50
 Int[i for i in 1:n]                      │ Vector{Int64}         1.08 μs          8256           3 │ Vector{Int64}         7.42 μs         10576          35
 [i for i in 1:n if iseven(i)]            │ Vector{Int64}         1.48 μs          6832           8 │ Vector{Int64}         7.75 μs         16480          67
 Int[i for i in 1:n if iseven(i)]         │ Vector{Int64}         1.48 μs          6800           7 │ Vector{Int64}         6.71 μs         16480          67
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 N = 1000000
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Expression                               │ Type                   Serial         Bytes      Allocs │ Type                 @threads         Bytes      Allocs
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 [i for i in 1:n]                         │ Vector{Int64}         1.07 ms       8011840           3 │ Vector{Int64}       572.96 μs       8014784          50
 Int[i for i in 1:n]                      │ Vector{Int64}         1.02 ms       8011840           3 │ Vector{Int64}       236.00 μs       8014160          35
 [i for i in 1:n if iseven(i)]            │ Vector{Int64}         1.58 ms      13597680          28 │ Vector{Int64}       584.00 μs      18919008         163
 Int[i for i in 1:n if iseven(i)]         │ Vector{Int64}         1.60 ms      13597648          27 │ Vector{Int64}       593.12 μs      18919008         163
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 N = 10000000
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Expression                               │ Type                   Serial         Bytes      Allocs │ Type                 @threads         Bytes      Allocs
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 [i for i in 1:n]                         │ Vector{Int64}        10.71 ms      80003136           3 │ Vector{Int64}         5.42 ms      80006080          50
 Int[i for i in 1:n]                      │ Vector{Int64}        10.83 ms      80003136           3 │ Vector{Int64}         2.19 ms      80005456          35
 [i for i in 1:n if iseven(i)]            │ Vector{Int64}        16.83 ms     164510864          38 │ Vector{Int64}        10.67 ms     197620064         211
 Int[i for i in 1:n if iseven(i)]         │ Vector{Int64}        16.73 ms     164510832          37 │ Vector{Int64}        10.39 ms     186364256         211
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```