### PR TITLE
Revert "Base.Docs: fix Binding constructor for renamed imports"

### DIFF
--- a/base/docs/bindings.jl
+++ b/base/docs/bindings.jl
@@ -8,20 +8,6 @@ struct Binding
         # Normalise the binding module for module symbols so that:
         #   Binding(Base, :Base) === Binding(Main, :Base)
         m = nameof(m) === v ? parentmodule(m) : m
-        # For renamed imports (`using X: y as z` / `import X: y as z`), the
-        # local symbol `v` doesn't exist on the canonical owner module.
-        # Inspect the binding partition: if it's an explicit by-name import
-        # (the only kinds where `as`-rename is syntactically possible), the
-        # partition's restriction is the underlying `Core.Binding` whose
-        # globalref carries the canonical `(mod, name)` pair.
-        world = Base.get_world_counter()
-        if Base.invoke_in_world(world, isdefinedglobal, m, v)
-            bpart = Base.lookup_binding_partition(world, GlobalRef(m, v))
-            if Base.is_some_explicit_imported(Base.binding_kind(bpart))
-                imported = Base.partition_restriction(bpart)::Core.Binding
-                return new(imported.globalref.mod, imported.globalref.name)
-            end
-        end
         new(Base.binding_module(m, v), v)
     end
 end

--- a/stdlib/REPL/test/docview.jl
+++ b/stdlib/REPL/test/docview.jl
@@ -176,15 +176,6 @@ end
 # Issue #51344, don't print "internal binding" warning for non-existent bindings.
 @test string(eval(REPL.helpmode("Base.no_such_symbol"))) == "No documentation found.\n\nBinding `Base.no_such_symbol` does not exist.\n"
 
-module AliasUsingTests
-    using Base: sum as sun
-end
-@testset "alias in using" begin
-    docstr = string(eval(REPL.helpmode(IOBuffer(), "sun", AliasUsingTests)))
-    @test contains(docstr, "sum")
-    @test !contains(docstr, "No documentation found.")
-end
-
 module TestSuggestPublic
     export dingo
     public dango


### PR DESCRIPTION
This breaks building Julia: https://github.com/JuliaLang/julia/pull/61869#issuecomment-4529617719. Reverts JuliaLang/julia#61869.  