### PR TITLE
Fix `Core.invoke` for `OpaqueClosure`

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1630,7 +1630,7 @@ jl_method_instance_t *cache_method(
     }
 
     jl_method_instance_t *newmeth = NULL;
-    if (definition->sig == (jl_value_t*)jl_anytuple_type && definition != jl_opaque_closure_method && !definition->is_for_opaque_closure) {
+    if (definition->source == NULL && definition->generator == NULL && !definition->is_for_opaque_closure) {
         newmeth = jl_atomic_load_relaxed(&definition->unspecialized);
         if (newmeth != NULL) { // handle builtin methods de-specialization (for invoke, or if the global cache entry somehow gets lost)
             jl_tupletype_t *cachett = (jl_tupletype_t*)newmeth->specTypes;

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -433,3 +433,16 @@ end
 
 # 49659: signature-scoped typevar shouldn't fail in lowering
 @test_throws "must be a tuple type" @opaque ((x::T,y::T) where {T}) -> 123
+
+@testset "invoke OC" begin
+    let oc = @opaque (x::Int) -> x + 1
+        @test invoke(oc, Tuple{Int}, 5) == 6
+    end
+    let oc = @opaque (a::Int, b::Int) -> a * b
+        @test invoke(oc, Tuple{Int, Int}, 3, 4) == 12
+    end
+    let c = 10
+        oc = @opaque (x::Int) -> x + c
+        @test invoke(oc, Tuple{Int}, 5) == 15
+    end
+end


### PR DESCRIPTION
This allows `cache_method` to work with builtins.

It would be preferable to remove the [`jl_opaque_closure_method` special case](https://github.com/JuliaLang/julia/blob/2045dc97e05c3c241fb0c4b29c211e6a404ee399/src/gf.c#L152) from `jl_specializations_get_linfo_`, but OpaqueClosures currently overload the `(::OpaqueClosure)(....)` Method to store `invoke` adapters so OpaqueClosure cannot de-specialize its MethodInstances like most built-ins.

I plan to clean that up next, but for now this is sufficient to fix this bug.