### PR TITLE
JuliaLowering: Reject duplicate field names in struct definitions

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -3203,7 +3203,7 @@ function _collect_struct_fields(ctx, field_names, field_types, field_attrs, fiel
                 # Struct field
                 for prev in field_names
                     if prev.name_val == m.name.name_val
-                        throw(LoweringError(m.name, "duplicate field name: \"$(m.name.name_val)\" is not unique"))
+                        throw(LoweringError(m.name, "duplicate field name"))
                     end
                 end
                 push!(field_names, m.name)

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -3201,6 +3201,11 @@ function _collect_struct_fields(ctx, field_names, field_types, field_attrs, fiel
             m = _match_struct_field(e)
             if !isnothing(m)
                 # Struct field
+                for prev in field_names
+                    if prev.name_val == m.name.name_val
+                        throw(LoweringError(m.name, "duplicate field name: \"$(m.name.name_val)\" is not unique"))
+                    end
+                end
                 push!(field_names, m.name)
                 n = length(field_names)
                 push!(field_types, isnothing(m.type) ? @ast(ctx, e, "Any"::K"core") : m.type)

--- a/JuliaLowering/test/typedefs.jl
+++ b/JuliaLowering/test/typedefs.jl
@@ -448,6 +448,11 @@ JuliaLowering.include_string(test_mod, "const orig_P36104 = P36104")
 JuliaLowering.include_string(test_mod, "primitive type P36104 16 end")
 @test test_mod.P36104 !== test_mod.orig_P36104
 
+# Duplicate field names should be rejected
+@test_throws LoweringError JuliaLowering.include_string(test_mod, "struct DupField; x; x; end")
+@test_throws LoweringError JuliaLowering.include_string(test_mod, "struct DupField2; x::Int; x::String; end")
+@test_throws LoweringError JuliaLowering.include_string(test_mod, "mutable struct DupField3; x; y; x; end")
+
 # Struct with outer constructor where one typevar is constrained by the other
 # See https://github.com/JuliaLang/julia/issues/27269)
 @test JuliaLowering.include_string(test_mod, """

--- a/JuliaLowering/test/typedefs_ir.jl
+++ b/JuliaLowering/test/typedefs_ir.jl
@@ -1370,3 +1370,27 @@ end
 47  (call top._defaultctors %₄₅ %₄₆)
 48  latestworld
 49  (return core.nothing)
+
+########################################
+# Error: Duplicate field name in struct
+struct A; x; x; end
+#---------------------
+LoweringError:
+struct A; x; x; end
+#            ╙ ── duplicate field name
+
+########################################
+# Error: Duplicate field name with different types
+struct A; x::Int; x::String; end
+#---------------------
+LoweringError:
+struct A; x::Int; x::String; end
+#                 ╙ ── duplicate field name
+
+########################################
+# Error: Duplicate field name in mutable struct
+mutable struct A; x; y; x; end
+#---------------------
+LoweringError:
+mutable struct A; x; y; x; end
+#                       ╙ ── duplicate field name


### PR DESCRIPTION
The flisp lowerer reports an error for `struct A; x; x; end`, but JuliaLowering did not have an explicit check. The duplicate was only caught later as a "function argument name not unique" error during constructor generation, which was confusing.

Add an explicit check in `_collect_struct_fields` that throws a `LoweringError` with the same message format as flisp when a duplicate field name is encountered.