### PR TITLE
[backports-release-1.13] GC: permanently mark pkg/sysimage objects to speed up GC (#61474)

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -31,6 +31,7 @@ struct GC_Num
     total_stack_pool_sweep_time::Int64
     last_full_sweep ::Int64
     last_incremental_sweep ::Int64
+    image_remset_size::Int64
 end
 
 gc_num() = ccall(:jl_gc_num, GC_Num, ())

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -694,6 +694,7 @@ void jl_print_gc_stats(JL_STREAM *s)
                    p2, p2 * 100.0 / REGION2_PG_COUNT,
                    p1, p1 * 100.0 / REGION1_PG_COUNT / p2,
                    p0, p0 * 100.0 / REGION0_PG_COUNT / p1);
+    jl_safe_printf("image remset\t%zu entries\n", image_remset.len);
 #ifdef _OS_LINUX_
     double gct = gc_num.total_time / 1e9;
     struct mallinfo mi = mallinfo();
@@ -743,13 +744,6 @@ void gc_time_pool_end(int sweep_full)
                    total_pages, total_pages - skipped_pages,
                    freed_pages,
                    sweep_full ? "full" : "quick");
-}
-
-void gc_time_sysimg_end(uint64_t t0)
-{
-    double sweep_pool_sec = (jl_hrtime() - t0) / 1e9;
-    jl_safe_printf("GC sweep sysimg end %.2f ms\n",
-                   sweep_pool_sec * 1000);
 }
 
 static int64_t big_total;

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -171,7 +171,6 @@ struct HeapSnapshot {
     size_t internal_root_idx = 0; // node index of the internal root node
     size_t _gc_root_idx = 1; // node index of the GC roots node
     size_t _gc_finlist_root_idx = 2; // node index of the GC finlist roots node
-    size_t _gc_image_node_idx = 3; // node index of the combined [image] node
 };
 
 // global heap snapshot, mutated by garbage collector
@@ -303,28 +302,6 @@ void _add_synthetic_root_entries(HeapSnapshot *snapshot) JL_NOTSAFEPOINT
         snapshot->_gc_finlist_root_idx // to
     };
     serialize_edge(snapshot, root_to_gc_finlist_roots);
-
-    // Add a synthetic node representing all sysimage/pkgimage objects.
-    // Image objects are permanently marked and never traced by the GC mark
-    // phase, so we collapse them into a single node rather than recording
-    // their internal structure.
-    snapshot->_gc_image_node_idx = snapshot->num_nodes;
-    Node gc_image_node{
-        (uint32_t)snapshot->node_types.find_or_create_string_id("synthetic"),
-        snapshot->names.serialize_if_necessary(snapshot->strings, "[image]"), // name
-        snapshot->_gc_image_node_idx, // id
-        0, // size (image memory is not GC-managed)
-        0, // size_t trace_node_id (unused)
-        0 // int detachedness;  // 0 - unknown,  1 - attached;  2 - detached
-    };
-    serialize_node(snapshot, gc_image_node);
-    Edge root_to_image{
-        (uint32_t)snapshot->edge_types.find_or_create_string_id("internal"),
-        snapshot->names.serialize_if_necessary(snapshot->strings, "[image]"), // edge label
-        snapshot->internal_root_idx, // from
-        snapshot->_gc_image_node_idx // to
-    };
-    serialize_edge(snapshot, root_to_image);
 }
 
 // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L597-L597
@@ -426,19 +403,15 @@ size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
     if (ios_need_close)
         ios_close(&str_);
 
-    // Image objects are permanently marked and never traced by the GC mark
-    // phase, so they would otherwise appear as orphan nodes. Root them under
-    // the synthetic [image] node with a label indicating which image they belong to.
-    if (jl_astaggedvalue(a)->bits.in_image) {
-        jl_value_t *top_mod = jl_object_top_module(a);
-        const char *label = "[image]";
-        if (top_mod != (jl_value_t*)jl_nothing && jl_is_module((jl_module_t*)top_mod))
-            label = jl_symbol_name_(((_jl_module_t*)top_mod)->name);
-        _record_gc_just_edge("internal", g_snapshot->_gc_image_node_idx, val.first->second,
-                             g_snapshot->names.serialize_if_necessary(g_snapshot->strings, label));
-    }
-
     return val.first->second;
+}
+
+int _gc_heap_snapshot_try_claim_image(jl_value_t *a) JL_NOTSAFEPOINT
+{
+    if (g_snapshot->node_ptr_to_index_map.find(a) != g_snapshot->node_ptr_to_index_map.end())
+        return 0;
+    record_node_to_gc_snapshot(a);
+    return 1;
 }
 
 static size_t record_pointer_to_gc_snapshot(void *a, size_t bytes, StringRef name) JL_NOTSAFEPOINT

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -171,6 +171,7 @@ struct HeapSnapshot {
     size_t internal_root_idx = 0; // node index of the internal root node
     size_t _gc_root_idx = 1; // node index of the GC roots node
     size_t _gc_finlist_root_idx = 2; // node index of the GC finlist roots node
+    size_t _gc_image_node_idx = 3; // node index of the combined [image] node
 };
 
 // global heap snapshot, mutated by garbage collector
@@ -302,6 +303,28 @@ void _add_synthetic_root_entries(HeapSnapshot *snapshot) JL_NOTSAFEPOINT
         snapshot->_gc_finlist_root_idx // to
     };
     serialize_edge(snapshot, root_to_gc_finlist_roots);
+
+    // Add a synthetic node representing all sysimage/pkgimage objects.
+    // Image objects are permanently marked and never traced by the GC mark
+    // phase, so we collapse them into a single node rather than recording
+    // their internal structure.
+    snapshot->_gc_image_node_idx = snapshot->num_nodes;
+    Node gc_image_node{
+        (uint32_t)snapshot->node_types.find_or_create_string_id("synthetic"),
+        snapshot->names.serialize_if_necessary(snapshot->strings, "[image]"), // name
+        snapshot->_gc_image_node_idx, // id
+        0, // size (image memory is not GC-managed)
+        0, // size_t trace_node_id (unused)
+        0 // int detachedness;  // 0 - unknown,  1 - attached;  2 - detached
+    };
+    serialize_node(snapshot, gc_image_node);
+    Edge root_to_image{
+        (uint32_t)snapshot->edge_types.find_or_create_string_id("internal"),
+        snapshot->names.serialize_if_necessary(snapshot->strings, "[image]"), // edge label
+        snapshot->internal_root_idx, // from
+        snapshot->_gc_image_node_idx // to
+    };
+    serialize_edge(snapshot, root_to_image);
 }
 
 // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L597-L597
@@ -402,6 +425,18 @@ size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
 
     if (ios_need_close)
         ios_close(&str_);
+
+    // Image objects are permanently marked and never traced by the GC mark
+    // phase, so they would otherwise appear as orphan nodes. Root them under
+    // the synthetic [image] node with a label indicating which image they belong to.
+    if (jl_astaggedvalue(a)->bits.in_image) {
+        jl_value_t *top_mod = jl_object_top_module(a);
+        const char *label = "[image]";
+        if (top_mod != (jl_value_t*)jl_nothing && jl_is_module((jl_module_t*)top_mod))
+            label = jl_symbol_name_(((_jl_module_t*)top_mod)->name);
+        _record_gc_just_edge("internal", g_snapshot->_gc_image_node_idx, val.first->second,
+                             g_snapshot->names.serialize_if_necessary(g_snapshot->strings, label));
+    }
 
     return val.first->second;
 }

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -34,6 +34,8 @@ void _gc_heap_snapshot_record_gc_roots(jl_value_t *root, char *name) JL_NOTSAFEP
 void _gc_heap_snapshot_record_finlist(jl_value_t *finlist, size_t index) JL_NOTSAFEPOINT;
 // Used for objects reachable from the binding partition pointer union
 void _gc_heap_snapshot_record_binding_partition_edge(jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT;
+// Used for objects that are permanently allocated in an image
+int _gc_heap_snapshot_try_claim_image(jl_value_t *a) JL_NOTSAFEPOINT;
 
 extern int gc_heap_snapshot_enabled;
 extern int prev_sweep_full;

--- a/src/gc-interface.h
+++ b/src/gc-interface.h
@@ -55,6 +55,8 @@ typedef struct {
     uint64_t total_stack_pool_sweep_time;
     uint64_t last_full_sweep;
     uint64_t last_incremental_sweep;
+    // Number of tracked image objects referencing non-image objects
+    uint64_t image_remset_size;
 } jl_gc_num_t;
 
 // ========================================================================= //

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -203,6 +203,7 @@ int current_sweep_full = 0;
 int next_sweep_full = 0;
 int under_pressure = 0;
 int gc_disable_auto_full_sweep = 0; // when set, automatic full collections are inhibited
+int gc_mark_image_subgraph = 0; // when set, descend into the object graph even for perm-alloc'd image objects
 
 // Full collection heuristics
 static int64_t live_bytes = 0;
@@ -237,8 +238,11 @@ FORCE_INLINE int gc_try_setmark_tag(jl_taggedvalue_t *o, uint8_t mark_mode) JL_N
 {
     assert(gc_marked(mark_mode));
     uintptr_t tag = o->header;
-    if (gc_marked(tag))
+    if (gc_marked(tag)) {
+        if (__unlikely(gc_mark_image_subgraph) && (tag & GC_IN_IMAGE))
+            return _gc_heap_snapshot_try_claim_image(jl_valueof(o));
         return 0;
+    }
     if (mark_reset_age) {
         // Reset the object as if it was just allocated
         mark_mode = GC_MARKED;
@@ -1599,6 +1603,8 @@ STATIC_INLINE void gc_assert_parent_validity(jl_value_t *parent, jl_value_t *chi
 STATIC_INLINE void gc_mark_push_remset(jl_ptls_t ptls, jl_value_t *obj,
                                        uintptr_t nptr) JL_NOTSAFEPOINT
 {
+    if (__unlikely(gc_mark_image_subgraph) && jl_astaggedvalue(obj)->bits.in_image)
+        return;
     if (__unlikely((nptr & 0x3) == 0x3)) {
         ptls->gc_tls.heap.remset_nptr += nptr >> 2;
         arraylist_t *remset = &ptls->gc_tls.heap.remset;
@@ -1824,6 +1830,8 @@ STATIC_INLINE void gc_mark_objarray(jl_ptls_t ptls, jl_value_t *obj_parent, jl_v
                     nptr |= 1;
                 if (!gc_marked(o->header))
                     break;
+                if (__unlikely(gc_mark_image_subgraph) && (o->header & GC_IN_IMAGE))
+                    gc_try_claim_and_push(mq, new_obj, NULL);
                 gc_heap_snapshot_record_array_edge(obj_parent, slot);
             }
         }
@@ -1896,6 +1904,8 @@ STATIC_INLINE void gc_mark_memory8(jl_ptls_t ptls, jl_value_t *ary8_parent, jl_v
                         early_end = 1;
                         break;
                     }
+                    if (__unlikely(gc_mark_image_subgraph) && (o->header & GC_IN_IMAGE))
+                        gc_try_claim_and_push(mq, new_obj, NULL);
                     gc_heap_snapshot_record_array_edge(ary8_parent, slot);
                 }
             }
@@ -1973,6 +1983,8 @@ STATIC_INLINE void gc_mark_memory16(jl_ptls_t ptls, jl_value_t *ary16_parent, jl
                         early_end = 1;
                         break;
                     }
+                    if (__unlikely(gc_mark_image_subgraph) && (o->header & GC_IN_IMAGE))
+                        gc_try_claim_and_push(mq, new_obj, NULL);
                     gc_heap_snapshot_record_array_edge(ary16_parent, slot);
                 }
             }
@@ -2136,6 +2148,8 @@ STATIC_INLINE void gc_mark_excstack(jl_ptls_t ptls, jl_excstack_t *excstack, siz
             // Found an extended backtrace entry: iterate over any
             // GC-managed values inside.
             size_t njlvals = jl_bt_num_jlvals(bt_entry);
+            if (njlvals > 0)
+                gc_heap_snapshot_record_frame_to_frame_edge((jl_gcframe_t *)excstack, (jl_gcframe_t *)bt_entry);
             for (size_t jlval_index = 0; jlval_index < njlvals; jlval_index++) {
                 new_obj = jl_bt_entry_jlvalue(bt_entry, jlval_index);
                 gc_try_claim_and_push(mq, new_obj, NULL);
@@ -2826,8 +2840,11 @@ static void gc_queue_bt_buf(jl_gc_markqueue_t *mq, jl_ptls_t ptls2) JL_NOTSAFEPO
         if (jl_bt_is_native(bt_entry))
             continue;
         size_t njlvals = jl_bt_num_jlvals(bt_entry);
-        for (size_t j = 0; j < njlvals; j++)
-            gc_try_claim_and_push(mq, jl_bt_entry_jlvalue(bt_entry, j), NULL);
+        for (size_t j = 0; j < njlvals; j++) {
+            jl_value_t *v = jl_bt_entry_jlvalue(bt_entry, j);
+            gc_try_claim_and_push(mq, v, NULL);
+            gc_heap_snapshot_record_gc_roots(v, (char*)"bt_buf");
+        }
     }
 }
 
@@ -2838,6 +2855,8 @@ static void gc_queue_remset(jl_gc_markqueue_t *mq, jl_ptls_t ptls2) JL_NOTSAFEPO
     for (size_t i = 0; i < len; i++) {
         void *_v = items[i];
         jl_astaggedvalue(_v)->bits.gc = GC_OLD_MARKED;
+        if (__unlikely(gc_mark_image_subgraph) && jl_astaggedvalue(_v)->bits.in_image)
+            continue;
         jl_value_t *v = (jl_value_t *)((uintptr_t)_v | GC_REMSET_PTR_TAG);
         gc_ptr_queue_push(mq, v);
     }
@@ -3074,6 +3093,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
     uint64_t before_free_heap_size = jl_atomic_load_relaxed(&gc_heap_stats.heap_size);
     uint64_t start_mark_time = jl_hrtime();
     JL_PROBE_GC_MARK_BEGIN();
+    gc_mark_image_subgraph = gc_heap_snapshot_enabled && prev_sweep_full;
     {
         JL_TIMING(GC, GC_Mark);
         assert(gc_n_threads);
@@ -3091,7 +3111,6 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
                 // 1.1. mark every thread local root
                 gc_queue_thread_local(mq_dest, ptls2);
                 // 1.2. mark any managed objects in the backtrace buffer
-                // TODO: treat these as roots for gc_heap_snapshot_record
                 gc_queue_bt_buf(mq_dest, ptls2);
                 // 1.3. mark every object in the remset
                 gc_queue_remset(mq_dest, ptls2);
@@ -3100,7 +3119,10 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
         gc_check_all_remsets_are_empty();
         // 1.4. in a full sweep, enqueue image remset
         // (image objects are a third, "permanent" GC generation)
-        if (prev_sweep_full)
+        // While recording a heap snapshot this is deferred to a second mark pass
+        // below, so the image remset only contributes liveness and not snapshot
+        // contents (see the comment on that pass).
+        if (prev_sweep_full && !gc_mark_image_subgraph)
             gc_queue_image_remset(mq);
 
         // 2. walk roots
@@ -3111,6 +3133,24 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
         }
         gc_mark_loop(ptls);
         gc_mark_loop_barrier();
+
+        // 2.5. When recording a heap snapshot, the root-reachable graph (which
+        // includes the root-reachable image subgraph, reached via descent) has
+        // now been recorded. Process the image remset for liveness only, with
+        // recording and image-subgraph descent disabled. This keeps image
+        // objects that are reachable solely through the (conservative) image
+        // remset -- and the objects they reference -- alive, without adding them
+        // to the snapshot, so the snapshot reports the same objects as it did
+        // before image objects were pretenured.
+        if (gc_mark_image_subgraph) { // i.e. recording a snapshot in a full sweep
+            gc_heap_snapshot_enabled = 0;
+            gc_mark_image_subgraph = 0;
+            gc_queue_image_remset(mq);
+            gc_mark_loop(ptls);
+            gc_mark_loop_barrier();
+            gc_heap_snapshot_enabled = 1;
+            gc_mark_image_subgraph = 1; // re-enable for finalizer marking below
+        }
         gc_mark_clean_reclaim_sets();
 
         // 3. check for objects to finalize
@@ -3150,6 +3190,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
         gc_mark_loop_serial(ptls);
         mark_reset_age = 0;
     }
+    gc_mark_image_subgraph = 0;
 
     JL_PROBE_GC_MARK_END(scanned_bytes, perm_scanned_bytes);
     gc_settime_premark_end();

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -1473,13 +1473,6 @@ static void gc_sweep_pool(void) JL_NOTSAFEPOINT
     gc_time_pool_end(current_sweep_full);
 }
 
-static void gc_sweep_perm_alloc(void) JL_NOTSAFEPOINT
-{
-    uint64_t t0 = jl_hrtime();
-    gc_sweep_sysimg();
-    gc_time_sysimg_end(t0);
-}
-
 // mark phase
 
 JL_DLLEXPORT void jl_gc_queue_root(const jl_value_t *ptr)
@@ -1494,6 +1487,16 @@ JL_DLLEXPORT void jl_gc_queue_root(const jl_value_t *ptr)
     if (header & GC_OLD) { // write barrier has not been triggered in this object yet
         arraylist_push(&ptls->gc_tls.heap.remset, (jl_value_t*)ptr);
         ptls->gc_tls.heap.remset_nptr++; // conservative
+        // Image objects are analogous to a third "permanent" GC
+        // generation, so here we maintain the remset for them.
+        if (__unlikely((header & GC_IN_IMAGE) && !(header & GC_IN_IMAGE_REMSET))) {
+            header = jl_atomic_fetch_or_relaxed((_Atomic(uintptr_t) *)&o->header, GC_IN_IMAGE_REMSET);
+            if (!(header & GC_IN_IMAGE_REMSET)) {
+                JL_LOCK_NOGC(&image_remset_lock);
+                arraylist_push(&image_remset, (void*)ptr);
+                JL_UNLOCK_NOGC(&image_remset_lock);
+            }
+        }
     }
 }
 
@@ -2843,6 +2846,17 @@ static void gc_queue_remset(jl_gc_markqueue_t *mq, jl_ptls_t ptls2) JL_NOTSAFEPO
     ptls2->gc_tls.heap.remset_nptr = 0;
 }
 
+static void gc_queue_image_remset(jl_gc_markqueue_t *mq) JL_NOTSAFEPOINT
+{
+    size_t len = image_remset.len;
+    void **items = image_remset.items;
+    for (size_t i = 0; i < len; i++) {
+        void *_v = items[i];
+        jl_value_t *v = (jl_value_t *)((uintptr_t)_v | GC_REMSET_PTR_TAG);
+        gc_ptr_queue_push(mq, v);
+    }
+}
+
 static void gc_check_all_remsets_are_empty(void) JL_NOTSAFEPOINT
 {
     for (int i = 0; i < gc_n_threads; i++) {
@@ -2965,6 +2979,9 @@ JL_DLLEXPORT jl_gc_num_t jl_gc_num(void)
 {
     jl_gc_num_t num = gc_num;
     combine_thread_gc_counts(&num, 0);
+    JL_LOCK_NOGC(&image_remset_lock);
+    num.image_remset_size = image_remset.len;
+    JL_UNLOCK_NOGC(&image_remset_lock);
     return num;
 }
 
@@ -3081,6 +3098,10 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
             }
         }
         gc_check_all_remsets_are_empty();
+        // 1.4. in a full sweep, enqueue image remset
+        // (image objects are a third, "permanent" GC generation)
+        if (prev_sweep_full)
+            gc_queue_image_remset(mq);
 
         // 2. walk roots
         gc_mark_roots(mq);
@@ -3202,8 +3223,6 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection) JL_NOTS
         gc_scrub();
         gc_verify_tags();
         gc_sweep_pool();
-        if (sweep_full)
-            gc_sweep_perm_alloc();
     }
 
     JL_PROBE_GC_SWEEP_END();
@@ -3723,6 +3742,8 @@ void jl_gc_init(void)
 {
     JL_MUTEX_INIT(&heapsnapshot_lock, "heapsnapshot_lock");
     JL_MUTEX_INIT(&finalizers_lock, "finalizers_lock");
+    JL_MUTEX_INIT(&image_remset_lock, "image_remset_lock");
+    arraylist_new(&image_remset, 0);
     uv_mutex_init(&page_profile_lock);
     uv_mutex_init(&gc_perm_lock);
     uv_mutex_init(&gc_pages_lock);

--- a/src/gc-stock.h
+++ b/src/gc-stock.h
@@ -531,8 +531,6 @@ void gc_final_pause_end(int64_t t0, int64_t tend);
 void gc_time_pool_start(void) JL_NOTSAFEPOINT;
 void gc_time_count_page(int freedall, int pg_skpd) JL_NOTSAFEPOINT;
 void gc_time_pool_end(int sweep_full) JL_NOTSAFEPOINT;
-void gc_time_sysimg_end(uint64_t t0) JL_NOTSAFEPOINT;
-
 void gc_time_big_start(void) JL_NOTSAFEPOINT;
 void gc_time_count_big(int old_bits, int bits) JL_NOTSAFEPOINT;
 void gc_time_big_end(void) JL_NOTSAFEPOINT;
@@ -565,7 +563,6 @@ STATIC_INLINE void gc_time_count_page(int freedall, int pg_skpd) JL_NOTSAFEPOINT
     (void)pg_skpd;
 }
 #define gc_time_pool_end(sweep_full) (void)(sweep_full)
-#define gc_time_sysimg_end(t0) (void)(t0)
 #define gc_time_big_start()
 STATIC_INLINE void gc_time_count_big(int old_bits, int bits) JL_NOTSAFEPOINT
 {

--- a/src/gc-wb-stock.h
+++ b/src/gc-wb-stock.h
@@ -15,7 +15,8 @@ STATIC_INLINE void jl_gc_wb(const void *parent, const void *ptr) JL_NOTSAFEPOINT
 {
     // parent and ptr isa jl_value_t*
     if (__unlikely(jl_astaggedvalue(parent)->bits.gc == 3 /* GC_OLD_MARKED */ && // parent is old and not in remset
-                   (jl_astaggedvalue(ptr)->bits.gc & 1 /* GC_MARKED */) == 0)) // ptr is young
+                   (jl_astaggedvalue(parent)->bits.in_image == 1 /* GC_IN_IMAGE_NOT_REMSET */ || // parent in image and not in remset
+                    (jl_astaggedvalue(ptr)->bits.gc & 1 /* GC_MARKED */) == 0))) // ptr is young
         jl_gc_queue_root((jl_value_t*)parent);
 }
 
@@ -29,11 +30,15 @@ STATIC_INLINE void jl_gc_wb_back(const void *ptr) JL_NOTSAFEPOINT // ptr isa jl_
 
 STATIC_INLINE void jl_gc_multi_wb(const void *parent, const jl_value_t *ptr) JL_NOTSAFEPOINT
 {
-    // 3 == GC_OLD_MARKED
     // ptr is an immutable object
-    if (__likely(jl_astaggedvalue(parent)->bits.gc != 3))
+    if (__likely(jl_astaggedvalue(parent)->bits.gc != 3 /* GC_OLD_MARKED */))
         return; // parent is young or in remset
-    if (__likely(jl_astaggedvalue(ptr)->bits.gc == 3))
+    if (__unlikely(jl_astaggedvalue(parent)->bits.in_image == 1 /* GC_IN_IMAGE_NOT_REMSET */)) {
+        // GC_MARKED optimizations are invalid for generations >= 2
+        jl_gc_queue_root((jl_value_t*)parent);
+        return;
+    }
+    if (__likely(jl_astaggedvalue(ptr)->bits.gc == 3 /* GC_OLD_MARKED */))
         return; // ptr is old and not in remset (thus it does not point to young)
     jl_datatype_t *dt = (jl_datatype_t*)jl_typeof(ptr);
     const jl_datatype_layout_t *ly = dt->layout;
@@ -48,6 +53,11 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const jl_value_t *dest_owne
     if (__unlikely(jl_astaggedvalue(dest_owner)->bits.gc == 3 /* GC_OLD_MARKED */ )) {
         jl_value_t *src_owner = jl_genericmemory_owner(src);
         size_t done = 0;
+        if (__unlikely(jl_astaggedvalue(dest_owner)->bits.in_image == 1 /* GC_IN_IMAGE_NOT_REMSET */)) {
+            // GC_MARKED optimizations are invalid for generations >= 2
+            jl_gc_queue_root(dest_owner);
+            return;
+        }
         if (jl_astaggedvalue(src_owner)->bits.gc != 3 /* GC_OLD_MARKED */) {
             _Atomic(void*) *dest_p = *dest_pp;
             _Atomic(void*) *src_p = *src_pp;
@@ -55,7 +65,7 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const jl_value_t *dest_owne
                 for (; done < (*n); done++) { // copy forwards
                     void *val = jl_atomic_load_relaxed(src_p + done);
                     jl_atomic_store_release(dest_p + done, val);
-                    // `val` is young or old-unmarked
+                    // `val` is young or old-unmarked (or dest is image and val is non-image)
                     if (val && !(jl_astaggedvalue(val)->bits.gc & 1 /* GC_MARKED */)) {
                         jl_gc_queue_root(dest_owner);
                         ++done;
@@ -72,7 +82,7 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_boxed(const jl_value_t *dest_owne
                 for (; done < (*n); done++) { // copy backwards
                     void *val = jl_atomic_load_relaxed(src_p + (*n) - done - 1);
                     jl_atomic_store_release(dest_p + (*n) - done - 1, val);
-                    // `val` is young or old-unmarked
+                    // `val` is young or old-unmarked (or dest is image and val is non-image)
                     if (val && !(jl_astaggedvalue(val)->bits.gc & 1 /* GC_MARKED */)) {
                         jl_gc_queue_root(dest_owner);
                         ++done;
@@ -89,6 +99,11 @@ STATIC_INLINE void jl_gc_wb_genericmemory_copy_ptr(const jl_value_t *owner, jl_g
                                           size_t n, jl_datatype_t *dt) JL_NOTSAFEPOINT
 {
     if (__unlikely(jl_astaggedvalue(owner)->bits.gc == 3 /* GC_OLD_MARKED */)) {
+        if (__unlikely(jl_astaggedvalue(owner)->bits.in_image == 1 /* GC_IN_IMAGE_NOT_REMSET */)) {
+            // GC_MARKED optimizations are invalid for generations >= 2
+            jl_gc_queue_root(owner);
+            return;
+        }
         jl_value_t *src_owner = jl_genericmemory_owner(src);
         size_t elsz = dt->layout->size;
         if (jl_astaggedvalue(src_owner)->bits.gc != 3 /* GC_OLD_MARKED */) {

--- a/src/julia.h
+++ b/src/julia.h
@@ -90,8 +90,7 @@ extern "C" {
 
 struct _jl_taggedvalue_bits {
     uintptr_t gc:2;
-    uintptr_t in_image:1;
-    uintptr_t unused:1;
+    uintptr_t in_image:2;
 #ifdef _P64
     uintptr_t tag:60;
 #else

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -412,8 +412,11 @@ static inline void memassign_safe(int hasptr, char *dst, const jl_value_t *src, 
 #define GC_CLEAN  0 // freshly allocated
 #define GC_MARKED 1 // reachable and young
 #define GC_OLD    2 // if it is reachable it will be marked as old
-#define GC_OLD_MARKED (GC_OLD | GC_MARKED) // reachable and old
 #define GC_IN_IMAGE 4
+#define GC_IN_IMAGE_REMSET 8
+
+#define GC_OLD_MARKED (GC_OLD | GC_MARKED) // reachable and old
+#define GC_IN_IMAGE_NOT_REMSET (GC_IN_IMAGE) // permalloc'd and not yet modified
 
 // data structures for runtime codegen
 typedef struct _jl_abi_t {
@@ -455,8 +458,8 @@ jl_value_t *jl_gc_small_alloc_noinline(jl_ptls_t ptls, int offset,
                                    int osize);
 jl_value_t *jl_gc_big_alloc_noinline(jl_ptls_t ptls, size_t allocsz);
 JL_DLLEXPORT int jl_gc_classify_pools(size_t sz, int *osize) JL_NOTSAFEPOINT;
-void gc_sweep_sysimg(void) JL_NOTSAFEPOINT;
-
+extern arraylist_t image_remset;
+extern jl_mutex_t image_remset_lock;
 
 // pools are 16376 bytes large (GC_POOL_SZ - GC_PAGE_OFFSET)
 static const int jl_gc_sizeclasses[] = {

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1986,11 +1986,17 @@ void LateLowerGCFrame::CleanupWriteBarriers(Function &F, State *S, const SmallVe
 
         IRBuilder<> builder(CI);
         builder.SetCurrentDebugLocation(CI->getDebugLoc());
-        auto parBits = builder.CreateAnd(EmitLoadTag(builder, T_size, parent), GC_OLD_MARKED, "parent_bits");
+        auto parTag = EmitLoadTag(builder, T_size, parent);
+        auto parBits = builder.CreateAnd(parTag, GC_OLD_MARKED, "parent_bits");
         auto parOldMarked = builder.CreateICmpEQ(parBits, ConstantInt::get(T_size, GC_OLD_MARKED), "parent_old_marked");
         auto mayTrigTerm = SplitBlockAndInsertIfThen(parOldMarked, CI, false);
         builder.SetInsertPoint(mayTrigTerm);
         mayTrigTerm->getParent()->setName("may_trigger_wb");
+        // At every generational boundary above the youngest, the "child marked"
+        // optimization does not apply so we can only check whether the parent
+        // is already in the relevant remset or not.
+        auto parInImage = builder.CreateAnd(parTag, ConstantInt::get(T_size, GC_IN_IMAGE | GC_IN_IMAGE_REMSET), "parent_in_image");
+        auto parIsImage = builder.CreateICmpEQ(parInImage, ConstantInt::get(T_size, GC_IN_IMAGE_NOT_REMSET), "parent_is_image");
         Value *anyChldNotMarked = NULL;
         for (unsigned i = 1; i < CI->arg_size(); i++) {
             Value *child = CI->getArgOperand(i);
@@ -1999,9 +2005,10 @@ void LateLowerGCFrame::CleanupWriteBarriers(Function &F, State *S, const SmallVe
             anyChldNotMarked = anyChldNotMarked ? builder.CreateOr(anyChldNotMarked, chldNotMarked) : chldNotMarked;
         }
         assert(anyChldNotMarked); // handled by all_of test above
+        auto shouldTrigger = builder.CreateOr(parIsImage, anyChldNotMarked, "should_trigger_wb");
         MDBuilder MDB(parent->getContext());
         SmallVector<uint32_t, 2> Weights{1, 9};
-        auto trigTerm = SplitBlockAndInsertIfThen(anyChldNotMarked, mayTrigTerm, false,
+        auto trigTerm = SplitBlockAndInsertIfThen(shouldTrigger, mayTrigTerm, false,
                                                   MDB.createBranchWeights(Weights));
         trigTerm->getParent()->setName("trigger_wb");
         builder.SetInsertPoint(trigTerm);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2186,41 +2186,11 @@ static void jl_read_arraylist(ios_t *s, arraylist_t *list)
     ios_read(s, (char*)list->items, list_len * sizeof(void*));
 }
 
-void gc_sweep_sysimg(void) JL_NOTSAFEPOINT
-{
-    size_t nblobs = n_linkage_blobs();
-    if (nblobs == 0)
-        return;
-    assert(jl_linkage_blobs.len == 2*nblobs);
-    assert(jl_image_relocs.len == nblobs);
-    for (size_t i = 0; i < 2*nblobs; i+=2) {
-        reloc_t *relocs = (reloc_t*)jl_image_relocs.items[i>>1];
-        if (!relocs)
-            continue;
-        uintptr_t base = (uintptr_t)jl_linkage_blobs.items[i];
-        uintptr_t last_pos = 0;
-        uint8_t *current = (uint8_t *)relocs;
-        while (1) {
-            // Read the offset of the next object
-            size_t pos_diff = 0;
-            size_t cnt = 0;
-            while (1) {
-                int8_t c = *current++;
-                pos_diff |= ((size_t)c & 0x7F) << (7 * cnt++);
-                if ((c >> 7) == 0)
-                    break;
-            }
-            if (pos_diff == 0)
-                break;
-
-            uintptr_t pos = last_pos + pos_diff;
-            last_pos = pos;
-            jl_taggedvalue_t *o = (jl_taggedvalue_t *)(base + pos);
-            o->bits.gc = GC_OLD;
-            assert(o->bits.in_image == 1);
-        }
-    }
-}
+// Persistent set of image objects that reference non-image objects.
+// Used to track GC reachability for mutable objects in the images,
+// treating them as a third, "permanent" GC generation.
+arraylist_t image_remset;
+jl_mutex_t image_remset_lock;
 
 // jl_write_value and jl_read_value are used for storing Julia objects that are adjuncts to
 // the image proper. For example, new methods added to external callables require
@@ -3946,7 +3916,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
     reloc_t *relocs_base = (reloc_t*)&relocs.buf[0];
 
     s.s = &sysimg;
-    jl_read_reloclist(&s, s.link_ids_gctags, GC_OLD | GC_IN_IMAGE); // gctags
+    jl_read_reloclist(&s, s.link_ids_gctags, GC_OLD_MARKED | GC_IN_IMAGE); // gctags
     size_t sizeof_tags = ios_pos(&relocs);
     (void)sizeof_tags;
     jl_read_reloclist(&s, s.link_ids_relocs, 0); // general relocs
@@ -4072,7 +4042,7 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image,
             arraylist_push(&cleanup_list, (void*)obj);
         }
         if (tag == 1)
-            *pfld = (uintptr_t)newobj | GC_OLD | GC_IN_IMAGE;
+            *pfld = (uintptr_t)newobj | GC_OLD_MARKED | GC_IN_IMAGE;
         else
             *pfld = (uintptr_t)newobj;
         assert(!(image_base < (char*)newobj && (char*)newobj <= image_base + sizeof_sysimg));

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -407,7 +407,9 @@ end
 
     # ensure that string data is redacted by default
     fname = cd(tmpdir) do
-        read(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; const x = \"redact_this\"; print(Profile.take_heap_snapshot())"`, String)
+        # (and also that the snapshot works when taking
+        #  a snapshot with a live exception stack)
+        read(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; const x = \"redact_this\"; f() = error(\"boom\"); try; f(); catch; print(Profile.take_heap_snapshot()); end"`, String)
     end
 
     @test isfile(fname)


### PR DESCRIPTION
This is a backport of https://github.com/JuliaLang/julia/pull/61474 and part of https://github.com/JuliaLang/julia/pull/61937, to restore the old heap snapshot behavior.

The snapshot implementation is now quite awkward, since the image remset expects to mark its objects quite early. However for the snapshot, we want to ignore any reachability from the image remset. That means the remset must not be marked until very late, so that we can fully collect the reachable object graph for the other "normal" roots. Nonetheless this seems like a good compromise on 1.13.

I have locally verified that a snapshot with the 1.13 RC1 sysimage gives a ~nearly identical heap (~200 objects differ, out of 1.6M)

Co-developed-by: Claude Opus 4.8 <noreply@anthropic.com>