### PR TITLE
[JuliaLowering] Mark `@eval`'s `eval_result` local as `is_internal`

### DIFF
--- a/JuliaLowering/src/syntax_macros.jl
+++ b/JuliaLowering/src/syntax_macros.jl
@@ -238,10 +238,15 @@ function Base.Experimental.var"@opaque"(__context__::MacroContext, ex)
 end
 
 function _at_eval_code(ctx, srcref, mod, ex)
+    # Mark the synthetic `eval_result` local as internal — it only exists to
+    # plumb the return value of `JuliaLowering.eval(...)` out of the expansion
+    # and never corresponds to a user-written name.
+    eval_result = (@ast ctx srcref "eval_result"::K"Identifier")
+    eval_result_decl = setmeta(eval_result, :is_internal, true)
     @ast ctx srcref [K"block"
         [K"local"
             [K"="
-                "eval_result"::K"Identifier"
+                eval_result_decl
                 [K"call"
                     # TODO: Call "eval"::K"core" here
                     JuliaLowering.eval::K"Value"


### PR DESCRIPTION
`_at_eval_code` introduces a synthetic `eval_result` local to plumb the return value of `JuliaLowering.eval(...)` out of the macro expansion. Since its identifier is built via `@ast ctx srcref ...` the node reuses the macrocall as source ref, so the resulting binding has a byte range that covers the entire `@eval` macrocall — and without `is_internal`, downstream consumers (reflection, LSP features) see it as a regular user-visible local spanning the macrocall.

Mark the declaration node with `:is_internal => true` so it matches the treatment of other compiler-generated bindings (e.g. the kwargs helpers marked at `desugaring.jl`).