### PR TITLE
change the granularity of timing printing in precompilation.

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -188,7 +188,8 @@ function printpkgstyle(io, header, msg; color=:green)
     end
 end
 
-timing_string(t) = string(lpad(round(t * 1e3, digits = 1), 9), " ms")
+_timing_string(t) = string(lpad(round(t, digits = 1), 9), " s")
+
 
 function color_string(cstr::String, col::Union{Int64, Symbol}, hascolor)
     if hascolor

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -188,7 +188,7 @@ function printpkgstyle(io, header, msg; color=:green)
     end
 end
 
-_timing_string(t) = string(lpad(round(t, digits = 1), 9), " s")
+timing_string(t) = string(lpad(round(t, digits = 1), 6), " s")
 
 
 function color_string(cstr::String, col::Union{Int64, Symbol}, hascolor)


### PR DESCRIPTION
 Showing up to tenth of millisecond is a bit excessive:

```
418445.8 ms  ✓ ModelingToolkitBase
 379875.4 ms  ✓ SymbolicUtils
 308874.9 ms  ✓ ModelingToolkit
 149406.0 ms  ✓ Symbolics
 148008.7 ms  ✓ NonlinearSolve
 136059.7 ms  ✓ OrdinaryDiffEqVerner
 114315.9 ms  ✓ NonlinearSolveFirstOrder
 ```

Now instead:

```
      0.9 s  ✓ PrecompileTools
      0.9 s  ✓ SimpleTraits
      0.9 s  ✓ JLLWrappers
      1.2 s  ✓ FilePathsBase → FilePathsBaseMmapExt
      1.8 s  ✓ DataStructures
```
