### PR TITLE
[JuliaLowering] Fix undefined variable in labeled `continue` desugaring

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -4709,7 +4709,7 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
             [K"continue" [K"Placeholder"]] ->
                 @ast ctx ex [K"break" "loop-cont"::K"symboliclabel"]
             [K"continue" [K"Identifier"]] ->
-                @ast ctx ex [K"break" string(label.name_val, "#cont")::K"symboliclabel"]
+                @ast ctx ex [K"break" string(ex[1].name_val, "#cont")::K"symboliclabel"]
         end
     elseif k == K"comparison"
         expand_forms_2(ctx, expand_compare_chain(ctx, ex))

--- a/JuliaLowering/test/loops.jl
+++ b/JuliaLowering/test/loops.jl
@@ -223,6 +223,21 @@ let
 end
 """) == [(1,2), (1,4), (2,2), (2,4)]
 
+# Labeled continue skips to next iteration of the named outer loop
+@test JuliaLowering.include_string(test_mod, """
+let
+    a = []
+    @label outer for i = 1:3
+        for j = 1:3
+            if j == 2
+                continue outer
+            end
+            push!(a, (i,j))
+        end
+    end
+    a
+end
+""") == [(1,1), (2,1), (3,1)]
 
 end
 


### PR DESCRIPTION
JETLS found that `continue label` was referencing `label.name_val` which is undefined; it should be `ex[1].name_val` to access the label identifier node. Add a test for labeled `continue` in `@label` loops.