### PR TITLE
[JuliaLowering] Switch to typed attribute API

### DIFF
--- a/JuliaLowering/src/JuliaLowering.jl
+++ b/JuliaLowering/src/JuliaLowering.jl
@@ -15,7 +15,7 @@ end
 using .JuliaSyntax: @KSet_str, @stm, Kind, NodeId, SourceAttrType, SourceRef, SyntaxGraph,
     SyntaxList, SyntaxTree, byte_range, check_compatible_graph, children, copy_ast,
     copy_attrs, copy_node, delete_attributes, ensure_attributes!, filename, first_byte,
-    flags, flattened_provenance, has_flags, hasattr, head, highlight, is_compatible_graph,
+    flags, flattened_provenance, getattr, has_flags, hasattr, head, highlight, is_compatible_graph,
     is_leaf, is_literal, kind, last_byte, mapchildren, mapsyntax, mkleaf, mknode, newleaf,
     newnode, node_string, numchildren, provenance, reparent, setattr, setattr!,
     source_location, sourcefile, sourceref, syntax_graph, tree_ids, mapindex

--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -343,7 +343,7 @@ to indicate that the "primary" location of the source is the location where
 macro ast(ctx, srcref, tree)
     quote
         ctx = $(esc(ctx))
-        srcref::$SyntaxTree = $(_match_srcref(srcref))
+        srcref = $(_match_srcref(srcref))::$SyntaxTree
         $(_expand_ast_tree(:ctx, :srcref, tree, QuoteNode(__source__)))
     end
 end

--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -88,13 +88,13 @@ function JuliaSyntax.newleaf(ctx, prov, k, @nospecialize(value))
     leaf = newleaf(ctx, prov, k)
     if k == K"Identifier" || k == K"core" || k == K"top" || k == K"Symbol" ||
             k == K"globalref" || k == K"Placeholder"
-        setattr!(leaf._graph, leaf._id, :name_val, value)
+        setattr!(String, leaf._graph, leaf._id, :name_val, value)
     elseif k == K"BindingId"
-        setattr!(leaf._graph, leaf._id, :var_id, value)
+        setattr!(IdTag, leaf._graph, leaf._id, :var_id, value)
     elseif k == K"label"
-        setattr!(leaf._graph, leaf._id, :id, value)
+        setattr!(Int, leaf._graph, leaf._id, :id, value)
     elseif k == K"symboliclabel" || k == K"symbolicgoto"
-        setattr!(leaf._graph, leaf._id, :name_val, value)
+        setattr!(String, leaf._graph, leaf._id, :name_val, value)
     elseif k in KSet"TOMBSTONE SourceLocation latestworld latestworld_if_toplevel
                      softscope"
         # no attributes
@@ -107,7 +107,7 @@ function JuliaSyntax.newleaf(ctx, prov, k, @nospecialize(value))
               k == K"Bool"    ? value                   :
               k == K"VERSION" ? value                   :
               error("Unexpected leaf kind `$k`")
-        setattr!(leaf._graph, leaf._id, :value, val)
+        setattr!(Any, leaf._graph, leaf._id, :value, val)
     end
     leaf
 end
@@ -232,16 +232,16 @@ function _expand_ast_tree(ctx, srcref, tree, jl_line::QuoteNode)
         let (kind, srcref, kws) = _match_kind(srcref, kindspec)
             n = :(newleaf($ctx, $srcref, $kind, $val))
             for (attr, val) in kws
-                n = :(setattr!($n, $attr, $val))
+                n = :(setattr!(Any, $n, $attr, $val))
             end
-            DEBUG ? :(setattr!($n, :jl_source, $jl_line)) : n
+            DEBUG ? :(setattr!(LineNumberNode, $n, :jl_source, $jl_line)) : n
         end
     elseif Meta.isexpr(tree, :call) && tree.args[1] === :(=>)
         # Leaf node with copied attributes
         kind = esc(tree.args[3])
         srcref2 = esc(tree.args[2])
-        n = :(setattr!(mkleaf($srcref2), :kind, $kind))
-        DEBUG ? :(setattr!($n, :jl_source, $jl_line)) : n
+        n = :(setattr!(Kind, mkleaf($srcref2), :kind, $kind))
+        DEBUG ? :(setattr!(LineNumberNode, $n, :jl_source, $jl_line)) : n
     elseif Meta.isexpr(tree, (:vcat, :hcat, :vect))
         # Interior node
         flatargs = []
@@ -267,9 +267,9 @@ function _expand_ast_tree(ctx, srcref, tree, jl_line::QuoteNode)
         let (kind, srcref, kws) = _match_kind(srcref, flatargs[1])
             n = :(newnode($ctx, $srcref, $kind, $children_ex))
             for (attr, val) in kws
-                n = :(setattr!($n, $attr, $val))
+                n = :(setattr!(Any, $n, $attr, $val))
             end
-            DEBUG ? :(setattr!($n, :jl_source, $jl_line)) : n
+            DEBUG ? :(setattr!(LineNumberNode, $n, :jl_source, $jl_line)) : n
         end
     elseif Meta.isexpr(tree, :(:=))
         lhs = tree.args[1]
@@ -351,7 +351,7 @@ end
 #-------------------------------------------------------------------------------
 function set_scope_layer(ctx, ex, layer_id, force)
     k = kind(ex)
-    new_layer = force ? layer_id : get(ex, :scope_layer, layer_id)
+    new_layer = force ? layer_id : getattr(LayerId, ex, :scope_layer, layer_id)
 
     ex2 = if k == K"module" || k == K"toplevel" || k == K"inert" || k == K"inert_syntaxtree"
         mknode(ex, children(ex))
@@ -363,7 +363,7 @@ function set_scope_layer(ctx, ex, layer_id, force)
     else
         mkleaf(ex)
     end
-    setattr!(ex2, :scope_layer, new_layer)
+    setattr!(LayerId, ex2, :scope_layer, new_layer)
 end
 
 """
@@ -380,7 +380,7 @@ function adopt_scope(ex::SyntaxTree, layer::ScopeLayer)
 end
 
 function adopt_scope(ex::SyntaxTree, ref::SyntaxTree)
-    adopt_scope(ex, ref.scope_layer)
+    adopt_scope(ex, getattr(LayerId, ref, :scope_layer))
 end
 
 function adopt_scope(exs::SyntaxList, ref)
@@ -400,10 +400,10 @@ const CompileHints = Base.ImmutableDict{Symbol,Any}
 
 function setmeta!(ex::SyntaxTree, key::Symbol, @nospecialize(val))
     meta = begin
-        m = get(ex, :meta, nothing)
+        m = getattr(CompileHints, ex, :meta, nothing)
         isnothing(m) ? CompileHints(key, val) : CompileHints(m, key, val)
     end
-    setattr!(ex, :meta, meta)
+    setattr!(CompileHints, ex, :meta, meta)
     ex
 end
 
@@ -411,7 +411,7 @@ setmeta(ex::SyntaxTree, k::Symbol, @nospecialize(v)) =
     setmeta!(copy_node(ex), k, v)
 
 function getmeta(ex::SyntaxTree, name::Symbol, default)
-    meta = get(ex, :meta, nothing)
+    meta = getattr(CompileHints, ex, :meta, nothing)
     isnothing(meta) ? default : get(meta, name, default)
 end
 
@@ -429,7 +429,7 @@ function extension_type(ex)
     @jl_assert kind(ex) == K"assert" ex
     @jl_assert numchildren(ex) >= 1 ex
     @jl_assert kind(ex[1]) == K"Symbol" ex
-    ex[1].name_val
+    getattr(String, ex[1], :name_val)
 end
 
 function is_sym_decl(x)
@@ -474,7 +474,7 @@ function is_valid_modref(ex)
 end
 
 function is_core_ref(ex, name)
-    kind(ex) == K"core" && ex.name_val == name
+    kind(ex) == K"core" && getattr(String, ex, :name_val) == name
 end
 
 function is_core_nothing(ex)
@@ -551,7 +551,7 @@ end
 
 function new_scope_layer(ctx, mod_ref::SyntaxTree)
     @jl_assert kind(mod_ref) == K"Identifier" mod_ref
-    new_scope_layer(ctx, ctx.scope_layers[mod_ref.scope_layer].mod)
+    new_scope_layer(ctx, ctx.scope_layers[getattr(LayerId, mod_ref, :scope_layer)].mod)
 end
 
 #-------------------------------------------------------------------------------

--- a/JuliaLowering/src/binding_analysis.jl
+++ b/JuliaLowering/src/binding_analysis.jl
@@ -171,7 +171,7 @@ function du_visit!(ctx, state::DefUseState, e)
     k = kind(e)
 
     if k == K"BindingId"
-        du_mark_used!(state, e.var_id)
+        du_mark_used!(state, getattr(IdTag, e, :var_id))
         return false
 
     elseif k == K"symboliclabel"
@@ -194,13 +194,13 @@ function du_visit!(ctx, state::DefUseState, e)
         has_label = du_visit!(ctx, state, e[2])
         lhs = e[1]
         if kind(lhs) == K"BindingId"
-            du_assign!(state, lhs.var_id)
+            du_assign!(state, getattr(IdTag, lhs, :var_id))
         end
         return has_label
 
     elseif k == K"lambda"
         # Check captures from nested lambda
-        nested_lb = e.lambda_bindings
+        nested_lb = getattr(LambdaBindings, e, :lambda_bindings)
         for (id, is_capt) in nested_lb.locals_capt
             if is_capt
                 du_mark_captured!(state, id)
@@ -216,7 +216,7 @@ function du_visit!(ctx, state::DefUseState, e)
         # a separate K"decl" node. So we only need to handle K"BindingId" here.
         for child in children(e)
             if kind(child) == K"BindingId"
-                du_declare!(state, child.var_id)
+                du_declare!(state, getattr(IdTag, child, :var_id))
             end
         end
         return false
@@ -303,7 +303,7 @@ function du_visit!(ctx, state::DefUseState, e)
 end
 
 function _analyze_lambda_vars!(ctx, ex)
-    lambda_bindings = ex.lambda_bindings
+    lambda_bindings = getattr(LambdaBindings, ex, :lambda_bindings)
 
     # Collect candidate variables: captured and single-assigned
     candidates = Set{IdTag}()

--- a/JuliaLowering/src/bindings.jl
+++ b/JuliaLowering/src/bindings.jl
@@ -98,13 +98,13 @@ function add_binding(bindings::Bindings, binding)
     push!(bindings.info, binding)
 end
 
-function _binding_id(id::Integer)
+function _binding_id(id::IdTag)
     id
 end
 
 function _binding_id(ex::SyntaxTree)
     @jl_assert kind(ex) == K"BindingId" ex
-    ex.var_id
+    ex.var_id::IdTag
 end
 
 function get_binding(bindings::Bindings, x)::BindingInfo
@@ -112,7 +112,7 @@ function get_binding(bindings::Bindings, x)::BindingInfo
 end
 
 function get_binding(ctx::AbstractLoweringContext, x)::BindingInfo
-    get_binding(ctx.bindings, x)
+    get_binding(ctx.bindings::Bindings, x)
 end
 
 function _new_binding(ctx::AbstractLoweringContext, srcref::SyntaxTree,
@@ -128,8 +128,7 @@ end
 
 # Create a new SSA binding
 function ssavar(ctx::AbstractLoweringContext, srcref, name="tmp")
-    nameref = newleaf(ctx, srcref, K"Identifier", name)
-    binding_ex(ctx, _new_binding(ctx, nameref, name, :local;
+    binding_ex(ctx, _new_binding(ctx, srcref, name, :local;
                                  is_ssa=true, is_internal=true))
 end
 

--- a/JuliaLowering/src/bindings.jl
+++ b/JuliaLowering/src/bindings.jl
@@ -104,7 +104,7 @@ end
 
 function _binding_id(ex::SyntaxTree)
     @jl_assert kind(ex) == K"BindingId" ex
-    ex.var_id::IdTag
+    getattr(IdTag, ex, :var_id)
 end
 
 function get_binding(bindings::Bindings, x)::BindingInfo

--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -36,7 +36,7 @@ end
 function captured_var_access(ctx, ex)
     cap_rewrite = ctx.capture_rewriting
     if cap_rewrite isa ClosureInfo
-        field_sym = cap_rewrite.field_names[cap_rewrite.field_inds[ex.var_id]]
+        field_sym = cap_rewrite.field_names[cap_rewrite.field_inds[getattr(IdTag, ex, :var_id)]]
         @ast ctx ex [K"call"
             "getfield"::K"core"
             binding_ex(ctx, current_lambda_bindings(ctx).self)
@@ -53,7 +53,7 @@ function captured_var_access(ctx, ex)
 end
 
 function get_box_contents(ctx::ClosureConversionCtx, var, box_ex)
-    undef_var = new_local_binding(ctx, var, get_binding(ctx, var.var_id).name;
+    undef_var = new_local_binding(ctx, var, get_binding(ctx, getattr(IdTag, var, :var_id)).name;
                                   is_used_undef=true)
     @ast ctx var [K"block"
         box := box_ex
@@ -389,8 +389,8 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
             binfo.mod, binfo.name
         else
             # See note about using eval on Expr(:global/:const, GlobalRef(...))
-            @jl_assert ex[1].value isa GlobalRef ex[1]
-            ex[1].value.mod, String(ex[1].value.name)
+            @jl_assert getattr(Any, ex[1], :value) isa GlobalRef ex[1]
+            getattr(Any, ex[1], :value).mod, String(getattr(Any, ex[1], :value).name)
         end
         @ast ctx ex [K"unused_only" make_globaldecl(ctx, ex, mod, name, false)]
     elseif k == K"local"
@@ -408,7 +408,7 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
     elseif k == K"function_decl"
         func_name = ex[1]
         @jl_assert kind(func_name) == K"BindingId" ex
-        func_name_id = func_name.var_id
+        func_name_id = getattr(IdTag, func_name, :var_id)
         if haskey(ctx.closure_bindings, func_name_id)
             closure_info = get(ctx.closure_infos, func_name_id, nothing)
             needs_def = isnothing(closure_info)
@@ -471,7 +471,7 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
             ]
         end
     elseif k == K"method" && kind(ex[1]) === K"BindingId" &&
-            haskey(ctx.closure_bindings, ex[1].var_id)
+            haskey(ctx.closure_bindings, getattr(IdTag, ex[1], :var_id))
         # rm method table argument if it's a closure id, since it's unnecessary
         # and requires the `(= id (new ...))` call to be lifted above the
         # method.  flisp might be messing up overlays when it does this, since
@@ -483,18 +483,18 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
     elseif k == K"function_type"
         func_name = ex[1]
         if kind(func_name) == K"BindingId" && get_binding(ctx, func_name).kind === :local
-            @jl_assert(haskey(ctx.closure_infos, func_name.var_id),
+            @jl_assert(haskey(ctx.closure_infos, getattr(IdTag, func_name, :var_id)),
                        (ex, "function_type of local without known closure type"))
-            ctx.closure_infos[func_name.var_id].type_name
+            ctx.closure_infos[getattr(IdTag, func_name, :var_id)].type_name
         else
             @ast ctx ex [K"call" "Typeof"::K"core" func_name]
         end
     elseif k == K"method_defs"
         name = ex[1]
         is_closure = kind(name) == K"BindingId" && get_binding(ctx, name).kind === :local
-        cap_rewrite = is_closure ? ctx.closure_infos[name.var_id] : nothing
+        cap_rewrite = is_closure ? ctx.closure_infos[getattr(IdTag, name, :var_id)] : nothing
         ctx2 = ClosureConversionCtx(ctx.graph, ctx.bindings, ctx.mod,
-                                    ctx.closure_bindings, cap_rewrite, ex.lambda_bindings,
+                                    ctx.closure_bindings, cap_rewrite, getattr(LambdaBindings, ex, :lambda_bindings),
                                     ctx.is_toplevel_seq_point, ctx.toplevel_pure, ctx.toplevel_stmts,
                                     ctx.closure_infos)
         body = map_cl_convert(ctx2, ex[2], false)
@@ -513,7 +513,7 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
             ]
         end
     elseif k == K"_opaque_closure"
-        closure_binds = ctx.closure_bindings[ex[1].var_id]
+        closure_binds = ctx.closure_bindings[getattr(IdTag, ex[1], :var_id)]
         field_syms, field_orig_bindings, field_inds, _field_is_box =
             closure_type_fields(ctx, ex, closure_binds, true)
 
@@ -553,7 +553,7 @@ end
 
 function closure_convert_lambda(ctx, ex)
     @jl_assert kind(ex) == K"lambda" ex
-    lambda_bindings = ex.lambda_bindings
+    lambda_bindings = getattr(LambdaBindings, ex, :lambda_bindings)
     interpolations = nothing
     if isnothing(ctx.capture_rewriting)
         # Global method which may capture locals
@@ -564,7 +564,7 @@ function closure_convert_lambda(ctx, ex)
     end
     ctx2 = ClosureConversionCtx(ctx.graph, ctx.bindings, ctx.mod,
                                 ctx.closure_bindings, cap_rewrite, lambda_bindings,
-                                ex.is_toplevel_thunk, ctx.toplevel_pure && ex.toplevel_pure,
+                                getattr(Bool, ex, :is_toplevel_thunk), ctx.toplevel_pure && getattr(Bool, ex, :toplevel_pure),
                                 ctx.toplevel_stmts, ctx.closure_infos)
     lambda_children = SyntaxList(ctx)
     args = ex[1]
@@ -595,7 +595,7 @@ function closure_convert_lambda(ctx, ex)
         push!(lambda_children, _convert_closures(ctx2, ex[4]))
     end
 
-    lam = setattr!(mknode(ex, lambda_children), :lambda_bindings, lambda_bindings)
+    lam = setattr!(LambdaBindings, mknode(ex, lambda_children), :lambda_bindings, lambda_bindings)
     if !isnothing(interpolations) && !isempty(interpolations)
         @ast ctx ex [K"call"
             replace_captured_locals!::K"Value"
@@ -629,7 +629,7 @@ Invariants:
 ) where Attrs
     ctx_out = ClosureConversionCtx(ctx.graph, ctx.bindings, ctx.mod,
                                    ctx.closure_bindings, nothing,
-                                   ex.lambda_bindings,
+                                   getattr(LambdaBindings, ex, :lambda_bindings),
                                    false, true, SyntaxList(ctx.graph),
                                    Dict{IdTag,ClosureInfo{Attrs}}())
     ex_out = closure_convert_lambda(ctx_out, ex)

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -512,7 +512,7 @@ function est_to_dst(st::SyntaxTree)
                 @ast g st [K"meta" s=>K"Symbol"]
             elseif length(vs) === 1
                 out = est_to_dst(vs[1])
-                setmeta(out, Symbol(s), true)
+                setmeta(out, Symbol(s.name_val), true)
             else
                 # Kick the can down the road (should only be simple atoms?)
                 out_cs = SyntaxList(g)

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -31,8 +31,10 @@ function _get_inner_lnn(e::Expr, default::LineNumberNode)
     length(e.args) >= 2 || return default
     b = e.args[end]
     b isa Expr && b.head === :block || return default
-    length(b.args) >= 1 && b.args[1] isa LineNumberNode || return default
-    return b.args[1]
+    b::Expr # inference TODO
+    length(b.args) >= 1 || return default
+    b_lnn = b.args[1]
+    return b_lnn isa LineNumberNode ? b_lnn : default
 end
 
 # List of Expr-AST forms that are always converted to some SyntaxTree form and
@@ -59,7 +61,7 @@ function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
     elseif e isa Expr && e.head === :scope_layer
         @assert length(e.args) === 2 && e.args[1] isa Symbol
         ident = newleaf(graph, src, K"Identifier")
-        setattr!(ident, :name_val, String(e.args[1]))
+        setattr!(ident, :name_val, String(e.args[1]::Symbol))
         setattr!(ident, :scope_layer, e.args[2])
     elseif e isa Expr && e.head === :static_parameter
         setattr!(newleaf(graph, src, K"Value"), :value, e)
@@ -123,7 +125,7 @@ function est_to_expr(st::SyntaxTree, suppress_linenodes=false)
     return if k === K"core" && numchildren(st) === 0 && st.name_val === "nothing"
         nothing
     elseif kind(st) === K"Identifier"
-        n = Symbol(st.name_val)
+        n = Symbol(st.name_val::String)
         mod = get(st, :mod, nothing)
         !isnothing(mod) ? GlobalRef(mod, n) :
             hasattr(st, :scope_layer) ? Expr(:scope_layer, n, st.scope_layer) :
@@ -144,7 +146,7 @@ function est_to_expr(st::SyntaxTree, suppress_linenodes=false)
         @jl_assert !is_leaf(st) (st, "est_to_expr should only be used pre-desugaring")
         # In a partially-expanded or quoted AST, there may be heads with no
         # corresponding kind
-        head = Symbol(k === K"unknown_head" ? st.name_val : untokenize(k))
+        head = Symbol((k === K"unknown_head" ? st.name_val : untokenize(k))::String)
         out = Expr(head)
 
         # (Move the following assumptions to the docs if they turn out accurate)
@@ -163,22 +165,19 @@ function est_to_expr(st::SyntaxTree, suppress_linenodes=false)
             end
         end
         # Add extra linenodes to some blocks for better provenance
-        @stm st begin
-            ([K"block"], when=!suppress_linenodes) ->
-                push!(out.args, source_location(LineNumberNode, st))
-            [K"module" _... [K"block" _...]] ->
-                pushfirst!(out.args[end].args, source_location(LineNumberNode, st))
-            [K"function" _ [K"block" _...]] ->
-                pushfirst!(out.args[end].args, source_location(LineNumberNode, st))
-            [K"macro" _ [K"block" _...]] ->
-                pushfirst!(out.args[end].args, source_location(LineNumberNode, st))
-            [K"for" _ [K"block" _...]] ->
-                push!(out.args[end].args, source_location(
-                    LineNumberNode, sourcefile(st), last_byte(st)))
-            [K"while" _ [K"block" _...]] ->
-                push!(out.args[end].args, source_location(
-                    LineNumberNode, sourcefile(st), last_byte(st)))
-            _ -> nothing
+        if head === :block && length(out.args) == 0 && !suppress_linenodes
+            push!(out.args, source_location(LineNumberNode, st))
+        elseif head in (:module, :function, :macro) && length(out.args) > 0
+            let b = out.args[end]
+                b isa Expr && b.head === :block && pushfirst!(
+                    b.args, source_location(LineNumberNode, st))
+            end
+        elseif head in (:for, :while) && length(out.args) > 0
+            let b = out.args[end]
+                b isa Expr && b.head === :block && push!(
+                    b.args, source_location(
+                        LineNumberNode, sourcefile(st), last_byte(st)))
+            end
         end
         out
     end
@@ -190,8 +189,9 @@ end
 # .op => (. op)
 function _dst_separate_dotop(st::SyntaxTree)
     k = kind(st)
-    if k === K"Identifier" && is_dotted_operator(st.name_val)
-        dotop_s = st.name_val
+    if k === K"Identifier"
+        dotop_s = st.name_val::String
+        !is_dotted_operator(dotop_s) && return est_to_dst(st)
         op_s = dotop_s[nextind(dotop_s,1):end]
         op_leaf = setattr(mkleaf(st), :name_val, op_s)
         return @ast st._graph st [K"." op_leaf]
@@ -294,7 +294,7 @@ function _expand_literal_pow(st::SyntaxTree)
 end
 
 function _est_to_dst_ident(st::SyntaxTree)
-    s = st.name_val
+    s = st.name_val::String
     if all(==('_'), s) || s == UNUSED
         setattr!(mkleaf(st), :kind, K"Placeholder")
     else
@@ -477,7 +477,7 @@ function est_to_dst(st::SyntaxTree)
         ([K"let" binds body], when=(kind(binds) !== K"block")) ->
             @ast g st [K"let" [K"block"(binds) rec(binds)] rec(body)]
         [K"struct" mut sig body] -> let
-            flags = JS.flags(st) | (_is_false(mut) ? 0 : JS.MUTABLE_FLAG)
+            flags = JS.flags(st) | (_is_false(mut) ? 0x0000 : JS.MUTABLE_FLAG)
             @ast g st [K"struct"(syntax_flags=flags)
                 rec(sig)
                 rec(body)

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -46,31 +46,31 @@ isa_lowering_ast_node(@nospecialize(e)) =
 function is_expr_value(st::SyntaxTree)
     k = kind(st)
     return JuliaSyntax.is_literal(k) || k === K"Value" ||
-        k === K"core" && get(st, :name_val, nothing) === "nothing"
+        k === K"core" && getattr(String, st, :name_val, nothing) === "nothing"
 end
 
 function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
     st = if e === Core.nothing
         # e.value can't be nothing in `K"Value"`, so represent with K"core"
-        setattr!(newleaf(graph, src, K"core"), :name_val, "nothing")
+        setattr!(String, newleaf(graph, src, K"core"), :name_val, "nothing")
     elseif e isa Symbol
-        setattr!(newleaf(graph, src, K"Identifier"), :name_val, String(e))
+        setattr!(String, newleaf(graph, src, K"Identifier"), :name_val, String(e))
     elseif e isa QuoteNode
         cid, _ = _expr_to_est(graph, e.value, src)
         newnode(graph, src, K"inert", NodeId[cid])
     elseif e isa Expr && e.head === :scope_layer
         @assert length(e.args) === 2 && e.args[1] isa Symbol
         ident = newleaf(graph, src, K"Identifier")
-        setattr!(ident, :name_val, String(e.args[1]::Symbol))
-        setattr!(ident, :scope_layer, e.args[2])
+        setattr!(String, ident, :name_val, String(e.args[1]::Symbol))
+        setattr!(LayerId, ident, :scope_layer, e.args[2])
     elseif e isa Expr && e.head === :static_parameter
-        setattr!(newleaf(graph, src, K"Value"), :value, e)
+        setattr!(Any, newleaf(graph, src, K"Value"), :value, e)
     elseif e isa Expr && e.head === :lambda && length(e.args) == 2
         argnames = e.args[1]::Vector{Any}
         arg_cs = NodeId[]
         for name in argnames
             id = newleaf(graph, src, K"Identifier")
-            setattr!(id, :name_val, String(name::Symbol))
+            setattr!(String, id, :name_val, String(name::Symbol))
             push!(arg_cs, id._id)
         end
         body_id, src = _expr_to_est(graph, e.args[2], src)
@@ -78,8 +78,8 @@ function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
         tvars_block = newnode(graph, src, K"block", NodeId[])
         st = newnode(graph, src, K"lambda",
                      NodeId[args_block._id, tvars_block._id, body_id])
-        setattr!(st, :is_toplevel_thunk, false)
-        setattr!(st, :toplevel_pure, false)
+        setattr!(Bool, st, :is_toplevel_thunk, false)
+        setattr!(Bool, st, :toplevel_pure, false)
     elseif e isa Expr
         head_s = string(e.head)
         st_k = find_kind(head_s)
@@ -95,13 +95,13 @@ function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
             end
         end
         if isnothing(st_k)
-            setattr!(newnode(graph, old_src, K"unknown_head", cs), :name_val, head_s)
+            setattr!(String, newnode(graph, old_src, K"unknown_head", cs), :name_val, head_s)
         else
             newnode(graph, old_src, st_k, cs)
         end
     elseif e isa GlobalRef
         # Represent globalref as K"Identifier" with :mod attribute
-        setattr!(newleaf(graph, src, K"Identifier", string(e.name)), :mod, e.mod)
+        setattr!(Module, newleaf(graph, src, K"Identifier", string(e.name)), :mod, e.mod)
     else
         # We may want additional special cases for other types where
         # `Base.isa_ast_node(e)`, but `K"Value"` should be fine for most, since
@@ -110,7 +110,7 @@ function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
             # linenode oustside of block or toplevel
             src = e
         end
-        setattr!(newleaf(graph, src, K"Value"), :value, e)
+        setattr!(Any, newleaf(graph, src, K"Value"), :value, e)
     end
     @jl_assert isa_lowering_ast_node(e) || is_expr_value(st) st
 
@@ -122,16 +122,16 @@ end
 # children.
 function est_to_expr(st::SyntaxTree, suppress_linenodes=false)
     k = kind(st)
-    return if k === K"core" && numchildren(st) === 0 && st.name_val === "nothing"
+    return if k === K"core" && numchildren(st) === 0 && getattr(String, st, :name_val) === "nothing"
         nothing
     elseif kind(st) === K"Identifier"
-        n = Symbol(st.name_val::String)
-        mod = get(st, :mod, nothing)
+        n = Symbol(getattr(String, st, :name_val)::String)
+        mod = getattr(Module, st, :mod, nothing)
         !isnothing(mod) ? GlobalRef(mod, n) :
-            hasattr(st, :scope_layer) ? Expr(:scope_layer, n, st.scope_layer) :
+            hasattr(LayerId, st, :scope_layer) ? Expr(:scope_layer, n, getattr(LayerId, st, :scope_layer)) :
             n
     elseif is_leaf(st) && is_expr_value(st)
-        v = st.value
+        v = getattr(Any, st, :value)
         # Let `st.value isa Symbol` (or other AST node).  Since we enforce that
         # this is never produced by the reverse Expr->SyntaxTree transformation,
         # there is no lonely Expr for which `st` is the only SyntaxTree
@@ -146,7 +146,7 @@ function est_to_expr(st::SyntaxTree, suppress_linenodes=false)
         @jl_assert !is_leaf(st) (st, "est_to_expr should only be used pre-desugaring")
         # In a partially-expanded or quoted AST, there may be heads with no
         # corresponding kind
-        head = Symbol((k === K"unknown_head" ? st.name_val : untokenize(k))::String)
+        head = Symbol((k === K"unknown_head" ? getattr(String, st, :name_val) : untokenize(k))::String)
         out = Expr(head)
 
         # (Move the following assumptions to the docs if they turn out accurate)
@@ -190,13 +190,13 @@ end
 function _dst_separate_dotop(st::SyntaxTree)
     k = kind(st)
     if k === K"Identifier"
-        dotop_s = st.name_val::String
+        dotop_s = getattr(String, st, :name_val)::String
         !is_dotted_operator(dotop_s) && return est_to_dst(st)
         op_s = dotop_s[nextind(dotop_s,1):end]
-        op_leaf = setattr(mkleaf(st), :name_val, op_s)
+        op_leaf = setattr(String, mkleaf(st), :name_val, op_s)
         return @ast st._graph st [K"." op_leaf]
-    elseif k === K"Value" && st.value isa GlobalRef &&
-        is_dotted_operator(string(st.value.name))
+    elseif k === K"Value" && getattr(Any, st, :value) isa GlobalRef &&
+        is_dotted_operator(string(getattr(Any, st, :value).name))
         @jl_assert false (st, "TODO: handle dotted globalref")
     else
         return est_to_dst(st)
@@ -278,14 +278,14 @@ function _dst_fix_arglist(st::SyntaxTree)
     end
 end
 
-_is_false(st::SyntaxTree) = kind(st) === K"Value" && st.value === false
+_is_false(st::SyntaxTree) = kind(st) === K"Value" && getattr(Any, st, :value) === false
 
 function _expand_literal_pow(st::SyntaxTree)
     k = kind(st)
     (k in KSet"call dotcall" &&
         numchildren(st) === 3 &&
-        get(st[1], :name_val, "") === "^" &&
-        get(st[3], :value, nothing) isa Integer) || return st
+        getattr(String, st[1], :name_val, "") === "^" &&
+        getattr(Any, st[3], :value, nothing) isa Integer) || return st
     @ast st._graph st [k
         "literal_pow"::K"top"
         st[1] st[2]
@@ -294,9 +294,9 @@ function _expand_literal_pow(st::SyntaxTree)
 end
 
 function _est_to_dst_ident(st::SyntaxTree)
-    s = st.name_val::String
+    s = getattr(String, st, :name_val)::String
     if all(==('_'), s) || s == UNUSED
-        setattr!(mkleaf(st), :kind, K"Placeholder")
+        setattr!(Kind, mkleaf(st), :kind, K"Placeholder")
     else
         st
     end
@@ -348,14 +348,14 @@ function est_to_dst(st::SyntaxTree)
         [K"Identifier"] -> _est_to_dst_ident(st)
         (_, when=is_leaf(st)) -> st
         ([K"unknown_head" l r],
-         when=(s=st.name_val; Base.isoperator(s))) -> let
+         when=(s=getattr(String, st, :name_val); Base.isoperator(s))) -> let
              (op_s, out_k) = s[1] === '.' ?
                  (s[nextind(s,1):prevind(s,end)], K".op=") :
                  (s[1:prevind(s,end)], K"op=")
 
              op_leaf = newleaf(g, st, K"Identifier")
              JS.copy_attrs!(op_leaf, st)
-             setattr!(op_leaf, :name_val, op_s)
+             setattr!(String, op_leaf, :name_val, op_s)
              @ast g st [out_k rec(l) op_leaf rec(r)]
          end
         [K"comparison" cs0...] -> let cs = copy(cs0)
@@ -365,7 +365,7 @@ function est_to_dst(st::SyntaxTree)
             mknode(st, cs)
         end
         [K"'" x] ->
-            @ast g st [K"call" "'"::K"Identifier"(scope_layer=st.scope_layer) rec(x)]
+            @ast g st [K"call" "'"::K"Identifier"(scope_layer=getattr(LayerId, st, :scope_layer)) rec(x)]
         [K"." f [K"tuple" args...]] -> _expand_literal_pow(
             @ast g st [K"dotcall" rec(f) _dst_sink_parameters(args)...])
         [K"." l r] -> let r2 = rec(r)
@@ -430,19 +430,19 @@ function est_to_dst(st::SyntaxTree)
             @ast g st [K"generator" rec(body) _dst_iterspec(st, iters)]
         [K"ncat" dim xs...] -> let
             out = mknode(st, mapsyntax(rec, xs))
-            setattr!(out, :syntax_flags,
-                     JS.flags(st) | JS.set_numeric_flags(dim.value))
+            setattr!(UInt16, out, :syntax_flags,
+                     JS.flags(st) | JS.set_numeric_flags(getattr(Any, dim, :value)))
         end
         [K"nrow" dim xs...] -> let
             out = mknode(st, mapsyntax(rec, xs))
-            setattr!(out, :syntax_flags,
-                     JS.flags(st) | JS.set_numeric_flags(dim.value))
+            setattr!(UInt16, out, :syntax_flags,
+                     JS.flags(st) | JS.set_numeric_flags(getattr(Any, dim, :value)))
         end
         [K"typed_ncat" t dim xs...] -> let
             out_cs = pushfirst!(mapsyntax(rec, xs), rec(t))
             out = mknode(st, out_cs)
-            setattr!(out, :syntax_flags,
-                     JS.flags(st) | JS.set_numeric_flags(dim.value))
+            setattr!(UInt16, out, :syntax_flags,
+                     JS.flags(st) | JS.set_numeric_flags(getattr(Any, dim, :value)))
         end
         ([K"=" l r], when=(is_eventually_call(l))) -> let
             if has_if_generated(r)
@@ -503,16 +503,16 @@ function est_to_dst(st::SyntaxTree)
 
         #-----------------------------------------------------------------------
         # Heads are not emitted from parsing
-        ([K"meta" [K"unknown_head" ps...]], when=st[1].name_val === "purity") ->
+        ([K"meta" [K"unknown_head" ps...]], when=getattr(String, st[1], :name_val) === "purity") ->
             @ast g st [K"meta" "purity"::K"Symbol"
-                Base.EffectsOverride([x.value for x in ps]...)::K"Value"]
+                Base.EffectsOverride([getattr(Any, x, :value) for x in ps]...)::K"Value"]
         ([K"meta" s vs...],
-         when=(get(s, :name_val, "") in ("nospecialize", "specialize"))) -> let
+         when=(getattr(String, s, :name_val, "") in ("nospecialize", "specialize"))) -> let
             if length(vs) === 0
                 @ast g st [K"meta" s=>K"Symbol"]
             elseif length(vs) === 1
                 out = est_to_dst(vs[1])
-                setmeta(out, Symbol(s.name_val), true)
+                setmeta(out, Symbol(getattr(String, s, :name_val)), true)
             else
                 # Kick the can down the road (should only be simple atoms?)
                 out_cs = SyntaxList(g)
@@ -524,28 +524,28 @@ function est_to_dst(st::SyntaxTree)
         end
         [K"meta" syms...] ->
             @ast g st [K"meta" mapsyntax(
-                s->(kind(s) === K"Identifier" ? setattr(s, :kind, K"Symbol") : s),
+                s->(kind(s) === K"Identifier" ? setattr(Kind, s, :kind, K"Symbol") : s),
                 syms)...
            ]
         # TODO: JL doesn't support inline/noinline/inbounds
         [K"inline" _] -> newleaf(g, st, K"TOMBSTONE")
         [K"noinline" _] -> newleaf(g, st, K"TOMBSTONE")
         [K"inbounds" _] -> newleaf(g, st, K"TOMBSTONE")
-        [K"core" x] -> setattr!(mkleaf(st), :name_val, x.name_val)
-        [K"top" x] -> setattr!(mkleaf(st), :name_val, x.name_val)
+        [K"core" x] -> setattr!(String, mkleaf(st), :name_val, getattr(String, x, :name_val))
+        [K"top" x] -> setattr!(String, mkleaf(st), :name_val, getattr(String, x, :name_val))
         [K"copyast" [K"inert" ex]] -> @ast g st [K"call"
             interpolate_ast::K"Value"
             Expr::K"Value"
             [K"inert"(st[1]) ex]
         ]
-        [K"symbolicgoto" lab] -> setattr!(mkleaf(st), :name_val, lab.name_val)
-        [K"symboliclabel" lab] -> setattr!(mkleaf(st), :name_val, lab.name_val)
-        [K"symbolicblock" id body] -> if all(==('_'), id.name_val)
+        [K"symbolicgoto" lab] -> setattr!(String, mkleaf(st), :name_val, getattr(String, lab, :name_val))
+        [K"symboliclabel" lab] -> setattr!(String, mkleaf(st), :name_val, getattr(String, lab, :name_val))
+        [K"symbolicblock" id body] -> if all(==('_'), getattr(String, id, :name_val))
             @ast g st [K"symbolicblock" id=>K"Placeholder" rec(body)]
         else
             @ast g st [K"symbolicblock" id=>K"symboliclabel" rec(body)]
         end
-        [K"unknown_head" cs...] -> let head = st.name_val
+        [K"unknown_head" cs...] -> let head = getattr(String, st, :name_val)
             if head === "latestworld-if-toplevel"
                 newleaf(g, st, K"latestworld_if_toplevel")
             else

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -1927,7 +1927,7 @@ function expand_call(ctx, ex)
     if any(kind(arg) == K"..." for arg in args)
         # Splatting, eg, `f(a, xs..., b)`
         expand_splat(ctx, ex, expand_forms_2(ctx, farg), args)
-    elseif kind(farg) == K"Identifier" && farg.name_val == "include"
+    elseif kind(farg) == K"Identifier" && farg.name_val === "include"
         # world age special case
         r = ssavar(ctx, ex)
         @ast ctx ex [K"block"
@@ -1949,8 +1949,6 @@ end
 #-------------------------------------------------------------------------------
 
 function expand_dot(ctx, ex)
-    @jl_assert numchildren(ex) in (1,2)  (ex, "`.` form requires either one or two children")
-
     if numchildren(ex) == 1
         # eg, `f = .+`
         # Upstream TODO: Remove the (. +) representation and replace with use
@@ -1974,6 +1972,8 @@ function expand_dot(ctx, ex)
             ex[1]
             rhs
         ]
+    else
+        @jl_assert false (ex, "`.` form requires either one or two children")
     end
 end
 
@@ -3938,11 +3938,11 @@ function expand_wheres(ctx, ex)
     body = ex[1]
     @stm ex begin
         [K"where" _ [K"_typevars" [K"block" names...] [K"block" stmts...]]] ->
-            for n in reverse(names)
+            for n in Iterators.reverse(names)
                 body = @ast ctx ex [K"call" "UnionAll"::K"core" n body]
             end
         [K"where" _ tvs...] ->
-            for v in reverse(tvs)
+            for v in Iterators.reverse(tvs)
                 body = expand_where(ctx, ex, body, v)
             end
     end

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -12,9 +12,9 @@ end
 # Translate a K"ssavalue" node from pre-lowered code into a normal SSA binding.
 # Uses ctx.ssa_mapping to ensure the same external SSA id maps to the same binding.
 function _resolve_ssavalue(ctx::DesugaringContext, ex)
-    binding_id = get!(ctx.ssa_mapping, ex[1].value) do
+    binding_id = get!(ctx.ssa_mapping, getattr(Any, ex[1], :value)) do
         s = ssavar(ctx, ex)
-        s.var_id
+        getattr(IdTag, s, :var_id)
     end
     binding_ex(ctx, binding_id)
 end
@@ -23,11 +23,11 @@ end
 # bindings (and hence ssa vars). See also `is_identifier_like()`
 function is_same_identifier_like(ex::SyntaxTree, y::SyntaxTree)
     return (kind(ex) == K"Identifier" && kind(y) == K"Identifier" && NameKey(ex) == NameKey(y)) ||
-           (kind(ex) == K"BindingId"  && kind(y) == K"BindingId"  && ex.var_id   == y.var_id)
+           (kind(ex) == K"BindingId"  && kind(y) == K"BindingId"  && getattr(IdTag, ex, :var_id)   == getattr(IdTag, y, :var_id))
 end
 
 function is_same_identifier_like(ex::SyntaxTree, name::AbstractString)
-    return kind(ex) == K"Identifier" && ex.name_val == name
+    return kind(ex) == K"Identifier" && getattr(String, ex, :name_val) == name
 end
 
 function contains_identifier(ex::SyntaxTree, idents::AbstractVector{<:SyntaxTree})
@@ -85,8 +85,8 @@ end
 # used outside of that scope (binding capture is OK).  This is the alternative.
 function newsym(ctx, src::SyntaxTree, name::String; unused=false)
     out = newleaf(ctx, src, unused ? K"Placeholder" : K"Identifier", name)
-    setattr!(out, :meta, get(src, :meta, nothing))
-    setattr!(out, :scope_layer, new_scope_layer(ctx))
+    setattr!(Any, out, :meta, getattr(CompileHints, src, :meta, nothing))
+    setattr!(LayerId, out, :scope_layer, new_scope_layer(ctx))
 end
 
 #-------------------------------------------------------------------------------
@@ -576,8 +576,8 @@ end
 # last index
 function replace_beginend(ctx, ex, arr, n, splats, is_last)
     k = kind(ex)
-    if k == K"Identifier" && ex.name_val in ("begin", "end")
-        indexfunc = @ast ctx ex (ex.name_val == "begin" ? "firstindex" : "lastindex")::K"top"
+    if k == K"Identifier" && getattr(String, ex, :name_val) in ("begin", "end")
+        indexfunc = @ast ctx ex (getattr(String, ex, :name_val) == "begin" ? "firstindex" : "lastindex")::K"top"
         if length(splats) == 0
             if is_last && n == 1
                 @ast ctx ex [K"call" indexfunc arr]
@@ -736,7 +736,7 @@ function expand_fuse_broadcast(ctx, ex)
             else
                 lhs
             end
-            if !(kind(rhs) == K"call" && kind(rhs[1]) == K"top" && rhs[1].name_val == "broadcasted")
+            if !(kind(rhs) == K"call" && kind(rhs[1]) == K"top" && getattr(String, rhs[1], :name_val) == "broadcasted")
                 # Ensure the rhs of .= is always wrapped in a call to `broadcasted()`
                 [K"call"(rhs)
                     "broadcasted"::K"top"
@@ -1500,7 +1500,7 @@ function expand_let(ctx, ex)
     bindings = ex[1]
     @jl_assert kind(bindings) == K"block" bindings
     blk = ex[2]
-    scope_type = get(ex, :scope_type, :hard)
+    scope_type = getattr(Symbol, ex, :scope_type, :hard)
     if numchildren(bindings) == 0
         return @ast ctx ex [K"scope_block"(scope_type=scope_type) blk]
     end
@@ -1661,7 +1661,7 @@ function expand_named_tuple(ctx, ex, kws; field_name="named tuple field",
         end
         if !isnothing(name) && !isnothing(value)
             if kind(name) == K"Symbol"
-                name_str = name.name_val
+                name_str = getattr(String, name, :name_val)
                 if name_str in name_strs
                     throw(LoweringError(name, "Repeated $field_name name"))
                 end
@@ -1855,7 +1855,7 @@ function expand_ccall(ctx, ex)
                     expanded_types...
                 ]
             ]
-            (cconv !== nothing && kind(cconv) === K"cconv" ? cconv[2].value :
+            (cconv !== nothing && kind(cconv) === K"cconv" ? getattr(Any, cconv[2], :value) :
                 isnothing(vararg_type) ? 0 :
                 length(arg_types))::K"Integer"
             if isnothing(cconv)
@@ -1908,9 +1908,9 @@ end
 
 function expand_call(ctx, ex)
     farg = ex[1]
-    if kind(farg) === K"Identifier" && farg.name_val === "ccall"
+    if kind(farg) === K"Identifier" && getattr(String, farg, :name_val) === "ccall"
         return expand_ccall(ctx, ex)
-    elseif kind(farg) === K"Identifier" && farg.name_val === "cglobal"
+    elseif kind(farg) === K"Identifier" && getattr(String, farg, :name_val) === "cglobal"
         return @ast ctx ex [K"call"
             [K"static_eval" ex[1]] # just so the globalref is inlined
             expand_forms_2(ctx, ex[2])
@@ -1927,7 +1927,7 @@ function expand_call(ctx, ex)
     if any(kind(arg) == K"..." for arg in args)
         # Splatting, eg, `f(a, xs..., b)`
         expand_splat(ctx, ex, expand_forms_2(ctx, farg), args)
-    elseif kind(farg) == K"Identifier" && farg.name_val === "include"
+    elseif kind(farg) == K"Identifier" && getattr(String, farg, :name_val) === "include"
         # world age special case
         r = ssavar(ctx, ex)
         @ast ctx ex [K"block"
@@ -2172,7 +2172,7 @@ function make_lhs_decls(ctx, stmts, declkind, declmeta, ex, type_decls=true)
         # TODO: consider removing support for Expr(:global, GlobalRef(...)) and
         # other Exprs that cannot be produced by the parser (tested by
         # test/precompile.jl #50538).
-        ([K"Value"], when=ex.value isa GlobalRef) -> ex
+        ([K"Value"], when=getattr(Any, ex, :value) isa GlobalRef) -> ex
         [K"Placeholder"] -> nothing
         ([K"::" [K"Identifier"] t], when=type_decls) -> let x = ex[1]
             t2 = expand_forms_2(ctx, t)
@@ -2201,7 +2201,7 @@ function make_lhs_decls(ctx, stmts, declkind, declmeta, ex, type_decls=true)
 
     if !isnothing(declname)
         stmt = @ast ctx ex [declkind declname]
-        !isnothing(declmeta) && setattr!(stmt, :meta, declmeta)
+        !isnothing(declmeta) && setattr!(Any, stmt, :meta, declmeta)
         push!(stmts, stmt)
     end
     return nothing
@@ -2224,7 +2224,7 @@ function expand_decls(ctx, ex)
             [K"function" x _] -> x
         end
         # type decls are handled elsewhere unless simple
-        make_lhs_decls(ctx, stmts, declkind, get(ex, :meta, nothing), lhs, simple)
+        make_lhs_decls(ctx, stmts, declkind, getattr(CompileHints, ex, :meta, nothing), lhs, simple)
         simple || push!(stmts, expand_forms_2(ctx, c))
     end
     newnode(ctx, ex, K"block", stmts)
@@ -2456,9 +2456,9 @@ end
 
 function _expr_arg_sym(a)
     @jl_assert kind(a) === K"::" || kind(a) === K"_typevar" a
-    sym = setattr(a[1], :kind, K"Symbol")
+    sym = setattr(Kind, a[1], :kind, K"Symbol")
     if kind(a[1]) === K"Placeholder"
-        setattr!(sym, :name_val, UNUSED)
+        setattr!(String, sym, :name_val, UNUSED)
     end
     sym
 end
@@ -2477,7 +2477,7 @@ function generated_method_defs(ctx, src, mtable, sparams, argl, body, rett)
             @ast(ctx, src, [K"::" arg1_name [K"function_type" gen_name]]),
             @ast(ctx, src, [K"::"
                 # TODO: correct scope layer?
-                "__context__"::K"Identifier"(scope_layer=get(mtable, :scope_layer, 1))
+                "__context__"::K"Identifier"(scope_layer=getattr(LayerId, mtable, :scope_layer, 1))
                 MacroContext::K"Value"
             ]),
             mapsyntax(_untyped_arg, sparams)...,
@@ -2604,7 +2604,7 @@ function expand_kw_args(ctx, kws)
         end
     end
     kw_names = mapindex(kw_decls, 1)
-    kw_syms = mapsyntax(x->setattr(x, :kind, K"Symbol"), kw_names)
+    kw_syms = mapsyntax(x->setattr(Kind, x, :kind, K"Symbol"), kw_names)
     restkw_list = isnothing(restkw) ? SyntaxList(ctx.graph) :
         SyntaxList(@ast ctx restkw [K"::"
             restkw [K"call" "pairs"::K"top" "NamedTuple"::K"core"]])
@@ -2634,7 +2634,7 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
     ordered_defaults = any(val->contains_identifier(val, kw_names), kw_defaults)
     positional_sparams = used_typevars(pargl, sparams)
 
-    m1_name = let n = is_core_nothing(mtable) ? "_" : mtable.name_val,
+    m1_name = let n = is_core_nothing(mtable) ? "_" : getattr(String, mtable, :name_val),
         mangled = string(startswith(n, '#') ? "" : "#kw_body#", n, "#")
         newsym(ctx, argl[1], reserve_module_binding_i(ctx.mod, mangled))
     end
@@ -2678,7 +2678,7 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
             use_ssa_kw_temps = !ordered_defaults &&
                 !any(val->contains_unquoted(e->kind(e) == K"=", val), kw_defaults)
         kw_temps = use_ssa_kw_temps ?
-            mapsyntax(x->ssavar(ctx, x, x.name_val), kw_names) : kw_names
+            mapsyntax(x->ssavar(ctx, x, getattr(String, x, :name_val)), kw_names) : kw_names
         tempslot = newsym(ctx, kws, "kwtmp")
         keyword_only_spnames = mapindex(unused_typevars(pargl, sparams), 1)
 
@@ -2832,7 +2832,7 @@ expand_function_arg(ctx, arg, used) = @stm arg begin
     [K"::" x t] ->
         @ast ctx arg [K"::" fix_argname(ctx, x, used) t]
     [K"::" t] -> let aname = newsym(ctx, arg, "#arg#"; unused=true)
-        setattr!(aname, :meta, get(arg, :meta, nothing))
+        setattr!(Any, aname, :meta, getattr(CompileHints, arg, :meta, nothing))
         @ast ctx arg [K"::" fix_argname(ctx, aname, used) t]
     end
     [K"kw" x v] ->
@@ -2948,8 +2948,8 @@ end
 function _make_macro_name(ctx, ex)
     k = kind(ex)
     if k == K"Identifier" || k == K"Symbol"
-        name = setattr!(mkleaf(ex), :kind, k)
-        name.name_val = "@$(ex.name_val)"
+        name = setattr!(Kind, mkleaf(ex), :kind, k)
+        setattr!(String, name, :name_val, "@$(getattr(String, ex, :name_val))")
         name
     elseif is_valid_modref(ex)
         @jl_assert numchildren(ex) == 2 ex
@@ -3019,8 +3019,8 @@ function typevar_bounds(ctx, ex)
     (name, lb, ub) = bounds = @stm ex begin
         [K"Identifier"] -> (ex, any, any)
         [K"Placeholder"] -> (ex, any, any)
-        ([K"comparison" lb op x _ ub], when=op.name_val==="<:") -> (x, lb, ub)
-        ([K"comparison" ub op x _ lb], when=op.name_val===">:") -> (x, lb, ub)
+        ([K"comparison" lb op x _ ub], when=getattr(String, op, :name_val)==="<:") -> (x, lb, ub)
+        ([K"comparison" ub op x _ lb], when=getattr(String, op, :name_val)===">:") -> (x, lb, ub)
         [K"<:" x ub] -> (x, any, ub)
         [K">:" x lb] -> (x, lb, any)
     end
@@ -3247,8 +3247,8 @@ end
 
 function _is_new_call(ex)
     kind(ex) == K"call" &&
-        ((kind(ex[1]) == K"Identifier" && ex[1].name_val == "new") ||
-         (kind(ex[1]) == K"curly" && kind(ex[1][1]) == K"Identifier" && ex[1][1].name_val == "new"))
+        ((kind(ex[1]) == K"Identifier" && getattr(String, ex[1], :name_val) == "new") ||
+         (kind(ex[1]) == K"curly" && kind(ex[1][1]) == K"Identifier" && getattr(String, ex[1][1], :name_val) == "new"))
 end
 
 # Rewrite constructor signature, returning extra information needed for
@@ -3272,7 +3272,7 @@ function rewrite_ctor_sig(ctx, sig, tname, global_tname, struct_typevars, wheres
         # constructor for X (rewrite it to `X{T}(...) where T`)
         ([K"call" [K"::" _ [K"where" _...]] args...], when=begin
              t, inner_wheres = flatten_wheres(ex[1][2])
-             isempty(wheres) && kind(t) === K"curly" && get(t[1], :name_val, "") == "Type"
+             isempty(wheres) && kind(t) === K"curly" && getattr(String, t[1], :name_val, "") == "Type"
          end) -> let
              append!(wheres, inner_wheres)
              ex2 = @ast ctx ex [K"call" t[2] args...]
@@ -3493,7 +3493,7 @@ function _insert_fieldtype_struct_shim(ctx, name, ex)
     if kind(ex) == K"." &&
         numchildren(ex) == 2 &&
         kind(ex[2]) == K"Symbol" &&
-        ex[2].name_val == name.name_val
+        getattr(String, ex[2], :name_val) == getattr(String, name, :name_val)
         @ast ctx ex [K"call" "struct_name_shim"::K"core" ex[1] ex[2] ctx.mod::K"Value" name]
     elseif numchildren(ex) > 0
         mapchildren(e->_insert_fieldtype_struct_shim(ctx, name, e), ctx, ex)
@@ -3514,7 +3514,7 @@ function _replace_type_constructors(ctx, ex)
         return ex
     end
     k = kind(ex)
-    if k == K"call" && numchildren(ex) >= 1 && kind(ex[1]) == K"core" && ex[1].name_val == "apply_type"
+    if k == K"call" && numchildren(ex) >= 1 && kind(ex[1]) == K"core" && getattr(String, ex[1], :name_val) == "apply_type"
         new_head = @ast ctx ex[1] "apply_type_or_typeapp"::K"core"
         new_children = SyntaxList(ctx)
         push!(new_children, new_head)
@@ -4004,7 +4004,7 @@ function expand_importpath(path)
             component = component[1]
         end
         @jl_assert kind(component) in (K"Identifier", K".") component
-        name = component.name_val
+        name = getattr(String, component, :name_val)
         is_dot = kind(component) == K"."
         if is_dot && !prev_was_dot
             throw(LoweringError(component, "invalid import path: `.` in identifier path"))
@@ -4042,7 +4042,7 @@ function expand_import_or_using(ctx, ex)
         if kind(spec) == K"as"
             @jl_assert numchildren(spec) == 2 spec
             @jl_assert kind(spec[2]) == K"Identifier" spec
-            as_name = Symbol(spec[2].name_val)
+            as_name = Symbol(getattr(String, spec[2], :name_val))
             path = QuoteNode(Expr(:as, expand_importpath(spec[1]), as_name))
         else
             path = QuoteNode(expand_importpath(spec))
@@ -4098,9 +4098,9 @@ function expand_public(ctx, ex)
     identifiers = String[]
     for e in children(ex)
         @jl_assert kind(e) == K"Identifier" (ex, "Expected identifier")
-        push!(identifiers, e.name_val)
+        push!(identifiers, getattr(String, e, :name_val))
     end
-    (e.name_val::K"String" for e in children(ex))
+    (getattr(String, e, :name_val)::K"String" for e in children(ex))
     @ast ctx ex [K"call"
         eval_public::K"Value"
         ctx.mod::K"Value"
@@ -4118,7 +4118,7 @@ function isquotedmacrocall(ex)
     let (f, ex) = (ex[1], ex[3])
         kind(f) == K"Value" || return false
         kind(ex) == K"inert" || return false
-        f.value === interpolate_ast || return false
+        getattr(Any, f, :value) === interpolate_ast || return false
         kind(ex[1]) == K"macrocall" || return false
         return true
     end
@@ -4129,7 +4129,7 @@ function expand_doc(ctx, ex, docex)
         expand_forms_2(ctx, @ast ctx docex [K"call"
             bind_static_docs!::K"Value"
             (kind(ex) === K"." ? ex[1] : ctx.mod::K"Value")
-            (kind(ex) === K"." ? ex[2] : ex).name_val::K"Symbol"
+            getattr(String, (kind(ex) === K"." ? ex[2] : ex), :name_val)::K"Symbol"
             docex[1]
             ::K"SourceLocation"(ex)
             Union{}::K"Value"
@@ -4225,7 +4225,7 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
             [K"continue" [K"Placeholder"]] ->
                 @ast ctx ex [K"break" "loop-cont"::K"symboliclabel"]
             [K"continue" [K"Identifier"]] ->
-                @ast ctx ex [K"break" string(ex[1].name_val, "#cont")::K"symboliclabel"]
+                @ast ctx ex [K"break" string(getattr(String, ex[1], :name_val), "#cont")::K"symboliclabel"]
         end
     elseif k == K"comparison"
         expand_forms_2(ctx, expand_compare_chain(ctx, ex))

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -160,11 +160,11 @@ end
 function ir_debug_info_state(ex)
     e1 = first(flattened_provenance(ex))
     topfile = filename(e1)
-    [(topfile, [], Vector{Int32}())]
+    Tuple{String, Vector{Any}, Vector{Int32}}[(topfile, [], Vector{Int32}())]
 end
 
 function add_ir_debug_info!(current_codelocs_stack, stmt)
-    locstk = [(filename(e), source_location(e)[1]) for e in flattened_provenance(stmt)]
+    locstk = Tuple{String, Int32}[(filename(e), source_location(e)[1]) for e in flattened_provenance(stmt)]
     for j in 1:length(locstk)
         if j === 1 && current_codelocs_stack[j][1] != locstk[j][1]
             # dilemma: the filename stack here shares no prefix with that of the
@@ -328,8 +328,8 @@ function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
     if is_literal(k)
         ex.value
     elseif k == K"core"
-        name = ex.name_val
-        if name == "nothing"
+        name = ex.name_val::String
+        if name === "nothing"
             # Translate Core.nothing into literal `nothing`s (flisp uses a
             # special form (null) for this during desugaring, etc)
             nothing
@@ -337,24 +337,24 @@ function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
             GlobalRef(Core, Symbol(name))
         end
     elseif k == K"top"
-        GlobalRef(Base, Symbol(ex.name_val))
+        GlobalRef(Base, Symbol(ex.name_val::String))
     elseif k == K"globalref"
-        GlobalRef(ex.mod, Symbol(ex.name_val))
+        GlobalRef(ex.mod::Module, Symbol(ex.name_val::String))
     elseif k == K"Identifier"
         # Implicitly refers to name in parent module
         # TODO: Should we even have plain identifiers at this point or should
         # they all effectively be resolved into GlobalRef earlier?
-        Symbol(ex.name_val)
+        Symbol(ex.name_val::String)
     elseif k == K"SourceLocation"
         QuoteNode(source_location(LineNumberNode, ex))
     elseif k == K"Symbol"
-        QuoteNode(Symbol(ex.name_val))
+        QuoteNode(Symbol(ex.name_val::String))
     elseif k == K"slot"
-        Core.SlotNumber(ex.var_id)
+        Core.SlotNumber(ex.var_id::IdTag)
     elseif k == K"static_parameter"
-        Expr(:static_parameter, ex.var_id)
+        Expr(:static_parameter, ex.var_id::IdTag)
     elseif k == K"SSAValue"
-        Core.SSAValue(ex.var_id + stmt_offset)
+        Core.SSAValue(ex.var_id::IdTag + stmt_offset)
     elseif k == K"return"
         Core.ReturnNode(_to_lowered_expr(ex[1], stmt_offset))
     elseif k == K"inert"

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -72,14 +72,14 @@ function lower_step(iter, mod, world=Base.get_world_counter())
     elseif k == K"module"
         (version, notbare, name, body) = @stm ex begin
             [K"module" version nb_st name body] ->
-                (version.value, nb_st.value, name, body)
+                (getattr(Any, version, :value), getattr(Any, nb_st, :value), name, body)
             [K"module" nb_st name body] ->
-                (nothing, nb_st.value, name, body)
+                (nothing, getattr(Any, nb_st, :value), name, body)
         end
         if kind(name) != K"Identifier"
             throw(LoweringError(name, "Expected module name"))
         end
-        newmod_name = Symbol(name.name_val)
+        newmod_name = Symbol(getattr(String, name, :name_val))
         loc = source_location(LineNumberNode, ex)
         push!(iter.todo, (body, true, 1))
         return Core.svec(:begin_module, version, newmod_name, notbare, loc)
@@ -326,9 +326,9 @@ end
 function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
     k = kind(ex)
     if is_literal(k)
-        ex.value
+        getattr(Any, ex, :value)
     elseif k == K"core"
-        name = ex.name_val::String
+        name = getattr(String, ex, :name_val)
         if name === "nothing"
             # Translate Core.nothing into literal `nothing`s (flisp uses a
             # special form (null) for this during desugaring, etc)
@@ -337,24 +337,24 @@ function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
             GlobalRef(Core, Symbol(name))
         end
     elseif k == K"top"
-        GlobalRef(Base, Symbol(ex.name_val::String))
+        GlobalRef(Base, Symbol(getattr(String, ex, :name_val)))
     elseif k == K"globalref"
-        GlobalRef(ex.mod::Module, Symbol(ex.name_val::String))
+        GlobalRef(getattr(Module, ex, :mod), Symbol(getattr(String, ex, :name_val)))
     elseif k == K"Identifier"
         # Implicitly refers to name in parent module
         # TODO: Should we even have plain identifiers at this point or should
         # they all effectively be resolved into GlobalRef earlier?
-        Symbol(ex.name_val::String)
+        Symbol(getattr(String, ex, :name_val))
     elseif k == K"SourceLocation"
         QuoteNode(source_location(LineNumberNode, ex))
     elseif k == K"Symbol"
-        QuoteNode(Symbol(ex.name_val::String))
+        QuoteNode(Symbol(getattr(String, ex, :name_val)))
     elseif k == K"slot"
-        Core.SlotNumber(ex.var_id::IdTag)
+        Core.SlotNumber(getattr(IdTag, ex, :var_id))
     elseif k == K"static_parameter"
-        Expr(:static_parameter, ex.var_id::IdTag)
+        Expr(:static_parameter, getattr(IdTag, ex, :var_id))
     elseif k == K"SSAValue"
-        Core.SSAValue(ex.var_id::IdTag + stmt_offset)
+        Core.SSAValue(getattr(IdTag, ex, :var_id) + stmt_offset)
     elseif k == K"return"
         Core.ReturnNode(_to_lowered_expr(ex[1], stmt_offset))
     elseif k == K"inert"
@@ -362,20 +362,20 @@ function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
     elseif k == K"inert_syntaxtree"
         ex[1]
     elseif k == K"code_info"
-        ir = to_code_info(ex[1], ex.slots, ex.meta)
-        if ex.is_toplevel_thunk
+        ir = to_code_info(ex[1], getattr(Vector{Slot}, ex, :slots), getattr(CompileHints, ex, :meta))
+        if getattr(Bool, ex, :is_toplevel_thunk)
             Expr(:thunk, ir) # TODO: Maybe nice to just return a CodeInfo here?
         else
             ir
         end
     elseif k == K"Value"
-        ex.value isa LineNumberNode ? QuoteNode(ex.value) : ex.value
+        let v = getattr(Any, ex, :value); v isa LineNumberNode ? QuoteNode(v) : v; end
     elseif k == K"goto"
-        Core.GotoNode(ex[1].id + stmt_offset)
+        Core.GotoNode(getattr(Int, ex[1], :id) + stmt_offset)
     elseif k == K"gotoifnot"
-        Core.GotoIfNot(_to_lowered_expr(ex[1], stmt_offset), ex[2].id + stmt_offset)
+        Core.GotoIfNot(_to_lowered_expr(ex[1], stmt_offset), getattr(Int, ex[2], :id) + stmt_offset)
     elseif k == K"enter"
-        catch_idx = ex[1].id + stmt_offset
+        catch_idx = getattr(Int, ex[1], :id) + stmt_offset
         numchildren(ex) == 1 ?
             Core.EnterNode(catch_idx) :
             Core.EnterNode(catch_idx, _to_lowered_expr(ex[2], stmt_offset))

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -192,7 +192,7 @@ function compile_pop_exception(ctx, srcref, src_tokens, dest_tokens)
     # dest_tokens when src_tokens is the same or nested within dest_tokens.
     # It's enough to check the token on the top of the dest stack.
     n = length(dest_tokens)
-    jump_ok = n == 0 || (n <= length(src_tokens) && dest_tokens[n].var_id == src_tokens[n].var_id)
+    jump_ok = n == 0 || (n <= length(src_tokens) && _binding_id(dest_tokens[n]) == _binding_id(src_tokens[n]))
     jump_ok || throw(LoweringError(srcref, "Attempt to jump into catch block"))
     if n < length(src_tokens)
         @ast ctx srcref [K"pop_exception" src_tokens[n+1]]
@@ -203,7 +203,7 @@ end
 
 function compile_leave_handler(ctx, srcref, src_tokens, dest_tokens)
     n = length(dest_tokens)
-    jump_ok = n == 0 || (n <= length(src_tokens) && dest_tokens[n].var_id == src_tokens[n].var_id)
+    jump_ok = n == 0 || (n <= length(src_tokens) && _binding_id(dest_tokens[n]) == _binding_id(src_tokens[n]))
     jump_ok || throw(LoweringError(srcref, "Attempt to jump into try block"))
     if n < length(src_tokens)
         @ast ctx srcref [K"leave" src_tokens[n+1:end]...]
@@ -358,7 +358,7 @@ end
 # `op` may be either K"=" (where global assignments are converted to setglobal!)
 # or K"constdecl".  flisp: emit-assignment-or-setglobal
 function emit_simple_assignment(ctx, srcref, lhs, rhs, op=K"=")
-    binfo = get_binding(ctx, lhs.var_id)
+    binfo = get_binding(ctx, lhs)
     if binfo.kind == :global
         emit(ctx, @ast ctx srcref [
             K"call"
@@ -935,7 +935,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
     elseif k == K"newvar"
         @jl_assert !needs_value ex
         is_duplicate = !isempty(ctx.code) &&
-            (e = last(ctx.code); kind(e) == K"newvar" && e[1].var_id == ex[1].var_id)
+            (e = last(ctx.code); kind(e) == K"newvar" && _binding_id(e[1]) == _binding_id(ex[1]))
         if !is_duplicate
             # TODO: also exclude deleted vars
             emit(ctx, ex)
@@ -962,7 +962,7 @@ function _remove_vars_with_isdefined_check!(vars, ex)
     if is_leaf(ex) || is_quoted(ex) || kind(ex) == K"static_eval"
         return
     elseif kind(ex) == K"isdefined"
-        delete!(vars, ex[1].var_id)
+        delete!(vars, ex[1].var_id::IdTag)
     else
         for e in children(ex)
             _remove_vars_with_isdefined_check!(vars, e)
@@ -987,14 +987,14 @@ function unnecessary_newvar_ids(ctx, stmts)
         _remove_vars_with_isdefined_check!(vars, ex)
         k = kind(ex)
         if k == K"newvar"
-            id = ex[1].var_id
+            id = _binding_id(ex[1])
             if !get_binding(ctx, id).is_captured
                 push!(vars, id)
             end
         elseif k == K"goto" || k == K"gotoifnot" || (k == K"=" && kind(ex[2]) == K"enter")
             empty!(vars)
         elseif k == K"="
-            id = ex[1].var_id
+            id = _binding_id(ex[1])
             if id in vars
                 delete!(vars, id)
                 push!(ids_assigned_before_branch, id)
@@ -1042,7 +1042,7 @@ function compile_body(ctx::LinearIRContext, ex)
     # Filter out unnecessary newvar nodes
     ids_assigned_before_branch = unnecessary_newvar_ids(ctx, ctx.code)
     filter!(ctx.code) do ex
-        !(kind(ex) == K"newvar" && ex[1].var_id in ids_assigned_before_branch)
+        !(kind(ex) == K"newvar" && _binding_id(ex[1]) in ids_assigned_before_branch)
     end
 end
 
@@ -1053,7 +1053,7 @@ end
 function _renumber(ctx, ssa_rewrites, slot_rewrites, label_table, ex)
     k = kind(ex)
     if k == K"BindingId"
-        id = ex.var_id
+        id = _binding_id(ex)
         if haskey(ssa_rewrites, id)
             setattr!(newleaf(ctx, ex, K"SSAValue"), :var_id, ssa_rewrites[id])
         else
@@ -1084,7 +1084,7 @@ function _renumber(ctx, ssa_rewrites, slot_rewrites, label_table, ex)
     elseif is_literal(k) || is_quoted(k)
         ex
     elseif k == K"label"
-        @ast ctx ex label_table[ex.id]::K"label"
+        @ast ctx ex label_table[ex.id::Int]::K"label"
     elseif k == K"code_info"
         ex
     else
@@ -1104,12 +1104,12 @@ function renumber_body(ctx, input_code, slot_rewrites)
         k = kind(ex)
         ex_out = nothing
         if k == K"=" && is_ssa(ctx, ex[1])
-            lhs_id = ex[1].var_id
+            lhs_id = _binding_id(ex[1])
             @jl_assert(!haskey(ssa_rewrites, lhs_id),
                        (ex, "multiple assignments to ssavalue"))
             if is_ssa(ctx, ex[2])
                 # For SSA₁ = SSA₂, record that all uses of SSA₁ should be replaced by SSA₂
-                ssa_rewrites[lhs_id] = ssa_rewrites[ex[2].var_id]
+                ssa_rewrites[lhs_id] = ssa_rewrites[_binding_id(ex[2])]
             else
                 # Otherwise, record which `code` index this SSA value refers to
                 ssa_rewrites[lhs_id] = length(code) + 1
@@ -1156,11 +1156,10 @@ function compile_lambda(outer_ctx, ex)
     for arg in children(lambda_args)
         kind(arg) == K"Placeholder" && continue
         @jl_assert kind(arg) == K"BindingId" ex
-        id = arg.var_id
-        binfo = get_binding(ctx, id)
+        binfo = get_binding(ctx, arg)
         if binfo.is_assigned
             @jl_assert !haskey(ctx.argmap, binfo.id) ex arg
-            ctx.argmap[binfo.id] = new_local_binding(ctx, binding_ex(ctx, binfo), binfo.name).var_id
+            ctx.argmap[binfo.id] = _binding_id(new_local_binding(ctx, binding_ex(ctx, binfo), binfo.name))
         end
     end
     compile_body(ctx, ex[3])

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -302,7 +302,7 @@ function emit_return(ctx, ex)
 end
 
 function emit_break(ctx, ex)
-    name = ex[1].name_val
+    name = getattr(String, ex[1], :name_val)
     target = get(ctx.break_targets, name, nothing)
     if isnothing(target)
         if name == "loop-exit"
@@ -391,7 +391,7 @@ end
 function make_label(ctx, srcref)
     id = ctx.next_label_id[]
     ctx.next_label_id[] += 1
-    setattr!(newleaf(ctx, srcref, K"label"), :id, id)
+    setattr!(Int, newleaf(ctx, srcref, K"label"), :id, id)
 end
 
 # flisp: make&mark-label
@@ -628,7 +628,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         if kind(ex1) == K"BindingId"
             binfo = get_binding(ctx, ex1)
             if haskey(ctx.argmap, binfo.id)
-                ex1 = setattr!(newleaf(ctx, ex1, K"BindingId"), :var_id, ctx.argmap[binfo.id])
+                ex1 = setattr!(IdTag, newleaf(ctx, ex1, K"BindingId"), :var_id, ctx.argmap[binfo.id])
             end
         end
         if in_tail_pos
@@ -670,8 +670,8 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
                 binfo = get_binding(ctx, ex[1])
                 binfo.mod, binfo.name
             else
-                @jl_assert kind(ex[1]) == K"Value" && typeof(ex[1].value) === GlobalRef ex
-                gr = ex[1].value
+                @jl_assert kind(ex[1]) == K"Value" && typeof(getattr(Any, ex[1], :value)) === GlobalRef ex
+                gr = getattr(Any, ex[1], :value)
                 gr.mod, String(gr.name)
             end
             emit(ctx, @ast ctx ex [K"call" "declare_const"::K"core"
@@ -681,7 +681,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
             if kind(lhs) == K"BindingId"
                 binfo = get_binding(ctx, lhs)
                 if haskey(ctx.argmap, binfo.id)
-                    lhs = setattr!(newleaf(ctx, lhs, K"BindingId"), :var_id, ctx.argmap[binfo.id])
+                    lhs = setattr!(IdTag, newleaf(ctx, lhs, K"BindingId"), :var_id, ctx.argmap[binfo.id])
                 end
             end
             if needs_value && !isnothing(rhs)
@@ -717,7 +717,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
             res
         end
     elseif k == K"symbolicblock"
-        name = ex[1].name_val
+        name = getattr(String, ex[1], :name_val)
         # Skip duplicate check for default-scope labels (loop-exit, loop-cont) which allow nesting
         if name != "loop-exit" && name != "loop-cont"
             if haskey(ctx.symbolic_jump_targets, name) || name in ctx.symbolic_block_labels
@@ -764,7 +764,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         emit_break(ctx, ex)
     elseif k == K"symboliclabel"
         label = emit_label(ctx, ex)
-        name = ex.name_val
+        name = getattr(String, ex, :name_val)
         if haskey(ctx.symbolic_jump_targets, name) || name in ctx.symbolic_block_labels
             throw(LoweringError(ex, "Label `$name` defined multiple times"))
         end
@@ -887,13 +887,13 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         nothing
     elseif k == K"meta"
         @jl_assert numchildren(ex) >= 1 ex
-        if ex[1].name_val in ("inline", "noinline", "propagate_inbounds",
+        if getattr(String, ex[1], :name_val) in ("inline", "noinline", "propagate_inbounds",
                               "nospecializeinfer", "aggressive_constprop", "no_constprop")
             for c in children(ex)
-                ctx.meta[Symbol(c.name_val)] = true
+                ctx.meta[Symbol(getattr(String, c, :name_val))] = true
             end
-        elseif ex[1].name_val === "purity"
-            ctx.meta[Symbol(ex[1].name_val)] = ex[2].value::Base.EffectsOverride
+        elseif getattr(String, ex[1], :name_val) === "purity"
+            ctx.meta[Symbol(getattr(String, ex[1], :name_val))] = getattr(Any, ex[2], :value)::Base.EffectsOverride
         else
             emit(ctx, ex)
         end
@@ -962,7 +962,7 @@ function _remove_vars_with_isdefined_check!(vars, ex)
     if is_leaf(ex) || is_quoted(ex) || kind(ex) == K"static_eval"
         return
     elseif kind(ex) == K"isdefined"
-        delete!(vars, ex[1].var_id::IdTag)
+        delete!(vars, getattr(IdTag, ex[1], :var_id))
     else
         for e in children(ex)
             _remove_vars_with_isdefined_check!(vars, e)
@@ -1011,7 +1011,7 @@ function compile_body(ctx::LinearIRContext, ex)
     # Fix up any symbolic gotos. (We can't do this earlier because the goto
     # might precede the label definition in unstructured control flow.)
     for origin in ctx.symbolic_jump_origins
-        name = origin.goto.name_val
+        name = getattr(String, origin.goto, :name_val)
         target = get(ctx.symbolic_jump_targets, name, nothing)
         if isnothing(target)
             # Check if it's a symbolic block label
@@ -1055,7 +1055,7 @@ function _renumber(ctx, ssa_rewrites, slot_rewrites, label_table, ex)
     if k == K"BindingId"
         id = _binding_id(ex)
         if haskey(ssa_rewrites, id)
-            setattr!(newleaf(ctx, ex, K"SSAValue"), :var_id, ssa_rewrites[id])
+            setattr!(IdTag, newleaf(ctx, ex, K"SSAValue"), :var_id, ssa_rewrites[id])
         else
             new_id = get(slot_rewrites, id, nothing)
             binfo = get_binding(ctx, id)
@@ -1063,14 +1063,14 @@ function _renumber(ctx, ssa_rewrites, slot_rewrites, label_table, ex)
                 sk = binfo.kind == :local || binfo.kind == :argument ? K"slot"             :
                      binfo.kind == :static_parameter                 ? K"static_parameter" :
                      throw(LoweringError(ex, "Found unexpected binding of kind $(binfo.kind)"))
-                setattr!(newleaf(ctx, ex, sk), :var_id, new_id)
+                setattr!(IdTag, newleaf(ctx, ex, sk), :var_id, new_id)
             else
                 if binfo.kind !== :global
                     throw(LoweringError(ex, "Found unexpected binding of kind $(binfo.kind)"))
                 end
                 out = newleaf(ctx, ex, K"globalref")
-                setattr!(out, :name_val, binfo.name)
-                setattr!(out, :mod, binfo.mod)
+                setattr!(String, out, :name_val, binfo.name)
+                setattr!(Module, out, :mod, binfo.mod)
             end
         end
     elseif k == K"meta" || k == K"static_eval"
@@ -1084,7 +1084,7 @@ function _renumber(ctx, ssa_rewrites, slot_rewrites, label_table, ex)
     elseif is_literal(k) || is_quoted(k)
         ex
     elseif k == K"label"
-        @ast ctx ex label_table[ex.id::Int]::K"label"
+        @ast ctx ex label_table[getattr(Int, ex, :id)]::K"label"
     elseif k == K"code_info"
         ex
     else
@@ -1116,7 +1116,7 @@ function renumber_body(ctx, input_code, slot_rewrites)
                 ex_out = ex[2]
             end
         elseif k == K"label"
-            label_table[ex.id] = length(code) + 1
+            label_table[getattr(Int, ex, :id)] = length(code) + 1
         elseif k == K"TOMBSTONE"
             # remove statement
         else
@@ -1150,8 +1150,8 @@ function compile_lambda(outer_ctx, ex)
     lambda_args = ex[1]
     static_parameters = ex[2]
     ret_var = numchildren(ex) == 4 ? ex[4] : nothing
-    lambda_bindings = ex.lambda_bindings
-    ctx = LinearIRContext(outer_ctx.graph, outer_ctx, ex.is_toplevel_thunk,
+    lambda_bindings = getattr(LambdaBindings, ex, :lambda_bindings)
+    ctx = LinearIRContext(outer_ctx.graph, outer_ctx, getattr(Bool, ex, :is_toplevel_thunk),
                           lambda_bindings, ret_var)
     for arg in children(lambda_args)
         kind(arg) == K"Placeholder" && continue
@@ -1177,7 +1177,7 @@ function compile_lambda(outer_ctx, ex)
                               false, false, false, false))
         else
             @jl_assert kind(arg) == K"BindingId" ex arg
-            id = arg.var_id
+            id = getattr(IdTag, arg, :var_id)
             binfo = get_binding(ctx, id)
             @jl_assert binfo.kind == :local || binfo.kind == :argument ex arg
             push!(slots, Slot(binfo.name, :argument, binfo.is_nospecialize,
@@ -1200,7 +1200,7 @@ function compile_lambda(outer_ctx, ex)
     end
     for (i,arg) in enumerate(children(static_parameters))
         @jl_assert kind(arg) == K"BindingId" arg
-        id = arg.var_id
+        id = getattr(IdTag, arg, :var_id)
         info = get_binding(ctx.bindings, id)
         @jl_assert info.kind == :static_parameter arg
         slot_rewrites[id] = i
@@ -1210,7 +1210,7 @@ function compile_lambda(outer_ctx, ex)
     for (k, v) in ctx.meta
         meta = CompileHints(meta, k, v)
     end
-    @ast ctx ex [K"code_info"(is_toplevel_thunk=ex.is_toplevel_thunk,
+    @ast ctx ex [K"code_info"(is_toplevel_thunk=getattr(Bool, ex, :is_toplevel_thunk),
                               slots=slots, meta=meta)
         [K"block"(ex[3])
             code...

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -312,7 +312,7 @@ function expand_macro(ctx, ex)
             rethrow(newexc)
         end
         if expanded isa SyntaxTree
-            if !is_compatible_graph(ctx, expanded)
+            if expanded._graph !== ctx.graph
                 # If the macro has produced syntax outside the macro context,
                 # copy it over. TODO: Do we expect this always to happen?  What
                 # is the API for access to the macro expansion context?
@@ -386,7 +386,7 @@ function append_sourceref(ctx, ex, secondary_prov)
         if kind(ex) == K"macrocall"
             copy_node(ex)
         else
-            cs = map(e->append_sourceref(ctx, e, secondary_prov)._id, children(ex))
+            cs = mapsyntax(e->append_sourceref(ctx, e, secondary_prov)._id, children(ex))
             mknode(ex, cs)
         end
     else
@@ -474,13 +474,15 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
     end
 end
 
-ensure_macro_attributes!(graph) = ensure_attributes!(
-    graph;
-    var_id=IdTag,
-    scope_layer=LayerId,
-    __macro_ctx__=Nothing,
-    meta=CompileHints,
-    (DEBUG ? (:jl_source=>LineNumberNode,) : ())...)
+function ensure_macro_attributes!(graph)
+    g2 = ensure_attributes!(
+        graph;
+        var_id=IdTag,
+        scope_layer=LayerId,
+        __macro_ctx__=Nothing,
+        meta=CompileHints)
+    DEBUG ? ensure_attributes!(g2; jl_source=LineNumberNode) : g2
+end
 
 @fzone "JL: macroexpand" function expand_forms_1(mod::Module, ex::SyntaxTree, expr_compat_mode::Bool, macro_world::UInt)
     if kind(ex) == K"local"

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -157,7 +157,7 @@ function _eval_dot(world::UInt, mod, ex::SyntaxTree)
         ex = ex[1]
     end
     kind(ex) in KSet"Identifier Symbol" && mod isa Module ?
-        Base.invoke_in_world(world, getproperty, mod, Symbol(ex.name_val)) :
+        Base.invoke_in_world(world, getproperty, mod, Symbol(getattr(String, ex, :name_val))) :
         nothing
 end
 
@@ -170,16 +170,17 @@ function eval_macro_name(ctx::MacroExpansionContext, mctx::MacroContext, ex0::Sy
     ex = expand_forms_1(ctx, ex0)
     try
         if kind(ex) === K"Value"
-            !(ex.value isa GlobalRef) ? ex.value :
+            v = getattr(Any, ex, :value)
+            !(v isa GlobalRef) ? v :
                 Base.invoke_in_world(ctx.macro_world, getglobal,
-                                     ex.value.mod, ex.value.name)
+                                     v.mod, v.name)
         elseif kind(ex) === K"Identifier"
-            layer = get(ex, :scope_layer, nothing)
+            layer = getattr(LayerId, ex, :scope_layer, nothing)
             if !isnothing(layer)
                 mod = ctx.scope_layers[layer].mod
             end
             Base.invoke_in_world(ctx.macro_world, getproperty,
-                                 mod, Symbol(ex.name_val))
+                                 mod, Symbol(getattr(String, ex, :name_val)))
         elseif kind(ex) === K"." &&
                 (ed = _eval_dot(ctx.macro_world, mod, ex); !isnothing(ed))
             ed
@@ -206,9 +207,9 @@ end
 # See also set_scope_layer()
 function set_macro_arg_hygiene(ctx, ex, layer_ids, layer_idx)
     k = kind(ex)
-    scope_layer = get(ex, :scope_layer, layer_ids[layer_idx])
+    scope_layer = getattr(LayerId, ex, :scope_layer, layer_ids[layer_idx])
     if is_leaf(ex)
-        setattr!(copy_node(ex), :scope_layer, scope_layer)
+        setattr!(LayerId, copy_node(ex), :scope_layer, scope_layer)
     else
         inner_layer_idx = k == K"escape" ? layer_idx - 1 : layer_idx
         if k == K"escape" && inner_layer_idx < 1
@@ -221,7 +222,7 @@ function set_macro_arg_hygiene(ctx, ex, layer_ids, layer_idx)
         end
         node = mapchildren(e->set_macro_arg_hygiene(
             ctx, e, layer_ids, inner_layer_idx), ctx, ex)
-        setattr!(node, :scope_layer, scope_layer)
+        setattr!(LayerId, node, :scope_layer, scope_layer)
     end
 end
 
@@ -277,7 +278,7 @@ function expand_macro(ctx, ex)
     macfunc = eval_macro_name(ctx, mctx, macname)
     raw_args = ex[3:end]
     macro_loc = if kind(ex[2]) === K"Value"
-        loc = ex[2].value
+        loc = getattr(Any, ex[2], :value)
         if loc isa LineNumberNode
         # Some macros, e.g. @cmd, don't play nicely with file == nothing
         isnothing(loc.file) ? LineNumberNode(loc.line, :none) : loc
@@ -331,7 +332,7 @@ function expand_macro(ctx, ex)
         if length(raw_args) >= 1 && kind(raw_args[1]) === K"VERSION"
             # Hack: see jl_invoke_julia_macro.  We may see an extra argument
             # depending on who parsed this macrocall.
-            macro_args[1] = Core.MacroSource(macro_loc, raw_args[1].value)
+            macro_args[1] = Core.MacroSource(macro_loc, getattr(Any, raw_args[1], :value))
         end
 
         for arg in raw_args
@@ -392,7 +393,7 @@ function append_sourceref(ctx, ex, secondary_prov)
     else
         copy_node(ex)
     end
-    setattr!(out, :source, _unpack_srcref(syntax_graph(ctx), srcref))
+    setattr!(SourceAttrType, out, :source, _unpack_srcref(syntax_graph(ctx), srcref))
 end
 
 function remove_scope_layer!(ex)
@@ -401,7 +402,7 @@ function remove_scope_layer!(ex)
             remove_scope_layer!(c)
         end
     end
-    JuliaSyntax.deleteattr!(ex, :scope_layer)
+    JuliaSyntax.deleteattr!(LayerId, ex, :scope_layer)
     ex
 end
 
@@ -418,9 +419,9 @@ identifier with the expansion it came from.
 function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
     k = kind(ex)
     if k == K"Identifier"
-        scope_layer = get(ex, :scope_layer, current_layer_id(ctx))
+        scope_layer = getattr(LayerId, ex, :scope_layer, current_layer_id(ctx))
         out = mkleaf(ex)
-        setattr!(out, :scope_layer, scope_layer)
+        setattr!(LayerId, out, :scope_layer, scope_layer)
     elseif k == K"escape"
         if numchildren(ex) !== 1
             throw(LoweringError(ex, "`escape` requires one argument"))
@@ -433,10 +434,10 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
         push!(ctx.scope_layer_stack, top_layer)
         escaped_ex
     elseif k == K"hygienic-scope"
-        if !(2 <= numchildren(ex) <= 3 && ex[2].value isa Module)
+        if !(2 <= numchildren(ex) <= 3 && getattr(Any, ex[2], :value) isa Module)
             throw(LoweringError(ex,"`hygienic-scope` requires an AST and a module"))
         end
-        new_layer = ScopeLayer(length(ctx.scope_layers)+1, ex[2].value,
+        new_layer = ScopeLayer(length(ctx.scope_layers)+1, getattr(Any, ex[2], :value),
                                current_layer_id(ctx), true, false)
         push!(ctx.scope_layers, new_layer)
         push!(ctx.scope_layer_stack, new_layer.id)
@@ -464,8 +465,8 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
         # if this is a form that requires resolving some identifier, add the
         # scope layer.  if this is an unknown form to be cleaned up by AST
         # conversion, save the scope layer just in case.
-        layerid = get(ex, :scope_layer, current_layer_id(ctx))
-        setattr(mapchildren(e->expand_forms_1(ctx,e), ctx, ex),
+        layerid = getattr(LayerId, ex, :scope_layer, current_layer_id(ctx))
+        setattr(LayerId, mapchildren(e->expand_forms_1(ctx,e), ctx, ex),
                 :scope_layer, layerid)
     elseif is_leaf(ex)
         ex

--- a/JuliaLowering/src/runtime.jl
+++ b/JuliaLowering/src/runtime.jl
@@ -115,7 +115,7 @@ function interpolate_ast(::Type{SyntaxTree}, ex::SyntaxTree, values...)
     graph = nothing
     for vals in values
         for v in vals
-            if v isa SyntaxTree && hasattr(syntax_graph(v), :__macro_ctx__)
+            if v isa SyntaxTree && hasattr(Nothing, syntax_graph(v), :__macro_ctx__)
                 graph = syntax_graph(v)
                 break
             end

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -87,8 +87,11 @@ struct ScopeResolutionContext{Attrs} <: AbstractLoweringContext
 end
 
 function contains_softscope_marker(ex)
-    kind(ex) == K"softscope" ||
-        needs_resolution(ex) && any(contains_softscope_marker, children(ex))
+    kind(ex) == K"softscope"  && return true
+    needs_resolution(ex) && for c in children(ex)
+        contains_softscope_marker(c) && return true
+    end
+    return false
 end
 
 top_scope(ctx) = ctx.scopes[1]
@@ -147,13 +150,15 @@ function declare_in_scope!(ctx, scope::ScopeInfo, ex, bk::Symbol; kws...)
     nk = NameKey(ex)
     if bk === :global
         declaration_scope = top_scope(ctx)
-        mod = hasattr(ex, :mod) ? ex.mod : ctx.scope_layers[ex.scope_layer].mod
+        mod = hasattr(ex, :mod) ? ex.mod::Module :
+            ctx.scope_layers[ex.scope_layer::LayerId].mod
     else
         declaration_scope = scope
         mod = hasattr(ex, :mod) ?
             throw(LoweringError(ex, "cannot use GlobalRef as local identifier")) : nothing
     end
-    is_internal = ctx.scope_layers[nk.layer].is_internal || getmeta(ex, :is_internal, false)
+    is_internal = ctx.scope_layers[nk.layer].is_internal ||
+        getmeta(ex, :is_internal, false)::Bool
     b = _new_binding(ctx, ex, nk.name, bk; mod, is_internal, kws...)
     declaration_scope.vars[nk] = b.id
     scope.vars[nk] = b.id
@@ -197,7 +202,7 @@ end
 
 function resolve_name(ctx, ex; exclude_toplevel_globals=false)
     # TODO: probably want to cache these lookups
-    for sid in reverse(ctx.scope_stack)
+    for sid in Iterators.reverse(ctx.scope_stack)
         bid = get(ctx.scopes[sid].vars, NameKey(ex), nothing)
         isnothing(bid) && continue
         b = get_binding(ctx, bid)
@@ -631,7 +636,7 @@ end
 function analyze_variables!(ctx, ex)
     k = kind(ex)
     if k == K"BindingId"
-        b = get_binding(ctx, ex.var_id)
+        b = get_binding(ctx, ex)
         b.is_read = true
         # The type of typed locals is invisible in the previous pass,
         # but is filled in here.
@@ -675,7 +680,7 @@ function analyze_variables!(ctx, ex)
         analyze_variables!(ctx, ex[2])
     elseif k == K"function_decl"
         name = ex[1]
-        b = get_binding(ctx, name.var_id)
+        b = get_binding(ctx, name)
         if b.kind === :local
             init_closure_bindings!(ctx, name)
         end
@@ -685,13 +690,13 @@ function analyze_variables!(ctx, ex)
             analyze_variables!(ctx, ex[1])
         end
     elseif k == K"constdecl"
-        b = get_binding(ctx, ex[1].var_id)
+        b = get_binding(ctx, ex[1])
         b.is_const = true
         add_assign!(b)
     elseif k == K"call"
         name = ex[1]
         if kind(name) == K"BindingId"
-            get_binding(ctx, name.var_id).is_called = true
+            get_binding(ctx, name).is_called = true
         end
         foreach(e->analyze_variables!(ctx, e), children(ex))
     elseif k == K"method_defs"
@@ -713,8 +718,8 @@ function analyze_variables!(ctx, ex)
             # Record all lambdas for the same closure type in one place
             func_name = last(ctx.method_def_stack)
             if kind(func_name) == K"BindingId"
-                func_name_id = func_name.var_id
-                if get_binding(ctx, func_name_id).kind === :local
+                func_name_id = func_name.var_id::IdTag
+                if get_binding(ctx, func_name).kind === :local
                     push!(ctx.closure_bindings[func_name_id].lambdas, lambda_bindings)
                 end
             end

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -14,7 +14,7 @@ end
 
 function NameKey(ex::SyntaxTree)
     @jl_assert kind(ex) === K"Identifier" ex
-    NameKey(ex.name_val, ex.scope_layer)
+    NameKey(getattr(String, ex, :name_val), getattr(LayerId, ex, :scope_layer))
 end
 
 struct ScopeInfo
@@ -50,13 +50,13 @@ function ScopeInfo(ctx, parent_id, ex::SyntaxTree)
     if parent_id == 0
         @jl_assert kind(ex) === K"lambda" ex
         lambda_id = id
-        is_permeable = ex.is_toplevel_thunk
+        is_permeable = getattr(Bool, ex, :is_toplevel_thunk)
         is_lifted = false
     else
         parent = ctx.scopes[parent_id]
         lambda_id = kind(ex) === K"lambda" ? id : parent.lambda_id
         is_permeable = (kind(ex) === K"scope_block" &&
-            ex.scope_type === :neutral && parent_id !== 0 && parent.is_permeable)
+            getattr(Symbol, ex, :scope_type) === :neutral && parent_id !== 0 && parent.is_permeable)
         is_lifted = kind(ex) === K"method_defs" ||
             (kind(ex) !== K"lambda" && parent.is_lifted)
     end
@@ -113,7 +113,7 @@ _var_str(v) = v === :local ? "local variable" :
 # variable usually can't be two things in one scope, but flisp has quirks.
 function maybe_declare_in_scope!(ctx, scope::ScopeInfo, ex, new_k::Symbol)
     if kind(ex) === K"BindingId"
-        bid = ex.var_id
+        bid = getattr(IdTag, ex, :var_id)
         b = get_binding(ctx, bid)
         @jl_assert b.kind === new_k ex
         @jl_assert b.lambda_id !== 0 (ex, "cannot declare a BindingId in multiple scopes")
@@ -150,11 +150,11 @@ function declare_in_scope!(ctx, scope::ScopeInfo, ex, bk::Symbol; kws...)
     nk = NameKey(ex)
     if bk === :global
         declaration_scope = top_scope(ctx)
-        mod = hasattr(ex, :mod) ? ex.mod::Module :
-            ctx.scope_layers[ex.scope_layer::LayerId].mod
+        mod = hasattr(Module, ex, :mod) ? getattr(Module, ex, :mod) :
+            ctx.scope_layers[getattr(LayerId, ex, :scope_layer)].mod
     else
         declaration_scope = scope
-        mod = hasattr(ex, :mod) ?
+        mod = hasattr(Module, ex, :mod) ?
             throw(LoweringError(ex, "cannot use GlobalRef as local identifier")) : nothing
     end
     is_internal = ctx.scope_layers[nk.layer].is_internal ||
@@ -228,7 +228,7 @@ function _find_scope_decls!(ctx, scope, ex)
                 ex, "allow local BindingId as function name?")
             get!(scope.binding_assignments, b.id, ex[1]._id)
         elseif k1 === K"Identifier"
-            hasattr(ex[1], :mod) && maybe_declare_in_scope!(ctx, scope, ex[1], :global)
+            hasattr(Module, ex[1], :mod) && maybe_declare_in_scope!(ctx, scope, ex[1], :global)
             get!(scope.assignments, NameKey(ex[1]), ex[1]._id)
         else
             @jl_assert false (ex, "unknown kind in assignment")
@@ -261,7 +261,7 @@ end
 function enter_scope!(ctx, ex)
     @jl_assert kind(ex) in KSet"lambda scope_block method_defs" ex
     # Note that generated functions produce lambdas with this false
-    is_toplevel_thunk = kind(ex) === K"lambda" && ex.is_toplevel_thunk
+    is_toplevel_thunk = kind(ex) === K"lambda" && getattr(Bool, ex, :is_toplevel_thunk)
     parent_id = (is_toplevel_thunk || isempty(ctx.scope_stack)) ?
         0 : ctx.scopes[ctx.scope_stack[end]].id
     scope = ScopeInfo(ctx, parent_id, ex)
@@ -404,9 +404,9 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
         self_id = if numchildren(arg_bindings) === 0
             0
         elseif getmeta(ex[1][1], :is_kwcall_self, false)
-            arg_bindings[3].var_id
+            getattr(IdTag, arg_bindings[3], :var_id)
         else
-            arg_bindings[1].var_id
+            getattr(IdTag, arg_bindings[1], :var_id)
         end
         lambda_bindings = LambdaBindings(self_id, newscope.id, newscope.locals_capt)
         body_stmts = SyntaxList(ctx)
@@ -422,8 +422,8 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
         pop!(ctx.scope_stack)
 
         @ast ctx ex [K"lambda"(;lambda_bindings=lambda_bindings,
-                               is_toplevel_thunk=ex.is_toplevel_thunk,
-                               toplevel_pure=ex.toplevel_pure)
+                               is_toplevel_thunk=getattr(Bool, ex, :is_toplevel_thunk),
+                               toplevel_pure=getattr(Bool, ex, :toplevel_pure))
             arg_bindings
             sparam_bindings
             [K"block"
@@ -546,7 +546,7 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
     elseif k == K"constdecl"
         resolved = mapchildren(e->_resolve_scopes(ctx, e, scope), ctx, ex)
         @jl_assert kind(resolved[1]) === K"BindingId" resolved[1]
-        if get_binding(ctx, resolved[1].var_id).kind === :local
+        if get_binding(ctx, getattr(IdTag, resolved[1], :var_id)).kind === :local
             throw(LoweringError(ex, "unsupported `const` declaration on local variable"))
         elseif !is_top_scope(enclosing_lambda(ctx, scope))
             throw(LoweringError(ex, "unsupported `const` inside function"))
@@ -595,7 +595,7 @@ struct VariableAnalysisContext{Attrs} <: AbstractLoweringContext
 end
 
 function init_closure_bindings!(ctx, fname)
-    func_name_id = fname.var_id
+    func_name_id = getattr(IdTag, fname, :var_id)
     @jl_assert get_binding(ctx, func_name_id).kind === :local fname
     get!(ctx.closure_bindings, func_name_id) do
         name_stack = Vector{String}()
@@ -612,7 +612,7 @@ end
 function find_any_local_binding(ctx, ex)
     k = kind(ex)
     if k == K"BindingId"
-        bkind = get_binding(ctx, ex.var_id).kind
+        bkind = get_binding(ctx, getattr(IdTag, ex, :var_id)).kind
         if bkind != :global && bkind != :static_parameter
             return ex
         end
@@ -713,12 +713,12 @@ function analyze_variables!(ctx, ex)
         analyze_variables!(ctx, ex[9])
         pop!(ctx.method_def_stack)
     elseif k == K"lambda"
-        lambda_bindings = ex.lambda_bindings
-        if !ex.is_toplevel_thunk && !isempty(ctx.method_def_stack)
+        lambda_bindings = getattr(LambdaBindings, ex, :lambda_bindings)
+        if !getattr(Bool, ex, :is_toplevel_thunk) && !isempty(ctx.method_def_stack)
             # Record all lambdas for the same closure type in one place
             func_name = last(ctx.method_def_stack)
             if kind(func_name) == K"BindingId"
-                func_name_id = func_name.var_id::IdTag
+                func_name_id = getattr(IdTag, func_name, :var_id)
                 if get_binding(ctx, func_name).kind === :local
                     push!(ctx.closure_bindings[func_name_id].lambdas, lambda_bindings)
                 end
@@ -771,7 +771,7 @@ enclosing lambda form and information about variables captured by closures.
                                   ctx.expr_compat_mode)
     ex2 = resolve_scopes(ctx2, ex)
     ctx3 = VariableAnalysisContext(graph, ctx2.bindings, ctx2.mod,
-                                   ctx2.scopes, ex2.lambda_bindings,
+                                   ctx2.scopes, getattr(LambdaBindings, ex2, :lambda_bindings),
                                    SyntaxList(graph),
                                    Dict{IdTag,ClosureBindings}())
     analyze_variables!(ctx3, ex2)

--- a/JuliaLowering/src/syntax_macros.jl
+++ b/JuliaLowering/src/syntax_macros.jl
@@ -24,9 +24,9 @@ function _apply_nospecialize(ctx, ex)
         # The @nospecialize macro is responsible for converting K"=" to K"kw".
         # Desugaring uses this helper internally, so we may see K"kw" too.
         if k == K"=" && numchildren(ex) === 2
-            ex = @ast ctx ex [K"kw" ex[1] ex[2]]
+            k = K"kw"
         end
-        mapchildren(c->_apply_nospecialize(ctx, c), ctx, ex, 1:1)
+        @ast ctx ex [k _apply_nospecialize(ctx, ex[1]) ex[2:end]...]
     else
         throw(LoweringError(ex, "Invalid function argument"))
     end

--- a/JuliaLowering/src/syntax_macros.jl
+++ b/JuliaLowering/src/syntax_macros.jl
@@ -126,12 +126,12 @@ function ccall_macro_parse(ctx, exs)
     ex = exs[end]
     for opt in opts
         @stm opt begin
-            [K"=" [K"Identifier"] val] -> if opt[1].name_val != "gc_safe"
+            [K"=" [K"Identifier"] val] -> if getattr(String, opt[1], :name_val) != "gc_safe"
                 throw(MacroExpansionError(opt[1], "unknown option name for ccall"))
             elseif !(kind(val) in KSet"Bool Value")
                 throw(MacroExpansionError(val, "gc_safe must be true or false"))
             else
-                gc_safe = val.value
+                gc_safe = getattr(Any, val, :value)
             end
             _ -> throw(MacroExpansionError(opt, "bad option to ccall"))
         end
@@ -147,8 +147,8 @@ function ccall_macro_parse(ctx, exs)
             [K"Identifier"] -> @ast ctx f [K"tuple" [K"inert" f]]
             [K"$" x] -> let kx = kind(x)
                 if kx in KSet"tuple String string" ||
-                        (kx === K"Value" && x.value isa Tuple) ||
-                        kx == K"inert" && !(kx[1].value isa Ptr)
+                        (kx === K"Value" && getattr(Any, x, :value) isa Tuple) ||
+                        kx == K"inert" && !(getattr(Any, x[1], :value) isa Ptr)
                     throw(MacroExpansionError(
                         f, "interpolated value should be a variable or expression, not a literal name or tuple"))
                 end

--- a/JuliaLowering/src/utils.jl
+++ b/JuliaLowering/src/utils.jl
@@ -319,7 +319,7 @@ function _print_ir(io::IO, ex, indent)
 end
 
 # Wrap a function body in Base.Compiler.@zone for profiling
-if isdefined(Base.Compiler, Symbol("@zone"))
+if isdefined(Base.Compiler, Symbol("@zone")) && DEBUG
     macro fzone(str, f)
         @assert(f isa Expr && f.head === :function && length(f.args) === 2 && str isa String,
                 "usage: @fzone name_string <function expression>")

--- a/JuliaLowering/src/utils.jl
+++ b/JuliaLowering/src/utils.jl
@@ -4,28 +4,28 @@ attrsummary(name, value::LineNumberNode) = "$name=L$(value.line)"
 
 function _value_string(ex)
     k = kind(ex)
-    str = k == K"Identifier"  ? ex.name_val           :
-          k == K"Placeholder" ? ex.name_val           :
+    str = k == K"Identifier"  ? getattr(String, ex, :name_val)           :
+          k == K"Placeholder" ? getattr(String, ex, :name_val)           :
           k == K"SSAValue"    ? "%"                   :
           k == K"BindingId"   ? "#"                   :
           k == K"label"       ? "label"               :
-          k == K"core"        ? "core.$(ex.name_val)" :
-          k == K"top"         ? "top.$(ex.name_val)"  :
-          k == K"Symbol"      ? ":$(ex.name_val)" :
-          k == K"globalref"   ? "$(ex.mod).$(ex.name_val)" :
+          k == K"core"        ? "core.$(getattr(String, ex, :name_val))" :
+          k == K"top"         ? "top.$(getattr(String, ex, :name_val))"  :
+          k == K"Symbol"      ? ":$(getattr(String, ex, :name_val))" :
+          k == K"globalref"   ? "$(getattr(Module, ex, :mod)).$(getattr(String, ex, :name_val))" :
           k == K"slot"        ? "slot" :
           k == K"latestworld" ? "latestworld" :
           k == K"static_parameter" ? "static_parameter" :
-          k == K"symboliclabel" ? "label:$(ex.name_val)" :
-          k == K"symbolicgoto" ? "goto:$(ex.name_val)" :
+          k == K"symboliclabel" ? "label:$(getattr(String, ex, :name_val))" :
+          k == K"symbolicgoto" ? "goto:$(getattr(String, ex, :name_val))" :
           k == K"SourceLocation" ?
               "SourceLocation:$(JuliaSyntax.filename(ex)):$(join(source_location(ex), ':'))" :
-          k == K"Value" && ex.value isa SourceRef ?
+          k == K"Value" && getattr(Any, ex, :value) isa SourceRef ?
               "SourceRef:$(JuliaSyntax.filename(ex)):$(join(source_location(ex), ':'))" :
-              hasattr(ex, :value) ? repr(ex.value) : "::K\"$(untokenize(k))\""
-    id = get(ex, :var_id, nothing)
+              hasattr(Any, ex, :value) ? repr(getattr(Any, ex, :value)) : "::K\"$(untokenize(k))\""
+    id = getattr(IdTag, ex, :var_id, nothing)
     if isnothing(id)
-        id = get(ex, :id, nothing)
+        id = getattr(Int, ex, :id, nothing)
     end
     if !isnothing(id)
         idstr = subscript_str(id)
@@ -35,7 +35,7 @@ function _value_string(ex)
         p = provenance(ex)[1]
         while p isa SyntaxTree
             if kind(p) == K"Identifier"
-                str = "$(str)/$(p.name_val)"
+                str = "$(str)/$(getattr(String, p, :name_val))"
                 break
             end
             p = provenance(p)[1]
@@ -57,7 +57,7 @@ function _show_syntax_tree(io, ex, indent, show_kinds)
     end
 
     std_attrs = Set([:name_val,:value,:kind,:syntax_flags,:source,:var_id])
-    attrstr = join([attrsummary(n, getproperty(ex, n))
+    attrstr = join([attrsummary(n, getattr(Any, ex, n))
                     for n in JuliaSyntax.attrnames(ex) if n ∉ std_attrs], ",")
     treestr = string(rpad(treestr, 60), " │ $attrstr")
 
@@ -175,8 +175,8 @@ end
 
 function _show_provtree(io::IO, ex::SyntaxTree, indent)
     print(io, ex)
-    if hasattr(ex, :jl_source)
-        printstyled(io, " @$(ex.jl_source)", color=:light_black)
+    if hasattr(LineNumberNode, ex, :jl_source)
+        printstyled(io, " @$(getattr(LineNumberNode, ex, :jl_source))", color=:light_black)
     end
     print(io, "\n")
     prov = provenance(ex)
@@ -228,7 +228,7 @@ end
 
 function _deref_ssa(stmts, ex)
     while kind(ex) == K"SSAValue"
-        ex = stmts[ex.var_id]
+        ex = stmts[getattr(IdTag, ex, :var_id)]
     end
     ex
 end
@@ -244,7 +244,7 @@ function _find_method_lambda(ex, name)
             arg_types = _deref_ssa(stmts, sig[2])
             @jl_assert kind(arg_types) == K"call" ex
             self_type = _deref_ssa(stmts, arg_types[2])
-            if kind(self_type) == K"globalref" && occursin(name, self_type.name_val)
+            if kind(self_type) == K"globalref" && occursin(name, getattr(String, self_type, :name_val))
                 return e[3]
             end
         end
@@ -269,8 +269,8 @@ function _print_ir(io::IO, ex, indent)
     added_indent = "    "
     @jl_assert ((kind(ex) == K"lambda" || kind(ex) == K"code_info")
                 && kind(ex[1]) == K"block") ex
-    if !ex.is_toplevel_thunk && kind(ex) == K"code_info"
-        slots = ex.slots
+    if !getattr(Bool, ex, :is_toplevel_thunk) && kind(ex) == K"code_info"
+        slots = getattr(Vector{Slot}, ex, :slots)
         print(io, indent, "slots: [")
         for (i,slot) in enumerate(slots)
             print(io, "slot$(subscript_str(i))/$(slot.name)")
@@ -309,7 +309,7 @@ function _print_ir(io::IO, ex, indent)
             println(io)
             _print_ir(io, e[5], indent*added_indent)
         elseif kind(e) == K"code_info"
-            println(io, indent, lno, " --- ", e.is_toplevel_thunk ? "thunk" : "code_info")
+            println(io, indent, lno, " --- ", getattr(Bool, e, :is_toplevel_thunk) ? "thunk" : "code_info")
             _print_ir(io, e, indent*added_indent)
         else
             code = string(e)
@@ -352,7 +352,7 @@ function _find_SyntaxTree_macro(ex, line)
                         name = name[2]
                     end
                     @jl_assert kind(name) == K"Identifier" name
-                    name.name_val == "@SyntaxTree"
+                    getattr(String, name, :name_val) == "@SyntaxTree"
                 end
             # We find the node we're looking for. NB: Currently assuming a max
             # of one @SyntaxTree invocation per line. Though we could relax
@@ -428,7 +428,7 @@ macro SyntaxTree(ex_old)
     # 4. Do the first step of JuliaLowering's syntax lowering to get
     # syntax interpolations to work
     _, ex1 = expand_forms_1(__module__, ex, false, Base.tls_world_age())
-    @jl_assert kind(ex1) == K"call" && ex1[1].value == interpolate_ast ex1
+    @jl_assert kind(ex1) == K"call" && getattr(Any, ex1[1], :value) == interpolate_ast ex1
     Expr(:call, :interpolate_ast, SyntaxTree, ex1[3][1],
          map(e->_scope_layer_1_to_esc!(Expr(e)), ex1[4:end])...)
 end

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -879,7 +879,7 @@ end
 #
 # Note simple `op` and `.op` are calls to (dotted) identifiers, so this special
 # handling isn't necessary.
-vst1_dotted_or_op_assign(vcx, st) = let op_s = get(st, :name_val, "")
+vst1_dotted_or_op_assign(vcx, st) = let op_s = get(st, :name_val, "")::String
     @stm st begin
         [K".=" l r] -> vst1_dotassign_lhs(vcx, l) & vst1(vcx, r)
         (_, when=(!Base.isoperator(op_s))) -> unknown()

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -249,7 +249,7 @@ vst1(vcx::Validation1Context, st::SyntaxTree)::ValidationResult = @stm st begin
     [K"ssavalue" [K"Value"]] -> pass()
     [K"inert" _] -> pass()
     [K"inert_syntaxtree" _] -> pass()
-    [K"core"] -> st.name_val === "nothing" ? pass() :
+    [K"core"] -> getattr(String, st, :name_val) === "nothing" ? pass() :
         @fail(st, "zero-arg `core` is only used for `Core.nothing`")
     [K"core" [K"Identifier"]] -> pass()
     [K"top" [K"Identifier"]] -> pass()
@@ -283,8 +283,8 @@ vst1(vcx::Validation1Context, st::SyntaxTree)::ValidationResult = @stm st begin
         all(vst1, vcx, roots_args)
     [K"cfunction" [K"Value"] f rt at [K"inert" [K"Identifier"]]] ->
         vst1(vcx, f) & vst1(vcx, rt) & vst1(vcx, at)
-    [K"cconv" tup nreq] -> (get(tup, :value, nothing) isa Tuple &&
-        get(nreq, :value, nothing) isa Int) ? pass() :
+    [K"cconv" tup nreq] -> (getattr(Any, tup, :value, nothing) isa Tuple &&
+        getattr(Any, nreq, :value, nothing) isa Int) ? pass() :
         @fail(st, "expected (cconv convention_tuple n_req_args)")
     [K"tryfinally" t f] -> vst1(vcx, t) & vst1(vcx, f)
     [K"tryfinally" t f scope] -> vst1(vcx, t) & vst1(vcx, f) & vst1(vcx, scope)
@@ -304,7 +304,7 @@ vst1(vcx::Validation1Context, st::SyntaxTree)::ValidationResult = @stm st begin
         @fail(st, "can only be used inside a function") :
         !vcx.return_ok ?
         @fail(st, "current function not defined in comprehension or generator") : pass()
-    [K"unknown_head"] -> let head = st.name_val
+    [K"unknown_head"] -> let head = getattr(String, st, :name_val)
         head === "latestworld-if-toplevel" ? pass() :
             @fail(st, string("unknown expr head: ", head))
     end
@@ -329,7 +329,7 @@ vst1(vcx::Validation1Context, st::SyntaxTree)::ValidationResult = @stm st begin
     [K"Placeholder"] ->
         @fail(st, "`Placeholder` kind not valid until desugaring")
     [K"unknown_head" _...] ->
-        @fail(st, string("unknown expr head: ", st.name_val))
+        @fail(st, string("unknown expr head: ", getattr(String, st, :name_val)))
     [K"$" x] -> @fail(st, raw"`$` expression outside string or quote")
     [K"continue" _...] ->
         @fail(st, "`continue` outside of a `while` or `for` loop")
@@ -352,17 +352,17 @@ end
 vst1_toplevel_only(vcx, st) = @stm st begin
     # body will be validated when lowered
     [K"module" [K"Value"] [K"Value"] [K"Identifier"] [K"block" xs...]] ->
-        !(st[1].value isa VersionNumber) ? @fail(st[1], "expected version") :
-        !(st[2].value isa Bool) ? @fail(st[2], "expected boolean bare flag") :
+        !(getattr(Any, st[1], :value) isa VersionNumber) ? @fail(st[1], "expected version") :
+        !(getattr(Any, st[2], :value) isa Bool) ? @fail(st[2], "expected boolean bare flag") :
         pass()
     [K"module" [K"Value"] [K"Identifier"] [K"block" xs...]] ->
-        !(st[1].value isa Bool) ? @fail(st[1], "expected boolean bare flag") :
+        !(getattr(Any, st[1], :value) isa Bool) ? @fail(st[1], "expected boolean bare flag") :
         pass()
     [K"macro" _...] ->
         vst1_macro(vcx, st)
     [K"struct" [K"Value"] sig [K"block" body...]] ->
         vst1_typesig(vcx, sig) & (
-            !(st[1].value isa Bool) ? @fail(st[1], "expected mutable flag") :
+            !(getattr(Any, st[1], :value) isa Bool) ? @fail(st[1], "expected mutable flag") :
                 all(vst1_struct_arg, vcx, body))
     [K"abstract" sig] ->
         vst1_typesig(vcx, sig)
@@ -471,7 +471,7 @@ end
 
 vst1_try_catchvar(_vcx, st) = @stm st begin
     [K"Identifier"] -> pass()
-    ([K"Value"], when=st.value===false) -> pass()
+    ([K"Value"], when=getattr(Any, st, :value)===false) -> pass()
 end
 
 # syntax TODO:
@@ -501,10 +501,10 @@ end
 vst1_simple_dot_rhs(vcx, st; lhs) = @stm st begin
     [K"inert" x] -> vst1_simple_dot_rhs(vcx, x; lhs)
     [K"Identifier"] -> vst1_ident(with(vcx; readable_underscore=true), st; lhs)
-    ([K"Value"], when=st.value isa String) ->
-        _ident_str(with(vcx; readable_underscore=true), st, st.value; lhs)
+    ([K"Value"], when=getattr(Any, st, :value) isa String) ->
+        _ident_str(with(vcx; readable_underscore=true), st, getattr(Any, st, :value); lhs)
     [K"String"] ->
-        _ident_str(with(vcx; readable_underscore=true), st, st.value; lhs)
+        _ident_str(with(vcx; readable_underscore=true), st, getattr(Any, st, :value); lhs)
     [K"tuple" _...] -> @fail(st, "dotcall syntax not valid here")
     _ -> @fail(st, "invalid `.` syntax")
 end
@@ -522,7 +522,7 @@ end
 # TODO: globalref (identifier with .mod) might not be valid everywhere; check
 # usage of this function
 vst1_ident(vcx, st; lhs=false) = @stm st begin
-    [K"Identifier"] -> _ident_str(vcx, st, st.name_val; lhs)
+    [K"Identifier"] -> _ident_str(vcx, st, getattr(String, st, :name_val); lhs)
     _ -> @fail(st, "expected identifier")
 end
 function _ident_str(vcx, st, s::String; lhs=false)
@@ -536,7 +536,7 @@ function _ident_str(vcx, st, s::String; lhs=false)
 end
 
 vst1_call(vcx, st) = @stm st begin
-    ([K"call" [K"Identifier"] args...], when=st[1].name_val==="cglobal") ->
+    ([K"call" [K"Identifier"] args...], when=getattr(String, st[1], :name_val)==="cglobal") ->
         (1 <= length(args) <= 2 ? pass() :
             @fail(st, "cglobal must have one or two arguments")) &
         all(vst1_call_arg, vcx, args)
@@ -575,7 +575,7 @@ vst1_call_kwarg(vcx, st) = @stm st begin
     [K"=" id val] -> vst1_ident(vcx, id; lhs=true) & vst1(vcx, val)
     [K"..." x] -> vst1(vcx, x)
     [K"." x [K"inert" id]] -> vst1(vcx, x) & vst1_ident(vcx, id; lhs=true)
-    ([K"call" [K"Identifier"] symval v], when=(st[1].name_val==="=>")) ->
+    ([K"call" [K"Identifier"] symval v], when=(getattr(String, st[1], :name_val)==="=>")) ->
         vst1(vcx, symval) & vst1(vcx, v)
     _ -> @fail(st, "expected identifier, `=`, or, `...` after semicolon")
 end
@@ -705,7 +705,7 @@ function _calldecl_positionals(vcx, params_meta, eq_is_kw)
     ok = Ref(pass())
     params = map(params_meta) do meta_p
         @stm meta_p begin
-            [K"meta" s p] -> let meta_s = get(s, :name_val, "")
+            [K"meta" s p] -> let meta_s = getattr(String, s, :name_val, "")
                 if !(meta_s in ("specialize", "nospecialize"))
                     ok[] &= @fail(p, "unrecognized meta function arg form")
                 end
@@ -829,7 +829,8 @@ vst1_typevar_decl(vcx, st) = @stm st begin
     [K">:" t old] ->
         vst1_ident(vcx, t; lhs=true) & vst1(vcx, old)
     ([K"comparison" val_l [K"Identifier"] t [K"Identifier"] val_r],
-     when=(st[2].name_val===st[4].name_val && st[2].name_val in ("<:", ">:"))) ->
+     when=(getattr(String, st[2], :name_val) === getattr(String, st[4], :name_val) &&
+           getattr(String, st[2], :name_val) in ("<:", ">:"))) ->
          vst1(vcx, val_l) &
          vst1_ident(vcx, t; lhs=true) &
          vst1(vcx, val_r)
@@ -879,7 +880,7 @@ end
 #
 # Note simple `op` and `.op` are calls to (dotted) identifiers, so this special
 # handling isn't necessary.
-vst1_dotted_or_op_assign(vcx, st) = let op_s = get(st, :name_val, "")::String
+vst1_dotted_or_op_assign(vcx, st) = let op_s = getattr(String, st, :name_val, "")::String
     @stm st begin
         [K".=" l r] -> vst1_dotassign_lhs(vcx, l) & vst1(vcx, r)
         (_, when=(!Base.isoperator(op_s))) -> unknown()
@@ -1059,7 +1060,7 @@ vst0_macrocall(vcx, st) = @stm st begin
     (_, when=!vcx.unexpanded) ->
         @fail(st, "macrocall not valid in AST after macro expansion")
     ([K"macrocall" name [K"Value"] args...],
-     when=(typeof(st[2].value) in (LineNumberNode, Core.MacroSource))) ->
+     when=(typeof(getattr(Any, st[2], :value)) in (LineNumberNode, Core.MacroSource))) ->
          pass()
     [K"macrocall" _...] ->
         @fail(st, "expected (macrocall name linenode args...)")
@@ -1103,9 +1104,8 @@ function _assert_syntaxtree(st::SyntaxTree, parents::Vector{NodeId}, vr)
         end
         return vr & @fail(st, err*"]")
     end
-    for a in (:kind, :source)
-        vr &= hasattr(st, a) ? pass() : @fail(st, string("needs attribute ", a))
-    end
+    vr &= hasattr(Kind, st, :kind) ? pass() : @fail(st, string("needs attribute ", a))
+    vr &= hasattr(SourceAttrType, st, :source) ? pass() : @fail(st, string("needs attribute ", a))
     if is_leaf(st)
         # Note some kinds can show up in non-leaves too
         required_attrs = @stm st begin
@@ -1141,7 +1141,7 @@ function _assert_syntaxtree(st::SyntaxTree, parents::Vector{NodeId}, vr)
         end
     end
     for a in required_attrs
-        vr &= hasattr(st, a) ? pass() : @fail(st, string("needs attribute ", a))
+        vr &= hasattr(Any, st, a) ? pass() : @fail(st, string("needs attribute ", a))
     end
     push!(parents, st._id)
     for c in children(st)
@@ -1179,7 +1179,7 @@ vst2(vcx::Validation2Context, st::SyntaxTree) = @stm st begin
     latestworld latestworld_if_toplevel symbolicgoto symboliclabel TOMBSTONE
     """ ? pass() : @fail(st, "unrecognized leaf kind")
 
-    [K"call" [K"static_eval" cg] xs...] -> get(cg, :name_val, nothing) == "cglobal" ?
+    [K"call" [K"static_eval" cg] xs...] -> getattr(String, cg, :name_val, nothing) == "cglobal" ?
         all(vst2, vcx, xs) : @fail(st, "expected (call (static_eval cglobal) _...)")
     [K"call" xs...] -> all(vst2, vcx, xs)
     [K"block" xs...] -> all(vst2, vcx, xs)

--- a/JuliaLowering/test/branching_ir.jl
+++ b/JuliaLowering/test/branching_ir.jl
@@ -241,8 +241,8 @@ LoweringError:
 Expression:
   label:foo
 Containing expressions:
-  (lambda (block) (block) (block (call core.declare_global Main.TestMod :x true) latestworld core.nothing (= #₂/tmp label:foo) (= #₃/binding_type (call core.get_binding_type Main.TestMod :x)) (= #₁/x (block (= #₅/type_tmp #₃/binding_type) (= #₄/tmp #₂/tmp) (if (call core.isa #₄/tmp #₅/type_tmp) core.nothing (= #₄/tmp (call top.convert #₅/type_tmp #₄/tmp))) #₄/tmp)) #₂/tmp))
-  (block (block (block (call core.declare_global Main.TestMod :x true) latestworld core.nothing) (= #₂/tmp label:foo) (= #₃/binding_type (call core.get_binding_type Main.TestMod :x)) (= #₁/x (block (= #₅/type_tmp #₃/binding_type) (= #₄/tmp #₂/tmp) (if (call core.isa #₄/tmp #₅/type_tmp) core.nothing (= #₄/tmp (call top.convert #₅/type_tmp #₄/tmp))) #₄/tmp)) #₂/tmp))
+  (lambda (block) (block) (block (call core.declare_global Main.TestMod :x true) latestworld core.nothing (= #₂ label:foo) (= #₃ (call core.get_binding_type Main.TestMod :x)) (= #₁/x (block (= #₅ #₃) (= #₄/tmp #₂) (if (call core.isa #₄/tmp #₅) core.nothing (= #₄/tmp (call top.convert #₅ #₄/tmp))) #₄/tmp)) #₂))
+  (block (block (block (call core.declare_global Main.TestMod :x true) latestworld core.nothing) (= #₂ label:foo) (= #₃ (call core.get_binding_type Main.TestMod :x)) (= #₁/x (block (= #₅ #₃) (= #₄/tmp #₂) (if (call core.isa #₄/tmp #₅) core.nothing (= #₄/tmp (call top.convert #₅ #₄/tmp))) #₄/tmp)) #₂))
   (lambda (block) (block) (block (= #₁/x label:foo)))
   (lambda (block) (block) (= x label:foo))
 

--- a/JuliaLowering/test/compat.jl
+++ b/JuliaLowering/test/compat.jl
@@ -152,24 +152,24 @@ end
         # No initial line provided
         st = JuliaLowering.expr_to_est(ex)
         for i in length(st._graph.edge_ranges)
-            @test !isnothing(get(SyntaxTree(st._graph, i), :source, nothing))
+            @test !isnothing(getattr(SourceAttrType, SyntaxTree(st._graph, i), :source, nothing))
         end
-        @test let lnn = st[1].source;    lnn isa LineNumberNode && lnn.line === 123; end
-        @test let lnn = st[1][1].source; lnn isa LineNumberNode && lnn.line === 123; end
-        @test let lnn = st[1][2].source; lnn isa LineNumberNode && lnn.line === 456; end
-        @test let lnn = st[2].source;    lnn isa LineNumberNode && lnn.line === 456; end
-        @test let lnn = st[2][1].source; lnn isa LineNumberNode && lnn.line === 456; end
-        @test let lnn = st[2][2].source; lnn isa LineNumberNode && lnn.line === 456; end
+        @test let lnn = getattr(SourceAttrType, st[1], :source);    lnn isa LineNumberNode && lnn.line === 123; end
+        @test let lnn = getattr(SourceAttrType, st[1][1], :source); lnn isa LineNumberNode && lnn.line === 123; end
+        @test let lnn = getattr(SourceAttrType, st[1][2], :source); lnn isa LineNumberNode && lnn.line === 456; end
+        @test let lnn = getattr(SourceAttrType, st[2], :source);    lnn isa LineNumberNode && lnn.line === 456; end
+        @test let lnn = getattr(SourceAttrType, st[2][1], :source); lnn isa LineNumberNode && lnn.line === 456; end
+        @test let lnn = getattr(SourceAttrType, st[2][2], :source); lnn isa LineNumberNode && lnn.line === 456; end
 
         # Same tree, but provide an initial line
         st = JuliaLowering.expr_to_est(ex, LineNumberNode(789))
-        @test let lnn = st.source;       lnn isa LineNumberNode && lnn.line === 789; end
-        @test let lnn = st[1].source;    lnn isa LineNumberNode && lnn.line === 123; end
-        @test let lnn = st[1][1].source; lnn isa LineNumberNode && lnn.line === 123; end
-        @test let lnn = st[1][2].source; lnn isa LineNumberNode && lnn.line === 456; end
-        @test let lnn = st[2].source;    lnn isa LineNumberNode && lnn.line === 456; end
-        @test let lnn = st[2][1].source; lnn isa LineNumberNode && lnn.line === 456; end
-        @test let lnn = st[2][2].source; lnn isa LineNumberNode && lnn.line === 456; end
+        @test let lnn = getattr(SourceAttrType, st, :source);       lnn isa LineNumberNode && lnn.line === 789; end
+        @test let lnn = getattr(SourceAttrType, st[1], :source);    lnn isa LineNumberNode && lnn.line === 123; end
+        @test let lnn = getattr(SourceAttrType, st[1][1], :source); lnn isa LineNumberNode && lnn.line === 123; end
+        @test let lnn = getattr(SourceAttrType, st[1][2], :source); lnn isa LineNumberNode && lnn.line === 456; end
+        @test let lnn = getattr(SourceAttrType, st[2], :source);    lnn isa LineNumberNode && lnn.line === 456; end
+        @test let lnn = getattr(SourceAttrType, st[2][1], :source); lnn isa LineNumberNode && lnn.line === 456; end
+        @test let lnn = getattr(SourceAttrType, st[2][2], :source); lnn isa LineNumberNode && lnn.line === 456; end
 
         ex = parsestmt(Expr, """
         begin
@@ -198,16 +198,16 @@ end
             ]
         ]
 
-        @test let lnn = st.source;             lnn isa LineNumberNode && lnn.line === 1; end
-        @test let lnn = st[1].source;          lnn isa LineNumberNode && lnn.line === 2; end
-        @test let lnn = st[1][1].source;       lnn isa LineNumberNode && lnn.line === 2; end
-        @test let lnn = st[1][1][1].source;    lnn isa LineNumberNode && lnn.line === 3; end
-        @test let lnn = st[1][1][2].source;    lnn isa LineNumberNode && lnn.line === 4; end
-        @test let lnn = st[1][1][3].source;    lnn isa LineNumberNode && lnn.line === 5; end
-        @test let lnn = st[1][1][4].source;    lnn isa LineNumberNode && lnn.line === 6; end
-        @test let lnn = st[1][2].source;       lnn isa LineNumberNode && lnn.line === 6; end
-        @test let lnn = st[1][3].source;       lnn isa LineNumberNode && lnn.line === 6; end
-        @test let lnn = st[1][3][1].source;    lnn isa LineNumberNode && lnn.line === 8; end
+        @test let lnn = getattr(SourceAttrType, st, :source);             lnn isa LineNumberNode && lnn.line === 1; end
+        @test let lnn = getattr(SourceAttrType, st[1], :source);          lnn isa LineNumberNode && lnn.line === 2; end
+        @test let lnn = getattr(SourceAttrType, st[1][1], :source);       lnn isa LineNumberNode && lnn.line === 2; end
+        @test let lnn = getattr(SourceAttrType, st[1][1][1], :source);    lnn isa LineNumberNode && lnn.line === 3; end
+        @test let lnn = getattr(SourceAttrType, st[1][1][2], :source);    lnn isa LineNumberNode && lnn.line === 4; end
+        @test let lnn = getattr(SourceAttrType, st[1][1][3], :source);    lnn isa LineNumberNode && lnn.line === 5; end
+        @test let lnn = getattr(SourceAttrType, st[1][1][4], :source);    lnn isa LineNumberNode && lnn.line === 6; end
+        @test let lnn = getattr(SourceAttrType, st[1][2], :source);       lnn isa LineNumberNode && lnn.line === 6; end
+        @test let lnn = getattr(SourceAttrType, st[1][3], :source);       lnn isa LineNumberNode && lnn.line === 6; end
+        @test let lnn = getattr(SourceAttrType, st[1][3][1], :source);    lnn isa LineNumberNode && lnn.line === 8; end
 
         st_shortfunc = JuliaLowering.expr_to_est(
             Expr(:block,
@@ -222,7 +222,7 @@ end
                 "body"::K"Identifier"
             ]
         ]
-        @test let lnn = st_shortfunc[1][1].source; lnn isa LineNumberNode && lnn.line === 11; end
+        @test let lnn = getattr(SourceAttrType, st_shortfunc[1][1], :source); lnn isa LineNumberNode && lnn.line === 11; end
 
         st_shortfunc_2 = JuliaLowering.expr_to_est(
             Expr(:block,
@@ -239,7 +239,7 @@ end
                 [K"block" "body"::K"Identifier"]
             ]
         ]
-        @test let lnn = st_shortfunc_2[1][1].source; lnn isa LineNumberNode && lnn.line === 22; end
+        @test let lnn = getattr(SourceAttrType, st_shortfunc_2[1][1], :source); lnn isa LineNumberNode && lnn.line === 22; end
     end
 
     @testset "linenodes equal (modules and functions have extra)" begin
@@ -512,11 +512,11 @@ end
     # Expr(:ssavalue, N) should be converted to [K"ssavalue" N::K"Value"]
     st = JuliaLowering.expr_to_est(Expr(:ssavalue, 0))
     @test kind(st) === K"ssavalue"
-    @test st[1].value == 0
+    @test getattr(Any, st[1], :value) == 0
 
     st = JuliaLowering.expr_to_est(Expr(:ssavalue, 42))
     @test kind(st) === K"ssavalue"
-    @test st[1].value == 42
+    @test getattr(Any, st[1], :value) == 42
 
     # Roundtrip: ssavalue should convert back to Expr(:ssavalue, N)
     @test JL.est_to_expr(JuliaLowering.expr_to_est(Expr(:ssavalue, 5))) ==

--- a/JuliaLowering/test/demo.jl
+++ b/JuliaLowering/test/demo.jl
@@ -3,8 +3,8 @@
 using JuliaSyntax
 using JuliaLowering
 
-using JuliaSyntax: ensure_attributes
-using JuliaLowering: @ast, SyntaxGraph, SyntaxTree, child, children, is_leaf,
+using JuliaSyntax: ensure_attributes, getattr
+using JuliaLowering: @ast, IdTag, SyntaxGraph, SyntaxTree, child, children, is_leaf,
     lookup_binding, makenode, newnode!, numchildren, setattr!, setchildren!, showprov,
     sourceref
 
@@ -12,7 +12,7 @@ using JuliaSyntaxFormatter
 
 # Extract variable kind for highlighting purposes
 function var_kind(ctx, ex)
-    id = get(ex, :var_id, nothing)
+    id = getattr(IdTag, ex, :var_id, nothing)
     if isnothing(id)
         return nothing
     end
@@ -24,7 +24,7 @@ end
 
 # Extract module of globals for highlighting
 function var_mod(ctx, ex)
-    id = get(ex, :var_id, nothing)
+    id = getattr(IdTag, ex, :var_id, nothing)
     if isnothing(id)
         return nothing
     end
@@ -203,13 +203,13 @@ eval(JuliaLowering.@SyntaxTree :(baremodule M
     end
 
     macro K_str(str)
-        JuliaSyntax.Kind(str[1].value)
+        JuliaSyntax.Kind(getattr(Any, str[1], :value))
     end
 
     # Recursive macro call
     macro recursive(N)
         Nval = if kind(N) == K"Integer" || kind(N) == K"Value"
-            N.value
+            getattr(Any, N, :value)
         end
         if !(Nval isa Integer)
             throw(MacroExpansionError(N, "argument must be an integer"))

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -66,7 +66,7 @@ module M
     end
 
     macro recursive(N)
-        Nval = N.value::Int
+        Nval = JuliaSyntax.getattr(Any, N, :value)::Int
         if Nval < 1
             return N
         end
@@ -155,8 +155,8 @@ call_world_arg_test = JuliaLowering.parsestmt(JuliaLowering.SyntaxTree, "@world_
         @ast_ 2::K"Value"
 
 # Layer parenting
-@test expanded[1].scope_layer == 2
-@test expanded[2][1].scope_layer == 3
+@test getattr(LayerId, expanded[1], :scope_layer) == 2
+@test getattr(LayerId, expanded[2][1], :scope_layer) == 3
 @test getfield.(ctx.scope_layers, :parent_layer) == [0,1,2]
 
 JuliaLowering.include_string(test_mod, """

--- a/JuliaLowering/test/macros_ir.jl
+++ b/JuliaLowering/test/macros_ir.jl
@@ -16,17 +16,17 @@ module MacroMethods
 end
 
 macro strmac_str(ex, suff=nothing)
-    s = "$(ex.value) from strmac"
+    s = "$(JuliaSyntax.getattr(Any, ex, :value)) from strmac"
     if !isnothing(suff)
-        s = "$s with suffix $(suff.value)"
+        s = "$s with suffix $(JuliaSyntax.getattr(Any, suff, :value))"
     end
     s
 end
 
 macro cmdmac_cmd(ex, suff=nothing)
-    s = "$(ex.value) from cmdmac"
+    s = "$(JuliaSyntax.getattr(Any, ex, :value)) from cmdmac"
     if !isnothing(suff)
-        s = "$s with suffix $(suff.value)"
+        s = "$s with suffix $(JuliaSyntax.getattr(Any, suff, :value))"
     end
     s
 end

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -422,19 +422,29 @@ end
 
 @testset "jl_assert" begin
     st = @ast_ [K"function" "foo"::K"Identifier"]
-    err = try
-        JuliaLowering.@jl_assert(1 == 2, (st, "error message 1"), (st, "error message 2"))
-        nothing
-    catch err
-        err
+    if JL.DEBUG
+        err = try
+            JuliaLowering.@jl_assert(1 == 2, (st, "error message 1"), (st, "error message 2"))
+            nothing
+        catch err
+            err
+        end
+        @test err isa LoweringError
+        @test err.internal === true
+        @test length(err.sts) == 2
+        @test length(err.msgs) == 2
+        shown = sprint(show, err)
+        @test contains(shown, "error message 1")
+        @test contains(shown, "error message 2")
+    else
+        @test nothing !== try
+            JuliaLowering.@jl_assert false st
+        catch err
+            err
+        else
+            nothing
+        end
     end
-    @test err isa LoweringError
-    @test err.internal === true
-    @test length(err.sts) == 2
-    @test length(err.msgs) == 2
-    shown = sprint(show, err)
-    @test contains(shown, "error message 1")
-    @test contains(shown, "error message 2")
 end
 
 end

--- a/JuliaLowering/test/quoting.jl
+++ b/JuliaLowering/test/quoting.jl
@@ -82,7 +82,7 @@ let
 end
 """)
 @test kind(ex) == K"Value"
-@test ex.value == 123
+@test getattr(Any, ex, :value) == 123
 
 # Test that interpolation with field access works
 # (the field name can be interpolated into
@@ -94,7 +94,7 @@ end
 """)
 @test kind(ex[2]) == K"inert"
 @test kind(ex[2][1]) == K"Identifier"
-@test ex[2][1].name_val == "a"
+@test getattr(String, ex[2][1], :name_val) == "a"
 
 # Test quoted property access syntax like `Core.:(foo)` and `Core.:(!==)`
 @test JuliaLowering.include_string(test_mod, """
@@ -178,7 +178,7 @@ end
 Base.eval(test_mod, :(xxx = 111))
 dinterp_eval = JuliaLowering.eval(test_mod, double_interp_ex)
 @test kind(dinterp_eval) == K"Value"
-@test dinterp_eval.value == 111
+@test getattr(Any, dinterp_eval, :value) == 111
 
 multi_interp_ex = JuliaLowering.include_string(test_mod, raw"""
 let

--- a/JuliaLowering/test/utils.jl
+++ b/JuliaLowering/test/utils.jl
@@ -15,11 +15,12 @@ import FileWatching
 using Markdown
 import REPL
 
-using .JuliaSyntax: SourceAttrType, new_id!, set_numeric_flags, sourcetext
+using .JuliaSyntax: SourceAttrType, getattr, new_id!, set_numeric_flags, sourcetext
 
-using .JuliaLowering: @ast, Bindings, Kind, LoweringError, MacroExpansionError, NodeId,
-    ScopeLayer, SourceRef, SyntaxGraph, SyntaxTree, children, flattened_provenance,
-    is_leaf, mapchildren, numchildren, setattr!, showprov, syntax_graph
+using .JuliaLowering: @ast, Bindings, IdTag, Kind, LayerId, LoweringError,
+    MacroExpansionError, NodeId, ScopeLayer, SourceRef, SyntaxGraph, SyntaxTree,
+    children, flattened_provenance, is_leaf, mapchildren, numchildren, setattr!,
+    showprov, syntax_graph
 
 function _ast_test_graph()
     JuliaLowering.ensure_desugaring_attributes!(
@@ -28,8 +29,8 @@ end
 
 function _source_node(graph, src)
     id = new_id!(graph)
-    setattr!(graph, id, :kind, K"TOMBSTONE")
-    setattr!(graph, id, :source, src)
+    setattr!(Kind, graph, id, :kind, K"TOMBSTONE")
+    setattr!(SourceAttrType, graph, id, :source, src)
     SyntaxTree(graph, id)
 end
 
@@ -55,11 +56,11 @@ function _format_as_ast_macro(io, ex, indent)
         println(io, indent, "]")
     else
         val_str = if k == K"Identifier" || k == K"core" || k == K"top"
-            repr(ex.name_val)
+            repr(getattr(String, ex, :name_val))
         elseif k == K"BindingId"
-            repr(ex.var_id)
+            repr(getattr(IdTag, ex, :var_id))
         else
-            repr(get(ex, :value, nothing))
+            repr(getattr(Any, ex, :value, nothing))
         end
         println(io, indent, val_str, "::", kind_str)
     end
@@ -138,6 +139,7 @@ end
 function setup_ir_test_module(preamble)
     test_mod = Module(:TestMod)
     Base.eval(test_mod, :(const JuliaLowering = $JuliaLowering))
+    Base.eval(test_mod, :(const JuliaSyntax = $(JuliaSyntax)))
     Base.eval(test_mod, :(const var"@ast_" = $(var"@ast_")))
     JuliaLowering.include_string(test_mod, preamble)
     test_mod
@@ -147,7 +149,7 @@ function format_ir_for_test(mod, case)
     ex = parsestmt(SyntaxTree, case.input)
     try
         if (kind(ex) == K"macrocall" && kind(ex[1]) == K"Identifier" &&
-            ex[1].name_val == "@ast_")
+            getattr(String, ex[1], :name_val) == "@ast_")
             # Total hack, until @ast_ can be implemented in terms of new-style
             # macros.
             ex = Base.eval(mod, JuliaLowering.est_to_expr(ex))

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -133,6 +133,8 @@ function child(graph::SyntaxGraph, id::NodeId, i::Integer)
     graph.edges[graph.edge_ranges[id][i]]
 end
 
+# XXX: the @noinline (and the one on setattr!) work around an issue where
+# codegen produces a trampoline for `getindex`
 @noinline function getattr(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}, name::Symbol)
     getfield(graph, :attributes)[name]
 end

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -17,19 +17,6 @@ SyntaxGraph() = ensure_required_attributes!(
         Vector{UnitRange{Int}}(),
         Vector{NodeId}(), Dict{Symbol,Dict{NodeId, Any}}()))
 
-# "Freeze" attribute names and types, encoding them in the type of the returned
-# SyntaxGraph.
-function freeze_attrs(graph::SyntaxGraph)
-    frozen_attrs = (; pairs(graph.attributes)...)
-    SyntaxGraph(graph.edge_ranges, graph.edges, frozen_attrs)
-end
-
-# Create a copy of `graph` where the attribute list is mutable
-function unfreeze_attrs(graph::SyntaxGraph)
-    unfrozen_attrs = Dict{Symbol,Any}(pairs(graph.attributes)...)
-    SyntaxGraph(graph.edge_ranges, graph.edges, unfrozen_attrs)
-end
-
 function _show_attrs(io, attributes::Dict)
     show(io, MIME("text/plain"), attributes)
 end
@@ -70,7 +57,7 @@ end
 
 function ensure_attributes!(graph::SyntaxGraph{<:NamedTuple}; kws...)
     throw(ErrorException("""
-        ensure_attributes!: $k is not an existing attribute, and the graph's attributes are frozen. \
+        ensure_attributes!: The graph's attributes are frozen. \
         Consider calling non-mutating `ensure_attributes` instead."""))
 end
 
@@ -109,7 +96,7 @@ end
 function delete_attributes(graph::SyntaxGraph{<:NamedTuple}, attr_names::Symbol...)
     unfrozen_attrs = Dict{Symbol,Any}(pairs(graph.attributes)...)
     for name in attr_names
-        delete!(graph.attributes, name)
+        delete!(unfrozen_attrs, name)
     end
     SyntaxGraph(graph.edge_ranges, graph.edges, (; pairs(unfrozen_attrs)...))
 end
@@ -858,7 +845,7 @@ function prune(graph1_a::SyntaxGraph, entrypoints_a::Vector{NodeId})
             push!(nodes1, c1)
         end
     end
-    graph2.edges = 1:length(nodes1) # our reward for unaliasing
+    append!(graph2.edges, 1:length(nodes1)) # our reward for unaliasing
 
     for attr in attrnames(graph1)
         attr === :source && continue
@@ -905,7 +892,7 @@ end
 Give each descendent of `st` a `parent::NodeId` attribute.
 """
 function annotate_parent!(st::SyntaxTree)
-    g = unfreeze_attrs(syntax_graph(st))
+    g = syntax_graph(st)
     st = unalias_nodes(SyntaxTree(g, st._id))
     ensure_attributes!(g; parent=NodeId)
     mapchildren(t->_annotate_parent!(t, st._id), syntax_graph(st), st)

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -7,15 +7,15 @@ one or several syntax trees.
 TODO: Global attributes!
 """
 mutable struct SyntaxGraph{Attrs}
-    edge_ranges::Vector{UnitRange{Int}}
-    edges::Vector{NodeId}
-    attributes::Attrs
+    const edge_ranges::Vector{UnitRange{Int}}
+    const edges::Vector{NodeId}
+    const attributes::Attrs
 end
 
 SyntaxGraph() = ensure_required_attributes!(
-    SyntaxGraph{Dict{Symbol,Any}}(
+    SyntaxGraph{Dict{Symbol,Dict{NodeId, Any}}}(
         Vector{UnitRange{Int}}(),
-        Vector{NodeId}(), Dict{Symbol,Any}()))
+        Vector{NodeId}(), Dict{Symbol,Dict{NodeId, Any}}()))
 
 # "Freeze" attribute names and types, encoding them in the type of the returned
 # SyntaxGraph.
@@ -53,33 +53,37 @@ function Base.show(io::IO, ::MIME"text/plain", graph::SyntaxGraph)
     _show_attrs(io, graph.attributes)
 end
 
-function ensure_attributes!(graph::SyntaxGraph; kws...)
-    for (k,v) in pairs(kws)
+function ensure_attributes!(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}; kws...)
+    for (k,_) in pairs(kws)
         @assert k isa Symbol
-        @assert v isa Type
-        if haskey(graph.attributes, k)
-            v0 = valtype(graph.attributes[k])
-            v == v0 || throw(ErrorException("Attribute type mismatch $v != $v0"))
-        elseif graph.attributes isa NamedTuple
-            throw(ErrorException("""
-                ensure_attributes!: $k is not an existing attribute, and the graph's attributes are frozen. \
-                Consider calling non-mutating `ensure_attributes` instead."""))
-        else
-            graph.attributes[k] = Dict{NodeId,v}()
+        if !haskey(graph.attributes, k)
+            graph.attributes[k] = Dict{NodeId,Any}()
         end
     end
     graph
 end
 
-function ensure_attributes(graph::SyntaxGraph{<:Dict}; kws...)
+function ensure_attributes(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}; kws...)
     g = copy_attrs(graph)
     ensure_attributes!(g; kws...)
 end
 
+function ensure_attributes!(graph::SyntaxGraph{<:NamedTuple}; kws...)
+    throw(ErrorException("""
+        ensure_attributes!: $k is not an existing attribute, and the graph's attributes are frozen. \
+        Consider calling non-mutating `ensure_attributes` instead."""))
+end
+
 function ensure_attributes(graph::SyntaxGraph{<:NamedTuple}; kws...)
-    g = unfreeze_attrs(graph)
-    ensure_attributes!(g; kws...)
-    freeze_attrs(g)
+    unfrozen_attrs = Dict{Symbol,Any}(pairs(graph.attributes)...)
+    for (k,v) in pairs(kws)
+        @assert k isa Symbol
+        @assert v isa Type
+        if !haskey(graph.attributes, k)
+            unfrozen_attrs[k] = Dict{NodeId,v}()
+        end
+    end
+    SyntaxGraph(graph.edge_ranges, graph.edges, (; pairs(unfrozen_attrs)...))
 end
 
 ensure_required_attributes!(g::SyntaxGraph) = ensure_attributes!(
@@ -91,20 +95,23 @@ ensure_required_attributes!(g::SyntaxGraph) = ensure_attributes!(
     name_val=String,
     mod=Module)
 
-function delete_attributes!(graph::SyntaxGraph{<:Dict}, attr_names::Symbol...)
+function delete_attributes!(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}, attr_names::Symbol...)
     for name in attr_names
         delete!(graph.attributes, name)
     end
     graph
 end
 
-function delete_attributes(graph::SyntaxGraph{<:Dict}, attr_names::Symbol...)
-    delete_attributes!(unfreeze_attrs(graph), attr_names...)
+function delete_attributes(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}, attr_names::Symbol...)
+    delete_attributes!(copy_attrs(graph), attr_names...)
 end
 
 function delete_attributes(graph::SyntaxGraph{<:NamedTuple}, attr_names::Symbol...)
-    g = delete_attributes!(unfreeze_attrs(graph), attr_names...)
-    freeze_attrs(g)
+    unfrozen_attrs = Dict{Symbol,Any}(pairs(graph.attributes)...)
+    for name in attr_names
+        delete!(graph.attributes, name)
+    end
+    SyntaxGraph(graph.edge_ranges, graph.edges, (; pairs(unfrozen_attrs)...))
 end
 
 function new_id!(graph::SyntaxGraph)
@@ -139,7 +146,7 @@ function child(graph::SyntaxGraph, id::NodeId, i::Integer)
     graph.edges[graph.edge_ranges[id][i]]
 end
 
-function getattr(graph::SyntaxGraph{<:Dict}, name::Symbol)
+@noinline function getattr(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}, name::Symbol)
     getfield(graph, :attributes)[name]
 end
 
@@ -147,16 +154,16 @@ function getattr(graph::SyntaxGraph{<:NamedTuple}, name::Symbol)
     getfield(getfield(graph, :attributes), name)
 end
 
-function getattr(graph::SyntaxGraph, name::Symbol, default)
-    get(getfield(graph, :attributes), name, default)
+function hasattr(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}, name::Symbol)
+    haskey(getfield(graph, :attributes), name)
 end
 
-function hasattr(graph::SyntaxGraph, name::Symbol)
-    getattr(graph, name, nothing) !== nothing
+function hasattr(graph::SyntaxGraph{<:NamedTuple}, name::Symbol)
+    haskey(getfield(graph, :attributes), name)
 end
 
 # TODO: Probably terribly non-inferable?
-function setattr!(graph::SyntaxGraph, id::NodeId, k::Symbol, @nospecialize(v))
+@noinline function setattr!(graph::SyntaxGraph, id::NodeId, k::Symbol, @nospecialize(v))
     if !isnothing(v)
         getattr(graph, k)[id] = v
     end
@@ -231,10 +238,10 @@ end
 function Base.getproperty(ex::SyntaxTree, name::Symbol)
     name === :_graph && return getfield(ex, :_graph)
     name === :_id  && return getfield(ex, :_id)
-    _id = getfield(ex, :_id)
-    return get(getproperty(getfield(ex, :_graph), name), _id) do
-        error("Property `$name` not defined on node: $(node_string(ex))")
-    end
+    graph = getfield(ex, :_graph)
+    val = get(getattr(graph, name), getfield(ex, :_id), nothing)
+    isnothing(val) && error("Property `$name` not defined on node: $(node_string(ex))")
+    return val
 end
 
 function Base.setproperty!(ex::SyntaxTree, name::Symbol, @nospecialize(val))
@@ -247,9 +254,9 @@ function Base.propertynames(ex::SyntaxTree)
 end
 
 function Base.get(ex::SyntaxTree, name::Symbol, default)
-    attr = getattr(getfield(ex, :_graph), name, nothing)
-    return isnothing(attr) ? default :
-           get(attr, getfield(ex, :_id), default)
+    graph = getfield(ex, :_graph)
+    !hasattr(graph, name) && return default
+    get(getattr(graph, name), getfield(ex, :_id), default)
 end
 
 function Base.getindex(ex::SyntaxTree, i::Integer)
@@ -279,7 +286,9 @@ function Base.:≈(ex1::SyntaxTree, ex2::SyntaxTree)
 end
 
 function hasattr(ex::SyntaxTree, name::Symbol)
-    attr = getattr(ex._graph, name, nothing)
+    graph = ex._graph
+    !hasattr(graph, name) && return false
+    attr = getattr(graph, name)
     return !isnothing(attr) && haskey(attr, ex._id)
 end
 
@@ -402,7 +411,7 @@ function _sourceref(sources, id)
 end
 
 function sourceref(ex::SyntaxTree)
-    sources = ex._graph.source::Dict{NodeId,SourceAttrType}
+    sources = ex._graph.source::Dict{Int, Any}
     id = ex._id
     while true
         s, _ = _sourceref(sources, id)
@@ -432,7 +441,7 @@ end
 function flattened_provenance(ex::SyntaxTree)
     refs = SyntaxList(ex._graph)
     _flattened_provenance(refs, ex._graph, ex._graph.source, ex._id)
-    return reverse(refs)
+    return reverse!(refs)
 end
 
 
@@ -484,7 +493,7 @@ end
 
 #-------------------------------------------------------------------------------
 # Lightweight vector of nodes ids with associated pointer to graph stored separately.
-mutable struct SyntaxList{Attrs, NodeIdVecType} <: AbstractVector{SyntaxTree}
+struct SyntaxList{Attrs, NodeIdVecType} <: AbstractVector{SyntaxTree}
     graph::SyntaxGraph{Attrs}
     ids::NodeIdVecType
 end
@@ -673,10 +682,7 @@ function copy_attrs!(dest, src, all=false)
     for (name, attr) in pairs(src._graph.attributes)
         if (all || (name !== :source && name !== :kind && name !== :syntax_flags)) &&
                 haskey(attr, src._id)
-            dest_attr = getattr(dest._graph, name, nothing)
-            if !isnothing(dest_attr)
-                dest_attr[dest._id] = attr[src._id]
-            end
+            setattr!(dest, name, attr[src._id])
         end
     end
 end
@@ -688,14 +694,14 @@ function copy_attrs!(dest, head::Union{Kind,SyntaxHead}, all=false)
     end
 end
 
-function mapchildren(f::Function, ctx, ex::SyntaxTree, do_map_child::Function)
+function mapchildren(f::Function, ctx, ex::SyntaxTree)
     if is_leaf(ex)
         return ex
     end
     orig_children = children(ex)
     cs = nothing
     for (i,e) in enumerate(orig_children)
-        newchild = do_map_child(i) ? f(e) : e
+        newchild = f(e)
         if isnothing(cs)
             if newchild == e
                 continue
@@ -715,26 +721,6 @@ function mapchildren(f::Function, ctx, ex::SyntaxTree, do_map_child::Function)
     ex2 = mknode(ex, cs)
     return ex2
 end
-
-function mapchildren(f::Function, ctx, ex::SyntaxTree,
-                     mapped_children::AbstractVector{<:Integer})
-    j = Ref(firstindex(mapped_children))
-    function do_map_child(i)
-        ind = j[]
-        if ind <= lastindex(mapped_children) && mapped_children[ind] == i
-            j[] += 1
-            true
-        else
-            false
-        end
-    end
-    mapchildren(f, ctx, ex, do_map_child)
-end
-
-function mapchildren(f::Function, ctx, ex::SyntaxTree)
-    mapchildren(f, ctx, ex, _->true)
-end
-
 
 """
 Recursively copy AST `ex` into `ctx`.
@@ -1243,7 +1229,7 @@ function _insert_green(graph::SyntaxGraph, sf::Base.RefValue{SourceFile},
         for c in reverse(cursor)
             push!(cs, _insert_green(graph, sf, txtbuf, offset, c))
         end
-        setchildren!(graph, id, reverse(cs))
+        setchildren!(graph, id, reverse!(cs))
     else
         v = parse_julia_literal(txtbuf, head(cursor), byte_range(cursor) .+ offset)
         if v isa Symbol

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -133,42 +133,23 @@ function child(graph::SyntaxGraph, id::NodeId, i::Integer)
     graph.edges[graph.edge_ranges[id][i]]
 end
 
-# XXX: the @noinline (and the one on setattr!) work around an issue where
-# codegen produces a trampoline for `getindex`
-@noinline function getattr(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}, name::Symbol)
-    getfield(graph, :attributes)[name]
+function getattr(::Type{T}, graph::SyntaxGraph, name::Symbol) where T
+    graph.attributes[name]
 end
 
-function getattr(graph::SyntaxGraph{<:NamedTuple}, name::Symbol)
-    getfield(getfield(graph, :attributes), name)
+function hasattr(::Type{T}, graph::SyntaxGraph, name::Symbol) where T
+    haskey(graph.attributes, name)
 end
 
-function hasattr(graph::SyntaxGraph{Dict{Symbol,Dict{NodeId,Any}}}, name::Symbol)
-    haskey(getfield(graph, :attributes), name)
-end
-
-function hasattr(graph::SyntaxGraph{<:NamedTuple}, name::Symbol)
-    haskey(getfield(graph, :attributes), name)
-end
-
-# TODO: Probably terribly non-inferable?
-@noinline function setattr!(graph::SyntaxGraph, id::NodeId, k::Symbol, @nospecialize(v))
+function setattr!(::Type{T}, graph::SyntaxGraph, id::NodeId, k::Symbol, v::T) where T
     if !isnothing(v)
-        getattr(graph, k)[id] = v
+        getattr(T, graph, k)[id] = v
     end
     id
 end
 
-function deleteattr!(graph::SyntaxGraph, id::NodeId, name::Symbol)
-    delete!(getattr(graph, name), id)
-end
-
-function Base.getproperty(graph::SyntaxGraph, name::Symbol)
-    # TODO: Remove access to internals?
-    name === :edge_ranges && return getfield(graph, :edge_ranges)
-    name === :edges       && return getfield(graph, :edges)
-    name === :attributes  && return getfield(graph, :attributes)
-    return getattr(graph, name)
+function deleteattr!(::Type{T}, graph::SyntaxGraph, id::NodeId, name::Symbol) where T
+    delete!(getattr(T, graph, name), id)
 end
 
 """
@@ -209,7 +190,7 @@ end
 function node_string(ex::SyntaxTree, depth=2)
     out = "(_id="*string(ex._id)
     for n in sort!(attrnames(ex))
-        out *= ", "*string(n)*"="*repr(getproperty(ex, n))
+        out *= ", "*string(n)*"="*repr(getattr(Any, ex, n))
     end
     if is_leaf(ex)
         out *= ", leaf"
@@ -224,28 +205,17 @@ function node_string(ex::SyntaxTree, depth=2)
     return out
 end
 
-function Base.getproperty(ex::SyntaxTree, name::Symbol)
-    name === :_graph && return getfield(ex, :_graph)
-    name === :_id  && return getfield(ex, :_id)
+function getattr(::Type{T}, ex::SyntaxTree, name::Symbol) where T
     graph = getfield(ex, :_graph)
-    val = get(getattr(graph, name), getfield(ex, :_id), nothing)
-    isnothing(val) && error("Property `$name` not defined on node: $(node_string(ex))")
-    return val
+    val = get(getattr(T, graph, name), getfield(ex, :_id), nothing)
+    isnothing(val) && error("Attribute `$name` not defined on node: $(node_string(ex))")
+    return val::T
 end
 
-function Base.setproperty!(ex::SyntaxTree, name::Symbol, @nospecialize(val))
-    setattr!(ex._graph, ex._id, name, val)
-    val
-end
-
-function Base.propertynames(ex::SyntaxTree)
-    attrnames(ex)
-end
-
-function Base.get(ex::SyntaxTree, name::Symbol, default)
+function getattr(::Type{T}, ex::SyntaxTree, name::Symbol, default::D) where {T, D}
     graph = getfield(ex, :_graph)
-    !hasattr(graph, name) && return default
-    get(getattr(graph, name), getfield(ex, :_id), default)
+    !hasattr(T, graph, name) && return default
+    return get(getattr(T, graph, name), getfield(ex, :_id), default)::Union{T, D}
 end
 
 function Base.getindex(ex::SyntaxTree, i::Integer)
@@ -264,8 +234,8 @@ function Base.:≈(ex1::SyntaxTree, ex2::SyntaxTree)
         return false
     end
     if is_leaf(ex1)
-        return get(ex1, :value,    nothing) == get(ex2, :value,    nothing) &&
-               get(ex1, :name_val, nothing) == get(ex2, :name_val, nothing)
+        return getattr(Any, ex1, :value, nothing) == getattr(Any, ex2, :value, nothing) &&
+               getattr(String, ex1, :name_val, nothing) == getattr(String, ex2, :name_val, nothing)
     else
         if numchildren(ex1) != numchildren(ex2)
             return false
@@ -274,10 +244,10 @@ function Base.:≈(ex1::SyntaxTree, ex2::SyntaxTree)
     end
 end
 
-function hasattr(ex::SyntaxTree, name::Symbol)
+function hasattr(::Type{T}, ex::SyntaxTree, name::Symbol) where T
     graph = ex._graph
-    !hasattr(graph, name) && return false
-    attr = getattr(graph, name)
+    !hasattr(T, graph, name) && return false
+    attr = getattr(T, graph, name)
     return !isnothing(attr) && haskey(attr, ex._id)
 end
 
@@ -297,15 +267,15 @@ function copy_node(ex::SyntaxTree)
     ex2
 end
 
-function setattr!(ex::SyntaxTree, name::Symbol, @nospecialize(val))
-    setattr!(ex._graph, ex._id, name, val)
+function setattr!(::Type{T}, ex::SyntaxTree, name::Symbol, val::T) where T
+    setattr!(T, ex._graph, ex._id, name, val)
     ex
 end
-setattr(ex::SyntaxTree, name::Symbol, @nospecialize(val)) =
-    setattr!(copy_node(ex), name, val)
+setattr(::Type{T}, ex::SyntaxTree, name::Symbol, val::T) where T =
+    setattr!(T, copy_node(ex), name, val)
 
-function deleteattr!(ex::SyntaxTree, name::Symbol)
-    deleteattr!(ex._graph, ex._id, name)
+function deleteattr!(::Type{T}, ex::SyntaxTree, name::Symbol) where T
+    deleteattr!(T, ex._graph, ex._id, name)
 end
 
 # JuliaSyntax tree API
@@ -327,11 +297,11 @@ function head(ex::SyntaxTree)
 end
 
 function kind(ex::SyntaxTree)
-    ex.kind::Kind
+    getattr(Kind, ex, :kind)
 end
 
 function flags(ex::SyntaxTree)
-    get(ex, :syntax_flags, 0x0000)
+    getattr(UInt16, ex, :syntax_flags, 0x0000)
 end
 
 
@@ -376,7 +346,7 @@ end
 
 
 function provenance(ex::SyntaxTree)
-    s = ex.source
+    s = getattr(SourceAttrType, ex, :source)
     if s isa NodeId
         return (SyntaxTree(ex._graph, s),)
     elseif s isa Tuple
@@ -400,7 +370,7 @@ function _sourceref(sources, id)
 end
 
 function sourceref(ex::SyntaxTree)
-    sources = ex._graph.source::Dict{Int, Any}
+    sources = getattr(SourceAttrType, ex._graph, :source)
     id = ex._id
     while true
         s, _ = _sourceref(sources, id)
@@ -429,7 +399,7 @@ end
 
 function flattened_provenance(ex::SyntaxTree)
     refs = SyntaxList(ex._graph)
-    _flattened_provenance(refs, ex._graph, ex._graph.source, ex._id)
+    _flattened_provenance(refs, ex._graph, getattr(SourceAttrType, ex._graph, :source), ex._id)
     return reverse!(refs)
 end
 
@@ -438,7 +408,7 @@ function is_ancestor(ex, ancestor)
     if !is_compatible_graph(ex, ancestor)
         return false
     end
-    sources = ex._graph.source
+    sources = getattr(SourceAttrType, ex._graph, :source)
     id::NodeId = ex._id
     while true
         s = get(sources, id, nothing)
@@ -635,8 +605,8 @@ function newnode(graph::SyntaxGraph, prov::SourceAttrType, k::Kind, children)
 end
 function newleaf(graph::SyntaxGraph, prov::SourceAttrType, k::Kind)
     st = SyntaxTree(graph, new_id!(graph))
-    setattr!(st, :kind, k)
-    setattr!(st, :source, prov)
+    setattr!(Kind, st, :kind, k)
+    setattr!(SourceAttrType, st, :source, prov)
 end
 
 newnode(graph::SyntaxGraph, prov::SyntaxTree, k::Kind, children) =
@@ -661,7 +631,7 @@ function mkleaf(old::SyntaxTree)
     graph = syntax_graph(old)
     st = SyntaxTree(graph, new_id!(graph))
     copy_attrs!(st, old, true)
-    setattr!(st, :source, old._id)
+    setattr!(SourceAttrType, st, :source, old._id)
 end
 
 #-------------------------------------------------------------------------------
@@ -671,15 +641,15 @@ function copy_attrs!(dest, src, all=false)
     for (name, attr) in pairs(src._graph.attributes)
         if (all || (name !== :source && name !== :kind && name !== :syntax_flags)) &&
                 haskey(attr, src._id)
-            setattr!(dest, name, attr[src._id])
+            setattr!(Any, dest, name, attr[src._id])
         end
     end
 end
 
 function copy_attrs!(dest, head::Union{Kind,SyntaxHead}, all=false)
     if all
-        setattr!(dest._graph, dest._id, :kind, kind(head))
-        !(head isa Kind) && setattr!(dest._graph, dest._id, :syntax_flags, flags(head))
+        setattr!(Kind, dest._graph, dest._id, :kind, kind(head))
+        !(head isa Kind) && setattr!(UInt16, dest._graph, dest._id, :syntax_flags, flags(head))
     end
 end
 
@@ -733,7 +703,7 @@ function _copy_ast(graph2::SyntaxGraph, graph1::SyntaxGraph,
     end
     id2 = new_id!(graph2)
     seen[id1] = id2
-    src1 = get(SyntaxTree(graph1, id1), :source, nothing)
+    src1 = getattr(SourceAttrType, SyntaxTree(graph1, id1), :source, nothing)
     src2 = if !copy_source
         src1
     elseif src1 isa NodeId
@@ -744,7 +714,7 @@ function _copy_ast(graph2::SyntaxGraph, graph1::SyntaxGraph,
         src1
     end
     copy_attrs!(SyntaxTree(graph2, id2), SyntaxTree(graph1, id1), true)
-    setattr!(graph2, id2, :source, src2)
+    setattr!(SourceAttrType, graph2, id2, :source, src2)
     if !is_leaf(graph1, id1)
         cs = NodeId[]
         for cid in children(graph1, id1)
@@ -863,7 +833,7 @@ function prune(graph1_a::SyntaxGraph, entrypoints_a::Vector{NodeId})
     resolved_sources = Dict{NodeId, SourceAttrType}() # graph1 id => graph2 src
 
     for (n2, n1) in enumerate(nodes1)
-        graph2.source[n2] = _prune_get_resolved!(n1, graph1, map12, resolved_sources)
+        getattr(SourceAttrType, graph2, :source)[n2] = _prune_get_resolved!(n1, graph1, map12, resolved_sources)
     end
 
     # The first n entries in nodes1 were our entrypoints, unique from unaliasing
@@ -875,7 +845,7 @@ function _prune_get_resolved!(id1::NodeId, graph1::SyntaxGraph,
                               resolved_sources::Dict{NodeId, SourceAttrType})
     out = get(resolved_sources, id1, nothing)
     if isnothing(out)
-        src1 = graph1.source[id1]
+        src1 = getattr(SourceAttrType, graph1, :source)[id1]
         out = if haskey(map12, src1)
             map12[src1]
         elseif src1 isa NodeId
@@ -901,7 +871,7 @@ function annotate_parent!(st::SyntaxTree)
 end
 
 function _annotate_parent!(st::SyntaxTree, pid::NodeId)
-    setattr!(st, :parent, pid)
+    setattr!(NodeId, st, :parent, pid)
     mapchildren(t->_annotate_parent!(t, st._id), syntax_graph(st), st)
 end
 
@@ -1187,8 +1157,8 @@ function build_tree(::Type{SyntaxTree}, stream::ParseStream;
     length(cs) === 1 && return only(cs)
     id = new_id!(graph)
     setchildren!(graph, id, reverse(cs).ids)
-    setattr!(graph, id, :source, source)
-    setattr!(graph, id, :kind, K"wrapper")
+    setattr!(SourceAttrType, graph, id, :source, source)
+    setattr!(Kind, graph, id, :kind, K"wrapper")
     return SyntaxTree(graph, id)
 end
 
@@ -1210,9 +1180,9 @@ function _insert_green(graph::SyntaxGraph, sf::Base.RefValue{SourceFile},
                        txtbuf::Vector{UInt8}, offset::Int,
                        cursor::RedTreeCursor)
     id = new_id!(graph)
-    setattr!(graph, id, :kind, kind(cursor))
-    setattr!(graph, id, :syntax_flags, flags(cursor))
-    setattr!(graph, id, :source, SourceRef(sf, first_byte(cursor), last_byte(cursor)))
+    setattr!(Kind, graph, id, :kind, kind(cursor))
+    setattr!(UInt16, graph, id, :syntax_flags, flags(cursor))
+    setattr!(SourceAttrType, graph, id, :source, SourceRef(sf, first_byte(cursor), last_byte(cursor)))
     if !is_leaf(cursor)
         cs = NodeId[]
         for c in reverse(cursor)
@@ -1223,9 +1193,9 @@ function _insert_green(graph::SyntaxGraph, sf::Base.RefValue{SourceFile},
         v = parse_julia_literal(txtbuf, head(cursor), byte_range(cursor) .+ offset)
         if v isa Symbol
             # TODO: Fixes in JuliaSyntax to avoid ever converting to Symbol
-            setattr!(graph, id, :name_val, string(v))
+            setattr!(String, graph, id, :name_val, string(v))
         elseif !isnothing(v)
-            setattr!(graph, id, :value, v)
+            setattr!(Any, graph, id, :value, v)
         end
     end
     return id
@@ -1263,18 +1233,18 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
 
     graph = syntax_graph(st)
     k = kind(st)
-    coreref(s::String) = setattr!(newleaf(graph, st, K"core"), :name_val, s)
-    symleaf(s::String) = setattr!(newleaf(graph, st, K"Identifier"), :name_val, s)
-    core_globalref(s::String) = setattr!(symleaf(s), :mod, Core)
-    valleaf(@nospecialize(v)) = setattr!(newleaf(graph, st, K"Value"), :value, v)
+    coreref(s::String) = setattr!(String, newleaf(graph, st, K"core"), :name_val, s)
+    symleaf(s::String) = setattr!(String, newleaf(graph, st, K"Identifier"), :name_val, s)
+    core_globalref(s::String) = setattr!(Module, symleaf(s), :mod, Core)
+    valleaf(@nospecialize(v)) = setattr!(Any, newleaf(graph, st, K"Value"), :value, v)
 
     if is_leaf(st)
         return if k === K"CmdMacroName" || k === K"StrMacroName"
-            name = lower_identifier_name(st.name_val, k)
+            name = lower_identifier_name(getattr(String, st, :name_val), k)
             symleaf(name)
         elseif k === K"VERSION"
             valleaf(version_to_expr(st))
-        elseif (v = get(st, :value, nothing); v isa Union{Int128,UInt128,BigInt})
+        elseif (v = getattr(Any, st, :value, nothing); v isa Union{Int128,UInt128,BigInt})
             # syntax TODO: likely unnecessary; this is just to match RGN->Expr,
             # which added this to match flisp parsing text->Expr.
             macname = v isa Int128 ? "@int128_str" :
@@ -1283,9 +1253,9 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
             arg = valleaf(replace(sourcetext(st), '_'=>""))
             ret_cids = tree_ids(mac, coreref("nothing"), arg)
             newnode(graph, st, K"macrocall", ret_cids)
-        elseif hasattr(st, :name_val) && !(kind(st) in KSet"Identifier core")
+        elseif hasattr(String, st, :name_val) && !(kind(st) in KSet"Identifier core")
             # certain kinds should really be identifiers.  known: &, |, :
-            symleaf(st.name_val)
+            symleaf(getattr(String, st, :name_val))
         else
             st
         end
@@ -1310,15 +1280,15 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
         # "@M.x" => (macro_name (. M x)) => (. M @x)
         #           (macro_name else) => else
         if kind(cs[1]) === K"Identifier"
-            return symleaf(lower_identifier_name(cs[1].name_val, K"macro_name"))
+            return symleaf(lower_identifier_name(getattr(String, cs[1], :name_val), K"macro_name"))
         else
             inner_st = cs[1]
             inner_cs = preprocessed_green_children(inner_st)
             if (length(inner_cs) === 2 && kind(inner_st) === K"." &&
                 kind(inner_cs[2]) === K"Identifier")
                 (lhs, raw_m) = _green_to_est(cs[1], 1, inner_cs[1]), inner_cs[2]
-                mname_s = lower_identifier_name(raw_m.name_val, K"macro_name")
-                mname = setattr!(mkleaf(raw_m), :name_val, mname_s)
+                mname_s = lower_identifier_name(getattr(String, raw_m, :name_val), K"macro_name")
+                mname = setattr!(String, mkleaf(raw_m), :name_val, mname_s)
                 mname_inert = newnode(graph, raw_m, K"inert", tree_ids(mname))
                 return mknode(inner_st, tree_ids(lhs, mname_inert))
             else
@@ -1334,13 +1304,13 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
         lhs = _green_to_est(st, 0, cs[1])
         rhs = _green_to_est(st, 0, cs[3])
         out = newnode(graph, st, K"unknown_head", tree_ids(lhs, rhs))
-        return setattr!(out, :name_val, op_s)
+        return setattr!(String, out, :name_val, op_s)
     elseif k === K".op=" && n_cs === 3
         op_s = '.' * string(cs[2]) * '='
         lhs = _green_to_est(st, 0, cs[1])
         rhs = _green_to_est(st, 0, cs[3])
         out = newnode(graph, st, K"unknown_head", tree_ids(lhs, rhs))
-        return setattr!(out, :name_val, op_s)
+        return setattr!(String, out, :name_val, op_s)
     elseif k === K"macrocall" && n_cs > 0
         # LineNumberNodes are not usually added to the tree as they are in Expr,
         # but this specifically inserts the macrocall child for compatibility
@@ -1372,7 +1342,7 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
             cs[2], cs[1] = cs[1], cs[2]
         end
         if is_postfix_op_call(st) && kind(cs[1]) == K"Identifier" &&
-            cs[1].name_val === "'"
+            getattr(String, cs[1], :name_val) === "'"
             popfirst!(cs)
             ret_k = K"'"
         end
@@ -1388,7 +1358,7 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
                 # (dotcall + args...) => (call .+ args...)
                 ret_k = K"call"
                 if kind(cs[1]) === K"Identifier"
-                    cs[1] = symleaf('.' * cs[1].name_val)
+                    cs[1] = symleaf('.' * getattr(String, cs[1], :name_val))
                 end
             end
         end
@@ -1412,7 +1382,7 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
 
             if (coalesce_dot || is_syntactic_operator(kind(cs[1])) ||
                 kind(parent) === K"comparison" && iseven(parent_i))
-                return symleaf('.' * cs[1].name_val)
+                return symleaf('.' * getattr(String, cs[1], :name_val))
             end
         end
     elseif k === K"ref" || k === K"curly"
@@ -1508,7 +1478,7 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
                 g_out = newnode(graph, c, K"flatten", tree_ids(g_out))
             end
         end
-        return setattr!(g_out, :source, st._id) # outermost provenance
+        return setattr!(SourceAttrType, g_out, :source, st._id) # outermost provenance
     elseif k === K"filter"
         @assert n_cs === 2
         # (filter (iteration is...) cond) => (filter cond is...)
@@ -1616,7 +1586,7 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
     # Recurse on `cs`.  If no children change, just return `st`.
     ret_cs = _map_green_to_est(st, cs; kw_in_params)
     return ret_cs.ids == children(st).ids && ret_k == kind(st) ?
-        st : setattr!(mknode(st, ret_cs), :kind, ret_k)
+        st : setattr!(Kind, mknode(st, ret_cs), :kind, ret_k)
 end
 
 function _map_green_to_est(parent::SyntaxTree, cs::SyntaxList;
@@ -1698,10 +1668,10 @@ function _string_to_est(st::SyntaxTree, cs::SyntaxList; unwrap_literal)
         if !prev_str && cur_str && !next_str
             push!(ret_cs, c)
         elseif cur_str
-            write(buf, c.value)
+            write(buf, getattr(Any, c, :value))
             if !next_str
                 ret_c = newleaf(st._graph, st, literal_k)
-                setattr!(ret_c, :value, String(take!(buf)))
+                setattr!(Any, ret_c, :value, String(take!(buf)))
                 push!(ret_cs, ret_c)
             end
         else

--- a/JuliaSyntax/test/syntax_graph.jl
+++ b/JuliaSyntax/test/syntax_graph.jl
@@ -1,52 +1,55 @@
-using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, freeze_attrs, unfreeze_attrs, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind, syntax_graph
+using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind, syntax_graph
 
 @testset "SyntaxGraph attrs" begin
-    st = parsestmt(SyntaxTree, "function foo end")
-    g_init = unfreeze_attrs(st._graph)
-    gf1 = freeze_attrs(g_init)
-    gu1 = unfreeze_attrs(gf1)
+    g_dict = SyntaxGraph()
+    g_nt = ensure_attributes(
+        SyntaxGraph(Vector{UnitRange{Int}}(), Vector{NodeId}(), (;)),
+        kind=Kind,
+        source=SourceAttrType,
+        syntax_flags=UInt16,
+        value=Any,
+        name_val=String,
+        mod=Module)
 
     # Check that a default graph has required attrs
-    g_empty = SyntaxGraph()
-    @test (:kind=>Kind) in attrdefs(g_empty)
-    @test (:source=>SourceAttrType) in attrdefs(g_empty)
-    @test (:value=>Any) in attrdefs(g_empty)
-    @test (:name_val=>String) in attrdefs(g_empty)
-
-    # Check that freeze/unfreeze do their jobs
-    @test gf1.attributes isa NamedTuple
-    @test gu1.attributes isa Dict
-    @test Set(keys(gf1.attributes)) == Set(keys(gu1.attributes))
+    @test (:kind=>Any) in attrdefs(g_dict)
+    @test (:source=>Any) in attrdefs(g_dict)
+    @test (:value=>Any) in attrdefs(g_dict)
+    @test (:name_val=>Any) in attrdefs(g_dict)
+    @test (:kind=>Kind) in attrdefs(g_nt)
+    @test (:source=>SourceAttrType) in attrdefs(g_nt)
+    @test (:value=>Any) in attrdefs(g_nt)
+    @test (:name_val=>String) in attrdefs(g_nt)
 
     # ensure_attributes
-    gf2 = ensure_attributes(gf1, test_attr=Symbol, foo=Type)
-    gu2 = ensure_attributes(gu1, test_attr=Symbol, foo=Type)
+    g_nt2 = ensure_attributes(g_nt, test_attr=Symbol, foo=Type)
+    g_dict2 = ensure_attributes(g_dict, test_attr=Symbol, foo=Type)
     # returns a graph with the same attribute storage
-    @test gf2.attributes isa NamedTuple
-    @test gu2.attributes isa Dict
+    @test g_nt2.attributes isa NamedTuple
+    @test g_dict2.attributes isa Dict
     # does its job
-    @test (:test_attr=>Symbol) in attrdefs(gf2)
-    @test (:foo=>Type) in attrdefs(gf2)
-    @test Set(keys(gf2.attributes)) == Set(keys(gu2.attributes))
+    @test (:test_attr=>Symbol) in attrdefs(g_nt2)
+    @test (:foo=>Type) in attrdefs(g_nt2)
+    @test Set(keys(g_nt2.attributes)) == Set(keys(g_dict2.attributes))
     # no mutation
-    @test !((:test_attr=>Symbol) in attrdefs(gf1))
-    @test !((:foo=>Type) in attrdefs(gf1))
-    @test Set(keys(gf1.attributes)) == Set(keys(gu1.attributes))
+    @test !((:test_attr=>Symbol) in attrdefs(g_nt))
+    @test !((:foo=>Type) in attrdefs(g_nt))
+    @test Set(keys(g_nt.attributes)) == Set(keys(g_dict.attributes))
 
     # delete_attributes
-    gf3 = delete_attributes(gf2, :test_attr, :foo)
-    gu3 = delete_attributes(gu2, :test_attr, :foo)
+    g_nt3 = delete_attributes(g_nt2, :test_attr, :foo)
+    g_dict3 = delete_attributes(g_dict2, :test_attr, :foo)
     # returns a graph with the same attribute storage
-    @test gf3.attributes isa NamedTuple
-    @test gu3.attributes isa Dict
+    @test g_nt3.attributes isa NamedTuple
+    @test g_dict3.attributes isa Dict
     # does its job
-    @test !((:test_attr=>Symbol) in attrdefs(gf3))
-    @test !((:foo=>Type) in attrdefs(gf3))
-    @test Set(keys(gf3.attributes)) == Set(keys(gu3.attributes))
+    @test !((:test_attr=>Symbol) in attrdefs(g_nt3))
+    @test !((:foo=>Type) in attrdefs(g_nt3))
+    @test Set(keys(g_nt3.attributes)) == Set(keys(g_dict3.attributes))
     # no mutation
-    @test (:test_attr=>Symbol) in attrdefs(gf2)
-    @test (:foo=>Type) in attrdefs(gf2)
-    @test Set(keys(gf2.attributes)) == Set(keys(gu2.attributes))
+    @test (:test_attr=>Symbol) in attrdefs(g_nt2)
+    @test (:foo=>Type) in attrdefs(g_nt2)
+    @test Set(keys(g_nt2.attributes)) == Set(keys(g_dict2.attributes))
 end
 
 @testset "SyntaxTree parsing" begin
@@ -60,15 +63,16 @@ end
 @testset "SyntaxTree utils" begin
     "For filling required attrs in graphs created by hand"
     function testgraph(edge_ranges, edges, more_attrs...)
-        kinds = Dict(map(i->(i=>K"block"), eachindex(edge_ranges)))
-        sources = Dict{Int, SourceAttrType}(
+        kinds = Dict{NodeId, Any}(map(i->(i=>K"block"), eachindex(edge_ranges)))
+        sources = Dict{NodeId, Any}(
             map(i->(i=>LineNumberNode(i)), eachindex(edge_ranges)))
-        orig = Dict(map(i->(i=>i), eachindex(edge_ranges)))
+        orig = Dict{NodeId, Any}(map(i->(i=>i), eachindex(edge_ranges)))
         SyntaxGraph(
             edge_ranges,
             edges,
-            Dict(:kind => kinds, :source => sources,
-                 :orig => orig, more_attrs...))
+            Dict{Symbol, Dict{NodeId, Any}}(
+                :kind => kinds, :source => sources,
+                :orig => orig, more_attrs...))
     end
 
     @testset "copy_ast" begin
@@ -279,10 +283,6 @@ end
         #    |      |
         #    +-> 3 -+
         g = testgraph([1:2, 3:3, 4:4, 5:5, 0:-1], [2, 3, 4, 4, 5])
-        st = JuliaSyntax.annotate_parent!(SyntaxTree(g, 1))
-        @test chk_parent(st, nothing)
-        # NamedTuple-based attrs
-        g = JuliaSyntax.freeze_attrs(testgraph([1:2, 3:3, 4:4, 5:5, 0:-1], [2, 3, 4, 4, 5]))
         st = JuliaSyntax.annotate_parent!(SyntaxTree(g, 1))
         @test chk_parent(st, nothing)
     end

--- a/JuliaSyntax/test/syntax_graph.jl
+++ b/JuliaSyntax/test/syntax_graph.jl
@@ -1,4 +1,4 @@
-using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind, syntax_graph
+using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind, syntax_graph, getattr
 
 @testset "SyntaxGraph attrs" begin
     g_dict = SyntaxGraph()
@@ -90,18 +90,18 @@ end
         @test length(g.edge_ranges) === 18
         @test st._id != stcopy._id
         @test st ≈ stcopy
-        @test st.source !== stcopy.source
-        @test st.source[1] !== stcopy.source[1]
-        @test st.source[1][1] !== stcopy.source[1][1]
+        @test getattr(SourceAttrType, st, :source) !== getattr(SourceAttrType, stcopy, :source)
+        @test getattr(SourceAttrType, st, :source)[1] !== getattr(SourceAttrType, stcopy, :source)[1]
+        @test getattr(SourceAttrType, st, :source)[1][1] !== getattr(SourceAttrType, stcopy, :source)[1][1]
 
         stcopy2 = copy_ast(g, st; copy_source=false)
         # Only nodes 1-3 should be copied
         @test length(g.edge_ranges) === 21
         @test st._id != stcopy2._id
         @test st ≈ stcopy2
-        @test st.source === stcopy2.source
-        @test st.source[1] === stcopy2.source[1]
-        @test st.source[1][1] === stcopy2.source[1][1]
+        @test getattr(SourceAttrType, st, :source) === getattr(SourceAttrType, stcopy2, :source)
+        @test getattr(SourceAttrType, st, :source)[1] === getattr(SourceAttrType, stcopy2, :source)[1]
+        @test getattr(SourceAttrType, st, :source)[1][1] === getattr(SourceAttrType, stcopy2, :source)[1][1]
 
         # Copy into a new graph
         new_g = ensure_attributes!(SyntaxGraph(); attrdefs(g)...)
@@ -125,8 +125,8 @@ end
         @test length(stu._graph.edge_ranges) == 5
         @test length(stu._graph.edges) == 4
         # Properties of node 4 should be preserved
-        @test 4 == stu[1][1].orig == stu[2][1].orig
-        @test st[1][1].source == stu[1][1].source == stu[2][1].source
+        @test 4 == getattr(Any, stu[1][1], :orig) == getattr(Any, stu[2][1], :orig)
+        @test getattr(SourceAttrType, st[1][1], :source) == getattr(SourceAttrType, stu[1][1], :source) == getattr(SourceAttrType, stu[2][1], :source)
         @test stu[1][1]._id != stu[2][1]._id
 
         #           +-> 5
@@ -147,7 +147,7 @@ end
         @test length(stu._graph.edge_ranges) == 10
         @test length(stu._graph.edges) == 9
         # the four copies of node 6 should have attrs identical to the original and distinct ids
-        @test 6 == stu[1][2].orig == stu[2][1][1].orig == stu[3][1].orig == stu[3][2].orig
+        @test 6 == getattr(Any, stu[1][2], :orig) == getattr(Any, stu[2][1][1], :orig) == getattr(Any, stu[3][1], :orig) == getattr(Any, stu[3][2], :orig)
         @test stu[1][2]._id != stu[2][1][1]._id != stu[3][1]._id != stu[3][2]._id
 
         # 1 -+-> 2 ->-> 4 -+----> 5 ->-> 7
@@ -163,11 +163,11 @@ end
         @test length(stu._graph.edge_ranges) == 15
         @test length(stu._graph.edges) == 14
         # attrs of nodes 4-7
-        @test 4 == stu[1][1].orig == stu[2][1].orig
-        @test 5 == stu[1][1][1].orig == stu[2][1][1].orig
-        @test 6 == stu[1][1][2].orig == stu[2][1][2].orig == stu[2][2].orig
-        @test 7 == stu[1][1][1][1].orig == stu[1][1][2][1].orig ==
-            stu[2][1][1][1].orig == stu[2][1][2][1].orig == stu[2][2][1].orig
+        @test 4 == getattr(Any, stu[1][1], :orig) == getattr(Any, stu[2][1], :orig)
+        @test 5 == getattr(Any, stu[1][1][1], :orig) == getattr(Any, stu[2][1][1], :orig)
+        @test 6 == getattr(Any, stu[1][1][2], :orig) == getattr(Any, stu[2][1][2], :orig) == getattr(Any, stu[2][2], :orig)
+        @test 7 == getattr(Any, stu[1][1][1][1], :orig) == getattr(Any, stu[1][1][2][1], :orig) ==
+            getattr(Any, stu[2][1][1][1], :orig) == getattr(Any, stu[2][1][2][1], :orig) == getattr(Any, stu[2][2][1], :orig)
         # ensure no duplication
         @test stu[1][1][1][1]._id != stu[1][1][2][1]._id !=
             stu[2][1][1][1]._id != stu[2][1][2][1]._id != stu[2][2][1]._id
@@ -182,10 +182,10 @@ end
         stp = JuliaSyntax.prune(st)
         @test st ≈ stp
         @test length(stp._graph.edge_ranges) === 4
-        @test stp.source == LineNumberNode(1)
-        @test stp[1].source == LineNumberNode(2)
-        @test stp[2].source == LineNumberNode(3)
-        @test stp[2][1].source == LineNumberNode(4)
+        @test getattr(SourceAttrType, stp, :source) == LineNumberNode(1)
+        @test getattr(SourceAttrType, stp[1], :source) == LineNumberNode(2)
+        @test getattr(SourceAttrType, stp[2], :source) == LineNumberNode(3)
+        @test getattr(SourceAttrType, stp[2][1], :source) == LineNumberNode(4)
 
         # (also checks that the last prune didn't destroy the graph)
         # 1 -+-> 2         5 --> 6
@@ -195,7 +195,7 @@ end
         stp = JuliaSyntax.prune(st)
         @test st ≈ stp
         @test length(stp._graph.edge_ranges) === 1
-        @test stp.orig == 7
+        @test getattr(Any, stp, :orig) == 7
 
         # 1 -+->[2]->-> 4
         #    |      |
@@ -205,8 +205,8 @@ end
         stp = JuliaSyntax.prune(st)
         @test st ≈ stp
         @test length(stp._graph.edge_ranges) === 2
-        @test stp.orig == 2
-        @test stp[1].orig == 4
+        @test getattr(Any, stp, :orig) == 2
+        @test getattr(Any, stp[1], :orig) == 4
 
         #  9 -->[1]--> 5    src(1) = 2
         # 10 --> 2 --> 6    src(2) = 3
@@ -222,37 +222,37 @@ end
         @test st ≈ stp
         # 1, 5, 4, 8 should remain
         @test length(stp._graph.edge_ranges) === 4
-        @test stp.source isa NodeId
-        orig_4 = SyntaxTree(stp._graph, stp.source)
-        @test orig_4.source === LineNumberNode(4)
+        @test getattr(SourceAttrType, stp, :source) isa NodeId
+        orig_4 = SyntaxTree(stp._graph, getattr(SourceAttrType, stp, :source))
+        @test getattr(SourceAttrType, orig_4, :source) === LineNumberNode(4)
         @test numchildren(orig_4) === 1
-        @test orig_4[1].source === LineNumberNode(8)
-        @test stp[1].source === LineNumberNode(5)
+        @test getattr(SourceAttrType, orig_4[1], :source) === LineNumberNode(8)
+        @test getattr(SourceAttrType, stp[1], :source) === LineNumberNode(5)
 
         # Try again with node 3 explicitly marked reachable
         stp = JuliaSyntax.prune(st, keep=SyntaxList(g, NodeId[3, 4]))
         @test st ≈ stp
         # 1, 5, 4, 8, and now 3, 7 as well
         @test length(stp._graph.edge_ranges) === 6
-        @test stp.source isa NodeId
-        @test stp[1].source === LineNumberNode(5)
+        @test getattr(SourceAttrType, stp, :source) isa NodeId
+        @test getattr(SourceAttrType, stp[1], :source) === LineNumberNode(5)
 
-        orig_3 = SyntaxTree(stp._graph, stp.source)
-        @test orig_3.source isa NodeId
-        orig_4 = SyntaxTree(stp._graph, orig_3.source)
-        @test orig_4.source === LineNumberNode(4)
+        orig_3 = SyntaxTree(stp._graph, getattr(SourceAttrType, stp, :source))
+        @test getattr(SourceAttrType, orig_3, :source) isa NodeId
+        orig_4 = SyntaxTree(stp._graph, getattr(SourceAttrType, orig_3, :source))
+        @test getattr(SourceAttrType, orig_4, :source) === LineNumberNode(4)
 
         @test numchildren(orig_3) === 1
         @test numchildren(orig_4) === 1
-        @test orig_3[1].source === LineNumberNode(7)
-        @test orig_4[1].source === LineNumberNode(8)
+        @test getattr(SourceAttrType, orig_3[1], :source) === LineNumberNode(7)
+        @test getattr(SourceAttrType, orig_4[1], :source) === LineNumberNode(8)
 
         # Try again with no node provenance
         stp = JuliaSyntax.prune(st, keep=nothing)
         @test st ≈ stp
         @test length(stp._graph.edge_ranges) === 2
-        @test stp.source === LineNumberNode(4)
-        @test stp[1].source === LineNumberNode(5)
+        @test getattr(SourceAttrType, stp, :source) === LineNumberNode(4)
+        @test getattr(SourceAttrType, stp[1], :source) === LineNumberNode(5)
 
         # test with real parsed, then copied output---not many properties we can
         # check without fragile tests, but there are some.
@@ -264,20 +264,20 @@ end
         @test st0_dup2 ≈ stp
         @test length(stp._graph.edge_ranges) <
             length(st0_dup2._graph.edge_ranges)
-        @test stp.source isa NodeId
-        @test SyntaxTree(stp._graph, stp.source) ≈ st0
+        @test getattr(SourceAttrType, stp, :source) isa NodeId
+        @test SyntaxTree(stp._graph, getattr(SourceAttrType, stp, :source)) ≈ st0
         @test sourcetext(stp) == code
         # try without preserving st0
         stp = JuliaSyntax.prune(st0_dup2, keep=nothing)
         @test st0_dup2 ≈ stp
         @test length(stp._graph.edge_ranges) <
             length(st0_dup2._graph.edge_ranges)
-        @test stp.source isa SourceRef
+        @test getattr(SourceAttrType, stp, :source) isa SourceRef
         @test sourcetext(stp) == code
     end
 
     @testset "annotate_parent" begin
-        chk_parent(st, parent) = get(st, :parent, nothing) === parent &&
+        chk_parent(st, parent) = getattr(NodeId, st, :parent, nothing) === parent &&
             all(c->chk_parent(c, st._id), children(st))
         # 1 -+-> 2 ->-> 4 --> 5
         #    |      |


### PR DESCRIPTION
This PR proposes a switch to a more verbose attribute API which expects attribute types to be provided at the call-site, rather than leaving them implicit (or enforcing them by ad-hoc typeasserts). I believe this PR also fixes several pre-existing type-instabilities around our usage of `.scope_layer` and `.var_id`, which were hard to spot otherwise.

Changes:
  1. Remove `Base.getproperty` / `Base.setproperty!` overloads for SyntaxGraph / SyntaxTree
  2. Add `::Type{T}` first argument to all `*attr` methods

The `::Type{T} where T` parameter should also allow us to experiment with other SyntaxGraph attribute storage styles, such as using a Dict{NodeId, UInt16} for `:flags` or a BitSet for `:is_toplevel_thunk` as well as the existing Dict{NodeId, Any} for "untyped" attributes like `:value`. As a side benefit, this makes it much easier to identify attribute accesses in the source code and see (at a glance) whether they are type-unstable. 

The main alternative would be to:
 1. Encode this type information as a separate `NamedTuple` (or similar) type parameter to `SyntaxGraph` OR
 2. Hard-code the expected types globally for each attribute
 
 which would avoid you needing to supply these types at the call-site. That would make it much harder for us to remove the `Attrs` type-parameter for `SyntaxGraph` though (if we ever choose to do that) and it would be less flexible.

Dependent on #61425.

---------

Co-authored-by: Claude <claude@anthropic.com> 🤖 

I performed the changes to `JuliaSyntax` manually and then had Claude roll out the remaining changes across `JuliaLowering` for me. I tried to force the bot to be consistent about the types used when accessing each attribute, so I don't expect major correctness issues but I do plan to review the code for structure / formatting before merge.