### PR TITLE
replace `Random.nth` by `Iterators.nth`

### DIFF
--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -518,14 +518,8 @@ _Sampler(RNG::Type{<:AbstractRNG}, t::Union{AbstractDict,AbstractSet}, n::Val{In
 _Sampler(::Type{<:AbstractRNG}, t::Union{AbstractDict,AbstractSet}, ::Val{1}) =
     SamplerTrivial(t)
 
-function nth(iter, n::Integer)::eltype(iter)
-    for (i, x) in enumerate(iter)
-        i == n && return x
-    end
-end
-
 rand(rng::AbstractRNG, sp::SamplerTrivial{<:Union{AbstractDict,AbstractSet}}) =
-    nth(sp[], rand(rng, 1:length(sp[])))
+    @inbounds Iterators.nth(sp[], rand(rng, 1:length(sp[])))
 
 
 ## random characters from a string


### PR DESCRIPTION
`Iterators.nth` has been added in #56580 for Julia 1.13. Currently `Random` has its own (non-public) `nth` function, which is used for `AbstractDict` and `AbstractSet`. This PR replaces it by `Iterators.nth`. Apart from removing redundant code, this also allows user-defined methods for `Iterators.nth` (which is public) to be used in `rand`.

Note that I call `Iterators.nth` with `@inbounds`. This doesn't make any difference for the default method (at least not for `AbstractDict` and `AbstractSet`), but it may do so for user-defined methods. I'm having `SmallBitSet` from my package SmallCollections.jl in mind, where `nth` is just some bit juggling, see matthias314/SmallCollections.jl#17. When filling a vector with random elements of a `SmallBitSet`, around 20% of the runtime would be spent on checking bounds. Of course, I can remove the `@inbounds` if you don't like it.

I've also dropped the `::eltype(iter)` return type indicator of `Random.nth`. I've tested `Set{T}` where `T` is a `Union` with up to 6 elements, and also `Generator`. In all cases, `@code_typed` could predict the return type.