### PR TITLE
Update Numbered prompt example code to prevent World Age warning

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -870,11 +870,13 @@ It is possible to get an interface which is similar to the IPython REPL and the 
 
 ```julia
 atreplinit() do repl
-    @eval import REPL
-    if !isdefined(repl, :interface)
-        repl.interface = REPL.setup_interface(repl)
+    @eval begin
+        import REPL
+        if !isdefined($repl, :interface)
+            $repl.interface = REPL.setup_interface($repl)
+        end
+        REPL.numbered_prompt!($repl)
     end
-    REPL.numbered_prompt!(repl)
 end
 ```
 


### PR DESCRIPTION
Update Numbered prompt example code to prevent World Age warning.

When I used the exact text provided in the julia code block, on v1.12, I was greeted with a warning:
```
WARNING: Detected access to binding `Main.REPL` in a world prior to its definition world.
  Julia 1.12 has introduced more strict world age semantics for global bindings.
  !!! This code may malfunction under Revise.
  !!! This code will error in future versions of Julia.
Hint: Add an appropriate `invokelatest` around the access to this binding.
To make this warning an error, and hence obtain a stack trace, use `julia --depwarn=error`.
```
After a couple of iterations, the provided code block achieves the same results, but eliminates the warning