### PR TITLE
`DebugInfo`: julia-side internal API improvements

### DIFF
--- a/Compiler/src/ssair/ir.jl
+++ b/Compiler/src/ssair/ir.jl
@@ -257,7 +257,6 @@ struct SourceLocation
 end
 
 function source_location(di::Union{DebugInfo,DebugInfoStream}, pc::Int)
-    @assert pc > 0 "no source for pc=0"
     while has_prev_debuginfo(di, pc)
         di, pc = prev_debuginfo(di, pc)
     end
@@ -266,6 +265,7 @@ function source_location(di::Union{DebugInfo,DebugInfoStream}, pc::Int)
         # information on its own.
         return SourceLocation(0,0,0,0,0,0)
     end
+    @assert pc > 0 "no source for pc<=0"
     (l1, c1) = ccall(:jl_cdi_firstxy, NTuple{2, Int32}, (Any, Int32), di, pc)
     if c1 <= 0
         return SourceLocation(0,0,0,0,l1,0)

--- a/Compiler/src/ssair/ir.jl
+++ b/Compiler/src/ssair/ir.jl
@@ -208,8 +208,14 @@ Core.DebugInfo(di::DebugInfoStream, nstmts::Int) =
     DebugInfo(something(di.def), di.linetable, Core.svec(di.edges...),
         ccall(:jl_compress_codelocs, Any, (Int32, Any, Int), di.firstline, di.codelocs, nstmts)::String)
 
-getdebugidx(debuginfo::DebugInfo, pc::Int) =
-    ccall(:jl_uncompress1_codeloc, NTuple{3,Int32}, (Any, Int), debuginfo, pc)
+function getdebugidx(debuginfo::DebugInfo, pc::Int)
+    if debuginfo.linetable isa String
+        # drop provenance for compatibility
+        ((pc <= 0 ? -1 : source_location(debuginfo, pc).line), 0, 0)
+    else
+        ccall(:jl_uncompress1_codeloc, NTuple{3,Int32}, (Any, Int), debuginfo, pc)
+    end
+end
 
 function getdebugidx(debuginfo::DebugInfoStream, pc::Int)
     if 3 <= 3pc <= length(debuginfo.codelocs)
@@ -221,6 +227,53 @@ function getdebugidx(debuginfo::DebugInfoStream, pc::Int)
     end
 end
 
+has_prev_debuginfo(di, pc::Int) = prev_debuginfo(di, pc)[1] !== nothing
+has_edge_debuginfo(di, pc::Int) = edge_debuginfo(di, pc)[1] !== nothing
+
+"(debuginfo, nextpc) from the previous step in the compiler"
+function prev_debuginfo(di, pc::Int)
+    di.linetable isa Core.DebugInfo || return (nothing, 0)
+    pc > 0 || return (nothing, 0)
+    nextpc::Int = getdebugidx(di, pc)[1]
+    (di.linetable, nextpc)
+end
+
+"(debuginfo, nextpc) of inlinee"
+function edge_debuginfo(di, pc::Int)
+    _, eid::Int, epc::Int = getdebugidx(di, pc)
+    # XXX: eid > 0 should imply epc > 0
+    (eid > 0 && epc > 0) || return (nothing, 0)
+    (di.edges[eid]::DebugInfo, epc)
+end
+
+# All 1-based.  0 if unavailable.
+struct SourceLocation
+    byte::Int
+    byte_end::Int
+    col::Int
+    col_end::Int
+    line::Int
+    line_end::Int
+end
+
+function source_location(di::Union{DebugInfo,DebugInfoStream}, pc::Int)
+    @assert pc > 0 "no source for pc=0"
+    while has_prev_debuginfo(di, pc)
+        di, pc = prev_debuginfo(di, pc)
+    end
+    if di isa DebugInfoStream
+        # DebugInfoStream with linetable=nothing does not contain source
+        # information on its own.
+        return SourceLocation(0,0,0,0,0,0)
+    end
+    (l1, c1) = ccall(:jl_cdi_firstxy, NTuple{2, Int32}, (Any, Int32), di, pc)
+    if c1 <= 0
+        return SourceLocation(0,0,0,0,l1,0)
+    end
+    (b1, b2) = ccall(:jl_cdi_bytespan, NTuple{2, Int32}, (Any, Int32), di, pc)
+    (l2, c2) = ccall(:jl_cdi_byte_to_xy, NTuple{2, Int32}, (Any, Int32), di, b2)
+    return SourceLocation(b1,b2,c1,c2,l1,l2)
+end
 
 # SSA values that need renaming
 struct OldSSAValue

--- a/Compiler/src/ssair/show.jl
+++ b/Compiler/src/ssair/show.jl
@@ -10,7 +10,7 @@ import Base: show
 using Base: isexpr, prec_decl, show_unquoted, with_output_color
 using .Compiler: ALWAYS_FALSE, ALWAYS_TRUE, argextype, BasicBlock, block_for_inst,
     CachedMethodTable, CFG, compute_basic_blocks, DebugInfoStream, Effects,
-    EMPTY_SPTYPES, getdebugidx, IncrementalCompact, InferenceResult, InferenceState,
+    EMPTY_SPTYPES, IncrementalCompact, InferenceResult, InferenceState,
     InvalidIRError, IRCode, LimitedAccuracy, NativeInterpreter, scan_ssa_use!,
     singleton_type, sptypes_from_meth_instance, StmtRange, Timings, VarState, widenconst,
     get_ci_mi, get_ci_abi
@@ -378,14 +378,18 @@ function debuginfo_file1(debuginfo::Union{DebugInfo,DebugInfoStream})
 end
 
 # utility function to extract the first line number and file of a block of code
-function debuginfo_firstline(debuginfo::Union{DebugInfo,DebugInfoStream})
-    linetable = debuginfo.linetable
-    while linetable !== nothing
-        debuginfo = linetable
-        linetable = debuginfo.linetable
+function debuginfo_firstline(di::DebugInfoStream)
+    if di.linetable isa DebugInfo
+        di = di.linetable
+        debuginfo_firstline(di)
+    else
+        # likely doesn't contain any usable provenance
+        debuginfo_file1(debuginfo), di.firstline
     end
-    codeloc = getdebugidx(debuginfo, 0)
-    return debuginfo_file1(debuginfo), codeloc[1]
+end
+function debuginfo_firstline(di::DebugInfo)
+    firstline = ccall(:jl_cdi_firstline_all, Int32, (Any,), di)
+    debuginfo_file1(di), firstline
 end
 
 struct LineInfoNode
@@ -399,25 +403,26 @@ end
 # Returns `false` if the line info should not be updated with this info because this
 # statement has no effect on the line numbers. The `scopes` will still be populated however
 # with as much information as was available about the inlining at that statement.
-function append_scopes!(scopes::Vector{LineInfoNode}, pc::Int, debuginfo, @nospecialize(def))
+function append_scopes!(scopes::Vector{LineInfoNode}, pc::Int, di, @nospecialize(def))
     doupdate = true
-    while true
-        debuginfo.def isa Symbol || (def = debuginfo.def)
-        codeloc = getdebugidx(debuginfo, pc)
-        line::Int = codeloc[1]
-        inl_to::Int = codeloc[2]
-        doupdate &= line != 0 || inl_to != 0 # disabled debug info--no update
-        if debuginfo.linetable === nothing || pc <= 0 || line < 0
-            line < 0 && (doupdate = false; line = 0) # broken debug info
-            push!(scopes, LineInfoNode(def, debuginfo_file1(debuginfo), Int32(line)))
+    while di !== nothing
+        di.def isa Symbol || (def = di.def)
+        if pc <= 0
+            push!(scopes, LineInfoNode(def, debuginfo_file1(di), Int32(0)))
+            return false
+        elseif !Base.Compiler.has_prev_debuginfo(di, pc)
+            line = Base.Compiler.source_location(di, pc).line # TODO: column ignored here
+            (line < 0) && (doupdate = false; line = 0) # broken debug info
+            push!(scopes, LineInfoNode(def, debuginfo_file1(di), Int32(line)))
         else
-            doupdate = append_scopes!(scopes, line, debuginfo.linetable::DebugInfo, def) && doupdate
+            di2, pc2 = Base.Compiler.prev_debuginfo(di, pc)
+            doupdate &= append_scopes!(scopes, pc2, di2, def)
         end
-        inl_to == 0 && return doupdate
         def = :var"macro expansion"
-        debuginfo = debuginfo.edges[inl_to]
-        pc::Int = codeloc[3]
+        di, pc = Base.Compiler.edge_debuginfo(di, pc)
+        doupdate |= di !== nothing
     end
+    return doupdate
 end
 
 # utility wrapper around `append_scopes!` that returns an empty list instead of false

--- a/Compiler/src/ssair/show.jl
+++ b/Compiler/src/ssair/show.jl
@@ -408,11 +408,11 @@ function append_scopes!(scopes::Vector{LineInfoNode}, pc::Int, di, @nospecialize
     while di !== nothing
         di.def isa Symbol || (def = di.def)
         if pc <= 0
-            push!(scopes, LineInfoNode(def, debuginfo_file1(di), Int32(0)))
+            # TODO: assert false
             return false
         elseif !Base.Compiler.has_prev_debuginfo(di, pc)
             line = Base.Compiler.source_location(di, pc).line # TODO: column ignored here
-            (line < 0) && (doupdate = false; line = 0) # broken debug info
+            (line <= 0) && (doupdate = false; line = 0) # broken debug info
             push!(scopes, LineInfoNode(def, debuginfo_file1(di), Int32(line)))
         else
             di2, pc2 = Base.Compiler.prev_debuginfo(di, pc)

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -112,12 +112,11 @@ function hash(frame::StackFrame, h::UInt)
 end
 
 function _add_linetable_frames!(frames, pointer, di::Core.DebugInfo, pc::Int)
-    lt = di.linetable
+    lt, ltpc = Base.Compiler.prev_debuginfo(di, pc)
     if lt isa Core.DebugInfo
-        ltpc::Int, _, _ = Base.Compiler.getdebugidx(di, pc)
         _add_linetable_frames!(frames, pointer, lt, ltpc)
-        _, eid::Int, epc::Int = Base.Compiler.getdebugidx(lt, ltpc)
-        eid != 0 && _add_di_frames!(frames, pointer, lt.edges[eid], epc)
+        edi, epc = Base.Compiler.edge_debuginfo(lt, ltpc)
+        edi !== nothing && _add_di_frames!(frames, pointer, edi, epc)
     end
     nothing
 end
@@ -126,7 +125,6 @@ end
 # 2. If there is a linetable, recurse on edges there (and not the linetable)
 # 3. Recurse on any of our own edges
 function _add_di_frames!(frames, pointer, di::Core.DebugInfo, pc::Int)
-    _, eid::Int, epc::Int = Base.Compiler.getdebugidx(di, pc)
     @assert pc > 0 "invalid pc"
     push!(frames, StackFrame(
         di.def isa Symbol ? Symbol("macro expansion") : IRShow.method_name(di.def),
@@ -138,7 +136,8 @@ function _add_di_frames!(frames, pointer, di::Core.DebugInfo, pc::Int)
         pointer,
         pc))
     _add_linetable_frames!(frames, pointer, di, pc)
-    eid != 0 && epc != 0 && _add_di_frames!(frames, pointer, di.edges[eid], epc)
+    edi, epc = Base.Compiler.edge_debuginfo(di, pc)
+    edi !== nothing && _add_di_frames!(frames, pointer, edi, epc)
     nothing
 end
 

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -965,17 +965,17 @@ static size_t codelocs_parseheader(jl_string_t *cl, int *loc_offset, int *loc_by
     int32_t header[3];
     memcpy(&header, (char*)jl_string_data(cl), sizeof(header));
     *loc_offset = header[0];
-    if (header[1] < 255)
+    if (header[1] <= UINT8_MAX)
         *loc_bytes = 1;
-    else if (header[1] < 65535)
+    else if (header[1] <= UINT16_MAX)
         *loc_bytes = 2;
     else
         *loc_bytes = 4;
     if (header[2] == 0)
         *to_bytes = 0;
-    else if (header[2] < 255)
+    else if (header[2] <= UINT8_MAX)
         *to_bytes = 1;
-    else if (header[2] < 65535)
+    else if (header[2] <= UINT16_MAX)
         *to_bytes = 2;
     else
         *to_bytes = 4;
@@ -1625,18 +1625,18 @@ JL_DLLEXPORT jl_string_t *jl_compress_codelocs(int32_t firstloc, jl_value_t *cod
     header[1] = min.loc > max.loc ? 0 : max.loc - min.loc;
     header[2] = max.to > max.pc ? max.to : max.pc;
     size_t loc_bytes;
-    if (header[1] < 255)
+    if (header[1] <= UINT8_MAX)
         loc_bytes = 1;
-    else if (header[1] < 65535)
+    else if (header[1] <= UINT16_MAX)
         loc_bytes = 2;
     else
         loc_bytes = 4;
     size_t to_bytes;
     if (header[2] == 0)
         to_bytes = 0;
-    else if (header[2] < 255)
+    else if (header[2] <= UINT8_MAX)
         to_bytes = 1;
-    else if (header[2] < 65535)
+    else if (header[2] <= UINT16_MAX)
         to_bytes = 2;
     else
         to_bytes = 4;


### PR DESCRIPTION
The sequel to https://github.com/JuliaLang/julia/pull/61817.  We want to move away from using  `getdebugidx`, which has signature
```
(::DebugInfo, pc::Int) -> (line_or_nextpc::Int, edge_id::Int, edge_pc::Int)
```
in debuginfo consumers since (1) there's no good way to return more information
than a line, and (2) the caller needs to come up with its own criteria to decide
whether to recurse (`di.linetable !== nothing` will soon be wrong).

TODO: I need to find callers in the ecosystem and move them to this new API.
