### PR TITLE
store crc of sysimage at build time and stop recomputing it on every startup

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -2047,6 +2047,7 @@ void jl_dump_native_locked(jl_native_code_desc_t *data, const char *bc_fname,
         sysimgM.setOverrideStackAlignment(OverrideStackAlignment);
 
         int compression = jl_options.compress_sysimage ? 15 : 0;
+        uint32_t sysimg_checksum = jl_crc32c(0, z->buf, z->size);
         ArrayRef<char> sysimg_data{z->buf, (size_t)z->size};
         SmallVector<char, 0> compressed_data;
         if (compression) {
@@ -2075,6 +2076,10 @@ void jl_dump_native_locked(jl_native_code_desc_t *data, const char *bc_fname,
         addComdat(new GlobalVariable(sysimgM, len->getType(), true,
                                      GlobalVariable::ExternalLinkage,
                                      len, "jl_system_image_size"), TheTriple);
+        Constant *checksum_val = ConstantInt::get(Type::getInt32Ty(Context), sysimg_checksum);
+        addComdat(new GlobalVariable(sysimgM, checksum_val->getType(), true,
+                                     GlobalVariable::ExternalLinkage,
+                                     checksum_val, "jl_system_image_checksum"), TheTriple);
 
         const char *unpack_func = compression ? "jl_image_unpack_zstd" : "jl_image_unpack_uncomp";
         auto unpack = new GlobalVariable(sysimgM, DL.getIntPtrType(Context), true,

--- a/src/julia.h
+++ b/src/julia.h
@@ -2167,6 +2167,7 @@ typedef struct {
     const char *data;
     size_t size;
     uint64_t base;
+    uint32_t checksum;
 } jl_image_buf_t;
 
 struct _jl_image_t;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3455,20 +3455,26 @@ static void jl_prefetch_system_image(const char *data, size_t size)
 JL_DLLEXPORT void jl_image_unpack_uncomp(void *handle, jl_image_buf_t *image)
 {
     size_t *plen;
+    uint32_t *pchecksum;
     jl_dlsym(handle, "jl_system_image_size", (void **)&plen, 1, 0);
     jl_dlsym(handle, "jl_system_image_data", (void **)&image->data, 1, 0);
     jl_dlsym(handle, "jl_image_pointers", (void**)&image->pointers, 1, 0);
+    jl_dlsym(handle, "jl_system_image_checksum", (void **)&pchecksum, 1, 0);
     image->size = *plen;
+    image->checksum = *pchecksum;
     jl_prefetch_system_image(image->data, image->size);
 }
 
 JL_DLLEXPORT void jl_image_unpack_zstd(void *handle, jl_image_buf_t *image)
 {
     size_t *plen;
+    uint32_t *pchecksum;
     const char *data;
     jl_dlsym(handle, "jl_system_image_size", (void **)&plen, 1, 0);
     jl_dlsym(handle, "jl_system_image_data", (void **)&data, 1, 0);
     jl_dlsym(handle, "jl_image_pointers", (void **)&image->pointers, 1, 0);
+    jl_dlsym(handle, "jl_system_image_checksum", (void **)&pchecksum, 1, 0);
+    image->checksum = *pchecksum;
     jl_prefetch_system_image(data, *plen);
     image->size = ZSTD_getFrameContentSize(data, *plen);
     size_t page_size = jl_getpagesize(); /* jl_page_size is not set yet when loading sysimg */
@@ -4301,7 +4307,7 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
             sysimg = &f->buf[f->bpos];
         if (needs_permalloc)
             success = ios_readall(f, sysimg, len) == len;
-        if (!success || jl_crc32c(0, sysimg, len) != (uint32_t)checksum) {
+        if (!success) {
             restored = jl_get_exceptionf(jl_errorexception_type, "Error reading package image file.");
             JL_SIGATOMIC_END();
         }
@@ -4406,8 +4412,7 @@ JL_DLLEXPORT void jl_restore_system_image(jl_image_t *image, jl_image_buf_t buf)
     JL_SIGATOMIC_BEGIN();
     ios_static_buffer(&f, (char *)buf.data, buf.size);
 
-    uint32_t checksum = jl_crc32c(0, buf.data, buf.size);
-    jl_restore_system_image_from_stream(&f, image, checksum);
+    jl_restore_system_image_from_stream(&f, image, buf.checksum);
 
     ios_close(&f);
     JL_SIGATOMIC_END();


### PR DESCRIPTION
fixes #50166

I keep seeing this crc computation taking a significant time (even in relative terms of julia startup). I feel the value it provides is not large. It would catch the case where we load julia with a corrupted data section of the sysimage, but this julia works well enough that it can try loading package images, it would then reject existing package images from getting loaded and instead recompile them. If you have random file corruptions in your files you are probably already in an unrecoverable situation.

This stores the crc instead of using a UUID to keep the possibility in the future of actually verifying the hash of the sysimage via e.g. a flag, but this is left for the future.

To see the perf impact on the julia we ship I did:

```
❯ hyperfine --warmup 3 './julia -e ""' 'julia +nightly -e ""' 
Benchmark 1: ./julia -e ""
  Time (mean ± σ):      65.8 ms ±   1.1 ms    [User: 46.6 ms, System: 17.3 ms]
  Range (min … max):    64.5 ms …  68.9 ms    44 runs
 
Benchmark 2: julia +nightly -e ""
  Time (mean ± σ):      77.0 ms ±   1.3 ms    [User: 55.5 ms, System: 18.6 ms]
  Range (min … max):    75.3 ms …  82.6 ms    38 runs
 
Summary
  ./julia -e "" ran
    1.17 ± 0.03 times faster than julia +nightly -e ""
```

but note that I've seen this crc check take 600+ms on larger sysimages:

<img width="1566" height="290" alt="image" src="https://github.com/user-attachments/assets/89c864b3-1a9b-425a-ba01-ef7fa6b718d5" />


🤖 Claude helped prepare this PR.