### PR TITLE
Reduce padding in `_jl_handler_t`

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -2351,11 +2351,11 @@ struct _jl_handler_t {
     jl_gcframe_t *gcstack;
     jl_value_t *scope;
     struct _jl_handler_t *prev;
-    int8_t gc_state;
     size_t locks_len;
-    sig_atomic_t defer_signal;
     jl_timing_block_t *timing_stack;
     size_t world_age;
+    sig_atomic_t defer_signal;
+    int8_t gc_state;
 };
 
 #define JL_TASK_STATE_RUNNABLE 0


### PR DESCRIPTION
Reorder fields in `_jl_handler_t` so that 8-byte fields come first, followed by the 4-byte `defer_signal` and 1-byte `gc_state` at the tail. This eliminates 8 bytes of padding, as `_jl_handler_t` is 8-byte-aligned and is the most flexible layout for future extensions. I haven't seen any disadvantages with the new order, but there might be internals that I don't know about.
Exception contexts are probably not the most pressing issues in terms of memory usage, but that does not mean that we should waste memory.

The problem was found by Claude Opus 4.7.