### PR TITLE
Complete the Julia logo color set in REPL modes 🟣

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -810,7 +810,7 @@ LineEditREPL(t::TextTerminal, hascolor::Bool, envcolors::Bool=false) =
         hascolor ? Base.input_color() : "",
         hascolor ? Base.answer_color() : "",
         hascolor ? Base.text_colors[:red] : "",
-        hascolor ? Base.text_colors[:yellow] : "",
+        hascolor ? Base.text_colors[:magenta] : "",
         hascolor ? Base.text_colors[:blue] : "",
         false, false, false, envcolors
     )

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -810,7 +810,7 @@ LineEditREPL(t::TextTerminal, hascolor::Bool, envcolors::Bool=false) =
         hascolor ? Base.input_color() : "",
         hascolor ? Base.answer_color() : "",
         hascolor ? Base.text_colors[:red] : "",
-        hascolor ? Base.text_colors[:magenta] : "",
+        hascolor ? Base.text_colors[:light_magenta] : "",
         hascolor ? Base.text_colors[:blue] : "",
         false, false, false, envcolors
     )


### PR DESCRIPTION
## Motivation

The Julia logo has four colors: **green**, **red**, **blue**, and **purple**.

Three of the four REPL modes already match three of them:

| Mode | Prompt | Color |
|------|--------|-------|
| Julia | `julia>` | 🟢 green |
| Shell | `shell>` | 🔴 red |
| Package manager | `pkg>` | 🔵 blue |
| Help | `help?>` | 🟡 yellow ← is not idiomatic |

Yet `help?>` This neglects our beloved purple of Julia.

## Change

Replace `:yellow` with `:magenta` in the `LineEditREPL` constructor in `stdlib/REPL/src/REPL.jl`.

| Mode | Prompt | Color |
|------|--------|-------|
| Julia | `julia>` | 🟢 green |
| Shell | `shell>` | 🔴 red |
| Package manager | `pkg>` | 🔵 blue |
| Help | `help?>` | 🟣 purple ← perfection doesn't exi.... |

Minimal change for maximal satisfaction

## Let's be idiomatic 🟣