### PR TITLE
[JuliaLowering] `ssaflags` support

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -557,9 +557,6 @@ function est_to_dst(st::SyntaxTree)
 
         #-----------------------------------------------------------------------
         # Heads not emitted from parsing
-        ([K"meta" [K"unknown_head" ps...]], when=st[1].name_val === "purity") ->
-            @ast g st [K"meta" "purity"::K"Symbol"
-                Base.EffectsOverride([x.value for x in ps]...)::K"Value"]
         ([K"meta" s vs...],
          when=(meta=get(s, :name_val, "")::String; meta in ("nospecialize", "specialize"))) ->
              # Should be handled in the function case
@@ -569,10 +566,8 @@ function est_to_dst(st::SyntaxTree)
                 s->(kind(s) === K"Identifier" ? setattr(s, :kind, K"Symbol") : s),
                 syms)...
            ]
-        # TODO: JL doesn't support inline/noinline/inbounds
-        [K"inline" _] -> newleaf(g, st, K"TOMBSTONE")
-        [K"noinline" _] -> newleaf(g, st, K"TOMBSTONE")
-        [K"inbounds" _] -> newleaf(g, st, K"TOMBSTONE")
+        [K"boundscheck" x] -> mknode(st, SyntaxList(g))
+        [K"inbounds" [K"Identifier"]] -> newnode(g, st, K"inbounds_pop", SyntaxList(g))
         [K"core" x] -> setattr!(mkleaf(st), :name_val, x.name_val)
         [K"top" x] -> setattr!(mkleaf(st), :name_val, x.name_val)
         [K"static_parameter" x] -> setattr!(mkleaf(st), :var_id, x.value::IdTag)
@@ -625,4 +620,13 @@ function est_to_dst(st::SyntaxTree)
             out_cs == children(st) ? st : mknode(st, out_cs)
         end
     end
+end
+
+#-------------------------------------------------------------------------------
+# misc
+
+function purity_expr_to_flags(st::SyntaxTree)
+    @jl_assert kind(st) === K"purity" st
+    args = Bool[x.value for x in children(st)]
+    Base.encode_effects_override(Base.EffectsOverride(args...))
 end

--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -205,6 +205,61 @@ function finish_ir_debug_info!(current_codelocs_stack)
     _compress_debuginfo(only(current_codelocs_stack))
 end
 
+# flisp: jl_new_code_info_from_ir (method.c)
+function compute_ssaflags(st::SyntaxTree)
+    @jl_assert kind(st) == K"block" st
+    stmts = children(st)
+    out = zeros(UInt32, length(stmts))
+    inline_flags = Vector{Bool}()
+    inbounds_depth = 0
+    purity_flags = Vector{UInt32}()
+
+    # Note this should probably go in validation or be a user-facing
+    # loweringerror, but method.c only checks this in asserts builds, so we may
+    # need to allow these to be unbalanced
+    function checked_pop!(stk)
+        @jl_assert(!isempty(stk), (st, "ssaflags pop without push"))
+        pop!(stk)
+    end
+    for (i, stmt) in enumerate(stmts)
+        is_flag_stmt = true
+        @stm stmt begin
+            [K"inbounds" [K"Value"]] -> stmt[1].value::Bool ?
+                (inbounds_depth += 1) : # push
+                (inbounds_depth = 0)    # clear
+            [K"inbounds_pop"] -> (inbounds_depth = max(0, inbounds_depth-1))
+            [K"boundscheck" _...] -> nothing
+            [K"inline" [K"Value"]] -> stmt[1].value::Bool ?
+                push!(inline_flags, true) : checked_pop!(inline_flags)
+            [K"noinline" [K"Value"]] -> stmt[1].value::Bool ?
+                push!(inline_flags, false) : checked_pop!(inline_flags)
+            [K"purity"] -> checked_pop!(purity_flags)
+            [K"purity" _ _...] -> push!(
+                purity_flags,
+                UInt32(purity_expr_to_flags(stmt)) << Core.Compiler.NUM_IR_FLAGS)
+            _ -> is_flag_stmt = false
+        end
+        flag = UInt32(0)
+        if !isempty(inline_flags)
+            flag |= (inline_flags[end] ?
+                Core.Compiler.IR_FLAG_INLINE : Core.Compiler.IR_FLAG_NOINLINE)
+        end
+        if inbounds_depth != 0
+            flag |= Core.Compiler.IR_FLAG_INBOUNDS
+        end
+        if !isempty(purity_flags)
+            for pf in purity_flags
+                flag |= pf
+            end
+        end
+        out[i] = is_flag_stmt ? UInt32(0) : flag
+    end
+    @jl_assert length(out) == length(stmts) st
+    @jl_assert length(inline_flags) == 0 st
+    @jl_assert length(purity_flags) == 0 st
+    out
+end
+
 # Convert SyntaxTree to the CodeInfo+Expr data structures understood by the
 # Julia runtime
 function to_code_info(ex::SyntaxTree, slots::Vector{Slot}, meta::CompileHints)
@@ -243,15 +298,8 @@ function to_code_info(ex::SyntaxTree, slots::Vector{Slot}, meta::CompileHints)
     end
 
     debuginfo = finish_ir_debug_info!(current_codelocs_stack)
-
     has_image_globalref = any(codeinfo_has_image_globalref, stmts)
-
-    # TODO: Set ssaflags based on call site annotations:
-    # - @inbounds annotations
-    # - call site @inline / @noinline
-    # - call site @assume_effects
-    ssaflags = zeros(UInt32, length(stmts))
-
+    ssaflags = compute_ssaflags(ex)
     propagate_inbounds =
         get(meta, :propagate_inbounds, false)
     # TODO: Set true if there's a foreigncall
@@ -266,7 +314,7 @@ function to_code_info(ex::SyntaxTree, slots::Vector{Slot}, meta::CompileHints)
         get(meta, :no_constprop, false) ? 0x02 : 0x00
     purity =
         let eo = get(meta, :purity, nothing)
-            isnothing(eo) ? 0x0000 : Base.encode_effects_override(eo)
+            isnothing(eo) ? 0x0000 : eo::UInt16
         end
 
     # The following CodeInfo fields always get their default values for
@@ -389,7 +437,7 @@ function _to_lowered_expr(ex::SyntaxTree)
         args = Any[_to_lowered_expr(e) for e in children(ex)]
         # Unpack K"Symbol" QuoteNode as `Expr(:meta)` requires an identifier here.
         arg1 = args[1]
-        @jl_assert arg1 isa QuoteNode ex
+        @jl_assert (arg1 isa QuoteNode) ex
         args[1] = arg1.value
         Expr(:meta, args...)
     elseif k == K"foreigncall_arg1"
@@ -411,6 +459,9 @@ function _to_lowered_expr(ex::SyntaxTree)
             end
         end
         return ret
+    elseif k in KSet"inline noinline inbounds inbounds_pop purity"
+        # only used in compute_ssaflags (see method.c)
+        nothing
     else
         # Allowed forms according to https://docs.julialang.org/en/v1/devdocs/ast/
         #

--- a/JuliaLowering/src/kinds.jl
+++ b/JuliaLowering/src/kinds.jl
@@ -16,12 +16,13 @@ function _register_kinds()
             "gc_preserve_end"
             # A (quoted) `Symbol`
             "Symbol"
-            # TODO: Use `meta` for inbounds and loopinfo etc?
             "inbounds"
+            "inbounds_pop" # expr: (inbounds pop) with identifier "pop"
             "boundscheck"
             "inline"
             "noinline"
             "loopinfo"
+            "purity"
             # Call into foreign code
             "foreigncall"
             # ccall convention

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -884,22 +884,26 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         emit(ctx, ex)
         nothing
     elseif k == K"meta"
-        numchildren(ex) >= 1 && if kind(ex[1]) === K"purity" ||
-            kind(ex[1]) === K"Symbol" && ex[1].name_val::String in (
-                "inline", "noinline", "propagate_inbounds",
-                "nospecializeinfer", "aggressive_constprop", "no_constprop")
-            for c in children(ex)
-                if kind(c) === K"purity"
-                    old = get(ctx.meta, :purity, UInt16(0))
-                    ctx.meta[:purity] = (old | purity_expr_to_flags(c))::UInt16
-                elseif kind(c) === K"Symbol"
-                    ctx.meta[Symbol(c.name_val::String)] = true
-                else
-                    @jl_assert false c
+        if numchildren(ex) >= 1
+            # Certain blessed forms are allowed to share a meta expression;
+            # others (nkw, optlevel) treat ex[1] as head and ex[2:end] as args
+            if kind(ex[1]) === K"purity" ||
+                kind(ex[1]) === K"Symbol" && ex[1].name_val::String in (
+                    "inline", "noinline", "propagate_inbounds",
+                    "nospecializeinfer", "aggressive_constprop", "no_constprop")
+                for c in children(ex)
+                    if kind(c) === K"purity"
+                        old = get(ctx.meta, :purity, UInt16(0))
+                        ctx.meta[:purity] = (old | purity_expr_to_flags(c))::UInt16
+                    elseif kind(c) === K"Symbol"
+                        ctx.meta[Symbol(c.name_val::String)] = true
+                    else
+                        @jl_assert false c
+                    end
                 end
+            else
+                emit(ctx, ex)
             end
-        else
-            emit(ctx, ex)
         end
         if needs_value
             val = @ast ctx ex (::K"nothing")

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -885,13 +885,14 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         nothing
     elseif k == K"meta"
         @jl_assert numchildren(ex) >= 1 ex
-        if ex[1].name_val in ("inline", "noinline", "propagate_inbounds",
+        if kind(ex[1]) === K"purity"
+            @jl_assert numchildren(ex) == 1 ex
+            ctx.meta[:purity] = purity_expr_to_flags(ex[1])
+        elseif ex[1].name_val in ("inline", "noinline", "propagate_inbounds",
                               "nospecializeinfer", "aggressive_constprop", "no_constprop")
             for c in children(ex)
                 ctx.meta[Symbol(c.name_val)] = true
             end
-        elseif ex[1].name_val === "purity"
-            ctx.meta[Symbol(ex[1].name_val)] = ex[2].value::Base.EffectsOverride
         else
             emit(ctx, ex)
         end
@@ -902,6 +903,13 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
             else
                 val
             end
+        end
+    elseif k == K"inbounds" || k == K"inbounds_pop" ||
+        k == K"inline" || k == K"noinline" || k == K"purity"
+        if in_tail_pos
+            emit_return(ctx, ex)
+        else
+            emit(ctx, ex) # converted to nothing later
         end
     elseif k == K"_while"
         end_label = make_label(ctx, ex)
@@ -923,8 +931,8 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         if needs_value
             compile(ctx, nothing_(ctx, ex), needs_value, in_tail_pos)
         end
-    elseif k == K"isdefined" || k == K"captured_local" || k == K"throw_undef_if_not" ||
-            k == K"boundscheck"
+    elseif k == K"isdefined" || k == K"captured_local" ||
+        k == K"throw_undef_if_not" || k == K"boundscheck"
         if in_tail_pos
             emit_return(ctx, ex)
         elseif needs_value

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -884,17 +884,20 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         emit(ctx, ex)
         nothing
     elseif k == K"meta"
-        @jl_assert numchildren(ex) >= 1 ex
-        if kind(ex[1]) === K"purity"
-            @jl_assert numchildren(ex) == 1 ex
-            ctx.meta[:purity] = purity_expr_to_flags(ex[1])
-        elseif ex[1].name_val in ("inline", "noinline", "propagate_inbounds",
-                              "nospecializeinfer", "aggressive_constprop", "no_constprop")
-            for c in children(ex)
-                ctx.meta[Symbol(c.name_val)] = true
-            end
-        else
+        numchildren(ex) >= 1 && if kind(ex[1]) === K"Symbol" &&
+            ex[1].name_val::String in (
+                "nkw", "generated", "generated_only")
             emit(ctx, ex)
+        else
+            for c in children(ex)
+                if kind(c) === K"purity"
+                    ctx.meta[:purity] = purity_expr_to_flags(c)
+                else
+                    # ("inline", "noinline", "propagate_inbounds",
+                    # "nospecializeinfer", "aggressive_constprop", "no_constprop")
+                    ctx.meta[Symbol(c.name_val::String)] = true
+                end
+            end
         end
         if needs_value
             val = @ast ctx ex (::K"nothing")

--- a/JuliaLowering/src/linear_ir.jl
+++ b/JuliaLowering/src/linear_ir.jl
@@ -884,20 +884,22 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         emit(ctx, ex)
         nothing
     elseif k == K"meta"
-        numchildren(ex) >= 1 && if kind(ex[1]) === K"Symbol" &&
-            ex[1].name_val::String in (
-                "nkw", "generated", "generated_only")
-            emit(ctx, ex)
-        else
+        numchildren(ex) >= 1 && if kind(ex[1]) === K"purity" ||
+            kind(ex[1]) === K"Symbol" && ex[1].name_val::String in (
+                "inline", "noinline", "propagate_inbounds",
+                "nospecializeinfer", "aggressive_constprop", "no_constprop")
             for c in children(ex)
                 if kind(c) === K"purity"
-                    ctx.meta[:purity] = purity_expr_to_flags(c)
-                else
-                    # ("inline", "noinline", "propagate_inbounds",
-                    # "nospecializeinfer", "aggressive_constprop", "no_constprop")
+                    old = get(ctx.meta, :purity, UInt16(0))
+                    ctx.meta[:purity] = (old | purity_expr_to_flags(c))::UInt16
+                elseif kind(c) === K"Symbol"
                     ctx.meta[Symbol(c.name_val::String)] = true
+                else
+                    @jl_assert false c
                 end
             end
+        else
+            emit(ctx, ex)
         end
         if needs_value
             val = @ast ctx ex (::K"nothing")
@@ -909,10 +911,14 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         end
     elseif k == K"inbounds" || k == K"inbounds_pop" ||
         k == K"inline" || k == K"noinline" || k == K"purity"
-        if in_tail_pos
-            emit_return(ctx, ex)
-        else
-            emit(ctx, ex) # converted to nothing later
+        emit(ctx, ex) # converted to nothing later
+        if needs_value
+            val = @ast ctx ex (::K"nothing")
+            if in_tail_pos
+                emit_return(ctx, val)
+            else
+                val
+            end
         end
     elseif k == K"_while"
         end_label = make_label(ctx, ex)

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -286,12 +286,16 @@ vst1(vcx::Validation1Context, st::SyntaxTree)::ValidationResult = @stm st begin
         @fail(st, "expected (cconv convention_tuple n_req_args)")
     [K"tryfinally" t f] -> vst1(vcx, t) & vst1(vcx, f)
     [K"tryfinally" t f scope] -> vst1(vcx, t) & vst1(vcx, f) & vst1(vcx, scope)
-    [K"inline" _] -> pass()
-    [K"noinline" _] -> pass()
-    [K"inbounds" _] -> pass()
-    [K"boundscheck"] -> pass()
-    [K"boundscheck" _] -> pass()
-    [K"loopinfo" _...] -> pass()
+    [K"loopinfo" _...] -> pass() # TODO
+    [K"boundscheck"] -> pass() # optional bool arg does nothing
+    ([K"boundscheck" [K"Value"]], when=(st[1].value isa Bool)) -> pass()
+    ([K"inbounds" [K"Value"]], when=(st[1].value isa Bool)) -> pass()
+    ([K"inbounds" [K"Identifier"]], when=(st[1].name_val == "pop")) -> pass()
+    ([K"inline" [K"Value"]], when=(st[1].value isa Bool)) -> pass()
+    ([K"noinline" [K"Value"]], when=(st[1].value isa Bool)) -> pass()
+    [K"purity"] -> pass()
+    [K"purity" _ _...] -> numchildren(st) == fieldcount(Base.EffectsOverride) ?
+        pass() : @fail(st, "wrong number of args to `purity` expression")
     [K"locals"] -> pass()
     [K"islocal" _] -> pass()
     [K"isglobal" _] -> pass()
@@ -1262,7 +1266,14 @@ vst2(vcx::Validation2Context, st::SyntaxTree) = @stm st begin
 
     [K"meta" xs...] -> all(vst2, vcx, xs) # TODO
     [K"loopinfo" xs...] -> all(vst2, vcx, xs) # TODO
-    [K"boundscheck" xs...] -> all(vst2, vcx, xs) # TODO
+    [K"boundscheck"] -> pass()
+    [K"inbounds_pop"] -> pass()
+    ([K"inbounds" [K"Value"]], when=(st[1].value isa Bool)) -> pass()
+    ([K"inline" [K"Value"]], when=(st[1].value isa Bool)) -> pass()
+    ([K"noinline" [K"Value"]], when=(st[1].value isa Bool)) -> pass()
+    [K"purity"] -> pass()
+    [K"purity" _ _...] -> numchildren(st) == fieldcount(Base.EffectsOverride) ?
+        pass() : @fail(st, "wrong number of args to `purity` expression")
 
     [K"always_defined" x] -> vst2_ident(vcx, x)
     [K"assert" [K"Symbol"] x] -> vst2(vcx, x)

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -498,6 +498,14 @@ end
     ref = Meta.lower(test_mod, Meta.parse(prog))
     our = jlower_e(prog)
     @test find_method_ci(ref).purity === find_method_ci(our).purity
+
+    # TODO: no api for option retrieval, just check that it compiles
+    let options_mod = Module()
+        @test fl_eval(options_mod, :(Base.Experimental.@optlevel 1)) == nothing
+        @test jl_eval(options_mod, :(Base.Experimental.@optlevel 1)) == nothing
+        @test fl_eval(options_mod, :(Base.Experimental.@max_methods 1)) == nothing
+        @test jl_eval(options_mod, :(Base.Experimental.@max_methods 1)) == nothing
+    end
 end
 
 # partially robot-generated

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -433,6 +433,19 @@ end
     end
 end
 
+@testset "empty meta" begin
+    @test fl_eval(test_mod, Expr(:meta)) == nothing
+    @test fl_eval(test_mod, Expr(:block, Expr(:meta))) == nothing
+    @test fl_eval(test_mod, Expr(:call,
+                                 Expr(:function, Expr(:call, :func_empty_meta),
+                                      Expr(:block, Expr(:meta))))) == nothing
+    @test jl_eval(test_mod, Expr(:meta)) == nothing
+    @test jl_eval(test_mod, Expr(:block, Expr(:meta))) == nothing
+    @test jl_eval(test_mod, Expr(:call,
+                                 Expr(:function, Expr(:call, :func_empty_meta),
+                                      Expr(:block, Expr(:meta))))) == nothing
+end
+
 @testset "macros producing meta forms" begin
     function find_method_ci(thunk)
         ci = thunk.args[1]::Core.CodeInfo
@@ -475,6 +488,11 @@ end
     our = jlower_e(prog)
     @test find_method_ci(ref).propagate_inbounds === find_method_ci(our).propagate_inbounds
 
+    prog = "Base.@assume_effects :total @inline function foo(); end"
+    ref = Meta.lower(test_mod, Meta.parse(prog))
+    our = jlower_e(prog)
+    @test find_method_ci(ref).inlining === find_method_ci(our).inlining
+    @test find_method_ci(ref).purity === find_method_ci(our).purity
 end
 
 # partially robot-generated
@@ -659,6 +677,9 @@ end
     end
 
     @testset "purity" begin
+        # Sanity: plain function with no purity annotation has no purity bits set.
+        @test has_none("function f(g,x); g(x); end",
+                       UInt32(0xFFFF) << Core.Compiler.NUM_IR_FLAGS)
         # `@assume_effects :foo expr` at a call site expands to
         #   (block (purity ...11 bool args...) (local (= val expr)) (purity) val)
         # where the trailing zero-arg `(purity)` is the region-end token.
@@ -668,28 +689,12 @@ end
         @test has_any(
             "function f(g,x); Base.@assume_effects :consistent :effect_free g(x); end",
             purity_mask(Base.EffectsOverride(consistent=true, effect_free=true)))
-        # Negated effect (`!:nothrow` after `:total`) clears just that bit:
-        # the :nothrow bit must NOT be set on any statement, but the other
-        # :total bits must still appear.
-        @test has_none(
-            "function f(g,x); Base.@assume_effects :total !:nothrow g(x); end",
-            purity_mask(Base.EffectsOverride(nothrow=true)))
-        @test has_any(
-            "function f(g,x); Base.@assume_effects :total !:nothrow g(x); end",
-            purity_mask(Base.EffectsOverride(consistent=true)))
-        # Plain function with no purity annotation has no purity bits set.
-        @test has_none("function f(g,x); g(x); end",
-                       UInt32(0xFFFF) << Core.Compiler.NUM_IR_FLAGS)
 
-        # Function-definition form goes through the `meta` path; the encoded
-        # `purity` field on the CodeInfo (not ssaflags) carries the override.
+        # Function form goes through a different path: `(meta (purity args...))`
         JuliaLowering.include_string(test_mod, """
         Base.@assume_effects :total f_assume_def(x) = x
         """; expr_compat_mode)
         @test test_mod.f_assume_def(5) == 5
-        # `purity_expr_to_flags` should agree with `Base.encode_effects_override`
-        # for the function-def path — same check is in "macros producing meta
-        # forms", repeated here to exercise the new `K"purity"` node end-to-end.
         prog_def = "Base.@assume_effects :total function f_assume_total(x); x; end"
         ref_ci = find_method_ci(Meta.lower(test_mod, Meta.parse(prog_def)))
         our_ci = find_method_ci(jlower_e(prog_def))

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -477,6 +477,226 @@ end
 
 end
 
+# partially robot-generated
+@testset "meta-like forms not using the `meta` expression" for expr_compat_mode in (true,false)
+    @testset "in value position" begin
+        @test fl_eval(test_mod, Expr(:boundscheck)) isa Bool
+        @test jl_eval(test_mod, Expr(:boundscheck); expr_compat_mode) isa Bool
+
+        @test fl_eval(test_mod, Expr(:inbounds, true)) === nothing
+        @test fl_eval(test_mod, Expr(:inbounds, false)) === nothing
+        @test fl_eval(test_mod, Expr(:inbounds, :pop)) === nothing
+        @test jl_eval(test_mod, Expr(:inbounds, true); expr_compat_mode) === nothing
+        @test jl_eval(test_mod, Expr(:inbounds, false); expr_compat_mode) === nothing
+        @test jl_eval(test_mod, Expr(:inbounds, :pop); expr_compat_mode) === nothing
+
+        @testset for inline in (:inline, :noinline)
+            @testset let ex = Expr(:block,
+                                   Expr(inline, true),
+                                   Expr(inline, false))
+                @test fl_eval(test_mod, ex) === nothing
+                @test jl_eval(test_mod, ex; expr_compat_mode) === nothing
+            end
+            @testset let ex = Expr(:function, Expr(:tuple),
+                                   Expr(:block,
+                                        Expr(inline, true),
+                                        Expr(inline, false)))
+                local f
+                f = fl_eval(test_mod, ex)
+                Core.@latestworld
+                @test f() === nothing
+
+                f = jl_eval(test_mod, ex; expr_compat_mode)
+                Core.@latestworld
+                @test f() === nothing
+            end
+        end
+    end
+
+    function find_method_ci(thunk)
+        ci = thunk.args[1]::Core.CodeInfo
+        m = findfirst(x->(x isa Expr && x.head === :method && length(x.args) === 3), ci.code)
+        ci.code[m].args[3]
+    end
+    jlower_e(s) = JuliaLowering.to_lowered_expr(
+        JuliaLowering.lower(
+            test_mod, JuliaLowering.parsestmt(
+                JuliaLowering.SyntaxTree, s);
+            expr_compat_mode))
+    our_ssaflags(prog) = find_method_ci(jlower_e(prog)).ssaflags
+
+    local INBOUNDS = Core.Compiler.IR_FLAG_INBOUNDS
+    local INLINE   = Core.Compiler.IR_FLAG_INLINE
+    local NOINLINE = Core.Compiler.IR_FLAG_NOINLINE
+
+    # `compute_ssaflags` shifts the encoded purity overrides up by NUM_IR_FLAGS.
+    purity_mask(eo::Base.EffectsOverride) =
+        UInt32(Base.encode_effects_override(eo)) << Core.Compiler.NUM_IR_FLAGS
+
+    # check any IR statement in `prog` has `flags`
+    has_any(prog, flags) = any(f -> (f & flags) == flags, our_ssaflags(prog))
+    has_none(prog, flags) = all(f -> (f & flags) == 0,    our_ssaflags(prog))
+
+    @testset "boundscheck" begin
+        JuliaLowering.include_string(test_mod, """
+        @inline function g_boundscheck(A, i)
+            @boundscheck checkbounds(A, i)
+            return A[i]
+        end
+        """; expr_compat_mode)
+        @test test_mod.g_boundscheck(1:2, 2) == 2
+        @test_throws BoundsError test_mod.g_boundscheck(1:2, 3)
+
+        # The boundscheck marker itself does not set IR_FLAG_INBOUNDS — it is
+        # a separate runtime predicate, not an annotation.
+        @test has_none("function f(A,i); @boundscheck checkbounds(A,i); A[i]; end",
+                       INBOUNDS)
+        # `Expr(:boundscheck)` should survive lowering as a top-level
+        # statement (it gets rewritten by inlining/codegen, not lowering).
+        let our = find_method_ci(jlower_e(
+                "function f(A,i); @boundscheck checkbounds(A,i); A[i]; end"))
+            @test any(s -> s isa Expr && s.head === :boundscheck, our.code)
+        end
+    end
+
+    @testset "inbounds" begin
+        JuliaLowering.include_string(test_mod, """
+        function sum_inbounds(A::AbstractArray)
+            r = zero(eltype(A))
+            for i in eachindex(A)
+                @inbounds r += A[i]
+            end
+            return r
+        end
+        """; expr_compat_mode)
+        @test test_mod.sum_inbounds([1,2,3]) == 6
+
+        @test has_none("function f(A,i); A[i]; end", INBOUNDS)
+        @test has_any("function f(A,i); @inbounds A[i]; end", INBOUNDS)
+        @test has_any("""
+            function f(A)
+                s = zero(eltype(A))
+                @inbounds for i in eachindex(A)
+                    s += A[i]
+                end
+                s
+            end
+        """, INBOUNDS)
+        let flags = our_ssaflags("""
+                function f(A, i, j)
+                    z = @inbounds A[i]
+                    A[j]
+                end
+            """)
+            @test any(f -> (f & INBOUNDS) != 0, flags)  # inside @inbounds
+            @test any(f -> (f & INBOUNDS) == 0, flags)  # outside
+        end
+    end
+
+    @testset "inline" begin
+        @test has_any("function f(g,x); @inline g(x); end", INLINE)
+        @test has_none("function f(g,x); g(x); end", INLINE)
+        @test has_none("function f(g,x); @inline g(x); end", NOINLINE)
+        @test has_any("function f(g,x); @inline g(x) + g(x); end", INLINE)
+
+        # Bare `@inline` inside a function body (1.8+) emits
+        # `Expr(:meta, :inline)`; no statement gets a call-site IR_FLAG_INLINE.
+        JuliaLowering.include_string(test_mod, """
+        function bare_inline(x)
+            @inline
+            x * 2
+        end
+        """; expr_compat_mode)
+        @test test_mod.bare_inline(3) == 6
+        @test has_none("function f(x); @inline; x * 2; end", INLINE)
+
+        # `@inline` on a definition is handled by the meta-expression path
+        # (covered in "macros producing meta forms"); confirm it still runs
+        # and that no call-site INLINE bit leaks into the body.
+        JuliaLowering.include_string(test_mod, """
+        @inline f_inline_def(x) = x + 1
+        """; expr_compat_mode)
+        @test test_mod.f_inline_def(2) == 3
+        @test has_none("@inline f(x) = x + 1", INLINE)
+    end
+
+    @testset "noinline" begin
+        # Analogous to `@inline` but pushes IR_FLAG_NOINLINE.
+        @test has_any("function f(g,x); @noinline g(x); end", NOINLINE)
+        @test has_none("function f(g,x); g(x); end", NOINLINE)
+        @test has_none("function f(g,x); @noinline g(x); end", INLINE)
+        @test has_any("function f(g,x); @noinline g(x) + g(x); end", NOINLINE)
+
+        JuliaLowering.include_string(test_mod, """
+        function bare_noinline(x)
+            @noinline
+            x * 2
+        end
+        """; expr_compat_mode)
+        @test test_mod.bare_noinline(3) == 6
+        @test has_none("function f(x); @noinline; x * 2; end", NOINLINE)
+
+        JuliaLowering.include_string(test_mod, """
+        @noinline f_noinline_def(x) = x + 1
+        """; expr_compat_mode)
+        @test test_mod.f_noinline_def(2) == 3
+
+        # Innermost annotation wins when @inline / @noinline nest: the inner
+        # call gets IR_FLAG_INLINE; the outer @noinline still applies to
+        # statements outside the inner region.
+        let flags = our_ssaflags("""
+                function f(g, x)
+                    @noinline let
+                        a = @inline g(x)
+                        b = g(x)
+                        (a, b)
+                    end
+                end
+            """)
+            @test any(f -> (f & INLINE)   != 0, flags)
+            @test any(f -> (f & NOINLINE) != 0, flags)
+        end
+    end
+
+    @testset "purity" begin
+        # `@assume_effects :foo expr` at a call site expands to
+        #   (block (purity ...11 bool args...) (local (= val expr)) (purity) val)
+        # where the trailing zero-arg `(purity)` is the region-end token.
+        @test has_any("function f(g,x); Base.@assume_effects :nothrow g(x); end",
+                      purity_mask(Base.EffectsOverride(nothrow=true)))
+        # Multiple atomic settings combine to set both bits at once.
+        @test has_any(
+            "function f(g,x); Base.@assume_effects :consistent :effect_free g(x); end",
+            purity_mask(Base.EffectsOverride(consistent=true, effect_free=true)))
+        # Negated effect (`!:nothrow` after `:total`) clears just that bit:
+        # the :nothrow bit must NOT be set on any statement, but the other
+        # :total bits must still appear.
+        @test has_none(
+            "function f(g,x); Base.@assume_effects :total !:nothrow g(x); end",
+            purity_mask(Base.EffectsOverride(nothrow=true)))
+        @test has_any(
+            "function f(g,x); Base.@assume_effects :total !:nothrow g(x); end",
+            purity_mask(Base.EffectsOverride(consistent=true)))
+        # Plain function with no purity annotation has no purity bits set.
+        @test has_none("function f(g,x); g(x); end",
+                       UInt32(0xFFFF) << Core.Compiler.NUM_IR_FLAGS)
+
+        # Function-definition form goes through the `meta` path; the encoded
+        # `purity` field on the CodeInfo (not ssaflags) carries the override.
+        JuliaLowering.include_string(test_mod, """
+        Base.@assume_effects :total f_assume_def(x) = x
+        """; expr_compat_mode)
+        @test test_mod.f_assume_def(5) == 5
+        # `purity_expr_to_flags` should agree with `Base.encode_effects_override`
+        # for the function-def path — same check is in "macros producing meta
+        # forms", repeated here to exercise the new `K"purity"` node end-to-end.
+        prog_def = "Base.@assume_effects :total function f_assume_total(x); x; end"
+        ref_ci = find_method_ci(Meta.lower(test_mod, Meta.parse(prog_def)))
+        our_ci = find_method_ci(jlower_e(prog_def))
+        @test ref_ci.purity === our_ci.purity
+    end
+end
+
 @testset "scope layers for normally-inert ASTs" begin
     # Right hand side of `.`
     @test JuliaLowering.include_string(test_mod, raw"""
@@ -654,27 +874,6 @@ end
 
     @test test_mod.inner([1,2,3], [1,2,3]) == 14
     @test test_mod.innersimd([1,2,3], [1,2,3]) == 14
-end
-
-@testset "@boundscheck / @inbounds" begin
-    JuliaLowering.include_string(test_mod, """
-    function sum_inbounds(A::AbstractArray)
-        r = zero(eltype(A))
-        for i in eachindex(A)
-            @inbounds r += A[i]
-        end
-        return r
-    end
-    """; expr_compat_mode=true)
-    @test test_mod.sum_inbounds([1,2,3]) == 6
-
-    JuliaLowering.include_string(test_mod, """
-    @inline function g_boundscheck(A, i)
-        @boundscheck checkbounds(A, i)
-        return A[i]
-    end
-    """; expr_compat_mode=true)
-    @test test_mod.g_boundscheck(1:2, 2) == 2
 end
 
 @testset "@__FUNCTION__ and Expr(:thisfunction)" begin

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -446,7 +446,7 @@ end
                                       Expr(:block, Expr(:meta))))) == nothing
 end
 
-@testset "macros producing meta forms" begin
+@testset "macros producing meta forms" for expr_compat_mode in [true, false]
     function find_method_ci(thunk)
         ci = thunk.args[1]::Core.CodeInfo
         m = findfirst(x->(x isa Expr && x.head === :method && length(x.args) === 3), ci.code)
@@ -456,7 +456,7 @@ end
         JuliaLowering.lower(
             test_mod, JuliaLowering.parsestmt(
                 JuliaLowering.SyntaxTree, s);
-            expr_compat_mode=true))
+            expr_compat_mode))
 
     prog = "Base.@assume_effects :foldable function foo(); end"
     ref = Meta.lower(test_mod, Meta.parse(prog))
@@ -492,6 +492,11 @@ end
     ref = Meta.lower(test_mod, Meta.parse(prog))
     our = jlower_e(prog)
     @test find_method_ci(ref).inlining === find_method_ci(our).inlining
+    @test find_method_ci(ref).purity === find_method_ci(our).purity
+
+    prog = "Base.@assume_effects :consistent Base.@assume_effects :nothrow function foo(); end"
+    ref = Meta.lower(test_mod, Meta.parse(prog))
+    our = jlower_e(prog)
     @test find_method_ci(ref).purity === find_method_ci(our).purity
 end
 


### PR DESCRIPTION
Fill in CodeInfo ssaflags, which was an outstanding TODO.  This means `inbounds`, `inline`, `noinline`, and `purity` should now be fully supported, where previously we only supported the cases they expanded to `(meta $symbol)`.  The implementation should match `jl_new_code_info_from_ir` in method.c.

Tests mostly botted.

Certain internal errors should now be fixed: fix #61737, fix https://github.com/JuliaLang/JuliaLowering.jl/issues/128