### PR TITLE
[JuliaLowering] Fix `ccall` nontrivial library expression within tuple

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -458,8 +458,16 @@ function est_to_dst(st::SyntaxTree)
             @ast g st [k _dst_sink_parameters(children(st))...]
         (_, when=(k = kind(st); k in KSet"curly ref")) ->
             @ast g st [k _dst_separate_dotop(st[1])
-                       _dst_sink_parameters(children(st)[2:end])...
-            ]
+                       _dst_sink_parameters(children(st)[2:end])...]
+        # tuple arg should not be converted or desugared
+        [K"foreigncall" [K"tuple" _...] args...] ->
+            @ast g st [K"foreigncall" [K"foreigncall_arg1" st[1]] args...]
+        ([K"call" [K"Identifier"] sym args...],
+         when=st[1].name_val::String === "ccall") -> if kind(sym) === K"tuple"
+             @ast g st [K"call" st[1] [K"foreigncall_arg1" st[2]] mapsyntax(rec, args)...]
+         else
+             @ast g st [K"call" st[1] rec(sym) mapsyntax(rec, args)...]
+         end
         [K"call" f args...] -> let
             out_k, out_f = @stm _dst_separate_dotop(f) begin
                 [K"." op] -> (K"dotcall", op)

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -1724,10 +1724,6 @@ end
 # Expand the (sym,lib) argument to ccall
 function expand_C_library_symbol(ctx, ex)
     @stm ex begin
-        [K"tuple" _...] -> @ast ctx ex [K"static_eval"(
-            meta=name_hint("function name and library expression"))
-            mapchildren(e->expand_forms_2(ctx,e), ctx, ex)
-        ]
         [K"static_eval" _] -> ex # already done
         _ -> expand_forms_2(ctx, ex)
     end
@@ -4396,7 +4392,7 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
                 ]
             ]
         ]
-    elseif k == K"inert" || k == K"inert_syntaxtree"
+    elseif k == K"inert" || k == K"inert_syntaxtree" || k == K"foreigncall_arg1"
         ex
     elseif k == K"foreigncall"
         # Assume user macros may produce this, but static_eval means desugaring

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -406,18 +406,12 @@ function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
         @jl_assert arg1 isa QuoteNode ex
         args[1] = arg1.value
         Expr(:meta, args...)
+    elseif k == K"foreigncall_arg1"
+        @jl_assert kind(ex[1]) == K"tuple" ex
+        _foreigncall_arg1_expr(ex[1], stmt_offset)
     elseif k == K"static_eval"
         @jl_assert numchildren(ex) == 1 ex
-        @stm ex[1] begin
-            # tuple should just be ccall library spec
-            [K"tuple" s lib] -> Expr(:tuple,
-                                     _to_lowered_expr(s, stmt_offset),
-                                     _to_lowered_expr(lib, stmt_offset))
-            [K"tuple" s] -> Expr(:tuple,
-                                 _to_lowered_expr(s, stmt_offset))
-            [K"function" _...] -> QuoteNode(est_to_expr(ex[1]))
-            _ -> _to_lowered_expr(ex[1], stmt_offset)
-        end
+        _to_lowered_expr(ex[1], stmt_offset)
     else
         # Allowed forms according to https://docs.julialang.org/en/v1/devdocs/ast/
         #
@@ -450,6 +444,17 @@ function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
             push!(ret.args, _to_lowered_expr(e, stmt_offset))
         end
         return ret
+    end
+end
+
+# ultra-permissive conversion allowing unlowered structure, but lowered leaves
+function _foreigncall_arg1_expr(ex, stmt_offset)
+    if is_leaf(ex) || kind(ex) == K"inert"
+        _to_lowered_expr(ex, stmt_offset)
+    else
+        k = kind(ex)
+        Expr(Symbol((k === K"unknown_head" ? st.name_val : untokenize(k))::String),
+             map(e->_foreigncall_arg1_expr(e, stmt_offset), children(ex))...)
     end
 end
 

--- a/JuliaLowering/src/kinds.jl
+++ b/JuliaLowering/src/kinds.jl
@@ -151,8 +151,10 @@ function _register_kinds()
             # Pre-lowered SSA value reference from Expr(:ssavalue, N).
             # Translated to a BindingId during desugaring.
             "ssavalue"
-            # Token used by interpolate_ast to mark where `$` was
-            raw"_$"
+            # Wraps the first argument of a foreigncall when it should not be
+            # lowered (and should mostly be treated as :inert), but requires
+            # scope resolution and special conversion to Expr.
+            "foreigncall_arg1"
         "END_LOWERING_KINDS"
 
         # The following kinds are emitted by lowering and used in Julia's untyped IR

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -3,7 +3,7 @@
 
 function is_valid_ir_argument(ctx, ex)
     k = kind(ex)
-    if is_simple_atom(ctx, ex) || k in KSet"inert inert_syntaxtree top core quote static_eval"
+    if is_simple_atom(ctx, ex) || k in KSet"inert inert_syntaxtree top core quote static_eval foreigncall_arg1"
         true
     elseif k == K"BindingId"
         binfo = get_binding(ctx, ex)
@@ -115,7 +115,8 @@ function is_simple_arg(ctx, ex)
     k = kind(ex)
     return is_simple_atom(ctx, ex) || k == K"BindingId" || k == K"quote" ||
         k == K"inert" || k == K"inert_syntaxtree" || k == K"top" ||
-        k == K"core" || k == K"globalref" || k == K"static_eval"
+        k == K"core" || k == K"globalref" || k == K"static_eval" ||
+        k == K"foreigncall_arg1"
 end
 
 # flisp note: arguments are always counted as single-assign, so effects on
@@ -132,7 +133,7 @@ function is_const_read_arg(ctx, ex)
     # locals cannot be affected by them so we can inline them anyway.
     # TODO from flisp: "We could also allow const globals here"
     return k == K"inert" || k == K"inert_syntaxtree" || k == K"top" ||
-        k == K"core" || k == K"static_eval" ||
+        k == K"core" || k == K"static_eval" || k == K"foreigncall_arg1" ||
         is_simple_atom(ctx, ex) || is_single_assign_var(ctx, ex)
 end
 
@@ -622,7 +623,8 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
     if k == K"BindingId" || is_literal(k) || k == K"nothing" ||
             k == K"inert" || k == K"inert_syntaxtree" || k == K"top" ||
             k == K"core" || k == K"Value" || k == K"Symbol" ||
-            k == K"SourceLocation" || k == K"static_eval"
+            k == K"SourceLocation" || k == K"static_eval" ||
+            k == K"foreigncall_arg1"
         ex1 = ex
         if kind(ex1) == K"BindingId"
             binfo = get_binding(ctx, ex1)

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -655,10 +655,12 @@ function analyze_variables!(ctx, ex)
         return
     elseif !needs_resolution(ex)
         return
-    elseif k == K"static_eval"
+    elseif k == K"static_eval" || k == K"foreigncall_arg1"
         badvar = find_any_local_binding(ctx, ex[1])
         if !isnothing(badvar)
-            name_hint = getmeta(ex, :name_hint, "syntax")
+            default = k == K"foreigncall_arg1" ?
+                "function name and library expression" : "syntax"
+            name_hint = getmeta(ex, :name_hint, default)::String
             throw(LoweringError(badvar, "$(name_hint) cannot reference local variable"))
         end
         return

--- a/JuliaLowering/test/function_calls_ir.jl
+++ b/JuliaLowering/test/function_calls_ir.jl
@@ -356,7 +356,7 @@ ccall((:strlen, libc), Csize_t, (Cstring,), "asdfg")
 1   TestMod.Cstring
 2   (call top.cconvert %₁ "asdfg")
 3   (call top.unsafe_convert %₁ %₂)
-4   (foreigncall (static_eval (tuple :strlen TestMod.libc)) (static_eval TestMod.Csize_t) (static_eval (call core.svec TestMod.Cstring)) 0 :ccall %₃ %₂)
+4   (foreigncall (foreigncall_arg1 (tuple-p (inert strlen) TestMod.libc)) (static_eval TestMod.Csize_t) (static_eval (call core.svec TestMod.Cstring)) 0 :ccall %₃ %₂)
 5   (return %₄)
 
 ########################################

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -109,6 +109,76 @@ end
     ccall((:ctest, libccalltest_var), Complex{Int}, (Complex{Int},), 10 + 20im)
 """) === 11 + 18im
 
+@testset "(robot-generated) ccall (sym, lib) tuple: globals and hygiene" begin
+    # library is a module-qualified global
+    JuliaLowering.include_string(test_mod, """
+    module CCallLibMod
+        const the_lib = "libccalltest"
+    end
+    """)
+    @test JuliaLowering.include_string(test_mod, """
+        ccall((:ctest, CCallLibMod.the_lib), Complex{Int}, (Complex{Int},), 10 + 20im)
+    """) === 11 + 18im
+
+    # macro in a nested module produces ccall with lib from that module (hygiene)
+    JuliaLowering.include_string(test_mod, raw"""
+    module CCallHygieneMod
+        const mylib = "libccalltest"
+        macro do_ccall()
+            :(ccall((:ctest, mylib), Complex{Int}, (Complex{Int},), 10 + 20im))
+        end
+    end
+    """)
+    @test JuliaLowering.include_string(test_mod, """
+        CCallHygieneMod.@do_ccall()
+    """) === 11 + 18im
+
+    # hygiene: `mylib` in the macro body should resolve in CCallHygieneMod, not
+    # the caller, even when the caller defines a different `mylib`
+    @test JuliaLowering.include_string(test_mod, """
+        mylib = "this_lib_does_not_exist"
+        CCallHygieneMod.@do_ccall()
+    """) === 11 + 18im
+
+    # macro that interpolates the lib value at expansion time
+    JuliaLowering.include_string(test_mod, raw"""
+    module CCallHygieneMod2
+        const mylib2 = "libccalltest"
+        macro do_ccall_interp()
+            lib = mylib2
+            :(ccall((:ctest, $lib), Complex{Int}, (Complex{Int},), 10 + 20im))
+        end
+    end
+    """)
+    @test JuliaLowering.include_string(test_mod, """
+        CCallHygieneMod2.@do_ccall_interp()
+    """) === 11 + 18im
+
+    # ccall with plain symbol name still works inside a function
+    @test JuliaLowering.include_string(test_mod, """
+        function ccall_plain_sym()
+            ccall(:strlen, Csize_t, (Cstring,), "abc")
+        end
+    """) isa Function
+    @test test_mod.ccall_plain_sym() == 3
+
+    # ccall with (sym, lib) tuple where lib is a global, inside a function
+    @test JuliaLowering.include_string(test_mod, """
+        function ccall_global_lib()
+            ccall((:ctest, libccalltest_var), Complex{Int}, (Complex{Int},), 10 + 20im)
+        end
+    """) isa Function
+    @test test_mod.ccall_global_lib() === 11 + 18im
+
+    # ccall with module-qualified lib inside a function
+    @test JuliaLowering.include_string(test_mod, """
+        function ccall_qualified_lib()
+            ccall((:ctest, CCallLibMod.the_lib), Complex{Int}, (Complex{Int},), 10 + 20im)
+        end
+    """) isa Function
+    @test test_mod.ccall_qualified_lib() === 11 + 18im
+end
+
 # cfunction
 JuliaLowering.include_string(test_mod, """
 function f_ccallable(x, y)

--- a/JuliaLowering/test/misc_ir.jl
+++ b/JuliaLowering/test/misc_ir.jl
@@ -422,7 +422,7 @@ end
 6   (call top.cconvert %₂ %₅)
 7   (call top.unsafe_convert %₁ %₄)
 8   (call top.unsafe_convert %₂ %₆)
-9   (foreigncall (static_eval (tuple :foo)) (static_eval TestMod.R) (static_eval (call core.svec TestMod.X TestMod.Y)) 0 (inert (:ccall, 0x0000, false)) %₇ %₈ %₄ %₆)
+9   (foreigncall (foreigncall_arg1 (tuple (inert foo))) (static_eval TestMod.R) (static_eval (call core.svec TestMod.X TestMod.Y)) 0 (inert (:ccall, 0x0000, false)) %₇ %₈ %₄ %₆)
 10  (return %₉)
 
 ########################################
@@ -437,7 +437,7 @@ end
 6   (call top.cconvert %₂ %₅)
 7   (call top.unsafe_convert %₁ %₄)
 8   (call top.unsafe_convert %₂ %₆)
-9   (foreigncall (static_eval (tuple :foo)) (static_eval TestMod.R) (static_eval (call core.svec TestMod.X TestMod.Y)) 1 (inert (:ccall, 0x0000, true)) %₇ %₈ %₄ %₆)
+9   (foreigncall (foreigncall_arg1 (tuple (inert foo))) (static_eval TestMod.R) (static_eval (call core.svec TestMod.X TestMod.Y)) 1 (inert (:ccall, 0x0000, true)) %₇ %₈ %₄ %₆)
 10  (return %₉)
 
 ########################################


### PR DESCRIPTION
Found precompiling Parsers in https://github.com/JuliaLang/julia/pull/61576.

Another place the `K"static_eval"` form wasn't quite accurate.  In the first arg of a foreigncall, if it is a tuple, we do want the "no referencing globals" property of `K"static_eval"`, but we also want it to be semi-inert: not converted in `est_to_dst`, and not desugared.  We do want the expression to go through scope resolution, though (it's surprising this works in either lowering implementation).  We don't have a way of converting this hybrid thing to Expr after lowering, so I've written one.  I don't think there's much point in trying to treat this like it isn't a special case, so I've just called it `K"foreigncall_arg1"`.

I tried treating it as inert until `to_lowered_expr` is done, then combing the expr for symbols and resolving all to GlobalRef, but realized we lack the module and hygiene information necessary to do that accurately.

TODO: Ideally we figure out what forms are allowed, then convert those accurately.

Tests robot-generated; more thorough tests coming in the next PR.