### PR TITLE
subtype: Rename `right` to existential

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -68,7 +68,7 @@ typedef struct jl_varbinding_t {
     jl_tvar_t *var; // store NULL to "delete" this from env (temporarily)
     jl_value_t *JL_NONNULL lb;
     jl_value_t *JL_NONNULL ub;
-    int8_t right;       // whether this variable came from the right side of `A <: B`
+    int8_t existential; // whether this variable should be treated as existential
     int8_t occurs_inv;  // occurs in invariant position
     int8_t occurs_cov;  // # of occurrences in covariant position
     int8_t concrete;    // 1 if another variable has a constraint forcing this one to be concrete
@@ -807,7 +807,7 @@ static int var_lt(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, int param)
     if (e->Loffset != 0 && !jl_is_typevar(a) &&
         a != jl_bottom_type && a != (jl_value_t *)jl_any_type)
         return 0;
-    if (!bb->right)  // check ∀b . b<:a
+    if (!bb->existential)  // check ∀b . b<:a
         return subtype_left_var(bb->ub, a, e, param);
     if (bb->ub == a)
         return 1;
@@ -828,7 +828,7 @@ static int var_lt(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, int param)
     assert(bb->ub != (jl_value_t*)b);
     if (jl_is_typevar(a)) {
         jl_varbinding_t *aa = lookup(e, (jl_tvar_t*)a);
-        if (aa && !aa->right && in_union(bb->lb, a) && bb->depth0 != aa->depth0 && var_outside(e, b, (jl_tvar_t*)a)) {
+        if (aa && !aa->existential && in_union(bb->lb, a) && bb->depth0 != aa->depth0 && var_outside(e, b, (jl_tvar_t*)a)) {
             // an "exists" var cannot equal a "forall" var inside it unless the forall
             // var has equal bounds.
             return subtype_left_var(aa->ub, aa->lb, e, param);
@@ -848,7 +848,7 @@ static int var_gt(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, int param)
     if (e->Loffset != 0 && !jl_is_typevar(a) &&
         a != jl_bottom_type && a != (jl_value_t *)jl_any_type)
         return 0;
-    if (!bb->right)  // check ∀b . b>:a
+    if (!bb->existential)  // check ∀b . b>:a
         return subtype_left_var(a, bb->lb, e, param);
     if (bb->lb == a)
         return 1;
@@ -863,7 +863,7 @@ static int var_gt(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, int param)
     assert(bb->lb != (jl_value_t*)b);
     if (jl_is_typevar(a)) {
         jl_varbinding_t *aa = lookup(e, (jl_tvar_t*)a);
-        if (aa && !aa->right && bb->depth0 != aa->depth0 && param == 2 && var_outside(e, b, (jl_tvar_t*)a))
+        if (aa && !aa->existential && bb->depth0 != aa->depth0 && param == 2 && var_outside(e, b, (jl_tvar_t*)a))
             return subtype_left_var(aa->ub, aa->lb, e, param);
     }
     return 1;
@@ -1426,7 +1426,7 @@ static int subtype_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, in
     }
     if (vvx != JL_VARARG_NONE && vvx != JL_VARARG_INT &&
         (!xbb || !jl_is_long(xbb->lb))) {
-        if (vvx == JL_VARARG_UNBOUND || (xbb && !xbb->right)) {
+        if (vvx == JL_VARARG_UNBOUND || (xbb && !xbb->existential)) {
             // Unbounded on the LHS, bounded on the RHS
             if (vvy == JL_VARARG_NONE || vvy == JL_VARARG_INT)
                 return 0;
@@ -1466,7 +1466,7 @@ static int subtype_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, in
 }
 
 static int try_subtype_by_bounds(jl_value_t *a, jl_value_t *b, jl_stenv_t *e);
-static int has_exists_typevar(jl_value_t *x, jl_stenv_t *e) JL_NOTSAFEPOINT;
+static int has_existential_typevar(jl_value_t *x, jl_stenv_t *e) JL_NOTSAFEPOINT;
 
 // `param` means we are currently looking at a parameter of a type constructor
 // (as opposed to being outside any type constructor, or comparing variable bounds).
@@ -1497,7 +1497,7 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param)
             // Note: `x <: ∃y` performs a local ∀-∃ check between `x` and `yb->ub`.
             // We need to ensure that there's no ∃ typevar as otherwise that check
             // might cause false alarm due to the accumulated env change.
-            if (yb == NULL || yb->right == 0 || !has_exists_typevar(yb->ub, e))
+            if (yb == NULL || !yb->existential || !has_existential_typevar(yb->ub, e))
                 return subtype_var(yvar, x, e, 1, param);
         }
         x = pick_union_element(x, e, 0);
@@ -1515,7 +1515,7 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param)
             // variables lurking inside.
             // note: for forall var, there's no need to split y if it has no free typevars.
             jl_varbinding_t *xx = lookup(e, (jl_tvar_t *)x);
-            ui = ((xx && xx->right) || jl_has_free_typevars(y)) && pick_union_decision(e, 1);
+            ui = ((xx && xx->existential) || jl_has_free_typevars(y)) && pick_union_decision(e, 1);
         }
         if (ui == 1)
             y = pick_union_element(y, e, 1);
@@ -1536,8 +1536,8 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param)
                 if (yub == ylb && jl_is_typevar(yub))
                     return subtype(x, yub, e, param);
             }
-            int xr = xx && xx->right;  // treat free variables as "forall" (left)
-            int yr = yy && yy->right;
+            int xr = xx && xx->existential;  // treat free variables as "forall" (left)
+            int yr = yy && yy->existential;
             if (xr) {
                 if (yy) record_var_occurrence(yy, e, param);
                 if (yr) {
@@ -1559,7 +1559,7 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param)
         if (jl_is_unionall(y)) {
             jl_varbinding_t *xb = lookup(e, (jl_tvar_t*)x);
             jl_value_t *xub = xb == NULL ? ((jl_tvar_t *)x)->ub : xb->ub;
-            if ((xb == NULL ? !e->ignore_free : !xb->right) && xub != y) {
+            if ((xb == NULL ? !e->ignore_free : !xb->existential) && xub != y) {
                 // We'd better unwrap `y::UnionAll` eagerly if `x` isa ∀-var.
                 // This makes sure the following cases work correct:
                 // 1) `∀T <: Union{∃S, SomeType{P}} where {P}`: `S == Any` ==> `S >: T`
@@ -1678,20 +1678,20 @@ static int is_definite_length_tuple_type(jl_value_t *x)
     return k == JL_VARARG_NONE || k == JL_VARARG_INT;
 }
 
-static int is_exists_typevar(jl_value_t *x, jl_stenv_t *e)
+static int is_existential_typevar(jl_value_t *x, jl_stenv_t *e)
 {
     if (!jl_is_typevar(x))
         return 0;
     jl_varbinding_t *vb = lookup(e, (jl_tvar_t *)x);
-    return vb && vb->right;
+    return vb && vb->existential;
 }
 
-static int has_exists_typevar(jl_value_t *x, jl_stenv_t *e) JL_NOTSAFEPOINT
+static int has_existential_typevar(jl_value_t *x, jl_stenv_t *e) JL_NOTSAFEPOINT
 {
     jl_typeenv_t *env = NULL;
     jl_varbinding_t *v = e->vars;
     while (v != NULL) {
-        if (v->right) {
+        if (v->existential) {
             jl_typeenv_t *newenv = (jl_typeenv_t*)alloca(sizeof(jl_typeenv_t));
             newenv->var = v->var;
             newenv->val = NULL;
@@ -1716,8 +1716,8 @@ static int local_forall_exists_subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t 
     int kindy = !jl_has_free_typevars(y);
     if (kindx && kindy)
         return jl_subtype(x, y);
-    int has_exists = (!kindx && has_exists_typevar(x, e)) ||
-                     (!kindy && has_exists_typevar(y, e));
+    int has_exists = (!kindx && has_existential_typevar(x, e)) ||
+                     (!kindy && has_existential_typevar(y, e));
     if (!has_exists) {
         // We can use ∀_∃_subtype safely for ∃ free inputs.
         // This helps to save some bits in union stack.
@@ -1729,7 +1729,7 @@ static int local_forall_exists_subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t 
         pop_unionstate(&e->Runions, &oldRunions);
         return sub;
     }
-    if (is_exists_typevar(x, e) != is_exists_typevar(y, e)) {
+    if (is_existential_typevar(x, e) != is_existential_typevar(y, e)) {
         e->Lunions.used = 0;
         while (1) {
             e->Lunions.more = 0;
@@ -1800,7 +1800,7 @@ static int equal_var(jl_tvar_t *v, jl_value_t *x, jl_stenv_t *e)
         return e->ignore_free || (
             local_forall_exists_subtype(x, v->lb, e, 2, !jl_has_free_typevars(x)) &&
             local_forall_exists_subtype(v->ub, x, e, 0, 0));
-    if (!vb->right)
+    if (!vb->existential)
         return local_forall_exists_subtype(x, vb->lb, e, 2, !jl_has_free_typevars(x)) &&
                local_forall_exists_subtype(vb->ub, x, e, 0, 0);
     if (vb->lb == x)
@@ -2811,14 +2811,14 @@ static int subtype_in_env_existential(jl_value_t *x, jl_value_t *y, jl_stenv_t *
     jl_varbinding_t *v = e->vars;
     int n = 0;
     while (v != NULL) {
-        rs[n++] = v->right;
-        v->right = 1;
+        rs[n++] = v->existential;
+        v->existential = 1;
         v = v->prev;
     }
     int issub = subtype_in_env(x, y, e);
     n = 0; v = e->vars;
     while (v != NULL) {
-        v->right = rs[n++];
+        v->existential = rs[n++];
         v = v->prev;
     }
     return issub;
@@ -3464,7 +3464,7 @@ static jl_value_t *finish_unionall(jl_value_t *res JL_MAYBE_UNROOTED, jl_varbind
         }
     }
 
-    if (vb->right && e->envidx < e->envsz) {
+    if (vb->existential && e->envidx < e->envsz) {
         jl_value_t *oldval = e->envout[e->envidx];
         if (!varval || (!is_leaf_bound(varval) && !vb->occurs_inv))
             e->envout[e->envidx] = (jl_value_t*)vb->var;
@@ -3908,7 +3908,7 @@ static void flip_vars(jl_stenv_t *e)
 {
     jl_varbinding_t *btemp = e->vars;
     while (btemp != NULL) {
-        btemp->right = !btemp->right;
+        btemp->existential = !btemp->existential;
         btemp = btemp->prev;
     }
 }


### PR DESCRIPTION
Currently the subtyping algorithm uses `right` to mean `existential`, rather than having structurally come from the right. This doesn't matter as much, because right now, if the LHS and RHS and egal typevars, we rename them. However, I'm working on a unionall representation change that will make it important to distinguish which side of the expression a var came from. As such, rename `right` to `existential`, freeing up `right` to refer to having structurally come from the RHS.