### PR TITLE
REPL: add docstrings for AbstractREPL, BasicREPL, LineEditREPL, StreamREPL

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -64,6 +64,24 @@ _displaysize(io::IO) = displaysize(io)::Tuple{Int,Int}
 
 using Base.Terminals
 
+"""
+    AbstractREPL
+
+Supertype for all Read-Eval-Print Loop (REPL) frontends.
+
+A REPL frontend reads user input, hands complete expressions to a backend for
+evaluation, and prints the response. A backend is started and connected to the
+frontend by [`run_repl`](@ref). The three concrete frontends shipped with Julia
+are [`LineEditREPL`](@ref) — the interactive terminal REPL with line editing,
+history, and prompt modes — [`BasicREPL`](@ref) — a minimal line-based fallback —
+and [`StreamREPL`](@ref) — a frontend that drives the REPL over an arbitrary
+`IO` stream.
+
+A concrete subtype `R <: AbstractREPL` is expected to implement
+`run_frontend(repl::R, backend::REPLBackendRef)`, which runs the read/print loop
+and feeds parsed input to `backend`, and the accessors `outstream(repl::R)` and
+`hascolor(repl::R)`.
+"""
 abstract type AbstractREPL end
 
 include("options.jl")
@@ -704,6 +722,20 @@ end
 
 ## BasicREPL ##
 
+"""
+    BasicREPL(terminal::TextTerminal) -> BasicREPL
+
+A minimal REPL frontend that reads input line-by-line from `terminal` without
+line editing, history, or prompt modes.
+
+`BasicREPL` is the fallback frontend used instead of [`LineEditREPL`](@ref) when
+the terminal is not fully functional — that is, when the `TERM` environment
+variable is `"dumb"` (or unset, on non-Windows systems). It writes a plain
+`julia> ` prompt, reads a complete expression (continuing to read while the
+parser reports the input as incomplete), evaluates it on the backend, and prints
+the response. Input is terminated by EOF (Ctrl-D); an `InterruptException`
+(Ctrl-C) cancels the current line.
+"""
 mutable struct BasicREPL <: AbstractREPL
     terminal::TextTerminal
     waserror::Bool
@@ -763,6 +795,31 @@ end
 
 ## LineEditREPL ##
 
+"""
+    LineEditREPL(t::TextTerminal, hascolor::Bool, envcolors::Bool=false) -> LineEditREPL
+
+The interactive line-editing REPL frontend: this is the REPL you get at a normal
+`julia` session prompt.
+
+It drives the terminal `t` through the `LineEdit` modal interface, providing line
+editing, history, tab completion, and the standard prompt modes (the `julia>`
+prompt, shell mode `;`, help mode `?`, and the package mode added by Pkg).
+`hascolor` selects whether output is colorized; when `envcolors` is `true`,
+prompt/input/answer colors follow the corresponding environment-variable settings
+rather than this REPL's own color fields.
+
+Construct one and start it with [`run_repl`](@ref):
+
+```julia
+import REPL
+term = REPL.Terminals.TTYTerminal("dumb", stdin, stdout, stderr)
+repl = REPL.LineEditREPL(term, true)
+REPL.run_repl(repl)
+```
+
+See also [`BasicREPL`](@ref) for the non-line-editing fallback and
+[`StreamREPL`](@ref) for driving a REPL over a plain `IO` stream.
+"""
 mutable struct LineEditREPL <: AbstractREPL
     t::TextTerminal
     hascolor::Bool
@@ -1705,6 +1762,21 @@ end
 
 ## StreamREPL ##
 
+"""
+    StreamREPL(stream::IO) -> StreamREPL
+
+A REPL frontend that reads input from, and writes results to, an arbitrary `IO`
+`stream`.
+
+Unlike [`LineEditREPL`](@ref) it provides no line editing or prompt modes: it
+prints a banner and a `julia> ` prompt to `stream`, reads one line at a time
+until end-of-file, and evaluates each complete expression on the backend,
+printing the response back to `stream`. Colorization follows the `:color`
+`IOContext` property of `stream`.
+
+The convenience method `run_repl(stream::IO)` builds a `StreamREPL` over `stream`
+and runs it.
+"""
 mutable struct StreamREPL <: AbstractREPL
     stream::IO
     prompt_color::String

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -71,16 +71,16 @@ Supertype for all Read-Eval-Print Loop (REPL) frontends.
 
 A REPL frontend reads user input, hands complete expressions to a backend for
 evaluation, and prints the response. A backend is started and connected to the
-frontend by [`run_repl`](@ref). The three concrete frontends shipped with Julia
-are [`LineEditREPL`](@ref) — the interactive terminal REPL with line editing,
-history, and prompt modes — [`BasicREPL`](@ref) — a minimal line-based fallback —
-and [`StreamREPL`](@ref) — a frontend that drives the REPL over an arbitrary
-`IO` stream.
+frontend by [`run_repl`](@ref). The three frontends defined by default are:
 
-A concrete subtype `R <: AbstractREPL` is expected to implement
-`run_frontend(repl::R, backend::REPLBackendRef)`, which runs the read/print loop
-and feeds parsed input to `backend`, and the accessors `outstream(repl::R)` and
-`hascolor(repl::R)`.
+- [`LineEditREPL`](@ref), the interactive terminal REPL with line editing,
+  history, and prompt modes. Julia's default REPL is a `LineEditREPL`.
+- [`BasicREPL`](@ref), a minimal, line-based fallback.
+- [`StreamREPL`](@ref), a frontend that drives the REPL over an arbitrary
+  `IO` stream.
+
+Every `AbstractREPL` subtype is expected to support `run_frontend`, `outstream`,
+and `hascolor`.
 """
 abstract type AbstractREPL end
 
@@ -730,11 +730,7 @@ line editing, history, or prompt modes.
 
 `BasicREPL` is the fallback frontend used instead of [`LineEditREPL`](@ref) when
 the terminal is not fully functional — that is, when the `TERM` environment
-variable is `"dumb"` (or unset, on non-Windows systems). It writes a plain
-`julia> ` prompt, reads a complete expression (continuing to read while the
-parser reports the input as incomplete), evaluates it on the backend, and prints
-the response. Input is terminated by EOF (Ctrl-D); an `InterruptException`
-(Ctrl-C) cancels the current line.
+variable is `"dumb"` (or unset, on non-Windows systems).
 """
 mutable struct BasicREPL <: AbstractREPL
     terminal::TextTerminal

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1808,9 +1808,7 @@ let io = IOBuffer()
 end
 
 @testset "Docstrings" begin
-    undoc = Docs.undocumented_names(REPL)
-    @test_broken isempty(undoc)
-    @test undoc == [:AbstractREPL, :BasicREPL, :LineEditREPL, :StreamREPL]
+    @test isempty(Docs.undocumented_names(REPL))
 end
 
 struct A40735


### PR DESCRIPTION
Document the REPL frontend interface contract (`run_frontend`, `outstream`, `hascolor`) on `AbstractREPL` and the role and behavior of each shipped frontend. This makes `Docs.undocumented_names(REPL)` empty, so the corresponding `@test_broken` regression test in `test/repl.jl` is now a passing `@test`.

Written to the bar set in the review of the earlier stale attempt (#52876): interface contract and behavior, not minimal one-liners. Every behavioral claim was checked against the source (e.g. the `BasicREPL` fallback condition is `TERM == "dumb"` per `base/client.jl`).

Part of #52725.

Disclosure: this pull request was written with the assistance of generative AI; all claims were verified against source and a running Julia session, and human-reviewed.