### PR TITLE
clarify some ambiguity in `in` docstring

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1462,12 +1462,13 @@ contains `missing` but not `item`, in which case `missing` is returned
 ([three-valued logic](https://en.wikipedia.org/wiki/Three-valued_logic),
 matching the behavior of [`any`](@ref) and [`==`](@ref)).
 Some collections follow a slightly different definition. For example,
-[`Set`](@ref)s check whether the item [`isequal`](@ref) to one of the elements;
-[`Dict`](@ref)s look for `key=>value` pairs, where the `key` is compared using
-[`isequal`](@ref) and the `value` is compared using [`==`](@ref).
+[`Set`](@ref)s check whether the item [`isequal`](@ref) to one of the elements.
+For [`Dict`](@ref), [`ImmutableDict`](@ref), and [`WeakKeyDict`](@ref),
+`key=>value` membership compares keys using [`isequal`](@ref) and values using
+[`==`](@ref); [`IdDict`](@ref) instead compares keys using [`===`](@ref).
 
 To test for the presence of a key in a dictionary, use [`haskey`](@ref)
-or `k in keys(dict)`. For the collections mentioned above,
+or `k in keys(dict)`. For the dictionaries mentioned above,
 the result of `haskey(dict, k)` or `k in keys(dict)` is always a `Bool`.
 
 When broadcasting with `in.(items, collection)` or `items .∈ collection`, both

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1463,12 +1463,12 @@ contains `missing` but not `item`, in which case `missing` is returned
 matching the behavior of [`any`](@ref) and [`==`](@ref)).
 Some collections follow a slightly different definition. For example,
 [`Set`](@ref)s check whether the item [`isequal`](@ref) to one of the elements;
-[`Dict`](@ref)s look for `key=>value` pairs, and the `key` is compared using
-[`isequal`](@ref).
+[`Dict`](@ref)s look for `key=>value` pairs, where the `key` is compared using
+[`isequal`](@ref) and the `value` is compared using [`==`](@ref).
 
 To test for the presence of a key in a dictionary, use [`haskey`](@ref)
 or `k in keys(dict)`. For the collections mentioned above,
-the result is always a `Bool`.
+the result of `haskey(dict, k)` or `k in keys(dict)` is always a `Bool`.
 
 When broadcasting with `in.(items, collection)` or `items .∈ collection`, both
 `items` and `collection` are broadcasted over, which is often not what is intended.


### PR DESCRIPTION
otherwise it might be quite confusing that e.g. 
```julia
julia> (:a => NaN) in Dict(:a => NaN)
false

julia> (:a => missing) in Dict(:a => missing)
missing
```