### PR TITLE
Compiler: avoid Const allocation when querying globalref types in IR

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3782,15 +3782,72 @@ world_range(ci::CodeInfo) = WorldRange(ci.min_world, ci.max_world)
 world_range(ci::CodeInstance) = WorldRange(ci.min_world, ci.max_world)
 world_range(compact::IncrementalCompact) = world_range(compact.ir)
 
-# n.b. this function is not part of abstract eval (where it would be unsound) but rather
-# for the optimizer to observe the result of abstract eval. Inference already guaranteed
-# consistency across the world range, so we just look up the partition at max_world.
-function abstract_eval_globalref_type(g::GlobalRef, src::Union{CodeInfo, IRCode, IncrementalCompact})
-    worlds = world_range(src)
+# Flat leaf-only walk used by the optimizer entry points below. Skips the WorldRange
+# tracking that `walk_binding_partition` performs for inference's validity bookkeeping.
+@inline function walk_to_leaf_partition(binding::Core.Binding, partition::Core.BindingPartition, world::UInt)
+    while is_some_binding_imported(binding_kind(partition))
+        binding = partition_restriction(partition)::Core.Binding
+        partition = lookup_binding_partition(world, binding)
+    end
+    return (binding, partition)
+end
+
+@inline function partition_rt(partition::Core.BindingPartition)
+    kind = binding_kind(partition)
+    (is_some_guard(kind) || kind == PARTITION_KIND_DECLARED) && return Any
+    if is_defined_const_binding(kind)
+        kind == PARTITION_KIND_BACKDATED_CONST && return Any
+        return Const(partition_restriction(partition))
+    end
+    return partition_restriction(partition)
+end
+
+@inline function partition_rt_widened(partition::Core.BindingPartition)
+    kind = binding_kind(partition)
+    (is_some_guard(kind) || kind == PARTITION_KIND_DECLARED) && return Any
+    if is_defined_const_binding(kind)
+        kind == PARTITION_KIND_BACKDATED_CONST && return Any
+        v = partition_restriction(partition)
+        return isa(v, Type) ? Type{v} : typeof(v)
+    end
+    return partition_restriction(partition)
+end
+
+# n.b. the helpers below are not part of abstract eval (where they would be unsound) but
+# IR-level queries for the optimizer to observe the result of abstract eval. Inference
+# already guaranteed consistency across the world range, so we just look up the partition
+# at max_world.
+@inline function globalref_leaf_partition(g::GlobalRef, src::Union{CodeInfo, IRCode, IncrementalCompact})
+    world = max_world(world_range(src))
     binding = convert(Core.Binding, g)
-    partition = lookup_binding_partition(max_world(worlds), binding)
-    (_, (leaf_binding, leaf_partition)) = walk_binding_partition(binding, partition, max_world(worlds))
-    return abstract_eval_partition_load(nothing, leaf_binding, leaf_partition).rt
+    partition = lookup_binding_partition(world, binding)
+    _, leaf_partition = walk_to_leaf_partition(binding, partition, world)
+    return leaf_partition
+end
+
+globalref_rt(g::GlobalRef, src::Union{CodeInfo, IRCode, IncrementalCompact}) =
+    partition_rt(globalref_leaf_partition(g, src))
+
+# Same as `globalref_rt` but returns the widened type directly, skipping the `Const(...)`
+# boxing on defined-const bindings. Use this when the caller is going to call `widenconst`
+# on the result anyway.
+globalref_rt_widened(g::GlobalRef, src::Union{CodeInfo, IRCode, IncrementalCompact}) =
+    partition_rt_widened(globalref_leaf_partition(g, src))
+
+# Equivalent to `singleton_type(globalref_rt(g, src))` but skips the intermediate
+# `Const(...)` boxing on defined-const bindings. Returns the singleton value (or `nothing`).
+# Like `singleton_type`, this also recognizes typed globals whose restriction is itself a
+# singleton type (e.g. `typeof(getfield)`) or a `Type{T}`.
+function globalref_singleton(g::GlobalRef, src::Union{CodeInfo, IRCode, IncrementalCompact})
+    partition = globalref_leaf_partition(g, src)
+    kind = binding_kind(partition)
+    (is_some_guard(kind) || kind == PARTITION_KIND_DECLARED) && return nothing
+    if is_defined_const_binding(kind)
+        kind == PARTITION_KIND_BACKDATED_CONST && return nothing
+        return partition_restriction(partition)
+    end
+    # Typed global: restriction is a type — recognize `Type{T}` and singleton types.
+    return singleton_type(partition_restriction(partition))
 end
 
 function lookup_binding_partition!(interp::AbstractInterpreter, g::Union{GlobalRef, Core.Binding}, sv::AbsIntState)

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3807,8 +3807,7 @@ end
     (is_some_guard(kind) || kind == PARTITION_KIND_DECLARED) && return Any
     if is_defined_const_binding(kind)
         kind == PARTITION_KIND_BACKDATED_CONST && return Any
-        v = partition_restriction(partition)
-        return isa(v, Type) ? Type{v} : typeof(v)
+        return Core.Typeof(partition_restriction(partition))
     end
     return partition_restriction(partition)
 end

--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -3782,8 +3782,8 @@ world_range(ci::CodeInfo) = WorldRange(ci.min_world, ci.max_world)
 world_range(ci::CodeInstance) = WorldRange(ci.min_world, ci.max_world)
 world_range(compact::IncrementalCompact) = world_range(compact.ir)
 
-# Flat leaf-only walk used by the optimizer entry points below. Skips the WorldRange
-# tracking that `walk_binding_partition` performs for inference's validity bookkeeping.
+# Like `walk_binding_partition` but drops the WorldRange tracking — IR-only callers
+# don't use it.
 @inline function walk_to_leaf_partition(binding::Core.Binding, partition::Core.BindingPartition, world::UInt)
     while is_some_binding_imported(binding_kind(partition))
         binding = partition_restriction(partition)::Core.Binding
@@ -3812,10 +3812,8 @@ end
     return partition_restriction(partition)
 end
 
-# n.b. the helpers below are not part of abstract eval (where they would be unsound) but
-# IR-level queries for the optimizer to observe the result of abstract eval. Inference
-# already guaranteed consistency across the world range, so we just look up the partition
-# at max_world.
+# IR-level GlobalRef queries. Not abstract eval (unsound there): inference already
+# guarantees consistency across the world range, so we just look up at max_world.
 @inline function globalref_leaf_partition(g::GlobalRef, src::Union{CodeInfo, IRCode, IncrementalCompact})
     world = max_world(world_range(src))
     binding = convert(Core.Binding, g)
@@ -3827,16 +3825,12 @@ end
 globalref_rt(g::GlobalRef, src::Union{CodeInfo, IRCode, IncrementalCompact}) =
     partition_rt(globalref_leaf_partition(g, src))
 
-# Same as `globalref_rt` but returns the widened type directly, skipping the `Const(...)`
-# boxing on defined-const bindings. Use this when the caller is going to call `widenconst`
-# on the result anyway.
+# `widenconst`-compatible variant — skips the `Const(...)` box on defined-const bindings.
 globalref_rt_widened(g::GlobalRef, src::Union{CodeInfo, IRCode, IncrementalCompact}) =
     partition_rt_widened(globalref_leaf_partition(g, src))
 
-# Equivalent to `singleton_type(globalref_rt(g, src))` but skips the intermediate
-# `Const(...)` boxing on defined-const bindings. Returns the singleton value (or `nothing`).
-# Like `singleton_type`, this also recognizes typed globals whose restriction is itself a
-# singleton type (e.g. `typeof(getfield)`) or a `Type{T}`.
+# `singleton_type`-compatible variant — skips the `Const(...)` box on defined-const
+# bindings, and (like `singleton_type`) also unwraps `Type{T}` / singleton restrictions.
 function globalref_singleton(g::GlobalRef, src::Union{CodeInfo, IRCode, IncrementalCompact})
     partition = globalref_leaf_partition(g, src)
     kind = binding_kind(partition)
@@ -3845,7 +3839,6 @@ function globalref_singleton(g::GlobalRef, src::Union{CodeInfo, IRCode, Incremen
         kind == PARTITION_KIND_BACKDATED_CONST && return nothing
         return partition_restriction(partition)
     end
-    # Typed global: restriction is a type — recognize `Type{T}` and singleton types.
     return singleton_type(partition_restriction(partition))
 end
 

--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -260,6 +260,7 @@ function OptimizationState(mi::MethodInstance, interp::AbstractInterpreter)
 end
 
 function argextype end # imported by EscapeAnalysis
+function argextype_widened end # imported by EscapeAnalysis
 function try_compute_field end # imported by EscapeAnalysis
 
 include("ssair/heap.jl")
@@ -515,7 +516,7 @@ function argextype(
     elseif isa(x, QuoteNode)
         return Const(x.value)
     elseif isa(x, GlobalRef)
-        return abstract_eval_globalref_type(x, src)
+        return globalref_rt(x, src)
     elseif isa(x, PhiNode) || isa(x, PhiCNode) || isa(x, UpsilonNode)
         return Any
     elseif isa(x, PiNode)
@@ -524,6 +525,18 @@ function argextype(
         return Const(x)
     end
 end
+
+# Like `widenconst(argextype(x, src, ...))` but avoids constructing a `Const` only to
+# widen it away when `x` is a `GlobalRef` to a defined-const binding. Non-GlobalRef args
+# fall through to `argextype`, which already handles the SSAValue/Argument/Slot dispatch.
+@inline function argextype_widened(@nospecialize(x),
+        src::Union{IRCode,IncrementalCompact,CodeInfo}, sptypes::Vector{VarState})
+    isa(x, GlobalRef) && return globalref_rt_widened(x, src)
+    return widenconst(argextype(x, src, sptypes))
+end
+@inline argextype_widened(@nospecialize(x), ir::IRCode) = argextype_widened(x, ir, ir.sptypes)
+@inline argextype_widened(@nospecialize(x), compact::IncrementalCompact) =
+    argextype_widened(x, compact, compact.ir.sptypes)
 function abstract_eval_ssavalue(s::SSAValue, src::CodeInfo)
     ssavaluetypes = src.ssavaluetypes
     if ssavaluetypes isa Int
@@ -1415,7 +1428,7 @@ function statement_cost(ex::Expr, line::Int, src::Union{CodeInfo, IRCode}, sptyp
             elseif f === Core.memoryrefunset! && length(ex.args) >= 3
                 atyp = argextype(ex.args[2], src, sptypes)
                 return isknowntype(atyp) ? 5 : params.inline_nonleaf_penalty
-            elseif f === typeassert && isconstType(widenconst(argextype(ex.args[3], src, sptypes)))
+            elseif f === typeassert && isconstType(argextype_widened(ex.args[3], src, sptypes))
                 return 1
             end
             fidx = find_tfunc(f)

--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -526,9 +526,7 @@ function argextype(
     end
 end
 
-# Like `widenconst(argextype(x, src, ...))` but avoids constructing a `Const` only to
-# widen it away when `x` is a `GlobalRef` to a defined-const binding. Non-GlobalRef args
-# fall through to `argextype`, which already handles the SSAValue/Argument/Slot dispatch.
+# `widenconst(argextype(x, src, ...))` without the throwaway `Const` for GlobalRef args.
 @inline function argextype_widened(@nospecialize(x),
         src::Union{IRCode,IncrementalCompact,CodeInfo}, sptypes::Vector{VarState})
     isa(x, GlobalRef) && return globalref_rt_widened(x, src)

--- a/Compiler/src/ssair/EscapeAnalysis.jl
+++ b/Compiler/src/ssair/EscapeAnalysis.jl
@@ -26,9 +26,9 @@ using Base:       # Base definitions
     !, !==, &, *, +, -, :, <, <<, >, |, ∈, ∉, ∩, ∪, ≠, ≤, ≥, ⊆
 using ..Compiler: # Compiler specific definitions
     AbstractLattice, Compiler, IRCode, IR_FLAG_NOTHROW,
-    argextype, fieldcount_noerror, has_flag, intrinsic_nothrow, is_meta_expr_head,
-    is_identity_free_argtype, isexpr, setfield!_nothrow, singleton_type, try_compute_field,
-    try_compute_fieldidx, widenconst
+    argextype, argextype_widened, fieldcount_noerror, has_flag, intrinsic_nothrow,
+    is_meta_expr_head, is_identity_free_argtype, isexpr, setfield!_nothrow, singleton_type,
+    try_compute_field, try_compute_fieldidx
 
 function include(x::String)
     if !isdefined(Base, :end_base_include)
@@ -1145,7 +1145,7 @@ function escape_new!(astate::AnalysisState, pc::Int, args::Vector{Any})
     if isa(AliasInfo, Bool)
         AliasInfo && @goto conservative_propagation
         # AliasInfo of this object hasn't been analyzed yet: set AliasInfo now
-        typ = widenconst(argextype(obj, astate.ir))
+        typ = argextype_widened(obj, astate.ir)
         nflds = fieldcount_noerror(typ)
         if nflds === nothing
             AliasInfo = Unindexable()
@@ -1255,7 +1255,7 @@ function escape_builtin!(::typeof(getfield), astate::AnalysisState, pc::Int, arg
     length(args) ≥ 3 || return false
     ir, estate = astate.ir, astate.estate
     obj = args[2]
-    typ = widenconst(argextype(obj, ir))
+    typ = argextype_widened(obj, ir)
     if hasintersect(typ, Module) # global load
         add_escape_change!(astate, SSAValue(pc), ⊤)
     end
@@ -1315,7 +1315,7 @@ function escape_builtin!(::typeof(setfield!), astate::AnalysisState, pc::Int, ar
     if isa(AliasInfo, Bool)
         AliasInfo && @goto conservative_propagation
         # AliasInfo of this object hasn't been analyzed yet: set AliasInfo now
-        typ = widenconst(argextype(obj, ir))
+        typ = argextype_widened(obj, ir)
         AliasInfo, fidx = analyze_fields(ir, typ, args[3])
         if isa(AliasInfo, IndexableFields)
             @goto escape_indexable_def
@@ -1323,7 +1323,7 @@ function escape_builtin!(::typeof(setfield!), astate::AnalysisState, pc::Int, ar
             @goto escape_unindexable_def
         end
     elseif isa(AliasInfo, IndexableFields)
-        typ = widenconst(argextype(obj, ir))
+        typ = argextype_widened(obj, ir)
         AliasInfo, fidx = reanalyze_fields(AliasInfo, ir, typ, args[3])
         isa(AliasInfo, Unindexable) && @goto escape_unindexable_def
         @label escape_indexable_def

--- a/Compiler/src/ssair/passes.jl
+++ b/Compiler/src/ssair/passes.jl
@@ -2,8 +2,9 @@
 
 function is_known_call(@nospecialize(x), @nospecialize(func), ir::Union{IRCode,IncrementalCompact})
     isexpr(x, :call) || return false
-    ft = argextype(x.args[1], ir)
-    return singleton_type(ft) === func
+    arg = x.args[1]
+    isa(arg, GlobalRef) && return globalref_singleton(arg, ir) === func
+    return singleton_type(argextype(arg, ir)) === func
 end
 
 function is_known_invoke_or_call(@nospecialize(x), @nospecialize(func), ir::Union{IRCode,IncrementalCompact})
@@ -11,8 +12,9 @@ function is_known_invoke_or_call(@nospecialize(x), @nospecialize(func), ir::Unio
     (isinvoke || isexpr(x, :call)) || return false
     narg = isinvoke ? 2 : 1
     length(x.args) < narg && return false
-    ft = argextype(x.args[narg], ir)
-    return singleton_type(ft) === func
+    arg = x.args[narg]
+    isa(arg, GlobalRef) && return globalref_singleton(arg, ir) === func
+    return singleton_type(argextype(arg, ir)) === func
 end
 
 struct SSAUse
@@ -304,7 +306,7 @@ function walk_to_defs(compact::IncrementalCompact, @nospecialize(defssa), @nospe
                 if is_old(compact, defssa) && isa(val, SSAValue)
                     val = OldSSAValue(val.id)
                 end
-                edge_typ = widenconst(argextype(val, compact))
+                edge_typ = argextype_widened(val, compact)
                 hasintersect(edge_typ, typeconstraint) || continue
                 push!(possible_predecessors, n)
             end
@@ -351,7 +353,7 @@ function record_immutable_preserve!(new_preserves::Vector{Any}, def::Expr, compa
     args = isexpr(def, :new) ? def.args : def.args[2:end]
     for i = 1:length(args)
         arg = args[i]
-        if !isbitstype(widenconst(argextype(arg, compact)))
+        if !isbitstype(argextype_widened(arg, compact))
             push!(new_preserves, arg)
         end
     end
@@ -606,7 +608,7 @@ end
 function lift_comparison_leaves!(@specialize(tfunc),
     compact::IncrementalCompact, @nospecialize(val), @nospecialize(cmp),
     idx::Int, 𝕃ₒ::AbstractLattice)
-    typeconstraint = widenconst(argextype(val, compact))
+    typeconstraint = argextype_widened(val, compact)
     if isa(val, Union{OldSSAValue, SSAValue})
         val, typeconstraint = simple_walk_constraint(compact, val, typeconstraint)
     end
@@ -910,7 +912,7 @@ function lift_apply_args!(compact::IncrementalCompact, idx::Int, stmt::Expr)
     compact[idx] = nothing
     for i in 4:length(stmt.args) # Skip `_apply_iterate`, `iterate`, and the function
         arg = stmt.args[i]
-        arg_type = widenconst(argextype(arg, compact))
+        arg_type = argextype_widened(arg, compact)
         if isa(arg_type, DataType) && arg_type.name === Tuple.name
             svec_args = nothing
             if isa(arg, SSAValue)
@@ -1415,7 +1417,7 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
                         push!(preserved, preserved_arg.id)
                         continue
                     elseif isexpr(def, :new)
-                        typ = unwrap_unionall(widenconst(argextype(SSAValue(defidx), compact)))
+                        typ = unwrap_unionall(argextype_widened(SSAValue(defidx), compact))
                         if typ isa DataType && !ismutabletype(typ)
                             record_immutable_preserve!(new_preserves, def, compact)
                             push!(preserved, preserved_arg.id)
@@ -1475,7 +1477,7 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
             # analyze `getfield` / `isdefined` / `setfield!` call
             val = stmt.args[2]
         end
-        struct_typ = widenconst(argextype(val, compact))
+        struct_typ = argextype_widened(val, compact)
         struct_argtyp = argument_datatype(struct_typ)
         if struct_argtyp === nothing
             if isa(struct_typ, Union) && is_isdefined
@@ -1970,7 +1972,7 @@ function sroa_mutables!(ir::IRCode, defuses::IdDict{Int,Tuple{SPCSet,SSADefUse}}
                     elseif use.kind === :preserve
                         newval = compute_value_for_use(ir, domtree, allblocks,
                             du, phinodes, fidx, use.idx)
-                        if !isbitstype(widenconst(argextype(newval, ir)))
+                        if !isbitstype(argextype_widened(newval, ir))
                             if preserve_uses === nothing
                                 preserve_uses = IdDict{Int, Vector{Any}}()
                             end
@@ -2241,7 +2243,7 @@ function adce_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
             if !isassigned(stmt.values, i)
                 # Should be impossible to have something used only by PiNodes that's undef
                 push!(to_drop, i)
-            elseif !hasintersect(widenconst(argextype(stmt.values[i], compact)),
+            elseif !hasintersect(argextype_widened(stmt.values[i], compact),
                                  widenconst(t))
                 push!(to_drop, i)
             end

--- a/Compiler/src/ssair/slot2ssa.jl
+++ b/Compiler/src/ssair/slot2ssa.jl
@@ -172,7 +172,7 @@ function typ_for_val(@nospecialize(x), ci::CodeInfo, ir::IRCode, idx::Int, slott
         end
         return (ci.ssavaluetypes::Vector{Any})[idx]
     end
-    isa(x, GlobalRef) && return abstract_eval_globalref_type(x, ci)
+    isa(x, GlobalRef) && return globalref_rt(x, ci)
     isa(x, SSAValue) && return (ci.ssavaluetypes::Vector{Any})[x.id]
     isa(x, Argument) && return slottypes[x.n]
     isa(x, NewSSAValue) && return types(ir)[new_to_regular(x, length(ir.stmts))]

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1628,7 +1628,7 @@ function collectinvokes!(workqueue::CompilationQueue, ci::CodeInfo, sptypes::Vec
         if isexpr(stmt, :call)
             farg = stmt.args[1]
             !applicable(argextype, farg, ci, sptypes) && continue # TODO: Why is this failing during bootstrap
-            ftyp = widenconst(argextype(farg, ci, sptypes))
+            ftyp = argextype_widened(farg, ci, sptypes)
 
             if ftyp === typeof(Core.finalizer) && length(stmt.args) == 3
                 finalizer = argextype(stmt.args[2], ci, sptypes)

--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -11,7 +11,7 @@ using ..Compiler:
      NamedTuple, Pair, PhiCNode, PhiNode, PiNode, QuoteNode, SSAValue, SimpleVector, String,
      Tuple, VarState, Vector,
      # functions
-     argextype_widened, empty!, error, get, get_ci_mi, get_world_counter, getglobal, getindex, getproperty,
+     argextype, argextype_widened, empty!, error, get, get_ci_mi, get_world_counter, getglobal, getindex, getproperty,
      hasintersect, haskey, in, isdefinedglobal, isdispatchelem, isempty, isexpr, iterate, length, map!, max,
      pop!, popfirst!, push!, pushfirst!, reinterpret, reverse!, reverse, setindex!,
      setproperty!, similar, singleton_type, sptypes_from_meth_instance, sp_type_rewrap,

--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -11,11 +11,11 @@ using ..Compiler:
      NamedTuple, Pair, PhiCNode, PhiNode, PiNode, QuoteNode, SSAValue, SimpleVector, String,
      Tuple, VarState, Vector,
      # functions
-     argextype, empty!, error, get, get_ci_mi, get_world_counter, getglobal, getindex, getproperty,
+     argextype_widened, empty!, error, get, get_ci_mi, get_world_counter, getglobal, getindex, getproperty,
      hasintersect, haskey, in, isdefinedglobal, isdispatchelem, isempty, isexpr, iterate, length, map!, max,
      pop!, popfirst!, push!, pushfirst!, reinterpret, reverse!, reverse, setindex!,
      setproperty!, similar, singleton_type, sptypes_from_meth_instance, sp_type_rewrap,
-     unsafe_pointer_to_objref, widenconst, isconcretetype,
+     unsafe_pointer_to_objref, isconcretetype,
      # misc
      @nospecialize, @assert, C_NULL
 using ..IRShow: LineInfoNode, print, show, println, append_scopes!, IOContext, IO, normalize_method_name, is_expected_union
@@ -115,7 +115,7 @@ end
 
 function has_unstable_arg(codeinfo::CodeInfo, sptypes::Vector{VarState}, args, startidx::Int)
     for i in (startidx + 1):length(args)
-        is_type_stable(widenconst(argextype(args[i], codeinfo, sptypes))) || return true
+        is_type_stable(argextype_widened(args[i], codeinfo, sptypes)) || return true
     end
     return false
 end
@@ -137,7 +137,7 @@ end
 # Print value with type annotation: value::type
 function print_typed(io::IO, codeinfo::CodeInfo, sptypes::Vector{VarState}, @nospecialize(stmt), stable::Bool;
                      depth::Int=0, indent::Int=0)
-    typ = widenconst(argextype(stmt, codeinfo, sptypes))
+    typ = argextype_widened(stmt, codeinfo, sptypes)
     arg_stable = is_type_stable(typ)
     # Fold deeply nested stable calls
     if arg_stable && depth >= MAX_NESTING_DEPTH && is_call_expr(codeinfo, stmt)
@@ -176,7 +176,7 @@ function print_stmt_colored(io::IO, codeinfo::CodeInfo, sptypes::Vector{VarState
         # Print function call
         if farg !== nothing
             fstmt = unwrap_stmt(codeinfo, farg)
-            ftyp = widenconst(argextype(farg, codeinfo, sptypes))
+            ftyp = argextype_widened(farg, codeinfo, sptypes)
             needs_type = !should_elide_type(fstmt, ftyp)
             needs_type && print(io, "(")
             print_value(io, codeinfo, farg, stable)
@@ -206,7 +206,7 @@ end
 function verify_print_stmt(io::IO, codeinfo::CodeInfo, sptypes::Vector{VarState}, stmtidx::Int)
     codeinfo.slotnames !== nothing && (io = IOContext(io, :SOURCE_SLOTNAMES => sourceinfo_slotnames(codeinfo)))
     stmt = unwrap_stmt(codeinfo, codeinfo.code[stmtidx])
-    typ = widenconst(argextype(SSAValue(stmtidx), codeinfo, sptypes))
+    typ = argextype_widened(SSAValue(stmtidx), codeinfo, sptypes)
     print_stmt_colored(io, codeinfo, sptypes, stmt)
     print(io, "::")
     print_type_colored(io, typ)
@@ -311,7 +311,7 @@ function verify_codeinstance!(interp::NativeInterpreter, codeinst::CodeInstance,
             # TODO: check for calls to Base.atexit?
         elseif isexpr(stmt, :call)
             farg = stmt.args[1]
-            ftyp = widenconst(argextype(farg, codeinfo, sptypes))
+            ftyp = argextype_widened(farg, codeinfo, sptypes)
             if ftyp <: IntrinsicFunction
                 #TODO: detect if f !== Core.Intrinsics.atomic_pointermodify (see statement_cost), otherwise error
                 continue
@@ -326,12 +326,12 @@ function verify_codeinstance!(interp::NativeInterpreter, codeinst::CodeInstance,
                         # args[1] is _apply_iterate object
                         # args[2] is invoke object
                         farg = stmt.args[3]
-                        ftyp = widenconst(argextype(farg, codeinfo, sptypes))
+                        ftyp = argextype_widened(farg, codeinfo, sptypes)
                         if may_dispatch(ftyp)
                             error = "unresolved call to function"
                         else
                             for i in 4:length(stmt.args)
-                                atyp = widenconst(argextype(stmt.args[i], codeinfo, sptypes))
+                                atyp = argextype_widened(stmt.args[i], codeinfo, sptypes)
                                 if !(atyp <: Union{SimpleVector, GenericMemory, Array, Tuple, NamedTuple})
                                     error = "unresolved argument to call"
                                     break


### PR DESCRIPTION


abstract_eval_globalref_type (used from argextype and slot2ssa) returned
an RTEffects-derived lattice element via abstract_eval_partition_load.
For defined-const bindings this allocated a Const wrapper on every call,
and the subsequent is_mutation_free_argtype query allocated a Type{T}
that was promptly discarded — both unused by IR-level callers.

Rename the helper to globalref_rt (it is not part of abstract eval) and
split out two specialized entry points: globalref_rt_widened, which
returns the widened type directly for callers that immediately widen
the result, and globalref_singleton, which extracts the singleton value
for is_known_call / is_known_invoke_or_call without boxing. Add a
matching argextype_widened that routes GlobalRefs through
globalref_rt_widened and falls through to widenconst(argextype(...))
otherwise, and update the widenconst(argextype(...)) call sites across
the optimizer to use it.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
