### PR TITLE
[JuliaLowering] Fix `try-finally` token stack handling

### DIFF
--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -347,7 +347,7 @@ function emit_break(ctx, ex)
     end
     if !isempty(ctx.finally_handlers)
         handler = last(ctx.finally_handlers)
-        if length(target.handler_token_stack) < length(handler.target.handler_token_stack)
+        if length(target.handler_token_stack) <= length(handler.target.handler_token_stack)
             enter_finally_block(ctx, ex, :break, ex)
             return
         end

--- a/JuliaLowering/test/exceptions.jl
+++ b/JuliaLowering/test/exceptions.jl
@@ -389,6 +389,49 @@ end
     end
     """) broken=true
 
+    # continue inside for/try/finally must run the finally block
+    @test JuliaLowering.include_string(test_mod, """
+    buf = []
+    for x in [1,2,3]
+        try
+            push!(buf, ("try", x))
+            continue
+        finally
+            push!(buf, ("finally", x))
+        end
+    end
+    buf
+    """) == [("try",1), ("finally",1), ("try",2), ("finally",2), ("try",3), ("finally",3)]
+
+    # break inside for/try/finally must run the finally block
+    @test JuliaLowering.include_string(test_mod, """
+    buf = []
+    for x in [1,2,3]
+        try
+            push!(buf, ("try", x))
+            break
+        finally
+            push!(buf, ("finally", x))
+        end
+    end
+    buf
+    """) == [("try",1), ("finally",1)]
+
+    # break/continue inside a loop that stays within the try block should not run finally
+    @test JuliaLowering.include_string(test_mod, """
+    buf = []
+    try
+        for x in [1,2,3]
+            x == 2 && continue
+            x == 3 && break
+            push!(buf, x)
+        end
+    finally
+        push!(buf, "finally")
+    end
+    buf
+    """) == [1, "finally"]
+
     # Test that @goto within try/catch/else is allowed when there's no finally
     @test JuliaLowering.include_string(test_mod, """
     function f()


### PR DESCRIPTION
The token stack of the `handler` is just outside of the `try-finally`, so the right logic is to check if we jump to that level or higher.

We could probably use more test coverage for this code, but let's do a spot fix for now.

Resolves https://github.com/JuliaLang/JuliaLowering.jl/issues/171.