### PR TITLE
Preserve line number on generator methods

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -1807,9 +1807,9 @@ types of AST object inside, and even may sometimes evaluate and interpolate any
 quoted(@nospecialize(x)) = isa_ast_node(x) ? QuoteNode(x) : x
 
 # Implementation of generated functions
-function generated_body_to_codeinfo(ex::Expr, defmod::Module, isva::Bool)
-    ci = ccall(:jl_fl_lower, Any, (Any, Any, Ptr{UInt8}, Csize_t, Csize_t, Cint),
-               ex, defmod, "none", 0, typemax(Csize_t), 0)[1]
+function generated_body_to_codeinfo(ex::Expr, defmod::Module, isva::Bool, loc::LineNumberNode)
+    ci = ccall(:jl_fl_lower, Any, (Any, Any, Cstring, Csize_t, Csize_t, Cint),
+               ex, defmod, loc.file, loc.line, typemax(Csize_t), 0)[1]
     if !isa(ci, CodeInfo)
         if isa(ci, Expr) && ci.head === :error
             msg = ci.args[1]
@@ -1838,15 +1838,18 @@ function (g::Core.GeneratedFunctionStub)(world::UInt, source::Method, @nospecial
     body = g.gen(args...)
     file = source.file
     file isa Symbol || (file = :none)
+    loc = LineNumberNode(Int(source.line), source.file)
     lam = Expr(:lambda, Expr(:argnames, g.argnames...).args,
                Expr(:var"scope-block",
                     Expr(:block,
-                         LineNumberNode(Int(source.line), source.file),
+                         loc,
                          Expr(:meta, :push_loc, file, :var"@generated body"),
                          Expr(:return, Expr(:toplevel_pure, body)),
                          Expr(:meta, :pop_loc))))
     spnames = g.spnames
-    return generated_body_to_codeinfo(spnames === Core.svec() ? lam : Expr(Symbol("with-static-parameters"), lam, spnames...),
+    return generated_body_to_codeinfo(
+        spnames === Core.svec() ? lam : Expr(Symbol("with-static-parameters"), lam, spnames...),
         source.module,
-        source.isva)
+        source.isva,
+        loc)
 end

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -1808,7 +1808,7 @@ quoted(@nospecialize(x)) = isa_ast_node(x) ? QuoteNode(x) : x
 
 # Implementation of generated functions
 function generated_body_to_codeinfo(ex::Expr, defmod::Module, isva::Bool, loc::LineNumberNode)
-    ci = ccall(:jl_fl_lower, Any, (Any, Any, Cstring, Csize_t, Csize_t, Cint),
+    ci = ccall(:jl_fl_lower, Any, (Any, Any, Ptr{UInt8}, Csize_t, Csize_t, Cint),
                ex, defmod, loc.file, loc.line, typemax(Csize_t), 0)[1]
     if !isa(ci, CodeInfo)
         if isa(ci, Expr) && ci.head === :error

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9344,7 +9344,8 @@ static jl_llvm_functions_t
                             info.loc = DILocation::get(ctx.builder.getContext(), info.line, col, SP, NULL);
                         }
                         else { // otherwise, describe this as an inlining frame
-                            DebugLoc inl_loc = new_lineinfo.empty() ? DebugLoc(DILocation::get(ctx.builder.getContext(), 0, 0, SP, NULL)) : new_lineinfo.back().loc;
+                            assert(!new_lineinfo.empty());
+                            DebugLoc inl_loc = new_lineinfo.back().loc;
                             DISubprogram *&inl_SP = subprograms[std::make_tuple(fname, info.file)];
                             if (inl_SP == NULL) {
                                 DIFile *difile = dbuilder.createFile(info.file, ".");

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9344,8 +9344,7 @@ static jl_llvm_functions_t
                             info.loc = DILocation::get(ctx.builder.getContext(), info.line, col, SP, NULL);
                         }
                         else { // otherwise, describe this as an inlining frame
-                            assert(!new_lineinfo.empty());
-                            DebugLoc inl_loc = new_lineinfo.back().loc;
+                            DebugLoc inl_loc = new_lineinfo.empty() ? DebugLoc(DILocation::get(ctx.builder.getContext(), 0, 0, SP, NULL)) : new_lineinfo.back().loc;
                             DISubprogram *&inl_SP = subprograms[std::make_tuple(fname, info.file)];
                             if (inl_SP == NULL) {
                                 DIFile *difile = dbuilder.createFile(info.file, ".");

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -306,7 +306,7 @@
                (map (lambda (x) (replace-vars x renames))
                     (cdr e))))))
 
-(define (make-generator-function name sp-names arg-names body)
+(define (make-generator-function name sp-names arg-names body loc)
   (let ((arg-names (append sp-names
                            (map (lambda (n)
                                   (if (eq? n '|#self#|) (gensy) n))
@@ -316,7 +316,7 @@
                                    `((meta nospecialize ,@(map (lambda (idx) `(slot ,(+ idx 2))) (iota (length arg-names))))))))
       `(block
         (global ,name)
-        (function (call ,name ,@arg-names) ,body)))))
+        (function (call ,name ,@arg-names) (block ,loc ,@(cdr body)))))))
 
 ;; select the `then` or `else` part of `if @generated` based on flag `genpart`
 (define (generated-part- x genpart)
@@ -393,7 +393,7 @@
                            (let* ((gen    (generated-version body))
                                   (nongen (non-generated-version body))
                                   (gname  (symbol (string "#" (current-julia-module-counter '()) "#" (current-julia-module-counter '()))))
-                                  (gf     (make-generator-function gname names anames gen)))
+                                  (gf     (make-generator-function gname names anames gen loc)))
                              (set! body (insert-after-meta
                                          nongen
                                          `((meta generated

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -479,3 +479,38 @@ module GeneratedScope57417
 end
 
 @test_throws "syntax: expression too large" code_lowered(ntuple, (Returns{Nothing}, Val{1000000}))
+
+# test that generated methods also have reasonable line numbers
+f_generated_lno1_lower_bound = @__LINE__()
+function f_generated_lno1(x)
+    if @generated
+        :(x)
+    else
+        "nongen"
+    end
+end
+
+@test f_generated_lno1(1) == 1
+let m = methods(f_generated_lno1)[1]
+    @test m.line > f_generated_lno1_lower_bound
+    @test m.file |> string == @__FILE__()
+    let mgen = methods(m.generator.gen)[1]
+        @test mgen.line > f_generated_lno1_lower_bound
+        @test mgen.file |> string == @__FILE__()
+    end
+end
+
+f_generated_lno2_lower_bound = @__LINE__()
+@generated function f_generated_lno2(x)
+    :(x)
+end
+
+@test f_generated_lno2(1) == 1
+let m = methods(f_generated_lno2)[1]
+    @test m.line > f_generated_lno2_lower_bound
+    @test m.file |> string == @__FILE__()
+    let mgen = methods(m.generator.gen)[1]
+        @test mgen.line > f_generated_lno2_lower_bound
+        @test mgen.file |> string == @__FILE__()
+    end
+end

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -490,7 +490,7 @@ function f_generated_lno1(x)
     end
 end
 
-@test f_generated_lno1(1) == 1
+@test f_generated_lno1(1) == 1 || f_generated_lno1(1) == "nongen"
 let m = methods(f_generated_lno1)[1]
     @test m.line > f_generated_lno1_lower_bound
     @test m.file |> string == @__FILE__()
@@ -505,7 +505,7 @@ f_generated_lno2_lower_bound = @__LINE__()
     :(x)
 end
 
-@test f_generated_lno2(1) == 1
+@test f_generated_lno2(1) == 1 || f_generated_lno2(1) == "nongen"
 let m = methods(f_generated_lno2)[1]
     @test m.line > f_generated_lno2_lower_bound
     @test m.file |> string == @__FILE__()

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -480,7 +480,7 @@ end
 
 @test_throws "syntax: expression too large" code_lowered(ntuple, (Returns{Nothing}, Val{1000000}))
 
-# test that generated methods also have reasonable line numbers
+# test that generator methods also have reasonable line numbers
 f_generated_lno1_lower_bound = @__LINE__()
 function f_generated_lno1(x)
     if @generated


### PR DESCRIPTION
An attempt to reduce garbage debuginfo that codegen needs to deal with: stop dropping provenance when producing generator methods in lowering, and generated expressions from `generated_body_to_codeinfo`.  This change appears to let us rule out a case in codegen, but I'll see what CI thinks.  The other changes are a provenance improvement regardless.