### PR TITLE
Add dynamic ASAN detection for RTLD_DEEPBIND / `dlopen` workarounds

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -172,7 +172,7 @@ JL_DLLEXPORT void *jl_dlopen(const char *filename, unsigned flags) JL_NOTSAFEPOI
 #define JL_RTLD(flags, FLAG) (flags & JL_RTLD_ ## FLAG ? RTLD_ ## FLAG : 0)
 
 #if defined(__GLIBC__)
-static int jl_running_under_sanitizer(int recheck) JL_NOTSAFEPOINT
+int jl_running_under_sanitizer(int recheck) JL_NOTSAFEPOINT
 {
 #if defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_) || defined(_COMPILER_MSAN_ENABLED_)
     return 1;

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -97,9 +97,10 @@ void win32_formatmessage(DWORD code, char *reason, int len) JL_NOTSAFEPOINT
 }
 #endif
 
+typedef void* (*dlopen_prototype)(const char* filename, int flags) JL_NOTSAFEPOINT;
+
 #if defined(_COMPILER_MSAN_ENABLED_) || defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_)
 struct link_map;
-typedef void* (dlopen_prototype)(const char* filename, int flags);
 
 /* This function is copied from the memory sanitizer runtime.
    Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -170,32 +171,86 @@ JL_DLLEXPORT void *jl_dlopen(const char *filename, unsigned flags) JL_NOTSAFEPOI
 
 #define JL_RTLD(flags, FLAG) (flags & JL_RTLD_ ## FLAG ? RTLD_ ## FLAG : 0)
 
+#if defined(__GLIBC__)
+static int jl_running_under_sanitizer(int recheck) JL_NOTSAFEPOINT
+{
+#if defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_) || defined(_COMPILER_MSAN_ENABLED_)
+    return 1;
+#else
+    static _Atomic(int) detected_ = -1;
+    int detected = jl_atomic_load_relaxed(&detected_);
+    if (detected < 0 || recheck) {
+        const char *env = getenv("JULIA_ASAN_COMPAT");
+        if (env != NULL && env[0] != '\0')
+            detected = strcmp(env, "0") != 0 ? 1 : 0;
+        else if (dlsym(RTLD_DEFAULT, "__asan_init") != NULL)
+            detected = 1;
+        else
+            detected = 0;
+        jl_atomic_store_relaxed(&detected_, detected);
+    }
+    return detected == 1;
+#endif
+}
+#endif
+
+#ifdef RTLD_DEEPBIND
+// RTLD_DEEPBIND is incompatible with the sanitizers' libc interposition
+// (c.f. https://github.com/google/sanitizers/issues/611)
+static int jl_use_rtld_deepbind(int recheck) JL_NOTSAFEPOINT
+{
+    static _Atomic(int) enabled_ = -1;
+    int enabled = jl_atomic_load_relaxed(&enabled_);
+    if (enabled < 0 || recheck) {
+        const char *env = getenv("JULIA_USE_RTLD_DEEPBIND");
+        if (env != NULL && env[0] != '\0')
+            enabled = strcmp(env, "0") != 0;
+        else
+            enabled = !jl_running_under_sanitizer(recheck);
+        jl_atomic_store_relaxed(&enabled_, enabled);
+    }
+    return enabled == 1;
+}
+#endif
+
+/* The sanitizers break RUNPATH use in dlopen for annoying reasons that are
+   are hard to fix. Specifically, libc will use the return address of the
+   caller to determine certain paths and flags that affect .so location lookup.
+   To work around this, we need to avoid using the sanitizer's dlopen interposition,
+   instead using the real dlopen directly from the current shared library.
+   Of course, this does mean that we need to manually perform the work that
+   the sanitizers would otherwise do. */
+static JL_NO_SANITIZE dlopen_prototype resolve_dlopen(void) JL_NOTSAFEPOINT
+{
+#if defined(__GLIBC__)
+    // When a sanitizer is active, bypass its dlopen interposition by resolving and
+    // caching the real libdl dlopen; otherwise use dlopen directly.
+    if (jl_running_under_sanitizer(/*recheck*/0)) {
+        static dlopen_prototype real_dlopen = NULL;
+        if (!real_dlopen) {
+            real_dlopen = (dlopen_prototype)dlsym(RTLD_NEXT, "dlopen");
+            if (!real_dlopen)
+                return NULL;
+            void *libdl_handle = real_dlopen("libdl.so.2", RTLD_NOW | RTLD_NOLOAD);
+            assert(libdl_handle);
+            real_dlopen = (dlopen_prototype)dlsym(libdl_handle, "dlopen");
+            dlclose(libdl_handle);
+            assert(real_dlopen);
+        }
+        // The real interceptors check the validity of the string here, but let's
+        // just skip that for the time being.
+        return real_dlopen;
+    }
+#endif
+    return &dlopen;
+}
+
 JL_DLLEXPORT JL_NO_SANITIZE void *jl_dlopen(const char *filename, unsigned flags) JL_NOTSAFEPOINT
 {
-    /* The sanitizers break RUNPATH use in dlopen for annoying reasons that are
-       are hard to fix. Specifically, libc will use the return address of the
-       caller to determine certain paths and flags that affect .so location lookup.
-       To work around this, we need to avoid using the sanitizer's dlopen interposition,
-       instead using the real dlopen directly from the current shared library.
-       Of course, this does mean that we need to manually perform the work that
-       the sanitizers would otherwise do. */
-#if (defined(_COMPILER_MSAN_ENABLED_) || defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_)) && __GLIBC__
-    static dlopen_prototype *dlopen = NULL;
-    if (!dlopen) {
-        dlopen = (dlopen_prototype*)dlsym(RTLD_NEXT, "dlopen");
-        if (!dlopen)
-            return NULL;
-        void *libdl_handle = dlopen("libdl.so.2", RTLD_NOW | RTLD_NOLOAD);
-        assert(libdl_handle);
-        dlopen = (dlopen_prototype*)dlsym(libdl_handle, "dlopen");
-        dlclose(libdl_handle);
-        assert(dlopen);
-    }
-    // The real interceptors check the validity of the string here, but let's
-    // just skip that for the time being.
-#endif
-    void *hnd = dlopen(filename,
-                  (flags & JL_RTLD_NOW ? RTLD_NOW : RTLD_LAZY)
+    dlopen_prototype dlopen_fptr = resolve_dlopen();
+    if (dlopen_fptr == NULL)
+        return NULL;
+    int real_flags = (flags & JL_RTLD_NOW ? RTLD_NOW : RTLD_LAZY)
                   | JL_RTLD(flags, LOCAL)
                   | JL_RTLD(flags, GLOBAL)
 #ifdef RTLD_NODELETE
@@ -204,13 +259,15 @@ JL_DLLEXPORT JL_NO_SANITIZE void *jl_dlopen(const char *filename, unsigned flags
 #ifdef RTLD_NOLOAD
                   | JL_RTLD(flags, NOLOAD)
 #endif
-#if defined(RTLD_DEEPBIND) && !(defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_) || defined(_COMPILER_MSAN_ENABLED_))
-                  | JL_RTLD(flags, DEEPBIND)
-#endif
 #ifdef RTLD_FIRST
                   | JL_RTLD(flags, FIRST)
 #endif
-                  );
+                  ;
+#ifdef RTLD_DEEPBIND
+    if (jl_use_rtld_deepbind(/*recheck*/0))
+        real_flags = real_flags | JL_RTLD(flags, DEEPBIND);
+#endif
+    void *hnd = dlopen_fptr(filename, real_flags);
 #if defined(_COMPILER_MSAN_ENABLED_) && defined(__GLIBC__)
     struct link_map *map = (struct link_map*)hnd;
     if (filename && map)

--- a/src/julia.h
+++ b/src/julia.h
@@ -2498,8 +2498,11 @@ void (ijl_longjmp)(jmp_buf _Buf, int _Value);
 #define jl_setjmp_name "sigsetjmp"
 #endif
 #define jl_setjmp(a,b) sigsetjmp(a,b)
-#if defined(_COMPILER_ASAN_ENABLED_) && defined(__GLIBC__)
-extern void (*real_siglongjmp)(jmp_buf _Buf, int _Value);
+#if defined(__GLIBC__)
+// Route jl_longjmp through a function pointer so we can bypass the sanitizers' longjmp
+// interceptor (which mishandles Julia's task stacks) when a sanitizer is active.
+typedef void (*siglongjmp_func_t)(jmp_buf _Buf, int _Value) JL_NOTSAFEPOINT;
+extern siglongjmp_func_t real_siglongjmp;
 #define jl_longjmp(a,b) real_siglongjmp(a,b)
 #else
 #define jl_longjmp(a,b) siglongjmp(a,b)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -236,6 +236,7 @@ JL_DLLEXPORT void jl_init_(jl_image_buf_t sysimage);
 JL_DLLEXPORT void jl_enter_threaded_region(void);
 JL_DLLEXPORT void jl_exit_threaded_region(void);
 int jl_running_under_rr(int recheck) JL_NOTSAFEPOINT;
+int jl_running_under_sanitizer(int recheck) JL_NOTSAFEPOINT;
 
 //--------------------------------------------------
 // timers

--- a/src/task.c
+++ b/src/task.c
@@ -36,14 +36,15 @@
 extern "C" {
 #endif
 
-#if defined(_COMPILER_ASAN_ENABLED_)
-#if __GLIBC__
+#if defined(__GLIBC__)
 #include <dlfcn.h>
 // Bypass the ASAN longjmp wrapper - we are unpoisoning the stack ourselves,
 // since ASAN normally unpoisons far too much.
 // c.f. interceptor in jl_dlopen as well
-void (*real_siglongjmp)(jmp_buf _Buf, int _Value) = NULL;
+siglongjmp_func_t real_siglongjmp = (siglongjmp_func_t)&siglongjmp;
 #endif
+
+#if defined(_COMPILER_ASAN_ENABLED_)
 static inline void sanitizer_start_switch_fiber(jl_ptls_t ptls, jl_ucontext_t *from, jl_ucontext_t *to) {
     if (to->copy_stack)
         __sanitizer_start_switch_fiber(&from->asan_fake_stack, (char*)ptls->stackbase - ptls->stacksize, ptls->stacksize);
@@ -1195,15 +1196,15 @@ void jl_init_tasks(void) JL_GC_DISABLED
         exit(1);
     }
 #endif
-#if defined(_COMPILER_ASAN_ENABLED_) && __GLIBC__
-    void *libc_handle = dlopen("libc.so.6", RTLD_NOW | RTLD_NOLOAD);
-    if (libc_handle) {
-        *(void**)&real_siglongjmp = dlsym(libc_handle, "siglongjmp");
-        dlclose(libc_handle);
-    }
-    if (real_siglongjmp == NULL) {
-        jl_safe_printf("failed to get real siglongjmp\n");
-        exit(1);
+#if defined(__GLIBC__)
+    if (jl_running_under_sanitizer(/*recheck*/0)) {
+        void *libc_handle = dlopen("libc.so.6", RTLD_NOW | RTLD_NOLOAD);
+        if (libc_handle) {
+            void *real = dlsym(libc_handle, "siglongjmp");
+            if (real)
+                *(void**)&real_siglongjmp = real;
+            dlclose(libc_handle);
+        }
     }
 #endif
 }


### PR DESCRIPTION
MSAN and TSAN require comprehensive build instrumentation, but ASAN can in theory be used with Julia loaded dynamically as a library in an application.

To enable this, this PR adds `JULIA_USE_RTLD_DEEPBIND` and `JULIA_ASAN_COMPAT` environment variables + a rudimentary `dlsym(...)`-based auto-detection for whether we are running under ASAN or not.

The auto-detection should work automatically for most users, but the environment variables exist to allow overriding if necessary.

Co-developed w/ Claude Opus 4.8, although essentially written by hand.