### PR TITLE
Fix `--trim` compatibility for `BoundsError`

### DIFF
--- a/contrib/juliac/juliac-trim-base.jl
+++ b/contrib/juliac/juliac-trim-base.jl
@@ -80,7 +80,9 @@ end
     end
     # these functions are not `--trim`-compatible if it resolves to a Varargs{...} specialization
     # and since it only has 1-argument methods this happens too often by default (just 2-3 args)
+    setfield!(typeof(throw_boundserror).name, :max_args, Int32(5), :monotonic)
     setfield!(typeof(throw_eachindex_mismatch_indices).name, :max_args, Int32(5), :monotonic)
+    setfield!(typeof(_throw_boundserror_indices).name, :max_args, Int32(5), :monotonic)
     setfield!(typeof(print).name, :max_args, Int32(10), :monotonic)
     setfield!(typeof(println).name, :max_args, Int32(10), :monotonic)
     setfield!(typeof(print_to_string).name, :max_args, Int32(10), :monotonic)

--- a/deps/jlutilities/juliac/Manifest.toml
+++ b/deps/jlutilities/juliac/Manifest.toml
@@ -1,0 +1,391 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.14.0-DEV"
+manifest_format = "2.1"
+project_hash = "d3f4758b27fc8d19cd1b7603061a3b69d4285c69"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.2"
+
+    [deps.ArgTools.syntax]
+    julia_version = "1.3.0"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+    [deps.Artifacts.syntax]
+    julia_version = "1.14.0-DEV.2012"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+    [deps.Base64.syntax]
+    julia_version = "1.14.0-DEV.2012"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.0+1"
+
+    [deps.CompilerSupportLibraries_jll.syntax]
+    julia_version = "1.6.0"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+    [deps.Dates.syntax]
+    julia_version = "1.14.0-DEV.2012"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.7.0"
+
+    [deps.Downloads.syntax]
+    julia_version = "1.10.0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
+
+    [deps.FileWatching.syntax]
+    julia_version = "1.14.0-DEV.2012"
+
+[[deps.Glob]]
+git-tree-sha1 = "83cb0092e2792b9e3a865b6655e88f5b862607e2"
+registries = "General"
+uuid = "c27321d9-0574-5035-807b-f59d2c89b15c"
+version = "1.4.0"
+
+    [deps.Glob.syntax]
+    julia_version = "1.0.0"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "0533e564aae234aff59ab625543145446d8b6ec2"
+registries = "General"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.7.1"
+
+    [deps.JLLWrappers.syntax]
+    julia_version = "1.0.0"
+
+[[deps.JuliaC]]
+deps = ["LazyArtifacts", "Libdl", "Mmap", "ObjectFile", "PackageCompiler", "Patchelf_jll", "Pkg", "RelocatableFolders", "StructIO"]
+git-tree-sha1 = "d2d87d6d9f7a12c695bc23db869cdd9d4bcbccde"
+repo-rev = "main"
+repo-url = "https://github.com/JuliaLang/JuliaC.jl.git"
+uuid = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
+version = "0.3.1"
+
+    [deps.JuliaC.syntax]
+    julia_version = "1.10.0"
+
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.13.0"
+
+    [deps.JuliaSyntaxHighlighting.syntax]
+    julia_version = "1.12.0"
+
+[[deps.LazyArtifacts]]
+deps = ["Artifacts", "Pkg"]
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+version = "1.11.0"
+
+    [deps.LazyArtifacts.syntax]
+    julia_version = "1.11.0"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "1.0.0"
+
+    [deps.LibCURL.syntax]
+    julia_version = "1.3.0"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "Zstd_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.19.0+0"
+
+    [deps.LibCURL_jll.syntax]
+    julia_version = "1.11.0"
+
+[[deps.LibGit2]]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+    [deps.LibGit2.syntax]
+    julia_version = "1.14.0-DEV.2012"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.9.2+0"
+
+    [deps.LibGit2_jll.syntax]
+    julia_version = "1.9.0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl", "OpenSSL_jll", "Zlib_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.3+1"
+
+    [deps.LibSSH2_jll.syntax]
+    julia_version = "1.8.0"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+    [deps.Libdl.syntax]
+    julia_version = "1.14.0-DEV.2012"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+    [deps.Logging.syntax]
+    julia_version = "1.14.0-DEV.2012"
+
+[[deps.Markdown]]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+    [deps.Markdown.syntax]
+    julia_version = "1.14.0-DEV.2012"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
+
+    [deps.Mmap.syntax]
+    julia_version = "1.14.0-DEV.2012"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2026.3.19"
+
+    [deps.MozillaCACerts_jll.syntax]
+    julia_version = "1.14.0-DEV.2012"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.3.0"
+
+    [deps.NetworkOptions.syntax]
+    julia_version = "1.12.0"
+
+[[deps.ObjectFile]]
+deps = ["Reexport", "StructIO"]
+git-tree-sha1 = "22faba70c22d2f03e60fbc61da99c4ebfc3eb9ba"
+registries = "General"
+uuid = "d8793406-e978-5875-9003-1fc021f44a92"
+version = "0.5.0"
+
+    [deps.ObjectFile.syntax]
+    julia_version = "1.6.0"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.5.6+0"
+
+    [deps.OpenSSL_jll.syntax]
+    julia_version = "1.6.0"
+
+[[deps.PCRE2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
+version = "10.47.0+0"
+
+    [deps.PCRE2_jll.syntax]
+    julia_version = "1.6.0"
+
+[[deps.PackageCompiler]]
+deps = ["Artifacts", "Glob", "LazyArtifacts", "Libdl", "Pkg", "Printf", "RelocatableFolders", "TOML", "UUIDs", "p7zip_jll"]
+git-tree-sha1 = "7b2dbae3d0eda41dad445b5f36f40588c208a942"
+registries = "General"
+uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
+version = "2.2.5"
+
+    [deps.PackageCompiler.syntax]
+    julia_version = "1.10.0"
+
+[[deps.Patchelf_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "ad1cab3e8273c912f722f40779e20f3e29d58f1f"
+registries = "General"
+uuid = "f2cf89d6-2bfd-5c44-bd2c-068eea195c0c"
+version = "0.18.0+0"
+
+    [deps.Patchelf_jll.syntax]
+    julia_version = "1.6.0"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "Zstd_jll", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.14.0"
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+    [deps.Pkg.syntax]
+    julia_version = "1.12.0"
+
+    [deps.Pkg.weakdeps]
+    REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+registries = "General"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
+    [deps.Preferences.syntax]
+    julia_version = "1.0.0"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+    [deps.Printf.syntax]
+    julia_version = "1.14.0-DEV.2012"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+    [deps.Random.syntax]
+    julia_version = "1.14.0-DEV.2012"
+
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+registries = "General"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+    [deps.Reexport.syntax]
+    julia_version = "1.0.0"
+
+[[deps.RelocatableFolders]]
+deps = ["SHA", "Scratch"]
+git-tree-sha1 = "ffdaf70d81cf6ff22c2b6e733c900c3321cab864"
+registries = "General"
+uuid = "05181044-ff0b-4ac5-8273-598c1e38db00"
+version = "1.0.1"
+
+    [deps.RelocatableFolders.syntax]
+    julia_version = "1.0.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "1.0.0"
+
+    [deps.SHA.syntax]
+    julia_version = "1.0.0"
+
+[[deps.Scratch]]
+deps = ["Dates"]
+git-tree-sha1 = "9b81b8393e50b7d4e6d0a9f14e192294d3b7c109"
+registries = "General"
+uuid = "6c6a2e73-6563-6170-7368-637461726353"
+version = "1.3.0"
+
+    [deps.Scratch.syntax]
+    julia_version = "1.9.0"
+
+[[deps.StructIO]]
+git-tree-sha1 = "c581be48ae1cbf83e899b14c07a807e1787512cc"
+registries = "General"
+uuid = "53d494c1-5632-5724-8f4c-31dff12d585f"
+version = "0.3.1"
+
+    [deps.StructIO.syntax]
+    julia_version = "1.0.0"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.13.0"
+
+    [deps.StyledStrings.syntax]
+    julia_version = "1.11.0"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+    [deps.TOML.syntax]
+    julia_version = "1.6.0"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+    [deps.Tar.syntax]
+    julia_version = "1.3.0"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+    [deps.UUIDs.syntax]
+    julia_version = "1.14.0-DEV.2012"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+    [deps.Unicode.syntax]
+    julia_version = "1.14.0-DEV.2012"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.3.2+0"
+
+    [deps.Zlib_jll.syntax]
+    julia_version = "1.6.0"
+
+[[deps.Zstd_jll]]
+deps = ["CompilerSupportLibraries_jll", "Libdl"]
+uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
+version = "1.5.7+1"
+
+    [deps.Zstd_jll.syntax]
+    julia_version = "1.6.0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.68.1+0"
+
+    [deps.nghttp2_jll.syntax]
+    julia_version = "1.11.0"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.8.0+0"
+
+    [deps.p7zip_jll.syntax]
+    julia_version = "1.6.0"
+
+[registries.General]
+url = "https://github.com/JuliaRegistries/General.git"
+uuid = "23338594-aafe-5451-b93e-139f81909106"

--- a/deps/jlutilities/juliac/Project.toml
+++ b/deps/jlutilities/juliac/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+JuliaC = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
+
+[sources]
+JuliaC = {rev = "main", url = "https://github.com/JuliaLang/JuliaC.jl.git"}


### PR DESCRIPTION
This regressed in https://github.com/JuliaLang/julia/pull/61535 but wasn't being tested until https://github.com/JuliaLang/julia/pull/61551, which caused CI to fail only after merging both (sorry folks!)

JuliaC.jl is already fixed up by https://github.com/JuliaLang/JuliaC.jl/pull/131. This PR resolves the Julia-side scripts. Also check in the `Manifest.toml` for JuliaC to prevent breaking CI in the future, although it wouldn't have prevented this regression.

Supersedes https://github.com/JuliaLang/julia/pull/61558.