### PR TITLE
[JuliaLowering] fix calls with form `(parameters (= name val))`

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -1626,8 +1626,7 @@ function _merge_named_tuple(ctx, srcref, old, new)
     end
 end
 
-function expand_named_tuple(ctx, ex, kws, eq_is_kw;
-                            field_name="named tuple field",
+function expand_named_tuple(ctx, ex, kws; field_name="named tuple field",
                             element_name="named tuple element")
     name_strs = Set{String}()
     names = SyntaxList(ctx)
@@ -1641,7 +1640,7 @@ function expand_named_tuple(ctx, ex, kws, eq_is_kw;
             # x  ==>  x = x
             name = to_symbol(ctx, kw)
             value = kw
-        elseif k == K"kw" || (eq_is_kw && k == K"=")
+        elseif k == K"kw" || k == K"="
             # syntax TODO: This should parse to K"kw"
             # x = a
             if kind(kw[1]) != K"Identifier" && kind(kw[1]) != K"Placeholder"
@@ -1710,7 +1709,7 @@ end
 function expand_kw_call(ctx, srcref, farg, args, kws)
     @ast ctx srcref [K"block"
         func := farg
-        kw_container := expand_named_tuple(ctx, srcref, kws, false;
+        kw_container := expand_named_tuple(ctx, srcref, kws;
                                            field_name="keyword argument",
                                            element_name="keyword argument")
         if all(kind(kw) == K"..." for kw in kws)
@@ -4793,9 +4792,9 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
             if numchildren(ex) > 1
                 throw(LoweringError(ex[end], "unexpected semicolon in tuple - use `,` to separate tuple elements"))
             end
-            expand_forms_2(ctx, expand_named_tuple(ctx, ex, children(ex[1]), true))
+            expand_forms_2(ctx, expand_named_tuple(ctx, ex, children(ex[1])))
         elseif any_assignment(children(ex))
-            expand_forms_2(ctx, expand_named_tuple(ctx, ex, children(ex), true))
+            expand_forms_2(ctx, expand_named_tuple(ctx, ex, children(ex)))
         else
             expand_forms_2(ctx, @ast ctx ex [K"call"
                 "tuple"::K"core"

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -224,7 +224,7 @@ vst1(vcx::Validation1Context, st::SyntaxTree)::ValidationResult = @stm st begin
     [K".&&" x y] -> vst1(vcx, x) & vst1(vcx, y)
     [K".||" x y] -> vst1(vcx, x) & vst1(vcx, y)
     (_, when=(vr=vst1_arraylike(vcx, st); is_known(vr))) -> vr
-    # syntax TODO: disallowpre-desugared const, broken with complex rhs
+    # syntax TODO: disallow pre-desugared const, broken with complex rhs
     [K"const" l r] -> vst1_ident(vcx, l; lhs=true) & vst1(vcx, r)
     [K"const" [K"global" x]] -> !vcx.toplevel ?
         @fail(st, "unsupported `const` inside function") :
@@ -562,10 +562,11 @@ vst1_call_arg(vcx, st) = @stm st begin
 end
 
 # Arg to `parameters` (post-semicolon) in a call (not function decl).  Stricter
-# than `vst1_call_arg`.
+# than `vst1_call_arg`.  `=` desugars to `kw`.
 vst1_call_kwarg(vcx, st) = @stm st begin
     [K"Identifier"] -> pass()
     [K"kw" id val] -> vst1_ident(vcx, id; lhs=true) & vst1(vcx, val)
+    [K"=" id val] -> vst1_ident(vcx, id; lhs=true) & vst1(vcx, val)
     [K"..." x] -> vst1(vcx, x)
     [K"." x [K"inert" id]] -> vst1(vcx, x) & vst1_ident(vcx, id; lhs=true)
     ([K"call" [K"Identifier"] symval v], when=(st[1].name_val==="=>")) ->

--- a/JuliaLowering/test/assignments.jl
+++ b/JuliaLowering/test/assignments.jl
@@ -134,9 +134,9 @@ end
         end
         @testset let ex = Expr(:call, :collect_args, peq)
             @test fl_eval(test_mod, ex) == (:semicolon, :a=>1)
-            @test_broken jl_eval(test_mod, ex) == (:semicolon, :a=>1)
+            @test jl_eval(test_mod, ex) == (:semicolon, :a=>1)
             @test fl_eval(test_mod, outer_ab(ex)) == (0, 0)
-            @test_broken jl_eval(test_mod, outer_ab(ex)) == (0, 0)
+            @test jl_eval(test_mod, outer_ab(ex)) == (0, 0)
         end
         # `kw` always passes a kwarg and does not assign a value
         @testset let ex = Expr(:call, :collect_args, kw)
@@ -167,9 +167,9 @@ end
             end
             @testset let ex = Expr(:(.), :collect_args, Expr(:tuple, peq))
                 @test fl_eval(test_mod, ex) == (:semicolon, :a=>[1])
-                @test_broken jl_eval(test_mod, ex) == (:semicolon, :a=>[1])
+                @test jl_eval(test_mod, ex) == (:semicolon, :a=>[1])
                 @test fl_eval(test_mod, outer_ab(ex)) == (0, 0)
-                @test_broken jl_eval(test_mod, outer_ab(ex)) == (0, 0)
+                @test jl_eval(test_mod, outer_ab(ex)) == (0, 0)
             end
             @testset let ex = Expr(:(.), :collect_args, Expr(:tuple, kw))
                 @test fl_eval(test_mod, ex) == (:semicolon, :b=>2)
@@ -220,7 +220,7 @@ end
         end
         @testset let ex = Expr(:tuple, peq)
             @test fl_eval(test_mod, ex) == (a=1,)
-            @test_broken jl_eval(test_mod, ex) == (a=1,)
+            @test jl_eval(test_mod, ex) == (a=1,)
         end
         @testset let ex = Expr(:tuple, kw) # calls tuple constructor with kw
             @test_throws MethodError fl_eval(test_mod, ex)
@@ -277,7 +277,7 @@ end
             @test_throws ErrorException fl_eval(test_mod, ex)
             @test_throws LoweringError jl_eval(test_mod, ex)
         end
-        @testset let ex = Expr(:braces, kw) # calls braces constructor with kw
+        @testset let ex = Expr(:braces, kw)
             @test_throws ErrorException fl_eval(test_mod, ex)
             @test_throws LoweringError jl_eval(test_mod, ex)
         end


### PR DESCRIPTION
Fixes some broken tests added in #61213.  Intended behaviour:
- `(call (kw a 1))` -> passes keyword `a=1`
- `(call (= a 1))` -> assigns outer a and passes 1
- `(call (parameters (kw a 1)))` -> passes keyword `a=1`
- `(call (parameters (= a 1)))` -> passes keyword `a=1` (fixed in this PR)

Calls in function declarations still disallow `=` as flisp does.  Fixes https://github.com/JuliaLang/JuliaLowering.jl/issues/151