### PR TITLE
Fix jl_gc_wb_genericmemory_copy_boxed not advancing src/dest ptr

### DIFF
--- a/src/gc-interface.h
+++ b/src/gc-interface.h
@@ -318,10 +318,10 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_ptr(const struct _jl_value_t *own
                                           size_t n, struct _jl_datatype_t *dt) JL_NOTSAFEPOINT;
 // Similar to jl_gc_wb_genericmemory_copy but must be used when copying *boxed* elements of a genericmemory
 // object. Note that this barrier also performs the copying unlike jl_gc_wb_genericmemory_copy_ptr.
-// The parameters src_p, dest_p and n will be modified and will contain information about
-// the *uncopied* data after performing this barrier, and will be copied using memmove_refs.
-STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const struct _jl_value_t *owner, _Atomic(void*) * dest_p,
-                                          struct _jl_genericmemory_t *src, _Atomic(void*) * src_p,
+// `*dest_pp`, `*src_pp` and `*n` will be advanced past any elements the barrier copied inline, so that
+// the caller's trailing memmove_refs picks up where the barrier left off.
+STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const struct _jl_value_t *owner, _Atomic(void*) ** dest_pp,
+                                          struct _jl_genericmemory_t *src, _Atomic(void*) ** src_pp,
                                           size_t* n) JL_NOTSAFEPOINT;
 #ifdef __cplusplus
 }

--- a/src/gc-wb-mmtk.h
+++ b/src/gc-wb-mmtk.h
@@ -63,8 +63,8 @@ STATIC_INLINE void jl_gc_multi_wb(const void *parent, const jl_value_t *ptr) JL_
     mmtk_gc_wb_fast(parent, (void*)0);
 }
 
-STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const jl_value_t *dest_owner, _Atomic(void*) * dest_p,
-                                          jl_genericmemory_t *src, _Atomic(void*) * src_p,
+STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const jl_value_t *dest_owner, _Atomic(void*) ** dest_pp,
+                                          jl_genericmemory_t *src, _Atomic(void*) ** src_pp,
                                           size_t* n) JL_NOTSAFEPOINT
 {
     mmtk_gc_wb_fast(dest_owner, (void*)0);

--- a/src/gc-wb-stock.h
+++ b/src/gc-wb-stock.h
@@ -58,6 +58,7 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const jl_value_t *dest_owne
                     // `val` is young or old-unmarked
                     if (val && !(jl_astaggedvalue(val)->bits.gc & 1 /* GC_MARKED */)) {
                         jl_gc_queue_root(dest_owner);
+                        ++done;
                         break;
                     }
                 }
@@ -74,6 +75,7 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const jl_value_t *dest_owne
                     // `val` is young or old-unmarked
                     if (val && !(jl_astaggedvalue(val)->bits.gc & 1 /* GC_MARKED */)) {
                         jl_gc_queue_root(dest_owner);
+                        ++done;
                         break;
                     }
                 }

--- a/src/gc-wb-stock.h
+++ b/src/gc-wb-stock.h
@@ -41,14 +41,16 @@ STATIC_INLINE void jl_gc_multi_wb(const void *parent, const jl_value_t *ptr) JL_
         jl_gc_queue_multiroot((jl_value_t*)parent, ptr, dt);
 }
 
-STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const jl_value_t *dest_owner, _Atomic(void*) * dest_p,
-                                          jl_genericmemory_t *src, _Atomic(void*) * src_p,
+STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const jl_value_t *dest_owner, _Atomic(void*) ** dest_pp,
+                                          jl_genericmemory_t *src, _Atomic(void*) ** src_pp,
                                           size_t* n) JL_NOTSAFEPOINT
 {
     if (__unlikely(jl_astaggedvalue(dest_owner)->bits.gc == 3 /* GC_OLD_MARKED */ )) {
         jl_value_t *src_owner = jl_genericmemory_owner(src);
         size_t done = 0;
         if (jl_astaggedvalue(src_owner)->bits.gc != 3 /* GC_OLD_MARKED */) {
+            _Atomic(void*) *dest_p = *dest_pp;
+            _Atomic(void*) *src_p = *src_pp;
             if (dest_p < src_p || dest_p > src_p + (*n)) {
                 for (; done < (*n); done++) { // copy forwards
                     void *val = jl_atomic_load_relaxed(src_p + done);
@@ -59,8 +61,11 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const jl_value_t *dest_owne
                         break;
                     }
                 }
-                src_p += done;
-                dest_p += done;
+                // advance caller's pointers past the elements we just
+                // copied so the trailing memmove_refs picks up where we
+                // left off
+                *src_pp = src_p + done;
+                *dest_pp = dest_p + done;
             }
             else {
                 for (; done < (*n); done++) { // copy backwards

--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -234,7 +234,7 @@ JL_DLLEXPORT void jl_genericmemory_copyto(jl_genericmemory_t *dest, char* destda
         _Atomic(void*) * dest_p = (_Atomic(void*)*)destdata;
         _Atomic(void*) * src_p = (_Atomic(void*)*)srcdata;
         jl_value_t *owner = jl_genericmemory_owner(dest);
-        jl_gc_wb_genericmemory_copy_boxed(owner, dest_p, src, src_p, &n);
+        jl_gc_wb_genericmemory_copy_boxed(owner, &dest_p, src, &src_p, &n);
         return memmove_refs(dest_p, src_p, n);
     }
     size_t elsz = layout->size;

--- a/test/gc.jl
+++ b/test/gc.jl
@@ -65,6 +65,7 @@ end
     run_gctest("gc/linkedlist.jl")
     run_gctest("gc/objarray.jl")
     run_gctest("gc/chunks.jl")
+    run_gctest("gc/copyto.jl")
 end
 
 #FIXME: Issue #57103 disabling tests for MMTk, since

--- a/test/gc/copyto.jl
+++ b/test/gc/copyto.jl
@@ -1,0 +1,12 @@
+dest = Any[nothing for i=1:16]
+# We want the destination GenericMemory to be OLD_MARKED
+for i in 1:5
+    GC.gc(true)
+    GC.gc(false)
+end
+
+src = vcat(Any[nothing], Any[Ref(100 * i) for i=1:15])
+copyto!(dest, src)
+for (x, y) in zip(dest, src)
+    @assert x === y
+end


### PR DESCRIPTION
Claude Opus 4.7 xhigh spotted this one when I was making some unrelated changes (I'm impressed!).  #57252/378a42508d4 introduced this bug when extracting the code for `jl_gc_wb_genericmemory_copy_boxed` from `jl_genericmemory_copyto`: the caller assumes `src_p` and `dest_p` will be updated to point to the remaining elements `memmove_refs` must copy, but we no longer mutate them.  I had Claude turn them into pointers, so they are updated like before.

Nifty PoC:
```julia
dest = Any[nothing for i=1:16]
for i in 1:2
GC.gc(true)
    GC.gc(false)
end
src = vcat(Any[nothing], Any[Ref(100 * i) for i=1:15])
copyto!(dest, src)
for (i, (x, y)) in enumerate(zip(dest, src))
    if x !== y
        println("dest[$i] = $x, expected src[$i] = $y")
    end
end
```