### PR TITLE
codegen: follow LLVM frontend tips for poison, lifetime, i1, and noundef

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3478,7 +3478,7 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
             emit_lockstate_value(ctx, needlock, false);
         return ret;
     }
-    else if (isa<UndefValue>(strct.V)) {
+    else if (isa<UndefValue>(strct.V) || isa<PoisonValue>(strct.V)) {
         return jl_cgval_t();
     }
     else {
@@ -3692,7 +3692,7 @@ static jl_value_t *static_constant_instance(const llvm::DataLayout &DL, Constant
     assert(constant != NULL && jl_is_concrete_type(jt));
     jl_datatype_t *jst = (jl_datatype_t*)jt;
 
-    if (isa<UndefValue>(constant))
+    if (isa<UndefValue>(constant) || isa<PoisonValue>(constant))
         return NULL;
 
     if (ConstantInt *cint = dyn_cast<ConstantInt>(constant)) {
@@ -3883,7 +3883,7 @@ static Value *compute_box_tindex(jl_codectx_t &ctx, const jl_cgval_t &val, jl_va
 static Value *compute_tindex_unboxed(jl_codectx_t &ctx, const jl_cgval_t &val, jl_value_t *typ, bool maybenull=false)
 {
     if (val.typ == jl_bottom_type)
-        return UndefValue::get(getInt8Ty(ctx.builder.getContext()));
+        return PoisonValue::get(getInt8Ty(ctx.builder.getContext()));
     if (val.constant)
         return ConstantInt::get(getInt8Ty(ctx.builder.getContext()), get_box_tindex((jl_datatype_t*)jl_typeof(val.constant), typ));
     if (val.TIndex)
@@ -4098,8 +4098,8 @@ static Value *boxed(jl_codectx_t &ctx, const jl_cgval_t &vinfo, bool is_promotab
 {
     jl_value_t *jt = vinfo.typ;
     if (jt == jl_bottom_type || jt == NULL)
-        // We have an undef value on a (hopefully) dead branch
-        return UndefValue::get(ctx.types().T_prjlvalue);
+        // We have a poison value on a (hopefully) dead branch
+        return PoisonValue::get(ctx.types().T_prjlvalue);
     if (vinfo.constant)
         return track_pjlvalue(ctx, literal_pointer_val(ctx, vinfo.constant));
     // This can happen in early bootstrap for `gc_preserve_begin` return value.
@@ -4156,9 +4156,10 @@ static Value *boxed(jl_codectx_t &ctx, const jl_cgval_t &vinfo, bool is_promotab
 static void emit_unionmove(jl_codectx_t &ctx, Value *dest, jl_value_t *desttype,
         MDNode *tbaa_dst, const jl_cgval_t &src, Value *tindex, Value *skip, bool isVolatile)
 {
-    if (AllocaInst *ai = dyn_cast<AllocaInst>(dest))
-        // TODO: make this a lifetime_end & dereferenceable annotation?
-        ctx.builder.CreateAlignedStore(UndefValue::get(ai->getAllocatedType()), ai, ai->getAlign());
+    if (isa<AllocaInst>(dest)) {
+        ctx.builder.CreateLifetimeEnd(dest);
+        ctx.builder.CreateLifetimeStart(dest);
+    }
     auto dest_ai = jl_aliasinfo_t::fromTBAA(ctx, tbaa_dst);
     if (src.constant) {
         jl_value_t *typ = jl_typeof(src.constant);
@@ -4439,7 +4440,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                     strct = Constant::getNullValue(lt);
                 }
                 else {
-                    strct = UndefValue::get(lt);
+                    strct = PoisonValue::get(lt);
                     if (nargs < nf)
                         strct = ctx.builder.CreateFreeze(strct); // Change this to zero initialize instead?
                 }
@@ -4692,7 +4693,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
         bool isboxed;
         Type *lt = julia_type_to_llvm(ctx, ty, &isboxed);
         assert(!isboxed);
-        return mark_julia_type(ctx, ctx.builder.CreateFreeze(UndefValue::get(lt)), false, ty);
+        return mark_julia_type(ctx, ctx.builder.CreateFreeze(PoisonValue::get(lt)), false, ty);
     }
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2617,14 +2617,14 @@ static void store_def_flag(jl_codectx_t &ctx, const jl_varinfo_t &vi, bool val)
 {
     assert((!vi.boxroot || vi.pTIndex) && "undef check is null pointer for boxed things");
     assert(vi.usedUndef && vi.defFlag && "undef flag codegen corrupted");
-    ctx.builder.CreateStore(ConstantInt::get(getInt1Ty(ctx.builder.getContext()), val), vi.defFlag, vi.isVolatile);
+    ctx.builder.CreateStore(ConstantInt::get(getInt8Ty(ctx.builder.getContext()), val), vi.defFlag, vi.isVolatile);
 }
 
 static void alloc_def_flag(jl_codectx_t &ctx, jl_varinfo_t& vi)
 {
     assert((!vi.boxroot || vi.pTIndex) && "undef check is null pointer for boxed things");
     if (vi.usedUndef) {
-        vi.defFlag = emit_static_alloca(ctx, getInt1Ty(ctx.builder.getContext()), Align(1));
+        vi.defFlag = emit_static_alloca(ctx, getInt8Ty(ctx.builder.getContext()), Align(1));
         setName(ctx.emission_context, vi.defFlag, "isdefined");
         store_def_flag(ctx, vi, false);
     }
@@ -3713,7 +3713,7 @@ static Value *emit_bits_compare(jl_codectx_t &ctx, const jl_cgval_t &arg1, const
 {
     ++EmittedBitsCompares;
     if (arg1.typ == jl_bottom_type || arg2.typ == jl_bottom_type)
-        return UndefValue::get(getInt1Ty(ctx.builder.getContext()));
+        return PoisonValue::get(getInt1Ty(ctx.builder.getContext()));
 
     jl_value_t *argty = (arg1.constant ? jl_typeof(arg1.constant) : arg1.typ);
     bool isboxed;
@@ -5857,7 +5857,11 @@ static jl_cgval_t emit_isdefined(jl_codectx_t &ctx, jl_value_t *sym, int allow_i
             return mark_julia_const(ctx, jl_true);
         if (vi.boxroot == NULL || vi.pTIndex != NULL) {
             assert(vi.defFlag);
-            isnull = ctx.builder.CreateAlignedLoad(getInt1Ty(ctx.builder.getContext()), vi.defFlag, Align(1), vi.isVolatile);
+            // Load i8 and truncate to i1: LLVM recommends against loads/stores of
+            // non-byte-sized types like i1 (see Frontend/PerformanceTips.rst)
+            isnull = ctx.builder.CreateTrunc(
+                ctx.builder.CreateAlignedLoad(getInt8Ty(ctx.builder.getContext()), vi.defFlag, Align(1), vi.isVolatile),
+                getInt1Ty(ctx.builder.getContext()));
         }
         if (vi.boxroot != NULL) {
             Value *boxed = ctx.builder.CreateAlignedLoad(ctx.types().T_prjlvalue, vi.boxroot, Align(sizeof(void*)), vi.isVolatile);
@@ -5952,7 +5956,11 @@ static jl_cgval_t emit_varinfo(jl_codectx_t &ctx, jl_varinfo_t &vi, jl_sym_t *va
         }
         if (vi.usedUndef) {
             assert(vi.defFlag);
-            isnull = ctx.builder.CreateAlignedLoad(getInt1Ty(ctx.builder.getContext()), vi.defFlag, Align(1), vi.isVolatile);
+            // Load i8 and truncate to i1: LLVM recommends against loads/stores of
+            // non-byte-sized types like i1 (see Frontend/PerformanceTips.rst)
+            isnull = ctx.builder.CreateTrunc(
+                ctx.builder.CreateAlignedLoad(getInt8Ty(ctx.builder.getContext()), vi.defFlag, Align(1), vi.isVolatile),
+                getInt1Ty(ctx.builder.getContext()));
         }
     }
     if (vi.boxroot != NULL) {
@@ -6011,8 +6019,10 @@ static void emit_vi_assignment_unboxed(jl_codectx_t &ctx, jl_varinfo_t &vi, Valu
         assert(vi.inline_roots || vi.value.ispointer() || (vi.pTIndex && vi.value.V == NULL));
         assert(jl_egal(vi.value.typ, rval_info.typ));
         // store value
-        if (vi.pTIndex && vi.value.V) // TODO: use lifetime-end here instead
-            ctx.builder.CreateStore(UndefValue::get(cast<AllocaInst>(vi.value.V)->getAllocatedType()), vi.value.V);
+        if (vi.pTIndex && vi.value.V) {
+            ctx.builder.CreateLifetimeEnd(vi.value.V);
+            ctx.builder.CreateLifetimeStart(vi.value.V);
+        }
         // Sometimes we can get into situations where the LHS and RHS
         // are the same slot. We're not allowed to memcpy in that case
         // due to LLVM bugs.
@@ -6379,7 +6389,7 @@ static Value *emit_condition(jl_codectx_t &ctx, const jl_cgval_t &condV, const T
             track_pjlvalue(ctx, literal_pointer_val(ctx, jl_false)));
     }
     // not a boolean (unreachable dead code)
-    return UndefValue::get(getInt1Ty(ctx.builder.getContext()));
+    return PoisonValue::get(getInt1Ty(ctx.builder.getContext()));
 }
 
 static Value *emit_condition(jl_codectx_t &ctx, jl_value_t *cond, const Twine &msg)
@@ -8322,6 +8332,7 @@ jl_returninfo_t get_specsig_function(jl_codegen_output_t &out, Module *M, Value 
             param.addAttribute(Attribute::SwiftSelf);
         param.addAttribute("gcstack");
         param.addAttribute(Attribute::NonNull);
+        param.addAttribute(Attribute::NoUndef);
         attrs.push_back(AttributeSet::get(M->getContext(), param));
         fsig.push_back(PointerType::get(M->getContext(), 0));
         argnames.push_back("pgcstack_arg");
@@ -8341,6 +8352,7 @@ jl_returninfo_t get_specsig_function(jl_codegen_output_t &out, Module *M, Value 
                 continue;
         }
         AttrBuilder param(M->getContext());
+        param.addAttribute(Attribute::NoUndef);
         Type *ty = et;
         if (et == nullptr || et->isAggregateType()) { // aggregate types are passed by pointer
             addNoCaptureAttr(param);
@@ -9984,7 +9996,7 @@ static jl_llvm_functions_t
                 continue;
             ctx.builder.SetInsertPoint(FromBB->getTerminator());
             // PHI is undef on this branch. But still may need to put a valid pointer in place.
-            Value *RTindex = TindexN ? UndefValue::get(getInt8Ty(ctx.builder.getContext())) : NULL;
+            Value *RTindex = TindexN ? PoisonValue::get(getInt8Ty(ctx.builder.getContext())) : NULL;
             if (VN) {
                 Value *undef = undef_value_for_type(VN->getType());
                 VN->addIncoming(undef, FromBB);
@@ -10003,7 +10015,7 @@ static jl_llvm_functions_t
 
     for (PHINode *PN : ToDelete) {
         // This basic block is statically unreachable, thus so is this PHINode
-        PN->replaceAllUsesWith(UndefValue::get(PN->getType()));
+        PN->replaceAllUsesWith(PoisonValue::get(PN->getType()));
         PN->eraseFromParent();
     }
 

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -328,7 +328,7 @@ static Constant *undef_value_for_type(Type *T) {
         // make sure gc pointers (including ptr_phi of union-split) are initialized to NULL
         undef = Constant::getNullValue(T);
     else
-        undef = UndefValue::get(T);
+        undef = PoisonValue::get(T);
     return undef;
 }
 

--- a/test/llvmpasses/names.jl
+++ b/test/llvmpasses/names.jl
@@ -81,10 +81,10 @@ function fmemory(nel)
     return Memory{Int64}(undef,nel)
 end
 # CHECK-LABEL: define {{(swiftcc )?}}double @julia_f1
-# CHECK-SAME: double %"a::Float64"
-# CHECK-SAME: double %"b::Float64"
-# CHECK-SAME: double %"c::Float64"
-# CHECK-SAME: double %"d::Float64"
+# CHECK-SAME: double noundef %"a::Float64"
+# CHECK-SAME: double noundef %"b::Float64"
+# CHECK-SAME: double noundef %"c::Float64"
+# CHECK-SAME: double noundef %"d::Float64"
 
 # CHECK: fadd double
 # CHECK-DAG: %"a::Float64"
@@ -106,31 +106,31 @@ end
 emit(f1, Float64, Float64, Float64, Float64)
 
 # CHECK: define {{(swiftcc )?}}double @julia_f2
-# CHECK-SAME: double %"a::Float64"
-# CHECK-SAME: double %"b::Float64"
-# CHECK-SAME: double %"c::Float64"
-# CHECK-SAME: double %"d::Float64"
-# CHECK-SAME: double %"e[1]::Float64"
+# CHECK-SAME: double noundef %"a::Float64"
+# CHECK-SAME: double noundef %"b::Float64"
+# CHECK-SAME: double noundef %"c::Float64"
+# CHECK-SAME: double noundef %"d::Float64"
+# CHECK-SAME: double noundef %"e[1]::Float64"
 emit(f2, Float64, Float64, Float64, Float64, Float64)
 
 # CHECK: define {{(swiftcc )?}}double @julia_f2
-# CHECK-SAME: double %"a::Float64"
-# CHECK-SAME: double %"b::Float64"
-# CHECK-SAME: double %"c::Float64"
-# CHECK-SAME: double %"d::Float64"
-# CHECK-SAME: double %"e[1]::Float64"
-# CHECK-SAME: double %"e[2]::Float64"
+# CHECK-SAME: double noundef %"a::Float64"
+# CHECK-SAME: double noundef %"b::Float64"
+# CHECK-SAME: double noundef %"c::Float64"
+# CHECK-SAME: double noundef %"d::Float64"
+# CHECK-SAME: double noundef %"e[1]::Float64"
+# CHECK-SAME: double noundef %"e[2]::Float64"
 emit(f2, Float64, Float64, Float64, Float64, Float64, Float64)
 
 
 # CHECK: define {{(swiftcc )?}}double @julia_f2
-# CHECK-SAME: double %"a::Float64"
-# CHECK-SAME: double %"b::Float64"
-# CHECK-SAME: double %"c::Float64"
-# CHECK-SAME: double %"d::Float64"
-# CHECK-SAME: double %"e[1]::Float64"
-# CHECK-SAME: double %"e[2]::Float64"
-# CHECK-SAME: double %"e[3]::Float64"
+# CHECK-SAME: double noundef %"a::Float64"
+# CHECK-SAME: double noundef %"b::Float64"
+# CHECK-SAME: double noundef %"c::Float64"
+# CHECK-SAME: double noundef %"d::Float64"
+# CHECK-SAME: double noundef %"e[1]::Float64"
+# CHECK-SAME: double noundef %"e[2]::Float64"
+# CHECK-SAME: double noundef %"e[3]::Float64"
 emit(f2, Float64, Float64, Float64, Float64, Float64, Float64, Float64)
 
 # CHECK: define {{(swiftcc )?}}nonnull ptr @julia_f5


### PR DESCRIPTION
## Summary

Address several recommendations from LLVM's `Frontend/PerformanceTips.rst`:

- **UndefValue → PoisonValue** on dead/unreachable code paths. Poison enables more aggressive optimization. All sites verified safe: bottom-type dead code, statically unreachable PHI predecessors, or immediately frozen values. GC pointer paths stay null. Also updated two `isa<UndefValue>` checks to catch both undef and poison (they're sibling classes in LLVM 15+).

- **Lifetime intrinsics instead of poison stores** to clear allocas before overwrite (resolves two TODOs). `lifetime.end` + `lifetime.start` properly communicates that previous contents are dead, enabling dead store elimination.

- **defFlag i1 → i8** with truncate on load. LLVM recommends against loads/stores of non-byte-sized types.

- **noundef on all function parameters** and gcstack arg. Julia functions can never receive undefined arguments.

## Test plan

- [x] Full build succeeds
- [x] Runtime sanity tests pass (array indexing, bounds errors, isdefined checks, nothing comparisons)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)