### PR TITLE
OpaqueClosure: Fix failure during AOT linking

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -765,14 +765,21 @@ static void aot_link_output(jl_codegen_output_t &out)
             funcs = {JL_INVOKE_ARGS, nullptr, f};
         }
 
+        Value *callee = funcs.specptr;
         if (funcs.invoke_api != api) {
-            assert(api == JL_INVOKE_SPECSIG); // Only possibility right now
-            Function *f = emit_specsig_to_fptr1(out, ci, funcs.specptr);
-            funcs.invoke_api = JL_INVOKE_SPECSIG;
-            funcs.specptr = f;
+            if (api == JL_INVOKE_SPECSIG) {
+                callee = emit_specsig_to_fptr1(out, ci, funcs.specptr);
+            }
+            else if (api == JL_INVOKE_ARGS) {
+                assert(funcs.invoke);
+                callee = funcs.invoke;
+            }
+            else {
+                assert(false);
+            }
         }
 
-        target.decl->replaceAllUsesWith(funcs.specptr);
+        target.decl->replaceAllUsesWith(callee);
         target.decl->eraseFromParent();
     }
 }


### PR DESCRIPTION
Resolves https://github.com/JuliaLang/julia/issues/61968.

Draft because this needs tests and there are a few more OpaqueClosure bugs in `--trim` to clean up.