### PR TITLE
implement String(::Base.Generator) constructor

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -150,6 +150,23 @@ Array{UInt8}(s::String)  = Vector{UInt8}(codeunits(s))
 
 String(s::CodeUnits{UInt8,String}) = s.s
 
+"""
+    String(g::Base.Generator)
+
+Create a new `String` from a `Generator` by joining all elements.
+Each element is converted to a string via `print`, and the results are concatenated.
+
+# Examples
+```jldoctest
+julia> String(x for x in ['a', 'b', 'c'])
+"abc"
+
+julia> String(Iterators.map(identity, "hello"))
+"hello"
+```
+"""
+String(g::Generator) = join(g)
+
 ## low-level functions ##
 
 pointer(s::String) = unsafe_convert(Ptr{UInt8}, s)


### PR DESCRIPTION
## Summary

This PR implements a `String(::Base.Generator)` constructor, resolving the method error when attempting to call `String` on a Generator (e.g., from `Iterators.map`).

## Problem

Currently, calling `String(Iterators.map(c->c+1, "Hello, world"))` results in a method error because there is no `String` method that accepts a `Generator` argument.

## Solution

Add a new constructor:
```julia
String(g::Generator) = join(g)
```

This uses `join` to convert the Generator elements to a String, where each element is converted via `print`.

## Example Usage

```julia
# Before: MethodError
String(x for x in ["a", "b", "c"])  # Now works: "abc"

String(Iterators.map(identity, "hello"))  # Now works: "hello"
```

## Notes

- The implementation uses `join(g)` which is a well-established method for converting iterables to strings.
- Each element is converted to string via `print`, providing flexibility for different element types.
- A docstring with examples has been added.

Closes #57072