### PR TITLE
LabelCheck.yml: switch to an altnerative actively maintained action

### DIFF
--- a/.github/workflows/LabelCheck.yml
+++ b/.github/workflows/LabelCheck.yml
@@ -14,9 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-    - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
+    - uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5.5.2
       with:
-        # REQUIRED_LABELS_ANY: "bug,enhancement,skip-changelog"
-        # REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['bug','enhancement','skip-changelog']"
-        BANNED_LABELS: "needs docs,needs compat annotation,needs more info,needs nanosoldier run,needs news,needs pkgeval,needs tests,needs decision,DO NOT MERGE,status:DO NOT MERGE"
-        BANNED_LABELS_DESCRIPTION: "A PR should not be merged with `needs *` or `status:DO NOT MERGE` labels"
+        mode: exactly
+        count: 0
+        labels: "needs docs,needs compat annotation,needs more info,needs nanosoldier run,needs news,needs pkgeval,needs tests,needs decision,DO NOT MERGE,status:DO NOT MERGE"
+        add_comment: false
+        message: "A PR should not be merged with `needs *` or `status:DO NOT MERGE` labels"


### PR DESCRIPTION
https://github.com/yogevbd/enforce-label-action is unmaintained and deps are old. I think it's started erroring,