### PR TITLE
[JuliaSyntax] Return generator from `attrnames(::SyntaxTree)`

### DIFF
--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -208,7 +208,7 @@ end
 # fallback printing
 function node_string(ex::SyntaxTree, depth=2)
     out = "(_id="*string(ex._id)
-    for n in sort!(attrnames(ex))
+    for n in sort!(collect(attrnames(ex)))
         out *= ", "*string(n)*"="*repr(getproperty(ex, n))
     end
     if is_leaf(ex)
@@ -283,7 +283,7 @@ end
 
 function attrnames(ex::SyntaxTree)
     attrs = ex._graph.attributes
-    Symbol[name for (name, value) in pairs(attrs) if haskey(value, ex._id)]
+    (name::Symbol for (name, value) in pairs(attrs) if haskey(value, ex._id))
 end
 
 function copy_node(ex::SyntaxTree)

--- a/JuliaSyntax/test/runtests.jl
+++ b/JuliaSyntax/test/runtests.jl
@@ -45,8 +45,10 @@ end
 
 include("serialization.jl")
 
-# Basic inference tests
 @static if isdefined(Base, :infer_return_type)
-    @test Base.infer_return_type(JuliaSyntax.sourcetext, (JuliaSyntax.SyntaxTree,)) <: AbstractString
-    @test Base.infer_return_type(JuliaSyntax.byte_range, (JuliaSyntax.SyntaxTree,)) == UnitRange{Int}
+    @testset "Basic inference tests" begin
+        @test Base.infer_return_type(JuliaSyntax.sourcetext, (JuliaSyntax.SyntaxTree,)) <: AbstractString
+        @test Base.infer_return_type(JuliaSyntax.byte_range, (JuliaSyntax.SyntaxTree,)) == UnitRange{Int}
+        @test Base.infer_return_type(JuliaSyntax.hasproperty, (JuliaSyntax.SyntaxTree,Symbol)) == Bool
+    end
 end


### PR DESCRIPTION
Return a generator instead of a `Vector{Symbol}` from `attrnames` to avoid unnecessary allocation. `attrnames` is called from `hasproperty(::SyntaxTree, ::Symbol)` and similar hot-path queries, so avoiding the allocation would be worthwhile. This is compatible with the `propertynames` interface which accepts any iterable of properties, although `node_string` needed to be updated since the return value is now `Tuple{Vararg{Symbol}}` instead of a vector of the symbols.

Also wrap inference tests in a `@testset` and add a test for `hasproperty` return type inference.

Follows up JuliaLang/julia#61518.