### PR TITLE
Make `unsafe_read` and `unsafe_write` GC preserve `Ref` arguments

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -826,8 +826,11 @@ function write(io::IO, x1, xs...)
     return written
 end
 
-@noinline unsafe_write(s::IO, p::Ref{T}, n::Integer) where {T} =
-    unsafe_write(s, unsafe_convert(Ref{T}, p)::Ptr, n) # mark noinline to ensure ref is gc-rooted somewhere (by the caller)
+function unsafe_write(s::IO, p::Ref{T}, n::Integer) where {T}
+    GC.@preserve p begin
+        unsafe_write(s, unsafe_convert(Ref{T}, p)::Ptr, n)
+    end
+end
 unsafe_write(s::IO, p::Ptr, n::Integer) = unsafe_write(s, convert(Ptr{UInt8}, p), convert(UInt, n))
 function write(s::IO, x::Ref{T}) where {T}
     x isa Ptr && error("write cannot copy from a Ptr")
@@ -853,7 +856,7 @@ function write(s::IO, A::AbstractArray)
     r = Ref{eltype(A)}()
     for a in A
         r[] = a
-        nb += @noinline unsafe_write(s, r, Core.sizeof(r)) # r must be heap-allocated
+        nb += unsafe_write(s, r, Core.sizeof(r))
     end
     return nb
 end
@@ -914,7 +917,11 @@ function write(to::IO, from::IO)
     return n
 end
 
-@noinline unsafe_read(s::IO, p::Ref{T}, n::Integer) where {T} = unsafe_read(s, unsafe_convert(Ref{T}, p)::Ptr, n) # mark noinline to ensure ref is gc-rooted somewhere (by the caller)
+function unsafe_read(s::IO, p::Ref{T}, n::Integer) where {T}
+    GC.@preserve p begin
+        unsafe_read(s, unsafe_convert(Ref{T}, p)::Ptr, n)
+    end
+end
 unsafe_read(s::IO, p::Ptr, n::Integer) = unsafe_read(s, convert(Ptr{UInt8}, p), convert(UInt, n))
 function read!(s::IO, x::Ref{T}) where {T}
     x isa Ptr && error("read! cannot copy into a Ptr")
@@ -943,7 +950,7 @@ function read!(s::IO, A::AbstractArray{T}) where {T}
         if isbitstype(T)
             r = Ref{T}()
             for i in eachindex(A)
-                @noinline unsafe_read(s, r, Core.sizeof(r)) # r must be heap-allocated
+                unsafe_read(s, r, Core.sizeof(r))
                 A[i] = r[]
             end
         else

--- a/base/io.jl
+++ b/base/io.jl
@@ -826,7 +826,8 @@ function write(io::IO, x1, xs...)
     return written
 end
 
-function unsafe_write(s::IO, p::Ref{T}, n::Integer) where {T}
+function unsafe_write(s::IO, _p::Ref{T}, n::Integer) where {T}
+    p::typeof(_p) = blackbox(_p) # Introduce an optimization barrier here to force heap allocation of `_p`. This is needed in order to support task-switch in cases where JULIA_COPY_STACKS is enabled
     GC.@preserve p begin
         unsafe_write(s, unsafe_convert(Ref{T}, p)::Ptr, n)
     end
@@ -917,7 +918,8 @@ function write(to::IO, from::IO)
     return n
 end
 
-function unsafe_read(s::IO, p::Ref{T}, n::Integer) where {T}
+function unsafe_read(s::IO, _p::Ref{T}, n::Integer) where {T}
+    p::typeof(_p) = blackbox(_p) # Introduce an optimization barrier here to force heap allocation of `_p`. This is needed in order to support task-switch in cases where JULIA_COPY_STACKS is enabled
     GC.@preserve p begin
         unsafe_read(s, unsafe_convert(Ref{T}, p)::Ptr, n)
     end

--- a/base/io.jl
+++ b/base/io.jl
@@ -826,8 +826,7 @@ function write(io::IO, x1, xs...)
     return written
 end
 
-function unsafe_write(s::IO, _p::Ref{T}, n::Integer) where {T}
-    p::typeof(_p) = blackbox(_p) # Introduce an optimization barrier here to force heap allocation of `_p`. This is needed in order to support task-switch in cases where JULIA_COPY_STACKS is enabled
+function unsafe_write(s::IO, p::Ref{T}, n::Integer) where {T}
     GC.@preserve p begin
         unsafe_write(s, unsafe_convert(Ref{T}, p)::Ptr, n)
     end
@@ -918,8 +917,7 @@ function write(to::IO, from::IO)
     return n
 end
 
-function unsafe_read(s::IO, _p::Ref{T}, n::Integer) where {T}
-    p::typeof(_p) = blackbox(_p) # Introduce an optimization barrier here to force heap allocation of `_p`. This is needed in order to support task-switch in cases where JULIA_COPY_STACKS is enabled
+function unsafe_read(s::IO, p::Ref{T}, n::Integer) where {T}
     GC.@preserve p begin
         unsafe_read(s, unsafe_convert(Ref{T}, p)::Ptr, n)
     end


### PR DESCRIPTION
Identified from the conversation in https://discourse.julialang.org/t/stack-size-of-a-task-in-its-lifetime/137264/7

___________

If I'm understanding correctly, `unsafe_read` and `unsafe_write` currently are written using an implicit assumption that a `Ref` will be GC rooted if it passes through a non-inlined function barrier, and that it'll remain rooted for the duration of that function's execution:

```julia
@noinline unsafe_write(s::IO, p::Ref{T}, n::Integer) where {T} =
    unsafe_write(s, unsafe_convert(Ref{T}, p)::Ptr, n) # mark noinline to ensure ref is gc-rooted somewhere (by the caller)
```
[...]
```julia
@noinline unsafe_read(s::IO, p::Ref{T}, n::Integer) where {T} = unsafe_read(s, unsafe_convert(Ref{T}, p)::Ptr, n) # mark noinline to ensure ref is gc-rooted somewhere (by the caller)
```

I think this is a questionable idea in general because it's an implicit assumption that's not even present in the docstring and could be easily overwritten by the user doing an explicit `@inline`. Even worse, the foundation of this assumption will be broken once we use interproceedural escape analysis to inform the stack allocation of mutable structs, so I don't think this method would even work.

I propose we just use `GC.@preserve` to prevent use-after-free here, rather than `@noinline`. 

_____________

**Edit:** Some additional context here after looking through the git history. The commit that introduced the concept of `@noinline`ing the function in order to gc-root the `Ref` is from Jan 2016: https://github.com/julialang/julia/commit/8b9774331b

which is more than a year and a half older than the commit which introduced (the ancestor of) `GC.@preserve`: https://github.com/julialang/julia/commit/d68e42f238, so I guess that answers why `@preserve` wasn't used here.