### PR TITLE
[JuliaLowering] Don't reintroduce `syntax_flags` after macro expansion

### DIFF
--- a/JuliaLowering/src/JuliaLowering.jl
+++ b/JuliaLowering/src/JuliaLowering.jl
@@ -15,7 +15,7 @@ end
 using .JuliaSyntax: @KSet_str, @stm, Kind, NodeId, SourceAttrType, SourceRef, SyntaxGraph,
     SyntaxList, SyntaxTree, byte_range, check_compatible_graph, children, copy_ast,
     copy_attrs, delete_attributes, ensure_attributes!, filename, first_byte,
-    flags, flattened_provenance, has_flags, hasattr, head, highlight, is_compatible_graph,
+    flattened_provenance, hasattr, head, highlight, is_compatible_graph,
     is_leaf, is_literal, kind, last_byte, mapchildren, mapsyntax, mkleaf, mknode, newleaf,
     newnode, node_string, numchildren, provenance, reparent, setattr, setattr!,
     source_location, sourcefile, sourceref, syntax_graph, tree_ids, mapindex, mktree

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -501,22 +501,6 @@ function est_to_dst(st::SyntaxTree)
         end
         [K"generator" body iters...] ->
             @ast g st [K"generator" rec(body) _dst_iterspec(st, iters)]
-        [K"ncat" dim xs...] -> let
-            out = mknode(st, mapsyntax(rec, xs))
-            setattr!(out, :syntax_flags,
-                     JS.flags(st) | JS.set_numeric_flags(dim.value))
-        end
-        [K"nrow" dim xs...] -> let
-            out = mknode(st, mapsyntax(rec, xs))
-            setattr!(out, :syntax_flags,
-                     JS.flags(st) | JS.set_numeric_flags(dim.value))
-        end
-        [K"typed_ncat" t dim xs...] -> let
-            out_cs = pushfirst!(mapsyntax(rec, xs), rec(t))
-            out = mknode(st, out_cs)
-            setattr!(out, :syntax_flags,
-                     JS.flags(st) | JS.set_numeric_flags(dim.value))
-        end
         ([K"=" l r], when=(is_eventually_call(l))) -> let
             # no fix_arglist needed, since this func can't be anonymous
             l = apply_arglist_meta(l, collect_body_arg_meta(r))
@@ -553,13 +537,6 @@ function est_to_dst(st::SyntaxTree)
         end
         ([K"let" binds body], when=(kind(binds) !== K"block")) ->
             @ast g st [K"let" [K"block"(binds) rec(binds)] rec(body)]
-        [K"struct" mut sig body] -> let
-            flags = JS.flags(st) | (_is_false(mut) ? 0x0000 : JS.MUTABLE_FLAG)
-            @ast g st [K"struct"(syntax_flags=flags)
-                rec(sig)
-                rec(body)
-            ]
-        end
         (_, when=(kind(st) in KSet"using import")) -> let
             # dot_importpath = (. _...)
             # as_or_dotip = dot_importpath | (as dot_importpath name)

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -1108,9 +1108,11 @@ function flatten_ncat_rows!(flat_elems, nrow_spans, row_major, parent_layout_dim
     k = kind(ex)
     if k == K"row"
         layout_dim = 1
+        elems = children(ex)
         parent_layout_dim != 1 || throw(LoweringError(ex,"Badly nested rows in `ncat`"))
     elseif k == K"nrow"
-        dim = JuliaSyntax.numeric_flags(ex)
+        dim = ex[1].value::Int
+        elems = children(ex)[2:end]
         dim > 0                || throw(LoweringError(ex,"Unsupported dimension $dim in ncat"))
         !row_major || dim != 2 || throw(LoweringError(ex,"2D `nrow` cannot be mixed with `row` in `ncat`"))
         layout_dim = nrow_flipdim(row_major, dim)
@@ -1125,7 +1127,7 @@ function flatten_ncat_rows!(flat_elems, nrow_spans, row_major, parent_layout_dim
     end
     row_start = length(flat_elems)
     parent_layout_dim > layout_dim || throw(LoweringError(ex, "Badly nested rows in `ncat`"))
-    for e in children(ex)
+    for e in elems
         if layout_dim == 1
             kind(e) ∉ KSet"nrow row" || throw(LoweringError(e,"Badly nested rows in `ncat`"))
         end
@@ -1143,11 +1145,11 @@ end
 # - ragged column first or row first
 function expand_ncat(ctx, ex)
     is_typed = kind(ex) == K"typed_ncat"
-    outer_dim = JuliaSyntax.numeric_flags(ex)
-    @jl_assert outer_dim > 0 (ex,"Unsupported dimension in ncat")
     eltype      = is_typed ? ex[1]     : nothing
-    elements    = is_typed ? ex[2:end] : ex[1:end]
+    outer_dim   = is_typed ? ex[2].value::Int : ex[1].value::Int
+    elements    = is_typed ? ex[3:end] : ex[2:end]
     hvncat_name = is_typed ? "typed_hvncat" : "hvncat"
+    @jl_assert outer_dim > 0 (ex,"Unsupported dimension in ncat")
     if !any(kind(e) in KSet"row nrow" for e in elements)
         # One-dimensional ncat along some dimension
         #   [a ;;; b ;;; c]
@@ -3559,9 +3561,10 @@ function expand_typegroup_def(ctx, ex)
             throw(LoweringError(child, "`typegroup` only supports `struct` definitions"))
         end
 
-        @jl_assert numchildren(sdef) == 2 sdef
-        type_sig = sdef[1]
-        type_body = sdef[2]
+        @jl_assert numchildren(sdef) == 3 sdef
+        is_mutable = sdef[1].value::Bool
+        type_sig = sdef[2]
+        type_body = sdef[3]
         if kind(type_body) != K"block"
             throw(LoweringError(type_body, "expected block for `struct` fields"))
         end
@@ -3575,7 +3578,6 @@ function expand_typegroup_def(ctx, ex)
         _collect_struct_fields(ctx, field_names, field_types, field_attrs, field_docs,
                                inner_defs, children(type_body))
 
-        is_mutable = has_flags(sdef, JuliaSyntax.MUTABLE_FLAG)
         min_initialized = minimum((_constructor_min_initialized(e) for e in inner_defs),
                                   init=length(field_names))
 
@@ -3735,9 +3737,10 @@ function expand_typegroup_def(ctx, ex)
 end
 
 function expand_struct_def(ctx, ex, docs)
-    @jl_assert numchildren(ex) == 2 ex
-    type_sig = ex[1]
-    type_body = ex[2]
+    @jl_assert numchildren(ex) == 3 ex
+    is_mutable = ex[1].value::Bool
+    type_sig = ex[2]
+    type_body = ex[3]
     if kind(type_body) != K"block"
         throw(LoweringError(type_body, "expected block for `struct` fields"))
     end
@@ -3750,7 +3753,6 @@ function expand_struct_def(ctx, ex, docs)
     inner_defs = SyntaxList(ctx)
     _collect_struct_fields(ctx, field_names, field_types, field_attrs, field_docs,
                            inner_defs, children(type_body))
-    is_mutable = has_flags(ex, JuliaSyntax.MUTABLE_FLAG)
     min_initialized = minimum((_constructor_min_initialized(e) for e in inner_defs),
                               init=length(field_names))
     newtype_var = ssavar(ctx, ex, "struct_type")

--- a/JuliaLowering/test/arrays_ir.jl
+++ b/JuliaLowering/test/arrays_ir.jl
@@ -289,9 +289,9 @@ Containing expressions:
 LoweringError:
 #= line 1 =# - 2D `nrow` cannot be mixed with `row` in `ncat`
 Expression:
-  (nrow-2 (row 1))
+  (nrow 2 (row 1))
 Containing expressions:
-  (ncat-3 (nrow-2 (row 1)))
+  (ncat 3 (nrow 2 (row 1)))
 
 ########################################
 # Error: bad nrow nesting
@@ -309,7 +309,7 @@ LoweringError:
 Expression:
   (row 1)
 Containing expressions:
-  (ncat-3 (row (row 1)))
+  (ncat 3 (row (row 1)))
 
 ########################################
 # Simple getindex

--- a/JuliaLowering/test/utils.jl
+++ b/JuliaLowering/test/utils.jl
@@ -15,7 +15,7 @@ import FileWatching
 using Markdown
 import REPL
 
-using .JuliaSyntax: SourceAttrType, new_id!, set_numeric_flags, sourcetext
+using .JuliaSyntax: SourceAttrType, new_id!, sourcetext
 
 using .JuliaLowering: @ast, Bindings, Kind, LoweringError, MacroExpansionError, NodeId,
     ScopeLayer, SourceRef, SyntaxGraph, SyntaxTree, children, flattened_provenance,

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -1236,7 +1236,9 @@ function _insert_green(graph::SyntaxGraph, sf::Base.RefValue{SourceFile},
                        cursor::RedTreeCursor)
     id = new_id!(graph)
     setattr!(graph, id, :kind, kind(cursor))
-    setattr!(graph, id, :syntax_flags, flags(cursor))
+    let f = remove_flags(flags(cursor), NON_TERMINAL_FLAG)
+        f != 0 && setattr!(graph, id, :syntax_flags, f)
+    end
     setattr!(graph, id, :source, SourceRef(sf, first_byte(cursor), last_byte(cursor)))
     if !is_leaf(cursor)
         cs = NodeId[]


### PR DESCRIPTION
In https://github.com/JuliaLang/julia/pull/60733, the macro-facing AST became
structured like Expr, so an adapter (`est_to_dst`) was added so I wouldn't need
to make a bunch of changes to desugaring.  In many cases, `est_to_dst` makes
desugaring easier, but in the case of re-introducing syntax flags in `struct`,
`ncat`, and `nrow`, it's just unnecessary complexity.  This change just desugars
the Expr-like version of these forms.