### PR TITLE
Allow setting the various optimization options on methods (as opposed to Modules)

### DIFF
--- a/Compiler/src/precompile.jl
+++ b/Compiler/src/precompile.jl
@@ -356,10 +356,13 @@ function compile_and_emit_native(worlds::Vector{UInt},
     for mod in module_init_order
         if Core.invoke_in_world(latestworld, isdefined, mod, :__init__)
             f = Core.invoke_in_world(latestworld, getglobal, mod, :__init__)
-            # Get module compile setting
-            setting = ccall(:jl_get_module_compile, Cint, (Any,), mod)
+            tt = Tuple{Core.Typeof(f)}
+            # Get the per-method compile setting (falls back to the module's)
+            match, _ = findsup(tt, InternalMethodTable(latestworld))
+            setting = match === nothing ?
+                ccall(:jl_get_module_compile, Cint, (Any,), mod) :
+                ccall(:jl_get_method_compile, Cint, (Any,), match.method)
             if setting != JL_OPTIONS_COMPILE_OFF && setting != JL_OPTIONS_COMPILE_MIN
-                tt = Tuple{Core.Typeof(f)}
                 compile_hint(tt)
                 trim_mode == 0x00 || add_entrypoint(tt)
             end

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1143,6 +1143,19 @@ function _schedule_edge_infer_task!(caller::AbsIntState, frame::InferenceState, 
     return mresult
 end
 
+# Whether inference is enabled for `mi`. For a generated function, a
+# per-expansion `Expr(:meta, Expr(:infer, n))` recorded in the generated
+# CodeInfo overrides the method/module-level setting.
+function infer_enabled(interp::AbstractInterpreter, mi::MethodInstance, method::Method)
+    if hasgenerator(method)
+        src = get_staged(mi, get_inference_world(interp))
+        if src isa CodeInfo && src.infer != 0xff
+            return src.infer != 0x00
+        end
+    end
+    return ccall(:jl_get_method_infer, Cint, (Any,), method) != 0
+end
+
 # compute (and cache) an inferred AST and return the current best estimate of the result type
 function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize(atype), sparams::SimpleVector, caller::AbsIntState, edgecycle::Bool, edgelimited::Bool)
     mi = specialize_method(method, atype, sparams)
@@ -1177,8 +1190,8 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
             end
         end
     end
-    if !InferenceParams(interp).force_enable_inference && ccall(:jl_get_module_infer, Cint, (Any,), method.module) == 0
-        add_remark!(interp, caller, "[typeinf_edge] Inference is disabled for the target module")
+    if !InferenceParams(interp).force_enable_inference && !infer_enabled(interp, mi, method)
+        add_remark!(interp, caller, "[typeinf_edge] Inference is disabled for the target method")
         return Future(MethodCallResult(interp, caller, method, Any, Any, Effects(), nothing, edgecycle, edgelimited))
     end
     if !is_cached(caller) && frame_parent(caller) === nothing
@@ -1517,7 +1530,7 @@ function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance, source_mod
         end
     end
     if !InferenceParams(interp).force_enable_inference
-        if isa(def, Method) && ccall(:jl_get_module_infer, Cint, (Any,), def.module) == 0
+        if isa(def, Method) && !infer_enabled(interp, mi, def)
             src = retrieve_code_info(mi, get_inference_world(interp))
             if src isa CodeInfo
                 finish!(interp, mi, ci, src)

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -437,27 +437,62 @@ function _mangle_writeonly(st, seen)
     end
 end
 
-# nothing if not found, or symbol if 0-arg [no]specialize, or dict arg->meta
-function collect_body_arg_meta(st)
-    out = nothing
+# Scan leading meta statements of a function body (only those are recognized
+# in lowering; ideally meta after non-meta statements would be an error).
+# Returns:
+# - arg [no]specialize meta: nothing if not found, symbol if 0-arg, or dict
+#   arg->meta, to be absorbed into the arglist by `apply_arglist_meta`
+# - method metas that desugaring must copy onto generated wrapper methods
+#   (like flisp's `propagate-method-meta`): inlining and constprop
+#   annotations, effects overrides, and per-method compiler options
+function collect_body_meta(st)
+    argmeta_all = nothing
+    argmeta = nothing
+    mmetas = nothing
     for c in children(st)
-        k = kind(c)
-        @stm c begin
-            [K"meta" [K"Identifier"] idents...] -> begin
-                meta = Symbol(c[1].name_val::String)
-                meta in (:specialize, :nospecialize) || continue
-                length(idents) == 0 && return meta
-                isnothing(out) && (out = Dict{String, Symbol}())
-                for id in idents
-                    kind(id) === K"Identifier" && (out[id.name_val] = meta)
+        kind(c) === K"meta" || break
+        spec = numchildren(c) >= 1 && kind(c[1]) === K"Identifier" ?
+            c[1].name_val::String : ""
+        if spec in ("specialize", "nospecialize")
+            meta = Symbol(spec)
+            if numchildren(c) == 1
+                isnothing(argmeta_all) && (argmeta_all = meta)
+            else
+                isnothing(argmeta) && (argmeta = Dict{String, Symbol}())
+                for id in c[2:end]
+                    kind(id) === K"Identifier" && (argmeta[id.name_val] = meta)
                 end
             end
-            # Only leading meta statements are recognized in lowering.  Ideally
-            # meta after non-meta statements would be an error.
-            _ -> break
+            continue
+        end
+        for m in children(c)
+            km = kind(m)
+            if km in KSet"purity optlevel compile infer"
+                isnothing(mmetas) && (mmetas = SyntaxList(st._graph))
+                push!(mmetas, m)
+            elseif (km === K"Identifier" || km === K"Symbol") &&
+                    m.name_val::String in ("inline", "noinline",
+                        "propagate_inbounds", "aggressive_constprop",
+                        "no_constprop")
+                isnothing(mmetas) && (mmetas = SyntaxList(st._graph))
+                push!(mmetas, km === K"Symbol" ? m :
+                    setattr(m, :kind, K"Symbol"))
+            end
         end
     end
-    out
+    (isnothing(argmeta_all) ? argmeta : argmeta_all), mmetas
+end
+
+# Convert a function body, handling `if @generated` and attaching collected
+# method metas for desugaring to find.
+function _dst_function_body(g, st, r, method_metas)
+    r2 = if has_if_generated(r)
+        gen, nongen = split_generated(r, true), split_generated(r, false)
+        @ast g st [K"_generated_body" [K"syntaxquote" gen] est_to_dst(nongen)]
+    else
+        est_to_dst(r)
+    end
+    isnothing(method_metas) ? r2 : setmeta(r2, :method_metas, method_metas)
 end
 
 """
@@ -574,41 +609,33 @@ function est_to_dst(st::SyntaxTree)
             @ast g st [K"generator" rec(body) _dst_iterspec(st, iters)]
         ([K"=" l r], when=(is_eventually_call(l))) -> let
             # no fix_arglist needed, since this func can't be anonymous
-            l = apply_arglist_meta(l, collect_body_arg_meta(r))
-            l = force_readable_sparams(l)
-            if has_if_generated(r)
-                gen, nongen = split_generated(r, true), split_generated(r, false)
-                r2 = @ast g st [K"_generated_body" [K"syntaxquote" gen] rec(nongen)]
-            else
-                r2 = rec(r)
-            end
-            @ast g st [K"function" rec(l) r2]
+            arg_meta, method_metas = collect_body_meta(r)
+            l = force_readable_sparams(apply_arglist_meta(l, arg_meta))
+            @ast g st [K"function"
+                rec(l)
+                _dst_function_body(g, st, r, method_metas)]
         end
         [K"function" l r] -> let
-            l = apply_arglist_meta(_dst_fix_arglist(l), collect_body_arg_meta(r))
-            l = force_readable_sparams(l)
-            if has_if_generated(r)
-                gen, nongen = split_generated(r, true), split_generated(r, false)
-                r2 = @ast g st [K"_generated_body" [K"syntaxquote" gen] rec(nongen)]
-            else
-                r2 = rec(r)
-            end
-            @ast g st [K"function" rec(l) r2]
+            arg_meta, method_metas = collect_body_meta(r)
+            l = force_readable_sparams(
+                apply_arglist_meta(_dst_fix_arglist(l), arg_meta))
+            @ast g st [K"function"
+                rec(l)
+                _dst_function_body(g, st, r, method_metas)]
         end
         [K"->" l r] -> let
-            l = apply_arglist_meta(_dst_fix_arglist(l), collect_body_arg_meta(r))
-            l = force_readable_sparams(l)
-            if has_if_generated(r)
-                gen, nongen = split_generated(r, true), split_generated(r, false)
-                r2 = @ast g st [K"_generated_body" [K"syntaxquote" gen] rec(nongen)]
-            else
-                r2 = rec(r)
-            end
-            @ast g st [K"->" rec(l) r2]
+            arg_meta, method_metas = collect_body_meta(r)
+            l = force_readable_sparams(
+                apply_arglist_meta(_dst_fix_arglist(l), arg_meta))
+            @ast g st [K"->"
+                rec(l)
+                _dst_function_body(g, st, r, method_metas)]
         end
         [K"macro" l r] -> let
-            l = apply_arglist_meta(l, collect_body_arg_meta(r))
-            @ast g st [K"macro" rec(l) rec(r)]
+            arg_meta, method_metas = collect_body_meta(r)
+            r2 = rec(r)
+            isnothing(method_metas) || (r2 = setmeta(r2, :method_metas, method_metas))
+            @ast g st [K"macro" rec(apply_arglist_meta(l, arg_meta)) r2]
         end
         [K"do" [K"call" f args...] lam] -> let
             @ast g st [K"call" rec(f) rec(lam) _dst_sink_parameters(args)...]

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2435,7 +2435,7 @@ end
 # desugarable AST to macro AST.  Fortunately there are only two places (meta
 # nkw, and destructuring arg assignments) we do this, so handle them manually.
 function prepend_function_body(ctx, body, ex)
-    @stm body begin
+    out = @stm body begin
         [K"_generated_body" [K"syntaxquote" gen] nongen] -> begin
             ex_est = @stm ex begin
                 [K"meta" [K"Symbol"] n] ->
@@ -2450,6 +2450,9 @@ function prepend_function_body(ctx, body, ex)
         end
         _ -> @ast ctx body [K"block" ex body]
     end
+    # keep :method_metas etc. visible to wrapper method generation
+    hasattr(body, :meta) && setattr!(out, :meta, body.meta)
+    out
 end
 
 # Produce all `method` exprs for the given `argl`
@@ -2594,6 +2597,9 @@ function optional_positional_defs(ctx, src, mtable, sparams, argl, body, rett)
     end
     req = pos_req_args(argl)
     passed = copy(req)
+    # collected by `collect_body_meta` in compat.jl, like flisp's
+    # `propagate-method-meta`
+    prop_metas = getmeta(body, :method_metas, nothing)
     methods = SyntaxList(ctx.graph)
     for i in eachindex(opt)
         @jl_assert i == length(passed)-length(req)+1 src
@@ -2602,10 +2608,12 @@ function optional_positional_defs(ctx, src, mtable, sparams, argl, body, rett)
             # splat, and doesn't have further args referring to it by name, so
             # we put it directly in the call (see #50563 for some notes)
             @ast ctx src [K"block"
+                isnothing(prop_metas) ? nothing : [K"meta" prop_metas...]
                 make_assigns(ctx, opt_names[i:end-1], opt_defaults[i:end-1])...
                 [K"call" mapindex(passed, 1)... opt_names[i:end-1]... opt_defaults[end]]]
         else
             @ast ctx src [K"block"
+                isnothing(prop_metas) ? nothing : [K"meta" prop_metas...]
                 [K"call" mapindex(passed, 1)... opt_defaults[i]]]
         end
         # this function and method_def_expr need sp bounds because of this
@@ -2688,6 +2696,10 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett)
     (kw_decls, kw_names, kw_syms, kw_defaults, restkw) = expand_kw_args(ctx, kws)
     ordered_defaults = any(val->contains_identifier(val, kw_names), kw_defaults)
     pos_sparams = used_typevars(pargl, sparams)
+    # collected by `collect_body_meta` in compat.jl; also re-attach the
+    # attribute to the sorter bodies below since they go through
+    # `method_def_expr` again when there are optional positional args
+    prop_metas = getmeta(body, :method_metas, nothing)
 
     m1_name = let n = kind(mtable) === K"nothing" ? "_" : mtable.name_val,
         mangled = reserve_module_binding_i(
@@ -2720,9 +2732,13 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett)
             scope_nest(ctx, make_assigns(ctx, kw_names, kw_defaults),
                 @ast ctx src [K"call" m1_name kw_names... rkw forward_pargl...])
         end
+        nokw_body = @ast(ctx, src, [K"block"
+            isnothing(prop_metas) ? nothing : [K"meta" prop_metas...]
+            [K"return" body2]])
+        isnothing(prop_metas) ||
+            (nokw_body = setmeta(nokw_body, :method_metas, prop_metas))
         method_def_expr(
-            ctx, src, mtable, pos_sparams, pargl,
-            @ast(ctx, src, [K"block" [K"return" body2]]))
+            ctx, src, mtable, pos_sparams, pargl, nokw_body)
     end
     # (3) Core.kwcall(arg2::NamedTuple, pargl...) methods (one per optarg).
     # - for each kwarg:
@@ -2799,6 +2815,11 @@ function keywords_method_def_expr(ctx, src, mtable, sparams, argl, body, rett)
         else
             scope_nest(ctx, kw_assigns,
                        @ast ctx src [K"block" handle_excess final_call])
+        end
+        if !isnothing(prop_metas)
+            kwcall_body = setmeta(@ast(ctx, src, [K"block"
+                [K"meta" prop_metas...]
+                kwcall_body]), :method_metas, prop_metas)
         end
         # Core.kwcall method has its own first argument.  Ensure closure
         # conversion knows not to put the closure there.

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -196,15 +196,18 @@ else
         fts = fieldtypes(Core.CodeInfo)
         conversions = [:(convert($t, $n)) for (t,n) in zip(fts, fns)]
 
-        expected_fns = (:code, :debuginfo, :ssavaluetypes, :ssaflags, :slotnames, :slotflags, :slottypes, :rettype, :parent, :edges, :min_world, :max_world, :method_for_inference_limit_heuristics, :nargs, :propagate_inbounds, :has_fcall, :has_image_globalref, :nospecializeinfer, :isva, :inlining, :constprop, :purity, :inlining_cost)
-        expected_fts = (Vector{Any}, Core.DebugInfo, Any, Vector{UInt32}, Vector{Symbol}, Vector{UInt8}, Any, Any, Any, Any, UInt, UInt, Any, UInt, Bool, Bool, Bool, Bool, Bool, UInt8, UInt8, UInt16, UInt16)
+        expected_fns = (:code, :debuginfo, :ssavaluetypes, :ssaflags, :slotnames, :slotflags, :slottypes, :rettype, :parent, :edges, :min_world, :max_world, :method_for_inference_limit_heuristics, :nargs, :propagate_inbounds, :has_fcall, :has_image_globalref, :nospecializeinfer, :isva, :inlining, :constprop, :purity, :optlevel, :compile, :infer, :inlining_cost)
+        expected_fts = (Vector{Any}, Core.DebugInfo, Any, Vector{UInt32}, Vector{Symbol}, Vector{UInt8}, Any, Any, Any, Any, UInt, UInt, Any, UInt, Bool, Bool, Bool, Bool, Bool, UInt8, UInt8, UInt16, UInt8, UInt8, UInt8, UInt16)
+
         code = if fns != expected_fns || fts != expected_fts
+            unexpected_fns = collect(setdiff(Set(fns), Set(expected_fns)))
+            missing_fns = collect(setdiff(Set(expected_fns), Set(fns)))
             :(function _CodeInfo(args...)
                   error(string(
                       "JuliaLowering didn't recognize Core.CodeInfo's fields; ",
                       "it may need updating to match Core.CodeInfo.\n",
-                      "expected field names: $($expected_fns)\n",
-                      "expected field types: $($expected_fts)\n"))
+                      "unexpected fields: $($unexpected_fns)\n",
+                      "missing fields: $($missing_fns)\n"))
               end)
         else
             :(function _CodeInfo($(fns...))
@@ -585,6 +588,9 @@ function to_code_info(ex::SyntaxTree, slots::Vector{Slot}, meta::CompileHints)
     min_world           = Csize_t(1)
     max_world           = typemax(Csize_t)
     isva                = false
+    optlevel            = get(meta, :optlevel, 0xff)
+    compile             = get(meta, :compile, 0xff)
+    infer               = get(meta, :infer, 0xff)
     inlining_cost       = 0xffff
     rettype             = Any
 
@@ -613,6 +619,9 @@ function to_code_info(ex::SyntaxTree, slots::Vector{Slot}, meta::CompileHints)
         inlining,
         constprop,
         purity,
+        optlevel,
+        compile,
+        infer,
         inlining_cost
     )
 end
@@ -695,10 +704,12 @@ function _to_lowered_expr(ex::SyntaxTree)
         Expr(:opaque_closure_method, args...)
     elseif k == K"meta"
         args = Any[_to_lowered_expr(e) for e in children(ex)]
-        # Unpack K"Symbol" QuoteNode as `Expr(:meta)` requires an identifier here.
-        arg1 = args[1]
-        @jl_assert (arg1 isa QuoteNode) ex
-        args[1] = arg1.value
+        # Flat metas like `(meta :nospecialize ...)` carry an identifier as the
+        # first child, which `Expr(:meta)` wants unquoted; nested metas like
+        # `(meta (max_methods n))` instead carry an `Expr` and are left as-is.
+        if !isempty(args) && args[1] isa QuoteNode
+            args[1] = args[1].value
+        end
         Expr(:meta, args...)
     elseif k == K"foreignsymbol"
         @jl_assert kind(ex[1]) == K"tuple" ex
@@ -748,6 +759,13 @@ function _to_lowered_expr(ex::SyntaxTree)
                k == K"aliasscope"        ? :aliasscope        :
                k == K"popaliasscope"     ? :popaliasscope     :
                k == K"new_opaque_closure" ? :new_opaque_closure :
+               # Module-level compiler options survive lowering as `(meta ...)`
+               # statements for the interpreter to apply (only per-method
+               # optlevel/compile/infer are consumed into the CodeInfo).
+               k == K"max_methods"       ? :max_methods       :
+               k == K"optlevel"          ? :optlevel          :
+               k == K"compile"           ? :compile           :
+               k == K"infer"             ? :infer             :
                nothing
         if isnothing(head)
             throw(LoweringError(ex, "Unhandled form for kind $k"))

--- a/JuliaLowering/src/kinds.jl
+++ b/JuliaLowering/src/kinds.jl
@@ -25,6 +25,11 @@ function _register_kinds()
             "purity"
             "aliasscope"
             "popaliasscope"
+            # Per-method/module compiler options (see `Base.Experimental.@compiler_options`)
+            "optlevel"
+            "compile"
+            "infer"
+            "max_methods"
             # Call into foreign code
             "foreigncall"
             # Look up a symbol in foreign code

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -891,24 +891,38 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         nothing
     elseif k == K"meta"
         if numchildren(ex) >= 1
-            # Certain blessed forms are allowed to share a meta expression;
-            # others (nkw, optlevel) treat ex[1] as head and ex[2:end] as args
-            if kind(ex[1]) === K"purity" ||
-                kind(ex[1]) === K"Symbol" && ex[1].name_val::String in (
-                    "inline", "noinline", "propagate_inbounds",
-                    "nospecializeinfer", "aggressive_constprop", "no_constprop")
-                for c in children(ex)
-                    if kind(c) === K"purity"
-                        old = get(ctx.meta, :purity, UInt16(0))
-                        ctx.meta[:purity] = (old | purity_expr_to_flags(c))::UInt16
-                    elseif kind(c) === K"Symbol"
-                        ctx.meta[Symbol(c.name_val::String)] = true
-                    else
-                        @jl_assert false c
+            # Classify each child independently. A single `(meta ...)` node may
+            # mix kinds because `Base.pushmeta!` appends into one node (e.g.
+            # `@inline` combined with `@optlevel`). Compiler-option markers
+            # (optlevel/compile/infer, see `Base.Experimental.@compiler_options`)
+            # on a method are recorded in the CodeInfo; the blessed inline/purity
+            # markers are likewise consumed. Anything else -- module-level options
+            # in a top-level thunk, `max_methods`, or unrecognized markers -- is
+            # left as a `(meta ...)` statement so the interpreter applies it in
+            # its original control-flow position.
+            leftover = SyntaxList(ctx)
+            for c in children(ex)
+                kc = kind(c)
+                if kc in KSet"optlevel compile infer" && !ctx.is_toplevel_thunk
+                    # Malformed or out-of-range markers are dropped, matching the
+                    # C consumers which silently ignore them.
+                    v = numchildren(c) == 1 ? get(c[1], :value, nothing) : nothing
+                    if v isa Integer && 0 <= v <= (kc == K"infer" ? 1 : 3)
+                        ctx.meta[Symbol(untokenize(kc))] = v
                     end
+                elseif kc === K"purity"
+                    old = get(ctx.meta, :purity, UInt16(0))
+                    ctx.meta[:purity] = (old | purity_expr_to_flags(c))::UInt16
+                elseif kc === K"Symbol" && c.name_val::String in (
+                        "inline", "noinline", "propagate_inbounds",
+                        "nospecializeinfer", "aggressive_constprop", "no_constprop")
+                    ctx.meta[Symbol(c.name_val::String)] = true
+                else
+                    push!(leftover, c)
                 end
-            else
-                emit(ctx, ex)
+            end
+            if !isempty(leftover)
+                emit(ctx, @ast ctx ex [K"meta" leftover...])
             end
         end
         if needs_value

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -1296,6 +1296,11 @@ vst2(vcx::Validation2Context, st::SyntaxTree) = @stm st begin
         pass() : @fail(st, "wrong number of args to `purity` expression")
     [K"aliasscope"] -> pass()
     [K"popaliasscope"] -> pass()
+    # Per-method/module compiler options (see `Base.Experimental.@compiler_options`)
+    [K"optlevel" x] -> vst2(vcx, x)
+    [K"compile" x] -> vst2(vcx, x)
+    [K"infer" x] -> vst2(vcx, x)
+    [K"max_methods" x] -> vst2(vcx, x)
 
     [K"always_defined" x] -> vst2_ident(vcx, x)
     [K"assert" [K"Symbol"] x] -> vst2(vcx, x)

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -1926,6 +1926,35 @@ end
     """)
     @test Base.Experimental.get_optlevel(only(methods(test_mod._test_opts_mixed))) == 0
 
+    # Per-method options and other method annotations propagate from the body
+    # to positional-default wrappers and the `Core.kwcall` sorter (matching
+    # flisp's `propagate-method-meta`).
+    JuliaLowering.include_string(test_mod, raw"""
+    Base.Experimental.@optlevel 0 @inline function _test_opts_kw(x::Int, y::Int=1; k::Int=2)
+        x + y + k
+    end
+    """)
+    fkw = test_mod._test_opts_kw
+    @test fkw(1) == 4
+    for m in (which(fkw, (Int,)), which(fkw, (Int, Int)),
+              which(Core.kwcall, (NamedTuple{(:k,), Tuple{Int}}, typeof(fkw), Int)))
+        @test Base.Experimental.get_optlevel(m) == 0
+        @test Base.uncompressed_ast(m).inlining == 0x01
+    end
+
+    # ... including when destructuring-arg assignments are prepended to the body
+    JuliaLowering.include_string(test_mod, raw"""
+    @inline function _test_opts_destr((a, b)::Tuple{Int,Int}, y::Int=1; k::Int=2)
+        a + b + y + k
+    end
+    """)
+    fd = test_mod._test_opts_destr
+    @test fd((1, 2)) == 6
+    for m in (which(fd, (Tuple{Int,Int},)), which(fd, (Tuple{Int,Int}, Int)),
+              which(Core.kwcall, (NamedTuple{(:k,), Tuple{Int}}, typeof(fd), Tuple{Int,Int})))
+        @test Base.uncompressed_ast(m).inlining == 0x01
+    end
+
     # Module-level options are emitted as statements and applied by the
     # interpreter; one in a non-taken branch is not applied.
     mod_cond = Module()

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -1876,3 +1876,64 @@ end
     @test !isdefined(test_mod, :a)
     @test !isdefined(macro_mod, :a)
 end
+
+# Per-method compiler options set via @compiler_options / @optlevel on a function
+# definition are recorded in the lowered CodeInfo and on the resulting Method.
+@testset "compiler options" begin
+    JuliaLowering.include_string(test_mod, raw"""
+    begin
+        Base.Experimental.@compiler_options optimize=0 function _test_opts_fn1(x)
+            x + 1
+        end
+        Base.Experimental.@compiler_options compile=min function _test_opts_fn2(x)
+            x + 1
+        end
+        Base.Experimental.@compiler_options infer=false function _test_opts_fn3(x)
+            x + 1
+        end
+        Base.Experimental.@compiler_options optimize=2 compile=min infer=true function _test_opts_fn5(x)
+            x + 1
+        end
+        Base.Experimental.@optlevel 1 function _test_opts_fn6(x)
+            x + 1
+        end
+        _test_opts_fn7(x) = x + 1
+    end
+    """)
+    @test Base.Experimental.get_optlevel(only(methods(test_mod._test_opts_fn1))) == 0
+    @test Base.Experimental.get_compile(only(methods(test_mod._test_opts_fn2))) == 3
+    @test Base.Experimental.get_infer(only(methods(test_mod._test_opts_fn3))) == 0
+
+    m5 = only(methods(test_mod._test_opts_fn5))
+    @test Base.Experimental.get_optlevel(m5) == 2
+    @test Base.Experimental.get_compile(m5) == 3
+    @test Base.Experimental.get_infer(m5) == 1
+
+    @test Base.Experimental.get_optlevel(only(methods(test_mod._test_opts_fn6))) == 1
+
+    # Unset options inherit from the enclosing module (-1 == module default)
+    m7 = only(methods(test_mod._test_opts_fn7))
+    @test Base.Experimental.get_compile(m7) == -1
+    @test Base.Experimental.get_infer(m7) == -1
+
+    # A compiler option combined with another annotation (`@inline`) shares a
+    # single `(meta ...)` node because `pushmeta!` merges them; each child must
+    # be classified independently.
+    JuliaLowering.include_string(test_mod, raw"""
+    Base.Experimental.@optlevel 0 @inline function _test_opts_mixed(x)
+        x + 1
+    end
+    """)
+    @test Base.Experimental.get_optlevel(only(methods(test_mod._test_opts_mixed))) == 0
+
+    # Module-level options are emitted as statements and applied by the
+    # interpreter; one in a non-taken branch is not applied.
+    mod_cond = Module()
+    JuliaLowering.include_string(mod_cond, raw"""
+    cond = false
+    if cond
+        Base.Experimental.@optlevel 0
+    end
+    """)
+    @test ccall(:jl_get_module_optlevel, Cint, (Any,), mod_cond) == -1
+end

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -120,9 +120,81 @@ Supported values are 0, 1, 2, and 3.
 The effective optimization level is the minimum of that specified on the
 command line and in per-module settings. If a `--min-optlevel` value is
 set on the command line, that is enforced as a lower bound.
+
+When applied to a function definition, sets the optimization level for
+that specific method rather than the enclosing module:
+
+```julia
+Experimental.@optlevel 0 function my_function(x)
+    ...
+end
+```
+
+When used inside a function body (without a function definition argument),
+sets the optimization level for the enclosing method:
+
+```julia
+function my_function(x)
+    Experimental.@optlevel 0
+    ...
+end
+```
 """
+# A function definition with a body that compiler-option metas can attach to
+# (excludes bare declarations like `function f end`).
+function is_annotatable_function_def(@nospecialize ex)
+    inner = Base.unwrap_macrocalls(ex)
+    return is_function_def(inner) &&
+        !(inner.head === :function && length(inner.args) == 1)
+end
+
 macro optlevel(n::Int)
-    return Expr(:meta, :optlevel, n)
+    0 <= n <= 3 || error("optimization level must be between 0 and 3, got $n")
+    return Expr(:meta, Expr(:optlevel, n))
+end
+macro optlevel(n::Int, ex)
+    0 <= n <= 3 || error("optimization level must be between 0 and 3, got $n")
+    if is_annotatable_function_def(ex)
+        return esc(Base.pushmeta!(ex, Expr(:optlevel, n)))
+    end
+    throw(ArgumentError(LazyString("Bad expression `", ex, "` in `@optlevel n ex`; ",
+        "expected a function definition with a body")))
+end
+
+"""
+    Experimental.get_optlevel(m::Method)
+
+Get the effective optimization level for a specific method. Returns the method's
+own optimization level if set, otherwise the enclosing module's level.
+
+See also [`Experimental.@optlevel`](@ref).
+"""
+function get_optlevel(m::Method)
+    return ccall(:jl_get_method_optlevel, Cint, (Any,), m)
+end
+
+"""
+    Experimental.get_compile(m::Method)
+
+Get the effective compilation mode for a specific method. Returns the method's
+own setting if set, otherwise the enclosing module's setting.
+
+See also [`Experimental.@compiler_options`](@ref).
+"""
+function get_compile(m::Method)
+    return ccall(:jl_get_method_compile, Cint, (Any,), m)
+end
+
+"""
+    Experimental.get_infer(m::Method)
+
+Get the effective inference setting for a specific method. Returns the method's
+own setting if set, otherwise the enclosing module's setting.
+
+See also [`Experimental.@compiler_options`](@ref).
+"""
+function get_infer(m::Method)
+    return ccall(:jl_get_method_infer, Cint, (Any,), m)
 end
 
 """
@@ -145,7 +217,7 @@ Supported values are `1`, `2`, `3`, `4`, and `default` (currently equivalent to 
 """
 macro max_methods(n::Int)
     1 <= n <= 4 || error("We must have that `1 <= max_methods <= 4`, but `max_methods = $n`.")
-    return Expr(:meta, :max_methods, n)
+    return Expr(:meta, Expr(:max_methods, n))
 end
 
 """
@@ -174,31 +246,57 @@ are currently supported:
     requests the minimum possible amount of compilation.
   * `infer`: Enable or disable type inference. If disabled, implies [`@nospecialize`](@ref).
   * `max_methods`: Maximum number of matching methods considered when running type inference.
+
+When applied to a function definition, sets the `optimize`, `compile`, and `infer`
+options for that specific method rather than the enclosing module:
+
+```julia
+Base.Experimental.@compiler_options optimize=0 compile=min function my_function(x)
+    ...
+end
+```
+
+`max_methods` can only be set at the module level; to set it for a specific
+generic function use [`@max_methods`](@ref).
+
+In a `@generated` function, the `optimize`, `compile`, and `infer` options can
+be set for an individual generated instance by splicing the corresponding meta
+expression, e.g. `Expr(:meta, Expr(:optlevel, 0))`, into the returned body.
 """
 macro compiler_options(args...)
-    opts = Expr(:block)
-    for ex in args
+    # Check if the last argument is a function definition
+    fdef = nothing
+    option_args = args
+    if !isempty(args) && is_annotatable_function_def(args[end])
+        fdef = args[end]
+        option_args = args[1:end-1]
+    end
+    metas = []
+    for ex in option_args
         if isa(ex, Expr) && ex.head === :(=) && length(ex.args) == 2
             if ex.args[1] === :optimize
-                push!(opts.args, Expr(:meta, :optlevel, ex.args[2]::Int))
+                n = ex.args[2]::Int
+                0 <= n <= 3 || error("optimization level must be between 0 and 3, got $n")
+                push!(metas, Expr(:optlevel, n))
             elseif ex.args[1] === :compile
                 a = ex.args[2]
                 a = #a === :no  ? 0 :
                     #a === :yes ? 1 :
                     #a === :all ? 2 :
                     a === :min ? 3 : error("invalid argument to \"compile\" option")
-                push!(opts.args, Expr(:meta, :compile, a))
+                push!(metas, Expr(:compile, a))
             elseif ex.args[1] === :infer
                 a = ex.args[2]
                 a = a === false || a === :no  ? 0 :
                     a === true  || a === :yes ? 1 : error("invalid argument to \"infer\" option")
-                push!(opts.args, Expr(:meta, :infer, a))
+                push!(metas, Expr(:infer, a))
             elseif ex.args[1] === :max_methods
+                fdef === nothing || error("`max_methods` can only be set at module level, not per-method; use `@max_methods n function f end` to set it for a generic function")
                 a = ex.args[2]
                 a = a === :default ? 3 :
                   a isa Int ? ((1 <= a <= 4) ? a : error("We must have that `1 <= max_methods <= 4`, but `max_methods = $a`.")) :
                   error("invalid argument to \"max_methods\" option")
-                push!(opts.args, Expr(:meta, :max_methods, a))
+                push!(metas, Expr(:max_methods, a))
             else
                 error("unknown option \"$(ex.args[1])\"")
             end
@@ -206,7 +304,18 @@ macro compiler_options(args...)
             error("invalid option syntax")
         end
     end
-    return opts
+    if fdef !== nothing
+        for m in metas
+            Base.pushmeta!(fdef, m)
+        end
+        return esc(fdef)
+    else
+        opts = Expr(:block)
+        for m in metas
+            push!(opts.args, Expr(:meta, m))
+        end
+        return opts
+    end
 end
 
 """

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -2714,7 +2714,10 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t *dump, jl_method_instance_t *mi, jl_
                         parseLLVMOptions(llvm_options, print_opts);
                         print_opts.out = &pass_output_stream;
                     }
-                    NewPM PM{jl_ExecutionEngine->cloneTargetMachine(), getOptLevel(jl_options.opt_level), opts, print_opts};
+                    // Use the lowest per-function optimization level requested,
+                    // matching the JIT's selectOptLevel logic.
+                    int fn_optlevel = jl_module_optlevel(output.get_module());
+                    NewPM PM{jl_ExecutionEngine->cloneTargetMachine(), getOptLevel(fn_optlevel), opts, print_opts};
                     //Safe b/c context lock is held by output
                     PM.run(output.get_module());
                     assert(!verifyLLVMIR(output.get_module()));

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -532,7 +532,7 @@
 (define (propagate-method-meta e)
   `(meta ,@(filter (lambda (x)
                      (or (method-meta-sym? x)
-                         (and (pair? x) (eq? (car x) 'purity))))
+                         (and (pair? x) (memq (car x) '(purity optlevel compile infer)))))
                    (cdr e))))
 
 (define (argwide-nospecialize-meta? e)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8925,8 +8925,19 @@ static jl_llvm_functions_t
     if (JL_FEAT_TEST(ctx, sanitize_thread))
         FnAttrs.addAttribute(llvm::Attribute::SanitizeThread);
 
-    // add the optimization level specified for this module, if any
-    int optlevel = jl_get_module_optlevel(ctx.module);
+    // add the optimization level: CodeInfo overrides Method overrides Module.
+    // Only methods carry a per-CodeInfo setting; in a top-level thunk the
+    // markers may come from non-executed branches, so the module setting
+    // (applied by the interpreter in control-flow order) governs.
+    int optlevel;
+    if (jl_is_method(lam->def.method)) {
+        optlevel = src->optlevel;
+        if (optlevel == UINT8_MAX)
+            optlevel = jl_get_method_optlevel(lam->def.method);
+    }
+    else {
+        optlevel = jl_get_module_optlevel(ctx.module);
+    }
     if (optlevel >= 0 && optlevel <= 3) {
         static const char* const optLevelStrings[] = { "0", "1", "2", "3" };
         FnAttrs.addAttribute("julia-optimization-level", optLevelStrings[optlevel]);

--- a/src/gf.c
+++ b/src/gf.c
@@ -3981,12 +3981,28 @@ static jl_code_instance_t *jl_compile_method_very_internal(jl_method_instance_t 
 
     jl_method_instance_t *mi2 = mi;
     int compile_option = jl_options.compile_enabled;
-    // disabling compilation per-module can override global setting
+    // disabling compilation per-method/module can override global setting
     if (jl_is_method(def)) {
-        int mod_setting = jl_get_module_compile(((jl_method_t*)def)->module);
-        if (mod_setting == JL_OPTIONS_COMPILE_OFF ||
-            mod_setting == JL_OPTIONS_COMPILE_MIN)
-            compile_option = ((jl_method_t*)def)->module->compile;
+        volatile int method_setting = jl_get_method_compile(def);
+        if (def->generator != NULL) {
+            // a generated function's expansion can override the method/module
+            // setting for this instance (CodeInfo overrides Method overrides Module)
+            JL_TRY {
+                jl_code_instance_t *uninferred = jl_cached_uninferred(
+                        jl_atomic_load_relaxed(&mi->cache), world);
+                jl_code_info_t *src = uninferred
+                    ? (jl_code_info_t*)jl_atomic_load_relaxed(&uninferred->inferred)
+                    : jl_code_for_staged(mi, world, &uninferred);
+                if (src != NULL && jl_is_code_info(src) && src->compile != 0xff)
+                    method_setting = src->compile;
+            }
+            JL_CATCH {
+                // generator errors are reported when the code is actually needed
+            }
+        }
+        if (method_setting == JL_OPTIONS_COMPILE_OFF ||
+            method_setting == JL_OPTIONS_COMPILE_MIN)
+            compile_option = method_setting;
     }
 
     // if compilation is disabled or source is unavailable, try calling unspecialized version

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -708,32 +708,46 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip,
                     jl_toplevel_eval(s->module, stmt);
                 }
                 else if (head == jl_meta_sym) {
-                    if (jl_expr_nargs(stmt) == 1 && jl_exprarg(stmt, 0) == (jl_value_t*)jl_nospecialize_sym) {
+                    size_t nmeta = jl_expr_nargs(stmt);
+                    // flat form: Expr(:meta, :optlevel, n)
+                    if (nmeta == 2 && jl_is_symbol(jl_exprarg(stmt, 0)) && jl_is_long(jl_exprarg(stmt, 1))) {
+                        jl_sym_t *which = (jl_sym_t*)jl_exprarg(stmt, 0);
+                        long n = jl_unbox_long(jl_exprarg(stmt, 1));
+                        if (which == jl_optlevel_sym)
+                            jl_set_module_optlevel(s->module, n);
+                        else if (which == jl_compile_sym)
+                            jl_set_module_compile(s->module, n);
+                        else if (which == jl_infer_sym)
+                            jl_set_module_infer(s->module, n);
+                        else if (which == jl_max_methods_sym)
+                            jl_set_module_max_methods(s->module, n);
+                    }
+                    // Bare `Expr(:meta, :nospecialize)` / `Expr(:meta, :specialize)`
+                    // toggle module-wide specialization. Only this sole-marker form
+                    // is a module directive; a multi-argument `@nospecialize x` is an
+                    // argument annotation, not a module setting.
+                    else if (nmeta == 1 && jl_exprarg(stmt, 0) == (jl_value_t*)jl_nospecialize_sym) {
                         jl_set_module_nospecialize(s->module, 1);
                     }
-                    if (jl_expr_nargs(stmt) == 1 && jl_exprarg(stmt, 0) == (jl_value_t*)jl_specialize_sym) {
+                    else if (nmeta == 1 && jl_exprarg(stmt, 0) == (jl_value_t*)jl_specialize_sym) {
                         jl_set_module_nospecialize(s->module, 0);
                     }
-                    if (jl_expr_nargs(stmt) == 2) {
-                        if (jl_exprarg(stmt, 0) == (jl_value_t*)jl_optlevel_sym) {
-                            if (jl_is_long(jl_exprarg(stmt, 1))) {
-                                int n = jl_unbox_long(jl_exprarg(stmt, 1));
-                                jl_set_module_optlevel(s->module, n);
-                            }
-                        }
-                        else if (jl_exprarg(stmt, 0) == (jl_value_t*)jl_compile_sym) {
-                            if (jl_is_long(jl_exprarg(stmt, 1))) {
-                                jl_set_module_compile(s->module, jl_unbox_long(jl_exprarg(stmt, 1)));
-                            }
-                        }
-                        else if (jl_exprarg(stmt, 0) == (jl_value_t*)jl_infer_sym) {
-                            if (jl_is_long(jl_exprarg(stmt, 1))) {
-                                jl_set_module_infer(s->module, jl_unbox_long(jl_exprarg(stmt, 1)));
-                            }
-                        }
-                        else if (jl_exprarg(stmt, 0) == (jl_value_t*)jl_max_methods_sym) {
-                            if (jl_is_long(jl_exprarg(stmt, 1))) {
-                                jl_set_module_max_methods(s->module, jl_unbox_long(jl_exprarg(stmt, 1)));
+                    else {
+                        // one or more nested markers, e.g.
+                        // Expr(:meta, Expr(:compile, 0), Expr(:optlevel, n))
+                        for (size_t i = 0; i < nmeta; i++) {
+                            jl_value_t *ma = jl_exprarg(stmt, i);
+                            if (jl_is_expr(ma) && jl_expr_nargs(ma) == 1 && jl_is_long(jl_exprarg(ma, 0))) {
+                                jl_sym_t *which = ((jl_expr_t*)ma)->head;
+                                long n = jl_unbox_long(jl_exprarg(ma, 0));
+                                if (which == jl_optlevel_sym)
+                                    jl_set_module_optlevel(s->module, n);
+                                else if (which == jl_compile_sym)
+                                    jl_set_module_compile(s->module, n);
+                                else if (which == jl_infer_sym)
+                                    jl_set_module_infer(s->module, n);
+                                else if (which == jl_max_methods_sym)
+                                    jl_set_module_max_methods(s->module, n);
                             }
                         }
                     }

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1054,6 +1054,10 @@ JL_DLLEXPORT jl_string_t *jl_compress_ir(jl_method_t *m, jl_code_info_t *code)
         write_int32(s.s, (int32_t)nargs);
     }
 
+    write_uint8(s.s, code->optlevel);
+    write_uint8(s.s, code->compile);
+    write_uint8(s.s, code->infer);
+
     size_t i, l = jl_array_dim0(code->code);
     write_uint64(s.s, l);
     for (i = 0; i < l; i++) {
@@ -1148,6 +1152,10 @@ JL_DLLEXPORT jl_code_info_t *jl_uncompress_ir(jl_method_t *m, jl_code_instance_t
     } else {
         code->nargs = read_int32(s.s);
     }
+
+    code->optlevel = read_uint8(s.s);
+    code->compile = read_uint8(s.s);
+    code->infer = read_uint8(s.s);
 
     size_t i, l = read_uint64(s.s);
     jl_gc_write(code, code->code, jl_array_t, jl_alloc_array_1d(jl_array_any_type, l));

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -633,30 +633,31 @@ static auto countBasicBlocks(const Function &F) JL_NOTSAFEPOINT
 
 static constexpr size_t N_optlevels = 4;
 
-static void selectOptLevel(Module &M) JL_NOTSAFEPOINT {
-    size_t opt_level = std::max(static_cast<int>(jl_options.opt_level), 0);
-    do {
-        if (jl_generating_output()) {
-            opt_level = 0;
-            break;
-        }
-        size_t opt_level_min = std::max(static_cast<int>(jl_options.opt_level_min), 0);
-        for (auto &F : M) {
-            if (!F.isDeclaration()) {
-                Attribute attr = F.getFnAttribute("julia-optimization-level");
-                StringRef val = attr.getValueAsString();
-                if (val != "") {
-                    size_t ol = (size_t)val[0] - '0';
-                    if (ol < opt_level)
-                        opt_level = ol;
-                }
+// Scan the module for the lowest per-function optimization level requested via
+// the "julia-optimization-level" attribute, then clamp to [opt_level_min, max].
+int jl_module_optlevel(Module &M) JL_NOTSAFEPOINT {
+    int opt_level = std::max(static_cast<int>(jl_options.opt_level), 0);
+    int opt_level_min = std::max(static_cast<int>(jl_options.opt_level_min), 0);
+    for (auto &F : M) {
+        if (!F.isDeclaration()) {
+            Attribute attr = F.getFnAttribute("julia-optimization-level");
+            StringRef val = attr.getValueAsString();
+            if (val != "") {
+                int ol = (int)val[0] - '0';
+                if (ol >= 0 && ol < opt_level)
+                    opt_level = ol;
             }
         }
-        if (opt_level < opt_level_min)
-            opt_level = opt_level_min;
-    } while (0);
+    }
+    if (opt_level < opt_level_min)
+        opt_level = opt_level_min;
     // currently -O3 is max
-    opt_level = std::min(opt_level, N_optlevels - 1);
+    return std::min(opt_level, static_cast<int>(N_optlevels) - 1);
+}
+
+static void selectOptLevel(Module &M) JL_NOTSAFEPOINT {
+    // pkgimage / sysimage generation always compiles at -O0
+    size_t opt_level = jl_generating_output() ? 0 : (size_t)jl_module_optlevel(M);
     M.addModuleFlag(Module::Warning, "julia.optlevel", opt_level);
 }
 

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -277,6 +277,7 @@ struct AnalysisManagers {
 };
 
 OptimizationLevel getOptLevel(int optlevel) JL_NOTSAFEPOINT;
+int jl_module_optlevel(Module &M) JL_NOTSAFEPOINT;
 
 struct jl_locked_stream {
     ios_t *stream = nullptr;

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -208,6 +208,9 @@
     XX(jl_get_JIT) \
     XX(jl_get_julia_bin) \
     XX(jl_get_julia_bindir) \
+    XX(jl_get_method_compile) \
+    XX(jl_get_method_infer) \
+    XX(jl_get_method_optlevel) \
     XX(jl_get_module_compile) \
     XX(jl_get_module_infer) \
     XX(jl_get_module_of_binding) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3909,7 +3909,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_code_info_type =
         jl_new_datatype(jl_symbol("CodeInfo"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(23,
+                        jl_perm_symsvec(26,
                             "code",
                             "debuginfo",
                             "ssavaluetypes",
@@ -3932,8 +3932,11 @@ void jl_init_types(void) JL_GC_DISABLED
                             "inlining",
                             "constprop",
                             "purity",
+                            "optlevel",
+                            "compile",
+                            "infer",
                             "inlining_cost"),
-                        jl_svec(23,
+                        jl_svec(26,
                             jl_array_any_type,
                             jl_debuginfo_type,
                             jl_any_type,
@@ -3956,14 +3959,17 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_uint8_type,
                             jl_uint8_type,
                             jl_uint16_type,
+                            jl_uint8_type,
+                            jl_uint8_type,
+                            jl_uint8_type,
                             jl_uint16_type),
                         jl_emptysvec,
-                        0, 1, 22);
+                        0, 1, 25);
 
     jl_method_type =
         jl_new_datatype(jl_symbol("Method"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(33,
+                        jl_perm_symsvec(36,
                             "name",
                             "module",
                             "file",
@@ -3996,8 +4002,11 @@ void jl_init_types(void) JL_GC_DISABLED
                             "did_scan_source",
                             "constprop",
                             "max_varargs",
-                            "purity"),
-                        jl_svec(33,
+                            "purity",
+                            "optlevel",
+                            "compile",
+                            "infer"),
+                        jl_svec(36,
                             jl_symbol_type,
                             jl_module_type,
                             jl_symbol_type,
@@ -4030,11 +4039,15 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_uint8_type,
                             jl_uint8_type,
                             jl_uint8_type,
-                            jl_uint16_type),
+                            jl_uint16_type,
+                            jl_uint8_type,
+                            jl_uint8_type,
+                            jl_uint8_type),
                         jl_emptysvec,
                         0, 1, 10);
     //const static uint32_t method_constfields[] = { 0b0, 0b0 }; // (1<<0)|(1<<1)|(1<<2)|(1<<3)|(1<<6)|(1<<9)|(1<<10)|(1<<17)|(1<<21)|(1<<22)|(1<<23)|(1<<24)|(1<<25)|(1<<26)|(1<<27)|(1<<28)|(1<<29)|(1<<30);
     //jl_method_type->name->constfields = method_constfields;
+    // atomic fields: dispatch_status(4), interferences(5), primary_world(6), did_scan_source(29)
     const static uint32_t method_atomicfields[] = { 0x20000070, 0x0 }; // (1<<4)|(1<<5)|(1<<6)|(1<<29)
     jl_method_type->name->atomicfields = method_atomicfields;
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -399,6 +399,9 @@ typedef struct _jl_code_info_t {
     uint8_t inlining; // 0 = default; 1 = @inline; 2 = @noinline
     uint8_t constprop; // 0 = use heuristic; 1 = aggressive; 2 = none
     _jl_purity_overrides_t purity;
+    uint8_t optlevel; // UINT8_MAX = inherit from module; 0-3 = explicit level
+    uint8_t compile; // UINT8_MAX = inherit from module; 0-3 = explicit level
+    uint8_t infer; // UINT8_MAX = inherit from module; 0 = off, 1 = on
     // uint16 settings
     uint16_t inlining_cost;
 } jl_code_info_t;
@@ -473,6 +476,12 @@ typedef struct _jl_method_t {
     // Override the conclusions of inter-procedural effect analysis,
     // forcing the conclusion to always true.
     _jl_purity_overrides_t purity;
+
+    // Per-method compiler option overrides.
+    // UINT8_MAX = inherit from module (default).
+    uint8_t optlevel;
+    uint8_t compile;
+    uint8_t infer;
 
 // hidden fields:
     jl_mutex_t writelock;
@@ -2220,6 +2229,9 @@ JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name, jl_module_t *parent) JL_
 JL_DLLEXPORT void jl_set_module_nospecialize(jl_module_t *self, int on);
 JL_DLLEXPORT void jl_set_module_optlevel(jl_module_t *self, int lvl);
 JL_DLLEXPORT int jl_get_module_optlevel(jl_module_t *m);
+JL_DLLEXPORT int jl_get_method_optlevel(jl_method_t *m);
+JL_DLLEXPORT int jl_get_method_compile(jl_method_t *m);
+JL_DLLEXPORT int jl_get_method_infer(jl_method_t *m);
 JL_DLLEXPORT void jl_set_module_compile(jl_module_t *self, int value);
 JL_DLLEXPORT int jl_get_module_compile(jl_module_t *m);
 JL_DLLEXPORT void jl_set_module_infer(jl_module_t *self, int value);

--- a/src/method.c
+++ b/src/method.c
@@ -502,6 +502,35 @@ jl_code_info_t *jl_new_code_info_from_ir(jl_expr_t *ir)
                     li->constprop = 1;
                 else if (ma == (jl_value_t*)jl_no_constprop_sym)
                     li->constprop = 2;
+                else if (jl_is_expr(ma) && ((jl_expr_t*)ma)->head == jl_optlevel_sym) {
+                    if (jl_expr_nargs(ma) == 1 && jl_is_long(jl_exprarg(ma, 0))) {
+                        long n = jl_unbox_long(jl_exprarg(ma, 0));
+                        if (n >= 0 && n <= 3)
+                            li->optlevel = n;
+                    }
+                    // Keep the marker in the body rather than consuming it. For a
+                    // method it is an inert no-op, but for a top-level thunk it
+                    // must remain executable so the interpreter applies the module
+                    // option in its original control-flow position (e.g. so an
+                    // option inside `if false` / `@static` is not applied).
+                    jl_array_ptr_set(meta, ins++, ma);
+                }
+                else if (jl_is_expr(ma) && ((jl_expr_t*)ma)->head == jl_compile_sym) {
+                    if (jl_expr_nargs(ma) == 1 && jl_is_long(jl_exprarg(ma, 0))) {
+                        long n = jl_unbox_long(jl_exprarg(ma, 0));
+                        if (n >= 0 && n <= 3)
+                            li->compile = n;
+                    }
+                    jl_array_ptr_set(meta, ins++, ma);
+                }
+                else if (jl_is_expr(ma) && ((jl_expr_t*)ma)->head == jl_infer_sym) {
+                    if (jl_expr_nargs(ma) == 1 && jl_is_long(jl_exprarg(ma, 0))) {
+                        long n = jl_unbox_long(jl_exprarg(ma, 0));
+                        if (n == 0 || n == 1)
+                            li->infer = n;
+                    }
+                    jl_array_ptr_set(meta, ins++, ma);
+                }
                 else if (jl_is_expr(ma) && ((jl_expr_t*)ma)->head == jl_purity_sym) {
                     if (jl_expr_nargs(ma) == NUM_EFFECTS_OVERRIDES) {
                         // N.B. this code allows multiple :purity expressions to be present in a single `:meta` node
@@ -707,6 +736,9 @@ JL_DLLEXPORT jl_code_info_t *jl_new_code_info_uninit(void)
     src->constprop = 0;
     src->inlining = 0;
     src->purity.bits = 0;
+    src->optlevel = UINT8_MAX;
+    src->compile = UINT8_MAX;
+    src->infer = UINT8_MAX;
     src->nargs = 0;
     src->isva = 0;
     src->inlining_cost = UINT16_MAX;
@@ -952,6 +984,18 @@ JL_DLLEXPORT void jl_method_set_source(jl_method_t *m, jl_code_info_t *src) JL_C
     m->nospecializeinfer = src->nospecializeinfer;
     m->constprop = src->constprop;
     m->purity.bits = src->purity.bits;
+    m->optlevel = src->optlevel;
+    m->compile = src->compile;
+    m->infer = src->infer;
+    // Explicitly disabling inference implies @nospecialize (there is no benefit
+    // to specializing a method that will not be inferred); explicitly enabling
+    // it re-enables specialization. This mirrors jl_set_module_infer for the
+    // module-level setting. Done before the per-argument @nospecialize /
+    // @specialize pass below, so those annotations still take precedence.
+    if (m->infer == 0)
+        m->nospecialize = -1;
+    else if (m->infer == 1)
+        m->nospecialize = 0;
 
     jl_array_t *copy = NULL;
     jl_svec_t *sparam_vars = jl_outer_unionall_vars(m->sig);
@@ -1089,6 +1133,9 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t *module)
     jl_atomic_store_relaxed(&m->did_scan_source, 0);
     m->constprop = 0;
     m->purity.bits = 0;
+    m->optlevel = UINT8_MAX;
+    m->compile = UINT8_MAX;
+    m->infer = UINT8_MAX;
     m->max_varargs = UINT8_MAX;
     JL_MUTEX_INIT(&m->writelock, "method->writelock");
     return m;

--- a/src/module.c
+++ b/src/module.c
@@ -790,6 +790,30 @@ JL_DLLEXPORT int jl_get_module_optlevel(jl_module_t *m)
     return lvl;
 }
 
+JL_DLLEXPORT int jl_get_method_optlevel(jl_method_t *m)
+{
+    uint8_t lvl = m->optlevel;
+    if (lvl != UINT8_MAX)
+        return lvl;
+    return jl_get_module_optlevel(m->module);
+}
+
+JL_DLLEXPORT int jl_get_method_compile(jl_method_t *m)
+{
+    uint8_t value = m->compile;
+    if (value != UINT8_MAX)
+        return value;
+    return jl_get_module_compile(m->module);
+}
+
+JL_DLLEXPORT int jl_get_method_infer(jl_method_t *m)
+{
+    uint8_t value = m->infer;
+    if (value != UINT8_MAX)
+        return value;
+    return jl_get_module_infer(m->module);
+}
+
 JL_DLLEXPORT void jl_set_module_compile(jl_module_t *self, int value)
 {
     self->compile = value;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2593,8 +2593,8 @@ static int strip_all_codeinfos__(jl_typemap_entry_t *def, void *_env) JL_CANSAFE
                 }
             }
             if (!should_strip_ir) {
-                int mod_setting = jl_get_module_compile(m->module);
-                if (!(mod_setting == JL_OPTIONS_COMPILE_OFF || mod_setting == JL_OPTIONS_COMPILE_MIN)) {
+                int method_setting = jl_get_method_compile(m);
+                if (!(method_setting == JL_OPTIONS_COMPILE_OFF || method_setting == JL_OPTIONS_COMPILE_MIN)) {
                     // if the method is declared not to be compiled, keep IR for interpreter
                     should_strip_ir = 1;
                 }

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -721,6 +721,13 @@ JL_DLLEXPORT jl_value_t *jl_eval_thunk(jl_module_t *JL_NONNULL m, jl_code_info_t
     JL_TYPECHK(jl_eval_thunk, code_info, (jl_value_t*)thk);
     JL_TYPECHK(jl_eval_thunk, array_any, (jl_value_t*)thk->code);
 
+    // Module-level `@optlevel` / `@compiler_options` are left as `(meta ...)`
+    // statements in the thunk body and applied by the interpreter (eval_body)
+    // in their original control-flow position, so options guarded by e.g.
+    // `if false` / `@static` only apply when their branch executes. The
+    // thk->optlevel/compile/infer fields are collected without regard for
+    // control flow and are therefore ignored for thunks (here and in codegen).
+
     // Set global jl_lineno/jl_filename to file and line info for the original
     // start of this block.
     int last_lineno = jl_atomic_load_relaxed(&jl_lineno);

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -89,7 +89,7 @@ const TAGS = Any[
 const NTAGS = length(TAGS)
 @assert NTAGS == 255
 
-const ser_version = 30 # do not make changes without bumping the version #!
+const ser_version = 31 # do not make changes without bumping the version #!
 
 format_version(::AbstractSerializer) = ser_version
 format_version(s::Serializer) = s.version
@@ -540,6 +540,9 @@ function serialize(s::AbstractSerializer, meth::Method)
     serialize(s, meth.nospecializeinfer)
     serialize(s, meth.constprop)
     serialize(s, meth.purity)
+    serialize(s, meth.optlevel)
+    serialize(s, meth.compile)
+    serialize(s, meth.infer)
     if isdefined(meth, :source)
         serialize(s, Base._uncompressed_ast(meth))
     else
@@ -1162,6 +1165,9 @@ function deserialize(s::AbstractSerializer, ::Type{Method})
     nospecializeinfer = false
     constprop = 0x00
     purity = 0x0000
+    optlevel = 0xff
+    compile = 0xff
+    infer = 0xff
     template_or_is_opaque = with(current_module => mod) do
         deserialize(s)
     end
@@ -1177,6 +1183,11 @@ function deserialize(s::AbstractSerializer, ::Type{Method})
             purity = deserialize(s)::UInt16
         elseif format_version(s) >= 17
             purity = UInt16(deserialize(s)::UInt8)
+        end
+        if format_version(s) >= 31
+            optlevel = deserialize(s)::UInt8
+            compile = deserialize(s)::UInt8
+            infer = deserialize(s)::UInt8
         end
         with(current_module => mod) do
             deserialize(s)
@@ -1202,6 +1213,9 @@ function deserialize(s::AbstractSerializer, ::Type{Method})
         meth.nospecializeinfer = nospecializeinfer
         meth.constprop = constprop
         meth.purity = purity
+        meth.optlevel = optlevel
+        meth.compile = compile
+        meth.infer = infer
         if template !== nothing
             # TODO: compress template
             template = template::CodeInfo
@@ -1426,6 +1440,11 @@ function deserialize(s::AbstractSerializer, ::Type{CodeInfo})
         ci.purity = deserialize(s)::UInt16
     elseif format_version(s) >= 17
         ci.purity = deserialize(s)::UInt8
+    end
+    if format_version(s) >= 31
+        ci.optlevel = deserialize(s)::UInt8
+        ci.compile = deserialize(s)::UInt8
+        ci.infer = deserialize(s)::UInt8
     end
     if format_version(s) >= 22
         ci.inlining_cost = deserialize(s)::UInt16

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1812,3 +1812,197 @@ if !Sys.iswindows() && !running_under_rr()
         end
     end
 end
+# Per-method compiler options via @compiler_options and programmatic API
+@testset "per-method compiler options" begin
+    # Test @compiler_options applied to function definitions
+    Base.Experimental.@compiler_options optimize=0 function _test_opts_fn1(x)
+        x + 1
+    end
+    m = only(methods(_test_opts_fn1))
+    @test Base.Experimental.get_optlevel(m) == 0
+
+    Base.Experimental.@compiler_options compile=min function _test_opts_fn2(x)
+        x + 1
+    end
+    m = only(methods(_test_opts_fn2))
+    @test Base.Experimental.get_compile(m) == 3
+
+    Base.Experimental.@compiler_options infer=false function _test_opts_fn3(x)
+        x + 1
+    end
+    m = only(methods(_test_opts_fn3))
+    @test Base.Experimental.get_infer(m) == 0
+
+    # Test multiple options at once
+    Base.Experimental.@compiler_options optimize=2 compile=min infer=true function _test_opts_fn5(x)
+        x + 1
+    end
+    m = only(methods(_test_opts_fn5))
+    @test Base.Experimental.get_optlevel(m) == 2
+    @test Base.Experimental.get_compile(m) == 3
+    @test Base.Experimental.get_infer(m) == 1
+
+    # Test @optlevel on function definition
+    Base.Experimental.@optlevel 1 function _test_opts_fn6(x)
+        x + 1
+    end
+    m = only(methods(_test_opts_fn6))
+    @test Base.Experimental.get_optlevel(m) == 1
+
+    # max_methods cannot be set per-method
+    @test_throws "max_methods" @macroexpand Base.Experimental.@compiler_options max_methods=1 function _test_opts_fn_mm(x)
+        x + 1
+    end
+
+    # Unset options inherit from the enclosing module (returns -1 for module default)
+    _test_opts_fn7(x) = x + 1
+    m = only(methods(_test_opts_fn7))
+    @test Base.Experimental.get_compile(m) == -1
+    @test Base.Experimental.get_infer(m) == -1
+
+    # Test generated functions can set compiler options via meta expressions
+    struct _TestWrapper{P, F}
+        f::F
+    end
+
+    @generated function _test_call_wrapper(w::_TestWrapper{P}, x) where {P}
+        optlevel = P
+        optlevel_meta = optlevel != 0xFF ? Expr(:meta, Expr(:optlevel, optlevel)) : nothing
+        return quote
+            $optlevel_meta
+            w.f(x)
+        end
+    end
+
+    _test_wrapper_f(x) = x .+ (1.0, 2.0, 3.0, 4.0)
+    w0 = _TestWrapper{0, typeof(_test_wrapper_f)}(_test_wrapper_f)
+    w2 = _TestWrapper{2, typeof(_test_wrapper_f)}(_test_wrapper_f)
+    wdefault = _TestWrapper{0xFF, typeof(_test_wrapper_f)}(_test_wrapper_f)
+
+    ci0 = only(code_lowered(_test_call_wrapper, (typeof(w0), Float64)))
+    ci2 = only(code_lowered(_test_call_wrapper, (typeof(w2), Float64)))
+    cidef = only(code_lowered(_test_call_wrapper, (typeof(wdefault), Float64)))
+
+    @test ci0.optlevel == 0x00
+    @test ci2.optlevel == 0x02
+    @test cidef.optlevel == 0xFF
+
+    # infer=0 in an expansion disables inference for that instance only
+    @generated function _test_staged_infer(w::_TestWrapper{P}, x) where {P}
+        meta = P ? Expr(:meta, Expr(:infer, 0)) : nothing
+        return quote
+            $meta
+            w.f(x)
+        end
+    end
+    wni = _TestWrapper{true, typeof(_test_wrapper_f)}(_test_wrapper_f)
+    wyi = _TestWrapper{false, typeof(_test_wrapper_f)}(_test_wrapper_f)
+    @test _test_staged_infer(wni, 1.0) == (2.0, 3.0, 4.0, 5.0)
+    @test only(Base.return_types(_test_staged_infer, (typeof(wni), Float64))) == Any
+    @test only(Base.return_types(_test_staged_infer, (typeof(wyi), Float64))) == NTuple{4, Float64}
+
+    # compile=min in an expansion makes that instance run in the interpreter
+    @generated function _test_staged_compile(w::_TestWrapper{P}, x) where {P}
+        meta = P ? Expr(:meta, Expr(:compile, 3)) : nothing
+        return quote
+            $meta
+            w.f(x)
+        end
+    end
+    wmin = _TestWrapper{true, typeof(_test_wrapper_f)}(_test_wrapper_f)
+    @test _test_staged_compile(wmin, 1.0) == (2.0, 3.0, 4.0, 5.0)
+    let mi = only(Base.specializations(only(methods(_test_staged_compile))))
+        ci = @atomic :acquire mi.cache
+        # skip the cached uninferred expansion (owner === :uninferred)
+        while ci.owner !== nothing
+            ci = @atomic :acquire ci.next
+        end
+        @test (@atomic :acquire ci.invoke) ==
+            unsafe_load(cglobal(:jl_fptr_interpret_call_addr, Ptr{Cvoid}))
+    end
+
+    # options propagate to positional-default wrappers and the kwcall sorter
+    Base.Experimental.@optlevel 0 function _test_opts_kwf(x::Int, y::Int=1; k::Int=2)
+        x + y + k
+    end
+    @test _test_opts_kwf(1) == 4
+    for m in (which(_test_opts_kwf, (Int,)), which(_test_opts_kwf, (Int, Int)),
+              which(Core.kwcall, (NamedTuple{(:k,), Tuple{Int}}, typeof(_test_opts_kwf), Int)))
+        @test Base.Experimental.get_optlevel(m) == 0
+    end
+
+    # a bodyless declaration cannot carry compiler options
+    @test_throws "function definition with a body" @macroexpand Base.Experimental.@optlevel 1 function _f_no_body end
+end
+
+# Module-level compiler options are applied to the enclosing module (not just methods)
+module _TestModuleOpts
+    Base.Experimental.@optlevel 1
+    Base.Experimental.@compiler_options compile=min max_methods=2
+    fmod(x) = x + 1
+end
+module _TestMethodOnlyOpts
+    Base.Experimental.@compiler_options optimize=0 function fmeth(x)
+        x + 1
+    end
+end
+@testset "module-level compiler options" begin
+    mm = only(methods(_TestModuleOpts.fmod))
+    # `fmod` has no per-method override, so these report the module-level settings
+    @test Base.Experimental.get_optlevel(mm) == 1
+    @test Base.Experimental.get_compile(mm) == 3
+    # `max_methods` is module-level only
+    @test ccall(:jl_get_module_max_methods, Cint, (Any,), _TestModuleOpts) == 2
+
+    # The function-definition form sets only the method, not the enclosing module
+    @test Base.Experimental.get_optlevel(only(methods(_TestMethodOnlyOpts.fmeth))) == 0
+    @test ccall(:jl_get_module_optlevel, Cint, (Any,), _TestMethodOnlyOpts) == -1
+end
+
+# Module-level options are applied by the interpreter in their control-flow
+# position, so an option guarded by a branch that is not taken is not applied.
+@testset "module-level compiler options respect control flow" begin
+    m1 = Module()
+    Core.eval(m1, quote
+        cond = false
+        if cond
+            Base.Experimental.@compiler_options infer=false optimize=0
+        end
+        f(x) = x + 1
+    end)
+    @test ccall(:jl_get_module_infer, Cint, (Any,), m1) == -1
+    @test ccall(:jl_get_module_optlevel, Cint, (Any,), m1) == -1
+
+    m2 = Module()
+    Core.eval(m2, quote
+        cond = true
+        if cond
+            Base.Experimental.@optlevel 0
+        end
+    end)
+    @test ccall(:jl_get_module_optlevel, Cint, (Any,), m2) == 0
+end
+
+# Disabling inference on a method implies @nospecialize (matching the module
+# setting); explicitly enabling it re-enables specialization.
+@testset "per-method infer implies (no)specialization" begin
+    Base.Experimental.@compiler_options infer=false function _test_noinfer(x)
+        x + 1
+    end
+    @test only(methods(_test_noinfer)).nospecialize == -1
+
+    mod = Module()
+    Core.eval(mod, quote
+        Base.Experimental.@compiler_options infer=false
+        Base.Experimental.@compiler_options infer=true function yesinfer(x)
+            x + 1
+        end
+        plain(x) = x + 1
+    end)
+    @test only(methods(mod.yesinfer)).nospecialize == 0
+    @test only(methods(mod.plain)).nospecialize == -1
+
+    # optimization level is validated
+    @test_throws Exception @macroexpand Base.Experimental.@optlevel 5
+    @test_throws Exception @macroexpand Base.Experimental.@compiler_options optimize=7 function _f(x) x end
+end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2101,6 +2101,44 @@ precompile_test_harness("BadInvalidations") do load_path
     end
 end
 
+# Test that per-method compiler options survive precompilation
+precompile_test_harness("PerMethodCompilerOpts") do load_path
+    write(joinpath(load_path, "PerMethodCompilerOpts.jl"),
+        """
+        module PerMethodCompilerOpts
+        Base.Experimental.@compiler_options optimize=0 compile=min function opt0_compile_min(x)
+            x + 1
+        end
+        Base.Experimental.@compiler_options infer=false function no_infer(x)
+            x + 1
+        end
+        Base.Experimental.@optlevel 1 function opt1(x)
+            x + 1
+        end
+        Base.Experimental.@compiler_options compile=min function __init__()
+            nothing
+        end
+        end
+        """)
+    Base.compilecache(Base.PkgId("PerMethodCompilerOpts"))
+    @eval using PerMethodCompilerOpts
+    invokelatest() do
+        m1 = only(methods(PerMethodCompilerOpts.opt0_compile_min))
+        @test Base.Experimental.get_optlevel(m1) == 0
+        @test Base.Experimental.get_compile(m1) == 3
+
+        m2 = only(methods(PerMethodCompilerOpts.no_infer))
+        @test Base.Experimental.get_infer(m2) == 0
+
+        m4 = only(methods(PerMethodCompilerOpts.opt1))
+        @test Base.Experimental.get_optlevel(m4) == 1
+
+        # compile=min __init__ is skipped by the pkgimage precompile hints and
+        # still runs (interpreted) at load time
+        @test Base.Experimental.get_compile(only(methods(PerMethodCompilerOpts.__init__))) == 3
+    end
+end
+
 # https://github.com/JuliaLang/julia/issues/48074
 precompile_test_harness("WindowsCacheOverwrite") do load_path
     # https://github.com/JuliaLang/julia/pull/47184#issuecomment-1364716312


### PR DESCRIPTION
The current way of setting optimization options on modules is a sometimes a bit awkward. When programatically defining methods it is not always desirable to tie them to a specific module with specific compiler options and if you use `@generated` function and want different optimization options for different expression inputs I don't think the current way allows for this.

This PR allows one to use the compiler option macros on methods instead. The `@generated` use case can be done by splicing in the meta expression.

I don't know if all the getters and setters are excessive but they mirror the existing ones.

Mostly done with Claude.