### PR TITLE
errorshow: hint that replace! does not work on strings

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -1395,10 +1395,10 @@ end
 Experimental.register_error_hint(string_concatenation_hint_handler, MethodError)
 
 # Display a hint in case the user tries to use replace! on a string
-# (strings are immutable, so the non-mutating replace is what they want)
+# (replace! cannot modify a string in place; replace returns a new string)
 function string_replace_hint_handler(@nospecialize(io::IO), ex::MethodError, arg_types::Vector{Any}, kwargs::Vector{Any})
     if ex.f === _replace! && any(@nospecialize(a) -> unwrapva(a) <: AbstractString, arg_types)
-        print(io, "\nStrings are immutable, so they cannot be modified with `replace!`. Use ")
+        print(io, "\n`String`s cannot be modified with `replace!`. Use ")
         printstyled(io, "replace", color=:cyan)
         print(io, " instead, which returns a new string.")
     end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -1394,6 +1394,18 @@ end
 
 Experimental.register_error_hint(string_concatenation_hint_handler, MethodError)
 
+# Display a hint in case the user tries to use replace! on a string
+# (strings are immutable, so the non-mutating replace is what they want)
+function string_replace_hint_handler(@nospecialize(io::IO), ex::MethodError, arg_types::Vector{Any}, kwargs::Vector{Any})
+    if ex.f === _replace! && any(@nospecialize(a) -> unwrapva(a) <: AbstractString, arg_types)
+        print(io, "\nStrings are immutable, so they cannot be modified with `replace!`. Use ")
+        printstyled(io, "replace", color=:cyan)
+        print(io, " instead, which returns a new string.")
+    end
+end
+
+Experimental.register_error_hint(string_replace_hint_handler, MethodError)
+
 # Display a hint in case the user tries to use the min or max function on an iterable
 # or tries to use something like `collect` on an iterator without defining either IteratorSize or length
 function methods_on_iterable(io, ex, arg_types, kwargs)

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -1458,11 +1458,11 @@ end
 # https://github.com/JuliaLang/julia/issues/57613
 let err_str
     err_str = @except_str replace!("abc", "a" => "1") MethodError
-    @test occursin("Strings are immutable, so they cannot be modified with `replace!`", err_str)
+    @test occursin("`String`s cannot be modified with `replace!`", err_str)
     err_str = @except_str replace!(uppercase, "abc") MethodError
-    @test occursin("Strings are immutable, so they cannot be modified with `replace!`", err_str)
+    @test occursin("`String`s cannot be modified with `replace!`", err_str)
     err_str = @except_str replace!((1, 2), 1 => 0) MethodError
-    @test !occursin("Strings are immutable", err_str)
+    @test !occursin("cannot be modified with `replace!`", err_str)
 end
 
 # https://github.com/JuliaLang/julia/issues/55745

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -15,6 +15,7 @@ function _register_if_missing(@nospecialize(handler), @nospecialize(exct::Type))
 end
 _register_if_missing(Base.noncallable_number_hint_handler, MethodError)
 _register_if_missing(Base.string_concatenation_hint_handler, MethodError)
+_register_if_missing(Base.string_replace_hint_handler, MethodError)
 _register_if_missing(Base.methods_on_iterable, MethodError)
 _register_if_missing(Base.nonsetable_type_hint_handler, MethodError)
 _register_if_missing(Base.fielderror_listfields_hint_handler, FieldError)
@@ -1452,6 +1453,16 @@ end
 let err_str
     err_str = @except_str "a" + "b" MethodError
     @test occursin("String concatenation is performed with *", err_str)
+end
+
+# https://github.com/JuliaLang/julia/issues/57613
+let err_str
+    err_str = @except_str replace!("abc", "a" => "1") MethodError
+    @test occursin("Strings are immutable, so they cannot be modified with `replace!`", err_str)
+    err_str = @except_str replace!(uppercase, "abc") MethodError
+    @test occursin("Strings are immutable, so they cannot be modified with `replace!`", err_str)
+    err_str = @except_str replace!((1, 2), 1 => 0) MethodError
+    @test !occursin("Strings are immutable", err_str)
 end
 
 # https://github.com/JuliaLang/julia/issues/55745


### PR DESCRIPTION

`replace!` on a `String` raised a bare `MethodError` on the internal `_replace!`, with no indication of the cause — that strings are immutable:

Before:
```
julia> replace!("abc", "a" => "1")
ERROR: MethodError: no method matching _replace!(::Base.var"#new#replace_pairs!##0"{...}, ::String, ::String, ::Int64)
```

After:
```
julia> replace!("abc", "a" => "1")
ERROR: MethodError: no method matching _replace!(::Base.var"#new#replace_pairs!##0"{...}, ::String, ::String, ::Int64)
...
Strings are immutable, so they cannot be modified with `replace!`. Use replace instead, which returns a new string.
```

This adds an error hint (same mechanism as the existing `+`-on-strings hint) that fires when `_replace!` hits a `MethodError` with a string argument, pointing to the non-mutating `replace`. Covers both `replace!(str, pairs...)` and `replace!(f, str)`.

Fixes #57613

Disclosure: this pull request was written with the assistance of generative AI; all claims were verified against source and a running Julia session, and human-reviewed.
