### PR TITLE
docs: Update Julia version compatible with three-arg `@test_throws` macro

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -903,7 +903,7 @@ a matching function, or a value.
     The ability to specify anything other than a type or a value as `exception` requires Julia v1.8 or later.
 
 !!! compat "Julia 1.13"
-    The three-argument form `@test_throws extype pattern expr` requires Julia v1.12 or later.
+    The three-argument form `@test_throws extype pattern expr` requires Julia v1.13 or later.
 
 !!! compat "Julia 1.14"
     The `context` keyword argument requires at least Julia 1.14.


### PR DESCRIPTION
Just a small docs/typo fix following up from https://github.com/JuliaLang/julia/pull/59117#discussion_r3005886008

Thanks!