### PR TITLE
AGENTS.md: explain how to read buildkite logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,11 @@ make sure to take them into account.
 - Do not `ccall` runtime C functions directly if there are existing wrappers for the function.
 - Do not explicitly add a module prefix if the code you're adding is in the same module. E.g. do not use `Base.` for code in Base unless required.
 
+## Reviewing Buildkite CI logs
+
+If you do not have the Buildkite MCP available, see `doc/src/devdocs/agents/buildkite-logs.md` for the
+recipe to fetch raw job logs without web sign-in.
+
 ## Commit messages and pull requests
 
 When writing commit messages, follow the format "component: Brief summary" for

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -301,6 +301,9 @@ DevDocs = [
         "devdocs/contributing/formatting.md",
         "devdocs/contributing/git-workflow.md",
         "devdocs/contributing/aiagents.md"
+    ],
+    "Agentic Devdocs" => [
+        "devdocs/agents/buildkite-logs.md"
     ]
 ]
 

--- a/doc/src/devdocs/agents/buildkite-logs.md
+++ b/doc/src/devdocs/agents/buildkite-logs.md
@@ -1,0 +1,33 @@
+# Reviewing Buildkite CI logs
+
+Julia's CI runs on Buildkite (pipeline `julialang/julia-master`). The public web
+UI requires sign-in to download `raw_log`, but the Buildkite frontend's JSON log
+endpoint is anonymously accessible for public pipelines. Recipe:
+
+1. List failing jobs and their UUIDs (the fragment after `#` in the URL):
+
+   ```sh
+   gh pr checks <PR-number> | grep -E "fail|pending"
+   ```
+
+2. Fetch the log JSON (replace `<BUILD>` and `<JOB-UUID>`):
+
+   ```sh
+   curl -sS -H "Accept: application/json" \
+     "https://buildkite.com/organizations/julialang/pipelines/julia-master/builds/<BUILD>/jobs/<JOB-UUID>/log" \
+     -o /tmp/bk.json
+   ```
+
+   The log text lives under the JSON `output` field, with embedded HTML
+   (`<time>` timestamps, ANSI-as-`<span>` colour) and entity-encoded shell
+   output. Strip with e.g.:
+
+   ```sh
+   python3 -c "import json,re,html; s=json.load(open('/tmp/bk.json'))['output']; \
+   s=re.sub(r'<[^>]+>','',s); print(html.unescape(s))" | tail -200
+   ```
+
+The same JSON endpoint also serves still-running jobs (partial output). Note
+that the top-level Build/Check/Test jobs on a PR are pipeline launchers — the
+actual per-platform builds are spawned as child jobs whose UUIDs only appear
+once they start.


### PR DESCRIPTION
In my experience without this it takes the agent a lot of attempts to figure it out.