### PR TITLE
[JuliaLowering] Macro hygiene: Use macrocall expression scope for expansion

### DIFF
--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -66,9 +66,16 @@ generates a new layer.
 struct ScopeLayer
     id::LayerId
     mod::Module
-    parent_layer::LayerId # Index of parent layer in a macro expansion. Equal to 0 for no parent
-    is_macro_expansion::Bool # FIXME
+    # Index of parent layer in a macro expansion. Equal to 0 for no parent
+    parent_id::LayerId
     is_internal::Bool
+end
+
+is_base_layer(sl::ScopeLayer) = sl.parent_id === 0
+
+base_layer(ctx, sl::ScopeLayer) = while true
+    is_base_layer(sl) && return sl
+    sl = ctx.scope_layers[sl.parent_id]
 end
 
 """
@@ -537,15 +544,23 @@ function to_symbol(ctx, ex)
     @ast ctx ex ex=>K"Symbol"
 end
 
-function new_scope_layer(ctx, mod_ref::Module=ctx.mod)
-    new_layer = ScopeLayer(length(ctx.scope_layers)+1, mod_ref, 0, false, true)
+function new_internal_scope_layer(ctx, mod_ref::Module=ctx.mod)
+    new_layer = ScopeLayer(length(ctx.scope_layers)+1, mod_ref, 0, true)
     push!(ctx.scope_layers, new_layer)
     new_layer.id
 end
 
-function new_scope_layer(ctx, mod_ref::SyntaxTree)
+function new_internal_scope_layer(ctx, mod_ref::SyntaxTree)
     @jl_assert kind(mod_ref) == K"Identifier" mod_ref
-    new_scope_layer(ctx, ctx.scope_layers[mod_ref.scope_layer].mod)
+    new_internal_scope_layer(ctx, ctx.scope_layers[mod_ref.scope_layer::LayerId].mod)
+end
+
+# TODO: `expr` is unused, but should be placed in the scope layer to trigger
+# certain compat behaviour.
+function new_macro_scope_layer(ctx, parent::ScopeLayer, mod::Module, expr::Bool)
+    sl = ScopeLayer(length(ctx.scope_layers)+1, mod, parent.id, false)
+    push!(ctx.scope_layers, sl)
+    sl
 end
 
 #-------------------------------------------------------------------------------

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -87,7 +87,7 @@ end
 function newsym(ctx, src::SyntaxTree, name::String; unused=false)
     out = newleaf(ctx, src, unused ? K"Placeholder" : K"Identifier", name)
     hasattr(src, :meta) && setattr!(out, :meta, src.meta)
-    setattr!(out, :scope_layer, new_scope_layer(ctx))
+    setattr!(out, :scope_layer, new_internal_scope_layer(ctx))
 end
 
 #-------------------------------------------------------------------------------
@@ -3586,7 +3586,7 @@ function expand_typegroup_def(ctx, ex)
                                       supertype, is_mutable, min_initialized,
                                       inner_defs, field_docs))
         push!(struct_names, struct_name)
-        layer = new_scope_layer(ctx, struct_name)
+        layer = new_internal_scope_layer(ctx, struct_name)
         push!(global_names, adopt_scope(struct_name, layer))
         push!(info_vars, ssavar(ctx, sdef, "struct_info"))
     end
@@ -3759,7 +3759,7 @@ function expand_struct_def(ctx, ex, docs)
     hasprev = ssavar(ctx, ex, "hasprev")
     prev = ssavar(ctx, ex, "prev")
     newdef = ssavar(ctx, ex, "newdef")
-    layer = new_scope_layer(ctx, struct_name)
+    layer = new_internal_scope_layer(ctx, struct_name)
     global_struct_name = adopt_scope(struct_name, layer)
     if !isempty(typevar_names)
         # Generate expression like `prev_struct.body.body.parameters`
@@ -4459,7 +4459,7 @@ ensure_desugaring_attributes!(graph) = ensure_attributes!(
     graph = ensure_desugaring_attributes!(copy_attrs(ctx.graph))
     ex = reparent(graph, ex)
     ctx_out = DesugaringContext(graph, ctx.bindings, ctx.scope_layers,
-                                current_layer(ctx).mod, ctx.expr_compat_mode,
+                                ctx.scope_layers[1].mod, ctx.expr_compat_mode,
                                 Dict{Int, IdTag}(), ctx.macro_world)
     vr = valid_st1(ex)
     # surface only one error until we have pretty-printing for multiple

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -1,31 +1,25 @@
 # Lowering pass 1: Macro expansion, simple normalizations and quote expansion
 
+# One per pass.  Current scope layer is managed separately.
 struct MacroExpansionContext{Attrs} <: AbstractLoweringContext
     graph::SyntaxGraph{Attrs}
     bindings::Bindings
     scope_layers::Vector{ScopeLayer}
-    scope_layer_stack::Vector{LayerId}
     expr_compat_mode::Bool
     macro_world::UInt
 end
 
-function MacroExpansionContext(graph::SyntaxGraph, mod::Module, expr_compat_mode::Bool, world::UInt)
-    layers = ScopeLayer[ScopeLayer(1, mod, 0, false, false)]
-    MacroExpansionContext(graph, Bindings(), layers, LayerId[length(layers)], expr_compat_mode, world)
-end
+parent_layer(ctx::MacroExpansionContext, sl, err_ex) =
+    is_base_layer(sl) ?
+    throw(MacroExpansionError(err_ex, "`escape` node in outer context")) :
+    ctx.scope_layers[sl.parent_id]
 
-function push_layer!(ctx::MacroExpansionContext, mod::Module)
-    new_layer = ScopeLayer(length(ctx.scope_layers)+1, mod,
-                           current_layer_id(ctx), true, false)
-    push!(ctx.scope_layers, new_layer)
-    push!(ctx.scope_layer_stack, new_layer.id)
+function MacroExpansionContext(graph::SyntaxGraph, mod::Module,
+                               expr_compat_mode::Bool, world::UInt)
+    base_layer = ScopeLayer(1, mod, 0, false)
+    MacroExpansionContext(
+        graph, Bindings(), ScopeLayer[base_layer], expr_compat_mode, world)
 end
-function pop_layer!(ctx::MacroExpansionContext)
-    pop!(ctx.scope_layer_stack)
-end
-
-current_layer(ctx::MacroExpansionContext) = ctx.scope_layers[last(ctx.scope_layer_stack)]
-current_layer_id(ctx::MacroExpansionContext) = last(ctx.scope_layer_stack)
 
 #--------------------------------------------------
 # Expansion of quoted expressions
@@ -90,7 +84,7 @@ end
 struct MacroContext <: AbstractLoweringContext
     graph::SyntaxGraph
     macrocall::Union{SyntaxTree,LineNumberNode,SourceRef}
-    scope_layer::ScopeLayer
+    scope_layer::ScopeLayer # of outer context
     expr_compat_mode::Bool
 end
 
@@ -172,9 +166,9 @@ end
 # it from the scope layer's module in ctx.macro_world.  Otherwise, we need to
 # eval arbitrary code (which, TODO: does not use the correct world age, and it
 # isn't clear the language is meant to support this).
-function eval_macro_name(ctx::MacroExpansionContext, mctx::MacroContext, ex0::SyntaxTree)
-    mod = current_layer(ctx).mod
-    ex = expand_forms_1(ctx, ex0)
+function eval_macro_name(ctx, mctx::MacroContext, ex0::SyntaxTree, sl)
+    mod = sl.mod
+    ex = expand_forms_1(ctx, ex0, sl)
     try
         if kind(ex) === K"Value"
             ex.value
@@ -211,28 +205,23 @@ end
 # from previous expansion of old-style macros.
 #
 # See also set_scope_layer()
-function set_macro_arg_hygiene(ctx, ex, layer_ids, layer_idx)
+function set_macro_arg_hygiene(ctx, ex, sl)
     k = kind(ex)
-    scope_layer = get(ex, :scope_layer, layer_ids[layer_idx])
+    sl = ctx.scope_layers[get(ex, :scope_layer, sl.id)]
     if is_leaf(ex)
-        setattr!(mkleaf(ex), :scope_layer, scope_layer)
+        setattr!(mkleaf(ex), :scope_layer, sl.id)
+    elseif k === K"hygienic-scope"
+        set_macro_arg_hygiene(
+            ctx, ex[1], new_macro_scope_layer(ctx, sl, ex[2].value::Module, false))
+    elseif k === K"escape"
+        set_macro_arg_hygiene(ctx, ex[1], parent_layer(ctx, sl, ex))
     else
-        inner_layer_idx = k == K"escape" ? layer_idx - 1 : layer_idx
-        if k == K"escape" && inner_layer_idx < 1
-            # If we encounter too many escape nodes, there's probably been
-            # an error in the previous macro expansion.
-            # todo: The error here isn't precise about that - maybe we
-            # should record that macro call expression with the scope layer
-            # if we want to report the error against the macro call?
-            throw(MacroExpansionError(ex, "`escape` node in outer context"))
-        end
-        node = mapchildren(e->set_macro_arg_hygiene(
-            ctx, e, layer_ids, inner_layer_idx), ctx, ex)
-        setattr!(node, :scope_layer, scope_layer)
+        node = mapchildren(e->set_macro_arg_hygiene(ctx, e, sl), ctx, ex)
+        setattr!(node, :scope_layer, sl.id)
     end
 end
 
-function prepare_macro_args(ctx, mctx, raw_args)
+function prepare_macro_args(ctx, sl, mctx, raw_args)
     macro_args = Any[mctx]
     for arg in raw_args
         # Add hygiene information to be carried along with macro arguments.
@@ -243,8 +232,7 @@ function prepare_macro_args(ctx, mctx, raw_args)
         #   a macro expansion.
         # In either case, we need to set scope layers before passing the
         # arguments to the macro call.
-        push!(macro_args, set_macro_arg_hygiene(ctx, arg, ctx.scope_layer_stack,
-                                                length(ctx.scope_layer_stack)))
+        push!(macro_args, set_macro_arg_hygiene(ctx, arg, sl))
     end
     return macro_args
 end
@@ -276,12 +264,13 @@ function fix_toplevel_expansion(ctx, ex::SyntaxTree, mod::Module, lnn::LineNumbe
     end
 end
 
-function expand_macro(ctx, ex)
+function expand_macro(ctx, ex, outer_sl)
     @jl_assert kind(ex) == K"macrocall" ex
 
     macname = ex[1]
-    mctx = MacroContext(ctx.graph, ex, current_layer(ctx), ctx.expr_compat_mode)
-    macfunc = eval_macro_name(ctx, mctx, macname)
+    # TODO: should this be base_layer(ctx, outer_sl)?
+    mctx = MacroContext(ctx.graph, ex, outer_sl, ctx.expr_compat_mode)
+    macfunc = eval_macro_name(ctx, mctx, macname, outer_sl)
     raw_args = ex[3:end]
     macro_loc = if kind(ex[2]) === K"Value"
         loc = ex[2].value
@@ -311,7 +300,7 @@ function expand_macro(ctx, ex)
         hasmethod(macfunc, Tuple{typeof(mctx), typeof.(raw_args)...}; world=ctx.macro_world)
 
     if has_new_macro
-        macro_args = prepare_macro_args(ctx, mctx, raw_args)
+        macro_args = prepare_macro_args(ctx, outer_sl, mctx, raw_args)
         expanded = try
             Base.invoke_in_world(ctx.macro_world, macfunc, macro_args...)
         catch exc
@@ -334,7 +323,7 @@ function expand_macro(ctx, ex)
     else
         # Compat: attempt to invoke an old-style macro if there's no applicable
         # method for new-style macro arguments.
-        macro_args = Any[macro_loc, ctx.scope_layers[1].mod]
+        macro_args = Any[macro_loc, base_layer(ctx, outer_sl).mod]
 
         for arg in raw_args
             @jl_assert kind(arg) !== K"VERSION" arg # handled in EST conversion
@@ -359,7 +348,10 @@ function expand_macro(ctx, ex)
                     # If the macro has at least some methods implemented in the
                     # new style, assume the user meant to call one of those
                     # rather than any old-style macro methods which might exist
-                    exc = MethodError(macfunc, (prepare_macro_args(ctx, mctx, raw_args)..., ), ctx.macro_world)
+                    exc = MethodError(
+                        macfunc,
+                        (prepare_macro_args(ctx, outer_sl, mctx, raw_args)..., ),
+                        ctx.macro_world)
                 end
             end
             rethrow(MacroExpansionError(mctx, ex, "Error expanding macro", :all, exc))
@@ -374,9 +366,9 @@ function expand_macro(ctx, ex)
         # method was defined (may be different from `parentmodule(macfunc)`)
         mod_for_ast = lookup_method_instance(macfunc, macro_args,
                                              ctx.macro_world).def.module
-        push_layer!(ctx, mod_for_ast)
-        expanded = expand_forms_1(ctx, expanded)
-        pop_layer!(ctx)
+        expanded = expand_forms_1(
+            ctx, expanded,
+            new_macro_scope_layer(ctx, outer_sl, mod_for_ast, has_new_macro))
     end
     return expanded
 end
@@ -410,44 +402,34 @@ Lowering pass 1
 This pass expands macros and quote (interpolations).  It also annotates every
 identifier with the expansion it came from.
 """
-function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
+function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree, sl::ScopeLayer)
     k = kind(ex)
+    expr_sl = ctx.scope_layers[get(ex, :scope_layer, sl.id)]
     if k == K"Identifier"
-        scope_layer = get(ex, :scope_layer, current_layer_id(ctx))
-        out = mkleaf(ex)
-        setattr!(out, :scope_layer, scope_layer)
+        hasattr(ex, :scope_layer) ?
+            ex : setattr!(mkleaf(ex), :scope_layer, sl.id)
     elseif k == K"escape"
         if numchildren(ex) !== 1
             throw(LoweringError(ex, "`escape` requires one argument"))
         end
-        if length(ctx.scope_layer_stack) === 1
-            throw(MacroExpansionError(ex, "`escape` node in outer context"))
-        end
-        top_layer = pop!(ctx.scope_layer_stack)
-        escaped_ex = expand_forms_1(ctx, ex[1])
-        push!(ctx.scope_layer_stack, top_layer)
-        escaped_ex
+        expand_forms_1(ctx, ex[1], parent_layer(ctx, expr_sl, ex))
     elseif k == K"hygienic-scope"
         if !(2 <= numchildren(ex) <= 3 && ex[2].value isa Module)
             throw(LoweringError(ex,"`hygienic-scope` requires an AST and a module"))
         end
-        new_layer = ScopeLayer(length(ctx.scope_layers)+1, ex[2].value,
-                               current_layer_id(ctx), true, false)
-        push!(ctx.scope_layers, new_layer)
-        push!(ctx.scope_layer_stack, new_layer.id)
-        hyg_ex = expand_forms_1(ctx, ex[1])
-        pop!(ctx.scope_layer_stack)
-        hyg_ex
+        expand_forms_1(
+            ctx, ex[1],
+            new_macro_scope_layer(ctx, expr_sl, ex[2].value::Module, false))
     elseif k == K"quote"
         if numchildren(ex) !== 1
             throw(LoweringError(ex,"`quote` expects one argument"))
         end
-        expand_forms_1(ctx, expand_quote(ctx, ex[1]))
+        expand_forms_1(ctx, expand_quote(ctx, ex[1]), sl)
     elseif k == K"macrocall"
-        expand_macro(ctx, ex)
-    elseif k == K"toplevel" && length(ctx.scope_layer_stack) > 1
-        fix_toplevel_expansion(ctx, ex, current_layer(ctx).mod,
-                               source_location(LineNumberNode, ex))
+        expand_macro(ctx, ex, expr_sl)
+    elseif k == K"toplevel" && !is_base_layer(expr_sl)
+        fix_toplevel_expansion(
+            ctx, ex, expr_sl.mod, source_location(LineNumberNode, ex))
     elseif k == K"module" || k == K"toplevel" || k == K"inert" || k == K"inert_syntaxtree"
         # Remove scope layer information from any inert syntax which survives
         # macro expansion so that it doesn't contaminate lowering passes which
@@ -459,9 +441,8 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
         # if this is a form that requires resolving some identifier, add the
         # scope layer.  if this is an unknown form to be cleaned up by AST
         # conversion, save the scope layer just in case.
-        layerid = get(ex, :scope_layer, current_layer_id(ctx))
-        setattr(mapchildren(e->expand_forms_1(ctx,e), ctx, ex),
-                :scope_layer, layerid)
+        setattr(mapchildren(e->expand_forms_1(ctx,e,sl), ctx, ex),
+                :scope_layer, expr_sl.id)
     elseif is_leaf(ex)
         ex
     elseif (k == K"do" && numchildren(ex) == 2 && kind(ex[1]) == K"macrocall" &&
@@ -473,9 +454,9 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
             ex[2]    # do-lambda
             children(ex[1])[3:end]...
         ]
-        expand_macro(ctx, mac_ex)
+        expand_macro(ctx, mac_ex, expr_sl)
     else
-        mapchildren(e->expand_forms_1(ctx,e), ctx, ex)
+        mapchildren(e->expand_forms_1(ctx,e,sl), ctx, ex)
     end
 end
 
@@ -499,13 +480,12 @@ end
     graph = ensure_macro_attributes!(copy_attrs(syntax_graph(ex)))
     ex = reparent(graph, ex)
     ctx_out = MacroExpansionContext(graph, mod, expr_compat_mode, macro_world)
-    ex_out = expand_forms_1(ctx_out, ex)
+    ex_out = expand_forms_1(ctx_out, ex, only(ctx_out.scope_layers))
     graph2 = delete_attributes(ex._graph, :__macro_ctx__)
     # TODO: Returning the context with pass-specific mutable data is a bad way
     # to carry state into the next pass. We might fix this by attaching such
     # data to the graph itself as global attributes?
     ctx2 = MacroExpansionContext(graph2, ctx_out.bindings, ctx_out.scope_layers,
-                                 ctx_out.scope_layer_stack,
                                  expr_compat_mode, macro_world)
     return ctx2, reparent(ctx2.graph, ex_out)
 end

--- a/JuliaLowering/src/runtime.jl
+++ b/JuliaLowering/src/runtime.jl
@@ -345,11 +345,10 @@ function (g::GeneratedFunctionStub)(world::UInt, source::Method, @nospecialize a
         ex0 = newleaf(syntax_graph(ctx1), g.srcref, K"Value", ex0)
     end
     # Expand any macros emitted by the generator
-    ex1 = expand_forms_1(ctx1, reparent(ctx1, ex0))
+    ex1 = expand_forms_1(ctx1, reparent(ctx1, ex0), layer)
     ctx1 = MacroExpansionContext(delete_attributes(graph, :__macro_ctx__),
                                  ctx1.bindings, ctx1.scope_layers,
-                                 ctx1.scope_layer_stack, g.expr_compat_mode,
-                                 macro_world)
+                                 g.expr_compat_mode, macro_world)
     ex1 = reparent(ctx1, ex1)
 
     # Desugaring

--- a/JuliaLowering/src/scope_analysis.jl
+++ b/JuliaLowering/src/scope_analysis.jl
@@ -301,7 +301,7 @@ function enter_scope!(ctx, ex)
         local ex = SyntaxTree(ctx.graph, node_id)
         b = resolve_name(ctx, ex)
         if b === nothing
-            if is_toplevel_thunk && !ctx.scope_layers[vk.layer].is_macro_expansion
+            if is_toplevel_thunk && is_base_layer(ctx.scope_layers[vk.layer])
                 push!(ctx.soft_assignable_globals, vk)
                 declare_in_scope!(ctx, top_scope(ctx), ex, :global)
             elseif scope.is_permeable && is_defined_and_owned_global(

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -520,7 +520,10 @@ end
     @testset for arg0 in [:x, :(x::Type), :(::Type), :(_), :(_::Type)],
         arg1 in [arg0, Expr(:..., arg0)],
         arg2 in [arg1, Expr(:kw, arg1, :Int)],
-        expander in [fl_macroexpand, jl_macroexpand]
+        expander in [fl_macroexpand, (_,x)->x]
+        # TODO: would use jl_macroexpand, but that cannot be done as a separate
+        # step due to MacroExpansionContext, and we must use jl_eval.
+        @test_broken false
 
         @testset let expanded = expander(
             test_mod, :(function (specialized, @nospecialize($arg2))
@@ -540,7 +543,7 @@ end
         end
     end
 
-    @testset "kwargs" for expander in [fl_macroexpand, jl_macroexpand]
+    @testset "kwargs" for expander in [fl_macroexpand, (_,x)->x]
         local f
         @test (f = jl_eval(test_mod, expander(
             test_mod, quote

--- a/JuliaLowering/test/macros.jl
+++ b/JuliaLowering/test/macros.jl
@@ -7,6 +7,83 @@ Base.eval(test_mod, :(const var"@K_str" = $(JuliaLowering.var"@K_str")))
 Base.eval(test_mod, :(const JuliaLowering = $(JuliaLowering)))
 Base.eval(test_mod, :(const JuliaSyntax = $(JuliaSyntax)))
 
+# Set up identity macros for use in this file
+# - `old_e`, escaping its whole output, should do nothing to an expression
+# - `new_m`, introducing no new syntax, should behave exactly as `old_e` does
+# - `old_*` should behave the same across JL and flisp
+# - `old_h` should not be specified too hard here (buggy renaming pass)
+fl_eval(test_mod, :(macro old_e(x); esc(x); end))
+fl_eval(test_mod, :(macro old_h(x); x; end))
+JuliaLowering.include_string(test_mod, "macro new_m(x); x; end")
+fl_eval(test_mod, :(global mvar = "global mvar"))
+
+@testset "basic hygiene and escaping: old macros" for run in [
+    (x::String)->Base.include_string(
+        test_mod, "#=FLISP SANITY-CHECK=# "*x),
+    (x::String)->JuliaLowering.include_string(
+        test_mod, "#=JL COMPAT=# "*x; expr_compat_mode=true),
+    (x::String)->JuliaLowering.include_string(
+        test_mod, "#=JL=# "*x; expr_compat_mode=false)]
+
+    @test run("@old_e let mvar = 0; mvar; end") == 0
+    @test run("@old_e let @old_e(mvar = 0); mvar; end") == 0
+    @test run("@old_e let @old_e(@old_e(mvar = 0)); mvar; end") == 0
+    @test run("@old_e let @old_e(mvar) = 0; mvar; end") == 0
+    @test run("@old_e let @old_e(@old_e(mvar)) = 0; mvar; end") == 0
+    @test run("@old_e let mvar = 0; @old_e(mvar); end") == 0
+    @test run("@old_e let mvar = 0; @old_e(@old_e(mvar)); end") == 0
+    @test run("@old_e let @old_e(@old_e(mvar) = 0); @old_e(mvar); end") == 0
+
+    @test run("@old_h let mvar = 0; mvar; end") == 0
+    @test run("@old_h let @old_e(mvar = 0); mvar; end") == 0
+    @test run("@old_h let @old_e(@old_e(mvar = 0)); mvar; end") == 0
+    @test run("@old_h let @old_e(mvar) = 0; mvar; end") == 0
+    @test run("@old_h let @old_e(@old_e(mvar)) = 0; mvar; end") == 0
+    @test run("@old_h let mvar = 0; @old_e(mvar); end") == 0
+    @test run("@old_h let mvar = 0; @old_e(@old_e(mvar)); end") == 0
+    @test run("@old_h let @old_e(@old_e(mvar) = 0); @old_e(mvar); end") == 0
+
+    @test run("@old_h @old_h let mvar = 0; mvar; end") == 0
+    @test run("@old_h @old_h let @old_e(mvar = 0); mvar; end") == 0
+    @test run("@old_h @old_h let @old_e(@old_e(mvar = 0)); mvar; end") == 0
+    @test run("@old_h @old_h let @old_e(mvar) = 0; mvar; end") == 0
+    @test run("@old_h @old_h let @old_e(@old_e(mvar)) = 0; mvar; end") == 0
+    @test run("@old_h @old_h let mvar = 0; @old_e(mvar); end") == 0
+    @test run("@old_h @old_h let mvar = 0; @old_e(@old_e(mvar)); end") == 0
+    @test run("@old_h @old_h let @old_e(@old_e(mvar) = 0); @old_e(mvar); end") == 0
+end
+
+@testset "basic hygiene and escaping: new macros only" for expr_compat_mode in [true, false]
+    local run = (x::String)->JuliaLowering.include_string(test_mod, x; expr_compat_mode)
+
+    @test run("@new_m let mvar = 0; mvar; end") == 0
+    @test run("@new_m let @new_m(mvar = 0); mvar; end") == 0
+    @test run("@new_m let @new_m(@new_m(mvar = 0)); mvar; end") == 0
+    @test run("@new_m let @new_m(mvar) = 0; mvar; end") == 0
+    @test run("@new_m let @new_m(@new_m(mvar)) = 0; mvar; end") == 0
+    @test run("@new_m let mvar = 0; @new_m(mvar); end") == 0
+    @test run("@new_m let mvar = 0; @new_m(@new_m(mvar)); end") == 0
+    @test run("@new_m let @new_m(@new_m(mvar) = 0); @new_m(mvar); end") == 0
+end
+
+@testset "basic hygiene and escaping: new+old interop" for expr_compat_mode in [true, false],
+    mcall in ["@old_e ", "@new_m ", "@old_e @new_m ", "@new_m @old_e "],
+    old_h in ["", "@old_h "]
+
+    local run = (x::String)->JuliaLowering.include_string(test_mod, x; expr_compat_mode)
+
+    @test run(old_h*mcall*"let mvar = 0; mvar; end") == 0
+    @test run(old_h*"let ("*mcall*"mvar = 0); mvar; end") == 0
+    @test run(old_h*"let ("*mcall*"mvar) = 0; mvar; end") == 0
+    @test run(old_h*"let mvar = 0; ("*mcall*"mvar); end") == 0
+
+    @testset for mcall2 in ["@old_e ", "@new_m ", "@old_e @new_m ", "@new_m @old_e "]
+        @test run(old_h*mcall*"let ("*mcall2*"mvar) = 0; mvar; end") == 0
+        @test run(old_h*mcall*"let mvar = 0; ("*mcall2*"mvar); end") == 0
+        @test run(old_h*"let ("*mcall*"mvar = 0); ("*mcall2*"mvar); end") == 0
+    end
+end
+
 JuliaLowering.include_string(test_mod, raw"""
 module M
     using ..JuliaLowering: JuliaLowering, adopt_scope
@@ -170,7 +247,7 @@ call_world_arg_test = JuliaLowering.parsestmt(JuliaLowering.SyntaxTree, "@world_
 # Layer parenting
 @test expanded[1].scope_layer == 2
 @test expanded[2][1].scope_layer == 3
-@test getfield.(ctx.scope_layers, :parent_layer) == [0,1,2]
+@test getfield.(ctx.scope_layers, :parent_id) == [0,1,2]
 
 JuliaLowering.include_string(test_mod, """
 f_throw(x) = throw(x)
@@ -233,9 +310,9 @@ JuliaLowering.include_string(test_mod, raw"""
         end
     end
 
-    macro newstyle(a, b, c)
+    macro newstyle3(a, b, c)
         quote
-            x = "x in @newstyle"
+            x = "x in @newstyle3"
             ($a, $b, $c, x)
         end
     end
@@ -246,7 +323,7 @@ Base.eval(test_mod, :(
 macro oldstyle(a, b)
     quote
         x = "x in @oldstyle"
-        @newstyle $(esc(a)) $(esc(b)) x
+        @newstyle3 $(esc(a)) $(esc(b)) x
     end
 end
 ))
@@ -257,17 +334,17 @@ end
 """) == ("x in outer scope",
          "x in call_oldstyle_macro",
          "x in @oldstyle",
-         "x in @newstyle")
+         "x in @newstyle3")
 
-# Old style unhygenic escaping with esc()
+# Old style unhygienic escaping with esc()
 Base.eval(test_mod, :(
-macro oldstyle_unhygenic()
+macro oldstyle_unhygienic()
     esc(:x)
 end
 ))
 @test JuliaLowering.include_string(test_mod, """
 let x = "x in outer scope"
-    @oldstyle_unhygenic
+    @oldstyle_unhygienic
 end
 """) == "x in outer scope"
 


### PR DESCRIPTION
Found precompiling JSON in #61576. Given the following macros:

```julia
# these are functionally equivalent
macro old_macro_escaped(x); esc(x); end
JuliaLowering.include_string(Main, "macro new_macro(x); x; end")
```

macro hygiene states that both `x`s below should refer to the same thing:
```julia
@new_macro let x = 1
    @old_macro_escaped show(x)
end
```

`@new_macro` introduces scope layer `n` and `@old_macro_escaped` introduces scope layer `o`.  We correctly tag the `let` expression and all subtrees with the base scope layer (1) before `@new_macro` expands, but we also currently say `@old_macro_escaped` expands atop layer `n` (and so `esc` takes us `o`->`n`) since it's in the expansion of `@new_macro`, which is incorrect.  The result is that the first `x` in `x = 1` (scope layer 1) is not the same as the second `x` in `show(x)` (scope layer `n`).  This change expands `@old_macro_escaped` on top of layer 1 instead of layer `n`,  fixing that issue.

Note I've also done some refactoring so we no longer manage the scope layer as a stack.  This makes it easier to manage escaping and gives us a net deletion of code (as we're already storing the parent layer in the layer itself).

This area (new macros, old macros, hygiene interop, escaping) could use a lot more testing.  I've added a bunch for identity macros like the ones above; ideas for more are welcome.