### PR TITLE
Fix `nothrow` effects for `(s/z)ext_int` / `trunc_int` intrinsics

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -2980,14 +2980,20 @@ function intrinsic_exct(𝕃::AbstractLattice, f::IntrinsicFunction, argtypes::V
             return ErrorException
         end
 
-        # fpext, fptrunc, fptoui, fptosi, uitofp, and sitofp have further
-        # restrictions on the allowed types.
+        # fpext, sext_int, zext_int, fptrunc, trunc_int, fptoui, fptosi, uitofp, and sitofp
+        # have further restrictions on the allowed types.
         if f === Intrinsics.fpext &&
             !(ty <: CORE_FLOAT_TYPES && xty <: CORE_FLOAT_TYPES && Core.sizeof(ty) > Core.sizeof(xty))
             return ErrorException
         end
+        if (f === Intrinsics.sext_int || f === Intrinsics.zext_int) && !(Core.sizeof(ty) > Core.sizeof(xty))
+            return ErrorException
+        end
         if f === Intrinsics.fptrunc &&
             !(ty <: CORE_FLOAT_TYPES && xty <: CORE_FLOAT_TYPES && Core.sizeof(ty) < Core.sizeof(xty))
+            return ErrorException
+        end
+        if f === Intrinsics.trunc_int && !(Core.sizeof(ty) < Core.sizeof(xty))
             return ErrorException
         end
         if (f === Intrinsics.fptoui || f === Intrinsics.fptosi) && !(xty <: CORE_FLOAT_TYPES)

--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -1496,3 +1496,30 @@ function null_offset(offset)
     Ptr{UInt8}(C_NULL) + offset
 end
 @test null_offset(Int(100)) == Ptr{UInt8}(UInt(100))
+
+# https://github.com/JuliaLang/julia/issues/61435
+function catch_error_61435(f, x)
+    try
+        f(x)
+    catch
+        return :caught
+    end
+end
+let f = (x) -> Core.Intrinsics.sext_int(Int16, x)
+    @test Compiler.is_nothrow(Base.infer_effects(f, (Int8,)))
+    @test !Compiler.is_nothrow(Base.infer_effects(f, (Int16,)))
+    @test !Compiler.is_nothrow(Base.infer_effects(f, (Int32,)))
+    @test catch_error_61435(f, Int16(0)) === :caught
+end
+let f = (x) -> Core.Intrinsics.zext_int(UInt16, x)
+    @test Compiler.is_nothrow(Base.infer_effects(f, (UInt8,)))
+    @test !Compiler.is_nothrow(Base.infer_effects(f, (UInt16,)))
+    @test !Compiler.is_nothrow(Base.infer_effects(f, (UInt32,)))
+    @test catch_error_61435(f, UInt16(0)) === :caught
+end
+let f = (x) -> Core.Intrinsics.trunc_int(Int16, x)
+    @test !Compiler.is_nothrow(Base.infer_effects(f, (Int8,)))
+    @test !Compiler.is_nothrow(Base.infer_effects(f, (Int16,)))
+    @test Compiler.is_nothrow(Base.infer_effects(f, (Int32,)))
+    @test catch_error_61435(f, Int16(0)) === :caught
+end


### PR DESCRIPTION
Resolves https://github.com/JuliaLang/julia/issues/61435.