### PR TITLE
set `max_methods` on `tail` to 1

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -540,6 +540,7 @@ ERROR: ArgumentError: Cannot call tail on an empty tuple.
 """
 tail(x::Tuple) = argtail(x...)
 tail(::Tuple{}) = throw(ArgumentError("Cannot call tail on an empty tuple."))
+typeof(tail).name.max_methods = UInt8(1)
 
 function unwrap_unionall(@nospecialize(a))
     @_foldable_meta


### PR DESCRIPTION
AD packages (at least some) overload `tail` (https://github.com/JuliaDiff/ChainRulesCore.jl/blob/0b2ebfec265e38353d80d1ebdd42e91264f60a22/src/tangent_types/thunks.jl#L33) which is disastrous for invalidations if you end up having an edge to `tail(::Any)`. 

As an example:

```julia
begin
using ModelingToolkit
sig = Tuple{typeof(ModelingToolkit.expand_connections), ModelingToolkit.System}
@time precompile(sig)
Base.tail(::Int) = ()
@time precompile(sig)
end

 # 0.000010 seconds (58 allocations: 2.703 KiB)
# 10.780681 seconds (34.22 M allocations: 1.677 GiB, 7.40% gc time, 100.00% compilation time: 100% of which was recompilation)
```

