### PR TITLE
Profile: Restore previous snapshot behavior and add `max_generation` option

### DIFF
--- a/src/gc-heap-snapshot.c
+++ b/src/gc-heap-snapshot.c
@@ -181,14 +181,29 @@ typedef struct {
     size_t internal_root_idx; // node index of the internal root node
     size_t _gc_root_idx; // node index of the GC roots node
     size_t _gc_finlist_root_idx; // node index of the GC finlist roots node
-    size_t _gc_image_node_idx; // node index of the combined [image] node
+    size_t _gc_image_node_idx; // node index of the [image] frontier node (immortal -> old)
+    size_t _gc_remset_node_idx; // node index of the [remset] frontier node (old -> young)
 } HeapSnapshot;
+
+#define HEAP_SNAPSHOT_NODE_SKIP ((size_t)-1)
 
 // global heap snapshot, mutated by garbage collector
 // when snapshotting is on.
 int gc_heap_snapshot_enabled = 0;
+int gc_heap_snapshot_max_generation = JL_SNAPSHOT_GENERATION_IMMORTAL;
+int gc_heap_snapshot_recording = 0;
 int gc_heap_snapshot_redact_data = 0;
 static HeapSnapshot *g_snapshot = NULL;
+
+static inline int heap_generation_of(jl_value_t *a) JL_NOTSAFEPOINT
+{
+    uintptr_t tag = jl_astaggedvalue(a)->header;
+    if (tag & GC_IN_IMAGE)
+        return JL_SNAPSHOT_GENERATION_IMMORTAL;
+    if (tag & GC_OLD)
+        return JL_SNAPSHOT_GENERATION_OLD;
+    return JL_SNAPSHOT_GENERATION_YOUNG;
+}
 // mutex for gc-heap-snapshot.
 jl_mutex_t heapsnapshot_lock;
 
@@ -200,7 +215,7 @@ static void _add_synthetic_root_entries(HeapSnapshot *snapshot) JL_NOTSAFEPOINT;
 
 
 JL_DLLEXPORT void jl_gc_take_heap_snapshot(ios_t *nodes, ios_t *edges,
-    ios_t *strings, ios_t *json, char all_one, char redact_data)
+    ios_t *strings, ios_t *json, char all_one, char redact_data, char max_generation)
 {
     HeapSnapshot snapshot;
     memset(&snapshot, 0, sizeof(snapshot));
@@ -215,21 +230,35 @@ JL_DLLEXPORT void jl_gc_take_heap_snapshot(ios_t *nodes, ios_t *edges,
     snapshot._gc_root_idx = 1;
     snapshot._gc_finlist_root_idx = 2;
 
+    int generation = (int)max_generation;
+    if (generation < JL_SNAPSHOT_GENERATION_YOUNG || generation > JL_SNAPSHOT_GENERATION_IMMORTAL)
+        generation = JL_SNAPSHOT_GENERATION_IMMORTAL;
+
     jl_mutex_lock(&heapsnapshot_lock);
 
     // Enable snapshotting
     g_snapshot = &snapshot;
     gc_heap_snapshot_redact_data = redact_data;
+    gc_heap_snapshot_max_generation = generation;
     gc_heap_snapshot_enabled = 1;
 
     _add_synthetic_root_entries(&snapshot);
 
-    // Do a full GC mark (and incremental sweep), which will invoke our callbacks on `g_snapshot`
-    jl_gc_collect(JL_GC_FULL);
+    // All generations record during a full mark (which traces the whole heap);
+    // the requested generation is applied as a recording filter. `_jl_gc_collect`
+    // arms `gc_heap_snapshot_recording` for the full-mark pass (invoking our
+    // callbacks on `g_snapshot`) and clears `gc_heap_snapshot_enabled` once it has
+    // recorded. JL_GC_FULL guarantees a full mark, recollecting if the previous
+    // sweep was not full; we loop until the request has been serviced.
+    int guard = 0;
+    while (gc_heap_snapshot_enabled && guard++ < 4)
+        jl_gc_collect(JL_GC_FULL);
 
     // Disable snapshotting
     gc_heap_snapshot_enabled = 0;
+    gc_heap_snapshot_recording = 0;
     gc_heap_snapshot_redact_data = 0;
+    gc_heap_snapshot_max_generation = JL_SNAPSHOT_GENERATION_IMMORTAL;
     g_snapshot = NULL;
 
     jl_mutex_unlock(&heapsnapshot_lock);
@@ -273,14 +302,19 @@ static void serialize_edge(HeapSnapshot *snapshot, Edge edge) JL_NOTSAFEPOINT
 }
 
 // Helper to insert into the pointer->index map, returning existing index if present.
-// Returns 1 if newly inserted, 0 if already present. *out_index is set either way.
-static int snapshot_insert_node(HeapSnapshot *snapshot, void *ptr, size_t *out_index) JL_NOTSAFEPOINT
+// Returns 1 if newly inserted, 0 if already present, -1 if skipped because the
+// object is older than the requested generation. *out_index is set for 0 and 1.
+// `force` bypasses the generation filter; it must be set for non-GC-object nodes
+// (synthetic frontier/pointer/frame nodes) whose tag bits are not meaningful.
+static int snapshot_insert_node(HeapSnapshot *snapshot, void *ptr, size_t *out_index, int force) JL_NOTSAFEPOINT
 {
     void **bp = ptrhash_bp(&snapshot->node_ptr_to_index_map, ptr);
     if (*bp != HT_NOTFOUND) {
         *out_index = (size_t)*bp - (size_t)HT_NOTFOUND - 1;
         return 0; // already present
     }
+    if (!force && heap_generation_of((jl_value_t *)ptr) > gc_heap_snapshot_max_generation)
+        return -1; // newly seen, but outside the requested generation range
     size_t idx = snapshot->num_nodes;
     *bp = (void *)((size_t)HT_NOTFOUND + idx + 1);
     *out_index = idx;
@@ -341,36 +375,67 @@ static void _add_synthetic_root_entries(HeapSnapshot *snapshot) JL_NOTSAFEPOINT
     };
     serialize_edge(snapshot, root_to_gc_finlist_roots);
 
-    // Add a synthetic node representing all sysimage/pkgimage objects.
-    // Image objects are permanently marked and never traced by the GC mark
-    // phase, so we collapse them into a single node rather than recording
-    // their internal structure.
-    snapshot->_gc_image_node_idx = snapshot->num_nodes;
-    Node gc_image_node = {
-        (uint8_t)st_find_or_create(&snapshot->node_types, "synthetic"),
-        st_find_or_serialize(&snapshot->names, snapshot->strings, "[image]"), // name
-        snapshot->_gc_image_node_idx, // id
-        0, // size (image memory is not GC-managed)
+    // Add a synthetic node for the old -> young generational frontier. Old
+    // objects that reference young ones are tracked in the GC remset; when a
+    // young snapshot collapses the old generation, those remset entries are
+    // rooted here so the young objects they keep alive remain reachable.
+    snapshot->_gc_remset_node_idx = snapshot->num_nodes;
+    Node gc_remset_node = {
+        (uint32_t)st_find_or_create(&snapshot->node_types, "synthetic"),
+        st_find_or_serialize(&snapshot->names, snapshot->strings, "[remset]"), // name
+        snapshot->_gc_remset_node_idx, // id
+        0, // size
         0, // size_t trace_node_id (unused)
         0 // int detachedness;  // 0 - unknown,  1 - attached;  2 - detached
     };
-    serialize_node(snapshot, gc_image_node);
-    Edge root_to_image = {
-        (uint8_t)st_find_or_create(&snapshot->edge_types, "internal"),
-        st_find_or_serialize(&snapshot->names, snapshot->strings, "[image]"), // edge label
+    serialize_node(snapshot, gc_remset_node);
+    Edge root_to_remset = {
+        (uint32_t)st_find_or_create(&snapshot->edge_types, "internal"),
+        st_find_or_serialize(&snapshot->names, snapshot->strings, "[remset]"), // edge label
         snapshot->internal_root_idx, // from
-        snapshot->_gc_image_node_idx // to
+        snapshot->_gc_remset_node_idx // to
     };
-    serialize_edge(snapshot, root_to_image);
+    serialize_edge(snapshot, root_to_remset);
+
+    // Add a synthetic node for the immortal -> old generational frontier. When a
+    // snapshot collapses the sysimage/pkgimage ("permalloc") generation, the
+    // mutated image objects tracked in the image remset are rooted here. (A
+    // young snapshot collapses the old generation too, so this frontier is not
+    // meaningful there and is omitted.)
+    if (gc_heap_snapshot_max_generation != JL_SNAPSHOT_GENERATION_YOUNG) {
+        snapshot->_gc_image_node_idx = snapshot->num_nodes;
+        Node gc_image_node = {
+            (uint32_t)st_find_or_create(&snapshot->node_types, "synthetic"),
+            st_find_or_serialize(&snapshot->names, snapshot->strings, "[image]"), // name
+            snapshot->_gc_image_node_idx, // id
+            0, // size (image memory is not GC-managed)
+            0, // size_t trace_node_id (unused)
+            0 // int detachedness;  // 0 - unknown,  1 - attached;  2 - detached
+        };
+        serialize_node(snapshot, gc_image_node);
+        Edge root_to_image = {
+            (uint32_t)st_find_or_create(&snapshot->edge_types, "internal"),
+            st_find_or_serialize(&snapshot->names, snapshot->strings, "[image]"), // edge label
+            snapshot->internal_root_idx, // from
+            snapshot->_gc_image_node_idx // to
+        };
+        serialize_edge(snapshot, root_to_image);
+    }
 }
 
 // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L597-L597
-// returns the index of the new node
-size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
+// returns the index of the new node, or HEAP_SNAPSHOT_NODE_SKIP if `a` is older
+// than the requested generation (callers must propagate the sentinel). When
+// `force` is set the object is recorded regardless of generation, used to root
+// the remset frontier entries that describe a collapsed older generation.
+static size_t record_node_to_gc_snapshot_(jl_value_t *a, int force) JL_NOTSAFEPOINT
 {
     size_t idx;
-    if (!snapshot_insert_node(g_snapshot, a, &idx))
+    int inserted = snapshot_insert_node(g_snapshot, a, &idx, force);
+    if (inserted == 0)
         return idx;
+    if (inserted < 0)
+        return HEAP_SNAPSHOT_NODE_SKIP;
 
     ios_t str_;
     int ios_need_close = 0;
@@ -465,25 +530,66 @@ size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
     if (ios_need_close)
         ios_close(&str_);
 
-    // Image objects are permanently marked and never traced by the GC mark
-    // phase, so they would otherwise appear as orphan nodes. Root them under
-    // the synthetic [image] node with a label indicating which image they belong to.
-    if (jl_astaggedvalue(a)->bits.in_image) {
-        jl_value_t *top_mod = jl_object_top_module(a);
-        const char *label = "[image]";
-        if (top_mod != (jl_value_t*)jl_nothing && jl_is_module((jl_module_t*)top_mod))
-            label = jl_symbol_name_(((jl_module_t*)top_mod)->name);
-        _record_gc_just_edge("internal", g_snapshot->_gc_image_node_idx, idx,
-                             st_find_or_serialize(&g_snapshot->names, g_snapshot->strings, label));
-    }
-
     return idx;
+}
+
+size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
+{
+    return record_node_to_gc_snapshot_(a, /*force=*/0);
+}
+
+// Root `entry` (an old object referencing a younger one) under the synthetic
+// `[remset]` node. The entry is force-recorded so the old -> young frontier is
+// visible even when the old generation is otherwise collapsed; its own
+// out-edges are recorded normally and filtered to the requested generation.
+void _gc_heap_snapshot_record_remset_entry(jl_value_t *entry) JL_NOTSAFEPOINT
+{
+    size_t idx = record_node_to_gc_snapshot_(entry, /*force=*/1);
+    _record_gc_just_edge("internal", g_snapshot->_gc_remset_node_idx, idx,
+                         st_find_or_serialize(&g_snapshot->names, g_snapshot->strings, "[remset]"));
+}
+
+// Root `entry` (a mutated image object referencing a younger one) under the
+// synthetic `[image]` node, labelled with the image it belongs to. As above,
+// the entry is force-recorded to surface the immortal -> old frontier.
+void _gc_heap_snapshot_record_image_remset_entry(jl_value_t *entry) JL_NOTSAFEPOINT
+{
+    // A young snapshot collapses the old generation too, so the immortal -> old
+    // frontier is not meaningful and the `[image]` node is not even created.
+    if (gc_heap_snapshot_max_generation == JL_SNAPSHOT_GENERATION_YOUNG)
+        return;
+    size_t idx = record_node_to_gc_snapshot_(entry, /*force=*/1);
+    jl_value_t *top_mod = jl_object_top_module(entry);
+    const char *label = "[image]";
+    if (top_mod != (jl_value_t*)jl_nothing && jl_is_module((jl_module_t*)top_mod))
+        label = jl_symbol_name_(((jl_module_t*)top_mod)->name);
+    _record_gc_just_edge("internal", g_snapshot->_gc_image_node_idx, idx,
+                         st_find_or_serialize(&g_snapshot->names, g_snapshot->strings, label));
+}
+
+// Consulted by the mark loop (only while recording an `:immortal` snapshot) when
+// it reaches an already-marked image object. Returns 1 the first time a given
+// image object is seen so the mark loop descends into it, and 0 thereafter.
+// Dedup relies on the snapshot node map; marking is single-threaded while a
+// snapshot is being recorded, so no synchronization is needed and GC tag bits
+// are never touched.
+int _gc_heap_snapshot_try_claim_image(jl_value_t *a) JL_NOTSAFEPOINT
+{
+    // Descend into `a` only the first time we see it. Recording its node now
+    // (rather than waiting for the edge that points at it) inserts it into the
+    // node map immediately, so any other reference to `a` -- and thus any repeat
+    // call here -- short-circuits, guaranteeing each image object is traversed at
+    // most once. Marking is single-threaded while recording, so this is race-free.
+    if (ptrhash_get(&g_snapshot->node_ptr_to_index_map, a) != HT_NOTFOUND)
+        return 0;
+    record_node_to_gc_snapshot_(a, /*force=*/0);
+    return 1;
 }
 
 static size_t record_pointer_to_gc_snapshot(void *a, size_t bytes, const char *name) JL_NOTSAFEPOINT
 {
     size_t idx;
-    if (!snapshot_insert_node(g_snapshot, a, &idx))
+    if (!snapshot_insert_node(g_snapshot, a, &idx, /*force=*/1))
         return idx;
 
     Node node = {
@@ -559,7 +665,7 @@ void _gc_heap_snapshot_record_finlist(jl_value_t *obj, size_t index) JL_NOTSAFEP
 size_t _record_stack_frame_node(HeapSnapshot *snapshot, void *frame) JL_NOTSAFEPOINT
 {
     size_t idx;
-    if (!snapshot_insert_node(g_snapshot, frame, &idx))
+    if (!snapshot_insert_node(g_snapshot, frame, &idx, /*force=*/1))
         return idx;
 
     Node node = {
@@ -667,6 +773,10 @@ static inline void _record_gc_edge(const char *edge_type, jl_value_t *a,
 
 static void _record_gc_just_edge(const char *edge_type, size_t from_idx, size_t to_idx, size_t name_or_idx) JL_NOTSAFEPOINT
 {
+    // Drop edges to/from objects that were filtered out of this snapshot's
+    // generation range (see `record_node_to_gc_snapshot`).
+    if (from_idx == HEAP_SNAPSHOT_NODE_SKIP || to_idx == HEAP_SNAPSHOT_NODE_SKIP)
+        return;
     Edge edge = {
         (uint32_t)st_find_or_create(&g_snapshot->edge_types, edge_type),
         name_or_idx, // edge label

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -10,6 +10,11 @@
 extern "C" {
 #endif
 
+typedef enum {
+    JL_SNAPSHOT_GENERATION_YOUNG    = 0,
+    JL_SNAPSHOT_GENERATION_OLD      = 1,
+    JL_SNAPSHOT_GENERATION_IMMORTAL = 2,
+} jl_gc_snapshot_generation_t;
 
 // ---------------------------------------------------------------------
 // Functions to call from GC when heap snapshot is enabled
@@ -34,9 +39,24 @@ void _gc_heap_snapshot_record_gc_roots(jl_value_t *root, char *name) JL_NOTSAFEP
 void _gc_heap_snapshot_record_finlist(jl_value_t *finlist, size_t index) JL_NOTSAFEPOINT;
 // Used for objects reachable from the binding partition pointer union
 void _gc_heap_snapshot_record_binding_partition_edge(jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT;
+// Records an old-generation remset entry under the synthetic `[remset]` node
+// (the old -> young generational frontier).
+void _gc_heap_snapshot_record_remset_entry(jl_value_t *entry) JL_NOTSAFEPOINT;
+// Records an image remset entry under the synthetic `[image]` node
+// (the immortal -> old generational frontier).
+void _gc_heap_snapshot_record_image_remset_entry(jl_value_t *entry) JL_NOTSAFEPOINT;
+// Returns non-zero if `a` (an already-marked image object) has not yet been seen
+// by the in-progress snapshot, so the mark loop should descend into it. Only
+// consulted while recording an `:immortal` snapshot; never mutates GC state.
+int _gc_heap_snapshot_try_claim_image(jl_value_t *a) JL_NOTSAFEPOINT;
 
+// Set for the whole duration of a `jl_gc_take_heap_snapshot` call.
 extern int gc_heap_snapshot_enabled;
-extern int prev_sweep_full;
+// The requested `jl_gc_snapshot_generation_t` for the in-progress snapshot.
+extern int gc_heap_snapshot_max_generation;
+// Set by the GC for exactly the one mark pass whose depth matches the requested
+// generation; all of the recording hooks below gate on this.
+extern int gc_heap_snapshot_recording;
 extern jl_mutex_t heapsnapshot_lock;
 
 int gc_slot_to_fieldidx(void *_obj, void *slot, jl_datatype_t *vt) JL_NOTSAFEPOINT;
@@ -44,85 +64,85 @@ int gc_slot_to_arrayidx(void *_obj, void *begin) JL_NOTSAFEPOINT;
 
 static inline void gc_heap_snapshot_record_frame_to_object_edge(void *from, jl_value_t *to) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
+    if (__unlikely(gc_heap_snapshot_recording)) {
         _gc_heap_snapshot_record_frame_to_object_edge(from, to);
     }
 }
 static inline void gc_heap_snapshot_record_task_to_frame_edge(jl_task_t *from, void *to) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
+    if (__unlikely(gc_heap_snapshot_recording)) {
         _gc_heap_snapshot_record_task_to_frame_edge(from, to);
     }
 }
 static inline void gc_heap_snapshot_record_frame_to_frame_edge(jl_gcframe_t *from, jl_gcframe_t *to) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
+    if (__unlikely(gc_heap_snapshot_recording)) {
         _gc_heap_snapshot_record_frame_to_frame_edge(from, to);
     }
 }
 static inline void gc_heap_snapshot_record_root(jl_value_t *root, char *name) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
+    if (__unlikely(gc_heap_snapshot_recording)) {
         _gc_heap_snapshot_record_root(root, name);
     }
 }
 static inline void gc_heap_snapshot_record_array_edge_index(jl_value_t *from, jl_value_t *to, size_t index) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full && from != NULL && to != NULL)) {
+    if (__unlikely(gc_heap_snapshot_recording && from != NULL && to != NULL)) {
         _gc_heap_snapshot_record_array_edge(from, to, index);
     }
 }
 static inline void gc_heap_snapshot_record_array_edge(jl_value_t *from, jl_value_t **to) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
+    if (__unlikely(gc_heap_snapshot_recording)) {
         _gc_heap_snapshot_record_array_edge(from, *to, gc_slot_to_arrayidx(from, to));
     }
 }
 static inline void gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t **to) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
+    if (__unlikely(gc_heap_snapshot_recording)) {
         _gc_heap_snapshot_record_object_edge(from, *to, to);
     }
 }
 
 static inline void gc_heap_snapshot_record_module_to_binding(jl_module_t* module, jl_value_t *bindings, jl_value_t *bindingkeyset) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full) && bindings != NULL && bindingkeyset != NULL) {
+    if (__unlikely(gc_heap_snapshot_recording) && bindings != NULL && bindingkeyset != NULL) {
         _gc_heap_snapshot_record_module_to_binding(module, bindings, bindingkeyset);
     }
 }
 
 static inline void gc_heap_snapshot_record_internal_array_edge(jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
+    if (__unlikely(gc_heap_snapshot_recording)) {
         _gc_heap_snapshot_record_internal_array_edge(from, to);
     }
 }
 
 static inline void gc_heap_snapshot_record_binding_partition_edge(jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
+    if (__unlikely(gc_heap_snapshot_recording)) {
         _gc_heap_snapshot_record_binding_partition_edge(from, to);
     }
 }
 
 static inline void gc_heap_snapshot_record_foreign_memory_edge(jl_value_t *from, void* to, size_t bytes) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
+    if (__unlikely(gc_heap_snapshot_recording)) {
         _gc_heap_snapshot_record_foreign_memory_edge(from, to, bytes);
     }
 }
 
 static inline void gc_heap_snapshot_record_gc_roots(jl_value_t *root, char *name) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full && root != NULL)) {
+    if (__unlikely(gc_heap_snapshot_recording && root != NULL)) {
         _gc_heap_snapshot_record_gc_roots(root, name);
     }
 }
 
 static inline void gc_heap_snapshot_record_finlist(jl_value_t *finlist, size_t index) JL_NOTSAFEPOINT
 {
-    if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full && finlist != NULL)) {
+    if (__unlikely(gc_heap_snapshot_recording && finlist != NULL)) {
         _gc_heap_snapshot_record_finlist(finlist, index);
     }
 }
@@ -131,7 +151,7 @@ static inline void gc_heap_snapshot_record_finlist(jl_value_t *finlist, size_t i
 // Functions to call from Julia to take heap snapshot
 // ---------------------------------------------------------------------
 JL_DLLEXPORT void jl_gc_take_heap_snapshot(ios_t *nodes, ios_t *edges,
-    ios_t *strings, ios_t *json, char all_one, char redact_data);
+    ios_t *strings, ios_t *json, char all_one, char redact_data, char max_generation);
 
 
 #ifdef __cplusplus

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -209,6 +209,7 @@ int current_sweep_full = 0;
 int next_sweep_full = 0;
 int under_pressure = 0;
 int gc_disable_auto_full_sweep = 0; // when set, automatic full collections are inhibited
+int gc_mark_image_subgraph = 0;
 
 // Full collection heuristics
 static int64_t live_bytes = 0;
@@ -243,8 +244,11 @@ FORCE_INLINE int gc_try_setmark_tag(jl_taggedvalue_t *o, uint8_t mark_mode) JL_N
 {
     assert(gc_marked(mark_mode));
     uintptr_t tag = o->header;
-    if (gc_marked(tag))
+    if (gc_marked(tag)) {
+        if (__unlikely(gc_mark_image_subgraph) && (tag & GC_IN_IMAGE))
+            return _gc_heap_snapshot_try_claim_image(jl_valueof(o));
         return 0;
+    }
     if (mark_reset_age) {
         // Reset the object as if it was just allocated
         mark_mode = GC_MARKED;
@@ -1614,6 +1618,12 @@ STATIC_INLINE void gc_assert_parent_validity(jl_value_t *parent, jl_value_t *chi
 STATIC_INLINE void gc_mark_push_remset(jl_ptls_t ptls, jl_value_t *obj,
                                        uintptr_t nptr) JL_NOTSAFEPOINT
 {
+    // While descending into the image subgraph for an `:immortal` snapshot we
+    // trace permanently-marked image objects that the GC normally never visits.
+    // Their writes are tracked separately (the image_remset), so they must not
+    // be added to the regular young remset here.
+    if (__unlikely(gc_mark_image_subgraph) && jl_astaggedvalue(obj)->bits.in_image)
+        return;
     if (__unlikely((nptr & 0x3) == 0x3)) {
         ptls->gc_tls.heap.remset_nptr += nptr >> 2;
         arraylist_t *remset = &ptls->gc_tls.heap.remset;
@@ -2830,6 +2840,9 @@ static void gc_queue_remset(jl_gc_markqueue_t *mq, jl_ptls_t ptls2) JL_NOTSAFEPO
     for (size_t i = 0; i < len; i++) {
         void *_v = items[i];
         jl_astaggedvalue(_v)->bits.gc = GC_OLD_MARKED;
+        // Surface the old -> young frontier under the synthetic `[remset]` node.
+        if (__unlikely(gc_heap_snapshot_recording))
+            _gc_heap_snapshot_record_remset_entry((jl_value_t *)_v);
         jl_value_t *v = (jl_value_t *)((uintptr_t)_v | GC_REMSET_PTR_TAG);
         gc_ptr_queue_push(mq, v);
     }
@@ -2844,6 +2857,9 @@ static void gc_queue_image_remset(jl_gc_markqueue_t *mq) JL_NOTSAFEPOINT
     void **items = image_remset.items;
     for (size_t i = 0; i < len; i++) {
         void *_v = items[i];
+        // Surface the immortal -> old frontier under the synthetic `[image]` node.
+        if (__unlikely(gc_heap_snapshot_recording))
+            _gc_heap_snapshot_record_image_remset_entry((jl_value_t *)_v);
         jl_value_t *v = (jl_value_t *)((uintptr_t)_v | GC_REMSET_PTR_TAG);
         gc_ptr_queue_push(mq, v);
     }
@@ -3087,6 +3103,15 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
     uint64_t before_free_heap_size = jl_atomic_load_relaxed(&gc_heap_stats.heap_size);
     uint64_t start_mark_time = jl_hrtime();
     JL_PROBE_GC_MARK_BEGIN();
+    if (__unlikely(gc_heap_snapshot_enabled)) {
+        gc_heap_snapshot_recording = prev_sweep_full;
+        gc_mark_image_subgraph = gc_heap_snapshot_recording &&
+            (gc_heap_snapshot_max_generation == JL_SNAPSHOT_GENERATION_IMMORTAL);
+    }
+    else {
+        gc_heap_snapshot_recording = 0;
+        gc_mark_image_subgraph = 0;
+    }
     {
         JL_TIMING(GC, GC_Mark);
         assert(gc_n_threads != 0);
@@ -3168,6 +3193,11 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
         gc_mark_finlist(mq, &to_finalize, 0);
         gc_mark_and_steal(ptls);
         mark_reset_age = 0;
+    }
+
+    if (__unlikely(gc_heap_snapshot_recording)) {
+        gc_heap_snapshot_enabled = 0;
+        gc_mark_image_subgraph = 0;
     }
 
     JL_PROBE_GC_MARK_END(scanned_bytes, perm_scanned_bytes);

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1374,9 +1374,11 @@ end
 
 """
     Profile.take_heap_snapshot(filepath::String, all_one::Bool=false;
-                               redact_data::Bool=true, streaming::Bool=false)
+                               redact_data::Bool=true, streaming::Bool=false,
+                               max_generation::Symbol=:immortal)
     Profile.take_heap_snapshot(all_one::Bool=false; redact_data:Bool=true,
-                               dir::String=nothing, streaming::Bool=false)
+                               dir::String=nothing, streaming::Bool=false,
+                               max_generation::Symbol=:immortal)
 
 Write a snapshot of the heap, in the JSON format expected by the Chrome
 Devtools Heap Snapshot viewer (.heapsnapshot extension) to a file
@@ -1388,6 +1390,14 @@ If `all_one` is true, then report the size of every object as one so they can be
 counted. Otherwise, report the actual size.
 
 If `redact_data` is true (default), then do not emit the contents of any object.
+
+`max_generation` controls how much of the generational heap is recorded:
+- `:young` records only young-generation objects, with old objects that reference them
+  collapsed into a synthetic `[remset]` node.
+- `:old` additionally records old-generation objects, with sysimage/pkgimage objects
+  collapsed into a synthetic `[image]` node.
+- `:immortal` (the default) additionally records the sysimage/pkgimage ("permalloc")
+  objects, i.e. the entire heap.
 
 If `streaming` is true, we will stream the snapshot data out into four files, using filepath
 as the prefix, to avoid having to hold the entire snapshot in memory. This option should be
@@ -1404,28 +1414,36 @@ backwards-compatibility) and your process is killed, note that this will always 
 parts in the same directory as your provided filepath, so you can still reconstruct the
 snapshot after the fact, via `assemble_snapshot()`.
 """
-function take_heap_snapshot(filepath::AbstractString, all_one::Bool=false; redact_data::Bool=true, streaming::Bool=false)
+function take_heap_snapshot(filepath::AbstractString, all_one::Bool=false; redact_data::Bool=true, streaming::Bool=false, max_generation::Symbol=:immortal)
     if streaming
-        _stream_heap_snapshot(filepath, all_one, redact_data)
+        _stream_heap_snapshot(filepath, all_one, redact_data, max_generation)
     else
         # Support the legacy, non-streaming mode, by first streaming the parts, then
         # reassembling it after we're done.
         prefix = filepath
-        _stream_heap_snapshot(prefix, all_one, redact_data)
+        _stream_heap_snapshot(prefix, all_one, redact_data, max_generation)
         Profile.HeapSnapshot.assemble_snapshot(prefix, filepath)
         Profile.HeapSnapshot.cleanup_streamed_files(prefix)
     end
     return filepath
 end
-function take_heap_snapshot(io::IO, all_one::Bool=false; redact_data::Bool=true)
+function take_heap_snapshot(io::IO, all_one::Bool=false; redact_data::Bool=true, max_generation::Symbol=:immortal)
     # Support the legacy, non-streaming mode, by first streaming the parts to a tempdir,
     # then reassembling it after we're done.
     dir = tempdir()
     prefix = joinpath(dir, "snapshot")
-    _stream_heap_snapshot(prefix, all_one, redact_data)
+    _stream_heap_snapshot(prefix, all_one, redact_data, max_generation)
     Profile.HeapSnapshot.assemble_snapshot(prefix, io)
 end
-function _stream_heap_snapshot(prefix::AbstractString, all_one::Bool, redact_data::Bool)
+# Map the `max_generation` symbol to the integer the runtime expects (youngest to oldest)
+function _max_generation_to_int(max_generation::Symbol)
+    max_generation === :young && return Cchar(0)
+    max_generation === :old && return Cchar(1)
+    max_generation === :immortal && return Cchar(2)
+    throw(ArgumentError("max_generation must be one of :young, :old, or :immortal, got :$(max_generation)"))
+end
+function _stream_heap_snapshot(prefix::AbstractString, all_one::Bool, redact_data::Bool, max_generation::Symbol=:immortal)
+    max_gen = _max_generation_to_int(max_generation)
     # Nodes and edges are binary files
     open("$prefix.nodes", "w") do nodes
         open("$prefix.edges", "w") do edges
@@ -1438,9 +1456,9 @@ function _stream_heap_snapshot(prefix::AbstractString, all_one::Bool, redact_dat
                     Base.@_lock_ios(json,
                         ccall(:jl_gc_take_heap_snapshot,
                             Cvoid,
-                            (Ptr{Cvoid},Ptr{Cvoid},Ptr{Cvoid},Ptr{Cvoid}, Cchar, Cchar),
+                            (Ptr{Cvoid},Ptr{Cvoid},Ptr{Cvoid},Ptr{Cvoid}, Cchar, Cchar, Cchar),
                             nodes.handle, edges.handle, strings.handle, json.handle,
-                            Cchar(all_one), Cchar(redact_data))
+                            Cchar(all_one), Cchar(redact_data), max_gen)
                     )
                     )
                     )

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -423,6 +423,32 @@ end
     @test !contains(sshot, "redact_this")
 
     rm(fname)
+
+    # `max_generation` controls how much of the generational heap is recorded:
+    # `:young` ⊆ `:old` ⊆ `:immortal`, with synthetic frontier nodes marking the
+    # boundaries of each collapsed older generation.
+    node_count(s) = parse(Int, match(r"\"node_count\":(\d+)", s).captures[1])
+    function snapshot_with(gen)
+        fpath = joinpath(tmpdir, "snap_$(gen).heapsnapshot")
+        Profile.take_heap_snapshot(fpath; max_generation=gen)
+        s = read(fpath, String)
+        rm(fpath; force=true)
+        return s
+    end
+    young = snapshot_with(:young)
+    old = snapshot_with(:old)
+    immortal = snapshot_with(:immortal)
+    # The `[remset]` (old -> young) frontier is present in every mode; the
+    # `[image]` (immortal -> old) frontier only once the old generation is recorded.
+    @test contains(young, "[remset]") && !contains(young, "[image]")
+    @test contains(old, "[remset]") && contains(old, "[image]")
+    @test contains(immortal, "[remset]") && contains(immortal, "[image]")
+    # Recording an older generation is strictly additive; the sysimage dominates
+    # the immortal generation, so it adds many nodes over `:old`.
+    @test node_count(young) <= node_count(old) < node_count(immortal)
+    # Unknown generations are rejected.
+    @test_throws ArgumentError Profile.take_heap_snapshot(joinpath(tmpdir, "bad.heapsnapshot"); max_generation=:bogus)
+
     rm(tmpdir, force = true, recursive = true)
 end
 end


### PR DESCRIPTION
As requested by @vtjnash in https://github.com/JuliaLang/julia/pull/61474#issuecomment-4547854085.

I think this change should make both of us happy. This preserves the "report all reachable objects" behavior of the heap snapshot (now behind `max_generation = :immortal`, the default), while still allowing filtering by the "GC-relevant" objects (via `max_generation = :old / :young`). We may also want the filtered options to record "dead" edges into a collapsed older generation, so that `[image]` and `[remset]` nodes are a target and not just a source, which should reduce the sense of "missing data" in the filtered snapshots.

Draft for now. Still needs clean-up and human review. The `if (__unlikely(...))` in the GC remset loops in particular might need manual loop unswitching (hopefully not), and I need to inspect the output heap snapshots to check that they have all the expected contents now.

Developed largely by Claude 🤖 after planning together.

#### Backport
1.13 will probably require a pared down version of these changes to restore previous snapshot behavior
(probably just the `gc_mark_image_subgraph` changes to the GC)