### PR TITLE
compiler: preserve task starts during trimming

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1656,6 +1656,23 @@ function collectinvokes!(workqueue::CompilationQueue, ci::CodeInfo, sptypes::Vec
             t, _, _, _ = instanceof_tfunc(argextype(stmt.args[1], ci, sptypes))
             t <: Function || continue
             atype = Tuple{t, Vararg}
+        elseif isexpr(stmt, :foreigncall)
+            foreigncall = stmt.args[1]
+            if isexpr(foreigncall, :tuple, 1)
+                foreigncall = foreigncall.args[1]
+                foreigncall isa String && (foreigncall = QuoteNode(Symbol(foreigncall)))
+                if foreigncall isa QuoteNode && foreigncall.value === :jl_new_task
+                    # Tasks defer invocation of their starter until the scheduler runs the task.
+                    # Enqueue the zero-argument starter body now so trim keeps it alive.
+                    length(stmt.args) >= 6 || continue
+                    starter = argextype(stmt.args[6], ci, sptypes)
+                    atype = argtypes_to_type(Any[starter])
+                else
+                    continue
+                end
+            else
+                continue
+            end
         else
             # TODO: handle other StmtInfo like OpaqueClosure?
             continue

--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -407,7 +407,21 @@ function verify_codeinstance!(interp::NativeInterpreter, codeinst::CodeInstance,
                     foreigncall = QuoteNode(Symbol(foreigncall))
                 end
                 if foreigncall isa QuoteNode
-                    if foreigncall.value in runtime_functions
+                    if foreigncall.value === :jl_new_task
+                        # Task starters are invoked later from the scheduler via jl_apply.
+                        # Require that trim already covered the zero-argument starter body.
+                        length(stmt.args) >= 6 || continue
+                        starter = argextype(stmt.args[6], codeinfo, sptypes)
+                        atype = argtypes_to_type(Any[starter])
+
+                        mi = compileable_specialization_for_call(interp, atype)
+                        if mi !== nothing
+                            ci = get(caches, mi, nothing)
+                            ci isa CodeInstance && continue
+                        end
+
+                        error = "unresolved task start registered"
+                    elseif foreigncall.value in runtime_functions
                         error = "disallowed ccall into a runtime function"
                     end
                 else

--- a/Compiler/test/verifytrim.jl
+++ b/Compiler/test/verifytrim.jl
@@ -19,6 +19,9 @@ let infos = Any[]
 end
 
 finalizer(@nospecialize(f), @nospecialize(o)) = Core.finalizer(f, o)
+task_register(@nospecialize(f)) = Task(f)
+task_register_concrete() = Task(task_callback)
+task_callback() = nothing
 
 let infos = typeinf_ext_toplevel(Any[Core.svec(Nothing, Tuple{typeof(finalizer), typeof(identity), Any})], [Base.get_world_counter()], TRIM_UNSAFE)
     errors, parents = get_verify_typeinf_trim(infos)
@@ -36,6 +39,24 @@ let infos = typeinf_ext_toplevel(Any[Core.svec(Nothing, Tuple{typeof(finalizer),
     @test occursin(r"o::Any"s, repr)
     @test occursin(r"::Nothing\n\nStacktrace:"s, repr)
     @test occursin(r"\[1\] finalizer\(f::Any, o::Any\)"s, repr)
+end
+
+let infos = typeinf_ext_toplevel(Any[Core.svec(Task, Tuple{typeof(task_register), Any})], [Base.get_world_counter()], TRIM_UNSAFE)
+    errors, parents = get_verify_typeinf_trim(infos)
+    @test !isempty(errors)
+
+    (warn, desc) = only(errors)
+    @test !warn
+    @test desc isa CallMissing
+    @test occursin("task start", desc.desc)
+    repr = sprint(verify_print_error, desc, parents, warn)
+    @test occursin(r"^unresolved task start registered from statement ccall\("s, repr)
+    @test occursin(r"task_register\(f::Any\)"s, repr)
+end
+
+let infos = typeinf_ext_toplevel(Any[Core.svec(Task, Tuple{typeof(task_register_concrete)})], [Base.get_world_counter()], TRIM_SAFE)
+    errors, parents = get_verify_typeinf_trim(infos)
+    @test isempty(errors)
 end
 
 # test that basic `cfunction` generation is allowed, when the dispatch target can be resolved

--- a/base/secretbuffer.jl
+++ b/base/secretbuffer.jl
@@ -188,7 +188,8 @@ function read(io::SecretBuffer, ::Type{UInt8})
 end
 
 function final_shred!(s::SecretBuffer)
-    !isshredded(s) && @async @warn("a SecretBuffer was `shred!`ed by the GC; use `shred!` manually after use to minimize exposure.")
+    !isshredded(s) && @async Core.print(Core.stderr,
+        "WARNING: a SecretBuffer was `shred!`ed by the GC; use `shred!` manually after use to minimize exposure.\n")
     shred!(s)
 end
 

--- a/test/trimming/trimmability.jl
+++ b/test/trimming/trimmability.jl
@@ -26,6 +26,12 @@ function add_one(x::Cint)::Cint
     return x + 1
 end
 
+# Exercise task starters that are only reachable through task registration.
+module TrimTaskModule
+const task_ran = Ref(false)
+plain_entry()::Nothing = (task_ran[] = true; nothing)
+end
+
 function @main(args::Vector{String})::Cint
     println(Core.stdout, str())
     println(Core.stdout, PROGRAM_FILE)
@@ -62,6 +68,19 @@ function @main(args::Vector{String})::Cint
     end
 
     Base.donotdelete(reshape([1,2,3],:,1,1))
+
+    task = Task(TrimTaskModule.plain_entry)
+    schedule(task)
+    wait(task)
+    println(Core.stdout, TrimTaskModule.task_ran[])
+
+    spawned_ran = Ref(false)
+    spawned = Threads.@spawn begin
+        spawned_ran[] = true
+        nothing
+    end
+    wait(spawned)
+    println(Core.stdout, spawned_ran[])
 
     return 0
 end

--- a/test/trimming/trimming.jl
+++ b/test/trimming/trimming.jl
@@ -15,7 +15,7 @@ let exe_suffix = splitext(Base.julia_exename())[2]
     @test filesize(hello_exe) < 1_900_000
 
     trimmability_exe = joinpath(bindir, "trimmability" * exe_suffix)
-    @test readchomp(`$trimmability_exe arg1 arg2`) == "Hello, world!\n$trimmability_exe\narg1\narg2\n$(4.0+pi)"
+    @test readchomp(`$trimmability_exe arg1 arg2`) == "Hello, world!\n$trimmability_exe\narg1\narg2\n$(4.0+pi)\ntrue\ntrue"
 
     basic_jll_exe = joinpath(bindir, "basic_jll" * exe_suffix)
     lines = split(readchomp(`$basic_jll_exe`), "\n")


### PR DESCRIPTION
Teach trim reachability to treat task creation as a deferred callback edge so task entry thunks survive trimming, and add verifier and trimming coverage for concrete and unresolved task starts.

An example trim-compile test where the proposed changes here "fix" rooting the Task code is: https://github.com/JuliaServices/Reseau.jl/blob/main/test/tls_trim_safe.jl#L43 (i.e. we can remove the entrypoint rooting and the Task code still survives trimming).

I'm working on some additional higher-level HTTP trim tests in [this PR](https://github.com/JuliaWeb/HTTP.jl/pull/1248), but need to massage unrelated verifier errors first (getting close). I've confirmed in some local, lower-level server/client tests that these changes also fix things.

DISLCAIMER: I'm not familiar with this code at all and heavily relied on codex AI/LLM to propose the fix, so apologies if this is way off or not the direction we want to go. At least from the little I do understand, it seems reasonable to key off of jl_new_task, but I'm not sure if there are other entrypoints/Task-related intrinsics we'd still be missing.

