### PR TITLE
show: Preserve alias binders when printing open types

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -549,8 +549,8 @@ function descend_params(io::IO, @nospecialize(sig), @nospecialize(called))
     n > 0 && n == length(called.parameters) || return nothing
     sig.name === typename(NamedTuple) && return nothing
     (any(isvarargtype, sig.parameters) || any(isvarargtype, called.parameters)) && return nothing
-    sa = make_typealias(makeproper(io, sig))
-    ca = make_typealias(makeproper(io, called))
+    sa = make_typealias(sig)
+    ca = make_typealias(called)
     if sa === nothing && ca === nothing
         return sig.parameters, called.parameters, nothing
     elseif sa !== nothing && ca !== nothing && sa[1] === ca[1]

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -549,8 +549,8 @@ function descend_params(io::IO, @nospecialize(sig), @nospecialize(called))
     n > 0 && n == length(called.parameters) || return nothing
     sig.name === typename(NamedTuple) && return nothing
     (any(isvarargtype, sig.parameters) || any(isvarargtype, called.parameters)) && return nothing
-    sa = make_typealias(sig)
-    ca = make_typealias(called)
+    sa = make_typealias(sig, io)
+    ca = make_typealias(called, io)
     if sa === nothing && ca === nothing
         return sig.parameters, called.parameters, nothing
     elseif sa !== nothing && ca !== nothing && sa[1] === ca[1]

--- a/base/show.jl
+++ b/base/show.jl
@@ -610,20 +610,41 @@ function modulesof!(s::Set{Module}, x::Type)
     s
 end
 
-# given an IO context for printing a type, reconstruct the proper type that
-# we're attempting to represent.
-# Union{T} where T is a degenerate case and is equal to T.ub, but we don't want
-# to print them that way, so filter those out from our aliases completely.
-function makeproper(io::IO, @nospecialize(x::Type))
-    if io isa IOContext
-        for (key, val) in io.dict
-            if key === :unionall_env && val isa TypeVar
-                x = UnionAll(val, x)
+function has_other_free_typevars(@nospecialize(x), free_before)
+    has_free_typevars(x) || return false
+    for v in find_free_typevars(x)
+        seen = false
+        for p in free_before
+            if p === v
+                seen = true
+                break
             end
         end
+        seen || return true
     end
-    has_free_typevars(x) && return Any
-    return x
+    return false
+end
+
+function unbounded_typealias(@nospecialize(alias::UnionAll))
+    original = alias
+    vars = TypeVar[]
+    changed = false
+    while alias isa UnionAll
+        oldvar = alias.var
+        if oldvar.lb === Union{} && oldvar.ub === Any
+            var = oldvar
+        else
+            var = TypeVar(oldvar.name)
+            changed = true
+        end
+        push!(vars, var)
+        alias = alias{var}
+    end
+    changed || return original
+    for var in reverse(vars)
+        alias = UnionAll(var, alias)
+    end
+    return alias
 end
 
 function make_typealias(@nospecialize(x::Type))
@@ -639,7 +660,7 @@ function make_typealias(@nospecialize(x::Type))
                 if alias isa Type && !has_free_typevars(alias) && !print_without_params(alias) && x <: alias
                     if alias isa UnionAll
                         free_before = find_free_typevars(x)
-                        (ti, env) = typeintersect_env(x, alias)
+                        (ti, env) = typeintersect_env(x, unbounded_typealias(alias))
                         # ti === Union{} && continue # impossible, since we already checked that x <: alias
                         env = env::SimpleVector
                         # unwrap `svec(tvar, constrained)` env markers down to the TypeVar
@@ -662,7 +683,7 @@ function make_typealias(@nospecialize(x::Type))
                                 continue
                             end
                         applied = rewrap_free_typevars(applied, free_before)
-                        has_free_typevars(applied) && continue
+                        has_other_free_typevars(applied, free_before) && continue
                         applied == x || continue # it couldn't figure out the parameter matching
                     elseif alias === x
                         env = Core.svec()
@@ -819,8 +840,7 @@ function show_wheres(io::IO, wheres::Vector{TypeVar})
 end
 
 function show_typealias(io::IO, @nospecialize(x::Type))
-    properx = makeproper(io, x)
-    alias = make_typealias(properx)
+    alias = make_typealias(x)
     alias === nothing && return false
     wheres = make_wheres(io, alias[2], x)
     show_typealias(io, alias[1], x, alias[2], wheres)
@@ -834,6 +854,7 @@ function make_typealiases(@nospecialize(x::Type))
     x <: Tuple && return aliases, Union{}
     mods = modulesof!(Set{Module}(), x)
     replace!(mods, Core=>Base)
+    free_before = find_free_typevars(x)
     vars = Dict{Symbol,TypeVar}()
     xenv = UnionAll[]
     each = Any[]
@@ -847,7 +868,8 @@ function make_typealiases(@nospecialize(x::Type))
             if isdefinedglobal(mod, name) && !isdeprecated(mod, name) && isconst(mod, name)
                 alias = getglobal(mod, name)
                 if alias isa Type && !has_free_typevars(alias) && !print_without_params(alias) && !(alias <: Tuple)
-                    (ti, env) = typeintersect_env(x, alias)
+                    intersect_alias = alias isa UnionAll ? unbounded_typealias(alias) : alias
+                    (ti, env) = typeintersect_env(x, intersect_alias)
                     ti === Union{} && continue
                     # make sure this alias wasn't from an unrelated part of the Union
                     mod2 = modulesof!(Set{Module}(), alias)
@@ -873,10 +895,12 @@ function make_typealiases(@nospecialize(x::Type))
                     for p in xenv
                         applied = rewrap_unionall(applied, p)
                     end
-                    has_free_typevars(applied) && continue
+                    applied = rewrap_free_typevars(applied, free_before)
+                    has_other_free_typevars(applied, free_before) && continue
                     applied <: x || continue # parameter matching didn't make a subtype
                     print_without_params(x) && (env = Core.svec())
                     for typ in each # check that the alias also fully subsumes at least component of the input
+                        typ isa TypeVar && continue
                         if typ <: applied
                             push!(aliases, Core.svec(GlobalRef(mod, name), env, applied, (ul, -length(env))))
                             break
@@ -912,8 +936,7 @@ function make_typealiases(@nospecialize(x::Type))
 end
 
 function show_unionaliases(io::IO, x::Union)
-    properx = makeproper(io, x)
-    aliases, applied = make_typealiases(properx)
+    aliases, applied = make_typealiases(x)
     isempty(aliases) && return false
     first = true
     tvar = false
@@ -921,7 +944,7 @@ function show_unionaliases(io::IO, x::Union)
         if isa(typ, TypeVar)
             tvar = true # sort bare TypeVars to the end
             continue
-        elseif rewrap_unionall(typ, properx) <: applied
+        elseif typ <: applied
             continue
         end
         print(io, first ? "Union{" : ", ")
@@ -958,8 +981,7 @@ end
 
 function show(io::IO, ::MIME"text/plain", @nospecialize(x::Type))
     if !print_without_params(x)
-        properx = makeproper(io, x)
-        if make_typealias(properx) !== nothing || (unwrap_unionall(x) isa Union && x <: make_typealiases(properx)[2])
+        if make_typealias(x) !== nothing || (unwrap_unionall(x) isa Union && x <: make_typealiases(x)[2])
             show(IOContext(io, :compact => true), x)
             if !(get(io, :compact, false)::Bool)
                 printstyled(io, " (alias for "; color = :light_black)

--- a/base/show.jl
+++ b/base/show.jl
@@ -625,39 +625,52 @@ function has_other_free_typevars(@nospecialize(x), free_before)
     return false
 end
 
-function unbounded_typealias(@nospecialize(alias::UnionAll))
-    original = alias
-    vars = TypeVar[]
-    changed = false
-    while alias isa UnionAll
-        oldvar = alias.var
-        if oldvar.lb === Union{} && oldvar.ub === Any
-            var = oldvar
-        else
-            var = TypeVar(oldvar.name)
-            changed = true
-        end
-        push!(vars, var)
-        alias = alias{var}
+# Return a copy of the type alias `alias` with every bounded binder replaced by
+# an unbounded one, so that `typeintersect_env` can match an open `x` (whose free
+# typevars are not yet known to satisfy the alias' bounds) against the alias.
+# The binders are rewritten from the innermost outward, so that a bound that
+# references an outer binder is rewritten consistently with that binder.
+function unbounded_typealias(@nospecialize(alias))
+    alias isa UnionAll || return alias
+    body = unbounded_typealias(alias.body)
+    var = alias.var
+    if var.lb === Union{} && var.ub === Any
+        body === alias.body && return alias
+        return UnionAll(var, body)
     end
-    changed || return original
-    for var in reverse(vars)
-        alias = UnionAll(var, alias)
-    end
-    return alias
+    newvar = TypeVar(var.name)
+    return UnionAll(newvar, UnionAll(var, body){newvar})
 end
 
-function make_typealias(@nospecialize(x::Type))
+# Reconstruct the closed type that the (possibly open) `x` is a piece of, by
+# re-wrapping it in the typevars bound by the surrounding printing context (the
+# `:unionall_env` entries of `io`). Subtype tests use this so that the
+# context-bound typevars are quantified rather than treated as rigid free
+# variables, while the rest of the alias machinery keeps operating on the open
+# `x` whose free typevars must be matched against the alias' parameters.
+function reapply_unionall_env(io::Union{IO,Nothing}, @nospecialize(x))
+    if io isa IOContext
+        for (key, val) in io.dict
+            if key === :unionall_env && val isa TypeVar
+                x = UnionAll(val, x)
+            end
+        end
+    end
+    return x
+end
+
+function make_typealias(@nospecialize(x::Type), io::Union{IO,Nothing}=nothing)
     Any === x && return nothing
     x <: Tuple && return nothing
     mods = modulesof!(Set{Module}(), x)
     replace!(mods, Core=>Base)
+    properx = reapply_unionall_env(io, x)
     aliases = Tuple{GlobalRef,SimpleVector}[]
     for mod in mods
         for name in unsorted_names(mod)
             if isdefinedglobal(mod, name) && !isdeprecated(mod, name) && isconst(mod, name)
                 alias = getglobal(mod, name)
-                if alias isa Type && !has_free_typevars(alias) && !print_without_params(alias) && x <: alias
+                if alias isa Type && !has_free_typevars(alias) && !print_without_params(alias) && properx <: alias
                     if alias isa UnionAll
                         free_before = find_free_typevars(x)
                         (ti, env) = typeintersect_env(x, unbounded_typealias(alias))
@@ -840,7 +853,7 @@ function show_wheres(io::IO, wheres::Vector{TypeVar})
 end
 
 function show_typealias(io::IO, @nospecialize(x::Type))
-    alias = make_typealias(x)
+    alias = make_typealias(x, io)
     alias === nothing && return false
     wheres = make_wheres(io, alias[2], x)
     show_typealias(io, alias[1], x, alias[2], wheres)
@@ -868,8 +881,7 @@ function make_typealiases(@nospecialize(x::Type))
             if isdefinedglobal(mod, name) && !isdeprecated(mod, name) && isconst(mod, name)
                 alias = getglobal(mod, name)
                 if alias isa Type && !has_free_typevars(alias) && !print_without_params(alias) && !(alias <: Tuple)
-                    intersect_alias = alias isa UnionAll ? unbounded_typealias(alias) : alias
-                    (ti, env) = typeintersect_env(x, intersect_alias)
+                    (ti, env) = typeintersect_env(x, unbounded_typealias(alias))
                     ti === Union{} && continue
                     # make sure this alias wasn't from an unrelated part of the Union
                     mod2 = modulesof!(Set{Module}(), alias)
@@ -981,7 +993,7 @@ end
 
 function show(io::IO, ::MIME"text/plain", @nospecialize(x::Type))
     if !print_without_params(x)
-        if make_typealias(x) !== nothing || (unwrap_unionall(x) isa Union && x <: make_typealiases(x)[2])
+        if make_typealias(x, io) !== nothing || (unwrap_unionall(x) isa Union && x <: make_typealiases(x)[2])
             show(IOContext(io, :compact => true), x)
             if !(get(io, :compact, false)::Bool)
                 printstyled(io, " (alias for "; color = :light_black)

--- a/test/show.jl
+++ b/test/show.jl
@@ -2543,6 +2543,20 @@ let S = TypeVar(:S, Union{}, Integer)
     @test string(UnionAll(S, Union{MBoundedAlias.A{S}, MBoundedAlias.B{S}})) == "$(curmod_prefix)MBoundedAlias.U"
 end
 
+# Alias printing should also recover the binders for an alias with several
+# bounded parameters, including when an inner binder is bounded by an outer one
+# and the printed type carries the matching typevars as free variables.
+module MBoundedAlias2
+export A, B, U
+struct A{T<:Integer, S<:T} end
+struct B{T<:Integer, S<:T} end
+const U{T<:Integer, S<:T} = Union{A{T,S}, B{T,S}}
+end
+let T = TypeVar(:T, Union{}, Integer), S = TypeVar(:S, Union{}, T)
+    @test string(Union{MBoundedAlias2.A{T,S}, MBoundedAlias2.B{T,S}}) ==
+        "$(curmod_prefix)MBoundedAlias2.U{T, S} where {T<:Integer, S<:T}"
+end
+
 @test sprint(show, :(./)) == ":((./))"
 @test sprint(show, :((.|).(.&, b))) == ":((.|).((.&), b))"
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -2532,6 +2532,17 @@ end
 @test string(Union{AbstractVector, T} where T) == "Union{AbstractVector, T} where T"
 @test string(Union{Array, Memory}) == "Union{Array, Memory}"
 
+# Alias printing should recover the source binder for bounded alias parameters.
+module MBoundedAlias
+export A, B, U
+struct A{T<:Integer} end
+struct B{T<:Integer} end
+const U{T<:Integer} = Union{A{T}, B{T}}
+end
+let S = TypeVar(:S, Union{}, Integer)
+    @test string(UnionAll(S, Union{MBoundedAlias.A{S}, MBoundedAlias.B{S}})) == "$(curmod_prefix)MBoundedAlias.U"
+end
+
 @test sprint(show, :(./)) == ":((./))"
 @test sprint(show, :((.|).(.&, b))) == ":((.|).((.&), b))"
 


### PR DESCRIPTION
Leverages the new invariant typevar semantics to fix a failure to identify a type alias (missed case from the earlier
typevar identity work).

Noticed by GPT 5.5 in #61915, but is an unrelated bug.