### PR TITLE
fix aliasing of PermutedDimsArray

### DIFF
--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -50,6 +50,8 @@ Base.size(A::PermutedDimsArray{T,N,perm}) where {T,N,perm} = genperm(size(parent
 Base.axes(A::PermutedDimsArray{T,N,perm}) where {T,N,perm} = genperm(axes(parent(A)), perm)
 Base.has_offset_axes(A::PermutedDimsArray) = Base.has_offset_axes(A.parent)
 Base.similar(A::PermutedDimsArray, T::Type, dims::Base.Dims) = similar(parent(A), T, dims)
+Base.dataids(A::PermutedDimsArray) = Base.dataids(parent(A))
+Base.unaliascopy(A::PermutedDimsArray{T,N,perm}) where {T,N,perm} = PermutedDimsArray(copy(parent(A)), perm)
 Base.cconvert(::Type{Ptr{T}}, A::PermutedDimsArray{T}) where {T} = Base.cconvert(Ptr{T}, parent(A))
 
 # It's OK to return a pointer to the first element, and indeed quite

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -51,7 +51,7 @@ Base.axes(A::PermutedDimsArray{T,N,perm}) where {T,N,perm} = genperm(axes(parent
 Base.has_offset_axes(A::PermutedDimsArray) = Base.has_offset_axes(A.parent)
 Base.similar(A::PermutedDimsArray, T::Type, dims::Base.Dims) = similar(parent(A), T, dims)
 Base.dataids(A::PermutedDimsArray) = Base.dataids(parent(A))
-Base.unaliascopy(A::PermutedDimsArray{T,N,perm}) where {T,N,perm} = PermutedDimsArray(copy(parent(A)), perm)
+Base.unaliascopy(A::PermutedDimsArray) = typeof(A)(Base.unaliascopy(parent(A)))
 Base.cconvert(::Type{Ptr{T}}, A::PermutedDimsArray{T}) where {T} = Base.cconvert(Ptr{T}, parent(A))
 
 # It's OK to return a pointer to the first element, and indeed quite

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -1115,6 +1115,22 @@ end
     @test Base.mightalias(permutedims(V1), permutedims(V1))
 end
 
+@testset "aliasing with PermutedDimsArray" begin
+    A = rand(3, 3)
+    P = PermutedDimsArray(A, (2, 1))
+    B = rand(3, 3)
+    Q = PermutedDimsArray(B, (2, 1))
+    @test Base.mightalias(A, P)
+    @test Base.mightalias(P, A)
+    @test !Base.mightalias(A, Q)
+    @test !Base.mightalias(P, Q)
+
+    A = [1.0 2.0 3.0; 4.0 5.0 6.0; 7.0 8.0 9.0]
+    P = PermutedDimsArray(A, (2, 1))
+    expected = collect(P)
+    copyto!(A, P)
+    @test A == expected
+end
 
 @test @views quote var"begin" + var"end" end isa Expr
 


### PR DESCRIPTION
`dataids` was falling back to `objectid` which is wrong, as a `PermutedDimsArray` plainly aliases its parent