### PR TITLE
Remove `definitely-initialized-vars`

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -4059,7 +4059,7 @@ f(x) = yt(x)
          meta inbounds boundscheck loopinfo decl aliasscope popaliasscope
          thunk with-static-parameters toplevel-only
          global globalref global-if-global assign-const-if-global isglobal thismodule thisfunction
-         const atomic null true false ssavalue isdefined toplevel module lambda
+         const atomic null true false ssavalue toplevel module lambda
          error gc_preserve_begin gc_preserve_end export public inline noinline purity)))
 
 (define (local-in? s lam (tab #f))
@@ -4092,7 +4092,7 @@ f(x) = yt(x)
     ;; Collect candidate variables: those that are captured (and hence we want to optimize)
     ;; and only assigned once. This populates the initial `unused` table.
     (for-each (lambda (v)
-                (if (and (vinfo:capt v) (vinfo:sa v))
+                (if (vinfo:sa v)
                     (put! unused (car v) #t)))
               vi)
     ;; Initialize decl with arguments since they're implicitly declared outside any loop
@@ -4214,7 +4214,7 @@ f(x) = yt(x)
               (append (table.keys live) (table.keys unused)))
     (for-each (lambda (v)
                 (if (and (vinfo:sa v) (vinfo:never-undef v))
-                    (set-car! (cddr v) (logand (caddr v) (lognot 5)))))
+                    (vinfo:set-capt! v #f)))
               vi)
     lam))
 
@@ -5496,59 +5496,13 @@ f(x) = yt(x)
                       (let ((pexc (pop-exc-expr src-catch-tokens target-catch-tokens)))
                         (if pexc (set-cdr! point (cons pexc (cdr point)))))))))
               handler-goto-fixups)
-    (let* ((stmts (reverse! code))
-           (di    (definitely-initialized-vars stmts vi))
-           (body  (cons 'block (filter (lambda (e)
-                                         (not (and (pair? e) (eq? (car e) 'newvar)
-                                                   (has? di (cadr e)))))
-                                       stmts))))
+    (let* ((body (cons 'block (reverse! code))))
       (if arg-map
           (insert-after-meta
            body
            (table.foldl (lambda (k v lst) (cons `(= ,v ,k) lst))
                         '() arg-map))
           body))))
-
-(define (for-each-isdefined f e)
-  (cond ((or (atom? e) (quoted? e)) #f)
-        ((and (pair? e) (eq? (car e) 'isdefined))
-         (f (cadr e)))
-        (else
-         (for-each (lambda (x) (for-each-isdefined f x))
-                   (cdr e)))))
-
-;; Find newvar nodes that are unnecessary because (1) the variable is not
-;; captured, and (2) the variable is assigned before any branches.
-;; This is used to remove newvar nodes that are not needed for re-initializing
-;; variables to undefined (see issue #11065).
-;; It doesn't look for variable *uses*, because any variables used-before-def
-;; that also pass this test are *always* used undefined, and therefore don't need
-;; to be *re*-initialized.
-;; The one exception to that is `@isdefined`, which can observe an undefined
-;; variable without throwing an error.
-(define (definitely-initialized-vars stmts vi)
-  (let ((vars (table))
-        (di   (table)))
-    (let loop ((stmts stmts))
-      (if (null? stmts)
-          di
-          (begin
-            (let ((e (car stmts)))
-              (for-each-isdefined (lambda (x) (if (has? vars x) (del! vars x)))
-                                  e)
-              (cond ((and (pair? e) (eq? (car e) 'newvar))
-                     (let ((vinf (var-info-for (cadr e) vi)))
-                       (if (and vinf (not (vinfo:capt vinf)))
-                           (put! vars (cadr e) #t))))
-                    ((and (pair? e) (or (memq (car e) '(goto gotoifnot))
-                                        (and (eq? (car e) '=) (pair? (caddr e))
-                                             (eq? (car (caddr e)) 'enter))))
-                     (set! vars (table)))
-                    ((and (pair? e) (eq? (car e) '=))
-                     (if (has? vars (cadr e))
-                         (begin (del! vars (cadr e))
-                                (put! di (cadr e) #t))))))
-            (loop (cdr stmts)))))))
 
 ;; pass 6: renumber slots and labels
 


### PR DESCRIPTION
I was debugging slowness in JuliaLowering and may have found an easy improvement
to flisp too.

A `(newvar x)` form should be placed at the beginning of `x`'s scope if `x` may
be used before it's defined.  Naively that makes one NewVarNode per local, so
https://github.com/JuliaLang/julia/commit/ebfebfdc48919b767124a62958b9b6455552f3c9 (may 2015) implements some filtering.  We loop through all IR statements twice:
once to find `(newvar x)` dominating `(= x val)`, and again to filter
unnecessary newvar nodes.  An additional scan of each statement was added in an
august 2017 bugfix (https://github.com/JuliaLang/julia/pull/23384).

However, each `vinfo` gained a never-undef flag in october 2016 tracking the
property we want, and the `newvar` generation was made conditional on that flag:
https://github.com/JuliaLang/julia/commit/3d8f8d14787e697fab4543e1bca1ce4519977281#diff-5d79463faae0f7f19454c7f9888498d9f876082e258ab3efdca36a0ee64b0c87L2828

This PR tries to remove the IR-scan-based newvar filtering and uses the
never-undef flag instead.  This will miss some newvars compared to master (where
the flag is unset), but I think it's worth a try.

Tweaks in the process:
- Fix unsetting the never-undef flag on unboxed locals.  This was because of a
  leftover magic number from when bit 4 meant "assigned in inner function"!
  (https://github.com/JuliaLang/julia/commit/a1ee8676f00fc14bd67aaf7eb20ce46ff99f322e#diff-3671d5875b64e1b31272a74e43c37530b1ecc4d6724488366eaf0891662fc036L217-L218)
- This PR includes non-captured vars in `lambda-optimize-vars`, which shouldn't do
  anything but set the never-undef flag slightly more frequently.
