### PR TITLE
debuginfo: Handle LineNumberNode with `file=nothing`

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -481,6 +481,7 @@ static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, jl_module_t *m
             JL_GC_PUSH3(&file, &linenum, &inlinedat);
             value_t lst = e;
             file = scm_to_julia_(fl_ctx, car_(lst), mod);
+            assert(jl_is_symbol(file));
             lst = cdr_(lst);
             linenum = scm_to_julia_(fl_ctx, car_(lst), mod);
             lst = cdr_(lst);

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1575,9 +1575,6 @@ JL_DLLEXPORT const char *jl_cdi_file(jl_debuginfo_t *di) JL_NOTSAFEPOINT
         jl_value_t *m = ((jl_method_instance_t *)di->def)->def.value;
         assert(jl_is_method(m) && "unimplemented");
         return jl_symbol_name(((jl_method_t*)m)->file);
-    } else if (jl_is_nothing(di->def)) {
-        // reachable when linenumbernode.file is nothing (through method.c)
-        return "<unknown>";
     } else {
         assert(0 && "unexpected type for debuginfo.def");
         return "<unknown>";

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -5561,8 +5561,9 @@ f(x) = yt(x)
              (list ,@(cadr vi)) ,(caddr vi) (list ,@(cadddr vi)))
        ,@(cdddr lam))))
 
+;; LineNumberNode may have file=nothing, but LegacyLineInfoNode may not
 (define (make-lineinfo file line (inlined-at #f))
-  `(lineinfo ,file ,line ,(or inlined-at 0)))
+  `(lineinfo ,(if (nothing? file) 'none file) ,line ,(or inlined-at 0)))
 
 (define (set-lineno! lineinfo num)
   (set-car! (cddr lineinfo) num))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -789,6 +789,17 @@ end"""))
     @test !any(x->(x == Expr(:meta, :push_loc, :none)), ex.args)
 end
 
+# LineNumberNode with file=nothing
+let ex = Expr(:toplevel,
+              LineNumberNode(1),
+              Expr(:->, Expr(:tuple),
+                   Expr(:block,
+                        LineNumberNode(2),
+                        Expr(:call, throw, 1))))
+    f = Core.eval(@__MODULE__, ex)
+    @test only(methods(f)).debuginfo.def isa Symbol
+end
+
 # Check qualified string macros
 Base.r"regex" == r"regex"
 


### PR DESCRIPTION
We currently assume `file` is a symbol when converting to `LegacyLineInfoNode`, which is then passed to
     the `DebugInfo` constructor giving us `def=nothing` out of nowhere.  This
     change cleans this up slightly.

Disallowing `file=nothing` in LineNumberNode (or aggressively converting to
     empty Symbol) might be a nicer way of doing things in the future.