### PR TITLE
arrayshow: fix unsigned index underflow in print_matrix_vdots

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -133,9 +133,9 @@ function print_matrix_vdots(io::IO, vdots::AbstractString,
                             A::Vector, sep::AbstractString, M::Integer, m::Integer,
                             pad_right::Bool = true)
     for k = 1:length(A)
-        w = A[k][1] + A[k][2]
+        w = Int(A[k][1]) + Int(A[k][2])
         if k % M == m
-            l = repeat(" ", max(0, A[k][1]-length(vdots)))
+            l = repeat(" ", max(0, Int(A[k][1])-length(vdots)))
             r = k == length(A) && !pad_right ?
                 "" :
                 repeat(" ", max(0, w-length(vdots)-length(l)))

--- a/test/show.jl
+++ b/test/show.jl
@@ -929,6 +929,16 @@ Base.methodloc_callback[] = nothing
     @test startswith(r, "50×2 Matrix{Any}:\n 0  …   \"look I'm wide! ---")
     @test endswith(r, "look I'm wide! --- \"\n 0     0\n 0     0\n 0     0\n 0     0\n 0  …  0\n 0     0\n 0     0\n 0     0\n 0     0\n ⋮  ⋱  \n 0     0\n 0     0\n 0     0\n 0     0\n 0  …  0\n 0     0\n 0     0\n 0     0\n 0     0")
 
+    let
+        struct UnsignedVec{T} <: AbstractVector{T}
+            data::Vector{T}
+        end
+        Base.IndexStyle(::Type{<:UnsignedVec}) = IndexLinear()
+        Base.size(x::UnsignedVec) = (UInt(length(x.data)),)
+        Base.@propagate_inbounds Base.getindex(x::UnsignedVec, i...) = getindex(x.data, i...)
+        @test occursin("⋮", replstr(UnsignedVec(fill(missing, 100))))
+    end
+
     # issue #34659
     @test replstr(Int32[]) == "Int32[]"
     @test replstr([Int32[]]) == "1-element Vector{Vector{Int32}}:\n []"


### PR DESCRIPTION
`A[k][1]` in `print_matrix_vdots` can be an unsigned integer when an AbstractArray subtype reports unsigned `size`. Subtracting `length(vdots)` from a `UInt(0)` wraps to `typemax(UInt)`, causing `repeat` to attempt an enormous allocation and OOM. Cast to `Int` before the subtraction.
Fixes #53907