### PR TITLE
strings: transcode(String, ::Vector{UInt8}) no longer empties the input

### DIFF
--- a/base/strings/cstring.jl
+++ b/base/strings/cstring.jl
@@ -176,7 +176,12 @@ function transcode(::Type{UInt8}, src::Vector{<:Union{Int32,UInt32}})
 end
 transcode(::Type{String}, src::String) = src
 transcode(T, src::String) = transcode(T, codeunits(src))
-transcode(::Type{String}, src) = String(transcode(UInt8, src))
+function transcode(::Type{String}, src)
+    b = transcode(UInt8, src)
+    # String(::Vector{UInt8}) empties its argument, so don't hand it the
+    # caller's own buffer.
+    b === src ? String(copy(b)) : String(b)
+end
 
 function transcode(::Type{UInt16}, src::AbstractVector{UInt8})
     require_one_based_indexing(src)

--- a/base/strings/cstring.jl
+++ b/base/strings/cstring.jl
@@ -176,12 +176,11 @@ function transcode(::Type{UInt8}, src::Vector{<:Union{Int32,UInt32}})
 end
 transcode(::Type{String}, src::String) = src
 transcode(T, src::String) = transcode(T, codeunits(src))
-function transcode(::Type{String}, src)
-    b = transcode(UInt8, src)
-    # String(::Vector{UInt8}) empties its argument, so don't hand it the
-    # caller's own buffer.
-    b === src ? String(copy(b)) : String(b)
-end
+# `String(::Vector{UInt8})` takes ownership of (and empties) its argument, so a
+# caller's own `Vector{UInt8}` must be copied; every other `src` produces a fresh
+# buffer from `transcode(UInt8, src)` that is safe to consume. (#28612)
+transcode(::Type{String}, src::Vector{UInt8}) = String(copy(src))
+transcode(::Type{String}, src) = String(transcode(UInt8, src))
 
 function transcode(::Type{UInt16}, src::AbstractVector{UInt8})
     require_one_based_indexing(src)

--- a/base/strings/cstring.jl
+++ b/base/strings/cstring.jl
@@ -176,10 +176,10 @@ function transcode(::Type{UInt8}, src::Vector{<:Union{Int32,UInt32}})
 end
 transcode(::Type{String}, src::String) = src
 transcode(T, src::String) = transcode(T, codeunits(src))
-# `String(::Vector{UInt8})` takes ownership of (and empties) its argument, so a
-# caller's own `Vector{UInt8}` must be copied; every other `src` produces a fresh
-# buffer from `transcode(UInt8, src)` that is safe to consume. (#28612)
-transcode(::Type{String}, src::Vector{UInt8}) = String(copy(src))
+# `String(::Vector{UInt8})` consumes (empties) its argument, so wrap a caller's
+# own vector in a view: `String` then copies the bytes out without touching the
+# source, and only that one copy is made. (#28612)
+transcode(::Type{String}, src::Vector{UInt8}) = String(view(src, :))
 transcode(::Type{String}, src) = String(transcode(UInt8, src))
 
 function transcode(::Type{UInt16}, src::AbstractVector{UInt8})

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -1536,6 +1536,18 @@ end
         @test transcode(String, transcode(UInt32, transcode(UInt8, str))) == str
         @test transcode(String, transcode(UInt8, transcode(UInt16, str))) == str
     end
+    # transcode(String, ::Vector{UInt8}) must not empty the input (#28612)
+    let v = UInt8[0x68, 0x65, 0x6c, 0x6c, 0x6f]
+        @test transcode(String, v) == "hello"
+        @test length(v) == 5
+        @test v == UInt8[0x68, 0x65, 0x6c, 0x6c, 0x6f]
+    end
+    let v = UInt8[0x68, 0x65, 0x6c, 0x6c, 0x6f]
+        sv = view(v, 1:5)
+        @test transcode(String, sv) == "hello"
+        @test length(sv) == 5
+        @test v == UInt8[0x68, 0x65, 0x6c, 0x6c, 0x6f]
+    end
 end
 
 if Sys.iswindows()


### PR DESCRIPTION
`transcode(String, src)` for a `Vector{UInt8}` calls `String(transcode(UInt8, src))`. `transcode(UInt8, src)` returns `src` unchanged (identity dispatch), and `String(::Vector{UInt8})` takes ownership and zeroes it — so the call silently empties the caller's vector:

```julia
julia> v = collect(codeunits("hello"));

julia> transcode(String, v)
"hello"

julia> v
UInt8[]
```

Capture the intermediate buffer and copy only when it aliases the input:

```julia
b = transcode(UInt8, src)
b === src ? String(copy(b)) : String(b)
```

`String(::Vector{UInt8})` is the only constructor that truncates its argument, and the identity dispatch only returns `src` for `Vector{UInt8}` among the inputs `String()` would steal. Fresh buffers (the `UInt16`/`UInt32` paths) still move without a copy.

Fixes #28612

---
This PR was done with the assistance of gen AI.
