### PR TITLE
Base: avoid losing Method provenance in `@enum`

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -233,7 +233,7 @@ macro enum(T::Union{Symbol,Expr}, syms...)
     end
     push!(blk.args, :nothing)
     blk.head = :toplevel
-    return blk
+    return Base.replace_linenums!(blk, __source__)
 end
 
 end # module


### PR DESCRIPTION
Improves stacktraces and `methods(...)` queries for any Methods defined through @enum:

```julia
julia> @enum Fruit Apple=1 Banana=2
julia> methods(Fruit)
 [1] Fruit(x::Integer)
     @ REPL[6]:1
```

versus before:
```julia
julia> methods(Fruit)
 [1] Fruit(x::Integer)
     @ Enums.jl:211
```