### PR TITLE
staticdata: fix always-true `jl_is_datatype(t)` check in serialization

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -900,7 +900,7 @@ static void jl_queue_for_serialization_(jl_serializer_state *s, jl_value_t *v, i
     // Items that require postorder traversal must visit their children prior to insertion into
     // the worklist/serialization_order (and also before their first use)
     if (s->incremental && !immediate) {
-        if (jl_is_datatype(t) && needs_uniquing(v, s->query_cache))
+        if (jl_is_datatype(v) && needs_uniquing(v, s->query_cache))
             immediate = 1;
         if (jl_is_datatype_singleton((jl_datatype_t*)t) && needs_uniquing(v, s->query_cache))
             immediate = 1;


### PR DESCRIPTION
Seems to go back to https://github.com/JuliaLang/julia/commit/cbfdb3facd

Caught by Claude:

In `jl_queue_for_serialization_`, `t = jl_typeof(v)` so `jl_is_datatype(t)` is always true (every value's type is a DataType). The intent is to check whether `v` itself is a DataType needing uniquing, to force postorder traversal for the super chain. Fix by testing `jl_is_datatype(v)` instead.