### PR TITLE
operators: Drop incorrect `:nothrow` from `supertype(::UnionAll)`

### DIFF
--- a/Compiler/test/effects.jl
+++ b/Compiler/test/effects.jl
@@ -46,6 +46,17 @@ end
     return nothing
 end
 
+# `supertype(::UnionAll)` can throw (its recursion hits `supertype(::Union)` for
+# inputs like `Union{S,T} where {S,T}`), so it must be `:foldable` rather than
+# `:total` and a dead call to it must not be eliminated (issue #61988)
+@test Compiler.is_foldable(Base.infer_effects(supertype, (UnionAll,)))
+@test !Compiler.is_nothrow(Base.infer_effects(supertype, (UnionAll,)))
+@test !fully_eliminated((UnionAll,)) do x
+    supertype(x)
+    return nothing
+end
+@test_throws MethodError (x -> (supertype(x); nothing))(Union{S,T} where {S,T})
+
 # Test that a missing methtable identification gets tainted
 # appropriately
 struct FCallback; f::Union{Nothing, Function}; end

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -84,7 +84,7 @@ DenseVector (alias for DenseArray{T, 1} where T)
 ```
 """
 supertype(T::DataType) = (@_total_meta; T.super)
-supertype(T::UnionAll) = (@_total_meta; UnionAll(T.var, supertype(T.body)))
+supertype(T::UnionAll) = (@_foldable_meta; UnionAll(T.var, supertype(T.body)))
 
 ## generic comparison ##
 


### PR DESCRIPTION
`supertype(T::UnionAll)` recurses as `UnionAll(T.var, supertype(T.body))`, which throws when the body is a `Union` (there is no `supertype(::Union)` method), e.g. `supertype(Union{S,T} where {S,T})`. Marking it `@assume_effects :total` therefore asserted `:nothrow` unsoundly, letting the compiler eliminate the call when its result is unused and silently swallow the exception.

Use `@_foldable_meta` (`:total` minus `:nothrow`) instead. Compile-time constant folding for valid inputs is preserved, while the call is no longer assumed to be exception-free. The `DataType` method is unchanged, and all internal hot-path callers reach `supertype` through it.

Fixes #61988.