### PR TITLE
avoid false-positive recursion detection in the presence of union splitting

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -67,6 +67,7 @@ any_ambig(info::MethodMatchInfo) = any_ambig(info.results)
 any_ambig(m::MethodMatches) = any_ambig(m.info)
 fully_covering(info::MethodMatchInfo) = info.fullmatch
 fully_covering(m::MethodMatches) = fully_covering(m.info)
+multiple_methods(m::MethodMatches) = length(m.applicable) > 1
 
 struct UnionSplitMethodMatches
     applicable::Vector{MethodMatchTarget}
@@ -78,6 +79,17 @@ any_ambig(info::UnionSplitInfo) = any(any_ambig, info.split)
 any_ambig(m::UnionSplitMethodMatches) = any_ambig(m.info)
 fully_covering(info::UnionSplitInfo) = all(fully_covering, info.split)
 fully_covering(m::UnionSplitMethodMatches) = fully_covering(m.info)
+function multiple_methods(m::UnionSplitMethodMatches)
+    first_method = nothing
+    for target in m.applicable
+        if first_method === nothing
+            first_method = target.match.method
+        elseif target.match.method !== first_method
+            return true
+        end
+    end
+    return false
+end
 
 nmatches(info::MethodMatchInfo) = length(info.results)
 function nmatches(info::UnionSplitInfo)
@@ -143,7 +155,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
     # split the for loop off into a function, so that we can pause and restart it at will
     function infercalls(interp, sv)
         local napplicable = length(applicable)
-        local multiple_matches = napplicable > 1
+        local multiple_matches = multiple_methods(matches)
         while state.inferidx <= napplicable
             (; match, edges, call_results, edge_idx) = applicable[state.inferidx]
             local method = match.method
@@ -296,7 +308,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
             inferidx = SafeBox{Int}(1)
             function infercalls2(interp, sv)
                 local napplicable = length(applicable)
-                local multiple_matches = napplicable > 1
+                local multiple_matches = multiple_methods(matches)
                 while inferidx[] <= napplicable
                     (; match, call_results, edge_idx) = applicable[inferidx[]]
                     inferidx[] += 1

--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -1527,3 +1527,25 @@ let f = (x) -> Core.Intrinsics.trunc_int(Int16, x)
     @test Compiler.is_nothrow(Base.infer_effects(f, (Int32,)))
     @test catch_error_61435(f, Int16(0)) === :caught
 end
+
+# issue #57324
+module Issue57324
+struct T <: AbstractVector{Float64}
+    m::Memory{UInt64}
+end
+function f(w)
+    r = Base.OneTo(w.m[1])
+    setindex!(w, 0.0, r[1])
+end
+Base.setindex!(w::T, v, i::Int) = _setindex!(w, i)
+function _setindex!(w, i)
+    w.m[w.m[1]] = 0 > i ? nothing : 0
+    w
+end
+Base.size(::T) = (0,)
+end
+let effects = Base.infer_effects(Issue57324.f, (Issue57324.T,))
+    @test Compiler.is_terminates(effects)
+    @test Compiler.is_notaskstate(effects)
+    @test Compiler.is_nortcall(effects)
+end


### PR DESCRIPTION
fixes https://github.com/JuliaLang/julia/issues/57324

see the MWE closely: the `setindex!` method added is `setindex!(_, _, i::Int)`, but the index passed is `UInt`. which means we hit `setindex!(A::AbstractArray, v, I...)` twice to convert the `UInt -> Int`, once via `T` and again via `Memory`. since `_setindex!(w, i)` returns `Union{Nothing, Int}`, this gets union-split causing `napplicable > 1`, triggering the aggressive recursion-limiting heuristic `hardlimit=true`

note this fix is not super general and there are probably several other similar scenarios one could construct dispatching through the same general method several times and ending up hitting this heuristic. but I think this should address all cases where this happens due to union splitting?