### PR TITLE
[release-1.10] Revert "Restrict COFF to a single thread when symbol count is high (#50874)

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -659,7 +659,6 @@ static FunctionInfo getFunctionWeight(const Function &F)
 }
 
 struct ModuleInfo {
-    Triple triple;
     size_t globals;
     size_t funcs;
     size_t bbs;
@@ -670,7 +669,6 @@ struct ModuleInfo {
 
 ModuleInfo compute_module_info(Module &M) {
     ModuleInfo info;
-    info.triple = Triple(M.getTargetTriple());
     info.globals = 0;
     info.funcs = 0;
     info.bbs = 0;
@@ -1423,13 +1421,6 @@ static unsigned compute_image_thread_count(const ModuleInfo &info) {
     LLVM_DEBUG(dbgs() << "32-bit systems are restricted to a single thread\n");
     return 1;
 #endif
-    // COFF has limits on external symbols (even hidden) up to 65536. We reserve the last few
-    // for any of our other symbols that we insert during compilation.
-    if (info.triple.isOSBinFormatCOFF() && info.globals > 64000) {
-        LLVM_DEBUG(dbgs() << "COFF is restricted to a single thread for large images\n");
-        return 1;
-    }
-
     // This is not overridable because empty modules do occasionally appear, but they'll be very small and thus exit early to
     // known easy behavior. Plus they really don't warrant multiple threads
     if (info.weight < 1000) {


### PR DESCRIPTION
This reverts commit eb4416b16b8a865376da5c76451a4d60516e2c4a.

Backport of https://github.com/JuliaLang/julia/pull/59736. See https://github.com/JuliaLang/PackageCompiler.jl/pull/1099 for why this is safe to backport despite not having LLVM 16 / `exclude-symbols` emission on Julia 1.10.