### PR TITLE
fix: duplicated words in signals-unix.c and desugaring.jl comments

### DIFF
--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -2271,7 +2271,7 @@ end
 # - `typevar_stmts` are a list of statements to define a `TypeVar` for each parameter
 #   name in `typevar_names`, with exactly one per `typevar_name`. Some of these
 #   may already have been emitted.
-# - `new_typevar_stmts` is the list of statements which needs to to be emitted
+# - `new_typevar_stmts` is the list of statements which needs to be emitted
 #   prior to uses of `typevar_names`.
 
 # (where (where x a b) c d) -> (x, [c d a b])

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -1302,7 +1302,7 @@ static void sigtrap_handler(int sig, siginfo_t *info, void *context)
     uint32_t* code = (uint32_t*)(pc);                              // https://gcc.gnu.org/legacy-ml/gcc-patches/2013-11/msg02228.html
     if (*code == 0xd4200020) { // brk #0x1 which is what LLVM defines as trap
         signal(sig, SIG_DFL);
-        sig = SIGILL; // redefine this as as an "unreachable reached" error message
+        sig = SIGILL; // redefine this as an "unreachable reached" error message
         sigdie_handler(sig, info, context);
     }
 }


### PR DESCRIPTION
Two one-line typo fixes for duplicated words in source comments:
- `src/signals-unix.c` — "redefine this as as an \"unreachable reached\" error message" → "redefine this as an \"unreachable reached\" error message"
- `JuliaLowering/src/desugaring.jl` — "is the list of statements which needs to to be emitted" → "...which needs to be emitted"

No code/behavior change.