### PR TITLE
inference: propagate `PartialStruct` for parametric struct construction

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3311,12 +3311,16 @@ function abstract_eval_new(interp::AbstractInterpreter, e::Expr, sstate::Stateme
         else
             consistent = ALWAYS_TRUE # immutable allocation is consistent
         end
-        if isconcretedispatch(rt)
-            nothrow = true
-            @assert fcount !== nothing && fcount ≥ nargs "malformed :new expression" # syntactically enforced by the front-end
+        # `:new` can carry `PartialStruct` even when `rt` isn't isconcretedispatch` —
+        # partially-instantiated parametric types (e.g. `Generator{Vector{Int}, F<:OC{Tuple{Int}, T} where T}`) still
+        # have well-defined field count, and field-level extended lattice elements carry
+        # information beyond the declared type.
+        if fcount !== nothing
+            nothrow = isconcretedispatch(rt)
+            @assert nargs ≤ fcount "malformed :new expression" # syntactically enforced by the front-end
             ats = Vector{Any}(undef, nargs)
             local anyrefine = false
-            local allconst = true
+            local allconst = isconcretedispatch(rt)
             for i = 1:nargs
                 at = widenslotwrapper(abstract_eval_value(interp, e.args[i+1], sstate, sv))
                 ft = fieldtype(rt, i)
@@ -3334,7 +3338,7 @@ function abstract_eval_new(interp::AbstractInterpreter, e::Expr, sstate::Stateme
                 end
                 ats[i] = at
             end
-            if fcount == nargs && consistent === ALWAYS_TRUE && allconst
+            if allconst && fcount == nargs && consistent === ALWAYS_TRUE
                 argvals = Vector{Any}(undef, nargs)
                 for j in 1:nargs
                     argvals[j] = (ats[j]::Const).val
@@ -3369,6 +3373,8 @@ function abstract_eval_new(interp::AbstractInterpreter, e::Expr, sstate::Stateme
                     end
                 end
                 rt = PartialStruct(𝕃ᵢ, rt, undefs, ats)
+            else
+                rt = refine_partial_type(rt)
             end
         else
             rt = refine_partial_type(rt)

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -6800,4 +6800,26 @@ end
     Val(concrete_eval_eligible_if_false(42., 5, false) == 5sin(42.))
 end == Val{true}
 
+# Const-prop' `PartialStruct` of well-formed types that are `!isconcretedispatch`:
+# Test with an example using `OpaqueClosure`, which would be represented as `PartialOpaque`,
+# which will be a field of `PartialStruct` representing `Some`. Here, since this `oc` has
+# untyped argument types, the return type cannot be derived by eager inference in the
+# current OC framework, so inference will fail unless `PartialOpaque` is propagated all the
+# way to `call_someoc`.
+call_someoc(some, x) = some.value(x)
+@test Base.infer_return_type() do
+    oc = Base.Experimental.@opaque x -> 2x
+    call_someoc(Some(oc), 1)
+end == Int
+# A somewhat artificial example, but a test case that exercises the above code path without
+# using `OpaqueClosure`
+struct UntypedBoxWithParam{T}
+    x::Some{Any}
+    UntypedBoxWithParam{T}(x) where T = new{T}(Some{Any}(x))
+end
+readbox(box::UntypedBoxWithParam) = box.x.value
+@test Base.infer_return_type((Type,Int)) do T, x
+    readbox(UntypedBoxWithParam{T}(x))
+end == Int
+
 end # module inference


### PR DESCRIPTION
`abstract_eval_new` previously gated `PartialStruct` formation on `isconcretedispatch(rt)`. That's correct for fully-instantiated concrete struct construction, but it discards extended lattice information when `rt` is a partially-instantiated parametric type, e.g. `Some{OpaqueClosure{Tuple{Any}, T} where T}` or
`Generator{Vector{Int}, F<:OpaqueClosure{Tuple{Int}, T} where T}`. Such types still have a well-defined field count and field types, so the per-field lattice elements (`PartialOpaque`, `Const`, `PartialStruct` of nested structs, …) carry strictly more precision than the declared field types — but without `PartialStruct` formation that precision is discarded at the construction site, and downstream `getfield` reads only recover the widened type.

Loosen the gate to also accept the parametric case (`fcount !== nothing && nargs ≤ fcount`). `nothrow` and the `Const`-folding fast path remain gated on `isconcretedispatch(rt)` — those genuinely require the concrete result type — and the new non-concretedispatch arm falls back to `refine_partial_type(rt)` when no field refinement happens, mirroring the outer `else` branch.

This complements the eager-body rt refinement
(`abstract_eval_new_opaque_closure`) for an ongoing experiment in JETLS that runs inference statelessly against top-level chunks, where JETLS converts closures to opaque closures at re-lowering phase to workaround the closure name-resolution issues. Common code patterns wrap a closure in another struct (e.g. `map`'s implementation), and without this change the wrapping erased the `PartialOpaque` info, so a later call recovered only the widened `OpaqueClosure{argt, T} where T` and `abstract_call_unknown`'s OC fallback widened the result to `T<:Any`. With this change the `PartialStruct` carries the `PartialOpaque` field through in such cases, so the reading `getfield` hands `abstract_call_opaque_closure` the precise lattice element it needs.