### PR TITLE
[JuliaLowering] Fix treatment of `..` as a dotted op (it's not)

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -5,9 +5,10 @@ function find_kind(s::String)
     return isnothing(out) ? nothing : JS.Kind(out)
 end
 
+# flisp: dot-operators
 function is_dotted_operator(s::AbstractString)
     return length(s) >= 2 &&
-        s[1] === '.' &&
+        s[1] === '.' && s[2] !== '.' &&
         JS.is_operator(something(find_kind(s[2:end]), K"None"))
 end
 

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -682,6 +682,9 @@ vst1_macro_calldecl_name(vcx, st) = @stm st begin
 end
 
 vst1_calldecl_name(vcx, st) = @stm st begin
+    [K"Identifier"] -> vst1_ident(vcx, st; lhs=true) &
+        (!is_dotted_operator(st.name_val::String) ? pass() :
+        @fail(st, "dotted operator is not a valid function name"))
     [K"." _ _] ->
         vst1_calldecl_dot_name(vcx, st)
     [K"curly" t tvs...] ->
@@ -697,7 +700,7 @@ vst1_calldecl_name(vcx, st) = @stm st begin
 
     [K"where" t tds...] ->
         vst1_calldecl_name(vcx, t) & all(vst1_typevar_decl, vcx, tds)
-    _ -> @fail(st, "invalid function name") | vst1_ident(vcx, st; lhs=true)
+    _ -> @fail(st, "invalid function name")
 end
 
 # Check mandatory and optional positional params:

--- a/JuliaLowering/test/compat.jl
+++ b/JuliaLowering/test/compat.jl
@@ -421,6 +421,13 @@ test_programs = [
     "try x catch e; y finally z end",
     "try x catch e; y else z end",
     "try x catch e; y else z finally w end",
+    "..",
+    "a..b",
+    "..(a)",
+    "..(..,..)",
+    "@.",
+    "@..",
+    "@..."
 ]
 test_toplevel_programs = [
     "\"docstr\"\nthing_to_be_documented",

--- a/JuliaLowering/test/function_calls_ir.jl
+++ b/JuliaLowering/test/function_calls_ir.jl
@@ -563,7 +563,7 @@ end
 #---------------------
 LoweringError:
 function ccall()
-#        └───┘ ── invalid function name
+#        └───┘ ── ccall is a reserved identifier
 end
 
 ########################################
@@ -583,7 +583,7 @@ end
 #---------------------
 LoweringError:
 function ccall{<:T}()
-#        └───┘ ── invalid function name
+#        └───┘ ── ccall is a reserved identifier
 end
 
 ########################################

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -392,6 +392,35 @@ function (.+)(x,y)
 end
 
 ########################################
+# Error: Invalid dotop function name
+function var".+"(x,y)
+end
+#---------------------
+LoweringError:
+function var".+"(x,y)
+#            └┘ ── dotted operator is not a valid function name
+end
+
+########################################
+# dotted normal name is fine
+function var".f"(); end
+#---------------------
+1   (method TestMod..f)
+2   latestworld
+3   TestMod..f
+4   (call core.Typeof %₃)
+5   (call core.svec %₄)
+6   (call core.svec)
+7   SourceLocation::1:10
+8   (call core.svec %₅ %₆ %₇)
+9   --- method TestMod..f %₈
+    slots: [slot₁/#self#(!read)]
+    1   (return core.nothing)
+10  latestworld
+11  TestMod..f
+12  (return %₁₁)
+
+########################################
 # Error: Invalid function name
 function f[](x,y)
 end

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -420,6 +420,46 @@ emptyblock_result = JuliaLowering.eval(test_mod, Expr(:(=), :emptyblock_144, Exp
     """) == `cmdstrinnerstr123`
 end
 
+let op_mod = Module(:opmod, false)
+    @testset "operators" for run in [
+            s->fl_eval(op_mod, JuliaSyntax.parseall(Expr, s)),
+            s->JuliaLowering.include_string(op_mod, s; expr_compat_mode=true),
+            s->JuliaLowering.include_string(op_mod, s; expr_compat_mode=false)]
+
+        @testset "unary prefix (no parens needed)" for op in String["⋆", "±", "∓", "~", "!", "¬", "√", "∛", "∜"]
+            @test run("$(op)x = (x,)") isa Function
+            Core.@latestworld
+            @test run(op) isa Function
+            @test run("$(op)1") == (1,)
+            @test run("""
+                let $(op)x = (x,x)
+                    $(op)1
+                end """) == (1,1)
+        end
+        @testset "prefix" for op in String["..", "+", "-", "⋆", "±", "∓", "~", "!", "¬", "√", "∛", "∜"]
+            @test run("$op(a,b,c) = 3") isa Function
+            Core.@latestworld
+            @test run(op) isa Function
+            @test run("$op(1,2,3)") == 3
+            @test run("""
+                let $op(a,b,c) = (c,b,a)
+                    $op(1,2,3)
+                end """) == (3,2,1)
+        end
+        @testset "infix" for op in String["&", "|", "+", "-", ":", ".."]
+            @test run("a$(op)b = (a,b)") isa Function
+            Core.@latestworld
+            @test run(op) isa Function
+            @test run("var\"$op\"(1,2)") == (1,2)
+            @test run("1$(op)2") == (1,2)
+            @test run("""
+                let a$(op)b = (b,a)
+                    1$(op)2
+                end """) == (2,1)
+        end
+    end
+end
+
 @testset "jl_assert" begin
     st = @ast_ [K"function" "foo"::K"Identifier"]
     if JL.DEBUG


### PR DESCRIPTION
fix https://github.com/JuliaLang/JuliaLowering.jl/issues/161, fix https://github.com/JuliaLang/JuliaLowering.jl/issues/154.  Just an edge case; not much to learn here.  Add some paranoid tests.