### PR TITLE
pow: fix various issues w.r.t sign when raising with an odd power

### DIFF
--- a/base/special/pow.jl
+++ b/base/special/pow.jl
@@ -19,7 +19,11 @@ end
         yint == 0 && return 1.0
         use_power_by_squaring(yint) && return @noinline pow_body(x, yint)
     end
-    2*xu==0 && return abs(y)*Inf*(!(y>0)) # if x === +0.0 or -0.0 (Inf * false === 0.0)
+    if 2*xu==0 # x === +0.0 or -0.0 (Inf * false === 0.0)
+        v = abs(y)*Inf*(!(y>0))
+        # Odd integer exponents preserve the sign of -0.0
+        return yisint && isodd(yint) ? copysign(v, x) : v
+    end
     s = 1
     if x < 0
         !yisint && throw_exp_domainerror(x) # y isn't an integer
@@ -50,6 +54,9 @@ end
     if x < 0
         !yisint && throw_exp_domainerror(x) # y isn't an integer
         s = ifelse(isodd(yint), -1, 1)
+    elseif iszero(x) && signbit(x) && yisint && isodd(yint)
+        # x < 0 is false for -0.0 per IEEE 754, but odd powers of -0.0 must be negative
+        s = -1
     end
     !isfinite(x) && return copysign(x,s)*(y>0 || isnan(x)) # x is inf or NaN
     return copysign(pow_body(abs(x), y), s)
@@ -61,7 +68,7 @@ end
     if use_power_by_squaring(n)
         return pow_body(x, n)
     else
-        s = ifelse(x < 0 && isodd(n), -1.0, 1.0)
+        s = ifelse(signbit(x) && isodd(n), -1.0, 1.0)
         x = abs(x)
         y = float(n)
         if y == n
@@ -82,7 +89,7 @@ end
     # Note that NaN can pass through this, but that will end up fine.
     n == 0 && return one(x)
     use_power_by_squaring(n) && return pow_body(x, n)
-    s = ifelse(x < 0 && isodd(n), -one(T), one(T))
+    s = ifelse(signbit(x) && isodd(n), -one(T), one(T))
     x = abs(x)
     return pow_body(x, widen(T)(n))
 end
@@ -126,6 +133,9 @@ end
         x = rx
         n = -n
     end
+    # two_mul(±0.0, ±0.0) and two_mul(±Inf, ±Inf) lose sign information,
+    # so fall back to simple power_by_squaring for these edge cases.
+    (iszero(x) | !isfinite(x)) && return Base.power_by_squaring(x, n)
     while n > 1
         if n&1 > 0
             err = muladd(y, xnlo, x*ynlo)

--- a/test/math.jl
+++ b/test/math.jl
@@ -1640,6 +1640,57 @@ end
         end
     end
 
+    # IEEE 754: sign of zero/Inf for pow(−0, n) and pow(−∞, −n) with odd integer n
+    @testset "pow negative zero sign" begin
+        # pow_body compensated squaring (small exponents, integer path)
+        @testset "(-0.0)^n integer" begin
+            for n in (5, 7, 9, 11, 101)
+                @test (-0.0)^n === -0.0
+                @test (-0.0)^(-n) === -Inf
+            end
+            for n in (2, 4, 6, 100)
+                @test (-0.0)^n === 0.0
+                @test (-0.0)^(-n) === Inf
+            end
+        end
+        # pow_body compensated squaring via inv (small exponents)
+        @testset "(-Inf)^(-n) integer" begin
+            for n in (3, 5, 7, 101)
+                @test (-Inf)^(-n) === -0.0
+            end
+            for n in (2, 4, 6, 100)
+                @test (-Inf)^(-n) === 0.0
+            end
+        end
+        # Float-exponent dispatch paths
+        @testset "(-0.0)^n float exponent" begin
+            for n in (5.0, 7.0, 101.0)
+                @test (-0.0)^n === -0.0
+            end
+            for n in (2.0, 4.0, 100.0)
+                @test (-0.0)^n === 0.0
+            end
+        end
+        # Large exponents outside use_power_by_squaring range
+        @testset "(-0.0)^n large exponents" begin
+            @test (-0.0)^25001 === -0.0
+            @test (-0.0)^(-25001) === -Inf
+            @test (-0.0)^25001.0 === -0.0
+            @test (-0.0)^(-25001.0) === -Inf
+            @test (-0.0)^25000 === 0.0
+            @test (-0.0)^(-25000) === Inf
+        end
+        # Float32/Float16 paths
+        @testset "Float32/Float16 negative zero" begin
+            for T in (Float16, Float32)
+                @test T(-0.0)^5 === T(-0.0)
+                @test T(-0.0)^4 === T(0.0)
+            end
+            @test Float32(-0.0)^Float32(25001) === Float32(-0.0)
+            @test Float32(-0.0)^Float32(25000) === Float32(0.0)
+        end
+    end
+
     # issue #55633
     struct Issue55633_1 <: Number end
     struct Issue55633_3 <: Number end


### PR DESCRIPTION
IEEE has the following to say about pow special cases:

```
For the pow operation:
pow(x, ±0) is 1 if x is not a signaling NaN
pow(±0, y) is ±∞ and signals the divideByZero exception for y an odd integer <0
pow(±0, −∞) is +∞ with no exception
pow(±0, +∞) is +0 with no exception
pow(±0, y) is ±0 for finite y>0 an odd integer
pow(−1, ±∞) is 1 with no exception
pow(+1, y) is 1 for any y (even a quiet NaN)
pow(x, +∞) is +0 for −1<x<1
pow(x, +∞) is +∞ for x<−1 or for 1<x (including ±∞)
pow(x, −∞) is +∞ for −1<x<1
pow(x, −∞) is +0 for x<−1 or for 1<x (including ±∞)
pow(+∞, y) is +0 for a number y < 0
pow(+∞, y) is +∞ for a number y > 0
pow(−∞, y) is −0 for finite y < 0 an odd integer
pow(−∞, y) is −∞ for finite y > 0 an odd integer
pow(−∞, y) is +0 for finite y < 0 and not an odd integer
pow(−∞, y) is +∞ for finite y > 0 and not an odd integer
pow(±0, y) is +∞ and signals the divideByZero exception for finite y<0 and not an odd integer
pow(±0, y) is +0 for finite y>0 and not an odd integer
pow(x, y) signals the invalid operation exception for finite x<0 and finite non-integer y
```

We had some misses for this, as an example:

```julia 

# ok
julia> (-0.0)^3.0
-0.0

# should be negative
julia> (-0.0)^5.0
0.0
```

This PR makes `pow` adhere more closely to IEEE for `pow`. 

Made together with Claude