### PR TITLE
fix some major issues with `map(f, ::BitArray...)`

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1758,13 +1758,20 @@ for (T, f) in ((:(Union{typeof(&), typeof(*), typeof(min)}), :(&)),
                (:(typeof(==)),                               :((p, q) -> ~xor(p, q))),
                (:(typeof(<)),                                :((p, q) -> ~p & q)),
                (:(typeof(>)),                                :((p, q) -> p & ~q)))
-    @eval map(::$T, A::BitArray, B::BitArray) = bit_map!($f, similar(A), A, B)
+    @eval map(::$T, A::BitArray, B::BitArray) = bit_map($f, A, B)
     @eval map!(::$T, dest::BitArray, A::BitArray, B::BitArray) = bit_map!($f, dest, A, B)
 end
 
 # If we were able to specialize the function to a known bitwise operation,
 # map across the chunks. Otherwise, fall-back to the AbstractArray method that
 # iterates bit-by-bit.
+function bit_map(f::F, A::BitArray, B::BitArray) where F
+    AB = zip(A, B)
+    isz = IteratorSize(AB)
+    dest = _similar_for(A, Bool, AB, isz, _similar_shape(AB, isz))
+    bit_map!(f, dest, A, B)
+end
+
 function bit_map!(f::F, dest::BitArray, A::BitArray) where F
     length(A) <= length(dest) || throw(DimensionMismatch("length of destination must be >= length of collection"))
     isempty(A) && return dest
@@ -1801,9 +1808,9 @@ function bit_map!(f::F, dest::BitArray, A::BitArray, B::BitArray) where F
     _msk = _msk_end(min_bitlen)
     # first zero out the bits mask is going to change
     # then update bits by `or`ing with a masked RHS
-    # DO NOT SEPARATE ONTO TO LINES.
+    # DO NOT SEPARATE ONTO TWO LINES.
     # Otherwise there will be bugs when Ac or Bc aliases destc
-    destc[len_Ac] = (dest_last & ~(_msk)) | f(Ac[end], Bc[end]) & _msk
+    destc[len_Ac] = (dest_last & ~(_msk)) | f(Ac[len_Ac], Bc[len_Ac]) & _msk
     dest
 end
 

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1767,8 +1767,7 @@ end
 # iterates bit-by-bit.
 function bit_map(f::F, A::BitArray, B::BitArray) where F
     AB = zip(A, B)
-    isz = IteratorSize(AB)
-    dest = similar(BitArray, _similar_shape(AB, isz))
+    dest = similar(BitArray, _similar_shape(AB, IteratorSize(AB)))
     bit_map!(f, dest, A, B)
 end
 

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1768,7 +1768,7 @@ end
 function bit_map(f::F, A::BitArray, B::BitArray) where F
     AB = zip(A, B)
     isz = IteratorSize(AB)
-    dest = _similar_for(A, Bool, AB, isz, _similar_shape(AB, isz))
+    dest = similar(BitArray, _similar_shape(AB, isz))
     bit_map!(f, dest, A, B)
 end
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -71,6 +71,8 @@ end
 and_iteratorsize(isz::T, ::T) where {T} = isz
 and_iteratorsize(::HasLength, ::HasShape) = HasLength()
 and_iteratorsize(::HasShape, ::HasLength) = HasLength()
+and_iteratorsize(::HasShape{N}, ::HasShape{N}) where {N} = HasShape{N}()
+and_iteratorsize(::HasShape, ::HasShape) = HasLength()
 and_iteratorsize(a, b) = SizeUnknown()
 
 and_iteratoreltype(iel::T, ::T) where {T} = iel

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1563,6 +1563,24 @@ timesofar("reductions")
             end
         end
     end
+
+    @testset "binary bitwise map shape and chunks" begin
+        @test axes(map(&, trues(2, 2), trues(4))) == axes(map(&, fill(true, 2, 2), fill(true, 4)))
+        @test_throws DimensionMismatch map(&, trues(2, 2), trues(2, 1))
+
+        A = falses(130)
+        A[[1, 3, 64, 65, 129]] .= true
+        B = falses(64)
+        B[[2, 3, 63]] .= true
+        for (X, Y) in ((A, B), (B, A))
+            expected = BitVector(map(&, Vector{Bool}(X), Vector{Bool}(Y)))
+            @test map(&, X, Y) == expected
+            dest = trues(70)
+            @test map!(&, dest, X, Y) === dest
+            @test dest == [expected; trues(6)]
+        end
+    end
+
     @testset "Issue #50780, map! bitarray map! where dest aliases source" begin
         a = BitVector([1,0])
         b = map(!, a)

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -1022,6 +1022,7 @@ end
     @test (@inferred Base.IteratorSize(zip(repeated(0), 1:5 ))) == Base.HasLength()     # for zip of ::IsInfinite and ::HasShape
     @test (@inferred Base.IteratorSize(zip((1,2,3), 1:5) )) == Base.HasLength()         # for zip of ::HasLength and ::HasShape
     @test (@inferred Base.IteratorSize(zip(1:5, (1,2,3)) )) == Base.HasLength()         # for zip of ::HasShape and ::HasLength
+    @test (@inferred Base.IteratorSize(zip(1:4, [1 2; 3 4]))) == Base.HasLength()       # for zip of mismatched ::HasShape
 end
 
 @testset "foldability inference" begin


### PR DESCRIPTION
previously:

```julia
# WRONG. output should be length 5, not 6. the last value here is junk from `similar`
julia> map(&, rand(6) .> 0.5, rand(5) .> 0.5)
6-element BitVector:
 0
 0
 0
 1
 0
 0

julia> dest = falses(64);

julia> map!(&, dest, trues(65), trues(64));

# what on earth?? should be 64
julia> count(dest)
1
```

the `and_iteratorsize` change is slightly drive-by but it makes the implementation nicer (and more parallel to `Array`, so if one changes they'll stay in sync). incidentally, it actually helps performance for some `collect(zip(..))` calls too
```julia
julia> using BenchmarkTools

julia> @btime collect(z) setup=z=zip(1:10000, rand(100, 100));
  15.875 μs (16 allocations: 437.53 KiB) # master
  3.344 μs (3 allocations: 160.06 KiB) # PR
```


codeveloped (mostly tests) with codex 5.5