### PR TITLE
codegen: Configure `--expand-fp-convert-bits 128` on targets with `__int128_t`

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -10435,14 +10435,17 @@ extern "C" void jl_init_llvm(void)
     if (clopt && clopt->getNumOccurrences() == 0)
         cl::ProvidePositionalOption(clopt, "4", 1);
 
-    // When the platform doesn't support __int128, compiler-rt/libgcc do not
-    // provide the corresponding libcalls (e.g. __floattidf, __fixdfti), so we
-    // must expand FP conversions for integer types wider than 64 bits inline.
-#ifndef _HAS_INT128_
+    // compiler-rt/libgcc only provide FP conversion libcalls (e.g. __floattidf,
+    // __fixdfti) up to the widest integer type the platform supports natively
+    // in C (_BitInt excluded). Wider FP conversions must be expanded inline.
     clopt = llvmopts.lookup("expand-fp-convert-bits");
-    if (clopt && clopt->getNumOccurrences() == 0)
+    if (clopt && clopt->getNumOccurrences() == 0) {
+#ifdef _HAS_INT128_
+        cl::ProvidePositionalOption(clopt, "128", 1);
+#else
         cl::ProvidePositionalOption(clopt, "64", 1);
 #endif
+    }
 
     clopt = llvmopts.lookup("time-passes");
     if (clopt && clopt->getNumOccurrences() > 0)

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -617,3 +617,7 @@ end
 # https://github.com/JuliaLang/julia/issues/61436
 tofloat(x) = Core.Intrinsics.uitofp(Float64, x)
 @test tofloat(UInt128(0)) == 0.0
+
+# https://github.com/JuliaLang/julia/issues/61436
+primitive type UIntN256 <: Unsigned 256 end
+@test tofloat(reinterpret(UIntN256, (zeros(UInt8, 32)...,))) == 0.0


### PR DESCRIPTION
This only seems to affect `aarch64` and is resolved on LLVM trunk already, but it's the 64-bit counterpart to https://github.com/JuliaLang/julia/pull/61439.

Resolves https://github.com/JuliaLang/julia/issues/61447.