### PR TITLE
Avoid potential read from uninitialized memory

### DIFF
--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -202,8 +202,7 @@ JL_DLLEXPORT jl_value_t *jl_genericmemory_to_string(jl_genericmemory_t *m, size_
         jl_value_t *o = jl_genericmemory_data_owner_field(m);
         if (how == JL_GENERICMEMORY_STRINGOWNED && // implies jl_is_string(o)
              ((mlength + sizeof(void*) + 1 <= GC_MAX_SZCLASS) == (len + sizeof(void*) + 1 <= GC_MAX_SZCLASS))) {
-            if (jl_string_data(o)[len] != '\0')
-                jl_string_data(o)[len] = '\0';
+            jl_string_data(o)[len] = '\0';
             if (*(size_t*)o != len)
                 *(size_t*)o = len;
             return o;

--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -203,8 +203,7 @@ JL_DLLEXPORT jl_value_t *jl_genericmemory_to_string(jl_genericmemory_t *m, size_
         if (how == JL_GENERICMEMORY_STRINGOWNED && // implies jl_is_string(o)
              ((mlength + sizeof(void*) + 1 <= GC_MAX_SZCLASS) == (len + sizeof(void*) + 1 <= GC_MAX_SZCLASS))) {
             jl_string_data(o)[len] = '\0';
-            if (*(size_t*)o != len)
-                *(size_t*)o = len;
+            *(size_t*)o = len;
             return o;
         }
         JL_GC_PUSH1(&o);


### PR DESCRIPTION
Valgrind complains about:

```
==207496== Conditional jump or move depends on uninitialised value(s)
==207496==    at 0x5392ABE: jl_genericmemory_to_string (genericmemory.c:203)
==207496==    by 0x1305F75B: String; (string.jl:78)
==207496==    by 0x1305F75B: julia_YY.sprintYY.594_62166.1 (io.jl:116)
==207496==    by 0x13278925: sprint; (io.jl:107)
==207496==    by 0x13278925: #repr#597; (io.jl:286)
==207496==    by 0x13278925: repr; (io.jl:286)
==207496==    by 0x13278925: julia__pkg_str_72280.1 (loading.jl:2946)
==207496==    by 0x1256612A: _pkg_str; (loading.jl:2948)
==207496==    by 0x1256612A: iterate; (generator.jl:48)
==207496==    by 0x1256612A: julia_collect_toNOT._57018.1 (array.jl:849)
==207496==    by 0x12738D16: collect_to_with_first!; (array.jl:827)
==207496==    by 0x12738D16: julia__collect_56746.1 (array.jl:821)
==207496==    by 0x1250E313: collect_similar; (array.jl:720)
==207496==    by 0x1250E313: map; (abstractarray.jl:3371)
==207496==    by 0x1250E313: julia__pkg_str_72296.1 (loading.jl:2947)
==207496==    by 0x1241BC23: julia_create_expr_cache_72303.1 (loading.jl:3010)
==207496==    by 0x11C35FDD: julia_YY.compilecacheYY.1123_72578.1 (loading.jl:3123)
==207496==    by 0x13581E12: compilecache; (loading.jl:3081)
==207496==    by 0x13581E12: julia_YY.33_71976.1 (precompilation.jl:933)
==207496==    by 0x129E6F43: julia_with_logstate_66897.1 (logging.jl:526)
==207496==    by 0x11D9E727: with_logger; (logging.jl:637)
==207496==    by 0x11D9E727: #32; (precompilation.jl:927)
==207496==    by 0x11D9E727: julia_YY.mkpidlockYY.7_76315.1 (pidfile.jl:95)
==207496==    by 0x11E171AC: jfptr_YY.mkpidlockYY.7_76316.1 (in /home/vchuravy/.julia/juliaup/julia-1.11.9+0.x64.linux.gnu/lib/julia/sys.so)
==207496==
```

And still present in current Julia.

As far as I can tell, there should be no harm in an unconditional write here.
