### PR TITLE
Fix `Base.summarysize` crash for instances of foreign types

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -2366,6 +2366,11 @@ jl_value_t *get_nth_pointer(jl_value_t *v, size_t i)
     uint32_t npointers = ly->npointers;
     if (i >= npointers)
         jl_bounds_error_int(v, i);
+    if (ly->flags.fielddesc_type == 3) {
+        // Foreign types can report that they contain pointers for GC purposes,
+        // but they do not expose an inline pointer-offset table to enumerate.
+        return NULL;
+    }
     const uint8_t *ptrs8 = (const uint8_t *)jl_dt_layout_ptrs(ly);
     const uint16_t *ptrs16 = (const uint16_t *)jl_dt_layout_ptrs(ly);
     const uint32_t *ptrs32 = (const uint32_t*)jl_dt_layout_ptrs(ly);

--- a/test/gcext/gcext-test.jl
+++ b/test/gcext/gcext-test.jl
@@ -66,6 +66,9 @@ end
             GC.gc(true)
         end
         @test Base.invokelatest(Foreign.get_nmark)  > 0
+        # Bugfix: the following used to crash
+        summarysize = Base.summarysize(Foreign.FObj())
+        @test summarysize >= sizeof(Ptr)
         @time Base.invokelatest(Foreign.test, 10)
         GC.gc(true)
         @test Base.invokelatest(Foreign.get_nsweep) > 0


### PR DESCRIPTION
Instances of foreign types are opaque to Julia and we can't traverse them. Teach `get_nth_pointer` about this. This in turn prevents `summarysize` from crashing when invoked on a foreign object.

Fixes https://github.com/oscar-system/GAP.jl/issues/1366

Extracted from PR #61411, figuring this is both easier to review and less controversial to backport.