### PR TITLE
(mostly) NFC: make Base dogfood its own APIs more sometimes

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -51,7 +51,7 @@ struct ValueIterator{T<:AbstractDict}
 end
 
 function summary(io::IO, iter::T) where {T<:Union{KeySet,ValueIterator}}
-    print(io, T.name.name, " for a ")
+    print(io, nameof(T), " for a ")
     summary(io, iter.dict)
 end
 

--- a/base/docs/bindings.jl
+++ b/base/docs/bindings.jl
@@ -40,7 +40,7 @@ function Base.show(io::IO, b::Binding)
 end
 
 aliasof(b::Binding)     = defined(b) ? (a = aliasof(resolve(b), b); defined(a) ? a : b) : b
-aliasof(d::DataType, b) = Binding(d.name.module, d.name.name)
-aliasof(λ::Function, b) = (m = typeof(λ).name; Binding(m.module, m.singletonname))
+aliasof(d::DataType, b) = Binding(parentmodule(d), nameof(d))
+aliasof(λ::Function, b) = Binding(parentmodule(λ), nameof(λ))
 aliasof(m::Module,   b) = Binding(m, nameof(m))
 aliasof(other,       b) = b

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -91,7 +91,7 @@ function showerror(io::IO, ex::TypeError)
         end
         if ex.context == ""
             ctx = "in $(ex.func)"
-        elseif isa(ex.context, Core.GlobalRef)
+        elseif isa(ex.context, GlobalRef)
             gr = ex.context
             ctx = "in $(ex.func) of global binding `$(gr.mod).$(gr.name)`"
         elseif ex.func === :var"keyword argument"

--- a/base/file.jl
+++ b/base/file.jl
@@ -1064,7 +1064,7 @@ struct DirEntry
     name::String
     rawtype::Cint
 end
-path(obj::DirEntry) = joinpath(obj.dir, obj.name)
+path(obj::DirEntry) = joinpath(getfield(obj, :dir), getfield(obj, :name))
 Base.isless(a::DirEntry, b::DirEntry) = a.dir == b.dir ? isless(a.name, b.name) : isless(a.dir, b.dir)
 Base.hash(o::DirEntry, h::UInt) = hash(o.dir, hash(o.name, hash(o.rawtype, h)))
 Base.:(==)(a::DirEntry, b::DirEntry) = a.name == b.name && a.dir == b.dir && a.rawtype == b.rawtype

--- a/base/file.jl
+++ b/base/file.jl
@@ -1064,7 +1064,7 @@ struct DirEntry
     name::String
     rawtype::Cint
 end
-path(obj::DirEntry) = joinpath(getfield(obj, :dir), getfield(obj, :name))
+path(obj::DirEntry) = joinpath(obj.dir, obj.name)
 Base.isless(a::DirEntry, b::DirEntry) = a.dir == b.dir ? isless(a.name, b.name) : isless(a.dir, b.dir)
 Base.hash(o::DirEntry, h::UInt) = hash(o.dir, hash(o.name, hash(o.rawtype, h)))
 Base.:(==)(a::DirEntry, b::DirEntry) = a.name == b.name && a.dir == b.dir && a.rawtype == b.rawtype

--- a/base/float.jl
+++ b/base/float.jl
@@ -901,7 +901,7 @@ for Ti in (Int8, Int16, Int32, Int64, Int128, UInt8, UInt16, UInt32, UInt64, UIn
                     if ($(Tf(typemin(Ti))) <= x < $(Tf(typemax(Ti))+one(Tf))) && isinteger(x)
                         return unsafe_trunc($Ti,x)
                     else
-                        throw(InexactError($(Expr(:quote,Ti.name.name)), $Ti, x))
+                        throw(InexactError($(Expr(:quote,nameof(Ti))), $Ti, x))
                     end
                 end
             end
@@ -922,7 +922,7 @@ for Ti in (Int8, Int16, Int32, Int64, Int128, UInt8, UInt16, UInt32, UInt64, UIn
                     if ($(Tf(typemin(Ti))) <= x < $(Tf(typemax(Ti)))) && isinteger(x)
                         return unsafe_trunc($Ti,x)
                     else
-                        throw(InexactError($(Expr(:quote,Ti.name.name)), $Ti, x))
+                        throw(InexactError($(Expr(:quote,nameof(Ti))), $Ti, x))
                     end
                 end
             end

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -157,7 +157,7 @@ enable_finalizers(on::Bool) = on ? enable_finalizers() : disable_finalizers()
 
 function enable_finalizers() @inline
     ccall(:jl_gc_enable_finalizers_internal, Cvoid, ())
-    if Core.Intrinsics.atomic_pointerref(cglobal(:jl_gc_have_pending_finalizers, Cint), :monotonic) != 0
+    if unsafe_load(cglobal(:jl_gc_have_pending_finalizers, Cint), :monotonic) != 0
         ccall(:jl_gc_run_pending_finalizers, Cvoid, (Ptr{Cvoid},), C_NULL)
     end
 end

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -310,10 +310,10 @@ end
 haskey(v::Pairs, key) = key in keys(v)
 keys(v::Pairs) = getfield(v, :itr) === nothing ? keys(getfield(v, :data)) : getfield(v, :itr)
 values(v::Pairs) = getfield(v, :data) # TODO: this should be a view of data subset by itr
-getindex(v::Pairs, key) = getfield(v, :data)[key]
-setindex!(v::Pairs, value, key) = (getfield(v, :data)[key] = value; v)
-get(v::Pairs, key, default) = get(getfield(v, :data), key, default)
-get(f::Base.Callable, v::Pairs, key) = get(f, getfield(v, :data), key)
+getindex(v::Pairs, key) = values(v)[key]
+setindex!(v::Pairs, value, key) = (values(v)[key] = value; v)
+get(v::Pairs, key, default) = get(values(v), key, default)
+get(f::Base.Callable, v::Pairs, key) = get(f, values(v), key)
 
 # zip
 
@@ -1562,7 +1562,7 @@ convert(::Type{Stateful}, itr) = Stateful(itr)
         throw(Base.EOFError())
     else
         val, state = vs
-        Core.setfield!(s, :nextvalstate, iterate(s.itr, state))
+        setfield!(s, :nextvalstate, iterate(s.itr, state))
         return val
     end
 end

--- a/base/opaque_closure.jl
+++ b/base/opaque_closure.jl
@@ -24,7 +24,7 @@ end
 macro opaque(ty, ex)
     if Base.isexpr(ty, :->)
         (AT, body) = ty.args
-        filter!((n)->!isa(n, Core.LineNumberNode), body.args)
+        filter!((n)->!isa(n, LineNumberNode), body.args)
         if !Base.isexpr(body, :block) || length(body.args) != 1
             error("Opaque closure type must be specified in the form Tuple{T,U...}->RT")
         end

--- a/base/ryu/exp.jl
+++ b/base/ryu/exp.jl
@@ -38,7 +38,7 @@ function writeexp(buf, pos, v::T,
         return pos + 3
     end
 
-    bits = Core.bitcast(UInt64, x)
+    bits = reinterpret(UInt64, x)
     mant = bits & MANTISSA_MASK
     exp = Int((bits >> 52) & EXP_MASK)
 

--- a/base/ryu/fixed.jl
+++ b/base/ryu/fixed.jl
@@ -34,7 +34,7 @@ function writefixed(buf, pos, v::T,
         return pos + 3
     end
 
-    bits = Core.bitcast(UInt64, x)
+    bits = reinterpret(UInt64, x)
     mant = bits & MANTISSA_MASK
     exp = Int((bits >> 52) & EXP_MASK)
 

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -104,7 +104,7 @@ let
     tot_time_stdlib = 0.0
     # use a temp module to avoid leaving the type of this closure in Main
     push!(empty!(LOAD_PATH), "@stdlib")
-    m = Core.Module()
+    m = Module()
     GC.@preserve m begin
         print_time = @eval m (mod, t) -> (print(rpad(string(mod) * "  ", $maxlen + 3, "─"));
                                           Base.time_print(stdout, t * 10^9); println())

--- a/base/task.jl
+++ b/base/task.jl
@@ -303,7 +303,7 @@ end
 
 # just wait for a task to be done, no error propagation
 function _wait(t::Task)
-    t === current_task() && Core.throw(ConcurrencyViolationError("deadlock detected: cannot wait on current task"))
+    t === current_task() && throw(ConcurrencyViolationError("deadlock detected: cannot wait on current task"))
     if !istaskdone(t)
         donenotify = t.donenotify::ThreadSynchronizer
         lock(donenotify)

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -44,7 +44,7 @@ to the Julia process, with atomic-acquire semantics. The result will always be
 greater than or equal to [`threadid()`](@ref) as well as `threadid(task)` for
 any task you were able to observe before calling `maxthreadid`.
 """
-maxthreadid() = Int(Core.Intrinsics.atomic_pointerref(cglobal(:jl_n_threads, Cint), :acquire))
+maxthreadid() = Int(unsafe_load(cglobal(:jl_n_threads, Cint), :acquire))
 
 """
     Threads.nthreads(:default | :interactive)::Int


### PR DESCRIPTION
`Base` is, of course, allowed to depend on its own internals. but that doesn't mean it always should. when possible I think we should prefer to use public alternatives vs private when equivalents of each are available.

includes an unintentional bugfix to `help?>` of any intrinsic, which on master leads you to the docstring for `Core.IntrinsicFunction` itself
```julia
help?> Core.Intrinsics.add_int
  │ Warning
  │
  │  The following bindings may be internal; they may change or be removed in future versions:
  │
  │  • Core.Intrinsics

  Core.IntrinsicFunction <: Core.Builtin <: Function

  The Core.IntrinsicFunction function define some basic primitives for what defines the abilities and behaviors of a Julia program
```

candidates generated by claude, which I then audited