### PR TITLE
[JuliaLowering] Fix UndefVarError for keyword arg names in return type

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2416,7 +2416,8 @@ end
 # - one wrapper per optional positional arg
 # - one containing the body
 # - possibly one generated method
-function method_def_expr(ctx, src, mtable, sparams, argl, body, rett)
+function method_def_expr(ctx, src, mtable, sparams, argl, body,
+                         rett=@ast(ctx, src, "Any"::K"core"))
     @jl_assert length(argl) > 0 src
     @jl_assert kind(argl[end]) !== K"parameters" src argl[end]
     if length(pos_opt_args(argl)) > 0
@@ -2568,7 +2569,7 @@ function optional_positional_defs(ctx, src, mtable, sparams, argl, body, rett)
         end
         push!(methods, method_def_expr(
             ctx, src, mtable, used_typevars(passed, sparams),
-            passed, wrapper_body, rett))
+            passed, wrapper_body))
         push!(passed, opt_decls[i])
     end
     if length(opt) + length(req) < length(argl)
@@ -2638,7 +2639,9 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
         newsym(ctx, argl[1], reserve_module_binding_i(ctx.mod, mangled))
     end
     # (1) Body method.  This contains the actual function body, and requires
-    # every possible default to be filled.
+    # (1) Body method.  This contains the actual function body, and requires
+    # every possible default to be filled.  `rett` is only passed here since it
+    # can reference any argument.
     mdefs1 = let arg1 = @ast ctx m1_name [K"::" m1_name [K"function_type" m1_name]]
         nkw = @ast ctx kws [K"meta" "nkw"::K"Symbol" numchildren(kws)::K"Value"]
         method_def_expr(
@@ -2660,7 +2663,7 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
         end
         method_def_expr(
             ctx, src, mtable, positional_sparams, pargl,
-            @ast(ctx, src, [K"block" [K"return" body2]]), rett)
+            @ast(ctx, src, [K"block" [K"return" body2]]))
     end
     # (3) Core.kwcall(arg2::NamedTuple, pargl...) methods (one per optarg).
     # - for each kwarg:
@@ -2749,7 +2752,7 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
             arg2 = @ast ctx arg2_name [K"::" arg2_name "NamedTuple"::K"core"]
             method_def_expr(
                 ctx, src, mtable, positional_sparams,
-                SyntaxList(arg1, arg2, pargl...), kwcall_body, rett)
+                SyntaxList(arg1, arg2, pargl...), kwcall_body)
         end
     end
     @ast ctx src [K"block"

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -676,6 +676,26 @@ end
     # dispatching to the body function.
     @test_throws MethodError values(test_mod.f_kw_type_errors(1; a="str", b=10))
 
+    # Return type annotation using default argument names
+    # The return type must be evaluated in a scope where keyword args are bound.
+    JuliaLowering.include_string(test_mod, """
+    function f_default_rett(T::Type=Int)::Vector{T}
+        T[1,2,3]
+    end
+    """)
+    @test test_mod.f_default_rett() isa Vector{Int}
+    @test test_mod.f_default_rett(Float64) isa Vector{Float64}
+
+    # Return type annotation using keyword argument names
+    # The return type must be evaluated in a scope where keyword args are bound.
+    JuliaLowering.include_string(test_mod, """
+    function f_kw_rett(; T::Type=Int)::Vector{T}
+        T[1,2,3]
+    end
+    """)
+    @test test_mod.f_kw_rett() isa Vector{Int}
+    @test test_mod.f_kw_rett(T=Float64) isa Vector{Float64}
+
     # Throwing of UndefKeywordError
     JuliaLowering.include_string(test_mod, """
     function f_kw_no_default(; x)

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -1048,17 +1048,10 @@ end
 7   SourceLocation::1:10
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.f %₈
-    slots: [slot₁/#self#(called) slot₂/tmp(!read)]
+    slots: [slot₁/#self#(called)]
     1   TestMod.default_x
-    2   TestMod.T
-    3   (= slot₂/tmp (call slot₁/#self# %₁))
-    4   (call core.isa slot₂/tmp %₂)
-    5   (gotoifnot %₄ label₇)
-    6   (goto label₉)
-    7   (call top.convert %₂ slot₂/tmp)
-    8   (= slot₂/tmp (call core.typeassert %₇ %₂))
-    9   slot₂/tmp
-    10  (return %₉)
+    2   (call slot₁/#self# %₁)
+    3   (return %₂)
 10  latestworld
 11  TestMod.f
 12  (call core.Typeof %₁₁)


### PR DESCRIPTION
The nokw and kwcall wrapper methods were receiving the raw `rett` expression as the return type of their lambdas. When keyword argument names appear in the return type (e.g., `f(; T::Type=Int)::Vector{T}`), those names are not bound in the wrapper scopes, causing `UndefVarError` at runtime.

Fix by omitting `rett` from the wrapper methods. Only the body method (which has keyword args as positional parameters) needs the return type check. Make `rett` a default argument of `method_def_expr` so callers can simply omit it.