### PR TITLE
doc: explain how type parameters interact with `new` in parametric constructors

### DIFF
--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -414,6 +414,29 @@ it is possible to make them behave in a more relaxed but sensible manner quite e
 since constructors can leverage all of the power of the type system, methods, and multiple dispatch,
 defining sophisticated behavior is typically quite simple.
 
+### How `new` works in parametric constructors
+
+In the inner constructor of `Point`, `new(x,y)` is shorthand for `new{T}(x,y)`.
+**Inside the body of an inner constructor, the type parameters are implicitly forwarded to `new`**.
+You can also write the type parameters explicitly, which is equivalent:
+
+```jldoctest parametric2
+julia> struct Point2{T<:Real}
+           x::T
+           y::T
+           Point2{T}(x,y) where {T<:Real} = new{T}(x,y)  # explicit, same as new(x,y)
+       end
+
+julia> Point2{Float64}(1,2)
+Point2{Float64}(1.0, 2.0)
+```
+The explicit form becomes necessary when the type parameters for `new`
+differ from those of the enclosing inner constructor.
+For instance, if a type has two parameters like `MyType{T,S}` but the inner constructor is
+defined as `MyType{T}(...)`, then `new` would only receive `{T}` — not enough to
+determine the concrete type. In such cases you must write `new{T,S}(...)` explicitly.
+We will see an example of this in the [Outer-only constructors](@ref) section below.
+
 ## Case Study: Rational
 
 Perhaps the best way to tie all these pieces together is to present a real world example of a
@@ -571,10 +594,12 @@ Stacktrace:
 [...]
 ```
 
-This constructor will be invoked by the syntax `SummedArray(a)`. The syntax `new{T,S}` allows
-specifying parameters for the type to be constructed, i.e. this call will return a `SummedArray{T,S}`.
-`new{T,S}` can be used in any constructor definition, but for convenience the parameters
-to `new{}` are automatically derived from the type being constructed when possible.
+This is the case where explicit type parameters on `new` are essential:
+the inner constructor name is bare `SummedArray` with no curly braces,
+so `new` has no type parameters to inherit (see
+[How `new` works in parametric constructors](@ref) above).
+The explicit `new{T,S}` tells Julia to construct a `SummedArray{T,S}`,
+where `T` comes from the element type of the input vector and `S` is computed as `widen(T)`.
 
 ## Constructors are just callable objects
 

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -417,7 +417,7 @@ defining sophisticated behavior is typically quite simple.
 ### How `new` works in parametric constructors
 
 In the inner constructor of `Point`, `new(x,y)` is shorthand for `new{T}(x,y)`.
-**Inside the body of an inner constructor, the type parameters are implicitly forwarded to `new`**.
+**Inside the body of an inner constructor, the type parameters listed in the curly braces on the constructor name (e.g. the `T` parameter in `Point{T}(...)`) are implicitly forwarded to `new`**.
 You can also write the type parameters explicitly, which is equivalent:
 
 ```jldoctest parametric2


### PR DESCRIPTION
The constructors documentation used `new` with implicit and explicit type parameters in examples without clearly stating the underlying rule. This adds a subsection explaining that `new` inherits the type parameters from the curly braces on the inner constructor name, when explicit parameters are needed, and what happens when the constructor name has fewer parameters than the type requires. The existing explanation in the "Outer-only constructors" section is also updated to reference this rule.

The rules described here were determined empirically, as the existing documentation did not specify them. If any details  are inaccurate, corrections are welcome.
