### PR TITLE
FinalGCLowering: Invalidate all analyses when modifications are made.

### DIFF
--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -273,7 +273,7 @@ PreservedAnalyses FinalLowerGCPass::run(Function &F, FunctionAnalysisManager &AM
 #ifdef JL_VERIFY_PASSES
         assert(!verifyLLVMIR(F));
 #endif
-        return PreservedAnalyses::allInSet<CFGAnalyses>();
+        return PreservedAnalyses::none();
     }
     return PreservedAnalyses::all();
 }


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/57769 moved `lowerWriteBarrier` from `LateLowerGCFrame` into FinalLowerGC, causing it to modify the CFG. This was not reflected in the invalidation of analyses, resulting in issues such as https://github.com/JuliaGPU/GPUCompiler.jl/issues/777.

Closes https://github.com/JuliaGPU/GPUCompiler.jl/issues/777