### PR TITLE
broadcast: give helpful error when @. is called with multiple arguments

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1344,6 +1344,11 @@ julia> @. (10:10:30) + (1:4)'
 macro __dot__(x)
     esc(__dot__(x))
 end
+macro __dot__(xs...)
+    error("`@.` requires a single expression as argument. " *
+          "If you used spaces around an operator (e.g. `vec +1`), " *
+          "add spaces on both sides: `vec + 1`.")
+end
 
 @inline function broadcasted_kwsyntax(f, args...; kwargs...)
     if isempty(kwargs) # some BroadcastStyles dispatch on `f`, so try to preserve its type

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1224,3 +1224,6 @@ end
     @test bc[1] == bc[CartesianIndex(1)] == bc[1, CartesianIndex()]
     @test a .+ [1 2] == a.a .+ [1 2]
 end
+
+# issue #49968: @. with spaces around operator gives helpful error
+@test_throws "add spaces on both sides" @macroexpand(@__dot__(a = a, +1))


### PR DESCRIPTION
When the user writes \`@. vec = vec +1\` (space before operator), Julia's
parser splits this into two macro arguments (\`vec = vec\` and \`+1\`),
causing a cryptic MethodError on \`@__dot__\`. Add a varargs method that
catches this case and suggests adding spaces on both sides of the operator.

Fixes #49968