### PR TITLE
Remove redundant boundscheck in getindex(::String, ::UnitRange)

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -579,8 +579,10 @@ end
         @inbounds isvalid(s, i) || string_index_err(s, i)
         @inbounds isvalid(s, j) || string_index_err(s, j)
     end
-    j = nextind(s, j) - 1
-    n = j - i + 1
+    # Safety: The boundscheck checked r is inbounds in s,
+    # and since we also checked r is not empty, j must be inbounds in s
+    j = @inbounds nextind(s, j) - 1
+    n = (j - i + 1) % UInt
     ss = _string_n(n)
     GC.@preserve s ss unsafe_copyto!(pointer(ss), pointer(s, i), n)
     return ss


### PR DESCRIPTION
This is unnecessarily boundschecked, since the boundscheck block above already checks for the validity of the index.

This closes https://github.com/JuliaLang/julia/issues/24841. The only redundant boundscheck now is that in `unsafe_copyto`, but in https://github.com/JuliaLang/julia/pull/57946 it was decided that double boundschecking was preferred.