### PR TITLE
LibGit2: fix various typos found by AI

### DIFF
--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -206,22 +206,18 @@ function diff_files(repo::GitRepo, branch1::AbstractString, branch2::AbstractStr
     tree1 = GitTree(repo, b1_id)
     tree2 = GitTree(repo, b2_id)
     files = AbstractString[]
-    try
-        diff = diff_tree(repo, tree1, tree2)
-        try
-            for i in 1:count(diff)
-                delta = diff[i]
-                delta === nothing && break
-                if Consts.DELTA_STATUS(delta.status) in filter
-                    Base.push!(files, unsafe_string(delta.new_file.path))
+    with(tree1) do tree1
+        with(tree2) do tree2
+            with(diff_tree(repo, tree1, tree2)) do diff
+                for i in 1:count(diff)
+                    delta = diff[i]
+                    delta === nothing && break
+                    if Consts.DELTA_STATUS(delta.status) in filter
+                        Base.push!(files, unsafe_string(delta.new_file.path))
+                    end
                 end
             end
-        finally
-            close(diff)
         end
-    finally
-        close(tree1)
-        close(tree2)
     end
     return files
 end
@@ -529,23 +525,16 @@ function checkout!(repo::GitRepo, commit::AbstractString = "";
     end
 
     # search for commit to get a commit object
-    obj = GitObject(repo, GitHash(commit))
-    try
-        peeled = peel(GitCommit, obj)
-        try
+    with(GitObject(repo, GitHash(commit))) do obj
+        with(peel(GitCommit, obj)) do peeled
             obj_oid = GitHash(peeled)
 
             # checkout commit
             checkout_tree(repo, peeled, options = force ? CheckoutOptions(checkout_strategy = Consts.CHECKOUT_FORCE) : CheckoutOptions())
 
-            ref = GitReference(repo, obj_oid, force=force,
-                         msg="libgit2.checkout: moving from $(head_name[]) to $(obj_oid)")
-            close(ref)
-        finally
-            close(peeled)
+            with(GitReference(repo, obj_oid, force=force,
+                         msg="libgit2.checkout: moving from $(head_name[]) to $(obj_oid)")) do _ end
         end
-    finally
-        close(obj)
     end
 
     return nothing

--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -525,14 +525,23 @@ function checkout!(repo::GitRepo, commit::AbstractString = "";
 
     # search for commit to get a commit object
     obj = GitObject(repo, GitHash(commit))
-    peeled = peel(GitCommit, obj)
-    obj_oid = GitHash(peeled)
+    try
+        peeled = peel(GitCommit, obj)
+        try
+            obj_oid = GitHash(peeled)
 
-    # checkout commit
-    checkout_tree(repo, peeled, options = force ? CheckoutOptions(checkout_strategy = Consts.CHECKOUT_FORCE) : CheckoutOptions())
+            # checkout commit
+            checkout_tree(repo, peeled, options = force ? CheckoutOptions(checkout_strategy = Consts.CHECKOUT_FORCE) : CheckoutOptions())
 
-    GitReference(repo, obj_oid, force=force,
-                 msg="libgit2.checkout: moving from $(head_name[]) to $(obj_oid)")
+            ref = GitReference(repo, obj_oid, force=force,
+                         msg="libgit2.checkout: moving from $(head_name[]) to $(obj_oid)")
+            close(ref)
+        finally
+            close(peeled)
+        end
+    finally
+        close(obj)
+    end
 
     return nothing
 end

--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -450,9 +450,11 @@ function branch!(repo::GitRepo, branch_name::AbstractString,
             new_branch_ref = create_branch(repo, branch_name, cmt, force=force)
         finally
             close(cmt)
-            new_branch_ref === nothing && throw(GitError(Error.Object, Error.ERROR, "cannot create branch `$branch_name` with `$commit_id`"))
-            branch_ref = new_branch_ref
         end
+        if new_branch_ref === nothing
+            throw(GitError(Error.Object, Error.ERROR, "cannot create branch `$branch_name` with `$commit_id`"))
+        end
+        branch_ref = new_branch_ref
     end
 
     branch_ref′ = branch_ref # Avoids boxing `branch_ref`

--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -532,7 +532,7 @@ function checkout!(repo::GitRepo, commit::AbstractString = "";
     checkout_tree(repo, peeled, options = force ? CheckoutOptions(checkout_strategy = Consts.CHECKOUT_FORCE) : CheckoutOptions())
 
     GitReference(repo, obj_oid, force=force,
-                 msg="libgit2.checkout: moving from $(head_name[]) to $(obj_oid))")
+                 msg="libgit2.checkout: moving from $(head_name[]) to $(obj_oid)")
 
     return nothing
 end

--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -208,14 +208,17 @@ function diff_files(repo::GitRepo, branch1::AbstractString, branch2::AbstractStr
     files = AbstractString[]
     try
         diff = diff_tree(repo, tree1, tree2)
-        for i in 1:count(diff)
-            delta = diff[i]
-            delta === nothing && break
-            if Consts.DELTA_STATUS(delta.status) in filter
-                Base.push!(files, unsafe_string(delta.new_file.path))
+        try
+            for i in 1:count(diff)
+                delta = diff[i]
+                delta === nothing && break
+                if Consts.DELTA_STATUS(delta.status) in filter
+                    Base.push!(files, unsafe_string(delta.new_file.path))
+                end
             end
+        finally
+            close(diff)
         end
-        close(diff)
     finally
         close(tree1)
         close(tree2)

--- a/stdlib/LibGit2/src/blob.jl
+++ b/stdlib/LibGit2/src/blob.jl
@@ -76,7 +76,7 @@ end
 function Base.show(io::IO, blob::GitBlob)
     if !isbinary(blob)
         conts   = split(content(blob), "\n")
-        showlen = max(length(conts), 3)
+        showlen = min(length(conts), 3)
         println(io, "GitBlob:\nBlob id: ", GitHash(blob), "\nContents:")
         for i in 1:showlen
             println(io, conts[i])

--- a/stdlib/LibGit2/src/gitcredential.jl
+++ b/stdlib/LibGit2/src/gitcredential.jl
@@ -151,7 +151,7 @@ function fill!(cfg::GitConfig, cred::GitCredential)
 
         # "Once Git has acquired both a username and a password, no more helpers will be
         # tried." – https://git-scm.com/docs/gitcredentials#gitcredentials-helper
-        !isfilled(cred) && break
+        isfilled(cred) && break
     end
 
     return cred

--- a/stdlib/LibGit2/src/merge.jl
+++ b/stdlib/LibGit2/src/merge.jl
@@ -41,16 +41,10 @@ function GitAnnotated(repo::GitRepo, fh::FetchHead)
 end
 
 function GitAnnotated(repo::GitRepo, committish::AbstractString)
-    obj = GitObject(repo, committish)
-    try
-        cmt = peel(GitCommit, obj)
-        try
-            return GitAnnotated(repo, GitHash(cmt))
-        finally
-            close(cmt)
+    with(GitObject(repo, committish)) do obj
+        with(peel(GitCommit, obj)) do cmt
+            GitAnnotated(repo, GitHash(cmt))
         end
-    finally
-        close(obj)
     end
 end
 
@@ -112,8 +106,7 @@ referred to by `ann` is descended from the current HEAD (e.g. if pulling changes
 from a remote branch which is simply ahead of the local branch tip).
 """
 function ffmerge!(repo::GitRepo, ann::GitAnnotated)
-    cmt = GitCommit(repo, GitHash(ann))
-    try
+    with(GitCommit(repo, GitHash(ann))) do cmt
         checkout_tree(repo, cmt)
         with(head(repo)) do head_ref
             cmt_oid = GitHash(cmt)
@@ -125,8 +118,6 @@ function ffmerge!(repo::GitRepo, ann::GitAnnotated)
             end
             close(new_head_ref)
         end
-    finally
-        close(cmt)
     end
     return true
 end

--- a/stdlib/LibGit2/src/merge.jl
+++ b/stdlib/LibGit2/src/merge.jl
@@ -230,7 +230,7 @@ function merge!(repo::GitRepo, anns::Vector{GitAnnotated}, fastforward::Bool;
     merge_result = if ffpref == Consts.MERGE_PREFERENCE_NONE
         if isset(ma, Cint(Consts.MERGE_ANALYSIS_FASTFORWARD))
             if length(anns) > 1
-                @warn "Unable to perform Fast-Forward merge with mith multiple merge heads"
+                @warn "Unable to perform Fast-Forward merge with multiple merge heads"
                 false
             else
                 ffmerge!(repo, anns[1])
@@ -243,7 +243,7 @@ function merge!(repo::GitRepo, anns::Vector{GitAnnotated}, fastforward::Bool;
     elseif ffpref == Consts.MERGE_PREFERENCE_FASTFORWARD_ONLY
         if isset(ma, Cint(Consts.MERGE_ANALYSIS_FASTFORWARD))
             if length(anns) > 1
-                @warn "Unable to perform Fast-Forward merge with mith multiple merge heads"
+                @warn "Unable to perform Fast-Forward merge with multiple merge heads"
                 false
             else
                 ffmerge!(repo, anns[1])

--- a/stdlib/LibGit2/src/merge.jl
+++ b/stdlib/LibGit2/src/merge.jl
@@ -113,17 +113,20 @@ from a remote branch which is simply ahead of the local branch tip).
 """
 function ffmerge!(repo::GitRepo, ann::GitAnnotated)
     cmt = GitCommit(repo, GitHash(ann))
-
-    checkout_tree(repo, cmt)
-    with(head(repo)) do head_ref
-        cmt_oid = GitHash(cmt)
-        msg = "libgit2.merge: fastforward $(string(cmt_oid)) into $(name(head_ref))"
-        new_head_ref = if reftype(head_ref) == Consts.REF_OID
-            target!(head_ref, cmt_oid, msg=msg)
-        else
-            GitReference(repo, cmt_oid, fullname(head_ref), msg=msg)
+    try
+        checkout_tree(repo, cmt)
+        with(head(repo)) do head_ref
+            cmt_oid = GitHash(cmt)
+            msg = "libgit2.merge: fastforward $(string(cmt_oid)) into $(name(head_ref))"
+            new_head_ref = if reftype(head_ref) == Consts.REF_OID
+                target!(head_ref, cmt_oid, msg=msg)
+            else
+                GitReference(repo, cmt_oid, fullname(head_ref), msg=msg)
+            end
+            close(new_head_ref)
         end
-        close(new_head_ref)
+    finally
+        close(cmt)
     end
     return true
 end

--- a/stdlib/LibGit2/src/merge.jl
+++ b/stdlib/LibGit2/src/merge.jl
@@ -42,8 +42,16 @@ end
 
 function GitAnnotated(repo::GitRepo, committish::AbstractString)
     obj = GitObject(repo, committish)
-    cmt = peel(GitCommit, obj)
-    return GitAnnotated(repo, GitHash(cmt))
+    try
+        cmt = peel(GitCommit, obj)
+        try
+            return GitAnnotated(repo, GitHash(cmt))
+        finally
+            close(cmt)
+        end
+    finally
+        close(obj)
+    end
 end
 
 function GitHash(ann::GitAnnotated)

--- a/stdlib/LibGit2/src/utils.jl
+++ b/stdlib/LibGit2/src/utils.jl
@@ -63,7 +63,7 @@ reset(val::Integer, flag::Integer) = (val &= ~flag)
 Flip the bits of `val` indexed by `flag`, so that if a bit is `0` it
 will be `1` after the toggle, and vice-versa.
 """
-toggle(val::Integer, flag::Integer) = (val |= flag)
+toggle(val::Integer, flag::Integer) = (val ⊻= flag)
 
 """
     features()

--- a/stdlib/LibGit2/test/libgit2-tests.jl
+++ b/stdlib/LibGit2/test/libgit2-tests.jl
@@ -922,6 +922,18 @@ mktempdir() do dir
                         LibGit2.delete_branch(tbref)
                         @test LibGit2.lookup_branch(repo, test_branch2, true) === nothing
                     end
+
+                    # an invalid branch name propagates the underlying error
+                    # instead of a generic "cannot create branch" error
+                    err = try
+                        LibGit2.branch!(repo, "invalid name", string(commit_oid1),
+                                        set_head=false, force=true)
+                        nothing
+                    catch ex
+                        ex
+                    end
+                    @test err isa LibGit2.Error.GitError
+                    @test err.code == LibGit2.Error.EINVALIDSPEC
                 end
                 branches = map(b->LibGit2.shortname(b[1]), LibGit2.GitBranchIter(repo))
                 @test default_branch in branches
@@ -1047,6 +1059,20 @@ mktempdir() do dir
                 @test length(blob2) == len1
                 @test blob  == blob2
                 @test blob !== blob2
+
+                # showing a text blob previews only the first 3 lines
+                text_file = joinpath(dir, "long_text_blob")
+                write(text_file, "l1\nl2\nl3\nl4\nl5\n")
+                text_blob = LibGit2.GitBlob(repo, LibGit2.addblob!(repo, text_file))
+                @test sprint(show, text_blob) ==
+                      "GitBlob:\nBlob id: $(LibGit2.GitHash(text_blob))\nContents:\nl1\nl2\nl3\n"
+
+                # showing a text blob with fewer than 3 lines should not error
+                short_file = joinpath(dir, "short_text_blob")
+                write(short_file, "l1\n")
+                short_blob = LibGit2.GitBlob(repo, LibGit2.addblob!(repo, short_file))
+                @test sprint(show, short_blob) ==
+                      "GitBlob:\nBlob id: $(LibGit2.GitHash(short_blob))\nContents:\nl1\n\n"
             end
         end
         @testset "trees" begin
@@ -1720,6 +1746,9 @@ mktempdir() do dir
             LibGit2.checkout!(repo, string(commit_oid1))
             @test !LibGit2.isattached(repo)
             @test LibGit2.headname(repo) == "(detached from $(string(commit_oid1)[1:7]))"
+            # the reflog message should end with the commit id (no stray paren)
+            reflog_msg = split(last(readlines(joinpath(cache_repo, ".git", "logs", "HEAD"))), '\t')[2]
+            @test endswith(reflog_msg, "to $(string(commit_oid1))")
         end
     end
 
@@ -1978,6 +2007,59 @@ mktempdir() do dir
 
                 Base.shred!(github_cred)
                 Base.shred!(mygit_cred)
+            end
+        end
+
+        @testset "fill! with multiple helpers" begin
+            # Requires `git` to be installed and available on the path.
+            if GIT_INSTALLED
+                config_path = joinpath(dir, config_file)
+                empty_store = joinpath(dir, "empty-credentials")
+                bob_store = joinpath(dir, "bob-credentials")
+                alice_store = joinpath(dir, "alice-credentials")
+                alice_alt_store = joinpath(dir, "alice-alt-credentials")
+                touch(empty_store)
+                write(bob_store, "https://bob:s3cre7@mygithost\n")
+                write(alice_store, "https://alice:pa55w0rd@mygithost\n")
+                write(alice_alt_store, "https://alice:0therpa55@mygithost\n")
+                store_helper(path) = "store --file=$(replace(path, '\\' => '/'))"
+
+                # helpers after one that returned nothing are still tried
+                open(config_path, "w+") do fp
+                    write(fp, """
+                        [credential]
+                            helper = $(store_helper(empty_store))
+                        [credential]
+                            helper = $(store_helper(bob_store))
+                        """)
+                end
+                LibGit2.with(LibGit2.GitConfig(config_path, LibGit2.Consts.CONFIG_LEVEL_APP)) do cfg
+                    cred = GitCredential("https", "mygithost")
+                    LibGit2.fill!(cfg, cred)
+                    @test LibGit2.isfilled(cred)
+                    @test cred.username == "bob"
+                    Base.shred!(cred)
+                end
+
+                # no more helpers are tried once the credential is filled
+                open(config_path, "w+") do fp
+                    write(fp, """
+                        [credential]
+                            helper = $(store_helper(alice_store))
+                        [credential]
+                            helper = $(store_helper(alice_alt_store))
+                        """)
+                end
+                LibGit2.with(LibGit2.GitConfig(config_path, LibGit2.Consts.CONFIG_LEVEL_APP)) do cfg
+                    cred = GitCredential("https", "mygithost")
+                    LibGit2.fill!(cfg, cred)
+                    @test LibGit2.isfilled(cred)
+                    @test cred.username == "alice"
+                    Base.shred!(Base.SecretBuffer("pa55w0rd")) do pw
+                        @test cred.password == pw
+                    end
+                    Base.shred!(cred)
+                end
             end
         end
 

--- a/stdlib/LibGit2/test/libgit2-tests.jl
+++ b/stdlib/LibGit2/test/libgit2-tests.jl
@@ -1075,7 +1075,10 @@ mktempdir() do dir
                 @test te_str == ref_te_str
                 blob = LibGit2.GitBlob(tree_entry)
                 blob_str = sprint(show, blob)
-                @test blob_str == "GitBlob:\nBlob id: $(LibGit2.GitHash(blob))\nContents:\n$(LibGit2.content(blob))\n"
+                blob_lines = split(LibGit2.content(blob), "\n")
+                expected = "GitBlob:\nBlob id: $(LibGit2.GitHash(blob))\nContents:\n" *
+                           join([blob_lines[i] for i in 1:min(length(blob_lines), 3)], "\n") * "\n"
+                @test blob_str == expected
 
                 # tests for walking the tree and accessing objects
                 @test tree[""] == tree


### PR DESCRIPTION
These all seem to make sense to me. 

The util function fixed is not used (there are a few others) but for some reason they are included in the manual. Why..?