### PR TITLE
Compiler: avoid per-SSA-value BitSet allocation in find_ssavalue_uses

### DIFF
--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -292,7 +292,7 @@ mutable struct InferenceState{I<:AbstractInterpreter}
     currpc::Int
     ip::BitSet#=TODO BoundedMinPrioritySet=# # current active instruction pointers
     handler_info::Union{Nothing,HandlerInfo{TryCatchFrame}}
-    ssavalue_uses::Vector{BitSet} # ssavalue sparsity and restart info
+    ssavalue_uses::SSAUses # ssavalue sparsity and restart info
     # Per-basic-block entry state. `nothing` if the BB has not been analyzed yet.
     # Populated lazily during the main inference loop by `update_bbstate!`, which merges
     # the current exit state into each successor. Both the variable-type table and the

--- a/Compiler/src/utilities.jl
+++ b/Compiler/src/utilities.jl
@@ -267,11 +267,12 @@ function foreach_anyssa(@specialize(f), @nospecialize(stmt))
     end
 end
 
-# Uses of each SSA value, in compressed-sparse-row form: a set per value would
-# waste ~2*nvals allocations since ~98% of values are used 0 or 1 times, so all
-# uses are scattered into one flat array for two allocations regardless of nvals.
+# Uses of each SSA value, in compressed-sparse-row form: the uses of ssa `i` are
+# `data[offsets[i]:offsets[i+1]-1]`. Entries are use occurrences, not distinct
+# statement indices, so a statement using the same value twice lists its line
+# twice; harmless for the consumers (`isempty` and idempotent block re-enqueue).
 struct SSAUses
-    offsets::Vector{Int} # uses of ssa `i` are `data[offsets[i]:offsets[i+1]-1]`
+    offsets::Vector{Int}
     data::Vector{Int}
 end
 

--- a/Compiler/src/utilities.jl
+++ b/Compiler/src/utilities.jl
@@ -267,8 +267,59 @@ function foreach_anyssa(@specialize(f), @nospecialize(stmt))
     end
 end
 
+# Uses of each SSA value, in compressed-sparse-row form: a set per value would
+# waste ~2*nvals allocations since ~98% of values are used 0 or 1 times, so all
+# uses are scattered into one flat array for two allocations regardless of nvals.
+struct SSAUses
+    offsets::Vector{Int} # uses of ssa `i` are `data[offsets[i]:offsets[i+1]-1]`
+    data::Vector{Int}
+end
+
+# Non-escaping view over one value's uses; supports `isempty` and iteration.
+struct SSAUseList
+    data::Vector{Int}
+    start::Int
+    stop::Int
+end
+
+@inline function getindex(uses::SSAUses, i::Int)
+    offsets = uses.offsets
+    return SSAUseList(uses.data, offsets[i], offsets[i+1] - 1)
+end
+
+@inline isempty(l::SSAUseList) = l.stop < l.start
+@inline length(l::SSAUseList) = l.stop - l.start + 1
+@inline function iterate(l::SSAUseList, i::Int = l.start)
+    i > l.stop && return nothing
+    return (l.data[i], i + 1)
+end
+
 function find_ssavalue_uses(body::Vector{Any}, nvals::Int)
-    uses = BitSet[ BitSet() for _ = 1:nvals ]
+    # count uses per value
+    counts = zeros(Int, nvals)
+    foreach_ssavalue_use(body) do id::Int, _line::Int
+        counts[id] += 1
+    end
+    # prefix-sum the counts into row pointers
+    offsets = Vector{Int}(undef, nvals + 1)
+    tot = 1
+    for i = 1:nvals
+        offsets[i] = tot
+        tot += counts[i]
+    end
+    offsets[nvals + 1] = tot
+    # scatter line numbers into `data`, reusing `counts` as write cursors
+    data = Vector{Int}(undef, tot - 1)
+    fill!(counts, 0)
+    foreach_ssavalue_use(body) do id::Int, line::Int
+        data[offsets[id] + counts[id]] = line
+        counts[id] += 1
+    end
+    return SSAUses(offsets, data)
+end
+
+# Call `f(ssa_id, line)` for each SSA value used as an operand in `body`.
+function foreach_ssavalue_use(@specialize(f), body::Vector{Any})
     for line in 1:length(body)
         e = body[line]
         if isa(e, ReturnNode)
@@ -278,17 +329,17 @@ function find_ssavalue_uses(body::Vector{Any}, nvals::Int)
             e = e.cond
         end
         if isa(e, SSAValue)
-            push!(uses[e.id], line)
+            f(e.id, line)
         elseif isa(e, Expr)
-            find_ssavalue_uses!(uses, e, line)
+            foreach_ssavalue_use(f, e, line)
         elseif isa(e, PhiNode)
-            find_ssavalue_uses!(uses, e, line)
+            foreach_ssavalue_use(f, e, line)
         end
     end
-    return uses
+    return nothing
 end
 
-function find_ssavalue_uses!(uses::Vector{BitSet}, e::Expr, line::Int)
+function foreach_ssavalue_use(@specialize(f), e::Expr, line::Int)
     head = e.head
     is_meta_expr_head(head) && return
     skiparg = (head === :(=))
@@ -296,22 +347,24 @@ function find_ssavalue_uses!(uses::Vector{BitSet}, e::Expr, line::Int)
         if skiparg
             skiparg = false
         elseif isa(a, SSAValue)
-            push!(uses[a.id], line)
+            f(a.id, line)
         elseif isa(a, Expr)
-            find_ssavalue_uses!(uses, a, line)
+            foreach_ssavalue_use(f, a, line)
         end
     end
+    return nothing
 end
 
-function find_ssavalue_uses!(uses::Vector{BitSet}, e::PhiNode, line::Int)
+function foreach_ssavalue_use(@specialize(f), e::PhiNode, line::Int)
     values = e.values
     for i = 1:length(values)
         isassigned(values, i) || continue
         val = values[i]
         if isa(val, SSAValue)
-            push!(uses[val.id], line)
+            f(val.id, line)
         end
     end
+    return nothing
 end
 
 # using a function to ensure we can infer this


### PR DESCRIPTION
Use a SparseArray like container for the SSA uses instead of a BitSet per value to avoid so many allocations. 

This pull request was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)