### PR TITLE
[docs] add LinearAlgebra changes to eigenvalue sorting to NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -90,7 +90,7 @@ Standard library changes
 
 #### LinearAlgebra
 
-* `eigvals`, `eigvecs`, and `eigen` now accept the `sortby` keyword argument for all matrix types, and is set to sort by default ([#1608](https://github.com/JuliaLang/LinearAlgebra.jl/pull/1608)).
+* `eigvals`, `eigvecs`, and `eigen` now accept the `sortby` keyword argument for all matrix types, and now sort by default ([#1608](https://github.com/JuliaLang/LinearAlgebra.jl/pull/1608)).
 
 #### Markdown
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -90,6 +90,8 @@ Standard library changes
 
 #### LinearAlgebra
 
+* `eigvals`, `eigvecs`, and `eigen` now accept the `sortby` keyword argument for all matrix types, and is set to sort by default ([#1608](https://github.com/JuliaLang/LinearAlgebra.jl/pull/1608)).
+
 #### Markdown
 
 * Support "raw" or "inline" HTML inside Markdown data ([#60629], [#60632], [#60732])


### PR DESCRIPTION
For [#1608](https://github.com/JuliaLang/LinearAlgebra.jl/pull/1608).
