### PR TITLE
Add eager `flatten`, as an alternative to `vcat(x...)`  for turning `Vector{Vector{T}}` into `Vector{T}`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2770,6 +2770,67 @@ end
     Ai
 end
 
+
+"""
+    flatten(iters)
+
+Given an iterator that yields iterators, return a `Vector` that contains the elements of those iterators.
+
+Put differently, the elements of the argument iterator are concatenated.
+
+This is equivalent to [`collect`](@ref)`(`[`Iterators.flatten`](@ref)`(iters))`, but may be more performant.
+"""
+flatten(iters) = collect(Iterators.flatten(iters))
+
+function flatten(iters::Union{AbstractArray, Tuple})
+    len = 0
+    unknown = false
+    isconcrete = isconcretetype(eltype(iters))
+    et = Union{}
+    for iter in iters
+        itersize = Base.IteratorSize(iter)
+        itersize === Base.IsInfinite() && throw(ArgumentError("cannot flatten an infinite iterator $(iter)"))
+        if itersize !== Base.SizeUnknown()
+            len += length(iter)
+        else
+            unknown = true
+        end
+        if !isconcrete
+            et = typejoin(et, eltype(typeof(iter)))
+        end
+    end
+
+    if isconcrete
+        et = eltype(eltype(iters))
+    end
+    # len = sum(length, iters)
+
+    res = Vector{et}(undef, unknown ? 1 << Base.top_set_bit(len) : len)
+    i = firstindex(res)
+    if unknown
+        for iter in iters
+            for element in iter
+                res[i] = element
+                i += 1
+                if i > lastindex(res)
+                    resize!(res, length(res) * 2)
+                end
+            end
+        end
+        resize!(res, i - firstindex(res))
+    else
+        for iter in iters
+            for element in iter
+                res[i] = element
+                i += 1
+            end
+        end
+        @assert i == lastindex(res) + 1
+    end
+    return res
+end
+
+
 """
     stack(iter; [dims])
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -445,6 +445,7 @@ export
     fill!,
     fill,
     first,
+    flatten,
     hcat,
     hvcat,
     hvncat,

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1754,6 +1754,35 @@ using Base: typed_hvncat
     @test [zeros(1, 0) zeros(1,0);;; zeros(0,0) zeros(0, 0)] == Array{Float64, 3}(undef, 1, 0, 0)
 end
 
+@testset "flatten" begin
+    examples = Any[
+        [[1,2], [3,4]],
+        [rand(rand(1:100)) for _ in 1:100],
+        [1:10, (3,2,1), [6,5]],
+        [1:10, (3,2,1), (eval(x) for x in ["1", "2"])],
+        (1:10, (3,2,1), (eval(x) for x in ["1", "2"])),
+        ((1,2), (3,4)),
+        (rand(10), rand(20)),
+        Any[1:3, 5:6],
+        Any[1:3, 5:0.5:6],
+        Vector[[1, 2], [3.0, 4.0]],
+        [rand(rand([Int, Float64]), rand(1:100)) for _ in 1:100],
+        [rand(rand(1:10)) for _ in 1:10000],
+        (1:i for i in 1:10),
+    ]
+
+    for e in examples
+        eager = flatten(e)
+        lazy = collect(Iterators.flatten(e))
+        @test eager == lazy
+        @test eager isa Vector
+        @test eltype(eager) <: eltype(lazy) # In some cases, eager gets a more precise eltype (see below for specific example)
+    end
+
+    @test flatten(Vector[[1, 2], [3.0, 4.0]]) isa Vector{Real}
+    @test collect(Iterators.flatten(Vector[[1, 2], [3.0, 4.0]])) isa Vector{Any}
+end
+
 @testset "stack" begin
     # Basics
     for args in ([[1, 2]], [1:2, 3:4], [[1 2; 3 4], [5 6; 7 8]],


### PR DESCRIPTION
`vcat(x...)` where `x::Vector` is a common source of confusion for folks new to Julia and performance optimization. The splat is type unstable, but does not trigger dynamic dispatch, making it significantly slower than optimal, but still not the allocations and catastrophic performance hit many more experienced users would expect.

https://discourse.julialang.org/t/very-best-way-to-concatenate-an-array-of-arrays/8672/50
https://discourse.julialang.org/t/vector-of-vectors-with-different-size-to-one-vector/40534/7
https://discourse.julialang.org/t/how-to-collapse-a-vector-of-vector/32877/12

What frustrates me, looking at these discussions, is that there is not a clear, good alternative to `vcat(x...)` to recommend. `reduce(vcat, x)` is the closest, but its semantics are very inefficient (pairwise `vcat`) so it's not at all obvious that it is better than `vcat(x...)`. And while we have good special handling cases for both of these, resulting in both `vcat(x...)` and `reduce(vcat, x)` being reasonably efficient, with the reduce version marginally faster, they are both less efficient than a reasonable `flatten` implementation.

I propose an eager `flatten` function with the same semantics as `collect(Iterators.flatten(_))`. This has semantics that are simple for simple inputs and robust to very diverse inputs and can clearly be implemented in a performant way. This gives an answer to "what do I replace `vcat(x...)` with?" that is clearly optimal.

Performance is better than existing Base alternatives:
```julia-repl
julia> using Chairmarks

julia> @b [rand(rand(1:100)) for _ in 1:100] flatten(_), collect(Iterators.flatten(_)), reduce(vcat,_), vcat(_...)
(3.265 μs (3 allocs: 32.445 KiB), 14.375 μs (13 allocs: 91.766 KiB), 4.300 μs (5 allocs: 33.352 KiB), 4.775 μs (3 allocs: 32.445 KiB))

julia> examples = Any[
           [[1,2], [3,4]],
           [rand(rand(1:100)) for _ in 1:100],
           [1:10, (3,2,1), [6,5]],
           [1:10, (3,2,1), (eval(x) for x in ["1", "2"])],
           (1:10, (3,2,1), (eval(x) for x in ["1", "2"])),
           ((1,2), (3,4)),
           (rand(10), rand(20)),
           Any[1:3, 5:6],
           Any[1:3, 5:0.5:6],
           Vector[[1, 2], [3.0, 4.0]],
           [rand(rand([Int, Float64]), rand(1:100)) for _ in 1:100],
           [rand(rand(1:10)) for _ in 1:10000],
           (1:i for i in 1:10),
       ];

julia> for e in examples
           @assert flatten(e) == collect(Iterators.flatten(e))
           print(rpad(summary(e), 52)[1:52])
           lazy, eager = (@b e collect(Iterators.flatten(_)),flatten(_))
           print(rpad(sprint(show, MIME"text/plain"(), lazy), 40))
           display(eager)
       end
2-element Vector{Vector{Int64}}                     91.529 ns (3 allocs: 176 bytes)         40.942 ns (2 allocs: 96 bytes)
100-element Vector{Vector{Float64}}                 14.621 μs (13 allocs: 91.766 KiB)       2.404 μs (3 allocs: 39.258 KiB)
3-element Vector{Any}                               9.231 μs (61 allocs: 2.578 KiB)         6.589 μs (17 allocs: 656 bytes)
3-element Vector{Any}                               10.313 μs (65 allocs: 3.094 KiB)        9.740 μs (17 allocs: 656 bytes)
Tuple{UnitRange{Int64}, Tuple{Int64, Int64, Int64}, 9.665 μs (82 allocs: 3.688 KiB)         652.500 ns (10 allocs: 528 bytes)
Tuple{Tuple{Int64, Int64}, Tuple{Int64, Int64}}     35.598 ns (2 allocs: 96 bytes)          30.779 ns (2 allocs: 96 bytes)
Tuple{Vector{Float64}, Vector{Float64}}             179.469 ns (4 allocs: 480 bytes)        56.656 ns (2 allocs: 304 bytes)
2-element Vector{Any}                               6.014 μs (28 allocs: 1.109 KiB)         2.563 μs (7 allocs: 256 bytes)
2-element Vector{Any}                               6.876 μs (38 allocs: 1.594 KiB)         3.073 μs (14 allocs: 400 bytes)
2-element Vector{Vector}                            1.142 μs (20 allocs: 672 bytes)         3.263 μs (8 allocs: 224 bytes)
100-element Vector{Vector}                          598.263 μs (19137 allocs: 613.906 KiB)  586.882 μs (13786 allocs: 253.992 KiB)
10000-element Vector{Vector{Float64}}               231.174 μs (19 allocs: 845.383 KiB)     176.956 μs (3 allocs: 426.570 KiB)
Base.Generator{UnitRange{Int64}, var"#389#390"}     351.889 ns (6 allocs: 1.641 KiB)        334.556 ns (6 allocs: 1.641 KiB)
```