### PR TITLE
Fix svg paths

### DIFF
--- a/doc/src/devdocs/jit.md
+++ b/doc/src/devdocs/jit.md
@@ -9,7 +9,7 @@ The JIT is responsible for managing compilation resources, looking up previously
 ## Overview
 
 ```@raw html
-<img src="img/compiler_diagram.svg" alt="Diagram of the compiler flow"/>
+<img src="../img/compiler_diagram.svg" alt="Diagram of the compiler flow"/>
 ```
 ```@raw latex
 \begin{figure}

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -171,7 +171,6 @@ JL_DLLEXPORT void *jl_dlopen(const char *filename, unsigned flags) JL_NOTSAFEPOI
 
 #define JL_RTLD(flags, FLAG) (flags & JL_RTLD_ ## FLAG ? RTLD_ ## FLAG : 0)
 
-#if defined(__GLIBC__)
 int jl_running_under_sanitizer(int recheck) JL_NOTSAFEPOINT
 {
 #if defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_) || defined(_COMPILER_MSAN_ENABLED_)
@@ -192,7 +191,6 @@ int jl_running_under_sanitizer(int recheck) JL_NOTSAFEPOINT
     return detected == 1;
 #endif
 }
-#endif
 
 #ifdef RTLD_DEEPBIND
 // RTLD_DEEPBIND is incompatible with the sanitizers' libc interposition


### PR DESCRIPTION

Fix broken SVG image paths in devdocs JIT page (#62046)
Problem
PR #60905 changed the developer documentation diagrams to use separate files for each output format (SVG for HTML, PDF for LaTeX). However, this introduced a regression in the deployed HTML docs which use Documenter's "pretty URLs" mode.
When pretty URLs are enabled, Documenter places the rendered HTML file at devdocs/jit/index.html — one directory level deeper than the source file. This means the relative image path img/compiler_diagram.svg resolves incorrectly, causing the compiler flow diagram to not render on the deployed documentation page at https://docs.julialang.org/en/v1.14-dev/devdocs/jit/.
Fix
Updated the image path in doc/src/devdocs/jit.md from:
html<img src="img/compiler_diagram.svg" alt="Diagram of the compiler flow"/>
to:
html<img src="../img/compiler_diagram.svg" alt="Diagram of the compiler flow"/>
This correctly resolves the path relative to the generated index.html location when pretty URLs are active.

Image Attached :


<img width="1464" height="838" alt="Screenshot 2026-06-10 at 6 42 27 PM" src="https://github.com/user-attachments/assets/7603688e-49ff-4aea-92eb-fbce9d3f1e43" />
