### PR TITLE
add single idempotence test for normpath

### DIFF
--- a/test/path.jl
+++ b/test/path.jl
@@ -137,6 +137,7 @@
         @test normpath(S(joinpath("foo",".","..","..","bar"))) == "..$(sep)bar"
         @test normpath(S(joinpath("foo","..",".","..","bar"))) == "..$(sep)bar"
         @test normpath(S(joinpath("foo","..","..",".","bar"))) == "..$(sep)bar"
+        @test normpath(normpath(S(joinpath("a", "..", "b", ".", "c")))) == normpath(S(joinpath("a", "..", "b", ".", "c")))
     end
     @test relpath(S(joinpath("foo","bar")), S("foo")) == "bar"
 


### PR DESCRIPTION
AI Acknowledgement: I used GitHub Copilot (GPT Codex 5.3) for coding assistance. I review and take responsibility for output. 


This PR adds one single idempotence assertion to normpath, verifying proper behavior and guarding against the potential corner case in which normalizing an already normalized path changes its output. The function should already be robust, but this test guards against the unlikely event that a downstream change subtly changes behavior of normpath.