### PR TITLE
cglobal: Remove `cglobal(::Ptr)` support

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -612,7 +612,6 @@ static Value *julia_to_native(
 // --- parse :sym or (:sym, :lib) argument into address info ---
 static void interpret_cglobal_symbol_arg(jl_codectx_t &ctx, native_sym_arg_t &out, jl_value_t *arg)
 {
-    Value *&jl_ptr = out.jl_ptr;
     const char *&f_name = out.f_name;
     const char *&f_lib = out.f_lib;
     jl_value_t *ptr = static_eval(ctx, arg);
@@ -658,10 +657,6 @@ static void interpret_cglobal_symbol_arg(jl_codectx_t &ctx, native_sym_arg_t &ou
             f_lib = jl_dlfind(f_name);
             out.f_name_expr = jl_new_struct(jl_quotenode_type, ptr);
             out.gcroot[0] = out.f_name_expr;
-        }
-        else if (jl_is_cpointer_type(jl_typeof(ptr))) {
-            uint64_t fptr = (uintptr_t)*(void(**)(void))jl_data_ptr(ptr);
-            jl_ptr = ConstantExpr::getIntToPtr(ConstantInt::get(ctx.types().T_size, fptr), ctx.types().T_ptr);
         }
         else if (jl_is_tuple(ptr) && jl_nfields(ptr) == 2) {
             jl_value_t *t0 = jl_fieldref(ptr, 0);
@@ -805,10 +800,7 @@ static jl_cgval_t emit_cglobal(jl_codectx_t &ctx, jl_value_t **args, size_t narg
         rt = (jl_value_t*)jl_voidpointer_type;
     }
     interpret_cglobal_symbol_arg(ctx, sym, args[1]);
-    if (sym.jl_ptr != NULL) {
-        res = sym.jl_ptr;
-    }
-    else if (sym.f_name_expr != NULL) {
+    if (sym.f_name_expr != NULL) {
         res = runtime_sym_lookup(ctx, sym, ctx.f);
     }
     else {
@@ -818,10 +810,7 @@ static jl_cgval_t emit_cglobal(jl_codectx_t &ctx, jl_value_t **args, size_t narg
         argv[0] = emit_expr(ctx, args[1]);
         if (nargs == 2)
             argv[1] = emit_expr(ctx, args[2]);
-        if (!jl_is_cpointer_type(argv[0].typ))
-            return emit_runtime_call(ctx, nargs == 1 ? JL_I::cglobal_auto : JL_I::cglobal, argv, nargs);
-        sym.jl_ptr = emit_unbox(ctx, ctx.types().T_ptr, voidpointer_update(ctx, argv[0]));
-        res = sym.jl_ptr;
+        return emit_runtime_call(ctx, nargs == 1 ? JL_I::cglobal_auto : JL_I::cglobal, argv, nargs);
     }
 
     JL_GC_POP();

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -659,9 +659,6 @@ JL_DLLEXPORT jl_value_t *jl_cglobal(jl_value_t *v, jl_value_t *ty)
     if (!jl_is_concrete_type(rt))
         jl_error("cglobal: type argument not concrete");
 
-    if (jl_is_pointer(v))
-        return jl_bitcast(rt, v);
-
     if (jl_is_tuple(v) && jl_nfields(v) == 1)
         v = jl_fieldref(v, 0);
 

--- a/stdlib/GMP_jll/test/runtests.jl
+++ b/stdlib/GMP_jll/test/runtests.jl
@@ -3,6 +3,6 @@
 using Test, Libdl, GMP_jll
 
 @testset "GMP_jll" begin
-    vn = VersionNumber(unsafe_string(unsafe_load(cglobal(dlsym(libgmp, :__gmp_version), Ptr{Cchar}))))
+    vn = VersionNumber(unsafe_string(unsafe_load(cglobal((:__gmp_version, libgmp), Ptr{Cchar}))))
     @test vn == v"6.3.0"
 end

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1899,11 +1899,11 @@ end
     function cglobal45187fn()
         return cglobal((:fn, fn45187))
     end
-    @test unsafe_load(cglobal33413_ptrvar()) == 1
-    @test unsafe_load(cglobal33413_ptrinline()) == 1
+    @test_throws TypeError cglobal33413_ptrvar()
+    @test_throws TypeError cglobal33413_ptrinline()
     @test unsafe_load(cglobal33413_tupleliteral()) == 1
-    @test unsafe_load(convert(Ptr{Cint}, cglobal33413_ptrvar_notype())) == 1
-    @test unsafe_load(convert(Ptr{Cint}, cglobal33413_ptrinline_notype())) == 1
+    @test_throws TypeError cglobal33413_ptrvar_notype()
+    @test_throws TypeError cglobal33413_ptrinline_notype()
     @test unsafe_load(convert(Ptr{Cint}, cglobal33413_tupleliteral_notype())) == 1
     @test cglobal33413_literal() != C_NULL
     @test cglobal33413_literal_notype() != C_NULL


### PR DESCRIPTION
A first step toward extending https://github.com/JuliaLang/julia/pull/59165/ to `cglobal`; this vestigial form is hopefully entirely unused.

Closes https://github.com/JuliaLang/julia/issues/10142.