### PR TITLE
ranges: detect integer overflow when constructing StepRangeLen

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -527,8 +527,36 @@ struct StepRangeLen{T,R,S,L<:Integer} <: AbstractRange{T}
         offset = convert(L, offset)
         L1 = oneunit(typeof(len))
         L1 <= offset <= max(L1, len) || throw(ArgumentError("StepRangeLen: offset must be in [1,$len], got $offset"))
+        _rangecheck(T, ref, step, len, offset)
         return new(ref, step, len, offset)
     end
+end
+
+# Detect silent integer wraparound when constructing a StepRangeLen. The element at
+# index `i` is computed as `ref + (i - offset) * step`, with the final result
+# converted to the element type `T`. When `T == typeof(ref) == typeof(step)` is a
+# hardware signed integer, that arithmetic runs entirely in `T` and can wrap
+# silently, so we use checked arithmetic on both endpoints. For other type
+# combinations (mixed widths, wider `T` than `ref`/`step`, user numeric types,
+# BigInt, unsigned moduli, floats) we silently no-op and leave existing behavior
+# unchanged.
+_rangecheck(::Type, ref, step, len::Integer, offset::Integer) = nothing
+function _rangecheck(::Type{T}, ref::T, step::T, len::Integer, offset::Integer) where {T<:Union{Int8,Int16,Int32,Int64,Int128}}
+    iszero(len) && return nothing
+    Tlen = T(len)
+    Toff = T(offset)
+    u_lo, of1 = Base.Checked.sub_with_overflow(one(T), Toff)
+    u_hi, of2 = Base.Checked.sub_with_overflow(Tlen, Toff)
+    p_lo, of3 = Base.Checked.mul_with_overflow(u_lo, step)
+    p_hi, of4 = Base.Checked.mul_with_overflow(u_hi, step)
+    _,    of5 = Base.Checked.add_with_overflow(p_lo, ref)
+    _,    of6 = Base.Checked.add_with_overflow(p_hi, ref)
+    if of1 | of2 | of3 | of4 | of5 | of6
+        @noinline
+        throw(ArgumentError(LazyString("StepRangeLen: arithmetic overflow constructing range with ref=",
+                                       ref, ", step=", step, ", len=", len)))
+    end
+    return nothing
 end
 
 StepRangeLen{T,R,S}(ref::R, step::S, len::Integer, offset::Integer = 1) where {T,R,S} =

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -781,6 +781,46 @@ end
     end
 end
 
+# Detect silent overflow when a StepRangeLen with hardware signed integer ref/step
+# would produce wrapped elements at its endpoints. Non-integer ref/step (and types
+# we cannot inspect) construct silently, as before.
+@testset "StepRangeLen overflow detection on construction (#59032)" begin
+    @testset "$T" for T in (Int8, Int16, Int32, Int64, Int128)
+        # multiplying (len-1) by step overflows
+        @test_throws ArgumentError StepRangeLen{T}(zero(T), typemax(T), 3)
+        # ref + (len-1)*step overflows on the positive side
+        @test_throws ArgumentError StepRangeLen{T}(typemax(T) - T(5), T(10), 3)
+        # ref + (len-1)*step overflows on the negative side
+        @test_throws ArgumentError StepRangeLen{T}(typemin(T) + T(5), -T(10), 3)
+        # overflow on the lower endpoint via a large offset
+        @test_throws ArgumentError StepRangeLen{T}(zero(T), -typemax(T), 3, 3)
+        # outer no-type constructor goes through the same path
+        @test_throws ArgumentError StepRangeLen(zero(T), typemax(T), 3)
+
+        # cases that must keep working
+        @test StepRangeLen{T}(zero(T), one(T), 0) isa StepRangeLen{T}  # empty range
+        @test collect(StepRangeLen{T}(typemax(T), one(T), 1)) == [typemax(T)]  # length 1
+        @test collect(StepRangeLen{T}(typemin(T), one(T), 1)) == [typemin(T)]
+        @test collect(StepRangeLen{T}(zero(T), one(T), 5)) == T[0,1,2,3,4]
+    end
+
+    # element type wider than ref/step: iteration math happens in the wider type
+    # and does not wrap, so the check must not fire
+    let r = StepRangeLen{Int}(Int8(0), Int8(127), 3)
+        @test r isa StepRangeLen
+        @test collect(r) == [0, 127, 254]
+    end
+    # check does not interfere with the float StepRangeLen path
+    @test range(0.0, step=0.1, length=5) isa StepRangeLen
+    # BigInt has no hardware bound, so the check is a no-op
+    let r = StepRangeLen(big(0), big(typemax(Int128)), 3)
+        @test r isa StepRangeLen
+        @test collect(r) == [big(0), big(typemax(Int128)), big(2)*big(typemax(Int128))]
+    end
+    # user types we do not understand still construct silently (no false positives)
+    @test StepRangeLen(0x0, 0x1, 5) isa StepRangeLen  # UInt remains unchecked
+end
+
 # A number type with the overflow behavior of `UInt8`. Conversion to `Integer` returns an
 # `Int32`, i.e., a type with different `typemin`/`typemax`. See  #41479
 struct OverflowingReal <: Real


### PR DESCRIPTION
StepRangeLen{T,R,S,L}(ref, step, len) silently constructed
ranges whose iteration formula `ref + (i - offset) * step`
wrapped within T. The reported example

    StepRangeLen{Int}(0, typemax(Int), 3)

evaluated to `0:9223372036854775807:-2`, with the third element
wrapping rather than being flagged as out of range.

Add a `_rangecheck(T, ref, step, len, offset)` hook in the inner
constructor (a no-op for types we cannot inspect) and specialize
it for hardware signed integers where `T == typeof(ref) ==
typeof(step)`, using `Base.Checked.{mul,add,sub}_with_overflow`
to throw `ArgumentError` if either endpoint overflows. User
numeric types, BigInt, unsigned integers, floats, and mixed-width
cases where iteration runs in a wider type all follow the no-op
path and keep their current behavior, so the change does not
affect code that was previously well-defined.

Fixes #59032

---

This pull request was developed with assistance from a generative AI
coding agent (REI). The diagnosis, fix, and regression test were
reviewed by the author before submission, per the contribution policy
in CONTRIBUTING.md / AGENTS.md.