### PR TITLE
compiler: Filter dominated original methods in overlay matching

### DIFF
--- a/Compiler/src/methodtable.jl
+++ b/Compiler/src/methodtable.jl
@@ -81,9 +81,17 @@ function findall(@nospecialize(sig::Type), table::OverlayMethodTable; limit::Int
     # fall back to the internal method table
     fallback_result = _findall(sig, nothing, table.world, limit)
     fallback_result === nothing && return nothing
-    # merge the fallback match results with the internal method table
+    # merge the fallback match results with the internal method table,
+    # filtering out base methods that are fully covered by overlay methods
+    overlay_matches = result.matches
+    filtered = filter(fallback_result.matches) do base_match::MethodMatch
+        dominated = any(overlay_matches) do overlay_match::MethodMatch
+            base_match.method.sig <: overlay_match.method.sig
+        end
+        return !dominated
+    end
     return MethodLookupResult(
-        vcat(result.matches, fallback_result.matches),
+        vcat(overlay_matches, filtered),
         WorldRange(
             max(result.valid_worlds.min_world, fallback_result.valid_worlds.min_world),
             min(result.valid_worlds.max_world, fallback_result.valid_worlds.max_world)),

--- a/Compiler/test/AbstractInterpreter.jl
+++ b/Compiler/test/AbstractInterpreter.jl
@@ -104,6 +104,15 @@ overlay_match(::Any) = nothing
     overlay_match(x)
 end |> only === Union{Nothing,Missing}
 
+# overlay method should shadow the base method with the same signature,
+# filtering it out from method match results
+overlay_shadow_zero() = Any[]
+overlay_shadow_zero(xs::Vector{Int}...) = Int[xs[i][j] for i=eachindex(xs) for j=eachindex(xs[i])]
+@overlay OVERLAY_MT overlay_shadow_zero() = error()
+@test Base.infer_return_type((Vector{Vector{Int}},); interp=MTOverlayInterp()) do x
+    overlay_shadow_zero(x...)
+end == Vector{Int}
+
 # partial concrete evaluation
 @test Base.return_types(; interp=MTOverlayInterp()) do
     isbitstype(Int) ? nothing : missing


### PR DESCRIPTION
When merging overlay and base method match results in `findall(sig, ::OverlayMethodTable)`, base methods whose signature is fully covered by any of matching overlay methods' signatures are now filtered out.

Previously, both the overlay and base methods with the same signature appeared in the results. This caused type inference to union their return types even though the overlay should take dispatch priority.

While this is a general inference correctness improvement that makes inference's emulation of overlay method selection at runtime more "correct", it might be worth explaining the concrete need that motivates this change:

Currently, inference for code like `[(x::Vector{Vector{Int}})...;]` unexpectedly infers `Union{Vector{Int},Vector{Any}}` instead of `Vector{Int}`, causing type instability isseus as reported in aviatesk/JET.jl#413.
The root cause of this type instability is the existence of the fallback method `vcat() = Any[]`.
To fix this, I initially attempted to remove the `vcat()` method (JuliaLang/julia#47628), but that turned out to be a considerably breaking change, so I concluded it was not viable to proceed in that direction as of Julia v1 time.
I also considered alternative approaches: 1.) changing the lowering of `[x...;]` to produce a primitive for `vcat` that would allow inference to work correctly in such cases, and 2.) adding a typed required 1st argument to other `vcat` methods so that dispatch to `vcat()` would not be considered — but both of those also proved impractical for various reasons (primarily because the complexity they introduce is too high). Removing the fallback method definitions for `vcat()` and `hcat()` themselves would be the simplest and most elegant fix, but that would have to wait for the release of Julia v2.

Therefore, rather than fixing this type instability on the Julia base side, I believe the least invasive solution is to define, on the JET side:
```julia
@overlay JET_METHOD_TABLE Base.vcat() = error()
```
so that, during JET's abstract interpretation, the method match that could produce the `Vector{Any}` possibility is effectively ignored. And this commit is required for that to actually work.