### PR TITLE
subtype: use static `var_occurs_invariant` in env_unchanged check

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -90,6 +90,11 @@ typedef struct jl_varbinding_t {
                           // would not be substituted by going to a more concrete LHS
                           // (they live inside Type{...}/etc value positions), so the
                           // binding is leaky regardless of what `constrained` says.
+    int8_t body_occurs_inv; // cached `var_occurs_invariant(u->body, u->var)` — the
+                            // static "occurs invariantly" check used by the diagonal
+                            // rule (since #34272). Unlike the dynamic `occurs_inv`
+                            // counter, this is a pure structural property of the
+                            // UnionAll body and does not change during traversal.
     int16_t depth0;         // # of invariant constructors nested around the UnionAll type for this var
     // array of typevars that our bounds depend on, whose UnionAlls need to be
     // moved outside ours.
@@ -719,8 +724,8 @@ static int env_unchanged(jl_stenv_t *e, jl_savedenv_t *se) JL_NOTSAFEPOINT
         if (v->existential) {
             if (v->lb != roots[i] || v->ub != roots[i + 1])
                 return 0; // check if bounds changed
-            if (is_leaf_typevar(v->var) && v->occurs_inv == 0 && v->occurs_cov > 1 && se->buf[j] <= 1)
-                return 0; // check if a variable became digonal from non-diagonal
+            if (is_leaf_typevar(v->var) && v->body_occurs_inv == 0 && v->occurs_cov > 1 && se->buf[j] <= 1)
+                return 0; // check if a variable became diagonal from non-diagonal
         }
         i += 3; // lb, ub, innervars
         j += 3;
@@ -1130,7 +1135,8 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
 {
     u = unalias_unionall(u, e);
     jl_value_t *new_tvar = NULL;
-    jl_varbinding_t vb = { u->var, u->var->lb, u->var->ub, R, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    int body_occurs_inv = var_occurs_invariant(u->body, u->var);
+    jl_varbinding_t vb = { u->var, u->var->lb, u->var->ub, R, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, body_occurs_inv,
                            e->invdepth, NULL, e->vars };
     JL_GC_PUSH5(&u, &vb.lb, &vb.ub, &vb.innervars, &new_tvar);
     e->vars = &vb;
@@ -1151,7 +1157,7 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
     //  ( Tuple{Int, Int}    <: Tuple{T, T} where T) but
     // !( Tuple{Int, String} <: Tuple{T, T} where T)
     // Then check concreteness by checking that the lower bound is not an abstract type.
-    int diagonal = vb.occurs_cov > 1 && !var_occurs_invariant(u->body, u->var);
+    int diagonal = vb.occurs_cov > 1 && !vb.body_occurs_inv;
     if (ans && (vb.concrete || (diagonal && is_leaf_typevar(u->var)))) {
         if (vb.concrete && !diagonal && !is_leaf_bound(vb.ub)) {
             // a non-diagonal var can only be a subtype of a diagonal var if its
@@ -3663,7 +3669,7 @@ static jl_value_t *intersect_unionall_(jl_value_t *t, jl_unionall_t *u, jl_stenv
         res = intersect(u->body, t, e, param);
     }
     vb->concrete |= (vb->occurs_cov > 1 && is_leaf_typevar(u->var) &&
-                     !var_occurs_invariant(u->body, u->var));
+                     !vb->body_occurs_inv);
 
     // handle the "diagonal dispatch" rule, which says that a type var occurring more
     // than once, and only in covariant position, is constrained to concrete types. E.g.
@@ -3749,11 +3755,12 @@ static jl_value_t *intersect_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_
 {
     jl_value_t *res = NULL;
     jl_savedenv_t se;
-    jl_varbinding_t vb = { u->var, u->var->lb, u->var->ub, R, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    int body_occurs_inv = var_occurs_invariant(u->body, u->var);
+    jl_varbinding_t vb = { u->var, u->var->lb, u->var->ub, R, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, body_occurs_inv,
                            e->invdepth, NULL, e->vars };
     JL_GC_PUSH4(&res, &vb.lb, &vb.ub, &vb.innervars);
     save_env(e, &se, 1);
-    int noinv = !var_occurs_invariant(u->body, u->var);
+    int noinv = !body_occurs_inv;
     if (is_leaf_typevar(u->var) && noinv && always_occurs_cov(u->body, u->var, param))
         vb.constraintkind = 1;
     res = intersect_unionall_(t, u, e, R, param, &vb);
@@ -5175,7 +5182,7 @@ static jl_value_t *_widen_diagonal(jl_value_t *t, jl_varbinding_t *troot) {
 
 static jl_value_t *widen_diagonal(jl_value_t *t, jl_unionall_t *u, jl_varbinding_t *troot)
 {
-    jl_varbinding_t vb = { u->var, NULL, NULL, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, NULL, troot };
+    jl_varbinding_t vb = { u->var, NULL, NULL, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, NULL, troot };
     jl_value_t *nt = NULL;
     JL_GC_PUSH2(&vb.innervars, &nt);
     if (jl_is_unionall(u->body))

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2889,6 +2889,10 @@ end
 @test !(Tuple{Union{Int16,Int8},Ref{Int16},Ref{Int16}} <: Tuple{<:Union{S,T},Ref{S},Ref{T}} where {S,T})
 @test !(Tuple{Ref{Int16},Ref{Int16},Union{Int16,Int8}} <: Tuple{Ref{S},Ref{T},<:Union{S,T}} where {S,T})
 @test Tuple{NTuple{2,Int}, Int8} <: Tuple{<:Union{NTuple{2,T},Tuple{S,T}}, <:T} where {S,T>:Int}
+# Variant of the above where T also appears in a non-traversed (inactive) Union
+# branch — body_occurs_inv(T) is structurally 1 even though dynamic occurs_inv
+# stays 0, exercising the static-`body_occurs_inv` check in env_unchanged.
+@test Tuple{NTuple{2,Int}, Int8} <: Tuple{<:Union{NTuple{2,T},Tuple{S,T},Ref{T}}, <:T} where {S,T>:Int}
 
 # An unused typevar in a method signature's `where` clause must be
 # reported in env at its declared index, not dropped or shifted.


### PR DESCRIPTION
The diagonal rule was changed to semi-static in #34272 — it uses `var_occurs_invariant(u->body, u->var)` (a structural check on the UnionAll body) rather than the dynamic `occurs_inv` counter, since the latter only reflects whichever invariant positions were actually traversed. The recently-added diagonality-change check in `env_unchanged` (#61503), however, still tested `v->occurs_inv == 0`, so it could spuriously flag a variable as "newly diagonal" when its body has T only in branches the algorithm never visited.

Cache `var_occurs_invariant(u->body, u->var)` once at varbinding creation as `body_occurs_inv` and use it in `env_unchanged` (and at the existing recompute sites in `subtype_unionall` and `intersect_unionall`).

The two checks can be made to diverge by hiding a `Ref{T}` in a Union branch that is never picked dynamically (added as a regression test); However, the divergence only changes how much `exists_subtype` exploration is performed after `sub == true` and not the boolean result or the chosen ∃-bindings. As a result, this is a performance fix, but not a correctness fix.