### PR TITLE
Include doc string for Base.@ccallable in the docs

### DIFF
--- a/doc/src/base/c.md
+++ b/doc/src/base/c.md
@@ -6,6 +6,7 @@ ccall
 Core.Intrinsics.cglobal
 Base.@cfunction
 Base.CFunction
+Base.@ccallable
 Base.unsafe_convert
 Base.cconvert
 Base.unsafe_load


### PR DESCRIPTION
I recently noticed that the doc string for `Base.@ccallable` is not included in the docs. Given how often it is used with PackageCompiler.jl and JuliaC.jl at this point, I assume it was just an oversight, and not an intentional exclusion.