### PR TITLE
Fix heap snapshots containing >256 node types

### DIFF
--- a/src/gc-heap-snapshot.c
+++ b/src/gc-heap-snapshot.c
@@ -45,7 +45,7 @@ static void print_str_escape_json(ios_t *stream, const char *s, size_t len) JL_N
 // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L2598-L2601
 
 typedef struct {
-    uint8_t type; // These *must* match the Enums on the JS side; control interpretation of name_or_index.
+    uint32_t type; // These *must* match the Enums on the JS side; control interpretation of name_or_index.
     size_t name_or_index; // name of the field (for objects/modules) or index of array
     size_t from_node;  // This is a deviation from the .heapsnapshot format to support streaming.
     size_t to_node;
@@ -57,7 +57,7 @@ typedef struct {
 // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L2568-L2575
 
 typedef struct {
-    uint8_t type; // index into snapshot->node_types
+    uint32_t type; // index into snapshot->node_types
     size_t name;
     size_t id; // This should be a globally-unique counter, but we use the memory address
     size_t self_size;
@@ -293,7 +293,7 @@ static void _add_synthetic_root_entries(HeapSnapshot *snapshot) JL_NOTSAFEPOINT
     // adds a node at id 0 which is the "uber root":
     // a synthetic node which points to all the GC roots.
     Node internal_root = {
-        (uint8_t)st_find_or_create(&snapshot->node_types, "synthetic"),
+        (uint32_t)st_find_or_create(&snapshot->node_types, "synthetic"),
         st_find_or_serialize(&snapshot->names, snapshot->strings, ""), // name
         0, // id
         0, // size
@@ -305,7 +305,7 @@ static void _add_synthetic_root_entries(HeapSnapshot *snapshot) JL_NOTSAFEPOINT
     // Add a node for the GC roots
     snapshot->_gc_root_idx = snapshot->internal_root_idx + 1;
     Node gc_roots = {
-        (uint8_t)st_find_or_create(&snapshot->node_types, "synthetic"),
+        (uint32_t)st_find_or_create(&snapshot->node_types, "synthetic"),
         st_find_or_serialize(&snapshot->names, snapshot->strings, "GC roots"), // name
         snapshot->_gc_root_idx, // id
         0, // size
@@ -314,7 +314,7 @@ static void _add_synthetic_root_entries(HeapSnapshot *snapshot) JL_NOTSAFEPOINT
     };
     serialize_node(snapshot, gc_roots);
     Edge root_to_gc_roots = {
-        (uint8_t)st_find_or_create(&snapshot->edge_types, "internal"),
+        (uint32_t)st_find_or_create(&snapshot->edge_types, "internal"),
         st_find_or_serialize(&snapshot->names, snapshot->strings, "GC roots"), // edge label
         snapshot->internal_root_idx, // from
         snapshot->_gc_root_idx // to
@@ -324,7 +324,7 @@ static void _add_synthetic_root_entries(HeapSnapshot *snapshot) JL_NOTSAFEPOINT
     // add a node for the gc finalizer list roots
     snapshot->_gc_finlist_root_idx = snapshot->internal_root_idx + 2;
     Node gc_finlist_roots = {
-        (uint8_t)st_find_or_create(&snapshot->node_types, "synthetic"),
+        (uint32_t)st_find_or_create(&snapshot->node_types, "synthetic"),
         st_find_or_serialize(&snapshot->names, snapshot->strings, "GC finalizer list roots"), // name
         snapshot->_gc_finlist_root_idx, // id
         0, // size
@@ -333,7 +333,7 @@ static void _add_synthetic_root_entries(HeapSnapshot *snapshot) JL_NOTSAFEPOINT
     };
     serialize_node(snapshot, gc_finlist_roots);
     Edge root_to_gc_finlist_roots = {
-        (uint8_t)st_find_or_create(&snapshot->edge_types, "internal"),
+        (uint32_t)st_find_or_create(&snapshot->edge_types, "internal"),
         st_find_or_serialize(&snapshot->names, snapshot->strings, "GC finalizer list roots"), // edge label
         snapshot->internal_root_idx, // from
         snapshot->_gc_finlist_root_idx // to
@@ -428,7 +428,7 @@ size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
     }
 
     Node node = {
-        (uint8_t)st_find_or_create(&g_snapshot->node_types, node_type), // size_t type;
+        (uint32_t)st_find_or_create(&g_snapshot->node_types, node_type), // size_t type;
         st_serialize(&g_snapshot->names, g_snapshot->strings, name), // size_t name;
         (size_t)a,     // size_t id;
         // We add 1 to self-size for the type tag that all heap-allocated objects have.
@@ -452,7 +452,7 @@ static size_t record_pointer_to_gc_snapshot(void *a, size_t bytes, const char *n
         return idx;
 
     Node node = {
-        (uint8_t)st_find_or_create(&g_snapshot->node_types, "object"), // size_t type;
+        (uint32_t)st_find_or_create(&g_snapshot->node_types, "object"), // size_t type;
         st_serialize(&g_snapshot->names, g_snapshot->strings, name), // size_t name;
         (size_t)a,     // size_t id;
         bytes,         // size_t self_size;
@@ -528,7 +528,7 @@ size_t _record_stack_frame_node(HeapSnapshot *snapshot, void *frame) JL_NOTSAFEP
         return idx;
 
     Node node = {
-        (uint8_t)st_find_or_create(&snapshot->node_types, "synthetic"),
+        (uint32_t)st_find_or_create(&snapshot->node_types, "synthetic"),
         st_find_or_serialize(&snapshot->names, snapshot->strings, "(stack frame)"), // name
         (size_t)frame, // id
         1, // size
@@ -633,7 +633,7 @@ static inline void _record_gc_edge(const char *edge_type, jl_value_t *a,
 static void _record_gc_just_edge(const char *edge_type, size_t from_idx, size_t to_idx, size_t name_or_idx) JL_NOTSAFEPOINT
 {
     Edge edge = {
-        (uint8_t)st_find_or_create(&g_snapshot->edge_types, edge_type),
+        (uint32_t)st_find_or_create(&g_snapshot->edge_types, edge_type),
         name_or_idx, // edge label
         from_idx, // from
         to_idx // to

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -10,13 +10,13 @@ Assemble a .heapsnapshot file from the .json files produced by `Profile.take_sna
 
 # SoA layout to reduce padding
 struct Edges
-    type::Vector{Int8}       # index into `snapshot.meta.edge_types`
+    type::Vector{UInt32}       # index into `snapshot.meta.edge_types`
     name_or_index::Vector{UInt} # Either an index into `snapshot.strings`, or the index in an array, depending on edge_type
     to_pos::Vector{UInt}   # index into `snapshot.nodes`
 end
 function Edges(n::Int)
     Edges(
-        Vector{Int8}(undef, n),
+        Vector{UInt32}(undef, n),
         Vector{UInt}(undef, n),
         Vector{UInt}(undef, n),
     )
@@ -25,7 +25,7 @@ Base.length(n::Edges) = length(n.type)
 
 # trace_node_id and detachedness are always 0 in the snapshots Julia produces so we don't store them
 struct Nodes
-    type::Vector{Int8}         # index into `snapshot.meta.node_types`
+    type::Vector{UInt32}         # index into `snapshot.meta.node_types`
     name_idx::Vector{UInt32} # index into `snapshot.strings`
     id::Vector{UInt}           # unique id, in julia it is the address of the object
     self_size::Vector{Int}     # size of the object itself, not including the size of its fields
@@ -40,7 +40,7 @@ struct Nodes
 end
 function Nodes(n::Int, e::Int)
     Nodes(
-        Vector{Int8}(undef, n),
+        Vector{UInt32}(undef, n),
         Vector{UInt32}(undef, n),
         Vector{UInt}(undef, n),
         Vector{Int}(undef, n),
@@ -101,7 +101,7 @@ function assemble_snapshot(in_prefix, io::IO)
     # Parse nodes with empty edge counts that we need to fill later
     open(string(in_prefix, ".nodes"), "r") do nodes_file
         for i in 1:length(nodes)
-            node_type = read(nodes_file, Int8)
+            node_type = read(nodes_file, UInt32)
             node_name_idx = read(nodes_file, UInt)
             id = read(nodes_file, UInt)
             self_size = read(nodes_file, Int)
@@ -121,7 +121,7 @@ function assemble_snapshot(in_prefix, io::IO)
     # Parse the edges to fill in the edge counts for nodes and correct the to_node offsets
     open(string(in_prefix, ".edges"), "r") do edges_file
         for i in 1:length(nodes.edges)
-            edge_type = read(edges_file, Int8)
+            edge_type = read(edges_file, UInt32)
             edge_name_or_index = read(edges_file, UInt)
             from_node = read(edges_file, UInt)
             to_node = read(edges_file, UInt)


### PR DESCRIPTION
I was getting some very silly results where `CodeInstance` nodes were `UnitRange{Int64}` and `Core.DebugInfo` was `Compiler.AnalysisResults`, etc.  

Bug found by claude.  Probably introduced in #52854, when this field went from `size_t` to `uint8_t`.  

~~todo: tests~~ would need to implement a parser for heapsnapshot files....