### PR TITLE
Use `@static if` in `CompilerSupportLibraries_jll.__init__()`

### DIFF
--- a/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
+++ b/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
@@ -134,15 +134,13 @@ end
 
 # Conform to LazyJLLWrappers API
 function eager_mode()
-    if @isdefined(libatomic)
-        dlopen(libatomic)
-    end
+    dlopen(libatomic)
     dlopen(libgcc_s)
     dlopen(libgomp)
-    if @isdefined libquadmath
+    @static if @isdefined libquadmath
         dlopen(libquadmath)
     end
-    if @isdefined libssp
+    @static if @isdefined libssp
         dlopen(libssp)
     end
     dlopen(libgfortran)
@@ -154,10 +152,10 @@ function __init__()
     global libatomic_path = string(libatomic.path)
     global libgcc_s_path = string(libgcc_s.path)
     global libgomp_path = string(libgomp.path)
-    if @isdefined libquadmath_path
+    @static if @isdefined libquadmath_path
         global libquadmath_path = string(libquadmath.path)
     end
-    if @isdefined libssp_path
+    @static if @isdefined libssp_path
         global libssp_path = string(libssp.path)
     end
     global libgfortran_path = string(libgfortran.path)


### PR DESCRIPTION
Hopefully enough to fix JuliaC on `aarch64-linux` (https://buildkite.com/julialang/julia-master/builds/56266#019d6367-fc8d-4806-a1f1-00ec67370c77/L1315-L1319):
```
Error #2: unresolved call from statement string(
  getproperty(
    libquadmath::Any,
    :path::Symbol
  )::Any
)::Any
 
Stacktrace:
[1] __init__()
@ CompilerSupportLibraries_jll ./CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl:158
```
