### PR TITLE
nicer error message when you try to `.=` into a scalar

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -738,8 +738,6 @@ broadcastable(x::Union{AbstractArray,Number,AbstractChar,Ref,Tuple,Broadcasted})
 broadcastable(x) = collect(x)
 broadcastable(::Union{AbstractDict, NamedTuple}) = throw(ArgumentError("broadcasting over dictionaries and `NamedTuple`s is reserved"))
 
-BroadcastStyle(::Type{<:BroadcastScalars}) = DefaultArrayStyle{0}()
-
 ## Computation of inferred result type, for empty and concretely inferred cases only
 _broadcast_getindex_eltype(bc::Broadcasted) = combine_eltypes(bc.f, bc.args)
 _broadcast_getindex_eltype(A) = eltype(A)  # Tuple, Array, etc.
@@ -909,12 +907,13 @@ end
     return materialize!(combine_styles(dest, bc), dest, bc)
 end
 
-@inline function materialize!(::AbstractArrayStyle{0}, dest, bc::Broadcasted{<:Any})
-    return copyto!(dest, instantiate(Broadcasted(bc.style, bc.f, bc.args, ())))
-end
-
 @inline function materialize!(::BroadcastStyle, dest, bc::Broadcasted{<:Any})
     return copyto!(dest, instantiate(Broadcasted(bc.style, bc.f, bc.args, axes(dest))))
+end
+
+materialize!(dest::Union{BroadcastScalars,Number,AbstractChar}, bc::Broadcasted{<:Any}) = _throw_unwritable_dest(dest)
+@noinline function _throw_unwritable_dest(@nospecialize dest)
+    throw(ArgumentError(LazyString("cannot broadcast-assign (`.=`) into a value of type ", typeof(dest))))
 end
 
 ## general `copy` methods
@@ -957,11 +956,6 @@ end
 # The most general method falls back to a method that replaces Style->Nothing
 # This permits specialization on typeof(dest) without introducing ambiguities
 @inline copyto!(dest::AbstractArray, bc::Broadcasted) = copyto!(dest, convert(Broadcasted{Nothing}, bc))
-
-copyto!(dest, bc::Broadcasted) = _throw_unwritable_dest(dest)
-@noinline function _throw_unwritable_dest(@nospecialize dest)
-    throw(ArgumentError(LazyString("cannot broadcast-assign (`.=`) into a value of type ", typeof(dest))))
-end
 
 # Performance optimization for the common identity scalar case: dest .= val
 @inline function copyto!(dest::AbstractArray, bc::Broadcasted{<:AbstractArrayStyle{0}})

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -729,12 +729,17 @@ julia> Broadcast.broadcastable("hello") # Strings break convention of matching i
 Base.RefValue{String}("hello")
 ```
 """
-broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,AbstractPattern,Pair,IO,CartesianIndex}) = Ref(x)
+
+const BroadcastScalars = Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,AbstractPattern,Pair,IO,CartesianIndex}
+
+broadcastable(x::BroadcastScalars) = Ref(x)
 broadcastable(::Type{T}) where {T} = Ref{Type{T}}(T)
 broadcastable(x::Union{AbstractArray,Number,AbstractChar,Ref,Tuple,Broadcasted}) = x
 # Default to collecting iterables — which will error for non-iterables
 broadcastable(x) = collect(x)
 broadcastable(::Union{AbstractDict, NamedTuple}) = throw(ArgumentError("broadcasting over dictionaries and `NamedTuple`s is reserved"))
+
+BroadcastStyle(::Type{<:BroadcastScalars}) = DefaultArrayStyle{0}()
 
 ## Computation of inferred result type, for empty and concretely inferred cases only
 _broadcast_getindex_eltype(bc::Broadcasted) = combine_eltypes(bc.f, bc.args)
@@ -904,6 +909,11 @@ end
 @inline function materialize!(dest, bc::Broadcasted{<:Any})
     return materialize!(combine_styles(dest, bc), dest, bc)
 end
+
+@inline function materialize!(::AbstractArrayStyle{0}, dest, bc::Broadcasted{<:Any})
+    return copyto!(dest, instantiate(Broadcasted(bc.style, bc.f, bc.args, ())))
+end
+
 @inline function materialize!(::BroadcastStyle, dest, bc::Broadcasted{<:Any})
     return copyto!(dest, instantiate(Broadcasted(bc.style, bc.f, bc.args, axes(dest))))
 end
@@ -948,6 +958,11 @@ end
 # The most general method falls back to a method that replaces Style->Nothing
 # This permits specialization on typeof(dest) without introducing ambiguities
 @inline copyto!(dest::AbstractArray, bc::Broadcasted) = copyto!(dest, convert(Broadcasted{Nothing}, bc))
+
+copyto!(dest, bc::Broadcasted) = _throw_unwritable_dest(dest)
+@noinline function _throw_unwritable_dest(@nospecialize dest)
+    throw(ArgumentError(LazyString("cannot broadcast-assign (`.=`) into a value of type ", typeof(dest))))
+end
 
 # Performance optimization for the common identity scalar case: dest .= val
 @inline function copyto!(dest::AbstractArray, bc::Broadcasted{<:AbstractArrayStyle{0}})

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -701,6 +701,8 @@ Base.@propagate_inbounds _getindex(args::Tuple{}, I) = ()
 
 @inline _broadcast_getindex_evalf(f::Tf, args::Vararg{Any,N}) where {Tf,N} = f(args...)  # not propagate_inbounds
 
+const BroadcastScalars = Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,AbstractPattern,Pair,IO,CartesianIndex}
+
 """
     Broadcast.broadcastable(x)
 
@@ -729,9 +731,6 @@ julia> Broadcast.broadcastable("hello") # Strings break convention of matching i
 Base.RefValue{String}("hello")
 ```
 """
-
-const BroadcastScalars = Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,AbstractPattern,Pair,IO,CartesianIndex}
-
 broadcastable(x::BroadcastScalars) = Ref(x)
 broadcastable(::Type{T}) where {T} = Ref{Type{T}}(T)
 broadcastable(x::Union{AbstractArray,Number,AbstractChar,Ref,Tuple,Broadcasted}) = x

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -708,7 +708,7 @@ end
     A[1] .= 0
     @test A[1] == [0, 0, 0]
     @test_throws Base.CanonicalIndexError A[2] .= 0
-    @test_throws MethodError A[3] .= 0
+    @test_throws ArgumentError A[3] .= 0
     A = [[1, 2, 3], 4:5]
     A[1] .= 0
     @test A[1] isa Vector{Int}

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1224,3 +1224,11 @@ end
     @test bc[1] == bc[CartesianIndex(1)] == bc[1, CartesianIndex()]
     @test a .+ [1 2] == a.a .+ [1 2]
 end
+
+@testset "issue #45086" begin
+    for x in (1, "Hello, World!", :foo, nothing, missing, 1=>2, CartesianIndex(1,2))
+        err = try; x .= x; catch e; e; end
+        @test err isa ArgumentError
+        @test occursin("cannot broadcast-assign", sprint(showerror, err))
+    end
+end


### PR DESCRIPTION
closes https://github.com/JuliaLang/julia/issues/45086

original MWE
old:
```julia
julia> a = 2; b = 4; a .= b
ERROR: MethodError: no method matching copyto!(::Int64, ::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Tuple{}, typeof(identity), Tuple{Int64}})
The function `copyto!` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  copyto!(::Base.MPFR.BigFloatData, ::Any)
   @ Base mpfr.jl:243
  copyto!(::AbstractArray, ::Base.Broadcast.Broadcasted{<:Base.Broadcast.AbstractArrayStyle{0}})
   @ Base broadcast.jl:953
  copyto!(::AbstractArray, ::Base.Broadcast.Broadcasted)
   @ Base broadcast.jl:950
  ...

Stacktrace:
 [1] materialize!
   @ ./broadcast.jl:908 [inlined]
 [2] materialize!(dest::Int64, bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(identity), Tuple{Int64}})
   @ Base.Broadcast ./broadcast.jl:905
 [3] top-level scope
   @ REPL[1]:1
```

new
```julia
julia> a = 2; b = 4; a .= b
ERROR: ArgumentError: cannot broadcast-assign (`.=`) into a value of type Int64
Stacktrace:
 [1] _throw_unwritable_dest(dest::Any)
   @ Base.Broadcast ~/Documents/code/julia_pr/usr/share/julia/base/broadcast.jl:964
 [2] copyto!(dest::Int64, bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Tuple{}, typeof(identity), Tuple{Int64}})
   @ Base.Broadcast ~/Documents/code/julia_pr/usr/share/julia/base/broadcast.jl:962
 [3] materialize!
   @ ~/Documents/code/julia_pr/usr/share/julia/base/broadcast.jl:923 [inlined]
 [4] materialize!(dest::Int64, bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(identity), Tuple{Int64}})
   @ Base.Broadcast ~/Documents/code/julia_pr/usr/share/julia/base/broadcast.jl:910
 [5] top-level scope
   @ REPL[19]:1
```

or old
```julia
julia> caeser_cipher(i) = s -> map(c -> c + i, s);

julia> str = "Hello, World!";

julia> str .= caeser_cipher(10)(str)
ERROR: MethodError: no method matching ndims(::Type{String})
The function `ndims` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  ndims(::Type{Union{}}, Any...)
   @ Base abstractarray.jl:280
  ndims(::Type{<:Number})
   @ Base number.jl:92
  ndims(::Type{<:Ref})
   @ Base refpointer.jl:104
  ...

Stacktrace:
 [1] Base.Broadcast.BroadcastStyle(::Type{String})
   @ Base.Broadcast ./broadcast.jl:103
 [2] combine_styles(c::String)
   @ Base.Broadcast ./broadcast.jl:430
 [3] combine_styles(c1::String, c2::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(identity), Tuple{Base.RefValue{String}}})
   @ Base.Broadcast ./broadcast.jl:435
 [4] materialize!(dest::String, bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(identity), Tuple{Base.RefValue{String}}})
   @ Base.Broadcast ./broadcast.jl:905
 [5] top-level scope
   @ REPL[13]:1
```

new
```julia
julia> str .= caeser_cipher(10)(str)
ERROR: ArgumentError: cannot broadcast-assign (`.=`) into a value of type String
Stacktrace:
 [1] _throw_unwritable_dest(dest::Any)
   @ Base.Broadcast ~/Documents/code/julia_pr/usr/share/julia/base/broadcast.jl:964
 [2] copyto!(dest::String, bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Tuple{}, typeof(identity), Tuple{Base.RefValue{String}}})
   @ Base.Broadcast ~/Documents/code/julia_pr/usr/share/julia/base/broadcast.jl:962
 [3] materialize!
   @ ~/Documents/code/julia_pr/usr/share/julia/base/broadcast.jl:923 [inlined]
 [4] materialize!(dest::String, bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(identity), Tuple{Base.RefValue{String}}})
   @ Base.Broadcast ~/Documents/code/julia_pr/usr/share/julia/base/broadcast.jl:910
 [5] top-level scope
   @ REPL[36]:1
```