### PR TITLE
Fix duplicate edge keys in heap snapshot for inlined array elements

### DIFF
--- a/src/gc-heap-snapshot.c
+++ b/src/gc-heap-snapshot.c
@@ -572,6 +572,57 @@ void _gc_heap_snapshot_record_array_edge(jl_value_t *from, jl_value_t *to, size_
     _record_gc_edge("element", from, to, index);
 }
 
+void _gc_heap_snapshot_record_array_edge_with_field(jl_value_t *from, jl_value_t *to, void *slot, void *elem_begin) JL_NOTSAFEPOINT
+{
+    jl_datatype_t *memtype = (jl_datatype_t*)jl_typeof(from);
+    jl_value_t *eltype_val = jl_tparam1(memtype);
+    if (!jl_is_datatype(eltype_val)) {
+        _record_gc_edge("element", from, to, gc_slot_to_arrayidx(from, slot));
+        return;
+    }
+    jl_datatype_t *eltype = (jl_datatype_t*)eltype_val;
+
+    // Compute element index from byte offset
+    jl_genericmemory_t *mem = (jl_genericmemory_t*)from;
+    size_t elsize = memtype->layout->size;
+    size_t index = 0;
+    if (elsize > 0)
+        index = ((char*)elem_begin - (char*)mem->ptr) / elsize;
+
+    // Build "[index].fieldpath" following the pattern of _fieldpath_for_slot
+    ios_t path;
+    ios_mem(&path, 128);
+    ios_printf(&path, "[%zu].", index);
+
+    void *obj = elem_begin;
+    jl_datatype_t *objtype = eltype;
+    while (1) {
+        int i = gc_slot_to_fieldidx(obj, slot, objtype);
+        if (jl_is_tuple_type((jl_value_t*)objtype) || jl_is_namedtuple_type((jl_value_t*)objtype)) {
+            ios_printf(&path, "[%d]", i);
+        }
+        else {
+            jl_svec_t *field_names = jl_field_names(objtype);
+            jl_sym_t *name = (jl_sym_t*)jl_svecref(field_names, i);
+            ios_puts(jl_symbol_name(name), &path);
+        }
+        if (!jl_field_isptr(objtype, i)) {
+            ios_putc('.', &path);
+            obj = (void*)((char*)obj + jl_field_offset(objtype, i));
+            objtype = (jl_datatype_t*)jl_field_type_concrete(objtype, i);
+        }
+        else {
+            break;
+        }
+    }
+
+    ios_putc('\0', &path);
+    size_t name_idx = st_find_or_serialize(&g_snapshot->names, g_snapshot->strings,
+                                           (const char*)path.buf);
+    ios_close(&path);
+    _record_gc_edge("property", from, to, name_idx);
+}
+
 void _gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, void *slot) JL_NOTSAFEPOINT
 {
     ios_t path;

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -19,6 +19,7 @@ void _gc_heap_snapshot_record_frame_to_object_edge(void *from, jl_value_t *to) J
 void _gc_heap_snapshot_record_task_to_frame_edge(jl_task_t *from, void *to) JL_NOTSAFEPOINT;
 void _gc_heap_snapshot_record_frame_to_frame_edge(jl_gcframe_t *from, jl_gcframe_t *to) JL_NOTSAFEPOINT;
 void _gc_heap_snapshot_record_array_edge(jl_value_t *from, jl_value_t *to, size_t index) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_array_edge_with_field(jl_value_t *from, jl_value_t *to, void *slot, void *elem_begin) JL_NOTSAFEPOINT;
 void _gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, void* slot) JL_NOTSAFEPOINT;
 void _gc_heap_snapshot_record_module_to_binding(jl_module_t* module, jl_value_t *bindings, jl_value_t *bindingkeyset) JL_NOTSAFEPOINT;
 // Used for objects managed by GC, but which aren't exposed in the julia object, so have no
@@ -76,6 +77,12 @@ static inline void gc_heap_snapshot_record_array_edge(jl_value_t *from, jl_value
 {
     if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
         _gc_heap_snapshot_record_array_edge(from, *to, gc_slot_to_arrayidx(from, to));
+    }
+}
+static inline void gc_heap_snapshot_record_array_edge_with_field(jl_value_t *from, jl_value_t **slot, jl_value_t **elem_begin) JL_NOTSAFEPOINT
+{
+    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
+        _gc_heap_snapshot_record_array_edge_with_field(from, *slot, slot, elem_begin);
     }
 }
 static inline void gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t **to) JL_NOTSAFEPOINT

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -1902,7 +1902,7 @@ STATIC_INLINE void gc_mark_memory8(jl_ptls_t ptls, jl_value_t *ary8_parent, jl_v
                         early_end = 1;
                         break;
                     }
-                    gc_heap_snapshot_record_array_edge(ary8_parent, slot);
+                    gc_heap_snapshot_record_array_edge_with_field(ary8_parent, slot, ary8_begin);
                 }
             }
             if (early_end)
@@ -1979,7 +1979,7 @@ STATIC_INLINE void gc_mark_memory16(jl_ptls_t ptls, jl_value_t *ary16_parent, jl
                         early_end = 1;
                         break;
                     }
-                    gc_heap_snapshot_record_array_edge(ary16_parent, slot);
+                    gc_heap_snapshot_record_array_edge_with_field(ary16_parent, slot, ary16_begin);
                 }
             }
             if (early_end)


### PR DESCRIPTION
When taking a heap snapshot of a `Memory` type with inlined elements containing multiple pointer fields (like Memory{Pair{Any,Any}}`), the snapshot would record all pointer fields within the same element using the same numeric index. This produced duplicate edge keys.

This adds a new function that generates named edges like `[0].first`, `[0].second` instead of duplicate numeric indices. The approach follows the existing `_fieldpath_for_slot` pattern already used for object field edges.

Fixes #61396