### PR TITLE
type system: Refactor Type{} structure

### DIFF
--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -37,8 +37,9 @@ else
 
 using Core.Intrinsics, Core.IR
 
-using Core: ABIOverride, Builtin, CodeInstance, IntrinsicFunction, MethodInstance, MethodMatch,
+using Core: ABIOverride, Builtin, CodeInstance, IntrinsicFunction, Kind, MethodInstance, MethodMatch,
     MethodTable, MethodCache, PartialOpaque, SimpleVector, TypeofVararg,
+    TypeEq,
     _apply_iterate, apply_type, compilerbarrier, donotdelete, memoryref_isassigned,
     memoryrefget, memoryrefnew, memoryrefoffset, memoryrefset!, memoryrefunset!, print, println, show, svec,
     typename, unsafe_write, write, stdout, stderr
@@ -61,7 +62,7 @@ using Base: @_foldable_meta, @_gc_preserve_begin, @_gc_preserve_end, @nospeciali
     iskindtype, ismutabletypename, ismutationfree, issingletontype, isvarargtype, isvatuple,
     kwerr, lookup_binding_partition, may_invoke_generator, methods, midpoint, moduleroot,
     partition_restriction, quoted, rename_unionall, rewrap_unionall, specialize_method,
-    structdiff, tls_world_age, unconstrain_vararg_length, unionlen, uniontype_layout,
+    structdiff, tls_world_age, type_parameter, unconstrain_vararg_length, unionlen, uniontype_layout,
     uniontypes, unsafe_convert, unwrap_unionall, unwrapva, vect, widen_diagonal,
     _uncompressed_ir, datatype_min_ninitialized,
     partialstruct_init_undefs, fieldcount_noerror, _eval_import, _eval_using,

--- a/Compiler/src/Compiler.jl
+++ b/Compiler/src/Compiler.jl
@@ -37,7 +37,7 @@ else
 
 using Core.Intrinsics, Core.IR
 
-using Core: ABIOverride, Builtin, CodeInstance, IntrinsicFunction, Kind, MethodInstance, MethodMatch,
+using Core: ABIOverride, Builtin, CodeInstance, IntrinsicFunction, AnyType, MethodInstance, MethodMatch,
     MethodTable, MethodCache, PartialOpaque, SimpleVector, TypeofVararg,
     TypeEq,
     _apply_iterate, apply_type, compilerbarrier, donotdelete, memoryref_isassigned,

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -1079,7 +1079,7 @@ collect_const_args(arginfo::ArgInfo, start::Int) = collect_const_args(arginfo.ar
 function collect_const_args(argtypes::Vector{Any}, start::Int)
     return Any[ let a = widenslotwrapper(argtypes[i])
                     isa(a, Const) ? a.val :
-                    isconstType(a) ? a.parameters[1] :
+                    isconstType(a) ? type_parameter(a) :
                     (a::DataType).instance
                 end for i = start:length(argtypes) ]
 end
@@ -2381,7 +2381,7 @@ function abstract_call_unionall(interp::AbstractInterpreter, argtypes::Vector{An
     if isa(a3, Const)
         body = a3.val
     elseif isType(a3)
-        body = a3.parameters[1]
+        body = type_parameter(a3)
         canconst = false
     else
         return CallMeta(Any, Any, Effects(EFFECTS_TOTAL; nothrow), call.info)
@@ -2470,7 +2470,6 @@ function abstract_invoke(interp::AbstractInterpreter, arginfo::ArgInfo, si::Stmt
         nargtype === Bottom && return Future(CallMeta(Bottom, TypeError, EFFECTS_THROWS, NoCallInfo()))
         nargtype isa DataType || return Future(CallMeta(Any, Any, Effects(), NoCallInfo())) # other cases are not implemented below
         isdispatchelem(ft) || return Future(CallMeta(Any, Any, Effects(), NoCallInfo())) # check that we might not have a subtype of `ft` at runtime, before doing supertype lookup below
-        ft = ft::DataType
         lookupsig = rewrap_unionall(Tuple{ft, unwrapped.parameters...}, types)::Type
         nargtype = Tuple{ft, nargtype.parameters...}
         argtype = Tuple{ft, argtype.parameters...}

--- a/Compiler/src/abstractlattice.jl
+++ b/Compiler/src/abstractlattice.jl
@@ -96,7 +96,7 @@ widenlattice(𝕃::InferenceLattice) = 𝕃.parent
 is_valid_lattice_norec(::InferenceLattice, @nospecialize(elem)) = isa(elem, LimitedAccuracy)
 
 """
-    tmeet(𝕃::AbstractLattice, a, b::Kind)
+    tmeet(𝕃::AbstractLattice, a, b::AnyType)
 
 Compute the lattice meet of lattice elements `a` and `b` over the lattice `𝕃`,
 dropping any results that will not be inhabited at runtime.
@@ -107,7 +107,7 @@ Note that currently `b` is restricted to being a type
 """
 function tmeet end
 
-function tmeet(::JLTypeLattice, @nospecialize(a::Kind), @nospecialize(b::Kind))
+function tmeet(::JLTypeLattice, @nospecialize(a::AnyType), @nospecialize(b::AnyType))
     ti = typeintersect(a, b)
     valid_as_lattice(ti, true) || return Bottom
     return ti
@@ -150,7 +150,7 @@ If `𝕃` is `JLTypeLattice`, this is equivalent to subtyping.
 """
 function ⊑ end
 
-@nospecializeinfer ⊑(::JLTypeLattice, @nospecialize(a::Kind), @nospecialize(b::Kind)) = a <: b
+@nospecializeinfer ⊑(::JLTypeLattice, @nospecialize(a::AnyType), @nospecialize(b::AnyType)) = a <: b
 
 """
     ⊏(𝕃::AbstractLattice, a, b)::Bool

--- a/Compiler/src/abstractlattice.jl
+++ b/Compiler/src/abstractlattice.jl
@@ -96,7 +96,7 @@ widenlattice(𝕃::InferenceLattice) = 𝕃.parent
 is_valid_lattice_norec(::InferenceLattice, @nospecialize(elem)) = isa(elem, LimitedAccuracy)
 
 """
-    tmeet(𝕃::AbstractLattice, a, b::Type)
+    tmeet(𝕃::AbstractLattice, a, b::Kind)
 
 Compute the lattice meet of lattice elements `a` and `b` over the lattice `𝕃`,
 dropping any results that will not be inhabited at runtime.
@@ -107,7 +107,7 @@ Note that currently `b` is restricted to being a type
 """
 function tmeet end
 
-function tmeet(::JLTypeLattice, @nospecialize(a::Type), @nospecialize(b::Type))
+function tmeet(::JLTypeLattice, @nospecialize(a::Kind), @nospecialize(b::Kind))
     ti = typeintersect(a, b)
     valid_as_lattice(ti, true) || return Bottom
     return ti
@@ -150,7 +150,7 @@ If `𝕃` is `JLTypeLattice`, this is equivalent to subtyping.
 """
 function ⊑ end
 
-@nospecializeinfer ⊑(::JLTypeLattice, @nospecialize(a::Type), @nospecialize(b::Type)) = a <: b
+@nospecializeinfer ⊑(::JLTypeLattice, @nospecialize(a::Kind), @nospecialize(b::Kind)) = a <: b
 
 """
     ⊏(𝕃::AbstractLattice, a, b)::Bool

--- a/Compiler/src/inferenceresult.jl
+++ b/Compiler/src/inferenceresult.jl
@@ -184,7 +184,7 @@ function most_general_argtypes(method::Union{Method,Nothing}, @nospecialize(spec
             # replace singleton types with their equivalent Const object
             atyp = Const(atyp.instance)
         elseif isconstType(atyp)
-            atyp = Const(atyp.parameters[1])
+            atyp = Const(type_parameter(atyp))
         else
             atyp = elim_free_typevars(rewrap_unionall(atyp, specTypes))
         end

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -740,6 +740,14 @@ function constrains_param(var::TypeVar, @nospecialize(typ), covariant::Bool, typ
         ba = constrains_param(var, typ.a, covariant, type_constrains)
         bb = constrains_param(var, typ.b, covariant, type_constrains)
         (ba && bb) && return true
+    elseif isType(typ)
+        p = type_parameter(typ)
+        if p === var && var.ub === Any
+            # Types with free type parameters are <: Type cause the typevar
+            # to be unconstrained because Type{T} with free typevars is illegal
+            return type_constrains
+        end
+        constrains_param(var, p, false, type_constrains) && return true
     elseif typ isa DataType
         # return true if any param constrains var
         fc = length(typ.parameters)
@@ -759,11 +767,6 @@ function constrains_param(var::TypeVar, @nospecialize(typ), covariant::Bool, typ
                     constrains_param(var, lastp, covariant, type_constrains) && return true
                 end
             else
-                if typ.name === typename(Type) && typ.parameters[1] === var && var.ub === Any
-                    # Types with free type parameters are <: Type cause the typevar
-                    # to be unconstrained because Type{T} with free typevars is illegal
-                    return type_constrains
-                end
                 for i in 1:fc
                     p = typ.parameters[i]
                     constrains_param(var, p, false, type_constrains) && return true
@@ -785,7 +788,7 @@ function sptype_for_tvar(vᵢ::TypeVar, output_tvar::TypeVar, sigtypes::Core.Sim
                          @nospecialize(specTypes))
     for j = 1:length(sigtypes)
         sⱼ = sigtypes[j]
-        if isType(sⱼ) && sⱼ.parameters[1] === vᵢ
+        if isType(sⱼ) && type_parameter(sⱼ) === vᵢ
             # `arg::Type{T}` pins the sparam to the arg's type
             return fieldtype(specTypes, j)
         elseif (va = va_from_vatuple(sⱼ)) !== nothing
@@ -799,7 +802,7 @@ function sptype_for_tvar(vᵢ::TypeVar, output_tvar::TypeVar, sigtypes::Core.Sim
         # `Bottom <: T <: Any` additionally allows non-Type tvars
         return Any
     end
-    return rewrap_free_typevars(Type{output_tvar}, find_free_typevars(specTypes))
+    return rewrap_free_typevars(TypeEq{output_tvar}, find_free_typevars(specTypes))
 end
 
 function sptypes_from_meth_instance(mi::MethodInstance)
@@ -845,7 +848,7 @@ function sptypes_from_meth_instance(mi::MethodInstance)
                                      (unwrap_unionall(temp)::DataType).parameters,
                                      mi.specTypes)
             else
-                ty = rewrap_free_typevars(Type{v}, find_free_typevars(mi.specTypes))
+                ty = rewrap_free_typevars(TypeEq{v}, find_free_typevars(mi.specTypes))
             end
             undef = !v_constrained
         elseif isvarargtype(v)

--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -338,8 +338,8 @@ function new_expr_effect_flags(𝕃ₒ::AbstractLattice, args::Vector{Any}, src:
     typ, isexact = instanceof_tfunc(atyp, true)
     if !isexact
         atyp = unwrap_unionall(widenconst(atyp))
-        if isType(atyp) && isTypeDataType(atyp.parameters[1])
-            typ = atyp.parameters[1]
+        if isType(atyp) && isTypeDataType(type_parameter(atyp))
+            typ = type_parameter(atyp)
         else
             return (false, false, false)
         end

--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -720,7 +720,7 @@ function rewrite_apply_exprargs!(todo::Vector{Pair{Int,Any}},
                             # replace singleton types with their equivalent Const object
                             p = Const(p.instance)
                         elseif isconstType(p)
-                            p = Const(p.parameters[1])
+                            p = Const(type_parameter(p))
                         end
                         push!(def_argtypes, p)
                     end
@@ -785,9 +785,12 @@ function compileable_specialization(code::Union{MethodInstance,CodeInstance}, ef
         # If this caller does not want us to optimize calls to use their
         # declared compilesig, then it is also likely they would handle sparams
         # incorrectly if there were any unknown typevars, so we conservatively return nothing
-        if any(@nospecialize(t)->isa(t, SimpleVector) || has_free_typevars(t), mi.sparam_vals)
+        if any(@nospecialize(t)->isa(t, SimpleVector), mi.sparam_vals)
             return nothing
         end
+    end
+    if unionall_depth(method.sig) != length(sparams) || !validate_sparams(sparams)
+        return nothing
     end
     # prefer using a CodeInstance gotten from the cache, since that is where the invoke target should get compiled to normally
     # TODO: can this code be gotten directly from inference sometimes?
@@ -1708,7 +1711,7 @@ function late_inline_special_case!(ir::IRCode, idx::Int, stmt::Expr, flag::UInt3
         return SomeCase(unionall_call)
     elseif is_return_type(f)
         if isconstType(type)
-            return SomeCase(quoted(type.parameters[1]))
+            return SomeCase(quoted(type_parameter(type)))
         elseif isa(type, Const)
             return SomeCase(quoted(type.val))
         end

--- a/Compiler/src/ssair/passes.jl
+++ b/Compiler/src/ssair/passes.jl
@@ -1135,7 +1135,7 @@ end
         argdef = compact[rarg][:stmt]
     else
         isType(arg) || return nothing
-        arg = arg.parameters[1]
+        arg = type_parameter(arg)
     end
 
     is_known_call(argdef, Core.apply_type, compact) || return nothing

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -74,7 +74,7 @@ const DATATYPE_NAME_FIELDINDEX = fieldindex(DataType, :name)
 
 # Note that in most places in the compiler here, we'll assume that T=Type{S} is well-formed,
 # and implies that `S <: Type`, not `1::Type{1}`, for example.
-# This means that isType(T) implies we can call subtype on T.parameters[1], etc.
+# This means that isType(T) implies we can call subtype on type_parameter(T), etc.
 
 function add_tfunc(f::IntrinsicFunction, minarg::Int, maxarg::Int, @nospecialize(tfunc), cost::Int)
     idx = reinterpret(Int32, f) + 1
@@ -109,7 +109,7 @@ function instanceof_tfunc(@nospecialize(t), astag::Bool=false, @nospecialize(tro
     elseif t === typeof(Bottom) || !hasintersect(t, Type)
         return Bottom, true, false, false # literal Bottom or non-Type
     elseif isType(t)
-        tp = t.parameters[1]
+        tp = type_parameter(t)
         valid_as_lattice(tp, astag) || return Bottom, true, false, false # runtime unreachable / throws on non-Type
         if troot isa UnionAll
             # Free `TypeVar`s inside `Type` has violated the "diagonal" rule.
@@ -323,7 +323,7 @@ add_tfunc(Core.Intrinsics.llvmcall, 3, INT_INF, llvmcall_tfunc, 10)
 @nospecs cglobal_tfunc(𝕃::AbstractLattice, fptr) = Ptr{Cvoid}
 @nospecs function cglobal_tfunc(𝕃::AbstractLattice, fptr, t)
     isa(t, Const) && return isa(t.val, Type) ? Ptr{t.val} : Ptr
-    return isType(t) ? Ptr{t.parameters[1]} : Ptr
+    return isType(t) ? Ptr{type_parameter(t)} : Ptr
 end
 add_tfunc(Core.Intrinsics.cglobal, 1, 2, cglobal_tfunc, 5)
 
@@ -416,7 +416,7 @@ end
     if arg1 isa MustAlias
         arg1 = widenmustalias(arg1)
     end
-    arg1t = arg1 isa Const ? typeof(arg1.val) : isconstType(arg1) ? typeof(arg1.parameters[1]) : widenconst(arg1)
+    arg1t = arg1 isa Const ? typeof(arg1.val) : isconstType(arg1) ? typeof(type_parameter(arg1)) : widenconst(arg1)
     a1 = unwrap_unionall(arg1t)
     if isa(a1, DataType) && !isabstracttype(a1)
         if a1 === Module
@@ -532,7 +532,7 @@ end
     x = widenmustalias(x)
     isa(x, Const) && return _const_sizeof(x.val)
     isa(x, Conditional) && return _const_sizeof(Bool)
-    isconstType(x) && return _const_sizeof(x.parameters[1])
+    isconstType(x) && return _const_sizeof(type_parameter(x))
     xu = unwrap_unionall(x)
     if isa(xu, Union)
         return tmerge(sizeof_tfunc(𝕃, rewrap_unionall(xu.a, x)),
@@ -564,7 +564,7 @@ add_tfunc(Core.sizeof, 1, 1, sizeof_tfunc, 1)
     isa(x, Conditional) && return Const(0)
     xt = widenconst(x)
     x = unwrap_unionall(xt)
-    isconstType(x) && return Const(nfields(x.parameters[1]))
+    isconstType(x) && return Const(nfields(type_parameter(x)))
     if isa(x, DataType) && !isabstracttype(x)
         if x.name === Tuple.name
             isvatuple(x) && return Int
@@ -623,7 +623,7 @@ add_tfunc(Core._svec_ref, 2, 2, _svec_ref_tfunc, 1)
         else
             lb_arg = widenslotwrapper(lb_arg)
             if isType(lb_arg)
-                lb = lb_arg.parameters[1]
+                lb = type_parameter(lb_arg)
                 lb_certain = false
             else
                 return TypeVar
@@ -634,7 +634,7 @@ add_tfunc(Core._svec_ref, 2, 2, _svec_ref_tfunc, 1)
         else
             ub_arg = widenslotwrapper(ub_arg)
             if isType(ub_arg)
-                ub = ub_arg.parameters[1]
+                ub = type_parameter(ub_arg)
                 ub_certain = false
             else
                 return TypeVar
@@ -821,7 +821,7 @@ end
     isa(t, Const) && return Const(typeof(t.val))
     t = widenconst(t)
     if isType(t)
-        tp = t.parameters[1]
+        tp = type_parameter(t)
         if hasuniquerep(tp)
             return Const(typeof(tp))
         end
@@ -877,7 +877,7 @@ add_tfunc(typeassert, 2, 2, typeassert_tfunc, 4)
     ⊑ = partialorder(𝕃)
     # ty, exact = instanceof_tfunc(t, true)
     # return exact && v ⊑ ty
-    if (isType(t) && !has_free_typevars(t) && v ⊑ t.parameters[1]) ||
+    if (isType(t) && !has_free_typevars(t) && v ⊑ type_parameter(t)) ||
         (isa(t, Const) && isa(t.val, Type) && v ⊑ t.val)
         return true
     end
@@ -1031,7 +1031,7 @@ end
             nflds = fieldcount_noerror(sty)
             ismod = false
         else
-            sv = (s00::DataType).parameters[1]
+            sv = type_parameter(s00)
             sty = typeof(sv)
             nflds = nfields(sv)
             ismod = sv isa Module
@@ -1063,7 +1063,7 @@ end
     if isa(s, Union)
         return getfield_nothrow(𝕃, rewrap_unionall(s.a, s00), name, boundscheck) &&
                getfield_nothrow(𝕃, rewrap_unionall(s.b, s00), name, boundscheck)
-    elseif isType(s) && isTypeDataType(s.parameters[1])
+    elseif isType(s) && isTypeDataType(type_parameter(s))
         s = s0 = DataType
     end
     if isa(s, DataType)
@@ -1200,14 +1200,14 @@ end
     end
     if isType(s)
         if isconstType(s)
-            sv = (s00::DataType).parameters[1]
+            sv = type_parameter(s)
             if isa(name, Const)
                 r = _getfield_tfunc_const(sv, name)
                 r !== nothing && return r
             end
             s = typeof(sv)
         else
-            sv = s.parameters[1]
+            sv = type_parameter(s)
             if isTypeDataType(sv) && isa(name, Const)
                 nv = _getfield_fieldindex(DataType, name)::Int
                 if nv == DATATYPE_NAME_FIELDINDEX
@@ -1571,13 +1571,14 @@ end
         end
         return Any
     end
+    isType(u) && return Bottom
     u isa DataType || return Any
     if isabstracttype(u)
         # Abstract types have no fields
         exact && return Bottom
         # Type{...} without free typevars has no subtypes, so it is actually
         # exact, even if `exact` is false.
-        isType(u) && !has_free_typevars(u.parameters[1]) && return Bottom
+        isType(u) && !has_free_typevars(type_parameter(u)) && return Bottom
         return Any
     end
     if u.name === _NAMEDTUPLE_NAME && !isconcretetype(u)
@@ -1663,8 +1664,48 @@ add_tfunc(fieldtype, 2, 3, fieldtype_tfunc, 0)
 
 # Like `valid_tparam`, but in the type domain.
 valid_tparam_type(T::DataType) = valid_typeof_tparam(T)
+valid_tparam_type(T::TypeEq) = true
 valid_tparam_type(U::Union) = valid_tparam_type(U.a) && valid_tparam_type(U.b)
 valid_tparam_type(U::UnionAll) = valid_tparam_type(unwrap_unionall(U))
+
+function typeeq_apply_type_nothrow(𝕃::AbstractLattice, argtypes::Vector{Any})
+    length(argtypes) == 2 || return false
+    ai = widenslotwrapper(widenconditional(argtypes[2]))
+    if isa(ai, Const)
+        v = ai.val
+        return isa(v, Type) || isa(v, TypeVar) || valid_tparam(v)
+    end
+    isType(ai) && return true
+    isa(ai, PartialTypeVar) && return true
+    ai = widenconst(ai)
+    return (⊑(𝕃, ai, Kind) || ⊑(𝕃, ai, TypeVar) ||
+            (isa(ai, Type) && valid_tparam_type(ai)))
+end
+
+function typeeq_apply_type_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any})
+    length(argtypes) == 2 || return Bottom
+    ai = widenslotwrapper(argtypes[2])
+    if isa(ai, Const)
+        v = ai.val
+        (isa(v, Type) || isa(v, TypeVar) || valid_tparam(v)) || return Bottom
+        return Const(apply_type(TypeEq, v))
+    end
+    if isType(ai)
+        return hasuniquerep(ai) ? Const(ai) : Type{ai}
+    end
+    if isa(ai, PartialTypeVar)
+        (ai.lb_certain && ai.ub_certain) || return TypeEq
+        return Type{TypeEq{ai.tv}}
+    end
+    ai = widenconst(ai)
+    if ⊑(𝕃, ai, Kind) || ⊑(𝕃, ai, TypeVar) || (isa(ai, Type) && valid_tparam_type(ai))
+        return TypeEq
+    end
+    if isa(ai, Type) && isconcretetype(ai)
+        return Bottom
+    end
+    return TypeEq
+end
 
 function apply_type_nothrow(𝕃::AbstractLattice, argtypes::Vector{Any}, @nospecialize(rt))
     rt === Type && return false
@@ -1673,13 +1714,14 @@ function apply_type_nothrow(𝕃::AbstractLattice, argtypes::Vector{Any}, @nospe
     if isa(headtypetype, Const)
         headtype = headtypetype.val
     elseif isconstType(headtypetype)
-        headtype = headtypetype.parameters[1]
+        headtype = type_parameter(headtypetype)
     else
         return false
     end
     # We know the apply_type is well formed. Otherwise our rt would have been
     # Bottom (or Type).
     (headtype === Union) && return true
+    headtype === TypeEq && return typeeq_apply_type_nothrow(𝕃, argtypes)
     isa(rt, Const) && return true
     u = headtype
     # TODO: implement optimization for isvarargtype(u) and istuple occurrences (which are valid but are not UnionAll)
@@ -1693,7 +1735,7 @@ function apply_type_nothrow(𝕃::AbstractLattice, argtypes::Vector{Any}, @nospe
                 return false
             end
         elseif (isa(ai, Const) && isa(ai.val, Type)) || isconstType(ai)
-            ai = isa(ai, Const) ? ai.val : (ai::DataType).parameters[1]
+            ai = isa(ai, Const) ? ai.val : type_parameter(ai)
             if has_free_typevars(u.var.lb) || has_free_typevars(u.var.ub)
                 return false
             end
@@ -1744,7 +1786,7 @@ function apply_type_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any};
     if isa(headtypetype, Const)
         headtype = headtypetype.val
     elseif isconstType(headtypetype)
-        headtype = headtypetype.parameters[1]
+        headtype = type_parameter(headtypetype)
     else
         return Any
     end
@@ -1784,7 +1826,7 @@ function apply_type_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any};
         for i = 2:largs
             ai = argtypes[i]
             if isType(ai)
-                aty = ai.parameters[1]
+                aty = type_parameter(ai)
                 allconst &= hasuniquerep(aty)
             else
                 aty = (ai::Const).val
@@ -1792,6 +1834,9 @@ function apply_type_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any};
             ty = Union{ty, aty}
         end
         return allconst ? Const(ty) : Type{ty}
+    end
+    if headtype === TypeEq
+        return typeeq_apply_type_tfunc(𝕃, argtypes)
     end
     if 1 < unionsplitcost(𝕃, argtypes) ≤ max_union_splitting
         rt = Bottom
@@ -1833,7 +1878,7 @@ end
     for i = 2:largs
         ai = widenslotwrapper(argtypes[i])
         if isType(ai)
-            aip1 = ai.parameters[1]
+            aip1 = type_parameter(ai)
             canconst &= !has_free_typevars(aip1)
             push!(tparams, aip1)
         elseif isa(ai, Const) && (isa(ai.val, Type) || isa(ai.val, TypeVar) ||
@@ -1848,7 +1893,7 @@ end
             isT = isType(unw)
             # compute our desired upper bound value
             if isT
-                ub = rewrap_unionall(unw.parameters[1], ai)
+                ub = rewrap_unionall(type_parameter(unw), ai)
             else
                 ub = Any
             end
@@ -1857,7 +1902,7 @@ end
                 # outer type, use the wrapper type, instead of letting it nest more
                 # complexity here. This is not monotonic, but seems to work out pretty well.
                 if isT
-                    ub = unwrap_unionall(unw.parameters[1])
+                    ub = unwrap_unionall(type_parameter(unw))
                     if ub isa DataType
                         ub = ub.name.wrapper
                         unw = Type{unwrap_unionall(ub)}
@@ -1888,13 +1933,13 @@ end
                     # make sure vars introduced here are unique
                     if contains_is(outervars, tai.var)
                         ai = rename_unionall(ai)
-                        unw = unwrap_unionall(ai)::DataType
+                        unw = unwrap_unionall(ai)
                         # ub = rewrap_unionall(unw, ai)
                         break
                     end
                     tai = tai.body
                 end
-                push!(tparams, unw.parameters[1])
+                push!(tparams, type_parameter(unw))
                 while isa(ai, UnionAll)
                     push!(outervars, ai.var)
                     ai = ai.body
@@ -2008,7 +2053,7 @@ function tuple_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any})
             # (::Union{Type{Int32},Type{Int64}}) -> Tuple{Type}
             if isType(x)
                 anyinfo = true
-                xparam = x.parameters[1]
+                xparam = type_parameter(x)
                 if hasuniquerep(xparam) || xparam === Bottom
                     params[i] = typeof(xparam)
                 else
@@ -3148,7 +3193,7 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
         return Future(UNKNOWN)
     end
 
-    af_argtype = isa(tt, Const) ? tt.val : (tt::DataType).parameters[1]
+    af_argtype = isa(tt, Const) ? tt.val : type_parameter(tt)
     if !isa(af_argtype, DataType) || !(af_argtype <: Tuple)
         return Future(UNKNOWN)
     end
@@ -3295,7 +3340,7 @@ function typename_static(@nospecialize(t))
     t isa Const && return _typename(t.val)
     t isa Conditional && return Bool.name
     t = unwrap_unionall(widenconst(t))
-    return isType(t) ? _typename(t.parameters[1]) : Core.TypeName
+    return isType(t) ? _typename(type_parameter(t)) : Core.TypeName
 end
 
 function global_order_exct(@nospecialize(o), loading::Bool, storing::Bool)

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1678,7 +1678,7 @@ function typeeq_apply_type_nothrow(𝕃::AbstractLattice, argtypes::Vector{Any})
     isType(ai) && return true
     isa(ai, PartialTypeVar) && return true
     ai = widenconst(ai)
-    return (⊑(𝕃, ai, Kind) || ⊑(𝕃, ai, TypeVar) ||
+    return (⊑(𝕃, ai, AnyType) || ⊑(𝕃, ai, TypeVar) ||
             (isa(ai, Type) && valid_tparam_type(ai)))
 end
 
@@ -1698,7 +1698,7 @@ function typeeq_apply_type_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any})
         return Type{TypeEq{ai.tv}}
     end
     ai = widenconst(ai)
-    if ⊑(𝕃, ai, Kind) || ⊑(𝕃, ai, TypeVar) || (isa(ai, Type) && valid_tparam_type(ai))
+    if ⊑(𝕃, ai, AnyType) || ⊑(𝕃, ai, TypeVar) || (isa(ai, Type) && valid_tparam_type(ai))
         return TypeEq
     end
     if isa(ai, Type) && isconcretetype(ai)

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -122,7 +122,7 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState, validation
             rettype_const = result_type
             const_flags = 0x2
         elseif isconstType(result_type)
-            rettype_const = result_type.parameters[1]
+            rettype_const = type_parameter(result_type)
             const_flags = 0x2
         elseif isa(result_type, PartialStruct)
             rettype_const = (_getundefs(result_type), result_type.fields)
@@ -1612,6 +1612,20 @@ markinspected!(queue::CompilationQueue, item) = push!(queue.inspected, item)
 isinspected(queue::CompilationQueue, item) = item in queue.inspected
 Base.isempty(queue::CompilationQueue) = isempty(queue.tocompile)
 
+function has_valid_abi_sparams(mi::MethodInstance)
+    isa(mi.specTypes, UnionAll) && return false
+    def = mi.def
+    isa(def, Method) || return true
+    unionall_depth(def.sig) == length(mi.sparam_vals) || return false
+    for i = 1:length(mi.sparam_vals)
+        sp = mi.sparam_vals[i]
+        if isa(sp, SimpleVector) || isvarargtype(sp)
+            return false
+        end
+    end
+    return true
+end
+
 # collect a list of all code that is needed along with CodeInstance to codegen it fully
 function collectinvokes!(workqueue::CompilationQueue, ci::CodeInfo, sptypes::Vector{VarState};
                          invokelatest_queue::Union{CompilationQueue,Nothing} = nothing)
@@ -1621,7 +1635,8 @@ function collectinvokes!(workqueue::CompilationQueue, ci::CodeInfo, sptypes::Vec
         isexpr(stmt, :(=)) && (stmt = stmt.args[2])
         if isexpr(stmt, :invoke) || isexpr(stmt, :invoke_modify)
             edge = stmt.args[1]
-            edge isa CodeInstance && isdefined(edge, :inferred) && push!(workqueue, edge)
+            edge isa CodeInstance && isdefined(edge, :inferred) &&
+                has_valid_abi_sparams(get_ci_mi(edge)) && push!(workqueue, edge)
         end
 
         invokelatest_queue === nothing && continue
@@ -1684,6 +1699,10 @@ function add_codeinsts_to_jit!(interp::AbstractInterpreter, ci, source_mode::UIn
         callee = pop!(workqueue)
         ci_has_invoke(callee) && continue
         isinspected(workqueue, callee) && continue
+        if !has_valid_abi_sparams(get_ci_mi(callee))
+            markinspected!(workqueue, callee)
+            continue
+        end
         src = ci_get_source(interp, callee)
         if !isa(src, CodeInfo)
             newcallee = typeinf_ext(workqueue.interp, callee.def, source_mode) # always SOURCE_MODE_ABI
@@ -1769,6 +1788,10 @@ function compile!(codeinfos::Vector{Any}, workqueue::CompilationQueue;
             callee = item
             isinspected(workqueue, callee) && continue
             mi = get_ci_mi(callee)
+            if !has_valid_abi_sparams(mi)
+                markinspected!(workqueue, callee)
+                continue
+            end
             # now make sure everything has source code, if desired
             if use_const_api(callee)
                 src = codeinfo_for_const(interp, mi, WorldRange(callee.min_world, callee.max_world), callee.edges, callee.rettype_const)

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -456,7 +456,8 @@ end
         return isa(b, Type) && a.typ <: b
     elseif isa(b, PartialStruct)
         if isa(a, Const)
-            widea = widenconst(a)::DataType
+            widea = widenconst(a)
+            isa(widea, DataType) || return false
             wideb = widenconst(b)
             wideb′ = unwrap_unionall(wideb)::DataType
             widea.name === wideb′.name || return false
@@ -596,7 +597,7 @@ end
 # lattice operations
 # ==================
 
-@nospecializeinfer function tmeet(lattice::PartialsLattice, @nospecialize(v), @nospecialize(t::Type))
+@nospecializeinfer function tmeet(lattice::PartialsLattice, @nospecialize(v), @nospecialize(t::Kind))
     if isa(v, PartialStruct)
         has_free_typevars(t) && return v
         widev = widenconst(v)
@@ -634,7 +635,7 @@ end
     return tmeet(widenlattice(lattice), v, t)
 end
 
-@nospecializeinfer function tmeet(lattice::ConstsLattice, @nospecialize(v), @nospecialize(t::Type))
+@nospecializeinfer function tmeet(lattice::ConstsLattice, @nospecialize(v), @nospecialize(t::Kind))
     if isa(v, Const)
         if !has_free_typevars(t) && !isa(v.val, t)
             return Bottom
@@ -644,7 +645,7 @@ end
     tmeet(widenlattice(lattice), widenconst(v), t)
 end
 
-@nospecializeinfer function tmeet(lattice::ConditionalsLattice, @nospecialize(v), @nospecialize(t::Type))
+@nospecializeinfer function tmeet(lattice::ConditionalsLattice, @nospecialize(v), @nospecialize(t::Kind))
     if isa(v, Conditional)
         if !(Bool <: t)
             return Bottom
@@ -654,26 +655,26 @@ end
     tmeet(widenlattice(lattice), v, t)
 end
 
-@nospecializeinfer function tmeet(𝕃::MustAliasesLattice, @nospecialize(v), @nospecialize(t::Type))
+@nospecializeinfer function tmeet(𝕃::MustAliasesLattice, @nospecialize(v), @nospecialize(t::Kind))
     if isa(v, MustAlias)
         v = widenmustalias(v)
     end
     return tmeet(widenlattice(𝕃), v, t)
 end
 
-@nospecializeinfer function tmeet(lattice::InferenceLattice, @nospecialize(v), @nospecialize(t::Type))
+@nospecializeinfer function tmeet(lattice::InferenceLattice, @nospecialize(v), @nospecialize(t::Kind))
     # TODO: This can probably happen and should be handled
     @assert !isa(v, LimitedAccuracy)
     tmeet(widenlattice(lattice), v, t)
 end
 
-@nospecializeinfer function tmeet(lattice::InterConditionalsLattice, @nospecialize(v), @nospecialize(t::Type))
+@nospecializeinfer function tmeet(lattice::InterConditionalsLattice, @nospecialize(v), @nospecialize(t::Kind))
     # TODO: This can probably happen and should be handled
     @assert !isa(v, AnyConditional)
     tmeet(widenlattice(lattice), v, t)
 end
 
-@nospecializeinfer function tmeet(𝕃::InterMustAliasesLattice, @nospecialize(v), @nospecialize(t::Type))
+@nospecializeinfer function tmeet(𝕃::InterMustAliasesLattice, @nospecialize(v), @nospecialize(t::Kind))
     if isa(v, InterMustAlias)
         v = widenmustalias(v)
     end
@@ -691,7 +692,7 @@ widenconst(c::Const) = (v = c.val; isa(v, Type) ? Type{v} : typeof(v))
 widenconst(::PartialTypeVar) = TypeVar
 widenconst(t::Core.PartialStruct) = t.typ
 widenconst(t::PartialOpaque) = t.typ
-@nospecializeinfer widenconst(@nospecialize t::Type) = t
+@nospecializeinfer widenconst(@nospecialize t::Kind) = t
 widenconst(::TypeVar) = error("unhandled TypeVar")
 widenconst(::TypeofVararg) = error("unhandled Vararg")
 widenconst(::LimitedAccuracy) = error("unhandled LimitedAccuracy")

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -597,7 +597,7 @@ end
 # lattice operations
 # ==================
 
-@nospecializeinfer function tmeet(lattice::PartialsLattice, @nospecialize(v), @nospecialize(t::Kind))
+@nospecializeinfer function tmeet(lattice::PartialsLattice, @nospecialize(v), @nospecialize(t::AnyType))
     if isa(v, PartialStruct)
         has_free_typevars(t) && return v
         widev = widenconst(v)
@@ -635,7 +635,7 @@ end
     return tmeet(widenlattice(lattice), v, t)
 end
 
-@nospecializeinfer function tmeet(lattice::ConstsLattice, @nospecialize(v), @nospecialize(t::Kind))
+@nospecializeinfer function tmeet(lattice::ConstsLattice, @nospecialize(v), @nospecialize(t::AnyType))
     if isa(v, Const)
         if !has_free_typevars(t) && !isa(v.val, t)
             return Bottom
@@ -645,7 +645,7 @@ end
     tmeet(widenlattice(lattice), widenconst(v), t)
 end
 
-@nospecializeinfer function tmeet(lattice::ConditionalsLattice, @nospecialize(v), @nospecialize(t::Kind))
+@nospecializeinfer function tmeet(lattice::ConditionalsLattice, @nospecialize(v), @nospecialize(t::AnyType))
     if isa(v, Conditional)
         if !(Bool <: t)
             return Bottom
@@ -655,26 +655,26 @@ end
     tmeet(widenlattice(lattice), v, t)
 end
 
-@nospecializeinfer function tmeet(𝕃::MustAliasesLattice, @nospecialize(v), @nospecialize(t::Kind))
+@nospecializeinfer function tmeet(𝕃::MustAliasesLattice, @nospecialize(v), @nospecialize(t::AnyType))
     if isa(v, MustAlias)
         v = widenmustalias(v)
     end
     return tmeet(widenlattice(𝕃), v, t)
 end
 
-@nospecializeinfer function tmeet(lattice::InferenceLattice, @nospecialize(v), @nospecialize(t::Kind))
+@nospecializeinfer function tmeet(lattice::InferenceLattice, @nospecialize(v), @nospecialize(t::AnyType))
     # TODO: This can probably happen and should be handled
     @assert !isa(v, LimitedAccuracy)
     tmeet(widenlattice(lattice), v, t)
 end
 
-@nospecializeinfer function tmeet(lattice::InterConditionalsLattice, @nospecialize(v), @nospecialize(t::Kind))
+@nospecializeinfer function tmeet(lattice::InterConditionalsLattice, @nospecialize(v), @nospecialize(t::AnyType))
     # TODO: This can probably happen and should be handled
     @assert !isa(v, AnyConditional)
     tmeet(widenlattice(lattice), v, t)
 end
 
-@nospecializeinfer function tmeet(𝕃::InterMustAliasesLattice, @nospecialize(v), @nospecialize(t::Kind))
+@nospecializeinfer function tmeet(𝕃::InterMustAliasesLattice, @nospecialize(v), @nospecialize(t::AnyType))
     if isa(v, InterMustAlias)
         v = widenmustalias(v)
     end
@@ -692,7 +692,7 @@ widenconst(c::Const) = (v = c.val; isa(v, Type) ? Type{v} : typeof(v))
 widenconst(::PartialTypeVar) = TypeVar
 widenconst(t::Core.PartialStruct) = t.typ
 widenconst(t::PartialOpaque) = t.typ
-@nospecializeinfer widenconst(@nospecialize t::Kind) = t
+@nospecializeinfer widenconst(@nospecialize t::AnyType) = t
 widenconst(::TypeVar) = error("unhandled TypeVar")
 widenconst(::TypeofVararg) = error("unhandled Vararg")
 widenconst(::LimitedAccuracy) = error("unhandled LimitedAccuracy")

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -86,7 +86,7 @@ end
 # The goal of this function is to return a type of greater "size" and less "complexity" than
 # both `t` or `c` over the lattice defined by `sources`, `depth`, and `allowed_tuplelen`.
 function _limit_type_size(@nospecialize(t), @nospecialize(c), sources::SimpleVector, depth::Int, allowed_tuplelen::Int)
-    @assert isa(t, Kind) && isa(c, Kind) "unhandled TypeVar / Vararg"
+    @assert isa(t, AnyType) && isa(c, AnyType) "unhandled TypeVar / Vararg"
     if t === c
         return t # quick egal test
     elseif t === Union{}
@@ -105,12 +105,12 @@ function _limit_type_size(@nospecialize(t), @nospecialize(c), sources::SimpleVec
     # then unwrap `t`
     # NOTE that `TypeVar` / `Vararg` are handled separately to catch the logic errors
     if isa(c, UnionAll)
-        return __limit_type_size(t, c.body, sources, depth, allowed_tuplelen)::Kind
+        return __limit_type_size(t, c.body, sources, depth, allowed_tuplelen)::AnyType
     end
     if isa(t, UnionAll)
         tbody = __limit_type_size(t.body, c, sources, depth, allowed_tuplelen)
         tbody === t.body && return t
-        return UnionAll(t.var, tbody)::Kind
+        return UnionAll(t.var, tbody)::AnyType
     elseif isa(t, Union)
         if isa(c, Union)
             a = __limit_type_size(t.a, c.a, sources, depth, allowed_tuplelen)
@@ -739,7 +739,7 @@ end
     return tmerge(wl, typea, typeb)
 end
 
-@nospecializeinfer function tmerge(lattice::JLTypeLattice, @nospecialize(typea::Kind), @nospecialize(typeb::Kind))
+@nospecializeinfer function tmerge(lattice::JLTypeLattice, @nospecialize(typea::AnyType), @nospecialize(typeb::AnyType))
     # it's always ok to form a Union of two concrete types
     act = isconcretetype(typea)
     bct = isconcretetype(typeb)
@@ -782,7 +782,7 @@ end
     return a.name === bname ? bname : nothing
 end
 
-@nospecializeinfer @noinline function tmerge_types_slow(@nospecialize(typea::Kind), @nospecialize(typeb::Kind))
+@nospecializeinfer @noinline function tmerge_types_slow(@nospecialize(typea::AnyType), @nospecialize(typeb::AnyType))
     # collect the list of types from past tmerge calls returning Union
     # and then reduce over that list
     types = Any[]

--- a/Compiler/src/typelimits.jl
+++ b/Compiler/src/typelimits.jl
@@ -53,6 +53,8 @@ function is_derived_type(@nospecialize(t), @nospecialize(c), mindepth::Int)
         # see if it is derived from the body
         # also handle the var here, since this construct bounds the mindepth to the smallest possible value
         return is_derived_type(t, c.var.ub, mindepth) || is_derived_type(t, c.body, mindepth)
+    elseif isType(c)
+        return is_derived_type(t, type_parameter(c), mindepth)
     elseif isa(c, DataType)
         if mindepth > 0
             mindepth -= 1
@@ -84,7 +86,7 @@ end
 # The goal of this function is to return a type of greater "size" and less "complexity" than
 # both `t` or `c` over the lattice defined by `sources`, `depth`, and `allowed_tuplelen`.
 function _limit_type_size(@nospecialize(t), @nospecialize(c), sources::SimpleVector, depth::Int, allowed_tuplelen::Int)
-    @assert isa(t, Type) && isa(c, Type) "unhandled TypeVar / Vararg"
+    @assert isa(t, Kind) && isa(c, Kind) "unhandled TypeVar / Vararg"
     if t === c
         return t # quick egal test
     elseif t === Union{}
@@ -103,45 +105,45 @@ function _limit_type_size(@nospecialize(t), @nospecialize(c), sources::SimpleVec
     # then unwrap `t`
     # NOTE that `TypeVar` / `Vararg` are handled separately to catch the logic errors
     if isa(c, UnionAll)
-        return __limit_type_size(t, c.body, sources, depth, allowed_tuplelen)::Type
+        return __limit_type_size(t, c.body, sources, depth, allowed_tuplelen)::Kind
     end
     if isa(t, UnionAll)
         tbody = __limit_type_size(t.body, c, sources, depth, allowed_tuplelen)
         tbody === t.body && return t
-        return UnionAll(t.var, tbody)::Type
+        return UnionAll(t.var, tbody)::Kind
     elseif isa(t, Union)
         if isa(c, Union)
             a = __limit_type_size(t.a, c.a, sources, depth, allowed_tuplelen)
             b = __limit_type_size(t.b, c.b, sources, depth, allowed_tuplelen)
             return Union{a, b}
         end
+    elseif isType(t)
+        # Type is fairly important, so do not widen it as fast as other types if avoidable
+        tt = type_parameter(t)
+        ttu = unwrap_unionall(tt) # TODO: use argument_datatype(tt) after #50692 fixed
+        # must forbid nesting through this if we detect that potentially occurring
+        # we already know !is_derived_type_from_any so refuse to recurse here
+        if isType(ttu)
+            return Type{<:Type}
+        elseif !isa(ttu, DataType)
+            return Type
+        end
+        # try to peek into c to get a comparison object, but if we can't perhaps t is already simple enough on its own
+        if isType(c)
+            ct = type_parameter(c)
+        else
+            ct = Union{}
+        end
+        Qt = __limit_type_size(tt, ct, sources, depth + 1, 0)
+        Qt === tt && return t
+        Qt === Any && return Type
+        # Can't form Type{<:Qt} just yet, without first make sure we limited the depth
+        # enough, since this moves Qt outside of Type for is_derived_type_from_any
+        Qt = __limit_type_size(tt, ct, sources, depth + 2, 0)
+        Qt === Any && return Type
+        return Type{<:Qt}
     elseif isa(t, DataType)
-        if isType(t)
-            # Type is fairly important, so do not widen it as fast as other types if avoidable
-            tt = t.parameters[1]
-            ttu = unwrap_unionall(tt) # TODO: use argument_datatype(tt) after #50692 fixed
-            # must forbid nesting through this if we detect that potentially occurring
-            # we already know !is_derived_type_from_any so refuse to recurse here
-            if !isa(ttu, DataType)
-                return Type
-            elseif isType(ttu)
-                return Type{<:Type}
-            end
-            # try to peek into c to get a comparison object, but if we can't perhaps t is already simple enough on its own
-            if isType(c)
-                ct = c.parameters[1]
-            else
-                ct = Union{}
-            end
-            Qt = __limit_type_size(tt, ct, sources, depth + 1, 0)
-            Qt === tt && return t
-            Qt === Any && return Type
-            # Can't form Type{<:Qt} just yet, without first make sure we limited the depth
-            # enough, since this moves Qt outside of Type for is_derived_type_from_any
-            Qt = __limit_type_size(tt, ct, sources, depth + 2, 0)
-            Qt === Any && return Type
-            return Type{<:Qt}
-        elseif isa(c, DataType)
+        if isa(c, DataType)
             tP = t.parameters
             cP = c.parameters
             if t.name === c.name && !isempty(cP)
@@ -190,6 +192,8 @@ end
 
 # helper function of `_limit_type_size`, which has the right to take and return `TypeVar` / `Vararg`
 function __limit_type_size(@nospecialize(t), @nospecialize(c), sources::SimpleVector, depth::Int, allowed_tuplelen::Int)
+    isa(t, SimpleVector) && (t = t[1])
+    isa(c, SimpleVector) && (c = c[1])
     cN = 0
     if isvarargtype(c) # Tuple{Vararg{T}} --> Tuple{T} is OK
         isdefined(c, :N) && (cN = c.N)
@@ -263,27 +267,28 @@ function type_more_complex(@nospecialize(t), @nospecialize(c), sources::SimpleVe
     elseif isa(t, Int) && isa(c, Int)
         return t !== 1 && !(0 <= t < c) # alternatively, could use !(abs(t) <= abs(c) || abs(t) < n) for some n
     end
+    if isType(t)
+        # Type is fairly important, so do not widen it as fast as other types if avoidable
+        tt = type_parameter(t)
+        # ttu = unwrap_unionall(tt) # TODO: use argument_datatype(tt) after #50692 fixed
+        if isType(c)
+            ct = type_parameter(c)
+        else
+            ct = Union{}
+            tupledepth == 0 && return true # cannot allow nesting
+        end
+        # allow creating variation within a nested Type, but not very deep
+        if tupledepth > 1
+            tupledepth = 1
+        else
+            tupledepth = 0
+        end
+        return type_more_complex(tt, ct, sources, depth + 1, tupledepth, 0)
+    end
     # base case for data types
     if isa(t, DataType)
         tP = t.parameters
-        if isType(t)
-            # Type is fairly important, so do not widen it as fast as other types if avoidable
-            tt = tP[1]
-            # ttu = unwrap_unionall(tt) # TODO: use argument_datatype(tt) after #50692 fixed
-            if isType(c)
-                ct = c.parameters[1]
-            else
-                ct = Union{}
-                tupledepth == 0 && return true # cannot allow nesting
-            end
-            # allow creating variation within a nested Type, but not very deep
-            if tupledepth > 1
-                tupledepth = 1
-            else
-                tupledepth = 0
-            end
-            return type_more_complex(tt, ct, sources, depth + 1, tupledepth, 0)
-        elseif isa(c, DataType) && t.name === c.name
+        if isa(c, DataType) && t.name === c.name
             cP = c.parameters
             length(cP) < length(tP) && return true
             isempty(tP) && return false
@@ -734,7 +739,7 @@ end
     return tmerge(wl, typea, typeb)
 end
 
-@nospecializeinfer function tmerge(lattice::JLTypeLattice, @nospecialize(typea::Type), @nospecialize(typeb::Type))
+@nospecializeinfer function tmerge(lattice::JLTypeLattice, @nospecialize(typea::Kind), @nospecialize(typeb::Kind))
     # it's always ok to form a Union of two concrete types
     act = isconcretetype(typea)
     bct = isconcretetype(typeb)
@@ -777,26 +782,34 @@ end
     return a.name === bname ? bname : nothing
 end
 
-@nospecializeinfer @noinline function tmerge_types_slow(@nospecialize(typea::Type), @nospecialize(typeb::Type))
+@nospecializeinfer @noinline function tmerge_types_slow(@nospecialize(typea::Kind), @nospecialize(typeb::Kind))
     # collect the list of types from past tmerge calls returning Union
     # and then reduce over that list
     types = Any[]
     _uniontypes(typea, types)
     _uniontypes(typeb, types)
     typenames = Vector{Core.TypeName}(undef, length(types))
+    all_datatypes = true
     for i in 1:length(types)
         # check that we will be able to analyze (and simplify) everything
-        # bail if everything isn't a well-formed DataType
+        # bail if everything isn't a well-formed nominal kind
         ti = types[i]
         uw = unwrap_unionall(ti)
-        uw isa DataType || return Any
-        ti <: uw.name.wrapper || return Any
-        typenames[i] = uw.name
+        if uw isa DataType
+            ti <: uw.name.wrapper || return Any
+            typenames[i] = uw.name
+        elseif isType(uw)
+            typenames[i] = TypeEq.name
+            all_datatypes = false
+        else
+            return Any
+        end
     end
     u = Union{types...}
     if issimpleenoughtype(u)
         return u
     end
+    all_datatypes || return Any
     # see if any of the union elements have the same TypeName
     # in which case, simplify this tmerge by replacing it with
     # the widest possible version of itself (the wrapper)

--- a/Compiler/src/typeutils.jl
+++ b/Compiler/src/typeutils.jl
@@ -480,6 +480,7 @@ function _is_immutable_type(@nospecialize ty)
     if isa(ty, Union)
         return _is_immutable_type(ty.a) && _is_immutable_type(ty.b)
     end
+    isType(ty) && return false
     return !isabstracttype(ty) && !ismutabletype(ty)
 end
 

--- a/Compiler/src/typeutils.jl
+++ b/Compiler/src/typeutils.jl
@@ -189,6 +189,7 @@ function _typename(a::Union)
 end
 _typename(union::UnionAll) = _typename(union.body)
 _typename(a::DataType) = Const(a.name)
+_typename(a::TypeEq) = Core.TypeName
 
 function tuple_tail_elem(𝕃::AbstractLattice, @nospecialize(init), ct::Vector{Any})
     t = init

--- a/Compiler/src/typeutils.jl
+++ b/Compiler/src/typeutils.jl
@@ -6,7 +6,7 @@
 
 # true if Type{T} is inlineable as constant T
 # requires that T is a singleton, s.t. T == S implies T === S
-isconstType(@nospecialize t) = isType(t) && hasuniquerep(t.parameters[1])
+isconstType(@nospecialize t) = isType(t) && hasuniquerep(type_parameter(t))
 
 # test whether type T has a unique representation, s.t. T == S implies T === S
 function hasuniquerep(@nospecialize t)
@@ -15,6 +15,11 @@ function hasuniquerep(@nospecialize t)
     t === typeof(Union{}) && return false
     t === Union{} && return true
     isa(t, TypeVar) && return false # TypeVars are identified by address, not equality
+    if isType(t)
+        p = type_parameter(t)
+        (p === Union{} || p === typeof(Union{})) && return false
+        return !has_free_typevars(p)
+    end
     iskindtype(typeof(t)) || return true # non-types are always compared by egal in the type system
     isconcretetype(t) && return true # these are also interned and pointer comparable
     if isa(t, DataType) && t.name !== Tuple.name && !isvarargtype(t) # invariant DataTypes
@@ -32,8 +37,8 @@ we have `isa(S, DataType)`. In particular, if a statement is typed as `Type{t}`
 will be a `DataType` at runtime (and not e.g. a `Union` or `UnionAll` typeequal to it).
 """
 function isTypeDataType(@nospecialize t)
-    isa(t, DataType) || return false
     isType(t) && return false
+    isa(t, DataType) || return false
     # Could be Union{} at runtime
     t === Core.TypeofBottom && return false
     # Return true if `t` is not covariant
@@ -46,7 +51,7 @@ has_extended_info(@nospecialize x) = (!isa(x, Type) && !isvarargtype(x)) || isTy
 # some of these queries, this check can be used to somewhat protect against making incorrect
 # decisions based on incorrect subtyping. Note that this check, itself, is broken for
 # certain combinations of `a` and `b` where one/both isa/are `Union`/`UnionAll` type(s)s.
-isnotbrokensubtype(@nospecialize(a), @nospecialize(b)) = (!iskindtype(b) || !isType(a) || hasuniquerep(a.parameters[1]) || b <: a)
+isnotbrokensubtype(@nospecialize(a), @nospecialize(b)) = (!iskindtype(b) || !isType(a) || hasuniquerep(type_parameter(a)) || b <: a)
 
 function argtypes_to_type(argtypes::Vector{Any})
     argtypes = anymap(@nospecialize(a) -> isvarargtype(a) ? a : widenconst(a), argtypes)
@@ -76,11 +81,13 @@ function valid_as_lattice(@nospecialize(x), astag::Bool=false)
         # operations that might remove the Union itself)
         return true
     end
+    if isType(x)
+        p = type_parameter(x)
+        p isa Type || p isa TypeVar || return false
+        return true
+    end
     if x isa DataType
-        if isType(x)
-            p = x.parameters[1]
-            p isa Type || p isa TypeVar || return false
-        elseif astag && isstructtype(x)
+        if astag && isstructtype(x)
             datatype_fieldtypes(x) # force computation of has_concrete_subtype to be updated now
             return has_concrete_subtype(x)
         end

--- a/Compiler/src/utilities.jl
+++ b/Compiler/src/utilities.jl
@@ -214,7 +214,7 @@ is_no_constprop(method::Union{Method,CodeInfo}) = method.constprop == 0x02
     if isa(ft, Const)
         return ft.val
     elseif isconstType(ft)
-        return ft.parameters[1]
+        return type_parameter(ft)
     elseif issingletontype(ft)
         return ft.instance
     end
@@ -226,7 +226,7 @@ end
         if issingletontype(t)
             return Const(t.instance)
         elseif isconstType(t)
-            return Const(t.parameters[1])
+            return Const(type_parameter(t))
         end
     end
     return t

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -307,8 +307,8 @@ let
     fT(x::T) where {T} = T
     @test fT(Any) === DataType
     @test fT(Int) === DataType
-    @test fT(Type{Any}) === DataType
-    @test fT(Type{Int}) === DataType
+    @test fT(Type{Any}) === Core.TypeEq
+    @test fT(Type{Int}) === Core.TypeEq
 
     ff(x::Type{T}) where {T} = T
     @test ff(Type{Any}) === Type{Any}
@@ -506,6 +506,11 @@ f11366(x::Type{Ref{T}}) where {T} = Ref{x}
 let f(T) = Type{T}
     @test Base.return_types(f, Tuple{Type{Int}}) == Any[Type{Type{Int}}]
 end
+
+# Keep tuple iteration precise when joining ordinary values with kind values.
+@test Core.Compiler.tmerge(String, Type) == Union{String, Type}
+@test Base.return_types(iterate, Tuple{Tuple{String, Type}, Int}) ==
+    Any[Union{Nothing, Tuple{Union{String, Type}, Int}}]
 
 # issue #9222
 function SimpleTest9222(pdedata, mu_actual::Vector{T1},
@@ -1563,7 +1568,7 @@ let nfields_tfunc(@nospecialize xs...) =
     @test nfields_tfunc(Number) === Int
     @test nfields_tfunc(Int) === Const(0)
     @test nfields_tfunc(Complex) === Const(2)
-    @test nfields_tfunc(Type{Type{Int}}) === Const(nfields(DataType))
+    @test nfields_tfunc(Type{Type{Int}}) === Const(nfields(Type{Int}))
     @test nfields_tfunc(UnionAll) === Const(2)
     @test nfields_tfunc(DataType) === Const(nfields(DataType))
     @test nfields_tfunc(Type{Int}) === Const(nfields(DataType))

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -827,7 +827,7 @@ end
 # test single, non-dispatchtuple callsite inlining
 
 @constprop :none @inline test_single_nondispatchtuple(@nospecialize(t)) =
-    isa(t, DataType) && t.name === Type.body.name
+    isa(t, DataType) && t.name === Core.TypeEq.name
 let
     src = code_typed1((Any,)) do x
         test_single_nondispatchtuple(x)
@@ -838,7 +838,7 @@ let
 end
 
 @constprop :aggressive @inline test_single_nondispatchtuple(c, @nospecialize(t)) =
-    c && isa(t, DataType) && t.name === Type.body.name
+    c && isa(t, DataType) && t.name === Core.TypeEq.name
 let
     src = code_typed1((Any,)) do x
         test_single_nondispatchtuple(true, x)
@@ -2315,13 +2315,13 @@ end
 path = Ref{Symbol}(:unknown)
 function f59018_generator(x)
     if @generated
-        if x isa DataType && x.name === Type.body.name
+        if x isa Core.TypeEq
             path[] = :generator
-            return Core.sizeof(x.parameters[1])
+            return Core.sizeof(x.T)
         end
     else
         path[] = :fallback
-        return Core.sizeof(x.parameters[1])
+        return Core.sizeof(x isa Core.TypeEq ? Base.type_parameter(x) : x.parameters[1])
     end
 end
 f59018() = f59018_generator(Base.inferencebarrier(Int64))

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -3,8 +3,8 @@
 # commented-out definitions are implemented in C
 
 #abstract type Any <: Any end
-#abstract type Kind end
-#struct TypeEq <: Kind
+#abstract type AnyType end
+#struct TypeEq <: AnyType
 #    T
 #end
 #const Type = TypeEq(T) where T
@@ -19,7 +19,7 @@
 #    name::Symbol
 #end
 
-#mutable struct DataType <: Kind
+#mutable struct DataType <: AnyType
 #    name::TypeName
 #    super::Type
 #    parameters::Tuple
@@ -33,7 +33,7 @@
 #    pointerfree::Bool
 #end
 
-#struct Union <: Kind
+#struct Union <: AnyType
 #    a
 #    b
 #end
@@ -44,7 +44,7 @@
 #    ub::Type
 #end
 
-#struct UnionAll <: Kind
+#struct UnionAll <: AnyType
 #    var::TypeVar
 #    body
 #end

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -3,7 +3,11 @@
 # commented-out definitions are implemented in C
 
 #abstract type Any <: Any end
-#abstract type Type{T} end
+#abstract type Kind end
+#struct TypeEq <: Kind
+#    T
+#end
+#const Type = TypeEq(T) where T
 
 #abstract type Vararg{T} end
 
@@ -15,7 +19,7 @@
 #    name::Symbol
 #end
 
-#mutable struct DataType <: Type
+#mutable struct DataType <: Kind
 #    name::TypeName
 #    super::Type
 #    parameters::Tuple
@@ -29,7 +33,7 @@
 #    pointerfree::Bool
 #end
 
-#struct Union <: Type
+#struct Union <: Kind
 #    a
 #    b
 #end
@@ -40,7 +44,7 @@
 #    ub::Type
 #end
 
-#struct UnionAll
+#struct UnionAll <: Kind
 #    var::TypeVar
 #    body
 #end
@@ -206,8 +210,8 @@
 
 export
     # key types
-    Any, DataType, Vararg, NTuple,
-    Tuple, Type, UnionAll, TypeVar, Union, Nothing, Cvoid,
+    Any, Kind, TypeEq, Type, DataType, Vararg, NTuple,
+    Tuple, UnionAll, TypeVar, Union, Nothing, Cvoid,
     AbstractArray, DenseArray, NamedTuple, Pair,
     # special objects
     Function, Method, Module, Symbol, Task, UndefInitializer, undef, WeakRef, VecElement,

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -210,7 +210,7 @@
 
 export
     # key types
-    Any, Kind, TypeEq, Type, DataType, Vararg, NTuple,
+    Any, TypeEq, Type, DataType, Vararg, NTuple,
     Tuple, UnionAll, TypeVar, Union, Nothing, Cvoid,
     AbstractArray, DenseArray, NamedTuple, Pair,
     # special objects

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -626,4 +626,9 @@ end
     return Core
 end
 
+@noinline function isabstracttype(x::TypeEq)
+    depwarn_if_not_pure("calling `isabstracttype` on a `Type{...}` is deprecated; `Type{}` is now a kind. If for detection, use `Base.isType(x)`.", :isabstracttype)
+    return true
+end
+
 # END 1.14 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -583,4 +583,18 @@ function explicit_manifest_entry_path(args...)
     return spec.path
 end
 
+@noinline function getproperty(x::TypeEq, s::Symbol)
+    if s === :parameters
+        depwarn("accessing `Type.parameters` is deprecated; use `Base.type_parameter(x)` instead", :getproperty)
+        return Core.svec(type_parameter(x))
+    elseif s === :name
+        depwarn("accessing `Type.name` is deprecated without replacement. Examine the callsite.", :getproperty)
+        return TypeEq.name
+    elseif s === :hash
+        depwarn("accessing `Type.hash` is deprecated; use `Base._jl_type_cache_hash(x)` instead", :getproperty)
+        return reinterpret(Int32, UInt32(_jl_type_cache_hash(x)))
+    end
+    return getfield(x, s)
+end
+
 # END 1.14 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -583,32 +583,46 @@ function explicit_manifest_entry_path(args...)
     return spec.path
 end
 
+# These functions get called from generated functions a lot where printing causes errors. We have the following options:
+# 1. Use ordinary depwarn. This breaks generated functions that use these deprecations, defeating the point.
+# 2. Always error in generated functions. This would probably be best (the depwarn would run at expansion time),
+#    but it completely breaks inference of these generated functions and some of them are important.
+# 3. Never print a warning in generated functions (but do throw the error if --depwarn=error).
+#
+# We choose option 3. It's not ideal, because users that never use --depawarn=error will never see the warning,
+# but it's the least bad tradeoff among the lot.
+function depwarn_if_not_pure(args...)
+    opts = JLOptions()
+    opts.depwarn != 2 && ccall(:jl_is_in_pure_context, Bool, ()) && return
+    depwarn(args...)
+end
+
 @noinline function getproperty(x::TypeEq, s::Symbol)
     if s === :parameters
-        depwarn("accessing `Type.parameters` is deprecated; use `Base.type_parameter(x)` instead", :getproperty)
+        depwarn_if_not_pure("accessing `Type.parameters` is deprecated; use `Base.type_parameter(x)` instead", :getproperty)
         return Core.svec(type_parameter(x))
     elseif s === :name
-        depwarn("accessing `Type.name` is deprecated without replacement. Examine the callsite.", :getproperty)
+        depwarn_if_not_pure("accessing `Type.name` is deprecated without replacement. If for detection, use `Base.isType(x)`.", :getproperty)
         return TypeEq.name
     elseif s === :hash
-        depwarn("accessing `Type.hash` is deprecated; use `Base._jl_type_cache_hash(x)` instead", :getproperty)
+        depwarn_if_not_pure("accessing `Type.hash` is deprecated; use `Base._jl_type_cache_hash(x)` instead", :getproperty)
         return reinterpret(Int32, UInt32(_jl_type_cache_hash(x)))
     end
     return getfield(x, s)
 end
 
 @noinline function typename(x::TypeEq)
-    depwarn("calling `typename` on `Type` is deprecated; use `Base.isType(x)` instead", :typename)
+    depwarn_if_not_pure("calling `typename` on `Type` is deprecated. If for detection, use `Base.isType(x)`.", :typename)
     return TypeEq.name
 end
 
 @noinline function nameof(x::TypeEq)
-    depwarn("calling `nameof` on `Type` is deprecated; use `Base.isType(x)` instead", :nameof)
+    depwarn_if_not_pure("calling `nameof` on `Type` is deprecated. If for detection, use `Base.isType(x)`.", :nameof)
     return :Type
 end
 
 @noinline function parentmodule(x::TypeEq)
-    depwarn("calling `parentmodule` on `Type` is deprecated; use `Base.isType(x)` instead", :parentmodule)
+    depwarn_if_not_pure("calling `parentmodule` on `Type` is deprecated. If for detection, use `Base.isType(x)`.", :parentmodule)
     return Core
 end
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -597,4 +597,19 @@ end
     return getfield(x, s)
 end
 
+@noinline function typename(x::TypeEq)
+    depwarn("calling `typename` on `Type` is deprecated; use `Base.isType(x)` instead", :typename)
+    return TypeEq.name
+end
+
+@noinline function nameof(x::TypeEq)
+    depwarn("calling `nameof` on `Type` is deprecated; use `Base.isType(x)` instead", :nameof)
+    return :Type
+end
+
+@noinline function parentmodule(x::TypeEq)
+    depwarn("calling `parentmodule` on `Type` is deprecated; use `Base.isType(x)` instead", :parentmodule)
+    return Core
+end
+
 # END 1.14 deprecations

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -470,6 +470,8 @@ function show_type_diff(io::IO, @nospecialize(sig), @nospecialize(called), use_c
     sig_params, called_params, alias = params
     if alias !== nothing
         show_typealias_name(io, alias)
+    elseif sig isa TypeEq
+        print(io, "Type")
     else
         show_type_name(io, (sig::DataType).name)
     end
@@ -543,6 +545,9 @@ end
 #   `(sa_env, ca_env, alias::GlobalRef)`           — both resolve to the same alias
 #   `nothing`                                      — bail; caller falls back to whole-subtree highlighting
 function descend_params(io::IO, @nospecialize(sig), @nospecialize(called))
+    if sig isa TypeEq && called isa TypeEq
+        return Core.svec(type_parameter(sig)), Core.svec(type_parameter(called)), nothing
+    end
     sig isa DataType && called isa DataType || return nothing
     sig.name === called.name || return nothing
     n = length(sig.parameters)
@@ -611,7 +616,7 @@ function show_shadowed_type_hint(io::IO, @nospecialize(f), san_arg_types_param::
             isa(expected, Core.TypeofVararg) && (expected = unwrapva(expected))
 
             e_dt = unwrap_unionall(expected); isa(e_dt, DataType) || continue
-            a_dt = unwrap_unionall(san_arg_types_param[i])::DataType
+            a_dt = unwrap_unionall(san_arg_types_param[i]); isa(a_dt, DataType) || continue
             e_tn, a_tn = e_dt.name, a_dt.name
 
             # actual shadowing heuristics
@@ -665,8 +670,11 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs=[])
     # pool MethodErrors for these two functions.
     if f === convert && !isempty(arg_types_param)
         at1 = arg_types_param[1]
-        if isType(at1) && !has_free_typevars(at1) && at1.parameters[1] isa Type
-            push!(funcs, (at1.parameters[1], arg_types_param[2:end]))
+        if isType(at1) && !has_free_typevars(at1)
+            at1p = type_parameter(at1)
+            if at1p isa Type
+                push!(funcs, (at1p, arg_types_param[2:end]))
+            end
         end
     end
 
@@ -1364,7 +1372,7 @@ function nonsetable_type_hint_handler(io, ex, arg_types, kwargs)
             printstyled(io, "a[1, 2]", color=:cyan)
             print(io, " rather than a[1][2]")
         elseif isType(T)
-            Tx = T.parameters[1]
+            Tx = type_parameter(T)
             print(io, "\nYou attempted to index the type $Tx, rather than an instance of the type. Make sure you create the type using its constructor: ")
             printstyled(io, "d = $Tx([...])", color=:cyan)
             print(io, " rather than d = $Tx")

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -3,7 +3,7 @@
 # Re-exports from `Core`
 export Core,
     # key types
-    Any, DataType, Vararg, NTuple,
+    Any, Kind, TypeEq, DataType, Vararg, NTuple,
     Tuple, Type, UnionAll, TypeVar, Union, Nothing, Cvoid,
     AbstractArray, DenseArray, NamedTuple, Pair,
     # special objects

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -3,7 +3,7 @@
 # Re-exports from `Core`
 export Core,
     # key types
-    Any, Kind, TypeEq, DataType, Vararg, NTuple,
+    Any, TypeEq, DataType, Vararg, NTuple,
     Tuple, Type, UnionAll, TypeVar, Union, Nothing, Cvoid,
     AbstractArray, DenseArray, NamedTuple, Pair,
     # special objects

--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -42,6 +42,7 @@ hash(w::WeakRef, h::UInt) = hash(w.value, h)
 
 # Types can't be deleted, so marking as total allows the compiler to look up the hash
 @noinline _jl_type_hash(T::Type) = @assume_effects :total ccall(:jl_type_hash, UInt, (Any,), T)
+@noinline _jl_type_cache_hash(T::Type) = @assume_effects :total ccall(:jl_type_cache_hash, UInt, (Any,), T)
 hash(T::Type, h::UInt) = hash(_jl_type_hash(T), h)
 hash(@nospecialize(data), h::UInt) = hash(objectid(data), h)
 

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -310,7 +310,7 @@ function _modulecolor(method::Method)
     # `ft` should be the type associated with the first argument in the method signature.
     # If it's `Type`, try to unwrap it again.
     if isType(ft)
-        ft = argument_datatype(ft.parameters[1])
+        ft = argument_datatype(type_parameter(ft))
     end
     if ft === nothing || parentmodule(method) === parentmodule(ft) !== Core
         return nothing

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -58,6 +58,8 @@ function typejoin(@nospecialize(a), @nospecialize(b))
         return typejoin(typejoin(a.a, a.b), b)
     elseif isa(b, Union)
         return typejoin(a, typejoin(b.a, b.b))
+    elseif isa(a, TypeEq) || isa(b, TypeEq)
+        return Type
     end
     # a and b are DataTypes
     # We have to hide Constant info from inference, see #44390
@@ -114,15 +116,6 @@ function typejoin(@nospecialize(a), @nospecialize(b))
         if _has_ancestor_typename(a, b.name)
             while !(a.name === b.name)
                 a = supertype(a)::DataType
-            end
-            if a.name === Type.body.name
-                ap = a.parameters[1]
-                bp = b.parameters[1]
-                if ((isa(ap,TypeVar) && ap.lb === Bottom && ap.ub === Any) ||
-                    (isa(bp,TypeVar) && bp.lb === Bottom && bp.ub === Any))
-                    # handle special Type{T} supertype
-                    return Type
-                end
             end
             aprimary = a.name.wrapper
             # join on parameters
@@ -191,7 +184,7 @@ Float64
 """
 function promote_typejoin(@nospecialize(a), @nospecialize(b))
     c = typejoin(_promote_typesubtract(a), _promote_typesubtract(b))
-    return Union{a, b, c}::Type
+    return Union{a, b, c}
 end
 _promote_typesubtract(@nospecialize(a)) =
     a === Any ? a :

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -59,7 +59,16 @@ function typejoin(@nospecialize(a), @nospecialize(b))
     elseif isa(b, Union)
         return typejoin(a, typejoin(b.a, b.b))
     elseif isa(a, TypeEq) || isa(b, TypeEq)
-        return Type
+        # At least one operand is a `Type{X}` kind. We have already ruled out
+        # `a <: b`, `b <: a`, and any `UnionAll`/`Union`/`TypeVar`. The least supertype
+        # of a `Type{X}` kind is the abstract `Type`, so widen each kind to `Type` and
+        # join the two by subtyping. We compare directly instead of recursing through
+        # `typejoin`, because `Type === (Type{T} where T)` would re-enter this branch and
+        # not terminate.
+        a = isa(a, TypeEq) ? Type : a
+        b = isa(b, TypeEq) ? Type : b
+        return a <: b ? b :
+               b <: a ? a : Any
     end
     # a and b are DataTypes
     # We have to hide Constant info from inference, see #44390

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -203,6 +203,8 @@ function promote_typejoin_union(::Type{T}) where T
     elseif T isa DataType
         T <: Tuple && return typejoin_union_tuple(T)
         return T
+    elseif isType(T)
+        return T
     else
         error("unreachable") # not a type??
     end

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1018,7 +1018,7 @@ function isdispatchelem(@nospecialize v)
 end
 
 isType(@nospecialize t) = isa(t, TypeEq)
-type_parameter(@nospecialize t) = getfield(t, :T)
+type_parameter(t::TypeEq) = getfield(t, :T)
 
 """
     isconcretetype(T)

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -1159,7 +1159,7 @@ We can use it to summarize information about a struct:
 julia> structinfo(T) = [(fieldoffset(T,i), fieldname(T,i), fieldtype(T,i)) for i = 1:fieldcount(T)];
 
 julia> structinfo(Base.Filesystem.StatStruct)
-14-element Vector{Tuple{UInt64, Symbol, AnyType}}:
+14-element Vector{Tuple{UInt64, Symbol, Core.AnyType}}:
  (0x0000000000000000, :desc, Union{RawFD, String})
  (0x0000000000000008, :device, UInt64)
  (0x0000000000000010, :inode, UInt64)

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -981,7 +981,7 @@ or [`Core.TypeofBottom`](@ref).
 
 All kinds are [concrete](@ref isconcretetype) because types are Julia values.
 """
-iskindtype(@nospecialize t) = (t === Kind || t === DataType || t === UnionAll || t === Union || t === TypeEq || t === typeof(Bottom))
+iskindtype(@nospecialize t) = (t === Core.Kind || t === DataType || t === UnionAll || t === Union || t === TypeEq || t === typeof(Bottom))
 
 """
     Base.isconcretedispatch(T)
@@ -1095,6 +1095,7 @@ false
 function isabstracttype(@nospecialize(t))
     @_total_meta
     t = unwrap_unionall(t)
+    isType(t) && return true
     # TODO: what to do for `Union`?
     return isa(t, DataType) && (t.name.flags & 0x1) == 0x1
 end
@@ -1383,7 +1384,7 @@ function to_tuple_type(@nospecialize(t))
             if isa(p, Core.TypeofVararg)
                 p = unwrapva(p)
             end
-            if !(isa(p, Kind) || isa(p, TypeVar))
+            if !(isa(p, Core.Kind) || isa(p, TypeVar))
                 error("argument tuple type must contain only types")
             end
         end
@@ -1413,7 +1414,7 @@ end
 
 Determine whether `t` is a Type for which one or more of its parameters is `Union{}`.
 """
-function has_bottom_parameter(@nospecialize(t::Kind))
+function has_bottom_parameter(@nospecialize(t::Core.Kind))
     t === Bottom && return true
     ty = typeof(t)
     if ty === DataType

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -981,7 +981,7 @@ or [`Core.TypeofBottom`](@ref).
 
 All kinds are [concrete](@ref isconcretetype) because types are Julia values.
 """
-iskindtype(@nospecialize t) = (t === Core.Kind || t === DataType || t === UnionAll || t === Union || t === TypeEq || t === typeof(Bottom))
+iskindtype(@nospecialize t) = (t === Core.AnyType || t === DataType || t === UnionAll || t === Union || t === TypeEq || t === typeof(Bottom))
 
 """
     Base.isconcretedispatch(T)
@@ -1159,7 +1159,7 @@ We can use it to summarize information about a struct:
 julia> structinfo(T) = [(fieldoffset(T,i), fieldname(T,i), fieldtype(T,i)) for i = 1:fieldcount(T)];
 
 julia> structinfo(Base.Filesystem.StatStruct)
-14-element Vector{Tuple{UInt64, Symbol, Kind}}:
+14-element Vector{Tuple{UInt64, Symbol, AnyType}}:
  (0x0000000000000000, :desc, Union{RawFD, String})
  (0x0000000000000008, :device, UInt64)
  (0x0000000000000010, :inode, UInt64)
@@ -1384,7 +1384,7 @@ function to_tuple_type(@nospecialize(t))
             if isa(p, Core.TypeofVararg)
                 p = unwrapva(p)
             end
-            if !(isa(p, Core.Kind) || isa(p, TypeVar))
+            if !(isa(p, Core.AnyType) || isa(p, TypeVar))
                 error("argument tuple type must contain only types")
             end
         end
@@ -1414,7 +1414,7 @@ end
 
 Determine whether `t` is a Type for which one or more of its parameters is `Union{}`.
 """
-function has_bottom_parameter(@nospecialize(t::Core.Kind))
+function has_bottom_parameter(@nospecialize(t::Core.AnyType))
     t === Bottom && return true
     ty = typeof(t)
     if ty === DataType

--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -232,6 +232,7 @@ function binding_module(m::Module, s::Symbol)
 end
 
 const _NAMEDTUPLE_NAME = NamedTuple.body.body.name
+const _TYPE_NAME = TypeEq.name
 
 function _fieldnames(@nospecialize t)
     if t.name === _NAMEDTUPLE_NAME
@@ -938,6 +939,9 @@ function ismutationfree(@nospecialize(t))
     t = unwrap_unionall(t)
     if isa(t, DataType)
         return datatype_ismutationfree(t)
+    elseif isa(t, TypeEq)
+        T = type_parameter(t)
+        return isa(T, Type) && ismutationfree(typeof(T))
     elseif isa(t, Union)
         return ismutationfree(t.a) && ismutationfree(t.b)
     end
@@ -958,6 +962,9 @@ function isidentityfree(@nospecialize(t))
     t = unwrap_unionall(t)
     if isa(t, DataType)
         return datatype_isidentityfree(t)
+    elseif isa(t, TypeEq)
+        T = type_parameter(t)
+        return isa(T, Type) && isidentityfree(typeof(T))
     elseif isa(t, Union)
         return isidentityfree(t.a) && isidentityfree(t.b)
     end
@@ -974,7 +981,7 @@ or [`Core.TypeofBottom`](@ref).
 
 All kinds are [concrete](@ref isconcretetype) because types are Julia values.
 """
-iskindtype(@nospecialize t) = (t === DataType || t === UnionAll || t === Union || t === typeof(Bottom))
+iskindtype(@nospecialize t) = (t === Kind || t === DataType || t === UnionAll || t === Union || t === TypeEq || t === typeof(Bottom))
 
 """
     Base.isconcretedispatch(T)
@@ -1010,8 +1017,8 @@ function isdispatchelem(@nospecialize v)
         (isType(v) && !has_free_typevars(v))
 end
 
-const _TYPE_NAME = Type.body.name
-isType(@nospecialize t) = isa(t, DataType) && t.name === _TYPE_NAME
+isType(@nospecialize t) = isa(t, TypeEq)
+type_parameter(@nospecialize t) = getfield(t, :T)
 
 """
     isconcretetype(T)
@@ -1151,7 +1158,7 @@ We can use it to summarize information about a struct:
 julia> structinfo(T) = [(fieldoffset(T,i), fieldname(T,i), fieldtype(T,i)) for i = 1:fieldcount(T)];
 
 julia> structinfo(Base.Filesystem.StatStruct)
-14-element Vector{Tuple{UInt64, Symbol, Type}}:
+14-element Vector{Tuple{UInt64, Symbol, Kind}}:
  (0x0000000000000000, :desc, Union{RawFD, String})
  (0x0000000000000008, :device, UInt64)
  (0x0000000000000010, :inode, UInt64)
@@ -1376,7 +1383,7 @@ function to_tuple_type(@nospecialize(t))
             if isa(p, Core.TypeofVararg)
                 p = unwrapva(p)
             end
-            if !(isa(p, Type) || isa(p, TypeVar))
+            if !(isa(p, Kind) || isa(p, TypeVar))
                 error("argument tuple type must contain only types")
             end
         end
@@ -1406,15 +1413,22 @@ end
 
 Determine whether `t` is a Type for which one or more of its parameters is `Union{}`.
 """
-function has_bottom_parameter(t::DataType)
-    for p in t.parameters
-        has_bottom_parameter(p) && return true
+function has_bottom_parameter(@nospecialize(t::Kind))
+    t === Bottom && return true
+    ty = typeof(t)
+    if ty === DataType
+        for p in getfield(t, :parameters)
+            has_bottom_parameter(p) && return true
+        end
+    elseif ty === TypeEq
+        return has_bottom_parameter(type_parameter(t))
+    elseif ty === UnionAll
+        return has_bottom_parameter(unwrap_unionall(t))
+    elseif ty === Union
+        return has_bottom_parameter(getfield(t, :a)) & has_bottom_parameter(getfield(t, :b))
     end
     return false
 end
-has_bottom_parameter(t::typeof(Bottom)) = true
-has_bottom_parameter(t::UnionAll) = has_bottom_parameter(unwrap_unionall(t))
-has_bottom_parameter(t::Union) = has_bottom_parameter(t.a) & has_bottom_parameter(t.b)
 has_bottom_parameter(t::TypeVar) = has_bottom_parameter(t.ub)
 has_bottom_parameter(::Any) = false
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1021,8 +1021,12 @@ end
 
 show(io::IO, @nospecialize(x::TypeEq)) = show_typeeq(io, x)
 show(io::IO, @nospecialize(x::Core.AnyType)) = _show_type(io, inferencebarrier(x))
+# `Type{T}` is the familiar user-facing spelling and is used for all normal
+# (compact) printing. In non-compact contexts (e.g. the REPL's `text/plain`
+# display) the canonical kind name `TypeEq{T}` is shown instead, so that a
+# concrete `Type{T}` renders as `Type{T} (alias for TypeEq{T})`.
 function show_typeeq(io::IO, @nospecialize(x::TypeEq))
-    print(io, "Type{")
+    print(io, get(io, :compact, true)::Bool ? "Type{" : "TypeEq{")
     show(io, type_parameter(x))
     print(io, "}")
 end
@@ -1034,9 +1038,6 @@ function _show_type(io::IO, @nospecialize(x::Type))
         return
     elseif x isa TypeEq
         show_typeeq(io, x)
-        return
-    elseif x === Type
-        print(io, "Type")
         return
     elseif x isa DataType
         show_datatype(io, x)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1020,7 +1020,7 @@ function show(io::IO, ::MIME"text/plain", @nospecialize(x::Type))
 end
 
 show(io::IO, @nospecialize(x::TypeEq)) = show_typeeq(io, x)
-show(io::IO, @nospecialize(x::Core.Kind)) = _show_type(io, inferencebarrier(x))
+show(io::IO, @nospecialize(x::Core.AnyType)) = _show_type(io, inferencebarrier(x))
 function show_typeeq(io::IO, @nospecialize(x::TypeEq))
     print(io, "Type{")
     show(io, type_parameter(x))
@@ -2791,7 +2791,7 @@ function show(io::IO, tv::TypeVar)
     # Otherwise, the lower bound should be printed if it is not `Bottom`
     # and the upper bound should be printed if it is not `Any`.
     in_env = (:unionall_env => tv) in io
-    function show_bound(io::IO, @nospecialize(b::Union{Core.Kind,TypeVar}))
+    function show_bound(io::IO, @nospecialize(b::Union{Core.AnyType,TypeVar}))
         parens = isa(b,UnionAll) && !print_without_params(b)
         parens && print(io, "(")
         show(io, b)

--- a/base/show.jl
+++ b/base/show.jl
@@ -599,10 +599,13 @@ end
 io_has_tvar_name(io::IO, name::Symbol, @nospecialize(x)) = false
 
 modulesof!(s::Set{Module}, x::TypeVar) = modulesof!(s, x.ub)
+modulesof!(s::Set{Module}, x::TypeEq) = modulesof!(s, type_parameter(x))
 function modulesof!(s::Set{Module}, x::Type)
     x = unwrap_unionall(x)
     if x isa DataType
         push!(s, parentmodule(x))
+    elseif x isa TypeEq
+        modulesof!(s, x)
     elseif x isa Union
         modulesof!(s, x.a)
         modulesof!(s, x.b)
@@ -1016,12 +1019,24 @@ function show(io::IO, ::MIME"text/plain", @nospecialize(x::Type))
     end
 end
 
+show(io::IO, @nospecialize(x::TypeEq)) = show_typeeq(io, x)
 show(io::IO, @nospecialize(x::Type)) = _show_type(io, inferencebarrier(x))
+function show_typeeq(io::IO, @nospecialize(x::TypeEq))
+    print(io, "Type{")
+    show(io, type_parameter(x))
+    print(io, "}")
+end
 function _show_type(io::IO, @nospecialize(x::Type))
     if print_without_params(x)
         show_type_name(io, (unwrap_unionall(x)::DataType).name)
         return
     elseif get(io, :compact, true)::Bool && show_typealias(io, x)
+        return
+    elseif x isa TypeEq
+        show_typeeq(io, x)
+        return
+    elseif x === Type
+        print(io, "Type")
         return
     elseif x isa DataType
         show_datatype(io, x)
@@ -1032,6 +1047,9 @@ function _show_type(io::IO, @nospecialize(x::Type))
         end
         print(io, "Union")
         show_delim_array(io, uniontypes(x), '{', ',', '}', false)
+        return
+    elseif x === Union{}
+        print(io, "Union{}")
         return
     end
 
@@ -2529,7 +2547,7 @@ function show_signature_function(io::IO, @nospecialize(ft), demangle=false, farg
         end
         s = sprint(show_sym, (demangle ? demangle_function_name : identity)(uw.name.singletonname), context=io)
         print_within_stacktrace(io, s, bold=true)
-    elseif isType(ft) && (f = ft.parameters[1]; !isa(f, TypeVar))
+    elseif isType(ft) && (f = type_parameter(ft); !isa(f, TypeVar))
         uwf = unwrap_unionall(f)
         parens = isa(f, UnionAll) && !(isa(uwf, DataType) && f === uwf.name.wrapper)
         parens && print(io, "(")

--- a/base/show.jl
+++ b/base/show.jl
@@ -1020,7 +1020,7 @@ function show(io::IO, ::MIME"text/plain", @nospecialize(x::Type))
 end
 
 show(io::IO, @nospecialize(x::TypeEq)) = show_typeeq(io, x)
-show(io::IO, @nospecialize(x::Type)) = _show_type(io, inferencebarrier(x))
+show(io::IO, @nospecialize(x::Kind)) = _show_type(io, inferencebarrier(x))
 function show_typeeq(io::IO, @nospecialize(x::TypeEq))
     print(io, "Type{")
     show(io, type_parameter(x))
@@ -2791,7 +2791,7 @@ function show(io::IO, tv::TypeVar)
     # Otherwise, the lower bound should be printed if it is not `Bottom`
     # and the upper bound should be printed if it is not `Any`.
     in_env = (:unionall_env => tv) in io
-    function show_bound(io::IO, @nospecialize(b))
+    function show_bound(io::IO, @nospecialize(b::Union{Kind,TypeVar}))
         parens = isa(b,UnionAll) && !print_without_params(b)
         parens && print(io, "(")
         show(io, b)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1020,7 +1020,7 @@ function show(io::IO, ::MIME"text/plain", @nospecialize(x::Type))
 end
 
 show(io::IO, @nospecialize(x::TypeEq)) = show_typeeq(io, x)
-show(io::IO, @nospecialize(x::Kind)) = _show_type(io, inferencebarrier(x))
+show(io::IO, @nospecialize(x::Core.Kind)) = _show_type(io, inferencebarrier(x))
 function show_typeeq(io::IO, @nospecialize(x::TypeEq))
     print(io, "Type{")
     show(io, type_parameter(x))
@@ -2791,7 +2791,7 @@ function show(io::IO, tv::TypeVar)
     # Otherwise, the lower bound should be printed if it is not `Bottom`
     # and the upper bound should be printed if it is not `Any`.
     in_env = (:unionall_env => tv) in io
-    function show_bound(io::IO, @nospecialize(b::Union{Kind,TypeVar}))
+    function show_bound(io::IO, @nospecialize(b::Union{Core.Kind,TypeVar}))
         parens = isa(b,UnionAll) && !print_without_params(b)
         parens && print(io, "(")
         show(io, b)

--- a/deps/jlutilities/revise/Manifest.toml
+++ b/deps/jlutilities/revise/Manifest.toml
@@ -70,11 +70,11 @@ version = "1.11.0"
 
 [[deps.JuliaInterpreter]]
 deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
-git-tree-sha1 = "c6a0611d4fbc9ee502e02afb3a15e571b45fadbe"
+git-tree-sha1 = "58927c485919bf17ea308d9d82156de1adf4b006"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaDebug/JuliaInterpreter.jl.git"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.10.9"
+version = "0.10.12"
 
     [deps.JuliaInterpreter.syntax]
     julia_version = "1.10.0"
@@ -120,11 +120,11 @@ version = "1.11.0"
 
 [[deps.LoweredCodeUtils]]
 deps = ["CodeTracking", "Compiler", "JuliaInterpreter"]
-git-tree-sha1 = "33ed9090b43f7e209ceff1f858fba1f906f869b5"
+git-tree-sha1 = "c46957d8047fe62dc59ffb83cbd005a511e90d5d"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaDebug/LoweredCodeUtils.jl.git"
 uuid = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
-version = "3.5.0"
+version = "3.5.2"
 
     [deps.LoweredCodeUtils.syntax]
     julia_version = "1.10.0"

--- a/deps/jlutilities/revise/Manifest.toml
+++ b/deps/jlutilities/revise/Manifest.toml
@@ -9,14 +9,14 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 version = "1.11.0"
 
     [deps.Artifacts.syntax]
-    julia_version = "1.14.0-DEV.1492"
+    julia_version = "1.14.0-DEV.2127"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 version = "1.11.0"
 
     [deps.Base64.syntax]
-    julia_version = "1.14.0-DEV.1492"
+    julia_version = "1.14.0-DEV.2127"
 
 [[deps.CodeTracking]]
 deps = ["InteractiveUtils", "UUIDs"]
@@ -40,7 +40,7 @@ version = "0.1.1"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.3.0+1"
+version = "1.5.1+0"
 
     [deps.CompilerSupportLibraries_jll.syntax]
     julia_version = "1.6.0"
@@ -51,14 +51,14 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 version = "1.11.0"
 
     [deps.Dates.syntax]
-    julia_version = "1.14.0-DEV.1492"
+    julia_version = "1.14.0-DEV.2127"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 version = "1.11.0"
 
     [deps.FileWatching.syntax]
-    julia_version = "1.14.0-DEV.1492"
+    julia_version = "1.14.0-DEV.2127"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
@@ -66,7 +66,7 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 version = "1.11.0"
 
     [deps.InteractiveUtils.syntax]
-    julia_version = "1.14.0-DEV.1492"
+    julia_version = "1.14.0-DEV.2127"
 
 [[deps.JuliaInterpreter]]
 deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
@@ -93,12 +93,12 @@ uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 version = "1.11.0"
 
     [deps.LibGit2.syntax]
-    julia_version = "1.14.0-DEV.1492"
+    julia_version = "1.14.0-DEV.2127"
 
 [[deps.LibGit2_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.9.2+0"
+version = "1.9.3+0"
 
     [deps.LibGit2_jll.syntax]
     julia_version = "1.9.0"
@@ -116,7 +116,7 @@ uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 version = "1.11.0"
 
     [deps.Libdl.syntax]
-    julia_version = "1.14.0-DEV.1492"
+    julia_version = "1.14.0-DEV.2127"
 
 [[deps.LoweredCodeUtils]]
 deps = ["CodeTracking", "Compiler", "JuliaInterpreter"]
@@ -135,7 +135,7 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 version = "1.11.0"
 
     [deps.Markdown.syntax]
-    julia_version = "1.14.0-DEV.1492"
+    julia_version = "1.14.0-DEV.2127"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -147,7 +147,7 @@ version = "1.3.0"
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.5.4+0"
+version = "3.5.6+0"
 
     [deps.OpenSSL_jll.syntax]
     julia_version = "1.6.0"
@@ -185,15 +185,15 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 version = "1.11.0"
 
     [deps.Printf.syntax]
-    julia_version = "1.14.0-DEV.1492"
+    julia_version = "1.14.0-DEV.2127"
 
 [[deps.REPL]]
-deps = ["Dates", "FileWatching", "InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+deps = ["Base64", "Dates", "FileWatching", "InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 version = "1.11.0"
 
     [deps.REPL.syntax]
-    julia_version = "1.14.0-DEV.1492"
+    julia_version = "1.14.0-DEV.2127"
 
 [[deps.Random]]
 deps = ["SHA"]
@@ -201,15 +201,15 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 version = "1.11.0"
 
     [deps.Random.syntax]
-    julia_version = "1.14.0-DEV.1492"
+    julia_version = "1.14.0-DEV.2127"
 
 [[deps.Revise]]
 deps = ["CodeTracking", "FileWatching", "InteractiveUtils", "JuliaInterpreter", "LibGit2", "LoweredCodeUtils", "OrderedCollections", "Preferences", "REPL", "UUIDs"]
-git-tree-sha1 = "a2db34dd8371e016edc4b20ad800dde5036463e8"
-repo-rev = "master"
+git-tree-sha1 = "42544c56a49b1d7890b6a930ab1fe381f76fbe6d"
+repo-rev = "637c38676d5d51181bd0ab105546999861c56a64"
 repo-url = "https://github.com/timholy/Revise.jl.git"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.13.2"
+version = "3.14.5"
 
     [deps.Revise.extensions]
     DistributedExt = "Distributed"
@@ -232,7 +232,7 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 version = "1.11.0"
 
     [deps.Sockets.syntax]
-    julia_version = "1.14.0-DEV.1492"
+    julia_version = "1.14.0-DEV.2127"
 
 [[deps.StyledStrings]]
 uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
@@ -255,19 +255,19 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 version = "1.11.0"
 
     [deps.UUIDs.syntax]
-    julia_version = "1.14.0-DEV.1492"
+    julia_version = "1.14.0-DEV.2127"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 version = "1.11.0"
 
     [deps.Unicode.syntax]
-    julia_version = "1.14.0-DEV.1492"
+    julia_version = "1.14.0-DEV.2127"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.3.1+2"
+version = "1.3.2+0"
 
     [deps.Zlib_jll.syntax]
     julia_version = "1.6.0"

--- a/deps/jlutilities/revise/Project.toml
+++ b/deps/jlutilities/revise/Project.toml
@@ -6,4 +6,4 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 [sources]
 JuliaInterpreter = {rev = "master", url = "https://github.com/JuliaDebug/JuliaInterpreter.jl.git"}
 LoweredCodeUtils = {rev = "master", url = "https://github.com/JuliaDebug/LoweredCodeUtils.jl.git"}
-Revise = {rev = "master", url = "https://github.com/timholy/Revise.jl.git"}
+Revise = {rev = "637c38676d5d51181bd0ab105546999861c56a64", url = "https://github.com/timholy/Revise.jl.git"}

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1229,8 +1229,8 @@ static jl_value_t *get_fieldtype(jl_value_t *t, jl_value_t *f, int dothrow)
         jl_value_t *a = ((jl_uniontype_t*)t)->a;
         jl_value_t *b = ((jl_uniontype_t*)t)->b;
         JL_GC_PUSHARGS(u, 2);
-        u[0] = jl_is_type_type(a) ? jl_bottom_type : get_fieldtype(a, f, 0);
-        u[1] = jl_is_type_type(b) ? jl_bottom_type : get_fieldtype(b, f, 0);
+        u[0] = jl_is_typeeq(a) ? jl_bottom_type : get_fieldtype(a, f, 0);
+        u[1] = jl_is_typeeq(b) ? jl_bottom_type : get_fieldtype(b, f, 0);
         if (u[0] == jl_bottom_type && u[1] == jl_bottom_type && dothrow) {
             // error if all types in the union might have
             get_fieldtype(a, f, 1);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -210,6 +210,8 @@ static int egal_types(const jl_value_t *a, const jl_value_t *b, jl_typeenv_t *en
         return egal_types(((jl_uniontype_t*)a)->a, ((jl_uniontype_t*)b)->a, env, tvar_names) &&
             egal_types(((jl_uniontype_t*)a)->b, ((jl_uniontype_t*)b)->b, env, tvar_names);
     }
+    if (dtag == jl_typeeq_tag << 4)
+        return egal_types(((jl_typeeq_t*)a)->T, ((jl_typeeq_t*)b)->T, env, tvar_names);
     if (dtag == jl_vararg_tag << 4) {
         jl_vararg_t *vma = (jl_vararg_t*)a;
         jl_vararg_t *vmb = (jl_vararg_t*)b;
@@ -289,6 +291,8 @@ JL_DLLEXPORT int jl_egal__bitstag(const jl_value_t *a JL_MAYBE_UNROOTED, const j
             return egal_types(a, b, NULL, 1);
         case jl_uniontype_tag:
             return compare_fields(a, b, jl_uniontype_type);
+        case jl_typeeq_tag:
+            return egal_types(a, b, NULL, 1);
         case jl_vararg_tag:
             return compare_fields(a, b, jl_vararg_type);
         case jl_task_tag:
@@ -403,6 +407,10 @@ static uintptr_t type_object_id_(jl_value_t *v, jl_varidx_t *env) JL_NOTSAFEPOIN
         return bitmix(bitmix(jl_object_id((jl_value_t*)tv),
                              type_object_id_(((jl_uniontype_t*)v)->a, env)),
                       type_object_id_(((jl_uniontype_t*)v)->b, env));
+    }
+    if (tv == jl_typeeq_type) {
+        return bitmix(jl_object_id((jl_value_t*)tv),
+                      type_object_id_(((jl_typeeq_t*)v)->T, env));
     }
     if (tv == jl_unionall_type) {
         jl_unionall_t *u = (jl_unionall_t*)v;
@@ -1218,20 +1226,23 @@ static jl_value_t *get_fieldtype(jl_value_t *t, jl_value_t *f, int dothrow)
     if (jl_is_uniontype(t)) {
         jl_value_t **u;
         jl_value_t *r;
+        jl_value_t *a = ((jl_uniontype_t*)t)->a;
+        jl_value_t *b = ((jl_uniontype_t*)t)->b;
         JL_GC_PUSHARGS(u, 2);
-        u[0] = get_fieldtype(((jl_uniontype_t*)t)->a, f, 0);
-        u[1] = get_fieldtype(((jl_uniontype_t*)t)->b, f, 0);
+        u[0] = jl_is_type_type(a) ? jl_bottom_type : get_fieldtype(a, f, 0);
+        u[1] = jl_is_type_type(b) ? jl_bottom_type : get_fieldtype(b, f, 0);
         if (u[0] == jl_bottom_type && u[1] == jl_bottom_type && dothrow) {
             // error if all types in the union might have
-            get_fieldtype(((jl_uniontype_t*)t)->a, f, 1);
-            get_fieldtype(((jl_uniontype_t*)t)->b, f, 1);
+            get_fieldtype(a, f, 1);
+            get_fieldtype(b, f, 1);
         }
         r = jl_type_union(u, 2);
         JL_GC_POP();
         return r;
     }
-    if (!jl_is_datatype(t))
+    if (!jl_is_datatype(t)) {
         jl_type_error("fieldtype", (jl_value_t*)jl_datatype_type, t);
+    }
     jl_datatype_t *st = (jl_datatype_t*)t;
     int field_index;
     if (jl_is_long(f)) {
@@ -1667,6 +1678,13 @@ JL_CALLABLE(jl_f_apply_type)
         // Union{} has extra restrictions, so it needs to be checked after
         // substituting typevars (a valid_type_param check here isn't sufficient).
         return (jl_value_t*)jl_type_union(&args[1], nargs-1);
+    }
+    else if (args[0] == (jl_value_t*)jl_typeeq_type) {
+        JL_NARGS(apply_type, 2, 2);
+        jl_value_t *pi = args[1];
+        if (!jl_valid_type_param(pi))
+            jl_type_error_rt("TypeEq", "parameter", (jl_value_t*)jl_type_type, pi);
+        return (jl_value_t*)jl_wrap_Type(pi);
     }
     else if (jl_is_vararg(args[0])) {
         jl_vararg_t *vm = (jl_vararg_t*)args[0];
@@ -2629,6 +2647,8 @@ void jl_init_primitives(void) JL_GC_DISABLED
 
     // builtin types
     add_builtin("Any", (jl_value_t*)jl_any_type);
+    add_builtin("Kind", (jl_value_t*)jl_kind_type);
+    add_builtin("TypeEq", (jl_value_t*)jl_typeeq_type);
     add_builtin("Type", (jl_value_t*)jl_type_type);
     add_builtin("Nothing", (jl_value_t*)jl_nothing_type);
     add_builtin("nothing", (jl_value_t*)jl_nothing);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2647,7 +2647,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
 
     // builtin types
     add_builtin("Any", (jl_value_t*)jl_any_type);
-    add_builtin("Kind", (jl_value_t*)jl_kind_type);
+    add_builtin("AnyType", (jl_value_t*)jl_anytype_type);
     add_builtin("TypeEq", (jl_value_t*)jl_typeeq_type);
     add_builtin("Type", (jl_value_t*)jl_type_type);
     add_builtin("Nothing", (jl_value_t*)jl_nothing_type);

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -857,7 +857,7 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
     if (jl_is_ssavalue(args[2]) && !jl_is_long(ctx.source->ssavaluetypes)) {
         jl_value_t *rtt = jl_array_ptr_ref((jl_array_t*)ctx.source->ssavaluetypes, ((jl_ssavalue_t*)args[2])->id - 1);
         if (jl_is_type_type(rtt))
-            rt = jl_tparam0(rtt);
+            rt = jl_typeeq_T(rtt);
     }
     if (!rt) {
         rt = static_eval(ctx, args[2]);
@@ -870,7 +870,7 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
     if (jl_is_ssavalue(args[3]) && !jl_is_long(ctx.source->ssavaluetypes)) {
         jl_value_t *att = jl_array_ptr_ref((jl_array_t*)ctx.source->ssavaluetypes, ((jl_ssavalue_t*)args[3])->id - 1);
         if (jl_is_type_type(att))
-            at = jl_tparam0(att);
+            at = jl_typeeq_T(att);
     }
     if (!at) {
         at = static_eval(ctx, args[3]);

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -856,7 +856,7 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
     }
     if (jl_is_ssavalue(args[2]) && !jl_is_long(ctx.source->ssavaluetypes)) {
         jl_value_t *rtt = jl_array_ptr_ref((jl_array_t*)ctx.source->ssavaluetypes, ((jl_ssavalue_t*)args[2])->id - 1);
-        if (jl_is_type_type(rtt))
+        if (jl_is_typeeq(rtt))
             rt = jl_typeeq_T(rtt);
     }
     if (!rt) {
@@ -869,7 +869,7 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
     }
     if (jl_is_ssavalue(args[3]) && !jl_is_long(ctx.source->ssavaluetypes)) {
         jl_value_t *att = jl_array_ptr_ref((jl_array_t*)ctx.source->ssavaluetypes, ((jl_ssavalue_t*)args[3])->id - 1);
-        if (jl_is_type_type(att))
+        if (jl_is_typeeq(att))
             at = jl_typeeq_T(att);
     }
     if (!at) {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -817,7 +817,7 @@ static bool is_typeofbottom_typealias(jl_value_t *jt)
         return false;
     return jt == (jl_value_t*)jl_bottom_type ||
            jt == (jl_value_t*)jl_typeofbottom_type ||
-           (jl_is_type_type(jt) && jl_typeeq_T(jt) == jl_bottom_type);
+           (jl_is_typeeq(jt) && jl_typeeq_T(jt) == jl_bottom_type);
 }
 
 static Type *_julia_type_to_llvm(jl_codegen_output_t *ctx, LLVMContext &ctxt, jl_value_t *jt, bool *isboxed, bool no_boxing)
@@ -1975,7 +1975,7 @@ static bool _can_optimize_isa(jl_value_t *type, int &counter)
     }
     if (type == (jl_value_t*)jl_type_type)
         return true;
-    if (jl_is_type_type(type) && jl_pointer_egal(type))
+    if (jl_is_typeeq(type) && jl_pointer_egal(type))
         return true;
     if (jl_has_intersect_type_not_kind(type))
         return false;
@@ -2101,7 +2101,7 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
         return std::make_pair(ConstantInt::get(getInt1Ty(ctx.builder.getContext()), *known_isa), true);
     }
 
-    if (jl_is_type_type(intersected_type) && jl_pointer_egal(intersected_type)) {
+    if (jl_is_typeeq(intersected_type) && jl_pointer_egal(intersected_type)) {
         // Use the check in `jl_pointer_egal` to see if the type enclosed
         // has unique pointer value.
         auto ptr = track_pjlvalue(ctx, literal_pointer_val(ctx, jl_typeeq_T(intersected_type)));

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -636,6 +636,8 @@ static JuliaVariable *julia_const_gv(jl_value_t *val);
 Constant *literal_pointer_val_slot(jl_codegen_output_t &params, jl_value_t *p)
 {
     Module *M = &params.get_module();
+    if (params.temporary_roots)
+        jl_temporary_root(params, p);
     // emit a pointer to a jl_value_t* which will allow it to be valid across reloading code
     // also, try to give it a nice name for gdb, for easy identification
     if (JuliaVariable *gv = julia_const_gv(p)) {
@@ -809,11 +811,20 @@ static unsigned convert_struct_offset(jl_codectx_t &ctx, Type *lty, unsigned byt
 
 static Type *_julia_struct_to_llvm(jl_codegen_output_t *ctx, LLVMContext &ctxt, jl_value_t *jt, bool *isboxed, bool llvmcall=false);
 
+static bool is_typeofbottom_typealias(jl_value_t *jt)
+{
+    if (jt == nullptr)
+        return false;
+    return jt == (jl_value_t*)jl_bottom_type ||
+           jt == (jl_value_t*)jl_typeofbottom_type ||
+           (jl_is_type_type(jt) && jl_typeeq_T(jt) == jl_bottom_type);
+}
+
 static Type *_julia_type_to_llvm(jl_codegen_output_t *ctx, LLVMContext &ctxt, jl_value_t *jt, bool *isboxed, bool no_boxing)
 {
     // this function converts a Julia Type into the equivalent LLVM type
     if (isboxed) *isboxed = false;
-    if (jt == (jl_value_t*)jl_bottom_type || jt == (jl_value_t*)jl_typeofbottom_type || jt == (jl_value_t*)jl_typeofbottom_type->super)
+    if (is_typeofbottom_typealias(jt))
         return getVoidTy(ctxt);
     if (jl_is_concrete_immutable(jt) || no_boxing) {
         if (jl_datatype_nbits(jt) == 0)
@@ -930,8 +941,12 @@ static Type *_julia_struct_to_llvm(jl_codegen_output_t *ctx, LLVMContext &ctxt, 
     // use this where C-compatible (unboxed) structs are desired
     // use julia_type_to_llvm directly when you want to preserve Julia's type semantics
     if (isboxed) *isboxed = false;
-    if (jt == (jl_value_t*)jl_bottom_type || jt == (jl_value_t*)jl_typeofbottom_type || jt == (jl_value_t*)jl_typeofbottom_type->super)
+    if (is_typeofbottom_typealias(jt))
         return getVoidTy(ctxt);
+    if (jl_is_kind(jt)) {
+        if (isboxed) *isboxed = true;
+        return JuliaType::get_prjlvalue_ty(ctxt);
+    }
     if (jl_is_primitivetype(jt))
         return bitstype_to_llvm(jt, ctxt, llvmcall);
     jl_datatype_t *jst = (jl_datatype_t*)jt;
@@ -1119,7 +1134,7 @@ static bool for_each_uniontype_small(
         allunbox &= for_each_uniontype_small(f, ((jl_uniontype_t*)ty)->b, counter);
         return allunbox;
     }
-    else if (ty == (jl_value_t*)jl_typeofbottom_type->super) {
+    else if (is_typeofbottom_typealias(ty)) {
         f(++counter, jl_typeofbottom_type); // treat Tuple{union{}} as identical to typeof(Union{})
     }
     else if (!deserves_unionbox(ty)) {
@@ -1150,8 +1165,6 @@ static unsigned get_box_tindex(jl_datatype_t *jt, jl_value_t *ut)
 {
     unsigned new_idx = 0;
     unsigned new_counter = 0;
-    if (jt == jl_typeofbottom_type->super)
-        jt = jl_typeofbottom_type; // treat Tuple{union{}} as identical to typeof(Union{})
     for_each_uniontype_small(
             // find the corresponding index in the new union-type
             [&](unsigned new_idx_, jl_datatype_t *new_jt) {
@@ -2010,7 +2023,7 @@ static Value *emit_exactly_isa(jl_codectx_t &ctx, const jl_cgval_t &arg, jl_data
             ctx.builder.SetInsertPoint(isaBB);
             Value *istype_boxed = NULL;
             if (is_uniquerep_Type((jl_value_t*)dt)) {
-                istype_boxed = ctx.builder.CreateICmpEQ(decay_derived(ctx, arg.Vboxed), decay_derived(ctx, literal_pointer_val(ctx, jl_tparam0(dt))));
+                istype_boxed = ctx.builder.CreateICmpEQ(decay_derived(ctx, arg.Vboxed), decay_derived(ctx, literal_pointer_val(ctx, jl_typeeq_T((jl_value_t*)dt))));
             } else {
                 istype_boxed = ctx.builder.CreateICmpEQ(emit_typeof(ctx, arg.Vboxed, false, true), emit_tagfrom(ctx, dt));
             }
@@ -2079,7 +2092,7 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
         if (intersected_type == (jl_value_t*)jl_bottom_type)
             known_isa = false;
     }
-    if (intersected_type == (jl_value_t*)jl_typeofbottom_type->super)
+    if (is_typeofbottom_typealias(intersected_type))
         intersected_type = (jl_value_t*)jl_typeofbottom_type; // swap abstract Type{Union{}} for concrete typeof(Union{})
     if (known_isa) {
         if (!*known_isa && !msg.isTriviallyEmpty()) {
@@ -2091,7 +2104,7 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
     if (jl_is_type_type(intersected_type) && jl_pointer_egal(intersected_type)) {
         // Use the check in `jl_pointer_egal` to see if the type enclosed
         // has unique pointer value.
-        auto ptr = track_pjlvalue(ctx, literal_pointer_val(ctx, jl_tparam0(intersected_type)));
+        auto ptr = track_pjlvalue(ctx, literal_pointer_val(ctx, jl_typeeq_T(intersected_type)));
         return {ctx.builder.CreateICmpEQ(boxed(ctx, x), ptr), false};
     }
     if (intersected_type == (jl_value_t*)jl_type_type) {
@@ -2107,7 +2120,9 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
                 ctx.builder.CreateICmpEQ(typ, emit_tagfrom(ctx, jl_datatype_type))),
             ctx.builder.CreateOr(
                 ctx.builder.CreateICmpEQ(typ, emit_tagfrom(ctx, jl_unionall_type)),
-                ctx.builder.CreateICmpEQ(typ, emit_tagfrom(ctx, jl_typeofbottom_type))));
+                ctx.builder.CreateOr(
+                    ctx.builder.CreateICmpEQ(typ, emit_tagfrom(ctx, jl_typeeq_type)),
+                    ctx.builder.CreateICmpEQ(typ, emit_tagfrom(ctx, jl_typeofbottom_type)))));
         setName(ctx.emission_context, val, "is_kind");
         return std::make_pair(val, false);
     }
@@ -3809,7 +3824,7 @@ static Value *_boxed_special(jl_codectx_t &ctx, const jl_cgval_t &vinfo, Type *t
     if (t == getInt1Ty(ctx.builder.getContext()))
         return track_pjlvalue(ctx, julia_bool(ctx, as_value(ctx, t, vinfo)));
 
-    if (ctx.linfo && jl_is_method(ctx.linfo->def.method) && vinfo.inline_roots.empty() && !vinfo.ispointer()) { // don't bother codegen pre-boxing for toplevel
+    if (ctx.linfo && jl_is_method(ctx.linfo->def.method) && vinfo.V && vinfo.inline_roots.empty() && !vinfo.ispointer()) { // don't bother codegen pre-boxing for toplevel
         if (Constant *c = dyn_cast<Constant>(vinfo.V)) {
             jl_value_t *s = static_constant_instance(jl_Module->getDataLayout(), c, jt);
             if (s) {
@@ -4120,7 +4135,6 @@ static Value *boxed(jl_codectx_t &ctx, const jl_cgval_t &vinfo, bool is_promotab
         assert(vinfo.V->getType() == ctx.types().T_prjlvalue);
         return vinfo.V;
     }
-
     Value *box;
     if (vinfo.TIndex) {
         SmallBitVector skip_none;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -505,7 +505,7 @@ static bool type_has_unique_rep(jl_value_t *t)
 
 static bool is_uniquerep_Type(jl_value_t *t)
 {
-    return jl_is_type_type(t) && type_has_unique_rep(jl_tparam0(t));
+    return jl_is_type_type(t) && type_has_unique_rep(jl_typeeq_T(t));
 }
 
 class jl_codectx_t;
@@ -1627,7 +1627,7 @@ static _Atomic(uint64_t) globalUniqueGeneratedNames{1};
 static MDNode *best_tbaa(jl_tbaacache_t &tbaa_cache, jl_value_t *jt) {
     jt = jl_unwrap_unionall(jt);
     if (jt == (jl_value_t*)jl_datatype_type ||
-        (jl_is_type_type(jt) && jl_is_datatype(jl_tparam0(jt))))
+        (jl_is_type_type(jt) && jl_is_datatype(jl_typeeq_T(jt))))
         return tbaa_cache.tbaa_datatype;
     if (!jl_is_datatype(jt))
         return tbaa_cache.tbaa_value;
@@ -1644,7 +1644,7 @@ static MDNode *best_tbaa(jl_tbaacache_t &tbaa_cache, jl_value_t *jt) {
 // note that this includes jl_isbits, although codegen should work regardless
 static bool jl_is_concrete_immutable(jl_value_t* t)
 {
-    return jl_may_be_immutable_datatype(t) && ((jl_datatype_t*)t)->isconcretetype;
+    return jl_may_be_immutable_datatype(t) && ((jl_datatype_t*)t)->isconcretetype && !jl_is_kind(t);
 }
 
 static bool jl_is_pointerfree(jl_value_t* t)
@@ -2369,14 +2369,14 @@ static inline jl_cgval_t ghostValue(jl_codectx_t &ctx, jl_value_t *typ)
         return jl_cgval_t(); // Undef{}
     if (typ == (jl_value_t*)jl_typeofbottom_type) {
         // normalize TypeofBottom to Type{Union{}}
-        typ = (jl_value_t*)jl_typeofbottom_type->super;
+        typ = jl_atomic_load_relaxed(&jl_typeofbottom_type->name->Typeofwrapper);
     }
     if (jl_is_type_type(typ)) {
         assert(is_uniquerep_Type(typ));
         // replace T::Type{T} with T, by assuming that T must be a leaftype of some sort
         jl_cgval_t constant(NULL, true, typ, NULL, best_tbaa(ctx.tbaa(), typ), jl_gc_roots_t());
-        constant.constant = jl_tparam0(typ);
-        if (typ == (jl_value_t*)jl_typeofbottom_type->super)
+        constant.constant = jl_typeeq_T(typ);
+        if (constant.constant == jl_bottom_type)
             constant.isghost = true;
         return constant;
     }
@@ -2538,9 +2538,11 @@ static inline jl_cgval_t update_julia_type(jl_codectx_t &ctx, const jl_cgval_t &
                 CreateTrap(ctx.builder);
             return jl_cgval_t();
         }
-        Type *T = julia_type_to_llvm(ctx, typ);
-        if (type_is_ghost(T))
-            return ghostValue(ctx, typ);
+        if (((jl_datatype_t*)typ)->layout) {
+            Type *T = julia_type_to_llvm(ctx, typ);
+            if (type_is_ghost(T))
+                return ghostValue(ctx, typ);
+        }
     }
     else if (jl_is_concrete_type(v.typ) && !jl_is_kind(v.typ)) {
         return v;
@@ -4398,7 +4400,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         const jl_cgval_t &arg = argv[1];
         const jl_cgval_t &ty = argv[2];
         if (jl_is_type_type(ty.typ) && !jl_has_free_typevars(ty.typ)) {
-            jl_value_t *tp0 = jl_tparam0(ty.typ);
+            jl_value_t *tp0 = jl_typeeq_T(ty.typ);
             emit_typecheck(ctx, arg, tp0, "typeassert");
             *ret = update_julia_type(ctx, arg, tp0);
             return true;
@@ -4416,7 +4418,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         const jl_cgval_t &arg = argv[1];
         const jl_cgval_t &ty = argv[2];
         if (jl_is_type_type(ty.typ) && !jl_has_free_typevars(ty.typ)) {
-            jl_value_t *tp0 = jl_tparam0(ty.typ);
+            jl_value_t *tp0 = jl_typeeq_T(ty.typ);
             Value *isa_result = emit_isa(ctx, arg, tp0, Twine()).first;
             *ret = mark_julia_type(ctx, isa_result, false, jl_bool_type);
             return true;
@@ -4428,7 +4430,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         const jl_cgval_t &tb = argv[2];
         if (jl_is_type_type(ta.typ) && !jl_has_free_typevars(ta.typ) &&
             jl_is_type_type(tb.typ) && !jl_has_free_typevars(tb.typ)) {
-            int issub = jl_subtype(jl_tparam0(ta.typ), jl_tparam0(tb.typ));
+            int issub = jl_subtype(jl_typeeq_T(ta.typ), jl_typeeq_T(tb.typ));
             *ret = mark_julia_type(ctx, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), issub), false, jl_bool_type);
             return true;
         }
@@ -4836,8 +4838,8 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         }
 
         jl_datatype_t *utt = (jl_datatype_t*)jl_unwrap_unionall(obj.typ);
-        if (jl_is_type_type((jl_value_t*)utt) && jl_is_concrete_type(jl_tparam0(utt)))
-            utt = (jl_datatype_t*)jl_typeof(jl_tparam0(utt));
+        if (jl_is_type_type((jl_value_t*)utt) && jl_is_concrete_type(jl_typeeq_T((jl_value_t*)utt)))
+            utt = (jl_datatype_t*)jl_typeof(jl_typeeq_T((jl_value_t*)utt));
 
         if (fld.constant && jl_is_symbol(fld.constant)) {
             jl_sym_t *name = (jl_sym_t*)fld.constant;
@@ -5041,7 +5043,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             nf = jl_datatype_nfields(jl_typeof(obj.constant));
         }
         else if (jl_is_type_type(obj.typ)) {
-            jl_value_t *tp0 = jl_tparam0(obj.typ);
+            jl_value_t *tp0 = jl_typeeq_T(obj.typ);
             if (jl_is_datatype(tp0) && jl_is_datatype_singleton((jl_datatype_t*)tp0))
                 nf = jl_datatype_nfields((jl_value_t*)jl_datatype_type);
         }
@@ -5060,7 +5062,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
     else if (f == BUILTIN(fieldtype) && (nargs == 2 || nargs == 3)) {
         const jl_cgval_t &typ = argv[1];
         const jl_cgval_t &fld = argv[2];
-        if ((jl_is_type_type(typ.typ) && jl_is_concrete_type(jl_tparam0(typ.typ))) ||
+        if ((jl_is_type_type(typ.typ) && jl_is_concrete_type(jl_typeeq_T(typ.typ))) ||
                 (typ.constant && jl_is_concrete_type(typ.constant))) {
             if (fld.typ == (jl_value_t*)jl_long_type) {
                 assert(typ.isboxed);
@@ -5186,8 +5188,9 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             // the representation type of Type{T} is either typeof(T), or unknown
             // TODO: could use `issingletontype` predicate here, providing better type knowledge
             // than only handling DataType
-            if (jl_is_concrete_type(jl_tparam0(stt)))
-                stt = (jl_datatype_t*)jl_typeof(jl_tparam0(stt));
+            jl_value_t *tp0 = jl_typeeq_T((jl_value_t*)stt);
+            if (jl_is_concrete_type(tp0))
+                stt = (jl_datatype_t*)jl_typeof(tp0);
             else
                 return false;
         }
@@ -6801,10 +6804,11 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaidx_
         }
         jl_value_t *ty = argv[0].typ;
         if (jl_is_type_type(ty) &&
-                jl_is_datatype(jl_tparam0(ty)) &&
-                jl_is_concrete_type(jl_tparam0(ty))) {
-            assert(nargs <= jl_datatype_nfields(jl_tparam0(ty)) + 1);
-            jl_cgval_t res = emit_new_struct(ctx, jl_tparam0(ty), nargs - 1, ArrayRef<jl_cgval_t>(argv).drop_front(), is_promotable);
+                jl_is_datatype(jl_typeeq_T(ty)) &&
+                jl_is_concrete_type(jl_typeeq_T(ty))) {
+            jl_value_t *tp0 = jl_typeeq_T(ty);
+            assert(nargs <= jl_datatype_nfields(tp0) + 1);
+            jl_cgval_t res = emit_new_struct(ctx, tp0, nargs - 1, ArrayRef<jl_cgval_t>(argv).drop_front(), is_promotable);
             if (is_promotable && res.promotion_point && res.promotion_ssa==-1)
                 res.promotion_ssa = ssaidx_0based;
             return res;
@@ -7265,7 +7269,7 @@ static void emit_specsig_to_specsig(
             et = julia_type_to_llvm(ctx, jt);
         }
         if (is_uniquerep_Type(jt)) {
-            myargs[i] = mark_julia_const(ctx, jl_tparam0(jt));
+            myargs[i] = mark_julia_const(ctx, jl_typeeq_T(jt));
         }
         else if (type_is_ghost(et)) {
             assert(jl_is_datatype(jt) && jl_is_datatype_singleton((jl_datatype_t*)jt));
@@ -7956,7 +7960,7 @@ static const char *derive_sigt_name(jl_value_t *jargty)
         return NULL;
     jl_sym_t *name = dt->name->singletonname;
     if (jl_is_type_type((jl_value_t*)dt)) {
-        dt = (jl_datatype_t*)jl_argument_datatype(jl_tparam0(dt));
+        dt = (jl_datatype_t*)jl_argument_datatype(jl_typeeq_T((jl_value_t*)dt));
         if ((jl_value_t*)dt != jl_nothing) {
             name = dt->name->singletonname;
         }
@@ -8501,7 +8505,7 @@ static jl_datatype_t *compute_va_type(jl_value_t *sig, size_t nreq)
         jl_value_t *argType = jl_nth_slot_type(sig, i);
         // n.b. specTypes is required to be a datatype by construction for specsig
         if (is_uniquerep_Type(argType))
-            argType = jl_typeof(jl_tparam0(argType));
+            argType = jl_typeof(jl_typeeq_T(argType));
         else if (jl_has_intersect_type_not_kind(argType)) {
             jl_value_t *ts[2] = {argType, (jl_value_t*)jl_type_type};
             argType = jl_type_union(ts, 2);
@@ -9131,7 +9135,7 @@ static jl_llvm_functions_t
             return ghostValue(ctx, argType);
         }
         else if (is_uniquerep_Type(argType)) {
-            return mark_julia_const(ctx, jl_tparam0(argType));
+            return mark_julia_const(ctx, jl_typeeq_T(argType));
         }
         Argument *Arg = &*AI;
         ++AI;
@@ -10135,7 +10139,8 @@ static jl_llvm_functions_t
                     cast<Instruction>(RU)->eraseFromParent();
                 }
                 root->eraseFromParent();
-                restTuple->eraseFromParent();
+                if (restTuple)
+                    restTuple->eraseFromParent();
             }
         }
     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -505,7 +505,7 @@ static bool type_has_unique_rep(jl_value_t *t)
 
 static bool is_uniquerep_Type(jl_value_t *t)
 {
-    return jl_is_type_type(t) && type_has_unique_rep(jl_typeeq_T(t));
+    return jl_is_typeeq(t) && type_has_unique_rep(jl_typeeq_T(t));
 }
 
 class jl_codectx_t;
@@ -1627,7 +1627,7 @@ static _Atomic(uint64_t) globalUniqueGeneratedNames{1};
 static MDNode *best_tbaa(jl_tbaacache_t &tbaa_cache, jl_value_t *jt) {
     jt = jl_unwrap_unionall(jt);
     if (jt == (jl_value_t*)jl_datatype_type ||
-        (jl_is_type_type(jt) && jl_is_datatype(jl_typeeq_T(jt))))
+        (jl_is_typeeq(jt) && jl_is_datatype(jl_typeeq_T(jt))))
         return tbaa_cache.tbaa_datatype;
     if (!jl_is_datatype(jt))
         return tbaa_cache.tbaa_value;
@@ -2371,7 +2371,7 @@ static inline jl_cgval_t ghostValue(jl_codectx_t &ctx, jl_value_t *typ)
         // normalize TypeofBottom to Type{Union{}}
         typ = jl_atomic_load_relaxed(&jl_typeofbottom_type->name->Typeofwrapper);
     }
-    if (jl_is_type_type(typ)) {
+    if (jl_is_typeeq(typ)) {
         assert(is_uniquerep_Type(typ));
         // replace T::Type{T} with T, by assuming that T must be a leaftype of some sort
         jl_cgval_t constant(NULL, true, typ, NULL, best_tbaa(ctx.tbaa(), typ), jl_gc_roots_t());
@@ -2485,7 +2485,7 @@ static inline jl_cgval_t value_to_pointer(jl_codectx_t &ctx, const jl_cgval_t &v
 
 static inline jl_cgval_t mark_julia_type(jl_codectx_t &ctx, Value *v, bool isboxed, jl_value_t *typ)
 {
-    if (jl_is_type_type(typ)) {
+    if (jl_is_typeeq(typ)) {
         if (is_uniquerep_Type(typ)) {
             // replace T::Type{T} with T
             return ghostValue(ctx, typ);
@@ -4399,7 +4399,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
     else if (f == BUILTIN(typeassert) && nargs == 2) {
         const jl_cgval_t &arg = argv[1];
         const jl_cgval_t &ty = argv[2];
-        if (jl_is_type_type(ty.typ) && !jl_has_free_typevars(ty.typ)) {
+        if (jl_is_typeeq(ty.typ) && !jl_has_free_typevars(ty.typ)) {
             jl_value_t *tp0 = jl_typeeq_T(ty.typ);
             emit_typecheck(ctx, arg, tp0, "typeassert");
             *ret = update_julia_type(ctx, arg, tp0);
@@ -4417,7 +4417,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
     else if (f == BUILTIN(isa) && nargs == 2) {
         const jl_cgval_t &arg = argv[1];
         const jl_cgval_t &ty = argv[2];
-        if (jl_is_type_type(ty.typ) && !jl_has_free_typevars(ty.typ)) {
+        if (jl_is_typeeq(ty.typ) && !jl_has_free_typevars(ty.typ)) {
             jl_value_t *tp0 = jl_typeeq_T(ty.typ);
             Value *isa_result = emit_isa(ctx, arg, tp0, Twine()).first;
             *ret = mark_julia_type(ctx, isa_result, false, jl_bool_type);
@@ -4428,8 +4428,8 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
     else if (f == BUILTIN(issubtype) && nargs == 2) {
         const jl_cgval_t &ta = argv[1];
         const jl_cgval_t &tb = argv[2];
-        if (jl_is_type_type(ta.typ) && !jl_has_free_typevars(ta.typ) &&
-            jl_is_type_type(tb.typ) && !jl_has_free_typevars(tb.typ)) {
+        if (jl_is_typeeq(ta.typ) && !jl_has_free_typevars(ta.typ) &&
+            jl_is_typeeq(tb.typ) && !jl_has_free_typevars(tb.typ)) {
             int issub = jl_subtype(jl_typeeq_T(ta.typ), jl_typeeq_T(tb.typ));
             *ret = mark_julia_type(ctx, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), issub), false, jl_bool_type);
             return true;
@@ -4838,7 +4838,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         }
 
         jl_datatype_t *utt = (jl_datatype_t*)jl_unwrap_unionall(obj.typ);
-        if (jl_is_type_type((jl_value_t*)utt) && jl_is_concrete_type(jl_typeeq_T((jl_value_t*)utt)))
+        if (jl_is_typeeq((jl_value_t*)utt) && jl_is_concrete_type(jl_typeeq_T((jl_value_t*)utt)))
             utt = (jl_datatype_t*)jl_typeof(jl_typeeq_T((jl_value_t*)utt));
 
         if (fld.constant && jl_is_symbol(fld.constant)) {
@@ -5042,7 +5042,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         if (obj.constant) {
             nf = jl_datatype_nfields(jl_typeof(obj.constant));
         }
-        else if (jl_is_type_type(obj.typ)) {
+        else if (jl_is_typeeq(obj.typ)) {
             jl_value_t *tp0 = jl_typeeq_T(obj.typ);
             if (jl_is_datatype(tp0) && jl_is_datatype_singleton((jl_datatype_t*)tp0))
                 nf = jl_datatype_nfields((jl_value_t*)jl_datatype_type);
@@ -5062,7 +5062,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
     else if (f == BUILTIN(fieldtype) && (nargs == 2 || nargs == 3)) {
         const jl_cgval_t &typ = argv[1];
         const jl_cgval_t &fld = argv[2];
-        if ((jl_is_type_type(typ.typ) && jl_is_concrete_type(jl_typeeq_T(typ.typ))) ||
+        if ((jl_is_typeeq(typ.typ) && jl_is_concrete_type(jl_typeeq_T(typ.typ))) ||
                 (typ.constant && jl_is_concrete_type(typ.constant))) {
             if (fld.typ == (jl_value_t*)jl_long_type) {
                 assert(typ.isboxed);
@@ -5184,7 +5184,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         const jl_cgval_t &fld = argv[2];
         jl_datatype_t *stt = (jl_datatype_t*)obj.typ;
         ssize_t fieldidx = -1;
-        if (jl_is_type_type((jl_value_t*)stt)) {
+        if (jl_is_typeeq((jl_value_t*)stt)) {
             // the representation type of Type{T} is either typeof(T), or unknown
             // TODO: could use `issingletontype` predicate here, providing better type knowledge
             // than only handling DataType
@@ -6803,7 +6803,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaidx_
             argv[i] = emit_expr(ctx, args[i]);
         }
         jl_value_t *ty = argv[0].typ;
-        if (jl_is_type_type(ty) &&
+        if (jl_is_typeeq(ty) &&
                 jl_is_datatype(jl_typeeq_T(ty)) &&
                 jl_is_concrete_type(jl_typeeq_T(ty))) {
             jl_value_t *tp0 = jl_typeeq_T(ty);
@@ -7959,7 +7959,7 @@ static const char *derive_sigt_name(jl_value_t *jargty)
     if ((jl_value_t*)dt == jl_nothing)
         return NULL;
     jl_sym_t *name = dt->name->singletonname;
-    if (jl_is_type_type((jl_value_t*)dt)) {
+    if (jl_is_typeeq((jl_value_t*)dt)) {
         dt = (jl_datatype_t*)jl_argument_datatype(jl_typeeq_T((jl_value_t*)dt));
         if ((jl_value_t*)dt != jl_nothing) {
             name = dt->name->singletonname;

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -376,8 +376,6 @@ int jl_struct_try_layout(jl_datatype_t *dt)
 
 int jl_datatype_isinlinealloc(jl_datatype_t *ty, int pointerfree)
 {
-    if (jl_typeofbottom_type && ty == jl_typeofbottom_type->super)
-        ty = jl_typeofbottom_type;
     if (ty->name->mayinlinealloc && jl_struct_try_layout(ty)) {
         if (ty->layout->npointers > 0) {
             if (pointerfree)
@@ -394,6 +392,13 @@ int jl_datatype_isinlinealloc(jl_datatype_t *ty, int pointerfree)
     return 0;
 }
 
+static jl_value_t *normalize_typeofbottom_layout_alias(jl_value_t *ty JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    if (jl_typeofbottom_type != NULL && jl_is_type_type(ty) && jl_typeeq_T(ty) == jl_bottom_type)
+        return (jl_value_t*)jl_typeofbottom_type;
+    return ty;
+}
+
 static unsigned union_isinlinable(jl_value_t *ty, int pointerfree, size_t *nbytes, size_t *align, int asfield)
 {
     if (jl_is_uniontype(ty)) {
@@ -405,6 +410,7 @@ static unsigned union_isinlinable(jl_value_t *ty, int pointerfree, size_t *nbyte
             return 0;
         return na + nb;
     }
+    ty = normalize_typeofbottom_layout_alias(ty);
     if (jl_is_datatype(ty) && jl_datatype_isinlinealloc((jl_datatype_t*)ty, pointerfree)) {
         size_t sz = jl_datatype_size(ty);
         size_t al = jl_datatype_align(ty);
@@ -453,12 +459,12 @@ int jl_pointer_egal(jl_value_t *t)
         !jl_is_kind(t))
         return 1;
     if ((jl_is_datatype(t) && jl_is_datatype_singleton((jl_datatype_t*)t)) ||
-        t == (jl_value_t*)jl_typeofbottom_type->super)
+        (jl_is_type_type(t) && jl_typeeq_T(t) == jl_bottom_type))
         return 1;
-    if (jl_is_type_type(t) && jl_is_datatype(jl_tparam0(t))) {
+    if (jl_is_type_type(t) && jl_is_datatype(jl_typeeq_T(t))) {
         // need to use typeseq for most types
         // but can compare some types by pointer
-        jl_datatype_t *dt = (jl_datatype_t*)jl_tparam0(t);
+        jl_datatype_t *dt = (jl_datatype_t*)jl_typeeq_T(t);
         // `Core.TypeofBottom` and `Type{Union{}}` are used interchangeably
         // with different pointer values even though `Core.TypeofBottom` is a concrete type.
         // See `Core.Compiler.hasuniquerep`
@@ -486,7 +492,7 @@ static void throw_ovf(int should_malloc, void *desc, jl_datatype_t* st, int offs
 
 static int is_type_mutationfree(jl_value_t *t)
 {
-    t = jl_unwrap_unionall(t);
+    t = normalize_typeofbottom_layout_alias(jl_unwrap_unionall(t));
     if (jl_is_uniontype(t)) {
         jl_uniontype_t *u = (jl_uniontype_t*)t;
         return is_type_mutationfree(u->a) && is_type_mutationfree(u->b);
@@ -500,7 +506,7 @@ static int is_type_mutationfree(jl_value_t *t)
 
 static int is_type_identityfree(jl_value_t *t)
 {
-    t = jl_unwrap_unionall(t);
+    t = normalize_typeofbottom_layout_alias(jl_unwrap_unionall(t));
     if (jl_is_uniontype(t)) {
         jl_uniontype_t *u = (jl_uniontype_t*)t;
         return is_type_identityfree(u->a) && is_type_identityfree(u->b);
@@ -735,9 +741,10 @@ void jl_compute_field_offsets(jl_datatype_t *st)
         jl_value_t *firstty = jl_field_type(st, 0);
         for (i = 0; i < nfields; i++) {
             jl_value_t *fld = jl_field_type(st, i);
+            jl_value_t *layout_fld = normalize_typeofbottom_layout_alias(fld);
             int isatomic = jl_field_isatomic(st, i);
             size_t fsz = 0, al = 1;
-            if (jl_islayout_inline(fld, &fsz, &al) && (!isatomic || jl_is_datatype(fld))) { // aka jl_datatype_isinlinealloc
+            if (jl_islayout_inline(fld, &fsz, &al) && (!isatomic || jl_is_datatype(layout_fld))) { // aka jl_datatype_isinlinealloc
                 if (__unlikely(fsz > max_size))
                     // Should never happen
                     throw_ovf(should_malloc, desc, st, fsz);
@@ -750,15 +757,16 @@ void jl_compute_field_offsets(jl_datatype_t *st)
                     isbitsegal = 0;
                 }
                 else {
-                    if (fsz > jl_datatype_size(fld)) {
+                    assert(jl_is_datatype(layout_fld));
+                    if (fsz > jl_datatype_size(layout_fld)) {
                         // We have to pad the size to integer size class, but it means this has some padding
                         isbitsegal = 0;
                         haspadding = 1;
                     }
-                    uint32_t fld_npointers = ((jl_datatype_t*)fld)->layout->npointers;
-                    if (((jl_datatype_t*)fld)->layout->flags.haspadding)
+                    uint32_t fld_npointers = ((jl_datatype_t*)layout_fld)->layout->npointers;
+                    if (((jl_datatype_t*)layout_fld)->layout->flags.haspadding)
                         haspadding = 1;
-                    if (!((jl_datatype_t*)fld)->layout->flags.isbitsegal)
+                    if (!((jl_datatype_t*)layout_fld)->layout->flags.isbitsegal)
                         isbitsegal = 0;
                     if (i >= nfields - st->name->n_uninitialized && fld_npointers &&
                         fld_npointers * sizeof(void*) != fsz) {
@@ -775,7 +783,7 @@ void jl_compute_field_offsets(jl_datatype_t *st)
                         isbitsegal = 0;
                     }
                     if (!zeroinit)
-                        zeroinit = ((jl_datatype_t*)fld)->zeroinit;
+                        zeroinit = ((jl_datatype_t*)layout_fld)->zeroinit;
                     npointers += fld_npointers;
                 }
             }
@@ -838,13 +846,14 @@ void jl_compute_field_offsets(jl_datatype_t *st)
         size_t ptr_i = 0;
         for (i = 0; i < nfields; i++) {
             jl_value_t *fld = jl_field_type(st, i);
+            jl_value_t *layout_fld = normalize_typeofbottom_layout_alias(fld);
             uint32_t offset = desc[i].offset / sizeof(jl_value_t**);
             if (desc[i].isptr)
                 pointers[ptr_i++] = offset;
-            else if (jl_is_datatype(fld)) {
-                int j, npointers = ((jl_datatype_t*)fld)->layout->npointers;
+            else if (jl_is_datatype(layout_fld)) {
+                int j, npointers = ((jl_datatype_t*)layout_fld)->layout->npointers;
                 for (j = 0; j < npointers; j++) {
-                    pointers[ptr_i++] = offset + jl_ptr_offset((jl_datatype_t*)fld, j);
+                    pointers[ptr_i++] = offset + jl_ptr_offset((jl_datatype_t*)layout_fld, j);
                 }
             }
         }
@@ -1760,8 +1769,6 @@ JL_DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type)
 {
     jl_task_t *ct = jl_current_task;
     if (!jl_is_datatype(type) || !type->isconcretetype || type->layout == NULL || jl_is_layout_opaque(type->layout)) {
-        if (type == jl_typeofbottom_type->super)
-            return jl_bottom_type; // ::Type{Union{}} is an abstract type, but is also a singleton when used as a field type
         jl_type_error("new", (jl_value_t*)jl_datatype_type, (jl_value_t*)type);
     }
     if (type->instance != NULL)
@@ -1867,27 +1874,29 @@ JL_DLLEXPORT jl_value_t *jl_get_nth_field(jl_value_t *v, size_t i)
         size_t fsz = jl_field_size(st, i);
         uint8_t sel = ((uint8_t*)v)[offs + fsz - 1];
         ty = jl_nth_union_component(ty, sel);
-        if (jl_is_datatype_singleton((jl_datatype_t*)ty))
-            return ((jl_datatype_t*)ty)->instance;
+        jl_value_t *layout_ty = normalize_typeofbottom_layout_alias(ty);
+        if (jl_is_datatype_singleton((jl_datatype_t*)layout_ty))
+            return ((jl_datatype_t*)layout_ty)->instance;
     }
+    jl_value_t *layout_ty = normalize_typeofbottom_layout_alias(ty);
     jl_value_t *r;
-    size_t fsz = jl_datatype_size(ty);
+    size_t fsz = jl_datatype_size(layout_ty);
     int needlock = (isatomic && fsz > MAX_ATOMIC_SIZE);
     if (isatomic && !needlock) {
-        r = jl_atomic_new_bits(ty, (char*)v + offs);
+        r = jl_atomic_new_bits(layout_ty, (char*)v + offs);
     }
     else if (needlock) {
         jl_task_t *ct = jl_current_task;
-        r = jl_gc_alloc(ct->ptls, fsz, ty);
+        r = jl_gc_alloc(ct->ptls, fsz, layout_ty);
         jl_lock_value((jl_mutex_t*)v);
         memcpy((char*)r, (char*)v + offs, fsz);
         jl_unlock_value((jl_mutex_t*)v);
     }
     else {
         // TODO: a finalizer here could make the isunion case not quite right
-        r = jl_new_bits(ty, (char*)v + offs);
+        r = jl_new_bits(layout_ty, (char*)v + offs);
     }
-    return undefref_check((jl_datatype_t*)ty, r);
+    return undefref_check((jl_datatype_t*)layout_ty, r);
 }
 
 JL_DLLEXPORT jl_value_t *jl_get_nth_field_noalloc(jl_value_t *v JL_PROPAGATES_ROOT, size_t i) JL_NOTSAFEPOINT
@@ -1920,6 +1929,7 @@ inline void set_nth_field(jl_datatype_t *st, jl_value_t *v, size_t i, jl_value_t
     }
     else {
         jl_value_t *ty = jl_field_type_concrete(st, i);
+        jl_value_t *layout_ty = normalize_typeofbottom_layout_alias(ty);
         jl_value_t *rty = jl_typeof(rhs);
         int hasptr;
         int isunion = jl_is_uniontype(ty);
@@ -1936,7 +1946,7 @@ inline void set_nth_field(jl_datatype_t *st, jl_value_t *v, size_t i, jl_value_t
             hasptr = 0;
         }
         else {
-            hasptr = ((jl_datatype_t*)ty)->layout->first_ptr >= 0;
+            hasptr = ((jl_datatype_t*)layout_ty)->layout->first_ptr >= 0;
         }
         size_t fsz = jl_datatype_size((jl_datatype_t*)rty); // need to shrink-wrap the final copy
         assert(!isatomic || jl_typeis(rhs, ty));
@@ -1960,6 +1970,7 @@ inline void set_nth_field(jl_datatype_t *st, jl_value_t *v, size_t i, jl_value_t
 inline jl_value_t *swap_bits(jl_value_t *ty, char *v, uint8_t *psel, jl_value_t *parent, jl_value_t *rhs, enum atomic_kind isatomic)
 {
     jl_value_t *rty = jl_typeof(rhs);
+    jl_value_t *layout_ty = normalize_typeofbottom_layout_alias(ty);
     int hasptr;
     int isunion = psel != NULL;
     if (isunion) {
@@ -1967,7 +1978,7 @@ inline jl_value_t *swap_bits(jl_value_t *ty, char *v, uint8_t *psel, jl_value_t 
         hasptr = 0;
     }
     else {
-        hasptr = ((jl_datatype_t*)ty)->layout->first_ptr >= 0;
+        hasptr = ((jl_datatype_t*)layout_ty)->layout->first_ptr >= 0;
     }
     size_t fsz = jl_datatype_size((jl_datatype_t*)rty); // need to shrink-wrap the final copy
     int needlock = (isatomic && fsz > MAX_ATOMIC_SIZE);
@@ -1986,7 +1997,7 @@ inline jl_value_t *swap_bits(jl_value_t *ty, char *v, uint8_t *psel, jl_value_t 
             unlock(v, parent, needlock, isatomic);
         }
         else {
-            r = jl_new_bits(isunion ? jl_nth_union_component(ty, *psel) : ty, v);
+            r = jl_new_bits(isunion ? normalize_typeofbottom_layout_alias(jl_nth_union_component(ty, *psel)) : layout_ty, v);
             if (isunion) {
                 unsigned nth = 0;
                 if (!jl_find_union_component(ty, rty, &nth))
@@ -1999,7 +2010,7 @@ inline jl_value_t *swap_bits(jl_value_t *ty, char *v, uint8_t *psel, jl_value_t 
         }
     }
     if (!isunion)
-        r = undefref_check((jl_datatype_t*)ty, r);
+        r = undefref_check((jl_datatype_t*)layout_ty, r);
     if (hasptr)
         jl_gc_multi_wb(parent, rhs); // rhs is immutable
     if (__unlikely(r == NULL))
@@ -2068,6 +2079,7 @@ inline jl_value_t *modify_value(jl_value_t *ty, _Atomic(jl_value_t*) *p, jl_valu
 
 inline jl_value_t *modify_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value_t *parent, jl_value_t *op, jl_value_t *rhs, enum atomic_kind isatomic)
 {
+    jl_value_t *layout_ty = normalize_typeofbottom_layout_alias(ty);
     int hasptr;
     int isunion = psel != NULL;
     if (isunion) {
@@ -2075,13 +2087,13 @@ inline jl_value_t *modify_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value_
         hasptr = 0;
     }
     else {
-        hasptr = ((jl_datatype_t*)ty)->layout->first_ptr >= 0;
+        hasptr = ((jl_datatype_t*)layout_ty)->layout->first_ptr >= 0;
     }
     jl_value_t **args;
     JL_GC_PUSHARGS(args, 2);
     while (1) {
         jl_value_t *r;
-        jl_value_t *rty = isunion ? jl_nth_union_component(ty, *psel) : ty;
+        jl_value_t *rty = isunion ? normalize_typeofbottom_layout_alias(jl_nth_union_component(ty, *psel)) : layout_ty;
         size_t fsz = jl_datatype_size((jl_datatype_t*)rty); // need to shrink-wrap the initial copy
         int needlock = (isatomic && fsz > MAX_ATOMIC_SIZE);
         if (isatomic && !needlock) {
@@ -2135,7 +2147,7 @@ inline jl_value_t *modify_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value_
                     fsz = jl_datatype_size((jl_datatype_t*)yty); // need to shrink-wrap the final copy
                 }
                 else {
-                    assert(yty == ty && rty == ty);
+                    assert(jl_typeis(y, ty) && rty == layout_ty);
                 }
                 memassign_safe(hasptr, px, y, fsz);
             }
@@ -2199,6 +2211,7 @@ inline jl_value_t *replace_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value
 {
     jl_datatype_t *rettyp = jl_apply_cmpswap_type(ty);
     JL_GC_PROMISE_ROOTED(rettyp); // (JL_ALWAYS_LEAFTYPE)
+    jl_value_t *layout_ty = normalize_typeofbottom_layout_alias(ty);
     int hasptr;
     int isunion = psel != NULL;
     size_t fsz = jl_field_size(rettyp, 0);
@@ -2211,7 +2224,8 @@ inline jl_value_t *replace_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value
         isatomic = isatomic_none; // this makes GCC happy
     }
     else {
-        hasptr = ((jl_datatype_t*)ty)->layout->first_ptr >= 0;
+        rty = layout_ty;
+        hasptr = ((jl_datatype_t*)layout_ty)->layout->first_ptr >= 0;
         assert(jl_typeis(rhs, ty));
     }
     int success;
@@ -2226,7 +2240,7 @@ inline jl_value_t *replace_bits(jl_value_t *ty, char *p, uint8_t *psel, jl_value
     else {
         char *px = lock(p, parent, needlock, isatomic);
         if (isunion)
-            rty = jl_nth_union_component(rty, *psel);
+            rty = normalize_typeofbottom_layout_alias(jl_nth_union_component(rty, *psel));
         size_t rsz = jl_datatype_size((jl_datatype_t*)rty); // need to shrink-wrap the compare
         memcpy((char*)r, px, rsz); // copy field // TODO: make this a memmove_refs if relevant
         if (isunion)
@@ -2322,11 +2336,12 @@ int set_nth_fieldonce(jl_datatype_t *st, jl_value_t *v, size_t i, jl_value_t *rh
         int isunion = jl_is_uniontype(ty);
         if (isunion)
             return 0;
-        int hasptr = ((jl_datatype_t*)ty)->layout->first_ptr >= 0;
+        jl_value_t *layout_ty = normalize_typeofbottom_layout_alias(ty);
+        int hasptr = ((jl_datatype_t*)layout_ty)->layout->first_ptr >= 0;
         if (!hasptr)
             return 0;
         assert(ty == jl_typeof(rhs));
-        success = setonce_bits((jl_datatype_t*)ty, p, v, rhs, isatomic ? isatomic_object : isatomic_none);
+        success = setonce_bits((jl_datatype_t*)layout_ty, p, v, rhs, isatomic ? isatomic_object : isatomic_none);
     }
     return success;
 }
@@ -2337,7 +2352,7 @@ JL_DLLEXPORT int jl_field_isdefined(jl_value_t *v, size_t i) JL_NOTSAFEPOINT
     size_t offs = jl_field_offset(st, i);
     _Atomic(jl_value_t*) *fld = (_Atomic(jl_value_t*)*)((char*)v + offs);
     if (!jl_field_isptr(st, i)) {
-        jl_datatype_t *ft = (jl_datatype_t*)jl_field_type_concrete(st, i);
+        jl_datatype_t *ft = (jl_datatype_t*)normalize_typeofbottom_layout_alias(jl_field_type_concrete(st, i));
         if (!jl_is_datatype(ft) || ft->layout->first_ptr < 0)
             return 2; // isbits are always defined
         fld += ft->layout->first_ptr;
@@ -2614,6 +2629,8 @@ void jl_check_valid_supertype(jl_value_t *super, const char *type_name)
         jl_errorf("invalid subtyping in definition of %s: cannot subtype a Union type.", type_name);
     if (jl_is_typevar(super))
         jl_errorf("invalid subtyping in definition of %s: cannot subtype a type variable.", type_name);
+    if (jl_is_type_type(super))
+        jl_errorf("invalid subtyping in definition of %s: cannot add subtypes to Type.", type_name);
     if (!jl_is_datatype(super)) {
         ios_t buf;
         ios_mem(&buf, 64);

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -394,7 +394,7 @@ int jl_datatype_isinlinealloc(jl_datatype_t *ty, int pointerfree)
 
 static jl_value_t *normalize_typeofbottom_layout_alias(jl_value_t *ty JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    if (jl_typeofbottom_type != NULL && jl_is_type_type(ty) && jl_typeeq_T(ty) == jl_bottom_type)
+    if (jl_typeofbottom_type != NULL && jl_is_typeeq(ty) && jl_typeeq_T(ty) == jl_bottom_type)
         return (jl_value_t*)jl_typeofbottom_type;
     return ty;
 }
@@ -448,7 +448,7 @@ JL_DLLEXPORT int jl_stored_inline(jl_value_t *eltype)
 int jl_pointer_egal(jl_value_t *t)
 {
     if (t == (jl_value_t*)jl_any_type)
-        return 0; // when setting up the initial types, jl_is_type_type gets confused about this
+        return 0; // when setting up the initial types, jl_is_typeeq gets confused about this
     if (t == (jl_value_t*)jl_symbol_type)
         return 1;
     if (t == (jl_value_t*)jl_bool_type)
@@ -459,9 +459,9 @@ int jl_pointer_egal(jl_value_t *t)
         !jl_is_kind(t))
         return 1;
     if ((jl_is_datatype(t) && jl_is_datatype_singleton((jl_datatype_t*)t)) ||
-        (jl_is_type_type(t) && jl_typeeq_T(t) == jl_bottom_type))
+        (jl_is_typeeq(t) && jl_typeeq_T(t) == jl_bottom_type))
         return 1;
-    if (jl_is_type_type(t) && jl_is_datatype(jl_typeeq_T(t))) {
+    if (jl_is_typeeq(t) && jl_is_datatype(jl_typeeq_T(t))) {
         // need to use typeseq for most types
         // but can compare some types by pointer
         jl_datatype_t *dt = (jl_datatype_t*)jl_typeeq_T(t);
@@ -2629,7 +2629,7 @@ void jl_check_valid_supertype(jl_value_t *super, const char *type_name)
         jl_errorf("invalid subtyping in definition of %s: cannot subtype a Union type.", type_name);
     if (jl_is_typevar(super))
         jl_errorf("invalid subtyping in definition of %s: cannot subtype a type variable.", type_name);
-    if (jl_is_type_type(super))
+    if (jl_is_typeeq(super))
         jl_errorf("invalid subtyping in definition of %s: cannot add subtypes to Type.", type_name);
     if (!jl_is_datatype(super)) {
         ios_t buf;

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -392,13 +392,6 @@ int jl_datatype_isinlinealloc(jl_datatype_t *ty, int pointerfree)
     return 0;
 }
 
-static jl_value_t *normalize_typeofbottom_layout_alias(jl_value_t *ty JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
-{
-    if (jl_typeofbottom_type != NULL && jl_is_typeeq(ty) && jl_typeeq_T(ty) == jl_bottom_type)
-        return (jl_value_t*)jl_typeofbottom_type;
-    return ty;
-}
-
 static unsigned union_isinlinable(jl_value_t *ty, int pointerfree, size_t *nbytes, size_t *align, int asfield)
 {
     if (jl_is_uniontype(ty)) {

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -1584,6 +1584,7 @@ STATIC_INLINE void gc_assert_parent_validity(jl_value_t *parent, jl_value_t *chi
     if (child_vt == (jl_datatype_tag << 4) ||
         child_vt == (jl_unionall_tag << 4) ||
         child_vt == (jl_uniontype_tag << 4) ||
+        child_vt == (jl_typeeq_tag << 4) ||
         child_vt == (jl_tvar_tag << 4) ||
         child_vt == (jl_vararg_tag << 4)) {
         // Skip, since these wouldn't hit the object assert anyway
@@ -2284,6 +2285,7 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
         if (vtag == (jl_datatype_tag << 4) ||
             vtag == (jl_unionall_tag << 4) ||
             vtag == (jl_uniontype_tag << 4) ||
+            vtag == (jl_typeeq_tag << 4) ||
             vtag == (jl_tvar_tag << 4) ||
             vtag == (jl_vararg_tag << 4) ||
             vtag == (jl_globalref_tag << 4) ||

--- a/src/gf.c
+++ b/src/gf.c
@@ -858,15 +858,15 @@ static void foreach_top_nth_typename(void (*f)(jl_typename_t*, int, void*), jl_v
         jl_value_t *current_a = (jl_value_t*)arraylist_pop(&workqueue);
         JL_GC_PROMISE_ROOTED(current_a);
 
-        if (jl_is_datatype(current_a)) {
+        if (jl_is_type_type(current_a)) {
+            *facts |= HAVE_TYPE;
+            arraylist_push(&workqueue, jl_typeeq_T(current_a));
+            arraylist_push(&workqueue, (void*)(uintptr_t)-1);
+        }
+        else if (jl_is_datatype(current_a)) {
             if (current_n <= 0) {
                 jl_datatype_t *dt = ((jl_datatype_t*)current_a);
-                if (dt->name == jl_type_typename) { // key Type{T} on T instead of Type
-                    *facts |= HAVE_TYPE;
-                    arraylist_push(&workqueue, jl_tparam0(current_a));
-                    arraylist_push(&workqueue, (void*)(uintptr_t)-1);
-                }
-                else if (dt == jl_function_type) {
+                if (dt == jl_function_type) {
                     if (current_n == -1) // key Type{>:Function} as Type instead of Function
                         *facts |= EXACTLY_TYPE; // HAVE_TYPE is already set
                     else
@@ -1214,8 +1214,9 @@ static void jl_compilation_sig(
             // then the match must been with the kind (e.g. UnionAll or DataType)
             // and the result of matching the type signature
             // needs to be restricted to the concrete type 'kind'
-            jl_value_t *kind = jl_typeof(jl_tparam0(elt));
-            if (jl_subtype(kind, type_i) && !jl_subtype((jl_value_t*)jl_type_type, type_i)) {
+            jl_value_t *kind = jl_typeof(jl_typeeq_T(elt));
+            if (!jl_has_free_typevars(decl_i) &&
+                    jl_subtype(kind, type_i) && !jl_subtype((jl_value_t*)jl_type_type, type_i)) {
                 // if we can prove the match was against the kind (not a Type)
                 // it's simpler (and thus better) to put that cache instead
                 if (!*newparams) *newparams = jl_svec_copy(tt->parameters);
@@ -1257,7 +1258,7 @@ static void jl_compilation_sig(
             // not triggered for isdispatchtuple(tt), this attempts to handle
             // some cases of adapting a random signature into a compilation signature
         }
-        else if (!jl_is_datatype(elt) && jl_subtype(elt, (jl_value_t*)jl_type_type)) { // elt <: Type{T}
+        else if (!jl_is_type_type(elt) && !jl_is_datatype(elt) && jl_subtype(elt, (jl_value_t*)jl_type_type)) { // elt <: Type{T}
             // not triggered for isdispatchtuple(tt), this attempts to handle
             // some cases of adapting a random signature into a compilation signature
             if (!*newparams) *newparams = jl_svec_copy(tt->parameters);
@@ -1290,9 +1291,9 @@ static void jl_compilation_sig(
                     jl_svecset(*newparams, i, jl_type_type);
                 }
             }
-            else if (jl_is_type_type(jl_tparam0(elt)) &&
+            else if (jl_is_type_type(jl_typeeq_T(elt)) &&
                      // try to give up on specializing type parameters for Type{Type{Type{...}}}
-                     (jl_is_type_type(jl_tparam0(jl_tparam0(elt))) || !jl_has_free_typevars(decl_i))) {
+                     (jl_is_type_type(jl_typeeq_T(jl_typeeq_T(elt))) || !jl_has_free_typevars(decl_i))) {
                 /*
                   actual argument was Type{...}, we computed its type as
                   Type{Type{...}}. we like to avoid unbounded nesting here, so
@@ -1364,7 +1365,7 @@ static void jl_compilation_sig(
         }
         if (all_are_subtypes) {
             // avoid Vararg{Type{Type{...}}}
-            if (jl_is_type_type(type_i) && jl_is_type_type(jl_tparam0(type_i)))
+            if (jl_is_type_type(type_i) && jl_is_type_type(jl_typeeq_T(type_i)))
                 type_i = (jl_value_t*)jl_type_type;
             type_i = (jl_value_t*)jl_wrap_vararg(type_i, (jl_value_t*)NULL, 1, 0); // this cannot throw for these inputs
         }
@@ -1390,8 +1391,9 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
 {
     jl_value_t *decl = definition->sig;
 
-    if (!jl_is_datatype(type) || jl_has_free_typevars((jl_value_t*)type))
+    if (!jl_is_datatype(type) || jl_has_free_typevars((jl_value_t*)type)) {
         return 0;
+    }
     if (definition->sig == (jl_value_t*)jl_anytuple_type && jl_atomic_load_relaxed(&definition->unspecialized))
         return jl_egal((jl_value_t*)type, definition->sig); // handle builtin methods
 
@@ -1447,7 +1449,7 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
             if (jl_egal(elt, type_i))
                 continue; // elt could be chosen by inst_varargp_in_env for these sparams
             elt = jl_unwrap_vararg(elt);
-            if (jl_is_type_type(elt) && jl_is_type_type(jl_tparam0(elt))) {
+            if (jl_is_type_type(elt) && jl_is_type_type(jl_typeeq_T(elt))) {
                 JL_GC_POP();
                 return 0; // elt would be set equal to jl_type_type instead
             }
@@ -1470,6 +1472,12 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
         if (jl_is_kind(elt)) {
             // kind slots always get guard entries (checking for subtypes of Type)
             if (jl_subtype(elt, type_i) && !jl_subtype((jl_value_t*)jl_type_type, type_i))
+                continue;
+            // if the declared slot is itself a kind (e.g. `::DataType` or the
+            // maximal `::Kind`, which is type-equal to `Type`), then
+            // jl_compilation_sig keeps the kind argument equal to that slot, so
+            // that is the canonical compileable form.
+            if (jl_is_kind(type_i) && jl_egal(elt, type_i))
                 continue;
             // TODO: other code paths that could reach here?
             JL_GC_POP();
@@ -1495,7 +1503,7 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
                 JL_GC_POP();
                 return 0;
             }
-            if (!jl_is_datatype(elt)) {
+            if (!jl_is_datatype(elt) && !jl_is_type_type(elt)) {
                 JL_GC_POP();
                 return 0;
             }
@@ -1504,19 +1512,20 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
             // then the match must been with kind, such as UnionAll or DataType,
             // and the result of matching the type signature
             // needs to be corrected to the concrete type 'kind' (and not to Type)
-            jl_value_t *kind = jl_typeof(jl_tparam0(elt));
+            jl_value_t *kind = jl_typeof(jl_typeeq_T(elt));
             if (kind == jl_bottom_type) {
                 JL_GC_POP();
                 return 0; // Type{Union{}} gets normalized to typeof(Union{})
             }
-            if (jl_subtype(kind, type_i) && !jl_subtype((jl_value_t*)jl_type_type, type_i)) {
+            if (!jl_has_free_typevars(decl_i) &&
+                    jl_subtype(kind, type_i) && !jl_subtype((jl_value_t*)jl_type_type, type_i)) {
                 JL_GC_POP();
                 return 0; // gets turned into a kind
             }
 
-            else if (jl_is_type_type(jl_tparam0(elt)) &&
+            else if (jl_is_type_type(jl_typeeq_T(elt)) &&
                      // give up on specializing static parameters for Type{Type{Type{...}}}
-                     (jl_is_type_type(jl_tparam0(jl_tparam0(elt))) || !jl_has_free_typevars(decl_i))) {
+                     (jl_is_type_type(jl_typeeq_T(jl_typeeq_T(elt))) || !jl_has_free_typevars(decl_i))) {
                 /*
                   actual argument was Type{...}, we computed its type as
                   Type{Type{...}}. we must avoid unbounded nesting here, so
@@ -1578,7 +1587,7 @@ static int concretesig_equal(jl_value_t *tt, jl_value_t *simplesig) JL_NOTSAFEPO
         jl_value_t *decl = sigs[i];
         jl_value_t *a = types[i];
         if (a != decl && decl != (jl_value_t*)jl_any_type) {
-            if (!(jl_is_type_type(a) && jl_typeof(jl_tparam0(a)) == decl))
+            if (!(jl_is_type_type(a) && jl_typeof(jl_typeeq_T(a)) == decl))
                 return 0;
         }
     }
@@ -1780,7 +1789,7 @@ jl_method_instance_t *cache_method(
         }
         else if (jl_is_type_type(elt)) {
             // TODO: if (!jl_is_singleton(elt)) ...
-            jl_value_t *kind = jl_typeof(jl_tparam0(elt));
+            jl_value_t *kind = jl_typeof(jl_typeeq_T(elt));
             if (!newparams) newparams = jl_svec_copy(cachett->parameters);
             jl_svecset(newparams, i, kind);
         }
@@ -1801,6 +1810,8 @@ jl_method_instance_t *cache_method(
         jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(jl_atomic_load_relaxed(cache), &search, offs, /*subtype*/1);
         if (entry && jl_egal((jl_value_t*)entry->simplesig, simplett ? (jl_value_t*)simplett : jl_nothing) &&
                 jl_egal((jl_value_t*)guardsigs, (jl_value_t*)entry->guardsigs)) {
+            if (mc)
+                JL_UNLOCK(&mc->writelock);
             JL_GC_POP();
             if (mc) JL_UNLOCK(&mc->writelock);
             return entry->func.linfo;

--- a/src/gf.c
+++ b/src/gf.c
@@ -1810,8 +1810,6 @@ jl_method_instance_t *cache_method(
         jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(jl_atomic_load_relaxed(cache), &search, offs, /*subtype*/1);
         if (entry && jl_egal((jl_value_t*)entry->simplesig, simplett ? (jl_value_t*)simplett : jl_nothing) &&
                 jl_egal((jl_value_t*)guardsigs, (jl_value_t*)entry->guardsigs)) {
-            if (mc)
-                JL_UNLOCK(&mc->writelock);
             JL_GC_POP();
             if (mc) JL_UNLOCK(&mc->writelock);
             return entry->func.linfo;

--- a/src/gf.c
+++ b/src/gf.c
@@ -65,7 +65,7 @@ static size_t get_max_varargs(
             dt = jl_nth_argument_datatype(m->sig, 3);
         else
             dt = dt1;
-        if (dt != NULL && !jl_is_type_type((jl_value_t*)dt) && dt != jl_kwcall_type) {
+        if (dt != NULL && !jl_is_typeeq((jl_value_t*)dt) && dt != jl_kwcall_type) {
             if (may_increase != NULL)
                 *may_increase = 1; // `max_args` can increase as new methods are inserted
 
@@ -858,7 +858,7 @@ static void foreach_top_nth_typename(void (*f)(jl_typename_t*, int, void*), jl_v
         jl_value_t *current_a = (jl_value_t*)arraylist_pop(&workqueue);
         JL_GC_PROMISE_ROOTED(current_a);
 
-        if (jl_is_type_type(current_a)) {
+        if (jl_is_typeeq(current_a)) {
             *facts |= HAVE_TYPE;
             arraylist_push(&workqueue, jl_typeeq_T(current_a));
             arraylist_push(&workqueue, (void*)(uintptr_t)-1);
@@ -1209,7 +1209,7 @@ static void jl_compilation_sig(
             elt = type_i;
             jl_svecset(*newparams, i, elt);
         }
-        else if (jl_is_type_type(elt)) {
+        else if (jl_is_typeeq(elt)) {
             // if the declared type was not Any or Union{Type, ...},
             // then the match must been with the kind (e.g. UnionAll or DataType)
             // and the result of matching the type signature
@@ -1258,13 +1258,13 @@ static void jl_compilation_sig(
             // not triggered for isdispatchtuple(tt), this attempts to handle
             // some cases of adapting a random signature into a compilation signature
         }
-        else if (!jl_is_type_type(elt) && !jl_is_datatype(elt) && jl_subtype(elt, (jl_value_t*)jl_type_type)) { // elt <: Type{T}
+        else if (!jl_is_typeeq(elt) && !jl_is_datatype(elt) && jl_subtype(elt, (jl_value_t*)jl_type_type)) { // elt <: Type{T}
             // not triggered for isdispatchtuple(tt), this attempts to handle
             // some cases of adapting a random signature into a compilation signature
             if (!*newparams) *newparams = jl_svec_copy(tt->parameters);
             jl_svecset(*newparams, i, jl_type_type);
         }
-        else if (jl_is_type_type(elt)) { // elt isa Type{T}
+        else if (jl_is_typeeq(elt)) { // elt isa Type{T}
             if (!jl_has_free_typevars(decl_i) && very_general_type(type_i)) {
                 /*
                   Here's a fairly simple heuristic: if this argument slot's
@@ -1291,9 +1291,9 @@ static void jl_compilation_sig(
                     jl_svecset(*newparams, i, jl_type_type);
                 }
             }
-            else if (jl_is_type_type(jl_typeeq_T(elt)) &&
+            else if (jl_is_typeeq(jl_typeeq_T(elt)) &&
                      // try to give up on specializing type parameters for Type{Type{Type{...}}}
-                     (jl_is_type_type(jl_typeeq_T(jl_typeeq_T(elt))) || !jl_has_free_typevars(decl_i))) {
+                     (jl_is_typeeq(jl_typeeq_T(jl_typeeq_T(elt))) || !jl_has_free_typevars(decl_i))) {
                 /*
                   actual argument was Type{...}, we computed its type as
                   Type{Type{...}}. we like to avoid unbounded nesting here, so
@@ -1365,7 +1365,7 @@ static void jl_compilation_sig(
         }
         if (all_are_subtypes) {
             // avoid Vararg{Type{Type{...}}}
-            if (jl_is_type_type(type_i) && jl_is_type_type(jl_typeeq_T(type_i)))
+            if (jl_is_typeeq(type_i) && jl_is_typeeq(jl_typeeq_T(type_i)))
                 type_i = (jl_value_t*)jl_type_type;
             type_i = (jl_value_t*)jl_wrap_vararg(type_i, (jl_value_t*)NULL, 1, 0); // this cannot throw for these inputs
         }
@@ -1449,7 +1449,7 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
             if (jl_egal(elt, type_i))
                 continue; // elt could be chosen by inst_varargp_in_env for these sparams
             elt = jl_unwrap_vararg(elt);
-            if (jl_is_type_type(elt) && jl_is_type_type(jl_typeeq_T(elt))) {
+            if (jl_is_typeeq(elt) && jl_is_typeeq(jl_typeeq_T(elt))) {
                 JL_GC_POP();
                 return 0; // elt would be set equal to jl_type_type instead
             }
@@ -1488,7 +1488,7 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
             return 0;
         }
 
-        if (jl_is_type_type(jl_unwrap_unionall(elt))) {
+        if (jl_is_typeeq(jl_unwrap_unionall(elt))) {
             int iscalled = (i_arg > 0 && i_arg <= 8 && (definition->called & (1 << (i_arg - 1)))) ||
                            jl_has_free_typevars(decl_i);
             if (jl_types_equal(elt, (jl_value_t*)jl_type_type)) {
@@ -1503,7 +1503,7 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
                 JL_GC_POP();
                 return 0;
             }
-            if (!jl_is_datatype(elt) && !jl_is_type_type(elt)) {
+            if (!jl_is_datatype(elt) && !jl_is_typeeq(elt)) {
                 JL_GC_POP();
                 return 0;
             }
@@ -1523,9 +1523,9 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
                 return 0; // gets turned into a kind
             }
 
-            else if (jl_is_type_type(jl_typeeq_T(elt)) &&
+            else if (jl_is_typeeq(jl_typeeq_T(elt)) &&
                      // give up on specializing static parameters for Type{Type{Type{...}}}
-                     (jl_is_type_type(jl_typeeq_T(jl_typeeq_T(elt))) || !jl_has_free_typevars(decl_i))) {
+                     (jl_is_typeeq(jl_typeeq_T(jl_typeeq_T(elt))) || !jl_has_free_typevars(decl_i))) {
                 /*
                   actual argument was Type{...}, we computed its type as
                   Type{Type{...}}. we must avoid unbounded nesting here, so
@@ -1587,7 +1587,7 @@ static int concretesig_equal(jl_value_t *tt, jl_value_t *simplesig) JL_NOTSAFEPO
         jl_value_t *decl = sigs[i];
         jl_value_t *a = types[i];
         if (a != decl && decl != (jl_value_t*)jl_any_type) {
-            if (!(jl_is_type_type(a) && jl_typeof(jl_typeeq_T(a)) == decl))
+            if (!(jl_is_typeeq(a) && jl_typeof(jl_typeeq_T(a)) == decl))
                 return 0;
         }
     }
@@ -1787,7 +1787,7 @@ jl_method_instance_t *cache_method(
         jl_value_t *elt = jl_svecref(cachett->parameters, i);
         if (jl_is_vararg(elt)) {
         }
-        else if (jl_is_type_type(elt)) {
+        else if (jl_is_typeeq(elt)) {
             // TODO: if (!jl_is_singleton(elt)) ...
             jl_value_t *kind = jl_typeof(jl_typeeq_T(elt));
             if (!newparams) newparams = jl_svec_copy(cachett->parameters);
@@ -2102,7 +2102,7 @@ static void update_max_args(jl_value_t *type)
 {
     type = jl_unwrap_unionall(type);
     jl_datatype_t *dt = jl_nth_argument_datatype(type, 1);
-    if (dt == NULL || dt == jl_kwcall_type || jl_is_type_type((jl_value_t*)dt))
+    if (dt == NULL || dt == jl_kwcall_type || jl_is_typeeq((jl_value_t*)dt))
         return;
     jl_typename_t *tn = dt->name;
     assert(jl_is_datatype(type));

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -531,7 +531,7 @@ static jl_datatype_t *staticeval_bitstype(const jl_cgval_t &targ)
 {
     // evaluate an argument at compile time to determine what type it is
     jl_value_t *unw = jl_unwrap_unionall(targ.typ);
-    if (jl_is_type_type(unw)) {
+    if (jl_is_typeeq(unw)) {
         jl_value_t *bt = jl_typeeq_T(unw);
         if (jl_is_primitivetype(bt))
             return (jl_datatype_t*)bt;

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -532,7 +532,7 @@ static jl_datatype_t *staticeval_bitstype(const jl_cgval_t &targ)
     // evaluate an argument at compile time to determine what type it is
     jl_value_t *unw = jl_unwrap_unionall(targ.typ);
     if (jl_is_type_type(unw)) {
-        jl_value_t *bt = jl_tparam0(unw);
+        jl_value_t *bt = jl_typeeq_T(unw);
         if (jl_is_primitivetype(bt))
             return (jl_datatype_t*)bt;
     }

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -66,6 +66,7 @@
     XX(interrupt_exception, jl_value_t*) \
     XX(intersect_type, jl_datatype_t*) \
     XX(intrinsic_type, jl_datatype_t*) \
+    XX(kind_type, jl_datatype_t*) \
     XX(kwcall_type, jl_datatype_t*) \
     XX(lineinfonode_type, jl_datatype_t*) \
     XX(linenumbernode_type, jl_datatype_t*) \
@@ -127,6 +128,7 @@
     XX(tuple_typename, jl_typename_t*) \
     XX(tvar_type, jl_datatype_t*) \
     XX(typeerror_type, jl_datatype_t*) \
+    XX(typeeq_type, jl_datatype_t*) \
     XX(typemap_entry_type, jl_datatype_t*) \
     XX(typemap_level_type, jl_datatype_t*) \
     XX(typename_type, jl_datatype_t*) \

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -66,7 +66,7 @@
     XX(interrupt_exception, jl_value_t*) \
     XX(intersect_type, jl_datatype_t*) \
     XX(intrinsic_type, jl_datatype_t*) \
-    XX(kind_type, jl_datatype_t*) \
+    XX(anytype_type, jl_datatype_t*) \
     XX(kwcall_type, jl_datatype_t*) \
     XX(lineinfonode_type, jl_datatype_t*) \
     XX(linenumbernode_type, jl_datatype_t*) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1876,7 +1876,7 @@ static unsigned typeeq_hash(jl_value_t *T, int *failed) JL_NOTSAFEPOINT
         // the unbounded `Type{T} where T` is `=== Kind`; hash it as such so that
         // e.g. `Vector{Type}` and `Vector{Kind}` land in the same cache bucket
         // (they are equal per `typekey_eq`/`jl_types_equal`).
-        return type_hash((jl_value_t*)jl_kind_type, failed);
+        return type_hash((jl_value_t*)jl_anytype_type, failed);
     unsigned hashT = type_hash(T, failed);
     return bitmix(~jl_type_typename->hash, hashT);
 }
@@ -3187,7 +3187,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_any_type = (jl_datatype_t*)jl_new_abstracttype((jl_value_t*)jl_symbol("Any"), core, NULL, jl_emptysvec);
     jl_any_type->super = jl_any_type;
 
-    jl_kind_type = jl_new_abstracttype((jl_value_t*)jl_symbol("Kind"), core, jl_any_type, jl_emptysvec);
+    jl_anytype_type = jl_new_abstracttype((jl_value_t*)jl_symbol("AnyType"), core, jl_any_type, jl_emptysvec);
     jl_type_type = (jl_unionall_t*)jl_any_type; // replaced with TypeEq(T) where T below
     jl_type_typename = NULL;
 
@@ -3195,7 +3195,7 @@ void jl_init_types(void) JL_GC_DISABLED
     // NOTE: types are not actually mutable, but we want to ensure they are heap-allocated with stable addresses
     jl_datatype_type->name = jl_new_typename_in(jl_symbol("DataType"), core, 0, 1);
     jl_datatype_type->name->wrapper = (jl_value_t*)jl_datatype_type;
-    jl_datatype_type->super = jl_kind_type;
+    jl_datatype_type->super = jl_anytype_type;
     jl_datatype_type->parameters = jl_emptysvec;
     jl_datatype_type->name->n_uninitialized = 8 - 3;
     jl_datatype_type->name->names = jl_perm_symsvec(8,
@@ -3307,14 +3307,14 @@ void jl_init_types(void) JL_GC_DISABLED
     const static uint32_t tvar_constfields[1] = { 0x00000007 }; // all fields are constant, even though TypeVar itself has identity
     jl_tvar_type->name->constfields = tvar_constfields;
 
-    jl_typeofbottom_type = jl_new_datatype(jl_symbol("TypeofBottom"), core, jl_kind_type, jl_emptysvec,
+    jl_typeofbottom_type = jl_new_datatype(jl_symbol("TypeofBottom"), core, jl_anytype_type, jl_emptysvec,
                                            jl_emptysvec, jl_emptysvec, jl_emptysvec, 0, 0, 0);
     XX(typeofbottom);
     jl_bottom_type = jl_gc_permobj(ct->ptls, 0, jl_typeofbottom_type, 0);
     jl_set_typetagof(jl_bottom_type, jl_typeofbottom_tag, GC_OLD_MARKED);
     jl_typeofbottom_type->instance = jl_bottom_type;
 
-    jl_unionall_type = jl_new_datatype(jl_symbol("UnionAll"), core, jl_kind_type, jl_emptysvec,
+    jl_unionall_type = jl_new_datatype(jl_symbol("UnionAll"), core, jl_anytype_type, jl_emptysvec,
                                        jl_perm_symsvec(2, "var", "body"),
                                        jl_svec(2, jl_tvar_type, jl_any_type),
                                        jl_emptysvec, 0, 0, 2);
@@ -3322,7 +3322,7 @@ void jl_init_types(void) JL_GC_DISABLED
     // It seems like we probably usually end up needing the box for kinds (often used in an Any context), so force it to exist
     jl_unionall_type->name->mayinlinealloc = 0;
 
-    jl_uniontype_type = jl_new_datatype(jl_symbol("Union"), core, jl_kind_type, jl_emptysvec,
+    jl_uniontype_type = jl_new_datatype(jl_symbol("Union"), core, jl_anytype_type, jl_emptysvec,
                                         jl_perm_symsvec(2, "a", "b"),
                                         jl_svec(2, jl_any_type, jl_any_type),
                                         jl_emptysvec, 0, 0, 2);
@@ -3330,21 +3330,21 @@ void jl_init_types(void) JL_GC_DISABLED
     // It seems like we probably usually end up needing the box for kinds (often used in an Any context), so force it to exist
     jl_uniontype_type->name->mayinlinealloc = 0;
 
-    jl_value_t *kind_or_typevar_types[2] = { (jl_value_t*)jl_kind_type, (jl_value_t*)jl_tvar_type };
-    jl_value_t *kind_or_typevar_type = jl_type_union(kind_or_typevar_types, 2);
+    jl_value_t *anytype_or_typevar_types[2] = { (jl_value_t*)jl_anytype_type, (jl_value_t*)jl_tvar_type };
+    jl_value_t *kind_or_typevar_type = jl_type_union(anytype_or_typevar_types, 2);
     jl_svecset(jl_tvar_type->types, 1, kind_or_typevar_type);
     jl_svecset(jl_tvar_type->types, 2, kind_or_typevar_type);
 
     // Internal-use-only kind dual to Union (see #61917). Not registered as a
     // small_typeof tag: it is recognized by identity (jl_is_intersecttype) and
     // only ever lives transiently inside the subtyping algorithm.
-    jl_intersect_type = jl_new_datatype(jl_symbol("Intersect"), core, jl_kind_type, jl_emptysvec,
+    jl_intersect_type = jl_new_datatype(jl_symbol("Intersect"), core, jl_anytype_type, jl_emptysvec,
                                         jl_perm_symsvec(2, "a", "b"),
                                         jl_svec(2, jl_any_type, jl_any_type),
                                         jl_emptysvec, 0, 0, 2);
     jl_intersect_type->name->mayinlinealloc = 0;
 
-    jl_typeeq_type = jl_new_datatype(jl_symbol("TypeEq"), core, jl_kind_type, jl_emptysvec,
+    jl_typeeq_type = jl_new_datatype(jl_symbol("TypeEq"), core, jl_anytype_type, jl_emptysvec,
                                      jl_perm_symsvec(1, "T"),
                                      jl_svec(1, kind_or_typevar_type),
                                      jl_emptysvec, 0, 0, 1);
@@ -3380,7 +3380,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_anytuple_type->maybe_subtype_of_cache = 0;
     jl_anytuple_type->layout = NULL;
 
-    jl_typeofbottom_type->super = jl_kind_type;
+    jl_typeofbottom_type->super = jl_anytype_type;
     jl_emptytuple_type = (jl_datatype_t*)jl_apply_tuple_type(jl_emptysvec, 0);
     jl_emptytuple = jl_gc_permobj(ct->ptls, 0, jl_emptytuple_type, 0);
     jl_emptytuple_type->instance = jl_emptytuple;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -104,7 +104,7 @@ static int layout_uses_free_typevars(jl_value_t *v, jl_typeenv_t *env)
                 return 1;
            v = ((jl_uniontype_t*)v)->b;
         }
-        else if (jl_is_type_type(v)) {
+        else if (jl_is_typeeq(v)) {
             v = jl_typeeq_T(v);
         }
         else if (jl_is_vararg(v)) {
@@ -160,7 +160,7 @@ static int has_free_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT
                 return 1;
            v = ((jl_uniontype_t*)v)->b;
         }
-        else if (jl_is_type_type(v)) {
+        else if (jl_is_typeeq(v)) {
             v = jl_typeeq_T(v);
         }
         else if (jl_is_vararg(v)) {
@@ -234,7 +234,7 @@ static void find_free_typevars(jl_value_t *v, jl_typeenv_t *env, jl_array_t *out
             find_free_typevars(((jl_uniontype_t*)v)->a, env, out);
             v = ((jl_uniontype_t*)v)->b;
         }
-        else if (jl_is_type_type(v)) {
+        else if (jl_is_typeeq(v)) {
             v = jl_typeeq_T(v);
         }
         else if (jl_is_vararg(v)) {
@@ -308,7 +308,7 @@ int jl_has_bound_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT
                 return 1;
            v = ((jl_uniontype_t*)v)->b;
         }
-        else if (jl_is_type_type(v)) {
+        else if (jl_is_typeeq(v)) {
             v = jl_typeeq_T(v);
         }
         else if (jl_is_vararg(v)) {
@@ -629,7 +629,7 @@ static int simple_subtype(jl_value_t *a, jl_value_t *b, int hasfree, int isUnion
     if (hasfree == 0) {
         int mergeable = isUnion;
         if (!mergeable) // issue #24521: don't merge Type{T} where typeof(T) varies
-            mergeable = !(jl_is_type_type(a) && jl_is_type_type(b) &&
+            mergeable = !(jl_is_typeeq(a) && jl_is_typeeq(b) &&
              jl_typeof(jl_typeeq_T(a)) != jl_typeof(jl_typeeq_T(b)));
         return mergeable && jl_subtype(a, b);
     }
@@ -652,7 +652,7 @@ static int simple_subtype(jl_value_t *a, jl_value_t *b, int hasfree, int isUnion
         // This branch is not valid for `Union`/`UnionAll`, e.g.
         // (Type{Union{Int,T2} where {T2<:T1}} where {T1}){Int} == Type{Int64}
         // (Type{Union{Int,T1}} where {T1}){Int} == Type{Int64}
-        return jl_is_type_type(a) && jl_typeof(jl_typeeq_T(a)) == b;
+        return jl_is_typeeq(a) && jl_typeof(jl_typeeq_T(a)) == b;
     }
     return 0;
 }
@@ -771,7 +771,7 @@ static int simple_subtype2(jl_value_t *a, jl_value_t *b, int hasfree, int isUnio
         subab = simple_subtype(a, b, hasfree, isUnion);
         subba = simple_subtype(b, a, ((hasfree & 2) >> 1) | ((hasfree & 1) << 1), isUnion);
     }
-    else if (jl_is_type_type(a) && jl_is_type_type(b) &&
+    else if (jl_is_typeeq(a) && jl_is_typeeq(b) &&
              jl_typeof(jl_typeeq_T(a)) != jl_typeof(jl_typeeq_T(b))) {
         // issue #24521: don't merge Type{T} where typeof(T) varies
     }
@@ -1015,7 +1015,7 @@ JL_DLLEXPORT jl_value_t *jl_type_unionall(jl_tvar_t *v, jl_value_t *body)
     if (body == (jl_value_t*)v)
         return v->ub;
     // where var doesn't occur in body just return body
-    if (jl_is_type_type(body) && v->ub != (jl_value_t*)jl_any_type) {
+    if (jl_is_typeeq(body) && v->ub != (jl_value_t*)jl_any_type) {
         if (!jl_has_typevar(body, v))
             return body;
     }
@@ -1044,7 +1044,7 @@ static int typekey_eq(jl_datatype_t *tt, jl_value_t **key, size_t n)
                 // require exact same Type{T} in covariant context. see e.g. issue #22842
                 // this should work because `Tuple{Type}`s don't need unique pointers, and aren't the
                 // direct tags of values (concrete) so we don't rely on pointer equality.
-                if (jl_is_type_type(tj) || jl_is_type_type(kj))
+                if (jl_is_typeeq(tj) || jl_is_typeeq(kj))
                     return 0;
             }
             if (jl_type_equality_is_identity(tj, kj))
@@ -1069,7 +1069,7 @@ static int typekeyvalue_eq(jl_datatype_t *tt, jl_value_t *key1, jl_value_t **key
     for (j = 0; j < n; j++) {
         jl_value_t *kj = j == 0 ? key1 : key[j - 1];
         jl_value_t *tj = jl_svecref(tt->parameters, j);
-        if (leaf && jl_is_type_type(tj)) {
+        if (leaf && jl_is_typeeq(tj)) {
             jl_value_t *tp0 = jl_typeeq_T(tj);
             if (!(kj == tp0 || (jl_typeof(tp0) == jl_typeof(kj) && jl_types_equal(tp0, kj))))
                 return 0;
@@ -1403,7 +1403,7 @@ static int has_concrete_supertype(jl_value_t *kj) JL_NOTSAFEPOINT
         int cb = has_concrete_supertype(((jl_uniontype_t*)uw)->b);
         return ca && cb;
     }
-    else if (jl_is_type_type(uw)) {
+    else if (jl_is_typeeq(uw)) {
         return 1;
     }
     else if (uw == jl_bottom_type) {
@@ -1774,7 +1774,7 @@ jl_value_t *jl_substitute_datatype(jl_value_t *t, jl_datatype_t * x, jl_datatype
         }
         JL_GC_POP();
     }
-    else if (jl_is_type_type(t)) {
+    else if (jl_is_typeeq(t)) {
         jl_typeeq_t *te = (jl_typeeq_t*)t;
         jl_value_t *T = NULL;
         JL_GC_PUSH1(&T);
@@ -1854,7 +1854,7 @@ static unsigned type_hash(jl_value_t *kj, int *failed) JL_NOTSAFEPOINT
         // since Union is associative
         return hasha + hashb;
     }
-    else if (jl_is_type_type(uw)) {
+    else if (jl_is_typeeq(uw)) {
         jl_value_t *T = jl_typeeq_T(uw);
         if (T == jl_bottom_type)
             return jl_typeofbottom_type->hash;
@@ -1886,7 +1886,7 @@ JL_DLLEXPORT uintptr_t jl_type_cache_hash(jl_value_t *v) JL_NOTSAFEPOINT
     uintptr_t hash = type_hash(v, &failed);
     if (!failed)
         return hash;
-    if (jl_is_type_type(v)) {
+    if (jl_is_typeeq(v)) {
         jl_value_t *T = jl_typeeq_T(v);
         if (!jl_has_free_typevars(T)) {
             jl_value_t *tw = extract_wrapper(T);
@@ -1972,7 +1972,7 @@ void jl_precompute_memoized_dt(jl_datatype_t *dt, int cacheable)
                     (jl_is_datatype(p) && ((!jl_is_kind(p) && ((jl_datatype_t*)p)->isconcretetype) ||
                      (p == (jl_value_t*)jl_typeofbottom_type) || // == Type{Union{}}, so needs to be consistent
                      (((jl_datatype_t*)p)->name == jl_type_typename && !((jl_datatype_t*)p)->hasfreetypevars))) ||
-                    (jl_is_type_type(p) && !jl_has_free_typevars(p));
+                    (jl_is_typeeq(p) && !jl_has_free_typevars(p));
             }
         }
         if (jl_is_vararg(p))
@@ -2119,7 +2119,7 @@ static int _may_substitute_ub(jl_value_t *v, jl_tvar_t *var, int inside_inv, int
                 inside_inv = 1; // treat as invariant inside vararg, for the sake of this algorithm
             v = va->T;
         }
-        else if (jl_is_type_type(v)) {
+        else if (jl_is_typeeq(v)) {
             inside_inv = 1;
             v = jl_typeeq_T(v);
         }
@@ -2154,7 +2154,7 @@ static jl_value_t *normalize_unionalls(jl_value_t *t)
         }
         JL_GC_POP();
     }
-    else if (jl_is_type_type(t)) {
+    else if (jl_is_typeeq(t)) {
         jl_typeeq_t *te = (jl_typeeq_t*)t;
         jl_value_t *T = normalize_unionalls(te->T);
         JL_GC_PUSH1(&T);
@@ -2294,7 +2294,7 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
                 if (p) jl_gc_wb(p, tw);
             }
         }
-        if (tn == jl_type_typename && jl_is_type_type(iparams[0]) &&
+        if (tn == jl_type_typename && jl_is_typeeq(iparams[0]) &&
             jl_typeeq_T(iparams[0]) == jl_bottom_type) {
             // normalize Type{Type{Union{}}} to Type{TypeofBottom}
             iparams[0] = (jl_value_t*)jl_typeofbottom_type;
@@ -2826,7 +2826,7 @@ static jl_value_t *inst_type_w_(jl_value_t *t, jl_typeenv_t *env, jl_typestack_t
         JL_GC_POP();
         return t;
     }
-    if (jl_is_type_type(t)) {
+    if (jl_is_typeeq(t)) {
         jl_typeeq_t *te = (jl_typeeq_t*)t;
         jl_value_t *T = inst_type_w_(te->T, env, stack, check, nothrow ? 1 : 0);
         JL_GC_PUSH1(&T);
@@ -2946,7 +2946,7 @@ JL_DLLEXPORT jl_value_t *jl_instantiate_type_in_env(jl_value_t *ty, jl_unionall_
 
 jl_typeeq_t *jl_wrap_Type(jl_value_t *t)
 {
-    if (jl_is_type_type(t) && jl_typeeq_T(t) == jl_bottom_type)
+    if (jl_is_typeeq(t) && jl_typeeq_T(t) == jl_bottom_type)
         t = (jl_value_t*)jl_typeofbottom_type;
     jl_value_t *tw = extract_wrapper(t);
     if (tw && tw != t && jl_typeof(t) == jl_typeof(tw) &&

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3320,6 +3320,11 @@ void jl_init_types(void) JL_GC_DISABLED
     // It seems like we probably usually end up needing the box for kinds (often used in an Any context), so force it to exist
     jl_uniontype_type->name->mayinlinealloc = 0;
 
+    jl_value_t *kind_or_typevar_types[2] = { (jl_value_t*)jl_kind_type, (jl_value_t*)jl_tvar_type };
+    jl_value_t *kind_or_typevar_type = jl_type_union(kind_or_typevar_types, 2);
+    jl_svecset(jl_tvar_type->types, 1, kind_or_typevar_type);
+    jl_svecset(jl_tvar_type->types, 2, kind_or_typevar_type);
+
     // Internal-use-only kind dual to Union (see #61917). Not registered as a
     // small_typeof tag: it is recognized by identity (jl_is_intersecttype) and
     // only ever lives transiently inside the subtyping algorithm.
@@ -3331,7 +3336,7 @@ void jl_init_types(void) JL_GC_DISABLED
 
     jl_typeeq_type = jl_new_datatype(jl_symbol("TypeEq"), core, jl_kind_type, jl_emptysvec,
                                      jl_perm_symsvec(1, "T"),
-                                     jl_svec(1, jl_any_type),
+                                     jl_svec(1, kind_or_typevar_type),
                                      jl_emptysvec, 0, 0, 1);
     XX(typeeq);
     // It seems like we probably usually end up needing the box for kinds (often used in an Any context), so force it to exist

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -78,8 +78,11 @@ static int layout_uses_free_typevars(jl_value_t *v, jl_typeenv_t *env)
                 return 0;
             if (dt->layout || !dt->name->mayinlinealloc)
                 return 0;
-            if (dt->name == jl_namedtuple_typename)
-                return layout_uses_free_typevars(jl_tparam0(dt), env) || layout_uses_free_typevars(jl_tparam1(dt), env);
+            if (dt->name == jl_namedtuple_typename) {
+                jl_value_t *names = jl_tparam0(dt);
+                jl_value_t *types = jl_tparam1(dt);
+                return layout_uses_free_typevars(names, env) || layout_uses_free_typevars(types, env);
+            }
             if (dt->name == jl_tuple_typename)
                 // conservative, since we don't want to inline an abstract tuple,
                 // and we currently declare !has_fixed_layout for these, but that
@@ -101,12 +104,17 @@ static int layout_uses_free_typevars(jl_value_t *v, jl_typeenv_t *env)
                 return 1;
            v = ((jl_uniontype_t*)v)->b;
         }
+        else if (jl_is_type_type(v)) {
+            v = jl_typeeq_T(v);
+        }
         else if (jl_is_vararg(v)) {
             jl_vararg_t *vm = (jl_vararg_t*)v;
             if (!vm->T)
                 return 0;
-            if (vm->N && layout_uses_free_typevars(vm->N, env))
-                return 1;
+            if (vm->N) {
+                if (layout_uses_free_typevars(vm->N, env))
+                    return 1;
+            }
             v = vm->T;
         }
         else {
@@ -152,12 +160,17 @@ static int has_free_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT
                 return 1;
            v = ((jl_uniontype_t*)v)->b;
         }
+        else if (jl_is_type_type(v)) {
+            v = jl_typeeq_T(v);
+        }
         else if (jl_is_vararg(v)) {
             jl_vararg_t *vm = (jl_vararg_t*)v;
             if (!vm->T)
                 return 0;
-            if (vm->N && has_free_typevars(vm->N, env))
-                return 1;
+            if (vm->N) {
+                if (has_free_typevars(vm->N, env))
+                    return 1;
+            }
             v = vm->T;
         }
         else {
@@ -211,20 +224,26 @@ static void find_free_typevars(jl_value_t *v, jl_typeenv_t *env, jl_array_t *out
             if (!((jl_datatype_t*)v)->hasfreetypevars)
                 return;
             size_t i;
-            for (i = 0; i < jl_nparams(v); i++)
-                find_free_typevars(jl_tparam(v, i), env, out);
+            for (i = 0; i < jl_nparams(v); i++) {
+                jl_value_t *p = jl_tparam(v, i);
+                find_free_typevars(p, env, out);
+            }
             return;
         }
         else if (jl_is_uniontype(v) || jl_is_intersecttype(v)) {
             find_free_typevars(((jl_uniontype_t*)v)->a, env, out);
             v = ((jl_uniontype_t*)v)->b;
         }
+        else if (jl_is_type_type(v)) {
+            v = jl_typeeq_T(v);
+        }
         else if (jl_is_vararg(v)) {
             jl_vararg_t *vm = (jl_vararg_t *)v;
             if (!vm->T)
                 return;
-            if (vm->N) // this swap the visited order, but we don't mind it
+            if (vm->N) { // this swap the visited order, but we don't mind it
                 find_free_typevars(vm->N, env, out);
+            }
             v = vm->T;
         }
         else {
@@ -289,12 +308,17 @@ int jl_has_bound_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT
                 return 1;
            v = ((jl_uniontype_t*)v)->b;
         }
+        else if (jl_is_type_type(v)) {
+            v = jl_typeeq_T(v);
+        }
         else if (jl_is_vararg(v)) {
             jl_vararg_t *vm = (jl_vararg_t *)v;
             if (!vm->T)
                 return 0;
-            if (vm->N && jl_has_bound_typevars(vm->N, env))
-                return 1;
+            if (vm->N) {
+                if (jl_has_bound_typevars(vm->N, env))
+                    return 1;
+            }
             v = vm->T;
         }
         else {
@@ -338,8 +362,11 @@ int jl_has_fixed_layout(jl_datatype_t *dt)
         return 1;
     if (dt->name->abstract)
         return 0;
-    if (dt->name == jl_namedtuple_typename)
-        return !layout_uses_free_typevars(jl_tparam0(dt), NULL) && !layout_uses_free_typevars(jl_tparam1(dt), NULL);
+    if (dt->name == jl_namedtuple_typename) {
+        jl_value_t *names = jl_tparam0(dt);
+        jl_value_t *types = jl_tparam1(dt);
+        return !layout_uses_free_typevars(names, NULL) && !layout_uses_free_typevars(types, NULL);
+    }
     if (dt->name == jl_tuple_typename)
         return 0;
     jl_svec_t *types = jl_get_fieldtypes(dt);
@@ -603,7 +630,7 @@ static int simple_subtype(jl_value_t *a, jl_value_t *b, int hasfree, int isUnion
         int mergeable = isUnion;
         if (!mergeable) // issue #24521: don't merge Type{T} where typeof(T) varies
             mergeable = !(jl_is_type_type(a) && jl_is_type_type(b) &&
-             jl_typeof(jl_tparam0(a)) != jl_typeof(jl_tparam0(b)));
+             jl_typeof(jl_typeeq_T(a)) != jl_typeof(jl_typeeq_T(b)));
         return mergeable && jl_subtype(a, b);
     }
     if (jl_is_typevar(a)) {
@@ -625,7 +652,7 @@ static int simple_subtype(jl_value_t *a, jl_value_t *b, int hasfree, int isUnion
         // This branch is not valid for `Union`/`UnionAll`, e.g.
         // (Type{Union{Int,T2} where {T2<:T1}} where {T1}){Int} == Type{Int64}
         // (Type{Union{Int,T1}} where {T1}){Int} == Type{Int64}
-        return jl_is_type_type(a) && jl_typeof(jl_tparam0(a)) == b;
+        return jl_is_type_type(a) && jl_typeof(jl_typeeq_T(a)) == b;
     }
     return 0;
 }
@@ -745,7 +772,7 @@ static int simple_subtype2(jl_value_t *a, jl_value_t *b, int hasfree, int isUnio
         subba = simple_subtype(b, a, ((hasfree & 2) >> 1) | ((hasfree & 1) << 1), isUnion);
     }
     else if (jl_is_type_type(a) && jl_is_type_type(b) &&
-             jl_typeof(jl_tparam0(a)) != jl_typeof(jl_tparam0(b))) {
+             jl_typeof(jl_typeeq_T(a)) != jl_typeof(jl_typeeq_T(b))) {
         // issue #24521: don't merge Type{T} where typeof(T) varies
     }
     else if (jl_typeof(a) == jl_typeof(b) && jl_types_egal(a, b)) {
@@ -832,7 +859,7 @@ jl_value_t *simple_union(jl_value_t *a, jl_value_t *b)
     return tu;
 }
 
-int obviously_disjoint(jl_value_t *a, jl_value_t *b, int specificity);
+int obviously_disjoint(jl_value_t *a, jl_value_t *b, int specificity) JL_NOTSAFEPOINT;
 
 jl_value_t *simple_intersect(jl_value_t *a, jl_value_t *b, int overesi)
 {
@@ -988,7 +1015,11 @@ JL_DLLEXPORT jl_value_t *jl_type_unionall(jl_tvar_t *v, jl_value_t *body)
     if (body == (jl_value_t*)v)
         return v->ub;
     // where var doesn't occur in body just return body
-    if (!jl_has_typevar(body, v))
+    if (jl_is_type_type(body) && v->ub != (jl_value_t*)jl_any_type) {
+        if (!jl_has_typevar(body, v))
+            return body;
+    }
+    else if (!jl_has_typevar(body, v))
         return body;
     //if (v->lb == v->ub)  // TODO maybe
     //    return jl_substitute_var(body, v, v->ub);
@@ -1005,15 +1036,6 @@ static int typekey_eq(jl_datatype_t *tt, jl_value_t **key, size_t n)
     size_t tnp = jl_nparams(tt);
     if (n != tnp)
         return 0;
-    if (tt->name == jl_type_typename) {
-        // for Type{T}, require `typeof(T)` to match also, to avoid incorrect
-        // dispatch from changing the type of something.
-        // this should work because `Type`s don't need unique pointers, and aren't the
-        // direct tags of values (concrete) so we don't rely on pointer equality.
-        jl_value_t *kj = key[0];
-        jl_value_t *tj = jl_tparam0(tt);
-        return (kj == tj || (jl_typeof(tj) == jl_typeof(kj) && jl_types_equal(tj, kj)));
-    }
     for (j = 0; j < n; j++) {
         jl_value_t *kj = key[j];
         jl_value_t *tj = jl_svecref(tt->parameters, j);
@@ -1044,20 +1066,11 @@ static int typekeyvalue_eq(jl_datatype_t *tt, jl_value_t *key1, jl_value_t **key
     size_t tnp = jl_nparams(tt);
     if (n != tnp)
         return 0;
-    if (leaf && tt->name == jl_type_typename) {
-        // for Type{T}, require `typeof(T)` to match also, to avoid incorrect
-        // dispatch from changing the type of something.
-        // this should work because `Type`s don't have uids, and aren't the
-        // direct tags of values so we don't rely on pointer equality.
-        jl_value_t *kj = key1;
-        jl_value_t *tj = jl_tparam0(tt);
-        return (kj == tj || (jl_typeof(tj) == jl_typeof(kj) && jl_types_equal(tj, kj)));
-    }
     for (j = 0; j < n; j++) {
         jl_value_t *kj = j == 0 ? key1 : key[j - 1];
         jl_value_t *tj = jl_svecref(tt->parameters, j);
         if (leaf && jl_is_type_type(tj)) {
-            jl_value_t *tp0 = jl_tparam0(tj);
+            jl_value_t *tp0 = jl_typeeq_T(tj);
             if (!(kj == tp0 || (jl_typeof(tp0) == jl_typeof(kj) && jl_types_equal(tp0, kj))))
                 return 0;
         }
@@ -1073,6 +1086,7 @@ static int typekeyvalue_eq(jl_datatype_t *tt, jl_value_t *key1, jl_value_t **key
 
 static unsigned typekey_hash(jl_typename_t *tn, jl_value_t **key, size_t n, int nofail) JL_NOTSAFEPOINT;
 static unsigned typekeyvalue_hash(jl_typename_t *tn, jl_value_t *key1, jl_value_t **key, size_t n, int leaf) JL_NOTSAFEPOINT;
+static jl_value_t *extract_wrapper(jl_value_t *t JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT JL_GLOBALLY_ROOTED;
 
 /* returns val if key is in hash, otherwise NULL */
 static jl_datatype_t *lookup_type_set(jl_svec_t *cache, jl_value_t **key, size_t n, uint_t hv)
@@ -1389,6 +1403,9 @@ static int has_concrete_supertype(jl_value_t *kj) JL_NOTSAFEPOINT
         int cb = has_concrete_supertype(((jl_uniontype_t*)uw)->b);
         return ca && cb;
     }
+    else if (jl_is_type_type(uw)) {
+        return 1;
+    }
     else if (uw == jl_bottom_type) {
         return 1;
     }
@@ -1463,6 +1480,15 @@ jl_value_t *jl_apply_type(jl_value_t *tc, jl_value_t **params, size_t n)
         return jl_apply_tuple_type_v(params, n);
     if (tc == (jl_value_t*)jl_uniontype_type)
         return (jl_value_t*)jl_type_union(params, n);
+    if (tc == (jl_value_t*)jl_typeeq_type) {
+        if (n == 0)
+            return (jl_value_t*)jl_type_type;
+        if (n != 1)
+            jl_errorf("too many parameters for type `TypeEq`: expected 1, got %zu", n);
+        if (!jl_valid_type_param(params[0]))
+            jl_type_error_rt("TypeEq", "parameter", (jl_value_t*)jl_type_type, params[0]);
+        return (jl_value_t*)jl_wrap_Type(params[0]);
+    }
     size_t i;
     if (n > 1) {
         // detect common case of applying a wrapper, where we know that all parameters will
@@ -1748,6 +1774,15 @@ jl_value_t *jl_substitute_datatype(jl_value_t *t, jl_datatype_t * x, jl_datatype
         }
         JL_GC_POP();
     }
+    else if (jl_is_type_type(t)) {
+        jl_typeeq_t *te = (jl_typeeq_t*)t;
+        jl_value_t *T = NULL;
+        JL_GC_PUSH1(&T);
+        T = jl_substitute_datatype(te->T, x, y);
+        if (T != te->T)
+            t = (jl_value_t*)jl_wrap_Type(T);
+        JL_GC_POP();
+    }
     else if jl_is_vararg(t) { // recursively call itself on T
         jl_vararg_t *vt = (jl_vararg_t*)t;
         if (vt->T) { // vt->T could be NULL
@@ -1819,6 +1854,19 @@ static unsigned type_hash(jl_value_t *kj, int *failed) JL_NOTSAFEPOINT
         // since Union is associative
         return hasha + hashb;
     }
+    else if (jl_is_type_type(uw)) {
+        jl_value_t *T = jl_typeeq_T(uw);
+        if (T == jl_bottom_type)
+            return jl_typeofbottom_type->hash;
+        if (jl_is_typevar(T) && ((jl_tvar_t*)T)->lb == jl_bottom_type &&
+                ((jl_tvar_t*)T)->ub == (jl_value_t*)jl_any_type)
+            // the unbounded `Type{T} where T` is `=== Kind`; hash it as such so
+            // that e.g. `Vector{Type}` and `Vector{Kind}` land in the same cache
+            // bucket (they are equal per `typekey_eq`/`jl_types_equal`).
+            return type_hash((jl_value_t*)jl_kind_type, failed);
+        unsigned hashT = type_hash(T, failed);
+        return bitmix(~jl_type_typename->hash, hashT);
+    }
     else {
         return jl_object_id(uw);
     }
@@ -1830,6 +1878,25 @@ JL_DLLEXPORT uintptr_t jl_type_hash(jl_value_t *v) JL_NOTSAFEPOINT
     // for other parts of the internal algorithm but not for exposing to the Julia side.
     int failed = 0;
     return type_hash(v, &failed);
+}
+
+JL_DLLEXPORT uintptr_t jl_type_cache_hash(jl_value_t *v) JL_NOTSAFEPOINT
+{
+    int failed = 0;
+    uintptr_t hash = type_hash(v, &failed);
+    if (!failed)
+        return hash;
+    if (jl_is_type_type(v)) {
+        jl_value_t *T = jl_typeeq_T(v);
+        if (!jl_has_free_typevars(T)) {
+            jl_value_t *tw = extract_wrapper(T);
+            if (tw && (tw == T || (jl_typeof(T) == jl_typeof(tw) && jl_types_egal(T, tw)))) {
+                jl_value_t *key = tw;
+                return typekey_hash(jl_type_typename, &key, 1, 1);
+            }
+        }
+    }
+    return 0;
 }
 
 static unsigned typekey_hash(jl_typename_t *tn, jl_value_t **key, size_t n, int nofail) JL_NOTSAFEPOINT
@@ -1898,12 +1965,14 @@ void jl_precompute_memoized_dt(jl_datatype_t *dt, int cacheable)
         }
         if (istuple) {
             if (dt->isconcretetype)
-                dt->isconcretetype = (jl_is_datatype(p) && ((jl_datatype_t*)p)->isconcretetype) || p == jl_bottom_type;
+                dt->isconcretetype = (jl_is_datatype(p) && ((jl_datatype_t*)p)->isconcretetype) ||
+                    p == jl_bottom_type;
             if (dt->isdispatchtuple) {
-                dt->isdispatchtuple = jl_is_datatype(p) &&
-                    ((!jl_is_kind(p) && ((jl_datatype_t*)p)->isconcretetype) ||
+                dt->isdispatchtuple =
+                    (jl_is_datatype(p) && ((!jl_is_kind(p) && ((jl_datatype_t*)p)->isconcretetype) ||
                      (p == (jl_value_t*)jl_typeofbottom_type) || // == Type{Union{}}, so needs to be consistent
-                     (((jl_datatype_t*)p)->name == jl_type_typename && !((jl_datatype_t*)p)->hasfreetypevars));
+                     (((jl_datatype_t*)p)->name == jl_type_typename && !((jl_datatype_t*)p)->hasfreetypevars))) ||
+                    (jl_is_type_type(p) && !jl_has_free_typevars(p));
             }
         }
         if (jl_is_vararg(p))
@@ -2026,7 +2095,8 @@ static int _may_substitute_ub(jl_value_t *v, jl_tvar_t *var, int inside_inv, int
         if (jl_is_datatype(v)) {
             int invar = inside_inv || !jl_is_tuple_type(v);
             for (size_t i = 0; i < jl_nparams(v); i++) {
-                if (!_may_substitute_ub(jl_tparam(v, i), var, invar, cov_count))
+                jl_value_t *p = jl_tparam(v, i);
+                if (!_may_substitute_ub(p, var, invar, cov_count))
                     return 0;
             }
             return 1;
@@ -2041,11 +2111,17 @@ static int _may_substitute_ub(jl_value_t *v, jl_tvar_t *var, int inside_inv, int
             jl_vararg_t *va = (jl_vararg_t*)v;
             if (!va->T)
                 return 1;
-            if (va->N && !_may_substitute_ub(va->N, var, 1, cov_count))
-                return 0;
+            if (va->N) {
+                if (!_may_substitute_ub(va->N, var, 1, cov_count))
+                    return 0;
+            }
             if (!jl_is_concrete_type(var->ub))
                 inside_inv = 1; // treat as invariant inside vararg, for the sake of this algorithm
             v = va->T;
+        }
+        else if (jl_is_type_type(v)) {
+            inside_inv = 1;
+            v = jl_typeeq_T(v);
         }
         else {
             return 1;
@@ -2076,6 +2152,14 @@ static jl_value_t *normalize_unionalls(jl_value_t *t)
         if (a != u->a || b != u->b) {
             t = jl_new_struct(jl_uniontype_type, a, b);
         }
+        JL_GC_POP();
+    }
+    else if (jl_is_type_type(t)) {
+        jl_typeeq_t *te = (jl_typeeq_t*)t;
+        jl_value_t *T = normalize_unionalls(te->T);
+        JL_GC_PUSH1(&T);
+        if (T != te->T && jl_typeof(T) == jl_typeof(te->T))
+            t = (jl_value_t*)jl_wrap_Type(T);
         JL_GC_POP();
     }
     else if (jl_is_unionall(t)) {
@@ -2210,8 +2294,8 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
                 if (p) jl_gc_wb(p, tw);
             }
         }
-        if (tn == jl_type_typename && jl_is_datatype(iparams[0]) && ((jl_datatype_t*)iparams[0])->name == jl_type_typename &&
-            jl_tparam0(iparams[0]) == jl_bottom_type) {
+        if (tn == jl_type_typename && jl_is_type_type(iparams[0]) &&
+            jl_typeeq_T(iparams[0]) == jl_bottom_type) {
             // normalize Type{Type{Union{}}} to Type{TypeofBottom}
             iparams[0] = (jl_value_t*)jl_typeofbottom_type;
         }
@@ -2742,6 +2826,20 @@ static jl_value_t *inst_type_w_(jl_value_t *t, jl_typeenv_t *env, jl_typestack_t
         JL_GC_POP();
         return t;
     }
+    if (jl_is_type_type(t)) {
+        jl_typeeq_t *te = (jl_typeeq_t*)t;
+        jl_value_t *T = inst_type_w_(te->T, env, stack, check, nothrow ? 1 : 0);
+        JL_GC_PUSH1(&T);
+        if (T == NULL) {
+            assert(nothrow);
+            t = NULL;
+        }
+        else if (T != te->T) {
+            t = (jl_value_t*)jl_wrap_Type(T);
+        }
+        JL_GC_POP();
+        return t;
+    }
     if (jl_is_vararg(t)) {
         jl_vararg_t *v = (jl_vararg_t*)t;
         jl_value_t *T = NULL;
@@ -2846,9 +2944,31 @@ JL_DLLEXPORT jl_value_t *jl_instantiate_type_in_env(jl_value_t *ty, jl_unionall_
     return typ;
 }
 
-jl_datatype_t *jl_wrap_Type(jl_value_t *t)
+jl_typeeq_t *jl_wrap_Type(jl_value_t *t)
 {
-    return (jl_datatype_t*)jl_instantiate_unionall(jl_type_type, t);
+    if (jl_is_type_type(t) && jl_typeeq_T(t) == jl_bottom_type)
+        t = (jl_value_t*)jl_typeofbottom_type;
+    jl_value_t *tw = extract_wrapper(t);
+    if (tw && tw != t && jl_typeof(t) == jl_typeof(tw) &&
+            !jl_has_free_typevars(t) && jl_types_equal(t, tw)) {
+        t = tw;
+    }
+    if (t == jl_bottom_type && jl_typeofbottom_type && jl_typeofbottom_type->name) {
+        jl_value_t *cached = jl_atomic_load_relaxed(&jl_typeofbottom_type->name->Typeofwrapper);
+        if (cached)
+            return (jl_typeeq_t*)cached;
+    }
+    jl_task_t *ct = jl_current_task;
+    JL_GC_PUSH1(&t);
+    jl_typeeq_t *te = (jl_typeeq_t*)jl_gc_alloc(ct->ptls, sizeof(jl_typeeq_t), jl_typeeq_type);
+    jl_set_typetagof(te, jl_typeeq_tag, 0);
+    te->T = t;
+    if (t == jl_bottom_type && jl_typeofbottom_type && jl_typeofbottom_type->name) {
+        jl_atomic_store_relaxed(&jl_typeofbottom_type->name->Typeofwrapper, (jl_value_t*)te);
+        jl_gc_wb(jl_typeofbottom_type->name, te);
+    }
+    JL_GC_POP();
+    return te;
 }
 
 jl_vararg_t *jl_wrap_vararg(jl_value_t *t, jl_value_t *n, int check, int nothrow)
@@ -3057,15 +3177,15 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_any_type = (jl_datatype_t*)jl_new_abstracttype((jl_value_t*)jl_symbol("Any"), core, NULL, jl_emptysvec);
     jl_any_type->super = jl_any_type;
 
-    jl_datatype_t *type_type = jl_new_abstracttype((jl_value_t*)jl_symbol("Type"), core, jl_any_type, jl_emptysvec);
-    jl_type_type = (jl_unionall_t*)type_type;
-    jl_type_typename = type_type->name;
+    jl_kind_type = jl_new_abstracttype((jl_value_t*)jl_symbol("Kind"), core, jl_any_type, jl_emptysvec);
+    jl_type_type = (jl_unionall_t*)jl_any_type; // replaced with TypeEq(T) where T below
+    jl_type_typename = NULL;
 
     // initialize them. lots of cycles.
     // NOTE: types are not actually mutable, but we want to ensure they are heap-allocated with stable addresses
     jl_datatype_type->name = jl_new_typename_in(jl_symbol("DataType"), core, 0, 1);
     jl_datatype_type->name->wrapper = (jl_value_t*)jl_datatype_type;
-    jl_datatype_type->super = type_type;
+    jl_datatype_type->super = jl_kind_type;
     jl_datatype_type->parameters = jl_emptysvec;
     jl_datatype_type->name->n_uninitialized = 8 - 3;
     jl_datatype_type->name->names = jl_perm_symsvec(8,
@@ -3177,14 +3297,14 @@ void jl_init_types(void) JL_GC_DISABLED
     const static uint32_t tvar_constfields[1] = { 0x00000007 }; // all fields are constant, even though TypeVar itself has identity
     jl_tvar_type->name->constfields = tvar_constfields;
 
-    jl_typeofbottom_type = jl_new_datatype(jl_symbol("TypeofBottom"), core, type_type, jl_emptysvec,
+    jl_typeofbottom_type = jl_new_datatype(jl_symbol("TypeofBottom"), core, jl_kind_type, jl_emptysvec,
                                            jl_emptysvec, jl_emptysvec, jl_emptysvec, 0, 0, 0);
     XX(typeofbottom);
     jl_bottom_type = jl_gc_permobj(ct->ptls, 0, jl_typeofbottom_type, 0);
     jl_set_typetagof(jl_bottom_type, jl_typeofbottom_tag, GC_OLD_MARKED);
     jl_typeofbottom_type->instance = jl_bottom_type;
 
-    jl_unionall_type = jl_new_datatype(jl_symbol("UnionAll"), core, type_type, jl_emptysvec,
+    jl_unionall_type = jl_new_datatype(jl_symbol("UnionAll"), core, jl_kind_type, jl_emptysvec,
                                        jl_perm_symsvec(2, "var", "body"),
                                        jl_svec(2, jl_tvar_type, jl_any_type),
                                        jl_emptysvec, 0, 0, 2);
@@ -3192,7 +3312,7 @@ void jl_init_types(void) JL_GC_DISABLED
     // It seems like we probably usually end up needing the box for kinds (often used in an Any context), so force it to exist
     jl_unionall_type->name->mayinlinealloc = 0;
 
-    jl_uniontype_type = jl_new_datatype(jl_symbol("Union"), core, type_type, jl_emptysvec,
+    jl_uniontype_type = jl_new_datatype(jl_symbol("Union"), core, jl_kind_type, jl_emptysvec,
                                         jl_perm_symsvec(2, "a", "b"),
                                         jl_svec(2, jl_any_type, jl_any_type),
                                         jl_emptysvec, 0, 0, 2);
@@ -3203,19 +3323,28 @@ void jl_init_types(void) JL_GC_DISABLED
     // Internal-use-only kind dual to Union (see #61917). Not registered as a
     // small_typeof tag: it is recognized by identity (jl_is_intersecttype) and
     // only ever lives transiently inside the subtyping algorithm.
-    jl_intersect_type = jl_new_datatype(jl_symbol("Intersect"), core, type_type, jl_emptysvec,
+    jl_intersect_type = jl_new_datatype(jl_symbol("Intersect"), core, jl_kind_type, jl_emptysvec,
                                         jl_perm_symsvec(2, "a", "b"),
                                         jl_svec(2, jl_any_type, jl_any_type),
                                         jl_emptysvec, 0, 0, 2);
     jl_intersect_type->name->mayinlinealloc = 0;
 
+    jl_typeeq_type = jl_new_datatype(jl_symbol("TypeEq"), core, jl_kind_type, jl_emptysvec,
+                                     jl_perm_symsvec(1, "T"),
+                                     jl_svec(1, jl_any_type),
+                                     jl_emptysvec, 0, 0, 1);
+    XX(typeeq);
+    // It seems like we probably usually end up needing the box for kinds (often used in an Any context), so force it to exist
+    jl_typeeq_type->name->mayinlinealloc = 0;
+    jl_typeeq_type->ismutationfree = 1;
+    jl_type_typename = jl_typeeq_type->name;
+
     jl_tvar_t *tttvar = tvar("T");
-    type_type->parameters = jl_svec(1, tttvar);
-    jl_precompute_memoized_dt(type_type, 0); // update the hash value ASAP
-    type_type->hasfreetypevars = 1;
-    type_type->ismutationfree = 1;
-    jl_type_typename->wrapper = jl_new_struct(jl_unionall_type, tttvar, (jl_value_t*)jl_type_type);
-    jl_type_type = (jl_unionall_t*)jl_type_typename->wrapper;
+    jl_value_t *typeeq_body = (jl_value_t*)jl_wrap_Type((jl_value_t*)tttvar);
+    JL_GC_PUSH1(&typeeq_body);
+    jl_type_type = (jl_unionall_t*)jl_new_struct(jl_unionall_type, tttvar, typeeq_body);
+    JL_GC_POP();
+    jl_wrap_Type(jl_bottom_type);
 
     jl_vararg_type = jl_new_datatype(jl_symbol("TypeofVararg"), core, jl_any_type, jl_emptysvec,
                                             jl_perm_symsvec(2, "T", "N"),
@@ -3236,8 +3365,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_anytuple_type->maybe_subtype_of_cache = 0;
     jl_anytuple_type->layout = NULL;
 
-    jl_typeofbottom_type->super = jl_wrap_Type(jl_bottom_type);
-    jl_typeofbottom_type->super->layout = jl_typeofbottom_type->layout; // the only abstract type with a layout
+    jl_typeofbottom_type->super = jl_kind_type;
     jl_emptytuple_type = (jl_datatype_t*)jl_apply_tuple_type(jl_emptysvec, 0);
     jl_emptytuple = jl_gc_permobj(ct->ptls, 0, jl_emptytuple_type, 0);
     jl_emptytuple_type->instance = jl_emptytuple;
@@ -3962,6 +4090,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_compute_field_offsets(jl_typename_type);
     jl_compute_field_offsets(jl_uniontype_type);
     jl_compute_field_offsets(jl_intersect_type);
+    jl_compute_field_offsets(jl_typeeq_type);
     jl_compute_field_offsets(jl_tvar_type);
     jl_compute_field_offsets(jl_methtable_type);
     jl_compute_field_offsets(jl_methcache_type);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1877,6 +1877,15 @@ static unsigned typeeq_hash(jl_value_t *T, int *failed) JL_NOTSAFEPOINT
         // e.g. `Vector{Type}` and `Vector{Kind}` land in the same cache bucket
         // (they are equal per `typekey_eq`/`jl_types_equal`).
         return type_hash((jl_value_t*)jl_anytype_type, failed);
+    if (jl_is_typeeq(T)) {
+        jl_value_t *innerT = jl_typeeq_T(T);
+        if (jl_is_typevar(innerT) && ((jl_tvar_t*)innerT)->lb == jl_bottom_type &&
+                ((jl_tvar_t*)innerT)->ub == (jl_value_t*)jl_any_type)
+            // the unbounded `Type{Type{T}} where T` is `== TypeEq` (the kind whose
+            // instances are the `Type{X}` types); hash it as `TypeEq` so that the two
+            // equal representations land in the same cache bucket.
+            return type_hash((jl_value_t*)jl_typeeq_type, failed);
+    }
     unsigned hashT = type_hash(T, failed);
     return bitmix(~jl_type_typename->hash, hashT);
 }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1820,6 +1820,8 @@ static jl_value_t *lookup_type_stack(jl_typestack_t *stack, jl_datatype_t *tt, s
     return NULL;
 }
 
+static unsigned typeeq_hash(jl_value_t *T, int *failed) JL_NOTSAFEPOINT;
+
 // stable numbering for types--starts with name->hash, then falls back to objectid
 // sets *failed if the hash value isn't stable (if this param not set on entry)
 static unsigned type_hash(jl_value_t *kj, int *failed) JL_NOTSAFEPOINT
@@ -1855,21 +1857,28 @@ static unsigned type_hash(jl_value_t *kj, int *failed) JL_NOTSAFEPOINT
         return hasha + hashb;
     }
     else if (jl_is_typeeq(uw)) {
-        jl_value_t *T = jl_typeeq_T(uw);
-        if (T == jl_bottom_type)
-            return jl_typeofbottom_type->hash;
-        if (jl_is_typevar(T) && ((jl_tvar_t*)T)->lb == jl_bottom_type &&
-                ((jl_tvar_t*)T)->ub == (jl_value_t*)jl_any_type)
-            // the unbounded `Type{T} where T` is `=== Kind`; hash it as such so
-            // that e.g. `Vector{Type}` and `Vector{Kind}` land in the same cache
-            // bucket (they are equal per `typekey_eq`/`jl_types_equal`).
-            return type_hash((jl_value_t*)jl_kind_type, failed);
-        unsigned hashT = type_hash(T, failed);
-        return bitmix(~jl_type_typename->hash, hashT);
+        return typeeq_hash(jl_typeeq_T(uw), failed);
     }
     else {
         return jl_object_id(uw);
     }
+}
+
+// hash of `Type{T}`. Shared between hashing by type (`type_hash`, e.g. type-cache
+// insertion) and by value (`typekeyvalue_hash`, e.g. argument-tuple dispatch
+// caching) so the two cannot diverge.
+static unsigned typeeq_hash(jl_value_t *T, int *failed) JL_NOTSAFEPOINT
+{
+    if (T == jl_bottom_type)
+        return jl_typeofbottom_type->hash;
+    if (jl_is_typevar(T) && ((jl_tvar_t*)T)->lb == jl_bottom_type &&
+            ((jl_tvar_t*)T)->ub == (jl_value_t*)jl_any_type)
+        // the unbounded `Type{T} where T` is `=== Kind`; hash it as such so that
+        // e.g. `Vector{Type}` and `Vector{Kind}` land in the same cache bucket
+        // (they are equal per `typekey_eq`/`jl_types_equal`).
+        return type_hash((jl_value_t*)jl_kind_type, failed);
+    unsigned hashT = type_hash(T, failed);
+    return bitmix(~jl_type_typename->hash, hashT);
 }
 
 JL_DLLEXPORT uintptr_t jl_type_hash(jl_value_t *v) JL_NOTSAFEPOINT
@@ -1935,8 +1944,9 @@ static unsigned typekeyvalue_hash(jl_typename_t *tn, jl_value_t *key1, jl_value_
         jl_value_t *kj = j == 0 ? key1 : key[j - 1];
         uint_t hj;
         if (leaf && jl_is_kind(jl_typeof(kj))) {
-            hj = typekey_hash(jl_type_typename, &kj, 1, 0);
-            if (hj == 0)
+            int failed = 0;
+            hj = typeeq_hash(kj, &failed);
+            if (failed)
                 return 0;
         }
         else {

--- a/src/julia.h
+++ b/src/julia.h
@@ -1638,7 +1638,6 @@ static inline int jl_field_isconst(jl_datatype_t *st, int i) JL_NOTSAFEPOINT
 #define jl_is_uniontype(v)   jl_typetagis(v,jl_uniontype_tag<<4)
 #define jl_is_intersecttype(v) jl_typetagis(v,jl_intersect_type)
 #define jl_is_typeeq(v)      jl_typetagis(v,jl_typeeq_tag<<4)
-#define jl_is_type_type(v)   jl_is_typeeq(v)
 #define jl_is_typevar(v)     jl_typetagis(v,jl_tvar_tag<<4)
 #define jl_is_unionall(v)    jl_typetagis(v,jl_unionall_tag<<4)
 #define jl_is_vararg(v)      jl_typetagis(v,jl_vararg_tag<<4)

--- a/src/julia.h
+++ b/src/julia.h
@@ -1010,7 +1010,6 @@ typedef struct {
     XX(datatype) \
     XX(unionall) \
     XX(uniontype) \
-    XX(typeeq) \
     /* type parameter objects */ \
     XX(vararg) \
     XX(tvar) \
@@ -1053,6 +1052,9 @@ typedef struct {
     XX(globalref) \
     XX(gotonode) \
     XX(quotenode) \
+    XX(typeeq) \
+    /* Add new tags here to keep existing builds ABI stable - we don't guarantee ABI \
+       stability, but it'll help PkgEval to not break it unnecessarily */ \
     /* end of JL_SMALL_TYPEOF */
 enum jl_small_typeof_tags {
     jl_null_tag = 0,

--- a/src/julia.h
+++ b/src/julia.h
@@ -1701,7 +1701,7 @@ int is_leaf_bound(jl_value_t *v) JL_NOTSAFEPOINT;
 
 STATIC_INLINE int jl_is_kind(jl_value_t *v) JL_NOTSAFEPOINT
 {
-    return (v==(jl_value_t*)jl_kind_type || v==(jl_value_t*)jl_uniontype_type || v==(jl_value_t*)jl_datatype_type ||
+    return (v==(jl_value_t*)jl_anytype_type || v==(jl_value_t*)jl_uniontype_type || v==(jl_value_t*)jl_datatype_type ||
             v==(jl_value_t*)jl_unionall_type || v==(jl_value_t*)jl_typeeq_type ||
             v==(jl_value_t*)jl_typeofbottom_type);
 }

--- a/src/julia.h
+++ b/src/julia.h
@@ -604,6 +604,11 @@ typedef struct {
     jl_value_t *JL_NONNULL b;
 } jl_intersecttype_t;
 
+typedef struct {
+    JL_DATA_TYPE
+    jl_value_t *JL_NONNULL T;
+} jl_typeeq_t;
+
 // in little-endian, isptr is always the first bit, avoiding the need for a branch in computing isptr
 typedef struct {
     uint8_t isptr:1;
@@ -1005,6 +1010,7 @@ typedef struct {
     XX(datatype) \
     XX(unionall) \
     XX(uniontype) \
+    XX(typeeq) \
     /* type parameter objects */ \
     XX(vararg) \
     XX(tvar) \
@@ -1631,6 +1637,8 @@ static inline int jl_field_isconst(jl_datatype_t *st, int i) JL_NOTSAFEPOINT
 #define jl_may_be_immutable_datatype(t) (jl_is_datatype(t) && (!((jl_datatype_t*)t)->name->mutabl))
 #define jl_is_uniontype(v)   jl_typetagis(v,jl_uniontype_tag<<4)
 #define jl_is_intersecttype(v) jl_typetagis(v,jl_intersect_type)
+#define jl_is_typeeq(v)      jl_typetagis(v,jl_typeeq_tag<<4)
+#define jl_is_type_type(v)   jl_is_typeeq(v)
 #define jl_is_typevar(v)     jl_typetagis(v,jl_tvar_tag<<4)
 #define jl_is_unionall(v)    jl_typetagis(v,jl_unionall_tag<<4)
 #define jl_is_vararg(v)      jl_typetagis(v,jl_vararg_tag<<4)
@@ -1692,15 +1700,17 @@ int is_leaf_bound(jl_value_t *v) JL_NOTSAFEPOINT;
 
 STATIC_INLINE int jl_is_kind(jl_value_t *v) JL_NOTSAFEPOINT
 {
-    return (v==(jl_value_t*)jl_uniontype_type || v==(jl_value_t*)jl_datatype_type ||
-            v==(jl_value_t*)jl_unionall_type || v==(jl_value_t*)jl_typeofbottom_type);
+    return (v==(jl_value_t*)jl_kind_type || v==(jl_value_t*)jl_uniontype_type || v==(jl_value_t*)jl_datatype_type ||
+            v==(jl_value_t*)jl_unionall_type || v==(jl_value_t*)jl_typeeq_type ||
+            v==(jl_value_t*)jl_typeofbottom_type);
 }
 
 STATIC_INLINE int jl_is_kindtag(uintptr_t t) JL_NOTSAFEPOINT
 {
     t >>= 4;
     return (t==(uintptr_t)jl_uniontype_tag || t==(uintptr_t)jl_datatype_tag ||
-            t==(uintptr_t)jl_unionall_tag || t==(uintptr_t)jl_typeofbottom_tag);
+            t==(uintptr_t)jl_unionall_tag || t==(uintptr_t)jl_typeeq_tag ||
+            t==(uintptr_t)jl_typeofbottom_tag);
 }
 
 STATIC_INLINE int jl_is_type(jl_value_t *v) JL_NOTSAFEPOINT
@@ -1832,10 +1842,10 @@ STATIC_INLINE int jl_is_vecelement_type(jl_value_t* t) JL_NOTSAFEPOINT
             ((jl_datatype_t*)(t))->name == jl_vecelement_typename);
 }
 
-STATIC_INLINE int jl_is_type_type(jl_value_t *v) JL_NOTSAFEPOINT
+STATIC_INLINE jl_value_t *jl_typeeq_T(jl_value_t *v JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    return (jl_is_datatype(v) &&
-            ((jl_datatype_t*)(v))->name == ((jl_datatype_t*)jl_type_type->body)->name);
+    assert(jl_is_typeeq(v));
+    return ((jl_typeeq_t*)v)->T;
 }
 
 STATIC_INLINE int jl_is_genericmemory_zeroinit(jl_genericmemory_t *m) JL_NOTSAFEPOINT
@@ -1850,6 +1860,7 @@ JL_DLLEXPORT int jl_egal__bitstag(const jl_value_t *a JL_MAYBE_UNROOTED, const j
 JL_DLLEXPORT int jl_egal__unboxed(const jl_value_t *a JL_MAYBE_UNROOTED, const jl_value_t *b JL_MAYBE_UNROOTED, uintptr_t dtag) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uintptr_t jl_object_id(jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uintptr_t jl_type_hash(jl_value_t *v) JL_NOTSAFEPOINT;
+JL_DLLEXPORT uintptr_t jl_type_cache_hash(jl_value_t *v) JL_NOTSAFEPOINT;
 
 STATIC_INLINE int jl_egal__unboxed_(const jl_value_t *a JL_MAYBE_UNROOTED, const jl_value_t *b JL_MAYBE_UNROOTED, uintptr_t dtag) JL_NOTSAFEPOINT
 {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1302,6 +1302,16 @@ STATIC_INLINE int jl_is_va_tuple(jl_datatype_t *t) JL_NOTSAFEPOINT
     return (l>0 && jl_is_vararg(jl_tparam(t,l-1)));
 }
 
+// `Type{Union{}}` (a `TypeEq`) is laid out as the singleton `typeof(Union{})`
+// `DataType`. Code that inspects a field's declared type for layout purposes
+// must use this normalized form, otherwise it sees a non-`DataType` kind.
+STATIC_INLINE jl_value_t *normalize_typeofbottom_layout_alias(jl_value_t *ty JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    if (jl_typeofbottom_type != NULL && jl_is_typeeq(ty) && jl_typeeq_T(ty) == jl_bottom_type)
+        return (jl_value_t*)jl_typeofbottom_type;
+    return ty;
+}
+
 STATIC_INLINE size_t jl_vararg_length(jl_value_t *v) JL_NOTSAFEPOINT
 {
     assert(jl_is_vararg(v));

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -968,7 +968,7 @@ jl_datatype_t *jl_new_abstracttype(jl_value_t *name, jl_module_t *module,
                                    jl_datatype_t *super, jl_svec_t *parameters);
 jl_datatype_t *jl_new_uninitialized_datatype(void);
 void jl_precompute_memoized_dt(jl_datatype_t *dt, int cacheable);
-JL_DLLEXPORT jl_datatype_t *jl_wrap_Type(jl_value_t *t);  // x -> Type{x}
+JL_DLLEXPORT jl_typeeq_t *jl_wrap_Type(jl_value_t *t);  // x -> Type{x}
 jl_vararg_t *jl_wrap_vararg(jl_value_t *t, jl_value_t *n, int check, int nothrow);
 void jl_reinstantiate_inner_types(jl_datatype_t *t);
 jl_datatype_t *jl_lookup_cache_type_(jl_datatype_t *type);

--- a/src/method.c
+++ b/src/method.c
@@ -1310,7 +1310,7 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
     // if we have a kwcall, try to derive the name from the callee argument method table
     jl_datatype_t *dtname = (jl_datatype_t*)jl_argument_datatype(jl_kwcall_type && ft == (jl_value_t*)jl_kwcall_type && nargs >= 3 ? jl_svecref(atypes, 2) : ft);
     name = (jl_value_t*)dtname != jl_nothing ? dtname->name->singletonname : jl_any_type->name->singletonname;
-    if (jl_is_type_type((jl_value_t*)dtname)) {
+    if (jl_is_typeeq((jl_value_t*)dtname)) {
         dtname = (jl_datatype_t*)jl_argument_datatype(jl_typeeq_T((jl_value_t*)dtname));
         if ((jl_value_t*)dtname != jl_nothing) {
             name = dtname->name->singletonname;

--- a/src/method.c
+++ b/src/method.c
@@ -1311,7 +1311,7 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
     jl_datatype_t *dtname = (jl_datatype_t*)jl_argument_datatype(jl_kwcall_type && ft == (jl_value_t*)jl_kwcall_type && nargs >= 3 ? jl_svecref(atypes, 2) : ft);
     name = (jl_value_t*)dtname != jl_nothing ? dtname->name->singletonname : jl_any_type->name->singletonname;
     if (jl_is_type_type((jl_value_t*)dtname)) {
-        dtname = (jl_datatype_t*)jl_argument_datatype(jl_tparam0(dtname));
+        dtname = (jl_datatype_t*)jl_argument_datatype(jl_typeeq_T((jl_value_t*)dtname));
         if ((jl_value_t*)dtname != jl_nothing) {
             name = dtname->name->singletonname;
         }

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -661,6 +661,8 @@ static jl_datatype_t *nth_arg_datatype(jl_value_t *a JL_PROPAGATES_ROOT, int n) 
             return (jl_datatype_t*)T;
         if (jl_is_typevar(T))
             return nth_arg_datatype(((jl_tvar_t*)T)->ub, 0);
+        if (jl_is_unionall(T))
+            return nth_arg_datatype(jl_unwrap_unionall(T), 0);
         return NULL;
     }
     else if (jl_is_typevar(a)) {

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -651,7 +651,7 @@ static jl_datatype_t *nth_arg_datatype(jl_value_t *a JL_PROPAGATES_ROOT, int n) 
         }
         return NULL;
     }
-    else if (jl_is_type_type(a)) {
+    else if (jl_is_typeeq(a)) {
         if (n != 0)
             return NULL;
         jl_value_t *T = jl_typeeq_T(a);
@@ -1577,7 +1577,7 @@ size_t jl_static_show_func_sig_(JL_STREAM *s, jl_value_t *type, jl_static_show_c
         return n;
     }
     if ((jl_nparams(ftype) == 0 || ftype == ((jl_datatype_t*)ftype)->name->wrapper) &&
-            !jl_is_type_type(ftype) && !jl_is_type_type((jl_value_t*)((jl_datatype_t*)ftype)->super)) { // aka !iskind
+            !jl_is_typeeq(ftype) && !jl_is_typeeq((jl_value_t*)((jl_datatype_t*)ftype)->super)) { // aka !iskind
         n += jl_static_show_symbol(s, ((jl_datatype_t*)ftype)->name->singletonname);
     }
     else {

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -651,6 +651,18 @@ static jl_datatype_t *nth_arg_datatype(jl_value_t *a JL_PROPAGATES_ROOT, int n) 
         }
         return NULL;
     }
+    else if (jl_is_type_type(a)) {
+        if (n != 0)
+            return NULL;
+        jl_value_t *T = jl_typeeq_T(a);
+        if (T == jl_bottom_type)
+            return jl_typeofbottom_type;
+        if (jl_is_datatype(T))
+            return (jl_datatype_t*)T;
+        if (jl_is_typevar(T))
+            return nth_arg_datatype(((jl_tvar_t*)T)->ub, 0);
+        return NULL;
+    }
     else if (jl_is_typevar(a)) {
         return nth_arg_datatype(((jl_tvar_t*)a)->ub, n);
     }
@@ -1148,6 +1160,11 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         n += jl_static_show_x(out, ua->body, depth, ctx);
         n += jl_printf(out, " where ");
         n += jl_static_show_x(out, (jl_value_t*)ua->var, depth->prev, ctx);
+    }
+    else if (vt == jl_typeeq_type) {
+        n += jl_printf(out, "Type{");
+        n += jl_static_show_x(out, ((jl_typeeq_t*)v)->T, depth, ctx);
+        n += jl_printf(out, "}");
     }
     else if (vt == jl_typename_type) {
         n += jl_printf(out, "typename(");

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1223,6 +1223,9 @@ static void record_memoryrefs_inside(jl_serializer_state *s, jl_datatype_t *t, s
         jl_value_t *ft = jl_field_type_concrete(t, i);
         if (jl_is_uniontype(ft))
             continue;
+        // a `Type{Union{}}` field is laid out as the singleton `typeof(Union{})`,
+        // so normalize it before recursing (it is otherwise a non-`DataType` kind)
+        ft = normalize_typeofbottom_layout_alias(ft);
         if (jl_is_genericmemoryref_type(ft))
             record_memoryref(s, reloc_offset + offset, *(jl_genericmemoryref_t*)(data + offset));
         else

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -39,6 +39,9 @@ int must_be_new_dt(jl_value_t *t, htable_t *news, char *image_base, size_t sizeo
         return must_be_new_dt(tv->lb, news, image_base, sizeof_sysimg) ||
                must_be_new_dt(tv->ub, news, image_base, sizeof_sysimg);
     }
+    else if (jl_is_typeeq(t)) {
+        return must_be_new_dt(jl_typeeq_T(t), news, image_base, sizeof_sysimg);
+    }
     else if (jl_is_vararg(t)) {
         jl_vararg_t *tv = (jl_vararg_t*)t;
         if (tv->T && must_be_new_dt(tv->T, news, image_base, sizeof_sysimg))
@@ -48,7 +51,10 @@ int must_be_new_dt(jl_value_t *t, htable_t *news, char *image_base, size_t sizeo
     }
     else if (jl_is_datatype(t)) {
         jl_datatype_t *dt = (jl_datatype_t*)t;
-        assert(jl_object_in_image((jl_value_t*)dt->name) && "type_in_worklist mistake?");
+        if (dt->name == NULL || dt->parameters == NULL ||
+            (dt->super == NULL && dt != jl_any_type))
+            return 1;
+        assert(jl_astaggedvalue(dt->name)->bits.in_image && "type_in_worklist mistake?");
         jl_datatype_t *super = dt->super;
         // fast-path: check if super is in news, since then we must be new also
         // (it is also possible that super is indeterminate or NULL right now,

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -482,13 +482,26 @@ static void restore_env(jl_stenv_t *e, jl_savedenv_t *se, int root) JL_NOTSAFEPO
 
 // type utilities
 
+static int is_typeofbottom_typealias(jl_value_t *t) JL_NOTSAFEPOINT
+{
+    if (t == NULL)
+        return 0;
+    if (jl_typeofbottom_type == NULL)
+        return 0;
+    return t == (jl_value_t*)jl_typeofbottom_type ||
+           (jl_is_type_type(t) && jl_typeeq_T(t) == jl_bottom_type);
+}
+
+static jl_value_t *normalize_typeofbottom_typealias(jl_value_t *t) JL_NOTSAFEPOINT
+{
+    return is_typeofbottom_typealias(t) ? (jl_value_t*)jl_typeofbottom_type : t;
+}
+
 // quickly test that two types are identical
 static int obviously_egal(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT
 {
-    if (a == (jl_value_t*)jl_typeofbottom_type->super)
-        a = (jl_value_t*)jl_typeofbottom_type; // supertype(typeof(Union{})) is equal to, although distinct from, itself
-    if (b == (jl_value_t*)jl_typeofbottom_type->super)
-        b = (jl_value_t*)jl_typeofbottom_type; // supertype(typeof(Union{})) is equal to, although distinct from, itself
+    a = normalize_typeofbottom_typealias(a);
+    b = normalize_typeofbottom_typealias(b);
     if (a == b) return 1;
     if (jl_typeof(a) != jl_typeof(b)) return 0;
     if (jl_is_datatype(a)) {
@@ -518,16 +531,16 @@ static int obviously_egal(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT
         return obviously_egal(jl_unwrap_vararg(vma), jl_unwrap_vararg(vmb)) &&
             ((!vma->N && !vmb->N) || (vma->N && vmb->N && obviously_egal(vma->N, vmb->N)));
     }
+    if (jl_is_type_type(a))
+        return obviously_egal(jl_typeeq_T(a), jl_typeeq_T(b));
     if (jl_is_typevar(a)) return 0;
     return !jl_is_type(a) && jl_egal(a,b);
 }
 
-static int obviously_unequal(jl_value_t *a, jl_value_t *b)
+static int obviously_unequal(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT
 {
-    if (a == (jl_value_t*)jl_typeofbottom_type->super)
-        a = (jl_value_t*)jl_typeofbottom_type; // supertype(typeof(Union{})) is equal to, although distinct from, itself
-    if (b == (jl_value_t*)jl_typeofbottom_type->super)
-        b = (jl_value_t*)jl_typeofbottom_type; // supertype(typeof(Union{})) is equal to, although distinct from, itself
+    a = normalize_typeofbottom_typealias(a);
+    b = normalize_typeofbottom_typealias(b);
     if (a == b)
         return 0;
     if (jl_is_unionall(a))
@@ -540,9 +553,9 @@ static int obviously_unequal(jl_value_t *a, jl_value_t *b)
         if (jl_is_datatype(b)) {
             jl_datatype_t *ad = (jl_datatype_t*)a;
             jl_datatype_t *bd = (jl_datatype_t*)b;
-            if (a == (jl_value_t*)jl_typeofbottom_type && bd->name == jl_type_typename)
+            if (a == (jl_value_t*)jl_typeofbottom_type && jl_is_type_type(b))
                 return obviously_unequal(jl_bottom_type, jl_tparam(bd, 0));
-            if (ad->name == jl_type_typename && b == (jl_value_t*)jl_typeofbottom_type)
+            if (jl_is_type_type(a) && b == (jl_value_t*)jl_typeofbottom_type)
                 return obviously_unequal(jl_tparam(ad, 0), jl_bottom_type);
             if (ad->name != bd->name)
                 return 1;
@@ -627,7 +640,7 @@ static int obviously_in_union(jl_value_t *u, jl_value_t *x)
     return obviously_egal(u, x);
 }
 
-int obviously_disjoint(jl_value_t *a, jl_value_t *b, int specificity)
+int obviously_disjoint(jl_value_t *a, jl_value_t *b, int specificity) JL_NOTSAFEPOINT
 {
     if (a == b || a == (jl_value_t*)jl_any_type || b == (jl_value_t*)jl_any_type)
         return 0;
@@ -728,9 +741,9 @@ static jl_value_t *simple_join(jl_value_t *a, jl_value_t *b)
         return a;
     if (!(jl_is_type(a) || jl_is_typevar(a)) || !(jl_is_type(b) || jl_is_typevar(b)))
         return (jl_value_t*)jl_any_type;
-    if (jl_is_kind(a) && jl_is_type_type(b) && jl_typeof(jl_tparam0(b)) == a)
+    if (jl_is_kind(a) && jl_is_type_type(b) && jl_typeof(jl_typeeq_T(b)) == a)
         return a;
-    if (jl_is_kind(b) && jl_is_type_type(a) && jl_typeof(jl_tparam0(a)) == b)
+    if (jl_is_kind(b) && jl_is_type_type(a) && jl_typeof(jl_typeeq_T(a)) == b)
         return b;
     if (jl_is_typevar(a) && obviously_egal(b, ((jl_tvar_t*)a)->lb))
         return a;
@@ -755,9 +768,9 @@ static jl_value_t *simple_meet(jl_value_t *a, jl_value_t *b, int overesi)
         return jl_new_struct(jl_intersect_type, a, b);
     if (!(jl_is_type(a) || jl_is_typevar(a)) || !(jl_is_type(b) || jl_is_typevar(b)))
         return jl_bottom_type;
-    if (jl_is_kind(a) && jl_is_type_type(b) && jl_typeof(jl_tparam0(b)) == a)
+    if (jl_is_kind(a) && jl_is_type_type(b) && jl_typeof(jl_typeeq_T(b)) == a)
         return b;
-    if (jl_is_kind(b) && jl_is_type_type(a) && jl_typeof(jl_tparam0(a)) == b)
+    if (jl_is_kind(b) && jl_is_type_type(a) && jl_typeof(jl_typeeq_T(a)) == b)
         return a;
     if (jl_is_typevar(a) && obviously_egal(b, ((jl_tvar_t*)a)->ub))
         return a;
@@ -1128,10 +1141,10 @@ int is_leaf_bound(jl_value_t *v) JL_NOTSAFEPOINT
         return 1;
     if (jl_is_intersecttype(v)) // internal meet node (see #61917), not a concrete leaf
         return 0;
+    if (jl_is_type_type(v))
+        return 1;
     if (jl_is_datatype(v)) {
         if (((jl_datatype_t*)v)->name->abstract) {
-            if (jl_is_type_type(v))
-                return 1;//!jl_has_free_typevars(jl_tparam0(v));
             return 0;
         }
         return ((jl_datatype_t*)v)->isconcretetype;
@@ -1146,8 +1159,8 @@ static int is_leaf_typevar(jl_tvar_t *v) JL_NOTSAFEPOINT
 
 static jl_value_t *widen_Type_if_concrete(jl_value_t *t JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    if (jl_is_type_type(t) && !jl_is_typevar(jl_tparam0(t)))
-        return jl_typeof(jl_tparam0(t));
+    if (jl_is_type_type(t) && !jl_is_typevar(jl_typeeq_T(t)))
+        return jl_typeof(jl_typeeq_T(t));
     if (jl_is_uniontype(t)) {
         jl_value_t *a = widen_Type_if_concrete(((jl_uniontype_t*)t)->a);
         jl_value_t *b = widen_Type_if_concrete(((jl_uniontype_t*)t)->b);
@@ -1169,8 +1182,9 @@ static int try_subtype_in_env(jl_value_t *a, jl_value_t *b, jl_stenv_t *e);
 // only if the widened kind satisfies `bound` , otherwise leave unchanged
 static jl_value_t *widen_Type_to_union(jl_value_t *t, jl_value_t *bound, jl_stenv_t *e)
 {
-    if (jl_is_type_type(t) && !jl_is_typevar(jl_tparam0(t))) {
-        jl_value_t *w = jl_typeof(jl_tparam0(t));
+    if (jl_is_type_type(t) && !jl_is_typevar(jl_typeeq_T(t))) {
+        jl_value_t *T = jl_typeeq_T(t);
+        jl_value_t *w = jl_typeof(T);
         if (!try_subtype_in_env(w, bound, e))
             return t;
         return w;
@@ -1232,6 +1246,13 @@ static int constrains_param_static(jl_tvar_t *var, jl_value_t *typ, int covarian
         return constrains_param_static(var, ((jl_uniontype_t*)typ)->a, covariant) &&
                constrains_param_static(var, ((jl_uniontype_t*)typ)->b, covariant);
     }
+    else if (jl_is_type_type(typ)) {
+        jl_value_t *T = jl_typeeq_T(typ);
+        if (T == (jl_value_t*)var && var->ub == (jl_value_t*)jl_any_type) {
+            return 0;
+        }
+        return constrains_param_static(var, T, 0);
+    }
     else if (jl_is_datatype(typ)) {
         jl_datatype_t *dt = (jl_datatype_t*)typ;
         size_t fc = jl_nparams(dt);
@@ -1258,12 +1279,6 @@ static int constrains_param_static(jl_tvar_t *var, jl_value_t *typ, int covarian
                 }
             }
             else {
-                if (dt->name == jl_type_typename && jl_tparam0(dt) == (jl_value_t*)var &&
-                    var->ub == (jl_value_t*)jl_any_type) {
-                    // Type{T} with free typevars is illegal; conservatively
-                    // return 0 here (matches `type_constrains=false` in Julia).
-                    return 0;
-                }
                 for (size_t i = 0; i < fc; i++) {
                     if (constrains_param_static(var, jl_tparam(dt, i), 0))
                         return 1;
@@ -1794,11 +1809,14 @@ static int subtype_tuple_tail(jl_datatype_t *xd, jl_datatype_t *yd, int8_t R, jl
         }
         else if ((e->Runions.depth == 0 ? !jl_has_free_typevars(xi) : jl_is_concrete_type(xi)) && !jl_has_free_typevars(yi)) {
             // fast path for separable sub-formulas
-            if (!jl_subtype(xi, yi))
+            int sub = jl_subtype(xi, yi);
+            if (!sub)
                 return 0;
         }
-        else if (!subtype(xi, yi, e, param)) {
-            return 0;
+        else {
+            int sub = subtype(xi, yi, e, param);
+            if (!sub)
+                return 0;
         }
         lastx = xi; lasty = yi;
         if (i < lx-1 || !vx)
@@ -2060,33 +2078,42 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_param_pos_t p
     }
     if (jl_is_unionall(y))
         return subtype_unionall(x, (jl_unionall_t*)y, e, 1, param);
+    if (x == (jl_value_t*)jl_typeofbottom_type && jl_is_type_type(y)) {
+        jl_value_t *tp0 = jl_typeeq_T(y);
+        e->invdepth++;
+        int ans = forall_exists_equal(jl_bottom_type, tp0, e);
+        e->invdepth--;
+        return ans;
+    }
+    if (jl_is_type_type(x) && jl_is_type_type(y)) {
+        e->invdepth++;
+        int ans = forall_exists_equal(jl_typeeq_T(x), jl_typeeq_T(y), e);
+        e->invdepth--;
+        return ans;
+    }
+    if (jl_is_type_type(x) && jl_is_datatype(y)) {
+        jl_value_t *tp0 = jl_typeeq_T(x);
+        if (!jl_is_typevar(tp0)) {
+            // TypeEq(T) dispatches as the singleton type of T. For example,
+            // TypeEq(Int) is a subtype of DataType, but not of TypeEq.
+            return subtype(jl_typeof(tp0), y, e, param);
+        }
+        // `TypeEq(T)` for a free typevar `T` is the kind of all types matching
+        // `T`'s bounds; every such instance is itself a type, i.e. a `Kind`. So
+        // `Type{T} <: y` reduces to `Kind <: y` (in particular `Type === Kind`).
+        return subtype((jl_value_t*)jl_kind_type, y, e, param);
+    }
+    if (jl_is_datatype(x) && jl_is_type_type(y) && x != (jl_value_t*)jl_typeofbottom_type) {
+        jl_value_t *tp0 = jl_typeeq_T(y);
+        if (!jl_is_typevar(tp0) || !jl_is_kind(x))
+            return 0;
+        int issub = subtype((jl_value_t*)jl_type_type, y, e, param);
+        return issub;
+    }
     if (jl_is_datatype(x) && jl_is_datatype(y)) {
         if (x == y) return 1;
         if (y == (jl_value_t*)jl_any_type) return 1;
         jl_datatype_t *xd = (jl_datatype_t*)x, *yd = (jl_datatype_t*)y;
-        if (jl_is_type_type(x) && !jl_is_type_type(y)) {
-            jl_value_t *tp0 = jl_tparam0(xd);
-            if (!jl_is_typevar(tp0)) {
-                // TODO this is not strictly correct, but we don't yet have any other way for
-                // e.g. the argument `Int` to match a `::DataType` slot. Most correct would be:
-                // Int isa DataType, Int isa Type{Int}, Type{Int} more specific than DataType,
-                // !(Type{Int} <: DataType), !isleaftype(Type{Int}), because non-DataTypes can
-                // be type-equal to `Int`.
-                return jl_typeof(tp0) == (jl_value_t*)yd;
-            }
-            return 0;
-        }
-        if (jl_is_type_type(y) && !jl_is_type_type(x) && x != (jl_value_t*)jl_typeofbottom_type) {
-            jl_value_t *tp0 = jl_tparam0(yd);
-            if (!jl_is_typevar(tp0) || !jl_is_kind(x))
-                return 0;
-            // DataType.super is special, so `DataType <: Type{T}` (T free) needs special handling.
-            // The answer is true iff `T` has full bounds (as in `Type`), but this needs to
-            // be checked at the same depth where `Type{T}` occurs --- the depth of the LHS
-            // doesn't matter because it (e.g. `DataType`) doesn't actually contain the variable.
-            int issub = subtype((jl_value_t*)jl_type_type, y, e, param);
-            return issub;
-        }
         while (xd != jl_any_type && xd->name != yd->name) {
             if (xd->super == NULL) {
                 assert(xd->parameters && jl_is_typename(xd->name));
@@ -2427,7 +2454,7 @@ static int concrete_min(jl_value_t *t)
     return 1; // a non-Type is also considered concrete
 }
 
-static jl_value_t *find_var_body(jl_value_t *t, jl_tvar_t *v)
+static jl_value_t *find_var_body(jl_value_t *t, jl_tvar_t *v) JL_NOTSAFEPOINT
 {
     if (jl_is_unionall(t)) {
         if (((jl_unionall_t*)t)->var == v)
@@ -2486,10 +2513,10 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
     }
     if (jl_is_unionall(y))
         y = jl_unwrap_unionall(y);
-    if (x == (jl_value_t*)jl_typeofbottom_type->super)
-        x = (jl_value_t*)jl_typeofbottom_type; // supertype(typeof(Union{})) is equal to, although distinct from, typeof(Union{})
-    if (y == (jl_value_t*)jl_typeofbottom_type->super)
-        y = (jl_value_t*)jl_typeofbottom_type; // supertype(typeof(Union{})) is equal to, although distinct from, typeof(Union{})
+    if (is_typeofbottom_typealias(x))
+        x = (jl_value_t*)jl_typeofbottom_type;
+    if (is_typeofbottom_typealias(y))
+        y = (jl_value_t*)jl_typeofbottom_type;
     if (x == y || y == (jl_value_t*)jl_any_type) {
         *subtype = 1;
         return 1;
@@ -2544,8 +2571,10 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
     }
     if (jl_is_uniontype(x)) {
         // TODO: consider handling more LHS unions, being wary of covariance
-        if (obvious_subtype(((jl_uniontype_t*)x)->a, y, y0, subtype) && *subtype) {
-            if (obvious_subtype(((jl_uniontype_t*)x)->b, y, y0, subtype) && *subtype)
+        jl_value_t *xa = ((jl_uniontype_t*)x)->a;
+        jl_value_t *xb = ((jl_uniontype_t*)x)->b;
+        if (obvious_subtype(xa, y, y0, subtype) && *subtype) {
+            if (obvious_subtype(xb, y, y0, subtype) && *subtype)
                 return 1;
         }
         //if (obvious_subtype(((jl_uniontype_t*)x)->a, y, y0, subtype)) {
@@ -2561,13 +2590,15 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
         return 0;
     }
     if (jl_is_uniontype(y)) {
-        if (obvious_subtype(x, ((jl_uniontype_t*)y)->a, y0, subtype)) {
+        jl_value_t *ya = ((jl_uniontype_t*)y)->a;
+        jl_value_t *yb = ((jl_uniontype_t*)y)->b;
+        if (obvious_subtype(x, ya, y0, subtype)) {
             if (*subtype)
                 return 1;
-            if (obvious_subtype(x, ((jl_uniontype_t*)y)->b, y0, subtype))
+            if (obvious_subtype(x, yb, y0, subtype))
                 return 1;
         }
-        else if (obvious_subtype(x, ((jl_uniontype_t*)y)->b, y0, subtype)) {
+        else if (obvious_subtype(x, yb, y0, subtype)) {
             if (*subtype)
                 return 1;
         }
@@ -2596,14 +2627,14 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
             int uncertain = 0;
             if (((jl_datatype_t*)x)->name != ((jl_datatype_t*)y)->name) {
                 if (jl_is_type_type(x) && jl_is_kind(y)) {
-                    jl_value_t *t0 = jl_tparam0(x);
+                    jl_value_t *t0 = jl_typeeq_T(x);
                     if (jl_is_typevar(t0))
                         return 0;
                     *subtype = jl_typeof(t0) == y;
                     return 1;
                 }
                 if (jl_is_type_type(y)) {
-                    jl_value_t *t0 = jl_tparam0(y);
+                    jl_value_t *t0 = jl_typeeq_T(y);
                     assert(!jl_is_type_type(x));
                     if ((jl_is_kind(x) && jl_is_typevar(t0)) || (x == (jl_value_t*)jl_typeofbottom_type))
                         return 0;
@@ -2626,7 +2657,12 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
             }
             if (!iscov && !((jl_datatype_t*)x)->hasfreetypevars) {
                 // by transitivity, if `wrapper <: y`, then `x <: y` if x is a leaf type of its name
-                if (obvious_subtype(((jl_datatype_t*)x)->name->wrapper, y, y0, subtype) && *subtype)
+                jl_value_t *wrapper = ((jl_datatype_t*)x)->name->wrapper;
+                int wrapper_sub = 0;
+                JL_GC_PUSH1(&wrapper);
+                wrapper_sub = obvious_subtype(wrapper, y, y0, subtype);
+                JL_GC_POP();
+                if (wrapper_sub && *subtype)
                     return 1;
             }
             int i, npx = jl_nparams(x), npy = jl_nparams(y);
@@ -2679,7 +2715,14 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
 
             // inspect the fixed parameters in y against x
             for (i = 0; i < npy - (vy == JL_VARARG_NONE ? 0 : 1); i++) {
-                jl_value_t *a = i >= (npx - (vx == JL_VARARG_NONE ? 0 : 1)) ? vxt : jl_tparam(x, i);
+                jl_value_t *a;
+                if (i >= (npx - (vx == JL_VARARG_NONE ? 0 : 1))) {
+                    a = vxt;
+                    assert(a != NULL);
+                }
+                else {
+                    a = jl_tparam(x, i);
+                }
                 jl_value_t *b = jl_tparam(y, i);
                 if (iscov || jl_is_typevar(b)) {
                     if (obvious_subtype(a, b, y0, subtype)) {
@@ -2733,8 +2776,8 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
                     return 1;
                 }
                 jl_value_t *a1u = jl_unwrap_unionall(a1);
-                if (jl_is_type_type(a1u) && jl_is_type(jl_tparam0(a1u))) {
-                    a1 = jl_typeof(jl_tparam0(a1u));
+                if (jl_is_type_type(a1u) && jl_is_type(jl_typeeq_T(a1u))) {
+                    a1 = jl_typeof(jl_typeeq_T(a1u));
                 }
                 for (; i < nparams_expanded_x; i++) {
                     jl_value_t *a = (vx != JL_VARARG_NONE && i >= npx - 1) ? vxt : jl_tparam(x, i);
@@ -2742,9 +2785,9 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
                         // diagonal rule: all the later parameters are also constrained to be type-equal to the first
                         jl_value_t *a2 = a;
                         jl_value_t *au = jl_unwrap_unionall(a);
-                        if (jl_is_type_type(au) && jl_is_type(jl_tparam0(au))) {
+                        if (jl_is_type_type(au) && jl_is_type(jl_typeeq_T(au))) {
                             // if a is exactly Type{T}, then use the concrete typeof(T) instead here
-                            a2 = jl_typeof(jl_tparam0(au));
+                            a2 = jl_typeof(jl_typeeq_T(au));
                         }
                         if (!obviously_egal(a1, a2)) {
                             if (obvious_subtype(a2, a1, y0, subtype)) {
@@ -2803,7 +2846,7 @@ JL_DLLEXPORT int jl_subtype_env(jl_value_t *x, jl_value_t *y, jl_value_t **env, 
         return 1;
     if (x == y ||
         (jl_typeof(x) == jl_typeof(y) &&
-         (jl_is_unionall(y) || jl_is_uniontype(y)) &&
+         (jl_is_unionall(y) || jl_is_uniontype(y) || jl_is_type_type(y)) &&
          jl_types_egal(x, y))) {
         if (envsz != 0) { // quickly copy env from x
             jl_unionall_t *ua = (jl_unionall_t*)x;
@@ -2995,6 +3038,10 @@ int jl_has_intersect_type_not_kind(jl_value_t *t)
     if (jl_is_uniontype(t))
         return jl_has_intersect_type_not_kind(((jl_uniontype_t*)t)->a) ||
                jl_has_intersect_type_not_kind(((jl_uniontype_t*)t)->b);
+    if (jl_is_type_type(t)) {
+        jl_value_t *T = jl_typeeq_T(t);
+        return jl_is_typevar(T) || !jl_is_kind(T);
+    }
     if (jl_is_typevar(t))
         return jl_has_intersect_type_not_kind(((jl_tvar_t*)t)->ub);
     if (jl_is_datatype(t))
@@ -3013,6 +3060,10 @@ int jl_has_intersect_kind_not_type(jl_value_t *t)
     if (jl_is_uniontype(t))
         return jl_has_intersect_kind_not_type(((jl_uniontype_t*)t)->a) ||
                jl_has_intersect_kind_not_type(((jl_uniontype_t*)t)->b);
+    if (jl_is_type_type(t)) {
+        jl_value_t *T = jl_typeeq_T(t);
+        return jl_is_typevar(T) || jl_is_kind(T);
+    }
     if (jl_is_typevar(t))
         return jl_has_intersect_kind_not_type(((jl_tvar_t*)t)->ub);
     return 0;
@@ -3034,36 +3085,34 @@ JL_DLLEXPORT int jl_isa(jl_value_t *x, jl_value_t *t)
             if (jl_is_concrete_type(t))
                 return 0;
             if (jl_is_type_type(t))
-                return jl_types_equal(x, jl_tparam0(t));
+                return jl_types_equal(x, jl_typeeq_T(t));
             jl_value_t *t2 = jl_unwrap_unionall(t);
-            if (jl_is_datatype(t2)) {
-                if (((jl_datatype_t*)t2)->name == jl_type_typename) {
-                    jl_value_t *tp = jl_tparam0(t2);
-                    if (jl_is_typevar(tp)) {
-                        if (((jl_tvar_t*)tp)->lb == jl_bottom_type) {
-                            while (jl_is_typevar(tp))
-                                tp = ((jl_tvar_t*)tp)->ub;
-                            if (!jl_has_free_typevars(tp))
-                                return jl_subtype(x, tp);
-                        }
-                        else if (((jl_tvar_t*)tp)->ub == (jl_value_t*)jl_any_type) {
-                            while (jl_is_typevar(tp))
-                                tp = ((jl_tvar_t*)tp)->lb;
-                            if (!jl_has_free_typevars(tp))
-                                return jl_subtype(tp, x);
-                        }
+            if (jl_is_type_type(t2)) {
+                jl_value_t *tp = jl_typeeq_T(t2);
+                if (jl_is_typevar(tp)) {
+                    if (((jl_tvar_t*)tp)->lb == jl_bottom_type) {
+                        while (jl_is_typevar(tp))
+                            tp = ((jl_tvar_t*)tp)->ub;
+                        if (!jl_has_free_typevars(tp))
+                            return jl_subtype(x, tp);
+                    }
+                    else if (((jl_tvar_t*)tp)->ub == (jl_value_t*)jl_any_type) {
+                        while (jl_is_typevar(tp))
+                            tp = ((jl_tvar_t*)tp)->lb;
+                        if (!jl_has_free_typevars(tp))
+                            return jl_subtype(tp, x);
                     }
                 }
-                else {
-                    return 0;
-                }
+            }
+            else if (jl_is_datatype(t2)) {
+                return jl_subtype(jl_typeof(x), t);
             }
             if (jl_subtype(jl_typeof(x), t))
                 return 1;
             if (jl_has_intersect_type_not_kind(t2)) {
-                JL_GC_PUSH1(&x);
-                x = (jl_value_t*)jl_wrap_Type(x);  // TODO jb/subtype avoid jl_wrap_Type
-                int ans = jl_subtype(x, t);
+                jl_value_t *wrapped = (jl_value_t*)jl_wrap_Type(x);  // TODO jb/subtype avoid jl_wrap_Type
+                JL_GC_PUSH1(&wrapped);
+                int ans = jl_subtype(wrapped, t);
                 JL_GC_POP();
                 return ans;
             }
@@ -3498,6 +3547,9 @@ static int var_occurs_inside(jl_value_t *v, jl_tvar_t *var, int inside, int want
             return vm->N && var_occurs_inside(vm->N, var, 1, want_inv);
         }
     }
+    else if (jl_is_type_type(v)) {
+        return var_occurs_inside(jl_typeeq_T(v), var, 1, want_inv);
+    }
     else if (jl_is_datatype(v)) {
         size_t i;
         int istuple = jl_is_tuple_type(v);
@@ -3564,7 +3616,8 @@ static jl_value_t *omit_bad_union(jl_value_t *u, jl_tvar_t *t)
 }
 
 // TODO: fuse with reachable_var?
-static int has_typevar_via_flatten_env(jl_value_t *x, jl_tvar_t *t, jl_ivarbinding_t *allvars, int8_t *checked) {
+static int has_typevar_via_flatten_env(jl_value_t *x, jl_tvar_t *t, jl_ivarbinding_t *allvars, int8_t *checked) JL_NOTSAFEPOINT
+{
     if (jl_is_unionall(x)) {
         jl_tvar_t *var = ((jl_unionall_t *)x)->var;
         if (has_typevar_via_flatten_env(var->lb, t, allvars, checked) ||
@@ -4054,6 +4107,9 @@ static int always_occurs_cov(jl_value_t *v, jl_tvar_t *var, jl_param_pos_t param
         jl_vararg_t *vm = (jl_vararg_t*)v;
         return vm->T && always_occurs_cov(vm->T, var, param);
     }
+    else if (jl_is_type_type(v)) {
+        return always_occurs_cov(jl_typeeq_T(v), var, PARAM_INVARIANT);
+    }
     else if (jl_is_datatype(v)) {
         jl_param_pos_t nparam = jl_is_tuple_type(v) ? PARAM_COVARIANT : param;
         for (size_t i = 0; i < jl_nparams(v); i++) {
@@ -4460,7 +4516,7 @@ static jl_value_t *intersect_invariant(jl_value_t *x, jl_value_t *y, jl_stenv_t 
 static jl_value_t *intersect_type_type(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int8_t R)
 {
     assert(e->Loffset == 0);
-    jl_value_t *p0 = jl_tparam0(x);
+    jl_value_t *p0 = jl_typeeq_T(x);
     if (!jl_is_typevar(p0))
         return (jl_typeof(p0) == y) ? x : jl_bottom_type;
     if (!jl_is_kind(y)) return jl_bottom_type;
@@ -4812,6 +4868,23 @@ static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_par
     }
     if (jl_is_unionall(y))
         return intersect_unionall(x, (jl_unionall_t*)y, e, 1, param);
+    if (jl_is_type_type(x) && jl_is_type_type(y)) {
+        jl_value_t *xp = jl_typeeq_T(x);
+        jl_value_t *yp = jl_typeeq_T(y);
+        jl_value_t *ii = intersect_invariant(xp, yp, e);
+        if (ii == NULL)
+            return jl_bottom_type;
+        JL_GC_PUSH1(&ii);
+        jl_value_t *ans = (jl_value_t*)jl_wrap_Type(ii);
+        JL_GC_POP();
+        return ans;
+    }
+    if (param != PARAM_INVARIANT) {
+        if (jl_is_type_type(x))
+            return intersect_type_type(x, y, e, 0);
+        if (jl_is_type_type(y))
+            return intersect_type_type(y, x, e, 1);
+    }
     if (jl_is_datatype(x) && jl_is_datatype(y)) {
         jl_datatype_t *xd = (jl_datatype_t*)x, *yd = (jl_datatype_t*)y;
         if (param != PARAM_INVARIANT) {
@@ -5149,7 +5222,7 @@ static jl_value_t *switch_union_tuple(jl_value_t *a, jl_value_t *b)
 // `a` might have a non-empty intersection with some concrete type b even if !(a<:b) and !(b<:a)
 // For example a=`Tuple{Type{<:Vector}}` and b=`Tuple{DataType}`
 // TODO: this query is partly available memoized as jl_type_equality_is_identity
-static int might_intersect_concrete(jl_value_t *a)
+static int might_intersect_concrete(jl_value_t *a) JL_NOTSAFEPOINT
 {
     if (jl_is_unionall(a))
         a = jl_unwrap_unionall(a);
@@ -5253,6 +5326,14 @@ jl_value_t *jl_type_intersection_env_s(jl_value_t *a, jl_value_t *b, jl_svec_t *
             }
         }
     }
+    if (sz > 0 && szb > 0) {
+        for (i = 0; i < sz; i++) {
+            if (!env[i]) {
+                sz = 0;
+                break;
+            }
+        }
+    }
     if (sz == 0 && szb > 0) {
         jl_unionall_t *ub = (jl_unionall_t*)b;
         while (jl_is_unionall(ub)) {
@@ -5334,7 +5415,8 @@ static void check_diagonal(jl_value_t *t, jl_varbinding_t *troot, jl_param_pos_t
             occurs[i*3+1] = v->occurs_cov;
             occurs[i*3+2] = v->cov_diag;
         }
-        check_diagonal(((jl_uniontype_t *)t)->a, troot, param);
+        jl_value_t *a = ((jl_uniontype_t *)t)->a;
+        check_diagonal(a, troot, param);
         for (v = troot, i = 0; v != NULL; v = v->prev, i++) {
             int8_t a_inv = v->occurs_inv;
             int8_t a_cov = v->occurs_cov;
@@ -5346,7 +5428,8 @@ static void check_diagonal(jl_value_t *t, jl_varbinding_t *troot, jl_param_pos_t
             occurs[i*3+1] = a_cov;
             occurs[i*3+2] = a_diag;
         }
-        check_diagonal(((jl_uniontype_t *)t)->b, troot, param);
+        jl_value_t *b = ((jl_uniontype_t *)t)->b;
+        check_diagonal(b, troot, param);
         for (v = troot, i = 0; v != NULL; v = v->prev, i++) {
             if (v->occurs_inv < occurs[i*3])
                 v->occurs_inv = occurs[i*3];
@@ -5367,14 +5450,20 @@ static void check_diagonal(jl_value_t *t, jl_varbinding_t *troot, jl_param_pos_t
             v1 = v2;
             v2 = v2->prev;
         }
-        check_diagonal(((jl_unionall_t *)t)->body, troot, param);
+        jl_value_t *body = ((jl_unionall_t *)t)->body;
+        check_diagonal(body, troot, param);
         v1->prev = v2;
+    }
+    else if (jl_is_type_type(t)) {
+        jl_value_t *T = jl_typeeq_T(t);
+        check_diagonal(T, troot, PARAM_INVARIANT);
     }
     else if (jl_is_datatype(t)) {
         jl_param_pos_t nparam = jl_is_tuple_type(t) ? PARAM_COVARIANT : PARAM_INVARIANT;
         if (nparam < param) nparam = param;
         for (size_t i = 0; i < jl_nparams(t); i++) {
-            check_diagonal(jl_tparam(t, i), troot, nparam);
+            jl_value_t *p = jl_tparam(t, i);
+            check_diagonal(p, troot, nparam);
         }
     }
     else if (jl_is_vararg(t)) {
@@ -5394,8 +5483,10 @@ static void check_diagonal(jl_value_t *t, jl_varbinding_t *troot, jl_param_pos_t
                 break;
             }
         }
-        if (v == NULL)
-            check_diagonal(((jl_tvar_t *)t)->ub, troot, PARAM_NONE);
+        if (v == NULL) {
+            jl_value_t *ub = ((jl_tvar_t *)t)->ub;
+            check_diagonal(ub, troot, PARAM_NONE);
+        }
     }
 }
 
@@ -5412,7 +5503,8 @@ static jl_value_t *insert_nondiagonal(jl_value_t *type, jl_varbinding_t *troot, 
         }
         if (v != NULL) {
             if (widen2ub) {
-                type = insert_nondiagonal(((jl_tvar_t *)type)->ub, troot, 2);
+                jl_value_t *ub = ((jl_tvar_t *)type)->ub;
+                type = insert_nondiagonal(ub, troot, 2);
             }
             else {
                 // we must replace each covariant occurrence of newvar with a different newvar2<:newvar (diagonal rule)
@@ -5445,9 +5537,11 @@ static jl_value_t *insert_nondiagonal(jl_value_t *type, jl_varbinding_t *troot, 
             if (body != newbody)
                 type = jl_new_struct(jl_unionall_type, var, newbody);
             // n.b. we do not widen lb, since that would be the wrong direction
-            newvar = insert_nondiagonal(var->ub, troot, widen2ub);
-            if (newvar != var->ub) {
-                newvar = (jl_value_t*)jl_new_typevar(var->name, var->lb, newvar);
+            jl_value_t *ub = var->ub;
+            newvar = insert_nondiagonal(ub, troot, widen2ub);
+            if (newvar != ub) {
+                jl_value_t *lb = var->lb;
+                newvar = (jl_value_t*)jl_new_typevar(var->name, lb, newvar);
                 newbody = jl_apply_type1(type, newvar);
                 type = jl_type_unionall((jl_tvar_t*)newvar, newbody);
             }
@@ -5476,6 +5570,15 @@ static jl_value_t *insert_nondiagonal(jl_value_t *type, jl_varbinding_t *troot, 
         if (t != newt) {
             JL_GC_PUSH1(&newt);
             type = (jl_value_t *)jl_wrap_vararg(newt, n, 0, 0);
+            JL_GC_POP();
+        }
+    }
+    else if (jl_is_type_type(type)) {
+        jl_value_t *T = jl_typeeq_T(type);
+        jl_value_t *newT = insert_nondiagonal(T, troot, 1);
+        if (T != newT) {
+            JL_GC_PUSH1(&newT);
+            type = (jl_value_t*)jl_wrap_Type(newT);
             JL_GC_POP();
         }
     }
@@ -5865,7 +5968,7 @@ static int args_morespecific_fix1(jl_value_t *a, jl_value_t *b, jl_value_t *a0, 
     return ret;
 }
 
-static int count_occurs(jl_value_t *t, jl_tvar_t *v)
+static int count_occurs(jl_value_t *t, jl_tvar_t *v) JL_NOTSAFEPOINT
 {
     if (t == (jl_value_t*)v)
         return 1;
@@ -5885,6 +5988,8 @@ static int count_occurs(jl_value_t *t, jl_tvar_t *v)
             return count_occurs(vm->T, v) + (vm->N ? count_occurs(vm->N, v) : 0);
         }
     }
+    if (jl_is_type_type(t))
+        return count_occurs(jl_typeeq_T(t), v);
     if (jl_is_datatype(t)) {
         int i, c=0;
         for(i=0; i < jl_nparams(t); i++)
@@ -5911,8 +6016,8 @@ int tuple_cmp_typeofbottom(jl_datatype_t *a, jl_datatype_t *b)
         jl_value_t *pa = i < la ? jl_tparam(a, i) : NULL;
         jl_value_t *pb = i < lb ? jl_tparam(b, i) : NULL;
         assert(jl_typeofbottom_type); // for clang-sa
-        int xa = pa == (jl_value_t*)jl_typeofbottom_type || pa == (jl_value_t*)jl_typeofbottom_type->super;
-        int xb = pb == (jl_value_t*)jl_typeofbottom_type || pb == (jl_value_t*)jl_typeofbottom_type->super;
+        int xa = is_typeofbottom_typealias(pa);
+        int xb = is_typeofbottom_typealias(pb);
         if (xa != xb)
             return xa - xb;
     }
@@ -5989,7 +6094,7 @@ static int type_morespecific_(jl_value_t *a, jl_value_t *b, jl_value_t *a0, jl_v
     if (jl_is_type_type(a) && !invariant) {
         if (b == (jl_value_t*)jl_typeofbottom_type)
             return 0;
-        jl_value_t *tp0a = jl_tparam0(a);
+        jl_value_t *tp0a = jl_typeeq_T(a);
         if (jl_is_typevar(tp0a)) {
             jl_value_t *ub = ((jl_tvar_t*)tp0a)->ub;
             if (jl_is_kind(b) && !sub_msp((jl_value_t*)jl_any_type, ub, b0, env))
@@ -6015,6 +6120,22 @@ static int type_morespecific_(jl_value_t *a, jl_value_t *b, jl_value_t *a0, jl_v
         return 0;
     }
 
+    if (jl_is_type_type(a) && jl_is_type_type(b)) {
+        jl_value_t *apara = jl_typeeq_T(a);
+        jl_value_t *bpara = jl_typeeq_T(b);
+        int afree = jl_has_free_typevars(apara);
+        int bfree = jl_has_free_typevars(bpara);
+        if (!afree && !bfree && !jl_types_equal(apara, bpara))
+            return 0;
+        if (type_morespecific_(apara, bpara, a0, b0, 1, env) && (jl_is_typevar(apara) || !afree || bfree))
+            return 1;
+        if (type_morespecific_(bpara, apara, b0, a0, 1, env) && (jl_is_typevar(bpara) || !bfree || afree))
+            return 0;
+        if (eq_msp(apara, bpara, a0, b0, env))
+            return !afree && bfree;
+        return 0;
+    }
+
     if (jl_is_datatype(a) && jl_is_datatype(b)) {
         jl_datatype_t *tta = (jl_datatype_t*)a, *ttb = (jl_datatype_t*)b;
         // Type{Union{}} is more specific than other types, so TypeofBottom must be too
@@ -6024,8 +6145,8 @@ static int type_morespecific_(jl_value_t *a, jl_value_t *b, jl_value_t *a0, jl_v
         while (tta != jl_any_type) {
             if (tta->name == ttb->name) {
                 if (super) {
-                    if (tta->name != jl_type_typename) return 1;
-                    jl_value_t *tp0 = jl_tparam0(b);
+                    if (!jl_is_type_type(b)) return 1;
+                    jl_value_t *tp0 = jl_typeeq_T(b);
                     if (jl_is_typevar(tp0)) {
                         if (sub_msp((jl_value_t*)jl_any_type, ((jl_tvar_t*)tp0)->ub, b0, env))
                             return 1;

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -6136,6 +6136,13 @@ static int type_morespecific_(jl_value_t *a, jl_value_t *b, jl_value_t *a0, jl_v
         return 0;
     }
 
+    if (jl_is_kind(a) && jl_is_typeeq(b) && !invariant) {
+        // a kind (e.g. `DataType`) is more specific than an unbounded `Type{T}`
+        jl_value_t *tp0b = jl_typeeq_T(b);
+        if (jl_is_typevar(tp0b) && sub_msp((jl_value_t*)jl_any_type, ((jl_tvar_t*)tp0b)->ub, b0, env))
+            return 1;
+    }
+
     if (jl_is_datatype(a) && jl_is_datatype(b)) {
         jl_datatype_t *tta = (jl_datatype_t*)a, *ttb = (jl_datatype_t*)b;
         // Type{Union{}} is more specific than other types, so TypeofBottom must be too

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2105,10 +2105,20 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_param_pos_t p
     }
     if (jl_is_datatype(x) && jl_is_typeeq(y) && x != (jl_value_t*)jl_typeofbottom_type) {
         jl_value_t *tp0 = jl_typeeq_T(y);
-        if (!jl_is_typevar(tp0) || !jl_is_kind(x))
-            return 0;
-        int issub = subtype((jl_value_t*)jl_type_type, y, e, param);
-        return issub;
+        if (jl_is_typevar(tp0)) {
+            if (!jl_is_kind(x))
+                return 0;
+            return subtype((jl_value_t*)jl_type_type, y, e, param);
+        }
+        // `Type{Type{T}}` with an unbounded `T` denotes the same set as the bare
+        // `TypeEq` (every `Type{X}` value), so a kind contained in `TypeEq` is a subtype
+        if (jl_is_typeeq(tp0)) {
+            jl_value_t *inner = jl_typeeq_T(tp0);
+            if (jl_is_typevar(inner) && ((jl_tvar_t*)inner)->lb == jl_bottom_type &&
+                    ((jl_tvar_t*)inner)->ub == (jl_value_t*)jl_any_type)
+                return subtype(x, (jl_value_t*)jl_typeeq_type, e, param);
+        }
+        return 0;
     }
     if (jl_is_datatype(x) && jl_is_datatype(y)) {
         if (x == y) return 1;

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2101,7 +2101,7 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_param_pos_t p
         // `TypeEq(T)` for a free typevar `T` is the kind of all types matching
         // `T`'s bounds; every such instance is itself a type, i.e. a `Kind`. So
         // `Type{T} <: y` reduces to `Kind <: y` (in particular `Type === Kind`).
-        return subtype((jl_value_t*)jl_kind_type, y, e, param);
+        return subtype((jl_value_t*)jl_anytype_type, y, e, param);
     }
     if (jl_is_datatype(x) && jl_is_typeeq(y) && x != (jl_value_t*)jl_typeofbottom_type) {
         jl_value_t *tp0 = jl_typeeq_T(y);

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -489,7 +489,7 @@ static int is_typeofbottom_typealias(jl_value_t *t) JL_NOTSAFEPOINT
     if (jl_typeofbottom_type == NULL)
         return 0;
     return t == (jl_value_t*)jl_typeofbottom_type ||
-           (jl_is_type_type(t) && jl_typeeq_T(t) == jl_bottom_type);
+           (jl_is_typeeq(t) && jl_typeeq_T(t) == jl_bottom_type);
 }
 
 static jl_value_t *normalize_typeofbottom_typealias(jl_value_t *t) JL_NOTSAFEPOINT
@@ -531,7 +531,7 @@ static int obviously_egal(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT
         return obviously_egal(jl_unwrap_vararg(vma), jl_unwrap_vararg(vmb)) &&
             ((!vma->N && !vmb->N) || (vma->N && vmb->N && obviously_egal(vma->N, vmb->N)));
     }
-    if (jl_is_type_type(a))
+    if (jl_is_typeeq(a))
         return obviously_egal(jl_typeeq_T(a), jl_typeeq_T(b));
     if (jl_is_typevar(a)) return 0;
     return !jl_is_type(a) && jl_egal(a,b);
@@ -553,9 +553,9 @@ static int obviously_unequal(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT
         if (jl_is_datatype(b)) {
             jl_datatype_t *ad = (jl_datatype_t*)a;
             jl_datatype_t *bd = (jl_datatype_t*)b;
-            if (a == (jl_value_t*)jl_typeofbottom_type && jl_is_type_type(b))
+            if (a == (jl_value_t*)jl_typeofbottom_type && jl_is_typeeq(b))
                 return obviously_unequal(jl_bottom_type, jl_tparam(bd, 0));
-            if (jl_is_type_type(a) && b == (jl_value_t*)jl_typeofbottom_type)
+            if (jl_is_typeeq(a) && b == (jl_value_t*)jl_typeofbottom_type)
                 return obviously_unequal(jl_tparam(ad, 0), jl_bottom_type);
             if (ad->name != bd->name)
                 return 1;
@@ -741,9 +741,9 @@ static jl_value_t *simple_join(jl_value_t *a, jl_value_t *b)
         return a;
     if (!(jl_is_type(a) || jl_is_typevar(a)) || !(jl_is_type(b) || jl_is_typevar(b)))
         return (jl_value_t*)jl_any_type;
-    if (jl_is_kind(a) && jl_is_type_type(b) && jl_typeof(jl_typeeq_T(b)) == a)
+    if (jl_is_kind(a) && jl_is_typeeq(b) && jl_typeof(jl_typeeq_T(b)) == a)
         return a;
-    if (jl_is_kind(b) && jl_is_type_type(a) && jl_typeof(jl_typeeq_T(a)) == b)
+    if (jl_is_kind(b) && jl_is_typeeq(a) && jl_typeof(jl_typeeq_T(a)) == b)
         return b;
     if (jl_is_typevar(a) && obviously_egal(b, ((jl_tvar_t*)a)->lb))
         return a;
@@ -768,9 +768,9 @@ static jl_value_t *simple_meet(jl_value_t *a, jl_value_t *b, int overesi)
         return jl_new_struct(jl_intersect_type, a, b);
     if (!(jl_is_type(a) || jl_is_typevar(a)) || !(jl_is_type(b) || jl_is_typevar(b)))
         return jl_bottom_type;
-    if (jl_is_kind(a) && jl_is_type_type(b) && jl_typeof(jl_typeeq_T(b)) == a)
+    if (jl_is_kind(a) && jl_is_typeeq(b) && jl_typeof(jl_typeeq_T(b)) == a)
         return b;
-    if (jl_is_kind(b) && jl_is_type_type(a) && jl_typeof(jl_typeeq_T(a)) == b)
+    if (jl_is_kind(b) && jl_is_typeeq(a) && jl_typeof(jl_typeeq_T(a)) == b)
         return a;
     if (jl_is_typevar(a) && obviously_egal(b, ((jl_tvar_t*)a)->ub))
         return a;
@@ -1141,7 +1141,7 @@ int is_leaf_bound(jl_value_t *v) JL_NOTSAFEPOINT
         return 1;
     if (jl_is_intersecttype(v)) // internal meet node (see #61917), not a concrete leaf
         return 0;
-    if (jl_is_type_type(v))
+    if (jl_is_typeeq(v))
         return 1;
     if (jl_is_datatype(v)) {
         if (((jl_datatype_t*)v)->name->abstract) {
@@ -1159,7 +1159,7 @@ static int is_leaf_typevar(jl_tvar_t *v) JL_NOTSAFEPOINT
 
 static jl_value_t *widen_Type_if_concrete(jl_value_t *t JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    if (jl_is_type_type(t) && !jl_is_typevar(jl_typeeq_T(t)))
+    if (jl_is_typeeq(t) && !jl_is_typevar(jl_typeeq_T(t)))
         return jl_typeof(jl_typeeq_T(t));
     if (jl_is_uniontype(t)) {
         jl_value_t *a = widen_Type_if_concrete(((jl_uniontype_t*)t)->a);
@@ -1182,7 +1182,7 @@ static int try_subtype_in_env(jl_value_t *a, jl_value_t *b, jl_stenv_t *e);
 // only if the widened kind satisfies `bound` , otherwise leave unchanged
 static jl_value_t *widen_Type_to_union(jl_value_t *t, jl_value_t *bound, jl_stenv_t *e)
 {
-    if (jl_is_type_type(t) && !jl_is_typevar(jl_typeeq_T(t))) {
+    if (jl_is_typeeq(t) && !jl_is_typevar(jl_typeeq_T(t))) {
         jl_value_t *T = jl_typeeq_T(t);
         jl_value_t *w = jl_typeof(T);
         if (!try_subtype_in_env(w, bound, e))
@@ -1246,7 +1246,7 @@ static int constrains_param_static(jl_tvar_t *var, jl_value_t *typ, int covarian
         return constrains_param_static(var, ((jl_uniontype_t*)typ)->a, covariant) &&
                constrains_param_static(var, ((jl_uniontype_t*)typ)->b, covariant);
     }
-    else if (jl_is_type_type(typ)) {
+    else if (jl_is_typeeq(typ)) {
         jl_value_t *T = jl_typeeq_T(typ);
         if (T == (jl_value_t*)var && var->ub == (jl_value_t*)jl_any_type) {
             return 0;
@@ -2059,7 +2059,7 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_param_pos_t p
     jl_value_t *ux = jl_unwrap_unionall(x);
     jl_value_t *uy = jl_unwrap_unionall(y);
     if ((x != ux || y != uy) && y != (jl_value_t*)jl_any_type && jl_is_datatype(ux) && jl_is_datatype(uy) &&
-        !jl_is_type_type(ux)) {
+        !jl_is_typeeq(ux)) {
         assert(ux);
         if (uy == (jl_value_t*)jl_any_type)
             return 1;
@@ -2078,20 +2078,20 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_param_pos_t p
     }
     if (jl_is_unionall(y))
         return subtype_unionall(x, (jl_unionall_t*)y, e, 1, param);
-    if (x == (jl_value_t*)jl_typeofbottom_type && jl_is_type_type(y)) {
+    if (x == (jl_value_t*)jl_typeofbottom_type && jl_is_typeeq(y)) {
         jl_value_t *tp0 = jl_typeeq_T(y);
         e->invdepth++;
         int ans = forall_exists_equal(jl_bottom_type, tp0, e);
         e->invdepth--;
         return ans;
     }
-    if (jl_is_type_type(x) && jl_is_type_type(y)) {
+    if (jl_is_typeeq(x) && jl_is_typeeq(y)) {
         e->invdepth++;
         int ans = forall_exists_equal(jl_typeeq_T(x), jl_typeeq_T(y), e);
         e->invdepth--;
         return ans;
     }
-    if (jl_is_type_type(x) && jl_is_datatype(y)) {
+    if (jl_is_typeeq(x) && jl_is_datatype(y)) {
         jl_value_t *tp0 = jl_typeeq_T(x);
         if (!jl_is_typevar(tp0)) {
             // TypeEq(T) dispatches as the singleton type of T. For example,
@@ -2103,7 +2103,7 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_param_pos_t p
         // `Type{T} <: y` reduces to `Kind <: y` (in particular `Type === Kind`).
         return subtype((jl_value_t*)jl_kind_type, y, e, param);
     }
-    if (jl_is_datatype(x) && jl_is_type_type(y) && x != (jl_value_t*)jl_typeofbottom_type) {
+    if (jl_is_datatype(x) && jl_is_typeeq(y) && x != (jl_value_t*)jl_typeofbottom_type) {
         jl_value_t *tp0 = jl_typeeq_T(y);
         if (!jl_is_typevar(tp0) || !jl_is_kind(x))
             return 0;
@@ -2436,7 +2436,7 @@ static int concrete_min(jl_value_t *t)
     if (t == (jl_value_t*)jl_bottom_type)
         return 1;
     if (jl_is_datatype(t)) {
-        if (jl_is_type_type(t))
+        if (jl_is_typeeq(t))
             return 0; // Type{T} may have the concrete supertype `typeof(T)`, so don't try to handle them here
         return jl_is_concrete_type(t) ? 1 : 2;
     }
@@ -2614,7 +2614,7 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
         // TODO: this would be a nice fast-path to have, unfortunately,
         //       datatype allocation fails to correctly hash-cons them
         //       and the subtyping tests include tests for this case
-        //if (!iscov && ((jl_datatype_t*)y)->isconcretetype && !jl_is_type_type(x)) {
+        //if (!iscov && ((jl_datatype_t*)y)->isconcretetype && !jl_is_typeeq(x)) {
         //    *subtype = 0;
         //    return 1;
         //}
@@ -2626,16 +2626,16 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
             //}
             int uncertain = 0;
             if (((jl_datatype_t*)x)->name != ((jl_datatype_t*)y)->name) {
-                if (jl_is_type_type(x) && jl_is_kind(y)) {
+                if (jl_is_typeeq(x) && jl_is_kind(y)) {
                     jl_value_t *t0 = jl_typeeq_T(x);
                     if (jl_is_typevar(t0))
                         return 0;
                     *subtype = jl_typeof(t0) == y;
                     return 1;
                 }
-                if (jl_is_type_type(y)) {
+                if (jl_is_typeeq(y)) {
                     jl_value_t *t0 = jl_typeeq_T(y);
-                    assert(!jl_is_type_type(x));
+                    assert(!jl_is_typeeq(x));
                     if ((jl_is_kind(x) && jl_is_typevar(t0)) || (x == (jl_value_t*)jl_typeofbottom_type))
                         return 0;
                     *subtype = 0;
@@ -2776,7 +2776,7 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
                     return 1;
                 }
                 jl_value_t *a1u = jl_unwrap_unionall(a1);
-                if (jl_is_type_type(a1u) && jl_is_type(jl_typeeq_T(a1u))) {
+                if (jl_is_typeeq(a1u) && jl_is_type(jl_typeeq_T(a1u))) {
                     a1 = jl_typeof(jl_typeeq_T(a1u));
                 }
                 for (; i < nparams_expanded_x; i++) {
@@ -2785,7 +2785,7 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
                         // diagonal rule: all the later parameters are also constrained to be type-equal to the first
                         jl_value_t *a2 = a;
                         jl_value_t *au = jl_unwrap_unionall(a);
-                        if (jl_is_type_type(au) && jl_is_type(jl_typeeq_T(au))) {
+                        if (jl_is_typeeq(au) && jl_is_type(jl_typeeq_T(au))) {
                             // if a is exactly Type{T}, then use the concrete typeof(T) instead here
                             a2 = jl_typeof(jl_typeeq_T(au));
                         }
@@ -2846,7 +2846,7 @@ JL_DLLEXPORT int jl_subtype_env(jl_value_t *x, jl_value_t *y, jl_value_t **env, 
         return 1;
     if (x == y ||
         (jl_typeof(x) == jl_typeof(y) &&
-         (jl_is_unionall(y) || jl_is_uniontype(y) || jl_is_type_type(y)) &&
+         (jl_is_unionall(y) || jl_is_uniontype(y) || jl_is_typeeq(y)) &&
          jl_types_egal(x, y))) {
         if (envsz != 0) { // quickly copy env from x
             jl_unionall_t *ua = (jl_unionall_t*)x;
@@ -2990,7 +2990,7 @@ JL_DLLEXPORT int jl_is_not_broken_subtype(jl_value_t *a, jl_value_t *b)
 {
     // TODO: the final commented out check here isn't correct; it should be closer to the
     // `issingletype` check used by `isnotbrokensubtype` in `base/compiler/typeutils.jl`
-    return !jl_is_kind(b) || !jl_is_type_type(a); // || jl_is_datatype_singleton((jl_datatype_t*)jl_tparam0(a));
+    return !jl_is_kind(b) || !jl_is_typeeq(a); // || jl_is_datatype_singleton((jl_datatype_t*)jl_tparam0(a));
 }
 
 int jl_tuple1_isa(jl_value_t *child1, jl_value_t **child, size_t cl, jl_datatype_t *pdt)
@@ -3038,7 +3038,7 @@ int jl_has_intersect_type_not_kind(jl_value_t *t)
     if (jl_is_uniontype(t))
         return jl_has_intersect_type_not_kind(((jl_uniontype_t*)t)->a) ||
                jl_has_intersect_type_not_kind(((jl_uniontype_t*)t)->b);
-    if (jl_is_type_type(t)) {
+    if (jl_is_typeeq(t)) {
         jl_value_t *T = jl_typeeq_T(t);
         return jl_is_typevar(T) || !jl_is_kind(T);
     }
@@ -3060,7 +3060,7 @@ int jl_has_intersect_kind_not_type(jl_value_t *t)
     if (jl_is_uniontype(t))
         return jl_has_intersect_kind_not_type(((jl_uniontype_t*)t)->a) ||
                jl_has_intersect_kind_not_type(((jl_uniontype_t*)t)->b);
-    if (jl_is_type_type(t)) {
+    if (jl_is_typeeq(t)) {
         jl_value_t *T = jl_typeeq_T(t);
         return jl_is_typevar(T) || jl_is_kind(T);
     }
@@ -3084,10 +3084,10 @@ JL_DLLEXPORT int jl_isa(jl_value_t *x, jl_value_t *t)
         if (!jl_has_free_typevars(x)) {
             if (jl_is_concrete_type(t))
                 return 0;
-            if (jl_is_type_type(t))
+            if (jl_is_typeeq(t))
                 return jl_types_equal(x, jl_typeeq_T(t));
             jl_value_t *t2 = jl_unwrap_unionall(t);
-            if (jl_is_type_type(t2)) {
+            if (jl_is_typeeq(t2)) {
                 jl_value_t *tp = jl_typeeq_T(t2);
                 if (jl_is_typevar(tp)) {
                     if (((jl_tvar_t*)tp)->lb == jl_bottom_type) {
@@ -3466,7 +3466,7 @@ static jl_value_t *intersect_var(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, int
         return (jl_value_t*)b;
     }
     if (bb->constraintkind == 1) {
-        if (!jl_is_type_type(ub) && !jl_is_uniontype(ub) && !jl_is_unionall(ub)) {
+        if (!jl_is_typeeq(ub) && !jl_is_uniontype(ub) && !jl_is_unionall(ub)) {
             // this branch is a fast path if there are no `Type`s and not needed for correctness
             set_bound(&bb->ub, ub, b, e);
             return (jl_value_t*)b;
@@ -3547,7 +3547,7 @@ static int var_occurs_inside(jl_value_t *v, jl_tvar_t *var, int inside, int want
             return vm->N && var_occurs_inside(vm->N, var, 1, want_inv);
         }
     }
-    else if (jl_is_type_type(v)) {
+    else if (jl_is_typeeq(v)) {
         return var_occurs_inside(jl_typeeq_T(v), var, 1, want_inv);
     }
     else if (jl_is_datatype(v)) {
@@ -4107,7 +4107,7 @@ static int always_occurs_cov(jl_value_t *v, jl_tvar_t *var, jl_param_pos_t param
         jl_vararg_t *vm = (jl_vararg_t*)v;
         return vm->T && always_occurs_cov(vm->T, var, param);
     }
-    else if (jl_is_type_type(v)) {
+    else if (jl_is_typeeq(v)) {
         return always_occurs_cov(jl_typeeq_T(v), var, PARAM_INVARIANT);
     }
     else if (jl_is_datatype(v)) {
@@ -4868,7 +4868,7 @@ static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_par
     }
     if (jl_is_unionall(y))
         return intersect_unionall(x, (jl_unionall_t*)y, e, 1, param);
-    if (jl_is_type_type(x) && jl_is_type_type(y)) {
+    if (jl_is_typeeq(x) && jl_is_typeeq(y)) {
         jl_value_t *xp = jl_typeeq_T(x);
         jl_value_t *yp = jl_typeeq_T(y);
         jl_value_t *ii = intersect_invariant(xp, yp, e);
@@ -4880,19 +4880,19 @@ static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_par
         return ans;
     }
     if (param != PARAM_INVARIANT) {
-        if (jl_is_type_type(x))
+        if (jl_is_typeeq(x))
             return intersect_type_type(x, y, e, 0);
-        if (jl_is_type_type(y))
+        if (jl_is_typeeq(y))
             return intersect_type_type(y, x, e, 1);
     }
     if (jl_is_datatype(x) && jl_is_datatype(y)) {
         jl_datatype_t *xd = (jl_datatype_t*)x, *yd = (jl_datatype_t*)y;
         if (param != PARAM_INVARIANT) {
-            if (jl_is_type_type(x)) {
-                if (!jl_is_type_type(y))
+            if (jl_is_typeeq(x)) {
+                if (!jl_is_typeeq(y))
                     return intersect_type_type(x, y, e, 0);
             }
-            else if (jl_is_type_type(y)) {
+            else if (jl_is_typeeq(y)) {
                 return intersect_type_type(y, x, e, 1);
             }
         }
@@ -5233,7 +5233,7 @@ static int might_intersect_concrete(jl_value_t *a) JL_NOTSAFEPOINT
                might_intersect_concrete(((jl_uniontype_t*)a)->b);
     if (jl_is_vararg(a))
         return might_intersect_concrete(jl_unwrap_vararg(a));
-    if (jl_is_type_type(a))
+    if (jl_is_typeeq(a))
         return 1;
     if (jl_is_datatype(a)) {
         int tpl = jl_is_tuple_type(a);
@@ -5454,7 +5454,7 @@ static void check_diagonal(jl_value_t *t, jl_varbinding_t *troot, jl_param_pos_t
         check_diagonal(body, troot, param);
         v1->prev = v2;
     }
-    else if (jl_is_type_type(t)) {
+    else if (jl_is_typeeq(t)) {
         jl_value_t *T = jl_typeeq_T(t);
         check_diagonal(T, troot, PARAM_INVARIANT);
     }
@@ -5573,7 +5573,7 @@ static jl_value_t *insert_nondiagonal(jl_value_t *type, jl_varbinding_t *troot, 
             JL_GC_POP();
         }
     }
-    else if (jl_is_type_type(type)) {
+    else if (jl_is_typeeq(type)) {
         jl_value_t *T = jl_typeeq_T(type);
         jl_value_t *newT = insert_nondiagonal(T, troot, 1);
         if (T != newT) {
@@ -5988,7 +5988,7 @@ static int count_occurs(jl_value_t *t, jl_tvar_t *v) JL_NOTSAFEPOINT
             return count_occurs(vm->T, v) + (vm->N ? count_occurs(vm->N, v) : 0);
         }
     }
-    if (jl_is_type_type(t))
+    if (jl_is_typeeq(t))
         return count_occurs(jl_typeeq_T(t), v);
     if (jl_is_datatype(t)) {
         int i, c=0;
@@ -6091,7 +6091,7 @@ static int type_morespecific_(jl_value_t *a, jl_value_t *b, jl_value_t *a0, jl_v
         return 0;
     }
 
-    if (jl_is_type_type(a) && !invariant) {
+    if (jl_is_typeeq(a) && !invariant) {
         if (b == (jl_value_t*)jl_typeofbottom_type)
             return 0;
         jl_value_t *tp0a = jl_typeeq_T(a);
@@ -6120,7 +6120,7 @@ static int type_morespecific_(jl_value_t *a, jl_value_t *b, jl_value_t *a0, jl_v
         return 0;
     }
 
-    if (jl_is_type_type(a) && jl_is_type_type(b)) {
+    if (jl_is_typeeq(a) && jl_is_typeeq(b)) {
         jl_value_t *apara = jl_typeeq_T(a);
         jl_value_t *bpara = jl_typeeq_T(b);
         int afree = jl_has_free_typevars(apara);
@@ -6139,13 +6139,13 @@ static int type_morespecific_(jl_value_t *a, jl_value_t *b, jl_value_t *a0, jl_v
     if (jl_is_datatype(a) && jl_is_datatype(b)) {
         jl_datatype_t *tta = (jl_datatype_t*)a, *ttb = (jl_datatype_t*)b;
         // Type{Union{}} is more specific than other types, so TypeofBottom must be too
-        if (tta == jl_typeofbottom_type && (jl_is_kind(b) || jl_is_type_type(b)))
+        if (tta == jl_typeofbottom_type && (jl_is_kind(b) || jl_is_typeeq(b)))
             return 1;
         int super = 0;
         while (tta != jl_any_type) {
             if (tta->name == ttb->name) {
                 if (super) {
-                    if (!jl_is_type_type(b)) return 1;
+                    if (!jl_is_typeeq(b)) return 1;
                     jl_value_t *tp0 = jl_typeeq_T(b);
                     if (jl_is_typevar(tp0)) {
                         if (sub_msp((jl_value_t*)jl_any_type, ((jl_tvar_t*)tp0)->ub, b0, env))

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2435,9 +2435,9 @@ static int concrete_min(jl_value_t *t)
         t = jl_unwrap_unionall(t);
     if (t == (jl_value_t*)jl_bottom_type)
         return 1;
+    if (jl_is_typeeq(t))
+        return 0; // Type{T} may have the concrete supertype `typeof(T)`, so don't try to handle them here
     if (jl_is_datatype(t)) {
-        if (jl_is_typeeq(t))
-            return 0; // Type{T} may have the concrete supertype `typeof(T)`, so don't try to handle them here
         return jl_is_concrete_type(t) ? 1 : 2;
     }
     if (jl_is_vararg(t))

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -33,7 +33,7 @@ static jl_value_t *jl_type_extract_name(jl_value_t *t1 JL_PROPAGATES_ROOT, int i
     else if (jl_is_typevar(t1)) {
         return jl_type_extract_name(((jl_tvar_t*)t1)->ub, 0);
     }
-    else if (jl_is_type_type(t1)) {
+    else if (jl_is_typeeq(t1)) {
         return (jl_value_t*)jl_type_typename;
     }
     else if (t1 == jl_bottom_type || t1 == (jl_value_t*)jl_typeofbottom_type) {
@@ -69,7 +69,7 @@ static int jl_type_extract_name_precise(jl_value_t *t1, int invariant)
     else if (jl_is_typevar(t1)) {
         return jl_type_extract_name_precise(((jl_tvar_t*)t1)->ub, 0);
     }
-    else if (jl_is_type_type(t1)) {
+    else if (jl_is_typeeq(t1)) {
         return 1;
     }
     else if (t1 == jl_bottom_type || t1 == (jl_value_t*)jl_typeofbottom_type) {
@@ -117,7 +117,7 @@ static int sig_match_by_type_leaf(jl_value_t **types, jl_tupletype_t *sig, size_
     for (i = 0; i < n; i++) {
         jl_value_t *decl = jl_tparam(sig, i);
         jl_value_t *a = types[i];
-        if (jl_is_type_type(a)) // decl is not Type, because it wouldn't be leafsig
+        if (jl_is_typeeq(a)) // decl is not Type, because it wouldn't be leafsig
             a = jl_typeof(jl_typeeq_T(a));
         if (!jl_types_equal(a, decl))
             return 0;
@@ -135,9 +135,9 @@ static int sig_match_by_type_simple(jl_value_t **types, size_t n, jl_tupletype_t
         jl_value_t *unw = jl_is_unionall(decl) ? ((jl_unionall_t*)decl)->body : decl;
         if (jl_is_vararg(a))
             return 0;
-        if (jl_is_type_type(unw)) {
+        if (jl_is_typeeq(unw)) {
             jl_value_t *tp0 = jl_typeeq_T(unw);
-            if (jl_is_type_type(a)) {
+            if (jl_is_typeeq(a)) {
                 if (jl_is_typevar(tp0)) {
                     // in the case of Type{_}, the types don't have to match exactly.
                     // this is cached as `Type{T} where T`.
@@ -158,7 +158,7 @@ static int sig_match_by_type_simple(jl_value_t **types, size_t n, jl_tupletype_t
         else if (decl == (jl_value_t*)jl_any_type) {
         }
         else {
-            if (jl_is_type_type(a)) // decl is not Type, because it would be caught above
+            if (jl_is_typeeq(a)) // decl is not Type, because it would be caught above
                 a = jl_typeof(jl_typeeq_T(a));
             if (!jl_types_equal(a, decl))
                 return 0;
@@ -223,7 +223,7 @@ static inline int sig_match_simple(jl_value_t *arg1, jl_value_t **args, size_t n
             continue;
         }
         jl_value_t *unw = jl_is_unionall(decl) ? ((jl_unionall_t*)decl)->body : decl;
-        if (jl_is_type_type(unw) && jl_is_type(a)) {
+        if (jl_is_typeeq(unw) && jl_is_type(a)) {
             jl_value_t *tp0 = jl_typeeq_T(unw);
             if (jl_is_typevar(tp0)) {
                 // in the case of Type{_}, the types don't have to match exactly.
@@ -433,7 +433,7 @@ static int tname_intersection(jl_value_t *a, jl_typename_t *bname, int8_t tparam
     if (jl_is_typevar(a))
         return tname_intersection(((jl_tvar_t*)a)->ub, bname, tparam);
     if (tparam) {
-        if (!jl_is_type_type(a))
+        if (!jl_is_typeeq(a))
             return 0;
         a = jl_unwrap_unionall(jl_typeeq_T(a));
         if (!jl_is_datatype(a))
@@ -470,7 +470,7 @@ static int jl_typemap_intersection_memory_visitor(jl_genericmemory_t *a, jl_valu
         jl_value_t *ttype = jl_unwrap_unionall(ty);
         if (tparam & 1)
             // extract T from Type{T} (if possible)
-            ttype = jl_is_type_type(ttype) ? jl_typeeq_T(ttype) : NULL;
+            ttype = jl_is_typeeq(ttype) ? jl_typeeq_T(ttype) : NULL;
         if (ttype && jl_is_datatype(ttype)) {
             tydt = (jl_datatype_t*)ttype;
         }
@@ -642,7 +642,7 @@ int jl_typemap_intersection_visitor(jl_typemap_t *map, int offs,
                 maybe_type = maybe_kind || jl_has_intersect_type_not_kind(ty);
                 if (maybe_type && !maybe_kind) {
                     typetype = jl_unwrap_unionall(ty);
-                    typetype = jl_is_type_type(typetype) ? jl_typeeq_T(typetype) : NULL;
+                    typetype = jl_is_typeeq(typetype) ? jl_typeeq_T(typetype) : NULL;
                     name = typetype ? jl_type_extract_name(typetype, 1) : NULL;
                     if (!typetype)
                         exclude_typeofbottom = !jl_subtype((jl_value_t*)jl_typeofbottom_type, ty);
@@ -966,7 +966,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(
         }
         if (ty) {
             // now look at the optimized leaftype caches
-            if (jl_is_type_type(ty)) {
+            if (jl_is_typeeq(ty)) {
                 jl_value_t *a0 = jl_typeeq_T(ty);
                 if (is_cache_leaf(a0, 1)) {
                     jl_genericmemory_t *targ = jl_atomic_load_relaxed(&cache->targ);
@@ -1002,7 +1002,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(
             // now look at the optimized TypeName caches
             jl_genericmemory_t *tname = jl_atomic_load_relaxed(&cache->tname);
             if (tname != (jl_genericmemory_t*)jl_an_empty_memory_any) {
-                jl_value_t *a0 = ty && jl_is_type_type(ty) ? jl_type_extract_name(jl_typeeq_T(ty), 1) : NULL;
+                jl_value_t *a0 = ty && jl_is_typeeq(ty) ? jl_type_extract_name(jl_typeeq_T(ty), 1) : NULL;
                 if (a0) { // TODO: if we start analyzing Union types in jl_type_extract_name, then a0 might be over-approximated here, leading us to miss possible subtypes
                     jl_datatype_t *super = (jl_datatype_t*)jl_unwrap_unionall(((jl_typename_t*)a0)->wrapper);
                     while (1) {
@@ -1313,7 +1313,7 @@ static jl_value_t *jl_method_convert_list_to_cache(
             if (jl_is_vararg(key))
                 key = jl_unwrap_vararg(key);
             if (tparam) {
-                assert(jl_is_type_type(key));
+                assert(jl_is_typeeq(key));
                 key = jl_typeeq_T(key);
             }
             jl_typemap_memory_insert_(map, &dblcache, key, ml, NULL, 0, offs, NULL);
@@ -1428,7 +1428,7 @@ static void jl_typemap_level_insert_(
     // Don't put Varargs in the optimized caches (too hard to handle in lookup and bp)
     if (t1 && !isva) {
         // try to put in leaf type caches
-        if (jl_is_type_type(t1)) {
+        if (jl_is_typeeq(t1)) {
             // if the argument is Type{...}, this method has specializations for singleton kinds
             // and we use the table indexed for that purpose.
             jl_value_t *a0 = jl_typeeq_T(t1);
@@ -1447,7 +1447,7 @@ static void jl_typemap_level_insert_(
         // try to put in TypeName caches
         jl_value_t *a0;
         t1 = jl_unwrap_unionall(t1);
-        if (jl_is_type_type(t1)) {
+        if (jl_is_typeeq(t1)) {
             jl_value_t *tp0 = jl_typeeq_T(t1);
             a0 = jl_type_extract_name(tp0, 1);
             jl_datatype_t *super = a0 ? (jl_datatype_t*)jl_unwrap_unionall(((jl_typename_t*)a0)->wrapper) : jl_any_type;
@@ -1483,7 +1483,7 @@ jl_typemap_entry_t *jl_typemap_alloc(
         jl_value_t *decl = jl_tparam(ttype, i);
         if (jl_is_kind(decl))
             isleafsig = 0; // Type{} may have a higher priority than a kind
-        else if (jl_is_type_type(decl))
+        else if (jl_is_typeeq(decl))
             isleafsig = 0; // Type{} may need special processing to compute the match
         else if (jl_is_vararg(decl))
             isleafsig = 0; // makes iteration easier when the endpoints are the same

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -33,7 +33,10 @@ static jl_value_t *jl_type_extract_name(jl_value_t *t1 JL_PROPAGATES_ROOT, int i
     else if (jl_is_typevar(t1)) {
         return jl_type_extract_name(((jl_tvar_t*)t1)->ub, 0);
     }
-    else if (t1 == jl_bottom_type || t1 == (jl_value_t*)jl_typeofbottom_type || t1 == (jl_value_t*)jl_typeofbottom_type->super) {
+    else if (jl_is_type_type(t1)) {
+        return (jl_value_t*)jl_type_typename;
+    }
+    else if (t1 == jl_bottom_type || t1 == (jl_value_t*)jl_typeofbottom_type) {
         return (jl_value_t*)jl_typeofbottom_type->name; // put Union{} and typeof(Union{}) and Type{Union{}} together for convenience
     }
     else if (jl_is_datatype(t1)) {
@@ -66,7 +69,10 @@ static int jl_type_extract_name_precise(jl_value_t *t1, int invariant)
     else if (jl_is_typevar(t1)) {
         return jl_type_extract_name_precise(((jl_tvar_t*)t1)->ub, 0);
     }
-    else if (t1 == jl_bottom_type || t1 == (jl_value_t*)jl_typeofbottom_type || t1 == (jl_value_t*)jl_typeofbottom_type->super) {
+    else if (jl_is_type_type(t1)) {
+        return 1;
+    }
+    else if (t1 == jl_bottom_type || t1 == (jl_value_t*)jl_typeofbottom_type) {
         return 1;
     }
     else if (jl_is_datatype(t1)) {
@@ -112,7 +118,7 @@ static int sig_match_by_type_leaf(jl_value_t **types, jl_tupletype_t *sig, size_
         jl_value_t *decl = jl_tparam(sig, i);
         jl_value_t *a = types[i];
         if (jl_is_type_type(a)) // decl is not Type, because it wouldn't be leafsig
-            a = jl_typeof(jl_tparam0(a));
+            a = jl_typeof(jl_typeeq_T(a));
         if (!jl_types_equal(a, decl))
             return 0;
     }
@@ -130,16 +136,16 @@ static int sig_match_by_type_simple(jl_value_t **types, size_t n, jl_tupletype_t
         if (jl_is_vararg(a))
             return 0;
         if (jl_is_type_type(unw)) {
-            jl_value_t *tp0 = jl_tparam0(unw);
+            jl_value_t *tp0 = jl_typeeq_T(unw);
             if (jl_is_type_type(a)) {
                 if (jl_is_typevar(tp0)) {
                     // in the case of Type{_}, the types don't have to match exactly.
                     // this is cached as `Type{T} where T`.
                     if (((jl_tvar_t*)tp0)->ub != (jl_value_t*)jl_any_type &&
-                        !jl_subtype(jl_tparam0(a), ((jl_tvar_t*)tp0)->ub))
+                        !jl_subtype(jl_typeeq_T(a), ((jl_tvar_t*)tp0)->ub))
                         return 0;
                 }
-                else if (!jl_types_equal(jl_tparam0(a), tp0)) {
+                else if (!jl_types_equal(jl_typeeq_T(a), tp0)) {
                     return 0;
                 }
             }
@@ -153,7 +159,7 @@ static int sig_match_by_type_simple(jl_value_t **types, size_t n, jl_tupletype_t
         }
         else {
             if (jl_is_type_type(a)) // decl is not Type, because it would be caught above
-                a = jl_typeof(jl_tparam0(a));
+                a = jl_typeof(jl_typeeq_T(a));
             if (!jl_types_equal(a, decl))
                 return 0;
         }
@@ -218,12 +224,12 @@ static inline int sig_match_simple(jl_value_t *arg1, jl_value_t **args, size_t n
         }
         jl_value_t *unw = jl_is_unionall(decl) ? ((jl_unionall_t*)decl)->body : decl;
         if (jl_is_type_type(unw) && jl_is_type(a)) {
-            jl_value_t *tp0 = jl_tparam0(unw);
+            jl_value_t *tp0 = jl_typeeq_T(unw);
             if (jl_is_typevar(tp0)) {
                 // in the case of Type{_}, the types don't have to match exactly.
                 // this is cached as `Type{T} where T`.
-                if (((jl_tvar_t*)tp0)->ub != (jl_value_t*)jl_any_type &&
-                    !jl_subtype(a, ((jl_tvar_t*)tp0)->ub))
+                jl_value_t *ub = ((jl_tvar_t*)tp0)->ub;
+                if (ub != (jl_value_t*)jl_any_type && !jl_subtype(a, ub))
                     return 0;
             }
             else {
@@ -426,14 +432,14 @@ static int tname_intersection(jl_value_t *a, jl_typename_t *bname, int8_t tparam
                tname_intersection(((jl_uniontype_t*)a)->b, bname, tparam);
     if (jl_is_typevar(a))
         return tname_intersection(((jl_tvar_t*)a)->ub, bname, tparam);
+    if (tparam) {
+        if (!jl_is_type_type(a))
+            return 0;
+        a = jl_unwrap_unionall(jl_typeeq_T(a));
+        if (!jl_is_datatype(a))
+            return tname_intersection(a, bname, 0);
+    }
     if (jl_is_datatype(a)) {
-        if (tparam) {
-            if (!jl_is_type_type(a))
-                return 0;
-            a = jl_unwrap_unionall(jl_tparam0(a));
-            if (!jl_is_datatype(a))
-                return tname_intersection(a, bname, 0);
-        }
         return tname_intersection_dt((jl_datatype_t*)a, bname, jl_supertype_height((jl_datatype_t*)a));
     }
     return 0;
@@ -464,7 +470,7 @@ static int jl_typemap_intersection_memory_visitor(jl_genericmemory_t *a, jl_valu
         jl_value_t *ttype = jl_unwrap_unionall(ty);
         if (tparam & 1)
             // extract T from Type{T} (if possible)
-            ttype = jl_is_type_type(ttype) ? jl_tparam0(ttype) : NULL;
+            ttype = jl_is_type_type(ttype) ? jl_typeeq_T(ttype) : NULL;
         if (ttype && jl_is_datatype(ttype)) {
             tydt = (jl_datatype_t*)ttype;
         }
@@ -616,8 +622,6 @@ int jl_typemap_intersection_visitor(jl_typemap_t *map, int offs,
         else {
             ty = NULL;
         }
-        if (ty == (jl_value_t*)jl_typeofbottom_type)
-            ty = (jl_value_t*)jl_assume(jl_typeofbottom_type)->super;
         if (ty) {
             while (jl_is_typevar(ty))
                 ty = ((jl_tvar_t*)ty)->ub;
@@ -638,7 +642,7 @@ int jl_typemap_intersection_visitor(jl_typemap_t *map, int offs,
                 maybe_type = maybe_kind || jl_has_intersect_type_not_kind(ty);
                 if (maybe_type && !maybe_kind) {
                     typetype = jl_unwrap_unionall(ty);
-                    typetype = jl_is_type_type(typetype) ? jl_tparam0(typetype) : NULL;
+                    typetype = jl_is_type_type(typetype) ? jl_typeeq_T(typetype) : NULL;
                     name = typetype ? jl_type_extract_name(typetype, 1) : NULL;
                     if (!typetype)
                         exclude_typeofbottom = !jl_subtype((jl_value_t*)jl_typeofbottom_type, ty);
@@ -862,7 +866,6 @@ static jl_typemap_entry_t *jl_typemap_entry_assoc_by_type(
                 if (ismatch && search->env)
                     resetenv = 1;
             }
-
             if (ismatch) {
                 size_t i, l;
                 for (i = 0, l = jl_svec_len(ml->guardsigs); i < l; i++) {
@@ -954,8 +957,6 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(
         else {
             ty = NULL;
         }
-        if (ty == (jl_value_t*)jl_typeofbottom_type)
-            ty = (jl_value_t*)jl_assume(jl_typeofbottom_type)->super;
         // If there is a type at offs, look in the optimized leaf type caches
         if (ty && !subtype) {
             if (jl_is_any(ty))
@@ -966,7 +967,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(
         if (ty) {
             // now look at the optimized leaftype caches
             if (jl_is_type_type(ty)) {
-                jl_value_t *a0 = jl_tparam0(ty);
+                jl_value_t *a0 = jl_typeeq_T(ty);
                 if (is_cache_leaf(a0, 1)) {
                     jl_genericmemory_t *targ = jl_atomic_load_relaxed(&cache->targ);
                     if (targ != (jl_genericmemory_t*)jl_an_empty_memory_any) {
@@ -1001,7 +1002,7 @@ jl_typemap_entry_t *jl_typemap_assoc_by_type(
             // now look at the optimized TypeName caches
             jl_genericmemory_t *tname = jl_atomic_load_relaxed(&cache->tname);
             if (tname != (jl_genericmemory_t*)jl_an_empty_memory_any) {
-                jl_value_t *a0 = ty && jl_is_type_type(ty) ? jl_type_extract_name(jl_tparam0(ty), 1) : NULL;
+                jl_value_t *a0 = ty && jl_is_type_type(ty) ? jl_type_extract_name(jl_typeeq_T(ty), 1) : NULL;
                 if (a0) { // TODO: if we start analyzing Union types in jl_type_extract_name, then a0 might be over-approximated here, leading us to miss possible subtypes
                     jl_datatype_t *super = (jl_datatype_t*)jl_unwrap_unionall(((jl_typename_t*)a0)->wrapper);
                     while (1) {
@@ -1311,11 +1312,9 @@ static jl_value_t *jl_method_convert_list_to_cache(
                 key = jl_tparam(key, len-1);
             if (jl_is_vararg(key))
                 key = jl_unwrap_vararg(key);
-            if (key == (jl_value_t*)jl_typeofbottom_type)
-                key = (jl_value_t*)jl_assume(jl_typeofbottom_type)->super;
             if (tparam) {
                 assert(jl_is_type_type(key));
-                key = jl_tparam0(key);
+                key = jl_typeeq_T(key);
             }
             jl_typemap_memory_insert_(map, &dblcache, key, ml, NULL, 0, offs, NULL);
         }
@@ -1421,8 +1420,6 @@ static void jl_typemap_level_insert_(
     else {
         t1 = NULL;
     }
-    if (t1 == (jl_value_t*)jl_typeofbottom_type)
-        t1 = (jl_value_t*)jl_assume(jl_typeofbottom_type)->super;
     // If the type at `offs` is Any, put it in the Any list
     if (t1 && jl_is_any(t1)) {
         jl_typemap_insert_generic(map, &cache->any, (jl_value_t*)cache, newrec, 0, offs+1, NULL);
@@ -1434,7 +1431,7 @@ static void jl_typemap_level_insert_(
         if (jl_is_type_type(t1)) {
             // if the argument is Type{...}, this method has specializations for singleton kinds
             // and we use the table indexed for that purpose.
-            jl_value_t *a0 = jl_tparam0(t1);
+            jl_value_t *a0 = jl_typeeq_T(t1);
             if (is_cache_leaf(a0, 1)) {
                 jl_typename_t *name = a0 == jl_bottom_type ? jl_typeofbottom_type->name : ((jl_datatype_t*)a0)->name;
                 jl_typemap_memory_insert_(map, &cache->targ, (jl_value_t*)name, newrec, (jl_value_t*)cache, 1, offs, jl_is_datatype(name->wrapper) ? NULL : a0);
@@ -1451,9 +1448,11 @@ static void jl_typemap_level_insert_(
         jl_value_t *a0;
         t1 = jl_unwrap_unionall(t1);
         if (jl_is_type_type(t1)) {
-            a0 = jl_type_extract_name(jl_tparam0(t1), 1);
+            jl_value_t *tp0 = jl_typeeq_T(t1);
+            a0 = jl_type_extract_name(tp0, 1);
             jl_datatype_t *super = a0 ? (jl_datatype_t*)jl_unwrap_unionall(((jl_typename_t*)a0)->wrapper) : jl_any_type;
-            jl_typemap_memory_insert_(map, &cache->tname, (jl_value_t*)super->name, newrec, (jl_value_t*)cache, 1, offs, NULL);
+            jl_typename_t *name = super->name;
+            jl_typemap_memory_insert_(map, &cache->tname, (jl_value_t*)name, newrec, (jl_value_t*)cache, 1, offs, NULL);
             return;
         }
         a0 = jl_type_extract_name(t1, 0);

--- a/test/clangsa/MissingRoots.c
+++ b/test/clangsa/MissingRoots.c
@@ -652,7 +652,7 @@ void module_member(jl_module_t *m)
 }
 
 int type_type(jl_value_t *v) {
-    return jl_is_type_type(jl_typeof(v));
+    return jl_is_typeeq(jl_typeof(v));
 }
 
 /* TODO: BROKEN

--- a/test/core.jl
+++ b/test/core.jl
@@ -195,7 +195,7 @@ f11840(::DataType) = "DataType"
 f11840(::UnionAll) = "UnionAll"
 f11840(::Type{T}) where {T<:Tuple} = "Tuple"
 @test f11840(Type) == "UnionAll"
-@test f11840(Type.body) == "DataType"
+@test f11840(Type.body) == "Type"
 @test f11840(Union{Int,Int8}) == "Type"
 @test f11840(Tuple) == "Tuple"
 @test f11840(TT11840) == "Tuple"
@@ -3645,6 +3645,12 @@ function f11355(sig::Type{T}) where T<:Tuple
 end
 function f11355(arg::DataType)
     if arg <: Tuple
+        return 200
+    end
+    return 100
+end
+function f11355(arg::TypeEq)
+    if Base.type_parameter(arg) <: Tuple
         return 200
     end
     return 100

--- a/test/core.jl
+++ b/test/core.jl
@@ -391,6 +391,29 @@ end  |> only == Type{typejoin(Int, UInt, Float64)}
 @test typejoin(1, 2, 3) === Any
 @test typejoin(Int, Int, 3) === Any
 
+# issue #61915: typejoin must stay sound when an operand is a `Type{X}` kind. Under the
+# TypeEq refactor `typeof(Type{X})` is no longer a `DataType`; joining a kind with an
+# unrelated non-`Type` operand must give `Any`, not `Type`.
+@test typejoin(Symbol, Type{Int}) === Any
+@test typejoin(Type{Int}, Symbol) === Any
+@test typejoin(Type{Int}, Int) === Any
+@test typejoin(Type{Int}, String) === Any
+@test typejoin(Type{Int}, Type{Float64}) === Type
+@test typejoin(Type{Int}, Type) === Type
+@test_broken typejoin(Type{Int}, DataType) !== DataType
+@test typejoin(Symbol, Type{Int}) === typejoin(Type{Int}, Symbol)
+@test typejoin(DataType, Type{Int}) === typejoin(Type{Int}, DataType)
+
+# issue #61915: a method whose function type is `Type{Foo{...} where ...}` must derive its
+# name as `Foo`, not `:Any` (nth_arg_datatype has to unwrap the wrapped UnionAll).
+struct UA61915{T,N,A<:AbstractArray{T,N}}
+    a::A
+end
+UA61915{T}(a) where {T} = UA61915{T,ndims(a),typeof(a)}(a)
+@test all(m -> m.name === :UA61915, methods(UA61915))
+@test which(UA61915{Int}, (Vector{Int},)).name === :UA61915
+@test ccall(:jl_argument_datatype, Any, (Any,), Type{Array}) === Base.unwrap_unionall(Array)
+
 # promote_typejoin returns a Union only with Nothing/Missing combined with concrete types
 for T in (Nothing, Missing)
     @test Base.promote_typejoin(Int, Float64) === Real

--- a/test/core.jl
+++ b/test/core.jl
@@ -421,6 +421,11 @@ end
 @test Base.promote_typejoin_union(Union{Type{Int}, Type{String}}) === Type
 @test fieldtype.(Tuple{Int,Float32,Int}, [1, 2, 3]) == [Int, Float32, Int]
 @test typeof.(Any[Int, "x", 1.0]) == [DataType, String, Float64]
+# PR #61915: dispatching `::Type{Type{T}}` on a `TypeEq`-typed value (e.g. iterating a
+# tuple of `Type{X}` values) must not infer `Union{}` (which crashed via `unreachable`)
+let get_param(::Type{Type{T}}) where {T} = T
+    @test Tuple(get_param(t) for t in (Type{Int}, Type{Float64})) === (Int, Float64)
+end
 
 @test promote_type(Bool,Bottom) === Bool
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -416,6 +416,12 @@ for T in (Nothing, Missing)
     @test Base.promote_typejoin(Union{}, T) === T
 end
 
+# PR #61915: `promote_typejoin_union` must handle `Type{X}` (a `TypeEq` kind), not error
+@test Base.promote_typejoin_union(Type{Int}) === Type{Int}
+@test Base.promote_typejoin_union(Union{Type{Int}, Type{String}}) === Type
+@test fieldtype.(Tuple{Int,Float32,Int}, [1, 2, 3]) == [Int, Float32, Int]
+@test typeof.(Any[Int, "x", 1.0]) == [DataType, String, Float64]
+
 @test promote_type(Bool,Bottom) === Bool
 
 # type declarations

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -135,10 +135,12 @@ begin # @deprecate
     @noinline deprecated_typename(T) = Base.typename(T)
     @noinline deprecated_nameof(T) = nameof(T)
     @noinline deprecated_parentmodule(T) = parentmodule(T)
+    @noinline deprecated_isabstracttype(T) = isabstracttype(T)
     deprecated_type_ref = Ref{Any}(Type{Int})
     @test @test_warn "calling `typename` on `Type` is deprecated" deprecated_typename(deprecated_type_ref[]) === TypeEq.name
     @test @test_warn "calling `nameof` on `Type` is deprecated" deprecated_nameof(deprecated_type_ref[]) === :Type
     @test @test_warn "calling `parentmodule` on `Type` is deprecated" deprecated_parentmodule(deprecated_type_ref[]) === Core
+    @test @test_warn "calling `isabstracttype` on a `Type{...}` is deprecated" deprecated_isabstracttype(deprecated_type_ref[]) === true
 
     # test that positional and keyword arguments are forwarded when
     # there is no explicit type annotation

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -132,6 +132,14 @@ begin # @deprecate
     end
     @test_deprecated "something" f21972()
 
+    @noinline deprecated_typename(T) = Base.typename(T)
+    @noinline deprecated_nameof(T) = nameof(T)
+    @noinline deprecated_parentmodule(T) = parentmodule(T)
+    deprecated_type_ref = Ref{Any}(Type{Int})
+    @test @test_warn "calling `typename` on `Type` is deprecated" deprecated_typename(deprecated_type_ref[]) === TypeEq.name
+    @test @test_warn "calling `nameof` on `Type` is deprecated" deprecated_nameof(deprecated_type_ref[]) === :Type
+    @test @test_warn "calling `parentmodule` on `Type` is deprecated" deprecated_parentmodule(deprecated_type_ref[]) === Core
+
     # test that positional and keyword arguments are forwarded when
     # there is no explicit type annotation
     @test_logs (:warn,) @test DeprecationTests.old_return_args(1, 2, 3) == ((1, 2, 3),(;))

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -294,11 +294,11 @@ end
 
 struct AUnionParam{T<:Union{Nothing,Float32,Float64}} end
 @test AUnionParam.body.hash == 0
-@test Type{AUnionParam}.hash != 0
-@test Type{AUnionParam{<:Union{Float32,Float64}}}.hash == 0
+@test Base._jl_type_cache_hash(Type{AUnionParam}) != 0
+@test Base._jl_type_cache_hash(Type{AUnionParam{<:Union{Float32,Float64}}}) == 0
 @test Type{AUnionParam{<:Union{Nothing,Float32,Float64}}} === Type{AUnionParam}
-@test Type{AUnionParam.body}.hash == 0
-@test Type{Base.Broadcast.Broadcasted}.hash != 0
+@test Base._jl_type_cache_hash(Type{AUnionParam.body}) == 0
+@test Base._jl_type_cache_hash(Type{Base.Broadcast.Broadcasted}) != 0
 
 
 @testset "issue 50628" begin

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1624,7 +1624,7 @@ end
 @testset "Base docstrings" begin
     undoc = Docs.undocumented_names(Base)
     @test_broken isempty(undoc)
-    @test isempty(setdiff(undoc, [:BufferStream, :CanonicalIndexError, :CapturedException, :Filesystem, :IOServer, :InvalidStateException, :Order, :PipeEndpoint, :ScopedValues, :Sort, :TTY, :AtomicMemoryRef, :Exception, :GenericMemoryRef, :GlobalRef, :IO, :Kind, :LineNumberNode, :MemoryRef, :Method, :SegmentationFault, :TypeEq, :TypeVar, :arrayref, :arrayset, :arraysize, :const_arrayref]))
+    @test isempty(setdiff(undoc, [:BufferStream, :CanonicalIndexError, :CapturedException, :Filesystem, :IOServer, :InvalidStateException, :Order, :PipeEndpoint, :ScopedValues, :Sort, :TTY, :AtomicMemoryRef, :Exception, :GenericMemoryRef, :GlobalRef, :IO, :AnyType, :LineNumberNode, :MemoryRef, :Method, :SegmentationFault, :TypeEq, :TypeVar, :arrayref, :arrayset, :arraysize, :const_arrayref]))
 end
 
 exported_names(m) = filter(s -> Base.isexported(m, s), names(m))

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1624,7 +1624,7 @@ end
 @testset "Base docstrings" begin
     undoc = Docs.undocumented_names(Base)
     @test_broken isempty(undoc)
-    @test isempty(setdiff(undoc, [:BufferStream, :CanonicalIndexError, :CapturedException, :Filesystem, :IOServer, :InvalidStateException, :Order, :PipeEndpoint, :ScopedValues, :Sort, :TTY, :AtomicMemoryRef, :Exception, :GenericMemoryRef, :GlobalRef, :IO, :LineNumberNode, :MemoryRef, :Method, :SegmentationFault, :TypeVar, :arrayref, :arrayset, :arraysize, :const_arrayref]))
+    @test isempty(setdiff(undoc, [:BufferStream, :CanonicalIndexError, :CapturedException, :Filesystem, :IOServer, :InvalidStateException, :Order, :PipeEndpoint, :ScopedValues, :Sort, :TTY, :AtomicMemoryRef, :Exception, :GenericMemoryRef, :GlobalRef, :IO, :Kind, :LineNumberNode, :MemoryRef, :Method, :SegmentationFault, :TypeEq, :TypeVar, :arrayref, :arrayset, :arraysize, :const_arrayref]))
 end
 
 exported_names(m) = filter(s -> Base.isexported(m, s), names(m))

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2893,6 +2893,187 @@ end
     end
 end
 
+# Ensure TypeEq objects that refer to newly-created DataType-like values are
+# retained correctly across package image save/restore.
+@testset "precompile TypeEq references to new datatypes" begin
+    mkdepottempdir() do depot
+        project_path = joinpath(depot, "testenv")
+        dev_path = joinpath(depot, "dev")
+        mkpath(project_path)
+        mkpath(dev_path)
+
+        trigger_uuid     = "10000000-0000-0000-0000-000000000103"
+        parent_uuid      = "10000000-0000-0000-0000-000000000104"
+
+        trigger_dir = joinpath(dev_path, "TypeEqTrigger")
+        mkpath(joinpath(trigger_dir, "src"))
+        write(joinpath(trigger_dir, "Project.toml"), """
+            name = "TypeEqTrigger"
+            uuid = "$trigger_uuid"
+            version = "0.1.0"
+            """)
+        write(joinpath(trigger_dir, "src", "TypeEqTrigger.jl"), """
+            module TypeEqTrigger
+            macro latestworld_if_toplevel()
+                Expr(Symbol("latestworld-if-toplevel"))
+            end
+            workload() = tuple(values(Dict(:a => 1))...)
+            if ccall(:jl_generating_output, Cint, ()) == 1
+                ccall(:jl_tag_newly_inferred_enable, Cvoid, ())
+                try
+                    @latestworld_if_toplevel
+                    workload()
+                finally
+                    ccall(:jl_tag_newly_inferred_disable, Cvoid, ())
+                end
+            end
+            end
+            """)
+
+        parent_dir = joinpath(dev_path, "TypeEqParent")
+        mkpath(joinpath(parent_dir, "src"))
+        mkpath(joinpath(parent_dir, "ext"))
+        write(joinpath(parent_dir, "Project.toml"), """
+            name = "TypeEqParent"
+            uuid = "$parent_uuid"
+            version = "0.1.0"
+
+            [weakdeps]
+            TypeEqTrigger = "$trigger_uuid"
+
+            [extensions]
+            TypeEqTriggerExt = "TypeEqTrigger"
+            """)
+        write(joinpath(parent_dir, "src", "TypeEqParent.jl"), """
+            module TypeEqParent
+            import Base: range
+
+            abstract type Colorant{T,N} end
+            abstract type Color{T,N} <: Colorant{T,N} end
+            abstract type TransparentColor{C<:Color,T,N} <: Colorant{T,N} end
+            abstract type AlphaColor{C<:Color,T,N} <: TransparentColor{C,T,N} end
+            abstract type ColorAlpha{C<:Color,T,N} <: TransparentColor{C,T,N} end
+            ColorantN{N,T} = Colorant{T,N}
+
+            struct HSV{T<:AbstractFloat} <: Color{T,3}
+                h::T
+                s::T
+                v::T
+            end
+            struct AHSV{T<:AbstractFloat} <: AlphaColor{HSV{T},T,4}
+                alpha::T
+                h::T
+                s::T
+                v::T
+            end
+            struct HSVA{T<:AbstractFloat} <: ColorAlpha{HSV{T},T,4}
+                h::T
+                s::T
+                v::T
+                alpha::T
+            end
+
+            struct ComponentIterator{C<:Colorant}
+                c::C
+            end
+            Base.eltype(::Type{ComponentIterator{C}}) where {T, C <: Colorant{T}} = T
+            Base.length(::ComponentIterator{C}) where {N, C <: ColorantN{N}} = N
+            Base.iterate(itr::ComponentIterator{C}, state::Int=0) where {N, C <: ColorantN{N}} =
+                state >= N ? nothing : (itr[state + 1], state + 1)
+            Base.getindex(itr::ComponentIterator{C}, i::Integer) where {N, C <: ColorantN{N}} =
+                i == 1 ? getfield(itr.c, 1) :
+                i == 2 ? getfield(itr.c, 2) :
+                i == 3 ? getfield(itr.c, 3) :
+                         getfield(itr.c, 4)
+            Base.getindex(itr::ComponentIterator, r::AbstractRange) = Tuple(itr[i] for i in r)
+            Base.getindex(itr::ComponentIterator, ::Colon) = itr
+            Base.firstindex(::ComponentIterator) = 1
+            Base.lastindex(itr::ComponentIterator) = length(itr)
+            Base.BroadcastStyle(::Type{<:ComponentIterator{C}}) where {T, N, C <: Colorant{T,N}} =
+                Base.BroadcastStyle(NTuple{N,T})
+            Base.axes(::ComponentIterator{C}) where {N, C <: ColorantN{N}} = (Base.OneTo(N),)
+            Base.ndims(::Type{ComponentIterator{C}}) where {C} = 1
+            Base.broadcastable(itr::ComponentIterator{C}) where {T, N, C <: Colorant{T,N}} =
+                (itr...,)::NTuple{N,T}
+
+            comps(c::Colorant) = ComponentIterator(c)
+            base_colorant_type(::Type{C}) where {C<:Colorant} = Base.typename(C).wrapper
+            base_colorant_type(c::Colorant) = base_colorant_type(typeof(c))
+            mapc(f::F, x, y) where {F} = base_colorant_type(x)(f.(comps(x), comps(y))...)
+
+            weighted_color_mean(w1::Real, c1::C, c2::C) where
+                {Cb<:HSV, C<:Union{AlphaColor{Cb},ColorAlpha{Cb}}} =
+                    mapc((x, y) -> x, c1, c2)
+
+            range(start::T; stop::T, length::Integer=100) where T<:Colorant =
+                T[weighted_color_mean(w1, start, stop) for w1 in range(1.0, stop=0.0, length=length)]
+            range(start::T, stop::T; kwargs...) where T<:Colorant = range(start; stop=stop, kwargs...)
+
+            macro latestworld_if_toplevel()
+                Expr(Symbol("latestworld-if-toplevel"))
+            end
+            function workload()
+                for T in (Float64, Int)
+                    range(one(T), T(2); length=2)
+                end
+            end
+            if ccall(:jl_generating_output, Cint, ()) == 1
+                ccall(:jl_tag_newly_inferred_enable, Cvoid, ())
+                try
+                    @latestworld_if_toplevel
+                    workload()
+                finally
+                    ccall(:jl_tag_newly_inferred_disable, Cvoid, ())
+                end
+            end
+            end
+            """)
+        write(joinpath(parent_dir, "ext", "TypeEqTriggerExt.jl"), """
+            module TypeEqTriggerExt
+            import TypeEqParent
+            end
+            """)
+
+        write(joinpath(project_path, "Project.toml"), """
+            [deps]
+            TypeEqParent = "$parent_uuid"
+            TypeEqTrigger = "$trigger_uuid"
+            """)
+        write(joinpath(project_path, "Manifest.toml"), """
+            manifest_format = "2.0"
+
+            [[deps.TypeEqParent]]
+            path = "../dev/TypeEqParent"
+            uuid = "$parent_uuid"
+            version = "0.1.0"
+
+            [deps.TypeEqParent.weakdeps]
+            TypeEqTrigger = "$trigger_uuid"
+
+            [deps.TypeEqParent.extensions]
+            TypeEqTriggerExt = "TypeEqTrigger"
+
+            [[deps.TypeEqTrigger]]
+            path = "../dev/TypeEqTrigger"
+            uuid = "$trigger_uuid"
+            version = "0.1.0"
+            """)
+
+        original_depot_path = copy(Base.DEPOT_PATH)
+        old_proj = Base.active_project()
+        try
+            push!(empty!(DEPOT_PATH), depot)
+            Base.set_active_project(project_path)
+            Base.Precompilation.precompilepkgs(; io=IOBuffer(), fancyprint=false)
+            @test Base.require(Main, :TypeEqParent) isa Module
+            @test Base.require(Main, :TypeEqTrigger) isa Module
+        finally
+            Base.set_active_project(old_proj)
+            append!(empty!(DEPOT_PATH), original_depot_path)
+        end
+    end
+end
+
 # Issue #61198 - extensions with superset triggers must be in the precompilation dep graph
 @testset "precompilation dep graph includes transitively-triggered extensions" begin
     mkdepottempdir() do depot

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2893,8 +2893,8 @@ end
     end
 end
 
-# Ensure TypeEq objects that refer to newly-created DataType-like values are
-# retained correctly across package image save/restore.
+# TypeEq payloads that mention package-image datatypes must be restored as new
+# before restore-side type-cache lookup compares them to cached types.
 @testset "precompile TypeEq references to new datatypes" begin
     mkdepottempdir() do depot
         project_path = joinpath(depot, "testenv")
@@ -2902,8 +2902,8 @@ end
         mkpath(project_path)
         mkpath(dev_path)
 
-        trigger_uuid     = "10000000-0000-0000-0000-000000000103"
-        parent_uuid      = "10000000-0000-0000-0000-000000000104"
+        trigger_uuid = "10000000-0000-0000-0000-000000000103"
+        parent_uuid = "10000000-0000-0000-0000-000000000104"
 
         trigger_dir = joinpath(dev_path, "TypeEqTrigger")
         mkpath(joinpath(trigger_dir, "src"))
@@ -2932,82 +2932,38 @@ end
 
         parent_dir = joinpath(dev_path, "TypeEqParent")
         mkpath(joinpath(parent_dir, "src"))
-        mkpath(joinpath(parent_dir, "ext"))
         write(joinpath(parent_dir, "Project.toml"), """
             name = "TypeEqParent"
             uuid = "$parent_uuid"
             version = "0.1.0"
-
-            [weakdeps]
-            TypeEqTrigger = "$trigger_uuid"
-
-            [extensions]
-            TypeEqTriggerExt = "TypeEqTrigger"
             """)
         write(joinpath(parent_dir, "src", "TypeEqParent.jl"), """
             module TypeEqParent
             import Base: range
 
-            abstract type Colorant{T,N} end
-            abstract type Color{T,N} <: Colorant{T,N} end
-            abstract type TransparentColor{C<:Color,T,N} <: Colorant{T,N} end
-            abstract type AlphaColor{C<:Color,T,N} <: TransparentColor{C,T,N} end
-            abstract type ColorAlpha{C<:Color,T,N} <: TransparentColor{C,T,N} end
-            ColorantN{N,T} = Colorant{T,N}
-
-            struct HSV{T<:AbstractFloat} <: Color{T,3}
-                h::T
-                s::T
-                v::T
-            end
-            struct AHSV{T<:AbstractFloat} <: AlphaColor{HSV{T},T,4}
-                alpha::T
-                h::T
-                s::T
-                v::T
-            end
-            struct HSVA{T<:AbstractFloat} <: ColorAlpha{HSV{T},T,4}
-                h::T
-                s::T
-                v::T
-                alpha::T
-            end
-
-            struct ComponentIterator{C<:Colorant}
+            abstract type Left{N} end
+            abstract type Right{N} end
+            struct Iter{C}
                 c::C
             end
-            Base.eltype(::Type{ComponentIterator{C}}) where {T, C <: Colorant{T}} = T
-            Base.length(::ComponentIterator{C}) where {N, C <: ColorantN{N}} = N
-            Base.iterate(itr::ComponentIterator{C}, state::Int=0) where {N, C <: ColorantN{N}} =
-                state >= N ? nothing : (itr[state + 1], state + 1)
-            Base.getindex(itr::ComponentIterator{C}, i::Integer) where {N, C <: ColorantN{N}} =
-                i == 1 ? getfield(itr.c, 1) :
-                i == 2 ? getfield(itr.c, 2) :
-                i == 3 ? getfield(itr.c, 3) :
-                         getfield(itr.c, 4)
-            Base.getindex(itr::ComponentIterator, r::AbstractRange) = Tuple(itr[i] for i in r)
-            Base.getindex(itr::ComponentIterator, ::Colon) = itr
-            Base.firstindex(::ComponentIterator) = 1
-            Base.lastindex(itr::ComponentIterator) = length(itr)
-            Base.BroadcastStyle(::Type{<:ComponentIterator{C}}) where {T, N, C <: Colorant{T,N}} =
-                Base.BroadcastStyle(NTuple{N,T})
-            Base.axes(::ComponentIterator{C}) where {N, C <: ColorantN{N}} = (Base.OneTo(N),)
-            Base.ndims(::Type{ComponentIterator{C}}) where {C} = 1
-            Base.broadcastable(itr::ComponentIterator{C}) where {T, N, C <: Colorant{T,N}} =
-                (itr...,)::NTuple{N,T}
 
-            comps(c::Colorant) = ComponentIterator(c)
-            base_colorant_type(::Type{C}) where {C<:Colorant} = Base.typename(C).wrapper
-            base_colorant_type(c::Colorant) = base_colorant_type(typeof(c))
-            mapc(f::F, x, y) where {F} = base_colorant_type(x)(f.(comps(x), comps(y))...)
+            Base.iterate(itr::Iter{C}, state::Int=0) where
+                {N, C <: Union{Left{N},Right{N}}} =
+                    state >= N ? nothing : (0, state + 1)
+            Base.BroadcastStyle(::Type{<:Iter{C}}) where
+                {N, C <: Union{Left{N},Right{N}}} =
+                    Base.BroadcastStyle(NTuple{N,Int})
+            Base.broadcastable(itr::Iter{C}) where
+                {N, C <: Union{Left{N},Right{N}}} =
+                    (itr...,)::NTuple{N,Int}
 
-            weighted_color_mean(w1::Real, c1::C, c2::C) where
-                {Cb<:HSV, C<:Union{AlphaColor{Cb},ColorAlpha{Cb}}} =
-                    mapc((x, y) -> x, c1, c2)
-
-            range(start::T; stop::T, length::Integer=100) where T<:Colorant =
-                T[weighted_color_mean(w1, start, stop) for w1 in range(1.0, stop=0.0, length=length)]
-            range(start::T, stop::T; kwargs...) where T<:Colorant = range(start; stop=stop, kwargs...)
+            comps(c::C) where {N, C <: Union{Left{N},Right{N}}} = Iter(c)
+            range(start::T; stop::T, length::Integer=100) where
+                {N, T <: Union{Left{N},Right{N}}} =
+                    comps(start) .+ comps(stop)
+            range(start::T, stop::T; kwargs...) where
+                {N, T <: Union{Left{N},Right{N}}} =
+                    range(start; stop=stop, kwargs...)
 
             macro latestworld_if_toplevel()
                 Expr(Symbol("latestworld-if-toplevel"))
@@ -3028,11 +2984,6 @@ end
             end
             end
             """)
-        write(joinpath(parent_dir, "ext", "TypeEqTriggerExt.jl"), """
-            module TypeEqTriggerExt
-            import TypeEqParent
-            end
-            """)
 
         write(joinpath(project_path, "Project.toml"), """
             [deps]
@@ -3046,12 +2997,6 @@ end
             path = "../dev/TypeEqParent"
             uuid = "$parent_uuid"
             version = "0.1.0"
-
-            [deps.TypeEqParent.weakdeps]
-            TypeEqTrigger = "$trigger_uuid"
-
-            [deps.TypeEqParent.extensions]
-            TypeEqTriggerExt = "TypeEqTrigger"
 
             [[deps.TypeEqTrigger]]
             path = "../dev/TypeEqTrigger"

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -3430,4 +3430,25 @@ end
     end end
 end
 
+# PR #61915: a precompiled value with an inline `Type{Union{}}` field used to abort
+# in `record_memoryrefs_inside` while writing the cache, because the `TypeEq` field
+# type is laid out as the singleton `typeof(Union{})` `DataType`.
+precompile_test_harness("Type{Union{}} inline field") do dir
+    TypeBottomField = :TypeBottomField61915
+    write(joinpath(dir, "$TypeBottomField.jl"),
+          """
+          module $TypeBottomField
+              struct HoldsBottom
+                  t::Type{Union{}}
+                  x::Int
+              end
+              const X = HoldsBottom(Union{}, 7)
+          end
+          """)
+    @test Base.compilecache(Base.PkgId(string(TypeBottomField))) isa Tuple
+    @eval using $TypeBottomField
+    @test (@eval $TypeBottomField.X.x) == 7
+    @test (@eval $TypeBottomField.X.t) === Union{}
+end
+
 finish_precompile_test!()

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -834,6 +834,9 @@ end
 @test !isabstracttype(ReflectionExample)
 @test !isabstracttype(Int)
 @test !isabstracttype(TLayout)
+# PR #61915: `Type{T}` (a `TypeEq` kind) is still reported abstract
+@test isabstracttype(Type)
+@test isabstracttype(Type{<:Integer})
 
 @test !isprimitivetype(Union{})
 @test !isprimitivetype(Union{Int,Float64})

--- a/test/specificity.jl
+++ b/test/specificity.jl
@@ -317,6 +317,14 @@ end
 @test args_morespecific(Tuple{Type{Union{}}, Type{Union{}}, Any}, Tuple{Type{Union{}}, Any, Type{Union{}}})
 @test args_morespecific(Tuple{Type{Union{}}, Type{Union{}}, Any, Type{Union{}}}, Tuple{Type{Union{}}, Any, Type{Union{}}, Type{Union{}}})
 
+# PR #61915: a kind (e.g. `DataType`) is more specific than an unbounded `Type{T}`
+@test  args_morespecific(Tuple{DataType}, Tuple{Type{T}} where T)
+@test  args_morespecific(Tuple{Vararg{DataType}}, Tuple{Type{T}} where T)
+@test  args_morespecific(Tuple{UnionAll}, Tuple{Type{T}} where T)
+@test !args_morespecific(Tuple{DataType}, Tuple{Type{T}} where T<:Integer)
+@test  args_morespecific(Tuple{Type{T}} where T<:Integer, Tuple{DataType})
+@test  args_morespecific(Tuple{Type{Int}}, Tuple{DataType})
+
 # requires assertions enabled
 let root = NTuple
     N = root.var

--- a/test/specificity.jl
+++ b/test/specificity.jl
@@ -187,8 +187,8 @@ let x = Type{Union{Tuple{T}, Tuple{Ptr{T}, Ptr{T}, Any}} where T},
     y = Type{Union{Tuple{T}, Tuple{Array{T, N} where N, Any, Array{T, N} where N, Any, Any}} where T}
     @test !args_morespecific(x, y)
     @test !args_morespecific(y, x)
-    @test !args_morespecific(x.parameters[1], y.parameters[1])
-    @test !args_morespecific(y.parameters[1], x.parameters[1])
+    @test !args_morespecific(Base.type_parameter(x), Base.type_parameter(y))
+    @test !args_morespecific(Base.type_parameter(y), Base.type_parameter(x))
 end
 
 let A = Tuple{Array{T,N}, Vararg{Int,N}} where {T,N},

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -137,7 +137,7 @@ f10502() = ()
 
 # issue #11982
 @generated function f11982(T)
-    string(T.parameters[1])
+    string(Base.type_parameter(T))
 end
 @test f11982(Float32) == "Float32"
 @test f11982(Int32) == "Int32"
@@ -414,7 +414,7 @@ end
 
 # Test that writing a bad cassette-style pass gives the expected error (#49715)
 function generator49715(world, source, self, f, tt)
-    tt = tt.parameters[1]
+    tt = Base.type_parameter(tt)
     sig = Tuple{f, tt.parameters...}
     mi = Base._which(sig; world)
     error("oh no")

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -3173,3 +3173,20 @@ let
     @test C <: B
     @test X <: Y
 end
+
+# PR #61915: `concrete_min` must treat a `Type{T}` (`TypeEq`) element as
+# contributing no fixed concrete type, so the covariant-tuple diagonal rule in
+# `obvious_subtype` does not wrongly reject a `Tuple` of `Type{}`s against a
+# diagonal `Vararg`. Previously `obvious_subtype` returned a definitive
+# not-subtype that disagreed with full subtyping, tripping `assert` in subtype.c.
+let X = Tuple{Union{Type{Int}, Type{Vector{T}} where T}, Type{Int}},
+    Y = (Tuple{Vararg{T}} where T)
+    @test X <: Y
+    @test typeintersect(X, Y) == X
+    @test typeintersect(Y, X) == X
+end
+let X = Tuple{Union{Type{Int}, Type{Vector{T}} where T}, Union{Type{Int}, Type{Vector{T}} where T}},
+    Y = (Tuple{Vararg{T}} where T)
+    @test X <: Y
+    @test typeintersect(X, Y) == X
+end

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -612,6 +612,12 @@ function test_old()
     @test (Type{T} where T<:Real) != Core.AnyType
     @test (Type{T} where T<:Real) <: Core.AnyType
     @test !(Core.AnyType <: (Type{T} where T<:Real))
+    # `Type{Type{T}} where T` (unbounded `T`) denotes the same set as the bare
+    # `TypeEq` (every `Type{X}` value), so they are equal
+    @test Core.TypeEq <: (Type{Type{T}} where T)
+    @test Core.TypeEq == (Type{Type{T}} where T)
+    @test (Type{Type{T}} where T) <: Core.TypeEq
+    @test !(DataType <: (Type{Type{T}} where T))
     # a `Type{X}` with a non-typevar parameter still dispatches as the singleton
     # `typeof(X)` (e.g. every `Ref{T}` is a `DataType`)
     @test (Type{Ref{T}} where T<:Real) <: DataType

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -602,16 +602,16 @@ function test_old()
     @test Type{Complex} <: UnionAll
     @test isa(Complex,Type{Complex})
 
-    # `Type` (i.e. `Type{T} where T`) and `Kind` denote the same set of all
+    # `Type` (i.e. `Type{T} where T`) and `AnyType` denote the same set of all
     # types, so they are equal; the type cache canonicalizes them as parameters.
-    @test Type <: Core.Kind
-    @test Core.Kind <: Type
-    @test Type == Core.Kind
-    @test Vector{Type} === Vector{Core.Kind}
-    # bounded `Type{}`s are strict subtypes of `Kind`, not equal to it
-    @test (Type{T} where T<:Real) != Core.Kind
-    @test (Type{T} where T<:Real) <: Core.Kind
-    @test !(Core.Kind <: (Type{T} where T<:Real))
+    @test Type <: Core.AnyType
+    @test Core.AnyType <: Type
+    @test Type == Core.AnyType
+    @test Vector{Type} === Vector{Core.AnyType}
+    # bounded `Type{}`s are strict subtypes of `AnyType`, not equal to it
+    @test (Type{T} where T<:Real) != Core.AnyType
+    @test (Type{T} where T<:Real) <: Core.AnyType
+    @test !(Core.AnyType <: (Type{T} where T<:Real))
     # a `Type{X}` with a non-typevar parameter still dispatches as the singleton
     # `typeof(X)` (e.g. every `Ref{T}` is a `DataType`)
     @test (Type{Ref{T}} where T<:Real) <: DataType

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -601,6 +601,24 @@ function test_old()
     @test !isa(Array,Type{Any})
     @test Type{Complex} <: UnionAll
     @test isa(Complex,Type{Complex})
+
+    # `Type` (i.e. `Type{T} where T`) and `Kind` denote the same set of all
+    # types, so they are equal; the type cache canonicalizes them as parameters.
+    @test Type <: Core.Kind
+    @test Core.Kind <: Type
+    @test Type == Core.Kind
+    @test Vector{Type} === Vector{Core.Kind}
+    # bounded `Type{}`s are strict subtypes of `Kind`, not equal to it
+    @test (Type{T} where T<:Real) != Core.Kind
+    @test (Type{T} where T<:Real) <: Core.Kind
+    @test !(Core.Kind <: (Type{T} where T<:Real))
+    # a `Type{X}` with a non-typevar parameter still dispatches as the singleton
+    # `typeof(X)` (e.g. every `Ref{T}` is a `DataType`)
+    @test (Type{Ref{T}} where T<:Real) <: DataType
+    # this uses `jl_typeof(X)` even when `X` has free typevars, which is unsound
+    # if the kind can vary: `Union{Int,T}` collapses to the `DataType` `Int` when
+    # `T==Int`, so this should not be `<: Union` (currently broken).
+    @test_broken !((Type{Union{Int,T}} where T<:Real) <: Union)
     @test !(Type{Ptr{Bottom}} <: Type{Ptr})
     @test !(Type{Rational{Int}} <: Type{Rational})
     @test Tuple{} <: Tuple{Vararg}


### PR DESCRIPTION
This refactors `Type` to be a proper kind (like Union) rather than a magic DataType. In addition, the (also, but separately) magic Type{T} (T free) supertype of `DataType` is replaced by a proper abstact type. The previous design dates back to before DataType and UnionAll were separate concepts and were essentially a hack to make `Type` behave properly. Such hacks are no longer required. This PR is primarily prepratory to address several long-standing soundness issues around the subtyping of Type, but this PR itself does not address those issues yet - it is intended to be purely the structural change that will enable those changes in a follow on PR.

The new kind is called TypeEq, but `const Type = TypeEq{T} where T` is retained, so users keep using `Type{}` as usual. The new supertype of DataType is called `Kind` and `Type == Kind` (but not === of course).

`getproperty` overloads are provided for compatibility, but the recommended accessor for new code is a (new) `Base.type_parameter`.

Written by GPT 5.5