### PR TITLE
operators: fix Integer shift fallback for arbitrary-precision types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,12 @@ New language features
 Language changes
 ----------------
 
+  - The abstract `<<`/`>>`/`>>>` fallbacks for `Integer` now throw `OverflowError`
+    on a shift count whose magnitude exceeds `typemax(Int)` when the value type
+    has no `typemax` (e.g. `BigInt` and user-defined arbitrary-precision integer
+    types). Previously such shifts silently returned `0`. Fixed-width integer
+    types (including `Bool`) retain the existing saturating behavior ([#57502]).
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -698,6 +698,10 @@ Left bit shift operator, `x << n`. For `n >= 0`, the result is `x` shifted left
 by `n` bits, filling with `0`s. This is equivalent to `x * 2^n`. For `n < 0`,
 this is equivalent to `x >> -n`.
 
+For arbitrary-precision integer types such as `BigInt`, a shift count whose
+magnitude exceeds `typemax(Int)` throws `OverflowError` rather than silently
+returning `0`, since no fixed bit width is available to saturate against.
+
 # Examples
 ```jldoctest
 julia> Int8(3) << 2
@@ -714,15 +718,27 @@ See also [`>>`](@ref), [`>>>`](@ref), [`exp2`](@ref), [`ldexp`](@ref).
 function <<(x::Integer, c::Integer)
     @inline
     typemin(Int) <= c <= typemax(Int) && return x << (c % Int)
-    (x >= 0 || c >= 0) && return zero(x) << 0  # for type stability
-    oftype(x, -1)
+    if hastypemax(typeof(x))
+        # Fixed-width: shifting past the bit width saturates.
+        (x >= 0 || c >= 0) && return zero(x) << 0  # for type stability
+        return oftype(x, -1)
+    end
+    # Arbitrary-precision: a huge left shift cannot be silently squashed
+    # to zero; only `x == 0` is invariant. A huge negative count is a huge
+    # right shift, which still sign-extends.
+    iszero(x) && return x
+    c >= 0 && throw(OverflowError(LazyString("shift count ", c, " is too large")))
+    x >= 0 ? zero(x) : oftype(x, -1)
 end
 function <<(x::Integer, c::Unsigned)
     @inline
     if c isa UInt
         throw(MethodError(<<, (x, c)))
     end
-    c <= typemax(UInt) ? x << (c % UInt) : zero(x) << UInt(0)
+    c <= typemax(UInt) && return x << (c % UInt)
+    hastypemax(typeof(x)) && return zero(x) << UInt(0)
+    iszero(x) && return x
+    throw(OverflowError(LazyString("shift count ", c, " is too large")))
 end
 <<(x::Integer, c::Int) = c >= 0 ? x << unsigned(c) : x >> unsigned(-c)
 
@@ -762,8 +778,17 @@ function >>(x::Integer, c::Integer)
         throw(MethodError(>>, (x, c)))
     end
     typemin(Int) <= c <= typemax(Int) && return x >> (c % Int)
-    (x >= 0 || c < 0) && return zero(x) >> 0
-    oftype(x, -1)
+    if hastypemax(typeof(x))
+        # Fixed-width: right shift past width sign-extends; huge negative
+        # count is a huge left shift, which saturates.
+        (x >= 0 || c < 0) && return zero(x) >> 0
+        return oftype(x, -1)
+    end
+    # Arbitrary-precision: huge right shift sign-extends; huge negative
+    # count is a huge left shift, which cannot be silently squashed.
+    iszero(x) && return x
+    c < 0 && throw(OverflowError(LazyString("shift count ", c, " is too large")))
+    x >= 0 ? zero(x) : oftype(x, -1)
 end
 >>(x::Integer, c::Int) = c >= 0 ? x >> unsigned(c) : x << unsigned(-c)
 
@@ -796,14 +821,22 @@ See also [`>>`](@ref), [`<<`](@ref).
 """
 function >>>(x::Integer, c::Integer)
     @inline
-    typemin(Int) <= c <= typemax(Int) ? x >>> (c % Int) : zero(x) >>> 0
+    typemin(Int) <= c <= typemax(Int) && return x >>> (c % Int)
+    hastypemax(typeof(x)) && return zero(x) >>> 0
+    # Arbitrary-precision: `>>>` matches `>>` since there is no fixed
+    # width to zero-fill within.
+    iszero(x) && return x
+    c < 0 && throw(OverflowError(LazyString("shift count ", c, " is too large")))
+    x >= 0 ? zero(x) : oftype(x, -1)
 end
 function >>>(x::Integer, c::Unsigned)
     @inline
     if c isa UInt
         throw(MethodError(>>>, (x, c)))
     end
-    c <= typemax(UInt) ? x >>> (c % UInt) : zero(x) >>> 0
+    c <= typemax(UInt) && return x >>> (c % UInt)
+    hastypemax(typeof(x)) && return zero(x) >>> 0
+    x >= 0 ? zero(x) : oftype(x, -1)
 end
 >>>(x::Integer, c::Int) = c >= 0 ? x >>> unsigned(c) : x << unsigned(-c)
 

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -208,6 +208,30 @@ end
     @test BigInt(5) << -1 == 2
     @test BigInt(-5) >> -3 == -40
     @test BigInt(-5) << -1 == -3
+
+    # shift counts outside the Int range: left shift throws OverflowError,
+    # right shift sign-extends since BigInt has no fixed width (#57502)
+    let huge = big(2)^1000
+        @test_throws OverflowError BigInt(2) << huge
+        @test_throws OverflowError BigInt(-2) << huge
+        @test BigInt(0) << huge == 0
+        @test BigInt(0) >> huge == 0
+        @test BigInt(2) >> huge == 0
+        @test BigInt(-2) >> huge == -1
+        @test BigInt(2) >>> huge == 0
+        @test BigInt(-2) >>> huge == -1
+        @test_throws OverflowError BigInt(2) >> -huge
+        @test BigInt(2) << -huge == 0
+        @test BigInt(-2) << -huge == -1
+    end
+    for c in (typemax(Int128), typemax(UInt128))
+        @test_throws OverflowError BigInt(2) << c
+        @test BigInt(0) << c == 0
+        @test BigInt(2) >> c == 0
+        @test BigInt(-2) >> c == -1
+        @test BigInt(2) >>> c == 0
+        @test BigInt(-2) >>> c == -1
+    end
 end
 @testset "boolean ops" begin
     @test ~BigInt(123) == -124

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -433,3 +433,34 @@ end
     end == Bool
     @test Base.infer_return_type(in, (Symbol,Tuple{Vararg{String}})) == Bool
 end
+
+# Regression test for #57502: huge shift on an unbounded Integer subtype
+# must not silently return 0.
+@testset "shift fallback on unbounded Integer subtypes" begin
+    struct UnboundedInt <: Integer
+        v::BigInt
+    end
+    Base.iszero(x::UnboundedInt) = iszero(x.v)
+    Base.zero(::UnboundedInt) = UnboundedInt(BigInt(0))
+    Base.:(>=)(x::UnboundedInt, y::Integer) = x.v >= y
+    Base.oftype(::UnboundedInt, y) = UnboundedInt(BigInt(y))
+    Base.:(==)(x::UnboundedInt, y::Integer) = x.v == y
+
+    @test !Base.hastypemax(UnboundedInt)
+
+    huge = big(2)^1000
+    pos, neg, z = UnboundedInt(big(2)), UnboundedInt(big(-2)), UnboundedInt(big(0))
+
+    @test_throws OverflowError pos << huge
+    @test_throws OverflowError neg << huge
+    @test z << huge == 0
+    @test pos >> huge == 0
+    @test neg >> huge == -1
+    @test z >> huge == 0
+    @test pos >>> huge == 0
+    @test neg >>> huge == -1
+    @test_throws OverflowError pos >> -huge
+    @test_throws OverflowError pos >>> -huge
+    @test pos << -huge == 0
+    @test neg << -huge == -1
+end


### PR DESCRIPTION
The abstract `<<(::Integer, ::Integer)` fallback (and its `>>`/`>>>`
counterparts) silently returns 0 or -1 on shift counts outside the Int
range, which is only semantically correct for fixed-width integers. Any
arbitrary-precision Integer subtype inherits the same silent-zero bug, so
`big"2" << big(2)^1000` returned `0` instead of overflowing.

Dispatch the fallback on `Base.hastypemax(typeof(x))`:

* Fixed-width branch — preserves the existing saturating behavior, so
  `Int8(1) << big(2)^1000`, `true << big(2)^1000`, and any user-defined
  bounded Integer keep returning 0 / -1.
* Arbitrary-precision branch — throws `OverflowError` on a huge left
  shift of a non-zero value (or a huge negative `>>`/`>>>`); huge right
  shifts continue to sign-extend, which is exact for any finite-magnitude
  value.

This makes the abstract method semantically correct regardless of which
Integer subtype hits it, without regressing fixed-width semantics or the
hot in-range path.

Adds a regression test in test/operators.jl using a synthetic
non-`BitInteger` unbounded subtype to exercise the fallback path directly.

Fixes #57502

---

This pull request was developed with assistance from a generative AI
coding agent (REI). The diagnosis, fix, and regression test were
reviewed by the author before submission, per the contribution policy
in CONTRIBUTING.md / AGENTS.md.
