### PR TITLE
document/make public IteratorEltype and IteratorSize return types

### DIFF
--- a/base/generator.jl
+++ b/base/generator.jl
@@ -60,9 +60,38 @@ isdone(g::Generator, state...) = isdone(g.iter, state...)
 ## iterator traits
 
 abstract type IteratorSize end
+
+"""
+    SizeUnknown <: IteratorSize
+
+Singleton type returned by [`IteratorSize`](@ref) for iterators whose length
+(number of elements) cannot be determined in advance.
+"""
 struct SizeUnknown <: IteratorSize end
+
+"""
+    HasLength <: IteratorSize
+
+Singleton type returned by [`IteratorSize`](@ref) for iterators whose length
+is fixed, finite, and returned by [`length`](@ref).
+"""
 struct HasLength <: IteratorSize end
+
+"""
+    HasShape{N} <: IteratorSize
+
+Singleton type returned by [`IteratorSize`](@ref) for iterators with a known length
+plus a notion of multidimensional shape (as for an array).  `N` should give the number of dimensions,
+and the [`axes`](@ref) function is valid for the iterator.
+"""
 struct HasShape{N} <: IteratorSize end
+
+"""
+    IsInfinite <: IteratorSize
+
+Singleton type returned by [`IteratorSize`](@ref) for iterators which
+yield values forever.
+"""
 struct IsInfinite <: IteratorSize end
 
 """
@@ -103,7 +132,21 @@ IteratorSize(::Type{<:Generator{I}}) where {I} = (@isdefined I) ? IteratorSize(I
 haslength(iter) = IteratorSize(iter) isa Union{HasShape, HasLength}
 
 abstract type IteratorEltype end
+
+"""
+    EltypeUnknown <: IteratorEltype
+
+Singleton type returned by [`IteratorEltype`](@ref) for iterators whose element
+type is not known in advance.
+"""
 struct EltypeUnknown <: IteratorEltype end
+
+"""
+    HasEltype <: IteratorEltype
+
+Singleton type returned by [`IteratorEltype`](@ref) for iterators whose element
+type known and returned by [`eltype`](@ref).
+"""
 struct HasEltype <: IteratorEltype end
 
 """

--- a/base/public.jl
+++ b/base/public.jl
@@ -38,7 +38,13 @@ public
 
 # collections
     IteratorEltype,
+    EltypeUnknown,
+    HasEltype,
     IteratorSize,
+    SizeUnknown,
+    HasLength,
+    HasShape,
+    IsInfinite,
     to_index,
     vect,
     isdone,


### PR DESCRIPTION
`IteratorEltype` and `IteratorSize` were `public` and documented, but I noticed that their various return types (`HasEltype` etcetera) were not marked `public` and had no docstrings, despite being documented within the docstrings of `IteratorEltype` and `IteratorSize` .

(Note that, once they are marked `public`, the existence of docstrings [is tested](https://github.com/JuliaLang/julia/blob/1f0777f0f6e1b8eac0429651bb18a2e8f3bf842b/test/iterators.jl#L1221-L1223).)

cc @LilithHafner, who made `IteratorEltype` and `IteratorSize` public in #50105 but not their subtypes.