### PR TITLE
Fix DISABLE_LIBUNWIND=1 build on Linux

### DIFF
--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -955,10 +955,17 @@ void trigger_profile_peek(void)
         profile_autostop_time = jl_hrtime() + (profile_peek_duration * 1e9);
 }
 
-#if !defined(JL_DISABLE_LIBUNWIND)
-
+// `signal_bt_data` and `signal_bt_size` are referenced by `signal_listener`
+// (signal_bt_size = 0; jl_exit_thread0(..., signal_bt_data, signal_bt_size);
+// and a print loop on critical signals) regardless of JL_DISABLE_LIBUNWIND,
+// so declare them unconditionally. With libunwind disabled they stay at zero
+// (no backtrace is ever recorded into them) and `jl_exit_thread0` receives
+// an empty buffer.
 static jl_bt_element_t signal_bt_data[JL_MAX_BT_SIZE + 1];
 static size_t signal_bt_size = 0;
+
+#if !defined(JL_DISABLE_LIBUNWIND)
+
 static void do_critical_profile(void)
 {
     bt_context_t signal_context;

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1123,7 +1123,15 @@ extern bt_context_t *jl_to_bt_context(void *sigctx) JL_NOTSAFEPOINT;
 // it and attempting to return normally.
 int jl_simulate_longjmp(jl_jmp_buf mctx, bt_context_t *c) JL_NOTSAFEPOINT
 {
-#if (defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_))
+#if defined(JL_DISABLE_LIBUNWIND)
+    // With libunwind disabled, `bt_context_t` is typedef'd to `int`
+    // (julia_internal.h, in the #else of the bt_context_t selection block),
+    // so the platform-specific code below that dereferences `c->uc_mcontext`,
+    // `c->Rsp`, etc. cannot compile. Bail out instead — callers handle a
+    // `0` return by falling back to a path that records no backtrace.
+    (void)mctx; (void)c;
+    return 0;
+#elif (defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_))
     // https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/hwasan/hwasan_interceptors.cpp
     return 0;
 #elif defined(_OS_WINDOWS_)


### PR DESCRIPTION
## Summary

Building Julia with `DISABLE_LIBUNWIND=1` (set in `Make.user` or
`Make.inc`) currently fails to compile on Linux:

```
src/stackwalk.c:1004:24: error: request for member 'uc_mcontext' in something not a structure or union
src/signals-unix.c:1061:9: error: 'signal_bt_size' undeclared (first use in this function)
src/signals-unix.c:1097:34: error: 'signal_bt_data' undeclared (first use in this function)
```

Two minimal patches:

1. **`src/stackwalk.c`** — `bt_context_t` is typedef'd to `int` when libunwind is disabled (in `julia_internal.h`'s `bt_context_t` selection block), but `jl_simulate_longjmp`'s platform-specific bodies all dereference fields of the libunwind / ucontext shape (`uc_mcontext`, `Rsp`, etc.). Short-circuit the function for the disabled case so it returns 0 — callers already handle that as "no usable context, no backtrace recorded".

2. **`src/signals-unix.c`** — `signal_bt_data` / `signal_bt_size` are declared inside `#if !defined(JL_DISABLE_LIBUNWIND)` but `signal_listener` uses them unconditionally (`signal_bt_size = 0;`, `jl_exit_thread0(sig, signal_bt_data, signal_bt_size);`, and a print loop on critical signals). Move just the declarations out of the guard so they always exist. With libunwind disabled, no code path ever writes into them, so `signal_bt_size` stays at zero and `jl_exit_thread0` receives an empty backtrace.

After these two changes a `DISABLE_LIBUNWIND=1` build on Linux x86_64 links and runs.

## Motivation

Producing redistributable shared libraries (via `juliac --output-lib`) whose embedded Julia does not pull in `libunwind.so` — `libunwind.so` in the bundle otherwise clashes with the modified `libunwind` that Matlab ships and causes segfaults during backtrace generation in the embedded library.

## Test plan

- [x] Builds cleanly: `Make.user` with `DISABLE_LIBUNWIND:=1` and `USE_BINARYBUILDER=0` on Linux x86_64 (verified on Julia 1.12.6 in a manylinux_2_28 container with the same patches applied)
- [ ] CI: build/test with `DISABLE_LIBUNWIND=1` is not currently part of CI, so this only verifies the regression is fixed for explicit users of the flag. Happy to add a CI job covering it on request.