### PR TITLE
inference: concrete-evaluate when const-prop refines effects to foldable

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -894,6 +894,23 @@ struct ConstCallResult
         const_edge::Union{Nothing,CodeInstance})
         return new(rt, exct, const_result, effects, const_edge)
     end
+    function ConstCallResult(
+            result::ConstCallResult;
+            effects::Effects = result.effects,
+            const_edge::Union{Nothing,CodeInstance} = result.const_edge
+        )
+        return new(result.rt, result.exct, result.const_result, effects, const_edge)
+    end
+end
+
+function use_concrete_eval_result(
+        interp::AbstractInterpreter, concrete_eval_result::ConstCallResult
+    )
+    # if we don't inline the result of this concrete evaluation,
+    # give const-prop' a chance to inline a better method body
+    return !may_optimize(interp) ||
+        may_inline_concrete_result(concrete_eval_result.const_result::ConcreteResult) ||
+        concrete_eval_result.rt === Bottom # unless this call deterministically throws and thus is non-inlineable
 end
 
 function abstract_call_method_with_const_args(interp::AbstractInterpreter,
@@ -906,12 +923,8 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter,
     concrete_eval_result = nothing
     if eligibility === :concrete_eval
         concrete_eval_result = concrete_eval_call(interp, f, result, arginfo, sv, invokecall)
-        if (concrete_eval_result !== nothing &&  # allow external abstract interpreters to disable concrete evaluation ad-hoc
-            # if we don't inline the result of this concrete evaluation,
-            # give const-prop' a chance to inline a better method body
-            (!may_optimize(interp) ||
-             may_inline_concrete_result(concrete_eval_result.const_result::ConcreteResult) ||
-             concrete_eval_result.rt === Bottom)) # unless this call deterministically throws and thus is non-inlineable
+        # allow external abstract interpreters to disable concrete evaluation ad-hoc
+        if concrete_eval_result !== nothing && use_concrete_eval_result(interp, concrete_eval_result)
             return concrete_eval_result
         end
         # TODO allow semi-concrete interp for this call?
@@ -930,7 +943,23 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter,
         end
     end
     # try constant prop'
-    return const_prop_call(interp, mi, result, arginfo, sv, concrete_eval_result)
+    new_result = const_prop_call(interp, mi, result, arginfo, sv, concrete_eval_result)
+    if eligibility === :none && new_result !== nothing
+        # const-prop' may have refined effects to be foldable when the original
+        # call was not; in that case, prefer concrete eval over the const-prop' result
+        new_eligibility = _concrete_eval_eligible(
+            interp, f, new_result.effects, new_result.const_edge, arginfo, sv)
+        if new_eligibility === :concrete_eval
+            new_concrete_eval_result = _concrete_eval_call(
+                interp, f, new_result.const_edge::CodeInstance, new_result.effects, arginfo, sv, invokecall)
+            if new_concrete_eval_result !== nothing
+                if use_concrete_eval_result(interp, new_concrete_eval_result)
+                    return ConstCallResult(new_concrete_eval_result; const_edge = new_result.const_edge)
+                end
+            end
+        end
+    end
+    return new_result
 end
 
 function bail_out_const_call(interp::AbstractInterpreter, result::MethodCallResult,
@@ -966,9 +995,17 @@ function bail_out_const_call(interp::AbstractInterpreter, result::MethodCallResu
     return false
 end
 
-function concrete_eval_eligible(interp::AbstractInterpreter,
-    @nospecialize(f), result::MethodCallResult, arginfo::ArgInfo, sv::AbsIntState)
-    (;effects) = result
+function concrete_eval_eligible(
+        interp::AbstractInterpreter, @nospecialize(f), result::MethodCallResult,
+        arginfo::ArgInfo, sv::AbsIntState
+    )
+    return _concrete_eval_eligible(interp, f, result.effects, result.edge, arginfo, sv)
+end
+
+function _concrete_eval_eligible(
+        interp::AbstractInterpreter, @nospecialize(f), effects::Effects,
+        edge::Union{Nothing,CodeInstance}, arginfo::ArgInfo, sv::AbsIntState
+    )
     if inbounds_option() === :off
         if !is_nothrow(effects)
             # Disable concrete evaluation in `--check-bounds=no` mode,
@@ -976,7 +1013,7 @@ function concrete_eval_eligible(interp::AbstractInterpreter,
             return :none
         end
     end
-    if result.edge !== nothing && is_foldable(effects, #=check_rtcall=#true)
+    if edge !== nothing && is_foldable(effects, #=check_rtcall=#true)
         if f !== nothing && is_all_const_arg(arginfo, #=start=#2)
             if (is_nonoverlayed(interp) || is_nonoverlayed(effects) ||
                 # Even if overlay methods are involved, when `:consistent_overlay` is
@@ -1034,9 +1071,18 @@ function collect_const_args(argtypes::Vector{Any}, start::Int)
                 end for i = start:length(argtypes) ]
 end
 
-function concrete_eval_call(interp::AbstractInterpreter,
-    @nospecialize(f), result::MethodCallResult, arginfo::ArgInfo, ::AbsIntState,
-    invokecall::Union{InvokeCall,Nothing}=nothing)
+function concrete_eval_call(
+        interp::AbstractInterpreter, @nospecialize(f), result::MethodCallResult,
+        arginfo::ArgInfo, sv::AbsIntState, invokecall::Union{InvokeCall,Nothing} = nothing
+    )
+    return _concrete_eval_call(
+        interp, f, result.edge::CodeInstance, result.effects, arginfo, sv, invokecall)
+end
+
+function _concrete_eval_call(
+        interp::AbstractInterpreter, @nospecialize(f), edge::CodeInstance, effects::Effects,
+        arginfo::ArgInfo, ::AbsIntState, invokecall::Union{InvokeCall,Nothing} = nothing
+    )
     args = collect_const_args(arginfo, #=start=#2)
     if invokecall !== nothing
         # this call should be `invoke`d, rewrite `args` back now
@@ -1044,14 +1090,13 @@ function concrete_eval_call(interp::AbstractInterpreter,
         f = invoke
     end
     world = get_inference_world(interp)
-    edge = result.edge::CodeInstance
     value = try
         Core._call_in_world_total(world, f, args...)
     catch
         # The evaluation threw. By :consistent-cy, we're guaranteed this would have happened at runtime.
         # Howevever, at present, :consistency does not mandate the type of the exception
-        concrete_result = ConcreteResult(edge, result.effects)
-        return ConstCallResult(Bottom, Any, concrete_result, result.effects, #=const_edge=#nothing)
+        concrete_result = ConcreteResult(edge, effects)
+        return ConstCallResult(Bottom, Any, concrete_result, effects, #=const_edge=#nothing)
     end
     concrete_result = ConcreteResult(edge, EFFECTS_TOTAL, value)
     return ConstCallResult(Const(value), Bottom, concrete_result, EFFECTS_TOTAL, #=const_edge=#nothing)

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -921,11 +921,16 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter,
     end
     eligibility = concrete_eval_eligible(interp, f, result, arginfo, sv)
     concrete_eval_result = nothing
+    always_nothrow = false
     if eligibility === :concrete_eval
         concrete_eval_result = concrete_eval_call(interp, f, result, arginfo, sv, invokecall)
         # allow external abstract interpreters to disable concrete evaluation ad-hoc
-        if concrete_eval_result !== nothing && use_concrete_eval_result(interp, concrete_eval_result)
-            return concrete_eval_result
+        if concrete_eval_result !== nothing
+            if use_concrete_eval_result(interp, concrete_eval_result)
+                return concrete_eval_result
+            elseif concrete_eval_result.rt !== Bottom
+                always_nothrow = true
+            end
         end
         # TODO allow semi-concrete interp for this call?
     end
@@ -944,7 +949,8 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter,
     end
     # try constant prop'
     new_result = const_prop_call(interp, mi, result, arginfo, sv, concrete_eval_result)
-    if eligibility === :none && new_result !== nothing
+    new_result === nothing && return nothing
+    if eligibility === :none
         # const-prop' may have refined effects to be foldable when the original
         # call was not; in that case, prefer concrete eval over the const-prop' result
         new_eligibility = _concrete_eval_eligible(
@@ -955,11 +961,18 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter,
             if new_concrete_eval_result !== nothing
                 if use_concrete_eval_result(interp, new_concrete_eval_result)
                     return ConstCallResult(new_concrete_eval_result; const_edge = new_result.const_edge)
+                elseif new_concrete_eval_result.rt !== Bottom
+                    always_nothrow = true
                 end
             end
         end
     end
-    return new_result
+    if always_nothrow
+        return ConstCallResult(new_result;
+            effects = Effects(new_result.effects; nothrow = true))
+    else
+        return new_result
+    end
 end
 
 function bail_out_const_call(interp::AbstractInterpreter, result::MethodCallResult,

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -6785,4 +6785,19 @@ f60252(f, nt::NamedTuple) = NamedTuple{keys(nt)}(f(v) for v in values(nt))
 f60252_2(t::Tuple) = NamedTuple{(:a, :b), typeof(t)}(t)
 @test Base.infer_return_type(f60252_2, (Tuple{Vararg{Int64}},)) == @NamedTuple{a::Int64, b::Int64}
 
+# perform post const-prop' concrete evaluation when effects are further improved by const-prop'
+@noinline function concrete_eval_eligible_if_false(x::Float64, n::Int, y::Bool)
+    if y # this prevents initial concrete-evaluation
+        println("x = ", x)
+    end
+    s = 0.0
+    Base.@assume_effects :terminates_locally for i = 1:n
+        s += sin(x)
+    end
+    return s
+end
+@test Base.infer_return_type() do
+    Val(concrete_eval_eligible_if_false(42., 5, false) == 5sin(42.))
+end == Val{true}
+
 end # module inference


### PR DESCRIPTION
`const_prop_call` may refine effects to be foldable when the original call was not (e.g., when constant arguments make a branch dead, eliminating side effects). Previously such cases would only receive the const-prop' result. Now we re-check eligibility on the const-prop'd effects/edge and prefer concrete evaluation when it becomes applicable, yielding `Const` returns and `EFFECTS_TOTAL`.

Note that we do not want to simply check concrete-eval eligibility upfront on const-prop'd effects to avoid the secondary check: concrete eval was originally introduced as a fast path for const-prop' itself, so reversing the order (running const-prop' before concrete-eval) would defeat that purpose by paying the const-prop' cost even for calls that the cheaper, upfront concrete-eval check would have caught. The secondary check here is intentionally constrained to `eligibility === :none`, where the upfront concrete-eval was not applicable to begin with.