### PR TITLE
fix trim regression from AnyType change

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -2792,11 +2792,12 @@ function show(io::IO, tv::TypeVar)
     # Otherwise, the lower bound should be printed if it is not `Bottom`
     # and the upper bound should be printed if it is not `Any`.
     in_env = (:unionall_env => tv) in io
-    function show_bound(io::IO, @nospecialize(b::Union{Core.AnyType,TypeVar}))
+    function show_bound(io::IO, @nospecialize(b)) # b::Union{Core.AnyType,TypeVar}
         parens = isa(b,UnionAll) && !print_without_params(b)
         parens && print(io, "(")
-        show(io, b)
+        b isa TypeVar ? show(io, b) : show(io, b::Core.AnyType)
         parens && print(io, ")")
+        nothing
     end
     lb, ub = tv.lb, tv.ub
     if !in_env && lb !== Bottom


### PR DESCRIPTION
Spotted in #62014 and other PRs. This is similar to `show_typeish`, but
avoids copying this whole method unnecessarily for trim-compatibility.