### PR TITLE
Don't promote arguments in `muladd` with `Bool` arguments

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -343,6 +343,12 @@ muladd(x::Real, y::Real, z::Complex) = Complex(muladd(x,y,real(z)), imag(z))
 muladd(z::Complex, w::Complex, x::Real) =
     Complex(muladd(real(z), real(w), -_mulsub(imag(z), imag(w), x)),
             muladd(real(z), imag(w), imag(z) * real(w)))
+# disambiguation with promotion.jl
+muladd(x::Bool, z::Complex, y::Union{Real,Complex}) = @invoke muladd(x::Real, z::Complex, y::Union{Real,Complex})
+muladd(z::Complex, x::Bool, y::Real) = @invoke muladd(z::Complex, x::Real, y::Real)
+muladd(z::Complex, x::Bool, w::Complex) = @invoke muladd(z::Complex, x::Real, w::Complex)
+muladd(x::Bool, y::Real, z::Complex) = @invoke muladd(x::Real, y::Real, z::Complex)
+muladd(x::Real, y::Bool, z::Complex) = @invoke muladd(x::Real, y::Real, z::Complex)
 
 /(a::R, z::S) where {R<:Real,S<:Complex} = (T = promote_type(R,S); a*inv(T(z)))
 /(z::Complex, x::Real) = Complex(real(z)/x, imag(z)/x)

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -343,12 +343,6 @@ muladd(x::Real, y::Real, z::Complex) = Complex(muladd(x,y,real(z)), imag(z))
 muladd(z::Complex, w::Complex, x::Real) =
     Complex(muladd(real(z), real(w), -_mulsub(imag(z), imag(w), x)),
             muladd(real(z), imag(w), imag(z) * real(w)))
-# disambiguation with promotion.jl
-muladd(x::Bool, z::Complex, y::Union{Real,Complex}) = @invoke muladd(x::Real, z::Complex, y::Union{Real,Complex})
-muladd(z::Complex, x::Bool, y::Real) = @invoke muladd(z::Complex, x::Real, y::Real)
-muladd(z::Complex, x::Bool, w::Complex) = @invoke muladd(z::Complex, x::Real, w::Complex)
-muladd(x::Bool, y::Real, z::Complex) = @invoke muladd(x::Real, y::Real, z::Complex)
-muladd(x::Real, y::Bool, z::Complex) = @invoke muladd(x::Real, y::Real, z::Complex)
 
 /(a::R, z::S) where {R<:Real,S<:Complex} = (T = promote_type(R,S); a*inv(T(z)))
 /(z::Complex, x::Real) = Complex(real(z)/x, imag(z)/x)

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -495,11 +495,11 @@ true
 ^(x::Number, y::Number) = ^(promote(x,y)...)
 
 fma(x::Number, y::Number, z::Number) = fma(promote(x,y,z)...)
-muladd(x::Number, y::Number, z::Number) = muladd(promote(x,y,z)...)
-# no promotion to not loose strong zero property of `false`
-muladd(x::Number, y::Bool, z::Number) = x*y+z
-muladd(x::Bool, y::Number, z::Number) = x*y+z
-muladd(x::Bool, y::Bool, z::Number) = x*y+z
+function muladd(a::Number, b::Number, c::Number)
+    _a, _b, _c = promote(a, b, c)
+    ((a === false) || (b === false)) && return _c
+    return muladd(_a, _b, _c)
+end
 
 ==(x::Number, y::Number) = (==)(promote(x,y)...)
 <( x::Real, y::Real)     = (< )(promote(x,y)...)

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -496,6 +496,10 @@ true
 
 fma(x::Number, y::Number, z::Number) = fma(promote(x,y,z)...)
 muladd(x::Number, y::Number, z::Number) = muladd(promote(x,y,z)...)
+# no promotion to not loose strong zero property of `false`
+muladd(x::Number, y::Bool, z::Number) = x*y+z
+muladd(x::Bool, y::Number, z::Number) = x*y+z
+muladd(x::Bool, y::Bool, z::Number) = x*y+z
 
 ==(x::Number, y::Number) = (==)(promote(x,y)...)
 <( x::Real, y::Real)     = (< )(promote(x,y)...)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1018,6 +1018,11 @@ end
     for x in (3, 3+13im, 1im), y in (2, 2+7im, 1im), z in (5, 5+11im, 0x01, 0x01 + 0x00*im)
         @test muladd(x,y,z) === x*y + z
     end
+    @test muladd(false, complex(NaN64), 2) == 2
+    @test muladd(complex(NaN64), false, 2) == 2
+    @test muladd(complex(NaN64), false, 2+7im) == 2+7im
+    @test muladd(false, NaN64, 2+7im) == 2+7im
+    @test muladd(NaN64, false, 2+7im) == 2+7im
 end
 
 @testset "issue #11839" begin

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -244,6 +244,11 @@ end
     @test muladd(big(1//1),2,3) == big(1//1)*2+3
     @test muladd(1.0,2,3) == 1.0*2+3
     @test muladd(big(1.0),2,3) == big(1.0)*2+3
+    @test muladd(Inf, false, 3) === 3.0
+    @test muladd(Inf, true, 3) === Inf
+    @test muladd(false, NaN, 3) === 3.0
+    @test muladd(true, NaN, 3) === NaN
+    @test muladd(true, true, 3) === 4
 end
 # lexing typemin(Int64)
 @test (-9223372036854775808)^1 == -9223372036854775808


### PR DESCRIPTION
Otherwise `muladd` doesn't respect the "strong zero property" of `false`.

Fixes https://github.com/JuliaSparse/SparseArrays.jl/issues/724