### PR TITLE
subtype: Remove another bad test

### DIFF
--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2371,9 +2371,7 @@ end
 #issue 46736
 let S = Tuple{Val{T}, T} where {S1,T<:Val{Union{Nothing,S1}}},
     T = Tuple{Val{Val{Union{Nothing, S2}}}, Any} where S2
-    @testintersect(S, T, !Union{})
-    # not ideal (`S1` should be unbounded)
-    @test_broken testintersect(S, T) == Tuple{Val{Val{Union{Nothing, S1}}}, Val{Union{Nothing, S1}}} where S1<:(Union{Nothing, S2} where S2)
+    @testintersect(S, T, Tuple{Val{Val{Union{Nothing, S1}}}, Val{Union{Nothing, S1}}} where S1)
 end
 
 #issue #47874:case1


### PR DESCRIPTION
This test failed because `testintersect` is a typo for `typeintersect`, but regardless the issue is fixed now, so just fold it into the previous test.