### PR TITLE
gc: fix build errors in gc-stock.c and gc-debug.c

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -401,7 +401,7 @@ void gc_verify_tags(void)
 
 #ifdef GC_DEBUG_ENV
 JL_DLLEXPORT jl_gc_debug_env_t jl_gc_debug_env = {
-    0, 0,
+    0,
     {0, UINT64_MAX, 0, 0, 0, {0, 0, 0}},
     {0, UINT64_MAX, 0, 0, 0, {0, 0, 0}},
     {0, UINT64_MAX, 0, 0, 0, {0, 0, 0}}

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -1594,7 +1594,7 @@ STATIC_INLINE void gc_assert_parent_validity(jl_value_t *parent, jl_value_t *chi
         jl_safe_static_show((JL_STREAM*)s, (jl_value_t *)jl_typeof(parent));
         jl_safe_fprintf(s, "While marking child at %p\n", (void *)child);
         jl_safe_fprintf(s, "of type:\n");
-        jl_safe_static_show(s, (jl_value_t *)child_vtag);
+        jl_safe_static_show((JL_STREAM*)s, (jl_value_t *)child_vtag);
         jl_gc_debug_fprint_critical_error(s);
         abort();
     }


### PR DESCRIPTION
Fix missing `(JL_STREAM*)` cast for `jl_safe_static_show` in
`gc_assert_parent_validity` in gc-stock.c, which caused an
incompatible pointer type error.

Fix stale initializer in gc-debug.c: the `always_full` field was
removed from `jl_gc_debug_env_t` in #58713 but the corresponding `0`
in the initializer was not removed, causing excess-elements-in-scalar
warnings.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>