### PR TITLE
Fix inference when adding multiple `Period`s to a `TimeType`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -159,6 +159,7 @@ Standard library changes
 #### Dates
 
 * `unix2datetime` now accepts a keyword argument `localtime=true` to use the host system's local time zone instead of UTC ([#50296]).
+* Adding several `Period`s to a `TimeType` in one expression (e.g. `dt + Day(1) + Month(1)`) is now allocation-free and always applies the periods ordered by type from coarsest to finest, independent of how many are given or their order. This fixes incorrect results when four or more periods were combined ([#61860]).
 
 #### InteractiveUtils
 

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -135,6 +135,7 @@ const PERIOD_TYPES = (OTHER_PERIOD_TYPES..., FIXED_PERIOD_TYPES...)
 # convertible among themselves but not to a fixed number of days.
 const FixedPeriod = Union{FIXED_PERIOD_TYPES...}
 const OtherPeriod = Union{OTHER_PERIOD_TYPES...}
+const BuiltInPeriod = Union{FixedPeriod, OtherPeriod}
 
 # Stores multiple periods in greatest to least order by type, not values,
 # canonicalized to eliminate zero periods, merge equal period types,
@@ -381,8 +382,8 @@ Base.isequal(x::CompoundPeriod, y::CompoundPeriod) = isequal(x.periods, y.period
 # without ever constructing a `CompoundPeriod`.
 
 # Total value of the periods in `ps` whose type is exactly `P`.
-@inline _sumperiods(::Type{P}, ::Tuple{}) where {P<:Period} = 0
-@inline _sumperiods(::Type{P}, ps::Tuple) where {P<:Period} =
+@inline _sumperiods(::Type{P}, ::Tuple{}) where {P<:BuiltInPeriod} = 0
+@inline _sumperiods(::Type{P}, ps::Tuple) where {P<:BuiltInPeriod} =
     (first(ps) isa P ? value(first(ps)) : 0) + _sumperiods(P, Base.tail(ps))
 
 @inline _addperiods(x::TimeType, ::Tuple{}, ::Tuple) = x
@@ -397,8 +398,15 @@ end
 
 # `PERIOD_TYPES` is a compile-time constant, so its element types stay known to the
 # compiler and `_addperiods` unrolls and constant-folds.
-(+)(x::TimeType, p1::Period, p2::Period, ps::Period...) =
+(+)(x::TimeType, p1::BuiltInPeriod, p2::BuiltInPeriod, ps::BuiltInPeriod...) =
     _addperiods(x, PERIOD_TYPES, (p1, p2, ps...))
+
+# Fallback for custom `Period`s. Collecting the periods into a single `CompoundPeriod`
+# groups equal types and sorts them coarsest-to-finest (by `tons ∘ oneunit`, the same
+# order key the built-in fast path is checked against), so custom subtypes are preserved
+# and applied in the same order as the fast path and as `dt + CompoundPeriod(...)`.
+(+)(x::TimeType, p1::Period, p2::Period, ps::Period...) =
+    x + CompoundPeriod(Period[p1, p2, ps...])
 
 function (+)(x::TimeType, y::CompoundPeriod)
     for p in y.periods

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -382,12 +382,12 @@ Base.isequal(x::CompoundPeriod, y::CompoundPeriod) = isequal(x.periods, y.period
 # without ever constructing a `CompoundPeriod`.
 
 # Total value of the periods in `ps` whose type is exactly `P`.
-@inline _sumperiods(::Type{P}, ::Tuple{}) where {P<:BuiltInPeriod} = 0
-@inline _sumperiods(::Type{P}, ps::Tuple) where {P<:BuiltInPeriod} =
+Base.@constprop :aggressive _sumperiods(::Type{P}, ::Tuple{}) where {P<:BuiltInPeriod} = 0
+Base.@constprop :aggressive _sumperiods(::Type{P}, ps::Tuple) where {P<:BuiltInPeriod} =
     (first(ps) isa P ? value(first(ps)) : 0) + _sumperiods(P, Base.tail(ps))
 
-@inline _addperiods(x::TimeType, ::Tuple{}, ::Tuple) = x
-@inline function _addperiods(x::TimeType, types::Tuple, ps::Tuple)
+Base.@constprop :aggressive _addperiods(x::TimeType, ::Tuple{}, ::Tuple) = x
+Base.@constprop :aggressive function _addperiods(x::TimeType, types::Tuple, ps::Tuple)
     P = first(types)
     s = _sumperiods(P, ps)
     # Types with a zero total are skipped, so absent types produce no code and a zero
@@ -396,8 +396,9 @@ Base.isequal(x::CompoundPeriod, y::CompoundPeriod) = isequal(x.periods, y.period
     return _addperiods(x, Base.tail(types), ps)
 end
 
-# `PERIOD_TYPES` is a compile-time constant, so its element types stay known to the
-# compiler and `_addperiods` unrolls and constant-folds.
+# `PERIOD_TYPES` is a compile-time constant. Its element type is only `DataType`, so the
+# per-type value `first(types)` is recovered through constant propagation; `@constprop
+# :aggressive` makes `_addperiods` unroll and fold to concrete period constructions.
 (+)(x::TimeType, p1::BuiltInPeriod, p2::BuiltInPeriod, ps::BuiltInPeriod...) =
     _addperiods(x, PERIOD_TYPES, (p1, p2, ps...))
 

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -374,9 +374,31 @@ Base.isequal(x::CompoundPeriod, y::Period) = isequal(x, CompoundPeriod(y))
 Base.isequal(x::Period, y::CompoundPeriod) = isequal(y, x)
 Base.isequal(x::CompoundPeriod, y::CompoundPeriod) = isequal(x.periods, y.periods)
 
-# Capture TimeType+-Period methods
-(+)(a::TimeType, b::Period, c::Period) = (+)(a, b + c)
-(+)(a::TimeType, b::Period, c::Period, d::Period...) = (+)((+)(a, b + c), d...)
+# Capture chained additions such as `dt + Day(1) + Month(1)`, which Julia parses as a
+# single n-ary call `+(dt, Day(1), Month(1))`. The periods are grouped by type and
+# applied from the coarsest type to the finest, independent of the order in which they
+# are given, so that the result is order-independent and matches `dt + CompoundPeriod(...)`
+# without ever constructing a `CompoundPeriod`.
+
+# Total value of the periods in `ps` whose type is exactly `P`.
+@inline _sumperiods(::Type{P}, ::Tuple{}) where {P<:Period} = 0
+@inline _sumperiods(::Type{P}, ps::Tuple) where {P<:Period} =
+    (first(ps) isa P ? value(first(ps)) : 0) + _sumperiods(P, Base.tail(ps))
+
+@inline _addperiods(x::TimeType, ::Tuple{}, ::Tuple) = x
+@inline function _addperiods(x::TimeType, types::Tuple, ps::Tuple)
+    P = first(types)
+    s = _sumperiods(P, ps)
+    # Types with a zero total are skipped, so absent types produce no code and a zero
+    # total never forces an invalid addition (e.g. a `Year` onto a `Time`).
+    x = iszero(s) ? x : x + P(s)
+    return _addperiods(x, Base.tail(types), ps)
+end
+
+# `PERIOD_TYPES` is a compile-time constant, so its element types stay known to the
+# compiler and `_addperiods` unrolls and constant-folds.
+(+)(x::TimeType, p1::Period, p2::Period, ps::Period...) =
+    _addperiods(x, PERIOD_TYPES, (p1, p2, ps...))
 
 function (+)(x::TimeType, y::CompoundPeriod)
     for p in y.periods

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -115,6 +115,27 @@ coarserperiod(::Type{Hour}) = (Day, 24)
 coarserperiod(::Type{Day}) = (Week, 7)
 coarserperiod(::Type{Month}) = (Year, 12)
 
+# Period types paired with the number of the next-finer period they contain, in
+# coarsest-to-finest order. The `OtherPeriod`s (Year, Quarter, Month) come first, followed
+# by the `FixedPeriod`s (Week down to Nanosecond). These tuples are the single source of
+# truth for the period ordering, the `FixedPeriod`/`OtherPeriod` unions, and the unit
+# conversions defined by `define_conversions`.
+const OTHER_PERIOD_CONVERSIONS = ((Year, 4), (Quarter, 3), (Month, 1))
+const FIXED_PERIOD_CONVERSIONS = ((Week, 7), (Day, 24), (Hour, 60), (Minute, 60),
+                                  (Second, 1000), (Millisecond, 1000), (Microsecond, 1000), (Nanosecond, 1))
+const OTHER_PERIOD_TYPES = map(first, OTHER_PERIOD_CONVERSIONS)
+const FIXED_PERIOD_TYPES = map(first, FIXED_PERIOD_CONVERSIONS)
+# All period types coarsest to finest; the order matches `CompoundPeriod`'s sort
+# (descending `tons ∘ oneunit`).
+const PERIOD_TYPES = (OTHER_PERIOD_TYPES..., FIXED_PERIOD_TYPES...)
+
+# A `FixedPeriod` is a fixed multiple of a day, so it has a constant length in the storage
+# unit (a week is always 7 days, an hour always 3600 seconds). An `OtherPeriod` is a
+# multiple of a month, whose length in days is not constant (28–31); they are exactly
+# convertible among themselves but not to a fixed number of days.
+const FixedPeriod = Union{FIXED_PERIOD_TYPES...}
+const OtherPeriod = Union{OTHER_PERIOD_TYPES...}
+
 # Stores multiple periods in greatest to least order by type, not values,
 # canonicalized to eliminate zero periods, merge equal period types,
 # and convert more-precise periods to less-precise periods when possible
@@ -375,10 +396,6 @@ end
 Base.iszero(x::CompoundPeriod) = isempty(canonicalize(x).periods)
 Base.zero(::Union{CompoundPeriod,Type{CompoundPeriod}}) = CompoundPeriod()
 
-# Fixed-value Periods (periods corresponding to a well-defined time interval,
-# as opposed to variable calendar intervals like Year).
-const FixedPeriod = Union{Week, Day, Hour, Minute, Second, Millisecond, Microsecond, Nanosecond}
-
 # like div but throw an error if remainder is nonzero
 function divexact(x, y)
     q, r = divrem(x, y)
@@ -414,12 +431,13 @@ function define_conversions(periods)
         end
     end
 end
-define_conversions([(:Week, 7), (:Day, 24), (:Hour, 60), (:Minute, 60), (:Second, 1000),
-                    (:Millisecond, 1000), (:Microsecond, 1000), (:Nanosecond, 1)])
-define_conversions([(:Year, 4), (:Quarter, 3), (:Month, 1)])
+# Two separate calls, one per group: conversions are exact within a group but must not
+# exist across the boundary (a month is not a fixed number of days), so `FixedPeriod`s and
+# `OtherPeriod`s are deliberately never made convertible to each other.
+define_conversions(FIXED_PERIOD_CONVERSIONS)
+define_conversions(OTHER_PERIOD_CONVERSIONS)
 
 # fixed is not comparable to other periods, except when both are zero (#37459)
-const OtherPeriod = Union{Month, Quarter, Year}
 (==)(x::FixedPeriod, y::OtherPeriod) = iszero(x) & iszero(y)
 (==)(x::OtherPeriod, y::FixedPeriod) = y == x
 

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -242,6 +242,55 @@ end
     @test Dates.OTHER_PERIOD_TYPES == map(first, Dates.OTHER_PERIOD_CONVERSIONS)
     @test Dates.FIXED_PERIOD_TYPES == map(first, Dates.FIXED_PERIOD_CONVERSIONS)
 end
+
+# Custom `Period`s used to check that `+(::TimeType, ::Period...)` keeps custom subtypes
+# and orders them coarsest-to-finest. Each defines only `toms`: the shared ordering key
+# `tons ∘ oneunit` then sorts them into place and generic `+(::DateTime, ::Period)` applies
+# them.
+struct HalfDay <: Dates.TimePeriod   # 12 hours, finer than a Day, coarser than an Hour
+    value::Int64
+end
+Dates.toms(x::HalfDay) = 12 * 60 * 60 * 1000 * Dates.value(x)
+struct Fortnight <: Dates.DatePeriod # 14 days, finer than a Month, coarser than a Week
+    value::Int64
+end
+Dates.toms(x::Fortnight) = 14 * 24 * 60 * 60 * 1000 * Dates.value(x)
+
+@testset "custom Period ordering" begin
+    # Adding built-in and custom periods together routes through the `CompoundPeriod`
+    # fallback, which groups by type and applies them coarsest-to-finest, independent of
+    # argument order. The result is observable around a leap day: a `HalfDay` (12 h) is
+    # finer than a `Month`, so the `Month` is applied first. On Jan 30 2020 that clamps to
+    # Feb 29 and the following full day lands on Mar 1; applying the `HalfDay`s first would
+    # reach Jan 31 and the `Month` would clamp to Feb 29 instead.
+    dt = Dates.DateTime(2020, 1, 30)
+    @test dt + Dates.Month(1) + HalfDay(2) == Dates.DateTime(2020, 3, 1)
+    @test dt + HalfDay(2) + Dates.Month(1) == Dates.DateTime(2020, 3, 1)
+    # The optimized and `CompoundPeriod` paths must agree.
+    @test dt + Dates.Month(1) + HalfDay(2) == dt + Dates.CompoundPeriod(Dates.Month(1), HalfDay(2))
+
+    # Equal custom types are merged first: HalfDay(1) + HalfDay(1) becomes a full day,
+    # applied after the Month, regardless of where the second HalfDay appears.
+    @test dt + HalfDay(1) + Dates.Month(1) + HalfDay(1) == Dates.DateTime(2020, 3, 1)
+
+    # Custom periods must not be silently dropped when mixed with built-in periods.
+    base = Dates.DateTime(2000)
+    @test base + HalfDay(1) + Dates.Millisecond(1) == base + Dates.Hour(12) + Dates.Millisecond(1)
+    @test base + HalfDay(1) + Dates.Millisecond(1) == base + Dates.Millisecond(1) + HalfDay(1)
+
+    # A `Fortnight` (14 days) is finer than a `Month`, so the `Month` clamps to Feb 29
+    # before the 14 days are added (reaching Mar 14); adding the days first would reach
+    # Feb 13 and land on Mar 13.
+    @test dt + Dates.Month(1) + Fortnight(1) == Dates.DateTime(2020, 3, 14)
+    @test dt + Fortnight(1) + Dates.Month(1) == Dates.DateTime(2020, 3, 14)
+
+    # Merging still applies across the coarsest types even with a custom period present:
+    # Year(1) + Year(3) merges to Year(4) (2020 -> 2024, a leap year) so Feb 29 survives,
+    # then the HalfDays add a full day to reach Mar 1. Applied separately, Year(1) would
+    # first clamp to 2021-02-28.
+    leap = Dates.DateTime(2020, 2, 29)
+    @test leap + Dates.Year(1) + HalfDay(2) + Dates.Year(3) == Dates.DateTime(2024, 3, 1)
+end
 @testset "traits" begin
     @test Dates._units(Dates.Year(0)) == " years"
     @test Dates._units(Dates.Year(1)) == " year"

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -220,6 +220,27 @@ end
     @test Dates.Date(2014, 1, 29) + Dates.Month(1) + Dates.Day(1) + Dates.Month(1) + Dates.Day(1) ==
         Dates.Date(2014, 1, 29) + Dates.Day(1) + Dates.Month(1) + Dates.Month(1) + Dates.Day(1)
     @test Dates.Date(2014, 1, 29) + Dates.Month(1) + Dates.Day(1) == Dates.Date(2014, 1, 29) + Dates.Day(1) + Dates.Month(1)
+    # Periods are applied by type from coarsest to finest, independent of their order,
+    # so both orderings apply the Month before the Day.
+    @test Dates.Date(2014, 1, 29) + Dates.Day(1) + Dates.Month(1) == Dates.Date(2014, 3, 1)
+    @test Dates.Date(2014, 1, 29) + Dates.Month(1) + Dates.Day(1) == Dates.Date(2014, 3, 1)
+    # Equal types are merged before being applied: Day(1) + Day(1) becomes Day(2), applied
+    # after the Month.
+    @test Dates.Date(2014, 1, 29) + Dates.Day(1) + Dates.Day(1) + Dates.Month(1) == Dates.Date(2014, 3, 2)
+    # Merging equal types matters across leap years: Year(1) + Year(3) becomes Year(4),
+    # landing on the leap day, unlike applying Year(1) and Year(3) separately.
+    @test Dates.Date(2020, 2, 29) + Dates.Year(1) + Dates.Year(3) == Dates.Date(2024, 2, 29)
+end
+@testset "PERIOD_TYPES ordering invariant" begin
+    # `+(::TimeType, ::Period...)` applies periods in `PERIOD_TYPES` order, which must stay
+    # coarsest-to-finest, matching the order `CompoundPeriod` sorts by (descending
+    # `tons ∘ oneunit`). Otherwise the two addition paths would disagree.
+    types = collect(Dates.PERIOD_TYPES)
+    @test types == sort(types; by = T -> Dates.tons(oneunit(T)), rev = true)
+    # `PERIOD_TYPES` is the concatenation of the two conversion groups' types.
+    @test Dates.PERIOD_TYPES == (Dates.OTHER_PERIOD_TYPES..., Dates.FIXED_PERIOD_TYPES...)
+    @test Dates.OTHER_PERIOD_TYPES == map(first, Dates.OTHER_PERIOD_CONVERSIONS)
+    @test Dates.FIXED_PERIOD_TYPES == map(first, Dates.FIXED_PERIOD_CONVERSIONS)
 end
 @testset "traits" begin
     @test Dates._units(Dates.Year(0)) == " years"


### PR DESCRIPTION
```julia
using Chairmarks, Dates
f(n, m) = DateTime(1970) + Day(n) + Millisecond(m)
```

master:
```julia
julia> @b f($1, $2)
89.303 ns (7 allocs: 160 bytes)
```
this PR:
```julia
julia> @b f($1, $2)
1.878 ns
```

Explanation from Claude:

**Buggy `a + (b + c)`:**
1. `b + c` (two `Period`s) dispatches to `(+)(x::Period, y::Period) = CompoundPeriod(Period[x, y])` — constructs a `CompoundPeriod` wrapping `Vector{Period}` (abstract eltype).
2. `a + CompoundPeriod` dispatches to `(+)(x::TimeType, y::CompoundPeriod)`, which loops `for p in y.periods` — `p` is inferred as `Period` (abstract), so `x += p` is a dynamic dispatch and the loop's accumulated return type widens to `Any`.

**Fixed `(a + b) + c`:**
1. `a + b`: dispatches on `(+)(::TimeType, ::Period)` where the concrete `Period` subtype (e.g. `Day`) is known at compile time → returns concrete `TimeType` (e.g. `DateTime`).
2. `+ c`: same again with the next concrete `Period` subtype.

No `CompoundPeriod` is ever constructed in the fixed path, so there is no abstract `Vector{Period}` to iterate. Each step is a fully-specialized two-argument `+` call with concrete types.

I used Claud Opus 4.7 in preparing this PR.