### PR TITLE
WIP/RFC: Switch diagonal rule to be structural

### DIFF
--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -1564,7 +1564,7 @@ let nfields_tfunc(@nospecialize xs...) =
     @test nfields_tfunc(Int) === Const(0)
     @test nfields_tfunc(Complex) === Const(2)
     @test nfields_tfunc(Type{Type{Int}}) === Const(nfields(DataType))
-    @test nfields_tfunc(UnionAll) === Const(2)
+    @test nfields_tfunc(UnionAll) === Const(3)
     @test nfields_tfunc(DataType) === Const(nfields(DataType))
     @test nfields_tfunc(Type{Int}) === Const(nfields(DataType))
     @test nfields_tfunc(Type{Integer}) === Const(nfields(DataType))

--- a/JuliaSyntax/src/julia/kinds.jl
+++ b/JuliaSyntax/src/julia/kinds.jl
@@ -489,6 +489,8 @@ register_kinds!(JuliaSyntax, 0, [
     "BEGIN_COMPARISON"
         "<:"
         ">:"
+        "<<:"
+        ">>:"
         ">"
         "<"
         ">="

--- a/JuliaSyntax/src/julia/parser.jl
+++ b/JuliaSyntax/src/julia/parser.jl
@@ -299,13 +299,13 @@ function is_syntactic_unary_op(k)
 end
 
 function is_type_operator(t, isdot)
-    kind(t) in KSet"<: >:" && !isdot
+    kind(t) in KSet"<: >: <<: >>:" && !isdot
 end
 
 function is_unary_op(t, isdot)
     k = kind(t)
     !is_suffixed(t) && (
-        (k in KSet"<: >:" && !isdot) ||
+        (k in KSet"<: >: <<: >>:" && !isdot) ||
         k in KSet"+ - ! ~ ¬ √ ∛ ∜ ⋆ ± ∓" # dotop allowed
     )
 end

--- a/JuliaSyntax/src/julia/tokenize.jl
+++ b/JuliaSyntax/src/julia/tokenize.jl
@@ -157,6 +157,8 @@ function optakessuffix(k)
         k == K"?"   ||
         k == K"<:"  ||
         k == K">:"  ||
+        k == K"<<:" ||
+        k == K">>:" ||
         k == K"&&"  ||
         k == K"||"  ||
         k == K"in"  ||
@@ -801,6 +803,8 @@ function lex_greater(l::Lexer)
             end
         elseif accept(l, '=')
             return emit(l, K"op=")
+        elseif accept(l, ':')
+            return emit(l, K">>:")
         else
             return emit(l, K">>")
         end
@@ -818,7 +822,9 @@ function lex_less(l::Lexer)
     if accept(l, '<')
         if accept(l, '=')
             return emit(l, K"op=")
-        else # '<<?', ? not =, ' '
+        elseif accept(l, ':')
+            return emit(l, K"<<:")
+        else # '<<?', ? not =, ' ', ':'
             return emit(l, K"<<")
         end
     elseif accept(l, '=')

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -336,6 +336,7 @@ TypeVar(@nospecialize(n)) = _typevar(n::Symbol, Union{}, Any)
 TypeVar(@nospecialize(n), @nospecialize(ub)) = _typevar(n::Symbol, Union{}, ub)
 TypeVar(@nospecialize(n), @nospecialize(lb), @nospecialize(ub)) = _typevar(n::Symbol, lb, ub)
 UnionAll(@nospecialize(v), @nospecialize(t)) = ccall(:jl_type_unionall, Any, (Any, Any), v::TypeVar, t)
+UnionAll(@nospecialize(v), @nospecialize(t), diag::UInt8) = ccall(:jl_type_unionall_diag, Any, (Any, Any, UInt8), v::TypeVar, t, diag)
 
 const Memory{T} = GenericMemory{:not_atomic, T, CPU}
 const MemoryRef{T} = GenericMemoryRef{:not_atomic, T, CPU}

--- a/base/show.jl
+++ b/base/show.jl
@@ -776,6 +776,7 @@ end
 function make_wheres(io::IO, env::SimpleVector, @nospecialize(x::Type))
     seen = IdSet()
     wheres = TypeVar[]
+    diag_overrides = UInt8[]   # parallel to `wheres`; UInt8(0) = no override
     # record things printed by the context
     if io isa IOContext
         for (key, val) in io.dict
@@ -789,6 +790,7 @@ function make_wheres(io::IO, env::SimpleVector, @nospecialize(x::Type))
         if !(x.var in seen)
             push!(seen, x.var)
             push!(wheres, x.var)
+            push!(diag_overrides, _unionall_diag_override(x))
         end
         x = x.body
     end
@@ -798,22 +800,87 @@ function make_wheres(io::IO, env::SimpleVector, @nospecialize(x::Type))
         if p isa TypeVar && !(p in seen)
             push!(seen, p)
             pushfirst!(wheres, p)
+            pushfirst!(diag_overrides, UInt8(0))   # env-derived: no source UnionAll
         end
     end
-    return wheres
+    return wheres, diag_overrides
 end
 
-function show_wheres(io::IO, wheres::Vector{TypeVar})
+# If the UnionAll's diag matches the static-default rule, returns 0 (no override).
+# Otherwise returns the actual diag value (1=CONCRETE, 2=NEVER) so the caller
+# can render with `<<:` on the appropriate side.
+function _unionall_diag_override(u::UnionAll)
+    diag = getfield(u, :diag)
+    diag == 0 && return UInt8(0)
+    default = ccall(:jl_unionall_diag_default, UInt8, (Any, Any), u.var, u.body)
+    return diag == default ? UInt8(0) : diag
+end
+
+function show_wheres(io::IO, wheres::Vector{TypeVar}, diag_overrides::Vector{UInt8}=zeros(UInt8, length(wheres)))
     isempty(wheres) && return
     io = IOContext(io)
     n = length(wheres)
     for i = 1:n
         p = wheres[i]
         print(io, n == 1 ? " where " : i == 1 ? " where {" : ", ")
-        show(io, p)
+        d = i <= length(diag_overrides) ? diag_overrides[i] : UInt8(0)
+        if d == 0
+            show(io, p)
+        else
+            show_typevar_with_diag(io, p, d)
+        end
         io = IOContext(io, :unionall_env => p)
     end
     n > 1 && print(io, "}")
+    nothing
+end
+
+# Print a TypeVar binding when the UnionAll's diag is an explicit override of
+# the default static rule. `diag` is the actual UnionAll diag value:
+#   1 = CONCRETE: marker on the upper-bound side, rendered as `T<<:Ub`
+#   2 = NEVER:    marker on the lower-bound side, rendered as `Lb<<:T` (or `T>>:Lb`)
+# Bounds defaulted to Bottom/Any are made explicit so the marker can attach.
+function show_typevar_with_diag(io::IO, tv::TypeVar, diag::UInt8)
+    in_env = (:unionall_env => tv) in io
+    function show_bound(io::IO, @nospecialize(b))
+        parens = isa(b, UnionAll) && !print_without_params(b)
+        parens && print(io, "(")
+        show(io, b)
+        parens && print(io, ")")
+    end
+    if in_env
+        show_unquoted(io, tv.name)
+        return nothing
+    end
+    lb, ub = tv.lb, tv.ub
+    if diag == 1   # CONCRETE: place `<<:` on the upper side
+        # Always need an explicit upper bound; emit `Any` if ub === Any.
+        if lb !== Bottom
+            show_bound(io, lb)
+            print(io, "<:")
+            show_unquoted(io, tv.name)
+        else
+            show_unquoted(io, tv.name)
+        end
+        print(io, "<<:")
+        show_bound(io, ub)
+    else           # NEVER: place `<<:` on the lower side
+        if lb !== Bottom && ub === Any
+            # Mirror of `Lb<<:T`: write as `T>>:Lb` for parity with `T>:Lb`.
+            show_unquoted(io, tv.name)
+            print(io, ">>:")
+            show_bound(io, lb)
+        else
+            # Make the lower bound explicit (Union{} if defaulted).
+            show_bound(io, lb)
+            print(io, "<<:")
+            show_unquoted(io, tv.name)
+            if ub !== Any
+                print(io, "<:")
+                show_bound(io, ub)
+            end
+        end
+    end
     nothing
 end
 
@@ -821,9 +888,9 @@ function show_typealias(io::IO, @nospecialize(x::Type))
     properx = makeproper(io, x)
     alias = make_typealias(properx)
     alias === nothing && return false
-    wheres = make_wheres(io, alias[2], x)
+    wheres, diag_overrides = make_wheres(io, alias[2], x)
     show_typealias(io, alias[1], x, alias[2], wheres)
-    show_wheres(io, wheres)
+    show_wheres(io, wheres, diag_overrides)
     return true
 end
 
@@ -928,17 +995,17 @@ function show_unionaliases(io::IO, x::Union)
     if first && !tvar && length(aliases) == 1
         alias = aliases[1]
         env = alias[2]::SimpleVector
-        wheres = make_wheres(io, env, x)
+        wheres, diag_overrides = make_wheres(io, env, x)
         show_typealias(io, alias[1], x, env, wheres)
-        show_wheres(io, wheres)
+        show_wheres(io, wheres, diag_overrides)
     else
         for alias in aliases
             print(io, first ? "Union{" : ", ")
             first = false
             env = alias[2]::SimpleVector
-            wheres = make_wheres(io, env, x)
+            wheres, diag_overrides = make_wheres(io, env, x)
             show_typealias(io, alias[1], x, env, wheres)
-            show_wheres(io, wheres)
+            show_wheres(io, wheres, diag_overrides)
         end
         if tvar
             for typ in uniontypes(x)
@@ -1000,8 +1067,10 @@ function _show_type(io::IO, @nospecialize(x::Type))
 
     x = x::UnionAll
     wheres = TypeVar[]
+    diag_overrides = UInt8[]
     let io = IOContext(io)
         while x isa UnionAll
+            override = _unionall_diag_override(x)
             var = x.var
             if var.name === :_ || io_has_tvar_name(io, var.name, x)
                 counter = 1
@@ -1018,6 +1087,7 @@ function _show_type(io::IO, @nospecialize(x::Type))
                 x = x.body
             end
             push!(wheres, var)
+            push!(diag_overrides, override)
             io = IOContext(io, :unionall_env => var)
         end
         if x isa DataType
@@ -1026,7 +1096,7 @@ function _show_type(io::IO, @nospecialize(x::Type))
             show(io, x)
         end
     end
-    show_wheres(io, wheres)
+    show_wheres(io, wheres, diag_overrides)
 end
 
 # Check whether 'sym' (defined in module 'parent') is visible from module 'from'

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -931,7 +931,7 @@ static void jl_setup_type_wrapper(jl_typename_t *tn, jl_svec_t *parameters, jl_v
     jl_gc_wb(tn, *wrapper);
     int np = jl_svec_len(parameters);
     for (int i = np - 1; i >= 0; i--) {
-        *wrapper = jl_new_struct(jl_unionall_type, jl_svecref(parameters, i), *wrapper);
+        *wrapper = jl_new_unionall((jl_tvar_t*)jl_svecref(parameters, i), *wrapper, JL_UNIONALL_DIAG_DYNAMIC);
         tn->wrapper = *wrapper;
         jl_gc_wb(tn, *wrapper);
     }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -929,6 +929,118 @@ jl_value_t *simple_intersect(jl_value_t *a, jl_value_t *b, int overesi)
 
 // unionall types -------------------------------------------------------------
 
+// --- static diagonal-rule analysis ---
+//
+// Given a UnionAll being constructed `body where var`, decide statically
+// whether the diagonal rule will apply to `var`. The dynamic check (in
+// subtype_unionall) marks `var` diagonal iff:
+//   - var occurs covariantly more than once in body, AND
+//   - var does not occur invariantly in body, AND
+//   - var is a leaf typevar (lower bound is leaf-bound)
+// The static analog walks the body once at construction time and counts
+// occurrences. Returns JL_UNIONALL_DIAG_CONCRETE if all three conditions
+// hold, otherwise JL_UNIONALL_DIAG_NEVER.
+
+typedef struct {
+    int cov;  // covariant occurrence count, saturated at 2
+    int inv;  // 1 if var occurs invariantly anywhere
+} _diag_count_t;
+
+static void diag_count_static(jl_value_t *t, jl_tvar_t *var, int param_cov,
+                              _diag_count_t *out) JL_NOTSAFEPOINT
+{
+    if (out->inv && out->cov >= 2)
+        return; // already saturated
+    if (jl_is_typevar(t)) {
+        if ((jl_tvar_t*)t == var) {
+            if (param_cov) {
+                if (out->cov < 2) out->cov++;
+            }
+            else {
+                out->inv = 1;
+            }
+        }
+        return;
+    }
+    if (jl_is_uniontype(t)) {
+        // Worst-case (max) across union branches for cov, OR for inv.
+        _diag_count_t a = {0, 0}, b = {0, 0};
+        diag_count_static(((jl_uniontype_t*)t)->a, var, param_cov, &a);
+        diag_count_static(((jl_uniontype_t*)t)->b, var, param_cov, &b);
+        int mc = (a.cov > b.cov) ? a.cov : b.cov;
+        if (mc > 2) mc = 2;
+        if (out->cov < mc) out->cov = mc;
+        if (out->cov > 2) out->cov = 2;
+        out->inv |= a.inv | b.inv;
+        return;
+    }
+    if (jl_is_unionall(t)) {
+        jl_unionall_t *ua = (jl_unionall_t*)t;
+        if (ua->var == var) // shadowed
+            return;
+        // Bounds of inner typevars are invariant positions
+        diag_count_static(ua->var->lb, var, 0, out);
+        diag_count_static(ua->var->ub, var, 0, out);
+        diag_count_static(ua->body, var, param_cov, out);
+        return;
+    }
+    if (jl_is_vararg(t)) {
+        jl_vararg_t *vm = (jl_vararg_t*)t;
+        if (vm->T) {
+            // Each value in a Vararg can be a separate value, so count twice
+            diag_count_static(vm->T, var, param_cov, out);
+            diag_count_static(vm->T, var, param_cov, out);
+        }
+        if (vm->N)
+            diag_count_static(vm->N, var, 0, out); // N is invariant
+        return;
+    }
+    if (jl_is_datatype(t)) {
+        int istuple = jl_is_tuple_type(t);
+        size_t np = jl_nparams(t);
+        for (size_t i = 0; i < np; i++) {
+            int child_cov = param_cov && istuple;
+            diag_count_static(jl_tparam(t, i), var, child_cov, out);
+        }
+        return;
+    }
+}
+
+static uint8_t compute_unionall_diag_static(jl_tvar_t *var, jl_value_t *body) JL_NOTSAFEPOINT
+{
+    _diag_count_t c = {0, 0};
+    diag_count_static(body, var, 1, &c);
+    if (!c.inv && c.cov > 1 && is_leaf_bound(var->lb))
+        return JL_UNIONALL_DIAG_CONCRETE;
+    return JL_UNIONALL_DIAG_NEVER;
+}
+
+// What the static auto rule would assign to a UnionAll with this var/body.
+// Used by printing to decide whether to emit `<:` (matches default) or `<<:`
+// (explicit override).
+JL_DLLEXPORT uint8_t jl_unionall_diag_default(jl_tvar_t *var, jl_value_t *body) JL_NOTSAFEPOINT
+{
+    return compute_unionall_diag_static(var, body);
+}
+
+// Allocate a UnionAll directly with all three fields. Avoids jl_new_struct
+// because the `diag` field is an inline UInt8 (1 byte) and set_nth_field
+// would expect a boxed UInt8 argument; we don't always have UInt8 boxes
+// available (early bootstrap) and the value is naturally a C uint8_t.
+JL_DLLEXPORT jl_value_t *jl_new_unionall(jl_tvar_t *var, jl_value_t *body, uint8_t diag)
+{
+    jl_task_t *ct = jl_current_task;
+    jl_unionall_t *u = (jl_unionall_t*)jl_gc_alloc(ct->ptls,
+                                                   jl_datatype_size(jl_unionall_type),
+                                                   jl_unionall_type);
+    if (jl_unionall_type->smalltag)
+        jl_set_typetagof(u, jl_unionall_type->smalltag, 0);
+    u->var = var;
+    u->body = body;
+    u->diag = diag;
+    return (jl_value_t*)u;
+}
+
 JL_DLLEXPORT jl_value_t *jl_type_unionall(jl_tvar_t *v, jl_value_t *body)
 {
     if (jl_is_vararg(body)) {
@@ -969,7 +1081,31 @@ JL_DLLEXPORT jl_value_t *jl_type_unionall(jl_tvar_t *v, jl_value_t *body)
         return body;
     //if (v->lb == v->ub)  // TODO maybe
     //    return jl_substitute_var(body, v, v->ub);
-    return jl_new_struct(jl_unionall_type, v, body);
+    return jl_new_unionall(v, body, compute_unionall_diag_static(v, body));
+}
+
+// Like jl_type_unionall, but uses an explicit `diag` value instead of the
+// statically-computed default. Used to implement the `<<:` / `>>:` syntax.
+//
+// When `diag == JL_UNIONALL_DIAG_CONCRETE` the typevar is forced to be diagonal,
+// so the `body == v` and `!jl_has_typevar(body, v)` simplifications that
+// `jl_type_unionall` performs are inappropriate -- they would silently drop the
+// concreteness constraint. Vararg handling and type-error checks still defer.
+JL_DLLEXPORT jl_value_t *jl_type_unionall_diag(jl_tvar_t *v, jl_value_t *body, uint8_t diag)
+{
+    if (diag > JL_UNIONALL_DIAG_NEVER)
+        jl_errorf("invalid UnionAll diag value: %u", (unsigned)diag);
+    if (jl_is_vararg(body))
+        return jl_type_unionall(v, body); // vararg wrapping is handled by the regular path
+    if (!jl_is_type(body) && !jl_is_typevar(body) && !jl_is_typeapp(body))
+        jl_type_error("UnionAll", (jl_value_t*)jl_type_type, body);
+    if (diag != JL_UNIONALL_DIAG_CONCRETE) {
+        if (body == (jl_value_t*)v)
+            return v->ub;
+        if (!jl_has_typevar(body, v))
+            return body;
+    }
+    return jl_new_unionall(v, body, diag);
 }
 
 // --- type instantiation and cache ---
@@ -1567,7 +1703,7 @@ jl_unionall_t *jl_rename_unionall(jl_unionall_t *u)
     JL_GC_PUSH2(&v, &t);
     jl_typeenv_t env = { u->var, (jl_value_t *)v, NULL };
     t = inst_type_w_(u->body, &env, NULL, 0, 0);
-    t = jl_new_struct(jl_unionall_type, v, t);
+    t = jl_new_unionall(v, t, u->diag);
     JL_GC_POP();
     return (jl_unionall_t*)t;
 }
@@ -1614,7 +1750,7 @@ jl_value_t *jl_rewrap_unionall(jl_value_t *t, jl_value_t *u)
     //if (v->lb == v->ub)  // TODO maybe
     //    t = jl_substitute_var(body, v, v->ub);
     //else
-    t = jl_new_struct(jl_unionall_type, v, t);
+    t = jl_new_unionall(v, t, ((jl_unionall_t*)u)->diag);
     JL_GC_POP();
     return t;
 }
@@ -1627,7 +1763,7 @@ jl_value_t *jl_rewrap_unionall_(jl_value_t *t, jl_value_t *u)
         return t;
     t = jl_rewrap_unionall_(t, ((jl_unionall_t*)u)->body);
     JL_GC_PUSH1(&t);
-    t = jl_new_struct(jl_unionall_type, ((jl_unionall_t*)u)->var, t);
+    t = jl_new_unionall(((jl_unionall_t*)u)->var, t, ((jl_unionall_t*)u)->diag);
     JL_GC_POP();
     return t;
 }
@@ -1705,11 +1841,11 @@ jl_value_t *jl_substitute_datatype(jl_value_t *t, jl_datatype_t * x, jl_datatype
             jl_tvar_t *newtvar = jl_new_typevar(ut->var->name, lb, ub);
             JL_GC_PUSH1(&newtvar);
             body = jl_substitute_var(body, ut->var, (jl_value_t*)newtvar);
-            t = jl_new_struct(jl_unionall_type, newtvar, body);
+            t = jl_new_unionall(newtvar, body, ut->diag);
             JL_GC_POP();
         }
         else if (body != ut->body) {
-            t = jl_new_struct(jl_unionall_type, ut->var, body);
+            t = jl_new_unionall(ut->var, body, ut->diag);
         }
         JL_GC_POP();
     }
@@ -2060,7 +2196,7 @@ static jl_value_t *normalize_unionalls(jl_value_t *t)
         jl_value_t *body = normalize_unionalls(u->body);
         JL_GC_PUSH2(&body, &t);
         if (body != u->body) {
-            t = jl_new_struct(jl_unionall_type, u->var, body);
+            t = jl_new_unionall(u->var, body, u->diag);
             u = (jl_unionall_t*)t;
         }
 
@@ -2679,7 +2815,7 @@ static jl_value_t *inst_type_w_(jl_value_t *t, jl_typeenv_t *env, jl_typestack_t
             }
             else if (newbody != ua->body || var != (jl_value_t*)ua->var) {
                 // if t's parameters are not bound in the environment, return it uncopied (#9378)
-                t = jl_new_struct(jl_unionall_type, var, newbody);
+                t = jl_new_unionall((jl_tvar_t*)var, newbody, ua->diag);
             }
         }
         JL_GC_POP();
@@ -3148,9 +3284,15 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_set_typetagof(jl_bottom_type, jl_typeofbottom_tag, GC_OLD_MARKED);
     jl_typeofbottom_type->instance = jl_bottom_type;
 
+    // create UInt8 early so it can be used as the inline storage type for
+    // UnionAll's `diag` field. Its super is fixed up later (to Unsigned).
+    jl_uint8_type = jl_new_primitivetype((jl_value_t*)jl_symbol("UInt8"), core,
+                                         jl_any_type, jl_emptysvec, 8);
+    XX(uint8);
+
     jl_unionall_type = jl_new_datatype(jl_symbol("UnionAll"), core, type_type, jl_emptysvec,
-                                       jl_perm_symsvec(2, "var", "body"),
-                                       jl_svec(2, jl_tvar_type, jl_any_type),
+                                       jl_perm_symsvec(3, "var", "body", "diag"),
+                                       jl_svec(3, jl_tvar_type, jl_any_type, jl_uint8_type),
                                        jl_emptysvec, 0, 0, 2);
     XX(unionall);
     // It seems like we probably usually end up needing the box for kinds (often used in an Any context), so force it to exist
@@ -3169,7 +3311,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_precompute_memoized_dt(type_type, 0); // update the hash value ASAP
     type_type->hasfreetypevars = 1;
     type_type->ismutationfree = 1;
-    jl_type_typename->wrapper = jl_new_struct(jl_unionall_type, tttvar, (jl_value_t*)jl_type_type);
+    jl_type_typename->wrapper = jl_new_unionall(tttvar, (jl_value_t*)jl_type_type, JL_UNIONALL_DIAG_DYNAMIC);
     jl_type_type = (jl_unionall_t*)jl_type_typename->wrapper;
 
     jl_vararg_type = jl_new_datatype(jl_symbol("TypeofVararg"), core, jl_any_type, jl_emptysvec,
@@ -3210,9 +3352,8 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_uint64_type = jl_new_primitivetype((jl_value_t*)jl_symbol("UInt64"), core,
                                           jl_any_type, jl_emptysvec, 64);
     XX(uint64);
-    jl_uint8_type = jl_new_primitivetype((jl_value_t*)jl_symbol("UInt8"), core,
-                                         jl_any_type, jl_emptysvec, 8);
-    XX(uint8);
+    // jl_uint8_type was created earlier (so it could be used as the storage
+    // type of UnionAll's `diag` field); skip recreation here.
     jl_uint16_type = jl_new_primitivetype((jl_value_t*)jl_symbol("UInt16"), core,
                                           jl_any_type, jl_emptysvec, 16);
     XX(uint16);
@@ -3789,8 +3930,9 @@ void jl_init_types(void) JL_GC_DISABLED
     tttvar = jl_new_typevar(jl_symbol("T"),
                             (jl_value_t*)jl_bottom_type,
                             (jl_value_t*)jl_anytuple_type);
-    jl_anytuple_type_type = (jl_unionall_t*)jl_new_struct(jl_unionall_type,
-                                                          tttvar, (jl_value_t*)jl_wrap_Type((jl_value_t*)tttvar));
+    jl_anytuple_type_type = (jl_unionall_t*)jl_new_unionall(tttvar,
+                                                            (jl_value_t*)jl_wrap_Type((jl_value_t*)tttvar),
+                                                            JL_UNIONALL_DIAG_DYNAMIC);
 
     jl_tvar_t *ntval_var = jl_new_typevar(jl_symbol("T"), (jl_value_t*)jl_bottom_type,
                                           (jl_value_t*)jl_anytuple_type);

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -15,7 +15,7 @@
 (define prec-lazy-and    (add-dots '(&&)))
 (define prec-comparison
   (append! '(in isa)
-           (add-dots '(> < >= ≥ <= ≤ == === ≡ != ≠ !== ≢ ∈ ∉ ∋ ∌ ⊆ ⊈ ⊂ ⊄ ⊊ ∝ ∊ ∍ ∥ ∦ ∷ ∺ ∻ ∽ ∾ ≁ ≃ ≂ ≄ ≅ ≆ ≇ ≈ ≉ ≊ ≋ ≌ ≍ ≎ ≐ ≑ ≒ ≓ ≖ ≗ ≘ ≙ ≚ ≛ ≜ ≝ ≞ ≟ ≣ ≦ ≧ ≨ ≩ ≪ ≫ ≬ ≭ ≮ ≯ ≰ ≱ ≲ ≳ ≴ ≵ ≶ ≷ ≸ ≹ ≺ ≻ ≼ ≽ ≾ ≿ ⊀ ⊁ ⊃ ⊅ ⊇ ⊉ ⊋ ⊏ ⊐ ⊑ ⊒ ⊜ ⊩ ⊬ ⊮ ⊰ ⊱ ⊲ ⊳ ⊴ ⊵ ⊶ ⊷ ⋍ ⋐ ⋑ ⋕ ⋖ ⋗ ⋘ ⋙ ⋚ ⋛ ⋜ ⋝ ⋞ ⋟ ⋠ ⋡ ⋢ ⋣ ⋤ ⋥ ⋦ ⋧ ⋨ ⋩ ⋪ ⋫ ⋬ ⋭ ⋲ ⋳ ⋴ ⋵ ⋶ ⋷ ⋸ ⋹ ⋺ ⋻ ⋼ ⋽ ⋾ ⋿ ⟈ ⟉ ⟒ ⦷ ⧀ ⧁ ⧡ ⧣ ⧤ ⧥ ⩦ ⩧ ⩪ ⩫ ⩬ ⩭ ⩮ ⩯ ⩰ ⩱ ⩲ ⩳ ⩵ ⩶ ⩷ ⩸ ⩹ ⩺ ⩻ ⩼ ⩽ ⩾ ⩿ ⪀ ⪁ ⪂ ⪃ ⪄ ⪅ ⪆ ⪇ ⪈ ⪉ ⪊ ⪋ ⪌ ⪍ ⪎ ⪏ ⪐ ⪑ ⪒ ⪓ ⪔ ⪕ ⪖ ⪗ ⪘ ⪙ ⪚ ⪛ ⪜ ⪝ ⪞ ⪟ ⪠ ⪡ ⪢ ⪣ ⪤ ⪥ ⪦ ⪧ ⪨ ⪩ ⪪ ⪫ ⪬ ⪭ ⪮ ⪯ ⪰ ⪱ ⪲ ⪳ ⪴ ⪵ ⪶ ⪷ ⪸ ⪹ ⪺ ⪻ ⪼ ⪽ ⪾ ⪿ ⫀ ⫁ ⫂ ⫃ ⫄ ⫅ ⫆ ⫇ ⫈ ⫉ ⫊ ⫋ ⫌ ⫍ ⫎ ⫏ ⫐ ⫑ ⫒ ⫓ ⫔ ⫕ ⫖ ⫗ ⫘ ⫙ ⫷ ⫸ ⫹ ⫺ ⊢ ⊣ ⟂ ⫪ ⫫ <: >:))))
+           (add-dots '(> < >= ≥ <= ≤ == === ≡ != ≠ !== ≢ ∈ ∉ ∋ ∌ ⊆ ⊈ ⊂ ⊄ ⊊ ∝ ∊ ∍ ∥ ∦ ∷ ∺ ∻ ∽ ∾ ≁ ≃ ≂ ≄ ≅ ≆ ≇ ≈ ≉ ≊ ≋ ≌ ≍ ≎ ≐ ≑ ≒ ≓ ≖ ≗ ≘ ≙ ≚ ≛ ≜ ≝ ≞ ≟ ≣ ≦ ≧ ≨ ≩ ≪ ≫ ≬ ≭ ≮ ≯ ≰ ≱ ≲ ≳ ≴ ≵ ≶ ≷ ≸ ≹ ≺ ≻ ≼ ≽ ≾ ≿ ⊀ ⊁ ⊃ ⊅ ⊇ ⊉ ⊋ ⊏ ⊐ ⊑ ⊒ ⊜ ⊩ ⊬ ⊮ ⊰ ⊱ ⊲ ⊳ ⊴ ⊵ ⊶ ⊷ ⋍ ⋐ ⋑ ⋕ ⋖ ⋗ ⋘ ⋙ ⋚ ⋛ ⋜ ⋝ ⋞ ⋟ ⋠ ⋡ ⋢ ⋣ ⋤ ⋥ ⋦ ⋧ ⋨ ⋩ ⋪ ⋫ ⋬ ⋭ ⋲ ⋳ ⋴ ⋵ ⋶ ⋷ ⋸ ⋹ ⋺ ⋻ ⋼ ⋽ ⋾ ⋿ ⟈ ⟉ ⟒ ⦷ ⧀ ⧁ ⧡ ⧣ ⧤ ⧥ ⩦ ⩧ ⩪ ⩫ ⩬ ⩭ ⩮ ⩯ ⩰ ⩱ ⩲ ⩳ ⩵ ⩶ ⩷ ⩸ ⩹ ⩺ ⩻ ⩼ ⩽ ⩾ ⩿ ⪀ ⪁ ⪂ ⪃ ⪄ ⪅ ⪆ ⪇ ⪈ ⪉ ⪊ ⪋ ⪌ ⪍ ⪎ ⪏ ⪐ ⪑ ⪒ ⪓ ⪔ ⪕ ⪖ ⪗ ⪘ ⪙ ⪚ ⪛ ⪜ ⪝ ⪞ ⪟ ⪠ ⪡ ⪢ ⪣ ⪤ ⪥ ⪦ ⪧ ⪨ ⪩ ⪪ ⪫ ⪬ ⪭ ⪮ ⪯ ⪰ ⪱ ⪲ ⪳ ⪴ ⪵ ⪶ ⪷ ⪸ ⪹ ⪺ ⪻ ⪼ ⪽ ⪾ ⪿ ⫀ ⫁ ⫂ ⫃ ⫄ ⫅ ⫆ ⫇ ⫈ ⫉ ⫊ ⫋ ⫌ ⫍ ⫎ ⫏ ⫐ ⫑ ⫒ ⫓ ⫔ ⫕ ⫖ ⫗ ⫘ ⫙ ⫷ ⫸ ⫹ ⫺ ⊢ ⊣ ⟂ ⫪ ⫫ <: >: <<: >>:))))
 (define prec-pipe<       '(|.<\|| |<\||))
 (define prec-pipe>       '(|.\|>| |\|>|))
 (define prec-colon       (append! '(: |..|) (add-dots '(… ⁝ ⋮ ⋱ ⋰ ⋯))))
@@ -61,7 +61,7 @@
 ; only allow/strip suffixes for some operators
 (define no-suffix? (Set (append prec-assignment prec-conditional prec-lazy-or prec-lazy-and
                                 prec-colon prec-decl prec-dot
-                                '(-> |<:| |>:| in isa $)
+                                '(-> |<:| |>:| |<<:| |>>:| in isa $)
                                 (list ctrans-op trans-op vararg-op))))
 (define (maybe-strip-op-suffix op)
   (if (symbol? op)
@@ -843,7 +843,7 @@
              (let ((op   (caddr ex))
                    (arg1 (cadr ex))
                    (arg2 (cadddr ex)))
-               (if (or (eq? op '|<:|) (eq? op '|>:|))
+               (if (memq op '(|<:| |>:| |<<:| |>>:|))
                    `(,op ,arg1 ,arg2)
                    `(call ,op ,arg1 ,arg2))))
             (else ex)))))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -467,13 +467,26 @@
                                          ;; each static param can see just the previous ones
                                          (cons (make-assignment (car t) (replace-vars (car sp) ren))
                                                assigns))))
+                           ;; 4-element argdata: types, sparams, location, diags.
+                           ;; The diag svec carries one UInt8 per sparam: 0xFF for
+                           ;; `auto` (use jl_type_unionall's static analysis), 1 for
+                           ;; `<<:` (CONCRETE), 2 for `>>:` (NEVER), 0 for explicit
+                           ;; DYNAMIC. jl_method_def consults this when wrapping
+                           ;; the argument tuple in UnionAlls so user-written
+                           ;; `<<:` / `>>:` annotations survive into the method
+                           ;; signature; auto runs the static rule.
                            (call (core svec) (call (core svec)
                                                    ,@(dots->vararg
                                                       (map (lambda (ty)
                                                              (replace-vars ty renames))
                                                            types)))
                                  (call (core svec) ,@temps)
-                                 (inert ,loc)))
+                                 (inert ,loc)
+                                 (call (core svec) ,@(map (lambda (sp)
+                                                            (let ((d (cadddr sp)))
+                                                              `(call (core UInt8)
+                                                                     ,(if (eq? d diag-auto) #xff d))))
+                                                          sparams))))
                           ,body))))
        (if (or (symbol? name) (globalref? name))
            `(block ,@generator (method ,name) (latestworld-if-toplevel) ,mdef (unnecessary ,name))  ;; return the function
@@ -4012,11 +4025,22 @@ f(x) = yt(x)
           (if iskw
               `(,(car types) ,(cadr types) ,closure-type ,@(cdddr types))
               `(,closure-type ,@(cdr types))))
-         (loc (caddddr te)))
+         (loc (caddddr te))
+         ;; Preserve the diag svec (5th argument of argdata svec, i.e. position
+         ;; 5 in the (call (core svec) types sparams loc diag) form) when it's
+         ;; present on `te`, and extend it with defaults for any newly-introduced
+         ;; closure-parameter sparams. Without this, `<<:` / `>>:` annotations
+         ;; on a method declared inside a closure would be silently dropped by
+         ;; closure-conversion.
+         (orig-diags (and (length> te 5) (cddr (list-ref te 5))))
+         (extra-diags (map (lambda (_) `(call (core UInt8) #xff)) type-sp)))
     `(call (core svec)
            (call (core svec) ,@newtypes)
            (call (core svec) ,@(append (cddr (cadddr te)) type-sp))
-           ,loc)))
+           ,loc
+           ,@(if orig-diags
+                 (list `(call (core svec) ,@orig-diags ,@extra-diags))
+                 '()))))
 
 ;; collect all toplevel-butfirst expressions inside `e`, and return
 ;; (ex . stmts), where `ex` is the expression to evaluated and

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -186,28 +186,64 @@
                        ,@(list-tail body (+ 1 (length meta))))))))))
 
 
-;; convert x<:T<:y etc. exprs into (name lower-bound upper-bound)
-;; a bound is #f if not specified
+;; UnionAll diag annotations at the lowering level. `auto` is the
+;; default (the C constructor picks CONCRETE or NEVER by static analysis);
+;; the explicit C values 1/2 map to forms produced by the `<<:` / `>>:`
+;; syntax. The C-level value 0 (DYNAMIC, "compute at subtype time") is
+;; intentionally distinct from `auto` and not produced by `<:`.
+(define diag-auto     'auto)
+(define diag-concrete 1)
+(define diag-never    2)
+
+;; relational operator decoding for typevar bounds. Returns (dir tight?)
+;; where dir is '< (subtype-style) or '> (supertype-style), and tight? is
+;; #t when the operator is the strict-concreteness form `<<:`/`>>:`.
+(define (typevar-rel op)
+  (cond ((eq? op '|<:|)  (cons '< #f))
+        ((eq? op '|>:|)  (cons '> #f))
+        ((eq? op '|<<:|) (cons '< #t))
+        ((eq? op '|>>:|) (cons '> #t))
+        (else #f)))
+
+;; convert x<:T<:y etc. exprs into (name lower-bound upper-bound diag)
+;; a bound is #f if not specified; diag is 0/1/2 as defined above.
 (define (analyze-typevar e)
   (define (check-sym s)
     (if (symbol? (unescape s)) ; unescape for macroexpand.scm use
         s
         (error (string "invalid type parameter name \"" (deparse s) "\""))))
-  (cond ((atom? e) (list (check-sym e) #f #f))
-        ((eq? (car e) 'var-bounds)  (cdr e))
+  (cond ((atom? e) (list (check-sym e) #f #f diag-auto))
+        ((eq? (car e) 'var-bounds)
+         (let ((b (cdr e)))
+           (if (length= b 3) (append b (list diag-auto)) b)))
         ((and (eq? (car e) 'comparison) (length= e 6))
-         (let* ((lhs (list-ref e 1))
-                (rel (list-ref e 2))
-                (t (check-sym (list-ref e 3)))
-                (rel-same (eq? rel (list-ref e 4)))
-                (rhs (list-ref e 5)))
-           (cond ((and rel-same (eq? rel '|<:|)) (list t lhs rhs))
-                 ((and rel-same (eq? rel '|>:|)) (list t rhs lhs))
-                 (else (error "invalid bounds in \"where\"")))))
+         (let* ((lhs   (list-ref e 1))
+                (rel1  (typevar-rel (list-ref e 2)))
+                (t     (check-sym (list-ref e 3)))
+                (rel2  (typevar-rel (list-ref e 4)))
+                (rhs   (list-ref e 5)))
+           (if (or (not rel1) (not rel2) (not (eq? (car rel1) (car rel2))))
+               (error "invalid bounds in \"where\""))
+           (if (and (cdr rel1) (cdr rel2))
+               (error "invalid bounds in \"where\": `<<:` (or `>>:`) may only appear once"))
+           (let ((lb (if (eq? (car rel1) '<) lhs rhs))
+                 (ub (if (eq? (car rel1) '<) rhs lhs))
+                 ;; from T's perspective: tight on the upper-bound side -> concrete;
+                 ;; tight on the lower-bound side -> never.
+                 (diag (cond ((and (eq? (car rel1) '<) (cdr rel1)) diag-never)
+                             ((and (eq? (car rel1) '<) (cdr rel2)) diag-concrete)
+                             ((and (eq? (car rel1) '>) (cdr rel1)) diag-concrete)
+                             ((and (eq? (car rel1) '>) (cdr rel2)) diag-never)
+                             (else diag-auto))))
+             (list t lb ub diag))))
         ((eq? (car e) '|<:|)
-         (list (check-sym (cadr e)) #f (caddr e)))
+         (list (check-sym (cadr e)) #f (caddr e) diag-auto))
         ((eq? (car e) '|>:|)
-         (list (check-sym (cadr e)) (caddr e) #f))
+         (list (check-sym (cadr e)) (caddr e) #f diag-auto))
+        ((eq? (car e) '|<<:|)
+         (list (check-sym (cadr e)) #f (caddr e) diag-concrete))
+        ((eq? (car e) '|>>:|)
+         (list (check-sym (cadr e)) (caddr e) #f diag-never))
         (else (error "invalid variable expression in \"where\""))))
 
 (define (sparam-name-bounds params)
@@ -2254,9 +2290,13 @@
 
 (define (expand-where body var)
   (let* ((bounds (analyze-typevar var))
-         (v  (car bounds)))
+         (v     (car bounds))
+         (diag  (if (length> bounds 3) (cadddr bounds) diag-auto)))
     `(let (= ,v ,(bounds-to-TypeVar bounds))
-       (call (core UnionAll) ,v ,body))))
+       (call (core UnionAll) ,v ,body
+             ,@(if (eq? diag diag-auto)
+                   '()
+                   (list `(call (core UInt8) ,diag)))))))
 
 (define (expand-wheres body vars)
   (if (null? vars)

--- a/src/julia.h
+++ b/src/julia.h
@@ -531,6 +531,12 @@ typedef struct {
     JL_DATA_TYPE
     jl_tvar_t *JL_NONNULL var;
     jl_value_t *JL_NONNULL body;
+    // 3-valued field controlling the diagonal rule for `var` in `body`.
+    // See JL_UNIONALL_DIAG_* in julia_internal.h:
+    //   0: dynamic semantics (current behavior; computed at subtype time)
+    //   1: always concrete (diagonal rule applies)
+    //   2: never concrete  (diagonal rule does not apply)
+    uint8_t diag;
 } jl_unionall_t;
 
 // represents the "name" part of a DataType, describing the syntactic structure

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -948,6 +948,22 @@ JL_DLLEXPORT jl_value_t *jl_instantiate_type_in_env(jl_value_t *ty, jl_unionall_
 jl_value_t *jl_substitute_var(jl_value_t *t, jl_tvar_t *var, jl_value_t *val);
 jl_value_t *jl_substitute_var_nothrow(jl_value_t *t, jl_tvar_t *var, jl_value_t *val, int nothrow);
 jl_unionall_t *jl_rename_unionall(jl_unionall_t *u);
+
+// Diagonal-rule mode for the `diag` field of UnionAll.
+// 0 = dynamic (current behavior, evaluated during subtype check)
+// 1 = always concrete (force the diagonal rule to apply)
+// 2 = never concrete  (force the diagonal rule to NOT apply)
+#define JL_UNIONALL_DIAG_DYNAMIC  ((uint8_t)0)
+#define JL_UNIONALL_DIAG_CONCRETE ((uint8_t)1)
+#define JL_UNIONALL_DIAG_NEVER    ((uint8_t)2)
+
+// Allocate a UnionAll directly, setting all three fields. Bypasses jl_new_struct
+// because the `diag` field is an inline UInt8 and would otherwise require a
+// boxed UInt8 argument (and the box caches may not yet exist during early
+// bootstrap).
+JL_DLLEXPORT jl_value_t *jl_new_unionall(jl_tvar_t *var, jl_value_t *body, uint8_t diag);
+JL_DLLEXPORT jl_value_t *jl_type_unionall_diag(jl_tvar_t *v, jl_value_t *body, uint8_t diag);
+JL_DLLEXPORT uint8_t jl_unionall_diag_default(jl_tvar_t *var, jl_value_t *body) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_unwrap_unionall(jl_value_t *v JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_rewrap_unionall(jl_value_t *t, jl_value_t *u);
 JL_DLLEXPORT jl_value_t *jl_rewrap_unionall_(jl_value_t *t, jl_value_t *u);

--- a/src/method.c
+++ b/src/method.c
@@ -1360,7 +1360,7 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
                       jl_symbol_name(file),
                       line,
                       jl_symbol_name(((jl_tvar_t*)tv)->name));
-        argtype = jl_new_struct(jl_unionall_type, tv, argtype);
+        argtype = jl_new_unionall((jl_tvar_t*)tv, argtype, JL_UNIONALL_DIAG_DYNAMIC);
     }
     if (jl_has_free_typevars(argtype)) {
         jl_exceptionf(jl_argumenterror_type,

--- a/src/method.c
+++ b/src/method.c
@@ -1262,10 +1262,20 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
                                         jl_code_info_t *f,
                                         jl_module_t *module)
 {
-    // argdata is svec(svec(types...), svec(typevars...), functionloc)
+    // argdata is svec(svec(types...), svec(typevars...), functionloc[, svec(diags...)]).
+    // The 4th slot is optional: when present it contains one UInt8 per typevar
+    // saying which UnionAll diag annotation to use for that binding (see jl_method_def
+    // diag handling below). Older lowering (and runtime callers via essentials.jl)
+    // emit only 3 slots and we fall back to JL_UNIONALL_DIAG_DYNAMIC.
     jl_svec_t *atypes = (jl_svec_t*)jl_svecref(argdata, 0);
     jl_svec_t *tvars = (jl_svec_t*)jl_svecref(argdata, 1);
     jl_value_t *functionloc = jl_svecref(argdata, 2);
+    jl_svec_t *tvar_diags = NULL;
+    if (jl_svec_len(argdata) >= 4) {
+        tvar_diags = (jl_svec_t*)jl_svecref(argdata, 3);
+        assert(jl_is_svec(tvar_diags));
+        assert(jl_svec_len(tvar_diags) == jl_svec_len(tvars));
+    }
     assert(jl_is_svec(atypes));
     assert(jl_is_svec(tvars));
     size_t nargs = jl_svec_len(atypes);
@@ -1360,7 +1370,26 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
                       jl_symbol_name(file),
                       line,
                       jl_symbol_name(((jl_tvar_t*)tv)->name));
-        argtype = jl_new_unionall((jl_tvar_t*)tv, argtype, JL_UNIONALL_DIAG_DYNAMIC);
+        // Apply per-tvar diag annotation. The encoding in tvar_diags is:
+        //   0xFF — "auto": pick the diag via static analysis of the body
+        //          (jl_unionall_diag_default); always wrap in a UnionAll even
+        //          when the var doesn't appear in the body, since the method's
+        //          source code may still reference it via static_parameter.
+        //   0/1/2 — explicit JL_UNIONALL_DIAG_DYNAMIC/CONCRETE/NEVER.
+        // 3-element argdata (no diag svec) — emitted by base/essentials.jl's
+        // _defaultctors when synthesizing default struct constructors — also
+        // gets the auto treatment, so default constructors pick up the static
+        // rule the same way regular `where` clauses do.
+        uint8_t encoded = 0xFF;
+        if (tvar_diags != NULL) {
+            jl_value_t *dv = jl_svecref(tvar_diags, i - 1);
+            assert(jl_is_uint8(dv));
+            encoded = *(uint8_t*)jl_data_ptr(dv);
+        }
+        uint8_t diag = (encoded == 0xFF)
+            ? jl_unionall_diag_default((jl_tvar_t*)tv, argtype)
+            : encoded;
+        argtype = jl_new_unionall((jl_tvar_t*)tv, argtype, diag);
     }
     if (jl_has_free_typevars(argtype)) {
         jl_exceptionf(jl_argumenterror_type,

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1066,7 +1066,13 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
     //  ( Tuple{Int, Int}    <: Tuple{T, T} where T) but
     // !( Tuple{Int, String} <: Tuple{T, T} where T)
     // Then check concreteness by checking that the lower bound is not an abstract type.
-    int diagonal = vb.occurs_cov > 1 && !var_occurs_invariant(u->body, u->var);
+    int diagonal;
+    if (u->diag == JL_UNIONALL_DIAG_CONCRETE)
+        diagonal = 1;
+    else if (u->diag == JL_UNIONALL_DIAG_NEVER)
+        diagonal = 0;
+    else
+        diagonal = vb.occurs_cov > 1 && !var_occurs_invariant(u->body, u->var);
     if (ans && (vb.concrete || (diagonal && is_leaf_typevar(u->var)))) {
         if (vb.concrete && !diagonal && !is_leaf_bound(vb.ub)) {
             // a non-diagonal var can only be a subtype of a diagonal var if its
@@ -3064,7 +3070,7 @@ static jl_value_t *omit_bad_union(jl_value_t *u, jl_tvar_t *t)
                     var = jl_new_typevar(var->name, var->lb, ub);
                     body = jl_substitute_var(body, ((jl_unionall_t *)u)->var, (jl_value_t *)var);
                 }
-                res = jl_new_struct(jl_unionall_type, var, body);
+                res = jl_new_unionall(var, body, ((jl_unionall_t *)u)->diag);
             }
         }
         JL_GC_POP();
@@ -3289,9 +3295,9 @@ static jl_value_t *finish_unionall(jl_value_t *res JL_MAYBE_UNROOTED, jl_varbind
                     has_typevar_via_flatten_env(vb->lb, ivar, allvars, checked) ||
                     has_typevar_via_flatten_env(vb->ub, ivar, allvars, checked)) {
                     if (innerflag & 1)
-                        *btemp->lb = jl_new_struct(jl_unionall_type, vb->var, ilb);
+                        *btemp->lb = jl_new_unionall(vb->var, ilb, JL_UNIONALL_DIAG_DYNAMIC);
                     if (innerflag & 2)
-                        *btemp->ub = jl_new_struct(jl_unionall_type, vb->var, iub);
+                        *btemp->ub = jl_new_unionall(vb->var, iub, JL_UNIONALL_DIAG_DYNAMIC);
                 }
                 else {
                     assert(btemp->root != vb);
@@ -3497,8 +3503,11 @@ static jl_value_t *intersect_unionall_(jl_value_t *t, jl_unionall_t *u, jl_stenv
     else {
         res = intersect(u->body, t, e, param);
     }
-    vb->concrete |= (vb->occurs_cov > 1 && is_leaf_typevar(u->var) &&
-                     !var_occurs_invariant(u->body, u->var));
+    if (u->diag == JL_UNIONALL_DIAG_CONCRETE)
+        vb->concrete = 1;
+    else if (u->diag == JL_UNIONALL_DIAG_DYNAMIC)
+        vb->concrete |= (vb->occurs_cov > 1 && is_leaf_typevar(u->var) &&
+                         !var_occurs_invariant(u->body, u->var));
 
     // handle the "diagonal dispatch" rule, which says that a type var occurring more
     // than once, and only in covariant position, is constrained to concrete types. E.g.
@@ -4930,7 +4939,7 @@ static jl_value_t *insert_nondiagonal(jl_value_t *type, jl_varbinding_t *troot, 
         JL_GC_PUSH3(&newbody, &newvar, &type);
         if (body == newbody || jl_has_typevar(newbody, var)) {
             if (body != newbody)
-                type = jl_new_struct(jl_unionall_type, var, newbody);
+                type = jl_new_unionall(var, newbody, ((jl_unionall_t*)type)->diag);
             // n.b. we do not widen lb, since that would be the wrong direction
             newvar = insert_nondiagonal(var->ub, troot, widen2ub);
             if (newvar != var->ub) {

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -74,6 +74,19 @@ typedef struct jl_varbinding_t {
     int8_t concrete;    // 1 if another variable has a constraint forcing this one to be concrete
     int8_t max_offset;  // record the maximum positive offset of the variable (up to 32)
                         // max_offset < 0 if this variable occurs outside VarargNum.
+    int8_t dynamic_uses; // # of dynamically-encountered uses (any position), saturated at 2.
+                         // Used at the usage site to detect when a statically-CONCRETE
+                         // typevar transitions from "first use" to "second use", at
+                         // which point we set diag_active.
+    int8_t diag_active;  // Set at the usage site (via record_var_occurrence) when a
+                         // CONCRETE-annotated typevar has been used dynamically more
+                         // than once — i.e. when the diagonal rule actually fires for
+                         // this subtype call. For DYNAMIC bindings the pop-time logic
+                         // still computes diagonality from occurs_cov; for NEVER it is
+                         // never set; for CONCRETE the pop site simply reads this flag
+                         // rather than re-deriving it from the use counter.
+    int8_t diag;        // Cached u->diag from the binding UnionAll, so use-site code
+                        // can dispatch on it without reaching back to the UnionAll.
     // constraintkind: in covariant position, we try three different ways to compute var ∩ type:
     // let ub = var.ub ∩ type
     // 0 - var.ub <: type ? var : ub
@@ -254,10 +267,17 @@ static int current_env_length(jl_stenv_t *e)
     return len;
 }
 
+// Each varbinding contributes 5 bytes to `buf` (occurs_inv, occurs_cov, max_offset,
+// dynamic_uses, diag_active) and 3 GC roots to `roots` (lb, ub, innervars). `concrete`
+// is intentionally not saved/restored: it is monotonic-on-set and represents an outside
+// constraint that should persist across union-arm retries. `diag_active` *is* saved so
+// that activation in one union arm does not falsely persist to a sibling arm where the
+// dynamic uses haven't yet reached 2 — matching the per-arm semantics master applied
+// via occurs_cov.
 typedef struct {
     int8_t *buf;
     int rdepth;
-    int8_t _space[24]; // == 8 * 3
+    int8_t _space[40]; // == 8 * 5
     jl_gcframe_t gcframe;
     jl_value_t *roots[24]; // == 8 * 3
 } jl_savedenv_t;
@@ -301,6 +321,8 @@ static void re_save_env(jl_stenv_t *e, jl_savedenv_t *se, int root)
         se->buf[j++] = v->occurs_inv;
         se->buf[j++] = v->occurs_cov;
         se->buf[j++] = v->max_offset;
+        se->buf[j++] = v->dynamic_uses;
+        se->buf[j++] = v->diag_active;
         v = v->prev;
     }
     assert(i == nroots); (void)nroots;
@@ -332,9 +354,9 @@ static void alloc_env(jl_stenv_t *e, jl_savedenv_t *se, int root)
             ct->gcstack = &se->gcframe;
         }
     }
-    se->buf = (len > 8 ? (int8_t*)malloc_s(len * 3) : se->_space);
+    se->buf = (len > 8 ? (int8_t*)malloc_s(len * 5) : se->_space);
 #ifdef __clang_gcanalyzer__
-    memset(se->buf, 0, len * 3);
+    memset(se->buf, 0, len * 5);
 #endif
 }
 
@@ -394,6 +416,8 @@ static void restore_env(jl_stenv_t *e, jl_savedenv_t *se, int root) JL_NOTSAFEPO
         v->occurs_inv = se->buf[j++];
         v->occurs_cov = se->buf[j++];
         v->max_offset = se->buf[j++];
+        v->dynamic_uses = se->buf[j++];
+        v->diag_active = se->buf[j++];
         v = v->prev;
     }
     assert(i == nroots); (void)nroots;
@@ -713,11 +737,24 @@ static int env_unchanged(jl_stenv_t *e, jl_savedenv_t *se) JL_NOTSAFEPOINT
         if (v->existential) {
             if (v->lb != roots[i] || v->ub != roots[i + 1])
                 return 0; // check if bounds changed
-            if (is_leaf_typevar(v->var) && v->occurs_inv == 0 && v->occurs_cov > 1 && se->buf[j] <= 1)
-                return 0; // check if a variable became digonal from non-diagonal
+            // For DYNAMIC bindings, diagonality keys off occurs_cov; for statically
+            // CONCRETE bindings it keys off diag_active (entry j+3 in the 5-byte
+            // group: occurs_inv, occurs_cov, max_offset, dynamic_uses, diag_active).
+            // diag_active is set at the use site when a CONCRETE typevar's dynamic
+            // uses cross the diagonal-rule threshold.
+            if (is_leaf_typevar(v->var)) {
+                if (v->diag == JL_UNIONALL_DIAG_CONCRETE) {
+                    if (v->diag_active && !se->buf[j + 3])
+                        return 0; // CONCRETE diagonal got activated this round
+                }
+                else if (v->diag != JL_UNIONALL_DIAG_NEVER) {
+                    if (v->occurs_inv == 0 && v->occurs_cov > 1 && se->buf[j] <= 1)
+                        return 0; // DYNAMIC became diagonal
+                }
+            }
         }
         i += 3; // lb, ub, innervars
-        j += 3;
+        j += 5;
         v = v->prev;
     }
     return 1;
@@ -763,11 +800,72 @@ static int subtype_left_var(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_para
     return subtype(x, y, e, param);
 }
 
-// use the current context to record where a variable occurred, for the purpose
-// of determining whether the variable is concrete.
-static void record_var_occurrence(jl_varbinding_t *vb, jl_stenv_t *e, jl_param_pos_t param) JL_NOTSAFEPOINT
+// Forward declarations; actual definitions below.
+int is_leaf_bound(jl_value_t *v) JL_NOTSAFEPOINT;
+static jl_value_t *widen_Type_if_concrete(jl_value_t *t JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
+
+// Apply the diagonal-rule effects for a CONCRETE-marked typevar at the usage
+// site. Must be called whenever:
+//  (a) `vb` just transitioned to "diagonally active" (its dynamic-use counter
+//      reached 2 inside `record_var_occurrence`),
+//  (b) `vb`'s lower bound was updated by a use that records into it (var_gt,
+//      equal_var),
+//  (c) `vb`'s upper bound was updated by a use (var_lt, equal_var) and the
+//      var is forced concrete by an outer constraint, or
+//  (d) `vb->concrete` was just set externally (the pop-time propagation
+//      `vlb->concrete = 1` in another var's pop).
+//
+// For DYNAMIC and NEVER bindings this is a no-op — those continue to be
+// handled at pop. For CONCRETE the entire effect of the diagonal rule lives
+// here, so the pop site does not need to re-derive anything from use counters.
+//
+// Returns 1 on success, 0 if the diagonal rule failed (lb not concrete, or
+// outer-forced concrete with non-concrete ub).
+static int apply_concrete_diagonal(jl_varbinding_t *vb, jl_stenv_t *e) JL_NOTSAFEPOINT
 {
-    if (vb != NULL && param != PARAM_NONE) {
+    if (vb->diag != JL_UNIONALL_DIAG_CONCRETE)
+        return 1;
+    if (!is_leaf_typevar(vb->var))
+        return 1;
+    if (!vb->concrete && !vb->diag_active)
+        return 1;
+    // outer forced this var concrete but our own diagonal isn't active:
+    // ub must be a leaf so the var truly ranges only over concrete types.
+    if (vb->concrete && !vb->diag_active && !is_leaf_bound(vb->ub))
+        return 0;
+    // For existential bindings (the typevar quantifier sits on the right of
+    // the subtype check, so the var is being solved), widen `Type{X}` to
+    // `typeof(X)` before the leaf-bound check. Master applies this same
+    // widening at pop just before its diagonal check; we apply it at the
+    // usage site so the outcome matches.
+    jl_value_t *lb = vb->lb;
+    if (vb->existential && !vb->occurs_inv)
+        lb = widen_Type_if_concrete(lb);
+    // lb work: if it's a typevar, propagate concreteness; if it's a non-leaf
+    // type, the diagonal rule says we can't satisfy the constraint.
+    if (jl_is_typevar(lb)) {
+        jl_varbinding_t *vlb = lookup(e, (jl_tvar_t*)lb);
+        if (vlb && !vlb->concrete) {
+            vlb->concrete = 1;
+            if (!apply_concrete_diagonal(vlb, e))
+                return 0;
+        }
+    }
+    else if (!is_leaf_bound(lb)) {
+        return 0;
+    }
+    return 1;
+}
+
+// use the current context to record where a variable occurred, for the purpose
+// of determining whether the variable is concrete. Returns 0 if the diagonal
+// rule fails as a result of the new occurrence (only possible for CONCRETE
+// bindings), 1 otherwise.
+static int record_var_occurrence(jl_varbinding_t *vb, jl_stenv_t *e, jl_param_pos_t param) JL_NOTSAFEPOINT
+{
+    if (vb == NULL)
+        return 1;
+    if (param != PARAM_NONE) {
         // saturate counters at 2; we don't need values bigger than that
         if (param == PARAM_INVARIANT && e->invdepth > vb->depth0) {
             if (vb->occurs_inv < 2)
@@ -781,6 +879,34 @@ static void record_var_occurrence(jl_varbinding_t *vb, jl_stenv_t *e, jl_param_p
         if (!vb->intersected)
             vb->max_offset = -1;
     }
+    // dynamic_uses counts every actual use of this var so far in the current
+    // subtype branch, INCLUDING uses through PARAM_NONE recursive calls (e.g.
+    // bound consistency checks via subtype_ccheck → var_gt / var_lt). Those
+    // also constrain the typevar's bounds, so they count toward the diagonal
+    // rule. When a CONCRETE-annotated binding is used a second time we
+    // activate its diagonal rule right here at the usage site.
+    if (vb->dynamic_uses < 2) {
+        vb->dynamic_uses++;
+        if (vb->dynamic_uses == 2 && vb->diag == JL_UNIONALL_DIAG_CONCRETE) {
+            vb->diag_active = 1;
+            // In intersection mode, master sets vb->concrete = 1 at
+            // intersect_unionall_'s pop for diagonally-active typevars, and
+            // a number of intersection helpers (constraintkind selection,
+            // the xx/yy concrete arbitration in `intersect`, etc.) consult
+            // vb->concrete. Mirror that here at the usage site.
+            //
+            // We deliberately don't set vb->concrete in subtype mode:
+            // vb->concrete is monotonic-on-set (not saved/restored across
+            // union arms), so setting it would falsely persist activation
+            // from a failed arm into a sibling arm's apply_concrete_diagonal
+            // and incorrectly trigger the !diag_active ub-leaf check.
+            if (e->intersection && is_leaf_typevar(vb->var))
+                vb->concrete = 1;
+            if (!apply_concrete_diagonal(vb, e))
+                return 0;
+        }
+    }
+    return 1;
 }
 
 // is var x's quantifier outside y's in nesting order
@@ -805,7 +931,8 @@ static int var_lt(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, jl_param_pos_t par
     jl_varbinding_t *bb = lookup(e, b);
     if (bb == NULL)
         return e->ignore_free || subtype_left_var(b->ub, a, e, param);
-    record_var_occurrence(bb, e, param);
+    if (!record_var_occurrence(bb, e, param))
+        return 0;
     assert(!jl_is_long(a) || e->Loffset == 0);
     if (e->Loffset != 0 && !jl_is_typevar(a) &&
         a != jl_bottom_type && a != (jl_value_t *)jl_any_type)
@@ -829,6 +956,10 @@ static int var_lt(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, jl_param_pos_t par
         bb->ub = simple_meet(bb->ub, a, 1);
     }
     assert(bb->ub != (jl_value_t*)b);
+    // ub just changed: if outer-forced concrete (vb.concrete) without being
+    // self-diagonal-active, the diagonal rule requires ub be a leaf bound.
+    if (!apply_concrete_diagonal(bb, e))
+        return 0;
     if (jl_is_typevar(a)) {
         jl_varbinding_t *aa = lookup(e, (jl_tvar_t*)a);
         if (aa && !aa->existential && in_union(bb->lb, a) && bb->depth0 != aa->depth0 && var_outside(e, b, (jl_tvar_t*)a)) {
@@ -846,7 +977,8 @@ static int var_gt(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, jl_param_pos_t par
     jl_varbinding_t *bb = lookup(e, b);
     if (bb == NULL)
         return e->ignore_free || subtype_left_var(a, b->lb, e, param);
-    record_var_occurrence(bb, e, param);
+    if (!record_var_occurrence(bb, e, param))
+        return 0;
     assert(!jl_is_long(a) || e->Loffset == 0);
     if (e->Loffset != 0 && !jl_is_typevar(a) &&
         a != jl_bottom_type && a != (jl_value_t *)jl_any_type)
@@ -864,6 +996,9 @@ static int var_gt(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, jl_param_pos_t par
     JL_GC_POP();
     // this bound should not be directly circular
     assert(bb->lb != (jl_value_t*)b);
+    // lb just changed: re-check the CONCRETE diagonal rule.
+    if (!apply_concrete_diagonal(bb, e))
+        return 0;
     if (jl_is_typevar(a)) {
         jl_varbinding_t *aa = lookup(e, (jl_tvar_t*)a);
         if (aa && !aa->existential && bb->depth0 != aa->depth0 && param == PARAM_INVARIANT && var_outside(e, b, (jl_tvar_t*)a))
@@ -1045,8 +1180,11 @@ static jl_unionall_t *unalias_unionall(jl_unionall_t *u, jl_stenv_t *e)
 static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8_t R, jl_param_pos_t param)
 {
     u = unalias_unionall(u, e);
-    jl_varbinding_t vb = { u->var, u->var->lb, u->var->ub, R, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                           e->invdepth, NULL, e->vars };
+    // Field order: var, lb, ub, existential, occurs_inv, occurs_cov, concrete,
+    // max_offset, dynamic_uses, diag_active, diag, constraintkind, intvalued,
+    // limited, intersected, widened_to_kind, depth0, innervars, prev.
+    jl_varbinding_t vb = { u->var, u->var->lb, u->var->ub, R, 0, 0, 0, 0, 0, 0, u->diag,
+                           0, 0, 0, 0, 0, e->invdepth, NULL, e->vars };
     JL_GC_PUSH4(&u, &vb.lb, &vb.ub, &vb.innervars);
     e->vars = &vb;
     int ans;
@@ -1061,32 +1199,41 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
     else
         ans = subtype(u->body, t, e, param);
 
-    // handle the "diagonal dispatch" rule, which says that a type var occurring more
-    // than once, and only in covariant position, is constrained to concrete types. E.g.
-    //  ( Tuple{Int, Int}    <: Tuple{T, T} where T) but
-    // !( Tuple{Int, String} <: Tuple{T, T} where T)
-    // Then check concreteness by checking that the lower bound is not an abstract type.
-    int diagonal;
-    if (u->diag == JL_UNIONALL_DIAG_CONCRETE)
-        diagonal = 1;
-    else if (u->diag == JL_UNIONALL_DIAG_NEVER)
-        diagonal = 0;
-    else
-        diagonal = vb.occurs_cov > 1 && !var_occurs_invariant(u->body, u->var);
-    if (ans && (vb.concrete || (diagonal && is_leaf_typevar(u->var)))) {
-        if (vb.concrete && !diagonal && !is_leaf_bound(vb.ub)) {
-            // a non-diagonal var can only be a subtype of a diagonal var if its
-            // upper bound is concrete.
-            ans = 0;
-        }
-        else if (jl_is_typevar(vb.lb)) {
-            jl_tvar_t *v = (jl_tvar_t*)vb.lb;
-            jl_varbinding_t *vlb = lookup(e, v);
-            if (vlb)
-                vlb->concrete = 1;
-        }
-        else if (!is_leaf_bound(vb.lb)) {
-            ans = 0;
+    // Handle the "diagonal dispatch" rule for DYNAMIC and NEVER bindings here.
+    // E.g. ( Tuple{Int, Int}    <: Tuple{T, T} where T) but
+    //     !( Tuple{Int, String} <: Tuple{T, T} where T) — checked by examining
+    // the lower bound's concreteness.
+    //
+    // CONCRETE bindings (`<<:` or static-auto) handle this entirely at the usage
+    // site through apply_concrete_diagonal: the rule fires at the second use
+    // (and at every subsequent bound update / external concrete propagation),
+    // so by the time we reach the pop there is nothing diagonal-related left
+    // for us to do for those bindings.
+    if (ans && u->diag != JL_UNIONALL_DIAG_CONCRETE) {
+        int diagonal = (u->diag == JL_UNIONALL_DIAG_NEVER)
+            ? 0
+            : (vb.occurs_cov > 1 && !var_occurs_invariant(u->body, u->var));
+        if (vb.concrete || (diagonal && is_leaf_typevar(u->var))) {
+            if (vb.concrete && !diagonal && !is_leaf_bound(vb.ub)) {
+                // a non-diagonal var can only be a subtype of a diagonal var if its
+                // upper bound is concrete.
+                ans = 0;
+            }
+            else if (jl_is_typevar(vb.lb)) {
+                jl_tvar_t *v = (jl_tvar_t*)vb.lb;
+                jl_varbinding_t *vlb = lookup(e, v);
+                if (vlb) {
+                    vlb->concrete = 1;
+                    // Propagation has just forced vlb concrete from outside its
+                    // own usage chain. If vlb is CONCRETE, run its use-site
+                    // diagonal check now — there's no later opportunity.
+                    if (!apply_concrete_diagonal(vlb, e))
+                        ans = 0;
+                }
+            }
+            else if (!is_leaf_bound(vb.lb)) {
+                ans = 0;
+            }
         }
     }
 
@@ -1544,16 +1691,19 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_param_pos_t p
             int xr = xx && xx->existential;  // treat free variables as "forall" (left)
             int yr = yy && yy->existential;
             if (xr) {
-                if (yy) record_var_occurrence(yy, e, param);
+                if (yy && !record_var_occurrence(yy, e, param))
+                    return 0;
                 if (yr) {
-                    record_var_occurrence(xx, e, param);
+                    if (!record_var_occurrence(xx, e, param))
+                        return 0;
                     int trysub = e->intersection ? try_subtype_by_bounds(xx->lb, yy->ub, e) : 0;
                     return trysub || subtype(xx->lb, yy->ub, e, PARAM_NONE);
                 }
                 return var_lt((jl_tvar_t*)x, y, e, param);
             }
             else if (yr) {
-                if (xx) record_var_occurrence(xx, e, param);
+                if (xx && !record_var_occurrence(xx, e, param))
+                    return 0;
                 return var_gt((jl_tvar_t*)y, x, e, param);
             }
             // check ∀x,y . x<:y
@@ -1800,7 +1950,8 @@ static int equal_var(jl_tvar_t *v, jl_value_t *x, jl_stenv_t *e)
     jl_varbinding_t *vb = lookup(e, v);
     if (e->intersection && vb != NULL && vb->lb == vb->ub && jl_is_typevar(vb->lb))
         return equal_var((jl_tvar_t *)vb->lb, x, e);
-    record_var_occurrence(vb, e, PARAM_INVARIANT);
+    if (!record_var_occurrence(vb, e, PARAM_INVARIANT))
+        return 0;
     if (vb == NULL)
         return e->ignore_free || (
             local_forall_exists_subtype(x, v->lb, e, PARAM_INVARIANT, !jl_has_free_typevars(x)) &&
@@ -1817,6 +1968,8 @@ static int equal_var(jl_tvar_t *v, jl_value_t *x, jl_stenv_t *e)
     if (!e->intersection || !jl_is_typevar(lb) || !reachable_var(lb, v, e))
         vb->lb = lb;
     JL_GC_POP();
+    if (!apply_concrete_diagonal(vb, e))
+        return 0;
     if (vb->ub == x)
         return 1;
     if (!subtype_ccheck(vb->lb, x, e))
@@ -1824,6 +1977,8 @@ static int equal_var(jl_tvar_t *v, jl_value_t *x, jl_stenv_t *e)
     // skip `simple_meet` here as we have proven `x <: vb->ub`
     if (!e->intersection || !reachable_var(x, v, e))
         vb->ub = x;
+    if (!apply_concrete_diagonal(vb, e))
+        return 0;
     return 1;
 }
 
@@ -1982,6 +2137,55 @@ static int concrete_min(jl_value_t *t)
     }
     assert(!jl_is_kind(t));
     return 1; // a non-Type is also considered concrete
+}
+
+// Locate the UnionAll wrapper that binds `v` within `t`, or NULL if `v` is
+// free in `t`. Used to consult the diag annotation on a typevar's binding.
+static jl_unionall_t *find_var_unionall(jl_value_t *t, jl_tvar_t *v) JL_NOTSAFEPOINT
+{
+    if (jl_is_unionall(t)) {
+        jl_unionall_t *ua = (jl_unionall_t*)t;
+        if (ua->var == v)
+            return ua;
+        jl_unionall_t *r = find_var_unionall(ua->var->lb, v);
+        if (r) return r;
+        r = find_var_unionall(ua->var->ub, v);
+        if (r) return r;
+        return find_var_unionall(ua->body, v);
+    }
+    else if (jl_is_uniontype(t)) {
+        jl_unionall_t *r = find_var_unionall(((jl_uniontype_t*)t)->a, v);
+        if (r) return r;
+        return find_var_unionall(((jl_uniontype_t*)t)->b, v);
+    }
+    else if (jl_is_vararg(t)) {
+        jl_vararg_t *vm = (jl_vararg_t *)t;
+        if (vm->T) {
+            jl_unionall_t *r = find_var_unionall(vm->T, v);
+            if (r) return r;
+            if (vm->N)
+                return find_var_unionall(vm->N, v);
+        }
+        return NULL;
+    }
+    else if (jl_is_datatype(t)) {
+        size_t i, np = jl_nparams(t);
+        for (i = 0; i < np; i++) {
+            jl_unionall_t *r = find_var_unionall(jl_tparam(t, i), v);
+            if (r) return r;
+        }
+    }
+    return NULL;
+}
+
+// Returns 1 if the UnionAll binding `v` in `y0` has its diag annotation
+// say diagonal-rule does NOT apply (NEVER). Used to skip the dynamic-style
+// diagonal heuristic in obvious_subtype_ when the static rule has determined
+// the typevar isn't concrete-forced.
+static int diag_definitely_off(jl_value_t *y0, jl_tvar_t *v) JL_NOTSAFEPOINT
+{
+    jl_unionall_t *ua = find_var_unionall(y0, v);
+    return ua && ua->diag == JL_UNIONALL_DIAG_NEVER;
 }
 
 static jl_value_t *find_var_body(jl_value_t *t, jl_tvar_t *v)
@@ -2269,8 +2473,10 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
                     if (var_occurs_invariant(body, (jl_tvar_t*)b))
                         return 0;
                 }
-                if (nparams_expanded_x > npy && jl_is_typevar(b) && is_leaf_typevar((jl_tvar_t *)b) && concrete_min(a1) > 1) {
-                    // diagonal rule for 2 or more elements: they must all be concrete on the LHS
+                if (nparams_expanded_x > npy && jl_is_typevar(b) && is_leaf_typevar((jl_tvar_t *)b) && concrete_min(a1) > 1
+                    && !diag_definitely_off(y0, (jl_tvar_t *)b)) {
+                    // diagonal rule for 2 or more elements: they must all be concrete on the LHS.
+                    // Skipped when the static-rule annotation on b's binding says NEVER.
                     *subtype = 0;
                     return 1;
                 }
@@ -2280,8 +2486,10 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
                 }
                 for (; i < nparams_expanded_x; i++) {
                     jl_value_t *a = (vx != JL_VARARG_NONE && i >= npx - 1) ? vxt : jl_tparam(x, i);
-                    if (i > npy && jl_is_typevar(b) && is_leaf_typevar((jl_tvar_t *)b)) { // i == npy implies a == a1
-                        // diagonal rule: all the later parameters are also constrained to be type-equal to the first
+                    if (i > npy && jl_is_typevar(b) && is_leaf_typevar((jl_tvar_t *)b)
+                        && !diag_definitely_off(y0, (jl_tvar_t *)b)) { // i == npy implies a == a1
+                        // diagonal rule: all the later parameters are also constrained to be type-equal to the first.
+                        // Skipped when b's static diag says NEVER.
                         jl_value_t *a2 = a;
                         jl_value_t *au = jl_unwrap_unionall(a);
                         if (jl_is_type_type(au) && jl_is_type(jl_tparam0(au))) {
@@ -2733,8 +2941,10 @@ static jl_value_t *bound_var_below(jl_tvar_t *tv, jl_varbinding_t *bb, jl_stenv_
     if (bb->depth0 != e->invdepth)
         return jl_bottom_type;
     e->invdepth++;
-    record_var_occurrence(bb, e, PARAM_INVARIANT);
+    int recorded = record_var_occurrence(bb, e, PARAM_INVARIANT);
     e->invdepth--;
+    if (!recorded)
+        return jl_bottom_type;
     int offset = R ? -e->Loffset : e->Loffset;
     if (jl_is_long(bb->lb)) {
         ssize_t blb = jl_unbox_long(bb->lb);
@@ -3503,18 +3713,18 @@ static jl_value_t *intersect_unionall_(jl_value_t *t, jl_unionall_t *u, jl_stenv
     else {
         res = intersect(u->body, t, e, param);
     }
-    if (u->diag == JL_UNIONALL_DIAG_CONCRETE)
-        vb->concrete = 1;
-    else if (u->diag == JL_UNIONALL_DIAG_DYNAMIC)
+    // For DYNAMIC bindings the diagonal rule is determined here from occurrence
+    // counts. CONCRETE bindings are handled entirely at the usage site by
+    // apply_concrete_diagonal — vb->concrete and the lb-leaf check have already
+    // been applied during recursion, so we don't touch CONCRETE here. NEVER
+    // bindings never engage.
+    if (u->diag == JL_UNIONALL_DIAG_DYNAMIC)
         vb->concrete |= (vb->occurs_cov > 1 && is_leaf_typevar(u->var) &&
                          !var_occurs_invariant(u->body, u->var));
 
-    // handle the "diagonal dispatch" rule, which says that a type var occurring more
-    // than once, and only in covariant position, is constrained to concrete types. E.g.
-    //  ( Tuple{Int, Int}    <: Tuple{T, T} where T) but
-    // !( Tuple{Int, String} <: Tuple{T, T} where T)
-    // Then check concreteness by checking that the lower bound is not an abstract type.
-    if (res != jl_bottom_type && vb->concrete) {
+    // For DYNAMIC/NEVER, do the pop-time lb leaf check; CONCRETE has handled
+    // it at the usage site.
+    if (res != jl_bottom_type && vb->concrete && u->diag != JL_UNIONALL_DIAG_CONCRETE) {
         if (jl_is_typevar(vb->lb)) {
         }
         else if (!is_leaf_bound(vb->lb)) {
@@ -3584,8 +3794,11 @@ static jl_value_t *intersect_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_
 {
     jl_value_t *res = NULL;
     jl_savedenv_t se;
-    jl_varbinding_t vb = { u->var, u->var->lb, u->var->ub, R, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                           e->invdepth, NULL, e->vars };
+    // Field order: var, lb, ub, existential, occurs_inv, occurs_cov, concrete,
+    // max_offset, dynamic_uses, diag_active, diag, constraintkind, intvalued,
+    // limited, intersected, widened_to_kind, depth0, innervars, prev.
+    jl_varbinding_t vb = { u->var, u->var->lb, u->var->ub, R, 0, 0, 0, 0, 0, 0, u->diag,
+                           0, 0, 0, 0, 0, e->invdepth, NULL, e->vars };
     JL_GC_PUSH4(&res, &vb.lb, &vb.ub, &vb.innervars);
     save_env(e, &se, 1);
     int noinv = !var_occurs_invariant(u->body, u->var);
@@ -3600,20 +3813,26 @@ static jl_value_t *intersect_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_
     }
     else if (res != jl_bottom_type) {
         int constraint1 = vb.constraintkind;
-        if (vb.concrete || vb.occurs_inv>1 || (vb.occurs_inv && vb.occurs_cov))
-            vb.constraintkind = vb.concrete ? 1 : 2;
+        // diag_active acts like vb.concrete for constraint-strength purposes:
+        // a CONCRETE-marked typevar that has been activated at the usage site
+        // must be tied tightly (constraintkind=1) and re-intersected so its
+        // bounds correlate across positions, matching what master does for
+        // diagonal vars at intersect_unionall_'s pop.
+        int forced_concrete = vb.concrete || vb.diag_active;
+        if (forced_concrete || vb.occurs_inv>1 || (vb.occurs_inv && vb.occurs_cov))
+            vb.constraintkind = forced_concrete ? 1 : 2;
         else if (u->var->lb != jl_bottom_type)
             vb.constraintkind = 2;
         else if (vb.occurs_cov && noinv)
             vb.constraintkind = 1;
-        int reintersection = constraint1 != vb.constraintkind || vb.concrete;
+        int reintersection = constraint1 != vb.constraintkind || forced_concrete;
         if (reintersection) {
             if (constraint1 == 1) {
                 vb.lb = vb.var->lb;
                 vb.ub = vb.var->ub;
             }
             restore_env(e, &se, vb.constraintkind == 1 ? 1 : 0);
-            vb.occurs_cov = vb.occurs_inv = 0;
+            vb.occurs_cov = vb.occurs_inv = vb.dynamic_uses = vb.diag_active = 0;
             res = intersect_unionall_(t, u, e, R, param, &vb);
         }
     }
@@ -3625,7 +3844,7 @@ static jl_value_t *intersect_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_
             if (is_leaf_bound(vb.ub)) {
                 restore_env(e, &se, 1);
                 vb.lb = vb.var->lb;
-                vb.occurs_cov = vb.occurs_inv = 0;
+                vb.occurs_cov = vb.occurs_inv = vb.dynamic_uses = 0;
                 res = intersect_unionall_(t, u, e, R, param, &vb);
             }
         }
@@ -3636,7 +3855,7 @@ static jl_value_t *intersect_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_
             vb.ub = vb.var->ub;
             vb.constraintkind = 0;
             vb.widened_to_kind = 0;
-            vb.occurs_cov = vb.occurs_inv = 0;
+            vb.occurs_cov = vb.occurs_inv = vb.dynamic_uses = 0;
             res = intersect_unionall_(t, u, e, R, param, &vb);
         }
     }
@@ -4146,14 +4365,17 @@ static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_par
                 jl_value_t *ylb = yy ? yy->lb : ((jl_tvar_t*)y)->lb;
                 jl_value_t *yub = yy ? yy->ub : ((jl_tvar_t*)y)->ub;
                 if (xx && yy && xx->depth0 != yy->depth0) {
-                    record_var_occurrence(xx, e, param);
-                    record_var_occurrence(yy, e, param);
+                    if (!record_var_occurrence(xx, e, param) ||
+                        !record_var_occurrence(yy, e, param))
+                        return jl_bottom_type;
                     return subtype_in_env(yy->ub, yy->lb, e) ? y : jl_bottom_type;
                 }
                 if (xub == xlb && jl_is_typevar(xub)) {
-                    record_var_occurrence(xx, e, param);
+                    if (!record_var_occurrence(xx, e, param))
+                        return jl_bottom_type;
                     if (y == xub) {
-                        record_var_occurrence(yy, e, param);
+                        if (!record_var_occurrence(yy, e, param))
+                            return jl_bottom_type;
                         return y;
                     }
                     if (R) flip_offset(e);
@@ -4162,14 +4384,16 @@ static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_par
                     return res;
                 }
                 if (yub == ylb && jl_is_typevar(yub)) {
-                    record_var_occurrence(yy, e, param);
+                    if (!record_var_occurrence(yy, e, param))
+                        return jl_bottom_type;
                     if (R) flip_offset(e);
                     jl_value_t *res = intersect(x, yub, e, param);
                     if (R) flip_offset(e);
                     return res;
                 }
-                record_var_occurrence(xx, e, param);
-                record_var_occurrence(yy, e, param);
+                if (!record_var_occurrence(xx, e, param) ||
+                    !record_var_occurrence(yy, e, param))
+                    return jl_bottom_type;
                 int xoffset = R ? -e->Loffset : e->Loffset;
                 if (!jl_is_type(ylb) && !jl_is_typevar(ylb)) {
                     if (xx)
@@ -4254,18 +4478,21 @@ static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_par
                 return xoffset < 0 ? x : y;
             }
             assert(e->Loffset == 0);
-            record_var_occurrence(xx, e, param);
-            record_var_occurrence(yy, e, param);
+            if (!record_var_occurrence(xx, e, param) ||
+                !record_var_occurrence(yy, e, param))
+                return jl_bottom_type;
             if (xx && yy && xx->concrete && !yy->concrete) {
                 return intersect_var((jl_tvar_t*)x, y, e, R, param);
             }
             return intersect_var((jl_tvar_t*)y, x, e, !R, param);
         }
-        record_var_occurrence(lookup(e, (jl_tvar_t*)x), e, param);
+        if (!record_var_occurrence(lookup(e, (jl_tvar_t*)x), e, param))
+            return jl_bottom_type;
         return intersect_var((jl_tvar_t*)x, y, e, 0, param);
     }
     if (jl_is_typevar(y)) {
-        record_var_occurrence(lookup(e, (jl_tvar_t*)y), e, param);
+        if (!record_var_occurrence(lookup(e, (jl_tvar_t*)y), e, param))
+            return jl_bottom_type;
         return intersect_var((jl_tvar_t*)y, x, e, 1, param);
     }
     if (e->Loffset == 0 && !jl_has_free_typevars(x) && !jl_has_free_typevars(y)) {
@@ -4458,7 +4685,12 @@ static int merge_env(jl_stenv_t *e, jl_savedenv_t *me, jl_savedenv_t *se, int co
         // merge max_offset by min
         if (!v->intersected && v->max_offset < me->buf[m+2])
             me->buf[m+2] = v->max_offset;
-        m = m + 3;
+        // merge dynamic_uses and diag_active by max (monotonic-on-set across union arms)
+        if (v->dynamic_uses > me->buf[m+3])
+            me->buf[m+3] = v->dynamic_uses;
+        if (v->diag_active > me->buf[m+4])
+            me->buf[m+4] = v->diag_active;
+        m = m + 5;
         n = n + 3;
         v = v->prev;
     }
@@ -5009,7 +5241,8 @@ static jl_value_t *_widen_diagonal(jl_value_t *t, jl_varbinding_t *troot) {
 
 static jl_value_t *widen_diagonal(jl_value_t *t, jl_unionall_t *u, jl_varbinding_t *troot)
 {
-    jl_varbinding_t vb = { u->var, NULL, NULL, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, NULL, troot };
+    jl_varbinding_t vb = { u->var, NULL, NULL, 1, 0, 0, 0, 0, 0, 0, u->diag,
+                           0, 0, 0, 0, 0, 0, NULL, troot };
     jl_value_t *nt = NULL;
     JL_GC_PUSH2(&vb.innervars, &nt);
     if (jl_is_unionall(u->body))

--- a/test/core.jl
+++ b/test/core.jl
@@ -5466,6 +5466,25 @@ missing_tvar(::T...) where {T} = T
 @test missing_tvar(1, 2, 3) === Int
 @test_throws MethodError missing_tvar(1, 2, "3")
 
+# `<<:` forces a typevar diagonal at method dispatch, so a Union arm and a
+# bare-T occurrence cannot bind T to two different concrete types — the call
+# below must miss the method rather than match and fail at runtime with an
+# UndefVarError on the unbound static parameter.
+let
+    f_concrete(a::Union{Vector{T}, T}, b::T) where T <<: Any = T
+    @test_throws MethodError f_concrete(Int[1], "String")
+end
+
+# `<<:` also constrains nested where bindings via bound-consistency: when S
+# constrains T from below (S<:T) and T is forced concrete, the implicit Int<:T
+# check raised by validating S=Int counts toward T's diagonal-rule activation,
+# so T's lb gets joined with the outer y::T = String → Union{Int,String} (not
+# leaf), and dispatch must miss.
+let
+    g_concrete(x::S, y::T) where S <<: T where T <<: Any = T
+    @test_throws MethodError g_concrete(1, "string")
+end
+
 # issue #19059 - test for lowering of `let` with assignment not adding Box in simple cases
 contains_Box(e::GlobalRef) = (e.name === :Box)
 contains_Box(@nospecialize(e)) = false
@@ -8424,12 +8443,7 @@ end
 @test_throws ErrorException Core.Intrinsics.pointerref(Ptr{Vector{Int64}}(C_NULL), 1, 0)
 
 # #53034 (Union normalization for typevar elimination)
-# With the static diagonal rule, T occurs in two covariant positions (inside
-# the Union and as the second tuple slot) with no invariant occurrence, and
-# T's lower bound `Int` is leaf, so the UnionAll is marked diagonal — Any
-# (abstract) cannot bind T. Under T>:Integer the lower bound is abstract,
-# so the diagonal rule does not apply.
-@test_broken Tuple{Int,Any} <: Tuple{Union{Int,T},T} where {T>:Int}
+@test Tuple{Int,Any} <: Tuple{Union{Int,T},T} where {T>:Int}
 @test Tuple{Int,Any} <: Tuple{Union{Int,T},T} where {T>:Integer}
 # #53034 (Union normalization for Type elimination)
 @test Int isa Type{Union{Int,T2} where {T2<:T1}} where {T1}

--- a/test/core.jl
+++ b/test/core.jl
@@ -8424,7 +8424,12 @@ end
 @test_throws ErrorException Core.Intrinsics.pointerref(Ptr{Vector{Int64}}(C_NULL), 1, 0)
 
 # #53034 (Union normalization for typevar elimination)
-@test Tuple{Int,Any} <: Tuple{Union{Int,T},T} where {T>:Int}
+# With the static diagonal rule, T occurs in two covariant positions (inside
+# the Union and as the second tuple slot) with no invariant occurrence, and
+# T's lower bound `Int` is leaf, so the UnionAll is marked diagonal — Any
+# (abstract) cannot bind T. Under T>:Integer the lower bound is abstract,
+# so the diagonal rule does not apply.
+@test_broken Tuple{Int,Any} <: Tuple{Union{Int,T},T} where {T>:Int}
 @test Tuple{Int,Any} <: Tuple{Union{Int,T},T} where {T>:Integer}
 # #53034 (Union normalization for Type elimination)
 @test Int isa Type{Union{Int,T2} where {T2<:T1}} where {T1}

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -114,8 +114,13 @@ function test_diagonal()
     @test issub_strict(Tuple{String, Real, Ref{Number}},
                        (@UnionAll T Tuple{Union{T,String}, T, Ref{T}}))
 
-    @test issub_strict(Tuple{String, Real},
-                       (@UnionAll T Tuple{Union{T,String}, T}))
+    # Under the static diagonal rule, T occurs in two covariant positions
+    # (inside the Union and as the second tuple slot) with no invariant
+    # occurrence, so the UnionAll is marked diagonal and Real (abstract)
+    # cannot bind T. Was previously accepted because dynamic counting only
+    # visits the actually-matched Union branch.
+    @test !issub(Tuple{String, Real},
+                 (@UnionAll T Tuple{Union{T,String}, T}))
 
     @test !issub(      Tuple{Real, Real},
                        (@UnionAll T Tuple{Union{T,String}, T}))
@@ -1237,12 +1242,15 @@ let a = Tuple{Float64,T3,T4} where T4 where T3,
     b = Tuple{S2,Tuple{S3},S3} where S2 where S3
     I1 = typeintersect(a, b)
     I2 = typeintersect(b, a)
-    @test_broken I1 <: I2
+    # Static diagonal rule treats S3 in `b` as concrete because it occurs in
+    # two covariant positions, so I2 (whose S3 is unconstrained) is no longer
+    # a subtype of b. The `I1 <: I2` previously broken case now succeeds.
+    @test I1 <: I2
     @test I2 <: I1
     @test I1 <: a
     @test I2 <: a
     @test_broken I1 <: b
-    @test I2 <: b
+    @test_broken I2 <: b
 end
 let a = Tuple{T1,Tuple{T1}} where T1,
     b = Tuple{Float64,S3} where S3
@@ -1259,12 +1267,13 @@ let a = Tuple{5,T4,T5} where T4 where T5,
     b = Tuple{S2,S3,Tuple{S3}} where S2 where S3
     I1 = typeintersect(a, b)
     I2 = typeintersect(b, a)
-    @test_broken I1 <: I2
+    # See note above: static diagonal rule reverses the previous outcomes.
+    @test I1 <: I2
     @test I2 <: I1
     @test I1 <: a
     @test I2 <: a
     @test_broken I1 <: b
-    @test I2 <: b
+    @test_broken I2 <: b
 end
 let a = Tuple{T2,Tuple{T4,T2}} where T4 where T2,
     b = Tuple{Float64,Tuple{Tuple{S3},S3}} where S3
@@ -1274,12 +1283,13 @@ let a = Tuple{Tuple{T2,4},T6} where T2 where T6,
     b = Tuple{Tuple{S2,S3},Tuple{S2}} where S2 where S3
     I1 = typeintersect(a, b)
     I2 = typeintersect(b, a)
-    @test_broken I1 <: I2
+    # See note above: static diagonal rule reverses the previous outcomes.
+    @test I1 <: I2
     @test I2 <: I1
     @test I1 <: a
     @test I2 <: a
     @test_broken I1 <: b
-    @test I2 <: b
+    @test_broken I2 <: b
 end
 let a = Tuple{T3,Int64,Tuple{T3}} where T3,
     b = Tuple{S3,S3,S4} where S4 where S3

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -114,13 +114,8 @@ function test_diagonal()
     @test issub_strict(Tuple{String, Real, Ref{Number}},
                        (@UnionAll T Tuple{Union{T,String}, T, Ref{T}}))
 
-    # Under the static diagonal rule, T occurs in two covariant positions
-    # (inside the Union and as the second tuple slot) with no invariant
-    # occurrence, so the UnionAll is marked diagonal and Real (abstract)
-    # cannot bind T. Was previously accepted because dynamic counting only
-    # visits the actually-matched Union branch.
-    @test !issub(Tuple{String, Real},
-                 (@UnionAll T Tuple{Union{T,String}, T}))
+    @test issub_strict(Tuple{String, Real},
+                       (@UnionAll T Tuple{Union{T,String}, T}))
 
     @test !issub(      Tuple{Real, Real},
                        (@UnionAll T Tuple{Union{T,String}, T}))
@@ -1242,9 +1237,10 @@ let a = Tuple{Float64,T3,T4} where T4 where T3,
     b = Tuple{S2,Tuple{S3},S3} where S2 where S3
     I1 = typeintersect(a, b)
     I2 = typeintersect(b, a)
-    # Static diagonal rule treats S3 in `b` as concrete because it occurs in
-    # two covariant positions, so I2 (whose S3 is unconstrained) is no longer
-    # a subtype of b. The `I1 <: I2` previously broken case now succeeds.
+    # The static diagonal rule treats S3 in `b` as concrete because it
+    # occurs in two covariant positions, so I2 (whose S3 is unconstrained)
+    # is no longer a subtype of b. The `I1 <: I2` previously broken case
+    # now succeeds.
     @test I1 <: I2
     @test I2 <: I1
     @test I1 <: a


### PR DESCRIPTION
The `diagonal rule` is one of the key innovations of the julia type system. It allows cases such as:

```
+(x::T, y::T) where T
```

to match precisely those cases where `x` and `y` have the same type, without allowing the degenerate `T == Any` case that would allow any types for `x` and `y`.

The way that the diagonal rule generally works is that is counts the number of invariant and covariant uses encountered during subtyping and if there are no invariant uses and 2 or more covariant uses, the variable is restricted to concrete types only.

This dynamic behavior in particular, allows the following:
```
let A = Tuple{Union{Bool, T}, T} where T
  # Not diagonal if the `Bool` branch of this Union is taken
  @test Tuple{ Bool, Real } <: A
  # True by diagonal rule
  @test Tuple{ Int, Int } <: A
  # False by diagonal rule
  @test !(Tuple{ Int, Real } <: A)
end
```

This makes a lot of sense, but it turns out to actually be quite hard to decide what "uses" count for purposes of the diagonal rule. For example, consider the following:

```
julia> Tuple{Tuple{Int}, Real} <: Tuple{S, T} where {T, S<:Tuple{T}}
false

julia> Tuple{Int, Real} <: Tuple{S, T} where {T, S<:T}
true
```
The second is an ordinary and designed feature of the type system. The former is possibly a bug, but we do rely on the following:

```
julia> Tuple{Tuple{X, X}} where X <: (Tuple{S} where S<:Tuple{T, T} where T)
```

But it is not entirely clear how the dynamic rule applies to this case. The counts get incremented during the subtyping consistency check with the synthesized bounds - it's very hard to know what the answer is because those rely on the simple meet and join algorithms in subtyping.

Additionally, we have known issues in cases where multiple union components match a particular subtype, but one of them would cause diagonality and one of them would not.

So this PR asks the question whether all of this complexity is really necessary. What if we just implemented #30363 and then statically decided whther a TypeVar is diagonal or not on construction of the UnionAll. This would break the `Tuple{Union{Bool, T}, T} where T` case above (possibly, there's further enhancements to this that may make it work), but are people really using it?

So this PR implements that, using the `<<:` syntax suggested in my latest comment. The primary purpose of this PR is to evaluate the impact of making this change. It is quite likely too breaking, but it'll be valuable data. There is also an intermediate state where we use syntax versioning to transition this gradually.

Completely written by Claude, so don't take the implementation with any particular seriousness, but hopefully useful for exploration.