### PR TITLE
abstractarraymath: make unary `+` consistent with unary `-` for Abstr…

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -292,7 +292,7 @@ reim(A::AbstractArray)
 
 -(A::AbstractArray) = broadcast_preserving_zero_d(-, A)
 
-+(x::AbstractArray{<:Number}) = x
++(x::AbstractArray) = broadcast_preserving_zero_d(+, x)
 *(x::AbstractArray{<:Number,2}) = x
 
 # index A[:,:,...,i,:,:,...] where "i" is in dimension "d"

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -961,11 +961,15 @@ end
 @testset "unary ops" begin
     let A = Diagonal(rand(1:5,5))
         @test +(A) == A
+        @test +(A) !== A
         @test *(A) == A
     end
-
-    # Unary addition is valid for Arrays over anything, not just numbers
     @test +[[1]] == [[1]]
+    let a = [1, 2, 3]
+        @test +a == a
+        @test +a !== a
+    end
+    @test eltype(+Bool[1, 0, 1]) == Int
 end
 
 @testset "reverse dim on empty" begin


### PR DESCRIPTION
Previously `+(x::AbstractArray{<:Number})` was the identity (returned the same object), while `-(A::AbstractArray)` uses `broadcast_preserving_zero_d`. This made unary `+` inconsistent: it did not return a copy, and did not promote element types (e.g. `Bool` arrays stayed `Bool` instead of promoting to `Int`). Fix by using `broadcast_preserving_zero_d` for unary `+` as well, and broaden the type from `AbstractArray{<:Number}` to `AbstractArray`.

Fixes #58295
