### PR TITLE
gf: redesign specialization strategy

### DIFF
--- a/Compiler/src/abstractinterpretation.jl
+++ b/Compiler/src/abstractinterpretation.jl
@@ -128,6 +128,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
         add_remark!(interp, sv, "Cannot infer call, because we previously saw :latestworld")
         return Future(CallMeta(Any, Any, Effects(), NoCallInfo()))
     end
+    current_world = get_world_counter()
     matches = find_method_matches(interp, argtypes, atype; max_methods, fargs=arginfo.fargs)
     if isa(matches, FailedMethodMatch)
         add_remark!(interp, sv, matches.reason)
@@ -314,7 +315,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
                     inferidx[] += 1
                     local method = match.method
                     local sig = match.spec_types
-                    mi = specialize_method(match; preexisting=true)
+                    local mi = specialize_method(match; preexisting=true)
                     local call_result = call_results[edge_idx]
                     if mi === nothing || !(call_result isa InferenceResult) || !const_prop_methodinstance_heuristic(interp, call_result, mi, arginfo, sv)
                         csig = get_compileable_sig(method, sig, match.sparams)
@@ -322,7 +323,22 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
                             #println(sig, " changed to ", csig, " for ", method)
                             (_, sparams) = typeintersect_env(csig, method.sig)
                             mresult = abstract_call_method(interp, method, csig, sparams, multiple_matches, StmtInfo(false, false), sv)::Future
-                            isready(mresult) || return false # wait for mresult Future to resolve off the callstack before continuing
+                            function infercalls3(interp, sv)
+                                local edge = mresult[].edge
+                                if edge !== nothing
+                                    local sig = match.spec_types
+                                    local mi = get_ci_mi(edge)
+                                    local vw = matches.valid_worlds
+                                    ccall(:jl_recache_method_by_type, Cvoid, (Any, Any, Any, UInt, UInt, UInt, UInt),
+                                            sig, mi, mi.specTypes, get_inference_world(interp),
+                                            first(vw), last(vw), current_world)
+                                end
+                                return true
+                            end
+                            if !isready(mresult) || !infercalls3(interp, sv)
+                                push!(sv.tasks, infercalls3)
+                                return false # wait for mresult Future to resolve off the callstack before continuing
+                            end
                         end
                     end
                 end
@@ -2951,38 +2967,6 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
     elseif isa(f, Core.OpaqueClosure)
         # calling an OpaqueClosure about which we have no information returns no information
         return Future(CallMeta(typeof(f).parameters[2], Any, Effects(), NoCallInfo()))
-    elseif f === TypeVar && !isvarargtype(argtypes[end])
-        # Manually look through the definition of TypeVar to
-        # make sure to be able to get `PartialTypeVar`s out.
-        2 ≤ la ≤ 4 || return Future(CallMeta(Bottom, Any, EFFECTS_THROWS, NoCallInfo()))
-        # make sure generic code is prepared for inlining if needed later
-        let T = Any[Type{TypeVar}, Any, Any, Any]
-            resize!(T, la)
-            atype = Tuple{T...}
-            T[1] = Const(TypeVar)
-            let call = abstract_call_gf_by_type(interp, f, ArgInfo(nothing, T), si, atype, vtypes, sv, max_methods)::Future
-                return Future{CallMeta}(call, interp, sv) do call, interp, sv
-                    n = argtypes[2]
-                    ub_var = Const(Any)
-                    lb_var = Const(Union{})
-                    if la == 4
-                        ub_var = argtypes[4]
-                        lb_var = argtypes[3]
-                    elseif la == 3
-                        ub_var = argtypes[3]
-                    end
-                    pT = typevar_tfunc(𝕃ᵢ, n, lb_var, ub_var)
-                    typevar_argtypes = Any[n, lb_var, ub_var]
-                    effects = builtin_effects(𝕃ᵢ, Core._typevar, typevar_argtypes, pT)
-                    if effects.nothrow
-                        exct = Union{}
-                    else
-                        exct = builtin_exct(𝕃ᵢ, Core._typevar, typevar_argtypes, pT)
-                    end
-                    return CallMeta(pT, exct, effects, call.info)
-                end
-            end
-        end
     elseif f === UnionAll
         let call = abstract_call_gf_by_type(interp, f, ArgInfo(nothing, Any[Const(UnionAll), Any, Any]), si, Tuple{Type{UnionAll}, Any, Any}, vtypes, sv, max_methods)::Future
             return Future{CallMeta}(call, interp, sv) do call, interp, sv
@@ -3014,20 +2998,67 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
     elseif la == 3 && f === Core.:(>:)
         # mark issupertype as a exact alias for issubtype
         # swap T1 and T2 arguments and call <:
-        if fargs !== nothing && length(fargs) == 3
-            fargs = Any[<:, fargs[3], fargs[2]]
-        else
-            fargs = nothing
+        atype = argtypes_to_type(argtypes)
+        let call = abstract_call_gf_by_type(interp, f, ArgInfo(fargs, Any[Const(f), Any, Any]), si, Tuple{typeof(f), Any, Any}, vtypes, sv, max_methods)::Future
+            if fargs !== nothing && length(fargs) == 3
+                fargs_reverse = Any[<:, fargs[3], fargs[2]]
+            else
+                fargs_reverse = nothing
+            end
+            argtypes_reverse = Any[typeof(<:), argtypes[3], argtypes[2]]
+            call_reverse = abstract_call_known(interp, <:, ArgInfo(fargs_reverse, argtypes_reverse), si, vtypes, sv, max_methods)
+            return Future{CallMeta}(isready(call) && isready(call_reverse), interp, sv) do interp, sv
+                return call_reverse[]
+            end
         end
-        argtypes = Any[typeof(<:), argtypes[3], argtypes[2]]
-        return abstract_call_known(interp, <:, ArgInfo(fargs, argtypes), si, vtypes, sv, max_methods)
-    elseif la == 2 && f === Core.typename
-        return Future(CallMeta(typename_static(argtypes[2]), Bottom, EFFECTS_TOTAL, MethodResultPure()))
-    elseif f === Core._hasmethod
-        return Future(_hasmethod_tfunc(interp, argtypes, sv))
     end
     atype = argtypes_to_type(argtypes)
-    return abstract_call_gf_by_type(interp, f, arginfo, si, atype, vtypes, sv, max_methods)::Future
+    call = abstract_call_gf_by_type(interp, f, arginfo, si, atype, vtypes, sv, max_methods)::Future
+    # Improve some results with custom tfuncs,
+    # now that we've inferred the target function to generate source code,
+    # which might be needed for inlining / invoke / dispatch.
+    if f === TypeVar && !isvarargtype(argtypes[end])
+        # Manually look through the definition of TypeVar to
+        # make sure to be able to get `PartialTypeVar`s out.
+        2 ≤ la ≤ 4 || return Future{CallMeta}(call, sv, interp) do call, sv, interp
+            return CallMeta(Bottom, Any, EFFECTS_THROWS, NoCallInfo())
+        end
+        # make sure generic code is prepared for inlining if needed later
+        let T = Any[Type{TypeVar}, Any, Any, Any]
+            resize!(T, la)
+            atype = Tuple{T...}
+            T[1] = Const(TypeVar)
+            return Future{CallMeta}(call, interp, sv) do call, interp, sv
+                n = argtypes[2]
+                ub_var = Const(Any)
+                lb_var = Const(Union{})
+                if la == 4
+                    ub_var = argtypes[4]
+                    lb_var = argtypes[3]
+                elseif la == 3
+                    ub_var = argtypes[3]
+                end
+                pT = typevar_tfunc(𝕃ᵢ, n, lb_var, ub_var)
+                typevar_argtypes = Any[n, lb_var, ub_var]
+                effects = builtin_effects(𝕃ᵢ, Core._typevar, typevar_argtypes, pT)
+                if effects.nothrow
+                    exct = Union{}
+                else
+                    exct = builtin_exct(𝕃ᵢ, Core._typevar, typevar_argtypes, pT)
+                end
+                return CallMeta(pT, exct, effects, call.info)
+            end
+        end
+    elseif la == 2 && f === Core.typename
+        return Future{CallMeta}(call, interp, sv) do call, interp, sv
+            return CallMeta(typename_static(argtypes[2]), Bottom, EFFECTS_TOTAL, MethodResultPure())
+        end
+    elseif f === Core._hasmethod
+        return Future{CallMeta}(call, interp, sv) do call, interp, sv
+            return _hasmethod_tfunc(interp, argtypes, sv)
+        end
+    end
+    return call
 end
 
 function abstract_call_opaque_closure(interp::AbstractInterpreter, closure::PartialOpaque,

--- a/Compiler/src/precompile.jl
+++ b/Compiler/src/precompile.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-# This file replaces the functionality from src/precompile_utils.c
-
 compile_hint(@nospecialize(argt::Type)) = ccall(:jl_compile_hint, Int32, (Any,), argt) != 0
 
 # Utility functions for type manipulation
@@ -273,10 +271,14 @@ function infer_all_method_defs!(all::Bool, allmeths, world::UInt, worklist)
     end
 end
 
-# This corresponds to precompile_enq_all_specializations_
 function enqueue_specializations!(all::Bool, newmethods, worklist)
     for method in newmethods
         method = method::Method
+
+        # skip all macros
+        if !all && !iszero(ccall(:jl_method_is_macro, Cint, (Any,), method))
+            continue
+        end
 
         # Check for special methods that should always be compiled
         if (method.name === :__init__ || isdefined(method, :ccallable)) && isdispatchtuple(method.sig)
@@ -290,10 +292,10 @@ function enqueue_specializations!(all::Bool, newmethods, worklist)
                 for i = 1:length(specializations)
                     mi = specializations[i]
                     if mi !== nothing
-                        enqueue_specialization!(all, worklist, mi::Core.MethodInstance)
+                        enqueue_specialization!(all, worklist, mi::MethodInstance)
                     end
                 end
-            elseif isa(specializations, Core.MethodInstance)
+            elseif isa(specializations, MethodInstance)
                 enqueue_specialization!(all, worklist, specializations)
             end
         end
@@ -305,8 +307,11 @@ function enqueue_specializations!(all::Bool, newmethods, worklist)
     end
 end
 
-function enqueue_specialization!(all::Bool, worklist, mi::Core.MethodInstance)
-    # Translation of precompile_enq_specialization_ from C
+function enqueue_specialization!(all::Bool, worklist, mi::MethodInstance)
+    if mi.precompile
+        push!(worklist, mi)
+        return true
+    end
     codeinst = isdefined(mi, :cache) ? mi.cache : nothing
     while codeinst !== nothing
         do_compile = false
@@ -314,7 +319,7 @@ function enqueue_specialization!(all::Bool, worklist, mi::Core.MethodInstance)
             # This code instance is from a foreign interpreter, so we skip it
         elseif use_const_api(codeinst) # Check if invoke is jl_fptr_const_return
             do_compile = true
-        elseif codeinst.invoke != C_NULL || codeinst.precompile
+        elseif codeinst.invoke != C_NULL
             do_compile = true
         elseif !do_compile && isdefined(codeinst, :inferred)
             inferred = codeinst.inferred
@@ -371,16 +376,20 @@ function compile_and_emit_native(worlds::Vector{UInt},
             infer_all_method_defs!(all, newmethods, latestworld, specialization_worklist)
         else
             # Compute new_ext_cis using queue_external_cis with global newly_inferred
-            new_ext_cis = ccall(:jl_compute_new_ext_cis, Any, ())
-            if new_ext_cis !== nothing
-                for i in 1:length(new_ext_cis::Vector{Any})
-                    ci = new_ext_cis[i]::CodeInstance
-                    if ci.owner !== nothing
-                        # enqueue_specialization will skip over CIs from foreign interpreters
-                        # and currently will visit at most one (do_compile) CI per method instance
-                        push!(ext_foreign_cis, ci)
-                    else
-                        enqueue_specialization!(all, specialization_worklist, get_ci_mi(ci))
+            new_ext = ccall(:jl_compute_new_ext, Any, ())
+            if new_ext !== nothing
+                for i in 1:length(new_ext::Vector{Any})
+                    ci = new_ext[i]
+                    if ci isa MethodInstance
+                        push!(specialization_worklist, ci)
+                    elseif ci isa CodeInstance
+                        if ci.owner !== nothing
+                            # enqueue_specialization will skip over CIs from foreign interpreters
+                            # and currently will visit at most one (do_compile) CI per method instance
+                            push!(ext_foreign_cis, ci)
+                        else
+                            enqueue_specialization!(all, specialization_worklist, get_ci_mi(ci))
+                        end
                     end
                 end
             end
@@ -432,8 +441,7 @@ function compile_and_emit_native(worlds::Vector{UInt},
 end
 
 # Helper function to process method instances for compilation
-# This corresponds to the logic in jl_precompile_
-function process_method_instance_for_compilation(mi::Core.MethodInstance, world::UInt)
+function process_method_instance_for_compilation(mi::MethodInstance, world::UInt)
     method = mi.def::Method
     if !(isdefined(method, :unspecialized) && mi === method.unspecialized)
         if !isa_compileable_sig(mi.specTypes, mi.sparam_vals, method)
@@ -445,7 +453,7 @@ function process_method_instance_for_compilation(mi::Core.MethodInstance, world:
     return mi
 end
 
-const _entrypoint_mis = Vector{Core.MethodInstance}()
+const _entrypoint_mis = Vector{MethodInstance}()
 
 # Add a method signature as an entrypoint for compilation.
 function add_entrypoint(types::Type)
@@ -457,11 +465,10 @@ function add_entrypoint(types::Type)
     if mi === nothing
         return false
     end
-    push!(_entrypoint_mis, mi::Core.MethodInstance)
+    push!(_entrypoint_mis, mi::MethodInstance)
     return true
 end
 
-# This corresponds to jl_add_ccallable_entrypoints
 function add_ccallable_entrypoints!()
     # Collect all methods with ccallable annotations
     ccallable_methods = Any[]

--- a/Compiler/src/precompile.jl
+++ b/Compiler/src/precompile.jl
@@ -438,8 +438,8 @@ function process_method_instance_for_compilation(mi::Core.MethodInstance, world:
     if !(isdefined(method, :unspecialized) && mi === method.unspecialized)
         if !isa_compileable_sig(mi.specTypes, mi.sparam_vals, method)
             # Try to get a compileable specialization
-            mi = ccall(:jl_get_specialization1, Any, (Any, Csize_t, Cint),
-                         mi.specTypes, world, #= mt_cache =# 0)::Union{Nothing,MethodInstance}
+            mi = ccall(:jl_get_specialization1, Any, (Any, Csize_t),
+                         mi.specTypes, world)::Union{Nothing,MethodInstance}
         end
     end
     return mi

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1738,7 +1738,8 @@ function add_codeinsts_to_jit!(interp::AbstractInterpreter, ci, source_mode::UIn
 end
 
 function typeinf_ext_toplevel(interp::AbstractInterpreter, mi::MethodInstance, source_mode::UInt8)
-    ci = typeinf_ext(interp, mi, source_mode)
+    mi2 = ccall(:jl_normalize_to_compilable_mi, Any, (Any,), mi)::MethodInstance
+    ci = typeinf_ext(interp, mi2, source_mode)
     ci = add_codeinsts_to_jit!(interp, ci, source_mode)
     return ci
 end

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1773,9 +1773,7 @@ function compile!(codeinfos::Vector{Any}, workqueue::CompilationQueue;
             invokelatest_queue === nothing && continue
             (rt::Type, sig::Type) = item
             # make a best-effort attempt to enqueue the relevant code for the ccallable
-            mi = ccall(:jl_get_specialization1, Any,
-                        (Any, Csize_t, Cint),
-                        sig, world, #= mt_cache =# 0)
+            mi = ccall(:jl_get_specialization1, Any, (Any, Csize_t), sig, world)
             if mi !== nothing
                 mi = mi::MethodInstance
                 ci = typeinf_ext(interp, mi, SOURCE_MODE_GET_SOURCE)

--- a/Compiler/src/verifytrim.jl
+++ b/Compiler/src/verifytrim.jl
@@ -454,9 +454,7 @@ function get_verify_typeinf_trim(codeinfos::Vector{Any})
         elseif item isa SimpleVector
             rt = item[1]::Type
             sig = item[2]::Type
-            mi = ccall(:jl_get_specialization1, Any,
-                        (Any, Csize_t, Cint),
-                        sig, this_world, #= mt_cache =# 0)
+            mi = ccall(:jl_get_specialization1, Any, (Any, Csize_t), sig, this_world)
             asrt = Any
             valid = if mi !== nothing
                 mi = mi::MethodInstance

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -4649,38 +4649,48 @@ Base.@nospecializeinfer func_nospecializeinfer_constprop(@nospecialize a) = func
 itr_dispatchonly = Any[sin, muladd, "foo", nothing, missing]   # untyped container can cause excessive runtime dispatch
 itr_withinfernce = tuple(sin, muladd, "foo", nothing, missing) # typed container can cause excessive inference
 
+function count_inferred(m::Method)
+    count = 0
+    for mi in Base.specializations(m)
+        isdefined(mi, :cache) || continue
+        # inferred methods come first in the cache by construction, so no iteratation needed
+        count += isdefined(mi.cache, :inferred)
+    end
+    return count
+end
+
 @testset "compilation annotations" begin
     @testset "@nospecialize" begin
         # `@nospecialize` should suppress runtime dispatches of `nospecialize`
         @test call_func_itr(func_nospecialized, itr_dispatchonly) == 2
-        @test length(Base.specializations(only(methods((func_nospecialized))))) == 1
+        @test length(Base.specializations(only(methods(func_nospecialized)))) == 1
         # `@nospecialize` should allow inference to happen
         @test call_func_itr(func_nospecialized, itr_withinfernce) == 2
-        @test length(Base.specializations(only(methods((func_nospecialized))))) == 6
+        @test length(Base.specializations(only(methods(func_nospecialized)))) == 6
         @test count(is_inline_checker, @get_code call_func_itr(func_nospecialized, itr_dispatchonly)) == 0
 
         # `@nospecialize` should allow inlinining
         @test call_func_itr(func_nospecialized_inline, itr_dispatchonly) == 2
-        @test length(Base.specializations(only(methods((func_nospecialized_inline))))) == 1
+        @test length(Base.specializations(only(methods(func_nospecialized_inline)))) == 1
         @test call_func_itr(func_nospecialized_inline, itr_withinfernce) == 2
-        @test length(Base.specializations(only(methods((func_nospecialized_inline))))) == 6
+        @test length(Base.specializations(only(methods(func_nospecialized_inline)))) == 6
         @test count(is_inline_checker, @get_code call_func_itr(func_nospecialized_inline, itr_dispatchonly)) == 5
     end
 
     @testset "@nospecializeinfer" begin
         # `@nospecialize` should suppress runtime dispatches of `nospecialize`
         @test call_func_itr(func_nospecializeinfer, itr_dispatchonly) == 2
-        @test length(Base.specializations(only(methods((func_nospecializeinfer))))) == 1
+        @test length(Base.specializations(only(methods(func_nospecializeinfer)))) == 1
         # `@nospecializeinfer` suppresses inference also
         @test call_func_itr(func_nospecializeinfer, itr_withinfernce) == 2
-        @test length(Base.specializations(only(methods((func_nospecializeinfer))))) == 1
+        @test count_inferred(only(methods(func_nospecializeinfer))) == 1
         @test !any(is_inline_checker, @get_code call_func_itr(func_nospecializeinfer, itr_dispatchonly))
 
         # `@nospecializeinfer` should allow inlinining
         @test call_func_itr(func_nospecializeinfer_inline, itr_dispatchonly) == 2
         @test length(Base.specializations(only(methods((func_nospecializeinfer_inline))))) == 1
         @test call_func_itr(func_nospecializeinfer_inline, itr_withinfernce) == 2
-        @test length(Base.specializations(only(methods((func_nospecializeinfer_inline))))) == 1
+        @test count_inferred(only(methods(func_nospecializeinfer_inline))) == 1
         @test any(is_inline_checker, @get_code call_func_itr(func_nospecializeinfer_inline, itr_dispatchonly))
 
         # `@nospecializeinfer` should allow constprop
@@ -4693,7 +4703,7 @@ itr_withinfernce = tuple(sin, muladd, "foo", nothing, missing) # typed container
         end
         @test call_func_itr(func_nospecializeinfer_constprop, itr_withinfernce) == 0
         for m = methods(func_nospecializeinfer_constprop)
-            @test length(Base.specializations(m)) == 1
+            @test count_inferred(m) == 1
         end
     end
 end

--- a/Compiler/test/invalidation.jl
+++ b/Compiler/test/invalidation.jl
@@ -116,8 +116,7 @@ begin
         @test any(iscall((src, pr48932_callee)), src.code)
     end
 
-    let mi = only(Base.specializations(Base.only(Base.methods(pr48932_callee))))
-        # Base.method_instance(pr48932_callee, (Any,))
+    let mi = only(Base.method_instances(pr48932_callee, Tuple, Base.get_world_counter()))
         ci = mi.cache
         @test isdefined(ci, :next)
         @test ci.owner === nothing
@@ -281,7 +280,7 @@ begin take!(GLOBAL_BUFFER)
         @test any(isinvoke(:pr48932_callee_inlined), src.code)
     end
 
-    let mi = Base.method_instance(pr48932_callee_inlined, (Int,))
+    let mi = only(Base.method_instances(pr48932_callee_inlined, (Any,), Base.get_world_counter()))
         ci = mi.cache
         @test isdefined(ci, :next)
         @test ci.owner === nothing
@@ -291,7 +290,7 @@ begin take!(GLOBAL_BUFFER)
         @test ci.owner === InvalidationTesterToken()
         @test ci.max_world == typemax(UInt)
     end
-    let mi = Base.method_instance(pr48932_caller_inlined, (Int,))
+    let mi = only(Base.method_instances(pr48932_caller_inlined, (Int,), Base.get_world_counter()))
         ci = mi.cache
         @test !isdefined(ci, :next)
         @test ci.owner === InvalidationTesterToken()

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -275,7 +275,6 @@ include("errorshow.jl")
 include("util.jl")
 
 include("initdefs.jl")
-Filesystem.__postinit__()
 
 # worker threads
 include("threadcall.jl")
@@ -343,6 +342,7 @@ set_syntax_version(Base, VERSION)
 
 end_base_include = time_ns()
 
+Filesystem.__postinit__()
 const _sysimage_modules = PkgId[]
 in_sysimage(pkgid::PkgId) = pkgid in _sysimage_modules
 

--- a/base/Base_compiler.jl
+++ b/base/Base_compiler.jl
@@ -242,6 +242,8 @@ function Core.kwcall(kwargs::NamedTuple, ::typeof(applicable), @nospecialize(arg
     return applicable(Core.kwcall, kwargs, args...)
 end
 function Core._hasmethod(@nospecialize(f), @nospecialize(t)) # this function has a special tfunc (TODO: make this a Builtin instead like applicable)
+    Core.@nospecializeinfer
+    @noinline
     tt = rewrap_unionall(Tuple{Core.Typeof(f), (unwrap_unionall(t)::DataType).parameters...}, t)
     return Core._hasmethod(tt)
 end

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -330,8 +330,9 @@ macro _foldable_meta()
         #=:nortcall=#true))
 end
 
-macro inline()   Expr(:meta, :inline)   end
-macro noinline() Expr(:meta, :noinline) end
+macro inline()      Expr(:meta, :inline)      end
+macro noinline()    Expr(:meta, :noinline)    end
+macro nospecializeinfer() Expr(:meta, :nospecializeinfer) end
 
 macro _boundscheck() Expr(:boundscheck) end
 
@@ -1233,6 +1234,8 @@ function resolve_typegroup(mod::Module, typevars::SimpleVector, struct_infos::Si
 end
 
 function _hasmethod(@nospecialize(tt)) # this function has a special tfunc
+    @nospecializeinfer
+    @noinline
     world = ccall(:jl_get_tls_world_age, UInt, ()) # tls_world_age()
     return Intrinsics.not_int(ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), tt, nothing, world) === nothing)
 end

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -502,7 +502,7 @@ may still be executing concurrently during shutdown.
 """
 function atexit(f::Function)
     # HACK: if generating output, hint that we might want to compile `f`, so that it is available for the no-codegen test
-    generating_output() && precompile(f, hasmethod(f, (Cint,)) ? (Cint,) : ())
+    generating_output() && (precompile(f, (Cint,)) || precompile(f, ()))
     @lock _atexit_hooks_lock begin
         _atexit_hooks_finished && error("cannot register new atexit hook; already exiting.")
         pushfirst!(atexit_hooks, f)

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -132,7 +132,7 @@ const DEPOT_PATH = String[]
 function append_bundled_depot_path!(DEPOT_PATH)
     path = abspath(Sys.BINDIR, "..", "local", "share", "julia")
     path in DEPOT_PATH || push!(DEPOT_PATH, path)
-    path = abspath(Sys.BINDIR, Base.DATAROOTDIR, "julia")
+    path = abspath(Sys.BINDIR, DATAROOTDIR, "julia")
     path in DEPOT_PATH || push!(DEPOT_PATH, path)
     return DEPOT_PATH
 end
@@ -297,7 +297,7 @@ end
 
 function init_active_project()
     project = (JLOptions().project != C_NULL ?
-        unsafe_string(Base.JLOptions().project) :
+        unsafe_string(JLOptions().project) :
         get(ENV, "JULIA_PROJECT", nothing))
     set_active_project(
         project === nothing ? nothing :
@@ -416,7 +416,7 @@ function set_active_project(projfile::Union{AbstractString,Nothing})
     ACTIVE_PROJECT[] = projfile
     for f in active_project_callbacks
         try
-            Base.invokelatest(f)
+            invokelatest(f)
         catch
             @error "active project callback $f failed" maxlog=1
         end
@@ -501,7 +501,9 @@ This situation may occur if you are registering exit hooks from background Tasks
 may still be executing concurrently during shutdown.
 """
 function atexit(f::Function)
-    Base.@lock _atexit_hooks_lock begin
+    # HACK: if generating output, hint that we might want to compile `f`, so that it is available for the no-codegen test
+    generating_output() && precompile(f, hasmethod(f, (Cint,)) ? (Cint,) : ())
+    @lock _atexit_hooks_lock begin
         _atexit_hooks_finished && error("cannot register new atexit hook; already exiting.")
         pushfirst!(atexit_hooks, f)
         return nothing
@@ -573,7 +575,7 @@ library_threading_enabled::Bool = true
 
 # Base.OncePerProcess ensures that any registered hooks do not outlive the session.
 # (even if they are registered during the sysimage build process by top-level code)
-const disable_library_threading_hooks = Base.OncePerProcess(Vector{Any})
+const disable_library_threading_hooks = OncePerProcess(Vector{Any})
 
 function at_disable_library_threading(f)
     push!(disable_library_threading_hooks(), f)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3255,7 +3255,7 @@ function load_path_setup_code(load_path::Bool=true)
 end
 
 # Const global for GC root
-const newly_inferred = CodeInstance[]
+const newly_inferred = []
 
 # this is called in the external process that generates precompiled package files
 function include_package_for_output(pkg::PkgId, input::String, syntax_version::VersionNumber, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String},
@@ -4642,8 +4642,3 @@ function precompile(@nospecialize(argt::Type), m::Method)
     mi = Base.Compiler.specialize_method(m, atype, sparams)
     return precompile(mi)
 end
-
-precompile(include_package_for_output, (PkgId, String, VersionNumber, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), Nothing)) || @assert false
-precompile(include_package_for_output, (PkgId, String, VersionNumber, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), String)) || @assert false
-precompile(create_expr_cache, (PkgId, PkgLoadSpec, String, String, typeof(_concrete_dependencies), Cmd, CacheFlags, IO, IO)) || @assert false
-precompile(create_expr_cache, (PkgId, PkgLoadSpec, String, Nothing, typeof(_concrete_dependencies), Cmd, CacheFlags, IO, IO)) || @assert false

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -33,6 +33,7 @@ DOWN_ARROW = "\e[B"
 hardcoded_precompile_statements = """
 precompile(Base.unsafe_string, (Ptr{UInt8},))
 precompile(Base.unsafe_string, (Ptr{Int8},))
+precompile(Base._atexit, (Cint,))
 
 # used by REPL
 precompile(Tuple{typeof(Base.getproperty), Base.Terminals.TTYTerminal, Symbol})
@@ -56,6 +57,10 @@ precompile(Tuple{typeof(Base.Compiler.ir_to_codeinf!), Base.Compiler.Optimizatio
 precompile(Tuple{typeof(Base.getindex), Type{Pair{Base.PkgId, UInt128}}, Pair{Base.PkgId, UInt128}, Pair{Base.PkgId, UInt128}, Pair{Base.PkgId, UInt128}, Vararg{Pair{Base.PkgId, UInt128}}})
 precompile(Tuple{typeof(Base.Compiler.ir_to_codeinf!), Base.Compiler.OptimizationState{Base.Compiler.NativeInterpreter}, Core.SimpleVector})
 precompile(Tuple{typeof(Base.Compiler.ir_to_codeinf!), Base.Compiler.OptimizationState{Base.Compiler.NativeInterpreter}})
+precompile(include_package_for_output, (PkgId, String, VersionNumber, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), Nothing)) || @assert false
+precompile(include_package_for_output, (PkgId, String, VersionNumber, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), String)) || @assert false
+precompile(create_expr_cache, (PkgId, PkgLoadSpec, String, String, typeof(_concrete_dependencies), Cmd, CacheFlags, IO, IO)) || @assert false
+precompile(create_expr_cache, (PkgId, PkgLoadSpec, String, Nothing, typeof(_concrete_dependencies), Cmd, CacheFlags, IO, IO)) || @assert false
 
 # LazyArtifacts (but more generally helpful)
 precompile(Tuple{Type{Base.Val{x} where x}, Module})

--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -628,6 +628,10 @@ for important details on how to modify these fields safely.
 
     Cache of `CodeInstance` objects that share this template instantiation.
 
+  * `precompile`
+
+    If set, this `MethodInstance` will be compiled and added to the output system image.
+
 ### CodeInstance
 
   * `def`

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -485,7 +485,7 @@ static void generate_cfunc_thunks(jl_codegen_output_t &out)
             initvals[0] = f;
             cfunc.cfuncdata->setInitializer(ConstantArray::get(init->getType(), initvals));
         };
-        jl_method_instance_t *mi = (jl_method_instance_t*)jl_get_specialization1((jl_tupletype_t*)sigt, latestworld, 0);
+        jl_method_instance_t *mi = (jl_method_instance_t*)jl_get_specialization1((jl_tupletype_t*)sigt, latestworld);
         Function *func = nullptr;
         if ((jl_value_t*)mi != jl_nothing) {
             auto it = compiled_mi.find(mi);
@@ -2479,7 +2479,7 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t *dump, jl_method_instance_t *mi, jl_
             for (cfunc_decl_t &cfunc : output.cfuncs) {
                 jl_value_t *sigt = cfunc.abi.sigt;
                 JL_GC_PROMISE_ROOTED(sigt);
-                jl_value_t *mi = jl_get_specialization1((jl_tupletype_t*)sigt, latestworld, 0);
+                jl_value_t *mi = jl_get_specialization1((jl_tupletype_t*)sigt, latestworld);
                 if (mi == jl_nothing)
                     continue;
                 jl_code_instance_t *codeinst = jl_type_infer((jl_method_instance_t*)mi, latestworld, SOURCE_MODE_NOT_REQUIRED, jl_options.trim);

--- a/src/ast.c
+++ b/src/ast.c
@@ -1049,11 +1049,11 @@ lno_ok:
         JL_GC_PROMISE_ROOTED(ctx_module);
         margs[0] = jl_toplevel_eval(ctx_module, margs[0]);
         jl_method_instance_t *mfunc = NULL;
-        mfunc = jl_method_lookup(margs, nargs, ct->world_age);
+        mfunc = jl_apply_lookup(margs, nargs, ct->world_age);
         JL_GC_PROMISE_ROOTED(mfunc);
         if (mfunc == NULL && retry_lno != NULL) {
             margs[1] = retry_lno;
-            mfunc = jl_method_lookup(margs, nargs, ct->world_age);
+            mfunc = jl_apply_lookup(margs, nargs, ct->world_age);
             JL_GC_PROMISE_ROOTED(mfunc);
         }
         if (mfunc == NULL) {

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1721,7 +1721,7 @@ JL_CALLABLE(jl_f_applicable)
 {
     JL_NARGSV(applicable, 1);
     size_t world = jl_current_task->world_age;
-    return jl_method_lookup(args, nargs, world) != NULL ? jl_true : jl_false;
+    return jl_apply_lookup(args, nargs, world) != NULL ? jl_true : jl_false;
 }
 
 JL_CALLABLE(jl_f_invoke)

--- a/src/gf.c
+++ b/src/gf.c
@@ -1660,7 +1660,7 @@ static inline jl_typemap_entry_t *lookup_leafcache(jl_genericmemory_t *leafcache
     return NULL;
 }
 
-static jl_typemap_entry_t *mt_find_cache_entry(_Atomic(jl_typemap_t* JL_NONNULL) *JL_NONNULL cache JL_PROPAGATES_ROOT, _Atomic(jl_genericmemory_t*) *leafcache JL_PROPAGATES_ROOT, jl_datatype_t *tt, size_t world, int offs)
+static jl_typemap_entry_t *mt_find_cache_entry(_Atomic(jl_typemap_t*) JL_NONNULL *JL_NONNULL cache JL_PROPAGATES_ROOT, _Atomic(jl_genericmemory_t*) *leafcache JL_PROPAGATES_ROOT, jl_datatype_t *tt, size_t world, int offs)
 {
     if (leafcache) {
         jl_typemap_entry_t *entry = lookup_leafcache(jl_atomic_load_relaxed(leafcache), (jl_value_t*)tt, world);
@@ -1668,6 +1668,7 @@ static jl_typemap_entry_t *mt_find_cache_entry(_Atomic(jl_typemap_t* JL_NONNULL)
             return entry;
     }
     struct jl_typemap_assoc search = {(jl_value_t*)tt, world, NULL};
+    assert(cache);
     jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(jl_atomic_load_relaxed(cache), &search, offs, /*subtype*/1);
     return entry;
 }
@@ -1842,7 +1843,7 @@ static jl_method_instance_t *cache_result(
 }
 
 static void recache_method(
-        jl_methtable_t *mt, jl_methcache_t *mc, _Atomic(jl_typemap_t*) *cache, jl_value_t *parent JL_PROPAGATES_ROOT,
+        jl_methtable_t *mt, jl_methcache_t *mc, _Atomic(jl_typemap_t*) JL_NONNULL *JL_NONNULL cache, jl_value_t *parent JL_PROPAGATES_ROOT,
         jl_tupletype_t *tt, // the original tupletype of the signature
         jl_method_t *definition,
         size_t world, size_t min_valid, size_t max_valid, size_t current_world,
@@ -1869,6 +1870,7 @@ static void recache_method(
     }
     { // scope block
         struct jl_typemap_assoc search = {tt ? (jl_value_t*)tt : compilationsig, world, NULL};
+        assert(cache);
         jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(jl_atomic_load_relaxed(cache), &search, offs, /*subtype*/1);
         if (entry && jl_subtype((jl_value_t*)entry->sig, (jl_value_t*)newmeth->specTypes)) {
             entry->func.linfo = newmeth;

--- a/src/gf.c
+++ b/src/gf.c
@@ -1660,7 +1660,7 @@ static inline jl_typemap_entry_t *lookup_leafcache(jl_genericmemory_t *leafcache
     return NULL;
 }
 
-static jl_typemap_entry_t *mt_find_cache_entry(_Atomic(jl_typemap_t*) JL_NONNULL *JL_NONNULL cache JL_PROPAGATES_ROOT, _Atomic(jl_genericmemory_t*) *leafcache JL_PROPAGATES_ROOT, jl_datatype_t *tt, size_t world, int offs)
+static jl_typemap_entry_t *mt_find_cache_entry(_Atomic(jl_typemap_t*) *cache JL_PROPAGATES_ROOT, _Atomic(jl_genericmemory_t*) *leafcache JL_PROPAGATES_ROOT, jl_datatype_t *tt, size_t world, int offs)
 {
     if (leafcache) {
         jl_typemap_entry_t *entry = lookup_leafcache(jl_atomic_load_relaxed(leafcache), (jl_value_t*)tt, world);
@@ -1673,7 +1673,7 @@ static jl_typemap_entry_t *mt_find_cache_entry(_Atomic(jl_typemap_t*) JL_NONNULL
     return entry;
 }
 
-JL_DLLEXPORT jl_typemap_entry_t *jl_mt_find_cache_entry(jl_methcache_t *JL_NONNULL cache, jl_datatype_t *tt, size_t world)
+JL_DLLEXPORT jl_typemap_entry_t *jl_mt_find_cache_entry(jl_methcache_t *cache, jl_datatype_t *tt, size_t world)
 { // exported only for debugging purposes, not for casual use
     return mt_find_cache_entry(&cache->cache, &cache->leafcache, tt, world, jl_cachearg_offset());
 }
@@ -1843,7 +1843,7 @@ static jl_method_instance_t *cache_result(
 }
 
 static void recache_method(
-        jl_methtable_t *mt, jl_methcache_t *mc, _Atomic(jl_typemap_t*) JL_NONNULL *JL_NONNULL cache, jl_value_t *parent JL_PROPAGATES_ROOT,
+        jl_methtable_t *mt, jl_methcache_t *mc, _Atomic(jl_typemap_t*) *cache, jl_value_t *parent JL_PROPAGATES_ROOT,
         jl_tupletype_t *tt, // the original tupletype of the signature
         jl_method_t *definition,
         size_t world, size_t min_valid, size_t max_valid, size_t current_world,
@@ -3410,9 +3410,9 @@ jl_method_instance_t *jl_builtin_method_lookup(jl_value_t *builtin)
     jl_tupletype_t *tt = (jl_datatype_t*)jl_apply_tuple_type_v(params, 2);
     JL_GC_PUSH1(&tt);
     jl_method_t *m = (jl_method_t*)jl_gf_invoke_lookup((jl_value_t*)tt, (jl_value_t*)jl_method_table, 1);
-    assert(jl_is_method(m) && m->unspecialized);
+    assert(jl_is_method(m) && jl_atomic_load_relaxed(&m->unspecialized));
     JL_GC_POP();
-    return m->unspecialized;
+    return jl_atomic_load_relaxed(&m->unspecialized);
 }
 
 // return a Vector{Any} of svecs, each describing a method match:

--- a/src/gf.c
+++ b/src/gf.c
@@ -157,10 +157,28 @@ static int speccache_eq(size_t idx, const void *ty, jl_value_t *data, uint_t hv)
     return jl_types_equal(sig, (jl_value_t*)ty);
 }
 
+static int jl_is_builtinfunc(jl_method_t *m)
+{
+    return m->source == NULL && m->generator == NULL &&
+        jl_atomic_load_relaxed(&m->unspecialized) != NULL &&
+        m != jl_opaque_closure_method && !m->is_for_opaque_closure;
+    // jl_value_t *tt = m->sig;
+    // if (!jl_is_datatype(tt) || jl_nparams(tt) != 2)
+    //     return 0;
+    // jl_datatype_t *t = jl_unwrap_unionall(jl_tparam(tt, 0));
+    // if (!jl_is_datatype(t))
+    //     return 0;
+    // for (; t->super != t; t = t->super)
+    //     if (t == jl_builtin_type)
+    //         return 1;
+    // return 0;
+}
+
+
 // get or create the MethodInstance for a specialization
 static jl_method_instance_t *jl_specializations_get_linfo_(jl_method_t *m JL_PROPAGATES_ROOT, jl_value_t *type, jl_svec_t *sparams, jl_method_instance_t *mi_insert)
 {
-    if (m->source == NULL && m->generator == NULL && jl_atomic_load_relaxed(&m->unspecialized) != NULL && m != jl_opaque_closure_method && !m->is_for_opaque_closure)
+    if (jl_is_builtinfunc(m))
         return jl_atomic_load_relaxed(&m->unspecialized); // handle builtin methods
     jl_value_t *ut = jl_is_unionall(type) ? jl_unwrap_unionall(type) : type;
     JL_TYPECHK(specializations, datatype, ut);
@@ -373,20 +391,6 @@ static int emit_codeinst_and_edges(jl_code_instance_t *codeinst)
                 code = (jl_value_t*)jl_uncompress_ir(def, codeinst, (jl_value_t*)code);
             if (jl_is_code_info(code)) {
                 jl_emit_codeinsts_to_jit(&codeinst, (jl_code_info_t **)&code, 1);
-                if (0) {
-                    // next emit all the invoke edges too (if this seems profitable)
-                    jl_array_t *src = ((jl_code_info_t*)code)->code;
-                    for (size_t i = 0; i < jl_array_dim0(src); i++) {
-                        jl_value_t *stmt = jl_array_ptr_ref(src, i);
-                        if (jl_is_expr(stmt) && ((jl_expr_t*)stmt)->head == jl_assign_sym)
-                            stmt = jl_exprarg(stmt, 1);
-                        if (jl_is_expr(stmt) && ((jl_expr_t*)stmt)->head == jl_invoke_sym) {
-                            jl_value_t *invoke = jl_exprarg(stmt, 0);
-                            if (jl_is_code_instance(invoke))
-                                emit_codeinst_and_edges((jl_code_instance_t*)invoke);
-                        }
-                    }
-                }
                 JL_GC_POP();
                 return 1;
             }
@@ -1169,8 +1173,9 @@ static void jl_compilation_sig(
         return;
     }
 
-    if (decl == (jl_value_t*)jl_anytuple_type && jl_atomic_load_relaxed(&definition->unspecialized)) {
-        *newparams = jl_anytuple_type->parameters; // handle builtin methods
+    if (jl_is_builtinfunc(definition)) {
+        assert(jl_is_datatype(decl));
+        *newparams = ((jl_datatype_t*)decl)->parameters; // handle builtin methods
         return;
     }
 
@@ -1405,7 +1410,7 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
     if (!jl_is_datatype(type) || jl_has_free_typevars((jl_value_t*)type)) {
         return 0;
     }
-    if (definition->sig == (jl_value_t*)jl_anytuple_type && jl_atomic_load_relaxed(&definition->unspecialized))
+    if (jl_is_builtinfunc(definition))
         return jl_egal((jl_value_t*)type, definition->sig); // handle builtin methods
 
     size_t i, np = jl_nparams(type);
@@ -1624,7 +1629,58 @@ static inline jl_typemap_entry_t *lookup_leafcache(jl_genericmemory_t *leafcache
     }
     return NULL;
 }
-jl_method_instance_t *cache_method(
+
+static jl_typemap_entry_t *mt_find_cache_entry(_Atomic(jl_typemap_t*) *cache JL_PROPAGATES_ROOT, _Atomic(jl_genericmemory_t*) *leafcache JL_PROPAGATES_ROOT, jl_datatype_t *tt, size_t world, int offs)
+{
+    if (leafcache) {
+        jl_typemap_entry_t *entry = lookup_leafcache(jl_atomic_load_relaxed(leafcache), (jl_value_t*)tt, world);
+        if (entry)
+            return entry;
+    }
+    struct jl_typemap_assoc search = {(jl_value_t*)tt, world, NULL};
+    jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(jl_atomic_load_relaxed(cache), &search, offs, /*subtype*/1);
+    return entry;
+}
+
+JL_DLLEXPORT jl_typemap_entry_t *jl_mt_find_cache_entry(jl_methcache_t *cache, jl_datatype_t *tt, size_t world)
+{ // exported only for debugging purposes, not for casual use
+    return mt_find_cache_entry(&cache->cache, &cache->leafcache, tt, world, jl_cachearg_offset());
+}
+
+jl_datatype_t *compute_simplett(jl_tupletype_t *cachett)
+{
+    // now scan `cachett` and ensure that `Type{T}` in the cache will be matched exactly by `typeof(T)`
+    // and also reduce the complexity of rejecting this entry in the cache
+    // by replacing non-simple types with jl_any_type to build a new `type`
+    // (for example, if the signature contains jl_function_type)
+    // TODO: this is also related to how we should handle partial matches
+    //       (which currently might miss detection of a MethodError)
+    jl_tupletype_t *simplett = NULL;
+    size_t i, np = jl_nparams(cachett);
+    jl_svec_t *newparams = NULL;
+    JL_GC_PUSH1(&newparams);
+    for (i = 0; i < np; i++) {
+        jl_value_t *elt = jl_svecref(cachett->parameters, i);
+        if (jl_is_vararg(elt)) {
+        }
+        else if (jl_is_typeeq(elt)) {
+            // TODO: if (!jl_is_singleton(elt)) ...
+            jl_value_t *kind = jl_typeof(jl_typeeq_T(elt));
+            if (!newparams) newparams = jl_svec_copy(cachett->parameters);
+            jl_svecset(newparams, i, kind);
+        }
+        else if (!jl_is_concrete_type(elt)) { // for example, jl_function_type or jl_tuple_type
+            if (!newparams) newparams = jl_svec_copy(cachett->parameters);
+            jl_svecset(newparams, i, jl_any_type);
+        }
+    }
+    if (newparams)
+        simplett = (jl_datatype_t*)jl_apply_tuple_type(newparams, 1);
+    JL_GC_POP();
+    return simplett;
+}
+
+static jl_method_instance_t *cache_method(
         jl_methtable_t *mt, jl_methcache_t *mc, _Atomic(jl_typemap_t*) *cache, jl_value_t *parent JL_PROPAGATES_ROOT,
         jl_tupletype_t *tt, // the original tupletype of the signature
         jl_method_t *definition,
@@ -1636,42 +1692,29 @@ jl_method_instance_t *cache_method(
         int tt_known_absent)
 {
     // caller must hold the parent->writelock, which this releases
-    // short-circuit (now that we hold the lock) if this entry is already present
     int8_t offs = mc ? jl_cachearg_offset() : 1;
-    if (!tt_known_absent) { // scope block
-        if (mc) {
-            jl_genericmemory_t *leafcache = jl_atomic_load_relaxed(&mc->leafcache);
-            jl_typemap_entry_t *entry = lookup_leafcache(leafcache, (jl_value_t*)tt, world);
-            if (entry) {
-                if (mc) JL_UNLOCK(&mc->writelock);
-                return entry->func.linfo;
-            }
-        }
-        struct jl_typemap_assoc search = {(jl_value_t*)tt, world, NULL};
-        jl_typemap_t *cacheentry = jl_atomic_load_relaxed(cache);
-        assert(cacheentry != NULL);
-        jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(cacheentry, &search, offs, /*subtype*/1);
-        if (entry && entry->func.value) {
+    // short-circuit (now that we hold the lock) if this entry is already present
+    if (!tt_known_absent) {
+        jl_typemap_entry_t *entry = mt_find_cache_entry(cache, mc ? &mc->leafcache : NULL, tt, world, offs);
+        if (entry) {
             if (mc) JL_UNLOCK(&mc->writelock);
             return entry->func.linfo;
         }
     }
 
     jl_method_instance_t *newmeth = NULL;
-    if (definition->source == NULL && definition->generator == NULL && !definition->is_for_opaque_closure) {
+    if (jl_is_builtinfunc(definition)) {
         newmeth = jl_atomic_load_relaxed(&definition->unspecialized);
-        if (newmeth != NULL) { // handle builtin methods de-specialization (for invoke, or if the global cache entry somehow gets lost)
-            jl_tupletype_t *cachett = (jl_tupletype_t*)newmeth->specTypes;
-            assert(cachett != jl_anytuple_type);
-            jl_typemap_entry_t *newentry = jl_typemap_alloc(cachett, NULL, jl_emptysvec, (jl_value_t*)newmeth, min_valid, max_valid);
-            JL_GC_PUSH1(&newentry);
-            jl_typemap_insert(cache, parent, newentry, offs);
-            if (mc)
-                jl_method_cache_inserted();
-            JL_GC_POP();
-            if (mc) JL_UNLOCK(&mc->writelock);
-            return newmeth;
-        }
+        assert(newmeth != NULL); // handle builtin methods de-specialization (for invoke, or if the global cache entry somehow gets lost)
+        jl_tupletype_t *cachett = (jl_tupletype_t*)definition->sig;
+        jl_typemap_entry_t *newentry = jl_typemap_alloc(cachett, NULL, jl_emptysvec, (jl_value_t*)newmeth, min_valid, max_valid);
+        JL_GC_PUSH1(&newentry);
+        jl_typemap_insert(cache, parent, newentry, offs);
+        if (mc)
+            jl_method_cache_inserted();
+        JL_GC_POP();
+        if (mc) JL_UNLOCK(&mc->writelock);
+        return newmeth;
     }
 
     jl_value_t *temp = NULL;
@@ -1792,34 +1835,7 @@ jl_method_instance_t *cache_method(
     if (max_valid > current_world)
         max_valid = current_world;
 
-    // now scan `cachett` and ensure that `Type{T}` in the cache will be matched exactly by `typeof(T)`
-    // and also reduce the complexity of rejecting this entry in the cache
-    // by replacing non-simple types with jl_any_type to build a new `type`
-    // (for example, if the signature contains jl_function_type)
-    // TODO: this is also related to how we should handle partial matches
-    //       (which currently might miss detection of a MethodError)
-    jl_tupletype_t *simplett = NULL;
-    size_t i, np = jl_nparams(cachett);
-    newparams = NULL;
-    for (i = 0; i < np; i++) {
-        jl_value_t *elt = jl_svecref(cachett->parameters, i);
-        if (jl_is_vararg(elt)) {
-        }
-        else if (jl_is_typeeq(elt)) {
-            // TODO: if (!jl_is_singleton(elt)) ...
-            jl_value_t *kind = jl_typeof(jl_typeeq_T(elt));
-            if (!newparams) newparams = jl_svec_copy(cachett->parameters);
-            jl_svecset(newparams, i, kind);
-        }
-        else if (!jl_is_concrete_type(elt)) { // for example, jl_function_type or jl_tuple_type
-            if (!newparams) newparams = jl_svec_copy(cachett->parameters);
-            jl_svecset(newparams, i, jl_any_type);
-        }
-    }
-    if (newparams) {
-        simplett = (jl_datatype_t*)jl_apply_tuple_type(newparams, 1);
-        temp2 = (jl_value_t*)simplett;
-    }
+    jl_datatype_t *simplett = compute_simplett(cachett);
 
     // short-circuit if an existing entry is already present
     // that satisfies our requirements
@@ -1958,40 +1974,28 @@ JL_DLLEXPORT void jl_promote_mi_to_current(jl_method_instance_t *mi, size_t min_
     JL_UNLOCK(&world_counter_lock);
 }
 
-static jl_method_match_t *_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT, jl_methtable_t *mt, size_t world, int cache, size_t *min_valid, size_t *max_valid);
+static jl_method_match_t *_gf_invoke_lookup(jl_value_t *tt JL_PROPAGATES_ROOT, jl_methtable_t *mt, size_t world, int cache, size_t *min_valid, size_t *max_valid);
 
-JL_DLLEXPORT jl_typemap_entry_t *jl_mt_find_cache_entry(jl_methcache_t *mc JL_PROPAGATES_ROOT, jl_datatype_t *tt JL_MAYBE_UNROOTED JL_ROOTS_TEMPORARILY, size_t world)
-{ // exported only for debugging purposes, not for casual use
-    if (tt->isdispatchtuple) {
-        jl_genericmemory_t *leafcache = jl_atomic_load_relaxed(&mc->leafcache);
-        jl_typemap_entry_t *entry = lookup_leafcache(leafcache, (jl_value_t*)tt, world);
-        if (entry)
-            return entry;
-    }
-    JL_GC_PUSH1(&tt);
-    struct jl_typemap_assoc search = {(jl_value_t*)tt, world, NULL};
-    jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(jl_atomic_load_relaxed(&mc->cache), &search, jl_cachearg_offset(), /*subtype*/1);
-    JL_GC_POP();
-    return entry;
-}
-
-static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_methcache_t *mc JL_PROPAGATES_ROOT, jl_datatype_t *tt JL_MAYBE_UNROOTED, size_t world)
+static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_methcache_t *mc JL_PROPAGATES_ROOT, jl_datatype_t *tt, size_t world)
 {
     size_t cache_insert_generation = jl_method_cache_insert_generation_load();
-    jl_typemap_entry_t *entry = jl_mt_find_cache_entry(mc, tt, world);
+    jl_typemap_entry_t *entry = mt_find_cache_entry(&mc->cache,
+         tt->isdispatchtuple ? &mc->leafcache : NULL,
+         tt, world, jl_cachearg_offset());
     if (entry)
         return entry->func.linfo;
     assert(tt->isdispatchtuple || tt->hasfreetypevars);
     JL_TIMING(METHOD_LOOKUP_SLOW, METHOD_LOOKUP_SLOW);
     jl_method_match_t *matc = NULL;
-    JL_GC_PUSH2(&tt, &matc);
     JL_LOCK(&mc->writelock);
     jl_method_instance_t *mi = NULL;
     // No need to re-check if no method cache insertion happened since the
     // lock-free probe above.
     int tt_known_absent = jl_method_cache_insert_generation_load() == cache_insert_generation;
     if (!tt_known_absent) {
-        entry = jl_mt_find_cache_entry(mc, tt, world);
+        entry = mt_find_cache_entry(&mc->cache,
+         tt->isdispatchtuple ? &mc->leafcache : NULL,
+         tt, world, jl_cachearg_offset());
         if (entry)
             mi = entry->func.linfo;
     }
@@ -2000,6 +2004,7 @@ static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_methcach
         size_t max_valid = ~(size_t)0;
         matc = _gf_invoke_lookup((jl_value_t*)tt, mt, world, 0, &min_valid, &max_valid);
         if (matc) {
+            JL_GC_PUSH1(&matc);
             jl_method_t *m = matc->method;
             jl_svec_t *env = matc->sparams;
             // tt was just proven absent above and no method cache insertion has
@@ -2010,7 +2015,6 @@ static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_methcach
         }
     }
     JL_UNLOCK(&mc->writelock);
-    JL_GC_POP();
     return mi;
 }
 
@@ -3241,9 +3245,11 @@ static jl_tupletype_t *lookup_arg_type_tuple(jl_value_t *arg1 JL_PROPAGATES_ROOT
     return jl_lookup_arg_tuple_type(arg1, args, nargs, 1);
 }
 
+// hook provided for caching-enhanced fast method instance lookup
+// for when the expensive caching cost is justified for some reason
 JL_DLLEXPORT jl_value_t *jl_method_lookup_by_tt(jl_tupletype_t *tt, size_t world, jl_value_t *_mt)
 {
-    jl_methtable_t *mt = NULL;
+    jl_methtable_t *mt;
     if (_mt == jl_nothing) {
         mt = jl_method_table;
     }
@@ -3255,19 +3261,23 @@ JL_DLLEXPORT jl_value_t *jl_method_lookup_by_tt(jl_tupletype_t *tt, size_t world
     jl_method_instance_t *mi = jl_mt_assoc_by_type(mt, mc, tt, world);
     if (!mi)
         return jl_nothing;
-    return (jl_value_t*) mi;
+    return (jl_value_t*)mi;
 }
 
-JL_DLLEXPORT jl_method_instance_t *jl_method_lookup(jl_value_t **args, size_t nargs, size_t world)
+// hook provided for legacy staticdata lookups
+jl_method_instance_t *jl_builtin_method_lookup(jl_value_t *builtin)
 {
-    assert(nargs > 0 && "expected caller to handle this case");
-    jl_methcache_t *mc = jl_method_table->cache;
-    jl_typemap_t *cache = jl_atomic_load_relaxed(&mc->cache); // XXX: gc root for this?
-    jl_typemap_entry_t *entry = jl_typemap_assoc_exact(cache, args[0], &args[1], nargs, jl_cachearg_offset(), world);
-    if (entry)
-        return entry->func.linfo;
-    jl_tupletype_t *tt = arg_type_tuple(args[0], &args[1], nargs);
-    return jl_mt_assoc_by_type(jl_method_table, mc, tt, world);
+    jl_datatype_t *dt = (jl_datatype_t*)jl_typeof(builtin);
+    jl_methtable_t *mt = jl_method_table;
+    jl_value_t *params[2];
+    params[0] = dt->name->wrapper;
+    params[1] = jl_tparam0(jl_anytuple_type);
+    jl_tupletype_t *tt = (jl_datatype_t*)jl_apply_tuple_type_v(params, 2);
+    JL_GC_PUSH1(&tt);
+    jl_method_instance_t *mi = jl_mt_assoc_by_type(mt, mt->cache, tt, 1);
+    assert(mi);
+    JL_GC_POP();
+    return mi;
 }
 
 // return a Vector{Any} of svecs, each describing a method match:
@@ -3542,7 +3552,7 @@ void jl_read_codeinst_invoke(jl_code_instance_t *ci, uint8_t *specsigflags, jl_c
     }
 }
 
-jl_method_instance_t *jl_normalize_to_compilable_mi(jl_method_instance_t *mi JL_PROPAGATES_ROOT);
+JL_DLLEXPORT jl_method_instance_t *jl_normalize_to_compilable_mi(jl_method_instance_t *mi JL_PROPAGATES_ROOT);
 
 JL_DLLEXPORT void jl_add_codeinsts_to_jit(jl_array_t *codeinsts, jl_array_t *srcs)
 {
@@ -3557,6 +3567,46 @@ JL_DLLEXPORT int jl_method_is_macro(jl_method_t *m)
     return jl_symbol_name(m->name)[0] == '@';
 }
 
+jl_code_instance_t *copy_to_mi_cache(jl_method_instance_t *mi, jl_code_instance_t *codeinst2)
+{
+    jl_code_instance_t *codeinst = jl_get_method_inferred(
+            mi, codeinst2->rettype,
+            jl_atomic_load_relaxed(&codeinst2->min_world),
+            jl_atomic_load_relaxed(&codeinst2->max_world), // TODO: use min(max_world, current_world) here
+            jl_atomic_load_relaxed(&codeinst2->debuginfo),
+            jl_atomic_load_relaxed(&codeinst2->edges));
+    if (jl_atomic_load_relaxed(&codeinst->invoke) == NULL) {
+        // TODO: add edges and jl_promote_ci_to_current here
+        codeinst->rettype_const = codeinst2->rettype_const;
+        jl_gc_wb(codeinst, codeinst->rettype_const);
+        uint8_t specsigflags;
+        jl_callptr_t invoke;
+        void *fptr;
+        jl_read_codeinst_invoke(codeinst2, &specsigflags, &invoke, &fptr, 1);
+        if (fptr != NULL) {
+            void *prev_fptr = NULL;
+            // see jitlayers.cpp for the ordering restrictions here
+            if (jl_atomic_cmpswap_acqrel(&codeinst->specptr.fptr, &prev_fptr, fptr)) {
+                jl_atomic_store_release(&codeinst->invoke, invoke);
+                // unspec is probably not specsig, but might be using specptr
+                jl_atomic_fetch_or_relaxed(&codeinst->flags, JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR);
+            }
+            else {
+                // someone else already compiled it
+                while (!(jl_atomic_load_acquire(&codeinst->flags) & JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR)) {
+                    jl_cpu_pause();
+                }
+                // codeinst is now set up fully, safe to return
+            }
+        }
+        else {
+            jl_callptr_t prev = NULL;
+            jl_atomic_cmpswap_acqrel(&codeinst->invoke, &prev, invoke);
+        }
+    }
+    return codeinst;
+}
+
 jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t world)
 {
     // quick check if we already have a compiled result
@@ -3568,42 +3618,9 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
     // instead and just copy it here for caching
     jl_method_instance_t *mi2 = jl_normalize_to_compilable_mi(mi);
     if (mi2 != mi) {
-        jl_code_instance_t *codeinst2 = jl_compile_method_internal(mi2, world);
-        jl_code_instance_t *codeinst = jl_get_method_inferred(
-                mi, codeinst2->rettype,
-                jl_atomic_load_relaxed(&codeinst2->min_world),
-                jl_atomic_load_relaxed(&codeinst2->max_world),
-                jl_atomic_load_relaxed(&codeinst2->debuginfo),
-                jl_atomic_load_relaxed(&codeinst2->edges));
-        if (jl_atomic_load_relaxed(&codeinst->invoke) == NULL) {
-            codeinst->rettype_const = codeinst2->rettype_const;
-            jl_gc_wb(codeinst, codeinst->rettype_const);
-            uint8_t specsigflags;
-            jl_callptr_t invoke;
-            void *fptr;
-            jl_read_codeinst_invoke(codeinst2, &specsigflags, &invoke, &fptr, 1);
-            if (fptr != NULL) {
-                void *prev_fptr = NULL;
-                // see jitlayers.cpp for the ordering restrictions here
-                if (jl_atomic_cmpswap_acqrel(&codeinst->specptr.fptr, &prev_fptr, fptr)) {
-                    jl_atomic_store_release(&codeinst->invoke, invoke);
-                    // unspec is probably not specsig, but might be using specptr
-                    jl_atomic_fetch_or_relaxed(&codeinst->flags, JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR);
-                }
-                else {
-                    // someone else already compiled it
-                    while (!(jl_atomic_load_acquire(&codeinst->flags) & JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR)) {
-                        jl_cpu_pause();
-                    }
-                    // codeinst is now set up fully, safe to return
-                }
-            }
-            else {
-                jl_callptr_t prev = NULL;
-                jl_atomic_cmpswap_acqrel(&codeinst->invoke, &prev, invoke);
-            }
-        }
+        codeinst = jl_compile_method_internal(mi2, world);
         // don't call record_precompile_statement here, since we already compiled it as mi2 which is better
+        codeinst = copy_to_mi_cache(mi, codeinst);
         return codeinst;
     }
 
@@ -3690,15 +3707,12 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
 
     // jl_type_infer will internally do a cache lookup and jl_engine_reserve call
     // to synchronize this across threads
-    if (!codeinst) {
-        // Don't bother inferring toplevel thunks or macros - the performance cost of inference is likely
-        // to significantly exceed the actual runtime.
-        int should_skip_inference = !jl_is_method(mi->def.method) || jl_method_is_macro(mi->def.method);
-
-        if (!should_skip_inference) {
-            codeinst = jl_type_infer(mi, world, SOURCE_MODE_ABI, jl_options.trim);
-        }
-    }
+    assert(!codeinst);
+    // Don't bother inferring toplevel thunks or macros - the performance cost of inference is likely
+    // to significantly exceed the actual runtime.
+    int should_skip_inference = !jl_is_method(mi->def.method) || jl_method_is_macro(mi->def.method);
+    if (!should_skip_inference)
+        codeinst = jl_type_infer(mi, world, SOURCE_MODE_ABI, jl_options.trim);
 
     if (codeinst) {
         if (jl_is_compiled_codeinst(codeinst)) {
@@ -3880,7 +3894,7 @@ jl_method_instance_t *jl_normalize_to_compilable_mi(jl_method_instance_t *mi JL_
 }
 
 // return a MethodInstance for a compileable method_match, if valid
-static jl_value_t *jl_method_match_to_mi(jl_method_match_t *match, size_t world, size_t min_valid, size_t max_valid, int mt_cache)
+static jl_value_t *jl_method_match_to_mi(jl_method_match_t *match, size_t world, size_t min_valid, size_t max_valid)
 {
     jl_method_t *m = match->method;
     JL_GC_PROMISE_ROOTED(m);
@@ -3888,30 +3902,15 @@ static jl_value_t *jl_method_match_to_mi(jl_method_match_t *match, size_t world,
     jl_tupletype_t *ti = match->spec_types;
     jl_value_t *mi = jl_nothing;
     if (jl_is_datatype(ti)) {
-        // get the specialization, possibly also caching it
-        if (mt_cache && ((jl_datatype_t*)ti)->isdispatchtuple) {
-            // Since we also use this presence in the cache
-            // to trigger compilation when producing `.ji` files,
-            // inject it there now if we think it will be
-            // used via dispatch later (e.g. because it was hinted via a call to `precompile`)
-            jl_methcache_t *mc = jl_method_table->cache;
-            assert(mc);
-            JL_LOCK(&mc->writelock);
-            // this path does not pre-probe `ti`, so cache_method must keep its
-            // own presence check (ti may already be cached from a prior hint)
-            mi = (jl_value_t*)cache_method(jl_method_get_table(m), mc, &mc->cache, (jl_value_t*)mc, ti, m, world, min_valid, max_valid, env, /*tt_known_absent*/0);
-        }
-        else {
-            jl_value_t *tt = jl_normalize_to_compilable_sig(ti, env, m, 1);
-            if (tt != jl_nothing) {
-                JL_GC_PUSH2(&tt, &env);
-                if (!jl_egal(tt, (jl_value_t*)ti)) {
-                    jl_value_t *ti = jl_type_intersection_env((jl_value_t*)tt, (jl_value_t*)m->sig, &env);
-                    assert(ti != jl_bottom_type); (void)ti;
-                }
-                mi = (jl_value_t*)jl_specializations_get_linfo(m, (jl_value_t*)tt, env);
-                JL_GC_POP();
+        jl_value_t *tt = jl_normalize_to_compilable_sig(ti, env, m, 1);
+        if (tt != jl_nothing) {
+            JL_GC_PUSH2(&tt, &env);
+            if (!jl_egal(tt, (jl_value_t*)ti)) {
+                jl_value_t *ti = jl_type_intersection_env((jl_value_t*)tt, (jl_value_t*)m->sig, &env);
+                assert(ti != jl_bottom_type); (void)ti;
             }
+            mi = (jl_value_t*)jl_specializations_get_linfo(m, (jl_value_t*)tt, env);
+            JL_GC_POP();
         }
     }
     return mi;
@@ -3919,7 +3918,7 @@ static jl_value_t *jl_method_match_to_mi(jl_method_match_t *match, size_t world,
 
 // compile-time method lookup
 // intersect types with the MT, and return a single compileable specialization that covers the intersection.
-jl_value_t *jl_get_specialization1(jl_tupletype_t *types, size_t world, int mt_cache)
+jl_value_t *jl_get_specialization1(jl_tupletype_t *types, size_t world)
 {
     if (jl_has_free_typevars((jl_value_t*)types))
         return jl_nothing; // don't poison the cache due to a malformed query
@@ -3935,14 +3934,14 @@ jl_value_t *jl_get_specialization1(jl_tupletype_t *types, size_t world, int mt_c
         return jl_nothing;
     JL_GC_PUSH1(&matches);
     jl_method_match_t *match = (jl_method_match_t*)jl_array_ptr_ref(matches, 0);
-    jl_value_t *mi = jl_method_match_to_mi(match, world, min_valid2, max_valid2, mt_cache);
+    jl_value_t *mi = jl_method_match_to_mi(match, world, min_valid2, max_valid2);
     JL_GC_POP();
     return mi;
 }
 
 // Try to get a MethodInstance for a precompile() call. This uses a special kind of lookup that
 // tries to find a method for which the requested signature is compileable.
-JL_DLLEXPORT jl_value_t *jl_get_compile_hint_specialization(jl_tupletype_t *types JL_PROPAGATES_ROOT, size_t world, int mt_cache)
+JL_DLLEXPORT jl_value_t *jl_get_compile_hint_specialization(jl_tupletype_t *types JL_PROPAGATES_ROOT, size_t world)
 {
     if (jl_has_free_typevars((jl_value_t*)types))
         return jl_nothing; // don't poison the cache due to a malformed query
@@ -3998,7 +3997,7 @@ JL_DLLEXPORT jl_value_t *jl_get_compile_hint_specialization(jl_tupletype_t *type
     }
     jl_value_t *mi = jl_nothing;
     if (match != NULL)
-        mi = jl_method_match_to_mi(match, world, min_valid2, max_valid2, mt_cache);
+        mi = jl_method_match_to_mi(match, world, min_valid2, max_valid2);
     JL_GC_POP();
     return mi;
 }
@@ -4073,14 +4072,14 @@ JL_DLLEXPORT void jl_compile_method_sig(jl_method_t *m, jl_value_t *types, jl_sv
 JL_DLLEXPORT int jl_is_compilable(jl_tupletype_t *types)
 {
     size_t world = jl_atomic_load_acquire(&jl_world_counter);
-    jl_value_t *mi = jl_get_compile_hint_specialization(types, world, 1);
+    jl_value_t *mi = jl_get_compile_hint_specialization(types, world);
     return mi == jl_nothing ? 0 : 1;
 }
 
 JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types)
 {
     size_t world = jl_atomic_load_acquire(&jl_world_counter);
-    jl_value_t *mi = jl_get_compile_hint_specialization(types, world, 1);
+    jl_value_t *mi = jl_get_compile_hint_specialization(types, world);
     if (mi == jl_nothing)
         return 0;
     JL_GC_PROMISE_ROOTED(mi);
@@ -4262,14 +4261,14 @@ void call_cache_stats()
 #endif
 
 STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t **args, uint32_t nargs,
-                                                       uint32_t callsite, size_t world)
+                                                       uint32_t callsite, size_t world, int for_call)
 {
 #ifdef JL_GF_PROFILE
     ncalls++;
 #endif
 #ifdef JL_TRACE
     int traceen = trace_en; //&& ((char*)&mt < jl_stack_hi-6000000);
-    if (traceen)
+    if (traceen && for_call)
         show_call(F, args, nargs);
 #endif
     nargs++; // add F to argument count
@@ -4351,7 +4350,7 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
             jl_atomic_store_relaxed(&pick_which[cache_idx[0]], which);
             jl_atomic_store_release(&call_cache[cache_idx[which & 3]], entry);
         }
-        if (entry) {
+        if (entry && for_call) {
             // mfunc was found in slow path, so log --trace-dispatch
             jl_method_instance_t *mfunc = entry->func.linfo;
             record_dispatch_statement_on_first_dispatch(mfunc);
@@ -4371,23 +4370,35 @@ have_entry:
         if (jl_options.malloc_log)
             jl_gc_sync_total_bytes(last_alloc); // discard allocation count from compilation
         if (mfunc == NULL) {
+            if (for_call) {
 #ifdef JL_TRACE
-            if (error_en)
-                show_call(F, args, nargs);
+                if (error_en)
+                    show_call(F, args, nargs);
 #endif
-            jl_method_error(F, args, nargs, world);
-            // unreachable
+                jl_method_error(F, args, nargs, world);
+                // unreachable
+            }
         }
-        // mfunc was found in slow path, so log --trace-dispatch
-        record_dispatch_statement_on_first_dispatch(mfunc);
+        else {
+            // mfunc was found in slow path, so log --trace-dispatch
+            record_dispatch_statement_on_first_dispatch(mfunc);
+        }
     }
 
 #ifdef JL_TRACE
-    if (traceen)
+    if (traceen && for_call)
         jl_printf(JL_STDOUT, " at %s:%d\n", jl_symbol_name(mfunc->def.method->file), mfunc->def.method->line);
 #endif
 
     return mfunc;
+}
+
+// introspect the expected result of jl_apply_generic (e.g. for applicable and macro expand)
+jl_method_instance_t *jl_apply_lookup(jl_value_t **args, size_t nargs, size_t world)
+{
+    assert(nargs);
+    return jl_lookup_generic_(args[0], &args[1], nargs - 1,
+            jl_int32hash_fast(jl_return_address()), world, 0);
 }
 
 JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t *F, jl_value_t **args, uint32_t nargs)
@@ -4395,9 +4406,25 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t *F, jl_value_t **args, uint
     size_t world = jl_current_task->world_age;
     jl_method_instance_t *mfunc = jl_lookup_generic_(F, args, nargs,
                                                      jl_int32hash_fast(jl_return_address()),
-                                                     world);
+                                                     world, 1);
     JL_GC_PROMISE_ROOTED(mfunc);
     return _jl_invoke(F, args, nargs, mfunc, world);
+}
+
+// buggy way to lookup a method given a list of arguments
+JL_DLLEXPORT jl_method_instance_t *jl_method_lookup(jl_value_t **args, size_t nargs, size_t world)
+{
+    assert(nargs > 0 && "expected caller to handle this case");
+    jl_methcache_t *mc = jl_method_table->cache;
+    jl_typemap_t *cache = jl_atomic_load_relaxed(&mc->cache); // XXX: gc root for this?
+    jl_typemap_entry_t *entry = jl_typemap_assoc_exact(cache, args[0], &args[1], nargs, jl_cachearg_offset(), world);
+    if (entry)
+        return entry->func.linfo;
+    jl_tupletype_t *tt = arg_type_tuple(args[0], &args[1], nargs);
+    JL_GC_PUSH1(&tt);
+    jl_method_instance_t *mi = jl_mt_assoc_by_type(jl_method_table, mc, tt, world);
+    JL_GC_POP();
+    return mi;
 }
 
 static jl_method_match_t *_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT, jl_methtable_t *mt, size_t world, int cache_result, size_t *min_valid, size_t *max_valid)

--- a/src/gf.c
+++ b/src/gf.c
@@ -3030,6 +3030,9 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
                     continue;
                 jl_array_ptr_1d_push(oldmi, (jl_value_t*)mi);
             }
+            jl_method_instance_t *unspec = jl_atomic_load_relaxed(&m->unspecialized);
+            if (unspec)
+                jl_array_ptr_1d_push(oldmi, (jl_value_t*)unspec);
             d = NULL;
             n = 0;
         }
@@ -3068,6 +3071,9 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
                     continue;
 
                 // Now examine if this caused any invalidations.
+                jl_method_instance_t *unspec = jl_atomic_load_relaxed(&m->unspecialized);
+                if (unspec)
+                    jl_array_ptr_1d_push(oldmi, (jl_value_t*)unspec);
                 loctag = jl_atomic_load_relaxed(&m->specializations); // use loctag for a gcroot
                 _Atomic(jl_method_instance_t*) *data;
                 size_t l;

--- a/src/gf.c
+++ b/src/gf.c
@@ -762,7 +762,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst_uninit(jl_method_instance_t *mi
 }
 
 JL_DLLEXPORT void jl_mi_cache_insert(jl_method_instance_t *mi,
-                                     jl_code_instance_t *ci JL_ROOTED_BY_ARG(0) JL_MAYBE_UNROOTED)
+                                     jl_code_instance_t *ci JL_MAYBE_UNROOTED)
 {
     JL_GC_PUSH1(&ci);
     if (jl_is_method(mi->def.method))
@@ -826,7 +826,7 @@ JL_DLLEXPORT void jl_mi_cache_insert(jl_method_instance_t *mi,
 
 JL_DLLEXPORT int jl_mi_try_insert(jl_method_instance_t *mi,
                                    jl_code_instance_t *expected_ci,
-                                   jl_code_instance_t *ci JL_ROOTED_BY_ARG(0) JL_MAYBE_UNROOTED)
+                                   jl_code_instance_t *ci JL_MAYBE_UNROOTED)
 {
     JL_GC_PUSH1(&ci);
     if (jl_is_method(mi->def.method))
@@ -1060,7 +1060,7 @@ JL_DLLEXPORT void jl_set_type_infer_preserve_ir(int8_t v)
 
 static int invalidate_all_entries(jl_typemap_entry_t *entry, void *env)
 {
-    entry->max_world = 0;
+    jl_atomic_store_relaxed(&entry->max_world, 0);
     return 1;
 }
 
@@ -1660,7 +1660,7 @@ static inline jl_typemap_entry_t *lookup_leafcache(jl_genericmemory_t *leafcache
     return NULL;
 }
 
-static jl_typemap_entry_t *mt_find_cache_entry(_Atomic(jl_typemap_t*) *JL_NONNULL cache JL_PROPAGATES_ROOT, _Atomic(jl_genericmemory_t*) *leafcache JL_PROPAGATES_ROOT, jl_datatype_t *tt, size_t world, int offs)
+static jl_typemap_entry_t *mt_find_cache_entry(_Atomic(jl_typemap_t* JL_NONNULL) *JL_NONNULL cache JL_PROPAGATES_ROOT, _Atomic(jl_genericmemory_t*) *leafcache JL_PROPAGATES_ROOT, jl_datatype_t *tt, size_t world, int offs)
 {
     if (leafcache) {
         jl_typemap_entry_t *entry = lookup_leafcache(jl_atomic_load_relaxed(leafcache), (jl_value_t*)tt, world);
@@ -1859,6 +1859,7 @@ static void recache_method(
         jl_typemap_entry_t *entry = lookup_leafcache(jl_atomic_load_relaxed(&mc->leafcache), (jl_value_t*)tt, world);
         if (entry) {
             entry->func.linfo = newmeth;
+            jl_gc_wb(entry, newmeth);
             orig_in_cache = 1;
             if (jl_egal((jl_value_t*)tt, (jl_value_t*)newmeth->specTypes)) {
                 if (mc) JL_UNLOCK(&mc->writelock);
@@ -1871,6 +1872,7 @@ static void recache_method(
         jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(jl_atomic_load_relaxed(cache), &search, offs, /*subtype*/1);
         if (entry && jl_subtype((jl_value_t*)entry->sig, (jl_value_t*)newmeth->specTypes)) {
             entry->func.linfo = newmeth;
+            jl_gc_wb(entry, newmeth);
             if (entry->simplesig == (void*)jl_nothing || jl_egal((jl_value_t*)entry->simplesig, compute_simplett((jl_tupletype_t*)newmeth->specTypes))) {
                 if (mc) JL_UNLOCK(&mc->writelock);
                 return; // cache entry already sufficient
@@ -1911,6 +1913,7 @@ static void recache_method(
         // now examine what will happen if we chose to use this sig in the cache
         size_t min_valid2 = 1;
         size_t max_valid2 = ~(size_t)0;
+        // TODO: check if inferences is empty, before doing the filtered lookup
         matches = ml_matches(mt, mc, (jl_tupletype_t*)compilationsig, MAX_UNSPECIALIZED_CONFLICTS, 1, 1, world, 0, &min_valid2, &max_valid2, NULL);
         int guards = 0;
         if (matches == jl_nothing) {
@@ -2016,14 +2019,11 @@ static void promote_cache_method(jl_value_t *F, jl_value_t **args, uint32_t narg
     else if (cause == TRIGGER_INVOKE) {
         jl_tupletype_t *tt = arg_type_tuple(F, args, nargs + 1);
         JL_GC_PUSH1(&tt);
-        size_t current_world = ~(size_t)0;
-        size_t min_valid = 1;
-        size_t max_valid = 1;
         jl_method_t *definition = newmeth->def.method;
         JL_LOCK(&definition->writelock);
         recache_method(
-            NULL, NULL, &definition->invokes, (jl_value_t*)definition, tt, definition, world,
-            min_valid, max_valid, current_world, newmeth->sparam_vals, newmeth, compilationsig);
+            NULL, NULL, &definition->invokes, (jl_value_t*)definition, tt, definition,
+            1, 1, 1, 1, newmeth->sparam_vals, newmeth, compilationsig);
         JL_UNLOCK(&definition->writelock);
         JL_GC_POP();
     }
@@ -2455,8 +2455,9 @@ static int _invalidate_dispatch_backedges(jl_method_instance_t *mi, jl_value_t *
     if (!backedges)
         return 0;
     size_t ib = 0, insb = 0, nb = jl_array_nrows(backedges);
-    jl_value_t *invokeTypes;
-    jl_code_instance_t *caller;
+    jl_value_t *invokeTypes = NULL;
+    jl_code_instance_t *caller = NULL;
+    JL_GC_PUSH2(&caller, &invokeTypes);
     int invalidated_any = 0;
     while (mi->backedges && ib < nb) {
         ib = get_next_edge(backedges, ib, &invokeTypes, &caller);
@@ -2485,6 +2486,7 @@ static int _invalidate_dispatch_backedges(jl_method_instance_t *mi, jl_value_t *
             insb = set_next_edge(backedges, insb, invokeTypes, caller);
         }
     }
+    JL_GC_POP();
     jl_mi_done_backedges(mi, backedge_recursion_flags);
     return invalidated_any;
 }
@@ -3792,7 +3794,7 @@ jl_code_instance_t *copy_to_mi_cache(jl_method_instance_t *mi JL_PROPAGATES_ROOT
 // a cacheable sig is normally the same as a compileable sig
 // except in the case where we can't execute the compileable sig without copying
 // (because of jl_fptr_sparam environment usage)
-static jl_value_t *normalize_to_cacheable_sig(jl_method_instance_t *mi)
+static jl_value_t *normalize_to_cacheable_sig(jl_method_instance_t *mi JL_PROPAGATES_ROOT)
 {
     jl_method_instance_t *mi2 = jl_normalize_to_compilable_mi(mi);
     if (mi != mi2 && need_copy_to_mi_cache(mi, mi2, TRIGGER_NONE)) // rarely true
@@ -3816,14 +3818,14 @@ static jl_code_instance_t *jl_compile_method_very_internal(jl_method_instance_t 
     // but many of the code paths here would be invalid if we reached them.
     jl_method_t *def = mi->def.method;
     if (def == jl_opaque_closure_method) {
-        codeinst = jl_method_compiled(def->unspecialized, world);
+        codeinst = jl_method_compiled(jl_atomic_load_relaxed(&def->unspecialized), world);
         promote_cache_method(F, args, nargs, world, mi, def->sig, cause);
         return codeinst;
     }
 
     // We don't really want to compile (or infer) unspecialized, since it confuses various heuristics and caches,
     // so re-acquire the specialized MethodInstance, and work forward with that
-    if (jl_is_method(def) && mi == def->unspecialized) {
+    if (jl_is_method(def) && mi == jl_atomic_load_relaxed(&def->unspecialized)) {
         if (F) {
             jl_tupletype_t *tt = arg_type_tuple(F, args, nargs + 1);
             jl_svec_t *env = NULL;
@@ -3958,7 +3960,7 @@ static jl_code_instance_t *jl_compile_method_very_internal(jl_method_instance_t 
         if (mi != mi2) {
             codeinst = jl_compile_method_very_internal(mi2, world, F, args, nargs, cause);
             if (need_copy_to_mi_cache(mi, mi2, cause)) {
-                codeinst = copy_to_mi_cache(mi2, codeinst);
+                codeinst = copy_to_mi_cache(mi, codeinst);
                 mi2 = mi;
             }
             else {
@@ -4549,11 +4551,13 @@ have_entry:
         assert(tt);
         // cache miss case
         jl_methcache_t *mc = jl_method_table->cache;
+        JL_GC_PUSH1(&tt);
         mfunc = jl_mt_assoc_by_type(jl_method_table, mc, tt, world);
+        JL_GC_POP();
         if (jl_options.malloc_log)
             jl_gc_sync_total_bytes(last_alloc); // discard allocation count from compilation
-        if (mfunc == NULL) {
-            if (for_call) {
+        if (for_call) {
+            if (mfunc == NULL) {
 #ifdef JL_TRACE
                 if (error_en)
                     show_call(F, args, nargs);
@@ -4561,8 +4565,6 @@ have_entry:
                 jl_method_error(F, args, nargs, world);
                 // unreachable
             }
-        }
-        else {
             // mfunc was found in slow path, so log --trace-dispatch
             record_dispatch_statement_on_first_dispatch(mfunc);
         }

--- a/src/gf.c
+++ b/src/gf.c
@@ -3400,19 +3400,19 @@ JL_DLLEXPORT jl_value_t *jl_method_lookup_by_tt(jl_tupletype_t *tt, size_t world
 }
 
 // hook provided for legacy staticdata lookups
+JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup(jl_value_t *types, jl_value_t *mt, size_t world);
 jl_method_instance_t *jl_builtin_method_lookup(jl_value_t *builtin)
 {
     jl_datatype_t *dt = (jl_datatype_t*)jl_typeof(builtin);
-    jl_methtable_t *mt = jl_method_table;
     jl_value_t *params[2];
     params[0] = dt->name->wrapper;
     params[1] = jl_tparam0(jl_anytuple_type);
     jl_tupletype_t *tt = (jl_datatype_t*)jl_apply_tuple_type_v(params, 2);
     JL_GC_PUSH1(&tt);
-    jl_method_instance_t *mi = jl_mt_assoc_by_type(mt, mt->cache, tt, 1);
-    assert(mi);
+    jl_method_t *m = (jl_method_t*)jl_gf_invoke_lookup((jl_value_t*)tt, (jl_value_t*)jl_method_table, 1);
+    assert(jl_is_method(m) && m->unspecialized);
     JL_GC_POP();
-    return mi;
+    return m->unspecialized;
 }
 
 // return a Vector{Any} of svecs, each describing a method match:

--- a/src/gf.c
+++ b/src/gf.c
@@ -24,6 +24,15 @@
 extern "C" {
 #endif
 
+// Record of which caches were involved in choosing this compile target.
+// To populate after compile for caching.
+enum internal_compilation_triggers {
+    TRIGGER_NONE, // No cache should be updated
+    TRIGGER_FOREIGN, // Unmanageable cache, requires exact updates
+    TRIGGER_DISPATCH, // Insert to global dispatch cache
+    TRIGGER_INVOKE // Insert to local (invoke) dispatch cache
+};
+
 _Atomic(int) allow_new_worlds = 1;
 JL_DLLEXPORT _Atomic(size_t) jl_world_counter = 1; // uses atomic acquire/release
 jl_mutex_t world_counter_lock;
@@ -368,10 +377,6 @@ jl_method_t *jl_mk_builtin_func(jl_datatype_t *dt, jl_sym_t *sname, jl_fptr_args
             (jl_value_t*)m, 1, ~(size_t)0);
     jl_typemap_insert(&jl_method_table->defs, (jl_value_t*)jl_method_table, newentry, 0);
 
-    newentry = jl_typemap_alloc(tuptyp, NULL, jl_emptysvec,
-            (jl_value_t*)mi, 1, ~(size_t)0);
-    jl_typemap_insert(&jl_method_table->cache->cache, (jl_value_t*)jl_method_table->cache, newentry, 0);
-
     JL_GC_POP();
     return m;
 }
@@ -408,7 +413,7 @@ static jl_code_instance_t *jl_method_inferred_with_abi(jl_method_instance_t *mi 
         if (codeinst->owner != jl_nothing)
             continue;
         if (jl_atomic_load_relaxed(&codeinst->min_world) <= world && world <= jl_atomic_load_relaxed(&codeinst->max_world)) {
-            if (emit_codeinst_and_edges(codeinst))
+            if (emit_codeinst_and_edges(codeinst) && jl_atomic_load_relaxed(&codeinst->invoke) != NULL)
                 return codeinst;
         }
     }
@@ -421,12 +426,8 @@ static jl_code_instance_t *jl_method_inferred_with_abi(jl_method_instance_t *mi 
 // if inference doesn't occur (or can't finish), returns NULL instead
 jl_code_instance_t *jl_type_infer(jl_method_instance_t *mi, size_t world, uint8_t source_mode, uint8_t trim_mode)
 {
-    if (jl_typeinf_func == NULL) {
-        if (source_mode == SOURCE_MODE_ABI)
-            return jl_method_inferred_with_abi(mi, world);
-        else
-            return NULL;
-    }
+    if (jl_typeinf_func == NULL)
+        return NULL;
     jl_task_t *ct = jl_current_task;
     if (ct->reentrant_timing & 0b1000) {
         // We must avoid attempting to re-enter inference here
@@ -574,7 +575,7 @@ JL_DLLEXPORT jl_value_t *jl_call_in_typeinf_world(jl_value_t **args, int nargs)
     return ret;
 }
 
-JL_DLLEXPORT jl_code_instance_t *jl_get_method_inferred(
+JL_DLLEXPORT jl_code_instance_t *jl_get_method_uninferred(
         jl_method_instance_t *mi JL_PROPAGATES_ROOT, jl_value_t *rettype,
         size_t min_world, size_t max_world, jl_debuginfo_t *di, jl_svec_t *edges)
 {
@@ -601,7 +602,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_method_inferred(
     }
     codeinst = jl_new_codeinst(
         mi, owner, rettype, (jl_value_t*)jl_any_type, NULL, NULL,
-        0, min_world, max_world, 0, jl_nothing, di, edges);
+        0, min_world, max_world, 0, NULL, di, edges);
     jl_mi_cache_insert(mi, codeinst);
     return codeinst;
 }
@@ -677,7 +678,6 @@ JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
     codeinst->time_infer_self = 0;
     jl_atomic_store_relaxed(&codeinst->time_compile, 0);
     jl_atomic_store_relaxed(&codeinst->flags, 0);
-    jl_atomic_store_relaxed(&codeinst->precompile, 0);
     jl_atomic_store_relaxed(&codeinst->next, NULL);
     jl_atomic_store_relaxed(&codeinst->ipo_purity_bits, effects);
     codeinst->analysis_results = analysis_results;
@@ -778,15 +778,15 @@ JL_DLLEXPORT void jl_mi_cache_insert(jl_method_instance_t *mi,
     jl_value_t *parent = (jl_value_t*)mi;
     _Atomic(jl_code_instance_t*) *slot = &mi->cache;
     jl_code_instance_t *oldci = jl_atomic_load_relaxed(slot);
-    int hasinvoke = jl_atomic_load_relaxed(&ci->invoke) != NULL;
     int hasinferred = jl_atomic_load_relaxed(&ci->inferred) != NULL;
+    int hasinvoke = hasinferred && jl_atomic_load_relaxed(&ci->invoke) != NULL;
     size_t max_world = jl_atomic_load_relaxed(&ci->max_world);
     jl_code_instance_t *next = jl_atomic_load_relaxed(&ci->next);
     while (oldci) {
         if (oldci == ci)
             break;
-        int old_hasinvoke = jl_atomic_load_relaxed(&oldci->invoke) != NULL;
         int old_hasinferred = jl_atomic_load_relaxed(&oldci->inferred) != NULL;
+        int old_hasinvoke = old_hasinferred && jl_atomic_load_relaxed(&oldci->invoke) != NULL;
         size_t old_max_world = jl_atomic_load_relaxed(&oldci->max_world);
         if (hasinvoke && !old_hasinvoke)
             break;
@@ -1058,8 +1058,38 @@ JL_DLLEXPORT void jl_set_type_infer_preserve_ir(int8_t v)
     jl_atomic_store_relaxed(&jl_type_infer_preserve_ir, v);
 }
 
+static int invalidate_all_entries(jl_typemap_entry_t *entry, void *env)
+{
+    entry->max_world = 0;
+    return 1;
+}
+
+static void drop_all_methcache(jl_methcache_t *mc)
+{
+    JL_LOCK(&mc->writelock);
+    jl_typemap_visitor(jl_atomic_load_relaxed(&mc->cache), invalidate_all_entries, NULL);
+    jl_genericmemory_t *leafcache = jl_atomic_load_relaxed(&mc->leafcache);
+    size_t i, l = leafcache->length;
+    for (i = 1; i < l; i += 2) {
+        jl_typemap_entry_t *oldentry = (jl_typemap_entry_t*)jl_genericmemory_ptr_ref(leafcache, i);
+        if (oldentry) {
+            while ((jl_value_t*)oldentry != jl_nothing) {
+                invalidate_all_entries(oldentry, NULL);
+                oldentry = jl_atomic_load_relaxed(&oldentry->next);
+            }
+        }
+    }
+    jl_atomic_store_relaxed(&mc->cache, jl_nothing);
+    jl_atomic_store_relaxed(&mc->leafcache, (jl_genericmemory_t*)jl_an_empty_memory_any);
+    JL_UNLOCK(&mc->writelock);
+}
+
 JL_DLLEXPORT void jl_set_typeinf_func(jl_value_t *f)
 {
+    if (jl_typeinf_func == NULL) {
+        // drop the major caches, so that their structure can now be inferred
+        drop_all_methcache(jl_method_table->cache);
+    }
     jl_typeinf_func = (jl_value_t*)f;
     jl_typeinf_world = jl_get_tls_world_age();
 }
@@ -1150,7 +1180,7 @@ static jl_value_t *inst_varargp_in_env(jl_value_t *decl, jl_svec_t *sparams)
 
 static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                               jl_tupletype_t *type, int lim, int include_ambiguous,
-                              int intersections, size_t world, int cache_result,
+                              int intersections, size_t world, int cache_result_recursion,
                               size_t *min_valid, size_t *max_valid, int *ambig);
 
 // get the compilation signature specialization for this method
@@ -1630,7 +1660,7 @@ static inline jl_typemap_entry_t *lookup_leafcache(jl_genericmemory_t *leafcache
     return NULL;
 }
 
-static jl_typemap_entry_t *mt_find_cache_entry(_Atomic(jl_typemap_t*) *cache JL_PROPAGATES_ROOT, _Atomic(jl_genericmemory_t*) *leafcache JL_PROPAGATES_ROOT, jl_datatype_t *tt, size_t world, int offs)
+static jl_typemap_entry_t *mt_find_cache_entry(_Atomic(jl_typemap_t*) *JL_NONNULL cache JL_PROPAGATES_ROOT, _Atomic(jl_genericmemory_t*) *leafcache JL_PROPAGATES_ROOT, jl_datatype_t *tt, size_t world, int offs)
 {
     if (leafcache) {
         jl_typemap_entry_t *entry = lookup_leafcache(jl_atomic_load_relaxed(leafcache), (jl_value_t*)tt, world);
@@ -1642,12 +1672,12 @@ static jl_typemap_entry_t *mt_find_cache_entry(_Atomic(jl_typemap_t*) *cache JL_
     return entry;
 }
 
-JL_DLLEXPORT jl_typemap_entry_t *jl_mt_find_cache_entry(jl_methcache_t *cache, jl_datatype_t *tt, size_t world)
+JL_DLLEXPORT jl_typemap_entry_t *jl_mt_find_cache_entry(jl_methcache_t *JL_NONNULL cache, jl_datatype_t *tt, size_t world)
 { // exported only for debugging purposes, not for casual use
     return mt_find_cache_entry(&cache->cache, &cache->leafcache, tt, world, jl_cachearg_offset());
 }
 
-jl_datatype_t *compute_simplett(jl_tupletype_t *cachett)
+jl_value_t *compute_simplett(jl_tupletype_t *cachett)
 {
     // now scan `cachett` and ensure that `Type{T}` in the cache will be matched exactly by `typeof(T)`
     // and also reduce the complexity of rejecting this entry in the cache
@@ -1655,7 +1685,10 @@ jl_datatype_t *compute_simplett(jl_tupletype_t *cachett)
     // (for example, if the signature contains jl_function_type)
     // TODO: this is also related to how we should handle partial matches
     //       (which currently might miss detection of a MethodError)
-    jl_tupletype_t *simplett = NULL;
+    jl_value_t *simplett = jl_nothing;
+    cachett = (jl_tupletype_t*) jl_unwrap_unionall((jl_value_t*)cachett);
+    if (!jl_is_datatype(cachett))
+        return simplett;
     size_t i, np = jl_nparams(cachett);
     jl_svec_t *newparams = NULL;
     JL_GC_PUSH1(&newparams);
@@ -1675,16 +1708,98 @@ jl_datatype_t *compute_simplett(jl_tupletype_t *cachett)
         }
     }
     if (newparams)
-        simplett = (jl_datatype_t*)jl_apply_tuple_type(newparams, 1);
+        simplett = jl_apply_tuple_type(newparams, 1);
     JL_GC_POP();
     return simplett;
 }
 
-static jl_method_instance_t *cache_method(
+static void cache_insert(
+        jl_methtable_t *mt, jl_methcache_t *mc, _Atomic(jl_typemap_t*) *cache, jl_value_t *parent JL_PROPAGATES_ROOT,
+        jl_method_t *definition,
+        jl_tupletype_t *tt, // the original tupletype of the signature
+        size_t min_valid, size_t max_valid, size_t current_world,
+        jl_tupletype_t *cachett,
+        jl_svec_t *guardsigs,
+        jl_method_instance_t *newmeth,
+        int offs)
+{
+    int unconstrained_max = max_valid == ~(size_t)0;
+    if (max_valid > current_world)
+        max_valid = current_world;
+    jl_datatype_t *simplett = NULL;
+    jl_typemap_entry_t *newentry = NULL;
+    JL_GC_PUSH2(&simplett, &newentry);
+    simplett = (jl_datatype_t*)compute_simplett(cachett);
+    newentry = jl_typemap_alloc(cachett, simplett, guardsigs, (jl_value_t*)newmeth, min_valid, max_valid);
+    if (mc && cachett == tt && tt->hash && !tt->hasfreetypevars) {
+        // we check `tt->hash` exists, since otherwise the NamedTuple
+        // constructor and `structdiff` method pollutes this lookup with a lot
+        // of garbage in the linear table search
+        if (jl_lookup_cache_type_(tt) == NULL) {
+            // if this type isn't normally in the cache, force it in there now
+            // anyways so that we can depend on it as a token (especially since
+            // we just cached it in memory as this method signature anyways)
+            JL_LOCK(&typecache_lock);
+            if (jl_lookup_cache_type_(tt) == NULL)
+                jl_cache_type_(tt);
+            JL_UNLOCK(&typecache_lock); // Might GC
+        }
+        jl_genericmemory_t *oldcache = jl_atomic_load_relaxed(&mc->leafcache);
+        jl_typemap_entry_t *old = (jl_typemap_entry_t*)jl_eqtable_get(oldcache, (jl_value_t*)tt, jl_nothing);
+        jl_atomic_store_relaxed(&newentry->next, old);
+        jl_gc_wb(newentry, old);
+        jl_genericmemory_t *newcache = jl_eqtable_put(jl_atomic_load_relaxed(&mc->leafcache), (jl_value_t*)tt, (jl_value_t*)newentry, NULL);
+        if (newcache != oldcache) {
+            jl_atomic_store_release(&mc->leafcache, newcache);
+            jl_gc_wb(mc, newcache);
+        }
+    }
+    else {
+         jl_typemap_insert(cache, parent, newentry, offs);
+         if (mt) {
+             jl_datatype_t *dt = jl_nth_argument_datatype((jl_value_t*)(tt ? tt : cachett), 1);
+             if (dt) {
+                 jl_typename_t *tn = dt->name;
+                 int cache_entry_count = jl_atomic_load_relaxed(&tn->cache_entry_count);
+                 if (cache_entry_count < 31)
+                     jl_atomic_store_relaxed(&tn->cache_entry_count, cache_entry_count + 1);
+             }
+         }
+    }
+    if (mc) {
+        jl_method_cache_inserted();
+        JL_UNLOCK(&mc->writelock); // before acquiring world_counter_lock
+
+        // Only set METHOD_SIG_LATEST_ONLY on method instance if method does NOT have the bit, no guards required, and min_valid == primary_world
+        int should_set_dispatch_status = !(jl_atomic_load_relaxed(&definition->dispatch_status) & METHOD_SIG_LATEST_ONLY) &&
+            (jl_value_t*)cachett == newmeth->specTypes && jl_svec_len(guardsigs) == 0 &&
+            min_valid == jl_atomic_load_relaxed(&definition->primary_world) &&
+            !(jl_atomic_load_relaxed(&newmeth->dispatch_status) & METHOD_SIG_LATEST_ONLY);
+
+        // Combined trylock for both dispatch_status setting and max_world restoration
+        if ((should_set_dispatch_status || unconstrained_max) &&
+            jl_atomic_load_relaxed(&jl_world_counter) == current_world) {
+            JL_LOCK(&world_counter_lock);
+            if (jl_atomic_load_relaxed(&jl_world_counter) == current_world) {
+                if (should_set_dispatch_status) {
+                    jl_atomic_store_relaxed(&newmeth->dispatch_status, METHOD_SIG_LATEST_ONLY);
+                }
+                if (unconstrained_max) {
+                    jl_atomic_store_relaxed(&newentry->max_world, ~(size_t)0);
+                }
+            }
+            JL_UNLOCK(&world_counter_lock);
+        }
+    }
+
+    JL_GC_POP();
+}
+
+static jl_method_instance_t *cache_result(
         jl_methtable_t *mt, jl_methcache_t *mc, _Atomic(jl_typemap_t*) *cache, jl_value_t *parent JL_PROPAGATES_ROOT,
         jl_tupletype_t *tt, // the original tupletype of the signature
         jl_method_t *definition,
-        size_t world, size_t min_valid, size_t max_valid,
+        size_t world, size_t min_valid, size_t max_valid, size_t current_world,
         jl_svec_t *sparams,
         // set by callers that have already proven `tt` is absent from the cache
         // immediately before acquiring the lock and that no insertion can have
@@ -1707,7 +1822,8 @@ static jl_method_instance_t *cache_method(
         newmeth = jl_atomic_load_relaxed(&definition->unspecialized);
         assert(newmeth != NULL); // handle builtin methods de-specialization (for invoke, or if the global cache entry somehow gets lost)
         jl_tupletype_t *cachett = (jl_tupletype_t*)definition->sig;
-        jl_typemap_entry_t *newentry = jl_typemap_alloc(cachett, NULL, jl_emptysvec, (jl_value_t*)newmeth, min_valid, max_valid);
+        jl_datatype_t *simplett = NULL;
+        jl_typemap_entry_t *newentry = jl_typemap_alloc(cachett, simplett, jl_emptysvec, (jl_value_t*)newmeth, min_valid, max_valid);
         JL_GC_PUSH1(&newentry);
         jl_typemap_insert(cache, parent, newentry, offs);
         if (mc)
@@ -1717,65 +1833,94 @@ static jl_method_instance_t *cache_method(
         return newmeth;
     }
 
-    jl_value_t *temp = NULL;
-    jl_value_t *temp2 = NULL;
-    jl_value_t *temp3 = NULL;
-    jl_svec_t *newparams = NULL;
-    jl_tupletype_t *cachett = tt;
-    JL_GC_PUSH6(&temp, &temp2, &temp3, &newmeth, &newparams, &cachett);
+    newmeth = jl_specializations_get_linfo(definition, (jl_value_t*)tt, sparams);
+    JL_GC_PUSH1(&newmeth);
+    cache_insert(mt, mc, cache, parent, definition, tt, min_valid, max_valid, current_world, tt,
+        jl_emptysvec, newmeth, offs);
+    JL_GC_POP();
+    return newmeth;
+}
 
-    // Consider if we can cache with the preferred compile signature
-    // so that we can minimize the number of required cache entries.
-    int cache_with_orig = 1;
-    jl_tupletype_t *compilationsig = tt;
-    intptr_t max_varargs = get_max_varargs(definition, NULL);
-    jl_compilation_sig(tt, sparams, definition, max_varargs, &newparams);
-    if (newparams) {
-        temp2 = jl_apply_tuple_type(newparams, 1);
-        // Now there may be a problem: the widened signature is more general
-        // than just the given arguments, so it might conflict with another
-        // definition that does not have cache instances yet. To fix this, we
-        // may insert guard cache entries for all intersections of this
-        // signature and definitions. Those guard entries will supersede this
-        // one in conflicted cases, alerting us that there should actually be a
-        // cache miss. Alternatively, we may use the original signature in the
-        // cache, but use this return for compilation.
-        //
-        // In most cases `!jl_isa_compileable_sig(tt, sparams, definition)`,
-        // although for some cases, (notably Varargs)
-        // we might choose a replacement type that's preferable but not strictly better
-        int issubty;
-        temp = jl_type_intersection_env_s(temp2, (jl_value_t*)definition->sig, &newparams, &issubty);
-        assert(temp != (jl_value_t*)jl_bottom_type); (void)temp;
-        if (jl_egal((jl_value_t*)newparams, (jl_value_t*)sparams)) {
-            cache_with_orig = !issubty;
-            compilationsig = (jl_datatype_t*)temp2;
+static void recache_method(
+        jl_methtable_t *mt, jl_methcache_t *mc, _Atomic(jl_typemap_t*) *cache, jl_value_t *parent JL_PROPAGATES_ROOT,
+        jl_tupletype_t *tt, // the original tupletype of the signature
+        jl_method_t *definition,
+        size_t world, size_t min_valid, size_t max_valid, size_t current_world,
+        jl_svec_t *sparams,
+        jl_method_instance_t *newmeth,
+        jl_value_t *compilationsig)
+{
+    // caller must hold the parent->writelock, which this releases
+    int8_t offs = mc ? jl_cachearg_offset() : 1;
+    // check each cache this might be present in, and update it there
+    // TODO: should/how do we check min/max valid on the previous entry before updating to newmeth?
+    int orig_in_cache = 0;
+    if (mc && tt != NULL) {
+        jl_typemap_entry_t *entry = lookup_leafcache(jl_atomic_load_relaxed(&mc->leafcache), (jl_value_t*)tt, world);
+        if (entry) {
+            entry->func.linfo = newmeth;
+            orig_in_cache = 1;
+            if (jl_egal((jl_value_t*)tt, (jl_value_t*)newmeth->specTypes)) {
+                if (mc) JL_UNLOCK(&mc->writelock);
+                return; // cache entry already sufficient
+            }
         }
-        newparams = NULL;
     }
-    // TODO: maybe assert(jl_isa_compileable_sig(compilationsig, sparams, definition));
-    newmeth = jl_specializations_get_linfo(definition, (jl_value_t*)compilationsig, sparams);
-    if (newmeth->cache_with_orig)
+    { // scope block
+        struct jl_typemap_assoc search = {tt ? (jl_value_t*)tt : compilationsig, world, NULL};
+        jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(jl_atomic_load_relaxed(cache), &search, offs, /*subtype*/1);
+        if (entry && jl_subtype((jl_value_t*)entry->sig, (jl_value_t*)newmeth->specTypes)) {
+            entry->func.linfo = newmeth;
+            if (entry->simplesig == (void*)jl_nothing || jl_egal((jl_value_t*)entry->simplesig, compute_simplett((jl_tupletype_t*)newmeth->specTypes))) {
+                if (mc) JL_UNLOCK(&mc->writelock);
+                return; // cache entry already sufficient
+            }
+        }
+    }
+
+    // cache it generically too, if valid
+    int cache_with_orig = newmeth->cache_with_orig;
+    if (!cache_with_orig && !jl_egal((jl_value_t*)sparams, (jl_value_t*)newmeth->sparam_vals))
         cache_with_orig = 1;
+    if (!cache_with_orig && !jl_subtype(compilationsig, (jl_value_t*)definition->sig))
+        // TODO: use (compilationsig = definition->sig; cache_with_orig = jl_is_unionall(definition->sig);) here instead?
+        cache_with_orig = 1;
+    if (cache_with_orig && (orig_in_cache || tt == NULL)) {
+        if (mc) JL_UNLOCK(&mc->writelock);
+        return; // leafcache entry alone is sufficient (or no orig tt to cache with)
+    }
 
-    // Capture world counter at start to detect races
-    size_t current_world = mc ? jl_atomic_load_acquire(&jl_world_counter) : ~(size_t)0;
-
+    jl_value_t *matches = NULL;
     jl_svec_t *guardsigs = jl_emptysvec;
+    JL_GC_PUSH2(&matches, &guardsigs);
+
+    // Now there may be a problem: the widened signature is more general
+    // than just the given arguments, so it might conflict with another
+    // definition that does not have cache instances yet. To fix this, we
+    // may insert guard cache entries for all intersections of this
+    // signature and definitions. Those guard entries will supersede this
+    // one in conflicted cases, alerting us that there should actually be a
+    // cache miss. Alternatively, we may use the original signature in the
+    // cache, but use this return for compilation.
+    //
+    // In most cases `!jl_isa_compileable_sig(tt, sparams, definition)`,
+    // although for some cases, (notably Varargs)
+    // we might choose a replacement type that's preferable but not strictly better
+    jl_value_t *cachett = (jl_value_t*)tt;
     if (!cache_with_orig && mt) {
         // now examine what will happen if we chose to use this sig in the cache
         size_t min_valid2 = 1;
         size_t max_valid2 = ~(size_t)0;
-        temp = ml_matches(mt, mc, compilationsig, MAX_UNSPECIALIZED_CONFLICTS, 1, 1, world, 0, &min_valid2, &max_valid2, NULL);
+        matches = ml_matches(mt, mc, (jl_tupletype_t*)compilationsig, MAX_UNSPECIALIZED_CONFLICTS, 1, 1, world, 0, &min_valid2, &max_valid2, NULL);
         int guards = 0;
-        if (temp == jl_nothing) {
+        if (matches == jl_nothing) {
             cache_with_orig = 1;
         }
         else {
             int unmatched_tvars = 0;
-            size_t i, l = jl_array_nrows(temp);
+            size_t i, l = jl_array_nrows(matches);
             for (i = 0; i < l; i++) {
-                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(temp, i);
+                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(matches, i);
                 if (matc->method == definition)
                     continue;
                 jl_svec_t *env = matc->sparams;
@@ -1804,10 +1949,9 @@ static jl_method_instance_t *cache_method(
             // from matching when another more specific definition also exists
             size_t i, l;
             guardsigs = jl_alloc_svec(guards);
-            temp3 = (jl_value_t*)guardsigs;
             guards = 0;
-            for (i = 0, l = jl_array_nrows(temp); i < l; i++) {
-                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(temp, i);
+            for (i = 0, l = jl_array_nrows(matches); i < l; i++) {
+                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(matches, i);
                 jl_method_t *other = matc->method;
                 if (other != definition) {
                     jl_svecset(guardsigs, guards, matc->spec_types);
@@ -1828,94 +1972,82 @@ static jl_method_instance_t *cache_method(
         else {
             // do not revisit this decision
             newmeth->cache_with_orig = 1;
-        }
-    }
-
-    int unconstrained_max = max_valid == ~(size_t)0;
-    if (max_valid > current_world)
-        max_valid = current_world;
-
-    jl_datatype_t *simplett = compute_simplett(cachett);
-
-    // short-circuit if an existing entry is already present
-    // that satisfies our requirements
-    if (cachett != tt) {
-        struct jl_typemap_assoc search = {(jl_value_t*)cachett, world, NULL};
-        jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(jl_atomic_load_relaxed(cache), &search, offs, /*subtype*/1);
-        if (entry && jl_egal((jl_value_t*)entry->simplesig, simplett ? (jl_value_t*)simplett : jl_nothing) &&
-                jl_egal((jl_value_t*)guardsigs, (jl_value_t*)entry->guardsigs)) {
-            JL_GC_POP();
-            if (mc) JL_UNLOCK(&mc->writelock);
-            return entry->func.linfo;
-        }
-    }
-
-    jl_typemap_entry_t *newentry = jl_typemap_alloc(cachett, simplett, guardsigs, (jl_value_t*)newmeth, min_valid, max_valid);
-    temp = (jl_value_t*)newentry;
-    if (mc && cachett == tt && jl_svec_len(guardsigs) == 0 && tt->hash && !tt->hasfreetypevars) {
-        // we check `tt->hash` exists, since otherwise the NamedTuple
-        // constructor and `structdiff` method pollutes this lookup with a lot
-        // of garbage in the linear table search
-        if (jl_lookup_cache_type_(tt) == NULL) {
-            // if this type isn't normally in the cache, force it in there now
-            // anyways so that we can depend on it as a token (especially since
-            // we just cached it in memory as this method signature anyways)
-            JL_LOCK(&typecache_lock);
-            if (jl_lookup_cache_type_(tt) == NULL)
-                jl_cache_type_(tt);
-            JL_UNLOCK(&typecache_lock); // Might GC
-        }
-        jl_genericmemory_t *oldcache = jl_atomic_load_relaxed(&mc->leafcache);
-        jl_typemap_entry_t *old = (jl_typemap_entry_t*)jl_eqtable_get(oldcache, (jl_value_t*)tt, jl_nothing);
-        jl_atomic_store_relaxed(&newentry->next, old);
-        jl_gc_wb(newentry, old);
-        jl_genericmemory_t *newcache = jl_eqtable_put(jl_atomic_load_relaxed(&mc->leafcache), (jl_value_t*)tt, (jl_value_t*)newentry, NULL);
-        if (newcache != oldcache) {
-            jl_atomic_store_release(&mc->leafcache, newcache);
-            jl_gc_wb(mc, newcache);
-        }
-    }
-    else {
-         jl_typemap_insert(cache, parent, newentry, offs);
-         if (mt) {
-             jl_datatype_t *dt = jl_nth_argument_datatype((jl_value_t*)tt, 1);
-             if (dt) {
-                 jl_typename_t *tn = dt->name;
-                 int cache_entry_count = jl_atomic_load_relaxed(&tn->cache_entry_count);
-                 if (cache_entry_count < 31)
-                     jl_atomic_store_relaxed(&tn->cache_entry_count, cache_entry_count + 1);
-             }
-         }
-    }
-    if (mc)
-        jl_method_cache_inserted();
-    if (mc) {
-        JL_UNLOCK(&mc->writelock);
-
-        // Only set METHOD_SIG_LATEST_ONLY on method instance if method does NOT have the bit, no guards required, and min_valid == primary_world
-        int should_set_dispatch_status = !(jl_atomic_load_relaxed(&definition->dispatch_status) & METHOD_SIG_LATEST_ONLY) &&
-            (!cache_with_orig && jl_svec_len(guardsigs) == 0) &&
-            min_valid == jl_atomic_load_relaxed(&definition->primary_world) &&
-            !(jl_atomic_load_relaxed(&newmeth->dispatch_status) & METHOD_SIG_LATEST_ONLY);
-
-        // Combined trylock for both dispatch_status setting and max_world restoration
-        if ((should_set_dispatch_status || unconstrained_max) &&
-            jl_atomic_load_relaxed(&jl_world_counter) == current_world) {
-            JL_LOCK(&world_counter_lock);
-            if (jl_atomic_load_relaxed(&jl_world_counter) == current_world) {
-                if (should_set_dispatch_status) {
-                    jl_atomic_store_relaxed(&newmeth->dispatch_status, METHOD_SIG_LATEST_ONLY);
-                }
-                if (unconstrained_max) {
-                    jl_atomic_store_relaxed(&newentry->max_world, ~(size_t)0);
-                }
+            if (orig_in_cache || tt == NULL) {
+                if (mc) JL_UNLOCK(&mc->writelock);
+                JL_GC_POP();
+                return; // leafcache entry alone is sufficient (or no orig tt to cache with)
             }
-            JL_UNLOCK(&world_counter_lock);
         }
     }
 
+    cache_insert(mt, mc, cache, parent, definition, tt, min_valid, max_valid, current_world, (jl_tupletype_t*)cachett,
+        guardsigs, newmeth, offs);
     JL_GC_POP();
-    return newmeth;
+    return;
+}
+
+static jl_method_match_t *_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT, jl_methtable_t *mt, size_t world, int cache_result_recursion, size_t *min_valid, size_t *max_valid);
+
+static void promote_cache_method(jl_value_t *F, jl_value_t **args, uint32_t nargs, size_t world,
+    jl_method_instance_t *newmeth, jl_value_t *compilationsig,
+    enum internal_compilation_triggers cause)
+{
+    if (F == NULL)
+        return;
+    if (cause == TRIGGER_DISPATCH) {
+        jl_tupletype_t *tt = arg_type_tuple(F, args, nargs + 1);
+        jl_method_match_t *matc = NULL;
+        JL_GC_PUSH2(&tt, &matc);
+        jl_methtable_t *mt = jl_method_table;
+        size_t current_world = jl_atomic_load_acquire(&jl_world_counter);
+        size_t min_valid = 0;
+        size_t max_valid = ~(size_t)0;
+        matc = _gf_invoke_lookup((jl_value_t*)tt, mt, world, 0, &min_valid, &max_valid);
+        jl_method_t *definition = newmeth->def.method;
+        if (matc && matc->method == definition) {
+            jl_methcache_t *mc = mt->cache;
+            JL_LOCK(&mc->writelock);
+            recache_method(
+                mt, mc, &mc->cache, (jl_value_t*)mc, tt, definition, world,
+                min_valid, max_valid, current_world, matc->sparams, newmeth, compilationsig);
+        }
+        JL_GC_POP();
+    }
+    else if (cause == TRIGGER_INVOKE) {
+        jl_tupletype_t *tt = arg_type_tuple(F, args, nargs + 1);
+        JL_GC_PUSH1(&tt);
+        size_t current_world = ~(size_t)0;
+        size_t min_valid = 1;
+        size_t max_valid = 1;
+        jl_method_t *definition = newmeth->def.method;
+        JL_LOCK(&definition->writelock);
+        recache_method(
+            NULL, NULL, &definition->invokes, (jl_value_t*)definition, tt, definition, world,
+            min_valid, max_valid, current_world, newmeth->sparam_vals, newmeth, compilationsig);
+        JL_UNLOCK(&definition->writelock);
+        JL_GC_POP();
+    }
+}
+
+// Like promote_cache_method(TRIGGER_DISPATCH) but takes the type tuple directly.
+// Called from the abstract interpreter after inferring a compilation signature,
+// to record in the dispatch/ml_lookup cache that dispatching/lookup of `tt` should use
+// `newmeth` to avoid making unnecessary new types for cache_result.
+JL_DLLEXPORT void jl_recache_method_by_type(jl_value_t *tt,
+    jl_method_instance_t *newmeth, jl_value_t *compilationsig, size_t world,
+    size_t min_valid, size_t max_valid, size_t current_world)
+{
+    if (newmeth->cache_with_orig)
+        return;
+    jl_method_t *definition = newmeth->def.method;
+    if (!jl_is_dispatch_tupletype(tt))
+        tt = NULL;
+    jl_methtable_t *mt = jl_method_table;
+    jl_methcache_t *mc = mt->cache;
+    JL_LOCK(&mc->writelock);
+    recache_method(mt, mc, &mc->cache, (jl_value_t*)mc, (jl_tupletype_t*)tt, definition, world,
+        min_valid, max_valid, current_world,
+        newmeth->sparam_vals, newmeth, compilationsig);
 }
 
 JL_DLLEXPORT void jl_promote_cis_to_current(jl_code_instance_t **cis, size_t n, size_t validated_world)
@@ -1974,9 +2106,8 @@ JL_DLLEXPORT void jl_promote_mi_to_current(jl_method_instance_t *mi, size_t min_
     JL_UNLOCK(&world_counter_lock);
 }
 
-static jl_method_match_t *_gf_invoke_lookup(jl_value_t *tt JL_PROPAGATES_ROOT, jl_methtable_t *mt, size_t world, int cache, size_t *min_valid, size_t *max_valid);
-
-static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_methcache_t *mc JL_PROPAGATES_ROOT, jl_datatype_t *tt, size_t world)
+static jl_method_instance_t *jl_mt_assoc_by_type(
+    jl_methtable_t *mt, jl_methcache_t *mc JL_PROPAGATES_ROOT, jl_datatype_t *tt, size_t world)
 {
     size_t cache_insert_generation = jl_method_cache_insert_generation_load();
     jl_typemap_entry_t *entry = mt_find_cache_entry(&mc->cache,
@@ -2000,6 +2131,7 @@ static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_methcach
             mi = entry->func.linfo;
     }
     if (!mi) {
+        size_t current_world = jl_atomic_load_acquire(&jl_world_counter);
         size_t min_valid = 0;
         size_t max_valid = ~(size_t)0;
         matc = _gf_invoke_lookup((jl_value_t*)tt, mt, world, 0, &min_valid, &max_valid);
@@ -2007,9 +2139,8 @@ static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_methcach
             JL_GC_PUSH1(&matc);
             jl_method_t *m = matc->method;
             jl_svec_t *env = matc->sparams;
-            // tt was just proven absent above and no method cache insertion has
-            // happened since, so cache_method can skip its redundant re-check.
-            mi = cache_method(mt, mc, &mc->cache, (jl_value_t*)mc, tt, m, world, min_valid, max_valid, env, tt_known_absent);
+            // TODO: get mi from jl_specializations_get_linfo?
+            mi = cache_result(mt, mc, &mc->cache, (jl_value_t*)mc, tt, m, world, min_valid, max_valid, current_world, env, tt_known_absent);
             JL_GC_POP();
             return mi;
         }
@@ -2388,7 +2519,7 @@ JL_DLLEXPORT void jl_method_instance_add_backedge(jl_method_instance_t *callee, 
     JL_LOCK(&callee->def.method->writelock);
     if (jl_atomic_load_relaxed(&allow_new_worlds)) {
         jl_array_t *backedges = jl_mi_get_backedges(callee);
-        // TODO: use jl_cache_type_(invokesig) like cache_method does to save memory
+        // TODO: use jl_cache_type_(invokesig) like cache_insert does to save memory
         if (!backedges) {
             // lazy-init the backedges array
             backedges = jl_alloc_vec_any(0);
@@ -2431,7 +2562,7 @@ static void _typename_add_backedge(jl_typename_t *tn, int explct, void *env0)
     // check if the edge is already present and avoid adding a duplicate
     size_t i, l = jl_array_nrows(backedges);
     // reuse an already cached instance of this type, if possible
-    // TODO: use jl_cache_type_(tt) like cache_method does, instead of this linear scan?
+    // TODO: use jl_cache_type_(tt) like cache_insert does, instead of this linear scan?
     // TODO: use as_global_root and de-dup edges array too
     for (i = 1; i < l; i += 2) {
         if (jl_array_ptr_ref(backedges, i) == env->caller) {
@@ -2543,14 +2674,14 @@ static void _typename_invalidate_backedges(jl_typename_t *tn, int explct, void *
 }
 
 struct invalidate_mt_env {
-    jl_typemap_entry_t *newentry;
+    jl_value_t *newentry_sig;
     jl_array_t *shadowed;
     size_t max_world;
 };
 static int invalidate_mt_cache(jl_typemap_entry_t *oldentry, void *closure0)
 {
     struct invalidate_mt_env *env = (struct invalidate_mt_env*)closure0;
-    JL_GC_PROMISE_ROOTED(env->newentry);
+    JL_GC_PROMISE_ROOTED(env->newentry_sig);
     if (jl_atomic_load_relaxed(&oldentry->max_world) == ~(size_t)0) {
         jl_method_instance_t *mi = oldentry->func.linfo;
         int intersects = 0;
@@ -2565,14 +2696,14 @@ static int invalidate_mt_cache(jl_typemap_entry_t *oldentry, void *closure0)
         if (intersects && (jl_value_t*)oldentry->sig != mi->specTypes) {
             // the entry may point to a widened MethodInstance, in which case it is worthwhile to check if the new method
             // actually has any meaningful intersection with the old one
-            intersects = !jl_has_empty_intersection((jl_value_t*)oldentry->sig, (jl_value_t*)env->newentry->sig);
+            intersects = !jl_has_empty_intersection((jl_value_t*)oldentry->sig, env->newentry_sig);
         }
         if (intersects && oldentry->guardsigs != jl_emptysvec) {
             // similarly, if it already matches an existing guardsigs, this is already safe to keep
             size_t i, l;
             for (i = 0, l = jl_svec_len(oldentry->guardsigs); i < l; i++) {
                 // see corresponding code in jl_typemap_entry_assoc_exact
-                if (jl_subtype((jl_value_t*)env->newentry->sig, jl_svecref(oldentry->guardsigs, i))) {
+                if (jl_subtype(env->newentry_sig, jl_svecref(oldentry->guardsigs, i))) {
                     intersects = 0;
                     break;
                 }
@@ -3158,7 +3289,7 @@ void jl_method_table_activate(jl_typemap_entry_t *newentry)
         struct invalidate_mt_env mt_cache_env;
         mt_cache_env.max_world = max_world;
         mt_cache_env.shadowed = oldmi;
-        mt_cache_env.newentry = newentry;
+        mt_cache_env.newentry_sig = (jl_value_t*)newentry->sig;
 
         jl_typemap_visitor(jl_atomic_load_relaxed(&mc->cache), invalidate_mt_cache, (void*)&mt_cache_env);
         jl_genericmemory_t *leafcache = jl_atomic_load_relaxed(&mc->leafcache);
@@ -3308,12 +3439,14 @@ JL_DLLEXPORT jl_value_t *jl_matching_methods(jl_tupletype_t *types, jl_value_t *
 JL_DLLEXPORT jl_method_instance_t *jl_get_unspecialized(jl_method_t *def JL_PROPAGATES_ROOT)
 {
     // one unspecialized version of a function can be shared among all cached specializations
-    if (!jl_is_method(def) || def->source == NULL) {
+    if (!jl_is_method(def)) {
         // generated functions might instead randomly just never get inferred, sorry
         return (jl_method_instance_t*)jl_nothing;
     }
     jl_method_instance_t *unspec = jl_atomic_load_relaxed(&def->unspecialized);
     if (unspec == NULL) {
+        if (def->source == NULL)
+            return (jl_method_instance_t*)jl_nothing;
         JL_LOCK(&def->writelock);
         unspec = jl_atomic_load_relaxed(&def->unspecialized);
         if (unspec == NULL) {
@@ -3408,7 +3541,7 @@ static void record_precompile_statement(jl_method_instance_t *mi, double compila
     uint8_t force_trace_compile = jl_atomic_load_relaxed(&jl_force_trace_compile_timing_enabled);
     if (force_trace_compile == 0 && jl_options.trace_compile == NULL)
         return;
-    if (!jl_is_method(def))
+    if (!jl_is_method(def) || jl_is_builtinfunc(def))
         return;
     if (def->is_for_opaque_closure)
         return; // OpaqueClosure methods cannot be looked up by their types, so are incompatible with `precompile(...)`
@@ -3557,9 +3690,50 @@ JL_DLLEXPORT jl_method_instance_t *jl_normalize_to_compilable_mi(jl_method_insta
 JL_DLLEXPORT void jl_add_codeinsts_to_jit(jl_array_t *codeinsts, jl_array_t *srcs)
 {
     assert(jl_array_dim0(codeinsts) == jl_array_dim0(srcs));
+    size_t ncodeinsts = jl_array_dim0(codeinsts);
     jl_emit_codeinsts_to_jit((jl_code_instance_t **)jl_array_ptr_data(codeinsts),
                              (jl_code_info_t **)jl_array_ptr_data(srcs),
-                             jl_array_dim0(codeinsts));
+                             ncodeinsts);
+    // since the user just injected new code for mi,
+    // drop any currently unspecialized caches for mi,
+    // this ensures they can be recomputed on the next dispatch
+    jl_array_t *shadowed = NULL;
+    JL_GC_PUSH1(&shadowed);
+    jl_methcache_t *mc = jl_method_table->cache;
+    JL_LOCK(&mc->writelock);
+    for (size_t i = 0; i < ncodeinsts; i++) {
+        jl_code_instance_t *codeinst = (jl_code_instance_t*)jl_array_ptr_ref(codeinsts, i);
+        jl_method_instance_t *mi = (jl_method_instance_t*)codeinst->def;
+        if (!jl_is_method(mi->def.method))
+            continue;
+        jl_method_t *m = mi->def.method;
+        jl_method_instance_t *unspecialized = jl_atomic_load_relaxed(&m->unspecialized);
+        if (unspecialized == NULL)
+            continue;
+        if (!shadowed)
+            shadowed = jl_alloc_vec_any(1);
+        jl_array_ptr_set(shadowed, 0, (jl_value_t*)unspecialized);
+        struct invalidate_mt_env mt_cache_env;
+        mt_cache_env.max_world = 0;
+        mt_cache_env.shadowed = shadowed;
+        mt_cache_env.newentry_sig = mi->specTypes;
+        jl_typemap_visitor(jl_atomic_load_relaxed(&mc->cache), invalidate_mt_cache, (void*)&mt_cache_env);
+        jl_genericmemory_t *leafcache = jl_atomic_load_relaxed(&mc->leafcache);
+        size_t i, l = leafcache->length;
+        for (i = 1; i < l; i += 2) {
+            jl_value_t *entry = jl_genericmemory_ptr_ref(leafcache, i);
+            if (entry) {
+                while (entry != jl_nothing) {
+                    jl_method_instance_t *cacheli = ((jl_typemap_entry_t*)entry)->func.linfo;
+                    if (cacheli == unspecialized)
+                        jl_atomic_store_relaxed(&((jl_typemap_entry_t*)entry)->max_world, 0);
+                    entry = (jl_value_t*)jl_atomic_load_relaxed(&((jl_typemap_entry_t*)entry)->next);
+                }
+            }
+        }
+    }
+    JL_UNLOCK(&mc->writelock);
+    JL_GC_POP();
 }
 
 JL_DLLEXPORT int jl_method_is_macro(jl_method_t *m)
@@ -3567,9 +3741,16 @@ JL_DLLEXPORT int jl_method_is_macro(jl_method_t *m)
     return jl_symbol_name(m->name)[0] == '@';
 }
 
-jl_code_instance_t *copy_to_mi_cache(jl_method_instance_t *mi, jl_code_instance_t *codeinst2)
+int need_copy_to_mi_cache(jl_method_instance_t *mi, jl_method_instance_t *mi2,
+    enum internal_compilation_triggers cause)
 {
-    jl_code_instance_t *codeinst = jl_get_method_inferred(
+    return cause == TRIGGER_FOREIGN ||
+        !jl_egal((jl_value_t*)mi->sparam_vals, (jl_value_t*)mi2->sparam_vals);
+}
+
+jl_code_instance_t *copy_to_mi_cache(jl_method_instance_t *mi JL_PROPAGATES_ROOT, jl_code_instance_t *codeinst2)
+{
+    jl_code_instance_t *codeinst = jl_get_method_uninferred(
             mi, codeinst2->rettype,
             jl_atomic_load_relaxed(&codeinst2->min_world),
             jl_atomic_load_relaxed(&codeinst2->max_world), // TODO: use min(max_world, current_world) here
@@ -3578,7 +3759,8 @@ jl_code_instance_t *copy_to_mi_cache(jl_method_instance_t *mi, jl_code_instance_
     if (jl_atomic_load_relaxed(&codeinst->invoke) == NULL) {
         // TODO: add edges and jl_promote_ci_to_current here
         codeinst->rettype_const = codeinst2->rettype_const;
-        jl_gc_wb(codeinst, codeinst->rettype_const);
+        if (codeinst->rettype_const)
+            jl_gc_wb(codeinst, codeinst->rettype_const);
         uint8_t specsigflags;
         jl_callptr_t invoke;
         void *fptr;
@@ -3607,25 +3789,58 @@ jl_code_instance_t *copy_to_mi_cache(jl_method_instance_t *mi, jl_code_instance_
     return codeinst;
 }
 
-jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t world)
+// a cacheable sig is normally the same as a compileable sig
+// except in the case where we can't execute the compileable sig without copying
+// (because of jl_fptr_sparam environment usage)
+static jl_value_t *normalize_to_cacheable_sig(jl_method_instance_t *mi)
 {
-    // quick check if we already have a compiled result
-    jl_code_instance_t *codeinst = jl_method_compiled(mi, world);
-    if (codeinst)
-        return codeinst;
-
-    // if mi has a better (wider) signature preferred for compilation use that
-    // instead and just copy it here for caching
     jl_method_instance_t *mi2 = jl_normalize_to_compilable_mi(mi);
-    if (mi2 != mi) {
-        codeinst = jl_compile_method_internal(mi2, world);
-        // don't call record_precompile_statement here, since we already compiled it as mi2 which is better
-        codeinst = copy_to_mi_cache(mi, codeinst);
+    if (mi != mi2 && need_copy_to_mi_cache(mi, mi2, TRIGGER_NONE)) // rarely true
+        mi2 = mi;
+    return mi2->specTypes;
+}
+
+static jl_code_instance_t *jl_compile_method_very_internal(jl_method_instance_t *mi JL_PROPAGATES_ROOT, size_t world,
+    jl_value_t *F, jl_value_t **args, uint32_t nargs,
+    enum internal_compilation_triggers cause)
+{
+    // Quick check if we already have a compiled result
+    // (which also catches any builtin functions).
+    jl_code_instance_t *codeinst = jl_method_compiled(mi, world);
+    if (codeinst) {
+        promote_cache_method(F, args, nargs, world, mi, normalize_to_cacheable_sig(mi), cause);
         return codeinst;
     }
 
-    int compile_option = jl_options.compile_enabled;
+    // And additionally we want to catch OpaqueClosure explicitly, since it is not a Builtin subtype,
+    // but many of the code paths here would be invalid if we reached them.
     jl_method_t *def = mi->def.method;
+    if (def == jl_opaque_closure_method) {
+        codeinst = jl_method_compiled(def->unspecialized, world);
+        promote_cache_method(F, args, nargs, world, mi, def->sig, cause);
+        return codeinst;
+    }
+
+    // We don't really want to compile (or infer) unspecialized, since it confuses various heuristics and caches,
+    // so re-acquire the specialized MethodInstance, and work forward with that
+    if (jl_is_method(def) && mi == def->unspecialized) {
+        if (F) {
+            jl_tupletype_t *tt = arg_type_tuple(F, args, nargs + 1);
+            jl_svec_t *env = NULL;
+            JL_GC_PUSH2(&tt, &env);
+            // this just calls jl_subtype_env (since we know that `tt <: def->sig`)
+            jl_value_t *ti = jl_type_intersection_env((jl_value_t*)tt, (jl_value_t*)def->sig, &env);
+            assert(ti != jl_bottom_type); (void)ti;
+            mi = jl_specializations_get_linfo(def, (jl_value_t*)tt, env);
+            JL_GC_POP();
+        }
+        else {
+            mi = jl_specializations_get_linfo(def, mi->specTypes, mi->sparam_vals);
+        }
+    }
+
+    jl_method_instance_t *mi2 = mi;
+    int compile_option = jl_options.compile_enabled;
     // disabling compilation per-module can override global setting
     if (jl_is_method(def)) {
         int mod_setting = jl_get_module_compile(((jl_method_t*)def)->module);
@@ -3635,33 +3850,26 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
     }
 
     // if compilation is disabled or source is unavailable, try calling unspecialized version
-    if (compile_option == JL_OPTIONS_COMPILE_OFF ||
-        compile_option == JL_OPTIONS_COMPILE_MIN ||
-        (jl_is_method(def) && def->source == jl_nothing)) {
-        // copy fptr from the template method definition
-        if (jl_is_method(def)) {
-            jl_method_instance_t *unspecmi = jl_atomic_load_relaxed(&def->unspecialized);
-            if (unspecmi) {
-                jl_code_instance_t *unspec = jl_atomic_load_relaxed(&unspecmi->cache);
-                if (unspec && jl_atomic_load_acquire(&unspec->invoke) != NULL) {
-                    uint8_t specsigflags;
-                    jl_callptr_t invoke;
-                    void *fptr;
-                    jl_read_codeinst_invoke(unspec, &specsigflags, &invoke, &fptr, 1);
-                    jl_debuginfo_t *di = NULL;
-                    jl_svec_t *edges = jl_emptysvec;
-                    jl_code_instance_t *codeinst = jl_new_codeinst(mi, jl_nothing,
-                        (jl_value_t*)jl_any_type, (jl_value_t*)jl_any_type, NULL, NULL,
-                        0, 1, ~(size_t)0, 0, jl_nothing, di, edges);
-                    codeinst->rettype_const = unspec->rettype_const;
-                    jl_atomic_store_relaxed(&codeinst->specptr.fptr, fptr);
-                    jl_atomic_store_relaxed(&codeinst->invoke, invoke);
-                    // unspec is probably not specsig, but might be using specptr
-                    jl_atomic_store_relaxed(&codeinst->flags, specsigflags & JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR);
-                    jl_mi_cache_insert(mi, codeinst);
-                    record_precompile_statement(mi, 0, 0);
+    if (jl_is_method(def)) {
+        if (compile_option == JL_OPTIONS_COMPILE_OFF ||
+            compile_option == JL_OPTIONS_COMPILE_MIN ||
+            def->source == jl_nothing) {
+            // copy fptr from the template method definition, if present
+            jl_method_instance_t *unspec = jl_atomic_load_relaxed(&def->unspecialized);
+            if (unspec) {
+                codeinst = jl_atomic_load_relaxed(&unspec->cache);
+                if (codeinst && jl_atomic_load_acquire(&codeinst->invoke) != NULL) {
+                    if (need_copy_to_mi_cache(mi, unspec, cause)) {
+                        codeinst = copy_to_mi_cache(mi, codeinst);
+                        mi2 = mi;
+                    }
+                    else {
+                        mi2 = unspec;
+                    }
+                    promote_cache_method(F, args, nargs, world, mi2, mi == mi2 ? mi->specTypes : normalize_to_cacheable_sig(mi), cause);
                     return codeinst;
                 }
+                codeinst = NULL;
             }
         }
     }
@@ -3678,17 +3886,13 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
                 0, 1, ~(size_t)0, 0, jl_nothing, di, edges);
             jl_atomic_store_release(&codeinst->invoke, jl_fptr_interpret_call);
             jl_mi_cache_insert(mi, codeinst);
-            record_precompile_statement(mi, 0, 0);
+            promote_cache_method(F, args, nargs, world, mi, mi == mi2 ? mi->specTypes : normalize_to_cacheable_sig(mi), cause);
             return codeinst;
-        }
-        if (compile_option == JL_OPTIONS_COMPILE_OFF) {
-            jl_printf(JL_STDERR, "No compiled code available for ");
-            jl_static_show(JL_STDERR, (jl_value_t*)mi);
-            jl_printf(JL_STDERR, " : sysimg may not have been built with --compile=all\n");
         }
     }
 
     // Ok, compilation is enabled. We'll need to try to compile something (probably).
+    jl_atomic_store_relaxed(&mi->precompile, 1);
 
     // Everything from here on is considered (user facing) compile time
     uint64_t compilation_start = jl_hrtime();
@@ -3715,10 +3919,23 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
         codeinst = jl_type_infer(mi, world, SOURCE_MODE_ABI, jl_options.trim);
 
     if (codeinst) {
+        mi2 = jl_get_ci_mi(codeinst);
+        if (mi2 != mi) {
+            if (need_copy_to_mi_cache(mi, mi2, cause)) {
+                codeinst = copy_to_mi_cache(mi, codeinst);
+                mi2 = mi;
+            }
+        }
         if (jl_is_compiled_codeinst(codeinst)) {
+            promote_cache_method(F, args, nargs, world, mi2, mi2->specTypes, cause);
             jl_typeinf_timing_end(inference_start, is_recompile);
             // Already compiled - e.g. constabi, or compiled by a different thread while we were waiting.
             return codeinst;
+        }
+        if (compile_option == JL_OPTIONS_COMPILE_OFF) {
+            jl_printf(JL_STDERR, "No compiled code available for ");
+            jl_static_show(JL_STDERR, (jl_value_t*)mi);
+            jl_printf(JL_STDERR, " : sysimg may not have been built with --compile=all\n");
         }
 
         JL_GC_PUSH1(&codeinst);
@@ -3735,46 +3952,57 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
         JL_GC_POP();
     }
     if (!codeinst) {
-        jl_method_instance_t *unspec = jl_get_unspecialized(def);
-        if ((jl_value_t*)unspec == jl_nothing)
-            unspec = mi;
-        jl_code_instance_t *ucache = jl_get_method_inferred(unspec, (jl_value_t*)jl_any_type, 1, ~(size_t)0, NULL, NULL);
-        // ask codegen to make the fptr for unspec
-        jl_callptr_t ucache_invoke = jl_atomic_load_acquire(&ucache->invoke);
-        if (ucache_invoke == NULL) {
-            if ((!jl_is_method(def) || def->source == jl_nothing) &&
-                !jl_cached_uninferred(jl_atomic_load_relaxed(&jl_get_ci_mi(ucache)->cache), world)) {
-                jl_throw(jl_new_struct(jl_missingcodeerror_type, (jl_value_t*)mi));
+        // primarily a bootstrapping fallback--use default heuristics
+        // and try to populate some caches
+        mi2 = jl_normalize_to_compilable_mi(mi);
+        if (mi != mi2) {
+            codeinst = jl_compile_method_very_internal(mi2, world, F, args, nargs, cause);
+            if (need_copy_to_mi_cache(mi, mi2, cause)) {
+                codeinst = copy_to_mi_cache(mi2, codeinst);
+                mi2 = mi;
             }
-            jl_generate_fptr_for_unspecialized(ucache);
-            ucache_invoke = jl_atomic_load_acquire(&ucache->invoke);
+            else {
+                return codeinst;
+            }
         }
-        assert(ucache_invoke != NULL);
-        if (ucache_invoke != jl_fptr_sparam &&
-            ucache_invoke != jl_fptr_interpret_call) {
-            // only these care about the exact specTypes, otherwise we can use it directly
-            jl_typeinf_timing_end(inference_start, is_recompile);
-            return ucache;
+        else {
+            codeinst = jl_method_inferred_with_abi(mi, world);
+            if (!codeinst) {
+                jl_method_instance_t *unspec = jl_get_unspecialized(def);
+                if ((jl_value_t*)unspec == jl_nothing)
+                    unspec = mi;
+                else
+                    codeinst = jl_method_compiled(unspec, world);
+                if (!codeinst || jl_atomic_load_relaxed(&codeinst->invoke) == NULL) {
+                    codeinst = jl_get_method_uninferred(unspec, (jl_value_t*)jl_any_type, 1, ~(size_t)0, NULL, NULL);
+                    // ask codegen to make the fptr for unspec
+                    jl_callptr_t ucache_invoke = jl_atomic_load_acquire(&codeinst->invoke);
+                    if (ucache_invoke == NULL) {
+                        if ((!jl_is_method(def) || def->source == jl_nothing) &&
+                            !jl_cached_uninferred(jl_atomic_load_relaxed(&jl_get_ci_mi(codeinst)->cache), world)) {
+                            jl_throw(jl_new_struct(jl_missingcodeerror_type, (jl_value_t*)mi));
+                        }
+                        jl_generate_fptr_for_unspecialized(codeinst);
+                    }
+                }
+                if (need_copy_to_mi_cache(mi, unspec, cause)) {
+                    // only these care about the exact specTypes (actually sparam_vals), otherwise we can use it directly
+                    codeinst = copy_to_mi_cache(mi, codeinst);
+                }
+                else {
+                    mi2 = unspec;
+                }
+            }
         }
-        uint8_t specsigflags;
-        jl_callptr_t invoke;
-        void *fptr;
-        jl_read_codeinst_invoke(ucache, &specsigflags, &invoke, &fptr, 1);
-        jl_debuginfo_t *di = NULL;
-        jl_svec_t *edges = jl_emptysvec;
-        codeinst = jl_new_codeinst(mi, jl_nothing,
-            (jl_value_t*)jl_any_type, (jl_value_t*)jl_any_type, NULL, NULL,
-            0, 1, ~(size_t)0, 0, jl_nothing, di, edges);
-        codeinst->rettype_const = ucache->rettype_const;
-        // unspec is always not specsig, but might use specptr
-        jl_atomic_store_relaxed(&codeinst->specptr.fptr, fptr);
-        jl_atomic_store_relaxed(&codeinst->invoke, invoke);
-        jl_atomic_store_relaxed(&codeinst->flags, specsigflags & JL_CI_FLAGS_INVOKE_MATCHES_SPECPTR);
-        jl_mi_cache_insert(mi, codeinst);
     }
-    jl_atomic_store_relaxed(&codeinst->precompile, 1);
+    promote_cache_method(F, args, nargs, world, mi2, mi == mi2 ? mi->specTypes : normalize_to_cacheable_sig(mi), cause);
     jl_typeinf_timing_end(inference_start, is_recompile);
     return codeinst;
+}
+
+jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t world)
+{
+    return jl_compile_method_very_internal(mi, world, NULL, NULL, 0, TRIGGER_FOREIGN);
 }
 
 jl_value_t *jl_fptr_const_return(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *m)
@@ -3876,7 +4104,7 @@ JL_DLLEXPORT jl_value_t *jl_normalize_to_compilable_sig(jl_tupletype_t *ti, jl_s
     return (!return_if_compileable || is_compileable) ? (jl_value_t*)tt : jl_nothing;
 }
 
-jl_method_instance_t *jl_normalize_to_compilable_mi(jl_method_instance_t *mi JL_PROPAGATES_ROOT)
+JL_DLLEXPORT jl_method_instance_t *jl_normalize_to_compilable_mi(jl_method_instance_t *mi JL_PROPAGATES_ROOT)
 {
     jl_method_t *def = mi->def.method;
     if (!jl_is_method(def) || !jl_is_datatype(mi->specTypes) || def->is_for_opaque_closure)
@@ -4002,59 +4230,13 @@ JL_DLLEXPORT jl_value_t *jl_get_compile_hint_specialization(jl_tupletype_t *type
     return mi;
 }
 
-static void _generate_from_hint(jl_method_instance_t *mi, size_t world)
-{
-    jl_value_t *codeinst = jl_rettype_inferred_native(mi, world, world);
-    if (codeinst == jl_nothing) {
-        (void)jl_type_infer(mi, world, SOURCE_MODE_NOT_REQUIRED, jl_options.trim);
-        codeinst = jl_rettype_inferred_native(mi, world, world);
-    }
-    if (codeinst != jl_nothing) {
-        if (jl_atomic_load_relaxed(&((jl_code_instance_t*)codeinst)->invoke) == jl_fptr_const_return)
-            return; // probably not a good idea to generate code
-        jl_atomic_store_relaxed(&((jl_code_instance_t*)codeinst)->precompile, 1);
-    }
-}
-
-static void jl_compile_now(jl_method_instance_t *mi)
-{
-    size_t world = jl_atomic_load_acquire(&jl_world_counter);
-    size_t tworld = jl_typeinf_world;
-    _generate_from_hint(mi, world);
-    if (jl_typeinf_func && jl_atomic_load_relaxed(&mi->def.method->primary_world) <= tworld) {
-        // if it's part of the compiler, also attempt to compile for the compiler world too
-        _generate_from_hint(mi, tworld);
-    }
-}
-
 JL_DLLEXPORT void jl_compile_method_instance(jl_method_instance_t *mi, jl_tupletype_t *types, size_t world)
 {
-    size_t tworld = jl_typeinf_world;
     uint8_t miflags = jl_atomic_load_relaxed(&mi->flags) | JL_MI_FLAGS_MASK_PRECOMPILED;
     jl_atomic_store_relaxed(&mi->flags, miflags);
     if (jl_generating_output()) {
-        jl_compile_now(mi);
-        // In addition to full compilation of the compilation-signature, if `types` is more specific (e.g. due to nospecialize),
-        // also run inference now on the original `types`, since that may help us guide inference to find
-        // additional useful methods that should be compiled
-        //ALT: if (jl_is_datatype(types) && ((jl_datatype_t*)types)->isdispatchtuple && !jl_egal(mi->specTypes, types))
-        //ALT: if (jl_subtype(types, mi->specTypes))
-        if (types && !jl_subtype(mi->specTypes, (jl_value_t*)types)) {
-            jl_svec_t *tpenv2 = jl_emptysvec;
-            jl_value_t *types2 = NULL;
-            JL_GC_PUSH2(&tpenv2, &types2);
-            types2 = jl_type_intersection_env((jl_value_t*)types, (jl_value_t*)mi->def.method->sig, &tpenv2);
-            jl_method_instance_t *mi2 = jl_specializations_get_linfo(mi->def.method, (jl_value_t*)types2, tpenv2);
-            JL_GC_POP();
-            miflags = jl_atomic_load_relaxed(&mi2->flags) | JL_MI_FLAGS_MASK_PRECOMPILED;
-            jl_atomic_store_relaxed(&mi2->flags, miflags);
-            if (jl_rettype_inferred_native(mi2, world, world) == jl_nothing)
-                (void)jl_type_infer(mi2, world, SOURCE_MODE_NOT_REQUIRED, jl_options.trim);
-            if (jl_typeinf_func && jl_atomic_load_relaxed(&mi->def.method->primary_world) <= tworld) {
-                if (jl_rettype_inferred_native(mi2, tworld, tworld) == jl_nothing)
-                    (void)jl_type_infer(mi2, tworld, SOURCE_MODE_NOT_REQUIRED, jl_options.trim);
-            }
-        }
+        jl_atomic_store_relaxed(&mi->precompile, 1);
+        jl_push_newly_inferred((jl_value_t*)mi);
     }
     else {
         // Otherwise (this branch), assuming we are at runtime (normal JIT) and
@@ -4149,7 +4331,8 @@ STATIC_INLINE jl_value_t *verify_type(jl_value_t *v) JL_NOTSAFEPOINT
     return v;
 }
 
-STATIC_INLINE jl_value_t *_jl_invoke(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_method_instance_t *mfunc, size_t world)
+STATIC_INLINE jl_value_t *_jl_invoke(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_method_instance_t *mfunc, size_t world,
+   enum internal_compilation_triggers cause)
 {
     jl_code_instance_t *codeinst = NULL;
     jl_callptr_t invoke = jl_method_compiled_callptr(mfunc, world, &codeinst);
@@ -4162,7 +4345,7 @@ STATIC_INLINE jl_value_t *_jl_invoke(jl_value_t *F, jl_value_t **args, uint32_t 
 #ifdef _OS_WINDOWS_
     DWORD last_error = GetLastError();
 #endif
-    codeinst = jl_compile_method_internal(mfunc, world);
+    codeinst = jl_compile_method_very_internal(mfunc, world, F, args, nargs, cause);
 #ifdef _OS_WINDOWS_
     SetLastError(last_error);
 #endif
@@ -4177,7 +4360,7 @@ STATIC_INLINE jl_value_t *_jl_invoke(jl_value_t *F, jl_value_t **args, uint32_t 
 JL_DLLEXPORT jl_value_t *jl_invoke(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_method_instance_t *mfunc)
 {
     size_t world = jl_current_task->world_age;
-    return _jl_invoke(F, args, nargs, mfunc, world);
+    return _jl_invoke(F, args, nargs, mfunc, world, TRIGGER_FOREIGN);
 }
 
 // Used by jl_eval_thunk to invoke top-level thunks.  They will be
@@ -4192,7 +4375,7 @@ JL_DLLEXPORT jl_value_t *jl_invoke_oneshot(jl_value_t *F, jl_value_t **args, uin
 #ifdef _OS_WINDOWS_
     DWORD last_error = GetLastError();
 #endif
-    jl_code_instance_t *codeinst = jl_compile_method_internal(mfunc, world);
+    jl_code_instance_t *codeinst = jl_compile_method_very_internal(mfunc, world, F, args, nargs, TRIGGER_NONE);
     if (jl_options.malloc_log)
         jl_gc_sync_total_bytes(last_alloc); // discard allocation count from compilation
     uint8_t specsigflags;
@@ -4216,7 +4399,7 @@ JL_DLLEXPORT jl_value_t *jl_invoke_oc(jl_value_t *F, jl_value_t **args, uint32_t
     size_t last_age = ct->world_age;
     size_t world = oc->world;
     ct->world_age = world;
-    jl_value_t *ret = _jl_invoke(F, args, nargs, mfunc, world);
+    jl_value_t *ret = _jl_invoke(F, args, nargs, mfunc, world, TRIGGER_NONE);
     ct->world_age = last_age;
     return ret;
 }
@@ -4271,7 +4454,7 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
     if (traceen && for_call)
         show_call(F, args, nargs);
 #endif
-    nargs++; // add F to argument count
+    nargs++; // add f to argument count
     jl_value_t *FT = jl_typeof(F);
 
     /*
@@ -4408,7 +4591,7 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t *F, jl_value_t **args, uint
                                                      jl_int32hash_fast(jl_return_address()),
                                                      world, 1);
     JL_GC_PROMISE_ROOTED(mfunc);
-    return _jl_invoke(F, args, nargs, mfunc, world);
+    return _jl_invoke(F, args, nargs, mfunc, world, TRIGGER_DISPATCH);
 }
 
 // buggy way to lookup a method given a list of arguments
@@ -4427,7 +4610,7 @@ JL_DLLEXPORT jl_method_instance_t *jl_method_lookup(jl_value_t **args, size_t na
     return mi;
 }
 
-static jl_method_match_t *_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT, jl_methtable_t *mt, size_t world, int cache_result, size_t *min_valid, size_t *max_valid)
+static jl_method_match_t *_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT, jl_methtable_t *mt, size_t world, int cache_result_recursion, size_t *min_valid, size_t *max_valid)
 {
     jl_value_t *unw = jl_unwrap_unionall((jl_value_t*)types);
     if (!jl_is_tuple_type(unw))
@@ -4435,7 +4618,7 @@ static jl_method_match_t *_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT
     if (jl_tparam0(unw) == jl_bottom_type)
         return NULL;
     jl_methcache_t *mc = ((jl_methtable_t*)mt)->cache;
-    jl_value_t *matches = ml_matches((jl_methtable_t*)mt, mc, (jl_tupletype_t*)types, 1, 0, 0, world, cache_result, min_valid, max_valid, NULL);
+    jl_value_t *matches = ml_matches((jl_methtable_t*)mt, mc, (jl_tupletype_t*)types, 1, 0, 0, world, cache_result_recursion, min_valid, max_valid, NULL);
     if (matches == jl_nothing || jl_array_nrows(matches) != 1)
         return NULL;
     jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(matches, 0);
@@ -4522,7 +4705,8 @@ jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value
                 int sub = jl_subtype_matching((jl_value_t*)tt, (jl_value_t*)method->sig, &tpenv);
                 assert(sub); (void)sub;
             }
-            mfunc = cache_method(NULL, NULL, &method->invokes, (jl_value_t*)method, tt, method, 1, 1, ~(size_t)0, tpenv, /*tt_known_absent*/0);
+            // TODO: get this mi from jl_specializations_get_linfo instead?
+            mfunc = cache_result(NULL, NULL, &method->invokes, (jl_value_t*)method, tt, method, 1, 1, 1, 1, tpenv, /*tt_known_absent*/0);
         }
         JL_UNLOCK(&method->writelock);
         JL_GC_POP();
@@ -4541,7 +4725,7 @@ jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value
         }
     }
     size_t world = jl_current_task->world_age;
-    return _jl_invoke(gf, args, nargs - 1, mfunc, world);
+    return _jl_invoke(gf, args, nargs - 1, mfunc, world, TRIGGER_INVOKE);
 }
 
 jl_sym_t *jl_gf_supertype_name(jl_sym_t *name)
@@ -4954,10 +5138,11 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
 // which is dominated by one which is (and thus should be excluded unless ambiguous)
 static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
                               jl_tupletype_t *type, int lim, int include_ambiguous,
-                              int intersections, size_t world, int cache_result,
+                              int intersections, size_t world, int cache_result_recursion,
                               size_t *min_valid, size_t *max_valid, int *ambig)
 {
-    if (world > jl_atomic_load_acquire(&jl_world_counter))
+    size_t current_world = jl_atomic_load_acquire(&jl_world_counter);
+    if (world > current_world)
         return jl_nothing; // the future is not enumerable
     JL_TIMING(METHOD_MATCH, METHOD_MATCH);
     int has_ambiguity = 0;
@@ -5260,7 +5445,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
         if (env.match.min_valid < min_world)
             env.match.min_valid = min_world;
     }
-    if (mc && cache_result && ((jl_datatype_t*)unw)->isdispatchtuple) { // cache_result parameter keeps this from being recursive
+    if (mc && cache_result_recursion && ((jl_datatype_t*)unw)->isdispatchtuple) { // cache_result_recursion prevents lock confusion and unnecessary work
         if (len == 1 && !has_ambiguity) {
             env.matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, 0);
             jl_method_t *meth = env.matc->method;
@@ -5270,7 +5455,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
             // through the full-cache check above to recompute min_world exactly),
             // so cache_method must keep its own presence check to avoid a
             // duplicate insertion
-            cache_method(mt, mc, &mc->cache, (jl_value_t*)mc, (jl_tupletype_t*)unw, meth, world, env.match.min_valid, env.match.max_valid, tpenv, /*tt_known_absent*/0);
+            cache_result(mt, mc, &mc->cache, (jl_value_t*)mc, (jl_tupletype_t*)unw, meth, world, env.match.min_valid, env.match.max_valid, current_world, tpenv, /*tt_known_absent*/0);
         }
     }
     *min_valid = env.match.min_valid;
@@ -5398,9 +5583,10 @@ static int invalidate_all_specializations(jl_typemap_entry_t *def, void *closure
     return 1;
 }
 
-static int invalidate_all_caches_visitor(jl_methtable_t *mt, void *env)
+static void invalidate_all_caches(jl_methtable_t *mt, size_t current_world)
 {
-    return jl_typemap_visitor(jl_atomic_load_relaxed(&mt->defs), invalidate_all_specializations, env);
+    jl_typemap_visitor(jl_atomic_load_relaxed(&mt->defs), invalidate_all_specializations, &current_world);
+    drop_all_methcache(mt->cache);
 }
 
 JL_DLLEXPORT void jl_drop_all_caches(void)
@@ -5410,7 +5596,7 @@ JL_DLLEXPORT void jl_drop_all_caches(void)
     // Get current world age - we'll invalidate everything at this world
     size_t current_world = jl_atomic_load_relaxed(&jl_world_counter);
 
-    invalidate_all_caches_visitor(jl_method_table, &current_world);
+    invalidate_all_caches(jl_method_table, current_world);
 
     // Increment world age - this forces all subsequent compilation to happen in the new world
     size_t new_world = current_world + 1;

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -225,7 +225,6 @@
     XX(jl_get_world_counter) \
     XX(jl_get_zero_subnormals) \
     XX(jl_gf_invoke_lookup) \
-    XX(jl_method_lookup_by_tt) \
     XX(jl_method_lookup) \
     XX(jl_gf_invoke_lookup_worlds) \
     XX(jl_global_event_loop) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3879,7 +3879,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_method_instance_type =
         jl_new_datatype(jl_symbol("MethodInstance"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(8,
+                        jl_perm_symsvec(9,
                             "def",
                             "specTypes",
                             "sparam_vals",
@@ -3887,8 +3887,9 @@ void jl_init_types(void) JL_GC_DISABLED
                             "cache",
                             "cache_with_orig",
                             "flags",
-                            "dispatch_status"),
-                        jl_svec(8,
+                            "dispatch_status",
+                            "precompile"),
+                        jl_svec(9,
                             jl_new_struct(jl_uniontype_type, jl_method_type, jl_module_type),
                             jl_any_type,
                             jl_simplevector_type,
@@ -3896,12 +3897,13 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_any_type/*jl_code_instance_type*/,
                             jl_bool_type,
                             jl_bool_type,
-                            jl_uint8_type),
+                            jl_uint8_type,
+                            jl_bool_type),
                         jl_emptysvec,
                         0, 1, 3);
     // These fields should be constant, but Serialization wants to mutate them in initialization
     //const static uint32_t method_instance_constfields[1] = { 0b00000111 }; // fields 1, 2, 3
-    const static uint32_t method_instance_atomicfields[1]  = { 0b11010000 }; // fields 5, 7, 8
+    const static uint32_t method_instance_atomicfields[1]  = { 0b111010000 }; // fields 5, 7, 8, 9
     //Fields 4 and 5 must be protected by method->write_lock, and thus all operations on jl_method_instance_t are threadsafe.
     //jl_method_instance_type->name->constfields = method_instance_constfields;
     jl_method_instance_type->name->atomicfields = method_instance_atomicfields;
@@ -3909,7 +3911,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_code_instance_type =
         jl_new_datatype(jl_symbol("CodeInstance"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(21,
+                        jl_perm_symsvec(20,
                             "def",
                             "owner",
                             "next",
@@ -3928,9 +3930,9 @@ void jl_init_types(void) JL_GC_DISABLED
                             "time_infer_self",
                             "time_compile",
                             //"absolute_max",
-                            "flags", "precompile",
+                            "flags",
                             "invoke", "specptr"), // function object decls
-                        jl_svec(21,
+                        jl_svec(20,
                             jl_any_type,
                             jl_any_type,
                             jl_any_type,
@@ -3950,13 +3952,12 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_uint16_type,
                             //jl_bool_type,
                             jl_uint8_type,
-                            jl_bool_type,
                             jl_any_type, jl_any_type), // fptrs
                         jl_emptysvec,
                         0, 1, 1);
     jl_svecset(jl_code_instance_type->types, 2, jl_code_instance_type);
-    const static uint32_t code_instance_constfields[1]  = { 0b000001110000011100011 }; // Set fields 1, 2, 6-8, 14-16 as const
-    const static uint32_t code_instance_atomicfields[1] = { 0b111110001011100011100 }; // Set fields 3-5, 9-12, 13, 17-21 as atomic
+    const static uint32_t code_instance_constfields[1]  = { 0b00001110000011100011 }; // Set fields 1, 2, 6-8, 14-16 as const
+    const static uint32_t code_instance_atomicfields[1] = { 0b11110001011100011100 }; // Set fields 3-5, 9-12, 13, 17-20 as atomic
     // Fields 4-5 are only operated on by construction and deserialization, so are effectively const at runtime
     // Fields ipo_purity_bits and analysis_results are not currently threadsafe or reliable, as they get mutated after optimization, but are not declared atomic
     // and there is no way to tell (during inference) if their value is finalized yet (to wait for them to be narrowed if applicable)
@@ -4104,8 +4105,8 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_method_type->types, 14, jl_method_instance_type);
     //jl_svecset(jl_debuginfo_type->types, 0, jl_method_instance_type); // union(jl_method_instance_type, jl_method_type, jl_symbol_type)
     jl_svecset(jl_method_instance_type->types, 4, jl_code_instance_type);
+    jl_svecset(jl_code_instance_type->types, 18, jl_voidpointer_type);
     jl_svecset(jl_code_instance_type->types, 19, jl_voidpointer_type);
-    jl_svecset(jl_code_instance_type->types, 20, jl_voidpointer_type);
     jl_svecset(jl_binding_type->types, 0, jl_globalref_type);
     jl_svecset(jl_binding_type->types, 3, jl_array_any_type);
     jl_svecset(jl_binding_partition_type->types, 3, jl_binding_partition_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -929,9 +929,9 @@ struct _jl_globalref_t {
 struct _jl_typemap_entry_t {
     JL_DATA_TYPE
     _Atomic(struct _jl_typemap_entry_t*) next; // invasive linked list
-    jl_tupletype_t *sig; // the type signature for this entry
+    jl_tupletype_t *JL_NONNULL sig; // the type signature for this entry
     jl_tupletype_t *simplesig; // a simple signature for fast rejection
-    jl_svec_t *guardsigs;
+    jl_svec_t *JL_NONNULL guardsigs;
     _Atomic(size_t) min_world;
     _Atomic(size_t) max_world;
     union {
@@ -953,24 +953,24 @@ typedef struct _jl_typemap_level_t {
     // next split may be on Type{T} as LeafTypes then TypeName's parents up to Any
     // next split may be on LeafType
     // next split may be on TypeName
-    _Atomic(jl_genericmemory_t*) arg1; // contains LeafType (in a map of non-abstract TypeName)
-    _Atomic(jl_genericmemory_t*) targ; // contains Type{LeafType} (in a map of non-abstract TypeName)
-    _Atomic(jl_genericmemory_t*) name1; // a map for a map for TypeName, for parents up to (excluding) Any
-    _Atomic(jl_genericmemory_t*) tname; // a map for Type{TypeName}, for parents up to (including) Any
+    _Atomic(jl_genericmemory_t*) JL_NONNULL arg1; // contains LeafType (in a map of non-abstract TypeName)
+    _Atomic(jl_genericmemory_t*) JL_NONNULL targ; // contains Type{LeafType} (in a map of non-abstract TypeName)
+    _Atomic(jl_genericmemory_t*) JL_NONNULL name1; // a map for a map for TypeName, for parents up to (excluding) Any
+    _Atomic(jl_genericmemory_t*) JL_NONNULL tname; // a map for Type{TypeName}, for parents up to (including) Any
     // next a linear list of things too complicated at this level for analysis (no more levels)
-    _Atomic(jl_typemap_entry_t*) linear;
+    _Atomic(jl_typemap_entry_t*) JL_NONNULL linear;
     // finally, start a new level if the type at offs is Any
-    _Atomic(jl_typemap_t*) any;
+    _Atomic(jl_typemap_t*) JL_NONNULL any;
 } jl_typemap_level_t;
 
 typedef struct _jl_methcache_t {
     JL_DATA_TYPE
     // hash map from dispatchtuple type to a linked-list of TypeMapEntry
     // entry.sig == type for all entries in the linked-list
-    _Atomic(jl_genericmemory_t*) leafcache;
+    _Atomic(jl_genericmemory_t*) JL_NONNULL leafcache;
 
     // cache for querying everything else (anything that didn't seem profitable to put into leafcache)
-    _Atomic(jl_typemap_t*) cache;
+    _Atomic(jl_typemap_t*) JL_NONNULL cache;
 
     jl_mutex_t writelock;
 } jl_methcache_t;
@@ -979,24 +979,24 @@ typedef struct _jl_methcache_t {
 typedef struct _jl_methtable_t {
     JL_DATA_TYPE
     // full set of entries
-    _Atomic(jl_typemap_t*) defs;
-    jl_methcache_t *cache;
-    jl_sym_t *name; // sometimes used for debug printing
-    jl_module_t *module; // sometimes used for debug printing
+    _Atomic(jl_typemap_t*) JL_NONNULL defs;
+    jl_methcache_t *JL_NONNULL cache;
+    jl_sym_t *JL_NONNULL name; // sometimes used for debug printing
+    jl_module_t *JL_NONNULL module; // sometimes used for debug printing
     jl_genericmemory_t *backedges; // IdDict{top typenames, Vector{uncovered (sig => caller::CodeInstance)}}
 } jl_methtable_t;
 
 typedef struct {
     JL_DATA_TYPE
-    jl_sym_t *head;
-    jl_array_t *args;
+    jl_sym_t *JL_NONNULL head;
+    jl_array_t *JL_NONNULL args;
 } jl_expr_t;
 
 typedef struct {
     JL_DATA_TYPE
-    jl_tupletype_t *spec_types;
-    jl_svec_t *sparams;
-    jl_method_t *method;
+    jl_tupletype_t *JL_NONNULL spec_types;
+    jl_svec_t *JL_NONNULL sparams;
+    jl_method_t *JL_NONNULL method;
     // A bool on the julia side, but can be temporarily 0x2 as a sentinel
     // during construction.
     uint8_t fully_covers;

--- a/src/julia.h
+++ b/src/julia.h
@@ -447,6 +447,7 @@ struct _jl_method_instance_t {
     //   bit 3: The ->backedges field was modified and should be compacted when clearing bit 2
     _Atomic(uint8_t) flags;
     _Atomic(uint8_t) dispatch_status; // bits defined in staticdata.jl
+    _Atomic(uint8_t) precompile; // if set, this will be added to the output system image
 };
 #define JL_MI_FLAGS_MASK_PRECOMPILED    0x01
 #define JL_MI_FLAGS_MASK_DISPATCHED     0x02
@@ -524,7 +525,6 @@ typedef struct _jl_code_instance_t {
                             // & 0b010 == invokeptr matches specptr
                             // & 0b100 == From image
                             // & 0b1000 == native_cache_valid
-    _Atomic(uint8_t) precompile;  // if set, this will be added to the output system image
     _Atomic(jl_callptr_t) invoke; // jlcall entry point usually, but if this codeinst belongs to an OC Method, then this is an jl_fptr_args_t fptr1 instead, unless it is not, because it is a special token object instead
     union _jl_generic_specptr_t {
         _Atomic(void*) fptr;
@@ -2278,7 +2278,7 @@ JL_DLLEXPORT jl_value_t *jl_restore_incremental(const char *fname, jl_array_t *d
 JL_DLLEXPORT jl_value_t *jl_object_top_module(jl_value_t* v) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT void jl_set_newly_inferred(jl_value_t *newly_inferred);
-JL_DLLEXPORT jl_array_t* jl_compute_new_ext_cis(void);
+JL_DLLEXPORT jl_array_t* jl_compute_new_ext(void);
 JL_DLLEXPORT void jl_push_newly_inferred(jl_value_t *ci);
 JL_DLLEXPORT void jl_set_inference_entrance_backtraces(jl_value_t *inference_entrance_backtraces);
 JL_DLLEXPORT void jl_push_inference_entrance_backtraces(jl_value_t *ci);

--- a/src/julia.h
+++ b/src/julia.h
@@ -929,9 +929,9 @@ struct _jl_globalref_t {
 struct _jl_typemap_entry_t {
     JL_DATA_TYPE
     _Atomic(struct _jl_typemap_entry_t*) next; // invasive linked list
-    jl_tupletype_t *JL_NONNULL sig; // the type signature for this entry
+    jl_tupletype_t *sig; // the type signature for this entry
     jl_tupletype_t *simplesig; // a simple signature for fast rejection
-    jl_svec_t *JL_NONNULL guardsigs;
+    jl_svec_t *guardsigs;
     _Atomic(size_t) min_world;
     _Atomic(size_t) max_world;
     union {
@@ -953,24 +953,24 @@ typedef struct _jl_typemap_level_t {
     // next split may be on Type{T} as LeafTypes then TypeName's parents up to Any
     // next split may be on LeafType
     // next split may be on TypeName
-    _Atomic(jl_genericmemory_t*) JL_NONNULL arg1; // contains LeafType (in a map of non-abstract TypeName)
-    _Atomic(jl_genericmemory_t*) JL_NONNULL targ; // contains Type{LeafType} (in a map of non-abstract TypeName)
-    _Atomic(jl_genericmemory_t*) JL_NONNULL name1; // a map for a map for TypeName, for parents up to (excluding) Any
-    _Atomic(jl_genericmemory_t*) JL_NONNULL tname; // a map for Type{TypeName}, for parents up to (including) Any
+    _Atomic(jl_genericmemory_t*) arg1; // contains LeafType (in a map of non-abstract TypeName)
+    _Atomic(jl_genericmemory_t*) targ; // contains Type{LeafType} (in a map of non-abstract TypeName)
+    _Atomic(jl_genericmemory_t*) name1; // a map for a map for TypeName, for parents up to (excluding) Any
+    _Atomic(jl_genericmemory_t*) tname; // a map for Type{TypeName}, for parents up to (including) Any
     // next a linear list of things too complicated at this level for analysis (no more levels)
-    _Atomic(jl_typemap_entry_t*) JL_NONNULL linear;
+    _Atomic(jl_typemap_entry_t*) linear;
     // finally, start a new level if the type at offs is Any
-    _Atomic(jl_typemap_t*) JL_NONNULL any;
+    _Atomic(jl_typemap_t*) any;
 } jl_typemap_level_t;
 
 typedef struct _jl_methcache_t {
     JL_DATA_TYPE
     // hash map from dispatchtuple type to a linked-list of TypeMapEntry
     // entry.sig == type for all entries in the linked-list
-    _Atomic(jl_genericmemory_t*) JL_NONNULL leafcache;
+    _Atomic(jl_genericmemory_t*) leafcache;
 
     // cache for querying everything else (anything that didn't seem profitable to put into leafcache)
-    _Atomic(jl_typemap_t*) JL_NONNULL cache;
+    _Atomic(jl_typemap_t*) cache;
 
     jl_mutex_t writelock;
 } jl_methcache_t;
@@ -979,24 +979,24 @@ typedef struct _jl_methcache_t {
 typedef struct _jl_methtable_t {
     JL_DATA_TYPE
     // full set of entries
-    _Atomic(jl_typemap_t*) JL_NONNULL defs;
-    jl_methcache_t *JL_NONNULL cache;
-    jl_sym_t *JL_NONNULL name; // sometimes used for debug printing
-    jl_module_t *JL_NONNULL module; // sometimes used for debug printing
+    _Atomic(jl_typemap_t*) defs;
+    jl_methcache_t *cache;
+    jl_sym_t *name; // sometimes used for debug printing
+    jl_module_t *module; // sometimes used for debug printing
     jl_genericmemory_t *backedges; // IdDict{top typenames, Vector{uncovered (sig => caller::CodeInstance)}}
 } jl_methtable_t;
 
 typedef struct {
     JL_DATA_TYPE
-    jl_sym_t *JL_NONNULL head;
-    jl_array_t *JL_NONNULL args;
+    jl_sym_t *head;
+    jl_array_t *args;
 } jl_expr_t;
 
 typedef struct {
     JL_DATA_TYPE
-    jl_tupletype_t *JL_NONNULL spec_types;
-    jl_svec_t *JL_NONNULL sparams;
-    jl_method_t *JL_NONNULL method;
+    jl_tupletype_t *spec_types;
+    jl_svec_t *sparams;
+    jl_method_t *method;
     // A bool on the julia side, but can be temporarily 0x2 as a sentinel
     // during construction.
     uint8_t fully_covers;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -815,7 +815,7 @@ JL_DLLEXPORT int8_t jl_get_type_infer_preserve_ir(void);
 JL_DLLEXPORT void jl_set_type_infer_preserve_ir(int8_t v);
 JL_DLLEXPORT jl_code_info_t *jl_gdbcodetyped1(jl_method_instance_t *mi, size_t world);
 JL_DLLEXPORT jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *meth JL_PROPAGATES_ROOT, size_t world);
-JL_DLLEXPORT jl_code_instance_t *jl_get_method_inferred(
+JL_DLLEXPORT jl_code_instance_t *jl_get_method_uninferred(
         jl_method_instance_t *mi JL_PROPAGATES_ROOT, jl_value_t *rettype,
         size_t min_world, size_t max_world, jl_debuginfo_t *di, jl_svec_t *edges);
 JL_DLLEXPORT int jl_mi_cache_has_ci(jl_method_instance_t *mi, jl_code_instance_t *ci) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1048,8 +1048,9 @@ jl_value_t *jl_call_scm_on_ast_and_loc(const char *funcname, jl_value_t *expr,
                                        jl_module_t *inmodule, const char *file, int line);
 int jl_isa_ast_node(jl_value_t *e) JL_NOTSAFEPOINT;
 
-JL_DLLEXPORT jl_value_t *jl_method_lookup_by_tt(jl_tupletype_t *tt, size_t world, jl_value_t *_mt);
+jl_method_instance_t *jl_builtin_method_lookup(jl_value_t *builtin);
 JL_DLLEXPORT jl_method_instance_t *jl_method_lookup(jl_value_t **args, size_t nargs, size_t world);
+jl_method_instance_t *jl_apply_lookup(jl_value_t **args, size_t nargs, size_t world);
 
 jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value_t **args, size_t nargs);
 jl_value_t *jl_gf_invoke(jl_value_t *types, jl_value_t *f, jl_value_t **args, size_t nargs);
@@ -1443,7 +1444,7 @@ jl_module_t *jl_new_module_(jl_sym_t *name, jl_module_t *parent, uint8_t default
 jl_module_t *jl_add_standard_imports(jl_module_t *m);
 JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *module);
 JL_DLLEXPORT jl_methcache_t *jl_new_method_cache(void);
-JL_DLLEXPORT jl_value_t *jl_get_specialization1(jl_tupletype_t *types JL_PROPAGATES_ROOT, size_t world, int mt_cache);
+JL_DLLEXPORT jl_value_t *jl_get_specialization1(jl_tupletype_t *types JL_PROPAGATES_ROOT, size_t world);
 jl_method_instance_t *jl_get_specialized(jl_method_t *m, jl_value_t *types, jl_svec_t *sp) JL_PROPAGATES_ROOT;
 JL_DLLEXPORT jl_value_t *jl_rettype_inferred(jl_value_t *owner, jl_method_instance_t *li JL_PROPAGATES_ROOT, size_t min_world, size_t max_world);
 JL_DLLEXPORT jl_value_t *jl_rettype_inferred_native(jl_method_instance_t *mi, size_t min_world, size_t max_world) JL_NOTSAFEPOINT;

--- a/src/method.c
+++ b/src/method.c
@@ -677,6 +677,7 @@ JL_DLLEXPORT jl_method_instance_t *jl_new_method_instance_uninit(void)
     mi->cache_with_orig = 0;
     jl_atomic_store_relaxed(&mi->flags, 0);
     jl_atomic_store_relaxed(&mi->dispatch_status, 0);
+    jl_atomic_store_relaxed(&mi->precompile, 0);
     return mi;
 }
 

--- a/src/method.c
+++ b/src/method.c
@@ -1293,13 +1293,6 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
         mt = jl_method_table;
     jl_methtable_t *external_mt = mt == jl_method_table ? NULL : mt;
 
-    //if (!external_mt) {
-    //    jl_value_t **ttypes = { jl_builtin_type, jl_tparam0(jl_anytuple_type) };
-    //    jl_value_t *invalidt = jl_apply_tuple_type_v(ttypes, 2); // Tuple{Union{Builtin,OpaqueClosure}, Vararg}
-    //    if (!jl_has_empty_intersection(argtype, invalidt))
-    //        jl_error("cannot add methods to builtin function");
-    //}
-
     assert(jl_is_linenode(functionloc));
     jl_sym_t *file = (jl_sym_t*)jl_linenode_file(functionloc);
     if (!jl_is_symbol(file))

--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -116,7 +116,7 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
         jl_method_instance_t *mi_generic = jl_specializations_get_linfo(jl_opaque_closure_method, sigtype, jl_emptysvec);
 
         // OC wrapper methods are not world dependent and have no edges or other info
-        ci = jl_get_method_inferred(mi_generic, selected_rt, 1, ~(size_t)0, NULL, NULL);
+        ci = jl_get_method_uninferred(mi_generic, selected_rt, 1, ~(size_t)0, NULL, NULL);
         if (!jl_atomic_load_acquire(&ci->invoke)) {
             jl_code_info_t *src = NULL;
             jl_emit_codeinsts_to_jit(&ci, &src, 1); // confusing this actually calls jl_emit_oc_wrapper and never actually compiles ci (which would be impossible since it cannot have source)

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -936,17 +936,20 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
     }
     else if (vt == jl_method_instance_type) {
         n += jl_printf(out, "MethodInstance ");
-        jl_method_instance_t *li = (jl_method_instance_t*)v;
-        if (jl_is_method(li->def.method)) {
-            n += jl_static_show_func_sig(out, li->specTypes);
+        jl_method_instance_t *mi = (jl_method_instance_t*)v;
+        if (jl_is_method(mi->def.method)) {
+            if (mi->def.method->unspecialized == mi)
+                n += jl_printf(out, "unspecialized");
+            else
+                n += jl_static_show_func_sig(out, mi->specTypes);
             n += jl_printf(out, " from ");
-            n += jl_static_show_func_sig(out, li->def.method->sig);
+            n += jl_static_show_func_sig(out, mi->def.method->sig);
         }
         else {
-            n += jl_static_show_x(out, (jl_value_t*)li->def.module, depth, ctx);
+            n += jl_static_show_x(out, (jl_value_t*)mi->def.module, depth, ctx);
             n += jl_printf(out, ".<toplevel thunk> -> ");
             n += jl_static_show_x(out, jl_atomic_load_relaxed(&jl_cached_uninferred(
-                jl_atomic_load_relaxed(&li->cache), 1)->inferred), depth, ctx);
+                jl_atomic_load_relaxed(&mi->cache), 1)->inferred), depth, ctx);
         }
     }
     else if (vt == jl_code_instance_type && ctx.verbosity < JL_STATIC_SHOW_VERBOSITY_FULL) {

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -938,7 +938,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         n += jl_printf(out, "MethodInstance ");
         jl_method_instance_t *mi = (jl_method_instance_t*)v;
         if (jl_is_method(mi->def.method)) {
-            if (mi->def.method->unspecialized == mi)
+            if (jl_atomic_load_relaxed(&mi->def.method->unspecialized) == mi)
                 n += jl_printf(out, "unspecialized");
             else
                 n += jl_static_show_func_sig(out, mi->specTypes);

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -404,7 +404,7 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
             JL_UNLOCK(&cfun_lock);
             return f;
         }
-        mi = jl_get_specialization1((jl_tupletype_t*)sigt, world, 0);
+        mi = jl_get_specialization1((jl_tupletype_t*)sigt, world);
         if (f != NULL) {
             if (last_ci == NULL) {
                 if (mi == jl_nothing) {

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2845,25 +2845,13 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
 
             // Record MethodInstances for built-ins (used when dynamically dispatching to a
             // built-in, e.g., in the Core._apply_iterate implementation)
-            jl_datatype_t *tt = NULL;
-            JL_GC_PUSH1(&tt);
             for (size_t i = 0; i < jl_n_builtins; i++) {
                 jl_value_t *builtin = jl_builtin_instances[i];
                 if (builtin == NULL)
                     continue;
-
-                jl_datatype_t *dt = (jl_datatype_t*)jl_typeof(builtin);
-                jl_value_t *params[2];
-                params[0] = dt->name->wrapper;
-                params[1] = jl_tparam0(jl_anytuple_type);
-                tt = (jl_datatype_t*)jl_apply_tuple_type_v(params, 2);
-                jl_method_instance_t *mi = (jl_method_instance_t *)jl_method_lookup_by_tt(
-                    tt, /* world */ 1, /* mt */ jl_nothing
-                );
-                assert(!jl_is_nothing(mi));
+                jl_method_instance_t *mi = jl_builtin_method_lookup(builtin);
                 arraylist_push(&MIs, mi);
             }
-            JL_GC_POP();
         }
     }
     if (jl_options.trim) {

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2767,7 +2767,7 @@ JL_DLLEXPORT jl_value_t *jl_as_global_root(jl_value_t *val, int insert)
 // In addition to the system image (where `worklist = NULL`), this can also save incremental images with external linkage
 static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
                                            jl_array_t *module_init_order, jl_array_t *worklist, jl_array_t *extext_methods,
-                                           jl_array_t *new_ext_cis, jl_query_cache *query_cache)
+                                           jl_array_t *new_ext, jl_query_cache *query_cache)
 {
     htable_new(&field_replace, 0);
     htable_new(&bits_replace, 0);
@@ -2957,7 +2957,7 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
             // Queue method extensions
             jl_queue_for_serialization(&s, extext_methods);
             // Queue the new specializations
-            jl_queue_for_serialization(&s, new_ext_cis);
+            jl_queue_for_serialization(&s, new_ext);
         }
         jl_serialize_reachable(&s);
         // step 1.2: ensure all gvars are part of the sysimage too
@@ -3148,7 +3148,7 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
             }
             jl_write_value(&s, module_init_order);
             jl_write_value(&s, extext_methods);
-            jl_write_value(&s, new_ext_cis);
+            jl_write_value(&s, new_ext);
             jl_write_value(&s, s.method_roots_list);
         }
         write_uint32(f, jl_array_len(s.link_ids_gctags));
@@ -3251,11 +3251,11 @@ JL_DLLEXPORT void jl_create_system_image(void **_native_data, jl_array_t *workli
         ff = f;
     }
 
-    jl_array_t *mod_array = NULL, *extext_methods = NULL, *new_ext_cis = NULL, *ext_foreign_cis = NULL;
+    jl_array_t *mod_array = NULL, *extext_methods = NULL, *new_ext = NULL, *ext_foreign_cis = NULL;
     int64_t checksumpos = 0;
     int64_t checksumpos_ff = 0;
     int64_t datastartpos = 0;
-    JL_GC_PUSH4(&mod_array, &extext_methods, &new_ext_cis, &ext_foreign_cis);
+    JL_GC_PUSH4(&mod_array, &extext_methods, &new_ext, &ext_foreign_cis);
 
     ext_foreign_cis = jl_alloc_vec_any(0);
 
@@ -3291,41 +3291,34 @@ JL_DLLEXPORT void jl_create_system_image(void **_native_data, jl_array_t *workli
     assert((ct->reentrant_timing & 0b1110) == 0);
     ct->reentrant_timing |= 0b1000;
     if (worklist) {
-        // extext_methods: [method1, ...], worklist-owned "extending external" methods added to functions owned by modules outside the worklist
-
+        // new_exts: [code_instances, ...], anything to add to the image just for side-effects
         // Save the inferred code from newly inferred, external methods
+        arraylist_t CIs;
+        arraylist_new(&CIs, 0);
         if (native_functions) {
-            arraylist_t CIs;
-            arraylist_new(&CIs, 0);
-            size_t num_cis;
+            size_t num_cis = 0;
             jl_get_llvm_cis(native_functions, &num_cis, NULL);
             arraylist_grow(&CIs, num_cis);
             jl_get_llvm_cis(native_functions, &num_cis, (jl_code_instance_t**)CIs.items);
-            // Create a filtered list of the compiled code instances that are
-            // possibly not referenced via any other way but valid for the
-            // Method cache field of an external method
-            new_ext_cis = jl_alloc_vec_any(0);
-            for (size_t i = 0; i < num_cis; i++) {
-                jl_code_instance_t *ci = (jl_code_instance_t*)CIs.items[i];
-                if (ci_not_internal_cache(ci))
-                    jl_array_ptr_1d_push(new_ext_cis, (jl_value_t*)ci);
-            }
-            arraylist_free(&CIs);
         }
-        else {
-            new_ext_cis = jl_compute_new_ext_cis();
+        // Create a filtered list of the compiled code instances that are
+        // possibly not referenced via any other way but valid for the
+        // Method cache field of an external method
+        new_ext = jl_alloc_vec_any(0);
+        for (size_t i = 0; i < CIs.len; i++) {
+            jl_code_instance_t *ci = (jl_code_instance_t*)CIs.items[i];
+            if (ci_not_internal_cache(ci))
+                jl_array_ptr_1d_push(new_ext, (jl_value_t*)ci);
         }
-
+        arraylist_free(&CIs);
         // Merge foreign & external CIs
-        if (ext_foreign_cis) {
-            size_t n_ext = jl_array_nrows(ext_foreign_cis);
-            for (size_t i = 0; i < n_ext; i++) {
-                jl_array_ptr_1d_push(new_ext_cis, jl_array_ptr_ref(ext_foreign_cis, i));
-            }
-        }
+        size_t n_ext = jl_array_nrows(ext_foreign_cis);
+        for (size_t i = 0; i < n_ext; i++)
+            jl_array_ptr_1d_push(new_ext, jl_array_ptr_ref(ext_foreign_cis, i));
         ext_foreign_cis = NULL; // not needed anymore, free it
 
         // Collect method extensions
+        // extext_methods: [method1, ...], worklist-owned "extending external" methods added to functions owned by modules outside the worklist
         extext_methods = jl_alloc_vec_any(0);
         jl_collect_extext_methods(extext_methods, mod_array);
 
@@ -3341,7 +3334,7 @@ JL_DLLEXPORT void jl_create_system_image(void **_native_data, jl_array_t *workli
 
     jl_query_cache query_cache;
     init_query_cache(&query_cache);
-    jl_save_system_image_to_stream(ff, mod_array, module_init_order, worklist, extext_methods, new_ext_cis, &query_cache);
+    jl_save_system_image_to_stream(ff, mod_array, module_init_order, worklist, extext_methods, new_ext, &query_cache);
     if (_native_data != NULL)
         native_functions = NULL;
     // make sure we don't run any Julia code concurrently before this point
@@ -3677,7 +3670,6 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
                                                  jl_array_t **init_order JL_REQUIRE_ROOTED_SLOT,
                                                  jl_array_t **extext_methods JL_REQUIRE_ROOTED_SLOT,
                                                  jl_array_t **internal_methods JL_REQUIRE_ROOTED_SLOT,
-                                                 jl_array_t **new_ext_cis JL_REQUIRE_ROOTED_SLOT,
                                                  jl_array_t **method_roots_list JL_REQUIRE_ROOTED_SLOT,
                                                  pkgcachesizes *cachesizes) JL_GC_DISABLED
 {
@@ -3750,7 +3742,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     ios_seek(f, LLT_ALIGN(ios_pos(f), 8));
     assert(!ios_eof(f));
     s.s = f;
-    uintptr_t offset_restored = 0, offset_init_order = 0, offset_extext_methods = 0, offset_new_ext_cis = 0, offset_method_roots_list = 0;
+    uintptr_t offset_restored = 0, offset_init_order = 0, offset_extext_methods = 0, offset_new_ext = 0, offset_method_roots_list = 0;
     if (!s.incremental) {
         size_t i;
         for (i = 0; tags[i] != NULL; i++) {
@@ -3786,7 +3778,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
         offset_restored = jl_read_offset(&s);
         offset_init_order = jl_read_offset(&s);
         offset_extext_methods = jl_read_offset(&s);
-        offset_new_ext_cis = jl_read_offset(&s);
+        offset_new_ext = jl_read_offset(&s);
         offset_method_roots_list = jl_read_offset(&s);
     }
     s.buildid_depmods_idxs = depmod_to_imageidx(depmods);
@@ -3812,11 +3804,11 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     }
     uint32_t external_fns_begin = read_uint32(f);
     if (s.incremental) {
-        assert(restored && init_order && extext_methods && internal_methods && new_ext_cis && method_roots_list);
+        assert(restored && init_order && extext_methods && internal_methods && method_roots_list);
         *restored = (jl_array_t*)jl_delayed_reloc(&s, offset_restored);
         *init_order = (jl_array_t*)jl_delayed_reloc(&s, offset_init_order);
         *extext_methods = (jl_array_t*)jl_delayed_reloc(&s, offset_extext_methods);
-        *new_ext_cis = (jl_array_t*)jl_delayed_reloc(&s, offset_new_ext_cis);
+        (void)(jl_array_t*)jl_delayed_reloc(&s, offset_new_ext);
         *method_roots_list = (jl_array_t*)jl_delayed_reloc(&s, offset_method_roots_list);
         *internal_methods = jl_alloc_vec_any(0);
     }
@@ -4274,9 +4266,9 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
     needs_permalloc = jl_options.permalloc_pkgimg || needs_permalloc;
 
     jl_value_t *restored = NULL;
-    jl_array_t *init_order = NULL, *extext_methods = NULL, *internal_methods = NULL, *new_ext_cis = NULL, *method_roots_list = NULL;
+    jl_array_t *init_order = NULL, *extext_methods = NULL, *internal_methods = NULL, *method_roots_list = NULL;
     jl_svec_t *cachesizes_sv = NULL;
-    JL_GC_PUSH7(&restored, &init_order, &extext_methods, &internal_methods, &new_ext_cis, &method_roots_list, &cachesizes_sv);
+    JL_GC_PUSH6(&restored, &init_order, &extext_methods, &internal_methods, &method_roots_list, &cachesizes_sv);
 
     { // make a permanent in-memory copy of f (excluding the header)
         ios_bufmode(f, bm_none);
@@ -4301,7 +4293,7 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
                 ios_close(f);
             ios_static_buffer(f, sysimg, len);
             pkgcachesizes cachesizes;
-            jl_restore_system_image_from_stream_(f, image, depmods, checksum, (jl_array_t**)&restored, &init_order, &extext_methods, &internal_methods, &new_ext_cis, &method_roots_list, &cachesizes);
+            jl_restore_system_image_from_stream_(f, image, depmods, checksum, (jl_array_t**)&restored, &init_order, &extext_methods, &internal_methods, &method_roots_list, &cachesizes);
             JL_SIGATOMIC_END();
 
             // Add roots to methods
@@ -4344,11 +4336,12 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
                 jl_svecset(cachesizes_sv, 4, jl_box_long(cachesizes.reloclist));
                 jl_svecset(cachesizes_sv, 5, jl_box_long(cachesizes.gvarlist));
                 jl_svecset(cachesizes_sv, 6, jl_box_long(cachesizes.fptrlist));
-                // Surface extext_methods and new_ext_cis to external inspectors (e.g. PkgCacheInspector.jl).
-                // With the single global jl_method_table, `extext_methods` contains *all* worklist methods
-                // (not just externally-extending ones); `internal_methods` overlaps it and exists only for
-                // per-object world-stamp updates during the fixup walk.
-                restored = (jl_value_t*)jl_svec(7, restored, init_order, internal_methods, extext_methods, new_ext_cis, method_roots_list, cachesizes_sv);
+                // Surface extext_methods to external inspectors (e.g.
+                // PkgCacheInspector.jl). With the single global jl_method_table,
+                // `extext_methods` contains all worklist methods; `internal_methods`
+                // only partially overlaps it and exists only for per-object world-stamp
+                // updates during the fixup walk.
+                restored = (jl_value_t*)jl_svec(6, restored, init_order, internal_methods, extext_methods, method_roots_list, cachesizes_sv);
             }
             else {
                 restored = (jl_value_t*)jl_svec(3, restored, init_order, internal_methods);
@@ -4363,7 +4356,7 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
 static void jl_restore_system_image_from_stream(ios_t *f, jl_image_t *image, uint32_t checksum)
 {
     JL_TIMING(LOAD_IMAGE, LOAD_Sysimg);
-    jl_restore_system_image_from_stream_(f, image, NULL, checksum | ((uint64_t)0xfdfcfbfa << 32), NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    jl_restore_system_image_from_stream_(f, image, NULL, checksum | ((uint64_t)0xfdfcfbfa << 32), NULL, NULL, NULL, NULL, NULL, NULL);
 }
 
 JL_DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(jl_image_buf_t buf, jl_image_t *image, jl_array_t *depmods, int completeinfo, const char *pkgname, int needs_permalloc)

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -116,34 +116,36 @@ JL_DLLEXPORT void jl_tag_newly_inferred_disable(void)
 // This gets called as the first step of Base.include_package_for_output
 JL_DLLEXPORT void jl_set_newly_inferred(jl_value_t* _newly_inferred)
 {
-    assert(_newly_inferred == NULL || _newly_inferred == jl_nothing || jl_is_array(_newly_inferred));
+    assert(_newly_inferred == NULL || _newly_inferred == jl_nothing || jl_is_array_any(_newly_inferred));
     if (_newly_inferred == jl_nothing)
         _newly_inferred = NULL;
     newly_inferred = (jl_array_t*) _newly_inferred;
 }
 
-static jl_array_t *queue_external_cis(jl_array_t *list, jl_query_cache *query_cache);
+static jl_array_t *queue_external(jl_array_t *list, jl_query_cache *query_cache);
 
-JL_DLLEXPORT jl_array_t* jl_compute_new_ext_cis(void)
+JL_DLLEXPORT jl_array_t* jl_compute_new_ext(void)
 {
     if (newly_inferred == NULL)
         return jl_alloc_vec_any(0);
     jl_query_cache query_cache;
     init_query_cache(&query_cache);
-    jl_array_t *new_ext_cis = queue_external_cis(newly_inferred, &query_cache);
+    jl_array_t *new_ext = queue_external(newly_inferred, &query_cache);
     destroy_query_cache(&query_cache);
-    return new_ext_cis;
+    return new_ext;
 }
 
 JL_DLLEXPORT void jl_push_newly_inferred(jl_value_t* ci)
 {
     if (!newly_inferred)
         return;
-    uint8_t tag_newly_inferred = jl_atomic_load_relaxed(&jl_tag_newly_inferred_enabled);
-    if (tag_newly_inferred) {
-        jl_method_instance_t *mi = jl_get_ci_mi((jl_code_instance_t*)ci);
-        uint8_t miflags = jl_atomic_load_relaxed(&mi->flags);
-        jl_atomic_store_relaxed(&mi->flags, miflags | JL_MI_FLAGS_MASK_PRECOMPILED);
+    if (jl_is_code_instance(ci)) {
+        uint8_t tag_newly_inferred = jl_atomic_load_relaxed(&jl_tag_newly_inferred_enabled);
+        if (tag_newly_inferred) {
+            jl_method_instance_t *mi = jl_get_ci_mi((jl_code_instance_t*)ci);
+            uint8_t miflags = jl_atomic_load_relaxed(&mi->flags);
+            jl_atomic_store_relaxed(&mi->flags, miflags | JL_MI_FLAGS_MASK_PRECOMPILED);
+        }
     }
     JL_LOCK(&newly_inferred_mutex);
     size_t end = jl_array_nrows(newly_inferred);
@@ -482,12 +484,11 @@ static int has_backedge_to_worklist(jl_method_instance_t *mi, htable_t *visited,
     return final_result;
 }
 
-// Given the list of CodeInstances that were inferred during the build, select
-// those that are (1) external, (2) still valid, (3) are inferred to be called
-// from the worklist or explicitly added by a `precompile` statement, and
-// (4) are the most recently computed result for that method.
-// These will be preserved in the image.
-static jl_array_t *queue_external_cis(jl_array_t *list, jl_query_cache *query_cache)
+// Given the list of CodeInstances or MethodInstances that were inferred during the build,
+// select those that are (1) external, (2) still valid, (3) are inferred to be called from
+// the worklist or explicitly added by a `precompile` statement, and (4) are the most
+// recently computed result for that method. These will be preserved in the image.
+static jl_array_t *queue_external(jl_array_t *list, jl_query_cache *query_cache)
 {
     if (list == NULL)
         return NULL;
@@ -498,37 +499,42 @@ static jl_array_t *queue_external_cis(jl_array_t *list, jl_query_cache *query_ca
     size_t n0 = jl_array_nrows(list);
     htable_new(&visited, n0);
     arraylist_new(&stack, 0);
-    jl_array_t *new_ext_cis = jl_alloc_vec_any(0);
-    JL_GC_PUSH1(&new_ext_cis);
+    jl_array_t *new_ext = jl_alloc_vec_any(0);
+    JL_GC_PUSH1(&new_ext);
     for (i = n0; i-- > 0; ) {
-        jl_code_instance_t *ci = (jl_code_instance_t*)jl_array_ptr_ref(list, i);
-        assert(jl_is_code_instance(ci));
-        jl_method_instance_t *mi = jl_get_ci_mi(ci);
-        jl_method_t *m = mi->def.method;
-        int dispatch_status = jl_atomic_load_relaxed(&m->dispatch_status);
-        if (!(dispatch_status & METHOD_SIG_LATEST_WHICH))
-            continue; // ignore replaced methods
-        if (jl_atomic_load_relaxed(&ci->inferred) && jl_is_method(m) && jl_object_in_image((jl_value_t*)m->module)) {
-            int found = has_backedge_to_worklist(mi, &visited, &stack, query_cache);
-            assert(found == 0 || found == 1 || found == 2);
-            assert(stack.len == 0);
-            if (found == 1) {
-                jl_array_ptr_1d_push(new_ext_cis, (jl_value_t*)ci);
+        jl_value_t *v = jl_array_ptr_ref(list, i);
+        if (jl_is_code_instance(v)) {
+            jl_code_instance_t *ci = (jl_code_instance_t*)v;
+            jl_method_instance_t *mi = jl_get_ci_mi(ci);
+            jl_method_t *m = mi->def.method;
+            int dispatch_status = jl_atomic_load_relaxed(&m->dispatch_status);
+            if (!(dispatch_status & METHOD_SIG_LATEST_WHICH))
+                continue; // ignore replaced methods
+            if (jl_atomic_load_relaxed(&ci->inferred) && jl_is_method(m) && jl_object_in_image((jl_value_t*)m->module)) {
+                int found = has_backedge_to_worklist(mi, &visited, &stack, query_cache);
+                assert(found == 0 || found == 1 || found == 2);
+                assert(stack.len == 0);
+                if (found == 1) {
+                    jl_array_ptr_1d_push(new_ext, (jl_value_t*)ci);
+                }
             }
+        }
+        else if (jl_is_method_instance(v)) {
+            jl_array_ptr_1d_push(new_ext, v);
         }
     }
     htable_free(&visited);
     arraylist_free(&stack);
     JL_GC_POP();
-    // reverse new_ext_cis
-    n0 = jl_array_nrows(new_ext_cis);
-    jl_value_t **news = jl_array_data(new_ext_cis, jl_value_t*);
-    for (i = 0; i < n0; i++) {
+    // reverse new_ext
+    n0 = jl_array_nrows(new_ext);
+    jl_value_t **news = jl_array_data(new_ext, jl_value_t*);
+    for (i = 0; i < n0 / 2; i++) {
         jl_value_t *temp = news[i];
         news[i] = news[n0 - i - 1];
         news[n0 - i - 1] = temp;
     }
-    return new_ext_cis;
+    return new_ext;
 }
 
 // For every method:

--- a/src/timing.c
+++ b/src/timing.c
@@ -670,7 +670,7 @@ void jl_timing_task_init(jl_task_t *t)
     // string live forever, so this allocation is intentionally leaked.
     char *fiber_name;
     if (start_name[0] == '#') {
-        jl_method_instance_t *mi = jl_method_lookup(&t->start, 1, jl_get_world_counter());
+        jl_method_instance_t *mi = jl_apply_lookup(&t->start, 1, jl_get_world_counter());
         const char *filename = gnu_basename(jl_symbol_name(mi->def.method->file));
         const char *module_name = jl_symbol_name(mi->def.method->module->name);
 

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -203,12 +203,9 @@ let
         ccall(:jl_tag_newly_inferred_enable, Cvoid, ())
         try
             repl_workload()
-            precompile(Tuple{typeof(Base.HashArrayMappedTries.next), Base.HashArrayMappedTries.HashState{Base.ScopedValues.ScopedValue{Any}}})
             precompile(Tuple{typeof(Base.setindex!), Base.Dict{Any, Any}, Any, Char})
             precompile(Tuple{typeof(Base.setindex!), Base.Dict{Any, Any}, Any, Int})
             precompile(Tuple{typeof(Base.delete!), Base.Set{Any}, String})
-            precompile(Tuple{typeof(Base.:(==)), Char, String})
-            precompile(Tuple{typeof(Base.convert), Type{Array{String, 1}}, Array{String, 1}})
         finally
             ccall(:jl_tag_newly_inferred_disable, Cvoid, ())
         end

--- a/test/core.jl
+++ b/test/core.jl
@@ -37,9 +37,9 @@ end
 # sanity tests that our built-in types are marked correctly for atomic fields
 for (T, c) in (
         (Core.CodeInfo, []),
-        (Core.CodeInstance, [:next, :min_world, :max_world, :inferred, :edges, :debuginfo, :ipo_purity_bits, :invoke, :specptr, :flags, :precompile, :time_compile]),
+        (Core.CodeInstance, [:next, :min_world, :max_world, :inferred, :edges, :debuginfo, :ipo_purity_bits, :invoke, :specptr, :flags, :time_compile]),
         (Core.Method, [:primary_world, :did_scan_source, :dispatch_status, :interferences]),
-        (Core.MethodInstance, [:cache, :flags, :dispatch_status]),
+        (Core.MethodInstance, [:cache, :flags, :dispatch_status, :precompile]),
         (Core.MethodTable, [:defs]),
         (Core.MethodCache, [:leafcache, :cache, :var""]),
         (Core.TypeMapEntry, [:next, :min_world, :max_world]),

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1083,8 +1083,9 @@ precompile_test_harness("code caching") do dir
         mi = m.specializations::Core.MethodInstance
         @test hasvalid(mi, world)       # was compiled with the new method
         m = only(methods(MA.fib))
-        mi = m.specializations::Core.MethodInstance
-        @test !hasvalid(mi, world)      # invalidated by redefining `gib` before loading StaleB
+        for mi in Base.specializations(m)
+            @test !hasvalid(mi, world)      # invalidated by redefining `gib` before loading StaleB
+        end
         @test MA.fib() === 2.0
 
         # Reporting test (ensure SnoopCompile works)
@@ -1979,7 +1980,7 @@ precompile_test_harness("PkgCacheInspector") do load_path
             cachefile, depmods, #=completeinfo=#true, "PCI")
     end
 
-    modules, init_order, internal_methods, extext_methods, new_ext_cis, new_method_roots, cache_sizes = sv
+    modules, init_order, internal_methods, extext_methods, new_method_roots, cache_sizes = sv
     for m in internal_methods::Vector{Any}
         m isa Core.MethodInstance || continue
         m = m.func::Method
@@ -2530,8 +2531,13 @@ precompile_test_harness("Package precompilation works without manifest") do load
 end
 
 # Verify that inference / caching was not performed for any macros in the sysimage
-let m = only(methods(Base.var"@big_str"))
-    @test m.specializations === Core.svec() || !isdefined(m.specializations, :cache)
+let m = only(methods(Base.var"@lazy_str"))
+    for mi in Base.specializations(m)
+        isdefined(mi, :cache) || continue
+        ci = mi.cache
+        @test !isdefined(ci, :inferred)
+        @test !isdefined(ci, :next)
+    end
 end
 
 # Issue #58841 - make sure we don't accidentally throw away code for inference

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1277,7 +1277,6 @@ end
     @test mi1.def.name == :+
     mi2 = Base.method_instance((typeof(+), Int, Int))
     @test mi2.def.name == :+
-    # Note `jl_method_lookup` doesn't return CNull if not found
     mi3 = @ccall jl_method_lookup(Any[+, 1, 1]::Ptr{Any}, 3::Csize_t, Base.get_world_counter()::Csize_t)::Ref{Core.MethodInstance}
     @test mi1 == mi3
     @test mi2 == mi3


### PR DESCRIPTION
This moves the method specialization logic from pre-caching to
post-inference. The current heuristics are unchanged, but this will let
us experiment with new heuristics in inference. It also can make
precompile output statements more accurate, since they can print the
actual argument types being dispatched instead guessing from the compile
signature.

Bootstrapping is a bit slower, since there is more work that needs to be
computed in Julia). This is probably expected, but maybe can be improved
again later.

Should probably remove `precompile` entirely from C since it is actually
in Compiler/src/precompile.jl, but not there quite yet for this PR.