### PR TITLE
[WIP] Recover inlined frames using `Core.Debuginfo` instead of DWARF

### DIFF
--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -127,48 +127,33 @@ up stack frame context information. Returns an array of frame information for al
 inlined at that point, innermost function first.
 """
 Base.@constprop :none function lookup(pointer::Ptr{Cvoid})
-    infos = @ccall jl_lookup_code_address(pointer::Ptr{Cvoid}, false::Cint)::Core.SimpleVector
+    frames = @ccall jl_lookup_code_address(pointer::Ptr{Cvoid}, false::Cint)::Core.SimpleVector
     pointer = convert(UInt64, pointer)
-    isempty(infos) && return [StackFrame(empty_sym, empty_sym, -1, nothing, true, false, pointer)] # this is equal to UNKNOWN
-    ninfos = length(infos)
-    res = Vector{StackFrame}(undef, ninfos)
-    local debuginfo = false
-    local parent_pc = 0
-    for i = ninfos:-1:1
-        info = infos[i]::Core.SimpleVector
-        @assert length(info) == 7 "corrupt return from jl_lookup_code_address"
-        func = info[1]::Symbol
-        file = info[2]::Symbol
-        linenum = info[3]::Int
-        linfo = info[4]
-        pc = info[7]::Int
-        if linfo isa Core.CodeInstance
-            if debuginfo === false
-                debuginfo = linfo.debuginfo
-            else
-                debuginfo = true
-            end
-            linfo = linfo.def
-        elseif debuginfo isa Core.DebugInfo && parent_pc > 0
-            # Use the parent frame's PC to look up which inlining edge of the
-            # current `debuginfo` corresponds to this frame's call site.
-            _, to::Int, _ = debuginfo_codeloc(debuginfo, parent_pc)
-            if to > 0 && to <= length(debuginfo.edges)
-                debuginfo = debuginfo.edges[to]::Core.DebugInfo
-                def = debuginfo.def
-                if !(def isa Symbol)
-                    linfo = def
-                end
-            else
-                debuginfo = true
-            end
-        end
-        parent_pc = pc
-        res[i] = StackFrame(func, file, linenum, linfo, info[5]::Bool, info[6]::Bool, pointer, pc)
-    end
-    return res
-end
+    isempty(frames) && return [StackFrame(empty_sym, empty_sym, -1, nothing, true, false, pointer)] # this is equal to UNKNOWN
 
+    out = Vector{StackFrame}(undef, length(frames))
+    for i in eachindex(frames)
+        f = frames[i]
+        @assert length(f) == 8 "corrupt return from jl_lookup_code_address"
+        func = f[1]::Symbol
+        file = f[2]::Symbol
+        linenum = f[3]::Int
+        linfo = f[4]
+        from_c = f[5]::Bool
+        inlined = f[6]::Bool
+        pc = f[7]::Int
+        debuginfo = f[8]
+        # TODO: make linfo consistently CI instead of MI
+        if (debuginfo isa Core.DebugInfo && debuginfo.def isa Core.MethodInstance)
+            linfo = debuginfo.def
+        elseif linfo isa Core.CodeInstance
+            linfo = linfo.def::Core.MethodInstance
+        end
+        out[i] = StackFrame(
+            func, file, linenum, linfo, from_c, inlined, pointer, pc)
+    end
+    return out
+end
 const top_level_scope_sym = Symbol("top-level scope")
 
 function lookup(ip::Base.InterpreterIP)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9280,6 +9280,10 @@ static jl_llvm_functions_t
         ssize_t line0; // if this represents pc=1, then also cover the entry to the function (pc=0)
         bool is_user_code;
         int32_t edgeid;
+        // TODO: unused.  A statment may have line 0, which means it should have
+        // approximately the same location as the previous statement, but if
+        // executed, should not count toward that location's code coverage.
+        bool no_coverage;
         bool sameframe(const DebugLineTable &other) const {
             // detect if the line info for this frame is unchanged (equivalent to loc == other.loc ignoring the inlined_at field)
             return other.edgeid == edgeid && other.line == line;
@@ -9294,94 +9298,37 @@ static jl_llvm_functions_t
     topinfo.edgeid = 0;
     std::map<std::tuple<StringRef, StringRef>, DISubprogram*> subprograms;
     SmallVector<DebugLineTable, 0> prev_lineinfo, new_lineinfo;
-    auto update_lineinfo = [&] (size_t pc) {
-        std::function<bool(jl_debuginfo_t*, jl_value_t*, size_t, size_t)> append_lineinfo =
-                [&] (jl_debuginfo_t *debuginfo, jl_value_t *func, size_t to, size_t pc) -> bool {
-            while (1) {
-                if (!jl_is_symbol(debuginfo->def)) // this is a path
-                    func = debuginfo->def; // this is inlined
-                struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo, pc);
-                size_t i = lineidx.loc;
-                if (i < 0) // pc out of range: broken debuginfo?
-                    return false;
-                if (i == 0 && lineidx.to == 0) // no update
-                    return false;
-                if (pc > 0 && jl_is_debuginfo(debuginfo->linetable)) {
-                    // indirection node
-                    if (!append_lineinfo((jl_debuginfo_t *)debuginfo->linetable,
-                                         func, to, i))
-                        return false; // no update
-                }
-                else {
-                    // actual node
-                    DebugLineTable info;
-                    info.edgeid = to;
-                    jl_module_t *modu = func ? jl_debuginfo_module1(func) : NULL;
-                    if (modu == NULL)
-                        modu = ctx.module;
-                    info.file = jl_cdi_file(debuginfo);
-                    info.line = i;
-                    info.line0 = 0;
-                    if (pc == 1) {
-                        int32_t line0 = jl_cdi_external_firstline(debuginfo);
-                        if (line0 > 0 && info.line != line0)
-                            info.line0 = line0;
-                    }
-                    if (info.file.empty())
-                        info.file = "<missing>";
-                    if (modu == ctx.module)
-                        info.is_user_code = mod_is_user_mod;
-                    else
-                        info.is_user_code = in_user_mod(modu);
-                    if (debug_enabled) {
-                        StringRef fname = jl_debuginfo_name(func);
-                        // Encode the 1-based statement index into the DWARF column field so that
-                        // stacktraces can recover the exact PC that each inlined frame points at.
-                        // `pc` here is the 1-based statement index within `debuginfo`'s CodeInfo.
-                        unsigned col = (unsigned)pc;
-                        if (new_lineinfo.empty() && info.file == ctx.file) { // if everything matches, emit a toplevel line number
-                            info.loc = DILocation::get(ctx.builder.getContext(), info.line, col, SP, NULL);
-                        }
-                        else { // otherwise, describe this as an inlining frame
-                            DebugLoc inl_loc = new_lineinfo.empty() ? DebugLoc(DILocation::get(ctx.builder.getContext(), 0, 0, SP, NULL)) : new_lineinfo.back().loc;
-                            DISubprogram *&inl_SP = subprograms[std::make_tuple(fname, info.file)];
-                            if (inl_SP == NULL) {
-                                DIFile *difile = dbuilder.createFile(info.file, ".");
-                                inl_SP = dbuilder.createFunction(difile
-                                                             ,std::string(fname) + ";" // Name
-                                                             ,fname            // LinkageName
-                                                             ,difile           // File
-                                                             ,0                // LineNo
-                                                             ,debugcache.jl_di_func_null_sig // Ty
-                                                             ,0                // ScopeLine
-                                                             ,DINode::FlagZero // Flags
-                                                             ,DISubprogram::SPFlagDefinition | DISubprogram::SPFlagOptimized // SPFlags
-                                                             ,nullptr          // Template Parameters
-                                                             ,nullptr          // Template Declaration
-                                                             ,nullptr          // ThrownTypes
-                                                             );
-                            }
-                            info.loc = DILocation::get(ctx.builder.getContext(), info.line, col, inl_SP, inl_loc);
-                        }
-                    }
-                    new_lineinfo.push_back(info);
-                }
-                to = lineidx.to;
-                if (to == 0)
-                    return true;
-                pc = lineidx.pc;
-                debuginfo = (jl_debuginfo_t*)jl_svecref(debuginfo->edges, to - 1);
-                func = NULL;
-            }
-        };
-        prev_lineinfo.truncate(0);
-        std::swap(prev_lineinfo, new_lineinfo);
-        bool updated = append_lineinfo(src->debuginfo, (jl_value_t*)lam, 0, pc + 1);
-        if (!updated)
-            std::swap(prev_lineinfo, new_lineinfo);
-        else
-            assert(new_lineinfo.size() > 0);
-        return updated;
+
+    size_t lastpc = 0;
+    DebugLineTable dl(topinfo); // updated with each update_lineinfo call
+    auto update_lineinfo = [&](size_t pc) {
+        if (pc < 1) {
+            jl_safe_printf(
+                "update_lineinfo:small pc???: ctx.file=%s, pc=%d",
+                ctx.file.str().c_str(), pc);
+            jl_(lam);
+            return false;
+        }
+        int32_t line = jl_cdi_firstxy(src->debuginfo, pc).first;
+        if (dl.line == line && lastpc == pc) {
+            jl_safe_printf(
+                "update_lineinfo:same pc??: ctx.file=%s, pc=%d, line=%d",
+                ctx.file.str().c_str(), pc, line);
+            jl_(lam);
+        }
+
+        if (line < 0) {
+            return false;
+        } else if (line == 0) {
+            dl.no_coverage = true;
+            line = dl.line;
+        }
+        lastpc = pc;
+        // Stash the 1-based `pc` in the DWARF column field so that stacktraces
+        // can recover it.
+        dl.line = line;
+        dl.loc = DILocation::get(ctx.builder.getContext(), line, pc, SP, NULL);
+        return true;
     };
 
     SmallVector<MDNode*, 0> aliasscopes;
@@ -9479,6 +9426,7 @@ static jl_llvm_functions_t
     auto coverageVisitStmt = [&] () {
         // Visit frames which differ from previous statement as tracked in
         // prev_lineinfo (tracked outer frame first).
+        // TODO: new_lineinfo length is 1, so inlined lines are missed.
         size_t dbg;
         for (dbg = 0; dbg < new_lineinfo.size(); dbg++) {
             if (dbg >= prev_lineinfo.size() || !new_lineinfo[dbg].sameframe(prev_lineinfo[dbg]))
@@ -9559,10 +9507,10 @@ static jl_llvm_functions_t
 
     find_next_stmt(0);
     while (cursor != -1) {
-        bool have_dbg_update = update_lineinfo(cursor);
+        bool have_dbg_update = update_lineinfo(cursor + 1);
         if (have_dbg_update) {
             if (debug_enabled)
-                ctx.builder.SetCurrentDebugLocation(new_lineinfo.back().loc);
+                ctx.builder.SetCurrentDebugLocation(dl.loc);
             coverageVisitStmt();
         }
         ctx.noalias().aliasscope.current = aliasscopes[cursor];

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8531,8 +8531,8 @@ static jl_llvm_functions_t
     }
     else if ((jl_value_t*)src->debuginfo != jl_nothing) {
         // look for the file and line info of the original start of this block, as reported by lowering
-        ctx.file = jl_debuginfo_firstline(src->debuginfo, &toplineno);
-        toplineno = std::max(0, toplineno);
+        ctx.file = jl_cdi_file(src->debuginfo);
+        toplineno = std::max(0, jl_cdi_firstline_all(src->debuginfo));
     }
     if (ctx.file.empty())
         ctx.file = "<missing>";
@@ -9319,14 +9319,13 @@ static jl_llvm_functions_t
                     jl_module_t *modu = func ? jl_debuginfo_module1(func) : NULL;
                     if (modu == NULL)
                         modu = ctx.module;
-                    info.file = jl_debuginfo_file1(debuginfo);
+                    info.file = jl_cdi_file(debuginfo);
                     info.line = i;
                     info.line0 = 0;
                     if (pc == 1) {
-                        struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo, 0);
-                        assert(lineidx.to == 0 && lineidx.pc == 0);
-                        if (lineidx.loc > 0 && info.line != lineidx.loc)
-                            info.line0 = lineidx.loc;
+                        int32_t line0 = jl_cdi_external_firstline(debuginfo);
+                        if (line0 > 0 && info.line != line0)
+                            info.line0 = line0;
                     }
                     if (info.file.empty())
                         info.file = "<missing>";
@@ -9518,7 +9517,7 @@ static jl_llvm_functions_t
             jl_module_t *modu = func ? jl_debuginfo_module1(func) : NULL;
             if (modu == NULL)
                 modu = ctx.module;
-            StringRef file = jl_debuginfo_file1(debuginfo);
+            StringRef file = jl_cdi_file(debuginfo);
             if (file.empty())
                 file = "<missing>";
             bool is_user_code;
@@ -9528,7 +9527,10 @@ static jl_llvm_functions_t
                 is_user_code = in_user_mod(modu);
             bool is_tracked = in_tracked_path(file);
             if (do_coverage(is_user_code, is_tracked)) {
-                for (size_t pc = 0; 1; pc++) {
+                int32_t extraline = jl_cdi_external_firstline(debuginfo);
+                if (extraline != -1)
+                    jl_coverage_alloc_line(file.data(), extraline);
+                for (size_t pc = 1; 1; pc++) {
                     struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo, pc);
                     if (lineidx.loc == -1)
                         break;

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -437,13 +437,36 @@ done:
     return std::make_pair(strdup(name), false);
 }
 
-// *frames is a one element array containing whatever we could come up
-// with for the current frame. here we'll try to expand it using debug info
-// func_name and file_name are either NULL or malloc'd pointers
+static void fill_frame_from_di(jl_frame_t *frame, const DILineInfo &info,
+                               int inlined, jl_code_instance_t *ci)
+{
+    std::string file_name(info.FileName);
+    std::string func_name(info.FunctionName);
+    if (func_name == "<invalid>")
+        frame->func_name = NULL;
+    else
+        jl_copy_str(&frame->func_name, func_name.c_str());
+    if (!frame->func_name)
+        frame->from_c = 1;
+
+    if (file_name == "<invalid>")
+        frame->file_name = NULL;
+    else
+        jl_copy_str(&frame->file_name, file_name.c_str());
+    frame->line = info.Line;
+    frame->pc = info.Column;
+    frame->inlined = inlined;
+    frame->ci = ci;
+    assert(frame->pc > 0 && "negative frame->pc");
+}
+
+// *frames is a one element array with, where frames[0] has at least `ci` and
+// `from_c` initialized.  Given this, expand frames at `pointer`.  The resulting
+// array is ordered inlinees-first, the last result being !inlined.
 static int lookup_pointer(
         object::SectionRef Section, DIContext *context,
         jl_frame_t **frames, size_t pointer, uint64_t slide,
-        bool demangle, bool noInline) JL_NOTSAFEPOINT
+        bool demangle, bool ignore_inlined) JL_NOTSAFEPOINT
 {
     // This function is not allowed to reference any TLS variables
     // since it can be called from an unmanaged thread on OSX.
@@ -453,7 +476,7 @@ static int lookup_pointer(
             if (oldname != NULL) {
                 std::pair<char *, bool> demangled = jl_demangle(oldname);
                 (*frames)[0].func_name = demangled.first;
-                (*frames)[0].fromC = !demangled.second;
+                (*frames)[0].from_c = !demangled.second;
                 free(oldname);
             }
             else {
@@ -461,7 +484,7 @@ static int lookup_pointer(
                 // but it is still good to have them for regular lookup of C frames.
                 // Technically not true, but we don't want them
                 // in julia backtraces, so close enough
-                (*frames)[0].fromC = 1;
+                (*frames)[0].from_c = 1;
             }
         }
         return 1;
@@ -471,73 +494,90 @@ static int lookup_pointer(
 
     // DWARFContext/DWARFUnit update some internal tables during these queries, so
     // a lock is needed.
-    if (!jl_lock_profile_wr())
-        return lookup_pointer(object::SectionRef(), NULL, frames, pointer, slide, demangle, noInline);
-    auto inlineInfo = context->getInliningInfoForAddress(makeAddress(Section, pointer + slide), infoSpec);
+    if (!jl_lock_profile_wr()) {
+        return lookup_pointer(object::SectionRef(), NULL, frames, pointer,
+                              slide, demangle, ignore_inlined);
+    }
+
+    auto inlineInfo = context->getInliningInfoForAddress(
+        makeAddress(Section, pointer + slide), infoSpec);
     jl_unlock_profile_wr();
 
-    int fromC = (*frames)[0].fromC;
+    jl_frame_t *lastf = &(*frames)[0];
     int n_frames = inlineInfo.getNumberOfFrames();
+    assert(n_frames == 0 || n_frames == 1 || lastf->from_c);
+
+    // no line number info available in the context, return without the context
     if (n_frames == 0) {
-        // no line number info available in the context, return without the context
-        return lookup_pointer(object::SectionRef(), NULL, frames, pointer, slide, demangle, noInline);
+        return lookup_pointer(object::SectionRef(), NULL, frames, pointer,
+                              slide, demangle, ignore_inlined);
     }
-    if (noInline)
-        n_frames = 1;
-    if (n_frames > 1) {
-        jl_frame_t *new_frames = (jl_frame_t*)calloc(n_frames, sizeof(jl_frame_t));
-        memcpy(&new_frames[n_frames - 1], *frames, sizeof(jl_frame_t));
+    fill_frame_from_di(lastf, inlineInfo.getFrame(n_frames-1), 0, lastf->ci);
+
+    // fill inlining frames, moving lastf to end of array
+    // TODO: inlining frames in .linetable are ignored (currently just macro linenodes)
+    if (lastf->from_c) {
+        if (n_frames == 1) {
+            return 1;
+        }
+        jl_frame_t *new_frames =
+            (jl_frame_t *)calloc(n_frames, sizeof(jl_frame_t));
+        memcpy(&new_frames[n_frames - 1], lastf, sizeof(jl_frame_t));
         free(*frames);
         *frames = new_frames;
+        for (int i = 0; i < n_frames-1; i++) {
+            jl_frame_t *frame = &(*frames)[i];
+            fill_frame_from_di(frame, inlineInfo.getFrame(i), 1, NULL);
+            frame->from_c = 1;
+            frame->debuginfo = NULL;
+        }
     }
-    for (int i = 0; i < n_frames; i++) {
-        bool inlined_frame = i != n_frames - 1;
-        DILineInfo info;
-        if (!noInline) {
-            info = inlineInfo.getFrame(i);
+    else {
+        if (ignore_inlined || !lastf->ci || !lastf->ci->debuginfo) {
+            return 1;
         }
-        else {
-            int havelock = jl_lock_profile_wr();
-            assert(havelock); (void)havelock;
-            auto lineinfo = context->getLineInfoForAddress(makeAddress(Section, pointer + slide), infoSpec);
-            jl_unlock_profile_wr();
-#if JL_LLVM_VERSION < 210000
-            info = std::move(lineinfo);
-#else
-            info = std::move(lineinfo.value());
-#endif
+        lastf->debuginfo = lastf->ci->debuginfo;
+        jl_debuginfo_t *di = lastf->debuginfo;
+        jl_codeloc_t loc0 = jl_uncompress1_codeloc(lastf->debuginfo, lastf->pc);
+        jl_codeloc_t loc = loc0;
+        while (loc.to > 0) { // just to count frames for calloc
+            n_frames++;
+            di = (jl_debuginfo_t *)jl_svecref(di->edges, loc.to-1);
+            loc = jl_uncompress1_codeloc(di, loc.pc);
         }
-
-        jl_frame_t *frame = &(*frames)[i];
-        std::string func_name(info.FunctionName);
-
-        if (inlined_frame) {
-            frame->inlined = 1;
-            frame->fromC = fromC;
-            if (!fromC) {
-                std::size_t semi_pos = func_name.find(';');
-                if (semi_pos != std::string::npos) {
-                    func_name = func_name.substr(0, semi_pos);
-                    frame->ci = NULL; // Looked up on Julia side
-                }
+        if (n_frames > 1) {
+            jl_frame_t *new_frames =
+                (jl_frame_t *)calloc(n_frames, sizeof(jl_frame_t));
+            memcpy(&new_frames[n_frames - 1], lastf, sizeof(jl_frame_t));
+            free(*frames);
+            *frames = new_frames;
+            lastf = &(*frames)[n_frames - 1];
+            di = lastf->debuginfo;
+            loc = loc0;
+            for (int i = n_frames-2; i >= 0; i--) {
+                di = (jl_debuginfo_t*)jl_svecref(di->edges, loc.to-1);
+                loc = jl_uncompress1_codeloc(di, loc.pc);
+                jl_frame_t *frame = &(*frames)[i];
+                jl_copy_str(&frame->func_name, jl_debuginfo_name(di->def));
+                jl_copy_str(&frame->file_name, jl_cdi_file(di));
+                frame->debuginfo = di;
+                if (loc.pc > 0)
+                    frame->line = jl_cdi_firstxy(di, loc.pc).first;
+                else
+                    frame->line = jl_cdi_firstline_all(di);
+                frame->pc = loc.pc;
+                frame->ci = NULL;
+                frame->from_c = !frame->func_name ? 1 : 0;
+                frame->inlined = 1;
+                // if (!from_c) {
+                //     std::size_t semi_pos = func_name.find(';');
+                //     if (semi_pos != std::string::npos) {
+                //         func_name = func_name.substr(0, semi_pos);
+                //         frame->ci = NULL; // Looked up on Julia side
+                //     }
+                // }
             }
         }
-
-        if (func_name == "<invalid>")
-            frame->func_name = NULL;
-        else
-            jl_copy_str(&frame->func_name, func_name.c_str());
-        if (!frame->func_name)
-            frame->fromC = 1;
-
-        frame->line = info.Line;
-        frame->pc = info.Column;
-        std::string file_name(info.FileName);
-
-        if (file_name == "<invalid>")
-            frame->file_name = NULL;
-        else
-            jl_copy_str(&frame->file_name, file_name.c_str());
     }
     return n_frames;
 }
@@ -1039,6 +1079,7 @@ static jl_object_file_entry_t find_object_file(uint64_t fbase, StringRef fname) 
 }
 
 // from llvm::SymbolizableObjectFile
+// XXX: on macOS, `Sec.getSize()` may return a too-small value
 static object::SectionRef getModuleSectionForAddress(const object::ObjectFile *obj, uint64_t Address) JL_NOTSAFEPOINT
 {
   for (object::SectionRef Sec : obj->sections()) {
@@ -1049,7 +1090,6 @@ static object::SectionRef getModuleSectionForAddress(const object::ObjectFile *o
   }
   return object::SectionRef();
 }
-
 
 bool jl_dylib_DI_for_fptr(size_t pointer, object::SectionRef *Section, uint64_t *slide, llvm::DIContext **context,
     bool onlyImage, bool *isImage, uint64_t *_fbase, void **saddr, char **name, char **filename) JL_NOTSAFEPOINT
@@ -1200,11 +1240,12 @@ static int jl_getDylibFunctionInfo(jl_frame_t **frames, size_t pointer, int skip
     bool isImage;
     void *saddr;
     uint64_t fbase;
-    if (!jl_dylib_DI_for_fptr(pointer, &Section, &slide, &context, skipC, &isImage, &fbase, &saddr, &frame0->func_name, &frame0->file_name)) {
-        frame0->fromC = 1;
+    if (!jl_dylib_DI_for_fptr(pointer, &Section, &slide, &context, skipC, &isImage, &fbase,
+                              &saddr, &frame0->func_name, &frame0->file_name)) {
+        frame0->from_c = 1;
         return 1;
     }
-    frame0->fromC = !isImage;
+    frame0->from_c = !isImage;
     {
         JITDebugInfoRegistry::image_info_t image;
         bool inimage = getJITDebugRegistry().get_image_info(fbase, &image);
@@ -1232,8 +1273,9 @@ int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, uint64_t *slide,
         object::SectionRef *Section, llvm::DIContext **context) JL_NOTSAFEPOINT
 {
     int found = 0;
-    if (!jl_lock_profile_wr())
+    if (!jl_lock_profile_wr()) {
         return 0;
+    }
 
     if (symsize)
         *symsize = 0;
@@ -1277,7 +1319,6 @@ int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, uint64_t *slide,
     return found;
 }
 
-// Set *name and *filename to either NULL or malloc'd string
 extern "C" JL_DLLEXPORT_CODEGEN int jl_getFunctionInfo_impl(jl_frame_t **frames_out, size_t pointer, int skipC, int noInline) JL_NOTSAFEPOINT
 {
     // This function is not allowed to reference any TLS variables if noInline
@@ -1293,6 +1334,7 @@ extern "C" JL_DLLEXPORT_CODEGEN int jl_getFunctionInfo_impl(jl_frame_t **frames_
     uint64_t symsize;
     if (jl_DI_for_fptr(pointer, &symsize, &slide, &Section, &context)) {
         frames[0].ci = getJITDebugRegistry().lookupCodeInstance(pointer);
+        frames[0].from_c = false;
         int nf = lookup_pointer(Section, context, frames_out, pointer, slide, true, noInline);
         return nf;
     }

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1442,9 +1442,145 @@ JL_DLLEXPORT struct jl_codeloc_t jl_uncompress1_codeloc(jl_debuginfo_t *di, size
     assert(jl_is_string(cl));
     int loc_offset, loc_bytes, to_bytes;
     size_t nstmts = codelocs_parseheader(cl, &loc_offset, &loc_bytes, &to_bytes);
-    if (pc > nstmts)
-        return badloc;
+    if (pc < 0 || pc > nstmts)
+        return badloc; // ideally an assertion, but currently happens too often
     return unpack_codeloc(cl, pc, loc_offset, loc_bytes, to_bytes);
+}
+
+static const char *sbt_parseheader(jl_string_t *str, jl_sourcebytetable_header_t *h) JL_NOTSAFEPOINT
+{
+    assert(jl_is_string(str));
+    const char *ptr = jl_string_data(str);
+    memcpy(h, ptr, SBT_HEADER_SIZE); // TODO assumes LE
+    return ptr + SBT_HEADER_SIZE;
+}
+
+/* `jl_cdi_*`: barebones non-allocating interface for reading compressed
+ * debuginfo.  Only `jl_cdi_firstxy` may be used on line-based DebugInfo.
+ * All byte positions, line numbers, column numbers, and program counters are
+ * 1-based, and all ranges are inclusive-inclusive. */
+
+/* traverse `di.linetable` (towards line/byte information, ignoring edges),
+ * returning new debuginfo in `p_di` and optionally pc in `p_pc`. */
+static void cdi_deref(jl_debuginfo_t **p_di, int32_t *p_pc, int recursive) JL_NOTSAFEPOINT
+{
+    jl_debuginfo_t *di = *p_di;
+    int32_t pc = 0;
+    if (!p_pc)
+        p_pc = &pc;
+    if (jl_typeof(di->linetable) == (jl_value_t *)jl_debuginfo_type) {
+        *p_pc = jl_uncompress1_codeloc(di, *p_pc).loc;
+        *p_di = (jl_debuginfo_t *)di->linetable;
+        if (recursive) {
+            cdi_deref(p_di, p_pc, recursive);
+        }
+    } else {
+        if (jl_is_string(di->linetable)) {jl_unreachable();} // TODO: remove when byte-precise
+        assert(jl_is_string(di->linetable) || jl_is_nothing(di->linetable));
+    }
+}
+
+JL_DLLEXPORT jl_locspan_t jl_cdi_bytespan(jl_debuginfo_t *di, int32_t pc) JL_NOTSAFEPOINT
+{
+    jl_unreachable(); // TODO: remove when byte-precise
+    cdi_deref(&di, &pc, 1);
+    pc = jl_uncompress1_codeloc(di, pc).loc;
+    jl_sourcebytetable_header_t h;
+    const char *ptr = sbt_parseheader(di->linetable, &h);
+    if (pc <= 0 || pc > h.nlocs) {
+        return (jl_locspan_t){-1, -1};
+    }
+    ptr += (pc-1)*(h.byte_encl+h.span_encl);
+    jl_locspan_t out;
+    out.first = _take_u32(&ptr, h.byte_encl) + h.byte_offset;
+    out.second = _take_u32(&ptr, h.span_encl) + out.first - 1;
+    return out;
+}
+
+/* O(line_starts); could binary search instead */
+JL_DLLEXPORT jl_locspan_t jl_cdi_byte_to_xy(jl_debuginfo_t *di, int32_t b) JL_NOTSAFEPOINT
+{
+    jl_unreachable(); // TODO: remove when byte-precise
+    cdi_deref(&di, NULL, 1);
+    jl_sourcebytetable_header_t h;
+    sbt_parseheader(di->linetable, &h);
+    size_t off = SBT_HEADER_SIZE + h.nlocs * (h.byte_encl + h.span_encl);
+    size_t n_lines = (jl_string_len(di->linetable) - off) / h.byte_encl;
+    jl_locspan_t out = {h.line_offset-1, -1};
+    const char *ptr = jl_string_data(di->linetable) + off;
+    for (int i = 0; i < n_lines; i++) {
+        int32_t line_start = _take_u32(&ptr, h.byte_encl);
+        if (line_start + h.byte_offset <= b) {
+            out.second = b - (line_start + h.byte_offset) + 1;
+            out.first++;
+        } else if (i == 0) { // b too small
+            return (jl_locspan_t){-1, -1};
+        } else {
+            break;
+        }
+    }
+    return out;
+}
+
+/* First (line, col) at the given pc, where col=-1 if unavailable */
+JL_DLLEXPORT jl_locspan_t jl_cdi_firstxy(jl_debuginfo_t *di, int32_t pc) JL_NOTSAFEPOINT
+{
+    assert(pc > 0);
+    cdi_deref(&di, &pc, 1);
+    jl_locspan_t out = {-1, -1};
+    if (jl_is_nothing(di->linetable)) {
+        out.first = jl_uncompress1_codeloc(di, pc).loc;
+    } else if (jl_is_string(di->linetable)) {
+        out = jl_cdi_byte_to_xy(di, jl_cdi_bytespan(di, pc).first);
+    }
+    return out;
+}
+
+/* Only when linetable==nothing, it's possible to have a separate first line not
+ * associated with any IR statement (the extra firstline argument to
+ * jl_compress_codelocs).  Coverage uses this.  -1 if not present.  Ideally the
+ * >-1 case will be deprecated, since this implementation doesn't allow a
+ * linetable to be shared between multiple owners */
+JL_DLLEXPORT int32_t jl_cdi_external_firstline(jl_debuginfo_t *di) JL_NOTSAFEPOINT
+{
+    int32_t pc = 0;
+    cdi_deref(&di, &pc, 1);
+    if (jl_is_nothing(di->linetable)) {
+        int32_t out = jl_uncompress1_codeloc(di, 0).loc;
+        return out > 0 ? out : -1;
+    } else if (jl_is_string(di->linetable)) {
+        return -1;
+    }
+    jl_unreachable();
+}
+
+JL_DLLEXPORT int32_t jl_cdi_firstline_all(jl_debuginfo_t *di) JL_NOTSAFEPOINT
+{
+    int32_t out = jl_cdi_external_firstline(di);
+    if (out == -1) {
+        /* TODO: not necessarily first, but a good enough guess for display */
+        cdi_deref(&di, NULL, 1);
+        out = jl_cdi_firstxy(di, 1).first;
+    }
+    return out;
+}
+
+JL_DLLEXPORT const char *jl_cdi_file(jl_debuginfo_t *di) JL_NOTSAFEPOINT
+{
+    cdi_deref(&di, NULL, 1);
+    if (jl_is_symbol(di->def)) {
+        return jl_symbol_name((jl_sym_t*)di->def);
+    } else if (jl_is_method_instance(di->def)) {
+        // reachable with hand-crafted CodeInstances in base tests
+        jl_value_t *m = ((jl_method_instance_t *)di->def)->def.value;
+        assert(jl_is_method(m));
+        return jl_symbol_name(((jl_method_t*)m)->file);
+    } else if (jl_is_nothing(di->def)) {
+        // reachable when linenumbernode.file is nothing (through method.c)
+        return "<unknown>";
+    } else {
+        jl_error("unexpected type for debuginfo.def");
+    }
 }
 
 static int allzero(jl_value_t *codelocs) JL_NOTSAFEPOINT

--- a/src/julia.h
+++ b/src/julia.h
@@ -235,15 +235,40 @@ JL_DLLEXPORT extern const jl_callptr_t jl_f_opaque_closure_call_addr;
 
 JL_DLLEXPORT extern const jl_callptr_t jl_fptr_wait_for_compiled_addr;
 
+typedef struct _jl_locspan_t {
+    int32_t first;
+    int32_t second;
+} jl_locspan_t;
+
 struct jl_codeloc_t {
     int32_t loc;
     int32_t to;
     int32_t pc;
 };
 
+// In a compressed jl_debuginfo_t linetable string, this header is followed by
+// (with byte_offest subtracted from all raw byte positions):
+//
+// bytespans: (byte_encl+span_encl)*nlocs bytes
+// line_starts: byte_encl*rest bytes
+typedef struct _jl_sourcebytetable_header_t {
+    // (>0) minimum byte
+    int32_t byte_offset;
+    // (>0) minimum line, where line_starts[0] is the byte position of this
+    // line's first character
+    int32_t line_offset;
+    // (>=0) number of (byte, len) bytespans
+    int32_t nlocs;
+    // (0,1,2,4) compressed lengths
+    uint8_t byte_encl;
+    uint8_t span_encl;
+} jl_sourcebytetable_header_t;
+// packed size
+#define SBT_HEADER_SIZE 14
+
 typedef struct _jl_debuginfo_t {
     jl_value_t *def;
-    jl_value_t *linetable; // debuginfo or nothing
+    jl_value_t *linetable; // debuginfo, compressed string, or nothing
     jl_svec_t *edges; // Memory{DebugInfo}
     jl_value_t *codelocs; // String // Memory{UInt8} // compressed info
 } jl_debuginfo_t;
@@ -2297,6 +2322,12 @@ JL_DLLEXPORT jl_value_t *jl_uncompress_argname_n(jl_value_t *syms, size_t i);
 JL_DLLEXPORT struct jl_codeloc_t jl_uncompress1_codeloc(jl_debuginfo_t *di, size_t pc) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_compress_codelocs(int32_t firstloc, jl_value_t *codelocs, size_t nstmts);
 JL_DLLEXPORT jl_value_t *jl_uncompress_codelocs(jl_debuginfo_t *di, size_t nstmts);
+JL_DLLEXPORT jl_locspan_t jl_cdi_bytespan(jl_debuginfo_t *di, int32_t pc) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_locspan_t jl_cdi_byte_to_xy(jl_debuginfo_t *di, int32_t b) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_locspan_t jl_cdi_firstxy(jl_debuginfo_t *di, int32_t pc) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int32_t jl_cdi_external_firstline(jl_debuginfo_t *di) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int32_t jl_cdi_firstline_all(jl_debuginfo_t *di) JL_NOTSAFEPOINT;
+JL_DLLEXPORT const char *jl_cdi_file(jl_debuginfo_t *di) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint8_t jl_encode_inlining_cost(uint16_t inlining_cost) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint16_t jl_decode_inlining_cost(uint8_t inlining_cost) JL_NOTSAFEPOINT;
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1571,12 +1571,14 @@ STATIC_INLINE size_t jl_bt_entry_size(jl_bt_element_t *bt_entry) JL_NOTSAFEPOINT
 typedef struct {
     char *func_name;
     char *file_name;
+    jl_debuginfo_t *debuginfo;
     int line;
-    // PC within the inlined frame's CodeInfo, or 0 if unavailable.
-    // Carried in the DWARF column field by codegen (see `update_lineinfo` in codegen.cpp).
+    // PC within debuginfo if !from_c, or just a column if from_c, or 0 if
+    // unavailable.  Carried in the DWARF column field by codegen (see
+    // `update_lineinfo` in codegen.cpp).
     int pc;
-    jl_code_instance_t *ci;
-    int fromC;
+    jl_code_instance_t *ci; // redundant if debuginfo.def becomes codeinstance
+    int from_c;
     int inlined;
 } jl_frame_t;
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -839,8 +839,6 @@ STATIC_INLINE jl_method_instance_t *jl_get_ci_mi(jl_code_instance_t *ci JL_PROPA
     return (jl_method_instance_t*)def;
 }
 
-JL_DLLEXPORT const char *jl_debuginfo_firstline(jl_debuginfo_t *debuginfo, int *line) JL_NOTSAFEPOINT;
-JL_DLLEXPORT const char *jl_debuginfo_file1(jl_debuginfo_t *debuginfo) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_module_t *jl_debuginfo_module1(jl_value_t *debuginfo_def) JL_NOTSAFEPOINT;
 JL_DLLEXPORT const char *jl_debuginfo_name(jl_value_t *func) JL_NOTSAFEPOINT;
 

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -794,7 +794,7 @@ JL_DLLEXPORT jl_value_t *jl_lookup_code_address(void *ip, int skipC)
     JL_GC_PUSH1(&rs);
     for (int i = 0; i < n; i++) {
         jl_frame_t frame = frames[i];
-        jl_value_t *r = (jl_value_t*)jl_alloc_svec(7);
+        jl_value_t *r = (jl_value_t*)jl_alloc_svec(8);
         jl_svecset(rs, i, r);
         if (frame.func_name)
             jl_svecset(r, 0, jl_symbol(frame.func_name));
@@ -808,9 +808,11 @@ JL_DLLEXPORT jl_value_t *jl_lookup_code_address(void *ip, int skipC)
         free(frame.file_name);
         jl_svecset(r, 2, jl_box_long(frame.line));
         jl_svecset(r, 3, frame.ci != NULL ? (jl_value_t*)frame.ci : jl_nothing);
-        jl_svecset(r, 4, jl_box_bool(frame.fromC));
+        jl_svecset(r, 4, jl_box_bool(frame.from_c));
         jl_svecset(r, 5, jl_box_bool(frame.inlined));
         jl_svecset(r, 6, jl_box_long(frame.pc));
+        jl_value_t *di = (jl_value_t*)frame.debuginfo;
+        jl_svecset(r, 7, di != NULL ? di : jl_nothing);
     }
     free(frames);
     JL_GC_POP();

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -818,14 +818,18 @@ JL_DLLEXPORT jl_value_t *jl_lookup_code_address(void *ip, int skipC)
 }
 
 static void jl_safe_fprint_codeloc(ios_t *s, const char* func_name, const char* file_name,
-                                   int line, int pc, int inlined) JL_NOTSAFEPOINT
+                                   int line, int col, int pc, int inlined) JL_NOTSAFEPOINT
 {
     const char *inlined_str = inlined ? " [inlined]" : "";
+    if (col == -1) {
+        col = 0;
+    }
     if (line != -1) {
         if (pc > 0)
-            jl_safe_fprintf(s, "%s at %s:%d:%d%s\n", func_name, file_name, line, pc, inlined_str);
+            jl_safe_fprintf(s, "%s at %s:%d:%d (pc: %d)%s\n",
+                            func_name, file_name, line, col, pc, inlined_str);
         else
-            jl_safe_fprintf(s, "%s at %s:%d%s\n", func_name, file_name, line, inlined_str);
+            jl_safe_fprintf(s, "%s at %s:%d:%d%s\n", func_name, file_name, line, col, inlined_str);
     }
     else {
         jl_safe_fprintf(s, "%s at %s (unknown line)%s\n", func_name, file_name, inlined_str);
@@ -850,39 +854,15 @@ void jl_fprint_native_codeloc(ios_t *s, uintptr_t ip) JL_NOTSAFEPOINT
             jl_safe_fprintf(s, "unknown function (ip: %p) at %s\n", (void*)ip, frame.file_name ? frame.file_name : "(unknown file)");
         }
         else {
-            jl_safe_fprint_codeloc(s, frame.func_name, frame.file_name, frame.line, frame.pc, frame.inlined);
+            int col = frame.fromC ? frame.pc : 0;
+            int pc = frame.fromC ? 0 : frame.pc;
+            jl_safe_fprint_codeloc(
+                s, frame.func_name, frame.file_name, frame.line, col, pc, frame.inlined);
             free(frame.func_name);
         }
         free(frame.file_name);
     }
     free(frames);
-}
-
-const char *jl_debuginfo_file1(jl_debuginfo_t *debuginfo)
-{
-    jl_value_t *def = debuginfo->def;
-    if (jl_is_method_instance(def))
-        def = ((jl_method_instance_t*)def)->def.value;
-    if (jl_is_method(def))
-        def = (jl_value_t*)((jl_method_t*)def)->file;
-    if (jl_is_symbol(def))
-        return jl_symbol_name((jl_sym_t*)def);
-    return "<unknown>";
-}
-
-// File name and line number of first line
-const char *jl_debuginfo_firstline(jl_debuginfo_t *debuginfo, int* line)
-{
-    jl_value_t *linetable = (jl_value_t*)debuginfo;
-    while (jl_is_debuginfo(linetable)) {
-        debuginfo = (jl_debuginfo_t*)linetable;
-        linetable = debuginfo->linetable;
-    }
-    if (line) {
-        struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo, 0);
-        *line = lineidx.loc;
-    }
-    return jl_debuginfo_file1(debuginfo);
 }
 
 jl_module_t *jl_debuginfo_module1(jl_value_t *debuginfo_def)
@@ -932,8 +912,9 @@ static void jl_fprint_debugloc(ios_t *s, jl_debuginfo_t *debuginfo, jl_value_t *
         if (ip2 < 0) // set broken debug info to ignored
             ip2 = 0;
         const char *func_name = jl_debuginfo_name(func);
-        const char *file = jl_debuginfo_firstline(debuginfo, NULL);
-        jl_safe_fprint_codeloc(s, func_name, file, ip2, (int)ip, inlined);
+        const char *file = jl_cdi_file(debuginfo);
+        jl_locspan_t xy = jl_cdi_firstxy(debuginfo, ip2);
+        jl_safe_fprint_codeloc(s, func_name, file, xy.first, xy.second, (int)ip, inlined);
     }
 }
 

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -726,8 +726,8 @@ JL_DLLEXPORT jl_value_t *jl_eval_thunk(jl_module_t *JL_NONNULL m, jl_code_info_t
     // start of this block.
     int last_lineno = jl_atomic_load_relaxed(&jl_lineno);
     const char *last_filename = jl_atomic_load_relaxed(&jl_filename);
-    int toplevel_lineno = 0;
-    const char* toplevel_filename = jl_debuginfo_firstline(thk->debuginfo, &toplevel_lineno);
+    int toplevel_lineno = jl_cdi_firstline_all(thk->debuginfo);
+    const char *toplevel_filename = jl_cdi_file(thk->debuginfo);
     jl_atomic_store_relaxed(&jl_lineno, toplevel_lineno);
     jl_atomic_store_relaxed(&jl_filename, toplevel_filename);
 


### PR DESCRIPTION
Atop #61817, idea by @vtjnash.  

Given a native code pointer, we want to be able to look up what IR statement it
came from.  As of #53925, we store the IR statement index in the DWARF column
field, but the wrong index (pre-inlining), so we can't get inlining information
from it.  #61699 was a naive attempt to fix this, but it blew up the number of
locations we had to deal with, since every place the same statement is inlined
now gets a unique index and hence a unique "location."

This change stores the post-inlining IR index like #61699 but uses julia
`DebugInfo` fully for stack frame lookups.  This means we can stop producing
DWARF info for julia-inlined frames, which were previously used for this.  Of
course, there are trade-offs: this should save quite a bit of space, but certain
native debugging tools might need help understanding julia-inlined functions.  I
don't mind putting the old behaviour behind a flag if there's enough demand to
justify the maintenance cost.

### TODO
- We need to resolve the issue I describe in
  https://github.com/llvm/llvm-project/pull/197286.  Our large debuginfo on
  macOS is currently masking an issue causing pointer lookups to fail, so
  shrinking it causes issues.
- lookup_pointer only traverses edges of the given debuginfo, and not its
  linetable(s), so some edges (currently just the "macro expansion" entries) are
  missing.
- I have yet to update coverage, so those tests fail.
- Update `jl_dump_asm_internal` so code_native and code_llvm continue to pick up
  inlining information (code_typed works, and anyone consuming debuginfo
  indirectly through Base.StackTraces or IRShow)