### PR TITLE
codegen: emit bounds checks as cold branches instead of ANDs

### DIFF
--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -151,8 +151,14 @@ end
     end
 
     (src, _) = only(code_typed(sum27403, Tuple{Vector{Int}}))
+    is_bounds_throw_invoke_target(@nospecialize(callee)) =
+        callee === Base.throw_boundserror ||
+        callee == Core.GlobalRef(Base, :throw_boundserror) ||
+        callee == Core.GlobalRef(Base, :_throw_boundserror_indices) ||
+        (callee isa Core.MethodInstance && (callee.def.def.name === :throw_boundserror ||
+                                            callee.def.def.name === :_throw_boundserror_indices))
     @test !any(src.code) do x
-        x isa Expr && x.head === :invoke && !(x.args[2] in (Core.GlobalRef(Base, :throw_boundserror), Base.throw_boundserror))
+        x isa Expr && x.head === :invoke && !is_bounds_throw_invoke_target(x.args[2])
     end
 end
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -721,7 +721,7 @@ See also [`checkbounds`](@ref).
 """
 function checkbounds_indices(::Type{Bool}, inds::Tuple, I::Tuple{Any, Vararg})
     @inline
-    return checkindex(Bool, get(inds, 1, OneTo(1)), I[1])::Bool &
+    return checkindex(Bool, get(inds, 1, OneTo(1)), I[1])::Bool &&
         checkbounds_indices(Bool, safe_tail(inds), tail(I))
 end
 

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -631,12 +631,12 @@ to_index(Is::Tuple{Any}) = Is[1]
 to_index(Is::Tuple) = CartesianIndex(Is)
 
 @inline function Base.checkbounds(bc::Broadcasted, I::CartesianIndex)
-    Base.checkbounds_indices(Bool, axes(bc), (I,)) || Base.throw_boundserror(bc, (I,))
+    Base.checkbounds_indices(Bool, axes(bc), (I,)) || Base.throw_boundserror(bc, I)
     nothing
 end
 
 @inline function Base.checkbounds(bc::Broadcasted, I::Integer)
-    Base.checkindex(Bool, eachindex(IndexLinear(), bc), I) || Base.throw_boundserror(bc, (I,))
+    Base.checkindex(Bool, eachindex(IndexLinear(), bc), I) || Base.throw_boundserror(bc, I)
     nothing
 end
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -12,8 +12,11 @@ blackbox(x) = compilerbarrier(:blackbox, x)
 size(a::Array) = getfield(a, :size)
 length(t::AbstractArray) = (@inline; prod(size(t)))
 size(a::GenericMemory) = (getfield(a, :length),)
+throw_boundserror(A) = (@noinline; throw(BoundsError(A, ())))
 throw_boundserror(A, I) = (@noinline; throw(BoundsError(A, I)))
 throw_boundserror(A, i1, i2, I...) = (@noinline; throw(BoundsError(A, (i1, i2, I...))))
+_throw_boundserror_indices(A) = (@noinline; throw(BoundsError(A, ())))
+_throw_boundserror_indices(A, i1, I...) = (@noinline; throw(BoundsError(A, (i1, I...))))
 
 # multidimensional getindex will be defined later on
 
@@ -385,7 +388,7 @@ function checkbounds(::Type{Bool}, A::Union{Array, Memory}, i::Int)
 end
 function checkbounds(A::AbstractArray, I...)
     @inline
-    checkbounds(Bool, A, I...) || throw_boundserror(A, I...)
+    checkbounds(Bool, A, I...) || _throw_boundserror_indices(A, I...)
     nothing
 end
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -13,6 +13,7 @@ size(a::Array) = getfield(a, :size)
 length(t::AbstractArray) = (@inline; prod(size(t)))
 size(a::GenericMemory) = (getfield(a, :length),)
 throw_boundserror(A, I) = (@noinline; throw(BoundsError(A, I)))
+throw_boundserror(A, i1, i2, I...) = (@noinline; throw(BoundsError(A, (i1, i2, I...))))
 
 # multidimensional getindex will be defined later on
 
@@ -384,7 +385,7 @@ function checkbounds(::Type{Bool}, A::Union{Array, Memory}, i::Int)
 end
 function checkbounds(A::AbstractArray, I...)
     @inline
-    checkbounds(Bool, A, I...) || throw_boundserror(A, I)
+    checkbounds(Bool, A, I...) || throw_boundserror(A, I...)
     nothing
 end
 

--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -272,7 +272,7 @@ end
 
 function setindex!(A::Memory{T}, x, i1::Int, i2::Int, I::Int...) where {T}
     @inline
-    @boundscheck (i2 == 1 && all(==(1), I)) || throw_boundserror(A, (i1, i2, I...))
+    @boundscheck (i2 == 1 && all(==(1), I)) || throw_boundserror(A, i1, i2, I...)
     setindex!(A, x, i1)
 end
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -759,12 +759,12 @@ end
 # Here we try to consume N of the indices (if there are that many available)
 @inline function checkbounds_indices(::Type{Bool}, inds::Tuple, I::Tuple{CartesianIndex,Vararg})
     inds1, rest = IteratorsMD.split(inds, Val(length(I[1])))
-    checkindex(Bool, inds1, I[1]) & checkbounds_indices(Bool, rest, tail(I))
+    checkindex(Bool, inds1, I[1]) && checkbounds_indices(Bool, rest, tail(I))
 end
 @inline checkindex(::Type{Bool}, inds::Tuple, I::CartesianIndex) =
     checkbounds_indices(Bool, inds, I.I)
 @inline checkindex(::Type{Bool}, inds::Tuple, i::AbstractRange{<:CartesianIndex}) =
-    isempty(i) | (checkindex(Bool, inds, first(i)) & checkindex(Bool, inds, last(i)))
+    isempty(i) | (checkindex(Bool, inds, first(i)) && checkindex(Bool, inds, last(i)))
 
 # Indexing into Array with mixtures of Integers and CartesianIndices is
 # extremely performance-sensitive. While the abstract fallbacks support this,
@@ -781,7 +781,7 @@ end
 # Here we try to consume N of the indices (if there are that many available)
 @inline function checkbounds_indices(::Type{Bool}, inds::Tuple, I::Tuple{AbstractArray{CartesianIndex{N}},Vararg}) where N
     inds1, rest = IteratorsMD.split(inds, Val(N))
-    checkindex(Bool, inds1, I[1]) & checkbounds_indices(Bool, rest, tail(I))
+    checkindex(Bool, inds1, I[1]) && checkbounds_indices(Bool, rest, tail(I))
 end
 @inline checkindex(::Type{Bool}, inds::Tuple, I::CartesianIndices) =
     checkbounds_indices(Bool, inds, I.indices)
@@ -907,12 +907,12 @@ checkbounds(::Type{Bool}, A::AbstractArray, i::AbstractVector{Bool}) =
     checkindex(Bool, eachindex(IndexLinear(), A), i)
 @inline function checkbounds_indices(::Type{Bool}, inds::Tuple, I::Tuple{AbstractArray{Bool},Vararg})
     inds1, rest = IteratorsMD.split(inds, Val(ndims(I[1])))
-    checkindex(Bool, inds1, I[1]) & checkbounds_indices(Bool, rest, tail(I))
+    checkindex(Bool, inds1, I[1]) && checkbounds_indices(Bool, rest, tail(I))
 end
 checkindex(::Type{Bool}, inds::AbstractUnitRange, I::AbstractVector{Bool}) = axes1(I) == inds
 checkindex(::Type{Bool}, inds::AbstractUnitRange, I::AbstractRange{Bool}) = axes1(I) == inds
 checkindex(::Type{Bool}, inds::Tuple, I::AbstractArray{Bool}) = _check_boolean_axes(inds, axes(I))
-_check_boolean_axes(inds::Tuple, axes::Tuple) = (inds[1] == axes[1]) & _check_boolean_axes(tail(inds), tail(axes))
+_check_boolean_axes(inds::Tuple, axes::Tuple) = (inds[1] == axes[1]) && _check_boolean_axes(tail(inds), tail(axes))
 _check_boolean_axes(::Tuple{}, axes::Tuple) = all(==(OneTo(1)), axes)
 
 ensure_indexable(I::Tuple{}) = ()

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2243,7 +2243,9 @@ static Value *emit_bounds_check(jl_codectx_t &ctx, const jl_cgval_t &ainfo, jl_v
         setName(ctx.emission_context, ok, "boundscheck");
         BasicBlock *failBB = BasicBlock::Create(ctx.builder.getContext(), "fail", ctx.f);
         BasicBlock *passBB = BasicBlock::Create(ctx.builder.getContext(), "pass");
-        ctx.builder.CreateCondBr(ok, passBB, failBB);
+        MDBuilder MDB(ctx.builder.getContext());
+        SmallVector<uint32_t, 2> Weights{2000, 1};
+        ctx.builder.CreateCondBr(ok, passBB, failBB, MDB.createBranchWeights(Weights));
         ctx.builder.SetInsertPoint(failBB);
         if (!ty) { // jl_value_t** tuple (e.g. the vararg)
             ctx.builder.CreateCall(prepare_call(jlvboundserror_func), { ainfo.V, len, i });
@@ -4945,7 +4947,9 @@ static jl_cgval_t emit_memoryref_direct(jl_codectx_t &ctx, const jl_cgval_t &mem
         Value *mlen = emit_genericmemorylen(ctx, boxmem, typ);
         Value *inbound = ctx.builder.CreateICmpULT(idx0, mlen);
         setName(ctx.emission_context, inbound, "memoryref_isinbounds");
-        ctx.builder.CreateCondBr(inbound, endBB, failBB);
+        MDBuilder MDB(ctx.builder.getContext());
+        SmallVector<uint32_t, 2> Weights{2000, 1};
+        ctx.builder.CreateCondBr(inbound, endBB, failBB, MDB.createBranchWeights(Weights));
         failBB->insertInto(ctx.f);
         ctx.builder.SetInsertPoint(failBB);
         ctx.builder.CreateCall(prepare_call(jlboundserror_func),
@@ -5031,7 +5035,9 @@ static jl_cgval_t emit_memoryref(jl_codectx_t &ctx, const jl_cgval_t &ref, jl_cg
             Value *mlen = emit_genericmemorylen(ctx, mem, ref.typ);
             Value *inbound = ctx.builder.CreateICmpULT(newdata, mlen);
             setName(ctx.emission_context, offset, "memoryref_isinbounds");
-            ctx.builder.CreateCondBr(inbound, endBB, failBB);
+            MDBuilder MDB(ctx.builder.getContext());
+            SmallVector<uint32_t, 2> Weights{2000, 1};
+            ctx.builder.CreateCondBr(inbound, endBB, failBB, MDB.createBranchWeights(Weights));
             failBB->insertInto(ctx.f);
             ctx.builder.SetInsertPoint(failBB);
             ctx.builder.CreateCall(prepare_call(jlboundserror_func),
@@ -5076,26 +5082,34 @@ static jl_cgval_t emit_memoryref(jl_codectx_t &ctx, const jl_cgval_t &ref, jl_cg
             endBB = BasicBlock::Create(ctx.builder.getContext(), "idxend");
             Value *mlen = emit_genericmemorylen(ctx, mem, ref.typ);
             Value *mptr = emit_genericmemoryptr(ctx, mem, layout, 0);
+            MDBuilder MDB(ctx.builder.getContext());
+            SmallVector<uint32_t, 2> Weights{2000, 1};
 #if 0
             Value *mend = mptr;
             Value *blen = ctx.builder.CreateMul(mlen, elsz, "", true, true);
             mend = ctx.builder.CreateInBoundsGEP(getInt8Ty(ctx.builder.getContext()), mptr, blen);
+            Value *notovflw = ctx.builder.CreateNot(ovflw);
+            BasicBlock *boundscheckBB = BasicBlock::Create(ctx.builder.getContext(), "boundscheck");
+            ctx.builder.CreateCondBr(notovflw, boundscheckBB, failBB, MDB.createBranchWeights(Weights));
+            boundscheckBB->insertInto(ctx.f);
+            ctx.builder.SetInsertPoint(boundscheckBB);
             Value *inbound = ctx.builder.CreateAnd(
                     ctx.builder.CreateICmpULE(mptr, newdata),
                     ctx.builder.CreateICmpULT(newdata, mend));
-            inbound = ctx.builder.CreateAnd(
-                    ctx.builder.CreateNot(ovflw),
-                    inbound);
 #elif 1
             Value *bidx0 = ctx.builder.CreateSub(
                 ctx.builder.CreatePtrToInt(newdata, ctx.types().T_size),
                 ctx.builder.CreatePtrToInt(mptr, ctx.types().T_size));
             Value *blen = ctx.builder.CreateMul(mlen, elsz, "", true, true);
             setName(ctx.emission_context, blen, "memoryref_bytelen");
+            Value *notovflw = ctx.builder.CreateNot(ovflw);
+            setName(ctx.emission_context, notovflw, "memoryref_notovflw");
+            BasicBlock *boundscheckBB = BasicBlock::Create(ctx.builder.getContext(), "boundscheck");
+            ctx.builder.CreateCondBr(notovflw, boundscheckBB, failBB, MDB.createBranchWeights(Weights));
+            boundscheckBB->insertInto(ctx.f);
+            ctx.builder.SetInsertPoint(boundscheckBB);
             Value *inbound = ctx.builder.CreateICmpULT(bidx0, blen);
             setName(ctx.emission_context, inbound, "memoryref_isinbounds");
-            inbound = ctx.builder.CreateAnd(ctx.builder.CreateNot(ovflw), inbound);
-            setName(ctx.emission_context, inbound, "memoryref_isinbounds&notovflw");
 #else
             Value *idx0; // (newdata - mptr) / elsz
             idx0 = ctx.builder.CreateSub(
@@ -5104,7 +5118,7 @@ static jl_cgval_t emit_memoryref(jl_codectx_t &ctx, const jl_cgval_t &ref, jl_cg
             idx0 = ctx.builder.CreateExactUDiv(idx0, elsz);
             Value *inbound = ctx.builder.CreateICmpULT(idx0, mlen);
 #endif
-            ctx.builder.CreateCondBr(inbound, endBB, failBB);
+            ctx.builder.CreateCondBr(inbound, endBB, failBB, MDB.createBranchWeights(Weights));
             failBB->insertInto(ctx.f);
             ctx.builder.SetInsertPoint(failBB);
             ctx.builder.CreateCall(prepare_call(jlboundserror_func),


### PR DESCRIPTION
For reference the big win here is that this allows for loop unswitch to trigger since it doesn't really understand our `and` sequence


## Summary

- Replace AND-combined bounds check conditions with separate branches annotated with branch weight metadata (2000:1) to mark the error path as cold in LLVM codegen (`emit_bounds_check`, `emit_memoryref_direct`, `emit_memoryref`)
- Change `checkbounds_indices` to use `&&` instead of `&` so each dimension check becomes its own branch rather than being combined into a single AND chain
- Change `throw_boundserror` to accept varargs for multi-index cases, so the index tuple is only constructed inside the `@noinline` error path rather than on the hot path

For a 2D array access `A[i, j]`, the net effect is:
- **Before**: one AND-combined branch + `alloca` for index tuple in the entry block
- **After**: two separate cold-annotated branches per dimension, zero tuple allocation on the hot path

Before:
```llvm
  %"new::Tuple" = alloca [2 x i64], align 8
  store i64 %"i::Int64", ptr %"new::Tuple", align 8
  store i64 %"j::Int64", ptr %0, align 8
  ...
  %.not = icmp ult i64 %0, %"x::Array.size.0"
  %1 = icmp ult i64 %2, %"x::Array.size.1"
  %combined = and i1 %.not, %1
  br i1 %combined, label %pass, label %fail
```

After:
```llvm
  %.not = icmp ult i64 %0, %"x::Array.size.sroa.0.0.copyload"
  br i1 %.not, label %L27, label %L29

L27:
  %.not10.not = icmp ult i64 %1, %"x::Array.size.sroa.2.0.copyload"
  br i1 %.not10.not, label %L32, label %L29

L29:
  call void @j_throw_boundserror_1(ptr %"x::Array", i64 %"i::Int64", i64 %"j::Int64")
  unreachable
```

## Test plan

- [x] Full `make -j8` build succeeds including sysimage precompilation
- [x] Verified LLVM IR output shows separate branches per dimension for `A[i, j]`
- [x] Verified tuple `alloca` is eliminated from the hot path
- [x] Verified single-index `A[i]` still works correctly (no tuple wrapping)
- [x] Verified `BoundsError` messages are unchanged at runtime
- [ ] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)