### PR TITLE
document task_local_storage()

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -260,6 +260,14 @@ end
 
 task_result(t::Task) = t.result
 
+"""
+    task_local_storage()
+
+Returns a dictionary (an [`IdDict`](@ref)) of the current task's task-local storage.
+
+For example, this dictionary can be passed to [`get!`](@ref) in order
+to either fetch or initialize the value of a key in the storage.
+"""
 task_local_storage() = get_task_tls(current_task())
 function get_task_tls(t::Task)
     if t.storage === nothing
@@ -272,6 +280,7 @@ end
     task_local_storage(key)
 
 Look up the value of a key in the current task's task-local storage.
+Key lookup is based on object equality ([`===`](@ref)).
 """
 task_local_storage(key) = task_local_storage()[key]
 
@@ -279,6 +288,7 @@ task_local_storage(key) = task_local_storage()[key]
     task_local_storage(key, value)
 
 Assign a value to a key in the current task's task-local storage.
+Key lookup is based on object equality ([`===`](@ref)).
 """
 task_local_storage(key, val) = (task_local_storage()[key] = val)
 


### PR DESCRIPTION
I notice that `task_local_storage` is documented but its `task_local_storage()` method, which directly returns the dictionary, is not.   This is a useful method because then one can use a wider range of dictionary functions, perhaps the most useful of which are `get` (to fetch with a default) and `get!` (to either fetch or initialize an entry).

A [package search](https://platform.juliahub.com/ui/Search?q=task_local_storage()&type=code) indicates that many packages are already calling `task_local_storage()`, mostly to use with `get` or `get!`.

It also seems to be worthwhile to document that this is an `IdDict` — and, in particular, that key lookup in the task-local dictionary is based on object identity.

(Are there certain usages of the task-local dictionary that should be warned against? e.g. iterating over it seems like a bad idea?  An alternative would be to define and export a function, e.g. `task_local_storage!`, that mimics `get!`, another function for `haskey`, another for `get`, another for `delete!`, etcetera, but this seems cumbersome if many methods are desired.  Or one could wrap the `IdDict` in another `AbstractDictionary` type that e.g. forbids iteration, but again this seems cumbersome and potentially breaking.)