### PR TITLE
InteractiveUtils: access bindings in fixed world

### DIFF
--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -88,7 +88,7 @@ function moduleloc(m::Module)
 end
 
 """
-    names(x::Module; all::Bool=false, imported::Bool=false, usings::Bool=false)::Vector{Symbol}
+    names(x::Module; all::Bool=false, imported::Bool=false, usings::Bool=false, world::UInt=Base.tls_world_age())::Vector{Symbol}
 
 Get a vector of the public names of a `Module`, excluding deprecated names.
 If `all` is true, then the list also includes non-public names defined in the module,
@@ -100,6 +100,10 @@ Names are returned in sorted order.
 
 As a special case, all names defined in `Main` are considered \"public\",
 since it is not idiomatic to explicitly mark names from `Main` as public.
+
+The `world` argument controls the world age used to look up binding partitions, defaulting
+to the current task's world age. Pass `world=Base.get_world_counter()` to include names
+from the latest world.
 
 !!! note
     `sym ∈ names(SomeModule)` does *not* imply `isdefined(SomeModule, sym)`.
@@ -116,8 +120,9 @@ since it is not idiomatic to explicitly mark names from `Main` as public.
 See also [`Base.isexported`](@ref), [`Base.ispublic`](@ref), [`Base.@locals`](@ref), [`@__MODULE__`](@ref).
 """
 names(m::Module; kwargs...) = sort!(unsorted_names(m; kwargs...))
-unsorted_names(m::Module; all::Bool=false, imported::Bool=false, usings::Bool=false) =
-    ccall(:jl_module_names, Array{Symbol,1}, (Any, Cint, Cint, Cint), m, all, imported, usings)
+unsorted_names(m::Module; all::Bool=false, imported::Bool=false, usings::Bool=false,
+               world::UInt=tls_world_age()) =
+    ccall(:jl_module_names, Array{Symbol,1}, (Any, Cint, Cint, Cint, UInt), m, all, imported, usings, world)
 
 """
     isexported(m::Module, s::Symbol)::Bool

--- a/src/module.c
+++ b/src/module.c
@@ -2094,10 +2094,9 @@ static void _materialize_reexported_bindings(jl_module_t *m, size_t world, jl_ar
     }
 }
 
-void append_module_names(jl_array_t* a, jl_module_t *m, int all, int imported, int usings)
+void append_module_names(jl_array_t* a, jl_module_t *m, int all, int imported, int usings, size_t world)
 {
     // Materialize reexported bindings first
-    size_t world = jl_current_task->world_age;
     jl_array_t *visited_modules = jl_alloc_vec_any(0);
     JL_GC_PUSH1(&visited_modules);
     _materialize_reexported_bindings(m, world, visited_modules);
@@ -2111,7 +2110,7 @@ void append_module_names(jl_array_t* a, jl_module_t *m, int all, int imported, i
         jl_sym_t *asname = b->globalref->name;
         int hidden = jl_symbol_name(asname)[0]=='#';
         int main_public = (m == jl_main_module && !(asname == jl_eval_sym || asname == jl_include_sym));
-        jl_binding_partition_t *bpart = jl_get_binding_partition(b, jl_current_task->world_age);
+        jl_binding_partition_t *bpart = jl_get_binding_partition(b, world);
         enum jl_partition_kind kind = jl_binding_kind(bpart);
         if (((jl_atomic_load_relaxed(&b->flags) & BINDING_FLAG_PUBLICP) ||
              jl_bpart_is_exported(bpart->kind) ||
@@ -2123,10 +2122,8 @@ void append_module_names(jl_array_t* a, jl_module_t *m, int all, int imported, i
     }
 }
 
-void append_exported_names(jl_array_t* a, jl_module_t *m, int all)
+void append_exported_names(jl_array_t* a, jl_module_t *m, int all, size_t world)
 {
-    size_t world = jl_current_task->world_age;
-
     // First, materialize all reexported bindings
     jl_array_t *visited_modules = jl_alloc_vec_any(0);
     JL_GC_PUSH1(&visited_modules);
@@ -2145,16 +2142,16 @@ void append_exported_names(jl_array_t* a, jl_module_t *m, int all)
     }
 }
 
-JL_DLLEXPORT jl_value_t *jl_module_names(jl_module_t *m, int all, int imported, int usings)
+JL_DLLEXPORT jl_value_t *jl_module_names(jl_module_t *m, int all, int imported, int usings, size_t world)
 {
     jl_array_t *a = jl_alloc_array_1d(jl_array_symbol_type, 0);
     JL_GC_PUSH1(&a);
-    append_module_names(a, m, all, imported, usings);
+    append_module_names(a, m, all, imported, usings, world);
     if (usings) {
         // If `usings` is specified, traverse the list of `using`-ed modules and incorporate
         // the names exported by those modules into the list.
         for (int i = module_usings_length(m)-1; i >= 0; i--)
-            append_exported_names(a, module_usings_getmod(m, i), all);
+            append_exported_names(a, module_usings_getmod(m, i), all, world);
     }
     JL_GC_POP();
     return (jl_value_t*)a;

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -43,17 +43,17 @@ The memory consumption estimate is an approximate lower bound on the size of the
 The output of `varinfo` is intended for display purposes only.  See also [`names`](@ref) to get an array of symbols defined in
 a module, which is suitable for more general manipulations.
 """
-function varinfo(m::Module=Base.active_module(), pattern::Regex=r""; all::Bool = false, imported::Bool = false, recursive::Bool = false, sortby::Symbol = :name, minsize::Int=0)
+function varinfo(m::Module=Base.active_module(), pattern::Regex=r""; all::Bool = false, imported::Bool = false, recursive::Bool = false, sortby::Symbol = :name, minsize::Int=0, world::UInt=Base.get_world_counter())
     sortby in (:name, :size, :summary) || throw(ArgumentError("Unrecognized `sortby` value `:$sortby`. Possible options are `:name`, `:size`, and `:summary`"))
     rows = Vector{Any}[]
     workqueue = [(m, ""),]
     while !isempty(workqueue)
         m2, prep = popfirst!(workqueue)
-        for v in names(m2; all, imported)
-            if !isdefined(m2, v) || !occursin(pattern, string(v))
+        for v in names(m2; all, imported, world)
+            if !Base.invoke_in_world(world, isdefined, m2, v) || !occursin(pattern, string(v))
                 continue
             end
-            value = getglobal(m2, v)
+            value = Base.invoke_in_world(world, getglobal, m2, v)
             isbuiltin = value === Base || value === Base.active_module() || value === Core
             if recursive && !isbuiltin && isa(value, Module) && value !== m2 && nameof(value) === v && parentmodule(value) === m2
                 push!(workqueue, (value, "$prep$v."))
@@ -229,11 +229,11 @@ function methodswith(@nospecialize(t::Type), @nospecialize(f::Base.Callable), me
     return meths
 end
 
-function _methodswith(@nospecialize(t::Type), m::Module, supertypes::Bool)
+function _methodswith(@nospecialize(t::Type), m::Module, supertypes::Bool, world::UInt)
     meths = Method[]
-    for nm in names(m)
-        if isdefinedglobal(m, nm)
-            f = getglobal(m, nm)
+    for nm in names(m; world)
+        if Base.invoke_in_world(world, isdefinedglobal, m, nm)
+            f = Base.invoke_in_world(world, getglobal, m, nm)
             if isa(f, Base.Callable)
                 methodswith(t, f, meths; supertypes = supertypes)
             end
@@ -242,18 +242,18 @@ function _methodswith(@nospecialize(t::Type), m::Module, supertypes::Bool)
     return unique(meths)
 end
 
-methodswith(@nospecialize(t::Type), m::Module; supertypes::Bool=false) = _methodswith(t, m, supertypes)
+methodswith(@nospecialize(t::Type), m::Module; supertypes::Bool=false, world::UInt=Base.get_world_counter()) = _methodswith(t, m, supertypes, world)
 
-function methodswith(@nospecialize(t::Type); supertypes::Bool=false)
+function methodswith(@nospecialize(t::Type); supertypes::Bool=false, world::UInt=Base.get_world_counter())
     meths = Method[]
     for mod in Base.loaded_modules_array()
-        append!(meths, _methodswith(t, mod, supertypes))
+        append!(meths, _methodswith(t, mod, supertypes, world))
     end
     return unique(meths)
 end
 
 # subtypes
-function _subtypes_in!(mods::Array, @nospecialize(x::Type))
+function _subtypes_in!(mods::Array, @nospecialize(x::Type), world::UInt)
     xt = unwrap_unionall(x)
     if !isabstracttype(x) || !isa(xt, DataType)
         # Fast path
@@ -263,9 +263,9 @@ function _subtypes_in!(mods::Array, @nospecialize(x::Type))
     while !isempty(mods)
         m = pop!(mods)
         xt = xt::DataType
-        for s in unsorted_names(m, all = true)
-            if !isdeprecated(m, s) && isdefinedglobal(m, s)
-                t = getglobal(m, s)
+        for s in unsorted_names(m; all = true, world)
+            if !isdeprecated(m, s) && Base.invoke_in_world(world, isdefinedglobal, m, s)
+                t = Base.invoke_in_world(world, getglobal, m, s)
                 dt = isa(t, UnionAll) ? unwrap_unionall(t) : t
                 if isa(dt, DataType)
                     if dt.name.name === s && dt.name.module == m && supertype(dt).name == xt.name
@@ -281,7 +281,7 @@ function _subtypes_in!(mods::Array, @nospecialize(x::Type))
     return permute!(sts, sortperm(map(string, sts)))
 end
 
-subtypes(m::Module, x::Type) = _subtypes_in!([m], x)
+subtypes(m::Module, x::Type; world::UInt=Base.get_world_counter()) = _subtypes_in!([m], x, world)
 
 """
     subtypes(T::DataType)
@@ -300,7 +300,7 @@ julia> subtypes(Integer)
  Unsigned
 ```
 """
-subtypes(x::Type) = _subtypes_in!(Base.loaded_modules_array(), x)
+subtypes(x::Type; world::UInt=Base.get_world_counter()) = _subtypes_in!(Base.loaded_modules_array(), x, world)
 
 """
     supertypes(T::Type)

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -1082,3 +1082,27 @@ var_line = @__LINE__()+1
 const _interactiveutils_some_var_ = 0
 
 @test InteractiveUtils.varloc(@__MODULE__, :_interactiveutils_some_var_) == (@__FILE__, var_line)
+
+@testset "world argument for varinfo and subtypes" begin
+    # varinfo: a non-const binding added after the recorded world should not
+    # appear when querying that older world (its partition does not yet exist
+    # at world_no_var, so `isdefined` in that world returns false).
+    M_varinfo = @eval module $(gensym()) end
+    world_no_var = Base.get_world_counter()
+    @eval M_varinfo begin
+        export tracked_var
+        tracked_var = 42
+    end
+    @test occursin("tracked_var", repr(varinfo(M_varinfo)))
+    @test !occursin("tracked_var", repr(varinfo(M_varinfo; world=world_no_var)))
+
+    # subtypes: subtype added after the recorded world should not appear when
+    # querying that older world.
+    M_sub = @eval module $(gensym())
+        abstract type MyAbstractParent end
+    end
+    world_no_subtype = Base.get_world_counter()
+    @eval M_sub struct MyConcreteChild <: MyAbstractParent end
+    @test length(subtypes(M_sub, M_sub.MyAbstractParent)) == 1
+    @test isempty(subtypes(M_sub, M_sub.MyAbstractParent; world=world_no_subtype))
+end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -365,6 +365,26 @@ let defaultset = Set((:A,))
     @test Set(names(TestMod54609.A, all=true, imported=true, usings=true)) == allset ∪ imported ∪ usings
 end
 
+@testset "names world argument" begin
+    # `names(M; all=true)` walks bindings and filters by partition kind at the
+    # given world. A binding that doesn't yet have a GLOBAL/CONST/DECLARED
+    # partition in the queried world should be excluded.
+    # Note: this can only be tested via plain assignment (not `export`/`public`,
+    # which set a non-partitioned per-binding flag that is world-insensitive).
+    M = @eval module $(gensym())
+        early_name = 1
+    end
+    world_mid = Base.get_world_counter()
+    @eval M late_name = 2
+    world_end = Base.get_world_counter()
+
+    @test :early_name ∈ names(M; all=true, world=world_end)
+    @test :late_name ∈ names(M; all=true, world=world_end)
+
+    @test :early_name ∈ names(M; all=true, world=world_mid)
+    @test :late_name ∉ names(M; all=true, world=world_mid)
+end
+
 let
     using .TestMod7648
     @test Base.binding_module(@__MODULE__, :a9475) == TestMod7648.TestModSub9475


### PR DESCRIPTION
This is a less-ambitious version of the program started in #60736 that avoids the need for #61200, by restricting itself to world-age at definition and side-stepping the issue of which names were `export`ed or `public` at specific world ages.
A copy of my OP plus a summary of the new strategy:

InteractiveUtils provides a number of utilities for querying and accessing the contents of modules. Because these modules can gain new bindings, some callers of InteractiveUtils functions produce warnings

    WARNING: Detected access to binding ... prior to its definition world.

One dramatic example occurs with the sequence

    using OptimizationProblems: OptimizationProblems
    using OptimizationProblems.ADNLPProblems
    using ADNLPModels: ADNLPModel

when running with Revise. ADNLPProblems loads new problems via Requires, and starting with v3.13 Revise queries `InteractiveUtils.subtypes` to cache dependent fieldtypes. This triggers the warning.

To fix this, add a `world` keyword argument to `names`/`unsorted_names` to control the world age at which bindings are looked up. It is then threaded through `varinfo`, `methodswith`, and `subtypes` in InteractiveUtils so they operate on bindings in the correct world.

The default for the `world` kwarg preserves the current behavior: `names`/`unsorted_names` default to `tls_world_age()` (matching the prior C-side use of `jl_current_task->world_age`); the InteractiveUtils entry points default to `get_world_counter()` so interactive tools see the latest definitions by default.

Closes #60736
Closes #61200

Related: https://github.com/timholy/Revise.jl/issues/993