### PR TITLE
codegen: share one UndefRefError throw block per function

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1734,6 +1734,37 @@ static void raise_exception(jl_codectx_t &ctx, Value *exc,
     ctx.builder.SetInsertPoint(contBB);
 }
 
+// Lazily create (per-function) a single block that throws UndefRefError, so
+// repeated array/field undef checks share one throw site instead of emitting
+// an identical fail block at every call site.
+static BasicBlock *get_undefref_throw_block(jl_codectx_t &ctx)
+{
+    if (ctx.undefref_throw_block)
+        return ctx.undefref_throw_block;
+    auto savedBB = ctx.builder.GetInsertBlock();
+    auto savedIP = ctx.builder.GetInsertPoint();
+    BasicBlock *failBB = BasicBlock::Create(ctx.builder.getContext(), "undefref_throw", ctx.f);
+    ctx.builder.SetInsertPoint(failBB);
+    ctx.builder.CreateCall(prepare_call(jlthrow_func),
+        { mark_callee_rooted(ctx, literal_pointer_val(ctx, jl_undefref_exception)) });
+    ctx.builder.CreateUnreachable();
+    if (savedBB)
+        ctx.builder.SetInsertPoint(savedBB, savedIP);
+    ctx.undefref_throw_block = failBB;
+    return failBB;
+}
+
+// Emit a conditional branch to the shared UndefRefError throw block.
+// `notnull` should be true when the value is defined (non-null).
+static void emit_undefref_check(jl_codectx_t &ctx, Value *notnull)
+{
+    ++EmittedConditionalExceptions;
+    BasicBlock *failBB = get_undefref_throw_block(ctx);
+    BasicBlock *passBB = BasicBlock::Create(ctx.builder.getContext(), "pass", ctx.f);
+    ctx.builder.CreateCondBr(notnull, passBB, failBB);
+    ctx.builder.SetInsertPoint(passBB);
+}
+
 // DO NOT PASS IN A CONST CONDITION!
 static void raise_exception_unless(jl_codectx_t &ctx, Value *cond, Value *exc)
 {
@@ -1795,8 +1826,7 @@ static void null_pointer_check(jl_codectx_t &ctx, Value *v, Value **nullcheck)
         *nullcheck = v;
         return;
     }
-    raise_exception_unless(ctx, null_pointer_cmp(ctx, v),
-            literal_pointer_val(ctx, jl_undefref_exception));
+    emit_undefref_check(ctx, null_pointer_cmp(ctx, v));
 }
 
 
@@ -1806,7 +1836,7 @@ static void null_load_check(jl_codectx_t &ctx, Value *v, jl_module_t *scope, jl_
     if (name && scope)
         undef_var_error_ifnot(ctx, notnull, name, (jl_value_t*)scope);
     else
-        raise_exception_unless(ctx, notnull, literal_pointer_val(ctx, jl_undefref_exception));
+        emit_undefref_check(ctx, notnull);
 }
 
 // ifnot == nullptr && return func()
@@ -3390,7 +3420,10 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
         order = isatomic ? jl_memory_order_unordered : jl_memory_order_notatomic;
     }
     if (jfty == jl_bottom_type) {
-        raise_exception(ctx, literal_pointer_val(ctx, jl_undefref_exception));
+        ++EmittedExceptions;
+        ctx.builder.CreateBr(get_undefref_throw_block(ctx));
+        BasicBlock *contBB = BasicBlock::Create(ctx.builder.getContext(), "after_throw", ctx.f);
+        ctx.builder.SetInsertPoint(contBB);
         return jl_cgval_t(); // unreachable
     }
     if (type_is_ghost(julia_type_to_llvm(ctx, jfty)))

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -644,7 +644,7 @@ static AttributeList get_func_attrs(LLVMContext &C)
 static AttributeList get_attrs_noreturn(LLVMContext &C)
 {
     return AttributeList::get(C,
-                Attributes(C, {Attribute::NoReturn}),
+                Attributes(C, {Attribute::NoReturn, Attribute::Cold}),
                 AttributeSet(),
                 {});
 }
@@ -2089,6 +2089,7 @@ public:
     Value *pgcstack = NULL;
     Instruction *topalloca = NULL;
     Value *world_age_at_entry = NULL;
+    llvm::BasicBlock *undefref_throw_block = NULL;
 
     bool external_linkage = false;
     const jl_cgparams_t *params = NULL;
@@ -6643,8 +6644,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaidx_
         jl_sym_t *var = (jl_sym_t*)args[0];
         Value *cond = emit_unbox(ctx, getInt1Ty(ctx.builder.getContext()), update_julia_type(ctx, emit_expr(ctx, args[1]), (jl_value_t*)jl_bool_type));
         if (var == jl_getfield_undefref_sym) {
-            raise_exception_unless(ctx, cond,
-                literal_pointer_val(ctx, jl_undefref_exception));
+            emit_undefref_check(ctx, cond);
         }
         else {
             undef_var_error_ifnot(ctx, cond, var, (jl_value_t*)jl_local_sym);


### PR DESCRIPTION
## Summary

`null_pointer_check`, `null_load_check`, the unconditional `jl_bottom_type` field-load path, and the `jl_throw_undef_if_not_sym` lowering each synthesised their own fail block ending in `call jl_throw(jl_undefref_exception); unreachable`. Repeated array indexing therefore produced many identical fail blocks that neither SimplifyCFG nor machine-level branch folding merged, so the duplication leaked all the way into native code.

This PR lazily emits a single per-function throw block (cached on `jl_codectx_t`) and routes every undefref check there. It also tags the `noreturn` codegen helpers (`jl_throw`, `jl_error`, the `jl_bounds_error_*` family, `jl_type_error`, `jl_undefined_var_error`, `jl_has_no_field_error`, `jl_atomic_error`, `jl_argument_error`) with `Cold` so the optimiser and register allocator know these are slow paths.

### Before / after

For `foo(x) = (first(x), last(x))` on `Vector{Vector{Any}}` the LLVM IR previously contained two separate `fail`/`fail17` blocks; it now contains a single `undefref_throw` block with both null comparisons branching to it. At the machine level the two `bl <throw>` stubs collapse to one.

### Test plan

- [x] `make -C src analyze-codegen` clean
- [x] `make fix-whitespace` clean
- [x] Runtime sanity: normal `Array{Vector{Int}}` access, `UndefRefError` from `first`/`last` on `Vector{T}(undef, n)`, `BoundsError` on empty arrays, struct field undef, divide-by-zero — all throw the expected exceptions.

This pull request was written with the assistance of Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)