### PR TITLE
[JuliaLowering] Treat GlobalRef like an identifier

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -39,7 +39,7 @@ end
 # never inserted as an opaque `K"Value"`. Note no LineNumberNode, which appears
 # unwrapped in a macrocall (possibly generated functions too, TODO check)
 isa_lowering_ast_node(@nospecialize(e)) =
-    e isa Symbol || e isa QuoteNode || e isa Expr # || e isa GlobalRef
+    e isa Symbol || e isa QuoteNode || e isa Expr || e isa GlobalRef
 
 function is_expr_value(st::SyntaxTree)
     k = kind(st)
@@ -97,8 +97,9 @@ function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
         else
             newnode(graph, old_src, st_k, cs)
         end
-    # elseif e isa GlobalRef
-        # TODO: Better-behaved as K"globalref", but lowering doesn't know this
+    elseif e isa GlobalRef
+        # Represent globalref as K"Identifier" with :mod attribute
+        setattr!(newleaf(graph, src, K"Identifier", string(e.name)), :mod, e.mod)
     else
         # We may want additional special cases for other types where
         # `Base.isa_ast_node(e)`, but `K"Value"` should be fine for most, since
@@ -121,9 +122,12 @@ function est_to_expr(st::SyntaxTree, suppress_linenodes=false)
     k = kind(st)
     return if k === K"core" && numchildren(st) === 0 && st.name_val === "nothing"
         nothing
-    elseif is_leaf(st) && hasattr(st, :name_val)
+    elseif kind(st) === K"Identifier"
         n = Symbol(st.name_val)
-        hasattr(st, :scope_layer) ? Expr(:scope_layer, n, st.scope_layer) : n
+        mod = get(st, :mod, nothing)
+        !isnothing(mod) ? GlobalRef(mod, n) :
+            hasattr(st, :scope_layer) ? Expr(:scope_layer, n, st.scope_layer) :
+            n
     elseif is_leaf(st) && is_expr_value(st)
         v = st.value
         # Let `st.value isa Symbol` (or other AST node).  Since we enforce that

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -1222,7 +1222,6 @@ end
 ensure_linearization_attributes!(graph) = ensure_attributes!(
     ensure_scope_attributes!(graph),
     slots=Vector{Slot},
-    mod=Module,
     id=Int)
 
 """

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -215,23 +215,32 @@ function _find_scope_decls!(ctx, scope, ex)
         maybe_declare_in_scope!(ctx, scope, ex[1], var_k)
     elseif k === K"global" && kind(ex[1]) === K"Identifier"
         maybe_declare_in_scope!(ctx, scope, ex[1], :global)
-    elseif k in KSet"= constdecl assign_or_constdecl_if_global function_decl"
+    elseif k === K"function_decl"
         k1 = kind(ex[1])
         if k1 === K"BindingId"
             b = get_binding(ctx, ex[1])
-            if k === K"function_decl" && !b.is_ssa && b.kind !== :global
-                @jl_assert false (ex, "allow local BindingId as function name?")
-            end
+            @jl_assert b.is_ssa || b.kind === :global (
+                ex, "allow local BindingId as function name?")
+            get!(scope.binding_assignments, b.id, ex[1]._id)
+        elseif k1 === K"Identifier"
+            hasattr(ex[1], :mod) && maybe_declare_in_scope!(ctx, scope, ex[1], :global)
+            get!(scope.assignments, NameKey(ex[1]), ex[1]._id)
+        else
+            @jl_assert false (ex, "unknown kind in assignment")
+        end
+    elseif k in KSet"= constdecl assign_or_constdecl_if_global"
+        k1 = kind(ex[1])
+        if k1 === K"BindingId"
+            b = get_binding(ctx, ex[1])
             get!(scope.binding_assignments, b.id, ex[1]._id)
         elseif k1 === K"Identifier"
             get!(scope.assignments, NameKey(ex[1]), ex[1]._id)
         elseif k1 === K"Placeholder"
-            @jl_assert k !== K"function_decl" ex
+            # nothing to declare
         else
             @jl_assert false (ex, "unknown kind in assignment")
         end
-        if (k === K"=" || k === K"assign_or_constdecl_if_global" ||
-            k === K"constdecl" && numchildren(ex) == 2)
+        if !(k == K"constdecl" && numchildren(ex) == 1)
             _find_scope_decls!(ctx, scope, ex[2])
         end
     elseif needs_resolution(ex) && !(k in KSet"scope_block lambda method_defs")

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -147,10 +147,11 @@ function declare_in_scope!(ctx, scope::ScopeInfo, ex, bk::Symbol; kws...)
     nk = NameKey(ex)
     if bk === :global
         declaration_scope = top_scope(ctx)
-        mod = ctx.scope_layers[ex.scope_layer].mod
+        mod = hasattr(ex, :mod) ? ex.mod : ctx.scope_layers[ex.scope_layer].mod
     else
         declaration_scope = scope
-        mod = nothing
+        mod = hasattr(ex, :mod) ?
+            throw(LoweringError(ex, "cannot use GlobalRef as local identifier")) : nothing
     end
     is_internal = ctx.scope_layers[nk.layer].is_internal || getmeta(ex, :is_internal, false)
     b = _new_binding(ctx, ex, nk.name, bk; mod, is_internal, kws...)

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -395,7 +395,6 @@ vst1_local_arg(vcx, st) = @stm st begin
 end
 
 vst1_global_arg(vcx, st) = @stm st begin
-    ([K"Value"], when=(st.value isa GlobalRef)) -> pass
     [K"function" _...] -> vcx.toplevel ?
         vst1_function(vcx, st) :
         @fail(st, "global function needs to be placed at top level, or use eval")
@@ -520,11 +519,10 @@ vst1_symdecl(vcx, st) = @stm st begin
     _ -> @fail(st, "expected identifier or `identifier::type`")
 end
 
-# TODO: globalref might not be valid everywhere; check usage of this function
+# TODO: globalref (identifer with .mod) might not be valid everywhere; check
+# usage of this function
 vst1_ident(vcx, st; lhs=false) = @stm st begin
     [K"Identifier"] -> _ident_str(vcx, st, st.name_val; lhs)
-    ([K"Value"], when=(st.value isa GlobalRef)) ->
-        _ident_str(vcx, st, string(st.value.name); lhs)
     _ -> @fail(st, "expected identifier")
 end
 function _ident_str(vcx, st, s::String; lhs=false)
@@ -930,7 +928,6 @@ vst1_assign_lhs(vcx, st; in_const=false, in_tuple=false) = @stm st begin
 end
 vst1_assign_lhs_nontuple(vcx, st; in_const=false, in_tuple=false) = @stm st begin
     [K"ssavalue" [K"Value"]] -> in_const ? @fail(st, "cannot declare ssavalue const") : pass()
-    ([K"Value"], when=(st.value isa GlobalRef)) -> pass()
     (_, when=(is_eventually_call(st))) ->
         vst1_function_calldecl(vcx, st)
     [K"::" x t] ->
@@ -1272,7 +1269,6 @@ vst2_ident_val(vcx, st) = @stm st begin
     [K"BindingId"] -> pass()
     [K"core"] -> pass()
     [K"top"] -> pass()
-    ([K"Value"], when=st.value isa GlobalRef) -> pass()
     _ -> @fail(st, "expected identifier (val)")
 end
 

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -519,7 +519,7 @@ vst1_symdecl(vcx, st) = @stm st begin
     _ -> @fail(st, "expected identifier or `identifier::type`")
 end
 
-# TODO: globalref (identifer with .mod) might not be valid everywhere; check
+# TODO: globalref (identifier with .mod) might not be valid everywhere; check
 # usage of this function
 vst1_ident(vcx, st; lhs=false) = @stm st begin
     [K"Identifier"] -> _ident_str(vcx, st, st.name_val; lhs)

--- a/JuliaLowering/test/decls.jl
+++ b/JuliaLowering/test/decls.jl
@@ -363,7 +363,7 @@ end
     end
 end
 
-@testset "all non-call assignment forms within `const`" begin
+@testset "all non-call non-globalref assignment forms within `const`" begin
     # prohibited by parsing as of writing this, so hard to make into an IR test
     ex = Expr(:const, Expr(:(.=), :x, 1))
     @test_throws LoweringError jl_lower(test_mod, ex)
@@ -495,4 +495,166 @@ end
         @test getproperty(test_mod, sym2) == (2, 22, 222)
         @test getproperty(test_mod, sym3) == 3
     end
+end
+
+module gr_mod end
+
+@testset "GlobalRef as an identifier" begin
+    # gr = 1
+    @gensym sym
+    @test 1 == jl_eval(test_mod, Expr(:(=), GlobalRef(gr_mod, sym), 1))
+    @test Base.isdefinedglobal(gr_mod, sym)
+    @test getproperty(gr_mod, sym) == 1
+    @test !Base.isdefinedglobal(test_mod, sym)
+    # test gr as a value
+    @test 1 == jl_eval(test_mod, Expr(:block, GlobalRef(gr_mod, sym)))
+
+    # gr1 = gr2 = gr3 = gr4 = 1
+    @gensym sym1 sym2 sym3 sym4
+    @test 1 == jl_eval(
+        test_mod,
+        Expr(:(=), GlobalRef(gr_mod, sym1),
+             Expr(:(=), GlobalRef(gr_mod, sym2),
+                  Expr(:(=), GlobalRef(gr_mod, sym3),
+                       Expr(:(=), GlobalRef(gr_mod, sym4), 1)))))
+    @test Base.isdefinedglobal(gr_mod, sym1)
+    @test Base.isdefinedglobal(gr_mod, sym2)
+    @test Base.isdefinedglobal(gr_mod, sym3)
+    @test Base.isdefinedglobal(gr_mod, sym4)
+    @test getproperty(gr_mod, sym1) == 1
+    @test getproperty(gr_mod, sym2) == 1
+    @test getproperty(gr_mod, sym3) == 1
+    @test getproperty(gr_mod, sym4) == 1
+    @test !Base.isdefinedglobal(test_mod, sym1)
+    @test !Base.isdefinedglobal(test_mod, sym2)
+    @test !Base.isdefinedglobal(test_mod, sym3)
+    @test !Base.isdefinedglobal(test_mod, sym4)
+
+    # gr += 5
+    @gensym sym
+    jl_eval(test_mod, Expr(:(=), GlobalRef(gr_mod, sym), 10))
+    @test 15 == jl_eval(
+        test_mod, Expr(:(+=), GlobalRef(gr_mod, sym), 5))
+    @test getproperty(gr_mod, sym) == 15
+
+    # (gr1, gr2) = (1, 2)
+    @gensym sym1 sym2
+    @test (1, 2) == jl_eval(
+        test_mod, Expr(:(=),
+                       Expr(:tuple, GlobalRef(gr_mod, sym1), GlobalRef(gr_mod, sym2)),
+                       Expr(:call, :tuple, 1, 2)))
+    @test getproperty(gr_mod, sym1) == 1
+    @test getproperty(gr_mod, sym2) == 2
+    @test !Base.isdefinedglobal(test_mod, sym1)
+
+    # global gr::Int = 1
+    @gensym sym
+    @test 1 == jl_eval(
+        test_mod, Expr(:global,
+                       Expr(:(=),
+                            Expr(:(::), GlobalRef(gr_mod, sym), Int),
+                            1)))
+    @test Base.isdefinedglobal(gr_mod, sym)
+    @test Core.get_binding_type(gr_mod, sym) == Int
+    @test getproperty(gr_mod, sym) == 1
+    @test !Base.isdefinedglobal(test_mod, sym)
+
+    # global gr::Int
+    @gensym sym
+    @test nothing == jl_eval(
+        test_mod, Expr(:global, Expr(:(::), GlobalRef(gr_mod, sym), Int)))
+    @test Core.get_binding_type(gr_mod, sym) == Int
+
+    # const gr = 1
+    @gensym sym
+    @test 1 == jl_eval(
+        test_mod, Expr(:const, Expr(:(=), GlobalRef(gr_mod, sym), 1)))
+    @test Base.isdefinedglobal(gr_mod, sym)
+    @test getproperty(gr_mod, sym) == 1
+    @test Base.binding_kind(gr_mod, sym) == Base.PARTITION_KIND_CONST
+    @test !Base.isdefinedglobal(test_mod, sym)
+
+    # const gr::Int = 42
+    @gensym sym
+    @test 42 == jl_eval(
+        test_mod, Expr(:const,
+                       Expr(:(=),
+                            Expr(:(::), GlobalRef(gr_mod, sym), Int),
+                            42)))
+    @test Base.isdefinedglobal(gr_mod, sym)
+    @test getproperty(gr_mod, sym) == 42
+    @test Base.binding_kind(gr_mod, sym) == Base.PARTITION_KIND_CONST
+    @test !Base.isdefinedglobal(test_mod, sym)
+
+    # local gr (error)
+    @gensym sym
+    @test_throws LoweringError jl_eval(
+        test_mod, Expr(:local, GlobalRef(gr_mod, sym)))
+    @test_throws LoweringError jl_eval(
+        test_mod, Expr(:let, Expr(:block, Expr(:(=), GlobalRef(gr_mod, sym), 1))))
+    @test !Base.isdefinedglobal(test_mod, sym)
+
+    # function gr end
+    @gensym sym
+    @test jl_eval(test_mod, Expr(:function, GlobalRef(gr_mod, sym))) isa Function
+    @test Base.isdefinedglobal(gr_mod, sym)
+    @test getproperty(gr_mod, sym) isa Function
+    @test !Base.isdefinedglobal(test_mod, sym)
+
+    # function gr(x); x; end
+    @gensym sym
+    @test jl_eval(test_mod, Expr(:function,
+                                 Expr(:call, GlobalRef(gr_mod, sym), :x),
+                                 Expr(:block, :x))) isa Function
+    @test Base.isdefinedglobal(gr_mod, sym)
+    @test getproperty(gr_mod, sym)(1) == 1
+    @test !Base.isdefinedglobal(test_mod, sym)
+
+    # function gr(x;kw1,kw2=2); x; end
+    @gensym sym
+    @test jl_eval(test_mod, Expr(:function,
+                                 Expr(:call,
+                                      GlobalRef(gr_mod, sym),
+                                      Expr(:parameters, :kw1, Expr(:kw, :kw2, 2)),
+                                      :x),
+                                 Expr(:block,
+                                      Expr(:tuple, :x, :kw1, :kw2)))) isa Function
+    @test Base.isdefinedglobal(gr_mod, sym)
+    @test getproperty(gr_mod, sym)(0;kw1=1) == (0,1,2)
+    @test getproperty(gr_mod, sym)(0;kw1=1,kw2=20) == (0,1,20)
+    @test !Base.isdefinedglobal(test_mod, sym)
+
+    # error: begin; local gr = 1; end
+    # (note: flisp allows this)
+    @gensym sym
+    @test_throws "cannot use GlobalRef as local identifier" jl_eval(
+        test_mod, Expr(:block,
+                       Expr(:local, Expr(:(=), GlobalRef(gr_mod, sym), 1))))
+    @test !Base.isdefinedglobal(test_mod, sym)
+    @test !Base.isdefinedglobal(gr_mod, sym)
+
+    # error: let gr = 1; end
+    # (note: flisp allows this)
+    @gensym sym
+    @test_throws "cannot use GlobalRef as local identifier" jl_eval(
+        test_mod, Expr(:let,
+                       Expr(:block, Expr(:(=), GlobalRef(gr_mod, sym), 1)),
+                       Expr(:block)))
+
+    # error: for gr = 1:3
+    # (note: flisp allows this)
+    @gensym sym
+    @test_throws "cannot use GlobalRef as local identifier" jl_eval(
+        test_mod, Expr(:for,
+                       Expr(:(=), GlobalRef(gr_mod, sym),
+                            Expr(:call, :(:), 1, 3)),
+                       Expr(:block, nothing)))
+
+    # error: try/catch with GlobalRef catch var
+    @gensym sym
+    @test_throws "cannot use GlobalRef as local identifier" jl_eval(
+        test_mod, Expr(:try,
+                       Expr(:block, Expr(:call, :error, "oops")),
+                       GlobalRef(gr_mod, sym),
+                       Expr(:block, GlobalRef(gr_mod, sym))))
 end

--- a/JuliaLowering/test/decls.jl
+++ b/JuliaLowering/test/decls.jl
@@ -497,7 +497,7 @@ end
     end
 end
 
-module gr_mod end
+gr_mod = Module()
 
 @testset "GlobalRef as an identifier" begin
     # gr = 1
@@ -624,6 +624,28 @@ module gr_mod end
     @test getproperty(gr_mod, sym)(0;kw1=1,kw2=20) == (0,1,20)
     @test !Base.isdefinedglobal(test_mod, sym)
 
+    # gr inner function (let) should act like global inner function
+    @gensym sym
+    @test jl_eval(
+        test_mod,
+        Expr(:let,
+             Expr(:block, Expr(:(=), :a, 1), Expr(:(=), :b, 2)),
+             Expr(:block,
+                  Expr(:function, Expr(:call, GlobalRef(gr_mod, sym), :c),
+                       Expr(:block, Expr(:tuple, :a, :b, :c)))))) isa Function
+    @test Base.isdefinedglobal(gr_mod, sym)
+    @test !Base.isdefinedglobal(test_mod, sym)
+    @test getproperty(gr_mod, sym)(3) == (1,2,3)
+
+    # error: gr inner function (function) should act like global inner function
+    @gensym sym outer_f
+    @test_throws LoweringError jl_eval(
+        test_mod,
+        Expr(:function, Expr(:call, outer_f),
+             Expr(:block,
+                  Expr(:function, Expr(:call, GlobalRef(gr_mod, sym)),
+                       Expr(:block)))))
+
     # error: begin; local gr = 1; end
     # (note: flisp allows this)
     @gensym sym
@@ -648,7 +670,15 @@ module gr_mod end
         test_mod, Expr(:for,
                        Expr(:(=), GlobalRef(gr_mod, sym),
                             Expr(:call, :(:), 1, 3)),
-                       Expr(:block, nothing)))
+                       Expr(:block)))
+
+    # error: function f(gr); end
+    @gensym sym
+    @test_throws "cannot use GlobalRef as local identifier" jl_eval(
+        test_mod, Expr(:function,
+                       Expr(:call, :fname, GlobalRef(gr_mod, sym)),
+                       Expr(:block)))
+
 
     # error: try/catch with GlobalRef catch var
     @gensym sym

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -88,7 +88,8 @@ ensure_required_attributes!(g::SyntaxGraph) = ensure_attributes!(
     source=SourceAttrType,
     syntax_flags=UInt16,
     value=Any,
-    name_val=String)
+    name_val=String,
+    mod=Module)
 
 function delete_attributes!(graph::SyntaxGraph{<:Dict}, attr_names::Symbol...)
     for name in attr_names
@@ -1287,6 +1288,7 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
     k = kind(st)
     coreref(s::String) = setattr!(newleaf(graph, st, K"core"), :name_val, s)
     symleaf(s::String) = setattr!(newleaf(graph, st, K"Identifier"), :name_val, s)
+    core_globalref(s::String) = setattr!(symleaf(s), :mod, Core)
     valleaf(@nospecialize(v)) = setattr!(newleaf(graph, st, K"Value"), :value, v)
 
     if is_leaf(st)
@@ -1300,7 +1302,7 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
             # which added this to match flisp parsing text->Expr.
             macname = v isa Int128 ? "@int128_str" :
                 v isa UInt128 ? "@uint128_str" : "@big_str"
-            mac = valleaf(GlobalRef(Core, Symbol(macname)))
+            mac = core_globalref(macname)
             arg = valleaf(replace(sourcetext(st), '_'=>""))
             ret_cids = tree_ids(mac, coreref("nothing"), arg)
             newnode(graph, st, K"macrocall", ret_cids)
@@ -1325,7 +1327,7 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
         cmd_arg = _string_to_est(st, cs; unwrap_literal=true)
         loc_st = valleaf(source_location(LineNumberNode, st))
         return newnode(graph, st, K"macrocall", tree_ids(
-            valleaf(GlobalRef(Core, Symbol("@cmd"))), loc_st, cmd_arg))
+            core_globalref("@cmd"), loc_st, cmd_arg))
     elseif k === K"macro_name" && n_cs === 1
         # "M.@x" => (. M (macro_name x)) => (. M @x)
         # "@M.x" => (macro_name (. M x)) => (. M @x)
@@ -1387,7 +1389,7 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
         # (doc str obj) => (macrocall Core.@doc lno str obj)
         ret_k = K"macrocall"
         pushfirst!(cs, valleaf(source_location(LineNumberNode, st)))
-        pushfirst!(cs, valleaf(GlobalRef(Core, Symbol("@doc"))))
+        pushfirst!(cs, core_globalref("@doc"))
     elseif k === K"dotcall" || k === K"call" && n_cs > 0
         if is_infix_op_call(st) || is_postfix_op_call(st)
             cs[2], cs[1] = cs[1], cs[2]


### PR DESCRIPTION
Atop #61372, fix https://github.com/JuliaLang/JuliaLowering.jl/issues/149.  Femtolisp lowering generally allows GlobalRef in any place a plain identifier would be allowed.  By representing GlobalRef as `K"Identifier"` with a `mod` attribute and checking `mod` in scope resolution, we can pretty neatly provide the same functionality (though I won't rule out tweaks being needed to desugaring or scope resolution on top of this easy implementation).

Note flisp will sometimes allow a globalref in the position of a local being declared.  I've just disallowed it in this PR.

```
julia> test_mod = Module()
julia> gr_mod = Module()

# local gr = 1
julia> Core.eval(test_mod, Expr(:local, Expr(:(=), GlobalRef(gr_mod, :local_assign), 1)))

julia> gr_mod.local_assign
1

# for gr = 1:3
julia> Core.eval(test_mod, Expr(:for,
                              Expr(:(=), GlobalRef(gr_mod, :for_assign),
                                   Expr(:call, :(:), 1, 3)),
                              Expr(:block, Expr(:call, :println, GlobalRef(gr_mod, :for_assign)))))
1
2
3

julia> gr_mod.for_assign
3

# local gr
julia> Core.eval(test_mod, Expr(:local, GlobalRef(gr_mod, :die)))
[26825] signal 11 (2): Segmentation fault: 11
in expression starting at none:1
jl_gc_small_alloc_inner at ./julia/src/gc-stock.c:751 [inlined]
jl_gc_small_alloc_noinline at ./julia/src/gc-stock.c:792 [inlined]
jl_gc_alloc_ at ./julia/src/gc-stock.c:806
ijl_box_slotnumber at ./julia/src/datatype.c:1580 [inlined]

# function fname(gr); end
julia> Core.eval(test_mod, Expr(:function,
                              Expr(:call, :fname, GlobalRef(gr_mod, :arg)),
                              Expr(:block)))
ERROR: syntax: "anonymous.arg" is not a valid function argument name
```

Also add plenty of tests (some from Claude).  Suggestions for more are welcome.