### PR TITLE
shell: refactor shell_parse into smaller functions

### DIFF
--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -199,7 +199,7 @@ function show(io::IO, cmd::Cmd)
     join(io, map(cmd.exec) do arg
         replace(sprint(context=io) do io
             with_output_color(:underline, io) do io
-                print_shell_word(io, arg, shell_special)
+                print_shell_word(io, arg, _shell_display_special)
             end
         end, '`' => "\\`")
     end, ' ')

--- a/base/path.jl
+++ b/base/path.jl
@@ -684,7 +684,7 @@ function homedir(username::AbstractString)
     # For the current user, just return homedir().
     current_user = try
         Sys.username()
-    catch
+    catch err
         err isa IOError || rethrow()
         nothing
     end
@@ -792,7 +792,7 @@ function homedir(username::AbstractString)
         ret = ccall(:getpwnam_r, Cint,
                     (Cstring, Ptr{Cvoid}, Ptr{UInt8}, Csize_t, Ptr{Ptr{Cvoid}}),
                     username, pwd_storage, str_buf, Csize_t(buflen), result)
-        if ret == 34  # ERANGE: string buffer too small, retry with more space
+        if ret == Libc.ERANGE  # string buffer too small, retry with more space
             buflen *= 2
         elseif ret == 0 && result[] != C_NULL
             # pw_uid sits at offset 2*sizeof(Ptr) in struct passwd on all supported

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -34,10 +34,11 @@ function rstrip_shell(s::AbstractString)
 end)
 
 # Scan from position `start` in string `s` (after an opening `{`) to find the
-# matching `}`. Returns `(found_close, has_comma, has_space)`.
+# matching `}`. Returns `(found_close, has_comma, has_dotdot, has_space)`.
 function _scan_brace(s, start)
     depth = 1
     has_comma = false
+    has_dotdot = false
     has_space = false
     pos = start
     @inbounds while pos <= lastindex(s)
@@ -69,17 +70,85 @@ function _scan_brace(s, start)
             end
         elseif isspace(c)
             has_space = true
+        elseif c == '.' && depth == 1 && pos < lastindex(s) && s[nextind(s, pos)] == '.'
+            has_dotdot = true
+            pos = nextind(s, pos)  # skip second dot
         elseif c == '{'
             depth += 1
         elseif c == '}'
             depth -= 1
-            depth == 0 && return (true, has_comma, has_space)
+            depth == 0 && return (true, has_comma, has_dotdot, has_space)
         elseif c == ',' && depth == 1
             has_comma = true
         end
         pos = nextind(s, pos)
     end
-    return (false, false, false)
+    return (false, false, false, false)
+end
+
+# Expand a brace range pattern like "1..10", "a..z", "1..10..2", or "01..10".
+# Returns a tuple of strings, or `nothing` if the content is not a valid range.
+function _brace_range_expand(content::AbstractString)
+    parts = split(content, "..")
+    (length(parts) == 2 || length(parts) == 3) || return nothing
+    a_str, b_str = parts[1], parts[2]
+    step_str = length(parts) == 3 ? parts[3] : nothing
+
+    # Character range: single ASCII letter endpoints, both same case
+    if length(a_str) == 1 && length(b_str) == 1
+        a_ch, b_ch = a_str[1], b_str[1]
+        if isletter(a_ch) && isletter(b_ch) && isascii(a_ch) && isascii(b_ch)
+            if isuppercase(a_ch) != isuppercase(b_ch)
+                return nothing  # cross-case ranges like {a..Z} are an error
+            end
+            step = 1
+            if step_str !== nothing
+                step = tryparse(Int, step_str)
+                step === nothing && return nothing
+                step == 0 && return nothing
+            end
+            step = a_ch <= b_ch ? step : -step
+            return Tuple(string(c) for c in a_ch:step:b_ch)
+        end
+    end
+
+    # Integer range
+    a = tryparse(Int, a_str)
+    b = tryparse(Int, b_str)
+    (a === nothing || b === nothing) && return nothing
+    step = 1
+    if step_str !== nothing
+        step = tryparse(Int, step_str)
+        step === nothing && return nothing
+        step == 0 && return nothing
+    end
+    step = a <= b ? step : -step
+
+    # Explicit plus sign: if either endpoint starts with +, show + on positive values.
+    show_plus = (a_str[1] == '+') || (b_str[1] == '+')
+
+    # Zero-padding: if either endpoint has leading zeros (including after a
+    # sign character), pad all values to the same total width (matching bash/zsh).
+    _has_leading_zero(s) = (length(s) > 1 && s[1] == '0') ||
+                           (length(s) > 2 && s[1] in ('-', '+') && s[2] == '0')
+    pad = (_has_leading_zero(a_str) || _has_leading_zero(b_str)) ?
+        max(length(a_str), length(b_str)) : 0
+
+    if pad > 0
+        return Tuple(let s = string(abs(n))
+            if n < 0
+                "-" * lpad(s, pad - 1, '0')
+            elseif show_plus
+                "+" * lpad(s, pad - 1, '0')
+            else
+                lpad(s, pad, '0')
+            end
+        end for n in a:step:b)
+    elseif show_plus
+        return Tuple((n < 0 ? string(n) : "+" * string(n)) for n in a:step:b)
+    else
+        return Tuple(string(n) for n in a:step:b)
+    end
 end
 
 # Convert a list of parts (strings and expressions) for one brace alternative
@@ -347,8 +416,28 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
                 # The tuple integrates with arg_gen's Cartesian product, so
                 # `pre{a,b}suf` generates arguments "preasuf" and "prebsuf".
                 i = consume_upto!(arg, s, i, j)
-                found_close, has_comma, has_space = _scan_brace(s, i)
-                if found_close && has_comma && has_space
+                found_close, has_comma, has_dotdot, has_space = _scan_brace(s, i)
+                if found_close && has_dotdot && !has_comma
+                    # Range expansion: {1..10}, {a..z}, {1..10..2}, {01..10}
+                    # Extract the raw content between { and }, advance past }.
+                    brace_content = ""
+                    while !isempty(st)
+                        (bp, bc) = peek(st)::P
+                        if bc == '}'
+                            brace_content = String(s[i:prevind(s, bp)::Int])
+                            popfirst!(st)
+                            break
+                        end
+                        popfirst!(st)
+                    end
+                    i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+                    expanded = _brace_range_expand(brace_content)
+                    if expanded === nothing
+                        error("parsing command `$str`: invalid brace range expansion {$brace_content}")
+                    end
+                    push!(arg, Expr(:tuple, expanded...))
+                    word_has_special = true
+                elseif found_close && has_comma && has_space
                     error("parsing command `$str`: unquoted space inside braces")
                 elseif !(found_close && has_comma)
                     # Not a valid brace expansion (no matching } or no comma):

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -168,6 +168,304 @@ function _brace_alt_expr(parts)
     end
 end
 
+## Helper functions for shell_parse ##
+
+function _push_nonempty!(list, x)
+    if !isa(x,AbstractString) || !isempty(x)
+        push!(list, x)
+    end
+    return nothing
+end
+
+function _consume_upto!(list, st, s, i, j)
+    _push_nonempty!(list, s[i:prevind(s, j)::Int])
+    something(peek(st), lastindex(s)::Int+1 => '\0').first::Int
+end
+
+function _append_word!(list, innerlist)
+    if isempty(innerlist); push!(innerlist, ""); end
+    push!(list, copy(innerlist))
+    empty!(innerlist)
+end
+
+function _redirect_word_expr(word)
+    if length(word) == 1 && isa(word[1], AbstractString)
+        return String(word[1])
+    else
+        return Expr(:call, GlobalRef(Base, :cmd_interpolate), word...)
+    end
+end
+
+# Parse the expression following a `$` interpolation marker.
+# Pops the first char of the expression from `st`, parses the atom, advances
+# `s` past it, and resets `st`. Returns `(expr, new_s, interp_pos)` where
+# `interp_pos` is the absolute position in `str` (for REPLCompletions).
+function _parse_dollar_interp(st, s, ::Type{P}, filename) where P
+    isempty(st) && error("\$ right before end of command")
+    stpos, c = popfirst!(st)::P
+    isspace(c) && error("space not allowed right after \$")
+    if startswith(SubString(s, stpos), "var\"")
+        # Disallow var"#" syntax in cmd interpolations.
+        # TODO: Allow only identifiers after the $ for consistency with
+        # string interpolation syntax (see #3150)
+        atom, j = :var, stpos+3
+    else
+        # use parseatom instead of parse to respect filename (#28188)
+        atom, j = Meta.parseatom(s, stpos, filename=filename)
+    end
+    interp_pos = stpos + s.offset
+    s = SubString(s, j)
+    Iterators.reset!(st, pairs(s))
+    return atom, s, interp_pos
+end
+
+# Redirect state for the current pipeline segment.
+mutable struct _RedirectState
+    stdin::Any
+    stdout::Any
+    stdout_append::Bool
+    stderr::Any
+    stderr_append::Bool
+    mode::Symbol  # :none | :stdin | :stdout | :stderr
+end
+_RedirectState() = _RedirectState(nothing, nothing, false, nothing, false, :none)
+
+function _reset_redirect!(r::_RedirectState)
+    r.stdin = nothing
+    r.stdout = nothing
+    r.stdout_append = false
+    r.stderr = nothing
+    r.stderr_append = false
+    r.mode = :none
+    return nothing
+end
+
+# Finalize the current word: if we're in redirect mode, assign the word as the redirect
+# filename; otherwise append it as a command argument.
+function _finalize_word!(args, arg, redir::_RedirectState, word_has_special::Bool)
+    if redir.mode != :none && (!isempty(arg) || word_has_special)
+        re = _redirect_word_expr(arg)
+        if redir.mode === :stdin; redir.stdin = re
+        elseif redir.mode === :stdout; redir.stdout = re
+        else; redir.stderr = re; end
+        empty!(arg)
+        redir.mode = :none
+    elseif redir.mode == :none && (!isempty(arg) || word_has_special)
+        _append_word!(args, arg)
+    end
+    return nothing
+end
+
+# Save the current pipeline segment and reset state for the next segment.
+function _save_pipeline_segment!(pipeline_parts, args, redir::_RedirectState)
+    seg_tuple = Expr(:tuple)
+    for a in args; push!(seg_tuple.args, Expr(:tuple, a...)); end
+    push!(pipeline_parts, (seg_tuple, redir.stdin, redir.stdout, redir.stdout_append,
+                           redir.stderr, redir.stderr_append))
+    empty!(args)
+    _reset_redirect!(redir)
+    return nothing
+end
+
+# Parse tilde expansion (~, ~user, ~$var) at the start of a word.
+# `i` should point to the position just after the `~` character.
+# Returns (s, i).
+function _parse_tilde!(arg, st, s, i, ::Type{P}, filename) where P
+    user_parts = []
+    user_lit_start = i
+    while !isempty(st)
+        nxt = peek(st)::P
+        nc = nxt[2]
+        (nc == '/' || isspace(nc) || nc == '\'' || nc == '"' || nc == '\\' ||
+         nc == '|' || nc == '<' || nc == '>') && break
+        if nc == '$'
+            _push_nonempty!(user_parts, s[user_lit_start:prevind(s, nxt[1])])
+            popfirst!(st)  # consume $
+            atom, s, _ = _parse_dollar_interp(st, s, P, filename)
+            push!(user_parts, atom)
+            i = firstindex(s)
+            user_lit_start = i
+        else
+            popfirst!(st)
+        end
+    end
+    user_end = something(peek(st), (lastindex(s) + 1) => '\0').first
+    _push_nonempty!(user_parts, s[user_lit_start:prevind(s, user_end)])
+    if isempty(user_parts)
+        push!(arg, :(expanduser("~")))
+    elseif length(user_parts) == 1 && isa(user_parts[1], AbstractString)
+        push!(arg, :(expanduser($("~" * user_parts[1]))))
+    else
+        push!(arg, :(let _u = string($(user_parts...)); isempty(_u) ? "~" : expanduser(string('~', _u)) end))
+    end
+    return s, user_end
+end
+
+# Parse comma-separated brace alternatives: {alt1,alt2,...}
+# `i` should point to the position just after the opening `{`.
+# Returns (alts, s, i, last_arg, update_last_arg).
+function _parse_brace_alts!(st, s, i, ::Type{P}, str, filename, last_arg, update_last_arg) where P
+    alts = Any[]
+    alt_parts = Any[]
+    alt_i = i   # start of current literal segment
+    bsq = false # single quotes within brace content
+    bdq = false # double quotes within brace content
+    bdepth = 0  # nested brace depth
+    while !isempty(st)
+        (bp, bc) = peek(st)::P
+        if bsq
+            # In single quotes: everything is literal until closing '
+            popfirst!(st)
+            if bc == '\''
+                _push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+                bsq = false
+                alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+            end
+        elseif !bdq && bc == '\''
+            _push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+            popfirst!(st)
+            bsq = true
+            alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+        elseif bc == '"'
+            _push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+            popfirst!(st)
+            bdq = !bdq
+            alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+        elseif !bsq && bc == '$'
+            _push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+            popfirst!(st)
+            atom, s, interp_pos = _parse_dollar_interp(st, s, P, filename)
+            push!(alt_parts, atom)
+            last_arg = interp_pos
+            update_last_arg = true
+            alt_i = firstindex(s)
+        elseif !bsq && bc == '\\'
+            _push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+            popfirst!(st)  # consume \
+            if bdq
+                if !isempty(st) && (peek(st)::P).second in ('"', '$', '\\')
+                    alt_i = (peek(st)::P).first::Int
+                    popfirst!(st)
+                else
+                    push!(alt_parts, "\\")
+                    alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+                end
+            else
+                isempty(st) && error("parsing command `$str`: dangling backslash in brace expansion")
+                alt_i = (peek(st)::P).first::Int
+                popfirst!(st)
+            end
+        elseif !bsq && !bdq && bc == '{'
+            bdepth += 1
+            popfirst!(st)
+        elseif !bsq && !bdq && bc == '}' && bdepth > 0
+            bdepth -= 1
+            popfirst!(st)
+        elseif !bsq && !bdq && bc == '}' && bdepth == 0
+            # End of brace expansion
+            _push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+            push!(alts, _brace_alt_expr(alt_parts))
+            popfirst!(st)
+            break
+        elseif !bsq && !bdq && bc == ',' && bdepth == 0
+            # Alternative separator
+            _push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+            push!(alts, _brace_alt_expr(alt_parts))
+            empty!(alt_parts)
+            popfirst!(st)
+            alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+        else
+            popfirst!(st)
+        end
+    end
+    i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+    return alts, s, i, last_arg, update_last_arg
+end
+
+# Parse brace expansion at current position.
+# `i` should point to the position just after the opening `{`.
+# Returns (s, i, word_has_special, last_arg, update_last_arg).
+function _parse_brace!(arg, st, s, i, ::Type{P}, str, filename, last_arg, update_last_arg) where P
+    found_close, has_comma, has_dotdot, has_space = _scan_brace(s, i)
+    if found_close && has_dotdot && !has_comma
+        # Range expansion: {1..10}, {a..z}, {1..10..2}, {01..10}
+        brace_content = ""
+        while !isempty(st)
+            (bp, bc) = peek(st)::P
+            if bc == '}'
+                brace_content = String(s[i:prevind(s, bp)::Int])
+                popfirst!(st)
+                break
+            end
+            popfirst!(st)
+        end
+        i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+        expanded = _brace_range_expand(brace_content)
+        if expanded === nothing
+            error("parsing command `$str`: invalid brace range expansion {$brace_content}")
+        end
+        push!(arg, Expr(:tuple, expanded...))
+        return s, i, true, last_arg, update_last_arg
+    elseif found_close && has_comma && has_space
+        error("parsing command `$str`: unquoted space inside braces")
+    elseif !(found_close && has_comma)
+        # Not a valid brace expansion (no matching } or no comma):
+        # treat the { as a literal character.
+        push!(arg, "{")
+        return s, i, false, last_arg, update_last_arg
+    else
+        alts, s, i, last_arg, update_last_arg =
+            _parse_brace_alts!(st, s, i, P, str, filename, last_arg, update_last_arg)
+        push!(arg, Expr(:tuple, alts...))
+        return s, i, true, last_arg, update_last_arg
+    end
+end
+
+# Build expression for a single pipeline segment with optional redirections.
+function _build_seg_expr(seg_tuple, s_in, s_out, s_out_app, s_err, s_err_app)
+    cmd_ex = Expr(:call, GlobalRef(Base, :cmd_gen), seg_tuple)
+    if s_in !== nothing || s_out !== nothing
+        kwargs = Any[]
+        s_in !== nothing && push!(kwargs, Expr(:kw, :stdin, s_in))
+        s_out !== nothing && push!(kwargs, Expr(:kw, :stdout, s_out))
+        s_out_app && push!(kwargs, Expr(:kw, :append, true))
+        cmd_ex = Expr(:call, GlobalRef(Base, :pipeline), Expr(:parameters, kwargs...), cmd_ex)
+    end
+    if s_err !== nothing
+        kwargs = Any[Expr(:kw, :stderr, s_err)]
+        s_err_app && push!(kwargs, Expr(:kw, :append, true))
+        cmd_ex = Expr(:call, GlobalRef(Base, :pipeline), Expr(:parameters, kwargs...), cmd_ex)
+    end
+    return cmd_ex
+end
+
+# Build the final expression for a pipeline with redirections.
+function _build_pipeline_expr(pipeline_parts, args, redir::_RedirectState)
+    final_seg_tuple = Expr(:tuple)
+    for a in args; push!(final_seg_tuple.args, Expr(:tuple, a...)); end
+
+    if isempty(pipeline_parts)
+        # Only redirects, no pipes.
+        return _build_seg_expr(final_seg_tuple, redir.stdin, redir.stdout, redir.stdout_append,
+                               redir.stderr, redir.stderr_append)
+    end
+
+    # Chain pipeline segments left-to-right: pipeline(seg1, pipeline(seg2, seg3, ...)).
+    (s0_args, s0_in, s0_out, s0_out_app, s0_err, s0_err_app) = pipeline_parts[1]
+    result = _build_seg_expr(s0_args, s0_in, s0_out, s0_out_app, s0_err, s0_err_app)
+    for k in 2:length(pipeline_parts)
+        (sk_args, sk_in, sk_out, sk_out_app, sk_err, sk_err_app) = pipeline_parts[k]
+        result = Expr(:call, GlobalRef(Base, :pipeline), result,
+                      _build_seg_expr(sk_args, sk_in, sk_out, sk_out_app, sk_err, sk_err_app))
+    end
+    result = Expr(:call, GlobalRef(Base, :pipeline), result,
+                  _build_seg_expr(final_seg_tuple, redir.stdin, redir.stdout, redir.stdout_append,
+                                   redir.stderr, redir.stderr_append))
+    return result
+end
+
+## Main shell_parse entry point ##
+
 shell_parse(str::AbstractString, interpolate::Bool=true;
             special::AbstractString="", filename="none") =
     __repl_entry_shell_parse(str, interpolate, special, filename)
@@ -190,126 +488,42 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
     update_last_arg = false # true after spaces or interpolate
     word_has_special = false # true if current word contains any quoted/escaped content
 
-    # Pipeline/redirection state (used only when interpolate=true).
-    # pipeline_parts accumulates completed segments as (seg_tuple, stdin, stdout, stdout_append, stderr, stderr_append).
     pipeline_parts = []
-    seg_stdin = nothing        # stdin redirect expression for current segment
-    seg_stdout = nothing       # stdout redirect expression for current segment
-    seg_stdout_append = false  # true if stdout redirect is >> (append mode)
-    seg_stderr = nothing       # stderr redirect expression for current segment
-    seg_stderr_append = false  # true if stderr redirect is >> (append mode)
-    redirect_mode = :none      # :none | :stdin | :stdout | :stderr
-
-    function push_nonempty!(list, x)
-        if !isa(x,AbstractString) || !isempty(x)
-            push!(list, x)
-        end
-        return nothing
-    end
-    function consume_upto!(list, s, i, j)
-        push_nonempty!(list, s[i:prevind(s, j)::Int])
-        something(peek(st), lastindex(s)::Int+1 => '\0').first::Int
-    end
-    function append_2to1!(list, innerlist)
-        if isempty(innerlist); push!(innerlist, ""); end
-        push!(list, copy(innerlist))
-        empty!(innerlist)
-    end
+    redir = _RedirectState()
 
     C = eltype(str)
     P = Pair{Int,C}
-
-    # Parse the expression following a `$` interpolation marker.
-    # Pops the first char of the expression from `st`, parses the atom, advances
-    # `s` past it, and resets `st`. Returns `(expr, new_s, interp_pos)` where
-    # `interp_pos` is the absolute position in `str` (for REPLCompletions).
-    function parse_dollar_interp(st, s)
-        isempty(st) && error("\$ right before end of command")
-        stpos, c = popfirst!(st)::P
-        isspace(c) && error("space not allowed right after \$")
-        if startswith(SubString(s, stpos), "var\"")
-            # Disallow var"#" syntax in cmd interpolations.
-            # TODO: Allow only identifiers after the $ for consistency with
-            # string interpolation syntax (see #3150)
-            atom, j = :var, stpos+3
-        else
-            # use parseatom instead of parse to respect filename (#28188)
-            atom, j = Meta.parseatom(s, stpos, filename=filename)
-        end
-        interp_pos = stpos + s.offset
-        s = SubString(s, j)
-        Iterators.reset!(st, pairs(s))
-        return atom, s, interp_pos
-    end
-
-    # Convert a word (list of string/expr parts) to a redirect filename expression.
-    function redirect_word_expr(word)
-        if length(word) == 1 && isa(word[1], AbstractString)
-            return String(word[1])
-        else
-            return Expr(:call, GlobalRef(Base, :cmd_interpolate), word...)
-        end
-    end
 
     for (j, c) in st
         j, c = j::Int, c::C
         if !in_single_quotes && !in_double_quotes && isspace(c)
             update_last_arg = true
-            i = consume_upto!(arg, s, i, j)
-            if redirect_mode != :none && (!isempty(arg) || word_has_special)
-                # This word is the redirect filename.
-                re = redirect_word_expr(arg)
-                if redirect_mode === :stdin; seg_stdin = re
-                elseif redirect_mode === :stdout; seg_stdout = re
-                else; seg_stderr = re; end
-                empty!(arg)
-                redirect_mode = :none
-            elseif redirect_mode == :none && (!isempty(arg) || word_has_special)
-                append_2to1!(args, arg)
-            end
+            i = _consume_upto!(arg, st, s, i, j)
+            _finalize_word!(args, arg, redir, word_has_special)
             word_has_special = false
-            # else: in redirect_mode but arg empty — still waiting for the filename.
             while !isempty(st)
-                # We've made sure above that we don't end in whitespace,
-                # so updating `i` here is ok
                 (i, c) = peek(st)::P
                 isspace(c) || break
                 popfirst!(st)
             end
         elseif interpolate && !in_single_quotes && c == '$'
-            i = consume_upto!(arg, s, i, j)
-            result = parse_dollar_interp(st, s)
-            s = result[2]
-            last_arg = result[3]
+            i = _consume_upto!(arg, st, s, i, j)
+            atom, s, interp_pos = _parse_dollar_interp(st, s, P, filename)
+            last_arg = interp_pos
             update_last_arg = true
-            push!(arg, result[1])
+            push!(arg, atom)
             i = firstindex(s)
         elseif interpolate && !in_single_quotes && !in_double_quotes && c == '|'
             # Pipeline operator: finalize current word/redirect, then save segment.
-            i = consume_upto!(arg, s, i, j)
-            if redirect_mode != :none && (!isempty(arg) || word_has_special)
-                re = redirect_word_expr(arg)
-                if redirect_mode === :stdin; seg_stdin = re
-                elseif redirect_mode === :stdout; seg_stdout = re
-                else; seg_stderr = re; end
-                empty!(arg)
-                redirect_mode = :none
-            elseif redirect_mode == :none && (!isempty(arg) || word_has_special)
-                append_2to1!(args, arg)
-            end
-            seg_tuple = Expr(:tuple)
-            for a in args; push!(seg_tuple.args, Expr(:tuple, a...)); end
-            push!(pipeline_parts, (seg_tuple, seg_stdin, seg_stdout, seg_stdout_append,
-                                   seg_stderr, seg_stderr_append))
-            empty!(args)
-            seg_stdin = nothing; seg_stdout = nothing; seg_stdout_append = false
-            seg_stderr = nothing; seg_stderr_append = false; redirect_mode = :none
+            i = _consume_upto!(arg, st, s, i, j)
+            _finalize_word!(args, arg, redir, word_has_special)
+            _save_pipeline_segment!(pipeline_parts, args, redir)
             word_has_special = false
             update_last_arg = true
         elseif interpolate && !in_single_quotes && !in_double_quotes && (c == '<' || c == '>')
             # Redirection operator: finalize any pending word, then set redirect mode.
             # A pure-integer word immediately before the operator is an fd number (e.g. 2>).
-            i = consume_upto!(arg, s, i, j)
+            i = _consume_upto!(arg, st, s, i, j)
             fd = nothing
             if !word_has_special && length(arg) == 1 && isa(arg[1], AbstractString) &&
                     !isempty(arg[1]::AbstractString) && all(isdigit, arg[1]::AbstractString)
@@ -317,7 +531,7 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
                 empty!(arg)
                 word_has_special = false
             elseif !isempty(arg)
-                append_2to1!(args, arg)
+                _append_word!(args, arg)
             end
             if c == '>'
                 append = false
@@ -327,16 +541,16 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
                     i = something(peek(st), lastindex(s)::Int+1 => '\0').first::Int
                 end
                 if fd === nothing || fd == 1
-                    redirect_mode = :stdout; seg_stdout_append = append
+                    redir.mode = :stdout; redir.stdout_append = append
                 elseif fd == 2
-                    redirect_mode = :stderr; seg_stderr_append = append
+                    redir.mode = :stderr; redir.stderr_append = append
                 else
                     error("parsing command `$str`: unsupported fd $fd in redirection")
                 end
             else  # '<'
                 (fd === nothing || fd == 0) ||
                     error("parsing command `$str`: unsupported fd $fd in redirection")
-                redirect_mode = :stdin
+                redir.mode = :stdin
             end
             update_last_arg = true
         else
@@ -347,15 +561,15 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
             if !in_double_quotes && c == '\''
                 in_single_quotes = !in_single_quotes
                 word_has_special = true
-                i = consume_upto!(arg, s, i, j)
+                i = _consume_upto!(arg, st, s, i, j)
             elseif !in_single_quotes && c == '"'
                 in_double_quotes = !in_double_quotes
                 word_has_special = true
-                i = consume_upto!(arg, s, i, j)
+                i = _consume_upto!(arg, st, s, i, j)
             elseif !in_single_quotes && c == '\\'
                 word_has_special = true
                 if !isempty(st) && (peek(st)::P)[2] in ('\n', '\r')
-                    i = consume_upto!(arg, s, i, j) + 1
+                    i = _consume_upto!(arg, st, s, i, j) + 1
                     if popfirst!(st)[2] == '\r' && (peek(st)::P)[2] == '\n'
                         i += 1
                         popfirst!(st)
@@ -368,160 +582,23 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
                     isempty(st) && error("unterminated double quote")
                     k, c′ = peek(st)::P
                     if c′ == '"' || c′ == '$' || c′ == '\\'
-                        i = consume_upto!(arg, s, i, j)
+                        i = _consume_upto!(arg, st, s, i, j)
                         _ = popfirst!(st)
                     end
                 else
                     isempty(st) && error("dangling backslash")
-                    i = consume_upto!(arg, s, i, j)
+                    i = _consume_upto!(arg, st, s, i, j)
                     _ = popfirst!(st)
                 end
             elseif interpolate && !in_single_quotes && !in_double_quotes &&
                     c == '~' && i == j && isempty(arg)
-                # Tilde expansion: `~` or `~username` at start of a word.
-                # Collect the username, which may include $interpolations (e.g. `~$user`).
-                # Stop at /, whitespace, uninterpolable chars (quotes, backslash), or operators.
-                i = consume_upto!(arg, s, i, j)  # i now points past the ~
-                user_parts = []
-                user_lit_start = i
-                while !isempty(st)
-                    nxt = peek(st)::P
-                    nc = nxt[2]
-                    (nc == '/' || isspace(nc) || nc == '\'' || nc == '"' || nc == '\\' ||
-                     nc == '|' || nc == '<' || nc == '>') && break
-                    if nc == '$'
-                        push_nonempty!(user_parts, s[user_lit_start:prevind(s, nxt[1])])
-                        popfirst!(st)  # consume $
-                        result = parse_dollar_interp(st, s)
-                        push!(user_parts, result[1])
-                        s = result[2]
-                        i = firstindex(s)
-                        user_lit_start = i
-                    else
-                        popfirst!(st)
-                    end
-                end
-                user_end = something(peek(st), (lastindex(s) + 1) => '\0').first
-                push_nonempty!(user_parts, s[user_lit_start:prevind(s, user_end)])
-                if isempty(user_parts)
-                    push!(arg, :(expanduser("~")))
-                elseif length(user_parts) == 1 && isa(user_parts[1], AbstractString)
-                    push!(arg, :(expanduser($("~" * user_parts[1]))))
-                else
-                    push!(arg, :(let _u = string($(user_parts...)); isempty(_u) ? "~" : expanduser(string('~', _u)) end))
-                end
-                i = user_end
+                i = _consume_upto!(arg, st, s, i, j)
+                s, i = _parse_tilde!(arg, st, s, i, P, filename)
             elseif interpolate && !in_single_quotes && !in_double_quotes && c == '{'
-                # Brace expansion: {alt1,alt2,...} produces a tuple of alternatives.
-                # The tuple integrates with arg_gen's Cartesian product, so
-                # `pre{a,b}suf` generates arguments "preasuf" and "prebsuf".
-                i = consume_upto!(arg, s, i, j)
-                found_close, has_comma, has_dotdot, has_space = _scan_brace(s, i)
-                if found_close && has_dotdot && !has_comma
-                    # Range expansion: {1..10}, {a..z}, {1..10..2}, {01..10}
-                    # Extract the raw content between { and }, advance past }.
-                    brace_content = ""
-                    while !isempty(st)
-                        (bp, bc) = peek(st)::P
-                        if bc == '}'
-                            brace_content = String(s[i:prevind(s, bp)::Int])
-                            popfirst!(st)
-                            break
-                        end
-                        popfirst!(st)
-                    end
-                    i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
-                    expanded = _brace_range_expand(brace_content)
-                    if expanded === nothing
-                        error("parsing command `$str`: invalid brace range expansion {$brace_content}")
-                    end
-                    push!(arg, Expr(:tuple, expanded...))
-                    word_has_special = true
-                elseif found_close && has_comma && has_space
-                    error("parsing command `$str`: unquoted space inside braces")
-                elseif !(found_close && has_comma)
-                    # Not a valid brace expansion (no matching } or no comma):
-                    # treat the { as a literal character.
-                    push!(arg, "{")
-                else
-                    word_has_special = true
-                    alts = Any[]
-                    alt_parts = Any[]
-                    alt_i = i   # start of current literal segment
-                    bsq = false # single quotes within brace content
-                    bdq = false # double quotes within brace content
-                    bdepth = 0  # nested brace depth
-                    while !isempty(st)
-                        (bp, bc) = peek(st)::P
-                        if bsq
-                            # In single quotes: everything is literal until closing '
-                            popfirst!(st)
-                            if bc == '\''
-                                push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
-                                bsq = false
-                                alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
-                            end
-                        elseif !bdq && bc == '\''
-                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
-                            popfirst!(st)
-                            bsq = true
-                            alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
-                        elseif bc == '"'
-                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
-                            popfirst!(st)
-                            bdq = !bdq
-                            alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
-                        elseif !bsq && bc == '$'
-                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
-                            popfirst!(st)
-                            result = parse_dollar_interp(st, s)
-                            push!(alt_parts, result[1])
-                            last_arg = result[3]
-                            update_last_arg = true
-                            s = result[2]
-                            alt_i = firstindex(s)
-                        elseif !bsq && bc == '\\'
-                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
-                            popfirst!(st)  # consume \
-                            if bdq
-                                if !isempty(st) && (peek(st)::P).second in ('"', '$', '\\')
-                                    alt_i = (peek(st)::P).first::Int
-                                    popfirst!(st)
-                                else
-                                    push!(alt_parts, "\\")
-                                    alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
-                                end
-                            else
-                                isempty(st) && error("parsing command `$str`: dangling backslash in brace expansion")
-                                alt_i = (peek(st)::P).first::Int
-                                popfirst!(st)
-                            end
-                        elseif !bsq && !bdq && bc == '{'
-                            bdepth += 1
-                            popfirst!(st)
-                        elseif !bsq && !bdq && bc == '}' && bdepth > 0
-                            bdepth -= 1
-                            popfirst!(st)
-                        elseif !bsq && !bdq && bc == '}' && bdepth == 0
-                            # End of brace expansion
-                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
-                            push!(alts, _brace_alt_expr(alt_parts))
-                            popfirst!(st)
-                            break
-                        elseif !bsq && !bdq && bc == ',' && bdepth == 0
-                            # Alternative separator
-                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
-                            push!(alts, _brace_alt_expr(alt_parts))
-                            empty!(alt_parts)
-                            popfirst!(st)
-                            alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
-                        else
-                            popfirst!(st)
-                        end
-                    end
-                    i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
-                    push!(arg, Expr(:tuple, alts...))
-                end
+                i = _consume_upto!(arg, st, s, i, j)
+                s, i, whs, last_arg, update_last_arg =
+                    _parse_brace!(arg, st, s, i, P, str, filename, last_arg, update_last_arg)
+                if whs; word_has_special = true; end
             elseif !in_single_quotes && !in_double_quotes && c in special
                 error("parsing command `$str`: special characters \"$special\" must be quoted in commands")
             end
@@ -531,23 +608,23 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
     if in_single_quotes; error("unterminated single quote"); end
     if in_double_quotes; error("unterminated double quote"); end
 
-    push_nonempty!(arg, s[i:end])
-    if interpolate && redirect_mode != :none
+    _push_nonempty!(arg, s[i:end])
+    if interpolate && redir.mode != :none
         isempty(arg) && error("parsing command `$str`: redirect operator without filename")
-        re = redirect_word_expr(arg)
-        if redirect_mode === :stdin; seg_stdin = re
-        elseif redirect_mode === :stdout; seg_stdout = re
-        else; seg_stderr = re; end
+        re = _redirect_word_expr(arg)
+        if redir.mode === :stdin; redir.stdin = re
+        elseif redir.mode === :stdout; redir.stdout = re
+        else; redir.stderr = re; end
         empty!(arg)
     elseif !isempty(arg) || word_has_special
-        append_2to1!(args, arg)
+        _append_word!(args, arg)
     end
 
     interpolate || return args, last_arg
 
-    # If no pipeline operators and no redirects: return existing tuple format (backward compat).
-    if isempty(pipeline_parts) && seg_stdin === nothing && seg_stdout === nothing &&
-            seg_stderr === nothing
+    # If no pipeline operators and no redirects: return existing tuple format.
+    if isempty(pipeline_parts) && redir.stdin === nothing && redir.stdout === nothing &&
+            redir.stderr === nothing
         ex = Expr(:tuple)
         for arg in args
             push!(ex.args, Expr(:tuple, arg...))
@@ -555,49 +632,7 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
         return ex, last_arg
     end
 
-    # Build a cmd_gen(seg_tuple) expression, wrapped in pipeline() calls for each redirect.
-    # stdin and stdout (with its append flag) are combined into one call; stderr is separate
-    # so that different append modes can be handled independently.
-    function build_seg_expr(seg_tuple, s_in, s_out, s_out_app, s_err, s_err_app)
-        cmd_ex = Expr(:call, GlobalRef(Base, :cmd_gen), seg_tuple)
-        if s_in !== nothing || s_out !== nothing
-            kwargs = Any[]
-            s_in !== nothing && push!(kwargs, Expr(:kw, :stdin, s_in))
-            s_out !== nothing && push!(kwargs, Expr(:kw, :stdout, s_out))
-            s_out_app && push!(kwargs, Expr(:kw, :append, true))
-            cmd_ex = Expr(:call, GlobalRef(Base, :pipeline), Expr(:parameters, kwargs...), cmd_ex)
-        end
-        if s_err !== nothing
-            kwargs = Any[Expr(:kw, :stderr, s_err)]
-            s_err_app && push!(kwargs, Expr(:kw, :append, true))
-            cmd_ex = Expr(:call, GlobalRef(Base, :pipeline), Expr(:parameters, kwargs...), cmd_ex)
-        end
-        return cmd_ex
-    end
-
-    # Build the final segment's tuple.
-    final_seg_tuple = Expr(:tuple)
-    for a in args; push!(final_seg_tuple.args, Expr(:tuple, a...)); end
-
-    if isempty(pipeline_parts)
-        # Only redirects, no pipes.
-        return build_seg_expr(final_seg_tuple, seg_stdin, seg_stdout, seg_stdout_append,
-                              seg_stderr, seg_stderr_append), last_arg
-    end
-
-    # Chain pipeline segments left-to-right: pipeline(seg1, pipeline(seg2, seg3, ...)).
-    (s0_args, s0_in, s0_out, s0_out_app, s0_err, s0_err_app) = pipeline_parts[1]
-    result = build_seg_expr(s0_args, s0_in, s0_out, s0_out_app, s0_err, s0_err_app)
-    for k in 2:length(pipeline_parts)
-        (sk_args, sk_in, sk_out, sk_out_app, sk_err, sk_err_app) = pipeline_parts[k]
-        result = Expr(:call, GlobalRef(Base, :pipeline), result,
-                      build_seg_expr(sk_args, sk_in, sk_out, sk_out_app, sk_err, sk_err_app))
-    end
-    result = Expr(:call, GlobalRef(Base, :pipeline), result,
-                  build_seg_expr(final_seg_tuple, seg_stdin, seg_stdout, seg_stdout_append,
-                                 seg_stderr, seg_stderr_append))
-
-    return result, last_arg
+    return _build_pipeline_expr(pipeline_parts, args, redir), last_arg
 end
 
 """

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -2,7 +2,12 @@
 
 ## shell-like command parsing ##
 
-const shell_special = "#{}()[]<>|&*?;"
+const shell_special = "#()[]<>|&*?;"
+
+# Characters that need quoting in backtick display.  Includes {} so that a Cmd
+# with literal braces round-trips correctly (they would otherwise be
+# brace-expanded when the displayed string is re-parsed).
+const _shell_display_special = shell_special * "{}"
 
 (@doc raw"""
     rstrip_shell(s::AbstractString)
@@ -27,6 +32,72 @@ function rstrip_shell(s::AbstractString)
     end
     SubString(s, 1, 0)
 end)
+
+# Scan from position `start` in string `s` (after an opening `{`) to find the
+# matching `}`. Returns `(found_close, has_comma, has_space)`.
+function _scan_brace(s, start)
+    depth = 1
+    has_comma = false
+    has_space = false
+    pos = start
+    @inbounds while pos <= lastindex(s)
+        c = s[pos]
+        if c == '\\'
+            pos = nextind(s, pos)  # skip escaped char
+        elseif c == '\''
+            # skip single-quoted content
+            pos = nextind(s, pos)
+            while pos <= lastindex(s) && s[pos] != '\''
+                pos = nextind(s, pos)
+            end
+        elseif c == '"'
+            # skip double-quoted content
+            pos = nextind(s, pos)
+            while pos <= lastindex(s)
+                s[pos] == '"' && break
+                s[pos] == '\\' && (pos = nextind(s, pos))
+                pos = nextind(s, pos)
+            end
+        elseif c == '$' && pos < lastindex(s) && s[nextind(s, pos)] == '('
+            # skip $(expr) — count parentheses
+            pos = nextind(s, nextind(s, pos))
+            pdepth = 1
+            while pos <= lastindex(s) && pdepth > 0
+                s[pos] == '(' && (pdepth += 1)
+                s[pos] == ')' && (pdepth -= 1)
+                pdepth > 0 && (pos = nextind(s, pos))
+            end
+        elseif isspace(c)
+            has_space = true
+        elseif c == '{'
+            depth += 1
+        elseif c == '}'
+            depth -= 1
+            depth == 0 && return (true, has_comma, has_space)
+        elseif c == ',' && depth == 1
+            has_comma = true
+        end
+        pos = nextind(s, pos)
+    end
+    return (false, false, false)
+end
+
+# Convert a list of parts (strings and expressions) for one brace alternative
+# into a single expression suitable for inclusion in a tuple.
+function _brace_alt_expr(parts)
+    if isempty(parts)
+        return ""
+    end
+    all_strings = all(p -> isa(p, AbstractString), parts)
+    if all_strings
+        return String(join(parts))
+    elseif length(parts) == 1
+        return parts[1]
+    else
+        cleaned = Any[isa(p, AbstractString) ? String(p) : p for p in parts]
+        return Expr(:call, GlobalRef(Base, :cmd_interpolate), cleaned...)
+    end
+end
 
 shell_parse(str::AbstractString, interpolate::Bool=true;
             special::AbstractString="", filename="none") =
@@ -271,6 +342,97 @@ function __repl_entry_shell_parse(str::AbstractString, interpolate::Bool, specia
                     push!(arg, :(let _u = string($(user_parts...)); isempty(_u) ? "~" : expanduser(string('~', _u)) end))
                 end
                 i = user_end
+            elseif interpolate && !in_single_quotes && !in_double_quotes && c == '{'
+                # Brace expansion: {alt1,alt2,...} produces a tuple of alternatives.
+                # The tuple integrates with arg_gen's Cartesian product, so
+                # `pre{a,b}suf` generates arguments "preasuf" and "prebsuf".
+                i = consume_upto!(arg, s, i, j)
+                found_close, has_comma, has_space = _scan_brace(s, i)
+                if found_close && has_comma && has_space
+                    error("parsing command `$str`: unquoted space inside braces")
+                elseif !(found_close && has_comma)
+                    # Not a valid brace expansion (no matching } or no comma):
+                    # treat the { as a literal character.
+                    push!(arg, "{")
+                else
+                    word_has_special = true
+                    alts = Any[]
+                    alt_parts = Any[]
+                    alt_i = i   # start of current literal segment
+                    bsq = false # single quotes within brace content
+                    bdq = false # double quotes within brace content
+                    bdepth = 0  # nested brace depth
+                    while !isempty(st)
+                        (bp, bc) = peek(st)::P
+                        if bsq
+                            # In single quotes: everything is literal until closing '
+                            popfirst!(st)
+                            if bc == '\''
+                                push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+                                bsq = false
+                                alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+                            end
+                        elseif !bdq && bc == '\''
+                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+                            popfirst!(st)
+                            bsq = true
+                            alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+                        elseif bc == '"'
+                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+                            popfirst!(st)
+                            bdq = !bdq
+                            alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+                        elseif !bsq && bc == '$'
+                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+                            popfirst!(st)
+                            result = parse_dollar_interp(st, s)
+                            push!(alt_parts, result[1])
+                            last_arg = result[3]
+                            update_last_arg = true
+                            s = result[2]
+                            alt_i = firstindex(s)
+                        elseif !bsq && bc == '\\'
+                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+                            popfirst!(st)  # consume \
+                            if bdq
+                                if !isempty(st) && (peek(st)::P).second in ('"', '$', '\\')
+                                    alt_i = (peek(st)::P).first::Int
+                                    popfirst!(st)
+                                else
+                                    push!(alt_parts, "\\")
+                                    alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+                                end
+                            else
+                                isempty(st) && error("parsing command `$str`: dangling backslash in brace expansion")
+                                alt_i = (peek(st)::P).first::Int
+                                popfirst!(st)
+                            end
+                        elseif !bsq && !bdq && bc == '{'
+                            bdepth += 1
+                            popfirst!(st)
+                        elseif !bsq && !bdq && bc == '}' && bdepth > 0
+                            bdepth -= 1
+                            popfirst!(st)
+                        elseif !bsq && !bdq && bc == '}' && bdepth == 0
+                            # End of brace expansion
+                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+                            push!(alts, _brace_alt_expr(alt_parts))
+                            popfirst!(st)
+                            break
+                        elseif !bsq && !bdq && bc == ',' && bdepth == 0
+                            # Alternative separator
+                            push_nonempty!(alt_parts, s[alt_i:prevind(s, bp)::Int])
+                            push!(alts, _brace_alt_expr(alt_parts))
+                            empty!(alt_parts)
+                            popfirst!(st)
+                            alt_i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+                        else
+                            popfirst!(st)
+                        end
+                    end
+                    i = something(peek(st), (lastindex(s)::Int+1) => '\0').first::Int
+                    push!(arg, Expr(:tuple, alts...))
+                end
             elseif !in_single_quotes && !in_double_quotes && c in special
                 error("parsing command `$str`: special characters \"$special\" must be quoted in commands")
             end

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -329,16 +329,12 @@ const _login_shells = Base.OncePerProcess{Vector{String}}() do
     end
 end
 
-# pw_shell byte offset in struct passwd — everything before the pw_shell field:
-# Linux:     pw_name, pw_passwd (2 Ptrs), pw_uid, pw_gid (2 Cuints),
-#            pw_gecos, pw_dir (2 Ptrs)
-# macOS/BSD: same as Linux plus pw_change (Clong) and pw_class (Ptr)
-#            between pw_gid and pw_gecos
-const _pw_shell_offset = @static if Sys.islinux()
-    4 * sizeof(Ptr{Cvoid}) + 2 * sizeof(Cuint)
-else
-    5 * sizeof(Ptr{Cvoid}) + 2 * sizeof(Cuint) + sizeof(Clong)
-end
+# pw_uid byte offset in struct passwd: after pw_name and pw_passwd (two pointers),
+# consistent across Linux and macOS/BSD.
+const _pw_uid_offset = 2 * sizeof(Ptr{Cvoid})
+
+# getpwent_r is available on Linux and FreeBSD but not macOS.
+const _getpwent_lock = Base.ReentrantLock()
 
 # Return a sorted, deduplicated list of real local usernames. When all=false
 # (the default), service accounts are excluded by requiring their shell to be
@@ -347,26 +343,60 @@ function list_users(; all::Bool=false)
     seen = Set{String}()
     @static if !Sys.iswindows()
         valid_shells = all ? String[] : _login_shells()
-        ccall(:setpwent, Cvoid, ())
-        try
-            while true
-                ptr = ccall(:getpwent, Ptr{Cvoid}, ())
-                ptr == C_NULL && break
-                name_ptr = unsafe_load(Ptr{Ptr{UInt8}}(ptr))
-                name_ptr == C_NULL && continue
-                name = unsafe_string(name_ptr)
-                if !all
-                    @static Sys.isapple() && startswith(name, '_') && continue
-                    if !isempty(valid_shells)
-                        shell_ptr = unsafe_load(Ptr{Ptr{UInt8}}(ptr + _pw_shell_offset))
-                        shell_ptr == C_NULL && continue
-                        unsafe_string(shell_ptr) in valid_shells || continue
+        @static if Sys.islinux() || Sys.isfreebsd()
+            # Use thread-safe getpwent_r on Linux and FreeBSD.
+            pwd_storage = zeros(UInt8, 256)
+            buflen = 1024
+            str_buf = Vector{UInt8}(undef, buflen)
+            result = Ref{Ptr{Cvoid}}(C_NULL)
+            ccall(:setpwent, Cvoid, ())
+            try
+                while true
+                    ret = ccall(:getpwent_r, Cint,
+                                (Ptr{Cvoid}, Ptr{UInt8}, Csize_t, Ptr{Ptr{Cvoid}}),
+                                pwd_storage, str_buf, Csize_t(buflen), result)
+                    if ret == Base.Libc.ERANGE
+                        buflen *= 2
+                        buflen > 65536 && break
+                        str_buf = Vector{UInt8}(undef, buflen)
+                        continue
                     end
+                    (ret != 0 || result[] == C_NULL) && break
+                    uid = unsafe_load(Ptr{Cuint}(result[] + _pw_uid_offset))
+                    pd = Base.Libc.getpwuid(uid, false)
+                    pd === nothing && continue
+                    if !all && !isempty(valid_shells)
+                        pd.shell in valid_shells || continue
+                    end
+                    push!(seen, pd.username)
                 end
-                push!(seen, name)
+            finally
+                ccall(:endpwent, Cvoid, ())
             end
-        finally
-            ccall(:endpwent, Cvoid, ())
+        else
+            # macOS: getpwent_r is not available, so guard the
+            # entire setpwent/getpwent/endpwent sequence with a lock.
+            @lock _getpwent_lock begin
+                ccall(:setpwent, Cvoid, ())
+                try
+                    while true
+                        ptr = ccall(:getpwent, Ptr{Cvoid}, ())
+                        ptr == C_NULL && break
+                        uid = unsafe_load(Ptr{Cuint}(ptr + _pw_uid_offset))
+                        pd = Base.Libc.getpwuid(uid, false)
+                        pd === nothing && continue
+                        if !all
+                            startswith(pd.username, '_') && continue
+                            if !isempty(valid_shells)
+                                pd.shell in valid_shells || continue
+                            end
+                        end
+                        push!(seen, pd.username)
+                    end
+                finally
+                    ccall(:endpwent, Cvoid, ())
+                end
+            end
         end
     end
     return sort!(collect(seen))

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -629,6 +629,47 @@ let echostr = Base.shell_escape(echocmd)
     end
 end
 
+# Brace range expansion
+@test `{1..5}` == Cmd(["1", "2", "3", "4", "5"])
+@test `{a..e}` == Cmd(["a", "b", "c", "d", "e"])
+@test `{1..10..3}` == Cmd(["1", "4", "7", "10"])      # step
+@test `{a..z..5}` == Cmd(["a", "f", "k", "p", "u", "z"])
+@test `{10..1}` == Cmd(["10", "9", "8", "7", "6", "5", "4", "3", "2", "1"])
+@test `{z..a..5}` == Cmd(["z", "u", "p", "k", "f", "a"])
+@test `{01..05}` == Cmd(["01", "02", "03", "04", "05"])  # zero-padding
+@test `{001..3}` == Cmd(["001", "002", "003"])
+@test `{-2..2}` == Cmd(["-2", "-1", "0", "1", "2"])
+@test `{-03..3}` == Cmd(["-03", "-02", "-01", "000", "001", "002", "003"])
+@test `{-3..03}` == Cmd(["-3", "-2", "-1", "00", "01", "02", "03"])
+@test `{03..-3}` == Cmd(["03", "02", "01", "00", "-1", "-2", "-3"])
+@test `{-03..-1}` == Cmd(["-03", "-02", "-01"])
+@test `{5..1..2}` == Cmd(["5", "3", "1"])
+@test `{3..3}` == Cmd(["3"])
+@test `file{1..3}.txt` == Cmd(["file1.txt", "file2.txt", "file3.txt"])
+@test `{1..3}.{a..c}` == Cmd(["1.a", "1.b", "1.c", "2.a", "2.b", "2.c",
+                               "3.a", "3.b", "3.c"])
+@test `{a,b}.{1..3}` == Cmd(["a.1", "a.2", "a.3", "b.1", "b.2", "b.3"])
+@test_throws "invalid brace range expansion" eval(:(`{a..1}`))
+@test_throws "invalid brace range expansion" eval(:(`{a..Z}`))  # cross-case
+@test_throws "invalid brace range expansion" eval(:(`{A..z}`))
+@test `{A..E}` == Cmd(["A", "B", "C", "D", "E"])
+@test `{-2..+3}` == Cmd(["-2", "-1", "+0", "+1", "+2", "+3"])  # plus sign
+@test `{+1..+3}` == Cmd(["+1", "+2", "+3"])
+@test `{+3..-1}` == Cmd(["+3", "+2", "+1", "+0", "-1"])
+@test `{-1..+1}` == Cmd(["-1", "+0", "+1"])
+@test `{-02..+3}` == Cmd(["-02", "-01", "+00", "+01", "+02", "+03"])  # plus with padding
+@test `{-2..+03}` == Cmd(["-02", "-01", "+00", "+01", "+02", "+03"])
+@test `{-2..+4..2}` == Cmd(["-2", "+0", "+2", "+4"])  # plus with step
+# range expansion works through shell mode path
+let echostr = Base.shell_escape(echocmd)
+    mktempdir() do dir
+        f = joinpath(dir, "out.txt")
+        fstr = Base.shell_escape(f)
+        shell_mode_run("$echostr {1..3} > $fstr")
+        @test read(f, String) == "1 2 3\n"
+    end
+end
+
 # Pipeline and redirection operators in backtick command literals
 (!Sys.iswindows() || havebb) &&
 mktempdir() do dir

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -594,6 +594,41 @@ withenv("OLDPWD" => nothing) do
     end
 end
 
+# Brace expansion in backtick commands
+@test `{a,b,c}` == Cmd(["a", "b", "c"])
+@test `echo {a,b,c}` == Cmd(["echo", "a", "b", "c"])
+@test `{a,b}.txt` == Cmd(["a.txt", "b.txt"])
+@test `echo {a,b}.txt` == Cmd(["echo", "a.txt", "b.txt"])
+@test `{a,b}.{x,y}` == Cmd(["a.x", "a.y", "b.x", "b.y"])
+@test `echo pre{a,b}suf` == Cmd(["echo", "preasuf", "prebsuf"])
+@test `{a,b} {c,d}` == Cmd(["a", "b", "c", "d"])
+@test `{a,,c}` == Cmd(["a", "", "c"])  # empty alternative
+let x = "foo"
+    @test `{$x,bar}` == Cmd(["foo", "bar"])
+    @test `{$x,bar}.txt` == Cmd(["foo.txt", "bar.txt"])
+end
+let xs = "a b"
+    @test `{$xs,c}` == Cmd(["a b", "c"])  # interpolated value is not word-split
+end
+@test `{"hello world",bye}` == Cmd(["hello world", "bye"])  # quoted space in braces ok
+@test_throws "unquoted space inside braces" eval(:(`{a b,c}`))  # unquoted space is an error
+@test `{a\,b,c}` == Cmd(["a,b", "c"])  # escaped comma
+@test `'{a,b}'` == Cmd(["{a,b}"])       # braces in single quotes: no expansion
+@test `"{a,b}"` == Cmd(["{a,b}"])       # braces in double quotes: no expansion
+@test `{a}` == Cmd(["{a}"])             # single item: no expansion (literal)
+@test `{}` == Cmd(["{}"])               # empty braces: no expansion (literal)
+@test `x{y}z` == Cmd(["x{y}z"])        # no comma: literal
+@test `{a,{b,c},d}` == Cmd(["a", "{b,c}", "d"])  # nested braces: inner not expanded
+# brace expansion works through shell mode path
+let echostr = Base.shell_escape(echocmd)
+    mktempdir() do dir
+        f = joinpath(dir, "out.txt")
+        fstr = Base.shell_escape(f)
+        shell_mode_run("$echostr {a,b,c} > $fstr")
+        @test read(f, String) == "a b c\n"
+    end
+end
+
 # Pipeline and redirection operators in backtick command literals
 (!Sys.iswindows() || havebb) &&
 mktempdir() do dir


### PR DESCRIPTION
## Summary

Refactors the `__repl_entry_shell_parse` function in `base/shell.jl`, which had
grown to ~425 lines with deeply nested logic, duplicated code, and closures
capturing mutable state. The function accumulated complexity as tilde expansion,
brace expansion, and pipeline/redirect support were added.

The refactoring extracts focused helper functions:

- **`_finalize_word!`** — deduplicates the word/redirect completion logic that was
  copy-pasted in three places (whitespace, pipe operator, and post-loop)
- **`_parse_tilde!`** / **`_parse_brace!`** / **`_parse_brace_alts!`** — extract
  the self-contained tilde and brace expansion sub-parsers
- **`_build_seg_expr`** / **`_build_pipeline_expr`** — extract pipeline expression
  assembly into pure functions
- **`_RedirectState`** — bundles six loose redirect variables into a struct
- Small utilities (`_push_nonempty!`, `_consume_upto!`, `_append_word!`,
  `_redirect_word_expr`, `_parse_dollar_interp`) promoted from closures to
  module-level functions

The main function shrinks from ~425 to ~130 lines. Net change is +35 lines
(function signatures and the struct definition).

No behavioral changes — all existing tests pass unmodified.

## Dependencies

This PR is based on #61559 (brace expansion) and #61562 (tilde fixes), and
should not be merged until both of those are merged.

## Test plan

- [x] `make test-revise-spawn` — 423 pass
- [x] `make test-revise-path` — 705 pass
- [x] `make test-revise-misc` — 1,285,536 pass

Written with the assistance of generative AI (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)