### PR TITLE
Compile libutf8proc with linker GC flags

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -964,12 +964,17 @@ endif
 # Linker garbage collection
 ifeq ($(USE_LINKER_GC), 1)
 ifeq ($(OS), Darwin)
-  JLDFLAGS += -Wl,-dead_strip
+  LINKER_GC_LDFLAGS := -Wl,-dead_strip
 else
-  JLDFLAGS += -Wl,--gc-sections
-  JCFLAGS += -ffunction-sections -fdata-sections
-  JCXXFLAGS += -ffunction-sections -fdata-sections
+  LINKER_GC_LDFLAGS := -Wl,--gc-sections
+  LINKER_GC_CFLAGS := -ffunction-sections -fdata-sections
+  LINKER_GC_CXXFLAGS := -ffunction-sections -fdata-sections
 endif
+
+JLDFLAGS += $(LINKER_GC_LDFLAGS)
+JCFLAGS += $(LINKER_GC_CFLAGS)
+JCXXFLAGS += $(LINKER_GC_CXXFLAGS)
+
 endif
 
 # ===========================================================================

--- a/deps/utf8proc.mk
+++ b/deps/utf8proc.mk
@@ -5,7 +5,7 @@ $(eval $(call git-external,utf8proc,UTF8PROC,,,$(BUILDDIR)))
 
 UTF8PROC_OBJ_LIB    := $(build_libdir)/libutf8proc.a
 UTF8PROC_OBJ_HEADER := $(build_includedir)/utf8proc.h
-UTF8PROC_CFLAGS     := -O2 $(SANITIZE_OPTS)
+UTF8PROC_CFLAGS     := -O2 $(SANITIZE_OPTS) $(LINKER_GC_CFLAGS)
 UTF8PROC_MFLAGS     := CC="$(CC)" CFLAGS="$(CFLAGS) $(UTF8PROC_CFLAGS)" PICFLAG="$(fPIC)" AR="$(AR)"
 UTF8PROC_BUILDDIR   := $(BUILDDIR)/$(UTF8PROC_SRC_DIR)
 


### PR DESCRIPTION
When we make a static libjulia-internal, we'll want to strip dead code in all the support libraries. `libflisp.a` and `libsupport.a` are already built with `-ffunction-sections` and `-fdata-sections`. This compiles `libutf8proc.a` with those flags too.