### PR TITLE
Fix field docstrings for `const` fields in mutable structs

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -368,6 +368,10 @@ function metadata(__source__, __module__, expr, ismodule)
         last_docstr = nothing
         for each in (expr.args[3]::Expr).args
             eachex = unescape(each)
+            # Unwrap `const` or `atomic` field modifiers in mutable structs
+            if isexpr(eachex, :const, 1) || isexpr(eachex, :atomic, 1)
+                eachex = eachex.args[1]
+            end
             if isa(eachex, Symbol) || isexpr(eachex, :(::))
                 # a field declaration
                 if last_docstr !== nothing

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -234,6 +234,18 @@ mutable struct FieldDocs
     three
 end
 
+# Issue #58820 -- const field docstrings in mutable structs.
+"ConstFieldDocs"
+mutable struct ConstFieldDocs
+    "mutable_field"
+    mutable_field
+    "const_field"
+    const const_field
+    "const_typed_field"
+    const const_typed_field::Int
+    undocumented
+end
+
 "h/0-3"
 h(x = 1, y = 2, z = 3) = x + y + z
 
@@ -399,6 +411,14 @@ end
 let fields = meta(DocsTest)[@var(DocsTest.FieldDocs)].docs[Union{}].data[:fields]
     @test haskey(fields, :one) && fields[:one] == "one"
     @test haskey(fields, :two) && fields[:two] == doc"two"
+end
+
+# Issue #58820
+let fields = meta(DocsTest)[@var(DocsTest.ConstFieldDocs)].docs[Union{}].data[:fields]
+    @test haskey(fields, :mutable_field) && fields[:mutable_field] == "mutable_field"
+    @test haskey(fields, :const_field) && fields[:const_field] == "const_field"
+    @test haskey(fields, :const_typed_field) && fields[:const_typed_field] == "const_typed_field"
+    @test !haskey(fields, :undocumented)
 end
 
 let a = @doc(DocsTest.multidoc),


### PR DESCRIPTION
Fixes #58820.

The `metadata` function in `base/docs/Docs.jl` extracts field documentation from struct body expressions by matching bare `Symbol` or `Expr(:(::), ...)` nodes. For `const` (and `atomic`) fields in mutable structs, the field declaration is wrapped in an additional `Expr(:const, ...)` layer that wasn't being unwrapped, so docstrings placed before `const` fields were silently dropped.

**Before:**
```julia
mutable struct SomeStruct
    "a field docstring"
    mutable_field
    "another field docstring"    # ← silently dropped
    const const_field
end
```
```
help?> SomeStruct.const_field
  SomeStruct has fields mutable_field, and const_field.
```

**After:**
```
help?> SomeStruct.const_field
  another field docstring
```

The fix unwraps `:const` and `:atomic` expression heads before checking whether the expression is a field declaration. This is the same approach used by `astname` (which already lists `:const` and `:atomic` in its head-matching logic for name extraction).

Includes a test with `const` fields (both bare and typed) to prevent regression.

**Disclosure:** This PR contains contributions from a generative AI tool. All changes have been reviewed.