### PR TITLE
[JuliaLowering] Replace Tuple `.source` with NodeId `.macro_source`

### DIFF
--- a/JuliaLowering/src/JuliaLowering.jl
+++ b/JuliaLowering/src/JuliaLowering.jl
@@ -14,11 +14,11 @@ end
 
 using .JuliaSyntax: @KSet_str, @stm, Kind, NodeId, SourceAttrType, SourceRef, SyntaxGraph,
     SyntaxList, SyntaxTree, byte_range, check_compatible_graph, children, copy_ast,
-    copy_attrs, copy_node, delete_attributes, ensure_attributes!, filename, first_byte,
+    copy_attrs, delete_attributes, ensure_attributes!, filename, first_byte,
     flags, flattened_provenance, has_flags, hasattr, head, highlight, is_compatible_graph,
     is_leaf, is_literal, kind, last_byte, mapchildren, mapsyntax, mkleaf, mknode, newleaf,
     newnode, node_string, numchildren, provenance, reparent, setattr, setattr!,
-    source_location, sourcefile, sourceref, syntax_graph, tree_ids, mapindex
+    source_location, sourcefile, sourceref, syntax_graph, tree_ids, mapindex, mktree
 
 const DEBUG = true
 

--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -409,7 +409,7 @@ function setmeta!(ex::SyntaxTree, key::Symbol, @nospecialize(val))
 end
 
 setmeta(ex::SyntaxTree, k::Symbol, @nospecialize(v)) =
-    setmeta!(copy_node(ex), k, v)
+    setmeta!(is_leaf(ex) ? mkleaf(ex) : mknode(ex, children(ex)), k, v)
 
 function getmeta(ex::SyntaxTree, name::Symbol, default)
     meta = get(ex, :meta, nothing)

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -423,8 +423,8 @@ function est_to_dst(st::SyntaxTree)
                  (s[1:prevind(s,end)], K"op=")
 
              op_leaf = newleaf(g, st, K"Identifier")
-             JS.copy_attrs!(op_leaf, st)
              setattr!(op_leaf, :name_val, op_s)
+             setattr!(op_leaf, :scope_layer, st.scope_layer)
              @ast g st [out_k rec(l) op_leaf rec(r)]
          end
         [K"comparison" cs0...] -> let cs = copy(cs0)

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -49,7 +49,7 @@ end
 function expand_quote(ctx, ex)
     unquoted = SyntaxList(ctx)
     collect_unquoted!(ctx, unquoted, ex, 0)
-    # Unlike user-defined macro expansion, we don't call append_sourceref for
+    # Unlike user-defined macro expansion, we don't call append_sourceref! for
     # the entire expression produced by `quote` expansion. We could, but it
     # seems unnecessary for `quote` because the surface syntax is a transparent
     # representation of the expansion process. However, it's useful to add the
@@ -215,7 +215,7 @@ function set_macro_arg_hygiene(ctx, ex, layer_ids, layer_idx)
     k = kind(ex)
     scope_layer = get(ex, :scope_layer, layer_ids[layer_idx])
     if is_leaf(ex)
-        setattr!(copy_node(ex), :scope_layer, scope_layer)
+        setattr!(mkleaf(ex), :scope_layer, scope_layer)
     else
         inner_layer_idx = k == K"escape" ? layer_idx - 1 : layer_idx
         if k == K"escape" && inner_layer_idx < 1
@@ -367,7 +367,7 @@ function expand_macro(ctx, ex)
     end
 
     if kind(expanded) != K"Value"
-        expanded = append_sourceref(ctx, expanded, ex)
+        expanded = append_sourceref!(ctx, expanded, ex._id)
         # Module scope for the returned AST is the module where this particular
         # method was defined (may be different from `parentmodule(macfunc)`)
         mod_for_ast = lookup_method_instance(macfunc, macro_args,
@@ -379,24 +379,13 @@ function expand_macro(ctx, ex)
     return expanded
 end
 
-_unpack_srcref(graph, srcref::SyntaxTree) = _node_id(graph, srcref)
-_unpack_srcref(graph, srcref::Tuple)      = _node_ids(graph, srcref...)
-_unpack_srcref(_graph, srcref)            = srcref
-
-# Add a secondary source of provenance to each expression in the tree `ex`.
-function append_sourceref(ctx, ex, secondary_prov)
-    srcref = (ex, secondary_prov)
-    out = if !is_leaf(ex)
-        if kind(ex) == K"macrocall"
-            copy_node(ex)
-        else
-            cs = mapsyntax(e->append_sourceref(ctx, e, secondary_prov)._id, children(ex))
-            mknode(ex, cs)
-        end
-    else
-        copy_node(ex)
+function append_sourceref!(ctx, ex, id::NodeId)
+    @jl_assert ex._id != id ex
+    setattr!(ex, :macro_source, id)
+    for c in children(ex)
+        append_sourceref!(ctx, c, id)
     end
-    setattr!(out, :source, _unpack_srcref(syntax_graph(ctx), srcref))
+    ex
 end
 
 function remove_scope_layer!(ex)
@@ -410,7 +399,7 @@ function remove_scope_layer!(ex)
 end
 
 function remove_scope_layer(ctx, ex)
-    remove_scope_layer!(copy_ast(ctx, ex; copy_source=false))
+    remove_scope_layer!(mktree(ex))
 end
 
 """
@@ -483,6 +472,7 @@ function ensure_macro_attributes!(graph)
         graph;
         var_id=IdTag,
         scope_layer=LayerId,
+        macro_source=NodeId,
         __macro_ctx__=Nothing,
         meta=CompileHints)
     DEBUG ? ensure_attributes!(g2; jl_source=LineNumberNode) : g2

--- a/JuliaLowering/src/runtime.jl
+++ b/JuliaLowering/src/runtime.jl
@@ -58,7 +58,7 @@ function _interpolated_value(ctx::InterpolationContext, srcref, @nospecialize(ex
         if !is_compatible_graph(ctx, ex)
             ex = copy_ast(ctx, ex)
         end
-        append_sourceref(ctx, ex, srcref)
+        append_sourceref!(ctx, ex, srcref._id)
     elseif ex isa Symbol
         # Plain symbols become identifiers. This is an accommodation for
         # compatibility to allow `:x` (a Symbol) and `:(x)` (a SyntaxTree) to

--- a/JuliaLowering/src/utils.jl
+++ b/JuliaLowering/src/utils.jl
@@ -34,13 +34,11 @@ function _value_string(ex)
         str = "$(str)$idstr"
     end
     if k == K"slot" || k == K"BindingId"
-        p = provenance(ex)[1]
-        while p isa SyntaxTree
+        for p in provenance(ex)
             if kind(p) == K"Identifier"
                 str = "$(str)/$(p.name_val)"
                 break
             end
-            p = provenance(p)[1]
         end
     end
     return str
@@ -180,20 +178,28 @@ function _show_provtree(io::IO, ex::SyntaxTree, indent)
     if hasattr(ex, :jl_source)
         printstyled(io, " @$(ex.jl_source)", color=:light_black)
     end
-    print(io, "\n")
     prov = provenance(ex)
-    for (i, e) in enumerate(prov)
-        islast = i == length(prov)
-        printstyled(io, "$indent$(islast ? "└─ " : "├─ ")", color=:light_black)
-        inner_indent = indent * (islast ? "   " : "│  ")
-        _show_provtree(io, e, inner_indent)
-    end
-end
 
-function _show_provtree(io::IO, prov, _indent)
-    fn = filename(prov)
-    line, _ = source_location(prov)
-    printstyled(io, "@ $fn:$line\n", color=:light_black)
+    print(io, "\n")
+
+    src = ex.source
+    msrc = get(ex, :macro_source, nothing)
+    printstyled(io, string(
+        indent, msrc === nothing ? "└─ " : "├─ "); color=:light_black)
+    if src isa NodeId
+        _show_provtree(io, SyntaxTree(ex._graph, src),
+                       string(indent, msrc === nothing ? "   " : "│  "))
+    else
+        @jl_assert ex.source isa Union{LineNumberNode, SourceRef} ex
+        src = sourceref(ex)
+        fn = filename(src)
+        line, _ = source_location(src)
+        printstyled(io, "@ $fn:$line\n", color=:light_black)
+    end
+    if msrc isa NodeId
+        printstyled(io, string(indent, "└─ "); color=:light_black)
+        _show_provtree(io, SyntaxTree(ex._graph, msrc), indent*"   ")
+    end
 end
 
 function showprov(io::IO, exs::AbstractVector;

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -1169,6 +1169,13 @@ function _assert_syntaxtree(st::SyntaxTree, parents::Vector{NodeId}, vr)
     for a in required_attrs
         vr &= hasattr(st, a) ? pass() : @fail(st, string("needs attribute ", a))
     end
+    # TODO: Proper traversal along .source and .macro_source (need to cache
+    # results to avoid exponential repeated lookups, and figure out how these
+    # edges may form cycles with child edges)
+    st.source === st._id && (vr &= @fail(st, ".source equal to self ID"))
+    get(st, :macro_source, nothing) === st._id &&
+        (vr &= @fail(st, ".macro_source equal to self ID"))
+
     push!(parents, st._id)
     for c in children(st)
         vr &= _assert_syntaxtree(c, parents, vr)

--- a/JuliaLowering/test/quoting.jl
+++ b/JuliaLowering/test/quoting.jl
@@ -23,15 +23,16 @@ end
 @test sourcetext(ex[1][2]) == "\$(x+1)"
 @test sourcetext.(flattened_provenance(ex[1][3])) == ["\$y", "g(z)"]
 @test sprint(io->JuliaLowering._show_provtree(io, ex[1][3], "")) == raw"""
-    (call g z)
-    ├─ (call g z)
-    │  └─ (call g z)
-    │     └─ (call g ✘ z ✘)
-    │        └─ @ string:3
-    └─ ($ y)
-       └─ ($ ::K"$" y)
-          └─ @ string:5
-    """
+(call g z)
+├─ (call g z)
+│  └─ (call g z)
+│     └─ (call g ✘ z ✘)
+│        └─ @ string:3
+└─ ($ y)
+   └─ ($ y)
+      └─ ($ ::K"$" y)
+         └─ @ string:5
+"""
 @test sprint(io->showprov(io, ex[1][3])) == raw"""
     begin
         x = 10

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -378,13 +378,13 @@ API.  As of writing this, the user has more freedom than they should have.
 """
 
 """
-SyntaxList of [ex.source, ex.source.source, ..., textref]
+SyntaxList of [st.source, st.source.source, ..., textref]
 """
-function provenance(ex::SyntaxTree)
-    prov = SyntaxList(ex._graph)
-    s = ex.source
+function provenance(st::SyntaxTree)
+    prov = SyntaxList(st._graph)
+    s = st.source
     while s isa NodeId
-        s_tree = SyntaxTree(ex._graph, s)
+        s_tree = SyntaxTree(st._graph, s)
         push!(prov, s_tree)
         s = s_tree.source
     end
@@ -392,50 +392,61 @@ function provenance(ex::SyntaxTree)
 end
 
 """
-provenance(ex)[1]
+`provenance(st)[1]`, or `st` if that's empty
 """
-function prov(ex::SyntaxTree)
-    ex.source isa NodeId ? SyntaxTree(ex._graph, ex.source) : ex.source
+function prov(st::SyntaxTree)
+    st.source isa NodeId ? SyntaxTree(st._graph, st.source) : st
 end
 
 """
-`ex`'s textref's `.source`, ignoring all `.macro_source`
+textref of st (possibly == st)
 """
-function sourceref(ex::SyntaxTree)
-    sources = ex._graph.source::Dict{Int, Any}
-    s = ex._id
-    while s isa NodeId
-        s = sources[s]
-    end
-    return s::Union{LineNumberNode, SourceRef}
-end
-
-"""
-A SyntaxList of every textref reachable by traversing both `source` and
-`macro_source`.  The number of returned trees should equal one plus the number
-of macro expansions `ex` was an input and output of (so syntax produced in a
-macro body should return just one.)
-"""
-function flattened_provenance(ex::SyntaxTree)
-    g = ex._graph
-    todo = NodeId[ex._id]
-    out = SyntaxList(g)
-    while !isempty(todo)
-        s_tree = SyntaxTree(g, pop!(todo))
-        src = s_tree.source
-        if src isa Union{LineNumberNode, SourceRef}
-            push!(out, s_tree)
-        else
-            push!(todo, src::NodeId)
-        end
-        let msrc = get(s_tree, :macro_source, nothing)
-            # macro source === source means `ex` is from the `msrc` macro body
-            if !isnothing(msrc) && msrc !== src
-                push!(todo, msrc)
-            end
-        end
+function prov_end(st::SyntaxTree)
+    out = st
+    while out.source isa NodeId
+        out = prov(out)
     end
     return out
+end
+
+"""
+`st`'s textref's `.source`, ignoring all `.macro_source`
+"""
+function sourceref(st::SyntaxTree)
+    prov_end(st).source::Union{LineNumberNode, SourceRef}
+end
+
+"""
+A SyntaxList of textrefs associated with `st`.  The number of returned trees
+should equal one plus the number of macro expansions `st` "went through":
+
+- For new macros, this is the number of macro expansions `st` was both an input
+  and output of, so if `st` was created in a macro body, `flattened_provenance`
+  returns a list of length 1.
+
+- For old macros, we can't determine whether expanded syntax is from the
+  macrocall args or macro body (it will have LineNumberNode .source), so all
+  expanded syntax counts as having "went through" the macrocall.
+
+The resulting list should be in the order
+`[outermost_macrocall, innermost_macrocall, ..., expression_textref]`.
+"""
+function flattened_provenance(st::SyntaxTree)
+    _flattened_provenance(st, SyntaxList(st._graph))
+end
+
+# Only recurse on the first .macro_source in any source chain
+function _flattened_provenance(st::SyntaxTree, out)
+    while !hasattr(st, :macro_source) && st.source isa NodeId
+        st = prov(st)
+    end
+    # macro_source === source means `st` is from the `msrc` macro body
+    msrc = get(st, :macro_source, nothing)
+    msrc isa NodeId && msrc !== st.source &&
+        _flattened_provenance(SyntaxTree(st._graph, msrc), out)
+
+    push!(out, prov_end(st))
+    out
 end
 
 function is_ancestor(ex, ancestor)

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -285,23 +285,12 @@ function attrnames(ex::SyntaxTree)
     (name::Symbol for (name, value) in pairs(attrs) if haskey(value, ex._id))
 end
 
-function copy_node(ex::SyntaxTree)
-    graph = syntax_graph(ex)
-    id = new_id!(graph)
-    if !is_leaf(ex)
-        setchildren!(graph, id, children(ex._graph, ex._id))
-    end
-    ex2 = SyntaxTree(graph, id)
-    copy_attrs!(ex2, ex, true)
-    ex2
-end
-
 function setattr!(ex::SyntaxTree, name::Symbol, @nospecialize(val))
     setattr!(ex._graph, ex._id, name, val)
     ex
 end
 setattr(ex::SyntaxTree, name::Symbol, @nospecialize(val)) =
-    setattr!(copy_node(ex), name, val)
+    setattr!(is_leaf(ex) ? mkleaf(ex) : mknode(ex, children(ex)), name, val)
 
 function deleteattr!(ex::SyntaxTree, name::Symbol)
     deleteattr!(ex._graph, ex._id, name)
@@ -373,65 +362,81 @@ function Base.show(io::IO, ::MIME"text/plain", src::SourceRef)
     highlight(io, src; note="these are the bytes you're looking for 😊", context_lines_inner=20)
 end
 
+"""
+Provenance notes: A SyntaxTree `st` has `.source` equal to one of:
+- NodeId (of the SyntaxTree `st` was transformed from)
+- a reference to source text (either SourceRef or LineNumberNode).
 
+Let "textref" refer to a SyntaxTree with non-NodeId `.source`.  Every SyntaxTree
+is either a textref or has one at the end of its `.source` chain.
+
+`st` may also have `.macro_source`, which is the NodeId of a macrocall if `st`
+was returned from its expansion.
+
+All invariants noted in this section are awaiting the design of the "new macro"
+API.  As of writing this, the user has more freedom than they should have.
+"""
+
+"""
+SyntaxList of [ex.source, ex.source.source, ..., textref]
+"""
 function provenance(ex::SyntaxTree)
+    prov = SyntaxList(ex._graph)
     s = ex.source
-    if s isa NodeId
-        return (SyntaxTree(ex._graph, s),)
-    elseif s isa Tuple
-        return SyntaxTree.((ex._graph,), s)
-    else
-        return (s,)
+    while s isa NodeId
+        s_tree = SyntaxTree(ex._graph, s)
+        push!(prov, s_tree)
+        s = s_tree.source
     end
+    return prov
 end
 
-function _sourceref(sources, id)
-    i = 1
-    while true
-        i += 1
-        s = sources[id]::SourceAttrType
-        if s isa NodeId
-            id = s
-        else
-            return s, id
-        end
-    end
+"""
+provenance(ex)[1]
+"""
+function prov(ex::SyntaxTree)
+    ex.source isa NodeId ? SyntaxTree(ex._graph, ex.source) : ex.source
 end
 
+"""
+`ex`'s textref's `.source`, ignoring all `.macro_source`
+"""
 function sourceref(ex::SyntaxTree)
     sources = ex._graph.source::Dict{Int, Any}
-    id = ex._id
-    while true
-        s, _ = _sourceref(sources, id)
-        if s isa Tuple
-            s = s[1]
-        end
-        if s isa NodeId
-            id = s
-        else
-            return s
-        end
+    s = ex._id
+    while s isa NodeId
+        s = sources[s]
     end
+    return s::Union{LineNumberNode, SourceRef}
 end
 
-function _flattened_provenance(refs, graph, sources, id)
-    # TODO: Implement in terms of `provenance()`?
-    s, id2 = _sourceref(sources, id)
-    if s isa Tuple
-        for i in s
-            _flattened_provenance(refs, graph, sources, i)
-        end
-    else
-        push!(refs, SyntaxTree(graph, id2))
-    end
-end
-
+"""
+A SyntaxList of every textref reachable by traversing both `source` and
+`macro_source`.  The number of returned trees should equal one plus the number
+of macro expansions `ex` was an input and output of (so syntax produced in a
+macro body should return just one.)
+"""
 function flattened_provenance(ex::SyntaxTree)
-    refs = SyntaxList(ex._graph)
-    _flattened_provenance(refs, ex._graph, ex._graph.source, ex._id)
-    return reverse!(refs)
+    g = ex._graph
+    todo = NodeId[ex._id]
+    out = SyntaxList(g)
+    while !isempty(todo)
+        s_tree = SyntaxTree(g, pop!(todo))
+        src = s_tree.source
+        if src isa Union{LineNumberNode, SourceRef}
+            push!(out, s_tree)
+        else
+            push!(todo, src::NodeId)
+        end
+        let msrc = get(s_tree, :macro_source, nothing)
+            # macro source === source means `ex` is from the `msrc` macro body
+            if !isnothing(msrc) && msrc !== src
+                push!(todo, msrc)
+            end
+        end
+    end
+    return out
 end
-
 
 function is_ancestor(ex, ancestor)
     if !is_compatible_graph(ex, ancestor)
@@ -452,7 +457,7 @@ function is_ancestor(ex, ancestor)
     end
 end
 
-const SourceAttrType = Union{SourceRef,LineNumberNode,NodeId,Tuple{Vararg{NodeId}}}
+const SourceAttrType = Union{SourceRef,LineNumberNode,NodeId}
 
 function reparent(ctx, ex::SyntaxTree)
     # Ensure `ex` has the same parent graph, in a somewhat loose sense.
@@ -659,26 +664,26 @@ end
 function mkleaf(old::SyntaxTree)
     graph = syntax_graph(old)
     st = SyntaxTree(graph, new_id!(graph))
-    copy_attrs!(st, old, true)
+    copy_attrs!(st, old)
     setattr!(st, :source, old._id)
+end
+function mktree(old::SyntaxTree)
+    if is_leaf(old)
+        mkleaf(old)
+    else
+        cs = mapsyntax(mktree, children(old))
+        mknode(old, cs)
+    end
 end
 
 #-------------------------------------------------------------------------------
 # Mapping and copying of AST nodes
-function copy_attrs!(dest, src, all=false)
+function copy_attrs!(dest, src)
     # TODO: Make this faster?
     for (name, attr) in pairs(src._graph.attributes)
-        if (all || (name !== :source && name !== :kind && name !== :syntax_flags)) &&
-                haskey(attr, src._id)
+        if (name !== :source && name !== :macro_source) && haskey(attr, src._id)
             setattr!(dest, name, attr[src._id])
         end
-    end
-end
-
-function copy_attrs!(dest, head::Union{Kind,SyntaxHead}, all=false)
-    if all
-        setattr!(dest._graph, dest._id, :kind, kind(head))
-        !(head isa Kind) && setattr!(dest._graph, dest._id, :syntax_flags, flags(head))
     end
 end
 
@@ -711,46 +716,40 @@ function mapchildren(f::Function, ctx, ex::SyntaxTree)
 end
 
 """
-Recursively copy AST `ex` into `ctx`.
-
-Special provenance handling: If `copy_source` is true, treat the `.source`
-attribute as a reference and recurse on its contents.  Otherwise, treat it like
-any other attribute.
+Recursively copy AST `ex` into `ctx`.  Every node in `ex` should be copied at
+most once.
 """
-function copy_ast(ctx, ex::SyntaxTree; copy_source=true)
+function copy_ast(ctx, ex::SyntaxTree)
     graph1 = syntax_graph(ex)
     graph2 = syntax_graph(ctx)
-    !copy_source && check_same_graph(graph1, graph2)
-    id2 = _copy_ast(graph2, graph1, ex._id, Dict{NodeId, NodeId}(), copy_source)
+    @assert graph1 !== graph2 "use mktree(ex) for this"
+    id2 = _copy_ast(graph2, graph1, ex._id, Dict{NodeId, NodeId}())
     return SyntaxTree(graph2, id2)
 end
 
-function _copy_ast(graph2::SyntaxGraph, graph1::SyntaxGraph,
-                   id1::NodeId, seen, copy_source)
+function _copy_ast(graph2::SyntaxGraph, graph1::SyntaxGraph, id1::NodeId, seen)
     let copied = get(seen, id1, nothing)
         isnothing(copied) || return copied
     end
     id2 = new_id!(graph2)
     seen[id1] = id2
-    src1 = get(SyntaxTree(graph1, id1), :source, nothing)
-    src2 = if !copy_source
-        src1
-    elseif src1 isa NodeId
-        _copy_ast(graph2, graph1, src1, seen, copy_source)
-    elseif src1 isa Tuple
-        map(i->_copy_ast(graph2, graph1, i, seen, copy_source), src1)
-    else
-        src1
-    end
-    copy_attrs!(SyntaxTree(graph2, id2), SyntaxTree(graph1, id1), true)
-    setattr!(graph2, id2, :source, src2)
     if !is_leaf(graph1, id1)
         cs = NodeId[]
         for cid in children(graph1, id1)
-            push!(cs, _copy_ast(graph2, graph1, cid, seen, copy_source))
+            push!(cs, _copy_ast(graph2, graph1, cid, seen))
         end
         setchildren!(graph2, id2, cs)
     end
+    for src_attr in (:source, :macro_source)
+        src1 = get(SyntaxTree(graph1, id1), src_attr, nothing)
+        if src1 isa NodeId
+            src2 =  _copy_ast(graph2, graph1, src1, seen)
+            setattr!(graph2, id2, src_attr, src2)
+        elseif src_attr == :source
+            setattr!(graph2, id2, src_attr, src1)
+        end
+    end
+    copy_attrs!(SyntaxTree(graph2, id2), SyntaxTree(graph1, id1))
     return id2
 end
 
@@ -779,12 +778,24 @@ function unalias_nodes(sl::SyntaxList)
                    sl.ids))
 end
 
+function _unalias_copy_tree(old::SyntaxTree)
+    out = if is_leaf(old)
+        mkleaf(old)
+    else
+        cs = mapsyntax(_unalias_copy_tree, children(old))
+        mknode(old, cs)
+    end
+    # difference from mktree: don't add to provenance chain
+    hasattr(out, :macro_source) && setattr!(out, :macro_source, old.macro_source)
+    setattr!(out, :source, old.source)
+end
+
 # Note that `seen_edges` is only needed for when edge ranges overlap, which is a
 # situation we don't produce yet.
 function _unalias_nodes(graph::SyntaxGraph, id::NodeId,
                         seen::Set{NodeId}, seen_edges::Set{Int})
     if id in seen
-        id = copy_ast(graph, SyntaxTree(graph, id); copy_source=false)._id
+        id = _unalias_copy_tree(SyntaxTree(graph, id))._id
     end
     # nodes may not share edges (SyntaxGraph invariant)
     @assert isempty(intersect(seen_edges, graph.edge_ranges[id]))
@@ -849,7 +860,7 @@ function prune(graph1_a::SyntaxGraph, entrypoints_a::Vector{NodeId})
     append!(graph2.edges, 1:length(nodes1)) # our reward for unaliasing
 
     for attr in attrnames(graph1)
-        attr === :source && continue
+        (attr === :source || attr === :macro_source) && continue
         for (n2, n1) in enumerate(nodes1)
             if haskey(graph1.attributes[attr], n1)
                 graph2.attributes[attr][n2] = graph1.attributes[attr][n1]
@@ -861,7 +872,13 @@ function prune(graph1_a::SyntaxGraph, entrypoints_a::Vector{NodeId})
     resolved_sources = Dict{NodeId, SourceAttrType}() # graph1 id => graph2 src
 
     for (n2, n1) in enumerate(nodes1)
-        graph2.source[n2] = _prune_get_resolved!(n1, graph1, map12, resolved_sources)
+        graph2.source[n2] = _prune_get_resolved!(n1, graph1, map12, resolved_sources, :source)
+        if hasattr(graph2, :macro_source) && haskey(graph2.macro_source, n1)
+            msrc = _prune_get_resolved!(n1, graph1, map12, resolved_sources, :macro_source)
+            if !isnothing(msrc)
+                graph.macro_source[n2] = msrc
+            end
+        end
     end
 
     # The first n entries in nodes1 were our entrypoints, unique from unaliasing
@@ -870,16 +887,15 @@ end
 
 function _prune_get_resolved!(id1::NodeId, graph1::SyntaxGraph,
                               map12::Dict{NodeId, Int},
-                              resolved_sources::Dict{NodeId, SourceAttrType})
+                              resolved_sources::Dict{NodeId, SourceAttrType},
+                              attr::Symbol)
     out = get(resolved_sources, id1, nothing)
     if isnothing(out)
-        src1 = graph1.source[id1]
+        src1 = getattr(graph1, attr)[id1]
         out = if haskey(map12, src1)
             map12[src1]
         elseif src1 isa NodeId
-            _prune_get_resolved!(src1, graph1, map12, resolved_sources)
-        elseif src1 isa Tuple
-            map(s -> _prune_get_resolved!(s, graph1, map12, resolved_sources), src1)
+            _prune_get_resolved!(src1, graph1, map12, resolved_sources, attr)
         else
             src1
         end

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -391,16 +391,12 @@ function provenance(st::SyntaxTree)
     return prov
 end
 
-"""
-`provenance(st)[1]`, or `st` if that's empty
-"""
+"`provenance(st)[1]`, or `st` if that's empty"
 function prov(st::SyntaxTree)
     st.source isa NodeId ? SyntaxTree(st._graph, st.source) : st
 end
 
-"""
-textref of st (possibly == st)
-"""
+"textref of st (possibly == st)"
 function prov_end(st::SyntaxTree)
     out = st
     while out.source isa NodeId
@@ -409,11 +405,18 @@ function prov_end(st::SyntaxTree)
     return out
 end
 
-"""
-`st`'s textref's `.source`, ignoring all `.macro_source`
-"""
+"`st`'s textref's `.source`, ignoring all `.macro_source`"
 function sourceref(st::SyntaxTree)
     prov_end(st).source::Union{LineNumberNode, SourceRef}
+end
+
+"The last macro expansion `st` was involved in, or nothing"
+function macro_prov(st::SyntaxTree)
+    while !hasattr(st, :macro_source) && st.source isa NodeId
+        st = prov(st)
+    end
+    hasattr(st, :macro_source) && return SyntaxTree(st._graph, st.macro_source)
+    return nothing
 end
 
 """
@@ -437,14 +440,10 @@ end
 
 # Only recurse on the first .macro_source in any source chain
 function _flattened_provenance(st::SyntaxTree, out)
-    while !hasattr(st, :macro_source) && st.source isa NodeId
-        st = prov(st)
-    end
+    msrc = macro_prov(st)
     # macro_source === source means `st` is from the `msrc` macro body
-    msrc = get(st, :macro_source, nothing)
-    msrc isa NodeId && msrc !== st.source &&
-        _flattened_provenance(SyntaxTree(st._graph, msrc), out)
-
+    !isnothing(msrc) && msrc._id !== st.source &&
+        _flattened_provenance(msrc, out)
     push!(out, prov_end(st))
     out
 end
@@ -797,7 +796,7 @@ function _unalias_copy_tree(old::SyntaxTree)
         mknode(old, cs)
     end
     # difference from mktree: don't add to provenance chain
-    hasattr(out, :macro_source) && setattr!(out, :macro_source, old.macro_source)
+    hasattr(old, :macro_source) && setattr!(out, :macro_source, old.macro_source)
     setattr!(out, :source, old.source)
 end
 
@@ -883,11 +882,12 @@ function prune(graph1_a::SyntaxGraph, entrypoints_a::Vector{NodeId})
     resolved_sources = Dict{NodeId, SourceAttrType}() # graph1 id => graph2 src
 
     for (n2, n1) in enumerate(nodes1)
-        graph2.source[n2] = _prune_get_resolved!(n1, graph1, map12, resolved_sources, :source)
-        if hasattr(graph2, :macro_source) && haskey(graph2.macro_source, n1)
-            msrc = _prune_get_resolved!(n1, graph1, map12, resolved_sources, :macro_source)
-            if !isnothing(msrc)
-                graph.macro_source[n2] = msrc
+        graph2.source[n2] =
+            _prune_get_resolved!(n1, graph1, map12, resolved_sources, :source)
+        if hasattr(graph1, :macro_source) && haskey(graph1.macro_source, n1)
+            msrc1 = graph1.macro_source[n1]
+            if haskey(map12, msrc1)
+                graph2.macro_source[n2] = map12[msrc1]
             end
         end
     end

--- a/JuliaSyntax/test/syntax_graph.jl
+++ b/JuliaSyntax/test/syntax_graph.jl
@@ -1,4 +1,4 @@
-using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind, syntax_graph, prov, prov_end, provenance, flattened_provenance, sourceref, newleaf, mkleaf, mknode, mktree, setattr!
+using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind, syntax_graph, prov, prov_end, provenance, macro_prov, flattened_provenance, sourceref, newleaf, mkleaf, mknode, mktree, setattr!, hasattr
 
 "For filling required attrs in graphs created by hand"
 function testgraph(edge_ranges, edges, more_attrs...)
@@ -112,7 +112,7 @@ end
         stm1 = setattr!(newleaf(g, LineNumberNode(1, :m), K"Identifier"), :name_val, "stm1")
         stm2 = setattr!(mkleaf(stm1), :name_val, "stm2")
         stm3 = setattr!(mkleaf(stm1), :name_val, "stm3")
-        stm_unused = setattr!(newleaf(g, LineNumberNode(0), K"Identifier"), :name_val, "m_unused")
+        stm_unused = setattr!(newleaf(g, LineNumberNode(0), K"Identifier"), :name_val, "stm_unused")
 
         stmm1 = setattr!(newleaf(g, LineNumberNode(1, :mm), K"Identifier"), :name_val, "stmm1")
         stmm2 = setattr!(mkleaf(stmm1), :name_val, "stmm2")
@@ -128,9 +128,9 @@ end
         # ├─ st2
         # │  ├─ st1
         # │  │  ├─ @ nothing:1
-        # │  │  └─ m_unused
+        # │  │  └─ stm_unused
         # │  │     └─ @ nothing:0
-        # │  └─ m_unused
+        # │  └─ stm_unused
         # │     └─ @ nothing:0
         # └─ stm3
         #    ├─ stm1
@@ -140,6 +140,15 @@ end
         #          └─ stmm1
         #             └─ @ mm:1
 
+        @test macro_prov(st3) == stm3
+        @test macro_prov(st2) == stm_unused
+        @test macro_prov(st1) == stm_unused
+        @test macro_prov(stm3) == stmm3
+        @test macro_prov(stm2) == nothing
+        @test macro_prov(stm1) == nothing
+        @test macro_prov(stmm3) == nothing
+        @test macro_prov(stmm2) == nothing
+        @test macro_prov(stmm1) == nothing
         @test flattened_provenance(st3) == SyntaxList(stmm1, stm1, st1)
         @test flattened_provenance(st2) == SyntaxList(stm_unused, st1)
         @test flattened_provenance(st1) == SyntaxList(stm_unused, st1)
@@ -187,18 +196,24 @@ end
     end
 
     @testset "unalias_nodes" begin
-        # 1 -+-> 2 ->-> 4
-        #    |      |
+        # 1 -+-> 2 ->-> 4    src(4) = 5
+        #    |      |       msrc(4) = 6
         #    +-> 3 -+
-        g = testgraph([1:2, 3:3, 4:4, 0:-1], [2, 3, 4, 4])
+        #               5
+        #               6
+        g = testgraph([1:2, 3:3, 4:4, 0:-1, 0:-1, 0:-1], [2, 3, 4, 4],
+                      :macro_source => Dict{Int, SourceAttrType}(4=>6))
+        setattr!(g, 4, :source, 5)
+
         st = SyntaxTree(g, 1)
         stu = JuliaSyntax.unalias_nodes(st)
         @test st ≈ stu
-        @test length(stu._graph.edge_ranges) == 5
+        @test length(stu._graph.edge_ranges) == 7
         @test length(stu._graph.edges) == 4
         # Properties of node 4 should be preserved
         @test 4 == stu[1][1].orig == stu[2][1].orig
         @test st[1][1].source == stu[1][1].source == stu[2][1].source
+        @test st[1][1].macro_source == stu[1][1].macro_source == stu[2][1].macro_source
         @test stu[1][1]._id != stu[2][1]._id
 
         #           +-> 5
@@ -325,6 +340,86 @@ end
         @test length(stp._graph.edge_ranges) === 2
         @test stp.source === LineNumberNode(4)
         @test stp[1].source === LineNumberNode(5)
+
+        # [1]--> 4    src(1) = 2, msrc(1) = 3
+        #  2 --> 5
+        #  3 --> 6
+        g = testgraph([1:1, 2:2, 3:3, 0:-1, 0:-1, 0:-1], [4, 5, 6],
+                      :source => Dict{Int, SourceAttrType}(
+                          1=>2,map(i->(i=>LineNumberNode(i)), 2:6)...),
+                      :macro_source => Dict{Int, SourceAttrType}(1=>3))
+        st = SyntaxTree(g, 1)
+        let stp = JuliaSyntax.prune(st)
+            @test st ≈ stp
+            @test length(stp._graph.edge_ranges) === 2
+            @test stp.orig == 1
+            @test stp[1].orig == 4
+            @test isempty(stp._graph.macro_source)
+        end
+        let stp = JuliaSyntax.prune(st; keep=SyntaxList(g, NodeId[2]))
+            @test st ≈ stp
+            @test length(stp._graph.edge_ranges) === 4
+            @test stp.orig == 1
+            @test stp[1].orig == 4
+            @test isempty(stp._graph.macro_source)
+            @test prov(stp).orig == 2
+        end
+        let stp = JuliaSyntax.prune(st; keep=SyntaxList(g, NodeId[2, 3]))
+            @test st ≈ stp
+            @test prov(st) ≈ prov(stp)
+            @test length(stp._graph.edge_ranges) === 6
+            @test hasattr(stp, :macro_source)
+            @test SyntaxTree(stp._graph, stp.macro_source).orig == 3
+        end
+
+        # 1
+        # 10 -->[2]--> 6    src(2) = 3
+        # 11 --> 3 --> 7    src(3) = 4, msrc(3) = 4
+        # 12 --> 4 --> 8    src(4) = 5
+        # 13 --> 5 --> 9    else src(i) = line(i)
+        g = testgraph([0:-1, 1:1, 2:2, 3:3, 4:4, 0:-1, 0:-1, 0:-1, 0:-1, 5:5, 6:6, 7:7, 8:8],
+                      [6, 7, 8, 9, 2, 3, 4, 5],
+                      :source => Dict{Int, SourceAttrType}(
+                          2=>3, 3=>4, 4=>5, 1=>LineNumberNode(1),
+                          map(i->(i=>LineNumberNode(i)), 4:12)...),
+                      :macro_source => Dict{Int, SourceAttrType}(3=>4))
+        st = SyntaxTree(g, 2)
+        stp = JuliaSyntax.prune(st; keep=SyntaxList(g, NodeId[5]))
+        @test st ≈ stp
+        # 1, 5, 4, 8 should remain; macro_source is removed
+        @test length(stp._graph.edge_ranges) === 4
+        @test isempty(stp._graph.macro_source)
+
+        # need both 3 and 4 preserved to keep the macro_source link (though we
+        # may want it to be a stronger prune-preserved reference in the future.)
+        let stp = JuliaSyntax.prune(st; keep=SyntaxList(g, NodeId[5, 3]))
+            @test st ≈ stp
+            @test length(stp._graph.edge_ranges) === 6
+            @test isempty(stp._graph.macro_source)
+        end
+        let stp = JuliaSyntax.prune(st; keep=SyntaxList(g, NodeId[5, 4]))
+            @test st ≈ stp
+            @test length(stp._graph.edge_ranges) === 6
+            @test isempty(stp._graph.macro_source)
+        end
+        let stp = JuliaSyntax.prune(st; keep=SyntaxList(g, NodeId[3]))
+            @test st ≈ stp
+            @test length(stp._graph.edge_ranges) === 4
+            @test isempty(stp._graph.macro_source)
+        end
+        let stp = JuliaSyntax.prune(st; keep=SyntaxList(g, NodeId[4]))
+            @test st ≈ stp
+            @test length(stp._graph.edge_ranges) === 4
+            @test isempty(stp._graph.macro_source)
+        end
+        let stp = JuliaSyntax.prune(st; keep=SyntaxList(g, NodeId[3, 4]))
+            @test st ≈ stp
+            @test length(stp._graph.edge_ranges) === 6
+            @test hasattr(prov(stp), :macro_source)
+            new_4 = SyntaxTree(stp._graph, prov(stp).macro_source)
+            @test new_4.orig == 4
+            @test new_4[1].source == LineNumberNode(8)
+        end
 
         # test with real parsed, then copied output---not many properties we can
         # check without fragile tests, but there are some.

--- a/JuliaSyntax/test/syntax_graph.jl
+++ b/JuliaSyntax/test/syntax_graph.jl
@@ -1,4 +1,18 @@
-using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind, syntax_graph, prov, mktree
+using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind, syntax_graph, prov, prov_end, provenance, flattened_provenance, sourceref, newleaf, mkleaf, mknode, mktree, setattr!
+
+"For filling required attrs in graphs created by hand"
+function testgraph(edge_ranges, edges, more_attrs...)
+    kinds = Dict{NodeId, Any}(map(i->(i=>K"block"), eachindex(edge_ranges)))
+    sources = Dict{NodeId, Any}(
+        map(i->(i=>LineNumberNode(i)), eachindex(edge_ranges)))
+    orig = Dict{NodeId, Any}(map(i->(i=>i), eachindex(edge_ranges)))
+    SyntaxGraph(
+        edge_ranges,
+        edges,
+        Dict{Symbol, Dict{NodeId, Any}}(
+            :kind => kinds, :source => sources,
+            :orig => orig, more_attrs...))
+end
 
 @testset "SyntaxGraph attrs" begin
     g_dict = SyntaxGraph()
@@ -62,23 +76,85 @@ end
     @test parsestmt(SyntaxTree, "'a b c'"; ignore_errors=true) isa SyntaxTree
 end
 
-@testset "SyntaxTree utils" begin
-    "For filling required attrs in graphs created by hand"
-    function testgraph(edge_ranges, edges, more_attrs...)
-        kinds = Dict{NodeId, Any}(map(i->(i=>K"block"), eachindex(edge_ranges)))
-        sources = Dict{NodeId, Any}(
-            map(i->(i=>LineNumberNode(i)), eachindex(edge_ranges)))
-        orig = Dict{NodeId, Any}(map(i->(i=>i), eachindex(edge_ranges)))
-        SyntaxGraph(
-            edge_ranges,
-            edges,
-            Dict{Symbol, Dict{NodeId, Any}}(
-                :kind => kinds, :source => sources,
-                :orig => orig, more_attrs...))
+@testset "SyntaxTree provenance accessors" begin
+
+    @testset "prov, prov_end, provenance, sourceref" begin
+        # 1 --> 2 --> 3     src(7-9) = line 7-9
+        # 4 --> 5 --> 6     src(i) = i + 3
+        # 7 --> 8 --> 9
+        g = testgraph([1:1, 2:2, 0:-1, 3:3, 4:4, 0:-1, 5:5, 6:6, 0:-1],
+                      [2, 3, 5, 6, 8, 9],
+                      :source => Dict{Int, SourceAttrType}(enumerate([
+                          map(i->i+3, 1:6)...
+                              map(LineNumberNode, 7:9)...])))
+        st = SyntaxTree(g, 1)
+        @test prov(st)._id == 4
+        @test prov(prov(st))._id == 7
+        @test prov(prov(prov(st)))._id == 7
+
+        @test prov_end(st)._id == 7
+        @test prov_end(prov_end(st))._id == 7
+
+        @test sourceref(st) == LineNumberNode(7)
+        @test sourceref(prov_end(st)) == LineNumberNode(7)
+
+        @test provenance(st).ids == NodeId[4, 7]
+        @test provenance(prov_end(st)).ids == NodeId[]
     end
+
+    @testset "flattened_provenance" begin
+        g = SyntaxGraph()
+        ensure_attributes!(g; macro_source=NodeId)
+        st1 = setattr!(newleaf(g, LineNumberNode(1), K"Identifier"), :name_val, "st1")
+        st2 = setattr!(mkleaf(st1), :name_val, "st2")
+        st3 = setattr!(mkleaf(st2), :name_val, "st3")
+
+        stm1 = setattr!(newleaf(g, LineNumberNode(1, :m), K"Identifier"), :name_val, "stm1")
+        stm2 = setattr!(mkleaf(stm1), :name_val, "stm2")
+        stm3 = setattr!(mkleaf(stm1), :name_val, "stm3")
+        stm_unused = setattr!(newleaf(g, LineNumberNode(0), K"Identifier"), :name_val, "m_unused")
+
+        stmm1 = setattr!(newleaf(g, LineNumberNode(1, :mm), K"Identifier"), :name_val, "stmm1")
+        stmm2 = setattr!(mkleaf(stmm1), :name_val, "stmm2")
+        stmm3 = setattr!(mkleaf(stmm2), :name_val, "stmm3")
+
+        setattr!(st1, :macro_source, stm_unused._id)
+        setattr!(st2, :macro_source, stm_unused._id)
+        setattr!(st3, :macro_source, stm3._id)
+        setattr!(stm3, :macro_source, stmm3._id)
+
+        # julia> JL._show_provtree(stdout, st3, "")
+        # st3
+        # ├─ st2
+        # │  ├─ st1
+        # │  │  ├─ @ nothing:1
+        # │  │  └─ m_unused
+        # │  │     └─ @ nothing:0
+        # │  └─ m_unused
+        # │     └─ @ nothing:0
+        # └─ stm3
+        #    ├─ stm1
+        #    │  └─ @ m:1
+        #    └─ stmm3
+        #       └─ stmm2
+        #          └─ stmm1
+        #             └─ @ mm:1
+
+        @test flattened_provenance(st3) == SyntaxList(stmm1, stm1, st1)
+        @test flattened_provenance(st2) == SyntaxList(stm_unused, st1)
+        @test flattened_provenance(st1) == SyntaxList(stm_unused, st1)
+        @test flattened_provenance(stm3) == SyntaxList(stmm1, stm1)
+        @test flattened_provenance(stm2) == SyntaxList(stm1)
+        @test flattened_provenance(stm1) == SyntaxList(stm1)
+        @test flattened_provenance(stmm3) == SyntaxList(stmm1)
+        @test flattened_provenance(stmm2) == SyntaxList(stmm1)
+        @test flattened_provenance(stmm1) == SyntaxList(stmm1)
+    end
+end
+
+@testset "SyntaxTree utils" begin
     mprov(st::SyntaxTree) = get(st, :macro_source, nothing) isa NodeId ?
         SyntaxTree(st._graph, st.macro_source) : nothing
-
 
     @testset "copy_ast, mktree" begin
         # 1 --> 2 --> 3     src(7-9) = line 7-9

--- a/JuliaSyntax/test/syntax_graph.jl
+++ b/JuliaSyntax/test/syntax_graph.jl
@@ -1,4 +1,4 @@
-using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind, syntax_graph
+using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind, syntax_graph, prov, mktree
 
 @testset "SyntaxGraph attrs" begin
     g_dict = SyntaxGraph()
@@ -54,6 +54,8 @@ end
 
 @testset "SyntaxTree parsing" begin
     # Errors should fall through
+    @test parsestmt(SyntaxTree, ""; ignore_errors=true) isa SyntaxTree
+    @test parsestmt(SyntaxTree, " "; ignore_errors=true) isa SyntaxTree
     @test parsestmt(SyntaxTree, "@"; ignore_errors=true) isa SyntaxTree
     @test parsestmt(SyntaxTree, "@@@"; ignore_errors=true) isa SyntaxTree
     @test parsestmt(SyntaxTree, "(a b c)"; ignore_errors=true) isa SyntaxTree
@@ -74,8 +76,11 @@ end
                 :kind => kinds, :source => sources,
                 :orig => orig, more_attrs...))
     end
+    mprov(st::SyntaxTree) = get(st, :macro_source, nothing) isa NodeId ?
+        SyntaxTree(st._graph, st.macro_source) : nothing
 
-    @testset "copy_ast" begin
+
+    @testset "copy_ast, mktree" begin
         # 1 --> 2 --> 3     src(7-9) = line 7-9
         # 4 --> 5 --> 6     src(i) = i + 3
         # 7 --> 8 --> 9
@@ -85,33 +90,24 @@ end
                           map(i->i+3, 1:6)...
                           map(LineNumberNode, 7:9)...])))
         st = SyntaxTree(g, 1)
-        stcopy = copy_ast(g, st)
-        # Each node should be copied once
-        @test length(g.edge_ranges) === 18
-        @test st._id != stcopy._id
-        @test st ≈ stcopy
-        @test st.source !== stcopy.source
-        @test st.source[1] !== stcopy.source[1]
-        @test st.source[1][1] !== stcopy.source[1][1]
+        new_g = ensure_attributes!(SyntaxGraph(); attrdefs(g)...)
 
-        stcopy2 = copy_ast(g, st; copy_source=false)
+        stcopy = copy_ast(new_g, st)
+        # Each node should be copied once
+        @test length(new_g.edge_ranges) === length(g.edge_ranges)
+        @test st ≈ stcopy
+        @test prov(st) ≈ prov(stcopy)
+        @test prov(prov(st)) ≈ prov(prov(stcopy))
+
+        stcopy2 = mktree(st)
         # Only nodes 1-3 should be copied
-        @test length(g.edge_ranges) === 21
+        @test length(g.edge_ranges) === 12
         @test st._id != stcopy2._id
         @test st ≈ stcopy2
-        @test st.source === stcopy2.source
-        @test st.source[1] === stcopy2.source[1]
-        @test st.source[1][1] === stcopy2.source[1][1]
+        @test stcopy2.source === st._id
 
-        # Copy into a new graph
-        new_g = ensure_attributes!(SyntaxGraph(); attrdefs(g)...)
-        stcopy3 = copy_ast(new_g, st)
-        @test length(new_g.edge_ranges) === 9
-        @test st ≈ stcopy3
-
-        new_g = ensure_attributes!(SyntaxGraph(); attrdefs(g)...)
-        # Disallow for now, since we can't prevent dangling sourcerefs
-        @test_throws ErrorException copy_ast(new_g, st; copy_source=false)
+        # Disallow copying into the same graph; slow for no good reason
+        @test_throws "mktree" copy_ast(st._graph, st)
     end
 
     @testset "unalias_nodes" begin


### PR DESCRIPTION

## Macro expansion performance issue

Noted in #61425, but here's a recap: Currently, we represent multi-provenance (a
tree originating from source text and >=1 macro expansions) by setting its
nodes' `.source` attributes to a tuple of NodeIds.  This is slow: when we
macroexpand, we need to copy, unpack, and repack the tuple associated with every
subtree coming from the expansion.  It also duplicates information we rarely
ever need, since this is only used for debuginfo production and certain
pretty-printing.  We're usually only interested in the first item in the tuple.

## Changes

### `.macro_source`

This change represents the same information (tuple elements 2:end) with a single
NodeId `.macro_source` on multiple nodes in a tree's provenance.  This fixes the
performance issue noted in the past, but also improves serializability of
SyntaxTree if we end up putting them on disk.

This representation is similar to lowered `DebugInfo`, where `st.source` is
`di.linetable` and `st.macro_source` is one of `di.edges`.

### Provenance API improvements

I needed to rewrite `flattened_provenance` and friends to use `.macro_source`,
so I've also written down what these functions should do.  Some
reverse-engineering was needed, and some functions have changed their behaviour
slightly, so @aviatesk let me know if there's some functionality that's missing.
`flattened_provenance` should be the same.

### `copy_ast`, `copy_node`, etc.

Cleaned up given that copying needs to have special behaviour with `.source` and
`.macro_source`.  `mktree` now copies a subtree for lowering purposes (extends
provenance, recurses on children) and `copy_ast` (actually copies `.source` and
`.macro_source`) is restricted to the foreign-graph case.

### Benchmarks

Script and GC-time disclaimer is the same as in #61425.  Improvement depends on
how macro-heavy the code is.

<details>
<summary>
Before
</summary>

```
julia> include("jlbench.jl"); @allocated main(["./test/char.jl"])
File: ./test/char.jl
Module: Main
Number of top-level expressions: 40
Number of runs: 10

1...2...3...4...5...6...7...8...9...10...
Best times (over 10 runs):
  expand_forms_1:              43.383 ms
  expand_forms_2:              30.849 ms
  resolve_scopes:              23.396 ms
  convert_closures:            29.841 ms
  linearize_ir:                34.429 ms
  to_lowered_expr:             46.547 ms

  Total:                       208.445 ms
  Total(flisp):                248.6 ms

Percentage breakdown:
  expand_forms_1:              20.8%
  expand_forms_2:              14.8%
  resolve_scopes:              11.2%
  convert_closures:            14.3%
  linearize_ir:                16.5%
  to_lowered_expr:             22.3%
1964449696

julia> include("jlbench.jl"); @allocated main(["./test/atomics.jl"])
File: ./test/atomics.jl
Module: Main
Number of top-level expressions: 392
Number of runs: 10

1...2...3...4...5...6...7...8...9...10...
Best times (over 10 runs):
  expand_forms_1:              112.906 ms
  expand_forms_2:              90.099 ms
  resolve_scopes:              55.319 ms
  convert_closures:            18.995 ms
  linearize_ir:                83.808 ms
  to_lowered_expr:             83.458 ms

  Total:                       444.585 ms
  Total(flisp):                378.801 ms

Percentage breakdown:
  expand_forms_1:              25.4%
  expand_forms_2:              20.3%
  resolve_scopes:              12.4%
  convert_closures:            4.3%
  linearize_ir:                18.9%
  to_lowered_expr:             18.8%
3792501984

julia> include("jlbench.jl"); @allocated main(["./test/numbers.jl"])
File: ./test/numbers.jl
Module: Main
Number of top-level expressions: 416
Number of runs: 10

1...2...3...4...5...6...7...8...9...10...
Best times (over 10 runs):
  expand_forms_1:              777.836 ms
  expand_forms_2:              558.305 ms
  resolve_scopes:              378.443 ms
  convert_closures:            211.51 ms
  linearize_ir:                592.592 ms
  to_lowered_expr:             736.205 ms

  Total:                       3254.891 ms
  Total(flisp):                2588.61 ms

Percentage breakdown:
  expand_forms_1:              23.9%
  expand_forms_2:              17.2%
  resolve_scopes:              11.6%
  convert_closures:            6.5%
  linearize_ir:                18.2%
  to_lowered_expr:             22.6%
20309895520
```
</details>

<details>
<summary>
After
</summary>

```
julia> include("jlbench.jl"); @allocated main(["./test/char.jl"])
File: ./test/char.jl
Module: Main
Number of top-level expressions: 40
Number of runs: 10

1...2...3...4...5...6...7...8...9...10...
Best times (over 10 runs):
  expand_forms_1:              28.689 ms
  expand_forms_2:              32.89 ms
  resolve_scopes:              22.794 ms
  convert_closures:            18.304 ms
  linearize_ir:                37.902 ms
  to_lowered_expr:             26.57 ms

  Total:                       167.149 ms
  Total(flisp):                243.393 ms

Percentage breakdown:
  expand_forms_1:              17.2%
  expand_forms_2:              19.7%
  resolve_scopes:              13.6%
  convert_closures:            11.0%
  linearize_ir:                22.7%
  to_lowered_expr:             15.9%
1696645648

julia> include("jlbench.jl"); @allocated main(["./test/atomics.jl"])
File: ./test/atomics.jl
Module: Main
Number of top-level expressions: 392
Number of runs: 10

1...2...3...4...5...6...7...8...9...10...
Best times (over 10 runs):
  expand_forms_1:              73.671 ms
  expand_forms_2:              86.262 ms
  resolve_scopes:              52.325 ms
  convert_closures:            19.826 ms
  linearize_ir:                81.106 ms
  to_lowered_expr:             58.467 ms

  Total:                       371.658 ms
  Total(flisp):                375.771 ms

Percentage breakdown:
  expand_forms_1:              19.8%
  expand_forms_2:              23.2%
  resolve_scopes:              14.1%
  convert_closures:            5.3%
  linearize_ir:                21.8%
  to_lowered_expr:             15.7%
3688971328

julia> include("jlbench.jl"); @allocated main(["./test/numbers.jl"])
File: ./test/numbers.jl
Module: Main
Number of top-level expressions: 416
Number of runs: 10

1...2...3...4...5...6...7...8...9...10...
Best times (over 10 runs):
  expand_forms_1:              585.484 ms
  expand_forms_2:              571.274 ms
  resolve_scopes:              364.441 ms
  convert_closures:            142.187 ms
  linearize_ir:                615.537 ms
  to_lowered_expr:             461.66 ms

  Total:                       2740.583 ms
  Total(flisp):                2560.689 ms

Percentage breakdown:
  expand_forms_1:              21.4%
  expand_forms_2:              20.8%
  resolve_scopes:              13.3%
  convert_closures:            5.2%
  linearize_ir:                22.5%
  to_lowered_expr:             16.8%
20738718400
```
</details>

If I really cheat (minimum time over 10 runs like above, `const DEBUG = false`
in JuliaLowering), it is reliably faster than flisp now :).  There's still much
more work to do in the practical case; memory use in particular needs
improvement.
