### PR TITLE
Replace magic `fielddesc_type` values by named constants

### DIFF
--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -759,14 +759,13 @@ function getindex(dtfd::DataTypeFieldDesc, i::Int)
     fielddesc_type = (layout.flags >> 1) & 3
     nfields = layout.nfields
     @boundscheck ((1 <= i <= nfields) || throw(BoundsError(dtfd, i)))
-    if fielddesc_type == 0
+    if fielddesc_type == 0  # JL_FIELDDESC_8
         return FieldDesc(unsafe_load(Ptr{FieldDescStorage{UInt8}}(fd_ptr), i))
-    elseif fielddesc_type == 1
+    elseif fielddesc_type == 1  # JL_FIELDDESC_16
         return FieldDesc(unsafe_load(Ptr{FieldDescStorage{UInt16}}(fd_ptr), i))
-    elseif fielddesc_type == 2
+    elseif fielddesc_type == 2  # JL_FIELDDESC_32
         return FieldDesc(unsafe_load(Ptr{FieldDescStorage{UInt32}}(fd_ptr), i))
-    else
-        # fielddesc_type == 3
+    else # fielddesc_type == 3  # JL_FIELDDESC_FOREIGN
         return FieldDesc(true, true, 0, 0)
     end
 end

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -148,7 +148,7 @@ static uint32_t _hash_layout_djb2(uintptr_t _layout, void *unused) JL_NOTSAFEPOI
     size_t fields_size = layout->nfields * jl_fielddesc_size(layout->flags.fielddesc_type);
     const char *pointers = jl_dt_layout_ptrs(layout);
     assert(pointers);
-    size_t pointers_size = layout->first_ptr < 0 ? 0 : (layout->npointers << layout->flags.fielddesc_type);
+    size_t pointers_size = layout->first_ptr < 0 ? 0 : (layout->npointers * jl_fielddesc_ptr_size(layout->flags.fielddesc_type));
 
     uint_t hash = 5381;
     hash = _hash_djb2(hash, (char *)layout, own_size);
@@ -171,7 +171,7 @@ static int layout_eq(void *_l1, void *_l2, void *unused) JL_NOTSAFEPOINT
         return 0;
     const char *p1 = jl_dt_layout_ptrs(l1);
     const char *p2 = jl_dt_layout_ptrs(l2);
-    size_t pointers_size = l1->first_ptr < 0 ? 0 : (l1->npointers << l1->flags.fielddesc_type);
+    size_t pointers_size = l1->first_ptr < 0 ? 0 : (l1->npointers * jl_fielddesc_ptr_size(l1->flags.fielddesc_type));
     if (memcmp(p1, p2, pointers_size))
         return 0;
     return 1;
@@ -199,7 +199,7 @@ static jl_datatype_layout_t *jl_get_layout(uint32_t sz,
     assert(alignment); // should have been verified by caller
 
     // compute the smallest fielddesc type that can hold the layout description
-    int fielddesc_type = 0;
+    int fielddesc_type = JL_FIELDDESC_8;
     uint32_t max_size = 0;
     uint32_t max_offset = 0;
     if (nfields > 0) {
@@ -215,9 +215,9 @@ static jl_datatype_layout_t *jl_get_layout(uint32_t sz,
     jl_fielddesc16_t maxdesc16 = { 0, max_size, max_offset };
     jl_fielddesc32_t maxdesc32 = { 0, max_size, max_offset };
     if (maxdesc8.size != max_size || maxdesc8.offset != max_offset) {
-        fielddesc_type = 1;
+        fielddesc_type = JL_FIELDDESC_16;
         if (maxdesc16.size != max_size || maxdesc16.offset != max_offset) {
-            fielddesc_type = 2;
+            fielddesc_type = JL_FIELDDESC_32;
             if (maxdesc32.size != max_size || maxdesc32.offset != max_offset) {
                 assert(0); // should have been verified by caller
             }
@@ -227,7 +227,7 @@ static jl_datatype_layout_t *jl_get_layout(uint32_t sz,
 
     // allocate a new descriptor, on the stack if possible.
     size_t fields_size = nfields * jl_fielddesc_size(fielddesc_type);
-    size_t pointers_size = first_ptr < 0 ? 0 : (npointers << fielddesc_type);
+    size_t pointers_size = first_ptr < 0 ? 0 : (npointers * jl_fielddesc_ptr_size(fielddesc_type));
     size_t flddesc_sz = sizeof(jl_datatype_layout_t) + fields_size + pointers_size;
     int should_malloc = flddesc_sz >= jl_page_size;
     jl_datatype_layout_t *mallocmem = (jl_datatype_layout_t *)(should_malloc ? malloc(flddesc_sz) : NULL);
@@ -253,12 +253,12 @@ static jl_datatype_layout_t *jl_get_layout(uint32_t sz,
     jl_fielddesc16_t *desc16 = (jl_fielddesc16_t *)jl_dt_layout_fields(flddesc);
     jl_fielddesc32_t *desc32 = (jl_fielddesc32_t *)jl_dt_layout_fields(flddesc);
     for (size_t i = 0; i < nfields; i++) {
-        if (fielddesc_type == 0) {
+        if (fielddesc_type == JL_FIELDDESC_8) {
             desc8[i].offset = desc[i].offset;
             desc8[i].size = desc[i].size;
             desc8[i].isptr = desc[i].isptr;
         }
-        else if (fielddesc_type == 1) {
+        else if (fielddesc_type == JL_FIELDDESC_16) {
             desc16[i].offset = desc[i].offset;
             desc16[i].size = desc[i].size;
             desc16[i].isptr = desc[i].isptr;
@@ -274,10 +274,10 @@ static jl_datatype_layout_t *jl_get_layout(uint32_t sz,
         uint16_t *ptrs16 = (uint16_t *)jl_dt_layout_ptrs(flddesc);
         uint32_t *ptrs32 = (uint32_t *)jl_dt_layout_ptrs(flddesc);
         for (size_t i = 0; i < npointers; i++) {
-            if (fielddesc_type == 0) {
+            if (fielddesc_type == JL_FIELDDESC_8) {
                 ptrs8[i] = pointers[i];
             }
-            else if (fielddesc_type == 1) {
+            else if (fielddesc_type == JL_FIELDDESC_16) {
                 ptrs16[i] = pointers[i];
             }
             else {
@@ -384,7 +384,9 @@ int jl_datatype_isinlinealloc(jl_datatype_t *ty, int pointerfree)
                 return 0;
             if (ty->name->n_uninitialized != 0)
                 return 0;
-            if (ty->layout->flags.fielddesc_type > 1) // GC only implements support for 8 and 16 (not array32)
+            jl_fielddesc_type_t fielddesc_type = (jl_fielddesc_type_t)ty->layout->flags.fielddesc_type;
+            if (fielddesc_type != JL_FIELDDESC_8 && fielddesc_type != JL_FIELDDESC_16)
+                // GC inlinealloc array support only handles compact Julia layouts.
                 return 0;
         }
         return 1;
@@ -561,10 +563,12 @@ void jl_get_genericmemory_layout(jl_datatype_t *st)
             if (el_layout->first_ptr >= 0) {
                 first_ptr = el_layout->first_ptr;
                 npointers = el_layout->npointers;
-                if (el_layout->flags.fielddesc_type == 2 && !needlock) {
+                if (el_layout->flags.fielddesc_type == JL_FIELDDESC_32 && !needlock) {
                     pointers = (uint32_t*)jl_dt_layout_ptrs(el_layout);
                 }
                 else {
+                    assert(el_layout->flags.fielddesc_type != JL_FIELDDESC_FOREIGN);
+                    // Array element layouts need explicit pointer offsets.
                     pointers = (uint32_t*)alloca(npointers * sizeof(uint32_t));
                     for (int j = 0; j < npointers; j++) {
                         pointers[j] = jl_ptr_offset((jl_datatype_t*)eltype, j);
@@ -1049,7 +1053,7 @@ JL_DLLEXPORT jl_datatype_t * jl_new_foreign_type(jl_sym_t *name,
     layout->npointers = haspointers;
     layout->flags.haspadding = 1;
     layout->flags.isbitsegal = 0;
-    layout->flags.fielddesc_type = 3;
+    layout->flags.fielddesc_type = JL_FIELDDESC_FOREIGN;
     layout->flags.padding = 0;
     layout->flags.arrayelem_isboxed = 0;
     layout->flags.arrayelem_isunion = 0;
@@ -1086,7 +1090,7 @@ JL_DLLEXPORT int jl_reinit_foreign_type(jl_datatype_t *dt,
 
 JL_DLLEXPORT int jl_is_foreign_type(jl_datatype_t *dt)
 {
-    return jl_is_datatype(dt) && dt->layout && dt->layout->flags.fielddesc_type == 3;
+    return jl_is_datatype(dt) && dt->layout && dt->layout->flags.fielddesc_type == JL_FIELDDESC_FOREIGN;
 }
 
 // bits constructors ----------------------------------------------------------
@@ -2366,7 +2370,7 @@ jl_value_t *get_nth_pointer(jl_value_t *v, size_t i)
     uint32_t npointers = ly->npointers;
     if (i >= npointers)
         jl_bounds_error_int(v, i);
-    if (ly->flags.fielddesc_type == 3) {
+    if (ly->flags.fielddesc_type == JL_FIELDDESC_FOREIGN) {
         // Foreign types can report that they contain pointers for GC purposes,
         // but they do not expose an inline pointer-offset table to enumerate.
         return NULL;
@@ -2375,9 +2379,9 @@ jl_value_t *get_nth_pointer(jl_value_t *v, size_t i)
     const uint16_t *ptrs16 = (const uint16_t *)jl_dt_layout_ptrs(ly);
     const uint32_t *ptrs32 = (const uint32_t*)jl_dt_layout_ptrs(ly);
     uint32_t fld;
-    if (ly->flags.fielddesc_type == 0)
+    if (ly->flags.fielddesc_type == JL_FIELDDESC_8)
         fld = ptrs8[i];
-    else if (ly->flags.fielddesc_type == 1)
+    else if (ly->flags.fielddesc_type == JL_FIELDDESC_16)
         fld = ptrs16[i];
     else
         fld = ptrs32[i];

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -1519,19 +1519,20 @@ void jl_gc_queue_multiroot(const jl_value_t *parent, const void *ptr, jl_datatyp
         jl_gc_wb_back(parent);
         return;
     }
+    assert(ly->flags.fielddesc_type != JL_FIELDDESC_FOREIGN);
     const uint8_t *ptrs8 = (const uint8_t *)jl_dt_layout_ptrs(ly);
     const uint16_t *ptrs16 = (const uint16_t *)jl_dt_layout_ptrs(ly);
     const uint32_t *ptrs32 = (const uint32_t*)jl_dt_layout_ptrs(ly);
     for (size_t i = 1; i < npointers; i++) {
         uint32_t fld;
-        if (ly->flags.fielddesc_type == 0) {
+        if (ly->flags.fielddesc_type == JL_FIELDDESC_8) {
             fld = ptrs8[i];
         }
-        else if (ly->flags.fielddesc_type == 1) {
+        else if (ly->flags.fielddesc_type == JL_FIELDDESC_16) {
             fld = ptrs16[i];
         }
         else {
-            assert(ly->flags.fielddesc_type == 2);
+            assert(ly->flags.fielddesc_type == JL_FIELDDESC_32);
             fld = ptrs32[i];
         }
         jl_value_t *ptrf = ((jl_value_t**)ptr)[fld];
@@ -2363,7 +2364,7 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
                     gc_mark_excstack(ptls, excstack, itr);
                 }
                 const jl_datatype_layout_t *layout = jl_task_type->layout;
-                assert(layout->flags.fielddesc_type == 0);
+                assert(layout->flags.fielddesc_type == JL_FIELDDESC_8);
                 assert(layout->nfields > 0);
                 uint32_t npointers = layout->npointers;
                 char *obj8_parent = (char *)ta;
@@ -2458,19 +2459,21 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
                     objary_begin += layout->first_ptr;
                     gc_mark_objarray(ptls, objary_parent, objary_begin, objary_end, step, nptr);
                 }
-                else if (layout->flags.fielddesc_type == 0) {
+                else if (layout->flags.fielddesc_type == JL_FIELDDESC_8) {
                     uint8_t *obj8_begin = (uint8_t*)jl_dt_layout_ptrs(layout);
                     uint8_t *obj8_end = obj8_begin + npointers;
                     gc_mark_memory8(ptls, objary_parent, objary_begin, objary_end, obj8_begin, obj8_end,
                                    elsize, nptr);
                 }
-                else if (layout->flags.fielddesc_type == 1) {
+                else if (layout->flags.fielddesc_type == JL_FIELDDESC_16) {
                     uint16_t *obj16_begin = (uint16_t*)jl_dt_layout_ptrs(layout);
                     uint16_t *obj16_end = obj16_begin + npointers;
                     gc_mark_memory16(ptls, objary_parent, objary_begin, objary_end, obj16_begin, obj16_end,
                                     elsize, nptr);
                 }
                 else {
+                    assert(layout->flags.fielddesc_type != JL_FIELDDESC_FOREIGN);
+                    // Inline array scanning does not implement 32-bit or foreign descriptors.
                     assert(0 && "unimplemented");
                 }
             }
@@ -2486,9 +2489,9 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
         if (npointers == 0)
             return;
         uintptr_t nptr = (npointers << 2 | (bits & GC_OLD));
-        assert((layout->nfields > 0 || layout->flags.fielddesc_type == 3) &&
+        assert((layout->nfields > 0 || layout->flags.fielddesc_type == JL_FIELDDESC_FOREIGN) &&
                "opaque types should have been handled specially");
-        if (layout->flags.fielddesc_type == 0) {
+        if (layout->flags.fielddesc_type == JL_FIELDDESC_8) {
             char *obj8_parent = (char *)new_obj;
             uint8_t *obj8_begin = (uint8_t *)jl_dt_layout_ptrs(layout);
             uint8_t *obj8_end = obj8_begin + npointers;
@@ -2501,7 +2504,7 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
                     gc_ptr_queue_push(mq, new_obj);
             }
         }
-        else if (layout->flags.fielddesc_type == 1) {
+        else if (layout->flags.fielddesc_type == JL_FIELDDESC_16) {
             char *obj16_parent = (char *)new_obj;
             uint16_t *obj16_begin = (uint16_t *)jl_dt_layout_ptrs(layout);
             uint16_t *obj16_end = obj16_begin + npointers;
@@ -2514,7 +2517,7 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
                     gc_ptr_queue_push(mq, new_obj);
             }
         }
-        else if (layout->flags.fielddesc_type == 2) {
+        else if (layout->flags.fielddesc_type == JL_FIELDDESC_32) {
             // This is very uncommon
             // Do not do store to load forwarding to save some code size
             char *obj32_parent = (char *)new_obj;
@@ -2530,7 +2533,7 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
             }
         }
         else {
-            assert(layout->flags.fielddesc_type == 3);
+            assert(layout->flags.fielddesc_type == JL_FIELDDESC_FOREIGN);
             jl_fielddescdyn_t *desc = (jl_fielddescdyn_t *)jl_dt_layout_fields(layout);
             int old = jl_astaggedvalue(new_obj)->bits.gc & 2;
             uintptr_t young = desc->markfunc(ptls, new_obj);

--- a/src/julia.h
+++ b/src/julia.h
@@ -589,6 +589,13 @@ typedef struct {
     uint32_t offset;   // offset relative to data start, excluding type tag
 } jl_fielddesc32_t;
 
+typedef enum {
+    JL_FIELDDESC_8 = 0,
+    JL_FIELDDESC_16 = 1,
+    JL_FIELDDESC_32 = 2,
+    JL_FIELDDESC_FOREIGN = 3,
+} jl_fielddesc_type_t;
+
 typedef struct {
     uint32_t size;
     uint32_t nfields;
@@ -597,7 +604,7 @@ typedef struct {
     uint16_t alignment; // strictest alignment over all fields
     struct { // combine these fields into a struct so that we can take addressof them
         uint16_t haspadding : 1; // has internal undefined bytes
-        uint16_t fielddesc_type : 2; // 0 -> 8, 1 -> 16, 2 -> 32, 3 -> foreign type
+        uint16_t fielddesc_type : 2; // jl_fielddesc_type_t
         // metadata bit only for GenericMemory eltype layout
         uint16_t arrayelem_isboxed : 1;
         uint16_t arrayelem_isunion : 1;
@@ -1469,22 +1476,40 @@ STATIC_INLINE const char *jl_module_debug_name(jl_module_t *mod) JL_NOTSAFEPOINT
 
 static inline uint32_t jl_fielddesc_size(int8_t fielddesc_type) JL_NOTSAFEPOINT
 {
-    assert(fielddesc_type >= 0 && fielddesc_type <= 2);
-    return 2 << fielddesc_type;
-    //if (fielddesc_type == 0) {
-    //    return sizeof(jl_fielddesc8_t);
-    //}
-    //else if (fielddesc_type == 1) {
-    //    return sizeof(jl_fielddesc16_t);
-    //}
-    //else {
-    //    return sizeof(jl_fielddesc32_t);
-    //}
+    switch ((jl_fielddesc_type_t)fielddesc_type) {
+    case JL_FIELDDESC_8:
+        return sizeof(jl_fielddesc8_t);
+    case JL_FIELDDESC_16:
+        return sizeof(jl_fielddesc16_t);
+    case JL_FIELDDESC_32:
+        return sizeof(jl_fielddesc32_t);
+    case JL_FIELDDESC_FOREIGN:
+        break;
+    }
+    assert(0 && "foreign field descriptors do not have inline layout entries");
+    return 0;
+}
+
+static inline uint32_t jl_fielddesc_ptr_size(int8_t fielddesc_type) JL_NOTSAFEPOINT
+{
+    switch ((jl_fielddesc_type_t)fielddesc_type) {
+    case JL_FIELDDESC_8:
+        return sizeof(uint8_t);
+    case JL_FIELDDESC_16:
+        return sizeof(uint16_t);
+    case JL_FIELDDESC_32:
+        return sizeof(uint32_t);
+    case JL_FIELDDESC_FOREIGN:
+        break;
+    }
+    assert(0 && "foreign field descriptors do not have inline pointer tables");
+    return 0;
 }
 
 #define jl_dt_layout_fields(d) ((const char*)(d) + sizeof(jl_datatype_layout_t))
 static inline const char *jl_dt_layout_ptrs(const jl_datatype_layout_t *l) JL_NOTSAFEPOINT
 {
+    assert(l->flags.fielddesc_type != JL_FIELDDESC_FOREIGN);
     return jl_dt_layout_fields(l) + jl_fielddesc_size(l->flags.fielddesc_type) * l->nfields;
 }
 
@@ -1494,14 +1519,14 @@ static inline const char *jl_dt_layout_ptrs(const jl_datatype_layout_t *l) JL_NO
     {                                                                         \
         const jl_datatype_layout_t *ly = jl_datatype_layout(st);              \
         assert(i >= 0 && (size_t)i < ly->nfields);                            \
-        if (ly->flags.fielddesc_type == 0) {                                  \
+        if (ly->flags.fielddesc_type == JL_FIELDDESC_8) {                     \
             return ((const jl_fielddesc8_t*)jl_dt_layout_fields(ly))[i].f;    \
         }                                                                     \
-        else if (ly->flags.fielddesc_type == 1) {                             \
+        else if (ly->flags.fielddesc_type == JL_FIELDDESC_16) {               \
             return ((const jl_fielddesc16_t*)jl_dt_layout_fields(ly))[i].f;   \
         }                                                                     \
         else {                                                                \
-            assert(ly->flags.fielddesc_type == 2);                            \
+            assert(ly->flags.fielddesc_type == JL_FIELDDESC_32);              \
             return ((const jl_fielddesc32_t*)jl_dt_layout_fields(ly))[i].f;   \
         }                                                                     \
     }                                                                         \
@@ -1514,6 +1539,7 @@ static inline int jl_field_isptr(jl_datatype_t *st, int i) JL_NOTSAFEPOINT
 {
     const jl_datatype_layout_t *ly = jl_datatype_layout(st);
     assert(i >= 0 && (size_t)i < ly->nfields);
+    assert(ly->flags.fielddesc_type != JL_FIELDDESC_FOREIGN);
     return ((const jl_fielddesc8_t*)(jl_dt_layout_fields(ly) + jl_fielddesc_size(ly->flags.fielddesc_type) * i))->isptr;
 }
 
@@ -1522,14 +1548,14 @@ static inline uint32_t jl_ptr_offset(jl_datatype_t *st, int i) JL_NOTSAFEPOINT
     const jl_datatype_layout_t *ly = st->layout; // NOT jl_datatype_layout(st)
     assert(i >= 0 && (size_t)i < ly->npointers);
     const void *ptrs = jl_dt_layout_ptrs(ly);
-    if (ly->flags.fielddesc_type == 0) {
+    if (ly->flags.fielddesc_type == JL_FIELDDESC_8) {
         return ((const uint8_t*)ptrs)[i];
     }
-    else if (ly->flags.fielddesc_type == 1) {
+    else if (ly->flags.fielddesc_type == JL_FIELDDESC_16) {
         return ((const uint16_t*)ptrs)[i];
     }
     else {
-        assert(ly->flags.fielddesc_type == 2);
+        assert(ly->flags.fielddesc_type == JL_FIELDDESC_32);
         return ((const uint32_t*)ptrs)[i];
     }
 }

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -66,7 +66,7 @@ JL_DLLEXPORT size_t jl_gc_max_internal_obj_size(void) JL_NOTSAFEPOINT;
 
 // Field layout descriptor for custom types that do
 // not fit Julia layout conventions. This is associated with
-// jl_datatype_t instances where fielddesc_type == 3.
+// jl_datatype_t instances where fielddesc_type == JL_FIELDDESC_FOREIGN.
 
 typedef struct {
     jl_markfunc_t markfunc;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1723,14 +1723,14 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
                     size_t nf = dt->layout->nfields;
                     size_t np = dt->layout->npointers;
                     size_t fieldsize = 0;
-                    uint8_t is_foreign_type = dt->layout->flags.fielddesc_type == 3;
+                    uint8_t is_foreign_type = dt->layout->flags.fielddesc_type == JL_FIELDDESC_FOREIGN;
                     if (!is_foreign_type) {
                         fieldsize = jl_fielddesc_size(dt->layout->flags.fielddesc_type);
                     }
                     char *flddesc = (char*)dt->layout;
                     size_t fldsize = sizeof(jl_datatype_layout_t) + nf * fieldsize;
                     if (!is_foreign_type && dt->layout->first_ptr != -1)
-                        fldsize += np << dt->layout->flags.fielddesc_type;
+                        fldsize += np * jl_fielddesc_ptr_size(dt->layout->flags.fielddesc_type);
                     uintptr_t layout = LLT_ALIGN(ios_pos(s->const_data), sizeof(void*));
                     write_padding(s->const_data, layout - ios_pos(s->const_data)); // realign stream
                     newdt->layout = NULL; // relocation offset


### PR DESCRIPTION
Also add helper functions so the supported layout forms are explicit at each use site.

Co-authored-by: Codex <codex@openai.com>

This PR used to also contain the fix for https://github.com/oscar-system/GAP.jl/issues/1366 but I got that merged separately via PR #61517

---

Off-topic, but: I am actually somewhat amazed by the AI here: while I discovered the source of the bug myself, and the fix was clear, I wondered if I could let the AI write the test for me... and then also thought that some enums for the `fielddesc_type` values would be good... I ended up *not* telling it about the specific crash; instead I just asked it to introduce the enum and adjust the code to use it; and to check for spots that are not handling all `fielddesc_type`. That's it. I thought I'd follow this up with telling it what to fix and to add a test case. But actually it one-shotted it, discovered the crash in `summarysize` and created a test case. *I did not tell it there is a crash.

