### PR TITLE
[JuliaLowering] Performance improvements

### DIFF
--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -343,7 +343,7 @@ to indicate that the "primary" location of the source is the location where
 macro ast(ctx, srcref, tree)
     quote
         ctx = $(esc(ctx))
-        srcref::$SyntaxTree = $(_match_srcref(srcref))
+        srcref = $(_match_srcref(srcref))::$SyntaxTree
         $(_expand_ast_tree(:ctx, :srcref, tree, QuoteNode(__source__)))
     end
 end

--- a/JuliaLowering/src/bindings.jl
+++ b/JuliaLowering/src/bindings.jl
@@ -98,13 +98,13 @@ function add_binding(bindings::Bindings, binding)
     push!(bindings.info, binding)
 end
 
-function _binding_id(id::Integer)
+function _binding_id(id::IdTag)
     id
 end
 
 function _binding_id(ex::SyntaxTree)
     @jl_assert kind(ex) == K"BindingId" ex
-    ex.var_id
+    ex.var_id::IdTag
 end
 
 function get_binding(bindings::Bindings, x)::BindingInfo
@@ -112,7 +112,7 @@ function get_binding(bindings::Bindings, x)::BindingInfo
 end
 
 function get_binding(ctx::AbstractLoweringContext, x)::BindingInfo
-    get_binding(ctx.bindings, x)
+    get_binding(ctx.bindings::Bindings, x)
 end
 
 function _new_binding(ctx::AbstractLoweringContext, srcref::SyntaxTree,
@@ -128,8 +128,7 @@ end
 
 # Create a new SSA binding
 function ssavar(ctx::AbstractLoweringContext, srcref, name="tmp")
-    nameref = newleaf(ctx, srcref, K"Identifier", name)
-    binding_ex(ctx, _new_binding(ctx, nameref, name, :local;
+    binding_ex(ctx, _new_binding(ctx, srcref, name, :local;
                                  is_ssa=true, is_internal=true))
 end
 

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -30,8 +30,8 @@ function _get_inner_lnn(e::Expr, default::LineNumberNode)
     e.head in (:function, :macro, :module, :(=)) || return default
     length(e.args) >= 2 || return default
     b = e.args[end]
-    b isa Expr && b.head === :block || return default
-    b::Expr # inference TODO
+    b isa Expr || return default
+    b.head === :block || return default
     length(b.args) >= 1 || return default
     b_lnn = b.args[1]
     return b_lnn isa LineNumberNode ? b_lnn : default

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -512,7 +512,7 @@ function est_to_dst(st::SyntaxTree)
                 @ast g st [K"meta" s=>K"Symbol"]
             elseif length(vs) === 1
                 out = est_to_dst(vs[1])
-                setmeta(out, Symbol(s), true)
+                setmeta(out, Symbol(s.name_val), true)
             else
                 # Kick the can down the road (should only be simple atoms?)
                 out_cs = SyntaxList(g)

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -31,8 +31,10 @@ function _get_inner_lnn(e::Expr, default::LineNumberNode)
     length(e.args) >= 2 || return default
     b = e.args[end]
     b isa Expr && b.head === :block || return default
-    length(b.args) >= 1 && b.args[1] isa LineNumberNode || return default
-    return b.args[1]
+    b::Expr # inference TODO
+    length(b.args) >= 1 || return default
+    b_lnn = b.args[1]
+    return b_lnn isa LineNumberNode ? b_lnn : default
 end
 
 # List of Expr-AST forms that are always converted to some SyntaxTree form and
@@ -59,7 +61,7 @@ function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
     elseif e isa Expr && e.head === :scope_layer
         @assert length(e.args) === 2 && e.args[1] isa Symbol
         ident = newleaf(graph, src, K"Identifier")
-        setattr!(ident, :name_val, String(e.args[1]))
+        setattr!(ident, :name_val, String(e.args[1]::Symbol))
         setattr!(ident, :scope_layer, e.args[2])
     elseif e isa Expr && e.head === :static_parameter
         setattr!(newleaf(graph, src, K"Value"), :value, e)
@@ -123,7 +125,7 @@ function est_to_expr(st::SyntaxTree, suppress_linenodes=false)
     return if k === K"core" && numchildren(st) === 0 && st.name_val === "nothing"
         nothing
     elseif kind(st) === K"Identifier"
-        n = Symbol(st.name_val)
+        n = Symbol(st.name_val::String)
         mod = get(st, :mod, nothing)
         !isnothing(mod) ? GlobalRef(mod, n) :
             hasattr(st, :scope_layer) ? Expr(:scope_layer, n, st.scope_layer) :
@@ -144,7 +146,7 @@ function est_to_expr(st::SyntaxTree, suppress_linenodes=false)
         @jl_assert !is_leaf(st) (st, "est_to_expr should only be used pre-desugaring")
         # In a partially-expanded or quoted AST, there may be heads with no
         # corresponding kind
-        head = Symbol(k === K"unknown_head" ? st.name_val : untokenize(k))
+        head = Symbol((k === K"unknown_head" ? st.name_val : untokenize(k))::String)
         out = Expr(head)
 
         # (Move the following assumptions to the docs if they turn out accurate)
@@ -163,22 +165,19 @@ function est_to_expr(st::SyntaxTree, suppress_linenodes=false)
             end
         end
         # Add extra linenodes to some blocks for better provenance
-        @stm st begin
-            ([K"block"], when=!suppress_linenodes) ->
-                push!(out.args, source_location(LineNumberNode, st))
-            [K"module" _... [K"block" _...]] ->
-                pushfirst!(out.args[end].args, source_location(LineNumberNode, st))
-            [K"function" _ [K"block" _...]] ->
-                pushfirst!(out.args[end].args, source_location(LineNumberNode, st))
-            [K"macro" _ [K"block" _...]] ->
-                pushfirst!(out.args[end].args, source_location(LineNumberNode, st))
-            [K"for" _ [K"block" _...]] ->
-                push!(out.args[end].args, source_location(
-                    LineNumberNode, sourcefile(st), last_byte(st)))
-            [K"while" _ [K"block" _...]] ->
-                push!(out.args[end].args, source_location(
-                    LineNumberNode, sourcefile(st), last_byte(st)))
-            _ -> nothing
+        if head === :block && length(out.args) == 0 && !suppress_linenodes
+            push!(out.args, source_location(LineNumberNode, st))
+        elseif head in (:module, :function, :macro) && length(out.args) > 0
+            let b = out.args[end]
+                b isa Expr && b.head === :block && pushfirst!(
+                    b.args, source_location(LineNumberNode, st))
+            end
+        elseif head in (:for, :while) && length(out.args) > 0
+            let b = out.args[end]
+                b isa Expr && b.head === :block && push!(
+                    b.args, source_location(
+                        LineNumberNode, sourcefile(st), last_byte(st)))
+            end
         end
         out
     end
@@ -190,8 +189,9 @@ end
 # .op => (. op)
 function _dst_separate_dotop(st::SyntaxTree)
     k = kind(st)
-    if k === K"Identifier" && is_dotted_operator(st.name_val)
-        dotop_s = st.name_val
+    if k === K"Identifier"
+        dotop_s = st.name_val::String
+        !is_dotted_operator(dotop_s) && return est_to_dst(st)
         op_s = dotop_s[nextind(dotop_s,1):end]
         op_leaf = setattr(mkleaf(st), :name_val, op_s)
         return @ast st._graph st [K"." op_leaf]
@@ -294,7 +294,7 @@ function _expand_literal_pow(st::SyntaxTree)
 end
 
 function _est_to_dst_ident(st::SyntaxTree)
-    s = st.name_val
+    s = st.name_val::String
     if all(==('_'), s) || s == UNUSED
         setattr!(mkleaf(st), :kind, K"Placeholder")
     else
@@ -477,7 +477,7 @@ function est_to_dst(st::SyntaxTree)
         ([K"let" binds body], when=(kind(binds) !== K"block")) ->
             @ast g st [K"let" [K"block"(binds) rec(binds)] rec(body)]
         [K"struct" mut sig body] -> let
-            flags = JS.flags(st) | (_is_false(mut) ? 0 : JS.MUTABLE_FLAG)
+            flags = JS.flags(st) | (_is_false(mut) ? 0x0000 : JS.MUTABLE_FLAG)
             @ast g st [K"struct"(syntax_flags=flags)
                 rec(sig)
                 rec(body)

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -1927,7 +1927,7 @@ function expand_call(ctx, ex)
     if any(kind(arg) == K"..." for arg in args)
         # Splatting, eg, `f(a, xs..., b)`
         expand_splat(ctx, ex, expand_forms_2(ctx, farg), args)
-    elseif kind(farg) == K"Identifier" && farg.name_val == "include"
+    elseif kind(farg) == K"Identifier" && farg.name_val === "include"
         # world age special case
         r = ssavar(ctx, ex)
         @ast ctx ex [K"block"
@@ -1949,8 +1949,6 @@ end
 #-------------------------------------------------------------------------------
 
 function expand_dot(ctx, ex)
-    @jl_assert numchildren(ex) in (1,2)  (ex, "`.` form requires either one or two children")
-
     if numchildren(ex) == 1
         # eg, `f = .+`
         # Upstream TODO: Remove the (. +) representation and replace with use
@@ -1974,6 +1972,8 @@ function expand_dot(ctx, ex)
             ex[1]
             rhs
         ]
+    else
+        @jl_assert false (ex, "`.` form requires either one or two children")
     end
 end
 
@@ -3938,11 +3938,11 @@ function expand_wheres(ctx, ex)
     body = ex[1]
     @stm ex begin
         [K"where" _ [K"_typevars" [K"block" names...] [K"block" stmts...]]] ->
-            for n in reverse(names)
+            for n in Iterators.reverse(names)
                 body = @ast ctx ex [K"call" "UnionAll"::K"core" n body]
             end
         [K"where" _ tvs...] ->
-            for v in reverse(tvs)
+            for v in Iterators.reverse(tvs)
                 body = expand_where(ctx, ex, body, v)
             end
     end

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -160,11 +160,11 @@ end
 function ir_debug_info_state(ex)
     e1 = first(flattened_provenance(ex))
     topfile = filename(e1)
-    [(topfile, [], Vector{Int32}())]
+    Tuple{String, Vector{Any}, Vector{Int32}}[(topfile, [], Vector{Int32}())]
 end
 
 function add_ir_debug_info!(current_codelocs_stack, stmt)
-    locstk = [(filename(e), source_location(e)[1]) for e in flattened_provenance(stmt)]
+    locstk = Tuple{String, Int32}[(filename(e), source_location(e)[1]) for e in flattened_provenance(stmt)]
     for j in 1:length(locstk)
         if j === 1 && current_codelocs_stack[j][1] != locstk[j][1]
             # dilemma: the filename stack here shares no prefix with that of the
@@ -328,8 +328,8 @@ function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
     if is_literal(k)
         ex.value
     elseif k == K"core"
-        name = ex.name_val
-        if name == "nothing"
+        name = ex.name_val::String
+        if name === "nothing"
             # Translate Core.nothing into literal `nothing`s (flisp uses a
             # special form (null) for this during desugaring, etc)
             nothing
@@ -337,24 +337,24 @@ function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
             GlobalRef(Core, Symbol(name))
         end
     elseif k == K"top"
-        GlobalRef(Base, Symbol(ex.name_val))
+        GlobalRef(Base, Symbol(ex.name_val::String))
     elseif k == K"globalref"
-        GlobalRef(ex.mod, Symbol(ex.name_val))
+        GlobalRef(ex.mod::Module, Symbol(ex.name_val::String))
     elseif k == K"Identifier"
         # Implicitly refers to name in parent module
         # TODO: Should we even have plain identifiers at this point or should
         # they all effectively be resolved into GlobalRef earlier?
-        Symbol(ex.name_val)
+        Symbol(ex.name_val::String)
     elseif k == K"SourceLocation"
         QuoteNode(source_location(LineNumberNode, ex))
     elseif k == K"Symbol"
-        QuoteNode(Symbol(ex.name_val))
+        QuoteNode(Symbol(ex.name_val::String))
     elseif k == K"slot"
-        Core.SlotNumber(ex.var_id)
+        Core.SlotNumber(ex.var_id::IdTag)
     elseif k == K"static_parameter"
-        Expr(:static_parameter, ex.var_id)
+        Expr(:static_parameter, ex.var_id::IdTag)
     elseif k == K"SSAValue"
-        Core.SSAValue(ex.var_id + stmt_offset)
+        Core.SSAValue(ex.var_id::IdTag + stmt_offset)
     elseif k == K"return"
         Core.ReturnNode(_to_lowered_expr(ex[1], stmt_offset))
     elseif k == K"inert"

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -192,7 +192,7 @@ function compile_pop_exception(ctx, srcref, src_tokens, dest_tokens)
     # dest_tokens when src_tokens is the same or nested within dest_tokens.
     # It's enough to check the token on the top of the dest stack.
     n = length(dest_tokens)
-    jump_ok = n == 0 || (n <= length(src_tokens) && dest_tokens[n].var_id == src_tokens[n].var_id)
+    jump_ok = n == 0 || (n <= length(src_tokens) && _binding_id(dest_tokens[n]) == _binding_id(src_tokens[n]))
     jump_ok || throw(LoweringError(srcref, "Attempt to jump into catch block"))
     if n < length(src_tokens)
         @ast ctx srcref [K"pop_exception" src_tokens[n+1]]
@@ -203,7 +203,7 @@ end
 
 function compile_leave_handler(ctx, srcref, src_tokens, dest_tokens)
     n = length(dest_tokens)
-    jump_ok = n == 0 || (n <= length(src_tokens) && dest_tokens[n].var_id == src_tokens[n].var_id)
+    jump_ok = n == 0 || (n <= length(src_tokens) && _binding_id(dest_tokens[n]) == _binding_id(src_tokens[n]))
     jump_ok || throw(LoweringError(srcref, "Attempt to jump into try block"))
     if n < length(src_tokens)
         @ast ctx srcref [K"leave" src_tokens[n+1:end]...]
@@ -358,7 +358,7 @@ end
 # `op` may be either K"=" (where global assignments are converted to setglobal!)
 # or K"constdecl".  flisp: emit-assignment-or-setglobal
 function emit_simple_assignment(ctx, srcref, lhs, rhs, op=K"=")
-    binfo = get_binding(ctx, lhs.var_id)
+    binfo = get_binding(ctx, lhs)
     if binfo.kind == :global
         emit(ctx, @ast ctx srcref [
             K"call"
@@ -935,7 +935,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
     elseif k == K"newvar"
         @jl_assert !needs_value ex
         is_duplicate = !isempty(ctx.code) &&
-            (e = last(ctx.code); kind(e) == K"newvar" && e[1].var_id == ex[1].var_id)
+            (e = last(ctx.code); kind(e) == K"newvar" && _binding_id(e[1]) == _binding_id(ex[1]))
         if !is_duplicate
             # TODO: also exclude deleted vars
             emit(ctx, ex)
@@ -962,7 +962,7 @@ function _remove_vars_with_isdefined_check!(vars, ex)
     if is_leaf(ex) || is_quoted(ex) || kind(ex) == K"static_eval"
         return
     elseif kind(ex) == K"isdefined"
-        delete!(vars, ex[1].var_id)
+        delete!(vars, ex[1].var_id::IdTag)
     else
         for e in children(ex)
             _remove_vars_with_isdefined_check!(vars, e)
@@ -987,14 +987,14 @@ function unnecessary_newvar_ids(ctx, stmts)
         _remove_vars_with_isdefined_check!(vars, ex)
         k = kind(ex)
         if k == K"newvar"
-            id = ex[1].var_id
+            id = _binding_id(ex[1])
             if !get_binding(ctx, id).is_captured
                 push!(vars, id)
             end
         elseif k == K"goto" || k == K"gotoifnot" || (k == K"=" && kind(ex[2]) == K"enter")
             empty!(vars)
         elseif k == K"="
-            id = ex[1].var_id
+            id = _binding_id(ex[1])
             if id in vars
                 delete!(vars, id)
                 push!(ids_assigned_before_branch, id)
@@ -1042,7 +1042,7 @@ function compile_body(ctx::LinearIRContext, ex)
     # Filter out unnecessary newvar nodes
     ids_assigned_before_branch = unnecessary_newvar_ids(ctx, ctx.code)
     filter!(ctx.code) do ex
-        !(kind(ex) == K"newvar" && ex[1].var_id in ids_assigned_before_branch)
+        !(kind(ex) == K"newvar" && _binding_id(ex[1]) in ids_assigned_before_branch)
     end
 end
 
@@ -1053,7 +1053,7 @@ end
 function _renumber(ctx, ssa_rewrites, slot_rewrites, label_table, ex)
     k = kind(ex)
     if k == K"BindingId"
-        id = ex.var_id
+        id = _binding_id(ex)
         if haskey(ssa_rewrites, id)
             setattr!(newleaf(ctx, ex, K"SSAValue"), :var_id, ssa_rewrites[id])
         else
@@ -1084,7 +1084,7 @@ function _renumber(ctx, ssa_rewrites, slot_rewrites, label_table, ex)
     elseif is_literal(k) || is_quoted(k)
         ex
     elseif k == K"label"
-        @ast ctx ex label_table[ex.id]::K"label"
+        @ast ctx ex label_table[ex.id::Int]::K"label"
     elseif k == K"code_info"
         ex
     else
@@ -1104,12 +1104,12 @@ function renumber_body(ctx, input_code, slot_rewrites)
         k = kind(ex)
         ex_out = nothing
         if k == K"=" && is_ssa(ctx, ex[1])
-            lhs_id = ex[1].var_id
+            lhs_id = _binding_id(ex[1])
             @jl_assert(!haskey(ssa_rewrites, lhs_id),
                        (ex, "multiple assignments to ssavalue"))
             if is_ssa(ctx, ex[2])
                 # For SSA₁ = SSA₂, record that all uses of SSA₁ should be replaced by SSA₂
-                ssa_rewrites[lhs_id] = ssa_rewrites[ex[2].var_id]
+                ssa_rewrites[lhs_id] = ssa_rewrites[_binding_id(ex[2])]
             else
                 # Otherwise, record which `code` index this SSA value refers to
                 ssa_rewrites[lhs_id] = length(code) + 1
@@ -1156,11 +1156,10 @@ function compile_lambda(outer_ctx, ex)
     for arg in children(lambda_args)
         kind(arg) == K"Placeholder" && continue
         @jl_assert kind(arg) == K"BindingId" ex
-        id = arg.var_id
-        binfo = get_binding(ctx, id)
+        binfo = get_binding(ctx, arg)
         if binfo.is_assigned
             @jl_assert !haskey(ctx.argmap, binfo.id) ex arg
-            ctx.argmap[binfo.id] = new_local_binding(ctx, binding_ex(ctx, binfo), binfo.name).var_id
+            ctx.argmap[binfo.id] = _binding_id(new_local_binding(ctx, binding_ex(ctx, binfo), binfo.name))
         end
     end
     compile_body(ctx, ex[3])

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -312,7 +312,7 @@ function expand_macro(ctx, ex)
             rethrow(newexc)
         end
         if expanded isa SyntaxTree
-            if !is_compatible_graph(ctx, expanded)
+            if expanded._graph !== ctx.graph
                 # If the macro has produced syntax outside the macro context,
                 # copy it over. TODO: Do we expect this always to happen?  What
                 # is the API for access to the macro expansion context?
@@ -386,7 +386,7 @@ function append_sourceref(ctx, ex, secondary_prov)
         if kind(ex) == K"macrocall"
             copy_node(ex)
         else
-            cs = map(e->append_sourceref(ctx, e, secondary_prov)._id, children(ex))
+            cs = mapsyntax(e->append_sourceref(ctx, e, secondary_prov)._id, children(ex))
             mknode(ex, cs)
         end
     else
@@ -474,13 +474,15 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
     end
 end
 
-ensure_macro_attributes!(graph) = ensure_attributes!(
-    graph;
-    var_id=IdTag,
-    scope_layer=LayerId,
-    __macro_ctx__=Nothing,
-    meta=CompileHints,
-    (DEBUG ? (:jl_source=>LineNumberNode,) : ())...)
+function ensure_macro_attributes!(graph)
+    g2 = ensure_attributes!(
+        graph;
+        var_id=IdTag,
+        scope_layer=LayerId,
+        __macro_ctx__=Nothing,
+        meta=CompileHints)
+    DEBUG ? ensure_attributes!(g2; jl_source=LineNumberNode) : g2
+end
 
 @fzone "JL: macroexpand" function expand_forms_1(mod::Module, ex::SyntaxTree, expr_compat_mode::Bool, macro_world::UInt)
     if kind(ex) == K"local"

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -87,8 +87,11 @@ struct ScopeResolutionContext{Attrs} <: AbstractLoweringContext
 end
 
 function contains_softscope_marker(ex)
-    kind(ex) == K"softscope" ||
-        needs_resolution(ex) && any(contains_softscope_marker, children(ex))
+    kind(ex) == K"softscope"  && return true
+    needs_resolution(ex) && for c in children(ex)
+        contains_softscope_marker(c) && return true
+    end
+    return false
 end
 
 top_scope(ctx) = ctx.scopes[1]
@@ -147,13 +150,15 @@ function declare_in_scope!(ctx, scope::ScopeInfo, ex, bk::Symbol; kws...)
     nk = NameKey(ex)
     if bk === :global
         declaration_scope = top_scope(ctx)
-        mod = hasattr(ex, :mod) ? ex.mod : ctx.scope_layers[ex.scope_layer].mod
+        mod = hasattr(ex, :mod) ? ex.mod::Module :
+            ctx.scope_layers[ex.scope_layer::LayerId].mod
     else
         declaration_scope = scope
         mod = hasattr(ex, :mod) ?
             throw(LoweringError(ex, "cannot use GlobalRef as local identifier")) : nothing
     end
-    is_internal = ctx.scope_layers[nk.layer].is_internal || getmeta(ex, :is_internal, false)
+    is_internal = ctx.scope_layers[nk.layer].is_internal ||
+        getmeta(ex, :is_internal, false)::Bool
     b = _new_binding(ctx, ex, nk.name, bk; mod, is_internal, kws...)
     declaration_scope.vars[nk] = b.id
     scope.vars[nk] = b.id
@@ -197,7 +202,7 @@ end
 
 function resolve_name(ctx, ex; exclude_toplevel_globals=false)
     # TODO: probably want to cache these lookups
-    for sid in reverse(ctx.scope_stack)
+    for sid in Iterators.reverse(ctx.scope_stack)
         bid = get(ctx.scopes[sid].vars, NameKey(ex), nothing)
         isnothing(bid) && continue
         b = get_binding(ctx, bid)
@@ -631,7 +636,7 @@ end
 function analyze_variables!(ctx, ex)
     k = kind(ex)
     if k == K"BindingId"
-        b = get_binding(ctx, ex.var_id)
+        b = get_binding(ctx, ex)
         b.is_read = true
         # The type of typed locals is invisible in the previous pass,
         # but is filled in here.
@@ -675,7 +680,7 @@ function analyze_variables!(ctx, ex)
         analyze_variables!(ctx, ex[2])
     elseif k == K"function_decl"
         name = ex[1]
-        b = get_binding(ctx, name.var_id)
+        b = get_binding(ctx, name)
         if b.kind === :local
             init_closure_bindings!(ctx, name)
         end
@@ -685,13 +690,13 @@ function analyze_variables!(ctx, ex)
             analyze_variables!(ctx, ex[1])
         end
     elseif k == K"constdecl"
-        b = get_binding(ctx, ex[1].var_id)
+        b = get_binding(ctx, ex[1])
         b.is_const = true
         add_assign!(b)
     elseif k == K"call"
         name = ex[1]
         if kind(name) == K"BindingId"
-            get_binding(ctx, name.var_id).is_called = true
+            get_binding(ctx, name).is_called = true
         end
         foreach(e->analyze_variables!(ctx, e), children(ex))
     elseif k == K"method_defs"
@@ -713,8 +718,8 @@ function analyze_variables!(ctx, ex)
             # Record all lambdas for the same closure type in one place
             func_name = last(ctx.method_def_stack)
             if kind(func_name) == K"BindingId"
-                func_name_id = func_name.var_id
-                if get_binding(ctx, func_name_id).kind === :local
+                func_name_id = func_name.var_id::IdTag
+                if get_binding(ctx, func_name).kind === :local
                     push!(ctx.closure_bindings[func_name_id].lambdas, lambda_bindings)
                 end
             end

--- a/JuliaLowering/src/syntax_macros.jl
+++ b/JuliaLowering/src/syntax_macros.jl
@@ -24,9 +24,9 @@ function _apply_nospecialize(ctx, ex)
         # The @nospecialize macro is responsible for converting K"=" to K"kw".
         # Desugaring uses this helper internally, so we may see K"kw" too.
         if k == K"=" && numchildren(ex) === 2
-            ex = @ast ctx ex [K"kw" ex[1] ex[2]]
+            k = K"kw"
         end
-        mapchildren(c->_apply_nospecialize(ctx, c), ctx, ex, 1:1)
+        @ast ctx ex [k _apply_nospecialize(ctx, ex[1]) ex[2:end]...]
     else
         throw(LoweringError(ex, "Invalid function argument"))
     end

--- a/JuliaLowering/src/utils.jl
+++ b/JuliaLowering/src/utils.jl
@@ -319,7 +319,7 @@ function _print_ir(io::IO, ex, indent)
 end
 
 # Wrap a function body in Base.Compiler.@zone for profiling
-if isdefined(Base.Compiler, Symbol("@zone"))
+if isdefined(Base.Compiler, Symbol("@zone")) && DEBUG
     macro fzone(str, f)
         @assert(f isa Expr && f.head === :function && length(f.args) === 2 && str isa String,
                 "usage: @fzone name_string <function expression>")

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -879,7 +879,7 @@ end
 #
 # Note simple `op` and `.op` are calls to (dotted) identifiers, so this special
 # handling isn't necessary.
-vst1_dotted_or_op_assign(vcx, st) = let op_s = get(st, :name_val, "")
+vst1_dotted_or_op_assign(vcx, st) = let op_s = get(st, :name_val, "")::String
     @stm st begin
         [K".=" l r] -> vst1_dotassign_lhs(vcx, l) & vst1(vcx, r)
         (_, when=(!Base.isoperator(op_s))) -> unknown()

--- a/JuliaLowering/test/branching_ir.jl
+++ b/JuliaLowering/test/branching_ir.jl
@@ -241,8 +241,8 @@ LoweringError:
 Expression:
   label:foo
 Containing expressions:
-  (lambda (block) (block) (block (call core.declare_global Main.TestMod :x true) latestworld core.nothing (= #₂/tmp label:foo) (= #₃/binding_type (call core.get_binding_type Main.TestMod :x)) (= #₁/x (block (= #₅/type_tmp #₃/binding_type) (= #₄/tmp #₂/tmp) (if (call core.isa #₄/tmp #₅/type_tmp) core.nothing (= #₄/tmp (call top.convert #₅/type_tmp #₄/tmp))) #₄/tmp)) #₂/tmp))
-  (block (block (block (call core.declare_global Main.TestMod :x true) latestworld core.nothing) (= #₂/tmp label:foo) (= #₃/binding_type (call core.get_binding_type Main.TestMod :x)) (= #₁/x (block (= #₅/type_tmp #₃/binding_type) (= #₄/tmp #₂/tmp) (if (call core.isa #₄/tmp #₅/type_tmp) core.nothing (= #₄/tmp (call top.convert #₅/type_tmp #₄/tmp))) #₄/tmp)) #₂/tmp))
+  (lambda (block) (block) (block (call core.declare_global Main.TestMod :x true) latestworld core.nothing (= #₂ label:foo) (= #₃ (call core.get_binding_type Main.TestMod :x)) (= #₁/x (block (= #₅ #₃) (= #₄/tmp #₂) (if (call core.isa #₄/tmp #₅) core.nothing (= #₄/tmp (call top.convert #₅ #₄/tmp))) #₄/tmp)) #₂))
+  (block (block (block (call core.declare_global Main.TestMod :x true) latestworld core.nothing) (= #₂ label:foo) (= #₃ (call core.get_binding_type Main.TestMod :x)) (= #₁/x (block (= #₅ #₃) (= #₄/tmp #₂) (if (call core.isa #₄/tmp #₅) core.nothing (= #₄/tmp (call top.convert #₅ #₄/tmp))) #₄/tmp)) #₂))
   (lambda (block) (block) (block (= #₁/x label:foo)))
   (lambda (block) (block) (= x label:foo))
 

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -422,19 +422,29 @@ end
 
 @testset "jl_assert" begin
     st = @ast_ [K"function" "foo"::K"Identifier"]
-    err = try
-        JuliaLowering.@jl_assert(1 == 2, (st, "error message 1"), (st, "error message 2"))
-        nothing
-    catch err
-        err
+    if JL.DEBUG
+        err = try
+            JuliaLowering.@jl_assert(1 == 2, (st, "error message 1"), (st, "error message 2"))
+            nothing
+        catch err
+            err
+        end
+        @test err isa LoweringError
+        @test err.internal === true
+        @test length(err.sts) == 2
+        @test length(err.msgs) == 2
+        shown = sprint(show, err)
+        @test contains(shown, "error message 1")
+        @test contains(shown, "error message 2")
+    else
+        @test nothing !== try
+            JuliaLowering.@jl_assert false st
+        catch err
+            err
+        else
+            nothing
+        end
     end
-    @test err isa LoweringError
-    @test err.internal === true
-    @test length(err.sts) == 2
-    @test length(err.msgs) == 2
-    shown = sprint(show, err)
-    @test contains(shown, "error message 1")
-    @test contains(shown, "error message 2")
 end
 
 end

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -133,6 +133,8 @@ function child(graph::SyntaxGraph, id::NodeId, i::Integer)
     graph.edges[graph.edge_ranges[id][i]]
 end
 
+# XXX: the @noinline (and the one on setattr!) work around an issue where
+# codegen produces a trampoline for `getindex`
 @noinline function getattr(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}, name::Symbol)
     getfield(graph, :attributes)[name]
 end

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -17,19 +17,6 @@ SyntaxGraph() = ensure_required_attributes!(
         Vector{UnitRange{Int}}(),
         Vector{NodeId}(), Dict{Symbol,Dict{NodeId, Any}}()))
 
-# "Freeze" attribute names and types, encoding them in the type of the returned
-# SyntaxGraph.
-function freeze_attrs(graph::SyntaxGraph)
-    frozen_attrs = (; pairs(graph.attributes)...)
-    SyntaxGraph(graph.edge_ranges, graph.edges, frozen_attrs)
-end
-
-# Create a copy of `graph` where the attribute list is mutable
-function unfreeze_attrs(graph::SyntaxGraph)
-    unfrozen_attrs = Dict{Symbol,Any}(pairs(graph.attributes)...)
-    SyntaxGraph(graph.edge_ranges, graph.edges, unfrozen_attrs)
-end
-
 function _show_attrs(io, attributes::Dict)
     show(io, MIME("text/plain"), attributes)
 end
@@ -70,7 +57,7 @@ end
 
 function ensure_attributes!(graph::SyntaxGraph{<:NamedTuple}; kws...)
     throw(ErrorException("""
-        ensure_attributes!: $k is not an existing attribute, and the graph's attributes are frozen. \
+        ensure_attributes!: The graph's attributes are frozen. \
         Consider calling non-mutating `ensure_attributes` instead."""))
 end
 
@@ -109,7 +96,7 @@ end
 function delete_attributes(graph::SyntaxGraph{<:NamedTuple}, attr_names::Symbol...)
     unfrozen_attrs = Dict{Symbol,Any}(pairs(graph.attributes)...)
     for name in attr_names
-        delete!(graph.attributes, name)
+        delete!(unfrozen_attrs, name)
     end
     SyntaxGraph(graph.edge_ranges, graph.edges, (; pairs(unfrozen_attrs)...))
 end
@@ -858,7 +845,7 @@ function prune(graph1_a::SyntaxGraph, entrypoints_a::Vector{NodeId})
             push!(nodes1, c1)
         end
     end
-    graph2.edges = 1:length(nodes1) # our reward for unaliasing
+    append!(graph2.edges, 1:length(nodes1)) # our reward for unaliasing
 
     for attr in attrnames(graph1)
         attr === :source && continue
@@ -905,7 +892,7 @@ end
 Give each descendent of `st` a `parent::NodeId` attribute.
 """
 function annotate_parent!(st::SyntaxTree)
-    g = unfreeze_attrs(syntax_graph(st))
+    g = syntax_graph(st)
     st = unalias_nodes(SyntaxTree(g, st._id))
     ensure_attributes!(g; parent=NodeId)
     mapchildren(t->_annotate_parent!(t, st._id), syntax_graph(st), st)

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -7,15 +7,15 @@ one or several syntax trees.
 TODO: Global attributes!
 """
 mutable struct SyntaxGraph{Attrs}
-    edge_ranges::Vector{UnitRange{Int}}
-    edges::Vector{NodeId}
-    attributes::Attrs
+    const edge_ranges::Vector{UnitRange{Int}}
+    const edges::Vector{NodeId}
+    const attributes::Attrs
 end
 
 SyntaxGraph() = ensure_required_attributes!(
-    SyntaxGraph{Dict{Symbol,Any}}(
+    SyntaxGraph{Dict{Symbol,Dict{NodeId, Any}}}(
         Vector{UnitRange{Int}}(),
-        Vector{NodeId}(), Dict{Symbol,Any}()))
+        Vector{NodeId}(), Dict{Symbol,Dict{NodeId, Any}}()))
 
 # "Freeze" attribute names and types, encoding them in the type of the returned
 # SyntaxGraph.
@@ -53,33 +53,37 @@ function Base.show(io::IO, ::MIME"text/plain", graph::SyntaxGraph)
     _show_attrs(io, graph.attributes)
 end
 
-function ensure_attributes!(graph::SyntaxGraph; kws...)
-    for (k,v) in pairs(kws)
+function ensure_attributes!(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}; kws...)
+    for (k,_) in pairs(kws)
         @assert k isa Symbol
-        @assert v isa Type
-        if haskey(graph.attributes, k)
-            v0 = valtype(graph.attributes[k])
-            v == v0 || throw(ErrorException("Attribute type mismatch $v != $v0"))
-        elseif graph.attributes isa NamedTuple
-            throw(ErrorException("""
-                ensure_attributes!: $k is not an existing attribute, and the graph's attributes are frozen. \
-                Consider calling non-mutating `ensure_attributes` instead."""))
-        else
-            graph.attributes[k] = Dict{NodeId,v}()
+        if !haskey(graph.attributes, k)
+            graph.attributes[k] = Dict{NodeId,Any}()
         end
     end
     graph
 end
 
-function ensure_attributes(graph::SyntaxGraph{<:Dict}; kws...)
+function ensure_attributes(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}; kws...)
     g = copy_attrs(graph)
     ensure_attributes!(g; kws...)
 end
 
+function ensure_attributes!(graph::SyntaxGraph{<:NamedTuple}; kws...)
+    throw(ErrorException("""
+        ensure_attributes!: $k is not an existing attribute, and the graph's attributes are frozen. \
+        Consider calling non-mutating `ensure_attributes` instead."""))
+end
+
 function ensure_attributes(graph::SyntaxGraph{<:NamedTuple}; kws...)
-    g = unfreeze_attrs(graph)
-    ensure_attributes!(g; kws...)
-    freeze_attrs(g)
+    unfrozen_attrs = Dict{Symbol,Any}(pairs(graph.attributes)...)
+    for (k,v) in pairs(kws)
+        @assert k isa Symbol
+        @assert v isa Type
+        if !haskey(graph.attributes, k)
+            unfrozen_attrs[k] = Dict{NodeId,v}()
+        end
+    end
+    SyntaxGraph(graph.edge_ranges, graph.edges, (; pairs(unfrozen_attrs)...))
 end
 
 ensure_required_attributes!(g::SyntaxGraph) = ensure_attributes!(
@@ -91,20 +95,23 @@ ensure_required_attributes!(g::SyntaxGraph) = ensure_attributes!(
     name_val=String,
     mod=Module)
 
-function delete_attributes!(graph::SyntaxGraph{<:Dict}, attr_names::Symbol...)
+function delete_attributes!(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}, attr_names::Symbol...)
     for name in attr_names
         delete!(graph.attributes, name)
     end
     graph
 end
 
-function delete_attributes(graph::SyntaxGraph{<:Dict}, attr_names::Symbol...)
-    delete_attributes!(unfreeze_attrs(graph), attr_names...)
+function delete_attributes(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}, attr_names::Symbol...)
+    delete_attributes!(copy_attrs(graph), attr_names...)
 end
 
 function delete_attributes(graph::SyntaxGraph{<:NamedTuple}, attr_names::Symbol...)
-    g = delete_attributes!(unfreeze_attrs(graph), attr_names...)
-    freeze_attrs(g)
+    unfrozen_attrs = Dict{Symbol,Any}(pairs(graph.attributes)...)
+    for name in attr_names
+        delete!(graph.attributes, name)
+    end
+    SyntaxGraph(graph.edge_ranges, graph.edges, (; pairs(unfrozen_attrs)...))
 end
 
 function new_id!(graph::SyntaxGraph)
@@ -139,7 +146,7 @@ function child(graph::SyntaxGraph, id::NodeId, i::Integer)
     graph.edges[graph.edge_ranges[id][i]]
 end
 
-function getattr(graph::SyntaxGraph{<:Dict}, name::Symbol)
+@noinline function getattr(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}, name::Symbol)
     getfield(graph, :attributes)[name]
 end
 
@@ -147,16 +154,16 @@ function getattr(graph::SyntaxGraph{<:NamedTuple}, name::Symbol)
     getfield(getfield(graph, :attributes), name)
 end
 
-function getattr(graph::SyntaxGraph, name::Symbol, default)
-    get(getfield(graph, :attributes), name, default)
+function hasattr(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}, name::Symbol)
+    haskey(getfield(graph, :attributes), name)
 end
 
-function hasattr(graph::SyntaxGraph, name::Symbol)
-    getattr(graph, name, nothing) !== nothing
+function hasattr(graph::SyntaxGraph{<:NamedTuple}, name::Symbol)
+    haskey(getfield(graph, :attributes), name)
 end
 
 # TODO: Probably terribly non-inferable?
-function setattr!(graph::SyntaxGraph, id::NodeId, k::Symbol, @nospecialize(v))
+@noinline function setattr!(graph::SyntaxGraph, id::NodeId, k::Symbol, @nospecialize(v))
     if !isnothing(v)
         getattr(graph, k)[id] = v
     end
@@ -231,10 +238,10 @@ end
 function Base.getproperty(ex::SyntaxTree, name::Symbol)
     name === :_graph && return getfield(ex, :_graph)
     name === :_id  && return getfield(ex, :_id)
-    _id = getfield(ex, :_id)
-    return get(getproperty(getfield(ex, :_graph), name), _id) do
-        error("Property `$name` not defined on node: $(node_string(ex))")
-    end
+    graph = getfield(ex, :_graph)
+    val = get(getattr(graph, name), getfield(ex, :_id), nothing)
+    isnothing(val) && error("Property `$name` not defined on node: $(node_string(ex))")
+    return val
 end
 
 function Base.setproperty!(ex::SyntaxTree, name::Symbol, @nospecialize(val))
@@ -247,9 +254,9 @@ function Base.propertynames(ex::SyntaxTree)
 end
 
 function Base.get(ex::SyntaxTree, name::Symbol, default)
-    attr = getattr(getfield(ex, :_graph), name, nothing)
-    return isnothing(attr) ? default :
-           get(attr, getfield(ex, :_id), default)
+    graph = getfield(ex, :_graph)
+    !hasattr(graph, name) && return default
+    get(getattr(graph, name), getfield(ex, :_id), default)
 end
 
 function Base.getindex(ex::SyntaxTree, i::Integer)
@@ -279,7 +286,9 @@ function Base.:≈(ex1::SyntaxTree, ex2::SyntaxTree)
 end
 
 function hasattr(ex::SyntaxTree, name::Symbol)
-    attr = getattr(ex._graph, name, nothing)
+    graph = ex._graph
+    !hasattr(graph, name) && return false
+    attr = getattr(graph, name)
     return !isnothing(attr) && haskey(attr, ex._id)
 end
 
@@ -402,7 +411,7 @@ function _sourceref(sources, id)
 end
 
 function sourceref(ex::SyntaxTree)
-    sources = ex._graph.source::Dict{NodeId,SourceAttrType}
+    sources = ex._graph.source::Dict{Int, Any}
     id = ex._id
     while true
         s, _ = _sourceref(sources, id)
@@ -432,7 +441,7 @@ end
 function flattened_provenance(ex::SyntaxTree)
     refs = SyntaxList(ex._graph)
     _flattened_provenance(refs, ex._graph, ex._graph.source, ex._id)
-    return reverse(refs)
+    return reverse!(refs)
 end
 
 
@@ -484,7 +493,7 @@ end
 
 #-------------------------------------------------------------------------------
 # Lightweight vector of nodes ids with associated pointer to graph stored separately.
-mutable struct SyntaxList{Attrs, NodeIdVecType} <: AbstractVector{SyntaxTree}
+struct SyntaxList{Attrs, NodeIdVecType} <: AbstractVector{SyntaxTree}
     graph::SyntaxGraph{Attrs}
     ids::NodeIdVecType
 end
@@ -673,10 +682,7 @@ function copy_attrs!(dest, src, all=false)
     for (name, attr) in pairs(src._graph.attributes)
         if (all || (name !== :source && name !== :kind && name !== :syntax_flags)) &&
                 haskey(attr, src._id)
-            dest_attr = getattr(dest._graph, name, nothing)
-            if !isnothing(dest_attr)
-                dest_attr[dest._id] = attr[src._id]
-            end
+            setattr!(dest, name, attr[src._id])
         end
     end
 end
@@ -688,14 +694,14 @@ function copy_attrs!(dest, head::Union{Kind,SyntaxHead}, all=false)
     end
 end
 
-function mapchildren(f::Function, ctx, ex::SyntaxTree, do_map_child::Function)
+function mapchildren(f::Function, ctx, ex::SyntaxTree)
     if is_leaf(ex)
         return ex
     end
     orig_children = children(ex)
     cs = nothing
     for (i,e) in enumerate(orig_children)
-        newchild = do_map_child(i) ? f(e) : e
+        newchild = f(e)
         if isnothing(cs)
             if newchild == e
                 continue
@@ -715,26 +721,6 @@ function mapchildren(f::Function, ctx, ex::SyntaxTree, do_map_child::Function)
     ex2 = mknode(ex, cs)
     return ex2
 end
-
-function mapchildren(f::Function, ctx, ex::SyntaxTree,
-                     mapped_children::AbstractVector{<:Integer})
-    j = Ref(firstindex(mapped_children))
-    function do_map_child(i)
-        ind = j[]
-        if ind <= lastindex(mapped_children) && mapped_children[ind] == i
-            j[] += 1
-            true
-        else
-            false
-        end
-    end
-    mapchildren(f, ctx, ex, do_map_child)
-end
-
-function mapchildren(f::Function, ctx, ex::SyntaxTree)
-    mapchildren(f, ctx, ex, _->true)
-end
-
 
 """
 Recursively copy AST `ex` into `ctx`.
@@ -1243,7 +1229,7 @@ function _insert_green(graph::SyntaxGraph, sf::Base.RefValue{SourceFile},
         for c in reverse(cursor)
             push!(cs, _insert_green(graph, sf, txtbuf, offset, c))
         end
-        setchildren!(graph, id, reverse(cs))
+        setchildren!(graph, id, reverse!(cs))
     else
         v = parse_julia_literal(txtbuf, head(cursor), byte_range(cursor) .+ offset)
         if v isa Symbol

--- a/JuliaSyntax/test/syntax_graph.jl
+++ b/JuliaSyntax/test/syntax_graph.jl
@@ -1,52 +1,55 @@
-using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, freeze_attrs, unfreeze_attrs, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind, syntax_graph
+using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind, syntax_graph
 
 @testset "SyntaxGraph attrs" begin
-    st = parsestmt(SyntaxTree, "function foo end")
-    g_init = unfreeze_attrs(st._graph)
-    gf1 = freeze_attrs(g_init)
-    gu1 = unfreeze_attrs(gf1)
+    g_dict = SyntaxGraph()
+    g_nt = ensure_attributes(
+        SyntaxGraph(Vector{UnitRange{Int}}(), Vector{NodeId}(), (;)),
+        kind=Kind,
+        source=SourceAttrType,
+        syntax_flags=UInt16,
+        value=Any,
+        name_val=String,
+        mod=Module)
 
     # Check that a default graph has required attrs
-    g_empty = SyntaxGraph()
-    @test (:kind=>Kind) in attrdefs(g_empty)
-    @test (:source=>SourceAttrType) in attrdefs(g_empty)
-    @test (:value=>Any) in attrdefs(g_empty)
-    @test (:name_val=>String) in attrdefs(g_empty)
-
-    # Check that freeze/unfreeze do their jobs
-    @test gf1.attributes isa NamedTuple
-    @test gu1.attributes isa Dict
-    @test Set(keys(gf1.attributes)) == Set(keys(gu1.attributes))
+    @test (:kind=>Any) in attrdefs(g_dict)
+    @test (:source=>Any) in attrdefs(g_dict)
+    @test (:value=>Any) in attrdefs(g_dict)
+    @test (:name_val=>Any) in attrdefs(g_dict)
+    @test (:kind=>Kind) in attrdefs(g_nt)
+    @test (:source=>SourceAttrType) in attrdefs(g_nt)
+    @test (:value=>Any) in attrdefs(g_nt)
+    @test (:name_val=>String) in attrdefs(g_nt)
 
     # ensure_attributes
-    gf2 = ensure_attributes(gf1, test_attr=Symbol, foo=Type)
-    gu2 = ensure_attributes(gu1, test_attr=Symbol, foo=Type)
+    g_nt2 = ensure_attributes(g_nt, test_attr=Symbol, foo=Type)
+    g_dict2 = ensure_attributes(g_dict, test_attr=Symbol, foo=Type)
     # returns a graph with the same attribute storage
-    @test gf2.attributes isa NamedTuple
-    @test gu2.attributes isa Dict
+    @test g_nt2.attributes isa NamedTuple
+    @test g_dict2.attributes isa Dict
     # does its job
-    @test (:test_attr=>Symbol) in attrdefs(gf2)
-    @test (:foo=>Type) in attrdefs(gf2)
-    @test Set(keys(gf2.attributes)) == Set(keys(gu2.attributes))
+    @test (:test_attr=>Symbol) in attrdefs(g_nt2)
+    @test (:foo=>Type) in attrdefs(g_nt2)
+    @test Set(keys(g_nt2.attributes)) == Set(keys(g_dict2.attributes))
     # no mutation
-    @test !((:test_attr=>Symbol) in attrdefs(gf1))
-    @test !((:foo=>Type) in attrdefs(gf1))
-    @test Set(keys(gf1.attributes)) == Set(keys(gu1.attributes))
+    @test !((:test_attr=>Symbol) in attrdefs(g_nt))
+    @test !((:foo=>Type) in attrdefs(g_nt))
+    @test Set(keys(g_nt.attributes)) == Set(keys(g_dict.attributes))
 
     # delete_attributes
-    gf3 = delete_attributes(gf2, :test_attr, :foo)
-    gu3 = delete_attributes(gu2, :test_attr, :foo)
+    g_nt3 = delete_attributes(g_nt2, :test_attr, :foo)
+    g_dict3 = delete_attributes(g_dict2, :test_attr, :foo)
     # returns a graph with the same attribute storage
-    @test gf3.attributes isa NamedTuple
-    @test gu3.attributes isa Dict
+    @test g_nt3.attributes isa NamedTuple
+    @test g_dict3.attributes isa Dict
     # does its job
-    @test !((:test_attr=>Symbol) in attrdefs(gf3))
-    @test !((:foo=>Type) in attrdefs(gf3))
-    @test Set(keys(gf3.attributes)) == Set(keys(gu3.attributes))
+    @test !((:test_attr=>Symbol) in attrdefs(g_nt3))
+    @test !((:foo=>Type) in attrdefs(g_nt3))
+    @test Set(keys(g_nt3.attributes)) == Set(keys(g_dict3.attributes))
     # no mutation
-    @test (:test_attr=>Symbol) in attrdefs(gf2)
-    @test (:foo=>Type) in attrdefs(gf2)
-    @test Set(keys(gf2.attributes)) == Set(keys(gu2.attributes))
+    @test (:test_attr=>Symbol) in attrdefs(g_nt2)
+    @test (:foo=>Type) in attrdefs(g_nt2)
+    @test Set(keys(g_nt2.attributes)) == Set(keys(g_dict2.attributes))
 end
 
 @testset "SyntaxTree parsing" begin
@@ -60,15 +63,16 @@ end
 @testset "SyntaxTree utils" begin
     "For filling required attrs in graphs created by hand"
     function testgraph(edge_ranges, edges, more_attrs...)
-        kinds = Dict(map(i->(i=>K"block"), eachindex(edge_ranges)))
-        sources = Dict{Int, SourceAttrType}(
+        kinds = Dict{NodeId, Any}(map(i->(i=>K"block"), eachindex(edge_ranges)))
+        sources = Dict{NodeId, Any}(
             map(i->(i=>LineNumberNode(i)), eachindex(edge_ranges)))
-        orig = Dict(map(i->(i=>i), eachindex(edge_ranges)))
+        orig = Dict{NodeId, Any}(map(i->(i=>i), eachindex(edge_ranges)))
         SyntaxGraph(
             edge_ranges,
             edges,
-            Dict(:kind => kinds, :source => sources,
-                 :orig => orig, more_attrs...))
+            Dict{Symbol, Dict{NodeId, Any}}(
+                :kind => kinds, :source => sources,
+                :orig => orig, more_attrs...))
     end
 
     @testset "copy_ast" begin
@@ -279,10 +283,6 @@ end
         #    |      |
         #    +-> 3 -+
         g = testgraph([1:2, 3:3, 4:4, 5:5, 0:-1], [2, 3, 4, 4, 5])
-        st = JuliaSyntax.annotate_parent!(SyntaxTree(g, 1))
-        @test chk_parent(st, nothing)
-        # NamedTuple-based attrs
-        g = JuliaSyntax.freeze_attrs(testgraph([1:2, 3:3, 4:4, 5:5, 0:-1], [2, 3, 4, 4, 5]))
         st = JuliaSyntax.annotate_parent!(SyntaxTree(g, 1))
         @test chk_parent(st, nothing)
     end


### PR DESCRIPTION
Easy performance improvements from a bit of profiling, and some other random cleanup.  

## Main changes
- Make attribute storage `Dict{Symbol, Dict{NodeId, Any}}` instead of
  `Dict{Symbol, Any}` so that tree.attr doesn't hit `getproperty(::Any,
  ::Symbol)`.  The actual type of `tree.attr` is less well-known in some cases,
  but it's not that common for JL to dispatch on that type (in most cases we're
  checking it's `===` to something).
  - I've added a few type assertions where we do dispatch on `tree.attr`.
  - Removed `freeze`/`unfreeze_attrs`, since since Dict-attributes no longer
    remember the attr type, so freezing that is no longer useful.  Using a
    NamedTuple as attribute storage is still supported and tested.
- Made `SyntaxList` immutable again.  I made this mutable a while ago along with
  `SyntaxGraph` for compilation-time reasons, but the more pressing issue now is
  too many allocations, and the effect on compilation time isn't huge (graph is
  still mutable).

## Measurements
I've mostly been using a modified version of a script from @aviatesk (#60756):
<details>
<summary>jlbench.jl</summary>

```
# Benchmark script for JuliaLowering steps
#
# Usage:
#   julia --project=. experiments/jlbench.jl <file.jl> [module_name] [-n nruns] [--eval|--no-eval]
#
# Examples:
#   julia --project=. experiments/jlbench.jl src/foo.jl
#   julia --project=. experiments/jlbench.jl src/foo.jl Base
#   julia --project=. experiments/jlbench.jl src/foo.jl JETLS
#   julia --project=. experiments/jlbench.jl src/foo.jl Main -n 20
#   julia --project=. experiments/jlbench.jl src/foo.jl --no-eval

# using JETLS
using JuliaSyntax: JuliaSyntax as JS
using JuliaLowering: JuliaLowering as JL

function lookup_parent_module(name::AbstractString)
    sym = Symbol(name)
    for mod in Base.loaded_modules_array()
        if nameof(mod) === sym
            return mod
        end
    end
    error("Module not found: $name. Available modules: $(join(nameof.(Base.loaded_modules_array()), ", "))")
end

function run_benchmark(filepath::String; parent_mod::Module=Main, nruns::Int=10, eval::Bool=true)
    if !isfile(filepath)
        error("File not found: $filepath")
    end

    module_map = Dict{UnitRange{Int},Module}(1:typemax(Int)=>parent_mod)
    function get_module_context(st)
        thisrange = JS.byte_range(st)
        thisinfo = nothing
        for (rng, mod) in module_map
            if thisrange ⊆ rng
                if isnothing(thisinfo)
                    thisinfo = (rng, mod)
                else
                    thisstart, thisend = rng
                    oldstart, oldend = thisinfo[1]
                    if oldstart < thisstart && thisend < oldend
                        thisinfo = (rng, mod)
                    end
                end
            end
        end
        return last(@something thisinfo return parent_mod)
    end

    function iterate_toplevel_tree(callback, st0_top::JS.SyntaxTree; define_module::Bool=false)
        sl = JS.SyntaxList(st0_top)
        push!(sl, st0_top)
        while !isempty(sl)
            st0 = pop!(sl)
            if JS.kind(st0) === JS.K"toplevel"
                for i = JS.numchildren(st0):-1:1 # reversed since we use `pop!`
                    push!(sl, st0[i])
                end
            elseif JS.kind(st0) === JS.K"module"
                if define_module
                    thismod = get_module_context(st0)
                    modname = try st0[1].name_val catch; "DummyName" end
                    mod = Core.eval(thismod, :(module $(Symbol()) end))
                    module_map[JS.byte_range(st0)] = mod
                end
                stblk = st0[end]
                JS.kind(stblk) === JS.K"block" || continue
                for i = JS.numchildren(stblk):-1:1 # reversed since we use `pop!`
                    push!(sl, stblk[i])
                end
            elseif JS.kind(st0) === JS.K"doc"
                # skip docstring expressions for now
                for i = JS.numchildren(st0):-1:1 # reversed since we use `pop!`
                    if JS.kind(st0[i]) !== JS.K"string"
                        push!(sl, st0[i])
                    end
                end
            else # st0 is lowerable tree
                callback(st0)
            end
        end
    end

    src = read(filepath, String)
    st0_top = JS.parseall(JS.SyntaxTree, src; filename=filepath)

    # Count top-level expressions and evaluate using/import statements
    n = 0
    iterate_toplevel_tree(st0_top; define_module=true) do st0
        n += 1
        k = JS.kind(st0)
        if k in JS.KSet"using import export function macro struct abstract primitive"
            if eval
                thismod = get_module_context(st0)
                try
                    JL.eval(thismod, st0)
                catch err
                    @warn "Failed to evaluate $(JS.sourcetext(st0))" err
                end
            end
        end
    end

    println("File: $filepath")
    println("Module: $(nameof(parent_mod))")
    println("Number of top-level expressions: $n")
    println("Number of runs: $nruns")
    println()

    # Timing accumulators (sum over all runs)
    t_expand1 = t_expand2 = t_scopes = t_closures = t_linearize = t_expr = t_flisp = Inf

    for run = 1:nruns
        print(string("$run..."))
        world = Base.get_world_counter()

        l_expand1 = l_expand2 = l_scopes = l_closures = l_linearize = l_expr =
            l_flisp_macros = l_flisp_lower = l_flisp = 0.0

        iterate_toplevel_tree(st0_top) do st0
            thismod = get_module_context(st0)
            l_expand1 += @elapsed begin
                ctx1, st1 = @invokelatest JL.expand_forms_1(thismod, st0, true, world)
            end

            l_expand2 += @elapsed begin
                ctx2, st2 = JL.expand_forms_2(ctx1, st1)
            end

            l_scopes += @elapsed begin
                ctx3, st3 = JL.resolve_scopes(ctx2, st2)
            end

            l_closures += @elapsed begin
                ctx4, st4 = JL.convert_closures(ctx3, st3)
            end

            l_linearize += @elapsed begin
                ctx5, st5 = JL.linearize_ir(ctx4, st4)
            end

            l_expr += @elapsed begin
                ex6 = JL.to_lowered_expr(st5)
            end

            let expr = JL.est_to_expr(st0)
                l_flisp += @elapsed begin
                    _ = Meta.lower(thismod, expr)
                end
            end
        end

        t_expand2 = min(t_expand2, l_expand2)
        t_scopes = min(t_scopes, l_scopes)
        t_closures = min(t_closures, l_closures)
        t_linearize = min(t_linearize, l_linearize)
        t_expr = min(t_expr, l_expr)
        t_flisp = min(t_flisp, l_flisp)
        t_expand1  = min(t_expand1, l_expand1)
    end

    println()
    println("Best times (over $nruns runs):")
    println("  expand_forms_1:              $(round(t_expand1 * 1000, digits=3)) ms")
    println("  expand_forms_2:              $(round(t_expand2 * 1000, digits=3)) ms")
    println("  resolve_scopes:              $(round(t_scopes * 1000, digits=3)) ms")
    println("  convert_closures:            $(round(t_closures * 1000, digits=3)) ms")
    println("  linearize_ir:                $(round(t_linearize * 1000, digits=3)) ms")
    println("  to_lowered_expr:             $(round(t_expr * 1000, digits=3)) ms")
    println()

    total = t_expand1 + t_expand2 + t_scopes + t_closures + t_linearize + t_expr
    println("  Total:                       $(round(total * 1000, digits=3)) ms")
    println("  Total(flisp):                $(round(t_flisp * 1000, digits=3)) ms")
    println()

    println("Percentage breakdown:")
    println("  expand_forms_1:              $(round(t_expand1 / total * 100, digits=1))%")
    println("  expand_forms_2:              $(round(t_expand2 / total * 100, digits=1))%")
    println("  resolve_scopes:              $(round(t_scopes / total * 100, digits=1))%")
    println("  convert_closures:            $(round(t_closures / total * 100, digits=1))%")
    println("  linearize_ir:                $(round(t_linearize / total * 100, digits=1))%")
    println("  to_lowered_expr:             $(round(t_expr / total * 100, digits=1))%")

    return (; t_expand1, t_expand2, t_scopes, t_linearize, t_expr, total)
end

function (@main)(args::Vector{String})
    positional = String[]
    i = 1
    nruns = 10
    do_eval = true
    while i <= length(args)
        arg = args[i]
        if arg == "-n"
            i += 1
            if i > length(args)
                println("Error: -n requires a value")
                exit(1)
            end
            nruns = parse(Int, args[i])
        elseif arg == "--eval"
            do_eval = true
        elseif arg == "--no-eval"
            do_eval = false
        else
            push!(positional, arg)
        end
        i += 1
    end
    if isempty(positional)
        println("Usage: julia --project=. experiments/jlbench.jl <file.jl> [module_name] [-n nruns] [--eval|--no-eval]")
        return Cint(1)
    end
    filepath = positional[1]
    parent_mod = length(positional) >= 2 ? lookup_parent_module(positional[2]) : Main
    run_benchmark(filepath; parent_mod, nruns, eval=do_eval)
    return Cint(0)
end
```
</details>

This script takes the minimum time over `n` runs to lower a whole file where all
measurements are grouped by lowering pass.  Note this gives an unfair advantage
to JuliaLowering in the comparisons below, since JL triggers more GC activity,
so the flisp comparison isn't to be taken too seriously yet (it's easier to measure
non-GC time and track allocations separately).

Before:

```
julia> include("./jlbench.jl")
julia> using Test
julia> @allocated main(["./test/char.jl"])
File: ./test/char.jl
Module: Main
Number of top-level expressions: 40
Number of runs: 10

1...2...3...4...5...6...7...8...9...10...
Best times (over 10 runs):
  expand_forms_1:              135.157 ms
  expand_forms_2:              99.624 ms
  resolve_scopes:              64.056 ms
  convert_closures:            28.814 ms
  linearize_ir:                92.875 ms
  to_lowered_expr:             38.908 ms

  Total:                       459.434 ms
  Total(flisp):                233.46 ms

Percentage breakdown:
  expand_forms_1:              29.4%
  expand_forms_2:              21.7%
  resolve_scopes:              13.9%
  convert_closures:            6.3%
  linearize_ir:                20.2%
  to_lowered_expr:             8.5%
4414729808

julia> @allocated main(["./test/atomics.jl"])
File: ./test/atomics.jl
Module: Main
Number of top-level expressions: 392
Number of runs: 10

1...2...3...4...5...6...7...8...9...10...
Average times (over 10 runs):
  expand_forms_1:              324.081 ms
  expand_forms_2:              263.015 ms
  resolve_scopes:              141.973 ms
  convert_closures:            53.474 ms
  linearize_ir:                234.445 ms
  to_lowered_expr:             82.89 ms

  Total:                       1099.877 ms
  Total(flisp):                372.631 ms

Percentage breakdown:
  expand_forms_1:              29.5%
  expand_forms_2:              23.9%
  resolve_scopes:              12.9%
  convert_closures:            4.9%
  linearize_ir:                21.3%
  to_lowered_expr:             7.5%
9332183872
```

After:

```
julia> include("./jlbench.jl")
julia> using Test
julia> @allocated main(["./test/char.jl"])
File: ./test/char.jl
Module: Main
Number of top-level expressions: 40
Number of runs: 10

1...2...3...4...5...6...7...8...9...10...
Best times (over 10 runs):
  expand_forms_1:              39.76 ms
  expand_forms_2:              27.848 ms
  resolve_scopes:              21.751 ms
  convert_closures:            34.665 ms
  linearize_ir:                33.473 ms
  to_lowered_expr:             48.348 ms

  Total:                       205.847 ms
  Total(flisp):                234.86 ms

Percentage breakdown:
  expand_forms_1:              19.3%
  expand_forms_2:              13.5%
  resolve_scopes:              10.6%
  convert_closures:            16.8%
  linearize_ir:                16.3%
  to_lowered_expr:             23.5%
2008991456

julia> @allocated main(["./test/atomics.jl"])
File: ./test/atomics.jl
Module: Main
Number of top-level expressions: 392
Number of runs: 10

1...2...3...4...5...6...7...8...9...10...
Best times (over 10 runs):
  expand_forms_1:              113.819 ms
  expand_forms_2:              88.26 ms
  resolve_scopes:              54.662 ms
  convert_closures:            19.209 ms
  linearize_ir:                84.478 ms
  to_lowered_expr:             83.179 ms

  Total:                       443.606 ms
  Total(flisp):                375.154 ms

Percentage breakdown:
  expand_forms_1:              25.7%
  expand_forms_2:              19.9%
  resolve_scopes:              12.3%
  convert_closures:            4.3%
  linearize_ir:                19.0%
  to_lowered_expr:             18.8%
3792470768
```

Note both are with `JL.DEBUG=true`, which takes about 20% more time than `DEBUG=false` in my measurements.

## TODO
There are still performance issues that will require more involved changes.
- `append_sourceref` (some details in #60765) performs poorly.  In the
  measurements above, I think this is the main reason for the slowness in macro
  expansion.
- SyntaxTree still isn't particularly type-stable, and I'm not sure the
  NamedTuple approach is doable without the overspecialization issues we had
  before.
- There are a crazy (and nondeterministic) number of `tojlinvoke` calls compiled
  into JuliaLowering.  My best guess right now is that the recursiveness of
  lowering is confusing inference, but I need to investigate further.

