### PR TITLE
[backports-release-1.13] x86-64: ignore privileged-only CPU feature bits

### DIFF
--- a/src/features_x86.h
+++ b/src/features_x86.h
@@ -85,7 +85,7 @@ JL_FEATURE_DEF(uintr, 32 * 4 + 5, 140000)
 JL_FEATURE_DEF(avx512vp2intersect, 32 * 4 + 8, 0)
 JL_FEATURE_DEF(serialize, 32 * 4 + 14, 110000)
 JL_FEATURE_DEF(tsxldtrk, 32 * 4 + 16, 110000)
-JL_FEATURE_DEF(pconfig, 32 * 4 + 18, 0)
+// JL_FEATURE_DEF(pconfig, 32 * 4 + 18, 0) // Privileged instruction
 // JL_FEATURE_DEF(ibt, 32 * 4 + 20, 0)
 JL_FEATURE_DEF_NAME(amx_bf16, 32 * 4 + 22, 110000, "amx-bf16")
 JL_FEATURE_DEF(avx512fp16, 32 * 4 + 23, 140000)
@@ -115,7 +115,7 @@ JL_FEATURE_DEF(xsaves, 32 * 7 + 3, 0)
 
 // EAX=0x80000008: EBX
 JL_FEATURE_DEF(clzero, 32 * 8 + 0, 0)
-JL_FEATURE_DEF(wbnoinvd, 32 * 8 + 9, 0)
+// JL_FEATURE_DEF(wbnoinvd, 32 * 8 + 9, 0) // Privileged instruction
 
 // EAX=7,ECX=1: EAX
 JL_FEATURE_DEF(sha512, 32 * 9 + 0, 170000)
@@ -126,7 +126,7 @@ JL_FEATURE_DEF(avxvnni, 32 * 9 + 4, 120000)
 JL_FEATURE_DEF(avx512bf16, 32 * 9 + 5, 0)
 JL_FEATURE_DEF(cmpccxadd, 32 * 9 + 7, 160000)
 JL_FEATURE_DEF_NAME(amx_fp16, 32 * 9 + 21, 160000, "amx-fp16")
-JL_FEATURE_DEF(hreset, 32 * 9 + 22, 160000)
+// JL_FEATURE_DEF(hreset, 32 * 9 + 22, 160000) // Privileged instruction
 JL_FEATURE_DEF(avxifma, 32 * 9 + 23, 160000)
 
 // EAX=7,ECX=1: EBX

--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -215,11 +215,11 @@ constexpr auto cannonlake = skylake | get_feature_masks(avx512f, avx512cd, avx51
 constexpr auto icelake = cannonlake | get_feature_masks(avx512bitalg, vaes, avx512vbmi2,
                                                         vpclmulqdq, avx512vpopcntdq,
                                                         gfni, clwb, rdpid);
-constexpr auto icelake_server = icelake | get_feature_masks(pconfig, wbnoinvd);
+constexpr auto icelake_server = icelake; // pconfig (privileged), wbnoinvd (privileged)
 constexpr auto tigerlake = icelake | get_feature_masks(avx512vp2intersect, movdiri,
                                                        movdir64b, shstk);
-constexpr auto alderlake = skylake | get_feature_masks(clwb, sha, waitpkg, shstk, gfni, vaes, vpclmulqdq, pconfig,
-                                                       rdpid, movdiri, pku, movdir64b, serialize, ptwrite, avxvnni);
+constexpr auto alderlake = skylake | get_feature_masks(clwb, sha, waitpkg, shstk, gfni, vaes, vpclmulqdq,
+                                                       rdpid, movdiri, pku, movdir64b, serialize, ptwrite, avxvnni); // pconfig (privileged)
 constexpr auto sapphirerapids = icelake_server |
     get_feature_masks(amx_tile, amx_int8, amx_bf16, avx512bf16, avx512fp16, serialize, cldemote, waitpkg,
                       avxvnni, uintr, ptwrite, tsxldtrk, enqcmd, shstk, avx512vp2intersect, movdiri, movdir64b);
@@ -242,7 +242,7 @@ constexpr auto bdver4 = bdver3 | get_feature_masks(avx2, bmi2, mwaitx, movbe, rd
 // See: https://github.com/JuliaLang/julia/issues/50102
 constexpr auto znver1 = haswell | get_feature_masks(adx, aes, clflushopt, clzero, mwaitx, prfchw,
                                                     rdseed, sha, sse4a, xsavec);
-constexpr auto znver2 = znver1 | get_feature_masks(clwb, rdpid, wbnoinvd);
+constexpr auto znver2 = znver1 | get_feature_masks(clwb, rdpid); // wbnoinvd (privileged)
 constexpr auto znver3 = znver2 | get_feature_masks(shstk, pku, vaes, vpclmulqdq);
 constexpr auto znver4 = znver3 | get_feature_masks(avx512f, avx512cd, avx512dq, avx512bw, avx512vl, avx512ifma, avx512vbmi,
                                                    avx512vbmi2, avx512vnni, avx512bitalg, avx512vpopcntdq, avx512bf16, gfni, shstk, xsaves);


### PR DESCRIPTION
Another fix for https://github.com/JuliaLang/julia/issues/61671.

On Arrow Lake these have been observed to vary from core to core, but these instructions are not available in user space so we should not be using them to key our images / codegen.