### PR TITLE
[JuliaLowering] Make `@cfunction` identifier callable scope-resolved

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -622,12 +622,26 @@ function est_to_dst(st::SyntaxTree)
             end
         end
         ([K"latestworld"], when=!is_leaf(st)) -> newleaf(g, st, K"latestworld")
-        [K"cfunction" typ fptr rt at sym] -> @ast g st [K"cfunction"
-            rec(typ) rec(fptr)
-            [K"static_eval"(rt, meta=name_hint("cfunction return type")) rec(rt)]
-            [K"static_eval"(at, meta=name_hint("cfunction argument type")) rec(at)]
-            rec(sym)
-        ]
+        [K"cfunction" typ fptr rt at sym] -> let
+            # Identifier callables are scope-resolved against the outermost
+            # lowering layer (which corresponds to the method module used by
+            # `method.c`'s `jl_toplevel_eval`), so the IR carries a binding
+            # reference matching `@cfunction`'s runtime resolution. Other
+            # forms (e.g. function definitions) stay inert.
+            out_fptr = if kind(fptr) == K"inert" && numchildren(fptr) == 1 &&
+                          kind(fptr[1]) == K"Identifier"
+                ident = setattr!(mkleaf(fptr[1]), :scope_layer, 1)
+                @ast g fptr [K"static_eval"(fptr) ident]
+            else
+                rec(fptr)
+            end
+            @ast g st [K"cfunction"
+                rec(typ) out_fptr
+                [K"static_eval"(rt, meta=name_hint("cfunction return type")) rec(rt)]
+                [K"static_eval"(at, meta=name_hint("cfunction argument type")) rec(at)]
+                rec(sym)
+            ]
+        end
 
         # avoid creating excess nodes
         _ -> let out_cs::Vector{NodeId} = map(x->rec(x)._id, children(st))

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -415,6 +415,19 @@ function _to_lowered_expr(ex::SyntaxTree, stmt_offset::Int)
     elseif k == K"static_eval"
         @jl_assert numchildren(ex) == 1 ex
         _to_lowered_expr(ex[1], stmt_offset)
+    elseif k == K"cfunction"
+        # For a scope-resolved callable (`K"static_eval"`), drop the module tag
+        # and emit a bare Symbol so `method.c` resolves it in the method's
+        # module at eval time, matching Base `@cfunction`'s runtime semantics.
+        ret = Expr(:cfunction)
+        for (i, e) in enumerate(children(ex))
+            if i == 2 && kind(e) == K"static_eval" && kind(e[1]) == K"globalref"
+                push!(ret.args, QuoteNode(Symbol(e[1].name_val::String)))
+            else
+                push!(ret.args, _to_lowered_expr(e, stmt_offset))
+            end
+        end
+        return ret
     else
         # Allowed forms according to https://docs.julialang.org/en/v1/devdocs/ast/
         #

--- a/JuliaLowering/src/syntax_macros.jl
+++ b/JuliaLowering/src/syntax_macros.jl
@@ -93,9 +93,15 @@ function Base.var"@cfunction"(__context__::MacroContext, callable, return_type, 
         # Kinda weird semantics here - without `$`, the callable is a top level
         # expression evaluated within the module where the `@cfunction` is
         # expanded into.
-        fptr = @ast __context__ callable [K"inert"
-            callable
-        ]
+        #
+        # Identifier callables go through `K"static_eval"` so scope resolution
+        # produces a binding reference visible in the lowered IR. Other
+        # expressions (e.g. function definitions) stay inert.
+        fptr = if kind(callable) == K"Identifier"
+            @ast __context__ callable [K"static_eval" callable]
+        else
+            @ast __context__ callable [K"inert" callable]
+        end
         typ = Ptr{Cvoid}
     end
     @ast __context__ __context__.macrocall [K"cfunction"

--- a/JuliaLowering/src/syntax_macros.jl
+++ b/JuliaLowering/src/syntax_macros.jl
@@ -93,15 +93,9 @@ function Base.var"@cfunction"(__context__::MacroContext, callable, return_type, 
         # Kinda weird semantics here - without `$`, the callable is a top level
         # expression evaluated within the module where the `@cfunction` is
         # expanded into.
-        #
-        # Identifier callables go through `K"static_eval"` so scope resolution
-        # produces a binding reference visible in the lowered IR. Other
-        # expressions (e.g. function definitions) stay inert.
-        fptr = if kind(callable) == K"Identifier"
-            @ast __context__ callable [K"static_eval" callable]
-        else
-            @ast __context__ callable [K"inert" callable]
-        end
+        fptr = @ast __context__ callable [K"inert"
+            callable
+        ]
         typ = Ptr{Cvoid}
     end
     @ast __context__ __context__.macrocall [K"cfunction"

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -279,6 +279,8 @@ vst1(vcx::Validation1Context, st::SyntaxTree)::ValidationResult = @stm st begin
         vst1(vcx, at) &
         vst1(vcx, cconv) &
         all(vst1, vcx, roots_args)
+    [K"cfunction" [K"Value"] [K"static_eval" f] rt at [K"inert" [K"Identifier"]]] ->
+        vst1(vcx, f) & vst1(vcx, rt) & vst1(vcx, at)
     [K"cfunction" [K"Value"] f rt at [K"inert" [K"Identifier"]]] ->
         vst1(vcx, f) & vst1(vcx, rt) & vst1(vcx, at)
     [K"cconv" tup nreq] -> (get(tup, :value, nothing) isa Tuple &&
@@ -1267,6 +1269,8 @@ vst2(vcx::Validation2Context, st::SyntaxTree) = @stm st begin
          vst2(vcx, at) &
          vst2(vcx, cconv) &
          all(vst2, vcx, roots_args)
+    [K"cfunction" [K"Value"] [K"static_eval" fptr] [K"static_eval" rt] [K"static_eval" at] [K"Symbol"]] ->
+         vst2(vcx, fptr) & vst2(vcx, rt) & vst2(vcx, at)
     [K"cfunction" [K"Value"] fptr [K"static_eval" rt] [K"static_eval" at] [K"Symbol"]] ->
          vst2(vcx, fptr) & vst2(vcx, rt) & vst2(vcx, at)
 

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -279,8 +279,6 @@ vst1(vcx::Validation1Context, st::SyntaxTree)::ValidationResult = @stm st begin
         vst1(vcx, at) &
         vst1(vcx, cconv) &
         all(vst1, vcx, roots_args)
-    [K"cfunction" [K"Value"] [K"static_eval" f] rt at [K"inert" [K"Identifier"]]] ->
-        vst1(vcx, f) & vst1(vcx, rt) & vst1(vcx, at)
     [K"cfunction" [K"Value"] f rt at [K"inert" [K"Identifier"]]] ->
         vst1(vcx, f) & vst1(vcx, rt) & vst1(vcx, at)
     [K"cconv" tup nreq] -> (get(tup, :value, nothing) isa Tuple &&

--- a/JuliaLowering/test/misc_ir.jl
+++ b/JuliaLowering/test/misc_ir.jl
@@ -367,7 +367,7 @@ JuxtuposeTest.@emit_juxtupose
 # @cfunction expansion with global generic function as function argument
 @cfunction(callable, Int, (Int, Float64))
 #---------------------
-1   (cfunction Ptr{Nothing} :callable (static_eval TestMod.Int) (static_eval (call core.svec TestMod.Int TestMod.Float64)) :ccall)
+1   (cfunction Ptr{Nothing} (static_eval TestMod.callable) (static_eval TestMod.Int) (static_eval (call core.svec TestMod.Int TestMod.Float64)) :ccall)
 2   (return %₁)
 
 ########################################


### PR DESCRIPTION
The non-`$` branch of `@cfunction` wraps an identifier callable in `K"static_eval"` instead of `K"inert"`, so scope resolution produces a binding reference visible in the lowered IR (usable by downstream tools like a language server that consume the IR). Non-identifier callables (function definitions, etc.) stay inert since they are not direct binding references.

At `_to_lowered_expr` time, a scope-resolved fptr is converted back to a bare `QuoteNode(Symbol)` so `method.c`'s `jl_toplevel_eval` looks it up in the method's module at eval time, preserving Base `@cfunction`'s current runtime behavior.