### PR TITLE
[JuliaLowering] Allow `cglobal`, `ccall`, `_` as macro names

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2951,13 +2951,15 @@ function _make_macro_name(ctx, ex)
     k = kind(ex)
     if k == K"Identifier" || k == K"Symbol"
         name = setattr!(mkleaf(ex), :kind, k)
-        name.name_val = "@$(ex.name_val)"
-        name
+        setattr!(name, :name_val, "@$(ex.name_val)")
+    elseif k == K"Placeholder"
+        name = setattr!(mkleaf(ex), :kind, K"Identifier")
+        setattr!(name, :name_val, "@$(ex.name_val)")
     elseif is_valid_modref(ex)
         @jl_assert numchildren(ex) == 2 ex
         @ast ctx ex [K"." ex[1] _make_macro_name(ctx, ex[2])]
     else
-        throw(LoweringError(ex, "invalid macro name"))
+        @jl_assert false ex
     end
 end
 

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -659,7 +659,7 @@ vst1_simple_calldecl(vcx, st) = @stm st begin
 end
 
 vst1_macro(vcx, st) = @stm st begin
-    [K"macro" m] -> vst1_ident(vcx, m)
+    [K"macro" m] -> vst1_ident(vcx, m; lhs=true) | vst1_ident(vcx, m; lhs=false)
     [K"macro" [K"call" _ [K"parameters" _...] _...] _...] ->
         @fail(st[1][end], "macros cannot accept keyword arguments")
     [K"macro" [K"call" m ps...] body] ->
@@ -674,9 +674,11 @@ vst1_macro(vcx, st) = @stm st begin
     _ -> unknown()
 end
 
+# Macros may have either underscore or reserved (ccall, cglobal) names
 vst1_macro_calldecl_name(vcx, st) = @stm st begin
     [K"." _ _] -> vst1_calldecl_dot_name(vcx, st)
-    _ -> @fail(st, "invalid macro name") | vst1_ident(vcx, st; lhs=true)
+    m -> @fail(st, "invalid macro name") |
+        vst1_ident(vcx, m; lhs=true) | vst1_ident(vcx, m; lhs=false)
 end
 
 vst1_calldecl_name(vcx, st) = @stm st begin

--- a/JuliaLowering/test/assignments.jl
+++ b/JuliaLowering/test/assignments.jl
@@ -287,3 +287,27 @@ end
         end
     end
 end
+
+@testset "macros can have lhs-reserved or underscore names" begin
+    local m = Module()
+
+    @test JuliaLowering.include_string(m, """
+    module ShortForm
+        macro ccall end
+        macro cglobal end
+        macro _ end
+    end
+    """) isa Module
+    @test Base.isdefinedglobal(m.ShortForm, Symbol("@ccall"))
+    @test Base.isdefinedglobal(m.ShortForm, Symbol("@cglobal"))
+    @test Base.isdefinedglobal(m.ShortForm, Symbol("@_"))
+
+    @test JuliaLowering.include_string(m, """ macro ccall(x); x; end """) isa Function
+    @test JuliaLowering.include_string(m, "@ccall(1)") == 1
+
+    @test JuliaLowering.include_string(m, """ macro cglobal(x); x; end """) isa Function
+    @test JuliaLowering.include_string(m, "@cglobal(1)") == 1
+
+    @test JuliaLowering.include_string(m, """ macro _(x); x; end """) isa Function
+    @test JuliaLowering.include_string(m, "@_(3)") == 3
+end


### PR DESCRIPTION
Silly bugs you only encounter when lowering Base.  Fix https://github.com/JuliaLang/JuliaLowering.jl/issues/165, and fix underscore macro names too.