### PR TITLE
[JuliaLowering] Mark machinery references as `synthetic_ref`

### DIFF
--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -418,6 +418,51 @@ end
 
 name_hint(name) = CompileHints(:name_hint, name)
 
+"""
+    synthetic_ref(ref::SyntaxTree) -> SyntaxTree
+
+Return a copy of `ref` tagged with `:synthetic_ref => true` metadata, marking
+this `K"Identifier"` (or post-resolution `K"BindingId"`) as a reference
+emitted by the lowering pipeline rather than something the user wrote in the
+source.
+
+# Why this exists
+
+Lowering threads a user-visible binding through generated scaffolding, which
+produces many `BindingId` references that don't line up with anything the
+user wrote. Examples:
+
+- `[K"method" mtable …]` / `[K"function_type" name]` / `[K"removable" …]`
+  for function definitions
+- `_setsuper!`, `_typebody!`, `_equiv_typedef`, `_defaultctors` calls
+  for `struct` / `abstract type` / `primitive type` definitions
+- trailing "return-value" occurrences emitted by method-less
+  `function foo end`, keyword-function desugaring, `[K"=" name …]`
+  shims, and similar constructs
+
+Downstream analyzers that walk the lowered tree to collect binding uses —
+e.g. LSP-style find-references, rename, unused-binding or unused-import
+diagnostics in JETLS — should skip them.
+
+# How to use
+
+- On the emitter side: when constructing a `BindingId` reference that is
+  not user-written, wrap it with `synthetic_ref`. The metadata survives
+  `resolve_scopes`' `K"Identifier" → K"BindingId"` conversion (see
+  scope_analysis.jl).
+- On the consumer side: when walking stage-3 (post-scope-resolution)
+  trees and collecting `K"BindingId"` uses, read the marker with
+  `getmeta(ref, :synthetic_ref, false)` and filter out any reference for
+  which it is `true`.
+
+# Difference from `:is_internal`
+
+`setmeta(binding_decl, :is_internal, true)` is set for entire binding.
+`:synthetic_ref` is finer-grained and applies _per reference_, leaving
+the binding itself visible.
+"""
+synthetic_ref(ref::SyntaxTree) = setmeta(ref, :synthetic_ref, true)
+
 #-------------------------------------------------------------------------------
 # Predicates and accessors working on expression trees
 

--- a/JuliaLowering/src/closure_conversion.jl
+++ b/JuliaLowering/src/closure_conversion.jl
@@ -466,7 +466,7 @@ function _convert_closures(ctx::ClosureConversionCtx, ex)
             # Single-arg K"method" has the side effect of creating a global
             # binding for `func_name` if it doesn't exist.
             @ast ctx ex [K"block"
-                [K"method" func_name]
+                [K"method" synthetic_ref(func_name)]
                 ::K"TOMBSTONE" # <- function_decl should not be used in value position
             ]
         end

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2425,7 +2425,7 @@ function method_def_expr(ctx, src, mtable, sparams, argl, body,
             [K"call" "svec"::K"core" mapindex(sparams, 1)...]
             ::K"SourceLocation"(src[1])]
         [K"method"
-            mtable
+            synthetic_ref(mtable)
             method_metadata
             [K"lambda"(body, is_toplevel_thunk=false, toplevel_pure=false)
                 [K"block" mapindex(argl, 1)...]
@@ -2461,7 +2461,7 @@ function generated_method_defs(ctx, src, mtable, sparams, argl, body, rett)
 
     gen_mdef = let arg1_name = newsym(ctx, argl[1], "#self#"),
          gen_argl = SyntaxList(
-            @ast(ctx, src, [K"::" arg1_name [K"function_type" gen_name]]),
+            @ast(ctx, src, [K"::" arg1_name [K"function_type" synthetic_ref(gen_name)]]),
             @ast(ctx, src, [K"::"
                 # TODO: correct scope layer?
                 "__context__"::K"Identifier"(scope_layer=get(mtable, :scope_layer, 1))
@@ -2543,16 +2543,21 @@ function optional_positional_defs(ctx, src, mtable, sparams, argl, body, rett)
     methods = SyntaxList(ctx.graph)
     for i in eachindex(opt)
         @jl_assert i == length(passed)-length(req)+1 src
+        # Forwards into the self-recursive call are machinery, but
+        # `opt_defaults[i]` / `opt_defaults[end]` are user-written and must
+        # stay unwrapped (they can contain genuine user references, e.g. `y=x`
+        # in `f(x, y=x)`).
+        forwarded_names = mapsyntax(synthetic_ref, mapindex(passed, 1))
         wrapper_body = if all((<)(i), deps[i+1:end])
             # fill-all-defaults case.  note that the final default may be a
             # splat, and doesn't have further args referring to it by name, so
             # we put it directly in the call (see #50563 for some notes)
             @ast ctx src [K"block"
                 make_assigns(ctx, opt_names[i:end-1], opt_defaults[i:end-1])...
-                [K"call" mapindex(passed, 1)... opt_names[i:end-1]... opt_defaults[end]]]
+                [K"call" forwarded_names... mapsyntax(synthetic_ref, opt_names[i:end-1])... opt_defaults[end]]]
         else
             @ast ctx src [K"block"
-                [K"call" mapindex(passed, 1)... opt_defaults[i]]]
+                [K"call" forwarded_names... opt_defaults[i]]]
         end
         push!(methods, method_def_expr(
             ctx, src, mtable, used_typevars(passed, sparams),
@@ -2617,6 +2622,7 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
         pos_va && (l[end] = @ast ctx l[end] [K"..." l[end]])
         l
     end
+    synth_forward_pargl = mapsyntax(synthetic_ref, forward_pargl)
     (kw_decls, kw_names, kw_syms, kw_defaults, restkw) = expand_kw_args(ctx, kws)
     ordered_defaults = any(val->contains_identifier(val, kw_names), kw_defaults)
     positional_sparams = used_typevars(pargl, sparams)
@@ -2628,7 +2634,7 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
     # (1) Body method.  This contains the actual function body, and requires
     # every possible default to be filled.  `rett` is only passed here since it
     # can reference any argument.
-    mdefs1 = let arg1 = @ast ctx m1_name [K"::" m1_name [K"function_type" m1_name]]
+    mdefs1 = let arg1 = @ast ctx m1_name [K"::" m1_name [K"function_type" synthetic_ref(m1_name)]]
         nkw = @ast ctx kws [K"meta" "nkw"::K"Symbol" numchildren(kws)::K"Value"]
         method_def_expr(
             ctx, src, m1_name, sparams,
@@ -2642,10 +2648,10 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
             @ast ctx restkw[1] [K"call"
                 "pairs"::K"top" [K"call" "NamedTuple"::K"core"]]
         body2 = if !ordered_defaults
-            @ast ctx src [K"call" m1_name kw_defaults... rkw forward_pargl...]
+            @ast ctx src [K"call" synthetic_ref(m1_name) kw_defaults... rkw synth_forward_pargl...]
         else
             scope_nest(ctx, make_assigns(ctx, kw_names, kw_defaults),
-                @ast ctx src [K"call" m1_name kw_names... rkw forward_pargl...])
+                @ast ctx src [K"call" synthetic_ref(m1_name) mapsyntax(synthetic_ref, kw_names)... rkw synth_forward_pargl...])
         end
         method_def_expr(
             ctx, src, mtable, positional_sparams, pargl,
@@ -2709,13 +2715,13 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
                         [K"call" "keys"::K"top" arg2_name]
                         [K"tuple" kw_syms...]]]
                 (::K"nothing")
-                [K"call" "kwerr"::K"top" arg2_name forward_pargl...]]
+                [K"call" "kwerr"::K"top" synthetic_ref(arg2_name) synth_forward_pargl...]]
         end
         final_call = @ast ctx kws [K"call"
-            m1_name
+            synthetic_ref(m1_name)
             kw_temps...
             isempty(restkw) ? nothing : excess_kw
-            forward_pargl...]
+            synth_forward_pargl...]
         kwcall_body = if use_ssa_kw_temps
             for n in kw_names
                 # If not using slots for the keyword argument values, still
@@ -2747,7 +2753,7 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett, p
         [K"method_defs" m1_name mdefs1]
         [K"method_defs" mtable mdefs2]
         [K"method_defs" mtable mdefs3]
-        mtable
+        synthetic_ref(mtable)
     ]
 end
 
@@ -2788,7 +2794,7 @@ function expand_function_arg1(ctx, arg)
     atype = @stm arg begin
         [K"::" t] -> t
         [K"::" _ t] -> t
-        _ -> @ast ctx arg [K"function_type" arg]
+        _ -> @ast ctx arg [K"function_type" synthetic_ref(arg)]
     end
     # first arg to Expr(:method)
     mt = @stm arg begin
@@ -2875,7 +2881,7 @@ function expand_function_def(ctx, src, raw_args, wheres, body, rett)
             [K"method_defs" mtable [K"block"
                 method_def_expr(ctx, src, mtable, sparams, argl, body, rett)]]
                 # TODO: overlay should return the method
-                [K"removable" mtable]]
+                [K"removable" synthetic_ref(mtable)]]
     end
 end
 
@@ -3125,7 +3131,7 @@ function expand_abstract_or_primitive_type(ctx, ex)
                 ]
                 [K"=" name newtype_var]
                 [K"call" "_setsuper!"::K"core" newtype_var supertype]
-                [K"call" "_typebody!"::K"core" false::K"Bool" name]
+                [K"call" "_typebody!"::K"core" false::K"Bool" synthetic_ref(name)]
             ]
         ]
         [K"assert" "toplevel_only"::K"Symbol" [K"inert_syntaxtree" ex] ]
@@ -3137,7 +3143,7 @@ function expand_abstract_or_primitive_type(ctx, ex)
                    ctx.mod::K"Value"
                    name=>K"Symbol"
                    false::K"Bool"]
-                [K"call" "_equiv_typedef"::K"core" name newtype_var]
+                [K"call" "_equiv_typedef"::K"core" synthetic_ref(name) newtype_var]
             ]
             nothing_(ctx, ex)
             [K"constdecl" name newtype_var]
@@ -3281,7 +3287,7 @@ function rewrite_ctor_sig(ctx, sig, tname, global_tname, struct_typevars, wheres
                 sig2 = @ast ctx sig [K"call"
                     [K"::" ctor_self
                         [K"curly" "Type"::K"core"
-                         [K"curly" global_tname curlyargs...]]]
+                         [K"curly" synthetic_ref(global_tname) curlyargs...]]]
                     args...]
             end
         end
@@ -3290,7 +3296,7 @@ function rewrite_ctor_sig(ctx, sig, tname, global_tname, struct_typevars, wheres
                 @jl_assert is_leaf(name) (sig, "didn't find ctor name in sig")
                 ctor_self = newsym(ctx, sig, "#ctor-self#")
                 sig2 = @ast ctx sig [K"call"
-                    [K"::" ctor_self [K"curly" "Type"::K"core" global_tname]]
+                    [K"::" ctor_self [K"curly" "Type"::K"core" synthetic_ref(global_tname)]]
                     args...]
             end
         end
@@ -3384,14 +3390,14 @@ function _rewrite_ctor_new_calls(ctx, ex, global_struct_name, ctor_sparams,
         elseif n_type_nonsplat > length(struct_typevars)
             throw(LoweringError(ex[1], "too many type parameters specified in `new{...}`"))
         end
-        @ast ctx ex[1] [K"curly" global_struct_name new_type_params...]
+        @ast ctx ex[1] [K"curly" synthetic_ref(global_struct_name) new_type_params...]
     elseif !isnothing(ctor_self)
         # new(...) in constructors
         ctor_self
     else
         # new(...) inside non-constructor inner functions
         if isempty(struct_typevars)
-            global_struct_name
+            synthetic_ref(global_struct_name)
         else
             throw(LoweringError(ex[1], "too few type parameters specified in `new`"))
         end
@@ -3652,19 +3658,21 @@ function expand_typegroup_def(ctx, ex)
         ])
     end
 
+    synthetic_struct_refs = mapsyntax(synthetic_ref, struct_names)
+
     # 2d. Call resolve_typegroup
     push!(stmts, @ast ctx ex [K"="
         [K"tuple" struct_names...]
         [K"call" "resolve_typegroup"::K"core"
             ctx.mod::K"Value"
-            [K"call" "svec"::K"core" struct_names...]
+            [K"call" "svec"::K"core" synthetic_struct_refs...]
             [K"call" "svec"::K"core" info_vars...]
         ]
     ])
 
     # 2e. Bind to global constants
     for i in 1:n
-        push!(stmts, @ast ctx entries[i].sdef [K"constdecl" global_names[i] struct_names[i]])
+        push!(stmts, @ast ctx entries[i].sdef [K"constdecl" global_names[i] synthetic_struct_refs[i]])
     end
 
     # 2f. latestworld
@@ -3679,7 +3687,7 @@ function expand_typegroup_def(ctx, ex)
         if isempty(e.inner_defs)
             push!(fdef_stmts, @ast ctx e.sdef [K"call"
                 "_defaultctors"::K"top"
-                global_names[i]
+                synthetic_ref(global_names[i])
                 ::K"SourceLocation"(e.sdef)
             ])
         else
@@ -3763,7 +3771,7 @@ function expand_struct_def(ctx, ex, docs)
     global_struct_name = adopt_scope(struct_name, layer)
     if !isempty(typevar_names)
         # Generate expression like `prev_struct.body.body.parameters`
-        prev_typevars = global_struct_name
+        prev_typevars = synthetic_ref(global_struct_name)
         for _ in 1:length(typevar_names)
             prev_typevars = @ast ctx type_sig [K"." prev_typevars "body"::K"Symbol"]
         end
@@ -3849,9 +3857,9 @@ function expand_struct_def(ctx, ex, docs)
                               ctx.mod::K"Value"
                               struct_name=>K"Symbol"
                               false::K"Bool"]
-                             [K"call" "_equiv_typedef"::K"core" global_struct_name newtype_var]
+                             [K"call" "_equiv_typedef"::K"core" synthetic_ref(global_struct_name) newtype_var]
                        ]]
-                [K"=" prev [K"if" hasprev global_struct_name false::K"Bool"]]
+                [K"=" prev [K"if" hasprev synthetic_ref(global_struct_name) false::K"Bool"]]
                 [K"if" hasprev
                    [K"block"
                     # if this is compatible with an old definition, use the old parameters, but the
@@ -3884,7 +3892,7 @@ function expand_struct_def(ctx, ex, docs)
             [K"block"
                 [K"call"
                     "_defaultctors"::K"top"
-                    global_struct_name
+                    synthetic_ref(global_struct_name)
                     ::K"SourceLocation"(ex)
                 ]
                 (::K"latestworld")
@@ -4252,7 +4260,7 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
         expand_forms_2(ctx, expand_generator(ctx, ex))
     elseif k == K"function"
         if numchildren(ex) == 1
-            return @ast ctx ex [K"block" [K"function_decl" ex[1]] ex[1]]
+            return @ast ctx ex [K"block" [K"function_decl" ex[1]] synthetic_ref(ex[1])]
         end
         sig, wheres = flatten_wheres(ex[1])
         name, args, rett = @stm sig begin

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -365,7 +365,14 @@ function _resolve_scopes(ctx, ex::SyntaxTree,
         if getmeta(ex, :nospecialize, false) && b.kind === :argument
             b.is_nospecialize = true
         end
-        newleaf(ctx, ex, K"BindingId", b.id)
+        # Propagate the `:synthetic_ref` machinery-reference marker from the
+        # source Identifier so consumers walking the post-scope-resolution
+        # tree can observe it on the resulting BindingId.
+        new_leaf = newleaf(ctx, ex, K"BindingId", b.id)
+        if getmeta(ex, :synthetic_ref, false)
+            setmeta!(new_leaf, :synthetic_ref, true)
+        end
+        new_leaf
     elseif k === K"BindingId"
         ex
     elseif k == K"softscope"

--- a/JuliaLowering/test/runtests.jl
+++ b/JuliaLowering/test/runtests.jl
@@ -27,6 +27,7 @@ include("utils.jl")
     @testset "modules" include("modules.jl")
     @testset "quoting" include("quoting.jl")
     @testset "scopes" include("scopes.jl")
+    @testset "synthetic_refs" include("synthetic_refs.jl")
     @testset "typedefs" include("typedefs.jl")
 
     @testset "compat" include("compat.jl")

--- a/JuliaLowering/test/synthetic_refs.jl
+++ b/JuliaLowering/test/synthetic_refs.jl
@@ -1,0 +1,186 @@
+# Regression coverage for `synthetic_ref` metadata (see `synthetic_ref` in `src/ast.jl`).
+# The lowering pipeline emits many internal references to user-visible bindings.
+# Each such reference must be tagged with `synthetic_ref(...)` at its emit site so consumers
+# walking the resolved tree can distinguish machinery refs from real user-written uses.
+# These tests exercise a minimal "pretend we are an LSP-style occurrence analyzer" walker
+# and assert that each of the known machinery constructs classifies correctly.
+module synthetic_refs
+
+using Test, JuliaSyntax, JuliaLowering
+using .JuliaLowering: VariableAnalysisContext, BindingInfo,
+    binding_ex, expand_forms_1, expand_forms_2, get_binding, getmeta, resolve_scopes
+using .JuliaSyntax: @K_str, Kind, SyntaxTree, byte_range, children, kind, numchildren, parsestmt
+
+function lower_to_st3(code::AbstractString; version::VersionNumber=VERSION)
+    mod = Module(:SyntheticRefTestMod)
+    st0 = parsestmt(SyntaxTree, code; version)
+    ctx1, st1 = expand_forms_1(mod, st0, false, Base.get_world_counter())
+    ctx2, st2 = expand_forms_2(ctx1, st1)
+    ctx3, st3 = resolve_scopes(ctx2, st2)
+    return (ctx3, st3)
+end
+
+# Return every `K"BindingId"` ref for `name` as
+# `(:decl | :def | :use, synthetic_ref::Bool, byte_range)`, following
+# the classification downstream LSP-style occurrence analyzers use:
+# - `K"local"` / `K"global"` / `K"function_decl"` child → :decl
+# - `K"="` LHS / `K"method_defs"` / `K"constdecl"` first child → :def
+# - `K"lambda"`'s arg / sparam block children → :def
+# - any other `K"BindingId"` → :use
+function classify_binding_id_refs(ctx3::VariableAnalysisContext, st3::SyntaxTree, name::String)
+    out = Tuple{Symbol,Bool,UnitRange{Int}}[]
+    function record_def!(c::SyntaxTree)
+        kind(c) === K"BindingId" || return
+        binfo = get_binding(ctx3, c)
+        binfo.name == name || return
+        sr = getmeta(c, :synthetic_ref, false)::Bool
+        push!(out, (:def, sr, byte_range(c)))
+    end
+    function walk(st::SyntaxTree)
+        k = kind(st)
+        nc = numchildren(st)
+        if (k === K"local" || k === K"global" || k === K"function_decl") && nc ≥ 1
+            c = st[1]
+            if kind(c) === K"BindingId"
+                binfo = get_binding(ctx3, c)
+                if binfo.name == name
+                    sr = getmeta(c, :synthetic_ref, false)::Bool
+                    push!(out, (:decl, sr, byte_range(c)))
+                end
+            end
+            return
+        end
+        if (k === K"=" || k === K"method_defs" || k === K"constdecl") && nc ≥ 1
+            record_def!(st[1])
+            for i = 2:nc
+                walk(st[i])
+            end
+            return
+        end
+        if k === K"lambda" && nc ≥ 2
+            # child 1 = arg block; child 2 = sparam block (direct children are decls)
+            for i in 1:numchildren(st[1]); record_def!(st[1][i]); end
+            for i in 1:numchildren(st[2]); record_def!(st[2][i]); end
+            for i = 3:nc; walk(st[i]); end
+            return
+        end
+        if k === K"BindingId"
+            binfo = get_binding(ctx3, st)
+            if binfo.name == name
+                sr = getmeta(st, :synthetic_ref, false)::Bool
+                push!(out, (:use, sr, byte_range(st)))
+            end
+            return
+        end
+        for c in children(st)
+            walk(c)
+        end
+    end
+    walk(st3)
+    return out
+end
+
+# Number of `:use` refs a downstream consumer would record (machinery
+# refs tagged `synthetic_ref` are skipped).
+function real_use_count(ctx3, st3, name::String)
+    refs = classify_binding_id_refs(ctx3, st3, name)
+    return count(ref -> ref[1] === :use && !ref[2], refs)
+end
+
+@testset "function definitions" begin
+    for code in ("function foo end",
+                 "foo(x) = x",
+                 "function foo(x)\n    return x\nend",
+                 "foo(x, y=1) = x + y",                                # optional positional
+                 "foo(x; k=1) = x + k",                                # keyword
+                 "foo(x, y=1; k=1) = x + y + k",                       # combined
+                 "foo(x::T) where T = x",                              # where clause
+                 "foo(x)::Int = x",                                    # return-type annotation
+                 "foo(x, y...) = (x, y)",                              # varargs
+                 "@generated function foo(x)\n    return :(x + 1)\nend")
+        ctx3, st3 = lower_to_st3(code)
+        @test real_use_count(ctx3, st3, "foo") == 0
+    end
+end
+
+@testset "macro definitions" begin
+    for code in ("macro foo end",
+                 "macro foo(x); x; end",
+                 "macro foo(x, y); x; end",
+                 "macro foo(args...); args; end")
+        ctx3, st3 = lower_to_st3(code)
+        @test real_use_count(ctx3, st3, "@foo") == 0
+    end
+end
+
+@testset "type definitions" begin
+    for code in ("struct Foo end",
+                 "mutable struct Foo; x::Int; end",
+                 "struct Foo{T}; x::T; end",                           # parametric
+                 "struct Foo; x::Int; Foo(x) = new(x); end",           # inner constructor
+                 "struct Foo{T}; x::T; Foo{T}(x) where T = new{T}(x); end",
+                 "abstract type Foo end",
+                 "abstract type Foo <: Integer end",                   # supertype
+                 "primitive type Foo 8 end")
+        ctx3, st3 = lower_to_st3(code)
+        @test real_use_count(ctx3, st3, "Foo") == 0
+    end
+    @testset "typegroup" begin
+        let (ctx3, st3) = lower_to_st3("""
+                typegroup
+                    struct A
+                        x::Int
+                    end
+                    struct B
+                        y::Int
+                    end
+                end
+                """; version=v"1.14")
+            @test real_use_count(ctx3, st3, "A") == 0
+            @test real_use_count(ctx3, st3, "B") == 0
+        end
+    end
+end
+
+# User-written refs must survive the machinery wrap: self-recursive
+# calls and identifiers inside default expressions stay `:use`.
+@testset "user-written refs preserved alongside machinery wraps" begin
+    # self-recursive call
+    let (ctx3, st3) = lower_to_st3("foo(x) = foo(x - 1)")
+        @test real_use_count(ctx3, st3, "foo") == 1
+    end
+    # self-recursive kwfunc call
+    let (ctx3, st3) = lower_to_st3("""
+            function foo(x; kw=1)
+                return foo(x - 1; kw=kw + 1)
+            end
+            """)
+        @test real_use_count(ctx3, st3, "foo") == 1
+        @test real_use_count(ctx3, st3, "x") == 1
+        @test real_use_count(ctx3, st3, "kw") == 2
+    end
+    # positional dependent default
+    let (ctx3, st3) = lower_to_st3("f(x, y=x) = x + y")
+        @test real_use_count(ctx3, st3, "x") == 2
+        @test real_use_count(ctx3, st3, "y") == 1
+    end
+    # keyword dependent default
+    let (ctx3, st3) = lower_to_st3("function f(a; b=a); b; end")
+        @test real_use_count(ctx3, st3, "a") == 2
+        @test real_use_count(ctx3, st3, "b") == 2
+    end
+    # inner constructor with dependent default
+    let (ctx3, st3) = lower_to_st3(
+            "struct B; v::Int; B(y, z=y) = new(y + z); end")
+        @test real_use_count(ctx3, st3, "y") == 2
+        @test real_use_count(ctx3, st3, "z") == 1
+    end
+    # positional + keyword dependent defaults combined
+    let (ctx3, st3) = lower_to_st3("f(x, y=x; kw=y) = x + y + kw")
+        @test real_use_count(ctx3, st3, "x") == 3
+        @test real_use_count(ctx3, st3, "y") == 3
+        @test real_use_count(ctx3, st3, "kw") == 2
+    end
+end
+
+end # module synthetic_refs


### PR DESCRIPTION
Many `K"BindingId"` nodes in the lowered tree are internal scaffolding — references to user-visible bindings emitted by lowering inside `K"method"`, `K"function_type"`, `_typebody!` / `_equiv_typedef` / `_defaultctors` / `resolve_typegroup` calls, trailing "return value" shims, etc. — rather than user-written uses.

This commit adds a per-reference `:synthetic_ref` metadata flag and tags every such machinery reference with it at its emit site, so downstream analyzers walking the lowered tree can distinguish machinery references from user-written uses by a single metadata check, without inspecting the surrounding AST shape.

The flag is admittedly not information JL needs for its core purpose of lowering-for-execution. It is intended for post-lowering analyzers (LSP-style find-references, rename, unused-binding diagnostics) — for instance, JETLS's "unused internal global binding" diagnostic relies on accurately ignoring lowering-emitted shim uses (e.g. the `_typebody!` self-ref of a struct definition) so that a binding whose only "uses" are machinery is correctly reported as unused.

The rationale for exposing this on the JL side rather than on each consumer is that the alternative — AST pattern matching on the lowered shape, in the style of Revise / LoweredCodeUtils — is fragile against lowering refactors and hard to get right in corner cases (kwfunc expansion, type redef shims, ...). JL is the only place that authoritatively knows what is scaffolding vs. user intent, so placing the classification here is the least-fragile option even though the metadata itself is consumer-facing.

Scope of this commit is deliberately narrow: a per-reference binary flag, nothing more. It does not encode the `:use` / `:def` / `:decl` role of each reference. A broader alternative exists — extending `synthetic_ref` (or replacing it with a richer per-reference classification) so that JL marks every reference with its role, letting downstream consumers walk the AST naively without any role-based pattern matching. That pushes substantially more maintenance onto JL contributors: a role classification decision at every emit site rather than a single binary judgment. The current AST-pattern-match-based approach in downstream consumers (a minimal form lives in `test/synthetic_refs.jl`) works well enough today, so the broader extension is left as future work. If taken up later, the natural home would more likely be a first-class occurrence-classification API exposed by JL rather than yet more per-reference metadata.

This commit does transfer a some ongoing cost onto JL: every new emit site that produces a machinery reference must wrap it with `synthetic_ref`, or downstream consumers will treat it as a user-written use. To keep that cost self-contained within JL (regressions surface here rather than only in downstream consumers), `test/synthetic_refs.jl` asserts the property with a minimal LSP-style occurrence walker. A dropped wrap in a future lowering refactor fails there directly.

Implementation: `synthetic_ref(ref::SyntaxTree)` is applied at each machinery emit site (function / macro / type definitions, typegroup struct-name aliases threaded into `resolve_typegroup`, per-type `constdecl` RHS, etc.). `scope_analysis.jl` propagates the flag through the `Identifier → BindingId` conversion so it survives on the stage-3 tree. Orthogonal to `:is_internal` (which hides the entire binding); `:synthetic_ref` is per-reference. Not consumed by JL itself; purely advisory for external tools.

---

To see how this change improves the analysis implementation on the downstream consumer side (JETLS), please take a look at https://github.com/aviatesk/JETLS.jl/pull/646. A lot of heuristic code is removed, and the tests added there confirm the improved accuracy of the analysis that this change enables.