### PR TITLE
Consistently disallow `:static_parameter` in argument position

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3143,11 +3143,7 @@ function abstract_eval_special_value(interp::AbstractInterpreter, @nospecialize(
 end
 
 function abstract_eval_value_expr(interp::AbstractInterpreter, e::Expr, sv::AbsIntState)
-    if e.head === :static_parameter
-        rt = abstract_eval_static_parameter(interp, e, sv)
-        merge_effects!(interp, sv, rt.effects)
-        return rt.rt
-    elseif e.head === :call && length(e.args) ≥ 1
+    if e.head === :call && length(e.args) ≥ 1
         # TODO: We still have non-linearized cglobal
         @assert e.args[1] === Core.tuple || e.args[1] === GlobalRef(Core, :tuple)
     else

--- a/Compiler/src/ssair/ir.jl
+++ b/Compiler/src/ssair/ir.jl
@@ -153,7 +153,7 @@ end
 function is_valid_phiblock_stmt(@nospecialize(stmt))
     isa(stmt, PhiNode) && return true
     isa(stmt, Union{UpsilonNode, PhiCNode, SSAValue}) && return false
-    isa(stmt, Expr) && return is_value_pos_expr_head(stmt.head)
+    isa(stmt, Expr) && return false
     return true
 end
 

--- a/Compiler/src/ssair/verify.jl
+++ b/Compiler/src/ssair/verify.jl
@@ -26,7 +26,6 @@ if !isdefined(@__MODULE__, Symbol("@verify_error"))
 end
 
 is_toplevel_expr_head(head::Symbol) = head === :method || head === :thunk
-is_value_pos_expr_head(head::Symbol) = head === :static_parameter
 function check_op(ir::IRCode, domtree::DomTree, @nospecialize(op), use_bb::Int, use_idx::Int, printed_use_idx::Int, print::Bool, isforeigncall::Bool, arg_idx::Int,
     allow_frontend_forms::Bool, @nospecialize(raise_error))
     if isa(op, SSAValue)
@@ -336,16 +335,14 @@ function verify_ir(ir::IRCode, print::Bool=true,
         end
 
         if is_phinode_block && !is_valid_phiblock_stmt(stmt)
-            if !isa(stmt, Expr) || !is_value_pos_expr_head(stmt.head)
-                # Go back and check that all non-PhiNodes are valid value-position
-                for validate_idx in firstidx:(lastphi-1)
-                    validate_stmt = ir[SSAValue(validate_idx)][:stmt]
-                    isa(validate_stmt, PhiNode) && continue
-                    check_op(ir, domtree, validate_stmt, bb, idx, idx, print, false, 0,
-                        allow_frontend_forms, raise_error)
-                end
-                is_phinode_block = false
+            # Go back and check that all non-PhiNodes are valid value-position
+            for validate_idx in firstidx:(lastphi-1)
+                validate_stmt = ir[SSAValue(validate_idx)][:stmt]
+                isa(validate_stmt, PhiNode) && continue
+                check_op(ir, domtree, validate_stmt, bb, idx, idx, print, false, 0,
+                         allow_frontend_forms, raise_error)
             end
+            is_phinode_block = false
         end
         if isa(stmt, PhiCNode)
             for i = 1:length(stmt.values)

--- a/Compiler/src/ssair/verify.jl
+++ b/Compiler/src/ssair/verify.jl
@@ -81,11 +81,9 @@ function check_op(ir::IRCode, domtree::DomTree, @nospecialize(op), use_bb::Int, 
             # Allow a tuple literal in symbol position for foreigncall - this
             # is syntax for a literal value or globalref - it is interpreted in
             # global scope by codegen.
-        elseif !is_value_pos_expr_head(op.head)
-            if !allow_frontend_forms || op.head !== :opaque_closure_method
-                @verify_error "Expr not allowed in value position"
-                raise_error()
-            end
+        elseif !allow_frontend_forms || op.head !== :opaque_closure_method
+            @verify_error "Expr not allowed in value position"
+            raise_error()
         end
     elseif isa(op, Union{OldSSAValue, NewSSAValue})
         @verify_error "At statement %$use_idx: Left over SSA marker ($op)"
@@ -381,9 +379,12 @@ function verify_ir(ir::IRCode, print::Bool=true,
                         @verify_error "malformed isdefined"
                         raise_error()
                     end
-                    if stmt.args[1] isa GlobalRef
-                        # undefined GlobalRef is OK in isdefined
-                        continue
+                    let v = stmt.args[1]
+                        # a GlobalRef or static_parameter isdefined check does
+                        # not evaluate its argument
+                        if v isa GlobalRef || isexpr(v, :static_parameter)
+                            continue
+                        end
                     end
                 elseif stmt.head === :throw_undef_if_not
                     if length(stmt.args) > 3
@@ -401,10 +402,6 @@ function verify_ir(ir::IRCode, print::Bool=true,
                     continue
                 elseif stmt.head === :foreigncall
                     isforeigncall = true
-                elseif stmt.head === :isdefined && length(stmt.args) == 1 &&
-                        isexpr(stmt.args[1], :static_parameter)
-                    # a GlobalRef or static_parameter isdefined check does not evaluate its argument
-                    continue
                 elseif stmt.head === :call
                     f = stmt.args[1]
                     if f isa GlobalRef && f.name === :cglobal

--- a/Compiler/src/validation.jl
+++ b/Compiler/src/validation.jl
@@ -242,7 +242,7 @@ is_valid_lvalue(@nospecialize(x)) = isa(x, SlotNumber) || isa(x, GlobalRef)
 
 function is_valid_argument(@nospecialize(x))
     if isa(x, SlotNumber) || isa(x, Argument) || isa(x, SSAValue) ||
-       isa(x, GlobalRef) || isa(x, QuoteNode) || (isa(x, Expr) && is_value_pos_expr_head(x.head))  ||
+       isa(x, GlobalRef) || isa(x, QuoteNode) ||
        isa(x, Number) || isa(x, AbstractString) || isa(x, AbstractChar) || isa(x, Tuple) ||
        isa(x, Type) || isa(x, Core.Box) || isa(x, Module) || x === nothing
         return true

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -6765,25 +6765,6 @@ let
     @test f(1, 2, 3) == (0, (0, (0, 1)))
 end
 
-# Expr(:static_parameter, ...) in argument position should be inferable
-function gen_static_parameter_argument_position(world::UInt, source, args...)
-    ci = make_codeinfo(Any[
-        ReturnNode(Expr(:static_parameter, 1))
-    ]; slottypes=Any[Any, Any])
-    ci.slotnames = Symbol[:var"#self#", :typ]
-    ci.nargs = 2
-    ci.isva = false
-    return ci
-end
-@eval function f_static_parameter_argument_position(typ::Type{T}) where T
-    $(Expr(:meta, :generated, gen_static_parameter_argument_position))
-    $(Expr(:meta, :generated_only))
-    #= no body =#
-end
-let result = code_typed(f_static_parameter_argument_position, Tuple{Type{Int}})
-    @test result[1].second === Type{Int}
-end
-
 # aviatesk/JETLS.jl/issues/618
 Base.@nospecializeinfer function jetls618(a, @nospecialize(rest...))
     if a > 0

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -190,6 +190,16 @@ let code = Any[
     @test_throws ["IR verification failed.", "Code location: "] Compiler.verify_ir(ir, false)
 end
 
+# Test that static_parameter in value position is non-canonical
+let code = Any[
+        Expr(:call, identity, Expr(:static_parameter, 1))
+        ReturnNode(SSAValue(1))
+    ]
+    ir = make_ircode(code; verify=false)
+    ir = Compiler.compact!(ir, true)
+    @test_throws ["IR verification failed.", "Code location: "] Compiler.verify_ir(ir, false)
+end
+
 # Issue #29107
 let code = Any[
         # Block 1

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -60,8 +60,6 @@ function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
         ident = newleaf(graph, src, K"Identifier")
         setattr!(ident, :name_val, String(e.args[1]::Symbol))
         setattr!(ident, :scope_layer, e.args[2])
-    elseif e isa Expr && e.head === :static_parameter
-        setattr!(newleaf(graph, src, K"Value"), :value, e)
     elseif e isa Expr && e.head === :lambda && length(e.args) == 2
         argnames = e.args[1]::Vector{Any}
         arg_cs = NodeId[]
@@ -600,6 +598,7 @@ function est_to_dst(st::SyntaxTree)
         [K"inbounds" _] -> newleaf(g, st, K"TOMBSTONE")
         [K"core" x] -> setattr!(mkleaf(st), :name_val, x.name_val)
         [K"top" x] -> setattr!(mkleaf(st), :name_val, x.name_val)
+        [K"static_parameter" x] -> setattr!(mkleaf(st), :var_id, x.value::IdTag)
         [K"copyast" [K"inert" ex]] -> @ast g st [K"call"
             interpolate_ast::K"Value"
             Expr::K"Value"

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -373,6 +373,9 @@ function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
             ir
         end
     elseif k == K"Value"
+        # TODO: we still do this in ccall, import
+        # @jl_assert !isa_lowering_ast_node(ex.value) (
+        #     ex, "smuggling AST through Value is asking for trouble; find a SyntaxTree representation")
         ex.value isa LineNumberNode ? QuoteNode(ex.value) : ex.value
     elseif k == K"goto"
         Core.GotoNode(ex[1].id + stmt_offset)

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -1,6 +1,7 @@
 #-------------------------------------------------------------------------------
 # Lowering pass 5: Flatten to linear IR
 
+# Must outline anything that can throw, e.g. globalrefs, static params
 function is_valid_ir_argument(ctx, ex)
     k = kind(ex)
     if is_simple_atom(ctx, ex) || k in KSet"inert inert_syntaxtree top core quote static_eval foreigncall_arg1"
@@ -9,11 +10,6 @@ function is_valid_ir_argument(ctx, ex)
         binfo = get_binding(ctx, ex)
         bk = binfo.kind
         bk === :slot
-        # TODO: We should theoretically be able to allow `bk ===
-        # :static_parameter` for slightly more compact IR, but it's uncertain
-        # what the compiler is built to tolerate.  Notably, flisp allows
-        # static_parameter, but doesn't produce this form until a later pass, so
-        # it doesn't end up in the IR.
     else
         false
     end

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -620,7 +620,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
             k == K"inert" || k == K"inert_syntaxtree" || k == K"top" ||
             k == K"core" || k == K"Value" || k == K"Symbol" ||
             k == K"SourceLocation" || k == K"static_eval" ||
-            k == K"foreigncall_arg1"
+            k == K"foreigncall_arg1" || k == K"static_parameter"
         ex1 = ex
         if kind(ex1) == K"BindingId"
             binfo = get_binding(ctx, ex1)

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -1155,7 +1155,7 @@ function _assert_syntaxtree(st::SyntaxTree, parents::Vector{NodeId}, vr)
             [K"latestworld_if_toplevel"] -> ()
             (_, when=JuliaSyntax.is_literal(st)) -> (:value,)
             (_, when=JuliaSyntax.is_trivia(st)) -> () # green tree only
-            (_, when=JuliaSyntax.is_operator(st)) -> (:name_val) # TODO: remove
+            (_, when=JuliaSyntax.is_operator(st)) -> (:name_val,) # TODO: remove
             _ -> return vr & @fail(st, "unrecognized leaf kind")
         end
     else

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -245,6 +245,7 @@ vst1(vcx::Validation1Context, st::SyntaxTree)::ValidationResult = @stm st begin
     #---------------------------------------------------------------------------
     # Forms not produced by the parser
     [K"ssavalue" [K"Value"]] -> pass()
+    [K"static_parameter" [K"Value"]] -> pass()
     [K"inert" _] -> pass()
     [K"inert_syntaxtree" _] -> pass()
     [K"core" [K"Identifier"]] -> pass()
@@ -1198,7 +1199,7 @@ end
 
 vst2(vcx::Validation2Context, st::SyntaxTree) = @stm st begin
     (_, when=is_leaf(st)) -> kind(st) in KSet"""
-    Identifier BindingId Placeholder nothing
+    Identifier BindingId Placeholder nothing static_parameter
     Bool Char Float Float32 BinInt OctInt HexInt Integer
     SourceLocation String Symbol Value core top
     latestworld latestworld_if_toplevel symbolicgoto oldsymbolicgoto symboliclabel TOMBSTONE

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -606,3 +606,36 @@ end
         end
     end
 end
+
+@testset "(static_parameter n) form as lowering input" begin
+    # function (::Type{T},) where T; return (sp 1); end
+    ex = Expr(:function,
+         Expr(:where,
+              Expr(:tuple, Expr(:(::), Expr(:curly, :Type, :T))),
+              :T),
+              Expr(:block, Expr(:return, Expr(:static_parameter, 1))))
+    local f
+    @test (f = fl_eval(test_mod, ex)) isa Function
+    @test f(String) == String
+    @test (f = jl_eval(test_mod, ex; expr_compat_mode=true)) isa Function
+    @test f(String) == String
+    @test (f = jl_eval(test_mod, ex; expr_compat_mode=false)) isa Function
+    @test f(String) == String
+
+    # function (x::T, y::U) where {T, U}; (x, y, (sp 1), (sp 2)); end
+    ex = Expr(:function,
+         Expr(:where,
+              Expr(:tuple, Expr(:(::), :x, :T), Expr(:(::), :y, :U)),
+              :T, :U),
+              Expr(:block,
+                   Expr(:return,
+                        Expr(:tuple, :x, :y,
+                             Expr(:static_parameter, 1),
+                             Expr(:static_parameter, 2)))))
+    @test (f = fl_eval(test_mod, ex)) isa Function
+    @test f(1, 'a') == (1, 'a', Int, Char)
+    @test (f = jl_eval(test_mod, ex; expr_compat_mode=true)) isa Function
+    @test f(1, 'a') == (1, 'a', Int, Char)
+    @test (f = jl_eval(test_mod, ex; expr_compat_mode=false)) isa Function
+    @test f(1, 'a') == (1, 'a', Int, Char)
+end

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -4666,8 +4666,7 @@ f(x) = yt(x)
 (define (valid-ir-argument? e)
   (or (simple-atom? e)
       (and (pair? e)
-           (memq (car e) '(quote inert top core
-                                 slot static_parameter)))))
+           (memq (car e) '(quote inert top core slot)))))
 
 (define (valid-ir-rvalue? lhs e)
   (or (ssavalue? lhs)


### PR DESCRIPTION
Undo https://github.com/JuliaLang/julia/pull/61511, and clean up flisp and IR validator cases where we previously considered this valid.

JL should now recognize `static_parameter` as a lowering input.  Both lowering implementations should now outline `static_parameter` unconditionally.

Fix https://github.com/JuliaLang/JuliaLowering.jl/issues/175