### PR TITLE
Compiler: prevent invalidating custom AbstractInterpreter precompiles

### DIFF
--- a/Compiler/Project.toml
+++ b/Compiler/Project.toml
@@ -2,6 +2,12 @@ name = "Compiler"
 uuid = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
 version = "0.1.1"
 
+# `typegroup` (used in inferencestate.jl) is a keyword only from syntax version
+# 1.14 onwards, so opt into it explicitly rather than inheriting the older default
+# derived from the `compat` floor below.
+[syntax]
+julia_version = "1.14"
+
 [compat]
 julia = "1.10"
 

--- a/Compiler/Project.toml
+++ b/Compiler/Project.toml
@@ -2,12 +2,6 @@ name = "Compiler"
 uuid = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
 version = "0.1.1"
 
-# `typegroup` (used in inferencestate.jl) is a keyword only from syntax version
-# 1.14 onwards, so opt into it explicitly rather than inheriting the older default
-# derived from the `compat` floor below.
-[syntax]
-julia_version = "1.14"
-
 [compat]
 julia = "1.10"
 

--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -162,6 +162,12 @@ else
     using Base: @show
 end
 
+# JuliaSyntax doesn't support syntax evolution in bare modules via Project.toml
+# This surfaces only when Compiler.jl is loaded as a standalone package.
+if isdefined(Base, :end_base_include) && isdefined(Base, :set_syntax_version)
+    Base.set_syntax_version(Compiler, Base.VersionNumber(1, 14))
+end
+
 include("cicache.jl")
 include("methodtable.jl")
 include("effects.jl")

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -767,9 +767,9 @@ function abstract_call_method(interp::AbstractInterpreter,
     return typeinf_edge(interp, method, sig, sparams, sv, edgecycle, edgelimited)
 end
 
-function edge_matches_sv(interp::AbstractInterpreter, frame::AbsIntState,
+function edge_matches_sv(interp::I, frame::AbsIntState,
                          method::Method, @nospecialize(sig), sparams::SimpleVector,
-                         hardlimit::Bool, sv::AbsIntState)
+                         hardlimit::Bool, sv::AbsIntState) where {I<:AbstractInterpreter}
     # The `method_for_inference_heuristics` will expand the given method's generator if
     # necessary in order to retrieve this field from the generated `CodeInfo`, if it exists.
     # The other `CodeInfo`s we inspect will already have this field inflated, so we just
@@ -780,8 +780,9 @@ function edge_matches_sv(interp::AbstractInterpreter, frame::AbsIntState,
     if callee_method2 !== inf_method2 # limit only if user token match
         return false
     end
-    if isa(frame, InferenceState) && cache_owner(frame.interp) !== cache_owner(interp)
-        # Don't assume that frames in different interpreters are the same
+    # Frames in one callstack share the same interpreter type (enforced by `::I`),
+    # but distinct instances of that type may still have different cache owners.
+    if isa(frame, InferenceState) && cache_owner(frame.interp::I) !== cache_owner(interp)
         return false
     end
     if !hardlimit || InferenceParams(interp).ignore_recursion_hardlimit
@@ -4825,7 +4826,7 @@ end
 
 # make as much progress on `frame` as possible (by handling cycles)
 warnlength::Int = 2500
-function typeinf(interp::AbstractInterpreter, frame::InferenceState)
+function typeinf(interp::I, frame::InferenceState) where {I<:AbstractInterpreter}
     time_before = _time_ns()
     callstack = frame.callstack::Vector{AbsIntState}
     nextstates = CurrentState[]
@@ -4846,7 +4847,7 @@ function typeinf(interp::AbstractInterpreter, frame::InferenceState)
                 takenext = length(callstack)
             end
         end
-        interp = callee.interp
+        interp = callee.interp::I
         nextstateid = takenext + 1 - frame.frameid
         while length(nextstates) < nextstateid
             push!(nextstates, CurrentState())

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -767,9 +767,9 @@ function abstract_call_method(interp::AbstractInterpreter,
     return typeinf_edge(interp, method, sig, sparams, sv, edgecycle, edgelimited)
 end
 
-function edge_matches_sv(interp::AbstractInterpreter, frame::AbsIntState,
+function edge_matches_sv(interp::I, frame::AbsIntState,
                          method::Method, @nospecialize(sig), sparams::SimpleVector,
-                         hardlimit::Bool, sv::AbsIntState)
+                         hardlimit::Bool, sv::AbsIntState) where {I<:AbstractInterpreter}
     # The `method_for_inference_heuristics` will expand the given method's generator if
     # necessary in order to retrieve this field from the generated `CodeInfo`, if it exists.
     # The other `CodeInfo`s we inspect will already have this field inflated, so we just
@@ -783,7 +783,7 @@ function edge_matches_sv(interp::AbstractInterpreter, frame::AbsIntState,
     # Frames in one callstack share the same interpreter type (enforced by the
     # `AbsIntState{I}` parameter), but distinct instances of that type may still
     # have different cache owners.
-    if isa(frame, InferenceState) && cache_owner(frame.interp) !== cache_owner(interp)
+    if isa(frame, InferenceState) && cache_owner(frame.interp::I) !== cache_owner(interp)
         return false
     end
     if !hardlimit || InferenceParams(interp).ignore_recursion_hardlimit
@@ -3927,14 +3927,14 @@ abstract_load_all_consistent_leaf_partitions(interp::AbstractInterpreter, g::Glo
 abstract_load_all_consistent_leaf_partitions(::Nothing, g::GlobalRef, wwr::WorldWithRange) =
     scan_leaf_partitions(abstract_eval_partition_load, nothing, g, wwr)
 
-function abstract_eval_globalref(interp::AbstractInterpreter, g::GlobalRef, saw_latestworld::Bool, sv::AbsIntState)
+function abstract_eval_globalref(interp::AbstractInterpreter, g::GlobalRef, saw_latestworld::Bool, sv::AbsIntState{I}) where {I<:AbstractInterpreter}
     if saw_latestworld
         return RTEffects(Any, Any, generic_getglobal_effects)
     end
     # For inference purposes, we don't particularly care which global binding we end up loading, we only
     # care about its type. However, we would still like to terminate the world range for the particular
     # binding we end up reaching such that codegen can emit a simpler pointer load.
-    world = get_inference_world(interp)
+    world = get_inference_world(interp::I)
     (valid_worlds, ret) = scan_leaf_partitions(abstract_eval_partition_load, interp, g, binding_world_hints(world, sv))
     update_valid_age!(sv, world, valid_worlds)
     return ret
@@ -4827,7 +4827,7 @@ end
 
 # make as much progress on `frame` as possible (by handling cycles)
 warnlength::Int = 2500
-function typeinf(interp::I, frame::InferenceState{I}) where {I<:AbstractInterpreter}
+function typeinf(interp::AbstractInterpreter, frame::InferenceState{I}) where {I<:AbstractInterpreter}
     time_before = _time_ns()
     callstack = frame.callstack
     nextstates = CurrentState[]

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -767,9 +767,9 @@ function abstract_call_method(interp::AbstractInterpreter,
     return typeinf_edge(interp, method, sig, sparams, sv, edgecycle, edgelimited)
 end
 
-function edge_matches_sv(interp::I, frame::AbsIntState,
+function edge_matches_sv(interp::AbstractInterpreter, frame::AbsIntState,
                          method::Method, @nospecialize(sig), sparams::SimpleVector,
-                         hardlimit::Bool, sv::AbsIntState) where {I<:AbstractInterpreter}
+                         hardlimit::Bool, sv::AbsIntState)
     # The `method_for_inference_heuristics` will expand the given method's generator if
     # necessary in order to retrieve this field from the generated `CodeInfo`, if it exists.
     # The other `CodeInfo`s we inspect will already have this field inflated, so we just
@@ -780,9 +780,10 @@ function edge_matches_sv(interp::I, frame::AbsIntState,
     if callee_method2 !== inf_method2 # limit only if user token match
         return false
     end
-    # Frames in one callstack share the same interpreter type (enforced by `::I`),
-    # but distinct instances of that type may still have different cache owners.
-    if isa(frame, InferenceState) && cache_owner(frame.interp::I) !== cache_owner(interp)
+    # Frames in one callstack share the same interpreter type (enforced by the
+    # `AbsIntState{I}` parameter), but distinct instances of that type may still
+    # have different cache owners.
+    if isa(frame, InferenceState) && cache_owner(frame.interp) !== cache_owner(interp)
         return false
     end
     if !hardlimit || InferenceParams(interp).ignore_recursion_hardlimit
@@ -1406,9 +1407,9 @@ function compute_forwarded_argtypes(interp::AbstractInterpreter, arginfo::ArgInf
     return SimpleArgtypes(arginfo.argtypes)
 end
 
-function const_prop_call(interp::AbstractInterpreter,
+function const_prop_call(interp::I,
     mi::MethodInstance, result::MethodCallResult, arginfo::ArgInfo, sv::AbsIntState,
-    concrete_eval_result::Union{Nothing,ConstCallResult}=nothing)
+    concrete_eval_result::Union{Nothing,ConstCallResult}=nothing) where {I<:AbstractInterpreter}
     𝕃ᵢ = typeinf_lattice(interp)
     forwarded_argtypes = compute_forwarded_argtypes(interp, arginfo, sv)
     # use `cache_argtypes` that has been constructed for fresh regular inference if available
@@ -1458,7 +1459,7 @@ function const_prop_call(interp::AbstractInterpreter,
         sv.time_paused += frame.time_paused
         add_remark!(interp, sv, "[constprop] Fresh constant inference hit a cycle")
         @assert frame.frameid != 0 && frame.cycleid == frame.frameid
-        callstack = frame.callstack::Vector{AbsIntState}
+        callstack = frame.callstack::Vector{AbsIntState{I}}
         @assert callstack[end] === frame && length(callstack) == frame.frameid
         pop!(callstack)
         # add to the cache to record that this will always fail
@@ -4826,9 +4827,9 @@ end
 
 # make as much progress on `frame` as possible (by handling cycles)
 warnlength::Int = 2500
-function typeinf(interp::I, frame::InferenceState) where {I<:AbstractInterpreter}
+function typeinf(interp::I, frame::InferenceState{I}) where {I<:AbstractInterpreter}
     time_before = _time_ns()
-    callstack = frame.callstack::Vector{AbsIntState}
+    callstack = frame.callstack::Vector{AbsIntState{I}}
     nextstates = CurrentState[]
     takenext = frame.frameid
     minwarn = warnlength
@@ -4847,7 +4848,7 @@ function typeinf(interp::I, frame::InferenceState) where {I<:AbstractInterpreter
                 takenext = length(callstack)
             end
         end
-        interp = callee.interp::I
+        interp = callee.interp
         nextstateid = takenext + 1 - frame.frameid
         while length(nextstates) < nextstateid
             push!(nextstates, CurrentState())

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -1407,9 +1407,9 @@ function compute_forwarded_argtypes(interp::AbstractInterpreter, arginfo::ArgInf
     return SimpleArgtypes(arginfo.argtypes)
 end
 
-function const_prop_call(interp::I,
+function const_prop_call(interp::AbstractInterpreter,
     mi::MethodInstance, result::MethodCallResult, arginfo::ArgInfo, sv::AbsIntState,
-    concrete_eval_result::Union{Nothing,ConstCallResult}=nothing) where {I<:AbstractInterpreter}
+    concrete_eval_result::Union{Nothing,ConstCallResult}=nothing)
     𝕃ᵢ = typeinf_lattice(interp)
     forwarded_argtypes = compute_forwarded_argtypes(interp, arginfo, sv)
     # use `cache_argtypes` that has been constructed for fresh regular inference if available
@@ -1459,7 +1459,7 @@ function const_prop_call(interp::I,
         sv.time_paused += frame.time_paused
         add_remark!(interp, sv, "[constprop] Fresh constant inference hit a cycle")
         @assert frame.frameid != 0 && frame.cycleid == frame.frameid
-        callstack = frame.callstack::Vector{AbsIntState{I}}
+        callstack = frame.callstack
         @assert callstack[end] === frame && length(callstack) == frame.frameid
         pop!(callstack)
         # add to the cache to record that this will always fail
@@ -4829,7 +4829,7 @@ end
 warnlength::Int = 2500
 function typeinf(interp::I, frame::InferenceState{I}) where {I<:AbstractInterpreter}
     time_before = _time_ns()
-    callstack = frame.callstack::Vector{AbsIntState{I}}
+    callstack = frame.callstack
     nextstates = CurrentState[]
     takenext = frame.frameid
     minwarn = warnlength

--- a/Compiler/src/bootstrap.jl
+++ b/Compiler/src/bootstrap.jl
@@ -26,8 +26,8 @@ function bootstrap!()
         ssa_inlining_pass!_tt = Tuple{typeof(ssa_inlining_pass!), IRCode, InliningState{NativeInterpreter}, Bool}
         optimize_tt = Tuple{typeof(optimize), NativeInterpreter, OptimizationState{NativeInterpreter}, InferenceResult}
         typeinf_ext_tt = Tuple{typeof(typeinf_ext), NativeInterpreter, MethodInstance, UInt8}
-        typeinf_tt = Tuple{typeof(typeinf), NativeInterpreter, InferenceState}
-        typeinf_edge_tt = Tuple{typeof(typeinf_edge), NativeInterpreter, Method, Any, SimpleVector, InferenceState, Bool, Bool}
+        typeinf_tt = Tuple{typeof(typeinf), NativeInterpreter, InferenceState{NativeInterpreter}}
+        typeinf_edge_tt = Tuple{typeof(typeinf_edge), NativeInterpreter, Method, Any, SimpleVector, InferenceState{NativeInterpreter}, Bool, Bool}
         fs = Any[
             # we first create caches for the optimizer, because they contain many loop constructions
             # and they're better to not run in interpreter even during bootstrapping

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -270,7 +270,13 @@ end
 intersect(world::WorldWithRange, valid_worlds::WorldRange) =
     WorldWithRange(world.this, intersect(world.valid_worlds, valid_worlds))
 
-mutable struct InferenceState{I<:AbstractInterpreter}
+# Forward-declared abstract supertype of `InferenceState` and `IRInterpretationState`,
+# so each can reference `Vector{AbsIntState{I}}` in its own field types. The concrete
+# `AbsIntState{I}` is then `Union{InferenceState{I}, IRInterpretationState{I}}` for
+# all practical purposes — see the `Union` alias defined further below.
+abstract type AbsIntState{I<:AbstractInterpreter} end
+
+mutable struct InferenceState{I<:AbstractInterpreter} <: AbsIntState{I}
     #= information about this method instance =#
     linfo::MethodInstance
     valid_worlds::WorldRange
@@ -313,10 +319,10 @@ mutable struct InferenceState{I<:AbstractInterpreter}
     tasks::Vector{WorkThunk}
     pclimitations::IdSet{InferenceState} # causes of precision restrictions (LimitedAccuracy) on currpc ssavalue
     limitations::IdSet{InferenceState} # causes of precision restrictions (LimitedAccuracy) on return
-    cycle_backedges::Vector{Tuple{InferenceState, Int}} # call-graph backedges connecting from callee to caller
+    cycle_backedges::Vector{Tuple{InferenceState{I}, Int}} # call-graph backedges connecting from callee to caller
 
     # IPO tracking of in-process work, shared with all frames given AbstractInterpreter
-    callstack #::Vector{AbsIntState}
+    callstack::Vector{AbsIntState{I}}
     parentid::Int # index into callstack of the parent frame that originally added this frame (call cycle_parent to extract the current parent of the SCC)
     frameid::Int # index into callstack at which this object is found (or zero, if this is not a cached frame and has no parent)
     cycleid::Int # index into the callstack of the topmost frame in the cycle (all frames in the same cycle share the same cycleid)
@@ -392,7 +398,7 @@ mutable struct InferenceState{I<:AbstractInterpreter}
         unreachable = BitSet()
         pclimitations = IdSet{InferenceState}()
         limitations = IdSet{InferenceState}()
-        cycle_backedges = Tuple{InferenceState,Int}[]
+        cycle_backedges = Tuple{InferenceState{I},Int}[]
         callstack = AbsIntState{I}[]
         tasks = WorkThunk[]
 
@@ -882,7 +888,7 @@ end
 # =====================
 
 # TODO add `result::InferenceResult` and put the irinterp result into the inference cache?
-mutable struct IRInterpretationState{I<:AbstractInterpreter}
+mutable struct IRInterpretationState{I<:AbstractInterpreter} <: AbsIntState{I}
     const spec_info::SpecInfo
     const ir::IRCode
     const mi::MethodInstance
@@ -897,7 +903,7 @@ mutable struct IRInterpretationState{I<:AbstractInterpreter}
     const lazyreachability::LazyCFGReachability
     const tasks::Vector{WorkThunk}
     const edges::Vector{Any}
-    callstack #::Vector{AbsIntState{I}}
+    callstack::Vector{AbsIntState{I}}
     frameid::Int
     parentid::Int
     interp::I
@@ -959,11 +965,12 @@ end
 # AbsIntState
 # ===========
 
-const AbsIntState{I<:AbstractInterpreter} = Union{InferenceState{I},IRInterpretationState{I}}
+## `AbsIntState` is the abstract supertype declared above; the only concrete
+## subtypes are `InferenceState` and `IRInterpretationState`.
 
-function print_callstack(frame::AbsIntState{I}) where {I<:AbstractInterpreter}
+function print_callstack(frame::AbsIntState)
     print("=================== Callstack: ==================\n")
-    frames = frame.callstack::Vector{AbsIntState{I}}
+    frames = frame.callstack
     for idx = (frame.frameid == 0 ? 0 : 1):length(frames)
         sv = (idx == 0 ? frame : frames[idx])
         idx == frame.frameid && print("*")
@@ -994,13 +1001,12 @@ function frame_module(sv::AbsIntState)
     return def.module
 end
 
-frame_parent(sv::AbsIntState{I}) where {I<:AbstractInterpreter} =
-    sv.parentid == 0 ? nothing : (sv.callstack::Vector{AbsIntState{I}})[sv.parentid]
+frame_parent(sv::AbsIntState) = sv.parentid == 0 ? nothing : sv.callstack[sv.parentid]
 
-function cycle_parent(sv::InferenceState{I}) where {I<:AbstractInterpreter}
+function cycle_parent(sv::InferenceState)
     sv.parentid == 0 && return nothing
-    callstack = sv.callstack::Vector{AbsIntState{I}}
-    sv = callstack[sv.cycleid]::InferenceState{I}
+    callstack = sv.callstack
+    sv = callstack[sv.cycleid]::InferenceState
     sv.parentid == 0 && return nothing
     return callstack[sv.parentid]
 end
@@ -1010,7 +1016,7 @@ cycle_parent(sv::IRInterpretationState) = frame_parent(sv)
 # add the orphan child to the parent and the parent to the child
 function assign_parentchild!(child::InferenceState{I}, parent::AbsIntState{I}) where {I<:AbstractInterpreter}
     @assert child.frameid in (0, 1)
-    child.callstack = callstack = parent.callstack::Vector{AbsIntState{I}}
+    child.callstack = callstack = parent.callstack
     child.parentid = parent.frameid
     push!(callstack, child)
     child.cycleid = child.frameid = length(callstack)
@@ -1018,7 +1024,7 @@ function assign_parentchild!(child::InferenceState{I}, parent::AbsIntState{I}) w
 end
 function assign_parentchild!(child::IRInterpretationState{I}, parent::AbsIntState{I}) where {I<:AbstractInterpreter}
     @assert child.frameid in (0, 1)
-    child.callstack = callstack = parent.callstack::Vector{AbsIntState{I}}
+    child.callstack = callstack = parent.callstack
     child.parentid = parent.frameid
     push!(callstack, child)
     child.frameid = length(callstack)
@@ -1080,8 +1086,7 @@ Note that cycles may be visited in any order.
 """
 struct AbsIntStackUnwind{I<:AbstractInterpreter}
     callstack::Vector{AbsIntState{I}}
-    AbsIntStackUnwind(sv::AbsIntState{I}) where {I<:AbstractInterpreter} =
-        new{I}(sv.callstack::Vector{AbsIntState{I}})
+    AbsIntStackUnwind(sv::AbsIntState{I}) where {I<:AbstractInterpreter} = new{I}(sv.callstack)
 end
 function iterate(unw::AbsIntStackUnwind, frame::Int=length(unw.callstack))
     frame == 0 && return nothing
@@ -1106,8 +1111,8 @@ Iterate through all callers of the given `AbsIntState` in the abstract
 interpretation stack (including the given `AbsIntState` itself) that are part
 of the same cycle, only if it is part of a cycle with multiple frames.
 """
-function callers_in_cycle(sv::InferenceState{I}) where {I<:AbstractInterpreter}
-    callstack = sv.callstack::Vector{AbsIntState{I}}
+function callers_in_cycle(sv::InferenceState)
+    callstack = sv.callstack
     cycletop = cycleid = sv.cycleid
     while cycletop < length(callstack)
         frame = callstack[cycletop + 1]
@@ -1117,8 +1122,7 @@ function callers_in_cycle(sv::InferenceState{I}) where {I<:AbstractInterpreter}
     end
     return AbsIntCycle(callstack, cycletop == cycleid ? 0 : cycleid, cycletop)
 end
-callers_in_cycle(sv::IRInterpretationState{I}) where {I<:AbstractInterpreter} =
-    AbsIntCycle(sv.callstack::Vector{AbsIntState{I}}, 0, 0)
+callers_in_cycle(sv::IRInterpretationState) = AbsIntCycle(sv.callstack, 0, 0)
 
 get_curr_ssaflag(sv::InferenceState) = sv.ssaflags[sv.currpc]
 get_curr_ssaflag(sv::IRInterpretationState) = sv.ir.stmts[sv.curridx][:flag]

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -346,8 +346,12 @@ mutable struct InferenceState{I<:AbstractInterpreter} <: AbsIntState{I}
     insert_coverage::Bool
 
     # The interpreter that created this inference state. Not looked at by
-    # NativeInterpreter. But other interpreters may use this to detect cycles
-    interp::I
+    # NativeInterpreter. But other interpreters may use this to detect cycles.
+    # Stored as the abstract supertype to keep reads boxed (the type parameter
+    # `I` lets callers narrow with `frame.interp::I` only at the specific call
+    # sites that need concrete dispatch, without propagating concrete unboxed
+    # values through every method that takes `interp`).
+    interp::AbstractInterpreter
 
     # src is assumed to be a newly-allocated CodeInfo, that can be modified in-place to contain intermediate results
     function InferenceState{I}(result::InferenceResult, src::CodeInfo, cache_mode::UInt8,
@@ -906,7 +910,7 @@ mutable struct IRInterpretationState{I<:AbstractInterpreter} <: AbsIntState{I}
     callstack::Vector{AbsIntState{I}}
     frameid::Int
     parentid::Int
-    interp::I
+    interp::AbstractInterpreter # see comment on `InferenceState.interp`
 
     function IRInterpretationState{I}(
             interp::I, spec_info::SpecInfo, ir::IRCode,

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -270,7 +270,7 @@ end
 intersect(world::WorldWithRange, valid_worlds::WorldRange) =
     WorldWithRange(world.this, intersect(world.valid_worlds, valid_worlds))
 
-mutable struct InferenceState
+mutable struct InferenceState{I<:AbstractInterpreter}
     #= information about this method instance =#
     linfo::MethodInstance
     valid_worlds::WorldRange
@@ -341,11 +341,11 @@ mutable struct InferenceState
 
     # The interpreter that created this inference state. Not looked at by
     # NativeInterpreter. But other interpreters may use this to detect cycles
-    interp::AbstractInterpreter
+    interp::I
 
     # src is assumed to be a newly-allocated CodeInfo, that can be modified in-place to contain intermediate results
-    function InferenceState(result::InferenceResult, src::CodeInfo, cache_mode::UInt8,
-                            interp::AbstractInterpreter)
+    function InferenceState{I}(result::InferenceResult, src::CodeInfo, cache_mode::UInt8,
+                               interp::I) where {I<:AbstractInterpreter}
         mi = result.linfo
         world = get_inference_world(interp)
         if world == typemax(UInt)
@@ -393,7 +393,7 @@ mutable struct InferenceState
         pclimitations = IdSet{InferenceState}()
         limitations = IdSet{InferenceState}()
         cycle_backedges = Tuple{InferenceState,Int}[]
-        callstack = AbsIntState[]
+        callstack = AbsIntState{I}[]
         tasks = WorkThunk[]
 
         valid_worlds = WorldRange(1, get_world_counter())
@@ -628,6 +628,8 @@ function InferenceState(result::InferenceResult, cache_mode::UInt8, interp::Abst
     maybe_validate_code(mi, src, "lowered")
     return InferenceState(result, src, cache_mode, interp)
 end
+InferenceState(result::InferenceResult, src::CodeInfo, cache_mode::UInt8, interp::I) where {I<:AbstractInterpreter} =
+    InferenceState{I}(result, src, cache_mode, interp)
 InferenceState(result::InferenceResult, cache_mode::Symbol, interp::AbstractInterpreter) =
     InferenceState(result, convert_cache_mode(cache_mode), interp)
 InferenceState(result::InferenceResult, src::CodeInfo, cache_mode::Symbol, interp::AbstractInterpreter) =
@@ -880,7 +882,7 @@ end
 # =====================
 
 # TODO add `result::InferenceResult` and put the irinterp result into the inference cache?
-mutable struct IRInterpretationState
+mutable struct IRInterpretationState{I<:AbstractInterpreter}
     const spec_info::SpecInfo
     const ir::IRCode
     const mi::MethodInstance
@@ -895,14 +897,15 @@ mutable struct IRInterpretationState
     const lazyreachability::LazyCFGReachability
     const tasks::Vector{WorkThunk}
     const edges::Vector{Any}
-    callstack #::Vector{AbsIntState}
+    callstack #::Vector{AbsIntState{I}}
     frameid::Int
     parentid::Int
+    interp::I
 
-    function IRInterpretationState(
-            interp::AbstractInterpreter, spec_info::SpecInfo, ir::IRCode,
+    function IRInterpretationState{I}(
+            interp::I, spec_info::SpecInfo, ir::IRCode,
             mi::MethodInstance, argtypes::Vector{Any}, min_world::UInt, max_world::UInt
-        )
+        ) where {I<:AbstractInterpreter}
         curridx = 1
         given_argtypes = Vector{Any}(undef, length(argtypes))
         for i = 1:length(given_argtypes)
@@ -925,12 +928,16 @@ mutable struct IRInterpretationState
         end
         tasks = WorkThunk[]
         edges = Any[]
-        callstack = AbsIntState[]
-        return new(spec_info, ir, mi, valid_worlds,
+        callstack = AbsIntState{I}[]
+        return new{I}(spec_info, ir, mi, valid_worlds,
                 curridx, 0.0, 0, argtypes_refined, ir.sptypes, tpdum,
-                ssa_refined, lazyreachability, tasks, edges, callstack, 0, 0)
+                ssa_refined, lazyreachability, tasks, edges, callstack, 0, 0, interp)
     end
 end
+IRInterpretationState(interp::I, spec_info::SpecInfo, ir::IRCode,
+                      mi::MethodInstance, argtypes::Vector{Any},
+                      min_world::UInt, max_world::UInt) where {I<:AbstractInterpreter} =
+    IRInterpretationState{I}(interp, spec_info, ir, mi, argtypes, min_world, max_world)
 
 function IRInterpretationState(
         interp::AbstractInterpreter, codeinst::CodeInstance, mi::MethodInstance,
@@ -952,11 +959,11 @@ end
 # AbsIntState
 # ===========
 
-const AbsIntState = Union{InferenceState,IRInterpretationState}
+const AbsIntState{I<:AbstractInterpreter} = Union{InferenceState{I},IRInterpretationState{I}}
 
-function print_callstack(frame::AbsIntState)
+function print_callstack(frame::AbsIntState{I}) where {I<:AbstractInterpreter}
     print("=================== Callstack: ==================\n")
-    frames = frame.callstack::Vector{AbsIntState}
+    frames = frame.callstack::Vector{AbsIntState{I}}
     for idx = (frame.frameid == 0 ? 0 : 1):length(frames)
         sv = (idx == 0 ? frame : frames[idx])
         idx == frame.frameid && print("*")
@@ -987,12 +994,13 @@ function frame_module(sv::AbsIntState)
     return def.module
 end
 
-frame_parent(sv::AbsIntState) = sv.parentid == 0 ? nothing : (sv.callstack::Vector{AbsIntState})[sv.parentid]
+frame_parent(sv::AbsIntState{I}) where {I<:AbstractInterpreter} =
+    sv.parentid == 0 ? nothing : (sv.callstack::Vector{AbsIntState{I}})[sv.parentid]
 
-function cycle_parent(sv::InferenceState)
+function cycle_parent(sv::InferenceState{I}) where {I<:AbstractInterpreter}
     sv.parentid == 0 && return nothing
-    callstack = sv.callstack::Vector{AbsIntState}
-    sv = callstack[sv.cycleid]::InferenceState
+    callstack = sv.callstack::Vector{AbsIntState{I}}
+    sv = callstack[sv.cycleid]::InferenceState{I}
     sv.parentid == 0 && return nothing
     return callstack[sv.parentid]
 end
@@ -1000,17 +1008,17 @@ cycle_parent(sv::IRInterpretationState) = frame_parent(sv)
 
 
 # add the orphan child to the parent and the parent to the child
-function assign_parentchild!(child::InferenceState, parent::AbsIntState)
+function assign_parentchild!(child::InferenceState{I}, parent::AbsIntState{I}) where {I<:AbstractInterpreter}
     @assert child.frameid in (0, 1)
-    child.callstack = callstack = parent.callstack::Vector{AbsIntState}
+    child.callstack = callstack = parent.callstack::Vector{AbsIntState{I}}
     child.parentid = parent.frameid
     push!(callstack, child)
     child.cycleid = child.frameid = length(callstack)
     nothing
 end
-function assign_parentchild!(child::IRInterpretationState, parent::AbsIntState)
+function assign_parentchild!(child::IRInterpretationState{I}, parent::AbsIntState{I}) where {I<:AbstractInterpreter}
     @assert child.frameid in (0, 1)
-    child.callstack = callstack = parent.callstack::Vector{AbsIntState}
+    child.callstack = callstack = parent.callstack::Vector{AbsIntState{I}}
     child.parentid = parent.frameid
     push!(callstack, child)
     child.frameid = length(callstack)
@@ -1070,17 +1078,18 @@ Iterate through all callers of the given `AbsIntState` in the abstract interpret
 ascending the tree from the given `AbsIntState`).
 Note that cycles may be visited in any order.
 """
-struct AbsIntStackUnwind
-    callstack::Vector{AbsIntState}
-    AbsIntStackUnwind(sv::AbsIntState) = new(sv.callstack::Vector{AbsIntState})
+struct AbsIntStackUnwind{I<:AbstractInterpreter}
+    callstack::Vector{AbsIntState{I}}
+    AbsIntStackUnwind(sv::AbsIntState{I}) where {I<:AbstractInterpreter} =
+        new{I}(sv.callstack::Vector{AbsIntState{I}})
 end
 function iterate(unw::AbsIntStackUnwind, frame::Int=length(unw.callstack))
     frame == 0 && return nothing
     return (unw.callstack[frame], frame - 1)
 end
 
-struct AbsIntCycle
-    frames::Vector{AbsIntState}
+struct AbsIntCycle{I<:AbstractInterpreter}
+    frames::Vector{AbsIntState{I}}
     cycleid::Int
     cycletop::Int
 end
@@ -1097,8 +1106,8 @@ Iterate through all callers of the given `AbsIntState` in the abstract
 interpretation stack (including the given `AbsIntState` itself) that are part
 of the same cycle, only if it is part of a cycle with multiple frames.
 """
-function callers_in_cycle(sv::InferenceState)
-    callstack = sv.callstack::Vector{AbsIntState}
+function callers_in_cycle(sv::InferenceState{I}) where {I<:AbstractInterpreter}
+    callstack = sv.callstack::Vector{AbsIntState{I}}
     cycletop = cycleid = sv.cycleid
     while cycletop < length(callstack)
         frame = callstack[cycletop + 1]
@@ -1108,7 +1117,8 @@ function callers_in_cycle(sv::InferenceState)
     end
     return AbsIntCycle(callstack, cycletop == cycleid ? 0 : cycleid, cycletop)
 end
-callers_in_cycle(sv::IRInterpretationState) = AbsIntCycle(sv.callstack::Vector{AbsIntState}, 0, 0)
+callers_in_cycle(sv::IRInterpretationState{I}) where {I<:AbstractInterpreter} =
+    AbsIntCycle(sv.callstack::Vector{AbsIntState{I}}, 0, 0)
 
 get_curr_ssaflag(sv::InferenceState) = sv.ssaflags[sv.currpc]
 get_curr_ssaflag(sv::IRInterpretationState) = sv.ir.stmts[sv.curridx][:flag]

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -270,13 +270,13 @@ end
 intersect(world::WorldWithRange, valid_worlds::WorldRange) =
     WorldWithRange(world.this, intersect(world.valid_worlds, valid_worlds))
 
-# Forward-declared abstract supertype of `InferenceState` and `IRInterpretationState`,
-# so each can reference `Vector{AbsIntState{I}}` in its own field types. The concrete
-# `AbsIntState{I}` is then `Union{InferenceState{I}, IRInterpretationState{I}}` for
-# all practical purposes — see the `Union` alias defined further below.
-abstract type AbsIntState{I<:AbstractInterpreter} end
+# `InferenceState` and `IRInterpretationState` are defined together in a `typegroup`
+# block so each can reference the other in its `callstack` field type. They are not
+# meant to be subtyped from outside, so rather than introducing an abstract supertype
+# the shared `AbsIntState{I}` is a `Union` type alias (defined further below).
+typegroup
 
-mutable struct InferenceState{I<:AbstractInterpreter} <: AbsIntState{I}
+mutable struct InferenceState{I<:AbstractInterpreter}
     #= information about this method instance =#
     linfo::MethodInstance
     valid_worlds::WorldRange
@@ -322,7 +322,7 @@ mutable struct InferenceState{I<:AbstractInterpreter} <: AbsIntState{I}
     cycle_backedges::Vector{Tuple{InferenceState{I}, Int}} # call-graph backedges connecting from callee to caller
 
     # IPO tracking of in-process work, shared with all frames given AbstractInterpreter
-    callstack::Vector{AbsIntState{I}}
+    callstack::Vector{Union{InferenceState{I},IRInterpretationState{I}}}
     parentid::Int # index into callstack of the parent frame that originally added this frame (call cycle_parent to extract the current parent of the SCC)
     frameid::Int # index into callstack at which this object is found (or zero, if this is not a cached frame and has no parent)
     cycleid::Int # index into the callstack of the topmost frame in the cycle (all frames in the same cycle share the same cycleid)
@@ -403,7 +403,7 @@ mutable struct InferenceState{I<:AbstractInterpreter} <: AbsIntState{I}
         pclimitations = IdSet{InferenceState}()
         limitations = IdSet{InferenceState}()
         cycle_backedges = Tuple{InferenceState{I},Int}[]
-        callstack = AbsIntState{I}[]
+        callstack = Union{InferenceState{I},IRInterpretationState{I}}[]
         tasks = WorkThunk[]
 
         valid_worlds = WorldRange(1, get_world_counter())
@@ -451,6 +451,62 @@ mutable struct InferenceState{I<:AbstractInterpreter} <: AbsIntState{I}
         return this
     end
 end
+
+# TODO add `result::InferenceResult` and put the irinterp result into the inference cache?
+mutable struct IRInterpretationState{I<:AbstractInterpreter}
+    const spec_info::SpecInfo
+    const ir::IRCode
+    const mi::MethodInstance
+    valid_worlds::WorldRange
+    curridx::Int
+    time_caches::Float64
+    time_paused::UInt64
+    const argtypes_refined::Vector{Bool}
+    const sptypes::Vector{VarState}
+    const tpdum::TwoPhaseDefUseMap
+    const ssa_refined::BitSet
+    const lazyreachability::LazyCFGReachability
+    const tasks::Vector{WorkThunk}
+    const edges::Vector{Any}
+    callstack::Vector{Union{InferenceState{I},IRInterpretationState{I}}}
+    frameid::Int
+    parentid::Int
+    interp::AbstractInterpreter # see comment on `InferenceState.interp`
+
+    function IRInterpretationState{I}(
+            interp::I, spec_info::SpecInfo, ir::IRCode,
+            mi::MethodInstance, argtypes::Vector{Any}, min_world::UInt, max_world::UInt
+        ) where {I<:AbstractInterpreter}
+        curridx = 1
+        given_argtypes = Vector{Any}(undef, length(argtypes))
+        for i = 1:length(given_argtypes)
+            given_argtypes[i] = widenslotwrapper(argtypes[i])
+        end
+        if isa(mi.def, Method)
+            argtypes_refined = Bool[!⊑(optimizer_lattice(interp), ir.argtypes[i], given_argtypes[i])
+                for i = 1:length(given_argtypes)]
+        else
+            argtypes_refined = Bool[false for _ = 1:length(given_argtypes)]
+        end
+        empty!(ir.argtypes)
+        append!(ir.argtypes, given_argtypes)
+        tpdum = TwoPhaseDefUseMap(length(ir.stmts))
+        ssa_refined = BitSet()
+        lazyreachability = LazyCFGReachability(ir)
+        valid_worlds = WorldRange(min_world, max_world == typemax(UInt) ? get_world_counter() : max_world)
+        if !(get_inference_world(interp) in valid_worlds)
+            error("invalid age range update")
+        end
+        tasks = WorkThunk[]
+        edges = Any[]
+        callstack = Union{InferenceState{I},IRInterpretationState{I}}[]
+        return new{I}(spec_info, ir, mi, valid_worlds,
+                curridx, 0.0, 0, argtypes_refined, ir.sptypes, tpdum,
+                ssa_refined, lazyreachability, tasks, edges, callstack, 0, 0, interp)
+    end
+end
+
+end # typegroup
 
 gethandler(frame::InferenceState, pc::Int=frame.currpc) = gethandler(frame.handler_info, pc)
 gethandler(::Nothing, ::Int) = nothing
@@ -890,60 +946,8 @@ end
 
 # IRInterpretationState
 # =====================
+# (the struct itself is defined in the `typegroup` block alongside `InferenceState`)
 
-# TODO add `result::InferenceResult` and put the irinterp result into the inference cache?
-mutable struct IRInterpretationState{I<:AbstractInterpreter} <: AbsIntState{I}
-    const spec_info::SpecInfo
-    const ir::IRCode
-    const mi::MethodInstance
-    valid_worlds::WorldRange
-    curridx::Int
-    time_caches::Float64
-    time_paused::UInt64
-    const argtypes_refined::Vector{Bool}
-    const sptypes::Vector{VarState}
-    const tpdum::TwoPhaseDefUseMap
-    const ssa_refined::BitSet
-    const lazyreachability::LazyCFGReachability
-    const tasks::Vector{WorkThunk}
-    const edges::Vector{Any}
-    callstack::Vector{AbsIntState{I}}
-    frameid::Int
-    parentid::Int
-    interp::AbstractInterpreter # see comment on `InferenceState.interp`
-
-    function IRInterpretationState{I}(
-            interp::I, spec_info::SpecInfo, ir::IRCode,
-            mi::MethodInstance, argtypes::Vector{Any}, min_world::UInt, max_world::UInt
-        ) where {I<:AbstractInterpreter}
-        curridx = 1
-        given_argtypes = Vector{Any}(undef, length(argtypes))
-        for i = 1:length(given_argtypes)
-            given_argtypes[i] = widenslotwrapper(argtypes[i])
-        end
-        if isa(mi.def, Method)
-            argtypes_refined = Bool[!⊑(optimizer_lattice(interp), ir.argtypes[i], given_argtypes[i])
-                for i = 1:length(given_argtypes)]
-        else
-            argtypes_refined = Bool[false for _ = 1:length(given_argtypes)]
-        end
-        empty!(ir.argtypes)
-        append!(ir.argtypes, given_argtypes)
-        tpdum = TwoPhaseDefUseMap(length(ir.stmts))
-        ssa_refined = BitSet()
-        lazyreachability = LazyCFGReachability(ir)
-        valid_worlds = WorldRange(min_world, max_world == typemax(UInt) ? get_world_counter() : max_world)
-        if !(get_inference_world(interp) in valid_worlds)
-            error("invalid age range update")
-        end
-        tasks = WorkThunk[]
-        edges = Any[]
-        callstack = AbsIntState{I}[]
-        return new{I}(spec_info, ir, mi, valid_worlds,
-                curridx, 0.0, 0, argtypes_refined, ir.sptypes, tpdum,
-                ssa_refined, lazyreachability, tasks, edges, callstack, 0, 0, interp)
-    end
-end
 IRInterpretationState(interp::I, spec_info::SpecInfo, ir::IRCode,
                       mi::MethodInstance, argtypes::Vector{Any},
                       min_world::UInt, max_world::UInt) where {I<:AbstractInterpreter} =
@@ -969,8 +973,7 @@ end
 # AbsIntState
 # ===========
 
-## `AbsIntState` is the abstract supertype declared above; the only concrete
-## subtypes are `InferenceState` and `IRInterpretationState`.
+const AbsIntState{I<:AbstractInterpreter} = Union{InferenceState{I}, IRInterpretationState{I}}
 
 function print_callstack(frame::AbsIntState)
     print("=================== Callstack: ==================\n")

--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -271,8 +271,8 @@ include("ssair/EscapeAnalysis.jl")
 include("ssair/passes.jl")
 include("ssair/irinterp.jl")
 
-function ir_to_codeinf!(opt::OptimizationState, frame::InferenceState, edges::SimpleVector)
-    ir_to_codeinf!(opt, edges, compute_inlining_cost(frame.interp, frame.result, opt.optresult))
+function ir_to_codeinf!(opt::OptimizationState{I}, frame::InferenceState{I}, edges::SimpleVector) where {I<:AbstractInterpreter}
+    ir_to_codeinf!(opt, edges, compute_inlining_cost(frame.interp::I, frame.result, opt.optresult))
 end
 
 function ir_to_codeinf!(opt::OptimizationState, edges::SimpleVector, inlining_cost::InlineCostType)
@@ -1019,7 +1019,7 @@ function ipo_dataflow_analysis!(interp::AbstractInterpreter, opt::OptimizationSt
 end
 
 # run the optimization work
-function optimize(interp::I, opt::OptimizationState{I}, caller::InferenceResult) where {I<:AbstractInterpreter}
+function optimize(interp::AbstractInterpreter, opt::OptimizationState{I}, caller::InferenceResult) where {I<:AbstractInterpreter}
     @zone "CC: OPTIMIZER" ir = run_passes_ipo_safe(opt.src, opt)
     ipo_dataflow_analysis!(interp, opt, ir, caller)
     finishopt!(interp, opt, ir)

--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -1019,7 +1019,7 @@ function ipo_dataflow_analysis!(interp::AbstractInterpreter, opt::OptimizationSt
 end
 
 # run the optimization work
-function optimize(interp::AbstractInterpreter, opt::OptimizationState, caller::InferenceResult)
+function optimize(interp::I, opt::OptimizationState{I}, caller::InferenceResult) where {I<:AbstractInterpreter}
     @zone "CC: OPTIMIZER" ir = run_passes_ipo_safe(opt.src, opt)
     ipo_dataflow_analysis!(interp, opt, ir, caller)
     finishopt!(interp, opt, ir)

--- a/Compiler/src/ssair/irinterp.jl
+++ b/Compiler/src/ssair/irinterp.jl
@@ -316,8 +316,8 @@ function is_all_const_call(@nospecialize(stmt), interp::AbstractInterpreter, irs
     return true
 end
 
-function ir_abstract_constant_propagation(interp::I, irsv::IRInterpretationState{I};
-        externally_refined::Union{Nothing,BitSet} = nothing) where {I<:AbstractInterpreter}
+function ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IRInterpretationState;
+        externally_refined::Union{Nothing,BitSet} = nothing)
     (; ir, tpdum, ssa_refined) = irsv
 
     @assert isempty(ir.new_nodes) "IRCode should be compacted before irinterp"
@@ -459,7 +459,7 @@ function ir_abstract_constant_propagation(interp::I, irsv::IRInterpretationState
     end
 
     if irsv.frameid != 0
-        callstack = irsv.callstack::Vector{AbsIntState{I}}
+        callstack = irsv.callstack
         @assert callstack[end] === irsv && length(callstack) == irsv.frameid
         pop!(callstack)
     end

--- a/Compiler/src/ssair/irinterp.jl
+++ b/Compiler/src/ssair/irinterp.jl
@@ -316,8 +316,8 @@ function is_all_const_call(@nospecialize(stmt), interp::AbstractInterpreter, irs
     return true
 end
 
-function ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IRInterpretationState;
-        externally_refined::Union{Nothing,BitSet} = nothing)
+function ir_abstract_constant_propagation(interp::I, irsv::IRInterpretationState{I};
+        externally_refined::Union{Nothing,BitSet} = nothing) where {I<:AbstractInterpreter}
     (; ir, tpdum, ssa_refined) = irsv
 
     @assert isempty(ir.new_nodes) "IRCode should be compacted before irinterp"
@@ -459,7 +459,7 @@ function ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IRI
     end
 
     if irsv.frameid != 0
-        callstack = irsv.callstack::Vector{AbsIntState}
+        callstack = irsv.callstack::Vector{AbsIntState{I}}
         @assert callstack[end] === irsv && length(callstack) == irsv.frameid
         pop!(callstack)
     end

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -270,20 +270,20 @@ function finish!(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInstan
     return nothing
 end
 
-function finish_nocycle(interp::I, frame::InferenceState{I}, time_before::UInt64) where {I<:AbstractInterpreter}
+function finish_nocycle(interp::AbstractInterpreter, frame::InferenceState{I}, time_before::UInt64) where {I<:AbstractInterpreter}
     opt_cache = IdDict{MethodInstance,CodeInstance}()
-    finishinfer!(frame, interp, frame.cycleid, opt_cache)
+    finishinfer!(frame, interp::I, frame.cycleid, opt_cache)
     opt = frame.result.src
     if opt isa OptimizationState # implies `may_optimize(interp) === true`
-        optimize(interp, opt::OptimizationState{I}, frame.result)
+        optimize(interp::I, opt::OptimizationState{I}, frame.result)
         # check the valid_worlds hasn't been narrowed by added :invoke edges
         valid_worlds = intersect(frame.valid_worlds, compute_recursive_worlds(opt.inlining.edges))
-        update_valid_age!(frame, get_inference_world(interp), valid_worlds)
+        update_valid_age!(frame, get_inference_world(interp::I), valid_worlds)
     end
     empty!(opt_cache)
     validation_world = get_world_counter()
-    finish!(interp, frame, validation_world, time_before)
-    promotecache!(interp, frame)
+    finish!(interp::I, frame, validation_world, time_before)
+    promotecache!(interp::I, frame)
     if isdefined(frame.result, :ci)
         # After validation, under the world_counter_lock, set max_world to typemax(UInt) for all dependencies
         # (recursively). From that point onward the ordinary backedge mechanism is responsible for maintaining
@@ -298,8 +298,8 @@ function finish_nocycle(interp::I, frame::InferenceState{I}, time_before::UInt64
     return nothing
 end
 
-function finish_cycle(interp::I, frames::Vector{AbsIntState{I}}, cycleid::Int, time_before::UInt64) where {I<:AbstractInterpreter}
-    world = get_inference_world(interp)
+function finish_cycle(interp::AbstractInterpreter, frames::Vector{AbsIntState{I}}, cycleid::Int, time_before::UInt64) where {I<:AbstractInterpreter}
+    world = get_inference_world(interp::I)
     cycle_valid_worlds = WorldRange()
     cycle_valid_effects = EFFECTS_TOTAL
     for frameid = cycleid:length(frames)
@@ -316,7 +316,7 @@ function finish_cycle(interp::I, frames::Vector{AbsIntState{I}}, cycleid::Int, t
     for frameid = cycleid:length(frames)
         caller = frames[frameid]::InferenceState
         adjust_cycle_frame!(caller, world, cycle_valid_worlds, cycle_valid_effects)
-        finishinfer!(caller, caller.interp, cycleid, opt_cache)
+        finishinfer!(caller, caller.interp::I, cycleid, opt_cache)
         time_now = _time_ns()
         caller.time_self_ns += (time_now - time_before)
         time_before = time_now
@@ -327,7 +327,7 @@ function finish_cycle(interp::I, frames::Vector{AbsIntState{I}}, cycleid::Int, t
         caller = frames[frameid]::InferenceState
         opt = caller.result.src
         if opt isa OptimizationState # implies `may_optimize(caller.interp) === true`
-            optimize(caller.interp, opt::OptimizationState{I}, caller.result)
+            optimize(caller.interp::I, opt::OptimizationState{I}, caller.result)
             cycle_valid_worlds = intersect(cycle_valid_worlds, compute_recursive_worlds(opt.inlining.edges))
             time_now = _time_ns()
             caller.time_self_ns += (time_now - time_before)
@@ -349,7 +349,7 @@ function finish_cycle(interp::I, frames::Vector{AbsIntState{I}}, cycleid::Int, t
         caller.time_caches = time_caches
         caller.time_paused = time_paused
         update_valid_age!(caller, world, cycle_valid_worlds)
-        finish!(caller.interp, caller, validation_world, time_before)
+        finish!(caller.interp::I, caller, validation_world, time_before)
         if isdefined(caller.result, :ci)
             push!(cis, caller.result.ci)
         end
@@ -362,7 +362,7 @@ function finish_cycle(interp::I, frames::Vector{AbsIntState{I}}, cycleid::Int, t
     # After everything is finished, promote the work into visible caches
     for frameid = cycleid:length(frames)
         caller = frames[frameid]::InferenceState
-        promotecache!(caller.interp, caller)
+        promotecache!(caller.interp::I, caller)
     end
     # After validation, under the world_counter_lock, set max_world to typemax(UInt) for all dependencies
     # (recursively). From that point onward the ordinary backedge mechanism is responsible for maintaining
@@ -963,8 +963,8 @@ function add_cycle_backedge!(caller::InferenceState, frame::InferenceState)
     return frame
 end
 
-function is_same_frame(interp::AbstractInterpreter, mi::MethodInstance, frame::InferenceState)
-    return mi === frame_instance(frame) && cache_owner(interp) === cache_owner(frame.interp)
+function is_same_frame(interp::I, mi::MethodInstance, frame::InferenceState) where {I<:AbstractInterpreter}
+    return mi === frame_instance(frame) && cache_owner(interp) === cache_owner(frame.interp::I)
 end
 
 function poison_callstack!(infstate::InferenceState, topmost::InferenceState)

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -291,7 +291,7 @@ function finish_nocycle(interp::I, frame::InferenceState{I}, time_before::UInt64
         ccall(:jl_promote_ci_to_current, Cvoid, (Any, UInt), frame.result.ci, validation_world)
     end
     if frame.cycleid != 0
-        frames = frame.callstack::Vector{AbsIntState{I}}
+        frames = frame.callstack
         @assert frames[end] === frame
         pop!(frames)
     end
@@ -508,9 +508,9 @@ function maybe_compress_codeinfo(interp::AbstractInterpreter, mi::MethodInstance
     return ci
 end
 
-function cycle_fix_limited(@nospecialize(typ), sv::InferenceState{I}, cycleid::Int) where {I<:AbstractInterpreter}
+function cycle_fix_limited(@nospecialize(typ), sv::InferenceState, cycleid::Int)
     if typ isa LimitedAccuracy
-        frames = sv.callstack::Vector{AbsIntState{I}}
+        frames = sv.callstack
         causes = typ.causes
         for frameid = cycleid:length(frames)
             caller = frames[frameid]::InferenceState
@@ -943,9 +943,9 @@ function type_annotate!(::AbstractInterpreter, sv::InferenceState)
     return nothing
 end
 
-function merge_call_chain!(::AbstractInterpreter, parent::InferenceState{I}, child::InferenceState{I}) where {I<:AbstractInterpreter}
+function merge_call_chain!(::AbstractInterpreter, parent::InferenceState, child::InferenceState)
     # update all cycleid to be in the same group
-    frames = parent.callstack::Vector{AbsIntState{I}}
+    frames = parent.callstack
     @assert child.callstack === frames
     ancestorid = child.cycleid
     # ensure that walking the callstack has the same cycleid (DAG)
@@ -978,12 +978,12 @@ end
 # we "resolve" it by merging the call chain, which entails updating each intermediary
 # frame's `cycleid` field. Finally, we return `mi`'s pre-existing frame.
 # If no cycles are found, `nothing` is returned instead.
-function resolve_call_cycle!(interp::I, mi::MethodInstance, parent::AbsIntState) where {I<:AbstractInterpreter}
+function resolve_call_cycle!(interp::AbstractInterpreter, mi::MethodInstance, parent::AbsIntState)
     # TODO (#48913) implement a proper recursion handling for irinterp:
     # This works most of the time currently just because the irinterp code doesn't get used much with
     # `@assume_effects`, so it never sees a cycle normally, but that may not be a sustainable solution.
     parent isa InferenceState || return false
-    frames = parent.callstack::Vector{AbsIntState{I}}
+    frames = parent.callstack
     uncached = false
     for frameid = reverse(1:length(frames))
         frame = frames[frameid]

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -270,7 +270,7 @@ function finish!(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInstan
     return nothing
 end
 
-function finish_nocycle(interp::I, frame::InferenceState, time_before::UInt64) where {I<:AbstractInterpreter}
+function finish_nocycle(interp::I, frame::InferenceState{I}, time_before::UInt64) where {I<:AbstractInterpreter}
     opt_cache = IdDict{MethodInstance,CodeInstance}()
     finishinfer!(frame, interp, frame.cycleid, opt_cache)
     opt = frame.result.src
@@ -291,14 +291,14 @@ function finish_nocycle(interp::I, frame::InferenceState, time_before::UInt64) w
         ccall(:jl_promote_ci_to_current, Cvoid, (Any, UInt), frame.result.ci, validation_world)
     end
     if frame.cycleid != 0
-        frames = frame.callstack::Vector{AbsIntState}
+        frames = frame.callstack::Vector{AbsIntState{I}}
         @assert frames[end] === frame
         pop!(frames)
     end
     return nothing
 end
 
-function finish_cycle(interp::I, frames::Vector{AbsIntState}, cycleid::Int, time_before::UInt64) where {I<:AbstractInterpreter}
+function finish_cycle(interp::I, frames::Vector{AbsIntState{I}}, cycleid::Int, time_before::UInt64) where {I<:AbstractInterpreter}
     world = get_inference_world(interp)
     cycle_valid_worlds = WorldRange()
     cycle_valid_effects = EFFECTS_TOTAL
@@ -316,7 +316,7 @@ function finish_cycle(interp::I, frames::Vector{AbsIntState}, cycleid::Int, time
     for frameid = cycleid:length(frames)
         caller = frames[frameid]::InferenceState
         adjust_cycle_frame!(caller, world, cycle_valid_worlds, cycle_valid_effects)
-        finishinfer!(caller, caller.interp::I, cycleid, opt_cache)
+        finishinfer!(caller, caller.interp, cycleid, opt_cache)
         time_now = _time_ns()
         caller.time_self_ns += (time_now - time_before)
         time_before = time_now
@@ -327,7 +327,7 @@ function finish_cycle(interp::I, frames::Vector{AbsIntState}, cycleid::Int, time
         caller = frames[frameid]::InferenceState
         opt = caller.result.src
         if opt isa OptimizationState # implies `may_optimize(caller.interp) === true`
-            optimize(caller.interp::I, opt::OptimizationState{I}, caller.result)
+            optimize(caller.interp, opt::OptimizationState{I}, caller.result)
             cycle_valid_worlds = intersect(cycle_valid_worlds, compute_recursive_worlds(opt.inlining.edges))
             time_now = _time_ns()
             caller.time_self_ns += (time_now - time_before)
@@ -349,7 +349,7 @@ function finish_cycle(interp::I, frames::Vector{AbsIntState}, cycleid::Int, time
         caller.time_caches = time_caches
         caller.time_paused = time_paused
         update_valid_age!(caller, world, cycle_valid_worlds)
-        finish!(caller.interp::I, caller, validation_world, time_before)
+        finish!(caller.interp, caller, validation_world, time_before)
         if isdefined(caller.result, :ci)
             push!(cis, caller.result.ci)
         end
@@ -362,7 +362,7 @@ function finish_cycle(interp::I, frames::Vector{AbsIntState}, cycleid::Int, time
     # After everything is finished, promote the work into visible caches
     for frameid = cycleid:length(frames)
         caller = frames[frameid]::InferenceState
-        promotecache!(caller.interp::I, caller)
+        promotecache!(caller.interp, caller)
     end
     # After validation, under the world_counter_lock, set max_world to typemax(UInt) for all dependencies
     # (recursively). From that point onward the ordinary backedge mechanism is responsible for maintaining
@@ -508,9 +508,9 @@ function maybe_compress_codeinfo(interp::AbstractInterpreter, mi::MethodInstance
     return ci
 end
 
-function cycle_fix_limited(@nospecialize(typ), sv::InferenceState, cycleid::Int)
+function cycle_fix_limited(@nospecialize(typ), sv::InferenceState{I}, cycleid::Int) where {I<:AbstractInterpreter}
     if typ isa LimitedAccuracy
-        frames = sv.callstack::Vector{AbsIntState}
+        frames = sv.callstack::Vector{AbsIntState{I}}
         causes = typ.causes
         for frameid = cycleid:length(frames)
             caller = frames[frameid]::InferenceState
@@ -943,9 +943,9 @@ function type_annotate!(::AbstractInterpreter, sv::InferenceState)
     return nothing
 end
 
-function merge_call_chain!(::AbstractInterpreter, parent::InferenceState, child::InferenceState)
+function merge_call_chain!(::AbstractInterpreter, parent::InferenceState{I}, child::InferenceState{I}) where {I<:AbstractInterpreter}
     # update all cycleid to be in the same group
-    frames = parent.callstack::Vector{AbsIntState}
+    frames = parent.callstack::Vector{AbsIntState{I}}
     @assert child.callstack === frames
     ancestorid = child.cycleid
     # ensure that walking the callstack has the same cycleid (DAG)
@@ -963,8 +963,8 @@ function add_cycle_backedge!(caller::InferenceState, frame::InferenceState)
     return frame
 end
 
-function is_same_frame(interp::I, mi::MethodInstance, frame::InferenceState) where {I<:AbstractInterpreter}
-    return mi === frame_instance(frame) && cache_owner(interp) === cache_owner(frame.interp::I)
+function is_same_frame(interp::AbstractInterpreter, mi::MethodInstance, frame::InferenceState)
+    return mi === frame_instance(frame) && cache_owner(interp) === cache_owner(frame.interp)
 end
 
 function poison_callstack!(infstate::InferenceState, topmost::InferenceState)
@@ -978,12 +978,12 @@ end
 # we "resolve" it by merging the call chain, which entails updating each intermediary
 # frame's `cycleid` field. Finally, we return `mi`'s pre-existing frame.
 # If no cycles are found, `nothing` is returned instead.
-function resolve_call_cycle!(interp::AbstractInterpreter, mi::MethodInstance, parent::AbsIntState)
+function resolve_call_cycle!(interp::I, mi::MethodInstance, parent::AbsIntState) where {I<:AbstractInterpreter}
     # TODO (#48913) implement a proper recursion handling for irinterp:
     # This works most of the time currently just because the irinterp code doesn't get used much with
     # `@assume_effects`, so it never sees a cycle normally, but that may not be a sustainable solution.
     parent isa InferenceState || return false
-    frames = parent.callstack::Vector{AbsIntState}
+    frames = parent.callstack::Vector{AbsIntState{I}}
     uncached = false
     for frameid = reverse(1:length(frames))
         frame = frames[frameid]

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -270,12 +270,12 @@ function finish!(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInstan
     return nothing
 end
 
-function finish_nocycle(interp::AbstractInterpreter, frame::InferenceState, time_before::UInt64)
+function finish_nocycle(interp::I, frame::InferenceState, time_before::UInt64) where {I<:AbstractInterpreter}
     opt_cache = IdDict{MethodInstance,CodeInstance}()
     finishinfer!(frame, interp, frame.cycleid, opt_cache)
     opt = frame.result.src
     if opt isa OptimizationState # implies `may_optimize(interp) === true`
-        optimize(interp, opt, frame.result)
+        optimize(interp, opt::OptimizationState{I}, frame.result)
         # check the valid_worlds hasn't been narrowed by added :invoke edges
         valid_worlds = intersect(frame.valid_worlds, compute_recursive_worlds(opt.inlining.edges))
         update_valid_age!(frame, get_inference_world(interp), valid_worlds)
@@ -298,7 +298,7 @@ function finish_nocycle(interp::AbstractInterpreter, frame::InferenceState, time
     return nothing
 end
 
-function finish_cycle(interp::AbstractInterpreter, frames::Vector{AbsIntState}, cycleid::Int, time_before::UInt64)
+function finish_cycle(interp::I, frames::Vector{AbsIntState}, cycleid::Int, time_before::UInt64) where {I<:AbstractInterpreter}
     world = get_inference_world(interp)
     cycle_valid_worlds = WorldRange()
     cycle_valid_effects = EFFECTS_TOTAL
@@ -316,7 +316,7 @@ function finish_cycle(interp::AbstractInterpreter, frames::Vector{AbsIntState}, 
     for frameid = cycleid:length(frames)
         caller = frames[frameid]::InferenceState
         adjust_cycle_frame!(caller, world, cycle_valid_worlds, cycle_valid_effects)
-        finishinfer!(caller, caller.interp, cycleid, opt_cache)
+        finishinfer!(caller, caller.interp::I, cycleid, opt_cache)
         time_now = _time_ns()
         caller.time_self_ns += (time_now - time_before)
         time_before = time_now
@@ -327,7 +327,7 @@ function finish_cycle(interp::AbstractInterpreter, frames::Vector{AbsIntState}, 
         caller = frames[frameid]::InferenceState
         opt = caller.result.src
         if opt isa OptimizationState # implies `may_optimize(caller.interp) === true`
-            optimize(caller.interp, opt, caller.result)
+            optimize(caller.interp::I, opt::OptimizationState{I}, caller.result)
             cycle_valid_worlds = intersect(cycle_valid_worlds, compute_recursive_worlds(opt.inlining.edges))
             time_now = _time_ns()
             caller.time_self_ns += (time_now - time_before)
@@ -349,7 +349,7 @@ function finish_cycle(interp::AbstractInterpreter, frames::Vector{AbsIntState}, 
         caller.time_caches = time_caches
         caller.time_paused = time_paused
         update_valid_age!(caller, world, cycle_valid_worlds)
-        finish!(caller.interp, caller, validation_world, time_before)
+        finish!(caller.interp::I, caller, validation_world, time_before)
         if isdefined(caller.result, :ci)
             push!(cis, caller.result.ci)
         end
@@ -362,7 +362,7 @@ function finish_cycle(interp::AbstractInterpreter, frames::Vector{AbsIntState}, 
     # After everything is finished, promote the work into visible caches
     for frameid = cycleid:length(frames)
         caller = frames[frameid]::InferenceState
-        promotecache!(caller.interp, caller)
+        promotecache!(caller.interp::I, caller)
     end
     # After validation, under the world_counter_lock, set max_world to typemax(UInt) for all dependencies
     # (recursively). From that point onward the ordinary backedge mechanism is responsible for maintaining
@@ -708,7 +708,7 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter, cycleid::
         ci.analysis_results = result.analysis_results
         if !iszero(me.cache_mode & CACHE_MODE_GLOBAL)
             ci = result.ci
-            if is_already_cached(me.interp, result)
+            if is_already_cached(interp, result)
                 # convert to a local cache
                 engine_reject(interp, ci)
                 me.cache_mode = CACHE_MODE_LOCAL
@@ -963,8 +963,8 @@ function add_cycle_backedge!(caller::InferenceState, frame::InferenceState)
     return frame
 end
 
-function is_same_frame(interp::AbstractInterpreter, mi::MethodInstance, frame::InferenceState)
-    return mi === frame_instance(frame) && cache_owner(interp) === cache_owner(frame.interp)
+function is_same_frame(interp::I, mi::MethodInstance, frame::InferenceState) where {I<:AbstractInterpreter}
+    return mi === frame_instance(frame) && cache_owner(interp) === cache_owner(frame.interp::I)
 end
 
 function poison_callstack!(infstate::InferenceState, topmost::InferenceState)


### PR DESCRIPTION
Packages defining a custom `AbstractInterpreter` that drive inference at precompile time (cuTile, JET, etc.) saw all their cached inference results invalidated as soon as `REPL` was loaded, unless they already imported `REPL` themselves.

The root cause is abstract dispatch through `InferenceState.interp` and `OptimizationState.inlining.interp`, both declared `::AbstractInterpreter`. Even though Julia auto-specializes the enclosing methods on the concrete interpreter subtype, reads of those struct fields widen back to the abstract supertype, so calls like `cache_owner(frame.interp)` register abstract-dispatch backedges. Loading `REPL` adds `REPLInterp` plus its own `cache_owner` method, which trips those backedges and invalidates every CodeInstance the package precompiled.

Bind a type variable `I<:AbstractInterpreter` on the inference and optimization entry points and re-narrow the field reads (`frame.interp::I`, `caller.interp::I`, `opt::OptimizationState{I}`) so the dispatches resolve concretely. This relies on the existing invariant that all frames in one callstack share the same interpreter type, which AFAIU `assign_parentchild!` and `typeinf_edge` already maintain.

Fixes #61711
Fixes #61510
Fixes #58000