### PR TITLE
[JuliaLowering] Guard `Core.MacroSource` references for Julia < 1.14 compat

### DIFF
--- a/JuliaLowering/src/JuliaLowering.jl
+++ b/JuliaLowering/src/JuliaLowering.jl
@@ -22,6 +22,10 @@ using .JuliaSyntax: @KSet_str, @stm, Kind, NodeId, SourceAttrType, SourceRef, Sy
 
 const DEBUG = true
 
+# Falls back to `Union{}` so that `loc isa MacroSource` is always false on Julia < 1.14
+# where `Core.MacroSource` is not defined.
+const MacroSource = isdefined(Core, :MacroSource) ? Core.MacroSource : Union{}
+
 _include("kinds.jl")
 _register_kinds()
 

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -285,7 +285,7 @@ function expand_macro(ctx, ex)
     raw_args = ex[3:end]
     macro_loc = if kind(ex[2]) === K"Value"
         loc = ex[2].value
-        if loc isa Core.MacroSource
+        if loc isa MacroSource
             loc
         elseif loc isa LineNumberNode
             # Some macros, e.g. @cmd, don't play nicely with file == nothing
@@ -294,7 +294,8 @@ function expand_macro(ctx, ex)
             LineNumberNode(0, :none)
         end
     elseif kind(ex[2]) === K"VERSION"
-        Core.MacroSource(source_location(LineNumberNode, ex), ex[2].value)
+        loc = source_location(LineNumberNode, ex)
+        isdefined(Core, :MacroSource) ? Core.MacroSource(loc, ex[2].value) : loc
     else
         LineNumberNode(0, :none)
     end
@@ -363,7 +364,7 @@ function expand_macro(ctx, ex)
             end
             rethrow(MacroExpansionError(mctx, ex, "Error expanding macro", :all, exc))
         end
-        macro_lnn = macro_loc isa Core.MacroSource ? macro_loc.lno : macro_loc
+        macro_lnn = macro_loc isa MacroSource ? macro_loc.lno : macro_loc
         expanded = expr_to_est(ex._graph, expanded, macro_lnn)
     end
 

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -1084,7 +1084,7 @@ vst0_macrocall(vcx, st) = @stm st begin
     (_, when=!vcx.unexpanded) ->
         @fail(st, "macrocall not valid in AST after macro expansion")
     ([K"macrocall" name [K"Value"] args...],
-     when=(typeof(st[2].value) in (LineNumberNode, Core.MacroSource))) ->
+     when=(typeof(st[2].value) in (LineNumberNode, MacroSource))) ->
          pass()
     [K"macrocall" _...] ->
         @fail(st, "expected (macrocall name linenode args...)")


### PR DESCRIPTION
`Core.MacroSource` was introduced in Julia 1.14. On older runtimes (e.g. 1.12), referencing it directly causes `UndefVarError` at module load time. Add a compat constant `MacroSource` that falls back to `Union{}` when `Core.MacroSource` is not defined, making `isa` checks always return false. Also guard the constructor call with `isdefined`.