### PR TITLE
Serialization: re-unroll small tuples for deser

### DIFF
--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1012,7 +1012,13 @@ function deserialize_symbol(s::AbstractSerializer, len::Int)
     return sym
 end
 
-deserialize_tuple(s::AbstractSerializer, len) = ntupleany(i->deserialize(s), len)
+function deserialize_tuple(s::AbstractSerializer, len)
+    len == 0 && return ()
+    Base.Cartesian.@nexprs 10 i -> begin
+        len == i && return (Base.Cartesian.@ntuple i _ -> deserialize(s))
+    end
+    return ntupleany(i -> deserialize(s), len)
+end
 
 function deserialize_svec(s::AbstractSerializer)
     n = read(s.io, Int32)


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/37163 changed `deserialize_tuple(s::AbstractSerializer, len) ` from `ntuple` to `ntupleany` to avoid union-eltyped `Vectors` in inference.

but for performance benefit, we can unroll small tuples and avoid `Vector` entirely.

```julia
julia> using Serialization, BenchmarkTools;

julia> const v = [(rand(Int), rand(Float64), "$i") for i in 1:100_000];

julia> const bytes = take!((io = IOBuffer(); serialize(io, v); io));

# master
julia> @benchmark deserialize(IOBuffer($bytes))
BenchmarkTools.Trial: 199 samples with 1 evaluation per sample.
 Range (min … max):  19.923 ms … 106.647 ms  ┊ GC (min … max):  0.00% … 80.91%
 Time  (median):     20.438 ms               ┊ GC (median):     0.00%
 Time  (mean ± σ):   25.131 ms ±  17.401 ms  ┊ GC (mean ± σ):  18.69% ± 17.64%

 Memory estimate: 19.58 MiB, allocs estimate: 600015.

# PR
julia> @benchmark deserialize(IOBuffer($bytes))
BenchmarkTools.Trial: 311 samples with 1 evaluation per sample.
 Range (min … max):  10.255 ms … 177.119 ms  ┊ GC (min … max):  0.00% … 88.61%
 Time  (median):     10.422 ms               ┊ GC (median):     0.00%
 Time  (mean ± σ):   16.059 ms ±  19.547 ms  ┊ GC (mean ± σ):  24.13% ± 17.89%

 Memory estimate: 11.95 MiB, allocs estimate: 400015.
```