### PR TITLE
Fix world update after resolving definition effects in `jl_eval_thunk`

### DIFF
--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -732,8 +732,7 @@ JL_DLLEXPORT jl_value_t *jl_eval_thunk(jl_module_t *JL_NONNULL m, jl_code_info_t
     jl_atomic_store_relaxed(&jl_filename, toplevel_filename);
 
     size_t last_age = ct->world_age;
-    size_t world = jl_atomic_load_acquire(&jl_world_counter);
-    ct->world_age = world;
+    ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
 
     int has_ccall = 0, has_defs = 0, has_loops = 0, has_opaque = 0, forced_compile = 0;
     body_attributes((jl_array_t*)thk->code, &has_ccall, &has_defs, &has_loops, &has_opaque, &forced_compile);
@@ -750,6 +749,9 @@ JL_DLLEXPORT jl_value_t *jl_eval_thunk(jl_module_t *JL_NONNULL m, jl_code_info_t
         // use codegen
         mfunc = jl_method_instance_for_thunk(thk, m);
         jl_resolve_definition_effects_in_ir((jl_array_t *)thk->code, m, NULL, NULL, 0);
+        // Update world again as resolving definition effects (eg ccall return type) may have side effects
+        size_t world = jl_atomic_load_acquire(&jl_world_counter);
+        ct->world_age = world;
         // Don't infer blocks containing e.g. method definitions, since it's probably
         // not worthwhile.
         if (!has_defs && jl_get_module_infer(m) != 0) {

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -616,3 +616,14 @@ end
 # Test that the hash function works without world age issues
 @test hash(bar59429, UInt(0)) isa UInt
 end
+
+# jl_eval_thunk should update the world after resolving definition effects but
+# before "actually running" the thunk as some such code - such as that
+# computing the return type of a ccall - may have arbitrary side effects. (Note
+# it's not clear there's any valid use for such side effects in clean code but
+# the runtime should still handle it gracefully.)
+rettype_with_side_effect() = eval(:(rettype_side_effect = "blah"; Cint))
+let
+    @test rettype_side_effect == "blah"
+    ccall(:strlen, rettype_with_side_effect(), (Cstring,), "xx")
+end


### PR DESCRIPTION
PR #60528 removed a world age update after
`jl_resolve_definition_effects` as part of a larger refactoring. However `jl_resolve_definition_effects` evaluates selected subexpressions of a thunk - such as the ccall return type - and this may run arbitrary code. Thus a world age update seems required for consistency.

IIUC this is the fix requested in the post-commit review by @vtjnash here https://github.com/JuliaLang/julia/pull/60528/files#r2705468506

(Side note - does anyone have an example of code which isn't actively perverse and where this would be required? I think this is good to have regardless (at least as long as we allow arbitrary code to run "before" running the thunk proper) but I couldn't think of an example where this is required to run clean user code.)