### PR TITLE
handle anonymous function docstrings gracefully

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -396,6 +396,9 @@ end
 
 function objectdoc(__source__, __module__, str, def, expr, sig = :(Union{}))
     @nospecialize str def expr sig
+    if isexpr(expr, :function) && isexpr((expr::Expr).args[1], :tuple)
+        return docerror(expr)
+    end
     binding = esc(bindingexpr(namify(expr)))
     docstr  = esc(docexpr(__source__, __module__, lazy_iterpolate(str), metadata(__source__, __module__, expr, false)))
     # Store the result of the definition and return it after documenting

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -447,6 +447,8 @@ end
 
 @test_throws ErrorException @doc("...", "error")
 @test_throws ErrorException @doc("...", @time 0)
+@test_throws "cannot document the following expression" @doc("...", function () end)
+@test_throws "cannot document the following expression" @doc("...", function (x) x end)
 
 # test that when no docs exist, they fallback to
 # the docs for the typeof(value)


### PR DESCRIPTION
closes #57524 

reproduced original example
```julia
julia> "abcdf" function () end
ERROR: cannot document the following expression:

function ()
    #= REPL[9]:1 =#
    #= REPL[9]:1 =#
end

Stacktrace:
 [1] error(::String, ::String)
   @ Base ./error.jl:56
 [2] top-level scope
   @ REPL[9]:1
```