### PR TITLE
[JuliaLowering] Fix-up `K"VERSION"` handling

### DIFF
--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -278,14 +278,16 @@ function expand_macro(ctx, ex)
     raw_args = ex[3:end]
     macro_loc = if kind(ex[2]) === K"Value"
         loc = ex[2].value
-        if loc isa LineNumberNode
-        # Some macros, e.g. @cmd, don't play nicely with file == nothing
-        isnothing(loc.file) ? LineNumberNode(loc.line, :none) : loc
-        elseif loc isa Core.MacroSource
-            loc.lno
+        if loc isa Core.MacroSource
+            loc
+        elseif loc isa LineNumberNode
+            # Some macros, e.g. @cmd, don't play nicely with file == nothing
+            isnothing(loc.file) ? LineNumberNode(loc.line, :none) : loc
         else
             LineNumberNode(0, :none)
         end
+    elseif kind(ex[2]) === K"VERSION"
+        Core.MacroSource(source_location(LineNumberNode, ex), ex[2].value)
     else
         LineNumberNode(0, :none)
     end
@@ -328,13 +330,8 @@ function expand_macro(ctx, ex)
         # method for new-style macro arguments.
         macro_args = Any[macro_loc, ctx.scope_layers[1].mod]
 
-        if length(raw_args) >= 1 && kind(raw_args[1]) === K"VERSION"
-            # Hack: see jl_invoke_julia_macro.  We may see an extra argument
-            # depending on who parsed this macrocall.
-            macro_args[1] = Core.MacroSource(macro_loc, raw_args[1].value)
-        end
-
         for arg in raw_args
+            @jl_assert kind(arg) !== K"VERSION" arg # handled in EST conversion
             # For hygiene in old-style macros, we omit any additional scope
             # layer information from macro arguments. Old-style macros will
             # handle that using manual escaping in the macro itself.
@@ -344,7 +341,7 @@ function expand_macro(ctx, ex)
             # new-style macros which call old-style macros. Instead of seeing
             # `Expr(:escape)` in such situations, old-style macros will now see
             # `Expr(:scope_layer)` inside `macro_args`.
-            kind(arg) !== K"VERSION" && push!(macro_args, est_to_expr(arg))
+            push!(macro_args, est_to_expr(arg))
         end
         expanded = try
             Base.invoke_in_world(ctx.macro_world, macfunc, macro_args...)
@@ -359,7 +356,8 @@ function expand_macro(ctx, ex)
             end
             rethrow(MacroExpansionError(mctx, ex, "Error expanding macro", :all, exc))
         end
-        expanded = expr_to_est(ex._graph, expanded, macro_loc)
+        macro_lnn = macro_loc isa Core.MacroSource ? macro_loc.lno : macro_loc
+        expanded = expr_to_est(ex._graph, expanded, macro_lnn)
     end
 
     if kind(expanded) != K"Value"

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -905,4 +905,15 @@ end
     # the following test needs to define this to be effective
     @test_throws UndefVarError JuliaLowering.include_string(test_mod, "invokelatest_target(1,2)")
     @test JuliaLowering.include_string(test_mod, "test_invokelatest()") === 3
+
+    for expr_compat_mode in (false, true),
+        version in (v"1.13", v"1.14")
+
+        _version = JuliaLowering.include_string(test_mod,
+            "Base.Experimental.@VERSION";
+            expr_compat_mode, version
+        )
+        @test _version isa NamedTuple
+        @test _version.syntax == version
+    end
 end


### PR DESCRIPTION
This shows up in the REPL tests: https://github.com/JuliaLang/julia/blob/f7ca35ebefbb1ba2bfb07bcc2007fe8ef5f12e86/stdlib/REPL/test/repl.jl#L2045

I realized I forgot to file it, but figured may as well fix directly