### PR TITLE
subtype: Use svec for uncertain tvar envout

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3036,6 +3036,26 @@ function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo, si::StmtIn
     return abstract_call_known(interp, f, arginfo, si, vtypes, sv, max_methods)
 end
 
+function reconstitute_sp_env(sparam_vals::Core.SimpleVector, spsig::UnionAll)
+    sparam_env = Any[]
+    i = 1
+    while isa(spsig, UnionAll)
+        val = sparam_vals[i]
+        if isa(val, Core.SimpleVector)
+            ub = val[end]
+            lb = length(val) == 2 ? val[1] : Union{}
+            push!(sparam_env, TypeVar(spsig.var.name, lb, ub))
+        elseif isvarargtype(val)
+            push!(sparam_env, TypeVar(:N, Union{}, Any))
+        else
+            push!(sparam_env, val)
+        end
+        spsig = spsig.body
+        i += 1
+    end
+    return sparam_env
+end
+
 function sp_type_rewrap(@nospecialize(T), mi::MethodInstance, isreturn::Bool)
     isref = false
     if unwrapva(T) === Bottom
@@ -3055,11 +3075,10 @@ function sp_type_rewrap(@nospecialize(T), mi::MethodInstance, isreturn::Bool)
         spsig = mi.def.sig
         if isa(spsig, UnionAll)
             if !isempty(mi.sparam_vals)
-                sparam_vals = Any[isvarargtype(v) ? TypeVar(:N, Union{}, Any) :
-                                  v for v in  mi.sparam_vals]
-                T = ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), T, spsig, sparam_vals)
+                sparam_env = reconstitute_sp_env(mi.sparam_vals, spsig)
+                T = ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), T, spsig, sparam_env)
                 isref && isreturn && T === Any && return Bottom # catch invalid return Ref{T} where T = Any
-                for v in sparam_vals
+                for v in sparam_env
                     if isa(v, TypeVar)
                         T = UnionAll(v, T)
                     end

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -728,7 +728,7 @@ function sptypes_from_meth_instance(mi::MethodInstance)
     sptypes = Vector{VarState}(undef, nvals)
     for i = 1:nvals
         v = spvals[i]
-        if v isa TypeVar
+        if v isa SimpleVector
             temp = sig
             for _ = 1:i-1
                 temp = temp.body
@@ -751,18 +751,18 @@ function sptypes_from_meth_instance(mi::MethodInstance)
                     end
                 end
             end
-            ub = unwraptv_ub(v)
+            ub = v[end]
             if has_free_typevars(ub)
                 ub = Any
             end
-            lb = unwraptv_lb(v)
+            lb = length(v) == 2 ? v[1] : Bottom
             if has_free_typevars(lb)
                 lb = Bottom
             end
             if Any === ub && lb === Bottom
                 ty = Any
             else
-                tv = TypeVar(v.name, lb, ub)
+                tv = TypeVar(vᵢ.name, lb, ub)
                 ty = UnionAll(tv, Type{tv})
             end
             @label ty_computed
@@ -775,7 +775,7 @@ function sptypes_from_meth_instance(mi::MethodInstance)
                     sig = mi.specTypes
                 end
                 @assert !has_free_typevars(sig)
-                constrains_param(v, sig, #=covariant=#true)
+                constrains_param(vᵢ, sig, #=covariant=#true)
             end)
         elseif isvarargtype(v)
             # if this parameter came from `func(..., ::Vararg{T,v})`,

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -786,7 +786,7 @@ function compileable_specialization(code::Union{MethodInstance,CodeInstance}, ef
         # If this caller does not want us to optimize calls to use their
         # declared compilesig, then it is also likely they would handle sparams
         # incorrectly if there were any unknown typevars, so we conservatively return nothing
-        if any(@nospecialize(t)->isa(t, TypeVar), mi.sparam_vals)
+        if any(@nospecialize(t)->isa(t, Core.SimpleVector), mi.sparam_vals)
             return nothing
         end
     end
@@ -855,7 +855,7 @@ end
 function validate_sparams(sparams::SimpleVector)
     for i = 1:length(sparams)
         spᵢ = sparams[i]
-        (isa(spᵢ, TypeVar) || isvarargtype(spᵢ)) && return false
+        (isa(spᵢ, Core.SimpleVector) || isvarargtype(spᵢ)) && return false
     end
     return true
 end
@@ -1749,22 +1749,32 @@ function ssa_substitute_op!(insert_node!::Inserter, subst_inst::Instruction, @no
         if head === :static_parameter
             spidx = e.args[1]::Int
             val = sparam_vals[spidx]
-            if !isa(val, TypeVar) && val !== Vararg
+            if !isa(val, Core.SimpleVector) && val !== Vararg
                 return quoted(val)
             else
                 flag = subst_inst[:flag]
-                maybe_undef = !has_flag(flag, IR_FLAG_NOTHROW) && isa(val, TypeVar)
+                maybe_undef = !has_flag(flag, IR_FLAG_NOTHROW) && isa(val, Core.SimpleVector)
                 (ret, tcheck_not) = insert_spval!(insert_node!, ssa_substitute.spvals_ssa::SSAValue, spidx, maybe_undef)
                 if maybe_undef
+                    spsig = ssa_substitute.mi.def.sig
+                    for j = 1:spidx
+                        spsig = (spsig::UnionAll).body
+                    end
+                    # Get the var name from the method signature, not from the sparam value
+                    # (which is now an svec marker, not a TypeVar)
+                    spname = let sig = ssa_substitute.mi.def.sig
+                        for _ = 1:spidx-1; sig = (sig::UnionAll).body; end
+                        (sig::UnionAll).var.name
+                    end
                     insert_node!(
-                        NewInstruction(Expr(:throw_undef_if_not, val.name, tcheck_not), Nothing))
+                        NewInstruction(Expr(:throw_undef_if_not, spname, tcheck_not), Nothing))
                 end
                 return ret
             end
         elseif head === :isdefined && isa(e.args[1], Expr) && e.args[1].head === :static_parameter
             spidx = (e.args[1]::Expr).args[1]::Int
             val = sparam_vals[spidx]
-            if !isa(val, TypeVar)
+            if !isa(val, Core.SimpleVector)
                 return true
             else
                 (_, tcheck_not) = insert_spval!(insert_node!, ssa_substitute.spvals_ssa::SSAValue, spidx, true)

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1695,7 +1695,7 @@ function may_invoke_generator(method::Method, @nospecialize(atype), sparams::Sim
 
     firstarg = 1
     for i = 1:nsparams
-        if isa(sparams[i], TypeVar)
+        if isa(sparams[i], Core.SimpleVector)
             if (ast_slotflag(code, firstarg + i) & SLOT_USED) != 0
                 return false
             end

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3102,11 +3102,12 @@ static bool uses_specsig(jl_value_t *sig, bool needsparams, jl_value_t *rettype,
 static std::pair<bool, bool> uses_specsig(jl_value_t *abi, jl_method_instance_t *lam, jl_value_t *rettype, bool prefer_specsig)
 {
     bool needsparams = false;
-    if (jl_is_method(lam->def.method)) {
+    if (jl_is_method(lam->def.method) && !(jl_is_datatype(lam->specTypes) && ((jl_datatype_t*)lam->specTypes)->isdispatchtuple)) {
         if ((size_t)jl_subtype_env_size(lam->def.method->sig) != jl_svec_len(lam->sparam_vals))
             needsparams = true;
         for (size_t i = 0; i < jl_svec_len(lam->sparam_vals); ++i) {
-            if (jl_is_typevar(jl_svecref(lam->sparam_vals, i)))
+            jl_value_t *sp = jl_svecref(lam->sparam_vals, i);
+            if (jl_is_svec(sp) && jl_svec_len(sp) >= 1)
                 needsparams = true;
         }
     }
@@ -3290,7 +3291,7 @@ static jl_value_t *static_eval(jl_codectx_t &ctx, jl_value_t *ex)
             size_t idx = jl_unbox_long(jl_exprarg(e, 0));
             if (idx <= jl_svec_len(ctx.linfo->sparam_vals)) {
                 jl_value_t *e = jl_svecref(ctx.linfo->sparam_vals, idx - 1);
-                if (jl_is_typevar(e))
+                if (jl_is_svec(e))
                     return NULL;
                 return e;
             }
@@ -5773,20 +5774,24 @@ static jl_cgval_t emit_sparam(jl_codectx_t &ctx, size_t i)
 {
     if (jl_svec_len(ctx.linfo->sparam_vals) > 0) {
         jl_value_t *e = jl_svecref(ctx.linfo->sparam_vals, i);
-        if (!jl_is_typevar(e)) {
+        if (!jl_is_svec(e)) {
             return mark_julia_const(ctx, e);
         }
     }
-    Value *bp = emit_ptrgep(ctx, maybe_decay_tracked(ctx, ctx.spvals_ptr), i * sizeof(jl_value_t*) + sizeof(jl_svec_t));
-    jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_const);
-    Value *sp = ai.decorateInst(ctx.builder.CreateAlignedLoad(ctx.types().T_prjlvalue, bp, Align(sizeof(void*))));
-    setName(ctx.emission_context, sp, "sparam");
-    Value *isnull = ctx.builder.CreateICmpNE(emit_typeof(ctx, sp, false, true), emit_tagfrom(ctx, jl_tvar_type));
     jl_unionall_t *sparam = (jl_unionall_t*)ctx.linfo->def.method->sig;
     for (size_t j = 0; j < i; j++) {
         sparam = (jl_unionall_t*)sparam->body;
         assert(jl_is_unionall(sparam));
     }
+    if (!ctx.spvals_ptr) {
+        undef_var_error_ifnot(ctx, ConstantInt::get(getInt1Ty(ctx.builder.getContext()), 0), sparam->var->name, (jl_value_t*)jl_static_parameter_sym);
+        return jl_cgval_t();
+    }
+    Value *bp = emit_ptrgep(ctx, maybe_decay_tracked(ctx, ctx.spvals_ptr), i * sizeof(jl_value_t*) + sizeof(jl_svec_t));
+    jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_const);
+    Value *sp = ai.decorateInst(ctx.builder.CreateAlignedLoad(ctx.types().T_prjlvalue, bp, Align(sizeof(void*))));
+    setName(ctx.emission_context, sp, "sparam");
+    Value *isnull = ctx.builder.CreateICmpNE(emit_typeof(ctx, sp, false, true), emit_tagfrom(ctx, jl_simplevector_type));
     undef_var_error_ifnot(ctx, isnull, sparam->var->name, (jl_value_t*)jl_static_parameter_sym);
     return mark_julia_type(ctx, sp, true, jl_any_type);
 }
@@ -5825,14 +5830,17 @@ static jl_cgval_t emit_isdefined(jl_codectx_t &ctx, jl_value_t *sym, int allow_i
         size_t i = jl_unbox_long(jl_exprarg(sym, 0)) - 1;
         if (jl_svec_len(ctx.linfo->sparam_vals) > 0) {
             jl_value_t *e = jl_svecref(ctx.linfo->sparam_vals, i);
-            if (!jl_is_typevar(e)) {
+            if (!jl_is_svec(e)) {
                 return mark_julia_const(ctx, jl_true);
             }
+        }
+        if (!ctx.spvals_ptr) {
+            return mark_julia_const(ctx, jl_false);
         }
         Value *bp = emit_ptrgep(ctx, maybe_decay_tracked(ctx, ctx.spvals_ptr), i * sizeof(jl_value_t*) + sizeof(jl_svec_t));
         jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_const);
         Value *sp = ai.decorateInst(ctx.builder.CreateAlignedLoad(ctx.types().T_prjlvalue, bp, Align(sizeof(void*))));
-        isnull = ctx.builder.CreateICmpNE(emit_typeof(ctx, sp, false, true), emit_tagfrom(ctx, jl_tvar_type));
+        isnull = ctx.builder.CreateICmpNE(emit_typeof(ctx, sp, false, true), emit_tagfrom(ctx, jl_simplevector_type));
     }
     else {
         assert(false && "malformed expression");

--- a/src/gf.c
+++ b/src/gf.c
@@ -1095,8 +1095,8 @@ static jl_value_t *inst_varargp_in_env(jl_value_t *decl, jl_svec_t *sparams)
         // and the user called it with `Tuple{Vararg{Union{Nothing,Int},N}}`, then T is unbound
         jl_value_t **sp = jl_svec_data(sparams);
         while (jl_is_unionall(decl)) {
-            jl_tvar_t *v = (jl_tvar_t*)*sp;
-            if (jl_is_typevar(v)) {
+            jl_tvar_t *v = ((jl_unionall_t*)decl)->var;
+            if (jl_is_svec(*sp)) {
                 // must unwrap and re-wrap Vararg object explicitly here since jl_type_unionall handles it differently
                 jl_value_t *T = ((jl_vararg_t*)vm)->T;
                 jl_value_t *N = ((jl_vararg_t*)vm)->N;
@@ -1697,7 +1697,7 @@ jl_method_instance_t *cache_method(
                 int k, l;
                 for (k = 0, l = jl_svec_len(env); k < l; k++) {
                     jl_value_t *env_k = jl_svecref(env, k);
-                    if (jl_is_typevar(env_k) || jl_is_vararg(env_k)) {
+                    if (jl_is_svec(env_k) || jl_is_vararg(env_k)) {
                         unmatched_tvars = 1;
                         break;
                     }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -266,7 +266,7 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
             assert(n > 0);
             if (s->sparam_vals && n <= jl_svec_len(s->sparam_vals)) {
                 jl_value_t *sp = jl_svecref(s->sparam_vals, n - 1);
-                defined = !jl_is_typevar(sp);
+                defined = !jl_is_simplevector(sp);
             }
             else {
                 // static parameter val unknown needs to be an error for ccall
@@ -324,8 +324,20 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         assert(n > 0);
         if (s->sparam_vals && n <= jl_svec_len(s->sparam_vals)) {
             jl_value_t *sp = jl_svecref(s->sparam_vals, n - 1);
-            if (jl_is_typevar(sp) && !s->preevaluation)
-                jl_undefined_var_error(((jl_tvar_t*)sp)->name, (jl_value_t*)jl_static_parameter_sym);
+            if (jl_is_simplevector(sp) && !s->preevaluation) {
+                jl_unionall_t *sig = (jl_unionall_t*)s->mi->def.method->sig;
+                jl_tvar_t *var = NULL;
+                for (int i = n; i > 0; i--) {
+                    if (jl_is_unionall(sig)) {
+                        var = sig->var;
+                        sig = (jl_unionall_t*)sig->body;
+                    }
+                    else {
+                        jl_error("malformed method signature");
+                    }
+                }
+                jl_undefined_var_error(var->name, (jl_value_t*)jl_static_parameter_sym);
+            }
             return sp;
         }
         // static parameter val unknown needs to be an error for ccall

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2787,13 +2787,29 @@ jl_value_t *jl_instantiate_type_with(jl_value_t *t, jl_value_t **env, size_t n)
     return instantiate_with(t, env, n, NULL);
 }
 
-static jl_value_t *_jl_instantiate_type_in_env(jl_value_t *ty, jl_unionall_t *env, jl_value_t **vals, jl_typeenv_t *prev, jl_typestack_t *stack)
+static jl_value_t *__jl_instantiate_type_in_env(jl_value_t *ty, jl_unionall_t *env, jl_value_t *val, jl_value_t **vals, jl_typeenv_t *prev, jl_typestack_t *stack)
 {
-    jl_typeenv_t en = { env->var, vals[0], prev };
+    jl_typeenv_t en = { env->var, val, prev };
     if (jl_is_unionall(env->body))
-        return _jl_instantiate_type_in_env(ty, (jl_unionall_t*)env->body, vals + 1, &en, stack);
+        return _jl_instantiate_type_in_env(ty, (jl_unionall_t*)env->body, vals, &en, stack);
     else
         return inst_type_w_(ty, &en, stack, 1, 0);
+}
+
+static jl_value_t *_jl_instantiate_type_in_env(jl_value_t *ty, jl_unionall_t *env, jl_value_t **vals, jl_typeenv_t *prev, jl_typestack_t *stack)
+{
+    jl_value_t *val = vals[0];
+    if (jl_is_svec(val)) {
+        size_t len = jl_svec_len((jl_svec_t*)val);
+        jl_value_t *ub = jl_svecref((jl_svec_t*)val, len - 1);
+        jl_value_t *lb = len == 2 ? jl_svecref((jl_svec_t*)val, 0) : jl_bottom_type;
+        jl_tvar_t *var = jl_new_typevar(env->var->name, lb, ub);
+        JL_GC_PUSH1(&var);
+        jl_value_t *ret = __jl_instantiate_type_in_env(ty, env, (jl_value_t*)var, vals + 1, prev, stack);
+        JL_GC_POP();
+        return ret;
+    }
+    return __jl_instantiate_type_in_env(ty, env, val, vals + 1, prev, stack);
 }
 
 JL_DLLEXPORT jl_value_t *jl_instantiate_type_in_env(jl_value_t *ty, jl_unionall_t *env, jl_value_t **vals)

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -941,8 +941,8 @@ static jl_value_t *widen_Type_to_union(jl_value_t *t, jl_value_t *bound, jl_sten
 static jl_value_t *fix_inferred_var_bound(jl_tvar_t *var, jl_value_t *ty JL_MAYBE_UNROOTED)
 {
     if (ty == NULL) // may happen if the user is intersecting with an incomplete type
-        return (jl_value_t*)var;
-    if (!jl_is_typevar(ty) && jl_has_free_typevars(ty)) {
+        return (jl_value_t*)jl_svec2(var->lb, var->ub);
+    if (!jl_is_svec(ty) && !jl_is_typevar(ty) && jl_has_free_typevars(ty)) {
         jl_value_t *ans = ty;
         jl_array_t *vs = NULL;
         JL_GC_PUSH2(&ans, &vs);
@@ -951,7 +951,7 @@ static jl_value_t *fix_inferred_var_bound(jl_tvar_t *var, jl_value_t *ty JL_MAYB
         for (i = 0; i < jl_array_nrows(vs); i++) {
             ans = jl_type_unionall((jl_tvar_t*)jl_array_ptr_ref(vs, i), ans);
         }
-        ans = (jl_value_t*)jl_new_typevar(var->name, jl_bottom_type, ans);
+        ans = (jl_value_t*)jl_svec2(jl_bottom_type, ans);
         JL_GC_POP();
         return ans;
     }
@@ -1067,22 +1067,20 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
         if (vb.intvalued && vb.lb == (jl_value_t*)jl_any_type)
             val = (jl_value_t*)jl_wrap_vararg(NULL, NULL, 0, 0); // special token result that represents N::Int in the envout
         else if (!vb.occurs_inv && vb.lb != jl_bottom_type)
-            val = is_leaf_bound(vb.lb) ? vb.lb : (jl_value_t*)jl_new_typevar(u->var->name, jl_bottom_type, vb.lb);
+            val = is_leaf_bound(vb.lb) ? vb.lb : (jl_value_t*)jl_svec2(jl_bottom_type, vb.lb);
         else if (vb.lb == vb.ub)
-            val = vb.lb;
+            val = jl_is_typevar(vb.lb) ? (jl_value_t*)jl_svec2(vb.lb, vb.ub) : vb.lb;
         else if (vb.lb != jl_bottom_type)
             // TODO: for now return the least solution, which is what
             // method parameters expect.
-            val = vb.lb;
-        else if (vb.lb == u->var->lb && vb.ub == u->var->ub)
-            val = (jl_value_t*)u->var;
+            val = jl_is_typevar(vb.lb) ? (jl_value_t*)jl_svec2(vb.lb, vb.ub) : vb.lb;
         else
-            val = (jl_value_t*)jl_new_typevar(u->var->name, vb.lb, vb.ub);
+            val = (jl_value_t*)jl_svec2(vb.lb, vb.ub);
         jl_value_t *oldval = e->envout[e->envidx];
         // if we try to assign different variable values (due to checking
         // multiple union members), consider the value unknown.
         if (oldval && !jl_egal(oldval, val))
-            e->envout[e->envidx] = (jl_value_t*)u->var;
+            e->envout[e->envidx] = (jl_value_t*)jl_svec1(jl_any_type);
         else
             e->envout[e->envidx] = val;
         // TODO: substitute the value (if any) of this variable into previous envout entries
@@ -1875,7 +1873,7 @@ static int forall_exists_subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, in
     return sub;
 }
 
-static void init_stenv(jl_stenv_t *e, jl_value_t **env, int envsz)
+static void init_stenv(jl_stenv_t *e, jl_value_t **env JL_REQUIRE_ROOTED_SLOT, int envsz)
 {
     e->vars = NULL;
     e->envsz = envsz;
@@ -2291,7 +2289,7 @@ JL_DLLEXPORT int jl_obvious_subtype(jl_value_t *x, jl_value_t *y, int *subtype)
 // points to a rooted array of length `jl_subtype_env_size(y)`.
 // This will be populated with the values of variables from unionall
 // types at the outer level of `y`.
-JL_DLLEXPORT int jl_subtype_env(jl_value_t *x, jl_value_t *y, jl_value_t **env, int envsz)
+JL_DLLEXPORT int jl_subtype_env(jl_value_t *x, jl_value_t *y, jl_value_t **env JL_REQUIRE_ROOTED_SLOT, int envsz)
 {
     jl_stenv_t e;
     if (y == (jl_value_t*)jl_any_type || x == jl_bottom_type)
@@ -2305,7 +2303,7 @@ JL_DLLEXPORT int jl_subtype_env(jl_value_t *x, jl_value_t *y, jl_value_t **env, 
             int i;
             for (i = 0; i < envsz; i++) {
                 assert(jl_is_unionall(ua));
-                env[i] = (jl_value_t*)ua->var;
+                env[i] = (jl_value_t*)jl_svec2(ua->var->lb, ua->var->ub);
                 ua = (jl_unionall_t*)ua->body;
             }
         }
@@ -3425,8 +3423,8 @@ static jl_value_t *finish_unionall(jl_value_t *res JL_MAYBE_UNROOTED, jl_varbind
     if (vb->right && e->envidx < e->envsz) {
         jl_value_t *oldval = e->envout[e->envidx];
         if (!varval || (!is_leaf_bound(varval) && !vb->occurs_inv))
-            e->envout[e->envidx] = (jl_value_t*)vb->var;
-        else if (!(oldval && jl_is_typevar(oldval) && jl_is_long(varval)))
+            e->envout[e->envidx] = (jl_value_t*)jl_svec1(jl_any_type);
+        else if (!(oldval && jl_is_svec(oldval) && jl_is_long(varval)))
             e->envout[e->envidx] = varval;
     }
 
@@ -4720,7 +4718,7 @@ jl_value_t *jl_type_intersection_env_s(jl_value_t *a, jl_value_t *b, jl_svec_t *
     if (sz == 0 && szb > 0) {
         jl_unionall_t *ub = (jl_unionall_t*)b;
         while (jl_is_unionall(ub)) {
-            env[i++] = (jl_value_t*)ub->var;
+            env[i++] = (jl_value_t*)jl_svec2(ub->var->lb, ub->var->ub);
             ub = (jl_unionall_t*)ub->body;
         }
         sz = szb;

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -107,24 +107,26 @@ function print_warntype_mi(io::IO, mi::Core.MethodInstance)
                 else
                     Base.print(io, v)
                 end
-            if val isa TypeVar
-                if val.lb === Union{}
+            if val isa Core.SimpleVector
+                ub = val[end]
+                lb = length(val) == 2 ? val[1] : Union{}
+                if lb === Union{}
                     print(io, "  ", name, " <: ")
-                    print_highlighted(io, "$(val.ub)", warn_color)
-                elseif val.ub === Any
-                    print(io, "  ", sig.var.name, " >: ")
-                    print_highlighted(io, "$(val.lb)", warn_color)
+                    print_highlighted(io, "$(ub)", warn_color)
+                elseif ub === Any
+                    print(io, "  ", name, " >: ")
+                    print_highlighted(io, "$(lb)", warn_color)
                 else
                     print(io, "  ")
-                    print_highlighted(io, "$(val.lb)", warn_color)
-                    print(io, " <: ", sig.var.name, " <: ")
-                    print_highlighted(io, "$(val.ub)", warn_color)
+                    print_highlighted(io, "$(lb)", warn_color)
+                    print(io, " <: ", name, " <: ")
+                    print_highlighted(io, "$(ub)", warn_color)
                 end
             elseif val isa typeof(Vararg)
                 print(io, "  ", name, "::")
                 print_highlighted(io, "Int", warn_color)
             else
-                print(io, "  ", sig.var.name, " = ")
+                print(io, "  ", name, " = ")
                 print_highlighted(io, "$(val)", :cyan) # show the "good" type
             end
             println(io)

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -994,7 +994,7 @@ function test_intersection()
     # first union component sets N==0, but for the second N is unknown
     _, E = intersection_env(Tuple{Tuple{Vararg{Int}}, Any},
                             Tuple{Union{Base.DimsInteger{N},Base.Indices{N}}, Int} where N)
-    @test length(E)==1 && isa(E[1],TypeVar)
+    @test length(E)==1 && isa(E[1],Core.SimpleVector)
 
     @testintersect(Tuple{Dict{Int,Int}, Ref{Pair{K,V}}} where V where K,
                    Tuple{AbstractDict{Int,Int}, Ref{Pair{T,T}} where T},
@@ -1007,7 +1007,7 @@ function test_intersection()
 
     # issue #20998
     _, E = intersection_env(Tuple{Int,Any,Any}, Tuple{T,T,S} where {T,S})
-    @test length(E) == 2 && E[1] == Int && isa(E[2], TypeVar)
+    @test length(E) == 2 && E[1] == Int && isa(E[2], Core.SimpleVector)
     _, E = intersection_env(Tuple{Dict{Int,Type}, Type, Any},
                             Tuple{Dict{K,V}, Any, Int} where {K,V})
     @test E[2] == Type
@@ -1479,7 +1479,7 @@ end
 
 # PR #24399
 let (t, e) = intersection_env(Tuple{Union{Int,Int8}}, Tuple{T} where T)
-    @test e[1] isa TypeVar
+    @test e[1] isa Core.SimpleVector
 end
 
 # issue #25430
@@ -2283,8 +2283,12 @@ function equal_envs(env1, env2)
     for i = 1:length(env1)
         a = env1[i]
         b = env2[i]
-        if a isa TypeVar
-            if !(b isa TypeVar && a.name == b.name && a.lb == b.lb && a.ub == b.ub)
+        if a isa Core.SimpleVector && b isa Core.SimpleVector
+            a_ub = a[end]
+            a_lb = length(a) == 2 ? a[1] : Union{}
+            b_ub = b[end]
+            b_lb = length(b) == 2 ? b[1] : Union{}
+            if !(a_lb == b_lb && a_ub == b_ub)
                 return false
             end
         elseif !(a == b)
@@ -2299,25 +2303,26 @@ let
     env_tuple(@nospecialize(x), @nospecialize(y)) = intersection_env(x, y)[2]
     TT0 = Tuple{Type{T},Union{Real,Missing,Nothing}} where {T}
     TT1 = Union{Type{Int8},Type{Int16}}
-    @test env_tuple(Tuple{TT1,Missing}, TT0) ===
-          env_tuple(Tuple{TT1,Nothing}, TT0) ===
-          env_tuple(Tuple{TT1,Int}, TT0) ===
-          Core.svec(TT0.var)
+    # env entry is an svec marker for an uncertain TypeVar value
+    @test env_tuple(Tuple{TT1,Missing}, TT0) ==
+          env_tuple(Tuple{TT1,Nothing}, TT0) ==
+          env_tuple(Tuple{TT1,Int}, TT0)
+    @test env_tuple(Tuple{TT1,Missing}, TT0)[1] isa Core.SimpleVector
 
     TT0 = Tuple{T1,T2,Union{Real,Missing,Nothing}} where {T1,T2}
     TT1 = Tuple{T1,T2,Union{Real,Missing,Nothing}} where {T2,T1}
     TT2 = Tuple{Union{Int,Int8},Union{Int,Int8},Int}
     TT3 = Tuple{Int,Union{Int,Int8},Int}
-    @test equal_envs(env_tuple(TT2, TT0), Core.svec(TypeVar(:T1, Union{Int, Int8}), TypeVar(:T2, Union{Int, Int8})))
-    @test equal_envs(env_tuple(TT2, TT1), Core.svec(TypeVar(:T2, Union{Int, Int8}), TypeVar(:T1, Union{Int, Int8})))
-    @test equal_envs(env_tuple(TT3, TT0), Core.svec(Int, TypeVar(:T2, Union{Int, Int8})))
-    @test equal_envs(env_tuple(TT3, TT1), Core.svec(TypeVar(:T2, Union{Int, Int8}), Int))
+    @test equal_envs(env_tuple(TT2, TT0), Core.svec(Core.svec(Union{}, Union{Int, Int8}), Core.svec(Union{}, Union{Int, Int8})))
+    @test equal_envs(env_tuple(TT2, TT1), Core.svec(Core.svec(Union{}, Union{Int, Int8}), Core.svec(Union{}, Union{Int, Int8})))
+    @test equal_envs(env_tuple(TT3, TT0), Core.svec(Int, Core.svec(Union{}, Union{Int, Int8})))
+    @test equal_envs(env_tuple(TT3, TT1), Core.svec(Core.svec(Union{}, Union{Int, Int8}), Int))
 
     TT0 = Tuple{T1,T2,T1,Union{Real,Missing,Nothing}} where {T1,T2}
     TT1 = Tuple{T1,T2,T1,Union{Real,Missing,Nothing}} where {T2,T1}
     TT2 = Tuple{Int,Union{Int,Int8},Int,Int}
-    @test equal_envs(env_tuple(TT2, TT0), Core.svec(Int, TypeVar(:T2, Union{Int, Int8})))
-    @test equal_envs(env_tuple(TT2, TT1), Core.svec(TypeVar(:T2, Union{Int, Int8}), Int))
+    @test equal_envs(env_tuple(TT2, TT0), Core.svec(Int, Core.svec(Union{}, Union{Int, Int8})))
+    @test equal_envs(env_tuple(TT2, TT1), Core.svec(Core.svec(Union{}, Union{Int, Int8}), Int))
 end
 
 #issue #46735
@@ -2354,7 +2359,7 @@ struct Z38497{T>:Int} <: Y38497{T} end
 @test Vector{Vector{Tuple{T,T}} where Int<:T<:Int} <: Vector{Vector{Tuple{S1,S1} where S<:S1<:S}} where S
 
 #issue #46970
-@test only(intersection_env(Union{S, Matrix{Int}} where S<:Matrix, Matrix)[2]) isa TypeVar
+@test only(intersection_env(Union{S, Matrix{Int}} where S<:Matrix, Matrix)[2]) isa Core.SimpleVector
 T46784{B<:Val, M<:AbstractMatrix} = Tuple{<:Union{B, <:Val{<:B}}, M, Union{AbstractMatrix{B}, AbstractMatrix{<:Vector{<:B}}}}
 @testintersect(T46784{T,S} where {T,S}, T46784, !Union{})
 @test T46784 <: T46784{T,S} where {T,S}


### PR DESCRIPTION
In preparation for making free TypeVars well defined (#61242), switch the marker for "unkown" TypeVar values to an svec (which is disallowed as a type parameter), rather than a TypeVar. In the new semantics, a free typevar is a valid output here, so the current representation is ambiguous.