### PR TITLE
[JuliaLowering] fix simple `(const ident val)`

### DIFF
--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -24,8 +24,9 @@ if DEBUG
           end)
     end
 else
+    # allow @jl_assert false in value position to not change rettype
     macro jl_assert(cond, args...)
-        nothing
+        cond === false ? :(throw("@jl_assert false")) : nothing
     end
 end
 

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2268,7 +2268,10 @@ end
 
 function expand_const_decl(ctx, ex)
     k = kind(ex[1])
-    if k == K"global"
+    if numchildren(ex) == 2
+        # pre-desugared const
+        @ast ctx ex [K"constdecl" ex[1] ex[2]]
+    elseif k == K"global"
         asgn = ex[1][1]
         @jl_assert (kind(asgn) == K"=" || kind(asgn) == K"function") (ex, "expected assignment after `const`")
         globals = SyntaxList(ctx)
@@ -2281,8 +2284,6 @@ function expand_const_decl(ctx, ex)
         ]
     elseif k == K"=" || k == K"function"
         expand_assignment(ctx, ex[1], true)
-    elseif k == K"local"
-        throw(LoweringError(ex, "unsupported `const local` declaration"))
     elseif k == K"Identifier" || k == K"Value"
         # Expr(:const, v) where v is a Symbol or a GlobalRef is an unfortunate
         # remnant from the days when const-ness was a flag that could be set on
@@ -2291,7 +2292,7 @@ function expand_const_decl(ctx, ex)
         @jl_assert numchildren(ex) == 1 ex
         @ast ctx ex [K"constdecl" ex[1]]
     else
-        throw(LoweringError(ex, "expected assignment after `const`"))
+        @jl_assert false ex
     end
 end
 
@@ -4767,12 +4768,7 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
     elseif k == K"const"
         expand_const_decl(ctx, ex)
     elseif k == K"local" || k == K"global"
-        if k == K"global" && kind(ex[1]) == K"const"
-            # Normalize `global const` to `const global`
-            expand_const_decl(ctx, @ast ctx ex [K"const" [K"global" ex[1][1]]])
-        else
-            expand_decls(ctx, ex)
-        end
+        expand_decls(ctx, ex)
     elseif k == K"where"
         expand_forms_2(ctx, expand_wheres(ctx, ex))
     elseif k == K"braces" || k == K"bracescat"

--- a/JuliaLowering/test/decls.jl
+++ b/JuliaLowering/test/decls.jl
@@ -375,8 +375,8 @@ end
     # pre-desugared const
     @gensym sym
     ex = Expr(:const, sym, 1)
-    @test_broken jl_eval(test_mod, ex)
-    @test_broken binding_kind(test_mod, sym) == Base.PARTITION_KIND_CONST
+    @test jl_eval(test_mod, ex) == 1
+    @test Base.binding_kind(test_mod, sym) == Base.PARTITION_KIND_CONST
 
     # chained, const first
     @gensym sym1 sym2 sym3


### PR DESCRIPTION
Lowering is expected to accept pre-desugared `(const ident val)` in addition to the standard `(const (= ident val))` produced by parsing.  

Fixes half of https://github.com/JuliaLang/JuliaLowering.jl/issues/149. To resolve it fully, I still need to make globalrefs work as identifiers, which I'll get to next.