### PR TITLE
`@cfunction`: Strengthen atomic ordering slightly

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7581,13 +7581,15 @@ std::string emit_abi_constreturn(jl_codegen_output_t &out, bool specsig, jl_code
     return emit_abi_constreturn(out, abi, codeinst->rettype_const);
 }
 
+// (get_abi_converter / method table mutating thread)
 // release jl_world_counter
-// store theFptr
+// release theFptr
 // release last_world_v
 //
+// (dispatch site)
 // acquire last_world_v
-// read theFptr
-// acquire jl_world_counter
+// acquire theFptr
+// read jl_world_counter
 // if (last_world_v != jl_world_counter)
 //   fptr = compute_new_fptr(&last_world_v)
 // return fptr()
@@ -7622,10 +7624,10 @@ static jl_cgval_t emit_abi_call(jl_codectx_t &ctx, jl_value_t *declrt, jl_value_
         LoadInst *last_world_v = ctx.builder.CreateAlignedLoad(T_size, last_world_p, ctx.types().alignof_ptr);
         last_world_v->setOrdering(AtomicOrdering::Acquire);
         LoadInst *callee = ctx.builder.CreateAlignedLoad(T_ptr, cfuncdata, ctx.types().alignof_ptr);
-        callee->setOrdering(AtomicOrdering::Monotonic);
+        callee->setOrdering(AtomicOrdering::Acquire);
         LoadInst *world_v = ctx.builder.CreateAlignedLoad(ctx.types().T_size,
             prepare_global_in(M, jlgetworld_global), ctx.types().alignof_ptr);
-        world_v->setOrdering(AtomicOrdering::Acquire);
+        world_v->setOrdering(AtomicOrdering::Monotonic);
         ctx.builder.CreateStore(world_v, world_age_field);
         Value *age_not_ok = ctx.builder.CreateICmpNE(last_world_v, world_v);
         Value *target = emit_guarded_test(ctx, age_not_ok, callee, [&] {

--- a/src/runtime_ccall.c
+++ b/src/runtime_ccall.c
@@ -363,13 +363,21 @@ static inline const char *name_from_method_instance(jl_method_instance_t *mi) JL
 }
 
 static jl_mutex_t cfun_lock;
+
+// (get_abi_converter / method table mutating thread)
 // release jl_world_counter
-// store theFptr
+// release theFptr
 // release last_world_v
 //
+// (dispatch site)
 // acquire last_world_v
-// read theFptr
-// acquire jl_world_counter
+// acquire theFptr
+// read jl_world_counter
+//
+// The above ordering requirements are intended to guarantee that if the
+// dispatch site observes last_world == jl_world_counter then the loaded
+// fptr is consistent with both of them, meaning it was published for
+// exactly that world.
 JL_DLLEXPORT
 void *jl_get_abi_converter(jl_task_t *ct, void *data)
 {
@@ -448,7 +456,7 @@ void *jl_get_abi_converter(jl_task_t *ct, void *data)
 
     cfuncdata->plast_codeinst = &cfuncdata->last_codeinst;
     cfuncdata->last_codeinst = codeinst;
-    jl_atomic_store_relaxed(&cfuncdata->fptr, f);
+    jl_atomic_store_release(&cfuncdata->fptr, f);
     jl_atomic_store_release(&cfuncdata->last_world, world);
     JL_UNLOCK(&cfun_lock);
     return f;


### PR DESCRIPTION
This strengthening seems to be required on weakly-ordered memory architectures, since otherwise it is technically possible for theFptr to observe a store from one publish event even though last_world and jl_world_counter both observed the stores from a strictly previous one.

If that happens, it's a soundness gap since it can mean invoking a CodeInstance in a world it was not compiled for. I expect this is unlikely to be an issue in practice, but it's good to tighten up anyway.

Found by human inspection and then discussed / explored with Claude 🤖 

At @vtjnash's recommendation I also had Claude write a TLA+ proof of the strengthened atomics. Although I do not understand TLA and I do not know if its model is reasonable, the TLA model checker did seem to find the counter-example that I had in mind (pre-strengthening): [cfunction-wrc-proof.tar.gz](https://github.com/user-attachments/files/28611374/cfunction-wrc-proof.tar.gz)

