### PR TITLE
Slightly improve "re-bootstrap" support for Base

### DIFF
--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module Base
+baremodule Base
 
 Core._import(Base, Core, :_eval_import, :_eval_import, true)
 Core._import(Base, Core, :_eval_using, :_eval_using, true)
@@ -37,6 +37,9 @@ end
 # from now on, this is now a top-module for resolving syntax
 const is_primary_base_module = ccall(:jl_module_parent, Ref{Module}, (Any,), Base) === Core.Main
 ccall(:jl_set_istopmod, Cvoid, (Any, Bool), Base, is_primary_base_module)
+
+# if true, Base will define "pirated" methods over Core types (such as `Tuple(...) = ...`)
+const ALLOW_CORE_PIRACY = is_primary_base_module
 
 # The @inline/@noinline macros that can be applied to a function declaration are not available
 # until after array.jl, and so we will mark them within a function body instead.

--- a/base/bool.jl
+++ b/base/bool.jl
@@ -162,4 +162,8 @@ div(x::Bool, y::Bool) = y ? x : throw(DivideError())
 rem(x::Bool, y::Bool) = y ? false : throw(DivideError())
 mod(x::Bool, y::Bool) = rem(x,y)
 
-Bool(x::Real) = x==0 ? false : x==1 ? true : throw(InexactError(:Bool, Bool, x))
+if ALLOW_CORE_PIRACY
+
+    Bool(x::Real) = x==0 ? false : x==1 ? true : throw(InexactError(:Bool, Bool, x))
+
+end

--- a/base/float.jl
+++ b/base/float.jl
@@ -236,21 +236,32 @@ uabs(x::BitSigned) = unsigned(abs(x))
 
 ## conversions to floating-point ##
 
-# TODO: deprecate in 2.0
-Float16(x::Integer) = convert(Float16, convert(Float32, x)::Float32)
+if ALLOW_CORE_PIRACY
+
+    # TODO: deprecate in 2.0
+    Float16(x::Integer) = convert(Float16, convert(Float32, x)::Float32)
+
+    for t1 in (Float16, Float32, Float64)
+        for st in (Int8, Int16, Int32, Int64)
+            @eval begin
+                (::Type{$t1})(x::($st)) = sitofp($t1, x)
+            end
+        end
+        for ut in (Bool, UInt8, UInt16, UInt32, UInt64)
+            @eval begin
+                (::Type{$t1})(x::($ut)) = uitofp($t1, x)
+            end
+        end
+    end
+
+end
 
 for t1 in (Float16, Float32, Float64)
     for st in (Int8, Int16, Int32, Int64)
-        @eval begin
-            (::Type{$t1})(x::($st)) = sitofp($t1, x)
-            promote_rule(::Type{$t1}, ::Type{$st}) = $t1
-        end
+        @eval promote_rule(::Type{$t1}, ::Type{$st}) = $t1
     end
     for ut in (Bool, UInt8, UInt16, UInt32, UInt64)
-        @eval begin
-            (::Type{$t1})(x::($ut)) = uitofp($t1, x)
-            promote_rule(::Type{$t1}, ::Type{$ut}) = $t1
-        end
+        @eval promote_rule(::Type{$t1}, ::Type{$ut}) = $t1
     end
 end
 
@@ -261,103 +272,107 @@ promote_rule(::Type{Float32}, ::Type{Int128}) = Float32
 promote_rule(::Type{Float16}, ::Type{UInt128}) = Float16
 promote_rule(::Type{Float16}, ::Type{Int128}) = Float16
 
-function Float64(x::UInt128)
-    if x < UInt128(1) << 104 # Can fit it in two 52 bits mantissas
-        low_exp = 0x1p52
-        high_exp = 0x1p104
-        low_bits = (x % UInt64) & Base.significand_mask(Float64)
-        low_value = reinterpret(Float64, reinterpret(UInt64, low_exp) | low_bits) - low_exp
-        high_bits = ((x >> 52) % UInt64)
-        high_value = reinterpret(Float64, reinterpret(UInt64, high_exp) | high_bits) - high_exp
-        low_value + high_value
-    else # Large enough that low bits only affect rounding, pack low bits
-        low_exp = 0x1p76
-        high_exp = 0x1p128
-        low_bits = ((x >> 12) % UInt64) >> 12 | (x % UInt64) & 0xFFFFFF
-        low_value = reinterpret(Float64, reinterpret(UInt64, low_exp) | low_bits) - low_exp
-        high_bits = ((x >> 76) % UInt64)
-        high_value = reinterpret(Float64, reinterpret(UInt64, high_exp) | high_bits) - high_exp
-        low_value + high_value
+if ALLOW_CORE_PIRACY
+
+    function Float64(x::UInt128)
+        if x < UInt128(1) << 104 # Can fit it in two 52 bits mantissas
+            low_exp = 0x1p52
+            high_exp = 0x1p104
+            low_bits = (x % UInt64) & Base.significand_mask(Float64)
+            low_value = reinterpret(Float64, reinterpret(UInt64, low_exp) | low_bits) - low_exp
+            high_bits = ((x >> 52) % UInt64)
+            high_value = reinterpret(Float64, reinterpret(UInt64, high_exp) | high_bits) - high_exp
+            low_value + high_value
+        else # Large enough that low bits only affect rounding, pack low bits
+            low_exp = 0x1p76
+            high_exp = 0x1p128
+            low_bits = ((x >> 12) % UInt64) >> 12 | (x % UInt64) & 0xFFFFFF
+            low_value = reinterpret(Float64, reinterpret(UInt64, low_exp) | low_bits) - low_exp
+            high_bits = ((x >> 76) % UInt64)
+            high_value = reinterpret(Float64, reinterpret(UInt64, high_exp) | high_bits) - high_exp
+            low_value + high_value
+        end
     end
-end
 
-function Float64(x::Int128)
-    sign_bit = ((x >> 127) % UInt64) << 63
-    ux = uabs(x)
-    if ux < UInt128(1) << 104 # Can fit it in two 52 bits mantissas
-        low_exp = 0x1p52
-        high_exp = 0x1p104
-        low_bits = (ux % UInt64) & Base.significand_mask(Float64)
-        low_value = reinterpret(Float64, reinterpret(UInt64, low_exp) | low_bits) - low_exp
-        high_bits = ((ux >> 52) % UInt64)
-        high_value = reinterpret(Float64, reinterpret(UInt64, high_exp) | high_bits) - high_exp
-        reinterpret(Float64, sign_bit | reinterpret(UInt64, low_value + high_value))
-    else # Large enough that low bits only affect rounding, pack low bits
-        low_exp = 0x1p76
-        high_exp = 0x1p128
-        low_bits = ((ux >> 12) % UInt64) >> 12 | (ux % UInt64) & 0xFFFFFF
-        low_value = reinterpret(Float64, reinterpret(UInt64, low_exp) | low_bits) - low_exp
-        high_bits = ((ux >> 76) % UInt64)
-        high_value = reinterpret(Float64, reinterpret(UInt64, high_exp) | high_bits) - high_exp
-        reinterpret(Float64, sign_bit | reinterpret(UInt64, low_value + high_value))
+    function Float64(x::Int128)
+        sign_bit = ((x >> 127) % UInt64) << 63
+        ux = uabs(x)
+        if ux < UInt128(1) << 104 # Can fit it in two 52 bits mantissas
+            low_exp = 0x1p52
+            high_exp = 0x1p104
+            low_bits = (ux % UInt64) & Base.significand_mask(Float64)
+            low_value = reinterpret(Float64, reinterpret(UInt64, low_exp) | low_bits) - low_exp
+            high_bits = ((ux >> 52) % UInt64)
+            high_value = reinterpret(Float64, reinterpret(UInt64, high_exp) | high_bits) - high_exp
+            reinterpret(Float64, sign_bit | reinterpret(UInt64, low_value + high_value))
+        else # Large enough that low bits only affect rounding, pack low bits
+            low_exp = 0x1p76
+            high_exp = 0x1p128
+            low_bits = ((ux >> 12) % UInt64) >> 12 | (ux % UInt64) & 0xFFFFFF
+            low_value = reinterpret(Float64, reinterpret(UInt64, low_exp) | low_bits) - low_exp
+            high_bits = ((ux >> 76) % UInt64)
+            high_value = reinterpret(Float64, reinterpret(UInt64, high_exp) | high_bits) - high_exp
+            reinterpret(Float64, sign_bit | reinterpret(UInt64, low_value + high_value))
+        end
     end
-end
 
-function Float32(x::UInt128)
-    x == 0 && return 0f0
-    n = top_set_bit(x) # ndigits0z(x,2)
-    if n <= 24
-        y = ((x % UInt32) << (24-n)) & 0x007f_ffff
-    else
-        y = ((x >> (n-25)) % UInt32) & 0x00ff_ffff # keep 1 extra bit
-        y = (y+one(UInt32))>>1 # round, ties up (extra leading bit in case of next exponent)
-        y &= ~UInt32(trailing_zeros(x) == (n-25)) # fix last bit to round to even
+    function Float32(x::UInt128)
+        x == 0 && return 0f0
+        n = top_set_bit(x) # ndigits0z(x,2)
+        if n <= 24
+            y = ((x % UInt32) << (24-n)) & 0x007f_ffff
+        else
+            y = ((x >> (n-25)) % UInt32) & 0x00ff_ffff # keep 1 extra bit
+            y = (y+one(UInt32))>>1 # round, ties up (extra leading bit in case of next exponent)
+            y &= ~UInt32(trailing_zeros(x) == (n-25)) # fix last bit to round to even
+        end
+        d = ((n+126) % UInt32) << 23
+        reinterpret(Float32, d + y)
     end
-    d = ((n+126) % UInt32) << 23
-    reinterpret(Float32, d + y)
-end
 
-function Float32(x::Int128)
-    x == 0 && return 0f0
-    s = ((x >>> 96) % UInt32) & 0x8000_0000 # sign bit
-    x = abs(x) % UInt128
-    n = top_set_bit(x) # ndigits0z(x,2)
-    if n <= 24
-        y = ((x % UInt32) << (24-n)) & 0x007f_ffff
-    else
-        y = ((x >> (n-25)) % UInt32) & 0x00ff_ffff # keep 1 extra bit
-        y = (y+one(UInt32))>>1 # round, ties up (extra leading bit in case of next exponent)
-        y &= ~UInt32(trailing_zeros(x) == (n-25)) # fix last bit to round to even
+    function Float32(x::Int128)
+        x == 0 && return 0f0
+        s = ((x >>> 96) % UInt32) & 0x8000_0000 # sign bit
+        x = abs(x) % UInt128
+        n = top_set_bit(x) # ndigits0z(x,2)
+        if n <= 24
+            y = ((x % UInt32) << (24-n)) & 0x007f_ffff
+        else
+            y = ((x >> (n-25)) % UInt32) & 0x00ff_ffff # keep 1 extra bit
+            y = (y+one(UInt32))>>1 # round, ties up (extra leading bit in case of next exponent)
+            y &= ~UInt32(trailing_zeros(x) == (n-25)) # fix last bit to round to even
+        end
+        d = ((n+126) % UInt32) << 23
+        reinterpret(Float32, s | d + y)
     end
-    d = ((n+126) % UInt32) << 23
-    reinterpret(Float32, s | d + y)
+
+    # TODO: optimize
+    Float16(x::UInt128) = convert(Float16, Float64(x))
+    Float16(x::Int128)  = convert(Float16, Float64(x))
+
+    Float16(x::Float32) = fptrunc(Float16, x)
+    Float16(x::Float64) = fptrunc(Float16, x)
+    Float32(x::Float64) = fptrunc(Float32, x)
+
+    Float32(x::Float16) = fpext(Float32, x)
+    Float64(x::Float32) = fpext(Float64, x)
+    Float64(x::Float16) = fpext(Float64, x)
+
+    AbstractFloat(x::Bool)    = Float64(x)
+    AbstractFloat(x::Int8)    = Float64(x)
+    AbstractFloat(x::Int16)   = Float64(x)
+    AbstractFloat(x::Int32)   = Float64(x)
+    AbstractFloat(x::Int64)   = Float64(x) # LOSSY
+    AbstractFloat(x::Int128)  = Float64(x) # LOSSY
+    AbstractFloat(x::UInt8)   = Float64(x)
+    AbstractFloat(x::UInt16)  = Float64(x)
+    AbstractFloat(x::UInt32)  = Float64(x)
+    AbstractFloat(x::UInt64)  = Float64(x) # LOSSY
+    AbstractFloat(x::UInt128) = Float64(x) # LOSSY
+
+    Bool(x::Float16) = x==0 ? false : x==1 ? true : throw(InexactError(:Bool, Bool, x))
+
 end
-
-# TODO: optimize
-Float16(x::UInt128) = convert(Float16, Float64(x))
-Float16(x::Int128)  = convert(Float16, Float64(x))
-
-Float16(x::Float32) = fptrunc(Float16, x)
-Float16(x::Float64) = fptrunc(Float16, x)
-Float32(x::Float64) = fptrunc(Float32, x)
-
-Float32(x::Float16) = fpext(Float32, x)
-Float64(x::Float32) = fpext(Float64, x)
-Float64(x::Float16) = fpext(Float64, x)
-
-AbstractFloat(x::Bool)    = Float64(x)
-AbstractFloat(x::Int8)    = Float64(x)
-AbstractFloat(x::Int16)   = Float64(x)
-AbstractFloat(x::Int32)   = Float64(x)
-AbstractFloat(x::Int64)   = Float64(x) # LOSSY
-AbstractFloat(x::Int128)  = Float64(x) # LOSSY
-AbstractFloat(x::UInt8)   = Float64(x)
-AbstractFloat(x::UInt16)  = Float64(x)
-AbstractFloat(x::UInt32)  = Float64(x)
-AbstractFloat(x::UInt64)  = Float64(x) # LOSSY
-AbstractFloat(x::UInt128) = Float64(x) # LOSSY
-
-Bool(x::Float16) = x==0 ? false : x==1 ? true : throw(InexactError(:Bool, Bool, x))
 
 """
     float(x)

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -20,11 +20,11 @@ using .Base:
 using .Core
 using Core: @doc
 
-using Base:
+using .Base:
     cld, fld, resize!, IndexCartesian, Checked
 using .Checked: checked_mul
 
-import Base:
+import .Base:
     first, last,
     isempty, length, size, axes, ndims,
     eltype, IteratorSize, IteratorEltype, promote_typejoin,

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -112,43 +112,47 @@ julia> (; t.x)
 """
 Core.NamedTuple
 
-@eval function (NT::Type{NamedTuple{names,T}})(args::Tuple) where {names, T <: Tuple}
-    if length(args) != length(names::Tuple)
-        throw(ArgumentError("Wrong number of arguments to named tuple constructor."))
+if ALLOW_CORE_PIRACY
+
+    @eval function (NT::Type{NamedTuple{names,T}})(args::Tuple) where {names, T <: Tuple}
+        if length(args) != length(names::Tuple)
+            throw(ArgumentError("Wrong number of arguments to named tuple constructor."))
+        end
+        # Note T(args) might not return something of type T; e.g.
+        # Tuple{Type{Float64}}((Float64,)) returns a Tuple{DataType}
+        $(Expr(:splatnew, :NT, :(T(args))))
     end
-    # Note T(args) might not return something of type T; e.g.
-    # Tuple{Type{Float64}}((Float64,)) returns a Tuple{DataType}
-    $(Expr(:splatnew, :NT, :(T(args))))
-end
 
-function (NT::Type{NamedTuple{names, T}})(nt::NamedTuple) where {names, T <: Tuple}
-    if @generated
-        Expr(:new, :NT,
-             Any[ :(let Tn = fieldtype(NT, $n),
-                      ntn = getfield(nt, $(QuoteNode(names[n])))
-                      ntn isa Tn ? ntn : convert(Tn, ntn)
-                  end) for n in 1:length(names) ]...)
-    else
-        NT(map(Fix1(getfield, nt), names))
+    function (NT::Type{NamedTuple{names, T}})(nt::NamedTuple) where {names, T <: Tuple}
+        if @generated
+            Expr(:new, :NT,
+                 Any[ :(let Tn = fieldtype(NT, $n),
+                          ntn = getfield(nt, $(QuoteNode(names[n])))
+                          ntn isa Tn ? ntn : convert(Tn, ntn)
+                      end) for n in 1:length(names) ]...)
+        else
+            NT(map(Fix1(getfield, nt), names))
+        end
     end
-end
 
-function NamedTuple{names}(nt::NamedTuple) where {names}
-    if @generated
-        idx = Int[ fieldindex(nt, names[n]) for n in 1:length(names) ]
-        types = Tuple{(fieldtype(nt, idx[n]) for n in 1:length(idx))...}
-        Expr(:new, :(NamedTuple{names, $types}), Any[ :(getfield(nt, $(idx[n]))) for n in 1:length(idx) ]...)
-    else
-        length_names = length(names::Tuple)
-        types = Tuple{(fieldtype(typeof(nt), names[n]) for n in 1:length_names)...}
-        _new_NamedTuple(NamedTuple{names, types}, map(Fix1(getfield, nt), names))
+    function NamedTuple{names}(nt::NamedTuple) where {names}
+        if @generated
+            idx = Int[ fieldindex(nt, names[n]) for n in 1:length(names) ]
+            types = Tuple{(fieldtype(nt, idx[n]) for n in 1:length(idx))...}
+            Expr(:new, :(NamedTuple{names, $types}), Any[ :(getfield(nt, $(idx[n]))) for n in 1:length(idx) ]...)
+        else
+            length_names = length(names::Tuple)
+            types = Tuple{(fieldtype(typeof(nt), names[n]) for n in 1:length_names)...}
+            _new_NamedTuple(NamedTuple{names, types}, map(Fix1(getfield, nt), names))
+        end
     end
+
+    (NT::Type{NamedTuple{names, T}})(itr) where {names, T <: Tuple} = NT(T(itr))
+    (NT::Type{NamedTuple{names}})(itr) where {names} = NT(Tuple(itr))
+
+    NamedTuple(itr) = (; itr...)
+
 end
-
-(NT::Type{NamedTuple{names, T}})(itr) where {names, T <: Tuple} = NT(T(itr))
-(NT::Type{NamedTuple{names}})(itr) where {names} = NT(Tuple(itr))
-
-NamedTuple(itr) = (; itr...)
 
 # Like NamedTuple{names, T} as a constructor, but omits the additional
 # `convert` call, when the types are known to match the fields
@@ -192,8 +196,12 @@ function convert(::Type{NT}, nt::NamedTuple{names}) where {names, NT<:NamedTuple
     return NT1(T1(nt))::NT1::NT
 end
 
-Tuple(nt::NamedTuple) = (nt...,)
-(::Type{T})(nt::NamedTuple) where {T <: Tuple} = (t = Tuple(nt); t isa T ? t : convert(T, t)::T)
+if ALLOW_CORE_PIRACY
+
+    Tuple(nt::NamedTuple) = (nt...,)
+    (::Type{T})(nt::NamedTuple) where {T <: Tuple} = (t = Tuple(nt); t isa T ? t : convert(T, t)::T)
+
+end
 
 function show(io::IO, t::NamedTuple)
     n = nfields(t)

--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -141,7 +141,9 @@ function unsafe_convert(::Type{Ptr{Any}}, b::RefArray{Any})::Ptr{Any}
 end
 
 ###
-if is_primary_base_module
+
+if ALLOW_CORE_PIRACY
+
     Ref(x::Any) = RefValue(x)
     Ref{T}() where {T} = RefValue{T}() # Ref{T}()
     Ref{T}(x) where {T} = RefValue{T}(x) # Ref{T}(x)
@@ -171,6 +173,7 @@ if is_primary_base_module
         end
     end
     Ref(x::AbstractArray, i::Integer) = RefArray(x, i)
+
 end
 
 cconvert(::Type{Ptr{P}}, a::Array{<:Union{Ptr,Cwstring,Cstring}}) where {P<:Union{Ptr,Cwstring,Cstring}} = getfield(a, :ref)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -445,12 +445,16 @@ function tuple_type_tail(T::Type)
     end
 end
 
-(::Type{T})(x::Tuple) where {T<:Tuple} = x isa T ? x : convert(T, x)  # still use `convert` for tuples
+if ALLOW_CORE_PIRACY
 
-Tuple(x::Ref) = tuple(getindex(x))  # faster than iterator for one element
-Tuple(x::Array{T,0}) where {T} = tuple(getindex(x))
+    (::Type{T})(x::Tuple) where {T<:Tuple} = x isa T ? x : convert(T, x)  # still use `convert` for tuples
 
-(::Type{T})(itr) where {T<:Tuple} = _totuple(T, itr)
+    Tuple(x::Ref) = tuple(getindex(x))  # faster than iterator for one element
+    Tuple(x::Array{T,0}) where {T} = tuple(getindex(x))
+
+    (::Type{T})(itr) where {T<:Tuple} = _totuple(T, itr)
+
+end
 
 _totuple(::Type{Tuple{}}, itr, s...) = ()
 


### PR DESCRIPTION
The idea here is to be able to do something like:
```julia
baremodule ReBase; end
Core.include(ReBase, "base/Base_compiler.jl")
# rest of bootstrap ...
```

to smoke test JuliaLowering.

Changes:
  - Separate any type-pirating methods (at least those I was able to find) over `Core` types
  - Define Base as a `baremodule` to avoid re-importing `include` if you try to "re-include" Base into another module at runtime
  - Import using `.Base` rather than `Base` to avoid confusion with "true" Base

This may or may not be very useful for bootstrap in the end, but it's nice to have the type-piracy made explicit and useful for JuliaLowering to be able to run over Base and catch a few extra bugs.

I recommend you review with whitespace ignored.