### PR TITLE
REPL: defensively enable cursor on every prompt

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -3057,6 +3057,7 @@ function prompt!(term::TextTerminal, prompt::ModalInterface, s::MIState = init_s
     enable_bracketed_paste(term)
     try
         activate(prompt, s, term, term)
+        print(term, "\e[?25h") # ensure cursor is visible (DECTCEM)
         # Notify that prompt is ready for input
         if s.prompt_ready_event !== nothing
             notify(s.prompt_ready_event)


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/60943 has introduced a bug where the cursor isn't reenabled on exit (#61470 ), but I think it makes sense for the REPL to be defensive on keeping the cursor visible.

I haven't checked impact on tests yet. Leaving that to CI