### PR TITLE
backticks: implement tilde expansion

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -32,9 +32,6 @@ stackframe_lineinfo_color() = repl_color("JULIA_STACKFRAME_LINEINFO_COLOR", :bol
 stackframe_function_color() = repl_color("JULIA_STACKFRAME_FUNCTION_COLOR", :bold)
 
 function repl_cmd(cmd, out)
-    # Immediately expand all arguments, so that typing e.g. ~/bin/foo works.
-    cmd.exec .= expanduser.(cmd.exec)
-
     if isempty(cmd.exec)
         throw(ArgumentError("no cmd to execute"))
     elseif cmd.exec[1] == "cd"

--- a/base/path.jl
+++ b/base/path.jl
@@ -753,9 +753,28 @@ function _win_profile_from_registry(username::AbstractString)
     home = transcode(String, buf[1:n])
     return isdir(home) ? home : nothing
 end
-# on windows, ~ means "temporary file"
-expanduser(path::AbstractString) = path
-contractuser(path::AbstractString) = path
+function contractuser(path::Union{String, SubString{String}})::String
+    # Walk prefixes of path, checking if any matches homedir() via inode.
+    # Only checks the current user's home (no ~username on Windows).
+    # Preserves the original path string after the matched prefix verbatim.
+    home_st = stat(homedir())
+    ispath(home_st) || return path
+    # check the full path (home directory itself, no trailing separator)
+    samefile(stat(path), home_st) && return "~"
+    # scan for separators; start after the first one to skip the root
+    m = findnext(path_separator_re, path, firstindex(path))
+    m === nothing && return path
+    while true
+        m = findnext(path_separator_re, path, nextind(path, last(m)))
+        m === nothing && return path
+        prefix = SubString(path, 1, prevind(path, first(m)))
+        st = stat(prefix)
+        ispath(st) || return path
+        if samefile(st, home_st)
+            return "~" * SubString(path, first(m))
+        end
+    end
+end
 
 else # !Sys.iswindows()
 
@@ -787,46 +806,106 @@ function homedir(username::AbstractString)
     end
     return nothing
 end
-function expanduser(path::AbstractString)
+function contractuser(path::Union{String, SubString{String}})::String
+    # Walk path prefixes from shortest to longest. At each existing prefix,
+    # check against the current user's home first, then the directory owner's
+    # home via inode comparison. This handles symlinks transparently.
+    # Preserves the original path string after the matched prefix verbatim.
+    home_st = stat(homedir())
+    ispath(home_st) || return path
+    cache_uid = ccall(:getuid, Cuint, ())
+    cache_uname = nothing
+    cache_home_st = nothing
+    # Check the full path (home directory itself, no trailing separator)
+    samefile(stat(path), home_st) && return "~"
+    # Scan for separators; start after the first one to skip the root
+    m = findnext(path_separator_re, path, firstindex(path))
+    m === nothing && return path
+    while true
+        m = findnext(path_separator_re, path, nextind(path, last(m)))
+        m === nothing && return path
+        prefix = SubString(path, 1, prevind(path, first(m)))
+        st = stat(prefix)
+        ispath(st) || return path
+        rest = SubString(path, first(m))
+        if samefile(st, home_st)
+            return "~" * rest
+        end
+        uid = st.uid
+        if uid != cache_uid
+            cache_uid = uid
+            pd = Libc.getpwuid(uid, false)
+            cache_uname = pd !== nothing && !isempty(pd.username) ? pd.username : nothing
+            if cache_uname !== nothing
+                pw_home = homedir(cache_uname)
+                cache_home_st = pw_home !== nothing ? stat(pw_home) : nothing
+            else
+                cache_home_st = nothing
+            end
+        end
+        if cache_home_st !== nothing && ispath(cache_home_st) && samefile(st, cache_home_st)
+            return "~$(cache_uname)" * rest
+        end
+    end
+end
+
+end # if Sys.iswindows()
+
+function expanduser(path::Union{String, SubString{String}})::String
     y = iterate(path)
     y === nothing && return path
     c, i = y::Tuple{eltype(path),Int}
     c != '~' && return path
-    y = iterate(path, i)
-    y === nothing && return homedir()
-    y[1]::eltype(path) == '/' && return homedir() * path[i:end]
-    throw(ArgumentError("~user tilde expansion not yet implemented"))
-end
-function contractuser(path::AbstractString)
-    home = homedir()
-    if path == home
-        return "~"
-    elseif startswith(path, home)
-        return joinpath("~", relpath(path, home))
-    else
+    # collect username: everything after ~ up to separator or end
+    m = findnext(path_separator_re, path, i)
+    j = prevind(path, m === nothing ?
+        nextind(path, lastindex(path)) : first(m))
+    username = SubString(path, i, j)
+    # can't use a regex because of bootstrap order
+    if isempty(username)
+        home = homedir()
+    elseif Sys.iswindows() || # ~username not supported on Windows
+        !all(c -> isletter(c) || isdigit(c) || c in "._-", username) # invalid
         return path
+    else
+        home = homedir(username)
+        home === nothing && return path
     end
-end
+    # use first separator in the rest of path in home
+    if m !== nothing
+        if Sys.iswindows()
+            sep = path[first(m)]
+            home = replace(home, path_separator_re => sep)
+        end
+        return home * SubString(path, first(m))
+    end
+    return home
 end
 
 
 """
     expanduser(path::AbstractString)::AbstractString
 
-On Unix systems, replace a tilde character at the start of a path with the current user's home directory.
+Replace a tilde character at the start of a path with the current user's home directory.
+On Unix, `~username` at the start of a path is replaced with that user's home directory;
+if the user does not exist the path is returned unchanged. On Windows, only `~` expansion
+is supported (not `~username`).
 
 See also: [`contractuser`](@ref).
 """
-expanduser(path::AbstractString)
+expanduser(path::AbstractString) = expanduser(String(path))
 
 """
     contractuser(path::AbstractString)::AbstractString
 
-On Unix systems, if the path starts with `homedir()`, replace it with a tilde character.
+Replace a home directory prefix in `path` with a tilde. If the path starts with the
+current user's home directory it is replaced with `~`. On Unix, if it starts with
+another user's home directory it is replaced with `~username`. The path is returned
+unchanged if no home directory prefix is found.
 
 See also: [`expanduser`](@ref).
 """
-contractuser(path::AbstractString)
+contractuser(path::AbstractString) = contractuser(String(path))
 
 
 """

--- a/base/path.jl
+++ b/base/path.jl
@@ -172,6 +172,13 @@ Return the current user's home directory.
     (for example on how to specify the home directory via environment variables), see the
     [`uv_os_homedir` documentation](http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_homedir).
 
+    homedir(username::AbstractString)::Union{String,Nothing}
+
+Return the home directory for the given `username`, or `nothing` if the user does not exist.
+On Unix, this performs a lookup via `getpwnam_r`. On Windows, the user's SID is resolved and
+the profile path is read from the registry; if that fails, the profile directory is inferred
+from the current user's home directory.
+
 See also [`Sys.username`](@ref).
 """
 function homedir()
@@ -672,10 +679,114 @@ function realpath(path::AbstractString)
 end
 
 if Sys.iswindows()
+
+function homedir(username::AbstractString)
+    # For the current user, just return homedir().
+    current_user = try
+        Sys.username()
+    catch
+        err isa IOError || rethrow()
+        nothing
+    end
+    if username == current_user
+        return homedir()
+    end
+    # Look up the user's SID, then query the registry for their profile path.
+    # This is the same approach Go uses (os/user.Lookup on Windows).
+    home = _win_profile_from_registry(username)
+    home !== nothing && return home
+    # Fallback: assume profiles are siblings in the same parent directory,
+    # but only if the current user's home follows the <parent>/<username>
+    # convention. If not, we can't guess reliably.
+    userhome = homedir()
+    if current_user !== nothing && basename(userhome) == current_user
+        home = joinpath(dirname(userhome), username)
+        isdir(home) && return home
+    end
+    return nothing
+end
+function _win_profile_from_registry(username::AbstractString)
+    # Step 1: Resolve username to a SID via LookupAccountNameW.
+    # First call with zero-length buffers to get required sizes.
+    wuser = cwstring(username)
+    sid_size = Ref{UInt32}(0)
+    domain_size = Ref{UInt32}(0)
+    use = Ref{Int32}(0)
+    ccall((:LookupAccountNameW, "advapi32"), stdcall, Cint,
+          (Ptr{UInt16}, Ptr{UInt16}, Ptr{Cvoid}, Ptr{UInt32},
+           Ptr{UInt16}, Ptr{UInt32}, Ptr{Int32}),
+          C_NULL, wuser, C_NULL, sid_size, C_NULL, domain_size, use)
+    sid_size[] == 0 && return nothing
+    sid_buf = Vector{UInt8}(undef, sid_size[])
+    domain_buf = Vector{UInt16}(undef, domain_size[])
+    ret = ccall((:LookupAccountNameW, "advapi32"), stdcall, Cint,
+                (Ptr{UInt16}, Ptr{UInt16}, Ptr{UInt8}, Ptr{UInt32},
+                 Ptr{UInt16}, Ptr{UInt32}, Ptr{Int32}),
+                C_NULL, wuser, sid_buf, sid_size, domain_buf, domain_size, use)
+    ret == 0 && return nothing
+    # Step 2: Convert SID to string form (e.g. "S-1-5-21-...").
+    str_sid_ptr = Ref{Ptr{UInt16}}(C_NULL)
+    ret = ccall((:ConvertSidToStringSidW, "advapi32"), stdcall, Cint,
+                (Ptr{UInt8}, Ref{Ptr{UInt16}}), sid_buf, str_sid_ptr)
+    ret == 0 && return nothing
+    len = ccall(:wcslen, Csize_t, (Ptr{UInt16},), str_sid_ptr[])
+    sid_str = transcode(String, unsafe_wrap(Array, str_sid_ptr[], len))
+    ccall((:LocalFree, "kernel32"), stdcall, Ptr{Cvoid}, (Ptr{Cvoid},), str_sid_ptr[])
+    # Step 3: Query the registry for the user's ProfileImagePath.
+    subkey = cwstring("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\$sid_str")
+    value = cwstring("ProfileImagePath")
+    buf_size = Ref{UInt32}(0)
+    # RRF_RT_REG_SZ | RRF_RT_REG_EXPAND_SZ = 0x00000006
+    HKEY_LOCAL_MACHINE = 0x80000002 % UInt
+    ret = ccall((:RegGetValueW, "advapi32"), stdcall, Clong,
+                (UInt, Ptr{UInt16}, Ptr{UInt16}, UInt32, Ptr{UInt32}, Ptr{UInt16}, Ptr{UInt32}),
+                HKEY_LOCAL_MACHINE, subkey, value, 0x00000006, C_NULL, C_NULL, buf_size)
+    buf_size[] == 0 && return nothing
+    buf = Vector{UInt16}(undef, buf_size[] ÷ 2)
+    ret = ccall((:RegGetValueW, "advapi32"), stdcall, Clong,
+                (UInt, Ptr{UInt16}, Ptr{UInt16}, UInt32, Ptr{UInt32}, Ptr{UInt16}, Ptr{UInt32}),
+                HKEY_LOCAL_MACHINE, subkey, value, 0x00000006, C_NULL, buf, buf_size)
+    ret != 0 && return nothing
+    # Remove trailing null and convert to String.
+    n = buf_size[] ÷ 2
+    n > 0 && buf[n] == 0 && (n -= 1)
+    home = transcode(String, buf[1:n])
+    return isdir(home) ? home : nothing
+end
 # on windows, ~ means "temporary file"
 expanduser(path::AbstractString) = path
 contractuser(path::AbstractString) = path
-else
+
+else # !Sys.iswindows()
+
+function homedir(username::AbstractString)
+    # Thread-safe user lookup via getpwnam_r.
+    # pwd_storage holds the struct passwd; 256 bytes is a generous upper bound
+    # for all supported platforms (Linux x86-64: ~56 bytes, macOS arm64: ~80 bytes).
+    pwd_storage = zeros(UInt8, 256)
+    # The string buffer holds the pointed-to strings (pw_name, pw_dir, etc.).
+    # Start at 1024 and double on ERANGE if any string is unusually long.
+    buflen = 1024
+    while buflen <= 65536
+        str_buf = Vector{UInt8}(undef, buflen)
+        result = Ref{Ptr{Cvoid}}(C_NULL)
+        ret = ccall(:getpwnam_r, Cint,
+                    (Cstring, Ptr{Cvoid}, Ptr{UInt8}, Csize_t, Ptr{Ptr{Cvoid}}),
+                    username, pwd_storage, str_buf, Csize_t(buflen), result)
+        if ret == 34  # ERANGE: string buffer too small, retry with more space
+            buflen *= 2
+        elseif ret == 0 && result[] != C_NULL
+            # pw_uid sits at offset 2*sizeof(Ptr) in struct passwd on all supported
+            # platforms (after pw_name and pw_passwd, which are both pointer-sized)
+            uid = unsafe_load(Ptr{Cuint}(pointer(pwd_storage) + 2 * sizeof(Ptr{Cvoid})))
+            pd = Libc.getpwuid(uid, false)
+            return pd !== nothing ? pd.homedir : nothing
+        else
+            return nothing  # user not found or error
+        end
+    end
+    return nothing
+end
 function expanduser(path::AbstractString)
     y = iterate(path)
     y === nothing && return path

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -2,7 +2,7 @@
 
 ## shell-like command parsing ##
 
-const shell_special = "#{}()[]<>|&*?~;"
+const shell_special = "#{}()[]<>|&*?;"
 
 (@doc raw"""
     rstrip_shell(s::AbstractString)
@@ -67,6 +67,30 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
 
     C = eltype(str)
     P = Pair{Int,C}
+
+    # Parse the expression following a `$` interpolation marker.
+    # Pops the first char of the expression from `st`, parses the atom, advances
+    # `s` past it, and resets `st`. Returns `(expr, new_s, interp_pos)` where
+    # `interp_pos` is the absolute position in `str` (for REPLCompletions).
+    function parse_dollar_interp(st, s)
+        isempty(st) && error("\$ right before end of command")
+        stpos, c = popfirst!(st)::P
+        isspace(c) && error("space not allowed right after \$")
+        if startswith(SubString(s, stpos), "var\"")
+            # Disallow var"#" syntax in cmd interpolations.
+            # TODO: Allow only identifiers after the $ for consistency with
+            # string interpolation syntax (see #3150)
+            ex, j = :var, stpos+3
+        else
+            # use parseatom instead of parse to respect filename (#28188)
+            ex, j = Meta.parseatom(s, stpos, filename=filename)
+        end
+        interp_pos = stpos + s.offset
+        s = SubString(s, j)
+        Iterators.reset!(st, pairs(s))
+        return ex, s, interp_pos
+    end
+
     for (j, c) in st
         j, c = j::Int, c::C
         if !in_single_quotes && !in_double_quotes && isspace(c)
@@ -82,23 +106,11 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
             end
         elseif interpolate && !in_single_quotes && c == '$'
             i = consume_upto!(arg, s, i, j)
-            isempty(st) && error("\$ right before end of command")
-            stpos, c = popfirst!(st)::P
-            isspace(c) && error("space not allowed right after \$")
-            if startswith(SubString(s, stpos), "var\"")
-                # Disallow var"#" syntax in cmd interpolations.
-                # TODO: Allow only identifiers after the $ for consistency with
-                # string interpolation syntax (see #3150)
-                ex, j = :var, stpos+3
-            else
-                # use parseatom instead of parse to respect filename (#28188)
-                ex, j = Meta.parseatom(s, stpos, filename=filename)
-            end
-            last_arg = stpos + s.offset
+            result = parse_dollar_interp(st, s)
+            s = result[2]
+            last_arg = result[3]
             update_last_arg = true
-            push!(arg, ex)
-            s = SubString(s, j)
-            Iterators.reset!(st, pairs(s))
+            push!(arg, result[1])
             i = firstindex(s)
         else
             if update_last_arg
@@ -134,6 +146,40 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
                     i = consume_upto!(arg, s, i, j)
                     _ = popfirst!(st)
                 end
+            elseif interpolate && !in_single_quotes && !in_double_quotes &&
+                    c == '~' && i == j && isempty(arg)
+                # Tilde expansion: `~` or `~username` at start of a word.
+                # Collect the username, which may include $interpolations (e.g. `~$user`).
+                # Stop at /, whitespace, or uninterpolable chars (quotes, backslash).
+                i = consume_upto!(arg, s, i, j)  # i now points past the ~
+                user_parts = []
+                user_lit_start = i
+                while !isempty(st)
+                    nxt = peek(st)::P
+                    nc = nxt[2]
+                    (nc == '/' || isspace(nc) || nc == '\'' || nc == '"' || nc == '\\') && break
+                    if nc == '$'
+                        push_nonempty!(user_parts, s[user_lit_start:prevind(s, nxt[1])])
+                        popfirst!(st)  # consume $
+                        result = parse_dollar_interp(st, s)
+                        push!(user_parts, result[1])
+                        s = result[2]
+                        i = firstindex(s)
+                        user_lit_start = i
+                    else
+                        popfirst!(st)
+                    end
+                end
+                user_end = something(peek(st), (lastindex(s) + 1) => '\0').first
+                push_nonempty!(user_parts, s[user_lit_start:prevind(s, user_end)])
+                if isempty(user_parts)
+                    push!(arg, :(expanduser("~")))
+                elseif length(user_parts) == 1 && isa(user_parts[1], AbstractString)
+                    push!(arg, :(expanduser($("~" * user_parts[1]))))
+                else
+                    push!(arg, :(let _u = string($(user_parts...)); isempty(_u) ? "~" : expanduser(string('~', _u)) end))
+                end
+                i = user_end
             elseif !in_single_quotes && !in_double_quotes && c in special
                 error("parsing command `$str`: special characters \"$special\" must be quoted in commands")
             end
@@ -149,11 +195,11 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
     interpolate || return args, last_arg
 
     # construct an expression
-    ex = Expr(:tuple)
+    expr = Expr(:tuple)
     for arg in args
-        push!(ex.args, Expr(:tuple, arg...))
+        push!(expr.args, Expr(:tuple, arg...))
     end
-    return ex, last_arg
+    return expr, last_arg
 end
 
 """

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -314,6 +314,95 @@ function do_cmd_escape(s; escape_backticks::Bool=false)
     escape_backticks && (s = Base.escape_raw_string(s, '`'))
     return s
 end
+
+# Cache the set of valid login shells from /etc/shells. Real users have their
+# shell listed here; service/daemon accounts use /bin/false etc. which are not.
+const _login_shells = Base.OncePerProcess{Vector{String}}() do
+    @static if Sys.iswindows()
+        String[]
+    else
+        try
+            filter!(l -> !isempty(l) && !startswith(l, '#'), readlines("/etc/shells"))
+        catch
+            String[]  # no /etc/shells; skip shell filtering
+        end
+    end
+end
+
+# pw_shell byte offset in struct passwd — everything before the pw_shell field:
+# Linux:     pw_name, pw_passwd (2 Ptrs), pw_uid, pw_gid (2 Cuints),
+#            pw_gecos, pw_dir (2 Ptrs)
+# macOS/BSD: same as Linux plus pw_change (Clong) and pw_class (Ptr)
+#            between pw_gid and pw_gecos
+const _pw_shell_offset = @static if Sys.islinux()
+    4 * sizeof(Ptr{Cvoid}) + 2 * sizeof(Cuint)
+else
+    5 * sizeof(Ptr{Cvoid}) + 2 * sizeof(Cuint) + sizeof(Clong)
+end
+
+# Return a sorted, deduplicated list of real local usernames. When all=false
+# (the default), service accounts are excluded by requiring their shell to be
+# listed in /etc/shells, and on macOS names starting with '_' are also excluded.
+function list_users(; all::Bool=false)
+    seen = Set{String}()
+    @static if !Sys.iswindows()
+        valid_shells = all ? String[] : _login_shells()
+        ccall(:setpwent, Cvoid, ())
+        try
+            while true
+                ptr = ccall(:getpwent, Ptr{Cvoid}, ())
+                ptr == C_NULL && break
+                name_ptr = unsafe_load(Ptr{Ptr{UInt8}}(ptr))
+                name_ptr == C_NULL && continue
+                name = unsafe_string(name_ptr)
+                if !all
+                    @static Sys.isapple() && startswith(name, '_') && continue
+                    if !isempty(valid_shells)
+                        shell_ptr = unsafe_load(Ptr{Ptr{UInt8}}(ptr + _pw_shell_offset))
+                        shell_ptr == C_NULL && continue
+                        unsafe_string(shell_ptr) in valid_shells || continue
+                    end
+                end
+                push!(seen, name)
+            end
+        finally
+            ccall(:endpwent, Cvoid, ())
+        end
+    end
+    return sort!(collect(seen))
+end
+
+# Return tilde-completion strings for usernames matching `prefix`.
+# With an empty prefix, the current user is represented as "~/" (not "~name/")
+# since that shorthand is always available. With a non-empty prefix the current
+# user's actual name is included when it matches, and "~/" is not offered.
+function _complete_tilde_usernames(prefix::AbstractString)::Vector{String}
+    me = try Sys.username() catch; "" end
+    users = list_users()
+    completions = String[]
+    if isempty(prefix)
+        push!(completions, "~/")            # always offer ~/ for current user
+        for name in users
+            name == me && continue          # ~/  already covers current user
+            push!(completions, "~$name/")
+        end
+    else
+        for name in users
+            startswith(name, prefix) && push!(completions, "~$name/")
+        end
+    end
+    return completions
+end
+
+function do_cmd_escape_tilde(s; escape_backticks::Bool=false)
+    # Tilde paths: ~[username] is handled by shell_parse and must not be
+    # quoted.  Escape only the path component after the first slash.
+    i = findfirst(isequal('/'), s)
+    i === nothing && return s  # bare "~username" — no special chars possible
+    tilde_prefix = SubString(s, 1, i - 1)  # "~" or "~alice"
+    rest = SubString(s, i)                  # "/rest/of/path"
+    return string(tilde_prefix, do_cmd_escape(rest; escape_backticks))
+end
 function do_string_escape(s)
     return escape_string(s, ('\"','$'))
 end
@@ -1325,17 +1414,30 @@ function shell_completions(str, pos, hint::Bool=false; escape_backticks::Bool=fa
         paths, dir, success = complete_path(""; use_envpath=false, cmd_escape=true, escape_backticks, dirsep='/')
         return paths, r, success
     elseif all(@nospecialize(arg) -> arg isa AbstractString, ex.args)
-        # Join these and treat this as a path
-        path::String = join(ex.args)
+        path = join(ex.args)
+    elseif Meta.isexpr(get(ex.args, 1, nothing), :call) &&
+           (call = ex.args[1]::Expr; call.args[1] === :expanduser) &&
+           (tilde_idx = findfirst(a -> a isa String, call.args); tilde_idx !== nothing) &&
+           all(@nospecialize(arg) -> arg isa AbstractString, ex.args[2:end])
+        tilde_str = call.args[tilde_idx]::String  # "~" or "~alice"
+        rest = join(ex.args[2:end])
         r = last_arg_start:pos
-
-        # Also try looking into the env path if the user wants to complete the first argument
-        use_envpath = length(args.args) < 2
-
-        paths, success = complete_path_string(path, hint; use_envpath, cmd_escape=true, escape_backticks, dirsep='/')
-        return paths, r, success
+        if isempty(rest)
+            # No path after the tilde: complete usernames.
+            username_prefix = SubString(tilde_str, 2)  # everything after "~"
+            usernames = _complete_tilde_usernames(username_prefix)
+            paths = Completion[PathCompletion(do_cmd_escape_tilde(u; escape_backticks))
+                               for u in usernames]
+            return paths, r, !isempty(paths)
+        end
+        path = tilde_str * rest
+    else
+        return Completion[], 1:0, false
     end
-    return Completion[], 1:0, false
+    r = last_arg_start:pos
+    use_envpath = length(args.args) < 2
+    paths, success = complete_path_string(path, hint; use_envpath, cmd_escape=true, escape_backticks, dirsep='/')
+    return paths, r, success
 end
 
 function complete_path_string(path, hint::Bool=false;
@@ -1345,43 +1447,42 @@ function complete_path_string(path, hint::Bool=false;
                               dirsep='/',
                               kws...)
     # Expand "~" and remember if we expanded it.
-    local expanded
-    try
-        let p = expanduser(path)
-            expanded = path != p
-            path = p
-        end
-    catch e
-        e isa ArgumentError || rethrow()
-        expanded = false
-    end
+    unexpanded_path = path
+    path = try expanduser(path) catch e; e isa ArgumentError || rethrow(); path end
+    expanded = path != unexpanded_path
 
     function escape(p)
+        # When the original input used a tilde (expanded=true), completions are
+        # returned in "~/..." form.  Use tilde-aware escaping so the "~[user]"
+        # prefix is left unquoted while the rest of the path is properly escaped.
         string_escape && (p = do_string_escape(p))
-        cmd_escape && (p = do_cmd_escape(p; escape_backticks))
+        cmd_escape && (p = expanded ? do_cmd_escape_tilde(p; escape_backticks) : do_cmd_escape(p; escape_backticks))
         p
     end
 
     paths, dir, success = complete_path(path; dirsep, kws...)
 
-    # Expand '~' if the user hits TAB after exhausting completions (either
-    # because we have found an existing file, or there is no such file).
-    full_path = try
-        ispath(path) || isempty(paths)
-    catch err
-        # access(2) errors unhandled by ispath: EACCES, EIO, ELOOP, ENAMETOOLONG
-        if err isa Base.IOError
-            false
-        elseif err isa Base.ArgumentError && occursin("embedded NULs", err.msg)
-            false
-        else
-            rethrow()
+    # For string literals (not backtick commands): when the path already exists
+    # or has no completions, expand ~ to the absolute path so the user sees the
+    # resolved location. (In backtick context shell_parse handles ~ at runtime,
+    # so the contracted tilde form is kept; normal processing produces it.)
+    if !cmd_escape && expanded && !hint && !endswith(path, '/')
+        full_path = try
+            ispath(path) || isempty(paths)
+        catch err
+            if err isa Base.IOError
+                false
+            elseif err isa Base.ArgumentError && occursin("embedded NULs", err.msg)
+                false
+            else
+                rethrow()
+            end
         end
+        full_path && return Completion[PathCompletion(escape(path))], true
     end
-    expanded && !hint && full_path && return Completion[PathCompletion(escape(path))], true
 
-    # Expand '~' if the user hits TAB on a path ending in '/'.
-    expanded && (hint || path != dir * "/") && (dir = contractuser(dir))
+    # Contract the directory back to tilde form when the input used a tilde.
+    expanded && (dir = contractuser(dir))
     local dir_for_paths = dir
 
     map!(paths) do c::PathCompletion

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -309,11 +309,10 @@ const sorted_keyvals = ["false", "true"]
 complete_keyval!(suggestions::Vector{Completion}, s::String) =
     complete_from_list!(suggestions, KeyvalCompletion, sorted_keyvals, s)
 
-function do_cmd_escape(s)
-    return Base.escape_raw_string(Base.shell_escape_posixly(s), '`')
-end
-function do_shell_escape(s)
-    return Base.shell_escape_posixly(s)
+function do_cmd_escape(s; escape_backticks::Bool=false)
+    s = Base.shell_escape_posixly(s)
+    escape_backticks && (s = Base.escape_raw_string(s, '`'))
+    return s
 end
 function do_string_escape(s)
     return escape_string(s, ('\"','$'))
@@ -436,12 +435,11 @@ end
 
 function complete_path(path::AbstractString;
                        use_envpath=false,
-                       shell_escape=false,
                        cmd_escape=false,
+                       escape_backticks=false,
                        string_escape=false,
                        contract_user=false,
                        dirsep=Sys.iswindows() ? '\\' : '/')
-    @assert !(shell_escape && string_escape)
     if Base.Sys.isunix() && occursin(r"^~(?:/|$)", path)
         # if the path is just "~", don't consider the expanded username as a prefix
         if path == "~"
@@ -484,8 +482,8 @@ function complete_path(path::AbstractString;
         end
     end
 
-    matches = ((shell_escape ? do_shell_escape(s) : string_escape ? do_string_escape(s) : s) for s in matches)
-    matches = ((cmd_escape ? do_cmd_escape(s) : s) for s in matches)
+    matches = ((string_escape ? do_string_escape(s) : s) for s in matches)
+    matches = ((cmd_escape ? do_cmd_escape(s; escape_backticks) : s) for s in matches)
     matches = Completion[PathCompletion(contract_user ? contractuser(s) : s) for s in matches]
     return matches, dir, !isempty(matches)
 end
@@ -493,12 +491,11 @@ end
 function complete_path(path::AbstractString,
                        pos::Int;
                        use_envpath=false,
-                       shell_escape=false,
                        string_escape=false,
                        contract_user=false)
     ## TODO: enable this depwarn once Pkg is fixed
     #Base.depwarn("complete_path with pos argument is deprecated because the return value [2] is incorrect to use", :complete_path)
-    paths, dir, success = complete_path(path; use_envpath, shell_escape, string_escape, dirsep='/')
+    paths, dir, success = complete_path(path; use_envpath, string_escape, dirsep='/')
 
     if Base.Sys.isunix() && occursin(r"^~(?:/|$)", path)
         # if the path is just "~", don't consider the expanded username as a prefix
@@ -1044,7 +1041,7 @@ function completions(string::String, pos::Int, context_module::Module=Main, shif
     #   `file ~/example.txt TAB  => `file /home/user/example.txt
     if (n = find_parent(cur, K"CmdString")) !== nothing
         off = char_first(n) - 1
-        ret, r, success = shell_completions(string[char_range(n)], pos - off, hint, cmd_escape=true)
+        ret, r, success = shell_completions(string[char_range(n)], pos - off, hint, escape_backticks=true)
         success && return ret, r .+ off, success
     end
 
@@ -1300,7 +1297,7 @@ function method_search(partial::AbstractString, context_module::Module, shift::B
     end
 end
 
-function shell_completions(str, pos, hint::Bool=false; cmd_escape::Bool=false)
+function shell_completions(str, pos, hint::Bool=false; escape_backticks::Bool=false)
     # First parse everything up to the current position
     scs = str[1:pos]
     args, last_arg_start = try
@@ -1325,7 +1322,7 @@ function shell_completions(str, pos, hint::Bool=false; cmd_escape::Bool=false)
         return ret, range, true
     elseif endswith(scs, ' ') && !endswith(scs, "\\ ")
         r = pos+1:pos
-        paths, dir, success = complete_path(""; use_envpath=false, shell_escape=!cmd_escape, cmd_escape, dirsep='/')
+        paths, dir, success = complete_path(""; use_envpath=false, cmd_escape=true, escape_backticks, dirsep='/')
         return paths, r, success
     elseif all(@nospecialize(arg) -> arg isa AbstractString, ex.args)
         # Join these and treat this as a path
@@ -1335,15 +1332,15 @@ function shell_completions(str, pos, hint::Bool=false; cmd_escape::Bool=false)
         # Also try looking into the env path if the user wants to complete the first argument
         use_envpath = length(args.args) < 2
 
-        paths, success = complete_path_string(path, hint; use_envpath, shell_escape=!cmd_escape, cmd_escape, dirsep='/')
+        paths, success = complete_path_string(path, hint; use_envpath, cmd_escape=true, escape_backticks, dirsep='/')
         return paths, r, success
     end
     return Completion[], 1:0, false
 end
 
 function complete_path_string(path, hint::Bool=false;
-                              shell_escape::Bool=false,
                               cmd_escape::Bool=false,
+                              escape_backticks::Bool=false,
                               string_escape::Bool=false,
                               dirsep='/',
                               kws...)
@@ -1360,9 +1357,8 @@ function complete_path_string(path, hint::Bool=false;
     end
 
     function escape(p)
-        shell_escape && (p = do_shell_escape(p))
         string_escape && (p = do_string_escape(p))
-        cmd_escape && (p = do_cmd_escape(p))
+        cmd_escape && (p = do_cmd_escape(p; escape_backticks))
         p
     end
 

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1193,23 +1193,79 @@ let s, c, r
     mktempdir() do tmphome
         withenv("HOME" => tmphome, "USERPROFILE" => tmphome) do
             path = homedir()
-            dir = joinpath(path, "tmpfoobar")
+            dname = "tilde_" * randstring(12)
+            prefix = dname[1:8]
+            dir = joinpath(path, dname)
             mkdir(dir)
-            s = "\"" * path * "/tmpfoob"
+            s = "\"" * path * "/" * prefix
             c,r = test_complete(s)
             @test string(dir, "/") in c
             @test r == 2:sizeof(s)
-            @test s[r] == joinpath(path, "tmpfoob")
+            @test s[r] == joinpath(path, prefix)
 
             # Homedir expansion inside Cmd string (#57624)
-            s = "`ls " * path * "/tmpfoob"
+            s = "`ls " * path * "/" * prefix
             c,r = test_complete(s)
             @test string(dir, "/") in c
             @test r == 5:sizeof(s)
-            @test s[r] == joinpath(path, "tmpfoob")
+            @test s[r] == joinpath(path, prefix)
+
+            # `~ completes to ~/ for current user plus ~name/ for other real users
+            me = Sys.username()
+            s_bare = "`ls ~"
+            c_bare, r_bare = test_complete(s_bare)
+            @test "~/" in c_bare              # current user always offered as ~/
+            @test !("~$me/" in c_bare)        # current user NOT listed by name (covered by ~/)
+            @test allunique(c_bare)           # no duplicates
+            @test all(c -> startswith(c, "~"), c_bare)
+            @test s_bare[r_bare] == "~"
+
+            # `~/prefix completes to ~/dname/ keeping the tilde form
+            s_tilde = "`ls ~/" * prefix
+            c_tilde, r_tilde = test_complete(s_tilde)
+            @test "~/$dname/" in c_tilde
+            @test all(c -> startswith(c, "~/"), c_tilde)
+            @test s_tilde[r_tilde] == "~/" * prefix
+
+            # `~/ (trailing slash) lists directory contents, all with ~/ prefix
+            s_tilde_slash = "`ls ~/"
+            c_tilde2, r_tilde2 = test_complete(s_tilde_slash)
+            @test "~/$dname/" in c_tilde2
+            @test all(c -> startswith(c, "~/"), c_tilde2)
+            @test s_tilde_slash[r_tilde2] == "~/"
+
+            # `~/. lists dotfiles (not just ~/.)
+            dotname = ".dot_" * randstring(12)
+            dotdir = joinpath(path, dotname)
+            mkdir(dotdir)
+            try
+                s_dot = "`ls ~/."
+                c_dot, r_dot = test_complete(s_dot)
+                @test "~/$dotname/" in c_dot          # dotfiles shown with tilde prefix
+                @test !("~/./" in c_dot)              # ~/. does NOT complete to ~/./
+                @test all(c -> startswith(c, "~/."), c_dot)
+                @test s_dot[r_dot] == "~/."
+            finally
+                rm(dotdir)
+            end
+
+            # `~letter completes to matching usernames including the current user's name
+            first_char = string(first(me))
+            s_prefix = "`ls ~$first_char"
+            c_prefix, r_prefix = test_complete(s_prefix)
+            @test "~$me/" in c_prefix             # current user included by name
+            @test !("~/" in c_prefix)             # ~/ shorthand NOT offered for non-empty prefix
+            @test all(c -> startswith(c, "~$first_char"), c_prefix)
+            @test s_prefix[r_prefix] == "~$first_char"
+
+            # Shell mode: ~/prefix completes with tilde preserved, not escaped
+            s_shell = "ls ~/" * prefix
+            c_shell, r_shell = test_scomplete(s_shell)
+            @test "~/$dname/" in c_shell
+            @test all(c -> startswith(c, "~/"), c_shell)
 
             s = "\"~"
-            @test joinpath(path, "tmpfoobar/") in c
+            @test joinpath(path, "$dname/") in c
             c,r = test_complete(s)
             s = "\"~user"
             c, r = test_complete(s)

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1417,12 +1417,9 @@ mktempdir() do path
 end
 
 # Test tilde path completion
-let (c, r, res) = test_complete("\"~/ka8w5rsz")
-    if !Sys.iswindows()
-        @test res && c == String[homedir() * "/ka8w5rsz\""]
-    else
-        @test !res
-    end
+let home = replace(homedir(), "\\" => "/"),
+    (c, r, res) = test_complete("\"~/ka8w5rsz")
+    @test res && c == String["$home/ka8w5rsz\""]
 
     c, r, res = test_complete("\"foo~bar")
     @test !res

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -1152,8 +1152,7 @@ end
 end
 
 @testset "provide informative location in backtrace for test failures" begin
-    win2unix(filename) = replace(filename, "\\" => '/')
-    utils = win2unix(tempname())
+    utils = tempname()
     write(utils,
     """
     function test_properties2(value)
@@ -1161,7 +1160,7 @@ end
     end
     """)
 
-    included = win2unix(tempname())
+    included = tempname()
     write(included,
     """
     @testset "Other tests" begin
@@ -1178,12 +1177,12 @@ end
     end))
     """)
 
-    runtests = win2unix(tempname())
+    runtests = tempname()
     write(runtests,
     """
     using Test
 
-    include("$utils")
+    include($(repr(utils)))
 
     function test_properties(value)
         @test isodd(value)
@@ -1194,11 +1193,13 @@ end
         @noinline test_properties(8)
         test_properties2(8)
 
-        include("$included")
+        include($(repr(included)))
     end
     """)
-    msg = read(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --color=no $runtests`), stderr=devnull), String)
-    msg = win2unix(msg)
+    # Disable homedir contraction in stack traces so paths match tempname() output
+    msg = withenv("JULIA_STACKTRACE_CONTRACT_HOMEDIR" => "0") do
+        read(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --color=no $runtests`), stderr=devnull), String)
+    end
     regex = r"((?:Tests|Other tests|Testset without source): Test Failed (?:.|\n)*?)\n  Stacktrace:(?:.|\n)*?(?=\n(?:Tests|Other tests))"
     failures = map(eachmatch(regex, msg)) do m
         m = match(r"(Tests|Other tests|Testset without source): .*? at (.*?)\n  Expression: (.*)(?:.|\n)*\n  Stacktrace:\n((?:.|\n)*)", m.match)

--- a/test/file.jl
+++ b/test/file.jl
@@ -1962,7 +1962,7 @@ end
                     # Cannot delete the working directory on Windows
                     rm(dir)
                     @test_throws Base._UVError("pwd()", Base.UV_ENOENT) pwd()
-                    Base.repl_cmd(@cmd("cd \\~"), io)
+                    Base.repl_cmd(@cmd("cd ~"), io)
                 end
             end
         end

--- a/test/path.jl
+++ b/test/path.jl
@@ -1,7 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 using Random: randstring
+isdefined(Main, :samepath) || @eval Main include("testhelpers/samepath.jl")
+using Main: samepath
 
-@testset "basic path functions for string type $S" for S in (String, GenericString)
+@testset "basic path functions for $S" for S in (String, SubString, GenericString)
     dir = pwd()
     sep = Base.Filesystem.path_separator
     @testset "isabspath and abspath" begin
@@ -33,13 +35,38 @@ using Random: randstring
     @testset "expanduser" begin
         @test expanduser(S("")) == ""
         @test expanduser(S("x")) == "x"
-        @test expanduser(S("~")) == (Sys.iswindows() ? "~" : homedir())
+        @test expanduser(S("~")) == homedir()
+        @test expanduser(S("~$(Base.Filesystem.path_separator)foo")) == joinpath(homedir(), "foo")
+        if Sys.iswindows()
+            # expanduser preserves the separator from the input path
+            home = homedir()
+            @test expanduser(S("~/foo")) == replace(home, '\\' => '/') * "/foo"
+            @test expanduser(S("~\\foo")) == replace(home, '/' => '\\') * "\\foo"
+        end
+        if !Sys.iswindows()
+            # ~username expansion (Unix only)
+            me = Sys.username()
+            @test samepath(expanduser(S("~$me")), homedir(me))
+            @test samepath(expanduser(S("~$me/bar")), joinpath(homedir(me), "bar"))
+            # unknown user is left unexpanded
+            nouser = "nouser_" * randstring(12)
+            @test expanduser(S("~$nouser")) == "~$nouser"
+        end
     end
     @testset "contractuser" begin
-        @test contractuser(S(homedir())) == (Sys.iswindows() ? homedir() : "~")
-        @test contractuser(S(joinpath(homedir(), "x"))) ==
-              (Sys.iswindows() ? joinpath(homedir(), "x") : "~$(sep)x")
-        @test contractuser(S("/foo/bar")) == "/foo/bar"
+        # contractuser is left-inverse of expanduser
+        @test contractuser(S(homedir())) == "~"
+        @test contractuser(S(joinpath(homedir(), "x"))) == "~$(sep)x"
+        if !Sys.iswindows()
+            @test contractuser(S("/foo/bar")) == "/foo/bar"
+            me = Sys.username()
+            # current user's home contracts to ~ or ~username via stat
+            result = contractuser(S(homedir()))
+            @test result == "~" || result == "~$me"
+        end
+        # round-trip: expanduser(contractuser(p)) == p for home-relative paths
+        p = joinpath(homedir(), "some", "path")
+        @test expanduser(contractuser(S(p))) == p
     end
     @testset "isdirpath" begin
         @test !isdirpath(S("foo"))
@@ -288,12 +315,8 @@ using Random: randstring
         #@test isabspath(S("_:/")) == false # FIXME?
         #@test isabspath(S("AB:/")) == false # FIXME?
         @test isabspath(S("\\\\")) == Sys.iswindows()
-        if Sys.isunix()
-            @test isabspath(S(expanduser("~"))) == true
-            @test startswith(expanduser(S("~")), homedir())
-        else
-            @test expanduser(S("~")) == "~"
-        end
+        @test isabspath(S(expanduser("~"))) == true
+        @test startswith(expanduser(S("~")), homedir())
         if Sys.iswindows()
             @test isabspath(S("\\\\?\\C:\\"))
             # Current behavior is to allow anything starting with a separator,

--- a/test/path.jl
+++ b/test/path.jl
@@ -1,4 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
+using Random: randstring
 
 @testset "basic path functions for string type $S" for S in (String, GenericString)
     dir = pwd()
@@ -458,4 +459,13 @@ end
         end == home
     end
     @test isabspath(withenv(homedir, var => nothing))
+    # homedir(username) returns a directory for the current user
+    me = Sys.username()
+    me_home = homedir(me)
+    @test me_home !== nothing
+    @test isdir(me_home)
+    @test isabspath(me_home)
+    # non-existent user returns nothing
+    nouser = "nouser_" * randstring(12)
+    @test homedir(nouser) === nothing
 end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -6,6 +6,8 @@
 
 using Random, Sockets, SHA
 using Downloads: Downloads, download
+isdefined(Main, :samepath) || @eval Main include("testhelpers/samepath.jl")
+using Main: samepath
 
 valgrind_off = ccall(:jl_running_on_valgrind, Cint, ()) == 0
 
@@ -543,6 +545,44 @@ end
 
 
 @test Base.shell_split("\"\\\\\"") == ["\\"]
+
+# Tilde expansion in backtick commands
+@test samepath(only(`~`.exec), homedir())
+@test samepath(only(`~/foo`.exec), joinpath(homedir(), "foo"))
+@test samepath(`foo ~`.exec[2], homedir())
+@test samepath(`foo ~/bar`.exec[2], joinpath(homedir(), "bar"))
+@test `foo~bar` == Cmd(["foo~bar"])  # ~ mid-word: no expansion
+@test `foo~` == Cmd(["foo~"])        # ~ end-word: no expansion
+@test `'~'` == Cmd(["~"])            # ~ in single quotes: no expansion
+@test `"~"` == Cmd(["~"])            # ~ in double quotes: no expansion
+@test Base.shell_split("~/foo") == ["~/foo"]  # shell_split does not expand ~
+if !Sys.iswindows()
+    me = Sys.username()
+    # ~user expansion: use samepath since passwd home may differ from $HOME
+    @test samepath(only(`~$me`.exec), homedir(me))
+    @test samepath(only(`~$me/foo`.exec), joinpath(homedir(me), "foo"))
+    nouser = "nouser_" * randstring(12)
+    @test `~$nouser` == Cmd(["~$nouser"])
+    name = ""
+    @test `~$name` == Cmd(["~"])
+end
+
+# Tilde expansion in shell mode via repl_cmd
+withenv("OLDPWD" => nothing) do
+    mktempdir() do dir
+        # cd \~ goes to a directory literally named "~", not home
+        cd(dir) do
+            mkdir("~") # literal tilde directory
+            Base.repl_cmd(@cmd("cd \\~"), devnull)
+            @test samefile(pwd(), joinpath(dir, "~"))
+        end
+        # cd ~ goes to home directory
+        cd(dir) do
+            Base.repl_cmd(@cmd("cd ~"), devnull)
+            @test samefile(pwd(), homedir())
+        end
+    end
+end
 
 let roundtrip(s) = first(Base.shell_split(Base.shell_escape(s))) == s
     @test roundtrip("foo'bar\\\$baz")

--- a/test/testhelpers/samepath.jl
+++ b/test/testhelpers/samepath.jl
@@ -1,0 +1,33 @@
+"""
+    samepath(path_a, path_b)
+
+Check if two paths would refer to the same file or directory, even if the full path does
+not exist yet. Each path is split into the longest prefix that exists on the filesystem
+and the remaining suffix. The paths are considered equivalent when the existing prefixes
+refer to the same file (`samefile`) and the suffixes are equal after `normpath`
+normalization.
+
+If both paths exist, this is equivalent to `samefile`.
+"""
+function samepath(a::AbstractString, b::AbstractString)
+    a_pre, a_suf = _split_at_existing(a)
+    b_pre, b_suf = _split_at_existing(b)
+    return samefile(a_pre, b_pre) && normpath(a_suf) == normpath(b_suf)
+end
+
+function _split_at_existing(path::AbstractString)
+    p = path
+    while true
+        ispath(p) && break
+        parent = dirname(p)
+        parent == p && break
+        p = parent
+    end
+    p == path && return (path, "")
+    # skip the separator between the existing prefix and the rest
+    i = nextind(path, lastindex(p))
+    if i <= lastindex(path) && Base.Filesystem.isseparator(path[i])
+        i = nextind(path, i)
+    end
+    return (String(p), String(SubString(path, i)))
+end


### PR DESCRIPTION
This PR makes four changes:

1. It implements `~user` expansion in `expanduser` (a long-standing TODO)
2. It implements the inverse transformation in `compressuser` keeping it a left-inverse of `expanduser`
3. It uses `expanduser` to implement tilde expansion in backticks command syntax
4. It adds tab completion support for paths with tildes in backticks syntax. 

Co-Authored-By: Claude Sonnet 4.6

Part of https://github.com/JuliaLang/julia/issues/20401.