### PR TITLE
[REPLCompletions] Asynchronous tab completion

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -537,6 +537,7 @@ end
 function async_get_completions(cb, s::MIState; interactive::Bool,
                                mutex::Union{Nothing, ReentrantLock}=nothing)
     keys_pressed = s.n_keys_pressed
+    current_action = s.current_action
     st = state(s)
     c, mod = state(s).p.complete, s.active_module
     complete = Threads.Atomic{Bool}(false)
@@ -573,7 +574,7 @@ function async_get_completions(cb, s::MIState; interactive::Bool,
                 changed = clear_hint(st)
                 if cb(completions, reg, should_complete)
                     changed = true
-                    hint || (s.last_action = s.current_action)
+                    hint || (s.last_action = current_action)
                 end
                 changed && refresh_line(s)
             end

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -430,7 +430,7 @@ function complete_line(s::MIState)
     set_action!(s, :complete_line)
     st = state(s)
     repeats = s.key_repeats
-    async_get_completions(s; hint=false) do completions, reg, should_complete
+    async_get_completions(s; interactive=true) do completions, reg, should_complete
         if isempty(completions)
             beep(st)
             return false
@@ -491,7 +491,7 @@ function check_show_hint(s::MIState)
         clear_hint(st) && refresh_line(s)
         return
     end
-    async_get_completions(s; hint=true, mutex=s.hint_generation_lock) do named_completions, reg, should_complete
+    async_get_completions(s; interactive=false, mutex=s.hint_generation_lock) do named_completions, reg, should_complete
         isempty(named_completions) && return false
         completions = map(x -> x.completion, named_completions)
         # Don't complete for single chars, given e.g. `x` completes to `xor`
@@ -529,11 +529,11 @@ function clear_hint(s::ModeState)
 end
 
 # Generate completions with complete_line_named asynchronously, then invoke cb
-# with the results.  When hint=false, show a "…" indicator when completions take
-# longer than the 0.1s to generate, and set the last_action.  With hint=true,
-# don't show any indicator and don't touch last_action.  A mutex can be
-# provided, which will be taken while generating the completions.  This is used
-# to prevent multiple hints from being generated at once.
+# with the results.  When interactive=true, show a "…" indicator when
+# completions take longer than the 0.1s to generate, and set the last_action.
+# With interactive=false, don't show any indicator and don't touch last_action.
+# A mutex can be provided, which will be taken while generating the completions.
+# This is used to prevent multiple hints from being generated at once.
 function async_get_completions(cb, s::MIState; interactive::Bool,
                                mutex::Union{Nothing, ReentrantLock}=nothing)
     keys_pressed = s.n_keys_pressed
@@ -544,9 +544,7 @@ function async_get_completions(cb, s::MIState; interactive::Bool,
 
     aborted() = s.n_keys_pressed > keys_pressed || s.aborted
 
-    timer = if hint
-        nothing
-    else
+    timer = if interactive
         Timer(0.1) do _
             @lock s.line_modify_lock begin
                 (complete[] || aborted()) && return
@@ -554,6 +552,8 @@ function async_get_completions(cb, s::MIState; interactive::Bool,
                 refresh_line(s)
             end
         end
+    else
+        nothing
     end
 
     t = Threads.@spawn :default begin
@@ -563,7 +563,7 @@ function async_get_completions(cb, s::MIState; interactive::Bool,
                 # We check aborted() before generating completions so we don't
                 # wait on mutex if we would wake up and throw the results away.
                 (@lock s.line_modify_lock aborted()) && return
-                complete_line_named(c, st, mod; hint)
+                complete_line_named(c, st, mod; hint=!interactive)
             finally
                 mutex !== nothing && unlock(mutex)
             end
@@ -574,13 +574,13 @@ function async_get_completions(cb, s::MIState; interactive::Bool,
                 changed = clear_hint(st)
                 if cb(completions, reg, should_complete)
                     changed = true
-                    hint || (s.last_action = current_action)
+                    interactive && (s.last_action = current_action)
                 end
                 changed && refresh_line(s)
             end
         finally
             complete[] = true
-            if !hint
+            if interactive
                 close(timer)
             end
         end
@@ -942,7 +942,7 @@ function edit_move_right(m::MIState)
         refresh_line(s)
         return true
     else
-        async_get_completions(m; hint=false) do completions, reg, should_complete
+        async_get_completions(m; interactive=true) do completions, reg, should_complete
             if should_complete && eof(buf) && length(completions) == 1 && reg.second - reg.first > 1
                 # Replace word by completion
                 prev_pos = position(s)

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -534,7 +534,7 @@ end
 # don't show any indicator and don't touch last_action.  A mutex can be
 # provided, which will be taken while generating the completions.  This is used
 # to prevent multiple hints from being generated at once.
-function async_get_completions(cb, s::MIState; hint::Bool,
+function async_get_completions(cb, s::MIState; interactive::Bool,
                                mutex::Union{Nothing, ReentrantLock}=nothing)
     keys_pressed = s.n_keys_pressed
     st = state(s)
@@ -947,7 +947,6 @@ function edit_move_right(m::MIState)
                 prev_pos = position(s)
                 push_undo(s)
                 edit_splice!(s, (prev_pos - reg.second + reg.first) => prev_pos, completions[1].completion)
-                refresh_line(s)
                 return true
             else
                 return false

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -428,12 +428,37 @@ end
 # Prompt Completions & Hints
 function complete_line(s::MIState)
     set_action!(s, :complete_line)
-    if complete_line(state(s), s.key_repeats, s.active_module)
-        return refresh_line(s)
-    else
-        beep(s)
-        return :ignore
+    st = state(s)
+    repeats = s.key_repeats
+    async_get_completions(s; hint=false) do completions, reg, should_complete
+        if isempty(completions)
+            beep(st)
+            return false
+        end
+        if !should_complete
+            # should_complete is false for cases where we only want to show
+            # a list of possible completions but not complete, e.g. foo(\t
+            show_completions(st, completions)
+        elseif length(completions) == 1
+            # Replace word by completion
+            push_undo(st)
+            edit_splice!(st, reg, completions[1].completion)
+        else
+            p = common_prefix(completions)
+            partial = content(st, reg.first => min(bufend(st), reg.first + sizeof(p)))
+            if !isempty(p) && p != partial
+                # All possible completions share the same prefix, so we might as
+                # well complete that.
+                push_undo(st)
+                edit_splice!(st, reg, p)
+            elseif repeats > 0
+                show_completions(st, completions)
+            end
+        end
+        return true
     end
+
+    return :ignore
 end
 
 # Old complete_line return type: Vector{String},          String, Bool
@@ -459,44 +484,16 @@ end
 # pressed a key since the hint generation was requested
 function check_show_hint(s::MIState)
     st = state(s)
-
-    this_key_i = s.n_keys_pressed
-    next_key_pressed() = @lock s.line_modify_lock s.n_keys_pressed > this_key_i
-    function lock_clear_hint()
-        @lock s.line_modify_lock begin
-            next_key_pressed() || s.aborted || clear_hint(st) && refresh_line(s)
-        end
-    end
-
     if !options(st).hint_tab_completes || !eof(buffer(st))
         # only generate hints if enabled and at the end of the line
         # TODO: maybe show hints for insertions at other positions
         # Requires making space for them earlier in refresh_multi_line
-        lock_clear_hint()
+        clear_hint(st) && refresh_line(s)
         return
     end
-    t_completion = Threads.@spawn :default begin
-        named_completions, reg, should_complete = nothing, nothing, nothing
-
-        # only allow one task to generate hints at a time and check around lock
-        # if the user has pressed a key since the hint was requested, to skip old completions
-        next_key_pressed() && return
-        @lock s.hint_generation_lock begin
-            next_key_pressed() && return
-            named_completions, reg, should_complete = try
-                complete_line_named(st.p.complete, st, s.active_module; hint = true)
-            catch
-                lock_clear_hint()
-                return
-            end
-        end
-        next_key_pressed() && return
-
+    async_get_completions(s; hint=true, mutex=s.hint_generation_lock) do named_completions, reg, should_complete
+        isempty(named_completions) && return false
         completions = map(x -> x.completion, named_completions)
-        if isempty(completions)
-            lock_clear_hint()
-            return
-        end
         # Don't complete for single chars, given e.g. `x` completes to `xor`
         if reg.second - reg.first > 1 && should_complete
             singlecompletion = length(completions) == 1
@@ -512,21 +509,14 @@ function check_show_hint(s::MIState)
                     # index of p from which to start providing the hint
                     startind = nextind(p, startind)
                     hint = p[startind:end]
-                    next_key_pressed() && return
-                    @lock s.line_modify_lock begin
-                        if !s.aborted
-                            state(s).hint = hint
-                            refresh_line(s)
-                        end
-                    end
-                    return
+                    st.hint = hint
+                    return true
                 end
             end
         end
-        lock_clear_hint()
+        return false
     end
-    Base.errormonitor(t_completion)
-    return
+    nothing
 end
 
 function clear_hint(s::ModeState)
@@ -538,30 +528,64 @@ function clear_hint(s::ModeState)
     end
 end
 
-function complete_line(s::PromptState, repeats::Int, mod::Module; hint::Bool=false)
-    completions, reg, should_complete = complete_line_named(s.p.complete, s, mod; hint)
-    isempty(completions) && return false
-    if !should_complete
-        # should_complete is false for cases where we only want to show
-        # a list of possible completions but not complete, e.g. foo(\t
-        show_completions(s, completions)
-    elseif length(completions) == 1
-        # Replace word by completion
-        push_undo(s)
-        edit_splice!(s, reg, completions[1].completion)
+# Generate completions with complete_line_named asynchronously, then invoke cb
+# with the results.  When hint=false, show a "…" indicator when completions take
+# longer than the 0.1s to generate, and set the last_action.  With hint=true,
+# don't show any indicator and don't touch last_action.  A mutex can be
+# provided, which will be taken while generating the completions.  This is used
+# to prevent multiple hints from being generated at once.
+function async_get_completions(cb, s::MIState; hint::Bool,
+                               mutex::Union{Nothing, ReentrantLock}=nothing)
+    keys_pressed = s.n_keys_pressed
+    st = state(s)
+    c, mod = state(s).p.complete, s.active_module
+    complete = Threads.Atomic{Bool}(false)
+
+    aborted() = s.n_keys_pressed > keys_pressed || s.aborted
+
+    timer = if hint
+        nothing
     else
-        p = common_prefix(completions)
-        partial = content(s, reg.first => min(bufend(s), reg.first + sizeof(p)))
-        if !isempty(p) && p != partial
-            # All possible completions share the same prefix, so we might as
-            # well complete that.
-            push_undo(s)
-            edit_splice!(s, reg, p)
-        elseif repeats > 0
-            show_completions(s, completions)
+        Timer(0.1) do _
+            @lock s.line_modify_lock begin
+                (complete[] || aborted()) && return
+                st.hint = "…"
+                refresh_line(s)
+            end
         end
     end
-    return true
+
+    t = Threads.@spawn :default begin
+        try
+            completions, reg, should_complete = try
+                mutex !== nothing && lock(mutex)
+                # We check aborted() before generating completions so we don't
+                # wait on mutex if we would wake up and throw the results away.
+                (@lock s.line_modify_lock aborted()) && return
+                complete_line_named(c, st, mod; hint)
+            finally
+                mutex !== nothing && unlock(mutex)
+            end
+
+            @lock s.line_modify_lock begin
+                complete[] = true
+                aborted() && return
+                changed = clear_hint(st)
+                if cb(completions, reg, should_complete)
+                    changed = true
+                    hint || (s.last_action = s.current_action)
+                end
+                changed && refresh_line(s)
+            end
+        finally
+            complete[] = true
+            if !hint
+                close(timer)
+            end
+        end
+    end
+    errormonitor(t)
+    nothing
 end
 
 function clear_input_area(terminal::AbstractTerminal, s::PromptState)
@@ -917,17 +941,19 @@ function edit_move_right(m::MIState)
         refresh_line(s)
         return true
     else
-        completions, reg, should_complete = complete_line(s.p.complete, s, m.active_module)
-        if should_complete && eof(buf) && length(completions) == 1 && reg.second - reg.first > 1
-            # Replace word by completion
-            prev_pos = position(s)
-            push_undo(s)
-            edit_splice!(s, (prev_pos - reg.second + reg.first) => prev_pos, completions[1].completion)
-            refresh_line(state(s))
-            return true
-        else
-            return false
+        async_get_completions(m; hint=false) do completions, reg, should_complete
+            if should_complete && eof(buf) && length(completions) == 1 && reg.second - reg.first > 1
+                # Replace word by completion
+                prev_pos = position(s)
+                push_undo(s)
+                edit_splice!(s, (prev_pos - reg.second + reg.first) => prev_pos, completions[1].completion)
+                refresh_line(s)
+                return true
+            else
+                return false
+            end
         end
+        return false
     end
 end
 


### PR DESCRIPTION
In #57192, we moved hint generation to a worker thread, so it doesn't block typing.  This commit moves manual completion (triggered by either TAB or the right arrow) to a worker thread, too.  I consolidated the code that kicks off a completion Task into async_get_completions to clean things up.

The way this works is you get a "…" indicator when completions are generating, but are taking a long time.  If you hit any other key, the completions are "cancelled" (we can't actually cancel the task at the moment, but we'll ignore the result), and you can type again without delay.  Unlike hints, we don't limit the number of manual completion Tasks, since we never want to have the REPL lock up and refuse to accept input.

This supersedes #52847.

Here's a demo of how it looks, where I've added a 1s sleep to completions to slow it down:

[demo.webm](https://github.com/user-attachments/assets/a597ef39-8975-4a2e-a75f-768f403379a3)
