### PR TITLE
Make `jl_object_in_image` thread-safe

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -767,6 +767,7 @@ JL_DLLEXPORT void jl_init_(jl_image_buf_t sysimage)
 #endif
 
     jl_init_rand();
+    jl_init_staticdata();
     jl_init_runtime_ccall();
     jl_init_tasks();
     jl_init_threading();
@@ -775,14 +776,6 @@ JL_DLLEXPORT void jl_init_(jl_image_buf_t sysimage)
         jl_install_default_signal_handlers();
 
     jl_gc_init();
-
-    arraylist_new(&jl_linkage_blobs, 0);
-    arraylist_new(&jl_image_relocs, 0);
-    arraylist_new(&jl_top_mods, 0);
-    arraylist_new(&eytzinger_image_tree, 0);
-    arraylist_new(&eytzinger_idxs, 0);
-    arraylist_push(&eytzinger_idxs, (void*)0);
-    arraylist_push(&eytzinger_image_tree, (void*)1); // outside image
 
     jl_ptls_t ptls = jl_init_threadtls(0);
 #pragma GCC diagnostic push

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -516,11 +516,6 @@ extern tracer_cb jl_newmeth_tracer;
 void jl_call_tracer(tracer_cb callback, jl_value_t *tracee);
 void print_func_loc(JL_STREAM *s, jl_method_t *m);
 extern jl_array_t *_jl_debug_method_invalidation JL_GLOBALLY_ROOTED;
-JL_DLLEXPORT extern arraylist_t jl_linkage_blobs; // external linkage: sysimg/pkgimages
-JL_DLLEXPORT extern arraylist_t jl_image_relocs;  // external linkage: sysimg/pkgimages
-JL_DLLEXPORT extern arraylist_t jl_top_mods;  // external linkage: sysimg/pkgimages
-extern arraylist_t eytzinger_image_tree;
-extern arraylist_t eytzinger_idxs;
 
 extern JL_DLLEXPORT size_t jl_page_size;
 extern JL_DLLEXPORT size_t jl_hugepage_size;
@@ -1324,6 +1319,7 @@ void jl_init_llvm(void);
 void jl_init_runtime_ccall(void);
 void jl_init_intrinsic_functions(void);
 void jl_init_intrinsic_properties(void);
+void jl_init_staticdata(void);
 // TypeApp: immutable struct with head::Any, param::Any
 // Represents a single lazy type application step (like UnionAll for where bindings).
 typedef struct {
@@ -1410,14 +1406,6 @@ extern pthread_mutex_t in_signal_lock;
 #endif
 
 void jl_set_gc_and_wait(jl_task_t *ct);
-
-// Query if a Julia object is if a permalloc region (due to part of a sys- pkg-image)
-STATIC_INLINE size_t n_linkage_blobs(void) JL_NOTSAFEPOINT
-{
-    return jl_image_relocs.len;
-}
-
-size_t external_blob_index(jl_value_t *v) JL_NOTSAFEPOINT;
 
 // Query if this object is perm-allocated in an image.
 JL_DLLEXPORT uint8_t jl_object_in_image(jl_value_t* v) JL_NOTSAFEPOINT;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -157,23 +157,18 @@ static arraylist_t serialization_queue;
 static arraylist_t layout_table;     // cache of `position(s)` for each `id` in `serialization_order`
 static arraylist_t object_worklist;  // used to mimic recursion by jl_serialize_reachable
 
-// image_tree.blobs stores (begin, end+1) pairs of system/package images loaded previously
-// image_tree.blobs.items[2i:2i+1] correspond to build_ids[i]   (0-offset indexing)
-//
-// XXX: If image_tree ever has multiple concurrent writers, then image_tree.blobs accesses
-//      (and also the related metadata just below) need to take the image_tree.rwlock.
+// Track image locations and some associated metadata for all loaded sys / pkgimages.
+// (image_tree.userdata.items[i] is an image_metadata_t* for build_ids[i])
 static eyt_tree_t image_tree;
-
-// relocs_base for each image blob
-static arraylist_t jl_image_relocs;
-// Keep track of which image corresponds to which top module.
-static arraylist_t jl_top_mods;
+typedef struct {
+    uintptr_t base;          // base address of the image
+    void *relocs_base;       // reloc_t* for GC sweep
+    jl_module_t *top_mod;    // owning top-level module
+    size_t idx;              // range index in image_tree (for serialization)
+} image_metadata_t;
 
 void jl_init_staticdata(void)
 {
-    arraylist_new(&jl_image_relocs, 0);
-    arraylist_new(&jl_top_mods, 0);
-
     eyt_tree_init(&image_tree);
 }
 
@@ -192,16 +187,23 @@ static void *to_seroder_entry(size_t idx) JL_NOTSAFEPOINT
 static htable_t new_methtables;
 //static size_t precompilation_world;
 
-// Query if a Julia object is if a permalloc region (due to part of a sys- pkg-image)
-size_t n_linkage_blobs(void) JL_NOTSAFEPOINT
+// Query if a Julia object is in a permalloc region (due to part of a sys- pkg-image)
+static size_t n_linkage_blobs(void) JL_NOTSAFEPOINT
 {
-    return jl_image_relocs.len;
+    return image_tree.userdata.len;
 }
 
-size_t external_blob_index(jl_value_t *v) JL_NOTSAFEPOINT
+static image_metadata_t *external_blob_metadata(jl_value_t *v) JL_NOTSAFEPOINT
 {
     assert((uintptr_t) v % 4 == 0 && "Object not 4-byte aligned!");
-    return eyt_tree_find_range_idx(&image_tree, (uintptr_t)v);
+    void *data = eyt_tree_find_data(&image_tree, (uintptr_t)v);
+    return data == EYT_NOTFOUND ? NULL : (image_metadata_t*)data;
+}
+
+static size_t external_blob_index(jl_value_t *v) JL_NOTSAFEPOINT
+{
+    image_metadata_t *meta = external_blob_metadata(v);
+    return meta ? meta->idx : (size_t)-1;
 }
 
 JL_DLLEXPORT uint8_t jl_object_in_image(jl_value_t *obj) JL_NOTSAFEPOINT
@@ -214,14 +216,12 @@ JL_DLLEXPORT uint8_t jl_object_in_image(jl_value_t *obj) JL_NOTSAFEPOINT
     return in_image;
 }
 
-// Map an object to it's "owning" top module
+// Map an object to its "owning" top module
 JL_DLLEXPORT jl_value_t *jl_object_top_module(jl_value_t* v) JL_NOTSAFEPOINT
 {
-    size_t idx = external_blob_index(v);
-    size_t lbids = n_linkage_blobs();
-    if (idx < lbids) {
-        return (jl_value_t*)jl_top_mods.items[idx];
-    }
+    image_metadata_t *meta = external_blob_metadata(v);
+    if (meta)
+        return (jl_value_t*)meta->top_mod;
     // The object is runtime allocated
     return (jl_value_t*)jl_nothing;
 }
@@ -258,7 +258,7 @@ typedef struct {
     // record of build_ids for all external linkages, in order of serialization for the current sysimg/pkgimg
     // conceptually, the base pointer for the jth externally-linked item is determined from
     //     i = findfirst(==(link_ids[j]), build_ids)
-    //     blob_base = image_tree.blobs.items[2i]                     # 0-offset indexing
+    //     blob_base = ((image_metadata_t*)image_tree.userdata.items[i])->base
     // We need separate lists since they are intermingled at creation but split when written.
     jl_array_t *link_ids_relocs;
     jl_array_t *link_ids_gctags;
@@ -980,11 +980,12 @@ static void write_pointer(ios_t *s) JL_NOTSAFEPOINT
 // Records the buildid holding `v` and returns the tagged offset within the corresponding image
 static uintptr_t add_external_linkage(jl_serializer_state *s, jl_value_t *v, jl_array_t *link_ids) JL_GC_DISABLED
 {
-    size_t i = external_blob_index(v);
-    if (i < n_linkage_blobs()) {
+    image_metadata_t *meta = external_blob_metadata(v);
+    if (meta) {
+        size_t i = meta->idx;
         // We found the sysimg/pkg that this item links against
         // Compute the relocation code
-        size_t offset = (uintptr_t)v - (uintptr_t)image_tree.blobs.items[2*i];
+        size_t offset = (uintptr_t)v - meta->base;
         assert((offset % SYS_EXTERNAL_LINK_UNIT) == 0);
         offset /= SYS_EXTERNAL_LINK_UNIT;
         assert(n_linkage_blobs() == jl_array_nrows(s->buildid_depmods_idxs));
@@ -1930,8 +1931,9 @@ static inline uintptr_t get_item_for_reloc(jl_serializer_state *s, uintptr_t bas
 #endif
         assert(s->buildid_depmods_idxs && depsidx < jl_array_len(s->buildid_depmods_idxs));
         size_t i = jl_array_data(s->buildid_depmods_idxs, uint32_t)[depsidx];
-        assert(2*i < image_tree.blobs.len);
-        return (uintptr_t)image_tree.blobs.items[2*i] + offset*SYS_EXTERNAL_LINK_UNIT;
+        assert(i < image_tree.userdata.len);
+        image_metadata_t *meta = (image_metadata_t*)image_tree.userdata.items[i];
+        return meta->base + offset*SYS_EXTERNAL_LINK_UNIT;
     }
     case ExternalLinkage: {
         assert(link_ids);
@@ -1941,8 +1943,9 @@ static inline uintptr_t get_item_for_reloc(jl_serializer_state *s, uintptr_t bas
         *link_index += 1;
         assert(depsidx < jl_array_len(s->buildid_depmods_idxs));
         size_t i = jl_array_data(s->buildid_depmods_idxs, uint32_t)[depsidx];
-        assert(2*i < image_tree.blobs.len);
-        return (uintptr_t)image_tree.blobs.items[2*i] + offset*SYS_EXTERNAL_LINK_UNIT;
+        assert(i < image_tree.userdata.len);
+        image_metadata_t *meta = (image_metadata_t*)image_tree.userdata.items[i];
+        return meta->base + offset*SYS_EXTERNAL_LINK_UNIT;
     }
     }
     abort();
@@ -2073,15 +2076,12 @@ void gc_sweep_sysimg(void) JL_NOTSAFEPOINT
     size_t nblobs = n_linkage_blobs();
     if (nblobs == 0)
         return;
-    assert(image_tree.blobs.len == 2*nblobs);
-    assert(jl_image_relocs.len == nblobs);
-    for (size_t i = 0; i < 2*nblobs; i+=2) {
-        // This access bypasses jl_image_relocs.wrlock, but it
-        // is safe since any writes are JL_NOTSAFEPOINT.
-        reloc_t *relocs = (reloc_t*)jl_image_relocs.items[i>>1];
+    for (size_t i = 0; i < nblobs; i++) {
+        image_metadata_t *meta = (image_metadata_t*)image_tree.userdata.items[i];
+        reloc_t *relocs = (reloc_t*)meta->relocs_base;
         if (!relocs)
             continue;
-        uintptr_t base = (uintptr_t)image_tree.blobs.items[i];
+        uintptr_t base = meta->base;
         uintptr_t last_pos = 0;
         uint8_t *current = (uint8_t *)relocs;
         while (1) {
@@ -3694,7 +3694,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     int en = jl_gc_enable(0);
     ios_t sysimg, const_data, symbols, relocs, gvar_record, fptr_record;
     jl_serializer_state s = {0};
-    s.incremental = restored != NULL; // image_tree.blobs.len > 0;
+    s.incremental = restored != NULL; // n_linkage_blobs() > 0;
     s.image = image;
     s.s = NULL;
     s.const_data = &const_data;
@@ -4208,12 +4208,12 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
 
     // Prepare for later external linkage against the sysimg
     // Also sets up images for protection against garbage collection
-    eyt_tree_add_range(&image_tree,
-        (uintptr_t)image_base,
-        (uintptr_t)image_base + sizeof_sysimg);
-    arraylist_push(&jl_image_relocs, (void*)relocs_base);
+    image_metadata_t *meta = (image_metadata_t*)malloc_s(sizeof(image_metadata_t));
+    meta->base = (uintptr_t)image_base;
+    meta->relocs_base = (void*)relocs_base;
+    meta->idx = n_linkage_blobs();
     if (restored == NULL) {
-        arraylist_push(&jl_top_mods, (void*)jl_top_module);
+        meta->top_mod = jl_top_module;
     } else {
         size_t len = jl_array_nrows(*restored);
         assert(len > 0);
@@ -4222,8 +4222,12 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         // just returns a reference to the sysimage version, so we set it here.
         topmod->build_id.hi = checksum;
         assert(jl_is_module(topmod));
-        arraylist_push(&jl_top_mods, (void*)topmod);
+        meta->top_mod = topmod;
     }
+    eyt_tree_add_range(&image_tree,
+        (uintptr_t)image_base,
+        (uintptr_t)image_base + sizeof_sysimg,
+        (void*)meta);
     jl_timing_counter_inc(JL_TIMING_COUNTER_ImageSize, sizeof_sysimg + sizeof(uintptr_t));
 
     // jl_printf(JL_STDOUT, "%ld blobs to link against\n", image_tree.blobs.len >> 1);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -158,7 +158,7 @@ static arraylist_t layout_table;     // cache of `position(s)` for each `id` in 
 static arraylist_t object_worklist;  // used to mimic recursion by jl_serialize_reachable
 
 // Track image locations and some associated metadata for all loaded sys / pkgimages.
-// (image_tree.userdata.items[i] is an image_metadata_t* for build_ids[i])
+// (image_tree.ranges[i].data is an image_metadata_t* for build_ids[i])
 static eyt_tree_t image_tree;
 typedef struct {
     uintptr_t base;          // base address of the image
@@ -190,7 +190,7 @@ static htable_t new_methtables;
 // Query if a Julia object is in a permalloc region (due to part of a sys- pkg-image)
 static size_t n_linkage_blobs(void) JL_NOTSAFEPOINT
 {
-    return image_tree.userdata.len;
+    return image_tree.nranges;
 }
 
 static image_metadata_t *external_blob_metadata(jl_value_t *v) JL_NOTSAFEPOINT
@@ -258,7 +258,7 @@ typedef struct {
     // record of build_ids for all external linkages, in order of serialization for the current sysimg/pkgimg
     // conceptually, the base pointer for the jth externally-linked item is determined from
     //     i = findfirst(==(link_ids[j]), build_ids)
-    //     blob_base = ((image_metadata_t*)image_tree.userdata.items[i])->base
+    //     blob_base = ((image_metadata_t*)image_tree.ranges[i].data)->base
     // We need separate lists since they are intermingled at creation but split when written.
     jl_array_t *link_ids_relocs;
     jl_array_t *link_ids_gctags;
@@ -1931,8 +1931,8 @@ static inline uintptr_t get_item_for_reloc(jl_serializer_state *s, uintptr_t bas
 #endif
         assert(s->buildid_depmods_idxs && depsidx < jl_array_len(s->buildid_depmods_idxs));
         size_t i = jl_array_data(s->buildid_depmods_idxs, uint32_t)[depsidx];
-        assert(i < image_tree.userdata.len);
-        image_metadata_t *meta = (image_metadata_t*)image_tree.userdata.items[i];
+        assert(i < image_tree.nranges);
+        image_metadata_t *meta = (image_metadata_t*)image_tree.ranges[i].data;
         return meta->base + offset*SYS_EXTERNAL_LINK_UNIT;
     }
     case ExternalLinkage: {
@@ -1943,8 +1943,8 @@ static inline uintptr_t get_item_for_reloc(jl_serializer_state *s, uintptr_t bas
         *link_index += 1;
         assert(depsidx < jl_array_len(s->buildid_depmods_idxs));
         size_t i = jl_array_data(s->buildid_depmods_idxs, uint32_t)[depsidx];
-        assert(i < image_tree.userdata.len);
-        image_metadata_t *meta = (image_metadata_t*)image_tree.userdata.items[i];
+        assert(i < image_tree.nranges);
+        image_metadata_t *meta = (image_metadata_t*)image_tree.ranges[i].data;
         return meta->base + offset*SYS_EXTERNAL_LINK_UNIT;
     }
     }
@@ -2077,7 +2077,7 @@ void gc_sweep_sysimg(void) JL_NOTSAFEPOINT
     if (nblobs == 0)
         return;
     for (size_t i = 0; i < nblobs; i++) {
-        image_metadata_t *meta = (image_metadata_t*)image_tree.userdata.items[i];
+        image_metadata_t *meta = (image_metadata_t*)image_tree.ranges[i].data;
         reloc_t *relocs = (reloc_t*)meta->relocs_base;
         if (!relocs)
             continue;
@@ -4230,7 +4230,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         (void*)meta);
     jl_timing_counter_inc(JL_TIMING_COUNTER_ImageSize, sizeof_sysimg + sizeof(uintptr_t));
 
-    // jl_printf(JL_STDOUT, "%ld blobs to link against\n", image_tree.blobs.len >> 1);
+    // jl_printf(JL_STDOUT, "%ld blobs to link against\n", image_tree.nranges);
     jl_gc_enable(en);
 
     if (s.incremental)

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -206,8 +206,12 @@ size_t external_blob_index(jl_value_t *v) JL_NOTSAFEPOINT
 
 JL_DLLEXPORT uint8_t jl_object_in_image(jl_value_t *obj) JL_NOTSAFEPOINT
 {
+    if (obj == NULL)
+        return 0;
+    uint8_t in_image = jl_astaggedvalue(obj)->bits.in_image != 0;
     assert((uintptr_t) obj % 4 == 0 && "Object not 4-byte aligned!");
-    return eyt_tree_is_in_range(&image_tree, (uintptr_t)obj);
+    assert(eyt_tree_is_in_range(&image_tree, (uintptr_t)obj) == in_image);
+    return in_image;
 }
 
 // Map an object to it's "owning" top module

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -90,6 +90,7 @@ External links:
 
 #include "valgrind.h"
 #include "julia_assert.h"
+#include "eytzinger.h"
 
 static const size_t WORLD_AGE_REVALIDATION_SENTINEL = 0x1;
 JL_DLLEXPORT size_t jl_require_world = ~(size_t)0;
@@ -156,20 +157,25 @@ static arraylist_t serialization_queue;
 static arraylist_t layout_table;     // cache of `position(s)` for each `id` in `serialization_order`
 static arraylist_t object_worklist;  // used to mimic recursion by jl_serialize_reachable
 
-// Permanent list of void* (begin, end+1) pairs of system/package images we've loaded previously
-// together with their module build_ids (used for external linkage)
-// jl_linkage_blobs.items[2i:2i+1] correspond to build_ids[i]   (0-offset indexing)
-arraylist_t jl_linkage_blobs;
-arraylist_t jl_image_relocs;
-// Keep track of which image corresponds to which top module.
-arraylist_t jl_top_mods;
+// image_tree.blobs stores (begin, end+1) pairs of system/package images loaded previously
+// image_tree.blobs.items[2i:2i+1] correspond to build_ids[i]   (0-offset indexing)
+//
+// XXX: If image_tree ever has multiple concurrent writers, then image_tree.blobs accesses
+//      (and also the related metadata just below) need to take the image_tree.rwlock.
+static eyt_tree_t image_tree;
 
-// Eytzinger tree of images. Used for very fast jl_object_in_image queries
-// See https://algorithmica.org/en/eytzinger
-arraylist_t eytzinger_image_tree;
-arraylist_t eytzinger_idxs;
-static uintptr_t img_min;
-static uintptr_t img_max;
+// relocs_base for each image blob
+static arraylist_t jl_image_relocs;
+// Keep track of which image corresponds to which top module.
+static arraylist_t jl_top_mods;
+
+void jl_init_staticdata(void)
+{
+    arraylist_new(&jl_image_relocs, 0);
+    arraylist_new(&jl_top_mods, 0);
+
+    eyt_tree_init(&image_tree);
+}
 
 // HT_NOTFOUND is a valid integer ID, so we store the integer ids mangled.
 // This pair of functions mangles/demanges
@@ -186,115 +192,22 @@ static void *to_seroder_entry(size_t idx) JL_NOTSAFEPOINT
 static htable_t new_methtables;
 //static size_t precompilation_world;
 
-static int ptr_cmp(const void *l, const void *r) JL_NOTSAFEPOINT
+// Query if a Julia object is if a permalloc region (due to part of a sys- pkg-image)
+size_t n_linkage_blobs(void) JL_NOTSAFEPOINT
 {
-    uintptr_t left = *(const uintptr_t*)l;
-    uintptr_t right = *(const uintptr_t*)r;
-    return (left > right) - (left < right);
-}
-
-// Build an eytzinger tree from a sorted array
-static int eytzinger(uintptr_t *src, uintptr_t *dest, size_t i, size_t k, size_t n) JL_NOTSAFEPOINT
-{
-    if (k <= n) {
-        i = eytzinger(src, dest, i, 2 * k, n);
-        dest[k-1] = src[i];
-        i++;
-        i = eytzinger(src, dest, i, 2 * k + 1, n);
-    }
-    return i;
-}
-
-static size_t eyt_obj_idx(jl_value_t *obj) JL_NOTSAFEPOINT
-{
-    size_t n = eytzinger_image_tree.len - 1;
-    if (n == 0)
-        return n;
-    assert(n % 2 == 0 && "Eytzinger tree not even length!");
-    uintptr_t cmp = (uintptr_t) obj;
-    if (cmp <= img_min || cmp > img_max)
-        return n;
-    uintptr_t *tree = (uintptr_t*)eytzinger_image_tree.items;
-    size_t k = 1;
-    // note that k preserves the history of how we got to the current node
-    while (k <= n) {
-        int greater = (cmp > tree[k - 1]);
-        k <<= 1;
-        k |= greater;
-    }
-    // Free to assume k is nonzero, since we start with k = 1
-    // and cmp > gc_img_min
-    // This shift does a fast revert of the path until we get
-    // to a node that evaluated less than cmp.
-    k >>= (__builtin_ctzll(k) + 1);
-    assert(k != 0);
-    assert(k <= n && "Eytzinger tree index out of bounds!");
-    assert(tree[k - 1] < cmp && "Failed to find lower bound for object!");
-    return k - 1;
-}
-
-//used in staticdata.c after we add an image
-void rebuild_image_blob_tree(void) JL_NOTSAFEPOINT
-{
-    size_t inc = 1 + jl_linkage_blobs.len - eytzinger_image_tree.len;
-    assert(eytzinger_idxs.len == eytzinger_image_tree.len);
-    assert(eytzinger_idxs.max == eytzinger_image_tree.max);
-    arraylist_grow(&eytzinger_idxs, inc);
-    arraylist_grow(&eytzinger_image_tree, inc);
-    eytzinger_idxs.items[eytzinger_idxs.len - 1] = (void*)jl_linkage_blobs.len;
-    eytzinger_image_tree.items[eytzinger_image_tree.len - 1] = (void*)1; // outside image
-    for (size_t i = 0; i < jl_linkage_blobs.len; i++) {
-        assert((uintptr_t) jl_linkage_blobs.items[i] % 4 == 0 && "Linkage blob not 4-byte aligned!");
-        // We abuse the pointer here a little so that a couple of properties are true:
-        // 1. a start and an end are never the same value. This simplifies the binary search.
-        // 2. ends are always after starts. This also simplifies the binary search.
-        // We assume that there exist no 0-size blobs, but that's a safe assumption
-        // since it means nothing could be there anyways
-        uintptr_t val = (uintptr_t) jl_linkage_blobs.items[i];
-        eytzinger_idxs.items[i] = (void*)(val + (i & 1));
-    }
-    qsort(eytzinger_idxs.items, eytzinger_idxs.len - 1, sizeof(void*), ptr_cmp);
-    img_min = (uintptr_t) eytzinger_idxs.items[0];
-    img_max = (uintptr_t) eytzinger_idxs.items[eytzinger_idxs.len - 2] + 1;
-    eytzinger((uintptr_t*)eytzinger_idxs.items, (uintptr_t*)eytzinger_image_tree.items, 0, 1, eytzinger_idxs.len - 1);
-    // Reuse the scratch memory to store the indices
-    // Still O(nlogn) because binary search
-    for (size_t i = 0; i < jl_linkage_blobs.len; i ++) {
-        uintptr_t val = (uintptr_t) jl_linkage_blobs.items[i];
-        // This is the same computation as in the prior for loop
-        uintptr_t eyt_val = val + (i & 1);
-        size_t eyt_idx = eyt_obj_idx((jl_value_t*)(eyt_val + 1)); assert(eyt_idx < eytzinger_idxs.len - 1);
-        assert(eytzinger_image_tree.items[eyt_idx] == (void*)eyt_val && "Eytzinger tree failed to find object!");
-        if (i & 1)
-            eytzinger_idxs.items[eyt_idx] = (void*)n_linkage_blobs();
-        else
-            eytzinger_idxs.items[eyt_idx] = (void*)(i / 2);
-    }
-}
-
-static int eyt_obj_in_img(jl_value_t *obj) JL_NOTSAFEPOINT
-{
-    assert((uintptr_t) obj % 4 == 0 && "Object not 4-byte aligned!");
-    int idx = eyt_obj_idx(obj);
-    // Now we use a tiny trick: tree[idx] & 1 is whether or not tree[idx] is a
-    // start (0) or an end (1) of a blob. If it's a start, then the object is
-    // in the image, otherwise it is not.
-    int in_image = ((uintptr_t)eytzinger_image_tree.items[idx] & 1) == 0;
-    return in_image;
+    return jl_image_relocs.len;
 }
 
 size_t external_blob_index(jl_value_t *v) JL_NOTSAFEPOINT
 {
     assert((uintptr_t) v % 4 == 0 && "Object not 4-byte aligned!");
-    int eyt_idx = eyt_obj_idx(v);
-    // We fill the invalid slots with the length, so we can just return that
-    size_t idx = (size_t) eytzinger_idxs.items[eyt_idx];
-    return idx;
+    return eyt_tree_find_range_idx(&image_tree, (uintptr_t)v);
 }
 
 JL_DLLEXPORT uint8_t jl_object_in_image(jl_value_t *obj) JL_NOTSAFEPOINT
 {
-    return eyt_obj_in_img(obj);
+    assert((uintptr_t) obj % 4 == 0 && "Object not 4-byte aligned!");
+    return eyt_tree_is_in_range(&image_tree, (uintptr_t)obj);
 }
 
 // Map an object to it's "owning" top module
@@ -341,7 +254,7 @@ typedef struct {
     // record of build_ids for all external linkages, in order of serialization for the current sysimg/pkgimg
     // conceptually, the base pointer for the jth externally-linked item is determined from
     //     i = findfirst(==(link_ids[j]), build_ids)
-    //     blob_base = jl_linkage_blobs.items[2i]                     # 0-offset indexing
+    //     blob_base = image_tree.blobs.items[2i]                     # 0-offset indexing
     // We need separate lists since they are intermingled at creation but split when written.
     jl_array_t *link_ids_relocs;
     jl_array_t *link_ids_gctags;
@@ -1067,7 +980,7 @@ static uintptr_t add_external_linkage(jl_serializer_state *s, jl_value_t *v, jl_
     if (i < n_linkage_blobs()) {
         // We found the sysimg/pkg that this item links against
         // Compute the relocation code
-        size_t offset = (uintptr_t)v - (uintptr_t)jl_linkage_blobs.items[2*i];
+        size_t offset = (uintptr_t)v - (uintptr_t)image_tree.blobs.items[2*i];
         assert((offset % SYS_EXTERNAL_LINK_UNIT) == 0);
         offset /= SYS_EXTERNAL_LINK_UNIT;
         assert(n_linkage_blobs() == jl_array_nrows(s->buildid_depmods_idxs));
@@ -2013,8 +1926,8 @@ static inline uintptr_t get_item_for_reloc(jl_serializer_state *s, uintptr_t bas
 #endif
         assert(s->buildid_depmods_idxs && depsidx < jl_array_len(s->buildid_depmods_idxs));
         size_t i = jl_array_data(s->buildid_depmods_idxs, uint32_t)[depsidx];
-        assert(2*i < jl_linkage_blobs.len);
-        return (uintptr_t)jl_linkage_blobs.items[2*i] + offset*SYS_EXTERNAL_LINK_UNIT;
+        assert(2*i < image_tree.blobs.len);
+        return (uintptr_t)image_tree.blobs.items[2*i] + offset*SYS_EXTERNAL_LINK_UNIT;
     }
     case ExternalLinkage: {
         assert(link_ids);
@@ -2024,8 +1937,8 @@ static inline uintptr_t get_item_for_reloc(jl_serializer_state *s, uintptr_t bas
         *link_index += 1;
         assert(depsidx < jl_array_len(s->buildid_depmods_idxs));
         size_t i = jl_array_data(s->buildid_depmods_idxs, uint32_t)[depsidx];
-        assert(2*i < jl_linkage_blobs.len);
-        return (uintptr_t)jl_linkage_blobs.items[2*i] + offset*SYS_EXTERNAL_LINK_UNIT;
+        assert(2*i < image_tree.blobs.len);
+        return (uintptr_t)image_tree.blobs.items[2*i] + offset*SYS_EXTERNAL_LINK_UNIT;
     }
     }
     abort();
@@ -2156,13 +2069,15 @@ void gc_sweep_sysimg(void) JL_NOTSAFEPOINT
     size_t nblobs = n_linkage_blobs();
     if (nblobs == 0)
         return;
-    assert(jl_linkage_blobs.len == 2*nblobs);
+    assert(image_tree.blobs.len == 2*nblobs);
     assert(jl_image_relocs.len == nblobs);
     for (size_t i = 0; i < 2*nblobs; i+=2) {
+        // This access bypasses jl_image_relocs.wrlock, but it
+        // is safe since any writes are JL_NOTSAFEPOINT.
         reloc_t *relocs = (reloc_t*)jl_image_relocs.items[i>>1];
         if (!relocs)
             continue;
-        uintptr_t base = (uintptr_t)jl_linkage_blobs.items[i];
+        uintptr_t base = (uintptr_t)image_tree.blobs.items[i];
         uintptr_t last_pos = 0;
         uint8_t *current = (uint8_t *)relocs;
         while (1) {
@@ -3663,7 +3578,6 @@ JL_DLLEXPORT jl_image_buf_t jl_set_sysimg_so(void *handle)
 // }
 #endif
 
-extern void rebuild_image_blob_tree(void);
 extern void export_jl_small_typeof(void);
 extern void export_jl_sysimg_globals(void);
 
@@ -3776,7 +3690,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     int en = jl_gc_enable(0);
     ios_t sysimg, const_data, symbols, relocs, gvar_record, fptr_record;
     jl_serializer_state s = {0};
-    s.incremental = restored != NULL; // jl_linkage_blobs.len > 0;
+    s.incremental = restored != NULL; // image_tree.blobs.len > 0;
     s.image = image;
     s.s = NULL;
     s.const_data = &const_data;
@@ -4290,8 +4204,9 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
 
     // Prepare for later external linkage against the sysimg
     // Also sets up images for protection against garbage collection
-    arraylist_push(&jl_linkage_blobs, (void*)image_base);
-    arraylist_push(&jl_linkage_blobs, (void*)(image_base + sizeof_sysimg));
+    eyt_tree_add_range(&image_tree,
+        (uintptr_t)image_base,
+        (uintptr_t)image_base + sizeof_sysimg);
     arraylist_push(&jl_image_relocs, (void*)relocs_base);
     if (restored == NULL) {
         arraylist_push(&jl_top_mods, (void*)jl_top_module);
@@ -4306,13 +4221,13 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         arraylist_push(&jl_top_mods, (void*)topmod);
     }
     jl_timing_counter_inc(JL_TIMING_COUNTER_ImageSize, sizeof_sysimg + sizeof(uintptr_t));
-    rebuild_image_blob_tree();
 
-    // jl_printf(JL_STDOUT, "%ld blobs to link against\n", jl_linkage_blobs.len >> 1);
+    // jl_printf(JL_STDOUT, "%ld blobs to link against\n", image_tree.blobs.len >> 1);
     jl_gc_enable(en);
 
     if (s.incremental)
         jl_add_methods(*extext_methods);
+
 }
 
 static jl_value_t *jl_validate_cache_file(ios_t *f, jl_array_t *depmods, uint64_t *checksum, int64_t *dataendpos, int64_t *datastartpos)

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -1,7 +1,7 @@
 
 // Forward declarations for private staticdata.c methods
-size_t n_linkage_blobs(void) JL_NOTSAFEPOINT;
-size_t external_blob_index(jl_value_t *v) JL_NOTSAFEPOINT;
+static size_t n_linkage_blobs(void) JL_NOTSAFEPOINT;
+static size_t external_blob_index(jl_value_t *v) JL_NOTSAFEPOINT;
 
 // inverse of backedges graph (caller=>callees hash)
 jl_array_t *internal_methods JL_GLOBALLY_ROOTED = NULL; // rooted for the duration of our uses of this

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -1,3 +1,8 @@
+
+// Forward declarations for private staticdata.c methods
+size_t n_linkage_blobs(void) JL_NOTSAFEPOINT;
+size_t external_blob_index(jl_value_t *v) JL_NOTSAFEPOINT;
+
 // inverse of backedges graph (caller=>callees hash)
 jl_array_t *internal_methods JL_GLOBALLY_ROOTED = NULL; // rooted for the duration of our uses of this
 

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -9,7 +9,7 @@ JCPPFLAGS_COMMON += $(CPPFLAGS) $(JL_CPPFLAGS)
 JLDFLAGS += $(LDFLAGS) $(JL_LDFLAGS)
 
 SRCS := hashing timefuncs ptrhash operators utf8 ios htable bitvector \
-	int2str libsupportinit arraylist strtod rle
+	int2str libsupportinit arraylist strtod rle eytzinger
 ifeq ($(OS),WINNT)
 SRCS += asprintf strptime
 ifeq ($(ARCH),i686)

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -28,7 +28,7 @@
 #define WIN32_LEAN_AND_MEAN
 /* Clang does not like fvisibility=hidden with windows headers. This adds the visibility attribute there.
    Arguably this is a clang bug. */
-# ifndef _COMPILER_MICROSOFT_
+# if !defined(_COMPILER_MICROSOFT_) && !defined(DECLSPEC_IMPORT)
 #  define DECLSPEC_IMPORT __declspec(dllimport) __attribute__ ((visibility("default")))
 # endif
 #include <windows.h>

--- a/src/support/eytzinger.c
+++ b/src/support/eytzinger.c
@@ -1,0 +1,106 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include "eytzinger.h"
+#include <assert.h>
+#include <stdlib.h>
+
+static int ptr_cmp(const void *l, const void *r) JL_NOTSAFEPOINT
+{
+    uintptr_t left = *(const uintptr_t*)l;
+    uintptr_t right = *(const uintptr_t*)r;
+    return (left > right) - (left < right);
+}
+
+// Build an eytzinger tree from a sorted array
+static int eytzinger(uintptr_t *src, uintptr_t *dest,
+                     size_t i, size_t k, size_t n) JL_NOTSAFEPOINT
+{
+    if (k <= n) {
+        i = eytzinger(src, dest, i, 2 * k, n);
+        dest[k - 1] = src[i];
+        i++;
+        i = eytzinger(src, dest, i, 2 * k + 1, n);
+    }
+    return i;
+}
+
+// Rebuild the tree from the current blobs. Caller must hold wrlock.
+static void rebuild_tree(eyt_tree_t *t) JL_NOTSAFEPOINT
+{
+    size_t nranges = t->blobs.len / 2;
+    size_t end = 2 * nranges;
+    size_t needed = end + 1; // + 1 for sentinel
+
+    arraylist_grow(&t->tree, needed - t->tree.len);
+    arraylist_grow(&t->idxs, needed - t->idxs.len);
+
+    uintptr_t *tree = (uintptr_t*)t->tree.items;
+    uintptr_t *idxs = (uintptr_t*)t->idxs.items;
+
+    // Sentinel: outside any range
+    idxs[end] = nranges;
+    tree[end] = 1;
+
+    for (size_t i = 0; i < end; i++) {
+        assert((uintptr_t)t->blobs.items[i] % 4 == 0 && "Blob not 4-byte aligned!");
+        // We abuse the pointer here a little so that a couple of properties are true:
+        // 1. a start and an end are never the same value. This simplifies the binary search.
+        // 2. ends are always after starts. This also simplifies the binary search.
+        // We assume that there exist no 0-size blobs, but that's a safe assumption
+        // since it means nothing could be there anyways
+        //
+        // FIXME: https://github.com/JuliaLang/julia/issues/61385
+        uintptr_t val = (uintptr_t)t->blobs.items[i];
+        idxs[i] = val + (i & 1);
+    }
+    qsort(idxs, end, sizeof(uintptr_t), ptr_cmp);
+    t->min_addr = idxs[0];
+    t->max_addr = idxs[end - 1] + 1;
+    eytzinger(idxs, tree, 0, 1, end);
+
+    // Reuse the scratch memory to store the indices
+    // Still O(nlogn) because binary search
+    for (size_t i = 0; i < end; i++) {
+        uintptr_t val = (uintptr_t)t->blobs.items[i];
+        // This is the same computation as in the prior for loop
+        uintptr_t eyt_val = val + (i & 1);
+        size_t eyt_idx = _eyt_obj_idx(eyt_val + 1, tree, end, t->min_addr, t->max_addr);
+        assert(eyt_idx < end);
+        assert(tree[eyt_idx] == eyt_val &&
+               "Eytzinger tree failed to find boundary!");
+        if (i & 1)
+            idxs[eyt_idx] = nranges;
+        else
+            idxs[eyt_idx] = i / 2;
+    }
+
+    t->n = end;
+}
+
+JL_DLLEXPORT void eyt_tree_init(eyt_tree_t *t) JL_NOTSAFEPOINT
+{
+    memset(t, 0, sizeof(*t));
+    arraylist_new(&t->blobs, 0);
+    arraylist_new(&t->tree, 0);
+    arraylist_new(&t->idxs, 0);
+    uv_rwlock_init(&t->rwlock);
+
+    // Initialize sentinel
+    arraylist_push(&t->tree, (void*)1); // outside image
+    arraylist_push(&t->idxs, (void*)0);
+}
+
+JL_DLLEXPORT void eyt_tree_add_range(eyt_tree_t *t, uintptr_t start, uintptr_t end) JL_NOTSAFEPOINT
+{
+    assert(start % 4 == 0 && "Range start not 4-byte aligned");
+    assert(end % 4 == 0 && "Range end not 4-byte aligned");
+    assert(start < end && "Empty range");
+
+    uv_rwlock_wrlock(&t->rwlock);
+
+    arraylist_push(&t->blobs, (void*)start);
+    arraylist_push(&t->blobs, (void*)end);
+    rebuild_tree(t);
+
+    uv_rwlock_wrunlock(&t->rwlock);
+}

--- a/src/support/eytzinger.c
+++ b/src/support/eytzinger.c
@@ -38,7 +38,7 @@ static void rebuild_tree(eyt_tree_t *t) JL_NOTSAFEPOINT
     uintptr_t *idxs = (uintptr_t*)t->idxs.items;
 
     // Sentinel: outside any range
-    idxs[end] = nranges;
+    idxs[end] = (uintptr_t)EYT_NOTFOUND;
     tree[end] = 1;
 
     for (size_t i = 0; i < end; i++) {
@@ -69,9 +69,9 @@ static void rebuild_tree(eyt_tree_t *t) JL_NOTSAFEPOINT
         assert(tree[eyt_idx] == eyt_val &&
                "Eytzinger tree failed to find boundary!");
         if (i & 1)
-            idxs[eyt_idx] = nranges;
+            idxs[eyt_idx] = (uintptr_t)EYT_NOTFOUND; // end boundary: not in range
         else
-            idxs[eyt_idx] = i / 2;
+            idxs[eyt_idx] = (uintptr_t)t->userdata.items[i / 2]; // start boundary: caller data
     }
 
     t->n = end;
@@ -81,16 +81,17 @@ JL_DLLEXPORT void eyt_tree_init(eyt_tree_t *t) JL_NOTSAFEPOINT
 {
     memset(t, 0, sizeof(*t));
     arraylist_new(&t->blobs, 0);
+    arraylist_new(&t->userdata, 0);
     arraylist_new(&t->tree, 0);
     arraylist_new(&t->idxs, 0);
     uv_rwlock_init(&t->rwlock);
 
     // Initialize sentinel
-    arraylist_push(&t->tree, (void*)1); // outside image
-    arraylist_push(&t->idxs, (void*)0);
+    arraylist_push(&t->tree, (void*)1);
+    arraylist_push(&t->idxs, EYT_NOTFOUND);
 }
 
-JL_DLLEXPORT void eyt_tree_add_range(eyt_tree_t *t, uintptr_t start, uintptr_t end) JL_NOTSAFEPOINT
+JL_DLLEXPORT void eyt_tree_add_range(eyt_tree_t *t, uintptr_t start, uintptr_t end, void *data) JL_NOTSAFEPOINT
 {
     assert(start % 4 == 0 && "Range start not 4-byte aligned");
     assert(end % 4 == 0 && "Range end not 4-byte aligned");
@@ -100,6 +101,7 @@ JL_DLLEXPORT void eyt_tree_add_range(eyt_tree_t *t, uintptr_t start, uintptr_t e
 
     arraylist_push(&t->blobs, (void*)start);
     arraylist_push(&t->blobs, (void*)end);
+    arraylist_push(&t->userdata, data);
     rebuild_tree(t);
 
     uv_rwlock_wrunlock(&t->rwlock);

--- a/src/support/eytzinger.c
+++ b/src/support/eytzinger.c
@@ -24,10 +24,10 @@ static int eytzinger(uintptr_t *src, uintptr_t *dest,
     return i;
 }
 
-// Rebuild the tree from the current blobs. Caller must hold wrlock.
+// Rebuild the tree from the current ranges. Caller must hold wrlock.
 static void rebuild_tree(eyt_tree_t *t) JL_NOTSAFEPOINT
 {
-    size_t nranges = t->blobs.len / 2;
+    size_t nranges = t->nranges;
     size_t end = 2 * nranges;
     size_t needed = end + 1; // + 1 for sentinel
 
@@ -42,15 +42,16 @@ static void rebuild_tree(eyt_tree_t *t) JL_NOTSAFEPOINT
     tree[end] = 1;
 
     for (size_t i = 0; i < end; i++) {
-        assert((uintptr_t)t->blobs.items[i] % 4 == 0 && "Blob not 4-byte aligned!");
+        eyt_range_t *r = &t->ranges[i / 2];
+        uintptr_t val = (i & 1) ? r->end : r->start;
+        assert(val % 4 == 0 && "Range boundary not 4-byte aligned!");
         // We abuse the pointer here a little so that a couple of properties are true:
         // 1. a start and an end are never the same value. This simplifies the binary search.
         // 2. ends are always after starts. This also simplifies the binary search.
-        // We assume that there exist no 0-size blobs, but that's a safe assumption
+        // We assume that there exist no 0-size ranges, but that's a safe assumption
         // since it means nothing could be there anyways
         //
         // FIXME: https://github.com/JuliaLang/julia/issues/61385
-        uintptr_t val = (uintptr_t)t->blobs.items[i];
         idxs[i] = val + (i & 1);
     }
     qsort(idxs, end, sizeof(uintptr_t), ptr_cmp);
@@ -58,10 +59,11 @@ static void rebuild_tree(eyt_tree_t *t) JL_NOTSAFEPOINT
     t->max_addr = idxs[end - 1] + 1;
     eytzinger(idxs, tree, 0, 1, end);
 
-    // Reuse the scratch memory to store the indices
+    // Reuse the scratch memory to store the userdata pointers
     // Still O(nlogn) because binary search
     for (size_t i = 0; i < end; i++) {
-        uintptr_t val = (uintptr_t)t->blobs.items[i];
+        eyt_range_t *r = &t->ranges[i / 2];
+        uintptr_t val = (i & 1) ? r->end : r->start;
         // This is the same computation as in the prior for loop
         uintptr_t eyt_val = val + (i & 1);
         size_t eyt_idx = _eyt_obj_idx(eyt_val + 1, tree, end, t->min_addr, t->max_addr);
@@ -69,9 +71,9 @@ static void rebuild_tree(eyt_tree_t *t) JL_NOTSAFEPOINT
         assert(tree[eyt_idx] == eyt_val &&
                "Eytzinger tree failed to find boundary!");
         if (i & 1)
-            idxs[eyt_idx] = (uintptr_t)EYT_NOTFOUND; // end boundary: not in range
+            idxs[eyt_idx] = (uintptr_t)EYT_NOTFOUND;
         else
-            idxs[eyt_idx] = (uintptr_t)t->userdata.items[i / 2]; // start boundary: caller data
+            idxs[eyt_idx] = (uintptr_t)r->data;
     }
 
     t->n = end;
@@ -80,11 +82,12 @@ static void rebuild_tree(eyt_tree_t *t) JL_NOTSAFEPOINT
 JL_DLLEXPORT void eyt_tree_init(eyt_tree_t *t) JL_NOTSAFEPOINT
 {
     memset(t, 0, sizeof(*t));
-    arraylist_new(&t->blobs, 0);
-    arraylist_new(&t->userdata, 0);
     arraylist_new(&t->tree, 0);
     arraylist_new(&t->idxs, 0);
     uv_rwlock_init(&t->rwlock);
+
+    t->nranges = 0;
+    t->ranges = NULL;
 
     // Initialize sentinel
     arraylist_push(&t->tree, (void*)1);
@@ -99,9 +102,9 @@ JL_DLLEXPORT void eyt_tree_add_range(eyt_tree_t *t, uintptr_t start, uintptr_t e
 
     uv_rwlock_wrlock(&t->rwlock);
 
-    arraylist_push(&t->blobs, (void*)start);
-    arraylist_push(&t->blobs, (void*)end);
-    arraylist_push(&t->userdata, data);
+    t->nranges++;
+    t->ranges = (eyt_range_t*)realloc(t->ranges, t->nranges * sizeof(eyt_range_t));
+    t->ranges[t->nranges - 1] = (eyt_range_t){start, end, data};
     rebuild_tree(t);
 
     uv_rwlock_wrunlock(&t->rwlock);

--- a/src/support/eytzinger.h
+++ b/src/support/eytzinger.h
@@ -1,0 +1,86 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// Thread-safe Eytzinger tree implementation for fast address range lookups.
+// See https://algorithmica.org/en/eytzinger
+
+#ifndef JL_EYTZINGER_H
+#define JL_EYTZINGER_H
+
+#include <uv.h>
+#include "dtypes.h"
+#include "arraylist.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Search an Eytzinger tree for the predecessor boundary of `addr`.
+// Returns the tree index (0-based) of the predecessor, or `n`
+// (the sentinel) if `addr` is outside all ranges.
+// `items` has `n + 1` entries (n boundaries + 1 sentinel).
+static inline size_t _eyt_obj_idx(uintptr_t addr, uintptr_t *tree, size_t n,
+                                  uintptr_t min_addr, uintptr_t max_addr) JL_NOTSAFEPOINT
+{
+    if (n == 0)
+        return n;
+    assert(n % 2 == 0 && "Eytzinger tree not even length!");
+    if (addr <= min_addr || addr > max_addr)
+        return n;
+    size_t k = 1;
+    while (k <= n) {
+        int greater = (addr > tree[k - 1]);
+        k <<= 1;
+        k |= greater;
+    }
+    k >>= (__builtin_ctzll(k) + 1);
+    assert(k != 0);
+    assert(k <= n && "Eytzinger tree index out of bounds!");
+    assert(tree[k - 1] < addr && "Failed to find lower bound for object!");
+    return k - 1;
+}
+
+typedef struct eyt_tree_t {
+    uv_rwlock_t rwlock;
+
+    size_t n; // 2 * n_ranges (tree/idxs have n+1 entries)
+    arraylist_t tree;
+    arraylist_t idxs;
+    uintptr_t min_addr;
+    uintptr_t max_addr;
+
+    arraylist_t blobs;
+} eyt_tree_t;
+
+JL_DLLEXPORT void eyt_tree_init(eyt_tree_t *t) JL_NOTSAFEPOINT;
+
+// Add a [start, end) range and rebuild the tree.
+// Thread-safe for concurrent access.
+JL_DLLEXPORT void eyt_tree_add_range(eyt_tree_t *t, uintptr_t start, uintptr_t end) JL_NOTSAFEPOINT;
+
+// Returns whether `addr` is inside any registered range.
+// Thread-safe for concurrent readers and writers.
+static inline int eyt_tree_is_in_range(eyt_tree_t *t, uintptr_t addr) JL_NOTSAFEPOINT
+{
+    uv_rwlock_rdlock(&t->rwlock);
+    size_t idx = _eyt_obj_idx(addr, (uintptr_t*)t->tree.items, t->n, t->min_addr, t->max_addr);
+    int result = ((uintptr_t)t->tree.items[idx] & 1) == 0;
+    uv_rwlock_rdunlock(&t->rwlock);
+    return result;
+}
+
+// Returns which registered range `addr` is inside, if any.
+// Thread-safe for concurrent readers and writers.
+static inline size_t eyt_tree_find_range_idx(eyt_tree_t *t, uintptr_t addr) JL_NOTSAFEPOINT
+{
+    uv_rwlock_rdlock(&t->rwlock);
+    size_t idx = _eyt_obj_idx(addr, (uintptr_t*)t->tree.items, t->n, t->min_addr, t->max_addr);
+    size_t result = (uintptr_t)t->idxs.items[idx];
+    uv_rwlock_rdunlock(&t->rwlock);
+    return result;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // JL_EYTZINGER_H

--- a/src/support/eytzinger.h
+++ b/src/support/eytzinger.h
@@ -44,18 +44,22 @@ typedef struct eyt_tree_t {
 
     size_t n; // 2 * n_ranges (tree/idxs have n+1 entries)
     arraylist_t tree;
-    arraylist_t idxs;
+    arraylist_t idxs; // Eytzinger-ordered: void* userdata for start boundaries, EYT_NOTFOUND for end/sentinel
     uintptr_t min_addr;
     uintptr_t max_addr;
 
-    arraylist_t blobs;
+    arraylist_t blobs;    // internal: (start, end) pairs, used only by rebuild_tree
+    arraylist_t userdata; // insertion-ordered: one void* per range (caller-defined)
 } eyt_tree_t;
+
+// Sentinel value stored in `idxs` for end-boundaries and out-of-range positions.
+#define EYT_NOTFOUND ((void*)1)
 
 JL_DLLEXPORT void eyt_tree_init(eyt_tree_t *t) JL_NOTSAFEPOINT;
 
-// Add a [start, end) range and rebuild the tree.
+// Add a [start, end) range with caller-defined data and rebuild the tree.
 // Thread-safe for concurrent access.
-JL_DLLEXPORT void eyt_tree_add_range(eyt_tree_t *t, uintptr_t start, uintptr_t end) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void eyt_tree_add_range(eyt_tree_t *t, uintptr_t start, uintptr_t end, void *data) JL_NOTSAFEPOINT;
 
 // Returns whether `addr` is inside any registered range.
 // Thread-safe for concurrent readers and writers.
@@ -68,13 +72,13 @@ static inline int eyt_tree_is_in_range(eyt_tree_t *t, uintptr_t addr) JL_NOTSAFE
     return result;
 }
 
-// Returns which registered range `addr` is inside, if any.
+// Returns the caller-defined data for the range containing `addr`, or EYT_NOTFOUND.
 // Thread-safe for concurrent readers and writers.
-static inline size_t eyt_tree_find_range_idx(eyt_tree_t *t, uintptr_t addr) JL_NOTSAFEPOINT
+static inline void *eyt_tree_find_data(eyt_tree_t *t, uintptr_t addr) JL_NOTSAFEPOINT
 {
     uv_rwlock_rdlock(&t->rwlock);
     size_t idx = _eyt_obj_idx(addr, (uintptr_t*)t->tree.items, t->n, t->min_addr, t->max_addr);
-    size_t result = (uintptr_t)t->idxs.items[idx];
+    void *result = t->idxs.items[idx];
     uv_rwlock_rdunlock(&t->rwlock);
     return result;
 }

--- a/src/support/eytzinger.h
+++ b/src/support/eytzinger.h
@@ -39,6 +39,12 @@ static inline size_t _eyt_obj_idx(uintptr_t addr, uintptr_t *tree, size_t n,
     return k - 1;
 }
 
+typedef struct {
+    uintptr_t start;
+    uintptr_t end;
+    void *data; // caller-defined per-range metadata
+} eyt_range_t;
+
 typedef struct eyt_tree_t {
     uv_rwlock_t rwlock;
 
@@ -48,8 +54,8 @@ typedef struct eyt_tree_t {
     uintptr_t min_addr;
     uintptr_t max_addr;
 
-    arraylist_t blobs;    // internal: (start, end) pairs, used only by rebuild_tree
-    arraylist_t userdata; // insertion-ordered: one void* per range (caller-defined)
+    size_t nranges;
+    eyt_range_t *ranges; // one entry per registered range
 } eyt_tree_t;
 
 // Sentinel value stored in `idxs` for end-boundaries and out-of-range positions.


### PR DESCRIPTION
This was being accessed from `method.c` / `module.c`, where it was a data race. This moves the Eytzinger code into `src/support` so that it can be maintained separately from `staticdata.c` and adds a `rwlock` to make the concurrent access thread-safe.

This lock does have significant overhead, compared to this (small) search. `jl_object_in_image` queries are typically ~15 ns w/o PR, and ~50 ns with (>2x regression). However since this is no longer used in the GC, this overhead amounts to ~2-3 milliseconds of total runtime even with many (200+) packages loaded.

My real motivation is to have an async-signal-safe range query that I can use for https://github.com/JuliaLang/julia/pull/61294 (I need to query whether we faulted in a pkgimage to know whether to throw a `DivideError`).

https://github.com/JuliaLang/julia/issues/61385 is not fixed by this PR

Claude 🤖 was used to assist with the re-factor. Also discussed various atomics-related minutia.