### PR TITLE
prevent `edit_move_right` from extending an active region

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -304,7 +304,7 @@ for f in Union{Symbol,Expr}[
 end
 
 for f in [:edit_insert, :edit_insert_newline, :edit_backspace, :edit_move_left,
-          :edit_move_right, :edit_move_word_left, :edit_move_word_right]
+          :edit_move_word_left, :edit_move_word_right]  # :edit_move_right is handled separately
     @eval function ($f)(s::MIState, args...)
         set_action!(s, $(Expr(:quote, f)))
         $(f)(state(s), args...)
@@ -911,6 +911,7 @@ function edit_move_right(buf::IOBuffer)
     return false
 end
 function edit_move_right(m::MIState)
+    set_action!(m, :edit_move_right)
     s = state(m)
     buf = s.input_buffer
     if edit_move_right(s.input_buffer)

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -525,6 +525,24 @@ end
     @test LineEdit.region(s) == (0=>9)
     @inferred Union{Bool, LineEdit.InputAreaState} LineEdit.edit_shift_move(s, LineEdit.edit_move_right)
     @test LineEdit.region(s) == (2=>9)
+
+    # issue #61377
+    for edit_move in [LineEdit.edit_insert_newline, LineEdit.edit_backspace,
+            LineEdit.edit_move_left, LineEdit.edit_move_right,
+            LineEdit.edit_move_word_left, LineEdit.edit_move_word_right,
+            LineEdit.edit_move_up, LineEdit.edit_move_down]
+        s = new_state()
+        edit_insert(s, "abcd\nefgh\nijkl")
+        s.current_action = :unknown
+        LineEdit.edit_move_up(s)
+        s.current_action = :unknown
+        LineEdit.edit_shift_move(s, LineEdit.edit_move_left)
+        s.current_action = :unknown
+        LineEdit.edit_shift_move(s, LineEdit.edit_move_left)
+        s.current_action = :unknown
+        edit_move(s)
+        @test !LineEdit.is_region_active(s)
+    end
 end
 
 @testset "tab/backspace alignment feature" begin


### PR DESCRIPTION
fixes #61377

See there for description and explanation of the bug.