### PR TITLE
`Core.DebugInfo`: expand C API, mostly to handle byte-precise information

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8531,8 +8531,8 @@ static jl_llvm_functions_t
     }
     else if ((jl_value_t*)src->debuginfo != jl_nothing) {
         // look for the file and line info of the original start of this block, as reported by lowering
-        ctx.file = jl_debuginfo_firstline(src->debuginfo, &toplineno);
-        toplineno = std::max(0, toplineno);
+        ctx.file = jl_cdi_file(src->debuginfo);
+        toplineno = std::max(0, jl_cdi_firstline_all(src->debuginfo));
     }
     if (ctx.file.empty())
         ctx.file = "<missing>";
@@ -9319,14 +9319,13 @@ static jl_llvm_functions_t
                     jl_module_t *modu = func ? jl_debuginfo_module1(func) : NULL;
                     if (modu == NULL)
                         modu = ctx.module;
-                    info.file = jl_debuginfo_file1(debuginfo);
+                    info.file = jl_cdi_file(debuginfo);
                     info.line = i;
                     info.line0 = 0;
                     if (pc == 1) {
-                        struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo, 0);
-                        assert(lineidx.to == 0 && lineidx.pc == 0);
-                        if (lineidx.loc > 0 && info.line != lineidx.loc)
-                            info.line0 = lineidx.loc;
+                        int32_t line0 = jl_cdi_external_firstline(debuginfo);
+                        if (line0 > 0 && info.line != line0)
+                            info.line0 = line0;
                     }
                     if (info.file.empty())
                         info.file = "<missing>";
@@ -9518,7 +9517,7 @@ static jl_llvm_functions_t
             jl_module_t *modu = func ? jl_debuginfo_module1(func) : NULL;
             if (modu == NULL)
                 modu = ctx.module;
-            StringRef file = jl_debuginfo_file1(debuginfo);
+            StringRef file = jl_cdi_file(debuginfo);
             if (file.empty())
                 file = "<missing>";
             bool is_user_code;
@@ -9528,7 +9527,10 @@ static jl_llvm_functions_t
                 is_user_code = in_user_mod(modu);
             bool is_tracked = in_tracked_path(file);
             if (do_coverage(is_user_code, is_tracked)) {
-                for (size_t pc = 0; 1; pc++) {
+                int32_t extraline = jl_cdi_external_firstline(debuginfo);
+                if (extraline != -1)
+                    jl_coverage_alloc_line(file.data(), extraline);
+                for (size_t pc = 1; 1; pc++) {
                     struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo, pc);
                     if (lineidx.loc == -1)
                         break;

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1442,9 +1442,131 @@ JL_DLLEXPORT struct jl_codeloc_t jl_uncompress1_codeloc(jl_debuginfo_t *di, size
     assert(jl_is_string(cl));
     int loc_offset, loc_bytes, to_bytes;
     size_t nstmts = codelocs_parseheader(cl, &loc_offset, &loc_bytes, &to_bytes);
-    if (pc > nstmts)
-        return badloc;
+    if (pc < 0 || pc > nstmts)
+        return badloc; // ideally an assertion, but currently happens too often
     return unpack_codeloc(cl, pc, loc_offset, loc_bytes, to_bytes);
+}
+
+static const char *sbt_parseheader(jl_string_t *str, jl_sourcebytetable_header_t *h) JL_NOTSAFEPOINT
+{
+    assert(jl_is_string(str));
+    const char *ptr = jl_string_data(str);
+    memcpy(h, ptr, SBT_HEADER_SIZE); // TODO assumes LE
+    return ptr + SBT_HEADER_SIZE;
+}
+
+/* `jl_cdi_*`: barebones non-allocating interface for reading compressed
+ * debuginfo.  Only `jl_cdi_firstxy` may be used on line-based DebugInfo.
+ * All byte positions, line numbers, column numbers, and program counters are
+ * 1-based, and all ranges are inclusive-inclusive. */
+
+/* traverse `di.linetable` (towards line/byte information, ignoring edges),
+ * returning new debuginfo in `p_di` and optionally pc in `p_pc`. */
+static void cdi_deref(jl_debuginfo_t **p_di, int32_t *p_pc, int recursive) JL_NOTSAFEPOINT
+{
+    jl_debuginfo_t *di = *p_di;
+    int32_t pc = 0;
+    if (!p_pc)
+        p_pc = &pc;
+    if (jl_typeof(di->linetable) == (jl_value_t *)jl_debuginfo_type) {
+        *p_pc = jl_uncompress1_codeloc(di, *p_pc).loc;
+        *p_di = (jl_debuginfo_t *)di->linetable;
+        if (recursive) {
+            cdi_deref(p_di, p_pc, recursive);
+        }
+    } else {
+        assert(jl_is_string(di->linetable) || jl_is_nothing(di->linetable));
+    }
+}
+
+JL_DLLEXPORT jl_locspan_t jl_cdi_bytespan(jl_debuginfo_t *di, int32_t pc) JL_NOTSAFEPOINT
+{
+    cdi_deref(&di, &pc, 1);
+    pc = jl_uncompress1_codeloc(di, pc).loc;
+    jl_sourcebytetable_header_t h;
+    const char *ptr = sbt_parseheader(di->linetable, &h);
+    if (pc <= 0 || pc > h.nlocs) {
+        return (jl_locspan_t){-1, -1};
+    }
+    ptr += (pc-1)*(h.byte_encl+h.span_encl);
+    jl_locspan_t out;
+    out.first = _take_u32(&ptr, h.byte_encl) + h.byte_offset;
+    out.second = _take_u32(&ptr, h.span_encl) + out.first - 1;
+    return out;
+}
+
+/* O(line_starts); could binary search instead */
+JL_DLLEXPORT jl_locspan_t jl_cdi_byte_to_xy(jl_debuginfo_t *di, int32_t b) JL_NOTSAFEPOINT
+{
+    cdi_deref(&di, NULL, 1);
+    jl_sourcebytetable_header_t h;
+    sbt_parseheader(di->linetable, &h);
+    size_t off = SBT_HEADER_SIZE + h.nlocs * (h.byte_encl + h.span_encl);
+    size_t n_lines = (jl_string_len(di->linetable) - off) / h.byte_encl;
+    jl_locspan_t out = {h.line_offset-1, -1};
+    const char *ptr = jl_string_data(di->linetable) + off;
+    for (int i = 0; i < n_lines; i++) {
+        int32_t line_start = _take_u32(&ptr, h.byte_encl);
+        if (line_start + h.byte_offset <= b) {
+            out.second = b - (line_start + h.byte_offset) + 1;
+            out.first++;
+        } else if (i == 0) { // b too small
+            return (jl_locspan_t){-1, -1};
+        } else {
+            break;
+        }
+    }
+    return out;
+}
+
+/* First (line, col) at the given pc, where col=-1 if unavailable */
+JL_DLLEXPORT jl_locspan_t jl_cdi_firstxy(jl_debuginfo_t *di, int32_t pc) JL_NOTSAFEPOINT
+{
+    assert(pc > 0);
+    cdi_deref(&di, &pc, 1);
+    jl_locspan_t out = {-1, -1};
+    if (jl_is_nothing(di->linetable)) {
+        out.first = jl_uncompress1_codeloc(di, pc).loc;
+    } else if (jl_is_string(di->linetable)) {
+        out = jl_cdi_byte_to_xy(di, jl_cdi_bytespan(di, pc).first);
+    }
+    return out;
+}
+
+/* Only when linetable==nothing, it's possible to have a separate first line not
+ * associated with any IR statement (the extra firstline argument to
+ * jl_compress_codelocs).  Coverage uses this.  -1 if not present.  Ideally the
+ * >-1 case will be deprecated, since this implementation doesn't allow a
+ * linetable to be shared between multiple owners */
+JL_DLLEXPORT int32_t jl_cdi_external_firstline(jl_debuginfo_t *di) JL_NOTSAFEPOINT
+{
+    int32_t pc = 0;
+    cdi_deref(&di, &pc, 1);
+    if (jl_is_nothing(di->linetable)) {
+        int32_t out = jl_uncompress1_codeloc(di, 0).loc;
+        return out > 0 ? out : -1;
+    } else if (jl_is_string(di->linetable)) {
+        return -1;
+    }
+    jl_unreachable();
+}
+
+JL_DLLEXPORT int32_t jl_cdi_firstline_all(jl_debuginfo_t *di) JL_NOTSAFEPOINT
+{
+    int32_t out = jl_cdi_external_firstline(di);
+    if (out == -1) {
+        /* TODO: not necessarily first, but a good enough guess for display */
+        cdi_deref(&di, NULL, 1);
+        out = jl_cdi_firstxy(di, 1).first;
+    }
+    return out;
+}
+
+JL_DLLEXPORT const char *jl_cdi_file(jl_debuginfo_t *di) JL_NOTSAFEPOINT
+{
+    cdi_deref(&di, NULL, 1);
+    assert(jl_is_symbol(di->def));
+    return jl_symbol_name((jl_sym_t*)di->def);
 }
 
 static int allzero(jl_value_t *codelocs) JL_NOTSAFEPOINT

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1573,13 +1573,14 @@ JL_DLLEXPORT const char *jl_cdi_file(jl_debuginfo_t *di) JL_NOTSAFEPOINT
     } else if (jl_is_method_instance(di->def)) {
         // reachable with hand-crafted CodeInstances in base tests
         jl_value_t *m = ((jl_method_instance_t *)di->def)->def.value;
-        assert(jl_is_method(m));
+        assert(jl_is_method(m) && "unimplemented");
         return jl_symbol_name(((jl_method_t*)m)->file);
     } else if (jl_is_nothing(di->def)) {
         // reachable when linenumbernode.file is nothing (through method.c)
         return "<unknown>";
     } else {
-        jl_error("unexpected type for debuginfo.def");
+        assert(0 && "unexpected type for debuginfo.def");
+        return "<unknown>";
     }
 }
 

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1475,12 +1475,14 @@ static void cdi_deref(jl_debuginfo_t **p_di, int32_t *p_pc, int recursive) JL_NO
             cdi_deref(p_di, p_pc, recursive);
         }
     } else {
+        if (jl_is_string (di->linetable)) {jl_unreachable();} // TODO: remove when byte-precise
         assert(jl_is_string(di->linetable) || jl_is_nothing(di->linetable));
     }
 }
 
 JL_DLLEXPORT jl_locspan_t jl_cdi_bytespan(jl_debuginfo_t *di, int32_t pc) JL_NOTSAFEPOINT
 {
+    jl_unreachable(); // TODO: remove when byte-precise
     cdi_deref(&di, &pc, 1);
     pc = jl_uncompress1_codeloc(di, pc).loc;
     jl_sourcebytetable_header_t h;
@@ -1498,6 +1500,7 @@ JL_DLLEXPORT jl_locspan_t jl_cdi_bytespan(jl_debuginfo_t *di, int32_t pc) JL_NOT
 /* O(line_starts); could binary search instead */
 JL_DLLEXPORT jl_locspan_t jl_cdi_byte_to_xy(jl_debuginfo_t *di, int32_t b) JL_NOTSAFEPOINT
 {
+    jl_unreachable(); // TODO: remove when byte-precise
     cdi_deref(&di, NULL, 1);
     jl_sourcebytetable_header_t h;
     sbt_parseheader(di->linetable, &h);

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1475,7 +1475,7 @@ static void cdi_deref(jl_debuginfo_t **p_di, int32_t *p_pc, int recursive) JL_NO
             cdi_deref(p_di, p_pc, recursive);
         }
     } else {
-        if (jl_is_string (di->linetable)) {jl_unreachable();} // TODO: remove when byte-precise
+        if (jl_is_string(di->linetable)) {jl_unreachable();} // TODO: remove when byte-precise
         assert(jl_is_string(di->linetable) || jl_is_nothing(di->linetable));
     }
 }
@@ -1568,8 +1568,19 @@ JL_DLLEXPORT int32_t jl_cdi_firstline_all(jl_debuginfo_t *di) JL_NOTSAFEPOINT
 JL_DLLEXPORT const char *jl_cdi_file(jl_debuginfo_t *di) JL_NOTSAFEPOINT
 {
     cdi_deref(&di, NULL, 1);
-    assert(jl_is_symbol(di->def));
-    return jl_symbol_name((jl_sym_t*)di->def);
+    if (jl_is_symbol(di->def)) {
+        return jl_symbol_name((jl_sym_t*)di->def);
+    } else if (jl_is_method_instance(di->def)) {
+        // reachable with hand-crafted CodeInstances in base tests
+        jl_value_t *m = ((jl_method_instance_t *)di->def)->def.value;
+        assert(jl_is_method(m));
+        return jl_symbol_name(((jl_method_t*)m)->file);
+    } else if (jl_is_nothing(di->def)) {
+        // reachable when linenumbernode.file is nothing (through method.c)
+        return "<unknown>";
+    } else {
+        jl_error("unexpected type for debuginfo.def");
+    }
 }
 
 static int allzero(jl_value_t *codelocs) JL_NOTSAFEPOINT

--- a/src/julia.h
+++ b/src/julia.h
@@ -235,15 +235,40 @@ JL_DLLEXPORT extern const jl_callptr_t jl_f_opaque_closure_call_addr;
 
 JL_DLLEXPORT extern const jl_callptr_t jl_fptr_wait_for_compiled_addr;
 
+typedef struct _jl_locspan_t {
+    int32_t first;
+    int32_t second;
+} jl_locspan_t;
+
 struct jl_codeloc_t {
     int32_t loc;
     int32_t to;
     int32_t pc;
 };
 
+// In a compressed jl_debuginfo_t linetable string, this header is followed by
+// (with byte_offest subtracted from all raw byte positions):
+//
+// bytespans: (byte_encl+span_encl)*nlocs bytes
+// line_starts: byte_encl*rest bytes
+typedef struct _jl_sourcebytetable_header_t {
+    // (>0) minimum byte
+    int32_t byte_offset;
+    // (>0) minimum line, where line_starts[0] is the byte position of this
+    // line's first character
+    int32_t line_offset;
+    // (>=0) number of (byte, len) bytespans
+    int32_t nlocs;
+    // (0,1,2,4) compressed lengths
+    uint8_t byte_encl;
+    uint8_t span_encl;
+} jl_sourcebytetable_header_t;
+// packed size
+#define SBT_HEADER_SIZE 14
+
 typedef struct _jl_debuginfo_t {
     jl_value_t *def;
-    jl_value_t *linetable; // debuginfo or nothing
+    jl_value_t *linetable; // debuginfo, compressed string, or nothing
     jl_svec_t *edges; // Memory{DebugInfo}
     jl_value_t *codelocs; // String // Memory{UInt8} // compressed info
 } jl_debuginfo_t;
@@ -2297,6 +2322,12 @@ JL_DLLEXPORT jl_value_t *jl_uncompress_argname_n(jl_value_t *syms, size_t i);
 JL_DLLEXPORT struct jl_codeloc_t jl_uncompress1_codeloc(jl_debuginfo_t *di, size_t pc) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_compress_codelocs(int32_t firstloc, jl_value_t *codelocs, size_t nstmts);
 JL_DLLEXPORT jl_value_t *jl_uncompress_codelocs(jl_debuginfo_t *di, size_t nstmts);
+JL_DLLEXPORT jl_locspan_t jl_cdi_bytespan(jl_debuginfo_t *di, int32_t pc) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_locspan_t jl_cdi_byte_to_xy(jl_debuginfo_t *di, int32_t b) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_locspan_t jl_cdi_firstxy(jl_debuginfo_t *di, int32_t pc) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int32_t jl_cdi_external_firstline(jl_debuginfo_t *di) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int32_t jl_cdi_firstline_all(jl_debuginfo_t *di) JL_NOTSAFEPOINT;
+JL_DLLEXPORT const char *jl_cdi_file(jl_debuginfo_t *di) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint8_t jl_encode_inlining_cost(uint16_t inlining_cost) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint16_t jl_decode_inlining_cost(uint8_t inlining_cost) JL_NOTSAFEPOINT;
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -839,8 +839,6 @@ STATIC_INLINE jl_method_instance_t *jl_get_ci_mi(jl_code_instance_t *ci JL_PROPA
     return (jl_method_instance_t*)def;
 }
 
-JL_DLLEXPORT const char *jl_debuginfo_firstline(jl_debuginfo_t *debuginfo, int *line) JL_NOTSAFEPOINT;
-JL_DLLEXPORT const char *jl_debuginfo_file1(jl_debuginfo_t *debuginfo) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_module_t *jl_debuginfo_module1(jl_value_t *debuginfo_def) JL_NOTSAFEPOINT;
 JL_DLLEXPORT const char *jl_debuginfo_name(jl_value_t *func) JL_NOTSAFEPOINT;
 

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -854,7 +854,10 @@ void jl_fprint_native_codeloc(ios_t *s, uintptr_t ip) JL_NOTSAFEPOINT
             jl_safe_fprintf(s, "unknown function (ip: %p) at %s\n", (void*)ip, frame.file_name ? frame.file_name : "(unknown file)");
         }
         else {
-            jl_safe_fprint_codeloc(s, frame.func_name, frame.file_name, frame.line, 0, frame.pc, frame.inlined);
+            int col = frame.fromC ? frame.pc : 0;
+            int pc = frame.fromC ? 0 : frame.pc;
+            jl_safe_fprint_codeloc(
+                s, frame.func_name, frame.file_name, frame.line, col, pc, frame.inlined);
             free(frame.func_name);
         }
         free(frame.file_name);

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -823,7 +823,7 @@ static void jl_safe_fprint_codeloc(ios_t *s, const char* func_name, const char* 
     const char *inlined_str = inlined ? " [inlined]" : "";
     if (line != -1) {
         if (pc > 0)
-            jl_safe_fprintf(s, "%s at %s:%d:%d%s\n", func_name, file_name, line, pc, inlined_str);
+            jl_safe_fprintf(s, "%s at %s:%d (pc: %d)%s\n", func_name, file_name, line, pc, inlined_str);
         else
             jl_safe_fprintf(s, "%s at %s:%d%s\n", func_name, file_name, line, inlined_str);
     }

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -913,7 +913,7 @@ static void jl_fprint_debugloc(ios_t *s, jl_debuginfo_t *debuginfo, jl_value_t *
             ip2 = 0;
         const char *func_name = jl_debuginfo_name(func);
         const char *file = jl_cdi_file(debuginfo);
-        jl_locspan_t xy = jl_cdi_firstxy(debuginfo, ip2);
+        jl_locspan_t xy = jl_cdi_firstxy(debuginfo, ip);
         jl_safe_fprint_codeloc(s, func_name, file, xy.first, xy.second, (int)ip, inlined);
     }
 }

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -818,14 +818,18 @@ JL_DLLEXPORT jl_value_t *jl_lookup_code_address(void *ip, int skipC)
 }
 
 static void jl_safe_fprint_codeloc(ios_t *s, const char* func_name, const char* file_name,
-                                   int line, int pc, int inlined) JL_NOTSAFEPOINT
+                                   int line, int col, int pc, int inlined) JL_NOTSAFEPOINT
 {
     const char *inlined_str = inlined ? " [inlined]" : "";
+    if (col == -1) {
+        col = 0;
+    }
     if (line != -1) {
         if (pc > 0)
-            jl_safe_fprintf(s, "%s at %s:%d (pc: %d)%s\n", func_name, file_name, line, pc, inlined_str);
+            jl_safe_fprintf(s, "%s at %s:%d:%d (pc: %d)%s\n",
+                            func_name, file_name, line, col, pc, inlined_str);
         else
-            jl_safe_fprintf(s, "%s at %s:%d%s\n", func_name, file_name, line, inlined_str);
+            jl_safe_fprintf(s, "%s at %s:%d:%d%s\n", func_name, file_name, line, col, inlined_str);
     }
     else {
         jl_safe_fprintf(s, "%s at %s (unknown line)%s\n", func_name, file_name, inlined_str);
@@ -850,39 +854,12 @@ void jl_fprint_native_codeloc(ios_t *s, uintptr_t ip) JL_NOTSAFEPOINT
             jl_safe_fprintf(s, "unknown function (ip: %p) at %s\n", (void*)ip, frame.file_name ? frame.file_name : "(unknown file)");
         }
         else {
-            jl_safe_fprint_codeloc(s, frame.func_name, frame.file_name, frame.line, frame.pc, frame.inlined);
+            jl_safe_fprint_codeloc(s, frame.func_name, frame.file_name, frame.line, 0, frame.pc, frame.inlined);
             free(frame.func_name);
         }
         free(frame.file_name);
     }
     free(frames);
-}
-
-const char *jl_debuginfo_file1(jl_debuginfo_t *debuginfo)
-{
-    jl_value_t *def = debuginfo->def;
-    if (jl_is_method_instance(def))
-        def = ((jl_method_instance_t*)def)->def.value;
-    if (jl_is_method(def))
-        def = (jl_value_t*)((jl_method_t*)def)->file;
-    if (jl_is_symbol(def))
-        return jl_symbol_name((jl_sym_t*)def);
-    return "<unknown>";
-}
-
-// File name and line number of first line
-const char *jl_debuginfo_firstline(jl_debuginfo_t *debuginfo, int* line)
-{
-    jl_value_t *linetable = (jl_value_t*)debuginfo;
-    while (jl_is_debuginfo(linetable)) {
-        debuginfo = (jl_debuginfo_t*)linetable;
-        linetable = debuginfo->linetable;
-    }
-    if (line) {
-        struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo, 0);
-        *line = lineidx.loc;
-    }
-    return jl_debuginfo_file1(debuginfo);
 }
 
 jl_module_t *jl_debuginfo_module1(jl_value_t *debuginfo_def)
@@ -932,8 +909,9 @@ static void jl_fprint_debugloc(ios_t *s, jl_debuginfo_t *debuginfo, jl_value_t *
         if (ip2 < 0) // set broken debug info to ignored
             ip2 = 0;
         const char *func_name = jl_debuginfo_name(func);
-        const char *file = jl_debuginfo_firstline(debuginfo, NULL);
-        jl_safe_fprint_codeloc(s, func_name, file, ip2, (int)ip, inlined);
+        const char *file = jl_cdi_file(debuginfo);
+        jl_locspan_t xy = jl_cdi_firstxy(debuginfo, ip2);
+        jl_safe_fprint_codeloc(s, func_name, file, xy.first, xy.second, (int)ip, inlined);
     }
 }
 

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -726,8 +726,8 @@ JL_DLLEXPORT jl_value_t *jl_eval_thunk(jl_module_t *JL_NONNULL m, jl_code_info_t
     // start of this block.
     int last_lineno = jl_atomic_load_relaxed(&jl_lineno);
     const char *last_filename = jl_atomic_load_relaxed(&jl_filename);
-    int toplevel_lineno = 0;
-    const char* toplevel_filename = jl_debuginfo_firstline(thk->debuginfo, &toplevel_lineno);
+    int toplevel_lineno = jl_cdi_firstline_all(thk->debuginfo);
+    const char *toplevel_filename = jl_cdi_file(thk->debuginfo);
     jl_atomic_store_relaxed(&jl_lineno, toplevel_lineno);
     jl_atomic_store_relaxed(&jl_filename, toplevel_filename);
 


### PR DESCRIPTION
This change adds a basic C API for reading `jl_debuginfo_t`, both in its current
form and with byte-precise provenance to be generated by JuliaLowering.

```
(debuginfo, pc) -> (firstbyte, lastbyte)
(debuginfo, byte) -> (line, column)
(debuginfo, pc) -> (firstline, firstcolumn)
debuginfo -> first_line_of_entire_codeinfo
```

Note that the byte-precise provenance is not yet produced (and I've marked those
branches unreachable).  I'm making this change first so I can use them to try
and resolve issues in #61699 and #53925. (Namely, I'm going to try and compute
inlined frames from julia debuginfo rather than DWARF.)

## Implementation of byte-precise info storage

The API shouldn't depend on how we do this, but I'll describe it here for
reference.

The simplicity of our current `Core.DebugInfo` (ref. #52415) is thanks to simple
line numbers looking the same as indices into the next debuginfo, so they can be
stored in the same way.  Unfortunately, byte-precise information breaks this:
from an index, we want to be able to know two byte positions, what lines they
fall on, and how far from the beginning of those lines they are.

I intend to store this info by putting a string in `linetable` like we do for
`di.codelocs`.  The compression format is described in julia.h, but only a
couple points are relevant here:
- Like `di.codelocs` today, I made a reasonable attempt to compress it (so we
  don't blow up the sysimg) without trying to be too clever.
- Position lookup for a single IR statement can still be done without
  decompressing everything.

I've already implemented the compression/decompression code (in JuliaLowering),
but it's not part of this PR.  This format might be torn out when we start
trying to store AST provenance.
