### PR TITLE
module: zero-init `export_set_changed_since_require_world` on module creation

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -542,6 +542,7 @@ static jl_module_t *jl_new_module__(jl_sym_t *name, jl_module_t *parent)
     m->infer = -1;
     m->max_methods = -1;
     jl_atomic_store_relaxed(&m->has_reexports, 0);
+    jl_atomic_store_relaxed(&m->export_set_changed_since_require_world, 0);
     m->file = jl_empty_sym;
     m->line = 0;
     m->hash = parent == NULL ? bitmix(name->hash, jl_module_type->hash) :


### PR DESCRIPTION
fix is fully claude one shot. I was also able to glean a small reproducible test, but it was not deterministic and I don't have confidence it would work on all machines, so I omitted it.

------------------------------------------------------------------------------------------

This `_Atomic(int8_t)` field was added in #57421 but never initialized in `jl_new_module__`. `jl_gc_alloc` does not zero the returned memory, so each fresh module started with whatever garbage was in the pool slot. The field is read by `all_usings_unchanged_implicit` in `src/staticdata.c` during pkgimage loading: a non-zero garbage value spuriously forces binding-partition revalidation for downstream modules.

The fix matches the existing zero-init of the adjacent `has_reexports` field that was added in #59859.