### PR TITLE
[JuliaSyntax] Fix issues reported by JETLS

### DIFF
--- a/JuliaSyntax/src/JuliaSyntax.jl
+++ b/JuliaSyntax/src/JuliaSyntax.jl
@@ -12,18 +12,14 @@ end
 # Public API, in the order of docs/src/api.md
 
 # Parsing.
-export parsestmt,
-    parseall,
-    parseatom
+export parseall, parseatom, parsestmt
 
 @_public parse!,
     ParseStream,
     build_tree
 
 # Tokenization
-export tokenize,
-    Token,
-    untokenize
+export Token, tokenize, untokenize
 
 # Source file handling
 @_public sourcefile,

--- a/JuliaSyntax/src/core/diagnostics.jl
+++ b/JuliaSyntax/src/core/diagnostics.jl
@@ -50,7 +50,7 @@ function _file_url(filename)
             path = abspath(filename)
         end
         return "file://$(path)"
-    catch exc
+    catch
         # abspath may fail if working directory doesn't exist
         # TODO: It seems rather non-ideal to have the behavior here depend on
         # the state of the local filesystem. And yet links in diagnostics seem

--- a/JuliaSyntax/src/core/parse_stream.jl
+++ b/JuliaSyntax/src/core/parse_stream.jl
@@ -162,7 +162,7 @@ function _reset_node_head(node, k, f)
     else
         f = flags(node)
     end
-    h = SyntaxHead(isnothing(k) ? kind(node) : k, f)
+    return SyntaxHead(isnothing(k) ? kind(node) : k, f)
 end
 
 Base.summary(node::RawGreenNode) = summary(node.head)
@@ -326,7 +326,7 @@ function ParseStream(io::IO; version=VERSION)
     ParseStream(textbuf, textbuf, 1, version)
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", stream::ParseStream)
+function Base.show(io::IO, ::MIME"text/plain", stream::ParseStream)
     println(io, "ParseStream at position $(stream.next_byte)")
 end
 
@@ -601,7 +601,6 @@ function last_child_position(stream::ParseStream, pos::ParseStreamPosition)
     output = stream.output
     @assert pos.node_index > 0
     cursor = RedTreeCursor(GreenTreeCursor(output, pos.node_index), pos.byte_index-1)
-    candidate = nothing
     for child in reverse(cursor)
         is_trivia(child) && continue
         return ParseStreamPosition(child.byte_end+UInt32(1), child.green.position)

--- a/JuliaSyntax/src/core/source_files.jl
+++ b/JuliaSyntax/src/core/source_files.jl
@@ -286,7 +286,6 @@ function _print_marker_line(io, prefix_str, str, underline, singleline, color,
         indent = "#" * (first(indent) == '\t' ? indent : indent[nextind(indent,1):end])
     end
 
-    midchar = '─'
     startstr, endstr, singlestart = underline ? ("└","┘","╙") : ("┌","┐","╓")
 
     markline =

--- a/JuliaSyntax/src/integration/expr.jl
+++ b/JuliaSyntax/src/integration/expr.jl
@@ -76,8 +76,6 @@ reverse_nontrivia_children(cursor) = Iterators.filter(should_include_node, Itera
 # reference parser.
 function _string_to_Expr(cursor, source, txtbuf::Vector{UInt8}, txtbuf_offset::UInt32)
     ret = Expr(:string)
-    args2 = Any[]
-    i = 1
     it = reverse_nontrivia_children(cursor)
     r = iterate(it)
     while r !== nothing

--- a/JuliaSyntax/src/integration/hooks.jl
+++ b/JuliaSyntax/src/integration/hooks.jl
@@ -21,7 +21,6 @@ end
 # within its parent and the node itself.
 function first_tree_error(c::RedTreeCursor, error_cursor::GreenTreeCursor)
     @assert !is_leaf(c) && !is_error(c)
-    first_child = first_error = nothing
     it = reverse_nontrivia_children(c)
     r = iterate(it)
     local child

--- a/JuliaSyntax/src/julia/julia_parse_stream.jl
+++ b/JuliaSyntax/src/julia/julia_parse_stream.jl
@@ -195,7 +195,6 @@ function validate_tokens(stream::ParseStream)
             # parse_int_literal
             # parse_uint_literal
         elseif k == K"Float" || k == K"Float32"
-            underflow0 = false
             if k == K"Float"
                 x, code = parse_float_literal(Float64, txtbuf, fbyte, nbyte)
                 # jl_strtod_c can return "underflow" even for valid cases such
@@ -287,7 +286,7 @@ function bump_split(stream::ParseStream, split_spec::Vararg{Any, N}) where {N}
     start_b = _next_byte(stream)
     toklen = tok.next_byte - start_b
     prev_b = start_b
-    for (i, (nbyte, k, f)) in enumerate(split_spec)
+    for (nbyte, k, f) in split_spec
         h = SyntaxHead(k, f)
         actual_nbyte = nbyte < 0 ? (toklen + nbyte) : nbyte
         orig_k = k == K"." ? K"." : kind(tok)

--- a/JuliaSyntax/src/julia/literal_parsing.jl
+++ b/JuliaSyntax/src/julia/literal_parsing.jl
@@ -212,7 +212,7 @@ function unescape_raw_string(io::IO, txtbuf::Vector{UInt8},
             # Backslashes before a delimiter must also be escaped
             nbackslash = div(nbackslash,2)
         end
-        for k = 1:nbackslash
+        for _ = 1:nbackslash
             write(io, u8"\\")
         end
         i = j
@@ -268,7 +268,7 @@ function unescape_julia_string(io::IO, txtbuf::Vector{UInt8},
                 i += 1
             end
             if k == 1 || n > 0x10ffff
-                u = m == 4 ? u8"u" : u8"U"
+                m == 4 ? u8"u" : u8"U"
                 msg = (m == 2) ? "invalid hex escape sequence" :
                                  "invalid unicode escape sequence"
                 emit_diagnostic(diagnostics, escstart:i, error=msg)

--- a/JuliaSyntax/src/julia/parser.jl
+++ b/JuliaSyntax/src/julia/parser.jl
@@ -1572,7 +1572,7 @@ function parse_call_chain(ps::ParseState, mark, is_macrocall=false)
             # A.@var"#" a ==> (macrocall (. A (macro_name (var #))) a)
             # @+x y       ==> (macrocall (macro_name +) x y)
             # A.@.x       ==> (macrocall (. A (macro_name .)) x)
-            processing_macro_name = maybe_parsed_macro_name(
+            maybe_parsed_macro_name(
                 ps, processing_macro_name, last_identifier_orig_kind, mark)
             let ps = with_space_sensitive(ps)
                 # Space separated macro arguments
@@ -2213,7 +2213,6 @@ function parse_if_elseif(ps, is_elseif=false, is_elseif_whitespace_err=false)
     else
         bump(ps, TRIVIA_FLAG)
     end
-    cond_mark = position(ps)
     if peek(ps) in KSet"NewlineWs end"
         # if end      ==>  (if (error) (block))
         # if \n end   ==>  (if (error) (block))
@@ -2275,7 +2274,6 @@ end
 # Parse function and macro definitions
 function parse_function_signature(ps::ParseState, is_function::Bool)
     is_anon_func = false
-    parsed_call = false
     needs_parse_call = true
 
     mark = position(ps)
@@ -2335,7 +2333,6 @@ function parse_function_signature(ps::ParseState, is_function::Bool)
             end::NamedTuple{(:needs_parameters, :is_anon_func, :parsed_call, :needs_parse_call, :maybe_grouping_parens, :delim_flags),
                             Tuple{Bool, Bool, Bool, Bool, Bool, RawFlags}}
             is_anon_func = opts.is_anon_func
-            parsed_call = opts.parsed_call
             needs_parse_call = opts.needs_parse_call
             if is_anon_func
                 # function (x) body end ==>  (function (tuple-p x) (block body))
@@ -2806,7 +2803,6 @@ end
 # flisp: parse-iteration-spec
 function parse_iteration_spec(ps::ParseState)
     mark = position(ps)
-    k = peek(ps)
     # Handle `outer` contextual keyword
     parse_pipe_lt(with_space_sensitive(ps))
     if peek_behind(ps).orig_kind == K"outer"
@@ -2839,7 +2835,7 @@ end
 # generators
 function parse_iteration_specs(ps::ParseState)
     mark = position(ps)
-    n_iters = parse_comma_separated(ps, parse_iteration_spec)
+    _n_iters = parse_comma_separated(ps, parse_iteration_spec)
     emit(ps, mark, K"iteration")
 end
 
@@ -3210,8 +3206,7 @@ function parse_paren(ps::ParseState, check_identifiers=true, has_unary_prefix=fa
     mark = position(ps)
     @check peek(ps) == K"("
     bump(ps, TRIVIA_FLAG) # K"("
-    after_paren_mark = position(ps)
-    (isdot, tok) = peek_dotted_op_token(ps)
+    (_isdot, tok) = peek_dotted_op_token(ps)
     k = kind(tok)
     if k == K")"
         # ()  ==>  (tuple-p)
@@ -3300,7 +3295,6 @@ function parse_brackets(after_parse::F,
                     where_enabled=true,
                     whitespace_newline=true)
     params_positions = acquire_positions(ps.stream)
-    last_eq_before_semi = 0
     num_subexprs = 0
     num_semis = 0
     had_commas = false
@@ -3390,8 +3384,6 @@ function parse_string(ps::ParseState, raw::Bool)
     bump(ps, TRIVIA_FLAG)
     first_chunk = true
     n_nontrivia_chunks = 0
-    removed_initial_newline = false
-    had_interpolation = false
     prev_chunk_newline = false
     while true
         t = peek_full_token(ps)
@@ -3416,7 +3408,7 @@ function parse_string(ps::ParseState, raw::Bool)
                 # "hi$("ho")"     ==>  (string "hi" (parens (string "ho")))
                 m = position(ps)
                 bump(ps, TRIVIA_FLAG)
-                opts = parse_brackets(ps, K")") do had_commas, had_splat, num_semis, num_subexprs
+                opts = parse_brackets(ps, K")") do had_commas, _had_splat, num_semis, num_subexprs
                     return (needs_parameters=false,
                             simple_interp=!had_commas && num_semis == 0 && num_subexprs == 1)
                 end::NamedTuple{(:needs_parameters, :simple_interp, :delim_flags), Tuple{Bool, Bool, RawFlags}}
@@ -3440,7 +3432,6 @@ function parse_string(ps::ParseState, raw::Bool)
             end
             first_chunk = false
             n_nontrivia_chunks += 1
-            had_interpolation = true
             prev_chunk_newline = false
         elseif k == string_chunk_kind
             if triplestr && first_chunk && span(t) <= 2 &&

--- a/JuliaSyntax/src/julia/tokenize.jl
+++ b/JuliaSyntax/src/julia/tokenize.jl
@@ -2,10 +2,9 @@ module Tokenize
 
 export tokenize, untokenize
 
-using ..JuliaSyntax: JuliaSyntax, Kind, @K_str, @KSet_str, @callsite_inline
+using ..JuliaSyntax: @KSet_str, @K_str, @callsite_inline, Kind
 
-import ..JuliaSyntax: kind,
-    is_literal, is_contextual_keyword, is_word_operator
+import ..JuliaSyntax: is_contextual_keyword, is_literal, is_word_operator, kind
 
 #-------------------------------------------------------------------------------
 # Character-based predicates for tokenization
@@ -1082,6 +1081,7 @@ function lex_digit(l::Lexer, kind)
         end
         if is_bin_oct_hex_int
             pc = peekchar(l)
+            @assert @isdefined(had_digits)
             if !had_digits || isdigit(pc) || is_identifier_start_char(pc)
                 accept_batch(l, c->isdigit(c) || is_identifier_start_char(c))
                 # `0x` `0xg` `0x_` `0x-`

--- a/JuliaSyntax/src/porcelain/green_node.jl
+++ b/JuliaSyntax/src/porcelain/green_node.jl
@@ -31,7 +31,7 @@ span(node::GreenNode) = node.span
 
 Base.getindex(node::GreenNode, i::Int) = children(node)[i]
 Base.getindex(node::GreenNode, rng::UnitRange) = view(children(node), rng)
-Base.firstindex(node::GreenNode) = 1
+Base.firstindex(::GreenNode) = 1
 Base.lastindex(node::GreenNode) = children(node) === nothing ? 0 : length(children(node))
 
 """
@@ -158,17 +158,16 @@ function build_tree(::Type{GreenNode}, stream::ParseStream;
     if has_toplevel_siblings(cursor)
         # There are multiple toplevel nodes, e.g. because we're using this
         # to test a partial parse. Wrap everything in K"wrapper"
-        all_processed = 0
         local cs
         for child in reverse_toplevel_siblings(cursor)
             c = GreenNode(child)
-            if !@isdefined(cs)
-                cs = GreenNode{SyntaxHead}[c]
-            else
+            if @isdefined(cs)
                 pushfirst!(cs, c)
+            else
+                cs = GreenNode{SyntaxHead}[c]
             end
         end
-        @assert length(cs) != 1
+        @assert @isdefined(cs) && length(cs) != 1
         return GreenNode(SyntaxHead(K"wrapper", NON_TERMINAL_FLAG), stream.next_byte-1, cs)
     else
         return GreenNode(cursor)

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -224,6 +224,7 @@ function node_string(ex::SyntaxTree, depth=2)
         out *= "]"
     end
     out *= ")"
+    return out
 end
 
 function Base.getproperty(ex::SyntaxTree, name::Symbol)
@@ -258,7 +259,7 @@ function Base.getindex(ex::SyntaxTree, r::UnitRange)
     SyntaxList(ex._graph, children(ex._graph, ex._id, r))
 end
 
-Base.firstindex(ex::SyntaxTree) = 1
+Base.firstindex(::SyntaxTree) = 1
 Base.lastindex(ex::SyntaxTree) = numchildren(ex)
 
 function Base.:≈(ex1::SyntaxTree, ex2::SyntaxTree)
@@ -348,16 +349,16 @@ byte_range(src::SourceRef) = src.first_byte:src.last_byte
 # TODO: Adding these methods to support LineNumberNode is kind of hacky but we
 # can remove these after JuliaLowering becomes self-bootstrapping for macros
 # and we a proper SourceRef for @ast's @HERE form.
-byte_range(src::LineNumberNode) = 0:0
+byte_range(::LineNumberNode) = 0:0
 source_location(src::LineNumberNode) = (src.line, 0)
 source_location(::Type{LineNumberNode}, src::LineNumberNode) = src
 source_line(src::LineNumberNode) = src.line
 # The follow somewhat strange cases are for where LineNumberNode is standing in
 # for SourceFile because we've only got Expr-based provenance info
 sourcefile(src::LineNumberNode) = src
-sourcetext(src::LineNumberNode) = SubString("")
-source_location(src::LineNumberNode, byte_index::Integer) = (src.line, 0)
-source_location(::Type{LineNumberNode}, src::LineNumberNode, byte_index::Integer) = src
+sourcetext(::LineNumberNode) = SubString("")
+source_location(src::LineNumberNode, _byte_index::Integer) = (src.line, 0)
+source_location(::Type{LineNumberNode}, src::LineNumberNode, _byte_index::Integer) = src
 filename(src::LineNumberNode) = string(src.file)
 
 function highlight(io::IO, src::LineNumberNode; note="")
@@ -724,7 +725,7 @@ function mapchildren(f::Function, ctx, ex::SyntaxTree,
 end
 
 function mapchildren(f::Function, ctx, ex::SyntaxTree)
-    mapchildren(f, ctx, ex, i->true)
+    mapchildren(f, ctx, ex, _->true)
 end
 
 
@@ -1702,7 +1703,7 @@ end
 function _string_to_est(st::SyntaxTree, cs::SyntaxList; unwrap_literal)
     ret_cs = SyntaxList(st._graph)
     literal_k = kind(st) === K"cmdstring" ? K"CmdString" : K"String"
-    prev_str = cur_str = false
+    cur_str = false
     next_str = length(cs) > 0 && kind(cs[1]) === literal_k
     buf = IOBuffer()
     for i in eachindex(cs)

--- a/JuliaSyntax/src/porcelain/syntax_node.jl
+++ b/JuliaSyntax/src/porcelain/syntax_node.jl
@@ -130,7 +130,7 @@ function _to_SyntaxNode(source::SourceFile, txtbuf::Vector{UInt8}, offset::Int,
         # We need to match up the filtered SyntaxNode children with the unfiltered GreenNode children
         # Both cursor and green children need to be traversed in the same order
         # Since cursor iterates in reverse, we need to match from the end of green_children
-        green_idx = green_children === nothing ? 0 : length(green_children)
+        green_children === nothing ? 0 : length(green_children)
 
         for (i, child_cursor) in enumerate(reverse(cursor))
             if should_include_node(child_cursor)
@@ -173,7 +173,7 @@ numchildren(node::TreeNode) = (isnothing(node.children) ? 0 : length(node.childr
 
 Base.getindex(node::AbstractSyntaxNode, i::Int) = children(node)[i]
 Base.getindex(node::AbstractSyntaxNode, rng::UnitRange) = view(children(node), rng)
-Base.firstindex(node::AbstractSyntaxNode) = 1
+Base.firstindex(::AbstractSyntaxNode) = 1
 Base.length(node::AbstractSyntaxNode) = length(children(node))
 Base.lastindex(node::AbstractSyntaxNode) = length(node)
 
@@ -225,7 +225,6 @@ function _show_syntax_node(io, current_filename, node::AbstractSyntaxNode,
     else
         posstr = ""
     end
-    val = node.val
     nodestr = is_leaf(node) ? leaf_string(node) : "[$(untokenize(head(node)))]"
     treestr = string(indent, nodestr)
     if show_kind && is_leaf(node)


### PR DESCRIPTION
Remove unused variables, add missing `return` statements, prefix unused parameters with `_`, add `@isdefined` guards, and sort export lists.