### PR TITLE
Compiler: infer `Expr(:static_parameter, ...)` in argument position

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3142,7 +3142,11 @@ function abstract_eval_special_value(interp::AbstractInterpreter, @nospecialize(
 end
 
 function abstract_eval_value_expr(interp::AbstractInterpreter, e::Expr, sv::AbsIntState)
-    if e.head === :call && length(e.args) ≥ 1
+    if e.head === :static_parameter
+        rt = abstract_eval_static_parameter(interp, e, sv)
+        merge_effects!(interp, sv, rt.effects)
+        return rt.rt
+    elseif e.head === :call && length(e.args) ≥ 1
         # TODO: We still have non-linearized cglobal
         @assert e.args[1] === Core.tuple || e.args[1] === GlobalRef(Core, :tuple)
     else

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -6765,4 +6765,23 @@ let
     @test f(1, 2, 3) == (0, (0, (0, 1)))
 end
 
+# Expr(:static_parameter, ...) in argument position should be inferable
+function gen_static_parameter_argument_position(world::UInt, source, args...)
+    ci = make_codeinfo(Any[
+        ReturnNode(Expr(:static_parameter, 1))
+    ]; slottypes=Any[Any, Any])
+    ci.slotnames = Symbol[:var"#self#", :typ]
+    ci.nargs = 2
+    ci.isva = false
+    return ci
+end
+@eval function f_static_parameter_argument_position(typ::Type{T}) where T
+    $(Expr(:meta, :generated, gen_static_parameter_argument_position))
+    $(Expr(:meta, :generated_only))
+    #= no body =#
+end
+let result = code_typed(f_static_parameter_argument_position, Tuple{Type{Int}})
+    @test result[1].second === Type{Int}
+end
+
 end # module inference


### PR DESCRIPTION
Kind of surprising we haven't encountered this before, but flisp tries to avoid this form (on accident?)

Previously:
```julia
julia> code_typed(f_static_parameter_argument_position, Tuple{Type{Int}})
1-element Vector{Any}:
 CodeInfo(
1 ─     return Int64
) => Any # should be Type{Any}
```

JuliaLowering _does_ generate it though, so this resolves https://github.com/JuliaLang/JuliaLowering.jl/issues/152.