### PR TITLE
inference: keep distinct const-prop'd pseudo CIs sharing a MI

### DIFF
--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -145,9 +145,14 @@ function add_one_edge!(edges::Vector{Any}, edge::CodeInstance)
                 # found edge we can upgrade
                 edges[i] = edge
                 return
-            elseif true # XXX compare `CodeInstance` identify?
+            elseif edgeᵢ_orig === edge || codeinst_edges_sub(edgeᵢ_orig, edge.min_world, edge.max_world, edge.edges)
+                # existing CodeInstance is identical
                 return
             end
+            # Different CodeInstance for the same MethodInstance with distinct
+            # edge information (e.g. two const-prop'd pseudo CIs of the same
+            # method recording different `Binding` edges). Keep both so that
+            # backedges are registered for each.
         end
         i += 1
     end

--- a/test/rebinding.jl
+++ b/test/rebinding.jl
@@ -411,6 +411,24 @@ module Invalidate59272
     @test Bar(1) == Foo.Bar(1)
 end
 
+# Test that two const-prop'd pseudo `CodeInstance`s for the same `MethodInstance`
+# carrying *different* binding edges are both kept on the caller's edge list, so
+# that redefining either binding properly invalidates the caller (#61745).
+module Invalidate61745
+    using Test
+    module N
+        const foo = "foo_unchanged"
+        const bar = "bar_unchanged"
+    end
+    helper(s::Symbol) = getglobal(N, s)::String
+    caller_both() = helper(:foo) * helper(:bar)
+    @test caller_both() == "foo_unchangedbar_unchanged"
+    Core.eval(N, :(const foo = "foo_changed!"))
+    @test caller_both() == "foo_changed!bar_unchanged"
+    Core.eval(N, :(const bar = "bar_changed!"))
+    @test caller_both() == "foo_changed!bar_changed!"
+end
+
 # Test @reexport
 module ReexportTests
     using Test


### PR DESCRIPTION
`add_one_edge!` previously deduplicated by `MethodInstance` alone, dropping any subsequent `CodeInstance` whose `def` matched an existing edge. When two const-prop'd pseudo `CodeInstance`s for the same method record different forward edges (e.g. distinct `Binding` edges produced by const-prop'ing the same callee with different constant arguments), the second one was silently discarded, breaking invalidation of the caller when its bindings were redefined.

Only dedup when the existing entry is the same object or its forward edges are identical and its world range covers the new one; otherwise keep both.

This was found by Claude looking at #61745, but is a distinct issue AFAICT.