### PR TITLE
optimizer: apply `unwrap_unionall` after `widenconst` in `sroa_mutables!`

### DIFF
--- a/Compiler/src/ssair/passes.jl
+++ b/Compiler/src/ssair/passes.jl
@@ -1815,10 +1815,9 @@ function sroa_mutables!(ir::IRCode, defuses::IdDict{Int,Tuple{SPCSet,SSADefUse}}
         # Find the type for this allocation
         defexpr = ir[SSAValue(defidx)][:stmt]
         isexpr(defexpr, :new) || continue
-        typ = unwrap_unionall(ir.stmts[defidx][:type])
         # Could still end up here if we tried to setfield! on an immutable, which would
         # error at runtime, but is not illegal to have in the IR.
-        typ = widenconst(typ)
+        typ = unwrap_unionall(widenconst(ir.stmts[defidx][:type]))
         ismutabletype(typ) || continue
         typ = typ::DataType
         # Check if there are any uses we did not account for. If so, the variable

--- a/Compiler/test/irpasses.jl
+++ b/Compiler/test/irpasses.jl
@@ -1337,6 +1337,19 @@ end
 @test wrap1_wrap1_wrapper(true, 1, 1.0) === 1.0
 @test wrap1_wrap1_wrapper(false, 1, 1.0) === 1
 
+# Regression test for #61740: `sroa_mutables!` previously asserted
+# `widenconst(:type)::DataType`, which broke after #61719 extended
+# `PartialStruct` to wrap parametric (UnionAll) types from `:new`.
+mutable struct MutBox61740{T}
+    const x::Some{Any}
+    y::Int
+    MutBox61740{T}(x, y) where T = new{T}(Some{Any}(x), y)
+end
+read_mutbox61740(box::MutBox61740) = box.x.value
+@test Base.infer_return_type((Type, Int)) do T, x
+    read_mutbox61740(MutBox61740{T}(x, 0))
+end === Int
+
 # Test unswitching-union optimization within SRO Apass
 function sroaunswitchuniontuple(c, x1, x2)
     t = c ? (x1,) : (x2,)


### PR DESCRIPTION
`sroa_mutables!` derived the allocation `DataType` by calling `unwrap_unionall` on the raw lattice element of a `:new` and only then widening it. That order was incorrect: `unwrap_unionall` is meaningful on a plain `Type`, not on any extended lattice elements (e.g., `PartialStruct` whose `.typ` may itself be a `UnionAll`), so when inference produced a `PartialStruct`-typed `:new` the unwrap was a no-op and the subsequent `typ::DataType` typeassert could fail on a `UnionAll`. Reorder so `widenconst` runs first.

This was latent since `Core.PartialStruct` was extended to admit `UnionAll` for `.typ` (#57304), and surfaced as a typeassert crash via #61719, which made `:new` actually emit such `PartialStruct`s.

I also directed an AI-driven audit of related sites — every place under `Compiler/src/` that derives a `DataType` from a lattice element which could be a `PartialStruct` (passes, inlining, EscapeAnalysis, tfuncs, typelattice) — and confirmed the rest already use `unwrap_unionall(widenconst(...))` or guard with explicit `isa(_, DataType)` / `argument_datatype` checks, so no other site needs the same reordering.

Both the diagnosis and the patch were developed with the assistance of generative AI.

Fixes #61740