### PR TITLE
issue #32684 - threading: allow combining @threads and @simd on the same loop

### DIFF
--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -53,6 +53,61 @@ simd_outer_range(r) = 0:0
 # Construct user-level element from original range, outer loop index j, and inner loop index i.
 @inline simd_index(r, j, i) = (@inbounds ret = r[i+firstindex(r)]; ret)
 
+function _macro_sym(mac)
+    if mac isa Symbol
+        return mac
+    elseif mac isa GlobalRef
+        return mac.name
+    elseif isa(mac, Expr) && mac.head === :.
+        arg = mac.args[end]
+        return arg isa QuoteNode ? arg.value : arg
+    end
+    return nothing
+end
+
+function _is_named_macrocall(ex, name::Symbol)
+    isa(ex, Expr) && ex.head === :macrocall || return false
+    return _macro_sym(ex.args[1]) === name
+end
+
+# Unwrap `@simd [ivdep] for ...` when it follows `@threads` (issue #32684).
+function unwrap_simd_for(ex)
+    _is_named_macrocall(ex, Symbol("@simd")) || return nothing
+    if length(ex.args) >= 4 && ex.args[3] === :ivdep &&
+            ex.args[4] isa Expr && ex.args[4].head === :for
+        return (ex.args[4], true)
+    elseif length(ex.args) >= 3 && ex.args[3] isa Expr && ex.args[3].head === :for
+        return (ex.args[3], false)
+    end
+    return nothing
+end
+
+# Unwrap `Threads.@threads [schedule] for ...` when it follows `@simd`.
+function _unwrap_threads_for(ex)
+    _is_named_macrocall(ex, Symbol("@threads")) || return nothing
+    if length(ex.args) >= 4 && ex.args[3] isa Symbol &&
+            ex.args[3] in (:static, :dynamic, :greedy) &&
+            ex.args[4] isa Expr && ex.args[4].head === :for
+        return (ex.args[3], ex.args[4])
+    elseif length(ex.args) >= 3 && ex.args[3] isa Expr && ex.args[3].head === :for
+        return (:default, ex.args[3])
+    end
+    return nothing
+end
+
+# Rewrite `@simd Threads.@threads for ...` to `Threads.@threads @simd for ...`.
+function _rewrite_as_threads_simd(forloop, ivdep::Bool)
+    unwrapped = _unwrap_threads_for(forloop)
+    unwrapped === nothing && return nothing
+    sched, for_ex = unwrapped
+    simd_loop = ivdep ? :(@simd ivdep $for_ex) : :(@simd $for_ex)
+    if sched === :default
+        return :(Base.Threads.@threads $simd_loop)
+    else
+        return :(Base.Threads.@threads $sched $simd_loop)
+    end
+end
+
 # Compile Expr x in context of @simd.
 function compile(x, ivdep)
     (isa(x, Expr) && x.head === :for) || throw(SimdError("for loop expected"))
@@ -123,13 +178,21 @@ either case, your inner loop should have the following properties to allow vecto
 
 * There exists no loop-carried memory dependencies
 * No iteration ever waits on a previous iteration to make forward progress.
+
+`@simd` can be combined with [`Threads.@threads`](@ref Threads.@threads) in either order,
+e.g. `Threads.@threads @simd for ... end` or `@simd Threads.@threads for ... end`.
+Each thread runs a SIMD-vectorized chunk of the iteration space.
 """
 macro simd(forloop)
+    rewritten = _rewrite_as_threads_simd(forloop, false)
+    rewritten === nothing || return rewritten
     compile(forloop, nothing)
 end
 
 macro simd(ivdep, forloop)
     if ivdep === :ivdep
+        rewritten = _rewrite_as_threads_simd(forloop, true)
+        rewritten === nothing || return rewritten
         compile(forloop, Symbol("julia.ivdep"))
     else
         throw(SimdError("Only ivdep is valid as the first argument to @simd"))

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -213,14 +213,24 @@ function _threading_run_expr(schedule)
     end
 end
 
-function _threadsfor(iter, lbody, schedule)
+function _threadsfor_loop(forloop::Expr, schedule; simd::Bool=false, ivdep::Bool=false)
+    if !(forloop.args[1] isa Expr && forloop.args[1].head === :(=))
+        throw(ArgumentError("nested outer loops are not currently supported by @threads"))
+    end
+    _threadsfor(forloop.args[1], forloop.args[2], schedule; simd, ivdep)
+end
+
+function _threadsfor(iter, lbody, schedule; simd::Bool=false, ivdep::Bool=false)
     lidx = iter.args[1]         # index
     range = iter.args[2]
     esc_range = esc(range)
+    if simd && schedule === :greedy
+        throw(ArgumentError("`@simd` is not supported with `@threads :greedy`"))
+    end
     func = if schedule === :greedy
         greedy_func(esc_range, lidx, lbody)
     else
-        default_func(esc_range, lidx, lbody)
+        default_func(esc_range, lidx, lbody; simd, ivdep)
     end
     quote
         local threadsfor_fun
@@ -510,17 +520,41 @@ function _work_distribution_code()
     end
 end
 
-function default_func(itr, lidx, lbody)
+function _threaded_chunk_loop(lidx, lbody; simd::Bool=false, ivdep::Bool=false)
+    chunk_body = quote
+        local $(esc(lidx)) = @inbounds r[i]
+        $(esc(lbody))
+    end
+    if !simd
+        quote
+            for i = loop_first:loop_last
+                $chunk_body
+            end
+        end
+    elseif ivdep
+        quote
+            @simd ivdep for i = loop_first:loop_last
+                $chunk_body
+            end
+        end
+    else
+        quote
+            @simd for i = loop_first:loop_last
+                $chunk_body
+            end
+        end
+    end
+end
+
+function default_func(itr, lidx, lbody; simd::Bool=false, ivdep::Bool=false)
     work_dist = _work_distribution_code()
+    inner_loop = _threaded_chunk_loop(lidx, lbody; simd, ivdep)
     quote
         let items = $itr
         function threadsfor_fun(tid = 1)
-            # Reads: items, tid. Defines: r, loop_first, loop_last.
+            # Each thread runs a (possibly SIMD) loop over its chunk of items.
             $work_dist
-            for i = loop_first:loop_last
-                local $(esc(lidx)) = @inbounds r[i]
-                $(esc(lbody))
-            end
+            $inner_loop
         end
         end
     end
@@ -570,6 +604,7 @@ end
     Threads.@threads [schedule] for ... end
     Threads.@threads [schedule] [expr for ... end]
     Threads.@threads [schedule] T[expr for ... end]
+    Threads.@threads [schedule] @simd for ... end
 
 A macro to execute a `for` loop or array comprehension in parallel. The iteration space is distributed to
 coarse-grained tasks. This policy can be specified by the `schedule` argument. The
@@ -802,12 +837,11 @@ macro threads(args...)
         else
             return _threadsfor_comprehension(ex.args[1], sched)
         end
+    elseif (simd_result = Base.SimdLoop.unwrap_simd_for(ex)) !== nothing
+        forloop, ivdep = simd_result
+        return _threadsfor_loop(forloop, sched; simd=true, ivdep)
     elseif isa(ex, Expr) && ex.head === :for
-        # Handle for loops
-        if !(ex.args[1] isa Expr && ex.args[1].head === :(=))
-            throw(ArgumentError("nested outer loops are not currently supported by @threads"))
-        end
-        return _threadsfor(ex.args[1], ex.args[2], sched)
+        return _threadsfor_loop(ex, sched)
     else
         throw(ArgumentError("@threads requires a `for` loop or comprehension expression"))
     end

--- a/test/simdloop.jl
+++ b/test/simdloop.jl
@@ -161,3 +161,12 @@ Base.SimdLoop.simd_index(v::iter31113, j, i) = j
 Base.SimdLoop.simd_inner_length(v::iter31113, j) = 1
 Base.SimdLoop.simd_outer_range(v::iter31113) = v
 @test 2001000 == simd_sum_over_array(iter31113(Vector(1:2000)))
+
+# Combining @threads and @simd (issue #32684)
+@testset "@threads and @simd composition" begin
+    using Base.Threads
+    @test isexpr(@macroexpand1(Threads.@threads @simd for i = 1:0; end), :block)
+    @test isexpr(@macroexpand1(Threads.@threads @simd ivdep for i = 1:0; end), :block)
+    @test isexpr(@macroexpand1(@simd Threads.@threads for i = 1:0; end), :block)
+    @test isexpr(@macroexpand1(@simd ivdep Threads.@threads for i = 1:0; end), :block)
+end

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -212,6 +212,29 @@ end
 
 test_threaded_loop_and_atomic_add()
 
+# @threads combined with @simd (issue #32684)
+@testset "@threads @simd" begin
+    function axpy_serial!(a, X, Y)
+        @simd for i = eachindex(X)
+            @inbounds Y[i] += a * X[i]
+        end
+        Y
+    end
+    function axpy_threads_simd!(a, X, Y)
+        @threads @simd for i = eachindex(X)
+            @inbounds Y[i] += a * X[i]
+        end
+        Y
+    end
+    for T in (Float32, Float64), n in (0, 1, 7, 255, 256)
+        X = rand(T, n)
+        Y = rand(T, n)
+        expected = axpy_serial!(T(2), X, copy(Y))
+        axpy_threads_simd!(T(2), X, Y)
+        @test Y == expected
+    end
+end
+
 # Helper for test_threaded_atomic_minmax that verifies sequential consistency.
 function check_minmax_consistency(old::Array{T,1}, m::T, start::T, o::Base.Ordering) where T
     for v in old


### PR DESCRIPTION
This PR fixes #32684 by allowing `@threads` and `@simd` to be used together on the same `for` loop.
- `@threads` now accepts `@simd` and `@simd ivdep` before a `for` loop
- Each thread runs a SIMD-vectorized chunk of the iteration space
- `@simd Threads.@threads for ...` is rewritten to `Threads.@threads @simd for ...`, so both orders work