### PR TITLE
[JuliaLowering] RFC: Align anonymous naming conventions with flisp

### DIFF
--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -273,6 +273,27 @@ function closure_type_fields(ctx, srcref, closure_binds, is_opaque)
     return field_syms, field_orig_bindings, field_inds, field_is_box
 end
 
+# Construct the closure type name following the flisp convention from
+# julia-syntax.scm:4461-4466. `name_stack` has the outermost enclosing
+# function first and the closure's own name last.
+#
+# - Named closure `inner` in `outer`: `#inner#outer##0`
+# - Anon closure (#N) in `outer`:     `#outer##0#outer##1`
+# - Anon closure at toplevel:         `#N#M`
+function closure_type_name!(mod::Module, name_stack)
+    closure_name = last(name_stack)
+    is_anon = length(closure_name) >= 2 &&
+              closure_name[1] == '#' && isdigit(closure_name[2])
+    prefix = if is_anon
+        "#$(current_module_counter!(mod, name_stack))"
+    elseif closure_name[1] == '#'
+        closure_name
+    else
+        "#$closure_name"
+    end
+    return "$prefix#$(current_module_counter!(mod, name_stack))"
+end
+
 # Return a thunk which creates a new type for a closure with `field_syms` named
 # fields. The new type will be named `name_str` which must be an unassigned
 # name in the module.
@@ -416,9 +437,7 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
                 closure_binds = ctx.closure_bindings[func_name_id]
                 field_syms, field_orig_bindings, field_inds, field_is_box =
                     closure_type_fields(ctx, ex, closure_binds, false)
-                name_str = reserve_module_binding_i(
-                    ctx.mod,
-                    string("#", join(closure_binds.name_stack, "#"), "##"))
+                name_str = closure_type_name!(ctx.mod, closure_binds.name_stack)
                 closure_type_def, closure_type_ =
                     type_for_closure(ctx, ex, name_str, field_syms, field_is_box)
                 if !ctx.is_toplevel_seq_point

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2454,9 +2454,9 @@ end
 # by adding (meta generated ...) to the non-generated body
 function generated_method_defs(ctx, src, mtable, sparams, argl, body, rett)
     @jl_assert kind(body) === K"_generated_body" && numchildren(body) == 2 body
-    gen_name = let mangled = reserve_module_binding_i(
-        ctx.mod, "#$(is_core_nothing(mtable) ? "_" : mtable)@generator#")
-        new_global_binding(ctx, src, mangled, ctx.mod)
+    gen_name = let c1 = module_next_counter!(ctx.mod),
+                   c2 = module_next_counter!(ctx.mod)
+        new_global_binding(ctx, src, "#$c1#$c2", ctx.mod)
     end
 
     gen_mdef = let arg1_name = newsym(ctx, argl[1], "#self#"),
@@ -2622,8 +2622,9 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
     positional_sparams = used_typevars(pargl, sparams)
 
     m1_name = let n = is_core_nothing(mtable) ? "_" : mtable.name_val,
-        mangled = string(startswith(n, '#') ? "" : "#kw_body#", n, "#")
-        newsym(ctx, argl[1], reserve_module_binding_i(ctx.mod, mangled))
+        mangled = string(startswith(n, '#') ? "" : "#", n, "#",
+                         module_next_counter!(ctx.mod))
+        newsym(ctx, argl[1], mangled)
     end
     # (1) Body method.  This contains the actual function body, and requires
     # every possible default to be filled.  `rett` is only passed here since it
@@ -4261,7 +4262,7 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
             [K"tuple" as...] -> (nothing, as, @ast(ctx, sig, "Any"::K"core"))
         end
         if isnothing(name)
-            name = newsym(ctx, sig, "#anon#")
+            name = newsym(ctx, sig, "#$(module_next_counter!(ctx.mod))")
             @ast ctx ex [K"block" [K"local" name] expand_function_def(
                 ctx, ex, SyntaxList(name, args...), wheres, ex[2], rett)]
         else
@@ -4271,7 +4272,7 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
     elseif k == K"->"
         sig, wheres = flatten_wheres(ex[1])
         @jl_assert kind(sig) === K"tuple" ex
-        name = newsym(ctx, sig, "#->#")
+        name = newsym(ctx, sig, "#$(module_next_counter!(ctx.mod))")
         rett = @ast(ctx, sig, "Any"::K"core")
         @ast ctx ex [K"block" [K"local" name] expand_function_def(
             ctx, ex, SyntaxList(name, children(sig)...), wheres, ex[2], rett)]

--- a/JuliaLowering/src/runtime.jl
+++ b/JuliaLowering/src/runtime.jl
@@ -439,6 +439,28 @@ function reserve_module_binding_i(mod, basename)
     end
 end
 
+function module_next_counter!(mod::Module)
+    ccall(:jl_module_next_counter, UInt32, (Any,), mod)
+end
+
+# Replicate fl_module_unique_name (src/ast.c:95-127).
+#
+# When name_stack is non-empty and the outermost enclosing function name
+# doesn't contain '#', uses binding reservation with the format
+# "outermost##N" to produce names scoped to the outermost function.
+# This makes precompile statements more stable (see JuliaLang/julia#53719).
+#
+# Otherwise, falls back to the bare module counter.
+function current_module_counter!(mod::Module, name_stack)
+    if !isempty(name_stack)
+        outermost = first(name_stack)
+        if !occursin('#', outermost)
+            return reserve_module_binding_i(mod, "$(outermost)##")
+        end
+    end
+    return string(module_next_counter!(mod))
+end
+
 function lookup_method_instance(func, args, world::Integer)
     allargs = Vector{Any}(undef, length(args) + 1)
     allargs[1] = func

--- a/JuliaLowering/test/closures.jl
+++ b/JuliaLowering/test/closures.jl
@@ -589,7 +589,7 @@ end
 let (inner, result) = test_mod.f_kwbody_box()
     @test result == 1
     # The kw body closure should be captured directly, not through a Box
-    kw_body_field = only(filter(f -> startswith(string(f), "#kw_body#"), fieldnames(typeof(inner))))
+    kw_body_field = only(filter(f -> startswith(string(f), "#inner#"), fieldnames(typeof(inner))))
     @test !(getfield(inner, kw_body_field) isa Core.Box)
 end
 

--- a/JuliaLowering/test/closures_ir.jl
+++ b/JuliaLowering/test/closures_ir.jl
@@ -10,14 +10,14 @@ end
 1   (= slot₂/x 1)
 2   (call core.svec :x)
 3   (call core.svec false)
-4   (call JuliaLowering.eval_closure_type TestMod :#f##0 %₂ %₃)
+4   (call JuliaLowering.eval_closure_type TestMod :#f#f##0 %₂ %₃)
 5   latestworld
-6   TestMod.#f##0
+6   TestMod.#f#f##0
 7   (call core._typeof_captured_variable slot₂/x)
 8   (call core.apply_type %₆ %₇)
 9   (new %₈ slot₂/x)
 10  (= slot₁/f %₉)
-11  TestMod.#f##0
+11  TestMod.#f#f##0
 12  (call core.svec %₁₁ core.Any)
 13  (call core.svec)
 14  SourceLocation::3:14
@@ -42,9 +42,9 @@ end
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :#no_method_f##0 %₁ %₂)
+3   (call JuliaLowering.eval_closure_type TestMod :#no_method_f#no_method_f##0 %₁ %₂)
 4   latestworld
-5   TestMod.#no_method_f##0
+5   TestMod.#no_method_f#no_method_f##0
 6   (new %₅)
 7   (= slot₁/no_method_f %₆)
 8   slot₁/no_method_f
@@ -65,13 +65,13 @@ end
 4   (call core.setfield! %₃ :contents %₂)
 5   (call core.svec :x)
 6   (call core.svec true)
-7   (call JuliaLowering.eval_closure_type TestMod :#f##1 %₅ %₆)
+7   (call JuliaLowering.eval_closure_type TestMod :#f#f##1 %₅ %₆)
 8   latestworld
-9   TestMod.#f##1
+9   TestMod.#f#f##1
 10  slot₂/x
 11  (new %₉ %₁₀)
 12  (= slot₁/f %₁₁)
-13  TestMod.#f##1
+13  TestMod.#f#f##1
 14  (call core.svec %₁₃ core.Any)
 15  (call core.svec)
 16  SourceLocation::3:14
@@ -100,9 +100,9 @@ end
 2   latestworld
 3   (call core.svec :x)
 4   (call core.svec true)
-5   (call JuliaLowering.eval_closure_type TestMod :#f#g##0 %₃ %₄)
+5   (call JuliaLowering.eval_closure_type TestMod :#g#f##2 %₃ %₄)
 6   latestworld
-7   TestMod.#f#g##0
+7   TestMod.#g#f##2
 8   (call core.svec %₇)
 9   (call core.svec)
 10  SourceLocation::2:14
@@ -125,7 +125,7 @@ end
     1   (= slot₅/x slot₂/x)
     2   slot₅/x
     3   (= slot₅/x (call core.Box %₂))
-    4   TestMod.#f#g##0
+    4   TestMod.#g#f##2
     5   slot₅/x
     6   (new %₄ %₅)
     7   (= slot₃/g %₆)
@@ -158,9 +158,9 @@ end
 2   latestworld
 3   (call core.svec :x)
 4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#foo##->###0 %₃ %₄)
+5   (call JuliaLowering.eval_closure_type TestMod :#foo##0#foo##1 %₃ %₄)
 6   latestworld
-7   TestMod.#foo##->###0
+7   TestMod.#foo##0#foo##1
 8   (call core.svec %₇)
 9   (call core.svec)
 10  SourceLocation::4:16
@@ -177,22 +177,22 @@ end
 18  SourceLocation::1:10
 19  (call core.svec %₁₆ %₁₇ %₁₈)
 20  --- method TestMod.foo %₁₉
-    slots: [slot₁/#self#(!read) slot₂/x(single_assign) slot₃/#->#(single_assign) slot₄/x(!read)]
+    slots: [slot₁/#self#(!read) slot₂/x(single_assign) slot₃/#1(single_assign) slot₄/x(!read)]
     1   (= slot₄/x slot₂/x)
-    2   (newvar slot₃/#->#)
+    2   (newvar slot₃/#1)
     3   TestMod.rand
     4   TestMod.Bool
     5   (call %₃ %₄)
     6   (gotoifnot %₅ label₁₇)
     7   (= slot₄/x 5)
-    8   TestMod.#foo##->###0
+    8   TestMod.#foo##0#foo##1
     9   slot₄/x
     10  (call core._typeof_captured_variable %₉)
     11  (call core.apply_type %₈ %₁₀)
     12  slot₄/x
     13  (new %₁₁ %₁₂)
-    14  (= slot₃/#-># %₁₃)
-    15  slot₃/#->#
+    14  (= slot₃/#1 %₁₃)
+    15  slot₃/#1
     16  (return %₁₅)
     17  slot₄/x
     18  (return %₁₇)
@@ -213,9 +213,9 @@ end
 2   latestworld
 3   (call core.svec :x)
 4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f#g##1 %₃ %₄)
+5   (call JuliaLowering.eval_closure_type TestMod :#g#f##3 %₃ %₄)
 6   latestworld
-7   TestMod.#f#g##1
+7   TestMod.#g#f##3
 8   (call core.svec %₇)
 9   (call core.svec)
 10  SourceLocation::2:14
@@ -234,7 +234,7 @@ end
 19  (call core.svec %₁₆ %₁₇ %₁₈)
 20  --- method TestMod.f %₁₉
     slots: [slot₁/#self#(!read) slot₂/x slot₃/g(single_assign) slot₄/z(!read,single_assign)]
-    1   TestMod.#f#g##1
+    1   TestMod.#g#f##3
     2   (call core._typeof_captured_variable slot₂/x)
     3   (call core.apply_type %₁ %₂)
     4   (new %₃ slot₂/x)
@@ -258,9 +258,9 @@ end
 2   latestworld
 3   (call core.svec :T)
 4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f#g##2 %₃ %₄)
+5   (call JuliaLowering.eval_closure_type TestMod :#g#f##4 %₃ %₄)
 6   latestworld
-7   TestMod.#f#g##2
+7   TestMod.#g#f##4
 8   (call core.svec %₇)
 9   (call core.svec)
 10  SourceLocation::2:14
@@ -283,7 +283,7 @@ end
 22  (call core.svec %₁₈ %₂₀ %₂₁)
 23  --- method TestMod.f %₂₂
     slots: [slot₁/#self#(!read) slot₂/#unused#(!read) slot₃/g(single_assign)]
-    1   TestMod.#f#g##2
+    1   TestMod.#g#f##4
     2   static_parameter₁
     3   (call core._typeof_captured_variable %₂)
     4   (call core.apply_type %₁ %₃)
@@ -314,9 +314,9 @@ end
 2   latestworld
 3   (call core.svec :x :y)
 4   (call core.svec false true)
-5   (call JuliaLowering.eval_closure_type TestMod :#f#g##3 %₃ %₄)
+5   (call JuliaLowering.eval_closure_type TestMod :#g#f##5 %₃ %₄)
 6   latestworld
-7   TestMod.#f#g##3
+7   TestMod.#g#f##5
 8   (call core.svec %₇)
 9   (call core.svec)
 10  SourceLocation::2:14
@@ -339,7 +339,7 @@ end
 20  --- method TestMod.f %₁₉
     slots: [slot₁/#self#(!read) slot₂/x slot₃/g(single_assign) slot₄/y(single_assign)]
     1   (= slot₄/y (call core.Box))
-    2   TestMod.#f#g##3
+    2   TestMod.#g#f##5
     3   (call core._typeof_captured_variable slot₂/x)
     4   (call core.apply_type %₂ %₃)
     5   slot₄/y
@@ -359,7 +359,7 @@ end
 ########################################
 # Nested captures - here `g` captures `x` because it is needed to initialize
 # the closure `h` which captures both `x` and `y`.
-# [method_filter: #f_nest#g_nest##0]
+# [method_filter: #g_nest#f_nest##0]
 function f_nest(x)
     function g_nest(y)
         function h_nest(z)
@@ -369,7 +369,7 @@ function f_nest(x)
 end
 #---------------------
 slots: [slot₁/#self#(!read) slot₂/y slot₃/h_nest(single_assign)]
-1   TestMod.#f_nest#g_nest#h_nest##0
+1   TestMod.#h_nest#f_nest##1
 2   (call core.getfield slot₁/#self# :x)
 3   (call core._typeof_captured_variable %₂)
 4   (call core._typeof_captured_variable slot₂/y)
@@ -429,12 +429,12 @@ x -> x*x
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###0 %₁ %₂)
+3   (call JuliaLowering.eval_closure_type TestMod :#3#4 %₁ %₂)
 4   latestworld
-5   TestMod.##->###0
+5   TestMod.#3#4
 6   (new %₅)
-7   (= slot₁/#-># %₆)
-8   TestMod.##->###0
+7   (= slot₁/#2 %₆)
+8   TestMod.#3#4
 9   (call core.svec %₈ core.Any)
 10  (call core.svec)
 11  SourceLocation::1:1
@@ -445,7 +445,7 @@ x -> x*x
     2   (call %₁ slot₂/x slot₂/x)
     3   (return %₂)
 14  latestworld
-15  slot₁/#->#
+15  slot₁/#2
 16  (return %₁₅)
 
 ########################################
@@ -456,12 +456,12 @@ end
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##anon###0 %₁ %₂)
+3   (call JuliaLowering.eval_closure_type TestMod :#6#7 %₁ %₂)
 4   latestworld
-5   TestMod.##anon###0
+5   TestMod.#6#7
 6   (new %₅)
-7   (= slot₁/#anon# %₆)
-8   TestMod.##anon###0
+7   (= slot₁/#5 %₆)
+8   TestMod.#6#7
 9   (call core.svec %₈ core.Any)
 10  (call core.svec)
 11  SourceLocation::1:10
@@ -472,7 +472,7 @@ end
     2   (call %₁ slot₂/x slot₂/x)
     3   (return %₂)
 14  latestworld
-15  slot₁/#anon#
+15  slot₁/#5
 16  (return %₁₅)
 
 ########################################
@@ -488,9 +488,9 @@ end
 5   (call %₃ %₄)
 6   (call core.svec)
 7   (call core.svec)
-8   (call JuliaLowering.eval_closure_type TestMod :##->###1 %₆ %₇)
+8   (call JuliaLowering.eval_closure_type TestMod :#9#10 %₆ %₇)
 9   latestworld
-10  TestMod.##->###1
+10  TestMod.#9#10
 11  (call core.svec %₁₀ core.Any)
 12  (call core.svec)
 13  SourceLocation::1:13
@@ -501,10 +501,10 @@ end
     2   (call %₁ slot₂/y 2)
     3   (return %₂)
 16  latestworld
-17  TestMod.##->###1
+17  TestMod.#9#10
 18  (new %₁₇)
-19  (= slot₁/#-># %₁₈)
-20  slot₁/#->#
+19  (= slot₁/#8 %₁₈)
+20  slot₁/#8
 21  TestMod.x
 22  (call core.kwcall %₅ %₁ %₂₀ %₂₁)
 23  (return %₂₂)
@@ -585,13 +585,13 @@ end
 1   (= slot₂/recursive_b (call core.Box))
 2   (call core.svec :recursive_b)
 3   (call core.svec true)
-4   (call JuliaLowering.eval_closure_type TestMod :#recursive_a##0 %₂ %₃)
+4   (call JuliaLowering.eval_closure_type TestMod :#recursive_a#recursive_a##0 %₂ %₃)
 5   latestworld
-6   TestMod.#recursive_a##0
+6   TestMod.#recursive_a#recursive_a##0
 7   slot₂/recursive_b
 8   (new %₆ %₇)
 9   (= slot₁/recursive_a %₈)
-10  TestMod.#recursive_a##0
+10  TestMod.#recursive_a#recursive_a##0
 11  (call core.svec %₁₀)
 12  (call core.svec)
 13  SourceLocation::2:14
@@ -610,15 +610,15 @@ end
 16  latestworld
 17  (call core.svec :recursive_a)
 18  (call core.svec false)
-19  (call JuliaLowering.eval_closure_type TestMod :#recursive_b##0 %₁₇ %₁₈)
+19  (call JuliaLowering.eval_closure_type TestMod :#recursive_b#recursive_b##0 %₁₇ %₁₈)
 20  latestworld
-21  TestMod.#recursive_b##0
+21  TestMod.#recursive_b#recursive_b##0
 22  (call core._typeof_captured_variable slot₁/recursive_a)
 23  (call core.apply_type %₂₁ %₂₂)
 24  (new %₂₃ slot₁/recursive_a)
 25  slot₂/recursive_b
 26  (call core.setfield! %₂₅ :contents %₂₄)
-27  TestMod.#recursive_b##0
+27  TestMod.#recursive_b#recursive_b##0
 28  (call core.svec %₂₇)
 29  (call core.svec)
 30  SourceLocation::5:14
@@ -650,51 +650,51 @@ end
 2   (= slot₁/y %₁)
 3   (call core.svec :y)
 4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :##kw_body#f_kw_closure#0##0 %₃ %₄)
+5   (call JuliaLowering.eval_closure_type TestMod :#f_kw_closure#11#12 %₃ %₄)
 6   latestworld
-7   TestMod.##kw_body#f_kw_closure#0##0
+7   TestMod.#f_kw_closure#11#12
 8   (call core._typeof_captured_variable slot₁/y)
 9   (call core.apply_type %₇ %₈)
 10  (new %₉ slot₁/y)
-11  (= slot₂/#kw_body#f_kw_closure#0 %₁₀)
-12  (call core.svec :#kw_body#f_kw_closure#0)
+11  (= slot₂/#f_kw_closure#11 %₁₀)
+12  (call core.svec :#f_kw_closure#11)
 13  (call core.svec false)
-14  (call JuliaLowering.eval_closure_type TestMod :#f_kw_closure##0 %₁₂ %₁₃)
+14  (call JuliaLowering.eval_closure_type TestMod :#f_kw_closure#f_kw_closure##0 %₁₂ %₁₃)
 15  latestworld
-16  TestMod.#f_kw_closure##0
-17  (call core._typeof_captured_variable slot₂/#kw_body#f_kw_closure#0)
+16  TestMod.#f_kw_closure#f_kw_closure##0
+17  (call core._typeof_captured_variable slot₂/#f_kw_closure#11)
 18  (call core.apply_type %₁₆ %₁₇)
-19  (new %₁₈ slot₂/#kw_body#f_kw_closure#0)
+19  (new %₁₈ slot₂/#f_kw_closure#11)
 20  (= slot₃/f_kw_closure %₁₉)
-21  TestMod.##kw_body#f_kw_closure#0##0
+21  TestMod.#f_kw_closure#11#12
 22  TestMod.X
-23  TestMod.#f_kw_closure##0
+23  TestMod.#f_kw_closure#f_kw_closure##0
 24  (call core.svec %₂₁ %₂₂ %₂₃)
 25  (call core.svec)
 26  SourceLocation::2:14
 27  (call core.svec %₂₄ %₂₅ %₂₆)
 28  --- method core.nothing %₂₇
-    slots: [slot₁/#kw_body#f_kw_closure#0(!read) slot₂/x slot₃/#self#(!read)]
+    slots: [slot₁/#f_kw_closure#11(!read) slot₂/x slot₃/#self#(!read)]
     1   (meta :nkw 1)
     2   TestMod.+
-    3   (call core.getfield slot₁/#kw_body#f_kw_closure#0 :y)
+    3   (call core.getfield slot₁/#f_kw_closure#11 :y)
     4   (call %₂ slot₂/x %₃)
     5   (return %₄)
 29  latestworld
-30  TestMod.#f_kw_closure##0
+30  TestMod.#f_kw_closure#f_kw_closure##0
 31  (call core.svec %₃₀)
 32  (call core.svec)
 33  SourceLocation::2:14
 34  (call core.svec %₃₁ %₃₂ %₃₃)
 35  --- method core.nothing %₃₄
     slots: [slot₁/#self#]
-    1   (call core.getfield slot₁/#self# :#kw_body#f_kw_closure#0)
+    1   (call core.getfield slot₁/#self# :#f_kw_closure#11)
     2   TestMod.x_default
     3   (call %₁ %₂ slot₁/#self#)
     4   (return %₃)
 36  latestworld
 37  (call core.typeof core.kwcall)
-38  TestMod.#f_kw_closure##0
+38  TestMod.#f_kw_closure#f_kw_closure##0
 39  (call core.svec %₃₇ core.NamedTuple %₃₈)
 40  (call core.svec)
 41  SourceLocation::2:14
@@ -725,7 +725,7 @@ end
     22  (gotoifnot %₂₁ label₂₄)
     23  (goto label₂₅)
     24  (call top.kwerr slot₂/kws slot₃/#self#)
-    25  (call core.getfield slot₃/#self# :#kw_body#f_kw_closure#0)
+    25  (call core.getfield slot₃/#self# :#f_kw_closure#11)
     26  (call %₂₅ %₁₇ slot₃/#self#)
     27  (return %₂₆)
 44  latestworld
@@ -772,9 +772,9 @@ end
 2   latestworld
 3   (call core.svec :y)
 4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f_after_if##->###0 %₃ %₄)
+5   (call JuliaLowering.eval_closure_type TestMod :#f_after_if##0#f_after_if##1 %₃ %₄)
 6   latestworld
-7   TestMod.#f_after_if##->###0
+7   TestMod.#f_after_if##0#f_after_if##1
 8   (call core.svec %₇)
 9   (call core.svec)
 10  SourceLocation::6:5
@@ -791,18 +791,18 @@ end
 18  SourceLocation::1:10
 19  (call core.svec %₁₆ %₁₇ %₁₈)
 20  --- method TestMod.f_after_if %₁₉
-    slots: [slot₁/#self#(!read) slot₂/cond slot₃/#->#(single_assign) slot₄/y(single_assign)]
-    1   (newvar slot₃/#->#)
+    slots: [slot₁/#self#(!read) slot₂/cond slot₃/#13(single_assign) slot₄/y(single_assign)]
+    1   (newvar slot₃/#13)
     2   (gotoifnot slot₂/cond label₅)
     3   TestMod.println
     4   (call %₃ "hello")
     5   (= slot₄/y 1)
-    6   TestMod.#f_after_if##->###0
+    6   TestMod.#f_after_if##0#f_after_if##1
     7   (call core._typeof_captured_variable slot₄/y)
     8   (call core.apply_type %₆ %₇)
     9   (new %₈ slot₄/y)
-    10  (= slot₃/#-># %₉)
-    11  slot₃/#->#
+    10  (= slot₃/#13 %₉)
+    11  slot₃/#13
     12  (return %₁₁)
 21  latestworld
 22  TestMod.f_after_if
@@ -819,9 +819,9 @@ end
 2   latestworld
 3   (call core.svec :y)
 4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f_ternary##->###0 %₃ %₄)
+5   (call JuliaLowering.eval_closure_type TestMod :#f_ternary##0#f_ternary##1 %₃ %₄)
 6   latestworld
-7   TestMod.#f_ternary##->###0
+7   TestMod.#f_ternary##0#f_ternary##1
 8   (call core.svec %₇)
 9   (call core.svec)
 10  SourceLocation::3:5
@@ -838,8 +838,8 @@ end
 18  SourceLocation::1:10
 19  (call core.svec %₁₆ %₁₇ %₁₈)
 20  --- method TestMod.f_ternary %₁₉
-    slots: [slot₁/#self#(!read) slot₂/x slot₃/#->#(single_assign) slot₄/y(single_assign) slot₅/if_val(!read)]
-    1   (newvar slot₃/#->#)
+    slots: [slot₁/#self#(!read) slot₂/x slot₃/#14(single_assign) slot₄/y(single_assign) slot₅/if_val(!read)]
+    1   (newvar slot₃/#14)
     2   TestMod.>
     3   (call %₂ slot₂/x 0)
     4   (gotoifnot %₃ label₈)
@@ -849,12 +849,12 @@ end
     8   (= slot₅/if_val 0)
     9   slot₅/if_val
     10  (= slot₄/y %₉)
-    11  TestMod.#f_ternary##->###0
+    11  TestMod.#f_ternary##0#f_ternary##1
     12  (call core._typeof_captured_variable slot₄/y)
     13  (call core.apply_type %₁₁ %₁₂)
     14  (new %₁₃ slot₄/y)
-    15  (= slot₃/#-># %₁₄)
-    16  slot₃/#->#
+    15  (= slot₃/#14 %₁₄)
+    16  slot₃/#14
     17  (return %₁₆)
 21  latestworld
 22  TestMod.f_ternary
@@ -872,9 +872,9 @@ end
 2   latestworld
 3   (call core.svec :y)
 4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f_or_guard##->###0 %₃ %₄)
+5   (call JuliaLowering.eval_closure_type TestMod :#f_or_guard##0#f_or_guard##1 %₃ %₄)
 6   latestworld
-7   TestMod.#f_or_guard##->###0
+7   TestMod.#f_or_guard##0#f_or_guard##1
 8   (call core.svec %₇)
 9   (call core.svec)
 10  SourceLocation::4:5
@@ -891,8 +891,8 @@ end
 18  SourceLocation::1:10
 19  (call core.svec %₁₆ %₁₇ %₁₈)
 20  --- method TestMod.f_or_guard %₁₉
-    slots: [slot₁/#self#(!read) slot₂/x slot₃/#->#(single_assign) slot₄/y(single_assign) slot₅/if_val(!read)]
-    1   (newvar slot₃/#->#)
+    slots: [slot₁/#self#(!read) slot₂/x slot₃/#15(single_assign) slot₄/y(single_assign) slot₅/if_val(!read)]
+    1   (newvar slot₃/#15)
     2   TestMod.===
     3   TestMod.nothing
     4   (call %₂ slot₂/x %₃)
@@ -909,12 +909,12 @@ end
     15  (goto label₁₆)
     16  slot₂/x
     17  (= slot₄/y %₁₆)
-    18  TestMod.#f_or_guard##->###0
+    18  TestMod.#f_or_guard##0#f_or_guard##1
     19  (call core._typeof_captured_variable slot₄/y)
     20  (call core.apply_type %₁₈ %₁₉)
     21  (new %₂₀ slot₄/y)
-    22  (= slot₃/#-># %₂₁)
-    23  slot₃/#->#
+    22  (= slot₃/#15 %₂₁)
+    23  slot₃/#15
     24  (return %₂₃)
 21  latestworld
 22  TestMod.f_or_guard
@@ -931,9 +931,9 @@ end
 2   latestworld
 3   (call core.svec :x)
 4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f_arg_reassign##->###0 %₃ %₄)
+5   (call JuliaLowering.eval_closure_type TestMod :#f_arg_reassign##0#f_arg_reassign##1 %₃ %₄)
 6   latestworld
-7   TestMod.#f_arg_reassign##->###0
+7   TestMod.#f_arg_reassign##0#f_arg_reassign##1
 8   (call core.svec %₇)
 9   (call core.svec)
 10  SourceLocation::3:12
@@ -950,17 +950,17 @@ end
 18  SourceLocation::1:10
 19  (call core.svec %₁₆ %₁₇ %₁₈)
 20  --- method TestMod.f_arg_reassign %₁₉
-    slots: [slot₁/#self#(!read) slot₂/x(single_assign) slot₃/#->#(single_assign) slot₄/x(!read)]
+    slots: [slot₁/#self#(!read) slot₂/x(single_assign) slot₃/#16(single_assign) slot₄/x(!read)]
     1   (= slot₄/x slot₂/x)
     2   (= slot₄/x 1)
-    3   TestMod.#f_arg_reassign##->###0
+    3   TestMod.#f_arg_reassign##0#f_arg_reassign##1
     4   slot₄/x
     5   (call core._typeof_captured_variable %₄)
     6   (call core.apply_type %₃ %₅)
     7   slot₄/x
     8   (new %₆ %₇)
-    9   (= slot₃/#-># %₈)
-    10  slot₃/#->#
+    9   (= slot₃/#16 %₈)
+    10  slot₃/#16
     11  (return %₁₀)
 21  latestworld
 22  TestMod.f_arg_reassign
@@ -975,7 +975,7 @@ let
     ()->y
 end
 #---------------------
-1   (newvar slot₁/#->#)
+1   (newvar slot₁/#17)
 2   (= slot₂/y (call core.Box))
 3   (goto label₇)
 4   1
@@ -983,13 +983,13 @@ end
 6   (call core.setfield! %₅ :contents %₄)
 7   (call core.svec :y)
 8   (call core.svec true)
-9   (call JuliaLowering.eval_closure_type TestMod :##->###2 %₇ %₈)
+9   (call JuliaLowering.eval_closure_type TestMod :#18#19 %₇ %₈)
 10  latestworld
-11  TestMod.##->###2
+11  TestMod.#18#19
 12  slot₂/y
 13  (new %₁₁ %₁₂)
-14  (= slot₁/#-># %₁₃)
-15  TestMod.##->###2
+14  (= slot₁/#17 %₁₃)
+15  TestMod.#18#19
 16  (call core.svec %₁₅)
 17  (call core.svec)
 18  SourceLocation::5:5
@@ -1005,7 +1005,7 @@ end
     7   (call core.getfield %₁ :contents)
     8   (return %₇)
 21  latestworld
-22  slot₁/#->#
+22  slot₁/#17
 23  (return %₂₂)
 
 ########################################
@@ -1020,9 +1020,9 @@ end
 2   latestworld
 3   (call core.svec :x)
 4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f_local_no_box##->###0 %₃ %₄)
+5   (call JuliaLowering.eval_closure_type TestMod :#f_local_no_box##0#f_local_no_box##1 %₃ %₄)
 6   latestworld
-7   TestMod.#f_local_no_box##->###0
+7   TestMod.#f_local_no_box##0#f_local_no_box##1
 8   (call core.svec %₇)
 9   (call core.svec)
 10  SourceLocation::4:5
@@ -1039,14 +1039,14 @@ end
 18  SourceLocation::1:10
 19  (call core.svec %₁₆ %₁₇ %₁₈)
 20  --- method TestMod.f_local_no_box %₁₉
-    slots: [slot₁/#self#(!read) slot₂/x(single_assign) slot₃/#->#(single_assign)]
+    slots: [slot₁/#self#(!read) slot₂/x(single_assign) slot₃/#20(single_assign)]
     1   (= slot₂/x 1)
-    2   TestMod.#f_local_no_box##->###0
+    2   TestMod.#f_local_no_box##0#f_local_no_box##1
     3   (call core._typeof_captured_variable slot₂/x)
     4   (call core.apply_type %₂ %₃)
     5   (new %₄ slot₂/x)
-    6   (= slot₃/#-># %₅)
-    7   slot₃/#->#
+    6   (= slot₃/#20 %₅)
+    7   slot₃/#20
     8   (return %₇)
 21  latestworld
 22  TestMod.f_local_no_box
@@ -1064,9 +1064,9 @@ end
 2   latestworld
 3   (call core.svec :x)
 4   (call core.svec false)
-5   (call JuliaLowering.eval_closure_type TestMod :#f_typed_local_no_box##->###0 %₃ %₄)
+5   (call JuliaLowering.eval_closure_type TestMod :#f_typed_local_no_box##0#f_typed_local_no_box##1 %₃ %₄)
 6   latestworld
-7   TestMod.#f_typed_local_no_box##->###0
+7   TestMod.#f_typed_local_no_box##0#f_typed_local_no_box##1
 8   (call core.svec %₇)
 9   (call core.svec)
 10  SourceLocation::4:5
@@ -1083,8 +1083,8 @@ end
 18  SourceLocation::1:10
 19  (call core.svec %₁₆ %₁₇ %₁₈)
 20  --- method TestMod.f_typed_local_no_box %₁₉
-    slots: [slot₁/#self#(!read) slot₂/x(single_assign) slot₃/#->#(single_assign) slot₄/tmp(!read)]
-    1   (newvar slot₃/#->#)
+    slots: [slot₁/#self#(!read) slot₂/x(single_assign) slot₃/#21(single_assign) slot₄/tmp(!read)]
+    1   (newvar slot₃/#21)
     2   1
     3   TestMod.Int
     4   (= slot₄/tmp %₂)
@@ -1095,12 +1095,12 @@ end
     9   (= slot₄/tmp (call core.typeassert %₈ %₃))
     10  slot₄/tmp
     11  (= slot₂/x %₁₀)
-    12  TestMod.#f_typed_local_no_box##->###0
+    12  TestMod.#f_typed_local_no_box##0#f_typed_local_no_box##1
     13  (call core._typeof_captured_variable slot₂/x)
     14  (call core.apply_type %₁₂ %₁₃)
     15  (new %₁₄ slot₂/x)
-    16  (= slot₃/#-># %₁₅)
-    17  slot₃/#->#
+    16  (= slot₃/#21 %₁₅)
+    17  slot₃/#21
     18  (return %₁₇)
 21  latestworld
 22  TestMod.f_typed_local_no_box
@@ -1119,6 +1119,6 @@ end
 LoweringError:
 #= line 1 =# - Top level code was found outside any top level context. `@generated` functions may not contain closures, including `do` syntax and generators/comprehension
 Expression:
-  (call JuliaLowering.eval_closure_type Main.TestMod :##->###3 (call core.svec) (call core.svec))
+  (call JuliaLowering.eval_closure_type Main.TestMod :#23#24 (call core.svec) (call core.svec))
 Containing expressions:
-  (call JuliaLowering.eval_closure_type Main.TestMod :##->###3 (call core.svec) (call core.svec))
+  (call JuliaLowering.eval_closure_type Main.TestMod :#23#24 (call core.svec) (call core.svec))

--- a/JuliaLowering/test/functions_ir.jl
+++ b/JuliaLowering/test/functions_ir.jl
@@ -1342,11 +1342,11 @@ function f_kw_simple(a::Int=1, b::Float64=1.0; x::Char='a', y::Bool=true)
     (a, b, x, y)
 end
 #---------------------
-1   (method TestMod.#kw_body#f_kw_simple#0)
+1   (method TestMod.#f_kw_simple#1)
 2   latestworld
 3   (method TestMod.f_kw_simple)
 4   latestworld
-5   TestMod.#kw_body#f_kw_simple#0
+5   TestMod.#f_kw_simple#1
 6   (call core.Typeof %₅)
 7   TestMod.Char
 8   TestMod.Bool
@@ -1358,8 +1358,8 @@ end
 14  (call core.svec)
 15  SourceLocation::1:10
 16  (call core.svec %₁₃ %₁₄ %₁₅)
-17  --- method TestMod.#kw_body#f_kw_simple#0 %₁₆
-    slots: [slot₁/#kw_body#f_kw_simple#0(!read) slot₂/x slot₃/y slot₄/#self#(!read) slot₅/a slot₆/b]
+17  --- method TestMod.#f_kw_simple#1 %₁₆
+    slots: [slot₁/#f_kw_simple#1(!read) slot₂/x slot₃/y slot₄/#self#(!read) slot₅/a slot₆/b]
     1   (meta :nkw 2)
     2   (call core.tuple slot₅/a slot₆/b slot₂/x slot₃/y)
     3   (return %₂)
@@ -1399,7 +1399,7 @@ end
 43  (call core.svec %₄₀ %₄₁ %₄₂)
 44  --- method TestMod.f_kw_simple %₄₃
     slots: [slot₁/#self# slot₂/a slot₃/b]
-    1   TestMod.#kw_body#f_kw_simple#0
+    1   TestMod.#f_kw_simple#1
     2   (call %₁ 'a' true slot₁/#self# slot₂/a slot₃/b)
     3   (return %₂)
 45  latestworld
@@ -1479,7 +1479,7 @@ end
     36  (gotoifnot %₃₅ label₃₈)
     37  (goto label₃₉)
     38  (call top.kwerr slot₂/kws slot₃/#self# slot₄/a slot₅/b)
-    39  TestMod.#kw_body#f_kw_simple#0
+    39  TestMod.#f_kw_simple#1
     40  (call %₃₉ %₁₇ %₃₁ slot₃/#self# slot₄/a slot₅/b)
     41  (return %₄₀)
 75  latestworld
@@ -1491,11 +1491,11 @@ end
 # underscore kwargs apart from `_...` are probably not intended to work anyway
 function f_kw_placeholders(; _=1, _=2); end
 #---------------------
-1   (method TestMod.#kw_body#f_kw_placeholders#0)
+1   (method TestMod.#f_kw_placeholders#2)
 2   latestworld
 3   (method TestMod.f_kw_placeholders)
 4   latestworld
-5   TestMod.#kw_body#f_kw_placeholders#0
+5   TestMod.#f_kw_placeholders#2
 6   (call core.Typeof %₅)
 7   TestMod.f_kw_placeholders
 8   (call core.Typeof %₇)
@@ -1503,8 +1503,8 @@ function f_kw_placeholders(; _=1, _=2); end
 10  (call core.svec)
 11  SourceLocation::1:10
 12  (call core.svec %₉ %₁₀ %₁₁)
-13  --- method TestMod.#kw_body#f_kw_placeholders#0 %₁₂
-    slots: [slot₁/#kw_body#f_kw_placeholders#0(!read) slot₂/#unused#(!read) slot₃/#unused#(!read) slot₄/#self#(!read)]
+13  --- method TestMod.#f_kw_placeholders#2 %₁₂
+    slots: [slot₁/#f_kw_placeholders#2(!read) slot₂/#unused#(!read) slot₃/#unused#(!read) slot₄/#self#(!read)]
     1   (meta :nkw 2)
     2   (return core.nothing)
 14  latestworld
@@ -1516,7 +1516,7 @@ function f_kw_placeholders(; _=1, _=2); end
 20  (call core.svec %₁₇ %₁₈ %₁₉)
 21  --- method TestMod.f_kw_placeholders %₂₀
     slots: [slot₁/#self#]
-    1   TestMod.#kw_body#f_kw_placeholders#0
+    1   TestMod.#f_kw_placeholders#2
     2   (call %₁ 1 2 slot₁/#self#)
     3   (return %₂)
 22  latestworld
@@ -1549,7 +1549,7 @@ function f_kw_placeholders(; _=1, _=2); end
     18  (gotoifnot %₁₇ label₂₀)
     19  (goto label₂₁)
     20  (call top.kwerr slot₂/kws slot₃/#self#)
-    21  TestMod.#kw_body#f_kw_placeholders#0
+    21  TestMod.#f_kw_placeholders#2
     22  (call %₂₁ %₇ %₁₃ slot₃/#self#)
     23  (return %₂₂)
 31  latestworld
@@ -1562,11 +1562,11 @@ function f_kw_slurp_simple(; all_kws...)
     all_kws
 end
 #---------------------
-1   (method TestMod.#kw_body#f_kw_slurp_simple#0)
+1   (method TestMod.#f_kw_slurp_simple#2)
 2   latestworld
 3   (method TestMod.f_kw_slurp_simple)
 4   latestworld
-5   TestMod.#kw_body#f_kw_slurp_simple#0
+5   TestMod.#f_kw_slurp_simple#2
 6   (call core.Typeof %₅)
 7   (call top.pairs core.NamedTuple)
 8   TestMod.f_kw_slurp_simple
@@ -1575,8 +1575,8 @@ end
 11  (call core.svec)
 12  SourceLocation::1:10
 13  (call core.svec %₁₀ %₁₁ %₁₂)
-14  --- method TestMod.#kw_body#f_kw_slurp_simple#0 %₁₃
-    slots: [slot₁/#kw_body#f_kw_slurp_simple#0(!read) slot₂/all_kws slot₃/#self#(!read)]
+14  --- method TestMod.#f_kw_slurp_simple#2 %₁₃
+    slots: [slot₁/#f_kw_slurp_simple#2(!read) slot₂/all_kws slot₃/#self#(!read)]
     1   (meta :nkw 1)
     2   slot₂/all_kws
     3   (return %₂)
@@ -1589,7 +1589,7 @@ end
 21  (call core.svec %₁₈ %₁₉ %₂₀)
 22  --- method TestMod.f_kw_slurp_simple %₂₁
     slots: [slot₁/#self#]
-    1   TestMod.#kw_body#f_kw_slurp_simple#0
+    1   TestMod.#f_kw_slurp_simple#2
     2   (call core.NamedTuple)
     3   (call top.pairs %₂)
     4   (call %₁ %₃ slot₁/#self#)
@@ -1605,7 +1605,7 @@ end
 31  --- method TestMod.f_kw_slurp_simple %₃₀
     slots: [slot₁/#unused#(!read) slot₂/kws slot₃/#self#]
     1   (call top.pairs slot₂/kws)
-    2   TestMod.#kw_body#f_kw_slurp_simple#0
+    2   TestMod.#f_kw_slurp_simple#2
     3   (call %₂ %₁ slot₃/#self#)
     4   (return %₃)
 32  latestworld
@@ -1618,11 +1618,11 @@ function f_kw_slurp(; x=x_default, non_x_kws...)
     all_kws
 end
 #---------------------
-1   (method TestMod.#kw_body#f_kw_slurp#0)
+1   (method TestMod.#f_kw_slurp#3)
 2   latestworld
 3   (method TestMod.f_kw_slurp)
 4   latestworld
-5   TestMod.#kw_body#f_kw_slurp#0
+5   TestMod.#f_kw_slurp#3
 6   (call core.Typeof %₅)
 7   (call top.pairs core.NamedTuple)
 8   TestMod.f_kw_slurp
@@ -1631,8 +1631,8 @@ end
 11  (call core.svec)
 12  SourceLocation::1:10
 13  (call core.svec %₁₀ %₁₁ %₁₂)
-14  --- method TestMod.#kw_body#f_kw_slurp#0 %₁₃
-    slots: [slot₁/#kw_body#f_kw_slurp#0(!read) slot₂/x(!read) slot₃/non_x_kws(!read) slot₄/#self#(!read)]
+14  --- method TestMod.#f_kw_slurp#3 %₁₃
+    slots: [slot₁/#f_kw_slurp#3(!read) slot₂/x(!read) slot₃/non_x_kws(!read) slot₄/#self#(!read)]
     1   (meta :nkw 2)
     2   TestMod.all_kws
     3   (return %₂)
@@ -1645,7 +1645,7 @@ end
 21  (call core.svec %₁₈ %₁₉ %₂₀)
 22  --- method TestMod.f_kw_slurp %₂₁
     slots: [slot₁/#self#]
-    1   TestMod.#kw_body#f_kw_slurp#0
+    1   TestMod.#f_kw_slurp#3
     2   TestMod.x_default
     3   (call core.NamedTuple)
     4   (call top.pairs %₃)
@@ -1674,7 +1674,7 @@ end
     11  (call core.apply_type core.NamedTuple %₁₀)
     12  (call top.structdiff slot₂/kws %₁₁)
     13  (call top.pairs %₁₂)
-    14  TestMod.#kw_body#f_kw_slurp#0
+    14  TestMod.#f_kw_slurp#3
     15  (call %₁₄ %₉ %₁₃ slot₃/#self#)
     16  (return %₁₅)
 32  latestworld
@@ -1690,11 +1690,11 @@ function f_kw_slurp_dep(; a=1, b=a, kws...)
     (a, b, kws)
 end
 #---------------------
-1   (method TestMod.#kw_body#f_kw_slurp_dep#0)
+1   (method TestMod.#f_kw_slurp_dep#4)
 2   latestworld
 3   (method TestMod.f_kw_slurp_dep)
 4   latestworld
-5   TestMod.#kw_body#f_kw_slurp_dep#0
+5   TestMod.#f_kw_slurp_dep#4
 6   (call core.Typeof %₅)
 7   (call top.pairs core.NamedTuple)
 8   TestMod.f_kw_slurp_dep
@@ -1703,8 +1703,8 @@ end
 11  (call core.svec)
 12  SourceLocation::1:10
 13  (call core.svec %₁₀ %₁₁ %₁₂)
-14  --- method TestMod.#kw_body#f_kw_slurp_dep#0 %₁₃
-    slots: [slot₁/#kw_body#f_kw_slurp_dep#0(!read) slot₂/a slot₃/b slot₄/kws slot₅/#self#(!read)]
+14  --- method TestMod.#f_kw_slurp_dep#4 %₁₃
+    slots: [slot₁/#f_kw_slurp_dep#4(!read) slot₂/a slot₃/b slot₄/kws slot₅/#self#(!read)]
     1   (meta :nkw 3)
     2   (call core.tuple slot₂/a slot₃/b slot₄/kws)
     3   (return %₂)
@@ -1721,7 +1721,7 @@ end
     2   (= slot₂/a %₁)
     3   slot₂/a
     4   (= slot₃/b %₃)
-    5   TestMod.#kw_body#f_kw_slurp_dep#0
+    5   TestMod.#f_kw_slurp_dep#4
     6   (call core.NamedTuple)
     7   (call top.pairs %₆)
     8   (call %₅ slot₂/a slot₃/b %₇ slot₁/#self#)
@@ -1756,7 +1756,7 @@ end
     18  (call core.apply_type core.NamedTuple %₁₇)
     19  (call top.structdiff slot₂/kws %₁₈)
     20  (call top.pairs %₁₉)
-    21  TestMod.#kw_body#f_kw_slurp_dep#0
+    21  TestMod.#f_kw_slurp_dep#4
     22  (call %₂₁ slot₅/a slot₆/b %₂₀ slot₃/#self#)
     23  (return %₂₂)
 32  latestworld
@@ -1773,13 +1773,13 @@ function f_kw_sparams(x::X; a::A=a_def, b::X=b_def) where {X,A}
     (X,A)
 end
 #---------------------
-1   (method TestMod.#kw_body#f_kw_sparams#0)
+1   (method TestMod.#f_kw_sparams#5)
 2   latestworld
 3   (method TestMod.f_kw_sparams)
 4   latestworld
 5   (= slot₁/X (call core.TypeVar :X))
 6   (= slot₂/A (call core.TypeVar :A))
-7   TestMod.#kw_body#f_kw_sparams#0
+7   TestMod.#f_kw_sparams#5
 8   (call core.Typeof %₇)
 9   slot₂/A
 10  slot₁/X
@@ -1792,8 +1792,8 @@ end
 17  (call core.svec %₁₅ %₁₆)
 18  SourceLocation::1:10
 19  (call core.svec %₁₄ %₁₇ %₁₈)
-20  --- method TestMod.#kw_body#f_kw_sparams#0 %₁₉
-    slots: [slot₁/#kw_body#f_kw_sparams#0(!read) slot₂/a(!read) slot₃/b(!read) slot₄/#self#(!read) slot₅/x(!read)]
+20  --- method TestMod.#f_kw_sparams#5 %₁₉
+    slots: [slot₁/#f_kw_sparams#5(!read) slot₂/a(!read) slot₃/b(!read) slot₄/#self#(!read) slot₅/x(!read)]
     1   (meta :nkw 2)
     2   static_parameter₁
     3   static_parameter₂
@@ -1811,7 +1811,7 @@ end
 30  (call core.svec %₂₆ %₂₈ %₂₉)
 31  --- method TestMod.f_kw_sparams %₃₀
     slots: [slot₁/#self# slot₂/x]
-    1   TestMod.#kw_body#f_kw_sparams#0
+    1   TestMod.#f_kw_sparams#5
     2   TestMod.a_def
     3   TestMod.b_def
     4   (call %₁ %₂ %₃ slot₁/#self# slot₂/x)
@@ -1861,7 +1861,7 @@ end
     30  (gotoifnot %₂₉ label₃₂)
     31  (goto label₃₃)
     32  (call top.kwerr slot₂/kws slot₃/#self# slot₄/x)
-    33  TestMod.#kw_body#f_kw_sparams#0
+    33  TestMod.#f_kw_sparams#5
     34  (call %₃₃ %₁₀ %₂₅ slot₃/#self# slot₄/x)
     35  (return %₃₄)
 44  latestworld
@@ -1886,11 +1886,11 @@ function f_kw_slurp(a,;kw1,kw2=2,restkw...)
     @nospecialize
 end
 #---------------------
-1   (method TestMod.#kw_body#f_kw_slurp#1)
+1   (method TestMod.#f_kw_slurp#6)
 2   latestworld
 3   (method TestMod.f_kw_slurp)
 4   latestworld
-5   TestMod.#kw_body#f_kw_slurp#1
+5   TestMod.#f_kw_slurp#6
 6   (call core.Typeof %₅)
 7   (call top.pairs core.NamedTuple)
 8   TestMod.f_kw_slurp
@@ -1899,8 +1899,8 @@ end
 11  (call core.svec)
 12  SourceLocation::1:10
 13  (call core.svec %₁₀ %₁₁ %₁₂)
-14  --- method TestMod.#kw_body#f_kw_slurp#1 %₁₃
-    slots: [slot₁/#kw_body#f_kw_slurp#1(!read) slot₂/kw1(nospecialize,!read) slot₃/kw2(nospecialize,!read) slot₄/restkw(nospecialize,!read) slot₅/#self#(!read) slot₆/a(nospecialize,!read)]
+14  --- method TestMod.#f_kw_slurp#6 %₁₃
+    slots: [slot₁/#f_kw_slurp#6(!read) slot₂/kw1(nospecialize,!read) slot₃/kw2(nospecialize,!read) slot₄/restkw(nospecialize,!read) slot₅/#self#(!read) slot₆/a(nospecialize,!read)]
     1   (meta :nkw 3)
     2   (return core.nothing)
 15  latestworld
@@ -1912,7 +1912,7 @@ end
 21  (call core.svec %₁₈ %₁₉ %₂₀)
 22  --- method TestMod.f_kw_slurp %₂₁
     slots: [slot₁/#self# slot₂/a(nospecialize)]
-    1   TestMod.#kw_body#f_kw_slurp#1
+    1   TestMod.#f_kw_slurp#6
     2   (call core.UndefKeywordError :kw1)
     3   (call core.throw %₂)
     4   (call core.NamedTuple)
@@ -1949,7 +1949,7 @@ end
     18  (call core.apply_type core.NamedTuple %₁₇)
     19  (call top.structdiff slot₂/kws %₁₈)
     20  (call top.pairs %₁₉)
-    21  TestMod.#kw_body#f_kw_slurp#1
+    21  TestMod.#f_kw_slurp#6
     22  (call %₂₁ %₁₀ %₁₆ %₂₀ slot₃/#self# slot₄/a)
     23  (return %₂₂)
 32  latestworld
@@ -2021,17 +2021,17 @@ end
 #---------------------
 1   (method TestMod.f_only_generated)
 2   latestworld
-3   (call core.declare_global TestMod :#f_only_generated@generator#0 false)
+3   (call core.declare_global TestMod :#7#8 false)
 4   latestworld
-5   (method TestMod.#f_only_generated@generator#0)
+5   (method TestMod.#7#8)
 6   latestworld
-7   TestMod.#f_only_generated@generator#0
+7   TestMod.#7#8
 8   (call core.Typeof %₇)
 9   (call core.svec %₈ JuliaLowering.MacroContext core.Any core.Any core.Any)
 10  (call core.svec)
 11  SourceLocation::1:21
 12  (call core.svec %₉ %₁₀ %₁₁)
-13  --- method TestMod.#f_only_generated@generator#0 %₁₂
+13  --- method TestMod.#7#8 %₁₂
     slots: [slot₁/#self#(!read) slot₂/__context__(!read) slot₃/#self#(nospecialize,!read) slot₄/x(nospecialize) slot₅/y(nospecialize)]
     1   TestMod.generator_code
     2   (call %₁ slot₄/x slot₅/y)
@@ -2047,7 +2047,7 @@ end
 20  (call core.svec %₁₇ %₁₈ %₁₉)
 21  --- method TestMod.f_only_generated %₂₀
     slots: [slot₁/#self#(!read) slot₂/x(!read) slot₃/y(!read)]
-    1   (meta :generated (new JuliaLowering.GeneratedFunctionStub false TestMod.#f_only_generated@generator#0 SourceRef::1:1 (call core.svec :#self# :x :y) (call core.svec)))
+    1   (meta :generated (new JuliaLowering.GeneratedFunctionStub false TestMod.#7#8 SourceRef::1:1 (call core.svec :#self# :x :y) (call core.svec)))
     2   (meta :generated_only)
     3   (return core.nothing)
 22  latestworld
@@ -2070,17 +2070,17 @@ end
 #---------------------
 1   (method TestMod.f_partially_generated)
 2   latestworld
-3   (call core.declare_global TestMod :#f_partially_generated@generator#0 false)
+3   (call core.declare_global TestMod :#9#10 false)
 4   latestworld
-5   (method TestMod.#f_partially_generated@generator#0)
+5   (method TestMod.#9#10)
 6   latestworld
-7   TestMod.#f_partially_generated@generator#0
+7   TestMod.#9#10
 8   (call core.Typeof %₇)
 9   (call core.svec %₈ JuliaLowering.MacroContext core.Any core.Any core.Any)
 10  (call core.svec)
 11  SourceLocation::1:10
 12  (call core.svec %₉ %₁₀ %₁₁)
-13  --- method TestMod.#f_partially_generated@generator#0 %₁₂
+13  --- method TestMod.#9#10 %₁₂
     slots: [slot₁/#self#(!read) slot₂/__context__(!read) slot₃/#self#(nospecialize,!read) slot₄/x(nospecialize,!read) slot₅/y(nospecialize,!read)]
     1   (call JuliaLowering.interpolate_ast SyntaxTree (inert_syntaxtree (block (= maybe_gen_stuff (call some_gen_stuff x y)))))
     2   (call core.tuple %₁)
@@ -2095,7 +2095,7 @@ end
 20  (call core.svec %₁₇ %₁₈ %₁₉)
 21  --- method TestMod.f_partially_generated %₂₀
     slots: [slot₁/#self#(!read) slot₂/x slot₃/y slot₄/maybe_gen_stuff(single_assign) slot₅/nongen_stuff(single_assign)]
-    1   (meta :generated (new JuliaLowering.GeneratedFunctionStub false TestMod.#f_partially_generated@generator#0 SourceRef::1:37 (call core.svec :#self# :x :y) (call core.svec)))
+    1   (meta :generated (new JuliaLowering.GeneratedFunctionStub false TestMod.#9#10 SourceRef::1:37 (call core.svec :#self# :x :y) (call core.svec)))
     2   TestMod.bothgen
     3   (= slot₅/nongen_stuff (call %₂ slot₂/x slot₃/y))
     4   TestMod.some_nongen_stuff

--- a/JuliaLowering/test/generators_ir.jl
+++ b/JuliaLowering/test/generators_ir.jl
@@ -4,9 +4,9 @@
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###0 %₁ %₂)
+3   (call JuliaLowering.eval_closure_type TestMod :#2#3 %₁ %₂)
 4   latestworld
-5   TestMod.##->###0
+5   TestMod.#2#3
 6   (call core.svec %₅ core.Any)
 7   (call core.svec)
 8   SourceLocation::1:2
@@ -17,10 +17,10 @@
     2   (call %₁ slot₂/x 1)
     3   (return %₂)
 11  latestworld
-12  TestMod.##->###0
+12  TestMod.#2#3
 13  (new %₁₂)
-14  (= slot₁/#-># %₁₃)
-15  slot₁/#->#
+14  (= slot₁/#1 %₁₃)
+15  slot₁/#1
 16  TestMod.xs
 17  (call top.Generator %₁₅ %₁₆)
 18  (return %₁₇)
@@ -31,9 +31,9 @@
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###1 %₁ %₂)
+3   (call JuliaLowering.eval_closure_type TestMod :#5#6 %₁ %₂)
 4   latestworld
-5   TestMod.##->###1
+5   TestMod.#5#6
 6   (call core.svec %₅ core.Any)
 7   (call core.svec)
 8   SourceLocation::1:2
@@ -52,10 +52,10 @@
     10  (call %₇ %₈ %₉)
     11  (return %₁₀)
 11  latestworld
-12  TestMod.##->###1
+12  TestMod.#5#6
 13  (new %₁₂)
-14  (= slot₁/#-># %₁₃)
-15  slot₁/#->#
+14  (= slot₁/#4 %₁₃)
+15  slot₁/#4
 16  TestMod.xs
 17  TestMod.ys
 18  (call top.product %₁₆ %₁₇)
@@ -68,9 +68,9 @@
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###2 %₁ %₂)
+3   (call JuliaLowering.eval_closure_type TestMod :#8#9 %₁ %₂)
 4   latestworld
-5   TestMod.##->###2
+5   TestMod.#8#9
 6   (call core.svec %₅ core.Any)
 7   (call core.svec)
 8   SourceLocation::1:29
@@ -88,10 +88,10 @@
     9   (call %₇ %₈)
     10  (return %₉)
 11  latestworld
-12  TestMod.##->###2
+12  TestMod.#8#9
 13  (new %₁₂)
-14  (= slot₁/#-># %₁₃)
-15  slot₁/#->#
+14  (= slot₁/#7 %₁₃)
+15  slot₁/#7
 16  TestMod.iter
 17  (call top.Filter %₁₅ %₁₆)
 18  (call top.Generator top.identity %₁₇)
@@ -103,9 +103,9 @@
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###3 %₁ %₂)
+3   (call JuliaLowering.eval_closure_type TestMod :#11#12 %₁ %₂)
 4   latestworld
-5   TestMod.##->###3
+5   TestMod.#11#12
 6   (call core.svec %₅ core.Any)
 7   (call core.svec)
 8   SourceLocation::1:2
@@ -114,10 +114,10 @@
     slots: [slot₁/#self#(!read) slot₂/#unused#(!read)]
     1   (return 1)
 11  latestworld
-12  TestMod.##->###3
+12  TestMod.#11#12
 13  (new %₁₂)
-14  (= slot₁/#-># %₁₃)
-15  slot₁/#->#
+14  (= slot₁/#10 %₁₃)
+15  slot₁/#10
 16  TestMod.xs
 17  (call top.Generator %₁₅ %₁₆)
 18  (return %₁₇)
@@ -136,9 +136,9 @@ LoweringError:
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###4 %₁ %₂)
+3   (call JuliaLowering.eval_closure_type TestMod :#14#15 %₁ %₂)
 4   latestworld
-5   TestMod.##->###4
+5   TestMod.#14#15
 6   (call core.svec %₅ core.Any)
 7   (call core.svec)
 8   SourceLocation::1:2
@@ -158,10 +158,10 @@ LoweringError:
     11  TestMod.body
     12  (return %₁₁)
 11  latestworld
-12  TestMod.##->###4
+12  TestMod.#14#15
 13  (new %₁₂)
-14  (= slot₁/#-># %₁₃)
-15  slot₁/#->#
+14  (= slot₁/#13 %₁₃)
+15  slot₁/#13
 16  TestMod.iter
 17  (call top.Generator %₁₅ %₁₆)
 18  (return %₁₇)
@@ -172,9 +172,9 @@ LoweringError:
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###5 %₁ %₂)
+3   (call JuliaLowering.eval_closure_type TestMod :#17#18 %₁ %₂)
 4   latestworld
-5   TestMod.##->###5
+5   TestMod.#17#18
 6   (call core.svec %₅ core.Any)
 7   (call core.svec)
 8   SourceLocation::1:4
@@ -184,10 +184,10 @@ LoweringError:
     1   (call JuliaLowering.interpolate_ast SyntaxTree (inert_syntaxtree (return x)))
     2   (return %₁)
 11  latestworld
-12  TestMod.##->###5
+12  TestMod.#17#18
 13  (new %₁₂)
-14  (= slot₁/#-># %₁₃)
-15  slot₁/#->#
+14  (= slot₁/#16 %₁₃)
+15  slot₁/#16
 16  TestMod.iter
 17  (call top.Generator %₁₅ %₁₆)
 18  (return %₁₇)
@@ -206,13 +206,13 @@ LoweringError:
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :##->###6 %₁ %₂)
+3   (call JuliaLowering.eval_closure_type TestMod :#21#22 %₁ %₂)
 4   latestworld
 5   (call core.svec)
 6   (call core.svec)
-7   (call JuliaLowering.eval_closure_type TestMod :##->###->###0 %₅ %₆)
+7   (call JuliaLowering.eval_closure_type TestMod :#23#24 %₅ %₆)
 8   latestworld
-9   TestMod.##->###->###0
+9   TestMod.#23#24
 10  (call core.svec %₉ core.Any)
 11  (call core.svec)
 12  SourceLocation::1:2
@@ -224,26 +224,26 @@ LoweringError:
     3   slot₃/x
     4   (return %₃)
 15  latestworld
-16  TestMod.##->###6
+16  TestMod.#21#22
 17  (call core.svec %₁₆ core.Any)
 18  (call core.svec)
 19  SourceLocation::1:2
 20  (call core.svec %₁₇ %₁₈ %₁₉)
 21  --- method core.nothing %₂₀
-    slots: [slot₁/#self#(!read) slot₂/x(!read) slot₃/#->#(single_assign)]
-    1   TestMod.##->###->###0
+    slots: [slot₁/#self#(!read) slot₂/x(!read) slot₃/#20(single_assign)]
+    1   TestMod.#23#24
     2   (new %₁)
-    3   (= slot₃/#-># %₂)
-    4   slot₃/#->#
+    3   (= slot₃/#20 %₂)
+    4   slot₃/#20
     5   TestMod.:
     6   (call %₅ 1 2)
     7   (call top.Generator %₄ %₆)
     8   (return %₇)
 22  latestworld
-23  TestMod.##->###6
+23  TestMod.#21#22
 24  (new %₂₃)
-25  (= slot₁/#-># %₂₄)
-26  slot₁/#->#
+25  (= slot₁/#19 %₂₄)
+26  slot₁/#19
 27  TestMod.:
 28  (call %₂₇ 1 3)
 29  (call top.Generator %₂₆ %₂₈)

--- a/JuliaLowering/test/modules.jl
+++ b/JuliaLowering/test/modules.jl
@@ -48,3 +48,135 @@ module A
 end
 """)
 @test Amod.init_order == ["B", "D", "E", "C", "A"]
+
+# Anonymous naming conventions
+# These tests verify that JuliaLowering generates the same anonymous function
+# and closure type names as flisp (julia-syntax.scm), with identical counter
+# values. The module counter starts at 1 for fresh modules.
+const _skip = Symbol("#_internal_julia_parse")
+filter_names(m) = sort([s for s in names(m; all=true)
+                        if startswith(string(s), "#") && s != _skip])
+
+# Arrow function: local name #1, type #2#3
+M = JuliaLowering.include_string(test_mod, """
+module _AnonArrow; f = x -> x + 1; end
+""")
+@test filter_names(M) == [Symbol("#2#3")]
+
+# Anonymous function(x) ... end: same pattern as arrow
+M = JuliaLowering.include_string(test_mod, """
+module _AnonFunc; f = function(x) x + 1 end; end
+""")
+@test filter_names(M) == [Symbol("#2#3")]
+
+# Two arrows: each statement lowered independently, 3 counter values each
+M = JuliaLowering.include_string(test_mod, """
+module _TwoArrows; f = x -> x; g = y -> y; end
+""")
+@test filter_names(M) == [Symbol("#2#3"), Symbol("#5#6")]
+
+# Named closure: type name is #<closure_name>#<outermost>##N
+M = JuliaLowering.include_string(test_mod, """
+module _NamedClosure
+    function outer()
+        x = 1
+        inner() = x + 1
+        inner()
+    end
+end
+""")
+@test filter_names(M) == [Symbol("#inner#outer##0"), Symbol("#outer")]
+
+# Nested closures: all share the outermost function's reservation space
+M = JuliaLowering.include_string(test_mod, """
+module _NestedClosures
+    function a()
+        x = 1
+        b() = begin
+            y = 2
+            c() = x + y
+            c()
+        end
+        b()
+    end
+end
+""")
+@test filter_names(M) == [Symbol("#a"), Symbol("#b#a##0"), Symbol("#c#a##1")]
+
+# Keyword function: body name is #name#<counter>
+M = JuliaLowering.include_string(test_mod, """
+module _KWFunc; function foo(x; y=1) x + y end; end
+""")
+@test filter_names(M) == [Symbol("##foo#1"), Symbol("#foo"), Symbol("#foo#1")]
+
+# Anonymous closure inside named function
+M = JuliaLowering.include_string(test_mod, """
+module _AnonClosure
+    function outer()
+        x = 1
+        f = y -> x + y
+        f
+    end
+end
+""")
+@test filter_names(M) == [Symbol("#outer"), Symbol("#outer##0#outer##1")]
+
+# Verify that generated names are compatible with jl_demangle_typename.
+# The runtime uses this to produce display names for closures and anonymous
+# function types (e.g. in stack traces, show methods).
+function demangle(s::Symbol)
+    ccall(:jl_demangle_typename, Any, (Any,), s)::Symbol
+end
+
+# Named closure: #inner#outer##0 → inner
+M = JuliaLowering.include_string(test_mod, """
+module _Demangle1
+    function outer()
+        x = 1
+        inner() = x + 1
+        inner()
+    end
+end
+""")
+@test demangle(Symbol("#inner#outer##0")) == :inner
+
+# Anonymous arrow at toplevel: #N#M → #N
+M = JuliaLowering.include_string(test_mod, """
+module _Demangle2; f = x -> x + 1; end
+""")
+closure_type_sym = only(filter(s -> s != Symbol("#_internal_julia_parse"), filter_names(M)))
+@test startswith(string(demangle(closure_type_sym)), "#")
+
+# Keyword body: #foo#N → foo
+M = JuliaLowering.include_string(test_mod, """
+module _Demangle3; function foo(x; y=1) x + y end; end
+""")
+@test demangle(Symbol("#foo#1")) == :foo
+
+# Nested closure: #b#a##0 → b
+M = JuliaLowering.include_string(test_mod, """
+module _Demangle4
+    function a()
+        x = 1
+        b() = x + 1
+        b()
+    end
+end
+""")
+@test demangle(Symbol("#b#a##0")) == :b
+
+# Anonymous closure in named function: #outer##N#outer##M → #outer##N
+# (canonicalized anonymous function name, preserved with leading #)
+M = JuliaLowering.include_string(test_mod, """
+module _Demangle5
+    function outer()
+        x = 1
+        f = y -> x + y
+        f
+    end
+end
+""")
+anon_type = only(filter(s -> occursin("##", string(s)), filter_names(M)))
+demangled = demangle(anon_type)
+# The demangled name for a canonicalized anonymous function keeps the leading #
+@test startswith(string(demangled), "#")

--- a/JuliaLowering/test/scopes_ir.jl
+++ b/JuliaLowering/test/scopes_ir.jl
@@ -69,12 +69,12 @@ end
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :#f##0 %₁ %₂)
+3   (call JuliaLowering.eval_closure_type TestMod :#f#f##0 %₁ %₂)
 4   latestworld
-5   TestMod.#f##0
+5   TestMod.#f#f##0
 6   (new %₅)
 7   (= slot₁/f %₆)
-8   TestMod.#f##0
+8   TestMod.#f#f##0
 9   (call core.svec %₈)
 10  (call core.svec)
 11  SourceLocation::1:5

--- a/JuliaLowering/test/typedefs_ir.jl
+++ b/JuliaLowering/test/typedefs_ir.jl
@@ -763,12 +763,12 @@ end
 26  latestworld
 27  (call core.svec)
 28  (call core.svec)
-29  (call JuliaLowering.eval_closure_type TestMod :#f##0 %₂₇ %₂₈)
+29  (call JuliaLowering.eval_closure_type TestMod :#f#f##0 %₂₇ %₂₈)
 30  latestworld
-31  TestMod.#f##0
+31  TestMod.#f#f##0
 32  (new %₃₁)
 33  (= slot₂/f %₃₂)
-34  TestMod.#f##0
+34  TestMod.#f#f##0
 35  (call core.svec %₃₄)
 36  (call core.svec)
 37  SourceLocation::3:5
@@ -926,12 +926,12 @@ end
 66  latestworld
 67  (call core.svec)
 68  (call core.svec)
-69  (call JuliaLowering.eval_closure_type TestMod :#f##1 %₆₇ %₆₈)
+69  (call JuliaLowering.eval_closure_type TestMod :#f#f##1 %₆₇ %₆₈)
 70  latestworld
-71  TestMod.#f##1
+71  TestMod.#f#f##1
 72  (new %₇₁)
 73  (= slot₅/f %₇₂)
-74  TestMod.#f##1
+74  TestMod.#f#f##1
 75  (call core.svec %₇₄)
 76  (call core.svec)
 77  SourceLocation::5:5

--- a/JuliaLowering/test/utils.jl
+++ b/JuliaLowering/test/utils.jl
@@ -200,7 +200,9 @@ function refresh_ir_test_cases(filename, pattern=nothing)
         println(io, "#*******************************************************************************")
     end
     for case in cases
-        if isnothing(pattern) || occursin(pattern, case.description)
+        if case.is_broken
+            ir = case.output # don't update broken tests - this would affect the module counter
+        elseif isnothing(pattern) || occursin(pattern, case.description)
             ir = format_ir_for_test(test_mod, case)
             if rstrip(ir) != case.output
                 @info "Refreshing test case $(repr(case.description)) in $filename"

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -20,7 +20,7 @@ extern "C" {
 
 // allocating TypeNames -----------------------------------------------------------
 
-static jl_sym_t *jl_demangle_typename(jl_sym_t *s) JL_NOTSAFEPOINT
+JL_DLLEXPORT jl_sym_t *jl_demangle_typename(jl_sym_t *s) JL_NOTSAFEPOINT
 {
     char *n = jl_symbol_name(s);
     if (n[0] != '#')

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -97,6 +97,7 @@
     XX(jl_cstr_to_string) \
     XX(jl_current_exception) \
     XX(jl_debug_method_invalidation) \
+    XX(jl_demangle_typename) \
     XX(jl_deprecate_binding) \
     XX(jl_dlclose) \
     XX(jl_dlopen) \
@@ -312,6 +313,7 @@
     XX(jl_module_import) \
     XX(jl_module_name) \
     XX(jl_module_names) \
+    XX(jl_module_next_counter) \
     XX(jl_module_parent) \
     XX(jl_module_getloc) \
     XX(jl_module_public) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1452,7 +1452,7 @@ JL_DLLEXPORT void jl_force_trace_dispatch_disable(void);
 JL_DLLEXPORT void jl_tag_newly_inferred_enable(void);
 JL_DLLEXPORT void jl_tag_newly_inferred_disable(void);
 
-uint32_t jl_module_next_counter(jl_module_t *m) JL_NOTSAFEPOINT;
+JL_DLLEXPORT uint32_t jl_module_next_counter(jl_module_t *m) JL_NOTSAFEPOINT;
 jl_tupletype_t *arg_type_tuple(jl_value_t *arg1, jl_value_t **args, size_t nargs);
 
 JL_DLLEXPORT int jl_has_meta(jl_array_t *body, jl_sym_t *sym) JL_NOTSAFEPOINT;

--- a/src/module.c
+++ b/src/module.c
@@ -675,7 +675,7 @@ JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name, jl_module_t *parent)
     return jl_new_module_(name, parent, 1, 1);
 }
 
-uint32_t jl_module_next_counter(jl_module_t *m)
+JL_DLLEXPORT uint32_t jl_module_next_counter(jl_module_t *m)
 {
     return jl_atomic_fetch_add_relaxed(&m->counter, 1);
 }


### PR DESCRIPTION
This makes it possible to lower into two parallel modules via flisp / JuliaLowering and compare their contents (incl. anonymous functions), or to compare anonymous function internals / results against flisp across processes (incl. hopefully inference results, etc.). This does not make it possible to "re-lower" only part of a module with JuliaLowering (or flisp) and faithfully obtain the module you "would have gotten" from lowering it via that front-end the first time around (i.e. "re-lowering" a function will still see counter, type-identity differences, etc.), but that's a non-goal.

The intention here is to (1) make it easier to inspect behavioral differences vs. flisp (perhaps including inference parity?), and (2) preserve any hacks that might be inspecting anonymized function names (hopefully there aren't too many of these since https://github.com/JuliaLang/julia/pull/53719 would have already broken them once)

Resolves https://github.com/JuliaLang/JuliaLowering.jl/issues/172.

Entirely AI-generated. Sorry to throw 🤖 -created changes your way @mlechu without any human touches, but the "real" changes are small:
```diff
 JuliaLowering/src/closure_conversion.jl |  25 ++++++++++++++++---
 JuliaLowering/src/desugaring.jl         |  15 ++++++------
 JuliaLowering/src/runtime.jl            |  22 +++++++++++++++++
 ```

Based on feedback, I'll either get these changes into proper shape or we can close this.