### PR TITLE
module: avoid materializing binding partitions in names/exported_names

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -2112,30 +2112,34 @@ void append_module_names(jl_array_t* a, jl_module_t *m, int all, int imported, i
         int hidden = jl_symbol_name(asname)[0]=='#';
         int main_public = (m == jl_main_module && !(asname == jl_eval_sym || asname == jl_include_sym));
         // Use non-materializing read to avoid creating binding partitions as a
-        // side effect. Fall back to materializing if we need the kind to
-        // determine visibility (e.g. for `all`, `imported`, or `usings`).
+        // side effect. Only fall back to materializing for `usings`, since
+        // using'd bindings may not have partitions yet. Non-using'd bindings
+        // (imported, global, const, etc.) will already have been materialized
+        // by their definition.
         struct implicit_search_gap gap;
         jl_binding_partition_t *bpart = jl_get_binding_partition_if_present(b, world, &gap);
+        if (!bpart && usings)
+            bpart = jl_get_binding_partition(b, world);
         if (!bpart) {
-            if (all || imported || usings) {
-                bpart = jl_get_binding_partition(b, world);
-            } else {
-                // We only need public/exported status. Public is on the binding
-                // itself; exported bindings were already materialized above.
-                if ((jl_atomic_load_relaxed(&b->flags) & BINDING_FLAG_PUBLICP) &&
-                    (!(gap.inherited_flags & PARTITION_FLAG_DEPRECATED) && !hidden))
-                    _append_symbol_to_bindings_array(a, asname);
+            // No partition — can only check the public flag on the binding.
+            // Exported bindings already have partitions from
+            // _materialize_reexported_bindings above.
+            if (!(jl_atomic_load_relaxed(&b->flags) & BINDING_FLAG_PUBLICP))
                 continue;
-            }
+            if (!all && ((gap.inherited_flags & PARTITION_FLAG_DEPRECATED) || hidden))
+                continue;
+        } else {
+            enum jl_partition_kind kind = jl_binding_kind(bpart);
+            if (!(jl_atomic_load_relaxed(&b->flags) & BINDING_FLAG_PUBLICP) &&
+                !jl_bpart_is_exported(bpart->kind) &&
+                !(imported && (kind == PARTITION_KIND_CONST_IMPORT || kind == PARTITION_KIND_IMPORTED)) &&
+                !(usings && kind == PARTITION_KIND_EXPLICIT) &&
+                !((kind == PARTITION_KIND_GLOBAL || kind == PARTITION_KIND_CONST || kind == PARTITION_KIND_DECLARED) && (all || main_public)))
+                continue;
+            if (!all && ((bpart->kind & PARTITION_FLAG_DEPRECATED) || hidden))
+                continue;
         }
-        enum jl_partition_kind kind = jl_binding_kind(bpart);
-        if (((jl_atomic_load_relaxed(&b->flags) & BINDING_FLAG_PUBLICP) ||
-             jl_bpart_is_exported(bpart->kind) ||
-             (imported && (kind == PARTITION_KIND_CONST_IMPORT || kind == PARTITION_KIND_IMPORTED)) ||
-             (usings && kind == PARTITION_KIND_EXPLICIT) ||
-             ((kind == PARTITION_KIND_GLOBAL || kind == PARTITION_KIND_CONST || kind == PARTITION_KIND_DECLARED) && (all || main_public))) &&
-            (all || (!(bpart->kind & PARTITION_FLAG_DEPRECATED) && !hidden)))
-            _append_symbol_to_bindings_array(a, asname);
+        _append_symbol_to_bindings_array(a, asname);
     }
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -2121,10 +2121,10 @@ void append_module_names(jl_array_t* a, jl_module_t *m, int all, int imported, i
         if (!bpart && usings)
             bpart = jl_get_binding_partition(b, world);
         if (!bpart) {
-            // No partition — can only check the public flag on the binding.
-            // Exported bindings already have partitions from
-            // _materialize_reexported_bindings above.
-            if (!(jl_atomic_load_relaxed(&b->flags) & BINDING_FLAG_PUBLICP))
+            // No partition — check public flag on the binding and exported
+            // flag from adjacent partitions.
+            if (!(jl_atomic_load_relaxed(&b->flags) & BINDING_FLAG_PUBLICP) &&
+                !jl_bpart_is_exported(gap.inherited_flags))
                 continue;
             if (!all && ((gap.inherited_flags & PARTITION_FLAG_DEPRECATED) || hidden))
                 continue;
@@ -2159,8 +2159,11 @@ void append_exported_names(jl_array_t* a, jl_module_t *m, int all, size_t world)
             break;
         struct implicit_search_gap gap;
         jl_binding_partition_t *bpart = jl_get_binding_partition_if_present(b, world, &gap);
-        if (!bpart)
+        if (!bpart) {
+            if (jl_bpart_is_exported(gap.inherited_flags) && (all || !(gap.inherited_flags & PARTITION_FLAG_DEPRECATED)))
+                _append_symbol_to_bindings_array(a, b->globalref->name);
             continue;
+        }
         if (jl_bpart_is_exported(bpart->kind) && (all || !(bpart->kind & PARTITION_FLAG_DEPRECATED)))
             _append_symbol_to_bindings_array(a, b->globalref->name);
     }

--- a/src/module.c
+++ b/src/module.c
@@ -2111,7 +2111,23 @@ void append_module_names(jl_array_t* a, jl_module_t *m, int all, int imported, i
         jl_sym_t *asname = b->globalref->name;
         int hidden = jl_symbol_name(asname)[0]=='#';
         int main_public = (m == jl_main_module && !(asname == jl_eval_sym || asname == jl_include_sym));
-        jl_binding_partition_t *bpart = jl_get_binding_partition(b, world);
+        // Use non-materializing read to avoid creating binding partitions as a
+        // side effect. Fall back to materializing if we need the kind to
+        // determine visibility (e.g. for `all`, `imported`, or `usings`).
+        struct implicit_search_gap gap;
+        jl_binding_partition_t *bpart = jl_get_binding_partition_if_present(b, world, &gap);
+        if (!bpart) {
+            if (all || imported || usings) {
+                bpart = jl_get_binding_partition(b, world);
+            } else {
+                // We only need public/exported status. Public is on the binding
+                // itself; exported bindings were already materialized above.
+                if ((jl_atomic_load_relaxed(&b->flags) & BINDING_FLAG_PUBLICP) &&
+                    (!(gap.inherited_flags & PARTITION_FLAG_DEPRECATED) && !hidden))
+                    _append_symbol_to_bindings_array(a, asname);
+                continue;
+            }
+        }
         enum jl_partition_kind kind = jl_binding_kind(bpart);
         if (((jl_atomic_load_relaxed(&b->flags) & BINDING_FLAG_PUBLICP) ||
              jl_bpart_is_exported(bpart->kind) ||
@@ -2137,7 +2153,10 @@ void append_exported_names(jl_array_t* a, jl_module_t *m, int all, size_t world)
         jl_binding_t *b = (jl_binding_t*)jl_svecref(table, i);
         if ((void*)b == jl_nothing)
             break;
-        jl_binding_partition_t *bpart = jl_get_binding_partition(b, world);
+        struct implicit_search_gap gap;
+        jl_binding_partition_t *bpart = jl_get_binding_partition_if_present(b, world, &gap);
+        if (!bpart)
+            continue;
         if (jl_bpart_is_exported(bpart->kind) && (all || !(bpart->kind & PARTITION_FLAG_DEPRECATED)))
             _append_symbol_to_bindings_array(a, b->globalref->name);
     }

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -365,6 +365,34 @@ let defaultset = Set((:A,))
     @test Set(names(TestMod54609.A, all=true, imported=true, usings=true)) == allset ∪ imported ∪ usings
 end
 
+module _TestModNamesNoMaterialize
+    export foo, bar, baz
+    foo() = 1
+    bar() = 2
+    baz() = 3
+end
+module _TestModNamesNoMaterializeUser
+    using .._TestModNamesNoMaterialize
+end
+@testset "names does not materialize binding partitions" begin
+    # names(m) should not materialize binding partitions for implicit imports,
+    # as doing so can trigger unnecessary invalidation cascades during
+    # subsequent `using` statements.
+    B = _TestModNamesNoMaterializeUser
+    # Create bindings in B for the using'd exports without materializing partitions
+    for sym in (:foo, :bar, :baz)
+        ccall(:jl_get_module_binding, Ref{Core.Binding}, (Any, Any, Cint), B, sym, Cint(1))
+    end
+    names(B)
+    # Verify partitions were not materialized as a side effect
+    for sym in (:foo, :bar, :baz)
+        b = ccall(:jl_get_module_binding_or_nothing, Any, (Any, Any), B, sym)
+        @test b !== nothing
+        has_partition = try (@atomic b.partitions; true) catch e; e isa UndefRefError ? false : rethrow(); end
+        @test !has_partition
+    end
+end
+
 @testset "names world argument" begin
     # `names(M; all=true)` walks bindings and filters by partition kind at the
     # given world. A binding that doesn't yet have a GLOBAL/CONST/DECLARED

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -388,8 +388,7 @@ end
     for sym in (:foo, :bar, :baz)
         b = ccall(:jl_get_module_binding_or_nothing, Any, (Any, Any), B, sym)
         @test b !== nothing
-        has_partition = try (@atomic b.partitions; true) catch e; e isa UndefRefError ? false : rethrow(); end
-        @test !has_partition
+        @test !isdefined(b, :partitions)
     end
 end
 


### PR DESCRIPTION
A user on Slack noted that the time for plotting with the following code:

```
using REPL, PythonCall, GLMakie
@time @eval plot(rand(10))
```

had significantly increased vs 1.12, and it was clear recompilation/invalidation was to blame. 


By commenting out parts of PythonCall, bisection style, I got the following MWE:

```
using REPL
Base.hasproperty(Base.Main, :hmm)
using GLMakie
@time @eval plot(rand(10))
```

(the original `hasproperty` call coming from https://github.com/JuliaPy/PythonCall.jl/blob/beec1ec0363d21886558962b6c78689cd1ddee41/src/C/context.jl#L108).

The timings for this (depending on if the `hasproperty` call is commented out or not are:

```
# commented out
  0.077892 seconds (69.93 k allocations: 3.549 MiB, 75.24% compilation time)

# not commented out
  3.138138 seconds (18.76 M allocations: 1019.914 MiB, 16.04% gc time, 99.35% compilation time: 75% of which was recompilation)
```

This didn't really make sense to me, and I got the bot to work on it and it found an issue that `hasproperty` on a module (which call `names` on it) causes many bindings to materialize invalidating later methods. The bot produced this patch and speaking about this diff with @Keno he told me to PR it.

 