### PR TITLE
Fix-up `--trim` support for `hcat` / `vcat` / etc.

### DIFF
--- a/contrib/juliac/juliac-trim-base.jl
+++ b/contrib/juliac/juliac-trim-base.jl
@@ -84,6 +84,29 @@ end
     setfield!(typeof(print).name, :max_args, Int32(10), :monotonic)
     setfield!(typeof(println).name, :max_args, Int32(10), :monotonic)
     setfield!(typeof(print_to_string).name, :max_args, Int32(10), :monotonic)
+
+    # not `--trim`-compatible if these resolve to a Varargs{...} specialization, primarily
+    # due to `Core._apply_iterate` having no dispatch-resolved form (#57830)
+    setfield!(typeof(_cat).name, :max_args, Int32(10), :monotonic)
+    setfield!(typeof(__cat).name, :max_args, Int32(10), :monotonic)
+    setfield!(typeof(__cat_offset!).name, :max_args, Int32(10), :monotonic)
+    setfield!(typeof(cat_size_shape).name, :max_args, Int32(10), :monotonic)
+    setfield!(typeof(_cat_size_shape).name, :max_args, Int32(10), :monotonic)
+
+    # vcat / hcat / hvcat / hvncat / cat all use this
+    unwrap_val(dims) = dims
+    unwrap_val(::Val{dims}) where dims = dims
+    function _cat_t(dims, ::Type{T}, X::Vararg{AbstractArray,N}) where {T,N}
+        @inline
+        Ndims = maximum(map(ndims, X))
+        catdims = ntuple(in(unwrap_val(dims)), Val(Ndims))
+        shape = cat_size_shape(catdims, X...)
+        A = cat_similar(X[1], T, shape)
+        if count(!iszero, catdims)::Int > 1
+            fill!(A, zero(T))
+        end
+        return __cat(A, shape, catdims, X...)
+    end
 end
 @eval Base.Sys begin
     __init_build() = nothing # VersionNumber parsing is not supported yet

--- a/test/trimming/trimmability.jl
+++ b/test/trimming/trimmability.jl
@@ -26,6 +26,70 @@ function add_one(x::Cint)::Cint
     return x + 1
 end
 
+function _test_cat()
+    # hcat
+    _cat1a = hcat(randn(3), rand(3), randn(3))
+    _cat1b = [randn(3) rand(3) randn(3)]
+    _cat1c = hcat(randn(3,3), rand(3,3), randn(3,3))
+    _cat1d = [randn(3,3) rand(3,3) randn(3,3)]
+    _cat1e = hcat(randn(3,3,3), rand(3,3,3), randn(3,3,3))
+    _cat1f = [randn(3,3,3) rand(3,3,3) randn(3,3,3)]
+
+    # v_cat
+    _cat2a = vcat(randn(3), rand(3), randn(3))
+    _cat2b = [randn(3); rand(3); randn(3)]
+    _cat2c = vcat(randn(3,3), rand(3,3), randn(3,3))
+    _cat2d = [randn(3,3); rand(3,3); randn(3,3)]
+    _cat2e = vcat(randn(3,3,3), rand(3,3,3), randn(3,3,3))
+    _cat2f = [randn(3,3,3); rand(3,3,3); randn(3,3,3)]
+
+    # hvcat
+    _cat3a = hvcat((2,2), rand(3,2), randn(3,4), rand(1,2), randn(1,4))
+    _cat3b = [rand(3,2) randn(3,4); rand(1,2) randn(1,4)]
+    _cat3c = hvcat((2, 2), rand(5,2,3), rand(5,4,3), rand(1,2,3), rand(1,4,3))
+    _cat3d = [rand(5,2,3) rand(5,4,3); rand(1,2,3) rand(1,4,3)]
+
+    # cat
+    _cat4a = cat(randn(3), randn(3); dims = 1)
+    _cat4b = cat(randn(3,3,3), randn(3,3,3); dims = 2)
+    _cat4c = cat(randn(3), randn(3,3); dims = 2)
+    _cat4d = cat(randn(3), randn(3), rand(3), rand(3), randn(3), randn(3); dims = (1,))
+    _cat4e = cat(randn(3,3), randn(3,3), rand(3,3), rand(3,3), randn(3,3), randn(3,3); dims = (1,2))
+    _cat4f = cat(randn(3,3,3), randn(3,3); dims=(1,3))
+
+    # hvncat
+    _cat5a = hvncat(2, randn(3), randn(3), randn(3))
+    _cat5b = [randn(3) ;; randn(3) ;; randn(3)]
+    _cat5c = hvncat(2, randn(3,3), randn(3,3), randn(3,3))
+    _cat5d = [randn(3,3) ;; randn(3,3) ;; randn(3,3)]
+    _cat5e = hvncat((1, 2, 2), false, randn(2,3), randn(2,3), randn(2,3), randn(2,3))
+    _cat5f = [randn(2,3) ;; randn(2,3) ;;; randn(2,3) ;; randn(2,3)]
+
+    # stack
+    _cat6a = stack([randn(3), randn(3), randn(3)])
+    _cat6b = stack([randn(3), randn(3), randn(3)]; dims=1)
+    _cat6c = stack([randn(2,3), randn(2,3)]; dims=3)
+    _cat6d = stack(x -> x .^ 2, [randn(3), randn(3)])
+
+    # repeat
+    _cat7a = repeat(randn(3), 2)
+    _cat7b = repeat(randn(2,3), 2, 3)
+    _cat7c = repeat(randn(2,3); inner=(2,1), outer=(1,3))
+    _cat7d = repeat(randn(3,3,3), 1, 2, 1)
+
+    # aggregate to prevent deletion
+    _cat1 = _cat1a[1] + _cat1b[1] + _cat1c[1] + _cat1d[1] + _cat1e[1] + _cat1f[1]
+    _cat2 = _cat2a[1] + _cat2b[1] + _cat2c[1] + _cat2d[1] + _cat2e[1] + _cat2f[1]
+    _cat3 = _cat3a[1] + _cat3b[1] + _cat3c[1] + _cat3d[1]
+    _cat4 = _cat4a[1] + _cat4b[1] + _cat4c[1] + _cat4d[1] + _cat4e[1] + _cat4f[1]
+    _cat5 = _cat5a[1] + _cat5b[1] + _cat5c[1] + _cat5d[1] + _cat5e[1] + _cat5f[1]
+    _cat6 = _cat6a[1] + _cat6b[1] + _cat6c[1] + _cat6d[1]
+    _cat7 = _cat7a[1] + _cat7b[1] + _cat7c[1] + _cat7d[1]
+
+    return _cat1 + _cat2 + _cat3 + _cat4 + _cat5 + _cat6 + _cat7
+end
+
+
 function @main(args::Vector{String})::Cint
     println(Core.stdout, str())
     println(Core.stdout, PROGRAM_FILE)
@@ -44,6 +108,8 @@ function @main(args::Vector{String})::Cint
     c = map(x -> x^2, sorted_arr)
     d = mapreduce(x -> x^2, +, sorted_arr)
     # e = reduce(xor, rand(Int, 10))
+
+    println(Core.stdout, _test_cat())
 
     for i = 1:10
         # https://github.com/JuliaLang/julia/issues/60846

--- a/test/trimming/trimming.jl
+++ b/test/trimming/trimming.jl
@@ -15,7 +15,13 @@ let exe_suffix = splitext(Base.julia_exename())[2]
     @test filesize(hello_exe) < 1_900_000
 
     trimmability_exe = joinpath(bindir, "trimmability" * exe_suffix)
-    @test readchomp(`$trimmability_exe arg1 arg2`) == "Hello, world!\n$trimmability_exe\narg1\narg2\n$(4.0+pi)"
+    lines = split(readchomp(`$trimmability_exe arg1 arg2`), "\n")
+    @test lines[1] == "Hello, world!"
+    @test lines[2] == trimmability_exe
+    @test lines[3] == "arg1"
+    @test lines[4] == "arg2"
+    @test lines[5] == string(4.0+pi)
+    @test parse(Float64, lines[6]) isa Float64
 
     basic_jll_exe = joinpath(bindir, "basic_jll" * exe_suffix)
     lines = split(readchomp(`$basic_jll_exe`), "\n")


### PR DESCRIPTION
Add some targeted overloads for now to allow `--trim` to support these essential functions.

These will also be ported to JuliaC in parallel, at least until / if @gbaraldi chooses these things should live in a single location (we have downstream consumers that use the `contrib/` version of these files).