### PR TITLE
Separate inference cache for `--trim`

### DIFF
--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1859,7 +1859,10 @@ const TRIM_SAFE = 0x1
 const TRIM_UNSAFE = 0x2
 const TRIM_UNSAFE_WARN = 0x3
 function typeinf_ext_toplevel(methods::Vector{Any}, worlds::Vector{UInt}, trim_mode::UInt8)
-    inf_params = InferenceParams(; force_enable_inference = trim_mode != TRIM_NO)
+    # During `--trim`, infer against an isolated cache namespace. The owner is re-stamped
+    # back to `nothing` at serialization time (see `src/staticdata.c`).
+    cache_owner = trim_mode == TRIM_NO ? nothing : :trim
+    inf_params = InferenceParams(; force_enable_inference = trim_mode != TRIM_NO, cache_owner)
 
     # Create an "invokelatest" queue to enable eager compilation of speculative
     # invokelatest calls such as from `Core.finalizer` and `ccallable`

--- a/Compiler/src/types.jl
+++ b/Compiler/src/types.jl
@@ -263,6 +263,7 @@ struct InferenceParams
     assume_bindings_static::Bool
     ignore_recursion_hardlimit::Bool
     force_enable_inference::Bool
+    cache_owner::Any
 
     function InferenceParams(
         max_methods::Int,
@@ -275,6 +276,7 @@ struct InferenceParams
         assume_bindings_static::Bool,
         ignore_recursion_hardlimit::Bool,
         force_enable_inference::Bool,
+        @nospecialize(cache_owner),
     )
         return new(
             max_methods,
@@ -287,6 +289,7 @@ struct InferenceParams
             assume_bindings_static,
             ignore_recursion_hardlimit,
             force_enable_inference,
+            cache_owner,
         )
     end
 end
@@ -301,7 +304,8 @@ function InferenceParams(
         #=aggressive_constant_propagation::Bool=# false,
         #=assume_bindings_static::Bool=# false,
         #=ignore_recursion_hardlimit::Bool=# false,
-        #=force_enable_inference::Bool=# false
+        #=force_enable_inference::Bool=# false,
+        #=cache_owner=# nothing
     );
     max_methods::Int = params.max_methods,
     max_union_splitting::Int = params.max_union_splitting,
@@ -313,6 +317,7 @@ function InferenceParams(
     assume_bindings_static::Bool = params.assume_bindings_static,
     ignore_recursion_hardlimit::Bool = params.ignore_recursion_hardlimit,
     force_enable_inference::Bool = params.force_enable_inference,
+    cache_owner = params.cache_owner,
 )
     return InferenceParams(
         max_methods,
@@ -325,6 +330,7 @@ function InferenceParams(
         assume_bindings_static,
         ignore_recursion_hardlimit,
         force_enable_inference,
+        cache_owner,
     )
 end
 
@@ -472,7 +478,7 @@ InferenceParams(interp::NativeInterpreter) = interp.inf_params
 OptimizationParams(interp::NativeInterpreter) = interp.opt_params
 get_inference_world(interp::NativeInterpreter) = interp.world
 get_inference_cache(interp::NativeInterpreter) = interp.inf_cache
-cache_owner(::NativeInterpreter) = nothing
+cache_owner(interp::NativeInterpreter) = interp.inf_params.cache_owner
 
 engine_reserve(interp::AbstractInterpreter, mi::MethodInstance) = engine_reserve(mi, cache_owner(interp))
 engine_reserve(mi::MethodInstance, @nospecialize owner) = ccall(:jl_engine_reserve, Any, (Any, Any), mi, owner)::CodeInstance

--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -441,7 +441,10 @@ function get_verify_typeinf_trim(codeinfos::Vector{Any})
         item = codeinfos[i]
         if item isa CodeInstance
             push!(inspected, item)
-            if item.owner === nothing && item.min_world <= this_world <= item.max_world
+            # Trim inference caches its results under the `:trim` symbol as the owner (see
+            # `typeinf_ext_toplevel`), so the `CodeInstance`s handed to us here carry that
+            # owner rather than `nothing`.
+            if item.owner === :trim && item.min_world <= this_world <= item.max_world
                 mi = get_ci_mi(item)
                 if mi === item.def
                     caches[mi] = item

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -518,7 +518,8 @@ static void generate_cfunc_thunks(jl_codegen_output_t &out)
     DenseMap<jl_method_instance_t*, jl_code_instance_t*> compiled_mi;
     for (auto &[ci, _] : out.ci_funcs) {
         jl_method_instance_t *mi = jl_get_ci_mi(ci);
-        if (ci->owner == jl_nothing && jl_atomic_load_relaxed(&ci->max_world) == ~(size_t)0 && ci->def == (jl_value_t*)mi)
+        if ((ci->owner == jl_nothing || ci->owner == (jl_value_t*)jl_trim_sym) &&
+            jl_atomic_load_relaxed(&ci->max_world) == ~(size_t)0 && ci->def == (jl_value_t*)mi)
             compiled_mi[mi] = ci;
     }
     size_t latestworld = jl_atomic_load_acquire(&jl_world_counter);

--- a/src/ast.c
+++ b/src/ast.c
@@ -330,6 +330,7 @@ void jl_init_common_symbols(void)
     jl_sequentially_consistent_sym = jl_symbol("sequentially_consistent");
     jl_uninferred_sym = jl_symbol("uninferred");
     jl_latestworld_sym = jl_symbol("latestworld");
+    jl_trim_sym = jl_symbol("trim");
 }
 
 void jl_lisp_prompt(void)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2075,6 +2075,7 @@ JL_DLLEXPORT int jl_isabspath(const char *in) JL_NOTSAFEPOINT;
     XX(top_sym) \
     XX(toplevel_sym) \
     XX(tuple_sym) \
+    XX(trim_sym) \
     XX(uninferred_sym) \
     XX(unordered_sym) \
     XX(unused_sym) \

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -586,6 +586,27 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
             // prevent this from happening, so we do not need to detect that user
             // error now.
         }
+        else if (jl_options.trim) {
+            // Rebuild the `mi->cache` list with any non-:trim-owned CodeInstances removed.
+            jl_code_instance_t *first = NULL;
+            jl_code_instance_t *prev = NULL;
+            jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
+            while (codeinst) {
+                jl_code_instance_t *next = jl_atomic_load_relaxed(&codeinst->next);
+                if (codeinst->owner == (jl_value_t *)jl_trim_sym) {
+                    record_field_change((jl_value_t**)&codeinst->owner, jl_nothing);
+                    if (prev == NULL)
+                        first = codeinst;
+                    else
+                        record_field_change((jl_value_t**)&prev->next, (jl_value_t*)codeinst);
+                    prev = codeinst;
+                }
+                codeinst = next;
+            }
+            if (prev != NULL)
+                record_field_change((jl_value_t**)&prev->next, NULL);
+            record_field_change((jl_value_t**)&mi->cache, (jl_value_t*)first);
+        }
         // don't recurse into all backedges memory (yet)
         jl_value_t *backedges = get_replaceable_field((jl_value_t**)&mi->backedges, 1);
         if (backedges) {
@@ -712,7 +733,7 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
                 }
                 else if (may_discard_trees &&
                          native_functions && // don't delete any code if making a ji file
-                         (ci->owner == jl_nothing) && // don't delete code for external interpreters
+                         (ci->owner == jl_nothing || ci->owner == (jl_value_t*)jl_trim_sym) && // don't delete code for external interpreters
                          !effects_foldable(jl_atomic_load_relaxed(&ci->ipo_purity_bits)) && // don't delete code we may want for irinterp
                          jl_ir_inlining_cost(inferred) == UINT16_MAX) { // don't delete inlineable code
                     // delete the code now: if we thought it was worth keeping, it would have been converted to object code


### PR DESCRIPTION
This is only a proof-of-concept (it's probably not the solution we want to merge). Nonetheless it does successfully resolve the issues with cache poisoning from non-`--trim`'d inference, so I thought I'd open it to trigger discussion about a proper solution.

Currently JuliaC / `--trim` suffers from some serious spurious failures due to cache poisoning from non-`--trim` inference. The "normal" Julia JIT runs inference with different [`InferenceParams`](https://github.com/JuliaLang/julia/blob/39bd0b4bf75d9f516c510735cea3d04eb3c995d6/Compiler/src/typeinfer.jl#L1729), less aggressive [`max_args` heuristics](https://github.com/JuliaLang/julia/blob/c2779f34f04859e914308b5b91147a3cc5b0fb02/contrib/juliac/juliac-trim-base.jl#L81-L88), and other differences that can lead to `--trim` failures. If inference was forced to widen, or generated results for too-wide signatures, then the `--trim` job will fail to notice that it would actually succeed if it re-inferred under its own settings. The solution to this is to separate the inference cache for `--trim` from the usual inference cache used by JIT / default AOT compilation (resolves https://github.com/JuliaLang/julia/issues/58834).

@vtjnash was hoping we'd be able to lean on inference's local cache entirely FWIU, but there are a few issues with that:
1. Writing all `--trim` results to the local cache exclusively does not give us a pathway to register those CI's in the global cache afterwards, which is necessary for dispatch to work properly.
2. Even if we could publish it after-the-fact, the local cache contains many results that are not sound to publish to the global cache (currently guarded by `CACHE_MODE_LOCAL`).
3. For cache reads, we auto-fallback from the local cache to the global cache anyway, so poisoning still occurs.

Given those complications, this PR is the simplest possible implementation that seems to achieve the same goal. There is also the chance that I mis-understood his suggestion, and that this PR is what he intended.

In either case, I am open to suggestions w.r.t. the "proper" solution here