### PR TITLE
loading: preserve inferred IR across precompile irgen phase boundary

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3267,6 +3267,12 @@ function include_package_for_output(pkg::PkgId, input::String, syntax_version::V
     __toplevel__.var"#_internal_julia_parse" = VersionedParse(syntax_version)
     # This one is the compatibility marker for cache loading
     __toplevel__._internal_syntax_version = cache_syntax_version(syntax_version)
+    # Keep inferred IR on CodeInstances during include so the subsequent
+    # compile_and_emit_native step (called from C after we return) can reuse
+    # it instead of re-inferring. Reset before returning so staticdata save
+    # can still discard `.inferred` per its usual rules.
+    preserve_ir = JLOptions().outputo != C_NULL
+    preserve_ir && ccall(:jl_set_type_infer_preserve_ir, Cvoid, (Int8,), 1)
     try
         Base.include(Base.__toplevel__, input)
     catch ex
@@ -3275,6 +3281,7 @@ function include_package_for_output(pkg::PkgId, input::String, syntax_version::V
         exit(125) # we define status = 125 means PrecompileableError
     finally
         ccall(:jl_set_newly_inferred, Cvoid, (Any,), nothing)
+        preserve_ir && ccall(:jl_set_type_infer_preserve_ir, Cvoid, (Int8,), 0)
     end
     # check that the package defined the expected module so we can give a nice error message if not
     m = maybe_root_module(pkg)


### PR DESCRIPTION
Speeds up a big env precompile by ~9%

master
```
(@v1.14) pkg> st
Status `~/.julia/environments/v1.14/Project.toml`
  [6e4b80f9] BenchmarkTools v1.8.0
  [e9467ef8] GLMakie v0.13.10
  [a408fb95] PkgCacheInspector v1.2.1 `~/Documents/GitHub/PkgCacheInspector.jl`
  [91a5bcdd] Plots v1.41.6
  [295af30f] Revise v3.14.3

(@v1.14) pkg> precompile
Precompiling project...
Precompiling packages finished.
  315 dependencies successfully precompiled in 195 seconds. 41 already precompiled.
```

PR
```
(@v1.14) pkg> precompile
Precompiling project...
Precompiling packages finished.
  315 dependencies successfully precompiled in 178 seconds. 41 already precompiled.
```

Claude:

---

When a precompile worker produces a pkgimage (`--output-o`), the subsequent `compile_and_emit_native` step (driven from C by `jl_create_native`) builds a fresh `NativeInterpreter` and calls `typeinf_ext(..., SOURCE_MODE_GET_SOURCE)` on every MethodInstance in its worklist. That call short-circuits when `CodeInstance.inferred` is still populated, but `may_discard_trees(::NativeInterpreter)` defaults to `true`, so the worker's include phase drops `.inferred` at the three sites in `finishinfer!`, `discard_optimized_result` and `maybe_compress_codeinfo`. By the time `compile_and_emit_native` runs in the same process the CIs are bare and inference re-runs.

Set `jl_set_type_infer_preserve_ir(1)` before `Base.include` so those drop sites no-op, and reset to `0` in the `finally` block so staticdata save can still discard `.inferred` per its usual rules and avoid pkgimage bloat. The worker exits right after staticdata save, so the extra in-memory IR is bounded to that one short-lived process.