### PR TITLE
staticdata: restore extext_methods and new_ext_cis to inspector svec

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -4335,7 +4335,11 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
                 jl_svecset(cachesizes_sv, 4, jl_box_long(cachesizes.reloclist));
                 jl_svecset(cachesizes_sv, 5, jl_box_long(cachesizes.gvarlist));
                 jl_svecset(cachesizes_sv, 6, jl_box_long(cachesizes.fptrlist));
-                restored = (jl_value_t*)jl_svec(5, restored, init_order, internal_methods, method_roots_list, cachesizes_sv);
+                // Surface extext_methods and new_ext_cis to external inspectors (e.g. PkgCacheInspector.jl).
+                // With the single global jl_method_table, `extext_methods` contains *all* worklist methods
+                // (not just externally-extending ones); `internal_methods` overlaps it and exists only for
+                // per-object world-stamp updates during the fixup walk.
+                restored = (jl_value_t*)jl_svec(7, restored, init_order, internal_methods, extext_methods, new_ext_cis, method_roots_list, cachesizes_sv);
             }
             else {
                 restored = (jl_value_t*)jl_svec(3, restored, init_order, internal_methods);

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1968,7 +1968,7 @@ precompile_test_harness("PkgCacheInspector") do load_path
             cachefile, depmods, #=completeinfo=#true, "PCI")
     end
 
-    modules, init_order, internal_methods, new_method_roots, cache_sizes = sv
+    modules, init_order, internal_methods, extext_methods, new_ext_cis, new_method_roots, cache_sizes = sv
     for m in internal_methods::Vector{Any}
         m isa Core.MethodInstance || continue
         m = m.func::Method


### PR DESCRIPTION
Found working on https://github.com/timholy/PkgCacheInspector.jl/pull/37

Claude:

---

`jl_restore_package_image_from_stream` (with `completeinfo=true`) loads `extext_methods` (the worklist-owned `TypeMapEntry` extensions of external functions) and `new_ext_cis` (new external `CodeInstance` specializations), GC-roots them, and feeds them to internal callers, but the final 5-element svec returned at the end of the function discards both arrays. External inspectors (e.g.
PkgCacheInspector.jl) therefore have no way to enumerate either: the `internal_methods` array exposed in the svec is populated only as a side-effect of the fixup walk and on every package image examined contained zero `TypeMapEntry` objects.

Return both arrays alongside `internal_methods` in a 7-element svec so the information is once again accessible.