### PR TITLE
codegen: add `@cpu_supports` macros (mirroring `__builtin_cpu_supports`)

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -51,7 +51,7 @@ end
 
 const INT_INF = typemax(Int) # integer infinity
 
-const N_IFUNC = reinterpret(Int32, have_fma) + 1
+const N_IFUNC = reinterpret(Int32, cpu_supports) + 1
 const T_IFUNC = Vector{Tuple{Int, Int, Any}}(undef, N_IFUNC)
 const T_IFUNC_COST = Vector{Int}(undef, N_IFUNC)
 const T_FFUNC_KEY = Vector{Any}()
@@ -328,6 +328,7 @@ end
 add_tfunc(Core.Intrinsics.cglobal, 1, 2, cglobal_tfunc, 5)
 
 add_tfunc(Core.Intrinsics.have_fma, 1, 1, @nospecs((𝕃::AbstractLattice, x)->Bool), 1)
+add_tfunc(Core.Intrinsics.cpu_supports, 1, 1, @nospecs((𝕃::AbstractLattice, x)->Bool), 1)
 
 # builtin functions
 # =================
@@ -3049,6 +3050,11 @@ function intrinsic_exct(𝕃::AbstractLattice, f::IntrinsicFunction, argtypes::V
         return Union{}
     end
 
+    if f === Intrinsics.cpu_supports
+        argtypes[1] ⊑ Symbol || return TypeError
+        return Union{}
+    end
+
     if f === Intrinsics.add_ptr || f === Intrinsics.sub_ptr
         if !(argtypes[1] ⊑ Ptr && argtypes[2] ⊑ UInt)
             return TypeError
@@ -3099,6 +3105,7 @@ function is_pure_intrinsic_infer(f::IntrinsicFunction, is_effect_free::Union{Not
             f === Intrinsics.pointerref ||            # this one is volatile
             f === Intrinsics.sqrt_llvm_fast ||        # this one may differ at runtime (by a few ulps)
             f === Intrinsics.have_fma ||              # this one depends on the runtime environment
+            f === Intrinsics.cpu_supports ||          # this one depends on the runtime environment
             f === Intrinsics.cglobal)                 # cglobal lookup answer changes at runtime
 end
 

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -290,6 +290,10 @@ include("loading.jl")
 # BinaryPlatforms, used by Artifacts.  Needs `Sort`.
 include("binaryplatforms.jl")
 
+# Compile-time CPU capability query macro (mirrors __builtin_cpu_supports;
+# additionally accepts CPU model names which expand to their feature set).
+using .BinaryPlatforms.CPUID: @cpu_supports
+
 # misc useful functions & macros
 include("timing.jl")
 include("client.jl")

--- a/base/cpuid.jl
+++ b/base/cpuid.jl
@@ -178,6 +178,144 @@ const ISAs_by_family = Dict(
 # Test a CPU feature exists on the currently-running host
 test_cpu_feature(feature::UInt32) = ccall(:jl_test_cpu_feature, Bool, (UInt32,), feature)
 
+# Architectures recognised as an arch prefix in `@cpu_supports`.
+const _KNOWN_ARCHES = (:x86_64, :aarch64, :arm64, :riscv64)
+
+_normalize_arch(a::Symbol) = a === :arm64 ? :aarch64 : a
+
+# Per-arch LLVM feature-name table for `@cpu_supports` parse-time validation.
+const _KNOWN_CPU_FEATURES_BY_ARCH = OncePerProcess{Dict{Symbol,Set{Symbol}}}() do
+    d = Dict{Symbol,Set{Symbol}}()
+    for a in ("x86_64", "aarch64", "riscv64")
+        s = Set{Symbol}()
+        for (_, name) in _build_bit_to_name(a)
+            push!(s, Symbol(name))
+        end
+        d[Symbol(a)] = s
+    end
+    d
+end
+
+# Host-arch shorthand.
+_KNOWN_CPU_FEATURES() = get(_KNOWN_CPU_FEATURES_BY_ARCH(), _normalize_arch(Sys.ARCH), Set{Symbol}())
+
+# Expand a CPU name to its JIT-relevant feature set via the same
+# `resolve_targets_for_llvm` path multiversioning uses. Returns
+# `nothing` for unknown names.
+function _lookup_cpu_features(name::String)
+    result = ccall(:jl_cpu_uarch_expand_features, Any, (Cstring,), name)
+    result === nothing && return nothing
+    feature_str = result::String
+    isempty(feature_str) && return Symbol[]
+    return sort!([Symbol(f) for f in split(feature_str, ',')])
+end
+
+@noinline _bad_feature_arg(x) =
+    error("@cpu_supports: expected literal feature names (Symbol or String), got $(repr(x))")
+
+# Parse a single macro argument as a feature Symbol.
+function _parse_feature_arg(feature)
+    if feature isa Symbol
+        return feature
+    elseif feature isa QuoteNode && feature.value isa Symbol
+        return feature.value
+    elseif feature isa AbstractString
+        return Symbol(feature)
+    else
+        _bad_feature_arg(feature)
+    end
+end
+
+"""
+    Base.@cpu_supports arch name1 [name2 ...] -> Bool
+
+Compile-time CPU capability query, ANDed across names. `arch` is a literal
+architecture name (`x86_64`, `aarch64`, or `riscv64`) that scopes the
+query; each `nameN` is a literal naming an LLVM target feature (`avx2`,
+`fma`, `"sse4.2"`) or a CPU model (`haswell`, `znver4`, `"x86-64-v3"`).
+Strings are required for names that contain `-` or `.`. CPU-model names
+expand to their JIT-relevant feature set. Unknown names error at
+macro-expansion time.
+
+On a host whose arch doesn't match the prefix, the call folds to `false`
+at parse time — letting you write cross-arch dispatch in a single source
+file.
+
+Mirrors GCC/Clang's `__builtin_cpu_supports`, folded against the function's
+effective `target-features` / `target-cpu` (so multiversioning clones get
+per-clone answers automatically).
+
+# Patterns
+
+Dispatch — the dead branch is eliminated:
+```julia
+function dot(xs, ys)
+    if @cpu_supports x86_64 avx2 fma
+        ...  # 256-bit path
+    elseif @cpu_supports aarch64 neon
+        ...  # NEON path
+    else
+        ...  # fallback
+    end
+end
+```
+
+Specialized kernel guard — the body after the assert is DCE'd on clones
+that don't satisfy it, so target-specific intrinsics inside never reach
+backend lowering:
+```julia
+function kernel_avx512(xs)
+    @assert @cpu_supports x86_64 avx512f
+    ...
+end
+```
+"""
+macro cpu_supports(names...)
+    isempty(names) && error("@cpu_supports: at least one name required")
+    # Arch-independent sentinel.
+    if length(names) == 1 && _parse_feature_arg(names[1]) === :__never__
+        return :(Core.Intrinsics.cpu_supports(:__never__))
+    end
+    length(names) < 2 && error("@cpu_supports: syntax is `@cpu_supports <arch> <name>...` where <arch> ∈ $(_KNOWN_ARCHES)")
+    arch_sym = _parse_feature_arg(names[1])
+    arch_sym in _KNOWN_ARCHES || error("@cpu_supports: first argument must be an architecture name (one of $(_KNOWN_ARCHES)), got `$arch_sym`")
+    arch = _normalize_arch(arch_sym)
+    names = names[2:end]
+    if arch !== _normalize_arch(Sys.ARCH)
+        # Arch doesn't match host — fold to false at parse time. No further
+        # validation of the feature names (we can't validate cross-arch CPU
+        # models on a host of a different arch anyway).
+        return false
+    end
+    feature_set = get(_KNOWN_CPU_FEATURES_BY_ARCH(), arch, Set{Symbol}())
+
+    exprs = Expr[]
+    for name in names
+        sym = _parse_feature_arg(name)
+        if sym === :__never__
+            # Sentinel: always folds to false via the pass's unknown-name
+            # handling. For lit-test use.
+            push!(exprs, :(Core.Intrinsics.cpu_supports($(QuoteNode(sym)))))
+            continue
+        end
+        if sym in feature_set
+            push!(exprs, :(Core.Intrinsics.cpu_supports($(QuoteNode(sym)))))
+            continue
+        end
+        # Try as a CPU model (host-arch lookup only).
+        features = _lookup_cpu_features(String(sym))
+        if features !== nothing
+            isempty(features) && error("@cpu_supports: CPU model `$sym` has no hw features (vacuously true)")
+            for f in features
+                push!(exprs, :(Core.Intrinsics.cpu_supports($(QuoteNode(f)))))
+            end
+            continue
+        end
+        error("@cpu_supports: unknown feature or CPU model `$sym` for $(Sys.ARCH)")
+    end
+    return foldr((a, b) -> :($a & $b), exprs)
+end
+
 # Normalize some variation in ARCH values (which typically come from `uname -m`)
 function normalize_arch(arch::String)
     arch = lowercase(arch)

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -37,6 +37,7 @@ STATISTIC(Emitted_fptrunc, "Number of fptrunc calls emitted");
 STATISTIC(Emitted_fpext, "Number of fpext calls emitted");
 STATISTIC(Emitted_not_int, "Number of not_int calls emitted");
 STATISTIC(Emitted_have_fma, "Number of have_fma calls emitted");
+STATISTIC(Emitted_cpu_supports, "Number of cpu_supports calls emitted");
 STATISTIC(EmittedUntypedIntrinsics, "Number of untyped intrinsics emitted");
 
 using namespace JL_I;
@@ -1468,6 +1469,22 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         else
             return emit_runtime_call(ctx, f, argv, nargs);
 
+        FunctionCallee intr = jl_Module->getOrInsertFunction(intr_name, getInt1Ty(ctx.builder.getContext()));
+        auto ret = ctx.builder.CreateCall(intr);
+        return mark_julia_type(ctx, ret, false, jl_bool_type);
+    }
+
+    case cpu_supports: {
+        ++Emitted_cpu_supports;
+        assert(nargs == 1);
+        const jl_cgval_t &x = argv[0];
+        if (!x.constant || !jl_is_symbol(x.constant))
+            return emit_runtime_call(ctx, f, argv, nargs);
+        const char *feat = jl_symbol_name((jl_sym_t*)x.constant);
+        if (*feat == '\0')
+            return emit_runtime_call(ctx, f, argv, nargs);
+        std::string intr_name = "julia.cpu.supports.";
+        intr_name += feat;
         FunctionCallee intr = jl_Module->getOrInsertFunction(intr_name, getInt1Ty(ctx.builder.getContext()));
         auto ret = ctx.builder.CreateCall(intr);
         return mark_julia_type(ctx, ret, false, jl_bool_type);

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -106,6 +106,7 @@
     ALIAS(llvmcall, llvmcall) \
     /*  cpu feature tests */ \
     ADD_I(have_fma, 1) \
+    ADD_I(cpu_supports, 1) \
     /*  hidden intrinsics */ \
     ADD_HIDDEN(cglobal_auto, 1)
 

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -193,6 +193,9 @@
     XX(jl_get_cpu_features) \
     XX(jl_get_sysimage_cpu_target) \
     XX(jl_cpu_has_fma) \
+    XX(jl_cpu_supports) \
+    XX(jl_host_cpu_supports) \
+    XX(jl_cpu_uarch_expand_features) \
     XX(jl_get_current_task) \
     XX(jl_get_default_sysimg_path) \
     XX(jl_get_excstack) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1871,6 +1871,7 @@ JL_DLLEXPORT jl_value_t *jl_copysign_float(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_flipsign_int(jl_value_t *a, jl_value_t *b);
 
 JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_cpu_supports(jl_value_t *feat);
 JL_DLLEXPORT int jl_stored_inline(jl_value_t *el_type);
 JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a);
 JL_DLLEXPORT jl_array_t *jl_array_copy(jl_array_t *ary);

--- a/src/llvm-cpufeatures.cpp
+++ b/src/llvm-cpufeatures.cpp
@@ -1,17 +1,14 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
-// Lower intrinsics that expose subtarget information to the language. This makes it
-// possible to write code that changes behavior based on, e.g., the availability of
-// specific CPU features.
+// Lower intrinsics that expose subtarget information to the language so
+// that Julia code can dispatch on CPU features at compile time.
 //
-// The following intrinsics are supported:
-// - julia.cpu.have_fma.$typ: returns 1 if the platform supports hardware-accelerated FMA.
+// Intrinsics:
+// - julia.cpu.have_fma.$typ:  hardware FMA support for $typ (f32/f64).
+// - julia.cpu.supports.$feat: LLVM target feature $feat (Base.@cpu_supports).
 //
-// Some of these intrinsics are overloaded, i.e., they are suffixed with a type name.
-// To extend support, make sure codegen (in intrinsics.cpp) knows how to emit them.
-//
-// XXX: can / do we want to make this a codegen pass to enable querying TargetPassConfig
-//      instead of using the global target machine?
+// Codegen (intrinsics.cpp) emits these as placeholder calls; this pass
+// folds each using the call site's effective MCSubtargetInfo.
 
 #include "llvm-version.h"
 #include "passes.h"
@@ -22,10 +19,12 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/IR/Verifier.h>
+#include <llvm/ADT/StringMap.h>
+#include <llvm/CodeGen/TargetSubtargetInfo.h>
+#include <llvm/MC/MCSubtargetInfo.h>
+#include <llvm/MC/TargetRegistry.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Support/Debug.h>
-
-#include "jitlayers.h"
 
 #define DEBUG_TYPE "cpufeatures"
 
@@ -33,94 +32,138 @@ using namespace llvm;
 
 STATISTIC(LoweredWithFMA, "Number of have_fma's that were lowered to true");
 STATISTIC(LoweredWithoutFMA, "Number of have_fma's that were lowered to false");
+STATISTIC(LoweredCPUSupports, "Number of cpu_supports calls lowered to a constant");
 
-extern JuliaOJIT *jl_ExecutionEngine;
-
-// whether this platform unconditionally (i.e. without needing multiversioning) supports FMA
-std::optional<bool> always_have_fma(Function &intr, const Triple &TT) JL_NOTSAFEPOINT {
+// True iff the triple guarantees FMA without needing multiversioning;
+// used by MultiVersioning to skip clone emission for have_fma callers.
+std::optional<bool> always_have_fma(Function &intr, const Triple &TT) JL_NOTSAFEPOINT
+{
     if (TT.isAArch64()) {
-        auto intr_name = intr.getName();
-        auto typ = intr_name.substr(strlen("julia.cpu.have_fma."));
+        StringRef typ = intr.getName().substr(strlen("julia.cpu.have_fma."));
         return typ == "f32" || typ == "f64";
-    } else {
-        return None;
     }
+    return std::nullopt;
 }
 
-static bool have_fma(Function &intr, Function &caller, const Triple &TT) JL_NOTSAFEPOINT {
-    auto unconditional = always_have_fma(intr, TT);
-    if (unconditional)
-        return *unconditional;
-
-    auto intr_name = intr.getName();
-    auto typ = intr_name.substr(strlen("julia.cpu.have_fma."));
-
-    Attribute FSAttr = caller.getFnAttribute("target-features");
-    StringRef FS =
-        FSAttr.isValid() ? FSAttr.getValueAsString() : jl_ExecutionEngine->getTargetFeatureString();
-
-    SmallVector<StringRef, 128> Features;
-    FS.split(Features, ',');
-    for (StringRef Feature : Features)
+static bool have_fma(StringRef typ, const MCSubtargetInfo &STI, const Triple &TT) JL_NOTSAFEPOINT
+{
+    if (TT.isAArch64())
+        return typ == "f32" || typ == "f64";
     if (TT.isARM()) {
-      if (Feature == "+vfp4")
-        return typ == "f32" || typ == "f64";
-      else if (Feature == "+vfp4sp")
-        return typ == "f32";
-    } else if (TT.isX86()) {
-      if (Feature == "+fma" || Feature == "+fma4")
-        return typ == "f32" || typ == "f64";
+        // ARM (32-bit): VFPv4 provides FMA on supported types
+        if (STI.checkFeatures("+vfp4"))
+            return typ == "f32" || typ == "f64";
+        if (STI.checkFeatures("+vfp4sp"))
+            return typ == "f32";
+        return false;
     }
-
+    if (TT.isX86()) {
+        if (STI.checkFeatures("+fma") || STI.checkFeatures("+fma4"))
+            return typ == "f32" || typ == "f64";
+        return false;
+    }
     return false;
 }
 
-void lowerHaveFMA(Function &intr, Function &caller, const Triple &TT, CallInst *I) JL_NOTSAFEPOINT {
-    if (have_fma(intr, caller, TT)) {
-        ++LoweredWithFMA;
-        I->replaceAllUsesWith(ConstantInt::get(I->getType(), 1));
-    } else {
-        ++LoweredWithoutFMA;
-        I->replaceAllUsesWith(ConstantInt::get(I->getType(), 0));
+// Per-(CPU, features) MCSubtargetInfo cache, used when the pass runs
+// without a TargetMachine (e.g. `opt -passes=CPUFeatures`).
+namespace {
+struct STIBuilder {
+    const Triple &TT;
+    const Target *T = nullptr;
+    StringMap<std::unique_ptr<MCSubtargetInfo>> cache;
+
+    explicit STIBuilder(const Triple &TT) : TT(TT) {
+        std::string Err;
+        T = TargetRegistry::lookupTarget(TT.str(), Err);
     }
-    return;
+
+    const MCSubtargetInfo *get(const Function &F) {
+        if (!T)
+            return nullptr;
+        StringRef CPU = F.getFnAttribute("target-cpu").getValueAsString();
+        StringRef FS = F.getFnAttribute("target-features").getValueAsString();
+        SmallString<256> key(CPU);
+        key += '\0';
+        key += FS;
+        auto &slot = cache[key];
+        if (!slot)
+            slot.reset(T->createMCSubtargetInfo(TT.str(), CPU, FS));
+        return slot.get();
+    }
+};
 }
 
-bool lowerCPUFeatures(Module &M) JL_NOTSAFEPOINT
+static const MCSubtargetInfo *getFunctionSubtarget(
+        const Function &F,
+        const TargetMachine *TM,
+        STIBuilder &fallback) JL_NOTSAFEPOINT
 {
-    auto TT = Triple(M.getTargetTriple());
-    SmallVector<Instruction*,6> Materialized;
+    if (TM)
+        return TM->getSubtargetImpl(F);
+    return fallback.get(F);
+}
 
-    for (auto &F: M.functions()) {
-        auto FN = F.getName();
+bool lowerCPUFeatures(Module &M, const TargetMachine *TM) JL_NOTSAFEPOINT
+{
+    Triple TT = Triple(M.getTargetTriple());
+    SmallVector<Instruction*, 6> Materialized;
+    STIBuilder fallback(TT);
+
+    for (auto &F : M.functions()) {
+        StringRef FN = F.getName();
 
         if (FN.starts_with("julia.cpu.have_fma.")) {
-            for (Use &U: F.uses()) {
-                User *RU = U.getUser();
-                CallInst *I = cast<CallInst>(RU);
-                lowerHaveFMA(F, *I->getParent()->getParent(), TT, I);
+            StringRef typ = FN.substr(strlen("julia.cpu.have_fma."));
+            for (Use &U : F.uses()) {
+                CallInst *I = cast<CallInst>(U.getUser());
+                Function *caller = I->getFunction();
+                const MCSubtargetInfo *STI = getFunctionSubtarget(*caller, TM, fallback);
+                bool result = STI && have_fma(typ, *STI, TT);
+                if (result)
+                    ++LoweredWithFMA;
+                else
+                    ++LoweredWithoutFMA;
+                I->replaceAllUsesWith(ConstantInt::get(I->getType(), result ? 1 : 0));
+                Materialized.push_back(I);
+            }
+        }
+        else if (FN.starts_with("julia.cpu.supports.")) {
+            StringRef feat = FN.substr(strlen("julia.cpu.supports."));
+            SmallString<64> query("+");
+            query += feat;
+            for (Use &U : F.uses()) {
+                CallInst *I = cast<CallInst>(U.getUser());
+                Function *caller = I->getFunction();
+                const MCSubtargetInfo *STI = getFunctionSubtarget(*caller, TM, fallback);
+                // checkFeatures matches unknown names vacuously; guard via the table.
+                bool known = false;
+                if (STI) {
+                    for (const auto &kv : STI->getAllProcessorFeatures()) {
+                        if (kv.Key == feat) { known = true; break; }
+                    }
+                }
+                bool result = known && STI->checkFeatures(query);
+                ++LoweredCPUSupports;
+                I->replaceAllUsesWith(ConstantInt::get(I->getType(), result ? 1 : 0));
                 Materialized.push_back(I);
             }
         }
     }
 
-    if (!Materialized.empty()) {
-        for (auto I: Materialized) {
-            I->eraseFromParent();
-        }
-#ifdef JL_VERIFY_PASSES
-        assert(!verifyLLVMIR(M));
-#endif
-        return true;
-    } else {
+    if (Materialized.empty())
         return false;
-    }
+    for (auto I : Materialized)
+        I->eraseFromParent();
+#ifdef JL_VERIFY_PASSES
+    assert(!verifyLLVMIR(M));
+#endif
+    return true;
 }
 
 PreservedAnalyses CPUFeaturesPass::run(Module &M, ModuleAnalysisManager &AM)
 {
-    if (lowerCPUFeatures(M)) {
+    if (lowerCPUFeatures(M, TM))
         return PreservedAnalyses::allInSet<CFGAnalyses>();
-    }
     return PreservedAnalyses::all();
 }

--- a/src/passes.h
+++ b/src/passes.h
@@ -9,6 +9,8 @@
 
 using namespace llvm;
 
+namespace llvm { class TargetMachine; }
+
 // Function Passes
 struct DemoteFloat16Pass : PassInfoMixin<DemoteFloat16Pass> {
     PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM) JL_NOTSAFEPOINT;
@@ -50,6 +52,8 @@ struct ExpandAtomicModifyPass : PassInfoMixin<ExpandAtomicModifyPass> {
 
 // Module Passes
 struct CPUFeaturesPass : PassInfoMixin<CPUFeaturesPass> {
+    const TargetMachine *TM;
+    explicit CPUFeaturesPass(const TargetMachine *TM = nullptr) JL_NOTSAFEPOINT : TM(TM) {}
     PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM) JL_NOTSAFEPOINT;
     static bool isRequired() { return true; }
 };

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -376,7 +376,7 @@ static void buildEarlySimplificationPipeline(ModulePassManager &MPM, PassBuilder
     MPM.addPass(AfterEarlySimplificationMarkerPass());
 }
 
-static void buildEarlyOptimizerPipeline(ModulePassManager &MPM, PassBuilder *PB, OptimizationLevel O, const OptimizationOptions &options) JL_NOTSAFEPOINT {
+static void buildEarlyOptimizerPipeline(ModulePassManager &MPM, PassBuilder *PB, OptimizationLevel O, const OptimizationOptions &options, const TargetMachine *TM) JL_NOTSAFEPOINT {
     MPM.addPass(BeforeEarlyOptimizationMarkerPass());
     if (options.enable_early_optimizations) {
       invokeOptimizerEarlyCallbacks(MPM, PB, O);
@@ -400,7 +400,7 @@ static void buildEarlyOptimizerPipeline(ModulePassManager &MPM, PassBuilder *PB,
           MPM.addPass(StripDeadPrototypesPass());
           JULIA_PASS(MPM.addPass(MultiVersioningPass(options.external_use)));
       }
-      JULIA_PASS(MPM.addPass(CPUFeaturesPass()));
+      JULIA_PASS(MPM.addPass(CPUFeaturesPass(TM)));
       if (O.getSpeedupLevel() >= 1) {
           FunctionPassManager FPM;
           if (O.getSpeedupLevel() >= 2) {
@@ -621,12 +621,12 @@ static void buildCleanupPipeline(ModulePassManager &MPM, PassBuilder *PB, Optimi
     MPM.addPass(AfterCleanupMarkerPass());
 }
 
-static void buildPipeline(ModulePassManager &MPM, PassBuilder *PB, OptimizationLevel O, const OptimizationOptions &options) JL_NOTSAFEPOINT {
+static void buildPipeline(ModulePassManager &MPM, PassBuilder *PB, OptimizationLevel O, const OptimizationOptions &options, const TargetMachine *TM = nullptr) JL_NOTSAFEPOINT {
     MPM.addPass(BeforeOptimizationMarkerPass());
     buildEarlySimplificationPipeline(MPM, PB, O, options);
     if (options.always_inline)
         MPM.addPass(AlwaysInlinerPass());
-    buildEarlyOptimizerPipeline(MPM, PB, O, options);
+    buildEarlyOptimizerPipeline(MPM, PB, O, options, TM);
     {
         FunctionPassManager FPM;
         buildLoopOptimizerPipeline(FPM, PB, O, options);
@@ -735,9 +735,9 @@ PIC.addClassToPassName(decltype(CREATE_PASS)::name(), NAME);
         return FAM;
     }
 
-    ModulePassManager createMPM(PassBuilder &PB, OptimizationLevel O, OptimizationOptions options) JL_NOTSAFEPOINT {
+    ModulePassManager createMPM(PassBuilder &PB, OptimizationLevel O, OptimizationOptions options, const TargetMachine *TM = nullptr) JL_NOTSAFEPOINT {
         ModulePassManager MPM;
-        buildPipeline(MPM, &PB, O, options);
+        buildPipeline(MPM, &PB, O, options, TM);
         return MPM;
     }
 }
@@ -972,7 +972,7 @@ void NewPM::run(Module &M) {
     PB.registerCGSCCAnalyses(CGAM);
     PB.registerModuleAnalyses(MAM);
     PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
-    ModulePassManager MPM = createMPM(PB, O, options);
+    ModulePassManager MPM = createMPM(PB, O, options, TM.get());
 #ifndef __clang_gcanalyzer__ /* the analyzer cannot prove we have not added instrumentation callbacks with safepoints */
     MPM.run(M, MAM);
 #endif

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -690,6 +690,17 @@ extern "C" int jl_test_cpu_feature(jl_cpu_feature_t feature)
     return feature_test(&host_feats, feature);
 }
 
+// Whether the JIT target supports `feature_name`. Backs the
+// jl_cpu_supports runtime fallback.
+extern "C" JL_DLLEXPORT int jl_host_cpu_supports(const char *feature_name)
+{
+    if (!feature_name || !*feature_name)
+        return 0;
+    if (jit_targets.empty())
+        return 0;
+    return tp::has_feature(jit_targets[0].en_features, feature_name);
+}
+
 // ============================================================================
 // Cross-architecture CPU/feature queries
 // ============================================================================
@@ -713,6 +724,26 @@ extern "C" JL_DLLEXPORT int jl_cpufeatures_lookup(const char *cpu_name,
         hw.bits[i] = entry->features.bits[i] & hw_feature_mask.bits[i];
     memcpy(features_out, &hw, sizeof(FeatureBits));
     return 0;
+}
+
+// Expand a CPU name to its JIT-ready features (comma-separated LLVM
+// names). Returns jl_nothing for unknown names. Backs Base.@cpu_supports.
+extern "C" JL_DLLEXPORT jl_value_t *jl_cpu_uarch_expand_features(const char *cpu_name)
+{
+    if (cpu_name == nullptr || *cpu_name == '\0')
+        return jl_nothing;
+    auto specs = tp::resolve_targets_for_llvm(cpu_name);
+    if (specs.empty() || (specs[0].flags & tp::TF_UNKNOWN_NAME))
+        return jl_nothing;
+    std::string names;
+    for (unsigned i = 0; i < num_features; i++) {
+        if (feature_test(&specs[0].en_features, feature_table[i].bit)) {
+            if (!names.empty())
+                names += ',';
+            names += feature_table[i].name;
+        }
+    }
+    return jl_pchar_to_string(names.data(), names.size());
 }
 
 extern "C" JL_DLLEXPORT void jl_cpufeatures_host(uint8_t *features_out, size_t bufsize)

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1727,6 +1727,7 @@ un_fintrinsic(rint_float,rint_llvm)
 un_fintrinsic(sqrt_float,sqrt_llvm)
 un_fintrinsic(sqrt_float,sqrt_llvm_fast)
 jl_value_t *jl_cpu_has_fma(int bits);
+int jl_host_cpu_supports(const char *feature_name);
 
 JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *typ)
 {
@@ -1737,6 +1738,12 @@ JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *typ)
         return jl_cpu_has_fma(64);
     else
         return jl_false;
+}
+
+JL_DLLEXPORT jl_value_t *jl_cpu_supports(jl_value_t *feat)
+{
+    JL_TYPECHK(cpu_supports, symbol, feat);
+    return jl_host_cpu_supports(jl_symbol_name((jl_sym_t*)feat)) ? jl_true : jl_false;
 }
 
 JL_DLLEXPORT jl_value_t *jl_add_ptr(jl_value_t *ptr, jl_value_t *offset)

--- a/test/llvmpasses/cpu-features-supports-aarch64.ll
+++ b/test/llvmpasses/cpu-features-supports-aarch64.ll
@@ -1,0 +1,112 @@
+; This file is a part of Julia. License is MIT: https://julialang.org/license
+
+; Same coverage as cpu-features-supports.ll, but targeting AArch64.
+
+; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -mtriple=aarch64-linux-gnu -passes='CPUFeatures,simplifycfg' -S %s | FileCheck %s
+; REQUIRES: aarch64
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64-linux-gnu"
+
+declare i1 @julia.cpu.supports.neon()
+declare i1 @julia.cpu.supports.sve()
+declare i1 @julia.cpu.supports.sve2()
+declare i1 @julia.cpu.supports.dotprod()
+declare i1 @julia.cpu.supports.fullfp16()
+
+declare i32 @sink_true()
+declare i32 @sink_false()
+
+; CHECK-LABEL: @explicit_neon
+; CHECK-NOT: julia.cpu.supports
+; CHECK: call i32 @sink_true
+define i32 @explicit_neon() #0 {
+  %v = call i1 @julia.cpu.supports.neon()
+  br i1 %v, label %T, label %F
+T:
+  %r1 = call i32 @sink_true()
+  ret i32 %r1
+F:
+  %r2 = call i32 @sink_false()
+  ret i32 %r2
+}
+
+; +sve2 implies +sve via the subtarget.
+; CHECK-LABEL: @sve2_implies_sve
+; CHECK-NOT: julia.cpu.supports
+; CHECK: call i32 @sink_true
+define i32 @sve2_implies_sve() #1 {
+  %v = call i1 @julia.cpu.supports.sve()
+  br i1 %v, label %T, label %F
+T:
+  %r1 = call i32 @sink_true()
+  ret i32 %r1
+F:
+  %r2 = call i32 @sink_false()
+  ret i32 %r2
+}
+
+; A target-cpu that has the feature folds to true.
+; CHECK-LABEL: @cortex_a78_has_dotprod
+; CHECK-NOT: julia.cpu.supports
+; CHECK: call i32 @sink_true
+define i32 @cortex_a78_has_dotprod() #2 {
+  %v = call i1 @julia.cpu.supports.dotprod()
+  br i1 %v, label %T, label %F
+T:
+  %r1 = call i32 @sink_true()
+  ret i32 %r1
+F:
+  %r2 = call i32 @sink_false()
+  ret i32 %r2
+}
+
+; Multiversioning shape: same body, different per-clone targets.
+; CHECK-LABEL: @clone_sve2
+; CHECK-NOT: julia.cpu.supports
+; CHECK: call i32 @sink_true
+define i32 @clone_sve2() #1 {
+  %v = call i1 @julia.cpu.supports.sve2()
+  br i1 %v, label %T, label %F
+T:
+  %r1 = call i32 @sink_true()
+  ret i32 %r1
+F:
+  %r2 = call i32 @sink_false()
+  ret i32 %r2
+}
+
+; CHECK-LABEL: @clone_a78
+; CHECK-NOT: julia.cpu.supports
+; CHECK: call i32 @sink_false
+define i32 @clone_a78() #2 {
+  %v = call i1 @julia.cpu.supports.sve2()
+  br i1 %v, label %T, label %F
+T:
+  %r1 = call i32 @sink_true()
+  ret i32 %r1
+F:
+  %r2 = call i32 @sink_false()
+  ret i32 %r2
+}
+
+; Unknown feature names fold to false (no vacuous match in checkFeatures).
+; CHECK-LABEL: @unknown_feature
+; CHECK-NOT: julia.cpu.supports
+; CHECK: call i32 @sink_false
+define i32 @unknown_feature() #1 {
+  %v = call i1 @julia.cpu.supports.totally_made_up_feature()
+  br i1 %v, label %T, label %F
+T:
+  %r1 = call i32 @sink_true()
+  ret i32 %r1
+F:
+  %r2 = call i32 @sink_false()
+  ret i32 %r2
+}
+
+declare i1 @julia.cpu.supports.totally_made_up_feature()
+
+attributes #0 = { "target-features"="+neon" }
+attributes #1 = { "target-features"="+sve2" }
+attributes #2 = { "target-cpu"="cortex-a78" }

--- a/test/llvmpasses/cpu-features-supports.ll
+++ b/test/llvmpasses/cpu-features-supports.ll
@@ -1,0 +1,159 @@
+; This file is a part of Julia. License is MIT: https://julialang.org/license
+
+; Verify the CPUFeatures pass folds julia.cpu.supports.* against each
+; function's per-attribute target-features / target-cpu. Covers:
+;   - feature implications (e.g. +avx512f implies +fma);
+;   - per-clone correctness — same body, different target-features per clone;
+;   - unknown feature names fold to false (no vacuous match).
+
+; RUN: opt --load-pass-plugin=libjulia-codegen%shlibext -mtriple=x86_64-linux-gnu -passes='CPUFeatures,simplifycfg' -S %s | FileCheck %s
+; REQUIRES: x86_64
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128-ni:10:11:12:13"
+target triple = "x86_64-linux-gnu"
+
+declare i1 @julia.cpu.supports.fma()
+declare i1 @julia.cpu.supports.avx2()
+declare i1 @julia.cpu.supports.avx512f()
+declare i1 @julia.cpu.supports.sse4.2()
+
+declare i32 @sink_true()
+declare i32 @sink_false()
+
+; CHECK-LABEL: @explicit_fma
+; CHECK-NOT: julia.cpu.supports
+; CHECK: call i32 @sink_true
+define i32 @explicit_fma() #0 {
+  %v = call i1 @julia.cpu.supports.fma()
+  br i1 %v, label %T, label %F
+T:
+  %r1 = call i32 @sink_true()
+  ret i32 %r1
+F:
+  %r2 = call i32 @sink_false()
+  ret i32 %r2
+}
+
+; +avx512f implies +fma via the subtarget.
+; CHECK-LABEL: @avx512f_implies_fma
+; CHECK-NOT: julia.cpu.supports
+; CHECK: call i32 @sink_true
+define i32 @avx512f_implies_fma() #1 {
+  %v = call i1 @julia.cpu.supports.fma()
+  br i1 %v, label %T, label %F
+T:
+  %r1 = call i32 @sink_true()
+  ret i32 %r1
+F:
+  %r2 = call i32 @sink_false()
+  ret i32 %r2
+}
+
+; CHECK-LABEL: @avx512f_implies_avx2
+; CHECK-NOT: julia.cpu.supports
+; CHECK: call i32 @sink_true
+define i32 @avx512f_implies_avx2() #1 {
+  %v = call i1 @julia.cpu.supports.avx2()
+  br i1 %v, label %T, label %F
+T:
+  %r1 = call i32 @sink_true()
+  ret i32 %r1
+F:
+  %r2 = call i32 @sink_false()
+  ret i32 %r2
+}
+
+; CHECK-LABEL: @no_fma
+; CHECK-NOT: julia.cpu.supports
+; CHECK: call i32 @sink_false
+define i32 @no_fma() #2 {
+  %v = call i1 @julia.cpu.supports.fma()
+  br i1 %v, label %T, label %F
+T:
+  %r1 = call i32 @sink_true()
+  ret i32 %r1
+F:
+  %r2 = call i32 @sink_false()
+  ret i32 %r2
+}
+
+; CHECK-LABEL: @sse42
+; CHECK-NOT: julia.cpu.supports
+; CHECK: call i32 @sink_true
+define i32 @sse42() #3 {
+  %v = call i1 @julia.cpu.supports.sse4.2()
+  br i1 %v, label %T, label %F
+T:
+  %r1 = call i32 @sink_true()
+  ret i32 %r1
+F:
+  %r2 = call i32 @sink_false()
+  ret i32 %r2
+}
+
+; Multiversioning shape: same body, three different per-clone targets.
+; CHECK-LABEL: @clone_avx512
+; CHECK-NOT: julia.cpu.supports
+; CHECK: call i32 @sink_true
+define i32 @clone_avx512() #1 {
+  %v = call i1 @julia.cpu.supports.avx512f()
+  br i1 %v, label %T, label %F
+T:
+  %r1 = call i32 @sink_true()
+  ret i32 %r1
+F:
+  %r2 = call i32 @sink_false()
+  ret i32 %r2
+}
+
+; CHECK-LABEL: @clone_haswell
+; CHECK-NOT: julia.cpu.supports
+; CHECK: call i32 @sink_false
+define i32 @clone_haswell() #4 {
+  %v = call i1 @julia.cpu.supports.avx512f()
+  br i1 %v, label %T, label %F
+T:
+  %r1 = call i32 @sink_true()
+  ret i32 %r1
+F:
+  %r2 = call i32 @sink_false()
+  ret i32 %r2
+}
+
+; CHECK-LABEL: @clone_generic
+; CHECK-NOT: julia.cpu.supports
+; CHECK: call i32 @sink_false
+define i32 @clone_generic() #5 {
+  %v = call i1 @julia.cpu.supports.avx2()
+  br i1 %v, label %T, label %F
+T:
+  %r1 = call i32 @sink_true()
+  ret i32 %r1
+F:
+  %r2 = call i32 @sink_false()
+  ret i32 %r2
+}
+
+; Unknown feature names fold to false (no vacuous match in checkFeatures).
+; CHECK-LABEL: @unknown_feature
+; CHECK-NOT: julia.cpu.supports
+; CHECK: call i32 @sink_false
+define i32 @unknown_feature() #1 {
+  %v = call i1 @julia.cpu.supports.totally_made_up_feature()
+  br i1 %v, label %T, label %F
+T:
+  %r1 = call i32 @sink_true()
+  ret i32 %r1
+F:
+  %r2 = call i32 @sink_false()
+  ret i32 %r2
+}
+
+declare i1 @julia.cpu.supports.totally_made_up_feature()
+
+attributes #0 = { "target-features"="+fma" }
+attributes #1 = { "target-features"="+avx512f" }
+attributes #2 = { "target-features"="-fma" }
+attributes #3 = { "target-features"="+sse4.2" }
+attributes #4 = { "target-cpu"="haswell" }
+attributes #5 = { "target-cpu"="x86-64" }

--- a/test/llvmpasses/cpu-supports-macro-aarch64.jl
+++ b/test/llvmpasses/cpu-supports-macro-aarch64.jl
@@ -1,0 +1,80 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# RUN: julia --startup-file=no %s %t -O && llvm-link -S %t/* -o %t/module.ll
+# RUN: cat %t/module.ll | FileCheck %s
+# REQUIRES: aarch64
+
+# Same coverage as cpu-supports-macro.jl, but for AArch64.
+
+include(joinpath("..", "testhelpers", "llvmpasses.jl"))
+
+# CHECK-LABEL: @julia_query_neon
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK: ret i8 {{[01]}}
+query_neon() = Base.@cpu_supports aarch64 neon
+emit(query_neon)
+
+# Multiple features ANDed.
+# CHECK-LABEL: @julia_query_multi
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK: ret i8 {{[01]}}
+query_multi() = Base.@cpu_supports aarch64 neon "fp-armv8"
+emit(query_multi)
+
+# Hyphenated name via String literal.
+# CHECK-LABEL: @julia_query_v82a
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK: ret i8 {{[01]}}
+query_v82a() = Base.@cpu_supports aarch64 "v8.2a"
+emit(query_v82a)
+
+# CPU-model expansion.
+# CHECK-LABEL: @julia_query_a78
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK: ret i8 {{[01]}}
+query_a78() = Base.@cpu_supports aarch64 "cortex-a78"
+emit(query_a78)
+
+# Cross-arch prefix: x86_64 on aarch64 host folds to false at parse time.
+# CHECK-LABEL: @julia_query_crossarch
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK: ret i8 0
+query_crossarch() = Base.@cpu_supports x86_64 avx2
+emit(query_crossarch)
+
+# Branch dispatch: dead arm eliminated.
+# CHECK-LABEL: @julia_dispatch
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK-NOT: br i1
+@inline dispatch(x) = (Base.@cpu_supports aarch64 neon) ? x * 2 : x + 1
+emit(dispatch, Int)
+
+# Assert true: folds to no-op.
+# CHECK-LABEL: @julia_assert_holds
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK-NOT: AssertionError
+# CHECK: ret i64
+function assert_holds(x::Int)
+    @assert Base.@cpu_supports aarch64 neon
+    return x * 2
+end
+emit(assert_holds, Int)
+
+# Assert false via the __never__ sentinel (arch-independent).
+# CHECK-LABEL: @julia_assert_fails
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK-NOT: 10000
+# CHECK: AssertionError
+function assert_fails(x::Int)
+    @assert Base.@cpu_supports __never__
+    return x * 10000
+end
+emit(assert_fails, Int)

--- a/test/llvmpasses/cpu-supports-macro.jl
+++ b/test/llvmpasses/cpu-supports-macro.jl
@@ -1,0 +1,97 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# RUN: julia --startup-file=no %s %t -O && llvm-link -S %t/* -o %t/module.ll
+# RUN: cat %t/module.ll | FileCheck %s
+# REQUIRES: x86_64
+
+# Verify that Base.@cpu_supports folds to constants and dead branches
+# are eliminated by the CPUFeatures pass + cleanup.
+
+include(joinpath("..", "testhelpers", "llvmpasses.jl"))
+
+# CHECK-LABEL: @julia_query_avx2
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK: ret i8 {{[01]}}
+query_avx2() = Base.@cpu_supports x86_64 avx2
+emit(query_avx2)
+
+# Multiple features ANDed.
+# CHECK-LABEL: @julia_query_multi
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK: ret i8 {{[01]}}
+query_multi() = Base.@cpu_supports x86_64 avx2 fma bmi2
+emit(query_multi)
+
+# Dotted name via String literal.
+# CHECK-LABEL: @julia_query_sse42
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK: ret i8 {{[01]}}
+query_sse42() = Base.@cpu_supports x86_64 "sse4.2"
+emit(query_sse42)
+
+# CPU-model expansion: all ~30 haswell feature queries collapse to one constant.
+# CHECK-LABEL: @julia_query_haswell
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK: ret i8 {{[01]}}
+query_haswell() = Base.@cpu_supports x86_64 haswell
+emit(query_haswell)
+
+# psABI level via the CPU table.
+# CHECK-LABEL: @julia_query_v3
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK: ret i8 {{[01]}}
+query_v3() = Base.@cpu_supports x86_64 "x86-64-v3"
+emit(query_v3)
+
+# Mixed feature + CPU model.
+# CHECK-LABEL: @julia_query_mixed
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK: ret i8 {{[01]}}
+query_mixed() = Base.@cpu_supports x86_64 avx2 haswell
+emit(query_mixed)
+
+# Cross-arch prefix: aarch64 on x86 host folds to false at parse time.
+# CHECK-LABEL: @julia_query_crossarch
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK: ret i8 0
+query_crossarch() = Base.@cpu_supports aarch64 neon
+emit(query_crossarch)
+
+# Branch dispatch: dead arm eliminated.
+# CHECK-LABEL: @julia_dispatch
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK-NOT: br i1
+@inline dispatch(x) = (Base.@cpu_supports x86_64 avx2) ? x * 2 : x + 1
+emit(dispatch, Int)
+
+# Assert true: folds to no-op (no comparison or throw).
+# CHECK-LABEL: @julia_assert_holds
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK-NOT: AssertionError
+# CHECK: ret i64
+function assert_holds(x::Int)
+    @assert Base.@cpu_supports x86_64 avx2
+    return x * 2
+end
+emit(assert_holds, Int)
+
+# Assert false via the __never__ sentinel (arch-independent).
+# CHECK-LABEL: @julia_assert_fails
+# CHECK-NOT: julia.cpu.supports
+# CHECK-NOT: ijl_cpu_supports
+# CHECK-NOT: 10000
+# CHECK: AssertionError
+function assert_fails(x::Int)
+    @assert Base.@cpu_supports __never__
+    return x * 10000
+end
+emit(assert_fails, Int)

--- a/test/llvmpasses/lit.cfg.py
+++ b/test/llvmpasses/lit.cfg.py
@@ -17,3 +17,5 @@ config.environment['HOME'] = "/tmp"
 
 if platform.machine() == "x86_64":
     config.available_features.add('x86_64')
+elif platform.machine() in ("aarch64", "arm64"):
+    config.available_features.add('aarch64')


### PR DESCRIPTION
## Summary

Adds a Julia analog of GCC/Clang's `__builtin_cpu_supports` as a compile-time macro that requires an explicit architecture prefix, with CPU-model expansion as a superset feature:

```julia
@cpu_supports x86_64 avx2 fma bmi2    # raw LLVM feature names, ANDed
@cpu_supports x86_64 "sse4.2"         # hyphenated/dotted names via String literal
@cpu_supports x86_64 haswell          # CPU model → expanded to its feature set
@cpu_supports x86_64 "x86-64-v3"      # psABI baselines (via the CPU table)
@cpu_supports aarch64 neon "fp-armv8" # arch prefix scopes the lookup
```

The arch prefix (one of `x86_64`, `aarch64`, `arm64`, `riscv64`) is **required**, not optional. On a host of a different arch the call folds to `false` at parse time — making cross-arch dispatch in a single source file natural:

```julia
function dot(xs, ys)
    if @cpu_supports x86_64 avx2 fma
        ...   # 256-bit path
    elseif @cpu_supports aarch64 neon
        ...   # NEON path
    else
        ...   # fallback
    end
end
```

The macro validates at parse time (typos and cross-feature/CPU lookups against the explicit arch's table; misuse errors at the macro call site, mirroring Clang's source-line errors) and expands to a conjunction of `Core.Intrinsics.cpu_supports(:literal)` calls. The `CPUFeatures` pass folds each call at codegen time using the function's per-attribute `MCSubtargetInfo` via `TargetMachine::getSubtargetImpl(F)` — the same machinery the LLVM backend uses for its own codegen, so the fold picks up:

- **feature implications** (e.g. `+avx512f` implies `+fma` — fixes a latent bug where the old hand-rolled `have_fma` string scan only matched `+fma` exactly)
- **`target-cpu`-implied features** (e.g. `znver4` has FMA without an explicit `+fma` in `target-features`)
- **per-function `target-features` set by multiversioning**, so each clone folds against its own target

CPU-model arguments route through a new `jl_cpu_target_features` C function which calls `tp::resolve_targets_for_llvm` — the same code path multiversioning uses — so the feature set for a CPU matches what a sysimg clone targeting that CPU would actually have: hw-masked and with non-deterministic features (rdrnd/rdseed/xsaveopt on x86) stripped.

### Pass changes

The pass now receives `TargetMachine` via its constructor (threaded through `buildPipeline` / `createMPM`); it no longer reads from `jl_ExecutionEngine` and stays strictly LLVM-only. A `TargetRegistry`-based fallback supports invoking the pass via `opt -passes=CPUFeatures` outside the Julia pipeline. The pass branches on:

- `julia.cpu.have_fma.<typ>` (existing) — now uses `MCSubtargetInfo::checkFeatures` (implication-aware)
- `julia.cpu.supports.<feat>` (new) — same machinery; unknown names fold to `false` (the macro's parse-time validation makes them unreachable through normal usage, but the raw intrinsic is safe)

`jl_cpu_has_feature` (backing the runtime fallback for `Core.Intrinsics.cpu_supports`) now queries the JIT target's `en_features` rather than raw host CPUID, so the runtime fallback gives the same answer as `@cpu_supports`'s constant-fold path for default-target code.

### Behavior summary

| Call | Result |
|---|---|
| `@cpu_supports x86_64 avx2` on x86 with AVX2 | `true` (folded) |
| `@cpu_supports x86_64 avx2` on aarch64 | `false` (folded at parse time, no validation of `avx2`) |
| `@cpu_supports x86_64 not_a_real_feature` on x86 | parse-time error |
| `@cpu_supports xtensa avx2` | parse-time error (bad arch) |
| `@cpu_supports avx2` (no arch) | parse-time error (helpful syntax message) |
| `Core.Intrinsics.cpu_supports(:not_a_real_feature)` direct | folds to `false` (pass guards vacuous match) |

### Folding evidence

A function calling `@cpu_supports` compiles all the way down — no `julia.cpu.supports.*` placeholder, no runtime `jl_cpu_supports` call, no branch:

```llvm
define i8 @julia_query_haswell_0() { ret i8 1 }              ; on Zen4 host

dispatch(x) = (@cpu_supports x86_64 avx2) ? x*2 : x+1
  →  define i64 @julia_dispatch_0(i64 %x) { %0 = shl i64 %x, 1   ret i64 %0 }
```

## Test plan

- [x] `test/llvmpasses/cpu-features-supports.ll` — IR-level (x86 triple): verifies implications (`+avx512f` ⇒ `+fma`), per-clone correctness with three multiversioning-shape clones, `-feat` overrides, hyphenated names, and unknown-name folding.
- [x] `test/llvmpasses/cpu-features-supports-aarch64.ll` — IR-level (aarch64 triple): same coverage with `+neon`/`+sve`/`+sve2` and `cortex-a78`.
- [x] `test/llvmpasses/cpu-supports-macro.jl` — Julia-level (x86 host): `emit()` + FileCheck verifies the full `@cpu_supports` macro pipeline collapses to a single constant `ret i8 {0|1}` for: single feature, multi-feature AND, dotted name, CPU model, psABI level, mixed feature+CPU, **cross-arch prefix folding to literal 0**, branch dispatch (no `br i1`, dead arm eliminated), `@assert` true (no-op), `@assert` false (body DCE'd).
- [x] `test/llvmpasses/cpu-supports-macro-aarch64.jl` — Julia-level (aarch64 host): mirrors the x86 version.
- [x] Existing `test/llvmpasses/cpu-features.ll` (legacy `have_fma`) still passes.

## What's not in this PR

- **Cache-size queries** (`l1d_cache_size`, `l2_cache_size`): LLVM's `TTI::getCacheSize` is hardcoded sentinels on x86 (32 KiB L1D, 256 KiB L2D for every CPU regardless of `-mcpu`) and `nullopt` on every other backend. Exposing it would be misleading. Users who need real cache sizes should use OS APIs (`sysconf(_SC_LEVEL1_DCACHE_SIZE)`, `sysctlbyname`, etc.) at runtime.
- **`cache_line_size` query**: `TTI::getCacheLineSize` returns 0 on X86 (no override) and 0 on RISC-V (field exists, no processor populates). Only PowerPC, SystemZ, LoongArch, Hexagon, and ~17 specific AArch64 CPUs return non-zero. A query that returns 0 on the dominant target is a worse API than no query.
- **SIMD width queries** (`getRegisterBitWidth`): these are well-supported by LLVM (drive LoopVectorize itself) and worth exposing as a follow-up. Left out of this PR for review hygiene; one small follow-up will add `@cpu_query :simd_bits` and friends.

This pull request was written with the assistance of generative AI ([Claude Code](https://claude.com/claude-code)).
