### PR TITLE
Emit llvm.fmuladd again for muladd intrinsics

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1619,11 +1619,14 @@ static Value *emit_untyped_intrinsic(jl_codectx_t &ctx, intrinsic f, ArrayRef<Va
         return ctx.builder.CreateCall(fmaintr, {x, y, z});
     }
     case muladd_float: {
-        // LLVM 5.0 can create FMA in the backend for contractible fmul and fadd
-        // Emitting fmul and fadd here since they are easier for other LLVM passes to
-        // optimize.
-        auto mathb = math_builder(ctx, true, true);
-        return mathb().CreateFAdd(mathb().CreateFMul(x, y), z);
+        assert(y->getType() == x->getType());
+        assert(z->getType() == y->getType());
+#if JL_LLVM_VERSION >= 200000
+        FunctionCallee fmuladdintr = Intrinsic::getOrInsertDeclaration(jl_Module, Intrinsic::fmuladd, ArrayRef<Type*>(t));
+#else
+        FunctionCallee fmuladdintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::fmuladd, ArrayRef<Type*>(t));
+#endif
+        return ctx.builder.CreateCall(fmuladdintr, {x, y, z});
     }
 
     case checked_sadd_int:


### PR DESCRIPTION
Since #22262 we are emitting `muladd` not as `fmuladd` but rather as a sequence of:

```
%t = fmul contract %a %b
%r = fadd contract %t %c
```

We came across an example in CUDA.jl where
that emission pattern hurt performance https://github.com/JuliaGPU/CUDA.jl/pull/3078#issue-4192795318

x-ref: https://github.com/JuliaGPU/CUDA.jl/pull/3149#discussion_r3276186709

We should benchmark and see if their is still a performance benefit
to the old form with current LLVM.

