### PR TITLE
Serialization: fast path for `serialize(_, ::Union)`

### DIFF
--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -493,6 +493,12 @@ function serialize(s::AbstractSerializer, linfo::Core.MethodInstance)
     nothing
 end
 
+function serialize(s::AbstractSerializer, @nospecialize(u::Union))
+    serialize_type(s, Union, false)
+    serialize(s, u.a)
+    serialize(s, u.b)
+end
+
 function serialize(s::AbstractSerializer, t::Task)
     serialize_cycle(s, t) && return
     if istaskstarted(t) && !istaskdone(t)

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -211,6 +211,18 @@ create_serialization_stream() do s # immutable struct with 4 field
     @test invokelatest(deserialize, s) === utval
 end
 
+create_serialization_stream() do s # union types
+    serialize(s, Union{Int,Float64})
+    serialize(s, Union{Int,Missing})
+    serialize(s, Union{Int,Float64,String})
+    serialize(s, [Union{Int,Float64}, Union{String,Symbol}, Union{Int,Missing}])
+    seek(s, 0)
+    @test deserialize(s) === Union{Int,Float64}
+    @test deserialize(s) === Union{Int,Missing}
+    @test deserialize(s) === Union{Int,Float64,String}
+    @test deserialize(s) == Type[Union{Int,Float64}, Union{String,Symbol}, Union{Int,Missing}]
+end
+
 # Expression
 create_serialization_stream() do s
     expr = Meta.parse("a = 1")


### PR DESCRIPTION
fixes https://github.com/JuliaLang/julia/issues/58007

PR:
```julia
julia> using Serialization, BenchmarkTools, LinearAlgebra

julia> const sig = Base.unwrap_unionall(methods(LinearAlgebra.herk_wrapper!).ms[1].sig);

julia> const sig_bytes = (io = IOBuffer(); serialize(io, sig); take!(io));

julia> @benchmark serialize(IOBuffer(), $sig)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  141.166 μs …  2.343 ms  ┊ GC (min … max): 0.00% … 92.20%
 Time  (median):     142.625 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   144.458 μs ± 22.477 μs  ┊ GC (mean ± σ):  0.15% ±  0.92%

 Memory estimate: 13.95 KiB, allocs estimate: 253.

julia> @benchmark deserialize(IOBuffer($sig_bytes))
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):   97.292 μs …  7.686 ms  ┊ GC (min … max): 0.00% … 97.60%
 Time  (median):      99.083 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   102.759 μs ± 99.222 μs  ┊ GC (mean ± σ):  1.58% ±  1.68%

 Memory estimate: 34.73 KiB, allocs estimate: 744.
```

master:
```julia
julia> const sig_bytes = (io = IOBuffer(); serialize(io, sig); take!(io))
# wait 10 minutes then give up
^C^C^C^C^C^CWARNING: Force throwing a SIGINT
ERROR: InterruptException:
```