### PR TITLE
[Random] Fix `rand!` for 0-dim complex arrays

### DIFF
--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -165,6 +165,11 @@ function rand!(r::AbstractRNG, A::Array{Complex{T}}, ::SamplerType{Complex{T}}) 
     rand!(r, reinterpret(T, A))
     return A
 end
+# Cannot reinterpret a 0-dim Complex{T} Array to T
+function rand!(r::AbstractRNG, A::Array{Complex{T},0}, sp::SamplerType{Complex{T}}) where {T<:Base.HWReal}
+    @inbounds A[] = rand(r, sp)
+    return A
+end
 
 ### random characters
 

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -511,7 +511,7 @@ end
     end
 end
 
-@testset "reproducility of methods for $RNG" for RNG=(MersenneTwister,Xoshiro)
+@testset "reproducibility of methods for $RNG" for RNG=(MersenneTwister,Xoshiro)
     mta, mtb = RNG(42), RNG(42)
 
     @test rand(mta) == rand(mtb)
@@ -529,6 +529,8 @@ end
     for T in Base.uniontypes(Base.HWReal)
         a, b = Vector{Complex{T}}(undef, 10), Vector{Complex{T}}(undef, 10)
         @test rand!(mta, a) == rand!(mtb, b)
+        c, d = Array{Complex{T},0}(undef), Array{Complex{T},0}(undef)
+        @test rand!(mta, c) == rand!(mtb, d)
     end
 
     @test randstring(mta) == randstring(mtb)


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/61762 reinterprets complex arrays as their underlying real type to take advantage of vectorization, but this fails for singleton arrays so we define a method for this case.

@adienes @IanButterworth 