### PR TITLE
Fix interaction between `foldr` and `Iterators.flatten`

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -198,9 +198,10 @@ foldl(op, itr; kw...) = mapfoldl(identity, op, itr; kw...)
 ## foldr & mapfoldr
 
 function mapfoldr_impl(f, op, nt, itr)
-    op′, itr′ = _xfadjoint(BottomRF(FlipArgs(op)), Generator(f, itr))
-    return foldl_impl(op′, nt, _reverse_iter(itr′))
+    op′, itr′ = _xfadjoint(BottomRF(FlipArgs(op)), Generator(f, _reverse_iter(itr)))
+    return foldl_impl(op′, nt, itr′)
 end
+
 
 _reverse_iter(itr) = Iterators.reverse(itr)
 _reverse_iter(itr::Union{Tuple,NamedTuple}) = length(itr) <= 32 ? reverse(itr) : Iterators.reverse(itr) #33235

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -779,4 +779,14 @@ let A=[1;;]
 end
 
 # issue #61805
-@test foldr(*, Iterators.flatten([["a", "b"], ["c", "d"]])) == "abcd"
+@testset "foldr iteraction with flatten" begin
+    @test foldr(*, Iterators.flatten([["a", "b"], ["c", "d"]])) == "abcd"
+
+    #Non-reversable collections inside the flatten should either error, or produce the right answer
+    res = try
+        foldr(tuple, Iterators.flatten((Iterators.take(1:3, 2), (3,))))
+    catch e
+        e
+    end
+    @test (res isa Exception) || res == (1, (2, 3))
+end

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -778,5 +778,5 @@ let A=[1;;]
     @test reduce(hcat, Any[A]) !== A
 end
 
-# correct interation between `foldr` and `Iterators.flatten`
+# correct interaction between `foldr` and `Iterators.flatten`
 @test foldr(*, Iterators.flatten([["a", "b"], ["c", "d"]])) == "abcd"

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -782,9 +782,10 @@ end
 @testset "foldr interaction with flatten" begin
     @test foldr(*, Iterators.flatten([["a", "b"], ["c", "d"]])) == "abcd"
 
-    #Non-reversable collections inside the flatten should either error, or produce the right answer
+    # Ideally, foldr would always get the right answer, but that currently requires that the iterator supports Iterators.reverse
+    # This tests a stateful iterator that cannot implement Iterators.reverse, ensuring it either errors or gets the right answer
     res = try
-        foldr(tuple, Iterators.flatten((Iterators.take(1:3, 2), (3,))))
+        foldr(tuple, Iterators.flatten((Iterators.Stateful(1:2), (3,))))
     catch e
         e
     end

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -777,3 +777,6 @@ let A=[1;;]
     @test reduce(vcat, Any[A]) !== A
     @test reduce(hcat, Any[A]) !== A
 end
+
+# correct interation between `foldr` and `Iterators.flatten`
+@test foldr(*, Iterators.flatten([["a", "b"], ["c", "d"]])) == "abcd"

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -779,7 +779,7 @@ let A=[1;;]
 end
 
 # issue #61805
-@testset "foldr iteraction with flatten" begin
+@testset "foldr interaction with flatten" begin
     @test foldr(*, Iterators.flatten([["a", "b"], ["c", "d"]])) == "abcd"
 
     #Non-reversable collections inside the flatten should either error, or produce the right answer

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -778,5 +778,5 @@ let A=[1;;]
     @test reduce(hcat, Any[A]) !== A
 end
 
-# correct interaction between `foldr` and `Iterators.flatten`
+# issue #61805
 @test foldr(*, Iterators.flatten([["a", "b"], ["c", "d"]])) == "abcd"


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/61805

It seems that the problem is that our `foldr_impl`  is passing a non-reversed iterator to `_xfadjoint`, and then doing the actual final reduction on a reversed iterator. This is normally fine, but it interacts incorrectly with `FlatteningRF` which does a sub-reduction inside each reducing step:
```julia
@inline function (op::FlatteningRF)(acc, x)
    op′, itr′ = _xfadjoint(op.rf, x)
    return _foldl_impl(op′, acc, itr′)
end
```
and this sub-reduction is not reversed when it gets hit during `foldr`, resulting in the weird reduction order shown in the linked issue:
```julia
julia> foldr(Iterators.flatten([["a","b"],["c","d"]])) do l, r
           @info "" l r
           l * r
       end
┌ Info: 
│   l = "d"
└   r = "c"
┌ Info: 
│   l = "a"
└   r = "dc"
┌ Info: 
│   l = "b"
└   r = "adc"
"badc"
```

This PR changes around the location of the `_reverse_iter` so that the sub-reductions are also reversed:

```julia

julia> foldr(Iterators.flatten([["a","b"],["c","d"]])) do l, r
           @info "" l r
           l * r
       end
┌ Info: 
│   l = "c"
└   r = "d"
┌ Info: 
│   l = "b"
└   r = "cd"
┌ Info: 
│   l = "a"
└   r = "bcd"
"abcd"
```