### PR TITLE
Makefile: link final sysimage with `lld` via `Base.Linking`

### DIFF
--- a/base/linking.jl
+++ b/base/linking.jl
@@ -88,17 +88,23 @@ function dsymutil(; adjust_PATH::Bool = true, adjust_LIBPATH::Bool = true)
     return Cmd(Cmd([dsymutil_path()]); env)
 end
 
-function ld()
+function ld(; strict_definitions::Bool = false)
     default_args = ``
     @static if Sys.iswindows()
         # From`x86_64-w64-mingw32-gcc -shared -Wl,--verbose`
         flavor = "gnu"
         m = Sys.ARCH == :x86_64 ? "i386pep" : "i386pe"
-        default_args = `-m $m -Bdynamic -e DllMainCRTStartup --enable-auto-image-base --allow-multiple-definition --disable-auto-import --disable-runtime-pseudo-reloc`
+        default_args = `-m $m -Bdynamic -e DllMainCRTStartup --enable-auto-image-base --disable-auto-import --disable-runtime-pseudo-reloc`
+        if !strict_definitions
+            default_args = `$default_args --allow-multiple-definition`
+        end
     elseif Sys.isapple()
         flavor = "darwin"
         arch = Sys.ARCH == :aarch64 ? :arm64 : Sys.ARCH
-        default_args = `-arch $arch -undefined dynamic_lookup -platform_version macos $(Base.MACOS_PRODUCT_VERSION) $(Base.MACOS_PLATFORM_VERSION)`
+        default_args = `-arch $arch -platform_version macos $(Base.MACOS_PRODUCT_VERSION) $(Base.MACOS_PLATFORM_VERSION)`
+        if !strict_definitions
+            default_args = `$default_args -undefined dynamic_lookup`
+        end
         # due to an lld bug: https://github.com/llvm/llvm-project/issues/193646
         # we must make sure the syslibroot does not point to the system or else
         # it will not respect the provided `libSystem.tbd` file
@@ -168,7 +174,7 @@ function _find_loaded(re::Regex)
     error("no loaded shared object matching $re")
 end
 
-function link_image_cmd(path, out)
+function link_image_cmd(path, out; is_sysimage::Bool = false)
     PRIVATE_LIBDIR = "-L$(private_libdir())"
     LIBDIR = "-L$(libdir())"
     SHLIBDIR = "-L$(shlibdir())"
@@ -208,11 +214,12 @@ function link_image_cmd(path, out)
     end
 
     V = verbose_linking() ? "--verbose" : ""
-    `$(ld()) $V $SHARED -o $out $crtbegin $(whole_archive(path)) $PRIVATE_LIBDIR $LIBDIR $SHLIBDIR $LIBS $crtend`
+    `$(ld(; strict_definitions = is_sysimage)) $V $SHARED -o $out $crtbegin $(whole_archive(path)) $PRIVATE_LIBDIR $LIBDIR $SHLIBDIR $LIBS $crtend`
 end
 
-function link_image(path, out, internal_stderr::IO=stderr, internal_stdout::IO=stdout)
-    run(link_image_cmd(path, out), Base.DevNull(), internal_stderr, internal_stdout)
+function link_image(path, out, internal_stderr::IO=stderr, internal_stdout::IO=stdout;
+                    is_sysimage::Bool = false)
+    run(link_image_cmd(path, out; is_sysimage), Base.DevNull(), internal_stderr, internal_stdout)
 end
 
 end # module Linking

--- a/sysimage.mk
+++ b/sysimage.mk
@@ -18,13 +18,36 @@ sysbase-debug: $(build_private_libdir)/sysbase-debug.$(SHLIB_EXT)
 
 VERSDIR := v$(shell cut -d. -f1-2 < $(JULIAHOME)/VERSION)
 
-$(build_private_libdir)/%.$(SHLIB_EXT): $(build_private_libdir)/%-o.a
-	@$(call PRINT_LINK, $(CXX) $(LDFLAGS) -shared $(fPIC) -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -o $@ \
-		$(call whole_archive,$<) \
-		$(if $(findstring -debug,$(notdir $@)),-ljulia-internal-debug -ljulia-debug,-ljulia-internal -ljulia) \
-		$$([ $(OS) = WINNT ] && echo '' $(LIBM) -lssp -Wl,--disable-auto-import -Wl,--disable-runtime-pseudo-reloc))
-	@$(INSTALL_NAME_CMD)$(notdir $@) $@
-	@$(DSYMUTIL) $@
+define bootstrap_sysimage_link
+$$(build_private_libdir)/$1$2.$$(SHLIB_EXT): $$(build_private_libdir)/$1$2-o.a
+	@$$(call PRINT_LINK, $$(CXX) $$(LDFLAGS) -shared $$(fPIC) -L$$(build_private_libdir) -L$$(build_libdir) -L$$(build_shlibdir) -o $$@ \
+		$$(call whole_archive,$$<) \
+		-ljulia-internal$2 -ljulia$2 \
+		$$$$([ $$(OS) = WINNT ] && echo '' $$(LIBM) -lssp -Wl,--disable-auto-import -Wl,--disable-runtime-pseudo-reloc))
+	@$$(INSTALL_NAME_CMD)$$(notdir $$@) $$@
+	@$$(DSYMUTIL) $$@
+endef
+
+$(eval $(call bootstrap_sysimage_link,basecompiler,))
+$(eval $(call bootstrap_sysimage_link,basecompiler,-debug))
+$(eval $(call bootstrap_sysimage_link,sysbase,))
+$(eval $(call bootstrap_sysimage_link,sysbase,-debug))
+
+define sysimage_link
+$$(build_private_libdir)/$1$2.$$(SHLIB_EXT): $$(build_private_libdir)/$1$2-o.a $$(build_private_libdir)/sysbase$2.$$(SHLIB_EXT)
+	@$$(call PRINT_LINK, $$(call spawn,$3) -J $$(call cygpath_w,$$(build_private_libdir)/sysbase$2.$$(SHLIB_EXT)) --startup-file=no -e \
+		'Base.Linking.link_image(ARGS[1], ARGS[2]; is_sysimage=true)' -- $$(call cygpath_w,$$<) $$(call cygpath_w,$$@))
+	@$$(INSTALL_NAME_CMD)$$(notdir $$@) $$@
+ifeq ($$(OS), Darwin)
+	@$$(call spawn,$3) -J $$(call cygpath_w,$$(build_private_libdir)/sysbase$2.$$(SHLIB_EXT)) --startup-file=no -e \
+		'run(`$$$$(Base.Linking.dsymutil()) $$$$(ARGS[1])`)' -- $$(call cygpath_w,$$@)
+endif
+endef
+
+$(eval $(call sysimage_link,sys,,$(JULIA_EXECUTABLE_release)))
+$(eval $(call sysimage_link,sys,-debug,$(JULIA_EXECUTABLE_debug)))
+$(eval $(call sysimage_link,sys-JL,,$(JULIA_EXECUTABLE_release)))
+$(eval $(call sysimage_link,sys-JL,-debug,$(JULIA_EXECUTABLE_debug)))
 
 COMPILER_SRCS := $(addprefix $(JULIAHOME)/, \
 		base/Base_compiler.jl \


### PR DESCRIPTION
This standardizes on using `lld` for the sysimage linker, which is the same tool we use to link pkgimages.

This does not change how the "intermediate" sysimages from the build (`base_compiler` and `sysbase`) are linked, since `Base.Linking` is not available until `Base` has been bootstrapped.

Resolves https://github.com/JuliaLang/julia/issues/59752.