### PR TITLE
Escape `@nospecialize` macro output

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -288,7 +288,7 @@ ccall(:jl_toplevel_eval_in, Any, (Any, Any),
 function iterate end
 
 macro nospecialize(x)
-    _expr(:meta, :nospecialize, x)
+    _expr(:escape, _expr(:meta, :nospecialize, x))
 end
 Expr(@nospecialize args...) = _expr(args...)
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -124,7 +124,7 @@ macro nospecialize(vars...)
             var.head = :kw
         end
     end
-    return Expr(:meta, :nospecialize, vars...)
+    return Expr(:escape, Expr(:meta, :nospecialize, vars...))
 end
 
 """
@@ -141,7 +141,7 @@ macro specialize(vars...)
             var.head = :kw
         end
     end
-    return Expr(:meta, :specialize, vars...)
+    return Expr(:escape, Expr(:meta, :specialize, vars...))
 end
 
 """


### PR DESCRIPTION
`@nospecialize` and `@specialize` refer to names passed as macro arguments, so
should theoretically escape them in their expansion.  They currently work
without escaping because macroexpand.scm makes a special case for `:meta` forms.
Unfortunately, that special handling escapes `:meta` too aggressively:

```
julia> macro mac(x); x; end
@mac (macro with 1 method)

julia> ex = @macroexpand @mac function f(@nospecialize(a))
                  a
              end
:(function Main.f($(Expr(:meta, :nospecialize, :a)))
      #= REPL[2]:1 =#
      #= REPL[2]:2 =#
      var"#2#a"
  end)

julia> func = @mac function f(@nospecialize(a))
                  a
              end
f (generic function with 1 method)

julia> func(1)
ERROR: UndefVarError: `#3#a` not defined in `Main`
```

This PR doesn't fix the above or change any current behaviour, but at least
ensures that JuliaLowering doesn't need to introduce the same bug.  There are
alternatives if this doesn't work, but all would be hacky.
