### PR TITLE
clangsa: Track GC root slot contents

### DIFF
--- a/src/clangsa/GCChecker.cpp
+++ b/src/clangsa/GCChecker.cpp
@@ -14,6 +14,7 @@
 #include "clang/Tooling/CompilationDatabase.h"
 #include "clang/Tooling/Tooling.h"
 #include "clang/StaticAnalyzer/Frontend/CheckerRegistry.h"
+#include "clang/Lex/Lexer.h"
 
 #include "llvm/Support/Debug.h"
 #include <iostream>
@@ -50,6 +51,29 @@ static unsigned getStackFrameHeight(const LocationContext *stack)
     return depth;
 }
 
+static bool isImmediateMacroExpansionNamed(CheckerContext &C,
+                                           SourceLocation Loc,
+                                           StringRef Name) {
+  if (!Loc.isMacroID())
+    return false;
+  return Lexer::getImmediateMacroName(Loc, C.getSourceManager(),
+                                      C.getASTContext().getLangOpts()) == Name;
+}
+
+static const Expr *getPointerArithmeticBase(const Expr *E) {
+  E = E->IgnoreParens();
+  const auto *BO = dyn_cast<BinaryOperator>(E);
+  if (!BO || !BO->isAdditiveOp())
+    return nullptr;
+  const Expr *LHS = BO->getLHS()->IgnoreParenCasts();
+  if (LHS->getType()->isPointerType())
+    return LHS;
+  const Expr *RHS = BO->getRHS()->IgnoreParenCasts();
+  if (RHS->getType()->isPointerType())
+    return RHS;
+  return nullptr;
+}
+
 class GCChecker
     : public Checker<
           eval::Call,
@@ -75,108 +99,150 @@ class GCChecker
 
 public:
   struct ValueState {
-    enum State { Allocated, Rooted, PotentiallyFreed, Untracked } S;
-    const MemRegion *Root;
-    int RootDepth;
+    enum State { Allocated, PotentiallyFreed, Untracked } S;
 
     // Optional Metadata (for error messages)
     const FunctionDecl *FD;
     const ParmVarDecl *PVD;
 
-    ValueState(State InS, const MemRegion *Root, int Depth)
-        : S(InS), Root(Root), RootDepth(Depth), FD(nullptr), PVD(nullptr) {}
-    ValueState()
-        : S(Untracked), Root(nullptr), RootDepth(0), FD(nullptr), PVD(nullptr) {
-    }
+    ValueState(State InS) : S(InS), FD(nullptr), PVD(nullptr) {}
+    ValueState() : S(Untracked), FD(nullptr), PVD(nullptr) {}
 
     USED_FUNC void dump() const {
       llvm::dbgs() << ((S == Allocated) ? "Allocated"
-                     : (S == Rooted) ? "Rooted"
                      : (S == PotentiallyFreed) ? "PotentiallyFreed"
                      : (S == Untracked) ? "Untracked"
                      : "Error");
-      if (S == Rooted)
-        llvm::dbgs() << "(" << RootDepth << ")";
       llvm::dbgs() << "\n";
     }
 
     bool operator==(const ValueState &VS) const {
-      return S == VS.S && Root == VS.Root && RootDepth == VS.RootDepth;
+      return S == VS.S;
     }
     bool operator!=(const ValueState &VS) const {
-      return S != VS.S || Root != VS.Root || RootDepth != VS.RootDepth;
+      return S != VS.S;
     }
 
     void Profile(llvm::FoldingSetNodeID &ID) const {
       ID.AddInteger(S);
-      ID.AddPointer(Root);
-      ID.AddInteger(RootDepth);
     }
 
-    bool isRooted() const { return S == Rooted; }
     bool isPotentiallyFreed() const { return S == PotentiallyFreed; }
     bool isJustAllocated() const { return S == Allocated; }
     bool isUntracked() const { return S == Untracked; }
 
-    bool isRootedBy(const MemRegion *R) const {
-      assert(R != nullptr);
-      return isRooted() && R == Root;
-    }
-
     static ValueState getAllocated() {
-      return ValueState(Allocated, nullptr, -1);
+      return ValueState(Allocated);
     }
     static ValueState getFreed() {
-      return ValueState(PotentiallyFreed, nullptr, -1);
+      return ValueState(PotentiallyFreed);
     }
     static ValueState getUntracked() {
-      return ValueState(Untracked, nullptr, -1);
-    }
-    static ValueState getRooted(const MemRegion *Root, int Depth) {
-      return ValueState(Rooted, Root, Depth);
+      return ValueState(Untracked);
     }
     static ValueState getForArgument(const FunctionDecl *FD,
                                      const ParmVarDecl *PVD,
                                      bool isFunctionSafepoint) {
       bool maybeUnrooted = declHasAnnotation(PVD, "julia_maybe_unrooted");
+      ValueState VS = getAllocated();
       if (!isFunctionSafepoint || maybeUnrooted) {
-        ValueState VS = getAllocated();
         VS.PVD = PVD;
         VS.FD = FD;
-        return VS;
       }
-      return getRooted(nullptr, -1);
+      return VS;
+    }
+  };
+
+  struct RootLifetime {
+    enum Kind { Permanent, GCFrame } K;
+    unsigned Depth;
+
+    RootLifetime(Kind InK, unsigned InDepth = 0) : K(InK), Depth(InDepth) {}
+
+    bool operator==(const RootLifetime &Other) const {
+      return K == Other.K && Depth == Other.Depth;
+    }
+    bool operator!=(const RootLifetime &Other) const {
+      return K != Other.K || Depth != Other.Depth;
+    }
+
+    bool shouldPopAtDepth(unsigned CurrentDepth) const {
+      return K == GCFrame && CurrentDepth == Depth;
+    }
+    bool outlives(const RootLifetime &Other) const {
+      if (K != Other.K)
+        return K == Permanent;
+      return K == GCFrame && Depth < Other.Depth;
+    }
+    int diagnosticDepth() const {
+      return K == Permanent ? -1 : static_cast<int>(Depth);
+    }
+
+    void Profile(llvm::FoldingSetNodeID &ID) const {
+      ID.AddInteger(K);
+      ID.AddInteger(Depth);
+    }
+
+    static RootLifetime getPermanent() {
+      return RootLifetime(Permanent);
+    }
+    static RootLifetime getGCFrame(unsigned Depth) {
+      return RootLifetime(GCFrame, Depth);
     }
   };
 
   struct RootState {
     enum Kind { Root, RootArray } K;
-    int RootedAtDepth;
+    RootLifetime Lifetime;
 
-    RootState(Kind InK, int Depth) : K(InK), RootedAtDepth(Depth) {}
+    RootState(Kind InK, RootLifetime InLifetime)
+        : K(InK), Lifetime(InLifetime) {}
 
     bool operator==(const RootState &VS) const {
-      return K == VS.K && RootedAtDepth == VS.RootedAtDepth;
+      return K == VS.K && Lifetime == VS.Lifetime;
     }
     bool operator!=(const RootState &VS) const {
-      return K != VS.K || RootedAtDepth != VS.RootedAtDepth;
+      return K != VS.K || Lifetime != VS.Lifetime;
     }
 
-    bool shouldPopAtDepth(int Depth) const { return Depth == RootedAtDepth; }
+    bool shouldPopAtDepth(unsigned Depth) const {
+      return Lifetime.shouldPopAtDepth(Depth);
+    }
     bool isRootArray() const { return K == RootArray; }
 
     void Profile(llvm::FoldingSetNodeID &ID) const {
       ID.AddInteger(K);
-      ID.AddInteger(RootedAtDepth);
+      Lifetime.Profile(ID);
     }
 
-    static RootState getRoot(int Depth) { return RootState(Root, Depth); }
-    static RootState getRootArray(int Depth) {
-      return RootState(RootArray, Depth);
+    static RootState getRoot(unsigned Depth) {
+      return RootState(Root, RootLifetime::getGCFrame(Depth));
+    }
+    static RootState getPermanentRoot() {
+      return RootState(Root, RootLifetime::getPermanent());
+    }
+    static RootState getRootArray(unsigned Depth) {
+      return RootState(RootArray, RootLifetime::getGCFrame(Depth));
     }
   };
 
 private:
+  struct RootLookupResult {
+    enum Provenance { ExactRoot, RootArrayElement, AliasToRootSlot };
+
+    const RootState *RS;
+    const MemRegion *RootRegion;
+    const MemRegion *SlotRegion;
+    Provenance P;
+
+    RootLookupResult()
+        : RS(nullptr), RootRegion(nullptr), SlotRegion(nullptr), P(ExactRoot) {}
+    RootLookupResult(const RootState *InRS, const MemRegion *InRootRegion,
+                     const MemRegion *InSlotRegion, Provenance InP)
+        : RS(InRS), RootRegion(InRootRegion), SlotRegion(InSlotRegion),
+          P(InP) {}
+  };
+
   template <typename callback>
   static bool isJuliaType(callback f, QualType QT) {
     if (QT->isReferenceType())
@@ -214,11 +280,39 @@ private:
   bool processArgumentRooting(const CallEvent &Call, CheckerContext &C,
                               ProgramStateRef &State) const;
   bool rootRegionIfGlobal(const MemRegion *R, ProgramStateRef &,
-                          CheckerContext &C, ValueState *ValS = nullptr) const;
+                          CheckerContext &C, ValueState *ValS = nullptr,
+                          bool *IsRooted = nullptr) const;
+  static const MemRegion *getOriginRegion(SymbolRef Sym);
+  static SymbolRef getTrackedSymbolForSVal(const ProgramStateRef &State,
+                                           SVal Val);
+  static bool lookupRootRegion(const ProgramStateRef &State,
+                               const MemRegion *R,
+                               RootLookupResult *Result);
+  static bool getBestRoot(const ProgramStateRef &State, SymbolRef Sym,
+                          const MemRegion **RootRegion = nullptr,
+                          int *RootDepth = nullptr);
+  static bool isSymbolRooted(const ProgramStateRef &State, SymbolRef Sym);
+  static bool isSymbolOrOriginRooted(const ProgramStateRef &State,
+                                     SymbolRef Sym);
+  static ProgramStateRef markSymbolRooted(ProgramStateRef State, SymbolRef Sym,
+                                          const MemRegion *SlotRegion);
+  static ProgramStateRef addSymbolRoots(ProgramStateRef State, SymbolRef To,
+                                        SymbolRef From);
+  static ProgramStateRef copySymbolRoots(ProgramStateRef State, SymbolRef To,
+                                         SymbolRef From);
+  static ProgramStateRef removeRootSlotFromValues(ProgramStateRef State,
+                                                  const MemRegion *SlotRegion);
+  static ProgramStateRef removeRootSlotsForRoot(ProgramStateRef State,
+                                                const MemRegion *RootRegion);
+  static ProgramStateRef setRootSlotContent(ProgramStateRef State,
+                                            const MemRegion *SlotRegion,
+                                            SymbolRef Sym);
   static const ValueState *getValStateForRegion(ASTContext &AstC,
                                                 const ProgramStateRef &State,
                                                 const MemRegion *R,
                                                 bool Debug = false);
+  static SymbolRef getRootedSymbolForRegion(const ProgramStateRef &State,
+                                            const MemRegion *R);
   bool gcEnabledHere(CheckerContext &C) const;
   bool gcEnabledHere(ProgramStateRef State) const;
   bool safepointEnabledHere(CheckerContext &C) const;
@@ -300,6 +394,21 @@ REGISTER_TRAIT_WITH_PROGRAMSTATE(MayCallSafepoint, bool)
 REGISTER_MAP_WITH_PROGRAMSTATE(GCValueMap, SymbolRef, GCChecker::ValueState)
 REGISTER_MAP_WITH_PROGRAMSTATE(GCRootMap, const MemRegion *,
                                GCChecker::RootState)
+REGISTER_SET_WITH_PROGRAMSTATE(GCValuePermanentRoots, SymbolRef)
+REGISTER_SET_FACTORY_WITH_PROGRAMSTATE(GCValueRootSet, const MemRegion *)
+REGISTER_MAP_WITH_PROGRAMSTATE(GCValueRootMap, SymbolRef, GCValueRootSet)
+// If GCRootContentMap[Slot] is Sym, GCValueRootMap[Sym] must contain Slot.
+// Root slot writes should use setRootSlotContent; direct updates must maintain
+// both maps.
+REGISTER_MAP_WITH_PROGRAMSTATE(GCRootContentMap, const MemRegion *, SymbolRef)
+
+const MemRegion *GCChecker::getOriginRegion(SymbolRef Sym) {
+  if (const SymbolRegionValue *SRV = dyn_cast<SymbolRegionValue>(Sym))
+    return SRV->getRegion();
+  if (const SymbolDerived *SD = dyn_cast<SymbolDerived>(Sym))
+    return SD->getRegion();
+  return nullptr;
+}
 
 template <typename callback>
 SymbolRef GCChecker::walkToRoot(callback f, const ProgramStateRef &State,
@@ -314,17 +423,263 @@ SymbolRef GCChecker::walkToRoot(callback f, const ProgramStateRef &State,
     SymbolRef Sym = SR->getSymbol();
     const ValueState *OldVState = State->get<GCValueMap>(Sym);
     if (f(Sym, OldVState)) {
-      if (const SymbolRegionValue *SRV = dyn_cast<SymbolRegionValue>(Sym)) {
-        Region = SRV->getRegion();
-        continue;
-      } else if (const SymbolDerived *SD = dyn_cast<SymbolDerived>(Sym)) {
-        Region = SD->getRegion();
+      if (const MemRegion *Origin = getOriginRegion(Sym)) {
+        Region = Origin;
         continue;
       }
       return nullptr;
     }
     return Sym;
   }
+}
+
+SymbolRef GCChecker::getTrackedSymbolForSVal(const ProgramStateRef &State,
+                                             SVal Val) {
+  if (SymbolRef Sym = Val.getAsSymbol()) {
+    if (State->get<GCValueMap>(Sym) && isSymbolOrOriginRooted(State, Sym))
+      return Sym;
+  }
+  if (SymbolRef Sym = getRootedSymbolForRegion(State, Val.getAsRegion()))
+    return Sym;
+  if (SymbolRef Sym = Val.getAsSymbol()) {
+    if (State->get<GCValueMap>(Sym))
+      return Sym;
+  }
+  return walkToRoot(
+      [](SymbolRef Sym, const ValueState *OldVState) { return !OldVState; },
+      State, Val.getAsRegion());
+}
+
+bool GCChecker::lookupRootRegion(const ProgramStateRef &State,
+                                 const MemRegion *Region,
+                                 RootLookupResult *Result) {
+  if (Result)
+    *Result = RootLookupResult();
+  bool SawAlias = false;
+  for (unsigned I = 0; I < 16 && Region; ++I) {
+    Region = Region->StripCasts();
+    if (const RootState *RS = State->get<GCRootMap>(Region)) {
+      if (Result)
+        *Result = RootLookupResult(
+            RS, Region, RS->isRootArray() ? nullptr : Region,
+            SawAlias ? RootLookupResult::AliasToRootSlot
+                     : RootLookupResult::ExactRoot);
+      return true;
+    }
+
+    if (const ElementRegion *ER = Region->getAs<ElementRegion>()) {
+      const MemRegion *Base = ER->getBaseRegion()->StripCasts();
+      if (const RootState *RS = State->get<GCRootMap>(Base)) {
+        if (RS->isRootArray()) {
+          if (Result)
+            *Result = RootLookupResult(
+                RS, Base, Region,
+                SawAlias ? RootLookupResult::AliasToRootSlot
+                         : RootLookupResult::RootArrayElement);
+          return true;
+        }
+      }
+      const auto Index = ER->getIndex().getAs<nonloc::ConcreteInt>();
+      if (!Index || !Index->getValue()->isZero())
+        break;
+      Region = ER->getSuperRegion();
+      continue;
+    }
+
+    if (const SymbolicRegion *SR = Region->getAs<SymbolicRegion>()) {
+      if (const MemRegion *Origin = getOriginRegion(SR->getSymbol())) {
+        Region = Origin;
+        SawAlias = true;
+        continue;
+      }
+    }
+
+    break;
+  }
+  return false;
+}
+
+bool GCChecker::getBestRoot(const ProgramStateRef &State, SymbolRef Sym,
+                            const MemRegion **RootRegion, int *RootDepth) {
+  if (RootRegion)
+    *RootRegion = nullptr;
+  if (RootDepth)
+    *RootDepth = 0;
+  if (!Sym)
+    return false;
+  if (State->contains<GCValuePermanentRoots>(Sym)) {
+    if (RootDepth)
+      *RootDepth = -1;
+    return true;
+  }
+  const RootState *BestRS = nullptr;
+  const MemRegion *BestRootRegion = nullptr;
+  if (const GCValueRootSet *Roots = State->get<GCValueRootMap>(Sym)) {
+    for (auto I = Roots->begin(), E = Roots->end(); I != E; ++I) {
+      RootLookupResult Lookup;
+      if (!lookupRootRegion(State, *I, &Lookup) || !Lookup.RootRegion)
+        continue;
+      if (!BestRS || Lookup.RS->Lifetime.outlives(BestRS->Lifetime)) {
+        BestRS = Lookup.RS;
+        BestRootRegion = Lookup.RootRegion;
+      }
+    }
+  }
+
+  if (!BestRS)
+    return false;
+  if (RootRegion)
+    *RootRegion = BestRootRegion;
+  if (RootDepth)
+    *RootDepth = BestRS->Lifetime.diagnosticDepth();
+  return true;
+}
+
+bool GCChecker::isSymbolRooted(const ProgramStateRef &State, SymbolRef Sym) {
+  return getBestRoot(State, Sym);
+}
+
+bool GCChecker::isSymbolOrOriginRooted(const ProgramStateRef &State,
+                                       SymbolRef Sym) {
+  if (isSymbolRooted(State, Sym))
+    return true;
+  const MemRegion *Origin = getOriginRegion(Sym);
+  return Origin && getRootedSymbolForRegion(State, Origin);
+}
+
+ProgramStateRef GCChecker::markSymbolRooted(ProgramStateRef State,
+                                            SymbolRef Sym,
+                                            const MemRegion *SlotRegion) {
+  if (!Sym)
+    return State;
+  if (const ValueState *VS = State->get<GCValueMap>(Sym)) {
+    if (VS->isPotentiallyFreed())
+      State = State->set<GCValueMap>(Sym, ValueState::getAllocated());
+  }
+  if (!SlotRegion)
+    return State->add<GCValuePermanentRoots>(Sym);
+
+  auto &Factory = State->get_context<GCValueRootSet>();
+  const GCValueRootSet *CurrentRoots = State->get<GCValueRootMap>(Sym);
+  GCValueRootSet Roots =
+      CurrentRoots ? *CurrentRoots : Factory.getEmptySet();
+  Roots = Factory.add(Roots, SlotRegion);
+  return State->set<GCValueRootMap>(Sym, Roots);
+}
+
+ProgramStateRef GCChecker::addSymbolRoots(ProgramStateRef State, SymbolRef To,
+                                          SymbolRef From) {
+  if (!To || !From)
+    return State;
+  if (State->contains<GCValuePermanentRoots>(From))
+    State = State->add<GCValuePermanentRoots>(To);
+
+  const GCValueRootSet *FromRoots = State->get<GCValueRootMap>(From);
+  if (!FromRoots)
+    return State;
+
+  auto &Factory = State->get_context<GCValueRootSet>();
+  const GCValueRootSet *CurrentRoots = State->get<GCValueRootMap>(To);
+  GCValueRootSet Roots =
+      CurrentRoots ? *CurrentRoots : Factory.getEmptySet();
+  for (auto I = FromRoots->begin(), E = FromRoots->end(); I != E; ++I)
+    Roots = Factory.add(Roots, *I);
+  return State->set<GCValueRootMap>(To, Roots);
+}
+
+ProgramStateRef GCChecker::copySymbolRoots(ProgramStateRef State, SymbolRef To,
+                                           SymbolRef From) {
+  if (!To || !From)
+    return State;
+  if (State->contains<GCValuePermanentRoots>(From))
+    State = State->add<GCValuePermanentRoots>(To);
+  else
+    State = State->remove<GCValuePermanentRoots>(To);
+  if (const GCValueRootSet *Roots = State->get<GCValueRootMap>(From)) {
+    return State->set<GCValueRootMap>(To, *Roots);
+  }
+  return State->remove<GCValueRootMap>(To);
+}
+
+ProgramStateRef
+GCChecker::removeRootSlotFromValues(ProgramStateRef State,
+                                    const MemRegion *SlotRegion) {
+  if (!SlotRegion)
+    return State;
+
+  auto &Factory = State->get_context<GCValueRootSet>();
+  GCValueRootMapTy RootMap = State->get<GCValueRootMap>();
+  for (auto I = RootMap.begin(), E = RootMap.end(); I != E; ++I) {
+    GCValueRootSet Roots = I.getData();
+    if (!Roots.contains(SlotRegion))
+      continue;
+    Roots = Factory.remove(Roots, SlotRegion);
+    if (Roots.isEmpty())
+      State = State->remove<GCValueRootMap>(I.getKey());
+    else
+      State = State->set<GCValueRootMap>(I.getKey(), Roots);
+  }
+
+  return State;
+}
+
+ProgramStateRef
+GCChecker::removeRootSlotsForRoot(ProgramStateRef State,
+                                  const MemRegion *RootRegion) {
+  if (!RootRegion)
+    return State;
+
+  SmallVector<const MemRegion *, 8> Slots;
+  GCRootContentMapTy ContentMap = State->get<GCRootContentMap>();
+  for (auto I = ContentMap.begin(), E = ContentMap.end(); I != E; ++I) {
+    RootLookupResult Lookup;
+    if (lookupRootRegion(State, I.getKey(), &Lookup) &&
+        Lookup.RootRegion == RootRegion && Lookup.SlotRegion)
+      Slots.push_back(Lookup.SlotRegion);
+  }
+
+  GCValueRootMapTy RootMap = State->get<GCValueRootMap>();
+  for (auto I = RootMap.begin(), E = RootMap.end(); I != E; ++I) {
+    const GCValueRootSet &Roots = I.getData();
+    for (auto RI = Roots.begin(), RE = Roots.end(); RI != RE; ++RI) {
+      RootLookupResult Lookup;
+      if (lookupRootRegion(State, *RI, &Lookup) &&
+          Lookup.RootRegion == RootRegion)
+        Slots.push_back(*RI);
+    }
+  }
+
+  for (const MemRegion *Slot : Slots) {
+    State = removeRootSlotFromValues(State, Slot);
+    State = State->remove<GCRootContentMap>(Slot);
+  }
+  return State;
+}
+
+ProgramStateRef GCChecker::setRootSlotContent(ProgramStateRef State,
+                                              const MemRegion *SlotRegion,
+                                              SymbolRef Sym) {
+  RootLookupResult Lookup;
+  if (!lookupRootRegion(State, SlotRegion, &Lookup) || !Lookup.SlotRegion)
+    return State;
+
+  const SymbolRef *Current = State->get<GCRootContentMap>(Lookup.SlotRegion);
+  if (!Sym && !Current)
+    return State;
+  if (Sym && Current && *Current == Sym) {
+    if (const GCValueRootSet *Roots = State->get<GCValueRootMap>(Sym)) {
+      if (Roots->contains(Lookup.SlotRegion))
+        return State;
+    }
+    return markSymbolRooted(State, Sym, Lookup.SlotRegion);
+  }
+
+  State = removeRootSlotFromValues(State, Lookup.SlotRegion);
+  if (!Sym)
+    return State->remove<GCRootContentMap>(Lookup.SlotRegion);
+
+  State = State->set<GCRootContentMap>(Lookup.SlotRegion, Sym);
+  return markSymbolRooted(State, Sym, Lookup.SlotRegion);
 }
 
 namespace Helpers {
@@ -456,7 +811,7 @@ PDP GCChecker::GCValueBugVisitor::ExplainNoPropagationFromExpr(
     BR.addVisitor(make_unique<GCValueBugVisitor>(Parent));
     return MakePDP(
         Pos, "Root not propagated because it may have been freed. Tracking.");
-  } else if (ValS->isRooted()) {
+  } else if (isSymbolRooted(N->getState(), Parent)) {
     BR.addVisitor(make_unique<GCValueBugVisitor>(Parent));
     return MakePDP(
         Pos, "Root was not propagated due to a bug. Tracking base value.");
@@ -498,6 +853,12 @@ PDP GCChecker::GCValueBugVisitor::VisitNode(const ExplodedNode *N,
   const ExplodedNode *PrevN = N->getFirstPred();
   const ValueState *NewValueState = N->getState()->get<GCValueMap>(Sym);
   const ValueState *OldValueState = PrevN->getState()->get<GCValueMap>(Sym);
+  bool NewRooted = isSymbolOrOriginRooted(N->getState(), Sym);
+  bool OldRooted = isSymbolOrOriginRooted(PrevN->getState(), Sym);
+  int NewRootDepth = 0;
+  int OldRootDepth = 0;
+  getBestRoot(N->getState(), Sym, nullptr, &NewRootDepth);
+  getBestRoot(PrevN->getState(), Sym, nullptr, &OldRootDepth);
   const Stmt *Stmt = getStmtForDiagnostics(N);
 
   PathDiagnosticLocation Pos;
@@ -510,7 +871,7 @@ PDP GCChecker::GCValueBugVisitor::VisitNode(const ExplodedNode *N,
   if (!NewValueState)
     return nullptr;
   if (!OldValueState) {
-    if (NewValueState->isRooted()) {
+    if (NewRooted) {
       return MakePDP(Pos, "Started tracking value here (root was inherited).");
     } else {
       if (NewValueState->FD) {
@@ -549,11 +910,11 @@ PDP GCChecker::GCValueBugVisitor::VisitNode(const ExplodedNode *N,
     // std::make_shared< in later LLVM
     return MakePDP(Pos,
                    "Value may have been GCed here (though I don't know why).");
-  } else if (NewValueState->isRooted() && OldValueState->isJustAllocated()) {
+  } else if (NewRooted && !OldRooted) {
     return MakePDP(Pos, "Value was rooted here.");
-  } else if (!NewValueState->isRooted() && OldValueState->isRooted()) {
+  } else if (!NewRooted && OldRooted) {
     return MakePDP(Pos, "Root was released here.");
-  } else if (NewValueState->RootDepth != OldValueState->RootDepth) {
+  } else if (NewRooted && OldRooted && NewRootDepth != OldRootDepth) {
     return MakePDP(Pos, "Rooting Depth changed here.");
   }
   return nullptr;
@@ -638,9 +999,7 @@ bool GCChecker::propagateArgumentRootedness(CheckerContext &C,
       continue;
     }
     auto Arg = State->getSVal(CE->getArg(idx++), LCtx->getParent());
-    SymbolRef ArgSym = walkToRoot(
-        [](SymbolRef Sym, const ValueState *OldVState) { return !OldVState; },
-        State, Arg.getAsRegion());
+    SymbolRef ArgSym = getTrackedSymbolForSVal(State, Arg);
     if (!ArgSym) {
       continue;
     }
@@ -661,12 +1020,13 @@ bool GCChecker::propagateArgumentRootedness(CheckerContext &C,
       continue;
     }
     if (isGloballyRootedType(P->getType())) {
-      State =
-          State->set<GCValueMap>(ParamSym, ValueState::getRooted(nullptr, -1));
+      State = State->set<GCValueMap>(ParamSym, ValueState::getAllocated());
+      State = markSymbolRooted(State, ParamSym, nullptr);
       Change = true;
       continue;
     }
     State = State->set<GCValueMap>(ParamSym, *ValS);
+    State = copySymbolRoots(State, ParamSym, ArgSym);
     Change = true;
   }
   return Change;
@@ -705,7 +1065,7 @@ void GCChecker::checkBeginFunction(CheckerContext &C) const {
     if (declHasAnnotation(P, "julia_require_rooted_slot")) {
       auto Param = State->getLValue(P, LCtx);
       const MemRegion *Root = State->getSVal(Param).getAsRegion();
-      State = State->set<GCRootMap>(Root, RootState::getRoot(-1));
+      State = State->set<GCRootMap>(Root, RootState::getPermanentRoot());
     } else if (isGCTrackedType(P->getType())) {
       auto Param = State->getLValue(P, LCtx);
       SymbolRef AssignedSym = State->getSVal(Param).getAsSymbol();
@@ -714,6 +1074,9 @@ void GCChecker::checkBeginFunction(CheckerContext &C) const {
       assert(AssignedSym);
       State = State->set<GCValueMap>(AssignedSym,
                                      ValueState::getForArgument(FD, P, isFunctionSafepoint));
+      if (isFunctionSafepoint &&
+          !declHasAnnotation(P, "julia_maybe_unrooted"))
+        State = markSymbolRooted(State, AssignedSym, nullptr);
       Change = true;
     }
   }
@@ -986,6 +1349,8 @@ bool GCChecker::processPotentialSafepoint(const CallEvent &Call,
   GCValueMapTy AMap = State->get<GCValueMap>();
   for (auto I = AMap.begin(), E = AMap.end(); I != E; ++I) {
     if (I.getData().isJustAllocated()) {
+      if (isSymbolOrOriginRooted(State, I.getKey()))
+        continue;
       if (SpeciallyRootedSymbol == I.getKey())
         continue;
       if (RetSym == I.getKey())
@@ -999,17 +1364,22 @@ bool GCChecker::processPotentialSafepoint(const CallEvent &Call,
 
 const GCChecker::ValueState *
 GCChecker::getValStateForRegion(ASTContext &AstC, const ProgramStateRef &State,
-                                const MemRegion *Region, bool Debug) {
-  if (!Region)
-    return nullptr;
-  SymbolRef Sym = walkToRoot(
-      [&](SymbolRef Sym, const ValueState *OldVState) {
-        return !OldVState || !OldVState->isRooted();
-      },
-      State, Region);
+                                 const MemRegion *Region, bool Debug) {
+  SymbolRef Sym = getRootedSymbolForRegion(State, Region);
   if (!Sym)
     return nullptr;
   return State->get<GCValueMap>(Sym);
+}
+
+SymbolRef GCChecker::getRootedSymbolForRegion(const ProgramStateRef &State,
+                                              const MemRegion *Region) {
+  if (!Region)
+    return nullptr;
+  return walkToRoot(
+      [&](SymbolRef Sym, const ValueState *OldVState) {
+        return !OldVState || !isSymbolRooted(State, Sym);
+      },
+      State, Region);
 }
 
 bool GCChecker::processArgumentRooting(const CallEvent &Call, CheckerContext &C,
@@ -1030,11 +1400,13 @@ bool GCChecker::processArgumentRooting(const CallEvent &Call, CheckerContext &C,
   }
   if (!RootingRegion || !RootedSymbol)
     return false;
+  SymbolRef RootingSym = getRootedSymbolForRegion(State, RootingRegion);
   const ValueState *OldVState =
-      getValStateForRegion(C.getASTContext(), State, RootingRegion);
+      RootingSym ? State->get<GCValueMap>(RootingSym) : nullptr;
   if (!OldVState)
     return false;
   State = State->set<GCValueMap>(RootedSymbol, *OldVState);
+  State = copySymbolRoots(State, RootedSymbol, RootingSym);
   return true;
 }
 
@@ -1054,16 +1426,18 @@ bool GCChecker::processAllocationOfResult(const CallEvent &Call,
     State = State->BindExpr(Call.getOriginExpr(), C.getLocationContext(), S);
     Sym = S.getAsSymbol();
   }
-  if (isGloballyRootedType(QT))
-    State = State->set<GCValueMap>(Sym, ValueState::getRooted(nullptr, -1));
-  else {
+  if (isGloballyRootedType(QT)) {
+    State = State->set<GCValueMap>(Sym, ValueState::getAllocated());
+    State = markSymbolRooted(State, Sym, nullptr);
+  } else {
     const ValueState *ValS = State->get<GCValueMap>(Sym);
     ValueState NewVState = ValS ? *ValS : ValueState::getAllocated();
+    bool NewSymbolIsRooted = false;
     auto *Decl = Call.getDecl();
     const FunctionDecl *FD = Decl ? Decl->getAsFunction() : nullptr;
     if (FD) {
       if (declHasAnnotation(FD, "julia_globally_rooted")) {
-        NewVState = ValueState::getRooted(nullptr, -1);
+        NewSymbolIsRooted = true;
       } else {
         // Special case for jl_box_ functions which have value-dependent
         // global roots.
@@ -1085,7 +1459,7 @@ bool GCChecker::processAllocationOfResult(const CallEvent &Call,
               }
             }
             if (GloballyRooted) {
-              NewVState = ValueState::getRooted(nullptr, -1);
+              NewSymbolIsRooted = true;
             }
           }
         } else {
@@ -1095,10 +1469,13 @@ bool GCChecker::processAllocationOfResult(const CallEvent &Call,
               SVal Test = Call.getArgSVal(i);
               // Walk backwards to find the region that roots this value
               const MemRegion *Region = Test.getAsRegion();
+              SymbolRef OldSym = getRootedSymbolForRegion(State, Region);
               const ValueState *OldVState =
-                  getValStateForRegion(C.getASTContext(), State, Region);
-              if (OldVState)
+                  OldSym ? State->get<GCValueMap>(OldSym) : nullptr;
+              if (OldVState) {
                 NewVState = *OldVState;
+                State = addSymbolRoots(State, Sym, OldSym);
+              }
               break;
             }
           }
@@ -1106,6 +1483,8 @@ bool GCChecker::processAllocationOfResult(const CallEvent &Call,
       }
     }
     State = State->set<GCValueMap>(Sym, NewVState);
+    if (NewSymbolIsRooted)
+      State = markSymbolRooted(State, Sym, nullptr);
   }
   return true;
 }
@@ -1113,7 +1492,8 @@ bool GCChecker::processAllocationOfResult(const CallEvent &Call,
 void GCChecker::checkPostCall(const CallEvent &Call, CheckerContext &C) const {
   ProgramStateRef State = C.getState();
   bool didChange = processArgumentRooting(Call, C, State);
-  didChange |= processPotentialSafepoint(Call, C, State);
+  if (!C.wasInlined)
+    didChange |= processPotentialSafepoint(Call, C, State);
   didChange |= processAllocationOfResult(Call, C, State);
   if (didChange)
     C.addTransition(State);
@@ -1122,13 +1502,20 @@ void GCChecker::checkPostCall(const CallEvent &Call, CheckerContext &C) const {
 // Implicitly root values that were casted to globally rooted values
 void GCChecker::checkPostStmt(const CStyleCastExpr *CE,
                               CheckerContext &C) const {
-  if (!isGloballyRootedType(CE->getTypeAsWritten()))
+  if (!isGloballyRootedType(CE->getTypeAsWritten())) {
+    if (isImmediateMacroExpansionNamed(C, CE->getExprLoc(), "jl_svec_data")) {
+      if (const Expr *Base = getPointerArithmeticBase(CE->getSubExpr()))
+        checkDerivingExpr(CE, Base, false, C);
+    }
     return;
+  }
   SymbolRef Sym = C.getSVal(CE).getAsSymbol();
   if (!Sym)
     return;
-  C.addTransition(
-      C.getState()->set<GCValueMap>(Sym, ValueState::getRooted(nullptr, -1)));
+  ProgramStateRef State = C.getState();
+  if (!State->get<GCValueMap>(Sym))
+    State = State->set<GCValueMap>(Sym, ValueState::getAllocated());
+  C.addTransition(markSymbolRooted(State, Sym, nullptr));
 }
 
 SymbolRef GCChecker::getSymbolForResult(const Expr *Result,
@@ -1173,12 +1560,12 @@ void GCChecker::checkDerivingExpr(const Expr *Result, const Expr *Parent,
     if (!NewSym) {
       return;
     }
-    const ValueState *NewValS = State->get<GCValueMap>(NewSym);
-    if (NewValS && NewValS->isRooted() && NewValS->RootDepth == -1) {
+    if (State->contains<GCValuePermanentRoots>(NewSym)) {
       return;
     }
-    C.addTransition(
-        State->set<GCValueMap>(NewSym, ValueState::getRooted(nullptr, -1)));
+    if (!State->get<GCValueMap>(NewSym))
+      State = State->set<GCValueMap>(NewSym, ValueState::getAllocated());
+    C.addTransition(markSymbolRooted(State, NewSym, nullptr));
     return;
   }
   if (!isGCTracked(Result)) {
@@ -1221,7 +1608,8 @@ void GCChecker::checkDerivingExpr(const Expr *Result, const Expr *Parent,
   if (Region) {
     const VarRegion *VR = Region->getAs<VarRegion>();
     bool inheritedState = false;
-    ValueState Updated = ValueState::getRooted(Region, -1);
+    bool inheritedRoot = false;
+    ValueState Updated = ValueState::getAllocated();
     if (VR && isa<ParmVarDecl>(VR->getDecl())) {
       // This works around us not being able to track symbols for struct/union
       // parameters very well.
@@ -1230,23 +1618,39 @@ void GCChecker::checkDerivingExpr(const Expr *Result, const Expr *Parent,
       if (FD) {
         inheritedState = true;
         bool isFunctionSafepoint = !isFDAnnotatedNotSafepoint(FD, getSM(C));
+        inheritedRoot =
+            isFunctionSafepoint &&
+            !declHasAnnotation(cast<ParmVarDecl>(VR->getDecl()),
+                               "julia_maybe_unrooted");
         Updated =
             ValueState::getForArgument(FD, cast<ParmVarDecl>(VR->getDecl()), isFunctionSafepoint);
       }
     } else {
       VR = Helpers::walk_back_to_global_VR(Region);
       if (VR) {
-        if (VR && rootRegionIfGlobal(VR, State, C)) {
+        if (VR && rootRegionIfGlobal(VR, State, C, &Updated, &inheritedRoot)) {
           inheritedState = true;
         }
       }
     }
     if (inheritedState && ResultTracked) {
-      C.addTransition(State->set<GCValueMap>(NewSym, Updated));
+      State = State->set<GCValueMap>(NewSym, Updated);
+      if (inheritedRoot) {
+        SymbolRef SourceSym = State->getSVal(VR).getAsSymbol();
+        if (SourceSym && isSymbolRooted(State, SourceSym))
+          State = copySymbolRoots(State, NewSym, SourceSym);
+        else
+          State = markSymbolRooted(State, NewSym, nullptr);
+      }
+      C.addTransition(State);
       return;
     }
   }
-  if (NewValS && NewValS->isRooted()) {
+  if (isSymbolOrOriginRooted(State, NewSym)) {
+    if (!NewValS && ResultTracked) {
+      C.addTransition(
+          State->set<GCValueMap>(NewSym, ValueState::getAllocated()));
+    }
     return;
   }
   if (!OldValS) {
@@ -1261,7 +1665,9 @@ void GCChecker::checkDerivingExpr(const Expr *Result, const Expr *Parent,
     report_value_error(C, OldSym,
                        "Creating derivative of value that may have been GCed");
   } else if (ResultTracked) {
-    C.addTransition(State->set<GCValueMap>(NewSym, *OldValS));
+    State = State->set<GCValueMap>(NewSym, *OldValS);
+    State = addSymbolRoots(State, NewSym, OldSym);
+    C.addTransition(State);
     return;
   }
 }
@@ -1271,24 +1677,23 @@ void GCChecker::checkPostStmt(const ArraySubscriptExpr *ASE,
                               CheckerContext &C) const {
   // Could be a root array, in which case this should be considered rooted
   // by that array.
-  const MemRegion *Region = C.getSVal(ASE->getLHS()).getAsRegion();
+  const MemRegion *Region = C.getSVal(ASE).getAsRegion();
   ProgramStateRef State = C.getState();
-  if (Region && Region->getAs<ElementRegion>() && isGCTracked(ASE)) {
-    const RootState *RS =
-        State->get<GCRootMap>(Region->getAs<ElementRegion>()->getSuperRegion());
-    if (RS) {
-      ValueState ValS = ValueState::getRooted(Region, State->get<GCDepth>());
-      SymbolRef NewSym = getSymbolForResult(ASE, &ValS, State, C);
-      if (!NewSym) {
-        return;
-      }
-      const ValueState *ExistingValS = State->get<GCValueMap>(NewSym);
-      if (ExistingValS && ExistingValS->isRooted() &&
-          ExistingValS->RootDepth < ValS.RootDepth)
-        return;
-      C.addTransition(State->set<GCValueMap>(NewSym, ValS));
+  RootLookupResult Lookup;
+  if (Region && isGCTracked(ASE) &&
+      lookupRootRegion(State, Region, &Lookup)) {
+    ValueState ValS = ValueState::getAllocated();
+    SymbolRef NewSym = getSymbolForResult(ASE, &ValS, State, C);
+    if (!NewSym)
       return;
-    }
+    if (!State->get<GCValueMap>(NewSym))
+      State = State->set<GCValueMap>(NewSym, ValS);
+    if (Lookup.SlotRegion)
+      State = setRootSlotContent(State, Lookup.SlotRegion, NewSym);
+    else
+      State = markSymbolRooted(State, NewSym, Lookup.RootRegion);
+    C.addTransition(State);
+    return;
   }
   checkDerivingExpr(ASE, ASE->getLHS(), true, C);
 }
@@ -1298,16 +1703,19 @@ void GCChecker::checkPostStmt(const MemberExpr *ME, CheckerContext &C) const {
   const MemRegion *Region = C.getSVal(ME).getAsRegion();
   ProgramStateRef State = C.getState();
   if (Region && isGCTracked(ME)) {
-    if (const RootState *RS = State->get<GCRootMap>(Region)) {
-      ValueState ValS = ValueState::getRooted(Region, RS->RootedAtDepth);
+    RootLookupResult Lookup;
+    if (lookupRootRegion(State, Region, &Lookup)) {
+      ValueState ValS = ValueState::getAllocated();
       SymbolRef NewSym = getSymbolForResult(ME, &ValS, State, C);
       if (!NewSym)
         return;
-      const ValueState *ExistingValS = State->get<GCValueMap>(NewSym);
-      if (ExistingValS && ExistingValS->isRooted() &&
-          ExistingValS->RootDepth < ValS.RootDepth)
-        return;
-      C.addTransition(C.getState()->set<GCValueMap>(NewSym, ValS));
+      if (!State->get<GCValueMap>(NewSym))
+        State = State->set<GCValueMap>(NewSym, ValS);
+      if (Lookup.SlotRegion)
+        State = setRootSlotContent(State, Lookup.SlotRegion, NewSym);
+      else
+        State = markSymbolRooted(State, NewSym, Lookup.RootRegion);
+      C.addTransition(State);
       return;
     }
   }
@@ -1403,7 +1811,7 @@ void GCChecker::checkPreCall(const CallEvent &Call, CheckerContext &C) const {
     if (ValState->isPotentiallyFreed()) {
       report_value_error(C, Sym, "Argument value may have been GCed", range);
     }
-    if (ValState->isRooted())
+    if (isSymbolOrOriginRooted(State, Sym))
       continue;
     bool MaybeUnrooted = false;
     if (FD) {
@@ -1442,17 +1850,11 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
     for (auto I = AMap.begin(), E = AMap.end(); I != E; ++I) {
       if (I.getData().shouldPopAtDepth(CurrentDepth)) {
         PoppedRoots.push_back(I.getKey());
-        State = State->remove<GCRootMap>(I.getKey());
       }
     }
-    GCValueMapTy VMap = State->get<GCValueMap>();
     for (const MemRegion *R : PoppedRoots) {
-      for (auto I = VMap.begin(), E = VMap.end(); I != E; ++I) {
-        if (I.getData().isRootedBy(R)) {
-          State =
-              State->set<GCValueMap>(I.getKey(), ValueState::getAllocated());
-        }
-      }
+      State = removeRootSlotsForRoot(State, R);
+      State = State->remove<GCRootMap>(R);
     }
     C.addTransition(State);
     return true;
@@ -1484,10 +1886,8 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
       if (ValState->isPotentiallyFreed())
         report_value_error(C, Sym,
                            "Trying to root value which may have been GCed");
-      if (!ValState->isRooted()) {
-        State = State->set<GCValueMap>(
-            Sym, ValueState::getRooted(Region, CurrentDepth));
-      }
+      State = State->set<GCRootContentMap>(Region, Sym);
+      State = markSymbolRooted(State, Sym, Region);
     }
     CurrentDepth += 1;
     State = State->set<GCDepth>(CurrentDepth);
@@ -1504,11 +1904,6 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
     const MemRegion *Region = MRV->getRegion()->StripCasts();
     State =
         State->set<GCRootMap>(Region, RootState::getRootArray(CurrentDepth));
-    // The Argument array may also be used as a value, so make it rooted
-    // SymbolRef ArgArraySym = ArgArray.getAsSymbol();
-    // assert(ArgArraySym);
-    // State = State->set<GCValueMap>(ArgArraySym, ValueState::getRooted(Region,
-    // CurrentDepth));
     CurrentDepth += 1;
     State = State->set<GCDepth>(CurrentDepth);
     C.addTransition(State);
@@ -1520,8 +1915,10 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
       report_error(C, "Can not understand this promise.");
       return true;
     }
-    C.addTransition(
-        C.getState()->set<GCValueMap>(Sym, ValueState::getRooted(nullptr, -1)));
+    ProgramStateRef State = C.getState();
+    if (!State->get<GCValueMap>(Sym))
+      State = State->set<GCValueMap>(Sym, ValueState::getAllocated());
+    C.addTransition(markSymbolRooted(State, Sym, nullptr));
     return true;
   } else if (name == "jl_gc_push_arraylist") {
     CurrentDepth += 1;
@@ -1562,8 +1959,9 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
     SymbolRef Sym = C.getSVal(CE->getArg(1)).getAsSymbol();
     if (!Sym)
       return true;
-    C.addTransition(
-        State->set<GCValueMap>(Sym, ValueState::getRooted(nullptr, -1)));
+    if (!State->get<GCValueMap>(Sym))
+      State = State->set<GCValueMap>(Sym, ValueState::getAllocated());
+    C.addTransition(markSymbolRooted(State, Sym, nullptr));
     return true;
   } else if (name == "jl_gc_enable" || name == "ijl_gc_enable") {
     ProgramStateRef State = C.getState();
@@ -1610,38 +2008,54 @@ void GCChecker::checkBind(SVal LVal, SVal RVal, const clang::Stmt *S,
   if (!R) {
     return;
   }
-  bool shouldBeRootArray = false;
-  const ElementRegion *ER = R->getAs<ElementRegion>();
-  if (ER) {
-    R = R->getBaseRegion()->StripCasts();
-    shouldBeRootArray = true;
-  }
+  RootLookupResult RootLookup;
+  bool shouldBeRootArray = R->getAs<ElementRegion>();
+  bool HasRoot = lookupRootRegion(State, R, &RootLookup);
   SymbolRef Sym = RVal.getAsSymbol();
-  if (!Sym) {
+  if (!Sym && !HasRoot) {
     return;
   }
-  const auto *RootState = State->get<GCRootMap>(R);
-  if (!RootState) {
-    const ValueState *ValSP = nullptr;
+  if (!HasRoot) {
+    if (const ElementRegion *ER = R->getAs<ElementRegion>()) {
+      R = ER->getBaseRegion()->StripCasts();
+      shouldBeRootArray = true;
+    }
     ValueState ValS;
-    if (rootRegionIfGlobal(R->getBaseRegion(), State, C, &ValS)) {
-      ValSP = &ValS;
+    bool LHSRooted = false;
+    SymbolRef RootSource = nullptr;
+    bool IsGlobalRoot = false;
+    const MemRegion *BaseRegion = R->getBaseRegion();
+    if (rootRegionIfGlobal(BaseRegion, State, C, &ValS, &IsGlobalRoot)) {
+      LHSRooted = IsGlobalRoot;
+      RootSource = BaseRegion ? State->getSVal(BaseRegion).getAsSymbol() : nullptr;
     } else {
-      ValSP = getValStateForRegion(C.getASTContext(), State, R);
+      RootSource = getRootedSymbolForRegion(State, R);
+      LHSRooted = RootSource != nullptr;
+      if (const ValueState *RootSourceState =
+              RootSource ? State->get<GCValueMap>(RootSource) : nullptr)
+        ValS = *RootSourceState;
     }
-    if (!ValSP || !ValSP->isRooted()) {
+    if (!LHSRooted)
       return;
-    }
-    const auto *RValState = State->get<GCValueMap>(Sym);
-    if (RValState && RValState->isRooted() &&
-        RValState->RootDepth < ValSP->RootDepth)
-      return;
-    C.addTransition(State->set<GCValueMap>(Sym, *ValSP));
+
+    State = State->set<GCValueMap>(Sym, ValS);
+    if (RootSource)
+      State = addSymbolRoots(State, Sym, RootSource);
+    else
+      State = markSymbolRooted(State, Sym, nullptr);
+    C.addTransition(State);
     return;
   }
-  if (shouldBeRootArray && !RootState->isRootArray()) {
+  if (shouldBeRootArray && !RootLookup.RS->isRootArray()) {
     report_error(
         C, "This assignment looks weird. Expected a root array on the LHS.");
+    return;
+  }
+  if (!Sym) {
+    if (RootLookup.SlotRegion) {
+      State = setRootSlotContent(State, RootLookup.SlotRegion, nullptr);
+      C.addTransition(State);
+    }
     return;
   }
   const auto *RValState = State->get<GCValueMap>(Sym);
@@ -1660,15 +2074,18 @@ void GCChecker::checkBind(SVal LVal, SVal RVal, const clang::Stmt *S,
   }
   if (RValState->isPotentiallyFreed())
     report_value_error(C, Sym, "Trying to root value which may have been GCed");
-  if (!RValState->isRooted() ||
-      RValState->RootDepth > RootState->RootedAtDepth) {
-    C.addTransition(State->set<GCValueMap>(
-        Sym, ValueState::getRooted(R, RootState->RootedAtDepth)));
-  }
+  if (RootLookup.SlotRegion)
+    State = setRootSlotContent(State, RootLookup.SlotRegion, Sym);
+  else
+    State = markSymbolRooted(State, Sym, RootLookup.RootRegion);
+  C.addTransition(State);
 }
 
 bool GCChecker::rootRegionIfGlobal(const MemRegion *R, ProgramStateRef &State,
-                                   CheckerContext &C, ValueState *ValS) const {
+                                   CheckerContext &C, ValueState *ValS,
+                                   bool *IsRooted) const {
+  if (IsRooted)
+    *IsRooted = false;
   if (!R)
     return false;
   const VarRegion *VR = R->getAs<VarRegion>();
@@ -1683,19 +2100,24 @@ bool GCChecker::rootRegionIfGlobal(const MemRegion *R, ProgramStateRef &State,
   bool isGlobalRoot = false;
   if (declHasAnnotation(VD, "julia_globally_rooted") ||
       isGloballyRootedType(VD->getType())) {
-    State = State->set<GCRootMap>(R, RootState::getRoot(-1));
+    State = State->set<GCRootMap>(R, RootState::getPermanentRoot());
     isGlobalRoot = true;
+    if (IsRooted)
+      *IsRooted = true;
   }
   SVal TheVal = State->getSVal(R);
   SymbolRef Sym = TheVal.getAsSymbol();
-  ValueState TheValS(isGlobalRoot ? ValueState::getRooted(R, -1)
-                                  : ValueState::getAllocated());
+  ValueState TheValS = ValueState::getAllocated();
   if (ValS)
     *ValS = TheValS;
   if (Sym) {
     const ValueState *GVState = C.getState()->get<GCValueMap>(Sym);
     if (!GVState)
       State = State->set<GCValueMap>(Sym, TheValS);
+    if (isGlobalRoot) {
+      State = State->set<GCRootContentMap>(R, Sym);
+      State = markSymbolRooted(State, Sym, R);
+    }
   }
   return true;
 }
@@ -1704,19 +2126,24 @@ void GCChecker::checkLocation(SVal SLoc, bool IsLoad, const Stmt *S,
                               CheckerContext &C) const {
   ProgramStateRef State = C.getState();
   bool DidChange = false;
-  const RootState *RS = nullptr;
+  RootLookupResult Lookup;
   // Loading from a root produces a rooted symbol. TODO: Can we do something
   // better than this.
-  if (IsLoad && (RS = State->get<GCRootMap>(SLoc.getAsRegion()))) {
+  if (IsLoad &&
+      lookupRootRegion(State, SLoc.getAsRegion(), &Lookup)) {
     SymbolRef LoadedSym =
         State->getSVal(*SLoc.getAs<Loc>()).getAsSymbol();
     if (LoadedSym) {
-      const ValueState *ValS = State->get<GCValueMap>(LoadedSym);
-      if (!ValS || !ValS->isRooted() || ValS->RootDepth > RS->RootedAtDepth) {
+      if (!State->get<GCValueMap>(LoadedSym))
+        State = State->set<GCValueMap>(LoadedSym, ValueState::getAllocated());
+      if (Lookup.SlotRegion) {
         DidChange = true;
-        State = State->set<GCValueMap>(
-            LoadedSym,
-            ValueState::getRooted(SLoc.getAsRegion(), RS->RootedAtDepth));
+        if (!State->get<GCRootContentMap>(Lookup.SlotRegion))
+          State = State->set<GCRootContentMap>(Lookup.SlotRegion, LoadedSym);
+        State = markSymbolRooted(State, LoadedSym, Lookup.SlotRegion);
+      } else if (!isSymbolOrOriginRooted(State, LoadedSym)) {
+        DidChange = true;
+        State = markSymbolRooted(State, LoadedSym, Lookup.RootRegion);
       }
     }
   }

--- a/src/clangsa/GCChecker.cpp
+++ b/src/clangsa/GCChecker.cpp
@@ -16,9 +16,11 @@
 #include "clang/StaticAnalyzer/Frontend/CheckerRegistry.h"
 #include "clang/Lex/Lexer.h"
 
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/Debug.h"
 #include <iostream>
 #include <memory>
+#include <optional>
 
 #if defined(__GNUC__)
 #define USED_FUNC __attribute__((used))
@@ -221,8 +223,88 @@ public:
     static RootState getPermanentRoot() {
       return RootState(Root, RootLifetime::getPermanent());
     }
+    static RootState getPermanentRootArray() {
+      return RootState(RootArray, RootLifetime::getPermanent());
+    }
     static RootState getRootArray(unsigned Depth) {
       return RootState(RootArray, RootLifetime::getGCFrame(Depth));
+    }
+  };
+
+  struct GCCell {
+    enum Kind { RegionCell, HeapField, HeapArrayElement } K;
+
+    const MemRegion *Region;
+    SymbolRef Owner;
+    const FieldDecl *Field;
+    int64_t Index;
+    bool Summary;
+
+    GCCell()
+        : K(RegionCell), Region(nullptr), Owner(nullptr), Field(nullptr),
+          Index(0), Summary(false) {}
+
+    bool operator==(const GCCell &Other) const {
+      return K == Other.K && Region == Other.Region && Owner == Other.Owner &&
+             Field == Other.Field && Index == Other.Index &&
+             Summary == Other.Summary;
+    }
+    bool operator!=(const GCCell &Other) const { return !(*this == Other); }
+    bool operator<(const GCCell &Other) const {
+      std::less<const void *> Less;
+      if (K != Other.K)
+        return K < Other.K;
+      if (Region != Other.Region)
+        return Less(Region, Other.Region);
+      if (Owner != Other.Owner)
+        return Less(Owner, Other.Owner);
+      if (Field != Other.Field)
+        return Less(Field, Other.Field);
+      if (Index != Other.Index)
+        return Index < Other.Index;
+      return Summary < Other.Summary;
+    }
+
+    bool isHeapCell() const { return K == HeapField || K == HeapArrayElement; }
+    bool isRegionCell() const { return K == RegionCell; }
+    bool isSummaryCell() const { return K == HeapArrayElement && Summary; }
+
+    void Profile(llvm::FoldingSetNodeID &ID) const {
+      ID.AddInteger(K);
+      ID.AddPointer(Region);
+      ID.AddPointer(Owner);
+      ID.AddPointer(Field);
+      ID.AddInteger(Index);
+      ID.AddBoolean(Summary);
+    }
+
+    static GCCell forRegion(const MemRegion *Region) {
+      GCCell Cell;
+      Cell.K = RegionCell;
+      Cell.Region = Region;
+      return Cell;
+    }
+    static GCCell forHeapField(SymbolRef Owner, const FieldDecl *Field) {
+      GCCell Cell;
+      Cell.K = HeapField;
+      Cell.Owner = Owner;
+      Cell.Field = Field;
+      return Cell;
+    }
+    static GCCell forHeapArrayElement(SymbolRef Owner, int64_t Index) {
+      GCCell Cell;
+      Cell.K = HeapArrayElement;
+      Cell.Owner = Owner;
+      Cell.Index = Index;
+      Cell.Summary = false;
+      return Cell;
+    }
+    static GCCell forHeapArraySummary(SymbolRef Owner) {
+      GCCell Cell;
+      Cell.K = HeapArrayElement;
+      Cell.Owner = Owner;
+      Cell.Summary = true;
+      return Cell;
     }
   };
 
@@ -279,6 +361,8 @@ private:
                                  ProgramStateRef &State) const;
   bool processArgumentRooting(const CallEvent &Call, CheckerContext &C,
                               ProgramStateRef &State) const;
+  bool processHeapEffects(const CallEvent &Call, CheckerContext &C,
+                          ProgramStateRef &State) const;
   bool rootRegionIfGlobal(const MemRegion *R, ProgramStateRef &,
                           CheckerContext &C, ValueState *ValS = nullptr,
                           bool *IsRooted = nullptr) const;
@@ -288,6 +372,33 @@ private:
   static bool lookupRootRegion(const ProgramStateRef &State,
                                const MemRegion *R,
                                RootLookupResult *Result);
+  static std::optional<GCCell> resolveCell(const ProgramStateRef &State,
+                                           const MemRegion *R);
+  static std::optional<GCCell> resolveCell(const ProgramStateRef &State,
+                                           SVal V);
+  static bool lookupRootCell(const ProgramStateRef &State, const GCCell &Cell,
+                             RootLookupResult *Result = nullptr);
+  static ProgramStateRef setCellContent(ProgramStateRef State,
+                                        const GCCell &Cell, SymbolRef Sym);
+  static ProgramStateRef addObjectChild(ProgramStateRef State, SymbolRef Owner,
+                                        const GCCell &Child);
+  static ProgramStateRef addObjectSymbolChild(ProgramStateRef State,
+                                              SymbolRef Owner,
+                                              SymbolRef Child);
+  static ProgramStateRef setObjectChildContent(ProgramStateRef State,
+                                               SymbolRef Owner,
+                                               const GCCell &Child,
+                                               SymbolRef ChildSym);
+  static bool getConcreteIndex(SVal V, int64_t &Index);
+  static bool traceReachableSymbols(const ProgramStateRef &State,
+                                    llvm::SmallPtrSetImpl<SymbolRef> &Reachable,
+                                    SymbolRef Target = nullptr,
+                                    const MemRegion **RootRegion = nullptr,
+                                    int *RootDepth = nullptr);
+  static ProgramStateRef runGCSafepoint(ProgramStateRef State,
+                                        SymbolRef SpeciallyRootedSymbol,
+                                        SymbolRef RetSym,
+                                        bool &DidChange);
   static bool getBestRoot(const ProgramStateRef &State, SymbolRef Sym,
                           const MemRegion **RootRegion = nullptr,
                           int *RootDepth = nullptr);
@@ -401,8 +512,18 @@ REGISTER_MAP_WITH_PROGRAMSTATE(GCValueRootMap, SymbolRef, GCValueRootSet)
 // Root slot writes should use setRootSlotContent; direct updates must maintain
 // both maps.
 REGISTER_MAP_WITH_PROGRAMSTATE(GCRootContentMap, const MemRegion *, SymbolRef)
+REGISTER_MAP_WITH_PROGRAMSTATE(GCRootRegistry, GCChecker::GCCell,
+                               GCChecker::RootState)
+REGISTER_MAP_WITH_PROGRAMSTATE(GCCellContentMap, GCChecker::GCCell, SymbolRef)
+REGISTER_SET_FACTORY_WITH_PROGRAMSTATE(GCCellSet, GCChecker::GCCell)
+REGISTER_MAP_WITH_PROGRAMSTATE(GCObjectChildrenMap, SymbolRef, GCCellSet)
+REGISTER_SET_FACTORY_WITH_PROGRAMSTATE(GCSymbolSet, SymbolRef)
+REGISTER_MAP_WITH_PROGRAMSTATE(GCObjectSymbolChildrenMap, SymbolRef,
+                               GCSymbolSet)
 
 const MemRegion *GCChecker::getOriginRegion(SymbolRef Sym) {
+  if (const SymbolCast *SC = dyn_cast<SymbolCast>(Sym))
+    return getOriginRegion(SC->getOperand());
   if (const SymbolRegionValue *SRV = dyn_cast<SymbolRegionValue>(Sym))
     return SRV->getRegion();
   if (const SymbolDerived *SD = dyn_cast<SymbolDerived>(Sym))
@@ -467,6 +588,22 @@ bool GCChecker::lookupRootRegion(const ProgramStateRef &State,
       return true;
     }
 
+    if (const FieldRegion *FR = Region->getAs<FieldRegion>()) {
+      const MemRegion *Super = FR->getSuperRegion()->StripCasts();
+      if (const auto *SR = Super->getAs<SymbolicRegion>()) {
+        if (const MemRegion *Origin = getOriginRegion(SR->getSymbol())) {
+          if (const auto *OriginSuper =
+                  dyn_cast<SubRegion>(Origin->StripCasts())) {
+            Region =
+                Region->getMemRegionManager().getFieldRegionWithSuper(FR,
+                                                                       OriginSuper);
+            SawAlias = true;
+            continue;
+          }
+        }
+      }
+    }
+
     if (const ElementRegion *ER = Region->getAs<ElementRegion>()) {
       const MemRegion *Base = ER->getBaseRegion()->StripCasts();
       if (const RootState *RS = State->get<GCRootMap>(Base)) {
@@ -477,6 +614,18 @@ bool GCChecker::lookupRootRegion(const ProgramStateRef &State,
                 SawAlias ? RootLookupResult::AliasToRootSlot
                          : RootLookupResult::RootArrayElement);
           return true;
+        }
+      }
+      if (const auto *SR = Base->getAs<SymbolicRegion>()) {
+        if (const MemRegion *Origin = getOriginRegion(SR->getSymbol())) {
+          if (const auto *OriginBase =
+                  dyn_cast<SubRegion>(Origin->StripCasts())) {
+            Region =
+                Region->getMemRegionManager().getElementRegionWithSuper(ER,
+                                                                         OriginBase);
+            SawAlias = true;
+            continue;
+          }
         }
       }
       const auto Index = ER->getIndex().getAs<nonloc::ConcreteInt>();
@@ -497,6 +646,277 @@ bool GCChecker::lookupRootRegion(const ProgramStateRef &State,
     break;
   }
   return false;
+}
+
+bool GCChecker::getConcreteIndex(SVal V, int64_t &Index) {
+  auto CI = V.getAs<nonloc::ConcreteInt>();
+  if (!CI)
+    return false;
+  const llvm::APSInt &Value = CI->getValue();
+  if (!Value.isSigned() && Value.getActiveBits() > 63)
+    return false;
+  Index = Value.getSExtValue();
+  return true;
+}
+
+std::optional<GCChecker::GCCell>
+GCChecker::resolveCell(const ProgramStateRef &State, SVal V) {
+  return resolveCell(State, V.getAsRegion());
+}
+
+std::optional<GCChecker::GCCell>
+GCChecker::resolveCell(const ProgramStateRef &State, const MemRegion *Region) {
+  if (!Region)
+    return std::nullopt;
+
+  for (unsigned I = 0; I < 16 && Region; ++I) {
+    Region = Region->StripCasts();
+
+    RootLookupResult Lookup;
+    if (lookupRootRegion(State, Region, &Lookup) && Lookup.SlotRegion)
+      return GCCell::forRegion(Lookup.SlotRegion);
+
+    if (const SymbolicRegion *SR = Region->getAs<SymbolicRegion>()) {
+      if (const MemRegion *Origin = getOriginRegion(SR->getSymbol())) {
+        Region = Origin;
+        continue;
+      }
+    }
+
+    if (const FieldRegion *FR = Region->getAs<FieldRegion>()) {
+      const MemRegion *Super = FR->getSuperRegion()->StripCasts();
+      SymbolRef Owner = walkToRoot(
+          [](SymbolRef Sym, const ValueState *OldVState) {
+            return !OldVState;
+          },
+          State, Super);
+      if (Owner)
+        return GCCell::forHeapField(Owner, FR->getDecl());
+      return GCCell::forRegion(Region);
+    }
+
+    if (const ElementRegion *ER = Region->getAs<ElementRegion>()) {
+      const MemRegion *Base = ER->getBaseRegion()->StripCasts();
+      RootLookupResult BaseLookup;
+      if (lookupRootRegion(State, Base, &BaseLookup))
+        return GCCell::forRegion(Region);
+
+      SymbolRef Owner = walkToRoot(
+          [](SymbolRef Sym, const ValueState *OldVState) {
+            return !OldVState;
+          },
+          State, Base);
+      if (Owner) {
+        int64_t Index = 0;
+        if (getConcreteIndex(ER->getIndex(), Index))
+          return GCCell::forHeapArrayElement(Owner, Index);
+        return GCCell::forHeapArraySummary(Owner);
+      }
+
+      // Do not collapse non-root array element zero to its super-region here:
+      // cell identity should describe the actual location being assigned.
+      return GCCell::forRegion(Region);
+    }
+
+    return GCCell::forRegion(Region);
+  }
+
+  return std::nullopt;
+}
+
+bool GCChecker::lookupRootCell(const ProgramStateRef &State,
+                               const GCCell &Cell,
+                               RootLookupResult *Result) {
+  if (Result)
+    *Result = RootLookupResult();
+  if (!Cell.isRegionCell())
+    return false;
+
+  if (const RootState *RS = State->get<GCRootRegistry>(Cell)) {
+    if (Result)
+      *Result =
+          RootLookupResult(RS, Cell.Region, RS->isRootArray() ? nullptr
+                                                              : Cell.Region,
+                           RootLookupResult::ExactRoot);
+    return true;
+  }
+
+  return lookupRootRegion(State, Cell.Region, Result);
+}
+
+ProgramStateRef GCChecker::setCellContent(ProgramStateRef State,
+                                          const GCCell &Cell, SymbolRef Sym) {
+  if (!Sym)
+    return State->remove<GCCellContentMap>(Cell);
+  return State->set<GCCellContentMap>(Cell, Sym);
+}
+
+ProgramStateRef GCChecker::addObjectChild(ProgramStateRef State,
+                                          SymbolRef Owner,
+                                          const GCCell &Child) {
+  if (!Owner || !Child.isHeapCell())
+    return State;
+
+  auto &Factory = State->get_context<GCCellSet>();
+  const GCCellSet *CurrentChildren = State->get<GCObjectChildrenMap>(Owner);
+  GCCellSet Children =
+      CurrentChildren ? *CurrentChildren : Factory.getEmptySet();
+  Children = Factory.add(Children, Child);
+  return State->set<GCObjectChildrenMap>(Owner, Children);
+}
+
+ProgramStateRef GCChecker::addObjectSymbolChild(ProgramStateRef State,
+                                                SymbolRef Owner,
+                                                SymbolRef Child) {
+  if (!Owner || !Child)
+    return State;
+
+  auto &Factory = State->get_context<GCSymbolSet>();
+  const GCSymbolSet *CurrentChildren =
+      State->get<GCObjectSymbolChildrenMap>(Owner);
+  GCSymbolSet Children =
+      CurrentChildren ? *CurrentChildren : Factory.getEmptySet();
+  Children = Factory.add(Children, Child);
+  return State->set<GCObjectSymbolChildrenMap>(Owner, Children);
+}
+
+ProgramStateRef GCChecker::setObjectChildContent(ProgramStateRef State,
+                                                 SymbolRef Owner,
+                                                 const GCCell &Child,
+                                                 SymbolRef ChildSym) {
+  State = addObjectChild(State, Owner, Child);
+  return setCellContent(State, Child, ChildSym);
+}
+
+bool GCChecker::traceReachableSymbols(
+    const ProgramStateRef &State, llvm::SmallPtrSetImpl<SymbolRef> &Reachable,
+    SymbolRef Target, const MemRegion **RootRegion, int *RootDepth) {
+  if (RootRegion)
+    *RootRegion = nullptr;
+  if (RootDepth)
+    *RootDepth = 0;
+
+  SmallVector<GCCell, 32> CellWorklist;
+  SmallVector<SymbolRef, 32> ObjectWorklist;
+
+  for (SymbolRef Sym : State->get<GCValuePermanentRoots>()) {
+    if (Reachable.insert(Sym).second)
+      ObjectWorklist.push_back(Sym);
+    if (Target && Sym == Target) {
+      if (RootDepth)
+        *RootDepth = -1;
+      return true;
+    }
+  }
+
+  GCCellContentMapTy ContentMap = State->get<GCCellContentMap>();
+  for (auto I = ContentMap.begin(), E = ContentMap.end(); I != E; ++I) {
+    RootLookupResult Lookup;
+    if (!lookupRootCell(State, I.getKey(), &Lookup))
+      continue;
+    if (Lookup.RS && Lookup.RS->isRootArray() && !Lookup.SlotRegion)
+      continue;
+    CellWorklist.push_back(I.getKey());
+  }
+
+  // Keep the older root-slot content map as a compatibility cache while the
+  // checker is migrated to GCCellContentMap.
+  GCRootContentMapTy RootContentMap = State->get<GCRootContentMap>();
+  for (auto I = RootContentMap.begin(), E = RootContentMap.end(); I != E; ++I) {
+    RootLookupResult Lookup;
+    if (!lookupRootRegion(State, I.getKey(), &Lookup) || !Lookup.SlotRegion)
+      continue;
+    CellWorklist.push_back(GCCell::forRegion(Lookup.SlotRegion));
+  }
+
+  // Transitional compatibility: legacy propagation records root slots directly
+  // on derived symbols. Treat those entries as a derived reachability cache
+  // while exact cell provenance is still being expanded.
+  GCValueRootMapTy LegacyRootMap = State->get<GCValueRootMap>();
+  for (auto I = LegacyRootMap.begin(), E = LegacyRootMap.end(); I != E; ++I) {
+    const GCValueRootSet &Roots = I.getData();
+    for (auto RI = Roots.begin(), RE = Roots.end(); RI != RE; ++RI) {
+      RootLookupResult Lookup;
+      if (!lookupRootRegion(State, *RI, &Lookup) || !Lookup.RootRegion)
+        continue;
+      if (Reachable.insert(I.getKey()).second)
+        ObjectWorklist.push_back(I.getKey());
+      if (Target && I.getKey() == Target) {
+        if (RootRegion)
+          *RootRegion = Lookup.RootRegion;
+        if (RootDepth && Lookup.RS)
+          *RootDepth = Lookup.RS->Lifetime.diagnosticDepth();
+        return true;
+      }
+      break;
+    }
+  }
+
+  while (!CellWorklist.empty() || !ObjectWorklist.empty()) {
+    while (!CellWorklist.empty()) {
+      GCCell Cell = CellWorklist.pop_back_val();
+      const SymbolRef *Sym = State->get<GCCellContentMap>(Cell);
+      if (!Sym && Cell.isRegionCell())
+        Sym = State->get<GCRootContentMap>(Cell.Region);
+      if (!Sym)
+        continue;
+
+      if (Reachable.insert(*Sym).second)
+        ObjectWorklist.push_back(*Sym);
+      if (Target && *Sym == Target) {
+        RootLookupResult Lookup;
+        if (RootRegion && lookupRootCell(State, Cell, &Lookup))
+          *RootRegion = Lookup.RootRegion;
+        if (RootDepth && lookupRootCell(State, Cell, &Lookup) && Lookup.RS)
+          *RootDepth = Lookup.RS->Lifetime.diagnosticDepth();
+        return true;
+      }
+    }
+
+    while (!ObjectWorklist.empty()) {
+      SymbolRef Obj = ObjectWorklist.pop_back_val();
+      if (const GCCellSet *Children = State->get<GCObjectChildrenMap>(Obj)) {
+        for (auto I = Children->begin(), E = Children->end(); I != E; ++I)
+          CellWorklist.push_back(*I);
+      }
+      if (const GCSymbolSet *Children =
+              State->get<GCObjectSymbolChildrenMap>(Obj)) {
+        for (auto I = Children->begin(), E = Children->end(); I != E; ++I) {
+          if (Reachable.insert(*I).second)
+            ObjectWorklist.push_back(*I);
+          if (Target && *I == Target)
+            return true;
+        }
+      }
+    }
+  }
+
+  return Target ? Reachable.count(Target) : false;
+}
+
+ProgramStateRef GCChecker::runGCSafepoint(ProgramStateRef State,
+                                          SymbolRef SpeciallyRootedSymbol,
+                                          SymbolRef RetSym,
+                                          bool &DidChange) {
+  llvm::SmallPtrSet<SymbolRef, 32> Reachable;
+  traceReachableSymbols(State, Reachable);
+  if (SpeciallyRootedSymbol)
+    Reachable.insert(SpeciallyRootedSymbol);
+  if (RetSym)
+    Reachable.insert(RetSym);
+
+  GCValueMapTy AMap = State->get<GCValueMap>();
+  for (auto I = AMap.begin(), E = AMap.end(); I != E; ++I) {
+    if (!I.getData().isJustAllocated())
+      continue;
+    if (Reachable.count(I.getKey()))
+      continue;
+    if (isSymbolOrOriginRooted(State, I.getKey()))
+      continue;
+    State = State->set<GCValueMap>(I.getKey(), ValueState::getFreed());
+    DidChange = true;
+  }
+  return State;
 }
 
 bool GCChecker::getBestRoot(const ProgramStateRef &State, SymbolRef Sym,
@@ -526,8 +946,10 @@ bool GCChecker::getBestRoot(const ProgramStateRef &State, SymbolRef Sym,
     }
   }
 
-  if (!BestRS)
-    return false;
+  if (!BestRS) {
+    llvm::SmallPtrSet<SymbolRef, 32> Reachable;
+    return traceReachableSymbols(State, Reachable, Sym, RootRegion, RootDepth);
+  }
   if (RootRegion)
     *RootRegion = BestRootRegion;
   if (RootDepth)
@@ -542,6 +964,9 @@ bool GCChecker::isSymbolRooted(const ProgramStateRef &State, SymbolRef Sym) {
 bool GCChecker::isSymbolOrOriginRooted(const ProgramStateRef &State,
                                        SymbolRef Sym) {
   if (isSymbolRooted(State, Sym))
+    return true;
+  llvm::SmallPtrSet<SymbolRef, 32> Reachable;
+  if (traceReachableSymbols(State, Reachable, Sym))
     return true;
   const MemRegion *Origin = getOriginRegion(Sym);
   return Origin && getRootedSymbolForRegion(State, Origin);
@@ -664,9 +1089,21 @@ ProgramStateRef GCChecker::setRootSlotContent(ProgramStateRef State,
     return State;
 
   const SymbolRef *Current = State->get<GCRootContentMap>(Lookup.SlotRegion);
-  if (!Sym && !Current)
-    return State;
-  if (Sym && Current && *Current == Sym) {
+  if (!Sym) {
+    State = setCellContent(State, GCCell::forRegion(Lookup.SlotRegion),
+                           nullptr);
+    if (!Current)
+      return State;
+    State = removeRootSlotFromValues(State, Lookup.SlotRegion);
+    return State->remove<GCRootContentMap>(Lookup.SlotRegion);
+  }
+  if (!Current) {
+    State = setCellContent(State, GCCell::forRegion(Lookup.SlotRegion), Sym);
+    State = State->set<GCRootContentMap>(Lookup.SlotRegion, Sym);
+    return markSymbolRooted(State, Sym, Lookup.SlotRegion);
+  }
+  if (Current && *Current == Sym) {
+    State = setCellContent(State, GCCell::forRegion(Lookup.SlotRegion), Sym);
     if (const GCValueRootSet *Roots = State->get<GCValueRootMap>(Sym)) {
       if (Roots->contains(Lookup.SlotRegion))
         return State;
@@ -675,9 +1112,7 @@ ProgramStateRef GCChecker::setRootSlotContent(ProgramStateRef State,
   }
 
   State = removeRootSlotFromValues(State, Lookup.SlotRegion);
-  if (!Sym)
-    return State->remove<GCRootContentMap>(Lookup.SlotRegion);
-
+  State = setCellContent(State, GCCell::forRegion(Lookup.SlotRegion), Sym);
   State = State->set<GCRootContentMap>(Lookup.SlotRegion, Sym);
   return markSymbolRooted(State, Sym, Lookup.SlotRegion);
 }
@@ -994,15 +1429,62 @@ bool GCChecker::propagateArgumentRootedness(CheckerContext &C,
 
   bool Change = false;
   int idx = 0;
+  auto hasCopyableRoots = [&](SymbolRef Sym) {
+    return Sym && (State->contains<GCValuePermanentRoots>(Sym) ||
+                   State->get<GCValueRootMap>(Sym));
+  };
+  auto stripCasts = [](const Expr *E) {
+    while (E) {
+      E = E->IgnoreParens();
+      if (const auto *Cast = dyn_cast<CastExpr>(E)) {
+        E = Cast->getSubExpr();
+        continue;
+      }
+      return E;
+    }
+    return E;
+  };
+  auto symbolForExprValue = [&](const Expr *E,
+                                const LocationContext *ArgLCtx) -> SymbolRef {
+    E = stripCasts(E);
+    SVal V = State->getSVal(E, ArgLCtx);
+    if (SymbolRef Sym = V.getAsSymbol())
+      return Sym;
+    if (const MemRegion *R = V.getAsRegion())
+      return State->getSVal(R).getAsSymbol();
+    if (const auto *DRE = dyn_cast_or_null<DeclRefExpr>(E)) {
+      if (const auto *VD = dyn_cast<VarDecl>(DRE->getDecl()))
+        return State->getSVal(State->getLValue(VD, ArgLCtx)).getAsSymbol();
+    }
+    return nullptr;
+  };
+  auto rootedBaseFromArgExpr = [&](const Expr *ArgExpr,
+                                   const LocationContext *ArgLCtx) -> SymbolRef {
+    ArgExpr = stripCasts(ArgExpr);
+    if (const auto *ME = dyn_cast_or_null<MemberExpr>(ArgExpr)) {
+      SymbolRef BaseSym = symbolForExprValue(ME->getBase(), ArgLCtx);
+      if (hasCopyableRoots(BaseSym))
+        return BaseSym;
+    }
+    return nullptr;
+  };
   for (const auto P : FD->parameters()) {
     if (!isGCTrackedType(P->getType())) {
       continue;
     }
-    auto Arg = State->getSVal(CE->getArg(idx++), LCtx->getParent());
+    const Expr *ArgExpr = CE->getArg(idx++);
+    const LocationContext *ArgLCtx = LCtx->getParent();
+    auto Arg = State->getSVal(ArgExpr, ArgLCtx);
     SymbolRef ArgSym = getTrackedSymbolForSVal(State, Arg);
+    SymbolRef BaseRootSym = rootedBaseFromArgExpr(ArgExpr, ArgLCtx);
+    if (!ArgSym && BaseRootSym)
+      ArgSym = BaseRootSym;
     if (!ArgSym) {
       continue;
     }
+    SymbolRef RootSourceSym = ArgSym;
+    if (!hasCopyableRoots(RootSourceSym) && BaseRootSym)
+      RootSourceSym = BaseRootSym;
     const ValueState *ValS = State->get<GCValueMap>(ArgSym);
     if (!ValS) {
       report_error(
@@ -1026,7 +1508,13 @@ bool GCChecker::propagateArgumentRootedness(CheckerContext &C,
       continue;
     }
     State = State->set<GCValueMap>(ParamSym, *ValS);
-    State = copySymbolRoots(State, ParamSym, ArgSym);
+    bool RootSourceReachable = isSymbolOrOriginRooted(State, RootSourceSym);
+    State = copySymbolRoots(State, ParamSym, RootSourceSym);
+    if (RootSourceReachable && !isSymbolOrOriginRooted(State, ParamSym)) {
+      State = setObjectChildContent(State, RootSourceSym,
+                                    GCCell::forHeapArraySummary(RootSourceSym),
+                                    ParamSym);
+    }
     Change = true;
   }
   return Change;
@@ -1066,6 +1554,17 @@ void GCChecker::checkBeginFunction(CheckerContext &C) const {
       auto Param = State->getLValue(P, LCtx);
       const MemRegion *Root = State->getSVal(Param).getAsRegion();
       State = State->set<GCRootMap>(Root, RootState::getPermanentRoot());
+      State = State->set<GCRootRegistry>(GCCell::forRegion(Root),
+                                         RootState::getPermanentRoot());
+    } else if (P->getName() == "args" && P->getType()->isPointerType() &&
+               P->getType()->getPointeeType()->isPointerType() &&
+               isGCTrackedType(P->getType()->getPointeeType())) {
+      auto Param = State->getLValue(P, LCtx);
+      const MemRegion *Root = State->getSVal(Param).getAsRegion();
+      State = State->set<GCRootMap>(Root, RootState::getPermanentRootArray());
+      State = State->set<GCRootRegistry>(GCCell::forRegion(Root),
+                                         RootState::getPermanentRootArray());
+      Change = true;
     } else if (isGCTrackedType(P->getType())) {
       auto Param = State->getLValue(P, LCtx);
       SymbolRef AssignedSym = State->getSVal(Param).getAsSymbol();
@@ -1345,20 +1844,7 @@ bool GCChecker::processPotentialSafepoint(const CallEvent &Call,
   // Don't free the return value
   SymbolRef RetSym = Call.getReturnValue().getAsSymbol();
 
-  // Symbolically free all unrooted values.
-  GCValueMapTy AMap = State->get<GCValueMap>();
-  for (auto I = AMap.begin(), E = AMap.end(); I != E; ++I) {
-    if (I.getData().isJustAllocated()) {
-      if (isSymbolOrOriginRooted(State, I.getKey()))
-        continue;
-      if (SpeciallyRootedSymbol == I.getKey())
-        continue;
-      if (RetSym == I.getKey())
-        continue;
-      State = State->set<GCValueMap>(I.getKey(), ValueState::getFreed());
-      DidChange = true;
-    }
-  }
+  State = runGCSafepoint(State, SpeciallyRootedSymbol, RetSym, DidChange);
   return DidChange;
 }
 
@@ -1388,26 +1874,257 @@ bool GCChecker::processArgumentRooting(const CallEvent &Call, CheckerContext &C,
   const FunctionDecl *FD = Decl ? Decl->getAsFunction() : nullptr;
   if (!FD)
     return false;
-  const MemRegion *RootingRegion = nullptr;
+  if (FD->getDeclName().isIdentifier()) {
+    StringRef Name = FD->getName();
+    if (Name == "jl_svecset" || Name == "jl_array_ptr_set")
+      return false;
+  }
+  SVal RootingVal;
+  bool SawRootingVal = false;
   SymbolRef RootedSymbol = nullptr;
   for (unsigned i = 0; i < FD->getNumParams(); ++i) {
     if (declHasAnnotation(FD->getParamDecl(i), "julia_rooting_argument")) {
-      RootingRegion = Call.getArgSVal(i).getAsRegion();
+      RootingVal = Call.getArgSVal(i);
+      SawRootingVal = true;
     } else if (declHasAnnotation(FD->getParamDecl(i),
                                  "julia_rooted_argument")) {
       RootedSymbol = Call.getArgSVal(i).getAsSymbol();
     }
   }
-  if (!RootingRegion || !RootedSymbol)
+  if (!SawRootingVal || !RootedSymbol)
     return false;
-  SymbolRef RootingSym = getRootedSymbolForRegion(State, RootingRegion);
+  SymbolRef RootingSym = getTrackedSymbolForSVal(State, RootingVal);
   const ValueState *OldVState =
       RootingSym ? State->get<GCValueMap>(RootingSym) : nullptr;
   if (!OldVState)
     return false;
-  State = State->set<GCValueMap>(RootedSymbol, *OldVState);
-  State = copySymbolRoots(State, RootedSymbol, RootingSym);
+  if (!State->get<GCValueMap>(RootedSymbol)) {
+    State = State->set<GCValueMap>(RootedSymbol, ValueState::getAllocated());
+  }
+  State = setObjectChildContent(State, RootingSym,
+                                GCCell::forHeapArraySummary(RootingSym),
+                                RootedSymbol);
+  State = addSymbolRoots(State, RootedSymbol, RootingSym);
   return true;
+}
+
+bool GCChecker::processHeapEffects(const CallEvent &Call, CheckerContext &C,
+                                   ProgramStateRef &State) const {
+  auto *Decl = Call.getDecl();
+  const FunctionDecl *FD = Decl ? Decl->getAsFunction() : nullptr;
+  if (!FD || !FD->getDeclName().isIdentifier())
+    return false;
+
+  StringRef Name = FD->getName();
+  bool Changed = false;
+
+  auto indexedChild = [&](SymbolRef Owner, unsigned IndexArg) {
+    int64_t Index = 0;
+    if (IndexArg < Call.getNumArgs() &&
+        getConcreteIndex(Call.getArgSVal(IndexArg), Index))
+      return GCCell::forHeapArrayElement(Owner, Index);
+    return GCCell::forHeapArraySummary(Owner);
+  };
+
+  auto ensureTracked = [&](SymbolRef Sym) {
+    if (Sym && !State->get<GCValueMap>(Sym))
+      State = State->set<GCValueMap>(Sym, ValueState::getAllocated());
+  };
+
+  auto hasCopyableRoots = [&](SymbolRef Sym) {
+    return Sym && (State->contains<GCValuePermanentRoots>(Sym) ||
+                   State->get<GCValueRootMap>(Sym));
+  };
+
+  auto stripCasts = [](const Expr *E) {
+    while (E) {
+      E = E->IgnoreParens();
+      if (const auto *Cast = dyn_cast<CastExpr>(E)) {
+        E = Cast->getSubExpr();
+        continue;
+      }
+      return E;
+    }
+    return E;
+  };
+
+  auto symbolForExprValue = [&](const Expr *E) -> SymbolRef {
+    E = stripCasts(E);
+    SVal V = C.getSVal(E);
+    if (SymbolRef Sym = V.getAsSymbol())
+      return Sym;
+    if (const MemRegion *R = V.getAsRegion())
+      return State->getSVal(R).getAsSymbol();
+    if (const auto *DRE = dyn_cast_or_null<DeclRefExpr>(E)) {
+      if (const auto *VD = dyn_cast<VarDecl>(DRE->getDecl()))
+        return State->getSVal(State->getLValue(VD, C.getLocationContext()))
+            .getAsSymbol();
+    }
+    return nullptr;
+  };
+
+  auto rootedBaseFromArgExpr = [&](unsigned ArgIdx) -> SymbolRef {
+    if (ArgIdx >= Call.getNumArgs())
+      return nullptr;
+    const Expr *ArgExpr = stripCasts(Call.getArgExpr(ArgIdx));
+    const auto *ME = dyn_cast_or_null<MemberExpr>(ArgExpr);
+    if (!ME)
+      return nullptr;
+    SymbolRef BaseSym = symbolForExprValue(ME->getBase());
+    return hasCopyableRoots(BaseSym) ? BaseSym : nullptr;
+  };
+
+  auto canonicalizeSymbol = [&](SymbolRef Sym) -> SymbolRef {
+    if (!Sym)
+      return nullptr;
+    if (const MemRegion *Origin = getOriginRegion(Sym)) {
+      SymbolRef OriginSym = State->getSVal(Origin).getAsSymbol();
+      if (OriginSym && State->get<GCValueMap>(OriginSym))
+        return OriginSym;
+    }
+    return Sym;
+  };
+
+  auto rootSourceForOrigin = [&](SymbolRef Sym) -> SymbolRef {
+    if (!Sym)
+      return nullptr;
+    const MemRegion *Origin = getOriginRegion(Sym);
+    if (!Origin)
+      return nullptr;
+    if (SymbolRef RootSource = getRootedSymbolForRegion(State, Origin))
+      return RootSource;
+    SymbolRef OriginSym = State->getSVal(Origin).getAsSymbol();
+    if (OriginSym && OriginSym != Sym && isSymbolOrOriginRooted(State, OriginSym))
+      return OriginSym;
+    return nullptr;
+  };
+
+  auto materializeOriginReachability = [&](SymbolRef Sym) {
+    for (unsigned I = 0; I < 4 && Sym && !isSymbolRooted(State, Sym); ++I) {
+      SymbolRef RootSource = rootSourceForOrigin(Sym);
+      if (!RootSource || RootSource == Sym)
+        return;
+      State = addObjectSymbolChild(State, RootSource, Sym);
+      State = addSymbolRoots(State, Sym, RootSource);
+      Sym = RootSource;
+    }
+  };
+
+  if (Name == "jl_gc_wb" || Name == "jl_gc_wb_fresh" ||
+      Name == "jl_gc_wb_current_task" || Name == "jl_gc_wb_knownold") {
+    if (Call.getNumArgs() < 2)
+      return false;
+    SymbolRef Owner =
+        canonicalizeSymbol(getTrackedSymbolForSVal(State, Call.getArgSVal(0)));
+    SymbolRef ChildSym = Call.getArgSVal(1).getAsSymbol();
+    if (!ChildSym)
+      ChildSym = getTrackedSymbolForSVal(State, Call.getArgSVal(1));
+    ChildSym = canonicalizeSymbol(ChildSym);
+    if (!Owner || !ChildSym)
+      return false;
+    ensureTracked(ChildSym);
+    materializeOriginReachability(Owner);
+    State = addObjectSymbolChild(State, Owner, ChildSym);
+    State = setObjectChildContent(State, Owner,
+                                  GCCell::forHeapArraySummary(Owner),
+                                  ChildSym);
+    if (hasCopyableRoots(Owner))
+      State = addSymbolRoots(State, ChildSym, Owner);
+    return true;
+  }
+
+  if (Name == "jl_svecset" || Name == "jl_array_ptr_set") {
+    if (Call.getNumArgs() < 3)
+      return false;
+    SymbolRef Owner =
+        canonicalizeSymbol(getTrackedSymbolForSVal(State, Call.getArgSVal(0)));
+    if (!Owner)
+      return false;
+    materializeOriginReachability(Owner);
+    SymbolRef ChildSym = Call.getArgSVal(2).getAsSymbol();
+    if (!ChildSym)
+      ChildSym = getTrackedSymbolForSVal(State, Call.getArgSVal(2));
+    ChildSym = canonicalizeSymbol(ChildSym);
+    ensureTracked(ChildSym);
+    State = setObjectChildContent(State, Owner, indexedChild(Owner, 1),
+                                  ChildSym);
+    SymbolRef RootingOwner = hasCopyableRoots(Owner) ? Owner
+                                                     : rootedBaseFromArgExpr(0);
+    if (RootingOwner) {
+      State = setObjectChildContent(State, RootingOwner,
+                                    GCCell::forHeapArraySummary(RootingOwner),
+                                    ChildSym);
+      State = addSymbolRoots(State, ChildSym, RootingOwner);
+    }
+    return true;
+  }
+
+  if (Name == "jl_svecref" || Name == "jl_array_ptr_ref" ||
+      Name == "jl_get_nth_field_checked") {
+    if (Call.getNumArgs() < 2)
+      return false;
+    SymbolRef Owner =
+        canonicalizeSymbol(getTrackedSymbolForSVal(State, Call.getArgSVal(0)));
+    SymbolRef RetSym = Call.getReturnValue().getAsSymbol();
+    if (!Owner || !RetSym)
+      return false;
+    materializeOriginReachability(Owner);
+    SymbolRef RootingOwner = hasCopyableRoots(Owner) ? Owner
+                                                     : rootedBaseFromArgExpr(0);
+    auto markReadFromRootedOwner = [&](SymbolRef Sym) {
+      if (!Sym)
+        return;
+      ensureTracked(Sym);
+      if (!RootingOwner)
+        return;
+      if (const ValueState *VS = State->get<GCValueMap>(Sym)) {
+        if (VS->isPotentiallyFreed())
+          State = State->set<GCValueMap>(Sym, ValueState::getAllocated());
+      }
+      State = addSymbolRoots(State, Sym, RootingOwner);
+    };
+
+    GCCell Child = indexedChild(Owner, 1);
+    State = addObjectChild(State, Owner, Child);
+    if (!Child.isSummaryCell() &&
+        State->get<GCCellContentMap>(Child)) {
+      const SymbolRef *Existing = State->get<GCCellContentMap>(Child);
+      markReadFromRootedOwner(*Existing);
+      if (Call.getOriginExpr())
+        State = State->BindExpr(Call.getOriginExpr(), C.getLocationContext(),
+                                C.getSValBuilder().makeSymbolVal(*Existing));
+      Changed = true;
+    } else {
+      markReadFromRootedOwner(RetSym);
+      if (!Child.isSummaryCell())
+        State = setCellContent(State, Child, RetSym);
+      Changed = true;
+    }
+    return Changed;
+  }
+
+  bool IsSVecConstructor =
+      Name == "jl_svec1" || Name == "jl_svec2" || Name == "jl_svec3" ||
+      Name == "jl_svec" || Name == "ijl_svec";
+  if (!IsSVecConstructor)
+    return false;
+
+  SymbolRef Owner = Call.getReturnValue().getAsSymbol();
+  if (!Owner)
+    return false;
+
+  unsigned FirstValueArg =
+      (Name == "jl_svec" || Name == "ijl_svec") ? 1 : 0;
+  for (unsigned I = FirstValueArg; I < Call.getNumArgs(); ++I) {
+    SymbolRef ChildSym = Call.getArgSVal(I).getAsSymbol();
+    if (!ChildSym || !State->get<GCValueMap>(ChildSym))
+      continue;
+    GCCell Child = GCCell::forHeapArrayElement(Owner, I - FirstValueArg);
+    State = setObjectChildContent(State, Owner, Child, ChildSym);
+    Changed = true;
+  }
+
+  return Changed;
 }
 
 bool GCChecker::processAllocationOfResult(const CallEvent &Call,
@@ -1495,6 +2212,7 @@ void GCChecker::checkPostCall(const CallEvent &Call, CheckerContext &C) const {
   if (!C.wasInlined)
     didChange |= processPotentialSafepoint(Call, C, State);
   didChange |= processAllocationOfResult(Call, C, State);
+  didChange |= processHeapEffects(Call, C, State);
   if (didChange)
     C.addTransition(State);
 }
@@ -1605,6 +2323,22 @@ void GCChecker::checkDerivingExpr(const Expr *Result, const Expr *Parent,
   }
   // NewSym might already have a better root
   const ValueState *NewValS = State->get<GCValueMap>(NewSym);
+  if (ParentIsLoc) {
+    if (std::optional<GCCell> SourceCell = resolveCell(State, Region)) {
+      if (SourceCell->isHeapCell()) {
+        SymbolRef Owner = SourceCell->Owner;
+        const ValueState *OwnerState =
+            Owner ? State->get<GCValueMap>(Owner) : nullptr;
+        if (OwnerState && isSymbolOrOriginRooted(State, Owner)) {
+          State = State->set<GCValueMap>(NewSym, ValueState::getAllocated());
+          State = setObjectChildContent(State, Owner, *SourceCell, NewSym);
+          State = addSymbolRoots(State, NewSym, Owner);
+          C.addTransition(State);
+          return;
+        }
+      }
+    }
+  }
   if (Region) {
     const VarRegion *VR = Region->getAs<VarRegion>();
     bool inheritedState = false;
@@ -1666,6 +2400,18 @@ void GCChecker::checkDerivingExpr(const Expr *Result, const Expr *Parent,
                        "Creating derivative of value that may have been GCed");
   } else if (ResultTracked) {
     State = State->set<GCValueMap>(NewSym, *OldValS);
+    GCCell Child = GCCell::forHeapArraySummary(OldSym);
+    const Expr *CellExpr = ParentIsLoc ? Parent : Result;
+    if (const auto *ME = dyn_cast<MemberExpr>(CellExpr->IgnoreParenCasts())) {
+      if (const auto *FD = dyn_cast<FieldDecl>(ME->getMemberDecl()))
+        Child = GCCell::forHeapField(OldSym, FD);
+    } else if (const auto *ASE =
+                   dyn_cast<ArraySubscriptExpr>(CellExpr->IgnoreParenCasts())) {
+      int64_t Index = 0;
+      if (getConcreteIndex(C.getSVal(ASE->getIdx()), Index))
+        Child = GCCell::forHeapArrayElement(OldSym, Index);
+    }
+    State = setObjectChildContent(State, OldSym, Child, NewSym);
     State = addSymbolRoots(State, NewSym, OldSym);
     C.addTransition(State);
     return;
@@ -1853,7 +2599,7 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
       }
     }
     for (const MemRegion *R : PoppedRoots) {
-      State = removeRootSlotsForRoot(State, R);
+      State = State->remove<GCRootRegistry>(GCCell::forRegion(R));
       State = State->remove<GCRootMap>(R);
     }
     C.addTransition(State);
@@ -1875,19 +2621,22 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
       }
       const MemRegion *Region = MRV->getRegion();
       State = State->set<GCRootMap>(Region, RootState::getRoot(CurrentDepth));
+      State = State->set<GCRootRegistry>(GCCell::forRegion(Region),
+                                         RootState::getRoot(CurrentDepth));
       // Now for the value
       SVal Value = State->getSVal(Region);
       SymbolRef Sym = Value.getAsSymbol();
-      if (!Sym)
+      if (!Sym) {
+        State = setRootSlotContent(State, Region, nullptr);
         continue;
+      }
       const ValueState *ValState = State->get<GCValueMap>(Sym);
       if (!ValState)
         continue;
       if (ValState->isPotentiallyFreed())
         report_value_error(C, Sym,
                            "Trying to root value which may have been GCed");
-      State = State->set<GCRootContentMap>(Region, Sym);
-      State = markSymbolRooted(State, Sym, Region);
+      State = setRootSlotContent(State, Region, Sym);
     }
     CurrentDepth += 1;
     State = State->set<GCDepth>(CurrentDepth);
@@ -1904,6 +2653,8 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
     const MemRegion *Region = MRV->getRegion()->StripCasts();
     State =
         State->set<GCRootMap>(Region, RootState::getRootArray(CurrentDepth));
+    State = State->set<GCRootRegistry>(GCCell::forRegion(Region),
+                                       RootState::getRootArray(CurrentDepth));
     CurrentDepth += 1;
     State = State->set<GCDepth>(CurrentDepth);
     C.addTransition(State);
@@ -1911,6 +2662,12 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
   } else if (name == "JL_GC_PROMISE_ROOTED") {
     SVal Arg = C.getSVal(CE->getArg(0));
     SymbolRef Sym = Arg.getAsSymbol();
+    if (!Sym)
+      Sym = getTrackedSymbolForSVal(C.getState(), Arg);
+    if (!Sym) {
+      if (const MemRegion *Region = Arg.getAsRegion())
+        Sym = C.getState()->getSVal(Region).getAsSymbol();
+    }
     if (!Sym) {
       report_error(C, "Can not understand this promise.");
       return true;
@@ -1949,6 +2706,8 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
       // The items list is now rooted
       State = State->set<GCRootMap>(Items.getAsRegion(),
                                     RootState::getRootArray(CurrentDepth));
+      State = State->set<GCRootRegistry>(GCCell::forRegion(Items.getAsRegion()),
+                                         RootState::getRootArray(CurrentDepth));
     }
     C.addTransition(State);
     return true;
@@ -2008,11 +2767,61 @@ void GCChecker::checkBind(SVal LVal, SVal RVal, const clang::Stmt *S,
   if (!R) {
     return;
   }
+  std::optional<GCCell> Cell = resolveCell(State, R);
   RootLookupResult RootLookup;
   bool shouldBeRootArray = R->getAs<ElementRegion>();
   bool HasRoot = lookupRootRegion(State, R, &RootLookup);
   SymbolRef Sym = RVal.getAsSymbol();
+  const auto *TrackedRValState = Sym ? State->get<GCValueMap>(Sym) : nullptr;
+  auto hasCopyableRoots = [&](SymbolRef RootSym) {
+    return RootSym && (State->contains<GCValuePermanentRoots>(RootSym) ||
+                       State->get<GCValueRootMap>(RootSym));
+  };
+  if (!TrackedRValState && Sym) {
+    bool LHSCanHoldGC = false;
+    if (const auto *TVR = R->getAs<TypedValueRegion>())
+      LHSCanHoldGC = isGCTrackedType(TVR->getValueType());
+    if (LHSCanHoldGC) {
+      if (const MemRegion *Origin = getOriginRegion(Sym)) {
+        std::optional<GCCell> SourceCell = resolveCell(State, Origin);
+        if (SourceCell && SourceCell->isHeapCell()) {
+          SymbolRef Owner = SourceCell->Owner;
+          const ValueState *OwnerState =
+              Owner ? State->get<GCValueMap>(Owner) : nullptr;
+          if (OwnerState && isSymbolOrOriginRooted(State, Owner)) {
+            State = State->set<GCValueMap>(Sym, *OwnerState);
+            State = setObjectChildContent(State, Owner, *SourceCell, Sym);
+            if (hasCopyableRoots(Owner))
+              State = addSymbolRoots(State, Sym, Owner);
+            TrackedRValState = State->get<GCValueMap>(Sym);
+          }
+        }
+      }
+    }
+  }
+  bool DidCellUpdate = false;
+  if (Cell && (TrackedRValState || State->get<GCCellContentMap>(*Cell))) {
+    State = setCellContent(State, *Cell, TrackedRValState ? Sym : nullptr);
+    DidCellUpdate = true;
+  }
+  if (Cell && Cell->isHeapCell()) {
+    if (TrackedRValState) {
+      if (TrackedRValState->isPotentiallyFreed())
+        report_value_error(C, Sym,
+                           "Trying to store value which may have been GCed");
+      State = setObjectChildContent(State, Cell->Owner, *Cell, Sym);
+      if (hasCopyableRoots(Cell->Owner))
+        State = addSymbolRoots(State, Sym, Cell->Owner);
+      C.addTransition(State);
+      return;
+    }
+    if (DidCellUpdate)
+      C.addTransition(State);
+    return;
+  }
   if (!Sym && !HasRoot) {
+    if (DidCellUpdate)
+      C.addTransition(State);
     return;
   }
   if (!HasRoot) {
@@ -2035,10 +2844,17 @@ void GCChecker::checkBind(SVal LVal, SVal RVal, const clang::Stmt *S,
               RootSource ? State->get<GCValueMap>(RootSource) : nullptr)
         ValS = *RootSourceState;
     }
-    if (!LHSRooted)
+    if (!LHSRooted) {
+      if (DidCellUpdate)
+        C.addTransition(State);
       return;
+    }
 
     State = State->set<GCValueMap>(Sym, ValS);
+    if (RootSource)
+      State = setObjectChildContent(State, RootSource,
+                                    GCCell::forHeapArraySummary(RootSource),
+                                    Sym);
     if (RootSource)
       State = addSymbolRoots(State, Sym, RootSource);
     else
@@ -2101,6 +2917,8 @@ bool GCChecker::rootRegionIfGlobal(const MemRegion *R, ProgramStateRef &State,
   if (declHasAnnotation(VD, "julia_globally_rooted") ||
       isGloballyRootedType(VD->getType())) {
     State = State->set<GCRootMap>(R, RootState::getPermanentRoot());
+    State = State->set<GCRootRegistry>(GCCell::forRegion(R),
+                                       RootState::getPermanentRoot());
     isGlobalRoot = true;
     if (IsRooted)
       *IsRooted = true;
@@ -2115,6 +2933,7 @@ bool GCChecker::rootRegionIfGlobal(const MemRegion *R, ProgramStateRef &State,
     if (!GVState)
       State = State->set<GCValueMap>(Sym, TheValS);
     if (isGlobalRoot) {
+      State = setCellContent(State, GCCell::forRegion(R), Sym);
       State = State->set<GCRootContentMap>(R, Sym);
       State = markSymbolRooted(State, Sym, R);
     }
@@ -2138,8 +2957,11 @@ void GCChecker::checkLocation(SVal SLoc, bool IsLoad, const Stmt *S,
         State = State->set<GCValueMap>(LoadedSym, ValueState::getAllocated());
       if (Lookup.SlotRegion) {
         DidChange = true;
-        if (!State->get<GCRootContentMap>(Lookup.SlotRegion))
+        if (!State->get<GCRootContentMap>(Lookup.SlotRegion)) {
+          State = setCellContent(State, GCCell::forRegion(Lookup.SlotRegion),
+                                 LoadedSym);
           State = State->set<GCRootContentMap>(Lookup.SlotRegion, LoadedSym);
+        }
         State = markSymbolRooted(State, LoadedSym, Lookup.SlotRegion);
       } else if (!isSymbolOrOriginRooted(State, LoadedSym)) {
         DidChange = true;

--- a/src/gf.c
+++ b/src/gf.c
@@ -1118,7 +1118,9 @@ static jl_value_t *inst_varargp_in_env(jl_value_t *decl, jl_svec_t *sparams)
                 vm = T_has_tv ? jl_type_unionall(v, T) : T;
                 if (N_has_tv)
                     N = NULL;
+                JL_GC_PUSH1(&N);
                 vm = (jl_value_t*)jl_wrap_vararg(vm, N, 1, 0); // this cannot throw for these inputs
+                JL_GC_POP();
             }
             sp++;
             decl = ((jl_unionall_t*)decl)->body;
@@ -2250,6 +2252,8 @@ static int jl_type_intersection2(jl_value_t *t1, jl_value_t *t2, jl_value_t **is
 // check if `type` is replacing `m` with an ambiguity here, given other methods in `d` that already match it
 static int is_replacing(char ambig, jl_value_t *type, jl_method_t *m, jl_method_t *const *d, size_t n, jl_value_t *isect, jl_value_t *isect2, char *morespec)
 {
+    int ret = 1;
+    JL_GC_PUSH2(&isect, &isect2);
     size_t k;
     for (k = 0; k < n; k++) {
         jl_method_t *m2 = d[k];
@@ -2258,7 +2262,7 @@ static int is_replacing(char ambig, jl_value_t *type, jl_method_t *m, jl_method_
             continue;
         if (morespec[k])
             // not actually shadowing this--m2 will still be better
-            return 0;
+            goto not_replacing;
         // if type is not more specific than m (thus now dominating it)
         // then there is a new ambiguity here,
         // since m2 was also a previous match over isect,
@@ -2266,10 +2270,15 @@ static int is_replacing(char ambig, jl_value_t *type, jl_method_t *m, jl_method_
         // or if this was already ambiguous before
         if (ambig && !jl_type_morespecific(m->sig, m2->sig)) {
             // m and m2 were previously ambiguous over the full intersection of mi with type, and will still be ambiguous with addition of type
-            return 0;
+            goto not_replacing;
         }
     }
-    return 1;
+    goto done;
+not_replacing:
+    ret = 0;
+done:
+    JL_GC_POP();
+    return ret;
 }
 
 static int _invalidate_dispatch_backedges(jl_method_instance_t *mi, jl_value_t *type, jl_method_t *m,
@@ -2726,7 +2735,7 @@ jl_typemap_entry_t *jl_method_table_add(jl_methtable_t *mt, jl_method_t *method,
     return newentry;
 }
 
-static int has_key(jl_genericmemory_t *keys, jl_value_t *key)
+static int has_key(jl_genericmemory_t *keys, jl_value_t *key) JL_NOTSAFEPOINT
 {
     for (size_t l = keys->length, i = 0; i < l; i++) {
         jl_value_t *k = jl_genericmemory_ptr_ref(keys, i);
@@ -2739,7 +2748,7 @@ static int has_key(jl_genericmemory_t *keys, jl_value_t *key)
 }
 
 // Check if m2 is in m1's interferences set, which means !morespecific(m1, m2)
-static int method_in_interferences(jl_method_t *m2, jl_method_t *m1)
+static int method_in_interferences(jl_method_t *m2, jl_method_t *m1) JL_NOTSAFEPOINT
 {
     return has_key(jl_atomic_load_relaxed(&m1->interferences), (jl_value_t*)m2);
 }
@@ -2902,8 +2911,9 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     jl_value_t *loctag = NULL;  // debug info for invalidation
     jl_value_t *isect = NULL;
     jl_value_t *isect2 = NULL;
+    jl_value_t *replaced_root = NULL;
     jl_genericmemory_t *interferences = NULL;
-    JL_GC_PUSH6(&oldvalue, &oldmi, &loctag, &isect, &isect2, &interferences);
+    JL_GC_PUSH9(&oldvalue, &oldmi, &loctag, &isect, &isect2, &replaced_root, &interferences, &type, &method);
     jl_typemap_entry_t *replaced = NULL;
     // Check what entries this intersects with in the prior world.
     oldvalue = get_intersect_matches(jl_atomic_load_relaxed(&mt->defs), newentry, &replaced, max_world);
@@ -2936,7 +2946,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
     if (oldvalue) {
         assert(n > 0);
         if (replaced) {
-            oldvalue = (jl_value_t*)replaced;
+            replaced_root = (jl_value_t*)replaced;
             jl_method_t *m = replaced->func.method;
             invalidated = 1;
             method_overwrite(newentry, m);

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -727,7 +727,7 @@ static jl_value_t *jl_decode_value_phic(jl_ircode_state *s, uint8_t tag)
         len = read_int32(s->s);
     jl_array_t *v = jl_alloc_vec_any(len);
     jl_value_t *phic = (jl_value_t*)v;
-    JL_GC_PUSH1(&phic);
+    JL_GC_PUSH2(&phic, &v);
     phic = jl_new_struct(jl_phicnode_type, v);
     jl_value_t **data = jl_array_ptr_data(v);
     for (i = 0; i < len; i++) {

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1089,8 +1089,14 @@ static jl_datatype_t *lookup_type_set(jl_svec_t *cache, jl_value_t **key, size_t
         jl_datatype_t *val = jl_atomic_load_relaxed(&tab[index]);
         if ((jl_value_t*)val == jl_nothing)
             return NULL;
-        if (val->hash == hv && typekey_eq(val, key, n))
-            return val;
+        if (val->hash == hv) {
+            int eq;
+            JL_GC_PUSH1(&val);
+            eq = typekey_eq(val, key, n);
+            JL_GC_POP();
+            if (eq)
+                return val;
+        }
         index = (index + 1) & (sz - 1);
         iter++;
     } while (iter <= maxprobe && index != orig);
@@ -1112,8 +1118,14 @@ static jl_datatype_t *lookup_type_setvalue(jl_svec_t *cache, jl_value_t *key1, j
         jl_datatype_t *val = jl_atomic_load_relaxed(&tab[index]);
         if ((jl_value_t*)val == jl_nothing)
             return NULL;
-        if (val->hash == hv && typekeyvalue_eq(val, key1, key, n, leaf))
-            return val;
+        if (val->hash == hv) {
+            int eq;
+            JL_GC_PUSH1(&val);
+            eq = typekeyvalue_eq(val, key1, key, n, leaf);
+            JL_GC_POP();
+            if (eq)
+                return val;
+        }
         index = (index + 1) & (sz - 1);
         iter++;
     } while (iter <= maxprobe && index != orig);
@@ -1134,7 +1146,11 @@ static ssize_t lookup_type_idx_linear(jl_svec_t *cache, jl_value_t **key, size_t
         jl_datatype_t *tt = jl_atomic_load_relaxed(&data[i]);
         if ((jl_value_t*)tt == jl_nothing)
             return ~i;
-        if (typekey_eq(tt, key, n))
+        int eq;
+        JL_GC_PUSH1(&tt);
+        eq = typekey_eq(tt, key, n);
+        JL_GC_POP();
+        if (eq)
             return i;
     }
     return ~cl;
@@ -1151,7 +1167,11 @@ static ssize_t lookup_type_idx_linearvalue(jl_svec_t *cache, jl_value_t *key1, j
         jl_datatype_t *tt = jl_atomic_load_relaxed(&data[i]);
         if ((jl_value_t*)tt == jl_nothing)
             return ~i;
-        if (typekeyvalue_eq(tt, key1, key, n, 1))
+        int eq;
+        JL_GC_PUSH1(&tt);
+        eq = typekeyvalue_eq(tt, key1, key, n, 1);
+        JL_GC_POP();
+        if (eq)
             return i;
     }
     return ~cl;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -933,7 +933,7 @@ JL_DLLEXPORT void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method
 void jl_method_table_activate(jl_typemap_entry_t *newentry);
 jl_typemap_entry_t *jl_method_table_add(jl_methtable_t *mt, jl_method_t *method, jl_tupletype_t *simpletype);
 jl_method_t *jl_mk_builtin_func(jl_datatype_t *dt, jl_sym_t *name, jl_fptr_args_t fptr) JL_GC_DISABLED;
-int jl_obviously_unequal(jl_value_t *a, jl_value_t *b);
+int jl_obviously_unequal(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT;
 int jl_has_bound_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_array_t *jl_find_free_typevars(jl_value_t *v);
 JL_DLLEXPORT jl_value_t *jl_rewrap_free_typevars(jl_value_t *t, jl_array_t *pre);

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -522,7 +522,7 @@ static int obviously_egal(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT
     return !jl_is_type(a) && jl_egal(a,b);
 }
 
-static int obviously_unequal(jl_value_t *a, jl_value_t *b)
+static int obviously_unequal(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT
 {
     if (a == (jl_value_t*)jl_typeofbottom_type->super)
         a = (jl_value_t*)jl_typeofbottom_type; // supertype(typeof(Union{})) is equal to, although distinct from, itself
@@ -593,7 +593,7 @@ static int obviously_unequal(jl_value_t *a, jl_value_t *b)
     return 0;
 }
 
-int jl_obviously_unequal(jl_value_t *a, jl_value_t *b)
+int jl_obviously_unequal(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT
 {
     return obviously_unequal(a, b);
 }

--- a/test/clangsa/MissingRoots.c
+++ b/test/clangsa/MissingRoots.c
@@ -391,6 +391,54 @@ void argument_propagation(jl_value_t *a) {
   JL_GC_POP();
 }
 
+void rooted_svec_parent_keeps_child(void) {
+  jl_value_t *child = (jl_value_t*)new_expr_for_analyzer();
+  jl_value_t *alias = child;
+  jl_svec_t *parent = NULL;
+  JL_GC_PUSH2(&child, &parent);
+  parent = jl_svec1(child);
+  child = NULL;
+  jl_gc_safepoint();
+  look_at_value(alias);
+  JL_GC_POP();
+}
+
+void rooted_svec_clear_releases_child(void) {
+  jl_value_t *child = (jl_value_t*)new_expr_for_analyzer(); // expected-note{{Started tracking value here}}
+  jl_value_t *alias = child;
+  jl_svec_t *parent = NULL;
+  JL_GC_PUSH2(&child, &parent); // expected-note{{GC frame changed here}}
+                                // expected-note@-1{{Value was rooted here}}
+  parent = jl_svec1(child);
+  child = NULL;
+  jl_svecset(parent, 0, NULL); // expected-note{{Root was released here}}
+  jl_gc_safepoint(); // expected-note{{Value may have been GCed here}}
+  look_at_value(alias); // expected-warning{{Argument value may have been GCed}}
+                        // expected-note@-1{{Argument value may have been GCed}}
+  JL_GC_POP();
+}
+
+void rooted_svec_replace_releases_old_child(void) {
+  jl_value_t *old_child = (jl_value_t*)new_expr_for_analyzer(); // expected-note{{Started tracking value here}}
+  jl_value_t *old_alias = old_child;
+  jl_value_t *new_child = NULL;
+  jl_value_t *new_alias = NULL;
+  jl_svec_t *parent = NULL;
+  JL_GC_PUSH3(&old_child, &new_child, &parent); // expected-note{{GC frame changed here}}
+                                                // expected-note@-1{{Value was rooted here}}
+  parent = jl_svec1(old_child);
+  old_child = NULL;
+  new_child = (jl_value_t*)new_expr_for_analyzer();
+  new_alias = new_child;
+  jl_svecset(parent, 0, new_child); // expected-note{{Root was released here}}
+  new_child = NULL;
+  jl_gc_safepoint(); // expected-note{{Value may have been GCed here}}
+  look_at_value(new_alias);
+  look_at_value(old_alias); // expected-warning{{Argument value may have been GCed}}
+                            // expected-note@-1{{Argument value may have been GCed}}
+  JL_GC_POP();
+}
+
 // New value creation via []
 void arg_array(jl_value_t **args) {
   jl_gc_safepoint();

--- a/test/clangsa/MissingRoots.c
+++ b/test/clangsa/MissingRoots.c
@@ -146,6 +146,103 @@ int pushargs_roots() {
   return val->length == 1;
 }
 
+// Root array slots remain roots when accessed through saved slot pointers.
+int pushargs_slot_pointer_roots() {
+  jl_value_t **margs;
+  jl_svec_t *val = jl_svec1(NULL);
+  JL_GC_PUSHARGS(margs, 2);
+  margs[1] = (jl_value_t*)val;
+  jl_value_t **slot = &margs[1];
+  jl_gc_safepoint();
+  look_at_value(*slot);
+  JL_GC_POP();
+  return 0;
+}
+
+int pushargs_slot_pointer_assignment_roots() {
+  jl_value_t **margs;
+  jl_svec_t *val = jl_svec1(NULL);
+  JL_GC_PUSHARGS(margs, 2);
+  jl_value_t **slot = &margs[1];
+  *slot = (jl_value_t*)val;
+  jl_gc_safepoint();
+  look_at_value(val);
+  JL_GC_POP();
+  return 0;
+}
+
+int pushargs_slot_pointer_after_pop_freed() {
+  jl_value_t **margs;
+  jl_svec_t *val = jl_svec1(NULL); // expected-note{{Started tracking value here}}
+  JL_GC_PUSHARGS(margs, 1); // expected-note{{GC frame changed here}}
+  jl_value_t **slot = &margs[0];
+  *slot = (jl_value_t*)val; // expected-note{{Value was rooted here}}
+  JL_GC_POP(); // expected-note{{GC frame changed here}}
+               // expected-note@-1{{Root was released here}}
+  jl_gc_safepoint(); // expected-note{{Value may have been GCed here}}
+  return val->length == 1; // expected-warning{{Trying to access value which may have been GCed}}
+                           // expected-note@-1{{Trying to access value which may have been GCed}}
+}
+
+int scalar_root_slot_pointer_assignment_roots() {
+  jl_svec_t *val = jl_svec1(NULL);
+  jl_value_t *root = NULL;
+  JL_GC_PUSH1(&root);
+  jl_value_t **slot = &root;
+  *slot = (jl_value_t*)val;
+  jl_gc_safepoint();
+  look_at_value((jl_value_t*)val);
+  JL_GC_POP();
+  return 0;
+}
+
+int scalar_root_overwrite_releases_old_value() {
+  jl_svec_t *root = jl_svec1(NULL); // expected-note{{Started tracking value here}}
+  jl_svec_t *alias = root;
+  JL_GC_PUSH1(&root); // expected-note{{GC frame changed here}}
+                      // expected-note@-1{{Value was rooted here}}
+  root = NULL; // expected-note{{Root was released here}}
+  jl_gc_safepoint(); // expected-note{{Value may have been GCed here}}
+  return alias->length == 1; // expected-warning{{Trying to access value which may have been GCed}}
+                             // expected-note@-1{{Trying to access value which may have been GCed}}
+}
+
+int permanent_root_slot_overwrite_releases_old_value(jl_value_t **slot JL_REQUIRE_ROOTED_SLOT) {
+  jl_svec_t *val = jl_svec1(NULL); // expected-note{{Started tracking value here}}
+  jl_svec_t *alias = val;
+  *slot = (jl_value_t*)val; // expected-note{{Value was rooted here}}
+  *slot = NULL; // expected-note{{Root was released here}}
+  jl_gc_safepoint(); // expected-note{{Value may have been GCed here}}
+  return alias->length == 1; // expected-warning{{Trying to access value which may have been GCed}}
+                             // expected-note@-1{{Trying to access value which may have been GCed}}
+}
+
+int multiple_root_overwrite_keeps_value_rooted() {
+  jl_svec_t *val = jl_svec1(NULL);
+  jl_value_t *root1 = NULL;
+  jl_value_t *root2 = NULL;
+  JL_GC_PUSH2(&root1, &root2);
+  root1 = (jl_value_t*)val;
+  root2 = (jl_value_t*)val;
+  root1 = NULL;
+  jl_gc_safepoint();
+  look_at_value((jl_value_t*)val);
+  JL_GC_POP();
+  return 0;
+}
+
+// Storing an already rooted value into a rooted object should not replace the
+// value's existing longer-lived root.
+void rooted_field_store_preserves_existing_root(jl_typename_t *tn) {
+  jl_datatype_t *dt = NULL;
+  JL_GC_PUSH1(&dt);
+  dt = (jl_datatype_t*)jl_svec1(NULL);
+  dt->name = tn;
+  JL_GC_POP();
+  jl_gc_safepoint();
+  look_at_value((jl_value_t*)tn);
+}
+
 int pushargs_roots_freed() {
   jl_value_t **margs;
   jl_svec_t *val = jl_svec1(NULL); // expected-note{{Started tracking value here}}
@@ -181,10 +278,107 @@ void globally_rooted() {
 }
 
 extern jl_value_t *first_array_elem(jl_array_t *a JL_PROPAGATES_ROOT);
+extern jl_expr_t *new_expr_for_analyzer(void);
 void root_propagation(jl_expr_t *expr) {
   jl_value_t *val = first_array_elem(expr->args);
   jl_gc_safepoint();
   look_at_value(val);
+}
+
+void rooted_argument_derivatives_keep_roots(jl_value_t *v) {
+  jl_value_t **data = (jl_value_t**)v;
+  jl_value_t *first = data[0];
+  jl_value_t *second = data[1];
+  jl_gc_safepoint();
+  look_at_value(first);
+  look_at_value(second);
+}
+
+void rooted_argument_cast_derivative_keeps_root(jl_value_t *v) {
+  jl_sym_t **data = (jl_sym_t**)v;
+  jl_sym_t *sym = data[0];
+  jl_gc_safepoint();
+  look_at_value((jl_value_t*)sym);
+}
+
+void rooted_svec_data_pointer_arithmetic_keeps_root(jl_svec_t *cache) {
+  jl_value_t **data = jl_svec_data(cache);
+  jl_value_t *val = data[0];
+  jl_gc_safepoint();
+  look_at_value(val);
+}
+
+static jl_value_t *rooted_svec_data_inlined_helper(jl_svec_t *cache) {
+  jl_value_t **data = jl_svec_data(cache);
+  return data[0];
+}
+
+void rooted_svec_data_inlined_call_keeps_root(jl_svec_t *cache) {
+  jl_svec_t *local = cache;
+  jl_value_t *val = rooted_svec_data_inlined_helper(local);
+  jl_gc_safepoint();
+  look_at_value(val);
+}
+
+void rooted_exprarg_siblings_keep_roots(jl_expr_t *warning) {
+  JL_GC_PUSH1(&warning);
+  jl_value_t *level = jl_exprarg(warning, 0);
+  jl_value_t *group = jl_exprarg(warning, 1);
+  (void)group;
+  jl_value_t *kwargs = jl_alloc_vec_any(0);
+  (void)kwargs;
+  look_at_value(level);
+  JL_GC_POP();
+}
+
+void rooted_returned_exprarg_siblings_keep_roots(void) {
+  jl_expr_t *warning = new_expr_for_analyzer();
+  JL_GC_PUSH1(&warning);
+  jl_value_t *level = jl_exprarg(warning, 0);
+  jl_value_t *group = jl_exprarg(warning, 1);
+  (void)group;
+  jl_value_t *kwargs = jl_alloc_vec_any(0);
+  (void)kwargs;
+  look_at_value(level);
+  JL_GC_POP();
+}
+
+static inline jl_value_t *root_array_outparam_value(jl_value_t **out) {
+  jl_value_t **margs;
+  JL_GC_PUSHARGS(margs, 1);
+  margs[0] = (jl_value_t*)new_expr_for_analyzer();
+  *out = margs[0];
+  JL_GC_POP();
+  return margs[0];
+}
+
+void root_outparam_after_safepointing_call(void) {
+  jl_value_t *out = NULL;
+  jl_value_t *result = root_array_outparam_value(&out);
+  (void)result;
+  JL_GC_PUSH1(&out);
+  JL_GC_POP();
+}
+
+static inline void rooted_outparam_value(jl_value_t **out) {
+  jl_svec_t *v = jl_svec1(NULL);
+  JL_GC_PUSH1(&v);
+  *out = (jl_value_t*)v;
+  JL_GC_POP();
+}
+
+void root_outparam_after_inlined_call(void) {
+  jl_value_t *out = NULL;
+  rooted_outparam_value(&out);
+  JL_GC_PUSH1(&out);
+  JL_GC_POP();
+}
+
+void apply_single_rooted_value(void) {
+  jl_value_t *f = jl_svec1(NULL);
+  JL_GC_PUSH1(&f);
+  (void)jl_apply(&f, 1);
+  JL_GC_POP();
 }
 
 void argument_propagation(jl_value_t *a) {


### PR DESCRIPTION
Split out from #61915, plus extra improvements. Separate root slot contents from value rootedness in the GC checker so assignments through saved root-slot pointers, root-slot overwrites, root-array aliases, and multi-root values update liveness consistently. Root lookup now returns both the canonical root lifetime and the concrete accessed slot, while ValueState remains the diagnostic summary of the best live root.

Plan by GPT 5.5 Pro. Implementation by GPT 5.5.