### PR TITLE
Don't rewrap other unioned types in flatten_type_union

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -564,7 +564,7 @@ static void flatten_type_union(jl_value_t **types, size_t n, jl_value_t **out, s
         if (widen && jl_is_unionall(e) && jl_is_uniontype(jl_unwrap_unionall(e))) {
             // flatten this UnionAll into place by switching the union and unionall
             jl_uniontype_t *u = (jl_uniontype_t*)jl_unwrap_unionall(e);
-            size_t old_idx = 0;
+            size_t old_idx = *idx;
             flatten_type_union(&u->a, 2, out, idx, widen);
             for (; old_idx < *idx; old_idx++)
                 out[old_idx] = jl_rewrap_unionall(out[old_idx], e);

--- a/test/core.jl
+++ b/test/core.jl
@@ -8858,3 +8858,11 @@ function _envleak_build(n::Int)
     return typeof(b)
 end
 @test _envleak_build(3) === Vector{_EnvLeak_Foo{3}}
+
+# (#61914) when transforming UnionAll of Union to Union of UnionAll, don't
+# re-wrap members of the union that were not beneath the UnionAll with the type
+# variable.
+let T = TypeVar(:T)
+    a = UnionAll(T, Union{Vector{T}, Int64})
+    @test Union{T, a} == Union{a, T} == Union{T, Int64, Vector}
+end


### PR DESCRIPTION
Fixes #61914, using the suggestion by Opus 4.6. (Thanks to @JeffBezanson for confirmation that the original issue was real)

Here's a simpler example I used to understand the problem:
```
T = TypeVar(:T)
a = UnionAll(T, Union{Vector{T}, Int64})
```

Now, when we do `Union{a, T}`, we get `Union{Int64, Vector, T}` like expected, since the `T` on the RHS is not bound by the UnionAll, and the UnionAll of Union was rewritten to Union of UnionAll, leaving us with `UnionAll(T, Vector{T}) == Vector`.

`Union{T, a}` gave us the wrong answer because `flatten_type_union`, when doing the UnionAll of Union transform, would re-wrap every Union component from the beginning of the `out` with the UnionAll's variable, even if those components were not originally under the UnionAll. The `out` array would go from `T, Vector{T}, Int64` to `UnionAll(T, T) => Any, UnionAll(T, Vector{T}) => Vector, UnionAll(T, Int64) => Int64`, leaving us with `Any`.