### PR TITLE
add issubnormal(x::BigFloat) = false

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -933,7 +933,7 @@ end
 """
     issubnormal(f)::Bool
 
-Test whether a number is subnormal.
+Test whether a floating point number is subnormal.
 
 An IEEE floating point number is [subnormal](https://en.wikipedia.org/wiki/Subnormal_number)
 when its exponent bits are zero and its significand is not zero.
@@ -950,7 +950,7 @@ julia> issubnormal(1.0f-38)
 true
 ```
 """
-issubnormal(x::Number) = false
+issubnormal(x::BigFloat) = false
 function issubnormal(x::T) where {T<:IEEEFloat}
     y = reinterpret(Unsigned, x)
     (y & exponent_mask(T) == 0) & (y & significand_mask(T) != 0)

--- a/base/float.jl
+++ b/base/float.jl
@@ -933,7 +933,7 @@ end
 """
     issubnormal(f)::Bool
 
-Test whether a floating point number is subnormal.
+Test whether a number is subnormal.
 
 An IEEE floating point number is [subnormal](https://en.wikipedia.org/wiki/Subnormal_number)
 when its exponent bits are zero and its significand is not zero.
@@ -950,6 +950,7 @@ julia> issubnormal(1.0f-38)
 true
 ```
 """
+issubnormal(x::Number) = false
 function issubnormal(x::T) where {T<:IEEEFloat}
     y = reinterpret(Unsigned, x)
     (y & exponent_mask(T) == 0) & (y & significand_mask(T) != 0)

--- a/base/float.jl
+++ b/base/float.jl
@@ -950,7 +950,6 @@ julia> issubnormal(1.0f-38)
 true
 ```
 """
-issubnormal(x::BigFloat) = false
 function issubnormal(x::T) where {T<:IEEEFloat}
     y = reinterpret(Unsigned, x)
     (y & exponent_mask(T) == 0) & (y & significand_mask(T) != 0)

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -9,7 +9,7 @@ export
 import
     .Base: *, +, -, /, <, <=, ==, >, >=, ^, ceil, cmp, convert, copysign, div,
         inv, exp, exp2, exponent, factorial, floor, fma, muladd, hypot, isinteger,
-        isfinite, isinf, isnan, ldexp, log, log2, log10, max, min, mod, modf,
+        isfinite, isinf, isnan, issubnormal, ldexp, log, log2, log10, max, min, mod, modf,
         nextfloat, prevfloat, promote_rule, rem, rem2pi, round, show, float,
         sum, sqrt, string, print, trunc, precision, _precision, exp10, expm1, log1p,
         eps, signbit, sign, sin, cos, sincos, tan, sec, csc, cot, acos, asin, atan,
@@ -1134,6 +1134,8 @@ end
 function isnan(x::BigFloat)
     return x.exp == mpfr_special_exponent_nan
 end
+
+issubnormal(x::BigFloat) = false
 
 isfinite(x::BigFloat) = !isinf(x) && !isnan(x)
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -975,11 +975,13 @@ end
     f19872b(x) = x ^ (-1024)
     @test 0 < f19872b(2.0) < 1e-300
     @test issubnormal(2.0 ^ (-1024))
+    @test !issubnormal(big(2.0 ^ (-1024)))
     @test issubnormal(f19872b(2.0))
     @test !issubnormal(f19872b(0.0))
     @test f19872a(2.0) === 32.0
     @test !issubnormal(f19872a(2.0))
     @test !issubnormal(0.0)
+    @test !issubnormal(0)
 end
 
 # no domain error is thrown for negative values

--- a/test/math.jl
+++ b/test/math.jl
@@ -981,7 +981,6 @@ end
     @test f19872a(2.0) === 32.0
     @test !issubnormal(f19872a(2.0))
     @test !issubnormal(0.0)
-    @test !issubnormal(0)
 end
 
 # no domain error is thrown for negative values

--- a/test/math.jl
+++ b/test/math.jl
@@ -976,6 +976,7 @@ end
     @test 0 < f19872b(2.0) < 1e-300
     @test issubnormal(2.0 ^ (-1024))
     @test !issubnormal(big(2.0 ^ (-1024)))
+    @test !issubnormal(nextfloat(BigFloat(0)))
     @test issubnormal(f19872b(2.0))
     @test !issubnormal(f19872b(0.0))
     @test f19872a(2.0) === 32.0


### PR DESCRIPTION
Needed to get the new `normalize` and `normalize!` functions working for `BigFloat` and probably some other types: https://github.com/JuliaLang/LinearAlgebra.jl/pull/1634

I followed the example of `isnan`, which simply returns `false` generically, and has specialized methods for types which actually have NaNs.