### PR TITLE
[JuliaLowering] Include a subset of Base tests

### DIFF
--- a/JuliaLowering/test/runtests.jl
+++ b/JuliaLowering/test/runtests.jl
@@ -31,4 +31,50 @@ include("utils.jl")
 
     @testset "compat" include("compat.jl")
     @testset "hooks" include("hooks.jl")
+
+end
+
+module BaseTestMod
+using Test
+# Currently many Base tests will fail for known reasons (e.g. checking error
+# message is equal to a string), so `!(@isdefined TESTING_JULIALOWERING)` can be
+# used to guard those.
+const TESTING_JULIALOWERING = true
+end
+
+@testset "Base tests under JuliaLowering" begin
+    try
+        base_testdir = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "test")
+        function include_basetest(file)
+            # println("JL $file")
+            @testset "JL base test $file" begin
+                try
+                    BaseTestMod.include(joinpath(base_testdir, file))
+                catch e
+                    @test e === nothing
+                end
+            end
+        end
+
+        JuliaLowering.activate!()
+
+        include_basetest("testenv.jl")
+
+        include_basetest("enums.jl")
+        include_basetest("triplequote.jl")
+        include_basetest("apint.jl")
+        include_basetest("atomics.jl")
+        include_basetest("intrinsics.jl")
+        include_basetest("operators.jl")
+        include_basetest("version.jl")
+        include_basetest("tuple.jl")
+        include_basetest("functional.jl")
+        include_basetest("ccall.jl")
+        include_basetest("llvmcall.jl")
+        include_basetest("llvmcall2.jl")
+        include_basetest("specificity.jl")
+
+    finally
+        JuliaLowering.activate!(false)
+    end
 end

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1474,6 +1474,27 @@ for i in 1:100
     @test_spill_n 10 int32args float32args
 end
 
+# cfunction on non-function singleton
+struct CallableSingleton
+end
+(::CallableSingleton)(x, y) = x + y
+@test ccall(@cfunction(CallableSingleton(), Int, (Int, Int)),
+            Int, (Int, Int), 1, 2) === 3
+
+global fn45187() = nothing
+
+@test_throws(TypeError, @eval ccall(nothing, Cvoid, ()))
+@test_throws(TypeError, @eval ccall(49142, Cvoid, ()))
+@test_throws(TypeError, @eval ccall((:fn, fn45187), Cvoid, ()))
+
+# 19805
+mutable struct callinfos_19805{FUNC_FT<:Function}
+    f :: FUNC_FT
+end
+
+evalf_callback_19805(ci::callinfos_19805{FUNC_FT}) where {FUNC_FT} = ci.f(0.5)::Float64
+
+if !(@isdefined TESTING_JULIALOWERING)
 # issue #20835
 @test_throws(ErrorException("could not evaluate ccall argument type (it might depend on a local variable)"),
              eval(:(f20835(x) = ccall(:fn, Cvoid, (Ptr{typeof(x)},), x))))
@@ -1516,12 +1537,6 @@ end
 @test_throws(ErrorException("ccall return type struct fields cannot contain a reference"),
              @eval ccall(:fn, typeof(Ref("")), ()))
 
-fn45187() = nothing
-
-@test_throws(TypeError, @eval ccall(nothing, Cvoid, ()))
-@test_throws(TypeError, @eval ccall(49142, Cvoid, ()))
-@test_throws(TypeError, @eval ccall((:fn, fn45187), Cvoid, ()))
-
 # test for malformed syntax errors
 @test Expr(:error, "more arguments than types for ccall") == Meta.lower(@__MODULE__, :(ccall(:fn, A, (), x)))
 @test Expr(:error, "more arguments than types for ccall") == Meta.lower(@__MODULE__, :(ccall(:fn, A, (B,), x, y)))
@@ -1544,20 +1559,6 @@ fn45187() = nothing
 @test_throws TypeError eval(:(f() = ccall((1 + 2,), A, (), )))
 @test_throws TypeError eval(:(f() = ccall((:a, 1 + 2), A, (), )))
 @test_throws TypeError eval(:(ccall_lazy_lib_name(x) = ccall((:testUcharX, compute_lib_name()), Int32, (UInt8,), x % UInt8)))
-
-# cfunction on non-function singleton
-struct CallableSingleton
-end
-(::CallableSingleton)(x, y) = x + y
-@test ccall(@cfunction(CallableSingleton(), Int, (Int, Int)),
-            Int, (Int, Int), 1, 2) === 3
-
-# 19805
-mutable struct callinfos_19805{FUNC_FT<:Function}
-    f :: FUNC_FT
-end
-
-evalf_callback_19805(ci::callinfos_19805{FUNC_FT}) where {FUNC_FT} = ci.f(0.5)::Float64
 
 @test_throws(ErrorException("cfunction method definition: argument 1 type doesn't correspond to a C type"),
              @eval evalf_callback_c_19805(ci::callinfos_19805{FUNC_FT}) where {FUNC_FT} =
@@ -1585,6 +1586,8 @@ evalf_callback_19805(ci::callinfos_19805{FUNC_FT}) where {FUNC_FT} = ci.f(0.5)::
              @eval @cfunction(+, Ptr, (Int, Int)))
 @test_throws(ErrorException("cfunction return type struct fields cannot contain a reference"),
              @eval @cfunction(+, typeof(Ref("")), ()))
+
+end # exclude JuliaLowering
 
 # test Ref{abstract_type} calling parameter passes a heap box
 abstract type Abstract22734 end

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -144,6 +144,7 @@ end
 call_jl_errno()
 
 # Test for proper parenting
+begin
 local foo
 function foo()
     # this IR snippet triggers an optimization relying
@@ -154,6 +155,7 @@ function foo()
     Cvoid, Tuple{})
 end
 code_llvm(devnull, foo, ())
+end
 
 # Issue #48093 - test that non-external globals are not deduplicated
 function kernel()


### PR DESCRIPTION
Depends on https://github.com/JuliaLang/julia/pull/61585 to pass.  

I don't want to take up too much CI time on questionably relevant tests, and I'm unsure if this is a good method of running them, but many already pass, so I've included some in `JuliaLowering/runtests.jl`.

I tried running most of them out of curiosity.  Most failures are due to error messages being different, but there are also many real failures.  

<details>
<summary>
Some notes on what the failures are (uncommented ones should pass)
</summary>

```julia
@testset "Base tests" begin
    try
        base_testdir = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "test")
        function include_basetest(file)
            println("JL $file")
            try
                BaseTestMod.include(joinpath(base_testdir, file))
            catch e
                @test e === nothing
            end
        end

        JuliaLowering.activate!()

        include_basetest("testenv.jl")

        # include_basetest("abstractarray.jl") # JuliaLang/JuliaLowering.jl/issues/178
        # include_basetest("ambiguous.jl") # JuliaLang/JuliaLowering.jl/issues/178
        include_basetest("apint.jl")
        # include_basetest("arrayops.jl") # needs helpers blocked by  # JuliaLang/JuliaLowering.jl/issues/178
        include_basetest("asyncmap.jl")
        # include_basetest("atexit.jl")
        include_basetest("atomics.jl")
        # include_basetest("backtrace.jl") # eval(Expr(:line, 1))
        include_basetest("binaryplatforms.jl")
        include_basetest("bitarray.jl")
        include_basetest("bitset.jl")
        # include_basetest("boundscheck.jl") # bad include, boundscheck unimplemented
        include_basetest("broadcast.jl")
        # include_basetest("cartesian.jl") # JuliaLang/JuliaLowering.jl/issues/182
        include_basetest("ccall.jl")
        include_basetest("channel_threadpool.jl")
        # include_basetest("channels.jl") # includes bad path
        # include_basetest("char.jl") # JuliaLowering.jl/issues/179
        include_basetest("checked.jl")
        # include_basetest("client.jl") # tests stacktrace string
        # include_basetest("cmdlineargs.jl")
        include_basetest("combinatorics.jl")
        # include_basetest("compileall.jl")
        include_basetest("complex.jl")
        include_basetest("copy.jl")
        # include_basetest("core.jl") # TODO many real failures
        # include_basetest("corelogging.jl")
        # include_basetest("dict.jl") # can't find any real failures
        # include_basetest("docs.jl") # docmacroception
        # include_basetest("download.jl")
        # include_basetest("download_exec.jl")
        include_basetest("enums.jl")
        include_basetest("env.jl")
        include_basetest("error.jl")
        # include_basetest("errorshow.jl")
        include_basetest("euler.jl")
        # include_basetest("exceptions.jl") # TODO bad exc stack
        include_basetest("fastmath.jl")
        include_basetest("faulty_constructor_method_should_not_cause_stack_overflows.jl")
        # include_basetest("file.jl") # assigns to global f
        include_basetest("filesystem.jl")
        # include_basetest("float16.jl") # assigns to global f
        include_basetest("floatapprox.jl")
        include_basetest("floatfuncs.jl")
        include_basetest("functional.jl")
        # include_basetest("gc.jl")
        include_basetest("generic_map_tests.jl")
        include_basetest("gmp.jl")
        # include_basetest("goto.jl") # tests errors, also real broken
        include_basetest("hashing.jl")
        include_basetest("int.jl")
        # include_basetest("interpreter.jl") # bad include
        # include_basetest("intfuncs.jl") # TODO global hygiene
        include_basetest("intrinsics.jl")
        include_basetest("iobuffer.jl")
        include_basetest("iostream.jl")
        # include_basetest("irdump.ll")
        include_basetest("iterators.jl")
        include_basetest("jit.jl")
        # include_basetest("keywordargs.jl") # TODO many fixes
        include_basetest("llvmcall.jl")
        include_basetest("llvmcall2.jl")
        # include_basetest("loading.jl")
        # include_basetest("math.jl") # sparam capture
        # include_basetest("meta.jl") # arbitrary expr heads in :meta.  Should
        # probably support, but not important for now.
        # include_basetest("misc.jl") # TODO: bad include, various real bugs
        include_basetest("missing.jl")
        include_basetest("mod2pi.jl")
        include_basetest("mpfr.jl")
        # include_basetest("namedtuple.jl") # many error tests
        # include_basetest("numbers.jl") # inference issues
        # include_basetest("offsetarray.jl") # JuliaLang/JuliaLowering.jl/issues/178
        # include_basetest("opaque_closure.jl") # TODO
        include_basetest("operators.jl")
        include_basetest("ordering.jl")
        include_basetest("osutils.jl")
        include_basetest("parse.jl")
        include_basetest("path.jl")
        # include_basetest("precompile.jl")
        # include_basetest("precompile_absint1.jl")
        # include_basetest("precompile_absint2.jl")
        # include_basetest("precompile_extmi.jl")
        # include_basetest("precompile_utils.jl")
        include_basetest("print_process_affinity.jl")
        include_basetest("profile_spawnmany_exec.jl")
        # include_basetest("ranges.jl") # probably JuliaLowering.jl/issues/179
        include_basetest("rational.jl")
        include_basetest("read.jl")
        # include_basetest("rebinding.jl")
        # include_basetest("reduce.jl") # world age issue, unsure if real failure
        include_basetest("reducedim.jl")
        # include_basetest("reflection.jl")
        include_basetest("regex.jl")
        # include_basetest("reinterpretarray.jl") # JuliaLang/JuliaLowering.jl/issues/178
        include_basetest("rounding.jl")
        include_basetest("ryu.jl")
        # include_basetest("scopedvalues.jl") # interesting test for no PhiC nodes
        include_basetest("secretbuffer.jl")
        include_basetest("sets.jl")
        # include_basetest("show.jl")
        include_basetest("simdloop.jl")
        include_basetest("smallarrayshrink.jl")
        include_basetest("some.jl")
        include_basetest("sorting.jl")
        # include_basetest("spawn.jl") # needs distributed
        include_basetest("specificity.jl")
        # include_basetest("stack_overflow.jl")
        # include_basetest("stacktraces.jl") # tests errors
        # include_basetest("staged.jl") # tests errors
        # include_basetest("stdlib_dependencies.jl")
        # include_basetest("subarray.jl") # @view tests test errors
        # include_basetest("subtype.jl") # JuliaLang/JuliaLowering.jl/issues/180
        # include_basetest("syntax.jl") # TODO many real failures, but many error tests
        include_basetest("sysinfo.jl")
        include_basetest("tempdepot.jl")
        include_basetest("terminfo.jl")
        include_basetest("test_sourcepath.jl")
        include_basetest("testdefs.jl")
        # include_basetest("threads.jl")
        include_basetest("triplequote.jl")
        include_basetest("tuple.jl")
        # include_basetest("typegroup.jl") # very broken, also tests errors
        include_basetest("vecelement.jl")
        include_basetest("version.jl")
        include_basetest("worlds.jl")
    finally
        JuliaLowering.activate!(false)
    end
end
```
</details>