### PR TITLE
[release 1.12] build: add -include cstdint for GCC 15+ builds

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -594,6 +594,11 @@ JCXXFLAGS  := $(JCXXFLAGS_GCC)
 DEBUGFLAGS := $(DEBUGFLAGS_GCC)
 SHIPFLAGS  := $(SHIPFLAGS_GCC) $(BOLT_CFLAGS_GCC)
 BOLT_CFLAGS  := $(BOLT_CFLAGS_GCC)
+# GCC 15+ requires explicit <cstdint> for bundled LLVM headers (#58478)
+GCC_MAJOR := $(shell $(CXX) -dumpversion 2>/dev/null | cut -d. -f1)
+ifeq ($(shell test $(GCC_MAJOR) -ge 15 2>/dev/null && echo yes),yes)
+JCXXFLAGS  += -include cstdint
+endif
 endif
 
 ifeq ($(USECLANG),1)


### PR DESCRIPTION
## note: this is for 1.12 only

this problem does not exist on the trunk.

GCC 15 removed implicit transitive includes of `<cstdint>`, causing build failures in bundled LLVM 18 headers that use `uint64_t`. This detects GCC >= 15 and force-includes `<cstdint>` via `JCXXFLAGS`.

Alternative approach: #61353

Fixes #58478

This PR was written with the assistance of generative AI (Claude).