### PR TITLE
Allow instance docstrings within `@enum`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,11 +74,11 @@ New library features
   printing unsigned integers in decimal instead of hexadecimal ([#60267]).
 * The `StringView` type wraps an `AbstractVector{UInt8}` and interprets it as a UTF-8 encoded string,
   superseding the [StringViews.jl](https://github.com/JuliaStrings/StringViews.jl) package ([#60526]).
-
 * Package precompilation now supports running precompilation in
   a background task and has new interactive keyboard controls:
   `c` to cleanly cancel immediately, `d` to detach, `i` for a profile peek,
   `v` to toggle verbose mode showing elapsed time, CPU%, and memory usage, and `?` for help. ([#60943]).
+* Instances of an `Enum` can now be given their own docstrings within the `@enum` definition ([#61955]).
 
 Standard library changes
 ------------------------

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -162,12 +162,19 @@ macro enum(T::Union{Symbol,Expr}, syms...)
     namemap = Dict{basetype,Symbol}()
     lo = hi = i = zero(basetype)
     hasexpr = false
+    docs = Dict{Symbol,Expr}()
 
     if length(syms) == 1 && syms[1] isa Expr && syms[1].head === :block
         syms = syms[1].args
     end
     for s in syms
         s isa LineNumberNode && continue
+        if isa(s, Expr) && s.head === :macrocall && s.args[1] == GlobalRef(Core, Symbol("@doc"))
+            doc = s
+            s = s.args[4]
+        else
+            doc = nothing
+        end
         if isa(s, Symbol)
             if i == typemin(basetype) && !isempty(values)
                 throw(ArgumentError(LazyString("overflow in value \"", s, "\" of Enum ", typename)))
@@ -203,6 +210,9 @@ macro enum(T::Union{Symbol,Expr}, syms...)
         else
             hi = max(hi, i)
         end
+        if doc !== nothing
+            docs[s] = doc
+        end
         i += oneunit(i)
     end
     blk = quote
@@ -228,7 +238,12 @@ macro enum(T::Union{Symbol,Expr}, syms...)
     end
     if isa(typename, Symbol)
         for (i, sym) in namemap
-            push!(blk.args, :(const $(esc(sym)) = $(esc(typename))($i)))
+            ex = :(const $(esc(sym)) = $(esc(typename))($i))
+            if haskey(docs, sym)
+                docs[sym].args[4] = ex
+                ex = docs[sym]
+            end
+            push!(blk.args, ex)
         end
     end
     push!(blk.args, :nothing)

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -231,6 +231,8 @@ let b = IOBuffer()
     @test str == "Union{$p.Alphabet, $p.BritishFood}" || str == "Union{$p.BritishFood, $p.Alphabet}"
 end
 
+module TestDocumentedEnums
+using REPL, Test  # REPL is needed for retrieving docstrings
 """
 Ancestral species of citrus
 """
@@ -252,3 +254,4 @@ _gimmedoc(x) = strip(sprint(show, MIME"text/plain"(), Docs.doc(Docs.Binding(@__M
 @test Int.(instances(Citrus)) == (0, 8, 9, 10)
 @test _gimmedoc.(instances(Citrus)) == "C. " .* ("reticulata", "maxima", "medica", "japonica")
 @test _gimmedoc(Citrus) == "Ancestral species of citrus"
+end

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -230,3 +230,25 @@ let b = IOBuffer()
     p = string(@__MODULE__)
     @test str == "Union{$p.Alphabet, $p.BritishFood}" || str == "Union{$p.BritishFood, $p.Alphabet}"
 end
+
+"""
+Ancestral species of citrus
+"""
+@enum Citrus begin
+    "C. reticulata"
+    mandarin
+    "C. maxima"
+    pomelo = 8
+    "C. medica"
+    citron
+    "C. japonica"
+    kumquat
+end
+
+_gimmedoc(x::Enum) = _gimmedoc(Symbol(x))
+_gimmedoc(T::Type) = _gimmedoc(nameof(T))
+_gimmedoc(x) = strip(sprint(show, MIME"text/plain"(), Docs.doc(Docs.Binding(@__MODULE__, x))))
+
+@test Int.(instances(Citrus)) == (0, 8, 9, 10)
+@test _gimmedoc.(instances(Citrus)) == "C. " .* ("reticulata", "maxima", "medica", "japonica")
+@test _gimmedoc(Citrus) == "Ancestral species of citrus"


### PR DESCRIPTION
Previously, docstrings were not recognized by the `@enum` macro, so documenting individual `Enum` instances had to be done separately after the macro call. This change permits including docstrings for instances, allowing e.g.:

```julia
"""
Edible seed-bearing structures of angiosperms.
"""
@enum Fruit begin
    "Pome of Malus domestica"
    apple = 1
    "Hesperidium of Citrus sinensis"
    orange = 2
    "Berry of Actinidia chinensis"
    kiwi = 3
end
```