### PR TITLE
subtype: Teach obvious_subtype about Intersect

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2528,6 +2528,29 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
         }
         return 0;
     }
+    // `Intersect` is an internal meet node, not a real type tag. Handle it
+    // before the non-type fallback, which would otherwise treat it as egal-only.
+    if (jl_is_intersecttype(y)) {
+        jl_intersecttype_t *iy = (jl_intersecttype_t*)y;
+        int sub_a, sub_b;
+        int known_a = obvious_subtype(x, iy->a, y0, &sub_a);
+        if (known_a && !sub_a) {
+            *subtype = 0;
+            return 1;
+        }
+        int known_b = obvious_subtype(x, iy->b, y0, &sub_b);
+        if (known_b && !sub_b) {
+            *subtype = 0;
+            return 1;
+        }
+        if (known_a && sub_a && known_b && sub_b) {
+            *subtype = 1;
+            return 1;
+        }
+        return 0;
+    }
+    if (jl_is_intersecttype(x))
+        return 0;
     if (!jl_is_type(x) || !jl_is_type(y)) {
         *subtype = jl_egal(x, y);
         return 1;

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -3141,3 +3141,17 @@ let A = AbstractVector{<:Signed}, B = AbstractArray{Int}
     @test !occursin("Intersect", string(r))
     @test Ref{AbstractArray{Int}} <: r   # sound over-approximation of the meet
 end
+# The `Intersect` meet node must be respected by subtype queries that take the
+# no-free-typevars fast path.
+let
+    A = Tuple{T,T} where T <: Real
+    B = Tuple{Integer,Integer}
+    C = Tuple{Int,Int}
+
+    X = Tuple{Ref{B}, Ref{C}}
+    Y = Tuple{Ref{S}, Ref{T}} where {T <: A, S >: T}
+
+    @test C <: A
+    @test C <: B
+    @test X <: Y
+end


### PR DESCRIPTION
Fixes regression noted in https://github.com/JuliaLang/julia/pull/61940#issuecomment-4579764722. Bug analyzed by GPT 5.5 Pro. Fix implemented by GPT 5.5.