### PR TITLE
Convert to Float64 in TOML's printvalue() to avoid invalidations

### DIFF
--- a/base/toml/printer.jl
+++ b/base/toml/printer.jl
@@ -128,12 +128,15 @@ function printvalue(f::Function, io::IO, value::Integer, sorted::Bool)
 end
 
 function printvalue(f::Function, io::IO, value::AbstractFloat, sorted::Bool)
+    # The early conversion here avoids invalidations from isnan/isinf
+    value = Float64(value)
+
     if isnan(value)
         Base.print(io, "nan")
     elseif isinf(value)
         Base.print(io, value > 0 ? "+inf" : "-inf")
     else
-        Base.print(io, Float64(value)) # TOML specifies IEEE 754 binary64 for float
+        Base.print(io, value) # TOML specifies IEEE 754 binary64 for float
     end
 end
 


### PR DESCRIPTION
Should fix these invalidations seen when loading CUDA.jl on 1.13:
```julia
 inserting isnan(x::Core.BFloat16) @ BFloat16s ~/.julia/packages/BFloat16s/lYUbX/src/bfloat16.jl:117 invalidated:
   mt_backedges: 1: signature Tuple{typeof(isnan), AbstractFloat} triggered MethodInstance for isunordered(::AbstractFloat) (79 children)
   backedges: 1: superseding isnan(x::AbstractFloat) @ Base float.jl:708 with MethodInstance for isnan(::AbstractFloat) (345 children)

 # If only isnan is fixed, we get another set of invalidations from isfinite
 inserting isfinite(x::Core.BFloat16) @ BFloat16s ~/.julia/dev/BFloat16s/src/bfloat16.jl:116 invalidated:                                                                                                                                      
   backedges: 1: superseding isfinite(x::AbstractFloat) @ Base float.jl:711 with MethodInstance for isfinite(::AbstractFloat) (313 children)                                                                                                   
```

These are currently the most invalidating methods for CUDA.jl. I attempted removing those specializations from BFloat16s.jl since Base already defines defaults for `AbstractFloat`, but for `isfinite()` that caused a ~40% slowdown. I think this is the safer fix. I also had a look at what was getting invalidated, and it turned out to be some printing code that was invalidating a giant chunk of Pkg:
```julia
julia> victim = trees[end].backedges[end]
MethodInstance for isnan(::AbstractFloat) at depth 0 with 345 children

julia> ascend(victim)
Choose a call for analysis (q to quit):
 >   isnan(::AbstractFloat)
       isinf(::AbstractFloat)
         printvalue(::typeof(identity), ::IOStream, ::AbstractFloat, ::Bool)
           #print_table#2(::Int64, ::Bool, ::Bool, ::IdSet{Dict{String}}, ::typeof(identity), ::typeof(Base.TOML.Printer.print_table), ::typeof(identity), ::IOStream, ::Dict{String, Any}, ::Vector{String})
             kwcall(::@NamedTuple{sorted::Bool, by::typeof(identity), inline_tables::IdSet{Dict{String}}}, ::typeof(Base.TOML.Printer.print_table), ::typeof(identity), ::IOStream, ::Dict{String, Any}, ::Vector{String})
               kwcall(::@NamedTuple{sorted::Bool, by::typeof(identity), inline_tables::IdSet{Dict{String}}}, ::typeof(Base.TOML.Printer.print_table), ::typeof(identity), ::IOStream, ::Dict{String, Any})
                 #print#11(::Bool, ::typeof(identity), ::IdSet{Dict{String}}, ::typeof(Base.TOML.Printer.print), ::IOStream, ::Dict{String, Any})
                   print(::IOStream, ::Dict{String, Any})
                     #atomic_toml_write#4(::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(Pkg.atomic_toml_write), ::String, ::Dict{String, Any})
v                      atomic_toml_write(::String, ::Dict{String, Any})
```