### PR TITLE
inference: unwrap `PartialStruct` typ in `precise_container_type` fast path

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -1624,7 +1624,7 @@ AbstractIterationResult(cti::Vector{Any}, info::MaybeAbstractIterationInfo) =
 function precise_container_type(interp::AbstractInterpreter, @nospecialize(itft), @nospecialize(typ),
                                 vtypes::Union{VarTable,Nothing}, sv::AbsIntState)
     if isa(typ, PartialStruct)
-        widet = typ.typ
+        widet = unwrap_unionall(typ.typ)
         if isa(widet, DataType)
             if widet.name === Tuple.name
                 return Future(AbstractIterationResult(typ.fields, nothing))


### PR DESCRIPTION
`PartialStruct.typ` may be a `UnionAll` (parametric `Tuple`/`NamedTuple` produced via `:new`), in which case the `isa(_, DataType)` gate misses and we fall through to the generic path, discarding the precise per-field info in `typ.fields`. Unwrap so the fast path engages.

Found as a minor improvement opportunity during the audit done for JuliaLang/julia#61743. No current code path is known to reach this with a UnionAll `PartialStruct`, so the change is defensive (thus no tests are added).