### PR TITLE
compiler: avoid per-frame ssaflags copy in InferenceState

### DIFF
--- a/Compiler/src/effects.jl
+++ b/Compiler/src/effects.jl
@@ -361,5 +361,9 @@ function decode_effects(e::UInt32)
         Bool((e >> 14) & 0x01))
 end
 
+# Raw per-statement `@assume_effects` override bits (0 if none).
+stmt_effects_override_bits(ssaflag::UInt32) =
+    UInt16((ssaflag >> NUM_IR_FLAGS) & (1 << NUM_EFFECTS_OVERRIDES - 1))
+
 decode_statement_effects_override(ssaflag::UInt32) =
-    decode_effects_override(UInt16((ssaflag >> NUM_IR_FLAGS) & (1 << NUM_EFFECTS_OVERRIDES - 1)))
+    decode_effects_override(stmt_effects_override_bits(ssaflag))

--- a/Compiler/src/inferencestate.jl
+++ b/Compiler/src/inferencestate.jl
@@ -344,6 +344,10 @@ mutable struct InferenceState{I<:AbstractInterpreter}
     restrict_abstract_call_sites::Bool
     cache_mode::UInt8 # TODO move this to InferenceResult?
     insert_coverage::Bool
+    # Sparse `pc => override_bits` snapshot of per-statement `@assume_effects` overrides
+    # (`nothing` if none). `ssaflags` aliases `src.ssaflags`, whose override bits inference
+    # clobbers, so `decode_statement_effects_override` reads them back from here.
+    stmt_effect_overrides::Union{Nothing,Vector{Pair{Int,UInt16}}}
 
     # The interpreter that created this inference state. Not looked at by
     # NativeInterpreter. But other interpreters may use this to detect cycles.
@@ -397,7 +401,20 @@ mutable struct InferenceState{I<:AbstractInterpreter}
             bb_vartable1[i] = VarState(argtyp, #= ssadef =# 0, i > nargtypes)
         end
         src.ssavaluetypes = ssavaluetypes = Any[ NOT_FOUND for _ = 1:nssavalues ]
-        ssaflags = copy(src.ssaflags)
+        # Inference writes inferred effect flags into `ssaflags`, overwriting the overlapping
+        # `@assume_effects` override bits. Instead of a dense copy to preserve them, alias
+        # `src.ssaflags` (a private CodeInfo) and snapshot only the overrides sparsely.
+        ssaflags = src.ssaflags
+        stmt_effect_overrides = nothing
+        for i = 1:length(ssaflags)
+            override = stmt_effects_override_bits(ssaflags[i])
+            if override != 0
+                if stmt_effect_overrides === nothing
+                    stmt_effect_overrides = Pair{Int,UInt16}[]
+                end
+                push!(stmt_effect_overrides, i => override)
+            end
+        end
 
         unreachable = BitSet()
         pclimitations = IdSet{InferenceState}()
@@ -434,6 +451,7 @@ mutable struct InferenceState{I<:AbstractInterpreter}
             result, unreachable, bestguess, exc_bestguess, ipo_effects,
             _time_ns(), 0.0, 0, 0,
             restrict_abstract_call_sites, cache_mode, insert_coverage,
+            stmt_effect_overrides,
             interp)
 
         # some more setups
@@ -1159,7 +1177,16 @@ function merge_effects!(::AbstractInterpreter, caller::InferenceState, effects::
 end
 merge_effects!(::AbstractInterpreter, ::IRInterpretationState, ::Effects) = return
 
-decode_statement_effects_override(sv::InferenceState) = decode_statement_effects_override(sv.src.ssaflags[sv.currpc])
+function decode_statement_effects_override(sv::InferenceState)
+    overrides = sv.stmt_effect_overrides
+    if overrides !== nothing
+        pc = sv.currpc
+        for (i, override) in overrides
+            i == pc && return decode_effects_override(override)
+        end
+    end
+    return decode_effects_override(UInt16(0))
+end
 decode_statement_effects_override(::IRInterpretationState) = decode_statement_effects_override(UInt32(0))
 
 struct InferenceLoopState


### PR DESCRIPTION
The `InferenceState` constructor copied `src.ssaflags` into a private working array on every frame, including on every `const_prop_call` attempt. The copy existed only so that `decode_statement_effects_override` could read back the original per-statement `@assume_effects` override bits, which occupy the same `ssaflags` bit range (`[NUM_IR_FLAGS, NUM_IR_FLAGS+NUM_EFFECTS_OVERRIDES)`) that inference overwrites with the inferred effect flags (`IR_FLAGS_EFFECTS`).

Since the source `CodeInfo` is freshly materialized and private to the frame, this aliases `src.ssaflags` directly and snapshots the rare statement-level overrides into a sparse `pc => override_bits` table instead. `decode_statement_effects_override` reads overrides back from that table, so it is unaffected by inference clobbering the aliased array. The resulting `ssaflags` are byte-identical to before (same starting bits + same masked writes; the finish-time `src.ssaflags = me.ssaflags` becomes a self-assign).

In the common case where a method has no statement-level effect overrides, this removes a per-frame allocation proportional to the number of statements — measured at 0 bytes from this code path for override-free functions, versus `4·nstmts + header` previously (e.g. ~7 KB for a 1600-statement function), saved on every inference frame and every constant-propagation attempt.

## Testing
`Compiler/test/{effects,inference,irpasses,inline}.jl` pass against a local build; the effects suite covers statement-level `@assume_effects` (the sparse path).

---
This pull request was written with the assistance of generative AI (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
