### PR TITLE
fix typemap simplesig for AnyType

### DIFF
--- a/src/typemap.c
+++ b/src/typemap.c
@@ -161,7 +161,7 @@ static int sig_match_by_type_simple(jl_value_t **types, size_t n, jl_tupletype_t
                 if (!jl_types_equal(jl_typeeq_T(a), tp0))
                     return 0;
             }
-            else if (!jl_is_kind(a)) {
+            else {
                 return 0;
             }
         }

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -125,6 +125,27 @@ static int sig_match_by_type_leaf(jl_value_t **types, jl_tupletype_t *sig, size_
     return 1;
 }
 
+// Returns true if every value of type `a` is itself a type (i.e., a <: AnyType)
+static int jl_subtype_anytype(jl_value_t *a) JL_NOTSAFEPOINT
+{
+    while (1) {
+        if (jl_is_kind(a) || jl_is_typeeq(a))
+            return 1;
+        else if (jl_is_unionall(a))
+            a = jl_unwrap_unionall(a);
+        else if (jl_is_uniontype(a)) {
+            jl_uniontype_t *u = (jl_uniontype_t*)a;
+            if (!jl_subtype_anytype(u->a))
+                return 0;
+            a = u->b;
+        }
+        else if (jl_is_typevar(a))
+            a = ((jl_tvar_t*)a)->ub;
+        else
+            return 0;
+    }
+}
+
 static int sig_match_by_type_simple(jl_value_t **types, size_t n, jl_tupletype_t *sig, size_t lensig, int va)
 {
     size_t i;
@@ -157,9 +178,14 @@ static int sig_match_by_type_simple(jl_value_t **types, size_t n, jl_tupletype_t
         }
         else if (decl == (jl_value_t*)jl_any_type) {
         }
+        else if (decl == (jl_value_t*)jl_anytype_type) {
+            if (!jl_subtype_anytype(a))
+                return 0;
+        }
         else {
-            if (jl_is_typeeq(a)) // decl is not Type, because it would be caught above
+            if (jl_is_typeeq(a)) { // decl is not TypeEq or AnyType, because it would be caught above, so it must be concrete
                 a = jl_typeof(jl_typeeq_T(a));
+            }
             if (!jl_types_equal(a, decl))
                 return 0;
         }
@@ -246,6 +272,10 @@ static inline int sig_match_simple(jl_value_t *arg1, jl_value_t **args, size_t n
                         return 0;
                 }
             }
+        }
+        else if (decl == (jl_value_t*)jl_anytype_type) {
+            if (!jl_is_type(a))
+                return 0;
         }
         else {
             return 0;

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -153,26 +153,15 @@ static int sig_match_by_type_simple(jl_value_t **types, size_t n, jl_tupletype_t
     for (i = 0; i < lensig; i++) {
         jl_value_t *decl = jl_tparam(sig, i);
         jl_value_t *a = types[i];
-        jl_value_t *unw = jl_is_unionall(decl) ? ((jl_unionall_t*)decl)->body : decl;
         if (jl_is_vararg(a))
             return 0;
-        if (jl_is_typeeq(unw)) {
-            jl_value_t *tp0 = jl_typeeq_T(unw);
+        if (jl_is_typeeq(decl)) {
+            jl_value_t *tp0 = jl_typeeq_T(decl);
             if (jl_is_typeeq(a)) {
-                if (jl_is_typevar(tp0)) {
-                    // in the case of Type{_}, the types don't have to match exactly.
-                    // this is cached as `Type{T} where T`.
-                    if (((jl_tvar_t*)tp0)->ub != (jl_value_t*)jl_any_type &&
-                        !jl_subtype(jl_typeeq_T(a), ((jl_tvar_t*)tp0)->ub))
-                        return 0;
-                }
-                else if (!jl_types_equal(jl_typeeq_T(a), tp0)) {
+                if (!jl_types_equal(jl_typeeq_T(a), tp0))
                     return 0;
-                }
             }
-            else if (!jl_is_kind(a) || !jl_is_typevar(tp0) || ((jl_tvar_t*)tp0)->ub != (jl_value_t*)jl_any_type) {
-                // manually unroll jl_subtype(a, decl)
-                // where `a` can be a subtype and decl is Type{T}
+            else if (!jl_is_kind(a)) {
                 return 0;
             }
         }
@@ -183,6 +172,7 @@ static int sig_match_by_type_simple(jl_value_t **types, size_t n, jl_tupletype_t
                 return 0;
         }
         else {
+            assert(jl_is_concrete_type(decl));
             if (jl_is_typeeq(a)) { // decl is not TypeEq or AnyType, because it would be caught above, so it must be concrete
                 a = jl_typeof(jl_typeeq_T(a));
             }
@@ -191,7 +181,8 @@ static int sig_match_by_type_simple(jl_value_t **types, size_t n, jl_tupletype_t
         }
     }
     if (va) {
-        jl_value_t *decl = jl_unwrap_unionall(jl_tparam(sig, i));
+        jl_value_t *decl = jl_tparam(sig, i);
+        assert(jl_is_vararg(decl));
         if (jl_vararg_kind(decl) == JL_VARARG_INT) {
             if (n - i != jl_unbox_long(jl_tparam1(decl)))
                 return 0;
@@ -248,29 +239,21 @@ static inline int sig_match_simple(jl_value_t *arg1, jl_value_t **args, size_t n
             */
             continue;
         }
-        jl_value_t *unw = jl_is_unionall(decl) ? ((jl_unionall_t*)decl)->body : decl;
-        if (jl_is_typeeq(unw) && jl_is_type(a)) {
-            jl_value_t *tp0 = jl_typeeq_T(unw);
-            if (jl_is_typevar(tp0)) {
-                // in the case of Type{_}, the types don't have to match exactly.
-                // this is cached as `Type{T} where T`.
-                jl_value_t *ub = ((jl_tvar_t*)tp0)->ub;
-                if (ub != (jl_value_t*)jl_any_type && !jl_subtype(a, ub))
+        if (jl_is_typeeq(decl)) {
+            if (!jl_is_type(a))
+                return 0;
+            jl_value_t *tp0 = jl_typeeq_T(decl);
+            if (a != tp0) {
+                jl_datatype_t *da = (jl_datatype_t*)a;
+                jl_datatype_t *dt = (jl_datatype_t*)tp0;
+                while (jl_is_unionall(da))
+                    da = (jl_datatype_t*)((jl_unionall_t*)da)->body;
+                while (jl_is_unionall(dt))
+                    dt = (jl_datatype_t*)((jl_unionall_t*)dt)->body;
+                if (jl_is_datatype(da) && jl_is_datatype(dt) && da->name != dt->name)
+                    return 0; // quick rejection test
+                if (!jl_types_equal(a, tp0))
                     return 0;
-            }
-            else {
-                if (a != tp0) {
-                    jl_datatype_t *da = (jl_datatype_t*)a;
-                    jl_datatype_t *dt = (jl_datatype_t*)tp0;
-                    while (jl_is_unionall(da))
-                        da = (jl_datatype_t*)((jl_unionall_t*)da)->body;
-                    while (jl_is_unionall(dt))
-                        dt = (jl_datatype_t*)((jl_unionall_t*)dt)->body;
-                    if (jl_is_datatype(da) && jl_is_datatype(dt) && da->name != dt->name)
-                        return 0;
-                    if (!jl_types_equal(a, tp0))
-                        return 0;
-                }
             }
         }
         else if (decl == (jl_value_t*)jl_anytype_type) {
@@ -278,6 +261,7 @@ static inline int sig_match_simple(jl_value_t *arg1, jl_value_t **args, size_t n
                 return 0;
         }
         else {
+            assert(jl_is_concrete_type(decl));
             return 0;
         }
     }


### PR DESCRIPTION
Ensures that type lookup is correctly implemented for typemap for AnyType, which is commonly used a a caching token. This is a targeted fix, which might not fix other similar regressions.

This is complementary to https://github.com/JuliaLang/julia/pull/62014, which may be fixing other similar issues.