### PR TITLE
Add maxfailures option to limit test failures before stopping

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2266,8 +2266,9 @@ function testset_beginend_call(args, tests, source)
             # something in the test block threw an error. Count that as an
             # error in this test set
             trigger_test_failure_break(err)
-            if is_failfast_error(err)
-                get_testset_depth() > 0 ? rethrow() : (err isa MaxFailuresError ? maxfailures_print(err) : failfast_print())
+            real_err = err isa LoadError ? err.error : err
+            if is_failfast_error(real_err)
+                get_testset_depth() > 0 ? rethrow() : (real_err isa MaxFailuresError ? maxfailures_print(real_err) : failfast_print())
             else
                 record(ts, Error(:nontest_error, Expr(:tuple), err, Base.current_exceptions(), $(QuoteNode(source)), nothing))
             end
@@ -2351,8 +2352,9 @@ function testset_forloop(args, testloop, source)
             # Something in the test block threw an error. Count that as an
             # error in this test set
             trigger_test_failure_break(err)
-            if is_failfast_error(err)
-                get_testset_depth() > 0 ? rethrow() : (err isa MaxFailuresError ? maxfailures_print(err) : failfast_print())
+            real_err = err isa LoadError ? err.error : err
+            if is_failfast_error(real_err)
+                get_testset_depth() > 0 ? rethrow() : (real_err isa MaxFailuresError ? maxfailures_print(real_err) : failfast_print())
             else
                 record(ts, Error(:nontest_error, Expr(:tuple), err, Base.current_exceptions(), $(QuoteNode(source)), nothing))
             end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -30,7 +30,6 @@ export detect_ambiguities, detect_unbound_args, detect_closure_boxes, detect_clo
 export GenericString, GenericSet, GenericDict, GenericArray, GenericOrder
 export TestSetException
 export TestLogger, LogRecord
-export set_max_failures, get_max_failures, get_failure_count, reset_failure_count
 
 using Random
 using Random: AbstractRNG, default_rng
@@ -43,57 +42,9 @@ const global_fail_fast = OncePerProcess{Bool}() do
     return Base.get_bool_env("JULIA_TEST_FAILFAST", false)
 end
 
-# Global state for tracking test failures across testsets
+# Global state for maxfailures tracking (0 = disabled)
 const global_failure_count = Threads.Atomic{Int}(0)
-const global_failure_limit = Threads.Atomic{Int}(typemax(Int))
-
-"""
-    set_max_failures(n::Integer)
-
-Set the maximum number of test failures (fails + errors) allowed before stopping.
-Default is `typemax(Int)` (no limit). Set to `0` to stop on first failure.
-
-!!! compat "Julia 1.14"
-    This function requires at least Julia 1.14.
-"""
-function set_max_failures(n::Integer)
-    n >= 0 || throw(ArgumentError("maxfailures must be non-negative, got $n"))
-    Threads.atomic_xchg!(global_failure_limit, Int(n))
-    return n
-end
-
-"""
-    get_max_failures()
-
-Get the current failure limit. Returns `typemax(Int)` if no limit is set.
-
-!!! compat "Julia 1.14"
-    This function requires at least Julia 1.14.
-"""
-get_max_failures() = Threads.atomic_add!(global_failure_limit, 0)
-
-"""
-    get_failure_count()
-
-Get the current count of test failures (fails + errors).
-
-!!! compat "Julia 1.14"
-    This function requires at least Julia 1.14.
-"""
-get_failure_count() = Threads.atomic_add!(global_failure_count, 0)
-
-"""
-    reset_failure_count()
-
-Reset the failure counter to zero. Called at the start of test runs.
-
-!!! compat "Julia 1.14"
-    This function requires at least Julia 1.14.
-"""
-function reset_failure_count()
-    Threads.atomic_xchg!(global_failure_count, 0)
-    return nothing
-end
+global_failure_limit::Int = 0
 
 #-----------------------------------------------------------------------
 
@@ -1638,9 +1589,11 @@ function record(ts::DefaultTestSet, t::Union{Fail, Error}; print_result::Bool=TE
     end
     @lock ts.results_lock push!(ts.results, t)
     ts.failfast && throw(FailFastError())
-    # check maxfailures limit; +1 because atomic_add! returns the old value
-    count = Threads.atomic_add!(global_failure_count, 1) + 1
-    count >= global_failure_limit[] && throw(MaxFailuresError(global_failure_limit[], count))
+    limit = global_failure_limit
+    if limit > 0
+        count = Threads.atomic_add!(global_failure_count, 1) + 1
+        count >= limit && throw(MaxFailuresError(limit, count))
+    end
     return t
 end
 

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -30,6 +30,7 @@ export detect_ambiguities, detect_unbound_args, detect_closure_boxes, detect_clo
 export GenericString, GenericSet, GenericDict, GenericArray, GenericOrder
 export TestSetException
 export TestLogger, LogRecord
+export set_max_failures, get_max_failures, get_failure_count, reset_failure_count
 
 using Random
 using Random: AbstractRNG, default_rng
@@ -40,6 +41,58 @@ using Base.ScopedValues: LazyScopedValue, ScopedValue, @with
 
 const global_fail_fast = OncePerProcess{Bool}() do
     return Base.get_bool_env("JULIA_TEST_FAILFAST", false)
+end
+
+# Global state for tracking test failures across testsets
+const global_failure_count = Threads.Atomic{Int}(0)
+const global_failure_limit = Threads.Atomic{Int}(typemax(Int))
+
+"""
+    set_max_failures(n::Integer)
+
+Set the maximum number of test failures (fails + errors) allowed before stopping.
+Default is `typemax(Int)` (no limit). Set to `0` to stop on first failure.
+
+!!! compat "Julia 1.14"
+    This function requires at least Julia 1.14.
+"""
+function set_max_failures(n::Integer)
+    n >= 0 || throw(ArgumentError("maxfailures must be non-negative, got $n"))
+    Threads.atomic_xchg!(global_failure_limit, Int(n))
+    return n
+end
+
+"""
+    get_max_failures()
+
+Get the current failure limit. Returns `typemax(Int)` if no limit is set.
+
+!!! compat "Julia 1.14"
+    This function requires at least Julia 1.14.
+"""
+get_max_failures() = Threads.atomic_add!(global_failure_limit, 0)
+
+"""
+    get_failure_count()
+
+Get the current count of test failures (fails + errors).
+
+!!! compat "Julia 1.14"
+    This function requires at least Julia 1.14.
+"""
+get_failure_count() = Threads.atomic_add!(global_failure_count, 0)
+
+"""
+    reset_failure_count()
+
+Reset the failure counter to zero. Called at the start of test runs.
+
+!!! compat "Julia 1.14"
+    This function requires at least Julia 1.14.
+"""
+function reset_failure_count()
+    Threads.atomic_xchg!(global_failure_count, 0)
+    return nothing
 end
 
 #-----------------------------------------------------------------------
@@ -1547,6 +1600,11 @@ extract_file(::Nothing) = nothing
 
 struct FailFastError <: Exception end
 
+struct MaxFailuresError <: Exception
+    limit::Int
+    count::Int
+end
+
 # For a broken result, simply store the result
 record(ts::DefaultTestSet, t::Broken) = ((@lock ts.results_lock push!(ts.results, t)); t)
 # For a passed result, do not store the result since it uses a lot of memory, unless
@@ -1580,6 +1638,9 @@ function record(ts::DefaultTestSet, t::Union{Fail, Error}; print_result::Bool=TE
     end
     @lock ts.results_lock push!(ts.results, t)
     ts.failfast && throw(FailFastError())
+    # check maxfailures limit; +1 because atomic_add! returns the old value
+    count = Threads.atomic_add!(global_failure_count, 1) + 1
+    count >= global_failure_limit[] && throw(MaxFailuresError(global_failure_limit[], count))
     return t
 end
 
@@ -2144,6 +2205,7 @@ trigger_test_failure_break(@nospecialize(err)) =
     ccall(:jl_test_failure_breakpoint, Cvoid, (Any,), err)
 
 is_failfast_error(err::FailFastError) = true
+is_failfast_error(err::MaxFailuresError) = true
 is_failfast_error(err::LoadError) = is_failfast_error(err.error) # handle `include` barrier
 is_failfast_error(err) = false
 
@@ -2252,7 +2314,7 @@ function testset_beginend_call(args, tests, source)
             # error in this test set
             trigger_test_failure_break(err)
             if is_failfast_error(err)
-                get_testset_depth() > 0 ? rethrow() : failfast_print()
+                get_testset_depth() > 0 ? rethrow() : (err isa MaxFailuresError ? maxfailures_print(err) : failfast_print())
             else
                 record(ts, Error(:nontest_error, Expr(:tuple), err, Base.current_exceptions(), $(QuoteNode(source)), nothing))
             end
@@ -2273,6 +2335,11 @@ end
 function failfast_print()
     printstyled("\nFail-fast enabled:"; color = Base.error_color(), bold=true)
     printstyled(" Fail or Error occurred\n\n"; color = Base.error_color())
+end
+
+function maxfailures_print(err::MaxFailuresError)
+    printstyled("\nMax failures reached:"; color = Base.error_color(), bold=true)
+    printstyled(" $(err.count) failures (limit=$(err.limit))\n\n"; color = Base.error_color())
 end
 
 """
@@ -2332,7 +2399,7 @@ function testset_forloop(args, testloop, source)
             # error in this test set
             trigger_test_failure_break(err)
             if is_failfast_error(err)
-                get_testset_depth() > 0 ? rethrow() : failfast_print()
+                get_testset_depth() > 0 ? rethrow() : (err isa MaxFailuresError ? maxfailures_print(err) : failfast_print())
             else
                 record(ts, Error(:nontest_error, Expr(:tuple), err, Base.current_exceptions(), $(QuoteNode(source)), nothing))
             end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -42,9 +42,14 @@ const global_fail_fast = OncePerProcess{Bool}() do
     return Base.get_bool_env("JULIA_TEST_FAILFAST", false)
 end
 
-# Global state for maxfailures tracking (0 = disabled)
 const global_failure_count = Threads.Atomic{Int}(0)
-global_failure_limit::Int = 0
+const global_failure_limit = OncePerProcess{Union{Nothing,Int}}() do
+    val = get(ENV, "JULIA_TEST_MAXFAILURES", "")
+    isempty(val) && return nothing
+    n = tryparse(Int, val)
+    (n === nothing || n < 0) && return nothing
+    return n
+end
 
 #-----------------------------------------------------------------------
 
@@ -1589,8 +1594,8 @@ function record(ts::DefaultTestSet, t::Union{Fail, Error}; print_result::Bool=TE
     end
     @lock ts.results_lock push!(ts.results, t)
     ts.failfast && throw(FailFastError())
-    limit = global_failure_limit
-    if limit > 0
+    limit = global_failure_limit()
+    if limit !== nothing
         count = Threads.atomic_add!(global_failure_count, 1) + 1
         count >= limit && throw(MaxFailuresError(limit, count))
     end

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -1958,7 +1958,7 @@ end
             write(f,
             """
             using Test
-            Test.reset_failure_count()
+            Test.global_failure_count[] = 0
             @testset "outer" begin
                 @testset "First" begin
                     @test false
@@ -1981,8 +1981,8 @@ end
             write(f,
             """
             using Test
-            Test.reset_failure_count()
-            Test.set_max_failures(1)
+            Test.global_failure_count[] = 0
+            Test.global_failure_limit = 1
             @testset "outer" begin
                 @testset "First" begin
                     @test false
@@ -2004,8 +2004,8 @@ end
             write(f,
             """
             using Test
-            Test.reset_failure_count()
-            Test.set_max_failures(2)
+            Test.global_failure_count[] = 0
+            Test.global_failure_limit = 2
             @testset "outer" begin
                 @testset "First" begin
                     @test false
@@ -2028,8 +2028,8 @@ end
             write(f,
             """
             using Test
-            Test.reset_failure_count()
-            Test.set_max_failures(1)
+            Test.global_failure_count[] = 0
+            Test.global_failure_limit = 1
             @testset "outer" begin
                 @testset "First" begin
                     @test error("oops")
@@ -2046,16 +2046,13 @@ end
             @test !occursin(r"Test Summary:.*\n.*Second", result)
         end
     end
-    @testset "invalid maxfailures throws" begin
-        @test_throws ArgumentError Test.set_max_failures(-1)
-    end
     @testset "process exits with failure" begin
         mktemp() do f, _
             write(f,
             """
             using Test
-            Test.reset_failure_count()
-            Test.set_max_failures(1)
+            Test.global_failure_count[] = 0
+            Test.global_failure_limit = 1
             @testset "outer" begin
                 @testset "First" begin
                     @test false

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -1952,6 +1952,122 @@ end
     end
 end
 
+@testset "maxfailures option" begin
+    @testset "default (no limit)" begin
+        mktemp() do f, _
+            write(f,
+            """
+            using Test
+            Test.reset_failure_count()
+            @testset "outer" begin
+                @testset "First" begin
+                    @test false
+                    @test false
+                end
+                @testset "Second" begin
+                    @test true
+                end
+            end
+            """)
+            cmd = `$(Base.julia_cmd()) --startup-file=no --color=no $f`
+            result = read(pipeline(ignorestatus(cmd), stderr=devnull), String)
+            @test occursin("Test Summary:", result)
+            @test occursin("First", result)
+            @test occursin("Second", result)
+        end
+    end
+    @testset "stop after 1 failure" begin
+        mktemp() do f, _
+            write(f,
+            """
+            using Test
+            Test.reset_failure_count()
+            Test.set_max_failures(1)
+            @testset "outer" begin
+                @testset "First" begin
+                    @test false
+                end
+                @testset "Second" begin
+                    @test true
+                end
+            end
+            """)
+            cmd = `$(Base.julia_cmd()) --startup-file=no --color=no $f`
+            result = read(pipeline(ignorestatus(cmd), stderr=devnull), String)
+            @test occursin("Max failures reached: 1", result)
+            @test occursin("First", result)
+            @test !occursin(r"Test Summary:.*\n.*Second", result)
+        end
+    end
+    @testset "stop after N failures" begin
+        mktemp() do f, _
+            write(f,
+            """
+            using Test
+            Test.reset_failure_count()
+            Test.set_max_failures(2)
+            @testset "outer" begin
+                @testset "First" begin
+                    @test false
+                    @test false
+                end
+                @testset "Second" begin
+                    @test true
+                end
+            end
+            """)
+            cmd = `$(Base.julia_cmd()) --startup-file=no --color=no $f`
+            result = read(pipeline(ignorestatus(cmd), stderr=devnull), String)
+            @test occursin("Max failures reached: 2", result)
+            @test occursin("First", result)
+            @test !occursin(r"Test Summary:.*\n.*Second", result)
+        end
+    end
+    @testset "errors count toward limit" begin
+        mktemp() do f, _
+            write(f,
+            """
+            using Test
+            Test.reset_failure_count()
+            Test.set_max_failures(1)
+            @testset "outer" begin
+                @testset "First" begin
+                    @test error("oops")
+                end
+                @testset "Second" begin
+                    @test true
+                end
+            end
+            """)
+            cmd = `$(Base.julia_cmd()) --startup-file=no --color=no $f`
+            result = read(pipeline(ignorestatus(cmd), stderr=devnull), String)
+            @test occursin("Max failures reached: 1", result)
+            @test occursin("First", result)
+            @test !occursin(r"Test Summary:.*\n.*Second", result)
+        end
+    end
+    @testset "invalid maxfailures throws" begin
+        @test_throws ArgumentError Test.set_max_failures(-1)
+    end
+    @testset "process exits with failure" begin
+        mktemp() do f, _
+            write(f,
+            """
+            using Test
+            Test.reset_failure_count()
+            Test.set_max_failures(1)
+            @testset "outer" begin
+                @testset "First" begin
+                    @test false
+                end
+            end
+            """)
+            cmd = `$(Base.julia_cmd()) --startup-file=no --color=no $f`
+            @test !success(ignorestatus(cmd))
+        end
+    end
+end
+
 # Non-booleans in @test (#35888)
 struct T35888 end
 Base.isequal(::T35888, ::T35888) = T35888()


### PR DESCRIPTION
Fixes #21594
Fixes #23375

This came out of the triage discussion on #61483, where @oscardssmith suggested that instead of changing the default behavior of `@testset`, we should add a `maxfailures` option that test runners can use to control how many failures are tolerated before stopping execution. This PR implements the Test stdlib side of that.

There's a global atomic counter that tracks failures and errors across testsets, and a configurable limit. When the count hits the limit, a `MaxFailuresError` is thrown and execution stops. The default limit is `typemax(Int)`, so existing behavior is completely unchanged unless you explicitly call `set_max_failures`.

Four new functions are exported from Test:
- `set_max_failures(n)` - set the limit
- `get_max_failures()` - read the current limit
- `get_failure_count()` - read the current failure count
- `reset_failure_count()` - reset the counter to zero

The `MaxFailuresError` integrates with the existing `is_failfast_error` machinery, so it propagates correctly through nested testsets the same way `FailFastError` does. If both `failfast` and `maxfailures` are set, `failfast` takes precedence since it's checked first in `record`.

The intended usage is for something like `Pkg.test(; maxfailures=10)` to call `Test.set_max_failures(10)` before running tests, which would be a follow-up PR.