### PR TITLE
precompilepkgs: add more timing info in timing & verbose mode

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2662,24 +2662,43 @@ function require(uuidkey::PkgId)
     return invoke_in_world(world, __require, uuidkey)
 end
 __require(uuidkey::PkgId) = @lock require_lock _require_prelocked(uuidkey)
+# Enabled by `include_package_for_output` so the precompile worker can attribute
+# wall-clock time spent loading dependencies from disk. Only outermost (depth==0)
+# calls accumulate to avoid double-counting transitive `require`s.
+const _precompile_track_dep_load = Ref{Bool}(false)
+const _precompile_dep_load_ns = Ref{UInt64}(0)
+const _precompile_dep_load_depth = Ref{Int}(0)
 function _require_prelocked(uuidkey::PkgId, env=nothing)
     assert_havelock(require_lock)
-    m = start_loading(uuidkey, UInt128(0), true)
-    if m === nothing
-        last = toplevel_load[]
-        try
-            toplevel_load[] = false
-            m = __require_prelocked(uuidkey, env)
-            m isa Module || check_package_module_loaded_error(uuidkey)
-        finally
-            toplevel_load[] = last
-            end_loading(uuidkey, m)
-        end
-        insert_extension_triggers(uuidkey)
-        # After successfully loading, notify downstream consumers
-        run_package_callbacks(uuidkey)
+    track = _precompile_track_dep_load[]
+    t0 = UInt64(0)
+    if track
+        _precompile_dep_load_depth[] == 0 && (t0 = time_ns())
+        _precompile_dep_load_depth[] += 1
     end
-    return m
+    try
+        m = start_loading(uuidkey, UInt128(0), true)
+        if m === nothing
+            last = toplevel_load[]
+            try
+                toplevel_load[] = false
+                m = __require_prelocked(uuidkey, env)
+                m isa Module || check_package_module_loaded_error(uuidkey)
+            finally
+                toplevel_load[] = last
+                end_loading(uuidkey, m)
+            end
+            insert_extension_triggers(uuidkey)
+            # After successfully loading, notify downstream consumers
+            run_package_callbacks(uuidkey)
+        end
+        return m
+    finally
+        if track
+            _precompile_dep_load_depth[] -= 1
+            _precompile_dep_load_depth[] == 0 && (_precompile_dep_load_ns[] += time_ns() - t0)
+        end
+    end
 end
 
 mutable struct PkgOrigin
@@ -3267,6 +3286,12 @@ function include_package_for_output(pkg::PkgId, input::String, syntax_version::V
     __toplevel__.var"#_internal_julia_parse" = VersionedParse(syntax_version)
     # This one is the compatibility marker for cache loading
     __toplevel__._internal_syntax_version = cache_syntax_version(syntax_version)
+    cumulative_compile_timing(true)
+    _precompile_dep_load_ns[] = 0
+    _precompile_dep_load_depth[] = 0
+    _precompile_track_dep_load[] = true
+    t_include_start = time_ns()
+    t_comp_before, _ = cumulative_compile_time_ns()
     try
         Base.include(Base.__toplevel__, input)
     catch ex
@@ -3274,6 +3299,17 @@ function include_package_for_output(pkg::PkgId, input::String, syntax_version::V
         @debug "Aborting `create_expr_cache'" exception=(ErrorException("Declaration of __precompile__(false) not allowed"), catch_backtrace())
         exit(125) # we define status = 125 means PrecompileableError
     finally
+        t_comp_after, _ = cumulative_compile_time_ns()
+        t_include_end = time_ns()
+        cumulative_compile_timing(false)
+        _precompile_track_dep_load[] = false
+        if Base.get_bool_env("JULIA_PRECOMP_REPORT_TIMING", false)
+            println(stderr, PRECOMPILE_VERBOSE_TIMING_MARKER,
+                    " include_ns=", t_include_end - t_include_start,
+                    " deps_ns=", _precompile_dep_load_ns[],
+                    " compilation_ns=", t_comp_after - t_comp_before,
+                    " methods=", length(newly_inferred))
+        end
         ccall(:jl_set_newly_inferred, Cvoid, (Any,), nothing)
     end
     # check that the package defined the expected module so we can give a nice error message if not
@@ -3302,6 +3338,9 @@ _pkg_str(_pkg::Pair{PkgId}) = _pkg_str(_pkg.first) * " => " * repr(_pkg.second)
 _pkg_str(_pkg::Nothing) = "nothing"
 
 const PRECOMPILE_TRACE_COMPILE = Ref{String}()
+# Marker prefix used by the precompile subprocess to report per-package timing
+# buckets back to the parent process; the parent surfaces them in verbose mode.
+const PRECOMPILE_VERBOSE_TIMING_MARKER = "__JL_PRECOMP_VERBOSE_TIMING__"
 function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, output_o::Union{Nothing, String},
                            concrete_deps::typeof(_concrete_dependencies), flags::Cmd=``, cacheflags::CacheFlags=CacheFlags(),
                            internal_stderr::IO = stderr, internal_stdout::IO = stdout, loadable_exts::Union{Vector{PkgId},Nothing}=nothing)
@@ -3359,7 +3398,8 @@ function create_expr_cache(pkg::PkgId, input::PkgLoadSpec, output::String, outpu
                                $(have_color === nothing ? "--color=auto" : have_color ? "--color=yes" : "--color=no")
                                -`,
                               "OPENBLAS_NUM_THREADS" => 1,
-                              "JULIA_NUM_THREADS" => 1),
+                              "JULIA_NUM_THREADS" => 1,
+                              "JULIA_PRECOMP_REPORT_TIMING" => 1),
                        stderr = internal_stderr, stdout = internal_stdout),
               "w", stdout)
     # write data over stdin to avoid the (unlikely) case of exceeding max command line size

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -28,7 +28,8 @@ mutable struct PrecompileJob
     lock_holder::String
     waiting_for_bg::Bool
     verbose_timing::String  # raw payload from the worker subprocess; surfaced in verbose mode
-    PrecompileJob() = new(JOB_PENDING, 0.0, "", IOBuffer(), Int32(0), false, "", false, "")
+    peak_rss_bytes::UInt64  # max RSS observed by `poll_process_stats!`; 0 on unsupported platforms
+    PrecompileJob() = new(JOB_PENDING, 0.0, "", IOBuffer(), Int32(0), false, "", false, "", UInt64(0))
 end
 
 is_pending(j::PrecompileJob)    = j.status == JOB_PENDING
@@ -202,7 +203,7 @@ timing_string(t) = string(lpad(round(t, digits = 1), 6), " s")
 # line in verbose mode. Column labels are emitted once via
 # `format_verbose_timing_header`. Returns an empty string if the payload is
 # missing or unparseable.
-function format_verbose_timing(payload::AbstractString, total_seconds::Float64, cache_bytes::Int, hascolor::Bool)
+function format_verbose_timing(payload::AbstractString, total_seconds::Float64, cache_bytes::Int, peak_rss_bytes::UInt64, hascolor::Bool)
     isempty(payload) && return ""
     include_ns = compilation_ns = deps_ns = UInt64(0)
     methods = 0
@@ -243,15 +244,18 @@ function format_verbose_timing(payload::AbstractString, total_seconds::Float64, 
     cache_mb = cache_bytes / 1024^2
     cache_str = cache_bytes <= 0 ? dim(lpad("-", 8), true) :
                                    string(lpad(round(cache_mb, digits = 1), 6), "MB")
+    peak_mb = peak_rss_bytes / 1024^2
+    peak_str = peak_rss_bytes == 0 ? dim(lpad("-", 7), true) :
+                                     string(lpad(round(Int, peak_mb), 5), "MB")
     methods_str = dim(lpad(methods, 7), methods == 0)
     bar = " │ "
     return string(bar, col(inc_s), "  ", col(deps_s), "  ", col(comp_s),
-                  bar, methods_str, "  ", col(img_s), "  ", cache_str)
+                  bar, methods_str, "  ", col(img_s), "  ", cache_str, "  ", peak_str)
 end
 
 # Header that labels the columns produced by `format_verbose_timing`. The leading
 # 8 spaces account for `timing_string`'s width so columns line up.
-format_verbose_timing_header() = "   total │ include   (deps)   (comp) │ methods  img-gen     cache"
+format_verbose_timing_header() = "   total │ include   (deps)   (comp) │ methods  img-gen     cache  ~pk-rss"
 
 # Sum the on-disk size of the `.ji` cache file and (optionally) its companion
 # pkgimage (`.so`/`.dylib`/`.dll`). Returns 0 if files are missing.
@@ -964,6 +968,10 @@ precompiles only the given packages and their dependencies (unless
     * `img-gen` — `total - include`: post-include work (native-code generation,
                   serialization, writing the `.ji` and pkgimage to disk).
     * `cache`   — combined on-disk size of the `.ji` cache and any pkgimage.
+    * `~pk-rss` — approximate peak resident set size of the worker subprocess.
+                  The leading `~` indicates the value is sampled (every ~0.5 s)
+                  rather than observed continuously, so transient peaks between
+                  samples may be missed. Linux/macOS only, `-` elsewhere.
   Values under 5 ms and zero counts are dimmed for readability.
 
 - `_from_loading::Bool`: Internal flag indicating the call originated from the
@@ -1675,11 +1683,35 @@ function poll_process_stats!(cpu_pcts::Dict{Int32, Float64}, rss::Dict{Int32, UI
         prev_cpu_times[pid] = stats.cpu_ns
         pct = dt > 0 ? (delta / 1.0e9) / dt * 100.0 : 0.0
         cpu_pcts[pid] = min(pct, 999.9)
-        stats.rss_bytes > 0 && (rss[pid] = stats.rss_bytes)
+        if stats.rss_bytes > 0
+            rss[pid] = stats.rss_bytes
+            stats.rss_bytes > job.peak_rss_bytes && (job.peak_rss_bytes = stats.rss_bytes)
+        end
     end
     pids_set = Set(job.pid for (_, job) in jobs if has_pid(job))
     for pid in keys(prev_cpu_times)
         pid in pids_set || delete!(prev_cpu_times, pid)
+    end
+    return
+end
+
+# Lightweight peak-RSS-only sampler used in non-fancy verbose timing mode,
+# where the live progress UI (which would otherwise drive `poll_process_stats!`)
+# is not running but the per-package verbose timing column still wants peak RSS.
+function sample_peak_rss!(jobs::Dict{PkgConfig, PrecompileJob})
+    @static if !(Sys.islinux() || Sys.isapple())
+        return
+    end
+    seen = Set{Int32}()
+    for (_, job) in jobs
+        has_pid(job) || continue
+        pid = job.pid
+        pid in seen && continue
+        push!(seen, pid)
+        stats = process_stats(pid)
+        if stats.rss_bytes > job.peak_rss_bytes
+            job.peak_rss_bytes = stats.rss_bytes
+        end
     end
     return
 end
@@ -2081,7 +2113,7 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                                 cache_bytes = _precompile_cache_bytes(cf_jl, cf_so)
                             end
                             !s.fancyprint && BG.monitoring && @lock s.print_lock begin
-                                verbose_prefix = BG.verbose ? format_verbose_timing(s.jobs[pkg_config].verbose_timing, t, cache_bytes, s.hascolor) : ""
+                                verbose_prefix = BG.verbose ? format_verbose_timing(s.jobs[pkg_config].verbose_timing, t, cache_bytes, s.jobs[pkg_config].peak_rss_bytes, s.hascolor) : ""
                                 println(s.logio, timing_string(t), verbose_prefix, color_string("  ✓ ", loaded ? Base.warn_color() : :green, s.hascolor), name)
                             end
                             if ret !== nothing
@@ -2565,6 +2597,16 @@ function do_precompile(pkgs::Union{Vector{String}, Vector{PkgId}},
 
     # Start print loop
     t_print = spawn_print_loop!(s)
+    # In non-fancy verbose timing mode, the print loop exits immediately and so
+    # `poll_process_stats!` never runs; spawn a lightweight peak-RSS sampler so
+    # the `~pk-rss` column in the verbose timing line can be populated.
+    peak_rss_timer = if !fancyprint && (@lock BG BG.verbose)
+        Timer(0.1; interval=0.5, spawn=true) do _
+            @lock s.print_lock sample_peak_rss!(s.jobs)
+        end
+    else
+        nothing
+    end
 
     try
         if !_from_loading
@@ -2599,6 +2641,7 @@ function do_precompile(pkgs::Union{Vector{String}, Vector{PkgId}},
         # Ensure print loop exits even on exception
         s.interrupted_or_done = true
         notify(s.first_started)
+        peak_rss_timer === nothing || close(peak_rss_timer)
     end
 end
 

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -202,7 +202,7 @@ timing_string(t) = string(lpad(round(t, digits = 1), 6), " s")
 # cache file size and cached method count) appended to the per-package timing
 # line in verbose mode. Column labels are emitted once via
 # `format_verbose_timing_header`. Returns an empty string if the payload is
-# missing or unparseable.
+# missing or unparsable.
 function format_verbose_timing(payload::AbstractString, total_seconds::Float64, cache_bytes::Int, peak_rss_bytes::UInt64, hascolor::Bool)
     isempty(payload) && return ""
     include_ns = compilation_ns = deps_ns = UInt64(0)

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -27,7 +27,8 @@ mutable struct PrecompileJob
     had_pid::Bool  # sticky: true once a subprocess was actually spawned for this job
     lock_holder::String
     waiting_for_bg::Bool
-    PrecompileJob() = new(JOB_PENDING, 0.0, "", IOBuffer(), Int32(0), false, "", false)
+    verbose_timing::String  # raw payload from the worker subprocess; surfaced in verbose mode
+    PrecompileJob() = new(JOB_PENDING, 0.0, "", IOBuffer(), Int32(0), false, "", false, "")
 end
 
 is_pending(j::PrecompileJob)    = j.status == JOB_PENDING
@@ -194,6 +195,76 @@ function printpkgstyle(io, header, msg; color=:green)
 end
 
 timing_string(t) = string(lpad(round(t, digits = 1), 6), " s")
+
+# Parse the marker payload emitted by `Base.include_package_for_output` and
+# format an inline breakdown (include / compilation / image-gen seconds,
+# cache file size and cached method count) appended to the per-package timing
+# line in verbose mode. Column labels are emitted once via
+# `format_verbose_timing_header`. Returns an empty string if the payload is
+# missing or unparseable.
+function format_verbose_timing(payload::AbstractString, total_seconds::Float64, cache_bytes::Int, hascolor::Bool)
+    isempty(payload) && return ""
+    include_ns = compilation_ns = deps_ns = UInt64(0)
+    methods = 0
+    seen = false
+    for tok in split(payload)
+        m = match(r"^(include|compilation|deps)_ns=(\d+)$", tok)
+        if m !== nothing
+            v = parse(UInt64, m.captures[2])
+            tag = m.captures[1]
+            if tag == "include"
+                include_ns = v; seen = true
+            elseif tag == "compilation"
+                compilation_ns = v
+            else
+                deps_ns = v
+            end
+            continue
+        end
+        m = match(r"^methods=(\d+)$", tok)
+        m === nothing || (methods = parse(Int, m.captures[1]))
+    end
+    seen || return ""
+    inc_s = include_ns / 1e9
+    comp_s = compilation_ns / 1e9
+    deps_s = deps_ns / 1e9
+    img_s = max(total_seconds - inc_s, 0.0)
+    dim(s, isz) = isz ? color_string(s, :light_black, hascolor) : s
+    function col(x)
+        s = string(round(x, digits = 2))
+        dot = findfirst('.', s)
+        if dot === nothing
+            s *= ".00"
+        elseif length(s) - dot == 1
+            s *= "0"
+        end
+        dim(string(lpad(s, 6), "s"), x < 0.005)
+    end
+    cache_mb = cache_bytes / 1024^2
+    cache_str = cache_bytes <= 0 ? dim(lpad("-", 8), true) :
+                                   string(lpad(round(cache_mb, digits = 1), 6), "MB")
+    methods_str = dim(lpad(methods, 7), methods == 0)
+    bar = " │ "
+    return string(bar, col(inc_s), "  ", col(deps_s), "  ", col(comp_s),
+                  bar, methods_str, "  ", col(img_s), "  ", cache_str)
+end
+
+# Header that labels the columns produced by `format_verbose_timing`. The leading
+# 8 spaces account for `timing_string`'s width so columns line up.
+format_verbose_timing_header() = "   total │ include   (deps)   (comp) │ methods  img-gen     cache"
+
+# Sum the on-disk size of the `.ji` cache file and (optionally) its companion
+# pkgimage (`.so`/`.dylib`/`.dll`). Returns 0 if files are missing.
+function _precompile_cache_bytes(cf_jl::AbstractString, cf_so::Union{Nothing,AbstractString})
+    total = 0
+    try
+        isfile(cf_jl) && (total += filesize(cf_jl))
+        cf_so === nothing || (isfile(cf_so) && (total += filesize(cf_so)))
+    catch
+    end
+    return total
+end
+
 
 
 function color_string(cstr::String, col::Union{Int64, Symbol}, hascolor)
@@ -880,6 +951,21 @@ precompiles only the given packages and their dependencies (unless
   each package compilation, but only if compilation might have succeeded.
   Disables fancy progress bar output (timing is shown in simple text mode).
 
+- `verbose::Bool`: When `true` (not default), enables verbose timing mode: implies
+  `timing=true` and appends a per-package breakdown to each completion line with
+  these columns:
+    * `total`   — total wall-clock time for the worker subprocess.
+    * `include` — time spent in `Base.include` of the package source.
+    * `(deps)`  — subset of `include`: time spent loading already-precompiled
+                  dependencies from disk (via `require`).
+    * `(comp)`  — subset of `include`: cumulative compile time (type inference
+                  and code generation) reported by `cumulative_compile_time_ns`.
+    * `methods` — number of newly-inferred methods cached for this package.
+    * `img-gen` — `total - include`: post-include work (native-code generation,
+                  serialization, writing the `.ji` and pkgimage to disk).
+    * `cache`   — combined on-disk size of the `.ji` cache and any pkgimage.
+  Values under 5 ms and zero counts are dimmed for readability.
+
 - `_from_loading::Bool`: Internal flag indicating the call originated from the
   package loading system. When `true` (not default): returns early instead of
   throwing when packages are not found; suppresses progress messages when not
@@ -948,15 +1034,21 @@ function precompilepkgs(pkgs::Union{Vector{String}, Vector{PkgId}}=String[];
                         strict::Bool = false,
                         warn_loaded::Bool = true,
                         timing::Bool = false,
+                        verbose::Bool = false,
                         _from_loading::Bool=false,
                         configs::Union{Config,Vector{Config}}=(``=>Base.CacheFlags()),
                         io::IO=stderr,
-                        # asking for timing disables fancy mode, as timing is shown in non-fancy mode
-                        fancyprint::Bool = can_fancyprint(io) && !timing,
+                        # asking for timing disables fancy mode, as timing is shown in non-fancy mode;
+                        # verbose implies timing (see below), so also disables fancy mode
+                        fancyprint::Bool = can_fancyprint(io) && !timing && !verbose,
                         manifest::Bool=false,
                         ignore_loaded::Bool=true,
                         detachable::Bool=false)
-    @debug "precompilepkgs called with" pkgs internal_call strict warn_loaded timing _from_loading configs fancyprint manifest ignore_loaded detachable
+    # verbose timing mode requires timing to be enabled (per-package breakdown
+    # is only shown alongside timing lines in non-fancy mode)
+    verbose && (timing = true)
+    @debug "precompilepkgs called with" pkgs internal_call strict warn_loaded timing verbose _from_loading configs fancyprint manifest ignore_loaded detachable
+    verbose && (@lock BG BG.verbose = true)
     # monomorphize this to avoid latency problems
     _precompilepkgs(pkgs, internal_call, strict, warn_loaded, timing, _from_loading,
                    configs isa Vector{Config} ? configs : [configs],
@@ -1643,6 +1735,7 @@ function spawn_print_loop!(s::PrecompileSession)
             @lock s.print_lock begin
                 if BG.monitoring
                     printpkgstyle(s.logio, :Precompiling, s.target)
+                    BG.verbose && println(s.logio, format_verbose_timing_header())
                 end
             end
             t = Timer(0; interval=1/10)
@@ -1789,6 +1882,10 @@ function precompilepkgs_monitor_std(s::PrecompileSession, pkg_config, pipe, sing
     thistaskwaiting = false
     while !eof(pipe)
         str = readline(pipe, keep=true)
+        if startswith(str, Base.PRECOMPILE_VERBOSE_TIMING_MARKER)
+            s.jobs[pkg_config].verbose_timing = strip(str)
+            continue
+        end
         if single_requested_pkg && (liveprinting || !isempty(str))
             BG.monitoring && @lock s.print_lock begin
                 if !liveprinting
@@ -1918,6 +2015,7 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                         @lock s.print_lock begin
                             if !s.fancyprint && isempty(s.pkg_queue) && BG.monitoring
                                 printpkgstyle(s.logio, :Precompiling, s.target)
+                                BG.verbose && println(s.logio, format_verbose_timing_header())
                             end
                             push!(s.pkg_queue, pkg_config)
                         end
@@ -1977,8 +2075,14 @@ function spawn_precompile_tasks!(s::PrecompileSession;
                                 println(s.logio, timing_string(t), color_string("  ? ", Base.warn_color(), s.hascolor), name)
                             end
                         else
+                            cache_bytes = 0
+                            if ret !== nothing
+                                cf_jl, cf_so = ret::Tuple{String, Union{Nothing, String}}
+                                cache_bytes = _precompile_cache_bytes(cf_jl, cf_so)
+                            end
                             !s.fancyprint && BG.monitoring && @lock s.print_lock begin
-                                println(s.logio, timing_string(t), color_string("  ✓ ", loaded ? Base.warn_color() : :green, s.hascolor), name)
+                                verbose_prefix = BG.verbose ? format_verbose_timing(s.jobs[pkg_config].verbose_timing, t, cache_bytes, s.hascolor) : ""
+                                println(s.logio, timing_string(t), verbose_prefix, color_string("  ✓ ", loaded ? Base.warn_color() : :green, s.hascolor), name)
                             end
                             if ret !== nothing
                                 mark_recompiled!(s.jobs[pkg_config])


### PR DESCRIPTION
<img width="650" height="264" alt="Screenshot 2026-05-24 at 3 30 20 PM" src="https://github.com/user-attachments/assets/59b1e5b9-a317-403d-8fa6-07885c5f8669" />


e.g.
```
julia> Base.Precompilation.precompilepkgs(verbose=true, timing=true)
Precompiling project...
   total │ include   (deps)   (comp) │ methods  img-gen     cache
   0.5 s │   0.06s    0.00s    0.02s │       0    0.41s     0.2MB  ✓ TensorCore
   0.5 s │   0.01s    0.00s    0.00s │       0    0.47s     0.1MB  ✓ Reexport
   0.5 s │   0.09s    0.00s    0.02s │      12    0.41s     0.2MB  ✓ Measures
   0.5 s │   0.11s    0.00s    0.06s │       0    0.43s     0.2MB  ✓ MappedArrays
   0.5 s │   0.15s    0.00s    0.09s │      29    0.40s     0.2MB  ✓ ConstructionBase
   0.3 s │   0.01s    0.00s    0.01s │       0    0.30s     0.1MB  ✓ DataValueInterfaces
   0.3 s │   0.07s    0.00s    0.02s │       3    0.27s     0.2MB  ✓ StatsAPI
   0.4 s │   0.06s    0.00s    0.03s │      15    0.34s     0.2MB  ✓ RoundingEmulator
   0.5 s │   0.12s    0.00s    0.03s │       5    0.37s     0.3MB  ✓ Observables
   0.4 s │   0.07s    0.00s    0.02s │       3    0.30s     0.1MB  ✓ PolygonOps
   1.2 s │   0.54s    0.00s    0.27s │     226    0.66s     0.8MB  ✓ IrrationalConstants
   0.7 s │   0.23s    0.00s    0.04s │       0    0.44s     0.4MB  ✓ IterTools
   0.7 s │   0.19s    0.00s    0.04s │       3    0.46s     0.4MB  ✓ IntervalSets
   0.6 s │   0.17s    0.00s    0.04s │       3    0.42s     0.1MB  ✓ CEnum
   1.4 s │   0.50s    0.00s    0.30s │     209    0.91s     0.8MB  ✓ Format
   0.8 s │   0.21s    0.00s    0.06s │       9    0.57s     0.2MB  ✓ Inflate
   0.5 s │   0.11s    0.00s    0.06s │       0    0.36s     0.1MB  ✓ LaTeXStrings
   0.9 s │   0.10s    0.00s    0.04s │       3    0.80s     0.2MB  ✓ Contour
   0.6 s │   0.16s    0.00s    0.02s │       0    0.42s     0.5MB  ✓ Statistics
   0.7 s │   0.28s    0.00s    0.13s │       6    0.45s     0.4MB  ✓ TranscodingStreams
   0.3 s │   0.08s    0.00s    0.04s │       0    0.25s     0.2MB  ✓ StaticArraysCore
   0.3 s │   0.07s    0.00s    0.04s │      23    0.25s     0.1MB  ✓ StableRNGs
   0.3 s │   0.02s    0.00s    0.01s │       0    0.27s     0.1MB  ✓ PtrArrays
   0.2 s │   0.02s    0.00s    0.01s │       3    0.21s     0.1MB  ✓ SimpleBufferStream
   0.3 s │   0.04s    0.00s    0.00s │       0    0.23s     0.2MB  ✓ DataAPI
   0.3 s │   0.06s    0.00s    0.01s │       5    0.22s     0.2MB  ✓ Adapt
   0.3 s │   0.07s    0.00s    0.05s │       0    0.23s     0.1MB  ✓ LazyModules
   0.4 s │   0.14s    0.00s    0.06s │      32    0.23s     0.4MB  ✓ URIs
   0.5 s │   0.15s    0.00s    0.04s │      54    0.39s     0.6MB  ✓ Grisu
   0.3 s │   0.05s    0.00s    0.02s │       3    0.22s     0.2MB  ✓ InverseFunctions
   0.2 s │   0.02s    0.00s    0.00s │       0    0.17s     0.1MB  ✓ MuladdMacro
   0.2 s │   0.03s    0.00s    0.01s │       0    0.17s     0.1MB  ✓ EnumX
   0.3 s │   0.09s    0.00s    0.02s │       3    0.21s     0.5MB  ✓ AbstractFFTs
   1.0 s │   0.73s    0.00s    0.05s │       7    0.26s     1.2MB  ✓ AdaptivePredicates
   0.3 s │   0.13s    0.00s    0.01s │       3    0.20s     0.6MB  ✓ AbstractTrees
   0.7 s │   0.44s    0.35s    0.03s │       0    0.23s     0.2MB  ✓ Missings
   0.2 s │   0.03s    0.00s    0.01s │       0    0.21s     0.1MB  ✓ IntegerMathUtils
   0.3 s │   0.06s    0.00s    0.01s │       3    0.20s     0.2MB  ✓ TriplotBase
   3.4 s │   0.99s    0.00s    0.83s │     922    2.39s     1.2MB  ✓ MacroTools
   0.2 s │   0.02s    0.00s    0.01s │       3    0.17s     0.1MB  ✓ RangeArrays
   0.3 s │   0.10s    0.00s    0.01s │       0    0.21s     0.4MB  ✓ Extents
   0.4 s │   0.15s    0.00s    0.04s │       4    0.21s     0.5MB  ✓ OrderedCollections
   0.3 s │   0.10s    0.00s    0.03s │      19    0.19s     0.4MB  ✓ DocStringExtensions
   0.7 s │   0.42s    0.00s    0.03s │       9    0.28s     1.3MB  ✓ FillArrays
   0.3 s │   0.09s    0.00s    0.04s │      64    0.22s     0.3MB  ✓ Unzip
   0.2 s │   0.06s    0.00s    0.01s │       8    0.17s     0.3MB  ✓ DelimitedFiles
   0.5 s │   0.33s    0.00s    0.02s │      14    0.19s     1.1MB  ✓ Compiler
   1.2 s │   0.96s    0.50s    0.40s │    1399    0.20s     0.2MB  ✓ AbstractFFTs → AbstractFFTsTestExt
   0.7 s │   0.24s    0.00s    0.06s │     204    0.43s     1.0MB  ✓ OffsetArrays
   0.5 s │   0.28s    0.21s    0.03s │       0    0.18s     0.2MB  ✓ NaNMath
   1.2 s │   0.85s    0.00s    0.13s │     203    0.34s     2.9MB  ✓ ModernGL
   0.4 s │   0.09s    0.00s    0.06s │      21    0.28s     0.2MB  ✓ Requires
   0.4 s │   0.20s    0.00s    0.10s │      11    0.18s     0.4MB  ✓ ConcurrentUtilities
   1.1 s │   0.87s    0.74s    0.08s │     189    0.20s     0.3MB  ✓ LogExpFunctions
   0.3 s │   0.06s    0.02s    0.01s │       2    0.25s     0.2MB  ✓ Scratch
   0.6 s │   0.27s    0.01s    0.13s │      35    0.32s     0.5MB  ✓ ProgressMeter
   0.5 s │   0.29s    0.23s    0.01s │       3    0.22s     0.2MB  ✓ WoodburyMatrices
   0.4 s │   0.12s    0.02s    0.02s │       3    0.28s     0.3MB  ✓ LoggingExtras
   1.7 s │   0.83s    0.00s    0.72s │    1033    0.90s     1.6MB  ✓ BaseDirs
   0.3 s │   0.13s    0.00s    0.04s │      10    0.19s     0.2MB  ✓ Compat
   0.5 s │   0.25s    0.02s    0.06s │       5    0.25s     0.7MB  ✓ StructUtils
   0.3 s │   0.13s    0.08s    0.02s │       4    0.20s     0.2MB  ✓ ExceptionUnwrapping
   0.9 s │   0.65s    0.45s    0.03s │       3    0.22s     0.6MB  ✓ PDMats
   0.4 s │   0.17s    0.17s    0.00s │       0    0.19s     0.1MB  ✓ ConstructionBase → ConstructionBaseLinearAlgebraExt
   0.9 s │   0.10s    0.02s    0.04s │      30    0.84s     0.3MB  ✓ Preferences
   0.7 s │   0.23s    0.15s    0.03s │      53    0.44s     0.3MB  ✓ CodeTracking
   0.7 s │   0.30s    0.14s    0.12s │     213    0.44s     0.5MB  ✓ UnicodeFun
   0.4 s │   0.24s    0.24s    0.00s │       0    0.17s     0.1MB  ✓ ConstructionBase → ConstructionBaseIntervalSetsExt
   0.4 s │   0.25s    0.25s    0.00s │       0    0.17s     0.1MB  ✓ IntervalSets → IntervalSetsRandomExt
   0.2 s │   0.05s    0.05s    0.00s │       0    0.15s     0.1MB  ✓ IntervalSets → IntervalSetsStatisticsExt
   0.5 s │   0.34s    0.32s    0.00s │       0    0.18s     0.1MB  ✓ Statistics → SparseArraysExt
   1.2 s │   0.34s    0.31s    0.02s │       9    0.87s     0.1MB  ✓ PkgVersion
   0.3 s │   0.10s    0.04s    0.01s │       4    0.17s     0.2MB  ✓ CodecZlib
   0.2 s │   0.03s    0.00s    0.01s │       0    0.16s     0.1MB  ✓ BitFlags
   0.9 s │   0.41s    0.33s    0.08s │     354    0.48s     0.6MB  ✓ SignedDistanceFields
   0.7 s │   0.49s    0.27s    0.11s │     111    0.22s     0.5MB  ✓ CodecZstd
   0.5 s │   0.29s    0.23s    0.02s │       2    0.18s     0.2MB  ✓ AliasTables
   0.3 s │   0.04s    0.02s    0.00s │       3    0.24s     0.1MB  ✓ Showoff
   0.2 s │   0.02s    0.00s    0.01s │       0    0.17s     0.1MB  ✓ IndirectArrays
   0.6 s │   0.42s    0.42s    0.00s │       0    0.20s     0.1MB  ✓ Adapt → AdaptSparseArraysExt
   0.5 s │   0.28s    0.28s    0.00s │       0    0.24s     0.1MB  ✓ InverseFunctions → InverseFunctionsDatesExt
   0.4 s │   0.21s    0.17s    0.04s │      24    0.21s     0.1MB  ✓ InverseFunctions → InverseFunctionsTestExt
   1.5 s │   0.88s    0.29s    0.40s │    2375    0.62s     2.2MB  ✓ FixedPointNumbers
   0.2 s │   0.00s    0.00s    0.00s │       0    0.16s     0.1MB  ✓ IteratorInterfaceExtensions
   0.6 s │   0.43s    0.33s    0.03s │      54    0.18s     0.4MB  ✓ Primes
   0.4 s │   0.16s    0.00s    0.11s │     205    0.19s     0.3MB  ✓ PkgCacheInspector
   0.7 s │   0.56s    0.44s    0.07s │      63    0.16s     0.2MB  ✓ SimpleTraits
   0.6 s │   0.41s    0.40s    0.00s │       0    0.19s     0.1MB  ✓ FillArrays → FillArraysStatisticsExt
   0.7 s │   0.47s    0.45s    0.01s │       0    0.18s     0.1MB  ✓ FillArrays → FillArraysSparseArraysExt
   0.2 s │   0.03s    0.00s    0.01s │       0    0.16s     0.1MB  ✓ Ratios
   0.6 s │   0.45s    0.44s    0.01s │       0    0.16s     0.1MB  ✓ OffsetArrays → OffsetArraysAdaptExt
   0.5 s │   0.34s    0.31s    0.01s │       0    0.16s     0.1MB  ✓ StackViews
   0.7 s │   0.55s    0.51s    0.01s │       0    0.17s     0.2MB  ✓ PaddedViews
   0.4 s │   0.19s    0.18s    0.00s │       0    0.16s     0.1MB  ✓ LogExpFunctions → LogExpFunctionsInverseFunctionsExt
   1.4 s │   1.16s    0.36s    0.06s │       8    0.20s     2.9MB  ✓ DataStructures
   0.6 s │   0.39s    0.35s    0.03s │      18    0.20s     0.1MB  ✓ RelocatableFolders
   0.7 s │   0.54s    0.52s    0.01s │       7    0.16s     0.1MB  ✓ Compat → CompatLinearAlgebraExt
   1.2 s │   1.02s    0.98s    0.01s │       3    0.18s     0.2MB  ✓ AxisAlgorithms
   1.3 s │   1.11s    1.11s    0.00s │       0    0.18s     0.1MB  ✓ FillArrays → FillArraysPDMatsExt
   1.4 s │   1.13s    1.10s    0.01s │       5    0.27s     0.1MB  ✓ PrecompileTools
   1.3 s │   1.05s    0.96s    0.06s │       5    0.27s     0.2MB  ✓ JLLWrappers
   1.8 s │   1.57s    1.57s    0.00s │       0    0.22s     0.1MB  ✓ StructUtils → StructUtilsStaticArraysCoreExt
   1.3 s │   1.06s    0.88s    0.05s │       5    0.28s     0.7MB  ✓ ComputePipeline
   2.8 s │   1.65s    0.98s    0.53s │    1374    1.14s     2.3MB  ✓ FileIO
   0.8 s │   0.66s    0.66s    0.00s │       0    0.18s     0.1MB  ✓ TableTraits
   1.5 s │   0.98s    0.47s    0.31s │     522    0.50s     1.0MB  ✓ OpenSSL
   1.6 s │   1.35s    0.88s    0.13s │     326    0.28s     1.4MB  ✓ ColorTypes
   0.7 s │   0.46s    0.45s    0.00s │       0    0.20s     0.1MB  ✓ Ratios → RatiosFixedPointNumbersExt
   8.6 s │   5.81s    0.02s    4.27s │   14644    2.82s    17.5MB  ✓ Unitful
   3.0 s │   2.67s    2.46s    0.02s │       3    0.35s     0.8MB  ✓ AxisArrays
   1.3 s │   1.11s    1.05s    0.03s │      42    0.19s     0.2MB  ✓ SortingAlgorithms
   1.3 s │   1.07s    0.74s    0.15s │     215    0.21s     0.6MB  ✓ QuadGK
   2.9 s │   2.72s    2.37s    0.27s │     429    0.19s     0.3MB  ✓ FFTA
   0.6 s │   0.32s    0.02s    0.11s │      49    0.28s     0.8MB  ✓ FilePathsBase
   2.3 s │   2.14s    2.08s    0.02s │       0    0.16s     0.2MB  ✓ MosaicViews
   4.3 s │   1.89s    0.64s    0.94s │    1144    2.44s     3.5MB  ✓ JuliaInterpreter
   1.1 s │   0.84s    0.41s    0.15s │     350    0.30s     1.3MB  ✓ ChainRulesCore
   0.4 s │   0.16s    0.09s    0.07s │       3    0.25s     0.1MB  ✓ Xorg_libICE_jll
   0.4 s │   0.11s    0.03s    0.07s │       3    0.26s     0.1MB  ✓ eudev_jll
   0.7 s │   0.35s    0.24s    0.10s │      14    0.35s     0.1MB  ✓ Libffi_jll
   1.2 s │   0.61s    0.32s    0.26s │     408    0.63s     0.7MB  ✓ RecipesBase
   0.4 s │   0.12s    0.03s    0.08s │       3    0.26s     0.1MB  ✓ mtdev_jll
   0.5 s │   0.13s    0.03s    0.09s │      14    0.35s     0.1MB  ✓ EarCut_jll
   0.5 s │   0.13s    0.03s    0.09s │      14    0.35s     0.1MB  ✓ Bzip2_jll
   0.5 s │   0.13s    0.04s    0.09s │      14    0.33s     0.1MB  ✓ isoband_jll
   0.5 s │   0.12s    0.03s    0.08s │      14    0.34s     0.1MB  ✓ OpenBLASConsistentFPCSR_jll
   0.5 s │   0.13s    0.03s    0.08s │      14    0.37s     0.2MB  ✓ XZ_jll
   0.5 s │   0.12s    0.03s    0.09s │      14    0.35s     0.1MB  ✓ Rmath_jll
   0.3 s │   0.10s    0.03s    0.07s │       3    0.25s     0.1MB  ✓ Xorg_xtrans_jll
   0.5 s │   0.12s    0.03s    0.09s │      14    0.34s     0.2MB  ✓ OpenSpecFun_jll
   0.5 s │   0.12s    0.03s    0.08s │      14    0.34s     0.1MB  ✓ Opus_jll
   0.5 s │   0.13s    0.03s    0.09s │      14    0.39s     0.2MB  ✓ x265_jll
   0.5 s │   0.13s    0.03s    0.09s │      14    0.34s     0.1MB  ✓ fzf_jll
   0.5 s │   0.14s    0.03s    0.10s │      14    0.34s     0.1MB  ✓ libpng_jll
   0.5 s │   0.12s    0.03s    0.09s │      14    0.37s     0.1MB  ✓ CRlibm_jll
   0.4 s │   0.10s    0.03s    0.07s │       3    0.27s     0.1MB  ✓ EpollShim_jll
   0.5 s │   0.13s    0.03s    0.08s │      14    0.40s     0.1MB  ✓ Imath_jll
   0.4 s │   0.12s    0.04s    0.08s │       3    0.28s     0.1MB  ✓ Libmount_jll
   0.6 s │   0.13s    0.03s    0.09s │      14    0.42s     0.1MB  ✓ libfdk_aac_jll
   0.4 s │   0.11s    0.03s    0.07s │       3    0.29s     0.1MB  ✓ Libuuid_jll
   4.0 s │   2.51s    0.03s    2.00s │    6277    1.49s     7.9MB  ✓ SIMD
   0.5 s │   0.14s    0.03s    0.09s │      14    0.37s     0.1MB  ✓ LERC_jll
   0.6 s │   0.16s    0.04s    0.11s │      14    0.40s     0.2MB  ✓ FriBidi_jll
   0.3 s │   0.09s    0.03s    0.06s │       3    0.25s     0.1MB  ✓ Xorg_libXau_jll
   0.3 s │   0.09s    0.03s    0.06s │       3    0.25s     0.1MB  ✓ libevdev_jll
   0.5 s │   0.13s    0.03s    0.09s │      14    0.35s     0.1MB  ✓ Ogg_jll
   0.5 s │   0.13s    0.03s    0.09s │      14    0.35s     0.1MB  ✓ CoreMath_jll
   0.5 s │   0.14s    0.03s    0.09s │      14    0.37s     0.2MB  ✓ LAME_jll
   0.5 s │   0.14s    0.04s    0.10s │      14    0.38s     0.1MB  ✓ Graphite2_jll
   0.4 s │   0.10s    0.03s    0.06s │       3    0.28s     0.1MB  ✓ Xorg_libpciaccess_jll
   0.6 s │   0.15s    0.04s    0.10s │      14    0.42s     0.2MB  ✓ x264_jll
   0.5 s │   0.13s    0.03s    0.09s │      14    0.40s     0.2MB  ✓ LLVMOpenMP_jll
   0.6 s │   0.15s    0.03s    0.11s │      14    0.49s     0.2MB  ✓ Libiconv_jll
   0.6 s │   0.15s    0.03s    0.11s │      14    0.42s     0.2MB  ✓ MbedTLS_jll
   0.4 s │   0.10s    0.03s    0.06s │       3    0.30s     0.1MB  ✓ Xorg_libXdmcp_jll
   0.6 s │   0.15s    0.04s    0.10s │      14    0.48s     0.2MB  ✓ libaom_jll
   0.6 s │   0.16s    0.04s    0.12s │      14    0.46s     0.1MB  ✓ Giflib_jll
   0.6 s │   0.18s    0.04s    0.12s │      14    0.40s     0.2MB  ✓ Expat_jll
   0.6 s │   0.16s    0.03s    0.11s │      14    0.48s     0.2MB  ✓ JpegTurbo_jll
   0.7 s │   0.51s    0.51s    0.00s │       0    0.22s     0.1MB  ✓ ColorTypes → StyledStringsExt
   1.3 s │   1.05s    0.64s    0.08s │       7    0.27s     0.8MB  ✓ Tables
   0.9 s │   0.58s    0.58s    0.00s │       0    0.30s     0.1MB  ✓ Unitful → ConstructionBaseUnitfulExt
   0.8 s │   0.48s    0.45s    0.03s │      13    0.28s     0.1MB  ✓ Unitful → PrintfExt
   6.3 s │   2.75s    0.03s    2.45s │    1962    3.59s     5.2MB  ✓ Parsers
   6.8 s │   3.17s    0.49s    1.63s │    5249    3.62s     8.9MB  ✓ StaticArrays
   0.5 s │   0.09s    0.08s    0.00s │       0    0.41s     0.1MB  ✓ Unitful → InverseFunctionsUnitfulExt
   1.5 s │   0.99s    0.37s    0.47s │    3848    0.47s     3.9MB  ✓ ColorVectorSpace
   0.8 s │   0.56s    0.56s    0.00s │       0    0.24s     0.1MB  ✓ Unitful → NaNMathExt
   0.8 s │   0.55s    0.55s    0.00s │       0    0.20s     0.1MB  ✓ FilePathsBase → FilePathsBaseMmapExt
   0.7 s │   0.52s    0.48s    0.04s │      89    0.20s     0.1MB  ✓ FilePaths
   1.3 s │   1.09s    0.78s    0.06s │      18    0.23s     1.0MB  ✓ FilePathsBase → FilePathsBaseTestExt
   2.6 s │   1.78s    0.12s    1.26s │    4239    0.79s     4.7MB  ✓ Colors
   0.6 s │   0.49s    0.47s    0.00s │       0    0.15s     0.1MB  ✓ AbstractFFTs → AbstractFFTsChainRulesCoreExt
   0.3 s │   0.08s    0.02s    0.05s │       3    0.21s     0.1MB  ✓ Xorg_libSM_jll
   1.1 s │   0.90s    0.90s    0.00s │       0    0.16s     0.1MB  ✓ ChainRulesCore → ChainRulesCoreSparseArraysExt
   1.0 s │   0.79s    0.45s    0.29s │     989    0.16s     0.2MB  ✓ LogExpFunctions → LogExpFunctionsChainRulesCoreExt
   0.9 s │   0.73s    0.71s    0.03s │       3    0.19s     0.1MB  ✓ IntervalSets → IntervalSetsRecipesBaseExt
   1.1 s │   0.86s    0.85s    0.01s │       0    0.19s     0.1MB  ✓ Isoband
   1.4 s │   1.15s    1.07s    0.07s │      14    0.30s     0.1MB  ✓ FreeType2_jll
   1.5 s │   1.32s    1.16s    0.08s │       6    0.20s     0.6MB  ✓ Rmath
   1.4 s │   1.23s    1.21s    0.01s │       0    0.22s     0.1MB  ✓ JLFzf
   1.3 s │   1.02s    0.93s    0.03s │       7    0.28s     0.4MB  ✓ CRlibm
   0.3 s │   0.08s    0.03s    0.06s │       3    0.21s     0.1MB  ✓ libinput_jll
   4.3 s │   3.99s    3.24s    0.15s │     199    0.33s     2.7MB  ✓ StatsBase
   2.4 s │   2.07s    1.28s    0.47s │    1602    0.34s     1.7MB  ✓ SpecialFunctions
   1.4 s │   1.03s    0.95s    0.07s │      14    0.38s     0.2MB  ✓ OpenEXR_jll
   0.3 s │   0.09s    0.03s    0.06s │       3    0.22s     0.1MB  ✓ libdrm_jll
   0.8 s │   0.52s    0.48s    0.01s │       0    0.24s     0.2MB  ✓ CoreMath
   0.3 s │   0.09s    0.03s    0.06s │       3    0.22s     0.1MB  ✓ Xorg_libxcb_jll
   1.1 s │   0.74s    0.65s    0.08s │      14    0.35s     0.2MB  ✓ libvorbis_jll
   1.0 s │   0.62s    0.54s    0.08s │      14    0.36s     0.1MB  ✓ Pixman_jll
   0.4 s │   0.11s    0.04s    0.08s │       3    0.29s     0.1MB  ✓ Dbus_jll
   0.4 s │   0.11s    0.03s    0.07s │       3    0.29s     0.1MB  ✓ Wayland_jll
   1.2 s │   0.70s    0.60s    0.08s │      14    0.45s     0.2MB  ✓ GettextRuntime_jll
   0.7 s │   0.33s    0.21s    0.11s │      14    0.39s     0.1MB  ✓ libsixel_jll
   1.6 s │   1.16s    0.77s    0.15s │      22    0.46s     0.9MB  ✓ MbedTLS
   6.0 s │   3.05s    1.53s    1.39s │    1548    2.94s     3.0MB  ✓ LoweredCodeUtils
   1.1 s │   0.38s    0.23s    0.10s │      14    0.73s     0.3MB  ✓ Ghostscript_jll
   1.2 s │   0.81s    0.69s    0.11s │      14    0.34s     0.2MB  ✓ Libtiff_jll
   0.9 s │   0.53s    0.34s    0.04s │      30    0.35s     0.8MB  ✓ StructArrays
   0.8 s │   0.51s    0.51s    0.00s │       0    0.25s     0.1MB  ✓ StructUtils → StructUtilsTablesExt
   2.0 s │   1.75s    1.68s    0.04s │       5    0.29s     0.2MB  ✓ QOI
   0.9 s │   0.63s    0.62s    0.01s │       0    0.22s     0.1MB  ✓ ConstructionBase → ConstructionBaseStaticArraysExt
   1.3 s │   1.11s    1.10s    0.01s │       0    0.22s     0.1MB  ✓ StaticArrays → StaticArraysStatisticsExt
   0.9 s │   0.64s    0.63s    0.01s │       0    0.23s     0.1MB  ✓ StaticArrays → StaticArraysChainRulesCoreExt
   0.4 s │   0.13s    0.13s    0.01s │       0    0.24s     0.1MB  ✓ Adapt → AdaptStaticArraysExt
   0.4 s │   0.16s    0.15s    0.01s │       0    0.23s     0.1MB  ✓ FillArrays → FillArraysStaticArraysExt
   1.0 s │   0.76s    0.70s    0.01s │       3    0.19s     0.3MB  ✓ Animations
   2.8 s │   1.56s    0.75s    0.62s │     961    1.21s     2.2MB  ✓ JSON
   1.3 s │   1.12s    1.12s    0.00s │       0    0.22s     0.1MB  ✓ FilePaths → FilePathsURIsExt
   2.0 s │   1.78s    1.45s    0.14s │      71    0.25s     0.6MB  ✓ FreeType
   8.1 s │   3.45s    1.04s    2.13s │    4484    4.66s     6.8MB  ✓ Automa
   2.2 s │   1.66s    1.50s    0.09s │      14    0.51s     0.3MB  ✓ Fontconfig_jll
   3.1 s │   2.58s    0.49s    0.10s │     143    0.54s     6.9MB  ✓ ColorSchemes
   1.0 s │   0.76s    0.75s    0.00s │       0    0.24s     0.1MB  ✓ PDMats → StatsBaseExt
   0.9 s │   0.66s    0.31s    0.11s │     146    0.25s     0.8MB  ✓ HypergeometricFunctions
   0.4 s │   0.12s    0.11s    0.01s │       0    0.29s     0.1MB  ✓ ColorVectorSpace → SpecialFunctionsExt
   1.1 s │   0.91s    0.36s    0.42s │     996    0.23s     0.4MB  ✓ SpecialFunctions → SpecialFunctionsChainRulesCoreExt
   0.3 s │   0.10s    0.03s    0.07s │       3    0.24s     0.1MB  ✓ Xorg_xcb_util_jll
   0.3 s │   0.10s    0.03s    0.06s │       3    0.23s     0.1MB  ✓ Xorg_libX11_jll
   1.1 s │   0.75s    0.64s    0.06s │       6    0.31s     0.3MB  ✓ OpenEXR
   1.7 s │   1.15s    1.04s    0.10s │      14    0.50s     0.2MB  ✓ Glib_jll
   2.8 s │   2.34s    1.32s    0.34s │     395    0.48s     2.5MB  ✓ IntervalArithmetic
   0.8 s │   0.56s    0.55s    0.00s │       0    0.26s     0.1MB  ✓ StructArrays → StructArraysSparseArraysExt
   0.3 s │   0.05s    0.04s    0.01s │       2    0.27s     0.1MB  ✓ StructArrays → StructArraysLinearAlgebraExt
   0.3 s │   0.03s    0.03s    0.00s │       0    0.25s     0.1MB  ✓ StructArrays → StructArraysAdaptExt
   0.7 s │   0.26s    0.21s    0.03s │       1    0.44s     0.1MB  ✓ StructArrays → StructArraysStaticArraysExt
   3.7 s │   2.76s    1.39s    1.03s │     882    0.94s     2.2MB  ✓ Latexify
  10.5 s │   5.10s    1.66s    3.02s │   12569    5.36s    14.6MB  ✓ GeometryBasics
   0.7 s │   0.36s    0.16s    0.21s │      94    0.31s     0.2MB  ✓ ColorBrewer
   3.4 s │   2.94s    2.11s    0.18s │     135    0.42s     1.7MB  ✓ Interpolations
  12.7 s │   7.11s    1.88s    5.00s │   15599    5.55s    19.4MB  ✓ ImageCore
   0.5 s │   0.13s    0.04s    0.08s │       3    0.35s     0.1MB  ✓ Xorg_xcb_util_renderutil_jll
   0.6 s │   0.16s    0.05s    0.11s │       3    0.46s     0.1MB  ✓ Xorg_xcb_util_wm_jll
   1.9 s │   1.13s    0.60s    0.32s │     389    0.74s     1.0MB  ✓ StatsFuns
   0.5 s │   0.11s    0.03s    0.07s │       3    0.44s     0.1MB  ✓ Xorg_xcb_util_image_jll
   4.7 s │   2.59s    0.83s    1.50s │    3519    2.11s     4.4MB  ✓ BenchmarkTools
   0.4 s │   0.11s    0.04s    0.07s │       3    0.34s     0.1MB  ✓ Xorg_xcb_util_keysyms_jll
   0.5 s │   0.14s    0.04s    0.10s │       3    0.33s     0.1MB  ✓ Xorg_libXfixes_jll
   9.9 s │   3.43s    0.87s    2.01s │    4672    6.51s     7.2MB  ✓ Revise
   0.4 s │   0.12s    0.04s    0.08s │       3    0.32s     0.1MB  ✓ Xorg_libXrender_jll
   0.4 s │   0.10s    0.03s    0.06s │       3    0.32s     0.1MB  ✓ Xorg_libXext_jll
   0.4 s │   0.13s    0.04s    0.09s │       3    0.31s     0.1MB  ✓ Xorg_libxkbfile_jll
   0.6 s │   0.29s    0.24s    0.04s │       3    0.30s     0.1MB  ✓ IntervalArithmetic → IntervalArithmeticRecipesBaseExt
   0.8 s │   0.38s    0.32s    0.04s │      23    0.39s     0.2MB  ✓ IntervalArithmetic → IntervalArithmeticIrrationalConstantsExt
   0.7 s │   0.39s    0.25s    0.05s │       4    0.29s     0.3MB  ✓ IntervalArithmetic → IntervalArithmeticLinearAlgebraExt
   1.1 s │   0.81s    0.80s    0.01s │       0    0.30s     0.1MB  ✓ IntervalArithmetic → IntervalArithmeticSparseArraysExt
   0.3 s │   0.06s    0.06s    0.01s │       0    0.27s     0.1MB  ✓ IntervalArithmetic → IntervalArithmeticIntervalSetsExt
   1.0 s │   0.54s    0.24s    0.25s │     123    0.45s     0.2MB  ✓ Unitful → LatexifyExt
   1.3 s │   0.81s    0.77s    0.04s │       2    0.46s     0.1MB  ✓ Latexify → SparseArraysExt
   8.2 s │   3.47s    0.58s    2.78s │    7410    4.71s     8.7MB  ✓ PlotUtils
  14.4 s │   8.16s    3.09s    3.81s │    5856    6.25s     9.7MB  ✓ HTTP
   3.1 s │   2.81s    2.72s    0.06s │       5    0.30s     0.2MB  ✓ Packing
   3.1 s │   2.62s    2.36s    0.13s │     335    0.49s     0.7MB  ✓ ShaderAbstractions
   1.5 s │   1.08s    1.08s    0.01s │       0    0.45s     0.1MB  ✓ Interpolations → InterpolationsUnitfulExt
  22.8 s │  11.16s    3.69s    7.10s │   21444   11.62s    24.7MB  ✓ TiffImages
   3.9 s │   3.16s    2.82s    0.21s │     136    0.71s     0.5MB  ✓ MeshIO
   2.0 s │   1.16s    0.83s    0.25s │     579    0.79s     1.1MB  ✓ ImageBase
   0.3 s │   0.08s    0.08s    0.01s │       0    0.24s     0.1MB  ✓ StatsFuns → StatsFunsInverseFunctionsExt
   5.8 s │   4.16s    2.73s    1.08s │    2614    1.60s     4.0MB  ✓ GridLayoutBase
   1.0 s │   0.78s    0.31s    0.46s │     991    0.24s     0.1MB  ✓ StatsFuns → StatsFunsChainRulesCoreExt
   1.3 s │   0.89s    0.48s    0.22s │     165    0.37s     0.7MB  ✓ JpegTurbo
   0.3 s │   0.09s    0.03s    0.06s │       3    0.22s     0.1MB  ✓ Xorg_xcb_util_cursor_jll
   0.3 s │   0.09s    0.02s    0.06s │       3    0.23s     0.1MB  ✓ Xorg_libXcursor_jll
   3.4 s │   2.61s    2.44s    0.12s │     534    0.80s     0.9MB  ✓ FreeTypeAbstraction
   0.3 s │   0.10s    0.03s    0.07s │       3    0.24s     0.1MB  ✓ Xorg_libXrandr_jll
   2.0 s │   1.71s    1.26s    0.29s │     108    0.31s     0.7MB  ✓ Sixel
   0.4 s │   0.09s    0.03s    0.06s │       3    0.26s     0.1MB  ✓ Xorg_libXinerama_jll
   0.4 s │   0.11s    0.03s    0.07s │       3    0.28s     0.1MB  ✓ Xorg_libXi_jll
   0.4 s │   0.11s    0.03s    0.08s │       3    0.28s     0.1MB  ✓ libva_jll
   0.4 s │   0.10s    0.03s    0.06s │       3    0.29s     0.1MB  ✓ Libglvnd_jll
   0.3 s │   0.10s    0.03s    0.07s │       3    0.23s     0.1MB  ✓ Xorg_xkbcomp_jll
   1.3 s │   0.87s    0.87s    0.00s │       0    0.39s     0.1MB  ✓ Revise → DistributedExt
   2.9 s │   1.40s    0.32s    0.83s │    2379    1.52s     4.3MB  ✓ PNGFiles
   2.0 s │   1.59s    0.93s    0.59s │    1946    0.43s     1.2MB  ✓ PlotThemes
   2.0 s │   1.78s    1.77s    0.01s │       0    0.26s     0.1MB  ✓ FileIO → HTTPExt
   2.5 s │   1.69s    0.78s    0.80s │    2567    0.86s     3.2MB  ✓ RecipesPipeline
   3.0 s │   2.63s    2.52s    0.10s │      14    0.41s     0.2MB  ✓ Cairo_jll
   3.6 s │   1.62s    0.80s    0.65s │     905    1.99s     1.9MB  ✓ ExactPredicates
   1.1 s │   0.88s    0.80s    0.07s │       8    0.23s     0.1MB  ✓ Xorg_xkeyboard_config_jll
   1.6 s │   1.21s    1.09s    0.09s │      14    0.42s     0.3MB  ✓ libwebp_jll
   5.5 s │   5.19s    3.12s    0.24s │     395    0.34s     7.0MB  ✓ Distributions
   0.3 s │   0.09s    0.03s    0.06s │       3    0.21s     0.1MB  ✓ xkbcommon_jll
   4.3 s │   4.10s    3.82s    0.23s │     348    0.24s     0.4MB  ✓ ImageAxes
   2.1 s │   1.77s    1.69s    0.08s │      14    0.36s     0.2MB  ✓ HarfBuzz_jll
   0.4 s │   0.10s    0.03s    0.07s │      14    0.29s     0.1MB  ✓ Vulkan_Loader_jll
   1.4 s │   1.09s    0.85s    0.11s │     115    0.28s     0.6MB  ✓ WebP
   1.4 s │   1.17s    1.12s    0.04s │      11    0.22s     0.2MB  ✓ Distributions → DistributionsChainRulesCoreExt
   1.6 s │   1.41s    1.30s    0.10s │     124    0.23s     0.2MB  ✓ Distributions → DistributionsTestExt
   1.5 s │   1.26s    1.18s    0.03s │       3    0.24s     0.3MB  ✓ ImageMetadata
   1.9 s │   1.55s    1.47s    0.08s │      14    0.31s     0.2MB  ✓ libass_jll
   1.6 s │   1.26s    1.18s    0.08s │      14    0.35s     0.2MB  ✓ Pango_jll
   0.3 s │   0.08s    0.02s    0.06s │       3    0.20s     0.1MB  ✓ libdecor_jll
   0.4 s │   0.10s    0.03s    0.07s │      14    0.29s     0.1MB  ✓ GLFW_jll
   4.1 s │   3.75s    2.03s    0.28s │     478    0.33s     7.6MB  ✓ DelaunayTriangulation
   1.5 s │   1.29s    1.23s    0.03s │      49    0.26s     0.2MB  ✓ Netpbm
   1.7 s │   1.26s    0.97s    0.16s │     138    0.39s     0.9MB  ✓ GLFW
   1.5 s │   1.28s    1.20s    0.04s │       4    0.23s     0.3MB  ✓ ImageIO
   7.4 s │   6.44s    5.29s    0.99s │    1666    0.94s    12.0MB  ✓ MathTeXEngine
   6.1 s │   5.89s    5.75s    0.10s │     166    0.22s     0.2MB  ✓ KernelDensity
   6.2 s │   5.71s    5.59s    0.09s │      14    0.46s     0.2MB  ✓ FFMPEG_jll
   0.8 s │   0.59s    0.57s    0.02s │       0    0.19s     0.1MB  ✓ FFMPEG
   9.0 s │   8.46s    8.36s    0.08s │      14    0.55s     0.2MB  ✓ Qt6Base_jll
   0.7 s │   0.40s    0.32s    0.08s │      14    0.30s     0.1MB  ✓ Qt6ShaderTools_jll
   0.7 s │   0.40s    0.32s    0.08s │      14    0.30s     0.2MB  ✓ Qt6Svg_jll
   0.8 s │   0.41s    0.32s    0.08s │      14    0.41s     0.2MB  ✓ GR_jll
   1.9 s │   0.84s    0.71s    0.09s │      14    1.05s     0.4MB  ✓ Qt6Declarative_jll
   0.3 s │   0.08s    0.02s    0.05s │       3    0.19s     0.1MB  ✓ Qt6Wayland_jll
   3.4 s │   1.56s    0.55s    0.50s │     738    1.82s     2.9MB  ✓ GR
  27.0 s │  16.29s    3.59s   11.32s │   36224   10.69s    44.0MB  ✓ Plots
   2.7 s │   2.17s    2.15s    0.04s │      31    0.51s     0.1MB  ✓ Plots → FileIOExt
   2.8 s │   2.28s    2.11s    0.17s │     242    0.50s     0.2MB  ✓ Plots → UnitfulExt
   3.9 s │   3.36s    3.33s    0.05s │      25    0.50s     0.1MB  ✓ Plots → GeometryBasicsExt
  84.9 s │  52.69s   13.92s   34.31s │  100396   32.19s   140.3MB  ✓ Makie
  44.1 s │  25.80s    6.63s   17.22s │   35695   18.26s    48.5MB  ✓ GLMakie
  315 dependencies successfully precompiled in 194 seconds. 41 already precompiled.
```