### PR TITLE
document end → lastindex in more places

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -413,7 +413,7 @@ keys(s::IndexStyle, A::AbstractArray, B::AbstractArray...) = eachindex(s, A, B..
 Return the last index of `collection`. If `d` is given, return the last index of `collection` along dimension `d`.
 
 The syntaxes `A[end]` and `A[end, end]` lower to `A[lastindex(A)]` and
-`A[lastindex(A, 1), lastindex(A, 2)]`, respectively.
+`A[lastindex(A, 1), lastindex(A, 2)]`, respectively; see [`end`](@ref).
 
 See also [`axes`](@ref), [`firstindex`](@ref), [`eachindex`](@ref), [`prevind`](@ref).
 
@@ -436,7 +436,7 @@ lastindex(a, d) = (@inline; last(axes(a, d)))
 Return the first index of `collection`. If `d` is given, return the first index of `collection` along dimension `d`.
 
 The syntaxes `A[begin]` and `A[1, begin]` lower to `A[firstindex(A)]` and
-`A[1, firstindex(A, 2)]`, respectively.
+`A[1, firstindex(A, 2)]`, respectively; see [`begin`](@ref).
 
 See also [`first`](@ref), [`axes`](@ref), [`lastindex`](@ref), [`nextind`](@ref).
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1509,7 +1509,7 @@ Usually `begin` will not be necessary, since keywords such as [`function`](@ref)
 implicitly begin blocks of code. See also [`;`](@ref).
 
 `begin` may also be used when indexing with `[...]` to represent the first index of a
-collection or the last index of a dimension of an array, where it is lowered to
+collection or the first index of a dimension of an array, where it is lowered to
 a call to [`firstindex`](@ref).  For example, `a[begin]` is the first element of an array `a`.
 
 !!! compat "Julia 1.4"

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1012,8 +1012,11 @@ kw"while"
 [`begin`](@ref), [`let`](@ref), [`for`](@ref) etc.
 
 `end` may also be used when indexing with `[...]` to represent the last index of a
-collection or the last index of a dimension of an array, where it is lowered to
-a call to [`lastindex`](@ref) along the relevant dimension (as determined by the context).
+collection or the last index of a dimension of an array. For example, the expression
+`A[end-1]` becomes `A[lastindex(A)-1]` and `A[:, end]` becomes `A[:, lastindex(A, 2)]`.
+Every occurrence of `end` within the square bracket indexing syntax is lowered to a
+call to [`lastindex`](@ref), using the one argument `lastindex(A)` there's only one index
+argument and the two argument `lastindex(A, n)` for the n-th index argument.
 
 # Examples
 ```jldoctest

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1510,7 +1510,7 @@ implicitly begin blocks of code. See also [`;`](@ref).
 
 `begin` may also be used when indexing with `[...]` to represent the first index of a
 collection or the first index of a dimension of an array, where it is lowered to
-a call to [`firstindex`](@ref).  For example, `a[begin]` is the first element of an array `a`.
+a call to [`firstindex`](@ref) along the relevant dimension, as determined by the context.  For example, `a[begin]` is the first element of an array `a`.
 
 !!! compat "Julia 1.4"
     Use of `begin` as an index requires Julia 1.4 or later.

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1013,7 +1013,7 @@ kw"while"
 
 `end` may also be used when indexing with `[...]` to represent the last index of a
 collection or the last index of a dimension of an array, where it is lowered to
-a call to [`lastindex`](@ref) along the relevant dimension, as determined by the context.
+a call to [`lastindex`](@ref) along the relevant dimension (as determined by the context).
 
 # Examples
 ```jldoctest
@@ -1510,7 +1510,7 @@ implicitly begin blocks of code. See also [`;`](@ref).
 
 `begin` may also be used when indexing with `[...]` to represent the first index of a
 collection or the first index of a dimension of an array, where it is lowered to
-a call to [`firstindex`](@ref) along the relevant dimension, as determined by the context.  For example, `a[begin]` is the first element of an array `a`.
+a call to [`firstindex`](@ref) along the relevant dimension (as determined by the context).  For example, `a[begin]` is the first element of an array `a`.
 
 !!! compat "Julia 1.4"
     Use of `begin` as an index requires Julia 1.4 or later.

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1508,9 +1508,9 @@ end
 Usually `begin` will not be necessary, since keywords such as [`function`](@ref) and [`let`](@ref)
 implicitly begin blocks of code. See also [`;`](@ref).
 
-`begin` may also be used when indexing to represent the first index of a
-collection or the first index of a dimension of an array. For example,
-`a[begin]` is the first element of an array `a`.
+`begin` may also be used when indexing with `[...]` to represent the first index of a
+collection or the last index of a dimension of an array, where it is lowered to
+a call to [`firstindex`](@ref).  For example, `a[begin]` is the first element of an array `a`.
 
 !!! compat "Julia 1.4"
     Use of `begin` as an index requires Julia 1.4 or later.

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1011,8 +1011,9 @@ kw"while"
 [`module`](@ref), [`struct`](@ref), [`mutable struct`](@ref),
 [`begin`](@ref), [`let`](@ref), [`for`](@ref) etc.
 
-`end` may also be used when indexing to represent the last index of a
-collection or the last index of a dimension of an array.
+`end` may also be used when indexing with `[...]` to represent the last index of a
+collection or the last index of a dimension of an array, where it is lowered to
+a call to [`lastindex`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1013,7 +1013,7 @@ kw"while"
 
 `end` may also be used when indexing with `[...]` to represent the last index of a
 collection or the last index of a dimension of an array, where it is lowered to
-a call to [`lastindex`](@ref).
+a call to [`lastindex`](@ref) along the relevant dimension, as determined by the context.
 
 # Examples
 ```jldoctest

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -559,7 +559,7 @@ As a special part of the `[...]` indexing syntax, the `end` keyword may be used 
 a dimension; specifically, it is "lowered" by the compiler to a call to [`lastindex`](@ref) for that
 dimension of the array for the innermost enclosing brackets.  Similarly, `begin` within `[...]` indexing is
 lowered to a call to [`firstindex`](@ref) (which always returns `1` for built-in types like `Array` and `String`, but
-external packages may implement containers with indexes that start at `0` or elsewhere).
+external packages may implement containers with indices that start at `0` or elsewhere).
 Otherwise, the bracket indexing syntax is equivalent to a call to [`getindex`](@ref):
 
 ```

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -555,9 +555,10 @@ The location `i_1, i_2, i_3, ..., i_{n+1}` contains the value at `A[I_1[i_1, i_2
 All dimensions indexed with scalars are dropped. For example, if `J` is an array of indices, then the result of `A[2, J, 3]` is an
 array with size `size(J)`. Its `j`th element is populated by `A[2, J[j], 3]`.
 
-As a special part of the `[...]` syntax, the `end` keyword may be used to represent the last index of
+As a special part of the `[...]` indexing syntax, the `end` keyword may be used to represent the last index of
 a dimension; specifically, it is "lowered" by the compiler to a call to [`lastindex`](@ref) for that
-dimension of the array for the innermost enclosing brackets.  Otherwise, the bracket indexing syntax
+dimension of the array for the innermost enclosing brackets.  Similarly, `begin` within `[...]` indexing is
+lowered to a call to [`firstindex`](@ref).  Otherwise, the bracket indexing syntax
 is equivalent to a call to [`getindex`](@ref):
 
 ```

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -585,6 +585,13 @@ julia> x[1, [2 3; 4 1]]
 2×2 Matrix{Int64}:
   5  9
  13  1
+
+julia> x[:, div(begin + end, 2)]
+4-element Vector{Int64}:
+ 5
+ 6
+ 7
+ 8
 ```
 
 ## [Indexed Assignment](@id man-indexed-assignment)

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -558,8 +558,9 @@ array with size `size(J)`. Its `j`th element is populated by `A[2, J[j], 3]`.
 As a special part of the `[...]` indexing syntax, the `end` keyword may be used to represent the last index of
 a dimension; specifically, it is "lowered" by the compiler to a call to [`lastindex`](@ref) for that
 dimension of the array for the innermost enclosing brackets.  Similarly, `begin` within `[...]` indexing is
-lowered to a call to [`firstindex`](@ref).  Otherwise, the bracket indexing syntax
-is equivalent to a call to [`getindex`](@ref):
+lowered to a call to [`firstindex`](@ref) (which always returns `1` for built-in types like `Array` and `String`, but
+external packages may implement containers with indexes that start at `0` or elsewhere).
+Otherwise, the bracket indexing syntax is equivalent to a call to [`getindex`](@ref):
 
 ```
 X = getindex(A, I_1, I_2, ..., I_n)

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -555,9 +555,10 @@ The location `i_1, i_2, i_3, ..., i_{n+1}` contains the value at `A[I_1[i_1, i_2
 All dimensions indexed with scalars are dropped. For example, if `J` is an array of indices, then the result of `A[2, J, 3]` is an
 array with size `size(J)`. Its `j`th element is populated by `A[2, J[j], 3]`.
 
-As a special part of this syntax, the `end` keyword may be used to represent the last index of
-each dimension within the indexing brackets, as determined by the size of the innermost array
-being indexed. Indexing syntax without the `end` keyword is equivalent to a call to [`getindex`](@ref):
+As a special part of the `[...]` syntax, the `end` keyword may be used to represent the last index of
+a dimension; specifically, it is "lowered" by the compiler to a call to [`lastindex`](@ref) for that
+dimension of the array for the innermost enclosing brackets.  Otherwise, the bracket indexing syntax
+is equivalent to a call to [`getindex`](@ref):
 
 ```
 X = getindex(A, I_1, I_2, ..., I_n)

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -555,9 +555,9 @@ The location `i_1, i_2, i_3, ..., i_{n+1}` contains the value at `A[I_1[i_1, i_2
 All dimensions indexed with scalars are dropped. For example, if `J` is an array of indices, then the result of `A[2, J, 3]` is an
 array with size `size(J)`. Its `j`th element is populated by `A[2, J[j], 3]`.
 
-As a special part of the `[...]` indexing syntax, the `end` keyword may be used to represent the last index of
+As a special part of the `[...]` indexing syntax, the [`end`](@ref) keyword may be used to represent the last index of
 a dimension; specifically, it is "lowered" by the compiler to a call to [`lastindex`](@ref) for that
-dimension of the array for the innermost enclosing brackets.  Similarly, `begin` within `[...]` indexing is
+dimension of the array for the innermost enclosing brackets.  Similarly, [`begin`](@ref) within `[...]` indexing is
 lowered to a call to [`firstindex`](@ref) (which always returns `1` for built-in types like `Array` and `String`, but
 external packages may implement containers with indices that start at `0` or elsewhere).
 Otherwise, the bracket indexing syntax is equivalent to a call to [`getindex`](@ref):


### PR DESCRIPTION
The fact that `end` in brackets lowers to a `lastindex` call was documented in the `lastindex` docstring, but was only alluded to more vaguely as the "last index" in other places, e.g. in the Arrays chapter of the manual or the `end` docstring.  Similarly for `begin` and `firstindex`.

(Inspired by a [discourse thread](https://discourse.julialang.org/t/where-is-the-lowering-of-end-within-documented/136736?u=stevengj) by @tpapp.)