### PR TITLE
jit: Fix UnexpectedSymbolDefinitions error when we lose addOutput race

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -212,6 +212,7 @@ void JITDebugInfoRegistry::registerJITObject(
 {
     object::section_iterator EndSection = Object.section_end();
 
+    auto &JIT = *jl_ExecutionEngine;
     StringMap<jl_code_instance_t *> sym_to_ci;
     for (auto &[ci, funcs] : Info.ci_funcs) {
         // don't remember toplevel thunks because
@@ -220,9 +221,9 @@ void JITDebugInfoRegistry::registerJITObject(
         if (!jl_is_method(jl_get_ci_mi(ci)->def.method))
             continue;
         if (funcs.invoke)
-            sym_to_ci[*funcs.invoke] = ci;
+            sym_to_ci[*JIT.mangle(*funcs.invoke)] = ci;
         if (funcs.specptr)
-            sym_to_ci[*funcs.specptr] = ci;
+            sym_to_ci[*JIT.mangle(*funcs.specptr)] = ci;
     }
 
     bool anyfunctions = false;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -875,13 +875,15 @@ public:
                 Syms[Unique.specptr] = JITSymbolFlags::Callable | JITSymbolFlags::Exported;
         }
 
-        for (auto &[CI, Funcs] : DeadCIs) {
+        auto Privatize = [&](const orc::SymbolStringPtr &S) JL_NOTSAFEPOINT {
             Function *F;
+            if (S && (F = Out.module->getFunction(JIT.demangle(*S))))
+                F->setLinkage(Function::PrivateLinkage);
+        };
+        for (auto &[CI, Funcs] : DeadCIs) {
             Out.linker_info->ci_funcs.erase(CI);
-            if (Funcs.invoke && (F = Out.module->getFunction(*Funcs.invoke)))
-                F->setLinkage(Function::PrivateLinkage);
-            if (Funcs.specptr && (F = Out.module->getFunction(*Funcs.specptr)))
-                F->setLinkage(Function::PrivateLinkage);
+            Privatize(Funcs.invoke);
+            Privatize(Funcs.specptr);
         }
 
         // Tell ORC about all the other definition in this module.  When
@@ -1941,6 +1943,15 @@ orc::SymbolStringPtr JuliaOJIT::mangle(StringRef Name)
 {
     std::string MangleName = getMangledName(Name);
     return ES.intern(MangleName);
+}
+
+StringRef JuliaOJIT::demangle(StringRef Name)
+{
+#if defined(_OS_WINDOWS_) && !defined(_CPU_X86_64_) || defined(_OS_DARWIN_)
+    if (Name.size() > 0 && Name[0] == '_')
+        return Name.drop_front();
+#endif
+    return Name;
 }
 
 void JuliaOJIT::addGlobalMapping(StringRef Name, uint64_t Addr)

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -844,25 +844,44 @@ public:
         Interface I;
         auto &Syms = I.SymbolFlags;
         SmallSet<SymbolStringPtr, 2> CISyms;
+        SmallVector<
+            std::pair<jl_code_instance_t *, jl_codeinst_funcs_t<orc::SymbolStringPtr>>, 2>
+            DeadCIs;
         for (auto &[CI, Funcs] : Out.linker_info->ci_funcs) {
+            jl_callptr_t Expected = NULL;
+            CISymbolPtr Unique{};
+
+            // If we lose the race to register a symbol for this CI, we must
+            // avoid defining a symbol in the ORC interface for this
+            // MaterializationUnit, lest we raise a UnexpectedSymbolDefinitions
+            // error.
+            if (jl_atomic_cmpswap_relaxed(&CI->invoke, &Expected,
+                                          jl_fptr_wait_for_compiled_addr)) {
+                Unique = JIT.makeUniqueCIName(CI, Funcs);
+            }
+            else {
+                DeadCIs.push_back({CI, Funcs});
+                continue;
+            }
+
             if (Funcs.invoke)
                 CISyms.insert(Funcs.invoke);
             if (Funcs.specptr)
                 CISyms.insert(Funcs.specptr);
 
-            // If we discover that another thread added this CI to the JIT
-            // first, we'll still add the original symbols to CISyms (so they
-            // will be filtered out of the MU Interface), but we won't register them in
-            // CISymbols.
-            jl_callptr_t Expected = NULL;
-            CISymbolPtr Unique{};
-            if (jl_atomic_cmpswap_relaxed(&CI->invoke, &Expected,
-                                          jl_fptr_wait_for_compiled_addr))
-                Unique = JIT.makeUniqueCIName(CI, Funcs);
             if (Unique.invoke)
                 Syms[Unique.invoke] = JITSymbolFlags::Callable | JITSymbolFlags::Exported;
             if (Unique.specptr)
                 Syms[Unique.specptr] = JITSymbolFlags::Callable | JITSymbolFlags::Exported;
+        }
+
+        for (auto &[CI, Funcs] : DeadCIs) {
+            Function *F;
+            Out.linker_info->ci_funcs.erase(CI);
+            if (Funcs.invoke && (F = Out.module->getFunction(*Funcs.invoke)))
+                F->setLinkage(Function::PrivateLinkage);
+            if (Funcs.specptr && (F = Out.module->getFunction(*Funcs.specptr)))
+                F->setLinkage(Function::PrivateLinkage);
         }
 
         // Tell ORC about all the other definition in this module.  When

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -290,23 +290,18 @@ jl_emitted_output_t jl_codegen_output_t::finish(std::unique_ptr<LLVMContext> ctx
                                                 orc::SymbolStringPool &SSP)
 {
     auto info = std::make_unique<jl_linker_info_t>();
-    auto intern = [&](StringRef name) {
-        SmallString<128> buf;
-        Mangler::getNameWithPrefix(buf, name, DL);
-        return SSP.intern(buf);
-    };
 
-    // Mangle and intern each part of the linking metadata, before all the
-    // pointers to LLVM values are invaliated.
+    // Intern each part of the linking metadata, before all the pointers to LLVM
+    // values are invaliated.
     for (auto &[ci, funcs] : ci_funcs) {
         info->ci_funcs[ci] = {funcs.invoke_api,
-                              funcs.invoke ? intern(funcs.invoke->getName()) : nullptr,
-                              funcs.specptr ? intern(funcs.specptr->getName()) : nullptr};
+                              funcs.invoke ? SSP.intern(funcs.invoke->getName()) : nullptr,
+                              funcs.specptr ? SSP.intern(funcs.specptr->getName()) : nullptr};
     }
     for (auto &[call, target] : call_targets)
-        info->call_targets[call] = intern(target.decl->getName());
+        info->call_targets[call] = SSP.intern(target.decl->getName());
     for (auto [val, gv] : global_targets) {
-        info->global_targets[val] = intern(gv->getName());
+        info->global_targets[val] = SSP.intern(gv->getName());
     }
 
     return {std::move(ctx), std::move(mod), std::move(info)};
@@ -877,7 +872,7 @@ public:
 
         auto Privatize = [&](const orc::SymbolStringPtr &S) JL_NOTSAFEPOINT {
             Function *F;
-            if (S && (F = Out.module->getFunction(JIT.demangle(*S))))
+            if (S && (F = Out.module->getFunction(*S)))
                 F->setLinkage(Function::PrivateLinkage);
         };
         for (auto &[CI, Funcs] : DeadCIs) {
@@ -897,7 +892,7 @@ public:
             if (isa<Function>(&G))
                 Flags |= JITSymbolFlags::Callable;
             auto S = JIT.mangle(G.getName());
-            if (CISyms.contains(S))
+            if (CISyms.contains(SSP->intern(G.getName())))
                 continue;
             Syms[S] = Flags;
         }
@@ -1945,15 +1940,6 @@ orc::SymbolStringPtr JuliaOJIT::mangle(StringRef Name)
     return ES.intern(MangleName);
 }
 
-StringRef JuliaOJIT::demangle(StringRef Name)
-{
-#if defined(_OS_WINDOWS_) && !defined(_CPU_X86_64_) || defined(_OS_DARWIN_)
-    if (Name.size() > 0 && Name[0] == '_')
-        return Name.drop_front();
-#endif
-    return Name;
-}
-
 void JuliaOJIT::addGlobalMapping(StringRef Name, uint64_t Addr)
 {
     cantFail(JD.define(orc::absoluteSymbols({{mangle(Name), {ExecutorAddr::fromPtr((void*)Addr), JITSymbolFlags::Exported}}})));
@@ -2259,7 +2245,7 @@ bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferR
 
     // Rename the defined CI functions.
     auto RenameDef = [&](const SymbolStringPtr &Orig, const SymbolStringPtr &Dest)
-                             JL_NOTSAFEPOINT { Syms.at(Orig)->setName(Dest); };
+                         JL_NOTSAFEPOINT { Syms.at(mangle(*Orig))->setName(Dest); };
     for (auto &[CI, Funcs] : Info->ci_funcs) {
         auto &S = CISymbols.at(CI);
         if (Funcs.invoke)
@@ -2271,13 +2257,14 @@ bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferR
     // Rename referenced CIs in the workqueue.
     for (auto &[Call, T] : Info->call_targets) {
         auto [CI, API] = Call;
-        if (!Syms.contains(T))
+        auto TM = mangle(*T);
+        if (!Syms.contains(TM))
             continue;
         JL_GC_PROMISE_ROOTED(CI);
         auto Dest = linkCallTarget(MR, CI, API);
         if (!Dest)
             return false;
-        Syms.at(T)->setName(Dest);
+        Syms.at(TM)->setName(Dest);
     }
 
     // Rename globals and add mappings
@@ -2290,7 +2277,7 @@ bool JuliaOJIT::linkOutput(orc::MaterializationResponsibility &MR, MemoryBufferR
     orc::SymbolMap GlobalSyms;
     for (auto &[Addr, Orig] : Info->global_targets) {
         auto Sym = ES.intern(Names(*Orig, "#"));
-        auto It = Syms.find(Orig);
+        auto It = Syms.find(mangle(*Orig));
         if (It == Syms.end())
             continue;
         It->second->setName(Sym);

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -794,6 +794,7 @@ public:
     void enablePerfJITEventListener() JL_NOTSAFEPOINT;
 
     orc::SymbolStringPtr mangle(StringRef Name) JL_NOTSAFEPOINT;
+    StringRef demangle(StringRef Name) JL_NOTSAFEPOINT;
     void addGlobalMapping(StringRef Name, uint64_t Addr) JL_NOTSAFEPOINT;
     void addOutput(jl_emitted_output_t O) JL_NOTSAFEPOINT;
 

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -794,7 +794,6 @@ public:
     void enablePerfJITEventListener() JL_NOTSAFEPOINT;
 
     orc::SymbolStringPtr mangle(StringRef Name) JL_NOTSAFEPOINT;
-    StringRef demangle(StringRef Name) JL_NOTSAFEPOINT;
     void addGlobalMapping(StringRef Name, uint64_t Addr) JL_NOTSAFEPOINT;
     void addOutput(jl_emitted_output_t O) JL_NOTSAFEPOINT;
 

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1771,4 +1771,27 @@ include("threads_comprehensions.jl")
     end
 end
 
+# Issue #61847: when threads race to compile related CodeInstances, the thread
+# that loses the addOutput race must skip installing its symbol definitions.
+@testset "Race addOutput in JIT compilation" begin
+    M = @__MODULE__
+    N = 20
+    for i in 1:N
+        @eval @noinline $(Symbol("race_leaf_", i))(x) = @big_expr(300, x)
+    end
+    for i in 1:N
+        j = mod1(i+1, N); k = mod1(i+2, N)
+        @eval @noinline $(Symbol("race_top_", i))(x) =
+            $(Symbol("race_leaf_", i))(x) + $(Symbol("race_leaf_", j))(x) - $(Symbol("race_leaf_", k))(x)
+    end
+    race_worker(offset) = for i in 1:N
+        f = getfield(M, Symbol("race_top_", mod1(i + offset, N)))
+        Base.invokelatest(f, 1)
+    end
+    t = Threads.@spawn race_worker(0)
+    race_worker(N ÷ 2)
+    wait(t)
+    @test true
+end
+
 end # main testset


### PR DESCRIPTION
If multiple threads want to compile a CodeInstance, one of them must win the race to install an entry in `JuliaOJIT::CISymbols`.  We regulate this by setting the CodeInstance's invoke pointer with CAS.  If we find `jl_fptr_wait_for_compiled_addr` is already in the defined CodeInstance's invoke field, we have lost the race and must avoid installing that definition in the JIT.  We used to do this by dropping the symbol from the `MaterializationUnit::Interface`, but this was incorrect, since the LinkGraph created from the compiled object would still have the defined symbol.

We fix this by removing CodeInstances where we have lost the race from `linker_info->ci_funcs`, as well as making the definition have internal linkage, so the optimizer can drop it.

Thanks to @gbaraldi for the reproducer script.

Fixes #61847.