### PR TITLE
ranges: avoid silent overflow in intersect(::StepRange, ::StepRange)

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -1191,10 +1191,40 @@ intersect(i::Integer, r::AbstractUnitRange{<:Integer}) = range(max(i, first(r)),
 
 intersect(r::AbstractUnitRange{<:Integer}, i::Integer) = intersect(i, r)
 
+# Empty StepRange{T,S}; the obvious sentinel `fr - sr` wraps at the type boundary
+# in narrow integer types and would yield a non-empty range (#47577). Swap
+# start/stop when the boundary is hit so the empty range stays empty. When `fr`
+# or `sr` can't be represented in `T`/`S` (e.g. mixed-signedness promotion gives
+# unsigned `T` but `fr` is a negative signed value), fall back to a canonical
+# empty range whose values are representable.
+function _empty_steprange(::Type{T}, ::Type{S}, fr::Integer, sr::Integer) where {T,S}
+    if isbitstype(T) && isbitstype(S) &&
+            typemin(T) <= fr <= typemax(T) && typemin(S) <= sr <= typemax(S)
+        o = oneunit(T)
+        if sr > zero(sr)
+            return fr > typemin(T) ? StepRange{T,S}(fr, sr, fr - o) : StepRange{T,S}(fr + o, sr, fr)
+        else
+            return fr < typemax(T) ? StepRange{T,S}(fr, sr, fr + o) : StepRange{T,S}(fr - o, sr, fr)
+        end
+    end
+    if !isbitstype(T)
+        # Unbounded integers (e.g. `BigInt`) have no `typemin`/`typemax`; the
+        # naive `fr - sr` sentinel can't wrap, so use the generic fallback shape.
+        return StepRange{T,S}(fr, sr, fr - sr)
+    end
+    if S <: Unsigned || sr > zero(sr)
+        return StepRange{T,S}(oneunit(T), oneunit(S), zero(T))
+    else
+        return StepRange{T,S}(zero(T), -oneunit(S), oneunit(T))
+    end
+end
+_empty_steprange(::Type{T}, ::Type{S}, fr, sr) where {T,S} =
+    StepRange{T,S}(fr, sr, fr - sr)
+
 function intersect(r::AbstractUnitRange{<:Integer}, s::StepRange{<:Integer})
     T = promote_type(eltype(r), eltype(s))
     if isempty(s)
-        StepRange{T}(first(r), +step(s), first(r)-step(s))
+        _empty_steprange(T, typeof(+step(s)), first(r), +step(s))
     else
         sta, ste, sto = first_step_last_ascending(s)
         lo = first(r)
@@ -1225,7 +1255,7 @@ function intersect(r::StepRange, s::StepRange)
     T = promote_type(eltype(r), eltype(s))
     S = promote_type(typeof(step(r)), typeof(step(s)))
     if isempty(r) || isempty(s)
-        return StepRange{T,S}(first(r), step(r), first(r)-step(r))
+        return _empty_steprange(T, S, first(r), step(r))
     end
 
     start1, step1, stop1 = first_step_last_ascending(r)
@@ -1233,14 +1263,11 @@ function intersect(r::StepRange, s::StepRange)
     a = lcm(step1, step2)
 
     g, x, y = gcdx(step1, step2)
+    rev = step(r) < zero(step(r))
 
     if !iszero(rem(start1 - start2, g))
-        # Unaligned, no overlap possible.
-        if  step(r) < zero(step(r))
-            return StepRange{T,S}(stop1, -a, stop1+a)
-        else
-            return StepRange{T,S}(start1, a, start1-a)
-        end
+        return rev ? _empty_steprange(T, S, last(r), step(r)) :
+                     _empty_steprange(T, S, first(r), step(r))
     end
 
     z = div(start1 - start2, g)
@@ -1250,7 +1277,49 @@ function intersect(r::StepRange, s::StepRange)
     # Determine where in the sequence to start and stop.
     m = max(start1 + mod(b - start1, a), start2 + mod(b - start2, a))
     n = min(stop1 - mod(stop1 - b, a), stop2 - mod(stop2 - b, a))
-    step(r) < zero(step(r)) ? StepRange{T,S}(n, -a, m) : StepRange{T,S}(m, a, n)
+    rev ? StepRange{T,S}(n, -a, m) : StepRange{T,S}(m, a, n)
+end
+
+# For Integer step-ranges, do the CRT and bounds computation in widen(T) to
+# avoid silent wrap on narrow types (#47577). The original implementation
+# computed `b = start1 - x*z*step1` in T, which overflowed for inputs as small
+# as `intersect(Int8(0):Int8(20):Int8(120), Int8(40):Int8(50):Int8(90))`
+# (intersection at 40, lost to wrap). It also wraps for Int64 starts near 2^60.
+# The m/n bound computation must also widen: `stop_i - b` (= span_i + i*step1)
+# can wrap in T even when every CRT input fits T. For unsigned `T`, widen to
+# a *signed* wider type, otherwise the difference and `gcdx` still wrap and
+# signed-negative inputs from a mixed-signedness promotion can't convert. When
+# `S` is unsigned, the output step must be non-negative; descending `r` is
+# rendered ascending.
+function intersect(r::StepRange{<:Integer}, s::StepRange{<:Integer})
+    T = promote_type(eltype(r), eltype(s))
+    S = promote_type(typeof(step(r)), typeof(step(s)))
+    if isempty(r) || isempty(s)
+        return _empty_steprange(T, S, first(r), step(r))
+    end
+    start1, step1, stop1 = first_step_last_ascending(r)
+    start2, step2, stop2 = first_step_last_ascending(s)
+    rev = step(r) < zero(step(r)) && !(S <: Unsigned)
+    W = T <: Unsigned ? signed(widen(T)) : widen(T)
+    ws1, ws2 = W(start1), W(start2)
+    wst1, wst2 = W(step1), W(step2)
+    g, x, _ = gcdx(wst1, wst2)
+    d = ws1 - ws2
+    if !iszero(rem(d, g))
+        return rev ? _empty_steprange(T, S, last(r), step(r)) :
+                     _empty_steprange(T, S, first(r), step(r))
+    end
+    a = (wst1 * wst2) ÷ g
+    # Reduce CRT coefficient mod step2÷g so |i*step1| < a; b stays bounded.
+    i = mod(div(d, g) * x, div(wst2, g))
+    b = ws1 - i * wst1
+    m = max(ws1 + mod(b - ws1, a), ws2 + mod(b - ws2, a))
+    n = min(W(stop1) - mod(W(stop1) - b, a), W(stop2) - mod(W(stop2) - b, a))
+    if m > n
+        return rev ? _empty_steprange(T, S, last(r), step(r)) :
+                     _empty_steprange(T, S, first(r), step(r))
+    end
+    rev ? StepRange{T,S}(T(n), -S(a), T(m)) : StepRange{T,S}(T(m), S(a), T(n))
 end
 
 function intersect(r1::AbstractRange, r2::AbstractRange)

--- a/base/range.jl
+++ b/base/range.jl
@@ -1319,6 +1319,13 @@ function intersect(r::StepRange{<:Integer}, s::StepRange{<:Integer})
         return rev ? _empty_steprange(T, S, last(r), step(r)) :
                      _empty_steprange(T, S, first(r), step(r))
     end
+    if m == n && !(typemin(S) <= a <= typemax(S))
+        # Single-point intersection whose nominal step (lcm) doesn't fit `S`.
+        # The result is representable as a one-element range; fall back to
+        # `oneunit(S)` rather than throwing `InexactError` from the constructor.
+        sa = oneunit(S)
+        return StepRange{T,S}(T(m), rev ? -sa : sa, T(m))
+    end
     rev ? StepRange{T,S}(T(n), -S(a), T(m)) : StepRange{T,S}(T(m), S(a), T(n))
 end
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -1300,6 +1300,40 @@ function intersect(r::StepRange{<:Integer}, s::StepRange{<:Integer})
     start1, step1, stop1 = first_step_last_ascending(r)
     start2, step2, stop2 = first_step_last_ascending(s)
     rev = step(r) < zero(step(r)) && !(S <: Unsigned)
+    # Signed types with native widening (Int64→Int128) take a fast path that
+    # stays in T for the CRT, falling back to the wide path on overflow.
+    # Smaller signed and all unsigned types go straight to the wide path,
+    # since their widen is cheap (or, for UInt, the with_overflow ladder
+    # interacts badly with `gcdx` Bezout coefficients).
+    if T <: Signed && sizeof(T) >= 8
+        g, x, _ = gcdx(step1, step2)
+        d, ovf = Base.Checked.sub_with_overflow(start1, start2)
+        if !ovf
+            if !iszero(rem(d, g))
+                return rev ? _empty_steprange(T, S, last(r), step(r)) :
+                             _empty_steprange(T, S, first(r), step(r))
+            end
+            zq, ovf = Base.Checked.mul_with_overflow(div(d, g), x)
+            if !ovf
+                p, ovf = Base.Checked.mul_with_overflow(step1, step2)
+                if !ovf
+                    W = widen(T)
+                    i = mod(zq, div(step2, g))
+                    # |i| < step2÷g and step1*step2 fits T, so
+                    # i*step1 < step1*step2÷g ≤ typemax(T).
+                    return _intersect_steprange_bounds(T, S, r,
+                        W(start1), W(stop1), W(start2), W(stop2),
+                        W(p ÷ g), W(start1) - W(i * step1), rev)
+                end
+            end
+        end
+    end
+    return _intersect_steprange_wide(T, S, r, start1, step1, stop1, start2, step2, stop2, rev)
+end
+
+function _intersect_steprange_wide(::Type{T}, ::Type{S}, r,
+        start1, step1, stop1, start2, step2, stop2, rev) where {T,S}
+    @noinline
     W = T <: Unsigned ? signed(widen(T)) : widen(T)
     ws1, ws2 = W(start1), W(start2)
     wst1, wst2 = W(step1), W(step2)
@@ -1310,19 +1344,20 @@ function intersect(r::StepRange{<:Integer}, s::StepRange{<:Integer})
                      _empty_steprange(T, S, first(r), step(r))
     end
     a = (wst1 * wst2) ÷ g
-    # Reduce CRT coefficient mod step2÷g so |i*step1| < a; b stays bounded.
     i = mod(div(d, g) * x, div(wst2, g))
     b = ws1 - i * wst1
-    m = max(ws1 + mod(b - ws1, a), ws2 + mod(b - ws2, a))
-    n = min(W(stop1) - mod(W(stop1) - b, a), W(stop2) - mod(W(stop2) - b, a))
+    return _intersect_steprange_bounds(T, S, r, ws1, W(stop1), ws2, W(stop2), a, b, rev)
+end
+
+function _intersect_steprange_bounds(::Type{T}, ::Type{S}, r,
+        start1, stop1, start2, stop2, a, b, rev) where {T,S}
+    m = max(start1 + mod(b - start1, a), start2 + mod(b - start2, a))
+    n = min(stop1 - mod(stop1 - b, a), stop2 - mod(stop2 - b, a))
     if m > n
         return rev ? _empty_steprange(T, S, last(r), step(r)) :
                      _empty_steprange(T, S, first(r), step(r))
     end
     if m == n && !(typemin(S) <= a <= typemax(S))
-        # Single-point intersection whose nominal step (lcm) doesn't fit `S`.
-        # The result is representable as a one-element range; fall back to
-        # `oneunit(S)` rather than throwing `InexactError` from the constructor.
         sa = oneunit(S)
         return StepRange{T,S}(T(m), rev ? -sa : sa, T(m))
     end

--- a/base/range.jl
+++ b/base/range.jl
@@ -1333,7 +1333,6 @@ end
 
 function _intersect_steprange_wide(::Type{T}, ::Type{S}, r,
         start1, step1, stop1, start2, step2, stop2, rev) where {T,S}
-    @noinline
     W = T <: Unsigned ? signed(widen(T)) : widen(T)
     ws1, ws2 = W(start1), W(start2)
     wst1, wst2 = W(step1), W(step2)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -640,6 +640,16 @@ end
             @test step(intersect(reverse(u), v)) == Int8(-1)
         end
 
+        @testset "Int64 fast-path wide fallback" begin
+            # `step1 * step2` overflows Int64 (~2^66), so the fast path bails to
+            # the widened (Int128) fallback. The two ranges are aligned mod
+            # gcd(step1, step2) only at a single point: 0 mod 2^33 and 0 mod
+            # (2^32 * 5) coincide only at 0, but neither range contains 0.
+            big_a = Int64(2)^32 * 3
+            big_b = Int64(2)^32 * 5
+            @test isempty(intersect(Int64(1):big_a:Int64(2)^60, Int64(2):big_b:Int64(2)^60))
+        end
+
         @testset "Two AbstractRanges" begin
             struct DummyRange{T} <: AbstractRange{T}
                 r

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -626,6 +626,20 @@ end
                   UInt[0,2,4,6,8,10,12,14,16,18,20]
         end
 
+        @testset "single-point intersection with lcm > typemax(S)" begin
+            # `lcm(125, 127) == 15875` doesn't fit `Int8`; the result is still a
+            # one-element range, so the step falls back to `oneunit(S)` rather
+            # than throwing `InexactError` from the StepRange constructor.
+            u = StepRange{Int8, Int8}(Int8(0):Int8(125):Int8(125))
+            v = StepRange{Int8, Int8}(Int8(0):Int8(127):Int8(127))
+            @test intersect(u, v) == [Int8(0)]
+            @test intersect(v, u) == [Int8(0)]
+            @test step(intersect(u, v)) == Int8(1)
+            # Reverse-step variant uses `-oneunit(S)`.
+            @test intersect(reverse(u), v) == [Int8(0)]
+            @test step(intersect(reverse(u), v)) == Int8(-1)
+        end
+
         @testset "Two AbstractRanges" begin
             struct DummyRange{T} <: AbstractRange{T}
                 r

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -568,6 +568,64 @@ end
                 start:Day(5):stop-Day(10)-mod(stop-start, Day(5))
         end
 
+        @testset "narrow integer overflow (#47577)" begin
+            # Empty-range sentinel `first(r) - step(r)` silently wrapped in narrow
+            # integer types and produced non-empty ranges.
+            a, b = StepRange{Int8, Int8}.((-56:121:-56, 35:62:34))
+            @test isempty(intersect(a, b))
+            @test isempty(intersect(b, a))
+            ur = Int8(-100):Int8(-90)
+            es = StepRange{Int8, Int8}(Int8(50):Int8(62):Int8(35))
+            @test isempty(intersect(ur, es))
+            @test isempty(intersect(es, ur))
+            # Unaligned no-overlap: same wrap previously in `start1 - a` / `stop1 + a`.
+            c = StepRange{Int8, Int8}(Int8(-127):Int8(4):Int8(120))
+            d = StepRange{Int8, Int8}(Int8(0):Int8(6):Int8(120))
+            @test isempty(intersect(c, d))
+            @test isempty(intersect(d, c))
+            # CRT product `x*z*step1` overflowed in T; widening + reducing the
+            # coefficient mod step2÷g recovers the correct intersection {40}.
+            p = StepRange{Int8, Int8}(Int8(0):Int8(20):Int8(120))
+            q = StepRange{Int8, Int8}(Int8(40):Int8(50):Int8(90))
+            @test intersect(p, q) == [Int8(40)]
+            @test intersect(q, p) == [Int8(40)]
+            # Int64 starts near 2^60: the unwidened `x*z*step1` overflows Int64.
+            @test intersect(Int64(2)^60 : Int64(7) : Int64(2)^60 + 50,
+                            Int64(0) : Int64(11) : Int64(2)^61) == [Int64(2)^60 + 21]
+            # Type boundary: `first(r) == typemin(T)` with positive step previously
+            # made the empty sentinel `fr - oneunit` wrap.
+            tmin_r = StepRange{Int8, Int8}(typemin(Int8), Int8(2), Int8(120))
+            odds   = StepRange{Int8, Int8}(Int8(1), Int8(2), Int8(121))
+            @test isempty(intersect(tmin_r, odds))
+            @test isempty(intersect(odds, tmin_r))
+            # `stop1 - b` (= span1 + i*step1) overflows in T even when every CRT
+            # input fits T; the m/n bounds must be computed in widen(T).
+            rb = StepRange{Int8, Int8}(Int8(-100), Int8(2), Int8(120))
+            sb = StepRange{Int8, Int8}(Int8(0),    Int8(3), Int8(120))
+            @test intersect(rb, sb) == Int8(0):Int8(6):Int8(120)
+            @test intersect(sb, rb) == Int8(0):Int8(6):Int8(120)
+        end
+
+        @testset "unsigned and mixed-signedness" begin
+            # Unsigned widening still wraps; the wide path needs a signed widen.
+            @test intersect(UInt8(0):UInt8(3):UInt8(9),
+                            UInt8(3):UInt8(3):UInt8(9)) == UInt8[3, 6, 9]
+            # Unsigned `S` can't carry a negative step; descending `r` must
+            # produce ascending output.
+            @test intersect(10:-1:0, UInt(0):UInt(1):UInt(10)) ==
+                  UInt[0,1,2,3,4,5,6,7,8,9,10]
+            # Signed-negative input can't convert to unsigned `widen(T)`; the
+            # signed widen avoids `InexactError`, and the unaligned check
+            # returns a representable empty range.
+            let r = intersect(-1:2:5, UInt(2):UInt(2):UInt(6))
+                @test isempty(r)
+                @test eltype(r) === UInt
+            end
+            @test intersect(-2:2:8, UInt(0):UInt(2):UInt(6)) == UInt[0,2,4,6]
+            @test intersect(20:-2:-10, UInt(0):UInt(2):UInt(20)) ==
+                  UInt[0,2,4,6,8,10,12,14,16,18,20]
+        end
+
         @testset "Two AbstractRanges" begin
             struct DummyRange{T} <: AbstractRange{T}
                 r


### PR DESCRIPTION
`intersect(::StepRange, ::StepRange)` had two wrap-around bugs for narrow
integer element types:

1. The "construct an empty range" sentinel `first(r) - step(r)` silently
   wrapped at the type boundary, turning a logically empty result into a
   non-empty one. The issue example:

   ```julia
   julia> a, b = StepRange{Int8,Int8}.((-56:121:-56, 35:62:34));
   julia> collect(intersect(a, b))   # before: values in neither input
   Int8[-56, 65]
   ```

2. The CRT representative `b = start1 - x*z*step1` was computed in the
   input element type and silently wrapped. For example, on `Int8`:

   ```julia
   julia> intersect(Int8(0):Int8(20):Int8(120), Int8(40):Int8(50):Int8(90))
   # before: wrong (silent wrap)
   # actual answer: [Int8(40)]
   ```

   The same wrap also affects `Int64` starts near `2^60`.

The previous revision threw `OverflowError`; per @adienes's review, the
right answer is to widen, since these intersections are recoverable.
This revision is structured as three commits, each independently
reviewable:

**1. `ranges: fix silent overflow in intersect(::StepRange, ::StepRange)`**

Adds a `_empty_steprange` helper that swaps start/stop at the type
boundary so the empty sentinel never wraps. Adds a specialized
`intersect(::StepRange{<:Integer}, ::StepRange{<:Integer})` that
performs the CRT and bounds computation in `widen(T)`. The CRT
coefficient is reduced mod `step2÷g` so `|i*step1| < lcm`, keeping `b`
bounded. The bounds also widen because `stop_i - b` can wrap in `T`
even when the CRT inputs fit `T`. This is the minimum viable fix.

**2. `ranges: representable single-point intersection when lcm doesn't fit step type`**

After commit 1, single-point intersections whose nominal step
`lcm(step1, step2)` exceeds `typemax(S)` throw `InexactError` from the
`StepRange{T,S}` constructor (e.g.
`intersect(Int8(0):Int8(125):Int8(125), Int8(0):Int8(127):Int8(127))`).
The one-element result is representable, so fall back to `oneunit(S)`
as the step. This is a deliberate behavior addition over the pre-PR
status quo — the constructor never threw before because the buggy CRT
silently produced an in-range step.

**3. `ranges: fast path for wide-Signed intersect avoiding widen() arithmetic`**

Pure perf refactor. For `T <: Signed && sizeof(T) >= 8` (`Int64`,
`Int128`), try the CRT in `T` with `Base.Checked.*_with_overflow`,
falling back to the widened path on overflow. Matters most for
`Int128`, where `widen(Int128) == BigInt` and the wide path otherwise
allocates on every call. `Int8`/`Int16`/`Int32` and unsigned types skip
the fast path.

The generic `intersect(::StepRange, ::StepRange)` keeps its original
arithmetic for non-`Integer` step types (e.g. `Day` over `Date`).

Fixes #47577

---

This pull request was developed with assistance from a generative AI
coding agent (REI). The diagnosis, fix, and regression tests were
reviewed by the author before submission, per the contribution policy
in CONTRIBUTING.md / AGENTS.md.