### PR TITLE
Optimize `ptrhash` / `htable_t` implementation

### DIFF
--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -26,7 +26,7 @@ NATIVE_BUILDDIR := $(BUILDDIR)
 LLT_BUILDDIR := $(BUILDDIR)/$(LLTDIR)
 endif
 
-HEADERS := $(wildcard *.h) $(LIBUV_INC)/uv.h $(wildcard $(LLTDIR)/*.h)
+HEADERS := $(wildcard *.h) $(LIBUV_INC)/uv.h $(wildcard $(LLTDIR)/*.h) $(wildcard $(LLTDIR)/*.inc)
 
 OBJS := $(SRCS:%.c=$(BUILDDIR)/%.o)
 DOBJS := $(SRCS:%.c=$(BUILDDIR)/%.dbg.obj)

--- a/src/flisp/table.c
+++ b/src/flisp/table.c
@@ -90,7 +90,7 @@ value_t fl_table(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
         nt = cvalue_no_finalizer(fl_ctx, fl_ctx->tabletype, sizeof(htable_t));
     }
     else {
-        nt = cvalue(fl_ctx, fl_ctx->tabletype, 2*sizeof(void*));
+        nt = cvalue(fl_ctx, fl_ctx->tabletype, offsetof(htable_t, _space));
     }
     htable_t *h = (htable_t*)cv_data((cvalue_t*)ptr(nt));
     htable_new(h, cnt/2);
@@ -106,7 +106,7 @@ value_t fl_table(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
         // We expected to use the inline table, but we ended up outgrowing it.
         // Make sure to register the finalizer.
         add_finalizer(fl_ctx, (cvalue_t*)ptr(nt));
-        ((cvalue_t*)ptr(nt))->len = 2*sizeof(void*);
+        ((cvalue_t*)ptr(nt))->len = offsetof(htable_t, _space);
     }
     return nt;
 }
@@ -122,7 +122,7 @@ value_t fl_table_put(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     if (table0 == &h->_space[0] && h->table != &h->_space[0]) {
         cvalue_t *cv = (cvalue_t*)ptr(args[0]);
         add_finalizer(fl_ctx, cv);
-        cv->len = 2*sizeof(void*);
+        cv->len = offsetof(htable_t, _space);
     }
     return args[0];
 }

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -19,7 +19,7 @@ SRCS += _setjmp.win64
 endif
 endif
 
-HEADERS := $(wildcard *.h) $(LIBUV_INC)/uv.h
+HEADERS := $(wildcard *.h) $(wildcard *.inc) $(LIBUV_INC)/uv.h
 
 OBJS := $(SRCS:%=$(BUILDDIR)/%.o)
 DOBJS := $(SRCS:%=$(BUILDDIR)/%.dbg.obj)

--- a/src/support/htable.c
+++ b/src/support/htable.c
@@ -33,6 +33,7 @@ htable_t *htable_new(htable_t *h, size_t size)
     }
     if (h->table == NULL)
         return NULL;
+    h->count = 0;
     size_t i;
     for (i = 0; i < size; i++)
         h->table[i] = HT_NOTFOUND;
@@ -59,6 +60,7 @@ void htable_reset(htable_t *h, size_t sz)
         size_t i, hsz = h->size;
         for (i = 0; i < hsz; i++)
             h->table[i] = HT_NOTFOUND;
+        h->count = 0;
     }
 }
 

--- a/src/support/htable.h
+++ b/src/support/htable.h
@@ -18,12 +18,13 @@ extern "C" {
 //   key   = table[2*i]
 //   value = table[2*i+1]
 // where `2*i < size`. An empty slot at index `i` is indicated with
-// `value == HT_NOTFOUND`.
+// `value == HT_NOTFOUND`. `count` is the number of live entries.
 //
 // `_space` is reserved space for efficiently allocating small tables.
 typedef struct {
     size_t size;
     void **table;
+    size_t count;
     void *_space[HT_N_INLINE];
 } htable_t;
 

--- a/src/support/htable.inc
+++ b/src/support/htable.inc
@@ -41,14 +41,21 @@ static void **HTNAME##_lookup_bp_r(htable_t *h, void *key, void *ctx)   \
             if (EQFUNC(key, tab[index], ctx))                           \
                 return &tab[index+1];                                   \
                                                                         \
-            index = (index+2) & (sz-1);                                 \
             iter++;                                                     \
+            index = (index + iter*2) & (sz-1);                          \
             if (iter > maxprobe)                                        \
-                break;                                                  \
+                break; /* grow if probe took too long */                \
         } while (index != orig);                                        \
+                                                                        \
+        /* grow if table is at least 75% full */                        \
+        if (empty_slot != -1) {                                         \
+            if (h->count * 4 >= hash_size(h) * 3)                       \
+                empty_slot = -1;                                        \
+        }                                                               \
                                                                         \
         if (empty_slot != -1) {                                         \
             tab[empty_slot] = key;                                      \
+            h->count++;                                                 \
             return &tab[empty_slot+1];                                  \
         }                                                               \
                                                                         \
@@ -72,6 +79,7 @@ static void **HTNAME##_lookup_bp_r(htable_t *h, void *key, void *ctx)   \
             tab[i] = HT_NOTFOUND;                                       \
         h->table = tab;                                                 \
         h->size = newsz;                                                \
+        h->count = 0;                                                   \
         for (i = 0; i < sz; i += 2) {                                   \
             if (ol[i+1] != HT_NOTFOUND) {                               \
                 (*HTNAME##_lookup_bp_r(h, ol[i], ctx)) = ol[i+1];       \
@@ -118,8 +126,9 @@ static void **HTNAME##_peek_bp_r(htable_t *h, void *key, void *ctx)     \
         if (EQFUNC(key, tab[index], ctx))                               \
             return &tab[index+1];                                       \
                                                                         \
-        index = (index+2) & (sz-1);                                     \
         iter++;                                                         \
+        /* quadratic (triangular) probing */                            \
+        index = (index + iter*2) & (sz-1);                              \
         if (iter > maxprobe)                                            \
             break;                                                      \
     } while (index != orig);                                            \
@@ -145,6 +154,7 @@ _STATIC int HTNAME##_remove_r(htable_t *h, void *key, void *ctx)        \
     void **bp = HTNAME##_peek_bp_r(h, key, ctx);                        \
     if (bp != NULL) {                                                   \
         *bp = HT_NOTFOUND;                                              \
+        h->count--;                                                     \
         return 1;                                                       \
     }                                                                   \
     return 0;                                                           \

--- a/src/support/ptrhash.c
+++ b/src/support/ptrhash.c
@@ -23,7 +23,10 @@
 extern "C" {
 #endif
 
-HTIMPL(ptrhash, inthash, OP_EQ)
+static inline uint_t ptrhash_hash(uintptr_t key) JL_NOTSAFEPOINT {
+    return (uint_t)((key >> 4) ^ (key >> 9));
+}
+HTIMPL(ptrhash, ptrhash_hash, OP_EQ)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This commit tweaks several behaviors of `htable_t`:
  - Switch from linear to quadratic (triangular) probing
  - Grow if fill factor exceeds 75%
  - Use a simpler hash for `ptrhash`

These choices are taken from LLVM's DenseMap implementation, which was outperforming `htable_t` significantly on #61401. With these changes, both hash maps have similar performance (within ~5-15% of each other):
  - LLVM DenseMap: 40 ns / `insert` call
  - master `ptrhash`: 85 ns / `ptrhash_bp` call
  - PR `ptrhash`: 43 ns / `ptrhash_bp` call

Additionally fix a `Makefile` bug that prevented `htable` changes from re-building flisp / libsupport as expected.