### PR TITLE
compiler: recycle InstructionStream buffers across optimizer compaction passes

### DIFF
--- a/Compiler/src/optimize.jl
+++ b/Compiler/src/optimize.jl
@@ -1054,18 +1054,22 @@ function run_passes_ipo_safe(
     end
 
     __stage__ = 0  # used by @pass
+    # Free-list of dead `InstructionStream`s, recycled across the sequential top-level
+    # compactions below (each pass's now-dead input stream feeds the next pass's result),
+    # avoiding a fresh per-pass allocation of the result buffers.
+    stream_pool = InstructionStream[]
     # NOTE: The pass name MUST be unique for `optimize_until::String` to work
     @pass "CC: CONVERT"   ir = convert_to_ircode(ci, sv)
     @pass "CC: SLOT2REG"  ir = slot2reg(ir, ci, sv)
     # TODO: Domsorting can produce an updated domtree - no need to recompute here
-    @pass "CC: COMPACT_1" ir = compact!(ir)
+    @pass "CC: COMPACT_1" ir = compact!(ir, false, stream_pool)
     @pass "CC: INLINING"  ir = ssa_inlining_pass!(ir, sv.inlining, ci.propagate_inbounds)
     # @zone "CC: VERIFY 2" verify_ir(ir)
-    @pass "CC: COMPACT_2" ir = compact!(ir)
+    @pass "CC: COMPACT_2" ir = compact!(ir, false, stream_pool)
     @pass "CC: SROA"      ir = sroa_pass!(ir, sv.inlining)
     @pass "CC: ADCE"      (ir, made_changes) = adce_pass!(ir, sv.inlining)
     if made_changes
-        @pass "CC: COMPACT_3" ir = compact!(ir, true)
+        @pass "CC: COMPACT_3" ir = compact!(ir, true, stream_pool)
     end
     if is_asserts()
         @zone "CC: VERIFY_3" begin

--- a/Compiler/src/ssair/ir.jl
+++ b/Compiler/src/ssair/ir.jl
@@ -303,6 +303,19 @@ function resize!(stmts::InstructionStream, len)
     return stmts
 end
 
+# Reset a recycled, no-longer-referenced stream to the state of a fresh
+# `InstructionStream(len)`, reusing the backing buffers when their capacity allows.
+# Used by the optimizer's per-pipeline stream pool to recycle a prior pass's dead
+# result stream instead of allocating fresh compaction buffers.
+function reinit_stream!(stmts::InstructionStream, len::Int)
+    empty!(stmts.stmt); resize!(stmts.stmt, len)   # leaves all slots #undef, as in InstructionStream(len)
+    empty!(stmts.type); resize!(stmts.type, len)   # leaves all slots #undef
+    resize!(stmts.info, len); fill!(stmts.info, NoCallInfo())
+    resize!(stmts.line, 3len); fill!(stmts.line, Int32(0))
+    resize!(stmts.flag, len); fill!(stmts.flag, IR_FLAG_NULL)
+    return stmts
+end
+
 struct Instruction
     data::InstructionStream
     idx::Int
@@ -793,12 +806,20 @@ mutable struct IncrementalCompact
     active_result_bb::Int
     renamed_new_nodes::Bool
 
-    function IncrementalCompact(code::IRCode, cfg_transform::CFGTransformState)
+    # Optional free-list of dead `InstructionStream`s (from earlier passes of the same
+    # optimize() pipeline) to recycle the `result` stream from instead of allocating.
+    # When non-`nothing`, this compaction's own (now-dead) input stream is returned to the
+    # pool by `complete`. `nothing` for nested/standalone compactions that don't pool.
+    stream_pool::Union{Nothing,Vector{InstructionStream}}
+
+    function IncrementalCompact(code::IRCode, cfg_transform::CFGTransformState,
+                                stream_pool::Union{Nothing,Vector{InstructionStream}}=nothing)
         # Sort by position with attach after nodes after regular ones
         info = code.new_nodes.info
         perm = sort!(collect(eachindex(info)); by=i::Int->(2info[i].pos+info[i].attach_after, i))
         new_len = length(code.stmts) + length(info)
-        result = InstructionStream(new_len)
+        result = stream_pool !== nothing && !isempty(stream_pool) ?
+            reinit_stream!(pop!(stream_pool), new_len) : InstructionStream(new_len)
         code.debuginfo.codelocs = result.line
         used_ssas = fill(0, new_len)
         new_new_used_ssas = Vector{Int}()
@@ -810,7 +831,7 @@ mutable struct IncrementalCompact
         pending_perm = Int[]
         return new(code, result, cfg_transform, ssa_rename, used_ssas, late_fixup, perm, 1,
             new_new_nodes, new_new_used_ssas, pending_nodes, pending_perm,
-            1, 1, 1, 1, false)
+            1, 1, 1, 1, false, stream_pool)
     end
 
     # For inlining
@@ -826,12 +847,13 @@ mutable struct IncrementalCompact
             ssa_rename, parent.used_ssas,
             parent.late_fixup, perm, 1,
             parent.new_new_nodes, parent.new_new_used_ssas, pending_nodes, pending_perm,
-            1, result_offset, 1, parent.active_result_bb, false)
+            1, result_offset, 1, parent.active_result_bb, false, nothing)
     end
 end
 
-function IncrementalCompact(code::IRCode, allow_cfg_transforms::Bool=false)
-    return IncrementalCompact(code, CFGTransformState!(code.cfg.blocks, allow_cfg_transforms))
+function IncrementalCompact(code::IRCode, allow_cfg_transforms::Bool=false,
+                            stream_pool::Union{Nothing,Vector{InstructionStream}}=nothing)
+    return IncrementalCompact(code, CFGTransformState!(code.cfg.blocks, allow_cfg_transforms), stream_pool)
 end
 
 struct TypesView{T}
@@ -2181,11 +2203,21 @@ function complete(compact::IncrementalCompact)
         resize!(compact.result, length(compact.result) - nundef)
     end
 
+    # The input stream is dead once we hand back the new IRCode (which wraps the freshly
+    # built `result`, not `compact.ir.stmts`). Return it to the pool for a later pass to
+    # recycle. Only reached for pooled (top-level run_passes) compactions, whose inputs are
+    # private post-slot2reg streams — never aliased to the CodeInfo's arrays.
+    pool = compact.stream_pool
+    if pool !== nothing
+        push!(pool, compact.ir.stmts)
+    end
+
     return IRCode(compact.ir, compact.result, cfg, compact.new_new_nodes)
 end
 
-function compact!(code::IRCode, allow_cfg_transforms::Bool=false)
-    compact = IncrementalCompact(code, allow_cfg_transforms)
+function compact!(code::IRCode, allow_cfg_transforms::Bool=false,
+                  stream_pool::Union{Nothing,Vector{InstructionStream}}=nothing)
+    compact = IncrementalCompact(code, allow_cfg_transforms, stream_pool)
     # Just run through the iterator without any processing
     for _ in compact; end # _ isa Pair{Int, Any}
     return finish(compact)


### PR DESCRIPTION
The optimizer's `run_passes_ipo_safe` pipeline runs several `compact!` passes in sequence. Each allocated a fresh `InstructionStream` (five parallel arrays, including a `3*nstmts` codelocs array) for its result and dropped the input stream as garbage once the new `IRCode` was built.

This adds a small free-list of dead `InstructionStream`s, recycled across the sequential top-level compactions: when a pooled `compact!` finishes, its now-dead input stream is returned to the pool, and the next pooled `compact!` recycles it for its result via `reinit_stream!` instead of allocating. The pool is a `run_passes_ipo_safe` local threaded only into the top-level `compact!` calls — these never nest, and their inputs are private post-`slot2reg` streams, so recycling is re-entrancy- and aliasing-safe. The ci-wrapping CONVERT stream and the retained final stream are never pooled.

## Validation
- The compaction SSA-count oracle (`__set_check_ssa_counts(true)`) passes when driving the InferenceBenchmarks targets through full optimization.
- `Compiler/test/{compact,ssair,irpasses,inline}.jl` all pass.
- Deterministic optimizer-isolated allocation A/B vs a freshly-built master baseline: ~1.8% reduction in optimizer allocation on the InferenceBenchmarks targets (e.g. `many_local_vars` 23.86MB → 23.44MB). The win is modest because only ~1-2 streams per function are recycled; it is larger for compaction-heavy functions.

---
This pull request was written with the assistance of generative AI (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
