### PR TITLE
Make `@nospecialize` work on underscore args

### DIFF
--- a/JuliaLowering/src/compat.jl
+++ b/JuliaLowering/src/compat.jl
@@ -381,7 +381,7 @@ function collect_body_arg_meta(st)
                 length(idents) == 0 && return meta
                 isnothing(out) && (out = Dict{String, Symbol}())
                 for id in idents
-                    kind(id) === K"Identifier" && (out[id.name_val] = meta)
+                    (kind(id) === K"Identifier" || kind(id) === K"Placeholder") && (out[id.name_val] = meta)
                 end
             end
             # Only leading meta statements are recognized in lowering.  Ideally

--- a/JuliaLowering/test/functions.jl
+++ b/JuliaLowering/test/functions.jl
@@ -588,6 +588,19 @@ end
         Core.@latestworld
         @test f(1, kw=2, a=3) == (1,:kw=>2,:a=>3)
         test_arg_specialized(f, 1)
+
+        # @nospecialize with underscore argument (Placeholder node handling)
+        JuliaLowering.include_string(test_mod, """
+        begin
+            function f_nospec_underscore(@nospecialize _)
+                1
+            end
+            f_nospec_underscore(1)
+            f_nospec_underscore("test")
+        end
+        """)
+        # One single method instance rather than an svec
+        @test only(methods(test_mod.f_nospec_underscore)).specializations isa Core.MethodInstance
     end
 end
 

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -322,7 +322,7 @@
 
 (define (arg-name v)
   (cond ((and (symbol? v) (valid-name? v))
-         v)
+         (if (underscore-symbol? v) (gensy) v))
         ((not (pair? v))
          (bad-formal-argument v))
         (else

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -161,6 +161,11 @@ end
 @test _nospec_with_default() == 2
 @test _nospec_with_default(10) == 20
 
+# @nospecialize with underscore argument (issue with placeholder nodes)
+_nospec_underscore(@nospecialize _) = 1
+@test _nospec_underscore(1) == 1
+@test _nospec_underscore("a") == 1
+@test only(methods(_nospec_underscore)).nospecialize == 1
 
 let oldout = stdout
     ex = Meta.@lower @dump x + y


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/61933

I implemented this as two separate commits to make it easier to backport just the femtolisp change.

With this PR:
```julia
julia> f(@nospecialize _) = 1
f (generic function with 1 method)

julia> f(1)
1

julia> f(nothing)
1

julia> f("hi")
1

julia> only(methods(f)).specializations
MethodInstance for f(::Any)
```