### PR TITLE
Allow definitions in `@enum` to reference others, and expand `@static` conditions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,8 @@ New library features
   `c` to cleanly cancel immediately, `d` to detach, `i` for a profile peek,
   `v` to toggle verbose mode showing elapsed time, CPU%, and memory usage, and `?` for help. ([#60943]).
 * Instances of an `Enum` can now be given their own docstrings within the `@enum` definition ([#61955]).
+* The expression defining a given `Enum` instance within `@enum` may now refer to preceding instances ([#61966]).
+* `@static` conditions are now expanded within `@enum` ([#61966]).
 
 Standard library changes
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -167,6 +167,8 @@ New library features
   `c` to cleanly cancel immediately, `d` to detach, `i` for a profile peek,
   `v` to toggle verbose mode showing elapsed time, CPU%, and memory usage, and `?` for help ([#60943]).
 * Instances of an `Enum` can now be given their own docstrings within the `@enum` definition ([#61955]).
+* The expression defining a given `Enum` instance within `@enum` may now refer to preceding instances ([#61966]).
+* `@static` conditions are now expanded within `@enum` ([#61966]).
 * New methods `readdir(path, DirEntry)` and `readdir(::DirEntry, DirEntry)` return directory contents
   along with the type of the entries in a vector of new `DirEntry` objects to provide more efficient `isfile`
   etc. checks. `readdir(::DirEntry)` accepts a `DirEntry` as input and, like `readdir(::AbstractString)`,

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -92,6 +92,23 @@ Base.broadcastable(x::Enum) = Ref(x)
 
 @noinline enum_argument_error(typename, x) = throw(ArgumentError(LazyString("invalid value for Enum ", typename, ": ", x)))
 
+function extractdefs!(out, xs, mod)
+    for x in xs
+        if x isa Expr
+            if x.head === :macrocall && x.args[1] === Symbol("@static")
+                x = macroexpand(mod, x)
+                x === nothing && continue
+            end
+            if x.head === :block
+                extractdefs!(out, x.args, mod)
+                continue
+            end
+        end
+        x isa LineNumberNode || push!(out, x)
+    end
+    return out
+end
+
 """
     @enum EnumName[::BaseType] value1[=x] value2[=y]
 
@@ -167,6 +184,7 @@ macro enum(T::Union{Symbol,Expr}, syms...)
     if length(syms) == 1 && syms[1] isa Expr && syms[1].head === :block
         syms = syms[1].args
     end
+    syms = extractdefs!(Any[], syms, __module__)
     for s in syms
         s isa LineNumberNode && continue
         if isa(s, Expr) && s.head === :macrocall && s.args[1] == GlobalRef(Core, Symbol("@doc"))
@@ -182,7 +200,11 @@ macro enum(T::Union{Symbol,Expr}, syms...)
         elseif isa(s, Expr) &&
                (s.head === :(=) || s.head === :kw) &&
                length(s.args) == 2 && isa(s.args[1], Symbol)
-            i = Core.eval(__module__, s.args[2]) # allow exprs, e.g. uint128"1"
+            # Allow expressions, e.g. `uint128"1"`, as well as ones that depend on preceding
+            # instance values, e.g. `x; y; z = x | y`
+            ex = Expr(:let, Expr(:block, (Expr(:(=), sym, val) for (val, sym) in namemap)...),
+                      Expr(:block, s.args[2]))
+            i = Core.eval(__module__, ex)
             if !isa(i, Integer)
                 throw(ArgumentError(LazyString("invalid value for Enum ", typename, ", ", s, "; values must be integers")))
             end

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -260,3 +260,29 @@ _gimmedoc(x) = strip(sprint(show, MIME"text/plain"(), Docs.doc(Docs.Binding(@__M
 @test _gimmedoc.(instances(Citrus)) == "C. " .* ("reticulata", "maxima", "medica", "japonica")
 @test _gimmedoc(Citrus) == "Ancestral species of citrus"
 end
+
+const ABI64 = 0x01000000
+@enum MachCPU::UInt32 begin
+    X86 = 7
+    X86_64 = X86 | ABI64
+    ARM = 12
+    POWERPC = 18
+    POWERPC64 = POWERPC | ABI64
+    ARM64 = ARM | ABI64
+end
+@test Integer.(instances(MachCPU)) == (0x00000007, 0x01000007, 0x0000000c, 0x00000012, 0x01000012, 0x0100000c)
+
+@enum PizzaTime begin
+    🍕 = 1
+    🍕🍕
+    @static if false
+        🌭
+    end
+    🍕🍕🍕
+    @static if true
+        🍕🍕🍕🍕
+    else
+        🍍🍕
+    end
+end
+@test instances(PizzaTime) == (🍕, 🍕🍕, 🍕🍕🍕, 🍕🍕🍕🍕) == ntuple(PizzaTime, 4)


### PR DESCRIPTION
This allows things like the following:
```julia
@enum Flags::UInt8 begin
    a = 0x01
    b = 0x02
    c = a | b
    @static if Sys.isapple()
        d = 0x0a
    end
end
```