### PR TITLE
errorshow: Hint on same-named types from different modules

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -360,9 +360,6 @@ function showerror(io::IO, ex::MethodError)
             end
         end
     end
-    # Check for arguments whose types share a name with a different type expected
-    # by some method of `f` — e.g. passing a `Main.Foo` where a `Bar.Foo` is expected
-    # (issue #41084). Surface this explicitly because both types print as plain `Foo`.
     if !is_arg_types && !(f isa Core.Builtin)
         show_shadowed_type_hint(io, f, san_arg_types_param)
     end
@@ -460,35 +457,21 @@ stacktrace_expand_basepaths()::Bool = Base.get_bool_env("JULIA_STACKTRACE_EXPAND
 stacktrace_contract_userdir()::Bool = Base.get_bool_env("JULIA_STACKTRACE_CONTRACT_HOMEDIR", true) === true
 stacktrace_linebreaks()::Bool = Base.get_bool_env("JULIA_STACKTRACE_LINEBREAKS", false) === true
 
-_shadow_datatype(@nospecialize(T)) = (T = unwrap_unionall(T); T isa DataType ? T : nothing)
+_datatype_or_nothing(@nospecialize(T)) = (T = unwrap_unionall(T); T isa DataType ? T : nothing)
 
-# For each argument of a failed dispatch, check whether any method of `f`
-# expects a different type that nonetheless shares the same short name
-# (e.g. the user passed `Main.Foo` where a method expected `Bar.Foo`).
-# Print a hint naming both types with their module prefixes.
 function show_shadowed_type_hint(io::IO, @nospecialize(f), san_arg_types_param::Vector{Any})
     reported = IdSet{Core.TypeName}()
-    ms = try
-        methods(f)
-    catch
-        return nothing
-    end
-    for method in ms
+    for method in methods(f)
         msig = unwrap_unionall(method.sig)
         isa(msig, DataType) || continue
         mparams = msig.parameters
-        # mparams[1] is the function type; argument types start at index 2
-        n = min(length(mparams) - 1, length(san_arg_types_param))
-        for i in 1:n
+        for i in 1:min(length(mparams) - 1, length(san_arg_types_param))
             expected = mparams[i + 1]
-            if isa(expected, Core.TypeofVararg)
-                expected = unwrapva(expected)
-            end
-            e_dt = _shadow_datatype(expected)
-            a_dt = _shadow_datatype(san_arg_types_param[i])
+            isa(expected, Core.TypeofVararg) && (expected = unwrapva(expected))
+            e_dt = _datatype_or_nothing(expected)
+            a_dt = _datatype_or_nothing(san_arg_types_param[i])
             (e_dt === nothing || a_dt === nothing) && continue
-            e_tn = e_dt.name
-            a_tn = a_dt.name
+            e_tn, a_tn = e_dt.name, a_dt.name
             e_tn === a_tn && continue
             e_tn.name === a_tn.name || continue
             (isdefined(e_tn, :module) && isdefined(a_tn, :module)) || continue
@@ -503,7 +486,6 @@ function show_shadowed_type_hint(io::IO, @nospecialize(f), san_arg_types_param::
                   "` but are distinct types defined in different modules.")
         end
     end
-    return nothing
 end
 
 function show_method_candidates(io::IO, ex::MethodError, kwargs=[])

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -360,6 +360,12 @@ function showerror(io::IO, ex::MethodError)
             end
         end
     end
+    # Check for arguments whose types share a name with a different type expected
+    # by some method of `f` — e.g. passing a `Main.Foo` where a `Bar.Foo` is expected
+    # (issue #41084). Surface this explicitly because both types print as plain `Foo`.
+    if !is_arg_types && !(f isa Core.Builtin)
+        show_shadowed_type_hint(io, f, san_arg_types_param)
+    end
     if ex.world == typemax(UInt) || hasmethod(f, arg_types, world=ex.world)
         if !isempty(kwargs)
             print(io, "\nThis method does not support all of the given keyword arguments (and may not support any).")
@@ -453,6 +459,52 @@ end
 stacktrace_expand_basepaths()::Bool = Base.get_bool_env("JULIA_STACKTRACE_EXPAND_BASEPATHS", false) === true
 stacktrace_contract_userdir()::Bool = Base.get_bool_env("JULIA_STACKTRACE_CONTRACT_HOMEDIR", true) === true
 stacktrace_linebreaks()::Bool = Base.get_bool_env("JULIA_STACKTRACE_LINEBREAKS", false) === true
+
+_shadow_datatype(@nospecialize(T)) = (T = unwrap_unionall(T); T isa DataType ? T : nothing)
+
+# For each argument of a failed dispatch, check whether any method of `f`
+# expects a different type that nonetheless shares the same short name
+# (e.g. the user passed `Main.Foo` where a method expected `Bar.Foo`).
+# Print a hint naming both types with their module prefixes.
+function show_shadowed_type_hint(io::IO, @nospecialize(f), san_arg_types_param::Vector{Any})
+    reported = IdSet{Core.TypeName}()
+    ms = try
+        methods(f)
+    catch
+        return nothing
+    end
+    for method in ms
+        msig = unwrap_unionall(method.sig)
+        isa(msig, DataType) || continue
+        mparams = msig.parameters
+        # mparams[1] is the function type; argument types start at index 2
+        n = min(length(mparams) - 1, length(san_arg_types_param))
+        for i in 1:n
+            expected = mparams[i + 1]
+            if isa(expected, Core.TypeofVararg)
+                expected = unwrapva(expected)
+            end
+            e_dt = _shadow_datatype(expected)
+            a_dt = _shadow_datatype(san_arg_types_param[i])
+            (e_dt === nothing || a_dt === nothing) && continue
+            e_tn = e_dt.name
+            a_tn = a_dt.name
+            e_tn === a_tn && continue
+            e_tn.name === a_tn.name || continue
+            (isdefined(e_tn, :module) && isdefined(a_tn, :module)) || continue
+            e_tn.module === a_tn.module && continue
+            a_tn in reported && continue
+            push!(reported, a_tn)
+            print(io, "\nThe types `")
+            show_unquoted(io, a_tn.module); print(io, ".", a_tn.name)
+            print(io, "` and `")
+            show_unquoted(io, e_tn.module); print(io, ".", e_tn.name)
+            print(io, "` share the same name `", a_tn.name,
+                  "` but are distinct types defined in different modules.")
+        end
+    end
+    return nothing
+end
 
 function show_method_candidates(io::IO, ex::MethodError, kwargs=[])
     @nospecialize io

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -461,12 +461,20 @@ _datatype_or_nothing(@nospecialize(T)) = (T = unwrap_unionall(T); T isa DataType
 
 function show_shadowed_type_hint(io::IO, @nospecialize(f), san_arg_types_param::Vector{Any})
     reported = IdSet{Core.TypeName}()
+    ft = Core.Typeof(f)
     for method in methods(f)
         msig = unwrap_unionall(method.sig)
         isa(msig, DataType) || continue
         mparams = msig.parameters
-        for i in 1:min(length(mparams) - 1, length(san_arg_types_param))
-            expected = mparams[i + 1]
+        nargs = length(san_arg_types_param)
+        last_is_va = !isempty(mparams) && isa(mparams[end], Core.TypeofVararg)
+        if !last_is_va && nargs != length(mparams) - 1
+            continue
+        end
+        new_args = copy(san_arg_types_param)
+        shadows = Tuple{Core.TypeName,Core.TypeName}[]
+        for i in 1:nargs
+            expected = i + 1 <= length(mparams) ? mparams[i + 1] : mparams[end]
             isa(expected, Core.TypeofVararg) && (expected = unwrapva(expected))
             e_dt = _datatype_or_nothing(expected)
             a_dt = _datatype_or_nothing(san_arg_types_param[i])
@@ -476,14 +484,19 @@ function show_shadowed_type_hint(io::IO, @nospecialize(f), san_arg_types_param::
             e_tn.name === a_tn.name || continue
             (isdefined(e_tn, :module) && isdefined(a_tn, :module)) || continue
             e_tn.module === a_tn.module && continue
+            new_args[i] = rewrap_unionall(expected, method.sig)
+            push!(shadows, (a_tn, e_tn))
+        end
+        isempty(shadows) && continue
+        Tuple{ft, new_args...} <: method.sig || continue
+        for (a_tn, e_tn) in shadows
             a_tn in reported && continue
             push!(reported, a_tn)
-            print(io, "\nThe types `")
-            show_unquoted(io, a_tn.module); print(io, ".", a_tn.name)
-            print(io, "` and `")
+            print(io, "\nYou may have intended `")
             show_unquoted(io, e_tn.module); print(io, ".", e_tn.name)
-            print(io, "` share the same name `", a_tn.name,
-                  "` but are distinct types defined in different modules.")
+            print(io, "` rather than `")
+            show_unquoted(io, a_tn.module); print(io, ".", a_tn.name)
+            print(io, "`.")
         end
     end
 end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -457,8 +457,6 @@ stacktrace_expand_basepaths()::Bool = Base.get_bool_env("JULIA_STACKTRACE_EXPAND
 stacktrace_contract_userdir()::Bool = Base.get_bool_env("JULIA_STACKTRACE_CONTRACT_HOMEDIR", true) === true
 stacktrace_linebreaks()::Bool = Base.get_bool_env("JULIA_STACKTRACE_LINEBREAKS", false) === true
 
-_datatype_or_nothing(@nospecialize(T)) = (T = unwrap_unionall(T); T isa DataType ? T : nothing)
-
 function show_shadowed_type_hint(io::IO, @nospecialize(f), san_arg_types_param::Vector{Any})
     reported = IdSet{Core.TypeName}()
     ft = Core.Typeof(f)
@@ -467,22 +465,20 @@ function show_shadowed_type_hint(io::IO, @nospecialize(f), san_arg_types_param::
         isa(msig, DataType) || continue
         mparams = msig.parameters
         nargs = length(san_arg_types_param)
-        last_is_va = !isempty(mparams) && isa(mparams[end], Core.TypeofVararg)
-        if !last_is_va && nargs != length(mparams) - 1
-            continue
-        end
+        is_va = !isempty(mparams) && isa(mparams[end], Core.TypeofVararg)
+        is_va || nargs == length(mparams) - 1 || continue
         new_args = copy(san_arg_types_param)
         shadows = Tuple{Core.TypeName,Core.TypeName}[]
         for i in 1:nargs
-            expected = i + 1 <= length(mparams) ? mparams[i + 1] : mparams[end]
+            expected = mparams[min(i + 1, length(mparams))]
             isa(expected, Core.TypeofVararg) && (expected = unwrapva(expected))
-            e_dt = _datatype_or_nothing(expected)
-            a_dt = _datatype_or_nothing(san_arg_types_param[i])
-            (e_dt === nothing || a_dt === nothing) && continue
+            e_dt = unwrap_unionall(expected)
+            a_dt = unwrap_unionall(san_arg_types_param[i])
+            isa(e_dt, DataType) && isa(a_dt, DataType) || continue
             e_tn, a_tn = e_dt.name, a_dt.name
             e_tn === a_tn && continue
             e_tn.name === a_tn.name || continue
-            (isdefined(e_tn, :module) && isdefined(a_tn, :module)) || continue
+            isdefined(e_tn, :module) && isdefined(a_tn, :module) || continue
             e_tn.module === a_tn.module && continue
             new_args[i] = rewrap_unionall(expected, method.sig)
             push!(shadows, (a_tn, e_tn))

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -360,9 +360,6 @@ function showerror(io::IO, ex::MethodError)
             end
         end
     end
-    if !is_arg_types && !(f isa Core.Builtin)
-        show_shadowed_type_hint(io, f, san_arg_types_param)
-    end
     if ex.world == typemax(UInt) || hasmethod(f, arg_types, world=ex.world)
         if !isempty(kwargs)
             print(io, "\nThis method does not support all of the given keyword arguments (and may not support any).")
@@ -396,6 +393,9 @@ function showerror(io::IO, ex::MethodError)
                       "\nNote the difference between 1d column vector [1,2,3] and 2d row vector [1 2 3].",
                       "\nYou can convert to a column vector with the vec() function.")
         end
+    end
+    if !is_arg_types && !(f isa Core.Builtin)
+        show_shadowed_type_hint(io, f, san_arg_types_param)
     end
     Experimental.show_error_hints(io, ex, san_arg_types_param, kwargs)
     try
@@ -496,7 +496,7 @@ function show_shadowed_type_hint(io::IO, @nospecialize(f), san_arg_types_param::
             # don't print too many hints
             a_tn in reported && continue
             push!(reported, a_tn)
-            print(io, "\nYou may have intended `")
+            print(io, "\nHint: You may have intended `")
             show_unquoted(io, e_tn.module); print(io, ".", e_tn.name)
             print(io, "` rather than `")
             show_unquoted(io, a_tn.module); print(io, ".", a_tn.name)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -461,21 +461,27 @@ function show_shadowed_type_hint(io::IO, @nospecialize(f), san_arg_types_param::
     reported = IdSet{Core.TypeName}()
     ft = Core.Typeof(f)
     for method in methods(f)
-        msig = unwrap_unionall(method.sig)
-        isa(msig, DataType) || continue
+        msig = unwrap_unionall(method.sig)::DataType
         mparams = msig.parameters
+
+        # skip methods where the arity can't match the call
         nargs = length(san_arg_types_param)
         is_va = !isempty(mparams) && isa(mparams[end], Core.TypeofVararg)
         is_va || nargs == length(mparams) - 1 || continue
+
+        # build a list of potential shadows, max one candidate per argument
         new_args = copy(san_arg_types_param)
         shadows = Tuple{Core.TypeName,Core.TypeName}[]
         for i in 1:nargs
+            # everything past nargs+1 hits vararg parameter
             expected = mparams[min(i + 1, length(mparams))]
             isa(expected, Core.TypeofVararg) && (expected = unwrapva(expected))
-            e_dt = unwrap_unionall(expected)
-            a_dt = unwrap_unionall(san_arg_types_param[i])
-            isa(e_dt, DataType) && isa(a_dt, DataType) || continue
+
+            e_dt = unwrap_unionall(expected); isa(e_dt, DataType) || continue
+            a_dt = unwrap_unionall(san_arg_types_param[i])::DataType
             e_tn, a_tn = e_dt.name, a_dt.name
+
+            # actual shadowing heuristics
             e_tn === a_tn && continue
             e_tn.name === a_tn.name || continue
             isdefined(e_tn, :module) && isdefined(a_tn, :module) || continue
@@ -484,8 +490,10 @@ function show_shadowed_type_hint(io::IO, @nospecialize(f), san_arg_types_param::
             push!(shadows, (a_tn, e_tn))
         end
         isempty(shadows) && continue
+        # make sure our suggestion hits an actual method
         Tuple{ft, new_args...} <: method.sig || continue
         for (a_tn, e_tn) in shadows
+            # don't print too many hints
             a_tn in reported && continue
             push!(reported, a_tn)
             print(io, "\nYou may have intended `")

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -457,6 +457,17 @@ stacktrace_expand_basepaths()::Bool = Base.get_bool_env("JULIA_STACKTRACE_EXPAND
 stacktrace_contract_userdir()::Bool = Base.get_bool_env("JULIA_STACKTRACE_CONTRACT_HOMEDIR", true) === true
 stacktrace_linebreaks()::Bool = Base.get_bool_env("JULIA_STACKTRACE_LINEBREAKS", false) === true
 
+function _resolves_to_self(tn::Core.TypeName)
+    isdefined(tn, :module) || return true
+    m = tn.module
+    (isdefined(m, tn.name) && getglobal(m, tn.name) === tn.wrapper) || return false
+    while (p = parentmodule(m)) !== m
+        (isdefined(p, nameof(m)) && getglobal(p, nameof(m)) === m) || return false
+        m = p
+    end
+    return true
+end
+
 function show_shadowed_type_hint(io::IO, @nospecialize(f), san_arg_types_param::Vector{Any})
     reported = IdSet{Core.TypeName}()
     ft = Core.Typeof(f)
@@ -485,7 +496,6 @@ function show_shadowed_type_hint(io::IO, @nospecialize(f), san_arg_types_param::
             e_tn === a_tn && continue
             e_tn.name === a_tn.name || continue
             isdefined(e_tn, :module) && isdefined(a_tn, :module) || continue
-            e_tn.module === a_tn.module && continue
             new_args[i] = rewrap_unionall(expected, method.sig)
             push!(shadows, (a_tn, e_tn))
         end
@@ -496,11 +506,17 @@ function show_shadowed_type_hint(io::IO, @nospecialize(f), san_arg_types_param::
             # don't print too many hints
             a_tn in reported && continue
             push!(reported, a_tn)
-            print(io, "\nHint: You may have intended `")
-            show_unquoted(io, e_tn.module); print(io, ".", e_tn.name)
-            print(io, "` rather than `")
-            show_unquoted(io, a_tn.module); print(io, ".", a_tn.name)
-            print(io, "`.")
+            if !_resolves_to_self(e_tn) || !_resolves_to_self(a_tn)
+                print(io, "\nHint: `")
+                show_unquoted(io, a_tn.module); print(io, ".", a_tn.name)
+                print(io, "` appears to have been redefined, and methods refer to the older definition.")
+            else
+                print(io, "\nHint: You may have intended `")
+                show_unquoted(io, e_tn.module); print(io, ".", e_tn.name)
+                print(io, "` rather than `")
+                show_unquoted(io, a_tn.module); print(io, ".", a_tn.name)
+                print(io, "`.")
+            end
         end
     end
 end

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -1136,33 +1136,26 @@ module TestShadowedTypeHintA
     struct Foo end
     f(::Foo) = 1
     g(::Foo, ::Int) = 1
-    h(::Vector{Foo}) = 1
-    k(::Type{Foo}) = 1
     diag(::Foo, x::T, y::T) where T = 1
 end
 module TestShadowedTypeHintB
     struct Foo end
 end
 @testset "shadowed-type hint #41084" begin
-    err(f) = try f(); catch e; e; end::MethodError
-    msg(f) = sprint(Base.showerror, err(f))
-
-    s = msg(() -> TestShadowedTypeHintA.f(TestShadowedTypeHintB.Foo()))
+    ex = try TestShadowedTypeHintA.f(TestShadowedTypeHintB.Foo()) catch e; e end
+    s = sprint(Base.showerror, ex)
     @test occursin("You may have intended `", s)
     @test occursin("TestShadowedTypeHintA.Foo", s)
     @test occursin("TestShadowedTypeHintB.Foo", s)
 
-    @test !occursin("You may have intended", msg(() -> sin("a")))
-    @test !occursin("You may have intended",
-                    msg(() -> TestShadowedTypeHintA.g(TestShadowedTypeHintB.Foo(), "not an int")))
-    # Diagonal rule: substituting the shadow still leaves Int/String mismatched on T.
-    @test !occursin("You may have intended",
-                    msg(() -> TestShadowedTypeHintA.diag(TestShadowedTypeHintB.Foo(), 1, "x")))
-    # Outer-TypeName-only detection misses inner shadows.
-    @test_broken occursin("You may have intended",
-                          msg(() -> TestShadowedTypeHintA.h([TestShadowedTypeHintB.Foo()])))
-    @test_broken occursin("You may have intended",
-                          msg(() -> TestShadowedTypeHintA.k(TestShadowedTypeHintB.Foo)))
+    ex = try sin("a") catch e; e end
+    @test !occursin("You may have intended", sprint(Base.showerror, ex))
+
+    ex = try TestShadowedTypeHintA.g(TestShadowedTypeHintB.Foo(), "not an int") catch e; e end
+    @test !occursin("You may have intended", sprint(Base.showerror, ex))
+
+    ex = try TestShadowedTypeHintA.diag(TestShadowedTypeHintB.Foo(), 1, "x") catch e; e end
+    @test !occursin("You may have intended", sprint(Base.showerror, ex))
 end
 
 # Test that implementation detail of include() is hidden from the user by default

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -1137,6 +1137,8 @@ module TestShadowedTypeHintA
     f(::Foo) = 1
     g(::Foo, ::Int) = 1
     h(::Vector{Foo}) = 1
+    k(::Type{Foo}) = 1
+    diag(::Foo, x::T, y::T) where T = 1
 end
 module TestShadowedTypeHintB
     struct Foo end
@@ -1153,8 +1155,14 @@ end
     @test !occursin("You may have intended", msg(() -> sin("a")))
     @test !occursin("You may have intended",
                     msg(() -> TestShadowedTypeHintA.g(TestShadowedTypeHintB.Foo(), "not an int")))
+    # Diagonal rule: substituting the shadow still leaves Int/String mismatched on T.
+    @test !occursin("You may have intended",
+                    msg(() -> TestShadowedTypeHintA.diag(TestShadowedTypeHintB.Foo(), 1, "x")))
+    # Outer-TypeName-only detection misses inner shadows.
     @test_broken occursin("You may have intended",
                           msg(() -> TestShadowedTypeHintA.h([TestShadowedTypeHintB.Foo()])))
+    @test_broken occursin("You may have intended",
+                          msg(() -> TestShadowedTypeHintA.k(TestShadowedTypeHintB.Foo)))
 end
 
 # Test that implementation detail of include() is hidden from the user by default

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -1132,6 +1132,34 @@ let ex = try
     @test occursin("may have intended to extend", sprint(Base.showerror, ex))
 end
 
+# Test hint when an argument's type is shadowed by a same-named type from
+# another module expected by the method (issue #41084).
+module TestShadowedTypeHint
+    struct Foo end
+    func(::Foo) = "hi"
+end
+module TestShadowedTypeHintOther
+    struct Foo end
+end
+let ex = try
+        TestShadowedTypeHint.func(TestShadowedTypeHintOther.Foo())
+    catch e
+        e
+    end::MethodError
+    s = sprint(Base.showerror, ex)
+    @test occursin("share the same name `Foo`", s)
+    @test occursin("TestShadowedTypeHintOther.Foo", s)
+    @test occursin("TestShadowedTypeHint.Foo", s)
+end
+# Negative: no hint when the call fails for unrelated reasons.
+let ex = try
+        sin("a")
+    catch e
+        e
+    end::MethodError
+    @test !occursin("share the same name", sprint(Base.showerror, ex))
+end
+
 # Test that implementation detail of include() is hidden from the user by default
 let bt = try
         @noinline include("testhelpers/include_error.jl")

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -1146,14 +1146,14 @@ end
     msg(f) = sprint(Base.showerror, err(f))
 
     s = msg(() -> TestShadowedTypeHintA.f(TestShadowedTypeHintB.Foo()))
-    @test occursin("You may have intended to pass an instance of `", s)
+    @test occursin("You may have intended `", s)
     @test occursin("TestShadowedTypeHintA.Foo", s)
     @test occursin("TestShadowedTypeHintB.Foo", s)
 
-    @test !occursin("You may have intended to pass", msg(() -> sin("a")))
-    @test !occursin("You may have intended to pass",
+    @test !occursin("You may have intended", msg(() -> sin("a")))
+    @test !occursin("You may have intended",
                     msg(() -> TestShadowedTypeHintA.g(TestShadowedTypeHintB.Foo(), "not an int")))
-    @test_broken occursin("You may have intended to pass",
+    @test_broken occursin("You may have intended",
                           msg(() -> TestShadowedTypeHintA.h([TestShadowedTypeHintB.Foo()])))
 end
 

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -1132,8 +1132,7 @@ let ex = try
     @test occursin("may have intended to extend", sprint(Base.showerror, ex))
 end
 
-# Test hint when an argument's type is shadowed by a same-named type from
-# another module expected by the method (issue #41084).
+# issue #41084
 module TestShadowedTypeHint
     struct Foo end
     func(::Foo) = "hi"
@@ -1151,7 +1150,6 @@ let ex = try
     @test occursin("TestShadowedTypeHintOther.Foo", s)
     @test occursin("TestShadowedTypeHint.Foo", s)
 end
-# Negative: no hint when the call fails for unrelated reasons.
 let ex = try
         sin("a")
     catch e

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -1132,30 +1132,29 @@ let ex = try
     @test occursin("may have intended to extend", sprint(Base.showerror, ex))
 end
 
-# issue #41084
-module TestShadowedTypeHint
+module TestShadowedTypeHintA
     struct Foo end
-    func(::Foo) = "hi"
+    f(::Foo) = 1
+    g(::Foo, ::Int) = 1
+    h(::Vector{Foo}) = 1
 end
-module TestShadowedTypeHintOther
+module TestShadowedTypeHintB
     struct Foo end
 end
-let ex = try
-        TestShadowedTypeHint.func(TestShadowedTypeHintOther.Foo())
-    catch e
-        e
-    end::MethodError
-    s = sprint(Base.showerror, ex)
-    @test occursin("share the same name `Foo`", s)
-    @test occursin("TestShadowedTypeHintOther.Foo", s)
-    @test occursin("TestShadowedTypeHint.Foo", s)
-end
-let ex = try
-        sin("a")
-    catch e
-        e
-    end::MethodError
-    @test !occursin("share the same name", sprint(Base.showerror, ex))
+@testset "shadowed-type hint #41084" begin
+    err(f) = try f(); catch e; e; end::MethodError
+    msg(f) = sprint(Base.showerror, err(f))
+
+    s = msg(() -> TestShadowedTypeHintA.f(TestShadowedTypeHintB.Foo()))
+    @test occursin("You may have intended to pass an instance of `", s)
+    @test occursin("TestShadowedTypeHintA.Foo", s)
+    @test occursin("TestShadowedTypeHintB.Foo", s)
+
+    @test !occursin("You may have intended to pass", msg(() -> sin("a")))
+    @test !occursin("You may have intended to pass",
+                    msg(() -> TestShadowedTypeHintA.g(TestShadowedTypeHintB.Foo(), "not an int")))
+    @test_broken occursin("You may have intended to pass",
+                          msg(() -> TestShadowedTypeHintA.h([TestShadowedTypeHintB.Foo()])))
 end
 
 # Test that implementation detail of include() is hidden from the user by default

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -1141,6 +1141,20 @@ end
 module TestShadowedTypeHintB
     struct Foo end
 end
+module TestShadowRedefA
+    module Sub
+        struct X end
+    end
+    f(::Sub.X) = 1
+    module Sub
+        struct X end
+    end
+end
+module TestShadowRedefB
+    struct Y; x; end
+    g(::Y) = 1
+    struct Y end
+end
 @testset "shadowed-type hint #41084" begin
     ex = try TestShadowedTypeHintA.f(TestShadowedTypeHintB.Foo()) catch e; e end
     s = sprint(Base.showerror, ex)
@@ -1156,6 +1170,16 @@ end
 
     ex = try TestShadowedTypeHintA.diag(TestShadowedTypeHintB.Foo(), 1, "x") catch e; e end
     @test !occursin("You may have intended", sprint(Base.showerror, ex))
+
+    ex = try TestShadowRedefA.f(TestShadowRedefA.Sub.X()) catch e; e end
+    s = sprint(Base.showerror, ex)
+    @test occursin("appears to have been redefined", s)
+    @test !occursin("rather than", s)
+
+    ex = try TestShadowRedefB.g(TestShadowRedefB.Y()) catch e; e end
+    s = sprint(Base.showerror, ex)
+    @test occursin("appears to have been redefined", s)
+    @test !occursin("rather than", s)
 end
 
 # Test that implementation detail of include() is hidden from the user by default


### PR DESCRIPTION
when you have types of the same name but different modules, and accidentally pass the wrong one to a function, the `MethodError` can be confusing until you realize what happened. this attempts to add a hint to alleviate that.

example:
```julia
julia> module Geometry
           struct Point
               x::Float64
               y::Float64
           end
           translate(p::Point, dx, dy) = Point(p.x + dx, p.y + dy)
       end
Main.Geometry

julia> struct Point
           lat::Float64
           lon::Float64
       end

julia> p = Point(40.7, -74.0);

julia> Geometry.translate(p, 1, 2)

# BEFORE
ERROR: MethodError: no method matching translate(::Point, ::Int64, ::Int64)
The function `translate` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  translate(::Main.Geometry.Point, ::Any, ::Any)
   @ Main.Geometry REPL[3]:6


# AFTER
ERROR: MethodError: no method matching translate(::Point, ::Int64, ::Int64)
You may have intended `Main.Geometry.Point` rather than `Main.Point`.
The function `translate` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  translate(::Main.Geometry.Point, ::Any, ::Any)
   @ Main.Geometry REPL[4]:6
```



fixes #41084
half claude half me