### PR TITLE
Add uuid7 to UUIDs documentation

### DIFF
--- a/stdlib/UUIDs/docs/src/index.md
+++ b/stdlib/UUIDs/docs/src/index.md
@@ -8,5 +8,6 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/UUIDs/docs/src/
 UUIDs.uuid1
 UUIDs.uuid4
 UUIDs.uuid5
+UUIDs.uuid7
 UUIDs.uuid_version
 ```


### PR DESCRIPTION
The uuid7 is implemented but is missing from the documentation. Added the documentation.