### PR TITLE
docs: fix Base.Libc.memcmp compat note (1.9 → 1.10)

### DIFF
--- a/base/cmem.jl
+++ b/base/cmem.jl
@@ -48,7 +48,7 @@ end
 Call `memcmp` from the C standard library.
 
 !!! compat "Julia 1.10"
-    Support for `memcmp` requires at least Julia 1.9.
+    Support for `memcmp` requires at least Julia 1.10.
 
 """
 function memcmp(a::Ptr, b::Ptr, n::Integer)


### PR DESCRIPTION
The compat block on `Base.Libc.memcmp` has a mismatched header and body the header reads `!!! compat "Julia 1.10"` but the body text says "requires at least Julia 1.9". 

This PR aligns the body with the header and the actual release history.

`memcmp` (and the other `mem*` methods added in #49550) first shipped in `v1.10.0-alpha1`, not `v1.9.0`:

    $ git tag --contains f8dd16e5c1 | sort -V | head -3
    v1.10.0
    v1.10.0-alpha1
    v1.10.0-beta1

(`f8dd16e5c1` is the merge commit for #49550.)

One-line text edit; no doctest or behaviour change.