### PR TITLE
add error hint for apply_type typos

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -1243,7 +1243,7 @@ Experimental.register_error_hint(fielderror_listfields_hint_handler, FieldError)
 
 function apply_type_unionall_hint_handler(io, ex)
     @nospecialize
-    if ex.expected === UnionAll && isa(ex.got, DataType)
+    if ex.func === :apply_type && ex.expected === UnionAll && isa(ex.got, DataType)
         print(io, "\nHint: `", ex.got, "` takes no type parameters.")
     end
 end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -1243,7 +1243,7 @@ Experimental.register_error_hint(fielderror_listfields_hint_handler, FieldError)
 
 function apply_type_unionall_hint_handler(io, ex)
     @nospecialize
-    if ex.func === :apply_type && ex.expected === UnionAll && isa(ex.got, DataType)
+    if ex.func === :apply_type && ex.expected === UnionAll
         print(io, "\nHint: `", ex.got, "` takes no type parameters.")
     end
 end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -1241,6 +1241,15 @@ end
 
 Experimental.register_error_hint(fielderror_listfields_hint_handler, FieldError)
 
+function apply_type_unionall_hint_handler(io, ex)
+    @nospecialize
+    if ex.expected === UnionAll && isa(ex.got, DataType)
+        print(io, "\nHint: `", ex.got, "` takes no type parameters.")
+    end
+end
+
+Experimental.register_error_hint(apply_type_unionall_hint_handler, TypeError)
+
 function UndefVarError_hint(io::IO, ex::UndefVarError)
     var = ex.var
     if isdefined(ex, :scope)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1691,6 +1691,9 @@ JL_CALLABLE(jl_f_apply_type)
         }
         return jl_apply_type(args[0], &args[1], nargs-1);
     }
+    else if (jl_is_datatype(args[0])) {
+        jl_type_error("apply_type", (jl_value_t*)jl_unionall_type, args[0]);
+    }
     jl_type_error("Type{...} expression", (jl_value_t*)jl_unionall_type, args[0]);
 }
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1457,7 +1457,7 @@ jl_value_t *jl_apply_type(jl_value_t *tc, jl_value_t **params, size_t n)
             char *typ = "";
             if (jl_is_datatype(tc0))
                 typ = jl_symbol_name_(((jl_datatype_t*)tc0)->name->name);
-            jl_errorf("too many parameters for type %s", typ);
+            jl_errorf("too many parameters for type `%s`: expected %zu, got %zu", typ, i, n);
         }
         jl_value_t *pi = params[i];
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -8783,18 +8783,3 @@ module AmbiguousUsing60659
     using .D, .A
     @test_throws UndefVarError X
 end
-
-# issue #45078
-@testset "apply_type TypeError hint for non-parameterizable types" begin
-    for expr in (:(Int{1}), :(Int{}), :(BitVector{1}), :(BitVector{}))
-        @test_throws TypeError eval(expr)
-    end
-    @test occursin("Hint: `Int64` takes no type parameters", sprint(showerror, try Int64{1} catch e; e end))
-    @test occursin("Hint: `Int64` takes no type parameters", sprint(showerror, try Int64{} catch e; e end))
-    @test occursin("Hint: `BitVector` takes no type parameters", sprint(showerror, try BitVector{1} catch e; e end))
-    @test !occursin("Hint:", sprint(showerror, try Core.apply_type(5, 2) catch e; e end))
-    @test !occursin("Hint:", sprint(showerror, try Union{Int64,Float64}{Int64} catch e; e end))
-    @test !occursin("Hint:", sprint(showerror, try typeassert(Int64, UnionAll) catch e; e end))
-    @test_throws ErrorException("too many parameters for type `Array`: expected 2, got 4") Array{1,2,3,4}
-    @test_throws ErrorException("too many parameters for type `BitArray`: expected 1, got 2") BitArray{1,2}
-end

--- a/test/core.jl
+++ b/test/core.jl
@@ -8783,3 +8783,17 @@ module AmbiguousUsing60659
     using .D, .A
     @test_throws UndefVarError X
 end
+
+# issue #45078
+@testset "apply_type TypeError hint for non-parameterizable types" begin
+    for expr in (:(Int{1}), :(Int{}), :(BitVector{1}), :(BitVector{}))
+        @test_throws TypeError eval(expr)
+    end
+    @test occursin("Hint: `Int64` takes no type parameters", sprint(showerror, try Int64{1} catch e; e end))
+    @test occursin("Hint: `Int64` takes no type parameters", sprint(showerror, try Int64{} catch e; e end))
+    @test occursin("Hint: `BitVector` takes no type parameters", sprint(showerror, try BitVector{1} catch e; e end))
+    @test !occursin("Hint:", sprint(showerror, try Core.apply_type(5, 2) catch e; e end))
+    @test !occursin("Hint:", sprint(showerror, try Union{Int64,Float64}{Int64} catch e; e end))
+    @test_throws ErrorException("too many parameters for type `Array`: expected 2, got 4") Array{1,2,3,4}
+    @test_throws ErrorException("too many parameters for type `BitArray`: expected 1, got 2") BitArray{1,2}
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -8794,6 +8794,7 @@ end
     @test occursin("Hint: `BitVector` takes no type parameters", sprint(showerror, try BitVector{1} catch e; e end))
     @test !occursin("Hint:", sprint(showerror, try Core.apply_type(5, 2) catch e; e end))
     @test !occursin("Hint:", sprint(showerror, try Union{Int64,Float64}{Int64} catch e; e end))
+    @test !occursin("Hint:", sprint(showerror, try typeassert(Int64, UnionAll) catch e; e end))
     @test_throws ErrorException("too many parameters for type `Array`: expected 2, got 4") Array{1,2,3,4}
     @test_throws ErrorException("too many parameters for type `BitArray`: expected 1, got 2") BitArray{1,2}
 end

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -19,6 +19,7 @@ _register_if_missing(Base.methods_on_iterable, MethodError)
 _register_if_missing(Base.nonsetable_type_hint_handler, MethodError)
 _register_if_missing(Base.fielderror_listfields_hint_handler, FieldError)
 _register_if_missing(Base.fielderror_dict_hint_handler, FieldError)
+_register_if_missing(Base.apply_type_unionall_hint_handler, TypeError)
 @testset "SystemError" begin
     err = try; systemerror("reason", Cint(0)); false; catch ex; ex; end::SystemError
     errs = sprint(Base.showerror, err)
@@ -1538,4 +1539,19 @@ end
     err_strA = @except_str memoryref(refA, 2) BoundsError
     @test occursin("AtomicMemoryRef", err_strA)
     @test occursin("1-element", err_strA)
+end
+
+# issue #4507
+@testset "apply_type TypeError hint for non-parameterizable types" begin
+    for expr in (:(Int{1}), :(Int{}), :(BitVector{1}), :(BitVector{}))
+        @test_throws TypeError eval(expr)
+    end
+    @test occursin("Hint: `Int64` takes no type parameters", sprint(showerror, try Int64{1} catch e; e end))
+    @test occursin("Hint: `Int64` takes no type parameters", sprint(showerror, try Int64{} catch e; e end))
+    @test occursin("Hint: `BitVector` takes no type parameters", sprint(showerror, try BitVector{1} catch e; e end))
+    @test !occursin("Hint:", sprint(showerror, try Core.apply_type(5, 2) catch e; e end))
+    @test !occursin("Hint:", sprint(showerror, try Union{Int64,Float64}{Int64} catch e; e end))
+    @test !occursin("Hint:", sprint(showerror, try typeassert(Int64, UnionAll) catch e; e end))
+    @test_throws ErrorException("too many parameters for type `Array`: expected 2, got 4") Array{1,2,3,4}
+    @test_throws ErrorException("too many parameters for type `BitArray`: expected 1, got 2") BitArray{1,2}
 end


### PR DESCRIPTION
fixes https://github.com/JuliaLang/julia/issues/45078 as suggested therein

before
```
julia> BitVector{1}
ERROR: TypeError: in Type{...} expression, expected UnionAll, got Type{BitVector}

julia> Array{Int, 1, String}
ERROR: too many parameters for type Array
```

after
```
julia> BitVector{1}
ERROR: TypeError: in Type{...} expression, expected UnionAll, got Type{BitVector}
Hint: `BitVector` takes no type parameters.

julia> Array{Int, 1, String}
ERROR: too many parameters for type `Array`: expected 2, got 3
```

etcetera