### PR TITLE
[JuliaLowering] Fix and test empty identifiers

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -288,7 +288,7 @@ end
 
 function _est_to_dst_ident(st::SyntaxTree)
     s = st.name_val::String
-    if all(==('_'), s) || s == UNUSED
+    if (all(==('_'), s) || s == UNUSED) && length(s) > 0
         setattr!(mkleaf(st), :kind, K"Placeholder")
     else
         st
@@ -584,10 +584,12 @@ function est_to_dst(st::SyntaxTree)
         [K"symbolicgoto" lab] -> setattr!(mkleaf(st), :name_val, lab.name_val)
         [K"oldsymbolicgoto" lab] -> setattr!(mkleaf(st), :name_val, lab.name_val)
         [K"symboliclabel" lab] -> setattr!(mkleaf(st), :name_val, lab.name_val)
-        [K"symbolicblock" id body] -> if all(==('_'), id.name_val)
-            @ast g st [K"symbolicblock" id=>K"Placeholder" rec(body)]
-        else
-            @ast g st [K"symbolicblock" id=>K"symboliclabel" rec(body)]
+        [K"symbolicblock" id body] -> let s = id.name_val::String
+            if all(==('_'), s) && length(s) > 0
+                @ast g st [K"symbolicblock" id=>K"Placeholder" rec(body)]
+            else
+                @ast g st [K"symbolicblock" id=>K"symboliclabel" rec(body)]
+            end
         end
         [K"unknown_head" cs...] -> let head = st.name_val
             if head === "latestworld-if-toplevel"

--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -288,7 +288,7 @@ end
 
 function _est_to_dst_ident(st::SyntaxTree)
     s = st.name_val::String
-    if (all(==('_'), s) || s == UNUSED) && length(s) > 0
+    if is_writeonly_est_name(s)
         setattr!(mkleaf(st), :kind, K"Placeholder")
     else
         st
@@ -585,7 +585,7 @@ function est_to_dst(st::SyntaxTree)
         [K"oldsymbolicgoto" lab] -> setattr!(mkleaf(st), :name_val, lab.name_val)
         [K"symboliclabel" lab] -> setattr!(mkleaf(st), :name_val, lab.name_val)
         [K"symbolicblock" id body] -> let s = id.name_val::String
-            if all(==('_'), s) && length(s) > 0
+            if is_writeonly_est_name(s)
                 @ast g st [K"symbolicblock" id=>K"Placeholder" rec(body)]
             else
                 @ast g st [K"symbolicblock" id=>K"symboliclabel" rec(body)]

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -530,7 +530,7 @@ vst1_ident(vcx, st; lhs=false) = @stm st begin
     _ -> @fail(st, "expected identifier")
 end
 function _ident_str(vcx, st, s::String; lhs=false)
-    if !lhs && all(==('_'), s) && !vcx.readable_underscore
+    if !lhs && all(==('_'), s) && !vcx.readable_underscore && length(s) > 0
         @fail(st, "all-underscore identifiers are write-only and their values cannot be used in expressions")
     elseif lhs && s in ("ccall", "cglobal")
         @fail(st, string(s, " is a reserved identifier"))

--- a/JuliaLowering/src/validation.jl
+++ b/JuliaLowering/src/validation.jl
@@ -530,13 +530,19 @@ vst1_ident(vcx, st; lhs=false) = @stm st begin
     _ -> @fail(st, "expected identifier")
 end
 function _ident_str(vcx, st, s::String; lhs=false)
-    if !lhs && all(==('_'), s) && !vcx.readable_underscore && length(s) > 0
+    if !lhs && !vcx.readable_underscore && is_writeonly_est_name(s)
         @fail(st, "all-underscore identifiers are write-only and their values cannot be used in expressions")
     elseif lhs && s in ("ccall", "cglobal")
         @fail(st, string(s, " is a reserved identifier"))
     else
         pass()
     end
+end
+
+"N.B. this shouldn't be used after `est_to_dst`, as JuliaLowering uses the
+Placeholder kind when we have write-only identifiers"
+function is_writeonly_est_name(s::String)
+    (all(==('_'), s) || s == UNUSED) && length(s) > 0
 end
 
 vst1_call(vcx, st) = @stm st begin

--- a/JuliaLowering/test/assignments.jl
+++ b/JuliaLowering/test/assignments.jl
@@ -310,4 +310,8 @@ end
 
     @test JuliaLowering.include_string(m, """ macro _(x); x; end """) isa Function
     @test JuliaLowering.include_string(m, "@_(3)") == 3
+
+    # empty name is usable (though won't parse)
+    @test jl_eval(m, Expr(:macro, Expr(:call, Symbol(""), :x), :x)) isa Function
+    @test jl_eval(m, Expr(:macrocall, Symbol("@"), LineNumberNode(1), 123)) == 123
 end

--- a/JuliaLowering/test/decls_ir.jl
+++ b/JuliaLowering/test/decls_ir.jl
@@ -344,6 +344,26 @@ let const a = 1
 end
 
 ########################################
+# Error: function-stub in let first arg
+let function foo end
+end
+#---------------------
+LoweringError:
+let function foo end
+#   └──────────────┘ ── expected identifier or assignment
+end
+
+########################################
+# Error: function in let first arg
+let function foo(x); x; end
+end
+#---------------------
+LoweringError:
+let function foo(x); x; end
+#   └─────────────────────┘ ── expected identifier or assignment
+end
+
+########################################
 # Error: Const not supported in function scope
 function (); global g; const g = 1; end
 #---------------------

--- a/JuliaLowering/test/misc.jl
+++ b/JuliaLowering/test/misc.jl
@@ -41,6 +41,91 @@ let x=11
 end
 """) == 220
 
+@testset "empty symbol" begin
+    @test JuliaLowering.include_string(test_mod, """
+    let var\"\"=1; 1; end
+    """) == 1
+
+    # Note function name fails in flisp
+    @test jl_eval(test_mod,
+                Expr(:let, Expr(:block),
+                     Expr(:block,
+                          Expr(:function, Expr(:call, Symbol(""), :x),
+                               Expr(:block, :x)),
+                          Expr(:call, Symbol(""), 1)))) == 1
+
+    # function arg
+    @test jl_eval(test_mod,
+                Expr(:let, Expr(:block),
+                     Expr(:block,
+                          Expr(:function, Expr(:call, :func, Symbol("")),
+                               Expr(:block, Symbol(""))),
+                          Expr(:call, :func, 2)))) == 2
+    # kwarg
+    @test jl_eval(test_mod,
+                Expr(:let, Expr(:block),
+                     Expr(:block,
+                          Expr(:function, Expr(:call, :func, Expr(:parameters, Symbol(""))),
+                               Expr(:block, Symbol(""))),
+                          Expr(:call, :func, Expr(:kw, Symbol(""), 2))))) == 2
+
+    # empty label
+    @test jl_eval(test_mod,
+                Expr(:symbolicblock, Symbol(""),
+                     Expr(:break, Symbol(""), 1))) == 1
+
+    # read empty local
+    @test jl_eval(test_mod,
+                Expr(:let, Expr(:block),
+                     Expr(:block, Expr(:local, Symbol("")),
+                          Expr(:(=), Symbol(""), 17),
+                          Symbol("")))) == 17
+
+    # read empty global
+    @test jl_eval(test_mod,
+                Expr(:block, Expr(:global, Symbol("")),
+                     Expr(:(=), Symbol(""), 7),
+                     Symbol(""))) == 7
+
+    # typed read of empty
+    @test jl_eval(test_mod,
+                Expr(:let, Expr(:block, Expr(:(=), Symbol(""), 5)),
+                     Expr(:block, Expr(:(::), Symbol(""), :Int)))) == 5
+
+    # empty in curly (read position)
+    @test jl_eval(test_mod,
+                Expr(:let, Expr(:block, Expr(:(=), Symbol(""), Int)),
+                     Expr(:block, Expr(:curly, :Vector, Symbol(""))))) == Vector{Int}
+
+    # empty in tuple (read position)
+    @test jl_eval(test_mod,
+                Expr(:let, Expr(:block, Expr(:(=), Symbol(""), 99)),
+                     Expr(:block, Expr(:tuple, Symbol(""))))) == (99,)
+
+    # isdefined on empty
+    @test jl_eval(test_mod,
+                Expr(:let, Expr(:block, Expr(:(=), Symbol(""), 1)),
+                     Expr(:block, Expr(:isdefined, Symbol("")))))
+
+    # for-loop empty iter var referenced in body
+    @test jl_eval(test_mod,
+                Expr(:let, Expr(:block, Expr(:(=), :s, 0)),
+                     Expr(:block,
+                          Expr(:for, Expr(:(=), Symbol(""), Expr(:tuple, 10, 20, 30)),
+                               Expr(:block, Expr(:(=), :s, Expr(:call, :+, :s, Symbol(""))))),
+                          :s))) == 60
+
+    # tuple destructure with empty lhs
+    @test jl_eval(test_mod,
+                Expr(:let, Expr(:block),
+                     Expr(:block, Expr(:local, Symbol("")), Expr(:local, :a),
+                          Expr(:(=), Expr(:tuple, Symbol(""), :a), Expr(:tuple, 1, 2)),
+                          Expr(:tuple, Symbol(""), :a)))) == (1, 2)
+
+    # quote of empty
+    @test jl_eval(test_mod, Expr(:quote, Symbol(""))) === Symbol("")
+end
+
 @eval test_mod libccalltest_var = "libccalltest"
 
 @testset "cglobal" begin

--- a/JuliaLowering/test/validation.jl
+++ b/JuliaLowering/test/validation.jl
@@ -153,3 +153,16 @@ end
     @test vst1_ok(:(local _))
     @test vst1_ok(:(local _::Int))
 end
+
+@testset "empty symbol is valid" for e in [
+    Expr(:block, Symbol(""))
+    Expr(:inert, Symbol(""))
+    Expr(:(::), Symbol(""), :Int)
+    Expr(:const, Expr(:(=), Symbol(""), 1))
+    Expr(:global, Expr(:(=), Symbol(""), 1))
+    Expr(:local, Expr(:(=), Symbol(""), 1))
+    Expr(:let, Expr(:block, Expr(:(=), Symbol(""), 1)), Expr(:block))
+    Expr(:function, Expr(:call, Symbol("")), Expr(:block))
+    ]
+    @test vst1_ok(e)
+end

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -688,3 +688,8 @@ function goto_into_while_break()
     end
 end
 @test goto_into_while_break() === nothing
+
+# empty label
+@test Core.eval(@__MODULE__,
+                Expr(:symbolicblock, Symbol(""),
+                     Expr(:break, Symbol(""), 1))) == 1


### PR DESCRIPTION
The second bug detected by #61576, and it's a silly one.  Empty identifiers trivially pass the all-characters-are-underscore check, but we really want them to behave like normal identifiers.  

Note flisp hits errors with empty function names (e.g. when checking if the first char is `'@'`).  I don't see any reason to reserve this syntax (variable and macro names are already allowed to be empty), so I've just allowed it in JL.

Some of the misc.jl tests were robot-written.