### PR TITLE
Call OnAbandoned from JLJITLinkMemoryManager::InFlightAlloc::abandon

### DIFF
--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -1002,8 +1002,7 @@ public:
     InFlightAlloc(JLJITLinkMemoryManager &MM, jitlink::LinkGraph &G) : MM(MM), G(G) {}
 
     void abandon(OnAbandonedFunction OnAbandoned) override {
-        // This shouldn't be reachable, but we will get a better error message
-        // from JITLink if we leak this allocation and fail elsewhere.
+        OnAbandoned(Error::success());
     }
 
     void finalize(OnFinalizedFunction OnFinalized) override


### PR DESCRIPTION
Without this change, if ORC materialization fails with an error, we instead see an assertion failure because of an unchecked Error rather than seeing the ORC error.  Improve the debugging experience by "successfully" abandoning the allocation, even though we don't support deallocating code.  #61847 correctly prints the `UnexpectedSymbolDefinitions` error that is the cause of the problem after this change.

For example, we get this error message instead of a deadlock:
```
nthreads=32
starting workers
JIT session error: Unexpected definitions in module leaf_62-jitted-178: [ julia_leaf_62_0#0, julia_mid_59_0#0 ]
Internal error: Lookup failed: Failed to materialize symbols: { (JuliaOJIT, { julia_topB_52_0#0, jfptr_topB_52_0#0 }) }
Program aborted due to an unhandled Error:
Failed to materialize symbols: { (JuliaOJIT, { julia_topB_52_0#0, jfptr_topB_52_0#0 }) }
```