### PR TITLE
Use DWARF 5

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3025,7 +3025,7 @@ std::unique_ptr<Module> jl_create_llvm_module(StringRef name, LLVMContext &conte
     else {
         // No source: set default Julia flags
         // According to clang darwin above 10.10 supports dwarfv4
-        m->addModuleFlag(llvm::Module::Warning, "Dwarf Version", 4);
+        m->addModuleFlag(llvm::Module::Warning, "Dwarf Version", 5);
         m->addModuleFlag(llvm::Module::Warning, "Debug Info Version",
                          llvm::DEBUG_METADATA_VERSION);
 


### PR DESCRIPTION
DWARF 5 comes with new, more efficient encodings for the `.debug_loc` and `.debug_ranges` sections (called `.debug_loclists` and `.debug_rnglists`).  We should consider having LLVM emit it to save some space in the system image.

DWARF 4:
```
.debug_info          12017654 (5.82%)
.debug_abbrev           32304 (0.02%)
.debug_line           6373321 (3.09%)
.debug_str             535394 (0.26%)
.debug_ranges         8628896 (4.18%)
.debug_gnu_pubnames    973608 (0.47%)
.debug_gnu_pubtypes      1152 (0.00%)
 Total Size: 28562329  (13.84%)
```

DWARF 5:
```
.debug_info           8216526 (4.11%)
.debug_abbrev           39758 (0.02%)
.debug_line           6238047 (3.12%)
.debug_str             535330 (0.27%)
.debug_addr           1836416 (0.92%)
.debug_line_str          4882 (0.00%)
.debug_rnglists       3720001 (1.86%)
.debug_str_offsets     442248 (0.22%)
.debug_gnu_pubnames    974451 (0.49%)
.debug_gnu_pubtypes      1152 (0.00%)
 Total Size: 22008811  (11.01%)
 Total File Size: 199883168
```
