### PR TITLE
Serialization: much faster `(de)serialize_cycle` by refactoring the lookup tables

### DIFF
--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -165,8 +165,8 @@ _getcycle(s::Serializer, @nospecialize(x)) = get(s.cycle_table, IdKey(x), -1)
 _setcycle!(s::AbstractSerializer, @nospecialize(x), v::Int) = (s.table[x] = v; nothing)
 _setcycle!(s::Serializer, @nospecialize(x), v::Int) = (s.cycle_table[IdKey(x)] = v; nothing)
 
-setbackref!(s::AbstractSerializer, slot::Int, @nospecialize(x)) = (s.table[slot] = x; nothing)
-function setbackref!(s::Serializer, slot::Int, @nospecialize(x))
+_setbackref!(s::AbstractSerializer, slot::Int, @nospecialize(x)) = (s.table[slot] = x; nothing)
+function _setbackref!(s::Serializer, slot::Int, @nospecialize(x))
     bt = s.backref_table
     i = slot + 1
     i > length(bt) && resize!(bt, max(i, 2 * length(bt) + 1))
@@ -192,11 +192,11 @@ function _getbackref(s::Serializer, id::Int)
     @inbounds return bt[i]
 end
 
-sizehint_cycle!(s::AbstractSerializer, n::Integer) = (sizehint!(s.table, n); nothing)
-sizehint_cycle!(s::Serializer, n::Integer) = (sizehint!(s.cycle_table, n); nothing)
+_sizehint_cycle!(s::AbstractSerializer, n::Integer) = (sizehint!(s.table, n); nothing)
+_sizehint_cycle!(s::Serializer, n::Integer) = (sizehint!(s.cycle_table, n); nothing)
 
-sizehint_backref!(s::AbstractSerializer, n::Integer) = (sizehint!(s.table, n); nothing)
-sizehint_backref!(s::Serializer, n::Integer) = (sizehint!(s.backref_table, n; shrink=false); nothing)
+_sizehint_backref!(s::AbstractSerializer, n::Integer) = (sizehint!(s.table, n); nothing)
+_sizehint_backref!(s::Serializer, n::Integer) = (sizehint!(s.backref_table, n; shrink=false); nothing)
 
 function _emit_backref(io::IO, offs::Int)
     if offs <= typemax(UInt16)
@@ -315,7 +315,7 @@ function serialize_array_data(s::IO, a)
 end
 
 function _serialize_non_bits_elements!(s::AbstractSerializer, a)
-    sizehint_cycle!(s, div(length(a), 4))  # prepare for lots of pointers
+    _sizehint_cycle!(s, div(length(a), 4))  # prepare for lots of pointers
     @inbounds for i in eachindex(a)
         if isassigned(a, i)
             serialize(s, a[i])
@@ -917,7 +917,7 @@ end
 
 function deserialize_cycle(s::AbstractSerializer, @nospecialize(x))
     slot = pop!(s.pending_refs)
-    setbackref!(s, slot, x)
+    _setbackref!(s, slot, x)
     nothing
 end
 
@@ -925,9 +925,9 @@ end
 #     slot = s.counter; s.counter += 1
 #     push!(s.pending_refs, slot)
 #     slot = pop!(s.pending_refs)
-#     setbackref!(s, slot, x)
+#     _setbackref!(s, slot, x)
 function resolve_ref_immediately(s::AbstractSerializer, @nospecialize(x))
-    setbackref!(s, s.counter, x)
+    _setbackref!(s, s.counter, x)
     s.counter += 1
     nothing
 end
@@ -972,7 +972,7 @@ function handle_deserialize(s::AbstractSerializer, b::Int32)
     elseif b == SHARED_REF_TAG
         slot = s.counter; s.counter += 1
         obj = deserialize(s)
-        setbackref!(s, slot, obj)
+        _setbackref!(s, slot, obj)
         return obj
     elseif b == SYMBOL_TAG
         return deserialize_symbol(s, Int(read(s.io, UInt8)::UInt8))
@@ -1416,7 +1416,7 @@ function deserialize_array(s::AbstractSerializer)
     if isa(d1, Int32) || isa(d1, Int64)
         if elty !== Bool && isbitstype(elty)
             a = Vector{elty}(undef, d1)
-            setbackref!(s, slot, a)
+            _setbackref!(s, slot, a)
             return read!(s.io, a)
         end
         dims = (Int(d1),)
@@ -1443,12 +1443,12 @@ function deserialize_array(s::AbstractSerializer)
         else
             A = read!(s.io, Array{elty}(undef, dims))
         end
-        setbackref!(s, slot, A)
+        _setbackref!(s, slot, A)
         return A
     end
     A = Array{elty, length(dims)}(undef, dims)
-    setbackref!(s, slot, A)
-    sizehint_backref!(s, s.counter + div(length(A)::Int,4))
+    _setbackref!(s, slot, A)
+    _sizehint_backref!(s, s.counter + div(length(A)::Int,4))
     deserialize_fillarray!(A, s)
     return A
 end
@@ -1484,12 +1484,12 @@ function deserialize(s::AbstractSerializer, X::Type{Memory{T}} where T)
         else
             A = read!(s.io, A)::X
         end
-        setbackref!(s, slot, A)
+        _setbackref!(s, slot, A)
         return A
     end
     A = X(undef, n)
-    setbackref!(s, slot, A)
-    sizehint_backref!(s, s.counter + div(n, 4))
+    _setbackref!(s, slot, A)
+    _sizehint_backref!(s, s.counter + div(n, 4))
     deserialize_fillarray!(A, s)
     return A
 end
@@ -1630,7 +1630,7 @@ function deserialize_datatype(s::AbstractSerializer, full::Bool)
             end
         end
     end
-    setbackref!(s, slot, t)
+    _setbackref!(s, slot, t)
     return t
 end
 

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -17,14 +17,20 @@ export serialize, deserialize, AbstractSerializer, Serializer
 
 abstract type AbstractSerializer end
 
+# Dict is generally a much better dictionary than IdDict, but we want objectid comparison
+struct IdKey val::Any end
+Base.hash(k::IdKey, h::UInt) = hash(objectid(k.val), h)
+Base.isequal(a::IdKey, b::IdKey) = a.val === b.val
+
 mutable struct Serializer{I<:IO} <: AbstractSerializer
-    io::I
+    const io::I
     counter::Int
-    table::IdDict{Any,Any}
-    pending_refs::Vector{Int}
-    known_object_data::Dict{UInt64,Any}
+    const cycle_table::Dict{IdKey,Int}
+    const backref_table::Vector{Any}
+    const pending_refs::Vector{Int}
+    const known_object_data::Dict{UInt64,Any}
     version::Int
-    Serializer{I}(io::I) where I<:IO = new(io, 0, IdDict(), Int[], Dict{UInt64,Any}(), ser_version)
+    Serializer{I}(io::I) where I<:IO = new(io, 0, Dict{IdKey,Int}(), Any[], Int[], Dict{UInt64,Any}(), ser_version)
 end
 
 Serializer(io::IO) = Serializer{typeof(io)}(io)
@@ -154,22 +160,65 @@ function write_as_tag(s::IO, tag)
 end
 
 # cycle handling
+_getcycle(s::AbstractSerializer, @nospecialize(x)) = get(s.table, x, -1)::Int
+_getcycle(s::Serializer, @nospecialize(x)) = get(s.cycle_table, IdKey(x), -1)
+_setcycle!(s::AbstractSerializer, @nospecialize(x), v::Int) = (s.table[x] = v; nothing)
+_setcycle!(s::Serializer, @nospecialize(x), v::Int) = (s.cycle_table[IdKey(x)] = v; nothing)
+
+setbackref!(s::AbstractSerializer, slot::Int, @nospecialize(x)) = (s.table[slot] = x; nothing)
+function setbackref!(s::Serializer, slot::Int, @nospecialize(x))
+    bt = s.backref_table
+    i = slot + 1
+    i > length(bt) && resize!(bt, max(i, 2 * length(bt) + 1))
+    @inbounds bt[i] = x
+    nothing
+end
+
+@noinline function __getbackref_error(id::Int)
+    error("""Inconsistent Serializer state when deserializing.
+            Attempt to access internal table with key $id failed.
+
+            This might occur if the Serializer contexts when serializing and deserializing are inconsistent.
+            In particular, if multiple serialize calls use the same Serializer object then
+            the corresponding deserialize calls should also use the same Serializer object.
+        """)
+end
+
+_getbackref(s::AbstractSerializer, id::Int) = get(() -> __getbackref_error(id), s.table, id)
+function _getbackref(s::Serializer, id::Int)
+    bt = s.backref_table
+    i = id + 1
+    (id < 0 || i > length(bt) || !isassigned(bt, i)) && __getbackref_error(id)
+    @inbounds return bt[i]
+end
+
+sizehint_cycle!(s::AbstractSerializer, n::Integer) = (sizehint!(s.table, n); nothing)
+sizehint_cycle!(s::Serializer, n::Integer) = (sizehint!(s.cycle_table, n); nothing)
+
+sizehint_backref!(s::AbstractSerializer, n::Integer) = (sizehint!(s.table, n); nothing)
+sizehint_backref!(s::Serializer, n::Integer) = (sizehint!(s.backref_table, n; shrink=false); nothing)
+
+function _emit_backref(io::IO, offs::Int)
+    if offs <= typemax(UInt16)
+        writetag(io, SHORTBACKREF_TAG)
+        write(io, UInt16(offs))
+    elseif offs <= typemax(Int32)
+        writetag(io, BACKREF_TAG)
+        write(io, Int32(offs))
+    else
+        writetag(io, LONGBACKREF_TAG)
+        write(io, Int64(offs))
+    end
+    nothing
+end
+
 function serialize_cycle(s::AbstractSerializer, @nospecialize(x))
-    offs = get(s.table, x, -1)::Int
+    offs = _getcycle(s, x)
     if offs != -1
-        if offs <= typemax(UInt16)
-            writetag(s.io, SHORTBACKREF_TAG)
-            write(s.io, UInt16(offs))
-        elseif offs <= typemax(Int32)
-            writetag(s.io, BACKREF_TAG)
-            write(s.io, Int32(offs))
-        else
-            writetag(s.io, LONGBACKREF_TAG)
-            write(s.io, Int64(offs))
-        end
+        _emit_backref(s.io, offs)
         return true
     end
-    s.table[x] = s.counter
+    _setcycle!(s, x, s.counter)
     s.counter += 1
     return false
 end
@@ -183,6 +232,13 @@ end
 function reset_state(s::AbstractSerializer)
     s.counter = 0
     empty!(s.table)
+    empty!(s.pending_refs)
+    s
+end
+function reset_state(s::Serializer)
+    s.counter = 0
+    empty!(s.cycle_table)
+    empty!(s.backref_table)
     empty!(s.pending_refs)
     s
 end
@@ -258,6 +314,17 @@ function serialize_array_data(s::IO, a)
     end
 end
 
+function _serialize_non_bits_elements!(s::AbstractSerializer, a)
+    sizehint_cycle!(s, div(length(a), 4))  # prepare for lots of pointers
+    @inbounds for i in eachindex(a)
+        if isassigned(a, i)
+            serialize(s, a[i])
+        else
+            writetag(s.io, UNDEFREF_TAG)
+        end
+    end
+end
+
 function serialize(s::AbstractSerializer, a::Array)
     serialize_cycle(s, a) && return
     elty = eltype(a)
@@ -273,14 +340,7 @@ function serialize(s::AbstractSerializer, a::Array)
     if isbitstype(elty)
         serialize_array_data(s.io, a)
     else
-        sizehint!(s.table, div(length(a),4))  # prepare for lots of pointers
-        @inbounds for i in eachindex(a)
-            if isassigned(a, i)
-                serialize(s, a[i])
-            else
-                writetag(s.io, UNDEFREF_TAG)
-            end
-        end
+        _serialize_non_bits_elements!(s, a)
     end
 end
 
@@ -299,14 +359,7 @@ function serialize(s::AbstractSerializer, m::Memory)
     if isbitstype(elty)
         serialize_array_data(s.io, m)
     else
-        sizehint!(s.table, div(length(m),4))  # prepare for lots of pointers
-        @inbounds for i in eachindex(m)
-            if isassigned(m, i)
-                serialize(s, m[i])
-            else
-                writetag(s.io, UNDEFREF_TAG)
-            end
-        end
+        _serialize_non_bits_elements!(s, m)
     end
 end
 
@@ -864,7 +917,7 @@ end
 
 function deserialize_cycle(s::AbstractSerializer, @nospecialize(x))
     slot = pop!(s.pending_refs)
-    s.table[slot] = x
+    setbackref!(s, slot, x)
     nothing
 end
 
@@ -872,24 +925,11 @@ end
 #     slot = s.counter; s.counter += 1
 #     push!(s.pending_refs, slot)
 #     slot = pop!(s.pending_refs)
-#     s.table[slot] = x
+#     setbackref!(s, slot, x)
 function resolve_ref_immediately(s::AbstractSerializer, @nospecialize(x))
-    s.table[s.counter] = x
+    setbackref!(s, s.counter, x)
     s.counter += 1
     nothing
-end
-
-function gettable(s::AbstractSerializer, id::Int)
-    get(s.table, id) do
-        errmsg = """Inconsistent Serializer state when deserializing.
-            Attempt to access internal table with key $id failed.
-
-            This might occur if the Serializer contexts when serializing and deserializing are inconsistent.
-            In particular, if multiple serialize calls use the same Serializer object then
-            the corresponding deserialize calls should also use the same Serializer object.
-        """
-        error(errmsg)
-    end
 end
 
 # deserialize_ is an internal function to dispatch on the tag
@@ -905,10 +945,10 @@ function handle_deserialize(s::AbstractSerializer, b::Int32)
         return deserialize_tuple(s, Int(read(s.io, UInt8)::UInt8))
     elseif b == SHORTBACKREF_TAG
         id = read(s.io, UInt16)::UInt16
-        return gettable(s, Int(id))
+        return _getbackref(s, Int(id))
     elseif b == BACKREF_TAG
         id = read(s.io, Int32)::Int32
-        return gettable(s, Int(id))
+        return _getbackref(s, Int(id))
     elseif b == ARRAY_TAG
         return deserialize_array(s)
     elseif b == DATATYPE_TAG
@@ -932,7 +972,7 @@ function handle_deserialize(s::AbstractSerializer, b::Int32)
     elseif b == SHARED_REF_TAG
         slot = s.counter; s.counter += 1
         obj = deserialize(s)
-        s.table[slot] = obj
+        setbackref!(s, slot, obj)
         return obj
     elseif b == SYMBOL_TAG
         return deserialize_symbol(s, Int(read(s.io, UInt8)::UInt8))
@@ -960,7 +1000,7 @@ function handle_deserialize(s::AbstractSerializer, b::Int32)
         return deserialize_expr(s, Int(read(s.io, Int32)::Int32))
     elseif b == LONGBACKREF_TAG
         id = read(s.io, Int64)::Int64
-        return gettable(s, Int(id))
+        return _getbackref(s, Int(id))
     elseif b == LONGSYMBOL_TAG
         return deserialize_symbol(s, Int(read(s.io, Int32)::Int32))
     elseif b == HEADER_TAG
@@ -1376,7 +1416,7 @@ function deserialize_array(s::AbstractSerializer)
     if isa(d1, Int32) || isa(d1, Int64)
         if elty !== Bool && isbitstype(elty)
             a = Vector{elty}(undef, d1)
-            s.table[slot] = a
+            setbackref!(s, slot, a)
             return read!(s.io, a)
         end
         dims = (Int(d1),)
@@ -1403,12 +1443,12 @@ function deserialize_array(s::AbstractSerializer)
         else
             A = read!(s.io, Array{elty}(undef, dims))
         end
-        s.table[slot] = A
+        setbackref!(s, slot, A)
         return A
     end
     A = Array{elty, length(dims)}(undef, dims)
-    s.table[slot] = A
-    sizehint!(s.table, s.counter + div(length(A)::Int,4))
+    setbackref!(s, slot, A)
+    sizehint_backref!(s, s.counter + div(length(A)::Int,4))
     deserialize_fillarray!(A, s)
     return A
 end
@@ -1444,12 +1484,12 @@ function deserialize(s::AbstractSerializer, X::Type{Memory{T}} where T)
         else
             A = read!(s.io, A)::X
         end
-        s.table[slot] = A
+        setbackref!(s, slot, A)
         return A
     end
     A = X(undef, n)
-    s.table[slot] = A
-    sizehint!(s.table, s.counter + div(n, 4))
+    setbackref!(s, slot, A)
+    sizehint_backref!(s, s.counter + div(n, 4))
     deserialize_fillarray!(A, s)
     return A
 end
@@ -1590,7 +1630,7 @@ function deserialize_datatype(s::AbstractSerializer, full::Bool)
             end
         end
     end
-    s.table[slot] = t
+    setbackref!(s, slot, t)
     return t
 end
 


### PR DESCRIPTION
closes https://github.com/JuliaLang/julia/issues/44175

`serialize` contains an optimization to deduplicate identical objects both for performance benefit and to retain aliasing relationships during round trips.

conceptually, it does this by: for each value that is eligible for `serialize_cycle` (in practice, this mostly resolves to `ismutable`), maintain `counter` for the index at which we encountered that object, and save the `objectid` for future lookups. Then, if we see the same `objectid` later, serialize a `BACKREF` to the appropriate `counter`.

On the deser side, when we see a `BACKREF`, access the object at the index of the associated `counter` rather than making a new object.

however, it uses an `IdDict` for both purposes. this PR squeezes out a lot more performance by using a `Dict` for the serialization lookup and a `Vector` for the deser.

questions for the reviewers mostly concern compatibility. this does change the fields of `Serializer` which is (unfortunately) a public type. but I'm not sure if the fields themselves are considered public? I have headed off in advance impacts to, e.g. [`Distributed.ClusterSerializer`](https://github.com/JuliaLang/Distributed.jl/blob/fde987fbb05c65bb6bd183396137383931107059/src/clusterserialize.jl#L10-L14) which makes assumptions about the way that `Serialization.serialize` makes use of a `.table` field on `AbstractSerializer`, by factoring out these field accesses into getter/setter functions and then specializing on `Serializer`. Is this an appropriate compromise? or should we just patch `Distributed` to not rely on this assumption? or is the change to `Serialization` considered wholesale breaking. there was a similar discussion in https://github.com/JuliaLang/julia/pull/43554

here are performance numbers on a few workloads:

on the motivating MWE from https://github.com/JuliaLang/julia/issues/44175:
<details>
<summary> setup</summary>

```julia
mutable struct MinimalNode
    childvalues::Union{NTuple{4, Int8}, NTuple{3, Int8}, NTuple{2, Int8}, NTuple{1, Int8}, Tuple{}};
    childnodes::Union{NTuple{4, MinimalNode}, NTuple{3, MinimalNode}, NTuple{2, MinimalNode}, NTuple{1, MinimalNode}, Tuple{}};
end

function addbranches!(mn::MinimalNode, aleft::Int64, bleft::Int64, parity::Int64, depth = 0)

    (depth == 12) && (return nothing);

    if parity == 1
        (aleft <= 1) && (return nothing);
        mn.childvalues = Tuple(1:aleft);
        mn.childnodes = Tuple([MinimalNode((), ()) for ii in 1:aleft]);
        aleft -= 1;
    else
        (bleft <= 1) && (return nothing);
        mn.childvalues = Tuple(1:bleft);
        mn.childnodes = Tuple([MinimalNode((), ()) for ii in 1:bleft]);
        bleft -= 1;
    end

    addbranches!.(mn.childnodes, aleft, bleft, 3-parity, depth + 1);
    
end

function buildfaketree()
    root = MinimalNode((), ());
    addbranches!(root, 4, 4, 1, 0);
    return root;
end


using Serialization;
MN = [buildfaketree() for ii in 1:10000];
@time serialize("test.jls", MN);
35 seconds
```
</details>

PR:
```julia
julia> @time serialize("test.jls", MN);
  6.419340 seconds (15.78 M allocations: 784.602 MiB, 17.18% gc time)

julia> @time deserialize("test.jls");
  4.382877 seconds (20.79 M allocations: 817.876 MiB, 32.13% gc time)
```

master:
```julia
julia> @time serialize("test_master.jls", MN);
 17.084042 seconds (26.55 M allocations: 917.083 MiB, 5.38% gc time)

julia> @time deserialize("test_master.jls");
 20.479949 seconds (31.56 M allocations: 1.204 GiB, 15.45% gc time)
```

but we also improve something as simple as `Vector{String}`

setup:
```julia
julia> using Random

julia> v = map((_)->randstring(10), 1:1000000);
```

PR:
```julia
julia> @time serialize("string.jls", v);
  0.240658 seconds (37 allocations: 59.501 MiB, 9.13% gc time)

julia> @time deserialize("string.jls");
  0.084324 seconds (1.00 M allocations: 64.112 MiB)
```

master:
```julia
julia> @time serialize("string.jls", v);
  0.592193 seconds (999.51 k allocations: 43.252 MiB, 11.42% gc time)

julia> @time deserialize("string.jls");
  0.371651 seconds (2.00 M allocations: 81.410 MiB, 15.02% gc time)
```

assisted as always by Opus 4.7