### PR TITLE
fix StringIndexError to use SubString indices (#55840)

### DIFF
--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -159,7 +159,16 @@ end
 
 function getindex(s::SubString, i::Integer)
     @boundscheck checkbounds(s, i)
+    @inbounds isvalid(s, i) || string_index_err(s, i)
     @inbounds return getindex(s.string, s.offset + i)
+end
+
+@propagate_inbounds function getindex(s::SubString{String}, i::Int)
+    @boundscheck checkbounds(s, i)
+    b = @inbounds codeunit(s, i)
+    u = UInt32(b) << 24
+    between(b, 0x80, 0xf7) || return reinterpret(Char, u)
+    return getindex_continued(s, i, u)
 end
 
 # `isascii(::AbstractVector)` reduces to `@inbounds codeunit(::SubString{String}, ::Int)`, total.

--- a/test/strings/types.jl
+++ b/test/strings/types.jl
@@ -119,6 +119,36 @@
         @test Base.cconvert(Ptr{Int8}, u) == u
     end
 
+    @testset "StringIndexError uses SubString indices (issue #55840)" begin
+        s = SubString("αβγ", 3)  # "βγ", offset 2
+        e = @test_throws StringIndexError s[2]
+        @test e.value.string === s
+        @test e.value.index == 2
+        @test sprint(showerror, e.value) ==
+            "StringIndexError: invalid index [2], valid nearby indices [1]=>'β', [3]=>'γ'"
+        ep = @test_throws StringIndexError "αβγ"[2]
+        @test ep.value.string isa String
+        @test ep.value.index == 2
+
+        eu = @test_throws StringIndexError s[0x02]
+        @test eu.value.string === s
+        @test eu.value.index == 2
+
+        as = Base.AnnotatedString("αβγ")
+        sa = SubString(as, 3)  # "βγ"
+        ea = @test_throws StringIndexError sa[2]
+        @test ea.value.string === sa
+        @test ea.value.index == 2
+        eau = @test_throws StringIndexError sa[0x02]
+        @test eau.value.string === sa
+        @test eau.value.index == 2
+
+        s2 = SubString("aβγ", 1)
+        e2 = @test_throws StringIndexError s2[3]
+        @test e2.value.string === s2
+        @test e2.value.index == 3
+    end
+
     let str = "føøbar"
         @test_throws BoundsError SubString(str, 10, 10)
         u = SubString(str, 4, 3)


### PR DESCRIPTION
`getindex` on a `SubString` forwarded an invalid mid-codepoint index to the
parent string, so `StringIndexError` reported parent coordinates:

```
julia> s = SubString("αβγ", 3)  # "βγ"
julia> s[2]
ERROR: StringIndexError: invalid index [4], valid nearby indices [3]=>'β', [5]=>'γ'
```

After:

```
julia> s[2]
ERROR: StringIndexError: invalid index [2], valid nearby indices [1]=>'β', [3]=>'γ'
```

The generic `getindex(::SubString, ::Integer)` validates in SubString
coordinates before forwarding. `SubString{String}` keeps a fast path that
mirrors `String` getindex via duck-typed `getindex_continued`.

Fixes #55840

Disclosure: this pull request was written with the assistance of generative AI;
all claims were verified against source and a running Julia session, and
human-reviewed.
