### PR TITLE
BinaryPlatforms: cover newer aarch64 ISAs and CPUs

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -624,8 +624,12 @@ const arch_march_isa_mapping = let
             "armv8_0" => get_set("aarch64", "armv8.0-a"),
             "armv8_1" => get_set("aarch64", "armv8.1-a"),
             "armv8_2_crypto" => get_set("aarch64", "armv8.2-a+crypto"),
+            "armv8_4" => get_set("aarch64", "armv8.4-a"),
+            "armv9_0" => get_set("aarch64", "armv9.0-a"),
+            "armv9_2" => get_set("aarch64", "armv9.2-a"),
             "a64fx" => get_set("aarch64", "a64fx"),
             "apple_m1" => get_set("aarch64", "apple_m1"),
+            "apple_m4" => get_set("aarch64", "apple_m4"),
         ],
         "riscv64" => [
             "riscv64" => get_set("riscv64", "riscv64"),

--- a/base/cpuid.jl
+++ b/base/cpuid.jl
@@ -146,8 +146,19 @@ function _make_isa_list(arch::String, entries::Vector{Pair{String,String}})
     return result
 end
 
-# ISA definitions per architecture family.
-# CPU names are LLVM names in the cpufeatures database.
+"""
+    ISAs_by_family
+
+ISA definitions per architecture family. Each label maps to an LLVM CPU name in
+the cpufeatures database whose feature mask represents the label's intent: the
+strict architectural-mandatory feature set at that ISA level, plus any optional
+extensions named in the label suffix (e.g. `armv8.2-a+crypto`). Where multiple
+LLVM CPUs sit at the same ISA level, prefer the one with the minimum feature
+set that still covers the label, so CPUs with richer feature sets match via the
+standard superset rule rather than being baked into the baseline. CPU-named
+labels (`a64fx`, `apple_m1`, `apple_m4`) are intentional exceptions for hardware
+whose feature mix doesn't fit a clean ISA label.
+"""
 # Keep in sync with `arch_march_isa_mapping` in binaryplatforms.jl.
 const ISAs_by_family = Dict(
     "i686" => _make_isa_list("x86_64", [
@@ -165,10 +176,14 @@ const ISAs_by_family = Dict(
     ]),
     "aarch64" => _make_isa_list("aarch64", [
         "armv8.0-a" => "",
-        "armv8.1-a" => "cortex-a76",
+        "armv8.1-a" => "cortex-a76",     # closest LLVM CPU; a76 is v8.2-class but carries the v8.1 mandatory features
         "armv8.2-a+crypto" => "cortex-a78",
+        "armv8.4-a" => "neoverse-v1",    # Graviton3; V1 has some v8.6 extras (SVE, BF16) but is the lowest v8.4-class LLVM CPU
+        "armv9.0-a" => "neoverse-n2",    # Cobalt 100, Yitian 710; V2 (Graviton4, Axion, Grace) matches via subset
+        "armv9.2-a" => "neoverse-v3",    # Graviton5, Cobalt 200, Jetson Thor; V3 over N3 since N3 has the same cpufeatures mask as N2
         "a64fx" => "a64fx",
-        "apple_m1" => "apple-a14",
+        "apple_m1" => "apple-a14",       # M1 reuses A14's CPU cores
+        "apple_m4" => "apple-m4",        # also covers M5
     ]),
     "riscv64" => _make_isa_list("riscv64", [
         "riscv64" => "",


### PR DESCRIPTION
Added four entries to CPUID.ISAs_by_family["aarch64"] and the matching arch_march_isa_mapping in base/binaryplatforms.jl, covering aarch64 hardware that has shipped or become widely deployed since the existing table was last extended:

- armv8_4 (neoverse-v1): ARMv8.4-A class. Covers AWS Graviton3. Imperfect: neoverse-v1 carries some v8.6 features (SVE, BF16) beyond strict v8.4-A, but no closer "pure v8.4 baseline" CPU exists in LLVM's table, so V1 is the lowest-tier proxy available at this ISA level.

- armv9_0 (neoverse-n2): ARMv9.0-A baseline. Covers Microsoft Azure Cobalt 100, Alibaba Yitian 710, and via subset matching also AWS Graviton4 / Google Axion / NVIDIA Grace (which add V2-specific extras like wider SVE2, BF16, I8MM on top of N2's v9.0-A features).

- armv9_2 (neoverse-v3): ARMv9.2-A. Covers AWS Graviton5, Microsoft Azure Cobalt 200, and NVIDIA Jetson Thor. Workaround: the strict-baseline choice would be N3, but LLVM/cpufeatures gives N2 and N3 identical feature masks — the v9.0-A vs v9.2-A architectural distinction isn't surfaced in any feature flag — so an N3-based armv9_2 would be feature-indistinguishable from armv9_0. V3's mask has one extra bit that creates a real distinction at this label, at the cost of conflating V3-specific features with the architectural baseline.

- apple_m4 (apple-m4): Apple's M-series cores from M4 onward (covers M5 too). Distinct from apple_m1 (mapped to apple-a14) because A14's feature set doesn't cover newer Apple cores. LLVM doesn't ship dedicated apple-m1/m2/m3/m5 CPU definitions, so M2/M3 fall back to apple_m1 and M5 is covered by apple_m4. (M4 is technically ARMv9.2-A per the ARM spec, but LLVM doesn't tag it as v9 since Apple omits SVE.)

These entries follow the table's original convention (introduced in #37722): each ISA label corresponds to the strict architectural-mandatory feature set at that level, plus any optional extensions explicitly named in the label suffix (e.g. armv8.2-a+crypto). After #61292 the feature sets are looked up indirectly via an LLVM CPU name rather than being hand-listed, which makes some labels necessarily approximate — there is no pure-v8.4 baseline CPU in LLVM, and at v9.x LLVM aggregates the architectural distinction into uarch tag bits that cpufeatures strips as tuning hints, so chip masks alone can't separate v9.0-A from v9.2-A. The per-entry CPU choices above are the best proxies available within that constraint. A follow-up on the cpufeatures side aims to expose ISA-baseline lookups derived from the uarch bit's `.implies` chain, after which future revisions of this table can use the architectural names directly and retire the proxies. Promoted the convention from a leading comment to a docstring on `ISAs_by_family` so it's discoverable from the REPL.

Fixes #58294.
