### PR TITLE
Specialize f in map(f, ::NamedTuple)

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -256,7 +256,7 @@ same_names(::NamedTuple{names}...) where {names} = true
 same_names(::NamedTuple...) = false
 
 # NOTE: this method signature makes sure we don't define map(f)
-function map(f, nt::NamedTuple{names}, nts::NamedTuple...) where names
+function map(f::F, nt::NamedTuple{names}, nts::NamedTuple...) where {names, F}
     if !same_names(nt, nts...)
         throw(ArgumentError("Named tuple names do not match."))
     end


### PR DESCRIPTION
This lack of specialization is problematic, because the result of the map is used in the function body. Without specialization, this causes excessive allocations.

This was discovered by @aplavin with this benchmark:
```julia
using BenchmarkTools

a = (x1=[1.0], x2=[2.0], x3=[3.0], x4=[4.0], x5=[5.0], x6=[6.0], x7=[7.0], x8=[8.0], x9=[9.0], x10=[10.0], x11=[11.0])
b = map(copy, a)

function bench(a, b, N)
    s = 0
    for _ in 1:N; s += length(map(copyto!, a, b).x1); end; s
end
bench(a, b, 1)

@showtime bench(a, b, 1_000_000)
```

Results:
* `map` on master: `bench(a, b, 1000000): 0.495330 seconds (4.00 M allocations: 366.211 MiB, 34.93% gc time)`
* `map` on PR: `bench(a, b, 1000000): 0.050094 seconds (1 allocation: 16 bytes)`