### PR TITLE
complex: fix NaN in complex^complex from intermediate over/underflow

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -843,17 +843,23 @@ function _cpow(z::Union{T,Complex{T}}, p::Union{T,Complex{T}}) where T
         else
             r = -zᵣ
             θ = copysign(Tf(π),imag(z))
-            # compute |z|^p in log space to avoid Inf*0 NaNs when
-            # r^pᵣ overflows and exp(-pᵢ*θ) underflows (or vice versa)
-            rᵖ = exp(pᵣ*log(r) - pᵢ*θ)
-            ϕ = pᵣ*θ + pᵢ*log(r)
+            logr = log(r)
+            re_log, im_phase = pᵣ*logr, pᵢ*θ
+            lim = log(floatmax(Tf)) - one(Tf)
+            rᵖ = (abs(re_log) < lim && abs(im_phase) < lim) ?
+                r^pᵣ * exp(-im_phase) : exp(re_log - im_phase)
+            ϕ = pᵣ*θ + pᵢ*logr
         end
     else
         pᵣ, pᵢ = reim(p)
         r = abs(z)
         θ = angle(z)
-        rᵖ = exp(pᵣ*log(r) - pᵢ*θ)
-        ϕ = pᵣ*θ + pᵢ*log(r)
+        logr = log(r)
+        re_log, im_phase = pᵣ*logr, pᵢ*θ
+        lim = log(floatmax(Tf)) - one(Tf)
+        rᵖ = (abs(re_log) < lim && abs(im_phase) < lim) ?
+            r^pᵣ * exp(-im_phase) : exp(re_log - im_phase)
+        ϕ = pᵣ*θ + pᵢ*logr
     end
 
     if isfinite(ϕ)

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -843,14 +843,16 @@ function _cpow(z::Union{T,Complex{T}}, p::Union{T,Complex{T}}) where T
         else
             r = -zᵣ
             θ = copysign(Tf(π),imag(z))
-            rᵖ = r^pᵣ * exp(-pᵢ*θ)
+            # compute |z|^p in log space to avoid Inf*0 NaNs when
+            # r^pᵣ overflows and exp(-pᵢ*θ) underflows (or vice versa)
+            rᵖ = exp(pᵣ*log(r) - pᵢ*θ)
             ϕ = pᵣ*θ + pᵢ*log(r)
         end
     else
         pᵣ, pᵢ = reim(p)
         r = abs(z)
         θ = angle(z)
-        rᵖ = r^pᵣ * exp(-pᵢ*θ)
+        rᵖ = exp(pᵣ*log(r) - pᵢ*θ)
         ϕ = pᵣ*θ + pᵢ*log(r)
     end
 

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1213,6 +1213,12 @@ end
     # negative real z, complex p hits the same formula
     @test isfinite((-2.0+0.0im)^(1e5*(1+im)))
     @test iszero((-2.0+0.0im)^(1e5*(1+im)))
+    # safe path keeps r^pᵣ's extra precision that exp(pᵣ*log(r)) loses
+    @test abs((2.0+1.0im)^(100.0+0.001im)) ≈ Float64(abs(big(2.0+1.0im)^big(100.0+0.001im))) rtol=40*eps()
+    @test abs((-3.0+0.0im)^(200.0+1e-6im)) ≈ Float64(abs(big(-3.0+0.0im)^big(200.0+1e-6im))) rtol=10*eps()
+    # type-aware threshold: a Float64-sized lim would re-introduce #54692 on Float32
+    @test isfinite(Complex{Float32}(1, 1) ^ Complex{Float32}(300, 300))
+    @test isfinite(Complex{Float32}(-2, 0) ^ Complex{Float32}(130, 40))
 
     # cases where phase angle is non-finite yield NaN + NaN*im:
     @test NaN + NaN*im ≟ Inf ^ (2 + 3im) ≟ (Inf + 1im) ^ (2 + 3im) ≟ (Inf*im) ^ (2 + 3im) ≟

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1203,6 +1203,17 @@ end
     @test_broken (Inf + 1im)^3 === (Inf + 1im)^3.0 === (Inf + 1im)^(3+0im) === Inf + Inf*im
     @test_broken (Inf + 1im)^3.1 === (Inf + 1im)^(3.1+0im) === Inf + Inf*im
 
+    # issue #54692: r^pᵣ * exp(-pᵢ*θ) could combine overflow with underflow
+    # and yield NaN where the true magnitude exp(pᵣ*log(r) - pᵢ*θ) is finite.
+    let a = exp(1+im), b = 1e5*(1+im)
+        @test a^b ≈ cis(2e5)
+        @test abs(a^b) ≈ 1
+        @test a^b * a^(-b) ≈ 1
+    end
+    # negative real z, complex p hits the same formula
+    @test isfinite((-2.0+0.0im)^(1e5*(1+im)))
+    @test iszero((-2.0+0.0im)^(1e5*(1+im)))
+
     # cases where phase angle is non-finite yield NaN + NaN*im:
     @test NaN + NaN*im ≟ Inf ^ (2 + 3im) ≟ (Inf + 1im) ^ (2 + 3im) ≟ (Inf*im) ^ (2 + 3im) ≟
           3^(Inf*im) ≟ (-3)^(Inf + 0im) ≟ (-3)^(Inf + 1im) ≟ (3+1im)^Inf ≟


### PR DESCRIPTION
`_cpow` decomposed `|z|^p` as `r^pᵣ * exp(-pᵢ*θ)`. When the two
factors land at opposite extremes — one overflowing to `Inf`, the
other underflowing to 0 — the product is `NaN` even when the true
magnitude `exp(pᵣ*log(r) - pᵢ*θ)` is representable.

For example, `exp(1+im) ^ (1e5 * (1+im))` returned `NaN+NaN*im` on
master; the correct answer is `cis(2e5)` (magnitude 1).

Compute the magnitude in log space instead. `log(r)` is already
needed for the phase angle, so this is also one fewer transcendental
call per evaluation. Affects both the general `Complex^Complex` path
and the negative-real-`z` `Complex^Complex` path.

Fixes #54692

This pull request was developed with assistance from a generative AI
coding agent (REI). The diagnosis, fix, and regression test were
reviewed by the author before submission, per the contribution policy
in CONTRIBUTING.md / AGENTS.md.