### PR TITLE
Consistently use stdlib name as header for stdlibs in documentation

### DIFF
--- a/stdlib/FileWatching/docs/src/index.md
+++ b/stdlib/FileWatching/docs/src/index.md
@@ -2,7 +2,7 @@
 EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/FileWatching/docs/src/index.md"
 ```
 
-# [File Events](@id lib-filewatching)
+# [FileWatching](@id lib-filewatching)
 
 ```@docs
 poll_fd

--- a/stdlib/FileWatching/docs/src/index.md
+++ b/stdlib/FileWatching/docs/src/index.md
@@ -2,7 +2,7 @@
 EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/FileWatching/docs/src/index.md"
 ```
 
-# [FileWatching](@id lib-filewatching)
+# [FileWatching (File Events)](@id lib-filewatching)
 
 ```@docs
 poll_fd

--- a/stdlib/InteractiveUtils/docs/src/index.md
+++ b/stdlib/InteractiveUtils/docs/src/index.md
@@ -2,7 +2,7 @@
 EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/InteractiveUtils/docs/src/index.md"
 ```
 
-# [Interactive Utilities](@id man-interactive-utils)
+# [InteractiveUtils](@id man-interactive-utils)
 
 The `InteractiveUtils` module provides utilities for interactive use of Julia,
 such as code introspection and clipboard access.

--- a/stdlib/Libdl/docs/src/index.md
+++ b/stdlib/Libdl/docs/src/index.md
@@ -6,7 +6,7 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Libdl/docs/src/
 Libdl
 ```
 
-# Libdl
+# Libdl (Dynamic Linker)
 
 ```@docs
 Libdl.dlopen

--- a/stdlib/Libdl/docs/src/index.md
+++ b/stdlib/Libdl/docs/src/index.md
@@ -6,7 +6,7 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Libdl/docs/src/
 Libdl
 ```
 
-# Dynamic Linker
+# Libdl
 
 ```@docs
 Libdl.dlopen

--- a/stdlib/Mmap/docs/src/index.md
+++ b/stdlib/Mmap/docs/src/index.md
@@ -2,7 +2,7 @@
 EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Mmap/docs/src/index.md"
 ```
 
-# Mmap
+# Mmap (Memory-mapped I/O)
 
 Low level module for mmap (memory mapping of files).
 

--- a/stdlib/Mmap/docs/src/index.md
+++ b/stdlib/Mmap/docs/src/index.md
@@ -2,7 +2,7 @@
 EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Mmap/docs/src/index.md"
 ```
 
-# Memory-mapped I/O
+# Mmap
 
 Low level module for mmap (memory mapping of files).
 

--- a/stdlib/Profile/docs/src/index.md
+++ b/stdlib/Profile/docs/src/index.md
@@ -2,7 +2,7 @@
 EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Profile/docs/src/index.md"
 ```
 
-# [Profiling](@id lib-profiling)
+# [Profile](@id lib-profiling)
 
 ## CPU Profiling
 

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -2,7 +2,7 @@
 EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/docs/src/index.md"
 ```
 
-# The Julia REPL
+# REPL
 
 Julia comes with a full-featured interactive command-line REPL (read-eval-print loop) built into
 the `julia` executable. In addition to allowing quick and easy evaluation of Julia statements,

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -2,7 +2,7 @@
 EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Random/docs/src/index.md"
 ```
 
-# Random Numbers
+# Random
 
 ```@meta
 DocTestSetup = :(using Random)

--- a/stdlib/SharedArrays/docs/src/index.md
+++ b/stdlib/SharedArrays/docs/src/index.md
@@ -2,7 +2,7 @@
 EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/SharedArrays/docs/src/index.md"
 ```
 
-# Shared Arrays
+# SharedArrays
 
 `SharedArray` represents an array, which is shared across multiple processes, on a single machine.
 

--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -2,7 +2,7 @@
 EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Test/docs/src/index.md"
 ```
 
-# Unit Testing
+# Test
 
 ```@meta
 DocTestSetup = :(using Test)


### PR DESCRIPTION
Resolves https://github.com/JuliaLang/julia/issues/61358.

But honestly, I am not sure if this is an improvement overall.

What do people instead think of e.g. `Libdl (Dynamic Linker)` for the cases where the stdlib name and the previous descriptive name are quite different?

cc @KristofferC 