### PR TITLE
Compiler: set syntax version to 1.14

### DIFF
--- a/Compiler/Project.toml
+++ b/Compiler/Project.toml
@@ -2,6 +2,9 @@ name = "Compiler"
 uuid = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
 version = "0.1.1"
 
+[syntax]
+julia_version = "1.14"
+
 [compat]
 julia = "1.10"
 


### PR DESCRIPTION
Best guess at why coverage jobs have started failing to parse coverage info.

https://buildkite.com/julialang/julia-master-scheduled/builds/1552#019e7d0c-ff9f-4434-b3a5-902b0aceaccb/L863