### PR TITLE
Update mtime of libclang_rt.osx.a after moving

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -386,6 +386,7 @@ ifeq ($(OS),Darwin)
 $(eval $(call bb-install,compilerrt,COMPILERRT,false,false))
 $(build_libdir)/libclang_rt.osx.a: $(build_prefix)/manifest/compilerrt
 	mv $(build_libdir)/darwin/libclang_rt.osx.a $@
+	touch $@
 	rm -rf $(build_libdir)/darwin
 install-compilerrt: $(build_libdir)/libclang_rt.osx.a
 install-llvm: install-compilerrt


### PR DESCRIPTION
`mv` preserves the mtime of `libclang_rt.osx.a`, which is older than the mtime of `$(build_prefix)/manifest/compilerrt`, causing subsequent builds to fail with `mv: cannot stat 'usr/lib/darwin/libclang_rt.osx.a': No such file or directory`. Fix this by touching `libclang_rt.osx.a` after installing it.