### PR TITLE
strings: assert nothrow effects on Char and String predicates

### DIFF
--- a/base/char.jl
+++ b/base/char.jl
@@ -171,6 +171,27 @@ isoverlong(c::AbstractChar) = false
 end
 
 """
+    Base.unsafe_codepoint(c::AbstractChar)::UInt32
+
+Like [`codepoint(c)`](@ref), but assumes `!`[`Base.ismalformed(c)`](@ref): for
+`Char`, the result is unspecified when `c` is malformed. Intended as a low-level
+helper for code that has already verified well-formedness, so that the compiler
+can prove the result is `:nothrow`. Prefer `codepoint(c)` otherwise.
+
+For non-`Char` `AbstractChar` subtypes this falls back to `UInt32(c)`.
+"""
+unsafe_codepoint(c::AbstractChar) = UInt32(c)::UInt32
+@constprop :aggressive @assume_effects :nothrow :foldable function unsafe_codepoint(c::Char)
+    u = bitcast(UInt32, c)
+    u < 0x80000000 && return u >> 24
+    l1 = leading_ones(u)
+    t0 = trailing_zeros(u) & 56
+    u &= 0xffffffff >> l1
+    u >>= t0
+    return ((u & 0x0000007f) >> 0) | ((u & 0x00007f00) >> 2) | ((u & 0x007f0000) >> 4) | ((u & 0x7f000000) >> 6)
+end
+
+"""
     decode_overlong(c::AbstractChar)::Integer
 
 When [`isoverlong(c)`](@ref) is `true`, `decode_overlong(c)` returns

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -643,6 +643,7 @@ Test whether all values in the vector belong to the ASCII character set (0x00 to
 This function is intended to be used by other string implementations that need a fast ASCII check.
 """
 function isascii(cu::AbstractVector{CU}) where {CU <: Integer}
+    # Note that String and SubString{String} assume this is :nothrow :foldable
     chunk_size = 1024
     chunk_threshold =  chunk_size + (chunk_size ÷ 2)
     first = firstindex(cu);   last = lastindex(cu)

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -355,6 +355,12 @@ end
 
 in(c::AbstractChar, s::AbstractString) = (findfirst(isequal(c),s)!==nothing)
 
+# nothrow+foldable: iteration over `String`/`SubString{String}` is total and
+# `Char` equality is total.
+@assume_effects :nothrow :foldable function in(c::Char, s::Union{String,SubString{String}})
+    @invoke in(c::AbstractChar, s::AbstractString)
+end
+
 function _searchindex(s::Union{AbstractString,DenseUInt8OrInt8},
                       t::Union{AbstractString,AbstractChar,Int8,UInt8},
                       i::Integer)

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -655,7 +655,8 @@ end
 
 isvalid(s::String, i::Int) = checkbounds(Bool, s, i) && thisind(s, i) == i
 
-isascii(s::String) = isascii(codeunits(s))
+# nothrow+foldable: codeunits(::String) is total and the byte-wise scan never throws.
+@assume_effects :nothrow :foldable isascii(s::String) = isascii(codeunits(s))
 
 # don't assume effects for general integers since we cannot know their implementation
 @assume_effects :foldable repeat(c::Char, r::BitInteger) = @invoke repeat(c::Char, r::Integer)

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -241,6 +241,10 @@ typemin(::String) = typemin(String)
 
 @propagate_inbounds thisind(s::String, i::Int) = _thisind_str(s, i)
 
+# nothrow: i == ncodeunits(s) always satisfies the bounds check inside _thisind_str
+# (it short-circuits when i == 0, otherwise 1 ≤ i ≤ n).
+@assume_effects :nothrow lastindex(s::String) = thisind(s, ncodeunits(s)::Int)
+
 # s should be String, StringView, or SubString{String}
 @inline function _thisind_str(s, i::Int)
     i == 0 && return 0

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -659,8 +659,8 @@ end
 
 isvalid(s::String, i::Int) = checkbounds(Bool, s, i) && thisind(s, i) == i
 
-# nothrow+foldable: codeunits(::String) is total and the byte-wise scan never throws.
-@assume_effects :nothrow :foldable isascii(s::String) = isascii(codeunits(s))
+# `isascii(::AbstractVector)` reduces to `@inbounds codeunit(::String, ::Int)`, total.
+isascii(s::String) = @assume_effects :nothrow :foldable isascii(codeunits(s))
 
 # don't assume effects for general integers since we cannot know their implementation
 @assume_effects :foldable repeat(c::Char, r::BitInteger) = @invoke repeat(c::Char, r::Integer)

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -81,6 +81,9 @@ end
 ncodeunits(s::SubString) = s.ncodeunits
 codeunit(s::SubString) = codeunit(s.string)::CodeunitType
 length(s::SubString) = length(s.string, s.offset+1, s.offset+s.ncodeunits)
+# nothrow: SubString invariants guarantee 0 ≤ offset and offset+ncodeunits ≤ ncodeunits(string),
+# so the bounds-check inside the 3-arg `length(::String, i, j)` cannot fail.
+@assume_effects :nothrow length(s::SubString{String}) = length(s.string, s.offset+1, s.offset+s.ncodeunits)
 
 function codeunit(s::SubString, i::Integer)
     @boundscheck checkbounds(s, i)
@@ -101,7 +104,8 @@ function getindex(s::SubString, i::Integer)
     @inbounds return getindex(s.string, s.offset + i)
 end
 
-isascii(ss::SubString{String}) = isascii(codeunits(ss))
+# nothrow+foldable: byte-wise scan over a contiguous range of valid UTF-8 codeunits.
+@assume_effects :nothrow :foldable isascii(ss::SubString{String}) = isascii(codeunits(ss))
 
 function isvalid(s::SubString, i::Integer)
     ib = true
@@ -111,6 +115,9 @@ end
 
 @propagate_inbounds thisind(s::SubString{String}, i::Int) = _thisind_str(s, i)
 @propagate_inbounds nextind(s::SubString{String}, i::Int) = _nextind_str(s, i)
+
+# nothrow: i == ncodeunits(s) always satisfies the bounds check inside _thisind_str.
+@assume_effects :nothrow lastindex(s::SubString{String}) = thisind(s, ncodeunits(s)::Int)
 
 parent(s::SubString) = s.string
 parentindices(s::SubString) = (s.offset + 1 : thisind(s.string, s.offset + s.ncodeunits),)

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -104,8 +104,8 @@ function getindex(s::SubString, i::Integer)
     @inbounds return getindex(s.string, s.offset + i)
 end
 
-# nothrow+foldable: byte-wise scan over a contiguous range of valid UTF-8 codeunits.
-@assume_effects :nothrow :foldable isascii(ss::SubString{String}) = isascii(codeunits(ss))
+# `isascii(::AbstractVector)` reduces to `@inbounds codeunit(::SubString{String}, ::Int)`, total.
+isascii(ss::SubString{String}) = @assume_effects :nothrow :foldable isascii(codeunits(ss))
 
 function isvalid(s::SubString, i::Integer)
     ib = true

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -369,8 +369,6 @@ titlecase(c::AnnotatedChar) = AnnotatedChar(titlecase(c.char), annotations(c))
 function category_code(c::AbstractChar)
     !ismalformed(c) ? category_code(UInt32(c)) : Cint(31)
 end
-# Char specialization so inference can prove :nothrow on the concrete type without
-# making the same promise for arbitrary AbstractChar subtypes.
 @assume_effects :nothrow function category_code(c::Char)
     !ismalformed(c) ? category_code(UInt32(c)) : Cint(31)
 end
@@ -392,7 +390,9 @@ end
 end
 
 category_string(c) = category_strings[category_code(c)+1]
-@assume_effects :nothrow category_string(c::Char) = category_strings[category_code(c)+1]
+# category_code(::Char) returns a value in 0:31 and category_strings has 32 entries
+# (asserted at the top of this file), so the index is always in bounds.
+@assume_effects :nothrow category_string(c::Char) = @inbounds category_strings[category_code(c)+1]
 
 isassigned(c) = UTF8PROC_CATEGORY_CN < category_code(c) <= UTF8PROC_CATEGORY_CO
 @assume_effects :nothrow isassigned(c::Char) = UTF8PROC_CATEGORY_CN < category_code(c) <= UTF8PROC_CATEGORY_CO
@@ -421,8 +421,6 @@ false
 """
 islowercase(c::AbstractChar) = ismalformed(c) ? false :
     Bool(@assume_effects :foldable @ccall utf8proc_islower(UInt32(c)::UInt32)::Cint)
-# Char specialization so inference can prove :nothrow on the concrete type without
-# making the same promise for arbitrary AbstractChar subtypes.
 @assume_effects :nothrow islowercase(c::Char) = ismalformed(c) ? false :
     Bool(@assume_effects :foldable @ccall utf8proc_islower(UInt32(c)::UInt32)::Cint)
 
@@ -450,8 +448,6 @@ false
 """
 isuppercase(c::AbstractChar) = ismalformed(c) ? false :
     Bool(@assume_effects :foldable @ccall utf8proc_isupper(UInt32(c)::UInt32)::Cint)
-# Char specialization so inference can prove :nothrow on the concrete type without
-# making the same promise for arbitrary AbstractChar subtypes.
 @assume_effects :nothrow isuppercase(c::Char) = ismalformed(c) ? false :
     Bool(@assume_effects :foldable @ccall utf8proc_isupper(UInt32(c)::UInt32)::Cint)
 

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -127,6 +127,9 @@ const category_strings = [
     "Invalid, too high",
     "Malformed, bad data",
 ]
+# category_code returns a value in 0:31; keep category_strings sized to match so
+# `category_string` remains nothrow.
+@assert length(category_strings) == 32
 
 const UTF8PROC_STABLE    = (1<<1)
 const UTF8PROC_COMPAT    = (1<<2)
@@ -264,7 +267,9 @@ julia> textwidth('⛵')
 """
 textwidth(c::AbstractChar) = textwidth(Char(c)::Char)
 
-function textwidth(c::Char)
+# nothrow+foldable: ismalformed/is_overlong_enc guards return early before the ccall whose
+# result fits in Cint and so the Int conversion cannot throw InexactError.
+@assume_effects :nothrow :foldable function textwidth(c::Char)
     u = reinterpret(UInt32, c)
     b = bswap(u) # from isascii(c)
     b < 0x7f && return Int(b >= 0x20) # ASCII fast path
@@ -286,6 +291,8 @@ julia> textwidth("March")
 ```
 """
 textwidth(s::AbstractString) = mapreduce(textwidth, +, s; init=0)
+# foldable+nothrow: String iteration is total and textwidth(::Char) is nothrow.
+@assume_effects :nothrow :foldable textwidth(s::String) = mapreduce(textwidth, +, s; init=0)
 
 textwidth(s::AnnotatedString) = textwidth(s.string)
 
@@ -359,7 +366,9 @@ titlecase(c::AnnotatedChar) = AnnotatedChar(titlecase(c.char), annotations(c))
 ############################################################################
 
 # returns UTF8PROC_CATEGORY code in 0:30 giving Unicode category
-function category_code(c::AbstractChar)
+# nothrow: ismalformed guards UInt32(c::Char) which is the only throwing call;
+# AbstractChar subtypes contract requires UInt32 to not throw when ismalformed is false.
+@assume_effects :nothrow function category_code(c::AbstractChar)
     !ismalformed(c) ? category_code(UInt32(c)) : Cint(31)
 end
 
@@ -368,15 +377,21 @@ function category_code(x::Integer)
 end
 
 # more human-readable representations of the category code
-function category_abbrev(c::AbstractChar)
+# nothrow+foldable: the ismalformed guard makes UInt32(c)/Char(c) total per the AbstractChar
+# contract, and utf8proc_category_string returns a non-null Cstring for valid category codes.
+@assume_effects :nothrow :foldable function category_abbrev(c::AbstractChar)
     ismalformed(c) && return "Ma"
     c ≤ '\U10ffff' || return "In"
     unsafe_string(ccall(:utf8proc_category_string, Cstring, (UInt32,), c))
 end
 
-category_string(c) = category_strings[category_code(c)+1]
+# nothrow: category_code returns a value in 0:31 and category_strings has 32 entries.
+@assume_effects :nothrow category_string(c::AbstractChar) = category_strings[category_code(c)+1]
+@assume_effects :nothrow category_string(x::Integer) = category_strings[category_code(x)+1]
 
-isassigned(c) = UTF8PROC_CATEGORY_CN < category_code(c) <= UTF8PROC_CATEGORY_CO
+# nothrow: category_code(::AbstractChar) is nothrow and integer comparisons cannot throw.
+@assume_effects :nothrow isassigned(c::AbstractChar) = UTF8PROC_CATEGORY_CN < category_code(c) <= UTF8PROC_CATEGORY_CO
+@assume_effects :nothrow isassigned(x::Integer) = UTF8PROC_CATEGORY_CN < category_code(x) <= UTF8PROC_CATEGORY_CO
 
 ## libc character class predicates ##
 
@@ -400,7 +415,7 @@ julia> islowercase('❤')
 false
 ```
 """
-islowercase(c::AbstractChar) = ismalformed(c) ? false :
+@assume_effects :nothrow islowercase(c::AbstractChar) = ismalformed(c) ? false :
     Bool(@assume_effects :foldable @ccall utf8proc_islower(UInt32(c)::UInt32)::Cint)
 
 # true for Unicode upper and mixed case
@@ -425,7 +440,7 @@ julia> isuppercase('❤')
 false
 ```
 """
-isuppercase(c::AbstractChar) = ismalformed(c) ? false :
+@assume_effects :nothrow isuppercase(c::AbstractChar) = ismalformed(c) ? false :
     Bool(@assume_effects :foldable @ccall utf8proc_isupper(UInt32(c)::UInt32)::Cint)
 
 """
@@ -621,6 +636,13 @@ false
 ```
 """
 isxdigit(c::AbstractChar) = '0'<=c<='9' || 'a'<=c<='f' || 'A'<=c<='F'
+
+# String-specialized overrides: each Char predicate above is nothrow on Char, so the
+# byte-wise iteration `all(f, ::String)` is itself nothrow+foldable.
+for f in (:isletter, :isspace, :isuppercase, :islowercase, :isdigit, :isnumeric,
+          :iscntrl, :ispunct, :isprint, :isxdigit)
+    @eval @assume_effects :nothrow :foldable $f(s::String) = all($f, s)
+end
 
 ## uppercase, lowercase, and titlecase transformations ##
 

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -366,9 +366,12 @@ titlecase(c::AnnotatedChar) = AnnotatedChar(titlecase(c.char), annotations(c))
 ############################################################################
 
 # returns UTF8PROC_CATEGORY code in 0:30 giving Unicode category
-# nothrow: ismalformed guards UInt32(c::Char) which is the only throwing call;
-# AbstractChar subtypes contract requires UInt32 to not throw when ismalformed is false.
-@assume_effects :nothrow function category_code(c::AbstractChar)
+function category_code(c::AbstractChar)
+    !ismalformed(c) ? category_code(UInt32(c)) : Cint(31)
+end
+# Char specialization so inference can prove :nothrow on the concrete type without
+# making the same promise for arbitrary AbstractChar subtypes.
+@assume_effects :nothrow function category_code(c::Char)
     !ismalformed(c) ? category_code(UInt32(c)) : Cint(31)
 end
 
@@ -377,21 +380,22 @@ function category_code(x::Integer)
 end
 
 # more human-readable representations of the category code
-# nothrow+foldable: the ismalformed guard makes UInt32(c)/Char(c) total per the AbstractChar
-# contract, and utf8proc_category_string returns a non-null Cstring for valid category codes.
-@assume_effects :nothrow :foldable function category_abbrev(c::AbstractChar)
+function category_abbrev(c::AbstractChar)
+    ismalformed(c) && return "Ma"
+    c ≤ '\U10ffff' || return "In"
+    unsafe_string(ccall(:utf8proc_category_string, Cstring, (UInt32,), c))
+end
+@assume_effects :nothrow :foldable function category_abbrev(c::Char)
     ismalformed(c) && return "Ma"
     c ≤ '\U10ffff' || return "In"
     unsafe_string(ccall(:utf8proc_category_string, Cstring, (UInt32,), c))
 end
 
-# nothrow: category_code returns a value in 0:31 and category_strings has 32 entries.
-@assume_effects :nothrow category_string(c::AbstractChar) = category_strings[category_code(c)+1]
-@assume_effects :nothrow category_string(x::Integer) = category_strings[category_code(x)+1]
+category_string(c) = category_strings[category_code(c)+1]
+@assume_effects :nothrow category_string(c::Char) = category_strings[category_code(c)+1]
 
-# nothrow: category_code(::AbstractChar) is nothrow and integer comparisons cannot throw.
-@assume_effects :nothrow isassigned(c::AbstractChar) = UTF8PROC_CATEGORY_CN < category_code(c) <= UTF8PROC_CATEGORY_CO
-@assume_effects :nothrow isassigned(x::Integer) = UTF8PROC_CATEGORY_CN < category_code(x) <= UTF8PROC_CATEGORY_CO
+isassigned(c) = UTF8PROC_CATEGORY_CN < category_code(c) <= UTF8PROC_CATEGORY_CO
+@assume_effects :nothrow isassigned(c::Char) = UTF8PROC_CATEGORY_CN < category_code(c) <= UTF8PROC_CATEGORY_CO
 
 ## libc character class predicates ##
 
@@ -415,7 +419,11 @@ julia> islowercase('❤')
 false
 ```
 """
-@assume_effects :nothrow islowercase(c::AbstractChar) = ismalformed(c) ? false :
+islowercase(c::AbstractChar) = ismalformed(c) ? false :
+    Bool(@assume_effects :foldable @ccall utf8proc_islower(UInt32(c)::UInt32)::Cint)
+# Char specialization so inference can prove :nothrow on the concrete type without
+# making the same promise for arbitrary AbstractChar subtypes.
+@assume_effects :nothrow islowercase(c::Char) = ismalformed(c) ? false :
     Bool(@assume_effects :foldable @ccall utf8proc_islower(UInt32(c)::UInt32)::Cint)
 
 # true for Unicode upper and mixed case
@@ -440,7 +448,11 @@ julia> isuppercase('❤')
 false
 ```
 """
-@assume_effects :nothrow isuppercase(c::AbstractChar) = ismalformed(c) ? false :
+isuppercase(c::AbstractChar) = ismalformed(c) ? false :
+    Bool(@assume_effects :foldable @ccall utf8proc_isupper(UInt32(c)::UInt32)::Cint)
+# Char specialization so inference can prove :nothrow on the concrete type without
+# making the same promise for arbitrary AbstractChar subtypes.
+@assume_effects :nothrow isuppercase(c::Char) = ismalformed(c) ? false :
     Bool(@assume_effects :foldable @ccall utf8proc_isupper(UInt32(c)::UInt32)::Cint)
 
 """
@@ -636,13 +648,6 @@ false
 ```
 """
 isxdigit(c::AbstractChar) = '0'<=c<='9' || 'a'<=c<='f' || 'A'<=c<='F'
-
-# String-specialized overrides: each Char predicate above is nothrow on Char, so the
-# byte-wise iteration `all(f, ::String)` is itself nothrow+foldable.
-for f in (:isletter, :isspace, :isuppercase, :islowercase, :isdigit, :isnumeric,
-          :iscntrl, :ispunct, :isprint, :isxdigit)
-    @eval @assume_effects :nothrow :foldable $f(s::String) = all($f, s)
-end
 
 ## uppercase, lowercase, and titlecase transformations ##
 

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -6,7 +6,7 @@ module Unicode
 import Base: show, ==, hash, string, Symbol, isless, length, eltype,
              convert, isvalid, ismalformed, isoverlong, iterate,
              AnnotatedString, AnnotatedChar, annotated_chartransform,
-             @assume_effects, annotations, is_overlong_enc
+             @assume_effects, annotations, is_overlong_enc, unsafe_codepoint
 
 # whether codepoints are valid Unicode scalar values, i.e. 0-0xd7ff, 0xe000-0x10ffff
 
@@ -267,16 +267,16 @@ julia> textwidth('⛵')
 """
 textwidth(c::AbstractChar) = textwidth(Char(c)::Char)
 
-# nothrow+foldable: ismalformed/is_overlong_enc guards return early before the ccall whose
-# result fits in Cint and so the Int conversion cannot throw InexactError.
-@assume_effects :nothrow :foldable function textwidth(c::Char)
+function textwidth(c::Char)
     u = reinterpret(UInt32, c)
     b = bswap(u) # from isascii(c)
     b < 0x7f && return Int(b >= 0x20) # ASCII fast path
     # We can't know a priori how terminals will render invalid UTF8 chars,
     # so we conservatively decide a width of 1.
     (ismalformed(c) || is_overlong_enc(u)) && return 1
-    Int(ccall(:utf8proc_charwidth, Cint, (UInt32,), c))
+    # `unsafe_codepoint` is sound here because both malformed-encoding cases
+    # have been ruled out above; this lets the compiler infer `:nothrow`.
+    Int(@assume_effects :foldable :nothrow @ccall utf8proc_charwidth(unsafe_codepoint(c)::UInt32)::Cint)
 end
 
 """
@@ -368,35 +368,39 @@ titlecase(c::AnnotatedChar) = AnnotatedChar(titlecase(c.char), annotations(c))
 
 # returns UTF8PROC_CATEGORY code in 0:30 giving Unicode category
 function category_code(c::AbstractChar)
-    !ismalformed(c) ? category_code(UInt32(c)) : Cint(31)
-end
-@assume_effects :nothrow function category_code(c::Char)
-    !ismalformed(c) ? category_code(UInt32(c)) : Cint(31)
+    # `unsafe_codepoint` is sound here because the `ismalformed` guard has ruled
+    # out the throwing path of `UInt32(::Char)`, allowing the compiler to infer
+    # `:nothrow` for `category_code(::Char)`.
+    !ismalformed(c) ? category_code(unsafe_codepoint(c)) : Cint(31)
 end
 
 function category_code(x::Integer)
-    x ≤ 0x10ffff ? (@assume_effects :foldable @ccall utf8proc_category(UInt32(x)::UInt32)::Cint) : Cint(30)
+    x ≤ 0x10ffff ? (@assume_effects :foldable :nothrow @ccall utf8proc_category(UInt32(x)::UInt32)::Cint) : Cint(30)
 end
 
 # more human-readable representations of the category code
 function category_abbrev(c::AbstractChar)
     ismalformed(c) && return "Ma"
     c ≤ '\U10ffff' || return "In"
-    unsafe_string(ccall(:utf8proc_category_string, Cstring, (UInt32,), c))
+    unsafe_string(@ccall utf8proc_category_string(UInt32(c)::UInt32)::Cstring)
 end
+# `unsafe_string` over a `utf8proc` cstring is not inferred as `:nothrow`/`:foldable`,
+# but the cstring is a static table entry inside utf8proc, and `unsafe_codepoint`
+# is sound here because of the `ismalformed` guard above.
 @assume_effects :nothrow :foldable function category_abbrev(c::Char)
     ismalformed(c) && return "Ma"
     c ≤ '\U10ffff' || return "In"
-    unsafe_string(ccall(:utf8proc_category_string, Cstring, (UInt32,), c))
+    unsafe_string(@ccall utf8proc_category_string(unsafe_codepoint(c)::UInt32)::Cstring)
 end
 
+# category_code(c) returns a value in 0:31 and category_strings has 32 entries
+# (asserted at the top of this file), so the index is always in bounds for `Char`.
 category_string(c) = category_strings[category_code(c)+1]
-# category_code(::Char) returns a value in 0:31 and category_strings has 32 entries
-# (asserted at the top of this file), so the index is always in bounds.
-@assume_effects :nothrow category_string(c::Char) = @inbounds category_strings[category_code(c)+1]
+# `getindex` on a `const` `Vector{String}` is not inferred as `:nothrow` even with
+# `@inbounds`, but the bounds are guaranteed by the assert above.
+@assume_effects :nothrow :foldable category_string(c::Char) = @inbounds category_strings[category_code(c)+1]
 
 isassigned(c) = UTF8PROC_CATEGORY_CN < category_code(c) <= UTF8PROC_CATEGORY_CO
-@assume_effects :nothrow isassigned(c::Char) = UTF8PROC_CATEGORY_CN < category_code(c) <= UTF8PROC_CATEGORY_CO
 
 ## libc character class predicates ##
 
@@ -420,10 +424,12 @@ julia> islowercase('❤')
 false
 ```
 """
-islowercase(c::AbstractChar) = ismalformed(c) ? false :
-    Bool(@assume_effects :foldable @ccall utf8proc_islower(UInt32(c)::UInt32)::Cint)
-@assume_effects :nothrow islowercase(c::Char) = ismalformed(c) ? false :
-    Bool(@assume_effects :foldable @ccall utf8proc_islower(UInt32(c)::UInt32)::Cint)
+function islowercase(c::AbstractChar)
+    # `unsafe_codepoint` is sound here because of the `ismalformed` guard;
+    # this lets the compiler infer `:nothrow` for `islowercase(::Char)`.
+    ismalformed(c) ? false :
+        !iszero(@assume_effects :foldable :nothrow @ccall utf8proc_islower(unsafe_codepoint(c)::UInt32)::Cint)
+end
 
 # true for Unicode upper and mixed case
 
@@ -447,10 +453,12 @@ julia> isuppercase('❤')
 false
 ```
 """
-isuppercase(c::AbstractChar) = ismalformed(c) ? false :
-    Bool(@assume_effects :foldable @ccall utf8proc_isupper(UInt32(c)::UInt32)::Cint)
-@assume_effects :nothrow isuppercase(c::Char) = ismalformed(c) ? false :
-    Bool(@assume_effects :foldable @ccall utf8proc_isupper(UInt32(c)::UInt32)::Cint)
+function isuppercase(c::AbstractChar)
+    # `unsafe_codepoint` is sound here because of the `ismalformed` guard;
+    # this lets the compiler infer `:nothrow` for `isuppercase(::Char)`.
+    ismalformed(c) ? false :
+        !iszero(@assume_effects :foldable :nothrow @ccall utf8proc_isupper(unsafe_codepoint(c)::UInt32)::Cint)
+end
 
 """
     iscased(c::AbstractChar)::Bool

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -293,6 +293,7 @@ julia> textwidth("March")
 textwidth(s::AbstractString) = mapreduce(textwidth, +, s; init=0)
 # foldable+nothrow: String iteration is total and textwidth(::Char) is nothrow.
 @assume_effects :nothrow :foldable textwidth(s::String) = mapreduce(textwidth, +, s; init=0)
+@assume_effects :nothrow :foldable textwidth(s::SubString{String}) = mapreduce(textwidth, +, s; init=0)
 
 textwidth(s::AnnotatedString) = textwidth(s.string)
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -77,6 +77,13 @@ function startswith(a::DenseUTF8String, b::DenseUTF8String)
     end
 end
 
+# nothrow+foldable: `String`/`SubString{String}` buffers are immutable, the
+# byte-wise `_memcmp` is bounded by `sizeof(b) ≤ ncodeunits(a)`, and
+# `nextind(a, cub)` operates on a valid index (`0 ≤ cub ≤ ncodeunits(a)`).
+@assume_effects :nothrow :foldable function startswith(a::Union{String,SubString{String}}, b::Union{String,SubString{String}})
+    @invoke startswith(a::DenseUTF8String, b::DenseUTF8String)
+end
+
 """
     startswith(io::IO, prefix::Union{AbstractString,Base.Chars})
 
@@ -106,6 +113,12 @@ function endswith(a::DenseUTF8String, b::DenseUTF8String)
     else
         false
     end
+end
+
+# nothrow+foldable: see `startswith` above; `pointer(a, astart)` is in bounds
+# (`1 ≤ astart ≤ ncodeunits(a)+1`), and `thisind(a, astart)` accepts the same range.
+@assume_effects :nothrow :foldable function endswith(a::Union{String,SubString{String}}, b::Union{String,SubString{String}})
+    @invoke endswith(a::DenseUTF8String, b::DenseUTF8String)
 end
 
 """

--- a/test/char.jl
+++ b/test/char.jl
@@ -401,4 +401,15 @@ end
     @test v isa Val{true}
     v = @inferred (() -> Val(isnumeric(MyChar('C'))))()
     @test v isa Val{false}
+
+    for f in (isletter, isspace, isuppercase, islowercase, isdigit, isnumeric,
+              iscntrl, ispunct, isprint, isxdigit, textwidth,
+              Base.Unicode.isassigned, Base.Unicode.category_code,
+              Base.Unicode.category_abbrev, Base.Unicode.category_string)
+        @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (Char,))) (f,)
+    end
+    for f in (isascii, textwidth, isletter, isspace, isuppercase, islowercase,
+              isdigit, isnumeric, iscntrl, ispunct, isprint, isxdigit)
+        @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (String,))) (f,)
+    end
 end

--- a/test/char.jl
+++ b/test/char.jl
@@ -355,6 +355,21 @@ end
     @test all(Base.ismalformed, overlong_chars)
     @test repr("text/plain", overlong_chars[1]) ==
         "'\\xc0': Malformed UTF-8 (category Ma: Malformed, bad data)"
+
+    # Predicates annotated `@assume_effects` must not throw on arbitrary Char bit-patterns.
+    # Skip 0x00000000 ('\0', well-formed); the rest must be malformed for this to test what we want.
+    for u in (0x80000000, 0xC0000000, 0xE0000000, 0xF0000000,
+              0xF8000000, 0xFF000000, 0xFFFFFFFF, 0x80808080)
+        c = reinterpret(Char, u)
+        @test Base.ismalformed(c)
+        @test textwidth(c) isa Int
+        @test Base.Unicode.category_code(c) isa Integer
+        @test Base.Unicode.category_abbrev(c) isa AbstractString
+        @test Base.Unicode.category_string(c) isa AbstractString
+        @test Base.Unicode.isassigned(c) isa Bool
+        @test islowercase(c) isa Bool
+        @test isuppercase(c) isa Bool
+    end
 end
 
 @testset "overlong, non-malformed chars" begin

--- a/test/char.jl
+++ b/test/char.jl
@@ -406,10 +406,9 @@ end
               iscntrl, ispunct, isprint, isxdigit, textwidth,
               Base.Unicode.isassigned, Base.Unicode.category_code,
               Base.Unicode.category_abbrev, Base.Unicode.category_string)
-        @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (Char,))) (f,)
+        @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (Char,)))
     end
-    for f in (isascii, textwidth, isletter, isspace, isuppercase, islowercase,
-              isdigit, isnumeric, iscntrl, ispunct, isprint, isxdigit)
-        @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (String,))) (f,)
+    for f in (isascii, textwidth)
+        @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (String,)))
     end
 end

--- a/test/char.jl
+++ b/test/char.jl
@@ -411,4 +411,7 @@ end
     for f in (isascii, textwidth, lastindex)
         @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (String,)))
     end
+    for f in (length, isascii, textwidth, lastindex)
+        @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (SubString{String},)))
+    end
 end

--- a/test/char.jl
+++ b/test/char.jl
@@ -408,7 +408,7 @@ end
               Base.Unicode.category_abbrev, Base.Unicode.category_string)
         @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (Char,)))
     end
-    for f in (isascii, textwidth)
+    for f in (isascii, textwidth, lastindex)
         @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (String,)))
     end
 end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -1294,6 +1294,58 @@ end
     @test_throws ArgumentError Symbol("a\0a")
 
     @test Base._string_n_override == Base.encode_effects_override(Base.compute_assumed_settings((:total, :(!:consistent))))
+
+    # Stress-test that the annotations added in this PR (and follow-ups) hold
+    # even when strings contain arbitrary, malformed UTF-8 byte sequences.
+    let garbage = String[
+            String(UInt8[0x80]),                  # lone continuation
+            String(UInt8[0xC0]),                  # truncated 2-byte lead
+            String(UInt8[0xE0, 0x80]),            # truncated 3-byte
+            String(UInt8[0xF0, 0x80, 0x80]),      # truncated 4-byte
+            String(UInt8[0xFF, 0xFE]),            # invalid lead bytes
+            String(UInt8[0xC0, 0x80]),            # overlong NUL
+            String(UInt8[0xED, 0xA0, 0x80]),      # surrogate
+            String(UInt8[0xF8, 0x88, 0x80, 0x80, 0x80]), # 5-byte (invalid)
+            "",
+            "ascii",
+            "naïve",
+        ]
+        for a in garbage, b in garbage
+            @test startswith(a, b) isa Bool
+            @test endswith(a, b) isa Bool
+            @test startswith(SubString(a), b) isa Bool
+            @test endswith(SubString(a), b) isa Bool
+            @test startswith(a, SubString(b)) isa Bool
+            @test endswith(a, SubString(b)) isa Bool
+        end
+        for a in garbage, c in ('\0', '\xff', 'a', 'α', '🎉')
+            @test in(c, a) isa Bool
+            @test in(c, SubString(a)) isa Bool
+        end
+        for a in garbage
+            sa = SubString(a)
+            @test length(a) isa Int
+            @test length(sa) isa Int
+            @test lastindex(a) isa Int
+            @test lastindex(sa) isa Int
+            @test isascii(a) isa Bool
+            @test isascii(sa) isa Bool
+            @test textwidth(a) isa Int
+            @test textwidth(sa) isa Int
+        end
+        # Char predicates must tolerate malformed Char bit-patterns.
+        for u in (0x00000000, 0x80000000, 0xC0000000, 0xE0000000, 0xF0000000,
+                  0xF8000000, 0xFF000000, 0xFFFFFFFF, 0x80808080)
+            c = reinterpret(Char, u)
+            @test textwidth(c) isa Int
+            @test Base.Unicode.category_code(c) isa Integer
+            @test Base.Unicode.category_abbrev(c) isa AbstractString
+            @test Base.Unicode.category_string(c) isa AbstractString
+            @test Base.Unicode.isassigned(c) isa Bool
+            @test islowercase(c) isa Bool
+            @test isuppercase(c) isa Bool
+        end
+    end
 end
 
 @testset "Ensure UTF-8 DFA can never leave invalid state" begin

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -1257,7 +1257,17 @@ end
                    (String, (Symbol,)),
                    (length, (String,)),
                    (hash, (String,UInt)),
-                   (hash, (Char,UInt)),]
+                   (hash, (Char,UInt)),
+                   (startswith, (String, String)),
+                   (startswith, (SubString{String}, String)),
+                   (startswith, (String, SubString{String})),
+                   (startswith, (SubString{String}, SubString{String})),
+                   (endswith, (String, String)),
+                   (endswith, (SubString{String}, String)),
+                   (endswith, (String, SubString{String})),
+                   (endswith, (SubString{String}, SubString{String})),
+                   (in, (Char, String)),
+                   (in, (Char, SubString{String})),]
         e = Base.infer_effects(f, Ts)
         @test Core.Compiler.is_foldable(e) context=(f, Ts)
         @test Core.Compiler.is_removable_if_unused(e) context=(f, Ts)

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -1333,18 +1333,6 @@ end
             @test textwidth(a) isa Int
             @test textwidth(sa) isa Int
         end
-        # Char predicates must tolerate malformed Char bit-patterns.
-        for u in (0x00000000, 0x80000000, 0xC0000000, 0xE0000000, 0xF0000000,
-                  0xF8000000, 0xFF000000, 0xFFFFFFFF, 0x80808080)
-            c = reinterpret(Char, u)
-            @test textwidth(c) isa Int
-            @test Base.Unicode.category_code(c) isa Integer
-            @test Base.Unicode.category_abbrev(c) isa AbstractString
-            @test Base.Unicode.category_string(c) isa AbstractString
-            @test Base.Unicode.isassigned(c) isa Bool
-            @test islowercase(c) isa Bool
-            @test isuppercase(c) isa Bool
-        end
     end
 end
 


### PR DESCRIPTION
Continuation of #61616 #61615

Developed with claude:

---

Several `Char` predicates and a couple of `String` predicates in `base/strings/unicode.jl` and `base/strings/string.jl` are spuriously inferred as `nothrow=false`, even though they are provably total. This prevents the compiler from constant-folding them or from eliminating them when their result is unused.

The root cause is that the compiler cannot prove that the `ismalformed` / `is_overlong_enc` guards rule out the throwing paths in their bodies — for example the `Int(::Cint)` conversion after the `utf8proc` ccall, or the `UInt32(::AbstractChar)` conversion in `category_code`. The `AbstractChar` contract guarantees that `UInt32(c)` only throws when `ismalformed(c)` returns `true`, and the `utf8proc_charwidth` result fits in a `Cint` so the `Int` conversion never throws `InexactError`.

This PR annotates the affected definitions with `@assume_effects` and adds regression tests in `test/char.jl` and `test/strings/basic.jl`.

### Scope

`Char`:
- `textwidth`, `category_code`, `category_abbrev`, `category_string`,
  `isassigned`, `islowercase`, `isuppercase`

`String`:
- `isascii`, `lastindex`, `textwidth`

`SubString{String}`:
- `length`, `isascii`, `lastindex`, `textwidth`

`String` / `SubString{String}` predicates:
- `startswith`, `endswith`, `in(::Char, _)`

Annotations are added on narrow concrete-type method overloads so they don't constrain user-defined `AbstractChar` / `AbstractString` subtypes. A static `@assert length(category_strings) == 32` is added so the `category_string(::Char)` annotation stays sound if the table is ever edited.

The bodies of `startswith` / `endswith` are `_memcmp` byte-bounded by `sizeof(b) ≤ ncodeunits(a)` plus `nextind` / `thisind` calls on indices proven in range, so they cannot throw even on strings containing arbitrary, malformed UTF-8 byte sequences. A stress test exercises every annotated function on adversarial byte sequences and on `Char` values constructed from invalid bit-patterns to lock in the `:nothrow` soundness against future refactors.

### Effect on generated code

`textwidth("hello world")` now constant-folds:

**nightly:**

```julia-repl
julia> code_typed(() -> textwidth("hello world"), ())[1]
CodeInfo(
1 ─ %1 =    invoke Base._foldl_impl(
                Base.MappingRF{typeof(textwidth), Base.BottomRF{typeof(+)}}(
                    textwidth, Base.BottomRF{typeof(+)}(+))::Base.MappingRF{...},
                0::Int64, "hello world"::String)::Int64
└──      return %1
) => Int64
```

**this PR:**

```julia-repl
julia> code_typed(() -> textwidth("hello world"), ())[1]
CodeInfo(
1 ─     return 11
) => Int64
```

Likewise, `startswith` / `endswith` / `in` over literal `String`s now constant-fold.

**nightly:**

```julia-repl
julia> code_typed(() -> startswith("https://example.com/foo", "https://"), ())[1]
CodeInfo(
1 ─ %1 =    invoke Main.startswith("https://example.com/foo"::String, "https://"::String)::Bool
└──      return %1
) => Bool

julia> code_typed(() -> endswith("foo.jl", ".jl"), ())[1]
CodeInfo(
1 ─ %1 =    invoke Main.endswith("foo.jl"::String, ".jl"::String)::Bool
└──      return %1
) => Bool

julia> code_typed(() -> in('a', "aeiou"), ())[1]
CodeInfo(
1 ─ %1  =    invoke Base.codeunits("aeiou"::String)::Base.CodeUnits{UInt8, String}
│   %2  = $(Expr(:gc_preserve_begin, :(%1)))
│   %3  =   builtin Base.getfield(%1, :s)::String
│   %4  =    invoke Base.cconvert(Ptr{UInt8}::Type{Ptr{UInt8}}, %3::String)::String
│   %5  = $(Expr(:foreigncall, :((:jl_string_ptr,)), Ptr{UInt8}, svec(Any), 0, :(:ccall), :(%4)))::Ptr{UInt8}
│   %6  = intrinsic Base.add_ptr(%5, 0x0000000000000001)::Ptr{UInt8}
│   %7  = intrinsic Base.sub_ptr(%6, 0x0000000000000001)::Ptr{UInt8}
│   %8  = $(Expr(:foreigncall, :((:memchr,)), Ptr{UInt8}, svec(Ptr{UInt8}, Int32, UInt64), 0, :(:ccall), :(%7), 97, 0x0000000000000005, 0x0000000000000005, 97, :(%7)))::Ptr{UInt8}
│         $(Expr(:gc_preserve_end, :(%2)))
│   %10 = intrinsic Core.bitcast(Core.UInt, %8)::UInt64
│   %11 =   builtin (%10 === 0x0000000000000000)::Bool
└──       goto #3 if not %11
2 ─       goto #4
3 ─       goto #4
4 ┄ %15 = φ (#2 => true, #3 => false)::Bool
│   %16 = intrinsic Core.Intrinsics.not_int(%15)::Bool
└──       goto #5
5 ─       return %16
) => Bool
```

**this PR:**

```julia-repl
julia> code_typed(() -> startswith("https://example.com/foo", "https://"), ())[1]
CodeInfo(
1 ─     return true
) => Bool

julia> code_typed(() -> endswith("foo.jl", ".jl"), ())[1]
CodeInfo(
1 ─     return true
) => Bool

julia> code_typed(() -> in('a', "aeiou"), ())[1]
CodeInfo(
1 ─     return true
) => Bool
```

And `SubString{String}` queries can now be DCE'd when their result is unused. With `describe(ss)` calling `length`, `lastindex`, `textwidth`, `isascii`:

**nightly:**

```llvm
define i64 @julia_caller_0(...) {
top:
  %"sret::NamedTuple" = alloca [4 x i64], align 8
  call void @j_describe_0(ptr ... sret(...) align 8 %"sret::NamedTuple", ...)
  ret i64 42
}
```

**this PR:**

```llvm
define i64 @julia_caller_0(...) {
top:
  ret i64 42
}
```