### PR TITLE
subtype: Keep precise track of subtype meets

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2637,6 +2637,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("TypeVar", (jl_value_t*)jl_tvar_type);
     add_builtin("UnionAll", (jl_value_t*)jl_unionall_type);
     add_builtin("Union", (jl_value_t*)jl_uniontype_type);
+    add_builtin("Intersect", (jl_value_t*)jl_intersect_type);
     add_builtin("TypeofBottom", (jl_value_t*)jl_typeofbottom_type);
     add_builtin("Tuple", (jl_value_t*)jl_anytuple_type);
     add_builtin("TypeofVararg", (jl_value_t*)jl_vararg_type);

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -64,6 +64,7 @@
     XX(inter_must_alias_type, jl_datatype_t*) \
     XX(interconditional_type, jl_datatype_t*) \
     XX(interrupt_exception, jl_value_t*) \
+    XX(intersect_type, jl_datatype_t*) \
     XX(intrinsic_type, jl_datatype_t*) \
     XX(kwcall_type, jl_datatype_t*) \
     XX(lineinfonode_type, jl_datatype_t*) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -912,19 +912,27 @@ jl_value_t *simple_intersect(jl_value_t *a, jl_value_t *b, int overesi)
         JL_GC_POP();
         return jl_bottom_type;
     }
-    if (!subs[0] && !subs[1]) {
+    if (!subs[0] && !subs[1] && overesi == 1) {
         // Neither operand subsumes the other and they are not disjoint, so the
-        // meet is not expressible as a single existing type. On the subtype
-        // path (overesi=1; the only path that reaches here, since overesi=0
-        // returned `Union{}` above) return it exactly as an internal
-        // `Intersect{a, b}` node rather than over-approximating to one side's
-        // components, which would silently drop the other side. See #61917.
+        // meet is not expressible as a single existing type. With `overesi==1`
+        // (exact-meet mode, used on the subtype path) keep it as an internal
+        // `Intersect{a, b}` node rather than over-approximating to one side,
+        // which would silently drop the other. `overesi==2` falls through to
+        // the legacy over-approximation below (used to widen an `Intersect`
+        // before it could escape into a static parameter). See #61917.
         JL_GC_POP();
         return jl_new_struct(jl_intersect_type, a, b);
     }
-    nt = subs[0] ? nta : nt;
-    i  = subs[0] ? 0   : nta;
+    nt = subs[0] ? nta : subs[1] ? nt  : nt;
+    i  = subs[0] ? 0   : subs[1] ? nta : 0;
     count = nt - i;
+    if (!subs[0] && !subs[1]) {
+        // over-approximate (`overesi==2`): keep only `a` components with strict
+        // `<:` and all of `b`, then union them.
+        for (j = 0; j < nt; j++)
+            if (stemp[j] < (j < nta ? 2 : 0))
+                temp[j] = NULL;
+    }
     isort_union(&temp[i], count);
     temp[nt] = jl_bottom_type;
     size_t k;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -96,7 +96,7 @@ static int layout_uses_free_typevars(jl_value_t *v, jl_typeenv_t *env)
             }
             return 0;
         }
-        else if (jl_is_uniontype(v)) {
+        else if (jl_is_uniontype(v) || jl_is_intersecttype(v)) {
             if (layout_uses_free_typevars(((jl_uniontype_t*)v)->a, env))
                 return 1;
            v = ((jl_uniontype_t*)v)->b;
@@ -147,7 +147,7 @@ static int has_free_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT
             }
             return 0;
         }
-        else if (jl_is_uniontype(v)) {
+        else if (jl_is_uniontype(v) || jl_is_intersecttype(v)) {
             if (has_free_typevars(((jl_uniontype_t*)v)->a, env))
                 return 1;
            v = ((jl_uniontype_t*)v)->b;
@@ -215,7 +215,7 @@ static void find_free_typevars(jl_value_t *v, jl_typeenv_t *env, jl_array_t *out
                 find_free_typevars(jl_tparam(v, i), env, out);
             return;
         }
-        else if (jl_is_uniontype(v)) {
+        else if (jl_is_uniontype(v) || jl_is_intersecttype(v)) {
             find_free_typevars(((jl_uniontype_t*)v)->a, env, out);
             v = ((jl_uniontype_t*)v)->b;
         }
@@ -284,7 +284,7 @@ int jl_has_bound_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT
             }
             return 0;
         }
-        else if (jl_is_uniontype(v)) {
+        else if (jl_is_uniontype(v) || jl_is_intersecttype(v)) {
             if (jl_has_bound_typevars(((jl_uniontype_t*)v)->a, env))
                 return 1;
            v = ((jl_uniontype_t*)v)->b;
@@ -683,7 +683,9 @@ JL_DLLEXPORT jl_value_t *jl_type_union(jl_value_t **ts, size_t n)
     size_t i;
     for (i = 0; i < n; i++) {
         jl_value_t *pi = ts[i];
-        if (!(jl_is_type(pi) || jl_is_typevar(pi)))
+        // reject the internal `Intersect` meet node (see #61917): it must not
+        // be embedded into a user-visible `Union`.
+        if (!(jl_is_type(pi) || jl_is_typevar(pi)) || jl_is_intersecttype(pi))
             jl_type_error("Union", (jl_value_t*)jl_type_type, pi);
     }
     if (n == 1)
@@ -910,17 +912,19 @@ jl_value_t *simple_intersect(jl_value_t *a, jl_value_t *b, int overesi)
         JL_GC_POP();
         return jl_bottom_type;
     }
-    nt = subs[0] ? nta : subs[1] ? nt  : nt;
-    i  = subs[0] ? 0   : subs[1] ? nta : 0;
-    count = nt - i;
     if (!subs[0] && !subs[1]) {
-        // prepare for over estimation
-        // only preserve `a` with strict <:, but preserve `b` without strict >:
-        for (j = 0; j < nt; j++) {
-            if (stemp[j] < (j < nta ? 2 : 0))
-                temp[j] = NULL;
-        }
+        // Neither operand subsumes the other and they are not disjoint, so the
+        // meet is not expressible as a single existing type. On the subtype
+        // path (overesi=1; the only path that reaches here, since overesi=0
+        // returned `Union{}` above) return it exactly as an internal
+        // `Intersect{a, b}` node rather than over-approximating to one side's
+        // components, which would silently drop the other side. See #61917.
+        JL_GC_POP();
+        return jl_new_struct(jl_intersect_type, a, b);
     }
+    nt = subs[0] ? nta : nt;
+    i  = subs[0] ? 0   : nta;
+    count = nt - i;
     isort_union(&temp[i], count);
     temp[nt] = jl_bottom_type;
     size_t k;
@@ -3188,6 +3192,15 @@ void jl_init_types(void) JL_GC_DISABLED
     // It seems like we probably usually end up needing the box for kinds (often used in an Any context), so force it to exist
     jl_uniontype_type->name->mayinlinealloc = 0;
 
+    // Internal-use-only kind dual to Union (see #61917). Not registered as a
+    // small_typeof tag: it is recognized by identity (jl_is_intersecttype) and
+    // only ever lives transiently inside the subtyping algorithm.
+    jl_intersect_type = jl_new_datatype(jl_symbol("Intersect"), core, type_type, jl_emptysvec,
+                                        jl_perm_symsvec(2, "a", "b"),
+                                        jl_svec(2, jl_any_type, jl_any_type),
+                                        jl_emptysvec, 0, 0, 2);
+    jl_intersect_type->name->mayinlinealloc = 0;
+
     jl_tvar_t *tttvar = tvar("T");
     type_type->parameters = jl_svec(1, tttvar);
     jl_precompute_memoized_dt(type_type, 0); // update the hash value ASAP
@@ -3940,6 +3953,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_compute_field_offsets(jl_datatype_type);
     jl_compute_field_offsets(jl_typename_type);
     jl_compute_field_offsets(jl_uniontype_type);
+    jl_compute_field_offsets(jl_intersect_type);
     jl_compute_field_offsets(jl_tvar_type);
     jl_compute_field_offsets(jl_methtable_type);
     jl_compute_field_offsets(jl_methcache_type);
@@ -3957,6 +3971,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_typename_type->ismutationfree = 1;
     jl_datatype_type->ismutationfree = 1;
     jl_uniontype_type->ismutationfree = 1;
+    jl_intersect_type->ismutationfree = 1;
     jl_unionall_type->ismutationfree = 1;
     assert(((jl_datatype_t*)jl_array_any_type)->ismutationfree == 0);
     assert(((jl_datatype_t*)jl_array_uint8_type)->ismutationfree == 0);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -685,7 +685,7 @@ JL_DLLEXPORT jl_value_t *jl_type_union(jl_value_t **ts, size_t n)
         jl_value_t *pi = ts[i];
         // reject the internal `Intersect` meet node (see #61917): it must not
         // be embedded into a user-visible `Union`.
-        if (!(jl_is_type(pi) || jl_is_typevar(pi)) || jl_is_intersecttype(pi))
+        if (!(jl_is_type(pi) || jl_is_typevar(pi)))
             jl_type_error("Union", (jl_value_t*)jl_type_type, pi);
     }
     if (n == 1)

--- a/src/julia.h
+++ b/src/julia.h
@@ -597,8 +597,7 @@ typedef struct {
 // Internal-use-only "meet" of two types, dual to Union: `Intersect{a, b}`
 // denotes `a ∩ b`. It is created transiently inside the subtyping algorithm to
 // represent a greatest-lower-bound that cannot be expressed precisely as a
-// single existing type, and never escapes into user-visible types. Same layout
-// as jl_uniontype_t so the two share traversal code. See #61917.
+// single existing type, and never escapes into user-visible types.
 typedef struct {
     JL_DATA_TYPE
     jl_value_t *JL_NONNULL a;

--- a/src/julia.h
+++ b/src/julia.h
@@ -594,6 +594,17 @@ typedef struct {
     jl_value_t *JL_NONNULL b;
 } jl_uniontype_t;
 
+// Internal-use-only "meet" of two types, dual to Union: `Intersect{a, b}`
+// denotes `a ∩ b`. It is created transiently inside the subtyping algorithm to
+// represent a greatest-lower-bound that cannot be expressed precisely as a
+// single existing type, and never escapes into user-visible types. Same layout
+// as jl_uniontype_t so the two share traversal code. See #61917.
+typedef struct {
+    JL_DATA_TYPE
+    jl_value_t *JL_NONNULL a;
+    jl_value_t *JL_NONNULL b;
+} jl_intersecttype_t;
+
 // in little-endian, isptr is always the first bit, avoiding the need for a branch in computing isptr
 typedef struct {
     uint8_t isptr:1;
@@ -1620,6 +1631,7 @@ static inline int jl_field_isconst(jl_datatype_t *st, int i) JL_NOTSAFEPOINT
 #define jl_is_immutable(t)   (!((jl_datatype_t*)t)->name->mutabl)
 #define jl_may_be_immutable_datatype(t) (jl_is_datatype(t) && (!((jl_datatype_t*)t)->name->mutabl))
 #define jl_is_uniontype(v)   jl_typetagis(v,jl_uniontype_tag<<4)
+#define jl_is_intersecttype(v) jl_typetagis(v,jl_intersect_type)
 #define jl_is_typevar(v)     jl_typetagis(v,jl_tvar_tag<<4)
 #define jl_is_unionall(v)    jl_typetagis(v,jl_unionall_tag<<4)
 #define jl_is_vararg(v)      jl_typetagis(v,jl_vararg_tag<<4)

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1132,6 +1132,17 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         n += jl_static_show_x(out, v, depth, ctx);
         n += jl_printf(out, "}");
     }
+    else if (vt == jl_intersect_type) {
+        // internal-use-only meet node (see #61917); shown for debugging only
+        n += jl_printf(out, "Intersect{");
+        while (jl_is_intersecttype(v)) {
+            n += jl_static_show_x(out, ((jl_intersecttype_t*)v)->a, depth, ctx);
+            n += jl_printf(out, ", ");
+            v = ((jl_intersecttype_t*)v)->b;
+        }
+        n += jl_static_show_x(out, v, depth, ctx);
+        n += jl_printf(out, "}");
+    }
     else if (vt == jl_unionall_type) {
         jl_unionall_t *ua = (jl_unionall_t*)v;
         n += jl_static_show_x(out, ua->body, depth, ctx);

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -504,7 +504,7 @@ static int obviously_egal(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT
         }
         return 1;
     }
-    if (jl_is_uniontype(a)) {
+    if (jl_is_uniontype(a) || jl_is_intersecttype(a)) {
         return obviously_egal(((jl_uniontype_t*)a)->a, ((jl_uniontype_t*)b)->a) &&
             obviously_egal(((jl_uniontype_t*)a)->b, ((jl_uniontype_t*)b)->b);
     }
@@ -749,6 +749,11 @@ static jl_value_t *simple_meet(jl_value_t *a, jl_value_t *b, int overesi)
         return b;
     if (b == (jl_value_t*)jl_any_type || a == jl_bottom_type)
         return a;
+    if (overesi && (jl_is_intersecttype(a) || jl_is_intersecttype(b)))
+        // one operand is already an internal `Intersect` meet node (see #61917):
+        // `Intersect` is not a `jl_is_type`, so it would otherwise fall through
+        // to `Union{}` below. Represent the combined meet exactly by nesting.
+        return jl_new_struct(jl_intersect_type, a, b);
     if (!(jl_is_type(a) || jl_is_typevar(a)) || !(jl_is_type(b) || jl_is_typevar(b)))
         return jl_bottom_type;
     if (jl_is_kind(a) && jl_is_type_type(b) && jl_typeof(jl_tparam0(b)) == a)
@@ -1022,6 +1027,12 @@ static int var_lt(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, jl_param_pos_t par
         JL_GC_POP();
     }
     else {
+        // `simple_meet` resolves the greatest-lower-bound of `bb->ub` and `a`
+        // precisely when one operand subsumes the other (or they are disjoint);
+        // otherwise it now returns an exact `Intersect{bb->ub, a}` meet node
+        // rather than over-approximating to one side, which would let `b` escape
+        // its declared range (e.g. equating `∃b<:Foo` with an outer `∀a<:Bar`
+        // even though `Bar ⊄ Foo`). See #61917.
         bb->ub = simple_meet(bb->ub, a, 1);
     }
     assert(bb->ub != (jl_value_t*)b);
@@ -1113,6 +1124,8 @@ int is_leaf_bound(jl_value_t *v) JL_NOTSAFEPOINT
 {
     if (v == jl_bottom_type)
         return 1;
+    if (jl_is_intersecttype(v)) // internal meet node (see #61917), not a concrete leaf
+        return 0;
     if (jl_is_datatype(v)) {
         if (((jl_datatype_t*)v)->name->abstract) {
             if (jl_is_type_type(v))
@@ -1495,6 +1508,12 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
         else if (vb.lb == u->var->lb && vb.ub == u->var->ub && !new_tvar)
             val = wrap_tvar_env((jl_value_t*)u->var, eff_constrained);
         else {
+            // The internal `Intersect` meet node (see #61917) must never escape
+            // here as the upper bound of a static-parameter typevar. We could
+            // not construct a case that hits this; if it ever fires, that is the
+            // test case needed to justify widening `vb.ub` to its
+            // over-approximation before building the typevar.
+            assert(!jl_is_intersecttype(vb.ub) && "Intersect leaked into envout");
             if (!new_tvar)
                 new_tvar = (jl_value_t*)jl_new_typevar(u->var->name, vb.lb, vb.ub);
             val = wrap_tvar_env(new_tvar, eff_constrained);
@@ -1908,6 +1927,16 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_param_pos_t p
         }
         if (ui == 1)
             y = pick_union_element(y, e, 1);
+    }
+    // An internal `Intersect` meet node is only ever produced as an existential
+    // upper bound, so it can appear on the right (`x <: a ∩ b`) but never on the
+    // left. Handling the left case (`a ∩ b <: y`) precisely needs the
+    // intersection machinery, so for now we assert it does not arise.
+    assert(!jl_is_intersecttype(x));
+    if (jl_is_intersecttype(y)) {
+        // `x <: a ∩ b`  iff  `x <: a` and `x <: b` (dual to `Union` on the left).
+        jl_intersecttype_t *iy = (jl_intersecttype_t*)y;
+        return subtype(x, iy->a, e, param) && subtype(x, iy->b, e, param);
     }
     if (jl_is_typevar(x)) {
         if (jl_is_typevar(y)) {
@@ -3237,7 +3266,7 @@ static int _reachable_var(jl_value_t *x, jl_tvar_t *y, jl_stenv_t *e, jl_typeenv
 {
     if (in_union(x, (jl_value_t*)y))
         return 1;
-    if (jl_is_uniontype(x))
+    if (jl_is_uniontype(x) || jl_is_intersecttype(x))
         return _reachable_var(((jl_uniontype_t *)x)->a, y, e, log) ||
                _reachable_var(((jl_uniontype_t *)x)->b, y, e, log);
     if (!jl_is_typevar(x))
@@ -3420,7 +3449,7 @@ static int var_occurs_inside(jl_value_t *v, jl_tvar_t *var, int inside, int want
     if (v == (jl_value_t*)var) {
         return inside;
     }
-    else if (jl_is_uniontype(v)) {
+    else if (jl_is_uniontype(v) || jl_is_intersecttype(v)) {
         return var_occurs_inside(((jl_uniontype_t*)v)->a, var, inside, want_inv) ||
             var_occurs_inside(((jl_uniontype_t*)v)->b, var, inside, want_inv);
     }

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -750,9 +750,8 @@ static jl_value_t *simple_meet(jl_value_t *a, jl_value_t *b, int overesi)
     if (b == (jl_value_t*)jl_any_type || a == jl_bottom_type)
         return a;
     if (overesi == 1 && (jl_is_intersecttype(a) || jl_is_intersecttype(b)))
-        // one operand is already an internal `Intersect` meet node (see #61917):
-        // `Intersect` is not a `jl_is_type`, so it would otherwise fall through
-        // to `Union{}` below. Represent the combined meet exactly by nesting.
+        // one operand is already an internal `Intersect` meet node.
+        // Represent the combined meet exactly by nesting.
         return jl_new_struct(jl_intersect_type, a, b);
     if (!(jl_is_type(a) || jl_is_typevar(a)) || !(jl_is_type(b) || jl_is_typevar(b)))
         return jl_bottom_type;
@@ -3604,11 +3603,10 @@ static jl_value_t *finish_unionall(jl_value_t *res JL_MAYBE_UNROOTED, jl_varbind
     jl_value_t *varval = NULL, *ilb = NULL, *iub = NULL, *nivar = NULL;
     jl_tvar_t *newvar = vb->var, *ivar = NULL;
     JL_GC_PUSH6(&res, &newvar, &ivar, &nivar, &ilb, &iub);
-    // An internal `Intersect` meet node (see #61917) is exact for subtyping but
-    // must not appear in the result type (it is not a real type). It only ever
-    // occurs as the top layer of `vb->ub`; over-approximate it before it is used
-    // as a substituted value or typevar bound below.
-    vb->ub = widen_intersect(vb->ub);
+    // Note: `Intersect` is subtype accounting only and is widened away before
+    // it leaves the subtype path (see `subtype_unionall`), so the intersection
+    // result here never contains one.
+    assert(!jl_is_intersecttype(vb->ub));
     // try to reduce var to a single value
     if (jl_is_long(vb->ub) && jl_is_typevar(vb->lb)) {
         varval = vb->ub;

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -749,7 +749,7 @@ static jl_value_t *simple_meet(jl_value_t *a, jl_value_t *b, int overesi)
         return b;
     if (b == (jl_value_t*)jl_any_type || a == jl_bottom_type)
         return a;
-    if (overesi && (jl_is_intersecttype(a) || jl_is_intersecttype(b)))
+    if (overesi == 1 && (jl_is_intersecttype(a) || jl_is_intersecttype(b)))
         // one operand is already an internal `Intersect` meet node (see #61917):
         // `Intersect` is not a `jl_is_type`, so it would otherwise fall through
         // to `Union{}` below. Represent the combined meet exactly by nesting.
@@ -765,6 +765,26 @@ static jl_value_t *simple_meet(jl_value_t *a, jl_value_t *b, int overesi)
     if (jl_is_typevar(b) && obviously_egal(a, ((jl_tvar_t*)b)->ub))
         return b;
     return simple_intersect(a, b, overesi);
+}
+
+// Over-approximate an internal `Intersect` meet node (see #61917) by a real
+// type, so it cannot escape subtyping into a result type or static parameter.
+// An `Intersect` only ever occurs as the top layer of a varbinding's `ub`
+// (possibly as a spine of nested `Intersect`s, but never under another type
+// constructor), so it suffices to peel that spine here. `Intersect{a, b}`
+// denotes `a ∩ b`, which `simple_meet` with `overesi==2` over-approximates by a
+// real supertype. `typeintersect` may over-approximate, so this is sound.
+static jl_value_t *widen_intersect(jl_value_t *t)
+{
+    if (t == NULL || !jl_is_intersecttype(t))
+        return t;
+    jl_value_t *a = NULL, *b = NULL, *res = NULL;
+    JL_GC_PUSH2(&a, &b);
+    a = widen_intersect(((jl_intersecttype_t*)t)->a);
+    b = widen_intersect(((jl_intersecttype_t*)t)->b);
+    res = simple_meet(a, b, 2);
+    JL_GC_POP();
+    return res;
 }
 
 // main subtyping algorithm
@@ -1408,6 +1428,12 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
         return 0;
     }
 
+    // An internal `Intersect` meet node (see #61917) is exact for subtyping but
+    // must not appear in a result type or static parameter (it is not a real
+    // type). It only ever occurs as the top layer of `vb.ub`; over-approximate
+    // it now, before `vb.ub` is used to build any result typevar below.
+    vb.ub = widen_intersect(vb.ub);
+
     // If this variable was resolved to something concrete, just use that value for the
     // substitution below.
     if (vb.lb == vb.ub) {
@@ -1508,12 +1534,6 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
         else if (vb.lb == u->var->lb && vb.ub == u->var->ub && !new_tvar)
             val = wrap_tvar_env((jl_value_t*)u->var, eff_constrained);
         else {
-            // The internal `Intersect` meet node (see #61917) must never escape
-            // here as the upper bound of a static-parameter typevar. We could
-            // not construct a case that hits this; if it ever fires, that is the
-            // test case needed to justify widening `vb.ub` to its
-            // over-approximation before building the typevar.
-            assert(!jl_is_intersecttype(vb.ub) && "Intersect leaked into envout");
             if (!new_tvar)
                 new_tvar = (jl_value_t*)jl_new_typevar(u->var->name, vb.lb, vb.ub);
             val = wrap_tvar_env(new_tvar, eff_constrained);
@@ -3584,6 +3604,11 @@ static jl_value_t *finish_unionall(jl_value_t *res JL_MAYBE_UNROOTED, jl_varbind
     jl_value_t *varval = NULL, *ilb = NULL, *iub = NULL, *nivar = NULL;
     jl_tvar_t *newvar = vb->var, *ivar = NULL;
     JL_GC_PUSH6(&res, &newvar, &ivar, &nivar, &ilb, &iub);
+    // An internal `Intersect` meet node (see #61917) is exact for subtyping but
+    // must not appear in the result type (it is not a real type). It only ever
+    // occurs as the top layer of `vb->ub`; over-approximate it before it is used
+    // as a substituted value or typevar bound below.
+    vb->ub = widen_intersect(vb->ub);
     // try to reduce var to a single value
     if (jl_is_long(vb->ub) && jl_is_typevar(vb->lb)) {
         varval = vb->ub;

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -3118,3 +3118,19 @@ typeintersect(Tuple{typeof(convert),
               Tuple{typeof(convert),
                     Type{B61876{T1,N,R} where {N, R<:(AbstractArray{<:AbstractArray{T1,N},N})}},
                     AbstractArray{T2,N}} where {T1,T2,N})
+
+# issue #61917: an existential var inside an invariant constructor must not be
+# equated with an outer universal var whose bound is disjoint, e.g. `Ref{Ref{Bar}}`
+# inhabits the LHS but not the RHS, so the `UnionAll`s are not in a subtype relation.
+struct Foo61917; end
+struct Bar61917; end
+@test !((Ref{Ref{U}} where U<:Bar61917) <: (Ref{Union{Ref{T}, Ref{U}}} where {T<:Foo61917, U<:Bar61917}))
+@test !((Ref{Ref{U}} where U<:Integer) <: (Ref{Union{Ref{T}, Ref{U}}} where {T<:AbstractString, U<:Integer}))
+# a collapsible union is still a supertype
+@test (Ref{Ref{U}} where U<:Bar61917) <: (Ref{Union{Ref{T}, Ref{U}}} where {T<:Bar61917, U<:Bar61917})
+# the internal `Intersect` meet node used to fix this must never escape into a
+# user-visible result type
+let r = typeintersect((Ref{Ref{U}} where U<:Bar61917), (Ref{Union{Ref{T}, Ref{U}}} where {T<:Foo61917, U<:Bar61917}))
+    @test !occursin("Intersect", string(r))
+    @test r == Ref{Ref{Union{}}}
+end

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -3134,3 +3134,10 @@ let r = typeintersect((Ref{Ref{U}} where U<:Bar61917), (Ref{Union{Ref{T}, Ref{U}
     @test !occursin("Intersect", string(r))
     @test r == Ref{Ref{Union{}}}
 end
+# issue #61917: the `Intersect` meet node can also reach the intersection result
+# (via a `where S>:T` lower bound); it must be over-approximated, not leaked.
+let A = AbstractVector{<:Signed}, B = AbstractArray{Int}
+    r = typeintersect(Ref{B}, (Ref{S} where S>:T) where T<:A)
+    @test !occursin("Intersect", string(r))
+    @test Ref{AbstractArray{Int}} <: r   # sound over-approximation of the meet
+end


### PR DESCRIPTION
When subtyping accumulates its constraints on existential vars, it needs to union all lower bound constraints and intersect all upper bound constraints. Currently, this is done with simple_meet (or, if in intersection with the full intersection algorithm). The problem with simple_meet is that it can overapproximate the intersection, which as shown in #61917 can lose constraints and give wrong subtyping answers. The solution is simple: If `simple_meet` cannot compute an exact intersection, allocate a new object that keeps a list of all the constraints. This object is semantically an intersection type. However, our use here is very limited: It only ever occurs in the `ub` of a `varbinding` and thus only ever occurs on the RHS of a subtype query. Fortunately for us, that is the simple direction: `A <: Intersect{X, Y} <=> A <: X && A <: Y`. It's therefore mostly used as a bookkeeping device rather than being a full extention to the type system. However, this PR does style it in such a way that it could be extended to a full typesystem feature in the future if we were so inclined (though I have no present plans to do so).

I should also note that the formation of `Intersect` is pretty rare. In the whole Compiler/Base bootstrap, it happens exactly twice out of millions of subtype queries.

Fixes #61917. Code by Claude.