### PR TITLE
[release 1.12] deps: bump LLVM to julia-18.1.7-5 for GCC 15 compat

### DIFF
--- a/deps/llvm.version
+++ b/deps/llvm.version
@@ -7,9 +7,9 @@ LLVM_ASSERT_JLL_VER := 18.1.7+5
 # Version number of LLVM
 LLVM_VER := 18.1.7
 # Git branch name in `LLVM_GIT_URL` repository
-LLVM_BRANCH=julia-18.1.7-4
+LLVM_BRANCH=julia-18.1.7-5
 # Git ref in `LLVM_GIT_URL` repository
-LLVM_SHA1=julia-18.1.7-4
+LLVM_SHA1=julia-18.1.7-5
 
 ## Following options are used to automatically fetch patchset from Julia's fork.  This is
 ## useful if you want to build an external LLVM while still applying Julia's patches.
@@ -20,4 +20,4 @@ LLVM_JULIA_DIFF_GITHUB_REPO := https://github.com/llvm/llvm-project
 # Base GitHub ref for generating the diff.
 LLVM_BASE_REF := llvm:llvmorg-18.1.7
 # Julia fork's GitHub ref for generating the diff.
-LLVM_JULIA_REF := JuliaLang:julia-18.1.7-4
+LLVM_JULIA_REF := JuliaLang:julia-18.1.7-5


### PR DESCRIPTION
Bump the LLVM source build pin from `julia-18.1.7-4` to a _yet-unmade_ `julia-18.1.7-5` tag to include the upstream `cstdint` patches that fix compilation with GCC 15.

This PR requires tag `julia-18.1.7-5` to be cut on JuliaLang/llvm-project at the current head of `julia-release/18.x` (`742dca0a1d`).

Alternative approach: #61352

Fixes #58478

This PR was written with the assistance of generative AI (Claude).