### PR TITLE
gf.c: skip dispatch cache re-checks when no mt insertions since check

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -27,6 +27,17 @@ extern "C" {
 _Atomic(int) allow_new_worlds = 1;
 JL_DLLEXPORT _Atomic(size_t) jl_world_counter = 1; // uses atomic acquire/release
 jl_mutex_t world_counter_lock;
+static _Atomic(size_t) jl_method_cache_insert_generation = 1;
+
+static inline size_t jl_method_cache_insert_generation_load(void) JL_NOTSAFEPOINT
+{
+    return jl_atomic_load_relaxed(&jl_method_cache_insert_generation);
+}
+
+static inline void jl_method_cache_inserted(void)
+{
+    jl_atomic_fetch_add_relaxed(&jl_method_cache_insert_generation, 1);
+}
 
 JL_DLLEXPORT size_t jl_get_world_counter(void) JL_NOTSAFEPOINT
 {
@@ -1617,12 +1628,16 @@ jl_method_instance_t *cache_method(
         jl_tupletype_t *tt, // the original tupletype of the signature
         jl_method_t *definition,
         size_t world, size_t min_valid, size_t max_valid,
-        jl_svec_t *sparams)
+        jl_svec_t *sparams,
+        // set by callers that have already proven `tt` is absent from the cache
+        // immediately before acquiring the lock and that no insertion can have
+        // happened since, allowing the redundant re-check below to be skipped
+        int tt_known_absent)
 {
     // caller must hold the parent->writelock, which this releases
     // short-circuit (now that we hold the lock) if this entry is already present
     int8_t offs = mc ? jl_cachearg_offset() : 1;
-    { // scope block
+    if (!tt_known_absent) { // scope block
         if (mc) {
             jl_genericmemory_t *leafcache = jl_atomic_load_relaxed(&mc->leafcache);
             jl_typemap_entry_t *entry = lookup_leafcache(leafcache, (jl_value_t*)tt, world);
@@ -1650,6 +1665,8 @@ jl_method_instance_t *cache_method(
             jl_typemap_entry_t *newentry = jl_typemap_alloc(cachett, NULL, jl_emptysvec, (jl_value_t*)newmeth, min_valid, max_valid);
             JL_GC_PUSH1(&newentry);
             jl_typemap_insert(cache, parent, newentry, offs);
+            if (mc)
+                jl_method_cache_inserted();
             JL_GC_POP();
             if (mc) JL_UNLOCK(&mc->writelock);
             return newmeth;
@@ -1853,6 +1870,8 @@ jl_method_instance_t *cache_method(
              }
          }
     }
+    if (mc)
+        jl_method_cache_inserted();
     if (mc) {
         JL_UNLOCK(&mc->writelock);
 
@@ -1957,6 +1976,7 @@ JL_DLLEXPORT jl_typemap_entry_t *jl_mt_find_cache_entry(jl_methcache_t *mc JL_PR
 
 static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_methcache_t *mc JL_PROPAGATES_ROOT, jl_datatype_t *tt JL_MAYBE_UNROOTED, size_t world)
 {
+    size_t cache_insert_generation = jl_method_cache_insert_generation_load();
     jl_typemap_entry_t *entry = jl_mt_find_cache_entry(mc, tt, world);
     if (entry)
         return entry->func.linfo;
@@ -1966,9 +1986,14 @@ static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_methcach
     JL_GC_PUSH2(&tt, &matc);
     JL_LOCK(&mc->writelock);
     jl_method_instance_t *mi = NULL;
-    entry = jl_mt_find_cache_entry(mc, tt, world);
-    if (entry)
-        mi = entry->func.linfo;
+    // No need to re-check if no method cache insertion happened since the
+    // lock-free probe above.
+    int tt_known_absent = jl_method_cache_insert_generation_load() == cache_insert_generation;
+    if (!tt_known_absent) {
+        entry = jl_mt_find_cache_entry(mc, tt, world);
+        if (entry)
+            mi = entry->func.linfo;
+    }
     if (!mi) {
         size_t min_valid = 0;
         size_t max_valid = ~(size_t)0;
@@ -1976,7 +2001,9 @@ static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_methcach
         if (matc) {
             jl_method_t *m = matc->method;
             jl_svec_t *env = matc->sparams;
-            mi = cache_method(mt, mc, &mc->cache, (jl_value_t*)mc, tt, m, world, min_valid, max_valid, env);
+            // tt was just proven absent above and no method cache insertion has
+            // happened since, so cache_method can skip its redundant re-check.
+            mi = cache_method(mt, mc, &mc->cache, (jl_value_t*)mc, tt, m, world, min_valid, max_valid, env, tt_known_absent);
             JL_GC_POP();
             return mi;
         }
@@ -3863,7 +3890,9 @@ static jl_value_t *jl_method_match_to_mi(jl_method_match_t *match, size_t world,
             jl_methcache_t *mc = jl_method_table->cache;
             assert(mc);
             JL_LOCK(&mc->writelock);
-            mi = (jl_value_t*)cache_method(jl_method_get_table(m), mc, &mc->cache, (jl_value_t*)mc, ti, m, world, min_valid, max_valid, env);
+            // this path does not pre-probe `ti`, so cache_method must keep its
+            // own presence check (ti may already be cached from a prior hint)
+            mi = (jl_value_t*)cache_method(jl_method_get_table(m), mc, &mc->cache, (jl_value_t*)mc, ti, m, world, min_valid, max_valid, env, /*tt_known_absent*/0);
         }
         else {
             jl_value_t *tt = jl_normalize_to_compilable_sig(ti, env, m, 1);
@@ -4459,7 +4488,7 @@ jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value
                 int sub = jl_subtype_matching((jl_value_t*)tt, (jl_value_t*)method->sig, &tpenv);
                 assert(sub); (void)sub;
             }
-            mfunc = cache_method(NULL, NULL, &method->invokes, (jl_value_t*)method, tt, method, 1, 1, ~(size_t)0, tpenv);
+            mfunc = cache_method(NULL, NULL, &method->invokes, (jl_value_t*)method, tt, method, 1, 1, ~(size_t)0, tpenv, /*tt_known_absent*/0);
         }
         JL_UNLOCK(&method->writelock);
         JL_GC_POP();
@@ -5203,7 +5232,11 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, jl_methcache_t *mc,
             jl_method_t *meth = env.matc->method;
             jl_svec_t *tpenv = env.matc->sparams;
             JL_LOCK(&mc->writelock);
-            cache_method(mt, mc, &mc->cache, (jl_value_t*)mc, (jl_tupletype_t*)unw, meth, world, env.match.min_valid, env.match.max_valid, tpenv);
+            // a matching entry may already be present here (e.g. ml_matches fell
+            // through the full-cache check above to recompute min_world exactly),
+            // so cache_method must keep its own presence check to avoid a
+            // duplicate insertion
+            cache_method(mt, mc, &mc->cache, (jl_value_t*)mc, (jl_tupletype_t*)unw, meth, world, env.match.min_valid, env.match.max_valid, tpenv, /*tt_known_absent*/0);
         }
     }
     *min_valid = env.match.min_valid;

--- a/src/gf.c
+++ b/src/gf.c
@@ -31,12 +31,12 @@ static _Atomic(size_t) jl_method_cache_insert_generation = 1;
 
 static inline size_t jl_method_cache_insert_generation_load(void) JL_NOTSAFEPOINT
 {
-    return jl_atomic_load_relaxed(&jl_method_cache_insert_generation);
+    return jl_atomic_load_acquire(&jl_method_cache_insert_generation);
 }
 
 static inline void jl_method_cache_inserted(void)
 {
-    jl_atomic_fetch_add_relaxed(&jl_method_cache_insert_generation, 1);
+    jl_atomic_fetch_add(&jl_method_cache_insert_generation, 1);
 }
 
 JL_DLLEXPORT size_t jl_get_world_counter(void) JL_NOTSAFEPOINT


### PR DESCRIPTION
Speeds method lookup by skipping redundant cache re-checks inside the lock when the method-table cache has not changed since the outer check, using a new generation counter. Initially I implemented it as a check for being single-threaded, but this approach seems more broadly valid.

Reduces big env precompilation time by ~6%

(`compiled/v1.14` was emptied before each of these)

master a8f97b19441f82ba082d7c01cbcea45b49f691a6
```
julia> Base.Precompilation.precompilepkgs(timing=true, verbose=true)
Precompiling project...
   total │ include   (deps)   (comp) │ methods  img-gen     cache  ~pk-rss
...
  37.3 s │  24.98s    3.72s   19.85s │   35989   12.32s    43.8MB   1930MB  ✓ Plots
...
 124.1 s │  82.36s   13.86s   63.81s │  104874   41.73s   145.3MB   3688MB  ✓ Makie
  66.6 s │  43.97s    8.35s   33.84s │   36921   22.59s    49.8MB   3428MB  ✓ GLMakie
  316 dependencies successfully precompiled in 262 seconds. 41 already precompiled.
```

This PR = 6% faster
```
   total │ include   (deps)   (comp) │ methods  img-gen     cache  ~pk-rss
...
  34.9 s │  23.26s    4.03s   17.83s │   35988   11.60s    43.8MB   2015MB  ✓ Plots
...
 118.4 s │  77.66s   14.36s   58.69s │  104876   40.78s   145.3MB   3607MB  ✓ Makie
  60.9 s │  39.63s    8.33s   29.52s │   36910   21.29s    49.7MB   3414MB  ✓ GLMakie
  316 dependencies successfully precompiled in 248 seconds. 41 already precompiled.
```

Help from Claude.

