### PR TITLE
Respect requested opt level for pkgimages

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -2049,11 +2049,7 @@ void jl_dump_native_locked(jl_native_code_desc_t *data, const char *bc_fname,
             jl_ExecutionEngine->getTargetOptions(),
             RelocModel,
             CMModel,
-#if JL_LLVM_VERSION >= 180000
-            CodeGenOptLevel::Aggressive // -O3 TODO: respect command -O0 flag?
-#else
-            CodeGenOpt::Aggressive // -O3 TODO: respect command -O0 flag?
-#endif
+            CodeGenOptLevelFor(jl_options.opt_level) // respect the command-line -O flag
             ));
     fixupTM(*SourceTM);
     auto DL = jl_create_datalayout(*SourceTM);


### PR DESCRIPTION
Seems like we've been force-compiling pkgimages to `-O3` when the default is `-O2`. Note the TODO.

Obviously this means the cached code would default to the normal opt level, so potentially slower, but perhaps that's arguably correct and if this improves precompilation speeds.. would be worth it IMO.

This maybe explains why some prior benchmarking of pkgimages at different `-O` levels didn't show any speedup in https://github.com/JuliaLang/julia/pull/61888#issuecomment-4526862149 😅