### PR TITLE
Debuginfo: Fixes for "julia-side internal API improvements"

### DIFF
--- a/Compiler/src/ssair/show.jl
+++ b/Compiler/src/ssair/show.jl
@@ -384,7 +384,7 @@ function debuginfo_firstline(di::DebugInfoStream)
         debuginfo_firstline(di)
     else
         # likely doesn't contain any usable provenance
-        debuginfo_file1(debuginfo), di.firstline
+        debuginfo_file1(di), di.firstline
     end
 end
 function debuginfo_firstline(di::DebugInfo)

--- a/Compiler/test/ssair.jl
+++ b/Compiler/test/ssair.jl
@@ -845,6 +845,13 @@ let cl = Int32[32, 1, 1, 1000, 240, 230, 0, 0, 0]
     @test roundtrip_di(cl, 32, 3) == cl
     @test roundtrip_di(cl, 33, 3) == cl
 end
+let cl = Int32[0,0,0,255,0,0,256,0,0,257,0,0]
+    @test roundtrip_di(cl, -1, 4) == cl
+    @test roundtrip_di(cl, 0, 4) == cl
+    @test roundtrip_di(cl, 1, 4) == cl
+    @test roundtrip_di(cl, 32, 4) == cl
+    @test roundtrip_di(cl, 33, 4) == cl
+end
 
 @test_throws ErrorException Base.code_ircode(+, (Float64, Float64); optimize_until = "nonexisting pass name")
 @test_throws ErrorException Base.code_ircode(+, (Float64, Float64); optimize_until = typemax(Int))

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -965,17 +965,17 @@ static size_t codelocs_parseheader(jl_string_t *cl, int *loc_offset, int *loc_by
     int32_t header[3];
     memcpy(&header, (char*)jl_string_data(cl), sizeof(header));
     *loc_offset = header[0];
-    if (header[1] <= UINT8_MAX)
+    if (header[1] < UINT8_MAX)
         *loc_bytes = 1;
-    else if (header[1] <= UINT16_MAX)
+    else if (header[1] < UINT16_MAX)
         *loc_bytes = 2;
     else
         *loc_bytes = 4;
     if (header[2] == 0)
         *to_bytes = 0;
-    else if (header[2] <= UINT8_MAX)
+    else if (header[2] < UINT8_MAX)
         *to_bytes = 1;
-    else if (header[2] <= UINT16_MAX)
+    else if (header[2] < UINT16_MAX)
         *to_bytes = 2;
     else
         *to_bytes = 4;
@@ -1625,18 +1625,19 @@ JL_DLLEXPORT jl_string_t *jl_compress_codelocs(int32_t firstloc, jl_value_t *cod
     header[1] = min.loc > max.loc ? 0 : max.loc - min.loc;
     header[2] = max.to > max.pc ? max.to : max.pc;
     size_t loc_bytes;
-    if (header[1] <= UINT8_MAX)
+    /* 0 encodes a special value, `n` encodes `n-1+loc_offset`. */
+    if (header[1] < UINT8_MAX)
         loc_bytes = 1;
-    else if (header[1] <= UINT16_MAX)
+    else if (header[1] < UINT16_MAX)
         loc_bytes = 2;
     else
         loc_bytes = 4;
     size_t to_bytes;
     if (header[2] == 0)
         to_bytes = 0;
-    else if (header[2] <= UINT8_MAX)
+    else if (header[2] < UINT8_MAX)
         to_bytes = 1;
-    else if (header[2] <= UINT16_MAX)
+    else if (header[2] < UINT16_MAX)
         to_bytes = 2;
     else
         to_bytes = 4;


### PR DESCRIPTION
Two fixes to #61979: one undefined variable in show.jl, and one encoding issue introduced trying to make codelocs consistent with the new stuff (the encoding of the special zero location needs to bump all locations by one, so we can't store `firstline`+255 in one byte as I had thought).  Thanks to @xal-0 for finding these.