### PR TITLE
[JuliaLowering] Fix `@nospecialize`

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -325,6 +325,81 @@ split_generated(st::SyntaxTree, gen_part) = @stm st begin
     _ -> mapchildren(x->split_generated(x, gen_part), st._graph, st)
 end
 
+# Set [no]specialize on a function parameter's identifier.  `meta` is a symbol
+# if we should set this arg's meta unconditionally, or a map identifier-string
+# to symbol if we should only do it for some identifiers (function body >0 arg
+# nospecialize), or nothing if we should just recurse to find meta forms.
+# Exceptions with unconditional meta: set meta on the tuple for a destructuring
+# arg, and the whole expression for (::T).
+function apply_arg_meta(st, meta::Union{Nothing, Symbol, Dict{String, Symbol}})
+    g = st._graph
+    k = kind(st)
+    if k == K"Identifier"
+        if meta isa Symbol
+            setmeta(st, meta, true)
+        elseif isnothing(meta)
+            st
+        else
+            sym = get(meta, st.name_val::String, nothing)
+            !isnothing(sym) ? setmeta(st, sym, true) : st
+        end
+    elseif k == K"Placeholder" || k == K"tuple" || k == K"::" && numchildren(st) == 1
+        meta isa Symbol ? setmeta(st, meta, true) : st
+    elseif k == K"..." || k == K"::" || k == K"=" || k == K"kw"
+        c1 = st[1]
+        out1 = apply_arg_meta(c1, meta)
+        c1 == out1 ? st : @ast g st [k out1 st[2:end]...]
+    elseif k == K"meta"
+        # not specified what to do here if we get conflicting
+        # specialize/nospecialize
+        meta2 = Symbol(st[1].name_val::String)
+        @jl_assert meta2 in (:specialize, :nospecialize) st
+        apply_arg_meta(st[2], meta2)
+    elseif k == K"parameters"
+        mapchildren(x->apply_arg_meta(x, meta), st._graph, st)
+    else
+        @jl_assert false st
+    end
+end
+
+function apply_arglist_meta(st, meta::Union{Nothing, Symbol, Dict{String, Symbol}})
+    g = st._graph
+    @stm st begin
+        [K"where" x tvs...] -> let fixed = apply_arglist_meta(x, meta)
+            fixed == x ? st : @ast g st [K"where" fixed tvs...]
+        end
+        [K"::" x t] ->  let fixed = apply_arglist_meta(x, meta)
+            fixed == x ? st : @ast g st [K"::" fixed t]
+        end
+        [K"call" f args...] -> mapchildren(x->
+            x == f ? f : apply_arg_meta(x, meta), st._graph, st)
+        [K"tuple" _...] -> mapchildren(x->apply_arg_meta(x, meta), st._graph, st)
+    end
+end
+
+# nothing if not found, or symbol if 0-arg [no]specialize, or dict arg->meta
+function collect_body_arg_meta(st)
+    out = nothing
+    for c in children(st)
+        k = kind(c)
+        @stm c begin
+            [K"meta" [K"Identifier"] idents...] -> begin
+                meta = Symbol(c[1].name_val::String)
+                meta in (:specialize, :nospecialize) || continue
+                length(idents) == 0 && return meta
+                isnothing(out) && (out = Dict{String, Symbol}())
+                for id in idents
+                    kind(id) === K"Identifier" && (out[id.name_val] = meta)
+                end
+            end
+            # Only leading meta statements are recognized in lowering.  Ideally
+            # meta after non-meta statements would be an error.
+            _ -> break
+        end
+    end
+    out
+end
+
 """
 Convert the Expr-like tree (EST) coming from macro expansion to the tree
 desugaring expects (DST), where some forms have SyntaxNode structure and others
@@ -446,6 +521,8 @@ function est_to_dst(st::SyntaxTree)
                      JS.flags(st) | JS.set_numeric_flags(dim.value))
         end
         ([K"=" l r], when=(is_eventually_call(l))) -> let
+            # no fix_arglist needed, since this func can't be anonymous
+            l = apply_arglist_meta(l, collect_body_arg_meta(r))
             if has_if_generated(r)
                 gen, nongen = split_generated(r, true), split_generated(r, false)
                 r2 = @ast g st [K"_generated_body" [K"quote" gen] rec(nongen)]
@@ -454,7 +531,8 @@ function est_to_dst(st::SyntaxTree)
             end
             @ast g st [K"function" rec(l) r2]
         end
-        [K"function" l r] -> let l = _dst_fix_arglist(l)
+        [K"function" l r] -> let
+            l = apply_arglist_meta(_dst_fix_arglist(l), collect_body_arg_meta(r))
             if has_if_generated(r)
                 gen, nongen = split_generated(r, true), split_generated(r, false)
                 r2 = @ast g st [K"_generated_body" [K"quote" gen] rec(nongen)]
@@ -463,7 +541,8 @@ function est_to_dst(st::SyntaxTree)
             end
             @ast g st [K"function" rec(l) r2]
         end
-        [K"->" l r] -> let l = _dst_fix_arglist(l)
+        [K"->" l r] -> let
+            l = apply_arglist_meta(_dst_fix_arglist(l), collect_body_arg_meta(r))
             if has_if_generated(r)
                 gen, nongen = split_generated(r, true), split_generated(r, false)
                 r2 = @ast g st [K"_generated_body" [K"quote" gen] rec(nongen)]
@@ -503,26 +582,14 @@ function est_to_dst(st::SyntaxTree)
         end
 
         #-----------------------------------------------------------------------
-        # Heads are not emitted from parsing
+        # Heads not emitted from parsing
         ([K"meta" [K"unknown_head" ps...]], when=st[1].name_val === "purity") ->
             @ast g st [K"meta" "purity"::K"Symbol"
                 Base.EffectsOverride([x.value for x in ps]...)::K"Value"]
         ([K"meta" s vs...],
-         when=(get(s, :name_val, "") in ("nospecialize", "specialize"))) -> let
-            if length(vs) === 0
-                @ast g st [K"meta" s=>K"Symbol"]
-            elseif length(vs) === 1
-                out = est_to_dst(vs[1])
-                setmeta(out, Symbol(s.name_val), true)
-            else
-                # Kick the can down the road (should only be simple atoms?)
-                out_cs = SyntaxList(g)
-                for v in vs
-                    push!(out_cs, @ast g v [K"meta" s=>K"Symbol" v])
-                end
-                @ast g st [K"block" out_cs...]
-            end
-        end
+         when=(meta=get(s, :name_val, "")::String; meta in ("nospecialize", "specialize"))) ->
+             # Should be handled in the function case
+             @ast g st "nothing"::K"core"
         [K"meta" syms...] ->
             @ast g st [K"meta" mapsyntax(
                 s->(kind(s) === K"Identifier" ? setattr(s, :kind, K"Symbol") : s),

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2641,7 +2641,6 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
         newsym(ctx, argl[1], reserve_module_binding_i(ctx.mod, mangled))
     end
     # (1) Body method.  This contains the actual function body, and requires
-    # (1) Body method.  This contains the actual function body, and requires
     # every possible default to be filled.  `rett` is only passed here since it
     # can reference any argument.
     mdefs1 = let arg1 = @ast ctx m1_name [K"::" m1_name [K"function_type" m1_name]]
@@ -2965,19 +2964,16 @@ end
 
 # flisp: expand-macro-def
 function expand_macro_def(ctx, ex)
-    @jl_assert numchildren(ex) >= 1 (ex,"invalid macro definition")
     if numchildren(ex) == 1
-        name = ex[1]
         # macro with zero methods
         # `macro m end`
-        return @ast ctx ex [K"function" _make_macro_name(ctx, name)]
+        return @ast ctx ex [K"function" _make_macro_name(ctx, ex[1])]
     end
-    # TODO: Making this manual pattern matching robust is such a pain!!!
-    sig = ex[1]
-    @jl_assert (kind(sig) == K"call" && numchildren(sig) >= 1) (sig, "invalid macro signature")
-    name = sig[1]
-    args = remove_empty_parameters(children(sig))
-    @jl_assert kind(args[end]) != K"parameters" (args[end], "macros cannot accept keyword arguments")
+    (sig, name, args) = @stm ex begin
+        [K"macro" [K"call" n a...] _] -> (ex[1], n, remove_empty_parameters(a))
+        _ -> @jl_assert false ex
+    end
+
     scope_ref = kind(name) == K"." ? name[1] : name
     if ctx.expr_compat_mode
         @ast ctx ex [K"function"
@@ -2992,7 +2988,7 @@ function expand_macro_def(ctx, ex)
                     adopt_scope(@ast(ctx, sig, "__module__"::K"Identifier"), scope_ref)
                     Module::K"Value"
                 ]
-                map(e->_apply_nospecialize(ctx, e), args[2:end])...
+                mapsyntax(e->apply_arg_meta(e, :nospecialize), args)...
             ]
             ex[2]
         ]
@@ -3006,7 +3002,7 @@ function expand_macro_def(ctx, ex)
                 ]
                 # flisp: We don't mark these @nospecialize because all arguments to
                 # new macros will be of type SyntaxTree
-                args[2:end]...
+                args...
             ]
             ex[2]
         ]

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -220,6 +220,7 @@ function to_code_info(ex::SyntaxTree, slots::Vector{Slot}, meta::CompileHints)
     slotnames = Vector{Symbol}(undef, length(slots))
     slot_rename_inds = Dict{String,Int}()
     slotflags = Vector{UInt8}(undef, length(slots))
+    nospecialize_slots = Core.SlotNumber[]
     for (i, slot) in enumerate(slots)
         name = slot.name
         # TODO: Do we actually want unique names here? The C code in
@@ -241,9 +242,16 @@ function to_code_info(ex::SyntaxTree, slots::Vector{Slot}, meta::CompileHints)
             slot.is_called        << 6   # SLOT_CALLED        | -
         if slot.is_nospecialize
             # Ideally this should be a slot flag instead
+            i > nargs && throw(LoweringError(
+                ex, "@nospecialize annotation applied to a non-argument"))
             add_ir_debug_info!(current_codelocs_stack, ex)
-            push!(stmts, Expr(:meta, :nospecialize, Core.SlotNumber(i)))
+            push!(nospecialize_slots, Core.SlotNumber(i))
         end
+    end
+    if length(nospecialize_slots) == nargs - 1 # self arg
+        push!(stmts, Expr(:meta, :nospecialize))
+    elseif !isempty(nospecialize_slots)
+        push!(stmts, Expr(:meta, :nospecialize, nospecialize_slots...))
     end
 
     stmt_offset = length(stmts)

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -248,10 +248,10 @@ function to_code_info(ex::SyntaxTree, slots::Vector{Slot}, meta::CompileHints)
             push!(nospecialize_slots, Core.SlotNumber(i))
         end
     end
-    if length(nospecialize_slots) == nargs - 1 # self arg
-        push!(stmts, Expr(:meta, :nospecialize))
-    elseif !isempty(nospecialize_slots)
-        push!(stmts, Expr(:meta, :nospecialize, nospecialize_slots...))
+    if !isempty(nospecialize_slots)
+        length(nospecialize_slots) == nargs - 1 ? # all args but self
+            push!(stmts, Expr(:meta, :nospecialize)) :
+            push!(stmts, Expr(:meta, :nospecialize, nospecialize_slots...))
     end
 
     stmt_offset = length(stmts)

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -244,11 +244,11 @@ function to_code_info(ex::SyntaxTree, slots::Vector{Slot}, meta::CompileHints)
             # Ideally this should be a slot flag instead
             i > nargs && throw(LoweringError(
                 ex, "@nospecialize annotation applied to a non-argument"))
-            add_ir_debug_info!(current_codelocs_stack, ex)
             push!(nospecialize_slots, Core.SlotNumber(i))
         end
     end
     if !isempty(nospecialize_slots)
+        add_ir_debug_info!(current_codelocs_stack, ex)
         length(nospecialize_slots) == nargs - 1 ? # all args but self
             push!(stmts, Expr(:meta, :nospecialize)) :
             push!(stmts, Expr(:meta, :nospecialize, nospecialize_slots...))

--- a/JuliaLowering/src/syntax_macros.jl
+++ b/JuliaLowering/src/syntax_macros.jl
@@ -15,33 +15,18 @@
 # `JuliaLowering.include()` or something. Then we'll be in the fun little world
 # of bootstrapping but it shouldn't be too painful :)
 
-function _apply_nospecialize(ctx, ex)
-    k = kind(ex)
-    if k == K"Identifier" || k == K"Placeholder" || k == K"tuple" ||
-        k == K"::" && numchildren(ex) == 1
-        setmeta(ex, :nospecialize, true)
-    elseif k == K"..." || k == K"::" || k == K"=" || k == K"kw"
-        # The @nospecialize macro is responsible for converting K"=" to K"kw".
-        # Desugaring uses this helper internally, so we may see K"kw" too.
-        if k == K"=" && numchildren(ex) === 2
-            k = K"kw"
-        end
-        @ast ctx ex [k _apply_nospecialize(ctx, ex[1]) ex[2:end]...]
-    else
-        throw(LoweringError(ex, "Invalid function argument"))
-    end
-end
-
 function Base.var"@nospecialize"(__context__::MacroContext, exs::SyntaxTree...)
     if length(exs) == 0
-        @ast __context__ __context__.macrocall [K"meta" "nospecialize"::K"Identifier"]
-    elseif length(exs) == 1
-        _apply_nospecialize(__context__, only(exs))
+        @ast __context__ __context__.macrocall [K"meta"
+            "nospecialize"::K"Identifier"]
+    elseif length(exs) == 1 && kind(exs[1]) === K"="
+        eq = exs[1]
+        @ast __context__ __context__.macrocall [K"meta"
+            "nospecialize"::K"Identifier" [K"kw"(eq) children(eq)...]]
     else
-        @ast __context__ __context__.macrocall [K"block"
-            map(ex->_apply_nospecialize(__context__, ex), exs)...
-        ]
-     end
+        @ast __context__ __context__.macrocall [K"meta"
+            "nospecialize"::K"Identifier" exs...]
+    end
 end
 
 # TODO: support all forms that the original supports

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -703,6 +703,16 @@ vst1_calldecl_name(vcx, st) = @stm st begin
     _ -> @fail(st, "invalid function name")
 end
 
+_is_arg_meta(st) = @stm st begin
+    [K"meta" s arg] -> let meta_s = get(s, :name_val, "")::String
+        kind(arg) === K"meta" ?
+            @fail(st, "invalid nested annotation") :
+        !(meta_s in ("specialize", "nospecialize")) ?
+            @fail(st, "unrecognized meta function arg form") : pass()
+    end
+    _ -> unknown()
+end
+
 # Check mandatory and optional positional params:
 # `[pparam* pparam_and_default* pparam_and_splatdefault? pparam_va?]`
 # TODO: add list matching to @stm
@@ -711,10 +721,8 @@ function _calldecl_positionals(vcx, params_meta, eq_is_kw)
     ok = Ref(pass())
     params = map(params_meta) do meta_p
         @stm meta_p begin
-            [K"meta" s p] -> let meta_s = get(s, :name_val, "")
-                if !(meta_s in ("specialize", "nospecialize"))
-                    ok[] &= @fail(p, "unrecognized meta function arg form")
-                end
+            [K"meta" s p] -> begin
+                ok[] &= _is_arg_meta(meta_p)
                 p
             end
             p -> p
@@ -781,8 +789,9 @@ vst1_pparam_simple_tuple(vcx, st) = @stm st begin
 end
 
 vst1_param(vcx, st) = @stm st begin
-    [K"Identifier"] -> pass()
-    [K"::" [K"Identifier"] t] -> vst1(with(vcx; readable_underscore=true), t)
+    [K"Identifier"] -> vst1_ident(vcx, st; lhs=true)
+    [K"::" id t] -> vst1_ident(vcx, id; lhs=true) &
+        vst1(with(vcx; readable_underscore=true), t)
     [K"::" t] -> vst1(with(vcx; readable_underscore=true), t)
     _ -> @fail(st, "expected identifier or `identifier::type`")
 end
@@ -808,12 +817,16 @@ end
 vst1_calldecl_kws(vcx, st) = @stm st begin
     [K"parameters" kws... [K"..." varkw]] ->
         all(vst1_param_kw, vcx, kws) & vst1_param_varkw(vcx, varkw)
+    [K"parameters" kws... [K"meta" _ [K"..." varkw]]] ->
+        all(vst1_param_kw, vcx, kws) &
+        _is_arg_meta(st[end]) &
+        vst1_param_varkw(vcx, varkw)
     [K"parameters" kws...] -> all(vst1_param_kw, vcx, kws)
     _ -> @fail(st, "malformed keyword parameters")
 end
 
 vst1_param_varkw(vcx, st) = @stm st begin
-    [K"Identifier"] -> pass()
+    [K"Identifier"] -> vst1_ident(vcx, st; lhs=true)
     [K"::" _...] ->
         @fail(st, "keyword parameter with `...` may not be given a type")
     _ -> @fail(st, "expected identifier")
@@ -822,6 +835,7 @@ end
 vst1_param_kw(vcx, st) = @stm st begin
     [K"kw" id val] ->
         vst1_param(vcx, id) & vst1(vcx, val)
+    [K"meta" s x] -> _is_arg_meta(st) & vst1_param_kw(vcx, x)
     [K"..." _...] ->
         @fail(st, "`...` may only be used for the final keyword parameter")
     _ -> vst1_param(vcx, st) |

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -364,7 +364,29 @@ f_return_in_interpolation()
 
 end
 
-@testset "Slot flags" begin
+@testset "slotflags" begin
+    JuliaLowering.include_string(test_mod, """
+    function f_slotflags(x, y, f, z)
+        f() + x + y
+    end
+    """)
+    @test only(methods(test_mod.f_slotflags)).called == 0b0100
+end
+
+@testset "nospecialize" begin
+    # note f(a,b,c) means a is arg 1, not f
+    function test_arg_unspecialized(f::Function, arg_i::Int)
+        for m in methods(f)
+            arg_i > m.nargs-1 && return nothing
+            @test m.nospecialize & (1 << (arg_i-1)) != 0
+        end
+    end
+    function test_arg_specialized(f::Function, arg_i::Int)
+        for m in methods(f)
+            arg_i > m.nargs-1 && return nothing
+            @test m.nospecialize & (1 << (arg_i-1)) == 0
+        end
+    end
 
     @test JuliaLowering.include_string(test_mod, """
     begin
@@ -378,21 +400,6 @@ end
     # We dig into the internal of `Method` here to check which slots have been
     # flagged as nospecialize.
     @test only(methods(test_mod.f_nospecialize)).nospecialize == 0b10100
-
-    # @nospecialize on unnamed arguments (issue #44428)
-    JuliaLowering.include_string(test_mod, """
-    function f_nospecialize_unnamed(@nospecialize(::Any), @nospecialize(x::Any))
-        x
-    end
-    """)
-    @test only(methods(test_mod.f_nospecialize_unnamed)).nospecialize == 0b11
-
-    JuliaLowering.include_string(test_mod, """
-    function f_slotflags(x, y, f, z)
-        f() + x + y
-    end
-    """)
-    @test only(methods(test_mod.f_slotflags)).called == 0b0100
 
     # Branching combined with nospecialize meta in CodeInfo
     @test JuliaLowering.include_string(test_mod, """
@@ -465,7 +472,6 @@ end
     @test any(m -> m.nargs == 2 && m.nospecialize == 0b00, ms)
 
     # Body-level @nospecialize with default value in signature
-    # See the TODO comment in `optional_positional_defs!`
     @test JuliaLowering.include_string(test_mod, """
     begin
         function f_body_nospecialize_default(x, y=1)
@@ -478,20 +484,110 @@ end
     # The 2-arg method has nospecialize on y (bit 2), the 1-arg forwarding method has no y
     ms = collect(methods(test_mod.f_body_nospecialize_default))
     @test count(m -> m.nargs == 3 && m.nospecialize == -1, ms) == 1
-    @test_broken count(m -> m.nargs == 2 && m.nospecialize == -1, ms) == 1
+    @test count(m -> m.nargs == 2 && m.nospecialize == -1, ms) == 1
 
-    # Body-level @nospecialize for methods with keyword arguments
+    # body nospecialize into complex sig: all
     @test JuliaLowering.include_string(test_mod, """
-    function f_body_nospecialize_with_kwargs(a; kw=1)
-        @nospecialize a
-        (a, kw)
+    begin
+        function f_body_nospecialize_nontrivial_sig(x::T, y::Vector{<:U}=[])::Any where T where U
+            @nospecialize
+            (x, y)
+        end
+        (f_body_nospecialize_nontrivial_sig(10, [20]), f_body_nospecialize_nontrivial_sig(30))
     end
-    (f_body_nospecialize_with_kwargs(1; kw=2), f_body_nospecialize_with_kwargs(3))
-    """) == ((1,2), (3,1))
-    # Although not tested here, the keyword body method (`var"#f_body_nospecialize_with_kwargs#0"`)'s
-    # third argument (corresponding to `a`) should probably be nospecialized too.
-    @test_broken only(methods(test_mod.f_body_nospecialize_with_kwargs)).nospecialize == 1
-    @test_broken only(methods(Core.kwcall, (NamedTuple,typeof(test_mod.f_body_nospecialize_with_kwargs),Any))).nospecialize == 1 << 2
+    """) == ((10, [20]), (30, []))
+    test_arg_unspecialized(test_mod.f_body_nospecialize_nontrivial_sig, 1)
+    test_arg_unspecialized(test_mod.f_body_nospecialize_nontrivial_sig, 2)
+    # should be blanket-nospecialized
+    ms = collect(methods(test_mod.f_body_nospecialize_nontrivial_sig))
+    @test count(m -> m.nargs == 3 && m.nospecialize == -1, ms) == 1
+    @test count(m -> m.nargs == 2 && m.nospecialize == -1, ms) == 1
+
+    # body nospecialize into complex sig: by name
+    @test JuliaLowering.include_string(test_mod, """
+    begin
+        function f_body_nospecialize_nontrivial_sig2(x::T, y::Vector{<:U}=[])::Any where T where U
+            @nospecialize x
+            (x, y)
+        end
+        (f_body_nospecialize_nontrivial_sig2(10, [20]), f_body_nospecialize_nontrivial_sig2(30))
+    end
+    """) == ((10, [20]), (30, []))
+    test_arg_unspecialized(test_mod.f_body_nospecialize_nontrivial_sig2, 1)
+    test_arg_specialized(test_mod.f_body_nospecialize_nontrivial_sig2, 2)
+
+    @testset "all positional arg forms" for arg0 in [:x, :(x::Type), :(::Type), :(_), :(_::Type)],
+        arg1 in [arg0, Expr(:..., arg0)],
+        arg2 in [arg1, Expr(:kw, arg1, :Int)],
+        expander in [fl_macroexpand, jl_macroexpand]
+
+        @testset let expanded = expander(
+            test_mod, :(function (specialized, @nospecialize($arg2))
+                            specialized
+                        end))
+            f = jl_eval(test_mod, expanded)
+            test_arg_specialized(f, 1)
+            test_arg_unspecialized(f, 2)
+        end
+
+        @testset let expanded = expander(
+            test_mod, :(function ($arg2,)
+                            @nospecialize
+                        end))
+            f = jl_eval(test_mod, expanded)
+            test_arg_unspecialized(f, 1)
+        end
+    end
+
+    @testset "kwargs" for expander in [fl_macroexpand, jl_macroexpand]
+        local f
+        @test (f = jl_eval(test_mod, expander(
+            test_mod, quote
+                function (@nospecialize(a); kw=1)
+                    (a, kw)
+                end
+            end))) isa Function
+        Core.@latestworld
+        @test f(1, kw=2) == (1,2) && f(3) == (3,1)
+        test_arg_unspecialized(f, 1)
+        @test only(methods(Core.kwcall, (NamedTuple,typeof(f),Any))).nospecialize == 1 << 2
+
+        # Body-level @nospecialize
+        @test (f = jl_eval(test_mod, expander(
+            test_mod, quote
+                function (a; kw=1)
+                    @nospecialize a
+                    (a, kw)
+                end
+            end))) isa Function
+        Core.@latestworld
+        @test f(1, kw=2) == (1,2) && f(3) == (3,1)
+        test_arg_unspecialized(f, 1)
+        @test only(methods(Core.kwcall, (NamedTuple,typeof(f),Any))).nospecialize == 1 << 2
+
+        # kw nospecialize.  TODO: The body method is local; how do we get it out
+        # for testing?
+        @test (f = jl_eval(test_mod, expander(
+            test_mod, quote
+                function (a; @nospecialize(kw=1))
+                    (a, kw)
+                end
+            end))) isa Function
+        Core.@latestworld
+        @test f(1, kw=2) == (1,2) && f(3) == (3,1)
+        test_arg_specialized(f, 1)
+
+        # kw... nospecialize (same TODO)
+        @test (f = jl_eval(test_mod, expander(
+            test_mod, quote
+                function (a; @nospecialize(kw...))
+                    (a, kw...)
+                end
+            end))) isa Function
+        Core.@latestworld
+        @test f(1, kw=2, a=3) == (1,:kw=>2,:a=>3)
+        test_arg_specialized(f, 1)
+    end
 end
 
 @testset "Keyword functions" begin

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -965,7 +965,7 @@ function (_,((a,b)...)::Int); end
 #---------------------
 LoweringError:
 function (_,((a,b)...)::Int); end
-#           └─────────────┘ ── expected identifier or `identifier::type`
+#            └──────┘ ── expected identifier
 
 ########################################
 # Error: destructured arg with kw
@@ -1169,6 +1169,54 @@ end
 10  latestworld
 11  TestMod.f
 12  (return %₁₁)
+
+########################################
+# Error: nospecialize should be outermost expr in arg
+function f_bad_nospecialize(@nospecialize(x)=1); end
+#---------------------
+LoweringError:
+function f_bad_nospecialize(@nospecialize(x)=1); end
+#                           └──────────────┘ ── expected identifier or `identifier::type`
+
+########################################
+# Error: nospecialize should be outermost expr in arg
+function f_bad_nospecialize(;@nospecialize(x)=1); end
+#---------------------
+LoweringError:
+function f_bad_nospecialize(;@nospecialize(x)=1); end
+#                            └──────────────┘ ── expected identifier or `identifier::type`
+
+########################################
+# Error: nospecialize should be outermost expr in arg
+function f_bad_nospecialize(@nospecialize(x)...); end
+#---------------------
+LoweringError:
+function f_bad_nospecialize(@nospecialize(x)...); end
+#                           └──────────────┘ ── expected identifier or `identifier::type`
+
+########################################
+# Error: nospecialize should be outermost expr in arg
+function f_bad_nospecialize(;@nospecialize(x)...); end
+#---------------------
+LoweringError:
+function f_bad_nospecialize(;@nospecialize(x)...); end
+#                            └──────────────┘ ── expected identifier
+
+########################################
+# Error: nospecialize should be outermost expr in arg
+function f_bad_nospecialize(@nospecialize(x)::T); end
+#---------------------
+LoweringError:
+function f_bad_nospecialize(@nospecialize(x)::T); end
+#                           └──────────────┘ ── expected identifier
+
+########################################
+# Error: nospecialize should be outermost expr in arg
+function f_bad_nospecialize(;@nospecialize(x)::T); end
+#---------------------
+LoweringError:
+function f_bad_nospecialize(;@nospecialize(x)::T); end
+#                            └──────────────┘ ── expected identifier
 
 ########################################
 # Function return without arguments
@@ -1833,6 +1881,82 @@ function f_kw_sparams(x::X; a::A) where {X,Y,A}
 #                                          ╙ ── method definition declares type variable but does not use it in the type of any function parameter
     (X,A)
 end
+
+########################################
+# Keyword @nospecialize
+function f_kw_slurp(a,;kw1,kw2=2,restkw...)
+    @nospecialize
+end
+#---------------------
+1   (method TestMod.f_kw_slurp)
+2   latestworld
+3   (method TestMod.#kw_body#f_kw_slurp#1)
+4   latestworld
+5   TestMod.#kw_body#f_kw_slurp#1
+6   (call core.Typeof %₅)
+7   (call top.pairs core.NamedTuple)
+8   TestMod.f_kw_slurp
+9   (call core.Typeof %₈)
+10  (call core.svec %₆ core.Any core.Any %₇ %₉ core.Any)
+11  (call core.svec)
+12  SourceLocation::1:10
+13  (call core.svec %₁₀ %₁₁ %₁₂)
+14  --- method TestMod.#kw_body#f_kw_slurp#1 %₁₃
+    slots: [slot₁/#kw_body#f_kw_slurp#1(!read) slot₂/kw1(nospecialize,!read) slot₃/kw2(nospecialize,!read) slot₄/restkw(nospecialize,!read) slot₅/#self#(!read) slot₆/a(nospecialize,!read)]
+    1   (meta :nkw 3)
+    2   (return core.nothing)
+15  latestworld
+16  TestMod.f_kw_slurp
+17  (call core.Typeof %₁₆)
+18  (call core.svec %₁₇ core.Any)
+19  (call core.svec)
+20  SourceLocation::1:10
+21  (call core.svec %₁₈ %₁₉ %₂₀)
+22  --- method TestMod.f_kw_slurp %₂₁
+    slots: [slot₁/#self# slot₂/a(nospecialize)]
+    1   TestMod.#kw_body#f_kw_slurp#1
+    2   (call core.UndefKeywordError :kw1)
+    3   (call core.throw %₂)
+    4   (call core.NamedTuple)
+    5   (call top.pairs %₄)
+    6   (call %₁ %₃ 2 %₅ slot₁/#self# slot₂/a)
+    7   (return %₆)
+23  latestworld
+24  (call core.typeof core.kwcall)
+25  TestMod.f_kw_slurp
+26  (call core.Typeof %₂₅)
+27  (call core.svec %₂₄ core.NamedTuple %₂₆ core.Any)
+28  (call core.svec)
+29  SourceLocation::1:10
+30  (call core.svec %₂₇ %₂₈ %₂₉)
+31  --- method TestMod.f_kw_slurp %₃₀
+    slots: [slot₁/#unused#(!read) slot₂/kws slot₃/#self# slot₄/a(nospecialize) slot₅/kw1(!read) slot₆/kw2(!read) slot₇/kwtmp]
+    1   (newvar slot₅/kw1)
+    2   (newvar slot₆/kw2)
+    3   (newvar slot₇/kwtmp)
+    4   (call core.isdefined slot₂/kws :kw1)
+    5   (gotoifnot %₄ label₈)
+    6   (= slot₇/kwtmp (call core.getfield slot₂/kws :kw1))
+    7   (goto label₁₀)
+    8   (call core.UndefKeywordError :kw1)
+    9   (= slot₇/kwtmp (call core.throw %₈))
+    10  slot₇/kwtmp
+    11  (call core.isdefined slot₂/kws :kw2)
+    12  (gotoifnot %₁₁ label₁₅)
+    13  (= slot₇/kwtmp (call core.getfield slot₂/kws :kw2))
+    14  (goto label₁₆)
+    15  (= slot₇/kwtmp 2)
+    16  slot₇/kwtmp
+    17  (call core.tuple :kw1 :kw2)
+    18  (call core.apply_type core.NamedTuple %₁₇)
+    19  (call top.structdiff slot₂/kws %₁₈)
+    20  (call top.pairs %₁₉)
+    21  TestMod.#kw_body#f_kw_slurp#1
+    22  (call %₂₁ %₁₀ %₁₆ %₂₀ slot₃/#self# slot₄/a)
+    23  (return %₂₂)
+32  latestworld
+33  TestMod.f_kw_slurp
+34  (return %₃₃)
 
 ########################################
 # Error: argument unpacking in keywords

--- a/JuliaLowering/test/macros_ir.jl
+++ b/JuliaLowering/test/macros_ir.jl
@@ -199,7 +199,7 @@ cmdmac`hello`12345
 
 ########################################
 # @nospecialize (zero args)
-function foo()
+function foo(a)
     @nospecialize
 end
 #---------------------
@@ -207,14 +207,13 @@ end
 2   latestworld
 3   TestMod.foo
 4   (call core.Typeof %₃)
-5   (call core.svec %₄)
+5   (call core.svec %₄ core.Any)
 6   (call core.svec)
 7   SourceLocation::1:10
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.foo %₈
-    slots: [slot₁/#self#(!read)]
-    1   (meta :nospecialize)
-    2   (return core.nothing)
+    slots: [slot₁/#self#(!read) slot₂/a(nospecialize,!read)]
+    1   (return core.nothing)
 10  latestworld
 11  TestMod.foo
 12  (return %₁₁)
@@ -236,10 +235,9 @@ end
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.foo %₈
     slots: [slot₁/#self#(!read) slot₂/a(nospecialize) slot₃/b]
-    1   slot₂/a
-    2   TestMod.+
-    3   (call %₂ slot₂/a slot₃/b)
-    4   (return %₃)
+    1   TestMod.+
+    2   (call %₁ slot₂/a slot₃/b)
+    3   (return %₂)
 10  latestworld
 11  TestMod.foo
 12  (return %₁₁)
@@ -261,11 +259,9 @@ end
 8   (call core.svec %₅ %₆ %₇)
 9   --- method TestMod.foo %₈
     slots: [slot₁/#self#(!read) slot₂/x(nospecialize) slot₃/y slot₄/z(nospecialize)]
-    1   slot₂/x
-    2   slot₄/z
-    3   TestMod.+
-    4   (call %₃ slot₂/x slot₃/y slot₄/z)
-    5   (return %₄)
+    1   TestMod.+
+    2   (call %₁ slot₂/x slot₃/y slot₄/z)
+    3   (return %₂)
 10  latestworld
 11  TestMod.foo
 12  (return %₁₁)

--- a/JuliaLowering/test/utils.jl
+++ b/JuliaLowering/test/utils.jl
@@ -366,7 +366,7 @@ function reduce_any_failing_toplevel(mod::Module, filename::AbstractString; do_e
 end
 
 function fl_macroexpand(mod::Module, x::Expr)
-    ccall(:jl_macroexpand, Any, (Any, Any, Cint, Cint, Cint), x, mod, recursive, false, legacyscope)
+    ccall(:jl_macroexpand, Any, (Any, Any, Cint, Cint, Cint), x, mod, true, false, true)
 end
 
 function fl_lower(mod::Module, x::Expr)
@@ -378,7 +378,7 @@ function fl_eval(mod::Module, x::Expr)
 end
 
 function jl_macroexpand(mod::Module, x::SyntaxTree; expr_compat_mode=false)
-    JuliaLowering.expand_forms_1(mod, x, expr_compat_mode, Base.get_world_counter())
+    JuliaLowering.expand_forms_1(mod, x, expr_compat_mode, Base.get_world_counter())[2]
 end
 
 function jl_lower(mod::Module, st::SyntaxTree; expr_compat_mode=false)


### PR DESCRIPTION
Fix https://github.com/JuliaLang/JuliaLowering.jl/issues/166 and related bugs:
- "new" `@nospecialize` should produce the same form as "old" `@nospecialize`
- Fix validation rejecting nospecialize on kwargs
- Fix function-body `@nospecialize` not propagating to wrapper methods (in optional positional and kw cases).  Femtolisp lowering does this by storing meta statements in the beginning of all method bodies and juggling that (usually in a variable named `prologue`) in function desugaring.  It isn't a great deal cleaner, but this PR absorbs meta statements from the body and stores it in the function's params in `est_to_dst` so desugaring doesn't need to worry about it.
- Bundle lowered `meta nospecialize` into one statement like flisp instead of one per slot

Note this implementation will have `method.nospecialize == -1` when everything is marked nospecialize (same as flisp), but also when each individual param is marked, i.e. `function f(x,y); @nospecialize(); end` and `function f(@nospecialize(x), @nospecialize(y)); end` are the same.  I'm hoping this can become a slot flag rather than IR-meta in the future.

TODO: There are a number of places we should inform users when `@nospecialize` is a no-op, but this isn't specific to JL.