### PR TITLE
Improve/clarify `versioninfo` output

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -163,8 +163,8 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
         print(io, "  Load Avg: ")
         Base.print_matrix(io, Sys.loadavg()')
         println(io)
+        println(io, "  WORD_SIZE: ", Sys.WORD_SIZE)
     end
-    println(io, "  WORD_SIZE: ", Sys.WORD_SIZE)
     println(io, "  LLVM: libLLVM-",Base.libllvm_version," (", Sys.JIT, ", ", Sys.CPU_NAME, ")")
     println(io, "  GC: ", unsafe_string(ccall(:jl_gc_active_impl, Ptr{UInt8}, ())))
     println(io, """Threads: $(Threads.nthreads(:default)) default, $(Threads.nthreads(:interactive)) interactive, \

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -147,13 +147,18 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
     if verbose
         cpuio = IOBuffer() # print cpu_summary with correct alignment
         Sys.cpu_summary(cpuio)
-        for (i, line) in enumerate(split(chomp(takestring!(cpuio)), "\n"))
+        for (i, _line) in enumerate(split(chomp(takestring!(cpuio)), "\n"))
             prefix = i == 1 ? "  CPU: " : "       "
+            line = if i == 1
+                strip(x -> isspace(x) || x == ':', _line) * " (" * Sys.CPU_NAME * "):"
+            else
+                _line
+            end
             println(io, prefix, line)
         end
     else
         cpu = Sys.cpu_info()
-        println(io, "  CPU: ", length(cpu), " × ", cpu[1].model)
+        println(io, "  CPU: ", length(cpu), " × ", cpu[1].model, " (", Sys.CPU_NAME, ")")
     end
 
     if verbose
@@ -164,7 +169,7 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
         println(io)
         println(io, "  WORD_SIZE: ", Sys.WORD_SIZE)
     end
-    println(io, "  LLVM: libLLVM-",Base.libllvm_version," (", Sys.JIT, ", ", Sys.CPU_NAME, ")")
+    println(io, "  LLVM: libLLVM-", Base.libllvm_version, " (", Sys.JIT, ")")
     println(io, """Threads: $(Threads.nthreads(:default)) default, $(Threads.nthreads(:interactive)) interactive, \
       $(Threads.ngcthreads()) GC (on $(Sys.CPU_THREADS) virtual cores)""")
 

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -127,9 +127,15 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
             """
         )
     end
+
+    jit_triple = let _jit = ccall(:JLJITGetJuliaOJIT, Ptr{Cvoid}, ())
+        unsafe_string(ccall(:JLJITGetTripleString, Cstring, (Ptr{Cvoid},), _jit))
+    end
+    jit_cpu = first(Base.current_image_targets()).name
+
     println(io, "Platform Info:")
     println(io, "  OS: ", Sys.iswindows() ? "Windows" : Sys.isapple() ?
-        "macOS" : Sys.KERNEL, " (", Sys.MACHINE, ")")
+        "macOS" : Sys.KERNEL, " (", jit_triple, ")")
 
     if verbose
         lsb = ""
@@ -172,7 +178,7 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
         println(io)
         println(io, "  WORD_SIZE: ", Sys.WORD_SIZE)
     end
-    println(io, "  LLVM: libLLVM-", Base.libllvm_version, " (", Sys.JIT, ")")
+    println(io, "  LLVM: libLLVM-", Base.libllvm_version, " (", Sys.JIT, ", ", jit_cpu, ")")
     println(io, """Threads: $(Threads.nthreads(:default)) default, $(Threads.nthreads(:interactive)) interactive, \
       $(Threads.ngcthreads()) GC (on $(Sys.CPU_THREADS) virtual cores)""")
 

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -102,28 +102,26 @@ See also: [`VERSION`](@ref).
 """
 function versioninfo(io::IO=stdout; verbose::Bool=false)
     println(io, "Julia Version $VERSION")
+    println(io, "Build Info:")
+    if Base.isdebugbuild()
+        println(io, "  DEBUG build")
+    end
+    if !isempty(Base.TAGGED_RELEASE_BANNER)
+        println(io, "  ", Base.TAGGED_RELEASE_BANNER)
+    end
     if !isempty(Base.GIT_VERSION_INFO.commit_short_raw)
-        println(io, "Commit $(Base.GIT_VERSION_INFO.commit_short) ($(Base.GIT_VERSION_INFO.date_string))")
+        println(io, "  Commit $(Base.GIT_VERSION_INFO.commit_short) ($(Base.GIT_VERSION_INFO.date_string))")
     end
     official_release = Base.TAGGED_RELEASE_BANNER == "Official https://julialang.org release"
-    if Base.isdebugbuild() || !isempty(Base.TAGGED_RELEASE_BANNER) || (Base.GIT_VERSION_INFO.tagged_commit && !official_release)
-        println(io, "Build Info:")
-        if Base.isdebugbuild()
-            println(io, "  DEBUG build")
-        end
-        if !isempty(Base.TAGGED_RELEASE_BANNER)
-            println(io, "  ", Base.TAGGED_RELEASE_BANNER)
-        end
-        if Base.GIT_VERSION_INFO.tagged_commit && !official_release
-            println(io,
-                """
+    if Base.GIT_VERSION_INFO.tagged_commit && !official_release
+        println(io,
+            """
 
-                    Note: This is an unofficial build, please report bugs to the project
-                    responsible for this build and not to the Julia project unless you can
-                    reproduce the issue using official builds available at https://julialang.org
-                """
-            )
-        end
+                Note: This is an unofficial build, please report bugs to the project
+                responsible for this build and not to the Julia project unless you can
+                reproduce the issue using official builds available at https://julialang.org
+            """
+        )
     end
     println(io, "Platform Info:")
     println(io, "  OS: ", Sys.iswindows() ? "Windows" : Sys.isapple() ?

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -176,8 +176,8 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
         print(io, "  Load Avg: ")
         Base.print_matrix(io, Sys.loadavg()')
         println(io)
-        println(io, "  WORD_SIZE: ", Sys.WORD_SIZE)
     end
+    println(io, "  WORD_SIZE: ", Sys.WORD_SIZE)
     println(io, "  LLVM: libLLVM-", Base.libllvm_version, " (", Sys.JIT, ", ", jit_cpu, ")")
     println(io, """Threads: $(Threads.nthreads(:default)) default, $(Threads.nthreads(:interactive)) interactive, \
       $(Threads.ngcthreads()) GC (on $(Sys.CPU_THREADS) virtual cores)""")

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -158,7 +158,7 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
     end
 
     if verbose
-        println(io, "  Memory: $(Sys.total_memory()/2^30) GB ($(Sys.free_memory()/2^20) MB free)")
+        println(io, "  Memory: $(Sys.total_memory()/2^30) GiB ($(Sys.free_memory()/2^20) MiB free)")
         try println(io, "  Uptime: $(Sys.uptime()) sec"); catch; end
         print(io, "  Load Avg: ")
         Base.print_matrix(io, Sys.loadavg()')

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -112,6 +112,7 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
     if !isempty(Base.GIT_VERSION_INFO.commit_short_raw)
         println(io, "  Commit $(Base.GIT_VERSION_INFO.commit_short) ($(Base.GIT_VERSION_INFO.date_string))")
     end
+    println(io, "  GC: ", unsafe_string(ccall(:jl_gc_active_impl, Ptr{UInt8}, ())))
     official_release = Base.TAGGED_RELEASE_BANNER == "Official https://julialang.org release"
     if Base.GIT_VERSION_INFO.tagged_commit && !official_release
         println(io,
@@ -164,7 +165,6 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
         println(io, "  WORD_SIZE: ", Sys.WORD_SIZE)
     end
     println(io, "  LLVM: libLLVM-",Base.libllvm_version," (", Sys.JIT, ", ", Sys.CPU_NAME, ")")
-    println(io, "  GC: ", unsafe_string(ccall(:jl_gc_active_impl, Ptr{UInt8}, ())))
     println(io, """Threads: $(Threads.nthreads(:default)) default, $(Threads.nthreads(:interactive)) interactive, \
       $(Threads.ngcthreads()) GC (on $(Sys.CPU_THREADS) virtual cores)""")
 

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -113,6 +113,9 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
         println(io, "  Commit $(Base.GIT_VERSION_INFO.commit_short) ($(Base.GIT_VERSION_INFO.date_string))")
     end
     println(io, "  GC: ", unsafe_string(ccall(:jl_gc_active_impl, Ptr{UInt8}, ())))
+    if verbose
+        println(io, "  Sysimage: ", Sys.sysimage_target(), " (", Sys.MACHINE, ")")
+    end
     official_release = Base.TAGGED_RELEASE_BANNER == "Official https://julialang.org release"
     if Base.GIT_VERSION_INFO.tagged_commit && !official_release
         println(io,


### PR DESCRIPTION
**Best reviewed with "Hide whitespace"

When looking into https://github.com/JuliaLang/julia/pull/61292, I tried to use `versioninfo` to get the JIT’s cpu target. I found out that even though it shares parentheses with “ORCJIT”, the displayed cpu is always just the host CPU.

Then I fell into the confusing and undocumented output of `versioninfo` rabbit hole trying to improve it and this is the result of that. Once I have a better idea about which changes are/aren't welcome, I’ll edit the docstring to be more explicit about what each item is.

May be worth reviewing per-commit as I've tried to separate each change

This PR:
* Changes “GB” and “MB” to “GiB” and “MiB” when reporting memory information.
* Moves the detected host cpu llvm target to be with the CPU instead of in the LLVM section. I changed this because the previous way implied it was the JIT target cpu. They usually match, but they may not if julia was launched with the `-C` flag
* The build commit has been moved down into “Build Information”
* Refactors the “Build Information” section. It will now always be shown, and the GC julia was built with was moved from the “Platform Information” section.
* Adds the target cpu and triple that the base system image was built with when `verbose=true`. ~This adds a new Sys.BASE_SYSIMG_TARGET constant variable because calling `sysimage_target` from InteractiveUtils returns “sysimage”. Hidden behind `verbose` flag~ Edit: `sysimage_target` behaviour seems to have been fixed so the implementation now uses it.
* LLVM section now reports the JIT target CPU where the host CPU use to be. ~This expands/uses API that was added by @gbaraldi for GPUCompiler in #49858.~ (edit: I found a way to do it using existing code)
* The triple on the OS line is now the JIT target triple (same implementations worries as above), and the build machine triple (MACHINE) is now reported in the verbose-only sysimage line in “Build Information”. This is probably more relevant on macOS, where the triple includes the kernel version, but I find it [confusing](https://github.com/JuliaGPU/Metal.jl/issues/179#issuecomment-1555068273) to show the build kernel version when reporting the current OS.

Current output (master):
```julia-repl
julia> versioninfo()
Julia Version 1.14.0-DEV.2169
Commit 61cb0461a4a (2026-05-10 23:05 UTC)
Build Info:
  Official https://julialang.org release
Platform Info:
  OS: macOS (arm64-apple-darwin24.0.0)
  CPU: 12 × Apple M2 Max
  WORD_SIZE: 64
  LLVM: libLLVM-21.1.8 (ORCJIT, apple-m2)
  GC: Built with stock GC
Threads: 8 default, 1 interactive, 8 GC (on 8 virtual cores)
Environment:
  JULIA_NUM_THREADS = auto

julia> versioninfo(verbose=true)
Julia Version 1.14.0-DEV.2169
Commit 61cb0461a4a (2026-05-10 23:05 UTC)
Build Info:
  Official https://julialang.org release
Platform Info:
  OS: macOS (arm64-apple-darwin24.0.0)
  uname: Darwin 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:09 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6020 arm64 arm
  CPU: Apple M2 Max:
                 speed         user         nice          sys         idle          irq
       #1-12  2400 MHz     131350 s          0 s      70466 s    1842258 s          0 s
  Memory: 32.0 GB (304.4375 MB free)
  Uptime: 469303.0 sec
  Load Avg:  3.224609375  3.75244140625  3.3671875
  WORD_SIZE: 64
  LLVM: libLLVM-21.1.8 (ORCJIT, apple-m2)
  GC: Built with stock GC
Threads: 8 default, 1 interactive, 8 GC (on 8 virtual cores)
Environment:
```

This PR:
```julia-repl
julia> versioninfo()
Julia Version 1.14.0-DEV.2178
Build Info:
  Official https://julialang.org release
  Commit 09e1b830fde (2026-05-11 13:03 UTC)
  GC: Built with stock GC
Platform Info:
  OS: macOS (arm64-apple-darwin25.5.0)
  CPU: 12 × Apple M2 Max (apple-m2)
  WORD_SIZE: 64
  LLVM: libLLVM-21.1.8 (ORCJIT, apple-m2)
Threads: 8 default, 1 interactive, 8 GC (on 8 virtual cores)
Environment:
  JULIA_NUM_THREADS = auto

julia> versioninfo(verbose=true)
Julia Version 1.14.0-DEV.2178
Build Info:
  Official https://julialang.org release
  Commit 09e1b830fde (2026-05-11 13:03 UTC)
  GC: Built with stock GC
  Sysimage: generic;apple-m1,clone_all (arm64-apple-darwin24.0.0)
Platform Info:
  OS: macOS (arm64-apple-darwin25.5.0)
  uname: Darwin 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:09 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6020 arm64 arm
  CPU: Apple M2 Max (apple-m2):
                 speed         user         nice          sys         idle          irq
       #1-12  2400 MHz     131335 s          0 s      70450 s    1842109 s          0 s
  Memory: 32.0 GiB (345.53125 MiB free)
  Uptime: 469288.0 sec
  Load Avg:  3.2978515625  3.7919921875  3.37451171875
  WORD_SIZE: 64
  LLVM: libLLVM-21.1.8 (ORCJIT, apple-m2)
Threads: 8 default, 1 interactive, 8 GC (on 8 virtual cores)
Environment:
```