### PR TITLE
perf: bulk fast paths for NTuple-from-array and rand!(::Array{Complex})

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -967,3 +967,21 @@ end
 
 mapreduce_impl(f::F, op::OP, A::AbstractArrayOrBroadcasted, ifirst::SCartesianIndex2, ilast::SCartesianIndex2) where {F,OP} =
     mapreduce_impl(f, op, A, ifirst, ilast, pairwise_blocksize(f, op))
+
+# Fast path for `NTuple{N,E}(::Union{Array,Memory})` with `N >= 32`. The default
+# All32 dispatch in tuple.jl `collect`s into an intermediate `Vector` and splats;
+# for an isbits eltype matching the input, the storage is layout-identical to
+# the tuple, so a single `reinterpret` view + scalar load suffices. The body is
+# O(1) in N (length check + one load), so it does not reintroduce the per-N
+# codegen blowup the All32 cap is designed to avoid. Lives here rather than in
+# tuple.jl because `reinterpret` on arrays is not yet defined that early.
+function _totuple(T::Type{All32{E,N}}, itr::Union{Array,Memory}) where {E,N}
+    len = N + 32
+    length(itr) >= len || _totuple_err(T)
+    if isbitstype(E) && eltype(itr) === E
+        v = length(itr) == len ? itr : view(itr, 1:len)
+        return @inbounds reinterpret(T, v)[1]
+    end
+    elts = collect(E, Iterators.take(itr, len))
+    return (elts...,)
+end

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -968,13 +968,9 @@ end
 mapreduce_impl(f::F, op::OP, A::AbstractArrayOrBroadcasted, ifirst::SCartesianIndex2, ilast::SCartesianIndex2) where {F,OP} =
     mapreduce_impl(f, op, A, ifirst, ilast, pairwise_blocksize(f, op))
 
-# Fast path for `NTuple{N,E}(::Union{Array,Memory})` with `N >= 32`. The default
-# All32 dispatch in tuple.jl `collect`s into an intermediate `Vector` and splats;
-# for an isbits eltype matching the input, the storage is layout-identical to
-# the tuple, so a single `reinterpret` view + scalar load suffices. The body is
-# O(1) in N (length check + one load), so it does not reintroduce the per-N
-# codegen blowup the All32 cap is designed to avoid. Lives here rather than in
-# tuple.jl because `reinterpret` on arrays is not yet defined that early.
+# Fast path for `NTuple{N,E}(::Union{Array,Memory})` with `N >= 32`: when the
+# eltype matches and is isbits, the storage is layout-identical to the tuple,
+# so a single `reinterpret` load suffices (O(1) in N, unlike the All32 fallback).
 function _totuple(T::Type{All32{E,N}}, itr::Union{Array,Memory}) where {E,N}
     len = N + 32
     length(itr) >= len || _totuple_err(T)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -482,8 +482,7 @@ function _totuple(T::Type{All32{E,N}}, itr) where {E,N}
     (elts...,)
 end
 
-# fast path on Array/Memory lives in reinterpretarray.jl, since `reinterpret`
-# on arrays is not yet defined at this load point.
+# fast path for Array/Memory lives in reinterpretarray.jl
 
 _totuple(::Type{Tuple{Vararg{E}}}, itr, s...) where {E} = (collect(E, Iterators.rest(itr,s...))...,)
 

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -482,6 +482,9 @@ function _totuple(T::Type{All32{E,N}}, itr) where {E,N}
     (elts...,)
 end
 
+# fast path on Array/Memory lives in reinterpretarray.jl, since `reinterpret`
+# on arrays is not yet defined at this load point.
+
 _totuple(::Type{Tuple{Vararg{E}}}, itr, s...) where {E} = (collect(E, Iterators.rest(itr,s...))...,)
 
 _totuple(::Type{Tuple}, itr, s...) = (collect(Iterators.rest(itr,s...))...,)

--- a/stdlib/Random/src/MersenneTwister.jl
+++ b/stdlib/Random/src/MersenneTwister.jl
@@ -2,8 +2,8 @@
 
 ## MersenneTwister
 
-# Non-reshaped, contiguous reinterpret view, suitable for the bulk pointer-based
-# fill paths below (`pointer` forwards to the parent's storage).
+# Contiguous reinterpret view; `pointer` forwards to the parent's storage,
+# so it is safe in the bulk pointer-based fill paths below.
 const ContigReinterpretArray{T} =
     Base.NonReshapedReinterpretArray{T,N,S,<:Base.MutableDenseArrayType{S}} where {N,S}
 const BulkArray{T} = Union{Array{T}, ContigReinterpretArray{T}}

--- a/stdlib/Random/src/MersenneTwister.jl
+++ b/stdlib/Random/src/MersenneTwister.jl
@@ -2,6 +2,12 @@
 
 ## MersenneTwister
 
+# Non-reshaped, contiguous reinterpret view, suitable for the bulk pointer-based
+# fill paths below (`pointer` forwards to the parent's storage).
+const ContigReinterpretArray{T} =
+    Base.NonReshapedReinterpretArray{T,N,S,<:Base.MutableDenseArrayType{S}} where {N,S}
+const BulkArray{T} = Union{Array{T}, ContigReinterpretArray{T}}
+
 const MT_CACHE_F = 501 << 1 # number of Float64 in the cache
 const MT_CACHE_I = 501 << 4 # number of bytes in the UInt128 cache
 
@@ -374,7 +380,7 @@ function rand!(r::MersenneTwister, A::UnsafeView{Float64},
 end
 
 # fills up A reinterpreted as an array of Float64 with n64 values
-function _rand!(r::MersenneTwister, A::Array{T}, n64::Int, I::FloatInterval_64) where T
+function _rand!(r::MersenneTwister, A::BulkArray{T}, n64::Int, I::FloatInterval_64) where T
     # n64 is the length in terms of `Float64` of the target
     @assert sizeof(Float64)*n64 <= sizeof(T)*length(A) && isbitstype(T)
     GC.@preserve A rand!(r, UnsafeView{Float64}(pointer(A), n64), SamplerTrivial(I))
@@ -383,7 +389,7 @@ end
 
 ##### Array: Float64, Float16, Float32
 
-rand!(r::MersenneTwister, A::Array{Float64}, I::SamplerTrivial{<:FloatInterval_64}) =
+rand!(r::MersenneTwister, A::BulkArray{Float64}, I::SamplerTrivial{<:FloatInterval_64}) =
     _rand!(r, A, length(A), I[])
 
 mask128(u::UInt128, ::Type{Float16}) =
@@ -393,7 +399,7 @@ mask128(u::UInt128, ::Type{Float32}) =
     (u & 0x007fffff007fffff007fffff007fffff) | 0x3f8000003f8000003f8000003f800000
 
 for T in (Float16, Float32)
-    @eval function rand!(r::MersenneTwister, A::Array{$T}, ::SamplerTrivial{CloseOpen12{$T}})
+    @eval function rand!(r::MersenneTwister, A::BulkArray{$T}, ::SamplerTrivial{CloseOpen12{$T}})
         n = length(A)
         n128 = n * sizeof($T) ÷ 16
         _rand!(r, A, 2*n128, CloseOpen12())
@@ -421,7 +427,7 @@ for T in (Float16, Float32)
         A
     end
 
-    @eval function rand!(r::MersenneTwister, A::Array{$T}, ::SamplerTrivial{CloseOpen01{$T}})
+    @eval function rand!(r::MersenneTwister, A::BulkArray{$T}, ::SamplerTrivial{CloseOpen01{$T}})
         rand!(r, A, CloseOpen12($T))
         I32 = one(Float32)
         for i in eachindex(A)
@@ -459,7 +465,7 @@ function rand!(r::MersenneTwister, A::UnsafeView{UInt128}, ::SamplerType{UInt128
 end
 
 for T in BitInteger_types
-    @eval function rand!(r::MersenneTwister, A::Array{$T}, sp::SamplerType{$T})
+    @eval function rand!(r::MersenneTwister, A::BulkArray{$T}, sp::SamplerType{$T})
         GC.@preserve A rand!(r, UnsafeView(pointer(A), length(A)), sp)
         A
     end

--- a/stdlib/Random/src/XoshiroSimd.jl
+++ b/stdlib/Random/src/XoshiroSimd.jl
@@ -292,7 +292,8 @@ end
     return i
 end
 
-const MutableDenseArray = Union{Base.MutableDenseArrayType{T}, UnsafeView{T}} where {T}
+const MutableDenseArray = Union{Base.MutableDenseArrayType{T}, UnsafeView{T},
+                                Base.NonReshapedReinterpretArray{T,N,S,<:Base.MutableDenseArrayType{S}} where {N,S}} where {T}
 
 function rand!(rng::Union{TaskLocalRNG, Xoshiro}, dst::MutableDenseArray{T}, ::SamplerTrivial{CloseOpen01{T}}) where {T<:Union{Float16,Float32,Float64}}
     GC.@preserve dst xoshiro_bulk(rng, convert(Ptr{UInt8}, pointer(dst)), length(dst)*sizeof(T), T, xoshiroWidth(), _bits2float)

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -159,6 +159,16 @@ rand_generic(r::AbstractRNG, ::Type{Int64})  = rand(r, UInt64) % Int64
 rand(r::AbstractRNG, ::SamplerType{Complex{T}}) where {T<:Real} =
     complex(rand(r, T), rand(r, T))
 
+# Fast path: a packed Array{Complex{T}} has the same memory layout as a
+# length-2N Array{T}, so reuse the bulk rand! for T (which is typically SIMD
+# vectorized) instead of falling back to the per-element scalar method above.
+# `reinterpret` is the supported, alias-safe view; the bulk dispatches accept
+# `NonReshapedReinterpretArray` over a contiguous parent.
+function rand!(r::AbstractRNG, A::Array{Complex{T}}, ::SamplerType{Complex{T}}) where {T<:Base.HWReal}
+    rand!(r, reinterpret(T, A))
+    return A
+end
+
 ### random characters
 
 # returns a random valid Unicode scalar value (i.e. 0 - 0xd7ff, 0xe000 - # 0x10ffff)

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -159,11 +159,8 @@ rand_generic(r::AbstractRNG, ::Type{Int64})  = rand(r, UInt64) % Int64
 rand(r::AbstractRNG, ::SamplerType{Complex{T}}) where {T<:Real} =
     complex(rand(r, T), rand(r, T))
 
-# Fast path: a packed Array{Complex{T}} has the same memory layout as a
-# length-2N Array{T}, so reuse the bulk rand! for T (which is typically SIMD
-# vectorized) instead of falling back to the per-element scalar method above.
-# `reinterpret` is the supported, alias-safe view; the bulk dispatches accept
-# `NonReshapedReinterpretArray` over a contiguous parent.
+# Reuse the bulk (SIMD) rand! for T on a reinterpreted view, instead of the
+# per-element scalar fallback above.
 function rand!(r::AbstractRNG, A::Array{Complex{T}}, ::SamplerType{Complex{T}}) where {T<:Base.HWReal}
     rand!(r, reinterpret(T, A))
     return A

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -525,6 +525,12 @@ end
     @test rand(mta,Bool) == rand(mtb,Bool)
     @test bitrand(mta,10) == bitrand(mtb,10)
 
+    # rand! fast path for Array{Complex{T}} must be reproducible across equal RNGs.
+    for T in Base.uniontypes(Base.HWReal)
+        a, b = Vector{Complex{T}}(undef, 10), Vector{Complex{T}}(undef, 10)
+        @test rand!(mta, a) == rand!(mtb, b)
+    end
+
     @test randstring(mta) == randstring(mtb)
     @test randstring(mta,10) == randstring(mtb,10)
 

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -89,6 +89,19 @@ end
     @test NTuple{20,Float64}(Iterators.countfrom(2)) === (2.,3.,4.,5.,6.,7.,8.,9.,10.,11.,12.,13.,14.,15.,16.,17.,18.,19.,20.,21.)
     @test_throws ArgumentError NTuple{20,Int}([1,2])
 
+    # long tuples (>=32 elements) constructed from indexable inputs hit a fast path
+    let v = collect(1.0:40.0)
+        @test NTuple{40,Float64}(v) === ntuple(i -> Float64(i), Val(40))
+        @test NTuple{40,Int}(v) === ntuple(i -> i, Val(40))
+        # over-long input is silently truncated to match the iterator-based fallback
+        @test NTuple{40,Float64}(collect(1.0:41.0)) === ntuple(i -> Float64(i), Val(40))
+        @test_throws ArgumentError NTuple{40,Float64}(collect(1.0:39.0))
+    end
+    let m = Memory{Float64}(undef, 40); m .= 1.0:40.0
+        @test NTuple{40,Float64}(m) === ntuple(i -> Float64(i), Val(40))
+        @test_throws ArgumentError NTuple{40,Float64}(Memory{Float64}(undef, 39))
+    end
+
     @test Tuple{Vararg{Float32}}(Float64[1,2,3]) === (1.0f0, 2.0f0, 3.0f0)
     @test Tuple{Int,Vararg{Float32}}(Float64[1,2,3]) === (1, 2.0f0, 3.0f0)
     @test Tuple{Int,Vararg{Any}}(Float64[1,2,3]) === (1, 2.0, 3.0)


### PR DESCRIPTION
I pointed Claude at [perf.julialang.org](https://perf.julialang.org/) and asked it to find opportunities to improve unusually slow benchmarks.

See [JuliaCI/julia-ci-timing@main/analysis](https://github.com/JuliaCI/julia-ci-timing/tree/main/analysis) for some of the scripts it used.

This is what it came up with:

----

Two small, BaseBenchmarks-driven perf fixes that share a theme — when the
storage of an array already has the layout you want, dispatch to the bulk
path on a `reinterpret` view instead of going through the per-element
fallback.

### `NTuple{N,E}(::Union{Array,Memory})` for `N >= 32`

The default `_totuple(::Type{All32{E,N}}, itr)` path collects into an
intermediate `Vector` and splats. The `All32` cap exists so we don't
specialize tuple construction on every `N`; this PR keeps that property
(no per-`N` codegen) by adding a single fast path for `Array`/`Memory`
inputs whose `isbits` element type matches the requested tuple element
type. In that case the storage is layout-identical to the tuple, so a
single `reinterpret` view + scalar load returns the tuple in O(1) (plus
a length check).

The fast path lives in `reinterpretarray.jl` because `reinterpret` on
arrays isn't yet defined when `tuple.jl` is loaded. Over-long inputs are
silently truncated to match the iterator-based fallback. Non-matching
eltypes / non-isbits eltypes fall through to the existing path
unchanged.

```
                                            master       this PR
NTuple{40,Float64}(::Vector{Float64})        1.36 μs      7.3 ns
NTuple{150,Float64}(::Vector{Float64})       4.92 μs     17.0 ns
```

(0 allocations on the fast path, vs. `N+~3` allocations and `~33 N` B
on master.)

### Bulk `rand!(::Array{Complex{T}})` for `T <: HWReal`

`rand!(::AbstractRNG, ::Array{Complex{T}})` previously fell through to
the generic `AbstractArray` path — two scalar `rand` calls per element.
A packed `Array{Complex{T}}` has the same memory layout as a length-`2N`
`Array{T}`, so reinterpreting and dispatching to the bulk `rand!` for
`T` (SIMD-vectorized for `HWReal` on Xoshiro/TaskLocalRNG, and pointer-
based for MersenneTwister) is correct and substantially faster.

Per @vtjnash's feedback in earlier review, this avoids
`unsafe_wrap`/`unsafe_load` entirely. Instead, the existing bulk
dispatches in `MersenneTwister` and `XoshiroSimd` are widened to also
accept a `NonReshapedReinterpretArray` over a `MutableDenseArrayType`
parent. `pointer`/`unsafe_convert` are already defined for
`ReinterpretArray` and forward to the parent's storage, so the existing
`GC.@preserve A ... pointer(A) ...` machinery keeps working unchanged.

Speedups on a length-1000 `Vector{Complex{T}}`, default RNG:

```
                  master       this PR
Complex{Float16}   3.5 μs       1.5 μs    2.4×
Complex{Float32}   3.4 μs       2.2 μs    1.5×
Complex{Float64}   3.1 μs       3.1 μs    ≈
Complex{Int8}      3.1 μs       539 ns    5.7×
Complex{Int16}     3.1 μs       1.1 μs    3.0×
Complex{Int32}     3.1 μs       1.9 μs    1.7×
Complex{Int64}     4.6 μs       4.2 μs    1.1×
Complex{UInt8}     3.1 μs       532 ns    5.9×
Complex{UInt16}    3.1 μs       1.0 μs    2.9×
Complex{UInt32}    3.0 μs       1.9 μs    1.6×
Complex{UInt64}    4.7 μs       4.2 μs    1.1×
```

All variants are 0-allocation. `Complex{Float64}` and the 64-bit integer
variants were already close to the bulk path's throughput on master and
see only a small win.

A reproducibility test was added so equal MT seeds keep producing equal
sequences for `Vector{Complex{T}}`.

---

Disclosure: written with the assistance of generative AI (GitHub
Copilot / Claude).