### PR TITLE
[JuliaLowering] Fix identifier -> GlobalRef conversion

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -450,8 +450,7 @@ function est_to_dst(st::SyntaxTree)
                 r3 -> @ast g st [K"." rec(l) r3]
             end
         end
-        [K"inert" [K"Identifier"]] -> @ast g st st[1]=>K"Symbol"
-        # [K"quote" [K"Identifier"]] -> @ast g st st[1]=>K"Symbol"
+        ([K"inert" [K"Identifier"]], when=!hasattr(st[1], :mod)) -> @ast g st st[1]=>K"Symbol"
         [K"inert" _] -> st
         [K"inert_syntaxtree" _] -> st
         [K"module" _...] -> st

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -881,3 +881,28 @@ end
     mac_st = JuliaLowering.expr_to_est(mac_ex, LineNumberNode(1, "badfile"))
     @test JuliaLowering.eval(test_mod, mac_st) == "none"
 end
+
+@testset "macro QuoteNode + inert behavior" begin
+    Base.include_string(test_mod, raw"""
+    macro quoted_gr()
+        QuoteNode(GlobalRef(Base, :dontresolveme))
+    end
+    """)
+    let gr = JuliaLowering.include_string(test_mod, "@quoted_gr")
+        @test gr.mod === Base
+        @test gr.name === :dontresolveme
+    end
+end
+
+@testset "Base macros" begin
+    jl_eval(test_mod,
+            :(function test_invokelatest()
+                  @eval invokelatest_target(x, y) = x + y
+                  out = @invokelatest(invokelatest_target(1, 2))
+                  Base.delete_binding(@__MODULE__, :invokelatest_target)
+                  out
+              end))
+    # the following test needs to define this to be effective
+    @test_throws UndefVarError JuliaLowering.include_string(test_mod, "invokelatest_target(1,2)")
+    @test JuliaLowering.include_string(test_mod, "test_invokelatest()") === 3
+end


### PR DESCRIPTION
This fixes the `@invokelatest` macro.

This is a somewhat blind fix without understanding the broader structure of `compat.jl`, so let me know if I'm in the wrong direction @mlechu. Resolves https://github.com/JuliaLang/JuliaLowering.jl/issues/174.