### PR TITLE
test: stop revise harness from tracking Core.Compiler (and thus fix `make test-revise-InteractiveUtils`)

### DIFF
--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -112,7 +112,6 @@ filter!(x->x!=".", LOAD_PATH)
 
 # Support for Revise
 function revise_trackall()
-    Revise.track(Core.Compiler)
     Revise.track(Base)
     for (id, mod) in Base.loaded_modules
         if id.name in STDLIBS


### PR DESCRIPTION
Fixes #61308.

Before this PR, `make test-revise-*` explicitly tracks `Core.Compiler`, which is enough to trigger the `make test-revise-InteractiveUtils` failure reported in #61308.

After this PR, we don't track `Core.Compiler`.

To test locally:

```bash
JULIA_PRECOMPILE=0 JULIA_TEST_FAILFAST=1 make test-revise-InteractiveUtils
```

🤖 Generated by Codex.