### PR TITLE
Move `engine.cpp` to `libjulia-codegen`

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -65,7 +65,7 @@ SRCS := \
 	simplevector runtime_intrinsics precompile jloptions mtarraylist \
 	threading scheduler stackwalk null_sysimage \
 	method jlapi signal-handling safepoint timing subtype rtutils \
-	crc32c APInt-C processor ircode opaque_closure codegen-stubs coverage runtime_ccall engine \
+	crc32c APInt-C processor ircode opaque_closure codegen-stubs coverage runtime_ccall \
 	$(GC_SRCS)
 
 RT_LLVMLINK :=
@@ -80,7 +80,7 @@ GC_CODEGEN_SRCS += llvm-final-gc-lowering-mmtk
 else
 GC_CODEGEN_SRCS += llvm-final-gc-lowering-stock
 endif
-CODEGEN_SRCS := codegen jitlayers aotcompile debuginfo disasm llvm-simdloop \
+CODEGEN_SRCS := codegen jitlayers aotcompile debuginfo disasm llvm-simdloop engine \
 	llvm-pass-helpers llvm-ptls llvm-propagate-addrspaces \
 	llvm-multiversioning llvm-alloc-opt llvm-alloc-helpers cgmemmgr llvm-remove-addrspaces \
 	llvm-remove-ni llvm-julia-licm llvm-demote-float16 llvm-cpufeatures llvm-expand-atomic-modify \

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -161,3 +161,11 @@ JL_DLLEXPORT const char JLJITGetGlobalPrefix_fallback(void* JIT) UNAVAILABLE
 JL_DLLEXPORT const char *JLJITGetDataLayoutString_fallback(void* JIT) UNAVAILABLE
 
 JL_DLLEXPORT void* JLJITGetIRCompileLayer_fallback(void* JIT) UNAVAILABLE
+
+JL_DLLEXPORT jl_code_instance_t *jl_engine_reserve_fallback(jl_method_instance_t *mi, jl_value_t *owner) UNAVAILABLE
+
+JL_DLLEXPORT void jl_engine_fulfill_fallback(jl_code_instance_t *ci, jl_code_info_t *src) UNAVAILABLE
+
+JL_DLLEXPORT int jl_engine_hasreserved_fallback(jl_method_instance_t *mi, jl_value_t *owner) UNAVAILABLE
+
+JL_DLLEXPORT void jl_engine_sweep_fallback(jl_ptls_t *gc_all_tls_states) { }

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -57,7 +57,7 @@ static SmallVector<InferKey, 0> Awaiting; // (this could be merged into ptls als
 extern "C" {
 #endif
 
-jl_code_instance_t *jl_engine_reserve(jl_method_instance_t *m, jl_value_t *owner)
+JL_DLLEXPORT_CODEGEN jl_code_instance_t *jl_engine_reserve_impl(jl_method_instance_t *m, jl_value_t *owner)
 {
     jl_task_t *ct = jl_current_task;
     ct->ptls->engine_nqueued++; // disables finalizers until inference is finished on this method graph
@@ -103,7 +103,7 @@ jl_code_instance_t *jl_engine_reserve(jl_method_instance_t *m, jl_value_t *owner
     return ci;
 }
 
-int jl_engine_hasreserved(jl_method_instance_t *m, jl_value_t *owner)
+JL_DLLEXPORT_CODEGEN int jl_engine_hasreserved_impl(jl_method_instance_t *m, jl_value_t *owner)
 {
     jl_task_t *ct = jl_current_task;
     InferKey key = {m, owner};
@@ -117,7 +117,7 @@ STATIC_INLINE int gc_marked(uintptr_t bits) JL_NOTSAFEPOINT
     return (bits & GC_MARKED) != 0;
 }
 
-void jl_engine_sweep(jl_ptls_t *gc_all_tls_states)
+JL_DLLEXPORT_CODEGEN void jl_engine_sweep_impl(jl_ptls_t *gc_all_tls_states)
 {
     std::unique_lock lock(engine_lock);
     bool any = false;
@@ -135,7 +135,7 @@ void jl_engine_sweep(jl_ptls_t *gc_all_tls_states)
         engine_wait.notify_all();
 }
 
-void jl_engine_fulfill(jl_code_instance_t *ci, jl_code_info_t *src)
+JL_DLLEXPORT_CODEGEN void jl_engine_fulfill_impl(jl_code_instance_t *ci, jl_code_info_t *src)
 {
     jl_task_t *ct = jl_current_task;
     std::unique_lock lock(engine_lock);

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -518,6 +518,10 @@
     YY(jl_dump_function_ir) \
     YY(jl_dump_method_asm) \
     YY(jl_emit_codeinst_to_jit) \
+    YY(jl_engine_reserve) \
+    YY(jl_engine_fulfill) \
+    YY(jl_engine_hasreserved) \
+    YY(jl_engine_sweep) \
     YY(jl_get_llvmf_defn) \
     YY(jl_get_llvm_function) \
     YY(jl_get_llvm_module) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -800,10 +800,10 @@ typedef union {
 #define METHOD_SIG_LATEST_ONLY              0b0010
 #define METHOD_SIG_PRECOMPILE_MANY          0b0100
 
-JL_DLLEXPORT jl_code_instance_t *jl_engine_reserve(jl_method_instance_t *m, jl_value_t *owner);
-JL_DLLEXPORT void jl_engine_fulfill(jl_code_instance_t *ci, jl_code_info_t *src);
-void jl_engine_sweep(jl_ptls_t *gc_all_tls_states) JL_NOTSAFEPOINT;
-int jl_engine_hasreserved(jl_method_instance_t *m, jl_value_t *owner) JL_NOTSAFEPOINT;
+JL_DLLIMPORT jl_code_instance_t *jl_engine_reserve(jl_method_instance_t *m, jl_value_t *owner);
+JL_DLLIMPORT void jl_engine_fulfill(jl_code_instance_t *ci, jl_code_info_t *src);
+JL_DLLIMPORT void jl_engine_sweep(jl_ptls_t *gc_all_tls_states) JL_NOTSAFEPOINT;
+JL_DLLIMPORT int jl_engine_hasreserved(jl_method_instance_t *m, jl_value_t *owner) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT jl_code_instance_t *jl_type_infer(jl_method_instance_t *li JL_PROPAGATES_ROOT, size_t world, uint8_t source_mode, uint8_t trim_mode);
 JL_DLLEXPORT jl_code_info_t *jl_gdbcodetyped1(jl_method_instance_t *mi, size_t world);


### PR DESCRIPTION
Thought I'd open this as an alternative, although discussion is ongoing in https://github.com/JuliaLang/julia/pull/61400.

This reduces the C++ dependencies in `libjulia-internal` without having to port this to C.