### PR TITLE
client: restrict `repl_cmd` to `AbstractCmd` arguments

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -31,7 +31,7 @@ answer_color() = text_colors[repl_color("JULIA_ANSWER_COLOR", default_color_answ
 stackframe_lineinfo_color() = repl_color("JULIA_STACKFRAME_LINEINFO_COLOR", :bold)
 stackframe_function_color() = repl_color("JULIA_STACKFRAME_FUNCTION_COLOR", :bold)
 
-function repl_cmd(cmd, out)
+function repl_cmd(cmd::AbstractCmd, out)
     if !(cmd isa Cmd)
         # Pipelines and redirects: run directly without shell wrapping.
         try
@@ -85,6 +85,9 @@ function repl_cmd(cmd, out)
     end
     nothing
 end
+
+repl_cmd(@nospecialize(cmd), out) =
+    throw(ArgumentError("repl_cmd: expected an `AbstractCmd`, got $(typeof(cmd))"))
 
 # deprecated function--preserved for DocTests.jl
 function ip_matches_func(ip, func::Symbol)


### PR DESCRIPTION
Fixes the noisy intentional fail in CI https://buildkite.com/julialang/julia-master/builds/57215#019e2720-98e6-4f9c-9f01-3bbef3010a3d/L1764
```
  | ┌ FooBar3
  | │  [Output was shown above]
  | └
  | ERROR: MethodError: no method matching ignorestatus(::Int64)
  | The function `ignorestatus` exists, but no method is defined for this combination of argument types.
  |  
  | Closest candidates are:
  | ignorestatus(::Base.CmdRedirect)
  | @ Base cmd.jl:300
  | ignorestatus(::Cmd)
  | @ Base cmd.jl:297
  | ignorestatus(::Union{Base.AndCmds, Base.OrCmds})
  | @ Base cmd.jl:298
  |  
  | precompile                                                  (1) \|   106.91 \|   0.52 \|  0.5 \|    1230.44 \|   547.52
```

Bug identified and developed with Claude:

---

After #61540 added a non-`Cmd` branch to `repl_cmd` for pipeline/redirect support, calling `repl_cmd` with a non-command argument (e.g. an `Int`) would route through `ignorestatus(cmd)`, raise a `MethodError`, then have its catch arm print the error via `display_error` — bypassing any caller-level `try`/`catch`.

Restrict the runnable method to `cmd::AbstractCmd` and add a fallback method that throws an explicit `ArgumentError` instead, so misuses remain catchable. This restores the behaviour the `PkgCacheInspector` precompile test relies on (it intentionally calls `repl_cmd(7, "hello")` inside a `try`/`catch` to create a stray external specialization).

