### PR TITLE
test: cover macro-generated method provenance

### DIFF
--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -11,11 +11,15 @@ using Logging
 module DeprecationTests # to test @deprecate
     f() = true
 
+    const source_file = Symbol(@__FILE__)
+
     # test the Symbol path of @deprecate
+    const f1_method_line = @__LINE__() + 1
     @deprecate f1 f
     @deprecate f2 f false # test that f2 is not exported
 
     # test the Expr path of @deprecate
+    const f3_method_line = @__LINE__() + 1
     @deprecate f3() f()
     @deprecate f4() f() false # test that f4 is not exported
     @deprecate f5(x::T) where T f()
@@ -32,6 +36,7 @@ module DeprecationTests # to test @deprecate
     @deprecate Sub.f2 f false
 
     # test that @deprecate_moved can be overridden by an import
+    const foo1234_method_line = @__LINE__() + 1
     Base.@deprecate_moved foo1234 "Foo"
     Base.@deprecate_moved bar "Bar" false
 
@@ -86,6 +91,20 @@ begin # @deprecate
     @test @test_warn "`A{T}(x::S) where {T, S}` is deprecated, use `f()` instead." A{Int}(1.)
 
     @test @test_warn "`Sub.f1()` is deprecated, use `f()` instead." DeprecationTests.Sub.f1()
+
+    # @deprecate-generated methods should report the macro call site.
+    let m = only(methods(DeprecationTests.f1))
+        @test m.file == DeprecationTests.source_file
+        @test m.line == DeprecationTests.f1_method_line
+    end
+    let m = only(methods(DeprecationTests.f3))
+        @test m.file == DeprecationTests.source_file
+        @test m.line == DeprecationTests.f3_method_line
+    end
+    let m = only(methods(DeprecationTests.foo1234))
+        @test m.file == DeprecationTests.source_file
+        @test m.line == DeprecationTests.foo1234_method_line
+    end
 
     redirect_stderr(devnull) do
         @test call(f1)

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -14,6 +14,7 @@ using Main.MacroCalls
 @test_throws ArgumentError("no arguments given for Enum Foo") @macrocall(@enum Foo)
 @test_throws ArgumentError("invalid base type for Enum Foo2, Foo2::Float64=::Float64; base type must be an integer primitive type") @macrocall(@enum Foo2::Float64 apple=1.)
 
+const fruit_enum_line = @__LINE__() + 1
 @enum Fruit apple orange kiwi
 @test typeof(Fruit) == DataType
 @test isbitstype(Fruit)
@@ -37,6 +38,10 @@ using Main.MacroCalls
 @test Fruit(2) == kiwi
 @test_throws ArgumentError Fruit(3)
 @test_throws ArgumentError Fruit(-1)
+let m = only(methods(Fruit))
+    @test m.file == Symbol(@__FILE__)
+    @test m.line == fruit_enum_line
+end
 @test UInt8(apple) === 0x00
 @test UInt16(orange) === 0x0001
 @test UInt128(kiwi) === 0x00000000000000000000000000000002


### PR DESCRIPTION
Add coverage for method source locations emitted by `@deprecate`, `@deprecate_moved`, and `@enum` so regressions point back to the macro call site.

Following up:
- #61931 
- #61932 