### PR TITLE
[JuliaLowering] Clean up `nothing` representation

### DIFF
--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -85,6 +85,7 @@ function JuliaSyntax.newleaf(ctx::AbstractLoweringContext,
 end
 
 function JuliaSyntax.newleaf(ctx, prov, k, @nospecialize(value))
+    @jl_assert k === K"Value" || value !== nothing (prov, "only Value may contain nothing")
     leaf = newleaf(ctx, prov, k)
     if k == K"Identifier" || k == K"core" || k == K"top" || k == K"Symbol" ||
             k == K"globalref" || k == K"Placeholder"
@@ -96,7 +97,7 @@ function JuliaSyntax.newleaf(ctx, prov, k, @nospecialize(value))
     elseif k == K"symboliclabel" || k == K"symbolicgoto"
         setattr!(leaf._graph, leaf._id, :name_val, value)
     elseif k in KSet"TOMBSTONE SourceLocation latestworld latestworld_if_toplevel
-                     softscope"
+                     softscope nothing"
         # no attributes
     else
         val = k == K"Integer" ? convert(Int,     value) :
@@ -119,8 +120,7 @@ JuliaSyntax.newnode(ctx::AbstractLoweringContext,
 
 # Convenience functions to create leaf nodes referring to identifiers within
 # the Core and Top modules.
-core_ref(ctx, ex, name) = newleaf(ctx, ex, K"core", name)
-nothing_(ctx, ex) = core_ref(ctx, ex, "nothing")
+nothing_(ctx, ex) = newleaf(ctx, ex, K"nothing")
 
 # Assign `ex` to an SSA variable.
 # Return (variable, assignment_node)
@@ -230,7 +230,8 @@ function _expand_ast_tree(ctx, srcref, tree, jl_line::QuoteNode)
             kindspec = tree.args[1]
         end
         let (kind, srcref, kws) = _match_kind(srcref, kindspec)
-            n = :(newleaf($ctx, $srcref, $kind, $val))
+            n = isnothing(val) ? :(newleaf($ctx, $srcref, $kind)) :
+                :(newleaf($ctx, $srcref, $kind, $val))
             for (attr, val) in kws
                 n = :(setattr!($n, $attr, $val))
             end
@@ -473,22 +474,15 @@ function is_valid_modref(ex)
            (kind(ex[1]) == K"Identifier" || is_valid_modref(ex[1]))
 end
 
-function is_core_ref(ex, name)
-    kind(ex) == K"core" && ex.name_val == name
-end
-
-function is_core_nothing(ex)
-    is_core_ref(ex, "nothing")
-end
-
 function is_core_Any(ex)
-    is_core_ref(ex, "Any")
+    kind(ex) === K"core" && ex.name_val::String === "Any"
 end
 
 function is_simple_atom(ctx, ex)
     k = kind(ex)
     # TODO thismodule
-    is_literal(k) || k == K"Symbol" || k == K"Value" || is_ssa(ctx, ex) || is_core_nothing(ex)
+    is_literal(k) || k == K"Symbol" || k == K"Value" || is_ssa(ctx, ex) ||
+        k == K"nothing"
 end
 
 function is_identifier_like(ex)

--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -98,7 +98,7 @@ function convert_for_type_decl(ctx, srcref, ex, type, do_typeassert)
         [K"=" tmp ex]
         [K"if"
             [K"call" "isa"::K"core" tmp type_tmp]
-            "nothing"::K"core"
+            (::K"nothing")
             [K"="
                 tmp
                 if do_typeassert
@@ -125,7 +125,7 @@ function make_globaldecl(ctx, src_ex, mod, name, strong=false, type=nothing)
             type
         ]
         (::K"latestworld")
-        "nothing"::K"core"
+        (::K"nothing")
     ]
     ctx.toplevel_pure && return newleaf(ctx, decl, K"TOMBSTONE")
     if !ctx.is_toplevel_seq_point
@@ -477,7 +477,7 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
         # method.  flisp might be messing up overlays when it does this, since
         # it removes all locals, not just closure ids.
         @ast ctx ex [K"method"
-            "nothing"::K"core"(ex[1])
+            (::K"nothing"(ex[1]))
             _convert_closures(ctx, ex[2])
             _convert_closures(ctx, ex[3])]
     elseif k == K"function_type"
@@ -533,7 +533,7 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
             ex[4] # return_upper_bound
             ex[5] # allow_partial
             [K"opaque_closure_method"
-                "nothing"::K"core"
+                (::K"nothing")
                 ex[6] # nargs
                 ex[7] # is_va
                 ex[8] # functionloc

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -46,15 +46,11 @@ isa_lowering_ast_node(@nospecialize(e)) =
 
 function is_expr_value(st::SyntaxTree)
     k = kind(st)
-    return JuliaSyntax.is_literal(k) || k === K"Value" ||
-        k === K"core" && get(st, :name_val, nothing) === "nothing"
+    return JuliaSyntax.is_literal(k) || k === K"Value"
 end
 
 function _expr_to_est(graph::SyntaxGraph, @nospecialize(e), src::LineNumberNode)
-    st = if e === Core.nothing
-        # e.value can't be nothing in `K"Value"`, so represent with K"core"
-        setattr!(newleaf(graph, src, K"core"), :name_val, "nothing")
-    elseif e isa Symbol
+    st = if e isa Symbol
         setattr!(newleaf(graph, src, K"Identifier"), :name_val, String(e))
     elseif e isa QuoteNode
         cid, _ = _expr_to_est(graph, e.value, src)
@@ -123,9 +119,7 @@ end
 # children.
 function est_to_expr(st::SyntaxTree, suppress_linenodes=false)
     k = kind(st)
-    return if k === K"core" && numchildren(st) === 0 && st.name_val === "nothing"
-        nothing
-    elseif kind(st) === K"Identifier"
+    if kind(st) === K"Identifier"
         n = Symbol(st.name_val::String)
         mod = get(st, :mod, nothing)
         !isnothing(mod) ? GlobalRef(mod, n) :
@@ -422,6 +416,7 @@ function est_to_dst(st::SyntaxTree)
 
     return @stm st begin
         [K"Identifier"] -> _est_to_dst_ident(st)
+        [K"Value"] -> st.value === nothing ? newleaf(g, st, K"nothing") : st
         (_, when=is_leaf(st)) -> st
         ([K"unknown_head" l r],
          when=(s=st.name_val; Base.isoperator(s))) -> let
@@ -585,7 +580,7 @@ function est_to_dst(st::SyntaxTree)
         ([K"meta" s vs...],
          when=(meta=get(s, :name_val, "")::String; meta in ("nospecialize", "specialize"))) ->
              # Should be handled in the function case
-             @ast g st "nothing"::K"core"
+             newleaf(g, st, K"nothing")
         [K"meta" syms...] ->
             @ast g st [K"meta" mapsyntax(
                 s->(kind(s) === K"Identifier" ? setattr(s, :kind, K"Symbol") : s),

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2050,7 +2050,7 @@ function expand_for(ctx, ex)
             [K"if"(iterspec) # if next !== nothing
                 [K"call"(iterspec)
                     "not_int"::K"top"
-                    [K"call" "==="::K"core" next "nothing"::K"core"]
+                    [K"call" "==="::K"core" next (::K"nothing")]
                 ]
                 [K"_do_while"(ex)
                     [K"block"
@@ -2060,7 +2060,7 @@ function expand_for(ctx, ex)
                     ]
                     [K"call"(iterspec)
                         "not_int"::K"top"
-                        [K"call" "==="::K"core" next "nothing"::K"core"]
+                        [K"call" "==="::K"core" next (::K"nothing")]
                     ]
                 ]
             ]
@@ -2389,7 +2389,9 @@ function prepend_function_body(ctx, body, ex)
             ex_est = @stm ex begin
                 [K"meta" [K"Symbol"] n] ->
                     @ast ctx ex [K"meta" "nkw"::K"Identifier" n]
-                [K"block" _...] -> ex # TODO
+                # TODO: need to handle destructuring arg assignments
+                [K"block" _... [K"nothing"]] ->
+                    newleaf(ctx, ex, K"Value", nothing)
                 _ -> @jl_assert false (ex, "unexpected prepend_function_body")
             end
             @ast ctx body [K"_generated_body"
@@ -2455,7 +2457,7 @@ end
 function generated_method_defs(ctx, src, mtable, sparams, argl, body, rett)
     @jl_assert kind(body) === K"_generated_body" && numchildren(body) == 2 body
     gen_name = let mangled = reserve_module_binding_i(
-        ctx.mod, "#$(is_core_nothing(mtable) ? "_" : mtable)@generator#")
+        ctx.mod, string("#", kind(mtable) === K"nothing" ? "_" : mtable, "@generator#"))
         new_global_binding(ctx, src, mangled, ctx.mod)
     end
 
@@ -2621,7 +2623,7 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
     ordered_defaults = any(val->contains_identifier(val, kw_names), kw_defaults)
     positional_sparams = used_typevars(pargl, sparams)
 
-    m1_name = let n = is_core_nothing(mtable) ? "_" : mtable.name_val,
+    m1_name = let n = kind(mtable) === K"nothing" ? "_" : mtable.name_val,
         mangled = string(startswith(n, '#') ? "" : "#kw_body#", n, "#")
         newsym(ctx, argl[1], reserve_module_binding_i(ctx.mod, mangled))
     end
@@ -2679,7 +2681,7 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
                 get_kw = @ast ctx decl [K"block"
                     getkw_tmp := get_kw
                     [K"if" [K"call" "isa"::K"core" getkw_tmp decl[2]]
-                        "nothing"::K"core"
+                        (::K"nothing")
                         [K"call" "throw"::K"core"
                             [K"new" "TypeError"::K"core"
                                 "keyword argument"::K"Symbol"
@@ -2708,7 +2710,7 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
                     [K"call" "diff_names"::K"top"
                         [K"call" "keys"::K"top" arg2_name]
                         [K"tuple" kw_syms...]]]
-                "nothing"::K"core"
+                (::K"nothing")
                 [K"call" "kwerr"::K"top" arg2_name forward_pargl...]]
         end
         final_call = @ast ctx kws [K"call"
@@ -2743,7 +2745,7 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
     end
     @ast ctx src [K"block"
         [K"function_decl" m1_name]
-        is_core_nothing(mtable) ? nothing : [K"function_decl" mtable]
+        kind(mtable) === K"nothing" ? nothing : [K"function_decl" mtable]
         [K"method_defs" m1_name mdefs1]
         [K"method_defs" mtable mdefs2]
         [K"method_defs" mtable mdefs3]
@@ -2769,7 +2771,7 @@ function lower_destructuring_args!(ctx, args)
         args[i] = _lower_destructuring_arg(stmts, ctx, a)
     end
     # return `nothing` from the assignments (issue #26518)
-    !isempty(stmts) && push!(stmts, @ast ctx stmts[1] "nothing"::K"core")
+    !isempty(stmts) && push!(stmts, @ast ctx stmts[1] (::K"nothing"))
     return stmts
 end
 
@@ -2795,7 +2797,7 @@ function expand_function_arg1(ctx, arg)
         [K"Identifier"] -> arg
         [K"Value"] -> arg # TODO delete with globalref support
         [K"Placeholder"] -> arg
-        _ -> @ast ctx arg "nothing"::K"core"
+        _ -> @ast ctx arg (::K"nothing")
     end
     return false, mt, @ast ctx arg [K"::" aname atype]
 end
@@ -2871,7 +2873,7 @@ function expand_function_def(ctx, src, raw_args, wheres, body, rett)
         keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, pos_va)
     else
         @ast ctx src [K"block"
-            (overlay || is_core_nothing(mtable)) ? nothing : [K"function_decl" mtable]
+            (overlay || kind(mtable) === K"nothing") ? nothing : [K"function_decl" mtable]
             [K"method_defs" mtable [K"block"
                 method_def_expr(ctx, src, mtable, sparams, argl, body, rett)]]
                 # TODO: overlay should return the method
@@ -2889,7 +2891,7 @@ expand_opaque_closure(ctx, ex) = @stm ex begin
         arg_names = SyntaxList(newsym(ctx, lam[1], "#self#"))
         inner_arg_types = SyntaxList(ctx.graph)
         for a in raw_args
-            if !is_core_nothing(argt) && kind(a) === K"::"
+            if kind(argt) !== K"nothing" && kind(a) === K"::"
                 throw(LoweringError(a, "opaque closure argument type may not be specified both in the method signature and separately"))
             end
             a2 = expand_function_arg(ctx, a, false)
@@ -2902,11 +2904,11 @@ expand_opaque_closure(ctx, ex) = @stm ex begin
             push!(arg_names, a2[1])
         end
 
-        out_argt = !is_core_nothing(argt) ? argt :
+        out_argt = kind(argt) !== K"nothing" ? argt :
             @ast ctx lam[1] [K"curly" "Tuple"::K"core" inner_arg_types...]
-        out_rt_lb = !is_core_nothing(rt_lb) ? rt_lb :
+        out_rt_lb = kind(rt_lb) !== K"nothing" ? rt_lb :
             @ast ctx lam[1] [K"curly" "Union"::K"core"]
-        out_rt_ub = !is_core_nothing(rt_ub) ? rt_ub :
+        out_rt_ub = kind(rt_ub) !== K"nothing" ? rt_ub :
             @ast ctx lam[1] "Any"::K"core"
         nargs = (length(arg_names)-1) # ignoring #self#
         is_va = kind(raw_args[end]) === K"..."
@@ -4060,7 +4062,7 @@ function expand_import_or_using(ctx, ex)
                         eval_import   ::K"Value"
                         (!is_using)   ::K"Bool"
                         ctx.mod       ::K"Value"
-                        "nothing"     ::K"top"
+                        (::K"nothing")
                         spec
                     ]
                 )
@@ -4082,7 +4084,7 @@ function expand_import_or_using(ctx, ex)
     @ast ctx ex [K"block"
         [K"assert" "toplevel_only"::K"Symbol" [K"inert_syntaxtree" ex]]
         stmts...
-        [K"removable" "nothing"::K"core"]
+        [K"removable" (::K"nothing")]
     ]
 end
 
@@ -4430,7 +4432,7 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
         ex
     elseif k == K"return"
         if numchildren(ex) == 0
-            @ast ctx ex [K"return" "nothing"::K"core"]
+            @ast ctx ex [K"return" (::K"nothing")]
         elseif numchildren(ex) == 1
             mapchildren(e->expand_forms_2(ctx,e), ctx, ex)
         else

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -86,7 +86,7 @@ end
 # used outside of that scope (binding capture is OK).  This is the alternative.
 function newsym(ctx, src::SyntaxTree, name::String; unused=false)
     out = newleaf(ctx, src, unused ? K"Placeholder" : K"Identifier", name)
-    setattr!(out, :meta, get(src, :meta, nothing))
+    hasattr(src, :meta) && setattr!(out, :meta, src.meta)
     setattr!(out, :scope_layer, new_scope_layer(ctx))
 end
 
@@ -2820,7 +2820,7 @@ expand_function_arg(ctx, arg, used) = @stm arg begin
     [K"::" x t] ->
         @ast ctx arg [K"::" fix_argname(ctx, x, used) t]
     [K"::" t] -> let aname = newsym(ctx, arg, "#arg#"; unused=true)
-        setattr!(aname, :meta, get(arg, :meta, nothing))
+        hasattr(arg, :meta) && setattr!(aname, :meta, arg.meta)
         @ast ctx arg [K"::" fix_argname(ctx, aname, used) t]
     end
     [K"kw" x v] ->

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -337,15 +337,10 @@ function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
     k = kind(ex)
     if is_literal(k)
         ex.value
+    elseif k == K"nothing"
+        nothing
     elseif k == K"core"
-        name = ex.name_val::String
-        if name === "nothing"
-            # Translate Core.nothing into literal `nothing`s (flisp uses a
-            # special form (null) for this during desugaring, etc)
-            nothing
-        else
-            GlobalRef(Core, Symbol(name))
-        end
+        GlobalRef(Core, Symbol(ex.name_val::String))
     elseif k == K"top"
         GlobalRef(Base, Symbol(ex.name_val::String))
     elseif k == K"globalref"

--- a/JuliaLowering/src/kinds.jl
+++ b/JuliaLowering/src/kinds.jl
@@ -98,7 +98,10 @@ function _register_kinds()
             # to occur before the methods are created
             "_generated_body"
             "with_static_parameters"
+            # converted from nothing::K"Value" into desugaring.  flisp: (null)
+            "nothing"
             "top"
+            "core"
             "lambda"
             # "A source location literal" - a node which exists only to record
             # a sourceref

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -619,7 +619,7 @@ end
 # the needed value.
 function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
     k = kind(ex)
-    if k == K"BindingId" || is_literal(k) || k == K"quote" ||
+    if k == K"BindingId" || is_literal(k) || k == K"nothing" ||
             k == K"inert" || k == K"inert_syntaxtree" || k == K"top" ||
             k == K"core" || k == K"Value" || k == K"Symbol" ||
             k == K"SourceLocation" || k == K"static_eval"
@@ -898,7 +898,7 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
             emit(ctx, ex)
         end
         if needs_value
-            val = @ast ctx ex "nothing"::K"core"
+            val = @ast ctx ex (::K"nothing")
             if in_tail_pos
                 emit_return(ctx, val)
             else

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -328,8 +328,6 @@ function expand_macro(ctx, ex)
                 # is the API for access to the macro expansion context?
                 expanded = copy_ast(ctx, expanded)
             end
-        elseif isnothing(expanded)
-            expanded = @ast ctx ex "nothing"::K"core"
         else
             expanded = @ast ctx ex expanded::K"Value"
         end

--- a/JuliaLowering/src/runtime.jl
+++ b/JuliaLowering/src/runtime.jl
@@ -53,7 +53,7 @@ _is_leaf(::Expr) = false
 _is_leaf(@nospecialize(_)) = true
 
 # Produce interpolated node for `$x` syntax
-function _interpolated_value(ctx::InterpolationContext, srcref, ex)
+function _interpolated_value(ctx::InterpolationContext, srcref, @nospecialize(ex))
     if ex isa SyntaxTree
         if !is_compatible_graph(ctx, ex)
             ex = copy_ast(ctx, ex)
@@ -69,7 +69,7 @@ function _interpolated_value(ctx::InterpolationContext, srcref, ex)
     end
 end
 
-function _interpolated_value(::ExprInterpolationContext, _, ex)
+function _interpolated_value(::ExprInterpolationContext, _, @nospecialize(ex))
     ex
 end
 

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -376,7 +376,7 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
         # Local declarations have a value of `nothing` according to flisp
         # lowering.
         # TODO: Should local decls be disallowed in value position?
-        @ast ctx ex "nothing"::K"core"
+        @ast ctx ex (::K"nothing")
     elseif k == K"decl"
         ex_out = mapchildren(e->_resolve_scopes(ctx, e, scope), ctx, ex)
         name = ex_out[1]

--- a/JuliaLowering/src/syntax_macros.jl
+++ b/JuliaLowering/src/syntax_macros.jl
@@ -66,11 +66,13 @@ function Base.var"@generated"(__context__::MacroContext, ex)
     end
     @ast __context__ __context__.macrocall [K"function"
         ex[1]
-        [K"if" [K"generated"]
-            ex[2]
-            [K"block"
-                [K"meta" "generated_only"::K"Identifier"]
-                [K"return" "nothing"::K"core"]
+        [K"block"
+            [K"if" [K"generated"]
+                ex[2]
+                [K"block"
+                    [K"meta" "generated_only"::K"Identifier"]
+                    [K"return" nothing::K"Value"]
+                ]
             ]
         ]
     ]
@@ -227,9 +229,9 @@ end
 function Base.Experimental.var"@opaque"(__context__::MacroContext, ex)
     @jl_assert kind(ex) == K"->" ex
     @ast __context__ __context__.macrocall [K"opaque_closure"
-        "nothing"::K"core"
-        "nothing"::K"core"
-        "nothing"::K"core"
+        nothing::K"Value"
+        nothing::K"Value"
+        nothing::K"Value"
         true::K"Bool"
         ex
     ]

--- a/JuliaLowering/src/utils.jl
+++ b/JuliaLowering/src/utils.jl
@@ -9,6 +9,7 @@ function _value_string(ex)
           k == K"SSAValue"    ? "%"                   :
           k == K"BindingId"   ? "#"                   :
           k == K"label"       ? "label"               :
+          k == K"nothing"     ? "core.nothing"        :
           k == K"core"        ? "core.$(ex.name_val)" :
           k == K"top"         ? "top.$(ex.name_val)"  :
           k == K"Symbol"      ? ":$(ex.name_val)" :
@@ -443,7 +444,7 @@ function _flatten_blocks(st::SyntaxTree)
         # special case: an empty final block has value nothing
         if (length(children(st)) > 0 && kind(st[end]) === K"block" &&
             numchildren(st[end]) == 0)
-            push!(out, @ast st._graph st[end] "nothing"::K"core")
+            push!(out, @ast st._graph st[end] (::K"nothing"))
         end
         return out
     elseif is_quoted(st)

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -247,8 +247,6 @@ vst1(vcx::Validation1Context, st::SyntaxTree)::ValidationResult = @stm st begin
     [K"ssavalue" [K"Value"]] -> pass()
     [K"inert" _] -> pass()
     [K"inert_syntaxtree" _] -> pass()
-    [K"core"] -> st.name_val === "nothing" ? pass() :
-        @fail(st, "zero-arg `core` is only used for `Core.nothing`")
     [K"core" [K"Identifier"]] -> pass()
     [K"top" [K"Identifier"]] -> pass()
     [K"meta" _...] -> pass() # TODO
@@ -1149,6 +1147,7 @@ function _assert_syntaxtree(st::SyntaxTree, parents::Vector{NodeId}, vr)
             [K"slot"] -> (:var_id,)
             [K"static_parameter"] -> (:var_id,)
             [K"SSAValue"] -> (:var_id,)
+            [K"nothing"] -> ()
             [K"TOMBSTONE"] -> ()
             [K"SourceLocation"] -> ()
             [K"latestworld"] -> ()
@@ -1199,7 +1198,7 @@ end
 
 vst2(vcx::Validation2Context, st::SyntaxTree) = @stm st begin
     (_, when=is_leaf(st)) -> kind(st) in KSet"""
-    Identifier BindingId Placeholder
+    Identifier BindingId Placeholder nothing
     Bool Char Float Float32 BinInt OctInt HexInt Integer
     SourceLocation String Symbol Value core top
     latestworld latestworld_if_toplevel symbolicgoto oldsymbolicgoto symboliclabel TOMBSTONE
@@ -1240,9 +1239,11 @@ vst2(vcx::Validation2Context, st::SyntaxTree) = @stm st begin
     [K"function_type" x] -> vst2(vcx, x)
     [K"method" name meta lam] -> !vcx.in_method_defs ?
         @fail(st, "method outside of method_defs") :
-        vst2_ident_val(vcx, name) & vst2(vcx, meta) & vst2_lam(vcx, lam)
+        (kind(name) === K"nothing" ? pass() : vst2_ident_val(vcx, name)) &
+        vst2(vcx, meta) & vst2_lam(vcx, lam)
     [K"method_defs" id body] ->
-        vst2_ident_val(vcx, id) & vst2(with(vcx; in_method_defs=true), body)
+        (kind(id) === K"nothing" ? pass() : vst2_ident_val(vcx, id)) &
+        vst2(with(vcx; in_method_defs=true), body)
     [K"new" t args...] -> vst2(vcx, t) & all(vst2, vcx, args)
     [K"splatnew" t arg] -> vst2(vcx, t) & vst2(vcx, arg)
     [K"softscope"] -> pass()

--- a/JuliaLowering/test/ast.jl
+++ b/JuliaLowering/test/ast.jl
@@ -1,3 +1,8 @@
+let node = JS.newleaf(SyntaxGraph(), LineNumberNode(1), K"Value", nothing)
+    @test JS.hasattr(node, :value)
+    @test node.value === nothing
+end
+
 @testset "assert_syntaxtree" begin
     st = parsestmt(SyntaxTree, "function foo end")
     g = st._graph
@@ -43,7 +48,7 @@ end
 
         st = @ast_ [K"block" 1::K"Value" [K"block"]]
         @test JuliaLowering.flatten_blocks(st) ≈
-            @ast_ [K"block" 1::K"Value" "nothing"::K"core"]
+            @ast_ [K"block" 1::K"Value" (::K"nothing")]
 
         st = @ast_ [K"block" 1::K"Value" [K"block"] 1::K"Value"]
         @test JuliaLowering.flatten_blocks(st) ≈
@@ -72,7 +77,7 @@ end
 
         st = @ast_ [K"call" [K"block" 1::K"Value" [K"block"]]]
         @test JuliaLowering.flatten_blocks(st) ≈
-            @ast_ [K"call" [K"block" 1::K"Value" "nothing"::K"core"]]
+            @ast_ [K"call" [K"block" 1::K"Value" (::K"nothing")]]
 
         st = @ast_ [K"call" [K"block" 1::K"Value" [K"block"] 1::K"Value"]]
         @test JuliaLowering.flatten_blocks(st) ≈

--- a/JuliaLowering/test/compat.jl
+++ b/JuliaLowering/test/compat.jl
@@ -100,9 +100,9 @@ end
     unused = JuliaSyntax.parsestmt(JuliaSyntax.SyntaxTree, "foo")
     JuliaLowering.ensure_macro_attributes!(unused._graph)
     local st_wrappers = Function[
-        x->(@assert(!isnothing(x)); @ast unused._graph unused (x::K"Value"))
-        x->(@assert(!isnothing(x)); @ast unused._graph unused [K"inert" x::K"Value"])
-        x->(@assert(!isnothing(x)); @ast unused._graph unused [K"function" x::K"Value"])
+        x->(@ast unused._graph unused (x::K"Value"))
+        x->(@ast unused._graph unused [K"inert" x::K"Value"])
+        x->(@ast unused._graph unused [K"function" x::K"Value"])
     ]
 
     @testset "every basic case" begin
@@ -112,7 +112,6 @@ end
         end
 
         for e in expr_syntax, st_w in st_wrappers, e_w in expr_wrappers
-            isnothing(e) && continue
             e_wrapped = st_w(e_w(e))
             @test roundtrip(e_wrapped) == e_wrapped
             e_wrapped = e_w(st_w(e))

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -1293,6 +1293,51 @@ end
 
 @testset "Generated functions" begin; for expr_compat_mode in (false, true)
     local genfunc_s, genfunc_f
+
+    @testset "returning special syntax forms" begin
+        @test JuliaLowering.include_string(test_mod, raw"""
+        begin
+            @generated f_gen_nothing() = nothing
+            f_gen_nothing()
+        end
+        """; expr_compat_mode) == nothing
+
+        @test JuliaLowering.include_string(test_mod, raw"""
+        begin
+            @generated f_gen_quotenothing() = :(nothing)
+            f_gen_quotenothing()
+        end
+        """; expr_compat_mode) == nothing
+
+        @test JuliaLowering.include_string(test_mod, raw"""
+        begin
+            @generated f_gen_quotenodenothing() = QuoteNode(nothing)
+            f_gen_quotenodenothing()
+        end
+        """; expr_compat_mode) == nothing
+
+        @test JuliaLowering.include_string(test_mod, raw"""
+        begin
+            @generated f_gen_gr_nothing() = GlobalRef(Core, :nothing)
+            f_gen_gr_nothing()
+        end
+        """; expr_compat_mode) == nothing
+
+        @test JuliaLowering.include_string(test_mod, raw"""
+        begin
+            @generated f_gen_quotegr_nothing() = :(GlobalRef(Core, :nothing))
+            f_gen_quotegr_nothing()
+        end
+        """; expr_compat_mode) == GlobalRef(Core, :nothing)
+
+        @test JuliaLowering.include_string(test_mod, raw"""
+        begin
+            @generated f_gen_quotenodegr_nothing() = QuoteNode(GlobalRef(Core, :nothing))
+            f_gen_quotenodegr_nothing()
+        end
+        """; expr_compat_mode) == GlobalRef(Core, :nothing)
+    end
+
     @test JuliaLowering.include_string(test_mod, raw"""
     begin
         @generated function f_gen_trivial(x)
@@ -1343,7 +1388,21 @@ end
         end
         """
         @test (genfunc_f = JL.include_string(test_mod, genfunc_s; expr_compat_mode)) isa Function
-        @test_broken genfunc_f((1,2)) == (Tuple{Int, Int}, "gen")
+        @test genfunc_f((1,2)) == (Tuple{Int, Int}, "gen")
+    end
+
+    @testset "destructured args: values" begin
+        genfunc_s = raw"""
+        function ((d1,d2)::T) where {T}
+            if @generated
+                :(d1, d2, $T, "gen")
+            else
+                :($T, "nongen")
+            end
+        end
+        """
+        @test (genfunc_f = JL.include_string(test_mod, genfunc_s; expr_compat_mode)) isa Function
+        @test_broken genfunc_f((1,2)) == (1, 2, Tuple{Int, Int}, "gen")
     end
 
     @testset "keyword args" begin

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -2036,7 +2036,7 @@ end
     1   TestMod.generator_code
     2   (call %₁ slot₄/x slot₅/y)
     3   (call core.tuple %₂)
-    4   (call JuliaLowering.interpolate_ast SyntaxTree (inert_syntaxtree ($ (block (call generator_code x y)))) %₃)
+    4   (call JuliaLowering.interpolate_ast SyntaxTree (inert_syntaxtree (block ($ (block (call generator_code x y))))) %₃)
     5   (return %₄)
 14  latestworld
 15  TestMod.f_only_generated

--- a/JuliaLowering/test/import_ir.jl
+++ b/JuliaLowering/test/import_ir.jl
@@ -18,9 +18,9 @@ import A.B.C: b, c.d as e
 # Imports without `from` module need separating with latestworld
 import A, B
 #---------------------
-1   (call JuliaLowering.eval_import true TestMod top.nothing :($(QuoteNode(:($(Expr(:., :A)))))))
+1   (call JuliaLowering.eval_import true TestMod core.nothing :($(QuoteNode(:($(Expr(:., :A)))))))
 2   latestworld
-3   (call JuliaLowering.eval_import true TestMod top.nothing :($(QuoteNode(:($(Expr(:., :B)))))))
+3   (call JuliaLowering.eval_import true TestMod core.nothing :($(QuoteNode(:($(Expr(:., :B)))))))
 4   latestworld
 5   (return core.nothing)
 

--- a/JuliaLowering/test/quoting.jl
+++ b/JuliaLowering/test/quoting.jl
@@ -282,6 +282,18 @@ end
 
     @test fl_eval(test_mod, Expr(:block, quoted)) == form
     @test jl_eval(test_mod, Expr(:block, quoted); expr_compat_mode) == form
+
+end
+
+@testset "self-quoting forms, interpolated into quote, expr compat" for
+    form in [1, true, "string", [], nothing, :symbol],
+    quoted in [Expr(:quote, form), Expr(:inert, form), QuoteNode(form)]
+
+    @test fl_eval(test_mod, Expr(:quote, Expr(:$, quoted))) == form
+    @test jl_eval(test_mod, Expr(:quote, Expr(:$, quoted)); expr_compat_mode=true) == form
+
+    # Just to track behaviour
+    @test jl_eval(test_mod, Expr(:quote, Expr(:$, quoted)); expr_compat_mode=false) isa SyntaxTree
 end
 
 # (. l r) should pass lowering only when r is one of:

--- a/JuliaLowering/test/validation.jl
+++ b/JuliaLowering/test/validation.jl
@@ -120,6 +120,10 @@ let
     end
 end
 
+@test !vst1_ok(Expr(:nothing))
+@test vst1_ok(Expr(:block, nothing))
+@test vst1_ok(Expr(:block, GlobalRef(Core, :nothing)))
+
 @test vst1_ok(Expr(:-->, 1))
 @test vst1_ok(Expr(:-->, 1, 2))
 @test vst1_ok(Expr(:-->, 1, 2, 3))

--- a/JuliaSyntax/src/julia/kinds.jl
+++ b/JuliaSyntax/src/julia/kinds.jl
@@ -1067,7 +1067,6 @@ register_kinds!(JuliaSyntax, 0, [
         # A literal Julia value of any kind, as might be inserted into the
         # AST during macro expansion.  Only used in parsing to SyntaxTree.
         "Value"
-        "core"
         "unknown_head"
         "flatten"
         # QuoteNode; not quasiquote

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -153,9 +153,7 @@ end
 
 # TODO: Probably terribly non-inferable?
 @noinline function setattr!(graph::SyntaxGraph, id::NodeId, k::Symbol, @nospecialize(v))
-    if !isnothing(v)
-        getattr(graph, k)[id] = v
-    end
+    getattr(graph, k)[id] = v
     id
 end
 
@@ -228,8 +226,9 @@ function Base.getproperty(ex::SyntaxTree, name::Symbol)
     name === :_graph && return getfield(ex, :_graph)
     name === :_id  && return getfield(ex, :_id)
     graph = getfield(ex, :_graph)
-    val = get(getattr(graph, name), getfield(ex, :_id), nothing)
-    isnothing(val) && error("Property `$name` not defined on node: $(node_string(ex))")
+    val = get(getattr(graph, name), getfield(ex, :_id)) do
+        error("Property `$name` not defined on node: $(node_string(ex))")
+    end
     return val
 end
 
@@ -264,7 +263,8 @@ function Base.:≈(ex1::SyntaxTree, ex2::SyntaxTree)
         return false
     end
     if is_leaf(ex1)
-        return get(ex1, :value,    nothing) == get(ex2, :value,    nothing) &&
+        return hasattr(ex1, :value) == hasattr(ex2, :value) &&
+               get(ex1, :value,    nothing) == get(ex2, :value,    nothing) &&
                get(ex1, :name_val, nothing) == get(ex2, :name_val, nothing)
     else
         if numchildren(ex1) != numchildren(ex2)
@@ -277,8 +277,7 @@ end
 function hasattr(ex::SyntaxTree, name::Symbol)
     graph = ex._graph
     !hasattr(graph, name) && return false
-    attr = getattr(graph, name)
-    return !isnothing(attr) && haskey(attr, ex._id)
+    return haskey(getattr(graph, name), ex._id)
 end
 
 function attrnames(ex::SyntaxTree)
@@ -852,9 +851,8 @@ function prune(graph1_a::SyntaxGraph, entrypoints_a::Vector{NodeId})
     for attr in attrnames(graph1)
         attr === :source && continue
         for (n2, n1) in enumerate(nodes1)
-            attrval = get(graph1.attributes[attr], n1, nothing)
-            if !isnothing(attrval)
-                graph2.attributes[attr][n2] = attrval
+            if haskey(graph1.attributes[attr], n1)
+                graph2.attributes[attr][n2] = graph1.attributes[attr][n1]
             end
         end
     end
@@ -1263,7 +1261,6 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
 
     graph = syntax_graph(st)
     k = kind(st)
-    coreref(s::String) = setattr!(newleaf(graph, st, K"core"), :name_val, s)
     symleaf(s::String) = setattr!(newleaf(graph, st, K"Identifier"), :name_val, s)
     core_globalref(s::String) = setattr!(symleaf(s), :mod, Core)
     valleaf(@nospecialize(v)) = setattr!(newleaf(graph, st, K"Value"), :value, v)
@@ -1281,9 +1278,9 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
                 v isa UInt128 ? "@uint128_str" : "@big_str"
             mac = core_globalref(macname)
             arg = valleaf(replace(sourcetext(st), '_'=>""))
-            ret_cids = tree_ids(mac, coreref("nothing"), arg)
+            ret_cids = tree_ids(mac, valleaf(nothing), arg)
             newnode(graph, st, K"macrocall", ret_cids)
-        elseif hasattr(st, :name_val) && !(kind(st) in KSet"Identifier core")
+        elseif hasattr(st, :name_val) && !(kind(st) in KSet"Identifier")
             # certain kinds should really be identifiers.  known: &, |, :
             symleaf(st.name_val)
         else
@@ -1582,7 +1579,7 @@ function _green_to_est(parent::SyntaxTree, parent_i::Int,
             cs = preprocessed_green_children(cs[1])
         end
     elseif k === K"return" && n_cs === 0
-        push!(cs, coreref("nothing"))
+        push!(cs, valleaf(nothing))
     elseif k === K"juxtapose"
         ret_k = K"call"
         pushfirst!(cs, symleaf("*"))


### PR DESCRIPTION
Fix https://github.com/JuliaLang/JuliaLowering.jl/issues/173 "the right way" by hopefully eliminating a footgun: SyntaxTree can now store the value `nothing` in an attribute, though in practice JL won't do this outside of K"Value", so things like `get(st, :name_val, nothing)` are still fine to do.  

`nothing::K"Value"` is a valid representation of `nothing` throughout lowering, but I've also added `K"nothing"` (analogous to flisp's `(null)` form) since lowering matches on it, and when we're peeking into `.value` or `.name_val` for a specific thing, we should usually be using a special form instead.  This form is not valid before desugaring (it's converted from `nothing::K"Value"` in `est_to_dst`), so it shouldn't cause confusion in "new" macro expansion.