### PR TITLE
update docs for @main to use eval when on old versions of julia

### DIFF
--- a/doc/src/manual/command-line-interface.md
+++ b/doc/src/manual/command-line-interface.md
@@ -70,7 +70,7 @@ expression.
 
 !!! compat "Julia 1.11"
     The special entry point `Main.main` was added in Julia 1.11. For compatibility with prior julia versions,
-    add an explicit `@isdefined(var"@main") ? eval(:( @main )) : exit(main(ARGS))` at the end of your scripts.
+    add an explicit `@static @isdefined(var"@main") ? (@main) : exit(main(ARGS))` at the end of your scripts.
 
 Only the `main` binding in the `Main` module has this behavior and only if
 the macro `@main` was used within the defining module.

--- a/doc/src/manual/command-line-interface.md
+++ b/doc/src/manual/command-line-interface.md
@@ -70,7 +70,7 @@ expression.
 
 !!! compat "Julia 1.11"
     The special entry point `Main.main` was added in Julia 1.11. For compatibility with prior julia versions,
-    add an explicit `@isdefined(var"@main") ? (@main) : exit(main(ARGS))` at the end of your scripts.
+    add an explicit `@isdefined(var"@main") ? eval(:( @main )) : exit(main(ARGS))` at the end of your scripts.
 
 Only the `main` binding in the `Main` module has this behavior and only if
 the macro `@main` was used within the defining module.


### PR DESCRIPTION
macros are expanded at parse time so ternary logic here breaks without using an `eval`.