### PR TITLE
stacktraces: Remove MI printing for inlined frames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,8 +34,6 @@ Compiler/Runtime improvements
     effect tracking; for those, the recommended pattern remains storing the field value in
     a local variable before the check (e.g. `val = x.field; if !isnothing(val) ... end`)
     ([#41199], [#47574]).
-  - Stack traces now show full method signatures with argument types for inlined
-    frames, matching the display of non-inlined frames ([#53925]).
 
 Command-line option changes
 ---------------------------

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -47,14 +47,6 @@ Stack information representing execution context, with the following fields:
 
   Representation of the pointer to the execution context as returned by `backtrace`.
 
-- `pc::Int`
-
-  1-based statement index within the frame's `CodeInfo`, recovered from the DWARF
-  column emitted by codegen. `0` when unavailable (e.g. for C frames or frames
-  without enriched debug info). Used internally by `StackTraces.lookup` to resolve
-  the `MethodInstance` for inlined frames; also surfaced in low-level safe
-  backtrace output (e.g. on segfault) but not in Julia's default `show` for
-  `StackFrame`.
 """
 struct StackFrame # this type should be kept platform-agnostic so that profiles can be dumped on one machine and read on another
     "the name of the function containing the execution context"
@@ -72,14 +64,10 @@ struct StackFrame # this type should be kept platform-agnostic so that profiles 
     inlined::Bool
     "representation of the pointer to the execution context as returned by `backtrace`"
     pointer::UInt64  # Large enough to be read losslessly on 32- and 64-bit machines.
-    "1-based statement index (PC) within the frame's CodeInfo, or 0 if unavailable"
-    pc::Int
 end
 
-StackFrame(func, file, line, linfo, from_c, inlined, pointer) =
-    StackFrame(func, file, line, linfo, from_c, inlined, pointer, 0)
 StackFrame(func, file, line) = StackFrame(Symbol(func), Symbol(file), line,
-                                          nothing, false, false, 0, 0)
+                                          nothing, false, false, 0)
 
 """
     StackTrace
@@ -111,14 +99,6 @@ function hash(frame::StackFrame, h::UInt)
     return h
 end
 
-# Decode a single codeloc entry, advancing one level of inlining. Returns
-# `(line, to, next_pc)` where `to` is the 1-based index into `debuginfo.edges`
-# for the inlined call directly at `pc` (0 if none), and `next_pc` is the PC
-# within `debuginfo.edges[to]`'s CodeInfo. To traverse nested inlinings, the
-# caller must follow the edge and call this again with `(edges[to], next_pc)`.
-debuginfo_codeloc(debuginfo::Core.DebugInfo, pc::Integer) =
-    @ccall jl_uncompress1_codeloc(debuginfo::Any, pc::Csize_t)::NTuple{3,Int32}
-
 """
     lookup(pointer::Ptr{Cvoid})::Vector{StackFrame}
 
@@ -127,44 +107,18 @@ up stack frame context information. Returns an array of frame information for al
 inlined at that point, innermost function first.
 """
 Base.@constprop :none function lookup(pointer::Ptr{Cvoid})
-    infos = @ccall jl_lookup_code_address(pointer::Ptr{Cvoid}, false::Cint)::Core.SimpleVector
+    infos = ccall(:jl_lookup_code_address, Any, (Ptr{Cvoid}, Cint), pointer, false)::Core.SimpleVector
     pointer = convert(UInt64, pointer)
     isempty(infos) && return [StackFrame(empty_sym, empty_sym, -1, nothing, true, false, pointer)] # this is equal to UNKNOWN
-    ninfos = length(infos)
-    res = Vector{StackFrame}(undef, ninfos)
-    local debuginfo = false
-    local parent_pc = 0
-    for i = ninfos:-1:1
+    res = Vector{StackFrame}(undef, length(infos))
+    for i in 1:length(infos)
         info = infos[i]::Core.SimpleVector
         @assert length(info) == 7 "corrupt return from jl_lookup_code_address"
         func = info[1]::Symbol
         file = info[2]::Symbol
         linenum = info[3]::Int
         linfo = info[4]
-        pc = info[7]::Int
-        if linfo isa Core.CodeInstance
-            if debuginfo === false
-                debuginfo = linfo.debuginfo
-            else
-                debuginfo = true
-            end
-            linfo = linfo.def
-        elseif debuginfo isa Core.DebugInfo && parent_pc > 0
-            # Use the parent frame's PC to look up which inlining edge of the
-            # current `debuginfo` corresponds to this frame's call site.
-            _, to::Int, _ = debuginfo_codeloc(debuginfo, parent_pc)
-            if to > 0 && to <= length(debuginfo.edges)
-                debuginfo = debuginfo.edges[to]::Core.DebugInfo
-                def = debuginfo.def
-                if !(def isa Symbol)
-                    linfo = def
-                end
-            else
-                debuginfo = true
-            end
-        end
-        parent_pc = pc
-        res[i] = StackFrame(func, file, linenum, linfo, info[5]::Bool, info[6]::Bool, pointer, pc)
+        res[i] = StackFrame(func, file, linenum, linfo, info[5]::Bool, info[6]::Bool, pointer)
     end
     return res
 end

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8531,8 +8531,8 @@ static jl_llvm_functions_t
     }
     else if ((jl_value_t*)src->debuginfo != jl_nothing) {
         // look for the file and line info of the original start of this block, as reported by lowering
-        ctx.file = jl_debuginfo_firstline(src->debuginfo, &toplineno);
-        toplineno = std::max(0, toplineno);
+        ctx.file = jl_cdi_file(src->debuginfo);
+        toplineno = std::max(0, jl_cdi_firstline_all(src->debuginfo));
     }
     if (ctx.file.empty())
         ctx.file = "<missing>";
@@ -9319,14 +9319,13 @@ static jl_llvm_functions_t
                     jl_module_t *modu = func ? jl_debuginfo_module1(func) : NULL;
                     if (modu == NULL)
                         modu = ctx.module;
-                    info.file = jl_debuginfo_file1(debuginfo);
+                    info.file = jl_cdi_file(debuginfo);
                     info.line = i;
                     info.line0 = 0;
                     if (pc == 1) {
-                        struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo, 0);
-                        assert(lineidx.to == 0 && lineidx.pc == 0);
-                        if (lineidx.loc > 0 && info.line != lineidx.loc)
-                            info.line0 = lineidx.loc;
+                        int32_t line0 = jl_cdi_external_firstline(debuginfo);
+                        if (line0 > 0 && info.line != line0)
+                            info.line0 = line0;
                     }
                     if (info.file.empty())
                         info.file = "<missing>";
@@ -9518,7 +9517,7 @@ static jl_llvm_functions_t
             jl_module_t *modu = func ? jl_debuginfo_module1(func) : NULL;
             if (modu == NULL)
                 modu = ctx.module;
-            StringRef file = jl_debuginfo_file1(debuginfo);
+            StringRef file = jl_cdi_file(debuginfo);
             if (file.empty())
                 file = "<missing>";
             bool is_user_code;
@@ -9528,7 +9527,10 @@ static jl_llvm_functions_t
                 is_user_code = in_user_mod(modu);
             bool is_tracked = in_tracked_path(file);
             if (do_coverage(is_user_code, is_tracked)) {
-                for (size_t pc = 0; 1; pc++) {
+                int32_t extraline = jl_cdi_external_firstline(debuginfo);
+                if (extraline != -1)
+                    jl_coverage_alloc_line(file.data(), extraline);
+                for (size_t pc = 1; 1; pc++) {
                     struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo, pc);
                     if (lineidx.loc == -1)
                         break;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9335,9 +9335,10 @@ static jl_llvm_functions_t
                         info.is_user_code = in_user_mod(modu);
                     if (debug_enabled) {
                         StringRef fname = jl_debuginfo_name(func);
-                        // Encode the 1-based statement index into the DWARF column field so that
-                        // stacktraces can recover the exact PC that each inlined frame points at.
-                        // `pc` here is the 1-based statement index within `debuginfo`'s CodeInfo.
+                        // Smuggle IR index through DWARF column field.  Note
+                        // `debuginfo` here is lowered, not optimized; optimized
+                        // would give us better provenance for inlined frames,
+                        // but produces too many unique DILocations.
                         unsigned col = (unsigned)pc;
                         if (new_lineinfo.empty() && info.file == ctx.file) { // if everything matches, emit a toplevel line number
                             info.loc = DILocation::get(ctx.builder.getContext(), info.line, col, SP, NULL);

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1442,9 +1442,146 @@ JL_DLLEXPORT struct jl_codeloc_t jl_uncompress1_codeloc(jl_debuginfo_t *di, size
     assert(jl_is_string(cl));
     int loc_offset, loc_bytes, to_bytes;
     size_t nstmts = codelocs_parseheader(cl, &loc_offset, &loc_bytes, &to_bytes);
-    if (pc > nstmts)
-        return badloc;
+    if (pc < 0 || pc > nstmts)
+        return badloc; // ideally an assertion, but currently happens too often
     return unpack_codeloc(cl, pc, loc_offset, loc_bytes, to_bytes);
+}
+
+static const char *sbt_parseheader(jl_string_t *str, jl_sourcebytetable_header_t *h) JL_NOTSAFEPOINT
+{
+    assert(jl_is_string(str));
+    const char *ptr = jl_string_data(str);
+    memcpy(h, ptr, SBT_HEADER_SIZE); // TODO assumes LE
+    return ptr + SBT_HEADER_SIZE;
+}
+
+/* `jl_cdi_*`: barebones non-allocating interface for reading compressed
+ * debuginfo.  Only `jl_cdi_firstxy` may be used on line-based DebugInfo.
+ * All byte positions, line numbers, column numbers, and program counters are
+ * 1-based, and all ranges are inclusive-inclusive. */
+
+/* traverse `di.linetable` (towards line/byte information, ignoring edges),
+ * returning new debuginfo in `p_di` and optionally pc in `p_pc`. */
+static void cdi_deref(jl_debuginfo_t **p_di, int32_t *p_pc, int recursive) JL_NOTSAFEPOINT
+{
+    jl_debuginfo_t *di = *p_di;
+    int32_t pc = 0;
+    if (!p_pc)
+        p_pc = &pc;
+    if (jl_typeof(di->linetable) == (jl_value_t *)jl_debuginfo_type) {
+        *p_pc = jl_uncompress1_codeloc(di, *p_pc).loc;
+        *p_di = (jl_debuginfo_t *)di->linetable;
+        if (recursive) {
+            cdi_deref(p_di, p_pc, recursive);
+        }
+    } else {
+        if (jl_is_string(di->linetable)) {jl_unreachable();} // TODO: remove when byte-precise
+        assert(jl_is_string(di->linetable) || jl_is_nothing(di->linetable));
+    }
+}
+
+JL_DLLEXPORT jl_locspan_t jl_cdi_bytespan(jl_debuginfo_t *di, int32_t pc) JL_NOTSAFEPOINT
+{
+    jl_unreachable(); // TODO: remove when byte-precise
+    cdi_deref(&di, &pc, 1);
+    pc = jl_uncompress1_codeloc(di, pc).loc;
+    jl_sourcebytetable_header_t h;
+    const char *ptr = sbt_parseheader(di->linetable, &h);
+    if (pc <= 0 || pc > h.nlocs) {
+        return (jl_locspan_t){-1, -1};
+    }
+    ptr += (pc-1)*(h.byte_encl+h.span_encl);
+    jl_locspan_t out;
+    out.first = _take_u32(&ptr, h.byte_encl) + h.byte_offset;
+    out.second = _take_u32(&ptr, h.span_encl) + out.first - 1;
+    return out;
+}
+
+/* O(line_starts); could binary search instead */
+JL_DLLEXPORT jl_locspan_t jl_cdi_byte_to_xy(jl_debuginfo_t *di, int32_t b) JL_NOTSAFEPOINT
+{
+    jl_unreachable(); // TODO: remove when byte-precise
+    cdi_deref(&di, NULL, 1);
+    jl_sourcebytetable_header_t h;
+    sbt_parseheader(di->linetable, &h);
+    size_t off = SBT_HEADER_SIZE + h.nlocs * (h.byte_encl + h.span_encl);
+    size_t n_lines = (jl_string_len(di->linetable) - off) / h.byte_encl;
+    jl_locspan_t out = {h.line_offset-1, -1};
+    const char *ptr = jl_string_data(di->linetable) + off;
+    for (int i = 0; i < n_lines; i++) {
+        int32_t line_start = _take_u32(&ptr, h.byte_encl);
+        if (line_start + h.byte_offset <= b) {
+            out.second = b - (line_start + h.byte_offset) + 1;
+            out.first++;
+        } else if (i == 0) { // b too small
+            return (jl_locspan_t){-1, -1};
+        } else {
+            break;
+        }
+    }
+    return out;
+}
+
+/* First (line, col) at the given pc, where col=-1 if unavailable */
+JL_DLLEXPORT jl_locspan_t jl_cdi_firstxy(jl_debuginfo_t *di, int32_t pc) JL_NOTSAFEPOINT
+{
+    assert(pc > 0);
+    cdi_deref(&di, &pc, 1);
+    jl_locspan_t out = {-1, -1};
+    if (jl_is_nothing(di->linetable)) {
+        out.first = jl_uncompress1_codeloc(di, pc).loc;
+    } else if (jl_is_string(di->linetable)) {
+        out = jl_cdi_byte_to_xy(di, jl_cdi_bytespan(di, pc).first);
+    }
+    return out;
+}
+
+/* Only when linetable==nothing, it's possible to have a separate first line not
+ * associated with any IR statement (the extra firstline argument to
+ * jl_compress_codelocs).  Coverage uses this.  -1 if not present.  Ideally the
+ * >-1 case will be deprecated, since this implementation doesn't allow a
+ * linetable to be shared between multiple owners */
+JL_DLLEXPORT int32_t jl_cdi_external_firstline(jl_debuginfo_t *di) JL_NOTSAFEPOINT
+{
+    int32_t pc = 0;
+    cdi_deref(&di, &pc, 1);
+    if (jl_is_nothing(di->linetable)) {
+        int32_t out = jl_uncompress1_codeloc(di, 0).loc;
+        return out > 0 ? out : -1;
+    } else if (jl_is_string(di->linetable)) {
+        return -1;
+    }
+    jl_unreachable();
+}
+
+JL_DLLEXPORT int32_t jl_cdi_firstline_all(jl_debuginfo_t *di) JL_NOTSAFEPOINT
+{
+    int32_t out = jl_cdi_external_firstline(di);
+    if (out == -1) {
+        /* TODO: not necessarily first, but a good enough guess for display */
+        cdi_deref(&di, NULL, 1);
+        out = jl_cdi_firstxy(di, 1).first;
+    }
+    return out;
+}
+
+JL_DLLEXPORT const char *jl_cdi_file(jl_debuginfo_t *di) JL_NOTSAFEPOINT
+{
+    cdi_deref(&di, NULL, 1);
+    if (jl_is_symbol(di->def)) {
+        return jl_symbol_name((jl_sym_t*)di->def);
+    } else if (jl_is_method_instance(di->def)) {
+        // reachable with hand-crafted CodeInstances in base tests
+        jl_value_t *m = ((jl_method_instance_t *)di->def)->def.value;
+        assert(jl_is_method(m) && "unimplemented");
+        return jl_symbol_name(((jl_method_t*)m)->file);
+    } else if (jl_is_nothing(di->def)) {
+        // reachable when linenumbernode.file is nothing (through method.c)
+        return "<unknown>";
+    } else {
+        assert(0 && "unexpected type for debuginfo.def");
+        return "<unknown>";
+    }
 }
 
 static int allzero(jl_value_t *codelocs) JL_NOTSAFEPOINT

--- a/src/julia.h
+++ b/src/julia.h
@@ -235,15 +235,40 @@ JL_DLLEXPORT extern const jl_callptr_t jl_f_opaque_closure_call_addr;
 
 JL_DLLEXPORT extern const jl_callptr_t jl_fptr_wait_for_compiled_addr;
 
+typedef struct _jl_locspan_t {
+    int32_t first;
+    int32_t second;
+} jl_locspan_t;
+
 struct jl_codeloc_t {
     int32_t loc;
     int32_t to;
     int32_t pc;
 };
 
+// In a compressed jl_debuginfo_t linetable string, this header is followed by
+// (with byte_offest subtracted from all raw byte positions):
+//
+// bytespans: (byte_encl+span_encl)*nlocs bytes
+// line_starts: byte_encl*rest bytes
+typedef struct _jl_sourcebytetable_header_t {
+    // (>0) minimum byte
+    int32_t byte_offset;
+    // (>0) minimum line, where line_starts[0] is the byte position of this
+    // line's first character
+    int32_t line_offset;
+    // (>=0) number of (byte, len) bytespans
+    int32_t nlocs;
+    // (0,1,2,4) compressed lengths
+    uint8_t byte_encl;
+    uint8_t span_encl;
+} jl_sourcebytetable_header_t;
+// packed size
+#define SBT_HEADER_SIZE 14
+
 typedef struct _jl_debuginfo_t {
     jl_value_t *def;
-    jl_value_t *linetable; // debuginfo or nothing
+    jl_value_t *linetable; // debuginfo, compressed string, or nothing
     jl_svec_t *edges; // Memory{DebugInfo}
     jl_value_t *codelocs; // String // Memory{UInt8} // compressed info
 } jl_debuginfo_t;
@@ -2297,6 +2322,12 @@ JL_DLLEXPORT jl_value_t *jl_uncompress_argname_n(jl_value_t *syms, size_t i);
 JL_DLLEXPORT struct jl_codeloc_t jl_uncompress1_codeloc(jl_debuginfo_t *di, size_t pc) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_compress_codelocs(int32_t firstloc, jl_value_t *codelocs, size_t nstmts);
 JL_DLLEXPORT jl_value_t *jl_uncompress_codelocs(jl_debuginfo_t *di, size_t nstmts);
+JL_DLLEXPORT jl_locspan_t jl_cdi_bytespan(jl_debuginfo_t *di, int32_t pc) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_locspan_t jl_cdi_byte_to_xy(jl_debuginfo_t *di, int32_t b) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_locspan_t jl_cdi_firstxy(jl_debuginfo_t *di, int32_t pc) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int32_t jl_cdi_external_firstline(jl_debuginfo_t *di) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int32_t jl_cdi_firstline_all(jl_debuginfo_t *di) JL_NOTSAFEPOINT;
+JL_DLLEXPORT const char *jl_cdi_file(jl_debuginfo_t *di) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint8_t jl_encode_inlining_cost(uint16_t inlining_cost) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uint16_t jl_decode_inlining_cost(uint8_t inlining_cost) JL_NOTSAFEPOINT;
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -839,8 +839,6 @@ STATIC_INLINE jl_method_instance_t *jl_get_ci_mi(jl_code_instance_t *ci JL_PROPA
     return (jl_method_instance_t*)def;
 }
 
-JL_DLLEXPORT const char *jl_debuginfo_firstline(jl_debuginfo_t *debuginfo, int *line) JL_NOTSAFEPOINT;
-JL_DLLEXPORT const char *jl_debuginfo_file1(jl_debuginfo_t *debuginfo) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_module_t *jl_debuginfo_module1(jl_value_t *debuginfo_def) JL_NOTSAFEPOINT;
 JL_DLLEXPORT const char *jl_debuginfo_name(jl_value_t *func) JL_NOTSAFEPOINT;
 

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -818,14 +818,18 @@ JL_DLLEXPORT jl_value_t *jl_lookup_code_address(void *ip, int skipC)
 }
 
 static void jl_safe_fprint_codeloc(ios_t *s, const char* func_name, const char* file_name,
-                                   int line, int pc, int inlined) JL_NOTSAFEPOINT
+                                   int line, int col, int pc, int inlined) JL_NOTSAFEPOINT
 {
     const char *inlined_str = inlined ? " [inlined]" : "";
+    if (col == -1) {
+        col = 0;
+    }
     if (line != -1) {
         if (pc > 0)
-            jl_safe_fprintf(s, "%s at %s:%d:%d%s\n", func_name, file_name, line, pc, inlined_str);
+            jl_safe_fprintf(s, "%s at %s:%d:%d (pc: %d)%s\n",
+                            func_name, file_name, line, col, pc, inlined_str);
         else
-            jl_safe_fprintf(s, "%s at %s:%d%s\n", func_name, file_name, line, inlined_str);
+            jl_safe_fprintf(s, "%s at %s:%d:%d%s\n", func_name, file_name, line, col, inlined_str);
     }
     else {
         jl_safe_fprintf(s, "%s at %s (unknown line)%s\n", func_name, file_name, inlined_str);
@@ -850,39 +854,15 @@ void jl_fprint_native_codeloc(ios_t *s, uintptr_t ip) JL_NOTSAFEPOINT
             jl_safe_fprintf(s, "unknown function (ip: %p) at %s\n", (void*)ip, frame.file_name ? frame.file_name : "(unknown file)");
         }
         else {
-            jl_safe_fprint_codeloc(s, frame.func_name, frame.file_name, frame.line, frame.pc, frame.inlined);
+            int col = frame.fromC ? frame.pc : 0;
+            int pc = frame.fromC ? 0 : frame.pc;
+            jl_safe_fprint_codeloc(
+                s, frame.func_name, frame.file_name, frame.line, col, pc, frame.inlined);
             free(frame.func_name);
         }
         free(frame.file_name);
     }
     free(frames);
-}
-
-const char *jl_debuginfo_file1(jl_debuginfo_t *debuginfo)
-{
-    jl_value_t *def = debuginfo->def;
-    if (jl_is_method_instance(def))
-        def = ((jl_method_instance_t*)def)->def.value;
-    if (jl_is_method(def))
-        def = (jl_value_t*)((jl_method_t*)def)->file;
-    if (jl_is_symbol(def))
-        return jl_symbol_name((jl_sym_t*)def);
-    return "<unknown>";
-}
-
-// File name and line number of first line
-const char *jl_debuginfo_firstline(jl_debuginfo_t *debuginfo, int* line)
-{
-    jl_value_t *linetable = (jl_value_t*)debuginfo;
-    while (jl_is_debuginfo(linetable)) {
-        debuginfo = (jl_debuginfo_t*)linetable;
-        linetable = debuginfo->linetable;
-    }
-    if (line) {
-        struct jl_codeloc_t lineidx = jl_uncompress1_codeloc(debuginfo, 0);
-        *line = lineidx.loc;
-    }
-    return jl_debuginfo_file1(debuginfo);
 }
 
 jl_module_t *jl_debuginfo_module1(jl_value_t *debuginfo_def)
@@ -932,8 +912,9 @@ static void jl_fprint_debugloc(ios_t *s, jl_debuginfo_t *debuginfo, jl_value_t *
         if (ip2 < 0) // set broken debug info to ignored
             ip2 = 0;
         const char *func_name = jl_debuginfo_name(func);
-        const char *file = jl_debuginfo_firstline(debuginfo, NULL);
-        jl_safe_fprint_codeloc(s, func_name, file, ip2, (int)ip, inlined);
+        const char *file = jl_cdi_file(debuginfo);
+        jl_locspan_t xy = jl_cdi_firstxy(debuginfo, ip);
+        jl_safe_fprint_codeloc(s, func_name, file, xy.first, xy.second, (int)ip, inlined);
     }
 }
 

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -726,8 +726,8 @@ JL_DLLEXPORT jl_value_t *jl_eval_thunk(jl_module_t *JL_NONNULL m, jl_code_info_t
     // start of this block.
     int last_lineno = jl_atomic_load_relaxed(&jl_lineno);
     const char *last_filename = jl_atomic_load_relaxed(&jl_filename);
-    int toplevel_lineno = 0;
-    const char* toplevel_filename = jl_debuginfo_firstline(thk->debuginfo, &toplevel_lineno);
+    int toplevel_lineno = jl_cdi_firstline_all(thk->debuginfo);
+    const char *toplevel_filename = jl_cdi_file(thk->debuginfo);
     jl_atomic_store_relaxed(&jl_lineno, toplevel_lineno);
     jl_atomic_store_relaxed(&jl_filename, toplevel_filename);
 

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -91,9 +91,12 @@ trace = (try; f(3); catch; stacktrace(catch_backtrace()); end)[1:3]
 can_inline = Bool(Base.JLOptions().can_inline)
 for (frame, func, inlined) in zip(trace, [g,h,f], (can_inline, can_inline, false))
     @test frame.func === typeof(func).name.singletonname
-    @test frame.linfo.def.module === which(func, (Any,)).module
-    @test frame.linfo.def === which(func, (Any,))
-    @test frame.linfo.specTypes === Tuple{typeof(func), Int}
+    # broken until #50082 can be addressed
+    mi = isa(frame.linfo, Core.CodeInstance) ? frame.linfo.def : frame.linfo
+    @test mi.def.module === which(func, (Any,)).module broken=inlined
+    @test mi.def === which(func, (Any,)) broken=inlined
+    @test mi.specTypes === Tuple{typeof(func), Int} broken=inlined
+    # line
     @test frame.file === Symbol(@__FILE__)
     @test !frame.from_c
     @test frame.inlined === inlined
@@ -292,63 +295,5 @@ end
         ci.def.def === mcaller && any(stacktrace(bt)) do sf
             sf.file == fl && sf.line == ln
         end
-    end
-end
-
-global f_parent1_line::Int, f_inner1_line::Int, f_innermost1_line::Int
-function f_parent1(a)
-    x = a
-    return begin
-        @inline f_inner1(x)
-    end
-end; f_parent1_line = (@__LINE__) - 2
-function f_inner1(a)
-    x = a
-    return @inline f_innermost1(x)
-end; f_inner1_line = (@__LINE__) - 1
-f_innermost1(x) = x > 0 ? @noinline(sin(x)) : error("x is negative")
-f_innermost1_line = (@__LINE__) - 1
-let st = try
-        f_parent1(-1)
-    catch err
-        stacktrace(catch_backtrace())
-    end
-    @test any(st) do sf
-        sf.func === :f_parent1 && sf.line == f_parent1_line && sf.linfo isa Core.MethodInstance
-    end
-    @test any(st) do sf
-        sf.func === :f_inner1 && sf.line == f_inner1_line && sf.linfo isa Core.MethodInstance && sf.inlined
-    end
-    @test any(st) do sf
-        sf.func === :f_innermost1 && sf.line == f_innermost1_line && sf.linfo isa Core.MethodInstance && sf.inlined
-    end
-end
-
-global f_parent2_line::Int, f_inner2_line::Int, f_innermost2_line::Int
-function f_parent2(a)
-    x = identity(a)
-    return begin
-        @inline f_inner2(x)
-    end
-end; f_parent2_line = (@__LINE__) - 2
-function f_inner2(a)
-    x = identity(a)
-    return @inline f_innermost2(x)
-end; f_inner2_line = (@__LINE__) - 1
-f_innermost2(x) = x > 0 ? @noinline(sin(x)) : error("x is negative")
-f_innermost2_line = (@__LINE__) - 1
-let st = try
-        f_parent2(-1)
-    catch err
-        stacktrace(catch_backtrace())
-    end
-    @test any(st) do sf
-        sf.func === :f_parent2 && sf.line == f_parent2_line && sf.linfo isa Core.MethodInstance
-    end
-    @test any(st) do sf
-        sf.func === :f_inner2 && sf.line == f_inner2_line && sf.linfo isa Core.MethodInstance && sf.inlined
-    end
-    @test any(st) do sf
-        sf.func === :f_innermost2 && sf.line == f_innermost2_line && sf.linfo isa Core.MethodInstance && sf.inlined
     end
 end


### PR DESCRIPTION
Atop #61817, reverts #61606 and parts of #53925.

I tried to make the original change correct by storing the post-optimization
program counter in #61699, but that was enough redundant information to cause
compile-time and image size regressions.  I also tried to fix that by using the
optimized PC instead of our megabytes of inlined-frame DWARF for frame retrieval
in #61819. That's still open to discussion, but if we must ship all
inlined-frame DWARF then that won't work either.  I've concluded the best option
is for me to to temporarily admit defeat and give up on finding MethodInstances
for inlined frames.

This change doesn't revert the use of the pre-optimization PC in the column
field since it gives us more information than just the column (both first and
last byte, column and line), but I don't think we want to do that forever, since
DWARF only gives it 16 bits.

Note that a DebugInfo-scan-based approach could be done here to restore MI
printing, but it would need to assume several things about the DebugInfo tree
that I might change in the next couple of months, so implement at your own risk!
