### PR TITLE
Remove `count` heuristic from `htable_t`

### DIFF
--- a/src/support/htable.c
+++ b/src/support/htable.c
@@ -33,7 +33,6 @@ htable_t *htable_new(htable_t *h, size_t size)
     }
     if (h->table == NULL)
         return NULL;
-    h->count = 0;
     size_t i;
     for (i = 0; i < size; i++)
         h->table[i] = HT_NOTFOUND;
@@ -60,7 +59,6 @@ void htable_reset(htable_t *h, size_t sz)
         size_t i, hsz = h->size;
         for (i = 0; i < hsz; i++)
             h->table[i] = HT_NOTFOUND;
-        h->count = 0;
     }
 }
 

--- a/src/support/htable.h
+++ b/src/support/htable.h
@@ -18,13 +18,12 @@ extern "C" {
 //   key   = table[2*i]
 //   value = table[2*i+1]
 // where `2*i < size`. An empty slot at index `i` is indicated with
-// `value == HT_NOTFOUND`. `count` is the number of live entries.
+// `value == HT_NOTFOUND`.
 //
 // `_space` is reserved space for efficiently allocating small tables.
 typedef struct {
     size_t size;
     void **table;
-    size_t count;
     void *_space[HT_N_INLINE];
 } htable_t;
 

--- a/src/support/htable.inc
+++ b/src/support/htable.inc
@@ -47,15 +47,8 @@ static void **HTNAME##_lookup_bp_r(htable_t *h, void *key, void *ctx)   \
                 break; /* grow if probe took too long */                \
         } while (index != orig);                                        \
                                                                         \
-        /* grow if table is at least 75% full */                        \
-        if (empty_slot != -1) {                                         \
-            if (h->count * 4 >= hash_size(h) * 3)                       \
-                empty_slot = -1;                                        \
-        }                                                               \
-                                                                        \
         if (empty_slot != -1) {                                         \
             tab[empty_slot] = key;                                      \
-            h->count++;                                                 \
             return &tab[empty_slot+1];                                  \
         }                                                               \
                                                                         \
@@ -79,7 +72,6 @@ static void **HTNAME##_lookup_bp_r(htable_t *h, void *key, void *ctx)   \
             tab[i] = HT_NOTFOUND;                                       \
         h->table = tab;                                                 \
         h->size = newsz;                                                \
-        h->count = 0;                                                   \
         for (i = 0; i < sz; i += 2) {                                   \
             if (ol[i+1] != HT_NOTFOUND) {                               \
                 (*HTNAME##_lookup_bp_r(h, ol[i], ctx)) = ol[i+1];       \
@@ -154,7 +146,6 @@ _STATIC int HTNAME##_remove_r(htable_t *h, void *key, void *ctx)        \
     void **bp = HTNAME##_peek_bp_r(h, key, ctx);                        \
     if (bp != NULL) {                                                   \
         *bp = HT_NOTFOUND;                                              \
-        h->count--;                                                     \
         return 1;                                                       \
     }                                                                   \
     return 0;                                                           \


### PR DESCRIPTION
Revert this heuristic to get `master` green again.

This size heuristic can be ill-behaved if `htable_t` users do not consistently update the live vs. tombstoned count, which happens in a couple places in the repo that need fixing. Let's revert this for now and fix those next.