### PR TITLE
subtype: Don't accumulate diagonal rule uses in consistency check

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -741,7 +741,18 @@ static int subtype_ccheck(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
     if (obviously_in_union(y, x))
         return 1;
     jl_saved_unionstate_t oldLunions; push_unionstate(&oldLunions, &e->Lunions);
+    // Save occurrence counts (occurs_inv/cov, max_offset) so the consistency
+    // check doesn't perturb the diagonal-rule accounting. We must NOT restore
+    // Runions.depth here: local_forall_exists_subtype does not restore it on
+    // success, and forcibly resetting it would put it out of sync with the
+    // Runions stack contents.
+    jl_savedenv_t se;
+    save_env(e, &se, 0);
     int sub = local_forall_exists_subtype(x, y, e, PARAM_NONE, 1);
+    int rdepth = e->Runions.depth;
+    restore_env(e, &se, 0);
+    e->Runions.depth = rdepth;
+    free_env(&se);
     pop_unionstate(&e->Lunions, &oldLunions);
     return sub;
 }
@@ -2367,7 +2378,7 @@ JL_DLLEXPORT int jl_subtype_env(jl_value_t *x, jl_value_t *y, jl_value_t **env, 
         obvious_subtype = 3;
     }
     init_stenv(&e, env, envsz);
-    int subtype = forall_exists_subtype(x, y, &e, PARAM_NONE);
+    int subtype = forall_exists_subtype(x, y, &e, PARAM_COVARIANT);
     free_stenv(&e);
     assert(obvious_subtype == 3 || obvious_subtype == subtype || jl_has_free_typevars(x) || jl_has_free_typevars(y));
 #ifndef NDEBUG
@@ -2460,7 +2471,7 @@ JL_DLLEXPORT int jl_types_equal(jl_value_t *a, jl_value_t *b)
 #endif
     {
         init_stenv(&e, NULL, 0);
-        int subtype = forall_exists_subtype(a, b, &e, PARAM_NONE);
+        int subtype = forall_exists_subtype(a, b, &e, PARAM_COVARIANT);
         free_stenv(&e);
         assert(subtype_ab == 3 || subtype_ab == subtype || jl_has_free_typevars(a) || jl_has_free_typevars(b));
 #ifndef NDEBUG
@@ -2477,7 +2488,7 @@ JL_DLLEXPORT int jl_types_equal(jl_value_t *a, jl_value_t *b)
 #endif
     {
         init_stenv(&e, NULL, 0);
-        int subtype = forall_exists_subtype(b, a, &e, PARAM_NONE);
+        int subtype = forall_exists_subtype(b, a, &e, PARAM_COVARIANT);
         free_stenv(&e);
         assert(subtype_ba == 3 || subtype_ba == subtype || jl_has_free_typevars(a) || jl_has_free_typevars(b));
 #ifndef NDEBUG

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1237,11 +1237,11 @@ let a = Tuple{Float64,T3,T4} where T4 where T3,
     b = Tuple{S2,Tuple{S3},S3} where S2 where S3
     I1 = typeintersect(a, b)
     I2 = typeintersect(b, a)
-    @test_broken I1 <: I2
+    @test I1 <: I2
     @test I2 <: I1
     @test I1 <: a
     @test I2 <: a
-    @test_broken I1 <: b
+    @test I1 <: b
     @test I2 <: b
 end
 let a = Tuple{T1,Tuple{T1}} where T1,
@@ -1259,11 +1259,11 @@ let a = Tuple{5,T4,T5} where T4 where T5,
     b = Tuple{S2,S3,Tuple{S3}} where S2 where S3
     I1 = typeintersect(a, b)
     I2 = typeintersect(b, a)
-    @test_broken I1 <: I2
+    @test I1 <: I2
     @test I2 <: I1
     @test I1 <: a
     @test I2 <: a
-    @test_broken I1 <: b
+    @test I1 <: b
     @test I2 <: b
 end
 let a = Tuple{T2,Tuple{T4,T2}} where T4 where T2,
@@ -1274,11 +1274,11 @@ let a = Tuple{Tuple{T2,4},T6} where T2 where T6,
     b = Tuple{Tuple{S2,S3},Tuple{S2}} where S2 where S3
     I1 = typeintersect(a, b)
     I2 = typeintersect(b, a)
-    @test_broken I1 <: I2
+    @test I1 <: I2
     @test I2 <: I1
     @test I1 <: a
     @test I2 <: a
-    @test_broken I1 <: b
+    @test I1 <: b
     @test I2 <: b
 end
 let a = Tuple{T3,Int64,Tuple{T3}} where T3,


### PR DESCRIPTION
The consistency check is necessary to ensure that a particular substitution is legal (and can contribute to narrowing bounds on existential vars), but is not technically "part" of the subtype query that counts for purposes of the diagonal rule. Reset the appropriate counts around the query. Fixes several tests previously marked as broken.

Written by me with bugfix by Claude.