### PR TITLE
inference: refine `OpaqueClosure` rt parameter via eager body inference

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3438,20 +3438,43 @@ function abstract_eval_new_opaque_closure(interp::AbstractInterpreter, e::Expr, 
                 # Propagation of PartialOpaque disabled
             end
             if isa(rt, PartialOpaque) && isa(sv, InferenceState) && !call_result_unused(sv, sv.currpc)
-                # Infer this now so that the specialization is available to
-                # optimization.
+                # Infer this now so that the specialization is available to optimization.
+                # Take the chance to refine `PartialOpaque.typ`'s rt parameter from the
+                # eager body inference's result.
                 argtypes = most_general_argtypes(rt)
                 pushfirst!(argtypes, rt.env)
                 callinfo = abstract_call_opaque_closure(interp, rt,
                     ArgInfo(nothing, argtypes), StmtInfo(true, false), sstate.vtypes, sv, #=check=#false)::Future
-                Future{Any}(callinfo, interp, sv) do callinfo, _, sv
+                local rt_for_future = rt
+                local effects_for_future = effects
+                return Future{RTEffects}(callinfo, interp, sv) do callinfo, _, sv
                     sv.stmt_info[sv.currpc] = OpaqueClosureCreateInfo(callinfo)
-                    nothing
+                    refined_rt = refine_partial_opaque_rt(rt_for_future, callinfo.rt)
+                    return RTEffects(refined_rt, Any, effects_for_future)
                 end
             end
         end
     end
     return Future(RTEffects(rt, Any, effects))
+end
+
+# Narrow `po.typ`'s rt parameter using the OC body's inferred return type when possible.
+# The OC type is shaped `OpaqueClosure{argt, T} where T<:rt_ub` (when `lb != ub`), and the
+# eager body inference yields a concrete `inferred_rt` that's a strict subtype of `rt_ub`.
+# Binding the outer `T` to that `inferred_rt` produces `OpaqueClosure{argt, inferred_rt}`.
+@nospecializeinfer function refine_partial_opaque_rt(po::PartialOpaque, @nospecialize(inferred_rt))
+    typ = po.typ
+    isa(typ, UnionAll) || return po
+    refined = widenconst(inferred_rt)
+    (refined === Any || refined === Union{}) && return po
+    tv = typ.var
+    tv.lb <: refined <: tv.ub || return po
+    refined_typ = try
+        typ{refined}
+    catch
+        return po
+    end
+    return PartialOpaque(refined_typ, po.env, po.parent, po.source)
 end
 
 function abstract_eval_copyast(interp::AbstractInterpreter, e::Expr, sstate::StatementState,

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -433,3 +433,19 @@ end
 
 # 49659: signature-scoped typevar shouldn't fail in lowering
 @test_throws "must be a tuple type" @opaque ((x::T,y::T) where {T}) -> 123
+
+# Refinement of return type information via eager inference:
+# Without this refinement, even if `PartialOpaque` is propagated through the `map` call stack,
+# the return type of the closure would be be lost at the `Core.Compiler._return_type` boundary
+# that `PartialOpaque` cannot cross. By storing the return type information known at eager
+# inference time in the type parameter of `Core.OpaqueClosure`, the following inference succeeds.
+@noinline print_oc_result(some) = @show some.value()
+@test Base.infer_return_type((Int,)) do x
+    oc = Base.Experimental.@opaque () -> 2x
+    some = Some(oc)
+    print_oc_result(some)
+end == Int
+@test Base.infer_return_type((Vector{Int},)) do xs
+    oc = Base.Experimental.@opaque x::Int -> 2x
+    return map(oc, xs)
+end == Vector{Int}


### PR DESCRIPTION
At each `:new_opaque_closure` site, the body is eagerly inferred so its specialization is available for downstream consumers. The body's inferred return type was discarded, however — `PartialOpaque.typ` stayed as `OpaqueClosure{argt, T} where T<:rt_ub`, with the rt typevar free. Anything that consults the OC's static type after `widenconst` then sees only `T<:rt_ub`. This includes `abstract_call_unknown`'s `OpaqueClosure` fallback (which extracts `unwrap_unionall.parameters[2]`) and any downstream `_return_type` probe whose argument lattice crosses a boundary that `PartialOpaque` can't traverse — `Base.@default_eltype`'s `Tuple{typeof(itr)}` widening is the canonical case. The result is that the OC's rt collapses to `rt_ub` (typically `Any`) even when eager inference saw a precise type.

An OC value's runtime type is `OpaqueClosure{argt, T0}` for a specific `T0` determined by the body's actual return. Eager body inference gives a sound upper bound on `T0` within `[rt_lb, rt_ub]`, so the static `PartialOpaque.typ` UnionAll can be collapsed to that tighter binding. Apply this refinement in `abstract_eval_new_opaque_closure` so the `PartialOpaque` emitted for the construction site already carries the precise rt.

This matters for an ongoing experiment in JETLS that runs inference statelessly against top-level chunks. Routing single-method local closures through `K"_opaque_closure"` avoids the synthetic-struct path's name-resolution issues — the synthetic closure type isn't materialized in the chunk's context module, so inference dispatching on it collapses to `Any`. With this refinement, common patterns like `map(xs::Vector{Int}) do x::Int; 2x; end` (where the `do` closure will be rewritten to OC at the re-lowering phase) infer the result as `Vector{Int}` rather than `Vector` — without it the OC's rt is lost across `map`'s internal lowering of the result element type, and the returned vector widens.