### PR TITLE
inference: Respect `@nospecializeinfer` semantics in constant prop

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -1362,6 +1362,7 @@ function const_prop_call(interp::AbstractInterpreter,
         cache_argtypes = matching_cache_argtypes(𝕃ᵢ, mi)
     end
     argtypes = matching_cache_argtypes(𝕃ᵢ, mi, forwarded_argtypes, cache_argtypes)
+    argtypes = get_nospecializeinfer_argtypes(argtypes, cache_argtypes, mi.def::Method)
     inf_result = constprop_cache_lookup(𝕃ᵢ, mi, argtypes, get_inference_cache(interp))
     if inf_result === missing
         # a previous const-prop attempt hit a cycle and produced a limited result;

--- a/Compiler/src/inferenceresult.jl
+++ b/Compiler/src/inferenceresult.jl
@@ -5,6 +5,25 @@ function matching_cache_argtypes(::AbstractLattice, mi::MethodInstance)
     return most_general_argtypes(isa(def, Method) ? def : nothing, specTypes)
 end
 
+# For `@nospecializeinfer` methods, widen the `@nospecialize`'d argument positions back to
+# `cache_argtypes` values to respect the `@nospecializeinfer` semantics.
+# This also ensures that the constprop `argtypes` have the same length as `cache_argtypes`.
+function get_nospecializeinfer_argtypes(argtypes::Vector{Any}, cache_argtypes::Vector{Any},
+                                        method::Method)
+    is_nospecializeinfer(method) || return argtypes
+    nargs = Int(method.nargs)
+    new_argtypes = Vector{Any}(undef, length(cache_argtypes))
+    for i = 1:length(cache_argtypes)
+        i_arg = min(i - 1, nargs - 1) # 0-indexed, 0 is the function slot
+        if i_arg > 0 && !iszero(method.nospecialize & (1 << (i_arg - 1)))
+            new_argtypes[i] = cache_argtypes[i]
+        else
+            new_argtypes[i] = argtypes[i]
+        end
+    end
+    return new_argtypes
+end
+
 struct SimpleArgtypes
     argtypes::Vector{Any}
 end

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -6784,4 +6784,18 @@ let result = code_typed(f_static_parameter_argument_position, Tuple{Type{Int}})
     @test result[1].second === Type{Int}
 end
 
+# aviatesk/JETLS.jl/issues/618
+Base.@nospecializeinfer function jetls618(a, @nospecialize(rest...))
+    if a > 0
+        z = a + length(rest)
+    else
+        z = 0
+    end
+    println(z)
+    return z
+end
+@test Base.infer_return_type() do
+    jetls618(1,2,3), jetls618(1,2,3,4)
+end == Tuple{Int,Int}
+
 end # module inference


### PR DESCRIPTION
`@nospecializeinfer` widens the `MethodInstance` signature so that inference does not specialize on `@nospecialize`'d arguments, but const prop was not respecting this and `matching_cache_argtypes` would expand a `Vararg` in the `MI`'s `cache_argtypes` to match the call-site arity, producing `argtypes` of different lengths for different const-prop call sites sharing the same `MI`. This caused an assertion failure in `constprop_cache_lookup` when a second call with a different number of varargs tried to look up a cached result.

Fix this by widening the `@nospecialize`'d arguments back to the `cache_argtypes`, using the same `nospecialize` bitmask convention as `jl_compilation_sig` in `src/gf.c`.
This ensures constprop argtypes always have the same shape as the `MI`'s baseline argtypes, and avoids unnecessary specialization that contradicts the intent of `@nospecializeinfer`.

Fixes aviatesk/JETLS.jl#618.