### PR TITLE
codegen: use a non-volatile memset when zeroing a GC frame; attach TBAA MD

### DIFF
--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -26,7 +26,8 @@ void FinalLowerGC::lowerNewGCFrame(CallInst *target, Function &F)
 
     // Zero out the GC frame.
     auto ptrsize = F.getParent()->getDataLayout().getPointerSize();
-    builder.CreateMemSet(gcframe, Constant::getNullValue(Type::getInt8Ty(F.getContext())), ptrsize * (nRoots + 2), Align(16), tbaa_gcframe);
+    auto memset_instr = builder.CreateMemSet(gcframe, Constant::getNullValue(Type::getInt8Ty(F.getContext())), ptrsize * (nRoots + 2), Align(16));
+    memset_instr->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
 
     target->replaceAllUsesWith(gcframe);
     target->eraseFromParent();

--- a/test/llvmpasses/names.jl
+++ b/test/llvmpasses/names.jl
@@ -154,7 +154,6 @@ emit(f5, A)
 # CHECK: %"e::E.f.tag"
 # CHECK: @"jl_sym#g
 # CHECK: @"jl_sym#h
-# CHECK: %gc_slot_addr_0
 emit(f6, E)
 
 


### PR DESCRIPTION
Prior to 734cafabbfb, in `FinalLowerGC::lowerNewGCFrame`, we passed an explicit 0 for the `isvolatile` argument in the call to the `memset` intrinsic.  In that change, the TBAA metadata was moved to the fifth argument to the `CreateMemSet` call, implicitly converting the `llvm::MDNode *` to `bool` and marking all our zeroing GC frame `memset`s volatile and dropping the TBAA metadata.  This seems unintentional.

Found while reviewing #61596.