### PR TITLE
doc: Fix description of datatype_isbitsegal

### DIFF
--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -640,8 +640,8 @@ end
     Base.datatype_isbitsegal(dt::DataType)::Bool
 
 Return whether egality of the (non-padding bits of the) in-memory representation
-of an instance of this type implies semantic egality of the instance itself.
-This may not be the case if the type contains to other values whose egality is
+of an instance of this type is equivalent to semantic egality of the instance itself.
+This may not be the case if the type contains pointers to other values whose egality is
 independent of their identity (e.g. immutable structs, some types, etc.).
 """
 function datatype_isbitsegal(dt::DataType)


### PR DESCRIPTION
I wrote this originally, but it doesn't really make sense as written. Two issues:

1. `Implies` implies injection, not bijection and moreover the implication we actually care about is the other way around (i.e. does semantic egality imply bits-egality, because then we can do the the cheap bits-compare, rather than calling `===` on every field.
2. The word `pointers` was missing.