### PR TITLE
Implement inv_fast using div_fast

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -172,6 +172,8 @@ max_fast(x::T, y::T) where {T<:FloatTypes} = max_float_fast(x, y)
 min_fast(x::T, y::T) where {T<:FloatTypes} = min_float_fast(x, y)
 minmax_fast(x::T, y::T) where {T<:FloatTypes} = (min_fast(x, y), max_fast(x, y))
 
+inv_fast(x::T) where {T<:FloatTypes} = div_fast(one(T), x)
+
 @fastmath begin
     cmp_fast(x::T, y::T) where {T<:FloatTypes} = ifelse(x==y, 0, ifelse(x<y, -1, +1))
     log_fast(b::T, x::T) where {T<:FloatTypes} = log_fast(x)/log_fast(b)

--- a/test/llvmpasses/fastmath.jl
+++ b/test/llvmpasses/fastmath.jl
@@ -14,5 +14,14 @@ include(joinpath("..", "testhelpers", "llvmpasses.jl"))
 
 import Base.FastMath
 
+# CHECK-LABEL: @julia_sqrt_fast
 # CHECK: call fast float @llvm.sqrt.f32(float %"x::Float32")
 emit(FastMath.sqrt_fast, Float32)
+
+# CHECK-LABEL: @julia_inv_fast
+# CHECK: fdiv fast float 1.000000e+00, %"x::Float32"
+emit(FastMath.inv_fast, Float32)
+
+# CHECK-LABEL: @julia_inv_fast
+# CHECK: fdiv fast double 1.000000e+00, %"x::Float64"
+emit(FastMath.inv_fast, Float64)


### PR DESCRIPTION
Noticed by @maleadt during a refactor of CUDA.jl fastmath support.

`inv_fast` currently is implemented via a fall-back using non-fast-math division.

```
julia> @code_llvm Base.FastMath.inv_fast(1.0)
; Function Signature: inv_fast(Float64)
;  @ fastmath.jl:256 within `inv_fast`
define double @julia_inv_fast_867(double %"xs[1]::Float64") #0 {
top:
; ┌ @ number.jl:255 within `inv`
; │┌ @ float.jl:494 within `/`
    %0 = fdiv double 1.000000e+00, %"xs[1]::Float64"
    ret double %0
; └└
}
```

and we want `afn` and `arcp`