### PR TITLE
namedtuple: add integer index method for `setindex`

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -485,6 +485,23 @@ function setindex(nt::NamedTuple, v, idx::Symbol)
 end
 
 """
+    setindex(nt::NamedTuple, val, idx::Int)
+
+Constructs a new `NamedTuple` with the value at index `idx` set to `val`.
+
+```jldoctest
+julia> nt = (a = 1, b = 2, c = 3)
+(a = 1, b = 2, c = 3)
+
+julia> Base.setindex(nt, 20, 2)
+(a = 1, b = 20, c = 3)
+```
+"""
+function setindex(nt::NamedTuple{names}, v, idx::Int) where {names}
+    NamedTuple{names}(Base.setindex(Tuple(nt), v, idx))
+end
+
+"""
     @NamedTuple{key1::Type1, key2::Type2, ...}
     @NamedTuple begin key1::Type1; key2::Type2; ...; end
 

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -351,6 +351,11 @@ let nt0 = NamedTuple(), nt1 = (a=33,), nt2 = (a=0, b=:v)
     @test Base.setindex(nt1, "value", :a) == (a="value",)
     @test Base.setindex(nt1, "value", :a) isa NamedTuple{(:a,),<:Tuple{AbstractString}}
 end
+let nt = (a=1, b=2, c=3)
+    @test Base.setindex(nt, 20, 2) === (a=1, b=20, c=3)
+    @test Base.setindex(nt, "x", 1) === (a="x", b=2, c=3)
+    @test Base.setindex(nt, 99, 3) === (a=1, b=2, c=99)
+end
 
 # @NamedTuple
 @testset "@NamedTuple" begin


### PR DESCRIPTION
Fixes #43155

`NamedTuple` supports both `Symbol` and `Int` `getindex`, but `setindex` only had a `Symbol` method. This adds the matching `Int` method for consistency.

> This PR was developed with the assistance of Claude (Anthropic).