### PR TITLE
inference: include const-abi CodeInstances in need_inlineable_code check

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1157,7 +1157,7 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
             inferred = nothing
         end
         if codeinst isa CodeInstance
-            need_inlineable_code = may_optimize(interp) && (force_inline || is_inlineable(inferred))
+            need_inlineable_code = may_optimize(interp) && (force_inline || is_inlineable(inferred) || use_const_api(codeinst))
             if need_inlineable_code
                 src = ci_get_source(interp, codeinst, inferred)
                 if src === nothing
@@ -1204,7 +1204,7 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
             if codeinst isa CodeInstance # return existing rettype if the code is already inferred
                 engine_reject(interp, ci_from_engine)
                 ci_from_engine = nothing
-                need_inlineable_code = may_optimize(interp) && (force_inline || is_inlineable(inferred))
+                need_inlineable_code = may_optimize(interp) && (force_inline || is_inlineable(inferred) || use_const_api(codeinst))
                 if need_inlineable_code
                     src = ci_get_source(interp, codeinst, inferred)
                     if src === nothing

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -2362,4 +2362,14 @@ let src = code_typed1(issue44428, (Any,))
     @test count(x->Meta.isexpr(x,:call), src.code) == 0
 end
 
+# issue #61552
+let mi = Compiler.specialize_method(only(methods(ndims, (Matrix{Float64},))),
+        Tuple{typeof(ndims), Matrix{Float64}}, Core.svec())
+    codeinst = getcacheci(mi)::Core.CodeInstance
+    @test Compiler.use_const_api(codeinst)
+    @test codeinst.inferred === nothing
+    interp = Compiler.NativeInterpreter()
+    @test Compiler.ci_get_source(interp, codeinst) isa Core.CodeInfo
+end
+
 end # module inline_tests


### PR DESCRIPTION
Const-abi CodeInstances have `inferred === nothing`, so `is_inlineable` returns false and `typeinf_edge` skips source retrieval. This prevents the inliner from folding these calls to constants.

Fixes #61552

can't wait for Mythos to release and then maybe claude will be able to take over all my other hobbies too