### PR TITLE
precompilation: preserve inferred IR across precompile irgen phase boundary

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -494,15 +494,23 @@ end
 
 function discard_optimized_result(interp::AbstractInterpreter, inlining_cost::InlineCostType)
     may_discard_trees(interp) || return false
-    return inlining_cost == MAX_INLINE_COST
+    inlining_cost == MAX_INLINE_COST || return false
+    precompile_keep_ir(interp) && return false
+    return true
 end
 
 function maybe_compress_codeinfo(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInfo)
     def = mi.def
     isa(def, Method) || return ci # don't compress toplevel code
     can_discard_trees = may_discard_trees(interp)
-    cache_the_tree = !can_discard_trees || is_inlineable(ci)
-    cache_the_tree || return nothing
+    inlineable = is_inlineable(ci)
+    if can_discard_trees && !inlineable
+        # Precompile-keep-ir mode: retain non-inlineable IR as raw CodeInfo so
+        # irgen's typeinf_ext can reuse it instead of re-inferring.
+        # jl_finalize_precompile_inferred nulls it before save.
+        precompile_keep_ir(interp) && return ci
+        return nothing
+    end
     # TODO: do we want to augment edges here with any :invoke targets that we got from inlining (such that we didn't have a direct edge to it already)?
     may_compress(interp) && return ccall(:jl_compress_ir, String, (Any, Any), def, ci)
     return ci

--- a/Compiler/src/types.jl
+++ b/Compiler/src/types.jl
@@ -497,6 +497,9 @@ may_compress(::AbstractInterpreter) = true
 may_discard_trees(::AbstractInterpreter) = true
 may_discard_trees(::NativeInterpreter) =
     ccall(:jl_get_type_infer_preserve_ir, Int8, ()) == 0
+precompile_keep_ir(::AbstractInterpreter) = false
+precompile_keep_ir(::NativeInterpreter) =
+    ccall(:jl_get_precompile_keep_ir, Int8, ()) != 0
 
 """
     method_table(interp::AbstractInterpreter)::MethodTableView

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3282,6 +3282,13 @@ function include_package_for_output(pkg::PkgId, input::String, syntax_version::V
     end
 
     ccall(:jl_set_newly_inferred, Cvoid, (Any,), newly_inferred)
+    # When this worker is producing a native object pkgimage, retain raw
+    # inferred IR on `CodeInstance.inferred` for the non-inlineable methods
+    # that would otherwise be discarded, so the irgen pass can short-circuit
+    # `typeinf_ext` instead of re-inferring. `jl_finalize_precompile_inferred`
+    # clears them (and the flag) before staticdata serialization.
+    keep_ir = JLOptions().outputo != C_NULL
+    keep_ir && ccall(:jl_set_precompile_keep_ir, Cvoid, (Int8,), 1)
     # This one changes the parser behavior
     __toplevel__.var"#_internal_julia_parse" = VersionedParse(syntax_version)
     # This one is the compatibility marker for cache loading
@@ -3311,6 +3318,7 @@ function include_package_for_output(pkg::PkgId, input::String, syntax_version::V
                     " methods=", length(newly_inferred))
         end
         ccall(:jl_set_newly_inferred, Cvoid, (Any,), nothing)
+        keep_ir && ccall(:jl_set_precompile_keep_ir, Cvoid, (Int8,), 0)
     end
     # check that the package defined the expected module so we can give a nice error message if not
     m = maybe_root_module(pkg)

--- a/src/gf.c
+++ b/src/gf.c
@@ -1058,6 +1058,22 @@ JL_DLLEXPORT void jl_set_type_infer_preserve_ir(int8_t v)
     jl_atomic_store_relaxed(&jl_type_infer_preserve_ir, v);
 }
 
+// Set by precompile workers around `Base.include` so non-inlineable inferred
+// IR is retained on `CodeInstance.inferred` through the irgen phase instead of
+// being discarded. `jl_finalize_precompile_inferred` nulls them before save
+// (with a backstop in jl_queue_for_serialization).
+static _Atomic(int8_t) jl_precompile_keep_ir = 0;
+
+JL_DLLEXPORT int8_t jl_get_precompile_keep_ir(void)
+{
+    return jl_atomic_load_relaxed(&jl_precompile_keep_ir);
+}
+
+JL_DLLEXPORT void jl_set_precompile_keep_ir(int8_t v)
+{
+    jl_atomic_store_relaxed(&jl_precompile_keep_ir, v);
+}
+
 static int invalidate_all_entries(jl_typemap_entry_t *entry, void *env)
 {
     jl_atomic_store_relaxed(&entry->max_world, 0);

--- a/src/julia.h
+++ b/src/julia.h
@@ -2278,6 +2278,7 @@ JL_DLLEXPORT jl_value_t *jl_restore_incremental(const char *fname, jl_array_t *d
 JL_DLLEXPORT jl_value_t *jl_object_top_module(jl_value_t* v) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT void jl_set_newly_inferred(jl_value_t *newly_inferred);
+JL_DLLEXPORT void jl_finalize_precompile_inferred(int8_t cleanup_keep_ir);
 JL_DLLEXPORT jl_array_t* jl_compute_new_ext(void);
 JL_DLLEXPORT void jl_push_newly_inferred(jl_value_t *ci);
 JL_DLLEXPORT void jl_set_inference_entrance_backtraces(jl_value_t *inference_entrance_backtraces);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -813,6 +813,8 @@ JL_DLLEXPORT void jl_engine_fulfill(jl_code_instance_t *ci, jl_code_info_t *src)
 JL_DLLEXPORT jl_code_instance_t *jl_type_infer(jl_method_instance_t *li JL_PROPAGATES_ROOT, size_t world, uint8_t source_mode, uint8_t trim_mode);
 JL_DLLEXPORT int8_t jl_get_type_infer_preserve_ir(void);
 JL_DLLEXPORT void jl_set_type_infer_preserve_ir(int8_t v);
+JL_DLLEXPORT int8_t jl_get_precompile_keep_ir(void);
+JL_DLLEXPORT void jl_set_precompile_keep_ir(int8_t v);
 JL_DLLEXPORT jl_code_info_t *jl_gdbcodetyped1(jl_method_instance_t *mi, size_t world);
 JL_DLLEXPORT jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *meth JL_PROPAGATES_ROOT, size_t world);
 JL_DLLEXPORT jl_code_instance_t *jl_get_method_uninferred(

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -690,7 +690,16 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
                     (jl_is_string(inferred) && jl_string_len(inferred) > 0 && jl_string_data(inferred)[jl_string_len(inferred) - 1]);
                 int may_discard_trees = !jl_get_type_infer_preserve_ir();
                 int discard = 0;
-                if (!is_relocatable) {
+                if (may_discard_trees && s->incremental && native_functions &&
+                    jl_options.outputo != NULL && ci->owner == jl_nothing && def->source != NULL &&
+                    jl_is_code_info(inferred) && jl_ir_inlining_cost(inferred) == UINT16_MAX) {
+                    // Backstop: CodeInstance cached by a task racing the end of
+                    // include phase can escape jl_finalize_precompile_inferred.
+                    // Mirror the def->source guard below so optimized opaque
+                    // closures (whose IR can't be reconstructed) are preserved.
+                    record_field_change((jl_value_t**)&ci->inferred, jl_nothing);
+                }
+                else if (!is_relocatable) {
                     discard = 1;
                 }
                 else if (def->source == NULL) {
@@ -3334,6 +3343,7 @@ JL_DLLEXPORT void jl_create_system_image(void **_native_data, jl_array_t *workli
 
     jl_query_cache query_cache;
     init_query_cache(&query_cache);
+    jl_finalize_precompile_inferred(worklist != NULL && _native_data != NULL && jl_options.outputo != NULL);
     jl_save_system_image_to_stream(ff, mod_array, module_init_order, worklist, extext_methods, new_ext, &query_cache);
     if (_native_data != NULL)
         native_functions = NULL;

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -122,6 +122,36 @@ JL_DLLEXPORT void jl_set_newly_inferred(jl_value_t* _newly_inferred)
     newly_inferred = (jl_array_t*) _newly_inferred;
 }
 
+// Null `CodeInstance.inferred` for native-owned CIs where it is still a raw
+// `CodeInfo` left by `jl_precompile_keep_ir`. These are non-inlineable methods
+// whose IR is otherwise discarded, retained only long enough for
+// `jl_create_native` to reuse via the `typeinf_ext` short-circuit. A
+// CodeInstance cached racing the end of the include phase can escape this walk;
+// see jl_queue_for_serialization.
+JL_DLLEXPORT void jl_finalize_precompile_inferred(int8_t cleanup_keep_ir)
+{
+    jl_set_precompile_keep_ir(0);
+    if (!cleanup_keep_ir || newly_inferred == NULL)
+        return;
+    size_t n = jl_array_nrows(newly_inferred);
+    for (size_t i = 0; i < n; i++) {
+        jl_code_instance_t *ci = (jl_code_instance_t*)jl_array_ptr_ref(newly_inferred, i);
+        if (ci == NULL)
+            continue;
+        if (ci->owner != jl_nothing)
+            continue; // foreign interpreters own their cached IR
+        jl_value_t *inferred = jl_atomic_load_relaxed(&ci->inferred);
+        if (inferred == NULL || !jl_is_code_info(inferred))
+            continue;
+        jl_method_instance_t *mi = jl_get_ci_mi(ci);
+        if (!jl_is_method(mi->def.value))
+            continue; // toplevel code retains its inferred IR
+        if (mi->def.method->source == NULL)
+            continue; // optimized opaque closures can't reconstruct their IR
+        jl_atomic_store_release(&ci->inferred, jl_nothing);
+    }
+}
+
 static jl_array_t *queue_external(jl_array_t *list, jl_query_cache *query_cache);
 
 JL_DLLEXPORT jl_array_t* jl_compute_new_ext(void)


### PR DESCRIPTION
Gives an ~8% improvement in precompilation time by keeping the inferred IR around so the image-gen phase doesn't have to re-generate it.

7 day old master https://github.com/JuliaLang/julia/commit/a8f97b19441f82ba082d7c01cbcea45b49f691a6
```
julia> Base.Precompilation.precompilepkgs(timing=true, verbose=true)
Precompiling project...
   total │ include   (deps)   (comp) │ methods  img-gen     cache  ~pk-rss
...
  37.3 s │  24.98s    3.72s   19.85s │   35989   12.32s    43.8MB   1930MB  ✓ Plots
...
 124.1 s │  82.36s   13.86s   63.81s │  104874   41.73s   145.3MB   3688MB  ✓ Makie
  66.6 s │  43.97s    8.35s   33.84s │   36921   22.59s    49.8MB   3428MB  ✓ GLMakie
  316 dependencies successfully precompiled in 262 seconds. 41 already precompiled.
```

current master https://github.com/JuliaLang/julia/commit/e21f47f03a4d1bb4d0869206d69b91f5b420e978 (28% faster)
```
   total │ include   (deps)   (comp) │ methods  img-gen     cache  ~pk-rss
...
  27.1 s │  17.16s    3.73s    0.61s │   36020    9.91s    44.0MB   1464MB  ✓ Plots
...
  85.5 s │  54.63s   12.94s    0.11s │  104275   30.88s   146.2MB   3121MB  ✓ Makie
  44.7 s │  27.48s    8.31s   17.10s │   36944   17.26s    49.8MB   2474MB  ✓ GLMakie
  316 dependencies successfully precompiled in 189 seconds. 41 already precompiled.
```

PR  (+4-8% faster, ~35% faster compared to https://github.com/JuliaLang/julia/commit/a8f97b19441f82ba082d7c01cbcea45b49f691a6)
```
   total │ include   (deps)   (comp) │ methods  img-gen     cache  ~pk-rss
...
  24.9 s │  16.51s    3.20s    0.61s │   35979    8.40s    43.8MB   1725MB  ✓ Plots
...
  82.5 s │  54.73s   12.74s    0.11s │  104628   27.77s   146.3MB   3200MB  ✓ Makie
  42.2 s │  27.39s    8.27s   17.01s │   36971   14.82s    49.7MB   2110MB  ✓ GLMakie
  316 dependencies successfully precompiled in 180 seconds. 41 already precompiled.
```