### PR TITLE
GC: permanently mark pkg/sysimage objects to speed up GC

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -72,6 +72,8 @@ struct GC_Num
     last_full_sweep::Int64
     # Timestamp of the last incremental GC sweep in nanoseconds
     last_incremental_sweep::Int64
+    # Number of tracked image objects referencing non-image objects
+    image_remset_size::Int64
 end
 
 gc_num() = ccall(:jl_gc_num, GC_Num, ())

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -745,13 +745,6 @@ void gc_time_pool_end(int sweep_full)
                    sweep_full ? "full" : "quick");
 }
 
-void gc_time_sysimg_end(uint64_t t0)
-{
-    double sweep_pool_sec = (jl_hrtime() - t0) / 1e9;
-    jl_safe_printf("GC sweep sysimg end %.2f ms\n",
-                   sweep_pool_sec * 1000);
-}
-
 static int64_t big_total;
 static int64_t big_freed;
 static int64_t big_reset;

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -694,6 +694,7 @@ void jl_print_gc_stats(JL_STREAM *s)
                    p2, p2 * 100.0 / REGION2_PG_COUNT,
                    p1, p1 * 100.0 / REGION1_PG_COUNT / p2,
                    p0, p0 * 100.0 / REGION0_PG_COUNT / p1);
+    jl_safe_printf("image remset\t%zu entries\n", image_remset.len);
 #ifdef _OS_LINUX_
     double gct = gc_num.total_time / 1e9;
     struct mallinfo mi = mallinfo();

--- a/src/gc-heap-snapshot.c
+++ b/src/gc-heap-snapshot.c
@@ -181,6 +181,7 @@ typedef struct {
     size_t internal_root_idx; // node index of the internal root node
     size_t _gc_root_idx; // node index of the GC roots node
     size_t _gc_finlist_root_idx; // node index of the GC finlist roots node
+    size_t _gc_image_node_idx; // node index of the combined [image] node
 } HeapSnapshot;
 
 // global heap snapshot, mutated by garbage collector
@@ -339,6 +340,28 @@ static void _add_synthetic_root_entries(HeapSnapshot *snapshot) JL_NOTSAFEPOINT
         snapshot->_gc_finlist_root_idx // to
     };
     serialize_edge(snapshot, root_to_gc_finlist_roots);
+
+    // Add a synthetic node representing all sysimage/pkgimage objects.
+    // Image objects are permanently marked and never traced by the GC mark
+    // phase, so we collapse them into a single node rather than recording
+    // their internal structure.
+    snapshot->_gc_image_node_idx = snapshot->num_nodes;
+    Node gc_image_node = {
+        (uint8_t)st_find_or_create(&snapshot->node_types, "synthetic"),
+        st_find_or_serialize(&snapshot->names, snapshot->strings, "[image]"), // name
+        snapshot->_gc_image_node_idx, // id
+        0, // size (image memory is not GC-managed)
+        0, // size_t trace_node_id (unused)
+        0 // int detachedness;  // 0 - unknown,  1 - attached;  2 - detached
+    };
+    serialize_node(snapshot, gc_image_node);
+    Edge root_to_image = {
+        (uint8_t)st_find_or_create(&snapshot->edge_types, "internal"),
+        st_find_or_serialize(&snapshot->names, snapshot->strings, "[image]"), // edge label
+        snapshot->internal_root_idx, // from
+        snapshot->_gc_image_node_idx // to
+    };
+    serialize_edge(snapshot, root_to_image);
 }
 
 // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L597-L597
@@ -441,6 +464,18 @@ size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
 
     if (ios_need_close)
         ios_close(&str_);
+
+    // Image objects are permanently marked and never traced by the GC mark
+    // phase, so they would otherwise appear as orphan nodes. Root them under
+    // the synthetic [image] node with a label indicating which image they belong to.
+    if (jl_astaggedvalue(a)->bits.in_image) {
+        jl_value_t *top_mod = jl_object_top_module(a);
+        const char *label = "[image]";
+        if (top_mod != (jl_value_t*)jl_nothing && jl_is_module((jl_module_t*)top_mod))
+            label = jl_symbol_name_(((jl_module_t*)top_mod)->name);
+        _record_gc_just_edge("internal", g_snapshot->_gc_image_node_idx, idx,
+                             st_find_or_serialize(&g_snapshot->names, g_snapshot->strings, label));
+    }
 
     return idx;
 }

--- a/src/gc-interface.h
+++ b/src/gc-interface.h
@@ -96,6 +96,8 @@ typedef struct {
     uint64_t last_full_sweep;
     // Timestamp of the last incremental GC sweep in nanoseconds
     uint64_t last_incremental_sweep;
+    // Number of tracked image objects referencing non-image objects
+    uint64_t image_remset_size;
 } jl_gc_num_t;
 
 // ========================================================================= //

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -2971,6 +2971,9 @@ JL_DLLEXPORT jl_gc_num_t jl_gc_num(void)
 {
     jl_gc_num_t num = gc_num;
     combine_thread_gc_counts(&num, 0);
+    JL_LOCK_NOGC(&image_remset_lock);
+    num.image_remset_size = image_remset.len;
+    JL_UNLOCK_NOGC(&image_remset_lock);
     return num;
 }
 

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -1488,13 +1488,6 @@ static void gc_sweep_pool(void) JL_NOTSAFEPOINT
     gc_time_pool_end(current_sweep_full);
 }
 
-static void gc_sweep_perm_alloc(void) JL_NOTSAFEPOINT
-{
-    uint64_t t0 = jl_hrtime();
-    gc_sweep_sysimg();
-    gc_time_sysimg_end(t0);
-}
-
 // mark phase
 
 JL_DLLEXPORT void jl_gc_queue_root(const jl_value_t *ptr)
@@ -1509,6 +1502,20 @@ JL_DLLEXPORT void jl_gc_queue_root(const jl_value_t *ptr)
     if (header & GC_OLD) { // write barrier has not been triggered in this object yet
         arraylist_push(&ptls->gc_tls.heap.remset, (jl_value_t*)ptr);
         ptls->gc_tls.heap.remset_nptr++; // conservative
+        // Permanently-marked image objects that are mutated need to be
+        // persistently tracked, since they would otherwise be skipped
+        // during the mark phase. The image_remset is append-only, so
+        // this object will be re-scanned every GC cycle hereafter.
+        // Deduplication via image_remset prevents unbounded growth
+        // from repeated mutations of the same image object.
+        if (__unlikely(o->bits.in_image)) {
+            JL_LOCK_NOGC(&image_remset_lock);
+            if (ptrhash_get(&image_remset, (void*)ptr) == HT_NOTFOUND) {
+                ptrhash_put(&image_remset, (void*)ptr, (void*)ptr);
+                arraylist_push(&image_remset_list, (void*)ptr);
+            }
+            JL_UNLOCK_NOGC(&image_remset_lock);
+        }
     }
 }
 
@@ -2835,6 +2842,22 @@ static void gc_queue_remset(jl_gc_markqueue_t *mq, jl_ptls_t ptls2) JL_NOTSAFEPO
     ptls2->gc_tls.heap.remset_nptr = 0;
 }
 
+// Queue image objects with cross-heap references for marking.
+// These are persistent (never cleared) so that image objects that reference
+// non-image objects are always re-scanned, even though the image objects
+// themselves are permanently marked and would otherwise be skipped.
+static void gc_queue_image_remset(jl_gc_markqueue_t *mq) JL_NOTSAFEPOINT
+{
+    size_t len = image_remset_list.len;
+    void **items = image_remset_list.items;
+    for (size_t i = 0; i < len; i++) {
+        void *_v = items[i];
+        jl_astaggedvalue(_v)->bits.gc = GC_OLD_MARKED;
+        jl_value_t *v = (jl_value_t *)((uintptr_t)_v | GC_REMSET_PTR_TAG);
+        gc_ptr_queue_push(mq, v);
+    }
+}
+
 static void gc_check_all_remsets_are_empty(void) JL_NOTSAFEPOINT
 {
     for (int i = 0; i < gc_n_threads; i++) {
@@ -3094,6 +3117,12 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
             }
         }
         gc_check_all_remsets_are_empty();
+        // 1.4. queue image objects with cross-heap references.
+        // Only needed after a full sweep (which clears non-image objects'
+        // mark bits). After quick sweeps, old objects retain their marks,
+        // so children of image_remset entries survive without re-tracing.
+        if (prev_sweep_full)
+            gc_queue_image_remset(mq);
 
         // 2. walk roots
         gc_mark_roots(mq);
@@ -3221,8 +3250,6 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
         gc_scrub();
         gc_verify_tags();
         gc_sweep_pool();
-        if (sweep_full)
-            gc_sweep_perm_alloc();
     }
 
     JL_PROBE_GC_SWEEP_END();
@@ -3745,6 +3772,9 @@ void jl_gc_init(void)
 {
     JL_MUTEX_INIT(&heapsnapshot_lock, "heapsnapshot_lock");
     JL_MUTEX_INIT(&finalizers_lock, "finalizers_lock");
+    JL_MUTEX_INIT(&image_remset_lock, "image_remset_lock");
+    htable_new(&image_remset, 0);
+    arraylist_new(&image_remset_list, 0);
     uv_mutex_init(&page_profile_lock);
     uv_mutex_init(&gc_perm_lock);
     uv_mutex_init(&gc_pages_lock);

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -1502,19 +1502,15 @@ JL_DLLEXPORT void jl_gc_queue_root(const jl_value_t *ptr)
     if (header & GC_OLD) { // write barrier has not been triggered in this object yet
         arraylist_push(&ptls->gc_tls.heap.remset, (jl_value_t*)ptr);
         ptls->gc_tls.heap.remset_nptr++; // conservative
-        // Permanently-marked image objects that are mutated need to be
-        // persistently tracked, since they would otherwise be skipped
-        // during the mark phase. The image_remset is append-only, so
-        // this object will be re-scanned every GC cycle hereafter.
-        // Deduplication via image_remset prevents unbounded growth
-        // from repeated mutations of the same image object.
-        if (__unlikely(o->bits.in_image)) {
-            JL_LOCK_NOGC(&image_remset_lock);
-            if (ptrhash_get(&image_remset, (void*)ptr) == HT_NOTFOUND) {
-                ptrhash_put(&image_remset, (void*)ptr, (void*)ptr);
-                arraylist_push(&image_remset_list, (void*)ptr);
+        // Image objects are analogous to a third "permanent" GC
+        // generation, so here we maintain the remset for them.
+        if (__unlikely((header & GC_IN_IMAGE) && !(header & GC_IN_IMAGE_REMSET))) {
+            header = jl_atomic_fetch_or_relaxed((_Atomic(uintptr_t) *)&o->header, GC_IN_IMAGE_REMSET);
+            if (!(header & GC_IN_IMAGE_REMSET)) {
+                JL_LOCK_NOGC(&image_remset_lock);
+                arraylist_push(&image_remset, (void*)ptr);
+                JL_UNLOCK_NOGC(&image_remset_lock);
             }
-            JL_UNLOCK_NOGC(&image_remset_lock);
         }
     }
 }
@@ -2842,17 +2838,12 @@ static void gc_queue_remset(jl_gc_markqueue_t *mq, jl_ptls_t ptls2) JL_NOTSAFEPO
     ptls2->gc_tls.heap.remset_nptr = 0;
 }
 
-// Queue image objects with cross-heap references for marking.
-// These are persistent (never cleared) so that image objects that reference
-// non-image objects are always re-scanned, even though the image objects
-// themselves are permanently marked and would otherwise be skipped.
 static void gc_queue_image_remset(jl_gc_markqueue_t *mq) JL_NOTSAFEPOINT
 {
-    size_t len = image_remset_list.len;
-    void **items = image_remset_list.items;
+    size_t len = image_remset.len;
+    void **items = image_remset.items;
     for (size_t i = 0; i < len; i++) {
         void *_v = items[i];
-        jl_astaggedvalue(_v)->bits.gc = GC_OLD_MARKED;
         jl_value_t *v = (jl_value_t *)((uintptr_t)_v | GC_REMSET_PTR_TAG);
         gc_ptr_queue_push(mq, v);
     }
@@ -3117,10 +3108,8 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
             }
         }
         gc_check_all_remsets_are_empty();
-        // 1.4. queue image objects with cross-heap references.
-        // Only needed after a full sweep (which clears non-image objects'
-        // mark bits). After quick sweeps, old objects retain their marks,
-        // so children of image_remset entries survive without re-tracing.
+        // 1.4. in a full sweep, enqueue image remset
+        // (image objects are a third, "permanent" GC generation)
         if (prev_sweep_full)
             gc_queue_image_remset(mq);
 
@@ -3773,8 +3762,7 @@ void jl_gc_init(void)
     JL_MUTEX_INIT(&heapsnapshot_lock, "heapsnapshot_lock");
     JL_MUTEX_INIT(&finalizers_lock, "finalizers_lock");
     JL_MUTEX_INIT(&image_remset_lock, "image_remset_lock");
-    htable_new(&image_remset, 0);
-    arraylist_new(&image_remset_list, 0);
+    arraylist_new(&image_remset, 0);
     uv_mutex_init(&page_profile_lock);
     uv_mutex_init(&gc_perm_lock);
     uv_mutex_init(&gc_pages_lock);

--- a/src/gc-stock.h
+++ b/src/gc-stock.h
@@ -607,8 +607,6 @@ void gc_final_pause_end(int64_t t0, int64_t tend);
 void gc_time_pool_start(void) JL_NOTSAFEPOINT;
 void gc_time_count_page(int freedall, int pg_skpd) JL_NOTSAFEPOINT;
 void gc_time_pool_end(int sweep_full) JL_NOTSAFEPOINT;
-void gc_time_sysimg_end(uint64_t t0) JL_NOTSAFEPOINT;
-
 void gc_time_big_start(void) JL_NOTSAFEPOINT;
 void gc_time_count_big(int old_bits, int bits) JL_NOTSAFEPOINT;
 void gc_time_big_end(void) JL_NOTSAFEPOINT;
@@ -641,7 +639,6 @@ STATIC_INLINE void gc_time_count_page(int freedall, int pg_skpd) JL_NOTSAFEPOINT
     (void)pg_skpd;
 }
 #define gc_time_pool_end(sweep_full) (void)(sweep_full)
-#define gc_time_sysimg_end(t0) (void)(t0)
 #define gc_time_big_start()
 STATIC_INLINE void gc_time_count_big(int old_bits, int bits) JL_NOTSAFEPOINT
 {

--- a/src/gc-wb-stock.h
+++ b/src/gc-wb-stock.h
@@ -33,11 +33,12 @@ STATIC_INLINE void jl_gc_multi_wb(const void *parent, const jl_value_t *ptr) JL_
     // ptr is an immutable object
     if (__likely(jl_astaggedvalue(parent)->bits.gc != 3 /* GC_OLD_MARKED */))
         return; // parent is young or in remset
-    if (jl_astaggedvalue(parent)->bits.in_image == 1 /* GC_IN_IMAGE_NOT_REMSET */) {
-        jl_gc_queue_root((jl_value_t*)parent); // parent is in image
+    if (__unlikely(jl_astaggedvalue(parent)->bits.in_image == 1 /* GC_IN_IMAGE_NOT_REMSET */)) {
+        // GC_MARKED optimizations are invalid for generations >= 2
+        jl_gc_queue_root((jl_value_t*)parent);
         return;
     }
-    if (__likely(jl_astaggedvalue(ptr)->bits.gc == 3))
+    if (__likely(jl_astaggedvalue(ptr)->bits.gc == 3 /* GC_OLD_MARKED */))
         return; // ptr is old and not in remset (thus it does not point to young)
     jl_datatype_t *dt = (jl_datatype_t*)jl_typeof(ptr);
     const jl_datatype_layout_t *ly = dt->layout;
@@ -52,14 +53,18 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const jl_value_t *dest_owne
     if (__unlikely(jl_astaggedvalue(dest_owner)->bits.gc == 3 /* GC_OLD_MARKED */ )) {
         jl_value_t *src_owner = jl_genericmemory_owner(src);
         size_t done = 0;
-        int in_image = jl_astaggedvalue(dest_owner)->bits.in_image == 1; /* GC_IN_IMAGE_NOT_REMSET */
-        if (in_image || jl_astaggedvalue(src_owner)->bits.gc != 3 /* GC_OLD_MARKED */) {
+        if (__unlikely(jl_astaggedvalue(dest_owner)->bits.in_image == 1 /* GC_IN_IMAGE_NOT_REMSET */)) {
+            // GC_MARKED optimizations are invalid for generations >= 2
+            jl_gc_queue_root(dest_owner);
+            return;
+        }
+        if (jl_astaggedvalue(src_owner)->bits.gc != 3 /* GC_OLD_MARKED */) {
             if (dest_p < src_p || dest_p > src_p + (*n)) {
                 for (; done < (*n); done++) { // copy forwards
                     void *val = jl_atomic_load_relaxed(src_p + done);
                     jl_atomic_store_release(dest_p + done, val);
                     // `val` is young or old-unmarked (or dest is image and val is non-image)
-                    if (val && (in_image || !(jl_astaggedvalue(val)->bits.gc & 1 /* GC_MARKED */))) {
+                    if (val && !(jl_astaggedvalue(val)->bits.gc & 1 /* GC_MARKED */)) {
                         jl_gc_queue_root(dest_owner);
                         break;
                     }
@@ -72,7 +77,7 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const jl_value_t *dest_owne
                     void *val = jl_atomic_load_relaxed(src_p + (*n) - done - 1);
                     jl_atomic_store_release(dest_p + (*n) - done - 1, val);
                     // `val` is young or old-unmarked (or dest is image and val is non-image)
-                    if (val && (in_image || !(jl_astaggedvalue(val)->bits.gc & 1 /* GC_MARKED */))) {
+                    if (val && !(jl_astaggedvalue(val)->bits.gc & 1 /* GC_MARKED */)) {
                         jl_gc_queue_root(dest_owner);
                         break;
                     }
@@ -87,10 +92,14 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_ptr(const jl_value_t *owner, jl_g
                                           size_t n, jl_datatype_t *dt) JL_NOTSAFEPOINT
 {
     if (__unlikely(jl_astaggedvalue(owner)->bits.gc == 3 /* GC_OLD_MARKED */)) {
+        if (__unlikely(jl_astaggedvalue(owner)->bits.in_image == 1 /* GC_IN_IMAGE_NOT_REMSET */)) {
+            // GC_MARKED optimizations are invalid for generations >= 2
+            jl_gc_queue_root(owner);
+            return;
+        }
         jl_value_t *src_owner = jl_genericmemory_owner(src);
         size_t elsz = dt->layout->size;
-        if (jl_astaggedvalue(owner)->bits.in_image == 1 /* GC_IN_IMAGE_NOT_REMSET */ ||
-            jl_astaggedvalue(src_owner)->bits.gc != 3 /* GC_OLD_MARKED */) {
+        if (jl_astaggedvalue(src_owner)->bits.gc != 3 /* GC_OLD_MARKED */) {
             dt = (jl_datatype_t*)jl_tparam1(dt);
             for (size_t done = 0; done < n; done++) { // copy forwards
                 char* s = (char*)src_p+done*elsz;

--- a/src/gc-wb-stock.h
+++ b/src/gc-wb-stock.h
@@ -14,8 +14,8 @@ extern "C" {
 STATIC_INLINE void jl_gc_wb(const void *parent, const void *ptr) JL_NOTSAFEPOINT
 {
     // parent and ptr isa jl_value_t*
-    if (__unlikely(jl_astaggedvalue(parent)->bits.gc == 3 /* GC_OLD_MARKED */ &&
-                   (jl_astaggedvalue(parent)->bits.in_image || // image parents are never fully traced
+    if (__unlikely(jl_astaggedvalue(parent)->bits.gc == 3 /* GC_OLD_MARKED */ && // parent is old and not in remset
+                   (jl_astaggedvalue(parent)->bits.in_image == 1 /* GC_IN_IMAGE_NOT_REMSET */ || // parent in image and not in remset
                     (jl_astaggedvalue(ptr)->bits.gc & 1 /* GC_MARKED */) == 0))) // ptr is young
         jl_gc_queue_root((jl_value_t*)parent);
 }
@@ -30,11 +30,14 @@ STATIC_INLINE void jl_gc_wb_back(const void *ptr) JL_NOTSAFEPOINT // ptr isa jl_
 
 STATIC_INLINE void jl_gc_multi_wb(const void *parent, const jl_value_t *ptr) JL_NOTSAFEPOINT
 {
-    // 3 == GC_OLD_MARKED
     // ptr is an immutable object
-    if (__likely(jl_astaggedvalue(parent)->bits.gc != 3))
+    if (__likely(jl_astaggedvalue(parent)->bits.gc != 3 /* GC_OLD_MARKED */))
         return; // parent is young or in remset
-    if (__likely(jl_astaggedvalue(ptr)->bits.gc == 3 && !jl_astaggedvalue(parent)->bits.in_image))
+    if (jl_astaggedvalue(parent)->bits.in_image == 1 /* GC_IN_IMAGE_NOT_REMSET */) {
+        jl_gc_queue_root((jl_value_t*)parent); // parent is in image
+        return;
+    }
+    if (__likely(jl_astaggedvalue(ptr)->bits.gc == 3))
         return; // ptr is old and not in remset (thus it does not point to young)
     jl_datatype_t *dt = (jl_datatype_t*)jl_typeof(ptr);
     const jl_datatype_layout_t *ly = dt->layout;
@@ -49,7 +52,7 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const jl_value_t *dest_owne
     if (__unlikely(jl_astaggedvalue(dest_owner)->bits.gc == 3 /* GC_OLD_MARKED */ )) {
         jl_value_t *src_owner = jl_genericmemory_owner(src);
         size_t done = 0;
-        int in_image = jl_astaggedvalue(dest_owner)->bits.in_image;
+        int in_image = jl_astaggedvalue(dest_owner)->bits.in_image == 1; /* GC_IN_IMAGE_NOT_REMSET */
         if (in_image || jl_astaggedvalue(src_owner)->bits.gc != 3 /* GC_OLD_MARKED */) {
             if (dest_p < src_p || dest_p > src_p + (*n)) {
                 for (; done < (*n); done++) { // copy forwards
@@ -86,7 +89,7 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_ptr(const jl_value_t *owner, jl_g
     if (__unlikely(jl_astaggedvalue(owner)->bits.gc == 3 /* GC_OLD_MARKED */)) {
         jl_value_t *src_owner = jl_genericmemory_owner(src);
         size_t elsz = dt->layout->size;
-        if (jl_astaggedvalue(owner)->bits.in_image ||
+        if (jl_astaggedvalue(owner)->bits.in_image == 1 /* GC_IN_IMAGE_NOT_REMSET */ ||
             jl_astaggedvalue(src_owner)->bits.gc != 3 /* GC_OLD_MARKED */) {
             dt = (jl_datatype_t*)jl_tparam1(dt);
             for (size_t done = 0; done < n; done++) { // copy forwards

--- a/src/gc-wb-stock.h
+++ b/src/gc-wb-stock.h
@@ -14,8 +14,9 @@ extern "C" {
 STATIC_INLINE void jl_gc_wb(const void *parent, const void *ptr) JL_NOTSAFEPOINT
 {
     // parent and ptr isa jl_value_t*
-    if (__unlikely(jl_astaggedvalue(parent)->bits.gc == 3 /* GC_OLD_MARKED */ && // parent is old and not in remset
-                   (jl_astaggedvalue(ptr)->bits.gc & 1 /* GC_MARKED */) == 0)) // ptr is young
+    if (__unlikely(jl_astaggedvalue(parent)->bits.gc == 3 /* GC_OLD_MARKED */ &&
+                   (jl_astaggedvalue(parent)->bits.in_image || // image parents are never fully traced
+                    (jl_astaggedvalue(ptr)->bits.gc & 1 /* GC_MARKED */) == 0))) // ptr is young
         jl_gc_queue_root((jl_value_t*)parent);
 }
 
@@ -33,7 +34,7 @@ STATIC_INLINE void jl_gc_multi_wb(const void *parent, const jl_value_t *ptr) JL_
     // ptr is an immutable object
     if (__likely(jl_astaggedvalue(parent)->bits.gc != 3))
         return; // parent is young or in remset
-    if (__likely(jl_astaggedvalue(ptr)->bits.gc == 3))
+    if (__likely(jl_astaggedvalue(ptr)->bits.gc == 3 && !jl_astaggedvalue(parent)->bits.in_image))
         return; // ptr is old and not in remset (thus it does not point to young)
     jl_datatype_t *dt = (jl_datatype_t*)jl_typeof(ptr);
     const jl_datatype_layout_t *ly = dt->layout;
@@ -48,13 +49,14 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const jl_value_t *dest_owne
     if (__unlikely(jl_astaggedvalue(dest_owner)->bits.gc == 3 /* GC_OLD_MARKED */ )) {
         jl_value_t *src_owner = jl_genericmemory_owner(src);
         size_t done = 0;
-        if (jl_astaggedvalue(src_owner)->bits.gc != 3 /* GC_OLD_MARKED */) {
+        int in_image = jl_astaggedvalue(dest_owner)->bits.in_image;
+        if (in_image || jl_astaggedvalue(src_owner)->bits.gc != 3 /* GC_OLD_MARKED */) {
             if (dest_p < src_p || dest_p > src_p + (*n)) {
                 for (; done < (*n); done++) { // copy forwards
                     void *val = jl_atomic_load_relaxed(src_p + done);
                     jl_atomic_store_release(dest_p + done, val);
-                    // `val` is young or old-unmarked
-                    if (val && !(jl_astaggedvalue(val)->bits.gc & 1 /* GC_MARKED */)) {
+                    // `val` is young or old-unmarked (or dest is image and val is non-image)
+                    if (val && (in_image || !(jl_astaggedvalue(val)->bits.gc & 1 /* GC_MARKED */))) {
                         jl_gc_queue_root(dest_owner);
                         break;
                     }
@@ -66,8 +68,8 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const jl_value_t *dest_owne
                 for (; done < (*n); done++) { // copy backwards
                     void *val = jl_atomic_load_relaxed(src_p + (*n) - done - 1);
                     jl_atomic_store_release(dest_p + (*n) - done - 1, val);
-                    // `val` is young or old-unmarked
-                    if (val && !(jl_astaggedvalue(val)->bits.gc & 1 /* GC_MARKED */)) {
+                    // `val` is young or old-unmarked (or dest is image and val is non-image)
+                    if (val && (in_image || !(jl_astaggedvalue(val)->bits.gc & 1 /* GC_MARKED */))) {
                         jl_gc_queue_root(dest_owner);
                         break;
                     }
@@ -84,7 +86,8 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_ptr(const jl_value_t *owner, jl_g
     if (__unlikely(jl_astaggedvalue(owner)->bits.gc == 3 /* GC_OLD_MARKED */)) {
         jl_value_t *src_owner = jl_genericmemory_owner(src);
         size_t elsz = dt->layout->size;
-        if (jl_astaggedvalue(src_owner)->bits.gc != 3 /* GC_OLD_MARKED */) {
+        if (jl_astaggedvalue(owner)->bits.in_image ||
+            jl_astaggedvalue(src_owner)->bits.gc != 3 /* GC_OLD_MARKED */) {
             dt = (jl_datatype_t*)jl_tparam1(dt);
             for (size_t done = 0; done < n; done++) { // copy forwards
                 char* s = (char*)src_p+done*elsz;

--- a/src/julia.h
+++ b/src/julia.h
@@ -90,8 +90,7 @@ extern "C" {
 
 struct _jl_taggedvalue_bits {
     uintptr_t gc:2;
-    uintptr_t in_image:1;
-    uintptr_t unused:1;
+    uintptr_t in_image:2;
 #ifdef _P64
     uintptr_t tag:60;
 #else

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -534,7 +534,9 @@ jl_value_t *jl_gc_small_alloc_noinline(jl_ptls_t ptls, int offset,
                                    int osize);
 jl_value_t *jl_gc_big_alloc_noinline(jl_ptls_t ptls, size_t allocsz);
 JL_DLLEXPORT int jl_gc_classify_pools(size_t sz, int *osize) JL_NOTSAFEPOINT;
-void gc_sweep_sysimg(void) JL_NOTSAFEPOINT;
+extern htable_t image_remset;
+extern arraylist_t image_remset_list;
+extern jl_mutex_t image_remset_lock;
 
 
 // pools are 16376 bytes large (GC_POOL_SZ - GC_PAGE_OFFSET)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -422,8 +422,11 @@ static inline void memassign_safe(int hasptr, char *dst, const jl_value_t *src, 
 #define GC_CLEAN  0 // freshly allocated
 #define GC_MARKED 1 // reachable and young
 #define GC_OLD    2 // if it is reachable it will be marked as old
-#define GC_OLD_MARKED (GC_OLD | GC_MARKED) // reachable and old
 #define GC_IN_IMAGE 4
+#define GC_IN_IMAGE_REMSET 8
+
+#define GC_OLD_MARKED (GC_OLD | GC_MARKED) // reachable and old
+#define GC_IN_IMAGE_NOT_REMSET (GC_IN_IMAGE) // permalloc'd and not yet modified
 
 // data structures for runtime codegen
 typedef struct _jl_abi_t {
@@ -534,10 +537,8 @@ jl_value_t *jl_gc_small_alloc_noinline(jl_ptls_t ptls, int offset,
                                    int osize);
 jl_value_t *jl_gc_big_alloc_noinline(jl_ptls_t ptls, size_t allocsz);
 JL_DLLEXPORT int jl_gc_classify_pools(size_t sz, int *osize) JL_NOTSAFEPOINT;
-extern htable_t image_remset;
-extern arraylist_t image_remset_list;
+extern arraylist_t image_remset;
 extern jl_mutex_t image_remset_lock;
-
 
 // pools are 16376 bytes large (GC_POOL_SZ - GC_PAGE_OFFSET)
 static const int jl_gc_sizeclasses[] = {

--- a/src/llvm-final-gc-lowering-stock.cpp
+++ b/src/llvm-final-gc-lowering-stock.cpp
@@ -58,10 +58,11 @@ void FinalLowerGC::lowerWriteBarrier(CallInst *target, Function &F) {
     auto mayTrigTerm = SplitBlockAndInsertIfThen(parOldMarked, target, false);
     builder.SetInsertPoint(mayTrigTerm);
     mayTrigTerm->getParent()->setName("may_trigger_wb");
-    // Image parents are never fully traced by the mark phase, so we must
-    // always trigger the write barrier regardless of the child's mark bits.
-    auto parInImage = builder.CreateAnd(parTag, ConstantInt::get(T_size, GC_IN_IMAGE), "parent_in_image");
-    auto parIsImage = builder.CreateICmpNE(parInImage, ConstantInt::get(T_size, 0), "parent_is_image");
+    // At every generational boundary above the youngest, the "child marked"
+    // optimization does not apply so we can only check whether the parent
+    // is already in the relevant remset or not.
+    auto parInImage = builder.CreateAnd(parTag, ConstantInt::get(T_size, GC_IN_IMAGE | GC_IN_IMAGE_REMSET), "parent_in_image");
+    auto parIsImage = builder.CreateICmpEQ(parInImage, ConstantInt::get(T_size, GC_IN_IMAGE), "parent_is_image");
     Value *anyChldNotMarked = NULL;
     for (unsigned i = 1; i < target->arg_size(); i++) {
         Value *child = target->getArgOperand(i);

--- a/src/llvm-final-gc-lowering-stock.cpp
+++ b/src/llvm-final-gc-lowering-stock.cpp
@@ -52,11 +52,16 @@ void FinalLowerGC::lowerWriteBarrier(CallInst *target, Function &F) {
     auto parent = target->getArgOperand(0);
     IRBuilder<> builder(target);
     builder.SetCurrentDebugLocation(target->getDebugLoc());
-    auto parBits = builder.CreateAnd(EmitLoadTag(builder, T_size, parent, tbaa_tag), GC_OLD_MARKED, "parent_bits");
+    auto parTag = EmitLoadTag(builder, T_size, parent, tbaa_tag);
+    auto parBits = builder.CreateAnd(parTag, GC_OLD_MARKED, "parent_bits");
     auto parOldMarked = builder.CreateICmpEQ(parBits, ConstantInt::get(T_size, GC_OLD_MARKED), "parent_old_marked");
     auto mayTrigTerm = SplitBlockAndInsertIfThen(parOldMarked, target, false);
     builder.SetInsertPoint(mayTrigTerm);
     mayTrigTerm->getParent()->setName("may_trigger_wb");
+    // Image parents are never fully traced by the mark phase, so we must
+    // always trigger the write barrier regardless of the child's mark bits.
+    auto parInImage = builder.CreateAnd(parTag, ConstantInt::get(T_size, GC_IN_IMAGE), "parent_in_image");
+    auto parIsImage = builder.CreateICmpNE(parInImage, ConstantInt::get(T_size, 0), "parent_is_image");
     Value *anyChldNotMarked = NULL;
     for (unsigned i = 1; i < target->arg_size(); i++) {
         Value *child = target->getArgOperand(i);
@@ -65,9 +70,10 @@ void FinalLowerGC::lowerWriteBarrier(CallInst *target, Function &F) {
         anyChldNotMarked = anyChldNotMarked ? builder.CreateOr(anyChldNotMarked, chldNotMarked) : chldNotMarked;
     }
     assert(anyChldNotMarked); // handled by all_of test above
+    auto shouldTrigger = builder.CreateOr(parIsImage, anyChldNotMarked, "should_trigger_wb");
     MDBuilder MDB(parent->getContext());
     SmallVector<uint32_t, 2> Weights{1, 9};
-    auto trigTerm = SplitBlockAndInsertIfThen(anyChldNotMarked, mayTrigTerm, false,
+    auto trigTerm = SplitBlockAndInsertIfThen(shouldTrigger, mayTrigTerm, false,
                                                 MDB.createBranchWeights(Weights));
     trigTerm->getParent()->setName("trigger_wb");
     builder.SetInsertPoint(trigTerm);

--- a/src/llvm-final-gc-lowering-stock.cpp
+++ b/src/llvm-final-gc-lowering-stock.cpp
@@ -62,7 +62,7 @@ void FinalLowerGC::lowerWriteBarrier(CallInst *target, Function &F) {
     // optimization does not apply so we can only check whether the parent
     // is already in the relevant remset or not.
     auto parInImage = builder.CreateAnd(parTag, ConstantInt::get(T_size, GC_IN_IMAGE | GC_IN_IMAGE_REMSET), "parent_in_image");
-    auto parIsImage = builder.CreateICmpEQ(parInImage, ConstantInt::get(T_size, GC_IN_IMAGE), "parent_is_image");
+    auto parIsImage = builder.CreateICmpEQ(parInImage, ConstantInt::get(T_size, GC_IN_IMAGE_NOT_REMSET), "parent_is_image");
     Value *anyChldNotMarked = NULL;
     for (unsigned i = 1; i < target->arg_size(); i++) {
         Value *child = target->getArgOperand(i);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2076,40 +2076,15 @@ static void jl_read_arraylist(ios_t *s, arraylist_t *list)
     ios_read(s, (char*)list->items, list_len * sizeof(void*));
 }
 
-void gc_sweep_sysimg(void) JL_NOTSAFEPOINT
-{
-    size_t nblobs = n_linkage_blobs();
-    if (nblobs == 0)
-        return;
-    for (size_t i = 0; i < nblobs; i++) {
-        image_metadata_t *meta = (image_metadata_t*)image_tree.ranges[i].data;
-        reloc_t *relocs = (reloc_t*)meta->relocs_base;
-        if (!relocs)
-            continue;
-        uintptr_t base = meta->base;
-        uintptr_t last_pos = 0;
-        uint8_t *current = (uint8_t *)relocs;
-        while (1) {
-            // Read the offset of the next object
-            size_t pos_diff = 0;
-            size_t cnt = 0;
-            while (1) {
-                int8_t c = *current++;
-                pos_diff |= ((size_t)c & 0x7F) << (7 * cnt++);
-                if ((c >> 7) == 0)
-                    break;
-            }
-            if (pos_diff == 0)
-                break;
-
-            uintptr_t pos = last_pos + pos_diff;
-            last_pos = pos;
-            jl_taggedvalue_t *o = (jl_taggedvalue_t *)(base + pos);
-            o->bits.gc = GC_OLD;
-            assert(o->bits.in_image == 1);
-        }
-    }
-}
+// Persistent set of image objects that reference non-image objects.
+// Processed as additional GC roots at the start of each full mark phase.
+// Maintained incrementally by jl_gc_queue_root when image objects are mutated.
+// Note: cross-heap refs created during pkgimage uniquing (types, method instances,
+// bindings) don't need tracking here because the uniqued objects are always rooted
+// through type caches, method specializations, or module binding tables.
+htable_t image_remset;
+arraylist_t image_remset_list;
+jl_mutex_t image_remset_lock;
 
 // jl_write_value and jl_read_value are used for storing Julia objects that are adjuncts to
 // the image proper. For example, new methods added to external callables require
@@ -3851,7 +3826,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     reloc_t *relocs_base = (reloc_t*)&relocs.buf[0];
 
     s.s = &sysimg;
-    jl_read_reloclist(&s, s.link_ids_gctags, GC_OLD | GC_IN_IMAGE); // gctags
+    jl_read_reloclist(&s, s.link_ids_gctags, GC_OLD_MARKED | GC_IN_IMAGE); // gctags
     size_t sizeof_tags = ios_pos(&relocs);
     (void)sizeof_tags;
     jl_read_reloclist(&s, s.link_ids_relocs, 0); // general relocs
@@ -3977,7 +3952,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
             arraylist_push(&cleanup_list, (void*)obj);
         }
         if (tag == 1)
-            *pfld = (uintptr_t)newobj | GC_OLD | GC_IN_IMAGE;
+            *pfld = (uintptr_t)newobj | GC_OLD_MARKED | GC_IN_IMAGE;
         else
             *pfld = (uintptr_t)newobj;
         assert(!(image_base < (char*)newobj && (char*)newobj <= image_base + sizeof_sysimg));

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2077,13 +2077,9 @@ static void jl_read_arraylist(ios_t *s, arraylist_t *list)
 }
 
 // Persistent set of image objects that reference non-image objects.
-// Processed as additional GC roots at the start of each full mark phase.
-// Maintained incrementally by jl_gc_queue_root when image objects are mutated.
-// Note: cross-heap refs created during pkgimage uniquing (types, method instances,
-// bindings) don't need tracking here because the uniqued objects are always rooted
-// through type caches, method specializations, or module binding tables.
-htable_t image_remset;
-arraylist_t image_remset_list;
+// Used to track GC reachability for mutable objects in the images,
+// treating them as a third, "permanent" GC generation.
+arraylist_t image_remset;
 jl_mutex_t image_remset_lock;
 
 // jl_write_value and jl_read_value are used for storing Julia objects that are adjuncts to


### PR DESCRIPTION
Image objects are already never freed and are ~somewhat rarely mutated, making them candidates for "pretenuring".

Load image objects as permanently marked (`GC_OLD_MARKED`) so `gc_try_setmark_tag` returns 0 immediately and the mark phase never enters the image subgraph. Maintain any mutations as a dedicated `image_remset` which effectively roots any "new" referents that are referred to by the image subgraph.

This significantly speeds up (full) GC pause times when dominated by immutable objects in the sysimage / pkgimage heaps:
```Julia
  GC full (not partial / quick) collection times:
  ┌───────────────────────────────┬─────────┬─────────┬─────────┐
  │           Benchmark           │ 1.12.5  │ Nightly │ This PR │
  ├───────────────────────────────┼─────────┼─────────┼─────────┤
  │ 1. Baseline (sysimage only)   │ 37.3 ms │ 40.3 ms │ 1.4 ms  │
  ├───────────────────────────────┼─────────┼─────────┼─────────┤
  │ 2. After loading packages     │ 39.4 ms │ 43.2 ms │ 3.4 ms  │
  ├───────────────────────────────┼─────────┼─────────┼─────────┤
  │ 3. Allocation pressure (1 MB) │ 40.0 ms │ 43.7 ms │ 3.5 ms  │ 
  ├───────────────────────────────┼─────────┼─────────┼─────────┤
  │ 4. Growing live set           │ 40.8 ms │ 43.8 ms │ 4.0 ms  │
  ├───────────────────────────────┼─────────┼─────────┼─────────┤
  │ 5. After method definitions   │ 40.5 ms │ 43.0 ms │ 4.1 ms  │
  ├───────────────────────────────┼─────────┼─────────┼─────────┤
  │ 6. Heavy JIT (eval in loop)   │ 42.3 ms │ 47.1 ms │ 7.4 ms  │
  ├───────────────────────────────┼─────────┼─────────┼─────────┤
  │ 7. Mixed 5-cycle pattern      │ 84.4 ms │ 93.3 ms │ 10.9 ms │
  ├───────────────────────────────┼─────────┼─────────┼─────────┤
  │ 8. Large transient (10 MB)    │ 41.8 ms │ 46.7 ms │ 4.4 ms  │
  └───────────────────────────────┴─────────┴─────────┴─────────┘
```

Partial / "quick" GC pause times are essentially unchanged. [Benchmark script](https://github.com/user-attachments/files/26420306/pretenure_stress.jl.txt)

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com> 🤖 
This commit is almost entirely written by Claude after laying out a plan together.

~~Draft because I think the sweep in `staticdata.c` is probably unnecessary. I'm hoping to remove that before this is ready for review.~~ (**edit:** done) This can likely also be generalized slightly to a "permalloc / pretenure" operation that applies to objects not necessarily in images. I'm not sure whether it'd be possible to "unfreeze" those objects once they are promoted to permalloc'd / pretenured though.