### PR TITLE
subtype: don't classify abstract AnyType as a kind for dispatch caching

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1497,7 +1497,10 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
             return 0;
         }
 
-        if (jl_is_typeeq(jl_unwrap_unionall(elt))) {
+        // `elt` can be either equal representation of `Type` (specializations are
+        // deduplicated by type-equality): both take the `jl_types_equal(elt,
+        // jl_type_type)` path; an `AnyType` elt must not reach `jl_typeeq_T` below
+        if (jl_is_typeeq(jl_unwrap_unionall(elt)) || elt == (jl_value_t*)jl_anytype_type) {
             int iscalled = (i_arg > 0 && i_arg <= 8 && (definition->called & (1 << (i_arg - 1)))) ||
                            jl_has_free_typevars(decl_i);
             if (jl_types_equal(elt, (jl_value_t*)jl_type_type)) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -1484,10 +1484,8 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
             // kind slots always get guard entries (checking for subtypes of Type)
             if (jl_subtype(elt, type_i) && !jl_subtype((jl_value_t*)jl_type_type, type_i))
                 continue;
-            // if the declared slot is itself a kind (e.g. `::DataType` or the
-            // maximal `::Kind`, which is type-equal to `Type`), then
-            // jl_compilation_sig keeps the kind argument equal to that slot, so
-            // that is the canonical compileable form.
+            // jl_compilation_sig keeps a slot declared as a concrete kind (e.g.
+            // `::DataType`) equal to that kind, making it the canonical form
             if (jl_is_kind(type_i) && jl_egal(elt, type_i))
                 continue;
             // TODO: other code paths that could reach here?

--- a/src/julia.h
+++ b/src/julia.h
@@ -1701,7 +1701,7 @@ int is_leaf_bound(jl_value_t *v) JL_NOTSAFEPOINT;
 
 STATIC_INLINE int jl_is_kind(jl_value_t *v) JL_NOTSAFEPOINT
 {
-    return (v==(jl_value_t*)jl_anytype_type || v==(jl_value_t*)jl_uniontype_type || v==(jl_value_t*)jl_datatype_type ||
+    return (v==(jl_value_t*)jl_uniontype_type || v==(jl_value_t*)jl_datatype_type ||
             v==(jl_value_t*)jl_unionall_type || v==(jl_value_t*)jl_typeeq_type ||
             v==(jl_value_t*)jl_typeofbottom_type);
 }

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -640,6 +640,13 @@ static int obviously_in_union(jl_value_t *u, jl_value_t *x)
     return obviously_egal(u, x);
 }
 
+// the types whose instances are all themselves types: the concrete kinds plus the
+// abstract kind `AnyType` (`== Type`, though not `===`)
+STATIC_INLINE int is_kind_or_anytype(jl_value_t *t) JL_NOTSAFEPOINT
+{
+    return jl_is_kind(t) || t == (jl_value_t*)jl_anytype_type;
+}
+
 int obviously_disjoint(jl_value_t *a, jl_value_t *b, int specificity) JL_NOTSAFEPOINT
 {
     if (a == b || a == (jl_value_t*)jl_any_type || b == (jl_value_t*)jl_any_type)
@@ -2106,7 +2113,11 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, jl_param_pos_t p
     if (jl_is_datatype(x) && jl_is_typeeq(y) && x != (jl_value_t*)jl_typeofbottom_type) {
         jl_value_t *tp0 = jl_typeeq_T(y);
         if (jl_is_typevar(tp0)) {
-            if (!jl_is_kind(x))
+            // kinds and `AnyType` are subtypes of `Type` but of no narrower `Type{T'}`,
+            // and no `TypeEq` appears in their supertype chains to derive this from; so
+            // answer as for `Type <: Type{T}`, at the depth where `Type{T}` occurs (the
+            // depth of `x` doesn't matter: it doesn't contain the variable)
+            if (!is_kind_or_anytype(x))
                 return 0;
             return subtype((jl_value_t*)jl_type_type, y, e, param);
         }
@@ -3050,7 +3061,7 @@ int jl_has_intersect_type_not_kind(jl_value_t *t)
                jl_has_intersect_type_not_kind(((jl_uniontype_t*)t)->b);
     if (jl_is_typeeq(t)) {
         jl_value_t *T = jl_typeeq_T(t);
-        return jl_is_typevar(T) || !jl_is_kind(T);
+        return jl_is_typevar(T) || !is_kind_or_anytype(T);
     }
     if (jl_is_typevar(t))
         return jl_has_intersect_type_not_kind(((jl_tvar_t*)t)->ub);
@@ -3064,7 +3075,7 @@ int jl_has_intersect_type_not_kind(jl_value_t *t)
 int jl_has_intersect_kind_not_type(jl_value_t *t)
 {
     t = jl_unwrap_unionall(t);
-    if (t == (jl_value_t*)jl_any_type || jl_is_kind(t))
+    if (t == (jl_value_t*)jl_any_type || is_kind_or_anytype(t))
         return 1;
     assert(!jl_is_vararg(t));
     if (jl_is_uniontype(t))
@@ -3072,7 +3083,7 @@ int jl_has_intersect_kind_not_type(jl_value_t *t)
                jl_has_intersect_kind_not_type(((jl_uniontype_t*)t)->b);
     if (jl_is_typeeq(t)) {
         jl_value_t *T = jl_typeeq_T(t);
-        return jl_is_typevar(T) || jl_is_kind(T);
+        return jl_is_typevar(T) || is_kind_or_anytype(T);
     }
     if (jl_is_typevar(t))
         return jl_has_intersect_kind_not_type(((jl_tvar_t*)t)->ub);
@@ -4529,7 +4540,7 @@ static jl_value_t *intersect_type_type(jl_value_t *x, jl_value_t *y, jl_stenv_t 
     jl_value_t *p0 = jl_typeeq_T(x);
     if (!jl_is_typevar(p0))
         return (jl_typeof(p0) == y) ? x : jl_bottom_type;
-    if (!jl_is_kind(y)) return jl_bottom_type;
+    if (!is_kind_or_anytype(y)) return jl_bottom_type;
     if (y == (jl_value_t*)jl_typeofbottom_type && ((jl_tvar_t*)p0)->lb == jl_bottom_type)
         return (jl_value_t*)jl_wrap_Type(jl_bottom_type);
     if (((jl_tvar_t*)p0)->ub == (jl_value_t*)jl_any_type)
@@ -6156,7 +6167,7 @@ static int type_morespecific_(jl_value_t *a, jl_value_t *b, jl_value_t *a0, jl_v
     if (jl_is_datatype(a) && jl_is_datatype(b)) {
         jl_datatype_t *tta = (jl_datatype_t*)a, *ttb = (jl_datatype_t*)b;
         // Type{Union{}} is more specific than other types, so TypeofBottom must be too
-        if (tta == jl_typeofbottom_type && (jl_is_kind(b) || jl_is_typeeq(b)))
+        if (tta == jl_typeofbottom_type && (is_kind_or_anytype(b) || jl_is_typeeq(b)))
             return 1;
         int super = 0;
         while (tta != jl_any_type) {

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -34,7 +34,12 @@ static jl_value_t *jl_type_extract_name(jl_value_t *t1 JL_PROPAGATES_ROOT, int i
         return jl_type_extract_name(((jl_tvar_t*)t1)->ub, 0);
     }
     else if (jl_is_typeeq(t1)) {
-        return (jl_value_t*)jl_type_typename;
+        // invariantly (a `T` from inside `Type{T}`, keying targ/tname) this is TypeEq's
+        // name; covariantly the key must lie on both the `typeof(arg)` and the TypeEq
+        // wrapper supertype chains that lookups walk, which intersect at `AnyType`
+        if (invariant)
+            return (jl_value_t*)jl_type_typename;
+        return (jl_value_t*)jl_anytype_type->name;
     }
     else if (t1 == jl_bottom_type || t1 == (jl_value_t*)jl_typeofbottom_type) {
         return (jl_value_t*)jl_typeofbottom_type->name; // put Union{} and typeof(Union{}) and Type{Union{}} together for convenience
@@ -42,7 +47,7 @@ static jl_value_t *jl_type_extract_name(jl_value_t *t1 JL_PROPAGATES_ROOT, int i
     else if (jl_is_datatype(t1)) {
         jl_datatype_t *dt = (jl_datatype_t*)t1;
         if (jl_is_kind(t1) && !invariant)
-            return (jl_value_t*)jl_type_typename;
+            return (jl_value_t*)jl_anytype_type->name;
         return (jl_value_t*)dt->name;
     }
     else if (jl_is_uniontype(t1)) {
@@ -452,6 +457,10 @@ static int tname_intersection(jl_value_t *a, jl_typename_t *bname, int8_t tparam
         a = jl_unwrap_unionall(jl_typeeq_T(a));
         if (!jl_is_datatype(a))
             return tname_intersection(a, bname, 0);
+    }
+    else if (jl_is_typeeq(a)) {
+        // a covariant `TypeEq{...}` reaches name buckets via its kind's supertype chain
+        return tname_intersection_dt(jl_typeeq_type, bname, jl_supertype_height(jl_typeeq_type));
     }
     if (jl_is_datatype(a)) {
         return tname_intersection_dt((jl_datatype_t*)a, bname, jl_supertype_height((jl_datatype_t*)a));

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -41,8 +41,10 @@ static jl_value_t *jl_type_extract_name(jl_value_t *t1 JL_PROPAGATES_ROOT, int i
             return (jl_value_t*)jl_type_typename;
         return (jl_value_t*)jl_anytype_type->name;
     }
-    else if (t1 == jl_bottom_type || t1 == (jl_value_t*)jl_typeofbottom_type) {
-        return (jl_value_t*)jl_typeofbottom_type->name; // put Union{} and typeof(Union{}) and Type{Union{}} together for convenience
+    else if (t1 == jl_bottom_type || (t1 == (jl_value_t*)jl_typeofbottom_type && invariant)) {
+        // group Union{} with Type{Union{}} for targ keying; a covariant typeof(Union{})
+        // is an ordinary concrete kind and files with the kinds below
+        return (jl_value_t*)jl_typeofbottom_type->name;
     }
     else if (jl_is_datatype(t1)) {
         jl_datatype_t *dt = (jl_datatype_t*)t1;

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -129,7 +129,7 @@ static int sig_match_by_type_leaf(jl_value_t **types, jl_tupletype_t *sig, size_
 static int jl_subtype_anytype(jl_value_t *a) JL_NOTSAFEPOINT
 {
     while (1) {
-        if (jl_is_kind(a) || jl_is_typeeq(a))
+        if (a == (jl_value_t*)jl_anytype_type || jl_is_kind(a) || jl_is_typeeq(a))
             return 1;
         else if (jl_is_unionall(a))
             a = jl_unwrap_unionall(a);
@@ -1495,8 +1495,9 @@ jl_typemap_entry_t *jl_typemap_alloc(
     size_t i, l;
     for (i = 0, l = jl_nparams(ttype); i < l && issimplesig; i++) {
         jl_value_t *decl = jl_tparam(ttype, i);
-        if (jl_is_kind(decl))
-            isleafsig = 0; // Type{} may have a higher priority than a kind
+        if (jl_is_kind(decl) || decl == (jl_value_t*)jl_anytype_type)
+            isleafsig = 0; // Type{} may have a higher priority than a kind; both are
+                           // still simple for sig_match_simple
         else if (jl_is_typeeq(decl))
             isleafsig = 0; // Type{} may need special processing to compute the match
         else if (jl_is_vararg(decl))

--- a/test/core.jl
+++ b/test/core.jl
@@ -499,6 +499,24 @@ end
 @test any(m -> m.sig == Tuple{typeof(anytype_levelsplit_61915), DataType},
           methods(anytype_levelsplit_61915, (Union{Type{Int}, Int},)))
 
+# `Core.TypeofBottom` methods file with the kinds: method matching and dispatch with
+# `Type{...}`-represented queries (e.g. for the value `Union{}`) must reach them after
+# a level split instead of using a less specific `::Type` method
+anytype_bottom_61915(::Core.TypeofBottom) = 0
+anytype_bottom_61915(@nospecialize ::Type) = 1
+anytype_bottom_61915(::Integer) = 2
+anytype_bottom_61915(::AbstractString) = 3
+anytype_bottom_61915(::AbstractFloat) = 4
+anytype_bottom_61915(::AbstractVector) = 5
+anytype_bottom_61915(::Exception) = 6
+anytype_bottom_61915(::IO) = 7
+anytype_bottom_61915(::Function) = 8
+let f = Ref{Any}(anytype_bottom_61915), r = Ref{Any}(Union{})
+    @noinline callit() = f[](r[])
+    @test callit() == 0
+    @test length(methods(anytype_bottom_61915, (Type,))) == 2
+end
+
 @test promote_type(Bool,Bottom) === Bool
 
 # type declarations

--- a/test/core.jl
+++ b/test/core.jl
@@ -517,6 +517,22 @@ let f = Ref{Any}(anytype_bottom_61915), r = Ref{Any}(Union{})
     @test length(methods(anytype_bottom_61915, (Type,))) == 2
 end
 
+# specializations are deduplicated by type equality (`Type == Core.AnyType`), so
+# `specTypes` carries whichever representation was interned first and
+# `jl_isa_compileable_sig` must accept both
+anytype_compilesig_61915(io::IO, T::Type) = 1
+let m = only(methods(anytype_compilesig_61915))
+    miA = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance}, (Any, Any, Any),
+                m, Tuple{typeof(anytype_compilesig_61915), IOBuffer, Core.AnyType}, Core.svec())
+    miB = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance}, (Any, Any, Any),
+                m, Tuple{typeof(anytype_compilesig_61915), IOBuffer, Type}, Core.svec())
+    @test miA === miB
+    for S in (Type, Core.AnyType)
+        sig = Tuple{typeof(anytype_compilesig_61915), IOBuffer, S}
+        @test ccall(:jl_isa_compileable_sig, Cint, (Any, Any, Any), sig, Core.svec(), m) == 1
+    end
+end
+
 @test promote_type(Bool,Bottom) === Bool
 
 # type declarations

--- a/test/core.jl
+++ b/test/core.jl
@@ -450,6 +450,23 @@ let get_param(::Type{Type{T}}) where {T} = T
     @test Tuple(get_param(t) for t in (Type{Int}, Type{Float64})) === (Int, Float64)
 end
 
+# PR #61915: dispatch onto an `@nospecialize`d `::Core.AnyType` method with a type-valued
+# argument must hit the method cache (a miss re-runs the full lookup, which allocates).
+# The extra methods keep inference from devirtualizing the call site outright.
+struct AnyTypeCache61915a end
+struct AnyTypeCache61915b end
+anytype_dispatch_61915(::Int8) = 1
+anytype_dispatch_61915(@nospecialize t::Core.AnyType) = 2
+anytype_dispatch_61915(::TypeVar) = 3
+anytype_dispatch_61915(::AnyTypeCache61915a) = 4
+anytype_dispatch_61915(::AnyTypeCache61915b) = 5
+let r = Ref{Any}(Int)
+    @noinline callit() = anytype_dispatch_61915(r[])
+    @test callit() == 2          # dispatches to the `::Core.AnyType` method
+    callit()                     # warmup: populate the method cache
+    @test @allocated(callit()) == 0
+end
+
 @test promote_type(Bool,Bottom) === Bool
 
 # type declarations

--- a/test/core.jl
+++ b/test/core.jl
@@ -467,6 +467,38 @@ let r = Ref{Any}(Int)
     @test @allocated(callit()) == 0
 end
 
+# kind-typed (e.g. `::DataType`) and `::Core.AnyType` cache entries must stay reachable
+# (allocation-free dispatch) after the typemap node holding them splits into a level
+anytype_levelsplit_61915(@nospecialize x::Integer) = 1
+anytype_levelsplit_61915(@nospecialize x::AbstractString) = 2
+anytype_levelsplit_61915(@nospecialize x::AbstractFloat) = 3
+anytype_levelsplit_61915(@nospecialize x::AbstractVector) = 4
+anytype_levelsplit_61915(@nospecialize x::Exception) = 5
+anytype_levelsplit_61915(@nospecialize x::IO) = 6
+anytype_levelsplit_61915(@nospecialize x::Function) = 7
+anytype_levelsplit_61915(@nospecialize x::DataType) = 8
+anytype_levelsplit_61915(@nospecialize x::Core.AnyType) = 9
+let f = Ref{Any}(anytype_levelsplit_61915), r = Ref{Any}(Int)
+    @noinline callit() = f[](r[])
+    # populate one widened cache entry per method so the typemap node splits into a level
+    for a in Any[1, "", 1.0, [1], ErrorException(""), IOBuffer(), sin, Int, Union{Int,Char}]
+        r[] = a
+        callit(); callit()
+    end
+    r[] = Int                      # typeof(Int) === DataType: the `::DataType` method
+    @test callit() == 8
+    callit()
+    @test @allocated(callit()) == 0
+    r[] = Union{Int,Char}          # typeof is the `Union` kind: the `::AnyType` method
+    @test callit() == 9
+    callit()
+    @test @allocated(callit()) == 0
+end
+# union-mixed queries take the full-scan intersection path over the method definitions,
+# which must also reach the kind-keyed bucket
+@test any(m -> m.sig == Tuple{typeof(anytype_levelsplit_61915), DataType},
+          methods(anytype_levelsplit_61915, (Union{Type{Int}, Int},)))
+
 @test promote_type(Bool,Bottom) === Bool
 
 # type declarations


### PR DESCRIPTION
PR #61915 made `AnyType` (the abstract supertype of the concrete kinds, with `Type === AnyType`) report true from `jl_is_kind`, and switched many hot inference signatures from `::Type` to `::AnyType`. In `jl_compilation_sig`, a kind-typed parameter slot is cached as the bare kind and marked as requiring guard entries. That is correct for a concrete kind, which a type-valued argument pins exactly, but not for the abstract `AnyType`, which it does not. As a result, dispatching such a method on a type-valued argument never produced a usable optimized-cache entry, so every call fell back to a full type-intersection method lookup. This made the type-manipulating code in inference (e.g. `widenconst`, `tmerge`, `⊑`) several times slower and regressed inference by up to ~5x in the daily nanosoldier benchmarks.

Restrict `jl_is_kind` to the concrete kinds (matching `jl_is_kindtag`) so that `::AnyType` parameters are cached like ordinary signatures. Subtyping queries that need to treat `AnyType` as a kind, so that `Type == AnyType` and the related intersection and specificity relations keep holding, now do so explicitly via `is_kind_or_anytype`.