### PR TITLE
cmd: allow mixed value types in environment variable pairs

### DIFF
--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -322,7 +322,7 @@ byteenv(env::AbstractArray{<:AbstractString}) =
 byteenv(env::AbstractDict) =
     String[cstr(string(k)*"="*string(v)) for (k,v) in env]
 byteenv(env::Nothing) = nothing
-byteenv(env::Union{AbstractVector{Pair{T,V}}, Tuple{Vararg{Pair{T,V}}}}) where {T<:AbstractString,V} =
+byteenv(env::Union{AbstractVector{<:Pair{<:AbstractString}}, Tuple{Vararg{Pair{<:AbstractString}}}}) =
     String[cstr(k*"="*string(v)) for (k,v) in env]
 
 """

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -344,7 +344,6 @@ end
         pop!(need_to_handle_undef_sparam, first(methods(Base.same_names)))
         @test_broken isempty(need_to_handle_undef_sparam)
         pop!(need_to_handle_undef_sparam, which(Base._cat, Tuple{Any, AbstractArray}))
-        pop!(need_to_handle_undef_sparam, which(Base.byteenv, (Union{AbstractArray{Pair{T,V}, 1}, Tuple{Vararg{Pair{T,V}}}} where {T<:AbstractString,V},)))
         pop!(need_to_handle_undef_sparam, which(Base.float, Tuple{AbstractArray{Union{Missing, T},N} where {T, N}}))
         @test isempty(need_to_handle_undef_sparam)
     end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -730,6 +730,11 @@ end
 @test Cmd(`foo`, env=["A"=>true]).env     == ["A=true"]
 @test Cmd(`foo`, env=nothing).env         === nothing
 
+# mixed value types in env pairs (#56780)
+@test Cmd(`foo`, env=("A"=>1, "B"=>"two")).env == ["A=1", "B=two"]
+@test Cmd(`foo`, env=["A"=>1, "B"=>"two"]).env == ["A=1", "B=two"]
+@test setenv(`foo`, "A"=>1, "B"=>"two").env    == ["A=1", "B=two"]
+
 # uid/gid - exercise code path with current effective ids (doesn't test privilege change)
 if !Sys.iswindows()
     @test success(setuid(setgid(`$(Base.julia_cmd()) -e "exit(0)"`, Libc.getegid()), Libc.geteuid()))


### PR DESCRIPTION
Fixes #56780.
Relaxes the `byteenv` type constraint from `Pair{T,V} where {T<:AbstractString, V}` to `Pair{<:AbstractString}`, allowing heterogeneous value types in env pairs.