### PR TITLE
Define `jl_running_under_sanitizer` on FreeBSD

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -171,7 +171,6 @@ JL_DLLEXPORT void *jl_dlopen(const char *filename, unsigned flags) JL_NOTSAFEPOI
 
 #define JL_RTLD(flags, FLAG) (flags & JL_RTLD_ ## FLAG ? RTLD_ ## FLAG : 0)
 
-#if defined(__GLIBC__)
 int jl_running_under_sanitizer(int recheck) JL_NOTSAFEPOINT
 {
 #if defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_) || defined(_COMPILER_MSAN_ENABLED_)
@@ -192,7 +191,6 @@ int jl_running_under_sanitizer(int recheck) JL_NOTSAFEPOINT
     return detected == 1;
 #endif
 }
-#endif
 
 #ifdef RTLD_DEEPBIND
 // RTLD_DEEPBIND is incompatible with the sanitizers' libc interposition


### PR DESCRIPTION
Thanks @DilumAluthge / @Keno for the heads up. I guess it was my turn to break master. (apologies)

This should fix the FreeBSD build regression from #62043.

This also enables one of the ASAN workarounds for FreeBSD (the RTLD_DEEPBIND one). The `dlopen` and `siglongjmp` workarounds still need implementation / testing before ASAN will fully work on FreeBSD - that's easy work, but I don't have easy access to a FreeBSD machine so it's left to future work for now.