### PR TITLE
Fix `none:-1` stack frame from generator/comprehension expressions

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2150,7 +2150,7 @@
                          `(let (block ,@(map (lambda (v) `(= ,v ,v)) (filter-not-underscore outervars)))
                             ,expr))
                         (else expr))))
-        `(-> ,argname (block ,@splat ,expr)))))))
+        `(-> ,argname (block ,*current-desugar-loc* ,@splat ,expr)))))))
 
 (define (expand-generator e flat outervars)
   (let* ((expr  (cadr e))

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -256,6 +256,32 @@ struct F49231{a,b,c,d,e,f,g} end
     @test contains(str, "[2] \e[0m\e[1m(::$F49231{Vector, Val{…}, Vector{…}, NTuple{…}, $Int, $Int, $Int})\e[22m\e[0m\e[1m(\e[22m\e[90ma\e[39m::\e[0m$Int, \e[90mb\e[39m::\e[0m$Int, \e[90mc\e[39m::\e[0m$Int\e[0m\e[1m)\e[22m\n")
 end
 
+# 33457: generator/comprehension lambda should, at the very least, not surface a
+# nonsense frame
+let st = nothing
+    try
+        [undef_var for _ in 1:10]
+    catch _
+        st = stacktrace(catch_backtrace())
+    end
+    @testset for frame in st
+        @test frame.line > 0
+        @test frame.file != :none
+    end
+end
+
+let st = nothing
+    try
+        collect(undef_var for _ in 1:10)
+    catch _
+        st = stacktrace(catch_backtrace())
+    end
+    @testset for frame in st
+        @test frame.line > 0
+        @test frame.file != :none
+    end
+end
+
 @testset "Base.StackTraces docstrings" begin
     @test isempty(Docs.undocumented_names(StackTraces))
 end


### PR DESCRIPTION
Fix #33457.  Nightly:

```
julia> begin
       # line 2
       [y for _ in 1:10]
       # line 4
       end
ERROR: UndefVarError: `y` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
Stacktrace:
 [1] #2
   @ ./none:-1 [inlined]
 [2] iterate
   @ ./generator.jl:48 [inlined]
 [3] collect(itr::Base.Generator{UnitRange{Int64}, var"#2#3"})
   @ Base ./array.jl:833
 [4] top-level scope
   @ REPL[1]:3
```

This change:
```
ERROR: UndefVarError: `y` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
Stacktrace:
 [1] #12
   @ ./REPL[1]:3 [inlined]
 [2] iterate
   @ ./generator.jl:48 [inlined]
 [3] collect(itr::Base.Generator{UnitRange{Int64}, var"#12#13"})
   @ Base ./array.jl:833
 [4] top-level scope
   @ REPL[1]:3
```

As a sneak peek, this is further improved with #61699:
```
ERROR: UndefVarError: `y` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
Stacktrace:
 [1] (::var"#12#13")(::Int64)
   @ Main REPL[1]:3 [inlined]
 [2] iterate(::Base.Generator{UnitRange{Int64}, var"#12#13"})
   @ Base generator.jl:48 [inlined]
 [3] collect(itr::Base.Generator{UnitRange{Int64}, var"#12#13"})
   @ Base array.jl:833
 [4] top-level scope
   @ REPL[1]:3
```


I doubt this frame is important (it being a lambda is considered an
implementation detail IIRC) but (1) we shouldn't show users a nonsense frame,
and (2) this fixes another case where we produce malformed DebugInfo.
