### PR TITLE
version printing: inline join to make call resolvable for juliaC

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -100,7 +100,7 @@ function print(io::IO, v::VersionNumber)
     print(io, v.patch)
     if !isempty(v.prerelease)
         print(io, '-')
-        # inline join to make call resolvable for juliaC
+        # inline join to make call resolvable for --trim
         @inline join(io, v.prerelease,'.')
     end
     if !isempty(v.build)

--- a/base/version.jl
+++ b/base/version.jl
@@ -100,6 +100,7 @@ function print(io::IO, v::VersionNumber)
     print(io, v.patch)
     if !isempty(v.prerelease)
         print(io, '-')
+        # inline join to make call resolvable for juliaC
         @inline join(io, v.prerelease,'.')
     end
     if !isempty(v.build)

--- a/base/version.jl
+++ b/base/version.jl
@@ -100,11 +100,11 @@ function print(io::IO, v::VersionNumber)
     print(io, v.patch)
     if !isempty(v.prerelease)
         print(io, '-')
-        join(io, v.prerelease,'.')
+        @inline join(io, v.prerelease,'.')
     end
     if !isempty(v.build)
         print(io, '+')
-        join(io, v.build,'.')
+        @inline join(io, v.build,'.')
     end
 end
 show(io::IO, v::VersionNumber) = print(io, "v\"", v, "\"")


### PR DESCRIPTION
These inline statements would fix the issue with juliaC https://github.com/JuliaLang/JuliaC.jl/issues/146. This issue arises for example in the `__init__`  function of `AWS.jl`, where version numbers are converted to strings:

https://github.com/JuliaCloud/AWS.jl/blob/7047a203e77161ffcaa8c9bd8b94fbbdbe48141c/src/AWS.jl#L474

The issue is that the argument of `join` is a `Tuple{Vararg{Union{UInt64, String}}}`. It seems that the julia compiler has problems to specialize for an argument of this type. The `@inline` avoid this issue (as would manually replacing it by a loop of calls to print):

```julia
@inline join(io,v.prerelease,'.')
# or
for i in eachindex(v.prerelease) # note `enumerate` does not work here for juliaC
     i > firstindex(v.prerelease) && print(io, '.')
    print(io, v.prerelease[i])
end
```

While this function is unlikely to be in a hot code path, with the `@inline` there is a small performance improvement for the following case:


```julia
 function print2(io::IO, v::VersionNumber)
    v == typemax(VersionNumber) && return print(io, "∞")
    print(io, v.major)
    print(io, '.')
    print(io, v.minor)
    print(io, '.')
    print(io, v.patch)

    if !isempty(v.prerelease)
        print(io, '-')
        @inline join(io, v.prerelease,'.')
    end

    if !isempty(v.build)
        print(io, '+')
        @inline join(io, v.build,'.')
    end
end

v = VersionNumber("1.2.3-rc1.pre1.almost.1")

io = IOBuffer(); @btime print($(io), $v); io2 = IOBuffer(); @btime print2($(io2), $v); 
# 387.122 ns (12 allocations: 416 bytes)  # original print
# 348.027 ns (9 allocations: 272 bytes)  # with @inline
io = IOBuffer(); print(io, v); io2 = IOBuffer(); print2(io2, v);

 String(take!(io)) == String(take!(io2))
# output
# true
julia> versioninfo()
Julia Version 1.12.5
Commit 5fe89b8ddc1 (2026-02-09 16:05 UTC)
Build Info:
  Official https://julialang.org release
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 8 × Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz
  WORD_SIZE: 64
  LLVM: libLLVM-18.1.7 (ORCJIT, skylake)
  GC: Built with stock GC
Threads: 1 default, 1 interactive, 1 GC (on 8 virtual cores)
Environment:
  JULIA_ERROR_COLOR = red
  JULIA_PKG_PRESERVE_TIERED_INSTALLED = true
```

