### PR TITLE
clarify that `muladd` doesn't respect intermediate overflow

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -1272,7 +1272,9 @@ with each other or with surrounding operations for performance.
 For example, this may be implemented as an [`fma`](@ref) if the hardware supports it
 efficiently.
 The result can be different on different machines and can also be different on the same machine
-due to constant propagation or other optimizations.
+due to constant propagation or other optimizations. The result can also differ from `x*y+z` if the
+intermediate product `x*y` would have overflowed, but the fused operation computes in a wider type.
+
 See [`fma`](@ref).
 
 # Examples

--- a/base/math.jl
+++ b/base/math.jl
@@ -1272,8 +1272,9 @@ with each other or with surrounding operations for performance.
 For example, this may be implemented as an [`fma`](@ref) if the hardware supports it
 efficiently.
 The result can be different on different machines and can also be different on the same machine
-due to constant propagation or other optimizations. The result can also differ from `x*y+z` if the
-intermediate product `x*y` would have overflowed, but the fused operation computes in a wider type.
+due to constant propagation or other optimizations. The result can also differ from `x*y+z` if
+the intermediate product `x*y` would have overflowed (or underflowed), but the fused operation
+computes in a wider type.
 
 See [`fma`](@ref).
 


### PR DESCRIPTION
some discussion on slack concluded this isn't a bug, but I still think it's confusing and should be documented explicitly.

```julia
julia> muladd(0xff, 0xff, 1)
65026

julia> (0xff * 0xff) + 1
2

julia> muladd(Int8(-1), 0x01, 1)
0

julia> (Int8(-1) * 0x1) + 1
256
```