### PR TITLE
libssh2: Correct syntax error in makefile

### DIFF
--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -32,8 +32,6 @@ endif
 
 LIBSSH2_SRC_PATH := $(SRCCACHE)/$(LIBSSH2_SRC_DIR)
 
-libssh2-CVE-2026-7598-256d04b60d80bf1190e96b0ad1e91b2174d744b1.patch
-
 $(SRCCACHE)/libssh2-$(LIBSSH2_VER)/libssh2-CVE-2026-7598-256d04b60d80bf1190e96b0ad1e91b2174d744b1.patch-applied: $(SRCCACHE)/libssh2-$(LIBSSH2_VER)/source-extracted
 	cd $(dir $@) && \
 		patch -p1 -f < $(SRCDIR)/patches/libssh2-CVE-2026-7598-256d04b60d80bf1190e96b0ad1e91b2174d744b1.patch-applied


### PR DESCRIPTION
Remove a spurious line. I wonder why CI didn't detect that.