### PR TITLE
Prevent adding methods to  operator !== and add test

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -1373,6 +1373,9 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
     if (!external_mt && !jl_has_empty_intersection(ft, (jl_value_t*)jl_builtin_type)) // disallow adding methods to Any, Function, Builtin, and subtypes, or Unions of those
         jl_errorf("cannot add methods to builtin function `%s`", jl_symbol_name(name));
 
+    if (!external_mt && name == jl_symbol("!===") && jl_atomic_load_relaxed(&mt->defs) != NULL)
+        jl_errorf("cannot add methods to protected operator `%s`", jl_symbol_name(name));
+
     m = jl_new_method_uninit(module);
     m->external_mt = (jl_value_t*)external_mt;
     if (external_mt)

--- a/test/core.jl
+++ b/test/core.jl
@@ -2719,7 +2719,7 @@ struct D14919 <: Function; end
 @test B14919()() == "It's a brand new world"
 @test C14919()() == D14919()() == "Boo."
 
-let ex_t = ErrorException, ex_r = r"cannot add methods to builtin function"
+let ex_t = ErrorException, ex_r = r"cannot add methods to protected operator"
     for f in (:(Core.Any), :(Core.Function), :(Core.Builtin), :(Base.Callable), :(Union{Nothing,F} where F), :(typeof(Core.getfield)), :(Core.IntrinsicFunction))
         @test_throws ex_t @eval (::$f)() = 1
         @test_throws ex_r @eval (::$f)() = 1
@@ -2730,6 +2730,8 @@ let ex_t = ErrorException, ex_r = r"cannot add methods to builtin function"
         @test_throws ex_t @eval $f() = 1
         @test_throws ex_r @eval $f() = 1
     end
+    @test_throws ex_t @eval Base.:(!==)(a::Int, b::Int) = a * b
+    @test_throws ex_r @eval Base.:(!==)(a::Int, b::Int) = a * b
 end
 
 # issue #33370


### PR DESCRIPTION
AI Use Acknowledgement: I used GitHub Copilot (Claude Haiku 3.5) to help me identify issues and make changes to code. I reviewed its output and take responsibility for the code changes.

I noticed that #61392 identifies unwanted behavior; a user is able to redefine the base operator `!==` with a custom function. With builtin functions such as `===`, the system will throw an error if a user tries to redefine it. However, this was not the case with `!===` because it is not a core builtin. 

I put in a guard so that Julia will throw an error when a user tries to redefine `!===`, in order to prevent unexpected behavior that comes with redefining such a basic identity check. 