### PR TITLE
JuliaSyntax: Type-annotate array comprehension in `attrnames`

### DIFF
--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -283,7 +283,7 @@ end
 
 function attrnames(ex::SyntaxTree)
     attrs = ex._graph.attributes
-    [name for (name, value) in pairs(attrs) if haskey(value, ex._id)]
+    Symbol[name for (name, value) in pairs(attrs) if haskey(value, ex._id)]
 end
 
 function copy_node(ex::SyntaxTree)


### PR DESCRIPTION
Add explicit `Symbol` element type to the comprehension in `attrnames(::SyntaxTree)` to guarantee a `Vector{Symbol}` return, independent of inference through the generic `Attrs` type parameter of `SyntaxGraph{Attrs}`.