### PR TITLE
codegen: shrink-wrap the GC shadow-stack frame

### DIFF
--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -16,17 +16,22 @@ void FinalLowerGC::lowerNewGCFrame(CallInst *target, Function &F)
     assert(target->arg_size() == 1);
     unsigned nRoots = cast<ConstantInt>(target->getArgOperand(0))->getLimitedValue(INT_MAX);
 
-    // Create the GC frame.
-    IRBuilder<> builder(target);
-    auto gcframe_alloca = builder.CreateAlloca(T_prjlvalue, ConstantInt::get(Type::getInt32Ty(F.getContext()), nRoots + 2));
+    // Alloca always lives in the entry block — shrink-wrap may have sunk
+    // the intrinsic call but the backing allocation must stay static.
+    IRBuilder<> entryBuilder(&F.getEntryBlock(), F.getEntryBlock().begin());
+    auto gcframe_alloca = entryBuilder.CreateAlloca(T_prjlvalue, ConstantInt::get(Type::getInt32Ty(F.getContext()), nRoots + 2));
     gcframe_alloca->setAlignment(Align(16));
     // addrspacecast as needed for non-0 alloca addrspace
-    auto gcframe = cast<Instruction>(builder.CreateAddrSpaceCast(gcframe_alloca, PointerType::getUnqual(T_prjlvalue->getContext())));
+    auto gcframe = cast<Instruction>(entryBuilder.CreateAddrSpaceCast(gcframe_alloca, PointerType::getUnqual(T_prjlvalue->getContext())));
     gcframe->takeName(target);
 
-    // Zero out the GC frame.
+    // lifetime.start + zero-init at the (possibly sunk) call site, so the
+    // slot is marked live and zeroed only on paths that execute the push.
+    IRBuilder<> builder(target);
     auto ptrsize = F.getParent()->getDataLayout().getPointerSize();
-    builder.CreateMemSet(gcframe, Constant::getNullValue(Type::getInt8Ty(F.getContext())), ptrsize * (nRoots + 2), Align(16), tbaa_gcframe);
+    auto size = ptrsize * (nRoots + 2);
+    builder.CreateLifetimeStart(gcframe_alloca, ConstantInt::get(Type::getInt64Ty(F.getContext()), size));
+    builder.CreateMemSet(gcframe, Constant::getNullValue(Type::getInt8Ty(F.getContext())), size, Align(16), tbaa_gcframe);
 
     target->replaceAllUsesWith(gcframe);
     target->eraseFromParent();
@@ -76,6 +81,15 @@ void FinalLowerGC::lowerPopGCFrame(CallInst *target, Function &F)
         pgcstack,
         Align(sizeof(void*)));
     inst->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
+
+    // lifetime.end on the backing alloca, if we can recover it. gcframe is
+    // normally an AddrSpaceCastInst of the alloca produced by lowerNewGCFrame.
+    if (auto *AI = dyn_cast<AllocaInst>(gcframe->stripPointerCasts())) {
+        auto ptrsize = F.getParent()->getDataLayout().getPointerSize();
+        unsigned nSlots = cast<ConstantInt>(AI->getArraySize())->getLimitedValue(INT_MAX);
+        builder.CreateLifetimeEnd(AI, ConstantInt::get(Type::getInt64Ty(F.getContext()), ptrsize * nSlots));
+    }
+
     target->eraseFromParent();
 }
 

--- a/src/llvm-gc-interface-passes.h
+++ b/src/llvm-gc-interface-passes.h
@@ -359,7 +359,7 @@ private:
     void PlaceGCFrameStore(State &S, unsigned R, unsigned MinColorRoot, ArrayRef<int> Colors, Value *GCFrame, Instruction *InsertBefore);
     void PlaceGCFrameStores(State &S, unsigned MinColorRoot, ArrayRef<int> Colors, int PreAssignedColors, Value *GCFrame);
     void PlaceGCFrameReset(State &S, unsigned R, unsigned MinColorRoot, ArrayRef<int> Colors, Value *GCFrame, Instruction *InsertBefore);
-    void PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAssignedColors, State &S, std::map<Value *, std::pair<int, int>>);
+    void PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAssignedColors, State &S, std::map<Value *, std::pair<int, int>>, bool *CFGModified = nullptr);
     void CleanupWriteBarriers(Function &F, State *S, const SmallVector<CallInst*, 0> &WriteBarriers, bool *CFGModified);
     bool CleanupIR(Function &F, State *S, bool *CFGModified);
     void NoteUseChain(State &S, BBState &BBS, User *TheUser);

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1,6 +1,9 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
 #include "llvm-gc-interface-passes.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/Analysis/LoopInfo.h"
+#include "llvm/IR/CFG.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/Support/Casting.h"
@@ -9,6 +12,29 @@
 
 static unsigned getValueAddrSpace(Value *V) {
     return V->getType()->getPointerAddressSpace();
+}
+
+// EH calls appear under either jl_* or ijl_* depending on the emission.
+static bool isRuntimeEHCall(StringRef Name) {
+    static const char *const Names[] = {
+        "jl_enter_handler",        "ijl_enter_handler",
+        "jl_pop_handler",          "ijl_pop_handler",
+        "jl_pop_handler_noexcept", "ijl_pop_handler_noexcept",
+    };
+    for (const char *N : Names)
+        if (Name == N)
+            return true;
+    return false;
+}
+
+static bool functionHasEH(Function &F) {
+    for (auto &BB : F)
+        for (auto &I : BB)
+            if (auto *CI = dyn_cast<CallBase>(&I))
+                if (Function *Callee = CI->getCalledFunction())
+                    if (isRuntimeEHCall(Callee->getName()))
+                        return true;
+    return false;
 }
 
 static bool isTrackedValue(Value *V) {
@@ -2401,7 +2427,7 @@ void LateLowerGCFrame::PlaceGCFrameStores(State &S, unsigned MinColorRoot,
 }
 
 void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAssignedColors, State &S,
-                                                std::map<Value *, std::pair<int, int>>) {
+                                                std::map<Value *, std::pair<int, int>>, bool *CFGModified) {
     auto F = S.F;
     auto T_int32 = Type::getInt32Ty(F->getContext());
     int MaxColor = -1;
@@ -2411,17 +2437,88 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
 
     // Insert instructions for the actual gc frame
     if (MaxColor != -1 || !S.ArrayAllocas.empty() || !S.TrackedStores.empty()) {
+        // Shrink-wrap: by default the frame goes in the entry block, but if all
+        // blocks that actually use the frame share a common dominator outside
+        // any loop, sink the alloc+push into that dominator so paths which
+        // never use the frame pay nothing. Modeled on LLVM's ShrinkWrap pass.
+        BasicBlock *EntryBB = &F->getEntryBlock();
+        BasicBlock *SaveBB = EntryBB;
+
+        // TODO: sink inside EH regions. For v1 we bail when the function
+        // has any runtime EH call, because a sunk push/pop must bracket the
+        // same set of jl_enter_handler / jl_pop_handler[_noexcept] calls
+        // (otherwise jl_eh_restore_state_noexcept's gcstack assertion fires).
+        if (!functionHasEH(*F)) {
+            if (!S.DT)
+                S.DT = &GetDT();
+            DominatorTree &DT = *S.DT;
+            LoopInfo LI(DT);
+
+            BasicBlock *NCD = nullptr;
+            auto addUser = [&](BasicBlock *BB) {
+                NCD = NCD ? DT.findNearestCommonDominator(NCD, BB) : BB;
+            };
+            for (auto &KV : S.BBStates) {
+                const BBState &BBS = KV.second;
+                if (!BBS.HasSafepoint)
+                    continue;
+                bool FrameLive = !BBS.LiveIn.empty();
+                if (!FrameLive) {
+                    for (int SP = BBS.LastSafepoint; SP <= BBS.FirstSafepoint; ++SP) {
+                        if (!S.LiveSets[SP].empty()) {
+                            FrameLive = true;
+                            break;
+                        }
+                    }
+                }
+                if (!FrameLive)
+                    continue;
+                addUser(const_cast<BasicBlock*>(KV.first));
+            }
+            // Every user of an ArrayAlloca (post-replacement, a user of the
+            // slot GEP) and every TrackedStore site must be dominated by
+            // SaveBB. Scattered users naturally pull NCD back to entry.
+            for (auto &KV : S.ArrayAllocas)
+                for (User *U : KV.first->users())
+                    if (auto *I = dyn_cast<Instruction>(U))
+                        addUser(I->getParent());
+            for (auto &Store : S.TrackedStores)
+                addUser(Store.first->getParent());
+
+            // Hoist out of any enclosing loop so Save executes at most once
+            // per function call; otherwise push would run per-iteration while
+            // pops (placed on loop-exit edges) run once, unbalancing the
+            // shadow stack.
+            while (NCD && LI.getLoopDepth(NCD) > 0) {
+                DomTreeNode *Node = DT.getNode(NCD);
+                if (!Node)
+                    break;
+                DomTreeNode *IdomNode = Node->getIDom();
+                if (!IdomNode)
+                    break;
+                NCD = IdomNode->getBlock();
+            }
+
+            if (NCD)
+                SaveBB = NCD;
+        }
+
+        bool SinkingFrame = (SaveBB != EntryBB);
+
         // Create and push a GC frame.
         auto gcframe = CallInst::Create(
             getOrDeclare(jl_intrinsics::newGCFrame),
             {ConstantInt::get(T_int32, 0)},
             "gcframe");
-        gcframe->insertBefore(F->getEntryBlock().begin());
+        if (SinkingFrame)
+            gcframe->insertBefore(SaveBB->getFirstInsertionPt());
+        else
+            gcframe->insertBefore(F->getEntryBlock().begin());
 
         auto pushGcframe = CallInst::Create(
             getOrDeclare(jl_intrinsics::pushGCFrame),
             {gcframe, ConstantInt::get(T_int32, 0)});
-        if (isa<Argument>(pgcstack))
+        if (SinkingFrame || isa<Argument>(pgcstack))
              pushGcframe->insertAfter(gcframe);
          else
              pushGcframe->insertAfter(cast<Instruction>(pgcstack));
@@ -2530,9 +2627,54 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
 
         // Insert GC frame stores
         PlaceGCFrameStores(S, AllocaSlot - 2, Colors, PreAssignedColors, gcframe);
-        // Insert GCFrame pops
-        for (auto &BB : *F) {
-            if (isa<ReturnInst>(BB.getTerminator())) {
+        // Insert GCFrame pops at two kinds of sites:
+        //   (1) ReturnInsts dominated by SaveBB — pop before the return.
+        //   (2) CFG edges U -> V where SaveBB dominates U but not V — split
+        //       the edge and pop in the new block.
+        // Unreachable terminators have no outgoing edges and aren't Returns,
+        // so they're naturally skipped; EH unwinding restores pgcstack.
+        if (SinkingFrame) {
+            DominatorTree &DT = *S.DT;
+            SmallVector<BasicBlock*, 4> InSinkReturns;
+            SmallVector<std::pair<BasicBlock*, BasicBlock*>, 4> ExitEdges;
+            for (auto &BB : *F) {
+                if (!DT.dominates(SaveBB, &BB))
+                    continue;
+                if (isa<ReturnInst>(BB.getTerminator()))
+                    InSinkReturns.push_back(&BB);
+                for (BasicBlock *Succ : successors(&BB)) {
+                    if (!DT.dominates(SaveBB, Succ))
+                        ExitEdges.push_back({&BB, Succ});
+                }
+            }
+            for (BasicBlock *BB : InSinkReturns) {
+                auto popGcframe = CallInst::Create(
+                    getOrDeclare(jl_intrinsics::popGCFrame),
+                    {gcframe});
+#if JL_LLVM_VERSION >= 200000
+                popGcframe->insertBefore(BB->getTerminator()->getIterator());
+#else
+                popGcframe->insertBefore(BB->getTerminator());
+#endif
+            }
+            for (auto &E : ExitEdges) {
+                BasicBlock *Split = SplitEdge(E.first, E.second, &DT);
+                auto popGcframe = CallInst::Create(
+                    getOrDeclare(jl_intrinsics::popGCFrame),
+                    {gcframe});
+#if JL_LLVM_VERSION >= 200000
+                popGcframe->insertBefore(Split->getTerminator()->getIterator());
+#else
+                popGcframe->insertBefore(Split->getTerminator());
+#endif
+                if (CFGModified)
+                    *CFGModified = true;
+            }
+        }
+        else {
+            for (auto &BB : *F) {
+                if (!isa<ReturnInst>(BB.getTerminator()))
+                    continue;
                 auto popGcframe = CallInst::Create(
                     getOrDeclare(jl_intrinsics::popGCFrame),
                     {gcframe});
@@ -2598,7 +2740,7 @@ bool LateLowerGCFrame::runOnFunction(Function &F, bool *CFGModified) {
         ComputeLiveness(S);
         auto Colors = ColorRoots(S);
         std::map<Value *, std::pair<int, int>> CallFrames; // = OptimizeCallFrames(S, Ordering);
-        PlaceRootsAndUpdateCalls(Colors.first, Colors.second, S, CallFrames);
+        PlaceRootsAndUpdateCalls(Colors.first, Colors.second, S, CallFrames, CFGModified);
       }
       CleanupIR(F, &S, CFGModified);
     }

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2488,11 +2488,19 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
                 }
             }
             // ArrayAlloca users become users of the slot GEP; TrackedStore
-            // sites store into slots. Both must be dominated by SaveBB.
-            for (auto &KV : S.ArrayAllocas)
-                for (User *U : KV.first->users())
-                    if (auto *I = dyn_cast<Instruction>(U))
+            // sites store into slots. Both must be dominated by SaveBB. For
+            // phi operands the relevant "user BB" is the incoming block,
+            // not the phi's parent (the phi operand must be dominated by
+            // the incoming predecessor's terminator).
+            for (auto &KV : S.ArrayAllocas) {
+                for (Use &U : KV.first->uses()) {
+                    if (auto *PN = dyn_cast<PHINode>(U.getUser())) {
+                        addUser(PN->getIncomingBlock(U));
+                    } else if (auto *I = dyn_cast<Instruction>(U.getUser())) {
                         addUser(I->getParent());
+                    }
+                }
+            }
             for (auto &Store : S.TrackedStores)
                 addUser(Store.first->getParent());
 

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2462,7 +2462,9 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
                 const BBState &BBS = KV.second;
                 if (!BBS.HasSafepoint)
                     continue;
-                bool FrameLive = !BBS.LiveIn.empty();
+                // LiveOut matters too: a value produced here and phi'd into
+                // a successor may be slot-rooted.
+                bool FrameLive = !BBS.LiveIn.empty() || !BBS.LiveOut.empty();
                 if (!FrameLive) {
                     for (int SP = BBS.LastSafepoint; SP <= BBS.FirstSafepoint; ++SP) {
                         if (!S.LiveSets[SP].empty()) {
@@ -2475,9 +2477,18 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
                     continue;
                 addUser(const_cast<BasicBlock*>(KV.first));
             }
-            // Every user of an ArrayAlloca (post-replacement, a user of the
-            // slot GEP) and every TrackedStore site must be dominated by
-            // SaveBB. Scattered users naturally pull NCD back to entry.
+            // Special-ptr phis: the phi result can be a slot address carried
+            // from a sink predecessor into a non-sink block.
+            for (auto &BB : *F) {
+                for (auto &PN : BB.phis()) {
+                    if (isSpecialPtr(PN.getType())) {
+                        addUser(&BB);
+                        break;
+                    }
+                }
+            }
+            // ArrayAlloca users become users of the slot GEP; TrackedStore
+            // sites store into slots. Both must be dominated by SaveBB.
             for (auto &KV : S.ArrayAllocas)
                 for (User *U : KV.first->users())
                     if (auto *I = dyn_cast<Instruction>(U))
@@ -2485,10 +2496,7 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
             for (auto &Store : S.TrackedStores)
                 addUser(Store.first->getParent());
 
-            // Hoist out of any enclosing loop so Save executes at most once
-            // per function call; otherwise push would run per-iteration while
-            // pops (placed on loop-exit edges) run once, unbalancing the
-            // shadow stack.
+            // Hoist out of loops — push must execute at most once per call.
             while (NCD && LI.getLoopDepth(NCD) > 0) {
                 DomTreeNode *Node = DT.getNode(NCD);
                 if (!Node)

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1,6 +1,9 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
 #include "llvm-gc-interface-passes.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/Analysis/LoopInfo.h"
+#include "llvm/IR/CFG.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/Support/Casting.h"
@@ -9,6 +12,29 @@
 
 static unsigned getValueAddrSpace(Value *V) {
     return V->getType()->getPointerAddressSpace();
+}
+
+// EH calls appear under either jl_* or ijl_* depending on the emission.
+static bool isRuntimeEHCall(StringRef Name) {
+    static const char *const Names[] = {
+        "jl_enter_handler",        "ijl_enter_handler",
+        "jl_pop_handler",          "ijl_pop_handler",
+        "jl_pop_handler_noexcept", "ijl_pop_handler_noexcept",
+    };
+    for (const char *N : Names)
+        if (Name == N)
+            return true;
+    return false;
+}
+
+static bool functionHasEH(Function &F) {
+    for (auto &BB : F)
+        for (auto &I : BB)
+            if (auto *CI = dyn_cast<CallBase>(&I))
+                if (Function *Callee = CI->getCalledFunction())
+                    if (isRuntimeEHCall(Callee->getName()))
+                        return true;
+    return false;
 }
 
 static bool isTrackedValue(Value *V) {
@@ -2401,7 +2427,7 @@ void LateLowerGCFrame::PlaceGCFrameStores(State &S, unsigned MinColorRoot,
 }
 
 void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAssignedColors, State &S,
-                                                std::map<Value *, std::pair<int, int>>) {
+                                                std::map<Value *, std::pair<int, int>>, bool *CFGModified) {
     auto F = S.F;
     auto T_int32 = Type::getInt32Ty(F->getContext());
     int MaxColor = -1;
@@ -2411,17 +2437,88 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
 
     // Insert instructions for the actual gc frame
     if (MaxColor != -1 || !S.ArrayAllocas.empty() || !S.TrackedStores.empty()) {
+        // Shrink-wrap: by default the frame goes in the entry block, but if all
+        // blocks that actually use the frame share a common dominator outside
+        // any loop, sink the alloc+push into that dominator so paths which
+        // never use the frame pay nothing. Modeled on LLVM's ShrinkWrap pass.
+        BasicBlock *EntryBB = &F->getEntryBlock();
+        BasicBlock *SaveBB = EntryBB;
+
+        // TODO: sink inside EH regions. For v1 we bail when the function
+        // has any runtime EH call, because a sunk push/pop must bracket the
+        // same set of jl_enter_handler / jl_pop_handler[_noexcept] calls
+        // (otherwise jl_eh_restore_state_noexcept's gcstack assertion fires).
+        if (!functionHasEH(*F)) {
+            if (!S.DT)
+                S.DT = &GetDT();
+            DominatorTree &DT = *S.DT;
+            LoopInfo LI(DT);
+
+            BasicBlock *NCD = nullptr;
+            auto addUser = [&](BasicBlock *BB) {
+                NCD = NCD ? DT.findNearestCommonDominator(NCD, BB) : BB;
+            };
+            for (auto &KV : S.BBStates) {
+                const BBState &BBS = KV.second;
+                if (!BBS.HasSafepoint)
+                    continue;
+                bool FrameLive = !BBS.LiveIn.empty();
+                if (!FrameLive) {
+                    for (int SP = BBS.LastSafepoint; SP <= BBS.FirstSafepoint; ++SP) {
+                        if (!S.LiveSets[SP].empty()) {
+                            FrameLive = true;
+                            break;
+                        }
+                    }
+                }
+                if (!FrameLive)
+                    continue;
+                addUser(const_cast<BasicBlock*>(KV.first));
+            }
+            // Every user of an ArrayAlloca (post-replacement, a user of the
+            // slot GEP) and every TrackedStore site must be dominated by
+            // SaveBB. Scattered users naturally pull NCD back to entry.
+            for (auto &KV : S.ArrayAllocas)
+                for (User *U : KV.first->users())
+                    if (auto *I = dyn_cast<Instruction>(U))
+                        addUser(I->getParent());
+            for (auto &Store : S.TrackedStores)
+                addUser(Store.first->getParent());
+
+            // Hoist out of any enclosing loop so Save executes at most once
+            // per function call; otherwise push would run per-iteration while
+            // pops (placed on loop-exit edges) run once, unbalancing the
+            // shadow stack.
+            while (NCD && LI.getLoopDepth(NCD) > 0) {
+                DomTreeNode *Node = DT.getNode(NCD);
+                if (!Node)
+                    break;
+                DomTreeNode *IdomNode = Node->getIDom();
+                if (!IdomNode)
+                    break;
+                NCD = IdomNode->getBlock();
+            }
+
+            if (NCD)
+                SaveBB = NCD;
+        }
+
+        bool SinkingFrame = (SaveBB != EntryBB);
+
         // Create and push a GC frame.
         auto gcframe = CallInst::Create(
             getOrDeclare(jl_intrinsics::newGCFrame),
             {ConstantInt::get(T_int32, 0)},
             "gcframe");
-        gcframe->insertBefore(F->getEntryBlock().begin());
+        if (SinkingFrame)
+            gcframe->insertBefore(SaveBB->getFirstInsertionPt());
+        else
+            gcframe->insertBefore(F->getEntryBlock().begin());
 
         auto pushGcframe = CallInst::Create(
             getOrDeclare(jl_intrinsics::pushGCFrame),
             {gcframe, ConstantInt::get(T_int32, 0)});
-        if (isa<Argument>(pgcstack))
+        if (SinkingFrame || isa<Argument>(pgcstack))
              pushGcframe->insertAfter(gcframe);
          else
              pushGcframe->insertAfter(cast<Instruction>(pgcstack));
@@ -2530,9 +2627,54 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(ArrayRef<int> Colors, int PreAss
 
         // Insert GC frame stores
         PlaceGCFrameStores(S, AllocaSlot - 2, Colors, PreAssignedColors, gcframe);
-        // Insert GCFrame pops
-        for (auto &BB : *F) {
-            if (isa<ReturnInst>(BB.getTerminator())) {
+        // Insert GCFrame pops at two kinds of sites:
+        //   (1) ReturnInsts dominated by SaveBB — pop before the return.
+        //   (2) CFG edges U -> V where SaveBB dominates U but not V — split
+        //       the edge and pop in the new block.
+        // Unreachable terminators have no outgoing edges and aren't Returns,
+        // so they're naturally skipped; EH unwinding restores pgcstack.
+        if (SinkingFrame) {
+            DominatorTree &DT = *S.DT;
+            SmallVector<BasicBlock*, 4> InSinkReturns;
+            SmallVector<std::pair<BasicBlock*, BasicBlock*>, 4> ExitEdges;
+            for (auto &BB : *F) {
+                if (!DT.dominates(SaveBB, &BB))
+                    continue;
+                if (isa<ReturnInst>(BB.getTerminator()))
+                    InSinkReturns.push_back(&BB);
+                for (BasicBlock *Succ : successors(&BB)) {
+                    if (!DT.dominates(SaveBB, Succ))
+                        ExitEdges.push_back({&BB, Succ});
+                }
+            }
+            for (BasicBlock *BB : InSinkReturns) {
+                auto popGcframe = CallInst::Create(
+                    getOrDeclare(jl_intrinsics::popGCFrame),
+                    {gcframe});
+#if JL_LLVM_VERSION >= 200000
+                popGcframe->insertBefore(BB->getTerminator()->getIterator());
+#else
+                popGcframe->insertBefore(BB->getTerminator());
+#endif
+            }
+            for (auto &E : ExitEdges) {
+                BasicBlock *Split = SplitEdge(E.first, E.second, &DT);
+                auto popGcframe = CallInst::Create(
+                    getOrDeclare(jl_intrinsics::popGCFrame),
+                    {gcframe});
+#if JL_LLVM_VERSION >= 200000
+                popGcframe->insertBefore(Split->getTerminator()->getIterator());
+#else
+                popGcframe->insertBefore(Split->getTerminator());
+#endif
+                if (CFGModified)
+                    *CFGModified = true;
+            }
+        }
+        else {
+            for (auto &BB : *F) {
+                if (!isa<ReturnInst>(BB.getTerminator()))
+                    continue;
                 auto popGcframe = CallInst::Create(
                     getOrDeclare(jl_intrinsics::popGCFrame),
                     {gcframe});
@@ -2567,7 +2709,7 @@ bool LateLowerGCFrame::runOnFunction(Function &F, bool *CFGModified) {
         ComputeLiveness(S);
         auto Colors = ColorRoots(S);
         std::map<Value *, std::pair<int, int>> CallFrames; // = OptimizeCallFrames(S, Ordering);
-        PlaceRootsAndUpdateCalls(Colors.first, Colors.second, S, CallFrames);
+        PlaceRootsAndUpdateCalls(Colors.first, Colors.second, S, CallFrames, CFGModified);
       }
       CleanupIR(F, &S, CFGModified);
     }

--- a/test/llvmpasses/final-lower-gc.ll
+++ b/test/llvmpasses/final-lower-gc.ll
@@ -48,6 +48,7 @@ top:
 ; OPAQUE-NEXT: [[PREV_GCFRAME_PTR4:%.*]] = load ptr addrspace(10), ptr [[PREV_GCFRAME_PTR3]], align 8, !tbaa !0
 ; OPAQUE-NEXT: store ptr addrspace(10) [[PREV_GCFRAME_PTR4]], ptr [[GCFRAME_SLOT]], align 8, !tbaa !0
   call void @julia.pop_gc_frame({} addrspace(10)** %gcframe)
+; OPAQUE-NEXT: call void @llvm.lifetime.end{{.*}}(i64 {{[0-9]+}}, ptr %gcframe)
 ; CHECK-NEXT: ret void
   ret void
 }

--- a/test/llvmpasses/late-lower-gc-shrink-wrap.jl
+++ b/test/llvmpasses/late-lower-gc-shrink-wrap.jl
@@ -1,0 +1,139 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Tests for GC frame shrink-wrapping in LateLowerGCFrame: the shadow-stack
+# frame push/pop (and the memset that zero-inits it) should be sunk into the
+# sub-CFG that actually needs GC roots, while the backing alloca stays in the
+# entry block (static alloca, bracketed by lifetime.start/end).
+
+# RUN: julia --startup-file=no %s %t -O && llvm-link -S %t/* -o %t/module.ll
+# RUN: cat %t/module.ll | FileCheck %s
+
+include(joinpath("..", "testhelpers", "llvmpasses.jl"))
+
+# COM: Test 1: early-exit pattern. The fast path (x < 0) returns 0 without
+# COM: rooting anything; the slow path holds a Ref{Any} live across two
+# COM: calls. The alloca stays at entry but the push/memset/lifetime land
+# COM: inside the slow-path block.
+@noinline _step1(r) = (r[] = r[] + 1; r)
+@noinline _step2(r) = (r[] = r[] * 2; r[])
+function shrinkwrap_early_exit(x::Int)
+    if x < 0
+        return 0
+    end
+    r = Ref{Any}(x)
+    _step1(r)
+    return _step2(r)::Int
+end
+
+# CHECK-LABEL: @julia_shrinkwrap_early_exit
+# CHECK: top:
+# COM: alloca at entry (static); entry must not push, memset, or begin lifetime
+# CHECK: %gcframe{{[0-9]*}} = alloca
+# CHECK-NOT: store ptr %gcframe{{[0-9]*}}, ptr %pgcstack_arg
+# CHECK-NOT: call void @llvm.lifetime.start
+# CHECK-NOT: call void @llvm.memset{{.*}} %gcframe
+# COM: the sunk block begins lifetime, memsets, and pushes
+# CHECK: L{{[0-9]+}}:
+# CHECK: call void @llvm.lifetime.start{{.*}} %gcframe
+# CHECK: call void @llvm.memset{{.*}} %gcframe
+# CHECK: store ptr %gcframe{{[0-9]*}}, ptr %pgcstack_arg
+emit(shrinkwrap_early_exit, Int)
+
+# COM: Test 2: loop preheader. Only the rare inner branch (i % 128 == 0)
+# COM: needs roots across a function call. The alloca is at entry; the
+# COM: push/memset land in the loop preheader (outside the body) and the
+# COM: pop on the loop-exit edge — NOT per-iteration inside the loop.
+@noinline _maybe_any(i::Int) = Base.inferencebarrier(i)
+@noinline _combine(x, y::Int) = (x isa Int ? x ⊻ y : y)::Int
+function shrinkwrap_loop(n::Int)
+    acc = 0
+    for i in 1:n
+        if i % 128 == 0
+            a = _maybe_any(i)
+            acc += _combine(a, i)
+        else
+            acc += i
+        end
+    end
+    return acc
+end
+
+# CHECK-LABEL: @julia_shrinkwrap_loop
+# CHECK: top:
+# COM: entry is the n==0 zero-trip guard; alloca here but no push/memset
+# CHECK: %gcframe{{[0-9]*}} = alloca
+# CHECK-NOT: store ptr %gcframe{{[0-9]*}}, ptr %pgcstack_arg
+# CHECK-NOT: call void @llvm.memset{{.*}} %gcframe
+# COM: push + memset + lifetime.start in the loop preheader
+# CHECK: .preheader
+# CHECK: call void @llvm.lifetime.start{{.*}} %gcframe
+# CHECK: call void @llvm.memset{{.*}} %gcframe
+# CHECK: store ptr %gcframe{{[0-9]*}}, ptr %pgcstack_arg
+# COM: pop and lifetime.end on the loop-exit edge (not inside the loop body)
+# CHECK: .loopexit
+# CHECK: store ptr %frame.prev{{[0-9]*}}, ptr %pgcstack_arg
+# CHECK: call void @llvm.lifetime.end{{.*}} %gcframe
+emit(shrinkwrap_loop, Int)
+
+# COM: Test 3: boundscheck pattern. N-dim indexing where the frame is only
+# COM: needed in the cold throw path (building BoundsError). Widely
+# COM: triggered across the stdlib.
+function shrinkwrap_boundscheck(A::Array{Float64,5}, i::Int, j::Int, k::Int, l::Int, m::Int)
+    return A[i, j, k, l, m]
+end
+
+# CHECK-LABEL: @julia_shrinkwrap_boundscheck
+# CHECK: top:
+# CHECK: %gcframe{{[0-9]*}} = alloca
+# CHECK-NOT: store ptr %gcframe{{[0-9]*}}, ptr %pgcstack_arg
+# COM: push appears in the throw path block; that block ends in unreachable
+# CHECK: call void @llvm.lifetime.start{{.*}} %gcframe
+# CHECK: store ptr %gcframe{{[0-9]*}}, ptr %pgcstack_arg
+# CHECK: unreachable
+emit(shrinkwrap_boundscheck, Array{Float64,5}, Int, Int, Int, Int, Int)
+
+# COM: Test 4: regression guard. When the frame IS needed on the hot path
+# COM: from entry, shrink-wrap must leave the push there. The alloca is
+# COM: always at entry; the push should also be in entry here.
+@noinline _identity_any(x)::Any = Base.inferencebarrier(x)
+function shrinkwrap_hot_path(x::Int)
+    a = _identity_any(x)
+    b = _identity_any(x + 1)
+    return (a isa Int ? a : 0) + (b isa Int ? b : 0)
+end
+
+# CHECK-LABEL: @julia_shrinkwrap_hot_path
+# CHECK: top:
+# CHECK: %gcframe{{[0-9]*}} = alloca
+# CHECK: store ptr %gcframe{{[0-9]*}}, ptr %pgcstack_arg
+emit(shrinkwrap_hot_path, Int)
+
+# COM: Test 5: try/catch bailout. Any runtime EH call (ijl_enter_handler /
+# COM: ijl_pop_handler[_noexcept]) must disable sinking for the whole
+# COM: function — otherwise jl_eh_restore_state_noexcept's gcstack assertion
+# COM: fires at normal try exit. Use @noinline Any-returning helpers so a
+# COM: frame actually gets allocated across calls inside the try body.
+@noinline _tc_step1(r) = (r[] = r[] + 1; r)
+@noinline _tc_step2(r) = (r[] = r[] * 2; r[])
+function shrinkwrap_try_catch(x::Int)
+    try
+        r = Ref{Any}(x)
+        _tc_step1(r)
+        return _tc_step2(r)::Int
+    catch
+        return -1
+    end
+end
+
+# CHECK-LABEL: @julia_shrinkwrap_try_catch
+# CHECK: top:
+# CHECK: %gcframe{{[0-9]*}} = alloca
+# COM: function has try/catch → push must stay in entry (no sinking),
+# COM: alongside the memset and lifetime.start
+# CHECK: call void @llvm.lifetime.start{{.*}} %gcframe
+# CHECK: call void @llvm.memset{{.*}} %gcframe
+# CHECK: store ptr %gcframe{{[0-9]*}}, ptr %pgcstack_arg
+# COM: and the EH entry call is in this function (confirms we exercised the
+# COM: bailout path rather than missing EH detection)
+# CHECK: call {{.*}}@ijl_enter_handler
+emit(shrinkwrap_try_catch, Int)

--- a/test/llvmpasses/late-lower-gc-shrink-wrap.jl
+++ b/test/llvmpasses/late-lower-gc-shrink-wrap.jl
@@ -137,3 +137,19 @@ end
 # COM: bailout path rather than missing EH detection)
 # CHECK: call {{.*}}@ijl_enter_handler
 emit(shrinkwrap_try_catch, Int)
+
+# COM: Test 6: slot-phi regression. A diamond where one branch allocates a
+# COM: rooted value and the merge block phi's it in must NOT sink — popping
+# COM: on the sink-exit edge would free the slot before the phi user reads
+# COM: it. Mirrors rem(BigFloat, BigFloat, RoundFromZero) which segfaulted
+# COM: in test/numbers.jl before the fix.
+function shrinkwrap_bigfloat_diamond(x::BigFloat, y::BigFloat)
+    return signbit(x) == signbit(y) ? rem(x, y, RoundUp) : rem(x, y, RoundDown)
+end
+
+# CHECK-LABEL: @julia_shrinkwrap_bigfloat_diamond
+# CHECK: top:
+# CHECK: %gcframe{{[0-9]*}} = alloca
+# COM: special-ptr phi in the merge block forces the frame to stay at entry
+# CHECK: store ptr %gcframe{{[0-9]*}}, ptr %pgcstack_arg
+emit(shrinkwrap_bigfloat_diamond, BigFloat, BigFloat)

--- a/test/llvmpasses/names.jl
+++ b/test/llvmpasses/names.jl
@@ -149,12 +149,12 @@ emit(f5, A)
 # CHECK: %ptls_load
 # CHECK: %safepoint
 # CHECK: %"e::E.f"
-# CHECK: @"+Main.Base.RefValue
-# CHECK: %"e::E.f.tag_addr"
-# CHECK: %"e::E.f.tag"
-# CHECK: @"jl_sym#g
-# CHECK: @"jl_sym#h
-# CHECK: %gc_slot_addr_0
+# CHECK-DAG: @"+Main.Base.RefValue
+# CHECK-DAG: %"e::E.f.tag_addr"
+# CHECK-DAG: %"e::E.f.tag"
+# CHECK-DAG: @"jl_sym#g
+# CHECK-DAG: @"jl_sym#h
+# CHECK-DAG: %gc_slot_addr_0
 emit(f6, E)
 
 


### PR DESCRIPTION
This sadly doesn't do as much as I wanted it to because swiftself seems to interact badly with the backend. It forces spills of the swiftself arg even where it's not needed. So a second thing might be to disable swiftcc and just pass the ptls as a normal argument


## Summary

The GC frame is allocated and pushed unconditionally at function entry.
For many functions it's only needed in a subsection of the CFG — the
cold branch of a diamond, a loop body that occasionally takes a rare
branch, or the throw path of a boundscheck — and the fast paths pay
the memset + shadow-stack push for nothing.

LateLowerGCFrame now picks a sink block (NCD of the BBs that actually
use the frame, hoisted out of loops) and places `julia.push_gc_frame`
there instead of at entry. Pops are inserted before in-sink returns
and on split CFG edges that leave the sink region. Functions that call
`jl_enter_handler` / `jl_pop_handler[_noexcept]` are skipped, since a
sunk push/pop must bracket the same enter/leave set.

FinalLowerGC keeps the backing alloca in the entry block (LLVM static
alloca) and only emits the memset plus `llvm.lifetime.start` at the
possibly-sunk call site. `llvm.lifetime.end` is emitted after each pop.

Modeled on LLVM's ShrinkWrap pass.

## Test plan

- [x] FileCheck test `test/llvmpasses/late-lower-gc-shrink-wrap.jl` covers five patterns: early-exit diamond, loop preheader, boundscheck throw, hot-path regression guard, try/catch EH bailout.
- [x] Full bootstrap (sysimg) builds clean.
- [x] Smoke: exception-heavy stdlib paths (`parse`, dict with tuple values, generators) run correctly.

This pull request was written with the assistance of generative AI (Claude Opus 4.7).