### PR TITLE
deps: re-sign bundled zstd on macOS

### DIFF
--- a/deps/zstd.mk
+++ b/deps/zstd.mk
@@ -48,10 +48,13 @@ post-install-zstd: $(build_prefix)/manifest/zstd $(PATCHELF_MANIFEST)
 	[ -e $(build_private_libexecdir)/zstd$(EXE) ]
 	[ -e $(build_private_libexecdir)/zstdmt$(EXE) ]
 ifeq ($(OS), Darwin)
+	# zstd is relocated from bin/ to libexec/julia/, so its JLL rpath must be updated to keep finding ../libzstd.
+	# but this invalidates the existing signature, and macOS can then refuse to launch zstd, so also call codesign.
 	for j in zstd zstdmt ; do \
 		[ -L $(build_private_libexecdir)/$$j ] && continue; \
 		install_name_tool -rpath @executable_path/$(reverse_build_private_libexecdir_rel) @loader_path/$(build_libdir_rel) $(build_private_libexecdir)/$$j 2>/dev/null || true; \
 		install_name_tool -rpath @loader_path/$(build_libdir_rel) @executable_path/$(reverse_build_private_libexecdir_rel) $(build_private_libexecdir)/$$j || exit 1; \
+		codesign -s - -f $(build_private_libexecdir)/$$j || exit 1; \
 	done
 else ifneq (,$(findstring $(OS),Linux FreeBSD))
 	for j in zstd zstdmt ; do \

--- a/stdlib/Zstd_jll/test/runtests.jl
+++ b/stdlib/Zstd_jll/test/runtests.jl
@@ -4,4 +4,7 @@ using Test, Zstd_jll
 
 @testset "Zstd_jll" begin
     @test ccall((:ZSTD_versionNumber, libzstd), Cuint, ()) == 1_05_07
+    let version = read(`$(zstd()) --version`, String)
+        @test contains(version, "Zstandard CLI")
+    end
 end


### PR DESCRIPTION
Rewriting the bundled zstd executables with install_name_tool
invalidates their existing signatures on macOS. Re-sign them ad
hoc after updating the rpath so the CLI remains launchable for Pkg
archive decompression.

Add a regression test that runs the bundled zstd executable
instead of only checking that libzstd can be loaded.

Fixes #61354 (but see discussion there as to whether it really does?)

Co-authored-by: Codex <codex@openai.com>
