### PR TITLE
backticks: implement brace expansion in command literals

### DIFF
--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -199,7 +199,7 @@ function show(io::IO, cmd::Cmd)
     join(io, map(cmd.exec) do arg
         replace(sprint(context=io) do io
             with_output_color(:underline, io) do io
-                print_shell_word(io, arg, shell_special)
+                print_shell_word(io, arg, _shell_display_special)
             end
         end, '`' => "\\`")
     end, ' ')

--- a/base/path.jl
+++ b/base/path.jl
@@ -684,7 +684,7 @@ function homedir(username::AbstractString)
     # For the current user, just return homedir().
     current_user = try
         Sys.username()
-    catch
+    catch err
         err isa IOError || rethrow()
         nothing
     end
@@ -792,7 +792,7 @@ function homedir(username::AbstractString)
         ret = ccall(:getpwnam_r, Cint,
                     (Cstring, Ptr{Cvoid}, Ptr{UInt8}, Csize_t, Ptr{Ptr{Cvoid}}),
                     username, pwd_storage, str_buf, Csize_t(buflen), result)
-        if ret == 34  # ERANGE: string buffer too small, retry with more space
+        if ret == Libc.ERANGE  # string buffer too small, retry with more space
             buflen *= 2
         elseif ret == 0 && result[] != C_NULL
             # pw_uid sits at offset 2*sizeof(Ptr) in struct passwd on all supported

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -34,10 +34,11 @@ function rstrip_shell(s::AbstractString)
 end)
 
 # Scan from position `start` in string `s` (after an opening `{`) to find the
-# matching `}`. Returns `(found_close, has_comma, has_space)`.
+# matching `}`. Returns `(found_close, has_comma, has_dotdot, has_space)`.
 function _scan_brace(s, start)
     depth = 1
     has_comma = false
+    has_dotdot = false
     has_space = false
     pos = start
     @inbounds while pos <= lastindex(s)
@@ -69,17 +70,85 @@ function _scan_brace(s, start)
             end
         elseif isspace(c)
             has_space = true
+        elseif c == '.' && depth == 1 && pos < lastindex(s) && s[nextind(s, pos)] == '.'
+            has_dotdot = true
+            pos = nextind(s, pos)  # skip second dot
         elseif c == '{'
             depth += 1
         elseif c == '}'
             depth -= 1
-            depth == 0 && return (true, has_comma, has_space)
+            depth == 0 && return (true, has_comma, has_dotdot, has_space)
         elseif c == ',' && depth == 1
             has_comma = true
         end
         pos = nextind(s, pos)
     end
-    return (false, false, false)
+    return (false, false, false, false)
+end
+
+# Expand a brace range pattern like "1..10", "a..z", "1..10..2", or "01..10".
+# Returns a tuple of strings, or `nothing` if the content is not a valid range.
+function _brace_range_expand(content::AbstractString)
+    parts = split(content, "..")
+    (length(parts) == 2 || length(parts) == 3) || return nothing
+    a_str, b_str = parts[1], parts[2]
+    step_str = length(parts) == 3 ? parts[3] : nothing
+
+    # Character range: single ASCII letter endpoints, both same case
+    if length(a_str) == 1 && length(b_str) == 1
+        a_ch, b_ch = a_str[1], b_str[1]
+        if isletter(a_ch) && isletter(b_ch) && isascii(a_ch) && isascii(b_ch)
+            if isuppercase(a_ch) != isuppercase(b_ch)
+                return nothing  # cross-case ranges like {a..Z} are an error
+            end
+            step = 1
+            if step_str !== nothing
+                step = tryparse(Int, step_str)
+                step === nothing && return nothing
+                step == 0 && return nothing
+            end
+            step = a_ch <= b_ch ? step : -step
+            return Tuple(string(c) for c in a_ch:step:b_ch)
+        end
+    end
+
+    # Integer range
+    a = tryparse(Int, a_str)
+    b = tryparse(Int, b_str)
+    (a === nothing || b === nothing) && return nothing
+    step = 1
+    if step_str !== nothing
+        step = tryparse(Int, step_str)
+        step === nothing && return nothing
+        step == 0 && return nothing
+    end
+    step = a <= b ? step : -step
+
+    # Explicit plus sign: if either endpoint starts with +, show + on positive values.
+    show_plus = (a_str[1] == '+') || (b_str[1] == '+')
+
+    # Zero-padding: if either endpoint has leading zeros (including after a
+    # sign character), pad all values to the same total width (matching bash/zsh).
+    _has_leading_zero(s) = (length(s) > 1 && s[1] == '0') ||
+                           (length(s) > 2 && s[1] in ('-', '+') && s[2] == '0')
+    pad = (_has_leading_zero(a_str) || _has_leading_zero(b_str)) ?
+        max(length(a_str), length(b_str)) : 0
+
+    if pad > 0
+        return Tuple(let s = string(abs(n))
+            if n < 0
+                "-" * lpad(s, pad - 1, '0')
+            elseif show_plus
+                "+" * lpad(s, pad - 1, '0')
+            else
+                lpad(s, pad, '0')
+            end
+        end for n in a:step:b)
+    elseif show_plus
+        return Tuple((n < 0 ? string(n) : "+" * string(n)) for n in a:step:b)
+    else
+        return Tuple(string(n) for n in a:step:b)
+    end
 end
 
 # Convert a list of parts (strings and expressions) for one brace alternative
@@ -347,8 +416,28 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
                 # The tuple integrates with arg_gen's Cartesian product, so
                 # `pre{a,b}suf` generates arguments "preasuf" and "prebsuf".
                 i = consume_upto!(arg, s, i, j)
-                found_close, has_comma, has_space = _scan_brace(s, i)
-                if found_close && has_comma && has_space
+                found_close, has_comma, has_dotdot, has_space = _scan_brace(s, i)
+                if found_close && has_dotdot && !has_comma
+                    # Range expansion: {1..10}, {a..z}, {1..10..2}, {01..10}
+                    # Extract the raw content between { and }, advance past }.
+                    brace_content = ""
+                    while !isempty(st)
+                        (bp, bc) = peek(st)::P
+                        if bc == '}'
+                            brace_content = String(s[i:prevind(s, bp)::Int])
+                            popfirst!(st)
+                            break
+                        end
+                        popfirst!(st)
+                    end
+                    i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+                    expanded = _brace_range_expand(brace_content)
+                    if expanded === nothing
+                        error("parsing command `$str`: invalid brace range expansion {$brace_content}")
+                    end
+                    push!(arg, Expr(:tuple, expanded...))
+                    word_has_special = true
+                elseif found_close && has_comma && has_space
                     error("parsing command `$str`: unquoted space inside braces")
                 elseif !(found_close && has_comma)
                     # Not a valid brace expansion (no matching } or no comma):

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -2,7 +2,12 @@
 
 ## shell-like command parsing ##
 
-const shell_special = "#{}()[]<>|&*?;"
+const shell_special = "#()[]<>|&*?;"
+
+# Characters that need quoting in backtick display.  Includes {} so that a Cmd
+# with literal braces round-trips correctly (they would otherwise be
+# brace-expanded when the displayed string is re-parsed).
+const _shell_display_special = shell_special * "{}"
 
 (@doc raw"""
     rstrip_shell(s::AbstractString)
@@ -27,6 +32,72 @@ function rstrip_shell(s::AbstractString)
     end
     SubString(s, 1, 0)
 end)
+
+# Scan from position `start` in string `s` (after an opening `{`) to find the
+# matching `}`. Returns `(found_close, has_comma, has_space)`.
+function _scan_brace(s, start)
+    depth = 1
+    has_comma = false
+    has_space = false
+    pos = start
+    @inbounds while pos <= lastindex(s)
+        c = s[pos]
+        if c == '\\'
+            pos = nextind(s, pos)  # skip escaped char
+        elseif c == '\''
+            # skip single-quoted content
+            pos = nextind(s, pos)
+            while pos <= lastindex(s) && s[pos] != '\''
+                pos = nextind(s, pos)
+            end
+        elseif c == '"'
+            # skip double-quoted content
+            pos = nextind(s, pos)
+            while pos <= lastindex(s)
+                s[pos] == '"' && break
+                s[pos] == '\\' && (pos = nextind(s, pos))
+                pos = nextind(s, pos)
+            end
+        elseif c == '$' && pos < lastindex(s) && s[nextind(s, pos)] == '('
+            # skip $(expr) — count parentheses
+            pos = nextind(s, nextind(s, pos))
+            pdepth = 1
+            while pos <= lastindex(s) && pdepth > 0
+                s[pos] == '(' && (pdepth += 1)
+                s[pos] == ')' && (pdepth -= 1)
+                pdepth > 0 && (pos = nextind(s, pos))
+            end
+        elseif isspace(c)
+            has_space = true
+        elseif c == '{'
+            depth += 1
+        elseif c == '}'
+            depth -= 1
+            depth == 0 && return (true, has_comma, has_space)
+        elseif c == ',' && depth == 1
+            has_comma = true
+        end
+        pos = nextind(s, pos)
+    end
+    return (false, false, false)
+end
+
+# Convert a list of parts (strings and expressions) for one brace alternative
+# into a single expression suitable for inclusion in a tuple.
+function _brace_alt_expr(parts)
+    if isempty(parts)
+        return ""
+    end
+    all_strings = all(p -> isa(p, AbstractString), parts)
+    if all_strings
+        return String(join(parts))
+    elseif length(parts) == 1
+        return parts[1]
+    else
+        cleaned = Any[isa(p, AbstractString) ? String(p) : p for p in parts]
+        return Expr(:call, GlobalRef(Base, :cmd_interpolate), cleaned...)
+    end
+end
 
 shell_parse(str::AbstractString, interpolate::Bool=true;
             special::AbstractString="", filename="none") =
@@ -271,6 +342,97 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
                     push!(arg, :(let _u = string($(user_parts...)); isempty(_u) ? "~" : expanduser(string('~', _u)) end))
                 end
                 i = user_end
+            elseif interpolate && !in_single_quotes && !in_double_quotes && c == '{'
+                # Brace expansion: {alt1,alt2,...} produces a tuple of alternatives.
+                # The tuple integrates with arg_gen's Cartesian product, so
+                # `pre{a,b}suf` generates arguments "preasuf" and "prebsuf".
+                i = consume_upto!(arg, s, i, j)
+                found_close, has_comma, has_space = _scan_brace(s, i)
+                if found_close && has_comma && has_space
+                    error("parsing command `$str`: unquoted space inside braces")
+                elseif !(found_close && has_comma)
+                    # Not a valid brace expansion (no matching } or no comma):
+                    # treat the { as a literal character.
+                    push!(arg, "{")
+                else
+                    word_has_special = true
+                    alts = Any[]
+                    alt_parts = Any[]
+                    alt_i = i   # start of current literal segment
+                    bsq = false # single quotes within brace content
+                    bdq = false # double quotes within brace content
+                    bdepth = 0  # nested brace depth
+                    while !isempty(st)
+                        (bp, bc) = peek(st)::P
+                        if bsq
+                            # In single quotes: everything is literal until closing '
+                            popfirst!(st)
+                            if bc == '\''
+                                push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+                                bsq = false
+                                alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+                            end
+                        elseif !bdq && bc == '\''
+                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+                            popfirst!(st)
+                            bsq = true
+                            alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+                        elseif bc == '"'
+                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+                            popfirst!(st)
+                            bdq = !bdq
+                            alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+                        elseif !bsq && bc == '$'
+                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+                            popfirst!(st)
+                            result = parse_dollar_interp(st, s)
+                            push!(alt_parts, result[1])
+                            last_arg = result[3]
+                            update_last_arg = true
+                            s = result[2]
+                            alt_i = firstindex(s)
+                        elseif !bsq && bc == '\\'
+                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+                            popfirst!(st)  # consume \
+                            if bdq
+                                if !isempty(st) && (peek(st)::P).second in ('"', '$', '\\')
+                                    alt_i = (peek(st)::P).first::Int
+                                    popfirst!(st)
+                                else
+                                    push!(alt_parts, "\\")
+                                    alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+                                end
+                            else
+                                isempty(st) && error("parsing command `$str`: dangling backslash in brace expansion")
+                                alt_i = (peek(st)::P).first::Int
+                                popfirst!(st)
+                            end
+                        elseif !bsq && !bdq && bc == '{'
+                            bdepth += 1
+                            popfirst!(st)
+                        elseif !bsq && !bdq && bc == '}' && bdepth > 0
+                            bdepth -= 1
+                            popfirst!(st)
+                        elseif !bsq && !bdq && bc == '}' && bdepth == 0
+                            # End of brace expansion
+                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+                            push!(alts, _brace_alt_expr(alt_parts))
+                            popfirst!(st)
+                            break
+                        elseif !bsq && !bdq && bc == ',' && bdepth == 0
+                            # Alternative separator
+                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+                            push!(alts, _brace_alt_expr(alt_parts))
+                            empty!(alt_parts)
+                            popfirst!(st)
+                            alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+                        else
+                            popfirst!(st)
+                        end
+                    end
+                    i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+                    push!(arg, Expr(:tuple, alts...))
+                end
             elseif !in_single_quotes && !in_double_quotes && c in special
                 error("parsing command `$str`: special characters \"$special\" must be quoted in commands")
             end

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -329,16 +329,12 @@ const _login_shells = Base.OncePerProcess{Vector{String}}() do
     end
 end
 
-# pw_shell byte offset in struct passwd — everything before the pw_shell field:
-# Linux:     pw_name, pw_passwd (2 Ptrs), pw_uid, pw_gid (2 Cuints),
-#            pw_gecos, pw_dir (2 Ptrs)
-# macOS/BSD: same as Linux plus pw_change (Clong) and pw_class (Ptr)
-#            between pw_gid and pw_gecos
-const _pw_shell_offset = @static if Sys.islinux()
-    4 * sizeof(Ptr{Cvoid}) + 2 * sizeof(Cuint)
-else
-    5 * sizeof(Ptr{Cvoid}) + 2 * sizeof(Cuint) + sizeof(Clong)
-end
+# pw_uid byte offset in struct passwd: after pw_name and pw_passwd (two pointers),
+# consistent across Linux and macOS/BSD.
+const _pw_uid_offset = 2 * sizeof(Ptr{Cvoid})
+
+# getpwent_r is available on Linux and FreeBSD but not macOS.
+const _getpwent_lock = Base.ReentrantLock()
 
 # Return a sorted, deduplicated list of real local usernames. When all=false
 # (the default), service accounts are excluded by requiring their shell to be
@@ -347,26 +343,60 @@ function list_users(; all::Bool=false)
     seen = Set{String}()
     @static if !Sys.iswindows()
         valid_shells = all ? String[] : _login_shells()
-        ccall(:setpwent, Cvoid, ())
-        try
-            while true
-                ptr = ccall(:getpwent, Ptr{Cvoid}, ())
-                ptr == C_NULL && break
-                name_ptr = unsafe_load(Ptr{Ptr{UInt8}}(ptr))
-                name_ptr == C_NULL && continue
-                name = unsafe_string(name_ptr)
-                if !all
-                    @static Sys.isapple() && startswith(name, '_') && continue
-                    if !isempty(valid_shells)
-                        shell_ptr = unsafe_load(Ptr{Ptr{UInt8}}(ptr + _pw_shell_offset))
-                        shell_ptr == C_NULL && continue
-                        unsafe_string(shell_ptr) in valid_shells || continue
+        @static if Sys.islinux() || Sys.isfreebsd()
+            # Use thread-safe getpwent_r on Linux and FreeBSD.
+            pwd_storage = zeros(UInt8, 256)
+            buflen = 1024
+            str_buf = Vector{UInt8}(undef, buflen)
+            result = Ref{Ptr{Cvoid}}(C_NULL)
+            ccall(:setpwent, Cvoid, ())
+            try
+                while true
+                    ret = ccall(:getpwent_r, Cint,
+                                (Ptr{Cvoid}, Ptr{UInt8}, Csize_t, Ptr{Ptr{Cvoid}}),
+                                pwd_storage, str_buf, Csize_t(buflen), result)
+                    if ret == Base.Libc.ERANGE
+                        buflen *= 2
+                        buflen > 65536 && break
+                        str_buf = Vector{UInt8}(undef, buflen)
+                        continue
                     end
+                    (ret != 0 || result[] == C_NULL) && break
+                    uid = unsafe_load(Ptr{Cuint}(result[] + _pw_uid_offset))
+                    pd = Base.Libc.getpwuid(uid, false)
+                    pd === nothing && continue
+                    if !all && !isempty(valid_shells)
+                        pd.shell in valid_shells || continue
+                    end
+                    push!(seen, pd.username)
                 end
-                push!(seen, name)
+            finally
+                ccall(:endpwent, Cvoid, ())
             end
-        finally
-            ccall(:endpwent, Cvoid, ())
+        else
+            # macOS: getpwent_r is not available, so guard the
+            # entire setpwent/getpwent/endpwent sequence with a lock.
+            @lock _getpwent_lock begin
+                ccall(:setpwent, Cvoid, ())
+                try
+                    while true
+                        ptr = ccall(:getpwent, Ptr{Cvoid}, ())
+                        ptr == C_NULL && break
+                        uid = unsafe_load(Ptr{Cuint}(ptr + _pw_uid_offset))
+                        pd = Base.Libc.getpwuid(uid, false)
+                        pd === nothing && continue
+                        if !all
+                            startswith(pd.username, '_') && continue
+                            if !isempty(valid_shells)
+                                pd.shell in valid_shells || continue
+                            end
+                        end
+                        push!(seen, pd.username)
+                    end
+                finally
+                    ccall(:endpwent, Cvoid, ())
+                end
+            end
         end
     end
     return sort!(collect(seen))

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -629,6 +629,47 @@ let echostr = Base.shell_escape(echocmd)
     end
 end
 
+# Brace range expansion
+@test `{1..5}` == Cmd(["1", "2", "3", "4", "5"])
+@test `{a..e}` == Cmd(["a", "b", "c", "d", "e"])
+@test `{1..10..3}` == Cmd(["1", "4", "7", "10"])      # step
+@test `{a..z..5}` == Cmd(["a", "f", "k", "p", "u", "z"])
+@test `{10..1}` == Cmd(["10", "9", "8", "7", "6", "5", "4", "3", "2", "1"])
+@test `{z..a..5}` == Cmd(["z", "u", "p", "k", "f", "a"])
+@test `{01..05}` == Cmd(["01", "02", "03", "04", "05"])  # zero-padding
+@test `{001..3}` == Cmd(["001", "002", "003"])
+@test `{-2..2}` == Cmd(["-2", "-1", "0", "1", "2"])
+@test `{-03..3}` == Cmd(["-03", "-02", "-01", "000", "001", "002", "003"])
+@test `{-3..03}` == Cmd(["-3", "-2", "-1", "00", "01", "02", "03"])
+@test `{03..-3}` == Cmd(["03", "02", "01", "00", "-1", "-2", "-3"])
+@test `{-03..-1}` == Cmd(["-03", "-02", "-01"])
+@test `{5..1..2}` == Cmd(["5", "3", "1"])
+@test `{3..3}` == Cmd(["3"])
+@test `file{1..3}.txt` == Cmd(["file1.txt", "file2.txt", "file3.txt"])
+@test `{1..3}.{a..c}` == Cmd(["1.a", "1.b", "1.c", "2.a", "2.b", "2.c",
+                               "3.a", "3.b", "3.c"])
+@test `{a,b}.{1..3}` == Cmd(["a.1", "a.2", "a.3", "b.1", "b.2", "b.3"])
+@test_throws "invalid brace range expansion" eval(:(`{a..1}`))
+@test_throws "invalid brace range expansion" eval(:(`{a..Z}`))  # cross-case
+@test_throws "invalid brace range expansion" eval(:(`{A..z}`))
+@test `{A..E}` == Cmd(["A", "B", "C", "D", "E"])
+@test `{-2..+3}` == Cmd(["-2", "-1", "+0", "+1", "+2", "+3"])  # plus sign
+@test `{+1..+3}` == Cmd(["+1", "+2", "+3"])
+@test `{+3..-1}` == Cmd(["+3", "+2", "+1", "+0", "-1"])
+@test `{-1..+1}` == Cmd(["-1", "+0", "+1"])
+@test `{-02..+3}` == Cmd(["-02", "-01", "+00", "+01", "+02", "+03"])  # plus with padding
+@test `{-2..+03}` == Cmd(["-02", "-01", "+00", "+01", "+02", "+03"])
+@test `{-2..+4..2}` == Cmd(["-2", "+0", "+2", "+4"])  # plus with step
+# range expansion works through shell mode path
+let echostr = Base.shell_escape(echocmd)
+    mktempdir() do dir
+        f = joinpath(dir, "out.txt")
+        fstr = Base.shell_escape(f)
+        shell_mode_run("$echostr {1..3} > $fstr")
+        @test read(f, String) == "1 2 3\n"
+    end
+end
+
 # Pipeline and redirection operators in backtick command literals
 (!Sys.iswindows() || havebb) &&
 mktempdir() do dir

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -594,6 +594,41 @@ withenv("OLDPWD" => nothing) do
     end
 end
 
+# Brace expansion in backtick commands
+@test `{a,b,c}` == Cmd(["a", "b", "c"])
+@test `echo {a,b,c}` == Cmd(["echo", "a", "b", "c"])
+@test `{a,b}.txt` == Cmd(["a.txt", "b.txt"])
+@test `echo {a,b}.txt` == Cmd(["echo", "a.txt", "b.txt"])
+@test `{a,b}.{x,y}` == Cmd(["a.x", "a.y", "b.x", "b.y"])
+@test `echo pre{a,b}suf` == Cmd(["echo", "preasuf", "prebsuf"])
+@test `{a,b} {c,d}` == Cmd(["a", "b", "c", "d"])
+@test `{a,,c}` == Cmd(["a", "", "c"])  # empty alternative
+let x = "foo"
+    @test `{$x,bar}` == Cmd(["foo", "bar"])
+    @test `{$x,bar}.txt` == Cmd(["foo.txt", "bar.txt"])
+end
+let xs = "a b"
+    @test `{$xs,c}` == Cmd(["a b", "c"])  # interpolated value is not word-split
+end
+@test `{"hello world",bye}` == Cmd(["hello world", "bye"])  # quoted space in braces ok
+@test_throws "unquoted space inside braces" eval(:(`{a b,c}`))  # unquoted space is an error
+@test `{a\,b,c}` == Cmd(["a,b", "c"])  # escaped comma
+@test `'{a,b}'` == Cmd(["{a,b}"])       # braces in single quotes: no expansion
+@test `"{a,b}"` == Cmd(["{a,b}"])       # braces in double quotes: no expansion
+@test `{a}` == Cmd(["{a}"])             # single item: no expansion (literal)
+@test `{}` == Cmd(["{}"])               # empty braces: no expansion (literal)
+@test `x{y}z` == Cmd(["x{y}z"])        # no comma: literal
+@test `{a,{b,c},d}` == Cmd(["a", "{b,c}", "d"])  # nested braces: inner not expanded
+# brace expansion works through shell mode path
+let echostr = Base.shell_escape(echocmd)
+    mktempdir() do dir
+        f = joinpath(dir, "out.txt")
+        fstr = Base.shell_escape(f)
+        shell_mode_run("$echostr {a,b,c} > $fstr")
+        @test read(f, String) == "a b c\n"
+    end
+end
+
 # Pipeline and redirection operators in backtick command literals
 (!Sys.iswindows() || havebb) &&
 mktempdir() do dir


### PR DESCRIPTION
## Summary

Implement bash-style brace expansion in backtick `Cmd` syntax, building on top of #61540.

**Comma expansion:** `{a,b,c}` expands to three separate arguments, and brace groups participate in the existing `arg_gen` Cartesian product logic, so `` `pre{a,b}.{x,y}suf` `` produces all four combinations. Alternatives support `$` interpolation, quoting, and escape sequences. Braces without a comma (`{a}`, `{}`) are treated as literal characters, matching bash semantics. Unquoted whitespace inside braces is an error, following zsh.

**Range expansion:** `{1..10}` expands to `"1"` through `"10"`, `{a..z}` to `"a"` through `"z"`. Stepped ranges (`{1..10..2}`) and zero-padded ranges (`{01..10}`) are supported. Zero-padding pads to the total width of the wider endpoint (matching bash/zsh), so `{-03..3}` produces `"-03"` through `"003"`.

### Differences from bash/zsh

- Cross-case character ranges (`{a..Z}`, `{A..z}`) are an error rather than iterating through non-letter ASCII characters between `Z` and `a`.
- An explicit `+` sign on integer endpoints (`{-2..+3}`) causes non-negative values to be prefixed with `+`. This is a Julia-specific extension; bash/zsh do not support it.

This PR was written with the assistance of generative AI.

## Test plan

- Comprehensive unit tests for comma expansion, range expansion, zero-padding, negative numbers, `+` signs, cross-case errors, and invalid range errors.
- Shell mode end-to-end tests verify brace expansion works through the REPL `shell_parse` → `cmd_gen` path.