### PR TITLE
ast: unwrap MacroSource before `jl_timing_show_macro`

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -1059,7 +1059,9 @@ lno_ok:
             jl_method_error(margs[0], &margs[1], nargs, ct->world_age);
             // unreachable
         }
-        jl_timing_show_macro(mfunc, margs[1], inmodule, JL_TIMING_DEFAULT_BLOCK);
+        // margs[1] may still be a MacroSource; timing wants the inner LineNumberNode
+        jl_timing_show_macro(mfunc, retry_lno != NULL ? retry_lno : margs[1],
+                             inmodule, JL_TIMING_DEFAULT_BLOCK);
         *ctx = mfunc->def.method->module;
         result = jl_invoke(margs[0], &margs[1], nargs - 1, mfunc);
     }


### PR DESCRIPTION
When a macro accepts a `Core.MacroSource` argument (e.g. `@VERSION`) and the first method lookup succeeds, `margs[1]` remains a `MacroSource` rather than the inner `LineNumberNode`. Passing it to `jl_timing_show_macro` then trips an assertion in assertions builds. Use the already-unwrapped `retry_lno` for the timing call when available.

This was introduced by https://github.com/JuliaLang/julia/pull/60018 (cc @keno).

Fixes assertion seen locally:
```
julia: /home/tim/Julia/src/julia/src/timing.c:617: jl_timing_show_macro: Assertion `jl_typetagis(lno, jl_linenumbernode_type)' failed.
```

Requires assertions + timings to be enabled (e.g. `WITH_TRACY=1`), which presumably explains why `gnuassert` didn't catch this.