### PR TITLE
subtype: Remove `envout` code in intersection

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -4723,7 +4723,6 @@ jl_value_t *jl_type_intersection_env_s(jl_value_t *a, jl_value_t *b, jl_svec_t *
         // TODO: code dealing with method signatures is not able to handle unions, so if
         // `a` and `b` are both tuples, we need to be careful and may not return a union,
         // even if `intersect` produced one
-        int env_from_subtype = 1;
         if (jl_is_tuple_type(jl_unwrap_unionall(a)) && jl_is_tuple_type(jl_unwrap_unionall(b)) &&
             !jl_is_datatype(jl_unwrap_unionall(*ans))) {
             jl_value_t *ans_unwrapped = jl_unwrap_unionall(*ans);
@@ -4736,18 +4735,19 @@ jl_value_t *jl_type_intersection_env_s(jl_value_t *a, jl_value_t *b, jl_svec_t *
             }
             JL_GC_POP();
             if (!jl_is_datatype(jl_unwrap_unionall(*ans))) {
+                // Bail: caller can't handle a non-datatype here. The env computed
+                // by `intersect` is meaningless after this assignment, but the
+                // subtype call below recovers a usable env via the `x == y` fast
+                // path in `jl_subtype_env` (typevars from `b`).
                 *ans = b;
-                env_from_subtype = 0;
             }
         }
-        if (env_from_subtype) {
-            sz = szb;
-            // TODO: compute better `env` directly during intersection.
-            // for now, we attempt to compute env by using subtype on the intersection result
-            if (szb > 0 && !jl_types_equal(b, (jl_value_t*)jl_type_type)) {
-                if (!jl_subtype_env(*ans, b, env, szb)) {
-                    sz = 0;
-                }
+        sz = szb;
+        // TODO: compute better `env` directly during intersection.
+        // for now, we attempt to compute env by using subtype on the intersection result
+        if (szb > 0 && !jl_types_equal(b, (jl_value_t*)jl_type_type)) {
+            if (!jl_subtype_env(*ans, b, env, szb)) {
+                sz = 0;
             }
         }
     }

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -3464,14 +3464,6 @@ static jl_value_t *finish_unionall(jl_value_t *res JL_MAYBE_UNROOTED, jl_varbind
         }
     }
 
-    if (vb->existential && e->envidx < e->envsz) {
-        jl_value_t *oldval = e->envout[e->envidx];
-        if (!varval || (!is_leaf_bound(varval) && !vb->occurs_inv))
-            e->envout[e->envidx] = (jl_value_t*)vb->var;
-        else if (!(oldval && jl_is_typevar(oldval) && jl_is_long(varval)))
-            e->envout[e->envidx] = varval;
-    }
-
     JL_GC_POP();
     return res;
 }


### PR DESCRIPTION
As far as I can tell this code is unused as envout is always computed in subtype. I'm reworking this code and would prefer to remove it rather than (possibly incorrectly) updating unused code.