### PR TITLE
Add `TypeName.concrete_only` flag to opt-in to inference barrier for abstract calls (prevents invalidations)

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -140,6 +140,17 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
 
     (; valid_worlds, applicable) = matches
     update_valid_age!(sv, get_inference_world(interp), valid_worlds) # need to record the negative world now, since even if we don't generate any useful information, inlining might want to add an invoke edge and it won't have this information anymore
+    # Concrete-only functions refuse to commit (and record no backedge) when any
+    # applicable match has a non-concrete signature, regardless of scope. This is the
+    # generalization of the top-level `!isdispatchtuple` bail below to a per-function opt-in.
+    if is_concrete_only(func)
+        for i = 1:length(applicable)
+            if !isdispatchtuple(applicable[i].match.spec_types)
+                add_remark!(interp, sv, "Refusing to infer non-concrete call site for concrete-only function")
+                return Future(CallMeta(Any, Any, Effects(), NoCallInfo()))
+            end
+        end
+    end
     if bail_out_toplevel_call(interp, sv)
         local napplicable = length(applicable)
         for i = 1:napplicable

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -1318,6 +1318,15 @@ function get_max_methods_for_func(@nospecialize(f))
     end
     return nothing
 end
+
+# Whether `f` is marked to only allow inference of call sites with fully concrete
+# argument types. `f === nothing` means the callee value is unknown.
+function is_concrete_only(@nospecialize(f))
+    f === nothing && return false
+    isa(f, DataType) && return f.name.concrete_only
+    return typeof(f).name.concrete_only
+end
+
 get_max_methods_for_module(sv::AbsIntState) = get_max_methods_for_module(frame_module(sv))
 function get_max_methods_for_module(mod::Module)
     max_methods = ccall(:jl_get_module_max_methods, Cint, (Any,), mod) % Int

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -5530,6 +5530,15 @@ g_max_methods(x) = f_max_methods(x)
 @test only(Base.return_types(g_max_methods, Tuple{Int})) === Int
 @test only(Base.return_types(g_max_methods, Tuple{Any})) === Any
 
+# Test that `Core.TypeName.concrete_only` makes inference give up at call sites with
+# non-concrete argument types while keeping concrete call sites precise
+function f_concrete_only end
+typeof(f_concrete_only).name.concrete_only = true
+f_concrete_only(x) = 1
+g_concrete_only(x) = f_concrete_only(x)
+@test only(Base.return_types(g_concrete_only, Tuple{Int})) === Int
+@test only(Base.return_types(g_concrete_only, Tuple{Integer})) === Any
+
 # Test that a module-wise `@max_methods` works as expected
 module Test43370
 using Test

--- a/Compiler/test/invalidation.jl
+++ b/Compiler/test/invalidation.jl
@@ -371,3 +371,37 @@ begin
     pr61102_callee(x::Int) = 3x
     @test !isdefined(callee_mi, :backedges)
 end
+
+# `Core.TypeName.concrete_only`: inference records no backedge at call sites with
+# non-concrete argument types, so adding a more-specific method later does not
+# invalidate the caller's compiled code
+abstract type COStyle end
+struct CODefStyle <: COStyle end
+struct COFill end
+function co_callee end
+typeof(co_callee).name.concrete_only = true
+co_callee(::COStyle, op, x) = 1
+struct COBox
+    s::COStyle
+    x::Any
+end
+co_caller(b::COBox) = co_callee(b.s, zero, b.x)
+
+# the non-concrete call site gives up to `Any`
+@test Base.return_types((COBox,); interp=InvalidationTester()) do b
+    co_caller(b)
+end |> only === Any
+
+let mi = Base.method_instance(co_caller, (COBox,))
+    ci = mi.cache
+    @test ci.owner === InvalidationTesterToken()
+    @test ci.max_world == typemax(UInt)
+end
+
+# add a more-specific method; the caller must remain valid
+co_callee(::CODefStyle, op, x::COFill) = 2
+let mi = Base.method_instance(co_caller, (COBox,))
+    ci = mi.cache
+    @test ci.owner === InvalidationTesterToken()
+    @test ci.max_world == typemax(UInt)
+end

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -194,6 +194,8 @@ end
 struct AndAnd end
 const andand = AndAnd()
 broadcasted(::AndAnd, a, b) = broadcasted((a, b) -> a && b, a, b)
+typeof(broadcasted).name.concrete_only = true
+
 function broadcasted(::AndAnd, a, bc::Broadcasted)
     bcf = flatten(bc)
     # Vararg type signature to specialize on args count. This is necessary for performance

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -93,6 +93,7 @@ JL_DLLEXPORT jl_typename_t *jl_new_typename_in(jl_sym_t *name, jl_module_t *modu
     jl_atomic_store_relaxed(&tn->max_args, 0);
     jl_atomic_store_relaxed(&tn->cache_entry_count, 0);
     tn->constprop_heustic = 0;
+    tn->concrete_only = 0;
     return tn;
 }
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3387,19 +3387,20 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_typename_type->name->wrapper = (jl_value_t*)jl_typename_type;
     jl_typename_type->super = jl_any_type;
     jl_typename_type->parameters = jl_emptysvec;
-    jl_typename_type->name->n_uninitialized = 18 - 2;
-    jl_typename_type->name->names = jl_perm_symsvec(18, "name", "module", "singletonname",
+    jl_typename_type->name->n_uninitialized = 19 - 2;
+    jl_typename_type->name->names = jl_perm_symsvec(19, "name", "module", "singletonname",
                                                     "names", "atomicfields", "constfields",
                                                     "wrapper", "Typeofwrapper", "cache", "linearcache",
                                                     "partial", "hash", "max_args", "n_uninitialized",
                                                     "flags", // "abstract", "mutable", "mayinlinealloc",
-                                                    "cache_entry_count", "max_methods", "constprop_heuristic");
-    const static uint32_t typename_constfields[1]  = { 0b000110100001001011 }; // TODO: put back atomicfields and constfields in this list
-    const static uint32_t typename_atomicfields[1] = { 0b001001001110000000 };
+                                                    "cache_entry_count", "max_methods", "constprop_heuristic",
+                                                    "concrete_only");
+    const static uint32_t typename_constfields[1]  = { 0b0000110100001001011 }; // TODO: put back atomicfields and constfields in this list
+    const static uint32_t typename_atomicfields[1] = { 0b0001001001110000000 };
     jl_typename_type->name->constfields = typename_constfields;
     jl_typename_type->name->atomicfields = typename_atomicfields;
     jl_precompute_memoized_dt(jl_typename_type, 1);
-    jl_typename_type->types = jl_svec(18, jl_symbol_type, jl_any_type /*jl_module_type*/, jl_symbol_type,
+    jl_typename_type->types = jl_svec(19, jl_symbol_type, jl_any_type /*jl_module_type*/, jl_symbol_type,
                                       jl_simplevector_type,
                                       jl_any_type/*jl_voidpointer_type*/, jl_any_type/*jl_voidpointer_type*/,
                                       jl_type_type, jl_simplevector_type, jl_simplevector_type,
@@ -3410,7 +3411,8 @@ void jl_init_types(void) JL_GC_DISABLED
                                       jl_any_type /*jl_uint8_type*/,
                                       jl_any_type /*jl_uint8_type*/,
                                       jl_any_type /*jl_uint8_type*/,
-                                      jl_any_type /*jl_uint8_type*/);
+                                      jl_any_type /*jl_uint8_type*/,
+                                      jl_any_type /*jl_bool_type*/);
 
     jl_methcache_type->name = jl_new_typename_in(jl_symbol("MethodCache"), core, 0, 1);
     jl_methcache_type->name->wrapper = (jl_value_t*)jl_methcache_type;
@@ -4261,6 +4263,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_typename_type->types, 15, jl_uint8_type);
     jl_svecset(jl_typename_type->types, 16, jl_uint8_type);
     jl_svecset(jl_typename_type->types, 17, jl_uint8_type);
+    jl_svecset(jl_typename_type->types, 18, jl_bool_type);
     jl_svecset(jl_methcache_type->types, 2, jl_long_type); // voidpointer
     jl_svecset(jl_methcache_type->types, 3, jl_long_type); // uint32_t plus alignment
     jl_svecset(jl_methtable_type->types, 3, jl_module_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -648,6 +648,7 @@ typedef struct {
     _Atomic(uint8_t) cache_entry_count; // (approximate counter of TypeMapEntry for heuristics)
     uint8_t max_methods; // override for inference's max_methods setting (0 = no additional limit or relaxation)
     uint8_t constprop_heustic; // override for inference's constprop heuristic
+    uint8_t concrete_only; // Bool: inference refuses to commit (records no backedge) at non-concrete call sites
 } jl_typename_t;
 
 typedef struct {


### PR DESCRIPTION
Should fix these invalidations seen when loading CurveFit.jl on 1.13 beta3:
```julia
 inserting broadcasted(::Base.Broadcast.DefaultArrayStyle, ::typeof(*), a::FillArrays.AbstractZeros, b::AbstractArray{<:Number}) @ FillArrays ~/.julia/packages/FillArrays/Ksvco/src/fillbroadcast.jl:151 invalidated:
   backedges: 1: superseding broadcasted(f::F, arg1, arg2, args...) where F @ Base.Broadcast broadcast.jl:1348 with MethodInstance for Base.Broadcast.broadcasted(::Any, ::typeof(*), ::Any, ::LinearAlgebra.Diagonal{Float64, Vector{Float64}}) (1 children)
              2: superseding broadcasted(f::F, arg1, arg2, args...) where F @ Base.Broadcast broadcast.jl:1348 with MethodInstance for Base.Broadcast.broadcasted(::Any, ::typeof(*), ::Any, ::Vector{Float64}) (1 children)
              3: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::typeof(*), ::Any, ::Vector{Float64}) (3 children)
              4: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::typeof(*), ::Any, ::LinearAlgebra.Diagonal{Float64, Vector{Float64}}) (57 children)

 inserting broadcasted(::Base.Broadcast.DefaultArrayStyle{1}, ::typeof(+), a::AbstractVector, b::FillArrays.AbstractZeros{T, 1} where T) @ FillArrays ~/.julia/packages/FillArrays/Ksvco/src/fillbroadcast.jl:222 invalidated:
   backedges: 1: superseding broadcasted(f::F, arg1, arg2, args...) where F @ Base.Broadcast broadcast.jl:1348 with MethodInstance for Base.Broadcast.broadcasted(::Any, ::typeof(+), ::Vector{Float64}, ::Any) (1 children)
              2: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::typeof(+), ::Vector{Float64}, ::Any) (68 children)

 inserting broadcasted(::Base.Broadcast.DefaultArrayStyle{N}, op::typeof(Base.literal_pow), ::Base.RefValue{typeof(^)}, r::FillArrays.AbstractZeros{T, N}, ::Base.RefValue{Val{k}}) where {T, N, k} @ FillArrays ~/.julia/packages/FillArrays/Ksvco/src/fillbroadcast.jl:266 invalidated:
   backedges: 1: superseding broadcasted(f::F, arg1, arg2, args...) where F @ Base.Broadcast broadcast.jl:1348 with MethodInstance for Base.Broadcast.broadcasted(::Any, ::Any, ::Base.RefValue, ::Any, ::Base.RefValue) (18 children)
              2: superseding broadcasted(f::F, arg1, arg2, args...) where F @ Base.Broadcast broadcast.jl:1348 with MethodInstance for Base.Broadcast.broadcasted(::Any, ::Any, ::Base.RefValue, ::Any, ::Vararg{Any}) (96 children)
              3: superseding broadcasted(f::F, arg1, arg2, args...) where F @ Base.Broadcast broadcast.jl:1348 with MethodInstance for Base.Broadcast.broadcasted(::Any, ::Any, ::Base.RefValue, ::Any, ::Any) (100 children)

 inserting broadcasted(::Base.Broadcast.DefaultArrayStyle{N}, op, r::FillArrays.AbstractFill{T, N}, x::Ref) where {T, N} @ FillArrays ~/.julia/packages/FillArrays/Ksvco/src/fillbroadcast.jl:259 invalidated:
   backedges: 1: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::typeof(Setfield.replace_underscore), ::Any, ::Base.RefValue{Symbol}) (3 children)
              2: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::typeof(Accessors.replace_underscore), ::Any, ::Base.RefValue{Symbol}) (3 children)
              3: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::F, ::Any, ::Base.RefValue, ::Vararg{Any}) where F (94 children)
              4: superseding broadcasted(f::F, arg1, arg2, args...) where F @ Base.Broadcast broadcast.jl:1348 with MethodInstance for Base.Broadcast.broadcasted(::Any, ::Any, ::Any, ::Base.RefValue, ::Vararg{Any}) (193 children)

 inserting broadcasted(::Base.Broadcast.DefaultArrayStyle{N}, op, x::Ref, r::FillArrays.AbstractFill{T, N}) where {T, N} @ FillArrays ~/.julia/packages/FillArrays/Ksvco/src/fillbroadcast.jl:260 invalidated:
   backedges:  1: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::typeof(!=), ::Any, ::Any) (1 children)
               2: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::F, ::Any, ::Any) where F<:ForwardDiff.var"#partials_wrap#extract_jacobian_chunk!##0" (1 children)
               3: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::ForwardDiff.var"#partials_wrap#extract_jacobian_chunk!##0"{ForwardDiff.Tag{NonlinearSolveBase.NonlinearSolveTag, Float64}}, ::Any, ::Any) (1 children)
               4: superseding broadcasted(f::F, arg1, arg2, args...) where F @ Base.Broadcast broadcast.jl:1348 with MethodInstance for Base.Broadcast.broadcasted(::Any, ::Pkg.API.var"#211#212"{Dict{String, Set{String}}, Dict{String, Dates.DateTime}}, ::Base.RefValue{String}, ::Any) (1 children)
               5: superseding broadcasted(f::F, arg1, arg2, args...) where F @ Base.Broadcast broadcast.jl:1348 with MethodInstance for Base.Broadcast.broadcasted(::Any, ::Pkg.API.var"#209#210"{Dict{String, Dates.DateTime}}, ::Base.RefValue{String}, ::Any) (1 children)
               6: superseding broadcasted(f::F, arg1, arg2, args...) where F @ Base.Broadcast broadcast.jl:1348 with MethodInstance for Base.Broadcast.broadcasted(::Any, ::Pkg.API.var"#207#208"{Dict{String, Dates.DateTime}}, ::Base.RefValue{String}, ::Any) (1 children)
               7: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::F, ::Any, ::Any) where F<:(ForwardDiff.var"#partials_wrap#extract_jacobian_chunk!##0"{T} where T<:(ForwardDiff.Tag{F} where F<:(Base.Fix2))) (2 children)
               8: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::F, ::Any, ::Any) where F<:(ForwardDiff.var"#partials_wrap#extract_jacobian_chunk!##0"{T} where T<:(ForwardDiff.Tag{F} where F<:NonlinearSolveBaseForwardDiffExt.var"#9#10")) (2 children)
               9: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::F, ::Any, ::Any) where F<:(ForwardDiff.var"#partials_wrap#extract_jacobian_chunk!##0"{T} where T<:(ForwardDiff.Tag{F} where F<:(Base.Fix1))) (2 children)
              10: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::Pkg.API.var"#211#212"{Dict{String, Set{String}}, Dict{String, Dates.DateTime}}, ::Base.RefValue{String}, ::Any) (3 children)
              11: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::Pkg.API.var"#209#210"{Dict{String, Dates.DateTime}}, ::Base.RefValue{String}, ::Any) (3 children)
              12: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::Pkg.API.var"#207#208"{Dict{String, Dates.DateTime}}, ::Base.RefValue{String}, ::Any) (3 children)
              13: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::Nothing, ::Base.RefValue{typeof(sqrt)}, ::Any) (3 children)
              14: superseding broadcasted(f::F, arg1, arg2, args...) where F @ Base.Broadcast broadcast.jl:1348 with MethodInstance for Base.Broadcast.broadcasted(::Any, ::Nothing, ::Base.RefValue, ::Any) (6 children)
              15: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::Nothing, ::Base.RefValue{typeof(esc)}, ::Any) (10 children)
              16: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::Nothing, ::Base.RefValue{typeof(float)}, ::Any) (12 children)
              17: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::Nothing, ::Base.RefValue{typeof(identity)}, ::Any) (47 children)
              18: superseding broadcasted(style::Base.Broadcast.BroadcastStyle, f::F, args...) where F @ Base.Broadcast broadcast.jl:1354 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::Nothing, ::Base.RefValue{Type{Base.UUID}}, ::Any) (225 children)
```

All the invalidations come from FillArrays.jl: https://github.com/JuliaArrays/FillArrays.jl/blob/master/src/fillbroadcast.jl