### PR TITLE
Allow retries when downloading files with jldownload

### DIFF
--- a/deps/tools/jldownload
+++ b/deps/tools/jldownload
@@ -10,8 +10,9 @@ CURL=$(which curl 2>/dev/null)
 FETCH=$(which fetch 2>/dev/null)
 
 TIMEOUT=15 # seconds
-WGET_OPTS="--no-check-certificate --tries=1 --timeout=$TIMEOUT"
-CURL_OPTS="-fkL --connect-timeout $TIMEOUT -y $TIMEOUT"
+RETRIES=3
+WGET_OPTS="--no-check-certificate --waitretry=$TIMEOUT --tries=$RETRIES --timeout=$TIMEOUT"
+CURL_OPTS="-fkL --connect-timeout $TIMEOUT -y $TIMEOUT --retry $RETRIES --retry-max-time $TIMEOUT"
 FETCH_OPTS="-T $TIMEOUT"
 
 if [ $# -eq 1 ]; then


### PR DESCRIPTION
Might help prevent failures like this: https://buildkite.com/julialang/julia-master/builds/56248/steps/canvas?sid=019d5d07-050c-42dc-aaf1-ee8f73fef943

This should only do retries for non-fatal errors. Relevant [curl docs](https://curl.se/docs/manpage.html#--retry):
> --retry <num>
> 
> If a transient error is returned when curl tries to perform a transfer, it retries this number of times before giving up. Setting the number to 0 makes curl do no retries (which is the default). Transient error means either: a timeout, an FTP 4xx response code or an HTTP 408, 429, 500, 502, 503, 504, 522 or 524 response code.
> 
> When curl is about to retry a transfer, it first waits one second and then for all forthcoming retries it doubles the waiting time until it reaches 10 minutes, which then remains the set fixed delay time between the rest of the retries. By using [--retry-delay](https://curl.se/docs/manpage.html#--retry-delay) you disable this exponential backoff algorithm. See also [--retry-max-time](https://curl.se/docs/manpage.html#--retry-max-time) to limit the total time allowed for retries.

And [wget](https://man7.org/linux/man-pages/man1/wget.1.html):
>        -t number
>        --tries=number
>            Set number of tries to number. Specify 0 or inf for infinite
>            retrying.  The default is to retry 20 times, with the
>            exception of fatal errors like "connection refused" or "not
>            found" (404), which are not retried.