### PR TITLE
lowering: avoid `gensy` in anonymous generator name

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -392,7 +392,7 @@
             (generator (if (expr-contains-p if-generated? body (lambda (x) (not (function-def? x))))
                            (let* ((gen    (generated-version body))
                                   (nongen (non-generated-version body))
-                                  (gname  (symbol (string (gensy) "#" (current-julia-module-counter '()))))
+                                  (gname  (symbol (string "#" (current-julia-module-counter '()) "#" (current-julia-module-counter '()))))
                                   (gf     (make-generator-function gname names anames gen)))
                              (set! body (insert-after-meta
                                          nongen


### PR DESCRIPTION
Change the anonymous function name for `if @generated` to use the module counter.

Using `gensy` (`gensym()`) for anonymous module-level names is generally avoided in lowering, since it makes the anonymized names susceptible to changes to unrelated execution / lowering in other modules etc. (in the same process), but it seems that we missed this usage.

Required for https://github.com/JuliaLang/julia/pull/61577, since JuliaLowering cannot guarantee `gensym()` parity with flisp (only module counter parity).