### PR TITLE
Reland "Base.Docs: fix Binding constructor for renamed imports" (#61897)

### DIFF
--- a/base/docs/bindings.jl
+++ b/base/docs/bindings.jl
@@ -8,6 +8,19 @@ struct Binding
         # Normalise the binding module for module symbols so that:
         #   Binding(Base, :Base) === Binding(Main, :Base)
         m = nameof(m) === v ? parentmodule(m) : m
+        # Walk every explicit by-name import to recover the canonical `(mod, name)` pair,
+        # threading `as`-renames through chained re-exports.
+        # `partition_restriction` only walks one hop; `binding_module` walks all hops
+        # but drops the name.
+        world = Base.get_world_counter()
+        while Base.invoke_in_world(world, isdefinedglobal, m, v)
+            bpart = Base.lookup_binding_partition(world, GlobalRef(m, v))
+            Base.is_some_explicit_imported(Base.binding_kind(bpart)) || break
+            imported = Base.partition_restriction(bpart)::Core.Binding
+            next_m, next_v = imported.globalref.mod, imported.globalref.name
+            (next_m === m && next_v === v) && break
+            m, v = next_m, next_v
+        end
         new(Base.binding_module(m, v), v)
     end
 end

--- a/stdlib/REPL/test/docview.jl
+++ b/stdlib/REPL/test/docview.jl
@@ -176,6 +176,75 @@ end
 # Issue #51344, don't print "internal binding" warning for non-existent bindings.
 @test string(eval(REPL.helpmode("Base.no_such_symbol"))) == "No documentation found.\n\nBinding `Base.no_such_symbol` does not exist.\n"
 
+module AliasUsingTests
+    using Base: sum as sun
+end
+@testset "alias in using" begin
+    docstr = string(eval(REPL.helpmode(IOBuffer(), "sun", AliasUsingTests)))
+    @test contains(docstr, "sum")
+    @test !contains(docstr, "No documentation found.")
+end
+
+# Regression: by-name re-exports without `as`-rename must keep normalising
+# the binding through the full import chain.
+module ChainedReexportInner
+    """
+        target
+
+    chained re-export docstring
+    """
+    const target = 42
+end
+module ChainedReexportMid
+    import ..ChainedReexportInner: target
+end
+module ChainedReexportOuter
+    import ..ChainedReexportMid: target
+end
+@testset "chained by-name re-export resolves docstring" begin
+    docstr = string(eval(REPL.helpmode(IOBuffer(), "target", ChainedReexportOuter)))
+    @test contains(docstr, "chained re-export docstring")
+    @test !contains(docstr, "No documentation found")
+    # All three modules in the chain must produce the same canonical Binding.
+    inner_b = Base.Docs.Binding(ChainedReexportInner, :target)
+    outer_b = Base.Docs.Binding(ChainedReexportOuter, :target)
+    @test inner_b.mod === outer_b.mod
+    @test inner_b.var === outer_b.var
+end
+
+# Regression: `as`-rename composed with a plain re-export, in either order.
+module RenameOrigin
+    """
+        renamed_origin
+
+    renamed_origin docstring
+    """
+    renamed_origin() = 1
+end
+module RenameThenReexportMid
+    using ..RenameOrigin: renamed_origin as renamed_alias
+end
+module RenameThenReexportOuter
+    using ..RenameThenReexportMid: renamed_alias
+end
+module ReexportThenRenameMid
+    using ..RenameOrigin: renamed_origin
+end
+module ReexportThenRenameOuter
+    using ..ReexportThenRenameMid: renamed_origin as renamed_alias
+end
+@testset "chained renamed re-exports resolve docstring" begin
+    origin_b = Base.Docs.Binding(RenameOrigin, :renamed_origin)
+    for outr in (RenameThenReexportOuter, ReexportThenRenameOuter)
+        b = Base.Docs.Binding(outr, :renamed_alias)
+        @test b.mod === origin_b.mod
+        @test b.var === origin_b.var
+        docstr = string(eval(REPL.helpmode(IOBuffer(), "renamed_alias", outr)))
+        @test contains(docstr, "renamed_origin docstring")
+        @test !contains(docstr, "No documentation found")
+    end
+end
+
 module TestSuggestPublic
     export dingo
     public dango


### PR DESCRIPTION
The stock `Base.Docs.Binding(m, v)` constructor keeps the local symbol `v` while normalising the module via `binding_module(m, v)`. For renamed imports such as `using X: y as z`, this produces a binding to a non-existent `canonical_owner.z`, so `?` doc lookup fails:

    julia> using Base: isvisible as iv

    help?> iv
      No documentation found.
      Binding `Base.iv` does not exist.

Resolve the alias by walking the binding partition chain: for each explicit by-name import (`PARTITION_KIND_EXPLICIT` / `PARTITION_KIND_IMPORTED`), follow the partition's restriction to its underlying `Core.Binding` and read the canonical `(mod, name)` from its globalref. Iterate until a non-explicit-import partition is reached, then defer to `binding_module` for any remaining implicit-import normalisation.

The iterative walk is needed because neither primitive alone suffices for chained re-exports: `partition_restriction` only walks one hop (stopping at the intermediate module for a plain re-export of an `as`-renamed binding), while `binding_module` walks all hops but drops the name (losing the canonical symbol when an `as`-rename appears anywhere in the chain).

The first reland attempt rewrote unconditionally on any explicit by-name import, which broke the docs build for plain chained re-exports such as `Libdl.DL_LOAD_PATH` (whose docstring lives one hop upstream of the local import). See
https://buildkite.com/julialang/julia-master/builds/57392#019e4dd3-f9a5-42dc-984d-374451e1a32b for the original failure.

Re-lands #61869, originally landed as #55119.