### PR TITLE
set `max_methods=1` for `!=`, `>`, `>=` to 1

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -318,6 +318,7 @@ false
 ```
 """
 !=(x, y) = !(x == y)
+typeof(!=).name.max_methods = UInt8(1)
 const ≠ = !=
 
 """
@@ -422,6 +423,7 @@ true
 ```
 """
 >(x, y) = y < x
+typeof(>).name.max_methods = UInt8(1)
 
 """
     <=(x, y)
@@ -477,6 +479,7 @@ true
 ```
 """
 >=(x, y) = (y <= x)
+typeof(>=).name.max_methods = UInt8(1)
 const ≥ = >=
 
 # this definition allows Number types to implement < instead of isless,


### PR DESCRIPTION
these methods are according to their docstring not really "supposed" to be overloaded and you should instead use the fallback. Overloading these methods right now causes a huge number of invalidations immidiately.

However, in some cases, one might not want to use the fallback, for example, in PythonCall, one wants the `>` method to in fact call the `__gt__` method.

So I think it is better to just set max methods on these to 1 to avoid the immidiate invalidations that occur when bringing the number of methods from 2 -> 3 whenever a package defines one of them
