### PR TITLE
[Julia 1.11] method: add missing write barriers for linetable and codelocs in jl_code_info_set_ir

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -304,8 +304,10 @@ static void jl_code_info_set_ir(jl_code_info_t *li, jl_expr_t *ir)
     jl_expr_t *bodyex = (jl_expr_t*)jl_exprarg(ir, 2);
     jl_value_t *codelocs = jl_exprarg(ir, 3);
     li->linetable = jl_exprarg(ir, 4);
+    jl_gc_wb(li, li->linetable);
     size_t nlocs = jl_array_nrows(codelocs);
     li->codelocs = (jl_value_t*)jl_alloc_array_1d(jl_array_int32_type, nlocs);
+    jl_gc_wb(li, li->codelocs);
     size_t j;
     for (j = 0; j < nlocs; j++) {
         jl_array_uint32_set((jl_array_t*)li->codelocs, j, jl_unbox_long(jl_array_ptr_ref((jl_array_t*)codelocs, j)));


### PR DESCRIPTION
Noticed while using `WITH_GC_DEBUG_ENV` and `JULIA_GC_ALLOC_OTHER=1 ./julia -e "exit()"` (#61637)

When jl_alloc_array_1d triggers a GC during jl_code_info_set_ir, the
CodeInfo `li` can be promoted from young to old. Subsequent assignments
to li->linetable and li->codelocs without write barriers leave those
objects invisible to the GC when li is later processed from the remset,
causing them to be incorrectly collected.

Fixes a crash in gc_assert_parent_validity (SEGFAULT on invalid child_vt)
when running with JULIA_GC_ALLOC_OTHER=1, exposed by the wb_back change
in 29b3528ccea which increased GC frequency during task switches.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
