### PR TITLE
ios: reset buffer state on lseek failure

### DIFF
--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -466,10 +466,12 @@ int64_t ios_seek(ios_t *s, int64_t pos)
     else {
         ios_flush(s);
         int64_t fdpos = lseek(s->fd, (off_t)pos, SEEK_SET);
+        // Clear even when lseek fails (ESPIPE on pipes/sockets), else stale
+        // read data leaks into the next write+flush (#50410).
+        s->bpos = s->size = 0;
         if (fdpos == (int64_t)-1)
             return fdpos;
         s->fpos = fdpos;
-        s->bpos = s->size = 0;
     }
     return 0;
 }
@@ -483,10 +485,11 @@ int64_t ios_seek_end(ios_t *s)
     else {
         ios_flush(s);
         int64_t fdpos = lseek(s->fd, 0, SEEK_END);
+        // See #50410: reset buffer state even on lseek failure.
+        s->bpos = s->size = 0;
         if (fdpos == (int64_t)-1)
             return fdpos;
         s->fpos = fdpos;
-        s->bpos = s->size = 0;
     }
     return 0;
 }
@@ -523,11 +526,12 @@ int64_t ios_skip(ios_t *s, int64_t offs)
         else if (s->state == bst_rd)
             offs -= (s->size - s->bpos);
         int64_t fdpos = lseek(s->fd, (off_t)offs, SEEK_CUR);
+        // See #50410: reset buffer state even on lseek failure.
+        s->bpos = s->size = 0;
+        s->_eof = 0;
         if (fdpos == (int64_t)-1)
             return fdpos;
         s->fpos = fdpos;
-        s->bpos = s->size = 0;
-        s->_eof = 0;
     }
     return 0;
 }

--- a/test/iostream.jl
+++ b/test/iostream.jl
@@ -194,3 +194,40 @@ end
 @testset "fd" begin
     @test open(fd, tempname(), "w") isa RawFD
 end
+
+# Regression for #50410: when the underlying lseek fails (sockets, pipes,
+# serial devices), the R->W transition must reset the buffer so previously
+# prefetched read bytes don't leak into the next write+flush.
+@testset "issue #50410 (ios_seek must reset buffer on lseek failure)" begin
+    if Sys.isunix()
+        fds = Vector{Cint}(undef, 2)
+        @test ccall(:socketpair, Cint, (Cint, Cint, Cint, Ptr{Cint}),
+                    Cint(1) #= AF_UNIX =#, Cint(1) #= SOCK_STREAM =#, 0, fds) == 0
+        try
+            prefill = b"PREFILL!"
+            @test ccall(:write, Cssize_t, (Cint, Ptr{UInt8}, Csize_t),
+                        fds[1], prefill, length(prefill)) == length(prefill)
+            io = fdio(fds[2], false)
+            try
+                # Prefetch the queued bytes into the IOStream's internal
+                # buffer; consume only the first, leaving the rest
+                # logically read but still physically in buf[1..size].
+                @test read(io, UInt8) == prefill[1]
+                # Write+flush one byte. With the bug, the prefetched
+                # bytes are appended in front of 'Z' on the wire.
+                write(io, UInt8('Z'))
+                flush(io)
+                got = Vector{UInt8}(undef, 32)
+                n = ccall(:read, Cssize_t, (Cint, Ptr{UInt8}, Csize_t),
+                         fds[1], got, length(got))
+                @test n == 1
+                @test got[1] == UInt8('Z')
+            finally
+                close(io)
+            end
+        finally
+            ccall(:close, Cint, (Cint,), fds[1])
+            ccall(:close, Cint, (Cint,), fds[2])
+        end
+    end
+end


### PR DESCRIPTION
Fixes #50410.

## Summary

`ios_seek`, `ios_seek_end`, and `ios_skip` only reset the internal buffer state (`bpos`, `size`) on the success path of `lseek`. On non-seekable streams (sockets, pipes, serial devices) `lseek` fails with `ESPIPE` and the buffer is left holding read-side data that has already been returned to the user. When the caller then does a write (R→W transition in `ios_write`, which uses `ios_seek` to flush+reposition), the write lands in `buf[bpos]`, past the residual data, and the next `flush` sends those previously-read bytes back out over the wire.

This is the symptom the reporter observed on `/dev/ttyACM0`: writes echo back data the program just read from the serial device.

## Trace

Reading 1 byte from a socketpair that has 8 bytes queued leaves:
- `state = bst_rd`, `buf = [P,R,E,F,I,L,L,!]`, `bpos = 1`, `size = 8`

Then `write(io, 'Z'); flush(io)`:
1. `ios_write` sees `state == bst_rd` and calls `ios_seek(s, ios_pos(s))`.
2. `ios_pos` calls `lseek(fd, 0, SEEK_CUR)` → `ESPIPE`, returns `-1`.
3. `ios_seek(s, -1)` calls `lseek(fd, -1, SEEK_SET)` → fails.
4. `ios_seek` returns early without resetting `bpos`/`size`.
5. Back in `ios_write`: `memcpy(buf + bpos, &Z, 1)` writes at `buf[1]`.
6. `flush` writes `buf[0..2] = "PZ"` to the fd.

## Fix

In all three seek functions, reset `bpos`/`size` after `lseek` regardless of whether it succeeded. `ios_flush` (which runs above) has already invalidated the buffer's relationship to the file position, so preserving the stale contents is never the right answer.

## Test

Added `test/iostream.jl` regression test using `socketpair(AF_UNIX, SOCK_STREAM)`, which exhibits the same `ESPIPE`-on-lseek behavior without needing serial hardware. With the fix, only the intended byte (`Z`) is sent; before the fix, the prefetched read data leaks (`PZ`).

Verified:
- `make test-iostream` (68/68 incl. new test)
- `make test-file` (1217/1217)
- `make test-read` (6636/6636)
- Full Julia rebuild (sysimg loading exercises `ios_seek` heavily on real files)

## Disclosure

This pull request was developed with assistance from a generative AI coding agent (REI). The diagnosis, fix, and regression test were reviewed by the author before submission, per the contribution policy in \`CONTRIBUTING.md\` / \`AGENTS.md\`.