### PR TITLE
Compiler: don't dynamic dispatch `widenconst`

### DIFF
--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -696,7 +696,7 @@ _widenconst(t::PartialOpaque) = t.typ
 _widenconst(::TypeVar) = error("unhandled TypeVar")
 _widenconst(::TypeofVararg) = error("unhandled Vararg")
 _widenconst(::LimitedAccuracy) = error("unhandled LimitedAccuracy")
-typeof(_widenconst).name.max_methods = UInt8(10)
+typeof(_widenconst).name.max_methods = UInt8(20)
 
 """
     widenconst(x) -> t::Type

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -681,21 +681,29 @@ end
     return tmeet(widenlattice(𝕃), v, t)
 end
 
+# The widening rules live in `_widenconst`. `widenconst` itself is a single-method
+# wrapper, so callers never have to dynamically dispatch over the (megamorphic) set of
+# lattice element types. `_widenconst`'s `max_methods` is raised above its method count so
+# that inference union-splits the wrapper body into a devirtualized `isa`-chain rather than
+# falling back to a runtime method lookup.
+_widenconst(::AnyConditional) = Bool
+_widenconst(a::AnyMustAlias) = widenconst(widenmustalias(a))
+_widenconst(c::Const) = (v = c.val; isa(v, Type) ? Type{v} : typeof(v))
+_widenconst(::PartialTypeVar) = TypeVar
+_widenconst(t::Core.PartialStruct) = t.typ
+_widenconst(t::PartialOpaque) = t.typ
+@nospecializeinfer _widenconst(@nospecialize t::AnyType) = t
+_widenconst(::TypeVar) = error("unhandled TypeVar")
+_widenconst(::TypeofVararg) = error("unhandled Vararg")
+_widenconst(::LimitedAccuracy) = error("unhandled LimitedAccuracy")
+typeof(function _widenconst end).name.max_methods = UInt8(10)
+
 """
     widenconst(x) -> t::Type
 
 Widens extended lattice element `x` to native `Type` representation.
 """
-widenconst(::AnyConditional) = Bool
-widenconst(a::AnyMustAlias) = widenconst(widenmustalias(a))
-widenconst(c::Const) = (v = c.val; isa(v, Type) ? Type{v} : typeof(v))
-widenconst(::PartialTypeVar) = TypeVar
-widenconst(t::Core.PartialStruct) = t.typ
-widenconst(t::PartialOpaque) = t.typ
-@nospecializeinfer widenconst(@nospecialize t::AnyType) = t
-widenconst(::TypeVar) = error("unhandled TypeVar")
-widenconst(::TypeofVararg) = error("unhandled Vararg")
-widenconst(::LimitedAccuracy) = error("unhandled LimitedAccuracy")
+widenconst(@nospecialize x) = _widenconst(x)
 
 ####################
 # state management #

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -696,7 +696,7 @@ _widenconst(t::PartialOpaque) = t.typ
 _widenconst(::TypeVar) = error("unhandled TypeVar")
 _widenconst(::TypeofVararg) = error("unhandled Vararg")
 _widenconst(::LimitedAccuracy) = error("unhandled LimitedAccuracy")
-typeof(function _widenconst end).name.max_methods = UInt8(10)
+typeof(_widenconst).name.max_methods = UInt8(10)
 
 """
     widenconst(x) -> t::Type

--- a/Compiler/test/AbstractInterpreter.jl
+++ b/Compiler/test/AbstractInterpreter.jl
@@ -358,7 +358,7 @@ function Compiler.:⊑(𝕃::AnyTaintLattice, @nospecialize(typea), @nospecializ
     end
     return ⊑(widenlattice(𝕃), typea, typeb)
 end
-Compiler.widenconst(taint::AnyTaint) = widenconst(taint.typ)
+Compiler._widenconst(taint::AnyTaint) = widenconst(taint.typ)
 
 function Compiler.abstract_eval_special_value(interp::TaintInterpreter,
     @nospecialize(e), sstate::Compiler.StatementState, sv::Compiler.InferenceState)

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -23,6 +23,20 @@ let ast = only(code_typed(f39082, Tuple{Rational, Vararg{Rational}}))[1]
     @test ast.slottypes == Any[Const(f39082), Tuple{Rational, Vararg{Rational}}]
 end
 
+# `widenconst` is a single-method wrapper forwarding to the `_widenconst` rule methods
+# (see `Compiler/src/typelattice.jl`); inference must union-split its body into a
+# devirtualized `isa`-chain rather than emitting a dynamic dispatch over the lattice
+# element types (a dynamic dispatch here made inference itself much slower).
+let src = code_typed1(Compiler.widenconst, (Any,))
+    function isdyndispatch(@nospecialize stmt)
+        isexpr(stmt, :(=)) && (stmt = stmt.args[2])
+        isexpr(stmt, :call) || return false
+        f = singleton_type(argextype(stmt.args[1], src))
+        return !(isa(f, Core.Builtin) || isa(f, Core.IntrinsicFunction))
+    end
+    @test !any(isdyndispatch, src.code)
+end
+
 # demonstrate some of the type-size limits
 @test Compiler.limit_type_size(Ref{Complex{T} where T}, Ref, Ref, 100, 0) == Ref
 @test Compiler.limit_type_size(Ref{Complex{T} where T}, Ref{Complex{T} where T}, Ref, 100, 0) == Ref{Complex{T} where T}


### PR DESCRIPTION
As mentioned in https://github.com/JuliaLang/julia/pull/62014, `widenconst(::Any)` is currently a dynamic dispatch. While that PR fixes the performance of that dispatch, it is also unnecessary since the set of type sare fixed. It is faster to inline an if nest. Force the compiler to do that (without increasing code size by generating it once and moving the rules to a helper).