### PR TITLE
processor: report actual JIT target in pkgimage rejection debug output

### DIFF
--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -875,8 +875,16 @@ JL_DLLEXPORT jl_value_t *jl_get_cpu_features(void)
 
 #ifndef __clang_analyzer__
 extern "C" JL_DLLEXPORT jl_value_t* jl_reflect_clone_targets() {
-    auto targets = jl_get_llvm_clone_targets(jl_options.cpu_target);
-    auto &data = targets.data;
+    // Return the actual JIT target(s) chosen after sysimage matching, so that
+    // debug output reflects what pkgimage clones are compared against rather
+    // than the unmatched targets parsed from `jl_options.cpu_target`.
+    std::vector<uint8_t> data;
+    if (!jit_targets.empty()) {
+        data = tp::serialize_targets(jit_targets);
+    } else {
+        auto targets = jl_get_llvm_clone_targets(jl_options.cpu_target);
+        data = std::move(targets.data);
+    }
     jl_value_t *arr = (jl_value_t*)jl_alloc_array_1d(jl_array_uint8_type, data.size());
     uint8_t *out = jl_array_data(arr, uint8_t);
     memcpy(out, data.data(), data.size());


### PR DESCRIPTION
## Summary

`jl_reflect_clone_targets` (exposed as `Base.current_image_targets()`) was re-resolving `jl_options.cpu_target` from scratch via `jl_get_llvm_clone_targets`, returning the originally-configured target spec list rather than the JIT target that `match_pkgimg_target` actually compares pkgimage clones against. The JIT target (`jit_targets.front()`) differs from the configured one because it is:

- intersected with the loaded sysimage's clone features,
- clamped by max vector-register width (e.g., AVX-512 features are stripped when the matched sysimage clone caps at AVX2).

As a result, `JULIA_DEBUG=loading` printed identical "Image Targets" and "Current Targets" feature strings on pkgimage rejection — hiding the real mismatch and making the rejection look spurious. See #61621 for two examples.

This change makes `jl_reflect_clone_targets` serialize `jit_targets` directly, with a fallback to the prior behavior in case it has not yet been populated.

Fixes #61621

Pull request was written with the assistance of generative AI (Claude).

## Test plan

- [ ] Trigger a pkgimage rejection (e.g. load a pkgimage built against a different sysimage clone) with `JULIA_DEBUG=loading` and confirm "Current Targets" now shows the post-match JIT feature set rather than the unmatched cpu_target spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)