### PR TITLE
compiler: honor explicit leave targets

### DIFF
--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -557,23 +557,25 @@ function (::ComputeTryCatch{Handler})(code::Vector{Any}, bbs::Union{Vector{Basic
             elseif isa(stmt, Expr)
                 head = stmt.head
                 if head === :leave
-                    l = 0
+                    cur_hand = cur_stacks[1]
                     for j = 1:length(stmt.args)
                         arg = stmt.args[j]
                         if arg === nothing
                             continue
                         else
-                            enter_stmt = code[(arg::SSAValue).id]
+                            enter_ssa = arg::SSAValue
+                            enter_stmt = code[enter_ssa.id]
                             if enter_stmt === nothing
                                 continue
                             end
                             @assert isa(enter_stmt, EnterNode) "malformed :leave"
                         end
-                        l += 1
-                    end
-                    cur_hand = cur_stacks[1]
-                    for _ = 1:l
-                        cur_hand = handler_at[get_enter_idx(handlers[cur_hand])][1]
+                        # `:leave` carries the specific `EnterNode` SSA targets being
+                        # left. We need to honor those explicit targets instead of
+                        # blindly popping the current handler stack, because the
+                        # current stack can already be empty along cleanup/finally
+                        # paths even when an outer `:leave` target still remains.
+                        cur_hand = handler_at[enter_ssa.id][1]
                     end
                     cur_stacks = (cur_hand, cur_stacks[2])
                     cur_stacks == (0, 0) && break

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -4687,10 +4687,13 @@ let x = Tuple{Int,Any}[
     @test map(x->x[1] == 0 ? 0 : Compiler.get_enter_idx(handlers[x[1]]), handler_at) == first.(x)
 end
 
-# Similar to the Windows ConnectEx path in Reseau: an outer try/catch, an
-# `@static` early-return region with a try/finally + swallowed cleanup error,
-# and a still-present sibling path after it. This used to make
-# `ComputeTryCatch` pop from an empty current handler stack even though the
+# This shape was discovered while investigating Reseau.jl's Windows TCP connect
+# path (`TCP._connect_socketaddr_impl`):
+# https://github.com/JuliaServices/Reseau.jl/blob/50919ecbf452536b0b38ddb95ab9895fc2711057/src/3_tcp.jl#L478-L550
+# The reduced repro keeps the relevant structure: an outer try/catch, an
+# `@static` early-return region, a try/finally with swallowed cleanup error,
+# and the still-present sibling path after the `@static` branch. This used to
+# make `ComputeTryCatch` pop from an empty current handler stack even though the
 # explicit `:leave` target still carried the right outer handler.
 let
     struct DummyFDConnectShape

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -4687,6 +4687,104 @@ let x = Tuple{Int,Any}[
     @test map(x->x[1] == 0 ? 0 : Compiler.get_enter_idx(handlers[x[1]]), handler_at) == first.(x)
 end
 
+# Similar to the Windows ConnectEx path in Reseau: an outer try/catch, an
+# `@static` early-return region with a try/finally + swallowed cleanup error,
+# and a still-present sibling path after it. This used to make
+# `ComputeTryCatch` pop from an empty current handler stack even though the
+# explicit `:leave` target still carried the right outer handler.
+let
+    struct DummyFDConnectShape
+        family::Int
+    end
+
+    @noinline addr_family_connect_shape(x) = x
+    @noinline open_fd_connect_shape(; family = 1) = DummyFDConnectShape(family)
+    @noinline bind_socket_connect_shape(fd, addr) = nothing
+    @noinline bind_local_connect_shape(fd, family) = nothing
+    @noinline set_nonblocking_connect_shape(fd, value) = nothing
+    @noinline register_connect_shape(fd) = nothing
+    @noinline set_deadline_connect_shape(fd, value) = nothing
+    @noinline wait_complete_connect_shape(fd, remote, cancel) = nothing
+    @noinline connect_socket_connect_shape(fd, remote) = Int32(1)
+    @noinline finalize_connect_shape(fd, remote) = nothing
+    @noinline apply_opts_connect_shape(fd) = nothing
+    @noinline close_fd_connect_shape(fd) = nothing
+    @noinline conn_connect_shape(fd) = fd
+    @noinline is_pending_connect_shape(errno) = true
+
+    function connect_shape(
+            remote_addr::Int,
+            local_addr::Union{Nothing, Int},
+            connect_deadline_ns::Int64,
+            cancel_state,
+        )
+        family = addr_family_connect_shape(remote_addr)
+        if local_addr !== nothing && addr_family_connect_shape(local_addr) != family
+            throw(ArgumentError("local and remote address families must match"))
+        end
+        fd = open_fd_connect_shape(; family = family)
+        try
+            if local_addr !== nothing
+                bind_socket_connect_shape(fd, local_addr)
+            elseif true
+                bind_local_connect_shape(fd, family)
+            end
+            set_nonblocking_connect_shape(fd, true)
+            @static if true
+                register_connect_shape(fd)
+                if connect_deadline_ns != 0
+                    set_deadline_connect_shape(fd, connect_deadline_ns)
+                end
+                try
+                    wait_complete_connect_shape(fd, remote_addr, cancel_state)
+                finally
+                    if connect_deadline_ns != 0
+                        try
+                            set_deadline_connect_shape(fd, Int64(0))
+                        catch
+                        end
+                    end
+                end
+                apply_opts_connect_shape(fd)
+                return conn_connect_shape(fd)
+            end
+            errno = connect_socket_connect_shape(fd, remote_addr)
+            if errno == Int32(0) || errno == Int32(106)
+                register_connect_shape(fd)
+                finalize_connect_shape(fd, remote_addr)
+                apply_opts_connect_shape(fd)
+                return conn_connect_shape(fd)
+            end
+            is_pending_connect_shape(errno) || throw(SystemError("connect", Int(errno)))
+            register_connect_shape(fd)
+            if connect_deadline_ns != 0
+                set_deadline_connect_shape(fd, connect_deadline_ns)
+            end
+            try
+                wait_complete_connect_shape(fd, remote_addr, cancel_state)
+            finally
+                if connect_deadline_ns != 0
+                    try
+                        set_deadline_connect_shape(fd, Int64(0))
+                    catch
+                    end
+                end
+            end
+            apply_opts_connect_shape(fd)
+            return conn_connect_shape(fd)
+        catch
+            close_fd_connect_shape(fd)
+            rethrow()
+        end
+    end
+
+    argtypes = Tuple{Int, Union{Nothing, Int}, Int64, Nothing}
+    ci = only(code_lowered(connect_shape, argtypes))
+    info = Compiler.ComputeTryCatch{Compiler.TryCatchFrame}()(ci.code)
+    @test length(info.handlers) == 7
+    @test length(Base.code_typed(connect_shape, argtypes; optimize = false)) == 1
+end
+
 @test only(Base.return_types((Bool,)) do y
         x = 1
         try


### PR DESCRIPTION
I originally thought this was a [windows socket](https://github.com/JuliaServices/Reseau.jl/pull/91) issue, but on further digging, was able to come up with a OS-agnostic reproduction.

Codex was heavily used throughout the process in trying to determine the root cause (see package PR linked above), coming up with a similar "shape" that reproduced the error on macos, and in suggesting the fix.

My guess is we could possibly further reduce the regression test case here if we want?

I definitely don't know the inferencestate.jl code hardly at all, so if this fix seems way off-base, I apologize for the noise, but hopefully a form of the regression test would still end up being useful?

I'm including the AI summary of investigations here for context if that helps:
```
We got to the bottom of it.

  The real trigger is now much clearer: it’s not “Windows syscalls” in any direct sense, it’s a specific lowered control-flow shape that
  the Windows ConnectEx path happens to produce. The readable source-level repro is in test/windows_connectex_shape_repro.jl. The key shape
  is:

  - outer try/catch
  - an @static early-return region
  - inside that, a try/finally with a swallowed cleanup error
  - and then the still-present sibling path after the @static early return

  That last part matters. The “full” shape reproduces; the trimmed/no-static variants do not.

  The compiler root cause is in /Users/jacob.quinn/julia/Compiler/src/inferencestate.jl. ComputeTryCatch was handling :leave by counting
  operands and popping the current handler stack that many times. In this shape, the current handler stack can already be 0 even though the
  explicit outer :leave target is still meaningful, so it underflows on handlers[0]. The fix is to honor the explicit SSAValue leave
  targets and recover the outer handler from handler_at[enter_ssa.id][1] instead of blindly popping by count.
```