### PR TITLE
add `memoryrefunset` intrinsic

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -40,7 +40,7 @@ using Core.Intrinsics, Core.IR
 using Core: ABIOverride, Builtin, CodeInstance, IntrinsicFunction, MethodInstance, MethodMatch,
     MethodTable, MethodCache, PartialOpaque, SimpleVector, TypeofVararg,
     _apply_iterate, apply_type, compilerbarrier, donotdelete, memoryref_isassigned,
-    memoryrefget, memoryrefnew, memoryrefoffset, memoryrefset!, print, println, show, svec,
+    memoryrefget, memoryrefnew, memoryrefoffset, memoryrefset!, memoryrefunset!, print, println, show, svec,
     typename, unsafe_write, write, stdout, stderr
 
 using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospecializeinfer,

--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -723,6 +723,8 @@ function iscall_with_boundscheck(@nospecialize(stmt), sv::PostOptAnalysisState)
         nargs = 4
     elseif f === memoryrefset!
         nargs = 5
+    elseif f === memoryrefunset!
+        nargs = 4
     else
         return false
     end
@@ -1408,6 +1410,9 @@ function statement_cost(ex::Expr, line::Int, src::Union{CodeInfo, IRCode}, sptyp
                 atyp = argextype(ex.args[2], src, sptypes)
                 return isknowntype(atyp) ? 1 : params.inline_nonleaf_penalty
             elseif f === Core.memoryrefset! && length(ex.args) >= 3
+                atyp = argextype(ex.args[2], src, sptypes)
+                return isknowntype(atyp) ? 5 : params.inline_nonleaf_penalty
+            elseif f === Core.memoryrefunset! && length(ex.args) >= 3
                 atyp = argextype(ex.args[2], src, sptypes)
                 return isknowntype(atyp) ? 5 : params.inline_nonleaf_penalty
             elseif f === typeassert && isconstType(widenconst(argextype(ex.args[3], src, sptypes)))

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -2041,6 +2041,10 @@ end
     hasintersect(widenconst(item), memoryrefget_tfunc(𝕃, mem, order, boundscheck)) || return Bottom
     return item
 end
+@nospecs function memoryrefunset!_tfunc(𝕃::AbstractLattice, mem, order, boundscheck)
+    memoryref_builtin_common_errorcheck(mem, order, boundscheck) || return Bottom
+    return Nothing
+end
 @nospecs function memoryrefswap!_tfunc(𝕃::AbstractLattice, mem, v, order, boundscheck)
     memoryrefset!_tfunc(𝕃, mem, v, order, boundscheck) === Bottom && return Bottom
     return memoryrefget_tfunc(𝕃, mem, order, boundscheck)
@@ -2068,6 +2072,7 @@ end
 
 add_tfunc(Core.memoryrefget, 3, 3, memoryrefget_tfunc, 20)
 add_tfunc(Core.memoryrefset!, 4, 4, memoryrefset!_tfunc, 20)
+add_tfunc(Core.memoryrefunset!, 3, 3, memoryrefunset!_tfunc, 20)
 add_tfunc(Core.memoryrefswap!, 4, 4, memoryrefswap!_tfunc, 20)
 add_tfunc(Core.memoryrefmodify!, 5, 5, memoryrefmodify!_tfunc, 20)
 add_tfunc(Core.memoryrefreplace!, 6, 6, memoryrefreplace!_tfunc, 20)
@@ -2240,6 +2245,8 @@ function memoryrefop_builtin_common_nothrow(𝕃::AbstractLattice, argtypes::Vec
         # If we could potentially throw undef ref errors, bail out now.
         array_type_undefable(memtype) && return false
     end
+    # memoryrefunset! has no value-typed arg to check; element type is always
+    # compatible with `nothing` since we are only zeroing pointer slots.
     # If we have @inbounds (last argument is false), we're allowed to assume
     # we don't throw bounds errors.
     if isa(boundscheck, Const)
@@ -2287,6 +2294,8 @@ function _builtin_nothrow(𝕃::AbstractLattice, @nospecialize(f::Builtin), argt
         memtype = widenconst(argtypes[1])
         return memtype ⊑ GenericMemoryRef
     elseif f === memoryrefset!
+        return memoryrefop_builtin_common_nothrow(𝕃, argtypes, f)
+    elseif f === memoryrefunset!
         return memoryrefop_builtin_common_nothrow(𝕃, argtypes, f)
     elseif f === memoryrefget
         return memoryrefop_builtin_common_nothrow(𝕃, argtypes, f)
@@ -2439,6 +2448,7 @@ const _ARGMEM_BUILTINS = Any[
     memoryrefget,
     memoryref_isassigned,
     memoryrefset!,
+    memoryrefunset!,
     modifyfield!,
     replacefield!,
     setfield!,
@@ -2627,6 +2637,7 @@ const _EFFECTS_KNOWN_BUILTINS = Any[
     memoryrefset!,
     # Core.memoryrefsetonce!,
     # Core.memoryrefswap!,
+    memoryrefunset!,
     Core.sizeof,
     svec,
     Core.throw_methoderror,
@@ -2709,14 +2720,14 @@ function builtin_effects(𝕃::AbstractLattice, @nospecialize(f::Builtin), argty
     else
         if contains_is(_CONSISTENT_BUILTINS, f)
             consistent = ALWAYS_TRUE
-        elseif f === memoryrefget || f === memoryrefset! || f === memoryref_isassigned || f === Core._svec_len || f === Core._svec_ref
+        elseif f === memoryrefget || f === memoryrefset! || f === memoryrefunset! || f === memoryref_isassigned || f === Core._svec_len || f === Core._svec_ref
             consistent = CONSISTENT_IF_INACCESSIBLEMEMONLY
         elseif f === Core._typevar || f === Core.memorynew
             consistent = CONSISTENT_IF_NOTRETURNED
         else
             consistent = ALWAYS_FALSE
         end
-        if f === setfield! || f === memoryrefset!
+        if f === setfield! || f === memoryrefset! || f === memoryrefunset!
             effect_free = EFFECT_FREE_IF_INACCESSIBLEMEMONLY
         elseif contains_is(_EFFECT_FREE_BUILTINS, f) || contains_is(_PURE_BUILTINS, f)
             effect_free = ALWAYS_TRUE
@@ -2731,7 +2742,7 @@ function builtin_effects(𝕃::AbstractLattice, @nospecialize(f::Builtin), argty
         else
             inaccessiblememonly = ALWAYS_FALSE
         end
-        if f === memoryrefnew || f === memoryrefget || f === memoryrefset! || f === memoryref_isassigned
+        if f === memoryrefnew || f === memoryrefget || f === memoryrefset! || f === memoryrefunset! || f === memoryref_isassigned
             noub = memoryop_noub(f, argtypes) ? ALWAYS_TRUE : ALWAYS_FALSE
         else
             noub = ALWAYS_TRUE
@@ -2752,7 +2763,7 @@ function memoryop_noub(@nospecialize(f), argtypes::Vector{Any})
             return true
         end
         expected_nargs = 3
-    elseif f === memoryrefget || f === memoryref_isassigned
+    elseif f === memoryrefget || f === memoryref_isassigned || f === memoryrefunset!
         expected_nargs = 3
     else
         @assert f === memoryrefset! "unexpected memoryop is given"

--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -88,31 +88,8 @@ memoryindex(ref::GenericMemoryRef) = memoryrefoffset(ref)
 
 pointer(mem::GenericMemoryRef) = unsafe_convert(Ptr{Cvoid}, mem) # no bounds check, even for empty array
 
-_unsetindex!(A::Memory, i::Int) =  (@_propagate_inbounds_meta; _unsetindex!(memoryref(A, i)); A)
-function _unsetindex!(A::MemoryRef{T}) where T
-    @_terminates_locally_meta
-    @_propagate_inbounds_meta
-    @inline
-    @boundscheck memoryref(A, 1)
-    mem = A.mem
-    MemT = typeof(mem)
-    arrayelem = datatype_arrayelem(MemT)
-    elsz = datatype_layoutsize(MemT)
-    isbits = 0; isboxed = 1; isunion = 2
-    arrayelem == isbits && datatype_pointerfree(T::DataType) && return A
-    t = @_gc_preserve_begin mem
-    p = Ptr{Ptr{Cvoid}}(@inbounds pointer(A))
-    if arrayelem == isboxed
-        Intrinsics.atomic_pointerset(p, C_NULL, :monotonic)
-    elseif arrayelem != isunion
-        for j = 1:Core.sizeof(Ptr{Cvoid}):elsz
-            # XXX: this violates memory ordering, since it writes more than one C_NULL to each
-            Intrinsics.atomic_pointerset(p + j - 1, C_NULL, :monotonic)
-        end
-    end
-    @_gc_preserve_end t
-    return A
-end
+_unsetindex!(A::Memory, i::Int) = (@_propagate_inbounds_meta; _unsetindex!(memoryref(A, i)); A)
+_unsetindex!(A::MemoryRef) = (@_propagate_inbounds_meta; Core.memoryrefunset!(A, default_access_order(A.mem), @_boundscheck); A)
 
 elsize(@nospecialize _::Type{A}) where {T,A<:GenericMemory{<:Any,T}} = aligned_sizeof(T) # XXX: probably supposed to be the stride?
 sizeof(a::GenericMemory) = Core.sizeof(a)

--- a/src/array.c
+++ b/src/array.c
@@ -323,15 +323,7 @@ JL_DLLEXPORT void jl_arrayunset(jl_array_t *a, size_t i)
 {
     if (i >= jl_array_len(a))
         jl_bounds_error_int((jl_value_t*)a, i + 1);
-    const jl_datatype_layout_t *layout = ((jl_datatype_t*)jl_typetagof(a->ref.mem))->layout;
-    if (layout->flags.arrayelem_isboxed) {
-        jl_atomic_store_relaxed(jl_array_data(a,_Atomic(jl_value_t*)) + i, NULL);
-    }
-    else if (layout->first_ptr >= 0) {
-        size_t elsize = layout->size;
-        jl_assume(elsize >= sizeof(void*) && elsize % sizeof(void*) == 0);
-        memset(jl_array_data(a,char) + elsize * i, 0, elsize);
-    }
+    jl_memoryrefunset(jl_memoryrefindex(a->ref, i), 0);
 }
 
 #ifdef __cplusplus

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -54,6 +54,7 @@ extern "C" {
     XX(memoryrefreplace,"memoryrefreplace!") \
     XX(memoryrefset,"memoryrefset!") \
     XX(memoryrefsetonce,"memoryrefsetonce!") \
+    XX(memoryrefunset,"memoryrefunset!") \
     XX(memoryrefswap,"memoryrefswap!") \
     XX(modifyfield,"modifyfield!") \
     XX(modifyglobal,"modifyglobal!") \

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1947,6 +1947,32 @@ JL_CALLABLE(jl_f_memoryrefset)
     return args[1];
 }
 
+JL_CALLABLE(jl_f_memoryrefunset)
+{
+    enum jl_memory_order order = jl_memory_order_notatomic;
+    JL_NARGS(memoryrefunset!, 3, 3);
+    JL_TYPECHK(memoryrefunset!, genericmemoryref, args[0]);
+    JL_TYPECHK(memoryrefunset!, symbol, args[1]);
+    JL_TYPECHK(memoryrefunset!, bool, args[2]);
+    jl_genericmemoryref_t m = *(jl_genericmemoryref_t*)args[0];
+    jl_value_t *kind = jl_tparam0(jl_typetagof(m.mem));
+    if (kind == (jl_value_t*)jl_not_atomic_sym) {
+        if (args[1] != kind) {
+            order = jl_get_atomic_order_checked((jl_sym_t*)args[1], 0, 1);
+            jl_atomic_error("memoryrefunset!: non-atomic memory cannot be written atomically");
+        }
+    }
+    else if (kind == (jl_value_t*)jl_atomic_sym) {
+        order = jl_get_atomic_order_checked((jl_sym_t*)args[1], 0, 1);
+        if (order == jl_memory_order_notatomic)
+            jl_atomic_error("memoryrefunset!: atomic memory cannot be written non-atomically");
+    }
+    if (m.mem->length == 0)
+        jl_bounds_error_int((jl_value_t*)m.mem, 1);
+    jl_memoryrefunset(m, kind == (jl_value_t*)jl_atomic_sym);
+    return jl_nothing;
+}
+
 JL_CALLABLE(jl_f_memoryref_isassigned)
 {
     enum jl_memory_order order = jl_memory_order_notatomic;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2576,6 +2576,9 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             if (isStrongerThanMonotonic(Order))
                 ctx.builder.CreateFence(Order);
             switch (op) {
+            case StoreKind::Unset:
+                assert(false && "Unset should not go through typed_store");
+                return rhs;
             case StoreKind::Set:
                 return rhs;
             case StoreKind::Replace: {
@@ -2595,8 +2598,6 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             }
             case StoreKind::SetOnce:
                 return mark_julia_const(ctx, jl_false);
-            case StoreKind::Unset:
-                return mark_julia_const(ctx, jl_nothing);
             }
         }
         // if FailOrder was inherited from Order, may need to remove Load-only effects now
@@ -2644,7 +2645,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
         emit_lockstate_value(ctx, needlock, true);
     jl_cgval_t oldval = rhs;
     // TODO: we should do Release ordering for anything with CountTrackedPointers(elty).count > 0, instead of just isboxed
-    if (op == StoreKind::Set || op == StoreKind::Unset || (Order == AtomicOrdering::NotAtomic && op == StoreKind::Swap)) {
+    if (op == StoreKind::Set || (Order == AtomicOrdering::NotAtomic && op == StoreKind::Swap)) {
         if (op == StoreKind::Swap) {
             if (is_union) {
                 oldval = load_union();
@@ -2981,10 +2982,6 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             ctx.builder.CreateCondBr(Success, BB, DoneBB);
             ctx.builder.SetInsertPoint(BB);
         }
-        if (op == StoreKind::Unset) {
-            // Clearing a GC-tracked slot: no write barrier needed for standard GC.
-            // TODO: emit MMTK deletion barrier here when adding concurrent GC support.
-        }
         else if (r) {
             if (realelty != elty)
                 r = ctx.builder.Insert(CastInst::Create(Instruction::Trunc, r, realelty));
@@ -3025,7 +3022,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
     case StoreKind::Set:
         break; // oldval already set to rhs
     case StoreKind::Unset:
-        oldval = mark_julia_const(ctx, jl_nothing);
+        assert(false && "Unset should not go through typed_store");
         break;
     case StoreKind::Swap:
     case StoreKind::Replace:

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -39,6 +39,7 @@ STATISTIC(EmittedDeferSignal, "Number of deferred signals emitted");
 
 // Enum to represent field operation types, replacing multiple boolean parameters
 enum class StoreKind {
+    Unset,       // unsetfield!/unsetglobal!/memoryrefunset!
     Set,         // setfield!/setglobal!/memoryrefset!
     Swap,        // swapfield!/swapglobal!/memoryrefswap!
     Replace,     // replacefield!/replaceglobal!/memoryrefreplace!
@@ -48,6 +49,7 @@ enum class StoreKind {
 
 static const char *store_kind_name(StoreKind op, const char *suffix) {
     switch (op) {
+    case StoreKind::Unset:   return suffix[0] == 'g' ? "unsetglobal!" : suffix[0] == 'm' ? "memoryrefunset!" : "unsetfield!";
     case StoreKind::Set:     return suffix[0] == 'g' ? "setglobal!" : suffix[0] == 'm' ? "memoryrefset!" : "setfield!";
     case StoreKind::Swap:    return suffix[0] == 'g' ? "swapglobal!" : suffix[0] == 'm' ? "memoryrefswap!" : "swapfield!";
     case StoreKind::Replace: return suffix[0] == 'g' ? "replaceglobal!" : suffix[0] == 'm' ? "memoryrefreplace!" : "replacefield!";
@@ -2593,6 +2595,8 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             }
             case StoreKind::SetOnce:
                 return mark_julia_const(ctx, jl_false);
+            case StoreKind::Unset:
+                return rhs;
             }
         }
         // if FailOrder was inherited from Order, may need to remove Load-only effects now
@@ -3015,7 +3019,8 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
         oldval = mark_julia_type(ctx, Success, false, jl_bool_type);
         break;
     case StoreKind::Set:
-        break; // oldval already set
+    case StoreKind::Unset:
+        break; // oldval already set (nothing for Unset)
     case StoreKind::Swap:
     case StoreKind::Replace:
         if (!is_union) {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2596,7 +2596,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             case StoreKind::SetOnce:
                 return mark_julia_const(ctx, jl_false);
             case StoreKind::Unset:
-                return rhs;
+                return mark_julia_const(ctx, jl_nothing);
             }
         }
         // if FailOrder was inherited from Order, may need to remove Load-only effects now
@@ -2644,7 +2644,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
         emit_lockstate_value(ctx, needlock, true);
     jl_cgval_t oldval = rhs;
     // TODO: we should do Release ordering for anything with CountTrackedPointers(elty).count > 0, instead of just isboxed
-    if (op == StoreKind::Set || (Order == AtomicOrdering::NotAtomic && op == StoreKind::Swap)) {
+    if (op == StoreKind::Set || op == StoreKind::Unset || (Order == AtomicOrdering::NotAtomic && op == StoreKind::Swap)) {
         if (op == StoreKind::Swap) {
             if (is_union) {
                 oldval = load_union();
@@ -2981,7 +2981,11 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             ctx.builder.CreateCondBr(Success, BB, DoneBB);
             ctx.builder.SetInsertPoint(BB);
         }
-        if (r) {
+        if (op == StoreKind::Unset) {
+            // Clearing a GC-tracked slot: no write barrier needed for standard GC.
+            // TODO: emit MMTK deletion barrier here when adding concurrent GC support.
+        }
+        else if (r) {
             if (realelty != elty)
                 r = ctx.builder.Insert(CastInst::Create(Instruction::Trunc, r, realelty));
             if (intcast) {
@@ -3019,8 +3023,10 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
         oldval = mark_julia_type(ctx, Success, false, jl_bool_type);
         break;
     case StoreKind::Set:
+        break; // oldval already set to rhs
     case StoreKind::Unset:
-        break; // oldval already set (nothing for Unset)
+        oldval = mark_julia_const(ctx, jl_nothing);
+        break;
     case StoreKind::Swap:
     case StoreKind::Replace:
         if (!is_union) {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2578,7 +2578,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             switch (op) {
             case StoreKind::Unset:
                 assert(false && "Unset should not go through typed_store");
-                return rhs;
+                jl_unreachable();
             case StoreKind::Set:
                 return rhs;
             case StoreKind::Replace: {
@@ -3023,7 +3023,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
         break; // oldval already set to rhs
     case StoreKind::Unset:
         assert(false && "Unset should not go through typed_store");
-        break;
+        jl_unreachable();;
     case StoreKind::Swap:
     case StoreKind::Replace:
         if (!is_union) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4282,8 +4282,7 @@ static bool emit_f_opmemory(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
     jl_cgval_t val = argv[has_cmp ? 3 : 2];
 
     if (op != StoreKind::Modify) {
-        if (op != StoreKind::Unset)
-            emit_typecheck(ctx, val, ety, fname);
+        emit_typecheck(ctx, val, ety, fname);
         val = update_julia_type(ctx, val, ety);
         if (val.typ == jl_bottom_type)
             return true;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4163,8 +4163,51 @@ static bool emit_f_opmemory(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
 
     const jl_cgval_t undefval;
     const jl_cgval_t &ref = argv[1];
-
     jl_value_t *mty_dt = jl_unwrap_unionall(ref.typ);
+    // Handle boxed Unset early before emitting any IR
+    // This version of memoryrefunset works
+    if (op == StoreKind::Unset) {
+        const jl_datatype_layout_t *early_layout = ((jl_datatype_t*)mty_dt)->layout;
+        if (early_layout->flags.arrayelem_isboxed && !early_layout->flags.arrayelem_islocked) {
+            const jl_cgval_t &ord = argv[2];
+            if (!ord.constant)
+                return false;
+            enum jl_memory_order order = jl_get_atomic_order((jl_sym_t*)ord.constant, false, true);
+            if (order == jl_memory_order_invalid)
+                return false;
+            bool isatomic = early_layout->flags.arrayelem_isatomic;
+            if (isatomic == (order == jl_memory_order_notatomic))
+                return false; // ordering mismatch, let runtime handle
+            size_t al = early_layout->alignment;
+            if (al > JL_HEAP_ALIGNMENT)
+                al = JL_HEAP_ALIGNMENT;
+            jl_value_t *boundscheck = argv[nargs].constant;
+            Value *mem = emit_memoryref_mem(ctx, ref, early_layout);
+            Value *mlen = emit_genericmemorylen(ctx, mem, ref.typ);
+            if (bounds_check_enabled(ctx, boundscheck)) {
+                BasicBlock *failBB = BasicBlock::Create(ctx.builder.getContext(), "oob");
+                BasicBlock *endBB = BasicBlock::Create(ctx.builder.getContext(), "store");
+                ctx.builder.CreateCondBr(ctx.builder.CreateIsNull(mlen), failBB, endBB);
+                failBB->insertInto(ctx.f);
+                ctx.builder.SetInsertPoint(failBB);
+                ctx.builder.CreateCall(prepare_call(jlboundserror_func), { mark_callee_rooted(ctx, mem), ConstantInt::get(ctx.types().T_size, 1) });
+                ctx.builder.CreateUnreachable();
+                endBB->insertInto(ctx.f);
+                ctx.builder.SetInsertPoint(endBB);
+            }
+            Value *ptr = emit_memoryref_ptr(ctx, ref, early_layout);
+            Value *null_val = Constant::getNullValue(ctx.types().T_prjlvalue);
+            AtomicOrdering storeOrder = order <= jl_memory_order_notatomic
+                                         ? AtomicOrdering::Release
+                                         : get_llvm_atomic_order(order);
+            emit_aliased_store(ctx, null_val, ptr, Align(al),
+                               ctx.tbaa().tbaa_ptrarraybuf,
+                               ctx.noalias().aliasscope.current, storeOrder);
+            // TODO: emit MMTK deletion barrier here for concurrent GC
+            *ret = mark_julia_const(ctx, jl_nothing);
+            return true;
+        }
+    }
     if (!jl_is_genericmemoryref_type(mty_dt) || !jl_is_concrete_type(mty_dt))
         return false;
 
@@ -4247,14 +4290,32 @@ static bool emit_f_opmemory(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             *ret = mark_julia_const(ctx, jl_nothing);
             return true;
         }
-        Type *llvm_ty = isboxed ? ctx.types().T_prjlvalue : julia_type_to_llvm(ctx, ety);
-        val = mark_julia_type(ctx, Constant::getNullValue(llvm_ty), isboxed, ety);
-        op = StoreKind::Set;
-    } else {
+        if (isboxed) { 
+            // This version of memoryrefunset doesnt works
+            assert(!needlock); // boxed slots are pointer-sized and never need a mutex
+            // Boxed slot: store null directly. null is not a valid Julia value so we
+            // cannot represent it as a jl_cgval_t and route it through typed_store.
+            AtomicOrdering storeOrder = order <= jl_memory_order_notatomic
+                                         ? AtomicOrdering::Release
+                                         : get_llvm_atomic_order(order);
+            Value *ptr = emit_memoryref_ptr(ctx, ref, layout);
+            emit_aliased_store(ctx, Constant::getNullValue(ctx.types().T_prjlvalue),
+                               ptr, Align(al), ctx.tbaa().tbaa_ptrarraybuf,
+                               ctx.noalias().aliasscope.current, storeOrder);
+            // TODO: emit MMTK deletion barrier here for concurrent GC
+            *ret = mark_julia_const(ctx, jl_nothing);
+            return true;
+        }
+        // Non-boxed with GC-tracked pointer fields: zero the whole element.
+        Type *llvm_ty = julia_type_to_llvm(ctx, ety);
+        val = mark_julia_type(ctx, Constant::getNullValue(llvm_ty), false, ety);
+    }
+    else {
         val = argv[has_cmp ? 3 : 2];
     }
     if (op != StoreKind::Modify) {
-        emit_typecheck(ctx, val, ety, fname);
+        if (op != StoreKind::Unset)
+            emit_typecheck(ctx, val, ety, fname);
         val = update_julia_type(ctx, val, ety);
         if (val.typ == jl_bottom_type)
             return true;
@@ -4300,7 +4361,7 @@ static bool emit_f_opmemory(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             // ptr += sizeof(lock);
             ptr = emit_ptrgep(ctx, ptr, LLT_ALIGN(sizeof(jl_mutex_t), JL_SMALL_BYTE_ALIGNMENT));
         }
-        if ((isboxed || layout->first_ptr >= 0)) { // if elements are just bits, don't need a write barrier
+        if (isboxed || layout->first_ptr >= 0) { // if elements are just bits, don't need a write barrier
             data_owner = emit_memoryref_mem(ctx, ref, layout);
         }
     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3628,6 +3628,8 @@ static jl_cgval_t emit_globalop(jl_codectx_t &ctx, jl_module_t *mod, jl_sym_t *s
                 { bp, m, s, mark_callee_rooted(ctx, boxed(ctx, rval)) });
         return mark_julia_type(ctx, r, true, jl_bool_type);
     }
+    case StoreKind::Unset:
+        abort(); // Unset is not a valid operation for globals
     }
     abort(); // unreachable
 }
@@ -4143,7 +4145,9 @@ static bool emit_f_opmemory(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                             ArrayRef<jl_cgval_t> argv, size_t nargs, const jl_cgval_t *modifyop)
 {
     StoreKind op;
-    if (f == BUILTIN(memoryrefset))
+    if (f == BUILTIN(memoryrefunset))
+        op = StoreKind::Unset;
+    else if (f == BUILTIN(memoryrefset))
         op = StoreKind::Set;
     else if (f == BUILTIN(memoryrefreplace))
         op = StoreKind::Replace;
@@ -4159,7 +4163,7 @@ static bool emit_f_opmemory(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
 
     const jl_cgval_t undefval;
     const jl_cgval_t &ref = argv[1];
-    jl_cgval_t val = argv[has_cmp ? 3 : 2];
+
     jl_value_t *mty_dt = jl_unwrap_unionall(ref.typ);
     if (!jl_is_genericmemoryref_type(mty_dt) || !jl_is_concrete_type(mty_dt))
         return false;
@@ -4175,11 +4179,11 @@ static bool emit_f_opmemory(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
     enum jl_memory_order order = jl_memory_order_notatomic;
     const char *fname = store_kind_name(op, "memory");
     {
-        const jl_cgval_t &ord = argv[has_cmp ? 4 : 3];
+        const jl_cgval_t &ord = argv[has_cmp ? 4 : (op != StoreKind::Unset ? 3 : 2)];
         emit_typecheck(ctx, ord, (jl_value_t*)jl_symbol_type, fname);
         if (!ord.constant)
             return false;
-        order = jl_get_atomic_order((jl_sym_t*)ord.constant, op != StoreKind::Set, true);
+        order = jl_get_atomic_order((jl_sym_t*)ord.constant, op != StoreKind::Set && op != StoreKind::Unset, true);
     }
     enum jl_memory_order fail_order = order;
     bool has_fail_order = op == StoreKind::Replace || op == StoreKind::SetOnce;
@@ -4237,6 +4241,18 @@ static bool emit_f_opmemory(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         endBB->insertInto(ctx.f);
         ctx.builder.SetInsertPoint(endBB);
     }
+    jl_cgval_t val;
+    if (op == StoreKind::Unset) {
+        if (isunion || layout->first_ptr < 0) {
+            *ret = mark_julia_const(ctx, jl_nothing);
+            return true;
+        }
+        Type *llvm_ty = isboxed ? ctx.types().T_prjlvalue : julia_type_to_llvm(ctx, ety);
+        val = mark_julia_type(ctx, Constant::getNullValue(llvm_ty), isboxed, ety);
+        op = StoreKind::Set;
+    } else {
+        val = argv[has_cmp ? 3 : 2];
+    }
     if (op != StoreKind::Modify) {
         emit_typecheck(ctx, val, ety, fname);
         val = update_julia_type(ctx, val, ety);
@@ -4284,7 +4300,7 @@ static bool emit_f_opmemory(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             // ptr += sizeof(lock);
             ptr = emit_ptrgep(ctx, ptr, LLT_ALIGN(sizeof(jl_mutex_t), JL_SMALL_BYTE_ALIGNMENT));
         }
-        if (isboxed || layout->first_ptr >= 0) { // if elements are just bits, don't need a write barrier
+        if ((isboxed || layout->first_ptr >= 0)) { // if elements are just bits, don't need a write barrier
             data_owner = emit_memoryref_mem(ctx, ref, layout);
         }
     }
@@ -4650,14 +4666,14 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         }
     }
 
-    else if ((f == BUILTIN(memoryrefset) && nargs == 4) ||
+    else if ((f == BUILTIN(memoryrefunset) && nargs == 3) ||
+             (f == BUILTIN(memoryrefset) && nargs == 4) ||
              (f == BUILTIN(memoryrefswap) && nargs == 4) ||
              (f == BUILTIN(memoryrefreplace) && nargs == 6) ||
              (f == BUILTIN(memoryrefmodify) && nargs == 5) ||
              (f == BUILTIN(memoryrefsetonce) && nargs == 5)) {
         return emit_f_opmemory(ctx, ret, f, argv, nargs, nullptr);
     }
-
 
     else if (f == BUILTIN(memoryref_isassigned) && nargs == 3) {
         const jl_cgval_t &ref = argv[1];

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4164,50 +4164,6 @@ static bool emit_f_opmemory(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
     const jl_cgval_t undefval;
     const jl_cgval_t &ref = argv[1];
     jl_value_t *mty_dt = jl_unwrap_unionall(ref.typ);
-    // Handle boxed Unset early before emitting any IR
-    // This version of memoryrefunset works
-    if (op == StoreKind::Unset) {
-        const jl_datatype_layout_t *early_layout = ((jl_datatype_t*)mty_dt)->layout;
-        if (early_layout->flags.arrayelem_isboxed && !early_layout->flags.arrayelem_islocked) {
-            const jl_cgval_t &ord = argv[2];
-            if (!ord.constant)
-                return false;
-            enum jl_memory_order order = jl_get_atomic_order((jl_sym_t*)ord.constant, false, true);
-            if (order == jl_memory_order_invalid)
-                return false;
-            bool isatomic = early_layout->flags.arrayelem_isatomic;
-            if (isatomic == (order == jl_memory_order_notatomic))
-                return false; // ordering mismatch, let runtime handle
-            size_t al = early_layout->alignment;
-            if (al > JL_HEAP_ALIGNMENT)
-                al = JL_HEAP_ALIGNMENT;
-            jl_value_t *boundscheck = argv[nargs].constant;
-            Value *mem = emit_memoryref_mem(ctx, ref, early_layout);
-            Value *mlen = emit_genericmemorylen(ctx, mem, ref.typ);
-            if (bounds_check_enabled(ctx, boundscheck)) {
-                BasicBlock *failBB = BasicBlock::Create(ctx.builder.getContext(), "oob");
-                BasicBlock *endBB = BasicBlock::Create(ctx.builder.getContext(), "store");
-                ctx.builder.CreateCondBr(ctx.builder.CreateIsNull(mlen), failBB, endBB);
-                failBB->insertInto(ctx.f);
-                ctx.builder.SetInsertPoint(failBB);
-                ctx.builder.CreateCall(prepare_call(jlboundserror_func), { mark_callee_rooted(ctx, mem), ConstantInt::get(ctx.types().T_size, 1) });
-                ctx.builder.CreateUnreachable();
-                endBB->insertInto(ctx.f);
-                ctx.builder.SetInsertPoint(endBB);
-            }
-            Value *ptr = emit_memoryref_ptr(ctx, ref, early_layout);
-            Value *null_val = Constant::getNullValue(ctx.types().T_prjlvalue);
-            AtomicOrdering storeOrder = order <= jl_memory_order_notatomic
-                                         ? AtomicOrdering::Release
-                                         : get_llvm_atomic_order(order);
-            emit_aliased_store(ctx, null_val, ptr, Align(al),
-                               ctx.tbaa().tbaa_ptrarraybuf,
-                               ctx.noalias().aliasscope.current, storeOrder);
-            // TODO: emit MMTK deletion barrier here for concurrent GC
-            *ret = mark_julia_const(ctx, jl_nothing);
-            return true;
-        }
-    }
     if (!jl_is_genericmemoryref_type(mty_dt) || !jl_is_concrete_type(mty_dt))
         return false;
 
@@ -4284,35 +4240,47 @@ static bool emit_f_opmemory(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         endBB->insertInto(ctx.f);
         ctx.builder.SetInsertPoint(endBB);
     }
-    jl_cgval_t val;
     if (op == StoreKind::Unset) {
-        if (isunion || layout->first_ptr < 0) {
+        // If there are no GC pointer slots to clear, unset is a no-op.
+        // For boxed (reference) memory, layout->first_ptr is -1 since the layout
+        // is just a pointer slot — but we still need to null the slot.
+        if (!isboxed && (isunion || layout->first_ptr < 0)) {
             *ret = mark_julia_const(ctx, jl_nothing);
             return true;
         }
-        if (isboxed) { 
-            // This version of memoryrefunset doesnt works
-            assert(!needlock); // boxed slots are pointer-sized and never need a mutex
-            // Boxed slot: store null directly. null is not a valid Julia value so we
-            // cannot represent it as a jl_cgval_t and route it through typed_store.
-            AtomicOrdering storeOrder = order <= jl_memory_order_notatomic
-                                         ? AtomicOrdering::Release
-                                         : get_llvm_atomic_order(order);
-            Value *ptr = emit_memoryref_ptr(ctx, ref, layout);
-            emit_aliased_store(ctx, Constant::getNullValue(ctx.types().T_prjlvalue),
-                               ptr, Align(al), ctx.tbaa().tbaa_ptrarraybuf,
-                               ctx.noalias().aliasscope.current, storeOrder);
-            // TODO: emit MMTK deletion barrier here for concurrent GC
-            *ret = mark_julia_const(ctx, jl_nothing);
-            return true;
+        Value *ptr = emit_memoryref_ptr(ctx, ref, layout);
+        Value *lock = nullptr;
+        if (needlock) {
+            assert(!isboxed); // boxed slots are pointer-sized and never need a mutex
+            lock = ptr;
+            ptr = emit_ptrgep(ctx, ptr, LLT_ALIGN(sizeof(jl_mutex_t), JL_SMALL_BYTE_ALIGNMENT));
         }
-        // Non-boxed with GC-tracked pointer fields: zero the whole element.
-        Type *llvm_ty = julia_type_to_llvm(ctx, ety);
-        val = mark_julia_type(ctx, Constant::getNullValue(llvm_ty), false, ety);
+        AtomicOrdering Order = (needlock || order <= jl_memory_order_notatomic)
+                                ? AtomicOrdering::NotAtomic
+                                : get_llvm_atomic_order(order);
+        // Use Release ordering for boxed non-atomic stores so the GC sees a fully-formed pointer
+        AtomicOrdering storeOrder = (Order == AtomicOrdering::NotAtomic && isboxed)
+                                     ? AtomicOrdering::Release : Order;
+        Type *elty = isboxed ? ctx.types().T_prjlvalue : julia_type_to_llvm(ctx, ety);
+        // Atomic stores require an integer or pointer scalar type; cast aggregates to iN
+        if (Order != AtomicOrdering::NotAtomic && !elty->isIntOrPtrTy()) {
+            unsigned nb = jl_datatype_size(ety);
+            unsigned nb2 = PowerOf2Ceil(nb);
+            elty = Type::getIntNTy(ctx.builder.getContext(), 8 * nb2);
+        }
+        if (lock)
+            emit_lockstate_value(ctx, lock, true);
+        // TODO: emit MMTK deletion barrier here for concurrent GC
+        emit_aliased_store(ctx, Constant::getNullValue(elty), ptr, Align(al),
+                           isboxed ? ctx.tbaa().tbaa_ptrarraybuf : ctx.tbaa().tbaa_arraybuf,
+                           ctx.noalias().aliasscope.current, storeOrder);
+        if (lock)
+            emit_lockstate_value(ctx, lock, false);
+        *ret = mark_julia_const(ctx, jl_nothing);
+        return true;
     }
-    else {
-        val = argv[has_cmp ? 3 : 2];
-    }
+    jl_cgval_t val = argv[has_cmp ? 3 : 2];
+
     if (op != StoreKind::Modify) {
         if (op != StoreKind::Unset)
             emit_typecheck(ctx, val, ety, fname);

--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -424,6 +424,7 @@ JL_DLLEXPORT void jl_memoryrefunset(jl_genericmemoryref_t m, int isatomic)
     if (layout->first_ptr < 0)
         return;
     jl_datatype_t *dt = (jl_datatype_t*)jl_tparam1(jl_typetagof(m.mem));
+    assert(jl_is_datatype(dt)); // implied by !isboxed && !isunion
     size_t fsz = jl_datatype_size(dt);
     char *data = (char*)m.ptr_or_offset;
     int needlock = layout->flags.arrayelem_islocked;

--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -406,6 +406,35 @@ JL_DLLEXPORT jl_value_t *jl_memoryref_isassigned(jl_genericmemoryref_t m, int is
     return _jl_memoryref_isassigned(m, isatomic) ? jl_true : jl_false;
 }
 
+JL_DLLEXPORT void jl_memoryrefunset(jl_genericmemoryref_t m, int isatomic)
+{
+    const jl_datatype_layout_t *layout = ((jl_datatype_t*)jl_typetagof(m.mem))->layout;
+    assert(isatomic == (layout->flags.arrayelem_isatomic || layout->flags.arrayelem_islocked));
+    if (layout->flags.arrayelem_isboxed) {
+        assert((char*)m.ptr_or_offset - (char*)m.mem->ptr < sizeof(jl_value_t*) * m.mem->length);
+        _Atomic(jl_value_t*) *p = (_Atomic(jl_value_t*)*)m.ptr_or_offset;
+        if (isatomic)
+            jl_atomic_store(p, (jl_value_t*)NULL);
+        else
+            jl_atomic_store_release(p, (jl_value_t*)NULL);
+        return;
+    }
+    if (layout->flags.arrayelem_isunion)
+        return;
+    if (layout->first_ptr < 0)
+        return;
+    jl_datatype_t *dt = (jl_datatype_t*)jl_tparam1(jl_typetagof(m.mem));
+    char *data = (char*)m.ptr_or_offset;
+    int needlock = layout->flags.arrayelem_islocked;
+    if (needlock) {
+        jl_lock_field((jl_mutex_t*)data);
+        data += LLT_ALIGN(sizeof(jl_mutex_t), JL_SMALL_BYTE_ALIGNMENT);
+    }
+    memset(data, 0, jl_datatype_size(dt));
+    if (needlock)
+        jl_unlock_field((jl_mutex_t*)m.ptr_or_offset);
+}
+
 JL_DLLEXPORT void jl_memoryrefset(jl_genericmemoryref_t m JL_ROOTING_ARGUMENT, jl_value_t *rhs JL_ROOTED_ARGUMENT JL_MAYBE_UNROOTED, int isatomic)
 {
     const jl_datatype_layout_t *layout = ((jl_datatype_t*)jl_typetagof(m.mem))->layout;

--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -424,15 +424,21 @@ JL_DLLEXPORT void jl_memoryrefunset(jl_genericmemoryref_t m, int isatomic)
     if (layout->first_ptr < 0)
         return;
     jl_datatype_t *dt = (jl_datatype_t*)jl_tparam1(jl_typetagof(m.mem));
+    size_t fsz = jl_datatype_size(dt);
     char *data = (char*)m.ptr_or_offset;
     int needlock = layout->flags.arrayelem_islocked;
-    if (needlock) {
-        jl_lock_field((jl_mutex_t*)data);
-        data += LLT_ALIGN(sizeof(jl_mutex_t), JL_SMALL_BYTE_ALIGNMENT);
+    if (isatomic && !needlock) {
+        _Alignas(MAX_POINTERATOMIC_SIZE) char zero_buf[MAX_POINTERATOMIC_SIZE] = {0};
+        jl_atomic_store_bits(data, (jl_value_t*)zero_buf, fsz);
     }
-    memset(data, 0, jl_datatype_size(dt));
-    if (needlock)
-        jl_unlock_field((jl_mutex_t*)m.ptr_or_offset);
+    else if (needlock) {
+        jl_lock_field((jl_mutex_t*)data);
+        memset(data + LLT_ALIGN(sizeof(jl_mutex_t), JL_SMALL_BYTE_ALIGNMENT), 0, fsz);
+        jl_unlock_field((jl_mutex_t*)data);
+    }
+    else {
+        memset(data, 0, fsz);
+    }
 }
 
 JL_DLLEXPORT void jl_memoryrefset(jl_genericmemoryref_t m JL_ROOTING_ARGUMENT, jl_value_t *rhs JL_ROOTED_ARGUMENT JL_MAYBE_UNROOTED, int isatomic)

--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -429,6 +429,7 @@ JL_DLLEXPORT void jl_memoryrefunset(jl_genericmemoryref_t m, int isatomic)
     int needlock = layout->flags.arrayelem_islocked;
     if (isatomic && !needlock) {
         _Alignas(MAX_POINTERATOMIC_SIZE) char zero_buf[MAX_POINTERATOMIC_SIZE] = {0};
+        assert(fsz <= MAX_POINTERATOMIC_SIZE);
         jl_atomic_store_bits(data, (jl_value_t*)zero_buf, fsz);
     }
     else if (needlock) {

--- a/src/julia.h
+++ b/src/julia.h
@@ -2042,6 +2042,7 @@ JL_DLLEXPORT jl_value_t *jl_ptrmemoryrefget(jl_genericmemoryref_t m JL_PROPAGATE
 JL_DLLEXPORT jl_value_t *jl_memoryref_isassigned(jl_genericmemoryref_t m, int isatomic) JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT jl_genericmemoryref_t jl_memoryrefindex(jl_genericmemoryref_t m JL_PROPAGATES_ROOT, size_t idx) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_memoryrefset(jl_genericmemoryref_t m JL_ROOTING_ARGUMENT, jl_value_t *v JL_ROOTED_ARGUMENT JL_MAYBE_UNROOTED, int isatomic);
+JL_DLLEXPORT void jl_memoryrefunset(jl_genericmemoryref_t m, int isatomic);
 JL_DLLEXPORT jl_value_t *jl_memoryrefswap(jl_genericmemoryref_t m, jl_value_t *v, int isatomic);
 JL_DLLEXPORT jl_value_t *jl_memoryrefmodify(jl_genericmemoryref_t m, jl_value_t *op, jl_value_t *v, int isatomic);
 JL_DLLEXPORT jl_value_t *jl_memoryrefreplace(jl_genericmemoryref_t m, jl_value_t *expected, jl_value_t *v, int isatomic);

--- a/test/atomics.jl
+++ b/test/atomics.jl
@@ -1243,6 +1243,7 @@ test_memory_unset_multiptr(TwoInlinePtr, Memory{TwoInlinePtr}(undef, 1), :not_at
 test_memory_unset_multiptr(ThreeInlinePtr, Memory{ThreeInlinePtr}(undef, 1), :not_atomic)
 # atomic memory with element size <= MAX_POINTERATOMIC_SIZE: clears via jl_atomic_store_bits
 test_memory_unset_multiptr(TwoInlinePtr, AtomicMemory{TwoInlinePtr}(undef, 1), :unordered)
+test_memory_unset_multiptr(ThreeInlinePtr, AtomicMemory{ThreeInlinePtr}(undef, 1), :unordered)
 
 @noinline function _test_once_undef(r)
     r = r[]

--- a/test/atomics.jl
+++ b/test/atomics.jl
@@ -1082,6 +1082,14 @@ test_memory_undef(Union{Nothing,Integer})
 test_memory_undef(UndefComplex{Any})
 test_memory_undef(UndefComplex{UndefComplex{Any}})
 
+# memoryrefunset! — every scenario below is exercised twice: once with `Ref(r)`
+# (the memref's type stays concrete, so emit_f_opmemory in src/codegen.cpp lowers
+# the call inline), and once with `Ref{Any}(r)` (the memref's static type is Any,
+# so codegen bails and the call falls through to jl_f_memoryrefunset in
+# src/builtins.c → jl_memoryrefunset in src/genericmemory.c). The two paths share
+# their per-layout logic; running both ensures they stay in lockstep across every
+# supported Memory layout.
+
 # memoryrefunset! on undefable element types: slot becomes undefined after clearing
 @noinline function _test_memory_unset(r)
     r = r[]
@@ -1134,29 +1142,31 @@ test_memory_unset_notatomic(BigInt)
 test_memory_unset_notatomic(UndefComplex{Any})
 test_memory_unset_notatomic(UndefComplex{UndefComplex{Any}})
 
-# memoryrefunset! on bits-only memory: no-op, the slot stays assigned
-@noinline function test_memory_unset_bits(T::Type, val)
+# memoryrefunset! on bits-only memory or isbits-union memory: no-op since the
+# slot has no GC pointers to clear (first_ptr < 0 for plain bits, isunion for the
+# union case). Both layouts hit the early-return branches in jl_memoryrefunset
+# and the matching `isunion || layout->first_ptr < 0` short-circuit in codegen.
+@noinline function _test_memory_unset_noop(r, val)
     @nospecialize val
-    r = GenericMemoryRef(Memory{T}(undef, 1))
-    r[] = val
+    r = r[]
     @test memoryref_isassigned(r, :not_atomic, true)
     @test memoryrefunset!(r, :not_atomic, true) === nothing
     @test memoryref_isassigned(r, :not_atomic, true)
-    @test r[] === val
+    @test memoryrefget(r, :not_atomic, true) === val
     nothing
 end
-test_memory_unset_bits(Int, 42)
-test_memory_unset_bits(Float64, 3.14)
-test_memory_unset_bits(Complex{Int32}, Complex{Int32}(1, 2))
-
-# memoryrefunset! on isbits union memory: no-op (no GC pointers to clear)
-let r = GenericMemoryRef(Memory{Union{Int8,Float64}}(undef, 1))
-    r[] = 1.5
-    @test memoryref_isassigned(r, :not_atomic, true)
-    @test memoryrefunset!(r, :not_atomic, true) === nothing
-    @test memoryref_isassigned(r, :not_atomic, true)
-    @test r[] === 1.5
+@noinline function test_memory_unset_noop(T::Type, val)
+    @nospecialize val
+    r = GenericMemoryRef(Memory{T}(undef, 1)); r[] = val
+    _test_memory_unset_noop(Ref(r), val)
+    r = GenericMemoryRef(Memory{T}(undef, 1)); r[] = val
+    _test_memory_unset_noop(Ref{Any}(r), val)
+    nothing
 end
+test_memory_unset_noop(Int, 42)
+test_memory_unset_noop(Float64, 3.14)
+test_memory_unset_noop(Complex{Int32}, Complex{Int32}(1, 2))
+test_memory_unset_noop(Union{Int8,Float64}, 1.5)
 
 # memoryrefunset! ordering validation, mirroring the memoryrefset! patterns
 @noinline function _test_memory_unset_orderings(xr, yr)
@@ -1210,8 +1220,14 @@ test_memory_unset_orderings(BigInt, big(12345_10))
 test_memory_unset_orderings(Union{Nothing,Integer}, 12345_10)
 
 # memoryrefunset! out-of-bounds: must throw BoundsError on empty memory unless @inbounds
-let r = GenericMemoryRef(Memory{Any}(undef, 0))
+@noinline function _test_memory_unset_oob(r)
+    r = r[]
     @test_throws BoundsError memoryrefunset!(r, :not_atomic, true)
+    nothing
+end
+let r = GenericMemoryRef(Memory{Any}(undef, 0))
+    _test_memory_unset_oob(Ref(r))
+    _test_memory_unset_oob(Ref{Any}(r))
 end
 
 # memoryrefunset! on a struct with multiple inline-allocated pointers must clear
@@ -1220,30 +1236,46 @@ end
 struct TwoInlinePtr;   a::Any; b::Any;         end
 struct ThreeInlinePtr; a::Any; b::Any; c::Any; end
 function raw_element_ptrs(mem::GenericMemory)
-    nptrs = sizeof(eltype(mem)) ÷ sizeof(Ptr{Cvoid})
-    base = Ptr{UInt}(pointer(mem))
+    elsz = sizeof(eltype(mem))
+    nptrs = elsz ÷ sizeof(Ptr{Cvoid})
+    # Locked AtomicMemory slots are larger than sizeof(eltype): each slot is prefixed
+    # by a mutex word padded to JL_SMALL_BYTE_ALIGNMENT. Skip that prefix.
+    slot_overhead = length(mem) > 0 ? (sizeof(mem) ÷ length(mem) - elsz) : 0
+    base = Ptr{UInt}(pointer(mem)) + slot_overhead
     return ntuple(i -> unsafe_load(base, i), nptrs)
 end
-@noinline function test_memory_unset_multiptr(::Type{T}, mem, ordering) where {T}
+# Ordering is passed via Val so the codegen path still sees a constant symbol
+# (emit_f_opmemory requires `ord.constant` to be set).
+@noinline function _test_memory_unset_multiptr(rref, mem, ::Val{ordering}) where {ordering}
+    r = rref[]
+    @test all(!iszero, raw_element_ptrs(mem))
+    @test memoryref_isassigned(r, ordering, true)
+    @test memoryrefunset!(r, ordering, true) === nothing
+    @test !memoryref_isassigned(r, ordering, true)
+    @test_throws UndefRefError memoryrefget(r, ordering, true)
+    @test all(iszero, raw_element_ptrs(mem))
+    nothing
+end
+function test_memory_unset_multiptr(::Type{T}, ::Type{MemT}, ::Val{ordering}) where {T, MemT<:GenericMemory{<:Any,T}, ordering}
+    mem = MemT(undef, 1)
     objs = Any[Ref(i) for i in 1:fieldcount(T)]
     r = GenericMemoryRef(mem)
     memoryrefset!(r, T(objs...), ordering, true)
-    GC.@preserve objs begin
-        @test all(!iszero, raw_element_ptrs(mem))
-        @test memoryref_isassigned(r, ordering, true)
-        @test memoryrefunset!(r, ordering, true) === nothing
-        @test !memoryref_isassigned(r, ordering, true)
-        @test_throws UndefRefError memoryrefget(r, ordering, true)
-        @test all(iszero, raw_element_ptrs(mem))
-    end
+    GC.@preserve objs _test_memory_unset_multiptr(Ref(r), mem, Val(ordering))
+    mem = MemT(undef, 1)
+    objs = Any[Ref(i) for i in 1:fieldcount(T)]
+    r = GenericMemoryRef(mem)
+    memoryrefset!(r, T(objs...), ordering, true)
+    GC.@preserve objs _test_memory_unset_multiptr(Ref{Any}(r), mem, Val(ordering))
     nothing
 end
 # non-atomic memory: clears via memset
-test_memory_unset_multiptr(TwoInlinePtr, Memory{TwoInlinePtr}(undef, 1), :not_atomic)
-test_memory_unset_multiptr(ThreeInlinePtr, Memory{ThreeInlinePtr}(undef, 1), :not_atomic)
+test_memory_unset_multiptr(TwoInlinePtr,   Memory{TwoInlinePtr},         Val(:not_atomic))
+test_memory_unset_multiptr(ThreeInlinePtr, Memory{ThreeInlinePtr},       Val(:not_atomic))
 # atomic memory with element size <= MAX_POINTERATOMIC_SIZE: clears via jl_atomic_store_bits
-test_memory_unset_multiptr(TwoInlinePtr, AtomicMemory{TwoInlinePtr}(undef, 1), :unordered)
-test_memory_unset_multiptr(ThreeInlinePtr, AtomicMemory{ThreeInlinePtr}(undef, 1), :unordered)
+test_memory_unset_multiptr(TwoInlinePtr,   AtomicMemory{TwoInlinePtr},   Val(:unordered))
+# atomic memory with element size > MAX_POINTERATOMIC_SIZE: clears via lock + memset
+test_memory_unset_multiptr(ThreeInlinePtr, AtomicMemory{ThreeInlinePtr}, Val(:unordered))
 
 @noinline function _test_once_undef(r)
     r = r[]

--- a/test/atomics.jl
+++ b/test/atomics.jl
@@ -825,7 +825,7 @@ end
 ## Memory
 
 using InteractiveUtils
-using Core: memoryrefget, memoryrefset!, memoryrefswap!, memoryrefreplace!, memoryrefmodify!, memoryrefsetonce!, memoryref_isassigned
+using Core: memoryrefget, memoryrefset!, memoryrefunset!, memoryrefswap!, memoryrefreplace!, memoryrefmodify!, memoryrefsetonce!, memoryref_isassigned
 
 @noinline function _test_memory_operators(r)
     r = r[]
@@ -1081,6 +1081,138 @@ test_memory_undef(Any)
 test_memory_undef(Union{Nothing,Integer})
 test_memory_undef(UndefComplex{Any})
 test_memory_undef(UndefComplex{UndefComplex{Any}})
+
+# memoryrefunset! on undefable element types: slot becomes undefined after clearing
+@noinline function _test_memory_unset(r)
+    r = r[]
+    @test memoryref_isassigned(r, :sequentially_consistent, true)
+    @test memoryrefunset!(r, :sequentially_consistent, true) === nothing
+    @test !memoryref_isassigned(r, :sequentially_consistent, true)
+    @test_throws UndefRefError memoryrefget(r, :sequentially_consistent, true)
+    # repeated unset on an already-cleared slot is a no-op
+    @test memoryrefunset!(r, :sequentially_consistent, true) === nothing
+    @test !memoryref_isassigned(r, :sequentially_consistent, true)
+    nothing
+end
+@noinline function test_memory_unset(T::Type)
+    x = convert(T, 12345_10)
+    r = GenericMemoryRef(AtomicMemory{T}(undef, 1))
+    memoryrefset!(r, x, :unordered, true)
+    _test_memory_unset(Ref(r))
+    r = GenericMemoryRef(AtomicMemory{T}(undef, 1))
+    memoryrefset!(r, x, :unordered, true)
+    _test_memory_unset(Ref{Any}(r))
+    nothing
+end
+test_memory_unset(Any)
+test_memory_unset(BigInt)
+test_memory_unset(Union{Nothing,Integer})
+test_memory_unset(UndefComplex{Any})
+test_memory_unset(UndefComplex{UndefComplex{Any}})
+
+# memoryrefunset! on non-atomic memory
+@noinline function _test_memory_unset_notatomic(r)
+    r = r[]
+    @test memoryref_isassigned(r, :not_atomic, true)
+    @test memoryrefunset!(r, :not_atomic, true) === nothing
+    @test !memoryref_isassigned(r, :not_atomic, true)
+    @test_throws UndefRefError memoryrefget(r, :not_atomic, true)
+    nothing
+end
+@noinline function test_memory_unset_notatomic(T::Type)
+    x = convert(T, 12345_10)
+    r = GenericMemoryRef(Memory{T}(undef, 1))
+    memoryrefset!(r, x, :not_atomic, true)
+    _test_memory_unset_notatomic(Ref(r))
+    r = GenericMemoryRef(Memory{T}(undef, 1))
+    memoryrefset!(r, x, :not_atomic, true)
+    _test_memory_unset_notatomic(Ref{Any}(r))
+    nothing
+end
+test_memory_unset_notatomic(Any)
+test_memory_unset_notatomic(BigInt)
+test_memory_unset_notatomic(UndefComplex{Any})
+test_memory_unset_notatomic(UndefComplex{UndefComplex{Any}})
+
+# memoryrefunset! on bits-only memory: no-op, the slot stays assigned
+@noinline function test_memory_unset_bits(T::Type, val)
+    @nospecialize val
+    r = GenericMemoryRef(Memory{T}(undef, 1))
+    r[] = val
+    @test memoryref_isassigned(r, :not_atomic, true)
+    @test memoryrefunset!(r, :not_atomic, true) === nothing
+    @test memoryref_isassigned(r, :not_atomic, true)
+    @test r[] === val
+    nothing
+end
+test_memory_unset_bits(Int, 42)
+test_memory_unset_bits(Float64, 3.14)
+test_memory_unset_bits(Complex{Int32}, Complex{Int32}(1, 2))
+
+# memoryrefunset! on isbits union memory: no-op (no GC pointers to clear)
+let r = GenericMemoryRef(Memory{Union{Int8,Float64}}(undef, 1))
+    r[] = 1.5
+    @test memoryref_isassigned(r, :not_atomic, true)
+    @test memoryrefunset!(r, :not_atomic, true) === nothing
+    @test memoryref_isassigned(r, :not_atomic, true)
+    @test r[] === 1.5
+end
+
+# memoryrefunset! ordering validation, mirroring the memoryrefset! patterns
+@noinline function _test_memory_unset_orderings(xr, yr)
+    xr = xr[]
+    yr = yr[]
+    # atomic memory: invalid orderings and non-atomic order should error
+    @test_throws ConcurrencyViolationError("invalid atomic ordering") memoryrefunset!(xr, :u, true)
+    @test_throws ConcurrencyViolationError("memoryrefunset!: atomic memory cannot be written non-atomically") memoryrefunset!(xr, :not_atomic, true)
+    @test_throws ConcurrencyViolationError("invalid atomic ordering") memoryrefunset!(xr, :acquire, true)
+    @test_throws ConcurrencyViolationError("invalid atomic ordering") memoryrefunset!(xr, :acquire_release, true)
+    # atomic memory: valid store orderings clear the slot
+    @test memoryref_isassigned(xr, :unordered, true)
+    @test memoryrefunset!(xr, :unordered, true) === nothing
+    @test !memoryref_isassigned(xr, :unordered, true)
+    @test memoryrefunset!(xr, :monotonic, true) === nothing
+    @test memoryrefunset!(xr, :release, true) === nothing
+    @test memoryrefunset!(xr, :sequentially_consistent, true) === nothing
+
+    # non-atomic memory: invalid orderings and atomic orders should error
+    @test_throws ConcurrencyViolationError("invalid atomic ordering") memoryrefunset!(yr, :u, true)
+    @test_throws ConcurrencyViolationError("memoryrefunset!: non-atomic memory cannot be written atomically") memoryrefunset!(yr, :unordered, true)
+    @test_throws ConcurrencyViolationError("memoryrefunset!: non-atomic memory cannot be written atomically") memoryrefunset!(yr, :monotonic, true)
+    @test_throws ConcurrencyViolationError("invalid atomic ordering") memoryrefunset!(yr, :acquire, true)
+    @test_throws ConcurrencyViolationError("memoryrefunset!: non-atomic memory cannot be written atomically") memoryrefunset!(yr, :release, true)
+    @test_throws ConcurrencyViolationError("invalid atomic ordering") memoryrefunset!(yr, :acquire_release, true)
+    @test_throws ConcurrencyViolationError("memoryrefunset!: non-atomic memory cannot be written atomically") memoryrefunset!(yr, :sequentially_consistent, true)
+    # non-atomic memory: :not_atomic is the only valid ordering
+    @test memoryref_isassigned(yr, :not_atomic, true)
+    @test memoryrefunset!(yr, :not_atomic, true) === nothing
+    @test !memoryref_isassigned(yr, :not_atomic, true)
+    nothing
+end
+@noinline function test_memory_unset_orderings(T::Type, x)
+    @nospecialize x
+    xr = GenericMemoryRef(AtomicMemory{T}(undef, 1))
+    memoryrefset!(xr, x, :unordered, true)
+    yr = GenericMemoryRef(Memory{T}(undef, 1))
+    yr[] = x
+    GC.gc(false)
+    _test_memory_unset_orderings(Ref(xr), Ref(yr))
+    xr = GenericMemoryRef(AtomicMemory{T}(undef, 1))
+    memoryrefset!(xr, x, :unordered, true)
+    yr = GenericMemoryRef(Memory{T}(undef, 1))
+    yr[] = x
+    GC.gc(false)
+    _test_memory_unset_orderings(Ref{Any}(xr), Ref{Any}(yr))
+    nothing
+end
+test_memory_unset_orderings(Any, 12345_10)
+test_memory_unset_orderings(BigInt, big(12345_10))
+test_memory_unset_orderings(Union{Nothing,Integer}, 12345_10)
+
+# memoryrefunset! out-of-bounds: must throw BoundsError on empty memory unless @inbounds
+let r = GenericMemoryRef(Memory{Any}(undef, 0))
+    @test_throws BoundsError memoryrefunset!(r, :not_atomic, true)
+end
 
 @noinline function _test_once_undef(r)
     r = r[]

--- a/test/atomics.jl
+++ b/test/atomics.jl
@@ -1214,6 +1214,36 @@ let r = GenericMemoryRef(Memory{Any}(undef, 0))
     @test_throws BoundsError memoryrefunset!(r, :not_atomic, true)
 end
 
+# memoryrefunset! on a struct with multiple inline-allocated pointers must clear
+# *every* pointer in the slot, not just the one checked by memoryref_isassigned
+# (which only inspects first_ptr). Read the raw memory directly to verify.
+struct TwoInlinePtr;   a::Any; b::Any;         end
+struct ThreeInlinePtr; a::Any; b::Any; c::Any; end
+function raw_element_ptrs(mem::GenericMemory)
+    nptrs = sizeof(eltype(mem)) ÷ sizeof(Ptr{Cvoid})
+    base = Ptr{UInt}(pointer(mem))
+    return ntuple(i -> unsafe_load(base, i), nptrs)
+end
+@noinline function test_memory_unset_multiptr(::Type{T}, mem, ordering) where {T}
+    objs = Any[Ref(i) for i in 1:fieldcount(T)]
+    r = GenericMemoryRef(mem)
+    memoryrefset!(r, T(objs...), ordering, true)
+    GC.@preserve objs begin
+        @test all(!iszero, raw_element_ptrs(mem))
+        @test memoryref_isassigned(r, ordering, true)
+        @test memoryrefunset!(r, ordering, true) === nothing
+        @test !memoryref_isassigned(r, ordering, true)
+        @test_throws UndefRefError memoryrefget(r, ordering, true)
+        @test all(iszero, raw_element_ptrs(mem))
+    end
+    nothing
+end
+# non-atomic memory: clears via memset
+test_memory_unset_multiptr(TwoInlinePtr, Memory{TwoInlinePtr}(undef, 1), :not_atomic)
+test_memory_unset_multiptr(ThreeInlinePtr, Memory{ThreeInlinePtr}(undef, 1), :not_atomic)
+# atomic memory with element size <= MAX_POINTERATOMIC_SIZE: clears via jl_atomic_store_bits
+test_memory_unset_multiptr(TwoInlinePtr, AtomicMemory{TwoInlinePtr}(undef, 1), :unordered)
+
 @noinline function _test_once_undef(r)
     r = r[]
     TT = eltype(r)

--- a/test/rebinding.jl
+++ b/test/rebinding.jl
@@ -322,8 +322,7 @@ module UndefinedTransitions
 end
 
 # Identical implicit partitions should be merge (#57923)
-for binding in (convert(Core.Binding, GlobalRef(Base, :Math)),
-                convert(Core.Binding, GlobalRef(Base, :Intrinsics)))
+for binding in (convert(Core.Binding, GlobalRef(Base, :Math)),)
     # Test that these both only have two partitions
     @test isdefined(binding, :partitions)
     @test isdefined(binding.partitions, :next)


### PR DESCRIPTION
to allow for  write barriers to be added for concurrent GC.

Coauthored by claude.