### PR TITLE
gc: fix assert(!freedall) when gc_scrub marks past lim_newpages 

### DIFF
--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -941,7 +941,12 @@ static void gc_sweep_page(gc_page_profiler_serializer_t *s, jl_gc_pool_t *p, jl_
             }
             v = (jl_taggedvalue_t*)((char*)v + osize);
         }
-        assert(!freedall);
+        // gc_scrub_range (active under WITH_GC_DEBUG_ENV) conservatively marks any
+        // pool object found on a task stack, including slots past lim_newpages on the
+        // currently-active bump-pointer page. Those slots are unconditionally treated
+        // as garbage by the sweep (line above: `(char*)v >= lim_newpages`), so
+        // freedall=1 is valid when this is the active newpages page.
+        assert(!freedall || lim_newpages < data + GC_PAGE_SZ);
         pg->has_marked = has_marked;
         pg->has_young = has_young;
         if (pfl_begin) {


### PR DESCRIPTION
`gc_scrub_range` (active under `WITH_GC_DEBUG_ENV`) conservatively marks any
pool object it finds on a task stack by setting `pg->has_marked = 1` and
`tag->bits.gc = GC_MARKED`. It does not account for the pool's bump-pointer
allocation frontier (`pool->newpages`): slots at or beyond this boundary are
unconditionally treated as garbage by `gc_sweep_page` regardless of their GC
bits (the `(char*)v >= lim_newpages` check). When every slot on such a page
falls past the frontier, `freedall` stays 1 and `assert(!freedall)` fires.

The mismatch was introduced by PR #50137 (June 2023), which switched the pool
allocator to a bump-pointer scheme and added the `lim_newpages` guard in
sweep, without updating `gc_scrub_range` to match.

Fix: relax the assertion to permit `freedall=1` when `lim_newpages` is before
the end of the page (i.e., this is the currently-active bump-pointer page).
That is precisely the case where `gc_scrub` can set `has_marked=1` while the
sweep legitimately finds no live objects.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
