### PR TITLE
[JuliaLowering] Allow GlobalRef in macro name

### DIFF
--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -170,13 +170,13 @@ function eval_macro_name(ctx::MacroExpansionContext, mctx::MacroContext, ex0::Sy
     ex = expand_forms_1(ctx, ex0)
     try
         if kind(ex) === K"Value"
-            !(ex.value isa GlobalRef) ? ex.value :
-                Base.invoke_in_world(ctx.macro_world, getglobal,
-                                     ex.value.mod, ex.value.name)
+            ex.value
         elseif kind(ex) === K"Identifier"
-            layer = get(ex, :scope_layer, nothing)
-            if !isnothing(layer)
-                mod = ctx.scope_layers[layer].mod
+            # module from globalref, or some expansion, or default
+            if hasattr(ex, :mod)
+                mod = ex.mod::Module
+            elseif hasattr(ex, :scope_layer)
+                mod = ctx.scope_layers[ex.scope_layer::LayerId].mod
             end
             Base.invoke_in_world(ctx.macro_world, getproperty,
                                  mod, Symbol(ex.name_val))

--- a/JuliaLowering/test/decls.jl
+++ b/JuliaLowering/test/decls.jl
@@ -646,6 +646,42 @@ gr_mod = Module()
                   Expr(:function, Expr(:call, GlobalRef(gr_mod, sym)),
                        Expr(:block)))))
 
+    # macro gr end
+    @gensym sym
+    mac_sym = Symbol("@"*string(sym))
+    @test jl_eval(test_mod, Expr(:macro, GlobalRef(gr_mod, sym))) isa Function
+    @test Base.isdefinedglobal(gr_mod, mac_sym)
+    @test !Base.isdefinedglobal(test_mod, mac_sym)
+
+    # macro gr(x); (x, @__MODULE__); end
+    #
+    # should define the symbol in gr_mod, but the method (and expansion) are
+    # attributed to test_mod, where the macro expression was evaluated.
+    @gensym sym
+    mac_sym = Symbol("@"*string(sym))
+    @test jl_eval(test_mod, Expr(:macro, Expr(:call, GlobalRef(gr_mod, sym), :x),
+                                 Expr(:block,
+                                      Expr(:tuple, :x, :(@__MODULE__()))));
+                  expr_compat_mode=true) isa Function
+    @test Base.isdefinedglobal(gr_mod, mac_sym)
+    @test !Base.isdefinedglobal(test_mod, mac_sym)
+    @test jl_eval(gr_mod, :(@($mac_sym)(1))) == (1, test_mod)
+    @testset "globalref as macrocall name" begin
+        @test (1, test_mod) == jl_eval(
+            test_mod,
+            Expr(:macrocall, GlobalRef(gr_mod, mac_sym), LineNumberNode(1, :none), 1))
+        @test (1, test_mod) == jl_eval(
+            gr_mod,
+            Expr(:macrocall, GlobalRef(gr_mod, mac_sym), LineNumberNode(1, :none), 1))
+        # globalref(test_mod, mac_sym) should fail
+        @test_throws MacroExpansionError jl_eval(
+            test_mod,
+            Expr(:macrocall, GlobalRef(test_mod, mac_sym), LineNumberNode(1, :none), 1))
+        @test_throws MacroExpansionError jl_eval(
+            gr_mod,
+            Expr(:macrocall, GlobalRef(test_mod, mac_sym), LineNumberNode(1, :none), 1))
+    end
+
     # error: begin; local gr = 1; end
     # (note: flisp allows this)
     @gensym sym

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -1,5 +1,3 @@
-@testset "Miscellaneous" begin
-
 test_mod = Module()
 
 # Blocks
@@ -263,6 +261,58 @@ end
     @test lower_str(Main, "x + y").args[1].has_image_globalref === true
 end
 
+baremodule baremod
+macro int128_str(x);  error("baremod macro; expected call to Core macro"); end
+macro uint128_str(x); error("baremod macro; expected call to Core macro"); end
+macro big_str(x);     error("baremod macro; expected call to Core macro"); end
+macro cmd(x);         error("baremod macro; expected call to Core macro"); end
+macro doc(x, y);      error("baremod macro; expected call to Core macro"); end
+global nothing = "baremod.nothing; expected core nothing"
+end
+@testset "globalrefs inserted by parsing" begin
+    local jl_s_eval = x->JuliaLowering.include_string(baremod, x; expr_compat_mode=true)
+    local fl_s_eval = x->fl_eval(baremod, JuliaSyntax.parsestmt(Expr, x; filename="file"))
+
+    let s = "100000000000000000000000000000"
+        @test jl_s_eval(s) == fl_s_eval(s)
+    end
+    let s = "0x100000000000000000000000000000"
+        @test jl_s_eval(s) == fl_s_eval(s)
+    end
+    let s = "10000000000000000000000000000000000000000000000000000000000000000"
+        @test jl_s_eval(s) == fl_s_eval(s)
+    end
+    let s = "`ls`"
+        @test jl_s_eval(s) == fl_s_eval(s)
+    end
+
+    let s = """
+            "foo" function fl_documented_function(); fl_documented_function; end
+            """
+        @test fl_s_eval(s) isa Function
+    end
+    @test baremod.fl_documented_function() == baremod.fl_documented_function
+    let s = """
+            "foo" function jl_documented_function(); jl_documented_function; end
+            """
+        @test jl_s_eval(s) isa Function
+    end
+    @test baremod.jl_documented_function() == baremod.jl_documented_function
+
+    let s = """
+            function fl_ret_nothing(); return; end
+            """
+        @test fl_s_eval(s) isa Function
+    end
+    @test baremod.fl_ret_nothing() == Core.nothing
+    let s = """
+            function jl_ret_nothing(); return; end
+            """
+        @test fl_s_eval(s) isa Function
+    end
+    @test baremod.jl_ret_nothing() == Core.nothing
+end
+
 @testset "docstrings: doc-only expressions" begin
     local jeval(mod, str) = JuliaLowering.include_string(mod, str; expr_compat_mode=true)
     jeval(test_mod, "function fun_exists(x); x; end")
@@ -445,6 +495,4 @@ end
             nothing
         end
     end
-end
-
 end


### PR DESCRIPTION
Fix and test https://github.com/JuliaLang/JuliaLowering.jl/issues/164.  Broke in https://github.com/JuliaLang/julia/pull/61410, where I forgot that another place we resolve identifiers to modules is when we evaluate a macro name.