### PR TITLE
Fix JuliaTaskDispatcher deadlock with std::future callers

### DIFF
--- a/src/julia-task-dispatcher.h
+++ b/src/julia-task-dispatcher.h
@@ -36,6 +36,10 @@ private:
   SmallVector<std::unique_ptr<Task>> TaskQueue;
   std::mutex DispatchMutex;
   std::condition_variable WorkFinishedCV;
+  /// Track whether the current thread is inside work_until/process_tasks.
+  /// When false, dispatch runs tasks inline to avoid deadlock with callers
+  /// that block on std::future (e.g. LocalTrampolinePool::reenter).
+  static inline thread_local bool InCooperativeContext = false;
 
 public:
 
@@ -338,8 +342,21 @@ private:
 }; // class JuliaTaskDispatcher
 
 void JuliaTaskDispatcher::dispatch(std::unique_ptr<Task> T) {
-  std::unique_lock Lock{DispatchMutex};
-  TaskQueue.push_back(std::move(T));
+  if (!InCooperativeContext) {
+    // Not inside work_until/process_tasks — run inline to prevent deadlock
+    // with callers that block on std::future (e.g. LocalTrampolinePool::reenter).
+    // Mark the inline run as cooperative so any nested dispatch() queues
+    // instead of recursing on the C stack.
+    InCooperativeContext = true;
+    T->run();
+    InCooperativeContext = false;
+    return;
+  }
+  {
+    std::unique_lock Lock{DispatchMutex};
+    TaskQueue.push_back(std::move(T));
+    WorkFinishedCV.notify_all();
+  }
 }
 
 void JuliaTaskDispatcher::shutdown() {
@@ -347,19 +364,22 @@ void JuliaTaskDispatcher::shutdown() {
 }
 
 void JuliaTaskDispatcher::work_until(future_base &F) {
+  bool WasCooperative = InCooperativeContext;
+  InCooperativeContext = true;
   jl_unique_gcsafe_lock Lock{DispatchMutex};
   while (!F.ready()) {
     process_tasks(Lock);
 
     // Check if our future is now ready
     if (F.ready())
-      return;
+      break;
 
     // If we get here, our queue is empty but the future isn't ready
     // We need to wait for other threads to finish work that should complete our
     // future
     Lock.wait(WorkFinishedCV);
   }
+  InCooperativeContext = WasCooperative;
 }
 
 void JuliaTaskDispatcher::process_tasks(jl_unique_gcsafe_lock &Lock) {

--- a/src/julia-task-dispatcher.h
+++ b/src/julia-task-dispatcher.h
@@ -346,9 +346,15 @@ void JuliaTaskDispatcher::dispatch(std::unique_ptr<Task> T) {
     // Not inside work_until/process_tasks — run inline to prevent deadlock
     // with callers that block on std::future (e.g. LocalTrampolinePool::reenter).
     // Mark the inline run as cooperative so any nested dispatch() queues
-    // instead of recursing on the C stack.
+    // instead of recursing on the C stack, then drain the queue so any
+    // continuations that fulfill the caller's std::future can fire before
+    // we return.
     InCooperativeContext = true;
     T->run();
+    {
+      jl_unique_gcsafe_lock Lock{DispatchMutex};
+      process_tasks(Lock);
+    }
     InCooperativeContext = false;
     return;
   }


### PR DESCRIPTION
`JuliaTaskDispatcher::dispatch()` only queues tasks, relying on `work_until()` to drain the queue. Any LLVM code that dispatches tasks and then blocks on `std::future::get()` (rather than `JuliaTaskDispatcher::future::get()` which calls `work_until()`) will deadlock: the task sits in the queue while the only thread is blocked on a future that will never be fulfilled.

The concrete case is `LocalTrampolinePool::reenter` which creates a `std::promise/future`, calls `ES.lookup()` (dispatching a materialization task), then blocks on `std::future::get()`. With the old `InPlaceTaskDispatcher`, `dispatch()` ran tasks inline so materialization completed before `get()` was called.

Fix by tracking whether the current thread is inside `work_until()` via a thread_local flag. When `dispatch()` is called outside this cooperative context, run the task inline (matching `InPlaceTaskDispatcher` behavior). Inside cooperative context, queue as before to preserve bounded-recursion. Also notify `WorkFinishedCV` from `dispatch()` so `work_until()` callers wake up when new work arrives.

This was encountered in LLVM.jl, which uses JuliaOJIT's `ExecutionSession` to create a `LocalLazyCallThroughManager` via the LLVM C API (`LLVMOrcCreateLocalLazyCallThroughManager`).

x-ref https://github.com/JuliaLang/julia/pull/60031