### PR TITLE
stacktraces: follow-up to "Enable method signature printing for inlined frames"

### DIFF
--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -324,17 +324,6 @@ let code = Any[
     oc = Core.OpaqueClosure(ir)
     @test oc(false, 1, 1) == 2
     @test_throws "potential throw" oc(true, 1, 1)
-
-    let buf = IOBuffer()
-        oc = Core.OpaqueClosure(ir; slotnames=Symbol[:ocfunc, :x, :y, :z])
-        try
-            oc(true, 1, 1)
-        catch
-            Base.show_backtrace(buf, catch_backtrace())
-        end
-        s = String(take!(buf))
-        @test occursin("(x::Bool, y::$Int, z::$Int)", s)
-    end
 end
 
 # Test dynamic update of domtree with edge insertions and deletions in the

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -187,7 +187,9 @@ let (err, st) = try
     @test !isnothing(err.err)
     # Check that `catch_backtrace` can capture the stacktrace of the macro functions
     @test any(sf->sf.func===:f_throw, st)
-    @test any(sf->sf.func===Symbol("@m_throw"), st)
+    # TODO: store this in DebugInfo
+    @test_broken any(sf->sf.func===Symbol("@m_throw"), st)
+    @test any(sf->sf.func===Symbol("macro expansion"), st)
 end
 
 let err = try

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -111,13 +111,36 @@ function hash(frame::StackFrame, h::UInt)
     return h
 end
 
-# Decode a single codeloc entry, advancing one level of inlining. Returns
-# `(line, to, next_pc)` where `to` is the 1-based index into `debuginfo.edges`
-# for the inlined call directly at `pc` (0 if none), and `next_pc` is the PC
-# within `debuginfo.edges[to]`'s CodeInfo. To traverse nested inlinings, the
-# caller must follow the edge and call this again with `(edges[to], next_pc)`.
-debuginfo_codeloc(debuginfo::Core.DebugInfo, pc::Integer) =
-    @ccall jl_uncompress1_codeloc(debuginfo::Any, pc::Csize_t)::NTuple{3,Int32}
+function _add_linetable_frames!(frames, pointer, di::Core.DebugInfo, pc::Int)
+    lt = di.linetable
+    if lt isa Core.DebugInfo
+        ltpc::Int, _, _ = Base.Compiler.getdebugidx(di, pc)
+        _add_linetable_frames!(frames, pointer, lt, ltpc)
+        _, eid::Int, epc::Int = Base.Compiler.getdebugidx(lt, ltpc)
+        eid != 0 && _add_di_frames!(frames, pointer, lt.edges[eid], epc)
+    end
+    nothing
+end
+
+# 1. Push our own frame
+# 2. If there is a linetable, recurse on edges there (and not the linetable)
+# 3. Recurse on any of our own edges
+function _add_di_frames!(frames, pointer, di::Core.DebugInfo, pc::Int)
+    _, eid::Int, epc::Int = Base.Compiler.getdebugidx(di, pc)
+    @assert pc > 0 "invalid pc for $di.def"
+    push!(frames, StackFrame(
+        di.def isa Symbol ? Symbol("macro expansion") : IRShow.method_name(di.def),
+        IRShow.debuginfo_file1(di),
+        @ccall(jl_cdi_firstxy(di::Core.DebugInfo, pc::Int32)::NTuple{2, Int32})[1],
+        di.def isa Core.MethodInstance ? di.def : nothing,
+        false, # we can assume C frames aren't inlined into julia
+        !isempty(frames),
+        pointer,
+        pc))
+    _add_linetable_frames!(frames, pointer, di, pc)
+    eid != 0 && _add_di_frames!(frames, pointer, di.edges[eid], epc)
+    nothing
+end
 
 """
     lookup(pointer::Ptr{Cvoid})::Vector{StackFrame}
@@ -127,46 +150,42 @@ up stack frame context information. Returns an array of frame information for al
 inlined at that point, innermost function first.
 """
 Base.@constprop :none function lookup(pointer::Ptr{Cvoid})
-    infos = @ccall jl_lookup_code_address(pointer::Ptr{Cvoid}, false::Cint)::Core.SimpleVector
+    frames = @ccall jl_lookup_code_address(pointer::Ptr{Cvoid}, false::Cint)::Core.SimpleVector
     pointer = convert(UInt64, pointer)
-    isempty(infos) && return [StackFrame(empty_sym, empty_sym, -1, nothing, true, false, pointer)] # this is equal to UNKNOWN
-    ninfos = length(infos)
-    res = Vector{StackFrame}(undef, ninfos)
-    local debuginfo = false
-    local parent_pc = 0
-    for i = ninfos:-1:1
-        info = infos[i]::Core.SimpleVector
-        @assert length(info) == 7 "corrupt return from jl_lookup_code_address"
-        func = info[1]::Symbol
-        file = info[2]::Symbol
-        linenum = info[3]::Int
-        linfo = info[4]
-        pc = info[7]::Int
-        if linfo isa Core.CodeInstance
-            if debuginfo === false
-                debuginfo = linfo.debuginfo
-            else
-                debuginfo = true
-            end
-            linfo = linfo.def
-        elseif debuginfo isa Core.DebugInfo && parent_pc > 0
-            # Use the parent frame's PC to look up which inlining edge of the
-            # current `debuginfo` corresponds to this frame's call site.
-            _, to::Int, _ = debuginfo_codeloc(debuginfo, parent_pc)
-            if to > 0 && to <= length(debuginfo.edges)
-                debuginfo = debuginfo.edges[to]::Core.DebugInfo
-                def = debuginfo.def
-                if !(def isa Symbol)
-                    linfo = def
-                end
-            else
-                debuginfo = true
-            end
-        end
-        parent_pc = pc
-        res[i] = StackFrame(func, file, linenum, linfo, info[5]::Bool, info[6]::Bool, pointer, pc)
+
+    # this is equal to UNKNOWN
+    isempty(frames) && return [StackFrame(
+        empty_sym, empty_sym, -1, nothing, true, false, pointer)]
+
+    # If we aren't given a PC and CodeInstance for the last (non-inlined) frame,
+    # we can't recover any more information than `frames`, so use those.
+    # Otherwise, DebugInfo lets us recover `linfo` for inlined frames too, so
+    # ignore `frames` and construct them by traversing the DebugInfo tree
+    # instead.  This is a separate code path since attempting to enhance
+    # existing `frames` would require matching them to our tree traversal.
+    pc = frames[end][5]::Bool ? 0 : frames[end][7]::Int
+    di = let x = frames[end][4]
+        x isa Core.CodeInstance ? x.debuginfo : nothing
     end
-    return res
+    if pc <= 0 || !(di isa Core.DebugInfo)
+        out = Vector{StackFrame}(undef, length(frames))
+        for i in 1:length(frames)
+            f = frames[i]
+            @assert length(f) == 7 "corrupt return from jl_lookup_code_address"
+            func = f[1]::Symbol
+            file = f[2]::Symbol
+            linenum = f[3]::Int
+            linfo = f[4]
+            from_c = f[5]::Bool
+            inlined = f[6]::Bool
+            out[i] = StackFrame(func, file, linenum, linfo, from_c, inlined, pointer, 0)
+        end
+    else
+        out = Vector{StackFrame}()
+        _add_di_frames!(out, pointer, di, pc)
+        reverse!(out)
+    end
+    return out
 end
 
 const top_level_scope_sym = Symbol("top-level scope")

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -131,7 +131,7 @@ function _add_di_frames!(frames, pointer, di::Core.DebugInfo, pc::Int)
     push!(frames, StackFrame(
         di.def isa Symbol ? Symbol("macro expansion") : IRShow.method_name(di.def),
         IRShow.debuginfo_file1(di),
-        @ccall(jl_cdi_firstxy(di::Core.DebugInfo, pc::Int32)::NTuple{2, Int32})[1],
+        @ccall(jl_cdi_firstxy(di::Any, pc::Int32)::NTuple{2, Int32})[1],
         di.def isa Core.MethodInstance ? di.def : nothing,
         false, # we can assume C frames aren't inlined into julia
         !isempty(frames),

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -127,7 +127,7 @@ end
 # 3. Recurse on any of our own edges
 function _add_di_frames!(frames, pointer, di::Core.DebugInfo, pc::Int)
     _, eid::Int, epc::Int = Base.Compiler.getdebugidx(di, pc)
-    @assert pc > 0 "invalid pc for $di.def"
+    @assert pc > 0 "invalid pc"
     push!(frames, StackFrame(
         di.def isa Symbol ? Symbol("macro expansion") : IRShow.method_name(di.def),
         IRShow.debuginfo_file1(di),
@@ -138,7 +138,7 @@ function _add_di_frames!(frames, pointer, di::Core.DebugInfo, pc::Int)
         pointer,
         pc))
     _add_linetable_frames!(frames, pointer, di, pc)
-    eid != 0 && _add_di_frames!(frames, pointer, di.edges[eid], epc)
+    eid != 0 && epc != 0 && _add_di_frames!(frames, pointer, di.edges[eid], epc)
     nothing
 end
 
@@ -178,7 +178,9 @@ Base.@constprop :none function lookup(pointer::Ptr{Cvoid})
             linfo = f[4]
             from_c = f[5]::Bool
             inlined = f[6]::Bool
-            out[i] = StackFrame(func, file, linenum, linfo, from_c, inlined, pointer, 0)
+            sv_pc = from_c ? f[7]::Int : 0
+            out[i] = StackFrame(
+                func, file, linenum, linfo, from_c, inlined, pointer, sv_pc)
         end
     else
         out = Vector{StackFrame}()

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -49,12 +49,12 @@ Stack information representing execution context, with the following fields:
 
 - `pc::Int`
 
-  1-based statement index within the frame's `CodeInfo`, recovered from the DWARF
-  column emitted by codegen. `0` when unavailable (e.g. for C frames or frames
-  without enriched debug info). Used internally by `StackTraces.lookup` to resolve
-  the `MethodInstance` for inlined frames; also surfaced in low-level safe
-  backtrace output (e.g. on segfault) but not in Julia's default `show` for
-  `StackFrame`.
+  If `from_c`, this is a column number.  Otherwise, it is a 1-based statement
+  index within the frame's `linfo.debuginfo`, recovered from the DWARF column
+  emitted by codegen, or `0` when debuginfo is unavailable. Used internally by
+  `StackTraces.lookup` to resolve the `MethodInstance` for inlined frames; also
+  surfaced in low-level safe backtrace output (e.g. on segfault) but not in
+  Julia's default `show` for `StackFrame`.
 """
 struct StackFrame # this type should be kept platform-agnostic so that profiles can be dumped on one machine and read on another
     "the name of the function containing the execution context"
@@ -72,7 +72,7 @@ struct StackFrame # this type should be kept platform-agnostic so that profiles 
     inlined::Bool
     "representation of the pointer to the execution context as returned by `backtrace`"
     pointer::UInt64  # Large enough to be read losslessly on 32- and 64-bit machines.
-    "1-based statement index (PC) within the frame's CodeInfo, or 0 if unavailable"
+    "if !from_c, 1-based statement index (PC) within the frame's CodeInfo, or 0 if unavailable"
     pc::Int
 end
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9338,9 +9338,10 @@ static jl_llvm_functions_t
     topinfo.edgeid = 0;
     std::map<std::tuple<StringRef, StringRef>, DISubprogram*> subprograms;
     SmallVector<DebugLineTable, 0> prev_lineinfo, new_lineinfo;
-    auto update_lineinfo = [&] (size_t pc) {
-        std::function<bool(jl_debuginfo_t*, jl_value_t*, size_t, size_t)> append_lineinfo =
-                [&] (jl_debuginfo_t *debuginfo, jl_value_t *func, size_t to, size_t pc) -> bool {
+    auto update_lineinfo = [&](size_t outerpc) {
+        std::function<bool(jl_debuginfo_t *, jl_value_t *, size_t, size_t, bool)>
+            append_lineinfo = [&](jl_debuginfo_t *debuginfo, jl_value_t *func, size_t to,
+                                  size_t pc, bool innermost) -> bool {
             while (1) {
                 if (!jl_is_symbol(debuginfo->def)) // this is a path
                     func = debuginfo->def; // this is inlined
@@ -9353,7 +9354,7 @@ static jl_llvm_functions_t
                 if (pc > 0 && jl_is_debuginfo(debuginfo->linetable)) {
                     // indirection node
                     if (!append_lineinfo((jl_debuginfo_t *)debuginfo->linetable,
-                                         func, to, i))
+                                         func, to, i, lineidx.to == 0))
                         return false; // no update
                 }
                 else {
@@ -9379,11 +9380,24 @@ static jl_llvm_functions_t
                         info.is_user_code = in_user_mod(modu);
                     if (debug_enabled) {
                         StringRef fname = jl_debuginfo_name(func);
-                        // Encode the 1-based statement index into the DWARF column field so that
-                        // stacktraces can recover the exact PC that each inlined frame points at.
-                        // `pc` here is the 1-based statement index within `debuginfo`'s CodeInfo.
-                        unsigned col = (unsigned)pc;
-                        if (new_lineinfo.empty() && info.file == ctx.file) { // if everything matches, emit a toplevel line number
+                        // Encode outermost (codeinstance) debuginfo PC on
+                        // innermost frame's DWARF column.  Note "innermost" is
+                        // fuzzy given that debuginfo is a tree, but as long as
+                        // it appears on at least one frame, stacktraces can
+                        // pick it up.
+                        //
+                        // DILocation has inlinee locs point to their inliners
+                        // (and DWARF is not dissimilar), so putting this
+                        // information on the outermost frame causes performance
+                        // issues (see #61699).
+                        //
+                        // FIXME: `col` is limited to 16 bits in DILocation, so
+                        // we should find a better place to put this.
+                        unsigned col = (lineidx.to == 0 && innermost &&
+                                        outerpc <= UINT16_MAX) ?
+                            (unsigned)outerpc : 0;
+                        if (new_lineinfo.empty() && info.file == ctx.file) {
+                            // if everything matches, emit a toplevel line number
                             info.loc = DILocation::get(ctx.builder.getContext(), info.line, col, SP, NULL);
                         }
                         else { // otherwise, describe this as an inlining frame
@@ -9420,7 +9434,7 @@ static jl_llvm_functions_t
         };
         prev_lineinfo.truncate(0);
         std::swap(prev_lineinfo, new_lineinfo);
-        bool updated = append_lineinfo(src->debuginfo, (jl_value_t*)lam, 0, pc + 1);
+        bool updated = append_lineinfo(src->debuginfo, (jl_value_t*)lam, 0, outerpc, true);
         if (!updated)
             std::swap(prev_lineinfo, new_lineinfo);
         else
@@ -9603,7 +9617,7 @@ static jl_llvm_functions_t
 
     find_next_stmt(0);
     while (cursor != -1) {
-        bool have_dbg_update = update_lineinfo(cursor);
+        bool have_dbg_update = update_lineinfo(cursor + 1);
         if (have_dbg_update) {
             if (debug_enabled)
                 ctx.builder.SetCurrentDebugLocation(new_lineinfo.back().loc);

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -531,7 +531,17 @@ static int lookup_pointer(
             frame->fromC = 1;
 
         frame->line = info.Line;
-        frame->pc = info.Column;
+        if (fromC) {
+            frame->pc = info.Column;
+        }
+        else if (info.Column > 0) {
+            // See "DWARF column" in codegen.cpp: If any frame has nonzero
+            // column, it is a PC into the first (non-inlined) frame.  Move it
+            // there for sanity.
+            jl_frame_t *frame0 = &(*frames)[n_frames - 1];
+            assert(frame0->pc == 0 || frame0->pc == info.Column && "please be true");
+            frame0->pc = info.Column;
+        }
         std::string file_name(info.FileName);
 
         if (file_name == "<invalid>")

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -539,7 +539,7 @@ static int lookup_pointer(
             // column, it is a PC into the first (non-inlined) frame.  Move it
             // there for sanity.
             jl_frame_t *frame0 = &(*frames)[n_frames - 1];
-            assert((frame0->pc == 0 || frame0->pc == (int)info.Column) && "please be true");
+            assert((frame0->pc == 0 || frame0->pc == (int)info.Column) && "conflicting pcs");
             frame0->pc = info.Column;
         }
         std::string file_name(info.FileName);

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -539,7 +539,7 @@ static int lookup_pointer(
             // column, it is a PC into the first (non-inlined) frame.  Move it
             // there for sanity.
             jl_frame_t *frame0 = &(*frames)[n_frames - 1];
-            assert(frame0->pc == 0 || frame0->pc == info.Column && "please be true");
+            assert((frame0->pc == 0 || frame0->pc == (int)info.Column) && "please be true");
             frame0->pc = info.Column;
         }
         std::string file_name(info.FileName);

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1464,6 +1464,7 @@ static const char *sbt_parseheader(jl_string_t *str, jl_sourcebytetable_header_t
  * returning new debuginfo in `p_di` and optionally pc in `p_pc`. */
 static void cdi_deref(jl_debuginfo_t **p_di, int32_t *p_pc, int recursive) JL_NOTSAFEPOINT
 {
+    assert(jl_is_debuginfo(*p_di));
     jl_debuginfo_t *di = *p_di;
     int32_t pc = 0;
     if (!p_pc)

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1468,7 +1468,8 @@ static void cdi_deref(jl_debuginfo_t **p_di, int32_t *p_pc, int recursive) JL_NO
     int32_t pc = 0;
     if (!p_pc)
         p_pc = &pc;
-    if (jl_typeof(di->linetable) == (jl_value_t *)jl_debuginfo_type) {
+    if (jl_is_debuginfo(di->linetable)) {
+        assert(*p_pc >= 0);
         *p_pc = jl_uncompress1_codeloc(di, *p_pc).loc;
         *p_di = (jl_debuginfo_t *)di->linetable;
         if (recursive) {

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -369,13 +369,13 @@ end
 let (bt, did_gc) = make_oc_and_collect_bt()
     GC.gc(true); GC.gc(true); GC.gc(true);
     @test did_gc[]
-    @test any(stacktrace(bt)) do frame
+    @test all(stacktrace(bt)) do frame
+        frame.from_c && return true
         li = frame.linfo
         isa(li, Core.CodeInstance) && (li = li.def)
         isa(li, Core.ABIOverride) && (li = li.def)
-        isa(li, Core.MethodInstance) || return false
-        isa(li.def, Method) || return false
-        return li.def.is_for_opaque_closure
+        isa(li, Core.MethodInstance) && (li = li.def)
+        return isa(li, Method) || isa(li, Core.CodeInfo) || li === nothing
     end
 end
 

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -343,6 +343,46 @@ for f in (const_int, const_int_barrier)
     end
 end
 
+@testset "OC stacktraces" begin
+    local oc = (@opaque (x::Bool, y::String)->throw(y))
+    let buf = IOBuffer()
+        try
+            oc(true, "foo")
+            @test false
+        catch e
+            @test e == "foo"
+            Base.show_backtrace(buf, catch_backtrace())
+        end
+        s = String(take!(buf))
+        @test occursin("(x::Bool, y::String)", s)
+    end
+
+    local function calls_oc(); oc(true, "bar"); end
+    let buf = IOBuffer()
+        try
+            calls_oc()
+            @test false
+        catch e
+            @test e == "bar"
+            Base.show_backtrace(buf, catch_backtrace())
+        end
+        s = String(take!(buf))
+        @test occursin("(x::Bool, y::String)", s)
+    end
+
+    local oc_calls_oc = (@opaque ()->oc(true, "baz"))
+    let buf = IOBuffer()
+        try
+            oc_calls_oc()
+            @test false
+        catch e
+            @test e == "baz"
+            Base.show_backtrace(buf, catch_backtrace())
+        end
+        s = String(take!(buf))
+        @test occursin("(x::Bool, y::String)", s)
+    end
+end
 
 # Attempting to construct an opaque closure backtrace after the oc is GC'ed
 f_oc_throws() = error("oops")

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -378,3 +378,17 @@ let st = try
         sf.func === :f_innermost2 && sf.line == f_innermost2_line && sf.linfo isa Core.MethodInstance && sf.inlined
     end
 end
+
+@inline f_inner3(x) = x > 0 ? x : error("neg: $x")
+function f_parent3(a, b, c, d)
+    s = 0
+    @noinline begin   # keep `+` as invokes so codelocs has `to=0` entries
+        s += a; s += b; s += c; s += d
+    end
+    return f_inner3(s)
+end
+let st = try f_parent3(1, 2, 3, -10) catch; stacktrace(catch_backtrace()) end
+    sf = only(filter(sf -> sf.func === :f_inner3 && sf.inlined, st))
+    @test sf.linfo isa Core.MethodInstance
+    @test sf.linfo.def === which(f_inner3, (Int,))
+end


### PR DESCRIPTION
Two changes to https://github.com/JuliaLang/julia/pull/53925:
- When recursing on `linetable` in `append_lineinfo`, we ended up with
the wrong `pc` in the column field, since we were using the innermost
index rather than the one usable with a CodeInstance's `.debuginfo`.
Store the optimized `pc` in the "innermost" frame, since DILocation
expects inlinee locations to change more quickly than inliners (see
performance discussion below). Thanks Cody and Jameson for this
suggestion.
- Update stacktraces.jl to reconstruct the list of inlined frames upon
seeing a `debuginfo`, `pc` pair. See comment; I don't like having both
this code and the old fallback `lookup` implementation, but it seems
less brittle to just re-create the inlined frame stack than to create it
and match it with the linear `frames` array from
`jl_lookup_code_address`.