### PR TITLE
fix unionall typeintersect

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2886,11 +2886,13 @@ static jl_value_t *intersect_var(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, int
             ub = a;
         }
         else {
-            e->triangular++;
-            ub = R ? intersect_aside(a, bb->ub, e, bb->depth0) : intersect_aside(bb->ub, a, e, bb->depth0);
-            e->triangular--;
-            if (ub != a && jl_subtype(a, bb->ub)) {
+            if (jl_subtype(a, bb->ub)) {
                 ub = a;
+            }
+            else {
+                e->triangular++;
+                ub = R ? intersect_aside(a, bb->ub, e, bb->depth0) : intersect_aside(bb->ub, a, e, bb->depth0);
+                e->triangular--;
             }
             jl_savedenv_t se;
             save_env(e, &se, 1);

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2889,6 +2889,9 @@ static jl_value_t *intersect_var(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, int
             e->triangular++;
             ub = R ? intersect_aside(a, bb->ub, e, bb->depth0) : intersect_aside(bb->ub, a, e, bb->depth0);
             e->triangular--;
+            if (ub != a && jl_subtype(a, bb->ub)) {
+                ub = a;
+            }
             jl_savedenv_t se;
             save_env(e, &se, 1);
             int issub = subtype_in_env_existential(bb->lb, ub, e);

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2537,6 +2537,8 @@ let A = W61602{T, 1} where T<:(Union{Missing, S} where S),
     E = Tuple{W61602{Union{Missing, T}}, T} where T
     @test Tuple{C, String} <: D
     @test !(Tuple{C, String} <: E)
+    @test Tuple{C, Int64} <: typeintersect(D, E)
+    @test Tuple{C, Int64} <: typeintersect(E, D)
     @test_broken !(Tuple{C, String} <: typeintersect(D, E))
     @test_broken !(Tuple{C, String} <: typeintersect(E, D))
 end

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2537,8 +2537,8 @@ let A = W61602{T, 1} where T<:(Union{Missing, S} where S),
     E = Tuple{W61602{Union{Missing, T}}, T} where T
     @test Tuple{C, String} <: D
     @test !(Tuple{C, String} <: E)
-    @test !(Tuple{C, String} <: typeintersect(D, E))
-    @test !(Tuple{C, String} <: typeintersect(E, D))
+    @test_broken !(Tuple{C, String} <: typeintersect(D, E))
+    @test_broken !(Tuple{C, String} <: typeintersect(E, D))
 end
 
 # try to fool a greedy algorithm that picks X=Int, Y=String here

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2526,12 +2526,13 @@ let T = Ref{NTuple{8, Ref{Union{Int, P}}}} where P,
 end
 
 # issue #61602
-struct W61602{T, N}
-    x::Array{T, N}
+struct W61602{T, N} x::Array{T, N} end
+let A = W61602{T, 1} where T<:(Union{Missing, S} where S),
+    B = W61602{Union{Missing, T}} where T
+    C = W61602{Union{Missing, Int64}, 1}
+    @test C <: typeintersect(A, B)
+    @test C <: typeintersect(B, A)
 end
-v = W61602{T, 1} where T<:(Union{Missing, S} where S)
-t = W61602{Union{Missing, T}} where T
-@test W61602{Union{Missing, Int64}, 1} <: typeintersect(v, t)
 
 # try to fool a greedy algorithm that picks X=Int, Y=String here
 @test Tuple{Ref{Union{Int,String}}, Ref{Union{Int,String}}} <: Tuple{Ref{Union{X,Y}}, Ref{X}} where {X,Y}

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2525,6 +2525,14 @@ let T = Ref{NTuple{8, Ref{Union{Int, P}}}} where P,
     @test T <: Union{Int, S}
 end
 
+# issue #61602
+struct W61602{T, N}
+    x::Array{T, N}
+end
+v = W61602{T, 1} where T<:(Union{Missing, S} where S)
+t = W61602{Union{Missing, T}} where T
+@test W61602{Union{Missing, Int64}, 1} <: typeintersect(v, t)
+
 # try to fool a greedy algorithm that picks X=Int, Y=String here
 @test Tuple{Ref{Union{Int,String}}, Ref{Union{Int,String}}} <: Tuple{Ref{Union{X,Y}}, Ref{X}} where {X,Y}
 @test Tuple{Ref{Union{Int,String,Missing}}, Ref{Union{Int,String}}} <: Tuple{Ref{Union{X,Y}}, Ref{X}} where {X,Y}

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2532,6 +2532,13 @@ let A = W61602{T, 1} where T<:(Union{Missing, S} where S),
     C = W61602{Union{Missing, Int64}, 1}
     @test C <: typeintersect(A, B)
     @test C <: typeintersect(B, A)
+
+    D = Tuple{W61602{T, 1}, X} where {T<:(Union{Missing, S} where S), X}
+    E = Tuple{W61602{Union{Missing, T}}, T} where T
+    @test Tuple{C, String} <: D
+    @test !(Tuple{C, String} <: E)
+    @test !(Tuple{C, String} <: typeintersect(D, E))
+    @test !(Tuple{C, String} <: typeintersect(E, D))
 end
 
 # try to fool a greedy algorithm that picks X=Int, Y=String here


### PR DESCRIPTION
fix https://github.com/JuliaLang/julia/issues/61602

originated from "real world" example causing unexpected crashes

basically we're getting `intersect_aside(bb->ub, a) = intersect_aside(Union{Missing, S} where S, Union{Missing, T}) = Any` but that result is not valid to use in invariant position when RHS contains a free typevar. so see if we can just use `a` directly.

I think this should also increase parity with the fast-path (which is hit when there are no free typevars)
https://github.com/JuliaLang/julia/blob/cacbbe8854d42bee042010045e7cfe4f4869cebb/src/subtype.c#L2875-L2886