### PR TITLE
add LoopIdiomRecognizePass for `memset`-table loops

### DIFF
--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -542,6 +542,8 @@ static void buildVectorPipeline(FunctionPassManager &FPM, PassBuilder *PB, Optim
         FPM.addPass(LoopVectorizePass());
         FPM.addPass(LoopLoadEliminationPass());
         FPM.addPass(SimplifyCFGPass(aggressiveSimplifyCFGOptions()));
+        FPM.addPass(createFunctionToLoopPassAdaptor(LoopIdiomRecognizePass(), /*UseMemorySSA=*/true, /*UseBlockFrequencyInfo=*/false));
+        FPM.addPass(createFunctionToLoopPassAdaptor(LoopDeletionPass(), /*UseMemorySSA=*/true, /*UseBlockFrequencyInfo=*/false));
         FPM.addPass(createFunctionToLoopPassAdaptor(LICMPass(LICMOptions()), /*UseMemorySSA=*/true, /*UseBlockFrequencyInfo=*/false));
         FPM.addPass(EarlyCSEPass());
         FPM.addPass(CorrelatedValuePropagationPass());

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -535,6 +535,7 @@ static void buildVectorPipeline(FunctionPassManager &FPM, PassBuilder *PB, Optim
         // Rerotate loops that might have been unrotated in the simplification
         LoopPassManager LPM;
         LPM.addPass(LoopRotatePass());
+        LPM.addPass(LoopIdiomRecognizePass());
         LPM.addPass(LoopDeletionPass());
         FPM.addPass(createFunctionToLoopPassAdaptor(std::move(LPM), /*UseMemorySSA=*/false, /*UseBlockFrequencyInfo=*/false));
         FPM.addPass(LoopDistributePass());
@@ -542,8 +543,6 @@ static void buildVectorPipeline(FunctionPassManager &FPM, PassBuilder *PB, Optim
         FPM.addPass(LoopVectorizePass());
         FPM.addPass(LoopLoadEliminationPass());
         FPM.addPass(SimplifyCFGPass(aggressiveSimplifyCFGOptions()));
-        FPM.addPass(createFunctionToLoopPassAdaptor(LoopIdiomRecognizePass(), /*UseMemorySSA=*/true, /*UseBlockFrequencyInfo=*/false));
-        FPM.addPass(createFunctionToLoopPassAdaptor(LoopDeletionPass(), /*UseMemorySSA=*/true, /*UseBlockFrequencyInfo=*/false));
         FPM.addPass(createFunctionToLoopPassAdaptor(LICMPass(LICMOptions()), /*UseMemorySSA=*/true, /*UseBlockFrequencyInfo=*/false));
         FPM.addPass(EarlyCSEPass());
         FPM.addPass(CorrelatedValuePropagationPass());


### PR DESCRIPTION
fixes https://github.com/JuliaLang/julia/issues/61870, closes https://github.com/JuliaLang/julia/pull/61871

```julia
julia> using BenchmarkTools

julia> function my_zero_inbounds!(A::Matrix{Float64})
           for i in eachindex(A)
               @inbounds A[i] = 0.0
           end
           return A
       end
my_zero_inbounds! (generic function with 1 method)

julia> function my_zero!(A::Matrix{Float64})
           for i in eachindex(A)
               A[i] = 0.0
           end
           return A
       end
my_zero! (generic function with 1 method)

julia> @benchmark my_zero_inbounds!(X) setup=X=rand(1000, 1000)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  27.083 μs … 226.500 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     32.750 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   41.400 μs ±  15.265 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▅▆██▇▅▃▂▁▁ ▇ ▂ ▂▃▂  ▁    ▂▅▅▅▄▃▂▁▂▁▁▃▁▁▁▂▂▂▁▁ ▁    ▁ ▃▂      ▂
  ██████████▇████████▇█▇▇▇▆██████████████████████▇███████▇▆▇█▆ █
  27.1 μs       Histogram: log(frequency) by time      82.8 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark my_zero!(X) setup=X=rand(1000, 1000)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  27.125 μs … 156.000 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     30.167 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   33.619 μs ±   5.419 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

         █▇                            ▂                        
  ▂▃▃▄▂▂████▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▃▃▃▂▃▅▇▇█▄▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  27.1 μs         Histogram: frequency by time         45.8 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

previously the non-inbounds one was slower
```julia
julia> @benchmark my_zero!(X) setup=X=rand(1000, 1000)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  55.250 μs …  1.088 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     63.250 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   67.430 μs ± 15.484 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▄ ▁▁▆▅▁   █▆▃▄▃▂▂▂▂▁▁▁▁▁▅▁▂▂▁▁▂▃▁▁                ▂▃▂▁      ▂
  ███████▇▇▇███████████████████████████▇▇▇▆▆▆▆▅▅▆▇▇█████▇█▇▇▇ █
  55.2 μs      Histogram: log(frequency) by time      98.4 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```