### PR TITLE
codegen: Configure `--expand-fp-convert-bits 64` on targets without `__int128_t`

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -10435,6 +10435,15 @@ extern "C" void jl_init_llvm(void)
     if (clopt && clopt->getNumOccurrences() == 0)
         cl::ProvidePositionalOption(clopt, "4", 1);
 
+    // When the platform doesn't support __int128, compiler-rt/libgcc do not
+    // provide the corresponding libcalls (e.g. __floattidf, __fixdfti), so we
+    // must expand FP conversions for integer types wider than 64 bits inline.
+#ifndef _HAS_INT128_
+    clopt = llvmopts.lookup("expand-fp-convert-bits");
+    if (clopt && clopt->getNumOccurrences() == 0)
+        cl::ProvidePositionalOption(clopt, "64", 1);
+#endif
+
     clopt = llvmopts.lookup("time-passes");
     if (clopt && clopt->getNumOccurrences() > 0)
         jl_is_timing_passes = 1;

--- a/src/support/platform.h
+++ b/src/support/platform.h
@@ -136,4 +136,8 @@
 #  error pointer size not known for your platform / compiler
 #endif
 
+#if defined(__LP64__) || defined(__wasm__) || defined(__mips64) || defined(__riscv) || defined(_WIN64)
+#define _HAS_INT128_
+#endif
+
 #endif /* !PLATFORM_H */

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -613,3 +613,7 @@ end
     end
     @test _pointerset_trigger(0) == (Int[1,2,3], 42, Int[1,2,3], 42)
 end
+
+# https://github.com/JuliaLang/julia/issues/61436
+tofloat(x) = Core.Intrinsics.uitofp(Float64, x)
+@test tofloat(UInt128(0)) == 0.0


### PR DESCRIPTION
This prevents LLVM from emitting Libcalls to `__floatuntidf`, `__floattidf`, `__fixdfti`, `__fixunsdfti` which are not included in compiler-rt / libgcc on these platforms.

Resolves https://github.com/JuliaLang/julia/issues/61436. It would be good to make the JIT error for similar bugs in the future instead of hanging.