### PR TITLE
jit: do not compile methods with different optlevel in the same llvm module

### DIFF
--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -1248,3 +1248,35 @@ end
     OptLevelNoLeakSlow.call2(a)               # ksum2 first reached (co-compiled) via an -O0 module
     @test OptLevelNoLeakHeavy.ksum2(a) === expected
 end
+
+module OptLevelInlineOnlyOp
+    Base.Experimental.@optlevel 0
+    add0(x::Float64, y::Float64) = x + y
+end
+mutable struct OptLevelInlineOnlyBox
+    @atomic v::Float64
+end
+@noinline function optlevel_inline_ref(a)
+    s = 0.0
+    @inbounds @simd for i in eachindex(a)
+        s += a[i] * a[i]
+    end
+    return s
+end
+# The atomic modify emits `add0` always-inline into this (default-optlevel)
+# function's module; that body must not drag the module down to -O0.
+@noinline function optlevel_inline_poison(b, a)
+    @atomic b.v OptLevelInlineOnlyOp.add0 1.0
+    s = 0.0
+    @inbounds @simd for i in eachindex(a)
+        s += a[i] * a[i]
+    end
+    return s
+end
+@testset "always-inline bodies do not leak optlevel into their host module" begin
+    Random.seed!(1)
+    a = rand(100_000)
+    b = OptLevelInlineOnlyBox(0.0)
+    expected = optlevel_inline_ref(a)
+    @test optlevel_inline_poison(b, a) === expected
+end

--- a/Compiler/test/codegen.jl
+++ b/Compiler/test/codegen.jl
@@ -1219,3 +1219,32 @@ _blackbox_licmloop_simple(1.0)
     @test count(re_licmcall, ir_bb_simple) == 5  # unrolled, not hoisted
     @test !occursin(re_raw_arg, ir_bb_simple)
 end
+
+module OptLevelNoLeakHeavy
+    @noinline function ksum1(a)
+        s = 0.0
+        @inbounds @simd for i in eachindex(a)
+            s += a[i] * a[i]
+        end
+        return s
+    end
+    @noinline function ksum2(a)
+        s = 0.0
+        @inbounds @simd for i in eachindex(a)
+            s += a[i] * a[i]
+        end
+        return s
+    end
+end
+module OptLevelNoLeakSlow
+    Base.Experimental.@optlevel 0
+    using ..OptLevelNoLeakHeavy: ksum2
+    call2(a) = ksum2(a)
+end
+@testset "per-module optlevel does not leak across co-compiled modules" begin
+    Random.seed!(1)
+    a = rand(100_000)
+    expected = OptLevelNoLeakHeavy.ksum1(a)   # compiled directly at the default level
+    OptLevelNoLeakSlow.call2(a)               # ksum2 first reached (co-compiled) via an -O0 module
+    @test OptLevelNoLeakHeavy.ksum2(a) === expected
+end

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -10452,6 +10452,11 @@ void emit_always_inline(jl_codegen_output_t &out,
                 if (decls.invoke)
                     decls.invoke->setLinkage(linkage);
                 decls.specptr->setLinkage(linkage);
+                // This body is emitted only to be inlined away, so it must not
+                // influence the module's optimization level: it may come from a
+                // differently annotated module (e.g. `@optlevel 0`) than the
+                // batch that owns this module.
+                decls.specptr->removeFnAttr("julia-optimization-level");
             }
 
             // TODO: jl_promote_method_roots?

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -450,6 +450,28 @@ static void jl_do_dump_compile(jl_code_instance_t *codeinst, uint64_t time) JL_N
                             julia_double_to_half(orig_time + time * 1e-9));
 }
 
+static constexpr size_t N_optlevels = 4;
+
+static int jl_clamp_optlevel(int requested) JL_NOTSAFEPOINT
+{
+    int opt_level = std::max(static_cast<int>(jl_options.opt_level), 0);
+    if (requested >= 0 && requested < opt_level)
+        opt_level = requested;
+    int opt_level_min = std::max(static_cast<int>(jl_options.opt_level_min), 0);
+    if (opt_level < opt_level_min)
+        opt_level = opt_level_min;
+    return std::min(opt_level, static_cast<int>(N_optlevels) - 1);
+}
+
+static int jl_codeinst_optlevel(jl_code_instance_t *ci)
+{
+    jl_method_instance_t *mi = jl_get_ci_mi(ci);
+    jl_value_t *def = mi->def.value;
+    int raw = jl_get_module_optlevel(jl_is_method(def) ? ((jl_method_t*)def)->module
+                                                       : mi->def.module);
+    return jl_clamp_optlevel(raw);
+}
+
 extern "C" JL_DLLEXPORT_CODEGEN void
 jl_emit_codeinsts_to_jit_impl(jl_code_instance_t **codeinsts, jl_code_info_t **srcs, int len)
 {
@@ -457,55 +479,71 @@ jl_emit_codeinsts_to_jit_impl(jl_code_instance_t **codeinsts, jl_code_info_t **s
         return;
 
     JL_TIMING(CODEINST_COMPILE, CODEINST_COMPILE);
-    const char *name = name_from_method_instance(jl_get_ci_mi(codeinsts[len - 1]));
-    auto ctx = std::make_unique<LLVMContext>();
-    auto &dl = jl_ExecutionEngine->getDataLayout();
-    auto &tt = jl_ExecutionEngine->getTargetTriple();
-    auto mod = jl_create_llvm_module(name, *ctx, dl, tt);
-    jl_codegen_output_t out{*mod};
-    out.get_context().setDiscardValueNames(true);
-    out.imaging_mode = false;
-    JL_GC_PUSH1(&out.temporary_roots);
 
+    // Partition the batch by effective optimization level and emit each group as
+    // its own LLVM module.
+    std::map<int, SmallVector<int, 0>> groups;
     for (int i = 0; i < len; ++i) {
-        jl_code_instance_t *codeinst = codeinsts[i];
-        jl_code_info_t *src = srcs[i];
-        jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
-
-        if (jl_atomic_load_relaxed(&codeinst->invoke))
-            continue;
-
-        out.temporary_roots = jl_alloc_array_1d(jl_array_any_type, 0);
-        out.temporary_roots_set.clear();
-        if (!jl_emit_codeinst(out, codeinst, src)) { // contains safepoints
-            JL_GC_POP();
-            return;
-        }
-
-        // contains safepoints
-        jl_promote_method_roots(out, mi);
-        emit_always_inline(out, jl_get_method_ir); // contains safepoints
-
-        // Non-opaque-closure MethodInstances are considered globally rooted
-        // through their methods, but for OC, we need to create a global root
-        // here.
-        if (jl_is_method(mi->def.value) && mi->def.method->is_for_opaque_closure)
-            jl_as_global_root((jl_value_t*)mi, 1);
+        if (jl_atomic_load_relaxed(&codeinsts[i]->invoke))
+            continue; // already compiled
+        groups[jl_codeinst_optlevel(codeinsts[i])].push_back(i);
     }
 
-    out.temporary_roots = nullptr;
-    out.temporary_roots_set.clear();
-    JL_GC_POP();
+    for (auto &group : groups) {
+        SmallVector<int, 0> &idxs = group.second;
+        const char *name = name_from_method_instance(jl_get_ci_mi(codeinsts[idxs.back()]));
+        auto ctx = std::make_unique<LLVMContext>();
+        auto &dl = jl_ExecutionEngine->getDataLayout();
+        auto &tt = jl_ExecutionEngine->getTargetTriple();
+        auto mod = jl_create_llvm_module(name, *ctx, dl, tt);
+        jl_codegen_output_t out{*mod};
+        out.get_context().setDiscardValueNames(true);
+        out.imaging_mode = false;
+        JL_GC_PUSH1(&out.temporary_roots);
 
-    if (out.ci_funcs.empty())
-        return;
+        bool failed = false;
+        for (int i : idxs) {
+            jl_code_instance_t *codeinst = codeinsts[i];
+            jl_code_info_t *src = srcs[i];
+            jl_method_instance_t *mi = jl_get_ci_mi(codeinst);
 
-    emit_llvmcall_modules(out);
+            if (jl_atomic_load_relaxed(&codeinst->invoke))
+                continue;
 
-    auto &ES = jl_ExecutionEngine->getExecutionSession();
-    jl_emitted_output_t emitted =
-        out.finish(std::move(ctx), std::move(mod), *ES.getSymbolStringPool());
-    jl_ExecutionEngine->addOutput(std::move(emitted));
+            out.temporary_roots = jl_alloc_array_1d(jl_array_any_type, 0);
+            out.temporary_roots_set.clear();
+            if (!jl_emit_codeinst(out, codeinst, src)) { // contains safepoints
+                failed = true;
+                break;
+            }
+
+            // contains safepoints
+            jl_promote_method_roots(out, mi);
+            emit_always_inline(out, jl_get_method_ir); // contains safepoints
+
+            // Non-opaque-closure MethodInstances are considered globally rooted
+            // through their methods, but for OC, we need to create a global root
+            // here.
+            if (jl_is_method(mi->def.value) && mi->def.method->is_for_opaque_closure)
+                jl_as_global_root((jl_value_t*)mi, 1);
+        }
+
+        out.temporary_roots = nullptr;
+        out.temporary_roots_set.clear();
+        JL_GC_POP();
+
+        if (failed)
+            return;
+        if (out.ci_funcs.empty())
+            continue;
+
+        emit_llvmcall_modules(out);
+
+        auto &ES = jl_ExecutionEngine->getExecutionSession();
+        jl_emitted_output_t emitted =
+            out.finish(std::move(ctx), std::move(mod), *ES.getSymbolStringPool());
+        jl_ExecutionEngine->addOutput(std::move(emitted));
+    }
 }
 
 extern "C" JL_DLLEXPORT_CODEGEN
@@ -631,32 +669,26 @@ static auto countBasicBlocks(const Function &F) JL_NOTSAFEPOINT
     return std::distance(F.begin(), F.end());
 }
 
-static constexpr size_t N_optlevels = 4;
-
 static void selectOptLevel(Module &M) JL_NOTSAFEPOINT {
-    size_t opt_level = std::max(static_cast<int>(jl_options.opt_level), 0);
-    do {
-        if (jl_generating_output()) {
-            opt_level = 0;
-            break;
-        }
-        size_t opt_level_min = std::max(static_cast<int>(jl_options.opt_level_min), 0);
+    size_t opt_level;
+    if (jl_generating_output()) {
+        opt_level = 0;
+    }
+    else {
+        int requested = -1;
         for (auto &F : M) {
             if (!F.isDeclaration()) {
                 Attribute attr = F.getFnAttribute("julia-optimization-level");
                 StringRef val = attr.getValueAsString();
                 if (val != "") {
-                    size_t ol = (size_t)val[0] - '0';
-                    if (ol < opt_level)
-                        opt_level = ol;
+                    int ol = (int)val[0] - '0';
+                    if (ol >= 0 && (requested < 0 || ol < requested))
+                        requested = ol;
                 }
             }
         }
-        if (opt_level < opt_level_min)
-            opt_level = opt_level_min;
-    } while (0);
-    // currently -O3 is max
-    opt_level = std::min(opt_level, N_optlevels - 1);
+        opt_level = jl_clamp_optlevel(requested);
+    }
     M.addModuleFlag(Module::Warning, "julia.optlevel", opt_level);
 }
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -481,7 +481,7 @@ jl_emit_codeinsts_to_jit_impl(jl_code_instance_t **codeinsts, jl_code_info_t **s
     JL_TIMING(CODEINST_COMPILE, CODEINST_COMPILE);
 
     // Partition the batch by effective optimization level and emit each group as
-    // its own LLVM module.
+    // its own LLVM module, then add them together so the batch stays atomic.
     std::map<int, SmallVector<int, 0>> groups;
     for (int i = 0; i < len; ++i) {
         if (jl_atomic_load_relaxed(&codeinsts[i]->invoke))
@@ -489,6 +489,7 @@ jl_emit_codeinsts_to_jit_impl(jl_code_instance_t **codeinsts, jl_code_info_t **s
         groups[jl_codeinst_optlevel(codeinsts[i])].push_back(i);
     }
 
+    SmallVector<jl_emitted_output_t> outputs;
     for (auto &group : groups) {
         SmallVector<int, 0> &idxs = group.second;
         const char *name = name_from_method_instance(jl_get_ci_mi(codeinsts[idxs.back()]));
@@ -540,10 +541,12 @@ jl_emit_codeinsts_to_jit_impl(jl_code_instance_t **codeinsts, jl_code_info_t **s
         emit_llvmcall_modules(out);
 
         auto &ES = jl_ExecutionEngine->getExecutionSession();
-        jl_emitted_output_t emitted =
-            out.finish(std::move(ctx), std::move(mod), *ES.getSymbolStringPool());
-        jl_ExecutionEngine->addOutput(std::move(emitted));
+        outputs.push_back(
+            out.finish(std::move(ctx), std::move(mod), *ES.getSymbolStringPool()));
     }
+
+    if (!outputs.empty())
+        jl_ExecutionEngine->addOutputs(outputs);
 }
 
 extern "C" JL_DLLEXPORT_CODEGEN
@@ -1982,16 +1985,26 @@ static void timing_print_module_names(jl_timing_block_t *block,
 
 void JuliaOJIT::addOutput(jl_emitted_output_t O)
 {
+    addOutputs(MutableArrayRef<jl_emitted_output_t>(&O, 1));
+}
+
+void JuliaOJIT::addOutputs(MutableArrayRef<jl_emitted_output_t> Os)
+{
     JL_TIMING(LLVM_JIT, JIT_Total);
-    ++ModulesAdded;
-#ifdef ENABLE_TIMINGS
-    timing_print_module_names(JL_TIMING_DEFAULT_BLOCK, *O.module);
-#endif
+    // Register and define every module before releasing the lock, so the whole
+    // batch becomes visible at once and cross-module references between
+    // co-emitted CodeInstances never fall back to a tojlinvoke trampoline.
     std::unique_lock Lock{LinkerMutex};
-    auto MU = std::make_unique<JLMaterializationUnit>(
-        JLMaterializationUnit::Create(*this, ObjectLayer, std::move(O)));
     ExitOnError check{"Failed to add objectfile to JIT!"};
-    check(JD.define(MU, JD.getDefaultResourceTracker()));
+    for (auto &O : Os) {
+        ++ModulesAdded;
+#ifdef ENABLE_TIMINGS
+        timing_print_module_names(JL_TIMING_DEFAULT_BLOCK, *O.module);
+#endif
+        auto MU = std::make_unique<JLMaterializationUnit>(
+            JLMaterializationUnit::Create(*this, ObjectLayer, std::move(O)));
+        check(JD.define(MU, JD.getDefaultResourceTracker()));
+    }
 }
 
 orc::JITDylib& JuliaOJIT::createJITDylib(StringRef NamePrefix)

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -821,6 +821,7 @@ public:
     orc::SymbolStringPtr mangle(StringRef Name) JL_NOTSAFEPOINT;
     void addGlobalMapping(StringRef Name, uint64_t Addr) JL_NOTSAFEPOINT;
     void addOutput(jl_emitted_output_t O) JL_NOTSAFEPOINT;
+    void addOutputs(MutableArrayRef<jl_emitted_output_t> Os) JL_NOTSAFEPOINT;
 
     // Methods mainly for the C API
     Error addExternalModule(orc::JITDylib &JD, orc::ThreadSafeModule TSM, bool ShouldOptimize = false) JL_NOTSAFEPOINT;


### PR DESCRIPTION
Currently, a module running with non-default opt-level could "poison" the opt-level of a method in another module if they happened to get compiled together (due to the optimization level picked for the LLVM module being picked as the minimum of the methods involved).

The test shows a possible interaction where calling a method from a O0 module causes it to get compiled with O0, giving it a different result if it was compiled on its own (simd effect).

Iterated on with Claude