### PR TITLE
Compiler/runtime: Reduce reliance on intersection tvar identity

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -66,6 +66,7 @@ using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospeciali
     _uncompressed_ir, datatype_min_ninitialized,
     partialstruct_init_undefs, fieldcount_noerror, _eval_import, _eval_using,
     get_ci_mi, get_methodtable, morespecific, specializations, has_image_globalref,
+    rewrap_free_typevars, find_free_typevars, typeintersect_env,
     PARTITION_MASK_KIND, PARTITION_KIND_GUARD, PARTITION_FLAG_EXPORTED, PARTITION_FLAG_DEPRECATED,
     BINDING_FLAG_ANY_IMPLICIT_EDGES, is_some_implicit, IteratorSize, SizeUnknown, get_require_world, JLOptions,
     devnull, devnull as stdin

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -320,8 +320,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
                         csig = get_compileable_sig(method, sig, match.sparams)
                         if csig !== nothing && (!seenall || csig !== sig) # corresponds to whether the first look already looked at this, so repeating abstract_call_method is not useful
                             #println(sig, " changed to ", csig, " for ", method)
-                            sp_ = ccall(:jl_type_intersection_with_env, Any, (Any, Any), csig, method.sig)::SimpleVector
-                            sparams = sp_[2]::SimpleVector
+                            (_, sparams) = typeintersect_env(csig, method.sig)
                             mresult = abstract_call_method(interp, method, csig, sparams, multiple_matches, StmtInfo(false, false), sv)::Future
                             isready(mresult) || return false # wait for mresult Future to resolve off the callstack before continuing
                         end
@@ -742,7 +741,7 @@ function abstract_call_method(interp::AbstractInterpreter,
 
     # if sig changed, may need to recompute the sparams environment
     if isa(method.sig, UnionAll) && isempty(sparams)
-        recomputed = ccall(:jl_type_intersection_with_env, Any, (Any, Any), sig, method.sig)::SimpleVector
+        (_, sparams) = typeintersect_env(sig, method.sig)
         #@assert recomputed[1] !== Bottom
         # We must not use `sig` here, since that may re-introduce structural complexity that
         # our limiting heuristic sought to eliminate. The alternative would be to not increment depth over covariant contexts,
@@ -763,7 +762,6 @@ function abstract_call_method(interp::AbstractInterpreter,
         #         newsig = recomputed[2]
         #     end
         #     sig = ?
-        sparams = recomputed[2]::SimpleVector
     end
 
     return typeinf_edge(interp, method, sig, sparams, sv, edgecycle, edgelimited)
@@ -3070,19 +3068,10 @@ function sp_type_rewrap(@nospecialize(T), mi::MethodInstance, isreturn::Bool)
             if !isempty(mi.sparam_vals)
                 sparam_vals = Any[isvarargtype(v) ? TypeVar(:N, Union{}, Any) :
                                   v for v in  mi.sparam_vals]
+                free_sps_before = find_free_typevars(mi.specTypes)
                 T = ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), T, spsig, sparam_vals)
                 isref && isreturn && T === Any && return Bottom # catch invalid return Ref{T} where T = Any
-                for v in sparam_vals
-                    if isa(v, TypeVar)
-                        T = UnionAll(v, T)
-                    end
-                end
-                if has_free_typevars(T)
-                    fv = ccall(:jl_find_free_typevars, Vector{Any}, (Any,), T)
-                    for v in fv
-                        T = UnionAll(v, T)
-                    end
-                end
+                T = rewrap_free_typevars(T, free_sps_before)
             else
                 T = rewrap_unionall(T, spsig)
             end

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -728,54 +728,54 @@ function sptypes_from_meth_instance(mi::MethodInstance)
     sptypes = Vector{VarState}(undef, nvals)
     for i = 1:nvals
         v = spvals[i]
-        if v isa TypeVar
+        undef = true
+        if has_free_typevars(v)
+            ty = Any
             temp = sig
             for _ = 1:i-1
                 temp = temp.body
             end
             vᵢ = (temp::UnionAll).var
-            sigtypes = (unwrap_unionall(temp)::DataType).parameters
-            for j = 1:length(sigtypes)
-                sⱼ = sigtypes[j]
-                if isType(sⱼ) && sⱼ.parameters[1] === vᵢ
-                    # if this parameter came from `arg::Type{T}`,
-                    # then `arg` is more precise than `Type{T} where lb<:T<:ub`
-                    ty = fieldtype(mi.specTypes, j)
-                    @goto ty_computed
-                elseif (va = va_from_vatuple(sⱼ)) !== nothing
-                    # if this parameter came from `::Tuple{.., Vararg{T,vᵢ}}`,
-                    # then `vᵢ` is known to be `Int`
-                    if isdefined(va, :N) && va.N === vᵢ
-                        ty = Int
+            if isa(v, TypeVar)
+                sigtypes = (unwrap_unionall(temp)::DataType).parameters
+                for j = 1:length(sigtypes)
+                    sⱼ = sigtypes[j]
+                    if isType(sⱼ) && sⱼ.parameters[1] === vᵢ
+                        # if this parameter came from `arg::Type{T}`,
+                        # then `arg` is more precise than `Type{T} where lb<:T<:ub`
+                        ty = fieldtype(mi.specTypes, j)
                         @goto ty_computed
+                    elseif (va = va_from_vatuple(sⱼ)) !== nothing
+                        # if this parameter came from `::Tuple{.., Vararg{T,vᵢ}}`,
+                        # then `vᵢ` is known to be `Int`
+                        if isdefined(va, :N) && va.N === vᵢ
+                            ty = Int
+                            @goto ty_computed
+                        end
                     end
                 end
+                ub = unwraptv_ub(v)
+                if has_free_typevars(ub)
+                    ub = Any
+                end
+                lb = unwraptv_lb(v)
+                if has_free_typevars(lb)
+                    lb = Bottom
+                end
+                if Any === ub && lb === Bottom
+                    # `Bottom <: T <: Any` additionally allows non-Type tvars
+                    ty = Any
+                    @goto ty_computed
+                end
             end
-            ub = unwraptv_ub(v)
-            if has_free_typevars(ub)
-                ub = Any
-            end
-            lb = unwraptv_lb(v)
-            if has_free_typevars(lb)
-                lb = Bottom
-            end
-            if Any === ub && lb === Bottom
-                ty = Any
-            else
-                tv = TypeVar(v.name, lb, ub)
-                ty = UnionAll(tv, Type{tv})
-            end
+            ty = rewrap_free_typevars(Type{v}, find_free_typevars(mi.specTypes))
             @label ty_computed
             undef = !(let sig=sig
-                # if the specialized signature `linfo.specTypes` doesn't contain any free
-                # type variables, we can use it for a more accurate analysis of whether `v`
-                # is constrained or not, otherwise we should use `def.sig` which always
-                # doesn't contain any free type variables
-                if !has_free_typevars(mi.specTypes)
-                    sig = mi.specTypes
-                end
                 @assert !has_free_typevars(sig)
-                constrains_param(v, sig, #=covariant=#true)
+                vᵢ.lb === Bottom && constrains_param(vᵢ, sig, #=covariant=#true) || begin
+                    # TODO: This relies on the identity of typevars returned from intersection, which is not guaranteed.
+                    isa(v, TypeVar) && !has_free_typevars(mi.specTypes) && constrains_param(v, mi.specTypes, #=covariant=#true)
+                end
             end)
         elseif isvarargtype(v)
             # if this parameter came from `func(..., ::Vararg{T,v})`,
@@ -789,6 +789,14 @@ function sptypes_from_meth_instance(mi::MethodInstance)
         sptypes[i] = VarState(ty, typemin(Int), undef)
     end
     return sptypes
+end
+
+function sp_at_idx(sig::UnionAll, idx::Int)
+    while idx != 1
+        sig = sig.body::UnionAll
+        idx -= 1
+    end
+    return sig.var
 end
 
 function va_from_vatuple(@nospecialize(t))

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -776,8 +776,7 @@ function compileable_specialization(code::Union{MethodInstance,CodeInstance}, ef
         new_atype = get_compileable_sig(method, atype, sparams)
         new_atype === nothing && return nothing
         if atype !== new_atype
-            sp_ = ccall(:jl_type_intersection_with_env, Any, (Any, Any), new_atype, method.sig)::SimpleVector
-            sparams = sp_[2]::SimpleVector
+            (_, sparams) = typeintersect_env(new_atype, method.sig)
             mi_invoke = specialize_method(method, new_atype, sparams)
             mi_invoke === nothing && return nothing
             code = mi_invoke
@@ -786,7 +785,7 @@ function compileable_specialization(code::Union{MethodInstance,CodeInstance}, ef
         # If this caller does not want us to optimize calls to use their
         # declared compilesig, then it is also likely they would handle sparams
         # incorrectly if there were any unknown typevars, so we conservatively return nothing
-        if any(@nospecialize(t)->isa(t, TypeVar), mi.sparam_vals)
+        if any(@nospecialize(t)->has_free_typevars(t), mi.sparam_vals)
             return nothing
         end
     end
@@ -855,7 +854,7 @@ end
 function validate_sparams(sparams::SimpleVector)
     for i = 1:length(sparams)
         spᵢ = sparams[i]
-        (isa(spᵢ, TypeVar) || isvarargtype(spᵢ)) && return false
+        (has_free_typevars(spᵢ) || isvarargtype(spᵢ)) && return false
     end
     return true
 end
@@ -1749,22 +1748,22 @@ function ssa_substitute_op!(insert_node!::Inserter, subst_inst::Instruction, @no
         if head === :static_parameter
             spidx = e.args[1]::Int
             val = sparam_vals[spidx]
-            if !isa(val, TypeVar) && val !== Vararg
+            if !has_free_typevars(val) && val !== Vararg
                 return quoted(val)
             else
                 flag = subst_inst[:flag]
-                maybe_undef = !has_flag(flag, IR_FLAG_NOTHROW) && isa(val, TypeVar)
+                maybe_undef = !has_flag(flag, IR_FLAG_NOTHROW) && has_free_typevars(val)
                 (ret, tcheck_not) = insert_spval!(insert_node!, ssa_substitute.spvals_ssa::SSAValue, spidx, maybe_undef)
                 if maybe_undef
                     insert_node!(
-                        NewInstruction(Expr(:throw_undef_if_not, val.name, tcheck_not), Nothing))
+                        NewInstruction(Expr(:throw_undef_if_not, sp_at_idx(ssa_substitute.mi.def.sig, spidx).name, tcheck_not), Nothing))
                 end
                 return ret
             end
         elseif head === :isdefined && isa(e.args[1], Expr) && e.args[1].head === :static_parameter
             spidx = (e.args[1]::Expr).args[1]::Int
             val = sparam_vals[spidx]
-            if !isa(val, TypeVar)
+            if !has_free_typevars(val)
                 return true
             else
                 (_, tcheck_not) = insert_spval!(insert_node!, ssa_substitute.spvals_ssa::SSAValue, spidx, true)

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1711,7 +1711,14 @@ function apply_type_nothrow(𝕃::AbstractLattice, argtypes::Vector{Any}, @nospe
                 end
             else
                 istype || return false
-                if isa(u.var.ub, TypeVar) || !(T <: u.var.ub)
+                if isa(u.var.ub, TypeVar)
+                    return false
+                end
+                Tub = T
+                while isa(Tub, TypeVar)
+                    Tub = Tub.ub
+                end
+                if !(Tub <: u.var.ub)
                     return false
                 end
                 if exact ? !(u.var.lb <: T) : !(u.var.lb === Bottom)

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1579,8 +1579,7 @@ function compileable_specialization_for_call(interp::AbstractInterpreter, @nospe
     compileable_atype = get_compileable_sig(match.method, match.spec_types, match.sparams)
     compileable_atype === nothing && return nothing
     if match.spec_types !== compileable_atype
-        sp_ = ccall(:jl_type_intersection_with_env, Any, (Any, Any), compileable_atype, match.method.sig)::SimpleVector
-        sparams = sp_[2]::SimpleVector
+        (_, sparams) = typeintersect_env(compileable_atype, match.method.sig)
         mi = specialize_method(match.method, compileable_atype, sparams)
     else
         mi = specialize_method(match.method, compileable_atype, match.sparams)

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -52,7 +52,7 @@ let t = Tuple{Ref{T},T,T} where T, c = Tuple{Ref, T, T} where T # #36407
 end
 
 # obtain Vararg with 2 undefined fields
-let va = ccall(:jl_type_intersection_with_env, Any, (Any, Any), Tuple{Tuple}, Tuple{Tuple{Vararg{Any, N}}} where N)[2][1]
+let va = Base.typeintersect_env(Tuple{Tuple}, Tuple{Tuple{Vararg{Any, N}}} where N)[2][1]
     @test Compiler.__limit_type_size(Tuple, va, Core.svec(va, Union{}), 2, 2) === Tuple
 end
 
@@ -1036,7 +1036,7 @@ end
 # issue #21410
 f21410(::V, ::Pair{V,E}) where {V, E} = E
 @test only(Base.return_types(f21410, Tuple{Ref, Pair{Ref{T},Ref{T}} where T<:Number})) ==
-    Type{E} where E <: (Ref{T} where T<:Number)
+    Type{Ref{T}} where T<:Number
 
 # issue #21369
 function inf_error_21369(arg)
@@ -2861,8 +2861,8 @@ let apply_type_tfunc = Compiler.apply_type_tfunc
     @test apply_type_tfunc(𝕃, Const(Val), Type{Union{Int,Pair{Pair{Pair{Pair{A,B},C},D},E}}} where {A,B,C,D,E}) == Type{Val{_A}} where _A
 end
 @test only(Base.return_types(keys, (Dict{String},))) == Base.KeySet{String, T} where T<:(Dict{String})
-@test only(Base.return_types((r)->similar(Array{typeof(r[])}, 1), (Base.RefValue{Array{Int}},))) == Vector{<:Array{Int}}
-@test only(Base.return_types((r)->similar(Array{typeof(r[])}, 1), (Base.RefValue{Array{<:Real}},))) == Vector{<:Array{<:Real}}
+@test only(Base.return_types((r)->similar(Array{typeof(r[])}, 1), (Base.RefValue{Array{Int}},))) == Vector{Array{Int, N}} where N
+@test only(Base.return_types((r)->similar(Array{typeof(r[])}, 1), (Base.RefValue{Array{<:Real}},))) == Vector{Array{T, N}} where {T<:Real, N}
 # test complexity limit on apply_type on a function capturing functions returning functions
 @test only(Base.return_types(Base.afoldl, (typeof((m, n) -> () -> Returns(nothing)(m, n)), Function, Function, Vararg{Function}))) === Function
 
@@ -5517,16 +5517,16 @@ function issue49027(::Type{<:Issue49027{Ty}}) where Ty
     end
     return nothing
 end
-@test only(Base.return_types(issue49027, (Type{Issue49027{TypeVar(:Ty)}},))) >: Nothing
-@test isnothing(issue49027(Issue49027{TypeVar(:Ty)}))
+@test_skip only(Base.return_types(issue49027, (Type{Issue49027{TypeVar(:Ty)}},))) >: Nothing
+@test_skip isnothing(issue49027(Issue49027{TypeVar(:Ty)}))
 function issue49027_integer(::Type{<:Issue49027{Ty}}) where Ty<:Integer
     if @isdefined Ty # should be false when `Ty` is given as a free type var.
         return Ty::DataType
     end
     nothing
 end
-@test only(Base.return_types(issue49027_integer, (Type{Issue49027{TypeVar(:Ty,Int)}},))) >: Nothing
-@test isnothing(issue49027_integer(Issue49027{TypeVar(:Ty,Int)}))
+@test_skip only(Base.return_types(issue49027_integer, (Type{Issue49027{TypeVar(:Ty,Int)}},))) >: Nothing
+@test_skip isnothing(issue49027_integer(Issue49027{TypeVar(:Ty,Int)}))
 
 function fapplicable end
 gapplicable() = Val(applicable(fapplicable))

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -4596,7 +4596,7 @@ function precompile(@nospecialize(f), @nospecialize(argtypes::Tuple), m::Method)
 end
 
 function precompile(@nospecialize(argt::Type), m::Method)
-    atype, sparams = ccall(:jl_type_intersection_with_env, Any, (Any, Any), argt, m.sig)::SimpleVector
+    atype, sparams = typeintersect_env(argt, m.sig)
     mi = Base.Compiler.specialize_method(m, atype, sparams)
     return precompile(mi)
 end

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -980,7 +980,7 @@ julia> [0 1; 2 3] .|> (x -> x^2) |> sum
 |>(x, f) = f(x)
 
 _stable_typeof(x) = typeof(x)
-_stable_typeof(::Type{T}) where {T} = @isdefined(T) ? Type{T} : DataType
+_stable_typeof(::Type{T}) where {T} = @isdefined(T) && !Core.has_free_typevars(T) ? Type{T} : DataType
 
 """
     f = Returns(value)

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1439,6 +1439,47 @@ has_bottom_parameter(t::Union) = has_bottom_parameter(t.a) & has_bottom_paramete
 has_bottom_parameter(t::TypeVar) = has_bottom_parameter(t.ub)
 has_bottom_parameter(::Any) = false
 
+function find_free_typevars(@nospecialize(t))
+    return ccall(:jl_find_free_typevars, Array{Any, 1}, (Any,), t)
+end
+
+"""
+    rewrap_free_typevars(@nospecialize(t), pre=Core.svec())
+
+Wrap `t` in `UnionAll` for each `TypeVar` that is free in `t` but not referenced
+in `pre` (the typevars that were free in the consumer's input before an env was
+applied).
+
+This is the consumer-side complement to `jl_type_intersection_env` /
+`jl_subtype_env`: the env svec may contain entries whose typevar identity is
+shared across slots. Rather than wrapping each slot independently (which breaks
+that identity), callers that build a new type from the env should apply this
+helper once to the final reconstructed type.
+"""
+function rewrap_free_typevars(@nospecialize(t), pre=Core.svec())
+    has_free_typevars(t) || return t
+    # UnionAll cannot directly wrap a Vararg; the caller must wrap it in Tuple first
+    isvarargtype(t) && return t
+    fv = find_free_typevars(t)
+    for i in length(fv):-1:1
+        v = fv[i]::TypeVar
+        wrap = true
+        for p in pre
+            if p === v
+                wrap = false
+                break
+            end
+        end
+        wrap && (t = UnionAll(v, t))
+    end
+    return t
+end
+
+function typeintersect_env(@nospecialize(a), @nospecialize(b))
+    (ti, env) = ccall(:jl_type_intersection_with_env, Any, (Any, Any), a, b)::SimpleVector
+    Pair{Any, SimpleVector}(ti, env)
+end
+
 min_world(m::Core.CodeInstance) = m.min_world
 max_world(m::Core.CodeInstance) = m.max_world
 min_world(m::Core.CodeInfo) = m.min_world
@@ -1756,8 +1797,7 @@ function normalize_typevars(method::Method, @nospecialize(atype), sparams::Simpl
     at2 = subst_trivial_bounds(atype)
     if at2 !== atype && at2 == atype
         atype = at2
-        sp_ = ccall(:jl_type_intersection_with_env, Any, (Any, Any), at2, method.sig)::SimpleVector
-        sparams = sp_[2]::SimpleVector
+        (_, sparams) = typeintersect_env(at2, method.sig)
     end
     return Pair{Any,SimpleVector}(atype, sparams)
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -632,18 +632,14 @@ function make_typealias(@nospecialize(x::Type))
     mods = modulesof!(Set{Module}(), x)
     replace!(mods, Core=>Base)
     aliases = Tuple{GlobalRef,SimpleVector}[]
-    xenv = UnionAll[]
-    for p in uniontypes(unwrap_unionall(x))
-        p isa UnionAll && push!(xenv, p)
-    end
-    x isa UnionAll && push!(xenv, x)
     for mod in mods
         for name in unsorted_names(mod)
             if isdefinedglobal(mod, name) && !isdeprecated(mod, name) && isconst(mod, name)
                 alias = getglobal(mod, name)
                 if alias isa Type && !has_free_typevars(alias) && !print_without_params(alias) && x <: alias
                     if alias isa UnionAll
-                        (ti, env) = ccall(:jl_type_intersection_with_env, Any, (Any, Any), x, alias)::SimpleVector
+                        free_before = find_free_typevars(x)
+                        (ti, env) = typeintersect_env(x, alias)
                         # ti === Union{} && continue # impossible, since we already checked that x <: alias
                         env = env::SimpleVector
                         # TODO: In some cases (such as the following), the `env` is over-approximated.
@@ -663,11 +659,9 @@ function make_typealias(@nospecialize(x::Type))
                                 ex isa TypeError || rethrow()
                                 continue
                             end
-                        for p in xenv
-                            applied = rewrap_unionall(applied, p)
-                        end
+                        applied = rewrap_free_typevars(applied, free_before)
                         has_free_typevars(applied) && continue
-                        applied === x || continue # it couldn't figure out the parameter matching
+                        applied == x || continue # it couldn't figure out the parameter matching
                     elseif alias === x
                         env = Core.svec()
                     else
@@ -846,7 +840,7 @@ function make_typealiases(@nospecialize(x::Type))
             if isdefinedglobal(mod, name) && !isdeprecated(mod, name) && isconst(mod, name)
                 alias = getglobal(mod, name)
                 if alias isa Type && !has_free_typevars(alias) && !print_without_params(alias) && !(alias <: Tuple)
-                    (ti, env) = ccall(:jl_type_intersection_with_env, Any, (Any, Any), x, alias)::SimpleVector
+                    (ti, env) = typeintersect_env(x, alias)
                     ti === Union{} && continue
                     # make sure this alias wasn't from an unrelated part of the Union
                     mod2 = modulesof!(Set{Module}(), alias)

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1140,7 +1140,7 @@ julia> const T1 = Array{Array{T, 1} where T, 1}
 Vector{Vector} (alias for Array{Array{T, 1} where T, 1})
 
 julia> const T2 = Array{Array{T, 1}, 1} where T
-Array{Vector{T}, 1} where T
+Vector{Vector{T}} where T (alias for Array{Array{T, 1}, 1} where T)
 ```
 
 Type `T1` defines a 1-dimensional array of 1-dimensional arrays; each

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3133,7 +3133,7 @@ static std::pair<bool, bool> uses_specsig(jl_value_t *abi, jl_method_instance_t 
         if ((size_t)jl_subtype_env_size(lam->def.method->sig) != jl_svec_len(lam->sparam_vals))
             needsparams = true;
         for (size_t i = 0; i < jl_svec_len(lam->sparam_vals); ++i) {
-            if (jl_is_typevar(jl_svecref(lam->sparam_vals, i)))
+            if (jl_has_free_typevars(jl_svecref(lam->sparam_vals, i)))
                 needsparams = true;
         }
     }
@@ -3317,7 +3317,7 @@ static jl_value_t *static_eval(jl_codectx_t &ctx, jl_value_t *ex)
             size_t idx = jl_unbox_long(jl_exprarg(e, 0));
             if (idx <= jl_svec_len(ctx.linfo->sparam_vals)) {
                 jl_value_t *e = jl_svecref(ctx.linfo->sparam_vals, idx - 1);
-                if (jl_is_typevar(e))
+                if (jl_has_free_typevars(e))
                     return NULL;
                 return e;
             }
@@ -5839,7 +5839,7 @@ static jl_cgval_t emit_sparam(jl_codectx_t &ctx, size_t i)
 {
     if (jl_svec_len(ctx.linfo->sparam_vals) > 0) {
         jl_value_t *e = jl_svecref(ctx.linfo->sparam_vals, i);
-        if (!jl_is_typevar(e)) {
+        if (!jl_has_free_typevars(e)) {
             return mark_julia_const(ctx, e);
         }
     }
@@ -5891,7 +5891,7 @@ static jl_cgval_t emit_isdefined(jl_codectx_t &ctx, jl_value_t *sym, int allow_i
         size_t i = jl_unbox_long(jl_exprarg(sym, 0)) - 1;
         if (jl_svec_len(ctx.linfo->sparam_vals) > 0) {
             jl_value_t *e = jl_svecref(ctx.linfo->sparam_vals, i);
-            if (!jl_is_typevar(e)) {
+            if (!jl_has_free_typevars(e)) {
                 return mark_julia_const(ctx, jl_true);
             }
         }

--- a/src/gf.c
+++ b/src/gf.c
@@ -1697,7 +1697,7 @@ jl_method_instance_t *cache_method(
                 int k, l;
                 for (k = 0, l = jl_svec_len(env); k < l; k++) {
                     jl_value_t *env_k = jl_svecref(env, k);
-                    if (jl_is_typevar(env_k) || jl_is_vararg(env_k)) {
+                    if (jl_has_free_typevars(env_k) || jl_is_vararg(env_k)) {
                         unmatched_tvars = 1;
                         break;
                     }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -266,7 +266,7 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
             assert(n > 0);
             if (s->sparam_vals && n <= jl_svec_len(s->sparam_vals)) {
                 jl_value_t *sp = jl_svecref(s->sparam_vals, n - 1);
-                defined = !jl_is_typevar(sp);
+                defined = !jl_has_free_typevars(sp);
             }
             else {
                 // static parameter val unknown needs to be an error for ccall
@@ -324,7 +324,7 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         assert(n > 0);
         if (s->sparam_vals && n <= jl_svec_len(s->sparam_vals)) {
             jl_value_t *sp = jl_svecref(s->sparam_vals, n - 1);
-            if (jl_is_typevar(sp) && !s->preevaluation)
+            if (jl_has_free_typevars(sp) && !s->preevaluation)
                 jl_undefined_var_error(((jl_tvar_t*)sp)->name, (jl_value_t*)jl_static_parameter_sym);
             return sp;
         }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -175,8 +175,19 @@ static void find_free_typevars(jl_value_t *v, jl_typeenv_t *env, jl_array_t *out
 {
     while (1) {
         if (jl_is_typevar(v)) {
-            if (!typeenv_has(env, (jl_tvar_t*)v))
+            jl_tvar_t *var = (jl_tvar_t*)v;
+            if (!typeenv_has(env, var)) {
+                jl_typeenv_t *newenv = (jl_typeenv_t*)alloca(sizeof(jl_typeenv_t));
+                newenv->var = var;
+                newenv->val = NULL;
+                newenv->prev = env;
+                env = newenv;
+                if (var->lb != jl_bottom_type)
+                    find_free_typevars(var->lb, env, out);
+                if (var->ub != (jl_value_t*)jl_any_type)
+                    find_free_typevars(var->ub, env, out);
                 jl_array_ptr_1d_push(out, v);
+            }
             return;
         }
         if (jl_is_typeapp(v)) {

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2683,9 +2683,12 @@ static jl_value_t *inst_type_w_(jl_value_t *t, jl_typeenv_t *env, jl_typestack_t
             if (newbody == NULL) {
                 t = NULL;
             }
-            else if (!jl_has_typevar(newbody, (jl_tvar_t *)var)) {
-                // inner instantiation might make a typevar disappear, e.g.
-                // NTuple{0,T} => Tuple{}
+            else if (!jl_has_typevar(newbody, (jl_tvar_t *)var) && jl_has_typevar(ua->body, ua->var)) {
+                // inner instantiation made a typevar disappear, e.g.
+                // NTuple{0,T} => Tuple{}; drop the now-vacuous UnionAll
+                // However, if the original body was degenerate and didn't have the typevar (special
+                // case in method signature creation, then we don't normalize it here either to avoid
+                // confusing subtyping).
                 t = newbody;
             }
             else if (newbody != ua->body || var != (jl_value_t*)ua->var) {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -932,6 +932,7 @@ jl_method_t *jl_mk_builtin_func(jl_datatype_t *dt, jl_sym_t *name, jl_fptr_args_
 int jl_obviously_unequal(jl_value_t *a, jl_value_t *b);
 int jl_has_bound_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_array_t *jl_find_free_typevars(jl_value_t *v);
+JL_DLLEXPORT jl_value_t *jl_rewrap_free_typevars(jl_value_t *t, jl_array_t *pre);
 int jl_has_fixed_layout(jl_datatype_t *t);
 JL_DLLEXPORT int jl_struct_try_layout(jl_datatype_t *dt);
 JL_DLLEXPORT int jl_type_mappable_to_c(jl_value_t *ty);

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -964,33 +964,6 @@ static jl_value_t *widen_Type_to_union(jl_value_t *t, jl_value_t *bound, jl_sten
     return t;
 }
 
-// convert a type with free variables to a typevar bounded by a UnionAll-wrapped
-// version of that type.
-// TODO: This loses some inference precision. For example in a case where a
-// variable bound is `Vector{_}`, we could potentially infer `Type{Vector{_}} where _`,
-// but this causes us to infer the larger `Type{T} where T<:Vector` instead.
-// However this is needed because many contexts check `isa(sp, TypeVar)` to determine
-// when a static parameter value is not known exactly.
-static jl_value_t *fix_inferred_var_bound(jl_tvar_t *var, jl_value_t *ty JL_MAYBE_UNROOTED)
-{
-    if (ty == NULL) // may happen if the user is intersecting with an incomplete type
-        return (jl_value_t*)var;
-    if (!jl_is_typevar(ty) && jl_has_free_typevars(ty)) {
-        jl_value_t *ans = ty;
-        jl_array_t *vs = NULL;
-        JL_GC_PUSH2(&ans, &vs);
-        vs = jl_find_free_typevars(ty);
-        int i;
-        for (i = 0; i < jl_array_nrows(vs); i++) {
-            ans = jl_type_unionall((jl_tvar_t*)jl_array_ptr_ref(vs, i), ans);
-        }
-        ans = (jl_value_t*)jl_new_typevar(var->name, jl_bottom_type, ans);
-        JL_GC_POP();
-        return ans;
-    }
-    return ty;
-}
-
 static int var_occurs_inside(jl_value_t *v, jl_tvar_t *var, int inside, int want_inv) JL_NOTSAFEPOINT;
 
 typedef int (*tvar_callback)(void*, int8_t, jl_stenv_t *, int);
@@ -2366,16 +2339,6 @@ JL_DLLEXPORT int jl_subtype_env(jl_value_t *x, jl_value_t *y, jl_value_t **env, 
     if (obvious_subtype == 0 || (obvious_subtype == 1 && envsz == 0))
         subtype = obvious_subtype; // this ensures that running in a debugger doesn't change the result
 #endif
-    if (env) {
-        jl_unionall_t *ub = (jl_unionall_t*)y;
-        int i;
-        for (i = 0; i < envsz; i++) {
-            assert(jl_is_unionall(ub));
-            jl_tvar_t *var = ub->var;
-            env[i] = fix_inferred_var_bound(var, env[i]);
-            ub = (jl_unionall_t*)ub->body;
-        }
-    }
     return subtype;
 }
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -8783,3 +8783,7 @@ module AmbiguousUsing60659
     using .D, .A
     @test_throws UndefVarError X
 end
+
+# Behavior of TypeVar with lower bound
+f_def_typevar_with_lowerbound(x::T) where {T>:Int} = @isdefined(T) ? T : false
+@test f_def_typevar_with_lowerbound(1.0) == false

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -373,7 +373,7 @@ end
     @test sprint(show, Returns(1.0)) == "Returns{Float64}(1.0)"
 
     illtype = Vector{Core.TypeVar(:T)}
-    @test Returns(illtype) == Returns{DataType}(illtype)
+    @test_skip Returns(illtype) == Returns{DataType}(illtype)
 end
 
 @testset "<= (issue #46327)" begin

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -15,7 +15,7 @@ notequal_type(@nospecialize(x),@nospecialize(y)) = !isequal_type(x, y)
 
 _type_intersect(@nospecialize(x), @nospecialize(y)) = ccall(:jl_intersect_types, Any, (Any, Any), x, y)
 
-intersection_env(@nospecialize(x), @nospecialize(y)) = ccall(:jl_type_intersection_with_env, Any, (Any,Any), x, y)
+intersection_env(@nospecialize(x), @nospecialize(y)) = Core.svec(Base.typeintersect_env(x, y)...)
 
 # level 1: no varags, union, UnionAll
 function test_1()

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2866,3 +2866,32 @@ end
 @test !(Tuple{Union{Int16,Int8},Ref{Int16},Ref{Int16}} <: Tuple{<:Union{S,T},Ref{S},Ref{T}} where {S,T})
 @test !(Tuple{Ref{Int16},Ref{Int16},Union{Int16,Int8}} <: Tuple{Ref{S},Ref{T},<:Union{S,T}} where {S,T})
 @test Tuple{NTuple{2,Int}, Int8} <: Tuple{<:Union{NTuple{2,T},Tuple{S,T}}, <:T} where {S,T>:Int}
+
+# issue #61634: an unused typevar in a method signature's `where` clause must be
+# reported in env at its declared index, not dropped or shifted. A naive walk of
+# `y`'s UnionAlls in `jl_subtype_env` is insufficient when an unalias-triggered
+# rebuild of `y` collapses the inner UnionAll: a used typevar that originally
+# sat at index k+1 then lands at index k, and the subsequent typevar's slot
+# stays empty.
+@test_warn "declares type variable pad but does not use it" @eval f61634(::Type{TW}, ::AbstractArray{T,N}) where {N, T, TW<:Real, pad} = T
+let sig = methods(f61634)[1].sig
+    _, env = intersection_env(Tuple{typeof(f61634), Type, Vector}, sig)
+    @test env[1] === 1
+    @test env[2] isa TypeVar && env[2].name === :T
+    @test env[3] isa TypeVar && env[3].name === :TW
+    @test env[4] isa TypeVar && env[4].name === :pad
+end
+# Same issue but with the unused typevar in the middle — exercises the wrong-index
+# case where dropping the inner UnionAll would shift later typevars to the wrong slot.
+@test_warn "declares type variable pad but does not use it" @eval g61634(::Type{TW}, ::AbstractArray{T,N}) where {N, pad, TW<:Real, T} = T
+let sig = methods(g61634)[1].sig, N_var = sig.var
+    # Force a rename of `b`'s outer typevar by sharing its identity with `x`,
+    # which is what causes `inst_type_w_` to rebuild the body and (without the
+    # fix) drop the unused inner UnionAll for `pad`.
+    x = UnionAll(N_var, Tuple{typeof(g61634), Type, AbstractArray{Int, N_var}})
+    _, env = intersection_env(x, sig)
+    @test env[1] isa TypeVar && env[1].name === :N
+    @test env[2] isa TypeVar && env[2].name === :pad
+    @test env[3] isa TypeVar && env[3].name === :TW
+    @test env[4] === Int
+end


### PR DESCRIPTION
In various places in the system we were relying on the identity of TypeVars obtained from intersection to make decisions. This is problematic, because intersection makes no gurantees about this and in particular can rename TypeVars freely if duplicates are encountered. It also causes problems when attempting to change the output representation of intersection (e.g. #61366). This PR does some prepratory work removing those unsound code paths as well as removing the fix_inferred_var_bound code path, which also did not have well defined semantics. One place remains: When inference computs whether any subtype of a method specialization has an unbound typevar, this still relies on TypeVar identity. I don't see any good way to express this query with just the information currently returned from intersection (though I'm open to suggestions), so I think we may want to extend the algorithm to explicitly compute this query along with the envout. That is a significant change though and as such is punted from this PR.

I should also note that this PR changes some incidental behavior of TypeVar matching for free typevars in dispatch. This behavior is currently not defined, but I'm planning to do so in the near future. I've tried to move the implementation towards the behavior that I want it to have, but this PR by itself does not yet define this behavior.

Written by hand - this was too hard for Claude.