### PR TITLE
typeinfer: fix is_already_cached assertion with OverlayCodeCache

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -727,7 +727,9 @@ function is_already_cached(interp::AbstractInterpreter, result::InferenceResult)
     cache = code_cache(interp, result.valid_worlds)
     if haskey(cache, mi)
         # n.b.: accurate edge representation might cause the CodeInstance for this to be constructed later
-        @assert isdefined(cache[mi], :inferred)
+        cached = cache[mi]
+        ci = cached isa InferenceResult ? cached.ci : cached
+        @assert isdefined(ci, :inferred)
         return true
     end
     return false

--- a/Compiler/test/AbstractInterpreter.jl
+++ b/Compiler/test/AbstractInterpreter.jl
@@ -565,3 +565,21 @@ let interp = InvokeInterp()
     @test isa(result, String)
     @test contains(result, "[1] error(::Char, ::Char, ::Char, ::Char)")
 end
+
+# Test that is_already_cached handles OverlayCodeCache returning InferenceResult.
+# Regression test: OverlayCodeCache.getindex may return InferenceResult (from the
+# local inference cache) rather than CodeInstance, which lacks an :inferred field.
+using REPL.REPLCompletions: completions
+@newinterp OverlayCacheInterp true
+@test let
+    interp = OverlayCacheInterp()
+    # completions has a call graph deep enough that during inference the same
+    # MethodInstance is encountered through different callers, exercising the
+    # OverlayCodeCache local-cache path in is_already_cached.
+    f = completions
+    args = ("", 0)
+    mi = @ccall jl_method_lookup(Any[f, args...]::Ptr{Any}, (1+length(args))::Csize_t,
+        Base.tls_world_age()::Csize_t)::Ref{Core.MethodInstance}
+    Compiler.typeinf_ext_toplevel(interp, mi, Compiler.SOURCE_MODE_NOT_REQUIRED)
+    true
+end


### PR DESCRIPTION
Proposal to fix a Compiler error from a benchmarks run.

The added test seems quite brittle, but locally it does fail on master and pass on this PR. Not sure if it should stay in this PR (if the PR is valid).

```
From worker 3:    ERROR: LoadError: AssertionError: isdefined(cache[mi], :inferred)
      From worker 3:    Stacktrace:
      From worker 3:       [1] is_already_cached(interp::BaseBenchmarks.InferenceBenchmarks.InferenceBenchmarker, result::Compiler.InferenceResult)
      From worker 3:         @ Compiler ./../usr/share/julia/Compiler/src/typeinfer.jl:730
      From worker 3:       [2] promotecache!(interp::BaseBenchmarks.InferenceBenchmarks.InferenceBenchmarker, caller::Compiler.InferenceState)
      From worker 3:         @ Compiler ./../usr/share/julia/Compiler/src/typeinfer.jl:205
      From worker 3:       [3] finish_nocycle(interp::BaseBenchmarks.InferenceBenchmarks.InferenceBenchmarker, frame::Compiler.InferenceState, time_before::UInt64)
      From worker 3:         @ Compiler ./../usr/share/julia/Compiler/src/typeinfer.jl:286
      From worker 3:       [4] typeinf(interp::BaseBenchmarks.InferenceBenchmarks.InferenceBenchmarker, frame::Compiler.InferenceState)
      From worker 3:         @ Compiler ./../usr/share/julia/Compiler/src/abstractinterpretation.jl:4821
      From worker 3:       [5] inf_method_instance!(interp::BaseBenchmarks.InferenceBenchmarks.InferenceBenchmarker, mi::Core.MethodInstance; run_optimizer::Bool)
      From worker 3:         @ BaseBenchmarks.InferenceBenchmarks ~ubuntu/.julia/dev/BaseBenchmarks/src/inference/InferenceBenchmarks.jl:138
      From worker 3:       [6] inf_method_instance!
      From worker 3:         @ ~ubuntu/.julia/dev/BaseBenchmarks/src/inference/InferenceBenchmarks.jl:134 [inlined]
      From worker 3:       [7] inf_method_signature!
      From worker 3:         @ ~ubuntu/.julia/dev/BaseBenchmarks/src/inference/InferenceBenchmarks.jl:131 [inlined]
      From worker 3:       [8] inf_gf_by_type!(interp::BaseBenchmarks.InferenceBenchmarks.InferenceBenchmarker, tt::Type{<:Tuple}; kwargs::@Kwargs{run_optimizer::Bool})
      From worker 3:         @ BaseBenchmarks.InferenceBenchmarks ~ubuntu/.julia/dev/BaseBenchmarks/src/inference/InferenceBenchmarks.jl:117
      From worker 3:       [9] inf_gf_by_type!
      From worker 3:         @ ~ubuntu/.julia/dev/BaseBenchmarks/src/inference/InferenceBenchmarks.jl:115 [inlined]
```

Developed with Claude:

----

Since #59413 introduced OverlayCodeCache, `code_cache(interp)[mi]` can return an `InferenceResult` (from the local inference cache) rather than a `CodeInstance`. The assertion `isdefined(cache[mi], :inferred)` always fails for `InferenceResult` since it has no `:inferred` field, even though the underlying `CodeInstance` is valid.

Extract the `CodeInstance` from the result before checking `isdefined`.