### PR TITLE
math: fix exp_impl_fast Float64 nothrow inference

### DIFF
--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -267,7 +267,7 @@ end
     r = muladd(N_float, LogBo256U(base, T), x)
     r = muladd(N_float, LogBo256L(base, T), r)
     k = N >> 8
-    jU = reinterpret(Float64, JU_CONST | (@inbounds J_TABLE[N&255 + 1] & JU_MASK))
+    jU, _ = table_unpack(N)
     small_part =  muladd(jU, expm1b_kernel(base, r), jU)
     twopk = Int64(k) << 52
     return reinterpret(T, twopk + reinterpret(Int64, small_part))

--- a/test/fastmath.jl
+++ b/test/fastmath.jl
@@ -374,3 +374,15 @@ end
     x = @fastmath 1. + 1. + 1f0
     @test x == 3.0
 end
+
+# fastmath functions that are nothrow should be removable if unused
+@testset "fastmath functions are removable if unused" begin
+    for T in (Float32, Float64)
+        for f in (Base.FastMath.exp_fast, Base.FastMath.exp2_fast, Base.FastMath.exp10_fast,
+                  Base.FastMath.expm1_fast, Base.FastMath.abs_fast, Base.FastMath.atan_fast,
+                  Base.FastMath.sinh_fast, Base.FastMath.cosh_fast, Base.FastMath.tanh_fast,
+                  Base.FastMath.cbrt_fast, Base.FastMath.inv_fast, Base.FastMath.sqrt_fast)
+            @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (T,)))
+        end
+    end
+end


### PR DESCRIPTION
Addresses the exp finding in https://github.com/JuliaLang/julia/pull/61394#issuecomment-4276926165 @giordano 

#61394
```
julia> code_llvm((Float64,); debuginfo=:none) do x; @fastmath exp(x) - exp(x) end
; Function Signature: var"#5"(Float64)
define double @"julia_#5_0"(double %"x::Float64") local_unnamed_addr #0 {
top:
  %0 = call double @j_exp_fast_0(double %"x::Float64") #9
  ret double 0.000000e+00
}
```

This PR
```
julia> code_llvm((Float64,); debuginfo=:none) do x; @fastmath exp(x) - exp(x) end
; Function Signature: var"#5"(Float64)
define double @"julia_#5_0"(double %"x::Float64") local_unnamed_addr #0 {
top:
  ret double 0.000000e+00
}
```

Developed with claude:

---

Use `table_unpack(N)` in `exp_impl_fast` for Float64 instead of a raw `@inbounds J_TABLE[N&255 + 1]` indexing. The compiler cannot prove the `@inbounds` access is safe, causing the function to be inferred as `!n` (not nothrow) and `!u` (not noundef), unlike its non-fast counterpart `exp_impl` which already uses `table_unpack` (annotated with `@assume_effects :nothrow`). This affected `exp_fast`, `exp2_fast`, and `exp10_fast` for Float64 since they all go through `exp_impl_fast`.