### PR TITLE
Test: add @test_hygienic macro for checking macro hygiene

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -110,6 +110,9 @@ Standard library changes
   allocate `Core.Box` in their lowered code, which can indicate performance issues from
   captured variables in closures.
 
+* New macro `@test_hygienic` checks that a macro expansion does not contain unhygienic
+  names, detecting both leaked bindings and captured variable references.
+
 #### Dates
 
 * `unix2datetime` now accepts a keyword argument `localtime=true` to use the host system's local time zone instead of UTC ([#50296]).

--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -296,6 +296,15 @@ in the test set reporting. The test will not run but gives a `Broken` `Result`.
 Test.@test_skip
 ```
 
+## Macro Hygiene Tests
+
+`@test_hygienic` checks that a macro expansion does not introduce unhygienic names —
+either leaked bindings or captured variable references.
+
+```@docs
+Test.@test_hygienic
+```
+
 ## Test result types
 
 ```@docs

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -22,7 +22,8 @@ module Test
 
 export @test, @test_throws, @test_broken, @test_skip,
     @test_warn, @test_nowarn,
-    @test_logs, @test_deprecated
+    @test_logs, @test_deprecated,
+    @test_hygienic
 
 export @testset
 export @inferred
@@ -203,6 +204,9 @@ function Base.show(io::IO, t::Fail)
         # @test_nowarn failed: unexpected output was produced
         print(io, "\n  Expected stderr: ", data)
         print(io, "\n  Captured stderr: ", value)
+    elseif t.test_type === :test_hygienic
+        # @test_hygienic failed: macro leaked bindings
+        print(io, "\n  ", data, ": ", value)
     elseif t.test_type === :test
         if data !== nothing && t.orig_expr != data
             # The test was an expression, so display the term-by-term
@@ -2472,6 +2476,147 @@ end
 
 _args_and_call((args..., f)...; kwargs...) = (args, kwargs, f(args...; kwargs...))
 _materialize_broadcasted(f, args...) = Broadcast.materialize(Broadcast.broadcasted(f, args...))
+
+# =====================================================
+# Macro hygiene testing
+# =====================================================
+
+function _is_hygienic_sym(s::Symbol)
+    contains(string(s), '#')
+end
+
+function _collect_user_symbols!(syms::Set{Symbol}, @nospecialize(ex))
+    if ex isa Symbol
+        push!(syms, ex)
+    elseif ex isa Expr
+        for a in ex.args
+            _collect_user_symbols!(syms, a)
+        end
+    end
+end
+
+# Symbols that are compiler special forms, not variable references.
+const _SPECIAL_FORM_SYMS = Set{Symbol}((:ccall, :cglobal))
+
+# Collect non-gensymmed, non-user Symbol nodes from an expanded AST.
+# Skips hygienic-scope (resolved by the macro system), quote/inert/meta,
+# QuoteNode (field names), dotted expressions (qualified names like Base.sin),
+# compiler directives (inbounds/boundscheck), special-form names (ccall/cglobal),
+# and name positions (keyword names, named tuple keys).
+# Any remaining plain symbols are unhygienic: either leaked bindings or captured references.
+function _collect_unhygienic_symbols!(@nospecialize(syms::Vector{Symbol}), @nospecialize(ex), user_syms::Set{Symbol})
+    if ex isa Symbol
+        if !_is_hygienic_sym(ex) && !(ex in user_syms) && !(ex in _SPECIAL_FORM_SYMS)
+            push!(syms, ex)
+        end
+        return
+    end
+    ex isa Expr || return
+    h = ex.head
+    # hygienic-scope: resolved by the macro system; quote/inert: quoted code;
+    # meta: compiler annotations; (.): qualified names (e.g. Base.sin);
+    # inbounds/boundscheck/loopinfo: compiler directives with sentinel args
+    if h === Symbol("hygienic-scope") || h === :quote || h === :inert || h === :meta ||
+       h === :(.) || h === :inbounds || h === :boundscheck || h === :loopinfo
+        return
+    end
+    if h === :kw && length(ex.args) >= 2
+        # Skip keyword name (args[1]), check value (args[2])
+        _collect_unhygienic_symbols!(syms, ex.args[2], user_syms)
+        return
+    end
+    # Inside tuple/call/parameters, = means named tuple or kwarg — skip the name
+    if h === :tuple || h === :parameters || h === :call
+        for a in ex.args
+            if a isa Expr && a.head === :(=) && length(a.args) >= 2
+                _collect_unhygienic_symbols!(syms, a.args[2], user_syms)
+            else
+                a isa QuoteNode && continue
+                _collect_unhygienic_symbols!(syms, a, user_syms)
+            end
+        end
+        return
+    end
+    for a in ex.args
+        a isa QuoteNode && continue
+        _collect_unhygienic_symbols!(syms, a, user_syms)
+    end
+end
+
+function _check_macro_hygiene(mod::Module, @nospecialize(macrocall::Expr))
+    expanded = macroexpand(mod, macrocall)
+    user_syms = Set{Symbol}()
+    for i in 3:length(macrocall.args)
+        _collect_user_symbols!(user_syms, macrocall.args[i])
+    end
+    leaked = Symbol[]
+    _collect_unhygienic_symbols!(leaked, expanded, user_syms)
+    unique!(leaked)
+    return leaked
+end
+
+"""
+    @test_hygienic expr
+    @test_hygienic expr broken=cond
+    @test_hygienic expr skip=cond
+
+Test that the macro call `expr` is hygienic, i.e. it does not introduce
+unhygienic names into the expanded code. This checks that a macro properly uses
+gensymmed names for local variables and module-qualified references (`GlobalRef`)
+for external names.
+
+The test expands the macro and walks the resulting AST looking for plain
+(non-gensymmed) symbols that were not part of the original user expression and
+are not inside a `hygienic-scope` block. Both leaked bindings (assignments to
+unqualified names) and captured references (reads of caller-scope variables) are
+detected. If any unhygienic names are found, the test fails with a message
+listing them.
+
+# Examples
+
+```julia
+@test_hygienic @time 1+1      # passes: @time is hygienic
+```
+
+# Keyword Arguments
+
+* `broken=cond`: if `cond==true`, indicates a test that should pass but currently
+  consistently fails.
+* `skip=cond`: if `cond==true`, marks a test that should not be executed but should
+  be included in test summary reporting as `Broken`.
+
+!!! compat "Julia 1.14"
+    This macro requires at least Julia 1.14.
+"""
+macro test_hygienic(ex, kws...)
+    broken, skip, _ = extract_broken_skip_kws(kws, "@test_hygienic")
+    orig_expr = QuoteNode(ex)
+    src = QuoteNode(__source__)
+    mod = __module__
+    quote
+        if $(skip !== nothing && esc(skip))
+            record(get_testset(), Broken(:skipped, $orig_expr))
+            nothing
+        else
+            leaked = _check_macro_hygiene($mod, $orig_expr)
+            if isempty(leaked)
+                testres = if $(broken !== nothing && esc(broken))
+                    Error(:test_unbroken, $orig_expr, nothing, nothing, $src)
+                else
+                    Pass(:test_hygienic, $orig_expr, nothing, nothing, $src)
+                end
+            else
+                testres = if $(broken !== nothing && esc(broken))
+                    Broken(:test_hygienic, $orig_expr)
+                else
+                    Fail(:test_hygienic, $orig_expr, "Unhygienic names",
+                        join(leaked, ", "), nothing, $src, false)
+                end
+            end
+            record(get_testset(), testres)
+        end
+    end
+end
 
 """
     @inferred [AllowedType] f(x)

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -1087,6 +1087,128 @@ tss = @testset CustomTestSet foo=foo "custom testset - escaping" begin
 end
 @test tss.foo == 3
 
+# test @test_hygienic
+macro _test_unhygienic(ex)
+    esc(:(leaked_var = $ex))
+end
+macro _test_unhygienic2(ex)
+    esc(quote
+        a_leaked = $ex
+        b_leaked = a_leaked + 1
+    end)
+end
+macro _test_user_assign(ex)
+    esc(ex)
+end
+# Bindings inside let/function/-> don't leak to caller scope
+macro _test_let_scoped(ex)
+    :(let; y = $(esc(ex)); y; end)
+end
+macro _test_func_scoped(ex)
+    :(() -> begin z = $(esc(ex)); z end)
+end
+# Leaked function definitions should be detected
+macro _test_leaked_func(ex)
+    esc(:(leaked_func() = $ex))
+end
+# Global declarations inside scoped blocks should be detected
+macro _test_global_in_let(ex)
+    esc(:(let; global leaked_global = $ex; end))
+end
+# Captured variables (reads of caller-scope names) should be detected
+macro _test_captured_ref(ex)
+    esc(:(println($ex + z)))
+end
+@testset "@test_hygienic" begin
+    # Hygienic stdlib macros should pass
+    @test_hygienic @time 1+1
+    @test_hygienic @elapsed 1+1
+    @test_hygienic @assert true
+    @test_hygienic @lock ReentrantLock() nothing
+
+    # Unhygienic macros should fail
+    let results = @testset NoThrowTestSet begin
+            @test_hygienic @_test_unhygienic 1+1
+        end
+        @test length(results) == 1
+        @test results[1] isa Test.Fail
+        @test results[1].test_type === :test_hygienic
+        @test occursin("leaked_var", results[1].value)
+    end
+
+    # Macros that introduce multiple leaked bindings
+    let results = @testset NoThrowTestSet begin
+            @test_hygienic @_test_unhygienic2 1+1
+        end
+        @test length(results) == 1
+        @test results[1] isa Test.Fail
+        @test occursin("a_leaked", results[1].value)
+        @test occursin("b_leaked", results[1].value)
+    end
+
+    # broken keyword: known-unhygienic macro marked broken should pass
+    let results = @testset NoThrowTestSet begin
+            @test_hygienic @_test_unhygienic(1+1) broken=true
+        end
+        @test length(results) == 1
+        @test results[1] isa Test.Broken
+    end
+
+    # broken keyword: hygienic macro marked broken should error (unexpected pass)
+    let results = @testset NoThrowTestSet begin
+            @test_hygienic @time(1+1) broken=true
+        end
+        @test length(results) == 1
+        @test results[1] isa Test.Error
+        @test results[1].test_type === :test_unbroken
+    end
+
+    # skip keyword
+    let results = @testset NoThrowTestSet begin
+            @test_hygienic @_test_unhygienic(1+1) skip=true
+        end
+        @test length(results) == 1
+        @test results[1] isa Test.Broken
+        @test results[1].test_type === :skipped
+    end
+
+    # User expression symbols are not flagged
+    @test_hygienic @_test_user_assign x = 1
+
+    # Bindings inside scope-introducing forms are not flagged
+    @test_hygienic @_test_let_scoped 1+1
+    @test_hygienic @_test_func_scoped 1+1
+    @test_hygienic @enum(_TH_Color, _th_red, _th_green, _th_blue)
+
+    # Leaked function definitions should be detected
+    let results = @testset NoThrowTestSet begin
+            @test_hygienic @_test_leaked_func 42
+        end
+        @test length(results) == 1
+        @test results[1] isa Test.Fail
+        @test occursin("leaked_func", results[1].value)
+    end
+
+    # Global declarations inside scoped blocks should be detected
+    let results = @testset NoThrowTestSet begin
+            @test_hygienic @_test_global_in_let 42
+        end
+        @test length(results) == 1
+        @test results[1] isa Test.Fail
+        @test occursin("leaked_global", results[1].value)
+    end
+
+    # Captured variables (references to caller-scope names) should be detected
+    let results = @testset NoThrowTestSet begin
+            @test_hygienic @_test_captured_ref x
+        end
+        @test length(results) == 1
+        @test results[1] isa Test.Fail
+        @test occursin("z", results[1].value)
+        @test occursin("println", results[1].value)
+    end
+end
+
 # test @inferred
 uninferable_function(i) = (1, "1")[i]
 uninferable_small_union(i) = (1, nothing)[i]


### PR DESCRIPTION
Draft claude-generated proposal (opening as a proof of concept), but it seems to work in the test cases, and it discovered three hygiene issues:

Passed:

- `@time`, `@elapsed`, `@allocated`, `@allocations`, `@timed`, `@assert`, `@show`, `@info`, `@warn`, `@error`, `@debug`, `@lock`, `@enum`, `@inline`, `@noinline`, `@boundscheck`, `@inbounds`, `@label`, `@goto`, `@static`, `@eval`, `@isdefined`, `@invoke`, `@invokelatest`, `@view`, `@views`, `@async`, `@sync`, `@atomic`, `@ccall`, `@kwdef`, `@deprecate`, `@task`, `@threadcall`, `@fastmath`, `@polly`, `@simd`, `@test`, `@test_throws`, `@test_broken`, `@test_skip`, `@test_warn`, `@test_nowarn`, `@test_logs`, `@testset`, `@logmsg`, `@sprintf`

Failed:

- **`Threads.@threads`** → `:onethread` — `onethread = "hello"` gets shadowed by macro's kwarg `onethread = false` https://github.com/JuliaLang/julia/pull/61501

i.e.
```
julia> onethread = "hello";

julia> Threads.@threads for i in 1:2
           println(onethread)
       end
false
false

julia> @test_hygienic Threads.@threads for i in 1:2
       i
       end
Test Failed at REPL[7]:1
  Expression: #= REPL[7]:1 =# Threads.@threads for i = 1:2
        #= REPL[7]:2 =#
        i
        #= REPL[7]:3 =#
    end
  Unhygienic names: onethread
ERROR: There was an error during testing
```

The implementation may be easier once JuliaLowering lands?


Developed with Claude:

---

Add a new macro `@test_hygienic` that verifies a macro expansion does not contain unhygienic names — either leaked bindings or captured variable references. After macroexpand, any plain Symbol (no gensym `#`) that appears outside `hygienic-scope` blocks and wasn't in the original user expression is flagged as unhygienic.

The implementation correctly handles compiler special forms (ccall, cglobal), qualified names (Expr(:.)), compiler directives (inbounds, boundscheck), keyword argument names, and QuoteNodes.

Supports `broken` and `skip` keyword arguments consistent with other Test macros.