### PR TITLE
Various `htable_t` fixes / improvements.

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -178,10 +178,11 @@ static int layout_eq(void *_l1, void *_l2, void *unused) JL_NOTSAFEPOINT
 }
 
 //HTPROT(layoutcache)
+static void **layoutcache_lookup_bp_r_impl(htable_t *h, void *key, void *ctx, int key_owned) JL_NOTSAFEPOINT;
 static void **layoutcache_lookup_bp_r(htable_t *h, void *key, void *ctx) JL_NOTSAFEPOINT;
 static void **layoutcache_peek_bp_r(htable_t *h, void *key, void *ctx) JL_NOTSAFEPOINT;
 HTPROT_R(layoutcache)
-HTIMPL_R(layoutcache, _hash_layout_djb2, layout_eq)
+HTIMPL_R(layoutcache, _hash_layout_djb2, layout_eq, _HTIMPL_IDENTITY_KEYALLOC, _HTIMPL_NOOP_KEYFREE)
 static htable_t layoutcache;
 static int layoutcache_initialized = 0;
 

--- a/src/engine.c
+++ b/src/engine.c
@@ -153,7 +153,8 @@ static int sweep_reservations(htable_t *h, jl_ptls_t *gc_all_tls_states) JL_NOTS
         jl_code_instance_t *ci = info->ci;
         if (!gc_marked(jl_astaggedvalue(ci)->bits.gc)) {
             int16_t tid = info->tid;
-            h->table[i+1] = HT_NOTFOUND; // remove
+            h->table[i+1] = HT_NOTFOUND; // remove (tombstone)
+            h->live--;
             free(info);
             jl_ptls_t ptls2 = gc_all_tls_states[tid];
             ptls2->engine_nqueued--;

--- a/src/flisp/equalhash.c
+++ b/src/flisp/equalhash.c
@@ -19,7 +19,7 @@
 extern "C" {
 #endif
 
-HTIMPL_R(equalhash, _hash_lispvalue_, _equal_lispvalue_)
+HTIMPL_R(equalhash, _hash_lispvalue_, _equal_lispvalue_, _HTIMPL_IDENTITY_KEYALLOC, _HTIMPL_NOOP_KEYFREE)
 
 #ifdef __cplusplus
 }

--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -15,7 +15,7 @@ extern "C" {
 #define _equal_wchar_(x, y, ctx) ((x) == (y))
 #define _hash_wchar_(x, ctx) inthash((uint32_t) ((uintptr_t) (x)))
 #include "htable.inc"
-HTIMPL_R(wcharhash, _hash_wchar_, _equal_wchar_)
+HTIMPL_R(wcharhash, _hash_wchar_, _equal_wchar_, _HTIMPL_IDENTITY_KEYALLOC, _HTIMPL_NOOP_KEYFREE)
 
 static int is_uws(uint32_t wc)
 {

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -448,11 +448,12 @@ static jl_value_t *get_replaceable_field(jl_value_t **addr, int mutabl) JL_GC_DI
 
 static uintptr_t jl_fptr_id(void *fptr)
 {
-    void **pbp = ptrhash_bp(&fptr_to_id, fptr);
-    if (*pbp == HT_NOTFOUND || fptr == NULL)
+    if (fptr == NULL)
         return 0;
-    else
-        return *(uintptr_t*)pbp;
+    void *val = ptrhash_get(&fptr_to_id, fptr);
+    if (val == HT_NOTFOUND)
+        return 0;
+    return (uintptr_t)val;
 }
 
 static int effects_foldable(uint32_t effects)
@@ -856,8 +857,8 @@ done_fields: ;
     // try to promote itself to be immediate)
     if (s->incremental && jl_is_datatype(v) && immediate && recursive) {
         jl_datatype_t *dt = (jl_datatype_t*)v;
-        void **bp = ptrhash_bp(&serialization_order, (void*)dt->super);
-        if (*bp != (void*)-2) {
+        void *bp = ptrhash_get(&serialization_order, (void*)dt->super);
+        if (bp != (void*)-2) {
             // if super is already on the stack of things to handle when this returns, do
             // not try to handle it now
             jl_queue_for_serialization_(s, (jl_value_t*)dt->super, 1, immediate);

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -405,8 +405,8 @@ static int has_backedge_to_worklist(jl_method_instance_t *mi, htable_t *visited,
                         continue;
                     }
 
-                    void **child_bp = ptrhash_bp(visited, child_mi);
-                    int child_found = (char*)*child_bp - (char*)HT_NOTFOUND;
+                    void *child_bpval = ptrhash_get(visited, child_mi);
+                    int child_found = (char*)child_bpval - (char*)HT_NOTFOUND;
                     if (child_found) {
                         int child_result = child_found - 1;
                         if (child_result == 1 || child_result == 2) {

--- a/src/support/htable.c
+++ b/src/support/htable.c
@@ -33,6 +33,8 @@ htable_t *htable_new(htable_t *h, size_t size)
     }
     if (h->table == NULL)
         return NULL;
+    h->count = 0;
+    h->live = 0;
     size_t i;
     for (i = 0; i < size; i++)
         h->table[i] = HT_NOTFOUND;
@@ -59,6 +61,8 @@ void htable_reset(htable_t *h, size_t sz)
         size_t i, hsz = h->size;
         for (i = 0; i < hsz; i++)
             h->table[i] = HT_NOTFOUND;
+        h->count = 0;
+        h->live = 0;
     }
 }
 

--- a/src/support/htable.h
+++ b/src/support/htable.h
@@ -24,6 +24,8 @@ extern "C" {
 typedef struct {
     size_t size;
     void **table;
+    size_t count; // # of occupied key slots (live + tombstone)
+    size_t live;  // # of live entries (value != HT_NOTFOUND)
     void *_space[HT_N_INLINE];
 } htable_t;
 

--- a/src/support/htable.inc
+++ b/src/support/htable.inc
@@ -6,11 +6,18 @@
 
 #define hash_size(h) ((h)->size/2)
 
+#define _HTIMPL_IDENTITY_KEYALLOC(key,ctx) (key)
+#define _HTIMPL_NOOP_KEYFREE(key,ctx)      (void)key
+
 // compute empirical max-probe for a given size
 #define max_probe(size) ((size)<=(HT_N_INLINE*2) ? (HT_N_INLINE/2) : (size)>>3)
 
-#define _HTIMPL_EX(HTNAME, HFUNC, EQFUNC, _STATIC)                      \
-static void **HTNAME##_lookup_bp_r(htable_t *h, void *key, void *ctx)   \
+#define _HTIMPL_EX(HTNAME, HFUNC, EQFUNC, KEYALLOC, KEYFREE, _STATIC)   \
+                                                                        \
+/* key_owned: if true, the key is already owned by the table */         \
+/*            if false, KEYALLOC is called on insert. */                \
+static void **HTNAME##_lookup_bp_r_impl(htable_t *h, void *key,         \
+                                        void *ctx, int key_owned)       \
 {                                                                       \
     uint_t hv;                                                          \
     size_t i, orig, index, iter, empty_slot;                            \
@@ -38,8 +45,11 @@ static void **HTNAME##_lookup_bp_r(htable_t *h, void *key, void *ctx)   \
                     empty_slot = index;                                 \
             }                                                           \
                                                                         \
-            if (EQFUNC(key, tab[index], ctx))                           \
+            if (EQFUNC(key, tab[index], ctx)) {                         \
+                if (tab[index+1] == HT_NOTFOUND)                        \
+                    h->live++; /* reviving a tombstone */               \
                 return &tab[index+1];                                   \
+            }                                                           \
                                                                         \
             iter++;                                                     \
             index = (index + iter*2) & (sz-1);                          \
@@ -47,18 +57,36 @@ static void **HTNAME##_lookup_bp_r(htable_t *h, void *key, void *ctx)   \
                 break; /* grow if probe took too long */                \
         } while (index != orig);                                        \
                                                                         \
+        /* grow if live entries >= 75% of slots */                      \
         if (empty_slot != -1) {                                         \
-            tab[empty_slot] = key;                                      \
+            if (h->live * 4 >= hash_size(h) * 3)                        \
+                empty_slot = -1;                                        \
+        }                                                               \
+        /* rehash if too many tombstones (>= 87.5% slots occupied) */   \
+        int grow = (empty_slot == -1);                                  \
+        if (empty_slot != -1) {                                         \
+            if (8 * (hash_size(h) - h->count) <= hash_size(h))          \
+                empty_slot = -1;                                        \
+        }                                                               \
+                                                                        \
+        if (empty_slot != -1) {                                         \
+            if (tab[empty_slot] == HT_NOTFOUND)                         \
+                h->count++;                                             \
+            else                                                        \
+                KEYFREE(tab[empty_slot], ctx); /* free tombstone key */ \
+            h->live++;                                                  \
+            tab[empty_slot] = key_owned ? key : KEYALLOC(key, ctx);     \
             return &tab[empty_slot+1];                                  \
         }                                                               \
                                                                         \
-        /* table full */                                                \
         /* quadruple size, rehash, retry the insert */                  \
         /* it's important to grow the table really fast; otherwise we waste */ \
         /* lots of time rehashing all the keys over and over. */        \
         sz = h->size;                                                   \
         ol = h->table;                                                  \
-        if (sz < HT_N_INLINE)                                           \
+        if (!grow)                                                      \
+            newsz = sz; /* just rehash to clean tombstones */           \
+        else if (sz < HT_N_INLINE)                                      \
             newsz = HT_N_INLINE;                                        \
         else if (sz >= (1<<19) || (sz <= (1<<8)))                       \
             newsz = sz<<1;                                              \
@@ -72,9 +100,15 @@ static void **HTNAME##_lookup_bp_r(htable_t *h, void *key, void *ctx)   \
             tab[i] = HT_NOTFOUND;                                       \
         h->table = tab;                                                 \
         h->size = newsz;                                                \
+        h->count = 0;                                                   \
+        h->live = 0;                                                    \
         for (i = 0; i < sz; i += 2) {                                   \
             if (ol[i+1] != HT_NOTFOUND) {                               \
-                (*HTNAME##_lookup_bp_r(h, ol[i], ctx)) = ol[i+1];       \
+                (*HTNAME##_lookup_bp_r_impl(h, ol[i], ctx, 1)) =        \
+                    ol[i+1];                                            \
+            }                                                           \
+            else if (ol[i] != HT_NOTFOUND) {                            \
+                KEYFREE(ol[i], ctx); /* free tombstone key */           \
             }                                                           \
         }                                                               \
         if (ol != &h->_space[0])                                        \
@@ -86,6 +120,11 @@ static void **HTNAME##_lookup_bp_r(htable_t *h, void *key, void *ctx)   \
     }                                                                   \
                                                                         \
     return NULL;                                                        \
+}                                                                       \
+                                                                        \
+static void **HTNAME##_lookup_bp_r(htable_t *h, void *key, void *ctx)   \
+{                                                                       \
+    return HTNAME##_lookup_bp_r_impl(h, key, ctx, /* key_owned */ 0);   \
 }                                                                       \
                                                                         \
 _STATIC void HTNAME##_put_r(htable_t *h, void *key, void *val, void *ctx) \
@@ -144,8 +183,9 @@ _STATIC int HTNAME##_has_r(htable_t *h, void *key, void *ctx)           \
 _STATIC int HTNAME##_remove_r(htable_t *h, void *key, void *ctx)        \
 {                                                                       \
     void **bp = HTNAME##_peek_bp_r(h, key, ctx);                        \
-    if (bp != NULL) {                                                   \
+    if (bp != NULL && *bp != HT_NOTFOUND) {                             \
         *bp = HT_NOTFOUND;                                              \
+        h->live--;                                                      \
         return 1;                                                       \
     }                                                                   \
     return 0;                                                           \
@@ -171,7 +211,8 @@ static uint_t HTNAME##_eqfunc_wrapper(void *key1, void *key2, void *ctx) \
     return EQFUNC(key1, key2);                                          \
 }                                                                       \
                                                                         \
-_HTIMPL_EX(HTNAME, HTNAME##_hfunc_wrapper, HTNAME##_eqfunc_wrapper, static) \
+_HTIMPL_EX(HTNAME, HTNAME##_hfunc_wrapper, HTNAME##_eqfunc_wrapper,     \
+           _HTIMPL_IDENTITY_KEYALLOC, _HTIMPL_NOOP_KEYFREE, static)     \
                                                                         \
 void HTNAME##_put(htable_t *h, void *key, void *val)                    \
 {                                                                       \
@@ -203,4 +244,4 @@ void HTNAME##_adjoin(htable_t *h, void *key, void *val)                 \
     HTNAME##_adjoin_r(h, key, val, NULL);                               \
 }
 
-#define HTIMPL_R(HTNAME, HFUNC, EQFUNC) _HTIMPL_EX(HTNAME, HFUNC, EQFUNC, )
+#define HTIMPL_R(HTNAME, HFUNC, EQFUNC, KEYALLOC, KEYFREE) _HTIMPL_EX(HTNAME, HFUNC, EQFUNC, KEYALLOC, KEYFREE, )

--- a/src/support/strhash.c
+++ b/src/support/strhash.c
@@ -31,62 +31,16 @@ static uint_t strhash_eq(void *key1, void *key2, void *ctx)
 
 #include "htable.inc"
 
-_HTIMPL_EX(strhash, strhash_hash, strhash_eq, )
+static void *strhash_keyalloc(void *key, void *ctx) JL_NOTSAFEPOINT { (void)ctx; return strdup((const char *)key); }
+static void strhash_keyfree(void *key, void *ctx) JL_NOTSAFEPOINT { (void)ctx; free(key); }
+_HTIMPL_EX(strhash, strhash_hash, strhash_eq, strhash_keyalloc, strhash_keyfree, )
 
-// Wrapper that internalizes the key on first insertion.
-void strhash_put(htable_t *h, void *key, void *val)
-{
-    // Check if the key already exists
-    void **bp = strhash_peek_bp_r(h, key, NULL);
-    if (bp != NULL) {
-        *bp = val;
-        return;
-    }
-    // Key not found — internalize it and insert
-    char *ikey = strdup((const char *)key);
-    strhash_put_r(h, ikey, val, NULL);
-}
-
-void **strhash_bp(htable_t *h, void *key)
-{
-    // Try to find existing entry first
-    void **bp = strhash_peek_bp_r(h, key, NULL);
-    if (bp != NULL)
-        return bp;
-    // Not found — internalize key and create entry
-    char *ikey = strdup((const char *)key);
-    return strhash_bp_r(h, ikey, NULL);
-}
-
-void *strhash_get(htable_t *h, void *key)
-{
-    return strhash_get_r(h, key, NULL);
-}
-
-int strhash_has(htable_t *h, void *key)
-{
-    return strhash_has_r(h, key, NULL);
-}
-
-int strhash_remove(htable_t *h, void *key)
-{
-    void **bp = strhash_peek_bp_r(h, key, NULL);
-    if (bp != NULL) {
-        // Free the internalized key (stored one slot before the value)
-        free(*(bp - 1));
-        *(bp - 1) = HT_NOTFOUND;
-        *bp = HT_NOTFOUND;
-        return 1;
-    }
-    return 0;
-}
-
-void strhash_adjoin(htable_t *h, void *key, void *val)
-{
-    void **bp = strhash_bp(h, key);
-    if (*bp == HT_NOTFOUND)
-        *bp = val;
-}
+void  strhash_put(htable_t *h, void *key, void *val) { strhash_put_r(h, key, val, NULL); }
+void *strhash_get(htable_t *h, void *key) { return strhash_get_r(h, key, NULL); }
+void **strhash_bp(htable_t *h, void *key) { return strhash_bp_r(h, key, NULL); }
+int   strhash_has(htable_t *h, void *key) { return strhash_has_r(h, key, NULL); }
+int   strhash_remove(htable_t *h, void *key) { return strhash_remove_r(h, key, NULL); }
+void  strhash_adjoin(htable_t *h, void *key, void *val) { strhash_adjoin_r(h, key, val, NULL); }
 
 htable_t *strhash_new(htable_t *h, size_t size)
 {
@@ -97,9 +51,9 @@ void strhash_free(htable_t *h)
 {
     size_t sz = h->size;
     void **tab = h->table;
-    // Free all internalized key strings
+    // Free all internalized key strings (live and tombstone entries)
     for (size_t i = 0; i < sz; i += 2) {
-        if (tab[i] != HT_NOTFOUND && tab[i+1] != HT_NOTFOUND)
+        if (tab[i] != HT_NOTFOUND)
             free(tab[i]);
     }
     htable_free(h);


### PR DESCRIPTION
Again inspired by LLVM DenseMap. AI (Claude) was used to assist with the re-factor.

 - Re-add the `count` heuristic with a separate `live` count to track tombstone entries vs. live buckets
 - Move `key` allocation / free into the `htable.inc` implementation (no-op for `ptrhash`)
 - Fix `strhash_remove` creating invalid empty slots rather than tombstone entries

~~Needs profiling before this is merge-ready.~~