### PR TITLE
Allow byte-precise stacktraces

### DIFF
--- a/JuliaLowering/src/eval.jl
+++ b/JuliaLowering/src/eval.jl
@@ -145,64 +145,232 @@ else
     end
 end
 
-function _compress_debuginfo(info)
-    filename, edges, codelocs = info
-    edges = Core.svec(map(_compress_debuginfo, edges)...)
-    codelocs = @ccall jl_compress_codelocs((-1)::Int32, codelocs::Any,
-                                           div(length(codelocs),3)::Csize_t)::String
-    Core.DebugInfo(Symbol(filename), nothing, edges, codelocs)
-end
-
-function ir_debug_info_state(ex)
-    e1 = first(flattened_provenance(ex))
-    topfile = filename(e1)
-    Tuple{String, Vector{Any}, Vector{Int32}}[(topfile, [], Vector{Int32}())]
-end
-
-function add_ir_debug_info!(current_codelocs_stack, stmt)
-    locstk = Tuple{String, Int32}[(filename(e), source_location(e)[1]) for e in flattened_provenance(stmt)]
-    for j in 1:length(locstk)
-        if j === 1 && current_codelocs_stack[j][1] != locstk[j][1]
-            # dilemma: the filename stack here shares no prefix with that of the
-            # previous statement, where differing filenames usually (j > 1) mean
-            # a different macro expansion has started at this statement.  guess
-            # that both files are the same, and inherit the previous filename.
-            locstk[j] = (current_codelocs_stack[j][1], locstk[j][2])
+"""
+Uncompressed form of DebugInfo's linetable::String.  When compressing, some
+conveniences are erased:
+- `file` is not present
+- `line_offset` is identical
+- `spans` pairs (s1, s2) are stored `(s1-byte_offset, s2-s1+1)`
+- `line_starts` are stored `x-byte_offset`
+"""
+struct SourceByteTable
+    file::Symbol
+    line_offset::Int32
+    spans::Vector{Tuple{Int32,Int32}}
+    line_starts::Vector{Int32}
+    function SourceByteTable(file, line_offset, spans, line_starts)
+        @assert issorted(spans)
+        @assert allunique(spans)
+        @assert issorted(line_starts)
+        @assert allunique(line_starts)
+        @assert length(line_starts) > 0
+        for s in spans
+            @assert 0 < s[2] "linenode provenance; expected SourceFile"
+            @assert 0 < s[1] <= s[2]+1
         end
-        if j < length(current_codelocs_stack) && (j === length(locstk) ||
-                current_codelocs_stack[j+1][1] != locstk[j+1][1])
-            while j < length(current_codelocs_stack)
-                info = pop!(current_codelocs_stack)
-                push!(last(current_codelocs_stack)[2], info)
+        if !isempty(spans)
+            @assert !isempty(line_starts)
+            min_byte = spans[begin][begin]
+            max_byte = maximum(last, spans)
+            @assert line_starts[begin] <= min_byte
+            for ls in line_starts[begin+1:end]
+                @assert min_byte < ls
+                @assert ls <= max_byte
             end
-        elseif j > length(current_codelocs_stack)
-            push!(current_codelocs_stack, (locstk[j][1], [], Vector{Int32}()))
-        end
-    end
-    @jl_assert length(locstk) === length(current_codelocs_stack) stmt
-    for (j, (file,line)) in enumerate(locstk)
-        fn, edges, codelocs = current_codelocs_stack[j]
-        @jl_assert fn == file stmt
-        if j < length(locstk)
-            edge_index = length(edges) + 1
-            edge_codeloc_index = fld1(length(current_codelocs_stack[j+1][3]) + 1, 3)
         else
-            edge_index = 0
-            edge_codeloc_index = 0
+            # Not used for now
+            @assert false
         end
-        push!(codelocs, line)
-        push!(codelocs, edge_index)
-        push!(codelocs, edge_codeloc_index)
+
+        new(file, line_offset, spans, line_starts)
+    end
+end
+function SourceByteTable(sf::SourceFile, spans::Vector{Tuple{Int32, Int32}})
+    # Trim all newlines outside SBT's range
+    line_starts = map(ls->Int32(ls+sf.byte_offset), sf.line_starts)
+    b0, _ = JuliaSyntax.source_line_range(sf, spans[1][1])
+    first_line = sf.first_line
+    while length(line_starts) >= 2 && line_starts[2] <= b0
+        popfirst!(line_starts)
+        first_line += 1
+    end
+    max_byte = maximum(last, spans)
+    while !isempty(line_starts) && max_byte < line_starts[end]
+        pop!(line_starts)
+    end
+    SourceByteTable(Symbol(sf.filename), first_line, spans, line_starts)
+end
+
+function _take32(io::IOBuffer, n::Integer)
+    n in (0, 1, 2, 4) || throw(ArgumentError("Unsupported byte count"))
+    v = Int32(0)
+    n >= 1 && (v |= Int32(read(io, UInt8)))
+    n >= 2 && (v |= Int32(read(io, UInt8))<<8)
+    n >= 4 && (v |= Int32(read(io, UInt8))<<16)
+    n >= 4 && (v |= Int32(read(io, UInt8))<<24)
+    return v
+end
+
+function _push32(io::IOBuffer, v::Int32, n)
+    n in (0, 1, 2, 4) || throw(ArgumentError("Unsupported byte count"))
+    n >= 1 && write(io, v % UInt8)
+    n >= 2 && write(io, (v>>>8) % UInt8)
+    n >= 4 && write(io, (v>>>16) % UInt8)
+    n >= 4 && write(io, (v>>>24) % UInt8)
+    nothing
+end
+
+_encoded_len(max::Int32) = Int32(max == 0 ? 0 :
+    max < typemax(UInt8) ? 1 :
+    max < typemax(UInt16) ? 2 : 4)
+
+function compress_sbt(sbt::SourceByteTable)
+    min_byte = sbt.line_starts[1]
+    max_byte = Int32(0)
+    max_span = Int32(0)
+    for (b1,b2) in sbt.spans
+        max_span = max(max_span, (b2+Int32(1))-b1)
+        max_byte = max(max_byte, b2)
+    end
+
+    max_byte_rel = Int32(min_byte >= max_byte ? 1 : (max_byte - min_byte))
+    nlocs::Int32 = length(sbt.spans)
+    encl_span = _encoded_len(max_span)
+    encl_byte = _encoded_len(max_byte_rel)
+    final_len = 14 + # header
+        (encl_byte + encl_span) * nlocs +
+        (encl_byte * length(sbt.line_starts))
+
+    io = IOBuffer(;sizehint=final_len)
+    _push32(io, min_byte, 4)
+    _push32(io, sbt.line_offset, 4)
+    _push32(io, nlocs, 4)
+    _push32(io, encl_byte, 1)
+    _push32(io, encl_span, 1)
+    for (b1, b2) in sbt.spans
+        _push32(io, b1 - min_byte, encl_byte)
+        _push32(io, b2 - b1 + Int32(1), encl_span)
+    end
+    for n in sbt.line_starts
+        _push32(io, n - min_byte, encl_byte)
+    end
+
+    out = take!(io)
+    let l = length(out)
+        @assert l == final_len "wrong final length $l"
+    end
+    return String(out)
+end
+
+function uncompress_sbt(di::Core.DebugInfo)
+    di.linetable isa String || throw(ArgumentError("linetable: expected string"))
+    io = IOBuffer(di.linetable)
+    byte_offset = _take32(io, 4)
+    line_offset = _take32(io, 4)
+    nlocs = _take32(io, 4)
+    byte_encl = _take32(io, 1)
+    span_encl = _take32(io, 1)
+
+    let newlines_offset = (byte_encl + span_encl) * nlocs
+        @assert bytesavailable(io) >= newlines_offset "compressed string too short"
+        @assert byte_encl == 0 ||
+            (bytesavailable(io) - newlines_offset) % byte_encl == 0 "bad newlines"
+    end
+
+    out_spans = Tuple{Int32,Int32}[]
+    for i in 1:nlocs
+        s1 = _take32(io, byte_encl)
+        s2 = _take32(io, span_encl)
+        push!(out_spans, (s1+byte_offset, s1+byte_offset+s2-1))
+    end
+
+    out_newlines = Int32[]
+    while bytesavailable(io) > 0
+        push!(out_newlines, _take32(io, byte_encl) + byte_offset)
+    end
+    return SourceByteTable(di.def, line_offset, out_spans, out_newlines)
+end
+
+function _di_pos(st::SyntaxTree)
+    src = JuliaSyntax.unexpanded_sourceref(st)
+    pos = if src isa SourceRef
+        (Int32(first_byte(src)), Int32(last_byte(src)))
+    elseif src isa LineNumberNode
+        (Int32(src.line), Int32(-1))
+    else
+        @jl_assert false st
     end
 end
 
-function finish_ir_debug_info!(current_codelocs_stack)
-    while length(current_codelocs_stack) > 1
-        info = pop!(current_codelocs_stack)
-        push!(last(current_codelocs_stack)[2], info)
+# TODO sourcefile(::LNN) should return Symbol, not LNN
+_di_sourcefile(st) =
+    let x = JuliaSyntax.unexpanded_sourceref(st)
+        x isa LineNumberNode ? x.file : x.file[]::SourceFile
     end
 
-    _compress_debuginfo(only(current_codelocs_stack))
+# A single pass over all IR to collect unique byte/line positions and CodeInfos
+function collect_locs!(node_sources, codeinfos, top_sf, st, toplevel)
+    if kind(st) === K"code_info"
+        push!(codeinfos, st)
+        # TODO: macro_source is ignored for now
+        get!(node_sources, st._id, _di_pos(st))
+        for c in children(st[1])
+            node_sources[c._id] =
+                if _di_sourcefile(c) !== top_sf
+                    top_sf isa SourceFile &&
+                        @warn "inconsistent provenance for child" c st
+                    node_sources[st._id]
+                else
+                    _di_pos(c)
+                end
+            collect_locs!(node_sources, codeinfos, top_sf, c, st.is_toplevel_thunk::Bool)
+        end
+    elseif toplevel
+        # Note non-toplevel codeinfo should not contain nested codeinfo
+        for c in children(st)
+            collect_locs!(node_sources, codeinfos, top_sf, c, true)
+        end
+    end
+end
+
+function add_ci_debuginfo!(st::SyntaxTree, file::Symbol,
+                           top_sbt::Union{String, Nothing},
+                           node_sources::Dict{NodeId, Tuple{Int32, Int32}},
+                           spans::Vector{Tuple{Int32, Int32}})
+    @jl_assert kind(st) === K"code_info" st
+    locs = let a = sizehint!(Vector{Int32}(), 3*numchildren(st[1]))
+        for c in children(st[1])
+            push!(a, Int32(searchsortedfirst(spans, node_sources[c._id])))
+            push!(a, Int32(0))
+            push!(a, Int32(0))
+        end
+        a
+    end
+
+    setattr!(st, :debuginfo, Core.DebugInfo(
+        file, top_sbt, Core.svec(),
+        @ccall(jl_compress_codelocs((-1)::Int32, locs::Any,
+                                    numchildren(st[1])::Csize_t)::String)))
+end
+
+# Populate `.debuginfo` on all K"code_info" in `st`
+function add_debuginfo!(st::SyntaxTree)
+    @jl_assert kind(st) === K"code_info" st
+    node_sources = Dict{NodeId, Tuple{Int32, Int32}}()
+    codeinfos = SyntaxList(st._graph)
+    top_sf = _di_sourcefile(st)
+    collect_locs!(node_sources, codeinfos, top_sf, st, true)
+    spans = sort!(unique(values(node_sources)))
+    if top_sf isa SourceFile
+        top_sbt = compress_sbt(SourceByteTable(top_sf, spans))
+        file = Symbol(top_sf.filename)
+    else
+        top_sbt = nothing
+        file = Symbol(top_sf)
+    end
+    for ci in codeinfos
+        add_ci_debuginfo!(ci, file, top_sbt, node_sources, spans)
+    end
 end
 
 # flisp: jl_new_code_info_from_ir (method.c)
@@ -263,10 +431,6 @@ end
 # Convert SyntaxTree to the CodeInfo+Expr data structures understood by the
 # Julia runtime
 function to_code_info(ex::SyntaxTree, slots::Vector{Slot}, meta::CompileHints)
-    stmts = Any[]
-
-    current_codelocs_stack = ir_debug_info_state(ex)
-
     nargs = sum((s.kind==:argument for s in slots), init=0)
     slotnames = Vector{Symbol}(undef, length(slots))
     slot_rename_inds = Dict{String,Int}()
@@ -292,14 +456,9 @@ function to_code_info(ex::SyntaxTree, slots::Vector{Slot}, meta::CompileHints)
             slot.is_called        << 6   # SLOT_CALLED        | -
     end
 
-    for stmt in children(ex)
-        push!(stmts, _to_lowered_expr(stmt))
-        add_ir_debug_info!(current_codelocs_stack, stmt)
-    end
-
-    debuginfo = finish_ir_debug_info!(current_codelocs_stack)
+    stmts = map(_to_lowered_expr, children(ex[1]))
     has_image_globalref = any(codeinfo_has_image_globalref, stmts)
-    ssaflags = compute_ssaflags(ex)
+    ssaflags = compute_ssaflags(ex[1])
     propagate_inbounds =
         get(meta, :propagate_inbounds, false)
     # TODO: Set true if there's a foreigncall
@@ -330,11 +489,11 @@ function to_code_info(ex::SyntaxTree, slots::Vector{Slot}, meta::CompileHints)
     inlining_cost       = 0xffff
     rettype             = Any
 
-    @jl_assert(length(stmts) == numchildren(ex), ex)
+    @jl_assert(length(stmts) == numchildren(ex[1]), ex)
 
     _CodeInfo(
         stmts,
-        debuginfo,
+        ex.debuginfo,
         ssavaluetypes,
         ssaflags,
         slotnames,
@@ -360,6 +519,8 @@ function to_code_info(ex::SyntaxTree, slots::Vector{Slot}, meta::CompileHints)
 end
 
 @fzone "JL: to_lowered_expr" function to_lowered_expr(ex::SyntaxTree)
+    ensure_attributes!(ex._graph; debuginfo=Any)
+    add_debuginfo!(ex)
     _to_lowered_expr(ex)
 end
 
@@ -397,7 +558,7 @@ function _to_lowered_expr(ex::SyntaxTree)
     elseif k == K"inert_syntaxtree"
         ex[1]
     elseif k == K"code_info"
-        ir = to_code_info(ex[1], ex.slots, ex.meta)
+        ir = to_code_info(ex, ex.slots, ex.meta)
         if ex.is_toplevel_thunk
             Expr(:thunk, ir) # TODO: Maybe nice to just return a CodeInfo here?
         else

--- a/JuliaLowering/src/macro_expansion.jl
+++ b/JuliaLowering/src/macro_expansion.jl
@@ -360,8 +360,8 @@ function expand_macro(ctx, ex, outer_sl)
         expanded = expr_to_est(ex._graph, expanded, macro_lnn)
     end
 
+    expanded = append_sourceref!(ctx, expanded, ex._id)
     if kind(expanded) != K"Value"
-        expanded = append_sourceref!(ctx, expanded, ex._id)
         # Module scope for the returned AST is the module where this particular
         # method was defined (may be different from `parentmodule(macfunc)`)
         mod_for_ast = lookup_method_instance(macfunc, macro_args,

--- a/JuliaLowering/test/provenance.jl
+++ b/JuliaLowering/test/provenance.jl
@@ -1,0 +1,46 @@
+using JuliaLowering: compress_sbt, uncompress_sbt, SourceByteTable,
+    add_debuginfo!
+
+test_mod = Module()
+
+function test_byte_precise(di::Core.DebugInfo, nstmts::Int)
+    for i in 1:nstmts
+        sl = Base.Compiler.source_location(di, i)
+        @test sl.byte > 0      context=di
+        @test sl.byte_end > 0  context=di
+        @test sl.col > 0       context=di
+        @test sl.col_end > 0   context=di
+        @test sl.line > 0      context=di
+        @test sl.line_end > 0  context=di
+    end
+end
+
+@testset "SourceByteTable roundtrip" begin
+    st = jl_lower(test_mod, JuliaSyntax.parsestmt(SyntaxTree, "1 + 2 - \n 3"))
+    JuliaSyntax.ensure_attributes!(st._graph; debuginfo=Any)
+    add_debuginfo!(st)
+    csbt = st.debuginfo
+    usbt = uncompress_sbt(csbt)
+    cusbt = compress_sbt(usbt)
+    @test csbt isa Core.DebugInfo
+    @test usbt isa SourceByteTable
+    @test cusbt isa String
+    @test cusbt === csbt.linetable
+
+    @test length(usbt.spans) <= numchildren(st[1]) # lhs is unique locs
+    test_byte_precise(csbt, numchildren(st[1]))
+end
+
+@testset "Attaching DebugInfo to methods" begin
+    local f = JuliaLowering.include_string(test_mod, """
+    function f_with_debuginfo(x)
+        show(x)
+        map(a->a+1, x)
+    end
+    """)
+    di = methods(f)[1].debuginfo
+    @test di.linetable isa String
+    let nstmts = length(Base._uncompressed_ir(methods(f)[1]).code)
+        test_byte_precise(di, nstmts)
+    end
+end

--- a/JuliaLowering/test/runtests.jl
+++ b/JuliaLowering/test/runtests.jl
@@ -29,6 +29,7 @@ include("utils.jl")
     @testset "scopes" include("scopes.jl")
     @testset "typedefs" include("typedefs.jl")
 
+    @testset "provenance" include("provenance.jl")
     @testset "compat" include("compat.jl")
     @testset "hooks" include("hooks.jl")
 end

--- a/JuliaSyntax/src/porcelain/syntax_graph.jl
+++ b/JuliaSyntax/src/porcelain/syntax_graph.jl
@@ -419,6 +419,21 @@ function macro_prov(st::SyntaxTree)
     return nothing
 end
 
+"The first macro expansion `st` was involved in (chronologically), or nothing"
+function macro_prov_end(st::SyntaxTree)
+    lastmp = mp = macro_prov(st)
+    while !isnothing(mp)
+        lastmp, mp = mp, macro_prov(mp)
+    end
+    return lastmp
+end
+
+"The top-level location of `st`"
+function unexpanded_sourceref(st::SyntaxTree)
+    mp = macro_prov_end(st)
+    isnothing(mp) ? sourceref(st) : sourceref(mp)
+end
+
 """
 A SyntaxList of textrefs associated with `st`.  The number of returned trees
 should equal one plus the number of macro expansions `st` "went through":

--- a/JuliaSyntax/test/syntax_graph.jl
+++ b/JuliaSyntax/test/syntax_graph.jl
@@ -1,4 +1,4 @@
-using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind, syntax_graph, prov, prov_end, provenance, macro_prov, flattened_provenance, sourceref, newleaf, mkleaf, mknode, mktree, setattr!, hasattr
+using .JuliaSyntax: SyntaxGraph, SyntaxTree, SyntaxList, ensure_attributes, ensure_attributes!, delete_attributes, copy_ast, attrdefs, @stm, NodeId, SourceRef, SourceAttrType, Kind, syntax_graph, prov, prov_end, provenance, macro_prov, macro_prov_end, flattened_provenance, sourceref, unexpanded_sourceref, newleaf, mkleaf, mknode, mktree, setattr!, hasattr
 
 "For filling required attrs in graphs created by hand"
 function testgraph(edge_ranges, edges, more_attrs...)
@@ -149,6 +149,24 @@ end
         @test macro_prov(stmm3) == nothing
         @test macro_prov(stmm2) == nothing
         @test macro_prov(stmm1) == nothing
+        @test macro_prov_end(st3) == stmm3
+        @test macro_prov_end(st2) == stm_unused
+        @test macro_prov_end(st1) == stm_unused
+        @test macro_prov_end(stm3) == stmm3
+        @test macro_prov_end(stm2) == nothing
+        @test macro_prov_end(stm1) == nothing
+        @test macro_prov_end(stmm3) == nothing
+        @test macro_prov_end(stmm2) == nothing
+        @test macro_prov_end(stmm1) == nothing
+        @test unexpanded_sourceref(st3) == LineNumberNode(1, :mm)
+        @test unexpanded_sourceref(st2) == LineNumberNode(0)
+        @test unexpanded_sourceref(st1) == LineNumberNode(0)
+        @test unexpanded_sourceref(stm3) == LineNumberNode(1, :mm)
+        @test unexpanded_sourceref(stm2) == LineNumberNode(1, :m)
+        @test unexpanded_sourceref(stm1) == LineNumberNode(1, :m)
+        @test unexpanded_sourceref(stmm3) == LineNumberNode(1, :mm)
+        @test unexpanded_sourceref(stmm2) == LineNumberNode(1, :mm)
+        @test unexpanded_sourceref(stmm1) == LineNumberNode(1, :mm)
         @test flattened_provenance(st3) == SyntaxList(stmm1, stm1, st1)
         @test flattened_provenance(st2) == SyntaxList(stm_unused, st1)
         @test flattened_provenance(st1) == SyntaxList(stm_unused, st1)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -833,7 +833,7 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs=[])
 
             m = parentmodule_before_main(method)
             modulecolor = get!(() -> popfirst!(STACKTRACE_MODULECOLORS), STACKTRACE_FIXEDCOLORS, m)
-            print_module_path_file(iob, m, string(file), line; modulecolor, digit_align_width = 3)
+            print_module_path_file(iob, m, string(file), line, 0; modulecolor, digit_align_width = 3)
             push!(lines, takestring!(buf))
             push!(line_score, -(right_matches * 2 + (length(arg_types_param) < 2 ? 1 : 0)))
         end
@@ -1041,12 +1041,13 @@ parentmodule_before_main(x) = parentmodule_before_main(parentmodule(x))
 
 # Print a stack frame where the module color is set manually with `modulecolor`.
 function print_stackframe(io, i, frame::StackFrame, ndigits_max::Int, max_nested_cycles::Int, nactive_cycles::Int, ncycle_starts::Int, modulecolor; prefix = nothing)
-    file, line = string(frame.file), frame.line
+    file = string(frame.file)
+    fl = StackTraces.frame_location(frame)
 
     # Used by the REPL to make it possible to open
     # the location of a stackframe/method in the editor.
     if haskey(io, :last_shown_line_infos)
-        push!(io[:last_shown_line_infos], (string(frame.file), frame.line))
+        push!(io[:last_shown_line_infos], (string(frame.file), fl.line))
     end
 
     inlined = getfield(frame, :inlined)
@@ -1074,13 +1075,16 @@ function print_stackframe(io, i, frame::StackFrame, ndigits_max::Int, max_nested
     printstyled(io, "│" ^ nactive_cycles; color = :light_black)
 
     # @ Module path / file : line
-    print_module_path_file(io, modul, file, line; modulecolor, digit_align_width = digit_align_width - 1)
+    print_module_path_file(
+        io, modul, file, fl.line, fl.col;
+        modulecolor, digit_align_width = digit_align_width - 1)
 
     # inlined
     printstyled(io, inlined ? " [inlined]" : "", color = :light_black)
 end
 
-function print_module_path_file(io, modul, file, line; modulecolor = :light_black, digit_align_width = 0)
+function print_module_path_file(io, modul, file, line, col;
+                                modulecolor = :light_black, digit_align_width = 0)
     printstyled(io, " " ^ digit_align_width * "@", color = :light_black)
 
     # module
@@ -1097,8 +1101,9 @@ function print_module_path_file(io, modul, file, line; modulecolor = :light_blac
     dir = dirname(file)
     !isempty(dir) && printstyled(io, dir, Filesystem.path_separator, color = :light_black)
 
-    # filename, separator, line
+    # filename, separator, line, column if available
     printstyled(io, basename(file), ":", line; color = :light_black, underline = true)
+    col != 0 && printstyled(io, ":", col; color = :light_black, underline = true)
 end
 
 #=

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -258,7 +258,7 @@ function show_method(io::IO, m::Method;
             digit_align_width += 4
         end
         # module & file, re-using function from errorshow.jl
-        print_module_path_file(io, parentmodule(m), string(file), line; modulecolor, digit_align_width)
+        print_module_path_file(io, parentmodule(m), string(file), line, 0; modulecolor, digit_align_width)
     end
 end
 

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -74,12 +74,15 @@ struct StackFrame # this type should be kept platform-agnostic so that profiles 
     pointer::UInt64  # Large enough to be read losslessly on 32- and 64-bit machines.
     "if !from_c, 1-based statement index (PC) within the frame's CodeInfo, or 0 if unavailable"
     pc::Int
+    # TODO: can be redundant given `linfo`, but needed for inlined frames with
+    # `linfo isa MethodInstance`
+    debuginfo::Union{Core.DebugInfo, Nothing}
 end
 
 StackFrame(func, file, line, linfo, from_c, inlined, pointer) =
-    StackFrame(func, file, line, linfo, from_c, inlined, pointer, 0)
+    StackFrame(func, file, line, linfo, from_c, inlined, pointer, 0, nothing)
 StackFrame(func, file, line) = StackFrame(Symbol(func), Symbol(file), line,
-                                          nothing, false, false, 0, 0)
+                                          nothing, false, false, 0, 0, nothing)
 
 """
     StackTrace
@@ -134,7 +137,8 @@ function _add_di_frames!(frames, pointer, di::Core.DebugInfo, pc::Int)
         false, # we can assume C frames aren't inlined into julia
         !isempty(frames),
         pointer,
-        pc))
+        pc,
+        di))
     _add_linetable_frames!(frames, pointer, di, pc)
     edi, epc = Base.Compiler.edge_debuginfo(di, pc)
     edi !== nothing && _add_di_frames!(frames, pointer, edi, epc)
@@ -179,7 +183,8 @@ Base.@constprop :none function lookup(pointer::Ptr{Cvoid})
             inlined = f[6]::Bool
             sv_pc = from_c ? f[7]::Int : 0
             out[i] = StackFrame(
-                func, file, linenum, linfo, from_c, inlined, pointer, sv_pc)
+                func, file, linenum, linfo, from_c, inlined, pointer, sv_pc,
+                nothing)
         end
     else
         out = Vector{StackFrame}()
@@ -327,6 +332,27 @@ function frame_mi(lkup::StackFrame)
     return code
 end
 
+function frame_location(frame::StackFrame)
+    if frame.from_c
+        Base.Compiler.SourceLocation(0,0,frame.pc,0,frame.line,0)
+    elseif isnothing(frame.debuginfo) || frame.pc <= 0
+        Base.Compiler.SourceLocation(0,0,0,0,frame.line,0)
+    else
+        # Ideally this would just be a source_location call, but we need to
+        # check for pc=0 recursively since source_location doesn't have a good
+        # answer for that until we stop producing that.
+        di, pc = frame.debuginfo, frame.pc
+        while Base.Compiler.has_prev_debuginfo(di, pc)
+            di, pc = Base.Compiler.prev_debuginfo(di, pc)
+        end
+        if pc <= 0
+            Base.Compiler.SourceLocation(0,0,0,0,frame.line,0)
+        else
+            Base.Compiler.source_location(frame.debuginfo, frame.pc)
+        end
+    end
+end
+
 function show_spec_linfo(io::IO, frame::StackFrame)
     linfo = frame.linfo
     if linfo === nothing
@@ -403,10 +429,15 @@ function show(io::IO, frame::StackFrame)
         file_info = basename(string(frame.file))
         print(io, " at ")
         print(io, file_info, ":")
-        if frame.line >= 0
-            print(io, frame.line)
+        fl = frame_location(frame)
+        if fl.line >= 0
+            print(io, fl.line)
         else
             print(io, "?")
+        end
+        if fl.col != 0
+            print(io, ":")
+            print(io, fl.col)
         end
     end
     if frame.inlined

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -196,64 +196,39 @@ end
 
 const top_level_scope_sym = Symbol("top-level scope")
 
+# Interpreted => unoptimized => no inlined frames, so >1 frames are returned
+# only with code from macro expansions.
 function lookup(ip::Base.InterpreterIP)
     code = ip.code
-    if code === nothing
-        # interpreted top-level expression with no CodeInfo
-        return [StackFrame(top_level_scope_sym, empty_sym, 0, nothing, false, false, 0)]
-    end
-    # prepare approximate code info
-    if code isa MethodInstance && (meth = code.def; meth isa Method)
-        func = meth.name
-        file = meth.file
-        line = meth.line
-        codeinfo = meth.source
-    else
-        func = top_level_scope_sym
-        file = empty_sym
-        line = Int32(0)
-        if code isa Core.CodeInstance
-            codeinfo = code.inferred::CodeInfo
-            def = code.def
-            if isa(def, Core.ABIOverride)
-                def = def.def
-            end
-            if isa(def, MethodInstance)
-                let meth = def.def
-                    if isa(meth, Method)
-                        func = meth.name
-                        file = meth.file
-                        line = meth.line
-                    end
-                end
-            end
-        else
-            codeinfo = code::CodeInfo
-        end
-    end
-    def = (code isa CodeInfo ? StackTraces : code) # Module just used as a token for top-level code
     pc::Int = max(ip.stmt + 1, 0) # n.b. ip.stmt is 0-indexed
-    scopes = IRShow.LineInfoNode[]
-    IRShow.append_scopes!(scopes, pc, codeinfo.debuginfo, def)
-    if isempty(scopes)
-        return [StackFrame(func, file, line, code, false, false, 0)]
-    end
-    res = Vector{StackFrame}(undef, length(scopes))
-    inlined = false
-    def_local = def
-    for i in eachindex(scopes)
-        lno = scopes[i]
-        if inlined
-            def_local = lno.method
-            def_local isa Union{Method,Core.CodeInstance,MethodInstance} || (def_local = nothing)
-        else
-            def_local = codeinfo
+    if code === nothing
+        return [StackFrame(
+            top_level_scope_sym, empty_sym, 0, nothing, false, false, 0)]
+    elseif code isa MethodInstance && (meth = code.def; meth isa Method)
+        func = meth.name
+        codeinfo = meth.source
+        di = codeinfo.debuginfo
+    elseif code isa Core.CodeInstance
+        codeinfo = code.inferred::CodeInfo
+        def = code.def isa Core.ABIOverride ? code.def.def : code.def
+        @assert def isa MethodInstance "unexpected $(typeof(def))"
+        meth = def.def
+        func = meth isa Method ? meth.name : top_level_scope_sym
+        di = code.debuginfo
+        while Base.Compiler.has_prev_debuginfo(di, pc)
+            di, pc = Base.Compiler.prev_debuginfo(di, pc)
         end
-        res[i] = StackFrame(IRShow.normalize_method_name(lno.method), lno.file, lno.line,
-            def_local, false, inlined, 0)
-        inlined = true
+    else
+        codeinfo = code::CodeInfo
+        di = codeinfo.debuginfo
+        func = top_level_scope_sym
     end
-    return res
+    file = IRShow.debuginfo_file1(di)
+    line = pc > 0 ? Base.Compiler.source_location(di, pc).line :
+        IRShow.debuginfo_firstline(di)
+    frames = [StackFrame(func, file, line, codeinfo, false, false, 0, pc, di)]
+    _add_linetable_frames!(frames, 0, di, pc)
+    return frames
 end
 
 """

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1452,6 +1452,7 @@ static const char *sbt_parseheader(jl_string_t *str, jl_sourcebytetable_header_t
     assert(jl_is_string(str));
     const char *ptr = jl_string_data(str);
     memcpy(h, ptr, SBT_HEADER_SIZE); // TODO assumes LE
+    assert(h->byte_encl == 1 || h->byte_encl == 2 || h->byte_encl == 4);
     return ptr + SBT_HEADER_SIZE;
 }
 
@@ -1477,14 +1478,12 @@ static void cdi_deref(jl_debuginfo_t **p_di, int32_t *p_pc, int recursive) JL_NO
             cdi_deref(p_di, p_pc, recursive);
         }
     } else {
-        if (jl_is_string(di->linetable)) {jl_unreachable();} // TODO: remove when byte-precise
         assert(jl_is_string(di->linetable) || jl_is_nothing(di->linetable));
     }
 }
 
 JL_DLLEXPORT jl_locspan_t jl_cdi_bytespan(jl_debuginfo_t *di, int32_t pc) JL_NOTSAFEPOINT
 {
-    jl_unreachable(); // TODO: remove when byte-precise
     cdi_deref(&di, &pc, 1);
     pc = jl_uncompress1_codeloc(di, pc).loc;
     jl_sourcebytetable_header_t h;
@@ -1502,7 +1501,6 @@ JL_DLLEXPORT jl_locspan_t jl_cdi_bytespan(jl_debuginfo_t *di, int32_t pc) JL_NOT
 /* O(line_starts); could binary search instead */
 JL_DLLEXPORT jl_locspan_t jl_cdi_byte_to_xy(jl_debuginfo_t *di, int32_t b) JL_NOTSAFEPOINT
 {
-    jl_unreachable(); // TODO: remove when byte-precise
     cdi_deref(&di, NULL, 1);
     jl_sourcebytetable_header_t h;
     sbt_parseheader(di->linetable, &h);

--- a/src/julia.h
+++ b/src/julia.h
@@ -258,8 +258,9 @@ typedef struct _jl_sourcebytetable_header_t {
     int32_t line_offset;
     // (>=0) number of (byte, len) bytespans
     int32_t nlocs;
-    // (0,1,2,4) compressed lengths
+    // (1,2,4) compressed length
     uint8_t byte_encl;
+    // (0,1,2,4) compressed length
     uint8_t span_encl;
 } jl_sourcebytetable_header_t;
 // packed size


### PR DESCRIPTION
Atop #61991.  With the plumbing work done (getting some of JuliaLowering's provenance through DebugInfo), we can print byte numbers in stack traces with little extra effort:

<img width="820" height="359" alt="a" src="https://github.com/user-attachments/assets/fafb25a2-8c14-4997-897a-893b091fb424" />

There's more information we can print that I'm leaving out for now.  For example, with a small patch to `Base.print_stackframe`, we can print the source code too.
<details>

<summary>patch</summary>

```
@eval Base begin
    # Print a stack frame where the module color is set manually with `modulecolor`.
    function print_stackframe(io, i, frame::StackFrame, ndigits_max::Int, max_nested_cycles::Int, nactive_cycles::Int, ncycle_starts::Int, modulecolor; prefix = nothing)
        file = string(frame.file)
        fl = StackTraces.frame_location(frame)

        # Used by the REPL to make it possible to open
        # the location of a stackframe/method in the editor.
        if haskey(io, :last_shown_line_infos)
            push!(io[:last_shown_line_infos], (string(frame.file), frame.line))
        end

        inlined = getfield(frame, :inlined)
        modul = parentmodule(frame)

        digit_align_width = ndigits_max + 2 + max_nested_cycles - nactive_cycles

        # repeated section bracket line 1
        prefix === nothing || print(io, prefix)
        print(io, " ")
        printstyled(io, "├" ^ (nactive_cycles - ncycle_starts); color = :light_black)
        printstyled(io, "┌" ^ ncycle_starts; color = :light_black)

        # frame number
        print(io, lpad("[" * string(i) * "]", digit_align_width))
        print(io, " ")

        # func name and arguments
        StackTraces.show_spec_linfo(IOContext(io, :backtrace=>true), frame)
        println(io)

        # repeated section bracket line 2
        prefix === nothing || print(io, prefix)
        print(io, " ")
        printstyled(io, "│" ^ nactive_cycles; color = :light_black)

        # @ Module path / file : line
        print_module_path_file(
            io, modul, file, fl.line, fl.col;
            modulecolor, digit_align_width = digit_align_width - 1)

        # inlined
        printstyled(io, inlined ? " [inlined]" : "", color = :light_black)

        if fl.col != 0 && !isempty(file) && !frame.from_c
            try
                open(file) do fd
                    seek(fd, fl.byte-fl.col)
                    source_str = String(readline(fd))
                    print(io, "\n")
                    printstyled(io, " " ^ digit_align_width * "|", color = :light_black)
                    printstyled(io, source_str; color=:light_black)
                    print(io, "\n")
                    printstyled(io, " " ^ digit_align_width * "|", color = :light_black)
                    for i in eachindex(source_str)
                        printstyled(io, 1 <= i - (fl.col-1) <= (fl.byte_end+1) - fl.byte ? '^' : ' '; color=:red)
                    end
                end
            catch e
            end
        end
    end
end
```
</details>

<img width="820" height="455" alt="b" src="https://github.com/user-attachments/assets/00d2fcb4-93bd-4ba2-ab7f-1c32a1dbd3c9" />


We'll probably want a more reliable way of fetching source code before implementing that (and before fixing the byte-column != character-column issue).