### PR TITLE
[JuliaLowering] Fix break/continue in try

### DIFF
--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -226,12 +226,6 @@ function emit_leave_handler(ctx::LinearIRContext, srcref, dest_tokens)
     end
 end
 
-function emit_jump(ctx, srcref, target::JumpTarget)
-    emit_pop_exception(ctx, srcref, target.catch_token_stack)
-    emit_leave_handler(ctx, srcref, target.handler_token_stack)
-    emit(ctx, @ast ctx srcref [K"goto" target.label])
-end
-
 # Enter the current finally block, either through the landing pad (on_exit ==
 # :rethrow) or via a jump (on_exit ∈ (:return, :break)).
 #
@@ -244,7 +238,9 @@ function enter_finally_block(ctx, srcref, on_exit, value)
     tag = length(handler.exit_actions)
     emit(ctx, @ast ctx srcref [K"=" handler.tagvar tag::K"Integer"])
     if on_exit != :rethrow
-        emit_jump(ctx, srcref, handler.target)
+        emit_pop_exception(ctx, srcref, handler.target.catch_token_stack)
+        emit_leave_handler(ctx, srcref, handler.target.handler_token_stack[1:end-1])
+        emit(ctx, @ast ctx srcref [K"goto" handler.target.label])
     end
 end
 
@@ -262,7 +258,7 @@ function _actually_return(ctx, ex)
     if !simple_ret_val
         ex = emit_assign_tmp(ctx, ex, "return_tmp")
     end
-    emit_pop_exception(ctx, ex, ())
+    emit_pop_exception(ctx, ex, SyntaxList(ctx.graph))
     emit(ctx, @ast ctx ex [K"return" ex])
     return nothing
 end
@@ -351,8 +347,11 @@ function emit_break(ctx, ex)
             enter_finally_block(ctx, ex, :break, ex)
             return
         end
+    else
+        emit_pop_exception(ctx, ex, target.catch_token_stack)
+        emit_leave_handler(ctx, ex, target.handler_token_stack)
+        emit(ctx, @ast ctx ex [K"goto" target.label])
     end
-    emit_jump(ctx, ex, target)
 end
 
 # `op` may be either K"=" (where global assignments are converted to setglobal!)
@@ -513,6 +512,7 @@ function compile_try(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         handler_token
         [K"enter" catch_label enter_scope_arg...]
     ])
+    push!(ctx.handler_token_stack, handler_token)
     if has_finally_block
         # TODO: Trivial finally block optimization from JuliaLang/julia#52593 (or
         # support a special form for @with)?
@@ -521,7 +521,6 @@ function compile_try(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         push!(ctx.finally_handlers, finally_handler)
         emit(ctx, @ast ctx finally_block [K"=" finally_handler.tagvar (-1)::K"Integer"])
     end
-    push!(ctx.handler_token_stack, handler_token)
 
     # Try block code.
     try_val = compile(ctx, try_block, needs_value, false)

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -242,6 +242,7 @@ function enter_finally_block(ctx, srcref, on_exit, value)
         emit_leave_handler(ctx, srcref, handler.target.handler_token_stack[1:end-1])
         emit(ctx, @ast ctx srcref [K"goto" handler.target.label])
     end
+    tag
 end
 
 # Helper function for emit_return
@@ -341,12 +342,10 @@ function emit_break(ctx, ex)
         val = compile(ctx, ex[2], true, false)
         emit_assignment(ctx, ex, target.result_var, val)
     end
-    if !isempty(ctx.finally_handlers)
-        handler = last(ctx.finally_handlers)
-        if length(target.handler_token_stack) < length(handler.target.handler_token_stack)
-            enter_finally_block(ctx, ex, :break, ex)
-            return
-        end
+    if (!isempty(ctx.finally_handlers) && length(target.handler_token_stack) <
+        length(last(ctx.finally_handlers).target.handler_token_stack))
+        enter_finally_block(ctx, ex, :break, ex)
+        return
     else
         emit_pop_exception(ctx, ex, target.catch_token_stack)
         emit_leave_handler(ctx, ex, target.handler_token_stack)
@@ -762,6 +761,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         end
     elseif k == K"break"
         emit_break(ctx, ex)
+        nothing
     elseif k == K"symboliclabel"
         label = emit_label(ctx, ex)
         name = ex.name_val

--- a/JuliaLowering/test/exceptions.jl
+++ b/JuliaLowering/test/exceptions.jl
@@ -385,6 +385,25 @@ end
     """) == [("try", 1), ("finally", 1)]
     @test isempty(current_exceptions())
 
+    # break/continue in loop in try -> loop-cont, loop-exit -> finally
+    @test JuliaLowering.include_string(test_mod, """
+    let out = [], x = 1
+        try
+            for outer x in 1:100
+                push!(out, ("try", x))
+                x > 2 && break
+                continue
+                push!(out, ("bad", x))
+            end
+        $maybe_catch
+        finally
+            push!(out, ("finally", x))
+        end
+        out
+    end
+    """) == [("try", 1), ("try", 2), ("try", 3), ("finally", 3)]
+    @test isempty(current_exceptions())
+
     # continue in finally -> loop-cont
     @test JuliaLowering.include_string(test_mod, """
     let out = []

--- a/JuliaLowering/test/exceptions.jl
+++ b/JuliaLowering/test/exceptions.jl
@@ -348,6 +348,172 @@ begin
 end
 """) == (1,2)
 
+@testset "continue/break and finally" for maybe_catch in ("", "catch _", "catch _\nelse")
+    # continue in try -> finally block -> loop-cont
+    @test JuliaLowering.include_string(test_mod, """
+    let out = []
+        for x in [1,2,3]
+            try
+                push!(out, ("try", x))
+                continue
+            $maybe_catch
+            finally
+                push!(out, ("finally", x))
+            end
+            push!(out, ("bad", x))
+        end
+        out
+    end
+    """) == [("try", 1), ("finally", 1), ("try", 2), ("finally", 2), ("try", 3), ("finally", 3)]
+    @test isempty(current_exceptions())
+
+    # break in try -> finally block -> loop-exit
+    @test JuliaLowering.include_string(test_mod, """
+    let out = []
+        for x in [1,2,3]
+            try
+                push!(out, ("try", x))
+                break
+            $maybe_catch
+            finally
+                push!(out, ("finally", x))
+            end
+            push!(out, ("bad", x))
+        end
+        out
+    end
+    """) == [("try", 1), ("finally", 1)]
+    @test isempty(current_exceptions())
+
+    # continue in finally -> loop-cont
+    @test JuliaLowering.include_string(test_mod, """
+    let out = []
+        for x in [1,2,3]
+            try
+                push!(out, ("try", x))
+            $maybe_catch
+            finally
+                continue
+                push!(out, ("finally", x))
+            end
+            push!(out, ("bad", x))
+        end
+        out
+    end
+    """) == [("try", 1), ("try", 2), ("try", 3)]
+    @test isempty(current_exceptions())
+
+    # break in finally -> loop-exit
+    @test JuliaLowering.include_string(test_mod, """
+    let out = []
+        for x in [1,2,3]
+            try
+                push!(out, ("try", x))
+            $maybe_catch
+            finally
+                break
+                push!(out, ("finally", x))
+            end
+            push!(out, ("bad", x))
+        end
+        out
+    end
+    """) == [("try", 1)]
+    @test isempty(current_exceptions())
+
+    # TODO: commented out to avoid polluting the exception stack; need to port
+    # https://github.com/JuliaLang/julia/pull/55876
+
+    # # error in try -> continue in finally -> loop-cont
+    # @test JuliaLowering.include_string(test_mod, """
+    # let out = []
+    #     for x in [1,2,3]
+    #         try
+    #             push!(out, ("try", x))
+    #             error()
+    #         $maybe_catch
+    #         finally
+    #             continue
+    #             push!(out, ("finally", x))
+    #         end
+    #         push!(out, ("bad", x))
+    #     end
+    #     out
+    # end
+    # """) == [("try", 1), ("try", 2), ("try", 3)]
+    # @test isempty(current_exceptions())
+    #
+    # # error in try -> break in finally -> loop-exit
+    # @test JuliaLowering.include_string(test_mod, """
+    # let out = []
+    #     for x in [1,2,3]
+    #         try
+    #             push!(out, ("try", x))
+    #             error()
+    #         $maybe_catch
+    #         finally
+    #             break
+    #             push!(out, ("finally", x))
+    #         end
+    #         push!(out, ("bad", x))
+    #     end
+    #     out
+    # end
+    # """) == [("try", 1)]
+    # @test isempty(current_exceptions())
+
+    # (nested) continue in try -> finally block -> loop-cont
+    @test JuliaLowering.include_string(test_mod, """
+    let out = []
+        for x in [1,2]
+            try
+                push!(out, ("try", x))
+                continue
+            $maybe_catch
+            finally
+                push!(out, ("finally", x))
+                try
+                    push!(out, ("try2", x))
+                    continue
+                finally
+                    push!(out, ("finally2", x))
+                end
+                push!(out, ("bad_finally", x))
+            end
+            push!(out, ("bad", x))
+        end
+        out
+    end
+    """) == [("try", 1), ("finally", 1), ("try2", 1), ("finally2", 1),
+             ("try", 2), ("finally", 2), ("try2", 2), ("finally2", 2)]
+    @test isempty(current_exceptions())
+
+    # (nested) break in try -> finally block -> loop-exit
+    @test JuliaLowering.include_string(test_mod, """
+    let out = []
+        for x in [1,2]
+            try
+                push!(out, ("try", x))
+                break
+            $maybe_catch
+            finally
+                push!(out, ("finally", x))
+                try
+                    push!(out, ("try2", x))
+                    break
+                finally
+                    push!(out, ("finally2", x))
+                end
+                push!(out, ("bad_finally", x))
+            end
+            push!(out, ("bad", x))
+        end
+        out
+    end
+    """) == [("try", 1), ("finally", 1), ("try2", 1), ("finally2", 1)]
+    @test isempty(current_exceptions())
+end
+
 @testset "goto from try/catch/else with finally" begin
     # Test that @goto from try block with finally is prevented
     @test_throws JuliaLowering.LoweringError r"goto from a try/finally block is not permitted" JuliaLowering.include_string(test_mod, """

--- a/JuliaLowering/test/exceptions.jl
+++ b/JuliaLowering/test/exceptions.jl
@@ -389,8 +389,9 @@ end
     @test JuliaLowering.include_string(test_mod, """
     let out = [], x = 1
         try
+            push!(out, ("try", x))
             for outer x in 1:100
-                push!(out, ("try", x))
+                push!(out, ("loop", x))
                 x > 2 && break
                 continue
                 push!(out, ("bad", x))
@@ -401,7 +402,27 @@ end
         end
         out
     end
-    """) == [("try", 1), ("try", 2), ("try", 3), ("finally", 3)]
+    """) == [("try", 1), ("loop", 1), ("loop", 2), ("loop", 3), ("finally", 3)]
+    @test isempty(current_exceptions())
+
+    # break/continue in loop in finally -> loop-cont, loop-exit
+    @test JuliaLowering.include_string(test_mod, """
+    let out = [], x = 1
+        try
+            push!(out, ("try", x))
+        $maybe_catch
+        finally
+            for outer x in 1:100
+                push!(out, ("loop", x))
+                x > 2 && break
+                continue
+                push!(out, ("bad", x))
+            end
+            push!(out, ("finally", x))
+        end
+        out
+    end
+    """) == [("try", 1), ("loop", 1), ("loop", 2), ("loop", 3), ("finally", 3)]
     @test isempty(current_exceptions())
 
     # continue in finally -> loop-cont

--- a/JuliaLowering/test/exceptions_ir.jl
+++ b/JuliaLowering/test/exceptions_ir.jl
@@ -235,27 +235,31 @@ while true
     end
 end
 #---------------------
-1   (gotoifnot true label₁₅)
-2   (enter label₉)
+1   (gotoifnot true label₁₉)
+2   (enter label₁₀)
 3   (= slot₂/finally_tag -1)
 4   TestMod.a
-5   (leave %₂)
-6   (goto label₁₆)
-7   (leave %₂)
-8   (goto label₁₀)
-9   (= slot₂/finally_tag 1)
-10  TestMod.b
-11  (call core.=== slot₂/finally_tag 1)
-12  (gotoifnot %₁₁ label₁₄)
-13  (call top.rethrow)
-14  (goto label₁)
-15  (= slot₁/loop-exit_result core.nothing)
-16  (isdefined slot₁/loop-exit_result)
-17  (gotoifnot %₁₆ label₁₉)
-18  (goto label₂₀)
+5   (= slot₂/finally_tag 1)
+6   (leave %₂)
+7   (goto label₁₁)
+8   (leave %₂)
+9   (goto label₁₁)
+10  (= slot₂/finally_tag 2)
+11  TestMod.b
+12  (call core.=== slot₂/finally_tag 2)
+13  (gotoifnot %₁₂ label₁₅)
+14  (call top.rethrow)
+15  (call core.=== slot₂/finally_tag 1)
+16  (gotoifnot %₁₅ label₁₈)
+17  (goto label₂₀)
+18  (goto label₁)
 19  (= slot₁/loop-exit_result core.nothing)
-20  slot₁/loop-exit_result
-21  (return %₂₀)
+20  (isdefined slot₁/loop-exit_result)
+21  (gotoifnot %₂₀ label₂₃)
+22  (goto label₂₄)
+23  (= slot₁/loop-exit_result core.nothing)
+24  slot₁/loop-exit_result
+25  (return %₂₄)
 
 ########################################
 # try/catch/finally


### PR DESCRIPTION
Alternative to https://github.com/JuliaLang/julia/pull/61523, fix https://github.com/JuliaLang/JuliaLowering.jl/issues/171.  

Push to `ctx.handler_token_stack` before construction of the `FinallyHandler`, since the `JumpTarget` constructor needs it.  The extra entry is ignored in `enter_finally_block`'s call to `emit_leave_handler`, but not in the one in `emit_break`.  These changes should directly match flisp.

I think we're still missing some `pop_exception`s compared to flisp, but wanted to get this PR up given the other one.  As noted in the tests, I need to port https://github.com/JuliaLang/julia/pull/55876, which duplicates the finally block and only adds `pop_exception` to one copy.