### PR TITLE
Improve return type inferrability of `in` for homogeneous tuples

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1382,23 +1382,18 @@ in(x, itr::Any) = any(==(x), itr)
 
 # Specialized variant of in for Tuple, which can generate typed comparisons for each element
 # of the tuple, skipping values that are statically known to be != at compile time.
-in(x, itr::Tuple) = _in_tuple(x, itr, false)
+in(x, itr::Tuple) = _in_tuple(x, itr)
+
 # This recursive function will be unrolled at compiletime, and will not generate separate
 # llvm-compiled specializations for each step of the recursion.
-function _in_tuple(x, @nospecialize(itr::Tuple), anymissing::Bool)
+function _in_tuple(x, @nospecialize(itr::Tuple), result = false)
     @inline
-    # Base case
-    if isempty(itr)
-        return anymissing ? missing : false
-    end
-    # Recursive case
+    isempty(itr) && return result
     v = (itr[1] == x)
-    if ismissing(v)
-        anymissing = true
-    elseif v
+    if v === true
         return true
     end
-    return _in_tuple(x, tail(itr), anymissing)
+    return _in_tuple(x, tail(itr), result | v)
 end
 
 # fallback to the loop implementation after some number of arguments to avoid inference blowup

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -417,4 +417,10 @@ end
     let t = ntuple(x->'A', 10000);
         @test Base.infer_return_type(in, (Char,typeof(t))) == Bool
     end
+
+    @test Base.infer_return_type(in, (String,Tuple{Vararg{String}})) == Bool
+    @test Base.infer_return_type((Vector{String},)) do xs
+        "foo" in tuple(xs...)
+    end == Bool
+    @test Base.infer_return_type(in, (Symbol,Tuple{Vararg{String}})) == Bool
 end


### PR DESCRIPTION
Overload `_in_tuple` for `Tuple{Vararg{T}}` so that, when the element type `T` is known not to intersect `Missing`, the return type is pinned as `Bool` rather than `Union{Bool,Missing}`.

This is motivated by JET(LS), which reports diagnostics when a non-`Bool` value appears in a branch condition. Without this change, straightforward code like:

```julia
function get_valid_flags(xs::Vector{String})
    flags = tuple(xs...)
    "flag" in flags ? flags : nothing  # non-boolean `Missing` found in boolean context (1/2 union split)
end
```
because the inferred return type of
`::String in ::Tuple{Vararg{String}}` is currently `Union{Bool,Missing}`, even though elements are all `String` and it's trivially clear that it never returns `missing`.

Implementation notes:
- Rather than adding a new `in` method for `Tuple{Vararg{T}}`, this overloads `_in_tuple` instead. Adding a separate `::Any in ::Tuple{Vararg{T}}` method would increase the number of methods matching `x::Any in itr::Tuple` from 3 to 4, potentially degrading inferrability at abstract call sites.
- The additional `hasintersect(T, Missing)` would no runtime cost: the added `_in_tuple` is only compiled for concrete `T`, and in that case the `typeintersect` result will be statically inlined.