### PR TITLE
re-add inbounds to `_fill!(::AbstractArray)`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -365,7 +365,7 @@ function fill!(A::AbstractArray{T}, x) where T
 end
 function _fill!(A::AbstractArray{T}, x::T) where T
     for i in eachindex(A)
-        A[i] = x
+       @inbounds A[i] = x
     end
     return A
 end


### PR DESCRIPTION
fixes https://github.com/JuliaLang/julia/issues/61870, partially reverts https://github.com/JuliaLang/julia/pull/59181

it appears the optimizer is not quite smart enough yet --- maybe after https://github.com/JuliaLang/julia/pull/50641 ..? --- to remove this `@inbounds` without performance regressions in pretty common cases, and this is a legal usage anyway (users should simply ask their AI to "be correct" when implementing `eachindex`)

before
```julia
julia> @benchmark zero(X) setup=X=rand(50,50)
BenchmarkTools.Trial: 10000 samples with 555 evaluations per sample.
 Range (min … max):  215.465 ns … 144.094 μs  ┊ GC (min … max):  0.00% … 99.60%
 Time  (median):     414.752 ns               ┊ GC (median):    20.45%
 Time  (mean ± σ):   747.628 ns ±   5.877 μs  ┊ GC (mean ± σ):  51.92% ± 13.69%

  ▄▁     ██▁                                                     
  ██▃▂▂▃▃███▆▅▅▅▇▇▆▇▇▇▆▆▇▆▅▅▅▅▄▄▄▃▃▃▃▂▂▃▂▂▂▂▂▂▂▁▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  215 ns           Histogram: frequency by time          979 ns <
```

after
```julia
julia> @benchmark zero(X) setup=X=rand(50,50)
BenchmarkTools.Trial: 10000 samples with 611 evaluations per sample.
 Range (min … max):  200.355 ns … 82.883 μs  ┊ GC (min … max):  0.00% … 99.43%
 Time  (median):     282.391 ns              ┊ GC (median):    24.70%
 Time  (mean ± σ):   496.646 ns ±  4.038 μs  ┊ GC (mean ± σ):  55.54% ± 13.11%

  ▂▂▁               ▅▇█▅▃▁                                      
  ████▄▃▃▂▂▁▁▁▁▁▁▁▁▁██████▄▅▄▄▃▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  200 ns          Histogram: frequency by time          446 ns <
```