### PR TITLE
[JuliaLowering] Fixes and tests for `expand_let`

### DIFF
--- a/JuliaLowering/src/ast.jl
+++ b/JuliaLowering/src/ast.jl
@@ -433,11 +433,6 @@ function extension_type(ex)
     ex[1].name_val
 end
 
-function is_sym_decl(x)
-    k = kind(x)
-    k == K"Identifier" || k == K"::"
-end
-
 function is_eventually_call(ex::SyntaxTree)
     k = kind(ex)
     return k == K"call" || ((k == K"where" || k == K"::") && is_eventually_call(ex[1]))

--- a/JuliaLowering/src/desugaring.jl
+++ b/JuliaLowering/src/desugaring.jl
@@ -31,6 +31,8 @@ function is_same_identifier_like(ex::SyntaxTree, name::AbstractString)
     return kind(ex) == K"Identifier" && ex.name_val == name
 end
 
+# Hack.  Scopes aren't resolved, so only use this where a false positive is
+# still a correct answer.
 function contains_identifier(ex::SyntaxTree, idents::AbstractVector{<:SyntaxTree})
     contains_unquoted(ex) do e
         any(is_same_identifier_like(e, id) for id in idents)
@@ -1509,16 +1511,16 @@ function expand_let(ctx, ex)
     end
     for binding in Iterators.reverse(children(bindings))
         kb = kind(binding)
-        if is_sym_decl(kb)
+        if kb == K"::" || is_identifier_like(binding)
             blk = @ast ctx ex [K"scope_block"(scope_type=scope_type)
                 [K"local" binding]
                 blk
             ]
-        elseif kb == K"=" && numchildren(binding) == 2
+        elseif kb == K"="
             lhs = binding[1]
             rhs = binding[2]
-            kl = kind(lhs)
-            if kl == K"Identifier" || kl == K"BindingId"
+            if is_identifier_like(lhs)
+                kind(lhs) === K"Placeholder" && continue
                 blk = @ast ctx binding [K"block"
                     tmp := rhs
                     [K"scope_block"(ex, scope_type=scope_type)
@@ -1528,9 +1530,10 @@ function expand_let(ctx, ex)
                         blk
                     ]
                 ]
-            elseif kl == K"::"
+            elseif kind(lhs) == K"::"
                 var = lhs[1]
-                if !(kind(var) in KSet"Identifier BindingId")
+                kind(var) === K"Placeholder" && continue
+                if !is_identifier_like(var)
                     throw(LoweringError(var, "Invalid assignment location in let syntax"))
                 end
                 blk = @ast ctx binding [K"block"
@@ -1573,18 +1576,13 @@ function expand_let(ctx, ex)
             blk = @ast ctx binding [K"block"
                 [K"scope_block"(ex, scope_type=scope_type)
                     [K"local"(func_name) func_name]
-                    [K"always_defined" func_name]
+                    # note no always_defined, as it's stronger than flisp's local-def
                     binding
-                    [K"scope_block"(ex, scope_type=scope_type)
-                        # The inside of the block is isolated from the closure,
-                        # which itself can only capture values from the outside.
-                        blk
-                    ]
+                    blk
                 ]
             ]
         else
-            throw(LoweringError(binding, "Invalid binding in let"))
-            continue
+            @jl_assert false (binding, "invalid binding in let")
         end
     end
     return blk

--- a/JuliaLowering/test/closures.jl
+++ b/JuliaLowering/test/closures.jl
@@ -437,6 +437,58 @@ let y = 10
 end
 """) == (11, 15)
 
+# Adding kw methods to kw let-function
+@test JuliaLowering.include_string(test_mod, """
+let f(a; kw1 = nothing, kw2 = nothing) = "outer"
+    f(::Integer; kwargs...) = "call me"
+    f(1; kw1 = 1, kw2 = 2)
+end
+""") == "call me"
+
+# Currently an error in both lowering implementations (closure-conversion ordering)
+@test_broken JuliaLowering.include_string(test_mod, """
+let f(a; kw1 = nothing, kw2 = nothing) = "outer"
+    let
+        f(::Integer; kwargs...) = error("call me")
+    end
+    f(1; kw1 = 1, kw2 = 2)
+end
+""") == "outer"
+
+# Self-reference in let-function
+@test JuliaLowering.include_string(test_mod, """
+let f(x) = x <= 0 ? x : f(x-1)
+    f(5)
+end
+""") == 0
+@test JuliaLowering.include_string(test_mod, """
+let f(x::typeof(f)) = x
+    f(f)
+end
+""") isa Function # broken in flisp
+
+# Self-reference in let-function default args
+@test JuliaLowering.include_string(test_mod, """
+let f(x=f) = x
+    f()
+end
+""") isa Function
+@test JuliaLowering.include_string(test_mod, """
+let f(x::typeof(f)) = x
+    f(f)
+end
+""") isa Function
+@test JuliaLowering.include_string(test_mod, """
+let f(;x=f) = x
+    f()
+end
+""") isa Function
+@test JuliaLowering.include_string(test_mod, """
+let f(;x::typeof(f)) = x
+    f(x=f)
+end
+""") isa Function
+
 # Anonymous function syntax with `function`
 @test JuliaLowering.include_string(test_mod, """
 begin

--- a/JuliaLowering/test/decls.jl
+++ b/JuliaLowering/test/decls.jl
@@ -724,3 +724,143 @@ gr_mod = Module()
                        GlobalRef(gr_mod, sym),
                        Expr(:block, GlobalRef(gr_mod, sym))))
 end
+
+@testset "All possible `let` forms" for run in [fl_eval, jl_eval],
+    maybe_int in [identity, x->Expr(:(::), x, :Int)]
+    # no-assignment forms
+    @test run(test_mod,
+              Expr(:let, maybe_int(:a),
+                   Expr(:tuple,
+                        Expr(:islocal, :a),
+                        Expr(:isdefined, :a)))) == (true, false)
+    @test run(test_mod,
+              Expr(:let, Expr(:block, maybe_int(:a)),
+                   Expr(:tuple,
+                        Expr(:islocal, :a),
+                        Expr(:isdefined, :a)))) == (true, false)
+    @test run(test_mod,
+              Expr(:let, Expr(:block, maybe_int(:a), maybe_int(:b), maybe_int(:c)),
+                   Expr(:tuple,
+                        Expr(:islocal, :a),
+                        Expr(:isdefined, :a),
+                        Expr(:islocal, :b),
+                        Expr(:isdefined, :b),
+                        Expr(:islocal, :c),
+                        Expr(:isdefined, :c)))) ==
+                            (true, false, true, false, true, false)
+
+    # placeholder should at least pass lowering
+    # flisp bug: isdefined throws because `_` is assumed global
+    @testset "placeholder" for p_inner in [maybe_int(:_), Expr(:(=), maybe_int(:_), 1)],
+        p_block in [p_inner, Expr(:block, p_inner)]
+        @test run(test_mod, Expr(:let, p_block,
+                                 Expr(:block, Expr(:islocal, :_)))) == false
+    end
+
+    # assignment forms
+    @test run(test_mod,
+              Expr(:let,
+                   Expr(:(=), maybe_int(:a), 1),
+                   Expr(:tuple, Expr(:islocal, :a), :a))) == (true, 1)
+    @test run(test_mod,
+              Expr(:let,
+                   Expr(:block, Expr(:(=), maybe_int(:a), 1)),
+                   Expr(:tuple, Expr(:islocal, :a), :a))) == (true, 1)
+    @test run(test_mod,
+              Expr(:let,
+                   Expr(:block,
+                        Expr(:(=), maybe_int(:a), 10),
+                        Expr(:(=), maybe_int(:b), 20),
+                        Expr(:(=), maybe_int(:c), 30)),
+                   Expr(:tuple,
+                        Expr(:islocal, :a), :a,
+                        Expr(:islocal, :b), :b,
+                        Expr(:islocal, :c), :c))) == (true, 10, true, 20, true, 30)
+
+    @test run(test_mod,
+              Expr(:let,
+                   Expr(:block,
+                        Expr(:(=),
+                             Expr(:tuple, :a1, maybe_int(:a2), :a3),
+                             Expr(:tuple, 11, 12, 13)),
+                        Expr(:(=),
+                             Expr(:tuple, :b1, :b2, :b3, :_),
+                             Expr(:tuple, 21, 22, 23, 0)),
+                        Expr(:(=),
+                             Expr(:tuple, Expr(:parameters, :c1, maybe_int(:c2), :c3)),
+                             :((;c1=31, c2=32, c3=33)))),
+                   Expr(:tuple,
+                        Expr(:islocal, :a1), :a1,
+                        Expr(:islocal, :a2), :a2,
+                        Expr(:islocal, :a3), :a3,
+                        Expr(:islocal, :b1), :b1,
+                        Expr(:islocal, :b2), :b2,
+                        Expr(:islocal, :b3), :b3,
+                        Expr(:islocal, :c1), :c1,
+                        Expr(:islocal, :c2), :c2,
+                        Expr(:islocal, :c3), :c3,
+                        ))) ==
+                            (true, 11, true, 12, true, 13,
+                             true, 21, true, 22, true, 23,
+                             true, 31, true, 32, true, 33)
+
+    @test run(test_mod,
+              Expr(:let,
+                   Expr(:block,
+                        Expr(:(=),
+                             Expr(:tuple, :a1, maybe_int(:a2), Expr(:..., :a3)),
+                             Expr(:tuple, 11, 12, 13, 14, 15)),
+                        Expr(:(=),
+                             Expr(:tuple, :b1, :b2, :b3, Expr(:..., :_)),
+                             Expr(:tuple, 21, 22, 23, 0, 0, 0))),
+                   Expr(:tuple,
+                        Expr(:islocal, :a1), :a1,
+                        Expr(:islocal, :a2), :a2,
+                        Expr(:islocal, :a3), :a3,
+                        Expr(:islocal, :b1), :b1,
+                        Expr(:islocal, :b2), :b2,
+                        Expr(:islocal, :b3), :b3,
+                        ))) ==
+                            (true, 11, true, 12, true, (13, 14, 15),
+                             true, 21, true, 22, true, 23)
+
+    # functions
+    @test run(test_mod,
+              Expr(:let,
+                   Expr(:(=), maybe_int(Expr(:call, :f)), 1),
+                   Expr(:tuple,
+                        Expr(:call, :f),
+                        Expr(:islocal, :f)))) == (1, true)
+
+    @test run(test_mod,
+              Expr(:let,
+                   Expr(:block,
+                        Expr(:(=), maybe_int(Expr(:call, :f)), 1),
+                        Expr(:(=), maybe_int(Expr(:call, :g)), 2)),
+                   Expr(:tuple,
+                        Expr(:call, :f),
+                        Expr(:islocal, :f),
+                        Expr(:call, :g),
+                        Expr(:islocal, :g)))) == (1, true, 2, true)
+
+    @test run(test_mod,
+              Expr(:let,
+                   Expr(:(=),
+                        Expr(:where, maybe_int(Expr(:call, :f, :(x::Int))), :Int),
+                        :x),
+                   Expr(:tuple,
+                        Expr(:call, :f, "foo"),
+                        Expr(:islocal, :f)))) == ("foo", true)
+
+    @test run(test_mod,
+              Expr(:let,
+                   Expr(:(=), Expr(:where,
+                                   Expr(:where,
+                                        maybe_int(Expr(:call, :f, :(x::Int), :(y::T))),
+                                        :T),
+                                   :Int), :(x*y)),
+                   Expr(:tuple,
+                        Expr(:call, :f, "x", "y"),
+                        Expr(:islocal, :f)))) == ("xy", true)
+
+end

--- a/JuliaLowering/test/scopes.jl
+++ b/JuliaLowering/test/scopes.jl
@@ -46,7 +46,7 @@ end
 # (In the flisp implementation it captures from inner scope, but this is
 # inconsistent with let assignment where the rhs refers to the outer scope and
 # thus seems like a bug.)
-@test JuliaLowering.include_string(test_mod, """
+@test_broken JuliaLowering.include_string(test_mod, """
 begin
     local y = :outer_y
     let f() = y


### PR DESCRIPTION
- Placeholders should be allowed even if they do nothing
- Functions that reference themselves should not be marked `always_defined`.
  flisp marks them local-def which happens to work in some cases, but not
  others.  The unboxing pass appears to mark easy cases anyway.
- The body of a `(let <function_def> <body>)` form shouldn't be wrapped in a new
  scope.  I know this was intended to be an upgrade to flisp so that let-defined
  functions don't capture stuff from below, but it currently interacts badly
  with closure conversion (with flisp too), so that will need more thought to do
  correctly.

 Fix https://github.com/JuliaLang/JuliaLowering.jl/issues/180
