### PR TITLE
[JuliaLowering] Add `soft_scope` kwarg to `resolve_scopes`

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -7,6 +7,7 @@ struct DesugaringContext{Attrs} <: AbstractLoweringContext
     mod::Module
     expr_compat_mode::Bool
     ssa_mapping::Dict{Int, IdTag}
+    world::UInt
 end
 
 # Translate a K"ssavalue" node from pre-lowered code into a normal SSA binding.
@@ -4472,7 +4473,7 @@ ensure_desugaring_attributes!(graph) = ensure_attributes!(
     ex = reparent(graph, ex)
     ctx_out = DesugaringContext(graph, ctx.bindings, ctx.scope_layers,
                                 current_layer(ctx).mod, ctx.expr_compat_mode,
-                                Dict{Int, IdTag}())
+                                Dict{Int, IdTag}(), ctx.macro_world)
     vr = valid_st1(ex)
     # surface only one error until we have pretty-printing for multiple
     if !vr.ok

--- a/JuliaLowering/src/runtime.jl
+++ b/JuliaLowering/src/runtime.jl
@@ -402,8 +402,8 @@ end
 # Has no side effects, unlike isdefined()
 #
 # (This should do what fl_defined_julia_global does for flisp lowering)
-function is_defined_and_owned_global(mod, name)
-    Base.binding_kind(mod, name) === Base.PARTITION_KIND_GLOBAL
+function is_defined_and_owned_global(mod, name, world::UInt=Base.get_world_counter())
+    return Base.invoke_in_world(world, Base.binding_kind, mod, name) === Base.PARTITION_KIND_GLOBAL
 end
 
 # "Reserve" a binding: create the binding if it doesn't exist but do not assign
@@ -414,7 +414,7 @@ function reserve_module_binding(mod, name)
     # lock is only accessible from C. See also the C code in
     # `fl_module_unique_name`.
     if _get_module_binding(mod, name; create=false) === nothing
-        _get_module_binding(mod, name; create=true) !== nothing
+        return _get_module_binding(mod, name; create=true) !== nothing
     else
         return false
     end

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -756,13 +756,15 @@ metadata about each binding.
 This pass also records the set of binding IDs used locally within the
 enclosing lambda form and information about variables captured by closures.
 """
-@fzone "JL: resolve_scopes" function resolve_scopes(ctx::DesugaringContext, ex)
+@fzone "JL: resolve_scopes" function resolve_scopes(ctx::DesugaringContext, ex;
+                                                    soft_scope::Union{Nothing,Bool}=nothing)
     graph = ensure_scope_attributes!(copy_attrs(ctx.graph))
     ex = reparent(graph, ex)
+    enable_soft_scopes = soft_scope !== nothing ? soft_scope : contains_softscope_marker(ex)
     ctx2 = ScopeResolutionContext(graph, ctx.bindings, ctx.mod,
                                   Vector{ScopeInfo}(), Vector{ScopeId}(),
                                   ctx.scope_layers, Set{NameKey}(),
-                                  contains_softscope_marker(ex),
+                                  enable_soft_scopes,
                                   ctx.expr_compat_mode)
     ex2 = resolve_scopes(ctx2, ex)
     ctx3 = VariableAnalysisContext(graph, ctx2.bindings, ctx2.mod,

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -84,6 +84,7 @@ struct ScopeResolutionContext{Attrs} <: AbstractLoweringContext
     soft_assignable_globals::Set{NameKey}
     enable_soft_scopes::Bool
     expr_compat_mode::Bool
+    world::UInt
 end
 
 function contains_softscope_marker(ex)
@@ -299,7 +300,7 @@ function enter_scope!(ctx, ex)
                 push!(ctx.soft_assignable_globals, vk)
                 declare_in_scope!(ctx, top_scope(ctx), ex, :global)
             elseif scope.is_permeable && is_defined_and_owned_global(
-                ctx.scope_layers[vk.layer].mod, Symbol(vk.name))
+                ctx.scope_layers[vk.layer].mod, Symbol(vk.name), ctx.world)
                 # special soft scope rules: existing global variables are assigned to
                 if ctx.enable_soft_scopes
                     push!(ctx.soft_assignable_globals, vk)
@@ -757,7 +758,8 @@ This pass also records the set of binding IDs used locally within the
 enclosing lambda form and information about variables captured by closures.
 """
 @fzone "JL: resolve_scopes" function resolve_scopes(ctx::DesugaringContext, ex;
-                                                    soft_scope::Union{Nothing,Bool}=nothing)
+                                                    soft_scope::Union{Nothing,Bool}=nothing,
+                                                    world::UInt=ctx.world)
     graph = ensure_scope_attributes!(copy_attrs(ctx.graph))
     ex = reparent(graph, ex)
     enable_soft_scopes = soft_scope !== nothing ? soft_scope : contains_softscope_marker(ex)
@@ -765,7 +767,8 @@ enclosing lambda form and information about variables captured by closures.
                                   Vector{ScopeInfo}(), Vector{ScopeId}(),
                                   ctx.scope_layers, Set{NameKey}(),
                                   enable_soft_scopes,
-                                  ctx.expr_compat_mode)
+                                  ctx.expr_compat_mode,
+                                  world)
     ex2 = resolve_scopes(ctx2, ex)
     ctx3 = VariableAnalysisContext(graph, ctx2.bindings, ctx2.mod,
                                    ctx2.scopes, ex2.lambda_bindings,

--- a/JuliaLowering/test/scopes.jl
+++ b/JuliaLowering/test/scopes.jl
@@ -419,6 +419,21 @@ end
         gbinfo = only(filter(b->b.kind==:global, binfos))
         @test !gbinfo.is_ambiguous_local
     end
+
+    @testset "soft_scope kwarg override" begin
+        # Without soft_scope, x becomes an ambiguous local
+        let bindings = resolve_and_get_bindings(ambiguous_local, :(for _ = 1:10; x = 1; end))
+            binfo = only(filter(b->b.name=="x", bindings))
+            @test binfo.kind === :local
+            @test binfo.is_ambiguous_local
+        end
+        # With soft_scope=true, x stays global (no local created)
+        let bindings = resolve_and_get_bindings(ambiguous_local, :(for _ = 1:10; x = 1; end); soft_scope=true)
+            binfo = only(filter(b->b.name=="x", bindings))
+            @test binfo.kind === :global
+            @test !binfo.is_ambiguous_local
+        end
+    end
 end
 
 # Note: Certain flisp (un)hygiene behaviour is yet to be implemented.

--- a/JuliaLowering/test/scopes.jl
+++ b/JuliaLowering/test/scopes.jl
@@ -434,6 +434,23 @@ end
             @test !binfo.is_ambiguous_local
         end
     end
+
+    @testset "world-age propagation" begin
+        let m = Module()
+            Core.eval(m, :(global x = 0))
+            bindings = resolve_and_get_bindings(m, :(for _ = 1:10; x = 1; end); world=Base.get_world_counter())
+            binfo = only(filter(b->b.name=="x", bindings))
+            @test binfo.kind === :local
+            @test binfo.is_ambiguous_local
+        end
+        let m = Module()
+            Core.eval(m, :(global x = 0))
+            bindings = resolve_and_get_bindings(m, :(for _ = 1:10; x = 1; end); world=Base.get_world_counter(), soft_scope=true)
+            binfo = only(filter(b->b.name=="x", bindings))
+            @test binfo.kind === :global
+            @test !binfo.is_ambiguous_local
+        end
+    end
 end
 
 # Note: Certain flisp (un)hygiene behaviour is yet to be implemented.

--- a/JuliaLowering/test/utils.jl
+++ b/JuliaLowering/test/utils.jl
@@ -82,12 +82,6 @@ format_as_ast_macro(ex) = format_as_ast_macro(stdout, ex)
 
 # Test tools
 
-function desugar(mod::Module, src::String)
-    ex = parsestmt(SyntaxTree, src, filename="foo.jl")
-    ctx = JuliaLowering.DesugaringContext(syntax_graph(ex), Bindings(), ScopeLayer[], mod)
-    JuliaLowering.expand_forms_2(ctx, ex)
-end
-
 function uncomment_description(desc)
     replace(desc, r"^# ?"m=>"")
 end


### PR DESCRIPTION
Add `soft_scope::Union{Nothing,Bool}=nothing` keyword argument to `resolve_scopes` so callers can explicitly control soft scope behavior without inserting `K"softscope"` marker nodes into the AST. When `nothing` (the default), the existing marker-based detection is used.

This is useful for tools like JETLS that lower code from different contexts (files vs notebooks). Notebook cells use REPL-like soft scope semantics, and with this kwarg, the language server can pass `soft_scope=true` directly rather than manipulating the AST to insert marker nodes.