### PR TITLE
math: fix spurious !nothrow effects on asinh, frexp, hypot, and unsafe_trunc

### DIFF
--- a/Compiler/test/irpasses.jl
+++ b/Compiler/test/irpasses.jl
@@ -1408,6 +1408,11 @@ end
 @testset "hypot($T, $T) removable if unused" for T in (Float16, Float32)
     @test Compiler.is_removable_if_unused(Base.infer_effects(hypot, (T, T)))
 end
+# unsafe_trunc(::Type{<:Integer}, ::Float64) is nothrow: the bit-shift result fits
+# within `Int` so `% Int` rather than `Int(...)` keeps the conversion non-throwing.
+@testset "unsafe_trunc($T, Float64) removable if unused" for T in (UInt128, Int128)
+    @test Compiler.is_removable_if_unused(Base.infer_effects(unsafe_trunc, (Type{T}, Float64)))
+end
 @test !Compiler.is_inlineable(code_typed1(exp, (Float64,)))
 @test fully_eliminated(; retval=Core.Argument(2)) do x::Float64
     return Core.ifelse(true, x, exp(x))

--- a/Compiler/test/irpasses.jl
+++ b/Compiler/test/irpasses.jl
@@ -1386,7 +1386,28 @@ end
 @test foo(true, 1) == 2
 
 # ifelse folding
-@test Compiler.is_removable_if_unused(Base.infer_effects(exp, (Float64,)))
+# Math functions that should be removable if unused (nothrow + effect-free).
+# Test all IEEEFloat types for single-argument functions.
+@testset "math functions removable if unused: $f($T)" for (f, T) in Iterators.product(
+    (exp, exp2, exp10, expm1, sinh, cosh, tanh, cbrt, frexp, modf, significand, rad2deg, deg2rad),
+    (Float16, Float32, Float64),
+)
+    @test Compiler.is_removable_if_unused(Base.infer_effects(f, (T,)))
+end
+# ldexp takes (T, Int); test all float types
+@testset "ldexp($T, Int) removable if unused" for T in (Float16, Float32, Float64)
+    @test Compiler.is_removable_if_unused(Base.infer_effects(ldexp, (T, Int)))
+end
+# asinh is nothrow for Float32/Float64: non-finite inputs handled early; all log/log1p
+# calls receive positive arguments. Float16 promotes via a separate method.
+@testset "asinh($T) removable if unused" for T in (Float32, Float64)
+    @test Compiler.is_removable_if_unused(Base.infer_effects(asinh, (T,)))
+end
+# hypot(Float32/Float16): _hypot uses sqrt(muladd(x,x,y*y)); argument is always ≥ 0.
+# hypot(Float64) uses a more complex algorithm and is intentionally excluded here.
+@testset "hypot($T, $T) removable if unused" for T in (Float16, Float32)
+    @test Compiler.is_removable_if_unused(Base.infer_effects(hypot, (T, T)))
+end
 @test !Compiler.is_inlineable(code_typed1(exp, (Float64,)))
 @test fully_eliminated(; retval=Core.Argument(2)) do x::Float64
     return Core.ifelse(true, x, exp(x))

--- a/base/float.jl
+++ b/base/float.jl
@@ -425,7 +425,9 @@ end
 
 function unsafe_trunc(::Type{UInt128}, x::Float64)
     xu = reinterpret(UInt64,x)
-    k = Int(xu >> 52) & 0x07ff - 1075
+    # use `% Int` instead of `Int(...)` to preserve `:nothrow` (the shifted value
+    # fits in 11 bits, but `Int(::UInt64)` would otherwise add a bounds check)
+    k = (xu >> 52) % Int & 0x07ff - 1075
     xu = (xu & 0x000f_ffff_ffff_ffff) | 0x0010_0000_0000_0000
     if k <= 0
         UInt128(xu >> -k)

--- a/base/float.jl
+++ b/base/float.jl
@@ -427,7 +427,7 @@ function unsafe_trunc(::Type{UInt128}, x::Float64)
     xu = reinterpret(UInt64,x)
     # use `% Int` instead of `Int(...)` to preserve `:nothrow` (the shifted value
     # fits in 11 bits, but `Int(::UInt64)` would otherwise add a bounds check)
-    k = (xu >> 52) % Int & 0x07ff - 1075
+    k = ((xu >> 52) % Int) & 0x07ff - 1075
     xu = (xu & 0x000f_ffff_ffff_ffff) | 0x0010_0000_0000_0000
     if k <= 0
         UInt128(xu >> -k)

--- a/base/math.jl
+++ b/base/math.jl
@@ -813,14 +813,16 @@ function _hypot(x, y)
     end
     return h*scale*oneunit(axu)
 end
-@inline function _hypot(x::Float32, y::Float32)
+# @assume_effects :nothrow: isinf guards handle Inf inputs; muladd(x,x,y*y) is always ≥ 0
+# so the sqrt call never throws.
+@assume_effects :nothrow @inline function _hypot(x::Float32, y::Float32)
     if isinf(x) || isinf(y)
         return Inf32
     end
     _x, _y = Float64(x), Float64(y)
     return Float32(sqrt(muladd(_x, _x, _y*_y)))
 end
-@inline function _hypot(x::Float16, y::Float16)
+@assume_effects :nothrow @inline function _hypot(x::Float16, y::Float16)
     if isinf(x) || isinf(y)
         return Inf16
     end
@@ -1079,7 +1081,9 @@ function frexp(x::T) where T<:IEEEFloat
     xu = reinterpret(Unsigned, x)
     xs = xu & ~sign_mask(T)
     xs >= exponent_mask(T) && return x, 0 # NaN or Inf
-    k = Int(xs >> significand_bits(T))
+    # Use rem instead of Int to avoid a spurious nothrow violation: after masking the sign
+    # bit, xs >> significand_bits(T) is at most 2^exponent_bits(T)-1, which always fits in Int.
+    k = rem(xs >> significand_bits(T), Int)
     if k == 0 # x is subnormal
         xs == 0 && return x, 0 # +-0
         m = leading_zeros(xs) - exponent_bits(T)

--- a/base/math.jl
+++ b/base/math.jl
@@ -968,7 +968,9 @@ function exponent(x::T) where T<:IEEEFloat
     @noinline throw2(x) = throw(DomainError(x, "Cannot be ±0.0."))
     xs = reinterpret(Unsigned, x) & ~sign_mask(T)
     xs >= exponent_mask(T) && throw1(x)
-    k = Int(xs >> significand_bits(T))
+    # use `% Int` instead of `Int(...)` to preserve `:nothrow` (the shifted value
+    # always fits in `exponent_bits(T)` bits, well below `typemax(Int)`)
+    k = (xs >> significand_bits(T)) % Int
     if k == 0 # x is subnormal
         xs == 0 && throw2(x)
         m = leading_zeros(xs) - exponent_bits(T)

--- a/base/math.jl
+++ b/base/math.jl
@@ -1083,9 +1083,9 @@ function frexp(x::T) where T<:IEEEFloat
     xu = reinterpret(Unsigned, x)
     xs = xu & ~sign_mask(T)
     xs >= exponent_mask(T) && return x, 0 # NaN or Inf
-    # Use rem instead of Int to avoid a spurious nothrow violation: after masking the sign
-    # bit, xs >> significand_bits(T) is at most 2^exponent_bits(T)-1, which always fits in Int.
-    k = rem(xs >> significand_bits(T), Int)
+    # use `% Int` instead of `Int(...)` to preserve `:nothrow` (after masking the sign
+    # bit, xs >> significand_bits(T) is at most 2^exponent_bits(T)-1, which always fits in Int)
+    k = (xs >> significand_bits(T)) % Int
     if k == 0 # x is subnormal
         xs == 0 && return x, 0 # +-0
         m = leading_zeros(xs) - exponent_bits(T)

--- a/base/special/hyperbolic.jl
+++ b/base/special/hyperbolic.jl
@@ -162,7 +162,7 @@ end
 AH_LN2(::Type{Float64}) = 6.93147180559945286227e-01
 AH_LN2(::Type{Float32}) = 6.9314718246f-01
 # asinh methods
-function asinh(x::T) where T <: Union{Float32, Float64}
+@assume_effects :nothrow function asinh(x::T) where T <: Union{Float32, Float64}
     # Method
     # mathematically asinh(x) = sign(x)*log(|x| + sqrt(x*x + 1))
     # is the principle value of the inverse hyperbolic sine
@@ -175,6 +175,8 @@ function asinh(x::T) where T <: Union{Float32, Float64}
     #        return sign(x)*log(2|x|+1/(|x|+sqrt(x*x+1)))
     #    d) |x| >= 2^28
     #        return sign(x)*(log(x)+ln2))
+    # Non-finite inputs are handled below; all log/log1p calls receive positive
+    # arguments, so this function never throws for Float32/Float64.
     if !isfinite(x)
         return x
     end

--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -274,11 +274,11 @@ end
         # Step 3
         xu = reinterpret(UInt64,x)
         # `% Int` rather than `Int(...)` to preserve `:nothrow` (the shifted value fits in 11 bits)
-        m = (xu >> 52) % Int & 0x07ff
+        m = ((xu >> 52) % Int) & 0x07ff
         if m == 0 # x is subnormal
             x *= 1.8014398509481984e16 # 0x1p54, normalise significand
             xu = reinterpret(UInt64,x)
-            m = (xu >> 52) % Int & 0x07ff - 54
+            m = ((xu >> 52) % Int) & 0x07ff - 54
         end
         m -= 1023
         y = reinterpret(Float64,(xu & 0x000f_ffff_ffff_ffff) | 0x3ff0_0000_0000_0000)
@@ -349,7 +349,7 @@ function log1p(x::Float64)
         zu = reinterpret(UInt64,z)
         s = reinterpret(Float64,0x7fe0_0000_0000_0000 - (zu & 0xfff0_0000_0000_0000)) # 2^-m
         # `% Int` rather than `Int(...)` to preserve `:nothrow` (the shifted value fits in 11 bits)
-        m = (zu >> 52) % Int & 0x07ff - 1023 # z cannot be subnormal
+        m = ((zu >> 52) % Int) & 0x07ff - 1023 # z cannot be subnormal
         c = m > 0 ? 1.0-(z-x) : x-(z-1.0) # 1+x = z+c exactly
         y = reinterpret(Float64,(zu & 0x000f_ffff_ffff_ffff) | 0x3ff0_0000_0000_0000)
 

--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -273,11 +273,12 @@ end
 
         # Step 3
         xu = reinterpret(UInt64,x)
-        m = Int(xu >> 52) & 0x07ff
+        # `% Int` rather than `Int(...)` to preserve `:nothrow` (the shifted value fits in 11 bits)
+        m = (xu >> 52) % Int & 0x07ff
         if m == 0 # x is subnormal
             x *= 1.8014398509481984e16 # 0x1p54, normalise significand
             xu = reinterpret(UInt64,x)
-            m = Int(xu >> 52) & 0x07ff - 54
+            m = (xu >> 52) % Int & 0x07ff - 54
         end
         m -= 1023
         y = reinterpret(Float64,(xu & 0x000f_ffff_ffff_ffff) | 0x3ff0_0000_0000_0000)
@@ -347,7 +348,8 @@ function log1p(x::Float64)
         z = 1.0 + x
         zu = reinterpret(UInt64,z)
         s = reinterpret(Float64,0x7fe0_0000_0000_0000 - (zu & 0xfff0_0000_0000_0000)) # 2^-m
-        m = Int(zu >> 52) & 0x07ff - 1023 # z cannot be subnormal
+        # `% Int` rather than `Int(...)` to preserve `:nothrow` (the shifted value fits in 11 bits)
+        m = (zu >> 52) % Int & 0x07ff - 1023 # z cannot be subnormal
         c = m > 0 ? 1.0-(z-x) : x-(z-1.0) # 1+x = z+c exactly
         y = reinterpret(Float64,(zu & 0x000f_ffff_ffff_ffff) | 0x3ff0_0000_0000_0000)
 


### PR DESCRIPTION
Looking for more opportunities to tighten up effects motivated by https://github.com/JuliaLang/julia/pull/61394 and similar to https://github.com/JuliaLang/julia/pull/61615

Developed with claude:

---

Several math functions were inferred as potentially throwing even though they never do for IEEEFloat inputs:

- `asinh(Float32/Float64)`: the function guards all non-finite inputs at the top (`!isfinite(x) && return x`), then calls `log`/`log1p` with provably positive arguments. The compiler conservatively marks it `!nothrow` because `log` itself is `!nothrow`. Fixed with `@assume_effects :nothrow`.

- `frexp(Float64)`: used `Int(xs >> significand_bits(T))` where the value after masking and shifting is always ≤ 2047, but `Int(::UInt64)` is `!nothrow` (can overflow). Changed to `rem(..., Int)`, matching the pattern already used in `_exponent_finite_nonzero`.

- `_hypot(Float32/Float16)`: calls `sqrt(muladd(x,x,y*y))` where the argument is always ≥ 0 (so sqrt never throws), but the compiler can't see through `sqrt`'s `!nothrow` signature. The `isinf` guards handle all Inf inputs. Fixed with `@assume_effects :nothrow`.

- `unsafe_trunc(::Type{UInt128}, ::Float64)` (cascading to the `Int128` variant): used `Int(xu >> 52)` for the same reason as `frexp`. Replaced with `(xu >> 52) % Int`, which is semantically identical when the value fits (it always does — at most 11 bits) and preserves `:nothrow`.

The same `Int(::UInt64) → % Int` cleanup is also applied in `exponent`, `_log(::Float64)`, and `log1p(::Float64)`. These functions still infer as `!nothrow` because of explicit domain-error branches, so the change is preparatory and does not flip their top-level effect.

All four `asinh`/`frexp`/`hypot`/`unsafe_trunc` functions are now `(+c,+e,+n,+t,+s,+m,+u,+o,+r)` (removable if unused), enabling DCE of calls to these functions with unused results.